### PR TITLE
fix: add Skeleton loading state to StackSelector, standardize status color opacities

### DIFF
--- a/web/src/components/cards/HardwareHealthCard.tsx
+++ b/web/src/components/cards/HardwareHealthCard.tsx
@@ -456,8 +456,8 @@ export function HardwareHealthCard() {
         <div className={cn(
           'p-2 rounded-lg border',
           criticalCount > 0
-            ? 'bg-red-500/20 border-red-500/30'
-            : 'bg-green-500/20 border-green-500/30'
+            ? 'bg-red-500/20 border-red-500/20'
+            : 'bg-green-500/20 border-green-500/20'
         )}>
           <div className="text-xl font-bold text-foreground">{criticalCount}</div>
           <div className={cn('text-2xs', criticalCount > 0 ? 'text-red-400' : 'text-green-400')}>
@@ -467,8 +467,8 @@ export function HardwareHealthCard() {
         <div className={cn(
           'p-2 rounded-lg border',
           warningCount > 0
-            ? 'bg-yellow-500/20 border-yellow-500/30'
-            : 'bg-green-500/20 border-green-500/30'
+            ? 'bg-yellow-500/20 border-yellow-500/20'
+            : 'bg-green-500/20 border-green-500/20'
         )}>
           <div className="text-xl font-bold text-foreground">{warningCount}</div>
           <div className={cn('text-2xs', warningCount > 0 ? 'text-yellow-400' : 'text-green-400')}>

--- a/web/src/components/cards/cloudevents_status/CloudEventsStatus.tsx
+++ b/web/src/components/cards/cloudevents_status/CloudEventsStatus.tsx
@@ -8,13 +8,13 @@ import type { CloudEventResourceState } from './demoData'
 
 const STATUS_STYLE: Record<CloudEventResourceState, { badge: string; icon: React.ReactNode }> = {
   ready: {
-    badge: 'bg-green-500/15 text-green-400',
+    badge: 'bg-green-500/20 text-green-400',
     icon: <CheckCircle className="w-3.5 h-3.5 text-green-400" /> },
   degraded: {
-    badge: 'bg-yellow-500/15 text-yellow-400',
+    badge: 'bg-yellow-500/20 text-yellow-400',
     icon: <CircleDashed className="w-3.5 h-3.5 text-yellow-400" /> },
   error: {
-    badge: 'bg-red-500/15 text-red-400',
+    badge: 'bg-red-500/20 text-red-400',
     icon: <AlertTriangle className="w-3.5 h-3.5 text-red-400" /> } }
 
 const STATUS_LABEL_KEY: Record<CloudEventResourceState, 'cloudevents.status_ready' | 'cloudevents.status_degraded' | 'cloudevents.status_error'> = {

--- a/web/src/components/cards/llmd/StackSelector.tsx
+++ b/web/src/components/cards/llmd/StackSelector.tsx
@@ -11,6 +11,7 @@ import { useOptionalStack } from '../../../contexts/StackContext'
 import type { LLMdStack } from '../../../hooks/useStackDiscovery'
 import { useTranslation } from 'react-i18next'
 import { StatusBadge } from '../../ui/StatusBadge'
+import { Skeleton } from '../../ui/Skeleton'
 import { useModalState } from '../../../lib/modals'
 
 const STATUS_COLORS = {
@@ -521,8 +522,22 @@ export function StackSelector() {
                   </div>
                 ))
               ) : isLoading ? (
-                <div className="px-3 py-4 text-center text-muted-foreground text-sm">
-                  Loading stacks...
+                <div className="px-3 py-4 space-y-3">
+                  {Array.from({ length: 3 }).map((_, i) => (
+                    <div key={i} className="px-3 py-2.5 border-b border-border/50 last:border-0">
+                      <div className="flex items-center justify-between mb-1">
+                        <div className="flex items-center gap-2">
+                          <Skeleton variant="circular" width={8} height={8} />
+                          <Skeleton variant="text" width={120} height={14} />
+                        </div>
+                        <Skeleton variant="text" width={40} height={12} />
+                      </div>
+                      <div className="flex items-center gap-2">
+                        <Skeleton variant="rounded" width={80} height={16} />
+                        <Skeleton variant="rounded" width={60} height={16} />
+                      </div>
+                    </div>
+                  ))}
                 </div>
               ) : (
                 <div className="px-3 py-4 text-center text-muted-foreground text-sm">

--- a/web/src/components/clusters/components/StatsOverview.tsx
+++ b/web/src/components/clusters/components/StatsOverview.tsx
@@ -7,6 +7,7 @@ import { useDemoMode } from '../../../hooks/useDemoMode'
 import { Skeleton } from '../../ui/Skeleton'
 import { useModalState } from '../../../lib/modals'
 import { wrapAbbreviations } from '../../shared/TechnicalAcronym'
+import { getSeverityColors } from '../../../lib/cards/statusColors'
 
 export interface ClusterStats {
   total: number
@@ -178,10 +179,10 @@ function StatBlock({ blockId, stats, hasData, onClick, color, icon }: StatBlockP
       break
   }
 
-  // Value color - some blocks have colored values
-  const valueColor = ['healthy'].includes(blockId) ? 'text-green-400' :
-    ['unhealthy'].includes(blockId) ? 'text-red-400' :
-    ['unreachable'].includes(blockId) ? 'text-yellow-400' : 'text-foreground'
+  // Value color - use canonical status colors for semantic stat blocks
+  const valueColor = ['healthy'].includes(blockId) ? getSeverityColors('success').text :
+    ['unhealthy'].includes(blockId) ? getSeverityColors('error').text :
+    ['unreachable'].includes(blockId) ? getSeverityColors('warning').text : 'text-foreground'
 
   return (
     <div

--- a/web/src/components/dashboard/CardFactoryModal.tsx
+++ b/web/src/components/dashboard/CardFactoryModal.tsx
@@ -753,7 +753,7 @@ export function CardFactoryModal({ isOpen, onClose, onCardCreated, embedded = fa
   const [t1Layout, setT1Layout] = useState<'list' | 'stats' | 'stats-and-list'>('list')
   const [t1Columns, setT1Columns] = useState<DynamicCardColumn[]>([
     { field: 'name', label: 'Name' },
-    { field: 'status', label: 'Status', format: 'badge', badgeColors: { healthy: 'bg-green-500/20 text-green-400 dark:bg-green-900/30 dark:text-green-400', error: 'bg-red-500/20 text-red-400 dark:bg-red-900/30 dark:text-red-400' } },
+    { field: 'status', label: 'Status', format: 'badge', badgeColors: { healthy: 'bg-green-500/20 text-green-400', error: 'bg-red-500/20 text-red-400' } },
   ])
   const [t1DataJson, setT1DataJson] = useState('[\n  { "name": "item-1", "status": "healthy" },\n  { "name": "item-2", "status": "error" }\n]')
   const [t1Width, setT1Width] = useState(6)

--- a/web/src/components/settings/sections/OpsGenieNotificationSettings.tsx
+++ b/web/src/components/settings/sections/OpsGenieNotificationSettings.tsx
@@ -81,7 +81,7 @@ export function OpsGenieNotificationSettings({
       {testResult && testResult.type === 'opsgenie' && (
         <div
           className={`flex items-start gap-2 p-3 rounded-lg ${
-            testResult.success ? 'bg-green-500/10 border border-green-500/20' : 'bg-red-500/10 border border-red-500/20'
+            testResult.success ? 'bg-green-500/20 border border-green-500/20' : 'bg-red-500/20 border border-red-500/20'
           }`}
         >
           {testResult.success ? (

--- a/web/src/components/settings/sections/PagerDutyNotificationSettings.tsx
+++ b/web/src/components/settings/sections/PagerDutyNotificationSettings.tsx
@@ -81,7 +81,7 @@ export function PagerDutyNotificationSettings({
       {testResult && testResult.type === 'pagerduty' && (
         <div
           className={`flex items-start gap-2 p-3 rounded-lg ${
-            testResult.success ? 'bg-green-500/10 border border-green-500/20' : 'bg-red-500/10 border border-red-500/20'
+            testResult.success ? 'bg-green-500/20 border border-green-500/20' : 'bg-red-500/20 border border-red-500/20'
           }`}
         >
           {testResult.success ? (

--- a/web/src/components/settings/sections/SlackNotificationSettings.tsx
+++ b/web/src/components/settings/sections/SlackNotificationSettings.tsx
@@ -99,7 +99,7 @@ export function SlackNotificationSettings({
       {testResult && testResult.type === 'slack' && (
         <div
           className={`flex items-start gap-2 p-3 rounded-lg ${
-            testResult.success ? 'bg-green-500/10 border border-green-500/20' : 'bg-red-500/10 border border-red-500/20'
+            testResult.success ? 'bg-green-500/20 border border-green-500/20' : 'bg-red-500/20 border border-red-500/20'
           }`}
         >
           {testResult.success ? (


### PR DESCRIPTION
## Summary
- **StackSelector**: Replace plain "Loading stacks..." text with Skeleton components for consistent loading UX (#5434)
- **Notification settings** (Slack, OpsGenie, PagerDuty): Use `bg-*/20` for test result banners instead of non-standard `bg-*/10`
- **HardwareHealthCard**: Use `border-*/20` instead of `border-*/30` to match canonical `STATUS_COLORS` system
- **CloudEventsStatus**: Use `bg-*/20` for status badges instead of `bg-*/15`
- **StatsOverview**: Use `getSeverityColors()` from `statusColors.ts` instead of hardcoded color classes
- **CardFactoryModal**: Remove redundant `dark:` variants from badge colors

## Test plan
- [ ] Verify StackSelector shows Skeleton loading animation when stacks are loading
- [ ] Verify notification test result banners in Slack/OpsGenie/PagerDuty settings render correctly
- [ ] Verify HardwareHealthCard critical/warning/healthy borders display consistently
- [ ] Verify CloudEventsStatus badges render with correct opacity
- [ ] Visual regression: no unexpected color changes across the dashboard

Closes #5434
Closes #5435