### PR TITLE
fix: resolve 26 test failures across 5 card test files

### DIFF
--- a/web/src/components/cards/__tests__/ArgoCDApplicationSets.test.tsx
+++ b/web/src/components/cards/__tests__/ArgoCDApplicationSets.test.tsx
@@ -138,8 +138,8 @@ describe('ArgoCDApplicationSets', () => {
       } as never)
       render(<ArgoCDApplicationSets />)
       expect(screen.getAllByText('Healthy').length).toBeGreaterThan(0)
-      expect(screen.getByText('Progressing')).toBeTruthy()
-      expect(screen.getByText('Error')).toBeTruthy()
+      expect(screen.getAllByText('Progressing').length).toBeGreaterThan(0)
+      expect(screen.getAllByText('Error').length).toBeGreaterThan(0)
     })
   })
 

--- a/web/src/components/cards/__tests__/CardChat.test.tsx
+++ b/web/src/components/cards/__tests__/CardChat.test.tsx
@@ -95,7 +95,7 @@ describe('CardChat', () => {
 
   beforeEach(() => {
     vi.clearAllMocks()
-    vi.useFakeTimers()
+    vi.useFakeTimers({ shouldAdvanceTime: true })
     user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime })
   })
 

--- a/web/src/components/cards/__tests__/ClusterHealth.test.tsx
+++ b/web/src/components/cards/__tests__/ClusterHealth.test.tsx
@@ -63,7 +63,7 @@ vi.mock('../../../lib/cards/cardHooks', async (importOriginal) => {
   }
 })
 
-vi.mock('../clusters/utils', () => ({
+vi.mock('../../clusters/utils', () => ({
   isClusterUnreachable: (c: ClusterInfo) => c.reachable === false,
   isClusterTokenExpired: (c: ClusterInfo) => c.errorMessage?.includes('token') ?? false,
   isClusterHealthy: (c: ClusterInfo) => c.healthy === true,
@@ -91,7 +91,7 @@ vi.mock('../../ui/CloudProviderIcon', () => ({
   getProviderLabel: () => 'Other',
 }))
 
-vi.mock('../clusters/ClusterDetailModal', () => ({
+vi.mock('../../clusters/ClusterDetailModal', () => ({
   ClusterDetailModal: ({ clusterName, onClose }: { clusterName: string; onClose: () => void }) => (
     <div data-testid="cluster-detail-modal">
       <span>{clusterName}</span>
@@ -294,8 +294,9 @@ describe('ClusterHealth', () => {
       const clusters = [makeCluster({ nodeCount: 4, podCount: 20 })]
       setupDefaults({ clusters })
       render(<ClusterHealth />)
-      expect(screen.getAllByText('4').length).toBeGreaterThan(0)
-      expect(screen.getAllByText('20').length).toBeGreaterThan(0)
+      // Node and pod counts are rendered inline with translated labels (e.g. "4 nodes")
+      expect(screen.getAllByText(/\b4\b/).length).toBeGreaterThan(0)
+      expect(screen.getAllByText(/\b20\b/).length).toBeGreaterThan(0)
     })
 
     it('shows AI actions for unhealthy clusters', () => {
@@ -328,7 +329,8 @@ describe('ClusterHealth', () => {
       render(<ClusterHealth />)
       await userEvent.click(screen.getByText('click-me'))
       expect(screen.getByTestId('cluster-detail-modal')).toBeInTheDocument()
-      expect(screen.getByText('click-me')).toBeInTheDocument()
+      // Cluster name appears both in the list row and in the modal
+      expect(screen.getAllByText('click-me').length).toBeGreaterThanOrEqual(2)
     })
 
     it('closes modal when onClose is called', async () => {

--- a/web/src/components/cards/__tests__/NamespaceOverview.test.tsx
+++ b/web/src/components/cards/__tests__/NamespaceOverview.test.tsx
@@ -130,8 +130,9 @@ describe('NamespaceOverview', () => {
 
     it('populates cluster options from useClusters', () => {
       render(<NamespaceOverview />)
-      expect(screen.getByText('cluster-1')).toBeTruthy()
-      expect(screen.getByText('cluster-2')).toBeTruthy()
+      // Cluster names may appear in both select options and badges
+      expect(screen.getAllByText('cluster-1').length).toBeGreaterThan(0)
+      expect(screen.getAllByText('cluster-2').length).toBeGreaterThan(0)
     })
 
     it('shows select cluster and namespace prompt when neither selected', () => {
@@ -203,7 +204,8 @@ describe('NamespaceOverview', () => {
   describe('Footer', () => {
     it('renders cluster and namespace in footer when both selected', () => {
       render(<NamespaceOverview config={{ cluster: 'cluster-1', namespace: 'default' }} />)
-      expect(screen.getByText('default')).toBeTruthy()
+      // "default" appears in both the select options and the footer
+      expect(screen.getAllByText('default').length).toBeGreaterThan(0)
     })
   })
 })

--- a/web/src/components/cards/__tests__/NodeConditions.test.tsx
+++ b/web/src/components/cards/__tests__/NodeConditions.test.tsx
@@ -220,9 +220,11 @@ describe('NodeConditions', () => {
       } as never)
       mockExecute.mockResolvedValue(undefined)
       render(<NodeConditions />)
+      // Click the row cordon button to open the confirmation dialog
       await act(async () => fireEvent.click(screen.getByText('nodeConditions.cordon')))
+      // The confirm button in the dialog renders first in DOM, row button second
       const buttons = screen.getAllByText('nodeConditions.cordon')
-      await act(async () => fireEvent.click(buttons[buttons.length - 1]))
+      await act(async () => fireEvent.click(buttons[0]))
       await waitFor(() => expect(mockExecute).toHaveBeenCalledWith('cluster-1', ['cordon', 'node-1']))
     })
 
@@ -234,9 +236,11 @@ describe('NodeConditions', () => {
       } as never)
       mockExecute.mockRejectedValue(new Error('kubectl failed'))
       render(<NodeConditions />)
+      // Click the row cordon button to open the confirmation dialog
       await act(async () => fireEvent.click(screen.getByText('nodeConditions.cordon')))
+      // The confirm button in the dialog renders first in DOM, row button second
       const buttons = screen.getAllByText('nodeConditions.cordon')
-      await act(async () => fireEvent.click(buttons[buttons.length - 1]))
+      await act(async () => fireEvent.click(buttons[0]))
       await waitFor(() => expect(screen.getByText(/kubectl failed/)).toBeTruthy())
     })
   })


### PR DESCRIPTION
## Summary
- **CardChat** (14 tests): Added `shouldAdvanceTime: true` to `vi.useFakeTimers()` to prevent `userEvent` + fake timer timeouts in Vitest 4
- **ArgoCDApplicationSets** (1 test): Changed `getByText` to `getAllByText` for status labels that appear in both the stats grid and list rows
- **ClusterHealth** (7 tests): Fixed `vi.mock` paths for `clusters/utils` and `ClusterDetailModal` — the `__tests__` subdirectory shifted relative paths by one level. Also switched to regex matching for inline node/pod counts and handled duplicate text after modal opens
- **NamespaceOverview** (2 tests): Changed `getByText` to `getAllByText` for cluster/namespace values that appear in both select options and rendered content
- **NodeConditions** (2 tests): Fixed cordon/uncordon confirm button click — the confirmation dialog button renders first in DOM (index 0), not last

## Root Causes
1. **Fake timer deadlock**: `vi.useFakeTimers()` without `shouldAdvanceTime` causes `userEvent` to hang waiting for internal delays that never advance
2. **Wrong mock paths**: `vi.mock('../clusters/utils')` from `__tests__/` resolves to `cards/clusters/utils` instead of `components/clusters/utils`, causing real implementations to run
3. **Multiple element matches**: `getByText` throws when text appears in multiple DOM locations (stats + list, options + footer, list + modal)
4. **Wrong button index**: Confirmation dialog renders before the node list, so `buttons[0]` is the confirm button, not `buttons[last]`

## Test plan
- [x] All 26 previously failing tests now pass
- [x] Full test suite passes (719 files, 13802 tests, 0 failures)

Closes #5334