### PR TITLE
fix: escape propagation, stale demo steps, stats footer overlap

### DIFF
--- a/web/src/components/layout/mission-sidebar/MissionSidebar.tsx
+++ b/web/src/components/layout/mission-sidebar/MissionSidebar.tsx
@@ -1121,7 +1121,7 @@ export function MissionSidebar() {
         <div
           className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-2xl"
           onClick={(e) => { if (e.target === e.currentTarget) setViewingMission(null) }}
-          onKeyDown={(e) => { if (e.key === 'Escape') setViewingMission(null) }}
+          onKeyDown={(e) => { if (e.key === 'Escape') { e.stopPropagation(); setViewingMission(null) } }}
           tabIndex={-1}
           ref={(el) => el?.focus()}
         >

--- a/web/src/components/mission-control/svg/ClusterZone.tsx
+++ b/web/src/components/mission-control/svg/ClusterZone.tsx
@@ -249,13 +249,13 @@ export function ClusterZone({
       {showCompute && (
         <g>
           {/* Stat block row at top-right */}
-          <StatBlock x={x + width - 120} y={y + height - 18} label="CPU" value={cpuUsage} max={cpuCores} unit="" color={SVG_COLORS.cpu} displayOverride={pct(cpuUsage, cpuCores) != null ? `${pct(cpuUsage, cpuCores)}%` : cpuCores != null ? `${cpuCores} cores` : '—'} />
-          <StatBlock x={x + width - 60} y={y + height - 18} label="MEM" value={memUsage} max={memGB} unit="" color={SVG_COLORS.mem} displayOverride={pct(memUsage, memGB) != null ? `${pct(memUsage, memGB)}%` : memGB != null ? formatStorage(memGB) : '—'} />
+          <StatBlock x={x + width - 120} y={y + height - 35} label="CPU" value={cpuUsage} max={cpuCores} unit="" color={SVG_COLORS.cpu} displayOverride={pct(cpuUsage, cpuCores) != null ? `${pct(cpuUsage, cpuCores)}%` : cpuCores != null ? `${cpuCores} cores` : '—'} />
+          <StatBlock x={x + width - 60} y={y + height - 35} label="MEM" value={memUsage} max={memGB} unit="" color={SVG_COLORS.mem} displayOverride={pct(memUsage, memGB) != null ? `${pct(memUsage, memGB)}%` : memGB != null ? formatStorage(memGB) : '—'} />
           {/* GPU / TPU row */}
           {(gpuCount != null || tpuCount != null) && (
             <>
-              <StatBlock x={x + width - 120} y={y + height - 34} label="GPU" value={undefined} max={gpuCount} unit="" color={SVG_COLORS.gpu} />
-              <StatBlock x={x + width - 60} y={y + height - 34} label="TPU" value={undefined} max={tpuCount} unit="" color={SVG_COLORS.tpu} />
+              <StatBlock x={x + width - 120} y={y + height - 51} label="GPU" value={undefined} max={gpuCount} unit="" color={SVG_COLORS.gpu} />
+              <StatBlock x={x + width - 60} y={y + height - 51} label="TPU" value={undefined} max={tpuCount} unit="" color={SVG_COLORS.tpu} />
             </>
           )}
         </g>
@@ -264,8 +264,8 @@ export function ClusterZone({
       {/* Storage overlay: PVC, Storage capacity */}
       {showStorage && (
         <g>
-          <StatBlock x={x + width - 120} y={y + height - 18} label="DISK" value={undefined} max={storageGB != null ? Math.round(storageGB) : undefined} unit="" color={SVG_COLORS.disk} displayOverride={storageGB != null ? formatStorage(storageGB) : '—'} />
-          <StatBlock x={x + width - 60} y={y + height - 18} label="PVC" value={pvcBoundCount} max={pvcCount} unit="" color={SVG_COLORS.pvc} noAlert />
+          <StatBlock x={x + width - 120} y={y + height - 35} label="DISK" value={undefined} max={storageGB != null ? Math.round(storageGB) : undefined} unit="" color={SVG_COLORS.disk} displayOverride={storageGB != null ? formatStorage(storageGB) : '—'} />
+          <StatBlock x={x + width - 60} y={y + height - 35} label="PVC" value={pvcBoundCount} max={pvcCount} unit="" color={SVG_COLORS.pvc} noAlert />
         </g>
       )}
 

--- a/web/src/hooks/useMissions.tsx
+++ b/web/src/hooks/useMissions.tsx
@@ -203,8 +203,12 @@ function loadMissions(): Mission[] {
     const stored = localStorage.getItem(MISSIONS_STORAGE_KEY)
     if (stored) {
       const parsed = JSON.parse(stored)
-      // In demo mode, if localStorage is empty use demo missions instead
-      if (getDemoMode() && Array.isArray(parsed) && parsed.length === 0) {
+      // In demo mode, replace stale demo data with fresh demo missions
+      // (catches both empty arrays and outdated demo entries without steps)
+      if (getDemoMode() && Array.isArray(parsed) && (
+        parsed.length === 0 ||
+        parsed.some((m: { id?: string }) => m.id?.startsWith('demo-'))
+      )) {
         return DEMO_MISSIONS_AS_MISSIONS
       }
       // Convert date strings back to Date objects


### PR DESCRIPTION
## Summary
1. **Escape key** — mission detail modal now `stopPropagation()` so only the modal closes, not the sidebar behind it
2. **Demo mission steps** — always reload fresh demo data (detects stale demo entries by `demo-` ID prefix) so orbit missions show their 3 steps instead of "No install steps"
3. **Stats footer overlap** — moved stat blocks higher (height-35) to clear the resource count row at bottom of cluster zones

## Test plan
- [ ] Press Escape on mission detail → modal closes, sidebar stays open
- [ ] Click eye icon on orbit mission → shows 3 install steps (not "No install steps available")
- [ ] Blueprint stats (DISK/PVC) don't overlap the pod/config count footer