### PR TITLE
fix: resolve 10 state, data, and edge-case bugs

### DIFF
--- a/pkg/api/handlers/self_upgrade.go
+++ b/pkg/api/handlers/self_upgrade.go
@@ -300,14 +300,27 @@ func (h *SelfUpgradeHandler) TriggerUpgrade(c *fiber.Ctx) error {
 		currentImage = dep.Spec.Template.Spec.Containers[0].Image
 	}
 
-	// Extract repository from current image (e.g., "ghcr.io/kubestellar/console:v0.3.11" → "ghcr.io/kubestellar/console")
+	// Extract repository from current image.
+	// Must handle registries with ports (e.g. "registry.internal:5000/console")
+	// where the colon is NOT a tag separator.  A tag colon always appears
+	// after the last slash, so we only strip a ":tag" suffix from the segment
+	// after the final "/".
 	repo := currentImage
-	if idx := strings.LastIndex(repo, ":"); idx > 0 {
-		repo = repo[:idx]
-	}
-	// Handle @sha256 digests
+	// Handle @sha256 digests first (e.g. "ghcr.io/console@sha256:abc123")
 	if idx := strings.LastIndex(repo, "@"); idx > 0 {
 		repo = repo[:idx]
+	}
+	// Strip tag — only look for ":" after the last "/"
+	if lastSlash := strings.LastIndex(repo, "/"); lastSlash >= 0 {
+		tail := repo[lastSlash:]
+		if colonIdx := strings.LastIndex(tail, ":"); colonIdx > 0 {
+			repo = repo[:lastSlash+colonIdx]
+		}
+	} else {
+		// No slash at all (e.g. "console:v1.0") — simple strip
+		if colonIdx := strings.LastIndex(repo, ":"); colonIdx > 0 {
+			repo = repo[:colonIdx]
+		}
 	}
 	newImage := repo + ":" + req.ImageTag
 

--- a/pkg/api/handlers/websocket.go
+++ b/pkg/api/handlers/websocket.go
@@ -23,6 +23,11 @@ const (
 	// wsMaxBroadcastBytes is the maximum serialized size of a single broadcast message.
 	// Messages exceeding this limit are dropped to prevent memory spikes.
 	wsMaxBroadcastBytes = 1 * 1024 * 1024 // 1 MB
+	// maxDemoSessions caps unique demo session IDs to prevent inflation attacks.
+	// This is unauthenticated telemetry — the cap is a reasonable upper bound.
+	maxDemoSessions = 500
+	// maxSessionIDLen is the maximum allowed length for a demo session ID.
+	maxSessionIDLen = 128
 )
 
 // Message represents a WebSocket message
@@ -199,11 +204,29 @@ func (h *Hub) DisconnectUser(userID uuid.UUID) {
 	slog.Info("[WebSocket] disconnected all connections for user", "user", userID, "count", len(clients))
 }
 
-// RecordDemoSession records a heartbeat from a demo mode session
-func (h *Hub) RecordDemoSession(sessionID string) {
+// RecordDemoSession records a heartbeat from a demo mode session.
+// The endpoint is unauthenticated (demo mode only) so we cap the number of
+// unique sessions and reject oversized IDs to limit abuse potential.
+func (h *Hub) RecordDemoSession(sessionID string) bool {
+	if len(sessionID) > maxSessionIDLen {
+		return false
+	}
 	h.mu.Lock()
 	defer h.mu.Unlock()
+
+	// Allow updates to existing sessions unconditionally
+	if _, exists := h.demoSessions[sessionID]; exists {
+		h.demoSessions[sessionID] = time.Now()
+		return true
+	}
+
+	// Reject new sessions if at capacity
+	if len(h.demoSessions) >= maxDemoSessions {
+		return false
+	}
+
 	h.demoSessions[sessionID] = time.Now()
+	return true
 }
 
 // GetDemoSessionCount returns the number of active demo sessions (seen in last 60 seconds)

--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -588,6 +588,8 @@ func (s *Server) setupRoutes() {
 	})
 
 	// Active users heartbeat endpoint (for demo mode session counting)
+	// This is unauthenticated telemetry — session IDs are validated for length
+	// and the total number of unique sessions is capped to prevent inflation.
 	s.app.Post("/api/active-users", func(c *fiber.Ctx) error {
 		var body struct {
 			SessionID string `json:"sessionId"`
@@ -595,7 +597,9 @@ func (s *Server) setupRoutes() {
 		if err := c.BodyParser(&body); err != nil || body.SessionID == "" {
 			return c.Status(400).JSON(fiber.Map{"error": "sessionId required"})
 		}
-		s.hub.RecordDemoSession(body.SessionID)
+		if !s.hub.RecordDemoSession(body.SessionID) {
+			return c.Status(429).JSON(fiber.Map{"error": "session limit reached"})
+		}
 		demoCount := s.hub.GetDemoSessionCount()
 		return c.JSON(fiber.Map{
 			"activeUsers":      demoCount,

--- a/web/src/components/cards/NamespaceEvents.tsx
+++ b/web/src/components/cards/NamespaceEvents.tsx
@@ -68,6 +68,8 @@ export function NamespaceEvents({ config }: NamespaceEventsProps) {
     storageKey: 'namespace-events' })
 
   // Apply config overrides (e.g., from drill-down navigation)
+  // Re-apply when config props change so that navigating to a different
+  // drilldown target actually updates the selection.
   useEffect(() => {
     if (config?.cluster && config.cluster !== selectedCluster) {
       setSelectedCluster(config.cluster)
@@ -75,9 +77,8 @@ export function NamespaceEvents({ config }: NamespaceEventsProps) {
     if (config?.namespace && config.namespace !== selectedNamespace) {
       setSelectedNamespace(config.namespace)
     }
-    // Only run on mount - config changes shouldn't override user selections
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [])
+  }, [config?.cluster, config?.namespace])
 
   // Fetch namespaces for the selected cluster
   const { namespaces } = useCachedNamespaces(selectedCluster || undefined)

--- a/web/src/components/clusters/utils.ts
+++ b/web/src/components/clusters/utils.ts
@@ -15,11 +15,16 @@ export const isClusterUnreachable = (c: ClusterInfo): boolean => {
 }
 
 // Helper to check if a cluster is healthy.
-// A cluster is healthy if its healthy flag is true OR it has nodes reporting in.
+// A cluster is healthy if its healthy flag is true, or if health is unknown
+// (undefined) and nodes are reporting in. When healthy is explicitly false,
+// node presence does NOT override the health status.
 // This single definition is used by both the stats overview counts and the filter
 // tabs so that clicking a stat always shows exactly the clusters it counted.
 export const isClusterHealthy = (c: ClusterInfo): boolean => {
-  return c.healthy === true || !!(c.nodeCount && c.nodeCount > 0)
+  if (c.healthy === true) return true
+  if (c.healthy === false) return false
+  // Health unknown — fall back to node presence as a heuristic
+  return !!(c.nodeCount && c.nodeCount > 0)
 }
 
 // Helper to check if cluster has token/auth expired error

--- a/web/src/hooks/mcp/shared.ts
+++ b/web/src/hooks/mcp/shared.ts
@@ -198,11 +198,12 @@ function mergeWithStoredClusters(newClusters: ClusterInfo[]): ClusterInfo[] {
   return newClusters.map(cluster => {
     const cached = storedMap.get(cluster.name)
     if (cached) {
-      // Helper: use new value only if it's a positive number, else use cached
+      // Helper: prefer new value when defined (including zero); only fall back
+      // to cached when the new value is truly missing (undefined).
+      // A legitimate zero (e.g. cluster scaled to 0 pods) must be respected.
       const pickMetric = (newVal: number | undefined, cachedVal: number | undefined) => {
-        if (newVal !== undefined && newVal > 0) return newVal
-        if (cachedVal !== undefined && cachedVal > 0) return cachedVal
-        return newVal // fallback to new value (could be 0 or undefined)
+        if (newVal !== undefined) return newVal
+        return cachedVal
       }
 
       // Merge: use new data but preserve cached metrics if new data is missing/zero
@@ -608,24 +609,11 @@ export function updateSingleClusterInCache(clusterName: string, updates: Partial
         return
       }
 
-      // For numeric metrics, preserve positive cached values when new value is 0
-      const metricsKeys = ['cpuCores', 'memoryBytes', 'memoryGB', 'storageBytes', 'storageGB', 'cpuRequestsMillicores', 'cpuRequestsCores', 'memoryRequestsBytes', 'memoryRequestsGB', 'cpuUsageMillicores', 'cpuUsageCores', 'memoryUsageBytes', 'memoryUsageGB']
-      if (metricsKeys.includes(key) && typeof value === 'number' && value === 0) {
-        // Keep existing positive value if available
-        const existingValue = c[key as keyof ClusterInfo]
-        if (typeof existingValue === 'number' && existingValue > 0) {
-          return // Skip, keep existing positive value
-        }
-      }
-
-      // Don't set reachable to false if we have valid cached node data
-      // This prevents transient health check failures from immediately marking clusters as offline
-      if (key === 'reachable' && value === false) {
-        const hasValidCachedData = typeof c.nodeCount === 'number' && c.nodeCount > 0
-        if (hasValidCachedData) {
-          return // Skip, keep cluster reachable since we have valid data
-        }
-      }
+      // For numeric metrics, only fall back to cached when new value is undefined.
+      // A real zero (e.g. scaled-to-zero) must be respected — see #5443.
+      // NOTE: reachability (key === 'reachable') is no longer blocked by cached
+      // node data — the useMCP hook already gates reachable=false behind 5 minutes
+      // of consecutive failures, so the value is authoritative — see #5444.
 
       // Apply the update
       (merged as Record<string, unknown>)[key] = value

--- a/web/src/hooks/useDeployMissions.ts
+++ b/web/src/hooks/useDeployMissions.ts
@@ -63,6 +63,8 @@ export interface DeployClusterStatus {
   replicas: number
   readyReplicas: number
   logs?: string[]
+  /** Consecutive status-fetch failures — transitions to 'failed' after threshold */
+  consecutiveFailures?: number
 }
 
 export interface DeployMission {
@@ -91,6 +93,8 @@ const POLL_INTERVAL_MS = 5000
 const MAX_MISSIONS = 50
 /** Cache TTL: 5 minutes — stop polling completed missions after this duration */
 const CACHE_TTL_MS = 5 * 60 * 1000
+/** After this many consecutive status-fetch failures a cluster is marked failed */
+const MAX_STATUS_FAILURES = 6
 
 function loadMissions(): DeployMission[] {
   try {
@@ -208,6 +212,22 @@ export function useDeployMissions() {
 
           const statuses = await Promise.all(
             mission.targetClusters.map(async (cluster): Promise<DeployClusterStatus> => {
+              // Track consecutive failures from previous poll cycle
+              const prevStatus = mission.clusterStatuses.find(cs => cs.cluster === cluster)
+              const prevFailures = prevStatus?.consecutiveFailures ?? 0
+
+              // Helper: build a "pending-or-failed" response depending on failure count
+              const pendingOrFailed = (): DeployClusterStatus => {
+                const failures = prevFailures + 1
+                if (failures >= MAX_STATUS_FAILURES) {
+                  return { cluster, status: 'failed', replicas: 0, readyReplicas: 0,
+                    consecutiveFailures: failures,
+                    logs: [`Status unreachable after ${failures} consecutive attempts`] }
+                }
+                return { cluster, status: 'pending', replicas: 0, readyReplicas: 0,
+                  consecutiveFailures: failures }
+              }
+
               // Try agent first (works when backend is down)
               try {
                 const clusterInfo = clusterCacheRef.clusters.find(c => c.name === cluster)
@@ -228,10 +248,12 @@ export function useDeployMissions() {
                       (d) => String(d.name) === mission.workload
                     )
                     if (match) {
-                      const replicas = Number(match.replicas || 0)
-                      const readyReplicas = Number(match.readyReplicas || 0)
+                      const replicas = Number(match.replicas ?? 0)
+                      const readyReplicas = Number(match.readyReplicas ?? 0)
                       let status: DeployClusterStatus['status'] = 'applying'
-                      if (readyReplicas > 0 && readyReplicas >= replicas) {
+                      // Zero-replica workloads are valid (e.g. scale-to-zero) — treat
+                      // readyReplicas >= replicas as success even when both are zero.
+                      if (readyReplicas >= replicas) {
                         status = 'running'
                       } else if (String(match.status) === 'failed') {
                         status = 'failed'
@@ -246,8 +268,8 @@ export function useDeployMissions() {
                       } catch { /* non-critical */ }
                       return { cluster, status, replicas, readyReplicas, logs }
                     }
-                    // Workload not found on this cluster yet — still pending
-                    return { cluster, status: 'pending', replicas: 0, readyReplicas: 0 }
+                    // Workload not found on this cluster yet — still pending (or failed after threshold)
+                    return pendingOrFailed()
                   }
                 }
               } catch {
@@ -261,15 +283,19 @@ export function useDeployMissions() {
                   { headers: authHeaders(), signal: AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS) }
                 )
                 if (!res.ok) {
-                  return { cluster, status: 'pending', replicas: 0, readyReplicas: 0 }
+                  return pendingOrFailed()
                 }
                 const data = await res.json()
                 let status: DeployClusterStatus['status'] = 'applying'
-                if (data.status === 'Running' && data.readyReplicas > 0 && data.readyReplicas >= data.replicas) {
+                const restReplicas = Number(data.replicas ?? 0)
+                const restReady = Number(data.readyReplicas ?? 0)
+                // Zero-replica workloads are valid — treat readyReplicas >= replicas
+                // as success even when both are zero.
+                if (data.status === 'Running' && restReady >= restReplicas) {
                   status = 'running'
                 } else if (data.status === 'Failed') {
                   status = 'failed'
-                } else if (data.readyReplicas > 0) {
+                } else if (restReady > 0) {
                   status = 'applying'
                 }
                 // Fetch deploy events/logs
@@ -295,7 +321,7 @@ export function useDeployMissions() {
                   readyReplicas: data.readyReplicas ?? 0,
                   logs }
               } catch {
-                return { cluster, status: 'pending', replicas: 0, readyReplicas: 0 }
+                return pendingOrFailed()
               }
             })
           )

--- a/web/src/hooks/useGlobalFilters.tsx
+++ b/web/src/hooks/useGlobalFilters.tsx
@@ -238,6 +238,17 @@ export function GlobalFiltersProvider({ children }: { children: ReactNode }) {
     return []
   })
 
+  // Reconcile selected clusters against available clusters — drop any that no longer exist
+  // This prevents filters from getting stuck on clusters that have been removed from kubeconfig
+  useEffect(() => {
+    if (selectedClusters.length === 0 || availableClusters.length === 0) return
+    const validSelections = selectedClusters.filter(c => availableClusters.includes(c))
+    if (validSelections.length !== selectedClusters.length) {
+      // Some selected clusters no longer exist — fall back to "all" if none remain
+      setSelectedClustersState(validSelections.length === 0 ? [] : validSelections)
+    }
+  }, [availableClusters, selectedClusters])
+
   // Persist to localStorage
   useEffect(() => {
     localStorage.setItem(CLUSTER_STORAGE_KEY, JSON.stringify(selectedClusters.length === 0 ? null : selectedClusters))

--- a/web/src/lib/cards/cardHooks.ts
+++ b/web/src/lib/cards/cardHooks.ts
@@ -377,9 +377,11 @@ export function useCardData<T, S extends string = string>(
   const needsPagination = itemsPerPage !== 'unlimited' && sorted.length > effectivePerPage
 
   // Reset page when filters change (but not on sort — sorting preserves page position)
+  // Watch the filtered result reference — it changes on any filter input including
+  // global cluster/status/severity/custom text filters, not just local search.
   useEffect(() => {
     setCurrentPage(1)
-  }, [filterResult.search, filterResult.localClusterFilter])
+  }, [filterResult.search, filterResult.localClusterFilter, filtered])
 
   // Ensure current page is valid
   useEffect(() => {


### PR DESCRIPTION
## Summary

Batch fix for 10 medium-severity bugs reported via console request system.

- **#5439** — Global cluster filters stuck on deleted clusters: added reconciliation effect that drops invalid selections when `availableClusters` changes
- **#5440** — Unhealthy clusters counted as healthy: `isClusterHealthy()` now only uses node presence as fallback when health is unknown, not when explicitly false
- **#5441** — Namespace drilldown props ignored after first mount: effect now depends on `config.cluster` / `config.namespace` instead of empty deps
- **#5442** — Pagination not resetting on global filter change: added `filtered` array to page-reset effect deps
- **#5443** — Zero metrics replaced by stale cache: `pickMetric()` now returns any defined value (including zero), only falls back to cache for `undefined`
- **#5444** — Reachability updates suppressed by cached node data: removed guard that blocked `reachable=false` when nodeCount > 0 (the useMCP hook already gates this behind 5 min of failures)
- **#5445** — Deploy missions stuck for zero-replica workloads: changed `readyReplicas > 0 && readyReplicas >= replicas` to `readyReplicas >= replicas` (both agent and REST paths)
- **#5446** — Missing deploy-status responses trap missions forever: tracks consecutive failures per cluster and transitions to `failed` after 6 failed polls (~30s)
- **#5447** — Self-upgrade breaks on registries with port and no tag: tag colon is now only stripped after the last `/`, preserving `registry:port` prefixes
- **#5448** — Demo presence counts spoofable: added session ID length validation (128 char max), unique session cap (500), and 429 response when limit reached

## Test plan

- [ ] Verify cluster filter clears when a cluster is removed from kubeconfig
- [ ] Verify unhealthy clusters with nodes are not counted as healthy
- [ ] Verify namespace events drilldown updates on prop change
- [ ] Verify pagination resets to page 1 on global filter change
- [ ] Verify zero-valued metrics (e.g. 0 pods) display correctly
- [ ] Verify cluster going offline updates reachability in cache
- [ ] Verify zero-replica deployments complete missions
- [ ] Verify missions fail after repeated status errors
- [ ] Verify self-upgrade with `registry:port/image` (no tag) produces correct image ref
- [ ] Verify demo heartbeat rejects oversized session IDs (HTTP 429)

Closes #5439, closes #5440, closes #5441, closes #5442, closes #5443, closes #5444, closes #5445, closes #5446, closes #5447, closes #5448