### PR TITLE
fix: restore working project icons (remove crossOrigin)

### DIFF
--- a/web/src/components/mission-control/svg/ProjectNode.tsx
+++ b/web/src/components/mission-control/svg/ProjectNode.tsx
@@ -188,43 +188,49 @@ export function ProjectNode({
         cursor="pointer"
       />
 
-      {/* Project icon — GitHub avatar via foreignObject, letter fallback on error */}
+      {/* Project icon via foreignObject — GitHub avatar or fallback letter */}
       <foreignObject
         x={cx - iconSize / 2}
         y={cy - iconSize / 2}
         width={iconSize}
         height={iconSize}
-        style={{ pointerEvents: 'none', overflow: 'hidden' }}
       >
-        {!imgFailed ? (
-          <img
-            src={getAvatarUrl(name)}
-            alt={displayName}
-            crossOrigin="anonymous"
-            style={{
-              width: iconSize,
-              height: iconSize,
-              borderRadius: '50%',
-              objectFit: 'cover',
-              display: 'block',
-            }}
-            onError={() => setImgFailed(true)}
-          />
-        ) : (
-          <div style={{
+        <div
+          style={{
             width: iconSize,
             height: iconSize,
             display: 'flex',
             alignItems: 'center',
             justifyContent: 'center',
-            color: primaryColor,
-            fontSize: radius * 0.9,
-            fontWeight: 700,
-            fontFamily: 'system-ui, sans-serif',
-          }}>
-            {name.charAt(0).toUpperCase()}
-          </div>
-        )}
+            borderRadius: '50%',
+            overflow: 'hidden',
+            cursor: 'pointer',
+          }}
+        >
+          {!imgFailed ? (
+            <img
+              src={getAvatarUrl(name)}
+              alt={displayName}
+              style={{
+                width: iconSize,
+                height: iconSize,
+                borderRadius: '50%',
+                objectFit: 'cover',
+              }}
+              onError={() => setImgFailed(true)}
+            />
+          ) : (
+            <span style={{
+              color: primaryColor,
+              fontSize: radius * 0.8,
+              fontWeight: 700,
+              fontFamily: 'system-ui, sans-serif',
+              cursor: 'pointer',
+            }}>
+              {name.charAt(0).toUpperCase()}
+            </span>
+          )}
+        </div>
       </foreignObject>
 
 


### PR DESCRIPTION
## Summary
The `crossOrigin="anonymous"` attribute I added broke GitHub avatar loading. The `github.com/{org}.png` URL does a 302 redirect to `avatars.githubusercontent.com` which doesn't include CORS headers — adding `crossOrigin` forces the browser to require them.

Restored the exact original `foreignObject` structure from commit `0601439c` (the version that was working 2 weeks ago). No `crossOrigin`, wrapping `<div>` with overflow hidden, `<img>` with `onError` fallback to letter initial.

## Test plan
- [ ] Blueprint shows GitHub project logos (Prometheus, Grafana, Falco, Kyverno, cert-manager)
- [ ] If avatar fails → colored letter fallback