### PR TITLE
fix: clarify update scopes in System Updates settings

### DIFF
--- a/web/src/components/settings/UpdateSettings.tsx
+++ b/web/src/components/settings/UpdateSettings.tsx
@@ -21,6 +21,7 @@ import {
   Shield,
   HardDrive,
   GitCommitHorizontal,
+  Info,
 } from 'lucide-react'
 import { useVersionCheck } from '../../hooks/useVersionCheck'
 import { useUpdateProgress } from '../../hooks/useUpdateProgress'
@@ -136,6 +137,7 @@ export function UpdateSettings() {
 
   const [showReleaseNotes, setShowReleaseNotes] = useState(false)
   const [showPrereqs, setShowPrereqs] = useState(false)
+  const [showScopeInfo, setShowScopeInfo] = useState(false)
   const [copiedCommand, setCopiedCommand] = useState<string | null>(null)
   const [channelDropdownOpen, setChannelDropdownOpen] = useState(false)
   const [triggerState, setTriggerState] = useState<'idle' | 'triggered' | 'error'>('idle')
@@ -298,6 +300,34 @@ export function UpdateSettings() {
             {t('settings.updates.checkNow')}
           </Button>
         </div>
+      </div>
+
+      {/* Scope info — explains what System Updates controls vs. other update types */}
+      <div className="mb-4">
+        <button
+          onClick={() => setShowScopeInfo(!showScopeInfo)}
+          className="flex items-center gap-2 text-sm text-muted-foreground hover:text-foreground transition-colors"
+        >
+          <Info className="w-4 h-4" />
+          <span>{t('settings.updates.scopeInfoToggle')}</span>
+          {showScopeInfo ? <ChevronUp className="w-3 h-3" /> : <ChevronDown className="w-3 h-3" />}
+        </button>
+        {showScopeInfo && (
+          <div className="mt-3 rounded-lg bg-secondary/50 border border-border p-4 space-y-3 text-sm">
+            <div>
+              <span className="font-medium text-foreground">{t('settings.updates.scopeSystemTitle')}</span>
+              <span className="text-muted-foreground"> — {t('settings.updates.scopeSystemDesc')}</span>
+            </div>
+            <div>
+              <span className="font-medium text-foreground">{t('settings.updates.scopeReloadTitle')}</span>
+              <span className="text-muted-foreground"> — {t('settings.updates.scopeReloadDesc')}</span>
+            </div>
+            <div>
+              <span className="font-medium text-foreground">{t('settings.updates.scopeCardDataTitle')}</span>
+              <span className="text-muted-foreground"> — {t('settings.updates.scopeCardDataDesc')}</span>
+            </div>
+          </div>
+        )}
       </div>
 
       {/* Channel Selector */}

--- a/web/src/locales/en/common.json
+++ b/web/src/locales/en/common.json
@@ -615,7 +615,14 @@
       "prereqGitCleanOk": "Clean",
       "prereqGitCleanFail": "Uncommitted changes",
       "allPrereqsMet": "All prerequisites met — update notifications active",
-      "prereqsMissing": "{{count}} prerequisite(s) not met — some features unavailable"
+      "prereqsMissing": "{{count}} prerequisite(s) not met — some features unavailable",
+      "scopeInfoToggle": "What do these settings control?",
+      "scopeSystemTitle": "System Updates",
+      "scopeSystemDesc": "Updates the entire console application to a new version. Controlled by the Update Channel and Auto-Update settings on this page.",
+      "scopeReloadTitle": "Auto-Reload",
+      "scopeReloadDesc": "When a new build is deployed, your browser automatically detects the change and prompts you to reload. This happens independently of System Updates.",
+      "scopeCardDataTitle": "Card Data",
+      "scopeCardDataDesc": "Individual dashboard cards refresh their data on their own schedules. Card refreshes are not controlled by System Updates."
     },
     "theme": {
       "title": "Appearance",


### PR DESCRIPTION
## Summary
- Adds a collapsible "What do these settings control?" info section at the top of the System Updates settings page
- Explains three distinct update scopes that users may encounter:
  - **System Updates** — updates the entire console to a new version (controlled by Update Channel / Auto-Update)
  - **Auto-Reload** — browser reloads when a new build is deployed (chunk hash mismatch detection)
  - **Card Data** — individual card data refreshes on their own schedules, independent of System Updates
- Adds translation keys under `settings.updates.scope*` for i18n support

Closes #5345

## Test plan
- [ ] Navigate to Settings > System Updates
- [ ] Verify "What do these settings control?" toggle appears below the header
- [ ] Click the toggle — three scope descriptions should expand
- [ ] Click again — descriptions should collapse
- [ ] Verify styling is consistent with the rest of the settings page