### PR TITLE
fix: Mission Control shows demo blueprint instead of empty wizard

### DIFF
--- a/web/src/components/mission-control/useMissionControl.ts
+++ b/web/src/components/mission-control/useMissionControl.ts
@@ -51,10 +51,19 @@ function loadPersistedState(): Partial<MissionControlState> | null {
         if (isDemoMode()) return getDemoMissionControlState()
         return null
       }
-      return entry.state
+      // In demo mode, replace empty/default persisted state with demo data
+      const s = entry.state
+      if (isDemoMode() && (!s?.projects || s.projects.length === 0)) {
+        return getDemoMissionControlState()
+      }
+      return s
     }
     // Legacy format — no expiry info, return as-is
-    return entry as Partial<MissionControlState>
+    const legacy = entry as Partial<MissionControlState>
+    if (isDemoMode() && (!legacy.projects || legacy.projects.length === 0)) {
+      return getDemoMissionControlState()
+    }
+    return legacy
   } catch {
     return null
   }


### PR DESCRIPTION
## Summary
On console.kubestellar.io, opening Mission Control showed an empty "Define Mission" wizard because a previous session persisted `{phase: 'define', projects: []}` to localStorage, which took priority over the demo data.

Now checks if persisted state has no projects in demo mode and replaces with the pre-populated "Security & Observability Stack" deployment (5 projects, 3 clusters, blueprint phase).

## Test plan
- [ ] console.kubestellar.io → click Mission Control → shows blueprint with 5 projects, not empty wizard
- [ ] Local install → Mission Control opens normally (empty or with user data)