### PR TITLE
fix: harden mission lifecycle handling (#5929-#5934)

### DIFF
--- a/web/src/components/layout/mission-sidebar/MissionChat.tsx
+++ b/web/src/components/layout/mission-sidebar/MissionChat.tsx
@@ -433,7 +433,7 @@ export function MissionChat({ mission, isFullScreen = false, fontSize = 'base' a
               <Maximize2 className="w-4 h-4 text-muted-foreground" />
             </button>
           )}
-          {mission.status === 'running' && (
+          {(mission.status === 'running' || mission.status === 'pending' || mission.status === 'blocked') && (
             <button
               onClick={() => cancelMission(mission.id)}
               className="flex items-center gap-1.5 px-2.5 py-1 text-xs font-medium bg-red-500/15 hover:bg-red-500/25 text-red-400 border border-red-500/30 rounded-lg transition-colors"
@@ -441,7 +441,9 @@ export function MissionChat({ mission, isFullScreen = false, fontSize = 'base' a
               data-testid="terminate-session-btn"
             >
               <StopCircle className="w-3.5 h-3.5" />
-              {t('missionChat.terminateSession', { defaultValue: 'Terminate Session' })}
+              {mission.status === 'pending'
+                ? t('missionChat.cancelPending', { defaultValue: 'Cancel' })
+                : t('missionChat.terminateSession', { defaultValue: 'Terminate Session' })}
             </button>
           )}
           <div className={cn('flex items-center gap-1', config.color)}>

--- a/web/src/components/layout/mission-sidebar/MissionListItem.tsx
+++ b/web/src/components/layout/mission-sidebar/MissionListItem.tsx
@@ -80,7 +80,7 @@ export function MissionListItem({ mission, isActive, onClick, onDismiss, onExpan
             <Loader2 className="w-3.5 h-3.5 text-orange-400 animate-spin" />
           </span>
         )}
-        {mission.status === 'running' && onTerminate && (
+        {(mission.status === 'running' || mission.status === 'pending' || mission.status === 'blocked') && onTerminate && (
           <button
             onClick={(e) => { e.stopPropagation(); onTerminate() }}
             className="p-0.5 hover:bg-red-500/20 rounded transition-colors flex-shrink-0"

--- a/web/src/components/layout/mission-sidebar/MissionSidebar.tsx
+++ b/web/src/components/layout/mission-sidebar/MissionSidebar.tsx
@@ -195,6 +195,17 @@ export function MissionSidebar() {
 
   const handleApplyResolution = (resolution: { title: string; resolution: { summary: string; steps: string[]; yaml?: string } }) => {
     if (!activeMission) return
+    // Enforce lifecycle validation (#5934): resolution should never be
+    // applied to a mission that is in a non-interactive state. Blocked
+    // missions are awaiting preflight fixes, pending missions have never
+    // left the queue, and cancelling/cancelled missions should not be
+    // restarted through the resolution flow. Running missions already
+    // have input disabled so sendMessage would no-op, but we surface a
+    // clearer guard here anyway.
+    const NON_APPLIABLE_STATUSES = new Set(['blocked', 'pending', 'cancelling', 'running'])
+    if (NON_APPLIABLE_STATUSES.has(activeMission.status)) {
+      return
+    }
     const applyMessage = `Please apply this saved resolution:\n\n**${resolution.title}**\n\n${resolution.resolution.summary}\n\nSteps:\n${resolution.resolution.steps.map((s: string, i: number) => `${i + 1}. ${s}`).join('\n')}${resolution.resolution.yaml ? `\n\nYAML:\n\`\`\`yaml\n${resolution.resolution.yaml}\n\`\`\`` : ''}`
     sendMessage(activeMission.id, applyMessage)
   }
@@ -442,8 +453,11 @@ export function MissionSidebar() {
   }, [isSidebarOpen, isFullScreen, setFullScreen, closeSidebar])
 
   // Count missions needing attention
+  // Blocked missions are stuck waiting on user action (preflight failure,
+  // missing credentials, RBAC denial). Surfacing them in the attention
+  // indicator ensures the user sees the required action (#5933).
   const needsAttention = missions.filter(m =>
-    m.status === 'waiting_input' || m.status === 'failed'
+    m.status === 'waiting_input' || m.status === 'failed' || m.status === 'blocked'
   ).length
 
   const runningCount = missions.filter(m => m.status === 'running').length
@@ -1213,8 +1227,11 @@ export function MissionSidebarToggle() {
   const { missions, isSidebarOpen, openSidebar } = useMissions()
   const { isMobile } = useMobile()
 
+  // Blocked missions are stuck waiting on user action (preflight failure,
+  // missing credentials, RBAC denial). Surfacing them in the attention
+  // indicator ensures the user sees the required action (#5933).
   const needsAttention = missions.filter(m =>
-    m.status === 'waiting_input' || m.status === 'failed'
+    m.status === 'waiting_input' || m.status === 'failed' || m.status === 'blocked'
   ).length
 
   const runningCount = missions.filter(m => m.status === 'running').length

--- a/web/src/hooks/useMissions.test.tsx
+++ b/web/src/hooks/useMissions.test.tsx
@@ -2491,18 +2491,20 @@ describe('ensureConnection timeout', () => {
 // ── WebSocket close fails pending missions ───────────────────────────────────
 
 describe('WS close fails pending running missions', () => {
-  it('fails all pending running missions when WS closes with error content', async () => {
+  it('keeps missions running with needsReconnect flag on transient WS close (#5929)', async () => {
     const { result } = renderHook(() => useMissions(), { wrapper })
     const { missionId } = await startMissionWithConnection(result)
     expect(result.current.missions.find(m => m.id === missionId)?.status).toBe('running')
 
-    // Simulate WebSocket closing
+    // Simulate WebSocket closing — transient disconnect, reconnect attempts still available
     act(() => { MockWebSocket.lastInstance?.simulateClose() })
 
     const mission = result.current.missions.find(m => m.id === missionId)
-    expect(mission?.status).toBe('failed')
-    const systemMsg = mission?.messages.find(m => m.role === 'system')
-    expect(systemMsg?.content).toContain('Agent Disconnected')
+    // Mission should remain running with needsReconnect flag set,
+    // not be failed (#5929 — transient disconnect shouldn't fail missions)
+    expect(mission?.status).toBe('running')
+    expect(mission?.context?.needsReconnect).toBe(true)
+    expect(mission?.currentStep).toBe('Reconnecting...')
   })
 })
 
@@ -4479,7 +4481,7 @@ describe('loadMissions: status preservation', () => {
     expect(mission?.currentStep).toBeUndefined()
   })
 
-  it('preserves pending missions without modification', () => {
+  it('fails pending missions on reload with recovery message (#5931)', () => {
     const pendingMission = {
       id: 'pending-1',
       title: 'Pending',
@@ -4494,7 +4496,11 @@ describe('loadMissions: status preservation', () => {
 
     const { result } = renderHook(() => useMissions(), { wrapper })
     const mission = result.current.missions.find(m => m.id === 'pending-1')
-    expect(mission?.status).toBe('pending')
+    // Pending missions cannot be resumed (backend never received the request),
+    // so they're failed on reload with a clear message (#5931).
+    expect(mission?.status).toBe('failed')
+    const systemMsg = mission?.messages.find(m => m.role === 'system')
+    expect(systemMsg?.content).toContain('Page was reloaded')
   })
 
   it('preserves saved (library) missions without modification', () => {
@@ -5373,17 +5379,18 @@ describe('unread tracking: active mission not marked unread', () => {
 // ── WebSocket close: fails pending missions, clears pendingRequests ─────────
 
 describe('WS close: pending request cleanup', () => {
-  it('clears all pending requests when WS closes', async () => {
+  it('clears all pending requests when WS closes and marks mission for reconnect (#5929)', async () => {
     const { result } = renderHook(() => useMissions(), { wrapper })
     const { missionId } = await startMissionWithConnection(result)
     expect(result.current.missions.find(m => m.id === missionId)?.status).toBe('running')
 
-    // Close WS
+    // Close WS — transient disconnect, should not fail the mission
     act(() => { MockWebSocket.lastInstance?.simulateClose() })
 
-    // Mission should have been failed
+    // Mission should still be running with needsReconnect flag (#5929)
     const mission = result.current.missions.find(m => m.id === missionId)
-    expect(mission?.status).toBe('failed')
+    expect(mission?.status).toBe('running')
+    expect(mission?.context?.needsReconnect).toBe(true)
 
     // New messages to the old request ID should be ignored (pending was cleared)
     // (This verifies pendingRequests.current.clear() was called)
@@ -5393,17 +5400,21 @@ describe('WS close: pending request cleanup', () => {
 // ── Timeout interval: does not change non-running missions ──────────────────
 
 describe('timeout interval: preserves non-running missions', () => {
-  it('does not fail pending missions when timeout fires', async () => {
+  it('does not fail waiting_input missions when timeout fires', async () => {
+    // Previously this test used `pending`, but pending missions are now
+    // auto-failed on hydration (#5931) since they cannot be resumed. The
+    // intent of this test is to verify the timeout interval only targets
+    // running missions — waiting_input is the equivalent non-running state.
     vi.useFakeTimers()
     try {
-      seedMission({ id: 'pending-safe', status: 'pending' })
+      seedMission({ id: 'waiting-safe-2', status: 'waiting_input' })
       const { result } = renderHook(() => useMissions(), { wrapper })
 
       // Advance past timeout + check interval
       act(() => { vi.advanceTimersByTime(315_000) })
 
-      const mission = result.current.missions.find(m => m.id === 'pending-safe')
-      expect(mission?.status).toBe('pending')
+      const mission = result.current.missions.find(m => m.id === 'waiting-safe-2')
+      expect(mission?.status).toBe('waiting_input')
     } finally {
       vi.useRealTimers()
     }

--- a/web/src/hooks/useMissions.tsx
+++ b/web/src/hooks/useMissions.tsx
@@ -252,6 +252,28 @@ function loadMissions(): Mission[] {
             context: { ...mission.context, needsReconnect: true }
           }
         }
+        // Missions stuck in 'pending' state after a page reload cannot be resumed —
+        // the backend never received the chat request (we only transition to
+        // 'running' after ensureConnection resolves and wsSend is called), so
+        // replaying it now would risk a duplicate execution on agents that are
+        // not idempotent. Fail the mission with a clear message prompting the
+        // user to retry manually (#5931).
+        if (mission.status === 'pending') {
+          return {
+            ...mission,
+            status: 'failed',
+            currentStep: undefined,
+            updatedAt: new Date(),
+            messages: [
+              ...mission.messages,
+              {
+                id: `msg-pending-reload-${mission.id}-${Date.now()}`,
+                role: 'system' as const,
+                content: 'Page was reloaded before this mission could start. Please retry the mission.',
+                timestamp: new Date() }
+            ]
+          }
+        }
         // Missions stuck in 'cancelling' after a page reload should be finalized
         if (mission.status === 'cancelling') {
           return {
@@ -562,6 +584,9 @@ export function MissionProvider({ children }: { children: ReactNode }) {
           // React StrictMode may invoke state updaters twice, which would
           // cause duplicate reconnection requests if the send lived inside.
           const missionsToReconnect: Mission[] = []
+          // Missions that have already had one reconnect attempt — don't
+          // replay the prompt again; fail them instead (#5930).
+          const missionsToFailDuplicate: string[] = []
 
           setMissions(prev => {
             const candidates = prev.filter(m =>
@@ -569,19 +594,44 @@ export function MissionProvider({ children }: { children: ReactNode }) {
             )
 
             if (candidates.length > 0) {
-              // Snapshot missions for the side effect scheduled below
-              missionsToReconnect.push(...candidates)
+              // Split candidates into first-attempt (safe to replay) vs
+              // already-attempted (unsafe — would duplicate execution on
+              // non-idempotent agents, see #5930).
+              for (const m of candidates) {
+                if (m.context?.reconnectAttempted) {
+                  missionsToFailDuplicate.push(m.id)
+                } else {
+                  missionsToReconnect.push(m)
+                }
+              }
 
-              // Clear the needsReconnect flag and update step (pure state update)
-              return prev.map(m =>
-                m.context?.needsReconnect
-                  ? {
-                      ...m,
-                      currentStep: 'Resuming...',
-                      context: { ...m.context, needsReconnect: false }
-                    }
-                  : m
-              )
+              // Clear the needsReconnect flag and mark reconnectAttempted
+              // so a subsequent reconnect won't replay the prompt again.
+              return prev.map(m => {
+                if (!m.context?.needsReconnect) return m
+                if (missionsToFailDuplicate.includes(m.id)) {
+                  return {
+                    ...m,
+                    status: 'failed' as MissionStatus,
+                    currentStep: undefined,
+                    updatedAt: new Date(),
+                    context: { ...m.context, needsReconnect: false },
+                    messages: [
+                      ...m.messages,
+                      {
+                        id: `msg-reconnect-abort-${m.id}-${Date.now()}`,
+                        role: 'system' as const,
+                        content: 'Connection was lost twice during this mission. To avoid duplicating an in-flight action, the mission was stopped. Please retry it manually.',
+                        timestamp: new Date() }
+                    ]
+                  }
+                }
+                return {
+                  ...m,
+                  currentStep: 'Resuming...',
+                  context: { ...m.context, needsReconnect: false, reconnectAttempted: true }
+                }
+              })
             }
             return prev
           })
@@ -598,6 +648,11 @@ export function MissionProvider({ children }: { children: ReactNode }) {
                   // Determine which agent to use - prefer claude-code for tool execution
                   const agentToUse = mission.agent || 'claude-code'
 
+                  // Tag the reconnect with a deterministic resumeKey per
+                  // mission — backends that support resume-by-key can
+                  // de-duplicate on this key and avoid replaying actions
+                  // that were already (partially) processed (#5930).
+                  const resumeKey = `resume-${mission.id}`
                   const requestId = `claude-reconnect-${Date.now()}-${mission.id}`
                   pendingRequests.current.set(requestId, mission.id)
 
@@ -616,7 +671,9 @@ export function MissionProvider({ children }: { children: ReactNode }) {
                       prompt: lastUserMessage.content,
                       sessionId: mId,
                       agent: agentToUse,
-                      history: history }
+                      history: history,
+                      resumeKey: resumeKey,
+                      isResume: true }
                   }), () => {
                     setMissions(prev => prev.map(m =>
                       m.id === mId ? { ...m, status: 'failed', currentStep: 'WebSocket reconnect failed' } : m
@@ -672,31 +729,54 @@ export function MissionProvider({ children }: { children: ReactNode }) {
             )
           }
 
-          // Fail any pending missions that were waiting for a response
+          // Transient disconnect handling (#5929): instead of failing running
+          // missions immediately, mark them with needsReconnect so that the
+          // auto-reconnect loop (above) can resume them once the WebSocket
+          // re-opens. We only fail missions permanently when the reconnect
+          // retries have been exhausted (handled in the `else if` branch
+          // below). The pending request IDs are cleared because a new request
+          // ID will be issued on reconnect — keeping them would cause late
+          // responses from the dead socket to be misattributed (#4499).
+          const isGivingUp = getDemoMode() || wsReconnectAttempts.current >= WS_RECONNECT_MAX_RETRIES
           if (pendingRequests.current.size > 0) {
-            const errorContent = `**Agent Disconnected**
-
-The WebSocket connection to the agent at \`${LOCAL_AGENT_WS_URL}\` was lost. Please verify the agent is running and reachable.`
-
             const pendingMissionIds = new Set(pendingRequests.current.values())
-            setMissions(prev => prev.map(m => {
-              if (pendingMissionIds.has(m.id) && m.status === 'running') {
-                return {
-                  ...m,
-                  status: 'failed',
-                  currentStep: undefined,
-                  messages: [
-                    ...m.messages,
-                    {
-                      id: `msg-${Date.now()}-${m.id}`,
-                      role: 'system',
-                      content: errorContent,
-                      timestamp: new Date() }
-                  ]
+
+            if (isGivingUp) {
+              const errorContent = `**Agent Disconnected**
+
+The WebSocket connection to the agent at \`${LOCAL_AGENT_WS_URL}\` was lost and reconnection attempts were exhausted. Please verify the agent is running and reachable, then retry the mission.`
+              setMissions(prev => prev.map(m => {
+                if (pendingMissionIds.has(m.id) && m.status === 'running') {
+                  return {
+                    ...m,
+                    status: 'failed',
+                    currentStep: undefined,
+                    messages: [
+                      ...m.messages,
+                      {
+                        id: `msg-${Date.now()}-${m.id}`,
+                        role: 'system',
+                        content: errorContent,
+                        timestamp: new Date() }
+                    ]
+                  }
                 }
-              }
-              return m
-            }))
+                return m
+              }))
+            } else {
+              // Transient disconnect — keep mission in 'running' but mark it
+              // as needing reconnect. The UI will show "Reconnecting..." and
+              // the onopen handler will resume the mission automatically.
+              setMissions(prev => prev.map(m => {
+                if (pendingMissionIds.has(m.id) && m.status === 'running') {
+                  return {
+                    ...m,
+                    currentStep: 'Reconnecting...',
+                    context: { ...m.context, needsReconnect: true } }
+                }
+                return m
+              }))
+            }
             pendingRequests.current.clear()
           }
         }
@@ -712,17 +792,29 @@ The WebSocket connection to the agent at \`${LOCAL_AGENT_WS_URL}\` was lost. Ple
             ws.close()
             wsRef.current = null
           }
-          // Fail only missions that have pending requests — don't sweep
-          // all running missions, as some may belong to a different WS session (#5851)
+          // Transient disconnect handling (#5929): only fail missions
+          // permanently when reconnection attempts are exhausted. Otherwise
+          // mark them as needing reconnect so onopen can resume them.
+          // Don't sweep all running missions — only those tied to pending
+          // requests, as others may belong to a different WS session (#5851).
+          const isGivingUp = getDemoMode() || wsReconnectAttempts.current >= WS_RECONNECT_MAX_RETRIES
           if (pendingRequests.current.size > 0) {
             const affectedMissionIds = new Set(pendingRequests.current.values())
-            const errorContent = `**Agent Disconnected**\n\nThe WebSocket connection failed. Please verify the agent is running and try again.`
-            setMissions(prev => prev.map(m => {
-              if (!affectedMissionIds.has(m.id)) return m
-              if (m.status !== 'running' && m.status !== 'waiting_input') return m
-              return { ...m, status: 'failed' as MissionStatus, currentStep: 'Connection failed',
-                messages: [...m.messages, { id: `msg-${Date.now()}-ws-error`, role: 'system' as const, content: errorContent, timestamp: new Date() }] }
-            }))
+            if (isGivingUp) {
+              const errorContent = `**Agent Disconnected**\n\nThe WebSocket connection failed and reconnection attempts were exhausted. Please verify the agent is running and try again.`
+              setMissions(prev => prev.map(m => {
+                if (!affectedMissionIds.has(m.id)) return m
+                if (m.status !== 'running' && m.status !== 'waiting_input') return m
+                return { ...m, status: 'failed' as MissionStatus, currentStep: 'Connection failed',
+                  messages: [...m.messages, { id: `msg-${Date.now()}-ws-error`, role: 'system' as const, content: errorContent, timestamp: new Date() }] }
+              }))
+            } else {
+              setMissions(prev => prev.map(m => {
+                if (!affectedMissionIds.has(m.id)) return m
+                if (m.status !== 'running' && m.status !== 'waiting_input') return m
+                return { ...m, currentStep: 'Reconnecting...', context: { ...m.context, needsReconnect: true } }
+              }))
+            }
             pendingRequests.current.clear()
           }
           setAgentsLoading(false)
@@ -1643,6 +1735,38 @@ Install the console locally with the KubeStellar Console agent to use AI mission
     // Guard against double-cancel: if already cancelling, don't schedule another timeout
     if (cancelTimeouts.current.has(missionId)) return
 
+    // Pending missions have never been sent to the backend yet (preflight
+    // check is still running, or ensureConnection has not resolved). We can
+    // short-circuit here and finalize the mission as cancelled without
+    // contacting the backend at all (#5932). This also applies to the
+    // 'blocked' state where the mission is waiting on preflight resolution.
+    const currentMission = missionsRef.current.find(m => m.id === missionId)
+    if (currentMission && (currentMission.status === 'pending' || currentMission.status === 'blocked')) {
+      // Clean up any tracking just in case
+      for (const [reqId, mId] of pendingRequests.current.entries()) {
+        if (mId === missionId) pendingRequests.current.delete(reqId)
+      }
+      lastStreamTimestamp.current.delete(missionId)
+
+      setMissions(prev => prev.map(m =>
+        m.id === missionId ? {
+          ...m,
+          status: 'failed' as MissionStatus,
+          currentStep: undefined,
+          updatedAt: new Date(),
+          messages: [
+            ...m.messages,
+            {
+              id: `msg-cancel-pending-${Date.now()}`,
+              role: 'system' as const,
+              content: 'Mission cancelled by user before it started.',
+              timestamp: new Date() }
+          ]
+        } : m
+      ))
+      return
+    }
+
     // Keep pendingRequests intact so that terminal messages (result, stream-done)
     // from the backend can still be matched to the mission. The handler for
     // 'cancelling' missions (below) treats any terminal message as implicit
@@ -1731,6 +1855,15 @@ Install the console locally with the KubeStellar Console agent to use AI mission
     // Only stop commands (handled above) are allowed during active execution.
     const currentMission = missionsRef.current.find(m => m.id === missionId)
     if (currentMission && (currentMission.status === 'running' || currentMission.status === 'cancelling')) {
+      return
+    }
+    // Blocked missions are waiting on preflight resolution (missing
+    // credentials, RBAC failures, etc.). New input must not bypass that
+    // validation — the user has to call retryPreflight after fixing the
+    // underlying issue, which will move the mission to 'running' first
+    // (#5934). Silently dropping the send here is safe because the UI
+    // already disables the input in the blocked state.
+    if (currentMission && currentMission.status === 'blocked') {
       return
     }
 


### PR DESCRIPTION
## Summary

Bundled fixes for six related mission lifecycle bugs reported via the Console feedback tool.

### #5929 — Transient WS disconnect causes permanent mission failure
The `onclose`/`onerror` handlers now mark running missions with `needsReconnect` instead of immediately failing them. Missions only transition to `failed` when the WebSocket reconnection retries are exhausted (or in demo mode). The existing `onopen` reconnect loop picks them up and resumes.

### #5930 — Reconnect replays last prompt causing duplicate execution
Each reconnect attempt now sets a `reconnectAttempted` flag on the mission context. A second disconnect during the same mission no longer replays the prompt — it fails the mission with a clear message instructing the user to retry manually. Reconnect requests are also tagged with a deterministic `resumeKey` (one per mission) so that backends implementing resume-by-key can de-duplicate replays.

### #5931 — Mission stuck in pending state after page reload
Pending missions are now failed on hydration (`loadMissions`) with a recovery message: _"Page was reloaded before this mission could start. Please retry the mission."_ The backend never received the chat request for pending missions, so resuming would risk a duplicate execution on non-idempotent agents.

### #5932 — Pending missions cannot be cancelled
- `MissionChat` and `MissionListItem` now show the terminate/cancel button for `pending`, `blocked`, and `running` states.
- `cancelMission` short-circuits to a clean `failed` transition (no backend call needed) when the mission is in `pending` or `blocked`.

### #5933 — Blocked missions not surfaced in attention indicators
The `needsAttention` count in the sidebar toggle now includes `blocked` missions. Blocked missions require user action to resolve preflight failures (RBAC denials, missing credentials, expired tokens), so they belong in the attention badge.

### #5934 — Resolution flow bypasses blocked-state validation
- `handleApplyResolution` in `MissionSidebar` now rejects apply on missions in `blocked`, `pending`, `cancelling`, or `running` states.
- `sendMessage` in `useMissions` now guards against the `blocked` state as a second layer of defense.

## Test plan

- [x] `npm run build` passes
- [x] `npm run lint` — no new errors introduced in touched files
- [x] `npx vitest run src/hooks/useMissions.test.tsx` — 280/280 pass
- [x] `npx vitest run src/components/layout/mission-sidebar` — 5/5 pass
- [ ] Manual: kill agent briefly, confirm mission stays running with "Reconnecting..." and resumes
- [ ] Manual: kill agent twice, confirm second disconnect fails the mission instead of replaying
- [ ] Manual: reload while mission is pending, confirm transition to failed with retry message
- [ ] Manual: cancel button works on pending missions
- [ ] Manual: blocked missions show in attention badge
- [ ] Manual: resolution panel refuses to apply on blocked missions

Closes #5929
Closes #5930
Closes #5931
Closes #5932
Closes #5933
Closes #5934