### PR TITLE
fix: reduce cluster name font size in blueprint

### DIFF
--- a/web/src/components/mission-control/svg/ClusterZone.tsx
+++ b/web/src/components/mission-control/svg/ClusterZone.tsx
@@ -234,7 +234,7 @@ export function ClusterZone({
         y={y + 17}
         textAnchor="start"
         fill="white"
-        fontSize={11}
+        fontSize={8}
         fontWeight="600"
         fontFamily="system-ui, sans-serif"
         opacity={0.9}


### PR DESCRIPTION
Cluster names (eks-prod-us-east-1, etc.) were too large. Reduced from 11px to 8px.