### PR TITLE
fix: mission browser overflow, dropdown spacing, health detection, URL escaping

### DIFF
--- a/pkg/kagent/client.go
+++ b/pkg/kagent/client.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	neturl "net/url"
 	"os"
 	"strings"
 	"time"
@@ -79,7 +80,8 @@ func (c *KagentClient) ListAgents() ([]AgentInfo, error) {
 
 // Discover fetches the A2A agent card for the given agent.
 func (c *KagentClient) Discover(namespace, agentName string) (*AgentCard, error) {
-	url := fmt.Sprintf("%s/api/a2a/%s/%s/.well-known/agent.json", c.baseURL, namespace, agentName)
+	url := fmt.Sprintf("%s/api/a2a/%s/%s/.well-known/agent.json",
+		c.baseURL, neturl.PathEscape(namespace), neturl.PathEscape(agentName))
 	resp, err := c.httpClient.Get(url)
 	if err != nil {
 		return nil, fmt.Errorf("failed to discover agent %s/%s: %w", namespace, agentName, err)
@@ -134,7 +136,8 @@ func (c *KagentClient) Invoke(ctx context.Context, namespace, agentName, message
 		return nil, fmt.Errorf("failed to marshal A2A request: %w", err)
 	}
 
-	url := fmt.Sprintf("%s/api/a2a/%s/%s", c.baseURL, namespace, agentName)
+	url := fmt.Sprintf("%s/api/a2a/%s/%s",
+		c.baseURL, neturl.PathEscape(namespace), neturl.PathEscape(agentName))
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, strings.NewReader(string(payload)))
 	if err != nil {
 		return nil, fmt.Errorf("failed to create request: %w", err)
@@ -166,7 +169,9 @@ func (c *KagentClient) Detect() string {
 		resp, err := c.httpClient.Get(url + "/health")
 		if err == nil {
 			resp.Body.Close()
-			return url
+			if resp.StatusCode < 400 {
+				return url
+			}
 		}
 	}
 	return ""

--- a/web/src/components/layout/UserProfileDropdown.tsx
+++ b/web/src/components/layout/UserProfileDropdown.tsx
@@ -348,13 +348,13 @@ export function UserProfileDropdown({ user, onLogout, onPreferences }: UserProfi
           )}
 
           {/* Actions */}
-          <div className="p-2">
+          <div className="p-2 space-y-1">
             <button
               onClick={() => {
                 closeDropdown()
                 openFeedbackModal()
               }}
-              className="w-full flex items-center gap-3 px-3 py-2 text-sm text-foreground hover:bg-secondary rounded-lg transition-colors"
+              className="w-full flex items-center gap-3 px-3 py-2.5 text-sm text-foreground hover:bg-secondary rounded-lg transition-colors"
             >
               <Lightbulb className="w-4 h-4 text-yellow-500" />
               <span>{t('feedback.feedback')}</span>
@@ -362,7 +362,7 @@ export function UserProfileDropdown({ user, onLogout, onPreferences }: UserProfi
             </button>
             <button
               onClick={handleLinkedInShare}
-              className="w-full flex items-center gap-3 px-3 py-2 text-sm text-foreground hover:bg-secondary rounded-lg transition-colors"
+              className="w-full flex items-center gap-3 px-3 py-2.5 text-sm text-foreground hover:bg-secondary rounded-lg transition-colors"
             >
               <Linkedin className="w-4 h-4 text-[#0A66C2]" />
               <span>{t('feedback.shareOnLinkedIn')}</span>
@@ -373,7 +373,7 @@ export function UserProfileDropdown({ user, onLogout, onPreferences }: UserProfi
                 closeDropdown()
                 onPreferences?.()
               }}
-              className="w-full flex items-center gap-3 px-3 py-2 text-sm text-foreground hover:bg-secondary rounded-lg transition-colors"
+              className="w-full flex items-center gap-3 px-3 py-2.5 text-sm text-foreground hover:bg-secondary rounded-lg transition-colors"
             >
               <Settings className="w-4 h-4 text-muted-foreground" />
               {t('settings.title')}
@@ -387,7 +387,7 @@ export function UserProfileDropdown({ user, onLogout, onPreferences }: UserProfi
                   onLogout()
                 }
               }}
-              className={`w-full flex items-center gap-3 px-3 py-2 text-sm rounded-lg transition-colors ${
+              className={`w-full flex items-center gap-3 px-3 py-2.5 text-sm rounded-lg transition-colors ${
                 isDemoModeForced
                   ? 'text-purple-400 hover:bg-purple-950'
                   : 'text-red-400 hover:bg-red-950'

--- a/web/src/components/missions/MissionBrowser.tsx
+++ b/web/src/components/missions/MissionBrowser.tsx
@@ -1183,7 +1183,7 @@ export function MissionBrowser({ isOpen, onClose, onImport, initialMission }: Mi
 
       {/* Filter bar — constrained height on mobile with scroll */}
       {showFilters && (
-        <div className="px-4 py-2.5 bg-card border-b border-border space-y-2 max-h-[40vh] md:max-h-none overflow-y-auto">
+        <div className="px-4 py-2.5 bg-card border-b border-border space-y-2 max-h-[40vh] md:max-h-[50vh] overflow-y-auto">
           {/* Row 1: Clear all + Match % + Source + Category */}
           <div className="flex items-center gap-3 flex-wrap">
             {activeFilterCount > 0 && (


### PR DESCRIPTION
## Summary

Fixes four reported issues:

- **#5260** — Mission browser filter bar overflows on desktop: capped at `max-h-[50vh]` (was `max-h-none`) so filters scroll instead of pushing bottom content outside the modal
- **#5262** — Profile dropdown action items too closely spaced: added `space-y-1` gap between items and increased vertical padding from `py-2` to `py-2.5`
- **#5263** — `Detect()` accepted unhealthy endpoints (500/503): now checks `resp.StatusCode < 400` before treating a kagent endpoint as reachable
- **#5264** — Unescaped path segments in agent URLs: namespace and agentName are now escaped with `url.PathEscape()` in both `Discover()` and `Invoke()`

Closes #5260, #5262, #5263, #5264

## Test plan

- [ ] Open mission browser with filters expanded -- filter bar should scroll on desktop if taller than 50vh
- [ ] Open profile dropdown -- action items should have visible spacing between them
- [ ] Go build passes (`go build ./...`)
- [ ] Frontend build passes (`npm run build`)