### PR TITLE
🧪 Fix mission analytics test expectations (#5518)

### DIFF
--- a/web/src/hooks/useMissions.test.tsx
+++ b/web/src/hooks/useMissions.test.tsx
@@ -274,15 +274,15 @@ describe('startMission', () => {
     expect(result.current.missions[0].status).toBe('waiting_input')
   })
 
-  it('calls emitMissionCompleted when stream done:true is received', async () => {
+  it('calls emitMissionCompleted when result message is received', async () => {
     const { result } = renderHook(() => useMissions(), { wrapper })
     const { requestId } = await startMissionWithConnection(result)
 
     act(() => {
       MockWebSocket.lastInstance?.simulateMessage({
         id: requestId,
-        type: 'stream',
-        payload: { content: '', done: true },
+        type: 'result',
+        payload: { content: 'Task completed.' },
       })
     })
 
@@ -2502,7 +2502,7 @@ describe('WS close fails pending running missions', () => {
     const mission = result.current.missions.find(m => m.id === missionId)
     expect(mission?.status).toBe('failed')
     const systemMsg = mission?.messages.find(m => m.role === 'system')
-    expect(systemMsg?.content).toContain('Local Agent Not Connected')
+    expect(systemMsg?.content).toContain('Agent Disconnected')
   })
 })
 
@@ -3796,7 +3796,7 @@ describe('status step transitions during mission execution', () => {
 // ── emitMissionCompleted on stream done vs result ───────────────────────────
 
 describe('analytics: emitMissionCompleted timing', () => {
-  it('emits completion analytics on stream done when mission is running', async () => {
+  it('emits completion analytics on result message when mission is running', async () => {
     vi.mocked(emitMissionCompleted).mockClear()
 
     const { result } = renderHook(() => useMissions(), { wrapper })
@@ -3805,8 +3805,8 @@ describe('analytics: emitMissionCompleted timing', () => {
     act(() => {
       MockWebSocket.lastInstance?.simulateMessage({
         id: requestId,
-        type: 'stream',
-        payload: { content: '', done: true },
+        type: 'result',
+        payload: { content: 'All done' },
       })
     })
 


### PR DESCRIPTION
## Summary

- Update 3 failing tests in `useMissions.test.tsx` caused by intentional behavior changes in PRs #5516 and #5511
- **Analytics tests**: PR #5516 moved `emitMissionCompleted` from the stream-done handler to the result message handler. Two tests were still asserting the old stream-done behavior — updated to send `result` messages instead.
- **WS disconnect test**: PR #5511 changed the disconnect error message from `"Local Agent Not Connected"` to a more descriptive `"**Agent Disconnected**"` markdown block. Updated the assertion to match.

Closes #5518

## Test plan

- [x] All 280 tests in `useMissions.test.tsx` pass
- [x] Build succeeds
- [x] Lint passes (no new warnings)