### PR TITLE
fix: KeepAlive followups for initial fetch and in-flight guards

### DIFF
--- a/web/src/lib/cache/index.ts
+++ b/web/src/lib/cache/index.ts
@@ -1196,8 +1196,9 @@ export function useCache<T>({
 
     // Only fetch immediately on initial mount or page navigation, NOT when
     // the effect re-fires due to consecutiveFailures/backoff interval changes.
-    if (!isModeTransition && !initialFetchDoneRef.current) {
-      // Initial mount or page navigation remount — fetch immediately
+    if (!isModeTransition && !initialFetchDoneRef.current && keepAliveActive) {
+      // Initial mount or page navigation remount — fetch immediately.
+      // Only mark done when we actually started a fetch (#5891).
       initialFetchDoneRef.current = true
       refetch().catch(() => { /* errors handled inside CacheStore.fetch */ })
     }

--- a/web/src/lib/unified/card/hooks/useDataSource.ts
+++ b/web/src/lib/unified/card/hooks/useDataSource.ts
@@ -8,7 +8,7 @@
  * - context: Read from React context
  */
 
-import { useState, useEffect, useCallback, useSyncExternalStore } from 'react'
+import { useState, useEffect, useCallback, useRef, useSyncExternalStore } from 'react'
 import type { CardDataSource } from '../../types'
 import { FETCH_DEFAULT_TIMEOUT_MS } from '../../../constants'
 import { useKeepAliveActive } from '../../../../hooks/useKeepAliveActive'
@@ -234,12 +234,15 @@ function useApiDataSourceInternal(
 
   // Pause polling when this component is on an inactive KeepAlive route (#5856)
   const keepAliveActive = useKeepAliveActive()
+  // Track active state in a ref so in-flight fetches can check before setState (#5891)
+  const keepAliveActiveRef = useRef(keepAliveActive)
+  keepAliveActiveRef.current = keepAliveActive
 
   // Stringify params for stable dependency comparison
   const paramsKey = params ? JSON.stringify(params) : ''
 
   const fetchData = useCallback(async () => {
-    if (!endpoint || !keepAliveActive) return
+    if (!endpoint || !keepAliveActiveRef.current) return
 
     try {
       setIsLoading(true)
@@ -272,13 +275,16 @@ function useApiDataSourceInternal(
       if (!json) throw new Error('Invalid JSON response from API')
       // Assume response is array or has data array property
       const resultData = Array.isArray(json) ? json : json.data ?? json.items ?? []
+      // Skip state update if route became inactive while fetch was in flight (#5891)
+      if (!keepAliveActiveRef.current) return
       setData(resultData)
     } catch (err) {
+      if (!keepAliveActiveRef.current) return
       setError(err instanceof Error ? err : new Error(String(err)))
     } finally {
-      setIsLoading(false)
+      if (keepAliveActiveRef.current) setIsLoading(false)
     }
-  }, [endpoint, method, paramsKey, keepAliveActive]) // eslint-disable-line react-hooks/exhaustive-deps
+  }, [endpoint, method, paramsKey]) // eslint-disable-line react-hooks/exhaustive-deps
 
   // Initial fetch (only if endpoint is provided)
   useEffect(() => {


### PR DESCRIPTION
## Summary
Address 2 Copilot review comments on PR #5890:

1. **useCache**: Defer setting `initialFetchDoneRef.current = true` until the route is actually active and the fetch starts. Previously the flag was set even when KeepAlive paused the fetch, so the initial fetch would never happen when the route became active later.

2. **useDataSource**: Add `keepAliveActiveRef` so in-flight fetches that started while active can check before calling `setData`/`setError`/`setIsLoading` after the route becomes inactive.

Fixes #5891

## Test plan
- [x] `npm run build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)