### PR TITLE
🐛 Fix mission stream analytics and WebSocket disconnect message

### DIFF
--- a/web/src/hooks/useMissions.tsx
+++ b/web/src/hooks/useMissions.tsx
@@ -662,9 +662,9 @@ export function MissionProvider({ children }: { children: ReactNode }) {
 
           // Fail any pending missions that were waiting for a response
           if (pendingRequests.current.size > 0) {
-            const errorContent = `**Local Agent Not Connected**
+            const errorContent = `**Agent Disconnected**
 
-Install the console locally with the KubeStellar Console agent to use AI missions.`
+The WebSocket connection to the agent at \`${LOCAL_AGENT_WS_URL}\` was lost. Please verify the agent is running and reachable.`
 
             const pendingMissionIds = new Set(pendingRequests.current.values())
             setMissions(prev => prev.map(m => {
@@ -958,11 +958,11 @@ Install the console locally with the KubeStellar Console agent to use AI mission
             }
           }
 
-          // Clear active token tracking
+          // Clear active token tracking.
+          // NOTE: Do NOT emit analytics completion here — stream-done is not
+          // authoritative. The backend sends a separate 'result' message with
+          // the final answer; emitMissionCompleted fires there (#5510).
           setActiveTokenCategory(null)
-          if (m.status === 'running') {
-            emitMissionCompleted(m.type, Math.round((Date.now() - m.createdAt.getTime()) / 1000))
-          }
           return {
             ...m,
             status: 'waiting_input' as MissionStatus,


### PR DESCRIPTION
## Summary

- **#5511**: Replace hardcoded "Install the console locally" WebSocket disconnect message with the actual agent URL from config (`LOCAL_AGENT_WS_URL`), making the error message topology-aware for deployed, remote-agent, and in-cluster setups.
- **#5510**: Remove premature `emitMissionCompleted` call from the stream-done handler. Analytics success now only fires in the `result` handler when the authoritative backend result message arrives, preventing false positive completion events when the final result is delayed or lost.

Both fixes are in `web/src/hooks/useMissions.tsx`.

Closes #5511
Closes #5510

## Test plan

- [ ] Deploy console with a remote agent, disconnect the WebSocket, and verify the error message shows the actual agent URL instead of "Install the console locally"
- [ ] Start a streaming mission, verify that `emitMissionCompleted` analytics event does NOT fire when stream-done arrives, only when the backend `result` message is received
- [ ] Verify missions still complete normally (stream → result → completed status)
- [ ] Verify cancelled missions during streaming still finalize correctly