### PR TITLE
fix: standardize cluster health logic and surface diagnostics (#5920-#5928)

### DIFF
--- a/pkg/api/handlers/mcp_cluster.go
+++ b/pkg/api/handlers/mcp_cluster.go
@@ -46,6 +46,13 @@ func (h *MCPHandlers) ListClusters(c *fiber.Ctx) error {
 				clusters[i].Healthy = health.Healthy
 				clusters[i].NodeCount = health.NodeCount
 				clusters[i].PodCount = health.PodCount
+				// Surface the stale-kubeconfig signal: a cluster that has
+				// a health cache entry but has never been successfully
+				// reached (empty LastSeen) drives the "never connected"
+				// warning banner in the Clusters page (#5921).
+				if !health.Reachable && health.LastSeen == "" {
+					clusters[i].NeverConnected = true
+				}
 			} else {
 				// No health data collected yet (e.g. immediately after boot).
 				// Signal "initializing" rather than falsely reporting Unhealthy.

--- a/web/src/components/cluster-admin/ClusterAdmin.tsx
+++ b/web/src/components/cluster-admin/ClusterAdmin.tsx
@@ -5,6 +5,7 @@ import { StatBlockValue } from '../ui/StatsOverview'
 import { DashboardPage } from '../../lib/dashboards'
 import { getDefaultCards } from '../../config/dashboards'
 import { RotatingTip } from '../ui/RotatingTip'
+import { getClusterHealthState, isClusterUnreachable } from '../clusters/utils'
 
 const STORAGE_KEY = 'kubestellar-cluster-admin-cards'
 const DEFAULT_CARDS = getDefaultCards('cluster-admin')
@@ -22,10 +23,12 @@ export function ClusterAdmin() {
   const warningEvents = rawWarningEvents || []
   const nodes = rawNodes || []
 
-  const reachable = clusters.filter(c => c.reachable !== false)
-  const healthy = reachable.filter(c => c.healthy === true)
-  const degraded = reachable.filter(c => c.healthy === false)
-  const offline = clusters.filter(c => c.reachable === false)
+  // Use the centralised health state machine so these counts always agree
+  // with the main cluster grid, sidebar stats and filter tabs (#5928).
+  const reachable = clusters.filter(c => !isClusterUnreachable(c))
+  const healthy = reachable.filter(c => getClusterHealthState(c) === 'healthy')
+  const degraded = reachable.filter(c => getClusterHealthState(c) === 'unhealthy')
+  const offline = clusters.filter(c => isClusterUnreachable(c))
   const hasData = clusters.length > 0
   const isDemoData = !hasData && !isLoading
 

--- a/web/src/components/clusters/ClusterDetailModal.tsx
+++ b/web/src/components/clusters/ClusterDetailModal.tsx
@@ -15,6 +15,7 @@ import { CloudProviderIcon, detectCloudProvider as detectCloudProviderShared, ge
 import { useTranslation } from 'react-i18next'
 import { StatusBadge } from '../ui/StatusBadge'
 import { Button } from '../ui/Button'
+import { ClusterStatusDetails } from './ClusterStatusDetails'
 
 // Cloud provider types
 type CloudProvider = 'eks' | 'gke' | 'aks' | 'openshift' | 'oci' | 'alibaba' | 'digitalocean' | 'rancher' | 'coreweave' | 'kind' | 'minikube' | 'k3s' | 'unknown'
@@ -329,6 +330,12 @@ After I approve, help me execute the repairs step by step.`,
             <X className="w-5 h-5" />
           </button>
         </div>
+
+        {/* Status details — surfaces unreachable reason (#5925),
+            external reachability (#5926) and freshness (#5927). */}
+        {clusterInfo && (
+          <ClusterStatusDetails cluster={clusterInfo} className="mb-4" />
+        )}
 
         {/* AI Actions */}
         <div className="mb-6 p-4 rounded-lg bg-gradient-to-r from-purple-500/10 to-blue-500/10 border border-purple-500/20">

--- a/web/src/components/clusters/ClusterGroupsSection.tsx
+++ b/web/src/components/clusters/ClusterGroupsSection.tsx
@@ -1,9 +1,10 @@
-import { useState } from 'react'
-import { Check, WifiOff, ChevronRight, CheckCircle, AlertTriangle, ChevronDown, FolderOpen, Plus, Trash2 } from 'lucide-react'
+import { useMemo, useState } from 'react'
+import { Check, WifiOff, ChevronRight, CheckCircle, AlertTriangle, HelpCircle, Loader2, ChevronDown, FolderOpen, Plus, Trash2 } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 import type { ClusterInfo } from '../../hooks/mcp/types'
 import type { ClusterGroup } from '../../hooks/useGlobalFilters'
-import { isClusterUnreachable } from './utils'
+import { deduplicateClustersByServer } from '../../hooks/mcp/shared'
+import { getClusterHealthState, isClusterUnreachable } from './utils'
 
 export interface ClusterGroupsSectionProps {
   /** All clusters (unfiltered) for the new-group cluster picker */
@@ -35,6 +36,11 @@ export function ClusterGroupsSection({
   const [showGroupForm, setShowGroupForm] = useState(false)
   const [newGroupName, setNewGroupName] = useState('')
   const [newGroupClusters, setNewGroupClusters] = useState<string[]>([])
+
+  // Deduplicate clusters so contexts pointing at the same server are not
+  // rendered twice in the picker (#5922). Uses the same helper as the main
+  // cluster list so both stay in sync.
+  const pickerClusters = useMemo(() => deduplicateClustersByServer(clusters), [clusters])
 
   // When no groups exist and form is not showing, render just the New Group button
   if (clusterGroups.length === 0 && !showGroupForm) {
@@ -95,8 +101,11 @@ export function ClusterGroupsSection({
               />
               <div className="text-xs text-muted-foreground mb-1">Select clusters for this group:</div>
               <div className="flex flex-wrap gap-2">
-                {clusters.map((cluster) => {
+                {pickerClusters.map((cluster) => {
                   const isInGroup = newGroupClusters.includes(cluster.name)
+                  // Use the shared health state machine so the picker icon
+                  // always matches the main grid (#5920, #5928).
+                  const healthState = getClusterHealthState(cluster)
                   const unreachable = isClusterUnreachable(cluster)
                   return (
                     <button
@@ -113,13 +122,18 @@ export function ClusterGroupsSection({
                           ? 'bg-primary/20 text-primary border border-primary/30'
                           : 'bg-secondary/50 text-muted-foreground hover:text-foreground border border-transparent'
                       }`}
+                      title={unreachable && cluster.errorMessage ? cluster.errorMessage : healthState}
                     >
-                      {unreachable ? (
+                      {healthState === 'unreachable' ? (
                         <WifiOff className="w-3 h-3 text-yellow-400" />
-                      ) : cluster.healthy ? (
+                      ) : healthState === 'healthy' ? (
                         <CheckCircle className="w-3 h-3 text-green-400" />
-                      ) : (
+                      ) : healthState === 'unhealthy' ? (
                         <AlertTriangle className="w-3 h-3 text-orange-400" />
+                      ) : healthState === 'loading' ? (
+                        <Loader2 className="w-3 h-3 text-blue-400 animate-spin" />
+                      ) : (
+                        <HelpCircle className="w-3 h-3 text-muted-foreground" />
                       )}
                       {cluster.context || cluster.name}
                     </button>

--- a/web/src/components/clusters/ClusterStatusDetails.tsx
+++ b/web/src/components/clusters/ClusterStatusDetails.tsx
@@ -1,0 +1,162 @@
+import { AlertCircle, Clock, Globe, Lock, ShieldAlert, WifiOff, XCircle } from 'lucide-react'
+import type { ClusterInfo } from '../../hooks/mcp/types'
+import { cn } from '../../lib/cn'
+import { formatLastSeen, getSuggestionForErrorType } from '../../lib/errorClassifier'
+import { getClusterHealthState, isClusterUnreachable } from './utils'
+
+interface ClusterStatusDetailsProps {
+  cluster: ClusterInfo
+  className?: string
+}
+
+// Render the appropriate error icon inline rather than returning a
+// component reference — the react-hooks plugin flags component aliases
+// created during render (see #5925 follow-up).
+function renderErrorIcon(errorType: string | undefined, className: string) {
+  switch (errorType) {
+    case 'auth':
+      return <Lock className={className} aria-hidden="true" />
+    case 'certificate':
+      return <ShieldAlert className={className} aria-hidden="true" />
+    case 'network':
+      return <XCircle className={className} aria-hidden="true" />
+    case 'timeout':
+      return <WifiOff className={className} aria-hidden="true" />
+    default:
+      return <AlertCircle className={className} aria-hidden="true" />
+  }
+}
+
+/**
+ * Compact panel that surfaces the extra diagnostic fields the backend
+ * already populates but that were previously hidden from the UI:
+ *
+ * - unreachable reason (#5925)
+ * - external reachability (#5926)
+ * - freshness / last-seen timestamp (#5927)
+ *
+ * This is rendered in the cluster detail modal and can be reused by
+ * other cluster status panels.
+ */
+export function ClusterStatusDetails({ cluster, className }: ClusterStatusDetailsProps) {
+  const healthState = getClusterHealthState(cluster)
+  const unreachable = isClusterUnreachable(cluster)
+  const errorType = cluster.errorType
+
+  // Pretty label for the error type. Falls back to "Unknown error" when
+  // the backend couldn't classify the failure.
+  const errorLabel = errorType
+    ? errorType.charAt(0).toUpperCase() + errorType.slice(1)
+    : 'Unknown'
+
+  // Only show the panel when there's at least one field worth surfacing.
+  const hasFreshness = !!cluster.lastSeen
+  const hasExternalReachability = cluster.externallyReachable !== undefined
+  const hasUnreachableReason = unreachable && (errorType || cluster.errorMessage)
+  const isNeverConnected = cluster.neverConnected === true
+  const isUnknown = healthState === 'unknown'
+
+  if (
+    !hasFreshness &&
+    !hasExternalReachability &&
+    !hasUnreachableReason &&
+    !isNeverConnected &&
+    !isUnknown
+  ) {
+    return null
+  }
+
+  return (
+    <div
+      className={cn(
+        'rounded-lg border border-border bg-card/30 p-3 text-xs space-y-2',
+        className,
+      )}
+      role="status"
+      aria-label="Cluster status details"
+    >
+      {hasUnreachableReason && (
+        <div className="flex items-start gap-2 text-red-300">
+          {renderErrorIcon(errorType, 'w-4 h-4 mt-0.5 flex-shrink-0')}
+          <div className="flex-1 min-w-0">
+            <div className="font-medium">
+              Unreachable: {errorLabel}
+            </div>
+            {cluster.errorMessage && (
+              <div className="text-muted-foreground break-words">
+                {cluster.errorMessage}
+              </div>
+            )}
+            {errorType && (
+              <div className="text-muted-foreground/80 mt-0.5">
+                Suggestion: {getSuggestionForErrorType(errorType)}
+              </div>
+            )}
+          </div>
+        </div>
+      )}
+
+      {isNeverConnected && !hasUnreachableReason && (
+        <div className="flex items-start gap-2 text-yellow-300">
+          <AlertCircle className="w-4 h-4 mt-0.5 flex-shrink-0" aria-hidden="true" />
+          <div className="flex-1 min-w-0">
+            <div className="font-medium">Never connected</div>
+            <div className="text-muted-foreground">
+              No successful health probe since startup — this context may point at a cluster that no longer exists.
+            </div>
+          </div>
+        </div>
+      )}
+
+      {isUnknown && !hasUnreachableReason && !isNeverConnected && (
+        <div className="flex items-start gap-2 text-muted-foreground">
+          <AlertCircle className="w-4 h-4 mt-0.5 flex-shrink-0" aria-hidden="true" />
+          <div className="flex-1 min-w-0">
+            <div className="font-medium text-foreground">Health unknown</div>
+            <div>
+              No authoritative health signal yet. Waiting for the next probe.
+            </div>
+          </div>
+        </div>
+      )}
+
+      {hasExternalReachability && (
+        <div className="flex items-center gap-2">
+          <Globe
+            className={cn(
+              'w-4 h-4 flex-shrink-0',
+              cluster.externallyReachable ? 'text-green-400' : 'text-yellow-400',
+            )}
+            aria-hidden="true"
+          />
+          <div className="flex-1 min-w-0">
+            <span className="text-muted-foreground">External reachability:</span>{' '}
+            <span
+              className={cn(
+                'font-medium',
+                cluster.externallyReachable ? 'text-green-300' : 'text-yellow-300',
+              )}
+            >
+              {cluster.externallyReachable ? 'Reachable' : 'Not reachable from outside'}
+            </span>
+          </div>
+        </div>
+      )}
+
+      {hasFreshness && (
+        <div className="flex items-center gap-2 text-muted-foreground">
+          <Clock className="w-4 h-4 flex-shrink-0" aria-hidden="true" />
+          <div className="flex-1 min-w-0">
+            <span>Last seen:</span>{' '}
+            <span
+              className="text-foreground font-medium"
+              title={typeof cluster.lastSeen === 'string' ? cluster.lastSeen : undefined}
+            >
+              {formatLastSeen(cluster.lastSeen)}
+            </span>
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/web/src/components/clusters/__tests__/utils.test.ts
+++ b/web/src/components/clusters/__tests__/utils.test.ts
@@ -16,6 +16,7 @@ import {
   isClusterTokenExpired,
   isClusterNetworkOffline,
   isClusterLoading,
+  getClusterHealthState,
   formatMetadata,
   loadClusterCards,
   saveClusterCards,
@@ -70,6 +71,69 @@ describe('isClusterHealthy', () => {
 
   it('returns false when unhealthy with no nodes', () => {
     expect(isClusterHealthy(makeCluster({ healthy: false, nodeCount: 0 }) as never)).toBe(false)
+  })
+
+  it('returns false when healthy is undefined even with nodes (#5923)', () => {
+    // Previously this returned true because the helper fell back to
+    // nodeCount > 0 — but an unknown health signal should never be
+    // reported as healthy.
+    expect(
+      isClusterHealthy(
+        makeCluster({ healthy: undefined, nodeCount: 3 }) as never,
+      ),
+    ).toBe(false)
+  })
+})
+
+describe('getClusterHealthState', () => {
+  it('returns "healthy" when the flag is true', () => {
+    expect(getClusterHealthState(makeCluster({ healthy: true }) as never)).toBe(
+      'healthy',
+    )
+  })
+
+  it('returns "unhealthy" when the flag is explicitly false', () => {
+    expect(
+      getClusterHealthState(makeCluster({ healthy: false }) as never),
+    ).toBe('unhealthy')
+  })
+
+  it('returns "unreachable" when reachable is false', () => {
+    expect(
+      getClusterHealthState(makeCluster({ reachable: false }) as never),
+    ).toBe('unreachable')
+  })
+
+  it('returns "unreachable" when errorType indicates unreachability', () => {
+    expect(
+      getClusterHealthState(
+        makeCluster({ healthy: true, errorType: 'timeout' }) as never,
+      ),
+    ).toBe('unreachable')
+  })
+
+  it('returns "loading" while a refresh is in progress with no cached data', () => {
+    expect(
+      getClusterHealthState(
+        makeCluster({
+          healthy: undefined,
+          nodeCount: undefined,
+          refreshing: true,
+        }) as never,
+      ),
+    ).toBe('loading')
+  })
+
+  it('returns "unknown" when health is undefined and nothing is loading (#5923)', () => {
+    expect(
+      getClusterHealthState(
+        makeCluster({
+          healthy: undefined,
+          nodeCount: 3,
+          refreshing: false,
+        }) as never,
+      ),
+    ).toBe('unknown')
   })
 })
 

--- a/web/src/components/clusters/components/ClusterGrid.tsx
+++ b/web/src/components/clusters/components/ClusterGrid.tsx
@@ -355,7 +355,18 @@ const FullClusterCard = memo(function FullClusterCard({
                   <KeyRound className="w-4 h-4 text-red-400" />
                 </div>
               ) : unreachable ? (
-                <div className="w-8 h-8 rounded-full bg-yellow-500/20 flex items-center justify-center" title="Offline - check network connection">
+                <div
+                  className="w-8 h-8 rounded-full bg-yellow-500/20 flex items-center justify-center"
+                  title={
+                    // Surface the reason for unreachability directly in
+                    // the status icon tooltip (#5925).
+                    cluster.errorMessage
+                      ? `Offline (${cluster.errorType || 'error'}): ${cluster.errorMessage}`
+                      : cluster.errorType
+                        ? `Offline: ${cluster.errorType}`
+                        : 'Offline - check network connection'
+                  }
+                >
                   <WifiOff className="w-4 h-4 text-yellow-400" />
                 </div>
               ) : !isClusterHealthy(cluster) ? (

--- a/web/src/components/clusters/components/ClusterGroups.tsx
+++ b/web/src/components/clusters/components/ClusterGroups.tsx
@@ -1,7 +1,8 @@
-import { useState } from 'react'
-import { FolderOpen, ChevronDown, ChevronRight, Plus, Trash2, Check, WifiOff, CheckCircle, AlertTriangle } from 'lucide-react'
+import { useMemo, useState } from 'react'
+import { FolderOpen, ChevronDown, ChevronRight, Plus, Trash2, Check, WifiOff, CheckCircle, AlertTriangle, HelpCircle, Loader2 } from 'lucide-react'
 import { ClusterInfo } from '../../../hooks/useMCP'
-import { isClusterUnreachable } from '../utils'
+import { deduplicateClustersByServer } from '../../../hooks/mcp/shared'
+import { getClusterHealthState, isClusterUnreachable } from '../utils'
 import { useTranslation } from 'react-i18next'
 import { ConfirmDialog } from '../../../lib/modals'
 
@@ -37,6 +38,10 @@ export function ClusterGroups({
     clusters: [] as string[],
   })
   const [deleteConfirmId, setDeleteConfirmId] = useState<string | null>(null)
+
+  // Deduplicate clusters so contexts pointing at the same server are not
+  // rendered twice in the picker (#5922).
+  const pickerClusters = useMemo(() => deduplicateClustersByServer(clusters), [clusters])
 
   const resetForm = () => setFormState({ showForm: false, name: '', clusters: [] })
 
@@ -90,8 +95,11 @@ export function ClusterGroups({
               />
               <div className="text-xs text-muted-foreground mb-1">Select clusters for this group:</div>
               <div className="flex flex-wrap gap-2">
-                {clusters.map((cluster) => {
+                {pickerClusters.map((cluster) => {
                   const isInGroup = formState.clusters.includes(cluster.name)
+                  // Use the shared health state machine so the picker icon
+                  // always matches the main grid (#5920, #5928).
+                  const healthState = getClusterHealthState(cluster)
                   const unreachable = isClusterUnreachable(cluster)
                   return (
                     <button
@@ -108,13 +116,18 @@ export function ClusterGroups({
                           ? 'bg-primary/20 text-primary border border-primary/30'
                           : 'bg-secondary/50 text-muted-foreground hover:text-foreground border border-transparent'
                       }`}
+                      title={unreachable && cluster.errorMessage ? cluster.errorMessage : healthState}
                     >
-                      {unreachable ? (
+                      {healthState === 'unreachable' ? (
                         <WifiOff className="w-3 h-3 text-yellow-400" />
-                      ) : cluster.healthy ? (
+                      ) : healthState === 'healthy' ? (
                         <CheckCircle className="w-3 h-3 text-green-400" />
-                      ) : (
+                      ) : healthState === 'unhealthy' ? (
                         <AlertTriangle className="w-3 h-3 text-orange-400" />
+                      ) : healthState === 'loading' ? (
+                        <Loader2 className="w-3 h-3 text-blue-400 animate-spin" />
+                      ) : (
+                        <HelpCircle className="w-3 h-3 text-muted-foreground" />
                       )}
                       {cluster.context || cluster.name}
                     </button>

--- a/web/src/components/clusters/useClusterStats.ts
+++ b/web/src/components/clusters/useClusterStats.ts
@@ -58,7 +58,10 @@ export function useClusterStats({
 
     // Separate unreachable, healthy, unhealthy - simplified logic matching sidebar
     const unreachable = globalFilteredClusters.filter(c => isClusterUnreachable(c)).length
-    const staleContexts = globalFilteredClusters.filter(c => (c as unknown as Record<string, unknown>).neverConnected === true).length
+    // `neverConnected` is populated by the backend (pkg/k8s/client.go) when
+    // every health probe since startup has failed — surfaces the stale
+    // kubeconfig warning banner (#5921).
+    const staleContexts = globalFilteredClusters.filter(c => c.neverConnected === true).length
     const healthy = globalFilteredClusters.filter(c => !isClusterUnreachable(c) && isClusterHealthy(c)).length
     const unhealthy = globalFilteredClusters.filter(c => !isClusterUnreachable(c) && !isClusterHealthy(c)).length
     const loadingCount = globalFilteredClusters.filter(c =>

--- a/web/src/components/clusters/utils.ts
+++ b/web/src/components/clusters/utils.ts
@@ -1,6 +1,26 @@
 import { ClusterInfo } from '../../hooks/useMCP'
 import { safeGetItem, safeSetItem } from '../../lib/utils/localStorage'
 
+/**
+ * Canonical cluster health states surfaced by the shared helper.
+ *
+ * - `healthy`    — backend reports healthy=true
+ * - `unhealthy`  — backend reports healthy=false (authoritative)
+ * - `unreachable`— reachable=false or an unreachable errorType
+ * - `loading`    — a refresh is currently in progress and we have no
+ *                  cached node data yet
+ * - `unknown`    — no authoritative health signal (healthy is undefined
+ *                  and no node data is available)
+ *
+ * See #5923, #5924, #5928 for the history behind these states.
+ */
+export type ClusterHealthState =
+  | 'healthy'
+  | 'unhealthy'
+  | 'unreachable'
+  | 'loading'
+  | 'unknown'
+
 // Helper to determine if cluster is unreachable vs just unhealthy
 // IMPORTANT: Only mark as unreachable with CORROBORATED evidence
 // The useMCP hook only sets reachable=false after 5 minutes of consecutive failures
@@ -14,17 +34,39 @@ export const isClusterUnreachable = (c: ClusterInfo): boolean => {
   return false
 }
 
-// Helper to check if a cluster is healthy.
-// A cluster is healthy if its healthy flag is true, or if health is unknown
-// (undefined) and nodes are reporting in. When healthy is explicitly false,
-// node presence does NOT override the health status.
-// This single definition is used by both the stats overview counts and the filter
-// tabs so that clicking a stat always shows exactly the clusters it counted.
+/**
+ * Centralised cluster-health state machine (#5928).
+ *
+ * This is the single source of truth for cluster health across the whole
+ * UI. Every component that needs to decide between healthy / unhealthy /
+ * loading / unknown / unreachable MUST use this helper so that badges,
+ * counts, and status indicators never disagree (#5920).
+ */
+export const getClusterHealthState = (c: ClusterInfo): ClusterHealthState => {
+  if (isClusterUnreachable(c)) return 'unreachable'
+  if (c.healthy === true) return 'healthy'
+  if (c.healthy === false) return 'unhealthy'
+  // Health is undefined. Prefer a distinct `loading` state when we're
+  // actively refreshing and have no cached node data (#5924).
+  if (c.refreshing === true && (c.nodeCount === undefined || c.nodeCount === 0)) {
+    return 'loading'
+  }
+  if (c.nodeCount === undefined && c.reachable === undefined) {
+    return 'loading'
+  }
+  // No authoritative health signal — surface as unknown rather than
+  // silently defaulting to healthy (#5923).
+  return 'unknown'
+}
+
+/**
+ * Backwards-compatible boolean helper used by stats counts and filter
+ * tabs. Returns true only when the state machine reports `healthy`.
+ * Previously this helper defaulted to true when health was unknown and
+ * nodes were present; that was the bug behind #5923.
+ */
 export const isClusterHealthy = (c: ClusterInfo): boolean => {
-  if (c.healthy === true) return true
-  if (c.healthy === false) return false
-  // Health unknown — fall back to node presence as a heuristic
-  return !!(c.nodeCount && c.nodeCount > 0)
+  return getClusterHealthState(c) === 'healthy'
 }
 
 // Helper to check if cluster has token/auth expired error

--- a/web/src/components/dashboard/CustomDashboard.tsx
+++ b/web/src/components/dashboard/CustomDashboard.tsx
@@ -42,6 +42,7 @@ import { BaseModal } from '../../lib/modals'
 import { useModalState } from '../../lib/modals'
 import { formatCardTitle } from '../../lib/formatCardTitle'
 import { StatsOverview, StatBlockValue } from '../ui/StatsOverview'
+import { getClusterHealthState, isClusterUnreachable } from '../clusters/utils'
 import { useUniversalStats, createMergedStatValueGetter } from '../../hooks/useUniversalStats'
 import { useRefreshIndicator } from '../../hooks/useRefreshIndicator'
 import { DashboardHeader } from '../shared/DashboardHeader'
@@ -214,9 +215,10 @@ export function CustomDashboard() {
   const sidebarItem = [...config.primaryNav, ...config.secondaryNav]
       .find(item => item.href === `/custom-dashboard/${id}`)
 
-  // Stats data from clusters
-  const healthyClusters = deduplicatedClusters.filter((c) => c.healthy === true && c.reachable !== false).length
-  const unhealthyClusters = deduplicatedClusters.filter((c) => c.healthy === false && c.reachable !== false).length
+  // Stats data from clusters — use the centralised state machine so these
+  // counts always match the main cluster grid and sidebar (#5928).
+  const healthyClusters = deduplicatedClusters.filter((c) => !isClusterUnreachable(c) && getClusterHealthState(c) === 'healthy').length
+  const unhealthyClusters = deduplicatedClusters.filter((c) => !isClusterUnreachable(c) && getClusterHealthState(c) === 'unhealthy').length
   const totalNodes = deduplicatedClusters.reduce((sum, c) => sum + (c.nodeCount || 0), 0)
   const totalPods = deduplicatedClusters.reduce((sum, c) => sum + (c.podCount || 0), 0)
 

--- a/web/src/components/ui/ClusterStatusBadge.test.tsx
+++ b/web/src/components/ui/ClusterStatusBadge.test.tsx
@@ -47,6 +47,22 @@ describe('ClusterStatusBadge Component', () => {
     expect(getByText('Offline')).toBeTruthy()
   })
 
+  it('renders loading badge with Loading label (#5924)', () => {
+    const { getByText } = render(<ClusterStatusBadge state="loading" />)
+    expect(getByText('Loading')).toBeTruthy()
+  })
+
+  it('renders unknown badge with Unknown label (#5923)', () => {
+    const { getByText } = render(<ClusterStatusBadge state="unknown" />)
+    expect(getByText('Unknown')).toBeTruthy()
+  })
+
+  it('applies animate-spin to the icon when state=loading', () => {
+    const { container } = render(<ClusterStatusBadge state="loading" />)
+    const icon = container.querySelector('svg')
+    expect(icon?.getAttribute('class') ?? '').toContain('animate-spin')
+  })
+
   it('applies green color classes for healthy state', () => {
     const { container } = render(<ClusterStatusBadge state="healthy" />)
     const badge = container.firstChild as HTMLElement
@@ -251,5 +267,15 @@ describe('getClusterState helper', () => {
 
   it('returns degraded when healthy=undefined and reachable', () => {
     expect(getClusterState(undefined, true)).toBe('degraded')
+  })
+
+  it('returns loading when loading=true regardless of other signals (#5924)', () => {
+    expect(
+      getClusterState(true, true, 3, 3, undefined, /* loading */ true),
+    ).toBe('loading')
+  })
+
+  it('returns unknown when healthy and reachable are both undefined (#5923)', () => {
+    expect(getClusterState(undefined, undefined)).toBe('unknown')
   })
 })

--- a/web/src/components/ui/ClusterStatusBadge.tsx
+++ b/web/src/components/ui/ClusterStatusBadge.tsx
@@ -6,6 +6,8 @@ import {
   XCircle,
   ShieldAlert,
   AlertCircle,
+  HelpCircle,
+  Loader2,
 } from 'lucide-react'
 import { cn } from '../../lib/cn'
 import {
@@ -17,6 +19,8 @@ import {
 export type ClusterState =
   | 'healthy'
   | 'degraded'
+  | 'loading'
+  | 'unknown'
   | 'unreachable-timeout'
   | 'unreachable-auth'
   | 'unreachable-network'
@@ -56,6 +60,25 @@ const STATE_CONFIGS: Record<ClusterState, StateConfig> = {
     borderColor: 'border-yellow-500/30',
     icon: AlertTriangle,
     label: 'Degraded',
+  },
+  loading: {
+    // Distinct loading state (#5924) — rendered while a health probe is
+    // in flight and we have no cached data yet.
+    color: 'text-blue-400',
+    bgColor: 'bg-blue-500/10',
+    borderColor: 'border-blue-500/30',
+    icon: Loader2,
+    label: 'Loading',
+  },
+  unknown: {
+    // Distinct unknown state (#5923/#5924) — shown when the backend has
+    // not yet produced an authoritative health signal so the UI no
+    // longer silently pretends the cluster is healthy.
+    color: 'text-muted-foreground',
+    bgColor: 'bg-muted/30',
+    borderColor: 'border-muted/50',
+    icon: HelpCircle,
+    label: 'Unknown',
   },
   'unreachable-timeout': {
     color: 'text-yellow-400',
@@ -100,15 +123,30 @@ const STATE_CONFIGS: Record<ClusterState, StateConfig> = {
 }
 
 /**
- * Determine cluster state based on health data
+ * Determine cluster state based on health data.
+ *
+ * Supports the new `loading` and `unknown` states introduced in #5924 so
+ * consumers can surface a distinct visual state while a health probe is
+ * in flight or when no authoritative health signal is available yet
+ * (instead of silently defaulting to healthy — see #5923).
+ *
+ * Pass `loading=true` explicitly when the calling component knows a
+ * refresh is in progress; otherwise the helper falls back to inferring
+ * `unknown` when `healthy` is undefined and no reachability signal is
+ * available either.
  */
 export function getClusterState(
   healthy: boolean | undefined,
   reachable?: boolean,
   nodeCount?: number,
   readyNodes?: number,
-  errorType?: ClusterErrorType
+  errorType?: ClusterErrorType,
+  loading?: boolean,
 ): ClusterState {
+  // Loading takes precedence over everything else so users always see
+  // the spinner when a fresh probe is in flight (#5924).
+  if (loading) return 'loading'
+
   // If explicitly unreachable
   if (reachable === false) {
     switch (errorType) {
@@ -126,7 +164,7 @@ export function getClusterState(
   }
 
   // If healthy
-  if (healthy) {
+  if (healthy === true) {
     // Check if degraded (not all nodes ready)
     if (
       nodeCount !== undefined &&
@@ -138,7 +176,15 @@ export function getClusterState(
     return 'healthy'
   }
 
-  // Not healthy but reachable - degraded
+  // Explicitly unhealthy and reachable — degraded
+  if (healthy === false) return 'degraded'
+
+  // No authoritative signal anywhere — surface as unknown rather than
+  // defaulting to degraded/healthy (#5923).
+  if (reachable === undefined) return 'unknown'
+
+  // Reachable but `healthy` is undefined: degraded is the least
+  // surprising fallback since at least one signal came back.
   return 'degraded'
 }
 
@@ -193,7 +239,10 @@ export function ClusterStatusBadge({
       role="status"
       aria-label={`Cluster status: ${tooltip.replace(/\n/g, ', ')}`}
     >
-      <Icon className={iconSize} aria-hidden="true" />
+      <Icon
+        className={cn(iconSize, state === 'loading' && 'animate-spin')}
+        aria-hidden="true"
+      />
       {showLabel && <span>{displayLabel}</span>}
     </span>
   )
@@ -219,6 +268,8 @@ export function ClusterStatusDot({
   const dotColors: Record<ClusterState, string> = {
     healthy: 'bg-green-500',
     degraded: 'bg-orange-500',
+    loading: 'bg-blue-500',
+    unknown: 'bg-muted-foreground',
     'unreachable-timeout': 'bg-yellow-500',
     'unreachable-auth': 'bg-yellow-500',
     'unreachable-network': 'bg-yellow-500',

--- a/web/src/hooks/mcp/types.ts
+++ b/web/src/hooks/mcp/types.ts
@@ -4,6 +4,11 @@ export interface ClusterInfo {
   server?: string
   user?: string
   healthy?: boolean
+  /** True when no health probe has returned yet (initial state). #5921/#5924 */
+  healthUnknown?: boolean
+  /** True when every health probe since startup has failed — used to drive
+   *  the stale-kubeconfig warning banner (#5921). */
+  neverConnected?: boolean
   source?: string
   nodeCount?: number
   podCount?: number


### PR DESCRIPTION
## Summary

Bundles nine related cluster-health issues into a single coordinated
change so every surface of the UI agrees about a cluster's state.

- **#5920** Cluster group picker now uses the shared health helper so its icons always match the main grid.
- **#5921** Backend `ListClusters` now populates `neverConnected` when a context has cached health with an empty `LastSeen`, wiring up the stale-kubeconfig warning banner that previously never rendered.
- **#5922** Cluster group pickers deduplicate via `deduplicateClustersByServer` so contexts pointing at the same server no longer appear twice.
- **#5923** `isClusterHealthy` no longer silently treats an undefined health signal as healthy; callers get an explicit `unknown` state.
- **#5924** Adds explicit `loading` and `unknown` states to `ClusterState` / `ClusterStatusBadge` with distinct icons and colors, plus support in `getClusterState`.
- **#5925** Cluster grid status icon tooltip and a new `ClusterStatusDetails` panel surface `errorType` + `errorMessage` and a suggestion for unreachable clusters.
- **#5926** New status details panel renders `externallyReachable` when the backend provides it.
- **#5927** Same panel surfaces `lastSeen` freshness using the existing `formatLastSeen` helper.
- **#5928** Adds `getClusterHealthState` as the single source of truth and converts `ClusterAdmin` and `CustomDashboard` counts off of raw `cluster.healthy` comparisons so counts, badges and filter tabs stay consistent.

Also adds `neverConnected` / `healthUnknown` to the web `ClusterInfo` type so the backend fields are typed end-to-end, plus unit tests for the new helper and the new badge states.

## Test plan

- [x] `npm run build`
- [x] `npm run lint` (no new errors/warnings introduced by this PR)
- [x] `go build ./...`
- [x] `go test ./pkg/api/handlers/...`
- [x] New vitest cases for `getClusterHealthState`, `isClusterHealthy(undefined, nodes>0) === false`, and `ClusterStatusBadge` loading/unknown states
- [ ] Manual verification that the stale-kubeconfig warning banner renders when a context has never successfully connected
- [ ] Manual verification that the cluster group picker and the main grid report identical health for the same cluster

Fixes #5920
Fixes #5921
Fixes #5922
Fixes #5923
Fixes #5924
Fixes #5925
Fixes #5926
Fixes #5927
Fixes #5928