### PR TITLE
fix: remove confusing checkmarks from demo blueprint

### DIFF
--- a/web/src/components/mission-control/demoState.ts
+++ b/web/src/components/mission-control/demoState.ts
@@ -129,25 +129,8 @@ const DEMO_PHASES: DeployPhase[] = [
   },
 ]
 
-const DEMO_LAUNCH_PROGRESS: PhaseProgress[] = [
-  {
-    phase: 1,
-    status: 'completed',
-    projects: [
-      { name: 'cert-manager', missionId: 'demo-mc-certmgr', status: 'completed' },
-      { name: 'prometheus', missionId: 'demo-mc-prom', status: 'completed' },
-    ],
-  },
-  {
-    phase: 2,
-    status: 'completed',
-    projects: [
-      { name: 'falco', missionId: 'demo-mc-falco', status: 'completed' },
-      { name: 'kyverno', missionId: 'demo-mc-kyverno', status: 'completed' },
-      { name: 'grafana', missionId: 'demo-mc-grafana', status: 'completed' },
-    ],
-  },
-]
+/** Blueprint phase = pre-deploy, so launch progress is empty (no checkmarks) */
+const DEMO_LAUNCH_PROGRESS: PhaseProgress[] = []
 
 /**
  * Returns a pre-populated MissionControlState for demo mode.


### PR DESCRIPTION
## Summary
Blueprint phase is pre-deploy — project nodes shouldn't show completed checkmarks. Cleared `launchProgress` so nodes render as pending (dashed ring, no checkmark).

## Test plan
- [ ] Blueprint project nodes show dashed rings (pending) instead of checkmarks
- [ ] "Deploy to Clusters" button is visible and actionable