### PR TITLE
fix(missions): surface AI errors, correct active filter, dedupe chat (#5945-5948)

### DIFF
--- a/web/src/components/drilldown/views/PodDrillDown.tsx
+++ b/web/src/components/drilldown/views/PodDrillDown.tsx
@@ -21,6 +21,7 @@ import {
   PodDeleteSection } from './pod-drilldown'
 import type { TabType, RelatedResource, CachedData } from './pod-drilldown'
 import { copyToClipboard } from '../../../lib/clipboard'
+import { useToast } from '../../ui/Toast'
 
 /** Keys that must never be used as object property names (prototype pollution prevention). */
 const UNSAFE_KEYS = new Set(['__proto__', 'constructor', 'prototype'])
@@ -78,6 +79,9 @@ export function PodDrillDown({ data }: { data: Record<string, unknown> }) {
   const [podStatusLoading, setPodStatusLoading] = useState(false)
   const [aiAnalysis, setAiAnalysis] = useState<string | null>(cache.aiAnalysis || null)
   const [aiAnalysisLoading, setAiAnalysisLoading] = useState(false)
+  // #5945 — Track AI analysis errors so failures are surfaced in the UI instead of silently swallowed
+  const [aiAnalysisError, setAiAnalysisError] = useState<string | null>(null)
+  const { showToast } = useToast()
   const [labels, setLabels] = useState<Record<string, string> | null>(cache.labels || null)
   const [annotations, setAnnotations] = useState<Record<string, string> | null>(cache.annotations || null)
   const [showAllLabels, setShowAllLabels] = useState(false)
@@ -323,6 +327,9 @@ export function PodDrillDown({ data }: { data: Record<string, unknown> }) {
   const fetchAiAnalysis = async () => {
     if (!agentConnected || aiAnalysisLoading) return
     setAiAnalysisLoading(true)
+    // #5945 — Clear any previous error when starting a new analysis so stale
+    // failures don't linger in the UI while the new request is in flight.
+    setAiAnalysisError(null)
 
     try {
       // Helper to run a kubectl command and get output
@@ -488,27 +495,50 @@ Be specific and reference actual values from the data. Keep response to 3-4 sent
           const msg = JSON.parse(event.data)
           if (msg.id === requestId) {
             if (msg.payload?.content) {
+              // #5945 — Success path: clear any lingering error state
               setAiAnalysis(msg.payload.content)
+              setAiAnalysisError(null)
             } else if (msg.payload?.error || msg.payload?.message) {
-              setAiAnalysis(`Analysis unavailable: ${msg.payload.error || msg.payload.message}`)
+              // #5945 — Surface backend error via dedicated error state + toast
+              // so the user sees a clear failure instead of a silent no-op.
+              const errMsg = `Analysis unavailable: ${msg.payload.error || msg.payload.message}`
+              setAiAnalysisError(errMsg)
+              setAiAnalysis(null)
+              showToast(errMsg, 'error')
             } else {
               setAiAnalysis('Analysis complete - no specific issues identified.')
+              setAiAnalysisError(null)
             }
           }
         } catch {
-          // Ignore malformed WebSocket messages
+          // #5945 — Even malformed WebSocket messages must be reported as a
+          // failure so the user knows the analysis did not complete.
+          const errMsg = 'AI analysis failed: received an invalid response from the agent.'
+          setAiAnalysisError(errMsg)
+          showToast(errMsg, 'error')
         }
         ws.close()
         setAiAnalysisLoading(false)
       }
 
       ws.onerror = () => {
-        setAiAnalysis('Could not connect to AI analysis service.')
+        // #5945 — Previously this only set aiAnalysis to a plain string which
+        // made the error look like a successful result. Now we route it to
+        // the error state and also show a toast so the failure is visible.
+        const errMsg = 'Could not connect to AI analysis service. Please check that the agent is running and try again.'
+        setAiAnalysisError(errMsg)
+        setAiAnalysis(null)
+        showToast(errMsg, 'error')
         setAiAnalysisLoading(false)
         ws.close()
       }
     } catch (err) {
-      setAiAnalysis(`Failed to perform AI analysis: ${err}`)
+      // #5945 — Unexpected errors (kubectl failures, network issues, etc.)
+      // must also be surfaced so the failure is not silent.
+      const errMsg = `Failed to perform AI analysis: ${err instanceof Error ? err.message : String(err)}`
+      setAiAnalysisError(errMsg)
+      setAiAnalysis(null)
+      showToast(errMsg, 'error')
       setAiAnalysisLoading(false)
     }
   }
@@ -1524,6 +1554,7 @@ Please proceed step by step and ask for confirmation before making any changes.`
           <PodAiAnalysis
             aiAnalysis={aiAnalysis}
             aiAnalysisLoading={aiAnalysisLoading}
+            aiAnalysisError={aiAnalysisError}
             fetchAiAnalysis={fetchAiAnalysis}
             handleRepairPod={handleRepairPod}
           />

--- a/web/src/components/layout/mission-sidebar/MissionSidebar.tsx
+++ b/web/src/components/layout/mission-sidebar/MissionSidebar.tsx
@@ -25,7 +25,7 @@ import {
   Search,
   Satellite } from 'lucide-react'
 import { useSearchParams, useLocation } from 'react-router-dom'
-import { useMissions } from '../../../hooks/useMissions'
+import { useMissions, isActiveMission } from '../../../hooks/useMissions'
 import { useMobile } from '../../../hooks/useMobile'
 import { StatusBadge } from '../../ui/StatusBadge'
 import { cn } from '../../../lib/cn'
@@ -338,8 +338,12 @@ export function MissionSidebar() {
     return m.title.toLowerCase().includes(q) || m.description.toLowerCase().includes(q)
   }
   const savedMissions = missions.filter(m => m.status === 'saved' && matchesSearch(m))
+  // #5946 — "Active" missions must exclude completed, failed, and cancelled
+  // missions. Previously this filter only excluded 'saved', which caused
+  // terminal missions to still appear under the active list and inflate the
+  // count.
   const activeMissions = missions
-    .filter(m => m.status !== 'saved' && matchesSearch(m))
+    .filter(m => isActiveMission(m) && matchesSearch(m))
     .sort((a, b) => new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime())
 
   /** Paginated slice of active missions for rendering (#4778) */
@@ -1235,8 +1239,12 @@ export function MissionSidebarToggle() {
   ).length
 
   const runningCount = missions.filter(m => m.status === 'running').length
-  /** Active (non-saved) mission count — computed once to avoid duplicate filter (#5745) */
-  const activeCount = missions.filter(m => m.status !== 'saved').length
+  /**
+   * Active mission count — excludes saved/completed/failed/cancelled (#5947).
+   * Previously this only filtered out 'saved' missions, which caused the
+   * toggle-button badge to include terminal missions and overstate activity.
+   */
+  const activeCount = missions.filter(isActiveMission).length
 
   // Always show toggle when sidebar is closed (even with no missions)
   if (isSidebarOpen) {

--- a/web/src/hooks/useMissions.tsx
+++ b/web/src/hooks/useMissions.tsx
@@ -13,6 +13,28 @@ import { kubectlProxy } from '../lib/kubectlProxy'
 
 export type MissionStatus = 'pending' | 'running' | 'waiting_input' | 'completed' | 'failed' | 'saved' | 'blocked' | 'cancelling' | 'cancelled'
 
+/**
+ * Mission statuses that are NOT considered "active" in the sidebar list,
+ * the active counter, or the toggle button badge (#5946, #5947).
+ *
+ * - `saved`  : library entries the user hasn't run yet
+ * - `completed` / `failed` / `cancelled` : terminal states — the mission is done
+ *
+ * Everything else (`pending`, `running`, `waiting_input`, `blocked`, `cancelling`)
+ * is treated as active because the user may still need to take action on it.
+ */
+export const INACTIVE_MISSION_STATUSES: ReadonlySet<MissionStatus> = new Set([
+  'saved',
+  'completed',
+  'failed',
+  'cancelled',
+])
+
+/** True if the mission is currently active (i.e. not saved/terminal). */
+export function isActiveMission(mission: Pick<Mission, 'status'>): boolean {
+  return !INACTIVE_MISSION_STATUSES.has(mission.status)
+}
+
 export interface MissionMessage {
   id: string
   role: 'user' | 'assistant' | 'system'
@@ -1193,10 +1215,33 @@ The WebSocket connection to the agent at \`${LOCAL_AGENT_WS_URL}\` was lost and 
           .filter(msg => msg.role === 'assistant')
           .map(msg => msg.content)
           .join('')
-        // Skip adding result message if content was already received via streaming
-        const alreadyStreamed = streamedSinceUser.length > 0 &&
-          resultContent.length > 0 &&
-          streamedSinceUser.startsWith(resultContent.slice(0, Math.min(resultContent.length, streamedSinceUser.length)))
+
+        // #5948 — Dedupe streamed vs final response.
+        //
+        // Previously this check used `streamedSinceUser.startsWith(resultContent.slice(...))`
+        // which only matched when the streamed content EXACTLY started with the
+        // final result. Small differences (trailing whitespace, newline chunks,
+        // punctuation added in the final pass, or the result arriving as a
+        // suffix of the stream) caused the dedupe to miss and the same
+        // assistant response was appended a second time.
+        //
+        // The new check normalizes whitespace and matches in BOTH directions
+        // (streamed contains result OR result contains streamed). This catches
+        // the common cases where the two differ only in trivial formatting.
+        /** Collapse whitespace + trim so trivial formatting differences don't defeat dedupe. */
+        const normalize = (s: string): string => s.replace(/\s+/g, ' ').trim()
+        const normalizedStreamed = normalize(streamedSinceUser)
+        const normalizedResult = normalize(resultContent)
+        /** Minimum content length required before we consider an overlap a real dedupe match. */
+        const DEDUPE_MIN_CONTENT_LEN = 1
+        const alreadyStreamed =
+          normalizedStreamed.length >= DEDUPE_MIN_CONTENT_LEN &&
+          normalizedResult.length >= DEDUPE_MIN_CONTENT_LEN &&
+          (
+            normalizedStreamed === normalizedResult ||
+            normalizedStreamed.includes(normalizedResult) ||
+            normalizedResult.includes(normalizedStreamed)
+          )
 
         // Transition to 'completed' when a result message arrives — this is the
         // backend's final answer for the current turn. The 'waiting_input' state


### PR DESCRIPTION
## Summary

Bundled fix for four AI Missions UI issues.

### #5945 — AI analysis failures are silent
`PodDrillDown.fetchAiAnalysis` was stuffing error text into `aiAnalysis` (the success slot), so the red error banner in `PodAiAnalysis` (which only shows on `aiAnalysisError`) never rendered.

- Added `aiAnalysisError` state in `PodDrillDown` and wired it through to `PodAiAnalysis`
- Errors from `ws.onerror`, backend `error`/`message` payloads, malformed messages, and unexpected exceptions all now set `aiAnalysisError` AND fire a toast via `useToast`
- On retry, the error is cleared so stale failures don't linger

### #5946 — Completed missions shown as active
`MissionSidebar.activeMissions` previously used `m.status !== 'saved'`, so terminal missions (`completed`, `failed`, `cancelled`) stayed in the Active list.

- Added `INACTIVE_MISSION_STATUSES` and `isActiveMission()` helpers to `useMissions.tsx`
- `activeMissions` now uses `isActiveMission(m)` so only `pending`/`running`/`waiting_input`/`blocked`/`cancelling` appear

### #5947 — Mission counter includes completed missions
`MissionSidebarToggle.activeCount` used the same broken filter.

- Switched to `missions.filter(isActiveMission).length` so the badge matches the list

### #5948 — Assistant responses can duplicate in chat
The streamed-vs-final dedupe in the `result` handler used `streamedSinceUser.startsWith(resultContent.slice(...))`, which failed on trivial whitespace/punctuation differences and let the final assistant response append a second time.

- Normalize whitespace, then match in BOTH directions (streamed contains result OR result contains streamed)
- Catches the common duplication cases where the stream and final result differ only in formatting

## Test plan
- [ ] Disconnect the local agent and click "Diagnose" on a pod drilldown — verify a red error banner + toast appears (not a silent no-op)
- [ ] Complete a mission and verify it disappears from the Active list in the sidebar
- [ ] Complete several missions and verify the toggle-button badge count drops to 0 when none are active
- [ ] Run a streaming mission and verify the final assistant response appears only once (no duplicate)
- [ ] Verify saved/library missions still appear only in the Library section

Fixes #5945
Fixes #5946
Fixes #5947
Fixes #5948