### PR TITLE
🐛 Fix multi-arch build and Node 22 upgrade

### DIFF
--- a/.github/workflows/auto-qa.yml
+++ b/.github/workflows/auto-qa.yml
@@ -42,7 +42,7 @@ env:
   ASSIGN_COPILOT: 'false'  # Set to 'true' to auto-assign Copilot to created issues
   COPILOT_ASSIGNMENT_DELAY_S: 120  # Seconds between Copilot assignments to avoid rate limiting
   ISSUE_PREFIX: "[Auto-QA]"
-  NODE_VERSION: "20"
+  NODE_VERSION: "22"
   GO_VERSION: "1.23"
 
 permissions:

--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -60,6 +60,9 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392 # v3.6.0
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3.10.0
 
@@ -89,6 +92,7 @@ jobs:
         with:
           context: .
           push: ${{ github.event_name != 'pull_request' }}
+          platforms: linux/amd64,linux/arm64
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |

--- a/.github/workflows/card-standard-nightly.yml
+++ b/.github/workflows/card-standard-nightly.yml
@@ -24,7 +24,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22'
           cache: 'npm'
           cache-dependency-path: web/package-lock.json
 

--- a/.github/workflows/copilot-build-check.yml
+++ b/.github/workflows/copilot-build-check.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Setup Node.js 20
         uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          node-version: "22"
           cache: "npm"
           cache-dependency-path: web/package-lock.json
 

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Setup Node.js 20
         uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          node-version: "22"
           cache: "npm"
           cache-dependency-path: web/package-lock.json
 

--- a/.github/workflows/ga4-error-monitor.yml
+++ b/.github/workflows/ga4-error-monitor.yml
@@ -51,7 +51,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22'
 
       - name: Install googleapis
         run: npm install googleapis@144

--- a/.github/workflows/nightly-compliance.yml
+++ b/.github/workflows/nightly-compliance.yml
@@ -22,7 +22,7 @@ on:
 
 env:
   CI: true
-  NODE_VERSION: '20'
+  NODE_VERSION: '22'
   PREVIEW_PORT: 4174
 
 permissions:

--- a/.github/workflows/nightly-dashboard-health.yml
+++ b/.github/workflows/nightly-dashboard-health.yml
@@ -21,7 +21,7 @@ on:
 
 env:
   CI: true
-  NODE_VERSION: '20'
+  NODE_VERSION: '22'
 
 permissions:
   contents: read

--- a/.github/workflows/perf-ttfi.yml
+++ b/.github/workflows/perf-ttfi.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22'
           cache: 'npm'
           cache-dependency-path: web/package-lock.json
 

--- a/.github/workflows/playwright-nightly.yml
+++ b/.github/workflows/playwright-nightly.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22'
           cache: 'npm'
           cache-dependency-path: web/package-lock.json
 
@@ -62,7 +62,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22'
           cache: 'npm'
           cache-dependency-path: web/package-lock.json
 

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22'
           cache: 'npm'
           cache-dependency-path: web/package-lock.json
 
@@ -67,7 +67,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22'
           cache: 'npm'
           cache-dependency-path: web/package-lock.json
 
@@ -116,7 +116,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22'
           cache: 'npm'
           cache-dependency-path: web/package-lock.json
 
@@ -250,7 +250,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22'
           cache: 'npm'
           cache-dependency-path: web/package-lock.json
 
@@ -302,7 +302,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22'
           cache: 'npm'
           cache-dependency-path: web/package-lock.json
 
@@ -347,7 +347,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22'
           cache: 'npm'
           cache-dependency-path: web/package-lock.json
 

--- a/.github/workflows/post-merge-verify.yml
+++ b/.github/workflows/post-merge-verify.yml
@@ -21,7 +21,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  NODE_VERSION: '20'
+  NODE_VERSION: '22'
   PRODUCTION_URL: 'https://console.kubestellar.io'
   # Maximum time (seconds) to wait for Netlify deploy
   DEPLOY_WAIT_MAX_SECONDS: 300

--- a/.github/workflows/pr-closed-verification.yml
+++ b/.github/workflows/pr-closed-verification.yml
@@ -14,7 +14,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  NODE_VERSION: '20'
+  NODE_VERSION: '22'
   # Timeout for the entire verification job (minutes)
   JOB_TIMEOUT_MINUTES: 15
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -168,7 +168,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@1d0ff469b7ec7b3cb9d8673fde0c81c44821de2a # v4.2.0
         with:
-          node-version: '20'
+          node-version: '22'
           cache: 'npm'
           cache-dependency-path: web/package-lock.json
 
@@ -210,9 +210,12 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@1d0ff469b7ec7b3cb9d8673fde0c81c44821de2a # v4.2.0
         with:
-          node-version: '20'
+          node-version: '22'
           cache: 'npm'
           cache-dependency-path: web/package-lock.json
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392 # v3.6.0
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3.10.0
@@ -256,6 +259,7 @@ jobs:
         with:
           context: .
           push: true
+          platforms: linux/amd64,linux/arm64
           tags: |
             ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ needs.determine-version.outputs.version }}
             ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ needs.determine-version.outputs.release_type }}

--- a/.github/workflows/startup-smoke.yml
+++ b/.github/workflows/startup-smoke.yml
@@ -37,7 +37,7 @@ concurrency:
 
 env:
   GO_VERSION: '1.23'
-  NODE_VERSION: '20'
+  NODE_VERSION: '22'
 
 jobs:
   # Test startup-demo.sh (no OAuth required, fastest to validate)

--- a/.github/workflows/ui-ux-standard.yml
+++ b/.github/workflows/ui-ux-standard.yml
@@ -25,7 +25,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22'
           cache: 'npm'
           cache-dependency-path: web/package-lock.json
 

--- a/.github/workflows/visual-regression.yml
+++ b/.github/workflows/visual-regression.yml
@@ -24,7 +24,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22'
           cache: 'npm'
           cache-dependency-path: web/package-lock.json
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,14 +10,15 @@ RUN go mod download
 # Copy source
 COPY . .
 
-# Build args for version
+# Build args for version and target architecture
 ARG APP_VERSION=dev
+ARG TARGETARCH
 
-# Build
-RUN CGO_ENABLED=0 GOOS=linux go build -ldflags="-s -w -X github.com/kubestellar/console/pkg/api.Version=${APP_VERSION}" -o console ./cmd/console
+# Build for the target platform (TARGETARCH is set automatically by buildx)
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=${TARGETARCH} go build -ldflags="-s -w -X github.com/kubestellar/console/pkg/api.Version=${APP_VERSION}" -o console ./cmd/console
 
 # Build stage - Frontend
-FROM node:20-alpine AS frontend-builder
+FROM node:22-alpine AS frontend-builder
 
 WORKDIR /app
 


### PR DESCRIPTION
## Summary
- **Dockerfile**: Upgrade frontend stage from `node:20-alpine` to `node:22-alpine` to satisfy dependencies requiring Node >=22 (`@sqlite.org/sqlite-wasm`, `camera-controls`). Add `TARGETARCH` build arg to Go backend stage for correct cross-compilation on ARM.
- **release.yml**: Add `docker/setup-qemu-action` and `platforms: linux/amd64,linux/arm64` to `docker/build-push-action` so release images are published as multi-arch manifests. Update Node from 20 to 22.
- **build-deploy.yml**: Same QEMU + multi-platform addition for CI images pushed on merge to main.
- **All CI workflows**: Update Node.js version from 20 to 22 across 15 workflow files for consistency.

Fixes #5497 (Node 20 -> 22), #5496 (single-arch release image), #5495 (ARM kind cluster image pull failure).

## Test plan
- [ ] CI build passes (Dockerfile builds correctly with node:22-alpine)
- [ ] Release workflow produces multi-arch manifest (`linux/amd64` + `linux/arm64`)
- [ ] Image runs on ARM kind clusters without `ErrImagePull`
- [ ] No EBADENGINE warnings during `npm ci` in container build