### PR TITLE
fix: suppress backend-unavailable noise in GA4 error tracking

### DIFF
--- a/web/src/components/gitops/GitOps.tsx
+++ b/web/src/components/gitops/GitOps.tsx
@@ -94,6 +94,9 @@ export function GitOps() {
   const [isDetecting, setIsDetecting] = useState(true)
   const [lastUpdated, setLastUpdated] = useState<Date | null>(null)
 
+  // Cache helm releases count to prevent showing 0 during refresh
+  const cachedHelmCount = useRef(0)
+
   // Set initial lastUpdated on mount
   useEffect(() => {
     setLastUpdated(new Date())
@@ -220,8 +223,6 @@ export function GitOps() {
     healthy: apps.filter(a => a.healthStatus === 'healthy').length,
     checking: apps.filter(a => a.syncStatus === 'checking').length }
 
-  // Cache helm releases count to prevent showing 0 during refresh
-  const cachedHelmCount = useRef(0)
   useEffect(() => {
     if (helmReleases.length > 0) cachedHelmCount.current = helmReleases.length
   }, [helmReleases.length])

--- a/web/src/lib/analytics.ts
+++ b/web/src/lib/analytics.ts
@@ -15,7 +15,7 @@
 
 import { STORAGE_KEY_ANALYTICS_OPT_OUT, STORAGE_KEY_ANONYMOUS_USER_ID } from './constants'
 import { CHUNK_RELOAD_TS_KEY, isChunkLoadMessage } from './chunkErrors'
-import { isDemoMode } from './demoMode'
+import { isDemoMode, isNetlifyDeployment } from './demoMode'
 
 // DECOY Measurement ID — the proxy rewrites this to the real ID server-side.
 const GA_MEASUREMENT_ID = 'G-0000000000'
@@ -1160,6 +1160,9 @@ export function startGlobalErrorTracking() {
       // send(). The kubectlProxy try/catch handles these; they surface here only
       // due to browser microtask ordering.
       if (msg.includes('send was called before connect') || msg.includes('InvalidStateError')) return
+      // Skip BackendUnavailableError on Netlify / console.kubestellar.io — expected
+      // because the Go backend is not deployed there (demo mode uses MSW).
+      if (isNetlifyDeployment && msg.includes('Backend API is currently unavailable')) return
       emitError('unhandled_rejection', msg)
     } finally {
       isEmitting = false


### PR DESCRIPTION
## Summary
Addresses GA4 error noise from April 7 (22/30 errors were false positives):

- **Suppress `BackendUnavailableError` on console.kubestellar.io** — the Go backend isn't deployed on Netlify, so these are expected. Added a skip in the `unhandledrejection` handler when `isNetlifyDeployment` is true.
- **Move `useRef` in GitOps.tsx** to top of component with other hooks — was placed after `useMemo` and business logic, which can confuse React's hook ordering in edge cases (related to the "Hooks called conditionally" error on `/gitops`).

The 3 card_render `useRef` errors (cluster_comparison, llmd_flow, llmd_stack_monitor) are from stale cached chunks — current code has correct imports. They'll self-resolve as users get the new bundle.

## Test plan
- [ ] Build passes
- [ ] Visit console.kubestellar.io → no `ksc_error` events for "Backend API is currently unavailable" in GA4
- [ ] Visit `/gitops` page → no "Hooks called conditionally" error