### PR TITLE
fix: EventsTimeline infinite loop, DynamicCard crash, analytics donut labels

### DIFF
--- a/web/public/analytics.html
+++ b/web/public/analytics.html
@@ -1124,7 +1124,7 @@
       const chart = new Chart(ctx, {
         type: 'doughnut',
         data: {
-          labels: errors.map(e => e.event),
+          labels: errors.map(e => e.detail && e.detail !== '(not set)' && e.detail !== '—' ? e.detail : e.event),
           datasets: [{
             data: errors.map(e => e.count),
             backgroundColor: ERROR_COLORS.slice(0, errors.length),

--- a/web/src/components/cards/DynamicCard.tsx
+++ b/web/src/components/cards/DynamicCard.tsx
@@ -145,8 +145,9 @@ export function Tier1CardRuntime({ cardDefinition }: Tier1Props) {
     return () => { cancelled = true }
   }, [isInvalidConfig, isMissingEndpoint, cardDefinition?.dataSource, cardDefinition?.apiEndpoint])
 
-  // useCardData for search/pagination
+  // useCardData for search/pagination — guard against undefined cardDefinition
   const searchFields = ((cardDefinition?.searchFields || []) as (keyof Record<string, unknown>)[])
+  const defaultSortField = searchFields.length > 0 ? (searchFields[0] as string) : 'name'
   const {
     items,
     totalItems,
@@ -158,16 +159,16 @@ export function Tier1CardRuntime({ cardDefinition }: Tier1Props) {
     filters,
     containerRef,
     containerStyle,
-  } = useCardData(data, {
+  } = useCardData(data ?? [], {
     filter: {
       searchFields,
     },
     sort: {
-      defaultField: searchFields[0] as string || 'name',
-      defaultDirection: 'asc',
+      defaultField: defaultSortField,
+      defaultDirection: 'asc' as const,
       comparators: {},
     },
-    defaultLimit: cardDefinition?.defaultLimit || 5,
+    defaultLimit: cardDefinition?.defaultLimit ?? 5,
   })
 
   // Validation-based early returns — placed after all hooks to respect Rules of Hooks (#4910)

--- a/web/src/components/cards/EventsTimeline.tsx
+++ b/web/src/components/cards/EventsTimeline.tsx
@@ -123,16 +123,15 @@ function EventsTimelineInternal() {
   const reachableClusters = clusters.filter(c => c.reachable !== false)
 
   // Get available clusters for local filter (respects global filter)
-  const availableClustersForFilter = (() => {
+  const availableClustersForFilter = useMemo(() => {
     if (isAllClustersSelected) return reachableClusters
     return reachableClusters.filter(c => selectedClusters.includes(c.name))
-  })()
+  }, [isAllClustersSelected, reachableClusters, selectedClusters])
 
   // Count filtered clusters for display
-  const filteredClusterCount = (() => {
-    if (localClusterFilter.length > 0) return localClusterFilter.length
-    return availableClustersForFilter.length
-  })()
+  const filteredClusterCount = localClusterFilter.length > 0
+    ? localClusterFilter.length
+    : availableClustersForFilter.length
 
   const toggleClusterFilter = (clusterName: string) => {
     setLocalClusterFilter(prev => {
@@ -144,9 +143,9 @@ function EventsTimelineInternal() {
   }
 
   // Filter events by selected clusters AND exclude offline/unreachable clusters
-  const filteredEvents = (() => {
+  const filteredEvents = useMemo(() => {
     // First filter to only events from reachable clusters
-    let result = events.filter(e => {
+    let result = (events || []).filter(e => {
       if (!e.cluster) return true // Include events without cluster info
       const clusterInfo = clusterInfoMap[e.cluster]
       return !clusterInfo || clusterInfo.reachable !== false
@@ -159,13 +158,16 @@ function EventsTimelineInternal() {
       result = result.filter(e => e.cluster && localClusterFilter.includes(e.cluster))
     }
     return result
-  })()
+  }, [events, clusterInfoMap, isAllClustersSelected, selectedClusters, localClusterFilter])
 
   // Get time range config
   const timeRangeConfig = TIME_RANGE_OPTIONS.find(t => t.value === timeRange) || TIME_RANGE_OPTIONS[1]
 
   // Group events into time buckets
-  const timeSeriesData = groupEventsByTime(filteredEvents, timeRangeConfig.bucketMinutes, timeRangeConfig.numBuckets)
+  const timeSeriesData = useMemo(
+    () => groupEventsByTime(filteredEvents, timeRangeConfig.bucketMinutes, timeRangeConfig.numBuckets),
+    [filteredEvents, timeRangeConfig.bucketMinutes, timeRangeConfig.numBuckets],
+  )
 
   // Calculate totals
   const totalWarnings = timeSeriesData.reduce((sum, d) => sum + d.warnings, 0)


### PR DESCRIPTION
## Summary
Three fixes from today's GA4 error analysis:

### 1. EventsTimeline infinite render loop (53 errors/week)
- `availableClustersForFilter`, `filteredEvents`, and `timeSeriesData` were IIFEs creating new array/object references every render
- This cascaded: new refs → useMemo recalculates → ECharts re-renders → component re-renders → infinite loop
- **Fix**: Wrap all three in `useMemo` with proper dependency arrays

### 2. DynamicCard config destructuring crash (10 errors/week)
- `searchFields[0]` could be undefined when dynamic/custom cards have empty searchFields
- **Fix**: Check `searchFields.length > 0` before accessing index, use `??` for defaultLimit

### 3. Analytics donut legend (UX fix)
- Error Summary donut chart on `/analytics` showed "error" for every slice instead of the category
- **Fix**: Use `e.detail` (category like `unhandled_rejection`, `card_render`) instead of `e.event` (generic "error")

## Test plan
- [ ] Build passes
- [ ] Visit /clusters, /compliance, /cluster-admin → no "Maximum update depth exceeded" errors
- [ ] Add a dynamic card on /alerts → no "Cannot destructure 'filter'" crash
- [ ] Visit /analytics → donut chart shows descriptive labels per error category