### PR TITLE
fix: add missing mocks for auth test dependencies (#5418)

### DIFF
--- a/web/src/lib/__tests__/auth-expand.test.ts
+++ b/web/src/lib/__tests__/auth-expand.test.ts
@@ -54,6 +54,26 @@ vi.mock('../analytics', () => ({
 
 vi.mock('../demoMode', () => ({
   setDemoMode: vi.fn(),
+  isDemoMode: vi.fn().mockReturnValue(false),
+  isNetlifyDeployment: false,
+  isDemoToken: vi.fn().mockReturnValue(false),
+  subscribeDemoMode: vi.fn(),
+}))
+
+vi.mock('../../hooks/usePermissions', () => ({
+  clearPermissionsCache: vi.fn(),
+}))
+
+vi.mock('../../hooks/useActiveUsers', () => ({
+  disconnectPresence: vi.fn(),
+}))
+
+vi.mock('../sseClient', () => ({
+  clearSSECache: vi.fn(),
+}))
+
+vi.mock('../../hooks/mcp/shared', () => ({
+  clearClusterCacheOnLogout: vi.fn(),
 }))
 
 // ---------------------------------------------------------------------------

--- a/web/src/lib/__tests__/auth.test.ts
+++ b/web/src/lib/__tests__/auth.test.ts
@@ -48,6 +48,26 @@ vi.mock('../analytics', () => ({
 vi.mock('../demoMode', () => ({
   setDemoMode: vi.fn(),
   setGlobalDemoMode: vi.fn(),
+  isDemoMode: vi.fn().mockReturnValue(false),
+  isNetlifyDeployment: false,
+  isDemoToken: vi.fn().mockReturnValue(false),
+  subscribeDemoMode: vi.fn(),
+}))
+
+vi.mock('../../hooks/usePermissions', () => ({
+  clearPermissionsCache: vi.fn(),
+}))
+
+vi.mock('../../hooks/useActiveUsers', () => ({
+  disconnectPresence: vi.fn(),
+}))
+
+vi.mock('../sseClient', () => ({
+  clearSSECache: vi.fn(),
+}))
+
+vi.mock('../../hooks/mcp/shared', () => ({
+  clearClusterCacheOnLogout: vi.fn(),
 }))
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Add missing `vi.mock` declarations for 4 modules newly imported by `auth.tsx` in PR #5412: `hooks/mcp/shared` (`clearClusterCacheOnLogout`), `hooks/usePermissions` (`clearPermissionsCache`), `hooks/useActiveUsers` (`disconnectPresence`), and `lib/sseClient` (`clearSSECache`)
- Add missing exports (`isNetlifyDeployment`, `isDemoMode`, `isDemoToken`, `subscribeDemoMode`) to the `demoMode` mock, which `hooks/mcp/shared` requires at module load time
- Fixes all 50 test failures from Coverage Suite run #343

Closes #5418

## Test plan
- [x] `npx vitest run src/lib/__tests__/auth-expand.test.ts` -- 35/35 pass (was 14 failures)
- [x] `npx vitest run src/lib/__tests__/auth.test.ts` -- 61/61 pass (was 36 failures)
- [x] Full test suite: 13,865 tests pass, 0 test failures (only OOM worker crashes on large suite)