### PR TITLE
fix: prevent AI streaming UI state desync during mid-stream JSON extraction

### DIFF
--- a/web/src/components/mission-control/useMissionControl.ts
+++ b/web/src/components/mission-control/useMissionControl.ts
@@ -191,8 +191,7 @@ export function useMissionControl() {
         lastParsedContentRef.current = latest.content
         setState((prev) => ({
           ...prev,
-          projects: mergeProjects(prev.projects, normalized),
-          aiStreaming: false }))
+          projects: mergeProjects(prev.projects, normalized) }))
       }
     } else if (state.phase === 'assign') {
       const parsed = extractJSON<{
@@ -211,8 +210,7 @@ export function useMissionControl() {
           return {
             ...prev,
             assignments: [...aiAssignments, ...preserved],
-            phases: parsed.phases ?? prev.phases,
-            aiStreaming: false }
+            phases: parsed.phases ?? prev.phases }
         })
       }
     }
@@ -225,7 +223,7 @@ export function useMissionControl() {
     if (isStreaming !== state.aiStreaming) {
       setState((prev) => ({ ...prev, aiStreaming: isStreaming }))
     }
-  }, [planningMission?.status])
+  }, [planningMission?.status, state.aiStreaming])
 
   // ---------------------------------------------------------------------------
   // Reconcile assignments when projects change (cascade Phase 1 → 2 → 3)


### PR DESCRIPTION
## Summary
- Stop setting `aiStreaming: false` when extracting JSON blocks mid-stream in Phase 1 (define) and Phase 2 (assign). The streaming indicator should only be toggled by the mission status watcher (`planningMission.status === 'running'`), not by the JSON parser.
- Add `state.aiStreaming` to the mission status `useEffect` dependency array to fix a stale closure that prevented the status watcher from correctly re-syncing the streaming state after the JSON parser prematurely set it to false.

## Problem
During Phase 1 definition, when the hook found a valid `projects` JSON block in the AI stream, it set `aiStreaming: false` even though the LLM was still sending data. This caused the streaming indicator to disappear while text was still arriving. A secondary `useEffect` intended to watch `planningMission.status` failed to correct this because it was missing `state.aiStreaming` in its dependency array, causing a stale closure.

## Test plan
- [ ] Start an AI "Define Solution" query in Mission Control
- [ ] Verify the streaming indicator stays active after JSON block is parsed
- [ ] Verify the streaming indicator disappears only when the stream completes
- [ ] Verify the same behavior during Phase 2 cluster assignment streaming

Closes #5393