### PR TITLE
fix(marketplace): sync CNCF banner across tabs and dismiss author tooltip on scroll

### DIFF
--- a/web/src/components/marketplace/Marketplace.tsx
+++ b/web/src/components/marketplace/Marketplace.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef } from 'react'
+import { useState, useRef, useEffect } from 'react'
 import { createPortal } from 'react-dom'
 import { motion, AnimatePresence } from 'framer-motion'
 import { useNavigate } from 'react-router-dom'
@@ -45,6 +45,19 @@ function CNCFProgressBanner({ stats }: { stats: CNCFStats }) {
   const [collapsed, setCollapsed] = useState(() => {
     try { return localStorage.getItem(BANNER_COLLAPSED_KEY) === 'true' } catch { return false }
   })
+
+  // Sync banner collapsed state across tabs (fix #6006).
+  // The `storage` event only fires in OTHER tabs when localStorage changes,
+  // so toggling in tab A will update tab B automatically.
+  useEffect(() => {
+    const handleStorage = (e: StorageEvent) => {
+      if (e.key !== BANNER_COLLAPSED_KEY) return
+      // If the key was removed, e.newValue is null — default to not collapsed.
+      setCollapsed(e.newValue === 'true')
+    }
+    window.addEventListener('storage', handleStorage)
+    return () => window.removeEventListener('storage', handleStorage)
+  }, [])
 
   const toggleCollapse = () => {
     const next = !collapsed
@@ -338,6 +351,18 @@ function AuthorBadge({ author, github, compact }: { author: string; github?: str
     updatePos()
     setHovered(true)
   }
+
+  // Dismiss tooltip on scroll (fix #6007).
+  // The tooltip captures its position once on mouse enter and does not
+  // track the trigger on scroll, so it detaches visually. Dismissing on
+  // scroll matches user expectation (the cursor has left the trigger anyway).
+  // Capture phase is used to catch scrolls in any nested container.
+  useEffect(() => {
+    if (!hovered) return
+    const dismiss = () => setHovered(false)
+    window.addEventListener('scroll', dismiss, true)
+    return () => window.removeEventListener('scroll', dismiss, true)
+  }, [hovered])
 
   if (!github) {
     return <span>{author}</span>


### PR DESCRIPTION
## Summary

Bundles two small Marketplace bug fixes in `web/src/components/marketplace/Marketplace.tsx`.

### Fixes #6006 — CNCF banner desync across tabs
`CNCFProgressBanner` read `localStorage(BANNER_COLLAPSED_KEY)` once at mount but never listened for changes. Toggling in tab A left tab B stale until reload.

**Fix:** Added a `useEffect` that subscribes to `window.addEventListener('storage', handler)`. The `storage` event only fires in *other* tabs when localStorage changes, so there is no infinite loop. The handler checks `e.key === BANNER_COLLAPSED_KEY` and syncs local state from `e.newValue`. Listener is cleaned up on unmount.

### Fixes #6007 — Author badge tooltip detaches on scroll
`AuthorBadge` uses `createPortal` to mount its tooltip and captures the trigger's viewport position once on `onMouseEnter` via `getBoundingClientRect()`. Scrolling while hovering left the tooltip pinned to the old position while the badge scrolled away.

**Fix:** When `hovered` is true, a `useEffect` subscribes to `window.addEventListener('scroll', dismiss, true)` (capture phase, so nested scroll containers are caught) that dismisses the tooltip. This matches user expectation — the cursor has effectively left the trigger anyway. Simpler than recalculating position on every scroll frame.

## Test plan

- [ ] Open Marketplace in two browser tabs — toggle the CNCF banner in tab A and verify tab B updates without reload
- [ ] Hover an author badge, then scroll the page while hovering — tooltip should dismiss cleanly instead of floating in the wrong place
- [ ] Hover an author badge without scrolling — tooltip still appears and stays until mouse leave
- [ ] Verify `npm run build` passes (verified locally)