### PR TITLE
fix: discard snapshots with unparseable timestamps in metrics history

### DIFF
--- a/pkg/agent/metrics_history.go
+++ b/pkg/agent/metrics_history.go
@@ -246,7 +246,7 @@ func (mh *MetricsHistory) captureSnapshot() error {
 	trimmed := make([]MetricsSnapshot, 0, len(mh.snapshots))
 	for _, s := range mh.snapshots {
 		ts, err := time.Parse(time.RFC3339, s.Timestamp)
-		if err != nil || ts.After(cutoff) {
+		if err == nil && ts.After(cutoff) {
 			trimmed = append(trimmed, s)
 		}
 	}
@@ -313,7 +313,7 @@ func (mh *MetricsHistory) loadFromDisk() {
 	filtered := make([]MetricsSnapshot, 0)
 	for _, s := range snapshots {
 		ts, err := time.Parse(time.RFC3339, s.Timestamp)
-		if err != nil || ts.After(cutoff) {
+		if err == nil && ts.After(cutoff) {
 			filtered = append(filtered, s)
 		}
 	}


### PR DESCRIPTION
Fixes #5552

The retention trimming logic in `metrics_history.go` used `if err != nil || ts.After(cutoff)`, which retained snapshots with unparseable timestamps forever (since parse error made the condition always true). Changed to `if err == nil && ts.After(cutoff)` so corrupted snapshots are discarded instead of accumulating indefinitely.

Fixed in both `trimAndSave()` and `loadFromDisk()` paths.