### PR TITLE
chore: disable all Copilot workflows

### DIFF
--- a/.github/workflows/ai-fix.yml
+++ b/.github/workflows/ai-fix.yml
@@ -19,6 +19,7 @@ permissions:
 
 jobs:
   ai-fix:
+    if: false # Copilot disabled — issues handled by Claude Code scanner
     uses: kubestellar/infra/.github/workflows/reusable-ai-fix.yml@main
     with:
       issue_number: ${{ github.event.inputs.issue_number || '' }}

--- a/.github/workflows/auto-triage.lock.yml
+++ b/.github/workflows/auto-triage.lock.yml
@@ -39,7 +39,7 @@ run-name: "Auto-Triage on Copilot Assignment"
 jobs:
   activation:
     needs: pre_activation
-    if: needs.pre_activation.outputs.activated == 'true'
+    if: false # Copilot disabled — issues handled by Claude Code scanner
     runs-on: ubuntu-slim
     permissions:
       contents: read
@@ -243,6 +243,7 @@ jobs:
           retention-days: 1
 
   agent:
+    if: false # Copilot disabled — issues handled by Claude Code scanner
     needs: activation
     runs-on: ubuntu-latest
     permissions:
@@ -838,7 +839,7 @@ jobs:
       - activation
       - agent
       - safe_outputs
-    if: (always()) && ((needs.agent.result != 'skipped') || (needs.activation.outputs.lockdown_check_failed == 'true'))
+    if: false # Copilot disabled — issues handled by Claude Code scanner
     runs-on: ubuntu-slim
     permissions:
       contents: read
@@ -939,6 +940,7 @@ jobs:
             await main();
 
   pre_activation:
+    if: false # Copilot disabled — issues handled by Claude Code scanner
     runs-on: ubuntu-slim
     outputs:
       activated: ${{ steps.check_membership.outputs.is_team_member == 'true' }}
@@ -963,7 +965,7 @@ jobs:
 
   safe_outputs:
     needs: agent
-    if: ((!cancelled()) && (needs.agent.result != 'skipped')) && (needs.agent.outputs.detection_success == 'true')
+    if: false # Copilot disabled — issues handled by Claude Code scanner
     runs-on: ubuntu-slim
     permissions:
       contents: read

--- a/.github/workflows/copilot-assigned.yml
+++ b/.github/workflows/copilot-assigned.yml
@@ -13,10 +13,7 @@ permissions:
 
 jobs:
   handle-copilot-assignment:
-    if: |
-      github.event.assignee.login == 'Copilot' ||
-      github.event.assignee.login == 'copilot-swe-agent' ||
-      github.event.assignee.login == 'copilot-swe-agent[bot]'
+    if: false # Copilot disabled — issues handled by Claude Code scanner
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/copilot-automation.yml
+++ b/.github/workflows/copilot-automation.yml
@@ -22,6 +22,7 @@ concurrency:
 
 jobs:
   copilot-automation:
+    if: false # Copilot disabled — issues handled by Claude Code scanner
     uses: kubestellar/infra/.github/workflows/reusable-copilot-automation.yml@main
     with:
       pr_number: ${{ github.event.inputs.pr_number || '' }}

--- a/.github/workflows/copilot-build-check.yml
+++ b/.github/workflows/copilot-build-check.yml
@@ -15,6 +15,7 @@ permissions:
 
 jobs:
   build-lint:
+    if: false # Copilot disabled — issues handled by Claude Code scanner
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/copilot-build-monitor.yml
+++ b/.github/workflows/copilot-build-monitor.yml
@@ -12,10 +12,8 @@ permissions:
 
 jobs:
   handle-build-failure:
+    if: false # Copilot disabled — issues handled by Claude Code scanner
     runs-on: ubuntu-latest
-    if: |
-      github.event.check_run.conclusion == 'failure' &&
-      contains(github.event.check_run.name, 'netlify')
     steps:
       - name: Handle Netlify Failure
         uses: actions/github-script@v7

--- a/.github/workflows/copilot-dco.yml
+++ b/.github/workflows/copilot-dco.yml
@@ -6,4 +6,5 @@ on:
 
 jobs:
   copilot-dco:
+    if: false # Copilot disabled — issues handled by Claude Code scanner
     uses: kubestellar/infra/.github/workflows/reusable-copilot-dco.yml@main

--- a/.github/workflows/copilot-pr-monitor.yml
+++ b/.github/workflows/copilot-pr-monitor.yml
@@ -19,6 +19,7 @@ permissions:
 
 jobs:
   monitor-copilot-prs:
+    if: false # Copilot disabled — issues handled by Claude Code scanner
     runs-on: ubuntu-latest
     steps:
       - name: Check Copilot PRs (3x with 20s intervals)

--- a/.github/workflows/copilot-recovery.yml
+++ b/.github/workflows/copilot-recovery.yml
@@ -39,16 +39,14 @@ jobs:
   # preventing GitHub from reporting "No jobs were run" as a failure
   # and sending noisy email notifications.
   gate:
+    if: false # Copilot disabled — issues handled by Claude Code scanner
     runs-on: ubuntu-latest
     steps:
       - run: echo "Event ${{ github.event_name }} received"
 
   # Override DCO for bot PRs automatically
   override-dco-for-bots:
-    if: |
-      github.event_name == 'check_run' &&
-      github.event.check_run.name == 'dco' &&
-      github.event.check_run.conclusion == 'failure'
+    if: false # Copilot disabled — issues handled by Claude Code scanner
     runs-on: ubuntu-latest
     steps:
       - name: Check if PR is from a bot
@@ -97,13 +95,7 @@ jobs:
   # Handle build failures on Copilot PRs
   # Only trigger on "Deploy Preview" check to avoid duplicate comments from Netlify sub-checks
   handle-build-failure:
-    if: |
-      github.event_name == 'check_run' &&
-      github.event.check_run.conclusion == 'failure' &&
-      github.event.check_run.name != 'dco' &&
-      !contains(github.event.check_run.name, 'Header rules') &&
-      !contains(github.event.check_run.name, 'Redirect rules') &&
-      !contains(github.event.check_run.name, 'Pages changed')
+    if: false # Copilot disabled — issues handled by Claude Code scanner
     runs-on: ubuntu-latest
     steps:
       - name: Get PR info
@@ -203,10 +195,7 @@ jobs:
   # Handle successful builds - trigger preview testing
   # Netlify check runs are named like "Header rules - kubestellarconsole"
   handle-build-success:
-    if: |
-      github.event_name == 'check_run' &&
-      github.event.check_run.conclusion == 'success' &&
-      contains(github.event.check_run.name, 'kubestellarconsole')
+    if: false # Copilot disabled — issues handled by Claude Code scanner
     runs-on: ubuntu-latest
     steps:
       - name: Get PR info
@@ -389,7 +378,7 @@ jobs:
 
   # Handle workflow run completion (for more complex build pipelines)
   handle-workflow-completion:
-    if: github.event_name == 'workflow_run'
+    if: false # Copilot disabled — issues handled by Claude Code scanner
     runs-on: ubuntu-latest
     steps:
       - name: Check workflow result
@@ -438,9 +427,7 @@ jobs:
 
   # Handle code review feedback on Copilot PRs
   handle-review-feedback:
-    if: |
-      (github.event_name == 'pull_request_review' && github.event.review.state == 'changes_requested') ||
-      github.event_name == 'pull_request_review_comment'
+    if: false # Copilot disabled — issues handled by Claude Code scanner
     runs-on: ubuntu-latest
     steps:
       - name: Check if PR is from Copilot
@@ -501,7 +488,7 @@ jobs:
 
   # Manual preview test (triggered via workflow_dispatch)
   manual-preview-test:
-    if: github.event_name == 'workflow_dispatch' && github.event.inputs.test_preview == 'true'
+    if: false # Copilot disabled — issues handled by Claude Code scanner
     runs-on: ubuntu-latest
     steps:
       - name: Test preview deployment
@@ -588,7 +575,7 @@ jobs:
 
   # Auto-request Copilot to test preview when commits are pushed
   request-copilot-preview-test:
-    if: github.event_name == 'pull_request_target' && github.event.action == 'synchronize'
+    if: false # Copilot disabled — issues handled by Claude Code scanner
     runs-on: ubuntu-latest
     steps:
       - name: Check if PR is from Copilot

--- a/.github/workflows/copilot-retry.yml
+++ b/.github/workflows/copilot-retry.yml
@@ -28,6 +28,7 @@ permissions:
 
 jobs:
   process-queue:
+    if: false # Copilot disabled — issues handled by Claude Code scanner
     runs-on: ubuntu-latest
     timeout-minutes: 15
     # Prevent overlapping runs

--- a/.github/workflows/copilot-review-apply.yml
+++ b/.github/workflows/copilot-review-apply.yml
@@ -14,10 +14,7 @@ permissions:
 
 jobs:
   apply-copilot-review:
-    # Only trigger when Copilot review agent submits a non-approval review
-    if: |
-      contains(fromJSON('["github-copilot[bot]", "copilot"]'), github.event.review.user.login) &&
-      github.event.review.state != 'approved'
+    if: false # Copilot disabled — issues handled by Claude Code scanner
     runs-on: ubuntu-latest
     steps:
       - name: Apply Copilot review suggestions

--- a/.github/workflows/implement-fix.lock.yml
+++ b/.github/workflows/implement-fix.lock.yml
@@ -44,7 +44,7 @@ run-name: "⚠️ MANDATORY: BUILD AND LINT BEFORE EVERY COMMIT ⚠️"
 jobs:
   activation:
     needs: pre_activation
-    if: needs.pre_activation.outputs.activated == 'true'
+    if: false # Copilot disabled — issues handled by Claude Code scanner
     runs-on: ubuntu-slim
     permissions:
       contents: read
@@ -248,6 +248,7 @@ jobs:
           retention-days: 1
 
   agent:
+    if: false # Copilot disabled — issues handled by Claude Code scanner
     needs: activation
     runs-on: ubuntu-latest
     permissions:
@@ -888,7 +889,7 @@ jobs:
       - activation
       - agent
       - safe_outputs
-    if: (always()) && ((needs.agent.result != 'skipped') || (needs.activation.outputs.lockdown_check_failed == 'true'))
+    if: false # Copilot disabled — issues handled by Claude Code scanner
     runs-on: ubuntu-slim
     permissions:
       contents: read
@@ -992,6 +993,7 @@ jobs:
             await main();
 
   pre_activation:
+    if: false # Copilot disabled — issues handled by Claude Code scanner
     runs-on: ubuntu-slim
     outputs:
       activated: ${{ steps.check_membership.outputs.is_team_member == 'true' }}
@@ -1016,7 +1018,7 @@ jobs:
 
   safe_outputs:
     needs: agent
-    if: ((!cancelled()) && (needs.agent.result != 'skipped')) && (needs.agent.outputs.detection_success == 'true')
+    if: false # Copilot disabled — issues handled by Claude Code scanner
     runs-on: ubuntu-slim
     permissions:
       contents: read

--- a/.github/workflows/stuck-detection.lock.yml
+++ b/.github/workflows/stuck-detection.lock.yml
@@ -43,6 +43,7 @@ run-name: "Stuck Detection Workflow"
 
 jobs:
   activation:
+    if: false # Copilot disabled — issues handled by Claude Code scanner
     runs-on: ubuntu-slim
     permissions:
       contents: read
@@ -232,6 +233,7 @@ jobs:
           retention-days: 1
 
   agent:
+    if: false # Copilot disabled — issues handled by Claude Code scanner
     needs: activation
     runs-on: ubuntu-latest
     permissions:
@@ -848,7 +850,7 @@ jobs:
       - activation
       - agent
       - safe_outputs
-    if: (always()) && ((needs.agent.result != 'skipped') || (needs.activation.outputs.lockdown_check_failed == 'true'))
+    if: false # Copilot disabled — issues handled by Claude Code scanner
     runs-on: ubuntu-slim
     permissions:
       contents: read
@@ -951,7 +953,7 @@ jobs:
 
   safe_outputs:
     needs: agent
-    if: ((!cancelled()) && (needs.agent.result != 'skipped')) && (needs.agent.outputs.detection_success == 'true')
+    if: false # Copilot disabled — issues handled by Claude Code scanner
     runs-on: ubuntu-slim
     permissions:
       contents: read

--- a/.github/workflows/triage-command.yml
+++ b/.github/workflows/triage-command.yml
@@ -88,7 +88,7 @@ jobs:
             -X POST -f content='rocket'
 
       - name: Assign Copilot to issue
-        if: steps.check_perms.outputs.authorized == 'true'
+        if: false # Copilot disabled — issues handled by Claude Code scanner
         id: assign_copilot
         env:
           GH_TOKEN: ${{ secrets.CONSOLE_AUTO }}
@@ -141,7 +141,7 @@ jobs:
           }
 
       - name: Update labels on assignment success
-        if: steps.check_perms.outputs.authorized == 'true' && steps.assign_copilot.outputs.success == 'true'
+        if: false # Copilot disabled — issues handled by Claude Code scanner
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
@@ -155,7 +155,7 @@ jobs:
           echo "Copilot assigned to issue #$ISSUE, status: ai-awaiting-fix"
 
       - name: Post instructions comment
-        if: steps.check_perms.outputs.authorized == 'true'
+        if: false # Copilot disabled — issues handled by Claude Code scanner
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
@@ -199,7 +199,7 @@ jobs:
           )"
 
       - name: Handle assignment failure
-        if: steps.check_perms.outputs.authorized == 'true' && steps.assign_copilot.outputs.success != 'true'
+        if: false # Copilot disabled — issues handled by Claude Code scanner
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
@@ -239,6 +239,7 @@ jobs:
 
     steps:
       - name: Skip if Copilot is already assigned
+        if: false # Copilot disabled — issues handled by Claude Code scanner
         id: check_existing
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -254,7 +255,6 @@ jobs:
           fi
 
       - name: Check actor permissions
-        if: steps.check_existing.outputs.skip == 'false'
         id: check_perms
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -272,7 +272,7 @@ jobs:
           fi
 
       - name: Add AI labels
-        if: steps.check_existing.outputs.skip == 'false' && steps.check_perms.outputs.authorized == 'true'
+        if: steps.check_perms.outputs.authorized == 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
@@ -299,7 +299,7 @@ jobs:
           echo "Label-triggered triage for issue #$ISSUE: added ai-fix-requested + ai-processing"
 
       - name: Add rocket reaction to issue
-        if: steps.check_existing.outputs.skip == 'false' && steps.check_perms.outputs.authorized == 'true'
+        if: steps.check_perms.outputs.authorized == 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
@@ -307,7 +307,7 @@ jobs:
             -X POST -f content='rocket'
 
       - name: Assign Copilot to issue
-        if: steps.check_existing.outputs.skip == 'false' && steps.check_perms.outputs.authorized == 'true'
+        if: false # Copilot disabled — issues handled by Claude Code scanner
         id: assign_copilot
         env:
           GH_TOKEN: ${{ secrets.CONSOLE_AUTO }}
@@ -358,7 +358,7 @@ jobs:
           }
 
       - name: Update labels on assignment success
-        if: steps.check_existing.outputs.skip == 'false' && steps.check_perms.outputs.authorized == 'true' && steps.assign_copilot.outputs.success == 'true'
+        if: false # Copilot disabled — issues handled by Claude Code scanner
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
@@ -371,7 +371,7 @@ jobs:
           echo "Copilot assigned to issue #$ISSUE, status: ai-awaiting-fix"
 
       - name: Post instructions comment
-        if: steps.check_existing.outputs.skip == 'false' && steps.check_perms.outputs.authorized == 'true'
+        if: false # Copilot disabled — issues handled by Claude Code scanner
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
@@ -415,7 +415,7 @@ jobs:
           )"
 
       - name: Handle assignment failure
-        if: steps.check_existing.outputs.skip == 'false' && steps.check_perms.outputs.authorized == 'true' && steps.assign_copilot.outputs.success != 'true'
+        if: false # Copilot disabled — issues handled by Claude Code scanner
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |


### PR DESCRIPTION
## Summary
- Disable all Copilot-related GitHub Action workflows by adding `if: false` to job/step level
- Issues are now handled by the Claude Code scanner instead of Copilot
- Workflow files are preserved for reference (not deleted)

### Workflows disabled (14 files):
1. `copilot-assigned.yml` — Copilot assignment handler
2. `copilot-automation.yml` — Copilot PR automation
3. `copilot-build-check.yml` — Build/lint on copilot/* branches
4. `copilot-build-monitor.yml` — Netlify build failure monitor
5. `copilot-dco.yml` — DCO override for Copilot
6. `copilot-pr-monitor.yml` — Per-minute Copilot PR polling
7. `copilot-recovery.yml` — Error recovery (8 jobs disabled)
8. `copilot-retry.yml` — Queue processor for Copilot assignments
9. `copilot-review-apply.yml` — Auto-apply Copilot review suggestions
10. `ai-fix.yml` — AI fix with Copilot
11. `triage-command.yml` — Copilot assignment steps only (triage labeling preserved)
12. `implement-fix.lock.yml` — Compiled agentic workflow
13. `auto-triage.lock.yml` — Compiled agentic workflow
14. `stuck-detection.lock.yml` — Compiled agentic workflow

### What still works in triage-command.yml:
- `/triage accepted` comment handling (permission check, label application, rocket reaction)
- `triage/accepted` label trigger (permission check, AI labels, rocket reaction)

## Test plan
- [ ] Verify no Copilot workflows trigger on new issues/PRs
- [ ] Verify `/triage accepted` still applies labels correctly
- [ ] Verify `triage/accepted` label still triggers labeling