### PR TITLE
feat: demo AI reasoning + Kubara catalog on console.kubestellar.io

### DIFF
--- a/web/src/components/mission-control/demoState.ts
+++ b/web/src/components/mission-control/demoState.ts
@@ -152,5 +152,6 @@ export function getDemoMissionControlState(): Partial<MissionControlState> {
     targetClusters: [],
     aiStreaming: false,
     groundControlDashboardId: undefined,
+    planningMissionId: 'demo-planning-mission',
   }
 }

--- a/web/src/mocks/demoMissions.ts
+++ b/web/src/mocks/demoMissions.ts
@@ -123,6 +123,58 @@ export const DEMO_MISSIONS: DemoMission[] = [
     ],
   },
 
+  // ── Planning Mission (hidden AI conversation for Mission Control) ──
+  {
+    id: 'demo-planning-mission',
+    title: 'Mission Control Planning',
+    description: 'AI-assisted deployment planning',
+    type: 'custom' as const,
+    status: 'completed' as const,
+    createdAt: hoursAgo(13),
+    updatedAt: hoursAgo(12),
+    messages: [
+      {
+        id: 'plan-user-1',
+        role: 'user' as const,
+        content: 'Deploy comprehensive security monitoring and observability across production clusters with automated certificate management.',
+        timestamp: hoursAgo(13),
+      },
+      {
+        id: 'plan-ai-1',
+        role: 'assistant' as const,
+        content: `Based on your requirements, I recommend a layered security and observability stack using 5 CNCF graduated projects:
+
+**Observability Layer**
+- **Prometheus** (required) — Industry-standard metrics collection with multi-dimensional data model and built-in alerting. Foundation for all observability.
+- **Grafana** (recommended) — Rich visualization and dashboarding platform. Depends on Prometheus for metrics data.
+
+**Security Layer**
+- **Falco** (required) — Runtime threat detection engine monitoring syscalls for container escapes, privilege escalation, and anomalous behavior. Sends alerts to Prometheus.
+- **Kyverno** (recommended) — Kubernetes-native policy engine. Enforces security policies as CRDs — image signing, resource limits, network restrictions. Depends on cert-manager for webhook TLS.
+
+**Infrastructure Layer**
+- **cert-manager** (required) — Automated TLS certificate lifecycle management. Required by Kyverno for secure webhook communication.
+
+**Deployment Strategy**: 2 phases
+1. Core Infrastructure: cert-manager + Prometheus (no dependencies)
+2. Security & Observability: Falco + Kyverno + Grafana (depend on Phase 1)
+
+\`\`\`json
+{
+  "projects": [
+    {"name":"prometheus","displayName":"Prometheus","reason":"Metrics collection and alerting — foundation for cluster observability.","category":"Observability","priority":"required","dependencies":[],"maturity":"graduated","difficulty":"beginner","githubOrg":"prometheus"},
+    {"name":"grafana","displayName":"Grafana","reason":"Visualization dashboards for Prometheus metrics.","category":"Observability","priority":"recommended","dependencies":["prometheus"],"maturity":"graduated","difficulty":"beginner","githubOrg":"grafana"},
+    {"name":"falco","displayName":"Falco Runtime Security","reason":"Runtime threat detection — monitors syscalls for malicious activity.","category":"Security","priority":"required","dependencies":["prometheus"],"maturity":"graduated","difficulty":"intermediate","githubOrg":"falcosecurity"},
+    {"name":"kyverno","displayName":"Kyverno","reason":"Policy engine — enforce security policies as Kubernetes resources.","category":"Security","priority":"recommended","dependencies":["cert-manager"],"maturity":"graduated","difficulty":"intermediate","githubOrg":"kyverno"},
+    {"name":"cert-manager","displayName":"cert-manager","reason":"TLS certificate lifecycle management — auto-renew certificates.","category":"Security","priority":"required","dependencies":[],"maturity":"graduated","difficulty":"beginner","githubOrg":"cert-manager"}
+  ]
+}
+\`\`\``,
+        timestamp: hoursAgo(12),
+      },
+    ],
+  },
+
   // ── Orbit Missions ────────────────────────────────────────────────
   {
     id: 'demo-orbit-prometheus-health',

--- a/web/src/mocks/handlers.ts
+++ b/web/src/mocks/handlers.ts
@@ -670,6 +670,20 @@ export const handlers = [
   http.get('/api/missions/file', () => passthrough()),
   http.get('/api/missions/browse', () => passthrough()),
 
+  // ── Kubara Platform Catalog (demo) ──────────────────────────────
+  http.get('/api/github/repos/kubara-io/kubara/contents/*', () => {
+    return HttpResponse.json([
+      { name: 'prometheus-stack', path: 'helm/prometheus-stack', type: 'directory', description: 'Production Prometheus + Grafana + Alertmanager' },
+      { name: 'cert-manager', path: 'helm/cert-manager', type: 'directory', description: 'Automated TLS certificate management' },
+      { name: 'falco-runtime-security', path: 'helm/falco-runtime-security', type: 'directory', description: 'Runtime threat detection and response' },
+      { name: 'kyverno-policies', path: 'helm/kyverno-policies', type: 'directory', description: 'Kubernetes policy engine for security' },
+      { name: 'argocd-gitops', path: 'helm/argocd-gitops', type: 'directory', description: 'Declarative GitOps continuous delivery' },
+      { name: 'istio-service-mesh', path: 'helm/istio-service-mesh', type: 'directory', description: 'Service mesh for traffic management and security' },
+      { name: 'velero-backups', path: 'helm/velero-backups', type: 'directory', description: 'Cluster backup and disaster recovery' },
+      { name: 'external-secrets', path: 'helm/external-secrets', type: 'directory', description: 'Sync secrets from external providers' },
+    ])
+  }),
+
   // ── Catch-all for unmocked API routes ────────────────────────────
   // On Netlify, unhandled /api/* and /health requests fall through to the SPA
   // catch-all which returns index.html (200 OK, text/html). Code calling


### PR DESCRIPTION
## Summary
Two demo mode improvements for console.kubestellar.io:

### AI Response on Define Mission
- Planning mission with full AI reasoning: explains why each project was recommended
- ExecutiveAnalysis panel renders markdown explanation on the Define Mission page
- Shows layered architecture: Observability → Security → Infrastructure
- `planningMissionId` linked in demo state

### Kubara Platform Catalog
- MSW handler returns 8 demo entries instead of "Empty"
- prometheus-stack, cert-manager, falco, kyverno, argocd, istio, velero, external-secrets

## Test plan
- [ ] MC Define Mission → AI analysis panel shows project reasoning
- [ ] MC Define Mission → right sidebar shows project details
- [ ] Mission Browser → Kubara Platform Catalog → 8 entries visible