### PR TITLE
fix: include docs repo issues in feedback queue

### DIFF
--- a/pkg/api/handlers/feedback.go
+++ b/pkg/api/handlers/feedback.go
@@ -259,6 +259,7 @@ type QueueItem struct {
 	Title             string `json:"title"`
 	Description       string `json:"description"`
 	RequestType       string `json:"request_type"`
+	TargetRepo        string `json:"target_repo,omitempty"`
 	GitHubIssueNumber int    `json:"github_issue_number"`
 	GitHubIssueURL    string `json:"github_issue_url"`
 	Status            string `json:"status"`
@@ -284,21 +285,43 @@ func (h *FeedbackHandler) ListAllFeatureRequests(c *fiber.Ctx) error {
 		currentGitHubLogin = user.GitHubLogin
 	}
 
-	// Fetch issues created by the logged-in user from GitHub
-	issues, err := h.fetchGitHubIssues(currentGitHubLogin)
+	// Fetch issues created by the logged-in user from both console and docs repos
+	consoleIssues, err := h.fetchGitHubIssuesFromRepo(currentGitHubLogin, h.repoName)
 	if err != nil {
-		slog.Error("[Feedback] failed to fetch GitHub issues", "error", err)
+		slog.Error("[Feedback] failed to fetch GitHub issues from console repo", "error", err)
 		// Fall back to local database if GitHub fetch fails
 		return h.listLocalFeatureRequests(c, userID)
 	}
 
-	// Fetch linked PRs for all issues
-	linkedPRs := h.fetchLinkedPRs(issues)
+	// Also fetch from docs repo — issues can be filed there too (#5529)
+	docsRepoName := "docs"
+	docsIssues, docsErr := h.fetchGitHubIssuesFromRepo(currentGitHubLogin, docsRepoName)
+	if docsErr != nil {
+		slog.Warn("[Feedback] failed to fetch GitHub issues from docs repo", "error", docsErr)
+		// Non-fatal — continue with console issues only
+	}
+
+	// Tag each issue with its source repo for the queue
+	type taggedIssue struct {
+		GitHubIssue
+		TargetRepo string
+	}
+	taggedIssues := make([]taggedIssue, 0, len(consoleIssues)+len(docsIssues))
+	for _, issue := range consoleIssues {
+		taggedIssues = append(taggedIssues, taggedIssue{issue, "console"})
+	}
+	for _, issue := range docsIssues {
+		taggedIssues = append(taggedIssues, taggedIssue{issue, "docs"})
+	}
+
+	// Fetch linked PRs for console issues only (docs issues use different PR workflow)
+	linkedPRs := h.fetchLinkedPRs(consoleIssues)
 
 	// Convert to queue items
 	// Note: preview URLs are fetched on-demand via CheckPreviewStatus endpoint
-	queueItems := make([]QueueItem, 0, len(issues))
-	for _, issue := range issues {
+	queueItems := make([]QueueItem, 0, len(taggedIssues))
+	for _, tagged := range taggedIssues {
+		issue := tagged.GitHubIssue
 		// Determine status based on labels
 		status := "needs_triage"
 		requestType := "feature"
@@ -365,12 +388,13 @@ func (h *FeedbackHandler) ListAllFeatureRequests(c *fiber.Ctx) error {
 		closedByUser := issue.State == "closed" && issue.ClosedBy != nil && issue.ClosedBy.Login == currentGitHubLogin
 
 		queueItems = append(queueItems, QueueItem{
-			ID:                fmt.Sprintf("gh-%d", issue.Number),
+			ID:                fmt.Sprintf("gh-%s-%d", tagged.TargetRepo, issue.Number),
 			UserID:            fmt.Sprintf("gh-%d", issue.User.ID),
 			GitHubLogin:       issue.User.Login,
 			Title:             title,
 			Description:       description,
 			RequestType:       requestType,
+			TargetRepo:        tagged.TargetRepo,
 			GitHubIssueNumber: issue.Number,
 			GitHubIssueURL:    issue.HTMLURL,
 			Status:            status,
@@ -611,9 +635,14 @@ func (h *FeedbackHandler) fetchPRPages(state string) []GitHubPR {
 	return allPRs
 }
 
-// fetchGitHubIssues fetches issues created by the given user from the configured GitHub repo
+// fetchGitHubIssues fetches issues created by the given user from the specified repo
 func (h *FeedbackHandler) fetchGitHubIssues(githubLogin string) ([]GitHubIssue, error) {
-	if h.getEffectiveToken() == "" || h.repoOwner == "" || h.repoName == "" {
+	return h.fetchGitHubIssuesFromRepo(githubLogin, h.repoName)
+}
+
+// fetchGitHubIssuesFromRepo fetches issues created by the given user from a specific repo
+func (h *FeedbackHandler) fetchGitHubIssuesFromRepo(githubLogin string, repoName string) ([]GitHubIssue, error) {
+	if h.getEffectiveToken() == "" || h.repoOwner == "" || repoName == "" {
 		return nil, fmt.Errorf("GitHub not configured")
 	}
 	if githubLogin == "" {
@@ -622,7 +651,7 @@ func (h *FeedbackHandler) fetchGitHubIssues(githubLogin string) ([]GitHubIssue, 
 
 	// Fetch all issues created by the logged-in user
 	url := fmt.Sprintf("https://api.github.com/repos/%s/%s/issues?state=all&creator=%s&per_page=50&sort=updated&direction=desc",
-		h.repoOwner, h.repoName, githubLogin)
+		h.repoOwner, repoName, githubLogin)
 
 	req, err := http.NewRequest("GET", url, nil)
 	if err != nil {


### PR DESCRIPTION
Fixes #5529

The feedback queue endpoint (`/api/feedback/queue`) only fetched issues from `kubestellar/console`, but users can file issues on `kubestellar/docs` too. Docs issues would appear briefly after creation (from the API response) then vanish on the next poll.

**Changes:**
- Added `fetchGitHubIssuesFromRepo()` to fetch from any repo under the same owner
- `ListAllFeatureRequests` now fetches from both `console` and `docs` repos
- Added `target_repo` field to queue items so the frontend can distinguish issue sources
- Unique IDs now include repo name to prevent collisions (`gh-console-123` vs `gh-docs-123`)