### PR TITLE
fix: restrict 7 RBAC endpoints to admin role

### DIFF
--- a/pkg/api/handlers/namespaces.go
+++ b/pkg/api/handlers/namespaces.go
@@ -132,8 +132,23 @@ func (h *NamespaceHandler) DeleteNamespace(c *fiber.Ctx) error {
 	return c.JSON(fiber.Map{"success": true})
 }
 
-// GetNamespaceAccess returns role bindings for a namespace
+// GetNamespaceAccess returns role bindings for a namespace.
+// SECURITY: Restricted to admin users to prevent non-admin users from
+// enumerating namespace access and binding subjects (#5466).
 func (h *NamespaceHandler) GetNamespaceAccess(c *fiber.Ctx) error {
+	userID := middleware.GetUserID(c)
+	currentUser, err := h.store.GetUser(userID)
+	if err != nil || currentUser == nil {
+		return fiber.NewError(fiber.StatusUnauthorized, "Unauthorized")
+	}
+
+	if currentUser.Role != models.UserRoleAdmin {
+		slog.Warn("[rbac] SECURITY: non-admin attempted to read namespace access",
+			"user_id", currentUser.ID,
+			"github_login", currentUser.GitHubLogin)
+		return fiber.NewError(fiber.StatusForbidden, "Admin access required")
+	}
+
 	if h.k8sClient == nil {
 		return fiber.NewError(fiber.StatusServiceUnavailable, "Kubernetes client not available")
 	}

--- a/pkg/api/handlers/rbac.go
+++ b/pkg/api/handlers/rbac.go
@@ -136,8 +136,23 @@ func (h *RBACHandler) DeleteConsoleUser(c *fiber.Ctx) error {
 	return c.JSON(fiber.Map{"success": true})
 }
 
-// GetUserManagementSummary returns an overview of users
+// GetUserManagementSummary returns an overview of users.
+// SECURITY: Restricted to admin users to prevent non-admin users from
+// reading user counts and permission summaries (#5459).
 func (h *RBACHandler) GetUserManagementSummary(c *fiber.Ctx) error {
+	userID := middleware.GetUserID(c)
+	currentUser, err := h.store.GetUser(userID)
+	if err != nil || currentUser == nil {
+		return fiber.NewError(fiber.StatusUnauthorized, "Unauthorized")
+	}
+
+	if currentUser.Role != models.UserRoleAdmin {
+		slog.Warn("[rbac] SECURITY: non-admin attempted to read user-management summary",
+			"user_id", currentUser.ID,
+			"github_login", currentUser.GitHubLogin)
+		return fiber.NewError(fiber.StatusForbidden, "Admin access required")
+	}
+
 	summary := models.UserManagementSummary{}
 
 	// Count console users by role
@@ -219,8 +234,23 @@ func (h *RBACHandler) ListK8sServiceAccounts(c *fiber.Ctx) error {
 	return c.JSON(allSAs)
 }
 
-// ListK8sRoles returns roles from clusters
+// ListK8sRoles returns roles from clusters.
+// SECURITY: Restricted to admin users to prevent non-admin users from
+// enumerating Kubernetes roles (#5460).
 func (h *RBACHandler) ListK8sRoles(c *fiber.Ctx) error {
+	userID := middleware.GetUserID(c)
+	currentUser, err := h.store.GetUser(userID)
+	if err != nil || currentUser == nil {
+		return fiber.NewError(fiber.StatusUnauthorized, "Unauthorized")
+	}
+
+	if currentUser.Role != models.UserRoleAdmin {
+		slog.Warn("[rbac] SECURITY: non-admin attempted to list Kubernetes roles",
+			"user_id", currentUser.ID,
+			"github_login", currentUser.GitHubLogin)
+		return fiber.NewError(fiber.StatusForbidden, "Admin access required")
+	}
+
 	if h.k8sClient == nil {
 		return fiber.NewError(fiber.StatusServiceUnavailable, "Kubernetes client not available")
 	}
@@ -254,8 +284,23 @@ func (h *RBACHandler) ListK8sRoles(c *fiber.Ctx) error {
 	return fiber.NewError(fiber.StatusBadRequest, "Cluster parameter required")
 }
 
-// ListK8sRoleBindings returns role bindings from clusters
+// ListK8sRoleBindings returns role bindings from clusters.
+// SECURITY: Restricted to admin users to prevent non-admin users from
+// enumerating role bindings (#5461).
 func (h *RBACHandler) ListK8sRoleBindings(c *fiber.Ctx) error {
+	userID := middleware.GetUserID(c)
+	currentUser, err := h.store.GetUser(userID)
+	if err != nil || currentUser == nil {
+		return fiber.NewError(fiber.StatusUnauthorized, "Unauthorized")
+	}
+
+	if currentUser.Role != models.UserRoleAdmin {
+		slog.Warn("[rbac] SECURITY: non-admin attempted to list role bindings",
+			"user_id", currentUser.ID,
+			"github_login", currentUser.GitHubLogin)
+		return fiber.NewError(fiber.StatusForbidden, "Admin access required")
+	}
+
 	if h.k8sClient == nil {
 		return fiber.NewError(fiber.StatusServiceUnavailable, "Kubernetes client not available")
 	}
@@ -382,8 +427,23 @@ func (h *RBACHandler) CreateRoleBinding(c *fiber.Ctx) error {
 	return c.JSON(fiber.Map{"success": true})
 }
 
-// ListK8sUsers returns all unique users/subjects from role bindings
+// ListK8sUsers returns all unique users/subjects from role bindings.
+// SECURITY: Restricted to admin users to prevent non-admin users from
+// enumerating Kubernetes subjects (#5462).
 func (h *RBACHandler) ListK8sUsers(c *fiber.Ctx) error {
+	userID := middleware.GetUserID(c)
+	currentUser, err := h.store.GetUser(userID)
+	if err != nil || currentUser == nil {
+		return fiber.NewError(fiber.StatusUnauthorized, "Unauthorized")
+	}
+
+	if currentUser.Role != models.UserRoleAdmin {
+		slog.Warn("[rbac] SECURITY: non-admin attempted to list Kubernetes subjects",
+			"user_id", currentUser.ID,
+			"github_login", currentUser.GitHubLogin)
+		return fiber.NewError(fiber.StatusForbidden, "Admin access required")
+	}
+
 	if h.k8sClient == nil {
 		return fiber.NewError(fiber.StatusServiceUnavailable, "Kubernetes client not available")
 	}
@@ -404,8 +464,23 @@ func (h *RBACHandler) ListK8sUsers(c *fiber.Ctx) error {
 	return c.JSON(users)
 }
 
-// ListOpenShiftUsers returns all OpenShift users (users.user.openshift.io) from a cluster
+// ListOpenShiftUsers returns all OpenShift users (users.user.openshift.io) from a cluster.
+// SECURITY: Restricted to admin users to prevent non-admin users from
+// enumerating OpenShift users (#5463).
 func (h *RBACHandler) ListOpenShiftUsers(c *fiber.Ctx) error {
+	userID := middleware.GetUserID(c)
+	currentUser, err := h.store.GetUser(userID)
+	if err != nil || currentUser == nil {
+		return fiber.NewError(fiber.StatusUnauthorized, "Unauthorized")
+	}
+
+	if currentUser.Role != models.UserRoleAdmin {
+		slog.Warn("[rbac] SECURITY: non-admin attempted to list OpenShift users",
+			"user_id", currentUser.ID,
+			"github_login", currentUser.GitHubLogin)
+		return fiber.NewError(fiber.StatusForbidden, "Admin access required")
+	}
+
 	if h.k8sClient == nil {
 		return fiber.NewError(fiber.StatusServiceUnavailable, "Kubernetes client not available")
 	}
@@ -428,8 +503,23 @@ func (h *RBACHandler) ListOpenShiftUsers(c *fiber.Ctx) error {
 	return c.JSON(users)
 }
 
-// GetPermissionsSummary returns permission summaries for all clusters
+// GetPermissionsSummary returns permission summaries for all clusters.
+// SECURITY: Restricted to admin users to prevent non-admin users from
+// reading per-cluster permission summaries (#5465).
 func (h *RBACHandler) GetPermissionsSummary(c *fiber.Ctx) error {
+	userID := middleware.GetUserID(c)
+	currentUser, err := h.store.GetUser(userID)
+	if err != nil || currentUser == nil {
+		return fiber.NewError(fiber.StatusUnauthorized, "Unauthorized")
+	}
+
+	if currentUser.Role != models.UserRoleAdmin {
+		slog.Warn("[rbac] SECURITY: non-admin attempted to read permissions summary",
+			"user_id", currentUser.ID,
+			"github_login", currentUser.GitHubLogin)
+		return fiber.NewError(fiber.StatusForbidden, "Admin access required")
+	}
+
 	if h.k8sClient == nil {
 		return fiber.NewError(fiber.StatusServiceUnavailable, "Kubernetes client not available")
 	}


### PR DESCRIPTION
## Summary

- Add admin role authorization checks to 7 RBAC/user-management endpoints that previously allowed any authenticated user to access sensitive cluster RBAC information
- Follows the same pattern established in `ListConsoleUsers` (PR #5464): verify user via `middleware.GetUserID` + `store.GetUser`, check `UserRoleAdmin`, return 403 with security warning log for non-admin attempts

### Endpoints secured:
| Endpoint | Issue |
|---|---|
| `GetUserManagementSummary` | #5459 |
| `ListK8sRoles` | #5460 |
| `ListK8sRoleBindings` | #5461 |
| `ListK8sUsers` | #5462 |
| `ListOpenShiftUsers` | #5463 |
| `GetPermissionsSummary` | #5465 |
| `GetNamespaceAccess` | #5466 |

### Files changed:
- `pkg/api/handlers/rbac.go` — 6 endpoints secured
- `pkg/api/handlers/namespaces.go` — 1 endpoint secured

Fixes #5459, Fixes #5460, Fixes #5461, Fixes #5462, Fixes #5463, Fixes #5465, Fixes #5466

## Test plan
- [ ] Verify `go build ./...` passes
- [ ] Verify non-admin users receive 403 on all 7 endpoints
- [ ] Verify admin users can still access all 7 endpoints normally
- [ ] Verify security warning logs are emitted for non-admin attempts