### PR TITLE
fix: Escape only closes topmost modal, not sidebar behind it

### DIFF
--- a/web/src/components/mission-control/MissionControlDialog.tsx
+++ b/web/src/components/mission-control/MissionControlDialog.tsx
@@ -75,7 +75,7 @@ export function MissionControlDialog({ open, onClose }: MissionControlDialogProp
   // Escape to close
   const handleKeyDown = useCallback(
     (e: KeyboardEvent) => {
-      if (e.key === 'Escape') onClose()
+      if (e.key === 'Escape') { e.stopImmediatePropagation(); onClose() }
     },
     [onClose]
   )

--- a/web/src/components/missions/ClusterSelectionDialog.tsx
+++ b/web/src/components/missions/ClusterSelectionDialog.tsx
@@ -55,7 +55,7 @@ export function ClusterSelectionDialog({ open, missionTitle, onSelect, onCancel 
   // Close on Escape
   useEffect(() => {
     if (!open) return
-    const handleEsc = (e: KeyboardEvent) => { if (e.key === 'Escape') onCancel() }
+    const handleEsc = (e: KeyboardEvent) => { if (e.key === 'Escape') { e.stopImmediatePropagation(); onCancel() } }
     document.addEventListener('keydown', handleEsc)
     return () => document.removeEventListener('keydown', handleEsc)
   }, [open, onCancel])

--- a/web/src/components/missions/MissionBrowser.tsx
+++ b/web/src/components/missions/MissionBrowser.tsx
@@ -1128,6 +1128,8 @@ export function MissionBrowser({ isOpen, onClose, onImport, initialMission }: Mi
 
     const handleKeyDown = (e: KeyboardEvent) => {
       if (e.key === 'Escape') {
+        // Stop the event from reaching the sidebar's Escape handler
+        e.stopImmediatePropagation()
         if (selectedMission) {
           setSelectedMission(null)
           setRawContent(null)

--- a/web/src/components/missions/StandaloneOrbitDialog.tsx
+++ b/web/src/components/missions/StandaloneOrbitDialog.tsx
@@ -103,7 +103,12 @@ export function StandaloneOrbitDialog({ onClose }: StandaloneOrbitDialogProps) {
 
   return (
     <>
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 backdrop-blur-sm">
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 backdrop-blur-sm"
+      onKeyDown={(e) => { if (e.key === 'Escape') { e.stopPropagation(); onClose() } }}
+      tabIndex={-1}
+      ref={(el) => el?.focus()}
+    >
       <div className="w-full max-w-md mx-4 rounded-xl border border-purple-500/30 bg-card shadow-2xl overflow-hidden">
         {/* Header */}
         <div className="flex items-center justify-between px-5 py-4 border-b border-border">


### PR DESCRIPTION
stopImmediatePropagation on Escape in all 5 modals opened from the AI Mission sidebar.