### PR TITLE
fix: resolve 8 mission execution bugs

### DIFF
--- a/web/src/components/dashboard/AiGenerationPanel.tsx
+++ b/web/src/components/dashboard/AiGenerationPanel.tsx
@@ -46,22 +46,24 @@ export function AiGenerationPanel<T>({
   // Track the active mission
   const trackedMission = missionId ? missions.find(m => m.id === missionId) : null
 
-  // Update streaming text from mission messages
+  // Update streaming text from mission messages.
+  // Concatenate ALL assistant messages (not just the last one) because tool-use
+  // gaps can split a single response across multiple message bubbles (#5483).
   useEffect(() => {
     if (!trackedMission || phase !== 'generating') return
 
     const assistantMessages = trackedMission.messages.filter(m => m.role === 'assistant')
-    const lastMsg = assistantMessages[assistantMessages.length - 1]
-    if (lastMsg) {
-      setStreamingText(lastMsg.content)
+    const combinedContent = assistantMessages.map(m => m.content).join('')
+    if (combinedContent) {
+      setStreamingText(combinedContent)
     }
 
     // Check for completion
     if (
       (trackedMission.status === 'waiting_input' || trackedMission.status === 'completed') &&
-      lastMsg
+      combinedContent
     ) {
-      const { data, error } = extractJsonFromMarkdown<unknown>(lastMsg.content)
+      const { data, error } = extractJsonFromMarkdown<unknown>(combinedContent)
       if (data) {
         const validation = validateResult(data)
         if (validation.valid) {

--- a/web/src/components/layout/mission-sidebar/MissionChat.tsx
+++ b/web/src/components/layout/mission-sidebar/MissionChat.tsx
@@ -41,7 +41,7 @@ import { MemoizedMessage } from './MemoizedMessage'
 
 export function MissionChat({ mission, isFullScreen = false, fontSize = 'base' as FontSize, onToggleFullScreen }: { mission: Mission; isFullScreen?: boolean; fontSize?: FontSize; onToggleFullScreen?: () => void }) {
   const { t } = useTranslation('common')
-  const { sendMessage, retryPreflight, cancelMission, rateMission, setActiveMission, dismissMission, renameMission, runSavedMission, updateSavedMission, selectedAgent } = useMissions()
+  const { sendMessage, retryPreflight, cancelMission, rateMission, setActiveMission, dismissMission, renameMission, runSavedMission, updateSavedMission } = useMissions()
   const { user } = useAuth()
   const { isDemoMode } = useDemoMode()
   const { findSimilarResolutions, recordUsage } = useResolutions()
@@ -754,19 +754,19 @@ export function MissionChat({ mission, isFullScreen = false, fontSize = 'base' a
           </div>
         )}
 
-        {/* Typing indicator when agent is working - uses currently selected agent */}
+        {/* Typing indicator when agent is working — always shows the agent
+            the mission was started with, not the current global selection (#5480) */}
         {mission.status === 'running' && (
           <div className="flex gap-3">
             <div className="w-8 h-8 rounded-full flex items-center justify-center flex-shrink-0 bg-purple-500/20">
               <AgentIcon
                 provider={
-                  // Use selectedAgent (currently processing) instead of mission.agent (original)
-                  (selectedAgent || mission.agent) === 'claude' ? 'anthropic' :
-                  (selectedAgent || mission.agent) === 'openai' ? 'openai' :
-                  (selectedAgent || mission.agent) === 'gemini' ? 'google' :
-                  (selectedAgent || mission.agent) === 'bob' ? 'bob' :
-                  (selectedAgent || mission.agent) === 'claude-code' ? 'anthropic-local' :
-                  (selectedAgent || mission.agent || 'anthropic')
+                  (mission.agent || 'anthropic') === 'claude' ? 'anthropic' :
+                  (mission.agent || 'anthropic') === 'openai' ? 'openai' :
+                  (mission.agent || 'anthropic') === 'gemini' ? 'google' :
+                  (mission.agent || 'anthropic') === 'bob' ? 'bob' :
+                  (mission.agent || 'anthropic') === 'claude-code' ? 'anthropic-local' :
+                  (mission.agent || 'anthropic')
                 }
                 className="w-4 h-4"
               />
@@ -799,20 +799,18 @@ export function MissionChat({ mission, isFullScreen = false, fontSize = 'base' a
           </div>
         ) : mission.status === 'running' ? (
           <div className="flex flex-col gap-2">
+            {/* Input is disabled while mission is running to prevent interleaved
+                responses from concurrent requests (#5478). Only cancel is allowed. */}
             <div className="flex gap-2 min-w-0">
               <input
-                ref={inputRef}
                 type="text"
-                value={input}
-                onChange={(e) => { setInput(e.target.value); setInputError(null) }}
-                onKeyDown={handleKeyDown}
-                placeholder={t('missionChat.typeNextMessage')}
-                className="flex-1 min-w-0 px-3 py-2 text-sm bg-secondary/50 border border-border rounded-lg text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-primary"
+                disabled
+                placeholder={t('missionChat.waitingForAgent', { defaultValue: 'Waiting for agent to finish...' })}
+                className="flex-1 min-w-0 px-3 py-2 text-sm bg-secondary/30 border border-border rounded-lg text-muted-foreground placeholder:text-muted-foreground/60 cursor-not-allowed"
               />
               <button
-                onClick={handleSend}
-                disabled={!input.trim()}
-                className="flex-shrink-0 px-3 py-2 bg-primary text-primary-foreground rounded-lg hover:bg-primary/80 disabled:opacity-50 disabled:cursor-not-allowed"
+                disabled
+                className="flex-shrink-0 px-3 py-2 bg-primary text-primary-foreground rounded-lg disabled:opacity-50 disabled:cursor-not-allowed"
                 title={t('missionChat.sendWillQueue')}
               >
                 <Send className="w-4 h-4" />

--- a/web/src/hooks/useMissions.tsx
+++ b/web/src/hooks/useMissions.tsx
@@ -190,6 +190,27 @@ const MISSION_INACTIVITY_TIMEOUT_MS = 90_000 // 90 seconds of stream silence
  */
 const CANCEL_ACK_TIMEOUT_MS = 10_000 // 10 seconds
 
+/**
+ * Strip interactive terminal prompt artifacts from agent metadata strings (#5482).
+ * Interactive agents (e.g. copilot-cli) sometimes leak prompt text, ANSI escape
+ * codes, or selection indicators into their description or displayName fields.
+ */
+function stripInteractiveArtifacts(text: string): string {
+  if (!text) return text
+  return text
+    // Remove ANSI escape codes (colors, cursor movement, etc.)
+    // eslint-disable-next-line no-control-regex
+    .replace(/\x1B\[[0-9;]*[A-Za-z]/g, '')
+    // Remove interactive prompt indicators (? prompt, > selection, etc.)
+    .replace(/^[?>]\s+/gm, '')
+    // Remove lines that look like interactive menu items
+    .replace(/^\s*[-*]\s+\[.\]\s+/gm, '')
+    // Remove carriage returns and excess whitespace
+    .replace(/\r/g, '')
+    .replace(/\n{2,}/g, '\n')
+    .trim()
+}
+
 /** Pre-converted demo missions for demo mode — showcases all mission types */
 const DEMO_MISSIONS_AS_MISSIONS: Mission[] = DEMO_MISSIONS.map(m => ({
   ...m,
@@ -743,7 +764,14 @@ Install the console locally with the KubeStellar Console agent to use AI mission
     // Handle agent-related messages (no mission ID needed)
     if (message.type === 'agents_list') {
       const payload = message.payload as AgentsListPayload
-      setAgents(payload.agents)
+      // Sanitize agent metadata — strip interactive prompt artifacts that leak
+      // from terminal-based agents (e.g. copilot-cli) into description fields (#5482).
+      const sanitizedAgents = payload.agents.map(agent => ({
+        ...agent,
+        description: stripInteractiveArtifacts(agent.description),
+        displayName: stripInteractiveArtifacts(agent.displayName),
+      }))
+      setAgents(sanitizedAgents)
       setDefaultAgent(payload.defaultAgent)
       // Prefer persisted selection if the agent is still available.
       // If persisted is 'none' but an agent IS available, auto-select it
@@ -753,16 +781,21 @@ Install the console locally with the KubeStellar Console agent to use AI mission
       const persistedAvailable = persisted && persisted !== 'none' && payload.agents.some(a => a.name === persisted && a.available)
 
       // When auto-selecting, prefer agents that execute commands directly over
-      // agents that only suggest commands (e.g. copilot-cli). This prevents
-      // missions from returning kubectl commands as text instead of running them (#3609).
-      const SUGGEST_ONLY_AGENTS = new Set(['copilot-cli', 'gh-copilot'])
+      // agents that only suggest commands (e.g. copilot-cli). Interactive/suggest-only
+      // agents produce terminal prompts instead of executing missions (#3609, #5481).
+      const INTERACTIVE_AGENTS = new Set(['copilot-cli', 'gh-copilot'])
       const bestAvailable = hasAvailableAgent
-        ? (payload.agents.find(a => a.available && ((a.capabilities ?? 0) & AgentCapabilityToolExec) !== 0 && !SUGGEST_ONLY_AGENTS.has(a.name))?.name
-          || payload.agents.find(a => a.available && !SUGGEST_ONLY_AGENTS.has(a.name))?.name
+        ? (payload.agents.find(a => a.available && ((a.capabilities ?? 0) & AgentCapabilityToolExec) !== 0 && !INTERACTIVE_AGENTS.has(a.name))?.name
+          || payload.agents.find(a => a.available && !INTERACTIVE_AGENTS.has(a.name))?.name
           || payload.agents.find(a => a.available)?.name
           || null)
         : null
-      const resolved = persistedAvailable ? persisted : (payload.selected || payload.defaultAgent || bestAvailable)
+      // Filter the backend's defaultAgent if it is interactive — fall through to
+      // bestAvailable which already excludes interactive agents (#5481).
+      const safeDefaultAgent = payload.defaultAgent && !INTERACTIVE_AGENTS.has(payload.defaultAgent)
+        ? payload.defaultAgent
+        : null
+      const resolved = persistedAvailable ? persisted : (payload.selected || safeDefaultAgent || bestAvailable)
       setSelectedAgent(resolved)
       // If we restored a persisted agent that differs from the server's selection, tell the server
       if (persistedAvailable && persisted !== payload.selected && wsRef.current?.readyState === WebSocket.OPEN) {
@@ -978,9 +1011,14 @@ Install the console locally with the KubeStellar Console agent to use AI mission
           resultContent.length > 0 &&
           streamedSinceUser.startsWith(resultContent.slice(0, Math.min(resultContent.length, streamedSinceUser.length)))
 
+        // Transition to 'completed' when a result message arrives — this is the
+        // backend's final answer for the current turn. The 'waiting_input' state
+        // is only used while streaming is in progress (stream done w/o result).
+        // The UI shows a completion panel with feedback buttons when status is
+        // 'completed', so reaching this state is the correct lifecycle end (#5479).
         return {
           ...m,
-          status: 'waiting_input' as MissionStatus,
+          status: 'completed' as MissionStatus,
           currentStep: undefined,
           updatedAt: new Date(),
           agent: chatPayload.agent || m.agent,
@@ -1548,12 +1586,11 @@ Install the console locally with the KubeStellar Console agent to use AI mission
     // Guard against double-cancel: if already cancelling, don't schedule another timeout
     if (cancelTimeouts.current.has(missionId)) return
 
-    // Immediately purge ALL pending request IDs for this mission so that late
-    // responses (from earlier failed or in-flight requests) are dropped before
-    // finalizeCancellation runs (#4499).
-    for (const [reqId, mId] of pendingRequests.current.entries()) {
-      if (mId === missionId) pendingRequests.current.delete(reqId)
-    }
+    // Keep pendingRequests intact so that terminal messages (result, stream-done)
+    // from the backend can still be matched to the mission. The handler for
+    // 'cancelling' missions (below) treats any terminal message as implicit
+    // cancel confirmation, so clearing these prematurely caused the mission to
+    // stay in 'cancelling' until the client-side timeout (#5476).
     lastStreamTimestamp.current.delete(missionId)
 
     // Try WebSocket first (fastest path when connected)
@@ -1564,12 +1601,24 @@ Install the console locally with the KubeStellar Console agent to use AI mission
         payload: { sessionId: missionId } }))
     } else {
       // HTTP fallback — WS may be disconnected during long agent runs.
-      // Use the response to determine if cancellation succeeded.
+      // Use the response body to determine if cancellation succeeded (#5477).
       fetch(`${LOCAL_AGENT_HTTP_URL}/cancel-chat`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ sessionId: missionId }) }).then(response => {
+        body: JSON.stringify({ sessionId: missionId }) }).then(async response => {
         if (response.ok) {
+          // Check the `cancelled` flag in the response body — HTTP 200 alone
+          // does not guarantee the session was actually cancelled (e.g. if the
+          // session was already finished or the ID was invalid).
+          try {
+            const body = await response.json() as { cancelled?: boolean; message?: string }
+            if (body.cancelled === false) {
+              finalizeCancellation(missionId, body.message || 'Mission cancellation failed — backend indicated the session was not cancelled.')
+              return
+            }
+          } catch {
+            // Body parsing failed — treat HTTP 200 as success (best effort)
+          }
           finalizeCancellation(missionId, 'Mission cancelled by user.')
         } else {
           finalizeCancellation(missionId, 'Mission cancellation failed — backend returned an error. The mission may still be running.')
@@ -1618,6 +1667,13 @@ Install the console locally with the KubeStellar Console agent to use AI mission
     const isStopCommand = STOP_KEYWORDS.some(kw => content.trim().toLowerCase() === kw)
     if (isStopCommand) {
       cancelMission(missionId)
+      return
+    }
+
+    // Prevent sending while mission is already running or cancelling (#5478).
+    // Only stop commands (handled above) are allowed during active execution.
+    const currentMission = missionsRef.current.find(m => m.id === missionId)
+    if (currentMission && (currentMission.status === 'running' || currentMission.status === 'cancelling')) {
       return
     }
 


### PR DESCRIPTION
## Summary

Fixes 8 bugs in the AI mission execution system:

- **#5476** — Cancel stays in cancelling state: Keep `pendingRequests` during cancel so terminal messages (stream-done, result) from the backend finalize the cancelling state immediately instead of waiting for the 10s client-side timeout
- **#5477** — Cancel fallback reports false success: Check the `cancelled` flag in the HTTP cancel fallback response body instead of treating any HTTP 200 as success
- **#5478** — Multiple prompts during execution: Block `sendMessage` while mission is running/cancelling and disable the input field in the UI to prevent interleaved responses from concurrent requests
- **#5479** — Mission never completes: Transition mission to `completed` (not `waiting_input`) when the backend sends a `result` message, enabling the completion panel with feedback buttons
- **#5480** — Wrong agent shown after switching: Show the agent the mission was started with (`mission.agent`) in the typing indicator instead of the current global selection (`selectedAgent`)
- **#5481** — Default agent picks interactive agent: Filter interactive/suggest-only agents (`copilot-cli`, `gh-copilot`) from default agent auto-selection when the backend reports them as the default
- **#5482** — Agent metadata has prompt artifacts: Strip ANSI escape codes, interactive prompt indicators (`?`, `>`), and menu selection artifacts from agent metadata `description` and `displayName` fields
- **#5483** — AI generation fails on split messages: Concatenate all assistant messages for a turn before parsing in `AiGenerationPanel` instead of only reading the last one

Closes #5476, #5477, #5478, #5479, #5480, #5481, #5482, #5483

## Files changed

- `web/src/hooks/useMissions.tsx` — Core fixes for cancel flow, sendMessage guard, completion state, agent selection, metadata sanitization
- `web/src/components/layout/mission-sidebar/MissionChat.tsx` — Disable input during running state, fix typing indicator agent display
- `web/src/components/dashboard/AiGenerationPanel.tsx` — Concatenate split assistant messages

## Test plan

- [ ] Start a mission and verify it transitions to `completed` after the agent finishes
- [ ] Cancel a running mission and verify immediate state transition (no 10s delay)
- [ ] Verify input is disabled while a mission is running (only cancel allowed)
- [ ] Switch global agent while a mission is running and verify the typing indicator still shows the original agent
- [ ] Test HTTP cancel fallback with an invalid session ID and verify error message
- [ ] Verify agent descriptions are clean (no ANSI codes or prompt artifacts)
- [ ] Test AI generation with a response that splits across multiple assistant messages