### PR TITLE
feat: show existing installs mixed with new deploys in demo blueprint

### DIFF
--- a/web/src/components/mission-control/useMissionControl.ts
+++ b/web/src/components/mission-control/useMissionControl.ts
@@ -608,6 +608,22 @@ Order phases by dependency — prerequisites first. Each phase completes before 
         }
       }
     }
+    // In demo mode, seed some projects as already installed to show the
+    // mixed installed/new-deploy visual in the Flight Plan blueprint
+    if (isDemoMode() && installed.size === 0 && state.projects.length > 0) {
+      // Prometheus and cert-manager are "already installed" on the first cluster
+      for (const name of ['prometheus', 'cert-manager']) {
+        if (state.projects.some(p => p.name === name)) {
+          installed.add(name)
+          const firstCluster = state.assignments[0]?.clusterName
+          if (firstCluster) {
+            if (!perCluster.has(name)) perCluster.set(name, new Set())
+            perCluster.get(name)!.add(firstCluster)
+          }
+        }
+      }
+    }
+
     return { installedProjects: installed, installedOnCluster: perCluster }
   }, [helmReleases, clusters, state.projects])
 


### PR DESCRIPTION
## Summary
The demo Flight Plan blueprint now shows a mix of already-installed and new-deploy projects:

- **Prometheus** and **cert-manager** — solid green rings (already installed on EKS)
- **Grafana**, **Falco**, **Kyverno** — dashed rings (new deployments)

This demonstrates how Mission Control visually distinguishes what's already running vs what needs to be deployed — a key feature visitors can't see without real cluster data.

## Test plan
- [ ] console.kubestellar.io → Mission Control → Prometheus + cert-manager show solid green rings
- [ ] Grafana, Falco, Kyverno show dashed rings (pending deploy)
- [ ] Local install → installed detection uses real helm/namespace data (no demo override)