### PR TITLE
feat: orbit redirects to local install dialog in demo mode

### DIFF
--- a/web/src/components/missions/OrbitSetupOffer.tsx
+++ b/web/src/components/missions/OrbitSetupOffer.tsx
@@ -15,6 +15,8 @@ import { useGroundControlDashboard } from '../../hooks/useGroundControlDashboard
 import { getApplicableOrbitTemplates } from '../../lib/orbit/orbitTemplates'
 import { ORBIT_DEFAULT_CADENCE } from '../../lib/constants/orbit'
 import { emitOrbitMissionCreated } from '../../lib/analytics'
+import { isDemoMode } from '../../lib/demoMode'
+import { SetupInstructionsDialog } from '../setup/SetupInstructionsDialog'
 import type { OrbitCadence, OrbitType } from '../../lib/missions/types'
 
 interface OrbitSetupOfferProps {
@@ -67,6 +69,7 @@ export function OrbitSetupOffer({
   const [isCreating, setIsCreating] = useState(false)
   const [createdDashboardId, setCreatedDashboardId] = useState<string | null>(null)
   const [isDone, setIsDone] = useState(false)
+  const [showSetupDialog, setShowSetupDialog] = useState(false)
 
   const toggleOrbitType = useCallback((orbitType: OrbitType) => {
     setSelectedOrbits(prev => {
@@ -78,6 +81,12 @@ export function OrbitSetupOffer({
   }, [])
 
   const handleSetup = useCallback(async () => {
+    // In demo mode, redirect to local install setup dialog
+    if (isDemoMode()) {
+      setShowSetupDialog(true)
+      return
+    }
+
     setIsCreating(true)
     try {
       // Create orbit missions for each selected type
@@ -139,6 +148,7 @@ export function OrbitSetupOffer({
   }
 
   return (
+    <>
     <div className="mx-4 mb-4 rounded-xl border border-purple-500/30 bg-purple-500/5 overflow-hidden">
       {/* Header */}
       <button
@@ -250,5 +260,9 @@ export function OrbitSetupOffer({
         </div>
       )}
     </div>
+    {showSetupDialog && (
+      <SetupInstructionsDialog isOpen={showSetupDialog} onClose={() => setShowSetupDialog(false)} />
+    )}
+    </>
   )
 }

--- a/web/src/components/missions/StandaloneOrbitDialog.tsx
+++ b/web/src/components/missions/StandaloneOrbitDialog.tsx
@@ -14,6 +14,8 @@ import { useMissions } from '../../hooks/useMissions'
 import { getApplicableOrbitTemplates } from '../../lib/orbit/orbitTemplates'
 import { ORBIT_DEFAULT_CADENCE } from '../../lib/constants/orbit'
 import { emitOrbitMissionCreated } from '../../lib/analytics'
+import { isDemoMode } from '../../lib/demoMode'
+import { SetupInstructionsDialog } from '../setup/SetupInstructionsDialog'
 import type { OrbitCadence, OrbitType, OrbitConfig } from '../../lib/missions/types'
 
 interface StandaloneOrbitDialogProps {
@@ -38,6 +40,7 @@ export function StandaloneOrbitDialog({ onClose }: StandaloneOrbitDialogProps) {
   const [autoRun, setAutoRun] = useState(false)
   const [selectedClusters, setSelectedClusters] = useState<Set<string>>(new Set())
   const [showClusterPicker, setShowClusterPicker] = useState(false)
+  const [showSetupDialog, setShowSetupDialog] = useState(false)
 
   const clusters = deduplicatedClusters || []
 
@@ -60,6 +63,13 @@ export function StandaloneOrbitDialog({ onClose }: StandaloneOrbitDialogProps) {
 
   const handleCreate = useCallback(() => {
     if (!selectedOrbit) return
+
+    // In demo mode, redirect to local install setup dialog
+    if (isDemoMode()) {
+      setShowSetupDialog(true)
+      return
+    }
+
     const template = templates.find(tpl => tpl.orbitType === selectedOrbit)
     if (!template) return
 
@@ -92,6 +102,7 @@ export function StandaloneOrbitDialog({ onClose }: StandaloneOrbitDialogProps) {
   }, [selectedOrbit, cadence, autoRun, selectedClusters, templates, saveMission, onClose])
 
   return (
+    <>
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 backdrop-blur-sm">
       <div className="w-full max-w-md mx-4 rounded-xl border border-purple-500/30 bg-card shadow-2xl overflow-hidden">
         {/* Header */}
@@ -282,5 +293,9 @@ export function StandaloneOrbitDialog({ onClose }: StandaloneOrbitDialogProps) {
         </div>
       </div>
     </div>
+    {showSetupDialog && (
+      <SetupInstructionsDialog isOpen={showSetupDialog} onClose={() => setShowSetupDialog(false)} />
+    )}
+    </>
   )
 }


### PR DESCRIPTION
## Summary
On console.kubestellar.io (demo mode), orbit actions now open the "Install Console Locally" setup dialog instead of trying to create orbit missions (which require a real cluster).

- **OrbitSetupOffer** (post-install "Keep it in orbit") → opens SetupInstructionsDialog
- **StandaloneOrbitDialog** (sidebar "Add Orbit") → opens SetupInstructionsDialog

Demo visitors can browse the orbit UI and see the full flow, then get directed to install locally to actually use it. Same pattern as the existing Demo button behavior.

## Test plan
- [ ] Build passes
- [ ] On console.kubestellar.io: click "Add Orbit" in sidebar → setup dialog opens
- [ ] On local install: orbit works normally (no setup dialog)