### PR TITLE
fix(store): remove dead CountDashboardCards and fix CreateCardWithLimit race

### DIFF
--- a/pkg/store/sqlite.go
+++ b/pkg/store/sqlite.go
@@ -31,6 +31,11 @@ const (
 	sqliteDefaultConnMaxLifetime = 5 * time.Minute
 	// sqliteDefaultConnMaxIdleTime closes long-idle connections
 	sqliteDefaultConnMaxIdleTime = 2 * time.Minute
+	// sqliteBusyTimeoutMs is the millisecond duration that a writer will
+	// wait for the SQLite write lock before returning SQLITE_BUSY. Under
+	// WAL mode only one writer holds the lock at a time; this timeout
+	// lets concurrent writers queue instead of failing immediately.
+	sqliteBusyTimeoutMs = 5000
 )
 
 // parseUUID parses a UUID string, logging a warning if malformed instead of
@@ -76,7 +81,20 @@ type SQLiteStore struct {
 
 // NewSQLiteStore creates a new SQLite store
 func NewSQLiteStore(dbPath string) (*SQLiteStore, error) {
-	db, err := sql.Open("sqlite", dbPath+"?_foreign_keys=on&_journal_mode=WAL&_synchronous=NORMAL")
+	// DSN notes (modernc.org/sqlite accepts PRAGMAs via _pragma=key=value):
+	//  - journal_mode=WAL enables Write-Ahead Logging so readers don't
+	//    block writers.
+	//  - synchronous=NORMAL is the recommended pairing with WAL for good
+	//    durability without the overhead of FULL fsyncs.
+	//  - busy_timeout queues contending writers instead of returning
+	//    SQLITE_BUSY immediately; required for safe concurrent writes
+	//    alongside db.SetMaxOpenConns > 1.
+	//  - foreign_keys=on enforces FK constraints (off by default in SQLite).
+	dsn := fmt.Sprintf(
+		"%s?_pragma=foreign_keys(on)&_pragma=journal_mode(WAL)&_pragma=synchronous(NORMAL)&_pragma=busy_timeout(%d)",
+		dbPath, sqliteBusyTimeoutMs,
+	)
+	db, err := sql.Open("sqlite", dsn)
 	if err != nil {
 		return nil, fmt.Errorf("failed to open database: %w", err)
 	}
@@ -639,19 +657,6 @@ func (s *SQLiteStore) GetDashboardCards(dashboardID uuid.UUID) ([]models.Card, e
 	return cards, rows.Err()
 }
 
-// CountDashboardCards returns the number of cards belonging to a dashboard
-// without materializing the full row set. This is used by the card-create
-// limit check (#6010) to avoid the overhead of GetDashboardCards just to
-// call len() on the result.
-func (s *SQLiteStore) CountDashboardCards(dashboardID uuid.UUID) (int, error) {
-	var count int
-	err := s.db.QueryRow(`SELECT COUNT(*) FROM cards WHERE dashboard_id = ?`, dashboardID.String()).Scan(&count)
-	if err != nil {
-		return 0, err
-	}
-	return count, nil
-}
-
 func (s *SQLiteStore) scanCard(row *sql.Row) (*models.Card, error) {
 	var c models.Card
 	var idStr, dashboardIDStr, positionStr string
@@ -739,11 +744,25 @@ func (s *SQLiteStore) CreateCard(card *models.Card) error {
 }
 
 // CreateCardWithLimit atomically enforces a per-dashboard card limit and
-// inserts the card in a single transaction. This closes the TOCTOU race
-// where two concurrent CreateCard handlers could both read a count of
-// maxCards-1 and both succeed inserting, pushing the dashboard above the
-// limit (#6010). Returns ErrDashboardCardLimitReached when the dashboard
-// is already at or above maxCards.
+// inserts the card in a single SQL statement. This closes the TOCTOU race
+// (#6010) where two concurrent CreateCard handlers could both read a count
+// of maxCards-1 and both succeed inserting, pushing the dashboard above
+// the limit.
+//
+// The previous implementation used db.Begin() (a deferred transaction),
+// which under SQLite's WAL journal mode does not acquire the write lock
+// until the first write statement runs. That left a window where two
+// transactions on separate connections could both run SELECT COUNT(*),
+// both observe a count below maxCards, and both proceed to INSERT — the
+// second write would simply wait for the first to commit and then succeed,
+// silently bypassing the limit.
+//
+// The fix is to make the count check and the insert a single atomic
+// statement: INSERT ... SELECT ... WHERE (SELECT COUNT(*) ...) < ?. SQLite
+// evaluates the subquery while holding the write lock for the INSERT, so
+// no other writer can add a row in between the count and the insert.
+// Returns ErrDashboardCardLimitReached when the dashboard is already at
+// or above maxCards.
 func (s *SQLiteStore) CreateCardWithLimit(card *models.Card, maxCards int) error {
 	if card.ID == uuid.Nil {
 		card.ID = uuid.New()
@@ -760,31 +779,27 @@ func (s *SQLiteStore) CreateCardWithLimit(card *models.Card, maxCards int) error
 		configStr = &str
 	}
 
-	tx, err := s.db.Begin()
+	// Conditional insert: the row is inserted only when the current count
+	// for this dashboard is strictly less than maxCards. Because this is a
+	// single statement, SQLite's per-database write lock serializes the
+	// count+insert atomically across connections under WAL mode.
+	result, err := s.db.Exec(
+		`INSERT INTO cards (id, dashboard_id, card_type, config, position, created_at)
+		 SELECT ?, ?, ?, ?, ?, ?
+		 WHERE (SELECT COUNT(*) FROM cards WHERE dashboard_id = ?) < ?`,
+		card.ID.String(), card.DashboardID.String(), string(card.CardType), configStr, string(positionJSON), card.CreatedAt,
+		card.DashboardID.String(), maxCards,
+	)
 	if err != nil {
-		return fmt.Errorf("failed to begin transaction: %w", err)
-	}
-	defer func() {
-		// Safe to call Rollback after Commit — it becomes a no-op that
-		// returns sql.ErrTxDone which we intentionally ignore.
-		_ = tx.Rollback()
-	}()
-
-	var count int
-	if err := tx.QueryRow(`SELECT COUNT(*) FROM cards WHERE dashboard_id = ?`, card.DashboardID.String()).Scan(&count); err != nil {
-		return fmt.Errorf("failed to count cards: %w", err)
-	}
-	if count >= maxCards {
-		return ErrDashboardCardLimitReached
-	}
-
-	if _, err := tx.Exec(`INSERT INTO cards (id, dashboard_id, card_type, config, position, created_at) VALUES (?, ?, ?, ?, ?, ?)`,
-		card.ID.String(), card.DashboardID.String(), string(card.CardType), configStr, string(positionJSON), card.CreatedAt); err != nil {
 		return fmt.Errorf("failed to insert card: %w", err)
 	}
 
-	if err := tx.Commit(); err != nil {
-		return fmt.Errorf("failed to commit: %w", err)
+	rowsAffected, err := result.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("failed to read rows affected: %w", err)
+	}
+	if rowsAffected == 0 {
+		return ErrDashboardCardLimitReached
 	}
 	return nil
 }

--- a/pkg/store/sqlite_test.go
+++ b/pkg/store/sqlite_test.go
@@ -3,6 +3,8 @@ package store
 import (
 	"encoding/json"
 	"path/filepath"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -362,6 +364,105 @@ func TestCardCRUD(t *testing.T) {
 		got, err := store.GetCard(card.ID)
 		require.NoError(t, err)
 		require.Nil(t, got)
+	})
+}
+
+// TestCreateCardWithLimit verifies that the per-dashboard card limit is
+// enforced both sequentially and under concurrent inserts. The concurrent
+// sub-test is a regression guard for #6027: the previous implementation
+// used a deferred BEGIN transaction which, under WAL mode, allowed two
+// writers to both observe a count below the limit and both succeed.
+func TestCreateCardWithLimit(t *testing.T) {
+	// cardLimitTest is the per-dashboard cap used in these tests. Small
+	// enough to be reachable, large enough to exercise multi-insert paths.
+	const cardLimitTest = 3
+
+	t.Run("allows inserts up to the limit and rejects the next one", func(t *testing.T) {
+		store := newTestStore(t)
+		user := createTestUser(t, store, "gh-limit-seq", "limitseq")
+		dash := &models.Dashboard{UserID: user.ID, Name: "LimitSeq"}
+		require.NoError(t, store.CreateDashboard(dash))
+
+		for i := 0; i < cardLimitTest; i++ {
+			err := store.CreateCardWithLimit(&models.Card{
+				DashboardID: dash.ID,
+				CardType:    models.CardTypeClusterHealth,
+				Position:    models.CardPosition{X: i, Y: 0, W: 4, H: 3},
+			}, cardLimitTest)
+			require.NoError(t, err, "insert %d should succeed under the limit", i)
+		}
+
+		err := store.CreateCardWithLimit(&models.Card{
+			DashboardID: dash.ID,
+			CardType:    models.CardTypeClusterHealth,
+			Position:    models.CardPosition{X: 0, Y: 1, W: 4, H: 3},
+		}, cardLimitTest)
+		require.ErrorIs(t, err, ErrDashboardCardLimitReached)
+
+		cards, err := store.GetDashboardCards(dash.ID)
+		require.NoError(t, err)
+		require.Len(t, cards, cardLimitTest)
+	})
+
+	t.Run("concurrent inserts never exceed the limit", func(t *testing.T) {
+		store := newTestStore(t)
+		user := createTestUser(t, store, "gh-limit-conc", "limitconc")
+		dash := &models.Dashboard{UserID: user.ID, Name: "LimitConc"}
+		require.NoError(t, store.CreateDashboard(dash))
+
+		// concurrentInserters is the number of goroutines racing to insert
+		// cards. Significantly larger than cardLimitTest so that most must
+		// be rejected — any extra successes beyond cardLimitTest indicate
+		// the TOCTOU race has returned.
+		const concurrentInserters = 16
+
+		var (
+			wg            sync.WaitGroup
+			successes     int64
+			rejections    int64
+			otherErrs     int64
+			firstOtherErr atomic.Value
+			start         = make(chan struct{})
+		)
+
+		wg.Add(concurrentInserters)
+		for i := 0; i < concurrentInserters; i++ {
+			i := i
+			go func() {
+				defer wg.Done()
+				<-start
+				err := store.CreateCardWithLimit(&models.Card{
+					DashboardID: dash.ID,
+					CardType:    models.CardTypeClusterHealth,
+					Position:    models.CardPosition{X: i, Y: 0, W: 4, H: 3},
+				}, cardLimitTest)
+				switch {
+				case err == nil:
+					atomic.AddInt64(&successes, 1)
+				case err == ErrDashboardCardLimitReached:
+					atomic.AddInt64(&rejections, 1)
+				default:
+					atomic.AddInt64(&otherErrs, 1)
+					firstOtherErr.CompareAndSwap(nil, err.Error())
+				}
+			}()
+		}
+		close(start)
+		wg.Wait()
+
+		if v := firstOtherErr.Load(); v != nil {
+			t.Logf("first unexpected error: %v", v)
+		}
+		require.Zero(t, atomic.LoadInt64(&otherErrs), "no unexpected errors")
+		require.Equal(t, int64(cardLimitTest), atomic.LoadInt64(&successes),
+			"exactly cardLimitTest inserts should succeed under concurrency")
+		require.Equal(t, int64(concurrentInserters-cardLimitTest), atomic.LoadInt64(&rejections),
+			"remaining inserts should be rejected with ErrDashboardCardLimitReached")
+
+		cards, err := store.GetDashboardCards(dash.ID)
+		require.NoError(t, err)
+		require.Len(t, cards, cardLimitTest,
+			"dashboard must never exceed cardLimitTest rows under concurrent writers")
 	})
 }
 

--- a/pkg/store/store.go
+++ b/pkg/store/store.go
@@ -36,7 +36,6 @@ type Store interface {
 	// Cards
 	GetCard(id uuid.UUID) (*models.Card, error)
 	GetDashboardCards(dashboardID uuid.UUID) ([]models.Card, error)
-	CountDashboardCards(dashboardID uuid.UUID) (int, error)
 	CreateCard(card *models.Card) error
 	CreateCardWithLimit(card *models.Card, maxCards int) error
 	UpdateCard(card *models.Card) error

--- a/pkg/test/mock_store.go
+++ b/pkg/test/mock_store.go
@@ -67,21 +67,6 @@ func (m *MockStore) DeleteDashboard(id uuid.UUID) error                         
 func (m *MockStore) GetCard(id uuid.UUID) (*models.Card, error)                     { return nil, nil }
 func (m *MockStore) GetDashboardCards(dashboardID uuid.UUID) ([]models.Card, error) { return nil, nil }
 
-// CountDashboardCards is overridable via testify/mock expectations so tests
-// can exercise the per-dashboard card limit without materializing a full row set.
-func (m *MockStore) CountDashboardCards(dashboardID uuid.UUID) (int, error) {
-	if len(m.ExpectedCalls) == 0 {
-		return 0, nil
-	}
-	for _, call := range m.ExpectedCalls {
-		if call.Method == "CountDashboardCards" {
-			args := m.Called(dashboardID)
-			return args.Int(0), args.Error(1)
-		}
-	}
-	return 0, nil
-}
-
 func (m *MockStore) CreateCard(card *models.Card) error { return nil }
 
 // CreateCardWithLimit is overridable so tests can exercise both the success


### PR DESCRIPTION
## Summary

Addresses the three Copilot review comments on PR #6019.

### 1. Dead `CountDashboardCards` method (`pkg/store/store.go`, `pkg/store/sqlite.go`, `pkg/test/mock_store.go`)

`CountDashboardCards` was added to the `Store` interface in #6019 but never ends up on the hot path — the new limit enforcement in `CreateCardWithLimit` runs its own `SELECT COUNT(*)` inline. Removed from the interface, the SQLite implementation, and the `MockStore` test helper.

### 2. WAL-mode TOCTOU race in `CreateCardWithLimit` (`pkg/store/sqlite.go`)

The previous implementation used `db.Begin()` (a SQLite **deferred** transaction) and then ran `SELECT COUNT(*)` followed by `INSERT`. Under WAL journal mode a deferred transaction does **not** acquire the write lock until the first write statement runs, so two concurrent writers on separate connections could both:

1. Begin a deferred transaction
2. Run `SELECT COUNT(*)` and observe a count below `maxCards`
3. Both proceed to `INSERT` — the second one simply waits for the write lock, then succeeds

This silently bypasses the per-dashboard card limit.

**Fix:** rewrite the operation as a single atomic statement:

```sql
INSERT INTO cards (id, dashboard_id, card_type, config, position, created_at)
SELECT ?, ?, ?, ?, ?, ?
WHERE (SELECT COUNT(*) FROM cards WHERE dashboard_id = ?) < ?
```

Because it is a single statement, SQLite holds the per-database write lock while evaluating the subquery and the insert, so the count check and the insert are impossible to interleave across connections. `rowsAffected == 0` signals the limit was reached and is mapped to `ErrDashboardCardLimitReached`.

Why this over the alternatives suggested in the issue:
- `BEGIN IMMEDIATE` via `db.ExecContext` is awkward to compose with `database/sql` because you have to manage the commit/rollback manually outside a `*sql.Tx`.
- `sql.LevelSerializable` is driver-specific and the modernc driver's exact semantics under concurrent writers are not well documented.
- The single-statement form is both simpler and strictly more correct — no extra round trips, and the atomicity is a guarantee of SQLite itself, not of any specific isolation level hint.

### 3. Missing `busy_timeout` (bonus fix while I was there)

The DSN set `_journal_mode=WAL` and `_synchronous=NORMAL` but no `busy_timeout`. In WAL mode only one writer holds the write lock at a time, so any legitimate concurrent writer would fail immediately with `SQLITE_BUSY` instead of queuing. Added a 5-second `busy_timeout` (named constant `sqliteBusyTimeoutMs`). This was also required to make the new concurrent regression test pass on a single SQLite file — the app-level fix is necessary whenever `SetMaxOpenConns > 1`. Also switched the existing PRAGMAs to the modernc `_pragma=key(value)` form for consistency.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./pkg/store/... ./pkg/api/handlers/...`
- [x] `go test ./...` (entire suite — all green, including the 73s agent tests)
- [x] New `TestCreateCardWithLimit` covers:
  - [x] sequential inserts up to the limit pass, the next one returns `ErrDashboardCardLimitReached`
  - [x] 16-way concurrent inserts into a dashboard with `cardLimitTest = 3`:
    - exactly 3 succeed, exactly 13 return `ErrDashboardCardLimitReached`, zero other errors
    - final `GetDashboardCards` row count is exactly 3

## Code quality

- No magic numbers — `sqliteBusyTimeoutMs`, `cardLimitTest`, `concurrentInserters` are all named constants with comments.
- Matches existing style in `pkg/store/sqlite.go` (pointer-to-SQLiteStore methods, wrapped errors with `fmt.Errorf`, error helpers at the top of the file).
- `MockStore` stays implementing the trimmed `Store` interface — no dangling methods.

Fixes #6027