### PR TITLE
fix: localize hardcoded strings in ChartVersions and AppStatus

### DIFF
--- a/web/src/components/cards/AppStatus.tsx
+++ b/web/src/components/cards/AppStatus.tsx
@@ -1,4 +1,5 @@
 import { useMemo } from 'react'
+import { useTranslation } from 'react-i18next'
 import { Box, CheckCircle, AlertTriangle, Clock, ChevronRight } from 'lucide-react'
 import { ClusterBadge } from '../ui/ClusterBadge'
 import { useDrillDownActions } from '../../hooks/useDrillDown'
@@ -44,6 +45,7 @@ interface AppData {
 }
 
 export function AppStatus(_props: AppStatusProps) {
+  const { t } = useTranslation()
   const { drillToDeployment } = useDrillDownActions()
   const { deployments, isLoading, isRefreshing, isDemoFallback, isFailed, consecutiveFailures, lastRefresh } = useCachedDeployments()
 
@@ -172,8 +174,8 @@ export function AppStatus(_props: AppStatusProps) {
     return (
       <CardEmptyState
         icon={Box}
-        title="No applications found"
-        message="Deploy applications to see their status across clusters."
+        title={t('appStatus.noApps', 'No applications found')}
+        message={t('appStatus.deployApps', 'Deploy applications to see their status across clusters.')}
       />
     )
   }

--- a/web/src/components/cards/ChartVersions.tsx
+++ b/web/src/components/cards/ChartVersions.tsx
@@ -119,8 +119,8 @@ export function ChartVersions({ config: _config }: ChartVersionsProps) {
   if (showEmptyState) {
     return (
       <div className="h-full flex flex-col items-center justify-center min-h-card text-muted-foreground">
-        <p className="text-sm">No Helm charts</p>
-        <p className="text-xs mt-1">Install Helm charts to track versions</p>
+        <p className="text-sm">{t('chartVersions.noCharts', 'No Helm charts')}</p>
+        <p className="text-xs mt-1">{t('chartVersions.installCharts', 'Install Helm charts to track versions')}</p>
       </div>
     )
   }
@@ -226,7 +226,9 @@ export function ChartVersions({ config: _config }: ChartVersionsProps) {
 
           {/* Footer */}
           <div className="mt-4 pt-3 border-t border-border/50 text-xs text-muted-foreground">
-            {totalItems} releases{localClusterFilter.length > 0 ? ` in ${localClusterFilter.length} cluster${localClusterFilter.length > 1 ? 's' : ''}` : ' across all clusters'}
+            {localClusterFilter.length > 0
+              ? t('chartVersions.releasesInClusters', '{{count}} releases in {{clusters}} cluster(s)', { count: totalItems, clusters: localClusterFilter.length })
+              : t('chartVersions.releasesAllClusters', '{{count}} releases across all clusters', { count: totalItems })}
           </div>
         </>
       )}


### PR DESCRIPTION
Fixes #5586, fixes #5587, fixes #5589

- ChartVersions: Replaced hardcoded "No Helm charts" and inline pluralization with `t()` calls
- AppStatus: Replaced hardcoded "No applications found" empty state with `t()` calls
- All strings use fallback defaults for backwards compatibility