### PR TITLE
fix: pause polling on hidden KeepAlive routes to prevent nav blocking

### DIFF
--- a/web/src/components/layout/KeepAliveOutlet.tsx
+++ b/web/src/components/layout/KeepAliveOutlet.tsx
@@ -14,6 +14,7 @@ import { useLocation, useOutlet } from 'react-router-dom'
 import { ContentLoadingSkeleton } from './Layout'
 import { ChunkErrorBoundary } from '../ChunkErrorBoundary'
 import { PageErrorBoundary } from '../PageErrorBoundary'
+import { KeepAliveActiveContext } from '../../hooks/useKeepAliveActive'
 
 const MAX_CACHED = 8
 
@@ -87,13 +88,15 @@ export function KeepAliveOutlet() {
           data-keepalive-active={active ? 'true' : 'false'}
           style={{ display: active ? 'contents' : 'none' }}
         >
-          <ChunkErrorBoundary>
-            <PageErrorBoundary>
-              <Suspense fallback={<ContentLoadingSkeleton />}>
-                {element}
-              </Suspense>
-            </PageErrorBoundary>
-          </ChunkErrorBoundary>
+          <KeepAliveActiveContext.Provider value={active}>
+            <ChunkErrorBoundary>
+              <PageErrorBoundary>
+                <Suspense fallback={<ContentLoadingSkeleton />}>
+                  {element}
+                </Suspense>
+              </PageErrorBoundary>
+            </ChunkErrorBoundary>
+          </KeepAliveActiveContext.Provider>
         </div>
       ))}
     </>

--- a/web/src/hooks/useKeepAliveActive.ts
+++ b/web/src/hooks/useKeepAliveActive.ts
@@ -1,0 +1,22 @@
+/**
+ * useKeepAliveActive — returns whether the current component is on the active
+ * KeepAlive route.
+ *
+ * Components inside a KeepAliveOutlet stay mounted even when their route is
+ * hidden (`display: none`). This hook lets polling hooks (e.g. useCache) pause
+ * auto-refresh while the route is inactive, preventing hidden dashboards from
+ * continuously fetching and triggering React state updates that block the
+ * active route from rendering (#5856).
+ *
+ * Returns `true` when:
+ *   - The component is on the currently-active KeepAlive route, OR
+ *   - The component is NOT inside a KeepAlive wrapper (safe default).
+ */
+
+import { useContext, createContext } from 'react'
+
+export const KeepAliveActiveContext = createContext<boolean>(true)
+
+export function useKeepAliveActive(): boolean {
+  return useContext(KeepAliveActiveContext)
+}

--- a/web/src/lib/cache/index.ts
+++ b/web/src/lib/cache/index.ts
@@ -24,6 +24,7 @@
  */
 
 import { useEffect, useCallback, useRef, useSyncExternalStore } from 'react'
+import { useKeepAliveActive } from '../../hooks/useKeepAliveActive'
 import { isDemoMode, subscribeDemoMode } from '../demoMode'
 import { registerCacheReset, registerRefetch } from '../modeTransition'
 import { STORAGE_KEY_KUBECTL_HISTORY } from '../constants'
@@ -1096,6 +1097,10 @@ export function useCache<T>({
     subscribeAutoRefreshPaused, isAutoRefreshPaused, isAutoRefreshPaused
   )
 
+  // Pause polling when this component is on an inactive KeepAlive route (#5856).
+  // Hidden routes should not fetch or trigger state updates that block rendering.
+  const keepAliveActive = useKeepAliveActive()
+
   // Effective enabled: both the passed prop AND not in demo mode
   // liveInDemoMode bypasses the demo check for cards backed by serverless functions
   const effectiveEnabled = enabled && (!demoMode || liveInDemoMode)
@@ -1155,9 +1160,9 @@ export function useCache<T>({
   progressiveFetcherRef.current = progressiveFetcher
 
   const refetch = useCallback(async () => {
-    if (!effectiveEnabled) return
+    if (!effectiveEnabled || !keepAliveActive) return
     await store.fetch(() => fetcherRef.current(), mergeRef.current, progressiveFetcherRef.current)
-  }, [effectiveEnabled, store])
+  }, [effectiveEnabled, keepAliveActive, store])
 
   const clearAndRefetch = async () => {
     await store.clear()
@@ -1204,7 +1209,9 @@ export function useCache<T>({
 
     // Auto-refresh interval — uses a ref-tracked timer to prevent thrashing.
     // Only create a new timer if none is already pending (#5252).
-    if (autoRefresh && !autoRefreshGloballyPaused) {
+    // Pause when the route is inactive in KeepAlive to stop hidden dashboards
+    // from polling and blocking the active route (#5856).
+    if (autoRefresh && !autoRefreshGloballyPaused && keepAliveActive) {
       if (!autoRefreshTimerRef.current) {
         autoRefreshTimerRef.current = setInterval(() => {
           refetch().catch(() => { /* errors handled inside CacheStore.fetch */ })
@@ -1218,18 +1225,18 @@ export function useCache<T>({
     return () => {
       unregisterRefetch()
     }
-  }, [effectiveEnabled, autoRefresh, autoRefreshGloballyPaused, refetch, store, key])
+  }, [effectiveEnabled, autoRefresh, autoRefreshGloballyPaused, keepAliveActive, refetch, store, key])
 
   // Restart the auto-refresh timer when the backoff interval changes.
   // Separated from the main effect to avoid re-running mount/mode-transition logic (#5252).
   useEffect(() => {
-    if (!autoRefreshTimerRef.current || !autoRefresh || autoRefreshGloballyPaused) return
+    if (!autoRefreshTimerRef.current || !autoRefresh || autoRefreshGloballyPaused || !keepAliveActive) return
     // Clear old timer and create a new one with updated interval
     clearInterval(autoRefreshTimerRef.current)
     autoRefreshTimerRef.current = setInterval(() => {
       refetch().catch(() => { /* errors handled inside CacheStore.fetch */ })
     }, effectiveInterval)
-  }, [effectiveInterval, autoRefresh, autoRefreshGloballyPaused, refetch])
+  }, [effectiveInterval, autoRefresh, autoRefreshGloballyPaused, keepAliveActive, refetch])
 
   // Clean up auto-refresh timer on unmount
   useEffect(() => {

--- a/web/src/lib/dynamic-cards/useCardFetch.ts
+++ b/web/src/lib/dynamic-cards/useCardFetch.ts
@@ -1,5 +1,6 @@
 import { useState, useEffect, useCallback, useRef } from 'react'
 import { STORAGE_KEY_TOKEN } from '../constants'
+import { useKeepAliveActive } from '../../hooks/useKeepAliveActive'
 
 /**
  * Result returned by useCardFetch — mirrors common data-fetching hook patterns.
@@ -71,6 +72,9 @@ export function createCardFetchScope() {
     const fetchIdRef = useRef(0)
     const abortRef = useRef<AbortController | null>(null)
 
+    // Pause polling when on an inactive KeepAlive route (#5856)
+    const keepAliveActive = useKeepAliveActive()
+
     const doFetch = useCallback(() => {
       if (!url) {
         setData(null)
@@ -78,6 +82,9 @@ export function createCardFetchScope() {
         setError(null)
         return
       }
+
+      // Skip fetch when on an inactive KeepAlive route (#5856)
+      if (!keepAliveActive) return
 
       // Per-card concurrency guard
       if (activeFetchCount >= MAX_CONCURRENT_FETCHES) {
@@ -131,19 +138,19 @@ export function createCardFetchScope() {
         .finally(() => {
           activeFetchCount = Math.max(0, activeFetchCount - 1)
         })
-    }, [url])
+    }, [url, keepAliveActive])
 
     // Initial fetch + auto-refresh
     useEffect(() => {
       mountedRef.current = true
 
-      if (!options?.skip) {
+      if (!options?.skip && keepAliveActive) {
         doFetch()
       }
 
-      // Set up auto-refresh if requested
+      // Set up auto-refresh if requested (paused when KeepAlive route is inactive)
       let intervalId: ReturnType<typeof setInterval> | undefined
-      if (options?.refreshInterval && options.refreshInterval > 0 && !options?.skip) {
+      if (options?.refreshInterval && options.refreshInterval > 0 && !options?.skip && keepAliveActive) {
         const clamped = Math.max(options.refreshInterval, MIN_REFRESH_INTERVAL_MS)
         intervalId = setInterval(doFetch, clamped)
       }
@@ -153,7 +160,7 @@ export function createCardFetchScope() {
         abortRef.current?.abort()
         if (intervalId) clearInterval(intervalId)
       }
-    }, [url, options?.refreshInterval, options?.skip, doFetch])
+    }, [url, options?.refreshInterval, options?.skip, doFetch, keepAliveActive])
 
     return { data, loading, error, refetch: doFetch }
   }

--- a/web/src/lib/unified/card/hooks/useDataSource.ts
+++ b/web/src/lib/unified/card/hooks/useDataSource.ts
@@ -11,6 +11,7 @@
 import { useState, useEffect, useCallback, useSyncExternalStore } from 'react'
 import type { CardDataSource } from '../../types'
 import { FETCH_DEFAULT_TIMEOUT_MS } from '../../../constants'
+import { useKeepAliveActive } from '../../../../hooks/useKeepAliveActive'
 
 // Hook registry - populated by registerDataHook
 const dataHookRegistry: Record<
@@ -231,11 +232,14 @@ function useApiDataSourceInternal(
   const [isLoading, setIsLoading] = useState(!!endpoint)
   const [error, setError] = useState<Error | null>(null)
 
+  // Pause polling when this component is on an inactive KeepAlive route (#5856)
+  const keepAliveActive = useKeepAliveActive()
+
   // Stringify params for stable dependency comparison
   const paramsKey = params ? JSON.stringify(params) : ''
 
   const fetchData = useCallback(async () => {
-    if (!endpoint) return
+    if (!endpoint || !keepAliveActive) return
 
     try {
       setIsLoading(true)
@@ -274,22 +278,22 @@ function useApiDataSourceInternal(
     } finally {
       setIsLoading(false)
     }
-  }, [endpoint, method, paramsKey]) // eslint-disable-line react-hooks/exhaustive-deps
+  }, [endpoint, method, paramsKey, keepAliveActive]) // eslint-disable-line react-hooks/exhaustive-deps
 
   // Initial fetch (only if endpoint is provided)
   useEffect(() => {
-    if (endpoint) {
+    if (endpoint && keepAliveActive) {
       fetchData()
     }
-  }, [endpoint, fetchData])
+  }, [endpoint, fetchData, keepAliveActive])
 
-  // Polling (only if endpoint and pollInterval are provided)
+  // Polling (only if endpoint and pollInterval are provided, and route is active)
   useEffect(() => {
-    if (!endpoint || !pollInterval || pollInterval <= 0) return
+    if (!endpoint || !pollInterval || pollInterval <= 0 || !keepAliveActive) return
 
     const interval = setInterval(fetchData, pollInterval)
     return () => clearInterval(interval)
-  }, [endpoint, fetchData, pollInterval])
+  }, [endpoint, fetchData, pollInterval, keepAliveActive])
 
   // Return empty result if no endpoint
   if (!endpoint) {


### PR DESCRIPTION
## Summary
When navigating away from a custom dashboard with auto-refreshing cards, the URL changed but content didn't update. Root cause: KeepAlive keeps hidden routes alive, and their polling `setInterval` timers continued firing state updates that blocked React from rendering the new route.

### Changes
- **New hook**: `useKeepAliveActive()` — reads `isActive` from `KeepAliveActiveContext`
- **KeepAliveOutlet**: Wraps each route in `<KeepAliveActiveContext.Provider value={active}>`
- **useCache**: Skips fetches and clears intervals when `!keepAliveActive`
- **useDataSource**: Same guard for unified card data sources
- **useCardFetch**: Same guard for dynamic card fetches

Polling resumes automatically when the user navigates back.

Fixes #5856

## Test plan
- [x] `npm run build` passes
- [x] Hidden routes no longer trigger state updates
- [x] Navigation between dashboards works immediately

🤖 Generated with [Claude Code](https://claude.com/claude-code)