### PR TITLE
fix: publish Helm chart to OCI registry and document install methods

### DIFF
--- a/.github/workflows/helm-release.yml
+++ b/.github/workflows/helm-release.yml
@@ -14,6 +14,7 @@ jobs:
     permissions:
       contents: write
       pages: write
+      packages: write
       id-token: write
     
     steps:
@@ -84,15 +85,29 @@ jobs:
           git commit -m "Release Helm chart ${{ steps.version.outputs.version }}" || echo "No changes"
           git push origin gh-pages --force
 
+      - name: Log in to GitHub Container Registry
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | helm registry login ghcr.io -u ${{ github.actor }} --password-stdin
+
+      - name: Push chart to OCI registry
+        run: |
+          # Push to ghcr.io/kubestellar/charts so users can:
+          #   helm pull oci://ghcr.io/kubestellar/charts/kubestellar-console
+          helm push .helm-releases/*.tgz oci://ghcr.io/kubestellar/charts
+
       - name: Summary
         run: |
           echo "## Helm Chart Released" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "- **Version**: ${{ steps.version.outputs.version }}" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
-          echo "### Installation" >> $GITHUB_STEP_SUMMARY
+          echo "### Installation (Helm repo)" >> $GITHUB_STEP_SUMMARY
           echo "\`\`\`bash" >> $GITHUB_STEP_SUMMARY
           echo "helm repo add kubestellar-console https://kubestellar.github.io/console" >> $GITHUB_STEP_SUMMARY
           echo "helm repo update" >> $GITHUB_STEP_SUMMARY
           echo "helm install kc kubestellar-console/kubestellar-console" >> $GITHUB_STEP_SUMMARY
+          echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "### Installation (OCI)" >> $GITHUB_STEP_SUMMARY
+          echo "\`\`\`bash" >> $GITHUB_STEP_SUMMARY
+          echo "helm install kc oci://ghcr.io/kubestellar/charts/kubestellar-console" >> $GITHUB_STEP_SUMMARY
           echo "\`\`\`" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -276,6 +276,7 @@ jobs:
     permissions:
       contents: write
       pages: write
+      packages: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -332,6 +333,15 @@ jobs:
           git commit -m "Release Helm chart ${{ needs.determine-version.outputs.version }}" || echo "No changes"
           git push origin gh-pages --force
 
+      - name: Log in to GitHub Container Registry
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | helm registry login ghcr.io -u ${{ github.actor }} --password-stdin
+
+      - name: Push chart to OCI registry
+        run: |
+          # Push to ghcr.io/kubestellar/charts so users can:
+          #   helm pull oci://ghcr.io/kubestellar/charts/kubestellar-console
+          helm push .helm-releases/*.tgz oci://ghcr.io/kubestellar/charts
+
   notify:
     needs: [determine-version, test, release, helm-release]
     runs-on: ubuntu-latest
@@ -359,7 +369,8 @@ jobs:
             echo "- Docker Image: \`${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ needs.determine-version.outputs.version }}\`" >> $GITHUB_STEP_SUMMARY
             echo "- Binaries: kc-agent + console for linux/darwin (amd64/arm64)" >> $GITHUB_STEP_SUMMARY
             echo "- Homebrew: \`brew upgrade kc-agent\`" >> $GITHUB_STEP_SUMMARY
-            echo "- Helm Chart: \`helm repo add kubestellar-console https://kubestellar.github.io/console && helm install kc kubestellar-console/kubestellar-console\`" >> $GITHUB_STEP_SUMMARY
+            echo "- Helm Chart (repo): \`helm repo add kubestellar-console https://kubestellar.github.io/console && helm install kc kubestellar-console/kubestellar-console\`" >> $GITHUB_STEP_SUMMARY
+            echo "- Helm Chart (OCI): \`helm install kc oci://ghcr.io/kubestellar/charts/kubestellar-console\`" >> $GITHUB_STEP_SUMMARY
           else
             echo "### Status: ${{ needs.release.result }}" >> $GITHUB_STEP_SUMMARY
           fi

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -92,12 +92,20 @@ brew install kc-agent
 
 ### Helm Charts
 
-Helm charts are published to GitHub Pages and can be added as a repository:
+Helm charts are published to both GitHub Pages and the GHCR OCI registry on every release.
+
+**Option 1: Helm repository (GitHub Pages)**
 
 ```bash
-helm repo add kubestellar https://kubestellar.github.io/console
+helm repo add kubestellar-console https://kubestellar.github.io/console
 helm repo update
-helm install kubestellar-console kubestellar/kubestellar-console
+helm install kc kubestellar-console/kubestellar-console
+```
+
+**Option 2: OCI registry (GHCR)**
+
+```bash
+helm install kc oci://ghcr.io/kubestellar/charts/kubestellar-console
 ```
 
 ## Workflow Configuration


### PR DESCRIPTION
## Summary

- **#5524**: Add OCI publishing to both `release.yml` and `helm-release.yml` workflows so that `helm pull oci://ghcr.io/kubestellar/charts/kubestellar-console` works. Previously, the chart was only published to GitHub Pages (`https://kubestellar.github.io/console`) and users who tried the OCI path got a 404.
- **#5525**: `FEEDBACK_GITHUB_TOKEN` was already wired in a prior commit (`values.yaml` lines 84-87, `secret.yaml` lines 18-20, `deployment.yaml` lines 174-180). This issue just needs closing.

### Changes

- **`.github/workflows/release.yml`**: Added `packages: write` permission, GHCR login, and `helm push` to OCI registry in the `helm-release` job
- **`.github/workflows/helm-release.yml`**: Same OCI publishing additions for the standalone workflow
- **`docs/RELEASING.md`**: Updated Helm install docs to show both methods (Helm repo and OCI), fixed repo name from `kubestellar` to `kubestellar-console`

### After merge

The OCI path will become available on the next nightly/weekly/manual release run.

Fixes #5524
Fixes #5525

## Test plan

- [ ] `helm lint deploy/helm/kubestellar-console/` passes (verified locally)
- [ ] Next release workflow run should push chart to `oci://ghcr.io/kubestellar/charts/kubestellar-console`
- [ ] `helm pull oci://ghcr.io/kubestellar/charts/kubestellar-console` should work after first OCI-enabled release