### PR TITLE
fix: nodes stat drill-down crash and error page UX (#5902)

### DIFF
--- a/web/src/components/AppErrorBoundary.tsx
+++ b/web/src/components/AppErrorBoundary.tsx
@@ -1,5 +1,5 @@
-import { Component, type ReactNode, type ErrorInfo } from 'react'
-import { AlertTriangle, RefreshCw } from 'lucide-react'
+import { Component, Fragment, type ReactNode, type ErrorInfo } from 'react'
+import { AlertTriangle, RefreshCw, Home } from 'lucide-react'
 import i18next from 'i18next'
 import { emitError, markErrorReported } from '../lib/analytics'
 
@@ -10,6 +10,14 @@ interface Props {
 interface State {
   hasError: boolean
   error: Error | null
+  /**
+   * Increments each time the user clicks "Try again". Used as a React `key`
+   * on the children subtree so the whole tree remounts with fresh state,
+   * instead of re-running against the same broken props that originally
+   * crashed. Without this, "Try again" appeared unresponsive because the
+   * same error would immediately re-throw (issue #5902).
+   */
+  resetKey: number
 }
 
 /**
@@ -23,10 +31,10 @@ interface State {
 export class AppErrorBoundary extends Component<Props, State> {
   constructor(props: Props) {
     super(props)
-    this.state = { hasError: false, error: null }
+    this.state = { hasError: false, error: null, resetKey: 0 }
   }
 
-  static getDerivedStateFromError(error: Error): State {
+  static getDerivedStateFromError(error: Error): Partial<State> {
     return { hasError: true, error }
   }
 
@@ -41,8 +49,20 @@ export class AppErrorBoundary extends Component<Props, State> {
     window.location.reload()
   }
 
+  handleGoHome = () => {
+    // Full navigation (not client-side) so any bad state in the SPA —
+    // including router/query caches — is cleared before landing on "/".
+    window.location.href = '/'
+  }
+
   handleRecover = () => {
-    this.setState({ hasError: false, error: null })
+    // Bump the reset key so the children subtree remounts instead of
+    // re-rendering with whatever bad props caused the original crash.
+    this.setState((prev) => ({
+      hasError: false,
+      error: null,
+      resetKey: prev.resetKey + 1,
+    }))
   }
 
   render() {
@@ -55,20 +75,33 @@ export class AppErrorBoundary extends Component<Props, State> {
               {i18next.t('common:appError.title', 'Something went wrong')}
             </h2>
             <p className="text-sm text-muted-foreground mb-6">
-              {i18next.t('common:appError.description', 'An unexpected error occurred. You can try recovering or reload the page.')}
+              {i18next.t('common:appError.description', 'An unexpected error occurred. Try rendering the page again, go back to the dashboard, or reload the app.')}
             </p>
             {this.state.error && (
-              <p className="text-xs text-muted-foreground/70 font-mono mb-6 break-all">
+              // `break-words` (overflow-wrap: break-word) prefers to wrap on
+              // whitespace and only breaks mid-word when a single token is
+              // wider than the container. `break-all` (used previously) would
+              // split after any character, producing lines like
+              // "…cardType is undefine" / "d" (issue #5902).
+              <p className="text-xs text-muted-foreground/70 font-mono mb-6 break-words whitespace-pre-wrap">
                 {this.state.error.message}
               </p>
             )}
-            <div className="flex items-center justify-center gap-3">
+            <div className="flex flex-wrap items-center justify-center gap-3">
               <button
                 onClick={this.handleRecover}
                 className="px-4 py-2 bg-secondary hover:bg-secondary/80 text-foreground rounded-lg text-sm font-medium transition-colors"
                 aria-label={i18next.t('common:appError.tryAgain', 'Try again')}
               >
                 {i18next.t('common:appError.tryAgain', 'Try again')}
+              </button>
+              <button
+                onClick={this.handleGoHome}
+                className="px-4 py-2 bg-secondary hover:bg-secondary/80 text-foreground rounded-lg text-sm font-medium transition-colors flex items-center gap-2"
+                aria-label={i18next.t('common:appError.goHome', 'Go to dashboard')}
+              >
+                <Home className="w-4 h-4" aria-hidden="true" />
+                {i18next.t('common:appError.goHome', 'Go to dashboard')}
               </button>
               <button
                 onClick={this.handleReload}
@@ -84,6 +117,10 @@ export class AppErrorBoundary extends Component<Props, State> {
       )
     }
 
-    return this.props.children
+    // The resetKey forces the subtree to remount after "Try again" so the
+    // children get a fresh start instead of re-rendering with the same
+    // state that originally triggered the error boundary. Using a keyed
+    // Fragment keeps DOM layout identical to rendering children directly.
+    return <Fragment key={this.state.resetKey}>{this.props.children}</Fragment>
   }
 }

--- a/web/src/components/PageErrorBoundary.tsx
+++ b/web/src/components/PageErrorBoundary.tsx
@@ -76,7 +76,10 @@ export class PageErrorBoundary extends Component<Props, State> {
             )}
           </div>
           {this.state.error && (
-            <div className="text-xs text-muted-foreground/70 font-mono mb-6 break-all max-w-lg">
+            // `break-words` avoids splitting words like "undefined" mid-letter
+            // (see issue #5902). `break-all` was the previous class and caused
+            // single-character lines when error messages contained long tokens.
+            <div className="text-xs text-muted-foreground/70 font-mono mb-6 break-words whitespace-pre-wrap max-w-lg">
               {this.state.error.message}
             </div>
           )}

--- a/web/src/components/compute/Compute.tsx
+++ b/web/src/components/compute/Compute.tsx
@@ -16,14 +16,18 @@ import { useTranslation } from 'react-i18next'
 
 const COMPUTE_CARDS_KEY = 'kubestellar-compute-cards'
 
-// Ensure new virtualization cards are present in existing saved layouts
+// Ensure new virtualization cards are present in existing saved layouts.
+// IMPORTANT: Use `card_type` (snake_case) to match the DashboardCard interface.
+// Previously this used `cardType` which caused card.card_type to be undefined,
+// crashing formatCardTitle() with "cardType is undefined" when clicking the
+// "nodes" stat block from the My Clusters dashboard (issue #5902).
 ensureCardInDashboard(COMPUTE_CARDS_KEY, 'vcluster_status', {
   id: 'compute-6',
-  cardType: 'vcluster_status',
+  card_type: 'vcluster_status',
   position: { w: 6, h: 3, x: 0, y: 6 } })
 ensureCardInDashboard(COMPUTE_CARDS_KEY, 'kubevirt_status', {
   id: 'compute-7',
-  cardType: 'kubevirt_status',
+  card_type: 'kubevirt_status',
   position: { w: 6, h: 3, x: 6, y: 6 } })
 
 // Default cards for the compute dashboard

--- a/web/src/components/security/Security.tsx
+++ b/web/src/components/security/Security.tsx
@@ -29,10 +29,12 @@ import { ensureCardInDashboard } from '../../lib/dashboards/migrateStorageKey'
 
 const SECURITY_CARDS_KEY = 'kubestellar-security-cards'
 
-// Ensure ISO 27001 audit card is present in existing saved layouts
+// Ensure ISO 27001 audit card is present in existing saved layouts.
+// Uses `card_type` (snake_case) to match the DashboardCard interface — see
+// issue #5902 where the legacy `cardType` field caused runtime crashes.
 ensureCardInDashboard(SECURITY_CARDS_KEY, 'iso27001_audit', {
   id: 'security-0',
-  cardType: 'iso27001_audit',
+  card_type: 'iso27001_audit',
   position: { w: 6, h: 3, x: 0, y: 0 } })
 
 // Default cards for the security dashboard

--- a/web/src/lib/__tests__/formatCardTitle.test.ts
+++ b/web/src/lib/__tests__/formatCardTitle.test.ts
@@ -36,6 +36,18 @@ describe('formatCardTitle', () => {
     expect(formatCardTitle('')).toBe('')
   })
 
+  // Regression test for issue #5902: defensive guard against undefined
+  // card_type. Stale dashboard layouts could contain entries without a
+  // card_type field, which used to crash with
+  // "can't access property 'replace', cardType is undefined".
+  it('returns a fallback title when cardType is undefined', () => {
+    expect(formatCardTitle(undefined)).toBe('Unknown Card')
+  })
+
+  it('returns a fallback title when cardType is null', () => {
+    expect(formatCardTitle(null)).toBe('Unknown Card')
+  })
+
   it('handles all-acronym type', () => {
     expect(formatCardTitle('gpu_cpu_ai')).toBe('GPU CPU AI')
   })

--- a/web/src/lib/dashboards/__tests__/migrateStorageKey.test.ts
+++ b/web/src/lib/dashboards/__tests__/migrateStorageKey.test.ts
@@ -28,7 +28,7 @@ describe('migrateStorageKey', () => {
 describe('ensureCardInDashboard', () => {
   const testCard = {
     id: 'test-card-id',
-    cardType: 'new_card',
+    card_type: 'new_card',
     position: { w: 4, h: 2, x: 0, y: 0 },
   }
 
@@ -41,28 +41,29 @@ describe('ensureCardInDashboard', () => {
   })
 
   it('does nothing when card already exists in layout', () => {
-    const layout = [{ id: '1', cardType: 'new_card', position: { w: 4, h: 2, x: 0, y: 0 } }]
+    const layout = [{ id: '1', card_type: 'new_card', position: { w: 4, h: 2, x: 0, y: 0 } }]
     localStorage.setItem('dash-key', JSON.stringify(layout))
     ensureCardInDashboard('dash-key', 'new_card', testCard)
     const result = JSON.parse(localStorage.getItem('dash-key')!)
     expect(result).toHaveLength(1) // unchanged
+    expect(result[0].card_type).toBe('new_card')
   })
 
   it('injects card at position 0 and shifts existing cards', () => {
     const layout = [
-      { id: '1', cardType: 'existing', position: { w: 4, h: 2, x: 0, y: 0 } },
+      { id: '1', card_type: 'existing', position: { w: 4, h: 2, x: 0, y: 0 } },
     ]
     localStorage.setItem('dash-key', JSON.stringify(layout))
     ensureCardInDashboard('dash-key', 'new_card', testCard)
     const result = JSON.parse(localStorage.getItem('dash-key')!)
     expect(result).toHaveLength(2)
-    expect(result[0].cardType).toBe('new_card')
+    expect(result[0].card_type).toBe('new_card')
     expect(result[1].position.y).toBe(2) // shifted by h=2
   })
 
   it('is idempotent (only runs once)', () => {
     const layout = [
-      { id: '1', cardType: 'existing', position: { w: 4, h: 2, x: 0, y: 0 } },
+      { id: '1', card_type: 'existing', position: { w: 4, h: 2, x: 0, y: 0 } },
     ]
     localStorage.setItem('dash-key', JSON.stringify(layout))
 
@@ -78,5 +79,46 @@ describe('ensureCardInDashboard', () => {
     ensureCardInDashboard('dash-key', 'new_card', testCard)
     expect(localStorage.getItem('dash-key')).toBeNull()
     expect(localStorage.getItem('dash-key:migrated:new_card')).toBe('1')
+  })
+
+  // Regression test for issue #5902: stale layouts written with the legacy
+  // `cardType` field (snake_case mismatch) must be normalized on read so that
+  // card.card_type is populated and formatCardTitle() does not crash with
+  // "can't access property 'replace', cardType is undefined".
+  it('normalizes legacy cardType field to card_type in stored layout', () => {
+    const staleLayout = [
+      // Stored with the legacy field name — simulates a layout written by
+      // an older build of ensureCardInDashboard / Compute.tsx.
+      { id: '1', cardType: 'existing', position: { w: 4, h: 2, x: 0, y: 0 } },
+    ]
+    localStorage.setItem('dash-key', JSON.stringify(staleLayout))
+
+    ensureCardInDashboard('dash-key', 'new_card', testCard)
+
+    const result = JSON.parse(localStorage.getItem('dash-key')!)
+    expect(result).toHaveLength(2)
+    // The newly injected card uses the canonical field name.
+    expect(result[0].card_type).toBe('new_card')
+    // The pre-existing stale entry got repaired to use card_type.
+    const existing = result.find((c: { card_type?: string; id: string }) => c.id === '1')
+    expect(existing?.card_type).toBe('existing')
+  })
+
+  it('accepts legacy cardType field on the injected card for back-compat', () => {
+    // Simulates a caller that still passes `cardType` instead of `card_type`.
+    const legacyCard = {
+      id: 'legacy-id',
+      cardType: 'new_card',
+      position: { w: 4, h: 2, x: 0, y: 0 },
+    }
+    const layout = [
+      { id: '1', card_type: 'existing', position: { w: 4, h: 2, x: 0, y: 0 } },
+    ]
+    localStorage.setItem('dash-key', JSON.stringify(layout))
+
+    ensureCardInDashboard('dash-key', 'new_card', legacyCard)
+
+    const result = JSON.parse(localStorage.getItem('dash-key')!)
+    expect(result[0].card_type).toBe('new_card')
   })
 })

--- a/web/src/lib/dashboards/migrateStorageKey.ts
+++ b/web/src/lib/dashboards/migrateStorageKey.ts
@@ -34,16 +34,46 @@ export function migrateStorageKey(oldKey: string, newKey: string): void {
  *
  * Idempotent — no-op if card already exists, no saved layout, or migration
  * already ran.
+ *
+ * NOTE: Saved dashboards use the `card_type` field (snake_case) to match the
+ * `DashboardCard` interface. Callers may pass the injected card using either
+ * `card_type` or the legacy `cardType` field — both are normalized so any
+ * previously-written stale entries also get repaired on the next read. See
+ * issue #5902 where the wrong field name caused `card_type` to be undefined,
+ * crashing formatCardTitle() on /compute.
  */
+interface StoredDashboardCard {
+  id: string
+  card_type?: string
+  /** Legacy field name kept for back-compat with previously-persisted layouts. */
+  cardType?: string
+  position?: { w: number; h: number; x: number; y: number }
+}
+
 export function ensureCardInDashboard(
   storageKey: string,
   cardType: string,
-  card: { id: string; cardType: string; position: { w: number; h: number; x: number; y: number } },
+  card: {
+    id: string
+    /** Preferred field name. */
+    card_type?: string
+    /** Legacy field name — still accepted for back-compat. */
+    cardType?: string
+    position: { w: number; h: number; x: number; y: number }
+  },
 ): void {
   if (typeof window === 'undefined' || typeof localStorage === 'undefined') return
 
   const migrationFlag = `${storageKey}:migrated:${cardType}`
   if (localStorage.getItem(migrationFlag)) return
+
+  // Normalize the injected card to use `card_type` (the canonical field name).
+  const injectedCardType = card.card_type || card.cardType
+  const normalizedInjected: StoredDashboardCard = {
+    id: card.id,
+    card_type: injectedCardType,
+    position: card.position,
+  }
 
   const stored = localStorage.getItem(storageKey)
   if (!stored) {
@@ -53,11 +83,26 @@ export function ensureCardInDashboard(
   }
 
   try {
-    const cards = JSON.parse(stored) as Array<{ id: string; cardType: string; position: { w: number; h: number; x: number; y: number } }>
+    const cards = JSON.parse(stored) as StoredDashboardCard[]
     if (!Array.isArray(cards)) return
 
-    // Already has the card — nothing to do
-    if (cards.some(c => c.cardType === cardType)) {
+    // Normalize any pre-existing stale entries that used the legacy
+    // `cardType` field (or had neither field). This repairs broken layouts
+    // written before the #5902 fix without requiring users to clear storage.
+    const normalizedCards: StoredDashboardCard[] = cards.map(c => {
+      const type = c.card_type || c.cardType
+      return {
+        ...c,
+        card_type: type,
+        // Strip the legacy field to keep storage clean going forward.
+        cardType: undefined,
+      }
+    })
+
+    // Already has the card — nothing to do, but still persist any
+    // repairs we made above so stale keys don't bite us later.
+    if (normalizedCards.some(c => c.card_type === cardType)) {
+      localStorage.setItem(storageKey, JSON.stringify(normalizedCards))
       localStorage.setItem(migrationFlag, '1')
       return
     }
@@ -65,8 +110,8 @@ export function ensureCardInDashboard(
     // Shift existing cards down by the height of the new card
     const shiftY = card.position?.h || 2
     const migrated = [
-      card,
-      ...cards.map(c => ({
+      normalizedInjected,
+      ...normalizedCards.map(c => ({
         ...c,
         position: { ...(c.position || { w: 4, h: 2, x: 0, y: 0 }), y: (c.position?.y || 0) + shiftY },
       })),

--- a/web/src/lib/formatCardTitle.ts
+++ b/web/src/lib/formatCardTitle.ts
@@ -51,12 +51,32 @@ const ACRONYMS = new Set([
   'argocd',
 ])
 
+/** Fallback title used when a card_type is missing or not a string. */
+const UNKNOWN_CARD_TITLE = 'Unknown Card'
+
 /**
  * Formats a card_type string into a proper title
  * Handles acronyms properly (e.g., "opa_policies" -> "OPA Policies")
  * Uses custom title overrides for specific card types
+ *
+ * Returns a safe fallback when `cardType` is null/undefined or not a string
+ * so callers don't crash on corrupt/legacy dashboard layouts. See issue #5902
+ * where a legacy field-name mismatch caused card.card_type to be undefined
+ * and triggered "can't access property 'replace', cardType is undefined".
  */
-export function formatCardTitle(cardType: string): string {
+export function formatCardTitle(cardType: string | null | undefined): string {
+  // Defensive guard — stale localStorage or bad API payloads can produce
+  // cards without a card_type. Never crash the whole dashboard over it.
+  if (cardType === null || cardType === undefined || typeof cardType !== 'string') {
+    return UNKNOWN_CARD_TITLE
+  }
+
+  // Preserve the historical behavior of returning an empty string for
+  // an empty input — only `null`/`undefined` fall back to "Unknown Card".
+  if (cardType === '') {
+    return ''
+  }
+
   // Check for custom title override first
   if (CUSTOM_TITLES[cardType]) {
     return CUSTOM_TITLES[cardType]


### PR DESCRIPTION
## Summary

Fixes #5902. Clicking the **nodes** stat block on the My Clusters dashboard
navigated to `/compute` and immediately hit the AppErrorBoundary with
`can't access property "replace", cardType is undefined`, and the recovery
UI itself had three UX bugs.

### Root cause

`ensureCardInDashboard()` in `Compute.tsx` (and `Security.tsx`) injected cards
into saved layouts using the legacy `cardType` field, but `DashboardCard` uses
the snake_case `card_type` field. When the renderer called
`formatCardTitle(card.card_type)` the value was `undefined` and crashed the
whole dashboard.

### Fixes

- **Compute.tsx / Security.tsx**: pass `card_type` (snake_case) to
  `ensureCardInDashboard` so injected cards match the `DashboardCard` shape.
- **migrateStorageKey.ts**: normalize stored layouts on read. Any entries
  written by older builds with the legacy `cardType` field are repaired to
  `card_type` automatically so users who already hit the crash recover
  without clearing localStorage. The helper still accepts `cardType` on the
  injected-card argument for back-compat.
- **formatCardTitle.ts**: defensive guard against `null`/`undefined` input
  so a single bad card can never crash the whole dashboard again.
- **AppErrorBoundary.tsx**:
  - **Try again** now bumps a `resetKey` used as a React `key` on the
    children subtree, forcing a full remount instead of re-rendering with
    the same broken props. Previously the button appeared unresponsive
    because the same error re-threw immediately.
  - Added a distinct **Go to dashboard** button so "Try again" and
    "Reload page" no longer look like synonyms.
  - Error text uses `break-words` + `whitespace-pre-wrap` instead of
    `break-all`, so long tokens like `undefined` stop wrapping mid-word
    (the reported "d" on its own line).
- **PageErrorBoundary.tsx**: same `break-words` fix for consistency.
- **Tests**: new regression tests for the undefined guard in
  `formatCardTitle` and for legacy-`cardType` normalization in
  `ensureCardInDashboard`.

## Test plan

- [x] `npm run build` passes
- [x] `npx vitest run src/lib/__tests__/formatCardTitle.test.ts src/lib/dashboards/__tests__/migrateStorageKey.test.ts` - 33/33 pass
- [ ] Manually verify clicking the **nodes** stat block on **My Clusters** navigates to **/compute** without error
- [ ] Manually verify stale layouts previously written with `cardType` load cleanly after the fix
- [ ] Manually verify the AppErrorBoundary error text no longer breaks mid-word and the **Try again** / **Go to dashboard** / **Reload page** buttons all work