### PR TITLE
fix: wire orbit demo data into mission sidebar on console.kubestellar.io

### DIFF
--- a/web/src/hooks/useMissions.tsx
+++ b/web/src/hooks/useMissions.tsx
@@ -2,6 +2,7 @@ import { createContext, useContext, useState, useRef, useEffect, ReactNode } fro
 import type { AgentInfo, AgentsListPayload, AgentSelectedPayload, ChatStreamPayload } from '../types/agent'
 import { AgentCapabilityToolExec } from '../types/agent'
 import { getDemoMode } from './useDemoMode'
+import { DEMO_ORBIT_MISSIONS } from '../mocks/orbitDemoData'
 import { addCategoryTokens, setActiveTokenCategory } from './useTokenUsage'
 import { detectIssueSignature, findSimilarResolutionsStandalone, generateResolutionPromptContext } from './useResolutions'
 import { LOCAL_AGENT_WS_URL, LOCAL_AGENT_HTTP_URL } from '../lib/constants'
@@ -189,6 +190,17 @@ const MISSION_INACTIVITY_TIMEOUT_MS = 90_000 // 90 seconds of stream silence
  */
 const CANCEL_ACK_TIMEOUT_MS = 10_000 // 10 seconds
 
+/** Pre-converted demo orbit missions for demo mode — avoids re-creating on every call */
+const DEMO_ORBIT_AS_MISSIONS: Mission[] = DEMO_ORBIT_MISSIONS.map(m => ({
+  ...m,
+  type: m.type as Mission['type'],
+  status: m.status as Mission['status'],
+  createdAt: new Date(Date.now() - 7 * 86_400_000),
+  updatedAt: new Date(),
+  messages: [],
+  cluster: (m.context.orbitConfig.clusters || [])[0],
+}))
+
 // Load missions from localStorage
 function loadMissions(): Mission[] {
   try {
@@ -237,6 +249,12 @@ function loadMissions(): Mission[] {
   } catch (e) {
     console.error('Failed to load missions from localStorage:', e)
   }
+
+  // In demo mode, seed with orbit demo missions so the feature is visible
+  if (getDemoMode()) {
+    return DEMO_ORBIT_AS_MISSIONS
+  }
+
   return []
 }
 


### PR DESCRIPTION
## Summary
The 3 demo orbit missions (created in #5295) were never loaded into `useMissions`, so they were invisible on console.kubestellar.io.

Now `loadMissions()` seeds the mission list with demo orbit data when in demo mode:
- **Prometheus Health Check** — weekly, ran 2 days ago, success
- **cert-manager Cert Rotation** — monthly, ran 1 week ago, warning (cert expiring)
- **ArgoCD Version Drift** — weekly, ran 10 days ago, failure (overdue)

These now appear in:
- Mission sidebar list with satellite 🛰️ badges
- OrbitReminderBanner (ArgoCD shows as overdue with amber indicator)
- "Add Orbit" button visible above saved missions

## Test plan
- [ ] Build passes
- [ ] Visit console.kubestellar.io → open AI Missions → 3 orbit missions visible
- [ ] ArgoCD mission shows overdue indicator in reminder banner
- [ ] Orbit missions have satellite badge in list