### PR TITLE
fix: GPU update validation, user list admin restriction

### DIFF
--- a/pkg/api/handlers/gpu.go
+++ b/pkg/api/handlers/gpu.go
@@ -239,6 +239,9 @@ func (h *GPUHandler) UpdateReservation(c *fiber.Ctx) error {
 		existing.Namespace = *input.Namespace
 	}
 	if input.GPUCount != nil {
+		if *input.GPUCount < 1 {
+			return fiber.NewError(fiber.StatusBadRequest, "GPU count must be at least 1")
+		}
 		existing.GPUCount = *input.GPUCount
 	}
 	if input.GPUType != nil {
@@ -251,6 +254,9 @@ func (h *GPUHandler) UpdateReservation(c *fiber.Ctx) error {
 		existing.StartDate = *input.StartDate
 	}
 	if input.DurationHours != nil {
+		if *input.DurationHours <= 0 {
+			return fiber.NewError(fiber.StatusBadRequest, "Duration must be greater than 0")
+		}
 		existing.DurationHours = *input.DurationHours
 	}
 	if input.Notes != nil {

--- a/pkg/api/handlers/gpu_test.go
+++ b/pkg/api/handlers/gpu_test.go
@@ -25,6 +25,11 @@ type gpuTestStore struct {
 	listAll            []models.GPUReservation
 	listMine           []models.GPUReservation
 	listErr            error
+	reservations       map[uuid.UUID]*models.GPUReservation
+	updateErr          error
+	updated            *models.GPUReservation
+	bulkSnapshots      map[string][]models.GPUUtilizationSnapshot
+	bulkSnapshotsErr   error
 }
 
 func (s *gpuTestStore) GetUser(id uuid.UUID) (*models.User, error) {
@@ -66,6 +71,33 @@ func (s *gpuTestStore) ListUserGPUReservations(userID uuid.UUID) ([]models.GPURe
 		return nil, s.listErr
 	}
 	return s.listMine, nil
+}
+
+func (s *gpuTestStore) GetGPUReservation(id uuid.UUID) (*models.GPUReservation, error) {
+	if s.reservations != nil {
+		r, ok := s.reservations[id]
+		if !ok {
+			return nil, nil
+		}
+		return r, nil
+	}
+	return nil, nil
+}
+
+func (s *gpuTestStore) UpdateGPUReservation(reservation *models.GPUReservation) error {
+	if s.updateErr != nil {
+		return s.updateErr
+	}
+	copy := *reservation
+	s.updated = &copy
+	return nil
+}
+
+func (s *gpuTestStore) GetBulkUtilizationSnapshots(ids []string) (map[string][]models.GPUUtilizationSnapshot, error) {
+	if s.bulkSnapshotsErr != nil {
+		return nil, s.bulkSnapshotsErr
+	}
+	return s.bulkSnapshots, nil
 }
 
 // stubCapacity returns a ClusterCapacityProvider that always returns the given value.
@@ -155,4 +187,128 @@ func TestGPUListReservations_MineNilReturnsEmptyArray(t *testing.T) {
 	var reservations []models.GPUReservation
 	require.NoError(t, json.NewDecoder(resp.Body).Decode(&reservations))
 	assert.Len(t, reservations, 0)
+}
+
+func TestGPUUpdateReservation_RejectsZeroGPUCount(t *testing.T) {
+	env := setupTestEnv(t)
+	resID := uuid.New()
+	store := &gpuTestStore{
+		user: &models.User{ID: testAdminUserID, GitHubLogin: "alice", Role: models.UserRoleAdmin},
+		reservations: map[uuid.UUID]*models.GPUReservation{
+			resID: {ID: resID, UserID: testAdminUserID, GPUCount: 2, DurationHours: 24, Cluster: "c1"},
+		},
+	}
+	handler := NewGPUHandler(store, nil)
+	env.App.Put("/api/gpu/reservations/:id", handler.UpdateReservation)
+
+	zero := 0
+	body, err := json.Marshal(map[string]any{"gpu_count": zero})
+	require.NoError(t, err)
+
+	req, err := http.NewRequest(http.MethodPut, "/api/gpu/reservations/"+resID.String(), bytes.NewReader(body))
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := env.App.Test(req, 5000)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+	assert.Nil(t, store.updated, "store should not have been updated")
+}
+
+func TestGPUUpdateReservation_RejectsNegativeGPUCount(t *testing.T) {
+	env := setupTestEnv(t)
+	resID := uuid.New()
+	store := &gpuTestStore{
+		user: &models.User{ID: testAdminUserID, GitHubLogin: "alice", Role: models.UserRoleAdmin},
+		reservations: map[uuid.UUID]*models.GPUReservation{
+			resID: {ID: resID, UserID: testAdminUserID, GPUCount: 2, DurationHours: 24, Cluster: "c1"},
+		},
+	}
+	handler := NewGPUHandler(store, nil)
+	env.App.Put("/api/gpu/reservations/:id", handler.UpdateReservation)
+
+	body, err := json.Marshal(map[string]any{"gpu_count": -1})
+	require.NoError(t, err)
+
+	req, err := http.NewRequest(http.MethodPut, "/api/gpu/reservations/"+resID.String(), bytes.NewReader(body))
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := env.App.Test(req, 5000)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+}
+
+func TestGPUUpdateReservation_RejectsNegativeDuration(t *testing.T) {
+	env := setupTestEnv(t)
+	resID := uuid.New()
+	store := &gpuTestStore{
+		user: &models.User{ID: testAdminUserID, GitHubLogin: "alice", Role: models.UserRoleAdmin},
+		reservations: map[uuid.UUID]*models.GPUReservation{
+			resID: {ID: resID, UserID: testAdminUserID, GPUCount: 2, DurationHours: 24, Cluster: "c1"},
+		},
+	}
+	handler := NewGPUHandler(store, nil)
+	env.App.Put("/api/gpu/reservations/:id", handler.UpdateReservation)
+
+	body, err := json.Marshal(map[string]any{"duration_hours": -5})
+	require.NoError(t, err)
+
+	req, err := http.NewRequest(http.MethodPut, "/api/gpu/reservations/"+resID.String(), bytes.NewReader(body))
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := env.App.Test(req, 5000)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+}
+
+func TestGPUUpdateReservation_RejectsZeroDuration(t *testing.T) {
+	env := setupTestEnv(t)
+	resID := uuid.New()
+	store := &gpuTestStore{
+		user: &models.User{ID: testAdminUserID, GitHubLogin: "alice", Role: models.UserRoleAdmin},
+		reservations: map[uuid.UUID]*models.GPUReservation{
+			resID: {ID: resID, UserID: testAdminUserID, GPUCount: 2, DurationHours: 24, Cluster: "c1"},
+		},
+	}
+	handler := NewGPUHandler(store, nil)
+	env.App.Put("/api/gpu/reservations/:id", handler.UpdateReservation)
+
+	body, err := json.Marshal(map[string]any{"duration_hours": 0})
+	require.NoError(t, err)
+
+	req, err := http.NewRequest(http.MethodPut, "/api/gpu/reservations/"+resID.String(), bytes.NewReader(body))
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := env.App.Test(req, 5000)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+}
+
+func TestGPUBulkUtilizations_ForbiddenForNonOwner(t *testing.T) {
+	env := setupTestEnv(t)
+	otherUserID := uuid.New()
+	resID := uuid.New()
+	store := &gpuTestStore{
+		user: &models.User{ID: testAdminUserID, GitHubLogin: "alice", Role: models.UserRoleViewer},
+		reservations: map[uuid.UUID]*models.GPUReservation{
+			resID: {ID: resID, UserID: otherUserID, GPUCount: 1, Cluster: "c1"},
+		},
+	}
+	handler := NewGPUHandler(store, nil)
+	env.App.Get("/api/gpu/utilizations", handler.GetBulkUtilizations)
+
+	req, err := http.NewRequest(http.MethodGet, "/api/gpu/utilizations?ids="+resID.String(), nil)
+	require.NoError(t, err)
+
+	resp, err := env.App.Test(req, 5000)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	assert.Equal(t, http.StatusForbidden, resp.StatusCode)
 }

--- a/pkg/api/handlers/rbac.go
+++ b/pkg/api/handlers/rbac.go
@@ -39,13 +39,21 @@ func NewRBACHandler(s store.Store, k8sClient *k8s.MultiClusterClient) *RBACHandl
 	return &RBACHandler{store: s, k8sClient: k8sClient}
 }
 
-// ListConsoleUsers returns all console users (frontend handles visibility/blurring)
+// ListConsoleUsers returns all console users.
+// SECURITY: Restricted to admin users to prevent non-admin users from
+// enumerating all user records (#5458).
 func (h *RBACHandler) ListConsoleUsers(c *fiber.Ctx) error {
-	// Check if current user is authenticated
 	userID := middleware.GetUserID(c)
 	currentUser, err := h.store.GetUser(userID)
 	if err != nil || currentUser == nil {
 		return fiber.NewError(fiber.StatusUnauthorized, "Unauthorized")
+	}
+
+	if currentUser.Role != models.UserRoleAdmin {
+		slog.Warn("[rbac] SECURITY: non-admin attempted to list all users",
+			"user_id", currentUser.ID,
+			"github_login", currentUser.GitHubLogin)
+		return fiber.NewError(fiber.StatusForbidden, "Admin access required")
 	}
 
 	users, err := h.store.ListUsers()

--- a/pkg/api/handlers/rbac_test.go
+++ b/pkg/api/handlers/rbac_test.go
@@ -108,6 +108,31 @@ func TestRBACUpdateUserRole_Success(t *testing.T) {
 	assert.Equal(t, string(models.UserRoleEditor), store.updatedRole)
 }
 
+func TestRBACListConsoleUsers_ForbiddenForNonAdmin(t *testing.T) {
+	env := setupTestEnv(t)
+	viewerUser := &models.User{
+		ID:   testAdminUserID,
+		Role: models.UserRoleViewer,
+	}
+
+	store := &rbacTestStore{
+		users: map[uuid.UUID]*models.User{
+			testAdminUserID: viewerUser,
+		},
+	}
+
+	handler := NewRBACHandler(store, nil)
+	env.App.Get("/api/rbac/users", handler.ListConsoleUsers)
+
+	req, err := http.NewRequest(http.MethodGet, "/api/rbac/users", nil)
+	require.NoError(t, err)
+
+	resp, err := env.App.Test(req, 5000)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	assert.Equal(t, http.StatusForbidden, resp.StatusCode)
+}
+
 func TestRBACListConsoleUsers_Success(t *testing.T) {
 	env := setupTestEnv(t)
 	adminUser := &models.User{


### PR DESCRIPTION
## Summary
- **#5457**: GPU `UpdateReservation` now rejects `gpuCount < 1` and `durationHours <= 0` with 400 Bad Request, preventing invalid reservation state
- **#5458**: `ListConsoleUsers` endpoint restricted to admin role — non-admin users now receive 403 Forbidden with a security audit log
- **#5455**: Bulk utilization ownership check was already in place (added in #5420); added test to confirm non-owners get 403

Closes #5455
Closes #5457
Closes #5458

## Test plan
- [x] `go build ./...` passes
- [x] New tests: `TestGPUUpdateReservation_RejectsZeroGPUCount`, `TestGPUUpdateReservation_RejectsNegativeGPUCount`, `TestGPUUpdateReservation_RejectsNegativeDuration`, `TestGPUUpdateReservation_RejectsZeroDuration`
- [x] New test: `TestRBACListConsoleUsers_ForbiddenForNonAdmin`
- [x] New test: `TestGPUBulkUtilizations_ForbiddenForNonOwner`
- [x] All existing tests still pass