### PR TITLE
feat: auto-run orbit maintenance when due

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -14,6 +14,7 @@ import { ToastProvider } from './components/ui/Toast'
 import { AlertsProvider } from './contexts/AlertsContext'
 import { RewardsProvider } from './hooks/useRewards'
 import { NPSSurvey } from './components/feedback'
+import { useOrbitAutoRun } from './hooks/useOrbitAutoRun'
 import { UnifiedDemoProvider } from './lib/unified/demo'
 import { ChunkErrorBoundary } from './components/ChunkErrorBoundary'
 import { AppErrorBoundary } from './components/AppErrorBoundary'
@@ -144,6 +145,9 @@ if (typeof window !== 'undefined') {
     setTimeout(prefetchRoutes, SHORT_DELAY_MS)
   }
 }
+
+/** Runs orbit auto-maintenance checks — must be inside provider tree */
+function OrbitAutoRunner() { useOrbitAutoRun(); return null }
 
 // Loading fallback component with delay to prevent flash on fast navigation
 function LoadingFallback() {
@@ -485,6 +489,7 @@ function FullDashboardApp() {
       <AppErrorBoundary>
       <Suspense fallback={null}><DrillDownModal /></Suspense>
       <NPSSurvey />
+      <OrbitAutoRunner />
       <ChunkErrorBoundary>
       <Suspense fallback={<LoadingFallback />}>
       <Routes>

--- a/web/src/components/cards/WorkloadDeployment.tsx
+++ b/web/src/components/cards/WorkloadDeployment.tsx
@@ -12,7 +12,6 @@ import {
   Server,
   Database,
   Gauge,
-  Plus,
   Minus,
   GripVertical,
   Loader2,

--- a/web/src/components/missions/OrbitSetupOffer.tsx
+++ b/web/src/components/missions/OrbitSetupOffer.tsx
@@ -28,6 +28,7 @@ interface OrbitSetupOfferProps {
   onCreateOrbit: (params: {
     orbitType: OrbitType
     cadence: OrbitCadence
+    autoRun: boolean
     title: string
     projects: string[]
     clusters: string[]
@@ -61,6 +62,7 @@ export function OrbitSetupOffer({
   )
   const [cadence, setCadence] = useState<OrbitCadence>(ORBIT_DEFAULT_CADENCE)
   const [createDashboard, setCreateDashboard] = useState(true)
+  const [autoRun, setAutoRun] = useState(false)
   const [isExpanded, setIsExpanded] = useState(true)
   const [isCreating, setIsCreating] = useState(false)
   const [createdDashboardId, setCreatedDashboardId] = useState<string | null>(null)
@@ -86,6 +88,7 @@ export function OrbitSetupOffer({
         onCreateOrbit({
           orbitType,
           cadence,
+          autoRun,
           title: `${template.title} — ${(projects || []).map(p => p.name).join(', ')}`,
           projects: (projects || []).map(p => p.name),
           clusters: clusters || [],
@@ -108,7 +111,7 @@ export function OrbitSetupOffer({
     } finally {
       setIsCreating(false)
     }
-  }, [selectedOrbits, cadence, createDashboard, projects, clusters, missionControlStateKey, onCreateOrbit, onDashboardCreated, generateGroundControlDashboard, applicableTemplates])
+  }, [selectedOrbits, cadence, autoRun, createDashboard, projects, clusters, missionControlStateKey, onCreateOrbit, onDashboardCreated, generateGroundControlDashboard, applicableTemplates])
 
   if (isDone) {
     return (
@@ -199,7 +202,7 @@ export function OrbitSetupOffer({
           </div>
 
           {/* Ground Control dashboard toggle */}
-          <label className="flex items-center gap-2 mb-4 cursor-pointer">
+          <label className="flex items-center gap-2 mb-2 cursor-pointer">
             <input
               type="checkbox"
               checked={createDashboard}
@@ -208,6 +211,18 @@ export function OrbitSetupOffer({
             />
             <LayoutDashboard className="w-3.5 h-3.5 text-muted-foreground" />
             <span className="text-xs text-foreground">{t('orbit.groundControlDescription')}</span>
+          </label>
+
+          {/* Auto-run toggle */}
+          <label className="flex items-center gap-2 mb-4 cursor-pointer">
+            <input
+              type="checkbox"
+              checked={autoRun}
+              onChange={e => setAutoRun(e.target.checked)}
+              className="accent-purple-500"
+            />
+            <Orbit className="w-3.5 h-3.5 text-muted-foreground" />
+            <span className="text-xs text-foreground">{t('orbit.autoRunDescription')}</span>
           </label>
 
           {/* Actions */}

--- a/web/src/hooks/useOrbitAutoRun.ts
+++ b/web/src/hooks/useOrbitAutoRun.ts
@@ -1,0 +1,68 @@
+/**
+ * useOrbitAutoRun — Automatically runs orbit missions when they're due.
+ *
+ * Scans saved orbit missions on an interval. If a mission has autoRun
+ * enabled and is past its cadence, it starts automatically. Shows a
+ * toast notification so the user knows what's happening.
+ *
+ * Only runs when the console is open — if the user hasn't visited in
+ * a week, overdue auto-runs execute on next visit.
+ */
+
+import { useEffect, useRef } from 'react'
+import { useAuth } from '../lib/auth'
+import { isDemoMode } from '../lib/demoMode'
+import { useMissions } from './useMissions'
+import { useToast } from '../components/ui/Toast'
+import { ORBIT_CADENCE_HOURS, ORBIT_AUTORUN_CHECK_INTERVAL_MS } from '../lib/constants/orbit'
+import { emitOrbitMissionRun } from '../lib/analytics'
+import type { OrbitConfig } from '../lib/missions/types'
+
+/** Tracks which missions were auto-run this session to prevent re-triggering */
+const autoRunTriggered = new Set<string>()
+
+function isDue(config: OrbitConfig): boolean {
+  if (!config.lastRunAt) return true
+  const cadenceMs = ORBIT_CADENCE_HOURS[config.cadence] * 3_600_000
+  const elapsed = Date.now() - new Date(config.lastRunAt).getTime()
+  return elapsed >= cadenceMs
+}
+
+export function useOrbitAutoRun() {
+  const { isAuthenticated } = useAuth()
+  const { missions, runSavedMission } = useMissions()
+  const { showToast } = useToast()
+  const missionsRef = useRef(missions)
+  missionsRef.current = missions
+
+  useEffect(() => {
+    if (!isAuthenticated || isDemoMode()) return
+
+    function checkAndRun() {
+      for (const mission of missionsRef.current || []) {
+        if (mission.importedFrom?.missionClass !== 'orbit') continue
+        if (mission.status !== 'saved') continue
+
+        const config = mission.context?.orbitConfig as OrbitConfig | undefined
+        if (!config?.autoRun) continue
+        if (!isDue(config)) continue
+        if (autoRunTriggered.has(mission.id)) continue
+
+        // Mark as triggered this session
+        autoRunTriggered.add(mission.id)
+
+        // Auto-run the mission
+        runSavedMission(mission.id)
+        emitOrbitMissionRun(config.orbitType, 'auto')
+        showToast(`Orbital maintenance started: ${mission.title}`, 'info')
+      }
+    }
+
+    // Check immediately on mount
+    checkAndRun()
+
+    // Then check periodically
+    const interval = setInterval(checkAndRun, ORBIT_AUTORUN_CHECK_INTERVAL_MS)
+    return () => clearInterval(interval)
+  }, [isAuthenticated, runSavedMission, showToast])
+}

--- a/web/src/lib/constants/orbit.ts
+++ b/web/src/lib/constants/orbit.ts
@@ -24,3 +24,6 @@ export const ORBIT_DEFAULT_CADENCE: OrbitCadence = 'weekly'
 
 /** Default dashboard name template — {project} is replaced at runtime */
 export const GROUND_CONTROL_DASHBOARD_NAME_TEMPLATE = 'Ground Control — {project}'
+
+/** How often (ms) the auto-run check scans for due orbit missions */
+export const ORBIT_AUTORUN_CHECK_INTERVAL_MS = 60_000

--- a/web/src/lib/missions/types.ts
+++ b/web/src/lib/missions/types.ts
@@ -48,6 +48,8 @@ export interface OrbitConfig {
   groundControlDashboardId?: string
   /** Run history (capped at ORBIT_MAX_HISTORY_ENTRIES) */
   history?: OrbitRunHistoryEntry[]
+  /** Auto-run when due — executes automatically when the console is open */
+  autoRun?: boolean
 }
 
 export interface MissionExport {

--- a/web/src/locales/en/common.json
+++ b/web/src/locales/en/common.json
@@ -1742,6 +1742,7 @@
     "changeCadence": "Change Cadence",
     "groundControl": "Ground Control",
     "groundControlDescription": "Auto-generate a monitoring dashboard for your deployment.",
+    "autoRunDescription": "Run maintenance automatically when due.",
     "createDashboard": "Create Dashboard",
     "viewDashboard": "View Dashboard",
     "cardRequest": "No monitoring card for {{project}} yet",


### PR DESCRIPTION
## Summary
Orbit missions can now run automatically when the console is open.

- **Auto-run toggle** in OrbitSetupOffer — opt-in, off by default
- **`autoRun` field** in `OrbitConfig` — persisted per orbit mission
- **`useOrbitAutoRun` hook** — checks every 60s, starts due missions with autoRun enabled
- **Session dedup** — won't re-trigger the same mission twice per session
- **Toast notification** — "Orbital maintenance started: [title]" when auto-run kicks off
- **Mounted in App.tsx** via `OrbitAutoRunner` component inside the full provider tree

Also fixes a pre-existing duplicate `Plus` import in WorkloadDeployment.tsx.

## Test plan
- [ ] Build passes
- [ ] Set up orbit with auto-run ON → when cadence elapses, mission starts automatically
- [ ] Set up orbit with auto-run OFF → only reminder banner shown, no auto-start
- [ ] Toast appears when auto-run triggers
- [ ] Same mission doesn't trigger twice in one session