### PR TITLE
fix: prevent false 'Agent Not Responding' during long-running tool calls

### DIFF
--- a/pkg/agent/server.go
+++ b/pkg/agent/server.go
@@ -42,6 +42,13 @@ const (
 	// missions from staying in "Running/Processing" state indefinitely when the
 	// AI provider hangs or never responds (#2375).
 	missionExecutionTimeout = 5 * time.Minute
+
+	// missionHeartbeatInterval is how often the backend sends a heartbeat
+	// progress event during mission execution.  This prevents the frontend's
+	// stream-inactivity timer (90s) from firing during legitimate long-running
+	// tool calls (e.g., `drasi init`, `helm install`) that produce no output
+	// for extended periods.
+	missionHeartbeatInterval = 30 * time.Second
 )
 
 // Version is set by ldflags during build

--- a/pkg/agent/server_ai.go
+++ b/pkg/agent/server_ai.go
@@ -489,7 +489,34 @@ func (s *Server) handleChatMessageStreaming(conn *websocket.Conn, msg protocol.M
 			})
 		}
 
+		// Heartbeat goroutine: sends periodic progress events to prevent the
+		// frontend's stream-inactivity timer from firing during long-running
+		// tool calls (e.g., `drasi init` which deploys Kubernetes components
+		// and can take several minutes with no output).
+		heartbeatDone := make(chan struct{})
+		go func() {
+			ticker := time.NewTicker(missionHeartbeatInterval)
+			defer ticker.Stop()
+			for {
+				select {
+				case <-heartbeatDone:
+					return
+				case <-ctx.Done():
+					return
+				case <-ticker.C:
+					safeWrite(ctx, protocol.Message{
+						ID:   msg.ID,
+						Type: protocol.TypeProgress,
+						Payload: protocol.ProgressPayload{
+							Step: "Still working...",
+						},
+					})
+				}
+			}
+		}()
+
 		resp, err = streamingProvider.StreamChatWithProgress(ctx, chatReq, onChunk, onProgress)
+		close(heartbeatDone)
 		if err != nil {
 			if ctx.Err() != nil {
 				// Distinguish timeout from user-initiated cancel (#2375)

--- a/web/src/hooks/useMissions.test.tsx
+++ b/web/src/hooks/useMissions.test.tsx
@@ -2358,6 +2358,44 @@ describe('mission timeout interval', () => {
     }
   })
 
+  it('progress events reset inactivity timer so long-running tools do not timeout', async () => {
+    vi.useFakeTimers()
+    try {
+      const { result } = renderHook(() => useMissions(), { wrapper })
+      const { missionId, requestId } = await startMissionWithConnection(result)
+
+      // Send a stream chunk to start tracking inactivity
+      act(() => {
+        MockWebSocket.lastInstance?.simulateMessage({
+          id: requestId,
+          type: 'stream',
+          payload: { content: 'Installing Drasi...', done: false },
+        })
+      })
+
+      // Advance 60s — within 90s window, still alive
+      act(() => { vi.advanceTimersByTime(60_000) })
+
+      // Send a progress event (heartbeat from tool execution)
+      act(() => {
+        MockWebSocket.lastInstance?.simulateMessage({
+          id: requestId,
+          type: 'progress',
+          payload: { step: 'Still working...' },
+        })
+      })
+
+      // Advance another 60s — 120s total, but only 60s since last progress event
+      act(() => { vi.advanceTimersByTime(60_000) })
+
+      // Mission should still be running (progress reset the timer)
+      const mission = result.current.missions.find(m => m.id === missionId)
+      expect(mission?.status).toBe('running')
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
   it('does not fire timeout when no running missions exist', async () => {
     vi.useFakeTimers()
     try {

--- a/web/src/hooks/useMissions.tsx
+++ b/web/src/hooks/useMissions.tsx
@@ -833,6 +833,9 @@ Install the console locally with the KubeStellar Console agent to use AI mission
           progress?: number
           tokens?: { input?: number; output?: number; total?: number }
         }
+        // Reset inactivity timer — progress events prove the agent is alive,
+        // even during long-running tool calls like `drasi init` (#5360).
+        lastStreamTimestamp.current.set(missionId, Date.now())
         // Track token delta for category usage
         if (payload.tokens?.total) {
           const previousTotal = m.tokenUsage?.total ?? 0


### PR DESCRIPTION
## Summary

- **Frontend**: Progress events now reset the stream-inactivity timer (`lastStreamTimestamp`). Previously only `stream` content chunks did, so long-running tool calls that only produced `progress` events would timeout after 90 seconds.
- **Backend**: Added a heartbeat goroutine that sends periodic `TypeProgress` events every 30 seconds during mission execution. This ensures the frontend always sees activity even when a CLI command (e.g., `drasi init`, `helm install`) produces no output for extended periods.
- **Test**: Added test verifying that progress events prevent inactivity timeout.

Fixes the "Agent Not Responding" issue reported by @ruokun-niu in drasi-project/drasi-platform#400 — `drasi init` deploys Dapr + control plane components and takes ~2 minutes, which exceeded the 90-second inactivity window.

## Test plan

- [x] `vitest run useMissions.test.tsx` — 279 passed (1 pre-existing failure unrelated)
- [x] `go build ./...` — clean
- [x] `npm run build` — clean