### PR TITLE
fix: update tests to expect throws after agentFetch error handling change

### DIFF
--- a/web/src/hooks/mcp/__tests__/kagent_crds.test.ts
+++ b/web/src/hooks/mcp/__tests__/kagent_crds.test.ts
@@ -765,9 +765,9 @@ describe('fetcher callback — agentFetchAllClusters', () => {
     renderHook(() => useKagentCRDTools())
 
     expect(capturedFetcher).toBeDefined()
-    const result = await capturedFetcher!()
-    // agentFetch returns null on non-ok => throws 'No data' => rejected => filtered out
-    expect(result).toEqual([])
+    // agentFetch now throws on non-ok response; when all clusters fail,
+    // agentFetchAllClusters re-throws with an aggregate error
+    await expect(capturedFetcher!()).rejects.toThrow('All kagent CRD fetches failed')
   })
 
   it('agentFetch returns null when fetch throws (network error)', async () => {
@@ -807,8 +807,9 @@ describe('fetcher callback — agentFetchAllClusters', () => {
     renderHook(() => useKagentCRDModels())
 
     expect(capturedFetcher).toBeDefined()
-    const result = await capturedFetcher!()
-    expect(result).toEqual([])
+    // agentFetch now throws on network error; when all clusters fail,
+    // agentFetchAllClusters re-throws with an aggregate error
+    await expect(capturedFetcher!()).rejects.toThrow('All kagent CRD fetches failed')
   })
 })
 
@@ -1152,10 +1153,9 @@ describe('agentFetch — abort timeout behavior', () => {
     renderHook(() => useKagentCRDModels())
 
     expect(capturedFetcher).toBeDefined()
-    const result = await capturedFetcher!()
-
-    // Should still work — catch block returns null, which causes 'No data' throw
-    expect(result).toEqual([])
+    // agentFetch now re-throws on failure; when all clusters fail,
+    // agentFetchAllClusters throws an aggregate error
+    await expect(capturedFetcher!()).rejects.toThrow('All kagent CRD fetches failed')
     expect(clearTimeoutSpy).toHaveBeenCalled()
     clearTimeoutSpy.mockRestore()
   })

--- a/web/src/hooks/mcp/__tests__/kagenti.test.ts
+++ b/web/src/hooks/mcp/__tests__/kagenti.test.ts
@@ -784,11 +784,9 @@ describe('useKagentiAgents — fetcher callback', () => {
     })
 
     renderHook(() => useKagentiAgents())
-    // agentFetch returns null when response is not ok, which causes
-    // agentFetchAllClusters to throw 'No data' for that cluster
-    // but the settled results filter handles it
-    const result = await capturedFetcher!()
-    expect(result).toEqual([])
+    // agentFetch now throws on non-ok response; when all clusters fail,
+    // agentFetchAllClusters re-throws with an aggregate error
+    await expect(capturedFetcher!()).rejects.toThrow('All kagenti fetches failed')
 
     globalThis.fetch = originalFetch
   })
@@ -813,9 +811,9 @@ describe('useKagentiAgents — fetcher callback', () => {
     globalThis.fetch = vi.fn().mockRejectedValue(new Error('ECONNREFUSED'))
 
     renderHook(() => useKagentiAgents())
-    const result = await capturedFetcher!()
-    // Should return empty array since the settled results filter rejects
-    expect(result).toEqual([])
+    // agentFetch now throws on network error; when all clusters fail,
+    // agentFetchAllClusters re-throws with an aggregate error
+    await expect(capturedFetcher!()).rejects.toThrow('All kagenti fetches failed')
 
     globalThis.fetch = originalFetch
   })


### PR DESCRIPTION
## Summary
- PR #5362 changed `agentFetch` to throw errors instead of returning `null`, and `agentFetchAllClusters` to throw an aggregate error when all clusters fail
- 5 tests in `kagent_crds.test.ts` (3) and `kagenti.test.ts` (2) still expected the old null-return behavior
- Updated all 5 assertions from `expect(result).toEqual([])` to `await expect(fn()).rejects.toThrow('All kagent... fetches failed')`

Closes #5369

## Test plan
- [x] All 3 failing test files pass: `npx vitest run src/hooks/mcp/__tests__/kagent_crds.test.ts src/hooks/mcp/__tests__/kagenti.test.ts src/hooks/useMissions.test.tsx` (367 tests pass)
- [x] Full test suite passes: 721 test files, 13864 tests pass