### PR TITLE
fix: skip tip fade entirely when user prefers reduced motion

### DIFF
--- a/cmd/console/watchdog_html.go
+++ b/cmd/console/watchdog_html.go
@@ -100,7 +100,18 @@ var TIPS=[
 var TIP_ROTATE_MS=8000;
 var tipTextEl=document.getElementById('tip-text');
 var tipIdx=Math.floor(Math.random()*TIPS.length);
-function showTip(){if(tipTextEl){tipTextEl.style.opacity='0';setTimeout(function(){tipTextEl.textContent=TIPS[tipIdx];tipTextEl.style.opacity='1';tipIdx=(tipIdx+1)%TIPS.length;},400);}}
+// Skip the fade transition entirely when the user prefers reduced motion (#5910)
+var prefersReducedMotion=window.matchMedia&&window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+function showTip(){
+  if(!tipTextEl)return;
+  if(prefersReducedMotion){
+    tipTextEl.textContent=TIPS[tipIdx];
+    tipIdx=(tipIdx+1)%TIPS.length;
+    return;
+  }
+  tipTextEl.style.opacity='0';
+  setTimeout(function(){tipTextEl.textContent=TIPS[tipIdx];tipTextEl.style.opacity='1';tipIdx=(tipIdx+1)%TIPS.length;},400);
+}
 showTip();
 setInterval(showTip,TIP_ROTATE_MS);
 


### PR DESCRIPTION
## Summary
The CSS reduced-motion block disabled the opacity transition but `showTip()` still set `opacity=0` and waited 400ms, causing the tip to flash blank. Detect `prefers-reduced-motion` in JS and skip the fade timeout entirely.

Fixes #5910

🤖 Generated with [Claude Code](https://claude.com/claude-code)