### PR TITLE
fix: add assignments to installed-project memo dependencies

### DIFF
--- a/web/src/components/mission-control/useMissionControl.ts
+++ b/web/src/components/mission-control/useMissionControl.ts
@@ -704,7 +704,7 @@ Order phases by dependency — prerequisites first. Each phase completes before 
     }
 
     return { installedProjects: installed, installedOnCluster: perCluster }
-  }, [helmReleases, clusters, state.projects])
+  }, [helmReleases, clusters, state.projects, state.assignments])
 
   // ---------------------------------------------------------------------------
   // Auto-assign: deterministic local algorithm (no AI)


### PR DESCRIPTION
Fixes #5532

The `installedProjects` useMemo reads `state.assignments[0]?.clusterName` in the demo-mode seed path but the dependency array did not include `state.assignments`. This caused stale installed markers when assignments changed.