### PR TITLE
fix: dashboard header wraps when sidebar open + demo missions load from empty storage

### DIFF
--- a/web/src/components/shared/DashboardHeader.tsx
+++ b/web/src/components/shared/DashboardHeader.tsx
@@ -113,9 +113,9 @@ export function DashboardHeader({
   const isLoading = isFetching
 
   return (
-    <div data-testid="dashboard-header" className="flex items-center justify-between mb-6">
+    <div data-testid="dashboard-header" className="flex items-center justify-between gap-4 flex-wrap mb-6">
       {/* Left side: title + hourglass */}
-      <div className="flex items-center gap-3">
+      <div className="flex items-center gap-3 min-w-0">
         <div>
           <h1 data-testid="dashboard-title" className="text-2xl font-bold text-foreground flex items-center gap-2">
             {icon}
@@ -136,7 +136,7 @@ export function DashboardHeader({
       </div>
 
       {/* Right side: controls + timestamp below */}
-      <div className="flex flex-col items-end gap-0.5">
+      <div className="flex flex-col items-end gap-0.5 shrink-0">
         <div className="flex items-center gap-3">
           {rightExtra}
           <label

--- a/web/src/hooks/useMissions.tsx
+++ b/web/src/hooks/useMissions.tsx
@@ -203,6 +203,10 @@ function loadMissions(): Mission[] {
     const stored = localStorage.getItem(MISSIONS_STORAGE_KEY)
     if (stored) {
       const parsed = JSON.parse(stored)
+      // In demo mode, if localStorage is empty use demo missions instead
+      if (getDemoMode() && Array.isArray(parsed) && parsed.length === 0) {
+        return DEMO_MISSIONS_AS_MISSIONS
+      }
       // Convert date strings back to Date objects
       // Mark running missions for auto-reconnection instead of failing them
       return parsed.map((m: Mission) => {


### PR DESCRIPTION
## Summary
Two fixes:

1. **Dashboard header squash** — tip bubble and warning badge overlapped when AI Mission sidebar was open. Added `flex-wrap gap-4` to the header container and `min-w-0` so elements wrap gracefully instead of overlapping.

2. **Demo missions not loading** — `localStorage` with empty `[]` bypassed the demo fallback. Now checks for empty array in demo mode and returns demo missions.

## Test plan
- [ ] Open sidebar on /deploy → tip and warnings wrap to new line instead of overlapping
- [ ] console.kubestellar.io → AI Missions shows 6 demo missions (even with empty localStorage)