### PR TITLE
🐛 Fix Helm chart default image tag causing ImagePullBackOff

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -263,6 +263,7 @@ jobs:
           tags: |
             ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ needs.determine-version.outputs.version }}
             ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ needs.determine-version.outputs.release_type }}
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
           build-args: |
             APP_VERSION=${{ needs.determine-version.outputs.version }}
             COMMIT_HASH=${{ github.sha }}

--- a/deploy/helm/kubestellar-console/Chart.yaml
+++ b/deploy/helm/kubestellar-console/Chart.yaml
@@ -3,7 +3,7 @@ name: kubestellar-console
 description: KubeStellar Console - AI-powered multi-cluster Kubernetes dashboard
 type: application
 version: 0.0.0
-appVersion: "0.0.0"
+appVersion: "latest"
 keywords:
   - kubernetes
   - dashboard

--- a/deploy/helm/kubestellar-console/values.yaml
+++ b/deploy/helm/kubestellar-console/values.yaml
@@ -3,7 +3,7 @@ replicaCount: 1
 image:
   repository: ghcr.io/kubestellar/console
   pullPolicy: IfNotPresent
-  tag: ""  # Defaults to chart appVersion
+  tag: ""  # Defaults to chart appVersion ("latest"); overridden at release time
 
 imagePullSecrets: []
 nameOverride: ""


### PR DESCRIPTION
## Summary
- Change `appVersion` in `Chart.yaml` from `"0.0.0"` to `"latest"` so the Helm chart works out of the box when installed from source
- Add explicit `latest` tag to the release workflow's Docker push step, ensuring the tag stays current with every release
- Update `values.yaml` comment to clarify the default behavior

## Problem
When users clone the repo and install the Helm chart directly (`helm install` from the local chart), the default `appVersion: "0.0.0"` was used as the image tag. Since no `0.0.0` image exists on GHCR, the pod enters `ImagePullBackOff`. The published Helm chart (from the repo's Helm registry) doesn't have this issue because the release workflow replaces `appVersion` at packaging time.

## Fix
The `appVersion` default is now `"latest"`, which resolves to a valid container image. The release workflow already overrides `appVersion` with the actual version when publishing the chart, so this only affects local/development installs.

Closes #5526

## Test plan
- [ ] Verify `ghcr.io/kubestellar/console:latest` exists and is pullable
- [ ] Install chart from source: `helm install kc deploy/helm/kubestellar-console` — pod should start without ImagePullBackOff
- [ ] Published chart releases still get version-specific appVersion (CI handles this)