### PR TITLE
fix: validate GPU capacity server-side, prevent stale cache/settings overwrite

### DIFF
--- a/pkg/api/handlers/gpu.go
+++ b/pkg/api/handlers/gpu.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"context"
 	"fmt"
 	"log/slog"
 	"strings"
@@ -14,14 +15,22 @@ import (
 	"github.com/kubestellar/console/pkg/store"
 )
 
+// ClusterCapacityProvider returns the total GPU capacity for a cluster
+// by querying authoritative server-side data (e.g. k8s node resources).
+// Returns 0 if the cluster has no GPUs or cannot be reached.
+type ClusterCapacityProvider func(ctx context.Context, cluster string) int
+
 // GPUHandler handles GPU reservation CRUD operations
 type GPUHandler struct {
-	store store.Store
+	store           store.Store
+	clusterCapacity ClusterCapacityProvider
 }
 
-// NewGPUHandler creates a new GPU handler
-func NewGPUHandler(s store.Store) *GPUHandler {
-	return &GPUHandler{store: s}
+// NewGPUHandler creates a new GPU handler.
+// capacityProvider supplies server-side cluster GPU capacity; if nil,
+// over-allocation checks are skipped (safe default for tests).
+func NewGPUHandler(s store.Store, capacityProvider ClusterCapacityProvider) *GPUHandler {
+	return &GPUHandler{store: s, clusterCapacity: capacityProvider}
 }
 
 // CreateReservation creates a new GPU reservation
@@ -52,21 +61,10 @@ func (h *GPUHandler) CreateReservation(c *fiber.Ctx) error {
 		return fiber.NewError(fiber.StatusBadRequest, "Start date must be RFC 3339 format (e.g. 2024-01-15T09:00:00Z)")
 	}
 
-	// Check over-allocation: sum of active/pending reservations + this request must not exceed cluster capacity
-	if input.MaxClusterGPUs > 0 {
-		reserved, err := h.store.GetClusterReservedGPUCount(input.Cluster, nil)
-		if err != nil {
-			return fiber.NewError(fiber.StatusInternalServerError, "Failed to check cluster GPU usage")
-		}
-		if reserved+input.GPUCount > input.MaxClusterGPUs {
-			available := input.MaxClusterGPUs - reserved
-			if available < 0 {
-				available = 0
-			}
-			return fiber.NewError(fiber.StatusConflict,
-				fmt.Sprintf("Over-allocation: cluster %q has %d GPUs available (%d reserved of %d total), but %d requested",
-					input.Cluster, available, reserved, input.MaxClusterGPUs, input.GPUCount))
-		}
+	// Check over-allocation using server-side cluster capacity (never trust client input).
+	// The client-supplied MaxClusterGPUs is intentionally ignored.
+	if err := h.checkOverAllocation(c.Context(), input.Cluster, input.GPUCount, nil); err != nil {
+		return err
 	}
 
 	// Get user info for user_name
@@ -268,20 +266,14 @@ func (h *GPUHandler) UpdateReservation(c *fiber.Ctx) error {
 		existing.QuotaEnforced = *input.QuotaEnforced
 	}
 
-	// Check over-allocation on update if GPU count changed and capacity is provided
-	if input.GPUCount != nil && input.MaxClusterGPUs != nil && *input.MaxClusterGPUs > 0 {
-		reserved, err := h.store.GetClusterReservedGPUCount(existing.Cluster, &existing.ID)
-		if err != nil {
-			return fiber.NewError(fiber.StatusInternalServerError, "Failed to check cluster GPU usage")
-		}
-		if reserved+existing.GPUCount > *input.MaxClusterGPUs {
-			available := *input.MaxClusterGPUs - reserved
-			if available < 0 {
-				available = 0
-			}
-			return fiber.NewError(fiber.StatusConflict,
-				fmt.Sprintf("Over-allocation: cluster %q has %d GPUs available (%d reserved of %d total), but %d requested",
-					existing.Cluster, available, reserved, *input.MaxClusterGPUs, existing.GPUCount))
+	// Re-validate capacity whenever the cluster, GPU count, or status changes —
+	// not just when GPUCount is provided (#5423). Uses server-side capacity (#5421).
+	clusterChanged := input.Cluster != nil
+	countChanged := input.GPUCount != nil
+	statusChanged := input.Status != nil
+	if clusterChanged || countChanged || statusChanged {
+		if err := h.checkOverAllocation(c.Context(), existing.Cluster, existing.GPUCount, &existing.ID); err != nil {
+			return err
 		}
 	}
 
@@ -406,4 +398,39 @@ func (h *GPUHandler) GetBulkUtilizations(c *fiber.Ctx) error {
 	}
 
 	return c.JSON(result)
+}
+
+// checkOverAllocation verifies that the requested GPU count does not exceed the
+// cluster's server-side capacity. excludeID is used on updates to exclude the
+// current reservation from the "already reserved" tally.
+func (h *GPUHandler) checkOverAllocation(ctx context.Context, cluster string, gpuCount int, excludeID *uuid.UUID) error {
+	if h.clusterCapacity == nil {
+		// No capacity provider configured — skip check (e.g. unit tests).
+		return nil
+	}
+
+	capacity := h.clusterCapacity(ctx, cluster)
+	if capacity <= 0 {
+		// Cluster has no GPUs or is unreachable — allow the reservation
+		// (the admin can cancel it later). Blocking here would prevent all
+		// reservations when the cluster is temporarily offline.
+		return nil
+	}
+
+	reserved, err := h.store.GetClusterReservedGPUCount(cluster, excludeID)
+	if err != nil {
+		return fiber.NewError(fiber.StatusInternalServerError, "Failed to check cluster GPU usage")
+	}
+
+	if reserved+gpuCount > capacity {
+		available := capacity - reserved
+		if available < 0 {
+			available = 0
+		}
+		return fiber.NewError(fiber.StatusConflict,
+			fmt.Sprintf("Over-allocation: cluster %q has %d GPUs available (%d reserved of %d total), but %d requested",
+				cluster, available, reserved, capacity, gpuCount))
+	}
+
+	return nil
 }

--- a/pkg/api/handlers/gpu_test.go
+++ b/pkg/api/handlers/gpu_test.go
@@ -2,6 +2,7 @@ package handlers
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"net/http"
 	"testing"
@@ -67,22 +68,29 @@ func (s *gpuTestStore) ListUserGPUReservations(userID uuid.UUID) ([]models.GPURe
 	return s.listMine, nil
 }
 
+// stubCapacity returns a ClusterCapacityProvider that always returns the given value.
+func stubCapacity(gpus int) ClusterCapacityProvider {
+	return func(_ context.Context, _ string) int { return gpus }
+}
+
 func TestGPUCreateReservation_OverAllocationReturnsConflict(t *testing.T) {
 	env := setupTestEnv(t)
+	// Server-side capacity says cluster has 4 GPUs; 3 are already reserved.
+	// Requesting 3 more should exceed capacity (3 + 3 > 4).
+	const clusterCapacity = 4
 	store := &gpuTestStore{
 		user:            &models.User{ID: testAdminUserID, GitHubLogin: "alice"},
 		clusterReserved: 3,
 	}
-	handler := NewGPUHandler(store)
+	handler := NewGPUHandler(store, stubCapacity(clusterCapacity))
 	env.App.Post("/api/gpu/reservations", handler.CreateReservation)
 
 	body, err := json.Marshal(map[string]any{
-		"title":            "Train model",
-		"cluster":          "cluster-a",
-		"namespace":        "ml",
-		"gpu_count":        3,
-		"start_date":       "2026-03-16T00:00:00Z",
-		"max_cluster_gpus": 4,
+		"title":      "Train model",
+		"cluster":    "cluster-a",
+		"namespace":  "ml",
+		"gpu_count":  3,
+		"start_date": "2026-03-16T00:00:00Z",
 	})
 	require.NoError(t, err)
 
@@ -97,20 +105,21 @@ func TestGPUCreateReservation_OverAllocationReturnsConflict(t *testing.T) {
 
 func TestGPUCreateReservation_SetsDefaultDurationAndUserName(t *testing.T) {
 	env := setupTestEnv(t)
+	// 8 GPU capacity, 0 reserved — should succeed
+	const clusterCapacity = 8
 	store := &gpuTestStore{
 		user:            &models.User{ID: testAdminUserID, GitHubLogin: "alice"},
 		clusterReserved: 0,
 	}
-	handler := NewGPUHandler(store)
+	handler := NewGPUHandler(store, stubCapacity(clusterCapacity))
 	env.App.Post("/api/gpu/reservations", handler.CreateReservation)
 
 	body, err := json.Marshal(map[string]any{
-		"title":            "Inference batch",
-		"cluster":          "cluster-a",
-		"namespace":        "ml",
-		"gpu_count":        1,
-		"start_date":       "2026-03-16T00:00:00Z",
-		"max_cluster_gpus": 8,
+		"title":      "Inference batch",
+		"cluster":    "cluster-a",
+		"namespace":  "ml",
+		"gpu_count":  1,
+		"start_date": "2026-03-16T00:00:00Z",
 	})
 	require.NoError(t, err)
 
@@ -129,8 +138,11 @@ func TestGPUCreateReservation_SetsDefaultDurationAndUserName(t *testing.T) {
 
 func TestGPUListReservations_MineNilReturnsEmptyArray(t *testing.T) {
 	env := setupTestEnv(t)
-	store := &gpuTestStore{listMine: nil}
-	handler := NewGPUHandler(store)
+	store := &gpuTestStore{
+		user:     &models.User{ID: testAdminUserID, GitHubLogin: "alice", Role: models.UserRoleAdmin},
+		listMine: nil,
+	}
+	handler := NewGPUHandler(store, nil)
 	env.App.Get("/api/gpu/reservations", handler.ListReservations)
 
 	req, err := http.NewRequest(http.MethodGet, "/api/gpu/reservations?mine=true", nil)

--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -970,8 +970,23 @@ func (s *Server) setupRoutes() {
 	api.Get("/nightly-e2e/runs", nightlyE2E.GetRuns)
 	api.Get("/nightly-e2e/run-logs", nightlyE2E.GetRunLogs)
 
-	// GPU reservation routes
-	gpuHandler := handlers.NewGPUHandler(s.store)
+	// GPU reservation routes — capacity provider uses live k8s node data
+	// so the server never trusts client-supplied GPU limits (#5421).
+	gpuCapacity := handlers.ClusterCapacityProvider(func(ctx context.Context, cluster string) int {
+		if s.k8sClient == nil {
+			return 0
+		}
+		nodes, err := s.k8sClient.GetNodes(ctx, cluster)
+		if err != nil {
+			return 0
+		}
+		total := 0
+		for _, n := range nodes {
+			total += n.GPUCount
+		}
+		return total
+	})
+	gpuHandler := handlers.NewGPUHandler(s.store, gpuCapacity)
 	api.Post("/gpu/reservations", gpuHandler.CreateReservation)
 	api.Get("/gpu/reservations", gpuHandler.ListReservations)
 	api.Get("/gpu/reservations/:id", gpuHandler.GetReservation)

--- a/web/src/components/logs/Logs.tsx
+++ b/web/src/components/logs/Logs.tsx
@@ -119,7 +119,7 @@ export function Logs() {
       isLoading={isLoading}
       isRefreshing={isRefreshing}
       lastUpdated={lastUpdated}
-      hasData={reachableClusters.length > 0}
+      hasData={reachableClusters.length > 0 || filteredEvents.length > 0}
       emptyState={{
         title: 'Logs & Events Dashboard',
         description: 'Add cards to monitor Kubernetes events, application logs, and system messages across your clusters.' }}

--- a/web/src/hooks/mcp/clusters.ts
+++ b/web/src/hooks/mcp/clusters.ts
@@ -288,8 +288,16 @@ export function useClusterHealth(cluster?: string) {
       recordClusterFailure(cluster)
 
       if (shouldMarkOffline(cluster)) {
+        // Prolonged failures — show explicit unreachable state, never demo data (#5424).
         setError('Failed to fetch cluster health')
-        setHealth(getDemoHealth(cluster))
+        setHealth({
+          cluster,
+          healthy: false,
+          reachable: false,
+          nodeCount: 0,
+          readyNodes: 0,
+          podCount: 0,
+          errorMessage: 'Unable to connect — cluster appears offline' })
       } else {
         // Keep previous data on transient error
         if (prevHealthRef.current) {

--- a/web/src/hooks/usePersistedSettings.ts
+++ b/web/src/hooks/usePersistedSettings.ts
@@ -159,16 +159,23 @@ export function usePersistedSettings() {
         const data = await settingsFetch<AllSettings>('/settings')
         if (!mountedRef.current) return
 
-        if (isLocalStorageEmpty() && data) {
+        // Determine whether the backend file has meaningful content
+        const backendHasData = data && (
+          data.theme || data.aiMode || data.feedbackGithubToken ||
+          Object.keys(data.apiKeys || {}).length > 0)
+
+        if (isLocalStorageEmpty() && backendHasData) {
           // Cache was cleared — restore from backend file
-          const hasData = data.theme || data.aiMode || data.feedbackGithubToken ||
-            Object.keys(data.apiKeys || {}).length > 0
-          if (hasData) {
-            restoreToLocalStorage(data)
-            setRestoredFromFile(true)
-          }
+          restoreToLocalStorage(data)
+          setRestoredFromFile(true)
+        } else if (backendHasData) {
+          // Both sides have data — backend is authoritative (#5426).
+          // Merge: backend wins for any key it has, then push the merged
+          // result back so the two stay in sync.
+          restoreToLocalStorage(data)
+          saveToBackend()
         } else {
-          // localStorage has data — sync it to backend (initial sync)
+          // Backend is empty but localStorage has data — seed the backend
           saveToBackend()
         }
         setSyncStatus('saved')

--- a/web/src/lib/cache/index.ts
+++ b/web/src/lib/cache/index.ts
@@ -1257,8 +1257,27 @@ export function useCache<T>({
   // Combined with useLayoutEffect state reports this caused React error #185
   // (Maximum update depth exceeded).  Capturing via ref keeps the identity
   // stable across renders while still picking up the first provided value.
+  //
+  // Update the refs when the caller provides meaningfully different data (#5425).
+  // JSON.stringify comparison is used to detect structural changes without
+  // triggering on every render when the caller creates new-but-equal objects.
   const demoDataRef = useRef(demoData)
   const initialDataRef = useRef(initialData)
+
+  const demoDataJSON = JSON.stringify(demoData)
+  const initialDataJSON = JSON.stringify(initialData)
+  const prevDemoJSON = useRef(demoDataJSON)
+  const prevInitialJSON = useRef(initialDataJSON)
+
+  if (demoDataJSON !== prevDemoJSON.current) {
+    prevDemoJSON.current = demoDataJSON
+    demoDataRef.current = demoData
+  }
+  if (initialDataJSON !== prevInitialJSON.current) {
+    prevInitialJSON.current = initialDataJSON
+    initialDataRef.current = initialData
+  }
+
   const stableDemoData = demoDataRef.current
   const stableInitialData = initialDataRef.current
 


### PR DESCRIPTION
## Summary

Fixes 6 data integrity and cache issues:

- **#5421** — GPU quota enforcement now uses server-side k8s node data via a new `ClusterCapacityProvider` interface instead of trusting client-supplied `maxClusterGPUs`
- **#5423** — GPU update handler re-validates capacity when cluster, count, or status changes (not just when GPUCount is provided)
- **#5424** — Offline cluster health shows explicit unreachable state instead of silently falling back to demo data after prolonged failures
- **#5425** — Cache `demoData`/`initialData` refs now update when the caller provides structurally different values (JSON deep comparison)
- **#5426** — Persisted settings fetch backend state first and treat it as authoritative, merging into localStorage instead of blindly overwriting
- **#5427** — Logs dashboard `hasData` check includes `filteredEvents.length` so cached events display even when all clusters are unreachable

## Test plan

- [x] `go build ./...` passes
- [x] `npm run build` passes
- [x] `go test ./pkg/api/handlers/ -run TestGPU` — all 3 tests pass
- [ ] CI build/lint pass

Closes #5421, closes #5423, closes #5424, closes #5425, closes #5426, closes #5427