### PR TITLE
fix: resolve sendMessage test failures and cluster health inconsistency

### DIFF
--- a/web/src/components/clusters/ClusterDetailModal.tsx
+++ b/web/src/components/clusters/ClusterDetailModal.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react'
 import { X, CheckCircle, AlertTriangle, WifiOff, Pencil, ChevronRight, ChevronDown, Layers, Server, Network, HardDrive, Box, FolderOpen, Loader2, Cpu, MemoryStick, Database, Wand2, Stethoscope, Wrench, Bot, ExternalLink } from 'lucide-react'
 import { BaseModal } from '../../lib/modals'
 import { useClusterHealth, usePodIssues, useDeploymentIssues, useGPUNodes, useNodes, useNamespaceStats, useDeployments, useClusters } from '../../hooks/useMCP'
+import { isClusterUnreachable, isClusterHealthy } from './utils'
 import { useDrillDownActions } from '../../hooks/useDrillDown'
 import { useMissions } from '../../hooks/useMissions'
 import { emitClusterAction } from '../../lib/analytics'
@@ -233,14 +234,10 @@ After I approve, help me execute the repairs step by step.`,
     onClose()
   }
 
-  // Determine cluster status - use same logic as utils.ts
-  // Only mark as unreachable when we have confirmed unreachable status, not when loading
-  const isUnreachable = health ? (
-    health.reachable === false ||
-    (health.errorType && ['timeout', 'network', 'certificate'].includes(health.errorType)) ||
-    health.nodeCount === 0
-  ) : false
-  const isHealthy = !isLoading && !isUnreachable && health?.healthy !== false
+  // Determine cluster status using the SAME shared helpers as the list view
+  // so that health badges are always consistent (#5487).
+  const isUnreachable = clusterInfo ? isClusterUnreachable(clusterInfo) : false
+  const isHealthy = clusterInfo ? isClusterHealthy(clusterInfo) : (!isLoading && health?.healthy !== false)
 
   // Group GPUs by type for summary
   const gpuByType = (() => {

--- a/web/src/hooks/useMissions.test.tsx
+++ b/web/src/hooks/useMissions.test.tsx
@@ -393,7 +393,16 @@ describe('startMission', () => {
 describe('sendMessage', () => {
   it('appends a user message to the correct mission', async () => {
     const { result } = renderHook(() => useMissions(), { wrapper })
-    const { missionId } = await startMissionWithConnection(result)
+    const { missionId, requestId } = await startMissionWithConnection(result)
+
+    // Transition to waiting_input so sendMessage is not blocked (#5478 guard)
+    act(() => {
+      MockWebSocket.lastInstance?.simulateMessage({
+        id: requestId,
+        type: 'stream',
+        payload: { content: '', done: true },
+      })
+    })
 
     act(() => {
       result.current.sendMessage(missionId, 'follow-up question')
@@ -407,7 +416,17 @@ describe('sendMessage', () => {
 
   it('sends the message payload over the WebSocket', async () => {
     const { result } = renderHook(() => useMissions(), { wrapper })
-    const { missionId } = await startMissionWithConnection(result)
+    const { missionId, requestId } = await startMissionWithConnection(result)
+
+    // Transition to waiting_input so sendMessage is not blocked (#5478 guard)
+    act(() => {
+      MockWebSocket.lastInstance?.simulateMessage({
+        id: requestId,
+        type: 'stream',
+        payload: { content: '', done: true },
+      })
+    })
+
     const beforeCallCount = MockWebSocket.lastInstance!.send.mock.calls.length
 
     await act(async () => {


### PR DESCRIPTION
## Summary
- **#5486**: Fix 2 failing `sendMessage` tests in `useMissions.test.tsx` — PR #5485 added a guard that blocks `sendMessage` while mission status is `running`. The tests now transition the mission to `waiting_input` (via simulated `stream done:true`) before calling `sendMessage`, matching the real user flow.
- **#5487**: Fix cluster health badge inconsistency between list view and detail view — the detail modal had inline health logic that diverged from the shared `isClusterHealthy`/`isClusterUnreachable` utilities used by the list view. Now both views use the same shared helpers from `utils.ts`.

## Test plan
- [x] `npx vitest run src/hooks/useMissions.test.tsx -t "sendMessage"` — all 22 tests pass
- [x] `npm run build` — clean build
- [x] Lint check on changed files — no new errors

Closes #5486
Closes #5487