### PR TITLE
🐛 Fix stale leaderboard coin data (#5517)

### DIFF
--- a/web/netlify/functions/github-rewards.mts
+++ b/web/netlify/functions/github-rewards.mts
@@ -1,0 +1,329 @@
+/**
+ * Netlify Function: GitHub Rewards
+ *
+ * Fetches a user's GitHub contribution data (issues + PRs) across configured
+ * orgs and computes reward points. This is the Netlify equivalent of
+ * pkg/api/handlers/rewards.go for serverless deployment.
+ *
+ * GITHUB_TOKEN must be set as a Netlify environment variable.
+ *
+ * The client passes the user's github_login via the Authorization header
+ * (JWT from the Go backend) or as a ?login= query param. On Netlify we
+ * cannot validate the JWT (no shared secret), so we accept the login param
+ * directly. This is safe because the data is computed from public GitHub
+ * activity — no secrets are exposed.
+ */
+
+import { getStore } from "@netlify/blobs";
+
+const GITHUB_API = "https://api.github.com";
+const CACHE_STORE = "github-rewards";
+/** Server-side cache TTL for rewards data (10 minutes) */
+const CACHE_TTL_MS = 10 * 60 * 1000;
+/** GitHub Search API results per page (max 100) */
+const PER_PAGE = 100;
+/** Max pages to fetch (GitHub caps search at 1000 results) */
+const MAX_PAGES = 10;
+/** Request timeout for GitHub API calls (30 seconds) */
+const API_TIMEOUT_MS = 30_000;
+
+/** Point values for contribution types — must match rewards.go */
+const POINTS_BUG_ISSUE = 300;
+const POINTS_FEATURE_ISSUE = 100;
+const POINTS_OTHER_ISSUE = 50;
+const POINTS_PR_OPENED = 200;
+const POINTS_PR_MERGED = 500;
+
+/** Repos to search for contributions */
+const SEARCH_REPOS =
+  "repo:kubestellar/console repo:kubestellar/console-marketplace repo:kubestellar/console-kb repo:kubestellar/docs";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+interface GitHubContribution {
+  type: string;
+  title: string;
+  url: string;
+  repo: string;
+  number: number;
+  points: number;
+  created_at: string;
+}
+
+interface RewardsBreakdown {
+  bug_issues: number;
+  feature_issues: number;
+  other_issues: number;
+  prs_opened: number;
+  prs_merged: number;
+}
+
+interface GitHubRewardsResponse {
+  total_points: number;
+  contributions: GitHubContribution[];
+  breakdown: RewardsBreakdown;
+  cached_at: string;
+  from_cache: boolean;
+}
+
+interface SearchItem {
+  title: string;
+  html_url: string;
+  number: number;
+  created_at: string;
+  labels: Array<{ name: string }>;
+  pull_request?: { merged_at?: string | null };
+  repository_url: string;
+}
+
+interface SearchResponse {
+  total_count: number;
+  items: SearchItem[];
+}
+
+interface CacheEntry {
+  response: GitHubRewardsResponse;
+  storedAt: number;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function extractRepo(repoUrl: string): string {
+  const prefix = "https://api.github.com/repos/";
+  return repoUrl.startsWith(prefix) ? repoUrl.slice(prefix.length) : repoUrl;
+}
+
+function classifyIssue(item: SearchItem): GitHubContribution {
+  let type = "issue_other";
+  let points = POINTS_OTHER_ISSUE;
+
+  for (const label of item.labels || []) {
+    if (["bug", "kind/bug", "type/bug"].includes(label.name)) {
+      type = "issue_bug";
+      points = POINTS_BUG_ISSUE;
+    } else if (
+      ["enhancement", "feature", "kind/feature", "type/feature"].includes(
+        label.name
+      )
+    ) {
+      type = "issue_feature";
+      points = POINTS_FEATURE_ISSUE;
+    }
+  }
+
+  return {
+    type,
+    title: item.title,
+    url: item.html_url,
+    repo: extractRepo(item.repository_url),
+    number: item.number,
+    points,
+    created_at: item.created_at,
+  };
+}
+
+function classifyPR(item: SearchItem): GitHubContribution[] {
+  const repo = extractRepo(item.repository_url);
+  const result: GitHubContribution[] = [
+    {
+      type: "pr_opened",
+      title: item.title,
+      url: item.html_url,
+      repo,
+      number: item.number,
+      points: POINTS_PR_OPENED,
+      created_at: item.created_at,
+    },
+  ];
+
+  if (item.pull_request?.merged_at) {
+    result.push({
+      type: "pr_merged",
+      title: item.title,
+      url: item.html_url,
+      repo,
+      number: item.number,
+      points: POINTS_PR_MERGED,
+      created_at: item.pull_request.merged_at,
+    });
+  }
+
+  return result;
+}
+
+async function searchItems(
+  login: string,
+  itemType: "issue" | "pr",
+  token: string
+): Promise<SearchItem[]> {
+  const yearStart = `${new Date().getFullYear()}-01-01`;
+  const query = `author:${login} ${SEARCH_REPOS} type:${itemType} created:>=${yearStart}`;
+  const allItems: SearchItem[] = [];
+
+  for (let page = 1; page <= MAX_PAGES; page++) {
+    const url = `${GITHUB_API}/search/issues?q=${encodeURIComponent(query)}&per_page=${PER_PAGE}&page=${page}&sort=created&order=desc`;
+    const headers: Record<string, string> = {
+      Accept: "application/vnd.github.v3+json",
+    };
+    if (token) headers["Authorization"] = `Bearer ${token}`;
+
+    const res = await fetch(url, {
+      headers,
+      signal: AbortSignal.timeout(API_TIMEOUT_MS),
+    });
+    if (!res.ok) {
+      throw new Error(`GitHub API ${res.status}: ${(await res.text()).slice(0, 200)}`);
+    }
+
+    const sr: SearchResponse = await res.json();
+    allItems.push(...sr.items);
+
+    if (allItems.length >= sr.total_count || sr.items.length < PER_PAGE) {
+      break;
+    }
+  }
+
+  return allItems;
+}
+
+// ---------------------------------------------------------------------------
+// Handler
+// ---------------------------------------------------------------------------
+
+export default async (req: Request) => {
+  const corsHeaders = {
+    "Access-Control-Allow-Origin": "*",
+    "Access-Control-Allow-Methods": "GET, OPTIONS",
+    "Access-Control-Allow-Headers": "Content-Type, Authorization, Accept",
+    "Cache-Control": "no-cache, no-store",
+  };
+
+  if (req.method === "OPTIONS") {
+    return new Response(null, { status: 204, headers: corsHeaders });
+  }
+
+  if (req.method !== "GET") {
+    return new Response(JSON.stringify({ error: "Method not allowed" }), {
+      status: 405,
+      headers: { ...corsHeaders, "Content-Type": "application/json" },
+    });
+  }
+
+  // Extract github_login from query param
+  const url = new URL(req.url);
+  const login = url.searchParams.get("login");
+
+  if (!login || !/^[a-zA-Z0-9_-]+$/.test(login)) {
+    return new Response(
+      JSON.stringify({ error: "Missing or invalid login parameter" }),
+      {
+        status: 400,
+        headers: { ...corsHeaders, "Content-Type": "application/json" },
+      }
+    );
+  }
+
+  const token = Netlify.env.get("GITHUB_TOKEN") || "";
+
+  // Check Netlify Blobs cache
+  try {
+    const store = getStore(CACHE_STORE);
+    const cached = await store.get(login, { type: "json" }) as CacheEntry | null;
+    if (cached && Date.now() - cached.storedAt < CACHE_TTL_MS) {
+      const response = { ...cached.response, from_cache: true };
+      return new Response(JSON.stringify(response), {
+        status: 200,
+        headers: { ...corsHeaders, "Content-Type": "application/json" },
+      });
+    }
+  } catch {
+    // Cache miss or blob error — proceed to fetch
+  }
+
+  // Fetch from GitHub
+  try {
+    const contributions: GitHubContribution[] = [];
+
+    const [issues, prs] = await Promise.all([
+      searchItems(login, "issue", token),
+      searchItems(login, "pr", token),
+    ]);
+
+    for (const item of issues) {
+      contributions.push(classifyIssue(item));
+    }
+    for (const item of prs) {
+      contributions.push(...classifyPR(item));
+    }
+
+    // Compute totals
+    let totalPoints = 0;
+    const breakdown: RewardsBreakdown = {
+      bug_issues: 0,
+      feature_issues: 0,
+      other_issues: 0,
+      prs_opened: 0,
+      prs_merged: 0,
+    };
+
+    for (const c of contributions) {
+      totalPoints += c.points;
+      switch (c.type) {
+        case "issue_bug":
+          breakdown.bug_issues++;
+          break;
+        case "issue_feature":
+          breakdown.feature_issues++;
+          break;
+        case "issue_other":
+          breakdown.other_issues++;
+          break;
+        case "pr_opened":
+          breakdown.prs_opened++;
+          break;
+        case "pr_merged":
+          breakdown.prs_merged++;
+          break;
+      }
+    }
+
+    const response: GitHubRewardsResponse = {
+      total_points: totalPoints,
+      contributions,
+      breakdown,
+      cached_at: new Date().toISOString(),
+      from_cache: false,
+    };
+
+    // Store in Netlify Blobs cache
+    try {
+      const store = getStore(CACHE_STORE);
+      const entry: CacheEntry = { response, storedAt: Date.now() };
+      await store.setJSON(login, entry);
+    } catch {
+      // Cache write failure is non-fatal
+    }
+
+    return new Response(JSON.stringify(response), {
+      status: 200,
+      headers: { ...corsHeaders, "Content-Type": "application/json" },
+    });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "Unknown error";
+    return new Response(
+      JSON.stringify({ error: "GitHub API unavailable", detail: message }),
+      {
+        status: 503,
+        headers: { ...corsHeaders, "Content-Type": "application/json" },
+      }
+    );
+  }
+};
+
+export const config = {
+  path: "/api/rewards/github",
+};

--- a/web/src/hooks/__tests__/useGitHubRewards.test.ts
+++ b/web/src/hooks/__tests__/useGitHubRewards.test.ts
@@ -1,9 +1,9 @@
 /**
  * Tests for the useGitHubRewards hook.
  *
- * Validates demo-user skip, unauthenticated skip, localStorage caching,
- * successful fetch, error handling with stale cache retention, and
- * periodic refresh via interval.
+ * Validates demo-user skip, unauthenticated skip, per-user localStorage
+ * caching with TTL, successful fetch, error handling with expired cache
+ * clearing, and periodic refresh via interval.
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
@@ -19,7 +19,14 @@ vi.mock('../../lib/auth', () => ({ useAuth: () => mockUseAuth() }))
 
 // Constants are simple values -- we mirror them here for localStorage setup.
 const STORAGE_KEY_TOKEN = 'token'
-const CACHE_KEY = 'github-rewards-cache'
+/** Per-user cache key format matching the hook's userCacheKey() */
+function userCacheKey(login: string): string {
+  return `github-rewards-cache:${login}`
+}
+/** Legacy global cache key — the hook should clean this up */
+const LEGACY_CACHE_KEY = 'github-rewards-cache'
+/** Client-side cache TTL in milliseconds (must match hook) */
+const CLIENT_CACHE_TTL_MS = 15 * 60 * 1000
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -34,6 +41,11 @@ function makeSampleResponse(overrides: Partial<GitHubRewardsResponse> = {}): Git
     from_cache: false,
     ...overrides,
   }
+}
+
+/** Store a cache entry in the new per-user format */
+function seedCache(login: string, data: GitHubRewardsResponse, storedAt = Date.now()): void {
+  localStorage.setItem(userCacheKey(login), JSON.stringify({ data, storedAt }))
 }
 
 // ---------------------------------------------------------------------------
@@ -78,10 +90,10 @@ describe('useGitHubRewards', () => {
     expect(global.fetch).not.toHaveBeenCalled()
   })
 
-  // 3. Cached data loaded from localStorage on mount
-  it('returns cached data from localStorage on mount', async () => {
+  // 3. Cached data loaded from localStorage on mount (per-user, within TTL)
+  it('returns cached data from localStorage on mount when within TTL', async () => {
     const cached = makeSampleResponse({ total_points: 999 })
-    localStorage.setItem(CACHE_KEY, JSON.stringify(cached))
+    seedCache('octocat', cached, Date.now()) // fresh cache
 
     // Prevent actual fetch from resolving during this test
     vi.mocked(global.fetch).mockReturnValue(new Promise(() => {}))
@@ -89,12 +101,45 @@ describe('useGitHubRewards', () => {
     const { useGitHubRewards } = await import('../useGitHubRewards')
     const { result } = renderHook(() => useGitHubRewards())
 
-    // Cached value available synchronously (useState initialiser)
-    expect(result.current.githubRewards).not.toBeNull()
-    expect(result.current.githubRewards!.total_points).toBe(999)
+    // Cached value loaded via useEffect (not useState initialiser)
+    await waitFor(() => {
+      expect(result.current.githubRewards).not.toBeNull()
+      expect(result.current.githubRewards!.total_points).toBe(999)
+    })
   })
 
-  // 4. Successful fetch updates state and writes cache
+  // 3b. Expired cache is discarded
+  it('discards expired cache and returns null', async () => {
+    const expired = makeSampleResponse({ total_points: 999 })
+    const twentyMinutesAgo = Date.now() - (CLIENT_CACHE_TTL_MS + 60_000)
+    seedCache('octocat', expired, twentyMinutesAgo)
+
+    // Prevent actual fetch from resolving
+    vi.mocked(global.fetch).mockReturnValue(new Promise(() => {}))
+
+    const { useGitHubRewards } = await import('../useGitHubRewards')
+    const { result } = renderHook(() => useGitHubRewards())
+
+    // Expired cache should be ignored — data stays null until fetch resolves
+    await act(async () => { /* flush effects */ })
+    expect(result.current.githubRewards).toBeNull()
+  })
+
+  // 3c. Legacy global cache key is cleaned up
+  it('removes legacy global cache key on load', async () => {
+    localStorage.setItem(LEGACY_CACHE_KEY, JSON.stringify(makeSampleResponse()))
+
+    vi.mocked(global.fetch).mockReturnValue(new Promise(() => {}))
+
+    const { useGitHubRewards } = await import('../useGitHubRewards')
+    renderHook(() => useGitHubRewards())
+
+    await act(async () => { /* flush effects */ })
+
+    expect(localStorage.getItem(LEGACY_CACHE_KEY)).toBeNull()
+  })
+
+  // 4. Successful fetch updates state and writes per-user cache
   it('updates state and caches result on successful fetch', async () => {
     const apiResponse = makeSampleResponse({ total_points: 1500 })
     vi.mocked(global.fetch).mockResolvedValue({
@@ -113,16 +158,20 @@ describe('useGitHubRewards', () => {
     expect(result.current.isLoading).toBe(false)
     expect(result.current.error).toBeNull()
 
-    // Cache should have been written
-    const raw = localStorage.getItem(CACHE_KEY)
+    // Per-user cache should have been written with storedAt timestamp
+    const raw = localStorage.getItem(userCacheKey('octocat'))
     expect(raw).not.toBeNull()
-    expect(JSON.parse(raw!).total_points).toBe(1500)
+    const entry = JSON.parse(raw!)
+    expect(entry.data.total_points).toBe(1500)
+    expect(entry.storedAt).toBeDefined()
   })
 
-  // 5. Failed fetch sets error and retains stale cache
-  it('sets error but keeps stale cached data on fetch failure', async () => {
+  // 5. Failed fetch clears data when cache has expired
+  it('clears data on fetch failure when cache has also expired', async () => {
+    // Seed an expired cache
     const stale = makeSampleResponse({ total_points: 800 })
-    localStorage.setItem(CACHE_KEY, JSON.stringify(stale))
+    const twentyMinutesAgo = Date.now() - (CLIENT_CACHE_TTL_MS + 60_000)
+    seedCache('octocat', stale, twentyMinutesAgo)
 
     vi.mocked(global.fetch).mockRejectedValue(new Error('Network down'))
 
@@ -134,8 +183,25 @@ describe('useGitHubRewards', () => {
     })
 
     expect(result.current.isLoading).toBe(false)
+    // Stale data should be cleared because cache has expired
+    expect(result.current.githubRewards).toBeNull()
+  })
 
-    // Stale data retained
+  // 5b. Failed fetch retains data when cache is still within TTL
+  it('retains data on fetch failure when cache is still valid', async () => {
+    const cached = makeSampleResponse({ total_points: 800 })
+    seedCache('octocat', cached, Date.now()) // fresh cache
+
+    vi.mocked(global.fetch).mockRejectedValue(new Error('Network down'))
+
+    const { useGitHubRewards } = await import('../useGitHubRewards')
+    const { result } = renderHook(() => useGitHubRewards())
+
+    await waitFor(() => {
+      expect(result.current.error).toBe('Network down')
+    })
+
+    // Data retained because cache is still valid
     expect(result.current.githubRewards).not.toBeNull()
     expect(result.current.githubRewards!.total_points).toBe(800)
   })
@@ -195,5 +261,24 @@ describe('useGitHubRewards', () => {
     expect(global.fetch).not.toHaveBeenCalled()
     // Data stays null since no cache and no fetch
     expect(result.current.githubRewards).toBeNull()
+  })
+
+  // 8. Fetch URL includes login query param
+  it('includes login query param in fetch URL', async () => {
+    const apiResponse = makeSampleResponse()
+    vi.mocked(global.fetch).mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve(apiResponse),
+    } as Response)
+
+    const { useGitHubRewards } = await import('../useGitHubRewards')
+    renderHook(() => useGitHubRewards())
+
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalled()
+    })
+
+    const fetchUrl = vi.mocked(global.fetch).mock.calls[0][0] as string
+    expect(fetchUrl).toContain('login=octocat')
   })
 })

--- a/web/src/hooks/useGitHubRewards.ts
+++ b/web/src/hooks/useGitHubRewards.ts
@@ -4,28 +4,71 @@
  * issues and PRs across configured orgs, computes points on the fly.
  */
 
-import { useState, useEffect, useCallback } from 'react'
+import { useState, useEffect, useCallback, useRef } from 'react'
 import { useAuth } from '../lib/auth'
 import { STORAGE_KEY_TOKEN } from '../lib/constants'
 import { BACKEND_DEFAULT_URL } from '../lib/constants'
 import { FETCH_DEFAULT_TIMEOUT_MS } from '../lib/constants/network'
 import type { GitHubRewardsResponse } from '../types/rewards'
 
-const CACHE_KEY = 'github-rewards-cache'
-const REFRESH_INTERVAL_MS = 10 * 60 * 1000 // 10 minutes
+/** Prefix for per-user localStorage cache keys */
+const CACHE_KEY_PREFIX = 'github-rewards-cache'
+/** Legacy cache key (pre-per-user). Cleared on first load to prevent stale data. */
+const LEGACY_CACHE_KEY = 'github-rewards-cache'
+/** How long client-side cached rewards data is considered fresh (15 minutes) */
+const CLIENT_CACHE_TTL_MS = 15 * 60 * 1000
+/** Interval between automatic background refreshes (10 minutes) */
+const REFRESH_INTERVAL_MS = 10 * 60 * 1000
 
-function loadCache(): GitHubRewardsResponse | null {
+/** Returns a per-user localStorage cache key */
+function userCacheKey(login: string): string {
+  return `${CACHE_KEY_PREFIX}:${login}`
+}
+
+interface CachedRewardsEntry {
+  data: GitHubRewardsResponse
+  /** Timestamp (ms) when the entry was stored in localStorage */
+  storedAt: number
+}
+
+/**
+ * Load cached rewards from localStorage for a specific user.
+ * Returns null if the cache is missing, corrupt, or expired.
+ */
+function loadCache(login: string): GitHubRewardsResponse | null {
   try {
-    const raw = localStorage.getItem(CACHE_KEY)
-    return raw ? JSON.parse(raw) : null
+    // Clean up legacy global cache key (not per-user, caused cross-user leaks)
+    localStorage.removeItem(LEGACY_CACHE_KEY)
+
+    const raw = localStorage.getItem(userCacheKey(login))
+    if (!raw) return null
+
+    const entry = JSON.parse(raw) as CachedRewardsEntry
+
+    // Validate shape — old format stored GitHubRewardsResponse directly
+    if (!entry.storedAt || !entry.data) {
+      localStorage.removeItem(userCacheKey(login))
+      return null
+    }
+
+    // Check TTL — discard stale cache
+    const ageMs = Date.now() - entry.storedAt
+    if (ageMs > CLIENT_CACHE_TTL_MS) {
+      localStorage.removeItem(userCacheKey(login))
+      return null
+    }
+
+    return entry.data
   } catch {
     return null
   }
 }
 
-function saveCache(data: GitHubRewardsResponse): void {
+/** Save rewards data to per-user localStorage cache with a timestamp. */
+function saveCache(login: string, data: GitHubRewardsResponse): void {
   try {
-    localStorage.setItem(CACHE_KEY, JSON.stringify(data))
+    const entry: CachedRewardsEntry = { data, storedAt: Date.now() }
+    localStorage.setItem(userCacheKey(login), JSON.stringify(entry))
   } catch {
     // quota exceeded — ignore
   }
@@ -33,14 +76,34 @@ function saveCache(data: GitHubRewardsResponse): void {
 
 export function useGitHubRewards() {
   const { user, isAuthenticated } = useAuth()
-  const [data, setData] = useState<GitHubRewardsResponse | null>(loadCache)
+  const [data, setData] = useState<GitHubRewardsResponse | null>(null)
   const [isLoading, setIsLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
 
   const isDemoUser = !user || user.github_login === 'demo-user'
+  const githubLogin = user?.github_login ?? ''
+
+  // Track the login so we can detect user switches and avoid stale closures
+  const loginRef = useRef(githubLogin)
+  loginRef.current = githubLogin
+
+  // Load per-user cache when the user changes
+  useEffect(() => {
+    if (isDemoUser || !githubLogin) {
+      setData(null)
+      return
+    }
+    const cached = loadCache(githubLogin)
+    if (cached) {
+      setData(cached)
+    } else {
+      // No valid cache — clear any stale data from a previous user
+      setData(null)
+    }
+  }, [githubLogin, isDemoUser])
 
   const fetchRewards = useCallback(async () => {
-    if (!isAuthenticated || isDemoUser) return
+    if (!isAuthenticated || isDemoUser || !githubLogin) return
 
     const token = localStorage.getItem(STORAGE_KEY_TOKEN)
     if (!token) return
@@ -48,7 +111,11 @@ export function useGitHubRewards() {
     setIsLoading(true)
     try {
       const apiBase = import.meta.env.VITE_API_BASE_URL || BACKEND_DEFAULT_URL
-      const res = await fetch(`${apiBase}/api/rewards/github`, {
+      // Pass login as query param for Netlify Function compatibility (no JWT
+      // validation on serverless). The Go backend ignores this param and reads
+      // the login from the JWT instead — no security impact either way since
+      // reward data is computed from public GitHub activity.
+      const res = await fetch(`${apiBase}/api/rewards/github?login=${encodeURIComponent(githubLogin)}`, {
         headers: { Authorization: `Bearer ${token}` },
         signal: AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS),
       })
@@ -57,25 +124,34 @@ export function useGitHubRewards() {
       // before the outer try/catch processes the rejection (microtask timing issue).
       const result = await res.json().catch(() => null) as GitHubRewardsResponse | null
       if (!result) throw new Error('Invalid JSON response')
+
+      // Guard against stale response arriving after user switched accounts
+      if (loginRef.current !== githubLogin) return
+
       setData(result)
-      saveCache(result)
+      saveCache(githubLogin, result)
       setError(null)
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Unknown error')
-      // Keep stale data if we have it
+      // On failure, clear data if the cache has also expired (prevents
+      // indefinite stale display). If cache is still valid, keep showing it.
+      const cached = loadCache(githubLogin)
+      if (!cached) {
+        setData(null)
+      }
     } finally {
       setIsLoading(false)
     }
-  }, [isAuthenticated, isDemoUser])
+  }, [isAuthenticated, isDemoUser, githubLogin])
 
   // Fetch on mount and refresh periodically
   useEffect(() => {
-    if (!isAuthenticated || isDemoUser) return
+    if (!isAuthenticated || isDemoUser || !githubLogin) return
 
     fetchRewards()
     const interval = setInterval(fetchRewards, REFRESH_INTERVAL_MS)
     return () => clearInterval(interval)
-  }, [fetchRewards, isAuthenticated, isDemoUser])
+  }, [fetchRewards, isAuthenticated, isDemoUser, githubLogin])
 
   return {
     githubRewards: data,

--- a/web/src/mocks/handlers.ts
+++ b/web/src/mocks/handlers.ts
@@ -669,6 +669,7 @@ export const handlers = [
   http.get('/api/medium/blog', () => passthrough()),
   http.get('/api/missions/file', () => passthrough()),
   http.get('/api/missions/browse', () => passthrough()),
+  http.get('/api/rewards/github', () => passthrough()),
 
   // ── Kubara Platform Catalog (demo) ──────────────────────────────
   http.get('/api/github/repos/kubara-io/kubara/contents/*', () => {


### PR DESCRIPTION
## Summary

Fixes #5517 — Leaderboard coin count not updating for ~24 hours despite continued activity.

**Root causes identified and fixed:**

- **Client-side localStorage cache had no TTL** — Cached rewards data persisted indefinitely. When API fetches failed (network issue, server restart, Netlify deployment), stale data was never cleared. Added a 15-minute TTL that discards expired cache entries.

- **Cache was not per-user** — All users shared a single `github-rewards-cache` localStorage key. If user A logged in, their rewards were cached; when user B logged in, they initially saw user A's data. Now keyed by `github-rewards-cache:<github_login>`.

- **No Netlify Function for `/api/rewards/github`** — The production site (console.kubestellar.io) had no serverless equivalent of the Go backend's rewards handler. API calls fell through to the SPA catch-all, returning HTML instead of JSON. Created a new Netlify Function that queries GitHub Search API with the same logic as `pkg/api/handlers/rewards.go`.

**Additional improvements:**

- Pass `login` as query parameter for Netlify Function compatibility (Go backend ignores it, reads from JWT)
- Add MSW passthrough rule for `/api/rewards/github` so demo mode doesn't intercept the request
- On fetch failure, clear data if the localStorage cache has also expired (prevents indefinite stale display)
- Guard against stale responses arriving after user switches accounts
- Clean up legacy global cache key on first load

## Test plan

- [x] All 11 useGitHubRewards tests pass (3 new tests for TTL expiry, legacy cleanup, login param)
- [x] Build passes
- [x] Lint passes (no new issues in changed files)
- [ ] Verify on console.kubestellar.io that rewards data refreshes within 15 minutes
- [ ] Verify per-user cache isolation by checking localStorage keys