### PR TITLE
fix(clusters): address Copilot review comments on PR #5940 (#5942)

### DIFF
--- a/web/src/components/clusters/__tests__/utils.test.ts
+++ b/web/src/components/clusters/__tests__/utils.test.ts
@@ -135,6 +135,46 @@ describe('getClusterHealthState', () => {
       ),
     ).toBe('unknown')
   })
+
+  it('returns "unknown" when healthUnknown is true even if healthy is false (#5942)', () => {
+    // Backend `ListClusters` returns `{ healthUnknown: true, healthy: false }`
+    // for clusters with no probe data yet. The UI must surface these as
+    // unknown, not unhealthy.
+    expect(
+      getClusterHealthState(
+        makeCluster({
+          healthy: false,
+          healthUnknown: true,
+        }) as never,
+      ),
+    ).toBe('unknown')
+  })
+
+  it('returns "unknown" when neverConnected is true even if healthy is false (#5942)', () => {
+    expect(
+      getClusterHealthState(
+        makeCluster({
+          healthy: false,
+          neverConnected: true,
+        }) as never,
+      ),
+    ).toBe('unknown')
+  })
+
+  it('prefers neverConnected/healthUnknown over reachable=false (#5942)', () => {
+    // Stale kubeconfig contexts that have never connected should show
+    // unknown rather than unreachable, so the UI can prompt the user to
+    // remove them rather than alarming.
+    expect(
+      getClusterHealthState(
+        makeCluster({
+          healthy: false,
+          reachable: false,
+          neverConnected: true,
+        }) as never,
+      ),
+    ).toBe('unknown')
+  })
 })
 
 describe('isClusterTokenExpired', () => {

--- a/web/src/components/clusters/useClusterStats.ts
+++ b/web/src/components/clusters/useClusterStats.ts
@@ -58,9 +58,11 @@ export function useClusterStats({
 
     // Separate unreachable, healthy, unhealthy - simplified logic matching sidebar
     const unreachable = globalFilteredClusters.filter(c => isClusterUnreachable(c)).length
-    // `neverConnected` is populated by the backend (pkg/k8s/client.go) when
-    // every health probe since startup has failed — surfaces the stale
-    // kubeconfig warning banner (#5921).
+    // `neverConnected` is populated by the backend — set in
+    // `pkg/api/handlers/mcp_cluster.go` (and also stamped in
+    // `pkg/k8s/client.go` when the health cache has never seen the
+    // cluster) — when every health probe since startup has failed.
+    // Surfaces the stale kubeconfig warning banner (#5921).
     const staleContexts = globalFilteredClusters.filter(c => c.neverConnected === true).length
     const healthy = globalFilteredClusters.filter(c => !isClusterUnreachable(c) && isClusterHealthy(c)).length
     const unhealthy = globalFilteredClusters.filter(c => !isClusterUnreachable(c) && !isClusterHealthy(c)).length

--- a/web/src/components/clusters/utils.ts
+++ b/web/src/components/clusters/utils.ts
@@ -4,15 +4,23 @@ import { safeGetItem, safeSetItem } from '../../lib/utils/localStorage'
 /**
  * Canonical cluster health states surfaced by the shared helper.
  *
+ * Priority (first match wins):
+ * 1. `neverConnected` → `unknown`  (never produced a successful probe)
+ * 2. `healthUnknown`  → `unknown`  (no probe has returned yet)
+ * 3. unreachable      → `unreachable`
+ * 4. `healthy === true`  → `healthy`
+ * 5. `healthy === false` → `unhealthy`
+ * 6. fallback         → `loading` or `unknown`
+ *
  * - `healthy`    — backend reports healthy=true
  * - `unhealthy`  — backend reports healthy=false (authoritative)
  * - `unreachable`— reachable=false or an unreachable errorType
  * - `loading`    — a refresh is currently in progress and we have no
  *                  cached node data yet
- * - `unknown`    — no authoritative health signal (healthy is undefined
- *                  and no node data is available)
+ * - `unknown`    — no authoritative health signal (no successful probe
+ *                  yet or `healthUnknown`/`neverConnected` from backend)
  *
- * See #5923, #5924, #5928 for the history behind these states.
+ * See #5923, #5924, #5928, #5942 for the history behind these states.
  */
 export type ClusterHealthState =
   | 'healthy'
@@ -43,6 +51,13 @@ export const isClusterUnreachable = (c: ClusterInfo): boolean => {
  * counts, and status indicators never disagree (#5920).
  */
 export const getClusterHealthState = (c: ClusterInfo): ClusterHealthState => {
+  // Priority order matters here — see #5942. The backend sets
+  // `healthy: false` together with `healthUnknown: true` / `neverConnected: true`
+  // for clusters that have never successfully reported health. We must
+  // surface those as `unknown`, not as `unhealthy`, so the UI doesn't
+  // alarm on clusters we've simply never heard from.
+  if (c.neverConnected === true) return 'unknown'
+  if (c.healthUnknown === true) return 'unknown'
   if (isClusterUnreachable(c)) return 'unreachable'
   if (c.healthy === true) return 'healthy'
   if (c.healthy === false) return 'unhealthy'

--- a/web/src/components/ui/ClusterFilterDropdown.tsx
+++ b/web/src/components/ui/ClusterFilterDropdown.tsx
@@ -139,15 +139,18 @@ export function ClusterFilterDropdown({
                 {t('clusterFilter.allClusters')}
               </Button>
               {availableClusters.map(cluster => {
+                // Pass `cluster.healthy` through as-is (don't default to true)
+                // so clusters with no health signal surface as `unknown`
+                // rather than silently appearing healthy (#5923, #5942).
                 const clusterState: ClusterState = cluster.healthy !== undefined || cluster.reachable !== undefined
                   ? getClusterState(
-                      cluster.healthy ?? true,
+                      cluster.healthy,
                       cluster.reachable,
                       cluster.nodeCount,
                       undefined,
                       cluster.errorType
                     )
-                  : 'healthy'
+                  : 'unknown'
 
                 const isUnreachable = cluster.reachable === false
                 const stateLabel = clusterState === 'healthy' ? '' :

--- a/web/src/components/ui/ClusterSelect.tsx
+++ b/web/src/components/ui/ClusterSelect.tsx
@@ -87,10 +87,13 @@ export function ClusterSelect({
   }, [isOpen, close])
 
   const selectedCluster = clusters.find(c => c.name === value)
+  // Pass `healthy` through as-is (don't default to true) so clusters with
+  // no health signal surface as `unknown` rather than silently appearing
+  // healthy (#5923, #5942).
   const selectedState: ClusterState | null = selectedCluster
     ? (selectedCluster.healthy !== undefined || selectedCluster.reachable !== undefined
-        ? getClusterState(selectedCluster.healthy ?? true, selectedCluster.reachable, selectedCluster.nodeCount, undefined, selectedCluster.errorType)
-        : 'healthy')
+        ? getClusterState(selectedCluster.healthy, selectedCluster.reachable, selectedCluster.nodeCount, undefined, selectedCluster.errorType)
+        : 'unknown')
     : null
 
   return (
@@ -148,9 +151,12 @@ export function ClusterSelect({
               {placeholder}
             </Button>
             {clusters.map(cluster => {
+              // Pass `cluster.healthy` through as-is (don't default to true)
+              // so clusters with no health signal surface as `unknown`
+              // rather than silently appearing healthy (#5923, #5942).
               const clusterState: ClusterState = cluster.healthy !== undefined || cluster.reachable !== undefined
-                ? getClusterState(cluster.healthy ?? true, cluster.reachable, cluster.nodeCount, undefined, cluster.errorType)
-                : 'healthy'
+                ? getClusterState(cluster.healthy, cluster.reachable, cluster.nodeCount, undefined, cluster.errorType)
+                : 'unknown'
 
               const isUnreachable = cluster.reachable === false
               const stateLabel = clusterState === 'healthy' ? '' :

--- a/web/src/lib/cards/CardComponents.tsx
+++ b/web/src/lib/cards/CardComponents.tsx
@@ -344,16 +344,19 @@ export function CardClusterFilter({
               All clusters
             </button>
             {availableClusters.map((cluster) => {
-              // Determine cluster state for status indicator
+              // Determine cluster state for status indicator.
+              // Pass `cluster.healthy` through as-is (don't default to true)
+              // so clusters with no health signal surface as `unknown`
+              // rather than silently appearing healthy (#5923, #5942).
               const clusterState: ClusterState = cluster.healthy !== undefined || cluster.reachable !== undefined
                 ? getClusterState(
-                  cluster.healthy ?? true,
+                  cluster.healthy,
                   cluster.reachable,
                   cluster.nodeCount,
                   undefined,
                   cluster.errorType
                 )
-                : 'healthy'
+                : 'unknown'
 
               const isUnreachable = cluster.reachable === false
 


### PR DESCRIPTION
## Summary

Follow-up to PR #5940 addressing three Copilot review findings on cluster health handling.

### 1. `getClusterHealthState` priority order (`utils.ts`)
The backend's `ListClusters` handler returns `{ healthUnknown: true, healthy: false }` for clusters with no probe data yet. Previously the UI surfaced those as `unhealthy`; they must surface as `unknown` so we don't alarm on clusters we've never heard from.

New priority (first match wins):
1. `neverConnected` -> `unknown`
2. `healthUnknown`  -> `unknown`
3. unreachable      -> `unreachable`
4. `healthy === true`  -> `healthy`
5. `healthy === false` -> `unhealthy`
6. fallback         -> `loading` / `unknown`

Added regression tests for each new priority rule in `utils.test.ts`.

### 2. `useClusterStats.ts` inline comment
Updated the comment about `neverConnected` to reference the correct source file - it's populated in `pkg/api/handlers/mcp_cluster.go` (and also stamped in `pkg/k8s/client.go`), not just `client.go`.

### 3. Call sites defaulting to healthy
Three call sites were passing `cluster.healthy ?? true` (and defaulting the outer branch to `'healthy'`), which defeated the new `'unknown'` state by making clusters with no health signal silently appear healthy:

- `web/src/lib/cards/CardComponents.tsx`
- `web/src/components/ui/ClusterFilterDropdown.tsx`
- `web/src/components/ui/ClusterSelect.tsx` (two spots)

All now pass `cluster.healthy` through as-is and surface `'unknown'` when no signal is available.

Closes #5942

## Test plan
- [x] `npm run build` passes
- [x] `npx vitest run src/components/clusters` - 77 tests passing (includes 3 new priority-order tests)
- [x] Lint clean on all modified files (pre-existing unrelated lint errors in other files only)
- [ ] Manual verification: clusters with `healthUnknown: true, healthy: false` show as "unknown" (not "unhealthy") in the cluster list, sidebar, filter dropdown, and cluster select