### PR TITLE
feat(clusters): add Remove cluster button for offline clusters (#5901)

### DIFF
--- a/web/src/components/clusters/Clusters.tsx
+++ b/web/src/components/clusters/Clusters.tsx
@@ -7,6 +7,7 @@ import { AddClusterDialog } from './AddClusterDialog'
 import { EmptyClusterState } from './EmptyClusterState'
 import {
   RenameModal,
+  RemoveClusterDialog,
   FilterTabs,
   ClusterGrid,
   GPUDetailModal,
@@ -133,6 +134,7 @@ export function Clusters() {
     return (stored as ClusterLayoutMode) || 'grid'
   })
   const [renamingCluster, setRenamingCluster] = useState<string | null>(null)
+  const [removingCluster, setRemovingCluster] = useState<string | null>(null)
 
   // Additional UI state
   const [showClusterGrid, setShowClusterGrid] = useState(true) // Cluster cards visible by default
@@ -155,6 +157,26 @@ export function Clusters() {
       const data = await response.json().catch(() => ({})) as { message?: string }
       throw new Error(data.message || 'Failed to rename context')
     }
+    refetch()
+  }
+
+  /**
+   * Remove an offline cluster's kubeconfig context (#5901).
+   * Backend: `RemoveContext` in pkg/k8s/client.go (added in #5658). The agent
+   * exposes it at POST /kubeconfig/remove on the localhost-only HTTP server.
+   */
+  const handleRemoveCluster = async (contextName: string) => {
+    if (!isConnected) throw new Error(t('cluster.removeClusterNoAgent'))
+    const response = await fetch(`${LOCAL_AGENT_HTTP_URL}/kubeconfig/remove`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ context: contextName }),
+      signal: AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS) })
+    if (!response.ok) {
+      const data = await response.json().catch(() => ({})) as { error?: string; message?: string }
+      throw new Error(data.error || data.message || t('cluster.removeClusterError'))
+    }
+    showToast(t('cluster.removeClusterSuccess', { name: contextName }), 'success')
     refetch()
   }
 
@@ -352,6 +374,7 @@ export function Clusters() {
                   onSelectCluster={setSelectedCluster}
                   onRenameCluster={setRenamingCluster}
                   onRefreshCluster={refreshSingleCluster}
+                  onRemoveCluster={setRemovingCluster}
                   onReorder={handleReorder}
                 />
               )}
@@ -413,6 +436,22 @@ export function Clusters() {
           onRename={handleRenameContext}
         />
       )}
+
+      {/* Remove Offline Cluster Modal (#5901) */}
+      {removingCluster && (() => {
+        const target = clusters.find(c => c.name === removingCluster)
+        // Prefer the kubeconfig context string (what the backend expects); fall back to name
+        const ctxName = target?.context || removingCluster
+        const displayName = target?.context || target?.name || removingCluster
+        return (
+          <RemoveClusterDialog
+            contextName={ctxName}
+            displayName={displayName}
+            onClose={() => setRemovingCluster(null)}
+            onConfirm={handleRemoveCluster}
+          />
+        )
+      })()}
 
       {/* GPU Detail Modal */}
       {showGPUModal && (

--- a/web/src/components/clusters/components/ClusterGrid.tsx
+++ b/web/src/components/clusters/components/ClusterGrid.tsx
@@ -1,5 +1,5 @@
 import { memo, useState, useEffect, useRef } from 'react'
-import { Pencil, Globe, User, ShieldAlert, ChevronRight, Star, WifiOff, RefreshCw, ExternalLink, AlertCircle, Cpu, Box, Server, KeyRound, Copy, Check, GripVertical, Play, Square, RotateCcw } from 'lucide-react'
+import { Pencil, Globe, User, ShieldAlert, ChevronRight, Star, WifiOff, RefreshCw, ExternalLink, AlertCircle, Cpu, Box, Server, KeyRound, Copy, Check, GripVertical, Play, Square, RotateCcw, Trash2 } from 'lucide-react'
 import {
   DndContext,
   closestCenter,
@@ -233,6 +233,8 @@ interface ClusterGridProps {
   onSelectCluster: (clusterName: string) => void
   onRenameCluster: (clusterName: string) => void
   onRefreshCluster?: (clusterName: string) => void
+  /** Invoked when the user clicks "Remove cluster" on an offline cluster card (#5901) */
+  onRemoveCluster?: (clusterName: string) => void
   onReorder?: (clusterNames: string[]) => void
   layoutMode?: ClusterLayoutMode
 }
@@ -247,9 +249,37 @@ interface ClusterCardProps {
   onSelectCluster: () => void
   onRenameCluster: () => void
   onRefreshCluster?: () => void
+  /** Invoked when the user clicks "Remove cluster" — only rendered when `unreachable` (#5901) */
+  onRemoveCluster?: () => void
   dragHandle?: React.ReactNode
   layoutMode: ClusterLayoutMode
 }
+
+/**
+ * Inline "Remove cluster" button shown only on offline/unreachable cluster cards (#5901).
+ * Delegates confirmation + API call to the parent via `onRemoveCluster`.
+ */
+const RemoveClusterButton = memo(function RemoveClusterButton({
+  onRemove,
+  size = 'sm' }: {
+  onRemove: () => void
+  size?: 'sm' | 'xs'
+}) {
+  const { t } = useTranslation()
+  const iconClass = size === 'xs' ? 'w-3 h-3' : 'w-3.5 h-3.5'
+  const btnClass = size === 'xs' ? 'p-1' : 'p-1.5'
+  return (
+    <button
+      onClick={(e) => { e.stopPropagation(); onRemove() }}
+      className={`${btnClass} rounded text-muted-foreground hover:text-red-400 hover:bg-red-500/20 transition-colors`}
+      title={t('cluster.removeCluster')}
+      aria-label={t('cluster.removeCluster')}
+      data-testid="remove-cluster-button"
+    >
+      <Trash2 className={iconClass} aria-hidden="true" />
+    </button>
+  )
+})
 
 // Keyboard handler for clickable card divs: activates on Enter or Space
 function handleCardKeyDown(callback: () => void) {
@@ -271,6 +301,7 @@ const FullClusterCard = memo(function FullClusterCard({
   onSelectCluster,
   onRenameCluster,
   onRefreshCluster,
+  onRemoveCluster,
   dragHandle }: Omit<ClusterCardProps, 'layoutMode'>) {
   const { t } = useTranslation()
   const loading = isClusterLoading(cluster)
@@ -391,6 +422,10 @@ const FullClusterCard = memo(function FullClusterCard({
                     <Pencil className="w-3 h-3" aria-hidden="true" />
                   </button>
                 )}
+                {/* Remove cluster button — only for unreachable clusters (#5901) */}
+                {isConnected && unreachable && onRemoveCluster && (cluster.source === 'kubeconfig' || !cluster.source) && (
+                  <RemoveClusterButton onRemove={onRemoveCluster} size="xs" />
+                )}
               </div>
               <div className="flex flex-col gap-1 mt-1">
                 {cluster.server && (
@@ -509,9 +544,11 @@ const ListClusterCard = memo(function ListClusterCard({
   gpuInfo,
   permissionsLoading,
   isClusterAdmin,
+  isConnected,
   onSelectCluster,
   onRefreshCluster,
-  dragHandle }: Omit<ClusterCardProps, 'layoutMode' | 'isConnected' | 'onRenameCluster'>) {
+  onRemoveCluster,
+  dragHandle }: Omit<ClusterCardProps, 'layoutMode' | 'onRenameCluster'>) {
   const { t } = useTranslation()
   const loading = isClusterLoading(cluster)
   const unreachable = isClusterUnreachable(cluster)
@@ -680,6 +717,10 @@ const ListClusterCard = memo(function ListClusterCard({
                 <RefreshCw className={`w-3.5 h-3.5 ${spinning ? 'animate-spin' : ''}`} aria-hidden="true" />
               </button>
             )}
+            {/* Remove cluster button — only for unreachable clusters (#5901) */}
+            {isConnected && unreachable && onRemoveCluster && (cluster.source === 'kubeconfig' || !cluster.source) && (
+              <RemoveClusterButton onRemove={onRemoveCluster} />
+            )}
             {!permissionsLoading && !isClusterAdmin && !unreachable && (
               <span title="Limited permissions">
                 <ShieldAlert className="w-3.5 h-3.5 text-yellow-400" />
@@ -697,8 +738,10 @@ const ListClusterCard = memo(function ListClusterCard({
 const CompactClusterCard = memo(function CompactClusterCard({
   cluster,
   gpuInfo,
+  isConnected,
   onSelectCluster,
-  dragHandle }: Omit<ClusterCardProps, 'layoutMode' | 'isConnected' | 'permissionsLoading' | 'isClusterAdmin' | 'onRenameCluster' | 'onRefreshCluster'>) {
+  onRemoveCluster,
+  dragHandle }: Omit<ClusterCardProps, 'layoutMode' | 'permissionsLoading' | 'isClusterAdmin' | 'onRenameCluster' | 'onRefreshCluster'>) {
   const { t } = useTranslation()
   const unreachable = isClusterUnreachable(cluster)
   const hasCachedData = cluster.nodeCount !== undefined && cluster.nodeCount > 0
@@ -753,6 +796,10 @@ const CompactClusterCard = memo(function CompactClusterCard({
           )}
           {cluster.isCurrent && (
             <Star className="w-3 h-3 text-primary fill-current flex-shrink-0" />
+          )}
+          {/* Remove cluster button — only for unreachable clusters (#5901) */}
+          {isConnected && unreachable && onRemoveCluster && (cluster.source === 'kubeconfig' || !cluster.source) && (
+            <RemoveClusterButton onRemove={onRemoveCluster} size="xs" />
           )}
         </div>
 
@@ -832,6 +879,7 @@ export const ClusterGrid = memo(function ClusterGrid({
   onSelectCluster,
   onRenameCluster,
   onRefreshCluster,
+  onRemoveCluster,
   onReorder,
   layoutMode = 'grid' }: ClusterGridProps) {
   const { t } = useTranslation()
@@ -881,15 +929,18 @@ export const ClusterGrid = memo(function ClusterGrid({
             return (
               <SortableClusterItem key={cluster.name} id={cluster.name} onReorder={onReorder}>
                 {(dragHandle) => {
+                  const removeHandler = onRemoveCluster ? () => onRemoveCluster(cluster.name) : undefined
                   if (layoutMode === 'list') {
                     return (
                       <ListClusterCard
                         cluster={cluster}
                         gpuInfo={gpuInfo}
+                        isConnected={isConnected}
                         permissionsLoading={permissionsLoading}
                         isClusterAdmin={clusterIsAdmin}
                         onSelectCluster={() => onSelectCluster(cluster.name)}
                         onRefreshCluster={onRefreshCluster ? () => onRefreshCluster(cluster.name) : undefined}
+                        onRemoveCluster={removeHandler}
                         dragHandle={dragHandle}
                       />
                     )
@@ -900,7 +951,9 @@ export const ClusterGrid = memo(function ClusterGrid({
                       <CompactClusterCard
                         cluster={cluster}
                         gpuInfo={gpuInfo}
+                        isConnected={isConnected}
                         onSelectCluster={() => onSelectCluster(cluster.name)}
+                        onRemoveCluster={removeHandler}
                         dragHandle={dragHandle}
                       />
                     )
@@ -917,6 +970,7 @@ export const ClusterGrid = memo(function ClusterGrid({
                       onSelectCluster={() => onSelectCluster(cluster.name)}
                       onRenameCluster={() => onRenameCluster(cluster.name)}
                       onRefreshCluster={onRefreshCluster ? () => onRefreshCluster(cluster.name) : undefined}
+                      onRemoveCluster={removeHandler}
                       dragHandle={dragHandle}
                     />
                   )

--- a/web/src/components/clusters/components/RemoveClusterDialog.tsx
+++ b/web/src/components/clusters/components/RemoveClusterDialog.tsx
@@ -1,0 +1,111 @@
+import { useState } from 'react'
+import { Loader2, Trash2, AlertTriangle } from 'lucide-react'
+import { useTranslation } from 'react-i18next'
+import { BaseModal } from '../../../lib/modals'
+
+interface RemoveClusterDialogProps {
+  isOpen?: boolean
+  /** Context name as stored in kubeconfig (what the backend needs) */
+  contextName: string
+  /** Friendly display name shown to the user */
+  displayName: string
+  onClose: () => void
+  /** Resolves on success, rejects with an Error on failure */
+  onConfirm: (contextName: string) => Promise<void>
+}
+
+/**
+ * Confirmation dialog for removing an offline cluster's kubeconfig context.
+ *
+ * Implements issue #5901: the backend endpoint for removing a stale kubeconfig
+ * context (`/kubeconfig/remove`) was added in #5658 but there was no UI affordance
+ * to invoke it. This dialog is surfaced from the cluster card's "Remove cluster"
+ * button, which only appears for unreachable clusters.
+ */
+export function RemoveClusterDialog({
+  isOpen = true,
+  contextName,
+  displayName,
+  onClose,
+  onConfirm }: RemoveClusterDialogProps) {
+  const { t } = useTranslation()
+  const [status, setStatus] = useState<{ removing: boolean; error: string | null }>({
+    removing: false,
+    error: null })
+
+  const handleConfirm = async () => {
+    setStatus({ removing: true, error: null })
+    try {
+      await onConfirm(contextName)
+      onClose()
+    } catch (err) {
+      setStatus({
+        removing: false,
+        error: err instanceof Error ? err.message : t('cluster.removeClusterError') })
+    }
+  }
+
+  return (
+    <BaseModal isOpen={isOpen} onClose={onClose} size="sm" closeOnBackdrop={!status.removing}>
+      <BaseModal.Header
+        title={t('cluster.removeClusterTitle')}
+        icon={Trash2}
+        onClose={onClose}
+        showBack={false}
+      />
+
+      <BaseModal.Content>
+        <div className="flex items-start gap-3 mb-4 p-3 rounded-lg bg-yellow-500/10 border border-yellow-500/20">
+          <AlertTriangle className="w-4 h-4 text-yellow-400 mt-0.5 flex-shrink-0" aria-hidden="true" />
+          <p className="text-sm text-yellow-200">
+            {t('cluster.removeClusterWarning')}
+          </p>
+        </div>
+
+        <p className="text-sm text-muted-foreground mb-2">
+          {t('cluster.removeClusterContext')}
+        </p>
+        <p className="text-foreground font-mono text-xs break-all mb-4">{displayName}</p>
+
+        {status.error && (
+          <p className="text-sm text-red-400 mb-2" role="alert">
+            {status.error}
+          </p>
+        )}
+
+        <p className="text-xs text-muted-foreground">{t('cluster.removeClusterDesc')}</p>
+      </BaseModal.Content>
+
+      <BaseModal.Footer showKeyboardHints>
+        <div className="flex-1" />
+        <div className="flex gap-2">
+          <button
+            onClick={onClose}
+            disabled={status.removing}
+            className="px-4 py-2 rounded-lg text-sm text-muted-foreground hover:text-foreground hover:bg-secondary/50 disabled:opacity-50"
+          >
+            {t('common.cancel')}
+          </button>
+          <button
+            onClick={handleConfirm}
+            disabled={status.removing}
+            className="flex items-center gap-2 px-4 py-2 rounded-lg text-sm bg-red-500/80 text-white hover:bg-red-500 disabled:opacity-50"
+            aria-label={t('cluster.removeClusterConfirm')}
+          >
+            {status.removing ? (
+              <>
+                <Loader2 className="w-4 h-4 animate-spin" aria-hidden="true" />
+                {t('cluster.removeClusterRemoving')}
+              </>
+            ) : (
+              <>
+                <Trash2 className="w-4 h-4" aria-hidden="true" />
+                {t('cluster.removeClusterConfirm')}
+              </>
+            )}
+          </button>
+        </div>
+      </BaseModal.Footer>
+    </BaseModal>
+  )
+}

--- a/web/src/components/clusters/components/index.ts
+++ b/web/src/components/clusters/components/index.ts
@@ -1,4 +1,5 @@
 export { RenameModal } from './RenameModal'
+export { RemoveClusterDialog } from './RemoveClusterDialog'
 export { StatsOverview, type ClusterStats } from './StatsOverview'
 export { FilterTabs, type FilterType, type SortByType } from './FilterTabs'
 export { ClusterGrid, type ClusterLayoutMode } from './ClusterGrid'

--- a/web/src/locales/de/common.json
+++ b/web/src/locales/de/common.json
@@ -2585,7 +2585,17 @@
     "connectAdding": "Adding...",
     "connectSuccess": "Cluster added successfully",
     "connectNext": "Next",
-    "connectBack": "Back"
+    "connectBack": "Back",
+    "removeCluster": "Remove cluster from kubeconfig",
+    "removeClusterTitle": "Remove Offline Cluster",
+    "removeClusterWarning": "This will permanently delete the cluster's context from your kubeconfig. The cluster itself will not be affected.",
+    "removeClusterContext": "Kubeconfig context to remove:",
+    "removeClusterDesc": "This updates your kubeconfig via the local agent. Only unreachable (offline) clusters can be removed from the cluster list.",
+    "removeClusterConfirm": "Remove cluster",
+    "removeClusterRemoving": "Removing...",
+    "removeClusterSuccess": "Removed cluster \"{{name}}\" from kubeconfig",
+    "removeClusterError": "Failed to remove cluster from kubeconfig",
+    "removeClusterNoAgent": "Local agent not connected"
   },
   "remediation": {
     "title": "AI Remediation Console",

--- a/web/src/locales/en/common.json
+++ b/web/src/locales/en/common.json
@@ -2861,7 +2861,17 @@
     "authBadgeCert": "Cert",
     "authBadgeSA": "SA",
     "authErrorIAMHint": "Your cloud session may have expired. Run:",
-    "authErrorTokenHint": "Your token may have expired. Generate a new token and update your kubeconfig."
+    "authErrorTokenHint": "Your token may have expired. Generate a new token and update your kubeconfig.",
+    "removeCluster": "Remove cluster from kubeconfig",
+    "removeClusterTitle": "Remove Offline Cluster",
+    "removeClusterWarning": "This will permanently delete the cluster's context from your kubeconfig. The cluster itself will not be affected.",
+    "removeClusterContext": "Kubeconfig context to remove:",
+    "removeClusterDesc": "This updates your kubeconfig via the local agent. Only unreachable (offline) clusters can be removed from the cluster list.",
+    "removeClusterConfirm": "Remove cluster",
+    "removeClusterRemoving": "Removing...",
+    "removeClusterSuccess": "Removed cluster \"{{name}}\" from kubeconfig",
+    "removeClusterError": "Failed to remove cluster from kubeconfig",
+    "removeClusterNoAgent": "Local agent not connected"
   },
   "remediation": {
     "title": "AI Remediation Console",

--- a/web/src/locales/es/common.json
+++ b/web/src/locales/es/common.json
@@ -2585,7 +2585,17 @@
     "connectAdding": "Adding...",
     "connectSuccess": "Cluster added successfully",
     "connectNext": "Next",
-    "connectBack": "Back"
+    "connectBack": "Back",
+    "removeCluster": "Remove cluster from kubeconfig",
+    "removeClusterTitle": "Remove Offline Cluster",
+    "removeClusterWarning": "This will permanently delete the cluster's context from your kubeconfig. The cluster itself will not be affected.",
+    "removeClusterContext": "Kubeconfig context to remove:",
+    "removeClusterDesc": "This updates your kubeconfig via the local agent. Only unreachable (offline) clusters can be removed from the cluster list.",
+    "removeClusterConfirm": "Remove cluster",
+    "removeClusterRemoving": "Removing...",
+    "removeClusterSuccess": "Removed cluster \"{{name}}\" from kubeconfig",
+    "removeClusterError": "Failed to remove cluster from kubeconfig",
+    "removeClusterNoAgent": "Local agent not connected"
   },
   "remediation": {
     "title": "AI Remediation Console",

--- a/web/src/locales/fr/common.json
+++ b/web/src/locales/fr/common.json
@@ -2585,7 +2585,17 @@
     "connectAdding": "Adding...",
     "connectSuccess": "Cluster added successfully",
     "connectNext": "Next",
-    "connectBack": "Back"
+    "connectBack": "Back",
+    "removeCluster": "Remove cluster from kubeconfig",
+    "removeClusterTitle": "Remove Offline Cluster",
+    "removeClusterWarning": "This will permanently delete the cluster's context from your kubeconfig. The cluster itself will not be affected.",
+    "removeClusterContext": "Kubeconfig context to remove:",
+    "removeClusterDesc": "This updates your kubeconfig via the local agent. Only unreachable (offline) clusters can be removed from the cluster list.",
+    "removeClusterConfirm": "Remove cluster",
+    "removeClusterRemoving": "Removing...",
+    "removeClusterSuccess": "Removed cluster \"{{name}}\" from kubeconfig",
+    "removeClusterError": "Failed to remove cluster from kubeconfig",
+    "removeClusterNoAgent": "Local agent not connected"
   },
   "remediation": {
     "title": "AI Remediation Console",

--- a/web/src/locales/hi/common.json
+++ b/web/src/locales/hi/common.json
@@ -2585,7 +2585,17 @@
     "connectAdding": "Adding...",
     "connectSuccess": "Cluster added successfully",
     "connectNext": "Next",
-    "connectBack": "Back"
+    "connectBack": "Back",
+    "removeCluster": "Remove cluster from kubeconfig",
+    "removeClusterTitle": "Remove Offline Cluster",
+    "removeClusterWarning": "This will permanently delete the cluster's context from your kubeconfig. The cluster itself will not be affected.",
+    "removeClusterContext": "Kubeconfig context to remove:",
+    "removeClusterDesc": "This updates your kubeconfig via the local agent. Only unreachable (offline) clusters can be removed from the cluster list.",
+    "removeClusterConfirm": "Remove cluster",
+    "removeClusterRemoving": "Removing...",
+    "removeClusterSuccess": "Removed cluster \"{{name}}\" from kubeconfig",
+    "removeClusterError": "Failed to remove cluster from kubeconfig",
+    "removeClusterNoAgent": "Local agent not connected"
   },
   "remediation": {
     "title": "AI Remediation Console",

--- a/web/src/locales/it/common.json
+++ b/web/src/locales/it/common.json
@@ -2585,7 +2585,17 @@
     "connectAdding": "Adding...",
     "connectSuccess": "Cluster added successfully",
     "connectNext": "Next",
-    "connectBack": "Back"
+    "connectBack": "Back",
+    "removeCluster": "Remove cluster from kubeconfig",
+    "removeClusterTitle": "Remove Offline Cluster",
+    "removeClusterWarning": "This will permanently delete the cluster's context from your kubeconfig. The cluster itself will not be affected.",
+    "removeClusterContext": "Kubeconfig context to remove:",
+    "removeClusterDesc": "This updates your kubeconfig via the local agent. Only unreachable (offline) clusters can be removed from the cluster list.",
+    "removeClusterConfirm": "Remove cluster",
+    "removeClusterRemoving": "Removing...",
+    "removeClusterSuccess": "Removed cluster \"{{name}}\" from kubeconfig",
+    "removeClusterError": "Failed to remove cluster from kubeconfig",
+    "removeClusterNoAgent": "Local agent not connected"
   },
   "remediation": {
     "title": "AI Remediation Console",

--- a/web/src/locales/ja/common.json
+++ b/web/src/locales/ja/common.json
@@ -2585,7 +2585,17 @@
     "connectAdding": "Adding...",
     "connectSuccess": "Cluster added successfully",
     "connectNext": "Next",
-    "connectBack": "Back"
+    "connectBack": "Back",
+    "removeCluster": "Remove cluster from kubeconfig",
+    "removeClusterTitle": "Remove Offline Cluster",
+    "removeClusterWarning": "This will permanently delete the cluster's context from your kubeconfig. The cluster itself will not be affected.",
+    "removeClusterContext": "Kubeconfig context to remove:",
+    "removeClusterDesc": "This updates your kubeconfig via the local agent. Only unreachable (offline) clusters can be removed from the cluster list.",
+    "removeClusterConfirm": "Remove cluster",
+    "removeClusterRemoving": "Removing...",
+    "removeClusterSuccess": "Removed cluster \"{{name}}\" from kubeconfig",
+    "removeClusterError": "Failed to remove cluster from kubeconfig",
+    "removeClusterNoAgent": "Local agent not connected"
   },
   "remediation": {
     "title": "AI Remediation Console",

--- a/web/src/locales/pt/common.json
+++ b/web/src/locales/pt/common.json
@@ -2585,7 +2585,17 @@
     "connectAdding": "Adding...",
     "connectSuccess": "Cluster added successfully",
     "connectNext": "Next",
-    "connectBack": "Back"
+    "connectBack": "Back",
+    "removeCluster": "Remove cluster from kubeconfig",
+    "removeClusterTitle": "Remove Offline Cluster",
+    "removeClusterWarning": "This will permanently delete the cluster's context from your kubeconfig. The cluster itself will not be affected.",
+    "removeClusterContext": "Kubeconfig context to remove:",
+    "removeClusterDesc": "This updates your kubeconfig via the local agent. Only unreachable (offline) clusters can be removed from the cluster list.",
+    "removeClusterConfirm": "Remove cluster",
+    "removeClusterRemoving": "Removing...",
+    "removeClusterSuccess": "Removed cluster \"{{name}}\" from kubeconfig",
+    "removeClusterError": "Failed to remove cluster from kubeconfig",
+    "removeClusterNoAgent": "Local agent not connected"
   },
   "remediation": {
     "title": "AI Remediation Console",

--- a/web/src/locales/zh/common.json
+++ b/web/src/locales/zh/common.json
@@ -2585,7 +2585,17 @@
     "connectAdding": "Adding...",
     "connectSuccess": "Cluster added successfully",
     "connectNext": "Next",
-    "connectBack": "Back"
+    "connectBack": "Back",
+    "removeCluster": "Remove cluster from kubeconfig",
+    "removeClusterTitle": "Remove Offline Cluster",
+    "removeClusterWarning": "This will permanently delete the cluster's context from your kubeconfig. The cluster itself will not be affected.",
+    "removeClusterContext": "Kubeconfig context to remove:",
+    "removeClusterDesc": "This updates your kubeconfig via the local agent. Only unreachable (offline) clusters can be removed from the cluster list.",
+    "removeClusterConfirm": "Remove cluster",
+    "removeClusterRemoving": "Removing...",
+    "removeClusterSuccess": "Removed cluster \"{{name}}\" from kubeconfig",
+    "removeClusterError": "Failed to remove cluster from kubeconfig",
+    "removeClusterNoAgent": "Local agent not connected"
   },
   "remediation": {
     "title": "AI Remediation Console",


### PR DESCRIPTION
## Summary

Closes #5901.

The backend endpoint for removing a stale kubeconfig context (`RemoveContext` in `pkg/k8s/client.go`, exposed by the local agent at `POST /kubeconfig/remove`) was added in #5658, but there was no UI affordance to invoke it. This PR wires up a "Remove cluster" button on offline cluster cards so users can clean up stale contexts without leaving the console.

## Changes

- New `RemoveClusterDialog` component with confirmation and error handling
- New `RemoveClusterButton` (trash icon) rendered on the Full, List and Compact cluster card variants
- Wired through `ClusterGrid` props and `Clusters.tsx` (`handleRemoveCluster` calls the agent and refetches the cluster list on success)
- Toast notification on success
- i18n keys added to all 9 locales (`cluster.removeCluster*`)

## Visibility rules

The trash button only appears when **all** of:
- Local agent is connected (`isConnected`)
- Cluster is unreachable (`isClusterUnreachable(cluster)` — i.e. `reachable === false`)
- Cluster source is `kubeconfig` (or unset)

This matches the existing rename-context button visibility and prevents accidental removal of reachable clusters.

## Test plan

- [x] `npm run build` passes
- [x] `npx eslint` on modified files — no new lint errors introduced
- [x] `npx vitest run src/components/clusters` — 67/67 tests pass
- [ ] Manually test against a local agent with a stale kubeconfig context:
  - [ ] Offline cluster card shows trash icon
  - [ ] Clicking it opens a confirmation modal with the context name
  - [ ] Confirming calls `/kubeconfig/remove`, shows success toast, and the card disappears on refresh
  - [ ] Error responses surface in the dialog
  - [ ] Reachable clusters do not show the button
  - [ ] Button respects all three layout modes (grid, list, compact)

🤖 Generated with [Claude Code](https://claude.com/claude-code)