### PR TITLE
fix: resolve nightly consistency-test failures

### DIFF
--- a/web/src/components/cards/llmd/PDDisaggregation.tsx
+++ b/web/src/components/cards/llmd/PDDisaggregation.tsx
@@ -266,8 +266,8 @@ export function PDDisaggregation() {
   const prefillIds = useMemo(() => servers.filter(s => s.type === 'prefill').map(s => s.id), [servers])
   const decodeIds = useMemo(() => servers.filter(s => s.type === 'decode').map(s => s.id), [servers])
   // Stable key for deps — only re-run effect when the actual IDs change
-  const prefillKey = prefillIds.join(',')
-  const decodeKey = decodeIds.join(',')
+  const prefillKey = (prefillIds || []).join(',')
+  const decodeKey = (decodeIds || []).join(',')
 
   // Generate transfer packets (only when disaggregated)
   useEffect(() => {

--- a/web/src/hooks/mcp/shared.ts
+++ b/web/src/hooks/mcp/shared.ts
@@ -50,7 +50,9 @@ export function agentFetch(input: RequestInfo | URL, init?: RequestInit): Promis
   if (token && !headers.has('Authorization')) {
     headers.set('Authorization', `Bearer ${token}`)
   }
-  return fetch(input, { ...init, headers })
+  // Use caller-provided signal, or fall back to a default timeout
+  const signal = init?.signal ?? AbortSignal.timeout(MCP_HOOK_TIMEOUT_MS)
+  return fetch(input, { ...init, headers, signal })
 }
 
 // ============================================================================


### PR DESCRIPTION
## Summary
- Guard `.join()` calls on `prefillIds`/`decodeIds` in `PDDisaggregation.tsx` with `|| []` fallback to satisfy Phase 3 (unguarded join) check
- Add `AbortSignal.timeout(MCP_HOOK_TIMEOUT_MS)` default to `agentFetch()` in `hooks/mcp/shared.ts` to satisfy Phase 5 (fetch without timeout/signal) check

The nightly test suite has been failing since Apr 3 with 3 test failures:
1. **consistency-test** -- Phase 3 (unguarded `.join()`) and Phase 5 (fetch without timeout/signal) -- **fixed in this PR**
2. **unit-test** -- raw hex color ratchet count exceeded (272 vs 273) -- already fixed in #4952
3. **gosec-test** -- missing `#nosec G402` annotation on `InsecureSkipVerify` -- already fixed in #4931

Fixes 2 and 3 merged after the Apr 6 nightly ran (06:39 UTC), so they were not picked up. This PR fixes the remaining consistency violations. All three tests should pass on the next nightly run.

## Test plan
- [x] `bash scripts/consistency-test.sh` passes locally (0 errors, 16 warnings)
- [x] `bash scripts/gosec-test.sh` passes locally (0 HIGH findings)
- [x] `npx vitest run src/test/ui-ux-standards.test.ts` passes locally (ratchet at 273)
- [x] `go build ./...` passes
- [x] `npm run build` passes
- [x] TypeScript compilation (`tsc --noEmit`) passes