### PR TITLE
fix: resolve 5 cache and SSE behavior issues

### DIFF
--- a/web/src/lib/__tests__/api.test.ts
+++ b/web/src/lib/__tests__/api.test.ts
@@ -247,6 +247,13 @@ describe('api.ts', () => {
       const result = await checkOAuthConfigured()
       expect(result).toEqual({ backendUp: false, oauthConfigured: false })
     })
+
+    it('treats degraded backend as up so demo mode is not triggered (#5401)', async () => {
+      vi.mocked(fetch).mockResolvedValue(makeResponse({ status: 'degraded', oauth_configured: true }))
+      const { checkOAuthConfigured } = await importFresh()
+      const result = await checkOAuthConfigured()
+      expect(result).toEqual({ backendUp: true, oauthConfigured: true })
+    })
   })
 
   // ── isBackendUnavailable ───────────────────────────────────────────────

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -215,7 +215,10 @@ export async function checkOAuthConfigured(): Promise<{ backendUp: boolean; oaut
     const data = await response.json().catch(() => null)
     if (!data) return { backendUp: false, oauthConfigured: false }
     return {
-      backendUp: data.status === 'ok',
+      // Any successful /health response means the backend is reachable.
+      // A "degraded" status (e.g. all clusters unreachable) should NOT
+      // flip the app into demo mode — only a network failure should (#5401).
+      backendUp: true,
       oauthConfigured: !!data.oauth_configured,
     }
   } catch {

--- a/web/src/lib/cache/index.ts
+++ b/web/src/lib/cache/index.ts
@@ -1100,6 +1100,19 @@ export function useCache<T>({
   // liveInDemoMode bypasses the demo check for cards backed by serverless functions
   const effectiveEnabled = enabled && (!demoMode || liveInDemoMode)
 
+  // Track mount state to distinguish initial mount from mode-switch re-fires.
+  // On initial mount / page navigation: fetch immediately (needed for data).
+  // On mode transition (enabled false→true after mount): skip immediate refetch,
+  // let triggerAllRefetches() handle it after the 500ms skeleton timer.
+  const hasMountedRef = useRef(false)
+  const prevEnabledRef = useRef(effectiveEnabled)
+  const initialFetchDoneRef = useRef(false)
+
+  // Track the auto-refresh timer in a ref to avoid thrashing (#5252).
+  // Without this, changing consecutiveFailures recreates the interval on every
+  // render, defeating the exponential backoff.
+  const autoRefreshTimerRef = useRef<ReturnType<typeof setInterval> | null>(null)
+
   // Get or create cache store.
   // Track the key so we can reset the ref when the cache key changes
   // (e.g., switching clusters). Without this, storeRef points to stale data (#5259).
@@ -1107,6 +1120,15 @@ export function useCache<T>({
   const storeKeyRef = useRef(key)
 
   if (!storeRef.current || storeKeyRef.current !== key) {
+    // Key changed — clear the old auto-refresh timer so it doesn't keep
+    // polling the previous key (#5399), and reset the initial-fetch guard
+    // so the new key triggers an immediate fetch (#5400).
+    if (autoRefreshTimerRef.current) {
+      clearInterval(autoRefreshTimerRef.current)
+      autoRefreshTimerRef.current = null
+    }
+    initialFetchDoneRef.current = false
+
     storeKeyRef.current = key
     storeRef.current = shared
       ? getOrCreateCache(key, initialData, persist)
@@ -1146,19 +1168,6 @@ export function useCache<T>({
   // Calculate effective interval with failure backoff
   const baseInterval = refreshInterval ?? REFRESH_RATES[category]
   const effectiveInterval = getEffectiveInterval(baseInterval, state.consecutiveFailures)
-
-  // Track mount state to distinguish initial mount from mode-switch re-fires.
-  // On initial mount / page navigation: fetch immediately (needed for data).
-  // On mode transition (enabled false→true after mount): skip immediate refetch,
-  // let triggerAllRefetches() handle it after the 500ms skeleton timer.
-  const hasMountedRef = useRef(false)
-  const prevEnabledRef = useRef(effectiveEnabled)
-  const initialFetchDoneRef = useRef(false)
-
-  // Track the auto-refresh timer in a ref to avoid thrashing (#5252).
-  // Without this, changing consecutiveFailures recreates the interval on every
-  // render, defeating the exponential backoff.
-  const autoRefreshTimerRef = useRef<ReturnType<typeof setInterval> | null>(null)
 
   useEffect(() => {
     if (!effectiveEnabled) {

--- a/web/src/lib/sseClient.ts
+++ b/web/src/lib/sseClient.ts
@@ -147,6 +147,11 @@ export function fetchSSE<T>(options: SSEFetchOptions<T>): Promise<T[]> {
 
   const promise = new Promise<T[]>((resolve, reject) => {
     const accumulated: T[] = []
+    /**
+     * Track items already received per-cluster so that reconnect retries
+     * replace stale data instead of appending duplicates (#5403).
+     */
+    const clusterItemCounts = new Map<string, number>()
     let aborted = false
     /** Whether we received a proper "done" event from the server */
     let receivedDone = false
@@ -173,7 +178,9 @@ export function fetchSSE<T>(options: SSEFetchOptions<T>): Promise<T[]> {
     const timeoutController = new AbortController()
     const timeoutId = setTimeout(() => {
       timeoutController.abort()
-      cleanup()
+      // Timeout with partial data — do NOT cache incomplete results (#5402).
+      // Pass wasAborted=true so the partial accumulation is not stored.
+      cleanup(/* wasAborted */ true)
       resolve(accumulated)
     }, SSE_TIMEOUT_MS)
 
@@ -233,7 +240,24 @@ export function fetchSSE<T>(options: SSEFetchOptions<T>): Promise<T[]> {
                   return rec.cluster ? item : ({ ...item, cluster: clusterName } as T)
                 })
 
+                // Deduplicate: if this cluster was already received (e.g. on a
+                // reconnect retry), remove the previous items before appending
+                // the fresh set so rows are not duplicated (#5403).
+                const prevCount = clusterItemCounts.get(clusterName)
+                if (prevCount !== undefined && prevCount > 0) {
+                  // Remove old items for this cluster from accumulated
+                  let removed = 0
+                  for (let i = accumulated.length - 1; i >= 0 && removed < prevCount; i--) {
+                    const rec = accumulated[i] as Record<string, unknown>
+                    if (rec.cluster === clusterName) {
+                      accumulated.splice(i, 1)
+                      removed++
+                    }
+                  }
+                }
+
                 accumulated.push(...tagged)
+                clusterItemCounts.set(clusterName, tagged.length)
                 onClusterData(clusterName, tagged)
               } catch (e) {
                 console.error('[SSE] Failed to parse cluster_data:', e)
@@ -260,12 +284,16 @@ export function fetchSSE<T>(options: SSEFetchOptions<T>): Promise<T[]> {
                 if (sseBuffer.trim()) {
                   parseSSEChunk(sseBuffer + '\n\n', handleEvent)
                 }
-                if (!receivedDone && accumulated.length > 0) {
+                // Only cache results if we received a proper "done" event.
+                // Without it, the data is incomplete and should not be
+                // served from cache on re-navigation (#5402).
+                const isPartial = !receivedDone
+                if (isPartial && accumulated.length > 0) {
                   console.warn(
-                    `[SSE] Stream ended without "done" event — returning ${accumulated.length} partial items`,
+                    `[SSE] Stream ended without "done" event — returning ${accumulated.length} partial items (not cached)`,
                   )
                 }
-                cleanup()
+                cleanup(/* wasAborted */ isPartial)
                 clearTimeout(timeoutId)
                 resolve(accumulated)
                 return


### PR DESCRIPTION
## Summary

- **#5399** — Clear auto-refresh timer when cache key changes, preventing orphaned timers from polling stale keys
- **#5400** — Reset `initialFetchDoneRef` when cache key changes so new keys trigger an immediate fetch instead of waiting for the next interval
- **#5401** — Treat any successful `/health` HTTP response as backend-up regardless of `status` field value (`"degraded"` no longer flips to demo mode)
- **#5402** — Mark SSE timeout and stream-ended-without-done paths as aborted so partial/incomplete results are not cached in the 10s result cache
- **#5403** — Track per-cluster item counts in SSE accumulator and replace stale entries on reconnect retries to prevent duplicate rows

## Test plan

- [ ] Switch cluster/namespace while a cache-backed card is visible — verify old key stops polling and new key fetches immediately
- [ ] Run backend with unreachable clusters (status: "degraded") — verify app stays in live mode and requires OAuth login
- [ ] Simulate SSE timeout with partial data — verify partial results are not served from cache on re-navigation
- [ ] Force SSE reconnect after partial cluster data — verify no duplicate rows appear

Closes #5399
Closes #5400
Closes #5401
Closes #5402
Closes #5403