### PR TITLE
fix: timer cleanup in AuthCallback + complete loading state in ActiveAlerts

### DIFF
--- a/web/src/components/auth/AuthCallback.tsx
+++ b/web/src/components/auth/AuthCallback.tsx
@@ -22,6 +22,7 @@ export function AuthCallback() {
   const { showToast } = useToast()
   const [status, setStatus] = useState(t('authCallback.signingIn'))
   const hasProcessed = useRef(false)
+  const errorTimerRef = useRef<ReturnType<typeof setTimeout>>(undefined)
 
   useEffect(() => {
     // Prevent running multiple times
@@ -80,10 +81,12 @@ export function AuthCallback() {
         clearTimeout(timeoutId)
         showToast(t('authCallback.failedToFetchUser'), 'warning')
         setStatus(t('authCallback.completingSignIn'))
-        setTimeout(() => {
+        errorTimerRef.current = setTimeout(() => {
           navigate(getLoginWithError('token_exchange_failed'))
         }, NAVIGATE_AFTER_ERROR_DELAY_MS)
       })
+
+    return () => clearTimeout(errorTimerRef.current)
   }, [searchParams, setToken, refreshUser, navigate, showToast, t])
 
   return (

--- a/web/src/components/cards/ActiveAlerts.tsx
+++ b/web/src/components/cards/ActiveAlerts.tsx
@@ -62,11 +62,15 @@ export function ActiveAlerts() {
   const { selectedSeverities, isAllSeveritiesSelected, customFilter } = useGlobalFilters()
   const { isDemoMode } = useDemoMode()
 
-  // Report state to CardWrapper for refresh animation
+  // Report state to CardWrapper for refresh animation and demo badge
   useCardLoadingState({
     isLoading: false,
-    hasAnyData: true,
-    isDemoData: isDemoMode })
+    isRefreshing: false,
+    hasAnyData: activeAlerts.length > 0 || acknowledgedAlerts.length > 0,
+    isDemoData: isDemoMode,
+    isFailed: false,
+    consecutiveFailures: 0,
+  })
   const { drillToAlert } = useDrillDownActions()
   const { missions, setActiveMission, openSidebar } = useMissions()
 


### PR DESCRIPTION
Fixes #5573, fixes #5580

- **AuthCallback.tsx**: Added ref-tracked cleanup for the error navigation setTimeout to prevent DOM mutation after unmount
- **ActiveAlerts.tsx**: Added missing `isRefreshing`, `isFailed`, `consecutiveFailures` to `useCardLoadingState()` call; also made `hasAnyData` reflect actual alert count instead of hardcoded `true`