### PR TITLE
fix(security): always scrub _token from URL + accurate cleanup doc (#5992)

### DIFF
--- a/pkg/api/middleware/auth.go
+++ b/pkg/api/middleware/auth.go
@@ -77,7 +77,12 @@ type TokenRevoker interface {
 //     request, even if instance B has never seen that JTI before.
 //   - The backfill in the slow path caches a zero-time entry so subsequent
 //     requests for the same revoked JTI hit the fast path. The periodic
-//     cleanup loop re-queries the DB for authoritative expiry.
+//     cleanup loop prunes expired rows from the persistent store
+//     (CleanupExpiredTokens) and evicts stale in-memory entries: entries
+//     whose JWT expiry has passed, plus zero-time backfilled entries when
+//     the cache exceeds half its max size (those can be re-fetched from
+//     the DB slow path on demand). Authoritative expiry continues to live
+//     in the persistent store.
 //
 // Deployment requirement: every instance must point at the same persistent
 // store (same SQLite file on shared storage, or an equivalent shared backend).
@@ -256,9 +261,20 @@ func JWTAuth(secret string) fiber.Handler {
 		// the fetch-based SSE client which sends the token via the
 		// Authorization header; this fallback exists for legacy EventSource
 		// callers. See #5979.
+		if tokenString == "" && c.Query("_token") != "" && strings.HasSuffix(c.Path(), "/stream") {
+			tokenString = c.Query("_token")
+		}
+
+		// SECURITY: Always strip the `_token` query parameter from the
+		// request URI whenever it is present, regardless of whether it
+		// was actually consumed for authentication. A misconfigured
+		// client could send both an Authorization header AND a
+		// `?_token=...` query param on the same request; without this
+		// unconditional scrub, the JWT in the URL would survive into
+		// downstream middleware, handlers, access logs, error pages,
+		// proxy-forwarded URLs, and metrics labels — leaking the token.
 		//
-		// SECURITY: Immediately after consuming the token, we strip the
-		// `_token` parameter from the request URI so that:
+		// Scrubbing ensures:
 		//   - downstream middleware and handlers never observe it,
 		//   - any code that serializes the URL (access logs, error pages,
 		//     proxy forwarding, metrics labels) cannot leak the JWT,
@@ -267,8 +283,7 @@ func JWTAuth(secret string) fiber.Handler {
 		// This is defense-in-depth: the top-level access logger already
 		// uses ${path} (no query string), but any future log line that
 		// prints the URL would otherwise leak the token.
-		if tokenString == "" && c.Query("_token") != "" && strings.HasSuffix(c.Path(), "/stream") {
-			tokenString = c.Query("_token")
+		if c.Query("_token") != "" {
 			args := c.Context().QueryArgs()
 			args.Del("_token")
 			// Rewrite the parsed URI so QueryArgs()/Query() no longer see the

--- a/pkg/api/middleware/auth_test.go
+++ b/pkg/api/middleware/auth_test.go
@@ -103,6 +103,70 @@ func TestJWTAuth(t *testing.T) {
 		assert.Contains(t, observedQuery, "cluster=prod", "other query params must be preserved")
 		assert.NotContains(t, observedOriginalURL, token, "token value must not appear in OriginalURL()")
 	})
+
+	t.Run("Token Scrubbed Even When Auth Came From Header (#5992)", func(t *testing.T) {
+		// A misconfigured client may send BOTH an Authorization header
+		// AND a ?_token=... query parameter on the same request. The
+		// middleware consumes the header (which takes priority), but the
+		// `_token` query parameter must still be scrubbed from the URL
+		// so it cannot leak into access logs, downstream handlers, or
+		// serialized URLs. Regression test for the Copilot review comment
+		// on PR #5986 / issue #5992.
+		token, _ := generateTestToken("test-secret", time.Now().Add(time.Hour))
+		bothTestApp := fiber.New()
+		var observedQuery string
+		var observedQueryToken string
+		var observedOriginalURL string
+		bothTestApp.Get("/events/stream", JWTAuth("test-secret"), func(c *fiber.Ctx) error {
+			observedQuery = string(c.Context().QueryArgs().QueryString())
+			observedQueryToken = c.Query("_token")
+			observedOriginalURL = c.OriginalURL()
+			return c.SendString("ok")
+		})
+
+		// Send both an Authorization header and a ?_token=... query param.
+		// Use a distinct "leaked" token in the query to make it obvious in
+		// assertions that the query value (not the header value) is what
+		// must be scrubbed.
+		leakedToken, _ := generateTestToken("test-secret", time.Now().Add(time.Hour))
+		req := httptest.NewRequest("GET", "/events/stream?cluster=prod&_token="+leakedToken, nil)
+		req.Header.Set("Authorization", "Bearer "+token)
+
+		resp, err := bothTestApp.Test(req, 5000)
+		assert.NoError(t, err)
+		assert.Equal(t, 200, resp.StatusCode)
+		assert.Empty(t, observedQueryToken, "_token must be scrubbed even when auth came from the header")
+		assert.NotContains(t, observedQuery, "_token=", "token parameter must be removed from query args")
+		assert.NotContains(t, observedQuery, leakedToken, "token value must not appear in query args")
+		assert.Contains(t, observedQuery, "cluster=prod", "other query params must be preserved")
+		assert.NotContains(t, observedOriginalURL, leakedToken, "token value must not appear in OriginalURL()")
+	})
+
+	t.Run("Token Scrubbed On Non-Stream Path When Auth From Header (#5992)", func(t *testing.T) {
+		// Even on non-/stream endpoints, a stray `_token` query param
+		// must be scrubbed from the URL when the request is otherwise
+		// authenticated (via header or cookie). This prevents leakage
+		// of tokens in URLs on any authenticated route, not just SSE.
+		token, _ := generateTestToken("test-secret", time.Now().Add(time.Hour))
+		nonStreamApp := fiber.New()
+		var observedQueryToken string
+		var observedOriginalURL string
+		nonStreamApp.Get("/api/resource", JWTAuth("test-secret"), func(c *fiber.Ctx) error {
+			observedQueryToken = c.Query("_token")
+			observedOriginalURL = c.OriginalURL()
+			return c.SendString("ok")
+		})
+
+		leakedToken, _ := generateTestToken("test-secret", time.Now().Add(time.Hour))
+		req := httptest.NewRequest("GET", "/api/resource?_token="+leakedToken, nil)
+		req.Header.Set("Authorization", "Bearer "+token)
+
+		resp, err := nonStreamApp.Test(req, 5000)
+		assert.NoError(t, err)
+		assert.Equal(t, 200, resp.StatusCode)
+		assert.Empty(t, observedQueryToken, "_token must be scrubbed on non-stream paths too")
+		assert.NotContains(t, observedOriginalURL, leakedToken, "token value must not appear in OriginalURL()")
+	})
 }
 
 func TestGetContextHelpers(t *testing.T) {


### PR DESCRIPTION
## Summary

Addresses two Copilot review comments on PR #5986 / issue #5992:

1. **Doc comment mismatch** (`pkg/api/middleware/auth.go:80`) — the `revokedTokenCache` docstring claimed the periodic cleanup loop "re-queries the DB for authoritative expiry", but `cleanup()` actually prunes expired rows via `CleanupExpiredTokens()` and evicts stale in-memory entries (expired JWTs plus zero-time backfilled entries when the cache exceeds half its max size). Comment now matches behavior.

2. **`_token` scrubbing only ran when token came from query** (`pkg/api/middleware/auth.go:282`) — a misconfigured client that sends BOTH an `Authorization` header AND a `?_token=<jwt>` query param would have the JWT survive in the URL and leak into access logs, error pages, proxy-forwarded URLs, and metrics labels. The scrub is now split out of the fallback branch and always runs whenever `_token` is present, regardless of where auth came from.

## Changes

- `pkg/api/middleware/auth.go`:
  - Rewrote the `cleanupLoop` bullet in the `revokedTokenCache` doc comment to describe the real `cleanup()` behavior (prune expired DB rows + evict stale cache entries).
  - Split the query-param fallback into two blocks: one that consumes `_token` for SSE (unchanged logic), and a second, unconditional scrub that removes `_token` from the URI whenever it is present on the request.
- `pkg/api/middleware/auth_test.go`:
  - New regression test: header + query together on `/events/stream` — auth succeeds via header, `_token` must still be scrubbed from `QueryArgs()`, `Query()`, and `OriginalURL()`.
  - New regression test: non-`/stream` path with header auth + stray `?_token=...` — `_token` is still scrubbed (not just on SSE).

## Test plan

- [x] `go test ./pkg/api/middleware/...` — passes (existing + 2 new subtests)
- [x] `go build ./...` — passes
- [x] `go vet ./pkg/api/middleware/...` — clean
- [ ] CI build/lint/preview pass