### PR TITLE
fix(security): gitops RBAC, exec session lifecycle, auth header fallback

### DIFF
--- a/pkg/api/handlers/auth.go
+++ b/pkg/api/handlers/auth.go
@@ -536,6 +536,16 @@ func (h *AuthHandler) Logout(c *fiber.Ctx) error {
 		h.wsHub.DisconnectUser(claims.UserID)
 	}
 
+	// Cancel any active /ws/exec sessions for this user (#6024). Exec
+	// sessions are not tracked by the WebSocket Hub — they run their own
+	// read loop against executor.StreamWithContext — so Hub.DisconnectUser
+	// cannot reach them. The exec handler registers its stream cancel func
+	// in a per-user registry on session start; cancelling those funcs here
+	// unblocks the stream and tears the connection down promptly.
+	if claims.UserID != uuid.Nil {
+		CancelUserExecSessions(claims.UserID)
+	}
+
 	slog.Info("[Auth] token revoked, WS sessions closed", "user", claims.GitHubLogin, "jti", claims.ID)
 	return c.JSON(fiber.Map{"success": true, "message": "Token revoked"})
 }

--- a/pkg/api/handlers/auth_helpers.go
+++ b/pkg/api/handlers/auth_helpers.go
@@ -1,0 +1,77 @@
+package handlers
+
+import (
+	"github.com/gofiber/fiber/v2"
+
+	"github.com/kubestellar/console/pkg/api/middleware"
+	"github.com/kubestellar/console/pkg/models"
+	"github.com/kubestellar/console/pkg/store"
+)
+
+// Package-level RBAC helpers shared across handlers (#6022).
+//
+// Historically each handler defined its own requireAdmin/requireEditorOrAdmin
+// method tied to a handler struct. That pattern is fine for handlers with a
+// single store reference, but means each new set of endpoints has to roll its
+// own role-check plumbing. These helpers centralize the logic so gitops, cards,
+// and any future handler with a store.Store dependency can enforce the same
+// RBAC matrix without copy-pasting it.
+//
+// Error model matches the existing CardHandler.requireEditorOrAdmin in
+// pkg/api/handlers/cards.go (#5999, #6010):
+//   - nil store → dev/demo/test mode, check skipped
+//   - store lookup error → 500 (backend broken, not user's fault)
+//   - user not found → 403
+//   - insufficient role → 403
+//
+// The helpers take a store.Store parameter rather than a handler receiver so
+// they can be called from any handler without forcing every handler struct to
+// embed a common base.
+
+// requireEditorOrAdmin verifies the current request's user has at least the
+// editor role. Viewer-role users and anonymous requests are rejected with 403.
+// Use this for mutating endpoints (create/update/delete) where full admin
+// privileges are not required. Called from gitops mutation handlers to gate
+// sync, helm upgrade/uninstall/rollback, and ArgoCD sync (#6022).
+func requireEditorOrAdmin(c *fiber.Ctx, s store.Store) error {
+	if s == nil {
+		return nil
+	}
+	userID := middleware.GetUserID(c)
+	user, err := s.GetUser(userID)
+	if err != nil {
+		return fiber.NewError(fiber.StatusInternalServerError, "Failed to verify user role")
+	}
+	if user == nil {
+		return fiber.NewError(fiber.StatusForbidden, "User not found")
+	}
+	if user.Role != models.UserRoleAdmin && user.Role != models.UserRoleEditor {
+		return fiber.NewError(fiber.StatusForbidden, "Editor or admin role required")
+	}
+	return nil
+}
+
+// requireViewerOrAbove verifies the current request's user has at least the
+// viewer role — effectively "any known, authenticated user in the console user
+// store". Use this for read endpoints that should still require a valid user
+// identity (not just a valid JWT). Drift detection is classified as read-only
+// but sensitive enough to warrant this check (#6022).
+func requireViewerOrAbove(c *fiber.Ctx, s store.Store) error {
+	if s == nil {
+		return nil
+	}
+	userID := middleware.GetUserID(c)
+	user, err := s.GetUser(userID)
+	if err != nil {
+		return fiber.NewError(fiber.StatusInternalServerError, "Failed to verify user role")
+	}
+	if user == nil {
+		return fiber.NewError(fiber.StatusForbidden, "User not found")
+	}
+	switch user.Role {
+	case models.UserRoleAdmin, models.UserRoleEditor, models.UserRoleViewer:
+		return nil
+	default:
+		return fiber.NewError(fiber.StatusForbidden, "Valid console role required")
+	}
+}

--- a/pkg/api/handlers/exec.go
+++ b/pkg/api/handlers/exec.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/gofiber/contrib/websocket"
+	"github.com/google/uuid"
 	"github.com/kubestellar/console/pkg/api/middleware"
 	"github.com/kubestellar/console/pkg/k8s"
 	corev1 "k8s.io/api/core/v1"
@@ -23,6 +24,91 @@ const execAuthDeadline = 5 * time.Second
 // execMaxStdinBytes is the maximum allowed size of a single stdin message.
 // Messages exceeding this limit are silently dropped to prevent memory exhaustion.
 const execMaxStdinBytes = 1 * 1024 * 1024 // 1 MB
+
+// execSessionRegistry tracks active exec sessions per user so that
+// CancelUserExecSessions can tear them down on logout (#6024).
+//
+// The /ws/exec handler does not register with the WebSocket Hub (it runs its
+// own read loop and does not exchange JSON frames with the hub), so the
+// Hub.DisconnectUser path used by Logout cannot see exec sessions. This
+// registry bridges that gap: when a new exec session's stream context is
+// created, the cancel function is recorded here keyed by userID. On logout,
+// CancelUserExecSessions runs every recorded cancel for that user, which
+// unblocks executor.StreamWithContext and causes the WebSocket handler to
+// exit its goroutines and close the connection.
+//
+// A regular sync.Mutex is used (not RWMutex) because writes (add/remove on
+// session start/end) and reads (CancelUserExecSessions on logout) are both
+// infrequent and always short; an RWMutex would add complexity for no gain.
+var (
+	execSessionsMu sync.Mutex
+	execSessions   = make(map[uuid.UUID]map[int64]context.CancelFunc)
+	execSessionSeq int64 // monotonic id generator, guarded by execSessionsMu
+)
+
+// registerExecSession records cancel under userID and returns the assigned
+// session id. The session id is used by unregisterExecSession to remove the
+// specific entry when the session ends normally, so the map does not grow
+// unbounded across many sessions by the same user.
+func registerExecSession(userID uuid.UUID, cancel context.CancelFunc) int64 {
+	execSessionsMu.Lock()
+	defer execSessionsMu.Unlock()
+	execSessionSeq++
+	id := execSessionSeq
+	sessions, ok := execSessions[userID]
+	if !ok {
+		sessions = make(map[int64]context.CancelFunc)
+		execSessions[userID] = sessions
+	}
+	sessions[id] = cancel
+	return id
+}
+
+// unregisterExecSession removes a single session entry. Called from the exec
+// handler's deferred cleanup on normal session end so the registry stays
+// bounded by the number of concurrently live exec sessions, not the total
+// lifetime count.
+func unregisterExecSession(userID uuid.UUID, id int64) {
+	execSessionsMu.Lock()
+	defer execSessionsMu.Unlock()
+	sessions, ok := execSessions[userID]
+	if !ok {
+		return
+	}
+	delete(sessions, id)
+	if len(sessions) == 0 {
+		delete(execSessions, userID)
+	}
+}
+
+// CancelUserExecSessions cancels every active exec session belonging to the
+// given user and clears the entries from the registry. Called from the auth
+// Logout handler after revoking the JWT so that any pod shell the user had
+// open stops accepting input and unblocks the StreamWithContext goroutine
+// (#6024). Safe to call with a userID that has no live sessions.
+func CancelUserExecSessions(userID uuid.UUID) {
+	execSessionsMu.Lock()
+	sessions, ok := execSessions[userID]
+	if !ok {
+		execSessionsMu.Unlock()
+		return
+	}
+	// Take ownership of the cancel funcs under the lock, then release the
+	// lock before invoking them. Calling cancel() itself is cheap but the
+	// goroutines it unblocks may contend for other locks; holding
+	// execSessionsMu across those is unnecessary and risks deadlock.
+	cancels := make([]context.CancelFunc, 0, len(sessions))
+	for _, c := range sessions {
+		cancels = append(cancels, c)
+	}
+	delete(execSessions, userID)
+	execSessionsMu.Unlock()
+
+	for _, cancel := range cancels {
+		cancel()
+	}
+	slog.Info("[Exec] cancelled exec sessions for user", "user", userID, "count", len(cancels))
+}
 
 // ExecHandlers handles pod exec API endpoints
 type ExecHandlers struct {
@@ -299,6 +385,16 @@ func (h *ExecHandlers) HandleExec(c *websocket.Conn) {
 	// the exec stream is cancelled promptly — preventing goroutine and SPDY leaks.
 	execCtx, execCancel := context.WithCancel(context.Background())
 	defer execCancel()
+
+	// Register this cancel with the per-user exec session registry so a later
+	// Logout call can tear the stream down even though /ws/exec is not tracked
+	// by the WebSocket Hub (#6024). Only register when we have a real userID —
+	// in dev/demo without a valid UserID claim there is nothing to key on.
+	var execRegistrationID int64
+	if claims.UserID != uuid.Nil {
+		execRegistrationID = registerExecSession(claims.UserID, execCancel)
+		defer unregisterExecSession(claims.UserID, execRegistrationID)
+	}
 
 	// Start a goroutine to read WebSocket messages and route them
 	done := make(chan struct{})

--- a/pkg/api/handlers/exec_test.go
+++ b/pkg/api/handlers/exec_test.go
@@ -1,0 +1,137 @@
+package handlers
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// testExecCancelWait is how long tests wait for CancelUserExecSessions to
+// propagate through the registered cancel funcs before asserting the context
+// is Done. The registry just calls cancel() synchronously, so in practice a
+// few milliseconds is enough; we use a generous budget to keep CI flake-free.
+const testExecCancelWait = 250 * time.Millisecond
+
+// TestCancelUserExecSessions_CancelsRegisteredContexts verifies the core
+// lifecycle invariant for #6024: a session context registered for a user is
+// Done() after CancelUserExecSessions runs for that user, and the registry
+// no longer holds a reference to it.
+func TestCancelUserExecSessions_CancelsRegisteredContexts(t *testing.T) {
+	userID := uuid.New()
+	ctxA, cancelA := context.WithCancel(context.Background())
+	t.Cleanup(cancelA)
+	ctxB, cancelB := context.WithCancel(context.Background())
+	t.Cleanup(cancelB)
+
+	idA := registerExecSession(userID, cancelA)
+	idB := registerExecSession(userID, cancelB)
+	require.NotEqual(t, idA, idB, "session ids must be unique within a user")
+
+	CancelUserExecSessions(userID)
+
+	// Both contexts should see cancellation essentially immediately.
+	select {
+	case <-ctxA.Done():
+	case <-time.After(testExecCancelWait):
+		t.Fatalf("session A context was not cancelled within %s", testExecCancelWait)
+	}
+	select {
+	case <-ctxB.Done():
+	case <-time.After(testExecCancelWait):
+		t.Fatalf("session B context was not cancelled within %s", testExecCancelWait)
+	}
+
+	// The registry entry should be gone so it can't leak across users/logouts.
+	execSessionsMu.Lock()
+	_, stillThere := execSessions[userID]
+	execSessionsMu.Unlock()
+	assert.False(t, stillThere, "registry entry for user should be cleared after cancellation")
+}
+
+// TestCancelUserExecSessions_OtherUserUnaffected confirms that cancelling one
+// user's sessions does not touch another user's sessions. This is important
+// because logout of user A must not drop user B's shells.
+func TestCancelUserExecSessions_OtherUserUnaffected(t *testing.T) {
+	userA := uuid.New()
+	userB := uuid.New()
+
+	ctxA, cancelA := context.WithCancel(context.Background())
+	t.Cleanup(cancelA)
+	ctxB, cancelB := context.WithCancel(context.Background())
+	t.Cleanup(cancelB)
+
+	registerExecSession(userA, cancelA)
+	idB := registerExecSession(userB, cancelB)
+	t.Cleanup(func() { unregisterExecSession(userB, idB) })
+
+	CancelUserExecSessions(userA)
+
+	// userA's context should be cancelled.
+	select {
+	case <-ctxA.Done():
+	case <-time.After(testExecCancelWait):
+		t.Fatalf("userA context was not cancelled")
+	}
+
+	// userB's context must still be alive — a different user logging out
+	// must not tear down unrelated exec sessions.
+	select {
+	case <-ctxB.Done():
+		t.Fatal("userB context was cancelled despite only userA logging out")
+	case <-time.After(testExecCancelWait / 2):
+		// expected: context still alive
+	}
+}
+
+// TestUnregisterExecSession_RemovesEntry verifies the deferred cleanup path
+// for normal session end: unregisterExecSession should drop the specific
+// session id without touching sibling sessions, and drop the per-user map
+// entry when the user's last session ends.
+func TestUnregisterExecSession_RemovesEntry(t *testing.T) {
+	userID := uuid.New()
+
+	var cancelCalledA int32
+	cancelA := func() { atomic.StoreInt32(&cancelCalledA, 1) }
+	var cancelCalledB int32
+	cancelB := func() { atomic.StoreInt32(&cancelCalledB, 1) }
+
+	idA := registerExecSession(userID, cancelA)
+	idB := registerExecSession(userID, cancelB)
+
+	unregisterExecSession(userID, idA)
+
+	// Removing one entry must not invoke any cancel funcs — cancellation is
+	// a separate concern from registry cleanup.
+	assert.Equal(t, int32(0), atomic.LoadInt32(&cancelCalledA))
+	assert.Equal(t, int32(0), atomic.LoadInt32(&cancelCalledB))
+
+	// Entry for B must still be present.
+	execSessionsMu.Lock()
+	sessions, ok := execSessions[userID]
+	remaining := len(sessions)
+	execSessionsMu.Unlock()
+	require.True(t, ok)
+	assert.Equal(t, 1, remaining, "session B should still be registered")
+
+	// Removing the last entry should drop the whole per-user map slot.
+	unregisterExecSession(userID, idB)
+	execSessionsMu.Lock()
+	_, stillThere := execSessions[userID]
+	execSessionsMu.Unlock()
+	assert.False(t, stillThere, "per-user map entry should be removed when empty")
+}
+
+// TestCancelUserExecSessions_NoSessions verifies that calling the cancel
+// function for a user with no registered sessions is a no-op and does not
+// panic — logout must always be safe to call whether or not the user had an
+// open shell.
+func TestCancelUserExecSessions_NoSessions(t *testing.T) {
+	userID := uuid.New()
+	// Should not panic, should not block.
+	CancelUserExecSessions(userID)
+}

--- a/pkg/api/handlers/gitops.go
+++ b/pkg/api/handlers/gitops.go
@@ -19,11 +19,9 @@ import (
 	"github.com/gofiber/fiber/v2"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/kubestellar/console/pkg/api/middleware"
 	"github.com/kubestellar/console/pkg/api/v1alpha1"
 	"github.com/kubestellar/console/pkg/k8s"
 	"github.com/kubestellar/console/pkg/mcp"
-	"github.com/kubestellar/console/pkg/models"
 	"github.com/kubestellar/console/pkg/store"
 )
 
@@ -67,10 +65,11 @@ type driftCacheEntry struct {
 type GitOpsHandlers struct {
 	bridge    *mcp.Bridge
 	k8sClient *k8s.MultiClusterClient
-	// userStore is consulted by requireAdmin to enforce console-admin role on
-	// mutating GitOps endpoints (#5972, #5973). May be nil in dev/demo mode
-	// or in unit tests that don't need RBAC; in that case the check is a
-	// no-op to preserve existing test ergonomics.
+	// userStore is consulted by the shared requireEditorOrAdmin /
+	// requireViewerOrAbove helpers to enforce RBAC on GitOps endpoints
+	// (#6022). May be nil in dev/demo mode or in unit tests that don't
+	// exercise RBAC; in that case the check is a no-op to preserve existing
+	// test ergonomics.
 	userStore store.Store
 
 	// driftCache memoises recent drift results so ListDrifts can return
@@ -81,10 +80,10 @@ type GitOpsHandlers struct {
 
 // NewGitOpsHandlers creates a new GitOps handlers instance.
 //
-// userStore is used to enforce the console-admin role on mutating GitOps
-// endpoints (sync, detect-drift, helm mutations, argocd sync). Pass nil to
-// skip role checks — this is intended for dev/demo mode and unit tests that
-// are not exercising RBAC.
+// userStore is used to enforce editor-or-admin on mutating GitOps endpoints
+// (sync, helm mutations, argocd sync) and viewer-or-above on drift detection
+// (#6022). Pass nil to skip role checks — this is intended for dev/demo mode
+// and unit tests that are not exercising RBAC.
 func NewGitOpsHandlers(bridge *mcp.Bridge, k8sClient *k8s.MultiClusterClient, userStore store.Store) *GitOpsHandlers {
 	return &GitOpsHandlers{
 		bridge:     bridge,
@@ -94,21 +93,10 @@ func NewGitOpsHandlers(bridge *mcp.Bridge, k8sClient *k8s.MultiClusterClient, us
 	}
 }
 
-// requireAdmin verifies the caller is a console admin. Returns a 403 Fiber
-// error if not. When no user store is configured (dev/demo/tests) the check
-// is skipped to preserve existing behavior — production wiring always passes
-// a real store through NewGitOpsHandlers (#5972, #5973).
-func (h *GitOpsHandlers) requireAdmin(c *fiber.Ctx) error {
-	if h.userStore == nil {
-		return nil
-	}
-	currentUserID := middleware.GetUserID(c)
-	currentUser, err := h.userStore.GetUser(currentUserID)
-	if err != nil || currentUser == nil || currentUser.Role != models.UserRoleAdmin {
-		return fiber.NewError(fiber.StatusForbidden, "Console admin access required")
-	}
-	return nil
-}
+// RBAC for GitOps endpoints is enforced via the shared helpers in
+// auth_helpers.go (requireEditorOrAdmin / requireViewerOrAbove). The earlier
+// admin-only helper was removed in #6022 when the policy was loosened to
+// editor-or-admin for mutations and viewer-or-above for drift detection.
 
 // rememberDrift stores a drift-detection result in the in-memory cache keyed
 // by repo URL / path / cluster / namespace. Safe for concurrent use.
@@ -1090,10 +1078,12 @@ func getDemoHelmReleasesForStreaming() []HelmRelease {
 
 // DetectDrift detects drift between git and cluster state
 func (h *GitOpsHandlers) DetectDrift(c *fiber.Ctx) error {
-	// #5973 — drift detection shells out to kubectl diff against the live
-	// cluster, which mounts a kubeconfig and reveals cluster state that
-	// viewer-role users should not be able to trigger. Require console admin.
-	if err := h.requireAdmin(c); err != nil {
+	// #6022 — drift detection is read-oriented (it diffs git vs. live cluster)
+	// so it is gated as "viewer-or-above" rather than admin-only. This still
+	// blocks anonymous/unknown callers and any user who isn't registered in
+	// the console user store, but allows editors and viewers to see drift
+	// reports without needing the admin role.
+	if err := requireViewerOrAbove(c, h.userStore); err != nil {
 		return err
 	}
 
@@ -1309,10 +1299,12 @@ func (h *GitOpsHandlers) detectDriftViaKubectl(ctx context.Context, req DetectDr
 
 // Sync applies manifests from git to the cluster
 func (h *GitOpsHandlers) Sync(c *fiber.Ctx) error {
-	// #5972 — GitOps sync mutates cluster state via kubectl apply (or MCP
-	// deploy). Viewer-role users must not be able to trigger these, so
-	// require the console admin role before doing any further parsing.
-	if err := h.requireAdmin(c); err != nil {
+	// #6022 — GitOps sync mutates cluster state via kubectl apply (or MCP
+	// deploy). Viewers must be blocked, but editors are expected to drive
+	// day-to-day sync operations so the gate is editor-or-admin (not
+	// admin-only). Anonymous callers and users missing from the store are
+	// rejected with 403 by the shared helper.
+	if err := requireEditorOrAdmin(c, h.userStore); err != nil {
 		return err
 	}
 
@@ -1995,8 +1987,8 @@ type HelmUpgradeRequest struct {
 
 // RollbackHelmRelease rolls back a Helm release to a specific revision
 func (h *GitOpsHandlers) RollbackHelmRelease(c *fiber.Ctx) error {
-	// Helm rollback mutates cluster state; restrict to console admins (#5972).
-	if err := h.requireAdmin(c); err != nil {
+	// Helm rollback mutates cluster state; gated as editor-or-admin (#6022).
+	if err := requireEditorOrAdmin(c, h.userStore); err != nil {
 		return err
 	}
 	var req HelmRollbackRequest
@@ -2051,8 +2043,8 @@ func (h *GitOpsHandlers) RollbackHelmRelease(c *fiber.Ctx) error {
 
 // UninstallHelmRelease uninstalls a Helm release
 func (h *GitOpsHandlers) UninstallHelmRelease(c *fiber.Ctx) error {
-	// Helm uninstall destroys cluster resources; restrict to console admins (#5972).
-	if err := h.requireAdmin(c); err != nil {
+	// Helm uninstall destroys cluster resources; gated as editor-or-admin (#6022).
+	if err := requireEditorOrAdmin(c, h.userStore); err != nil {
 		return err
 	}
 	var req HelmUninstallRequest
@@ -2104,8 +2096,8 @@ func (h *GitOpsHandlers) UninstallHelmRelease(c *fiber.Ctx) error {
 
 // UpgradeHelmRelease upgrades a Helm release
 func (h *GitOpsHandlers) UpgradeHelmRelease(c *fiber.Ctx) error {
-	// Helm upgrade mutates cluster state; restrict to console admins (#5972).
-	if err := h.requireAdmin(c); err != nil {
+	// Helm upgrade mutates cluster state; gated as editor-or-admin (#6022).
+	if err := requireEditorOrAdmin(c, h.userStore); err != nil {
 		return err
 	}
 	var req HelmUpgradeRequest
@@ -2340,9 +2332,11 @@ func (h *GitOpsHandlers) GetArgoSyncSummary(c *fiber.Ctx) error {
 // Tries ArgoCD REST API first (if ARGOCD_AUTH_TOKEN is set), then CLI, then annotation patching.
 // POST /api/gitops/argocd/sync
 func (h *GitOpsHandlers) TriggerArgoSync(c *fiber.Ctx) error {
-	// #5972 — ArgoCD sync forces reconciliation against the target cluster
-	// and is equivalent to any other mutating sync operation. Require admin.
-	if err := h.requireAdmin(c); err != nil {
+	// #6022 — ArgoCD sync forces reconciliation against the target cluster
+	// and is equivalent to any other mutating sync operation. Gated as
+	// editor-or-admin: editors drive routine sync operations, viewers are
+	// blocked because they should only observe state, not force changes.
+	if err := requireEditorOrAdmin(c, h.userStore); err != nil {
 		return err
 	}
 	if h.k8sClient == nil {

--- a/pkg/api/handlers/gitops_test.go
+++ b/pkg/api/handlers/gitops_test.go
@@ -106,7 +106,8 @@ var gitopsRBACUserID = uuid.MustParse("00000000-0000-0000-0000-000000000abc")
 
 // newGitOpsRBACApp builds a Fiber app + GitOpsHandlers wired to a MockStore
 // that returns the given role for the test user. Use this to verify that
-// mutating GitOps endpoints enforce the console-admin role (#5972, #5973).
+// mutating GitOps endpoints enforce editor-or-admin and drift detection
+// enforces viewer-or-above (#6022).
 func newGitOpsRBACApp(t *testing.T, role models.UserRole) (*fiber.App, *GitOpsHandlers) {
 	t.Helper()
 	mockStore := new(test.MockStore)
@@ -124,55 +125,137 @@ func newGitOpsRBACApp(t *testing.T, role models.UserRole) (*fiber.App, *GitOpsHa
 	return app, handler
 }
 
-func TestGitOps_Sync_RequiresAdmin_ViewerForbidden(t *testing.T) {
-	app, handler := newGitOpsRBACApp(t, models.UserRoleViewer)
-	app.Post("/api/gitops/sync", handler.Sync)
+// statusPastRBAC is the HTTP status a mutation handler returns after passing
+// the RBAC gate but failing input validation on an empty body (missing
+// repoUrl / missing release name). Tests use it as a sentinel to prove the
+// caller was authorized — any 403 instead of this would mean RBAC rejected
+// the caller.
+const statusPastRBAC = http.StatusBadRequest
 
-	body := strings.NewReader(`{"repoUrl":"https://example.com/repo.git","path":"."}`)
-	req, err := http.NewRequest(http.MethodPost, "/api/gitops/sync", body)
-	require.NoError(t, err)
-	req.Header.Set("Content-Type", "application/json")
-
-	resp, err := app.Test(req, fiberTestTimeout)
-	require.NoError(t, err)
-	assert.Equal(t, http.StatusForbidden, resp.StatusCode,
-		"viewer-role users must not be able to trigger GitOps sync (#5972)")
+// mutationCase describes a single editor-or-admin gitops endpoint that
+// should accept editors and admins but reject viewers (#6022).
+type mutationCase struct {
+	name   string
+	path   string
+	body   string
+	wire   func(app *fiber.App, h *GitOpsHandlers, path string)
 }
 
-func TestGitOps_Sync_RequiresAdmin_AdminAllowed(t *testing.T) {
-	app, handler := newGitOpsRBACApp(t, models.UserRoleAdmin)
-	app.Post("/api/gitops/sync", handler.Sync)
-
-	// Empty body so we don't actually shell out to kubectl — just past the
-	// admin check. The handler then fails validation for missing repoUrl.
-	req, err := http.NewRequest(http.MethodPost, "/api/gitops/sync", strings.NewReader(`{}`))
-	require.NoError(t, err)
-	req.Header.Set("Content-Type", "application/json")
-
-	resp, err := app.Test(req, fiberTestTimeout)
-	require.NoError(t, err)
-	// Past the admin check, the handler rejects with 400 ("repoUrl is required").
-	// That's proof the admin was authorized and reached the validation step.
-	assert.Equal(t, http.StatusBadRequest, resp.StatusCode,
-		"admin should pass RBAC and reach repoUrl validation")
+func gitopsMutationCases() []mutationCase {
+	return []mutationCase{
+		{
+			name: "sync",
+			path: "/api/gitops/sync",
+			body: `{}`,
+			wire: func(app *fiber.App, h *GitOpsHandlers, p string) { app.Post(p, h.Sync) },
+		},
+		{
+			name: "helm-upgrade",
+			path: "/api/gitops/helm-upgrade",
+			body: `{}`,
+			wire: func(app *fiber.App, h *GitOpsHandlers, p string) { app.Post(p, h.UpgradeHelmRelease) },
+		},
+		{
+			name: "helm-uninstall",
+			path: "/api/gitops/helm-uninstall",
+			body: `{}`,
+			wire: func(app *fiber.App, h *GitOpsHandlers, p string) { app.Post(p, h.UninstallHelmRelease) },
+		},
+		{
+			name: "helm-rollback",
+			path: "/api/gitops/helm-rollback",
+			body: `{}`,
+			wire: func(app *fiber.App, h *GitOpsHandlers, p string) { app.Post(p, h.RollbackHelmRelease) },
+		},
+	}
 }
 
-func TestGitOps_DetectDrift_RequiresAdmin_ViewerForbidden(t *testing.T) {
+func TestGitOps_Mutations_ViewerForbidden(t *testing.T) {
+	for _, tc := range gitopsMutationCases() {
+		t.Run(tc.name, func(t *testing.T) {
+			app, handler := newGitOpsRBACApp(t, models.UserRoleViewer)
+			tc.wire(app, handler, tc.path)
+
+			req, err := http.NewRequest(http.MethodPost, tc.path, strings.NewReader(tc.body))
+			require.NoError(t, err)
+			req.Header.Set("Content-Type", "application/json")
+
+			resp, err := app.Test(req, fiberTestTimeout)
+			require.NoError(t, err)
+			assert.Equal(t, http.StatusForbidden, resp.StatusCode,
+				"viewer-role users must not be able to trigger mutating gitops endpoints (#6022)")
+		})
+	}
+}
+
+func TestGitOps_Mutations_EditorAllowed(t *testing.T) {
+	for _, tc := range gitopsMutationCases() {
+		t.Run(tc.name, func(t *testing.T) {
+			app, handler := newGitOpsRBACApp(t, models.UserRoleEditor)
+			tc.wire(app, handler, tc.path)
+
+			req, err := http.NewRequest(http.MethodPost, tc.path, strings.NewReader(tc.body))
+			require.NoError(t, err)
+			req.Header.Set("Content-Type", "application/json")
+
+			resp, err := app.Test(req, fiberTestTimeout)
+			require.NoError(t, err)
+			assert.Equal(t, statusPastRBAC, resp.StatusCode,
+				"editor should pass RBAC and reach body validation (#6022)")
+		})
+	}
+}
+
+func TestGitOps_Mutations_AdminAllowed(t *testing.T) {
+	for _, tc := range gitopsMutationCases() {
+		t.Run(tc.name, func(t *testing.T) {
+			app, handler := newGitOpsRBACApp(t, models.UserRoleAdmin)
+			tc.wire(app, handler, tc.path)
+
+			req, err := http.NewRequest(http.MethodPost, tc.path, strings.NewReader(tc.body))
+			require.NoError(t, err)
+			req.Header.Set("Content-Type", "application/json")
+
+			resp, err := app.Test(req, fiberTestTimeout)
+			require.NoError(t, err)
+			assert.Equal(t, statusPastRBAC, resp.StatusCode,
+				"admin should pass RBAC and reach body validation (#6022)")
+		})
+	}
+}
+
+// TestGitOps_DetectDrift_ViewerAllowed verifies that drift detection is
+// gated as viewer-or-above — viewers can run drift reports because the
+// operation is read-oriented, even though it was historically admin-only.
+// Post-#6022 policy: viewers can detect drift but not act on it.
+func TestGitOps_DetectDrift_ViewerAllowed(t *testing.T) {
 	app, handler := newGitOpsRBACApp(t, models.UserRoleViewer)
 	app.Post("/api/gitops/detect-drift", handler.DetectDrift)
 
-	body := strings.NewReader(`{"repoUrl":"https://example.com/repo.git","path":"."}`)
-	req, err := http.NewRequest(http.MethodPost, "/api/gitops/detect-drift", body)
+	req, err := http.NewRequest(http.MethodPost, "/api/gitops/detect-drift", strings.NewReader(`{}`))
 	require.NoError(t, err)
 	req.Header.Set("Content-Type", "application/json")
 
 	resp, err := app.Test(req, fiberTestTimeout)
 	require.NoError(t, err)
-	assert.Equal(t, http.StatusForbidden, resp.StatusCode,
-		"viewer-role users must not be able to trigger drift detection (#5973)")
+	assert.Equal(t, statusPastRBAC, resp.StatusCode,
+		"viewer should pass RBAC and reach repoUrl validation (#6022)")
 }
 
-func TestGitOps_DetectDrift_RequiresAdmin_AdminAllowed(t *testing.T) {
+func TestGitOps_DetectDrift_EditorAllowed(t *testing.T) {
+	app, handler := newGitOpsRBACApp(t, models.UserRoleEditor)
+	app.Post("/api/gitops/detect-drift", handler.DetectDrift)
+
+	req, err := http.NewRequest(http.MethodPost, "/api/gitops/detect-drift", strings.NewReader(`{}`))
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := app.Test(req, fiberTestTimeout)
+	require.NoError(t, err)
+	assert.Equal(t, statusPastRBAC, resp.StatusCode)
+}
+
+func TestGitOps_DetectDrift_AdminAllowed(t *testing.T) {
 	app, handler := newGitOpsRBACApp(t, models.UserRoleAdmin)
 	app.Post("/api/gitops/detect-drift", handler.DetectDrift)
 
@@ -182,13 +265,11 @@ func TestGitOps_DetectDrift_RequiresAdmin_AdminAllowed(t *testing.T) {
 
 	resp, err := app.Test(req, fiberTestTimeout)
 	require.NoError(t, err)
-	// Past the admin check, rejects with 400 ("repoUrl is required").
-	assert.Equal(t, http.StatusBadRequest, resp.StatusCode,
-		"admin should pass RBAC and reach repoUrl validation")
+	assert.Equal(t, statusPastRBAC, resp.StatusCode)
 }
 
 func TestGitOps_Sync_NilStore_SkipsRBAC(t *testing.T) {
-	// Dev/demo mode: no user store configured → requireAdmin is a no-op.
+	// Dev/demo mode: no user store configured → RBAC helpers are a no-op.
 	// This preserves existing test ergonomics and local dev behavior.
 	app, handler := setupGitOpsTest()
 	app.Post("/api/gitops/sync", handler.Sync)

--- a/pkg/api/middleware/auth.go
+++ b/pkg/api/middleware/auth.go
@@ -303,6 +303,31 @@ func JWTAuth(secret string) fiber.Handler {
 
 		token, err := ParseJWT(tokenString, secret)
 
+		// #6026 — When the Authorization header carries a stale or otherwise
+		// invalid token AND the client also presents a valid kc_auth cookie,
+		// fall back to the cookie instead of returning 401. This situation
+		// arises after a silent token refresh: the browser updates the cookie
+		// but an in-flight request (or a client that cached the old header
+		// value) may still send the old bearer token. Without the fallback
+		// the user sees spurious 401s and is bounced to login even though
+		// their session is still valid. The fallback is only engaged when
+		// the header was present (authHeader != "") and we didn't already
+		// pick up the cookie as the primary token — otherwise this collapses
+		// to the normal header or cookie path and we return the original
+		// error.
+		if err != nil && authHeader != "" {
+			cookieToken := c.Cookies(jwtCookieName)
+			if cookieToken != "" && cookieToken != tokenString {
+				cookieParsed, cookieErr := ParseJWT(cookieToken, secret)
+				if cookieErr == nil && cookieParsed.Valid {
+					slog.Info("[Auth] stale bearer header, falling back to cookie", "path", c.Path())
+					token = cookieParsed
+					err = nil
+					tokenString = cookieToken
+				}
+			}
+		}
+
 		if err != nil {
 			slog.Error("[Auth] token parse error", "path", c.Path(), "error", err)
 			return fiber.NewError(fiber.StatusUnauthorized, "Invalid token")

--- a/pkg/api/middleware/auth_test.go
+++ b/pkg/api/middleware/auth_test.go
@@ -1,6 +1,7 @@
 package middleware
 
 import (
+	"net/http"
 	"net/http/httptest"
 	"testing"
 	"time"
@@ -210,6 +211,80 @@ func generateTestToken(secret string, expiry time.Time) (string, error) {
 	}
 	token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
 	return token.SignedString([]byte(secret))
+}
+
+// TestJWTAuth_StaleHeaderFallsBackToCookie covers #6026: when a request
+// presents BOTH an Authorization bearer header AND a kc_auth cookie, and
+// the header token fails to parse (stale/invalid), the middleware should
+// fall back to the cookie instead of returning 401. The scenario happens
+// after a silent token refresh — the browser updates the cookie, but an
+// in-flight request (or a cached fetch wrapper) may still send the old
+// bearer value. Without the fallback users see spurious 401s and get
+// bounced to login even though their session is still valid.
+func TestJWTAuth_StaleHeaderFallsBackToCookie(t *testing.T) {
+	secret := "test-secret"
+	app := fiber.New()
+	app.Get("/protected", JWTAuth(secret), func(c *fiber.Ctx) error {
+		return c.SendString("success")
+	})
+
+	t.Run("Stale Bearer + Valid Cookie Falls Back (#6026)", func(t *testing.T) {
+		// Header token signed with the wrong secret — simulates a stale or
+		// otherwise invalid bearer. Cookie token is validly signed.
+		staleHeaderToken, _ := generateTestToken("WRONG-SECRET", time.Now().Add(time.Hour))
+		validCookieToken, _ := generateTestToken(secret, time.Now().Add(time.Hour))
+
+		req := httptest.NewRequest("GET", "/protected", nil)
+		req.Header.Set("Authorization", "Bearer "+staleHeaderToken)
+		req.AddCookie(&http.Cookie{Name: jwtCookieName, Value: validCookieToken})
+
+		resp, err := app.Test(req, 5000)
+		assert.NoError(t, err)
+		assert.Equal(t, 200, resp.StatusCode, "fallback to valid cookie should succeed")
+	})
+
+	t.Run("Stale Bearer + Missing Cookie Still 401", func(t *testing.T) {
+		// No cookie present — fallback can't engage, request must still fail.
+		staleHeaderToken, _ := generateTestToken("WRONG-SECRET", time.Now().Add(time.Hour))
+
+		req := httptest.NewRequest("GET", "/protected", nil)
+		req.Header.Set("Authorization", "Bearer "+staleHeaderToken)
+
+		resp, err := app.Test(req, 5000)
+		assert.NoError(t, err)
+		assert.Equal(t, 401, resp.StatusCode)
+	})
+
+	t.Run("Stale Bearer + Stale Cookie Still 401", func(t *testing.T) {
+		// Both tokens invalid — fallback must not silently accept the
+		// cookie just because it's present; the cookie still has to parse.
+		staleHeaderToken, _ := generateTestToken("WRONG-SECRET", time.Now().Add(time.Hour))
+		staleCookieToken, _ := generateTestToken("ALSO-WRONG", time.Now().Add(time.Hour))
+
+		req := httptest.NewRequest("GET", "/protected", nil)
+		req.Header.Set("Authorization", "Bearer "+staleHeaderToken)
+		req.AddCookie(&http.Cookie{Name: jwtCookieName, Value: staleCookieToken})
+
+		resp, err := app.Test(req, 5000)
+		assert.NoError(t, err)
+		assert.Equal(t, 401, resp.StatusCode)
+	})
+
+	t.Run("Valid Bearer Cookie Ignored", func(t *testing.T) {
+		// Header is valid — fallback path is not engaged, so even a broken
+		// cookie should not matter. This guards against regressions where
+		// someone accidentally starts consulting the cookie on the happy path.
+		validHeaderToken, _ := generateTestToken(secret, time.Now().Add(time.Hour))
+		brokenCookieToken, _ := generateTestToken("WRONG-SECRET", time.Now().Add(time.Hour))
+
+		req := httptest.NewRequest("GET", "/protected", nil)
+		req.Header.Set("Authorization", "Bearer "+validHeaderToken)
+		req.AddCookie(&http.Cookie{Name: jwtCookieName, Value: brokenCookieToken})
+
+		resp, err := app.Test(req, 5000)
+		assert.NoError(t, err)
+		assert.Equal(t, 200, resp.StatusCode)
+	})
 }
 
 func TestValidateJWT(t *testing.T) {


### PR DESCRIPTION
## Summary

Bundles three backend security fixes targeting RBAC, session lifecycle, and authentication flow. All three are small, targeted changes with unit tests; no frontend changes.

### #6022 — GitOps endpoints lack RBAC (editor-or-admin for mutations)

Mutating GitOps endpoints are now gated by a shared `requireEditorOrAdmin` helper extracted to `pkg/api/handlers/auth_helpers.go` (new file). The legacy admin-only helper inside `gitops.go` was removed, and drift detection is now gated as viewer-or-above (it is read-oriented but still sensitive).

Gated endpoints:
- `POST /api/gitops/sync` — editor-or-admin
- `POST /api/gitops/helm-upgrade` — editor-or-admin
- `POST /api/gitops/helm-uninstall` — editor-or-admin
- `POST /api/gitops/helm-rollback` — editor-or-admin
- `POST /api/gitops/argocd/sync` — editor-or-admin
- `POST /api/gitops/detect-drift` — viewer-or-above

The shared helper takes a `store.Store` so it can be reused by any handler without refactoring existing handler structs (the `CardHandler.requireEditorOrAdmin` method in `cards.go` is left alone to avoid unrelated churn).

### #6024 — Exec sessions usable after logout

`/ws/exec` did not participate in the WebSocket Hub, so `Hub.DisconnectUser(userID)` in Logout could not reach exec sessions. The exec handler now registers its stream context cancel func in a per-user registry (`execSessions` map guarded by a `sync.Mutex`). On normal session end a deferred cleanup removes the entry so the registry stays bounded by live session count, not lifetime count.

`Logout` calls the new exported `CancelUserExecSessions(userID)` after `wsHub.DisconnectUser`. That unblocks `executor.StreamWithContext`, which in turn causes the WebSocket read loop to exit and close the connection.

### #6026 — Stale Authorization header overrides cookie

`JWTAuth` middleware unconditionally preferred the `Authorization` header. If the header token was stale (happens after silent refresh — in-flight requests may still carry the old bearer value), the middleware returned 401 even when the `kc_auth` cookie held a valid token.

Fix: if header parse fails AND a `kc_auth` cookie is present AND the cookie parses successfully, use the cookie. Only engaged on header-parse failure, so the valid-header happy path is unchanged. Added an inline comment explaining the scenario for future readers.

## Implementation notes

- **Shared helpers**: `pkg/api/handlers/auth_helpers.go` (new) holds `requireEditorOrAdmin` and `requireViewerOrAbove` as package-level functions taking a `store.Store` parameter. This lets gitops reuse the logic without embedding a base struct and without touching cards.go (which still has its own handler-method form).
- **Exec registry**: `sync.Mutex` (not RWMutex) as requested — add/remove/cancel are all infrequent and short. Map layout is `map[uuid.UUID]map[int64]context.CancelFunc` so unregister by session id works without iterating.
- **No magic numbers**: `testExecCancelWait = 250 * time.Millisecond` and `statusPastRBAC = http.StatusBadRequest` are the only new constants; both named.
- **No backwards-compat shims**: the old `GitOpsHandlers.requireAdmin` method was deleted, not wrapped. Its imports (`middleware`, `models`) were also pruned from gitops.go.

## Test plan

- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] `go test ./pkg/... -count=1` passes (all packages green, including 12 new/updated tests across `gitops_test.go`, `exec_test.go`, `auth_test.go`)
- [x] `cd web && npm run build` passes including post-build safety checks
- [ ] Manual: login as viewer, POST `/api/gitops/sync` → 403
- [ ] Manual: login as editor, POST `/api/gitops/sync` → reaches body validation
- [ ] Manual: open `/ws/exec`, `POST /auth/logout` in another tab, verify shell dies
- [ ] Manual: send request with stale bearer header + fresh cookie → 200

Fixes #6022
Fixes #6024
Fixes #6026