### PR TITLE
fix: improve OpenSSF Scorecard score (YAML fix + SLSA provenance + token permissions)

### DIFF
--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -35,6 +35,10 @@ on:
           - none
 
 # Only one deploy at a time — newer commits cancel in-progress deploys
+
+# Least-privilege: read-only by default; jobs declare write scopes individually
+permissions: read-all
+
 concurrency:
   group: deploy-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/card-standard-nightly.yml
+++ b/.github/workflows/card-standard-nightly.yml
@@ -12,6 +12,9 @@ on:
       - 'web/package-lock.json'
   workflow_dispatch:
 
+# Least-privilege: read-only by default; jobs declare write scopes individually
+permissions: read-all
+
 jobs:
   card-standard:
     runs-on: ubuntu-latest

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -10,6 +10,9 @@ on:
     #   - "src/**/*.js"
     #   - "src/**/*.jsx"
 
+# Least-privilege: read-only by default; jobs declare write scopes individually
+permissions: read-all
+
 jobs:
   claude-review:
     # Optional: Filter by PR author

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -10,6 +10,9 @@ on:
   pull_request_review:
     types: [submitted]
 
+# Least-privilege: read-only by default; jobs declare write scopes individually
+permissions: read-all
+
 jobs:
   claude:
     if: |

--- a/.github/workflows/copilot-dco.yml
+++ b/.github/workflows/copilot-dco.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     types: [opened, synchronize, reopened]
 
+# Least-privilege: read-only by default; jobs declare write scopes individually
+permissions: read-all
+
 jobs:
   copilot-dco:
     if: false # Copilot disabled — issues handled by Claude Code scanner

--- a/.github/workflows/copilot-recovery.yml
+++ b/.github/workflows/copilot-recovery.yml
@@ -413,16 +413,19 @@ jobs:
             RUN_URL="${{ github.event.workflow_run.html_url }}"
             WF_NAME="${{ github.event.workflow_run.name }}"
 
-            # Post failure comment
-            gh pr comment "$PR_NUM" --repo "${{ github.repository }}" --body "## 🔴 Workflow Failed
+            # Post failure comment (use heredoc to avoid YAML alias parse errors from **)
+            gh pr comment "$PR_NUM" --repo "${{ github.repository }}" --body "$(cat <<EOF
+            ## 🔴 Workflow Failed
 
-**Workflow:** $WF_NAME
-**Status:** Failed
-**Details:** [View Workflow Run]($RUN_URL)
+            **Workflow:** $WF_NAME
+            **Status:** Failed
+            **Details:** [View Workflow Run]($RUN_URL)
 
-@copilot Please investigate the workflow failure and push fixes.
+            @copilot Please investigate the workflow failure and push fixes.
 
-*This comment was automatically generated.*"
+            *This comment was automatically generated.*
+            EOF
+            )"
           fi
 
   # Handle code review feedback on Copilot PRs

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -5,6 +5,9 @@ name: Copilot Setup Steps
 
 on: workflow_dispatch
 
+# Least-privilege: read-only by default; jobs declare write scopes individually
+permissions: read-all
+
 jobs:
   copilot-setup-steps:
     runs-on: ubuntu-latest

--- a/.github/workflows/helm-release.yml
+++ b/.github/workflows/helm-release.yml
@@ -8,6 +8,9 @@ on:
         required: true
         default: '0.1.0'
 
+# Least-privilege: read-only by default; jobs declare write scopes individually
+permissions: read-all
+
 jobs:
   release-helm:
     runs-on: ubuntu-latest

--- a/.github/workflows/helm-test.yml
+++ b/.github/workflows/helm-test.yml
@@ -12,6 +12,9 @@ on:
       - '.github/workflows/helm-test.yml'
   workflow_call: {}
 
+# Least-privilege: read-only by default; jobs declare write scopes individually
+permissions: read-all
+
 jobs:
   helm-lint-and-template:
     runs-on: ubuntu-latest

--- a/.github/workflows/perf-ttfi.yml
+++ b/.github/workflows/perf-ttfi.yml
@@ -9,6 +9,9 @@ on:
       - '.github/workflows/perf-ttfi.yml'
   workflow_dispatch:
 
+# Least-privilege: read-only by default; jobs declare write scopes individually
+permissions: read-all
+
 env:
   CI: true
 

--- a/.github/workflows/playwright-nightly.yml
+++ b/.github/workflows/playwright-nightly.yml
@@ -5,6 +5,9 @@ on:
     - cron: '30 6 * * *'  # 6:30 AM UTC daily
   workflow_dispatch: {}
 
+# Least-privilege: read-only by default; jobs declare write scopes individually
+permissions: read-all
+
 concurrency:
   group: playwright-nightly-${{ github.run_id }}
   cancel-in-progress: false

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -8,6 +8,9 @@ on:
       - '.github/workflows/playwright.yml'
   workflow_dispatch: {}
 
+# Least-privilege: read-only by default; jobs declare write scopes individually
+permissions: read-all
+
 concurrency:
   group: playwright-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,6 +25,9 @@ on:
         default: false
         type: boolean
 
+# Least-privilege: read-only by default; jobs declare write scopes individually
+permissions: read-all
+
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
@@ -194,6 +197,8 @@ jobs:
     permissions:
       contents: write
       packages: write
+      id-token: write
+      attestations: write
 
     steps:
       - name: Checkout repository
@@ -255,6 +260,7 @@ jobs:
           RELEASE_NAME: ${{ needs.determine-version.outputs.release_name }}
 
       - name: Build and push Docker image
+        id: docker-push
         uses: docker/build-push-action@14487ce63c7a62a4a324b0bfb37086795e31c6c1 # v6.16.0
         with:
           context: .
@@ -269,6 +275,18 @@ jobs:
             COMMIT_HASH=${{ github.sha }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+
+      - name: Attest container image provenance
+        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
+        with:
+          subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          subject-digest: ${{ steps.docker-push.outputs.digest }}
+          push-to-registry: true
+
+      - name: Attest GoReleaser binary artifacts
+        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
+        with:
+          subject-path: dist/*.tar.gz
 
   helm-release:
     needs: [determine-version, release, helm-test]

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -21,18 +21,18 @@ jobs:
       actions: read
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           persist-credentials: false
 
       - name: Run Scorecard
-        uses: ossf/scorecard-action@v2.4.0
+        uses: ossf/scorecard-action@62b2cac7ed8198b15735ed49ab1e5cf35480ba46 # v2.4.0
         with:
           results_file: results.sarif
           results_format: sarif
           publish_results: true
 
       - name: Upload SARIF
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@5c8a8a642e79153f5d047b10ec1cba1d1cc65699 # v3
         with:
           sarif_file: results.sarif

--- a/.github/workflows/ui-ux-standard.yml
+++ b/.github/workflows/ui-ux-standard.yml
@@ -12,6 +12,9 @@ on:
       - 'web/package-lock.json'
   workflow_dispatch:
 
+# Least-privilege: read-only by default; jobs declare write scopes individually
+permissions: read-all
+
 jobs:
   ui-ux-standard:
     if: github.repository == 'kubestellar/console'

--- a/.github/workflows/visual-regression.yml
+++ b/.github/workflows/visual-regression.yml
@@ -11,6 +11,9 @@ on:
       - 'web/e2e/visual/**'
   workflow_dispatch:
 
+# Least-privilege: read-only by default; jobs declare write scopes individually
+permissions: read-all
+
 jobs:
   visual-regression:
     if: github.repository == 'kubestellar/console'


### PR DESCRIPTION
## Summary
- **Fix YAML parse error** in `copilot-recovery.yml` at line 419 where markdown bold syntax (`**`) was misinterpreted as a YAML alias reference. Converted the inline multiline string to a heredoc, matching the pattern used elsewhere in the file. This unblocks **4 scorecard checks** (Dangerous-Workflow, Pinned-Dependencies, SAST, Token-Permissions) that were erroring with "invalid GitHub workflow".
- **Add SLSA build provenance attestation** to the release workflow for both the container image (pushed to GHCR) and GoReleaser binary artifacts using `actions/attest-build-provenance@v4.1.0`. This addresses the **Signed-Releases** check (previously scoring 0).
- **Add top-level `permissions: read-all`** to 14 workflow files that were missing it, following the principle of least privilege. Jobs that need write access already have job-level permission overrides. This addresses the **Token-Permissions** check.
- **Pin actions** in `scorecard.yml` to full commit SHAs for reproducibility.

## Expected Scorecard Impact
| Check | Before | After (expected) |
|-------|--------|-------------------|
| Dangerous-Workflow | ? (error) | Scored |
| Pinned-Dependencies | ? (error) | Scored |
| SAST | ? (error) | Scored |
| Token-Permissions | ? (error) | Scored |
| Signed-Releases | 0 | 10 |
| Branch-Protection | 3 | 3 (unchanged, by design) |
| Code-Review | 0 | 0 (unchanged, single maintainer) |
| Maintained | 0 | 0 (repo age, not activity) |

## Test plan
- [ ] Verify all YAML workflows parse correctly (validated locally with Python yaml.safe_load)
- [ ] Build/lint CI passes
- [ ] Next release run produces provenance attestations
- [ ] Re-run OpenSSF Scorecard after merge to verify improved score