### PR TITLE
fix: use exact matching for project installation detection

### DIFF
--- a/web/src/components/mission-control/useMissionControl.ts
+++ b/web/src/components/mission-control/useMissionControl.ts
@@ -677,9 +677,7 @@ Order phases by dependency — prerequisites first. Each phase completes before 
     for (const project of state.projects) {
       const pName = project.name.toLowerCase()
       for (const [clusterName, names] of clusterNames) {
-        const found = Array.from(names).some(n =>
-          n === pName || n.includes(pName) || pName.includes(n)
-        )
+        const found = names.has(pName)
         if (found) {
           installed.add(project.name)
           if (!perCluster.has(project.name)) perCluster.set(project.name, new Set())


### PR DESCRIPTION
Fixes #5536, fixes #5535

The installed-project detection used bidirectional substring matching (`n.includes(pName) || pName.includes(n)`), which caused false positives when project names overlapped (e.g., "prom" matching "prometheus") and cluster cross-matching (e.g., "prod" matching "prod-east").

Replaced with exact Set lookup (`names.has(pName)`) which is both correct and more performant.