### PR TITLE
fix: address Copilot review on NPS survey

### DIFF
--- a/web/src/components/feedback/NPSSurvey.tsx
+++ b/web/src/components/feedback/NPSSurvey.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback } from 'react'
+import { useState, useCallback, useEffect, useRef } from 'react'
 import { createPortal } from 'react-dom'
 import { useTranslation } from 'react-i18next'
 import { X, Send, CheckCircle2 } from 'lucide-react'
@@ -18,7 +18,7 @@ const THANK_YOU_DISPLAY_MS = 2_000
 
 const FEEDBACK_PROMPT_KEYS = {
   detractor: 'nps.feedbackNegative',
-  passive: 'nps.feedbackNegative',
+  passive: 'nps.feedbackNeutral',
   satisfied: 'nps.feedbackNeutral',
   promoter: 'nps.feedbackPositive',
 } as const
@@ -31,6 +31,12 @@ export function NPSSurvey() {
   const [feedback, setFeedback] = useState('')
   const [isSubmitting, setIsSubmitting] = useState(false)
   const [showThankYou, setShowThankYou] = useState(false)
+  const thankYouTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  // Cleanup thank-you timer on unmount
+  useEffect(() => () => {
+    if (thankYouTimerRef.current) clearTimeout(thankYouTimerRef.current)
+  }, [])
 
   const selectedOption = NPS_OPTIONS.find(o => o.score === selectedScore) ?? null
 
@@ -41,7 +47,7 @@ export function NPSSurvey() {
       await submitResponse(selectedScore, feedback.trim() || undefined)
       setShowThankYou(true)
       showToast(t('nps.thankYou'), 'success')
-      setTimeout(() => setShowThankYou(false), THANK_YOU_DISPLAY_MS)
+      thankYouTimerRef.current = setTimeout(() => setShowThankYou(false), THANK_YOU_DISPLAY_MS)
     } finally {
       setIsSubmitting(false)
     }

--- a/web/src/hooks/__tests__/useNPSSurvey.test.ts
+++ b/web/src/hooks/__tests__/useNPSSurvey.test.ts
@@ -124,12 +124,12 @@ describe('useNPSSurvey', () => {
     act(() => { vi.advanceTimersByTime(30_000) })
 
     await act(async () => {
-      await result.current.submitResponse(1, 'Too complex')
+      await result.current.submitResponse(1, 'The UI is too complex and hard to navigate')
     })
 
     expect(mockApiPost).toHaveBeenCalledWith('/api/feedback/requests', {
       title: 'NPS Detractor Feedback (Score: 1)',
-      description: 'Too complex',
+      description: 'The UI is too complex and hard to navigate',
       request_type: 'bug',
     })
   })

--- a/web/src/hooks/useNPSSurvey.ts
+++ b/web/src/hooks/useNPSSurvey.ts
@@ -43,9 +43,14 @@ export interface NPSSurveyState {
   dismiss: () => void
 }
 
+/** Minimum description length required by the backend feedback API */
+const MIN_FEEDBACK_LENGTH = 20
+
 function daysSince(isoDate: string | null): number {
   if (!isoDate) return Infinity
-  return (Date.now() - new Date(isoDate).getTime()) / MS_PER_DAY
+  const timestamp = new Date(isoDate).getTime()
+  if (!Number.isFinite(timestamp)) return 0
+  return (Date.now() - timestamp) / MS_PER_DAY
 }
 
 function isEligible(state: NPSPersistentState): boolean {
@@ -92,15 +97,19 @@ export function useNPSSurvey(): NPSSurveyState {
   }, [isAuthenticated])
 
   const submitResponse = useCallback(async (score: number, feedback?: string) => {
-    const category = NPS_CATEGORIES[score - 1] || 'unknown'
+    if (!Number.isInteger(score) || score < 1 || score > 4) return
+
+    const category = NPS_CATEGORIES[score - 1]
     emitNPSResponse(score, category, feedback ? feedback.length : undefined)
 
     // Create GitHub issue for detractors (score 1 = "Not great")
-    if (score === 1 && feedback?.trim()) {
+    // Backend requires description >= MIN_FEEDBACK_LENGTH chars
+    const trimmed = feedback?.trim() || ''
+    if (score === 1 && trimmed.length >= MIN_FEEDBACK_LENGTH) {
       try {
         await api.post('/api/feedback/requests', {
           title: `NPS Detractor Feedback (Score: ${score})`,
-          description: feedback.trim(),
+          description: trimmed,
           request_type: 'bug',
         })
       } catch {


### PR DESCRIPTION
Follow-up to #5274 — addresses all 6 Copilot review comments:

1. **NaN guard in daysSince()** — corrupted localStorage dates now treated as "just now" (score=0) instead of eligible
2. **Score validation** — reject out-of-range values before updating state/analytics/rewards
3. **Backend min length** — only call `/api/feedback/requests` when feedback >= 20 chars (backend enforces this)
4. **Passive prompt key** — map to `nps.feedbackNeutral` instead of `nps.feedbackNegative`
5. **setTimeout cleanup** — clear thank-you timer on unmount via useRef + useEffect
6. **PR body format** — already addressed in merged PR

## Test plan
- [ ] 11 unit tests pass
- [ ] Build clean