### PR TITLE
fix: scope scorecard permissions to job level

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -7,16 +7,18 @@ on:
     branches: [ "main" ]
   workflow_dispatch:
 
-permissions:
-  security-events: write
-  contents: read
-  actions: read
-  id-token: write
+# Global permissions must be read-only for scorecard publishing
+permissions: read-all
 
 jobs:
   analysis:
     name: Scorecard analysis
     runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      id-token: write
+      contents: read
+      actions: read
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
Global permissions must be read-all. Write permissions (security-events, id-token) scoped to job per ossf/scorecard-action requirements.