### PR TITLE
feat: Mission Control shows full deployment blueprint in demo mode

### DIFF
--- a/web/src/components/mission-control/demoState.ts
+++ b/web/src/components/mission-control/demoState.ts
@@ -1,0 +1,173 @@
+/**
+ * Demo Mission Control State
+ *
+ * Pre-populated state for console.kubestellar.io that shows a completed
+ * multi-cluster security + observability deployment. Starts on the
+ * 'blueprint' phase so visitors see the SVG deployment visualization.
+ */
+
+import type {
+  MissionControlState,
+  PayloadProject,
+  ClusterAssignment,
+  DeployPhase,
+  PhaseProgress,
+} from './types'
+
+const DEMO_PROJECTS: PayloadProject[] = [
+  {
+    name: 'prometheus',
+    displayName: 'Prometheus',
+    reason: 'Metrics collection and alerting — foundation for cluster observability.',
+    category: 'Observability',
+    priority: 'required',
+    dependencies: [],
+    maturity: 'graduated',
+    difficulty: 'beginner',
+    githubOrg: 'prometheus',
+  },
+  {
+    name: 'grafana',
+    displayName: 'Grafana',
+    reason: 'Visualization dashboards for Prometheus metrics.',
+    category: 'Observability',
+    priority: 'recommended',
+    dependencies: ['prometheus'],
+    maturity: 'graduated',
+    difficulty: 'beginner',
+    githubOrg: 'grafana',
+  },
+  {
+    name: 'falco',
+    displayName: 'Falco Runtime Security',
+    reason: 'Runtime threat detection — monitors syscalls for malicious activity.',
+    category: 'Security',
+    priority: 'required',
+    dependencies: [],
+    maturity: 'graduated',
+    difficulty: 'intermediate',
+    githubOrg: 'falcosecurity',
+  },
+  {
+    name: 'kyverno',
+    displayName: 'Kyverno',
+    reason: 'Policy engine — enforce security policies as Kubernetes resources.',
+    category: 'Security',
+    priority: 'recommended',
+    dependencies: [],
+    maturity: 'graduated',
+    difficulty: 'intermediate',
+    githubOrg: 'kyverno',
+  },
+  {
+    name: 'cert-manager',
+    displayName: 'cert-manager',
+    reason: 'TLS certificate lifecycle management — auto-renew certificates.',
+    category: 'Security',
+    priority: 'required',
+    dependencies: [],
+    maturity: 'graduated',
+    difficulty: 'beginner',
+    githubOrg: 'cert-manager',
+  },
+]
+
+const DEMO_ASSIGNMENTS: ClusterAssignment[] = [
+  {
+    clusterName: 'eks-prod-us-east-1',
+    clusterContext: 'eks-prod-us-east-1',
+    provider: 'eks',
+    projectNames: ['prometheus', 'grafana', 'falco', 'cert-manager'],
+    warnings: [],
+    readiness: {
+      cpuHeadroomPercent: 68,
+      memHeadroomPercent: 72,
+      storageHeadroomPercent: 85,
+      overallScore: 75,
+    },
+  },
+  {
+    clusterName: 'aks-dev-westeu',
+    clusterContext: 'aks-dev-westeu',
+    provider: 'aks',
+    projectNames: ['prometheus', 'kyverno', 'cert-manager'],
+    warnings: ['Limited storage headroom (38% remaining)'],
+    readiness: {
+      cpuHeadroomPercent: 55,
+      memHeadroomPercent: 62,
+      storageHeadroomPercent: 38,
+      overallScore: 52,
+    },
+  },
+  {
+    clusterName: 'openshift-prod',
+    clusterContext: 'openshift-prod',
+    provider: 'openshift',
+    projectNames: ['falco', 'kyverno'],
+    warnings: [],
+    readiness: {
+      cpuHeadroomPercent: 78,
+      memHeadroomPercent: 81,
+      storageHeadroomPercent: 90,
+      overallScore: 83,
+    },
+  },
+]
+
+const DEMO_PHASES: DeployPhase[] = [
+  {
+    phase: 1,
+    name: 'Core Infrastructure',
+    projectNames: ['cert-manager', 'prometheus'],
+    estimatedSeconds: 90,
+  },
+  {
+    phase: 2,
+    name: 'Security & Observability',
+    projectNames: ['falco', 'kyverno', 'grafana'],
+    estimatedSeconds: 150,
+  },
+]
+
+const DEMO_LAUNCH_PROGRESS: PhaseProgress[] = [
+  {
+    phase: 1,
+    status: 'completed',
+    projects: [
+      { name: 'cert-manager', missionId: 'demo-mc-certmgr', status: 'completed' },
+      { name: 'prometheus', missionId: 'demo-mc-prom', status: 'completed' },
+    ],
+  },
+  {
+    phase: 2,
+    status: 'completed',
+    projects: [
+      { name: 'falco', missionId: 'demo-mc-falco', status: 'completed' },
+      { name: 'kyverno', missionId: 'demo-mc-kyverno', status: 'completed' },
+      { name: 'grafana', missionId: 'demo-mc-grafana', status: 'completed' },
+    ],
+  },
+]
+
+/**
+ * Returns a pre-populated MissionControlState for demo mode.
+ * Shows the blueprint phase so visitors see the SVG deployment visualization
+ * with all projects, clusters, and deployment phases visible.
+ */
+export function getDemoMissionControlState(): Partial<MissionControlState> {
+  return {
+    phase: 'blueprint',
+    title: 'Security & Observability Stack',
+    description: 'Deploy comprehensive security monitoring and observability across production clusters with automated certificate management.',
+    projects: DEMO_PROJECTS,
+    assignments: DEMO_ASSIGNMENTS,
+    phases: DEMO_PHASES,
+    launchProgress: DEMO_LAUNCH_PROGRESS,
+    overlay: 'architecture',
+    deployMode: 'phased',
+    isDryRun: false,
+    targetClusters: [],
+    aiStreaming: false,
+    groundControlDashboardId: undefined,
+  }
+}

--- a/web/src/components/mission-control/useMissionControl.ts
+++ b/web/src/components/mission-control/useMissionControl.ts
@@ -9,6 +9,8 @@ import { useState, useEffect, useRef, useMemo } from 'react'
 import { useMissions } from '../../hooks/useMissions'
 import { useHelmReleases } from '../../hooks/mcp/helm'
 import { useClusters } from '../../hooks/mcp/clusters'
+import { isDemoMode } from '../../lib/demoMode'
+import { getDemoMissionControlState } from './demoState'
 import type {
   MissionControlState,
   PayloadProject,
@@ -34,13 +36,19 @@ interface PersistedStateEntry {
 function loadPersistedState(): Partial<MissionControlState> | null {
   try {
     const raw = localStorage.getItem(STORAGE_KEY) // TTL validation applied below via WIZARD_STATE_TTL_MS
-    if (!raw) return null
+    if (!raw) {
+      // In demo mode, seed with a pre-populated Mission Control state so
+      // visitors see the full blueprint visualization on console.kubestellar.io
+      if (isDemoMode()) return getDemoMissionControlState()
+      return null
+    }
     const entry = JSON.parse(raw) as PersistedStateEntry | Partial<MissionControlState>
     // Support both new format (with savedAt timestamp) and legacy format (plain state)
     if ('savedAt' in entry && typeof entry.savedAt === 'number') {
       // Check TTL — discard wizard state older than WIZARD_STATE_TTL_MS
       if (Date.now() - entry.savedAt > WIZARD_STATE_TTL_MS) {
         localStorage.removeItem(STORAGE_KEY)
+        if (isDemoMode()) return getDemoMissionControlState()
         return null
       }
       return entry.state


### PR DESCRIPTION
## Summary
Mission Control on console.kubestellar.io now opens with a pre-populated deployment plan showing the full SVG blueprint visualization.

**Demo deployment: "Security & Observability Stack"**
- 5 CNCF projects: Prometheus, Grafana, Falco, Kyverno, cert-manager
- 3 target clusters: EKS (75% ready), AKS (52%), OpenShift (83%)
- 2 deployment phases: Core Infrastructure → Security & Observability
- Architecture overlay with the full deployment graph
- Completed launch progress for all projects

Opens on the **blueprint phase** so visitors immediately see the SVG flight plan — the most impressive view of Mission Control.

Falls back to demo state only when no user-created state exists in localStorage.

## Test plan
- [ ] Build passes
- [ ] console.kubestellar.io → click Mission Control → blueprint with 5 projects across 3 clusters
- [ ] SVG flight plan renders with project nodes, cluster zones, dependency edges
- [ ] Phase timeline visible at bottom
- [ ] Local install → Mission Control opens empty (no demo injection)