### PR TITLE
Fix launch sequence phasing and error handling

### DIFF
--- a/web/src/components/mission-control/LaunchSequence.tsx
+++ b/web/src/components/mission-control/LaunchSequence.tsx
@@ -5,7 +5,7 @@
  * calls startMission() per cluster. Animated checklist with progress.
  */
 
-import { useEffect, useRef, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { motion, AnimatePresence } from 'framer-motion'
 import {
   Rocket,
@@ -22,6 +22,9 @@ import { useMissions } from '../../hooks/useMissions'
 import { loadMissionPrompt } from '../cards/multi-tenancy/missionLoader'
 import type { MissionControlState, PhaseProgress, PhaseStatus } from './types'
 
+/** Terminal statuses that indicate a project is no longer in-flight */
+const TERMINAL_STATUSES: readonly string[] = ['completed', 'failed', 'skipped']
+
 interface LaunchSequenceProps {
   state: MissionControlState
   onUpdateProgress: (progress: PhaseProgress[]) => void
@@ -37,6 +40,29 @@ const STATUS_ICONS: Record<string, React.ReactNode> = {
   failed: <X className="w-4 h-4 text-red-400" />,
   skipped: <SkipForward className="w-4 h-4 text-muted-foreground" /> }
 
+/**
+ * Build a content-based signature for phases so reinitialization triggers
+ * when phase membership changes, not just when the phase count changes (#5508).
+ */
+function computePhaseSignature(phases: MissionControlState['phases']): string {
+  return phases
+    .map((p) => `${p.phase}:${p.name}:${(p.projectNames || []).join(',')}`)
+    .join('|')
+}
+
+/**
+ * Recompute phase-level status from its project statuses.
+ * Used by both the mission-monitor effect and the error catch path (#5507).
+ */
+function derivePhaseStatus(phase: PhaseProgress): PhaseStatus {
+  const allDone = phase.projects.every(
+    (p) => TERMINAL_STATUSES.includes(p.status)
+  )
+  if (!allDone) return phase.status
+  const anyFailed = phase.projects.some((p) => p.status === 'failed')
+  return anyFailed ? 'failed' : 'completed'
+}
+
 export function LaunchSequence({
   state,
   onUpdateProgress,
@@ -47,7 +73,13 @@ export function LaunchSequence({
   const progressRef = useRef<PhaseProgress[]>(state.launchProgress)
   const startedMissions = useRef(new Set<string>())
 
-  // Initialize progress from phases
+  /** Content-based signature for phase membership (#5508) */
+  const phaseSignature = useMemo(
+    () => computePhaseSignature(state.phases),
+    [state.phases]
+  )
+
+  // Initialize progress from phases — keyed on content signature, not just length (#5508)
   useEffect(() => {
     if (state.launchProgress.length > 0) {
       progressRef.current = state.launchProgress
@@ -58,12 +90,14 @@ export function LaunchSequence({
     const initial: PhaseProgress[] = state.phases.map((phase) => ({
       phase: phase.phase,
       status: 'pending' as PhaseStatus,
-      projects: phase.projectNames.map((name) => ({
+      projects: (phase.projectNames || []).map((name) => ({
         name,
         status: 'pending' as const })) }))
     progressRef.current = initial
+    startedMissions.current = new Set<string>()
+    setIsStarted(false)
     onUpdateProgress(initial)
-  }, [state.phases.length])
+  }, [phaseSignature])
 
   const updateProgress = (updater: (prev: PhaseProgress[]) => PhaseProgress[]) => {
       const next = updater(progressRef.current)
@@ -77,7 +111,7 @@ export function LaunchSequence({
       if (!project) return
 
       const assignment = state.assignments.find((a) =>
-        a.projectNames.includes(projectName)
+        (a.projectNames || []).includes(projectName)
       )
       const clusterName = assignment?.clusterName ?? 'default'
 
@@ -127,18 +161,18 @@ export function LaunchSequence({
           )
         )
       } catch (err) {
+        // Mark project as failed AND recompute phase-level status (#5507)
         updateProgress((prev) =>
-          prev.map((p) =>
-            p.phase === phaseNum
-              ? {
-                  ...p,
-                  projects: p.projects.map((proj) =>
-                    proj.name === projectName
-                      ? { ...proj, status: 'failed' as const, error: String(err) }
-                      : proj
-                  ) }
-              : p
-          )
+          prev.map((p) => {
+            if (p.phase !== phaseNum) return p
+            const updatedProjects = p.projects.map((proj) =>
+              proj.name === projectName
+                ? { ...proj, status: 'failed' as const, error: String(err) }
+                : proj
+            )
+            const updatedPhase = { ...p, projects: updatedProjects }
+            return { ...updatedPhase, status: derivePhaseStatus(updatedPhase) }
+          })
         )
       }
     }
@@ -167,29 +201,39 @@ export function LaunchSequence({
       }) }))
 
     if (changed) {
-      // Update phase-level status
-      const updated = next.map((phase) => {
-        const allDone = phase.projects.every(
-          (p) => (['completed', 'failed', 'skipped'] as string[]).includes(p.status)
-        )
-        const anyFailed = phase.projects.some((p) => p.status === 'failed')
-        return {
-          ...phase,
-          status: allDone
-            ? anyFailed
-              ? ('failed' as PhaseStatus)
-              : ('completed' as PhaseStatus)
-            : phase.status }
-      })
+      // Update phase-level status using shared helper
+      const updated = next.map((phase) => ({
+        ...phase,
+        status: derivePhaseStatus(phase) }))
       progressRef.current = updated
       onUpdateProgress(updated)
 
       // Check if all phases complete
-      if (updated.every((p) => p.status === 'completed' || p.status === 'failed' || p.status === 'skipped')) {
+      if (updated.every((p) => TERMINAL_STATUSES.includes(p.status))) {
         onComplete()
       }
     }
   }, [missions, onUpdateProgress, onComplete])
+
+  /**
+   * Wait for a specific phase to reach a terminal status.
+   * Used by phased mode to gate sequential phase execution (#5506).
+   */
+  const waitForPhaseCompletion = useCallback((phaseNum: number): Promise<PhaseStatus> => {
+    return new Promise((resolve) => {
+      /** Poll interval in ms — checks progressRef for phase terminal state */
+      const PHASE_POLL_INTERVAL_MS = 500
+      const check = () => {
+        const phase = progressRef.current.find((p) => p.phase === phaseNum)
+        if (phase && TERMINAL_STATUSES.includes(phase.status)) {
+          resolve(phase.status)
+          return
+        }
+        setTimeout(check, PHASE_POLL_INTERVAL_MS)
+      }
+      check()
+    })
+  }, [])
 
   // Execute the launch sequence
   const startLaunch = async () => {
@@ -200,8 +244,8 @@ export function LaunchSequence({
 
     if (isYolo) {
       // Launch everything at once
-      for (const phase of state.phases) {
-        for (const projectName of phase.projectNames) {
+      for (const phase of (state.phases || [])) {
+        for (const projectName of (phase.projectNames || [])) {
           if (!startedMissions.current.has(projectName)) {
             startedMissions.current.add(projectName)
             launchProject(projectName, phase.phase)
@@ -209,8 +253,8 @@ export function LaunchSequence({
         }
       }
     } else {
-      // Phased: launch phase 1, wait, then phase 2, etc.
-      for (const phase of state.phases) {
+      // Phased: launch phase N, wait for completion, then phase N+1 (#5506)
+      for (const phase of (state.phases || [])) {
         updateProgress((prev) =>
           prev.map((p) =>
             p.phase === phase.phase ? { ...p, status: 'running' } : p
@@ -218,25 +262,25 @@ export function LaunchSequence({
         )
 
         // Launch all projects in this phase
-        for (const projectName of phase.projectNames) {
+        for (const projectName of (phase.projectNames || [])) {
           if (!startedMissions.current.has(projectName)) {
             startedMissions.current.add(projectName)
             await launchProject(projectName, phase.phase)
           }
         }
 
-        // For phased mode, we don't wait here — the useEffect monitors mission completions
-        // and advances automatically
+        // Wait for this phase to reach a terminal state before starting the next (#5506)
+        await waitForPhaseCompletion(phase.phase)
       }
     }
   }
 
-  // Auto-start on mount
+  // Auto-start on mount — keyed on content signature (#5508)
   useEffect(() => {
     if (!isStarted && state.phases.length > 0) {
       startLaunch()
     }
-  }, [state.phases.length])
+  }, [phaseSignature])
 
   const progress = state.launchProgress.length > 0 ? state.launchProgress : progressRef.current
   const allComplete = progress.every(


### PR DESCRIPTION
## Summary

- **#5506 (HIGH)**: Phased deploy mode now correctly waits for each phase to complete before starting the next. Added `waitForPhaseCompletion()` that polls `progressRef` for terminal status, gating sequential phase execution. Previously the `for...of` loop launched all phases back-to-back because `await launchProject()` only waited for mission *creation*, not *completion*.

- **#5507 (HIGH)**: Launch failures in `loadMissionPrompt()` or `startMission()` now correctly transition the phase to failed. Extracted `derivePhaseStatus()` helper and call it in the catch path so the phase aggregate status is recomputed immediately, not left stuck in "running".

- **#5508 (MEDIUM)**: Launch state reinitializes when phase *contents* change, not just phase count. Replaced `state.phases.length` dependency with a content-based `phaseSignature` (computed from phase numbers, names, and project name lists via `useMemo`). Also resets `startedMissions` and `isStarted` on reinitialization.

Closes #5506, closes #5507, closes #5508

## Test plan

- [ ] Create a multi-phase mission (3+ phases with dependencies) and launch in **phased** mode — verify Phase 2 does not start until Phase 1 completes
- [ ] Force a `loadMissionPrompt()` failure (e.g., invalid kbPath) — verify the phase transitions to "failed" (red), not stuck on "running"
- [ ] Edit phase membership (move a project between phases) without changing phase count, then launch — verify the launch UI reflects the updated membership
- [ ] Launch in **yolo** mode — verify all phases still fire concurrently (no regression)
- [ ] Use "Retry Failed" button on a failed phase — verify it re-launches only the failed projects