### PR TITLE
fix: propagate JSON decode errors in kagent/kagenti clients

### DIFF
--- a/pkg/kagent/client.go
+++ b/pkg/kagent/client.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	neturl "net/url"
 	"os"
+	"bytes"
 	"strings"
 	"time"
 )
@@ -86,8 +87,7 @@ func (c *KagentClient) ListAgents() ([]AgentInfo, error) {
 
 	var agents []AgentInfo
 	if err := json.NewDecoder(resp.Body).Decode(&agents); err != nil {
-		// The controller may return a wrapper object — try unwrapping
-		return []AgentInfo{}, nil
+		return nil, fmt.Errorf("failed to decode agent list: %w", err)
 	}
 	return agents, nil
 }
@@ -152,7 +152,7 @@ func (c *KagentClient) Invoke(ctx context.Context, namespace, agentName, message
 
 	url := fmt.Sprintf("%s/api/a2a/%s/%s",
 		c.baseURL, neturl.PathEscape(namespace), neturl.PathEscape(agentName))
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, strings.NewReader(string(payload)))
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(payload))
 	if err != nil {
 		return nil, fmt.Errorf("failed to create request: %w", err)
 	}

--- a/pkg/kagenti_provider/client.go
+++ b/pkg/kagenti_provider/client.go
@@ -86,8 +86,7 @@ func (c *KagentiClient) ListAgents() ([]AgentInfo, error) {
 
 	var agents []AgentInfo
 	if err := json.NewDecoder(resp.Body).Decode(&agents); err != nil {
-		// The controller may return a wrapper object — try unwrapping
-		return []AgentInfo{}, nil
+		return nil, fmt.Errorf("failed to decode agent list: %w", err)
 	}
 	return agents, nil
 }


### PR DESCRIPTION
Fixes #5564, fixes #5565, fixes #5572

- **kagent/client.go**: Propagate JSON decode error instead of silently returning empty array
- **kagent/client.go**: Use `bytes.NewReader(payload)` instead of `strings.NewReader(string(payload))` to avoid unnecessary `[]byte→string→[]byte` conversion
- **kagenti_provider/client.go**: Same decode error propagation fix