### PR TITLE
feat: enhance KubeVirt Status card with multi-cluster support

### DIFF
--- a/web/src/components/cards/cardMetadata.ts
+++ b/web/src/components/cards/cardMetadata.ts
@@ -565,7 +565,7 @@ export const CARD_DESCRIPTIONS: Record<string, string> = {
   ovn_status: 'OVN-Kubernetes network status, User Defined Networks, and tenant isolation.',
   kubeflex_status: 'KubeFlex controller status, control planes per tenant, and CP health.',
   k3s_status: 'K3s lightweight Kubernetes server pods, agent connections, and cluster health.',
-  kubevirt_status: 'KubeVirt VM status, running/stopped/migrating VMs, and data-plane isolation.',
+  kubevirt_status: 'KubeVirt VM status across clusters — running, stopped, paused, migrating, and error states with per-cluster breakdown, CPU/memory allocation, and data-plane isolation.',
   multi_tenancy_overview: 'Aggregated view of tenant isolation across OVN, KubeFlex, K3s, and KubeVirt.',
   tenant_isolation_setup: 'AI-powered multi-tenancy setup wizard with component detection and one-click configuration.',
   tenant_topology: 'Interactive SVG topology of the KubeCon multi-tenancy architecture: KubeVirt VMs, K3s control planes, Layer-2/3 UDN networks, and KubeFlex controller with live status indicators.',

--- a/web/src/components/cards/multi-tenancy/kubevirt-status/KubevirtDetailModal.tsx
+++ b/web/src/components/cards/multi-tenancy/kubevirt-status/KubevirtDetailModal.tsx
@@ -8,7 +8,7 @@
  */
 
 import { useState } from 'react'
-import { Monitor, Search, ExternalLink, CheckCircle, XCircle, Server, Users, RefreshCw } from 'lucide-react'
+import { Monitor, Search, ExternalLink, CheckCircle, XCircle, Server, Users, RefreshCw, Cpu, HardDrive, Clock, Pause } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 import { BaseModal } from '../../../../lib/modals'
 import { StatusBadge } from '../../../ui/StatusBadge'
@@ -26,6 +26,7 @@ const SUMMARY_GRID_COLS = 3
 const VM_STATE_BADGE_COLORS: Record<string, string> = {
   running: 'text-green-400 bg-green-500/15',
   stopped: 'text-zinc-400 bg-zinc-500/15',
+  paused: 'text-amber-400 bg-amber-500/15',
   migrating: 'text-blue-400 bg-blue-500/15',
   pending: 'text-yellow-400 bg-yellow-500/15',
   failed: 'text-red-400 bg-red-500/15',
@@ -35,6 +36,7 @@ const VM_STATE_BADGE_COLORS: Record<string, string> = {
 const VM_STATE_BAR_COLORS: Record<string, string> = {
   running: 'bg-green-500',
   stopped: 'bg-zinc-500',
+  paused: 'bg-amber-500',
   migrating: 'bg-blue-500',
   pending: 'bg-yellow-500',
   failed: 'bg-red-500',
@@ -44,6 +46,7 @@ const VM_STATE_BAR_COLORS: Record<string, string> = {
 const VM_STATE_TEXT_COLORS: Record<string, string> = {
   running: 'text-green-400',
   stopped: 'text-zinc-400',
+  paused: 'text-amber-400',
   migrating: 'text-blue-400',
   pending: 'text-yellow-400',
   failed: 'text-red-400',
@@ -64,8 +67,23 @@ interface KubevirtDetailModalProps {
 // Sub-components
 // ============================================================================
 
+/** Format an ISO date string to a short relative or absolute display */
+function formatVmAge(isoString?: string): string {
+  if (!isoString) return ''
+  const diff = Date.now() - new Date(isoString).getTime()
+  if (isNaN(diff) || diff < 0) return ''
+  /** Milliseconds per hour */
+  const HOUR_MS = 3_600_000
+  /** Milliseconds per day */
+  const DAY_MS = 86_400_000
+  if (diff < HOUR_MS) return '<1h'
+  if (diff < DAY_MS) return `${Math.floor(diff / HOUR_MS)}h`
+  return `${Math.floor(diff / DAY_MS)}d`
+}
+
 function VmRow({ vm }: { vm: VmInfo }) {
   const stateColor = VM_STATE_BADGE_COLORS[vm.state] || VM_STATE_BADGE_COLORS.unknown
+  const age = formatVmAge(vm.creationTime)
 
   return (
     <div className="flex items-center justify-between text-sm gap-3 px-3 py-2.5 rounded-lg bg-secondary/30 hover:bg-secondary/50 transition-colors">
@@ -75,14 +93,34 @@ function VmRow({ vm }: { vm: VmInfo }) {
           <span className="text-foreground truncate font-medium block" title={vm.name}>
             {vm.name}
           </span>
-          <span className="text-[10px] text-muted-foreground truncate block" title={vm.namespace}>
-            {vm.namespace}
+          <span className="text-[10px] text-muted-foreground truncate block" title={`${vm.namespace} @ ${vm.cluster}`}>
+            {vm.namespace} @ {vm.cluster}
           </span>
         </div>
       </div>
-      <span className={`px-2 py-0.5 rounded text-xs font-medium capitalize shrink-0 ${stateColor}`}>
-        {vm.state}
-      </span>
+      <div className="flex items-center gap-2 shrink-0">
+        {vm.cpu && (
+          <span className="flex items-center gap-0.5 text-[10px] text-muted-foreground" title={`${vm.cpu} CPU cores`}>
+            <Cpu className="w-3 h-3" />
+            {vm.cpu}
+          </span>
+        )}
+        {vm.memory && (
+          <span className="flex items-center gap-0.5 text-[10px] text-muted-foreground" title={vm.memory}>
+            <HardDrive className="w-3 h-3" />
+            {vm.memory}
+          </span>
+        )}
+        {age && (
+          <span className="flex items-center gap-0.5 text-[10px] text-muted-foreground" title={vm.creationTime}>
+            <Clock className="w-3 h-3" />
+            {age}
+          </span>
+        )}
+        <span className={`px-2 py-0.5 rounded text-xs font-medium capitalize shrink-0 ${stateColor}`}>
+          {vm.state}
+        </span>
+      </div>
     </div>
   )
 }
@@ -96,6 +134,7 @@ export function KubevirtDetailModal({ isOpen, onClose, data, isDemoData }: Kubev
   const [search, setSearch] = useState('')
 
   const vms = data.vms || []
+  const clusters = data.clusters || []
   const isHealthy = data.health === 'healthy'
 
   // Count VMs by state
@@ -193,7 +232,7 @@ export function KubevirtDetailModal({ isOpen, onClose, data, isDemoData }: Kubev
               <p className="text-xs font-medium text-muted-foreground">
                 {t('kubevirtStatus.stateBreakdown', 'VM State Breakdown')}
               </p>
-              <div className="grid grid-cols-4 gap-2">
+              <div className="grid grid-cols-5 gap-2">
                 <div className="p-2 rounded bg-green-500/10 text-center">
                   <div className="flex items-center justify-center gap-1 mb-0.5">
                     <CheckCircle className="w-3 h-3 text-green-400" />
@@ -207,6 +246,13 @@ export function KubevirtDetailModal({ isOpen, onClose, data, isDemoData }: Kubev
                   </div>
                   <p className="text-sm font-bold text-zinc-400">{stateCounts['stopped'] || 0}</p>
                   <p className="text-[10px] text-muted-foreground">{t('kubevirtStatus.stoppedVMs', 'Stopped')}</p>
+                </div>
+                <div className="p-2 rounded bg-amber-500/10 text-center">
+                  <div className="flex items-center justify-center gap-1 mb-0.5">
+                    <Pause className="w-3 h-3 text-amber-400" />
+                  </div>
+                  <p className="text-sm font-bold text-amber-400">{stateCounts['paused'] || 0}</p>
+                  <p className="text-[10px] text-muted-foreground">{t('kubevirtStatus.pausedVMs', 'Paused')}</p>
                 </div>
                 <div className="p-2 rounded bg-blue-500/10 text-center">
                   <div className="flex items-center justify-center gap-1 mb-0.5">
@@ -260,6 +306,30 @@ export function KubevirtDetailModal({ isOpen, onClose, data, isDemoData }: Kubev
                     <p className="text-[10px] text-muted-foreground truncate" title={td.namespace}>
                       {td.namespace}
                     </p>
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
+
+          {/* Per-cluster breakdown */}
+          {clusters.length > 0 && (
+            <div>
+              <p className="text-xs font-medium text-muted-foreground mb-2">
+                {t('kubevirtStatus.clusterBreakdown', 'Per-Cluster Breakdown')}
+              </p>
+              <div className="space-y-1.5">
+                {clusters.map((ci) => (
+                  <div key={ci.cluster} className="flex items-center justify-between text-sm gap-3 px-3 py-2 rounded-lg bg-secondary/30">
+                    <div className="flex items-center gap-2 min-w-0 flex-1">
+                      <Server className="w-4 h-4 text-cyan-400 shrink-0" />
+                      <span className="text-foreground font-medium truncate" title={ci.cluster}>{ci.cluster}</span>
+                    </div>
+                    <div className="flex items-center gap-3 shrink-0 text-xs text-muted-foreground">
+                      <span>{ci.infraPods} {t('kubevirtStatus.infraPods', 'pods')}</span>
+                      <span className="text-foreground font-medium">{ci.runningCount}/{ci.vmCount} {t('kubevirtStatus.vmsRunning', 'VMs running')}</span>
+                      <span className={`w-2 h-2 rounded-full ${ci.health === 'healthy' ? 'bg-green-400' : 'bg-orange-400'}`} />
+                    </div>
                   </div>
                 ))}
               </div>

--- a/web/src/components/cards/multi-tenancy/kubevirt-status/KubevirtStatus.tsx
+++ b/web/src/components/cards/multi-tenancy/kubevirt-status/KubevirtStatus.tsx
@@ -6,7 +6,7 @@
  * installation mission.
  */
 
-import { AlertTriangle, CheckCircle, Monitor, RefreshCw, Server, Users, XCircle } from 'lucide-react'
+import { AlertTriangle, CheckCircle, Monitor, Pause, RefreshCw, Server, XCircle } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 import { Skeleton } from '../../../ui/Skeleton'
 import { MetricTile } from '../../../../lib/cards/CardComponents'
@@ -61,6 +61,7 @@ function vmStateColorClass(state: string): string {
   switch (state) {
     case 'running': return 'text-green-400 bg-green-500/15'
     case 'stopped': return 'text-zinc-400 bg-zinc-500/15'
+    case 'paused': return 'text-amber-400 bg-amber-500/15'
     case 'migrating': return 'text-blue-400 bg-blue-500/15'
     case 'pending': return 'text-yellow-400 bg-yellow-500/15'
     case 'failed': return 'text-red-400 bg-red-500/15'
@@ -143,9 +144,12 @@ export function KubevirtStatus() {
   // ------ Detected ------
   const isHealthy = data.health === 'healthy'
   const vms = data.vms || []
+  const clusters = data.clusters || []
   const runningVMs = vms.filter((vm) => vm.state === 'running').length
   const stoppedVMs = vms.filter((vm) => vm.state === 'stopped').length
+  const pausedVMs = vms.filter((vm) => vm.state === 'paused').length
   const migratingVMs = vms.filter((vm) => vm.state === 'migrating').length
+  const errorVMs = vms.filter((vm) => vm.state === 'failed').length
 
   return (
     <div className="h-full flex flex-col min-h-card content-loaded gap-4">
@@ -192,10 +196,10 @@ export function KubevirtStatus() {
           icon={<Monitor className="w-4 h-4 text-purple-400" />}
         />
         <MetricTile
-          label={t('kubevirtStatus.tenants')}
-          value={data.tenantCount}
+          label={t('kubevirtStatus.clusters')}
+          value={clusters.length}
           colorClass="text-cyan-400"
-          icon={<Users className="w-4 h-4 text-cyan-400" />}
+          icon={<Server className="w-4 h-4 text-cyan-400" />}
         />
       </div>
 
@@ -213,6 +217,14 @@ export function KubevirtStatus() {
           colorClass={stoppedVMs > 0 ? 'text-zinc-400' : 'text-muted-foreground'}
           icon={<XCircle className="w-4 h-4 text-zinc-400" />}
         />
+        {pausedVMs > 0 && (
+          <MetricTile
+            label={t('kubevirtStatus.pausedVMs')}
+            value={pausedVMs}
+            colorClass="text-amber-400"
+            icon={<Pause className="w-4 h-4 text-amber-400" />}
+          />
+        )}
         {migratingVMs > 0 && (
           <MetricTile
             label={t('kubevirtStatus.migratingVMs')}
@@ -221,7 +233,36 @@ export function KubevirtStatus() {
             icon={<RefreshCw className="w-4 h-4 text-blue-400" />}
           />
         )}
+        {errorVMs > 0 && (
+          <MetricTile
+            label={t('kubevirtStatus.errorVMs')}
+            value={errorVMs}
+            colorClass="text-red-400"
+            icon={<AlertTriangle className="w-4 h-4 text-red-400" />}
+          />
+        )}
       </div>
+
+      {/* Per-cluster breakdown */}
+      {clusters.length > 0 && (
+        <div className="flex flex-col gap-2 pt-2 border-t border-border/50">
+          <p className="text-xs font-medium text-muted-foreground">{t('kubevirtStatus.clusterBreakdown')}</p>
+          <div className="space-y-1.5">
+            {clusters.map((ci) => (
+              <div key={ci.cluster} className="flex items-center justify-between text-xs gap-2 px-2 py-1.5 rounded bg-secondary/30 cursor-pointer hover:bg-secondary/50 transition-colors" role="button" tabIndex={0} aria-label={t('kubevirtStatus.viewCluster', { cluster: ci.cluster })} onClick={openDetailModal} onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); openDetailModal() } }}>
+                <div className="flex items-center gap-2 min-w-0 flex-1">
+                  <Server className="w-3 h-3 text-cyan-400 shrink-0" />
+                  <span className="text-foreground truncate" title={ci.cluster}>{ci.cluster}</span>
+                </div>
+                <div className="flex items-center gap-2 shrink-0">
+                  <span className="text-muted-foreground">{ci.runningCount}/{ci.vmCount} {t('kubevirtStatus.vmsRunning')}</span>
+                  <span className={`w-2 h-2 rounded-full ${ci.health === 'healthy' ? 'bg-green-400' : 'bg-orange-400'}`} />
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
 
       {/* VM list */}
       {vms.length > 0 && (
@@ -229,15 +270,20 @@ export function KubevirtStatus() {
           <p className="text-xs font-medium text-muted-foreground">{t('kubevirtStatus.vmList')}</p>
           <div className="space-y-1.5 max-h-40 overflow-y-auto scrollbar-thin">
             {vms.map((vm) => (
-              <div key={`${vm.namespace}/${vm.name}`} className="flex items-center justify-between text-xs gap-2 px-2 py-1.5 rounded bg-secondary/30 cursor-pointer hover:bg-secondary/50 transition-colors" role="button" tabIndex={0} aria-label={t('kubevirtStatus.viewVm', { name: vm.name, namespace: vm.namespace })} onClick={openDetailModal} onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); openDetailModal() } }}>
+              <div key={`${vm.cluster}/${vm.namespace}/${vm.name}`} className="flex items-center justify-between text-xs gap-2 px-2 py-1.5 rounded bg-secondary/30 cursor-pointer hover:bg-secondary/50 transition-colors" role="button" tabIndex={0} aria-label={t('kubevirtStatus.viewVm', { name: vm.name, namespace: vm.namespace })} onClick={openDetailModal} onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); openDetailModal() } }}>
                 <div className="flex flex-col min-w-0 flex-1">
                   <span className="text-foreground truncate" title={vm.name}>
                     {vm.name}
                   </span>
-                  <span className="text-muted-foreground/70 text-[10px] truncate" title={vm.namespace}>
-                    {vm.namespace}
+                  <span className="text-muted-foreground/70 text-[10px] truncate" title={`${vm.namespace} @ ${vm.cluster}`}>
+                    {vm.namespace} @ {vm.cluster}
                   </span>
                 </div>
+                {vm.cpu && vm.memory && (
+                  <span className="text-muted-foreground/70 text-[10px] shrink-0">
+                    {vm.cpu} {t('kubevirtStatus.cpuCores')} / {vm.memory}
+                  </span>
+                )}
                 <span className={`px-1.5 py-0.5 rounded text-[10px] font-medium shrink-0 ${vmStateColorClass(vm.state)}`}>
                   {vm.state}
                 </span>

--- a/web/src/components/cards/multi-tenancy/kubevirt-status/__tests__/KubevirtDetailModal.test.tsx
+++ b/web/src/components/cards/multi-tenancy/kubevirt-status/__tests__/KubevirtDetailModal.test.tsx
@@ -36,7 +36,7 @@ import { KubevirtDetailModal } from '../KubevirtDetailModal'
 
 describe('KubevirtDetailModal', () => {
   it('renders without crashing', () => {
-    const { container } = render(<KubevirtDetailModal isOpen={false} onClose={() => {}} data={{} as Record<string, unknown>} isDemoData={false} />)
+    const { container } = render(<KubevirtDetailModal isOpen={false} onClose={() => {}} data={{ vms: [], clusters: [] } as Record<string, unknown>} isDemoData={false} />)
     expect(container).toBeTruthy()
   })
 })

--- a/web/src/components/cards/multi-tenancy/kubevirt-status/__tests__/helpers.test.ts
+++ b/web/src/components/cards/multi-tenancy/kubevirt-status/__tests__/helpers.test.ts
@@ -105,6 +105,14 @@ describe('kubevirt-status helpers', () => {
       expect(getVmStatus({ status: 'Running', ready: '0/1' })).toBe('pending')
     })
 
+    it('returns paused for paused VMs', () => {
+      expect(getVmStatus({ status: 'Paused' })).toBe('paused')
+    })
+
+    it('returns paused for suspended VMs', () => {
+      expect(getVmStatus({ status: 'Suspended' })).toBe('paused')
+    })
+
     it('returns unknown for unrecognized status', () => {
       expect(getVmStatus({ status: 'SomeWeirdStatus' })).toBe('unknown')
     })

--- a/web/src/components/cards/multi-tenancy/kubevirt-status/demoData.ts
+++ b/web/src/components/cards/multi-tenancy/kubevirt-status/demoData.ts
@@ -1,9 +1,11 @@
 /**
  * Demo data for the KubeVirt status card.
  *
- * Represents a healthy KubeVirt deployment with the operator infrastructure
- * running, and 6 VMs (4 running, 1 stopped, 1 migrating) distributed across
- * 3 tenants. Used when the dashboard is in demo mode or no clusters are connected.
+ * Represents a healthy multi-cluster KubeVirt deployment with the operator
+ * infrastructure running across 3 clusters, with 8 VMs (5 running, 1 stopped,
+ * 1 migrating, 1 paused) distributed across tenants. Includes CPU, memory, and
+ * creation time per VM. Used when the dashboard is in demo mode or no clusters
+ * are connected.
  */
 
 import type { ComponentHealth } from '../shared'
@@ -17,6 +19,30 @@ export interface VmInfo {
   namespace: string
   /** Current VM state */
   state: VmState
+  /** Cluster where this VM runs */
+  cluster: string
+  /** CPU cores allocated to this VM */
+  cpu?: string
+  /** Memory allocated to this VM (e.g. "2Gi") */
+  memory?: string
+  /** ISO creation timestamp */
+  creationTime?: string
+}
+
+/** Per-cluster KubeVirt summary for the cluster breakdown view */
+export interface ClusterKubevirtInfo {
+  /** Cluster name */
+  cluster: string
+  /** Whether KubeVirt is installed on this cluster */
+  installed: boolean
+  /** Number of VMs on this cluster */
+  vmCount: number
+  /** Number of running VMs on this cluster */
+  runningCount: number
+  /** Number of infra pods on this cluster */
+  infraPods: number
+  /** Health of KubeVirt on this cluster */
+  health: ComponentHealth
 }
 
 export interface KubevirtStatusDemoData {
@@ -28,22 +54,41 @@ export interface KubevirtStatusDemoData {
   vms: VmInfo[]
   tenantCount: number
   lastCheckTime: string
+  /** Per-cluster KubeVirt breakdown */
+  clusters: ClusterKubevirtInfo[]
 }
 
 /** Demo: timestamp offset for latest refresh (2 minutes ago) */
 const DEMO_LAST_CHECK_AGO_MS = 2 * 60 * 1000
 
-/** Demo: total KubeVirt infrastructure pods (operator + controller + api + handler + handler) */
-const DEMO_POD_COUNT = 5
+/** Demo: total KubeVirt infrastructure pods across all clusters */
+const DEMO_POD_COUNT = 12
 
 /** Demo: all infrastructure pods healthy */
-const DEMO_HEALTHY_PODS = 5
+const DEMO_HEALTHY_PODS = 12
 
 /** Demo: no unhealthy infrastructure pods */
 const DEMO_UNHEALTHY_PODS = 0
 
 /** Demo: number of tenants with VMs */
 const DEMO_TENANT_COUNT = 3
+
+/** Demo: days ago offset for VM creation timestamps */
+const DEMO_CREATION_DAYS_AGO_WEB01 = 14
+const DEMO_CREATION_DAYS_AGO_WEB02 = 14
+const DEMO_CREATION_DAYS_AGO_DB_PRIMARY = 30
+const DEMO_CREATION_DAYS_AGO_DB_REPLICA = 28
+const DEMO_CREATION_DAYS_AGO_APP_SERVER = 7
+const DEMO_CREATION_DAYS_AGO_BATCH_WORKER = 21
+const DEMO_CREATION_DAYS_AGO_ML_TRAINER = 3
+const DEMO_CREATION_DAYS_AGO_DEV_ENV = 1
+
+/** Helper to generate a creation timestamp N days ago */
+function daysAgo(days: number): string {
+  /** Milliseconds per day */
+  const MS_PER_DAY = 86_400_000
+  return new Date(Date.now() - days * MS_PER_DAY).toISOString()
+}
 
 export const KUBEVIRT_DEMO_DATA: KubevirtStatusDemoData = {
   detected: true,
@@ -52,13 +97,20 @@ export const KUBEVIRT_DEMO_DATA: KubevirtStatusDemoData = {
   healthyPods: DEMO_HEALTHY_PODS,
   unhealthyPods: DEMO_UNHEALTHY_PODS,
   vms: [
-    { name: 'web-server-01', namespace: 'tenant-alpha', state: 'running' },
-    { name: 'web-server-02', namespace: 'tenant-alpha', state: 'running' },
-    { name: 'db-primary', namespace: 'tenant-beta', state: 'running' },
-    { name: 'db-replica', namespace: 'tenant-beta', state: 'migrating' },
-    { name: 'app-server', namespace: 'tenant-gamma', state: 'running' },
-    { name: 'batch-worker', namespace: 'tenant-gamma', state: 'stopped' },
+    { name: 'web-server-01', namespace: 'tenant-alpha', state: 'running', cluster: 'prod-east', cpu: '4', memory: '8Gi', creationTime: daysAgo(DEMO_CREATION_DAYS_AGO_WEB01) },
+    { name: 'web-server-02', namespace: 'tenant-alpha', state: 'running', cluster: 'prod-east', cpu: '4', memory: '8Gi', creationTime: daysAgo(DEMO_CREATION_DAYS_AGO_WEB02) },
+    { name: 'db-primary', namespace: 'tenant-beta', state: 'running', cluster: 'prod-east', cpu: '8', memory: '32Gi', creationTime: daysAgo(DEMO_CREATION_DAYS_AGO_DB_PRIMARY) },
+    { name: 'db-replica', namespace: 'tenant-beta', state: 'migrating', cluster: 'prod-west', cpu: '8', memory: '32Gi', creationTime: daysAgo(DEMO_CREATION_DAYS_AGO_DB_REPLICA) },
+    { name: 'app-server', namespace: 'tenant-gamma', state: 'running', cluster: 'prod-west', cpu: '2', memory: '4Gi', creationTime: daysAgo(DEMO_CREATION_DAYS_AGO_APP_SERVER) },
+    { name: 'batch-worker', namespace: 'tenant-gamma', state: 'stopped', cluster: 'prod-west', cpu: '16', memory: '64Gi', creationTime: daysAgo(DEMO_CREATION_DAYS_AGO_BATCH_WORKER) },
+    { name: 'ml-trainer', namespace: 'tenant-alpha', state: 'running', cluster: 'staging', cpu: '4', memory: '16Gi', creationTime: daysAgo(DEMO_CREATION_DAYS_AGO_ML_TRAINER) },
+    { name: 'dev-env', namespace: 'tenant-gamma', state: 'paused', cluster: 'staging', cpu: '2', memory: '4Gi', creationTime: daysAgo(DEMO_CREATION_DAYS_AGO_DEV_ENV) },
   ],
   tenantCount: DEMO_TENANT_COUNT,
   lastCheckTime: new Date(Date.now() - DEMO_LAST_CHECK_AGO_MS).toISOString(),
+  clusters: [
+    { cluster: 'prod-east', installed: true, vmCount: 3, runningCount: 3, infraPods: 5, health: 'healthy' },
+    { cluster: 'prod-west', installed: true, vmCount: 3, runningCount: 1, infraPods: 5, health: 'healthy' },
+    { cluster: 'staging', installed: true, vmCount: 2, runningCount: 1, infraPods: 2, health: 'healthy' },
+  ],
 }

--- a/web/src/components/cards/multi-tenancy/kubevirt-status/helpers.ts
+++ b/web/src/components/cards/multi-tenancy/kubevirt-status/helpers.ts
@@ -23,7 +23,7 @@ export interface KubevirtPodInfo {
 }
 
 /** Possible VM states derived from virt-launcher pod status */
-export type VmState = 'running' | 'stopped' | 'migrating' | 'pending' | 'failed' | 'unknown'
+export type VmState = 'running' | 'stopped' | 'paused' | 'migrating' | 'pending' | 'failed' | 'unknown'
 
 // ============================================================================
 // Constants
@@ -95,6 +95,7 @@ export function isPodHealthy(pod: KubevirtPodInfo): boolean {
  *
  * - Running + ready => 'running'
  * - Status contains 'migrat' => 'migrating'
+ * - Paused => 'paused' (VM suspended / hibernated)
  * - Pending => 'pending'
  * - Succeeded/Completed => 'stopped' (VM powered off gracefully)
  * - Failed/CrashLoopBackOff => 'failed'
@@ -105,6 +106,9 @@ export function getVmStatus(pod: KubevirtPodInfo): VmState {
 
   // Check for migration-related status first
   if (status.includes('migrat')) return 'migrating'
+
+  // Check for paused/suspended VMs
+  if (status === 'paused' || status === 'suspended') return 'paused'
 
   if (status === 'running') {
     const { ready, total } = parseReadyCount(pod.ready)
@@ -152,6 +156,7 @@ export function countVmsByState(vmPods: KubevirtPodInfo[]): Record<VmState, numb
   const counts: Record<VmState, number> = {
     running: 0,
     stopped: 0,
+    paused: 0,
     migrating: 0,
     pending: 0,
     failed: 0,

--- a/web/src/components/cards/multi-tenancy/kubevirt-status/useKubevirtStatus.ts
+++ b/web/src/components/cards/multi-tenancy/kubevirt-status/useKubevirtStatus.ts
@@ -20,7 +20,7 @@ import {
   countVmTenants,
 } from './helpers'
 import type { KubevirtPodInfo } from './helpers'
-import { KUBEVIRT_DEMO_DATA, type VmInfo, type KubevirtStatusDemoData } from './demoData'
+import { KUBEVIRT_DEMO_DATA, type VmInfo, type ClusterKubevirtInfo, type KubevirtStatusDemoData } from './demoData'
 
 // ============================================================================
 // Data Interface
@@ -35,6 +35,8 @@ export interface KubevirtStatus {
   vms: VmInfo[]
   tenantCount: number
   lastCheckTime: string
+  /** Per-cluster KubeVirt breakdown */
+  clusters: ClusterKubevirtInfo[]
 }
 
 // ============================================================================
@@ -50,6 +52,7 @@ const INITIAL_DATA: KubevirtStatus = {
   vms: [],
   tenantCount: 0,
   lastCheckTime: new Date().toISOString(),
+  clusters: [],
 }
 
 // ============================================================================
@@ -62,6 +65,15 @@ interface BackendPodInfo {
   status?: string
   ready?: string
   labels?: Record<string, string>
+  /** Cluster context this pod belongs to */
+  cluster?: string
+  /** Resource requests/limits (used to extract CPU/memory for VMs) */
+  resources?: {
+    requests?: Record<string, string>
+    limits?: Record<string, string>
+  }
+  /** Pod creation timestamp */
+  creationTimestamp?: string
 }
 
 // ============================================================================
@@ -125,6 +137,10 @@ async function fetchKubevirtStatus(): Promise<KubevirtStatus> {
       name: pod.name ?? 'unknown',
       namespace: pod.namespace ?? 'unknown',
       state: getVmStatus(podInfo),
+      cluster: pod.cluster ?? 'unknown',
+      cpu: pod.resources?.requests?.cpu || pod.resources?.limits?.cpu,
+      memory: pod.resources?.requests?.memory || pod.resources?.limits?.memory,
+      creationTime: pod.creationTimestamp,
     }
   })
 
@@ -140,6 +156,38 @@ async function fetchKubevirtStatus(): Promise<KubevirtStatus> {
 
   const health: ComponentHealth = unhealthy > 0 ? 'degraded' : 'healthy'
 
+  // Build per-cluster breakdown
+  const clusterMap = new Map<string, ClusterKubevirtInfo>()
+  for (const pod of kubevirtPods) {
+    const clusterName = pod.cluster ?? 'unknown'
+    if (!clusterMap.has(clusterName)) {
+      clusterMap.set(clusterName, {
+        cluster: clusterName,
+        installed: true,
+        vmCount: 0,
+        runningCount: 0,
+        infraPods: 0,
+        health: 'healthy',
+      })
+    }
+    const entry = clusterMap.get(clusterName)!
+    entry.infraPods += 1
+    const podInfo: KubevirtPodInfo = { status: pod.status, ready: pod.ready }
+    if (!isPodHealthy(podInfo)) {
+      entry.health = 'degraded'
+    }
+  }
+  for (const vm of vms) {
+    const entry = clusterMap.get(vm.cluster)
+    if (entry) {
+      entry.vmCount += 1
+      if (vm.state === 'running') {
+        entry.runningCount += 1
+      }
+    }
+  }
+  const clusters = Array.from(clusterMap.values())
+
   return {
     detected: true,
     health,
@@ -149,6 +197,7 @@ async function fetchKubevirtStatus(): Promise<KubevirtStatus> {
     vms,
     tenantCount,
     lastCheckTime: new Date().toISOString(),
+    clusters,
   }
 }
 
@@ -166,6 +215,7 @@ function toDemoStatus(demo: KubevirtStatusDemoData): KubevirtStatus {
     vms: demo.vms,
     tenantCount: demo.tenantCount,
     lastCheckTime: demo.lastCheckTime,
+    clusters: demo.clusters || [],
   }
 }
 

--- a/web/src/components/dashboard/shared/cardCatalog.ts
+++ b/web/src/components/dashboard/shared/cardCatalog.ts
@@ -313,7 +313,7 @@ export const CARD_CATALOG = {
     { type: 'ovn_status', title: 'OVN-Kubernetes', description: 'OVN network and UDN status', visualization: 'status' },
     { type: 'kubeflex_status', title: 'KubeFlex', description: 'Control plane management', visualization: 'status' },
     { type: 'k3s_status', title: 'K3s', description: 'Lightweight Kubernetes clusters', visualization: 'status' },
-    { type: 'kubevirt_status', title: 'KubeVirt', description: 'Virtual machine management', visualization: 'status' },
+    { type: 'kubevirt_status', title: 'KubeVirt Status', description: 'VM status across clusters with per-cluster breakdown, CPU/memory, and health', visualization: 'status' },
   ],
   'Orchestration': [
     { type: 'keda_status', title: 'KEDA', description: 'KEDA autoscaler status, scaled object metrics, and trigger queue depths', visualization: 'status' },

--- a/web/src/config/cards/index.ts
+++ b/web/src/config/cards/index.ts
@@ -89,6 +89,7 @@ import { kubecostOverviewConfig } from './kubecost-overview'
 import { kubectlConfig } from './kubectl'
 import { kubedleConfig } from './kubedle'
 import { kubescapeScanConfig } from './kubescape-scan'
+import { kubevirtStatusConfig } from './kubevirt-status'
 import { kustomizationStatusConfig } from './kustomization-status'
 import { kyvernoPoliciesConfig } from './kyverno-policies'
 import { limitRangeStatusConfig } from './limit-range-status'
@@ -251,6 +252,7 @@ export const CARD_CONFIGS: CardConfigRegistry = {
   kubectl: kubectlConfig,
   kubedle: kubedleConfig,
   kubescape_scan: kubescapeScanConfig,
+  kubevirt_status: kubevirtStatusConfig,
   kustomization_status: kustomizationStatusConfig,
   kyverno_policies: kyvernoPoliciesConfig,
   limit_range_status: limitRangeStatusConfig,
@@ -501,6 +503,7 @@ export {
   kubectlConfig,
   kubedleConfig,
   kubescapeScanConfig,
+  kubevirtStatusConfig,
   kustomizationStatusConfig,
   kyvernoPoliciesConfig,
   limitRangeStatusConfig,

--- a/web/src/config/cards/kubevirt-status.ts
+++ b/web/src/config/cards/kubevirt-status.ts
@@ -1,0 +1,66 @@
+/**
+ * KubeVirt Status Card Configuration
+ *
+ * Displays KubeVirt operator health, VM count by state (running, stopped,
+ * paused, migrating, error), per-cluster breakdown, and VM details including
+ * CPU/memory allocation and creation time.
+ *
+ * Data source: Multi-tenancy KubeVirt hook detecting virt-operator and
+ * virt-launcher pods across clusters. Falls back to demo data when KubeVirt
+ * is not installed or in demo mode.
+ *
+ * KubeVirt resources queried (via pod detection):
+ * - virtualmachines.kubevirt.io (VMs — detected via virt-launcher pods)
+ * - virtualmachineinstances.kubevirt.io (running VM instances)
+ *
+ * TODO: Add direct CRD querying via kc-agent for richer VM metadata
+ * (CPU/memory from VMI spec, live migration status, node affinity).
+ */
+
+import type { UnifiedCardConfig } from '../../lib/unified/types'
+
+export const kubevirtStatusConfig: UnifiedCardConfig = {
+  type: 'kubevirt_status',
+  title: 'KubeVirt Status',
+  category: 'operators',
+  description: 'Virtual machine status across clusters — running, stopped, paused, and error states with per-cluster breakdown',
+
+  // Appearance
+  icon: 'Monitor',
+  iconColor: 'text-orange-400',
+  defaultWidth: 6,
+  defaultHeight: 4,
+
+  // Data source — uses custom hook (not unified data layer)
+  dataSource: {
+    type: 'hook',
+    hook: 'useKubevirtStatus',
+  },
+
+  // Content — custom component renders its own layout
+  content: {
+    type: 'custom',
+    component: 'KubevirtStatus',
+  },
+
+  // Empty state when KubeVirt is not installed
+  emptyState: {
+    icon: 'Monitor',
+    title: 'KubeVirt not detected',
+    message: 'No KubeVirt operator found. Install KubeVirt to run VMs as pods for data-plane tenant isolation.',
+    variant: 'info',
+  },
+
+  // Loading state
+  loadingState: {
+    type: 'status',
+    rows: 3,
+    showSearch: false,
+  },
+
+  // Metadata
+  isDemoData: false,
+  isLive: true,
+}
+
+export default kubevirtStatusConfig

--- a/web/src/locales/en/cards.json
+++ b/web/src/locales/en/cards.json
@@ -2995,7 +2995,21 @@
     "statusAriaLabel": "KubeVirt status: {{status}}. Click to view details.",
     "viewInfraMetrics": "View KubeVirt infrastructure metrics",
     "viewVmBreakdown": "View virtual machine state breakdown",
-    "viewVm": "View VM {{name}} in {{namespace}}"
+    "viewVm": "View VM {{name}} in {{namespace}}",
+    "clusters": "Clusters",
+    "clusterBreakdown": "Per-Cluster Breakdown",
+    "viewCluster": "View KubeVirt on {{cluster}}",
+    "vmsRunning": "running",
+    "pausedVMs": "Paused",
+    "errorVMs": "Error",
+    "cpuCores": "CPU",
+    "detailTitle": "KubeVirt Details",
+    "stateBreakdown": "VM State Breakdown",
+    "tenantDistribution": "Tenant Distribution",
+    "searchVMs": "Search VMs...",
+    "noVMs": "No virtual machines found.",
+    "noVMMatch": "No VMs match your search.",
+    "failedPending": "Failed/Pending"
   },
   "kyvernoPolicies": {
     "scanningClusters": "Scanning clusters...",


### PR DESCRIPTION
## Summary

Enhances the KubeVirt Status dashboard card with multi-cluster VM management capabilities, addressing the feature request from Jorge Castro (CNCF DevRel) in #5247.

### What changed

- **Per-cluster breakdown** — shows which clusters have KubeVirt installed, with VM counts, running counts, infra pod counts, and health indicator per cluster
- **CPU/memory allocation** — displays resource allocation (CPU cores and memory) for each VM in both the card list and detail modal
- **Creation time** — shows relative age for each VM (e.g., "14d", "3h") in the detail modal with full ISO timestamp on hover
- **Paused/suspended state** — new VM state alongside running/stopped/migrating/failed with amber color coding
- **Error VM count** — dedicated metric tile for failed VMs on the card summary
- **Enhanced demo data** — 8 VMs across 3 clusters (prod-east, prod-west, staging) for realistic multi-cluster visualization on console.kubestellar.io
- **Card config file** — `kubevirt-status.ts` registered in the unified config system
- **i18n** — new translation keys for cluster breakdown, paused state, CPU/memory labels, and detail modal text
- **Updated catalog** — enhanced description in the Add Cards browse dialog

### Files changed

| File | Change |
|------|--------|
| `web/src/config/cards/kubevirt-status.ts` | **New** — unified card config |
| `web/src/config/cards/index.ts` | Register config |
| `web/src/components/cards/multi-tenancy/kubevirt-status/demoData.ts` | Add cluster, cpu, memory, creationTime fields; ClusterKubevirtInfo type; 8-VM multi-cluster demo |
| `web/src/components/cards/multi-tenancy/kubevirt-status/helpers.ts` | Add `paused` VmState |
| `web/src/components/cards/multi-tenancy/kubevirt-status/useKubevirtStatus.ts` | Per-cluster aggregation, enhanced VmInfo fields |
| `web/src/components/cards/multi-tenancy/kubevirt-status/KubevirtStatus.tsx` | Cluster breakdown section, paused/error tiles |
| `web/src/components/cards/multi-tenancy/kubevirt-status/KubevirtDetailModal.tsx` | CPU/memory/age columns, cluster info, paused state, per-cluster section |
| `web/src/components/cards/cardMetadata.ts` | Updated description |
| `web/src/components/dashboard/shared/cardCatalog.ts` | Updated catalog entry |
| `web/src/locales/en/cards.json` | 13 new translation keys |
| Tests | Paused/suspended state tests, updated modal test |

## Test plan

- [x] `npm run build` passes
- [x] `npm run lint` — no new errors (308 pre-existing)
- [x] All 30 KubeVirt unit tests pass (including 2 new paused/suspended tests)
- [ ] Verify card renders in demo mode on console.kubestellar.io after deploy
- [ ] Verify per-cluster breakdown shows 3 clusters in demo data
- [ ] Verify VM list shows cluster, CPU, memory for each VM
- [ ] Verify detail modal shows age, per-cluster breakdown, and paused state

Closes #5247