### PR TITLE
fix(token-usage): per-operation category tracking and agent restart detection

### DIFF
--- a/web/src/hooks/__tests__/useAIPredictions.test.ts
+++ b/web/src/hooks/__tests__/useAIPredictions.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { renderHook, act, waitFor } from '@testing-library/react'
 
-const { mockGetPredictionSettings, mockGetDemoMode, mockIsAgentUnavailable, mockReportAgentDataSuccess, mockReportAgentDataError, mockGetSettingsForBackend, mockSetActiveTokenCategory, mockFullFetchClusters, mockClusterCache } = vi.hoisted(() => ({
+const { mockGetPredictionSettings, mockGetDemoMode, mockIsAgentUnavailable, mockReportAgentDataSuccess, mockReportAgentDataError, mockGetSettingsForBackend, mockSetActiveTokenCategory, mockClearActiveTokenCategory, mockFullFetchClusters, mockClusterCache } = vi.hoisted(() => ({
   mockGetPredictionSettings: vi.fn(() => ({ aiEnabled: true, minConfidence: 50 })),
   mockGetDemoMode: vi.fn(() => true),
   mockIsAgentUnavailable: vi.fn(() => true),
@@ -9,6 +9,7 @@ const { mockGetPredictionSettings, mockGetDemoMode, mockIsAgentUnavailable, mock
   mockReportAgentDataError: vi.fn(),
   mockGetSettingsForBackend: vi.fn(() => ({ aiEnabled: true, minConfidence: 50 })),
   mockSetActiveTokenCategory: vi.fn(),
+  mockClearActiveTokenCategory: vi.fn(),
   mockFullFetchClusters: vi.fn(),
   mockClusterCache: { consecutiveFailures: 0, isFailed: false },
 }))
@@ -30,6 +31,7 @@ vi.mock('../useLocalAgent', () => ({
 
 vi.mock('../useTokenUsage', () => ({
   setActiveTokenCategory: mockSetActiveTokenCategory,
+  clearActiveTokenCategory: mockClearActiveTokenCategory,
 }))
 
 vi.mock('../mcp/shared', () => ({
@@ -491,9 +493,11 @@ describe('useAIPredictions', () => {
       await vi.advanceTimersByTimeAsync(2000)
     })
 
-    // setActiveTokenCategory should have been called with 'predictions' and then null
-    expect(mockSetActiveTokenCategory).toHaveBeenCalledWith('predictions')
-    expect(mockSetActiveTokenCategory).toHaveBeenCalledWith(null)
+    // Per-operation tracking (#6016): setActiveTokenCategory called with
+    // opId + 'predictions', then clearActiveTokenCategory called with the
+    // same opId.
+    expect(mockSetActiveTokenCategory).toHaveBeenCalledWith(expect.any(String), 'predictions')
+    expect(mockClearActiveTokenCategory).toHaveBeenCalledWith(expect.any(String))
   })
 
   it('analyze in non-demo mode sends POST to /predictions/analyze', async () => {

--- a/web/src/hooks/__tests__/useTokenUsage.test.ts
+++ b/web/src/hooks/__tests__/useTokenUsage.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { renderHook, act } from '@testing-library/react'
 
 // ---------------------------------------------------------------------------
@@ -30,8 +30,13 @@ vi.mock('../../lib/constants/network', () => ({
   QUICK_ABORT_TIMEOUT_MS: 2000,
 }))
 
-import { useTokenUsage, setActiveTokenCategory, getActiveTokenCategory, addCategoryTokens } from '../useTokenUsage'
+import { useTokenUsage, setActiveTokenCategory, clearActiveTokenCategory, getActiveTokenCategories, addCategoryTokens } from '../useTokenUsage'
 import type { TokenCategory } from '../useTokenUsage'
+
+// Fixed opIds used across the concurrent-operation tests so assertions
+// don't depend on random UUIDs.
+const OP_ID_A = 'op-a-0000-0000'
+const OP_ID_B = 'op-b-0000-0000'
 
 describe('useTokenUsage', () => {
   beforeEach(() => {
@@ -439,22 +444,53 @@ describe('useTokenUsage', () => {
   })
 })
 
-describe('setActiveTokenCategory / getActiveTokenCategory', () => {
-  it('sets and gets active category', () => {
-    setActiveTokenCategory('missions')
-    expect(getActiveTokenCategory()).toBe('missions')
-    setActiveTokenCategory(null)
-    expect(getActiveTokenCategory()).toBeNull()
+describe('setActiveTokenCategory / clearActiveTokenCategory (per-op tracking, #6016)', () => {
+  beforeEach(() => {
+    // Clean all active ops between tests
+    for (const _ of getActiveTokenCategories()) {
+      // no-op: the loop body is just to read the list length
+    }
+    clearActiveTokenCategory(OP_ID_A)
+    clearActiveTokenCategory(OP_ID_B)
+  })
+
+  it('sets and clears a single active op', () => {
+    setActiveTokenCategory(OP_ID_A, 'missions')
+    expect(getActiveTokenCategories()).toEqual(['missions'])
+    clearActiveTokenCategory(OP_ID_A)
+    expect(getActiveTokenCategories()).toEqual([])
+  })
+
+  it('tracks multiple concurrent operations independently', () => {
+    setActiveTokenCategory(OP_ID_A, 'missions')
+    setActiveTokenCategory(OP_ID_B, 'predictions')
+    const active = getActiveTokenCategories()
+    expect(active).toHaveLength(2)
+    expect(active).toContain('missions')
+    expect(active).toContain('predictions')
+
+    // Clearing A must not remove B's entry
+    clearActiveTokenCategory(OP_ID_A)
+    expect(getActiveTokenCategories()).toEqual(['predictions'])
+    clearActiveTokenCategory(OP_ID_B)
+    expect(getActiveTokenCategories()).toEqual([])
   })
 
   it('cycles through all category types correctly', () => {
     const categories: TokenCategory[] = ['missions', 'diagnose', 'insights', 'predictions', 'other']
     for (const cat of categories) {
-      setActiveTokenCategory(cat)
-      expect(getActiveTokenCategory()).toBe(cat)
+      setActiveTokenCategory(OP_ID_A, cat)
+      expect(getActiveTokenCategories()).toEqual([cat])
     }
-    setActiveTokenCategory(null)
-    expect(getActiveTokenCategory()).toBeNull()
+    clearActiveTokenCategory(OP_ID_A)
+    expect(getActiveTokenCategories()).toEqual([])
+  })
+
+  it('overwriting the same opId replaces (not duplicates) the category', () => {
+    setActiveTokenCategory(OP_ID_A, 'missions')
+    setActiveTokenCategory(OP_ID_A, 'diagnose')
+    expect(getActiveTokenCategories()).toEqual(['diagnose'])
+    clearActiveTokenCategory(OP_ID_A)
   })
 })
 
@@ -534,5 +570,190 @@ describe('addCategoryTokens', () => {
     expect(result.current.usage.byCategory.predictions).toBeGreaterThanOrEqual(400)
     expect(result.current.usage.byCategory.other).toBeGreaterThanOrEqual(500)
     expect(result.current.usage.used).toBe(1500)
+  })
+})
+
+// ───────────────────────────────────────────────────────────────────────────
+// Agent restart detection + concurrent-op attribution (#6015, #6016)
+//
+// These tests drive the fetchTokenUsage polling path by stubbing global
+// fetch + marking the agent as available. Because module state (lastKnown,
+// active ops) persists across tests, each test uses vi.resetModules() +
+// dynamic import to get a clean copy of useTokenUsage.
+// ───────────────────────────────────────────────────────────────────────────
+
+const LAST_KNOWN_USAGE_KEY = 'kc:tokenUsage:lastKnown'
+const AGENT_SESSION_KEY = 'kc:tokenUsage:agentSession'
+const POLL_SETTLE_MS = 50
+
+describe('agent restart detection (#6015) + per-op attribution (#6016)', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    vi.resetModules()
+    vi.clearAllMocks()
+    mockGetDemoMode.mockReturnValue(false)
+    mockIsAgentUnavailable.mockReturnValue(false)
+  })
+
+  afterEach(() => {
+    // @ts-expect-error — cleanup global mock
+    delete globalThis.fetch
+  })
+
+  async function mountAndPoll(tokens: { input: number; output: number }, agentSessionId?: string) {
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve({
+        claude: {
+          tokenUsage: { today: tokens },
+          ...(agentSessionId !== undefined ? { agentSessionId } : {}),
+        },
+      }),
+    }) as unknown as typeof fetch
+    const mod = await import('../useTokenUsage')
+    const { result } = renderHook(() => mod.useTokenUsage())
+    // Let the initial fetch + subscriber update flush
+    await act(async () => { await new Promise(r => setTimeout(r, POLL_SETTLE_MS)) })
+    return { mod, result }
+  }
+
+  it('first poll establishes baseline without attributing any delta', async () => {
+    // Baseline total: 10_000 tokens. With no active op and no prior
+    // baseline, the hook must set `used` to 10_000 without dumping all
+    // 10_000 into the default category.
+    const INITIAL_INPUT = 6000
+    const INITIAL_OUTPUT = 4000
+    const { result } = await mountAndPoll({ input: INITIAL_INPUT, output: INITIAL_OUTPUT }, 'session-1')
+    expect(result.current.usage.used).toBe(INITIAL_INPUT + INITIAL_OUTPUT)
+    // byCategory should still be all zero
+    const sum = Object.values(result.current.usage.byCategory).reduce((a, b) => a + b, 0)
+    expect(sum).toBe(0)
+  })
+
+  it('persists last-known usage + session id to localStorage', async () => {
+    const INITIAL_TOKENS = 5000
+    await mountAndPoll({ input: INITIAL_TOKENS, output: 0 }, 'session-abc')
+    expect(localStorage.getItem(LAST_KNOWN_USAGE_KEY)).toBe(String(INITIAL_TOKENS))
+    expect(localStorage.getItem(AGENT_SESSION_KEY)).toBe('session-abc')
+  })
+
+  it('agent session change resets baseline without attributing delta', async () => {
+    // Pre-populate localStorage as if a previous page-load saw 10_000 tokens
+    // under session-1.
+    const PRIOR_BASELINE = 10_000
+    localStorage.setItem(LAST_KNOWN_USAGE_KEY, String(PRIOR_BASELINE))
+    localStorage.setItem(AGENT_SESSION_KEY, 'session-1')
+
+    // The agent then restarts → new session id, counter reset to 3_000.
+    const RESTART_TOKENS = 3000
+    const { result } = await mountAndPoll({ input: RESTART_TOKENS, output: 0 }, 'session-2')
+
+    // `used` should track the new total, and no category should have
+    // absorbed the spurious "delta".
+    expect(result.current.usage.used).toBe(RESTART_TOKENS)
+    const sum = Object.values(result.current.usage.byCategory).reduce((a, b) => a + b, 0)
+    expect(sum).toBe(0)
+    // Session id should be updated in storage.
+    expect(localStorage.getItem(AGENT_SESSION_KEY)).toBe('session-2')
+  })
+
+  it('counter going backwards (no session id) is also treated as a restart', async () => {
+    const PRIOR_BASELINE = 50_000
+    localStorage.setItem(LAST_KNOWN_USAGE_KEY, String(PRIOR_BASELINE))
+
+    // Agent reports a lower value; no session id sent.
+    const RESTART_TOKENS = 1000
+    const { result } = await mountAndPoll({ input: RESTART_TOKENS, output: 0 })
+
+    expect(result.current.usage.used).toBe(RESTART_TOKENS)
+    const sum = Object.values(result.current.usage.byCategory).reduce((a, b) => a + b, 0)
+    expect(sum).toBe(0)
+  })
+
+  it('single active op receives the full delta', async () => {
+    // Baseline 1000 tokens.
+    const BASELINE = 1000
+    localStorage.setItem(LAST_KNOWN_USAGE_KEY, String(BASELINE))
+    localStorage.setItem(AGENT_SESSION_KEY, 'session-1')
+
+    // Start a single active op, then poll reports a higher total.
+    const NEXT_TOTAL = 1500
+    const EXPECTED_DELTA = NEXT_TOTAL - BASELINE
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve({ claude: { tokenUsage: { today: { input: NEXT_TOTAL, output: 0 } }, agentSessionId: 'session-1' } }),
+    }) as unknown as typeof fetch
+    const mod = await import('../useTokenUsage')
+    mod.setActiveTokenCategory('op-missions', 'missions')
+    const { result } = renderHook(() => mod.useTokenUsage())
+    await act(async () => { await new Promise(r => setTimeout(r, POLL_SETTLE_MS)) })
+    mod.clearActiveTokenCategory('op-missions')
+
+    expect(result.current.usage.byCategory.missions).toBe(EXPECTED_DELTA)
+  })
+
+  it('multiple concurrent ops split the delta evenly', async () => {
+    const BASELINE = 2000
+    localStorage.setItem(LAST_KNOWN_USAGE_KEY, String(BASELINE))
+    localStorage.setItem(AGENT_SESSION_KEY, 'session-1')
+
+    // Delta of 1000, split across 2 ops → 500 each.
+    const NEXT_TOTAL = 3000
+    const EXPECTED_PER_OP = (NEXT_TOTAL - BASELINE) / 2
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve({ claude: { tokenUsage: { today: { input: NEXT_TOTAL, output: 0 } }, agentSessionId: 'session-1' } }),
+    }) as unknown as typeof fetch
+    const mod = await import('../useTokenUsage')
+    mod.setActiveTokenCategory('op-m', 'missions')
+    mod.setActiveTokenCategory('op-p', 'predictions')
+    const { result } = renderHook(() => mod.useTokenUsage())
+    await act(async () => { await new Promise(r => setTimeout(r, POLL_SETTLE_MS)) })
+    mod.clearActiveTokenCategory('op-m')
+    mod.clearActiveTokenCategory('op-p')
+
+    expect(result.current.usage.byCategory.missions).toBe(EXPECTED_PER_OP)
+    expect(result.current.usage.byCategory.predictions).toBe(EXPECTED_PER_OP)
+  })
+
+  it('localStorage quota failure on persist is swallowed gracefully', async () => {
+    // Force setItem to throw to simulate QuotaExceededError.
+    const originalSetItem = Storage.prototype.setItem
+    Storage.prototype.setItem = vi.fn(() => { throw new Error('QuotaExceededError') })
+
+    try {
+      globalThis.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve({ claude: { tokenUsage: { today: { input: 500, output: 0 } }, agentSessionId: 'session-q' } }),
+      }) as unknown as typeof fetch
+      const mod = await import('../useTokenUsage')
+      const { result } = renderHook(() => mod.useTokenUsage())
+      // Poll must complete without throwing even though persistUsage hit quota.
+      await act(async () => { await new Promise(r => setTimeout(r, POLL_SETTLE_MS)) })
+      expect(result.current.usage.used).toBe(500)
+    } finally {
+      Storage.prototype.setItem = originalSetItem
+    }
+  })
+
+  it('corrupted localStorage baseline is ignored on init', async () => {
+    localStorage.setItem(LAST_KNOWN_USAGE_KEY, 'not-a-number')
+    localStorage.setItem(AGENT_SESSION_KEY, 'session-1')
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve({ claude: { tokenUsage: { today: { input: 100, output: 0 } }, agentSessionId: 'session-1' } }),
+    }) as unknown as typeof fetch
+    const mod = await import('../useTokenUsage')
+    const { result } = renderHook(() => mod.useTokenUsage())
+    await act(async () => { await new Promise(r => setTimeout(r, POLL_SETTLE_MS)) })
+    // Should treat as first-init (baseline null), no delta attributed.
+    expect(result.current.usage.used).toBe(100)
+    const sum = Object.values(result.current.usage.byCategory).reduce((a, b) => a + b, 0)
+    expect(sum).toBe(0)
   })
 })

--- a/web/src/hooks/useAIPredictions.ts
+++ b/web/src/hooks/useAIPredictions.ts
@@ -6,7 +6,7 @@ import type {
 import { getPredictionSettings, getSettingsForBackend } from './usePredictionSettings'
 import { getDemoMode } from './useDemoMode'
 import { isAgentUnavailable, reportAgentDataSuccess, reportAgentDataError } from './useLocalAgent'
-import { setActiveTokenCategory } from './useTokenUsage'
+import { setActiveTokenCategory, clearActiveTokenCategory } from './useTokenUsage'
 import { fullFetchClusters, clusterCache } from './mcp/shared'
 
 import { LOCAL_AGENT_WS_URL, LOCAL_AGENT_HTTP_URL } from '../lib/constants'
@@ -323,8 +323,17 @@ export function useAIPredictions() {
 
   // Trigger analysis
   const analyze = async (specificProviders?: string[]) => {
+    // Generate a stable opId for the lifetime of this analyze call so
+    // concurrent analyze() invocations (e.g. from different providers)
+    // get independent token attribution (#6016). Fall back to a
+    // timestamp-based id when crypto.randomUUID is unavailable (non-secure
+    // contexts such as plain-http dev servers).
+    const opId: string =
+      typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function'
+        ? crypto.randomUUID()
+        : `predictions-${Date.now()}-${Math.random().toString(36).slice(2)}`
     setIsAnalyzing(true)
-    setActiveTokenCategory('predictions')
+    setActiveTokenCategory(opId, 'predictions')
     try {
       await triggerAnalysis(specificProviders)
       // Wait a bit then fetch results
@@ -332,7 +341,7 @@ export function useAIPredictions() {
       await fetchAIPredictions()
     } finally {
       setIsAnalyzing(false)
-      setActiveTokenCategory(null)
+      clearActiveTokenCategory(opId)
     }
   }
 

--- a/web/src/hooks/useMissions.test.tsx
+++ b/web/src/hooks/useMissions.test.tsx
@@ -15,6 +15,8 @@ vi.mock('./useDemoMode', () => ({
 vi.mock('./useTokenUsage', () => ({
   addCategoryTokens: vi.fn(),
   setActiveTokenCategory: vi.fn(),
+  clearActiveTokenCategory: vi.fn(),
+  getActiveTokenCategories: vi.fn(() => []),
 }))
 
 vi.mock('./useResolutions', () => ({
@@ -2878,10 +2880,10 @@ describe('token usage tracking', () => {
     expect(addCategoryTokens).toHaveBeenCalledWith(75, 'missions')
   })
 
-  it('calls setActiveTokenCategory when stream completes with usage', async () => {
-    const { setActiveTokenCategory } = await import('./useTokenUsage')
+  it('calls clearActiveTokenCategory when stream completes with usage', async () => {
+    const { clearActiveTokenCategory } = await import('./useTokenUsage')
     const { result } = renderHook(() => useMissions(), { wrapper })
-    const { requestId } = await startMissionWithConnection(result)
+    const { missionId, requestId } = await startMissionWithConnection(result)
 
     act(() => {
       MockWebSocket.lastInstance?.simulateMessage({
@@ -2891,8 +2893,8 @@ describe('token usage tracking', () => {
       })
     })
 
-    // Should clear active token category
-    expect(setActiveTokenCategory).toHaveBeenCalledWith(null)
+    // Should clear active token category for this specific mission (#6016)
+    expect(clearActiveTokenCategory).toHaveBeenCalledWith(missionId)
   })
 
   it('tracks token delta on stream-done with usage', async () => {
@@ -4087,7 +4089,7 @@ describe('setActiveTokenCategory on mission actions', () => {
     await act(async () => { await Promise.resolve() })
     await act(async () => { MockWebSocket.lastInstance?.simulateOpen() })
 
-    expect(setActiveTokenCategory).toHaveBeenCalledWith('missions')
+    expect(setActiveTokenCategory).toHaveBeenCalledWith(expect.any(String), 'missions')
   })
 
   it('sets active token category to "missions" on sendMessage', async () => {
@@ -4109,15 +4111,16 @@ describe('setActiveTokenCategory on mission actions', () => {
       result.current.sendMessage(missionId, 'follow up')
     })
 
-    expect(setActiveTokenCategory).toHaveBeenCalledWith('missions')
+    // Per-operation tracking keyed by missionId (#6016)
+    expect(setActiveTokenCategory).toHaveBeenCalledWith(missionId, 'missions')
   })
 
   it('clears active token category on result message', async () => {
-    const { setActiveTokenCategory } = await import('./useTokenUsage')
-    vi.mocked(setActiveTokenCategory).mockClear()
+    const { clearActiveTokenCategory } = await import('./useTokenUsage')
+    vi.mocked(clearActiveTokenCategory).mockClear()
 
     const { result } = renderHook(() => useMissions(), { wrapper })
-    const { requestId } = await startMissionWithConnection(result)
+    const { missionId, requestId } = await startMissionWithConnection(result)
 
     act(() => {
       MockWebSocket.lastInstance?.simulateMessage({
@@ -4127,7 +4130,8 @@ describe('setActiveTokenCategory on mission actions', () => {
       })
     })
 
-    expect(setActiveTokenCategory).toHaveBeenCalledWith(null)
+    // Per-operation clear keyed by missionId (#6016)
+    expect(clearActiveTokenCategory).toHaveBeenCalledWith(missionId)
   })
 })
 

--- a/web/src/hooks/useMissions.tsx
+++ b/web/src/hooks/useMissions.tsx
@@ -3,7 +3,7 @@ import type { AgentInfo, AgentsListPayload, AgentSelectedPayload, ChatStreamPayl
 import { AgentCapabilityToolExec } from '../types/agent'
 import { getDemoMode } from './useDemoMode'
 import { DEMO_MISSIONS } from '../mocks/demoMissions'
-import { addCategoryTokens, setActiveTokenCategory } from './useTokenUsage'
+import { addCategoryTokens, setActiveTokenCategory, clearActiveTokenCategory } from './useTokenUsage'
 import { detectIssueSignature, findSimilarResolutionsStandalone, generateResolutionPromptContext } from './useResolutions'
 import { LOCAL_AGENT_WS_URL, LOCAL_AGENT_HTTP_URL } from '../lib/constants'
 import { emitMissionStarted, emitMissionCompleted, emitMissionError, emitMissionRated } from '../lib/analytics'
@@ -1163,11 +1163,13 @@ The WebSocket connection to the agent at \`${LOCAL_AGENT_WS_URL}\` was lost and 
             }
           }
 
-          // Clear active token tracking.
+          // Clear active token tracking for this specific mission (#6016 —
+          // per-operation tracking so concurrent missions don't clobber each
+          // other's category).
           // NOTE: Do NOT emit analytics completion here — stream-done is not
           // authoritative. The backend sends a separate 'result' message with
           // the final answer; emitMissionCompleted fires there (#5510).
-          setActiveTokenCategory(null)
+          clearActiveTokenCategory(missionId)
           // Start the watchdog that auto-fails the mission if no final result
           // message arrives within WAITING_INPUT_TIMEOUT_MS (#5936).
           startWaitingInputTimeout(missionId)
@@ -1200,8 +1202,9 @@ The WebSocket connection to the agent at \`${LOCAL_AGENT_WS_URL}\` was lost and 
           }
         }
 
-        // Clear active token tracking and emit completion event
-        setActiveTokenCategory(null)
+        // Clear active token tracking for this mission and emit completion
+        // event (#6016 — per-operation tracking keyed by missionId).
+        clearActiveTokenCategory(missionId)
         if (m.status === 'running') {
           emitMissionCompleted(m.type, Math.round((Date.now() - m.createdAt.getTime()) / 1000))
         }
@@ -1586,8 +1589,9 @@ The WebSocket connection to the agent at \`${LOCAL_AGENT_WS_URL}\` was lost and 
         m.id === missionId ? { ...m, status: 'running', currentStep: 'Connecting to agent...' } : m
       ))
 
-      // Track token usage for this mission
-      setActiveTokenCategory('missions')
+      // Track token usage for this specific mission (#6016 — keyed by
+      // missionId so concurrent missions get independent attribution).
+      setActiveTokenCategory(missionId, 'missions')
 
       wsSend(JSON.stringify({
         id: requestId,
@@ -1979,8 +1983,9 @@ Install the console locally with the KubeStellar Console agent to use AI mission
       return
     }
 
-    // Track token usage for this mission
-    setActiveTokenCategory('missions')
+    // Track token usage for this specific mission (#6016 — keyed by
+    // missionId so concurrent missions get independent attribution).
+    setActiveTokenCategory(missionId, 'missions')
 
     setMissions(prev => prev.map(m => {
       if (m.id !== missionId) return m

--- a/web/src/hooks/useTokenUsage.ts
+++ b/web/src/hooks/useTokenUsage.ts
@@ -10,6 +10,15 @@ const MAX_SINGLE_DELTA_TOKENS = 50_000
 /** Minimum valid stop threshold — prevents "AI Disabled" at 0% from corrupted localStorage */
 const MIN_STOP_THRESHOLD = 0.01
 
+/** localStorage key for the persisted last-known total token count (agent restart detection) */
+const LAST_KNOWN_USAGE_KEY = 'kc:tokenUsage:lastKnown'
+
+/** localStorage key for the persisted agent session marker (agent restart detection) */
+const AGENT_SESSION_KEY = 'kc:tokenUsage:agentSession'
+
+/** Default category used when a delta arrives with no active operation */
+const DEFAULT_CATEGORY: TokenCategory = 'other'
+
 export type TokenCategory = 'missions' | 'diagnose' | 'insights' | 'predictions' | 'other'
 
 export interface TokenUsageByCategory {
@@ -70,53 +79,125 @@ let pollStarted = false
 let pollIntervalId: ReturnType<typeof setInterval> | null = null
 const subscribers = new Set<(usage: TokenUsage) => void>()
 
-// Track active AI operation for attributing token usage
-let activeCategory: TokenCategory | null = null
-let lastKnownUsage: number | null = null // null means not yet initialized
+// Track all active AI operations for attributing token usage.
+// Keyed by a stable operation id (e.g. missionId, analyze-call uuid) so
+// concurrent operations across multiple tabs/cards don't clobber each
+// other — the previous module-level `let activeCategory` variable caused
+// bug #6016 where starting a second operation rerouted the first one's
+// tokens to the wrong category.
+const activeCategoriesByOp = new Map<string, TokenCategory>()
+
+// Persisted baseline for total token count reported by the local agent.
+// This is loaded from localStorage on module init so that an agent restart
+// (which resets `today` counters to a lower value) can be distinguished from
+// real usage growth — see bug #6015 and the restart-detection logic below.
+let lastKnownUsage: number | null = null
+let lastKnownSessionId: string | null = null
 
 /**
- * Set the currently active AI operation category.
- * Call this when starting an AI operation (mission, diagnose, etc.)
+ * Set the active token category for a specific operation id.
+ * The opId should be stable for the lifetime of the operation (mission id,
+ * analyze-call uuid, etc.) so concurrent operations are tracked separately.
  */
-export function setActiveTokenCategory(category: TokenCategory | null) {
-  activeCategory = category
+export function setActiveTokenCategory(opId: string, category: TokenCategory) {
+  activeCategoriesByOp.set(opId, category)
 }
 
 /**
- * Get the currently active category (for debugging/display)
+ * Clear the active token category for a specific operation id.
+ * Call this when the operation completes (success, failure, or cancel).
  */
-export function getActiveTokenCategory(): TokenCategory | null {
-  return activeCategory
+export function clearActiveTokenCategory(opId: string) {
+  activeCategoriesByOp.delete(opId)
+}
+
+/**
+ * Return the set of currently active categories. Exposed for debugging.
+ */
+export function getActiveTokenCategories(): TokenCategory[] {
+  return Array.from(activeCategoriesByOp.values())
+}
+
+/**
+ * Safely load the persisted last-known usage + agent session marker from
+ * localStorage. Returns null fields if localStorage is unavailable (SSR,
+ * private mode) or the stored data is corrupted.
+ */
+function loadPersistedUsage(): { lastKnown: number | null; sessionId: string | null } {
+  if (typeof window === 'undefined') return { lastKnown: null, sessionId: null }
+  try {
+    const rawLastKnown = localStorage.getItem(LAST_KNOWN_USAGE_KEY)
+    const rawSession = localStorage.getItem(AGENT_SESSION_KEY)
+    const lastKnown = rawLastKnown !== null ? Number(rawLastKnown) : null
+    return {
+      lastKnown: lastKnown !== null && Number.isFinite(lastKnown) ? lastKnown : null,
+      sessionId: rawSession,
+    }
+  } catch {
+    // localStorage may throw in private mode or when quota is exceeded.
+    return { lastKnown: null, sessionId: null }
+  }
+}
+
+/**
+ * Safely persist the last-known usage baseline + agent session marker to
+ * localStorage. Silently ignores quota/SSR/private-mode errors — persistence
+ * is best-effort and losing it only degrades restart detection on the next
+ * page load.
+ */
+function persistUsage(lastKnown: number, sessionId: string | null): void {
+  if (typeof window === 'undefined') return
+  try {
+    localStorage.setItem(LAST_KNOWN_USAGE_KEY, String(lastKnown))
+    if (sessionId !== null) {
+      localStorage.setItem(AGENT_SESSION_KEY, sessionId)
+    }
+  } catch {
+    // Quota exceeded / private mode — ignore, this is best-effort.
+  }
+}
+
+// Hydrate the in-memory baseline from localStorage at module init so that
+// page reloads and new tabs don't mis-attribute the entire current usage
+// count as fresh delta on the first poll.
+{
+  const persisted = loadPersistedUsage()
+  lastKnownUsage = persisted.lastKnown
+  lastKnownSessionId = persisted.sessionId
 }
 
 // Initialize from localStorage
 if (typeof window !== 'undefined') {
-  const settings = localStorage.getItem(SETTINGS_KEY)
-  if (settings) {
-    const parsedSettings = JSON.parse(settings)
-    sharedUsage = { ...sharedUsage, ...parsedSettings }
-    // Ensure limit is never zero/negative (causes NaN in percentage calculations)
-    if (sharedUsage.limit <= 0) sharedUsage.limit = DEFAULT_SETTINGS.limit
-    // Ensure thresholds are sane — corrupted stopThreshold=0 causes "AI Disabled" at 0% usage
-    if (!sharedUsage.stopThreshold || sharedUsage.stopThreshold < MIN_STOP_THRESHOLD) {
-      sharedUsage.stopThreshold = DEFAULT_SETTINGS.stopThreshold
+  try {
+    const settings = localStorage.getItem(SETTINGS_KEY)
+    if (settings) {
+      const parsedSettings = JSON.parse(settings)
+      sharedUsage = { ...sharedUsage, ...parsedSettings }
+      // Ensure limit is never zero/negative (causes NaN in percentage calculations)
+      if (sharedUsage.limit <= 0) sharedUsage.limit = DEFAULT_SETTINGS.limit
+      // Ensure thresholds are sane — corrupted stopThreshold=0 causes "AI Disabled" at 0% usage
+      if (!sharedUsage.stopThreshold || sharedUsage.stopThreshold < MIN_STOP_THRESHOLD) {
+        sharedUsage.stopThreshold = DEFAULT_SETTINGS.stopThreshold
+      }
+      if (!sharedUsage.criticalThreshold || sharedUsage.criticalThreshold <= 0) {
+        sharedUsage.criticalThreshold = DEFAULT_SETTINGS.criticalThreshold
+      }
+      if (!sharedUsage.warningThreshold || sharedUsage.warningThreshold <= 0) {
+        sharedUsage.warningThreshold = DEFAULT_SETTINGS.warningThreshold
+      }
     }
-    if (!sharedUsage.criticalThreshold || sharedUsage.criticalThreshold <= 0) {
-      sharedUsage.criticalThreshold = DEFAULT_SETTINGS.criticalThreshold
-    }
-    if (!sharedUsage.warningThreshold || sharedUsage.warningThreshold <= 0) {
-      sharedUsage.warningThreshold = DEFAULT_SETTINGS.warningThreshold
-    }
+  } catch {
+    // Corrupted settings JSON — fall back to defaults.
   }
   // Load persisted category data
-  const categoryData = localStorage.getItem(CATEGORY_KEY)
-  if (categoryData) {
-    try {
+  try {
+    const categoryData = localStorage.getItem(CATEGORY_KEY)
+    if (categoryData) {
       const parsedCategories = JSON.parse(categoryData)
       sharedUsage.byCategory = { ...DEFAULT_BY_CATEGORY, ...parsedCategories }
-    } catch {
-      // Ignore invalid data
     }
+  } catch {
+    // Ignore invalid data — start from zeroed byCategory.
   }
   // Set demo usage if in demo mode
   if (getDemoMode()) {
@@ -196,22 +277,78 @@ async function fetchTokenUsage() {
         // Track both input and output tokens
         const totalUsed = (todayTokens.input || 0) + (todayTokens.output || 0)
 
-        // Attribute token increase to active category (only after initialization)
-        if (lastKnownUsage !== null && totalUsed > lastKnownUsage && activeCategory) {
+        // --- Agent restart detection (bug #6015) ----------------------------
+        // The local kc-agent reports a `today` counter that resets to zero
+        // whenever the agent process restarts. Without detecting restarts we
+        // would either:
+        //   (a) attribute the full new total as a single huge delta, or
+        //   (b) silently swallow real usage because totalUsed < lastKnownUsage.
+        // We detect a restart by either:
+        //   1. The agent session marker changing (preferred — exact signal), or
+        //   2. totalUsed going backwards compared to our persisted baseline.
+        // On restart we reset the baseline without attributing a delta. The
+        // baseline is also persisted to localStorage so a page reload doesn't
+        // mis-attribute the current running total as fresh usage.
+        const reportedSessionId: string | null = data.claude?.agentSessionId ?? null
+        const sessionChanged =
+          reportedSessionId !== null &&
+          lastKnownSessionId !== null &&
+          reportedSessionId !== lastKnownSessionId
+        const wentBackwards = lastKnownUsage !== null && totalUsed < lastKnownUsage
+        const isRestart = sessionChanged || wentBackwards
+
+        if (isRestart || lastKnownUsage === null) {
+          // Reset baseline without attributing any delta. On first init
+          // (lastKnownUsage === null) we also take this branch to establish
+          // a baseline without pretending all current usage happened just now.
+          updateSharedUsage({ used: totalUsed })
+        } else if (totalUsed > lastKnownUsage) {
           const delta = totalUsed - lastKnownUsage
-          // Sanity check: don't attribute more than 50k tokens at once (likely a bug)
+          // Sanity check: don't attribute more than MAX_SINGLE_DELTA_TOKENS
+          // at once (likely a bug / init race).
           if (delta < MAX_SINGLE_DELTA_TOKENS) {
-            const newByCategory = { ...sharedUsage.byCategory }
-            newByCategory[activeCategory] += delta
-            updateSharedUsage({ used: totalUsed, byCategory: newByCategory })
+            const activeCount = activeCategoriesByOp.size
+            if (activeCount === 0) {
+              // No active operation — attribute to the default category.
+              const newByCategory = { ...sharedUsage.byCategory }
+              newByCategory[DEFAULT_CATEGORY] += delta
+              updateSharedUsage({ used: totalUsed, byCategory: newByCategory })
+            } else if (activeCount === 1) {
+              // Single operation — attribute the entire delta to it.
+              const category = activeCategoriesByOp.values().next().value as TokenCategory
+              const newByCategory = { ...sharedUsage.byCategory }
+              newByCategory[category] += delta
+              updateSharedUsage({ used: totalUsed, byCategory: newByCategory })
+            } else {
+              // Multiple concurrent operations — split the delta evenly
+              // across all active operations. This is a best-effort
+              // heuristic: the local agent reports only an aggregate count,
+              // so we cannot perfectly attribute per-operation usage. Any
+              // remainder from integer division goes to the first operation.
+              const perOp = Math.floor(delta / activeCount)
+              const remainder = delta - perOp * activeCount
+              const newByCategory = { ...sharedUsage.byCategory }
+              let first = true
+              for (const category of activeCategoriesByOp.values()) {
+                newByCategory[category] += perOp + (first ? remainder : 0)
+                first = false
+              }
+              updateSharedUsage({ used: totalUsed, byCategory: newByCategory })
+            }
           } else {
             console.warn(`[TokenUsage] Skipping large delta ${delta} - likely initialization`)
             updateSharedUsage({ used: totalUsed })
           }
         } else {
+          // totalUsed === lastKnownUsage — nothing to attribute.
           updateSharedUsage({ used: totalUsed })
         }
+
         lastKnownUsage = totalUsed
+        if (reportedSessionId !== null) {
+          lastKnownSessionId = reportedSessionId
+        }
+        persistUsage(totalUsed, reportedSessionId)
       }
     } else {
       reportAgentDataError('/health (token)', `HTTP ${response.status}`)

--- a/web/src/lib/unified/__tests__/index.test.ts
+++ b/web/src/lib/unified/__tests__/index.test.ts
@@ -65,6 +65,8 @@ vi.mock('../../../hooks/useTokenUsage', () => ({
   }),
   addCategoryTokens: () => {},
   setActiveTokenCategory: () => {},
+  clearActiveTokenCategory: () => {},
+  getActiveTokenCategories: () => [],
 }))
 
 vi.mock('../../hooks/useTokenUsage', () => ({
@@ -81,6 +83,8 @@ vi.mock('../../hooks/useTokenUsage', () => ({
   }),
   addCategoryTokens: () => {},
   setActiveTokenCategory: () => {},
+  clearActiveTokenCategory: () => {},
+  getActiveTokenCategories: () => [],
 }))
 
 vi.mock('react-i18next', () => ({

--- a/web/src/test/utils/setupMocks.ts
+++ b/web/src/test/utils/setupMocks.ts
@@ -52,4 +52,6 @@ vi.mock('../../hooks/useTokenUsage', () => ({
   }),
   addCategoryTokens: () => {},
   setActiveTokenCategory: () => {},
+  clearActiveTokenCategory: () => {},
+  getActiveTokenCategories: () => [],
 }));


### PR DESCRIPTION
## Summary

Fixes two bugs in `web/src/hooks/useTokenUsage.ts` that caused token usage to be mis-attributed across categories.

### Bug 1 - #6016: concurrent operations clobber each other's category

The previous module-level `activeCategory` was a single variable. When two AI operations ran concurrently (e.g. a mission + a predictions analyze, or two missions across tabs), the second `setActiveTokenCategory()` call overwrote the first, and **all** subsequent deltas were attributed to the wrong category.

**Fix:** replace the single variable with a `Map<opId, TokenCategory>`. New API:

- `setActiveTokenCategory(opId: string, category: TokenCategory)`
- `clearActiveTokenCategory(opId: string)`

When attributing a poll delta:
- 0 active ops -> attribute to `DEFAULT_CATEGORY` (`'other'`)
- 1 active op  -> attribute the full delta to it
- N active ops -> split evenly across all active ops (best-effort - the kc-agent only reports an aggregate count, so perfect per-op attribution isn't possible; this is documented in a code comment)

Callers updated:
- `useMissions.tsx` - keyed by `missionId`
- `useAIPredictions.ts` - keyed by a per-`analyze()` UUID

### Bug 2 - #6015: token usage miscalculated after agent restart

`lastKnownUsage` was a module-level variable reset to `null` on every page load. When the local kc-agent restarted, its `today` counter dropped, the polling guard swallowed the negative delta, and then any real subsequent growth was mis-attributed or lost.

**Fix:**
- Persist `lastKnownUsage` + `agentSessionId` to `localStorage` under `kc:tokenUsage:lastKnown` and `kc:tokenUsage:agentSession` (constants `LAST_KNOWN_USAGE_KEY` / `AGENT_SESSION_KEY`).
- On each poll, detect a restart by either:
  1. The agent session marker changing, or
  2. `totalUsed` going backwards vs the persisted baseline.
- On restart, reset the baseline without attributing any delta.
- Guard all `localStorage` reads/writes with `try/catch` so SSR, private mode, and `QuotaExceededError` all fall back gracefully.
- `loadPersistedUsage()` / `persistUsage()` helpers encapsulate storage access.

## Code quality
- No magic numbers - every literal is a named constant with a comment
- All `JSON.parse` + `localStorage` access wrapped in `try/catch`
- No backwards-compat shims; callers updated inline

## Test plan
- [x] `npm run build` passes locally
- [x] `npm run lint` - no new errors introduced (pre-existing errors in unrelated files)
- [x] `npx vitest run src/hooks/__tests__/useTokenUsage.test.ts` - **53 / 53 passing**
- [x] `npx vitest run src/hooks/useMissions.test.tsx src/hooks/__tests__/useAIPredictions.test.ts` - **330 / 330 passing**
- [x] `npx vitest run src/lib/unified/__tests__/index.test.ts` - **4 / 4 passing**

Fixes #6015
Fixes #6016