### PR TITLE
fix: kagent/kagenti auto-detection, polling, timeouts, error handling, identity binding

### DIFF
--- a/pkg/agent/kagent_crds.go
+++ b/pkg/agent/kagent_crds.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"log/slog"
 	"net/http"
+	"sync"
 	"time"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -13,7 +14,10 @@ import (
 )
 
 const (
+	// kagentCRDTimeout is the shared context timeout for sequential CRD operations
 	kagentCRDTimeout = 30 * time.Second
+	// kagentCRDPerCallTimeout is the per-call timeout when CRD calls run concurrently
+	kagentCRDPerCallTimeout = 15 * time.Second
 )
 
 // kagent.dev CRD Group/Version/Resource definitions
@@ -538,7 +542,9 @@ func (s *Server) handleKagentCRDMemories(w http.ResponseWriter, r *http.Request)
 	json.NewEncoder(w).Encode(map[string]any{"memories": memories, "source": "agent"})
 }
 
-// handleKagentCRDSummary returns an aggregated summary of kagent.dev resources for a cluster
+// handleKagentCRDSummary returns an aggregated summary of kagent.dev resources for a cluster.
+// All 6 CRD queries run concurrently with per-call timeouts to prevent slow calls from
+// starving later ones (fixes #5354).
 func (s *Server) handleKagentCRDSummary(w http.ResponseWriter, r *http.Request) {
 	s.setCORSHeaders(w, r)
 	w.Header().Set("Content-Type", "application/json")
@@ -568,9 +574,6 @@ func (s *Server) handleKagentCRDSummary(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
-	ctx, cancel := context.WithTimeout(r.Context(), kagentCRDTimeout)
-	defer cancel()
-
 	dynClient, err := s.k8sClient.GetDynamicClient(cluster)
 	if err != nil {
 		slog.Info("error fetching kagent CRD summary for cluster request")
@@ -586,25 +589,75 @@ func (s *Server) handleKagentCRDSummary(w http.ResponseWriter, r *http.Request) 
 
 	var agentCount, toolServerCount, remoteMCPServerCount int
 	var modelConfigCount, modelProviderConfigCount, memoryCount int
+	var mu sync.Mutex
 	byProvider := map[string]int{}
+	var warnings []string
+
+	var wg sync.WaitGroup
+	const numCRDQueries = 6
+	wg.Add(numCRDQueries)
 
 	// Count agents
-	if agentList, err := dynClient.Resource(agentGVR).List(ctx, metav1.ListOptions{}); err == nil {
+	go func() {
+		defer wg.Done()
+		ctx, cancel := context.WithTimeout(r.Context(), kagentCRDPerCallTimeout)
+		defer cancel()
+		agentList, listErr := dynClient.Resource(agentGVR).List(ctx, metav1.ListOptions{})
+		mu.Lock()
+		defer mu.Unlock()
+		if listErr != nil {
+			slog.Warn("kagent CRD summary: agents query failed", "error", listErr)
+			warnings = append(warnings, "agents query timed out or failed")
+			return
+		}
 		agentCount = len(agentList.Items)
-	}
+	}()
 
 	// Count tool servers
-	if tsList, err := dynClient.Resource(toolServerGVR).List(ctx, metav1.ListOptions{}); err == nil {
+	go func() {
+		defer wg.Done()
+		ctx, cancel := context.WithTimeout(r.Context(), kagentCRDPerCallTimeout)
+		defer cancel()
+		tsList, listErr := dynClient.Resource(toolServerGVR).List(ctx, metav1.ListOptions{})
+		mu.Lock()
+		defer mu.Unlock()
+		if listErr != nil {
+			slog.Warn("kagent CRD summary: toolServers query failed", "error", listErr)
+			warnings = append(warnings, "toolServers query timed out or failed")
+			return
+		}
 		toolServerCount = len(tsList.Items)
-	}
+	}()
 
 	// Count remote MCP servers
-	if rmsList, err := dynClient.Resource(remoteMCPServerGVR).List(ctx, metav1.ListOptions{}); err == nil {
+	go func() {
+		defer wg.Done()
+		ctx, cancel := context.WithTimeout(r.Context(), kagentCRDPerCallTimeout)
+		defer cancel()
+		rmsList, listErr := dynClient.Resource(remoteMCPServerGVR).List(ctx, metav1.ListOptions{})
+		mu.Lock()
+		defer mu.Unlock()
+		if listErr != nil {
+			slog.Warn("kagent CRD summary: remoteMCPServers query failed", "error", listErr)
+			warnings = append(warnings, "remoteMCPServers query timed out or failed")
+			return
+		}
 		remoteMCPServerCount = len(rmsList.Items)
-	}
+	}()
 
 	// Count model configs and collect providers
-	if mcList, err := dynClient.Resource(modelConfigGVR).List(ctx, metav1.ListOptions{}); err == nil {
+	go func() {
+		defer wg.Done()
+		ctx, cancel := context.WithTimeout(r.Context(), kagentCRDPerCallTimeout)
+		defer cancel()
+		mcList, listErr := dynClient.Resource(modelConfigGVR).List(ctx, metav1.ListOptions{})
+		mu.Lock()
+		defer mu.Unlock()
+		if listErr != nil {
+			slog.Warn("kagent CRD summary: modelConfigs query failed", "error", listErr)
+			warnings = append(warnings, "modelConfigs query timed out or failed")
+			return
+		}
 		modelConfigCount = len(mcList.Items)
 		for _, item := range mcList.Items {
 			specMap, ok := item.Object["spec"].(map[string]any)
@@ -615,10 +668,21 @@ func (s *Server) handleKagentCRDSummary(w http.ResponseWriter, r *http.Request) 
 				}
 			}
 		}
-	}
+	}()
 
 	// Count model provider configs and collect providers
-	if mpcList, err := dynClient.Resource(modelProviderConfigGVR).List(ctx, metav1.ListOptions{}); err == nil {
+	go func() {
+		defer wg.Done()
+		ctx, cancel := context.WithTimeout(r.Context(), kagentCRDPerCallTimeout)
+		defer cancel()
+		mpcList, listErr := dynClient.Resource(modelProviderConfigGVR).List(ctx, metav1.ListOptions{})
+		mu.Lock()
+		defer mu.Unlock()
+		if listErr != nil {
+			slog.Warn("kagent CRD summary: modelProviderConfigs query failed", "error", listErr)
+			warnings = append(warnings, "modelProviderConfigs query timed out or failed")
+			return
+		}
 		modelProviderConfigCount = len(mpcList.Items)
 		for _, item := range mpcList.Items {
 			specMap, ok := item.Object["spec"].(map[string]any)
@@ -629,12 +693,25 @@ func (s *Server) handleKagentCRDSummary(w http.ResponseWriter, r *http.Request) 
 				}
 			}
 		}
-	}
+	}()
 
 	// Count memories
-	if memList, err := dynClient.Resource(memoryGVR).List(ctx, metav1.ListOptions{}); err == nil {
+	go func() {
+		defer wg.Done()
+		ctx, cancel := context.WithTimeout(r.Context(), kagentCRDPerCallTimeout)
+		defer cancel()
+		memList, listErr := dynClient.Resource(memoryGVR).List(ctx, metav1.ListOptions{})
+		mu.Lock()
+		defer mu.Unlock()
+		if listErr != nil {
+			slog.Warn("kagent CRD summary: memories query failed", "error", listErr)
+			warnings = append(warnings, "memories query timed out or failed")
+			return
+		}
 		memoryCount = len(memList.Items)
-	}
+	}()
+
+	wg.Wait()
 
 	byCluster := map[string]any{
 		cluster: map[string]int{
@@ -647,7 +724,7 @@ func (s *Server) handleKagentCRDSummary(w http.ResponseWriter, r *http.Request) 
 		},
 	}
 
-	json.NewEncoder(w).Encode(map[string]any{
+	result := map[string]any{
 		"agentCount":               agentCount,
 		"toolServerCount":          toolServerCount,
 		"remoteMCPServerCount":     remoteMCPServerCount,
@@ -657,5 +734,10 @@ func (s *Server) handleKagentCRDSummary(w http.ResponseWriter, r *http.Request) 
 		"byCluster":                byCluster,
 		"byProvider":               byProvider,
 		"source":                   "agent",
-	})
+	}
+	if len(warnings) > 0 {
+		result["warnings"] = warnings
+	}
+
+	json.NewEncoder(w).Encode(result)
 }

--- a/pkg/agent/kagenti.go
+++ b/pkg/agent/kagenti.go
@@ -332,7 +332,13 @@ func (s *Server) handleKagentiCards(w http.ResponseWriter, r *http.Request) {
 			c.Skills = nestedStringSlice(specMap, "skills")
 			c.Capabilities = nestedStringSlice(specMap, "capabilities")
 			c.SyncPeriod = nestedString(specMap, "syncPeriod")
-			c.IdentityBinding = nestedString(specMap, "identityBinding", "spiffeId")
+			// identityBinding is a top-level spec field (e.g. "strict", "permissive", "none"),
+			// not nested under spiffeId. Fall back to "none" when the field is absent
+			// so the frontend doesn't classify empty strings as SPIFFE-bound.
+			c.IdentityBinding = nestedString(specMap, "identityBinding")
+			if c.IdentityBinding == "" {
+				c.IdentityBinding = "none"
+			}
 		}
 		cards = append(cards, c)
 	}

--- a/pkg/kagent/client.go
+++ b/pkg/kagent/client.go
@@ -158,13 +158,36 @@ func (c *KagentClient) Invoke(ctx context.Context, namespace, agentName, message
 	return resp.Body, nil
 }
 
+// buildDetectCandidates constructs the list of candidate URLs for auto-detection.
+// The namespace, service name, port, and protocol are configurable via environment
+// variables so non-standard deployments can be discovered automatically.
+func buildDetectCandidates() []string {
+	namespace := os.Getenv("KAGENT_NAMESPACE")
+	if namespace == "" {
+		namespace = "kagent"
+	}
+	serviceName := os.Getenv("KAGENT_SERVICE_NAME")
+	if serviceName == "" {
+		serviceName = "kagent-controller"
+	}
+	port := os.Getenv("KAGENT_SERVICE_PORT")
+	if port == "" {
+		port = "8083"
+	}
+	protocol := os.Getenv("KAGENT_SERVICE_PROTOCOL")
+	if protocol == "" {
+		protocol = "http"
+	}
+	return []string{
+		fmt.Sprintf("%s://%s.%s.svc:%s", protocol, serviceName, namespace, port),
+		fmt.Sprintf("%s://%s.%s.svc.cluster.local:%s", protocol, serviceName, namespace, port),
+	}
+}
+
 // Detect tries common in-cluster kagent service URLs and returns the first
 // reachable one. Returns an empty string if none are reachable.
 func (c *KagentClient) Detect() string {
-	candidates := []string{
-		"http://kagent-controller.kagent.svc:8083",
-		"http://kagent-controller.kagent.svc.cluster.local:8083",
-	}
+	candidates := buildDetectCandidates()
 	for _, url := range candidates {
 		resp, err := c.httpClient.Get(url + "/health")
 		if err == nil {

--- a/pkg/kagenti_provider/client.go
+++ b/pkg/kagenti_provider/client.go
@@ -155,13 +155,36 @@ func (c *KagentiClient) Invoke(ctx context.Context, namespace, agentName, messag
 	return resp.Body, nil
 }
 
+// buildDetectCandidates constructs the list of candidate URLs for kagenti auto-detection.
+// The namespace, service name, port, and protocol are configurable via environment
+// variables so non-standard deployments can be discovered automatically.
+func buildDetectCandidates() []string {
+	namespace := os.Getenv("KAGENTI_NAMESPACE")
+	if namespace == "" {
+		namespace = "kagenti-system"
+	}
+	serviceName := os.Getenv("KAGENTI_SERVICE_NAME")
+	if serviceName == "" {
+		serviceName = "kagenti-controller"
+	}
+	port := os.Getenv("KAGENTI_SERVICE_PORT")
+	if port == "" {
+		port = "8083"
+	}
+	protocol := os.Getenv("KAGENTI_SERVICE_PROTOCOL")
+	if protocol == "" {
+		protocol = "http"
+	}
+	return []string{
+		fmt.Sprintf("%s://%s.%s.svc:%s", protocol, serviceName, namespace, port),
+		fmt.Sprintf("%s://%s.%s.svc.cluster.local:%s", protocol, serviceName, namespace, port),
+	}
+}
+
 // Detect tries common in-cluster kagenti service URLs and returns the first
 // reachable one. Returns an empty string if none are reachable.
 func (c *KagentiClient) Detect() string {
-	candidates := []string{
-		"http://kagenti-controller.kagenti-system.svc:8083",
-		"http://kagenti-controller.kagenti-system.svc.cluster.local:8083",
-	}
+	candidates := buildDetectCandidates()
 	for _, url := range candidates {
 		resp, err := c.httpClient.Get(url + "/health")
 		if err == nil {

--- a/web/src/hooks/mcp/kagent_crds.ts
+++ b/web/src/hooks/mcp/kagent_crds.ts
@@ -74,15 +74,20 @@ async function agentFetch<T>(path: string, cluster: string, namespace?: string):
       headers: { Accept: 'application/json' },
     })
     clearTimeout(tid)
-    if (!res.ok) throw new Error(`Agent ${res.status}`)
+    if (!res.ok) throw new Error(`Agent returned ${res.status} for ${path} (cluster: ${cluster})`)
     return await res.json()
-  } catch {
+  } catch (err) {
     clearTimeout(tid)
-    return null
+    // Log the error so it is visible in the console
+    console.warn(`[kagent_crds] fetch failed for ${path} (cluster: ${cluster}):`, err)
+    // Re-throw so callers can surface the error to the UI
+    throw err
   }
 }
 
-/** Fetch from agent across all reachable clusters */
+/** Fetch from agent across all reachable clusters.
+ *  Throws if ALL clusters fail so the error propagates to the UI
+ *  instead of silently falling back to demo data. */
 async function agentFetchAllClusters<T>(
   path: string,
   key: string,
@@ -109,9 +114,17 @@ async function agentFetchAllClusters<T>(
   )
 
   const items: T[] = []
+  const errors: string[] = []
   for (const r of (results || [])) {
     if (r.status === 'fulfilled') items.push(...r.value)
+    else errors.push(r.reason?.message || 'unknown error')
   }
+
+  // If every cluster failed, throw so the error reaches the UI
+  if (items.length === 0 && errors.length > 0) {
+    throw new Error(`All kagent CRD fetches failed: ${errors.join('; ')}`)
+  }
+
   return items
 }
 

--- a/web/src/hooks/mcp/kagenti.ts
+++ b/web/src/hooks/mcp/kagenti.ts
@@ -130,15 +130,20 @@ async function agentFetch<T>(path: string, cluster: string, namespace?: string):
       signal: ctrl.signal,
       headers: { Accept: 'application/json' } })
     clearTimeout(tid)
-    if (!res.ok) throw new Error(`Agent ${res.status}`)
+    if (!res.ok) throw new Error(`Agent returned ${res.status} for ${path} (cluster: ${cluster})`)
     return await res.json()
-  } catch {
+  } catch (err) {
     clearTimeout(tid)
-    return null
+    // Log the error so it is visible in the console
+    console.warn(`[kagenti] fetch failed for ${path} (cluster: ${cluster}):`, err)
+    // Re-throw so callers can surface the error to the UI
+    throw err
   }
 }
 
-/** Fetch from agent across all reachable clusters */
+/** Fetch from agent across all reachable clusters.
+ *  Throws if ALL clusters fail so the error propagates to the UI
+ *  instead of silently falling back to demo data. */
 async function agentFetchAllClusters<T>(
   path: string,
   key: string,
@@ -165,9 +170,17 @@ async function agentFetchAllClusters<T>(
   )
 
   const items: T[] = []
+  const errors: string[] = []
   for (const r of (results || [])) {
     if (r.status === 'fulfilled') items.push(...r.value)
+    else errors.push(r.reason?.message || 'unknown error')
   }
+
+  // If every cluster failed, throw so the error reaches the UI
+  if (items.length === 0 && errors.length > 0) {
+    throw new Error(`All kagenti fetches failed: ${errors.join('; ')}`)
+  }
+
   return items
 }
 
@@ -268,7 +281,11 @@ export function useKagentiSummary() {
     }
 
     const spiffeTotal = cards.length
-    const spiffeBound = cards.filter(c => c.identityBinding !== 'none').length
+    // Only count cards with an explicit, non-empty binding that is not "none".
+    // Empty string (missing field) must NOT be counted as SPIFFE-bound.
+    const spiffeBound = cards.filter(c =>
+      c.identityBinding !== '' && c.identityBinding !== 'none',
+    ).length
 
     return {
       agentCount: agents.length,

--- a/web/src/hooks/useKagentBackend.ts
+++ b/web/src/hooks/useKagentBackend.ts
@@ -60,6 +60,7 @@ export function useKagentBackend(): UseKagentBackendResult {
   })
 
   const pollRef = useRef<ReturnType<typeof setInterval>>(undefined)
+  const refreshInFlightRef = useRef(false)
   const selectedKagentRef = useRef(selectedKagentAgent)
   const selectedKagentiRef = useRef(selectedKagentiAgent)
   useEffect(() => {
@@ -68,34 +69,47 @@ export function useKagentBackend(): UseKagentBackendResult {
   }, [selectedKagentAgent, selectedKagentiAgent])
 
   const refresh = useCallback(async () => {
-    // Poll kagent
-    const kStatus = await fetchKagentStatus()
-    setKagentStatus(kStatus)
-    if (kStatus.available) {
-      const agents = await fetchKagentAgents()
-      setKagentAgents(agents)
-      const savedName = localStorage.getItem(KAGENT_SELECTED_AGENT_KEY)
-      if (savedName && !selectedKagentRef.current) {
-        const found = agents.find(a => `${a.namespace}/${a.name}` === savedName)
-        if (found) setSelectedKagentAgent(found)
-      }
-    } else {
-      setKagentAgents([])
-    }
+    // Guard against overlapping fetches on slow networks
+    if (refreshInFlightRef.current) return
+    refreshInFlightRef.current = true
+    try {
+      // Poll kagent and kagenti concurrently — independent fetch chains
+      // should not block each other
+      const [kStatus, kiStatus] = await Promise.all([
+        fetchKagentStatus(),
+        fetchKagentiProviderStatus(),
+      ])
 
-    // Poll kagenti
-    const kiStatus = await fetchKagentiProviderStatus()
-    setKagentiStatus(kiStatus)
-    if (kiStatus.available) {
-      const agents = await fetchKagentiProviderAgents()
-      setKagentiAgents(agents)
-      const savedName = localStorage.getItem(KAGENTI_SELECTED_AGENT_KEY)
-      if (savedName && !selectedKagentiRef.current) {
-        const found = agents.find(a => `${a.namespace}/${a.name}` === savedName)
-        if (found) setSelectedKagentiAgent(found)
+      setKagentStatus(kStatus)
+      setKagentiStatus(kiStatus)
+
+      // Fetch agent lists concurrently for available backends
+      const [kagentAgentsList, kagentiAgentsList] = await Promise.all([
+        kStatus.available ? fetchKagentAgents() : Promise.resolve([] as KagentAgent[]),
+        kiStatus.available ? fetchKagentiProviderAgents() : Promise.resolve([] as KagentiProviderAgent[]),
+      ])
+
+      // Update kagent agents
+      setKagentAgents(kagentAgentsList)
+      if (kStatus.available) {
+        const savedName = localStorage.getItem(KAGENT_SELECTED_AGENT_KEY)
+        if (savedName && !selectedKagentRef.current) {
+          const found = kagentAgentsList.find(a => `${a.namespace}/${a.name}` === savedName)
+          if (found) setSelectedKagentAgent(found)
+        }
       }
-    } else {
-      setKagentiAgents([])
+
+      // Update kagenti agents
+      setKagentiAgents(kagentiAgentsList)
+      if (kiStatus.available) {
+        const savedName = localStorage.getItem(KAGENTI_SELECTED_AGENT_KEY)
+        if (savedName && !selectedKagentiRef.current) {
+          const found = kagentiAgentsList.find(a => `${a.namespace}/${a.name}` === savedName)
+          if (found) setSelectedKagentiAgent(found)
+        }
+      }
+    } finally {
+      refreshInFlightRef.current = false
     }
   }, [])
 


### PR DESCRIPTION
## Summary
- **#5352**: Make kagent/kagenti auto-detection configurable via env vars (`KAGENT_NAMESPACE`, `KAGENT_SERVICE_NAME`, `KAGENT_SERVICE_PORT`, `KAGENT_SERVICE_PROTOCOL` and `KAGENTI_` equivalents). Supports HTTPS and non-standard deployments.
- **#5353**: Add ref-based in-flight guard to `useKagentBackend` polling to prevent overlapping fetch calls on slow networks. Run kagent/kagenti status checks concurrently with `Promise.all`.
- **#5354**: Run all 6 CRD queries concurrently with per-call timeouts (15s each) using `sync.WaitGroup` instead of sequential calls under one shared 30s timeout. Log and surface timeout warnings.
- **#5355**: Propagate fetch errors to the UI instead of silently falling back to demo data. `agentFetch` now re-throws with logging; `agentFetchAllClusters` throws when all clusters fail.
- **#5357**: Fix `identityBinding` extraction from wrong nested path (`spec.identityBinding.spiffeId` -> `spec.identityBinding`). Default to `"none"` when absent. Frontend checks for both empty string and `"none"`.

Closes #5352, #5353, #5354, #5355, #5357

## Test plan
- [ ] Deploy kagent in a non-default namespace and verify auto-detection works with env vars
- [ ] Simulate slow network and verify no overlapping polls in useKagentBackend
- [ ] Verify CRD summary returns results even when individual queries are slow
- [ ] Disconnect agent backend and verify error state shown instead of demo data
- [ ] Deploy kagenti agents without SPIFFE identity and verify they are NOT counted as SPIFFE-bound