### PR TITLE
fix(missions): confirm and edit AI prompt before Install-via-AI runs (#5913)

### DIFF
--- a/web/src/components/cards/CardWrapper.tsx
+++ b/web/src/components/cards/CardWrapper.tsx
@@ -26,6 +26,7 @@ import { useLocalAgent } from '../../hooks/useLocalAgent'
 import { CARD_INSTALL_MAP } from '../../lib/cards/cardInstallMap'
 import { loadMissionPrompt } from '../cards/multi-tenancy/missionLoader'
 import { ClusterSelectionDialog } from '../missions/ClusterSelectionDialog'
+import { ConfirmMissionPromptDialog } from '../missions/ConfirmMissionPromptDialog'
 // Lazy-load the widget export modal (~42 KB + code generator ~30 KB) — only when user exports
 const WidgetExportModal = lazy(() =>
   import('../widgets/WidgetExportModal').then(m => ({ default: m.WidgetExportModal }))
@@ -392,6 +393,15 @@ export function CardWrapper({
   const [showBugReport, setShowBugReport] = useState(false)
   const [showInstallClusterSelect, setShowInstallClusterSelect] = useState(false)
   const [showInstallGuide, setShowInstallGuide] = useState<{ mission: { mission?: { title?: string; description?: string; steps?: { title?: string; description?: string }[] } } } | null>(null)
+  /**
+   * State for the install-via-AI prompt confirmation dialog (#5913).
+   * After the user picks clusters, we load the prompt and stash it here so
+   * the user can review/edit it before the mission actually starts.
+   */
+  const [pendingInstallMission, setPendingInstallMission] = useState<{
+    prompt: string
+    clusters: string[]
+  } | null>(null)
   const installInfo = CARD_INSTALL_MAP[cardType]
 
   // Register expand trigger for keyboard navigation
@@ -1400,15 +1410,37 @@ export function CardWrapper({
                 const clusterContext = clusters.length > 0
                   ? `\n\n**Target cluster(s):** ${clusters.join(', ')}\n\nPlease install on ${clusters.length === 1 ? `cluster "${clusters[0]}"` : `the following clusters: ${clusters.join(', ')}`}.`
                   : ''
+                // #5913 — Do not start the mission yet. Stash the prompt and
+                // let the user review/edit it via ConfirmMissionPromptDialog.
+                setPendingInstallMission({
+                  prompt: prompt + clusterContext,
+                  clusters,
+                })
+              }}
+              missionTitle={`Install ${installInfo.project}`}
+            />
+          )}
+
+          {/* Install CTA: confirm and edit the AI mission prompt before running (#5913) */}
+          {pendingInstallMission && installInfo && (
+            <ConfirmMissionPromptDialog
+              open={!!pendingInstallMission}
+              missionTitle={`Install ${installInfo.project}`}
+              missionDescription={`Install and configure ${installInfo.project}`}
+              initialPrompt={pendingInstallMission.prompt}
+              onCancel={() => setPendingInstallMission(null)}
+              onConfirm={(editedPrompt) => {
+                const { clusters } = pendingInstallMission
+                setPendingInstallMission(null)
                 startMission({
                   title: `Install ${installInfo.project}`,
                   description: `Install and configure ${installInfo.project}`,
                   type: 'deploy',
                   cluster: clusters.length > 0 ? clusters.join(',') : undefined,
-                  initialPrompt: prompt + clusterContext })
+                  initialPrompt: editedPrompt,
+                })
                 openSidebar()
               }}
-              missionTitle={`Install ${installInfo.project}`}
             />
           )}
 

--- a/web/src/components/cards/multi-tenancy/k3s-status/K3sStatus.tsx
+++ b/web/src/components/cards/multi-tenancy/k3s-status/K3sStatus.tsx
@@ -6,6 +6,7 @@
  * installation mission.
  */
 
+import { useState } from 'react'
 import { AlertTriangle, Box, CheckCircle, RefreshCw, Server, XCircle } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 import { Skeleton } from '../../../ui/Skeleton'
@@ -13,6 +14,7 @@ import { MetricTile } from '../../../../lib/cards/CardComponents'
 import { useModalState } from '../../../../lib/modals'
 import { useMissions } from '../../../../hooks/useMissions'
 import { useApiKeyCheck, ApiKeyPromptModal } from '../../console-missions/shared'
+import { ConfirmMissionPromptDialog } from '../../../missions/ConfirmMissionPromptDialog'
 import { useK3sStatus } from './useK3sStatus'
 import { K3S_INSTALL_PROMPT } from '../shared'
 import { loadMissionPrompt } from '../missionLoader'
@@ -63,6 +65,8 @@ export function K3sStatus() {
   const { startMission } = useMissions()
   const { showKeyPrompt, checkKeyAndRun, goToSettings, dismissPrompt } = useApiKeyCheck()
   const { isOpen: isDetailModalOpen, open: openDetailModal, close: closeDetailModal } = useModalState()
+  // #5913 — Holds the AI prompt pending user review/edit before the mission runs.
+  const [pendingPrompt, setPendingPrompt] = useState<string | null>(null)
 
   // ------ Loading ------
   if (showSkeleton) {
@@ -103,12 +107,8 @@ export function K3sStatus() {
           onClick={() =>
             checkKeyAndRun(async () => {
               const prompt = await loadMissionPrompt('k3s', K3S_INSTALL_PROMPT)
-              startMission({
-                title: 'Deploy K3s Clusters',
-                description: 'Deploy K3s lightweight Kubernetes for multi-tenant control planes',
-                type: 'deploy',
-                initialPrompt: prompt,
-              })
+              // #5913 — Let the user review/edit the prompt before running.
+              setPendingPrompt(prompt)
             })
           }
           className="mt-1 px-4 py-2 rounded-lg bg-blue-500/20 text-blue-400 text-xs font-medium hover:bg-blue-500/30 transition-colors"
@@ -116,6 +116,24 @@ export function K3sStatus() {
           {t('k3sStatus.installWithAgent')}
         </button>
         <ApiKeyPromptModal isOpen={showKeyPrompt} onDismiss={dismissPrompt} onGoToSettings={goToSettings} />
+        {pendingPrompt !== null && (
+          <ConfirmMissionPromptDialog
+            open={pendingPrompt !== null}
+            missionTitle="Deploy K3s Clusters"
+            missionDescription="Deploy K3s lightweight Kubernetes for multi-tenant control planes"
+            initialPrompt={pendingPrompt}
+            onCancel={() => setPendingPrompt(null)}
+            onConfirm={(editedPrompt) => {
+              setPendingPrompt(null)
+              startMission({
+                title: 'Deploy K3s Clusters',
+                description: 'Deploy K3s lightweight Kubernetes for multi-tenant control planes',
+                type: 'deploy',
+                initialPrompt: editedPrompt,
+              })
+            }}
+          />
+        )}
       </div>
     )
   }

--- a/web/src/components/cards/multi-tenancy/kubeflex-status/KubeFlexStatus.tsx
+++ b/web/src/components/cards/multi-tenancy/kubeflex-status/KubeFlexStatus.tsx
@@ -6,6 +6,7 @@
  * installation mission.
  */
 
+import { useState } from 'react'
 import { AlertTriangle, CheckCircle, Layers, RefreshCw, Server, XCircle } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 import { Skeleton } from '../../../ui/Skeleton'
@@ -13,6 +14,7 @@ import { MetricTile } from '../../../../lib/cards/CardComponents'
 import { useModalState } from '../../../../lib/modals'
 import { useMissions } from '../../../../hooks/useMissions'
 import { useApiKeyCheck, ApiKeyPromptModal } from '../../console-missions/shared'
+import { ConfirmMissionPromptDialog } from '../../../missions/ConfirmMissionPromptDialog'
 import { useKubeFlexStatus } from './useKubeflexStatus'
 import { KUBEFLEX_INSTALL_PROMPT } from '../shared'
 import { loadMissionPrompt } from '../missionLoader'
@@ -60,6 +62,8 @@ export function KubeFlexStatus() {
   const { startMission } = useMissions()
   const { showKeyPrompt, checkKeyAndRun, goToSettings, dismissPrompt } = useApiKeyCheck()
   const { isOpen: isDetailModalOpen, open: openDetailModal, close: closeDetailModal } = useModalState()
+  // #5913 — Holds the AI prompt pending user review/edit before the mission runs.
+  const [pendingPrompt, setPendingPrompt] = useState<string | null>(null)
 
   const handleDetailKeyDown = (e: React.KeyboardEvent) => {
     if (e.key === 'Enter' || e.key === ' ') {
@@ -107,12 +111,8 @@ export function KubeFlexStatus() {
           onClick={() =>
             checkKeyAndRun(async () => {
               const prompt = await loadMissionPrompt('kubeflex', KUBEFLEX_INSTALL_PROMPT)
-              startMission({
-                title: 'Install KubeFlex',
-                description: 'Install KubeFlex for dedicated per-tenant control planes',
-                type: 'deploy',
-                initialPrompt: prompt,
-              })
+              // #5913 — Let the user review/edit the prompt before running.
+              setPendingPrompt(prompt)
             })
           }
           className="mt-1 px-4 py-2 rounded-lg bg-blue-500/20 text-blue-400 text-xs font-medium hover:bg-blue-500/30 transition-colors"
@@ -120,6 +120,24 @@ export function KubeFlexStatus() {
           {t('kubeFlexStatus.installWithAgent')}
         </button>
         <ApiKeyPromptModal isOpen={showKeyPrompt} onDismiss={dismissPrompt} onGoToSettings={goToSettings} />
+        {pendingPrompt !== null && (
+          <ConfirmMissionPromptDialog
+            open={pendingPrompt !== null}
+            missionTitle="Install KubeFlex"
+            missionDescription="Install KubeFlex for dedicated per-tenant control planes"
+            initialPrompt={pendingPrompt}
+            onCancel={() => setPendingPrompt(null)}
+            onConfirm={(editedPrompt) => {
+              setPendingPrompt(null)
+              startMission({
+                title: 'Install KubeFlex',
+                description: 'Install KubeFlex for dedicated per-tenant control planes',
+                type: 'deploy',
+                initialPrompt: editedPrompt,
+              })
+            }}
+          />
+        )}
       </div>
     )
   }

--- a/web/src/components/cards/multi-tenancy/kubevirt-status/KubevirtStatus.tsx
+++ b/web/src/components/cards/multi-tenancy/kubevirt-status/KubevirtStatus.tsx
@@ -6,6 +6,7 @@
  * installation mission.
  */
 
+import { useState } from 'react'
 import { AlertTriangle, CheckCircle, Monitor, Pause, RefreshCw, Server, XCircle } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 import { Skeleton } from '../../../ui/Skeleton'
@@ -13,6 +14,7 @@ import { MetricTile } from '../../../../lib/cards/CardComponents'
 import { useModalState } from '../../../../lib/modals'
 import { useMissions } from '../../../../hooks/useMissions'
 import { useApiKeyCheck, ApiKeyPromptModal } from '../../console-missions/shared'
+import { ConfirmMissionPromptDialog } from '../../../missions/ConfirmMissionPromptDialog'
 import { useKubevirtStatus } from './useKubevirtStatus'
 import { KUBEVIRT_INSTALL_PROMPT } from '../shared'
 import { loadMissionPrompt } from '../missionLoader'
@@ -80,6 +82,8 @@ export function KubevirtStatus() {
   const { startMission } = useMissions()
   const { showKeyPrompt, checkKeyAndRun, goToSettings, dismissPrompt } = useApiKeyCheck()
   const { isOpen: isDetailModalOpen, open: openDetailModal, close: closeDetailModal } = useModalState()
+  // #5913 — Holds the AI prompt pending user review/edit before the mission runs.
+  const [pendingPrompt, setPendingPrompt] = useState<string | null>(null)
 
   // ------ Loading ------
   if (showSkeleton) {
@@ -124,12 +128,8 @@ export function KubevirtStatus() {
           onClick={() =>
             checkKeyAndRun(async () => {
               const prompt = await loadMissionPrompt('kubevirt', KUBEVIRT_INSTALL_PROMPT)
-              startMission({
-                title: 'Install KubeVirt',
-                description: 'Install KubeVirt for VM-based data-plane tenant isolation',
-                type: 'deploy',
-                initialPrompt: prompt,
-              })
+              // #5913 — Let the user review/edit the prompt before running.
+              setPendingPrompt(prompt)
             })
           }
           className="mt-1 px-4 py-2 rounded-lg bg-blue-500/20 text-blue-400 text-xs font-medium hover:bg-blue-500/30 transition-colors"
@@ -137,6 +137,24 @@ export function KubevirtStatus() {
           {t('kubevirtStatus.installWithAgent')}
         </button>
         <ApiKeyPromptModal isOpen={showKeyPrompt} onDismiss={dismissPrompt} onGoToSettings={goToSettings} />
+        {pendingPrompt !== null && (
+          <ConfirmMissionPromptDialog
+            open={pendingPrompt !== null}
+            missionTitle="Install KubeVirt"
+            missionDescription="Install KubeVirt for VM-based data-plane tenant isolation"
+            initialPrompt={pendingPrompt}
+            onCancel={() => setPendingPrompt(null)}
+            onConfirm={(editedPrompt) => {
+              setPendingPrompt(null)
+              startMission({
+                title: 'Install KubeVirt',
+                description: 'Install KubeVirt for VM-based data-plane tenant isolation',
+                type: 'deploy',
+                initialPrompt: editedPrompt,
+              })
+            }}
+          />
+        )}
       </div>
     )
   }

--- a/web/src/components/cards/multi-tenancy/ovn-status/OvnStatus.tsx
+++ b/web/src/components/cards/multi-tenancy/ovn-status/OvnStatus.tsx
@@ -6,6 +6,7 @@
  * installation mission.
  */
 
+import { useState } from 'react'
 import { AlertTriangle, CheckCircle, Network, RefreshCw, Wifi, WifiOff } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 import { Skeleton } from '../../../ui/Skeleton'
@@ -13,6 +14,7 @@ import { MetricTile } from '../../../../lib/cards/CardComponents'
 import { useModalState } from '../../../../lib/modals'
 import { useMissions } from '../../../../hooks/useMissions'
 import { useApiKeyCheck, ApiKeyPromptModal } from '../../console-missions/shared'
+import { ConfirmMissionPromptDialog } from '../../../missions/ConfirmMissionPromptDialog'
 import { useOvnStatus } from './useOvnStatus'
 import { OVN_INSTALL_PROMPT } from '../shared'
 import { loadMissionPrompt } from '../missionLoader'
@@ -63,6 +65,8 @@ export function OvnStatus() {
   const { startMission } = useMissions()
   const { showKeyPrompt, checkKeyAndRun, goToSettings, dismissPrompt } = useApiKeyCheck()
   const { isOpen: isDetailModalOpen, open: openDetailModal, close: closeDetailModal } = useModalState()
+  // #5913 — Holds the AI prompt pending user review/edit before the mission runs.
+  const [pendingPrompt, setPendingPrompt] = useState<string | null>(null)
 
   // ------ Loading ------
   if (showSkeleton) {
@@ -103,12 +107,8 @@ export function OvnStatus() {
           onClick={() =>
             checkKeyAndRun(async () => {
               const prompt = await loadMissionPrompt('ovn', OVN_INSTALL_PROMPT)
-              startMission({
-                title: 'Install OVN-Kubernetes',
-                description: 'Install OVN-Kubernetes with UDN support for tenant network isolation',
-                type: 'deploy',
-                initialPrompt: prompt,
-              })
+              // #5913 — Let the user review/edit the prompt before running.
+              setPendingPrompt(prompt)
             })
           }
           className="mt-1 px-4 py-2 rounded-lg bg-blue-500/20 text-blue-400 text-xs font-medium hover:bg-blue-500/30 transition-colors"
@@ -116,6 +116,24 @@ export function OvnStatus() {
           {t('ovnStatus.installWithAgent')}
         </button>
         <ApiKeyPromptModal isOpen={showKeyPrompt} onDismiss={dismissPrompt} onGoToSettings={goToSettings} />
+        {pendingPrompt !== null && (
+          <ConfirmMissionPromptDialog
+            open={pendingPrompt !== null}
+            missionTitle="Install OVN-Kubernetes"
+            missionDescription="Install OVN-Kubernetes with UDN support for tenant network isolation"
+            initialPrompt={pendingPrompt}
+            onCancel={() => setPendingPrompt(null)}
+            onConfirm={(editedPrompt) => {
+              setPendingPrompt(null)
+              startMission({
+                title: 'Install OVN-Kubernetes',
+                description: 'Install OVN-Kubernetes with UDN support for tenant network isolation',
+                type: 'deploy',
+                initialPrompt: editedPrompt,
+              })
+            }}
+          />
+        )}
       </div>
     )
   }

--- a/web/src/components/cards/multi-tenancy/tenant-isolation-setup/TenantIsolationSetup.tsx
+++ b/web/src/components/cards/multi-tenancy/tenant-isolation-setup/TenantIsolationSetup.tsx
@@ -4,12 +4,14 @@
  * Shows component readiness, isolation levels, architecture description,
  * and CTA buttons to launch AI missions for configuration.
  */
+import { useState } from 'react'
 import {
   CheckCircle, XCircle, AlertTriangle, Shield, Wand2, Download,
   Network, Layers, Box, Monitor } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 import { useMissions } from '../../../../hooks/useMissions'
 import { useApiKeyCheck, ApiKeyPromptModal } from '../../console-missions/shared'
+import { ConfirmMissionPromptDialog } from '../../../missions/ConfirmMissionPromptDialog'
 import { useCardLoadingState } from '../../CardDataContext'
 import { useTenantIsolationSetup } from './useTenantIsolationSetup'
 import { DEMO_TENANT_ISOLATION_SETUP } from './demoData'
@@ -107,6 +109,13 @@ export function TenantIsolationSetup() {
     goToSettings,
     dismissPrompt } = useApiKeyCheck()
 
+  // #5913 — Holds a mission awaiting user review/edit of its prompt.
+  const [pendingMission, setPendingMission] = useState<{
+    title: string
+    description: string
+    prompt: string
+  } | null>(null)
+
   // Use demo data when all hooks return demo data
   const data = liveData.isDemoData ? DEMO_TENANT_ISOLATION_SETUP : liveData
 
@@ -119,11 +128,12 @@ export function TenantIsolationSetup() {
   const handleConfigureAll = () => {
     checkKeyAndRun(async () => {
       const prompt = await loadMissionPrompt('multi-tenancy', MULTI_TENANCY_SETUP_PROMPT)
-      startMission({
+      // #5913 — Let the user review/edit the prompt before running.
+      setPendingMission({
         title: 'Configure Multi-Tenancy',
         description: 'Set up OVN, KubeFlex, K3s, and KubeVirt for tenant isolation',
-        type: 'deploy',
-        initialPrompt: prompt })
+        prompt,
+      })
     })
   }
 
@@ -140,11 +150,12 @@ export function TenantIsolationSetup() {
 
     checkKeyAndRun(async () => {
       const prompt = await loadMissionPrompt(key, fallbackPrompt)
-      startMission({
+      // #5913 — Let the user review/edit the prompt before running.
+      setPendingMission({
         title: `Install ${componentNames[key] || key}`,
         description: `Install and configure ${componentNames[key] || key} for multi-tenancy`,
-        type: 'deploy',
-        initialPrompt: prompt })
+        prompt,
+      })
     })
   }
 
@@ -166,6 +177,27 @@ export function TenantIsolationSetup() {
         onDismiss={dismissPrompt}
         onGoToSettings={goToSettings}
       />
+
+      {/* #5913 — Review/edit the AI mission prompt before running */}
+      {pendingMission && (
+        <ConfirmMissionPromptDialog
+          open={!!pendingMission}
+          missionTitle={pendingMission.title}
+          missionDescription={pendingMission.description}
+          initialPrompt={pendingMission.prompt}
+          onCancel={() => setPendingMission(null)}
+          onConfirm={(editedPrompt) => {
+            const { title, description } = pendingMission
+            setPendingMission(null)
+            startMission({
+              title,
+              description,
+              type: 'deploy',
+              initialPrompt: editedPrompt,
+            })
+          }}
+        />
+      )}
 
       {/* Component readiness row */}
       <div>

--- a/web/src/components/missions/ConfirmMissionPromptDialog.tsx
+++ b/web/src/components/missions/ConfirmMissionPromptDialog.tsx
@@ -1,0 +1,134 @@
+/**
+ * ConfirmMissionPromptDialog
+ *
+ * Shows the AI prompt that will be sent to an "Install via AI" mission
+ * and lets the user review and edit it before the mission is executed.
+ *
+ * Fixes #5913 — Install-via-AI buttons previously started a mission
+ * immediately with no chance for the user to see or edit the prompt.
+ *
+ * Usage:
+ *   <ConfirmMissionPromptDialog
+ *     open={open}
+ *     missionTitle="Install cert-manager"
+ *     missionDescription="Install and configure cert-manager"
+ *     initialPrompt={prompt}
+ *     onCancel={() => setOpen(false)}
+ *     onConfirm={(editedPrompt) => startMission({ ..., initialPrompt: editedPrompt })}
+ *   />
+ */
+
+import { useState } from 'react'
+import { Wand2, Info } from 'lucide-react'
+import { useTranslation } from 'react-i18next'
+import { BaseModal } from '../../lib/modals/BaseModal'
+import { Button } from '../ui/Button'
+import { TextArea } from '../ui/TextArea'
+
+/** Minimum visible rows for the prompt textarea. */
+const PROMPT_TEXTAREA_ROWS = 12
+
+interface ConfirmMissionPromptDialogProps {
+  /** Whether the dialog is open. */
+  open: boolean
+  /** Title of the mission — shown in the modal header. */
+  missionTitle: string
+  /** Short description of the mission — shown under the header title. */
+  missionDescription?: string
+  /** The prompt that will be sent to the AI agent. The user can edit this. */
+  initialPrompt: string
+  /** Called when the user clicks Cancel or dismisses the dialog. */
+  onCancel: () => void
+  /** Called with the (possibly edited) prompt when the user clicks Confirm. */
+  onConfirm: (editedPrompt: string) => void
+}
+
+export function ConfirmMissionPromptDialog({
+  open,
+  missionTitle,
+  missionDescription,
+  initialPrompt,
+  onCancel,
+  onConfirm,
+}: ConfirmMissionPromptDialogProps) {
+  const { t } = useTranslation(['common'])
+  // Parents of this dialog always conditionally mount it (e.g.
+  // `{pending && <ConfirmMissionPromptDialog ... />}`) so a new instance
+  // is created for each pending mission. That means a lazy `useState`
+  // initializer is enough — we never need to sync with changing props.
+  const [prompt, setPrompt] = useState<string>(() => initialPrompt)
+
+  const trimmed = prompt.trim()
+  const confirmDisabled = trimmed.length === 0
+
+  return (
+    <BaseModal isOpen={open} onClose={onCancel} size="lg">
+      <BaseModal.Header
+        title={t('confirmMissionPrompt.title', 'Review AI mission prompt')}
+        description={missionTitle}
+        icon={Wand2}
+        onClose={onCancel}
+      />
+
+      <BaseModal.Content>
+        <div className="flex flex-col gap-3">
+          {missionDescription && (
+            <p className="text-sm text-muted-foreground">{missionDescription}</p>
+          )}
+
+          <div className="flex items-start gap-2 rounded-lg border border-purple-500/20 bg-purple-500/5 p-3 text-xs text-muted-foreground">
+            <Info className="h-4 w-4 text-purple-400 flex-shrink-0 mt-0.5" />
+            <p>
+              {t(
+                'confirmMissionPrompt.helpText',
+                'Review the prompt below before running. You can edit it to add extra context, change parameters, or remove anything you do not want the AI agent to do.'
+              )}
+            </p>
+          </div>
+
+          <label
+            htmlFor="confirm-mission-prompt-textarea"
+            className="text-xs font-medium text-muted-foreground"
+          >
+            {t('confirmMissionPrompt.promptLabel', 'Prompt sent to the AI agent')}
+          </label>
+          <TextArea
+            id="confirm-mission-prompt-textarea"
+            rows={PROMPT_TEXTAREA_ROWS}
+            value={prompt}
+            onChange={(e) => setPrompt(e.target.value)}
+            resizable
+            textAreaSize="sm"
+            className="font-mono"
+            spellCheck={false}
+            aria-label={t('confirmMissionPrompt.promptLabel', 'Prompt sent to the AI agent')}
+          />
+
+          {confirmDisabled && (
+            <p className="text-2xs text-red-400">
+              {t(
+                'confirmMissionPrompt.emptyPromptError',
+                'Prompt cannot be empty.'
+              )}
+            </p>
+          )}
+        </div>
+      </BaseModal.Content>
+
+      <BaseModal.Footer showKeyboardHints={false}>
+        <Button variant="ghost" size="sm" onClick={onCancel}>
+          {t('confirmMissionPrompt.cancel', 'Cancel')}
+        </Button>
+        <Button
+          variant="accent"
+          size="sm"
+          onClick={() => onConfirm(prompt)}
+          disabled={confirmDisabled}
+          className="ml-auto"
+        >
+          {t('confirmMissionPrompt.confirm', 'Run mission')}
+        </Button>
+      </BaseModal.Footer>
+    </BaseModal>
+  )
+}

--- a/web/src/locales/en/common.json
+++ b/web/src/locales/en/common.json
@@ -3348,5 +3348,13 @@
         "troubleshootingEmpty": "Troubleshooting steps not yet available for this mission."
       }
     }
+  },
+  "confirmMissionPrompt": {
+    "title": "Review AI mission prompt",
+    "helpText": "Review the prompt below before running. You can edit it to add extra context, change parameters, or remove anything you do not want the AI agent to do.",
+    "promptLabel": "Prompt sent to the AI agent",
+    "emptyPromptError": "Prompt cannot be empty.",
+    "cancel": "Cancel",
+    "confirm": "Run mission"
   }
 }


### PR DESCRIPTION
## Summary

Fixes #5913

Previously, clicking any "Install via AI" button on a card (or in the multi-tenancy status cards) immediately started an AI mission with zero opportunity for the user to see, review, or edit the prompt that was about to be sent to the AI agent.

This PR introduces a reusable `ConfirmMissionPromptDialog` that is shown between the install CTA and the actual `startMission()` call. It:

- Displays the full AI prompt in an editable `TextArea`
- Lets the user freely edit it (add constraints, remove steps, tweak parameters)
- Has explicit **Cancel** and **Run mission** buttons
- Blocks Confirm when the prompt has been emptied

## Wired into

- `CardWrapper.tsx` — the main "Install for live data" flow used by every card with `installInfo` (cert-manager, Trivy, Kyverno, OPA, Kubecost, Argo CD, Flux, Prometheus, KubeVela, etc.). Flow is now: CTA -> ClusterSelectionDialog -> ConfirmMissionPromptDialog -> startMission.
- `K3sStatus`, `KubeFlexStatus`, `KubevirtStatus`, `OvnStatus` — multi-tenancy "Install with AI Agent" CTAs
- `TenantIsolationSetup` — both the "Configure Multi-Tenancy" combined mission and each per-component install button

## i18n

New keys added to `common.json` under `confirmMissionPrompt`:
- `title`, `helpText`, `promptLabel`, `emptyPromptError`, `cancel`, `confirm`

Only English is populated in this PR; the i18n fallback keys in the component default to English copy so other locales degrade gracefully.

## Test plan

- [x] `npm run build` passes
- [x] `npm run lint` — no new errors introduced (pre-existing errors unchanged)
- [x] `vitest run src/components/missions/__tests__/ src/components/cards/multi-tenancy/` — 122/122 tests pass
- [ ] Manual: click "Install with AI Agent" on K3s, KubeFlex, KubeVirt, OVN cards in demo mode — confirm dialog appears with prompt
- [ ] Manual: click "Install for live data" on a card with installInfo (e.g. cert-manager) — confirm dialog appears after cluster selection, prompt is editable, Cancel aborts, Confirm runs the mission with the edited text
- [ ] Manual: edit the prompt in the dialog, click Run mission — verify the mission starts with the edited prompt visible in the mission chat

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)