### PR TITLE
fix: remove conflicting aria-live from role=alert error banner

### DIFF
--- a/web/src/components/mission-control/FixerDefinitionPanel.tsx
+++ b/web/src/components/mission-control/FixerDefinitionPanel.tsx
@@ -946,7 +946,6 @@ function AISuggestErrorBanner({
       initial={{ opacity: 0, y: -8 }}
       animate={{ opacity: 1, y: 0 }}
       role="alert"
-      aria-live="polite"
       className="rounded-lg border border-destructive/40 bg-destructive/10 overflow-hidden"
     >
       <div className="flex items-start gap-3 px-4 py-3">


### PR DESCRIPTION
Fixes #5916

role="alert" already implies aria-live="assertive". Removing the explicit aria-live="polite" since it conflicts with the implicit one from role=alert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)