### PR TITLE
fix(security): harden CSP to address OWASP ZAP findings (#5971)

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -143,7 +143,29 @@
     Strict-Transport-Security = "max-age=31536000; includeSubDomains"
     Permissions-Policy = "camera=(), microphone=(), geolocation=()"
     X-XSS-Protection = "1; mode=block"
-    Content-Security-Policy = "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://www.googletagmanager.com https://analytics.kubestellar.io; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: https://github.com https://*.githubusercontent.com https://api.dicebear.com; connect-src 'self' https://*.google-analytics.com https://*.googleapis.com https://www.googletagmanager.com https://api.github.com https://api.dicebear.com https://fonts.gstatic.com https://analytics.kubestellar.io https://raw.githubusercontent.com ws://localhost:* wss:; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'none'; frame-src 'none'; worker-src 'self' blob:; manifest-src 'self'"
+    # Content Security Policy
+    #
+    # Hardened per OWASP ZAP findings (issue #5971):
+    #   - Removed script-src 'unsafe-inline' — the one inline <script> in
+    #     index.html was moved to /secure-context-check.js.
+    #   - Removed host wildcards (https://*.google-analytics.com etc.) in
+    #     favor of explicit subdomain allowlists.
+    #   - Removed scheme-only wss: wildcard; same-origin WebSockets are
+    #     already covered by 'self' under CSP Level 3.
+    #   - Removed ws://localhost:* — the local agent WebSocket is a dev-only
+    #     feature and never successfully connects from console.kubestellar.io.
+    #
+    # Retained unsafe directives (cannot be removed without breaking features):
+    #   - script-src 'unsafe-eval' — required by the Tier 2 dynamic cards
+    #     feature, which compiles user-authored card modules at runtime via
+    #     `new Function()` in web/src/lib/dynamic-cards/compiler.ts. Removing
+    #     this would disable the dynamic card factory entirely.
+    #   - style-src 'unsafe-inline' — React renders `style={{}}` props as
+    #     `style="..."` HTML attributes, which are blocked under strict CSP
+    #     without 'unsafe-inline'. Tailwind and our app-shell <style> block
+    #     also rely on inline styles. Removing this would require rewriting
+    #     every inline style across the entire component tree.
+    Content-Security-Policy = "default-src 'self'; script-src 'self' 'unsafe-eval' https://www.googletagmanager.com https://analytics.kubestellar.io; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: https://github.com https://avatars.githubusercontent.com https://raw.githubusercontent.com https://api.dicebear.com; connect-src 'self' https://www.google-analytics.com https://region1.google-analytics.com https://analytics.google.com https://fonts.googleapis.com https://www.googleapis.com https://www.googletagmanager.com https://api.github.com https://api.dicebear.com https://fonts.gstatic.com https://analytics.kubestellar.io https://raw.githubusercontent.com; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'none'; frame-src 'none'; worker-src 'self' blob:; manifest-src 'self'"
     Cache-Control = "no-cache, no-store, must-revalidate"
     Pragma = "no-cache"
 

--- a/web/index.html
+++ b/web/index.html
@@ -35,33 +35,12 @@
         <div class="spinner"></div>
       </div>
     </div>
-    <script>
-      // Pre-flight: crypto.subtle requires a Secure Context (HTTPS or localhost).
-      // Show a clear message instead of a cryptic "Importing a module script failed" error.
-      (function(){
-        var isSecure = window.isSecureContext ||
-          location.hostname === 'localhost' ||
-          location.hostname === '127.0.0.1';
-        if (!isSecure) {
-          var shell = document.getElementById('app-shell');
-          if (shell) {
-            shell.innerHTML =
-              '<svg style="width:48px;height:48px" viewBox="0 0 24 24" fill="none" stroke="#ef4444" stroke-width="1.5">' +
-              '<path d="M12 9v4m0 4h.01M3.6 20h16.8a1 1 0 0 0 .87-1.5L12.87 3.5a1 1 0 0 0-1.74 0L2.73 18.5A1 1 0 0 0 3.6 20z"/></svg>' +
-              '<p style="font-size:18px;font-weight:600;color:#f4f4f5;margin-top:16px">HTTPS Required</p>' +
-              '<p style="max-width:480px;text-align:center;line-height:1.6;margin-top:8px">' +
-              'KubeStellar Console requires a secure context (HTTPS) to run.<br>' +
-              'You are accessing <code style="background:#27272a;padding:2px 6px;border-radius:4px">' +
-              location.origin + '</code> over plain HTTP.</p>' +
-              '<p style="max-width:480px;text-align:center;line-height:1.6;margin-top:16px;font-size:13px">' +
-              '<strong style="color:#a78bfa">To fix:</strong> Access this URL with <code style="background:#27272a;padding:2px 6px;border-radius:4px">https://</code> instead, ' +
-              'or use <code style="background:#27272a;padding:2px 6px;border-radius:4px">localhost</code> for local development.</p>';
-          }
-          // Prevent the module script from loading (it will fail on crypto.subtle)
-          throw new Error('Insecure context — HTTPS required');
-        }
-      })();
-    </script>
+    <!--
+      Secure-context preflight moved to an external file so that the CSP
+      does not need script-src 'unsafe-inline'. See web/public/secure-context-check.js
+      and the Content-Security-Policy header in netlify.toml.
+    -->
+    <script src="/secure-context-check.js"></script>
     <script type="module" src="/src/main.tsx"></script>
   </body>
 </html>

--- a/web/public/secure-context-check.js
+++ b/web/public/secure-context-check.js
@@ -1,0 +1,30 @@
+// Pre-flight: crypto.subtle requires a Secure Context (HTTPS or localhost).
+// Show a clear message instead of a cryptic "Importing a module script failed" error.
+//
+// This file is loaded from index.html as an external script so that the CSP
+// does not need to allow 'unsafe-inline' for script-src. See netlify.toml.
+(function () {
+  var isSecure =
+    window.isSecureContext ||
+    location.hostname === 'localhost' ||
+    location.hostname === '127.0.0.1'
+  if (isSecure) return
+
+  var shell = document.getElementById('app-shell')
+  if (shell) {
+    shell.innerHTML =
+      '<svg style="width:48px;height:48px" viewBox="0 0 24 24" fill="none" stroke="#ef4444" stroke-width="1.5">' +
+      '<path d="M12 9v4m0 4h.01M3.6 20h16.8a1 1 0 0 0 .87-1.5L12.87 3.5a1 1 0 0 0-1.74 0L2.73 18.5A1 1 0 0 0 3.6 20z"/></svg>' +
+      '<p style="font-size:18px;font-weight:600;color:#f4f4f5;margin-top:16px">HTTPS Required</p>' +
+      '<p style="max-width:480px;text-align:center;line-height:1.6;margin-top:8px">' +
+      'KubeStellar Console requires a secure context (HTTPS) to run.<br>' +
+      'You are accessing <code style="background:#27272a;padding:2px 6px;border-radius:4px">' +
+      location.origin +
+      '</code> over plain HTTP.</p>' +
+      '<p style="max-width:480px;text-align:center;line-height:1.6;margin-top:16px;font-size:13px">' +
+      '<strong style="color:#a78bfa">To fix:</strong> Access this URL with <code style="background:#27272a;padding:2px 6px;border-radius:4px">https://</code> instead, ' +
+      'or use <code style="background:#27272a;padding:2px 6px;border-radius:4px">localhost</code> for local development.</p>'
+  }
+  // Prevent the module script from loading (it will fail on crypto.subtle)
+  throw new Error('Insecure context — HTTPS required')
+})()


### PR DESCRIPTION
## Summary

Addresses OWASP ZAP nightly DAST findings from issue #5971 by tightening the `Content-Security-Policy` header in `netlify.toml`.

## Findings addressed

### Fixed

- **CSP: script-src `'unsafe-inline'`** — The only inline `<script>` in `web/index.html` (a secure-context preflight that shows an HTTPS-required message) has been moved to `web/public/secure-context-check.js` and is loaded as an external file. `'unsafe-inline'` has been removed from `script-src`.

- **CSP: Wildcard Directive** — Host wildcards replaced with explicit subdomain allowlists:
  - `https://*.google-analytics.com` to `https://www.google-analytics.com https://region1.google-analytics.com https://analytics.google.com`
  - `https://*.googleapis.com` to `https://fonts.googleapis.com https://www.googleapis.com`
  - `https://*.githubusercontent.com` to `https://avatars.githubusercontent.com https://raw.githubusercontent.com`
  - Removed scheme-only `wss:` — same-origin WebSockets are covered by `'self'` under CSP Level 3.
  - Removed `ws://localhost:*` — the local-agent WebSocket is a dev-only feature and never successfully connects from `console.kubestellar.io`.

### Retained with inline justification

- **CSP: script-src `'unsafe-eval'`** — Required by the Tier 2 dynamic-cards feature, which compiles user-authored card modules at runtime via `new Function(...)` in `web/src/lib/dynamic-cards/compiler.ts:88`. Removing this would break the dynamic card factory entirely.

- **CSP: style-src `'unsafe-inline'`** — React renders `style={{}}` props as `style="..."` HTML attributes, which are blocked under strict CSP without `'unsafe-inline'`. Tailwind and the app-shell `<style>` block in `index.html` also depend on inline styles. Removing this would require rewriting every inline style across the entire component tree. ZAP will continue to report this finding; see the inline comment in `netlify.toml` for the rationale.

Both retained directives now have explanatory comments directly in `netlify.toml` above the CSP header.

## Changes

- `netlify.toml` — tightened CSP; added inline comments explaining the retained `unsafe-*` directives.
- `web/index.html` — replaced inline preflight `<script>` with external `src="/secure-context-check.js"`.
- `web/public/secure-context-check.js` — new file containing the HTTPS preflight check.

## Test plan

- [x] `npm run build` passes; `secure-context-check.js` is copied into `dist/` and referenced from the built `index.html`.
- [ ] Netlify preview deploys successfully.
- [ ] Preview serves the new, tightened CSP header (verify with `curl -I`).
- [ ] Console loads without CSP violations in the browser devtools console on the preview.
- [ ] Tier 2 dynamic cards still compile and render (feature depends on retained `'unsafe-eval'`).
- [ ] After merge, re-run the nightly ZAP scan to confirm `Wildcard Directive` and `script-src unsafe-inline` findings drop from 4 to 2.

Closes #5971 (partial — 2 of 4 CSP findings fixed; `'unsafe-eval'` and style-src `'unsafe-inline'` documented as won't-fix due to feature constraints).