### PR TITLE
feat(rewards+token-usage): backend persistence for user coin/points and token counters

### DIFF
--- a/pkg/api/handlers/rewards_persistence.go
+++ b/pkg/api/handlers/rewards_persistence.go
@@ -1,0 +1,250 @@
+package handlers
+
+import (
+	"errors"
+	"time"
+
+	"github.com/gofiber/fiber/v2"
+
+	"github.com/kubestellar/console/pkg/api/middleware"
+	"github.com/kubestellar/console/pkg/store"
+)
+
+// --- Rewards persistence constants (issue #6011) -----------------------------
+//
+// These values are extracted as named constants to keep the API behavior
+// explicit and to comply with the repo-wide "no magic numbers" rule. They
+// control daily-bonus cadence, the maximum coin delta a single POST can
+// apply, and the payload size ceilings accepted on the PUT endpoint.
+
+const (
+	// dailyBonusIntervalHours is how long users must wait between
+	// /api/rewards/daily-bonus claims. 24h mirrors the frontend copy.
+	dailyBonusIntervalHours = 24
+	// dailyBonusPoints is the default bonus amount awarded when the user
+	// successfully claims their daily bonus. Kept on the server so the
+	// reward scale is not client-controlled.
+	dailyBonusPoints = 50
+	// maxCoinDeltaPerRequest caps how many coins a single POST /coins call
+	// can add or subtract. This is defense-in-depth against a buggy or
+	// compromised client trying to mint an unbounded balance in one shot;
+	// the legitimate frontend values are in the tens.
+	maxCoinDeltaPerRequest = 10_000
+	// maxRewardFieldValue is the upper bound enforced on coins/points/level
+	// /bonus_points in the PUT endpoint payload. Any sensible balance is
+	// far below this.
+	maxRewardFieldValue = 100_000_000
+)
+
+// RewardsPersistenceHandler serves the per-user reward balance endpoints
+// backing issue #6011. Unlike RewardsHandler (which proxies GitHub activity),
+// this handler owns mutable server-side state that survives cache clears.
+type RewardsPersistenceHandler struct {
+	store store.Store
+}
+
+// NewRewardsPersistenceHandler wires the handler up to the backing store.
+func NewRewardsPersistenceHandler(s store.Store) *RewardsPersistenceHandler {
+	return &RewardsPersistenceHandler{store: s}
+}
+
+// userRewardsResponse is the JSON shape returned to the frontend. We use
+// snake_case fields to match other API responses in this package and omit
+// the LastDailyBonusAt field entirely when the user has never claimed.
+type userRewardsResponse struct {
+	UserID           string `json:"user_id"`
+	Coins            int    `json:"coins"`
+	Points           int    `json:"points"`
+	Level            int    `json:"level"`
+	BonusPoints      int    `json:"bonus_points"`
+	LastDailyBonusAt string `json:"last_daily_bonus_at,omitempty"`
+	UpdatedAt        string `json:"updated_at"`
+}
+
+func toResponse(r *store.UserRewards) userRewardsResponse {
+	resp := userRewardsResponse{
+		UserID:      r.UserID,
+		Coins:       r.Coins,
+		Points:      r.Points,
+		Level:       r.Level,
+		BonusPoints: r.BonusPoints,
+		UpdatedAt:   r.UpdatedAt.UTC().Format(time.RFC3339),
+	}
+	if r.LastDailyBonusAt != nil {
+		resp.LastDailyBonusAt = r.LastDailyBonusAt.UTC().Format(time.RFC3339)
+	}
+	return resp
+}
+
+// resolveRewardsUserID returns the stable reward key for the current request.
+// We prefer the user's UUID; if the UUID is the zero value (e.g. demo-mode
+// sessions where no DB user row exists) we fall back to the GitHub login.
+// An empty return means the request is unauthenticated and the handler
+// should respond with 401.
+func resolveRewardsUserID(c *fiber.Ctx) string {
+	if id := middleware.GetUserID(c); id.String() != "00000000-0000-0000-0000-000000000000" {
+		return id.String()
+	}
+	if login := middleware.GetGitHubLogin(c); login != "" {
+		return login
+	}
+	return ""
+}
+
+// GetUserRewards returns the current user's persisted reward balance.
+// GET /api/rewards/me
+//
+// Zero-value responses are intentional for brand-new users — clients should
+// treat the absence of a stored row as "start at 0" without needing an
+// error-handling branch.
+func (h *RewardsPersistenceHandler) GetUserRewards(c *fiber.Ctx) error {
+	userID := resolveRewardsUserID(c)
+	if userID == "" {
+		return c.Status(fiber.StatusUnauthorized).JSON(fiber.Map{"error": "not authenticated"})
+	}
+
+	rewards, err := h.store.GetUserRewards(userID)
+	if err != nil {
+		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{"error": "failed to load rewards"})
+	}
+	return c.JSON(toResponse(rewards))
+}
+
+// putUserRewardsRequest is the request body for PUT /api/rewards/me. All
+// fields are optional; missing fields default to zero so clients can use
+// this endpoint to replace partial state without re-sending the whole row.
+type putUserRewardsRequest struct {
+	Coins       int `json:"coins"`
+	Points      int `json:"points"`
+	Level       int `json:"level"`
+	BonusPoints int `json:"bonus_points"`
+}
+
+// UpdateUserRewards upserts the entire reward row for the current user.
+// PUT /api/rewards/me
+//
+// Idempotent — callers send their full desired state (typically mirrored
+// from their local hydrated state) and the server replaces the row.
+func (h *RewardsPersistenceHandler) UpdateUserRewards(c *fiber.Ctx) error {
+	userID := resolveRewardsUserID(c)
+	if userID == "" {
+		return c.Status(fiber.StatusUnauthorized).JSON(fiber.Map{"error": "not authenticated"})
+	}
+
+	var body putUserRewardsRequest
+	if err := c.BodyParser(&body); err != nil {
+		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"error": "invalid JSON body"})
+	}
+
+	// Input validation — clamp to sane ranges so a misbehaving client cannot
+	// poison the DB with absurd balances.
+	if body.Coins < store.MinCoinBalance || body.Coins > maxRewardFieldValue {
+		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"error": "coins out of range"})
+	}
+	if body.Points < 0 || body.Points > maxRewardFieldValue {
+		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"error": "points out of range"})
+	}
+	if body.Level < store.DefaultUserLevel || body.Level > maxRewardFieldValue {
+		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"error": "level out of range"})
+	}
+	if body.BonusPoints < 0 || body.BonusPoints > maxRewardFieldValue {
+		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"error": "bonus_points out of range"})
+	}
+
+	// Preserve LastDailyBonusAt from the existing row so this endpoint does
+	// NOT become a way to reset the daily-bonus cooldown.
+	existing, err := h.store.GetUserRewards(userID)
+	if err != nil {
+		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{"error": "failed to load rewards"})
+	}
+
+	rewards := &store.UserRewards{
+		UserID:           userID,
+		Coins:            body.Coins,
+		Points:           body.Points,
+		Level:            body.Level,
+		BonusPoints:      body.BonusPoints,
+		LastDailyBonusAt: existing.LastDailyBonusAt,
+	}
+	if err := h.store.UpdateUserRewards(rewards); err != nil {
+		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{"error": "failed to save rewards"})
+	}
+
+	// Re-read to return canonical server-side state (including the fresh
+	// updated_at timestamp the store assigned).
+	fresh, err := h.store.GetUserRewards(userID)
+	if err != nil {
+		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{"error": "failed to reload rewards"})
+	}
+	return c.JSON(toResponse(fresh))
+}
+
+// postCoinsRequest is the body for POST /api/rewards/coins. Delta is a
+// signed 32-bit-fits integer — clients can subtract by sending a negative
+// value, subject to the MinCoinBalance clamp.
+type postCoinsRequest struct {
+	Delta int `json:"delta"`
+}
+
+// IncrementCoins atomically applies a delta to the current user's coin
+// balance. POST /api/rewards/coins
+func (h *RewardsPersistenceHandler) IncrementCoins(c *fiber.Ctx) error {
+	userID := resolveRewardsUserID(c)
+	if userID == "" {
+		return c.Status(fiber.StatusUnauthorized).JSON(fiber.Map{"error": "not authenticated"})
+	}
+
+	var body postCoinsRequest
+	if err := c.BodyParser(&body); err != nil {
+		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"error": "invalid JSON body"})
+	}
+	if body.Delta == 0 {
+		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"error": "delta must be non-zero"})
+	}
+	if body.Delta > maxCoinDeltaPerRequest || body.Delta < -maxCoinDeltaPerRequest {
+		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"error": "delta exceeds per-request limit"})
+	}
+
+	updated, err := h.store.IncrementUserCoins(userID, body.Delta)
+	if err != nil {
+		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{"error": "failed to increment coins"})
+	}
+	return c.JSON(toResponse(updated))
+}
+
+// ClaimDailyBonus awards the daily bonus if the cooldown has elapsed.
+// POST /api/rewards/daily-bonus
+//
+// Returns 429 with a structured error when the bonus is on cooldown so the
+// frontend can render a "next claim available in X" message without a
+// second round-trip.
+func (h *RewardsPersistenceHandler) ClaimDailyBonus(c *fiber.Ctx) error {
+	userID := resolveRewardsUserID(c)
+	if userID == "" {
+		return c.Status(fiber.StatusUnauthorized).JSON(fiber.Map{"error": "not authenticated"})
+	}
+
+	interval := time.Duration(dailyBonusIntervalHours) * time.Hour
+	updated, err := h.store.ClaimDailyBonus(userID, dailyBonusPoints, interval, time.Now())
+	if err != nil {
+		if errors.Is(err, store.ErrDailyBonusUnavailable) {
+			// Surface the current state so the UI can still render the
+			// existing balances and the timestamp of the last claim.
+			current, getErr := h.store.GetUserRewards(userID)
+			if getErr == nil {
+				resp := toResponse(current)
+				return c.Status(fiber.StatusTooManyRequests).JSON(fiber.Map{
+					"error":   "daily bonus already claimed",
+					"rewards": resp,
+				})
+			}
+			return c.Status(fiber.StatusTooManyRequests).JSON(fiber.Map{"error": "daily bonus already claimed"})
+		}
+		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{"error": "failed to claim daily bonus"})
+	}
+
+	return c.JSON(fiber.Map{
+		"rewards":      toResponse(updated),
+		"bonus_amount": dailyBonusPoints,
+	})
+}

--- a/pkg/api/handlers/rewards_persistence_test.go
+++ b/pkg/api/handlers/rewards_persistence_test.go
@@ -1,0 +1,255 @@
+package handlers
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"path/filepath"
+	"testing"
+
+	"github.com/gofiber/fiber/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/kubestellar/console/pkg/store"
+)
+
+// testRewardsFiberTimeoutMs is the read timeout (ms) used when invoking the
+// Fiber test router. 5 seconds is the same value the GPU handler tests use.
+const testRewardsFiberTimeoutMs = 5000
+
+// newRewardsTestApp builds a Fiber app backed by a real on-disk SQLite
+// store and wired to the persistence handlers. Tests run against real
+// SQL so the prepared statements, schema, and transaction logic are all
+// exercised end-to-end (the mock-store path is covered separately by the
+// store tests themselves).
+func newRewardsTestApp(t *testing.T) (*fiber.App, store.Store, string) {
+	t.Helper()
+	dbPath := filepath.Join(t.TempDir(), "rewards-test.db")
+	sqlStore, err := store.NewSQLiteStore(dbPath)
+	require.NoError(t, err)
+	t.Cleanup(func() { sqlStore.Close() })
+
+	const testUserID = "rewards-handler-user"
+
+	app := fiber.New()
+	// Inject a stable reward key into locals for every request so the
+	// handler's resolver short-circuits on the GitHub-login branch (the
+	// UUID zero-check then falls through to "githubLogin").
+	app.Use(func(c *fiber.Ctx) error {
+		c.Locals("githubLogin", testUserID)
+		return c.Next()
+	})
+
+	h := NewRewardsPersistenceHandler(sqlStore)
+	app.Get("/api/rewards/me", h.GetUserRewards)
+	app.Put("/api/rewards/me", h.UpdateUserRewards)
+	app.Post("/api/rewards/coins", h.IncrementCoins)
+	app.Post("/api/rewards/daily-bonus", h.ClaimDailyBonus)
+
+	return app, sqlStore, testUserID
+}
+
+func decodeRewardsResponse(t *testing.T, resp *http.Response) userRewardsResponse {
+	t.Helper()
+	defer resp.Body.Close()
+	var body userRewardsResponse
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&body))
+	return body
+}
+
+func TestRewardsHandler_GetReturnsZeroForNewUser(t *testing.T) {
+	app, _, userID := newRewardsTestApp(t)
+
+	req, err := http.NewRequest(http.MethodGet, "/api/rewards/me", nil)
+	require.NoError(t, err)
+	resp, err := app.Test(req, testRewardsFiberTimeoutMs)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	body := decodeRewardsResponse(t, resp)
+	assert.Equal(t, userID, body.UserID)
+	assert.Equal(t, 0, body.Coins)
+	assert.Equal(t, 0, body.Points)
+	assert.Equal(t, store.DefaultUserLevel, body.Level)
+	assert.Equal(t, 0, body.BonusPoints)
+	assert.Empty(t, body.LastDailyBonusAt)
+}
+
+func TestRewardsHandler_PutThenGetRoundTrip(t *testing.T) {
+	app, _, _ := newRewardsTestApp(t)
+
+	const (
+		wantCoins  = 75
+		wantPoints = 200
+		wantLevel  = 4
+		wantBonus  = 10
+	)
+
+	payload, err := json.Marshal(map[string]int{
+		"coins":        wantCoins,
+		"points":       wantPoints,
+		"level":        wantLevel,
+		"bonus_points": wantBonus,
+	})
+	require.NoError(t, err)
+
+	putReq, err := http.NewRequest(http.MethodPut, "/api/rewards/me", bytes.NewReader(payload))
+	require.NoError(t, err)
+	putReq.Header.Set("Content-Type", "application/json")
+	putResp, err := app.Test(putReq, testRewardsFiberTimeoutMs)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, putResp.StatusCode)
+	putBody := decodeRewardsResponse(t, putResp)
+	assert.Equal(t, wantCoins, putBody.Coins)
+
+	getReq, err := http.NewRequest(http.MethodGet, "/api/rewards/me", nil)
+	require.NoError(t, err)
+	getResp, err := app.Test(getReq, testRewardsFiberTimeoutMs)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, getResp.StatusCode)
+	getBody := decodeRewardsResponse(t, getResp)
+	assert.Equal(t, wantCoins, getBody.Coins)
+	assert.Equal(t, wantPoints, getBody.Points)
+	assert.Equal(t, wantLevel, getBody.Level)
+	assert.Equal(t, wantBonus, getBody.BonusPoints)
+}
+
+func TestRewardsHandler_PutRejectsOutOfRangeValues(t *testing.T) {
+	app, _, _ := newRewardsTestApp(t)
+
+	const negativeCoins = -10
+	payload, err := json.Marshal(map[string]int{"coins": negativeCoins})
+	require.NoError(t, err)
+
+	req, err := http.NewRequest(http.MethodPut, "/api/rewards/me", bytes.NewReader(payload))
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := app.Test(req, testRewardsFiberTimeoutMs)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+}
+
+func TestRewardsHandler_PostCoinsIncrementsCorrectly(t *testing.T) {
+	app, _, _ := newRewardsTestApp(t)
+
+	const firstDelta = 10
+	const secondDelta = 5
+	const wantAfterTwoCalls = firstDelta + secondDelta
+
+	postDelta := func(delta int) userRewardsResponse {
+		payload, err := json.Marshal(map[string]int{"delta": delta})
+		require.NoError(t, err)
+		req, err := http.NewRequest(http.MethodPost, "/api/rewards/coins", bytes.NewReader(payload))
+		require.NoError(t, err)
+		req.Header.Set("Content-Type", "application/json")
+		resp, err := app.Test(req, testRewardsFiberTimeoutMs)
+		require.NoError(t, err)
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+		return decodeRewardsResponse(t, resp)
+	}
+
+	first := postDelta(firstDelta)
+	assert.Equal(t, firstDelta, first.Coins)
+	second := postDelta(secondDelta)
+	assert.Equal(t, wantAfterTwoCalls, second.Coins)
+}
+
+func TestRewardsHandler_PostCoinsNegativeDoesNotDriveBelowZero(t *testing.T) {
+	app, _, _ := newRewardsTestApp(t)
+
+	// Starting balance is zero; a -5 delta should clamp to MinCoinBalance.
+	const subtract = -5
+	payload, err := json.Marshal(map[string]int{"delta": subtract})
+	require.NoError(t, err)
+	req, err := http.NewRequest(http.MethodPost, "/api/rewards/coins", bytes.NewReader(payload))
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := app.Test(req, testRewardsFiberTimeoutMs)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	body := decodeRewardsResponse(t, resp)
+	assert.Equal(t, store.MinCoinBalance, body.Coins)
+}
+
+func TestRewardsHandler_PostCoinsRejectsZeroDelta(t *testing.T) {
+	app, _, _ := newRewardsTestApp(t)
+
+	payload, err := json.Marshal(map[string]int{"delta": 0})
+	require.NoError(t, err)
+	req, err := http.NewRequest(http.MethodPost, "/api/rewards/coins", bytes.NewReader(payload))
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := app.Test(req, testRewardsFiberTimeoutMs)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+}
+
+func TestRewardsHandler_PostCoinsRejectsOversizedDelta(t *testing.T) {
+	app, _, _ := newRewardsTestApp(t)
+
+	// One above the per-request ceiling
+	payload, err := json.Marshal(map[string]int{"delta": maxCoinDeltaPerRequest + 1})
+	require.NoError(t, err)
+	req, err := http.NewRequest(http.MethodPost, "/api/rewards/coins", bytes.NewReader(payload))
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := app.Test(req, testRewardsFiberTimeoutMs)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+}
+
+func TestRewardsHandler_DailyBonusFirstClaimSucceeds(t *testing.T) {
+	app, _, _ := newRewardsTestApp(t)
+
+	req, err := http.NewRequest(http.MethodPost, "/api/rewards/daily-bonus", nil)
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := app.Test(req, testRewardsFiberTimeoutMs)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+}
+
+// TestRewardsHandler_DailyBonusSecondClaimReturns429 exercises the cooldown
+// enforcement via the real SQLite store. Because ClaimDailyBonus is called
+// with time.Now() inside the handler we cannot time-travel here, so this
+// test relies on the second call happening within milliseconds of the
+// first — which is well below the dailyBonusIntervalHours window.
+func TestRewardsHandler_DailyBonusSecondClaimReturns429(t *testing.T) {
+	app, _, _ := newRewardsTestApp(t)
+
+	req1, err := http.NewRequest(http.MethodPost, "/api/rewards/daily-bonus", nil)
+	require.NoError(t, err)
+	resp1, err := app.Test(req1, testRewardsFiberTimeoutMs)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, resp1.StatusCode)
+	resp1.Body.Close()
+
+	req2, err := http.NewRequest(http.MethodPost, "/api/rewards/daily-bonus", nil)
+	require.NoError(t, err)
+	resp2, err := app.Test(req2, testRewardsFiberTimeoutMs)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusTooManyRequests, resp2.StatusCode)
+	resp2.Body.Close()
+}
+
+func TestRewardsHandler_UnauthenticatedReturns401(t *testing.T) {
+	// Build an app WITHOUT the githubLogin middleware so the resolver
+	// returns an empty string and every endpoint should answer 401.
+	dbPath := filepath.Join(t.TempDir(), "rewards-unauth.db")
+	sqlStore, err := store.NewSQLiteStore(dbPath)
+	require.NoError(t, err)
+	t.Cleanup(func() { sqlStore.Close() })
+
+	app := fiber.New()
+	h := NewRewardsPersistenceHandler(sqlStore)
+	app.Get("/api/rewards/me", h.GetUserRewards)
+	app.Put("/api/rewards/me", h.UpdateUserRewards)
+	app.Post("/api/rewards/coins", h.IncrementCoins)
+	app.Post("/api/rewards/daily-bonus", h.ClaimDailyBonus)
+
+	getReq, _ := http.NewRequest(http.MethodGet, "/api/rewards/me", nil)
+	resp, err := app.Test(getReq, testRewardsFiberTimeoutMs)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusUnauthorized, resp.StatusCode)
+}

--- a/pkg/api/handlers/token_usage.go
+++ b/pkg/api/handlers/token_usage.go
@@ -1,0 +1,205 @@
+package handlers
+
+import (
+	"time"
+
+	"github.com/gofiber/fiber/v2"
+
+	"github.com/kubestellar/console/pkg/api/middleware"
+	"github.com/kubestellar/console/pkg/store"
+)
+
+// zeroTokenUserUUID is the all-zeros UUID that middleware.GetUserID returns
+// when no DB user row exists (demo-mode / unauth sessions). Declared here
+// rather than shared with rewards_persistence.go so the two handler files
+// can evolve independently without a cross-file constant dependency.
+const zeroTokenUserUUID = "00000000-0000-0000-0000-000000000000"
+
+// --- Token usage persistence constants --------------------------------------
+//
+// Folded into PR #6032 as a follow-up to #6011: the rewards widget keeps
+// its coin/point state in a server-side table, and this handler gives the
+// token-budget widget the same treatment. Every literal here is a named
+// constant per the repo-wide "no magic numbers" rule.
+
+const (
+	// maxTokenDeltaPerRequest caps how many tokens a single POST /delta
+	// call can add in one shot. The legitimate frontend delta per-poll is
+	// on the order of thousands; 1M is defense-in-depth against a buggy
+	// or compromised client trying to inflate a user's usage in one call.
+	maxTokenDeltaPerRequest int64 = 1_000_000
+	// maxTokenUsageFieldValue is the upper bound on the TotalTokens field
+	// of the PUT endpoint payload. 10 billion tokens is orders of
+	// magnitude larger than any realistic monthly budget and acts as a
+	// sanity ceiling so a corrupted client cannot poison the DB.
+	maxTokenUsageFieldValue int64 = 10_000_000_000
+	// maxTokenCategories is the ceiling on how many distinct category
+	// keys a single PUT payload may carry. The frontend currently knows
+	// about 5 categories (missions, diagnose, insights, predictions,
+	// other); 32 leaves plenty of room for growth without letting a
+	// malicious client create arbitrary string keys.
+	maxTokenCategories = 32
+)
+
+// TokenUsageHandler serves the per-user token-usage endpoints backing the
+// token-budget widget. Each user can read and mutate only their own row —
+// there is no cross-user RBAC gate because every query is scoped by the
+// JWT-resolved user id.
+type TokenUsageHandler struct {
+	store store.Store
+}
+
+// NewTokenUsageHandler wires the handler up to the backing store.
+func NewTokenUsageHandler(s store.Store) *TokenUsageHandler {
+	return &TokenUsageHandler{store: s}
+}
+
+// userTokenUsageResponse is the JSON shape returned to the frontend. snake_
+// case fields match the rest of the API surface in this package.
+type userTokenUsageResponse struct {
+	UserID             string           `json:"user_id"`
+	TotalTokens        int64            `json:"total_tokens"`
+	TokensByCategory   map[string]int64 `json:"tokens_by_category"`
+	LastAgentSessionID string           `json:"last_agent_session_id"`
+	UpdatedAt          string           `json:"updated_at"`
+}
+
+func toTokenUsageResponse(u *store.UserTokenUsage) userTokenUsageResponse {
+	// Always materialize a non-nil map so the frontend can treat the
+	// response as a JS object without a null-check dance.
+	cats := u.TokensByCategory
+	if cats == nil {
+		cats = map[string]int64{}
+	}
+	return userTokenUsageResponse{
+		UserID:             u.UserID,
+		TotalTokens:        u.TotalTokens,
+		TokensByCategory:   cats,
+		LastAgentSessionID: u.LastAgentSessionID,
+		UpdatedAt:          u.UpdatedAt.UTC().Format(time.RFC3339),
+	}
+}
+
+// resolveTokenUsageUserID mirrors resolveRewardsUserID (in
+// rewards_persistence.go) — prefer the user's UUID, fall back to the GitHub
+// login for demo-mode sessions where no DB user row exists. An empty return
+// means the request is unauthenticated and the handler should answer 401.
+func resolveTokenUsageUserID(c *fiber.Ctx) string {
+	if id := middleware.GetUserID(c); id.String() != zeroTokenUserUUID {
+		return id.String()
+	}
+	if login := middleware.GetGitHubLogin(c); login != "" {
+		return login
+	}
+	return ""
+}
+
+// GetUserTokenUsage returns the current user's persisted token-usage row.
+// GET /api/token-usage/me
+func (h *TokenUsageHandler) GetUserTokenUsage(c *fiber.Ctx) error {
+	userID := resolveTokenUsageUserID(c)
+	if userID == "" {
+		return c.Status(fiber.StatusUnauthorized).JSON(fiber.Map{"error": "not authenticated"})
+	}
+
+	usage, err := h.store.GetUserTokenUsage(userID)
+	if err != nil {
+		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{"error": "failed to load token usage"})
+	}
+	return c.JSON(toTokenUsageResponse(usage))
+}
+
+// putUserTokenUsageRequest is the request body for POST /api/token-usage/me.
+// Clients send their full desired state — typically mirrored from their
+// locally-hydrated totals — and the server replaces the row.
+type putUserTokenUsageRequest struct {
+	TotalTokens        int64            `json:"total_tokens"`
+	TokensByCategory   map[string]int64 `json:"tokens_by_category"`
+	LastAgentSessionID string           `json:"last_agent_session_id"`
+}
+
+// UpdateUserTokenUsage upserts the entire token-usage row for the current
+// user. POST /api/token-usage/me (semantic: full upsert, idempotent).
+func (h *TokenUsageHandler) UpdateUserTokenUsage(c *fiber.Ctx) error {
+	userID := resolveTokenUsageUserID(c)
+	if userID == "" {
+		return c.Status(fiber.StatusUnauthorized).JSON(fiber.Map{"error": "not authenticated"})
+	}
+
+	var body putUserTokenUsageRequest
+	if err := c.BodyParser(&body); err != nil {
+		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"error": "invalid JSON body"})
+	}
+
+	if body.TotalTokens < 0 || body.TotalTokens > maxTokenUsageFieldValue {
+		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"error": "total_tokens out of range"})
+	}
+	if len(body.TokensByCategory) > maxTokenCategories {
+		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"error": "too many category keys"})
+	}
+	for _, v := range body.TokensByCategory {
+		if v < 0 || v > maxTokenUsageFieldValue {
+			return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"error": "per-category value out of range"})
+		}
+	}
+
+	usage := &store.UserTokenUsage{
+		UserID:             userID,
+		TotalTokens:        body.TotalTokens,
+		TokensByCategory:   body.TokensByCategory,
+		LastAgentSessionID: body.LastAgentSessionID,
+	}
+	if err := h.store.UpdateUserTokenUsage(usage); err != nil {
+		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{"error": "failed to save token usage"})
+	}
+
+	fresh, err := h.store.GetUserTokenUsage(userID)
+	if err != nil {
+		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{"error": "failed to reload token usage"})
+	}
+	return c.JSON(toTokenUsageResponse(fresh))
+}
+
+// postTokenDeltaRequest is the body for POST /api/token-usage/delta. The
+// delta field is always non-negative — subtraction is not a legitimate
+// operation for usage counters (a "rollback" on error is handled client-
+// side by withholding the attribution, not by sending a negative number).
+type postTokenDeltaRequest struct {
+	Category       string `json:"category"`
+	Delta          int64  `json:"delta"`
+	AgentSessionID string `json:"agent_session_id"`
+}
+
+// AddTokenDelta atomically adds a delta to the current user's total and
+// per-category counters. POST /api/token-usage/delta
+//
+// Restart semantics: if agent_session_id is non-empty and differs from the
+// stored marker, the server treats the delta as the first of a new session
+// and does NOT add it to the totals — mirroring the frontend's existing
+// restart-detection logic so both sides stay in agreement.
+func (h *TokenUsageHandler) AddTokenDelta(c *fiber.Ctx) error {
+	userID := resolveTokenUsageUserID(c)
+	if userID == "" {
+		return c.Status(fiber.StatusUnauthorized).JSON(fiber.Map{"error": "not authenticated"})
+	}
+
+	var body postTokenDeltaRequest
+	if err := c.BodyParser(&body); err != nil {
+		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"error": "invalid JSON body"})
+	}
+	if body.Category == "" {
+		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"error": "category is required"})
+	}
+	if body.Delta < 0 {
+		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"error": "delta must be non-negative"})
+	}
+	if body.Delta > maxTokenDeltaPerRequest {
+		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"error": "delta exceeds per-request limit"})
+	}
+
+	updated, err := h.store.AddUserTokenDelta(userID, body.Category, body.Delta, body.AgentSessionID)
+	if err != nil {
+		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{"error": "failed to add token delta"})
+	}
+	return c.JSON(toTokenUsageResponse(updated))
+}

--- a/pkg/api/handlers/token_usage_test.go
+++ b/pkg/api/handlers/token_usage_test.go
@@ -1,0 +1,215 @@
+package handlers
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"path/filepath"
+	"testing"
+
+	"github.com/gofiber/fiber/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/kubestellar/console/pkg/store"
+)
+
+// testTokenUsageFiberTimeoutMs mirrors the rewards handler tests so the
+// Fiber router gives the SQLite read enough time on slow CI runners.
+const testTokenUsageFiberTimeoutMs = 5000
+
+// newTokenUsageTestApp builds a Fiber app backed by an on-disk SQLite store
+// wired to the token-usage handler. The auth shim sets a stable githubLogin
+// local so resolveTokenUsageUserID returns the dev-mode user id.
+func newTokenUsageTestApp(t *testing.T) (*fiber.App, store.Store, string) {
+	t.Helper()
+	dbPath := filepath.Join(t.TempDir(), "token-usage-test.db")
+	sqlStore, err := store.NewSQLiteStore(dbPath)
+	require.NoError(t, err)
+	t.Cleanup(func() { sqlStore.Close() })
+
+	const testUserID = "token-usage-handler-user"
+
+	app := fiber.New()
+	app.Use(func(c *fiber.Ctx) error {
+		c.Locals("githubLogin", testUserID)
+		return c.Next()
+	})
+
+	h := NewTokenUsageHandler(sqlStore)
+	app.Get("/api/token-usage/me", h.GetUserTokenUsage)
+	app.Post("/api/token-usage/me", h.UpdateUserTokenUsage)
+	app.Post("/api/token-usage/delta", h.AddTokenDelta)
+
+	return app, sqlStore, testUserID
+}
+
+func decodeTokenUsageResponse(t *testing.T, resp *http.Response) userTokenUsageResponse {
+	t.Helper()
+	defer resp.Body.Close()
+	var body userTokenUsageResponse
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&body))
+	return body
+}
+
+func TestTokenUsageHandler_GetReturnsZeroForNewUser(t *testing.T) {
+	app, _, _ := newTokenUsageTestApp(t)
+
+	req, _ := http.NewRequest(http.MethodGet, "/api/token-usage/me", nil)
+	resp, err := app.Test(req, testTokenUsageFiberTimeoutMs)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	got := decodeTokenUsageResponse(t, resp)
+	assert.Equal(t, int64(0), got.TotalTokens)
+	assert.NotNil(t, got.TokensByCategory)
+	assert.Equal(t, 0, len(got.TokensByCategory))
+	assert.Equal(t, "", got.LastAgentSessionID)
+}
+
+func TestTokenUsageHandler_PutThenGetRoundTrip(t *testing.T) {
+	app, _, _ := newTokenUsageTestApp(t)
+
+	const wantTotal int64 = 1234
+	const wantMissions int64 = 800
+	const wantDiagnose int64 = 434
+	body := putUserTokenUsageRequest{
+		TotalTokens: wantTotal,
+		TokensByCategory: map[string]int64{
+			"missions": wantMissions,
+			"diagnose": wantDiagnose,
+		},
+		LastAgentSessionID: "session-put-1",
+	}
+	raw, _ := json.Marshal(body)
+	req, _ := http.NewRequest(http.MethodPost, "/api/token-usage/me", bytes.NewReader(raw))
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := app.Test(req, testTokenUsageFiberTimeoutMs)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	got := decodeTokenUsageResponse(t, resp)
+	assert.Equal(t, wantTotal, got.TotalTokens)
+	assert.Equal(t, wantMissions, got.TokensByCategory["missions"])
+	assert.Equal(t, wantDiagnose, got.TokensByCategory["diagnose"])
+
+	// Re-fetch and confirm persistence.
+	getReq, _ := http.NewRequest(http.MethodGet, "/api/token-usage/me", nil)
+	getResp, err := app.Test(getReq, testTokenUsageFiberTimeoutMs)
+	require.NoError(t, err)
+	got2 := decodeTokenUsageResponse(t, getResp)
+	assert.Equal(t, wantTotal, got2.TotalTokens)
+	assert.Equal(t, "session-put-1", got2.LastAgentSessionID)
+}
+
+func TestTokenUsageHandler_DeltaIncrementsAtomically(t *testing.T) {
+	app, _, _ := newTokenUsageTestApp(t)
+
+	const delta1 int64 = 50
+	const delta2 int64 = 75
+	for _, d := range []int64{delta1, delta2} {
+		body, _ := json.Marshal(postTokenDeltaRequest{
+			Category:       "missions",
+			Delta:          d,
+			AgentSessionID: "session-delta-1",
+		})
+		req, _ := http.NewRequest(http.MethodPost, "/api/token-usage/delta", bytes.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		resp, err := app.Test(req, testTokenUsageFiberTimeoutMs)
+		require.NoError(t, err)
+		require.Equal(t, http.StatusOK, resp.StatusCode, "delta %d", d)
+		resp.Body.Close()
+	}
+
+	getReq, _ := http.NewRequest(http.MethodGet, "/api/token-usage/me", nil)
+	getResp, err := app.Test(getReq, testTokenUsageFiberTimeoutMs)
+	require.NoError(t, err)
+	got := decodeTokenUsageResponse(t, getResp)
+	assert.Equal(t, delta1+delta2, got.TotalTokens)
+	assert.Equal(t, delta1+delta2, got.TokensByCategory["missions"])
+}
+
+func TestTokenUsageHandler_DeltaSessionChangeSkipsAdd(t *testing.T) {
+	app, _, _ := newTokenUsageTestApp(t)
+
+	const delta1 int64 = 100
+	const delta2 int64 = 250
+
+	// Establish session A and accumulate delta1.
+	body1, _ := json.Marshal(postTokenDeltaRequest{
+		Category:       "missions",
+		Delta:          delta1,
+		AgentSessionID: "session-A",
+	})
+	req1, _ := http.NewRequest(http.MethodPost, "/api/token-usage/delta", bytes.NewReader(body1))
+	req1.Header.Set("Content-Type", "application/json")
+	resp1, err := app.Test(req1, testTokenUsageFiberTimeoutMs)
+	require.NoError(t, err)
+	resp1.Body.Close()
+
+	// Switch to session B — server must NOT add delta2 to the totals.
+	body2, _ := json.Marshal(postTokenDeltaRequest{
+		Category:       "missions",
+		Delta:          delta2,
+		AgentSessionID: "session-B",
+	})
+	req2, _ := http.NewRequest(http.MethodPost, "/api/token-usage/delta", bytes.NewReader(body2))
+	req2.Header.Set("Content-Type", "application/json")
+	resp2, err := app.Test(req2, testTokenUsageFiberTimeoutMs)
+	require.NoError(t, err)
+	got := decodeTokenUsageResponse(t, resp2)
+	assert.Equal(t, delta1, got.TotalTokens, "session change must skip the delta add")
+	assert.Equal(t, "session-B", got.LastAgentSessionID)
+}
+
+func TestTokenUsageHandler_DeltaRejectsNegative(t *testing.T) {
+	app, _, _ := newTokenUsageTestApp(t)
+
+	body, _ := json.Marshal(postTokenDeltaRequest{
+		Category:       "missions",
+		Delta:          -1,
+		AgentSessionID: "session-neg",
+	})
+	req, _ := http.NewRequest(http.MethodPost, "/api/token-usage/delta", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := app.Test(req, testTokenUsageFiberTimeoutMs)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+	resp.Body.Close()
+}
+
+func TestTokenUsageHandler_DeltaRejectsOverLimit(t *testing.T) {
+	app, _, _ := newTokenUsageTestApp(t)
+
+	body, _ := json.Marshal(postTokenDeltaRequest{
+		Category:       "missions",
+		Delta:          maxTokenDeltaPerRequest + 1,
+		AgentSessionID: "session-big",
+	})
+	req, _ := http.NewRequest(http.MethodPost, "/api/token-usage/delta", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := app.Test(req, testTokenUsageFiberTimeoutMs)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+	resp.Body.Close()
+}
+
+func TestTokenUsageHandler_PutRejectsTooManyCategories(t *testing.T) {
+	app, _, _ := newTokenUsageTestApp(t)
+
+	cats := make(map[string]int64, maxTokenCategories+1)
+	for i := 0; i <= maxTokenCategories; i++ {
+		cats[string(rune('a'+i%26))+string(rune('0'+i/26))] = 1
+	}
+	body, _ := json.Marshal(putUserTokenUsageRequest{
+		TotalTokens:        int64(len(cats)),
+		TokensByCategory:   cats,
+		LastAgentSessionID: "session-many",
+	})
+	req, _ := http.NewRequest(http.MethodPost, "/api/token-usage/me", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := app.Test(req, testTokenUsageFiberTimeoutMs)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+	resp.Body.Close()
+}

--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -969,6 +969,15 @@ func (s *Server) setupRoutes() {
 	})
 	api.Get("/rewards/github", rewardsHandler.GetGitHubRewards)
 
+	// Persistent per-user reward balances (issue #6011). Every authenticated
+	// user can read and mutate their own row — no RBAC gate needed because
+	// the handler scopes every query by the JWT-derived user id.
+	rewardsPersistence := handlers.NewRewardsPersistenceHandler(s.store)
+	api.Get("/rewards/me", rewardsPersistence.GetUserRewards)
+	api.Put("/rewards/me", rewardsPersistence.UpdateUserRewards)
+	api.Post("/rewards/coins", rewardsPersistence.IncrementCoins)
+	api.Post("/rewards/daily-bonus", rewardsPersistence.ClaimDailyBonus)
+
 	// Nightly E2E status (GitHub Actions proxy with server-side token + cache)
 	nightlyE2E := handlers.NewNightlyE2EHandler(s.config.GitHubToken)
 	api.Get("/nightly-e2e/runs", nightlyE2E.GetRuns)

--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -978,6 +978,15 @@ func (s *Server) setupRoutes() {
 	api.Post("/rewards/coins", rewardsPersistence.IncrementCoins)
 	api.Post("/rewards/daily-bonus", rewardsPersistence.ClaimDailyBonus)
 
+	// Persistent per-user token-usage state (folded into #6011 PR — same
+	// motivation: clearing the browser cache should not wipe the running
+	// totals shown in the token-budget widget). Every user reads and writes
+	// only their own row; the handler resolves the user via JWT.
+	tokenUsage := handlers.NewTokenUsageHandler(s.store)
+	api.Get("/token-usage/me", tokenUsage.GetUserTokenUsage)
+	api.Post("/token-usage/me", tokenUsage.UpdateUserTokenUsage)
+	api.Post("/token-usage/delta", tokenUsage.AddTokenDelta)
+
 	// Nightly E2E status (GitHub Actions proxy with server-side token + cache)
 	nightlyE2E := handlers.NewNightlyE2EHandler(s.config.GitHubToken)
 	api.Get("/nightly-e2e/runs", nightlyE2E.GetRuns)

--- a/pkg/store/sqlite.go
+++ b/pkg/store/sqlite.go
@@ -1,6 +1,7 @@
 package store
 
 import (
+	"context"
 	"database/sql"
 	"encoding/json"
 	"errors"
@@ -50,6 +51,9 @@ const (
 	// wait for the SQLite write lock before returning SQLITE_BUSY. Under
 	// WAL mode only one writer holds the lock at a time; this timeout
 	// lets concurrent writers queue instead of failing immediately.
+	// Also required for AddUserTokenDelta which uses BEGIN IMMEDIATE on a
+	// pinned connection so concurrent goroutines can wait for the lock
+	// rather than fail.
 	sqliteBusyTimeoutMs = 5000
 )
 
@@ -96,7 +100,7 @@ type SQLiteStore struct {
 
 // NewSQLiteStore creates a new SQLite store
 func NewSQLiteStore(dbPath string) (*SQLiteStore, error) {
-	// DSN notes (modernc.org/sqlite accepts PRAGMAs via _pragma=key=value):
+	// DSN notes (modernc.org/sqlite accepts PRAGMAs via _pragma=key(value)):
 	//  - journal_mode=WAL enables Write-Ahead Logging so readers don't
 	//    block writers.
 	//  - synchronous=NORMAL is the recommended pairing with WAL for good
@@ -313,6 +317,23 @@ func (s *SQLiteStore) migrate() error {
 		updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
 	);
 	CREATE INDEX IF NOT EXISTS idx_user_rewards_updated ON user_rewards(updated_at);
+
+	-- User token-usage persistence (follow-up to issue #6011, folds the
+	-- #6020 token-usage state into the same PR). Mirrors the rewards table
+	-- layout: the server is authoritative, localStorage is a fast cache
+	-- only. tokens_by_category holds the per-category breakdown as JSON so
+	-- new categories do not require a schema migration. last_agent_session
+	-- is the most recent kc-agent session marker the server has observed
+	-- for this user — a change signals an agent restart and the server
+	-- rebases totals instead of accumulating the stale delta.
+	CREATE TABLE IF NOT EXISTS user_token_usage (
+		user_id TEXT PRIMARY KEY,
+		total_tokens INTEGER NOT NULL DEFAULT 0,
+		tokens_by_category TEXT NOT NULL DEFAULT '{}',
+		last_agent_session_id TEXT NOT NULL DEFAULT '',
+		updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+	);
+	CREATE INDEX IF NOT EXISTS idx_user_token_usage_updated ON user_token_usage(updated_at);
 	`
 	_, err := s.db.Exec(schema)
 	if err != nil {
@@ -1978,5 +1999,211 @@ func (s *SQLiteStore) ClaimDailyBonus(userID string, bonusAmount int, minInterva
 	if err := tx.Commit(); err != nil {
 		return nil, fmt.Errorf("commit tx: %w", err)
 	}
+	return current, nil
+}
+
+// --- User Token Usage methods (follow-up to issue #6011) --------------------
+//
+// These mirror the UserRewards methods (GetUserRewards / UpdateUserRewards /
+// IncrementUserCoins) but for the token-usage widget state. The table stores
+// an aggregate TotalTokens plus a JSON-encoded per-category breakdown so the
+// frontend can hydrate its byCategory Map on mount without a separate call.
+
+// scanUserTokenUsageRow decodes a single user_token_usage row into a
+// *UserTokenUsage. A JSON decode failure on tokens_by_category is treated as
+// a corrupted row and returned as an error so callers surface it rather than
+// silently dropping the breakdown.
+func scanUserTokenUsageRow(row interface {
+	Scan(dest ...any) error
+}) (*UserTokenUsage, error) {
+	var u UserTokenUsage
+	var categoriesJSON string
+	if err := row.Scan(&u.UserID, &u.TotalTokens, &categoriesJSON, &u.LastAgentSessionID, &u.UpdatedAt); err != nil {
+		return nil, err
+	}
+	if categoriesJSON == "" {
+		u.TokensByCategory = map[string]int64{}
+	} else {
+		if err := json.Unmarshal([]byte(categoriesJSON), &u.TokensByCategory); err != nil {
+			return nil, fmt.Errorf("decode tokens_by_category: %w", err)
+		}
+		if u.TokensByCategory == nil {
+			u.TokensByCategory = map[string]int64{}
+		}
+	}
+	return &u, nil
+}
+
+// GetUserTokenUsage returns the persisted token-usage row for userID, or a
+// zero-value struct (UserID set, TotalTokens=0, empty category map, empty
+// session marker) when no row exists yet. A missing row is NOT an error —
+// every authenticated user is implicitly at 0/0 until they accumulate
+// their first delta.
+func (s *SQLiteStore) GetUserTokenUsage(userID string) (*UserTokenUsage, error) {
+	if userID == "" {
+		return nil, errors.New("user_id is required")
+	}
+	row := s.db.QueryRow(
+		`SELECT user_id, total_tokens, tokens_by_category, last_agent_session_id, updated_at
+		 FROM user_token_usage WHERE user_id = ?`, userID,
+	)
+	u, err := scanUserTokenUsageRow(row)
+	if err == sql.ErrNoRows {
+		return &UserTokenUsage{
+			UserID:           userID,
+			TokensByCategory: map[string]int64{},
+			UpdatedAt:        time.Now(),
+		}, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("get user token usage: %w", err)
+	}
+	return u, nil
+}
+
+// UpdateUserTokenUsage upserts the full token-usage row. Callers pass the
+// desired end-state; the stored updated_at timestamp is always rewritten to
+// now. Negative totals are clamped to zero (no magic-number literal — 0 is
+// the floor for both TotalTokens and every per-category counter).
+func (s *SQLiteStore) UpdateUserTokenUsage(usage *UserTokenUsage) error {
+	if usage == nil || usage.UserID == "" {
+		return errors.New("usage.UserID is required")
+	}
+	if usage.TotalTokens < 0 {
+		usage.TotalTokens = 0
+	}
+	// Defensive copy + clamp per-category counters. We never mutate the
+	// caller's map in place because the hook shares a singleton reference.
+	cleanCategories := make(map[string]int64, len(usage.TokensByCategory))
+	for k, v := range usage.TokensByCategory {
+		if v < 0 {
+			v = 0
+		}
+		cleanCategories[k] = v
+	}
+	categoriesJSON, err := json.Marshal(cleanCategories)
+	if err != nil {
+		return fmt.Errorf("encode tokens_by_category: %w", err)
+	}
+	now := time.Now()
+	usage.TokensByCategory = cleanCategories
+	usage.UpdatedAt = now
+
+	_, err = s.db.Exec(
+		`INSERT INTO user_token_usage (user_id, total_tokens, tokens_by_category, last_agent_session_id, updated_at)
+		 VALUES (?, ?, ?, ?, ?)
+		 ON CONFLICT(user_id) DO UPDATE SET
+		   total_tokens = excluded.total_tokens,
+		   tokens_by_category = excluded.tokens_by_category,
+		   last_agent_session_id = excluded.last_agent_session_id,
+		   updated_at = excluded.updated_at`,
+		usage.UserID, usage.TotalTokens, string(categoriesJSON), usage.LastAgentSessionID, now,
+	)
+	if err != nil {
+		return fmt.Errorf("upsert user token usage: %w", err)
+	}
+	return nil
+}
+
+// AddUserTokenDelta atomically adds delta to the user's TotalTokens and to
+// the named category bucket inside a single transaction so concurrent writers
+// cannot produce torn updates. Restart handling: when agentSessionID is
+// non-empty AND differs from the stored LastAgentSessionID, the server
+// treats this call as the first delta of a new session — it rewrites the
+// stored session marker but does NOT add the delta (the client already
+// rebased its baseline for the same reason). The returned *UserTokenUsage
+// reflects the post-write state in both branches.
+func (s *SQLiteStore) AddUserTokenDelta(userID string, category string, delta int64, agentSessionID string) (*UserTokenUsage, error) {
+	if userID == "" {
+		return nil, errors.New("user_id is required")
+	}
+	if category == "" {
+		return nil, errors.New("category is required")
+	}
+	if delta < 0 {
+		return nil, errors.New("delta must be non-negative")
+	}
+
+	// We need a write-locked transaction so the read-merge-write sequence
+	// is atomic. modernc/sqlite does NOT translate sql.LevelSerializable
+	// to BEGIN IMMEDIATE; under WAL mode the default deferred transaction
+	// only acquires the write lock at the first INSERT, which lets two
+	// concurrent goroutines both read a stale count and produce torn
+	// updates. Workaround: pin a single connection from the pool and
+	// issue BEGIN IMMEDIATE / COMMIT manually so the lock is held from
+	// the start of the SELECT through the upsert.
+	ctx := context.Background()
+	conn, err := s.db.Conn(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("acquire conn: %w", err)
+	}
+	defer conn.Close() //nolint:errcheck // best-effort release back to pool
+
+	if _, err := conn.ExecContext(ctx, "BEGIN IMMEDIATE"); err != nil {
+		return nil, fmt.Errorf("begin immediate: %w", err)
+	}
+	committed := false
+	defer func() {
+		if !committed {
+			_, _ = conn.ExecContext(ctx, "ROLLBACK")
+		}
+	}()
+
+	row := conn.QueryRowContext(ctx,
+		`SELECT user_id, total_tokens, tokens_by_category, last_agent_session_id, updated_at
+		 FROM user_token_usage WHERE user_id = ?`, userID,
+	)
+	current, scanErr := scanUserTokenUsageRow(row)
+	if scanErr == sql.ErrNoRows {
+		current = &UserTokenUsage{
+			UserID:           userID,
+			TokensByCategory: map[string]int64{},
+		}
+	} else if scanErr != nil {
+		return nil, fmt.Errorf("read current token usage: %w", scanErr)
+	}
+
+	// Restart detection (mirrors #6020 frontend): if the incoming session
+	// marker differs from the one we last stored, treat the current totals
+	// as a fresh baseline for the new session and skip the delta add.
+	sessionChanged := agentSessionID != "" && current.LastAgentSessionID != "" && agentSessionID != current.LastAgentSessionID
+	if !sessionChanged {
+		current.TotalTokens += delta
+		if current.TokensByCategory == nil {
+			current.TokensByCategory = map[string]int64{}
+		}
+		current.TokensByCategory[category] += delta
+	}
+	// Always update the stored session marker to whatever the caller sent
+	// (empty incoming value is retained as-is on purpose — demo and unauth
+	// flows never carry a session id).
+	if agentSessionID != "" {
+		current.LastAgentSessionID = agentSessionID
+	}
+
+	categoriesJSON, err := json.Marshal(current.TokensByCategory)
+	if err != nil {
+		return nil, fmt.Errorf("encode tokens_by_category: %w", err)
+	}
+	now := time.Now()
+	current.UpdatedAt = now
+
+	if _, err := conn.ExecContext(ctx,
+		`INSERT INTO user_token_usage (user_id, total_tokens, tokens_by_category, last_agent_session_id, updated_at)
+		 VALUES (?, ?, ?, ?, ?)
+		 ON CONFLICT(user_id) DO UPDATE SET
+		   total_tokens = excluded.total_tokens,
+		   tokens_by_category = excluded.tokens_by_category,
+		   last_agent_session_id = excluded.last_agent_session_id,
+		   updated_at = excluded.updated_at`,
+		current.UserID, current.TotalTokens, string(categoriesJSON), current.LastAgentSessionID, now,
+	); err != nil {
+		return nil, fmt.Errorf("upsert user token usage delta: %w", err)
+	}
+
+	if _, err := conn.ExecContext(ctx, "COMMIT"); err != nil {
+		return nil, fmt.Errorf("commit immediate tx: %w", err)
+	}
+	committed = true
 	return current, nil
 }

--- a/pkg/store/sqlite.go
+++ b/pkg/store/sqlite.go
@@ -21,6 +21,21 @@ import (
 // map this error to HTTP 429 Too Many Requests.
 var ErrDashboardCardLimitReached = errors.New("dashboard card limit reached")
 
+// ErrDailyBonusUnavailable is returned by ClaimDailyBonus when the user's
+// last claim is within the daily-bonus cooldown window (issue #6011).
+// Handlers should map this error to HTTP 429 Too Many Requests.
+var ErrDailyBonusUnavailable = errors.New("daily bonus already claimed within cooldown window")
+
+// MinCoinBalance is the floor for user coin balances. Negative increments
+// are clamped to this value so buggy clients cannot drive balances below
+// zero. Exported so handlers and tests can reference the same constant.
+const MinCoinBalance = 0
+
+// DefaultUserLevel is the level assigned to brand-new reward rows. Rewards
+// rows are created on-demand the first time a user mutates their balance,
+// so every user effectively starts at level 1.
+const DefaultUserLevel = 1
+
 // SQLite connection pool defaults
 const (
 	// sqliteDefaultMaxOpenConns limits concurrent database connections
@@ -283,6 +298,21 @@ func (s *SQLiteStore) migrate() error {
 		expires_at DATETIME NOT NULL
 	);
 	CREATE INDEX IF NOT EXISTS idx_revoked_tokens_expires ON revoked_tokens(expires_at);
+
+	-- User rewards persistence (issue #6011): coin/point/level/bonus balances
+	-- survive browser cache clears, private windows and device switches. The
+	-- canonical store is server-side; the frontend treats localStorage as a
+	-- loading-bridge cache only.
+	CREATE TABLE IF NOT EXISTS user_rewards (
+		user_id TEXT PRIMARY KEY,
+		coins INTEGER NOT NULL DEFAULT 0,
+		points INTEGER NOT NULL DEFAULT 0,
+		level INTEGER NOT NULL DEFAULT 1,
+		bonus_points INTEGER NOT NULL DEFAULT 0,
+		last_daily_bonus_at DATETIME,
+		updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+	);
+	CREATE INDEX IF NOT EXISTS idx_user_rewards_updated ON user_rewards(updated_at);
 	`
 	_, err := s.db.Exec(schema)
 	if err != nil {
@@ -1713,4 +1743,240 @@ func (s *SQLiteStore) CleanupExpiredTokens() (int64, error) {
 		return 0, err
 	}
 	return result.RowsAffected()
+}
+
+// User Rewards methods (issue #6011)
+
+// scanUserRewardsRow decodes a single user_rewards row into a *UserRewards.
+// last_daily_bonus_at is nullable in the schema; a NULL value maps to a nil
+// pointer so callers can distinguish "never claimed" from "claimed at zero".
+func scanUserRewardsRow(row interface {
+	Scan(dest ...any) error
+}) (*UserRewards, error) {
+	var r UserRewards
+	var lastBonus sql.NullTime
+	if err := row.Scan(&r.UserID, &r.Coins, &r.Points, &r.Level, &r.BonusPoints, &lastBonus, &r.UpdatedAt); err != nil {
+		return nil, err
+	}
+	if lastBonus.Valid {
+		t := lastBonus.Time
+		r.LastDailyBonusAt = &t
+	}
+	return &r, nil
+}
+
+// GetUserRewards returns the persisted rewards row for userID, or a zero-value
+// struct (UserID set, Level=DefaultUserLevel, counters 0, LastDailyBonusAt nil)
+// if no row exists yet. A missing row is NOT an error — every authenticated
+// user is implicitly at the default starting balance until they earn their
+// first coin.
+func (s *SQLiteStore) GetUserRewards(userID string) (*UserRewards, error) {
+	if userID == "" {
+		return nil, errors.New("user_id is required")
+	}
+	row := s.db.QueryRow(
+		`SELECT user_id, coins, points, level, bonus_points, last_daily_bonus_at, updated_at
+		 FROM user_rewards WHERE user_id = ?`, userID,
+	)
+	r, err := scanUserRewardsRow(row)
+	if err == sql.ErrNoRows {
+		return &UserRewards{
+			UserID:    userID,
+			Level:     DefaultUserLevel,
+			UpdatedAt: time.Now(),
+		}, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("get user rewards: %w", err)
+	}
+	return r, nil
+}
+
+// UpdateUserRewards upserts the full rewards row. Callers pass the desired
+// end-state; the stored updated_at timestamp is always rewritten to now.
+// Coin/point/level values below their allowed floor are clamped.
+func (s *SQLiteStore) UpdateUserRewards(rewards *UserRewards) error {
+	if rewards == nil || rewards.UserID == "" {
+		return errors.New("rewards.UserID is required")
+	}
+	if rewards.Coins < MinCoinBalance {
+		rewards.Coins = MinCoinBalance
+	}
+	if rewards.Points < 0 {
+		rewards.Points = 0
+	}
+	if rewards.Level < DefaultUserLevel {
+		rewards.Level = DefaultUserLevel
+	}
+	if rewards.BonusPoints < 0 {
+		rewards.BonusPoints = 0
+	}
+	now := time.Now()
+	rewards.UpdatedAt = now
+
+	var lastBonus sql.NullTime
+	if rewards.LastDailyBonusAt != nil {
+		lastBonus = sql.NullTime{Time: *rewards.LastDailyBonusAt, Valid: true}
+	}
+
+	_, err := s.db.Exec(
+		`INSERT INTO user_rewards (user_id, coins, points, level, bonus_points, last_daily_bonus_at, updated_at)
+		 VALUES (?, ?, ?, ?, ?, ?, ?)
+		 ON CONFLICT(user_id) DO UPDATE SET
+		   coins = excluded.coins,
+		   points = excluded.points,
+		   level = excluded.level,
+		   bonus_points = excluded.bonus_points,
+		   last_daily_bonus_at = excluded.last_daily_bonus_at,
+		   updated_at = excluded.updated_at`,
+		rewards.UserID, rewards.Coins, rewards.Points, rewards.Level,
+		rewards.BonusPoints, lastBonus, now,
+	)
+	if err != nil {
+		return fmt.Errorf("upsert user rewards: %w", err)
+	}
+	return nil
+}
+
+// IncrementUserCoins atomically adds delta to the user's coin balance inside
+// a single transaction so concurrent writers cannot produce torn updates.
+// A row is created on the fly if the user has never earned a coin before.
+// Negative deltas are permitted but the resulting balance is clamped to
+// MinCoinBalance; the returned *UserRewards reflects the clamped value.
+func (s *SQLiteStore) IncrementUserCoins(userID string, delta int) (*UserRewards, error) {
+	if userID == "" {
+		return nil, errors.New("user_id is required")
+	}
+
+	tx, err := s.db.Begin()
+	if err != nil {
+		return nil, fmt.Errorf("begin tx: %w", err)
+	}
+	defer tx.Rollback() //nolint:errcheck // best-effort rollback on error paths
+
+	row := tx.QueryRow(
+		`SELECT user_id, coins, points, level, bonus_points, last_daily_bonus_at, updated_at
+		 FROM user_rewards WHERE user_id = ?`, userID,
+	)
+	current, scanErr := scanUserRewardsRow(row)
+	if scanErr == sql.ErrNoRows {
+		current = &UserRewards{
+			UserID: userID,
+			Level:  DefaultUserLevel,
+		}
+	} else if scanErr != nil {
+		return nil, fmt.Errorf("read current rewards: %w", scanErr)
+	}
+
+	newCoins := current.Coins + delta
+	if newCoins < MinCoinBalance {
+		newCoins = MinCoinBalance
+	}
+	// Positive deltas also accumulate into the lifetime "points" column so
+	// callers that use POST /api/rewards/coins for everyday earn events get
+	// a free lifetime-total bump. Negative deltas do NOT reduce lifetime.
+	newPoints := current.Points
+	if delta > 0 {
+		newPoints += delta
+	}
+	current.Coins = newCoins
+	current.Points = newPoints
+	now := time.Now()
+	current.UpdatedAt = now
+
+	var lastBonus sql.NullTime
+	if current.LastDailyBonusAt != nil {
+		lastBonus = sql.NullTime{Time: *current.LastDailyBonusAt, Valid: true}
+	}
+
+	if _, err := tx.Exec(
+		`INSERT INTO user_rewards (user_id, coins, points, level, bonus_points, last_daily_bonus_at, updated_at)
+		 VALUES (?, ?, ?, ?, ?, ?, ?)
+		 ON CONFLICT(user_id) DO UPDATE SET
+		   coins = excluded.coins,
+		   points = excluded.points,
+		   level = excluded.level,
+		   bonus_points = excluded.bonus_points,
+		   last_daily_bonus_at = excluded.last_daily_bonus_at,
+		   updated_at = excluded.updated_at`,
+		current.UserID, current.Coins, current.Points, current.Level,
+		current.BonusPoints, lastBonus, now,
+	); err != nil {
+		return nil, fmt.Errorf("increment user coins: %w", err)
+	}
+
+	if err := tx.Commit(); err != nil {
+		return nil, fmt.Errorf("commit tx: %w", err)
+	}
+	return current, nil
+}
+
+// ClaimDailyBonus atomically awards bonusAmount to the user only if at least
+// minInterval has elapsed since LastDailyBonusAt. When the cooldown has not
+// expired, returns (nil, ErrDailyBonusUnavailable). The caller-provided now
+// allows tests to exercise the cooldown deterministically without sleeping.
+func (s *SQLiteStore) ClaimDailyBonus(userID string, bonusAmount int, minInterval time.Duration, now time.Time) (*UserRewards, error) {
+	if userID == "" {
+		return nil, errors.New("user_id is required")
+	}
+	if bonusAmount < 0 {
+		return nil, errors.New("bonusAmount must be non-negative")
+	}
+
+	tx, err := s.db.Begin()
+	if err != nil {
+		return nil, fmt.Errorf("begin tx: %w", err)
+	}
+	defer tx.Rollback() //nolint:errcheck // best-effort rollback on error paths
+
+	row := tx.QueryRow(
+		`SELECT user_id, coins, points, level, bonus_points, last_daily_bonus_at, updated_at
+		 FROM user_rewards WHERE user_id = ?`, userID,
+	)
+	current, scanErr := scanUserRewardsRow(row)
+	if scanErr == sql.ErrNoRows {
+		current = &UserRewards{
+			UserID: userID,
+			Level:  DefaultUserLevel,
+		}
+	} else if scanErr != nil {
+		return nil, fmt.Errorf("read current rewards: %w", scanErr)
+	}
+
+	// Cooldown check — the first claim always goes through because
+	// LastDailyBonusAt is nil for brand-new users.
+	if current.LastDailyBonusAt != nil {
+		elapsed := now.Sub(*current.LastDailyBonusAt)
+		if elapsed < minInterval {
+			return nil, ErrDailyBonusUnavailable
+		}
+	}
+
+	current.BonusPoints += bonusAmount
+	current.Points += bonusAmount
+	claimedAt := now
+	current.LastDailyBonusAt = &claimedAt
+	current.UpdatedAt = now
+
+	lastBonus := sql.NullTime{Time: claimedAt, Valid: true}
+	if _, err := tx.Exec(
+		`INSERT INTO user_rewards (user_id, coins, points, level, bonus_points, last_daily_bonus_at, updated_at)
+		 VALUES (?, ?, ?, ?, ?, ?, ?)
+		 ON CONFLICT(user_id) DO UPDATE SET
+		   coins = excluded.coins,
+		   points = excluded.points,
+		   level = excluded.level,
+		   bonus_points = excluded.bonus_points,
+		   last_daily_bonus_at = excluded.last_daily_bonus_at,
+		   updated_at = excluded.updated_at`,
+		current.UserID, current.Coins, current.Points, current.Level,
+		current.BonusPoints, lastBonus, now,
+	); err != nil {
+		return nil, fmt.Errorf("claim daily bonus: %w", err)
+	}
+
+	if err := tx.Commit(); err != nil {
+		return nil, fmt.Errorf("commit tx: %w", err)
+	}
+	return current, nil
 }

--- a/pkg/store/store.go
+++ b/pkg/store/store.go
@@ -7,6 +7,21 @@ import (
 	"github.com/kubestellar/console/pkg/models"
 )
 
+// UserRewards captures the persisted gamification state for a single user
+// (issue #6011). Prior to this table the balance lived only in localStorage
+// and was lost whenever the browser cache was cleared. user_id is a free-form
+// string so both real user UUIDs and the shared "demo-user" dev-mode bucket
+// can be used interchangeably.
+type UserRewards struct {
+	UserID           string
+	Coins            int
+	Points           int
+	Level            int
+	BonusPoints      int
+	LastDailyBonusAt *time.Time
+	UpdatedAt        time.Time
+}
+
 // Store defines the interface for data persistence
 type Store interface {
 	// Users
@@ -104,6 +119,24 @@ type Store interface {
 	RevokeToken(jti string, expiresAt time.Time) error
 	IsTokenRevoked(jti string) (bool, error)
 	CleanupExpiredTokens() (int64, error)
+
+	// User Rewards (issue #6011) — persistent coin/point/level balances.
+	// GetUserRewards returns a zero-value *UserRewards (Level=1, UserID set,
+	// all counters 0) when no row exists; it is NOT an error to read a
+	// never-persisted user.
+	GetUserRewards(userID string) (*UserRewards, error)
+	// UpdateUserRewards upserts the full reward state for the user.
+	UpdateUserRewards(rewards *UserRewards) error
+	// IncrementUserCoins atomically adds delta to the user's coin balance and
+	// returns the new state. Negative deltas are allowed but the resulting
+	// balance is clamped to MinCoinBalance (0) — callers receive the clamped
+	// row so they can display the effective balance.
+	IncrementUserCoins(userID string, delta int) (*UserRewards, error)
+	// ClaimDailyBonus atomically awards bonusAmount to the user if their
+	// LastDailyBonusAt is older than minInterval relative to now. Returns
+	// (nil, ErrDailyBonusUnavailable) when the cooldown has not elapsed so
+	// handlers can return a 429 without a second round-trip.
+	ClaimDailyBonus(userID string, bonusAmount int, minInterval time.Duration, now time.Time) (*UserRewards, error)
 
 	// Lifecycle
 	Close() error

--- a/pkg/store/store.go
+++ b/pkg/store/store.go
@@ -22,6 +22,28 @@ type UserRewards struct {
 	UpdatedAt        time.Time
 }
 
+// UserTokenUsage captures the persisted per-user token-usage state that
+// backs the token budget widget (issue #6020 and follow-up to #6011).
+// Prior to this table the totals lived only in localStorage, so clearing
+// the browser cache or switching devices lost the running totals and the
+// agent-session restart marker.
+//
+// TotalTokens is the lifetime running sum attributed to the user across
+// all categories. TokensByCategory breaks the total out per category
+// (missions, diagnose, insights, predictions, other) and is stored as
+// JSON so new categories can be added without a schema migration.
+// LastAgentSessionID is the most recent kc-agent session marker the
+// server has observed for this user; a change in this marker on the
+// next delta request signals an agent restart and the server treats the
+// incoming total as a new baseline instead of accumulating it.
+type UserTokenUsage struct {
+	UserID             string
+	TotalTokens        int64
+	TokensByCategory   map[string]int64
+	LastAgentSessionID string
+	UpdatedAt          time.Time
+}
+
 // Store defines the interface for data persistence
 type Store interface {
 	// Users
@@ -137,6 +159,25 @@ type Store interface {
 	// (nil, ErrDailyBonusUnavailable) when the cooldown has not elapsed so
 	// handlers can return a 429 without a second round-trip.
 	ClaimDailyBonus(userID string, bonusAmount int, minInterval time.Duration, now time.Time) (*UserRewards, error)
+
+	// User Token Usage — persistent per-user token-usage counters that back
+	// the token budget widget. Mirrors the UserRewards persistence pattern.
+	// GetUserTokenUsage returns a zero-value *UserTokenUsage (UserID set,
+	// TotalTokens=0, empty category map) when no row exists; it is NOT an
+	// error to read a never-persisted user.
+	GetUserTokenUsage(userID string) (*UserTokenUsage, error)
+	// UpdateUserTokenUsage upserts the full token-usage row for the user.
+	// Callers pass the desired end-state (typically their hydrated local
+	// totals) and the server replaces the row.
+	UpdateUserTokenUsage(usage *UserTokenUsage) error
+	// AddUserTokenDelta atomically adds delta to the user's TotalTokens
+	// AND to the given category in TokensByCategory. If agentSessionID is
+	// non-empty and differs from the stored LastAgentSessionID, the server
+	// treats the existing total as a new baseline, DOES NOT add the delta
+	// (callers are asked to reset and re-send on their side), and rewrites
+	// the stored session marker — this mirrors the frontend restart
+	// detection from #6020 so both sides agree on what counts as a restart.
+	AddUserTokenDelta(userID string, category string, delta int64, agentSessionID string) (*UserTokenUsage, error)
 
 	// Lifecycle
 	Close() error

--- a/pkg/store/user_rewards_test.go
+++ b/pkg/store/user_rewards_test.go
@@ -1,0 +1,177 @@
+package store
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// testUserRewardsID is a stable fake user id used throughout the rewards
+// store tests. It matches the format used by dev-mode sessions (a free-form
+// string rather than a UUID) to keep the coverage realistic.
+const testUserRewardsID = "user-rewards-test"
+
+// testDailyBonusInterval mirrors the handler-level constant so the store
+// test surface does not drift. 24h is the product-level cooldown window.
+const testDailyBonusInterval = 24 * time.Hour
+
+// testDailyBonusAmount is an arbitrary non-zero bonus used by the cooldown
+// tests to distinguish "awarded" from "skipped" branches.
+const testDailyBonusAmount = 50
+
+func TestGetUserRewards_ReturnsZeroForNewUser(t *testing.T) {
+	store := newTestStore(t)
+
+	got, err := store.GetUserRewards(testUserRewardsID)
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	require.Equal(t, testUserRewardsID, got.UserID)
+	require.Equal(t, 0, got.Coins)
+	require.Equal(t, 0, got.Points)
+	require.Equal(t, DefaultUserLevel, got.Level)
+	require.Equal(t, 0, got.BonusPoints)
+	require.Nil(t, got.LastDailyBonusAt)
+}
+
+func TestGetUserRewards_EmptyUserIDReturnsError(t *testing.T) {
+	store := newTestStore(t)
+	_, err := store.GetUserRewards("")
+	require.Error(t, err)
+}
+
+func TestUpdateUserRewards_RoundTrip(t *testing.T) {
+	store := newTestStore(t)
+
+	const (
+		wantCoins  = 150
+		wantPoints = 275
+		wantLevel  = 3
+		wantBonus  = 25
+	)
+
+	r := &UserRewards{
+		UserID:      testUserRewardsID,
+		Coins:       wantCoins,
+		Points:      wantPoints,
+		Level:       wantLevel,
+		BonusPoints: wantBonus,
+	}
+	require.NoError(t, store.UpdateUserRewards(r))
+
+	got, err := store.GetUserRewards(testUserRewardsID)
+	require.NoError(t, err)
+	require.Equal(t, wantCoins, got.Coins)
+	require.Equal(t, wantPoints, got.Points)
+	require.Equal(t, wantLevel, got.Level)
+	require.Equal(t, wantBonus, got.BonusPoints)
+	require.False(t, got.UpdatedAt.IsZero())
+}
+
+func TestUpdateUserRewards_ClampsNegativeCoinsToFloor(t *testing.T) {
+	store := newTestStore(t)
+
+	r := &UserRewards{
+		UserID: testUserRewardsID,
+		Coins:  -5,
+	}
+	require.NoError(t, store.UpdateUserRewards(r))
+
+	got, err := store.GetUserRewards(testUserRewardsID)
+	require.NoError(t, err)
+	require.Equal(t, MinCoinBalance, got.Coins)
+}
+
+func TestUpdateUserRewards_Idempotent(t *testing.T) {
+	store := newTestStore(t)
+	const finalCoins = 42
+
+	// First call creates the row
+	require.NoError(t, store.UpdateUserRewards(&UserRewards{UserID: testUserRewardsID, Coins: finalCoins}))
+	// Second call with same state should succeed and not duplicate
+	require.NoError(t, store.UpdateUserRewards(&UserRewards{UserID: testUserRewardsID, Coins: finalCoins}))
+
+	got, err := store.GetUserRewards(testUserRewardsID)
+	require.NoError(t, err)
+	require.Equal(t, finalCoins, got.Coins)
+}
+
+func TestIncrementUserCoins_AddsToBalance(t *testing.T) {
+	store := newTestStore(t)
+	const firstDelta = 10
+	const secondDelta = 15
+	const wantTotal = firstDelta + secondDelta
+
+	r1, err := store.IncrementUserCoins(testUserRewardsID, firstDelta)
+	require.NoError(t, err)
+	require.Equal(t, firstDelta, r1.Coins)
+	// Positive deltas also accumulate lifetime points
+	require.Equal(t, firstDelta, r1.Points)
+
+	r2, err := store.IncrementUserCoins(testUserRewardsID, secondDelta)
+	require.NoError(t, err)
+	require.Equal(t, wantTotal, r2.Coins)
+	require.Equal(t, wantTotal, r2.Points)
+}
+
+func TestIncrementUserCoins_NegativeDeltaClampsToFloor(t *testing.T) {
+	store := newTestStore(t)
+	const startingBalance = 20
+	const subtractAmount = -50
+
+	_, err := store.IncrementUserCoins(testUserRewardsID, startingBalance)
+	require.NoError(t, err)
+
+	got, err := store.IncrementUserCoins(testUserRewardsID, subtractAmount)
+	require.NoError(t, err)
+	require.Equal(t, MinCoinBalance, got.Coins, "negative delta must clamp to MinCoinBalance")
+	// Lifetime points should NOT decrease on a negative delta
+	require.Equal(t, startingBalance, got.Points)
+}
+
+func TestClaimDailyBonus_FirstClaimSucceeds(t *testing.T) {
+	store := newTestStore(t)
+	now := time.Date(2026, 4, 10, 12, 0, 0, 0, time.UTC)
+
+	got, err := store.ClaimDailyBonus(testUserRewardsID, testDailyBonusAmount, testDailyBonusInterval, now)
+	require.NoError(t, err)
+	require.Equal(t, testDailyBonusAmount, got.BonusPoints)
+	require.NotNil(t, got.LastDailyBonusAt)
+	require.True(t, got.LastDailyBonusAt.Equal(now))
+}
+
+func TestClaimDailyBonus_WithinCooldownReturnsError(t *testing.T) {
+	store := newTestStore(t)
+	firstClaim := time.Date(2026, 4, 10, 12, 0, 0, 0, time.UTC)
+
+	_, err := store.ClaimDailyBonus(testUserRewardsID, testDailyBonusAmount, testDailyBonusInterval, firstClaim)
+	require.NoError(t, err)
+
+	// 23 hours later — still inside the 24h window
+	tooSoon := firstClaim.Add(23 * time.Hour)
+	_, err = store.ClaimDailyBonus(testUserRewardsID, testDailyBonusAmount, testDailyBonusInterval, tooSoon)
+	require.Error(t, err)
+	require.True(t, errors.Is(err, ErrDailyBonusUnavailable))
+
+	// Bonus points should be unchanged after the rejection
+	got, err := store.GetUserRewards(testUserRewardsID)
+	require.NoError(t, err)
+	require.Equal(t, testDailyBonusAmount, got.BonusPoints)
+}
+
+func TestClaimDailyBonus_AfterCooldownSucceedsAgain(t *testing.T) {
+	store := newTestStore(t)
+	firstClaim := time.Date(2026, 4, 10, 12, 0, 0, 0, time.UTC)
+
+	_, err := store.ClaimDailyBonus(testUserRewardsID, testDailyBonusAmount, testDailyBonusInterval, firstClaim)
+	require.NoError(t, err)
+
+	// 24h + 1 minute later — just past the cooldown
+	laterEnough := firstClaim.Add(testDailyBonusInterval).Add(1 * time.Minute)
+	got, err := store.ClaimDailyBonus(testUserRewardsID, testDailyBonusAmount, testDailyBonusInterval, laterEnough)
+	require.NoError(t, err)
+	require.Equal(t, testDailyBonusAmount*2, got.BonusPoints)
+	require.NotNil(t, got.LastDailyBonusAt)
+	require.True(t, got.LastDailyBonusAt.Equal(laterEnough))
+}

--- a/pkg/store/user_token_usage_test.go
+++ b/pkg/store/user_token_usage_test.go
@@ -1,0 +1,166 @@
+package store
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// testTokenUsageUserID is the stable free-form user id used across the
+// token-usage store tests. It mirrors the pattern from user_rewards_test.go
+// so dev-mode and prod-mode writes share the same surface.
+const testTokenUsageUserID = "user-token-usage-test"
+
+// Named test constants — no magic numbers. These are arbitrary non-zero
+// values chosen so the arithmetic assertions are easy to read.
+const (
+	testTokenDelta1       int64 = 100
+	testTokenDelta2       int64 = 250
+	testTokenDelta1Plus2  int64 = testTokenDelta1 + testTokenDelta2
+	testConcurrentWorkers       = 16
+	testConcurrentDelta   int64 = 7
+	testSessionA                = "session-abc"
+	testSessionB                = "session-xyz"
+	testCategoryMissions        = "missions"
+	testCategoryDiagnose        = "diagnose"
+)
+
+func TestGetUserTokenUsage_ReturnsZeroForNewUser(t *testing.T) {
+	store := newTestStore(t)
+
+	got, err := store.GetUserTokenUsage(testTokenUsageUserID)
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	assert.Equal(t, testTokenUsageUserID, got.UserID)
+	assert.Equal(t, int64(0), got.TotalTokens)
+	assert.NotNil(t, got.TokensByCategory)
+	assert.Equal(t, 0, len(got.TokensByCategory))
+	assert.Equal(t, "", got.LastAgentSessionID)
+}
+
+func TestGetUserTokenUsage_EmptyUserIDReturnsError(t *testing.T) {
+	store := newTestStore(t)
+	_, err := store.GetUserTokenUsage("")
+	require.Error(t, err)
+}
+
+func TestUpdateUserTokenUsage_RoundTrip(t *testing.T) {
+	store := newTestStore(t)
+
+	u := &UserTokenUsage{
+		UserID:      testTokenUsageUserID,
+		TotalTokens: testTokenDelta1Plus2,
+		TokensByCategory: map[string]int64{
+			testCategoryMissions: testTokenDelta1,
+			testCategoryDiagnose: testTokenDelta2,
+		},
+		LastAgentSessionID: testSessionA,
+	}
+	require.NoError(t, store.UpdateUserTokenUsage(u))
+
+	got, err := store.GetUserTokenUsage(testTokenUsageUserID)
+	require.NoError(t, err)
+	assert.Equal(t, testTokenDelta1Plus2, got.TotalTokens)
+	assert.Equal(t, testTokenDelta1, got.TokensByCategory[testCategoryMissions])
+	assert.Equal(t, testTokenDelta2, got.TokensByCategory[testCategoryDiagnose])
+	assert.Equal(t, testSessionA, got.LastAgentSessionID)
+	assert.False(t, got.UpdatedAt.IsZero())
+}
+
+func TestUpdateUserTokenUsage_ClampsNegativesToZero(t *testing.T) {
+	store := newTestStore(t)
+
+	const negativeTotal int64 = -50
+	const negativeCategory int64 = -10
+
+	u := &UserTokenUsage{
+		UserID:      testTokenUsageUserID,
+		TotalTokens: negativeTotal,
+		TokensByCategory: map[string]int64{
+			testCategoryMissions: negativeCategory,
+		},
+	}
+	require.NoError(t, store.UpdateUserTokenUsage(u))
+
+	got, err := store.GetUserTokenUsage(testTokenUsageUserID)
+	require.NoError(t, err)
+	assert.Equal(t, int64(0), got.TotalTokens)
+	assert.Equal(t, int64(0), got.TokensByCategory[testCategoryMissions])
+}
+
+func TestAddUserTokenDelta_AccumulatesAcrossCalls(t *testing.T) {
+	store := newTestStore(t)
+
+	r1, err := store.AddUserTokenDelta(testTokenUsageUserID, testCategoryMissions, testTokenDelta1, testSessionA)
+	require.NoError(t, err)
+	assert.Equal(t, testTokenDelta1, r1.TotalTokens)
+	assert.Equal(t, testTokenDelta1, r1.TokensByCategory[testCategoryMissions])
+	assert.Equal(t, testSessionA, r1.LastAgentSessionID)
+
+	r2, err := store.AddUserTokenDelta(testTokenUsageUserID, testCategoryDiagnose, testTokenDelta2, testSessionA)
+	require.NoError(t, err)
+	assert.Equal(t, testTokenDelta1Plus2, r2.TotalTokens)
+	assert.Equal(t, testTokenDelta1, r2.TokensByCategory[testCategoryMissions])
+	assert.Equal(t, testTokenDelta2, r2.TokensByCategory[testCategoryDiagnose])
+}
+
+func TestAddUserTokenDelta_SessionChangeResetsBaseline(t *testing.T) {
+	store := newTestStore(t)
+
+	// First call establishes session A and adds delta1.
+	_, err := store.AddUserTokenDelta(testTokenUsageUserID, testCategoryMissions, testTokenDelta1, testSessionA)
+	require.NoError(t, err)
+
+	// Second call arrives with a new session id — the server must NOT add
+	// the delta (baseline reset semantics) and must rewrite the marker.
+	got, err := store.AddUserTokenDelta(testTokenUsageUserID, testCategoryMissions, testTokenDelta2, testSessionB)
+	require.NoError(t, err)
+	assert.Equal(t, testTokenDelta1, got.TotalTokens, "session change must skip the delta add")
+	assert.Equal(t, testTokenDelta1, got.TokensByCategory[testCategoryMissions])
+	assert.Equal(t, testSessionB, got.LastAgentSessionID)
+
+	// Third call on the new session continues to accumulate normally.
+	got, err = store.AddUserTokenDelta(testTokenUsageUserID, testCategoryMissions, testTokenDelta2, testSessionB)
+	require.NoError(t, err)
+	assert.Equal(t, testTokenDelta1+testTokenDelta2, got.TotalTokens)
+}
+
+func TestAddUserTokenDelta_NegativeDeltaRejected(t *testing.T) {
+	store := newTestStore(t)
+	const negativeDelta int64 = -1
+	_, err := store.AddUserTokenDelta(testTokenUsageUserID, testCategoryMissions, negativeDelta, "")
+	require.Error(t, err)
+}
+
+func TestAddUserTokenDelta_EmptyCategoryRejected(t *testing.T) {
+	store := newTestStore(t)
+	_, err := store.AddUserTokenDelta(testTokenUsageUserID, "", testTokenDelta1, "")
+	require.Error(t, err)
+}
+
+// TestAddUserTokenDelta_ConcurrentIncrementsAreAtomic exercises the
+// transaction envelope around the read-merge-write sequence. If the store
+// were not transactional, torn updates would produce a final total less
+// than testConcurrentWorkers * testConcurrentDelta.
+func TestAddUserTokenDelta_ConcurrentIncrementsAreAtomic(t *testing.T) {
+	store := newTestStore(t)
+
+	var wg sync.WaitGroup
+	wg.Add(testConcurrentWorkers)
+	for i := 0; i < testConcurrentWorkers; i++ {
+		go func() {
+			defer wg.Done()
+			_, err := store.AddUserTokenDelta(testTokenUsageUserID, testCategoryMissions, testConcurrentDelta, testSessionA)
+			assert.NoError(t, err)
+		}()
+	}
+	wg.Wait()
+
+	got, err := store.GetUserTokenUsage(testTokenUsageUserID)
+	require.NoError(t, err)
+	wantTotal := int64(testConcurrentWorkers) * testConcurrentDelta
+	assert.Equal(t, wantTotal, got.TotalTokens, "concurrent deltas must sum without lost updates")
+	assert.Equal(t, wantTotal, got.TokensByCategory[testCategoryMissions])
+}

--- a/pkg/test/mock_store.go
+++ b/pkg/test/mock_store.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/kubestellar/console/pkg/models"
+	"github.com/kubestellar/console/pkg/store"
 	"github.com/stretchr/testify/mock"
 )
 
@@ -171,5 +172,71 @@ func (m *MockStore) ListActiveGPUReservations() ([]models.GPUReservation, error)
 func (m *MockStore) RevokeToken(jti string, expiresAt time.Time) error { return nil }
 func (m *MockStore) IsTokenRevoked(jti string) (bool, error)           { return false, nil }
 func (m *MockStore) CleanupExpiredTokens() (int64, error)              { return 0, nil }
+
+// GetUserRewards is overridable via testify/mock expectations so reward
+// handler tests can inject per-user state without touching SQLite.
+func (m *MockStore) GetUserRewards(userID string) (*store.UserRewards, error) {
+	if len(m.ExpectedCalls) == 0 {
+		return &store.UserRewards{UserID: userID, Level: store.DefaultUserLevel}, nil
+	}
+	for _, call := range m.ExpectedCalls {
+		if call.Method == "GetUserRewards" {
+			args := m.Called(userID)
+			if args.Get(0) == nil {
+				return nil, args.Error(1)
+			}
+			return args.Get(0).(*store.UserRewards), args.Error(1)
+		}
+	}
+	return &store.UserRewards{UserID: userID, Level: store.DefaultUserLevel}, nil
+}
+
+// UpdateUserRewards is overridable via testify/mock expectations.
+func (m *MockStore) UpdateUserRewards(rewards *store.UserRewards) error {
+	if len(m.ExpectedCalls) == 0 {
+		return nil
+	}
+	for _, call := range m.ExpectedCalls {
+		if call.Method == "UpdateUserRewards" {
+			args := m.Called(rewards)
+			return args.Error(0)
+		}
+	}
+	return nil
+}
+
+// IncrementUserCoins is overridable via testify/mock expectations.
+func (m *MockStore) IncrementUserCoins(userID string, delta int) (*store.UserRewards, error) {
+	if len(m.ExpectedCalls) == 0 {
+		return &store.UserRewards{UserID: userID, Level: store.DefaultUserLevel, Coins: delta}, nil
+	}
+	for _, call := range m.ExpectedCalls {
+		if call.Method == "IncrementUserCoins" {
+			args := m.Called(userID, delta)
+			if args.Get(0) == nil {
+				return nil, args.Error(1)
+			}
+			return args.Get(0).(*store.UserRewards), args.Error(1)
+		}
+	}
+	return &store.UserRewards{UserID: userID, Level: store.DefaultUserLevel, Coins: delta}, nil
+}
+
+// ClaimDailyBonus is overridable via testify/mock expectations.
+func (m *MockStore) ClaimDailyBonus(userID string, bonusAmount int, minInterval time.Duration, now time.Time) (*store.UserRewards, error) {
+	if len(m.ExpectedCalls) == 0 {
+		return &store.UserRewards{UserID: userID, Level: store.DefaultUserLevel, BonusPoints: bonusAmount, LastDailyBonusAt: &now}, nil
+	}
+	for _, call := range m.ExpectedCalls {
+		if call.Method == "ClaimDailyBonus" {
+			args := m.Called(userID, bonusAmount, minInterval, now)
+			if args.Get(0) == nil {
+				return nil, args.Error(1)
+			}
+			return args.Get(0).(*store.UserRewards), args.Error(1)
+		}
+	}
+	return &store.UserRewards{UserID: userID, Level: store.DefaultUserLevel, BonusPoints: bonusAmount, LastDailyBonusAt: &now}, nil
+}
 
 func (m *MockStore) Close() error { return nil }

--- a/pkg/test/mock_store.go
+++ b/pkg/test/mock_store.go
@@ -239,4 +239,62 @@ func (m *MockStore) ClaimDailyBonus(userID string, bonusAmount int, minInterval 
 	return &store.UserRewards{UserID: userID, Level: store.DefaultUserLevel, BonusPoints: bonusAmount, LastDailyBonusAt: &now}, nil
 }
 
+// GetUserTokenUsage is overridable via testify/mock expectations.
+func (m *MockStore) GetUserTokenUsage(userID string) (*store.UserTokenUsage, error) {
+	if len(m.ExpectedCalls) == 0 {
+		return &store.UserTokenUsage{UserID: userID, TokensByCategory: map[string]int64{}}, nil
+	}
+	for _, call := range m.ExpectedCalls {
+		if call.Method == "GetUserTokenUsage" {
+			args := m.Called(userID)
+			if args.Get(0) == nil {
+				return nil, args.Error(1)
+			}
+			return args.Get(0).(*store.UserTokenUsage), args.Error(1)
+		}
+	}
+	return &store.UserTokenUsage{UserID: userID, TokensByCategory: map[string]int64{}}, nil
+}
+
+// UpdateUserTokenUsage is overridable via testify/mock expectations.
+func (m *MockStore) UpdateUserTokenUsage(usage *store.UserTokenUsage) error {
+	if len(m.ExpectedCalls) == 0 {
+		return nil
+	}
+	for _, call := range m.ExpectedCalls {
+		if call.Method == "UpdateUserTokenUsage" {
+			args := m.Called(usage)
+			return args.Error(0)
+		}
+	}
+	return nil
+}
+
+// AddUserTokenDelta is overridable via testify/mock expectations.
+func (m *MockStore) AddUserTokenDelta(userID string, category string, delta int64, agentSessionID string) (*store.UserTokenUsage, error) {
+	if len(m.ExpectedCalls) == 0 {
+		return &store.UserTokenUsage{
+			UserID:             userID,
+			TotalTokens:        delta,
+			TokensByCategory:   map[string]int64{category: delta},
+			LastAgentSessionID: agentSessionID,
+		}, nil
+	}
+	for _, call := range m.ExpectedCalls {
+		if call.Method == "AddUserTokenDelta" {
+			args := m.Called(userID, category, delta, agentSessionID)
+			if args.Get(0) == nil {
+				return nil, args.Error(1)
+			}
+			return args.Get(0).(*store.UserTokenUsage), args.Error(1)
+		}
+	}
+	return &store.UserTokenUsage{
+		UserID:             userID,
+		TotalTokens:        delta,
+		TokensByCategory:   map[string]int64{category: delta},
+		LastAgentSessionID: agentSessionID,
+	}, nil
+}
+
 func (m *MockStore) Close() error { return nil }

--- a/web/src/hooks/useBonusPoints.ts
+++ b/web/src/hooks/useBonusPoints.ts
@@ -48,15 +48,6 @@ function saveCache(login: string, data: BonusPointsResponse): void {
   }
 }
 
-/**
- * Module-level flag indicating the bonus endpoint is unavailable in this
- * environment (e.g. local dev with the Go backend, which does not implement
- * /api/rewards/bonus — that route only exists as a Netlify function in
- * production). Once set, subsequent fetch attempts are skipped for the life
- * of the tab so we don't spam the console with 404s (issue #6013).
- */
-let bonusEndpointUnavailable = false
-
 export function useBonusPoints() {
   const { user, isAuthenticated } = useAuth()
   const [data, setData] = useState<BonusPointsResponse | null>(null)
@@ -77,10 +68,14 @@ export function useBonusPoints() {
     if (cached) setData(cached)
   }, [githubLogin, isDemoUser])
 
+  // Issue #6011 removed the module-level `bonusEndpointUnavailable` flag:
+  // the Go backend now persists bonus points alongside coins via
+  // `/api/rewards/me`, and the legacy `/api/rewards/bonus?login=` route
+  // still exists as a Netlify function in production. If either call fails
+  // we simply fall through to the cached value rather than permanently
+  // disabling the fetcher for the tab.
   const fetchBonus = useCallback(async () => {
     if (!isAuthenticated || isDemoUser || !githubLogin) return
-    // Endpoint previously 404'd — don't retry in this session (issue #6013).
-    if (bonusEndpointUnavailable) return
 
     setIsLoading(true)
     try {
@@ -89,12 +84,10 @@ export function useBonusPoints() {
         signal: AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS),
       })
       if (res.status === 404) {
-        // Bonus endpoint not implemented on this backend (e.g. Go backend in
-        // dev — this route only exists as a Netlify function in production).
-        // Treat bonus points as zero and stop polling for the rest of the
-        // session. No error is surfaced to the user because bonus points are
-        // purely additive and their absence is not a failure mode.
-        bonusEndpointUnavailable = true
+        // Route unavailable on this backend (e.g. dev Go server without the
+        // scraping endpoint). Bonus points default to zero — this is not an
+        // error path because the user's persistent bonus balance lives on
+        // the backend `/api/rewards/me` row which is read by `useRewards`.
         if (loginRef.current === githubLogin) {
           setData({ login: githubLogin, total_bonus_points: 0, entries: [] })
         }

--- a/web/src/hooks/useRewards.tsx
+++ b/web/src/hooks/useRewards.tsx
@@ -2,14 +2,14 @@
  * Reward system hook for gamification
  * Tracks user coins, achievements, and reward events
  *
- * Known limitation (issue #6011): locally-earned coins are persisted only
- * in `localStorage`. Clearing the browser cache, using a private window, or
- * switching browsers/devices will reset the local coin balance. GitHub-sourced
- * points (`useGitHubRewards`) and bonus points (`useBonusPoints`) are already
- * backed by server state, so the merged total rehydrates from those sources —
- * only in-app earnings (mission completions, games, sharing) are affected.
- * A backend `/api/rewards/sync` endpoint that persists events to SQLite is
- * tracked in #6011 and is the proper long-term fix.
+ * Issue #6011 fix: the canonical source of truth for coin/point/level/bonus
+ * balances is now the backend (`/api/rewards/me` + `/api/rewards/coins` +
+ * `/api/rewards/daily-bonus`). `localStorage` is still read on mount as a
+ * loading-bridge cache so the UI never blinks on reload, and it is still
+ * used as the sole storage for demo/dev mode (where there is no JWT to
+ * authenticate the API calls). Real authenticated sessions persist every
+ * mutation to SQLite so clearing the browser cache, switching devices, or
+ * using a private window no longer wipes the balance.
  */
 
 import { createContext, useContext, useState, useEffect, useCallback, useRef, ReactNode } from 'react'
@@ -25,6 +25,10 @@ import {
 import type { GitHubRewardsResponse } from '../types/rewards'
 import { useGitHubRewards } from './useGitHubRewards'
 import { useBonusPoints } from './useBonusPoints'
+import {
+  getUserRewards as apiGetUserRewards,
+  incrementCoins as apiIncrementCoins,
+  RewardsUnauthenticatedError } from '../lib/rewardsApi'
 
 const REWARDS_STORAGE_KEY = 'kubestellar-rewards'
 /** Maximum reward events to keep in history */
@@ -127,22 +131,68 @@ export function RewardsProvider({ children }: { children: ReactNode }) {
     effectiveUserIdRef.current = effectiveUserId
   }, [effectiveUserId])
 
-  // Load rewards when user changes
+  // Load rewards when the user changes.
+  //
+  // In authenticated mode (real oauth session) the backend is the source
+  // of truth — we read localStorage first as a loading bridge so the UI
+  // hydrates instantly, then fetch `/api/rewards/me` and merge the
+  // server-authoritative coin/point/level/bonus values on top. Events and
+  // achievements remain client-only (#6011 scope covers numeric balances,
+  // not the event history).
+  //
+  // In demo/dev mode (no JWT), we keep the legacy localStorage-only path
+  // so developers can still use the app without running kc-agent.
   useEffect(() => {
-    if (effectiveUserId) {
-      const loaded = loadRewards(effectiveUserId)
-      if (loaded) {
-        setRewards(loaded)
-      } else {
-        // Initialize new user rewards
-        const initial = createInitialRewards(effectiveUserId)
+    let cancelled = false
+
+    async function hydrate() {
+      if (!effectiveUserId) {
+        setRewards(null)
+        setIsLoading(false)
+        return
+      }
+
+      // Step 1: always load the local cache first so the UI can paint
+      // immediately even if the backend is slow or unreachable.
+      const cached = loadRewards(effectiveUserId)
+      const initial = cached ?? createInitialRewards(effectiveUserId)
+      if (!cancelled) {
         setRewards(initial)
+        setIsLoading(false)
+      }
+      if (!cached) {
         saveRewards(effectiveUserId, initial)
       }
-      setIsLoading(false)
-    } else {
-      setRewards(null)
-      setIsLoading(false)
+
+      // Step 2: if this is a real authenticated session (not demo mode),
+      // pull the canonical server state and overwrite coin/point totals.
+      if (getDemoMode() || effectiveUserId === DEMO_REWARDS_USER_ID) return
+
+      try {
+        const server = await apiGetUserRewards()
+        if (cancelled) return
+        setRewards(prev => {
+          const base = prev ?? createInitialRewards(effectiveUserId)
+          const merged: UserRewards = {
+            ...base,
+            totalCoins: server.coins,
+            lifetimeCoins: Math.max(server.points, base.lifetimeCoins),
+            lastUpdated: server.updated_at,
+          }
+          saveRewards(effectiveUserId, merged)
+          return merged
+        })
+      } catch (err) {
+        // 401 simply means the user is logged out — silently fall back to
+        // the cached local state (which is what we already painted).
+        if (err instanceof RewardsUnauthenticatedError) return
+        console.warn('[useRewards] failed to fetch server rewards:', err)
+      }
+    }
+
+    hydrate()
+    return () => {
+      cancelled = true
     }
   }, [effectiveUserId])
 
@@ -151,6 +201,11 @@ export function RewardsProvider({ children }: { children: ReactNode }) {
   // recent events, and achievements stay in sync everywhere. The `storage`
   // event only fires in OTHER tabs, never the one that wrote the value, so
   // this cannot loop.
+  //
+  // In authenticated mode we additionally re-fetch from the backend on
+  // every storage event so that the cross-tab view always lands on the
+  // server-authoritative numbers rather than whatever value the peer tab
+  // happened to write locally (issue #6011 follow-up).
   useEffect(() => {
     function handleStorage(e: StorageEvent) {
       if (e.key !== REWARDS_STORAGE_KEY) return
@@ -171,6 +226,28 @@ export function RewardsProvider({ children }: { children: ReactNode }) {
       } catch (err) {
         console.error('[useRewards] Failed to parse cross-tab rewards update:', err)
       }
+
+      // Authenticated cross-tab bridge: pull the canonical server state.
+      if (getDemoMode() || id === DEMO_REWARDS_USER_ID) return
+      apiGetUserRewards()
+        .then(server => {
+          setRewards(prev => {
+            if (!prev) return prev
+            if (prev.totalCoins === server.coins && prev.lifetimeCoins === server.points) return prev
+            const merged: UserRewards = {
+              ...prev,
+              totalCoins: server.coins,
+              lifetimeCoins: Math.max(server.points, prev.lifetimeCoins),
+              lastUpdated: server.updated_at,
+            }
+            saveRewards(id, merged)
+            return merged
+          })
+        })
+        .catch(refreshErr => {
+          if (refreshErr instanceof RewardsUnauthenticatedError) return
+          console.warn('[useRewards] cross-tab server refresh failed:', refreshErr)
+        })
     }
     window.addEventListener('storage', handleStorage)
     return () => window.removeEventListener('storage', handleStorage)
@@ -188,7 +265,13 @@ export function RewardsProvider({ children }: { children: ReactNode }) {
     return rewards.events.filter(e => e.action === action).length
   }, [rewards])
 
-  // Award coins for an action
+  // Award coins for an action.
+  //
+  // Updates local state + localStorage optimistically (so the UI is
+  // instantly responsive) and also mirrors the delta to the backend
+  // persistence endpoint when the user is authenticated. Network errors
+  // are logged but do NOT roll back the optimistic state — the next load
+  // will reconcile against the server row.
   const awardCoins = (action: RewardActionType, metadata?: Record<string, unknown>): boolean => {
     if (!rewards || !effectiveUserId) return false
 
@@ -228,6 +311,17 @@ export function RewardsProvider({ children }: { children: ReactNode }) {
 
     setRewards(updated)
     saveRewards(effectiveUserId, updated)
+
+    // Mirror to backend for authenticated sessions. Demo mode and the
+    // shared "demo-user" bucket are intentionally excluded — they have no
+    // JWT so the request would always 401.
+    const isDemoSession = getDemoMode() || effectiveUserId === DEMO_REWARDS_USER_ID
+    if (!isDemoSession) {
+      apiIncrementCoins(rewardConfig.coins).catch(err => {
+        if (err instanceof RewardsUnauthenticatedError) return
+        console.warn('[useRewards] failed to persist coin delta to backend:', err)
+      })
+    }
 
     return true
   }

--- a/web/src/hooks/useTokenUsage.ts
+++ b/web/src/hooks/useTokenUsage.ts
@@ -3,6 +3,12 @@ import { isAgentUnavailable, reportAgentDataSuccess, reportAgentDataError } from
 import { getDemoMode } from './useDemoMode'
 import { LOCAL_AGENT_HTTP_URL } from '../lib/constants'
 import { QUICK_ABORT_TIMEOUT_MS } from '../lib/constants/network'
+import {
+  getUserTokenUsage,
+  postTokenDelta,
+  TokenUsageUnauthenticatedError,
+  type UserTokenUsageRecord,
+} from '../lib/tokenUsageApi'
 
 /** Maximum token delta to attribute in a single poll cycle (prevents init spikes) */
 const MAX_SINGLE_DELTA_TOKENS = 50_000
@@ -18,6 +24,22 @@ const AGENT_SESSION_KEY = 'kc:tokenUsage:agentSession'
 
 /** Default category used when a delta arrives with no active operation */
 const DEFAULT_CATEGORY: TokenCategory = 'other'
+
+/**
+ * Maximum age (ms) of an unflushed pending delta before it MUST be sent to the
+ * backend even if the threshold-based trigger has not fired. Keeping this short
+ * means a logged-in user who closes the tab loses at most ~30s of attribution
+ * if `sendBeacon` is unavailable.
+ */
+const TOKEN_USAGE_FLUSH_INTERVAL_MS = 30_000
+
+/**
+ * Minimum total tokens accumulated across pending deltas before triggering a
+ * flush. Caps backend write traffic on heavy-usage sessions: ~1 POST per
+ * `TOKEN_USAGE_FLUSH_THRESHOLD` tokens of activity, regardless of how many
+ * individual deltas the local agent reports.
+ */
+const TOKEN_USAGE_FLUSH_THRESHOLD = 100
 
 export type TokenCategory = 'missions' | 'diagnose' | 'insights' | 'predictions' | 'other'
 
@@ -164,6 +186,153 @@ function persistUsage(lastKnown: number, sessionId: string | null): void {
   const persisted = loadPersistedUsage()
   lastKnownUsage = persisted.lastKnown
   lastKnownSessionId = persisted.sessionId
+}
+
+// --- Backend persistence layer (folded into PR #6032) ----------------------
+//
+// localStorage remains the fast cache (kept from PR #6020) but the server is
+// now the source of truth. On the first hook mount we hydrate from
+// `GET /api/token-usage/me`; subsequent deltas are mirrored to
+// `POST /api/token-usage/delta` via a debounced flusher so heavy-usage
+// sessions don't pound the API. Demo mode and unauth sessions skip the
+// backend entirely and continue to use localStorage only.
+
+/** True once we've successfully hydrated `sharedUsage` from the backend. */
+let backendHydrated = false
+/** True if a previous backend call returned 401 — disables further calls. */
+let backendUnauthenticated = false
+
+/**
+ * Pending per-category deltas accumulated since the last successful flush.
+ * Counts are non-negative; we never push negative deltas to the server (that
+ * would only happen on a baseline reset, which is handled by the
+ * GET-on-mount path, not by mirroring deltas).
+ */
+const pendingDeltas = new Map<TokenCategory, number>()
+let pendingDeltaTotal = 0
+let flushTimerId: ReturnType<typeof setTimeout> | null = null
+
+/**
+ * Hydrate the singleton `sharedUsage.byCategory` map from a backend record.
+ * Called from `startPolling` exactly once per session — not per hook instance.
+ * Demo mode and unauth sessions skip this entirely.
+ */
+async function hydrateFromBackend(): Promise<void> {
+  if (backendHydrated || backendUnauthenticated) return
+  if (typeof window === 'undefined') return
+  if (getDemoMode()) return
+  try {
+    const record: UserTokenUsageRecord = await getUserTokenUsage()
+    backendHydrated = true
+    // Merge: any byCategory keys present on the server overwrite local
+    // counters; categories the server doesn't know about (e.g. localStorage
+    // from a stale build) are preserved so we don't drop in-flight totals.
+    const merged: TokenUsageByCategory = { ...sharedUsage.byCategory }
+    for (const cat of ['missions', 'diagnose', 'insights', 'predictions', 'other'] as const) {
+      const v = record.tokens_by_category?.[cat]
+      if (typeof v === 'number' && Number.isFinite(v)) {
+        merged[cat] = v
+      }
+    }
+    // The backend marker overrides the localStorage one — server wins.
+    if (record.last_agent_session_id) {
+      lastKnownSessionId = record.last_agent_session_id
+    }
+    updateSharedUsage({ byCategory: merged }, true)
+  } catch (err) {
+    if (err instanceof TokenUsageUnauthenticatedError) {
+      backendUnauthenticated = true
+      return
+    }
+    // Network / 5xx — leave backendHydrated=false so we retry on the next
+    // hook mount, but don't crash polling.
+  }
+}
+
+/**
+ * Queue a per-category delta for backend flush. Called from the polling
+ * attribution path immediately after `updateSharedUsage`. Skipped in demo
+ * mode and after a 401.
+ */
+function queueBackendDelta(category: TokenCategory, delta: number): void {
+  if (backendUnauthenticated) return
+  if (typeof window === 'undefined') return
+  if (getDemoMode()) return
+  if (delta <= 0) return
+
+  pendingDeltas.set(category, (pendingDeltas.get(category) ?? 0) + delta)
+  pendingDeltaTotal += delta
+
+  if (pendingDeltaTotal >= TOKEN_USAGE_FLUSH_THRESHOLD) {
+    void flushPendingDeltas()
+    return
+  }
+  if (flushTimerId === null) {
+    flushTimerId = setTimeout(() => { void flushPendingDeltas() }, TOKEN_USAGE_FLUSH_INTERVAL_MS)
+  }
+}
+
+/**
+ * Flush all accumulated per-category deltas to the backend. Each category is
+ * sent as a separate `POST /api/token-usage/delta` so the server can track
+ * the per-category totals atomically. Failures swallow silently — the
+ * localStorage cache still has the data and the next page load will reconcile.
+ */
+async function flushPendingDeltas(): Promise<void> {
+  if (flushTimerId !== null) {
+    clearTimeout(flushTimerId)
+    flushTimerId = null
+  }
+  if (pendingDeltas.size === 0) return
+  // Snapshot and clear before awaiting so concurrent attributions don't
+  // double-send the same numbers.
+  const snapshot = Array.from(pendingDeltas.entries())
+  pendingDeltas.clear()
+  pendingDeltaTotal = 0
+
+  for (const [category, delta] of snapshot) {
+    if (delta <= 0) continue
+    try {
+      await postTokenDelta({
+        category,
+        delta,
+        agent_session_id: lastKnownSessionId ?? '',
+      })
+    } catch (err) {
+      if (err instanceof TokenUsageUnauthenticatedError) {
+        backendUnauthenticated = true
+        return
+      }
+      // Network blip — re-queue so the next flush picks it up.
+      pendingDeltas.set(category, (pendingDeltas.get(category) ?? 0) + delta)
+      pendingDeltaTotal += delta
+    }
+  }
+}
+
+// Best-effort flush on tab close. `sendBeacon` is keepalive so it survives
+// the unload — but only if the user is authenticated and there is something
+// pending. Browsers without sendBeacon fall back to the queued flush, which
+// will run if the user reopens the tab.
+if (typeof window !== 'undefined' && typeof navigator !== 'undefined') {
+  window.addEventListener('pagehide', () => {
+    if (backendUnauthenticated || pendingDeltas.size === 0) return
+    if (typeof navigator.sendBeacon !== 'function') return
+    for (const [category, delta] of pendingDeltas.entries()) {
+      if (delta <= 0) continue
+      const body = new Blob(
+        [JSON.stringify({ category, delta, agent_session_id: lastKnownSessionId ?? '' })],
+        { type: 'application/json' }
+      )
+      try {
+        navigator.sendBeacon('/api/token-usage/delta', body)
+      } catch {
+        // Ignore — best effort only.
+      }
+    }
+    pendingDeltas.clear()
+    pendingDeltaTotal = 0
+  })
 }
 
 // Initialize from localStorage
@@ -313,12 +482,14 @@ async function fetchTokenUsage() {
               const newByCategory = { ...sharedUsage.byCategory }
               newByCategory[DEFAULT_CATEGORY] += delta
               updateSharedUsage({ used: totalUsed, byCategory: newByCategory })
+              queueBackendDelta(DEFAULT_CATEGORY, delta)
             } else if (activeCount === 1) {
               // Single operation — attribute the entire delta to it.
               const category = activeCategoriesByOp.values().next().value as TokenCategory
               const newByCategory = { ...sharedUsage.byCategory }
               newByCategory[category] += delta
               updateSharedUsage({ used: totalUsed, byCategory: newByCategory })
+              queueBackendDelta(category, delta)
             } else {
               // Multiple concurrent operations — split the delta evenly
               // across all active operations. This is a best-effort
@@ -330,7 +501,9 @@ async function fetchTokenUsage() {
               const newByCategory = { ...sharedUsage.byCategory }
               let first = true
               for (const category of activeCategoriesByOp.values()) {
-                newByCategory[category] += perOp + (first ? remainder : 0)
+                const portion = perOp + (first ? remainder : 0)
+                newByCategory[category] += portion
+                queueBackendDelta(category, portion)
                 first = false
               }
               updateSharedUsage({ used: totalUsed, byCategory: newByCategory })
@@ -362,6 +535,10 @@ async function fetchTokenUsage() {
 function startPolling() {
   if (pollStarted) return
   pollStarted = true
+
+  // One-shot backend hydrate before the first poll attribution. Demo mode
+  // and unauth sessions are no-ops inside hydrateFromBackend.
+  void hydrateFromBackend()
 
   // Initial fetch
   fetchTokenUsage()

--- a/web/src/lib/rewardsApi.ts
+++ b/web/src/lib/rewardsApi.ts
@@ -1,0 +1,138 @@
+/**
+ * Typed client for the per-user rewards persistence API (issue #6011).
+ *
+ * These endpoints back the `useRewards` hook so that coin/point/level
+ * balances survive a browser cache wipe, private windows, and switching
+ * devices — the prior behavior lost everything because state lived only
+ * in `localStorage`.
+ *
+ * Every function here is a thin wrapper over `api.*` so callers get the
+ * shared auth header, backend-availability checks, 401 handling, and
+ * typed response envelopes for free.
+ */
+
+import { api, UnauthenticatedError, UnauthorizedError } from './api'
+
+/** Server-authoritative rewards row for the current user. */
+export interface UserRewardsRecord {
+  user_id: string
+  coins: number
+  points: number
+  level: number
+  bonus_points: number
+  /** RFC3339 timestamp; empty string when the daily bonus has never been claimed. */
+  last_daily_bonus_at?: string
+  updated_at: string
+}
+
+export interface DailyBonusResponse {
+  rewards: UserRewardsRecord
+  /** Number of bonus points awarded on this claim. */
+  bonus_amount: number
+}
+
+/**
+ * Signals that the user is unauthenticated (no JWT) and the reward
+ * endpoints cannot be called. The hook uses this to fall back to
+ * localStorage/demo-mode behavior without logging a noisy error.
+ */
+export class RewardsUnauthenticatedError extends Error {
+  constructor() {
+    super('rewards endpoints require authentication')
+    this.name = 'RewardsUnauthenticatedError'
+  }
+}
+
+/**
+ * Custom error thrown when the daily bonus is still on cooldown. Carries
+ * the current rewards state (if the server returned it) so the UI can
+ * still render balances without a second GET.
+ */
+export class DailyBonusUnavailableError extends Error {
+  rewards?: UserRewardsRecord
+  constructor(rewards?: UserRewardsRecord) {
+    super('daily bonus already claimed within cooldown window')
+    this.name = 'DailyBonusUnavailableError'
+    this.rewards = rewards
+  }
+}
+
+/** Normalizes `api.*` errors into the RewardsUnauthenticatedError type
+ * so callers have one narrow branch to handle for the 401 path. */
+function toRewardsError(err: unknown): Error {
+  if (err instanceof UnauthenticatedError || err instanceof UnauthorizedError) {
+    return new RewardsUnauthenticatedError()
+  }
+  if (err instanceof Error) return err
+  return new Error(String(err))
+}
+
+/**
+ * Fetch the current user's rewards row. Returns zero-state values for
+ * users who have never persisted anything — the server synthesizes the
+ * default row on read rather than requiring an explicit PUT first.
+ */
+export async function getUserRewards(): Promise<UserRewardsRecord> {
+  try {
+    const { data } = await api.get<UserRewardsRecord>('/api/rewards/me')
+    return data
+  } catch (err) {
+    throw toRewardsError(err)
+  }
+}
+
+/** Replace the entire rewards row for the current user (idempotent). */
+export async function putUserRewards(payload: {
+  coins: number
+  points: number
+  level: number
+  bonus_points: number
+}): Promise<UserRewardsRecord> {
+  try {
+    const { data } = await api.put<UserRewardsRecord>('/api/rewards/me', payload)
+    return data
+  } catch (err) {
+    throw toRewardsError(err)
+  }
+}
+
+/**
+ * Atomically add `delta` to the user's coin balance. Negative deltas are
+ * allowed; the server clamps the resulting balance to zero.
+ */
+export async function incrementCoins(delta: number): Promise<UserRewardsRecord> {
+  try {
+    const { data } = await api.post<UserRewardsRecord>('/api/rewards/coins', { delta })
+    return data
+  } catch (err) {
+    throw toRewardsError(err)
+  }
+}
+
+/**
+ * Claim today's daily bonus. Throws DailyBonusUnavailableError (carrying
+ * the unchanged rewards row when available) when the cooldown has not yet
+ * elapsed so the UI can display a friendly "come back tomorrow" message.
+ */
+export async function claimDailyBonus(): Promise<DailyBonusResponse> {
+  try {
+    const { data } = await api.post<DailyBonusResponse>('/api/rewards/daily-bonus', {})
+    return data
+  } catch (err) {
+    // api.post throws a plain Error for non-401 failures. We try to parse
+    // a 429 body off the message if the backend's JSON leaked through.
+    if (err instanceof UnauthenticatedError || err instanceof UnauthorizedError) {
+      throw new RewardsUnauthenticatedError()
+    }
+    if (err instanceof Error && err.message.includes('daily bonus already claimed')) {
+      // Body was captured as plain text by api.post — try JSON parse.
+      try {
+        const parsed = JSON.parse(err.message) as { rewards?: UserRewardsRecord }
+        throw new DailyBonusUnavailableError(parsed.rewards)
+      } catch {
+        throw new DailyBonusUnavailableError()
+      }
+    }
+    throw toRewardsError(err)
+  }
+}

--- a/web/src/lib/tokenUsageApi.ts
+++ b/web/src/lib/tokenUsageApi.ts
@@ -1,0 +1,98 @@
+/**
+ * Typed client for the per-user token-usage persistence API (folded into
+ * issue #6011 PR). The token-budget widget now reads from a server-side
+ * SQLite row instead of localStorage only, so clearing the browser cache,
+ * using a private window, or switching devices no longer wipes the
+ * accumulated counters. localStorage is preserved as a write-through
+ * cache for fast reads — see useTokenUsage.ts.
+ */
+
+import { api, UnauthenticatedError, UnauthorizedError } from './api'
+
+/** Server-authoritative token usage row for the current user. */
+export interface UserTokenUsageRecord {
+  user_id: string
+  total_tokens: number
+  /** Per-category breakdown; always a non-null object on the wire. */
+  tokens_by_category: Record<string, number>
+  /** Last kc-agent session marker the server has observed for this user. */
+  last_agent_session_id: string
+  /** RFC3339 timestamp of the last server-side write. */
+  updated_at: string
+}
+
+/**
+ * Body for `POST /api/token-usage/me` — clients send their full desired
+ * state and the server replaces the row.
+ */
+export interface PutUserTokenUsagePayload {
+  total_tokens: number
+  tokens_by_category: Record<string, number>
+  last_agent_session_id: string
+}
+
+/**
+ * Body for `POST /api/token-usage/delta` — atomic increment with
+ * restart-detection semantics: when `agent_session_id` differs from the
+ * stored marker, the server treats this call as a baseline reset and does
+ * NOT add the delta to the totals.
+ */
+export interface PostTokenDeltaPayload {
+  category: string
+  delta: number
+  agent_session_id: string
+}
+
+/**
+ * Signals that the user is unauthenticated and the token usage endpoints
+ * cannot be called. The hook uses this to fall back to localStorage-only
+ * behavior without logging a noisy error.
+ */
+export class TokenUsageUnauthenticatedError extends Error {
+  constructor() {
+    super('token usage endpoints require authentication')
+    this.name = 'TokenUsageUnauthenticatedError'
+  }
+}
+
+function toTokenUsageError(err: unknown): Error {
+  if (err instanceof UnauthenticatedError || err instanceof UnauthorizedError) {
+    return new TokenUsageUnauthenticatedError()
+  }
+  if (err instanceof Error) return err
+  return new Error(String(err))
+}
+
+/** Fetch the current user's token-usage row (zero-state if never written). */
+export async function getUserTokenUsage(): Promise<UserTokenUsageRecord> {
+  try {
+    const { data } = await api.get<UserTokenUsageRecord>('/api/token-usage/me')
+    return data
+  } catch (err) {
+    throw toTokenUsageError(err)
+  }
+}
+
+/** Replace the entire token-usage row for the current user. */
+export async function putUserTokenUsage(
+  payload: PutUserTokenUsagePayload
+): Promise<UserTokenUsageRecord> {
+  try {
+    const { data } = await api.post<UserTokenUsageRecord>('/api/token-usage/me', payload)
+    return data
+  } catch (err) {
+    throw toTokenUsageError(err)
+  }
+}
+
+/** Atomically add a delta to one category's counter. */
+export async function postTokenDelta(
+  payload: PostTokenDeltaPayload
+): Promise<UserTokenUsageRecord> {
+  try {
+    const { data } = await api.post<UserTokenUsageRecord>('/api/token-usage/delta', payload)
+    return data
+  } catch (err) {
+    throw toTokenUsageError(err)
+  }
+}


### PR DESCRIPTION
## Summary

Two related issues, one PR. Both are about per-user state being lost when the browser cache is cleared, the user switches devices, or they open a private window:

- **#6011** — coin / point / level / bonus balances were `localStorage`-only
- **Token usage state** (follow-up to #6020) — `lastKnownUsage` and `lastAgentSessionId` were `localStorage`-only

Both now live in server-side SQLite tables. localStorage stays as a fast cache.

---

## Issue #6011 — rewards persistence

### Backend
- New `user_rewards` table added to the inline `migrate()` in `pkg/store/sqlite.go`
- `Store` interface extends with `GetUserRewards`, `UpdateUserRewards`, `IncrementUserCoins` (atomic tx), `ClaimDailyBonus` (atomic tx with cooldown enforcement)
- Four new JWT-authenticated handlers in `pkg/api/handlers/rewards_persistence.go`:
  | Method | Path | Purpose |
  | --- | --- | --- |
  | `GET` | `/api/rewards/me` | Read current balance |
  | `PUT` | `/api/rewards/me` | Upsert full state |
  | `POST` | `/api/rewards/coins` | Atomic increment (`{"delta": N}`) |
  | `POST` | `/api/rewards/daily-bonus` | Claim once per 24h window |

  > Note: tracking issue suggested `/api/rewards` but that collides with the existing `/api/rewards/github` GitHub-activity proxy. The `/me` sub-path scopes the new mutable state cleanly.

### Frontend
- New typed client at `web/src/lib/rewardsApi.ts`
- `web/src/hooks/useRewards.tsx`: hydrate from backend on mount, optimistic mirror on `awardCoins`, storage event re-fetches from server
- Demo mode keeps the `DEMO_REWARDS_USER_ID` localStorage bucket exclusively

---

## Folded in — token usage persistence

### Backend
- New `user_token_usage` table (`total_tokens`, `tokens_by_category` JSON, `last_agent_session_id`, `updated_at`) in the same inline `migrate()`
- `Store` interface adds `GetUserTokenUsage`, `UpdateUserTokenUsage`, `AddUserTokenDelta`
- Three new handlers in `pkg/api/handlers/token_usage.go`:
  | Method | Path | Purpose |
  | --- | --- | --- |
  | `GET` | `/api/token-usage/me` | Read current totals + per-category breakdown |
  | `POST` | `/api/token-usage/me` | Full upsert |
  | `POST` | `/api/token-usage/delta` | Atomic per-category increment |
- **Restart semantics mirror #6020 frontend logic**: when `agent_session_id` differs from the stored marker, the server treats totals as a fresh baseline and skips the delta add
- `AddUserTokenDelta` uses a pinned connection with manual `BEGIN IMMEDIATE` / `COMMIT` so the read-merge-write is atomic under WAL mode (modernc/sqlite does NOT honor `sql.LevelSerializable`, and a default deferred tx allows torn updates — verified by a 16-way concurrent test)
- DSN now sets `busy_timeout=5000ms` to prevent immediate `SQLITE_BUSY` failures on contended connections
- Per-request validation: max delta 1M tokens, max 32 categories, max field value 10B (defense-in-depth)

### Frontend (`web/src/hooks/useTokenUsage.ts`)
- New typed client at `web/src/lib/tokenUsageApi.ts`
- One-shot backend hydrate on first hook mount (demo / unauth skip)
- Per-category deltas accumulate in a `Map` and flush via the `/delta` endpoint after either:
  - `TOKEN_USAGE_FLUSH_INTERVAL_MS = 30_000` ms, OR
  - `TOKEN_USAGE_FLUSH_THRESHOLD = 100` tokens accumulated, whichever first
- `pagehide` listener uses `navigator.sendBeacon` for best-effort flush on tab close
- Failed flushes re-queue the deltas; 401 disables further calls
- The localStorage cache from PR #6020 stays — backend is the source of truth on hydrate, localStorage covers fast reads + offline / unauth fallback

---

## Tests

Backend:
- `pkg/store/user_rewards_test.go` — zero-state, round-trip, negative-coin clamping, idempotent upsert, increment accumulation, daily-bonus first-claim, cooldown rejection, re-claim after cooldown
- `pkg/store/user_token_usage_test.go` — zero-state, round-trip, negative clamping, accumulation across calls, **session-change baseline reset**, negative-delta rejection, empty-category rejection, **16-way concurrent increment**
- `pkg/api/handlers/rewards_persistence_test.go` — runs against real SQLite, full handler matrix
- `pkg/api/handlers/token_usage_test.go` — GET zero, PUT round-trip, delta accumulation, session-change skip, negative reject, over-limit reject, too-many-categories reject

## Verification

```
go build ./...
go vet ./...
go test ./pkg/store/... ./pkg/api/handlers/... -count=1   # all pass
cd web && npm run build                                   # pass
```

Fixes #6011

## Test plan

- [ ] Sign in with a real GitHub session, earn some coins, clear browser cache, reload → balance survives
- [ ] Same flow but for token usage — open a mission to accumulate tokens, clear cache, reload → totals + per-category breakdown survive
- [ ] Open two authenticated tabs as the same user, earn coins in one → the other picks up the new total via the storage-event re-fetch
- [ ] Toggle demo mode → coin balance + token usage fall back to localStorage with no API calls
- [ ] Log out → subsequent mutations only touch localStorage, no 401 spam