### PR TITLE
fix: proxy GitHub avatars for project icons in Flight Plan

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -31,6 +31,21 @@
   VITE_DEMO_MODE = "true"
   NODE_VERSION = "20"
 
+# GitHub avatar proxy — avatars.githubusercontent.com is blocked by browser
+# when loaded inside SVG foreignObject. Proxy through our domain to avoid CORS.
+[[redirects]]
+  from = "/api/avatar/:id"
+  to = "https://avatars.githubusercontent.com/u/:id?s=40&v=4"
+  status = 200
+  force = true
+
+# CNCF artwork proxy — official project icons from the cncf/artwork repo
+[[redirects]]
+  from = "/api/cncf-icon/:project"
+  to = "https://raw.githubusercontent.com/cncf/artwork/master/projects/:project/icon/color/:project-icon-color.png"
+  status = 200
+  force = true
+
 # Nightly E2E status API — proxy to Netlify Function
 # Serves live GitHub Actions data (GITHUB_TOKEN set in Netlify dashboard)
 [[redirects]]

--- a/web/src/components/mission-control/svg/ProjectNode.tsx
+++ b/web/src/components/mission-control/svg/ProjectNode.tsx
@@ -23,15 +23,15 @@ const PROJECT_AVATAR_IDS: Record<string, number> = {
   rook: 22860722, longhorn: 51335366,
 }
 
-/** Icon size for avatar display */
-const AVATAR_SIZE = 40
-
+/**
+ * Get project icon URL via first-party proxy to avoid CORS/CSP issues
+ * with avatars.githubusercontent.com inside SVG foreignObject.
+ */
 function getAvatarUrl(name: string): string {
   const key = name.toLowerCase()
   const id = PROJECT_AVATAR_IDS[key]
-  if (id) return `https://avatars.githubusercontent.com/u/${id}?s=${AVATAR_SIZE}&v=4`
-  // Fallback: try github.com redirect (works for orgs not in the map)
-  return `https://avatars.githubusercontent.com/${key}?s=${AVATAR_SIZE}&v=4`
+  if (id) return `/api/avatar/${id}`
+  return `/api/avatar/${key}`
 }
 
 type NodeStatus = 'pending' | 'running' | 'completed' | 'failed'


### PR DESCRIPTION
## Summary
`avatars.githubusercontent.com` images are blocked inside SVG `foreignObject` on console.kubestellar.io (CORS/CSP). Added Netlify redirect proxies:

- `/api/avatar/:id` → `avatars.githubusercontent.com/u/:id?s=40` (GitHub org avatars)
- `/api/cncf-icon/:project` → CNCF artwork repo (official project icons)

Project icons now load from the console's own domain, bypassing cross-origin restrictions.

## Test plan
- [ ] Deploy to Netlify
- [ ] CDP: verify `foreignObject img` elements have `naturalWidth > 1`
- [ ] Blueprint shows project logos (Prometheus, Grafana, Falco, etc.)