### PR TITLE
🐛 fix(rbac): enforce admin role on GitOps sync/drift and workload mutations

### DIFF
--- a/pkg/api/handlers/gitops.go
+++ b/pkg/api/handlers/gitops.go
@@ -19,9 +19,12 @@ import (
 	"github.com/gofiber/fiber/v2"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	"github.com/kubestellar/console/pkg/api/middleware"
 	"github.com/kubestellar/console/pkg/api/v1alpha1"
 	"github.com/kubestellar/console/pkg/k8s"
 	"github.com/kubestellar/console/pkg/mcp"
+	"github.com/kubestellar/console/pkg/models"
+	"github.com/kubestellar/console/pkg/store"
 )
 
 // Maximum number of concurrent helm/kubectl subprocesses across all handlers.
@@ -64,6 +67,11 @@ type driftCacheEntry struct {
 type GitOpsHandlers struct {
 	bridge    *mcp.Bridge
 	k8sClient *k8s.MultiClusterClient
+	// userStore is consulted by requireAdmin to enforce console-admin role on
+	// mutating GitOps endpoints (#5972, #5973). May be nil in dev/demo mode
+	// or in unit tests that don't need RBAC; in that case the check is a
+	// no-op to preserve existing test ergonomics.
+	userStore store.Store
 
 	// driftCache memoises recent drift results so ListDrifts can return
 	// something meaningful (#5950). Populated by DetectDrift.
@@ -71,13 +79,35 @@ type GitOpsHandlers struct {
 	driftCache   map[string]driftCacheEntry
 }
 
-// NewGitOpsHandlers creates a new GitOps handlers instance
-func NewGitOpsHandlers(bridge *mcp.Bridge, k8sClient *k8s.MultiClusterClient) *GitOpsHandlers {
+// NewGitOpsHandlers creates a new GitOps handlers instance.
+//
+// userStore is used to enforce the console-admin role on mutating GitOps
+// endpoints (sync, detect-drift, helm mutations, argocd sync). Pass nil to
+// skip role checks — this is intended for dev/demo mode and unit tests that
+// are not exercising RBAC.
+func NewGitOpsHandlers(bridge *mcp.Bridge, k8sClient *k8s.MultiClusterClient, userStore store.Store) *GitOpsHandlers {
 	return &GitOpsHandlers{
 		bridge:     bridge,
 		k8sClient:  k8sClient,
+		userStore:  userStore,
 		driftCache: make(map[string]driftCacheEntry),
 	}
+}
+
+// requireAdmin verifies the caller is a console admin. Returns a 403 Fiber
+// error if not. When no user store is configured (dev/demo/tests) the check
+// is skipped to preserve existing behavior — production wiring always passes
+// a real store through NewGitOpsHandlers (#5972, #5973).
+func (h *GitOpsHandlers) requireAdmin(c *fiber.Ctx) error {
+	if h.userStore == nil {
+		return nil
+	}
+	currentUserID := middleware.GetUserID(c)
+	currentUser, err := h.userStore.GetUser(currentUserID)
+	if err != nil || currentUser == nil || currentUser.Role != models.UserRoleAdmin {
+		return fiber.NewError(fiber.StatusForbidden, "Console admin access required")
+	}
+	return nil
 }
 
 // rememberDrift stores a drift-detection result in the in-memory cache keyed
@@ -1060,6 +1090,13 @@ func getDemoHelmReleasesForStreaming() []HelmRelease {
 
 // DetectDrift detects drift between git and cluster state
 func (h *GitOpsHandlers) DetectDrift(c *fiber.Ctx) error {
+	// #5973 — drift detection shells out to kubectl diff against the live
+	// cluster, which mounts a kubeconfig and reveals cluster state that
+	// viewer-role users should not be able to trigger. Require console admin.
+	if err := h.requireAdmin(c); err != nil {
+		return err
+	}
+
 	var req DetectDriftRequest
 	if err := c.BodyParser(&req); err != nil {
 		return c.Status(400).JSON(fiber.Map{"error": "invalid request body"})
@@ -1272,6 +1309,13 @@ func (h *GitOpsHandlers) detectDriftViaKubectl(ctx context.Context, req DetectDr
 
 // Sync applies manifests from git to the cluster
 func (h *GitOpsHandlers) Sync(c *fiber.Ctx) error {
+	// #5972 — GitOps sync mutates cluster state via kubectl apply (or MCP
+	// deploy). Viewer-role users must not be able to trigger these, so
+	// require the console admin role before doing any further parsing.
+	if err := h.requireAdmin(c); err != nil {
+		return err
+	}
+
 	var req SyncRequest
 	if err := c.BodyParser(&req); err != nil {
 		return c.Status(400).JSON(fiber.Map{"error": "invalid request body"})
@@ -1951,6 +1995,10 @@ type HelmUpgradeRequest struct {
 
 // RollbackHelmRelease rolls back a Helm release to a specific revision
 func (h *GitOpsHandlers) RollbackHelmRelease(c *fiber.Ctx) error {
+	// Helm rollback mutates cluster state; restrict to console admins (#5972).
+	if err := h.requireAdmin(c); err != nil {
+		return err
+	}
 	var req HelmRollbackRequest
 	if err := c.BodyParser(&req); err != nil {
 		return c.Status(400).JSON(fiber.Map{"error": "invalid request body"})
@@ -2003,6 +2051,10 @@ func (h *GitOpsHandlers) RollbackHelmRelease(c *fiber.Ctx) error {
 
 // UninstallHelmRelease uninstalls a Helm release
 func (h *GitOpsHandlers) UninstallHelmRelease(c *fiber.Ctx) error {
+	// Helm uninstall destroys cluster resources; restrict to console admins (#5972).
+	if err := h.requireAdmin(c); err != nil {
+		return err
+	}
 	var req HelmUninstallRequest
 	if err := c.BodyParser(&req); err != nil {
 		return c.Status(400).JSON(fiber.Map{"error": "invalid request body"})
@@ -2052,6 +2104,10 @@ func (h *GitOpsHandlers) UninstallHelmRelease(c *fiber.Ctx) error {
 
 // UpgradeHelmRelease upgrades a Helm release
 func (h *GitOpsHandlers) UpgradeHelmRelease(c *fiber.Ctx) error {
+	// Helm upgrade mutates cluster state; restrict to console admins (#5972).
+	if err := h.requireAdmin(c); err != nil {
+		return err
+	}
 	var req HelmUpgradeRequest
 	if err := c.BodyParser(&req); err != nil {
 		return c.Status(400).JSON(fiber.Map{"error": "invalid request body"})
@@ -2284,6 +2340,11 @@ func (h *GitOpsHandlers) GetArgoSyncSummary(c *fiber.Ctx) error {
 // Tries ArgoCD REST API first (if ARGOCD_AUTH_TOKEN is set), then CLI, then annotation patching.
 // POST /api/gitops/argocd/sync
 func (h *GitOpsHandlers) TriggerArgoSync(c *fiber.Ctx) error {
+	// #5972 — ArgoCD sync forces reconciliation against the target cluster
+	// and is equivalent to any other mutating sync operation. Require admin.
+	if err := h.requireAdmin(c); err != nil {
+		return err
+	}
 	if h.k8sClient == nil {
 		return c.Status(503).JSON(fiber.Map{
 			"error":   "Kubernetes client not configured",

--- a/pkg/api/handlers/gitops_test.go
+++ b/pkg/api/handlers/gitops_test.go
@@ -10,13 +10,19 @@ import (
 	"testing"
 
 	"github.com/gofiber/fiber/v2"
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/kubestellar/console/pkg/models"
+	"github.com/kubestellar/console/pkg/test"
 )
 
 func setupGitOpsTest() (*fiber.App, *GitOpsHandlers) {
 	app := fiber.New()
-	handler := NewGitOpsHandlers(nil, nil)
+	// Pass nil userStore — requireAdmin treats this as dev/demo and skips
+	// the role check, which is what these existing tests expect.
+	handler := NewGitOpsHandlers(nil, nil, nil)
 	return app, handler
 }
 
@@ -93,6 +99,108 @@ func TestGitOps_ListHelmHistory_UsesClusterAndNamespaceFilters(t *testing.T) {
 	require.NoError(t, json.NewDecoder(resp.Body).Decode(&body))
 	require.Len(t, body["history"], 1)
 	assert.Equal(t, 1, body["history"][0].Revision)
+}
+
+// gitopsRBACUserID is the fixed Fiber locals userID used by gitops RBAC tests.
+var gitopsRBACUserID = uuid.MustParse("00000000-0000-0000-0000-000000000abc")
+
+// newGitOpsRBACApp builds a Fiber app + GitOpsHandlers wired to a MockStore
+// that returns the given role for the test user. Use this to verify that
+// mutating GitOps endpoints enforce the console-admin role (#5972, #5973).
+func newGitOpsRBACApp(t *testing.T, role models.UserRole) (*fiber.App, *GitOpsHandlers) {
+	t.Helper()
+	mockStore := new(test.MockStore)
+	mockStore.On("GetUser", gitopsRBACUserID).Return(&models.User{
+		ID:   gitopsRBACUserID,
+		Role: role,
+	}, nil)
+
+	handler := NewGitOpsHandlers(nil, nil, mockStore)
+	app := fiber.New()
+	app.Use(func(c *fiber.Ctx) error {
+		c.Locals("userID", gitopsRBACUserID)
+		return c.Next()
+	})
+	return app, handler
+}
+
+func TestGitOps_Sync_RequiresAdmin_ViewerForbidden(t *testing.T) {
+	app, handler := newGitOpsRBACApp(t, models.UserRoleViewer)
+	app.Post("/api/gitops/sync", handler.Sync)
+
+	body := strings.NewReader(`{"repoUrl":"https://example.com/repo.git","path":"."}`)
+	req, err := http.NewRequest(http.MethodPost, "/api/gitops/sync", body)
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := app.Test(req, fiberTestTimeout)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusForbidden, resp.StatusCode,
+		"viewer-role users must not be able to trigger GitOps sync (#5972)")
+}
+
+func TestGitOps_Sync_RequiresAdmin_AdminAllowed(t *testing.T) {
+	app, handler := newGitOpsRBACApp(t, models.UserRoleAdmin)
+	app.Post("/api/gitops/sync", handler.Sync)
+
+	// Empty body so we don't actually shell out to kubectl — just past the
+	// admin check. The handler then fails validation for missing repoUrl.
+	req, err := http.NewRequest(http.MethodPost, "/api/gitops/sync", strings.NewReader(`{}`))
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := app.Test(req, fiberTestTimeout)
+	require.NoError(t, err)
+	// Past the admin check, the handler rejects with 400 ("repoUrl is required").
+	// That's proof the admin was authorized and reached the validation step.
+	assert.Equal(t, http.StatusBadRequest, resp.StatusCode,
+		"admin should pass RBAC and reach repoUrl validation")
+}
+
+func TestGitOps_DetectDrift_RequiresAdmin_ViewerForbidden(t *testing.T) {
+	app, handler := newGitOpsRBACApp(t, models.UserRoleViewer)
+	app.Post("/api/gitops/detect-drift", handler.DetectDrift)
+
+	body := strings.NewReader(`{"repoUrl":"https://example.com/repo.git","path":"."}`)
+	req, err := http.NewRequest(http.MethodPost, "/api/gitops/detect-drift", body)
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := app.Test(req, fiberTestTimeout)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusForbidden, resp.StatusCode,
+		"viewer-role users must not be able to trigger drift detection (#5973)")
+}
+
+func TestGitOps_DetectDrift_RequiresAdmin_AdminAllowed(t *testing.T) {
+	app, handler := newGitOpsRBACApp(t, models.UserRoleAdmin)
+	app.Post("/api/gitops/detect-drift", handler.DetectDrift)
+
+	req, err := http.NewRequest(http.MethodPost, "/api/gitops/detect-drift", strings.NewReader(`{}`))
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := app.Test(req, fiberTestTimeout)
+	require.NoError(t, err)
+	// Past the admin check, rejects with 400 ("repoUrl is required").
+	assert.Equal(t, http.StatusBadRequest, resp.StatusCode,
+		"admin should pass RBAC and reach repoUrl validation")
+}
+
+func TestGitOps_Sync_NilStore_SkipsRBAC(t *testing.T) {
+	// Dev/demo mode: no user store configured → requireAdmin is a no-op.
+	// This preserves existing test ergonomics and local dev behavior.
+	app, handler := setupGitOpsTest()
+	app.Post("/api/gitops/sync", handler.Sync)
+
+	req, err := http.NewRequest(http.MethodPost, "/api/gitops/sync", strings.NewReader(`{}`))
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := app.Test(req, fiberTestTimeout)
+	require.NoError(t, err)
+	// 400 for missing repoUrl — proves we got past the (skipped) admin check.
+	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
 }
 
 func TestGitOps_ListHelmHistory_HelmErrorMapping(t *testing.T) {

--- a/pkg/api/handlers/workloads.go
+++ b/pkg/api/handlers/workloads.go
@@ -52,6 +52,23 @@ func NewWorkloadHandlers(k8sClient *k8s.MultiClusterClient, hub *Hub, s store.St
 	}
 }
 
+// requireAdmin enforces the console-admin role on mutating workload endpoints
+// (#5974). All modify endpoints — deploy, scale, delete, cluster-group CRUD —
+// go through this single helper so the check can never drift between
+// handlers. When no user store is configured (dev/demo/tests) the check is
+// skipped; production wiring always passes a real store in.
+func (h *WorkloadHandlers) requireAdmin(c *fiber.Ctx) error {
+	if h.store == nil {
+		return nil
+	}
+	currentUserID := middleware.GetUserID(c)
+	currentUser, err := h.store.GetUser(currentUserID)
+	if err != nil || currentUser == nil || currentUser.Role != models.UserRoleAdmin {
+		return fiber.NewError(fiber.StatusForbidden, "Console admin access required")
+	}
+	return nil
+}
+
 // ListWorkloads returns all workloads across clusters
 // GET /api/workloads
 func (h *WorkloadHandlers) ListWorkloads(c *fiber.Ctx) error {
@@ -104,11 +121,9 @@ func (h *WorkloadHandlers) GetWorkload(c *fiber.Ctx) error {
 // DeployWorkload deploys a workload to specified clusters
 // POST /api/workloads/deploy
 func (h *WorkloadHandlers) DeployWorkload(c *fiber.Ctx) error {
-	// Require console admin role for workload mutations
-	currentUserID := middleware.GetUserID(c)
-	currentUser, err := h.store.GetUser(currentUserID)
-	if err != nil || currentUser == nil || currentUser.Role != models.UserRoleAdmin {
-		return fiber.NewError(fiber.StatusForbidden, "Console admin access required")
+	// Workload mutations require console admin (#5974).
+	if err := h.requireAdmin(c); err != nil {
+		return err
 	}
 
 	if h.k8sClient == nil {
@@ -398,11 +413,9 @@ func (h *WorkloadHandlers) ListClusterGroups(c *fiber.Ctx) error {
 // CreateClusterGroup creates a new cluster group and labels the member clusters
 // POST /api/cluster-groups
 func (h *WorkloadHandlers) CreateClusterGroup(c *fiber.Ctx) error {
-	// Require console admin role for cluster group mutations
-	currentUserID := middleware.GetUserID(c)
-	currentUser, err := h.store.GetUser(currentUserID)
-	if err != nil || currentUser == nil || currentUser.Role != models.UserRoleAdmin {
-		return fiber.NewError(fiber.StatusForbidden, "Console admin access required")
+	// Cluster group mutations require console admin (#5974).
+	if err := h.requireAdmin(c); err != nil {
+		return err
 	}
 
 	var group ClusterGroup
@@ -453,11 +466,9 @@ func (h *WorkloadHandlers) CreateClusterGroup(c *fiber.Ctx) error {
 // UpdateClusterGroup updates a cluster group
 // PUT /api/cluster-groups/:name
 func (h *WorkloadHandlers) UpdateClusterGroup(c *fiber.Ctx) error {
-	// Require console admin role for cluster group mutations
-	currentUserID := middleware.GetUserID(c)
-	currentUser, err := h.store.GetUser(currentUserID)
-	if err != nil || currentUser == nil || currentUser.Role != models.UserRoleAdmin {
-		return fiber.NewError(fiber.StatusForbidden, "Console admin access required")
+	// Cluster group mutations require console admin (#5974).
+	if err := h.requireAdmin(c); err != nil {
+		return err
 	}
 
 	name := c.Params("name")
@@ -523,11 +534,9 @@ func (h *WorkloadHandlers) UpdateClusterGroup(c *fiber.Ctx) error {
 // DeleteClusterGroup deletes a cluster group and removes labels
 // DELETE /api/cluster-groups/:name
 func (h *WorkloadHandlers) DeleteClusterGroup(c *fiber.Ctx) error {
-	// Require console admin role for cluster group mutations
-	currentUserID := middleware.GetUserID(c)
-	currentUser, err := h.store.GetUser(currentUserID)
-	if err != nil || currentUser == nil || currentUser.Role != models.UserRoleAdmin {
-		return fiber.NewError(fiber.StatusForbidden, "Console admin access required")
+	// Cluster group mutations require console admin (#5974).
+	if err := h.requireAdmin(c); err != nil {
+		return err
 	}
 
 	name := c.Params("name")
@@ -567,11 +576,9 @@ func (h *WorkloadHandlers) DeleteClusterGroup(c *fiber.Ctx) error {
 // SyncClusterGroups bulk-syncs cluster groups from frontend localStorage
 // POST /api/cluster-groups/sync
 func (h *WorkloadHandlers) SyncClusterGroups(c *fiber.Ctx) error {
-	// Bulk sync overwrites all cluster groups — require console admin role
-	currentUserID := middleware.GetUserID(c)
-	currentUser, err := h.store.GetUser(currentUserID)
-	if err != nil || currentUser == nil || currentUser.Role != models.UserRoleAdmin {
-		return fiber.NewError(fiber.StatusForbidden, "Console admin access required")
+	// Bulk sync overwrites all cluster groups — require console admin (#5974).
+	if err := h.requireAdmin(c); err != nil {
+		return err
 	}
 
 	// Reject oversized payloads (defense-in-depth beyond Fiber's default limit)
@@ -968,11 +975,9 @@ func buildClusterContextForAI(healthData []k8s.ClusterHealth) string {
 // ScaleWorkload scales a workload in specified clusters
 // POST /api/workloads/scale
 func (h *WorkloadHandlers) ScaleWorkload(c *fiber.Ctx) error {
-	// Require console admin role for workload mutations
-	currentUserID := middleware.GetUserID(c)
-	currentUser, err := h.store.GetUser(currentUserID)
-	if err != nil || currentUser == nil || currentUser.Role != models.UserRoleAdmin {
-		return fiber.NewError(fiber.StatusForbidden, "Console admin access required")
+	// Workload mutations require console admin (#5974).
+	if err := h.requireAdmin(c); err != nil {
+		return err
 	}
 
 	if h.k8sClient == nil {
@@ -1014,11 +1019,9 @@ func (h *WorkloadHandlers) ScaleWorkload(c *fiber.Ctx) error {
 // DeleteWorkload deletes a workload from specified clusters
 // DELETE /api/workloads/:cluster/:namespace/:name
 func (h *WorkloadHandlers) DeleteWorkload(c *fiber.Ctx) error {
-	// Require console admin role for workload mutations
-	currentUserID := middleware.GetUserID(c)
-	currentUser, err := h.store.GetUser(currentUserID)
-	if err != nil || currentUser == nil || currentUser.Role != models.UserRoleAdmin {
-		return fiber.NewError(fiber.StatusForbidden, "Console admin access required")
+	// Workload mutations require console admin (#5974).
+	if err := h.requireAdmin(c); err != nil {
+		return err
 	}
 
 	if h.k8sClient == nil {

--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -852,7 +852,7 @@ func (s *Server) setupRoutes() {
 
 	// GitOps routes (drift detection and sync)
 	// SECURITY: All GitOps routes require authentication in both dev and production modes
-	gitopsHandlers := handlers.NewGitOpsHandlers(s.bridge, s.k8sClient)
+	gitopsHandlers := handlers.NewGitOpsHandlers(s.bridge, s.k8sClient, s.store)
 	api.Get("/gitops/drifts", gitopsHandlers.ListDrifts)
 	api.Get("/gitops/helm-releases", gitopsHandlers.ListHelmReleases)
 	api.Get("/gitops/helm-history", gitopsHandlers.ListHelmHistory)


### PR DESCRIPTION
## Summary

Fixes three related RBAC gaps where viewer-role users could trigger mutating operations:

- **#5972** — `POST /api/gitops/sync` was missing the admin check entirely. A viewer could trigger `kubectl apply` (or the MCP deploy bridge) against any cluster.
- **#5973** — `POST /api/gitops/detect-drift` was missing the admin check. Drift detection shells out to `kubectl diff` against the live cluster, exposing state viewers should not be able to read/trigger.
- **#5974** — Workload modify endpoints all had the role check, but it was inlined per-handler (six copies) and easy to miss on a new endpoint. Consolidated into a single `requireAdmin` helper on `WorkloadHandlers`, matching the pattern already used in `ConsolePersistenceHandlers`.

## Changes

### `pkg/api/handlers/gitops.go`
- `GitOpsHandlers` now takes a `store.Store` (userStore).
- New `requireAdmin(c)` helper — same nil-store-skips-check pattern as `ConsolePersistenceHandlers.requireAdmin` so dev/demo mode and existing unit tests keep working.
- Added admin check to: `Sync`, `DetectDrift`, `RollbackHelmRelease`, `UninstallHelmRelease`, `UpgradeHelmRelease`, `TriggerArgoSync` (all are mutating cluster operations in the same security class).

### `pkg/api/handlers/workloads.go`
- Added `requireAdmin(c)` helper on `WorkloadHandlers`.
- Replaced six inlined `currentUser.Role != models.UserRoleAdmin` blocks with single-line calls to the helper. Behavior is identical; the point is structural — new modify endpoints can no longer silently skip the check.
- Endpoints consolidated: `DeployWorkload`, `ScaleWorkload`, `DeleteWorkload`, `CreateClusterGroup`, `UpdateClusterGroup`, `DeleteClusterGroup`, `SyncClusterGroups`.

### `pkg/api/server.go`
- `NewGitOpsHandlers(..., s.store)` — wire the user store through.

### `pkg/api/handlers/gitops_test.go`
- New tests using the existing `test.MockStore` helper:
  - `TestGitOps_Sync_RequiresAdmin_ViewerForbidden` — viewer gets 403
  - `TestGitOps_Sync_RequiresAdmin_AdminAllowed` — admin passes RBAC, reaches validation
  - `TestGitOps_DetectDrift_RequiresAdmin_ViewerForbidden` — viewer gets 403
  - `TestGitOps_DetectDrift_RequiresAdmin_AdminAllowed` — admin passes RBAC
  - `TestGitOps_Sync_NilStore_SkipsRBAC` — dev/demo mode still works

## Endpoints now protected

| Method | Path | Handler |
|--------|------|---------|
| POST | `/api/gitops/sync` | `GitOpsHandlers.Sync` |
| POST | `/api/gitops/detect-drift` | `GitOpsHandlers.DetectDrift` |
| POST | `/api/gitops/helm-rollback` | `GitOpsHandlers.RollbackHelmRelease` |
| POST | `/api/gitops/helm-uninstall` | `GitOpsHandlers.UninstallHelmRelease` |
| POST | `/api/gitops/helm-upgrade` | `GitOpsHandlers.UpgradeHelmRelease` |
| POST | `/api/gitops/argocd/sync` | `GitOpsHandlers.TriggerArgoSync` |
| POST | `/api/workloads/deploy` | `WorkloadHandlers.DeployWorkload` (already, now via helper) |
| POST | `/api/workloads/scale` | `WorkloadHandlers.ScaleWorkload` (already, now via helper) |
| DELETE | `/api/workloads/:cluster/:namespace/:name` | `WorkloadHandlers.DeleteWorkload` (already, now via helper) |
| POST | `/api/cluster-groups` | `WorkloadHandlers.CreateClusterGroup` (already, now via helper) |
| POST | `/api/cluster-groups/sync` | `WorkloadHandlers.SyncClusterGroups` (already, now via helper) |
| PUT | `/api/cluster-groups/:name` | `WorkloadHandlers.UpdateClusterGroup` (already, now via helper) |
| DELETE | `/api/cluster-groups/:name` | `WorkloadHandlers.DeleteClusterGroup` (already, now via helper) |

## Test plan
- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] `go test ./pkg/api/...` passes (handlers + middleware)
- [x] New RBAC tests cover viewer-forbidden and admin-allowed paths
- [x] Nil-store dev/demo path still works

Fixes #5972
Fixes #5973
Fixes #5974