### PR TITLE
fix: authorization checks for notifications/GPU endpoints + tooltip detachment

### DIFF
--- a/pkg/api/handlers/gpu.go
+++ b/pkg/api/handlers/gpu.go
@@ -2,6 +2,7 @@ package handlers
 
 import (
 	"fmt"
+	"log/slog"
 	"strings"
 	"time"
 
@@ -101,13 +102,54 @@ func (h *GPUHandler) CreateReservation(c *fiber.Ctx) error {
 	return c.Status(fiber.StatusCreated).JSON(reservation)
 }
 
-// ListReservations lists GPU reservations (optionally filtered to current user)
-func (h *GPUHandler) ListReservations(c *fiber.Ctx) error {
-	mine := c.Query("mine") == "true"
+// getCallerUser looks up the calling user and returns it. Returns nil + error
+// response if the user cannot be resolved.
+func (h *GPUHandler) getCallerUser(c *fiber.Ctx) (*models.User, error) {
+	userID := middleware.GetUserID(c)
+	user, err := h.store.GetUser(userID)
+	if err != nil || user == nil {
+		return nil, fiber.NewError(fiber.StatusForbidden, "Unable to verify user")
+	}
+	return user, nil
+}
 
+// requireOwnerOrAdmin returns a 403 error if the caller is neither the
+// reservation owner nor an admin.
+func requireOwnerOrAdmin(c *fiber.Ctx, user *models.User, reservationOwnerID uuid.UUID) error {
+	if user.ID != reservationOwnerID && user.Role != models.UserRoleAdmin {
+		slog.Warn("[gpu] SECURITY: unauthorized access attempt",
+			"user_id", user.ID,
+			"github_login", user.GitHubLogin,
+			"reservation_owner", reservationOwnerID)
+		return fiber.NewError(fiber.StatusForbidden, "Not authorized — owner or admin access required")
+	}
+	return nil
+}
+
+// ListReservations lists GPU reservations.
+// Non-admin users only see their own reservations. Admins see all (#5414).
+func (h *GPUHandler) ListReservations(c *fiber.Ctx) error {
+	user, err := h.getCallerUser(c)
+	if err != nil {
+		return err
+	}
+
+	// Non-admin users always see only their own reservations
+	if user.Role != models.UserRoleAdmin {
+		reservations, err := h.store.ListUserGPUReservations(user.ID)
+		if err != nil {
+			return fiber.NewError(fiber.StatusInternalServerError, "Failed to list reservations")
+		}
+		if reservations == nil {
+			reservations = []models.GPUReservation{}
+		}
+		return c.JSON(reservations)
+	}
+
+	// Admins: honour ?mine=true filter, otherwise return all
+	mine := c.Query("mine") == "true"
 	if mine {
-		userID := middleware.GetUserID(c)
-		reservations, err := h.store.ListUserGPUReservations(userID)
+		reservations, err := h.store.ListUserGPUReservations(user.ID)
 		if err != nil {
 			return fiber.NewError(fiber.StatusInternalServerError, "Failed to list reservations")
 		}
@@ -127,8 +169,14 @@ func (h *GPUHandler) ListReservations(c *fiber.Ctx) error {
 	return c.JSON(reservations)
 }
 
-// GetReservation gets a single GPU reservation by ID
+// GetReservation gets a single GPU reservation by ID.
+// Only the owner or an admin may read a reservation (#5415).
 func (h *GPUHandler) GetReservation(c *fiber.Ctx) error {
+	user, uerr := h.getCallerUser(c)
+	if uerr != nil {
+		return uerr
+	}
+
 	id, err := uuid.Parse(c.Params("id"))
 	if err != nil {
 		return fiber.NewError(fiber.StatusBadRequest, "Invalid reservation ID")
@@ -142,11 +190,21 @@ func (h *GPUHandler) GetReservation(c *fiber.Ctx) error {
 		return fiber.NewError(fiber.StatusNotFound, "Reservation not found")
 	}
 
+	if authErr := requireOwnerOrAdmin(c, user, reservation.UserID); authErr != nil {
+		return authErr
+	}
+
 	return c.JSON(reservation)
 }
 
-// UpdateReservation updates an existing GPU reservation
+// UpdateReservation updates an existing GPU reservation.
+// Only the owner or an admin may modify a reservation (#5416).
 func (h *GPUHandler) UpdateReservation(c *fiber.Ctx) error {
+	user, uerr := h.getCallerUser(c)
+	if uerr != nil {
+		return uerr
+	}
+
 	id, err := uuid.Parse(c.Params("id"))
 	if err != nil {
 		return fiber.NewError(fiber.StatusBadRequest, "Invalid reservation ID")
@@ -158,6 +216,10 @@ func (h *GPUHandler) UpdateReservation(c *fiber.Ctx) error {
 	}
 	if existing == nil {
 		return fiber.NewError(fiber.StatusNotFound, "Reservation not found")
+	}
+
+	if authErr := requireOwnerOrAdmin(c, user, existing.UserID); authErr != nil {
+		return authErr
 	}
 
 	var input models.UpdateGPUReservationInput
@@ -230,8 +292,14 @@ func (h *GPUHandler) UpdateReservation(c *fiber.Ctx) error {
 	return c.JSON(existing)
 }
 
-// DeleteReservation deletes a GPU reservation
+// DeleteReservation deletes a GPU reservation.
+// Only the owner or an admin may delete a reservation (#5417).
 func (h *GPUHandler) DeleteReservation(c *fiber.Ctx) error {
+	user, uerr := h.getCallerUser(c)
+	if uerr != nil {
+		return uerr
+	}
+
 	id, err := uuid.Parse(c.Params("id"))
 	if err != nil {
 		return fiber.NewError(fiber.StatusBadRequest, "Invalid reservation ID")
@@ -245,6 +313,10 @@ func (h *GPUHandler) DeleteReservation(c *fiber.Ctx) error {
 		return fiber.NewError(fiber.StatusNotFound, "Reservation not found")
 	}
 
+	if authErr := requireOwnerOrAdmin(c, user, existing.UserID); authErr != nil {
+		return authErr
+	}
+
 	if err := h.store.DeleteGPUReservation(id); err != nil {
 		return fiber.NewError(fiber.StatusInternalServerError, "Failed to delete reservation")
 	}
@@ -252,11 +324,30 @@ func (h *GPUHandler) DeleteReservation(c *fiber.Ctx) error {
 	return c.JSON(fiber.Map{"status": "ok"})
 }
 
-// GetReservationUtilization returns utilization snapshots for a single reservation
+// GetReservationUtilization returns utilization snapshots for a single reservation.
+// Only the owner or an admin may read utilization data.
 func (h *GPUHandler) GetReservationUtilization(c *fiber.Ctx) error {
+	user, uerr := h.getCallerUser(c)
+	if uerr != nil {
+		return uerr
+	}
+
 	id := c.Params("id")
-	if _, err := uuid.Parse(id); err != nil {
+	parsedID, err := uuid.Parse(id)
+	if err != nil {
 		return fiber.NewError(fiber.StatusBadRequest, "Invalid reservation ID")
+	}
+
+	// Verify ownership before returning utilization data
+	reservation, err := h.store.GetGPUReservation(parsedID)
+	if err != nil {
+		return fiber.NewError(fiber.StatusInternalServerError, "Failed to get reservation")
+	}
+	if reservation == nil {
+		return fiber.NewError(fiber.StatusNotFound, "Reservation not found")
+	}
+	if authErr := requireOwnerOrAdmin(c, user, reservation.UserID); authErr != nil {
+		return authErr
 	}
 
 	snapshots, err := h.store.GetUtilizationSnapshots(id)
@@ -270,18 +361,36 @@ func (h *GPUHandler) GetReservationUtilization(c *fiber.Ctx) error {
 	return c.JSON(snapshots)
 }
 
-// GetBulkUtilizations returns utilization snapshots for multiple reservations
+// GetBulkUtilizations returns utilization snapshots for multiple reservations.
+// Non-admin users may only request utilization for their own reservations.
 func (h *GPUHandler) GetBulkUtilizations(c *fiber.Ctx) error {
+	user, uerr := h.getCallerUser(c)
+	if uerr != nil {
+		return uerr
+	}
+
 	idsParam := c.Query("ids")
 	if idsParam == "" {
 		return c.JSON(map[string][]models.GPUUtilizationSnapshot{})
 	}
 
 	ids := strings.Split(idsParam, ",")
-	// Validate all IDs
+	// Validate all IDs and check ownership for non-admin users
 	for _, id := range ids {
-		if _, err := uuid.Parse(strings.TrimSpace(id)); err != nil {
+		trimmed := strings.TrimSpace(id)
+		parsedID, err := uuid.Parse(trimmed)
+		if err != nil {
 			return fiber.NewError(fiber.StatusBadRequest, fmt.Sprintf("Invalid reservation ID: %s", id))
+		}
+		// Non-admin: verify each reservation belongs to the caller
+		if user.Role != models.UserRoleAdmin {
+			reservation, err := h.store.GetGPUReservation(parsedID)
+			if err != nil || reservation == nil {
+				return fiber.NewError(fiber.StatusNotFound, fmt.Sprintf("Reservation not found: %s", trimmed))
+			}
+			if reservation.UserID != user.ID {
+				return fiber.NewError(fiber.StatusForbidden, "Not authorized — owner or admin access required")
+			}
 		}
 	}
 

--- a/pkg/api/handlers/notifications.go
+++ b/pkg/api/handlers/notifications.go
@@ -4,6 +4,8 @@ import (
 	"log/slog"
 
 	"github.com/gofiber/fiber/v2"
+	"github.com/kubestellar/console/pkg/api/middleware"
+	"github.com/kubestellar/console/pkg/models"
 	"github.com/kubestellar/console/pkg/notifications"
 	"github.com/kubestellar/console/pkg/store"
 )
@@ -34,9 +36,26 @@ type SendAlertNotificationRequest struct {
 	Channels []notifications.NotificationChannel `json:"channels"`
 }
 
+// requireAdmin checks that the caller has the admin role.
+// Returns a 403 Forbidden response if not, or nil on success.
+func (h *NotificationHandler) requireAdmin(c *fiber.Ctx) error {
+	currentUserID := middleware.GetUserID(c)
+	currentUser, err := h.store.GetUser(currentUserID)
+	if err != nil || currentUser == nil || currentUser.Role != models.UserRoleAdmin {
+		return fiber.NewError(fiber.StatusForbidden, "Console admin access required")
+	}
+	return nil
+}
+
 // TestNotification tests a notification channel configuration
 // POST /api/notifications/test
 func (h *NotificationHandler) TestNotification(c *fiber.Ctx) error {
+	// Only admins may trigger test notifications — they open outbound
+	// connections to Slack/SMTP/PagerDuty/OpsGenie (#5410).
+	if err := h.requireAdmin(c); err != nil {
+		return err
+	}
+
 	var req TestNotificationRequest
 	if err := c.BodyParser(&req); err != nil {
 		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{
@@ -68,6 +87,12 @@ func (h *NotificationHandler) TestNotification(c *fiber.Ctx) error {
 // SendAlertNotification sends an alert notification to configured channels
 // POST /api/notifications/send
 func (h *NotificationHandler) SendAlertNotification(c *fiber.Ctx) error {
+	// Only admins may send real alert notifications — they trigger outbound
+	// messages to Slack/email/PagerDuty channels (#5413).
+	if err := h.requireAdmin(c); err != nil {
+		return err
+	}
+
 	var req SendAlertNotificationRequest
 	if err := c.BodyParser(&req); err != nil {
 		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{

--- a/web/src/components/onboarding/Tour.tsx
+++ b/web/src/components/onboarding/Tour.tsx
@@ -281,14 +281,17 @@ export function TourOverlay() {
       }
     }, 100))
 
-    // Reposition on window resize
-    const handleResize = () => positionTooltip()
-    window.addEventListener('resize', handleResize)
+    // Reposition on window resize and scroll so the tooltip stays
+    // anchored to its target element (#5411).
+    const handleReposition = () => positionTooltip()
+    window.addEventListener('resize', handleReposition)
+    window.addEventListener('scroll', handleReposition, true) // capture phase catches nested scrollable containers
 
     return () => {
       isCancelled = true
       timeoutIds.forEach(id => clearTimeout(id))
-      window.removeEventListener('resize', handleResize)
+      window.removeEventListener('resize', handleReposition)
+      window.removeEventListener('scroll', handleReposition, true)
     }
   }, [isActive, currentStep, currentStepIndex])
 


### PR DESCRIPTION
## Summary

- **#5410, #5413 (Notification endpoints):** Add admin role check to `POST /api/notifications/test` and `POST /api/notifications/send`. Previously any authenticated user could trigger outbound connections to Slack/SMTP/PagerDuty/OpsGenie.
- **#5414 (GPU list):** Non-admin users now only see their own reservations. Admins retain the `?mine=true` filter and full listing.
- **#5415 (GPU get by ID):** Ownership or admin check before returning reservation data.
- **#5416 (GPU update):** Ownership or admin check before allowing modifications.
- **#5417 (GPU delete):** Ownership or admin check before allowing deletion.
- **#5411 (Tooltip detachment):** Add `scroll` event listener (capture phase) alongside the existing `resize` listener so the tour tooltip recalculates position when the page or any nested container scrolls.

Utilization endpoints (`GetReservationUtilization`, `GetBulkUtilizations`) also received the same ownership checks for defense in depth.

Fixes #5410, fixes #5411, fixes #5413, fixes #5414, fixes #5415, fixes #5416, fixes #5417

## Test plan

- [ ] As a non-admin user, `POST /api/notifications/test` returns 403
- [ ] As a non-admin user, `POST /api/notifications/send` returns 403
- [ ] As admin, both notification endpoints still work
- [ ] As a non-admin user, `GET /api/gpu/reservations` returns only own reservations
- [ ] As a non-admin user, `GET /api/gpu/reservations/:id` for another user's reservation returns 403
- [ ] As a non-admin user, `PUT /api/gpu/reservations/:id` for another user's reservation returns 403
- [ ] As a non-admin user, `DELETE /api/gpu/reservations/:id` for another user's reservation returns 403
- [ ] As admin, all GPU endpoints work for any reservation
- [ ] Start tour, scroll page — tooltip stays anchored to target element
- [ ] `go build ./...` passes
- [ ] `npm run build` passes