### PR TITLE
fix(security): bundled audit follow-ups (#5975 #5977 #5979)

### DIFF
--- a/pkg/api/middleware/auth.go
+++ b/pkg/api/middleware/auth.go
@@ -67,9 +67,22 @@ type TokenRevoker interface {
 // TokenRevoker (typically SQLite). The cache avoids a DB query on every request
 // while the persistent store ensures revocations survive server restarts.
 //
-// Limitation: In multi-instance deployments, the in-memory cache on one instance
-// will not see tokens revoked by another instance until the next DB check (slow path).
-// For single-instance deployments (the current architecture), this is not an issue.
+// Cross-instance correctness (#5977):
+//   - Revocations are written through to the shared persistent store on
+//     every Revoke() call, so they are visible to every instance that shares
+//     the same DB as soon as the transaction commits.
+//   - IsRevoked() checks the in-memory cache first (fast path); on a cache
+//     miss it falls through to the persistent store (slow path). This means
+//     a token revoked on instance A is rejected by instance B on the next
+//     request, even if instance B has never seen that JTI before.
+//   - The backfill in the slow path caches a zero-time entry so subsequent
+//     requests for the same revoked JTI hit the fast path. The periodic
+//     cleanup loop re-queries the DB for authoritative expiry.
+//
+// Deployment requirement: every instance must point at the same persistent
+// store (same SQLite file on shared storage, or an equivalent shared backend).
+// Running multiple instances against independent stores would break the
+// cross-instance revocation guarantee.
 type revokedTokenCache struct {
 	sync.RWMutex
 	tokens map[string]time.Time // jti -> expiresAt
@@ -238,9 +251,34 @@ func JWTAuth(secret string) fiber.Handler {
 		}
 
 		// Fallback 2: accept _token query param for SSE /stream endpoints
-		// (EventSource API does not support custom headers)
+		// (EventSource API does not support custom headers, so SSE endpoints
+		// may receive the JWT as a query parameter). Preferred clients use
+		// the fetch-based SSE client which sends the token via the
+		// Authorization header; this fallback exists for legacy EventSource
+		// callers. See #5979.
+		//
+		// SECURITY: Immediately after consuming the token, we strip the
+		// `_token` parameter from the request URI so that:
+		//   - downstream middleware and handlers never observe it,
+		//   - any code that serializes the URL (access logs, error pages,
+		//     proxy forwarding, metrics labels) cannot leak the JWT,
+		//   - `c.OriginalURL()` and fasthttp's RequestURI reflect the
+		//     sanitized URL for the remainder of request handling.
+		// This is defense-in-depth: the top-level access logger already
+		// uses ${path} (no query string), but any future log line that
+		// prints the URL would otherwise leak the token.
 		if tokenString == "" && c.Query("_token") != "" && strings.HasSuffix(c.Path(), "/stream") {
 			tokenString = c.Query("_token")
+			args := c.Context().QueryArgs()
+			args.Del("_token")
+			// Rewrite the parsed URI so QueryArgs()/Query() no longer see the
+			// token, then sync the raw request URI header so OriginalURL()
+			// and RequestURI reflect the sanitized query string. Both writes
+			// are required — fasthttp caches the raw request URI on the
+			// request header separately from the parsed URI object.
+			reqURI := c.Context().Request.URI()
+			reqURI.SetQueryStringBytes(args.QueryString())
+			c.Context().Request.Header.SetRequestURIBytes(reqURI.RequestURI())
 		}
 
 		if tokenString == "" {

--- a/pkg/api/middleware/auth_test.go
+++ b/pkg/api/middleware/auth_test.go
@@ -73,6 +73,36 @@ func TestJWTAuth(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, 200, resp.StatusCode)
 	})
+
+	t.Run("Token Stripped From URL After Consumption (#5979)", func(t *testing.T) {
+		// After the auth middleware consumes a ?_token=... query param on
+		// an SSE /stream endpoint, the `_token` parameter MUST be removed
+		// from the request URI so that any downstream handler, access log,
+		// or serialized URL cannot leak the JWT.
+		token, _ := generateTestToken("test-secret", time.Now().Add(time.Hour))
+		stripTestApp := fiber.New()
+		var observedQuery string
+		var observedQueryToken string
+		var observedOriginalURL string
+		stripTestApp.Get("/events/stream", JWTAuth("test-secret"), func(c *fiber.Ctx) error {
+			observedQuery = string(c.Context().QueryArgs().QueryString())
+			observedQueryToken = c.Query("_token")
+			observedOriginalURL = c.OriginalURL()
+			return c.SendString("ok")
+		})
+
+		// Include an additional benign query param so we can verify only
+		// `_token` is removed (not the whole query string).
+		req := httptest.NewRequest("GET", "/events/stream?cluster=prod&_token="+token, nil)
+		resp, err := stripTestApp.Test(req, 5000)
+		assert.NoError(t, err)
+		assert.Equal(t, 200, resp.StatusCode)
+		assert.Empty(t, observedQueryToken, "_token should not be visible to downstream handlers")
+		assert.NotContains(t, observedQuery, "_token=", "token must be scrubbed from query args")
+		assert.NotContains(t, observedQuery, token, "token value must not appear in query args")
+		assert.Contains(t, observedQuery, "cluster=prod", "other query params must be preserved")
+		assert.NotContains(t, observedOriginalURL, token, "token value must not appear in OriginalURL()")
+	})
 }
 
 func TestGetContextHelpers(t *testing.T) {

--- a/web/src/components/clusters/utils.ts
+++ b/web/src/components/clusters/utils.ts
@@ -16,10 +16,15 @@ import { safeGetItem, safeSetItem } from '../../lib/utils/localStorage'
  * - `unhealthy`  — backend reports healthy=false AND no higher-priority
  *                  signal (healthUnknown/neverConnected) is set
  * - `unreachable`— reachable=false or an unreachable errorType
- * - `loading`    — initial load with no cached data yet (nodeCount and
- *                  reachable both undefined). An explicit refresh on a
- *                  cluster that has cached data does NOT return loading;
- *                  it returns the cached state.
+ * - `loading`    — `healthy` is undefined AND one of:
+ *                    (a) an explicit refresh is in progress
+ *                        (`refreshing===true`) and `nodeCount` is either
+ *                        undefined or 0 (no cached node data to show), OR
+ *                    (b) no probe has completed yet — both `nodeCount`
+ *                        and `reachable` are undefined (initial load).
+ *                  An explicit refresh on a cluster that already has
+ *                  cached node data (`nodeCount > 0`) does NOT return
+ *                  loading; it returns the cached state.
  * - `unknown`    — no authoritative health signal (no successful probe
  *                  yet or `healthUnknown`/`neverConnected` from backend)
  *


### PR DESCRIPTION
## Summary

Bundled security-audit follow-ups addressing three of the five issues filed in the recent audit. The remaining two require architectural work and are deferred.

### Fixed

- **#5975 — Copilot review on PR #5968**
  - Rewrote the `loading` bullet in `getClusterHealthState`'s docstring so it accurately describes **both** return paths: (a) explicit refresh with no cached node data (`refreshing===true && (nodeCount===undefined || nodeCount===0)`) and (b) initial load with both `nodeCount` and `reachable` undefined.
  - Verified the PodDrillDown test's Toast mock path is correct. From the test file at `web/src/components/drilldown/views/__tests__/PodDrillDown.test.tsx`, the relative path `../../../ui/Toast` resolves to `web/src/components/ui/Toast`, which is exactly the module PodDrillDown.tsx imports. Ran the test locally: `1 passed`. The Copilot comment was a false positive. No change required.

- **#5977 — Token revocation not immediately enforced across instances**
  - The `revokedTokenCache` is already a write-through cache backed by a persistent `TokenRevoker` (SQLite). Writes are sent to the persistent store on every `Revoke()` call, and `IsRevoked()` falls through to the persistent store on cache miss (with a cache backfill). Instances that share the same persistent store therefore see each other's revocations immediately — the prior code comment claiming this was a limitation was out of date. Replaced that comment with an accurate description of the cross-instance correctness guarantee and documented the deployment requirement (shared persistent store).

- **#5979 — SSE endpoints expose token in query params**
  - The fetch-based SSE client (`web/src/lib/sseClient.ts`) already sends the JWT via the Authorization header. The `_token` query-param fallback in the auth middleware exists only for legacy EventSource callers.
  - Hardened the middleware so that, immediately after consuming the token, it scrubs `_token` from the request URI — rewriting both the parsed `QueryArgs()` and the raw request URI header so that `OriginalURL()`, `RequestURI()`, `Query("_token")`, and any downstream log line that serializes the URL no longer contain the JWT. The top-level access logger already uses `${path}` (no query string), so this is defense-in-depth.
  - Added a regression test asserting the token is stripped from both the query args and `OriginalURL()` while benign query params (e.g. `cluster=prod`) are preserved.

### Deferred (tracked on their original issues)

- **#5976 — JWT in sessionStorage** — the backend already ships JWTs via an HttpOnly, `SameSite=Lax`, `Secure`-when-HTTPS cookie (`kc_auth`). Moving the frontend fully off of `localStorage.STORAGE_KEY_TOKEN` requires refactoring every call site in `api.ts`, hooks, and the test suite. Not in scope for this bundle.
- **#5978 — Cluster access not validated per user** — requires a new per-user cluster authorization layer and multi-tenancy work. Architectural change, not in scope for this bundle.

## Test plan

- [x] `go test ./pkg/api/middleware/...` — passes (includes new `Token_Stripped_From_URL_After_Consumption` test)
- [x] `go test ./pkg/...` — passes
- [x] `npm run build` — passes
- [x] `npx vitest run src/components/drilldown/views/__tests__/PodDrillDown.test.tsx src/components/clusters` — 78/78 tests pass
- [x] `npx eslint` on changed files — clean (no new lint errors)
- [ ] CI build/lint/preview pass (Playwright not blocking)

Closes #5975
Closes #5977
Closes #5979
