### PR TITLE
fix: PodDrillDown test mock + cluster health loading docstring

### DIFF
--- a/web/src/components/clusters/utils.ts
+++ b/web/src/components/clusters/utils.ts
@@ -16,8 +16,10 @@ import { safeGetItem, safeSetItem } from '../../lib/utils/localStorage'
  * - `unhealthy`  — backend reports healthy=false AND no higher-priority
  *                  signal (healthUnknown/neverConnected) is set
  * - `unreachable`— reachable=false or an unreachable errorType
- * - `loading`    — initial load with no data yet (nodeCount and reachable
- *                  both undefined) OR an explicit refresh is in progress
+ * - `loading`    — initial load with no cached data yet (nodeCount and
+ *                  reachable both undefined). An explicit refresh on a
+ *                  cluster that has cached data does NOT return loading;
+ *                  it returns the cached state.
  * - `unknown`    — no authoritative health signal (no successful probe
  *                  yet or `healthUnknown`/`neverConnected` from backend)
  *

--- a/web/src/components/drilldown/views/__tests__/PodDrillDown.test.tsx
+++ b/web/src/components/drilldown/views/__tests__/PodDrillDown.test.tsx
@@ -57,6 +57,10 @@ vi.mock('../../../../lib/clipboard', () => ({
   copyToClipboard: vi.fn(),
 }))
 
+vi.mock('../../../ui/Toast', () => ({
+  useToast: () => ({ showToast: vi.fn() }),
+}))
+
 import { PodDrillDown } from '../PodDrillDown'
 
 describe('PodDrillDown', () => {


### PR DESCRIPTION
## Summary

Fixes two small regressions/documentation issues:

- **#5965** — PodDrillDown test was failing with `useToast must be used within a ToastProvider` after PR #5962 introduced `useToast` and `aiAnalysisError` state in `PodDrillDown.tsx`. Added the missing `useToast` mock to `PodDrillDown.test.tsx`, matching the pattern used by other tests (e.g. `AlertDetail.test.tsx`).
- **#5966** — The `loading` bullet in the `ClusterHealthState` docstring (`web/src/components/clusters/utils.ts`) incorrectly suggested that any explicit refresh returns `loading`. In reality, `getClusterHealthState` only returns `loading` during the initial load when there is no cached data — a refresh on a cluster that already has cached data returns the cached state. Updated the bullet to be precise.

## Changes

- `web/src/components/drilldown/views/__tests__/PodDrillDown.test.tsx` — add `vi.mock('../../../ui/Toast', ...)` returning `useToast: () => ({ showToast: vi.fn() })`.
- `web/src/components/clusters/utils.ts` — tighten the `loading` bullet in the `ClusterHealthState` docstring.

## Test plan

- [x] `npx vitest run src/components/drilldown/views/__tests__/PodDrillDown.test.tsx` passes (1/1)
- [x] `npm run build` passes, including post-build safety checks
- [ ] CI green (build/lint/preview)

Closes #5965
Closes #5966