### PR TITLE
fix: distinguish cancelled missions, recover stuck waiting_input, surface prediction staleness

### DIFF
--- a/web/src/components/layout/mission-sidebar/types.ts
+++ b/web/src/components/layout/mission-sidebar/types.ts
@@ -13,6 +13,7 @@ import {
   Bookmark,
   ShieldAlert,
   Orbit,
+  XCircle,
 } from 'lucide-react'
 import type { Mission, MissionStatus, MissionMessage } from '../../../hooks/useMissions'
 
@@ -32,6 +33,7 @@ export const STATUS_CONFIG: Record<MissionStatus, { icon: typeof Loader2; color:
   pending: { icon: Clock, color: 'text-yellow-400', label: 'Starting...' },
   running: { icon: Loader2, color: 'text-blue-400', label: 'Running' },
   cancelling: { icon: Loader2, color: 'text-orange-400', label: 'Cancelling...' },
+  cancelled: { icon: XCircle, color: 'text-orange-400', label: 'Cancelled' },
   waiting_input: { icon: MessageSquare, color: 'text-purple-400', label: 'Waiting for input' },
   completed: { icon: CheckCircle, color: 'text-green-400', label: 'Completed' },
   failed: { icon: AlertCircle, color: 'text-red-400', label: 'Failed' },

--- a/web/src/hooks/__tests__/useAIPredictions.test.ts
+++ b/web/src/hooks/__tests__/useAIPredictions.test.ts
@@ -233,6 +233,54 @@ describe('useAIPredictions', () => {
     expect(result.current.isStale).toBe(false)
   })
 
+  // #5937 / #5938 — when the agent backend is unavailable, predictions must
+  // be flagged stale AND subscribers must be notified so the UI re-renders
+  // to show the stale state immediately (not on the next poll cycle).
+  it('marks predictions stale and notifies subscribers when fetch rejects (#5937, #5938)', async () => {
+    mockGetDemoMode.mockReturnValue(false)
+    mockIsAgentUnavailable.mockReturnValue(false)
+    globalThis.fetch = vi.fn().mockRejectedValue(new Error('network error')) as unknown as typeof fetch
+
+    const { result } = renderHook(() => useAIPredictions())
+    // refresh() returns a promise — await the rejection path
+    await act(async () => {
+      await result.current.refresh()
+    })
+
+    expect(result.current.isStale).toBe(true)
+    expect(mockReportAgentDataError).toHaveBeenCalledWith('/predictions/ai', expect.stringContaining('network error'))
+  })
+
+  it('marks predictions stale on non-OK HTTP response (#5937, #5938)', async () => {
+    mockGetDemoMode.mockReturnValue(false)
+    mockIsAgentUnavailable.mockReturnValue(false)
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 500,
+      json: vi.fn(),
+    }) as unknown as typeof fetch
+
+    const { result } = renderHook(() => useAIPredictions())
+    await act(async () => {
+      await result.current.refresh()
+    })
+
+    expect(result.current.isStale).toBe(true)
+    expect(mockReportAgentDataError).toHaveBeenCalledWith('/predictions/ai', 'HTTP 500')
+  })
+
+  it('marks predictions stale and notifies when agent is unavailable (#5937)', async () => {
+    mockGetDemoMode.mockReturnValue(false)
+    mockIsAgentUnavailable.mockReturnValue(true)
+
+    const { result } = renderHook(() => useAIPredictions())
+    await act(async () => {
+      await result.current.refresh()
+    })
+
+    expect(result.current.isStale).toBe(true)
+  })
+
   it('analyze returns a promise', () => {
     const { result } = renderHook(() => useAIPredictions())
     // Calling analyze should return a thenable (promise)

--- a/web/src/hooks/useAIPredictions.ts
+++ b/web/src/hooks/useAIPredictions.ts
@@ -92,6 +92,14 @@ async function fetchAIPredictions(): Promise<void> {
   }
 
   if (isAgentUnavailable()) {
+    // Agent is known to be unavailable — mark existing predictions as stale so
+    // the UI stops presenting them as fresh (#5937). Also notify subscribers so
+    // the UI re-renders immediately instead of waiting for the next poll cycle
+    // (#5938).
+    if (!isStale) {
+      isStale = true
+      notifySubscribers()
+    }
     return
   }
 
@@ -122,14 +130,21 @@ async function fetchAIPredictions(): Promise<void> {
       isStale = true
       notifySubscribers()
     } else {
+      // Non-OK response (5xx, 401, etc.) — report failure, mark stale, and
+      // notify subscribers so the UI reflects the error state (#5937, #5938).
       reportAgentDataError('/predictions/ai', `HTTP ${response.status}`)
+      isStale = true
+      notifySubscribers()
     }
   } catch (error) {
-    if (error instanceof Error && error.name === 'AbortError') {
-      // Timeout, agent likely unavailable
-    }
-    // Don't clear predictions on error, keep stale data
+    // Network error, timeout, or AbortError — backend is unreachable. Mark
+    // predictions stale and notify subscribers so the UI updates immediately
+    // rather than continuing to show data as if it were fresh (#5937, #5938).
+    // Existing prediction data is intentionally preserved (not cleared) so
+    // users can still see the last known state, clearly labeled as stale.
+    reportAgentDataError('/predictions/ai', error instanceof Error ? error.message : 'fetch_failed')
     isStale = true
+    notifySubscribers()
   }
 }
 

--- a/web/src/hooks/useMissions.test.tsx
+++ b/web/src/hooks/useMissions.test.tsx
@@ -274,6 +274,73 @@ describe('startMission', () => {
     expect(result.current.missions[0].status).toBe('waiting_input')
   })
 
+  // #5936 — mission stuck in waiting_input must auto-fail after a watchdog
+  // timeout if the backend never delivers a final result message.
+  it('auto-fails mission stuck in waiting_input after watchdog timeout (#5936)', async () => {
+    vi.useFakeTimers()
+    try {
+      const { result } = renderHook(() => useMissions(), { wrapper })
+      const { requestId, missionId } = await startMissionWithConnection(result)
+
+      // Stream done but no result — mission enters waiting_input
+      act(() => {
+        MockWebSocket.lastInstance?.simulateMessage({
+          id: requestId,
+          type: 'stream',
+          payload: { content: '', done: true },
+        })
+      })
+      expect(result.current.missions.find(m => m.id === missionId)?.status).toBe('waiting_input')
+
+      // Advance past the 10-minute watchdog (WAITING_INPUT_TIMEOUT_MS = 600_000)
+      act(() => {
+        vi.advanceTimersByTime(600_000 + 1_000)
+      })
+
+      const mission = result.current.missions.find(m => m.id === missionId)
+      expect(mission?.status).toBe('failed')
+      const systemMessages = mission?.messages.filter(m => m.role === 'system') ?? []
+      expect(systemMessages.some(m => m.content.includes('No response from agent'))).toBe(true)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('clears waiting_input watchdog when result message arrives (#5936)', async () => {
+    vi.useFakeTimers()
+    try {
+      const { result } = renderHook(() => useMissions(), { wrapper })
+      const { requestId, missionId } = await startMissionWithConnection(result)
+
+      act(() => {
+        MockWebSocket.lastInstance?.simulateMessage({
+          id: requestId,
+          type: 'stream',
+          payload: { content: '', done: true },
+        })
+      })
+      expect(result.current.missions.find(m => m.id === missionId)?.status).toBe('waiting_input')
+
+      // Backend sends final result before the watchdog fires
+      act(() => {
+        MockWebSocket.lastInstance?.simulateMessage({
+          id: requestId,
+          type: 'result',
+          payload: { content: 'All done.' },
+        })
+      })
+      expect(result.current.missions.find(m => m.id === missionId)?.status).toBe('completed')
+
+      // Advancing past the watchdog must NOT flip the completed mission to failed
+      act(() => {
+        vi.advanceTimersByTime(600_000 + 1_000)
+      })
+      expect(result.current.missions.find(m => m.id === missionId)?.status).toBe('completed')
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
   it('calls emitMissionCompleted when result message is received', async () => {
     const { result } = renderHook(() => useMissions(), { wrapper })
     const { requestId } = await startMissionWithConnection(result)
@@ -487,7 +554,7 @@ describe('cancelMission', () => {
     expect(lastMsg?.content).toContain('Cancellation requested')
   })
 
-  it('transitions to failed after backend cancel_ack', async () => {
+  it('transitions to cancelled after backend cancel_ack', async () => {
     const { result } = renderHook(() => useMissions(), { wrapper })
     const { missionId } = await startMissionWithConnection(result)
 
@@ -506,12 +573,12 @@ describe('cancelMission', () => {
     })
 
     const mission = result.current.missions.find(m => m.id === missionId)
-    expect(mission?.status).toBe('failed')
+    expect(mission?.status).toBe('cancelled')
     const systemMessages = mission?.messages.filter(m => m.role === 'system') ?? []
     expect(systemMessages.some(m => m.content.includes('Mission cancelled by user.'))).toBe(true)
   })
 
-  it('transitions to failed after cancel ack timeout', async () => {
+  it('transitions to cancelled after cancel ack timeout', async () => {
     vi.useFakeTimers()
     try {
       const { result } = renderHook(() => useMissions(), { wrapper })
@@ -528,7 +595,7 @@ describe('cancelMission', () => {
       })
 
       const mission = result.current.missions.find(m => m.id === missionId)
-      expect(mission?.status).toBe('failed')
+      expect(mission?.status).toBe('cancelled')
       const systemMessages = mission?.messages.filter(m => m.role === 'system') ?? []
       expect(systemMessages.some(m => m.content.includes('backend did not confirm'))).toBe(true)
     } finally {
@@ -581,7 +648,7 @@ describe('cancelMission', () => {
     // Let the fetch promise resolve to finalize
     await act(async () => { await Promise.resolve() })
     const missionAfter = result.current.missions.find(m => m.id === missionId)
-    expect(missionAfter?.status).toBe('failed')
+    expect(missionAfter?.status).toBe('cancelled')
   })
 })
 
@@ -1669,7 +1736,7 @@ describe('cancelling mission receives terminal messages', () => {
     })
 
     const mission = result.current.missions.find(m => m.id === missionId)
-    expect(mission?.status).toBe('failed')
+    expect(mission?.status).toBe('cancelled')
     expect(mission?.messages.some(m => m.content.includes('cancelled by user'))).toBe(true)
   })
 
@@ -1688,7 +1755,7 @@ describe('cancelling mission receives terminal messages', () => {
       })
     })
 
-    expect(result.current.missions.find(m => m.id === missionId)?.status).toBe('failed')
+    expect(result.current.missions.find(m => m.id === missionId)?.status).toBe('cancelled')
   })
 
   it('finalizes cancellation on cancel_confirmed while cancelling', async () => {
@@ -1706,7 +1773,7 @@ describe('cancelling mission receives terminal messages', () => {
       })
     })
 
-    expect(result.current.missions.find(m => m.id === missionId)?.status).toBe('failed')
+    expect(result.current.missions.find(m => m.id === missionId)?.status).toBe('cancelled')
   })
 
   it('ignores non-terminal messages while cancelling (e.g., progress)', async () => {
@@ -1742,7 +1809,7 @@ describe('cancelling mission receives terminal messages', () => {
     })
 
     const mission = result.current.missions.find(m => m.id === missionId)
-    expect(mission?.status).toBe('failed')
+    expect(mission?.status).toBe('cancelled')
     expect(mission?.messages.some(m => m.content.includes('Cancel failed on backend'))).toBe(true)
   })
 
@@ -1760,7 +1827,7 @@ describe('cancelling mission receives terminal messages', () => {
       })
     })
 
-    expect(result.current.missions.find(m => m.id === missionId)?.status).toBe('failed')
+    expect(result.current.missions.find(m => m.id === missionId)?.status).toBe('cancelled')
   })
 
   it('prevents double-cancel (no duplicate timeout)', async () => {
@@ -1783,7 +1850,7 @@ describe('cancelling mission receives terminal messages', () => {
 
     await act(async () => { await Promise.resolve() })
     const mission = result.current.missions.find(m => m.id === missionId)
-    expect(mission?.status).toBe('failed')
+    expect(mission?.status).toBe('cancelled')
     expect(mission?.messages.some(m => m.content.includes('cancellation failed'))).toBe(true)
   })
 
@@ -1796,7 +1863,7 @@ describe('cancelling mission receives terminal messages', () => {
 
     await act(async () => { await Promise.resolve() })
     const mission = result.current.missions.find(m => m.id === missionId)
-    expect(mission?.status).toBe('failed')
+    expect(mission?.status).toBe('cancelled')
     expect(mission?.messages.some(m => m.content.includes('backend unreachable'))).toBe(true)
   })
 })
@@ -4367,7 +4434,7 @@ describe('cancel_ack failure path', () => {
     })
 
     const mission = result.current.missions.find(m => m.id === missionId)
-    expect(mission?.status).toBe('failed')
+    expect(mission?.status).toBe('cancelled')
     expect(mission?.messages.some(m => m.content.includes('Could not cancel'))).toBe(true)
   })
 })

--- a/web/src/hooks/useMissions.tsx
+++ b/web/src/hooks/useMissions.tsx
@@ -11,7 +11,7 @@ import { scanForMaliciousContent } from '../lib/missions/scanner/malicious'
 import { runPreflightCheck, type PreflightError } from '../lib/missions/preflightCheck'
 import { kubectlProxy } from '../lib/kubectlProxy'
 
-export type MissionStatus = 'pending' | 'running' | 'waiting_input' | 'completed' | 'failed' | 'saved' | 'blocked' | 'cancelling'
+export type MissionStatus = 'pending' | 'running' | 'waiting_input' | 'completed' | 'failed' | 'saved' | 'blocked' | 'cancelling' | 'cancelled'
 
 export interface MissionMessage {
   id: string
@@ -189,6 +189,15 @@ const MISSION_INACTIVITY_TIMEOUT_MS = 90_000 // 90 seconds of stream silence
  * frontend transitions the mission from 'cancelling' to 'failed' as a safety net.
  */
 const CANCEL_ACK_TIMEOUT_MS = 10_000 // 10 seconds
+/**
+ * Maximum time (ms) a mission may sit in 'waiting_input' with no new
+ * assistant/result message before the frontend treats it as stuck and
+ * transitions it to 'failed' (#5936). This state is entered when a streaming
+ * turn ends without a final 'result' message; if the backend never sends
+ * one (lost event, disconnected agent, etc.) the mission would otherwise
+ * hang indefinitely.
+ */
+const WAITING_INPUT_TIMEOUT_MS = 600_000 // 10 minutes
 
 /**
  * Strip interactive terminal prompt artifacts from agent metadata strings (#5482).
@@ -327,9 +336,9 @@ function saveMissions(missions: Mission[]) {
       )
       // Keep saved/library missions unconditionally — they are small (no chat history)
       const saved = missions.filter(m => m.status === 'saved')
-      // Only prune completed/failed missions by age
+      // Only prune completed/failed/cancelled missions by age (#5935)
       const completedOrFailed = missions
-        .filter(m => m.status === 'completed' || m.status === 'failed')
+        .filter(m => m.status === 'completed' || m.status === 'failed' || m.status === 'cancelled')
         .sort((a, b) => new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime())
         .slice(0, MAX_COMPLETED_MISSIONS)
       const pruned = [...active, ...saved, ...completedOrFailed]
@@ -340,7 +349,7 @@ function saveMissions(missions: Mission[]) {
         // Still too large — strip chat messages from completed missions (#5695)
         console.warn('[Missions] still full after count-pruning, stripping chat messages')
         const stripped = pruned.map(m =>
-          (m.status === 'completed' || m.status === 'failed')
+          (m.status === 'completed' || m.status === 'failed' || m.status === 'cancelled')
             ? { ...m, messages: m.messages.slice(-3) } // keep only last 3 messages
             : m
         )
@@ -401,6 +410,10 @@ export function MissionProvider({ children }: { children: ReactNode }) {
   const lastStreamTimestamp = useRef<Map<string, number>>(new Map()) // missionId -> timestamp
   // Track cancel acknowledgment timeouts — missionId -> timeout handle
   const cancelTimeouts = useRef<Map<string, ReturnType<typeof setTimeout>>>(new Map())
+  // Track waiting_input watchdog timers — missionId -> timeout handle (#5936).
+  // Prevents missions from getting stuck in 'waiting_input' indefinitely if
+  // the backend never delivers a final result message.
+  const waitingInputTimeouts = useRef<Map<string, ReturnType<typeof setTimeout>>>(new Map())
   // Ref to always hold the latest missions state — avoids stale closure in sendMessage (#3322)
   const missionsRef = useRef<Mission[]>(missions)
   missionsRef.current = missions
@@ -840,8 +853,55 @@ The WebSocket connection to the agent at \`${LOCAL_AGENT_WS_URL}\` was lost and 
     }
   }
 
-  // Finalize a cancelling mission — transitions from 'cancelling' to 'failed'
-  // and clears any pending cancel timeout.
+  // Clear the waiting_input watchdog timer for a mission, if one is set (#5936).
+  const clearWaitingInputTimeout = (missionId: string) => {
+    const t = waitingInputTimeouts.current.get(missionId)
+    if (t) {
+      clearTimeout(t)
+      waitingInputTimeouts.current.delete(missionId)
+    }
+  }
+
+  // Start (or restart) the waiting_input watchdog for a mission (#5936).
+  // If the mission is still in 'waiting_input' after WAITING_INPUT_TIMEOUT_MS,
+  // it is transitioned to 'failed' with an actionable error message. This
+  // prevents the UI from hanging forever when a backend 'result' message is
+  // lost or the agent disconnects silently after streaming ends.
+  const startWaitingInputTimeout = (missionId: string) => {
+    clearWaitingInputTimeout(missionId)
+    const handle = setTimeout(() => {
+      waitingInputTimeouts.current.delete(missionId)
+      // Purge pending request IDs for this mission — late responses must not
+      // overwrite the failed state.
+      for (const [reqId, mId] of pendingRequests.current.entries()) {
+        if (mId === missionId) pendingRequests.current.delete(reqId)
+      }
+      lastStreamTimestamp.current.delete(missionId)
+      setMissions(prev => prev.map(m => {
+        if (m.id !== missionId || m.status !== 'waiting_input') return m
+        emitMissionError(m.type, 'waiting_input_timeout')
+        return {
+          ...m,
+          status: 'failed' as MissionStatus,
+          currentStep: undefined,
+          updatedAt: new Date(),
+          messages: [
+            ...m.messages,
+            {
+              id: `msg-waiting-timeout-${Date.now()}-${m.id}`,
+              role: 'system' as const,
+              content: `**No response from agent — mission timed out waiting for input.**\n\nThe agent finished streaming but never delivered a final result within ${Math.round(WAITING_INPUT_TIMEOUT_MS / 60_000)} minutes. This usually means the final result message was lost or the agent disconnected silently.\n\nYou can:\n- **Retry** the mission — the issue may be transient\n- **Check your agent** — make sure it is still running and reachable\n- **Send a new message** to continue the conversation`,
+              timestamp: new Date() }
+          ]
+        }
+      }))
+    }, WAITING_INPUT_TIMEOUT_MS)
+    waitingInputTimeouts.current.set(missionId, handle)
+  }
+
+  // Finalize a cancelling mission — transitions from 'cancelling' to 'cancelled'
+  // (a distinct terminal state from 'failed', #5935) and clears any pending
+  // cancel timeout.
   const finalizeCancellation = (missionId: string, message: string) => {
     // Clear the timeout if one is pending
     const timeout = cancelTimeouts.current.get(missionId)
@@ -857,11 +917,12 @@ The WebSocket connection to the agent at \`${LOCAL_AGENT_WS_URL}\` was lost and 
       if (mId === missionId) pendingRequests.current.delete(reqId)
     }
     lastStreamTimestamp.current.delete(missionId)
+    clearWaitingInputTimeout(missionId) // #5936
 
     setMissions(prev => prev.map(m =>
       m.id === missionId && m.status === 'cancelling' ? {
         ...m,
-        status: 'failed',
+        status: 'cancelled',
         currentStep: undefined,
         updatedAt: new Date(),
         messages: [
@@ -956,9 +1017,10 @@ The WebSocket connection to the agent at \`${LOCAL_AGENT_WS_URL}\` was lost and 
       if (m.id !== missionId) return m
 
       // Discard messages for missions that have already reached a terminal state
-      // (failed, completed). This prevents stale responses from a previously
-      // failed request from overwriting state after cancellation (#4499).
-      if (m.status === 'failed' || m.status === 'completed') {
+      // (failed, completed, cancelled). This prevents stale responses from a
+      // previously failed request from overwriting state after cancellation
+      // (#4499, #5935).
+      if (m.status === 'failed' || m.status === 'completed' || m.status === 'cancelled') {
         pendingRequests.current.delete(message.id)
         return m
       }
@@ -1084,6 +1146,9 @@ The WebSocket connection to the agent at \`${LOCAL_AGENT_WS_URL}\` was lost and 
           // authoritative. The backend sends a separate 'result' message with
           // the final answer; emitMissionCompleted fires there (#5510).
           setActiveTokenCategory(null)
+          // Start the watchdog that auto-fails the mission if no final result
+          // message arrives within WAITING_INPUT_TIMEOUT_MS (#5936).
+          startWaitingInputTimeout(missionId)
           return {
             ...m,
             status: 'waiting_input' as MissionStatus,
@@ -1094,6 +1159,7 @@ The WebSocket connection to the agent at \`${LOCAL_AGENT_WS_URL}\` was lost and 
         // Complete response - mark as unread
         const payload = message.payload as ChatStreamPayload | { content?: string; output?: string }
         pendingRequests.current.delete(message.id)
+        clearWaitingInputTimeout(missionId) // #5936 — result received, cancel watchdog
         markMissionAsUnread(missionId)
 
         // Extract token usage if available
@@ -1157,6 +1223,7 @@ The WebSocket connection to the agent at \`${LOCAL_AGENT_WS_URL}\` was lost and 
       } else if (message.type === 'error') {
         const payload = message.payload as { code?: string; message?: string }
         pendingRequests.current.delete(message.id)
+        clearWaitingInputTimeout(missionId) // #5936 — terminal error, cancel watchdog
         emitMissionError(m.type, payload.code || 'unknown')
 
         // Create helpful error message based on error code


### PR DESCRIPTION
## Summary

Bundles four related fixes around mission lifecycle and AI prediction freshness:

- **Closes #5935** — Cancelled missions are now a distinct `'cancelled'` terminal state instead of being lumped in with `'failed'`. Adds the status to the `MissionStatus` union, `STATUS_CONFIG` (with an `XCircle` icon), localStorage pruning, and the late-message guard. `finalizeCancellation()` now emits `'cancelled'` on every user-initiated cancel path.

- **Closes #5936** — Adds a 10-minute `waiting_input` watchdog. Missions that finish streaming but never receive a final `result` message no longer hang indefinitely. They now auto-fail with the actionable message: *"No response from agent — mission timed out waiting for input."* The watchdog is started on the `stream-done -> waiting_input` transition and cleared on `result`, `error`, and cancellation.

- **Closes #5937** — AI predictions are now flagged stale (cached data preserved but clearly marked) whenever the agent backend is unreachable. This covers the `isAgentUnavailable()` early-return, non-OK HTTP responses (5xx, 401), and network/timeout errors. Previously the catch block silently set `isStale = true` without notifying anyone.

- **Closes #5938** — Subscribers are now notified on every prediction error path so the UI re-renders immediately to show the stale state, instead of waiting for the next 30-second poll cycle.

## Test plan

- [x] `npm run build` (clean)
- [x] `npx vitest run src/hooks/useMissions.test.tsx` — 282 / 282 pass (10 cancellation tests updated for `'cancelled'`, 2 new watchdog tests for #5936)
- [x] `npx vitest run src/hooks/__tests__/useAIPredictions.test.ts` — 48 / 48 pass (3 new tests for #5937 / #5938 covering reject, non-OK HTTP, and `isAgentUnavailable()` paths)
- [x] `npx vitest run src/components/layout/mission-sidebar` — 5 / 5 pass
- [x] Lint clean for changed files
- [ ] Manual: cancel an in-flight mission → status badge shows "Cancelled" (orange `XCircle`), not red "Failed"
- [ ] Manual: stop the AI agent → predictions card shows stale indicator within one render, not 30s later