### PR TITLE
fix(ux,security,i18n): splash tips, secure-context overlay, no split translations (#5984, #5985, #5991)

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -21,8 +21,16 @@
       #app-shell svg.logo{width:48px;height:48px;animation:pulse 2s ease-in-out infinite}
       #app-shell p{margin-top:16px;font-size:14px;letter-spacing:0.05em;opacity:0.7}
       .spinner{width:24px;height:24px;margin-top:20px;border:2.5px solid rgba(124,58,237,0.2);border-top-color:#7c3aed;border-radius:50%;animation:spin .8s linear infinite}
+      /* Rotating tips on the splash page (#5984) */
+      #app-shell-tip{margin-top:1.5rem;padding:.75rem 1rem;max-width:28rem;background:rgba(124,58,237,.05);border:1px solid rgba(124,58,237,.15);border-radius:.5rem;font-size:.75rem;color:#94a3b8;line-height:1.5;text-align:left;min-height:3rem;display:flex;align-items:center;gap:.5rem;opacity:0;animation:tipFadeIn .5s ease forwards .8s}
+      #app-shell-tip .tip-label{color:#a78bfa;font-weight:600;flex-shrink:0}
+      #app-shell-tip .tip-text{flex:1;transition:opacity .4s ease}
+      @keyframes tipFadeIn{to{opacity:1}}
       @keyframes pulse{0%,100%{opacity:.4}50%{opacity:1}}
       @keyframes spin{to{transform:rotate(360deg)}}
+      @media (prefers-reduced-motion:reduce){
+        #app-shell svg.logo,.spinner,#app-shell-tip,#app-shell-tip .tip-text{animation:none!important;transition:none!important;opacity:1}
+      }
     </style>
   </head>
   <body>
@@ -33,8 +41,10 @@
         </svg>
         <p>Loading KubeStellar Console</p>
         <div class="spinner"></div>
+        <div id="app-shell-tip"><span class="tip-label">Tip</span><span class="tip-text" id="app-shell-tip-text">Loading&hellip;</span></div>
       </div>
     </div>
+    <script src="/splash-tips.js"></script>
     <!--
       Secure-context preflight moved to an external file so that the CSP
       does not need script-src 'unsafe-inline'. See web/public/secure-context-check.js

--- a/web/public/secure-context-check.js
+++ b/web/public/secure-context-check.js
@@ -3,6 +3,13 @@
 //
 // This file is loaded from index.html as an external script so that the CSP
 // does not need to allow 'unsafe-inline' for script-src. See netlify.toml.
+//
+// Note: An uncaught exception in a classic script does NOT stop the HTML parser
+// from continuing to the subsequent <script type="module"> tag. Instead of
+// relying on the throw to block loading, we inject a full-screen overlay that
+// covers any React content that might render underneath, AND we replace the
+// #root element's content so the React app cannot hydrate a conflicting UI.
+// See issue #5985 for context.
 (function () {
   var isSecure =
     window.isSecureContext ||
@@ -10,10 +17,12 @@
     location.hostname === '127.0.0.1'
   if (isSecure) return
 
-  var shell = document.getElementById('app-shell')
-  if (shell) {
-    shell.innerHTML =
-      '<svg style="width:48px;height:48px" viewBox="0 0 24 24" fill="none" stroke="#ef4444" stroke-width="1.5">' +
+  // Z-index well above any React-rendered content.
+  var OVERLAY_Z_INDEX = 2147483647
+
+  function buildErrorHtml() {
+    return (
+      '<svg style="width:48px;height:48px" viewBox="0 0 24 24" fill="none" stroke="#ef4444" stroke-width="1.5" aria-hidden="true">' +
       '<path d="M12 9v4m0 4h.01M3.6 20h16.8a1 1 0 0 0 .87-1.5L12.87 3.5a1 1 0 0 0-1.74 0L2.73 18.5A1 1 0 0 0 3.6 20z"/></svg>' +
       '<p style="font-size:18px;font-weight:600;color:#f4f4f5;margin-top:16px">HTTPS Required</p>' +
       '<p style="max-width:480px;text-align:center;line-height:1.6;margin-top:8px">' +
@@ -24,7 +33,48 @@
       '<p style="max-width:480px;text-align:center;line-height:1.6;margin-top:16px;font-size:13px">' +
       '<strong style="color:#a78bfa">To fix:</strong> Access this URL with <code style="background:#27272a;padding:2px 6px;border-radius:4px">https://</code> instead, ' +
       'or use <code style="background:#27272a;padding:2px 6px;border-radius:4px">localhost</code> for local development.</p>'
+    )
   }
-  // Prevent the module script from loading (it will fail on crypto.subtle)
+
+  function injectOverlay() {
+    // 1) Replace the app-shell content so the pre-React shell shows the error.
+    var shell = document.getElementById('app-shell')
+    if (shell) {
+      shell.innerHTML = buildErrorHtml()
+    }
+    // 2) Replace the #root content entirely — if React has already started
+    //    mounting, this wipes any partial UI before the overlay covers it.
+    var root = document.getElementById('root')
+    if (root) {
+      root.innerHTML = ''
+    }
+    // 3) Inject a full-screen fixed overlay that sits above any React content
+    //    that may still render after this script (module scripts continue to
+    //    load even if a classic script throws).
+    var overlay = document.createElement('div')
+    overlay.setAttribute('role', 'alert')
+    overlay.setAttribute('aria-live', 'assertive')
+    overlay.id = 'secure-context-overlay'
+    overlay.style.cssText =
+      'position:fixed;inset:0;background:#0a0a0a;color:#a1a1aa;' +
+      'display:flex;flex-direction:column;align-items:center;justify-content:center;' +
+      'font-family:-apple-system,BlinkMacSystemFont,\'Segoe UI\',sans-serif;' +
+      'padding:2rem;text-align:center;z-index:' + OVERLAY_Z_INDEX + ';'
+    overlay.innerHTML = buildErrorHtml()
+    if (document.body) {
+      document.body.appendChild(overlay)
+    }
+  }
+
+  if (document.readyState === 'loading') {
+    // Body may not exist yet; wait until it does to inject the overlay.
+    document.addEventListener('DOMContentLoaded', injectOverlay, { once: true })
+  } else {
+    injectOverlay()
+  }
+
+  // We still throw so any synchronous consumers (and dev tools) see the reason
+  // the app refused to boot, even though this does NOT stop the subsequent
+  // module script from loading. The overlay above is what the user actually sees.
   throw new Error('Insecure context — HTTPS required')
 })()

--- a/web/public/splash-tips.js
+++ b/web/public/splash-tips.js
@@ -1,0 +1,63 @@
+// Rotating tips for the pre-React splash page (#5984).
+//
+// Mirrors the watchdog loading screen tips (cmd/console/watchdog_html.go) so
+// users learn about console features while the initial JS bundle loads.
+// Runs before React; must be CSP-safe (no inline scripts, no eval).
+//
+// The element IDs and classes here are injected by web/index.html.
+(function () {
+  // Rotate a new tip every 8 seconds — matches the watchdog loader cadence.
+  var TIP_ROTATE_MS = 8000
+  // Fade-out duration must match the CSS transition on .tip-text (400ms).
+  var TIP_FADE_MS = 400
+
+  var TIPS = [
+    'Press <kbd>?</kbd> anywhere in the console to see all keyboard shortcuts.',
+    'Use the global cluster filter at the top to scope every card to specific clusters.',
+    'Right-click any resource for quick actions like logs, exec, and YAML view.',
+    'Drag cards to rearrange your dashboard. Your layout auto-saves.',
+    'Use <kbd>Cmd/Ctrl+K</kbd> to open the universal search across all clusters.',
+    'The Mission sidebar lets you describe what you want — the AI will figure out the kubectl.',
+    'Pin frequently-used dashboards so they appear at the top of the sidebar.',
+    'Custom dashboards can mix cards from different categories. Try the Customize button.',
+    'The Marketplace has 60+ CNCF project cards ready to install with one click.',
+    'Demo mode (toggle in Settings) lets you explore every feature without a real cluster.',
+    'Cards with a yellow border are showing demo data — connect a cluster to see real data.',
+    'The Compliance card runs OPA, Kyverno, and Falco checks across all your clusters.',
+    'GPU dashboards show per-namespace allocations and utilization across multi-cluster fleets.',
+    'Use the AI agent picker to switch between Claude, Copilot, and other agents per mission.',
+    'Saved missions are stored permanently — click any to re-run or fork as a template.'
+  ]
+
+  var tipTextEl = document.getElementById('app-shell-tip-text')
+  if (!tipTextEl) return
+
+  // Respect users who prefer reduced motion — show one tip and stop.
+  var prefersReducedMotion =
+    typeof window.matchMedia === 'function' &&
+    window.matchMedia('(prefers-reduced-motion: reduce)').matches
+
+  var tipIdx = Math.floor(Math.random() * TIPS.length)
+
+  function showTip() {
+    if (!tipTextEl) return
+    tipTextEl.style.opacity = '0'
+    setTimeout(function () {
+      tipTextEl.innerHTML = TIPS[tipIdx]
+      tipTextEl.style.opacity = '1'
+      tipIdx = (tipIdx + 1) % TIPS.length
+    }, prefersReducedMotion ? 0 : TIP_FADE_MS)
+  }
+
+  showTip()
+  if (!prefersReducedMotion) {
+    var rotateTimer = setInterval(showTip, TIP_ROTATE_MS)
+    // Stop rotating once React removes the app-shell element.
+    var stopTimer = setInterval(function () {
+      if (!document.getElementById('app-shell-tip-text')) {
+        clearInterval(rotateTimer)
+        clearInterval(stopTimer)
+      }
+    }, TIP_ROTATE_MS)
+  }
+})()

--- a/web/src/components/cards/slo_compliance/SLOCompliance.tsx
+++ b/web/src/components/cards/slo_compliance/SLOCompliance.tsx
@@ -113,7 +113,12 @@ export function SLOCompliance() {
           return (
             <DonutGauge
               key={target.metric}
-              label={target.name.split(' ').slice(0, 2).join(' ')}
+              // Issue #5991: do not manually truncate the label with
+              // .split(' ').slice(0, 2).join(' '). That loses meaningful
+              // content in non-English locales (and even English phrases
+              // like "P99 Latency (API)"). The DonutGauge label span
+              // already uses CSS `truncate max-w-16` to clip overflow.
+              label={target.name}
               value={budgetRemaining}
               burnRate={burnRate}
             />

--- a/web/src/components/gpu/GPUReservationsTab.tsx
+++ b/web/src/components/gpu/GPUReservationsTab.tsx
@@ -95,8 +95,17 @@ export function GPUReservationsTab({
       {filteredReservations.length === 0 && !reservationsLoading && (
         <div className={'glass p-8 rounded-lg text-center'}>
           <Settings2 className="w-12 h-12 mx-auto mb-3 text-muted-foreground opacity-50" />
+          {/*
+            Issue #5991: do not manually truncate translation output with
+            .split('"')[0]. That assumes an English-shaped string containing
+            a literal double quote and silently drops text in locales whose
+            translated string has no such quote. Use a dedicated short key
+            for the empty-state headline instead.
+          */}
           <p className="text-muted-foreground mb-4">
-            {showOnlyMine ? t('gpuReservations.overview.noReservationsUser') : t('gpuReservations.overview.noReservationsYet').split('"')[0]}
+            {showOnlyMine
+              ? t('gpuReservations.overview.noReservationsUser')
+              : t('gpuReservations.overview.noReservationsYetShort')}
           </p>
           {!showOnlyMine && (
             <button onClick={onCreateReservation}

--- a/web/src/locales/de/cards.json
+++ b/web/src/locales/de/cards.json
@@ -1754,7 +1754,8 @@
       "activeGpuReservations": "Active GPU Reservations",
       "durationHours": "{{hours}}h duration",
       "noReservationsUser": "No reservations found for your user.",
-      "noReservationsYet": "No GPU reservations yet. Click \"Create GPU Reservation\" to get started."
+      "noReservationsYet": "No GPU reservations yet. Click \"Create GPU Reservation\" to get started.",
+      "noReservationsYetShort": "No GPU reservations yet."
     },
     "calendar": {
       "previousMonth": "Previous month",

--- a/web/src/locales/en/cards.json
+++ b/web/src/locales/en/cards.json
@@ -1786,7 +1786,8 @@
       "activeGpuReservations": "Active GPU Reservations",
       "durationHours": "{{hours}}h duration",
       "noReservationsUser": "No reservations found for your user.",
-      "noReservationsYet": "No GPU reservations yet. Click \"Create GPU Reservation\" to get started."
+      "noReservationsYet": "No GPU reservations yet. Click \"Create GPU Reservation\" to get started.",
+      "noReservationsYetShort": "No GPU reservations yet."
     },
     "calendar": {
       "previousMonth": "Previous month",

--- a/web/src/locales/es/cards.json
+++ b/web/src/locales/es/cards.json
@@ -1754,7 +1754,8 @@
       "activeGpuReservations": "Active GPU Reservations",
       "durationHours": "{{hours}}h duration",
       "noReservationsUser": "No reservations found for your user.",
-      "noReservationsYet": "No GPU reservations yet. Click \"Create GPU Reservation\" to get started."
+      "noReservationsYet": "No GPU reservations yet. Click \"Create GPU Reservation\" to get started.",
+      "noReservationsYetShort": "No GPU reservations yet."
     },
     "calendar": {
       "previousMonth": "Previous month",

--- a/web/src/locales/fr/cards.json
+++ b/web/src/locales/fr/cards.json
@@ -1754,7 +1754,8 @@
       "activeGpuReservations": "Active GPU Reservations",
       "durationHours": "{{hours}}h duration",
       "noReservationsUser": "No reservations found for your user.",
-      "noReservationsYet": "No GPU reservations yet. Click \"Create GPU Reservation\" to get started."
+      "noReservationsYet": "No GPU reservations yet. Click \"Create GPU Reservation\" to get started.",
+      "noReservationsYetShort": "No GPU reservations yet."
     },
     "calendar": {
       "previousMonth": "Previous month",

--- a/web/src/locales/hi/cards.json
+++ b/web/src/locales/hi/cards.json
@@ -1754,7 +1754,8 @@
       "activeGpuReservations": "Active GPU Reservations",
       "durationHours": "{{hours}}h duration",
       "noReservationsUser": "No reservations found for your user.",
-      "noReservationsYet": "No GPU reservations yet. Click \"Create GPU Reservation\" to get started."
+      "noReservationsYet": "No GPU reservations yet. Click \"Create GPU Reservation\" to get started.",
+      "noReservationsYetShort": "No GPU reservations yet."
     },
     "calendar": {
       "previousMonth": "Previous month",

--- a/web/src/locales/it/cards.json
+++ b/web/src/locales/it/cards.json
@@ -1754,7 +1754,8 @@
       "activeGpuReservations": "Active GPU Reservations",
       "durationHours": "{{hours}}h duration",
       "noReservationsUser": "No reservations found for your user.",
-      "noReservationsYet": "No GPU reservations yet. Click \"Create GPU Reservation\" to get started."
+      "noReservationsYet": "No GPU reservations yet. Click \"Create GPU Reservation\" to get started.",
+      "noReservationsYetShort": "No GPU reservations yet."
     },
     "calendar": {
       "previousMonth": "Previous month",

--- a/web/src/locales/ja/cards.json
+++ b/web/src/locales/ja/cards.json
@@ -1754,7 +1754,8 @@
       "activeGpuReservations": "Active GPU Reservations",
       "durationHours": "{{hours}}h duration",
       "noReservationsUser": "No reservations found for your user.",
-      "noReservationsYet": "No GPU reservations yet. Click \"Create GPU Reservation\" to get started."
+      "noReservationsYet": "No GPU reservations yet. Click \"Create GPU Reservation\" to get started.",
+      "noReservationsYetShort": "No GPU reservations yet."
     },
     "calendar": {
       "previousMonth": "Previous month",

--- a/web/src/locales/pt/cards.json
+++ b/web/src/locales/pt/cards.json
@@ -1754,7 +1754,8 @@
       "activeGpuReservations": "Active GPU Reservations",
       "durationHours": "{{hours}}h duration",
       "noReservationsUser": "No reservations found for your user.",
-      "noReservationsYet": "No GPU reservations yet. Click \"Create GPU Reservation\" to get started."
+      "noReservationsYet": "No GPU reservations yet. Click \"Create GPU Reservation\" to get started.",
+      "noReservationsYetShort": "No GPU reservations yet."
     },
     "calendar": {
       "previousMonth": "Previous month",

--- a/web/src/locales/zh/cards.json
+++ b/web/src/locales/zh/cards.json
@@ -1754,7 +1754,8 @@
       "activeGpuReservations": "Active GPU Reservations",
       "durationHours": "{{hours}}h duration",
       "noReservationsUser": "No reservations found for your user.",
-      "noReservationsYet": "No GPU reservations yet. Click \"Create GPU Reservation\" to get started."
+      "noReservationsYet": "No GPU reservations yet. Click \"Create GPU Reservation\" to get started.",
+      "noReservationsYetShort": "No GPU reservations yet."
     },
     "calendar": {
       "previousMonth": "Previous month",


### PR DESCRIPTION
Bundle of three small fixes.

## #5984 — Rotating tips on the splash page
PR #5900 added rotating tips to the watchdog loading screen. The pre-React splash shell in web/index.html was still a bare "Loading KubeStellar Console" spinner with no tips. Added a dedicated web/public/splash-tips.js that runs before the module bundle loads (CSP-safe, no inline script) and rotates through the same tips every 8 seconds.

- Honors prefers-reduced-motion (shows one tip, no animation)
- Auto-stops once React removes the app-shell element
- Uses the same 15 tips as the watchdog loader for consistency

## #5985 — secure-context-check.js no longer relies on throw to block loading
Copilot review comment on PR #5980 pointed out that an uncaught exception in a classic script does NOT stop the HTML parser from continuing to the subsequent module script tag — the comment was wrong.

Fix:
- Updated the comment to accurately describe browser behavior
- Injected a full-screen fixed overlay (z-index 2147483647) that covers any React UI that might still render underneath
- Wiped #root content after DOMContentLoaded so any partial hydration is hidden
- Kept the throw so devtools still show the root cause, but the overlay is what the user actually sees

## #5991 — Remove manual translation truncation with split
Two cases of manual truncation that break i18n:

1. GPUReservationsTab.tsx:99 called t(...).split('"')[0], which only worked because the English string happens to contain a literal double quote. The split drops everything after the first quote, silently breaking any locale that translates the quoted button name away from that exact form. Fix: added a dedicated noReservationsYetShort key in all 9 locale files.

2. SLOCompliance.tsx:116 called target.name.split(' ').slice(0, 2).join(' ') to keep donut gauge labels short. The DonutGauge label span already uses className="truncate max-w-16", so the manual split is both redundant and harmful for non-English locales. Fix: removed the split — CSS handles overflow.

## Test plan
- [x] npm run build passes (postbuild safety checks all green)
- [x] npm run lint — no new errors/warnings from changed files
- [x] Vitest passes for affected components
- [x] Verified splash-tips.js and secure-context-check.js ship in dist/ and are referenced from dist/index.html
- [ ] Manual smoke: throttled network tab — confirm tip rotates under spinner before React mounts
- [ ] Manual smoke: visit over plain HTTP — confirm HTTPS-required overlay covers the page

Closes #5984
Closes #5991
Addresses #5985 (Copilot follow-up from PR #5980)