### PR TITLE
feat: wire Orbital Maintenance into mission sidebar UI

### DIFF
--- a/web/src/components/layout/mission-sidebar/MissionChat.tsx
+++ b/web/src/components/layout/mission-sidebar/MissionChat.tsx
@@ -33,6 +33,7 @@ import { AgentBadge, AgentIcon } from '../../agent/AgentIcon'
 import { PreflightFailure } from '../../missions/PreflightFailure'
 import { SaveResolutionDialog } from '../../missions/SaveResolutionDialog'
 import { SetupInstructionsDialog } from '../../setup/SetupInstructionsDialog'
+import { OrbitSetupOffer } from '../../missions/OrbitSetupOffer'
 import { STATUS_CONFIG, TYPE_ICONS } from './types'
 import type { FontSize } from './types'
 import { TypingIndicator } from './TypingIndicator'
@@ -902,6 +903,19 @@ export function MissionChat({ mission, isFullScreen = false, fontSize = 'base' a
                 </div>
               </div>
             </div>
+
+            {/* Orbit Setup Offer — shown after install/deploy missions complete */}
+            {(mission.importedFrom?.missionClass === 'install' || mission.type === 'deploy') && (
+              <OrbitSetupOffer
+                projects={mission.importedFrom?.cncfProject
+                  ? [{ name: mission.importedFrom.cncfProject, cncfProject: mission.importedFrom.cncfProject, category: (mission.context?.category as string) }]
+                  : [{ name: mission.title, category: (mission.context?.category as string) }]}
+                clusters={mission.cluster ? [mission.cluster] : []}
+                onCreateOrbit={() => {/* handled internally by OrbitSetupOffer */}}
+                onDashboardCreated={() => {/* navigation handled internally */}}
+                onSkip={() => {/* dismiss is internal */}}
+              />
+            )}
 
             <button
               onClick={() => setActiveMission(null)}

--- a/web/src/components/layout/mission-sidebar/MissionListItem.tsx
+++ b/web/src/components/layout/mission-sidebar/MissionListItem.tsx
@@ -6,6 +6,7 @@ import {
   Trash2,
   StopCircle,
   Loader2,
+  Satellite,
 } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 import type { Mission } from '../../../hooks/useMissions'
@@ -113,6 +114,12 @@ export function MissionListItem({ mission, isActive, onClick, onDismiss, onExpan
         >
           <p className="text-xs text-muted-foreground truncate">{mission.description}</p>
           <div className="flex items-center gap-2 mt-1">
+            {mission.importedFrom?.missionClass === 'orbit' && (
+              <span className="inline-flex items-center gap-1 text-[10px] font-medium text-purple-400 bg-purple-500/10 px-1.5 py-0.5 rounded-full border border-purple-500/20">
+                <Satellite className="w-2.5 h-2.5" />
+                {t('orbit.title')}
+              </span>
+            )}
             {mission.cluster && (
               <span className="text-xs text-purple-400">@{mission.cluster}</span>
             )}

--- a/web/src/components/layout/mission-sidebar/types.ts
+++ b/web/src/components/layout/mission-sidebar/types.ts
@@ -12,6 +12,7 @@ import {
   Hammer,
   Bookmark,
   ShieldAlert,
+  Orbit,
 } from 'lucide-react'
 import type { Mission, MissionStatus, MissionMessage } from '../../../hooks/useMissions'
 
@@ -45,6 +46,7 @@ export const TYPE_ICONS: Record<Mission['type'], typeof ArrowUpCircle> = {
   deploy: Rocket,
   repair: Hammer,
   custom: Sparkles,
+  maintain: Orbit,
 }
 
 export type FontSize = 'sm' | 'base' | 'lg'

--- a/web/src/hooks/useMissions.tsx
+++ b/web/src/hooks/useMissions.tsx
@@ -34,7 +34,7 @@ export interface Mission {
   id: string
   title: string
   description: string
-  type: 'upgrade' | 'troubleshoot' | 'analyze' | 'deploy' | 'repair' | 'custom'
+  type: 'upgrade' | 'troubleshoot' | 'analyze' | 'deploy' | 'repair' | 'custom' | 'maintain'
   status: MissionStatus
   progress?: number
   cluster?: string


### PR DESCRIPTION
## Summary
Follow-up to #5288 — connects the orbit infrastructure to the live UI.

- **OrbitSetupOffer** wired into `MissionChat.tsx` completion area — shows after install/deploy missions complete
- **`maintain`** added to `Mission.type` union (matches the `MissionType` in types.ts)
- **Orbit icon** added to `TYPE_ICONS` map in sidebar types
- **Orbit badge** (satellite icon + "Orbital Maintenance" label) shown on orbit missions in the mission list

## Test plan
- [ ] Build passes
- [ ] Complete an install mission → "Keep it in orbit" offer appears below the feedback buttons
- [ ] Orbit missions in sidebar show satellite badge
- [ ] No type errors