### PR TITLE
fix: stop propagation on payload card remove click

### DIFF
--- a/web/src/components/mission-control/PayloadCard.tsx
+++ b/web/src/components/mission-control/PayloadCard.tsx
@@ -120,7 +120,10 @@ export function PayloadCard({ project, onRemove, onUpdatePriority, onHover, onCl
               <Button
                 variant="ghost"
                 size="sm"
-                onClick={onRemove}
+                onClick={(e) => {
+                  e.stopPropagation()
+                  onRemove()
+                }}
                 className="opacity-0 group-hover:opacity-100 !p-0.5 rounded hover:bg-destructive/20 text-muted-foreground hover:text-destructive"
                 title="Remove"
                 icon={<X className="w-3 h-3" />}


### PR DESCRIPTION
Fixes #5533

The remove button on PayloadCard did not call `e.stopPropagation()`, so clicking it also triggered the parent card's `onClick` handler, causing noisy/incorrect UI behavior.

**Fix:** Added `e.stopPropagation()` to the remove button's click handler, consistent with how the priority dropdown already handles it.