### PR TITLE
fix: blueprint cluster name overlap + always show completed project names

### DIFF
--- a/web/src/components/mission-control/svg/ClusterZone.tsx
+++ b/web/src/components/mission-control/svg/ClusterZone.tsx
@@ -228,7 +228,7 @@ export function ClusterZone({
         </div>
       </foreignObject>
 
-      {/* Cluster name (positioned after icon) */}
+      {/* Cluster name (positioned after icon, clipped to avoid overlapping stat blocks) */}
       <text
         x={x + 30}
         y={y + 17}
@@ -239,8 +239,9 @@ export function ClusterZone({
         fontFamily="system-ui, sans-serif"
         opacity={0.9}
         cursor="pointer"
+        clipPath={`rect(0 ${width - 140} 30 0)`}
       >
-        {name}
+        {name.length > 18 ? `${name.slice(0, 16)}...` : name}
       </text>
 
       {/* ── Overlay-dependent resource display ─────────────── */}

--- a/web/src/components/mission-control/svg/ProjectNode.tsx
+++ b/web/src/components/mission-control/svg/ProjectNode.tsx
@@ -271,8 +271,8 @@ export function ProjectNode({
         />
       )}
 
-      {/* Name label — only shown when this node is glowing, placed above to avoid edge labels */}
-      {glow && (() => {
+      {/* Name label — shown on hover (glow) or when completed so project names are always visible */}
+      {(glow || status === 'completed') && (() => {
         const shortName = name.length <= 16 ? name : name.replace(/-/g, ' ')
         const labelW = shortName.length * 3 + 6
         const labelY = cy - radius - 8


### PR DESCRIPTION
## Summary
Two Flight Plan Blueprint visual fixes:

1. **Cluster name overlap** — long names like "eks-prod-us-east-1" overlapped with DISK/PVC stat blocks. Now truncates to 16 chars with "..." suffix.

2. **Project names on completed nodes** — labels only showed on hover (glow). Completed nodes now always display their project name, making the blueprint readable at a glance without hovering.

## Test plan
- [ ] console.kubestellar.io → Mission Control → blueprint shows truncated cluster names
- [ ] All 5 completed project nodes show their names (prometheus, grafana, falco, kyverno, cert-manager)
- [ ] Hover still highlights with brighter label