### PR TITLE
🐛 Fix deploy mission state and polling bugs

### DIFF
--- a/web/src/hooks/__tests__/useDeployMissions-expand.test.ts
+++ b/web/src/hooks/__tests__/useDeployMissions-expand.test.ts
@@ -226,19 +226,19 @@ describe('useDeployMissions — expanded edge cases', () => {
     expect(result.current.hasActive).toBe(true)
   })
 
-  // 6. activeMissions and completedMissions are correctly categorized
+  // 6. activeMissions and completedMissions are correctly categorized (partial is terminal)
   it('correctly categorizes active vs completed missions', () => {
     const missions = [
       makeMission({ id: 'a', status: 'deploying' }),
       makeMission({ id: 'b', status: 'launching' }),
       makeMission({ id: 'c', status: 'orbit', completedAt: Date.now() }),
       makeMission({ id: 'd', status: 'abort', completedAt: Date.now() }),
-      makeMission({ id: 'e', status: 'partial' }),
+      makeMission({ id: 'e', status: 'partial', completedAt: Date.now() }),
     ]
     localStorage.setItem(MISSIONS_STORAGE_KEY, JSON.stringify(missions))
     const { result } = renderHook(() => useDeployMissions())
-    expect(result.current.activeMissions.map(m => m.id)).toEqual(expect.arrayContaining(['a', 'b', 'e']))
-    expect(result.current.completedMissions.map(m => m.id)).toEqual(expect.arrayContaining(['c', 'd']))
+    expect(result.current.activeMissions.map(m => m.id)).toEqual(expect.arrayContaining(['a', 'b']))
+    expect(result.current.completedMissions.map(m => m.id)).toEqual(expect.arrayContaining(['c', 'd', 'e']))
   })
 
   // 7. Poll fetches deployment status via agent

--- a/web/src/hooks/__tests__/useDeployMissions.test.ts
+++ b/web/src/hooks/__tests__/useDeployMissions.test.ts
@@ -336,43 +336,43 @@ describe('useDeployMissions', () => {
   })
 
   // =========================================================================
-  // 10. clearCompleted removes orbit and abort missions
+  // 10. clearCompleted removes orbit, abort, and partial missions
   // =========================================================================
-  it('clearCompleted removes only completed missions', () => {
+  it('clearCompleted removes only completed missions (orbit, abort, partial)', () => {
     const missions = [
       makeMission({ id: 'active-1', status: 'deploying' }),
       makeMission({ id: 'done-1', status: 'orbit', completedAt: Date.now() }),
       makeMission({ id: 'failed-1', status: 'abort', completedAt: Date.now() }),
-      makeMission({ id: 'partial-1', status: 'partial' }),
+      makeMission({ id: 'partial-1', status: 'partial', completedAt: Date.now() }),
     ]
     localStorage.setItem(MISSIONS_STORAGE_KEY, JSON.stringify(missions))
 
     const { result } = renderHook(() => useDeployMissions())
-    expect(result.current.completedMissions).toHaveLength(2)
+    expect(result.current.completedMissions).toHaveLength(3)
 
     act(() => { result.current.clearCompleted() })
 
-    expect(result.current.missions).toHaveLength(2)
+    expect(result.current.missions).toHaveLength(1)
     expect(result.current.completedMissions).toHaveLength(0)
-    expect(result.current.missions.map(m => m.id)).toEqual(['active-1', 'partial-1'])
+    expect(result.current.missions.map(m => m.id)).toEqual(['active-1'])
   })
 
   // =========================================================================
-  // 11. activeMissions and completedMissions filtering
+  // 11. activeMissions and completedMissions filtering (partial is terminal)
   // =========================================================================
   it('correctly separates active and completed missions', () => {
     const missions = [
       makeMission({ id: 'launch', status: 'launching' }),
       makeMission({ id: 'deploy', status: 'deploying' }),
-      makeMission({ id: 'partial', status: 'partial' }),
+      makeMission({ id: 'partial', status: 'partial', completedAt: Date.now() }),
       makeMission({ id: 'orbit', status: 'orbit', completedAt: Date.now() }),
       makeMission({ id: 'abort', status: 'abort', completedAt: Date.now() }),
     ]
     localStorage.setItem(MISSIONS_STORAGE_KEY, JSON.stringify(missions))
 
     const { result } = renderHook(() => useDeployMissions())
-    expect(result.current.activeMissions).toHaveLength(3)
-    expect(result.current.completedMissions).toHaveLength(2)
+    expect(result.current.activeMissions).toHaveLength(2)
+    expect(result.current.completedMissions).toHaveLength(3)
     expect(result.current.hasActive).toBe(true)
   })
 
@@ -1233,5 +1233,281 @@ describe('useDeployMissions', () => {
     await advancePastInitialPoll()
 
     expect(fetchSpy).not.toHaveBeenCalled()
+  })
+
+  // =========================================================================
+  // 41. #5501: partial mission reaches terminal state with completedAt
+  // =========================================================================
+  it('treats partial as terminal and sets completedAt', async () => {
+    const startedAt = Date.now() - MIN_ACTIVE_MS - 1
+    const missions = [makeMission({
+      id: 'partial-terminal', status: 'deploying', startedAt,
+      targetClusters: ['c1', 'c2'],
+      clusterStatuses: [
+        { cluster: 'c1', status: 'pending', replicas: 0, readyReplicas: 0 },
+        { cluster: 'c2', status: 'pending', replicas: 0, readyReplicas: 0 },
+      ],
+    })]
+    localStorage.setItem(MISSIONS_STORAGE_KEY, JSON.stringify(missions))
+
+    mockClusterCacheRef.clusters = [
+      { name: 'c1', context: 'ctx-c1' },
+      { name: 'c2', context: 'ctx-c2' },
+    ]
+
+    global.fetch = vi.fn().mockImplementation((url: string) => {
+      if (url.includes('cluster=ctx-c1')) {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve({
+            deployments: [{ name: 'nginx', replicas: 1, readyReplicas: 1 }],
+          }),
+        })
+      }
+      return Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve({
+          deployments: [{ name: 'nginx', replicas: 1, readyReplicas: 0, status: 'failed' }],
+        }),
+      })
+    })
+    mockKubectlExec.mockResolvedValue({ exitCode: 1, output: '' })
+
+    const { result } = renderHook(() => useDeployMissions())
+
+    await advancePastInitialPoll()
+
+    expect(result.current.missions[0].status).toBe('partial')
+    expect(result.current.missions[0].completedAt).toBeDefined()
+    // partial is terminal — should appear in completedMissions
+    expect(result.current.completedMissions).toHaveLength(1)
+    expect(result.current.activeMissions).toHaveLength(0)
+  })
+
+  // =========================================================================
+  // 42. #5501: partial mission stops polling after CACHE_TTL when logs exist
+  // =========================================================================
+  it('stops polling partial missions past TTL with existing logs', async () => {
+    const completedAt = Date.now() - CACHE_TTL_MS - 1
+    const missions = [makeMission({
+      id: 'partial-ttl', status: 'partial',
+      startedAt: completedAt - MIN_ACTIVE_MS, completedAt,
+      targetClusters: ['c1', 'c2'],
+      clusterStatuses: [
+        { cluster: 'c1', status: 'running', replicas: 1, readyReplicas: 1, logs: ['ok'] },
+        { cluster: 'c2', status: 'failed', replicas: 1, readyReplicas: 0, logs: ['fail'] },
+      ],
+    })]
+    localStorage.setItem(MISSIONS_STORAGE_KEY, JSON.stringify(missions))
+
+    const fetchSpy = vi.fn()
+    global.fetch = fetchSpy
+
+    renderHook(() => useDeployMissions())
+
+    await advancePastInitialPoll()
+
+    expect(fetchSpy).not.toHaveBeenCalled()
+  })
+
+  // =========================================================================
+  // 43. #5500: event log does not mix workloads with shared prefix
+  // =========================================================================
+  it('excludes events from workloads sharing a prefix (e.g. api vs api-gateway)', async () => {
+    const startedAt = Date.now() - MIN_ACTIVE_MS - 1
+    const missions = [makeMission({
+      id: 'prefix-test', workload: 'api', status: 'deploying', startedAt,
+      targetClusters: ['c1'],
+    })]
+    localStorage.setItem(MISSIONS_STORAGE_KEY, JSON.stringify(missions))
+
+    mockClusterCacheRef.clusters = [{ name: 'c1', context: 'ctx-c1' }]
+
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({
+        deployments: [{ name: 'api', replicas: 1, readyReplicas: 1 }],
+      }),
+    })
+
+    mockKubectlExec.mockResolvedValue({
+      exitCode: 0,
+      output: JSON.stringify({
+        items: [
+          {
+            lastTimestamp: '2024-01-15T10:30:00Z',
+            reason: 'Scaled',
+            message: 'Scaled up api ReplicaSet',
+            involvedObject: { name: 'api' },
+          },
+          {
+            lastTimestamp: '2024-01-15T10:30:01Z',
+            reason: 'Pulled',
+            message: 'Container image pulled',
+            involvedObject: { name: 'api-7f8d9c' },
+          },
+          {
+            lastTimestamp: '2024-01-15T10:30:02Z',
+            reason: 'Started',
+            message: 'Started api-gateway container',
+            involvedObject: { name: 'api-gateway' },
+          },
+          {
+            lastTimestamp: '2024-01-15T10:30:03Z',
+            reason: 'Pulled',
+            message: 'Pulled gateway image',
+            involvedObject: { name: 'api-gateway-5f4d3c' },
+          },
+          {
+            lastTimestamp: '2024-01-15T10:30:04Z',
+            reason: 'Started',
+            message: 'Started gateway pod',
+            involvedObject: { name: 'api-gateway-5f4d3c-ab12c' },
+          },
+        ],
+      }),
+    })
+
+    const { result } = renderHook(() => useDeployMissions())
+
+    await advancePastInitialPoll()
+
+    const logs = result.current.missions[0].clusterStatuses[0].logs
+    expect(logs).toBeDefined()
+    // Only api (exact) and api-7f8d9c (K8s child) — not api-gateway or its children
+    expect(logs!.length).toBe(2)
+    expect(logs!.some(l => l.includes('Scaled up api ReplicaSet'))).toBe(true)
+    expect(logs!.some(l => l.includes('Container image pulled'))).toBe(true)
+    expect(logs!.some(l => l.includes('gateway'))).toBe(false)
+  })
+
+  // =========================================================================
+  // 44. #5499: 401 during deploy is reported as auth error, not unreachable
+  // =========================================================================
+  it('reports auth error for 401 instead of status unreachable', async () => {
+    const startedAt = Date.now() - MIN_ACTIVE_MS - 1
+    const missions = [makeMission({
+      id: 'auth-401', status: 'deploying', startedAt,
+      targetClusters: ['c1'],
+    })]
+    localStorage.setItem(MISSIONS_STORAGE_KEY, JSON.stringify(missions))
+
+    mockClusterCacheRef.clusters = []
+    global.fetch = vi.fn().mockResolvedValue({ ok: false, status: 401 })
+
+    const { result } = renderHook(() => useDeployMissions())
+
+    await advancePastInitialPoll()
+
+    const cs = result.current.missions[0].clusterStatuses[0]
+    expect(cs.status).toBe('failed')
+    expect(cs.logs).toBeDefined()
+    expect(cs.logs![0]).toContain('Authentication failed')
+    expect(cs.logs![0]).toContain('401')
+  })
+
+  // =========================================================================
+  // 45. #5499: 403 during deploy is reported as auth error
+  // =========================================================================
+  it('reports auth error for 403 instead of status unreachable', async () => {
+    const startedAt = Date.now() - MIN_ACTIVE_MS - 1
+    const missions = [makeMission({
+      id: 'auth-403', status: 'deploying', startedAt,
+      targetClusters: ['c1'],
+    })]
+    localStorage.setItem(MISSIONS_STORAGE_KEY, JSON.stringify(missions))
+
+    mockClusterCacheRef.clusters = []
+    global.fetch = vi.fn().mockResolvedValue({ ok: false, status: 403 })
+
+    const { result } = renderHook(() => useDeployMissions())
+
+    await advancePastInitialPoll()
+
+    const cs = result.current.missions[0].clusterStatuses[0]
+    expect(cs.status).toBe('failed')
+    expect(cs.logs).toBeDefined()
+    expect(cs.logs![0]).toContain('Authentication failed')
+    expect(cs.logs![0]).toContain('403')
+  })
+
+  // =========================================================================
+  // 46. #5499: 500 still goes through pendingOrFailed (not auth error)
+  // =========================================================================
+  it('treats 500 as pending (not auth error)', async () => {
+    const startedAt = Date.now() - MIN_ACTIVE_MS - 1
+    const missions = [makeMission({
+      id: 'rest-500', status: 'deploying', startedAt,
+      targetClusters: ['c1'],
+    })]
+    localStorage.setItem(MISSIONS_STORAGE_KEY, JSON.stringify(missions))
+
+    mockClusterCacheRef.clusters = []
+    global.fetch = vi.fn().mockResolvedValue({ ok: false, status: 500 })
+
+    const { result } = renderHook(() => useDeployMissions())
+
+    await advancePastInitialPoll()
+
+    const cs = result.current.missions[0].clusterStatuses[0]
+    expect(cs.status).toBe('pending')
+    // Should NOT have auth error message
+    expect(cs.logs).toBeUndefined()
+  })
+
+  // =========================================================================
+  // 47. #5498: abort timer is cleared on agent fetch failure
+  // =========================================================================
+  it('clears abort timer even when agent fetch throws', async () => {
+    const missions = [makeMission({
+      id: 'timer-leak', status: 'deploying',
+      startedAt: Date.now(), targetClusters: ['c1'],
+    })]
+    localStorage.setItem(MISSIONS_STORAGE_KEY, JSON.stringify(missions))
+
+    mockClusterCacheRef.clusters = [{ name: 'c1', context: 'ctx-c1' }]
+
+    const clearTimeoutSpy = vi.spyOn(global, 'clearTimeout')
+
+    // Agent fetch throws — the finally block should still clear the timer
+    global.fetch = vi.fn().mockRejectedValue(new Error('Agent network failure'))
+
+    renderHook(() => useDeployMissions())
+
+    await advancePastInitialPoll()
+
+    // clearTimeout should have been called for the abort timer (among others)
+    // The abort timer clearTimeout is called in the finally block
+    expect(clearTimeoutSpy).toHaveBeenCalled()
+  })
+
+  // =========================================================================
+  // 48. #5501: saveMissions preserves logs for partial missions
+  // =========================================================================
+  it('preserves logs for partial missions when persisting to localStorage', () => {
+    const missions = [
+      makeMission({
+        id: 'partial-logs', status: 'partial', completedAt: Date.now(),
+        clusterStatuses: [
+          {
+            cluster: 'c1', status: 'running', replicas: 1, readyReplicas: 1,
+            logs: ['success log'],
+          },
+          {
+            cluster: 'c2', status: 'failed', replicas: 1, readyReplicas: 0,
+            logs: ['failure log'],
+          },
+        ],
+      }),
+    ]
+    localStorage.setItem(MISSIONS_STORAGE_KEY, JSON.stringify(missions))
+
+    renderHook(() => useDeployMissions())
+
+    const stored = JSON.parse(localStorage.getItem(MISSIONS_STORAGE_KEY) || '[]')
+    const partialMission = stored.find((m: DeployMission) => m.id === 'partial-logs')
+    // partial is terminal — logs should be preserved, not stripped
+    expect(partialMission.clusterStatuses[0].logs).toEqual(['success log'])
+    expect(partialMission.clusterStatuses[1].logs).toEqual(['failure log'])
   })
 })

--- a/web/src/hooks/useDeployMissions.ts
+++ b/web/src/hooks/useDeployMissions.ts
@@ -6,6 +6,15 @@ import type { DeployStartedPayload, DeployResultPayload, DeployedDep } from '../
 import { LOCAL_AGENT_HTTP_URL, STORAGE_KEY_TOKEN, STORAGE_KEY_MISSIONS_ACTIVE, STORAGE_KEY_MISSIONS_HISTORY } from '../lib/constants'
 import { FETCH_DEFAULT_TIMEOUT_MS, DEPLOY_ABORT_TIMEOUT_MS } from '../lib/constants/network'
 
+/** HTTP status codes that indicate authentication/authorization failure */
+const HTTP_UNAUTHORIZED = 401
+const HTTP_FORBIDDEN = 403
+
+/** Check whether a mission status is terminal (no longer needs active polling) */
+function isTerminalStatus(s: DeployMissionStatus): boolean {
+  return s === 'orbit' || s === 'abort' || s === 'partial'
+}
+
 function authHeaders(): Record<string, string> {
   const token = localStorage.getItem(STORAGE_KEY_TOKEN)
   return token ? { Authorization: `Bearer ${token}` } : {}
@@ -39,10 +48,19 @@ async function fetchDeployEventsViaProxy(
   } catch {
     return []
   }
-  const prefix = workload + '-'
+  // Match the deployment itself and its Kubernetes-generated children.
+  // ReplicaSet names follow the pattern <deployment>-<hash> where the hash
+  // is a 7-10 char alphanumeric string containing at least one digit.
+  // Pod names follow <deployment>-<rs-hash>-<5-char-pod-hash>.
+  // Requiring a digit in the first hash segment distinguishes K8s-generated
+  // suffixes from human-readable names (e.g. "api-gateway" won't match "api").
+  const escapedWorkload = workload.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+  const k8sChildPattern = new RegExp(
+    `^${escapedWorkload}-(?=[a-z0-9]*[0-9])[a-z0-9]{1,10}(-[a-z0-9]{1,5})?$`
+  )
   const relevant = (data.items || []).filter((e: KubeEvent) => {
     const name = e.involvedObject?.name || ''
-    return name === workload || name.startsWith(prefix)
+    return name === workload || k8sChildPattern.test(name)
   })
   return relevant
     .slice(-tail)
@@ -123,12 +141,11 @@ function loadMissions(): DeployMission[] {
 function saveMissions(missions: DeployMission[]) {
   // Keep logs for completed missions (they won't be re-fetched after the poll cutoff).
   // Strip logs for active missions (transient data, re-fetched on each poll cycle).
-  const isTerminal = (s: DeployMissionStatus) => s === 'orbit' || s === 'abort'
   const clean = missions.slice(0, MAX_MISSIONS).map(m => ({
     ...m,
     clusterStatuses: m.clusterStatuses.map(cs => ({
       ...cs,
-      logs: isTerminal(m.status) ? cs.logs : undefined })) }))
+      logs: isTerminalStatus(m.status) ? cs.logs : undefined })) }))
   localStorage.setItem(MISSIONS_STORAGE_KEY, JSON.stringify(clean))
 }
 
@@ -198,7 +215,7 @@ export function useDeployMissions() {
 
       const updated = await Promise.all(
         current.map(async (mission) => {
-          const isCompleted = mission.status === 'orbit' || mission.status === 'abort'
+          const isCompleted = isTerminalStatus(mission.status)
           // Stop polling completed missions after cutoff — unless logs were
           // never loaded (e.g. restored from localStorage after page reload).
           if (isCompleted && mission.completedAt &&
@@ -237,39 +254,43 @@ export function useDeployMissions() {
                   params.append('namespace', mission.namespace)
                   const ctrl = new AbortController()
                   const tid = setTimeout(() => ctrl.abort(), DEPLOY_ABORT_TIMEOUT_MS)
-                  const res = await fetch(`${LOCAL_AGENT_HTTP_URL}/deployments?${params}`, {
-                    signal: ctrl.signal,
-                    headers: { Accept: 'application/json' } })
-                  clearTimeout(tid)
-                  if (res.ok) {
-                    const data = await res.json()
-                    const deployments = (data.deployments || []) as Array<Record<string, unknown>>
-                    const match = deployments.find(
-                      (d) => String(d.name) === mission.workload
-                    )
-                    if (match) {
-                      const replicas = Number(match.replicas ?? 0)
-                      const readyReplicas = Number(match.readyReplicas ?? 0)
-                      let status: DeployClusterStatus['status'] = 'applying'
-                      // Zero-replica workloads are valid (e.g. scale-to-zero) — treat
-                      // readyReplicas >= replicas as success even when both are zero.
-                      if (readyReplicas >= replicas) {
-                        status = 'running'
-                      } else if (String(match.status) === 'failed') {
-                        status = 'failed'
+                  try {
+                    const res = await fetch(`${LOCAL_AGENT_HTTP_URL}/deployments?${params}`, {
+                      signal: ctrl.signal,
+                      headers: { Accept: 'application/json' } })
+                    if (res.ok) {
+                      const data = await res.json()
+                      const deployments = (data.deployments || []) as Array<Record<string, unknown>>
+                      const match = deployments.find(
+                        (d) => String(d.name) === mission.workload
+                      )
+                      if (match) {
+                        const replicas = Number(match.replicas ?? 0)
+                        const readyReplicas = Number(match.readyReplicas ?? 0)
+                        let status: DeployClusterStatus['status'] = 'applying'
+                        // Zero-replica workloads are valid (e.g. scale-to-zero) — treat
+                        // readyReplicas >= replicas as success even when both are zero.
+                        if (readyReplicas >= replicas) {
+                          status = 'running'
+                        } else if (String(match.status) === 'failed') {
+                          status = 'failed'
+                        }
+                        // Fetch K8s events via kubectlProxy
+                        let logs: string[] | undefined
+                        try {
+                          logs = await fetchDeployEventsViaProxy(
+                            clusterInfo.context || cluster, mission.namespace, mission.workload,
+                          )
+                          if (logs.length === 0) logs = undefined
+                        } catch { /* non-critical */ }
+                        return { cluster, status, replicas, readyReplicas, logs }
                       }
-                      // Fetch K8s events via kubectlProxy
-                      let logs: string[] | undefined
-                      try {
-                        logs = await fetchDeployEventsViaProxy(
-                          clusterInfo.context || cluster, mission.namespace, mission.workload,
-                        )
-                        if (logs.length === 0) logs = undefined
-                      } catch { /* non-critical */ }
-                      return { cluster, status, replicas, readyReplicas, logs }
+                      // Workload not found on this cluster yet — still pending (or failed after threshold)
+                      return pendingOrFailed()
                     }
-                    // Workload not found on this cluster yet — still pending (or failed after threshold)
-                    return pendingOrFailed()
+                  } finally {
+                    // Always clear the abort timer to prevent leak on fetch failure (#5498)
+                    clearTimeout(tid)
                   }
                 }
               } catch {
@@ -283,6 +304,14 @@ export function useDeployMissions() {
                   { headers: authHeaders(), signal: AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS) }
                 )
                 if (!res.ok) {
+                  // Surface auth failures explicitly instead of masking as "unreachable" (#5499)
+                  if (res.status === HTTP_UNAUTHORIZED || res.status === HTTP_FORBIDDEN) {
+                    return {
+                      cluster, status: 'failed' as const, replicas: 0, readyReplicas: 0,
+                      consecutiveFailures: prevFailures + 1,
+                      logs: [`Authentication failed (HTTP ${res.status}) — token may be expired or revoked`],
+                    }
+                  }
                   return pendingOrFailed()
                 }
                 const data = await res.json()
@@ -343,7 +372,7 @@ export function useDeployMissions() {
           // Grace period: keep mission in deploying state for at least 10s
           const elapsed = Date.now() - mission.startedAt
           const MIN_ACTIVE_MS = 10000
-          if ((missionStatus === 'orbit' || missionStatus === 'abort') && elapsed < MIN_ACTIVE_MS) {
+          if (isTerminalStatus(missionStatus) && elapsed < MIN_ACTIVE_MS) {
             missionStatus = 'deploying'
           }
 
@@ -352,15 +381,15 @@ export function useDeployMissions() {
             clusterStatuses: statuses,
             status: missionStatus,
             pollCount,
-            completedAt: (missionStatus === 'orbit' || missionStatus === 'abort')
+            completedAt: isTerminalStatus(missionStatus)
               ? (mission.completedAt ?? Date.now())
               : undefined }
         })
       )
 
       // Sort: active missions first (newest first), completed missions below (newest first)
-      const active = updated.filter(m => m.status !== 'orbit' && m.status !== 'abort')
-      const completed = updated.filter(m => m.status === 'orbit' || m.status === 'abort')
+      const active = updated.filter(m => !isTerminalStatus(m.status))
+      const completed = updated.filter(m => isTerminalStatus(m.status))
       active.sort((a, b) => b.startedAt - a.startedAt)
       completed.sort((a, b) => (b.completedAt ?? b.startedAt) - (a.completedAt ?? a.startedAt))
 
@@ -379,11 +408,11 @@ export function useDeployMissions() {
     }
   }, []) // No dependencies - uses ref for current missions
 
-  const activeMissions = missions.filter(m => m.status !== 'orbit' && m.status !== 'abort')
-  const completedMissions = missions.filter(m => m.status === 'orbit' || m.status === 'abort')
+  const activeMissions = missions.filter(m => !isTerminalStatus(m.status))
+  const completedMissions = missions.filter(m => isTerminalStatus(m.status))
 
   const clearCompleted = () => {
-    setMissions(prev => prev.filter(m => m.status !== 'orbit' && m.status !== 'abort'))
+    setMissions(prev => prev.filter(m => !isTerminalStatus(m.status)))
   }
 
   return {


### PR DESCRIPTION
## Summary

Fixes four deploy mission bugs in `useDeployMissions.ts`:

- **#5501** — Partial multi-cluster deploy missions now reach a terminal state. `partial` is treated as terminal alongside `orbit` and `abort`, with `completedAt` set and polling stopped after cache TTL. The `clearCompleted` action now also clears partial missions.
- **#5500** — Deploy event log collection no longer mixes unrelated workloads sharing a prefix (e.g. "api" vs "api-gateway"). Replaced naive prefix matching with a K8s naming pattern regex that requires at least one digit in the hash segment, distinguishing generated suffixes from human-readable names.
- **#5499** — 401/403 responses during deploy polling are now reported as explicit authentication errors instead of being collapsed into the generic "status unreachable" message after N retries.
- **#5498** — Abort timer for agent fetch is now cleaned up in a `finally` block, preventing timer accumulation when fetch repeatedly fails.

## Test plan

- [x] All 60 existing + new tests pass (`vitest run`)
- [x] Build passes (`npm run build`)
- [x] Lint clean on changed files
- [ ] Verify partial missions show in completed list and can be cleared
- [ ] Verify event logs for "api" workload don't include "api-gateway" events
- [ ] Verify expired token shows auth error, not "unreachable"

Closes #5501, #5500, #5499, #5498