### PR TITLE
fix: resolve 6 bugs (#5250, #5252, #5253, #5255, #5258, #5259)

### DIFF
--- a/web/src/components/cards/CardWrapper.tsx
+++ b/web/src/components/cards/CardWrapper.tsx
@@ -752,16 +752,39 @@ export function CardWrapper({
     }
   }, [showMenu])
 
-  // Keep menu anchored to button on scroll/resize
+  // Keep menu anchored to button on scroll/resize.
+  // Includes boundary detection to prevent the menu from rendering off-screen (#5253).
   useEffect(() => {
     if (!showMenu || !menuButtonRef.current) return
+
+    /** Approximate height of the card action menu (px) */
+    const MENU_APPROX_HEIGHT = 300
+    /** Width of the card action menu (w-48 = 192px) */
+    const MENU_WIDTH_PX = 192
+    /** Viewport edge padding (px) */
+    const VIEWPORT_PADDING = 8
 
     const updatePosition = () => {
       if (menuButtonRef.current) {
         const rect = menuButtonRef.current.getBoundingClientRect()
-        setMenuPosition({
-          top: rect.bottom + 4,
-          right: window.innerWidth - rect.right })
+        let top = rect.bottom + 4
+        let right = window.innerWidth - rect.right
+
+        // If the menu would extend below the viewport, position it above the button
+        if (top + MENU_APPROX_HEIGHT > window.innerHeight - VIEWPORT_PADDING) {
+          top = Math.max(VIEWPORT_PADDING, rect.top - MENU_APPROX_HEIGHT - 4)
+        }
+        // If the menu would extend beyond the right edge, clamp it
+        if (right < VIEWPORT_PADDING) {
+          right = VIEWPORT_PADDING
+        }
+        // If the menu would extend beyond the left edge, clamp it
+        const leftEdge = window.innerWidth - right - MENU_WIDTH_PX
+        if (leftEdge < VIEWPORT_PADDING) {
+          right = window.innerWidth - MENU_WIDTH_PX - VIEWPORT_PADDING
+        }
+
+        setMenuPosition({ top, right })
       }
     }
 
@@ -982,9 +1005,29 @@ export function CardWrapper({
                     onClick={() => {
                       if (!showMenu && menuButtonRef.current) {
                         const rect = menuButtonRef.current.getBoundingClientRect()
-                        setMenuPosition({
-                          top: rect.bottom + 4,
-                          right: window.innerWidth - rect.right })
+                        /** Approximate height of the card action menu (px) */
+                        const MENU_APPROX_HEIGHT = 300
+                        /** Width of the card action menu (w-48 = 192px) */
+                        const MENU_WIDTH_PX = 192
+                        /** Viewport edge padding (px) */
+                        const VIEWPORT_PADDING = 8
+
+                        let top = rect.bottom + 4
+                        let right = window.innerWidth - rect.right
+
+                        // Prevent menu from rendering off-screen (#5253)
+                        if (top + MENU_APPROX_HEIGHT > window.innerHeight - VIEWPORT_PADDING) {
+                          top = Math.max(VIEWPORT_PADDING, rect.top - MENU_APPROX_HEIGHT - 4)
+                        }
+                        if (right < VIEWPORT_PADDING) {
+                          right = VIEWPORT_PADDING
+                        }
+                        const leftEdge = window.innerWidth - right - MENU_WIDTH_PX
+                        if (leftEdge < VIEWPORT_PADDING) {
+                          right = window.innerWidth - MENU_WIDTH_PX - VIEWPORT_PADDING
+                        }
+
+                        setMenuPosition({ top, right })
                       }
                       setShowMenu(!showMenu)
                     }}

--- a/web/src/components/cards/ClusterMetrics.tsx
+++ b/web/src/components/cards/ClusterMetrics.tsx
@@ -380,7 +380,7 @@ export function ClusterMetrics() {
           <div>
             <p className="text-xs text-muted-foreground">{t('cards:clusterMetrics.min')}</p>
             <p className="text-sm font-medium text-foreground">
-              {Math.round(Math.min(...data.map((d) => d.value)))}{config.unit}
+              {(() => { const vals = data.map((d) => d.value); return Math.round(vals.length > 0 ? Math.min(...vals) : 0) })()}{config.unit}
             </p>
           </div>
           <div>
@@ -392,7 +392,7 @@ export function ClusterMetrics() {
           <div>
             <p className="text-xs text-muted-foreground">{t('cards:clusterMetrics.max')}</p>
             <p className="text-sm font-medium text-foreground">
-              {Math.round(Math.max(...data.map((d) => d.value)))}{config.unit}
+              {(() => { const vals = data.map((d) => d.value); return Math.round(vals.length > 0 ? Math.max(...vals) : 0) })()}{config.unit}
             </p>
           </div>
         </div>

--- a/web/src/contexts/AlertsContext.tsx
+++ b/web/src/contexts/AlertsContext.tsx
@@ -424,7 +424,23 @@ export function AlertsProvider({ children }: { children: ReactNode }) {
   // from sending repeated macOS notifications on every evaluation cycle.
   // Keys are NOT cleared on resolve — a cooldown period prevents re-notification
   // when clusters flap between reachable/unreachable states.
+  //
+  // Persisted to localStorage on every mutation to prevent duplicate
+  // notifications after page refresh (#5258). Previously keys were only
+  // saved at the end of evaluateConditions, so a refresh mid-cycle lost them.
   const notifiedAlertKeysRef = useRef<Map<string, number>>(loadNotifiedAlertKeys())
+
+  /** Set a notification dedup key and immediately persist to localStorage (#5258). */
+  const setNotifiedKey = useCallback((key: string, timestamp: number) => {
+    notifiedAlertKeysRef.current.set(key, timestamp)
+    saveNotifiedAlertKeys(notifiedAlertKeysRef.current)
+  }, [])
+
+  /** Delete a notification dedup key and immediately persist to localStorage (#5258). */
+  const deleteNotifiedKey = useCallback((key: string) => {
+    notifiedAlertKeysRef.current.delete(key)
+    saveNotifiedAlertKeys(notifiedAlertKeysRef.current)
+  }, [])
 
   // CronJob health results cache — fetched async, read synchronously by evaluator
   const cronJobResultsRef = useRef<Record<string, GPUHealthCheckResult[]>>({})
@@ -1248,7 +1264,7 @@ Please provide:
             rule.channels?.some(ch => ch.type === 'browser' && ch.enabled) &&
             (!notifiedAlertKeysRef.current.has(notifKey) || (Date.now() - (notifiedAlertKeysRef.current.get(notifKey) ?? 0)) > NOTIFICATION_COOLDOWN_MS)
           ) {
-            notifiedAlertKeysRef.current.set(notifKey, Date.now())
+            setNotifiedKey(notifKey, Date.now())
             const firstNode = failedNodes[0]
             sendNotificationWithDeepLink(
               `GPU Health Alert: ${cluster.name}`,
@@ -1304,7 +1320,7 @@ Please provide:
             rule.channels?.some(ch => ch.type === 'browser' && ch.enabled) &&
             (!notifiedAlertKeysRef.current.has(notifKey) || (Date.now() - (notifiedAlertKeysRef.current.get(notifKey) ?? 0)) > NOTIFICATION_COOLDOWN_MS)
           ) {
-            notifiedAlertKeysRef.current.set(notifKey, Date.now())
+            setNotifiedKey(notifKey, Date.now())
             sendNotificationWithDeepLink(
               `Disk Pressure: ${cluster.name}`,
               diskPressureIssue,
@@ -1393,7 +1409,7 @@ Please provide:
           rule.channels?.some(ch => ch.type === 'browser' && ch.enabled) &&
           (!notifiedAlertKeysRef.current.has(notifKey) || (Date.now() - (notifiedAlertKeysRef.current.get(notifKey) ?? 0)) > NOTIFICATION_COOLDOWN_MS)
         ) {
-          notifiedAlertKeysRef.current.set(notifKey, Date.now())
+          setNotifiedKey(notifKey, Date.now())
           sendNotificationWithDeepLink(
             `DNS Failure: ${cluster}`,
             `${pods.length} CoreDNS pod(s) unhealthy — ${issues || 'check pod status'}`,
@@ -1445,7 +1461,7 @@ Please provide:
           if (
             rule.channels?.some(ch => ch.type === 'browser' && ch.enabled) && shouldNotify
           ) {
-            notifiedAlertKeysRef.current.set(notifKey, Date.now())
+            setNotifiedKey(notifKey, Date.now())
             sendNotificationWithDeepLink(
               `Certificate Error: ${cluster.name}`,
               cluster.errorMessage || 'TLS certificate validation failed',
@@ -1455,7 +1471,7 @@ Please provide:
         } else {
           // Auto-resolve if cert error clears — also clear dedup so next failure re-notifies
           const notifKey = alertDedupKey(rule.id, rule.condition.type, cluster.name)
-          notifiedAlertKeysRef.current.delete(notifKey)
+          deleteNotifiedKey(notifKey)
           queueAutoResolve(rule.id, cluster.name)
         }
       }
@@ -1498,7 +1514,7 @@ Please provide:
           if (
             rule.channels?.some(ch => ch.type === 'browser' && ch.enabled) && shouldNotify
           ) {
-            notifiedAlertKeysRef.current.set(notifKey, Date.now())
+            setNotifiedKey(notifKey, Date.now())
             sendNotificationWithDeepLink(
               `Cluster Unreachable: ${cluster.name}`,
               `${errorLabel}${cluster.lastSeen ? ` — last seen ${cluster.lastSeen}` : ''}`,
@@ -1508,7 +1524,7 @@ Please provide:
         } else if (cluster.reachable !== false) {
           // Auto-resolve when cluster becomes reachable — clear dedup so next failure re-notifies
           const notifKey = alertDedupKey(rule.id, rule.condition.type, cluster.name)
-          notifiedAlertKeysRef.current.delete(notifKey)
+          deleteNotifiedKey(notifKey)
           queueAutoResolve(rule.id, cluster.name)
         }
       }
@@ -1566,7 +1582,7 @@ Please provide:
             rule.channels?.some(ch => ch.type === 'browser' && ch.enabled) &&
             (!notifiedAlertKeysRef.current.has(notifKey) || (Date.now() - (notifiedAlertKeysRef.current.get(notifKey) ?? 0)) > NOTIFICATION_COOLDOWN_MS)
           ) {
-            notifiedAlertKeysRef.current.set(notifKey, Date.now())
+            setNotifiedKey(notifKey, Date.now())
             sendNotificationWithDeepLink(
               `Nightly E2E Failed: ${guide.acronym} (${guide.platform})`,
               `Run #${run.runNumber} failed — ${guide.guide}`,

--- a/web/src/lib/cache/index.ts
+++ b/web/src/lib/cache/index.ts
@@ -1100,10 +1100,14 @@ export function useCache<T>({
   // liveInDemoMode bypasses the demo check for cards backed by serverless functions
   const effectiveEnabled = enabled && (!demoMode || liveInDemoMode)
 
-  // Get or create cache store
+  // Get or create cache store.
+  // Track the key so we can reset the ref when the cache key changes
+  // (e.g., switching clusters). Without this, storeRef points to stale data (#5259).
   const storeRef = useRef<CacheStore<T> | null>(null)
+  const storeKeyRef = useRef(key)
 
-  if (!storeRef.current) {
+  if (!storeRef.current || storeKeyRef.current !== key) {
+    storeKeyRef.current = key
     storeRef.current = shared
       ? getOrCreateCache(key, initialData, persist)
       : new CacheStore(key, initialData, persist)
@@ -1151,6 +1155,11 @@ export function useCache<T>({
   const prevEnabledRef = useRef(effectiveEnabled)
   const initialFetchDoneRef = useRef(false)
 
+  // Track the auto-refresh timer in a ref to avoid thrashing (#5252).
+  // Without this, changing consecutiveFailures recreates the interval on every
+  // render, defeating the exponential backoff.
+  const autoRefreshTimerRef = useRef<ReturnType<typeof setInterval> | null>(null)
+
   useEffect(() => {
     if (!effectiveEnabled) {
       // In demo/disabled mode, no fetch will run — mark loading as done
@@ -1158,6 +1167,11 @@ export function useCache<T>({
       hasMountedRef.current = true
       prevEnabledRef.current = effectiveEnabled
       initialFetchDoneRef.current = false
+      // Clear any pending auto-refresh timer
+      if (autoRefreshTimerRef.current) {
+        clearInterval(autoRefreshTimerRef.current)
+        autoRefreshTimerRef.current = null
+      }
       return
     }
 
@@ -1179,15 +1193,44 @@ export function useCache<T>({
     // Register for mode-transition refetches so triggerAllRefetches() reaches us
     const unregisterRefetch = registerRefetch(`cache:${key}`, refetch)
 
-    // Auto-refresh interval
-    // The interval restarts when consecutiveFailures changes (backoff kicks in).
-    // Suppressed when the dashboard "Auto" checkbox is unchecked (global pause).
+    // Auto-refresh interval — uses a ref-tracked timer to prevent thrashing.
+    // Only create a new timer if none is already pending (#5252).
     if (autoRefresh && !autoRefreshGloballyPaused) {
-      const intervalId = setInterval(() => { refetch().catch(() => { /* errors handled inside CacheStore.fetch */ }) }, effectiveInterval)
-      return () => { clearInterval(intervalId); unregisterRefetch() }
+      if (!autoRefreshTimerRef.current) {
+        autoRefreshTimerRef.current = setInterval(() => {
+          refetch().catch(() => { /* errors handled inside CacheStore.fetch */ })
+        }, effectiveInterval)
+      }
+    } else if (autoRefreshTimerRef.current) {
+      clearInterval(autoRefreshTimerRef.current)
+      autoRefreshTimerRef.current = null
     }
-    return () => unregisterRefetch()
-  }, [effectiveEnabled, autoRefresh, autoRefreshGloballyPaused, effectiveInterval, refetch, store, key, state.consecutiveFailures])
+
+    return () => {
+      unregisterRefetch()
+    }
+  }, [effectiveEnabled, autoRefresh, autoRefreshGloballyPaused, refetch, store, key])
+
+  // Restart the auto-refresh timer when the backoff interval changes.
+  // Separated from the main effect to avoid re-running mount/mode-transition logic (#5252).
+  useEffect(() => {
+    if (!autoRefreshTimerRef.current || !autoRefresh || autoRefreshGloballyPaused) return
+    // Clear old timer and create a new one with updated interval
+    clearInterval(autoRefreshTimerRef.current)
+    autoRefreshTimerRef.current = setInterval(() => {
+      refetch().catch(() => { /* errors handled inside CacheStore.fetch */ })
+    }, effectiveInterval)
+  }, [effectiveInterval, autoRefresh, autoRefreshGloballyPaused, refetch])
+
+  // Clean up auto-refresh timer on unmount
+  useEffect(() => {
+    return () => {
+      if (autoRefreshTimerRef.current) {
+        clearInterval(autoRefreshTimerRef.current)
+        autoRefreshTimerRef.current = null
+      }
+    }
+  }, [])
 
   // Cleanup non-shared stores on unmount
   useEffect(() => {

--- a/web/src/lib/cards/useStablePageHeight.ts
+++ b/web/src/lib/cards/useStablePageHeight.ts
@@ -31,9 +31,11 @@ export function useStablePageHeight(pageSize: number | string, totalItems: numbe
   // when a taller page is observed. The guard prevents calling setState
   // when the height hasn't actually changed (avoiding re-render loops).
   //
-  // IMPORTANT: We temporarily remove minHeight before measuring to avoid a
-  // feedback loop where setting minHeight increases scrollHeight, which
-  // triggers another setState, ad infinitum ("Maximum update depth exceeded").
+  // CLS fix (#5255): Only temporarily remove minHeight for measurement when
+  // no max height has been tracked yet. Once we have a max height from a full
+  // page, we compare scrollHeight directly — if the content grew beyond our
+  // tracked max, we update. Otherwise we skip the measurement entirely to
+  // avoid the brief layout flicker caused by clearing and restoring minHeight.
   // eslint-disable-next-line react-hooks/exhaustive-deps
   useLayoutEffect(() => {
     const el = containerRef.current
@@ -41,8 +43,21 @@ export function useStablePageHeight(pageSize: number | string, totalItems: numbe
     const effectivePageSize = typeof pageSize === 'number' ? pageSize : Infinity
     if (totalItems <= effectivePageSize) return // no pagination active
 
-    // Temporarily clear minHeight so we measure the natural content height,
-    // not the inflated height from a previous minHeight setting.
+    if (maxHeightRef.current > 0) {
+      // We already have a tracked max height. Check if content grew beyond it
+      // WITHOUT clearing minHeight (avoids CLS flicker on partial pages).
+      const height = el.scrollHeight
+      if (height > maxHeightRef.current) {
+        maxHeightRef.current = height
+        if (height !== stableMinHeight) {
+          setStableMinHeight(height)
+        }
+      }
+      return
+    }
+
+    // First measurement: temporarily clear minHeight so we measure the
+    // natural content height, not an inflated height from a prior setting.
     const prevMinHeight = el.style.minHeight
     el.style.minHeight = ''
     const height = el.scrollHeight


### PR DESCRIPTION
## Summary
- **#5250** — Guard `Math.min`/`Math.max` with empty array check in `ClusterMetrics` to prevent `-Infinity` crash
- **#5252** — Track auto-refresh timer in a ref to prevent interval thrashing during exponential backoff
- **#5253** — Add viewport boundary detection to `CardWrapper` action menu positioning (prevents off-screen rendering)
- **#5255** — Skip `minHeight` removal during measurement when max height is tracked (prevents CLS flicker on partial pages)
- **#5258** — Persist notification dedup keys to `localStorage` immediately on each mutation (prevents duplicate notifications on refresh)
- **#5259** — Reset `storeRef` in `useCache` when cache key changes (prevents stale data when switching clusters)

## Test plan
- [ ] Open ClusterMetrics card with no clusters connected — verify no crash
- [ ] Disconnect a cluster to trigger consecutive failures — verify backoff intervals increase properly
- [ ] Open card action menu on a right-edge card near bottom of viewport — verify menu stays visible
- [ ] Navigate to last page of a paginated card — verify no height flicker
- [ ] Trigger an alert, refresh the page — verify no duplicate notification
- [ ] Switch between clusters in a cached view — verify data updates correctly

Fixes #5250, #5252, #5253, #5255, #5258, #5259