### PR TITLE
fix: reduce dependency edge thickness in Flight Plan

### DIFF
--- a/web/src/components/mission-control/svg/DependencyPath.tsx
+++ b/web/src/components/mission-control/svg/DependencyPath.tsx
@@ -92,8 +92,8 @@ export function DependencyPath({
         d={pathD}
         fill="none"
         stroke={gradientRef}
-        strokeWidth={highlight ? 2 : crossCluster ? 1.2 : 0.6}
-        strokeOpacity={highlight ? 1 : crossCluster ? 0.8 : 0.5}
+        strokeWidth={highlight ? 1.5 : crossCluster ? 0.6 : 0.3}
+        strokeOpacity={highlight ? 1 : crossCluster ? 0.6 : 0.4}
         filter={highlight ? 'url(#glow)' : undefined}
         strokeDasharray={crossCluster ? 'none' : '3 2'}
         initial={{ pathLength: 0 }}
@@ -103,7 +103,7 @@ export function DependencyPath({
 
       {/* Flowing particle */}
       {showParticle && (
-        <circle r={crossCluster ? 2 : 1.2} fill={particleColor} opacity={0.8}>
+        <circle r={crossCluster ? 1.5 : 1} fill={particleColor} opacity={0.7}>
           <animateMotion
             dur={`${3 + index * 0.5}s`}
             repeatCount="indefinite"


### PR DESCRIPTION
Reduces cross-cluster edges from 1.2→0.6px and intra-cluster from 0.6→0.3px. Particles reduced from 2→1.5 (cross) and 1.2→1 (intra).