### PR TITLE
feat: complete Orbital Maintenance UI — reminders, tracker, card requests, demo

### DIFF
--- a/web/src/components/layout/mission-sidebar/MissionSidebar.tsx
+++ b/web/src/components/layout/mission-sidebar/MissionSidebar.tsx
@@ -39,6 +39,7 @@ import type { MissionExport } from '../../../lib/missions/types'
 import type { Mission } from '../../../hooks/useMissions'
 import type { FontSize } from './types'
 import { MissionListItem } from './MissionListItem'
+import { OrbitReminderBanner } from '../../missions/OrbitReminderBanner'
 import { MissionChat } from './MissionChat'
 import { ClusterSelectionDialog } from '../../missions/ClusterSelectionDialog'
 import { ResolutionKnowledgePanel } from '../../missions/ResolutionKnowledgePanel'
@@ -1031,6 +1032,15 @@ export function MissionSidebar() {
               </div>
             </div>
           )}
+
+          {/* Orbit reminder banner — shows when orbit missions are due/overdue */}
+          <OrbitReminderBanner
+            missions={missions}
+            onRunMission={(missionId) => {
+              setActiveMission(missionId)
+              runSavedMission(missionId)
+            }}
+          />
 
           {/* Active missions section — paginated for performance (#4778) */}
           {activeMissions.length > 0 && (

--- a/web/src/components/missions/CardRequestDialog.tsx
+++ b/web/src/components/missions/CardRequestDialog.tsx
@@ -1,0 +1,84 @@
+/**
+ * CardRequestDialog — Opens a pre-filled GitHub issue when no monitoring card
+ * exists for a deployed CNCF project. Reuses the existing feedback pipeline.
+ */
+
+import { useState, useCallback } from 'react'
+import { useTranslation } from 'react-i18next'
+import { LayoutGrid, X, Send } from 'lucide-react'
+import { api } from '../../lib/api'
+import { emitGroundControlCardRequestOpened } from '../../lib/analytics'
+import { useToast } from '../ui/Toast'
+
+interface CardRequestDialogProps {
+  /** Projects that have no direct monitoring card mapping */
+  missingProjects: string[]
+  onClose: () => void
+}
+
+export function CardRequestDialog({ missingProjects, onClose }: CardRequestDialogProps) {
+  const { t } = useTranslation()
+  const { showToast } = useToast()
+  const [isSubmitting, setIsSubmitting] = useState(false)
+  const [submitted, setSubmitted] = useState<Set<string>>(new Set())
+
+  const handleRequest = useCallback(async (project: string) => {
+    setIsSubmitting(true)
+    try {
+      await api.post('/api/feedback/requests', {
+        title: `Card Request: ${project} monitoring card`,
+        description: `A user deployed ${project} via Mission Control and a Ground Control dashboard was generated, but no specific monitoring card exists for ${project}. Please consider adding a dedicated monitoring card for this CNCF project.\n\nRequested automatically by the Orbital Maintenance system.`,
+        request_type: 'feature',
+      })
+      emitGroundControlCardRequestOpened(project)
+      setSubmitted(prev => new Set(prev).add(project))
+      showToast(`Card request submitted for ${project}`, 'success')
+    } catch {
+      // Non-critical — user can manually open an issue
+      showToast('Could not submit request — try opening a GitHub issue directly', 'warning')
+    } finally {
+      setIsSubmitting(false)
+    }
+  }, [showToast])
+
+  if ((missingProjects || []).length === 0) return null
+
+  return (
+    <div className="mx-4 mb-4 rounded-xl border border-border bg-secondary/20 overflow-hidden">
+      <div className="flex items-start justify-between px-4 py-3">
+        <div className="flex items-center gap-1.5">
+          <LayoutGrid className="w-3.5 h-3.5 text-muted-foreground" />
+          <span className="text-xs font-medium text-foreground">Missing monitoring cards</span>
+        </div>
+        <button
+          onClick={onClose}
+          className="p-0.5 hover:bg-secondary/50 rounded transition-colors"
+        >
+          <X className="w-3 h-3 text-muted-foreground" />
+        </button>
+      </div>
+
+      <div className="px-4 pb-3 space-y-2">
+        {(missingProjects || []).map(project => (
+          <div key={project} className="flex items-center justify-between">
+            <span className="text-[10px] text-muted-foreground">
+              {t('orbit.cardRequest', { project })}
+            </span>
+            {submitted.has(project) ? (
+              <span className="text-[10px] text-green-400 font-medium">Requested</span>
+            ) : (
+              <button
+                onClick={() => handleRequest(project)}
+                disabled={isSubmitting}
+                className="flex items-center gap-1 px-2 py-1 text-[10px] font-medium text-primary hover:bg-primary/10 rounded transition-colors"
+              >
+                <Send className="w-2.5 h-2.5" />
+                {t('orbit.cardRequestAction')}
+              </button>
+            )}
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/web/src/components/missions/OrbitReminderBanner.tsx
+++ b/web/src/components/missions/OrbitReminderBanner.tsx
@@ -1,0 +1,138 @@
+/**
+ * OrbitReminderBanner — Shows in the Mission Sidebar when orbit missions are due/overdue.
+ * Groups multiple due missions into a single banner.
+ */
+
+import { useMemo, useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import { Satellite, X, Play } from 'lucide-react'
+import type { Mission } from '../../hooks/useMissions'
+import { ORBIT_CADENCE_HOURS, ORBIT_OVERDUE_GRACE_HOURS } from '../../lib/constants/orbit'
+import type { OrbitConfig } from '../../lib/missions/types'
+import { cn } from '../../lib/cn'
+
+/** Hours per unit for human-readable display */
+const HOURS_PER_DAY = 24
+
+function formatDuration(hours: number): string {
+  if (hours < 1) return 'less than 1 hour'
+  if (hours < HOURS_PER_DAY) return `${Math.round(hours)}h`
+  const days = Math.round(hours / HOURS_PER_DAY)
+  return `${days}d`
+}
+
+interface OrbitReminder {
+  missionId: string
+  title: string
+  orbitType: string
+  overdueHours: number
+  isOverdue: boolean
+}
+
+function computeReminders(missions: Mission[]): OrbitReminder[] {
+  const reminders: OrbitReminder[] = []
+
+  for (const mission of missions || []) {
+    if (mission.importedFrom?.missionClass !== 'orbit') continue
+    if (mission.status !== 'saved' && mission.status !== 'completed') continue
+
+    const orbitConfig = mission.context?.orbitConfig as OrbitConfig | undefined
+    if (!orbitConfig) continue
+
+    const cadenceHours = ORBIT_CADENCE_HOURS[orbitConfig.cadence] || ORBIT_CADENCE_HOURS.weekly
+    const lastRun = orbitConfig.lastRunAt ? new Date(orbitConfig.lastRunAt).getTime() : 0
+    const hoursSinceRun = lastRun ? (Date.now() - lastRun) / (3_600_000) : Infinity
+    const overdueHours = hoursSinceRun - cadenceHours
+
+    if (overdueHours > -ORBIT_OVERDUE_GRACE_HOURS) {
+      reminders.push({
+        missionId: mission.id,
+        title: mission.title,
+        orbitType: orbitConfig.orbitType,
+        overdueHours: Math.max(0, overdueHours),
+        isOverdue: overdueHours > 0,
+      })
+    }
+  }
+
+  return reminders.sort((a, b) => b.overdueHours - a.overdueHours)
+}
+
+interface OrbitReminderBannerProps {
+  missions: Mission[]
+  onRunMission: (missionId: string) => void
+}
+
+export function OrbitReminderBanner({ missions, onRunMission }: OrbitReminderBannerProps) {
+  const { t } = useTranslation()
+  const [dismissed, setDismissed] = useState(false)
+
+  const reminders = useMemo(() => computeReminders(missions), [missions])
+
+  if (dismissed || reminders.length === 0) return null
+
+  const overdueCount = reminders.filter(r => r.isOverdue).length
+
+  return (
+    <div className={cn(
+      'mx-2 mb-2 rounded-lg border p-3',
+      overdueCount > 0
+        ? 'border-amber-500/30 bg-amber-500/5'
+        : 'border-purple-500/30 bg-purple-500/5',
+    )}>
+      <div className="flex items-start justify-between mb-2">
+        <div className="flex items-center gap-1.5">
+          <Satellite className={cn('w-3.5 h-3.5', overdueCount > 0 ? 'text-amber-400' : 'text-purple-400')} />
+          <span className="text-xs font-medium text-foreground">
+            {t('orbit.reminderTitle')}
+          </span>
+          <span className={cn(
+            'text-[10px] font-medium px-1.5 py-0.5 rounded-full',
+            overdueCount > 0
+              ? 'bg-amber-500/20 text-amber-400'
+              : 'bg-purple-500/20 text-purple-400',
+          )}>
+            {reminders.length}
+          </span>
+        </div>
+        <button
+          onClick={() => setDismissed(true)}
+          className="p-0.5 hover:bg-secondary/50 rounded transition-colors"
+          aria-label={t('orbit.reminderDismiss')}
+        >
+          <X className="w-3 h-3 text-muted-foreground" />
+        </button>
+      </div>
+
+      <div className="space-y-1.5">
+        {reminders.slice(0, 3).map(reminder => (
+          <div key={reminder.missionId} className="flex items-center justify-between">
+            <div className="min-w-0 flex-1">
+              <span className="text-[10px] text-foreground truncate block">{reminder.title}</span>
+              <span className={cn(
+                'text-[10px]',
+                reminder.isOverdue ? 'text-amber-400' : 'text-muted-foreground',
+              )}>
+                {reminder.isOverdue
+                  ? t('orbit.overdue', { time: formatDuration(reminder.overdueHours) })
+                  : t('orbit.dueIn', { time: formatDuration(Math.abs(reminder.overdueHours)) })}
+              </span>
+            </div>
+            <button
+              onClick={() => onRunMission(reminder.missionId)}
+              className="flex items-center gap-1 px-2 py-1 text-[10px] font-medium text-primary hover:bg-primary/10 rounded transition-colors shrink-0"
+            >
+              <Play className="w-2.5 h-2.5" />
+              {t('orbit.runNow')}
+            </button>
+          </div>
+        ))}
+        {reminders.length > 3 && (
+          <span className="text-[10px] text-muted-foreground">
+            +{reminders.length - 3} more
+          </span>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/web/src/components/missions/OrbitStatusTracker.tsx
+++ b/web/src/components/missions/OrbitStatusTracker.tsx
@@ -1,0 +1,151 @@
+/**
+ * OrbitStatusTracker — Run history timeline for orbit missions.
+ * Shows inside the mission detail view when viewing an orbit mission.
+ */
+
+import { useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import { CheckCircle2, AlertTriangle, XCircle, Clock, Play, ChevronDown, ChevronUp } from 'lucide-react'
+import type { OrbitRunHistoryEntry, OrbitCadence } from '../../lib/missions/types'
+import { ORBIT_CADENCE_HOURS } from '../../lib/constants/orbit'
+import { cn } from '../../lib/cn'
+
+/** Maximum history entries shown before "Show more" */
+const VISIBLE_HISTORY_COUNT = 5
+
+const RESULT_CONFIG = {
+  success: { icon: CheckCircle2, color: 'text-green-400', bg: 'bg-green-500/20' },
+  warning: { icon: AlertTriangle, color: 'text-yellow-400', bg: 'bg-yellow-500/20' },
+  failure: { icon: XCircle, color: 'text-red-400', bg: 'bg-red-500/20' },
+} as const
+
+interface OrbitStatusTrackerProps {
+  history: OrbitRunHistoryEntry[]
+  cadence: OrbitCadence
+  lastRunAt?: string | null
+  onRunNow: () => void
+  onChangeCadence: (cadence: OrbitCadence) => void
+}
+
+const CADENCE_OPTIONS: OrbitCadence[] = ['daily', 'weekly', 'monthly']
+
+export function OrbitStatusTracker({
+  history,
+  cadence,
+  lastRunAt,
+  onRunNow,
+  onChangeCadence,
+}: OrbitStatusTrackerProps) {
+  const { t } = useTranslation()
+  const [showAll, setShowAll] = useState(false)
+  const [showCadenceMenu, setShowCadenceMenu] = useState(false)
+
+  const visibleHistory = showAll ? (history || []) : (history || []).slice(0, VISIBLE_HISTORY_COUNT)
+  const hasMore = (history || []).length > VISIBLE_HISTORY_COUNT
+
+  // Compute next run
+  const cadenceMs = ORBIT_CADENCE_HOURS[cadence] * 3_600_000
+  const lastRunTime = lastRunAt ? new Date(lastRunAt).getTime() : 0
+  const nextRunTime = lastRunTime ? lastRunTime + cadenceMs : 0
+  const msUntilNext = nextRunTime ? nextRunTime - Date.now() : 0
+  const hoursUntilNext = msUntilNext / 3_600_000
+
+  return (
+    <div className="mx-4 mb-4 rounded-xl border border-border bg-secondary/20 overflow-hidden">
+      {/* Header with next run + actions */}
+      <div className="flex items-center justify-between px-4 py-3 border-b border-border/50">
+        <div>
+          <div className="text-xs font-medium text-foreground">{t('orbit.title')}</div>
+          <div className="text-[10px] text-muted-foreground mt-0.5">
+            {lastRunAt
+              ? hoursUntilNext > 0
+                ? t('orbit.dueIn', { time: hoursUntilNext < 24 ? `${Math.round(hoursUntilNext)}h` : `${Math.round(hoursUntilNext / 24)}d` })
+                : t('orbit.overdue', { time: Math.abs(hoursUntilNext) < 24 ? `${Math.round(Math.abs(hoursUntilNext))}h` : `${Math.round(Math.abs(hoursUntilNext) / 24)}d` })
+              : t('orbit.neverRun')}
+          </div>
+        </div>
+        <div className="flex items-center gap-1.5">
+          {/* Cadence selector */}
+          <div className="relative">
+            <button
+              onClick={() => setShowCadenceMenu(!showCadenceMenu)}
+              className="flex items-center gap-1 px-2 py-1 text-[10px] font-medium text-muted-foreground hover:text-foreground bg-secondary/50 hover:bg-secondary rounded-md transition-colors"
+            >
+              <Clock className="w-3 h-3" />
+              {t(`orbit.cadence${cadence.charAt(0).toUpperCase() + cadence.slice(1)}` as 'orbit.cadenceDaily')}
+              <ChevronDown className="w-2.5 h-2.5" />
+            </button>
+            {showCadenceMenu && (
+              <div className="absolute right-0 top-full mt-1 z-50 bg-popover border border-border rounded-md shadow-lg py-1">
+                {CADENCE_OPTIONS.map(option => (
+                  <button
+                    key={option}
+                    onClick={() => { onChangeCadence(option); setShowCadenceMenu(false) }}
+                    className={cn(
+                      'w-full px-3 py-1 text-[10px] text-left hover:bg-secondary/50 transition-colors',
+                      cadence === option ? 'text-primary font-medium' : 'text-foreground',
+                    )}
+                  >
+                    {t(`orbit.cadence${option.charAt(0).toUpperCase() + option.slice(1)}` as 'orbit.cadenceDaily')}
+                  </button>
+                ))}
+              </div>
+            )}
+          </div>
+          {/* Run Now */}
+          <button
+            onClick={onRunNow}
+            className="flex items-center gap-1 px-2 py-1 text-[10px] font-medium text-primary bg-primary/10 hover:bg-primary/20 rounded-md transition-colors"
+          >
+            <Play className="w-3 h-3" />
+            {t('orbit.runNow')}
+          </button>
+        </div>
+      </div>
+
+      {/* Timeline */}
+      {visibleHistory.length > 0 ? (
+        <div className="px-4 py-2">
+          {visibleHistory.map((entry, idx) => {
+            const config = RESULT_CONFIG[entry.result]
+            const Icon = config.icon
+            const date = new Date(entry.timestamp)
+            return (
+              <div key={idx} className="flex items-start gap-2.5 py-1.5">
+                <div className={cn('w-5 h-5 rounded-full flex items-center justify-center shrink-0 mt-0.5', config.bg)}>
+                  <Icon className={cn('w-3 h-3', config.color)} />
+                </div>
+                <div className="flex-1 min-w-0">
+                  <div className="flex items-center justify-between">
+                    <span className="text-[10px] text-foreground">
+                      {date.toLocaleDateString()} {date.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}
+                    </span>
+                    <span className={cn('text-[10px] font-medium', config.color)}>
+                      {entry.result}
+                    </span>
+                  </div>
+                  {entry.summary && (
+                    <p className="text-[10px] text-muted-foreground mt-0.5 truncate">{entry.summary}</p>
+                  )}
+                </div>
+              </div>
+            )
+          })}
+          {hasMore && (
+            <button
+              onClick={() => setShowAll(!showAll)}
+              className="w-full flex items-center justify-center gap-1 py-1.5 text-[10px] text-primary hover:bg-primary/5 rounded transition-colors"
+            >
+              {showAll ? <ChevronUp className="w-3 h-3" /> : <ChevronDown className="w-3 h-3" />}
+              {showAll ? 'Show less' : `Show ${(history || []).length - VISIBLE_HISTORY_COUNT} more`}
+            </button>
+          )}
+        </div>
+      ) : (
+        <div className="px-4 py-4 text-center">
+          <p className="text-[10px] text-muted-foreground">{t('orbit.neverRun')}</p>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/web/src/lib/orbit/__tests__/orbitReminders.test.ts
+++ b/web/src/lib/orbit/__tests__/orbitReminders.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from 'vitest'
+import { ORBIT_CADENCE_HOURS, ORBIT_OVERDUE_GRACE_HOURS } from '../../constants/orbit'
+
+describe('orbit cadence constants', () => {
+  it('daily cadence is 24 hours', () => {
+    expect(ORBIT_CADENCE_HOURS.daily).toBe(24)
+  })
+
+  it('weekly cadence is 168 hours (7 days)', () => {
+    expect(ORBIT_CADENCE_HOURS.weekly).toBe(168)
+  })
+
+  it('monthly cadence is 720 hours (30 days)', () => {
+    expect(ORBIT_CADENCE_HOURS.monthly).toBe(720)
+  })
+
+  it('overdue grace period is 4 hours', () => {
+    expect(ORBIT_OVERDUE_GRACE_HOURS).toBe(4)
+  })
+})
+
+describe('orbit overdue calculation', () => {
+  function isOverdue(lastRunAt: string, cadence: keyof typeof ORBIT_CADENCE_HOURS): boolean {
+    const cadenceMs = ORBIT_CADENCE_HOURS[cadence] * 3_600_000
+    const elapsed = Date.now() - new Date(lastRunAt).getTime()
+    return elapsed > cadenceMs
+  }
+
+  it('daily mission run 25 hours ago is overdue', () => {
+    const lastRun = new Date(Date.now() - 25 * 3_600_000).toISOString()
+    expect(isOverdue(lastRun, 'daily')).toBe(true)
+  })
+
+  it('daily mission run 23 hours ago is not overdue', () => {
+    const lastRun = new Date(Date.now() - 23 * 3_600_000).toISOString()
+    expect(isOverdue(lastRun, 'daily')).toBe(false)
+  })
+
+  it('weekly mission run 6 days ago is not overdue', () => {
+    const lastRun = new Date(Date.now() - 6 * 24 * 3_600_000).toISOString()
+    expect(isOverdue(lastRun, 'weekly')).toBe(false)
+  })
+
+  it('weekly mission run 8 days ago is overdue', () => {
+    const lastRun = new Date(Date.now() - 8 * 24 * 3_600_000).toISOString()
+    expect(isOverdue(lastRun, 'weekly')).toBe(true)
+  })
+
+  it('monthly mission run 29 days ago is not overdue', () => {
+    const lastRun = new Date(Date.now() - 29 * 24 * 3_600_000).toISOString()
+    expect(isOverdue(lastRun, 'monthly')).toBe(false)
+  })
+
+  it('monthly mission run 31 days ago is overdue', () => {
+    const lastRun = new Date(Date.now() - 31 * 24 * 3_600_000).toISOString()
+    expect(isOverdue(lastRun, 'monthly')).toBe(true)
+  })
+})

--- a/web/src/mocks/orbitDemoData.ts
+++ b/web/src/mocks/orbitDemoData.ts
@@ -1,0 +1,124 @@
+/**
+ * Demo mode mock data for Orbital Maintenance missions.
+ * Provides realistic orbit missions with run history for the demo experience.
+ */
+
+import type { OrbitConfig } from '../lib/missions/types'
+
+/** Two days ago in ISO format */
+const TWO_DAYS_AGO = new Date(Date.now() - 2 * 86_400_000).toISOString()
+/** One week ago in ISO format */
+const ONE_WEEK_AGO = new Date(Date.now() - 7 * 86_400_000).toISOString()
+/** Ten days ago — overdue for a weekly cadence */
+const TEN_DAYS_AGO = new Date(Date.now() - 10 * 86_400_000).toISOString()
+
+function daysAgo(days: number): string {
+  return new Date(Date.now() - days * 86_400_000).toISOString()
+}
+
+export interface DemoOrbitMission {
+  id: string
+  title: string
+  description: string
+  type: 'maintain'
+  status: 'saved' | 'completed'
+  importedFrom: {
+    title: string
+    description: string
+    missionClass: 'orbit'
+    cncfProject?: string
+  }
+  context: {
+    orbitConfig: OrbitConfig
+    category?: string
+  }
+}
+
+export const DEMO_ORBIT_MISSIONS: DemoOrbitMission[] = [
+  {
+    id: 'demo-orbit-prometheus-health',
+    title: 'Health Check — Prometheus, Grafana',
+    description: 'Weekly pod readiness and service endpoint verification for the observability stack.',
+    type: 'maintain',
+    status: 'saved',
+    importedFrom: {
+      title: 'Health Check — Prometheus, Grafana',
+      description: 'Weekly pod readiness and service endpoint verification for the observability stack.',
+      missionClass: 'orbit',
+      cncfProject: 'prometheus',
+    },
+    context: {
+      category: 'Observability',
+      orbitConfig: {
+        cadence: 'weekly',
+        orbitType: 'health-check',
+        projects: ['prometheus', 'grafana'],
+        clusters: ['eks-prod-us-east-1'],
+        lastRunAt: TWO_DAYS_AGO,
+        lastRunResult: 'success',
+        history: [
+          { timestamp: TWO_DAYS_AGO, result: 'success', summary: 'All 12 pods healthy, 3 services reachable' },
+          { timestamp: daysAgo(9), result: 'success', summary: 'All pods healthy' },
+          { timestamp: daysAgo(16), result: 'warning', summary: 'prometheus-server pod restarted 2x in 24h' },
+          { timestamp: daysAgo(23), result: 'success', summary: 'All pods healthy' },
+        ],
+      },
+    },
+  },
+  {
+    id: 'demo-orbit-certmanager-certs',
+    title: 'Certificate Rotation — cert-manager',
+    description: 'Monthly TLS certificate expiry check.',
+    type: 'maintain',
+    status: 'saved',
+    importedFrom: {
+      title: 'Certificate Rotation — cert-manager',
+      description: 'Monthly TLS certificate expiry check.',
+      missionClass: 'orbit',
+      cncfProject: 'cert-manager',
+    },
+    context: {
+      category: 'Security',
+      orbitConfig: {
+        cadence: 'monthly',
+        orbitType: 'cert-rotation',
+        projects: ['cert-manager'],
+        clusters: ['eks-prod-us-east-1', 'aks-dev-westeu'],
+        lastRunAt: ONE_WEEK_AGO,
+        lastRunResult: 'warning',
+        history: [
+          { timestamp: ONE_WEEK_AGO, result: 'warning', summary: '1 cert expiring in 14 days: api-gateway-tls' },
+          { timestamp: daysAgo(37), result: 'success', summary: 'All 8 certificates valid, earliest expiry in 45 days' },
+        ],
+      },
+    },
+  },
+  {
+    id: 'demo-orbit-argocd-drift',
+    title: 'Version Drift — ArgoCD',
+    description: 'Weekly Helm chart and image version drift detection.',
+    type: 'maintain',
+    status: 'saved',
+    importedFrom: {
+      title: 'Version Drift — ArgoCD',
+      description: 'Weekly Helm chart and image version drift detection.',
+      missionClass: 'orbit',
+      cncfProject: 'argocd',
+    },
+    context: {
+      category: 'App Definition',
+      orbitConfig: {
+        cadence: 'weekly',
+        orbitType: 'version-drift',
+        projects: ['argocd'],
+        clusters: ['eks-prod-us-east-1'],
+        lastRunAt: TEN_DAYS_AGO,
+        lastRunResult: 'failure',
+        history: [
+          { timestamp: TEN_DAYS_AGO, result: 'failure', summary: 'ArgoCD v2.13.1 installed, v2.14.0 available (security fix)' },
+          { timestamp: daysAgo(17), result: 'success', summary: 'All charts up to date' },
+        ],
+      },
+    },
+  },
+]


### PR DESCRIPTION
## Summary
Final piece of the Orbital Maintenance feature (#5288, #5293). All remaining UI components:

- **OrbitReminderBanner** — shows in sidebar header when orbit missions are due/overdue. Groups multiple reminders, color-coded (amber=overdue, purple=upcoming). Run Now + Dismiss actions.
- **OrbitStatusTracker** — run history timeline for orbit mission detail view. Shows past runs with success/warning/failure icons, next-run countdown, cadence selector dropdown, Run Now button.
- **CardRequestDialog** — when Ground Control dashboard can't find a monitoring card for a deployed project, offers to open a GitHub issue via the existing `/api/feedback/requests` pipeline.
- **Demo mode data** — 3 realistic orbit missions: Prometheus health check (2 days ago, success), cert-manager cert rotation (1 week ago, warning — cert expiring), ArgoCD version drift (10 days ago, failure — security update available).
- **OrbitReminderBanner wired** into MissionSidebar above the mission list.
- **10 new tests** for orbit cadence/overdue calculations (19 total orbit tests).

## Test plan
- [ ] Build passes, 19 orbit tests pass
- [ ] Sidebar shows orbit reminder banner when missions are due
- [ ] Reminder banner shows amber for overdue, purple for upcoming
- [ ] Run Now on reminder opens and runs the mission
- [ ] Dismiss hides the banner for the session