### PR TITLE
fix(auth): persist OAuth state for restart resilience

### DIFF
--- a/pkg/api/handlers/auth.go
+++ b/pkg/api/handlers/auth.go
@@ -10,7 +10,6 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
-	"sync"
 	"time"
 
 	"github.com/gofiber/fiber/v2"
@@ -35,7 +34,7 @@ const (
 	// oauthStateExpiration is how long an OAuth state token remains valid.
 	oauthStateExpiration = 10 * time.Minute
 	// oauthStateCleanupInterval is how often the background goroutine sweeps
-	// for expired OAuth state entries.
+	// for expired OAuth state entries in the persistent store.
 	oauthStateCleanupInterval = 5 * time.Minute
 	// jwtExpiration is the lifetime of issued JWT tokens.
 	// Set to 7 days — the auth middleware signals clients to silently refresh
@@ -48,68 +47,29 @@ const (
 	defaultOAuthCallbackURL = "http://localhost:8080/auth/github/callback"
 )
 
-// oauthStateStore stores OAuth state tokens server-side (Safari blocks cookies in OAuth flows)
-var oauthStateStore = struct {
-	sync.RWMutex
-	states map[string]time.Time
-}{states: make(map[string]time.Time)}
-
-// init starts a background goroutine that periodically purges expired
-// OAuth state entries.  This ensures the map stays bounded even when no
-// new OAuth flows are initiated (the inline cleanup in storeOAuthState
-// only runs when a new state is added).
-func init() {
-	go func() {
-		ticker := time.NewTicker(oauthStateCleanupInterval)
-		defer ticker.Stop()
-		for range ticker.C {
-			purgeExpiredOAuthStates()
-		}
-	}()
+// storeOAuthState persists an OAuth CSRF state token in the backing store.
+//
+// Previously this lived in an in-process map, which meant a backend restart
+// between /auth/login and /auth/callback would drop every in-flight OAuth
+// flow and surface as `csrf_validation_failed` to users (issue #6028). The
+// persistent store makes OAuth flows resilient across restarts, as long as
+// the user completes the flow within oauthStateExpiration.
+func (h *AuthHandler) storeOAuthState(state string) error {
+	return h.store.StoreOAuthState(state, oauthStateExpiration)
 }
 
-// purgeExpiredOAuthStates removes all state entries older than oauthStateExpiration.
-func purgeExpiredOAuthStates() {
-	oauthStateStore.Lock()
-	defer oauthStateStore.Unlock()
-	now := time.Now()
-	for s, t := range oauthStateStore.states {
-		if now.Sub(t) > oauthStateExpiration {
-			delete(oauthStateStore.states, s)
-		}
+// validateAndConsumeOAuthState atomically looks up and deletes an OAuth state
+// token. Returns true only when the state was found, had not expired, and was
+// successfully consumed (single-use). Returns false on any error or miss so
+// callers can respond with a generic csrf_validation_failed without leaking
+// details.
+func (h *AuthHandler) validateAndConsumeOAuthState(state string) bool {
+	ok, err := h.store.ConsumeOAuthState(state)
+	if err != nil {
+		slog.Error("[Auth] failed to consume OAuth state", "error", err)
+		return false
 	}
-}
-
-// inlineCleanupThreshold is the map size above which storeOAuthState performs
-// an inline sweep of expired entries. Below this threshold, the background
-// goroutine handles cleanup, avoiding an O(n) scan on every insert.
-const inlineCleanupThreshold = 100
-
-func storeOAuthState(state string) {
-	oauthStateStore.Lock()
-	defer oauthStateStore.Unlock()
-	// Inline cleanup only when the map has grown large enough to warrant it.
-	// Under normal load (a few concurrent OAuth flows), the background sweep
-	// in purgeExpiredOAuthStates handles cleanup on its own.
-	if len(oauthStateStore.states) >= inlineCleanupThreshold {
-		now := time.Now()
-		for s, t := range oauthStateStore.states {
-			if now.Sub(t) > oauthStateExpiration {
-				delete(oauthStateStore.states, s)
-			}
-		}
-	}
-	oauthStateStore.states[state] = time.Now()
-}
-
-func validateAndConsumeOAuthState(state string) bool {
-	oauthStateStore.Lock()
-	defer oauthStateStore.Unlock()
-	if t, ok := oauthStateStore.states[state]; ok {
-		delete(oauthStateStore.states, state)
-		return time.Since(t) < oauthStateExpiration
-	}
-	return false
+	return ok
 }
 
 // isLocalhostURL returns true if the given URL points to a loopback address
@@ -207,7 +167,7 @@ func NewAuthHandler(s store.Store, cfg AuthConfig) *AuthHandler {
 		slog.Info("[Auth] GitHub Enterprise configured", "oauthURL", ghURL, "apiBase", apiBase)
 	}
 
-	return &AuthHandler{
+	h := &AuthHandler{
 		store: s,
 		oauthConfig: &oauth2.Config{
 			ClientID:     cfg.GitHubClientID,
@@ -225,6 +185,29 @@ func NewAuthHandler(s store.Store, cfg AuthConfig) *AuthHandler {
 		githubToken:    cfg.GitHubToken,
 		devMode:        cfg.DevMode,
 		skipOnboarding: cfg.SkipOnboarding,
+	}
+
+	// Periodically purge expired OAuth states from the persistent store so the
+	// oauth_states table does not grow unbounded in long-running processes.
+	// ConsumeOAuthState deletes individual rows on the happy path, but
+	// abandoned flows (user never returns to the callback) would otherwise
+	// linger until their expires_at passed with no cleanup.
+	go h.runOAuthStateCleanup()
+
+	return h
+}
+
+// runOAuthStateCleanup ticks every oauthStateCleanupInterval and removes
+// expired OAuth state rows. It runs for the lifetime of the process — the
+// AuthHandler has no explicit Close hook, matching the existing pattern in
+// the old in-memory init() goroutine.
+func (h *AuthHandler) runOAuthStateCleanup() {
+	ticker := time.NewTicker(oauthStateCleanupInterval)
+	defer ticker.Stop()
+	for range ticker.C {
+		if _, err := h.store.CleanupExpiredOAuthStates(); err != nil {
+			slog.Warn("[Auth] OAuth state cleanup failed", "error", err)
+		}
 	}
 }
 
@@ -255,8 +238,12 @@ func (h *AuthHandler) GitHubLogin(c *fiber.Ctx) error {
 	// Generate cryptographically secure state for CSRF protection
 	state := uuid.New().String()
 
-	// Store state server-side (Safari blocks cookies in OAuth redirect flows)
-	storeOAuthState(state)
+	// Persist state in the backing store (Safari blocks cookies in OAuth
+	// redirect flows, and an in-memory map would be lost on restart — #6028).
+	if err := h.storeOAuthState(state); err != nil {
+		slog.Error("[Auth] failed to store OAuth state", "error", err)
+		return h.oauthErrorRedirect(c, "oauth_state_store_failed", "")
+	}
 
 	url := h.oauthConfig.AuthCodeURL(state)
 	// Prevent Safari from caching the 307 redirect (which contains a unique CSRF state).
@@ -419,7 +406,7 @@ func (h *AuthHandler) GitHubCallback(c *fiber.Ctx) error {
 	// CSRF validation: verify state parameter matches server-side store
 	// (Safari blocks cookies in OAuth redirect flows, so we use server-side state)
 	state := c.Query("state")
-	if state == "" || !validateAndConsumeOAuthState(state) {
+	if state == "" || !h.validateAndConsumeOAuthState(state) {
 		slog.Error("[Auth] CSRF validation failed: invalid or expired state token")
 		return h.oauthErrorRedirect(c, "csrf_validation_failed", "")
 	}

--- a/pkg/api/handlers/auth_test.go
+++ b/pkg/api/handlers/auth_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -12,9 +13,11 @@ import (
 	"github.com/google/uuid"
 	"github.com/kubestellar/console/pkg/api/middleware"
 	"github.com/kubestellar/console/pkg/models"
+	"github.com/kubestellar/console/pkg/store"
 	"github.com/kubestellar/console/pkg/test"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 )
 
 // setupAuthTest creates a fresh Fiber app and an AuthHandler with a mock store
@@ -166,13 +169,19 @@ func TestRefreshToken(t *testing.T) {
 
 func TestGitHubLogin_Redirects(t *testing.T) {
 	app, _, _ := setupAuthTest()
+	// Use a real SQLiteStore so the handler can persist the OAuth state
+	// (the in-memory map was replaced by a store-backed write in #6028).
+	dbPath := filepath.Join(t.TempDir(), "github-login.db")
+	s, err := store.NewSQLiteStore(dbPath)
+	require.NoError(t, err)
+	defer s.Close()
 	// Override config to simulate existing OAuth credentials
 	cfg := AuthConfig{
 		GitHubClientID: "client-id",
 		GitHubSecret:   "secret",
 		BackendURL:     "http://backend",
 	}
-	handler := NewAuthHandler(nil, cfg)
+	handler := NewAuthHandler(s, cfg)
 	app.Get("/auth/github", handler.GitHubLogin)
 
 	req, _ := http.NewRequest("GET", "/auth/github", nil)
@@ -298,3 +307,85 @@ func TestClassifyExchangeError(t *testing.T) {
 
 // We cannot easily test successful GitHubCallback flow without mocking oauth lib
 // or doing extensive interface extraction, but we covered the error paths above.
+
+// newRealStoreAuthHandler creates an AuthHandler backed by a real SQLiteStore
+// so tests can exercise persistence behavior (#6028). Using a real store
+// instead of the mock lets us verify the end-to-end OAuth state round-trip
+// without wiring up testify expectations for every internal call.
+func newRealStoreAuthHandler(t *testing.T) (*AuthHandler, store.Store) {
+	t.Helper()
+	dbPath := filepath.Join(t.TempDir(), "auth-test.db")
+	s, err := store.NewSQLiteStore(dbPath)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = s.Close() })
+
+	cfg := AuthConfig{
+		GitHubClientID: "client-id",
+		GitHubSecret:   "secret",
+		JWTSecret:      "test-secret",
+		FrontendURL:    "http://frontend",
+		BackendURL:     "http://backend",
+	}
+	return NewAuthHandler(s, cfg), s
+}
+
+// TestOAuthStatePersistence_RoundTrip verifies that a state stored via the
+// handler helper can be consumed via the handler helper on the happy path.
+func TestOAuthStatePersistence_RoundTrip(t *testing.T) {
+	h, _ := newRealStoreAuthHandler(t)
+
+	const state = "round-trip-state"
+	require.NoError(t, h.storeOAuthState(state))
+
+	ok := h.validateAndConsumeOAuthState(state)
+	assert.True(t, ok, "freshly stored state should validate")
+
+	// Single-use: a second call must fail.
+	ok = h.validateAndConsumeOAuthState(state)
+	assert.False(t, ok, "consumed state should not validate twice")
+}
+
+// TestOAuthStatePersistence_SurvivesRestart simulates the #6028 scenario:
+// the backend restarts between /auth/login and /auth/callback. The user's
+// state was written to the persistent store on /login, and after a restart
+// the callback can still consume it successfully. With the old in-memory
+// map this test would fail with csrf_validation_failed.
+func TestOAuthStatePersistence_SurvivesRestart(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "restart.db")
+
+	// First "process" — /auth/login stores the state.
+	s1, err := store.NewSQLiteStore(dbPath)
+	require.NoError(t, err)
+	h1 := NewAuthHandler(s1, AuthConfig{
+		GitHubClientID: "client-id",
+		GitHubSecret:   "secret",
+		JWTSecret:      "test-secret",
+		FrontendURL:    "http://frontend",
+		BackendURL:     "http://backend",
+	})
+	const state = "state-across-restart"
+	require.NoError(t, h1.storeOAuthState(state))
+	require.NoError(t, s1.Close())
+
+	// Second "process" — /auth/callback consumes the state after restart.
+	s2, err := store.NewSQLiteStore(dbPath)
+	require.NoError(t, err)
+	defer s2.Close()
+	h2 := NewAuthHandler(s2, AuthConfig{
+		GitHubClientID: "client-id",
+		GitHubSecret:   "secret",
+		JWTSecret:      "test-secret",
+		FrontendURL:    "http://frontend",
+		BackendURL:     "http://backend",
+	})
+
+	ok := h2.validateAndConsumeOAuthState(state)
+	assert.True(t, ok, "OAuth state must survive backend restart (#6028)")
+}
+
+// TestOAuthStatePersistence_InvalidStateRejected ensures unknown states
+// continue to fail CSRF validation — no regression in the rejection path.
+func TestOAuthStatePersistence_InvalidStateRejected(t *testing.T) {
+	h, _ := newRealStoreAuthHandler(t)
+	assert.False(t, h.validateAndConsumeOAuthState("never-issued"))
+}

--- a/pkg/store/oauth_states_test.go
+++ b/pkg/store/oauth_states_test.go
@@ -1,0 +1,109 @@
+package store
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// oauthStateTestTTL is a generous TTL used when the test does not care about
+// expiry — long enough that the state will not lapse during a single test.
+const oauthStateTestTTL = 5 * time.Minute
+
+// oauthStateExpiredTTL is a negative TTL used to force the state to be
+// "already expired" at the moment it is stored.
+const oauthStateExpiredTTL = -1 * time.Second
+
+func TestOAuthStateRoundTrip(t *testing.T) {
+	s := newTestStore(t)
+
+	t.Run("StoreOAuthState and ConsumeOAuthState round-trip", func(t *testing.T) {
+		const state = "state-happy-path"
+		require.NoError(t, s.StoreOAuthState(state, oauthStateTestTTL))
+
+		ok, err := s.ConsumeOAuthState(state)
+		require.NoError(t, err)
+		require.True(t, ok, "fresh state should validate on first consume")
+	})
+
+	t.Run("ConsumeOAuthState is single-use", func(t *testing.T) {
+		const state = "state-single-use"
+		require.NoError(t, s.StoreOAuthState(state, oauthStateTestTTL))
+
+		ok, err := s.ConsumeOAuthState(state)
+		require.NoError(t, err)
+		require.True(t, ok)
+
+		// Second consume must fail — the row was deleted.
+		ok, err = s.ConsumeOAuthState(state)
+		require.NoError(t, err)
+		require.False(t, ok, "already-consumed state must not validate again")
+	})
+
+	t.Run("ConsumeOAuthState returns false for unknown state", func(t *testing.T) {
+		ok, err := s.ConsumeOAuthState("never-stored")
+		require.NoError(t, err)
+		require.False(t, ok)
+	})
+
+	t.Run("ConsumeOAuthState returns false for expired state", func(t *testing.T) {
+		const state = "state-expired"
+		require.NoError(t, s.StoreOAuthState(state, oauthStateExpiredTTL))
+
+		ok, err := s.ConsumeOAuthState(state)
+		require.NoError(t, err)
+		require.False(t, ok, "expired state must not validate")
+
+		// It should also be deleted so a retry does not succeed either.
+		ok, err = s.ConsumeOAuthState(state)
+		require.NoError(t, err)
+		require.False(t, ok, "expired state should have been deleted on first consume")
+	})
+}
+
+func TestCleanupExpiredOAuthStates(t *testing.T) {
+	s := newTestStore(t)
+
+	// Seed a mix of expired and valid states.
+	require.NoError(t, s.StoreOAuthState("expired-1", oauthStateExpiredTTL))
+	require.NoError(t, s.StoreOAuthState("expired-2", oauthStateExpiredTTL))
+	require.NoError(t, s.StoreOAuthState("valid-1", oauthStateTestTTL))
+
+	removed, err := s.CleanupExpiredOAuthStates()
+	require.NoError(t, err)
+	require.Equal(t, int64(2), removed)
+
+	// Valid entry should still consume successfully.
+	ok, err := s.ConsumeOAuthState("valid-1")
+	require.NoError(t, err)
+	require.True(t, ok)
+
+	// Expired entries should be gone.
+	ok, err = s.ConsumeOAuthState("expired-1")
+	require.NoError(t, err)
+	require.False(t, ok)
+}
+
+// TestOAuthStateSurvivesRestart simulates the #6028 scenario: an OAuth state
+// is stored in the DB, the process "restarts" (we drop the in-memory handle
+// and reopen the same DB file), and the callback still validates.
+func TestOAuthStateSurvivesRestart(t *testing.T) {
+	dbPath := t.TempDir() + "/restart.db"
+
+	s1, err := NewSQLiteStore(dbPath)
+	require.NoError(t, err)
+
+	const state = "state-across-restart"
+	require.NoError(t, s1.StoreOAuthState(state, oauthStateTestTTL))
+	require.NoError(t, s1.Close())
+
+	// "Restart" — reopen the same DB file from scratch.
+	s2, err := NewSQLiteStore(dbPath)
+	require.NoError(t, err)
+	defer s2.Close()
+
+	ok, err := s2.ConsumeOAuthState(state)
+	require.NoError(t, err)
+	require.True(t, ok, "OAuth state should survive a process restart (#6028)")
+}

--- a/pkg/store/sqlite.go
+++ b/pkg/store/sqlite.go
@@ -265,6 +265,15 @@ func (s *SQLiteStore) migrate() error {
 		expires_at DATETIME NOT NULL
 	);
 	CREATE INDEX IF NOT EXISTS idx_revoked_tokens_expires ON revoked_tokens(expires_at);
+
+	-- OAuth state tokens (persisted so in-flight OAuth flows survive a
+	-- backend restart between /auth/login and /auth/callback — see issue #6028).
+	CREATE TABLE IF NOT EXISTS oauth_states (
+		state TEXT PRIMARY KEY,
+		created_at TIMESTAMP NOT NULL,
+		expires_at TIMESTAMP NOT NULL
+	);
+	CREATE INDEX IF NOT EXISTS idx_oauth_states_expires_at ON oauth_states(expires_at);
 	`
 	_, err := s.db.Exec(schema)
 	if err != nil {
@@ -1693,6 +1702,71 @@ func (s *SQLiteStore) IsTokenRevoked(jti string) (bool, error) {
 func (s *SQLiteStore) CleanupExpiredTokens() (int64, error) {
 	result, err := s.db.Exec(
 		`DELETE FROM revoked_tokens WHERE expires_at < ?`, time.Now(),
+	)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected()
+}
+
+// OAuth State methods — persist OAuth state tokens so in-flight logins survive
+// a backend restart between /auth/login and /auth/callback (issue #6028).
+
+// StoreOAuthState persists an OAuth state token with the given time-to-live.
+// The state is a single-use CSRF token; ConsumeOAuthState must be called once
+// to validate and delete it on the callback.
+func (s *SQLiteStore) StoreOAuthState(state string, ttl time.Duration) error {
+	now := time.Now()
+	expiresAt := now.Add(ttl)
+	_, err := s.db.Exec(
+		`INSERT INTO oauth_states (state, created_at, expires_at) VALUES (?, ?, ?)`,
+		state, now, expiresAt,
+	)
+	return err
+}
+
+// ConsumeOAuthState atomically looks up and deletes an OAuth state token in a
+// single transaction. It returns true only when the state exists, has not
+// expired, and was successfully deleted — ensuring single-use semantics.
+//
+// Expired states are also deleted to keep the table lean, but the call still
+// returns false for them so the caller treats the flow as invalid.
+func (s *SQLiteStore) ConsumeOAuthState(state string) (bool, error) {
+	tx, err := s.db.Begin()
+	if err != nil {
+		return false, err
+	}
+	// Rollback is a no-op after a successful Commit.
+	defer tx.Rollback()
+
+	var expiresAt time.Time
+	err = tx.QueryRow(
+		`SELECT expires_at FROM oauth_states WHERE state = ?`, state,
+	).Scan(&expiresAt)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return false, nil
+		}
+		return false, err
+	}
+
+	// Delete unconditionally — whether the state is valid or expired, it should
+	// not be reusable after this call.
+	if _, err := tx.Exec(`DELETE FROM oauth_states WHERE state = ?`, state); err != nil {
+		return false, err
+	}
+	if err := tx.Commit(); err != nil {
+		return false, err
+	}
+
+	return time.Now().Before(expiresAt), nil
+}
+
+// CleanupExpiredOAuthStates removes OAuth state rows whose expires_at has
+// passed. Returns the number of rows deleted.
+func (s *SQLiteStore) CleanupExpiredOAuthStates() (int64, error) {
+	result, err := s.db.Exec(
+		`DELETE FROM oauth_states WHERE expires_at < ?`, time.Now(),
 	)
 	if err != nil {
 		return 0, err

--- a/pkg/store/store.go
+++ b/pkg/store/store.go
@@ -106,6 +106,15 @@ type Store interface {
 	IsTokenRevoked(jti string) (bool, error)
 	CleanupExpiredTokens() (int64, error)
 
+	// OAuth State (persisted across server restarts so in-flight OAuth
+	// flows survive a backend restart between /auth/login and /auth/callback).
+	StoreOAuthState(state string, ttl time.Duration) error
+	// ConsumeOAuthState atomically looks up and deletes an OAuth state token.
+	// Returns true only when the state was found, not expired, and successfully
+	// deleted (single-use). Returns false for missing, expired, or already-consumed states.
+	ConsumeOAuthState(state string) (bool, error)
+	CleanupExpiredOAuthStates() (int64, error)
+
 	// Lifecycle
 	Close() error
 }

--- a/pkg/test/mock_store.go
+++ b/pkg/test/mock_store.go
@@ -187,4 +187,34 @@ func (m *MockStore) RevokeToken(jti string, expiresAt time.Time) error { return 
 func (m *MockStore) IsTokenRevoked(jti string) (bool, error)           { return false, nil }
 func (m *MockStore) CleanupExpiredTokens() (int64, error)              { return 0, nil }
 
+// OAuth state — overridable via testify/mock expectations so tests can
+// exercise restart-resilience of the OAuth flow (#6028).
+func (m *MockStore) StoreOAuthState(state string, ttl time.Duration) error {
+	if len(m.ExpectedCalls) == 0 {
+		return nil
+	}
+	for _, call := range m.ExpectedCalls {
+		if call.Method == "StoreOAuthState" {
+			args := m.Called(state, ttl)
+			return args.Error(0)
+		}
+	}
+	return nil
+}
+
+func (m *MockStore) ConsumeOAuthState(state string) (bool, error) {
+	if len(m.ExpectedCalls) == 0 {
+		return false, nil
+	}
+	for _, call := range m.ExpectedCalls {
+		if call.Method == "ConsumeOAuthState" {
+			args := m.Called(state)
+			return args.Bool(0), args.Error(1)
+		}
+	}
+	return false, nil
+}
+
+func (m *MockStore) CleanupExpiredOAuthStates() (int64, error) { return 0, nil }
+
 func (m *MockStore) Close() error { return nil }


### PR DESCRIPTION
Fixes #6028. Stacked on #6031 (base branch will auto-update to \`main\` once #6031 merges).

## Problem

\`pkg/api/handlers/auth.go\` stored OAuth CSRF state tokens in an in-memory \`map[string]time.Time\`. If the backend restarted between \`/auth/login\` (where the state is generated and the user is redirected to GitHub) and \`/auth/github/callback\` (where the state must be validated), the map was gone and every in-flight user hit \`csrf_validation_failed\`.

## Fix

Persist OAuth state in the backing store so in-flight flows survive restarts, as long as the user completes them within \`oauthStateExpiration\` (10 minutes, unchanged).

- **New table** \`oauth_states (state PRIMARY KEY, created_at, expires_at)\` with an index on \`expires_at\`, added to \`pkg/store/sqlite.go\` \`migrate()\` next to \`revoked_tokens\`.
- **Store interface** gains three additive methods:
  - \`StoreOAuthState(state, ttl)\`
  - \`ConsumeOAuthState(state) (bool, error)\` — single transaction that \`SELECT\`s, \`DELETE\`s, and returns whether the row existed and had not expired. Always deletes so a row cannot be reused even on the expired/invalid path.
  - \`CleanupExpiredOAuthStates() (int64, error)\`
- **auth.go**:
  - Removed the global \`oauthStateStore\` map, its \`sync.RWMutex\`, the package-level \`init()\` goroutine, \`purgeExpiredOAuthStates\`, and \`inlineCleanupThreshold\`.
  - \`storeOAuthState\` / \`validateAndConsumeOAuthState\` are now methods on \`*AuthHandler\` delegating to the store.
  - \`NewAuthHandler\` starts a per-handler cleanup ticker (\`oauthStateCleanupInterval = 5m\`) that calls \`CleanupExpiredOAuthStates\`.
  - \`GitHubLogin\` now returns \`oauth_state_store_failed\` if the DB write fails (new, narrow error path).
- **MockStore** in \`pkg/test/mock_store.go\` gains overridable implementations of all three methods.

## Tests

- \`pkg/store/oauth_states_test.go\` — round-trip, single-use semantics, unknown state, expired state (including rejection on retry), bulk cleanup, and a **reopen-the-same-SQLite-file restart** test.
- \`pkg/api/handlers/auth_test.go\` — three new tests using a real \`SQLiteStore\`:
  - \`TestOAuthStatePersistence_RoundTrip\`
  - \`TestOAuthStatePersistence_SurvivesRestart\` — instantiates two \`AuthHandler\`s against the same DB file to simulate the restart scenario from #6028
  - \`TestOAuthStatePersistence_InvalidStateRejected\`
- Fixed \`TestGitHubLogin_Redirects\` to pass a real store instead of \`nil\` (storeOAuthState now requires one).

## Verification

\`\`\`
go build ./...                                      # clean
go vet ./...                                        # clean
go test ./pkg/store/... ./pkg/api/handlers/...      # PASS
cd web && npm run build                             # PASS
\`\`\`

## Notes

- No magic numbers — all intervals/TTLs go through the existing \`oauthStateExpiration\` / \`oauthStateCleanupInterval\` constants.
- No other handlers in \`auth.go\` were touched.
- The DB-backed approach is consistent with the existing \`revoked_tokens\` pattern added for token revocation.