### PR TITLE
fix: allow Suggest button without description

### DIFF
--- a/web/src/components/mission-control/FixerDefinitionPanel.tsx
+++ b/web/src/components/mission-control/FixerDefinitionPanel.tsx
@@ -70,8 +70,7 @@ export function FixerDefinitionPanel({
   }, [])
 
   const handleSubmit = () => {
-    if (!state.description.trim()) return
-    if (!state.title) {
+    if (!state.title && state.description.trim()) {
       const firstSentence = state.description.split(/[.!?\n]/)[0].trim()
       onTitleChange(firstSentence.slice(0, 60))
     }
@@ -238,7 +237,7 @@ export function FixerDefinitionPanel({
                 variant="primary"
                 size="sm"
                 onClick={handleSubmit}
-                disabled={!state.description.trim() || aiStreaming}
+                disabled={aiStreaming}
                 className="h-7 px-3"
                 icon={
                   aiStreaming ? (


### PR DESCRIPTION
## Summary
- Removed the empty-description guard on the Suggest button — it was disabled when the description textarea was empty
- AI can now infer context from selected clusters, title, and existing payload even without a description

## Test plan
- [ ] Leave description empty, click Suggest — button should be enabled and AI should respond
- [ ] Fill in description, click Suggest — should still work as before
- [ ] Auto-title generation still works when description is provided but title is empty