### PR TITLE
fix: error counting, RS drilldown, OAuth failure redirect, SSE dedup callbacks

### DIFF
--- a/web/src/components/auth/AuthCallback.tsx
+++ b/web/src/components/auth/AuthCallback.tsx
@@ -81,7 +81,7 @@ export function AuthCallback() {
         showToast(t('authCallback.failedToFetchUser'), 'warning')
         setStatus(t('authCallback.completingSignIn'))
         setTimeout(() => {
-          navigate(destination)
+          navigate(getLoginWithError('token_exchange_failed'))
         }, NAVIGATE_AFTER_ERROR_DELAY_MS)
       })
   }, [searchParams, setToken, refreshUser, navigate, showToast, t])

--- a/web/src/components/cards/EventStream.tsx
+++ b/web/src/components/cards/EventStream.tsx
@@ -94,7 +94,7 @@ function EventStreamInternal() {
     defaultLimit: 5,
   })
 
-  const { drillToEvents, drillToPod, drillToDeployment } = useDrillDownActions()
+  const { drillToEvents, drillToPod, drillToDeployment, drillToReplicaSet } = useDrillDownActions()
 
   const handleEventClick = (event: ClusterEvent) => {
     // Parse object to get resource type and name
@@ -108,7 +108,9 @@ function EventStreamInternal() {
 
     if (resourceType.toLowerCase() === 'pod') {
       drillToPod(cluster, event.namespace, resourceName, { fromEvent: true })
-    } else if (resourceType.toLowerCase() === 'deployment' || resourceType.toLowerCase() === 'replicaset') {
+    } else if (resourceType.toLowerCase() === 'replicaset') {
+      drillToReplicaSet(cluster, event.namespace, resourceName, { fromEvent: true })
+    } else if (resourceType.toLowerCase() === 'deployment') {
       drillToDeployment(cluster, event.namespace, resourceName, { fromEvent: true })
     } else {
       // Generic events view for other resources

--- a/web/src/components/logs/Logs.tsx
+++ b/web/src/components/logs/Logs.tsx
@@ -53,7 +53,8 @@ export function Logs() {
   const currentWarningCount = filteredWarningEvents.length
   const currentNormalCount = filteredEvents.filter(e => e.type === 'Normal').length
   const currentErrorCount = filteredEvents.filter(e =>
-    e.type === 'Warning' && (e.reason?.toLowerCase().includes('error') || e.reason?.toLowerCase().includes('failed'))
+    e.type === 'Error' ||
+    (e.type === 'Warning' && (e.reason?.toLowerCase().includes('error') || e.reason?.toLowerCase().includes('failed')))
   ).length
   const oneHourAgo = new Date(Date.now() - 60 * 60 * 1000)
   const currentRecentCount = filteredEvents.filter(e => {

--- a/web/src/lib/sseClient.ts
+++ b/web/src/lib/sseClient.ts
@@ -45,6 +45,13 @@ const SSE_MAX_RECONNECT_ATTEMPTS = 5
 // Dedup: prevent duplicate concurrent SSE requests to the same URL
 const inflightRequests = new Map<string, Promise<unknown[]>>()
 
+/** Subscribers waiting for callbacks on an in-flight SSE stream */
+interface SSESubscriber<T = unknown> {
+  onClusterData: (clusterName: string, items: T[]) => void
+  onDone?: (summary: Record<string, unknown>) => void
+}
+const inflightSubscribers = new Map<string, SSESubscriber[]>()
+
 // Result cache: serve cached data on re-navigation within 10s
 const resultCache = new Map<string, { data: unknown[]; at: number }>()
 /** Cache TTL: 10 seconds */
@@ -57,6 +64,7 @@ const RESULT_CACHE_TTL_MS = 10_000
 export function clearSSECache(): void {
   resultCache.clear()
   inflightRequests.clear()
+  inflightSubscribers.clear()
 }
 
 /**
@@ -139,11 +147,18 @@ export function fetchSSE<T>(options: SSEFetchOptions<T>): Promise<T[]> {
     return Promise.resolve(items)
   }
 
-  // Dedup: if same URL is already in-flight, return the existing promise
+  // Dedup: if same URL is already in-flight, register as a subscriber and
+  // return the existing promise so all consumers get progressive callbacks.
   const inflight = inflightRequests.get(cacheKey)
   if (inflight) {
+    const subscribers = inflightSubscribers.get(cacheKey) || []
+    subscribers.push({ onClusterData: onClusterData as SSESubscriber['onClusterData'], onDone })
+    inflightSubscribers.set(cacheKey, subscribers)
     return inflight as Promise<T[]>
   }
+
+  // Register the first caller as a subscriber too
+  inflightSubscribers.set(cacheKey, [])
 
   const promise = new Promise<T[]>((resolve, reject) => {
     const accumulated: T[] = []
@@ -160,6 +175,7 @@ export function fetchSSE<T>(options: SSEFetchOptions<T>): Promise<T[]> {
 
     const cleanup = (wasAborted = false) => {
       inflightRequests.delete(cacheKey)
+      inflightSubscribers.delete(cacheKey)
       if (reconnectTimerId !== null) {
         clearTimeout(reconnectTimerId)
         reconnectTimerId = null
@@ -259,6 +275,11 @@ export function fetchSSE<T>(options: SSEFetchOptions<T>): Promise<T[]> {
                 accumulated.push(...tagged)
                 clusterItemCounts.set(clusterName, tagged.length)
                 onClusterData(clusterName, tagged)
+                // Fan out to additional subscribers that joined via dedup
+                const subs = inflightSubscribers.get(cacheKey) || []
+                for (const sub of subs) {
+                  try { sub.onClusterData(clusterName, tagged) } catch { /* subscriber error */ }
+                }
               } catch (e) {
                 console.error('[SSE] Failed to parse cluster_data:', e)
               }
@@ -269,9 +290,15 @@ export function fetchSSE<T>(options: SSEFetchOptions<T>): Promise<T[]> {
               try {
                 const summary = JSON.parse(data) as Record<string, unknown>
                 onDone?.(summary)
+                // Fan out onDone to additional subscribers
+                const doneSubs = inflightSubscribers.get(cacheKey) || []
+                for (const sub of doneSubs) {
+                  try { sub.onDone?.(summary) } catch { /* subscriber error */ }
+                }
               } catch {
                 /* ignore parse errors on summary */
               }
+              inflightSubscribers.delete(cacheKey)
               resolve(accumulated)
             }
           }


### PR DESCRIPTION
## Summary
Fixes four bugs reported in issues #5428, #5429, #5430, #5431:

- **#5428 — Logs error undercount**: Error stat now counts events with `type: "Error"` in addition to the existing heuristic that checks warnings with error/failed reasons. Previously, genuine Error-typed events were missed entirely.
- **#5429 — ReplicaSet drilldown wrong name**: ReplicaSet events now use `drillToReplicaSet()` instead of incorrectly passing the RS name to `drillToDeployment()`, which expected a Deployment name.
- **#5430 — OAuth proceeds after failure**: The catch block in AuthCallback now redirects to the login page with an error param instead of navigating to the protected destination after a token exchange failure.
- **#5431 — SSE dedup drops callbacks**: When multiple hooks share an in-flight SSE stream via dedup, all consumers now receive `onClusterData` and `onDone` callbacks through a subscriber fan-out mechanism.

## Test plan
- [ ] Verify Logs dashboard error count includes events with `type: "Error"` and neutral reasons
- [ ] Click a ReplicaSet event in EventStream and confirm the ReplicaSet drilldown opens (not Deployment)
- [ ] Force `/auth/refresh` to fail (e.g., expired cookie) and confirm redirect to login page
- [ ] Mount two cards that fetch the same SSE URL concurrently; confirm both receive progressive updates

Closes #5428, closes #5429, closes #5430, closes #5431