### PR TITLE
ci(build): native arm64 runner instead of QEMU — cuts PR builds from 40m to ~5m

### DIFF
--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -50,22 +50,36 @@ env:
   HELM_RELEASE_NAME: kc
 
 jobs:
+  # Build each platform on its NATIVE runner in parallel. Previously this
+  # workflow built linux/amd64 + linux/arm64 in a single ubuntu-latest job
+  # using QEMU emulation for arm64, which made every PR pay ~35 minutes for
+  # the emulated arm64 leg (total ~40 min wall-clock). With native runners
+  # the two legs run side-by-side in ~3-5 min each, so PR builds drop to
+  # roughly 5-7 min wall-clock total.
+  #
+  # Each matrix leg pushes its single-arch image to GHCR by digest only
+  # (no human-readable tag). The `merge` job then assembles the multi-arch
+  # manifest list under the real tags. PR builds skip both the push and
+  # the merge — they just verify each platform compiles on its real CPU.
   build:
-    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            runner: ubuntu-24.04
+            arch: amd64
+          - platform: linux/arm64
+            runner: ubuntu-24.04-arm
+            arch: arm64
+    runs-on: ${{ matrix.runner }}
     permissions:
       contents: read
       packages: write
 
-    outputs:
-      image_tag: ${{ steps.meta.outputs.tags }}
-      image_digest: ${{ steps.build.outputs.digest }}
-
     steps:
       - name: Checkout repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392 # v3.6.0
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3.10.0
@@ -84,29 +98,95 @@ jobs:
         with:
           images: |
             ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-          tags: |
-            type=ref,event=branch
-            type=ref,event=pr
-            type=sha,prefix=,format=long
-            type=raw,value=latest,enable={{is_default_branch}}
 
-      - name: Build and push Docker image
+      - name: Build and push by digest
         id: build
         uses: docker/build-push-action@14487ce63c7a62a4a324b0bfb37086795e31c6c1 # v6.16.0
         with:
           context: .
-          push: ${{ github.event_name != 'pull_request' }}
-          platforms: linux/amd64,linux/arm64
-          tags: ${{ steps.meta.outputs.tags }}
+          platforms: ${{ matrix.platform }}
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
             APP_VERSION=main-${{ github.sha }}
             COMMIT_HASH=${{ github.sha }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          # push-by-digest writes the image to GHCR with no tag — only the
+          # digest is referenceable until `merge` assembles the manifest.
+          # On PRs we drop the push entirely so the build still verifies
+          # but does not consume registry storage.
+          outputs: type=image,name=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }},push-by-digest=true,name-canonical=true,push=${{ github.event_name != 'pull_request' }}
+          # Per-architecture cache scope so amd64 and arm64 don't evict
+          # each other's layers from a shared scope (which would cause
+          # cold rebuilds on every PR).
+          cache-from: type=gha,scope=build-${{ matrix.arch }}
+          cache-to: type=gha,mode=max,scope=build-${{ matrix.arch }}
+
+      - name: Export digest
+        if: github.event_name != 'pull_request'
+        run: |
+          mkdir -p "${RUNNER_TEMP}/digests"
+          digest="${{ steps.build.outputs.digest }}"
+          touch "${RUNNER_TEMP}/digests/${digest#sha256:}"
+
+      - name: Upload digest
+        if: github.event_name != 'pull_request'
+        uses: actions/upload-artifact@v4
+        with:
+          name: digests-${{ matrix.arch }}
+          path: ${{ runner.temp }}/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  # Combine the per-architecture digests into a multi-arch manifest list
+  # under all the real tags (sha, branch, latest). Skipped on PRs because
+  # nothing was pushed in the build matrix above.
+  merge:
+    if: github.event_name != 'pull_request'
+    runs-on: ubuntu-latest
+    needs: build
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Download digests
+        uses: actions/download-artifact@v4
+        with:
+          path: ${{ runner.temp }}/digests
+          pattern: digests-*
+          merge-multiple: true
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3.10.0
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@902fa8ec7d6ecbf8d84d538b9b233a880e428804 # v5.7.0
+        with:
+          images: |
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=ref,event=branch
+            type=sha,prefix=,format=long
+            type=raw,value=latest,enable={{is_default_branch}}
+
+      - name: Create manifest list and push
+        working-directory: ${{ runner.temp }}/digests
+        run: |
+          docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+            $(printf '${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@sha256:%s ' *)
+
+      - name: Inspect image
+        run: |
+          docker buildx imagetools inspect ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }}
 
   deploy-vllm-d:
-    needs: build
+    needs: merge
     if: github.ref == 'refs/heads/main' && github.event_name != 'pull_request'
     runs-on: [self-hosted, kc, openshift]
     environment: vllm-d
@@ -202,7 +282,7 @@ jobs:
           echo "Access KC at: https://kc.apps.fmaas-vllm-d.fmaas.res.ibm.com"
 
   deploy-pok-prod:
-    needs: build
+    needs: merge
     if: github.ref == 'refs/heads/main' && github.event_name != 'pull_request'
     runs-on: [self-hosted, kc-pok]
     environment: pok-prod


### PR DESCRIPTION
## Summary

Replaces QEMU-emulated arm64 builds in `build-deploy.yml` with a matrix that runs each platform on its native runner in parallel:
- `linux/amd64` → `ubuntu-24.04`
- `linux/arm64` → `ubuntu-24.04-arm` (GitHub-hosted, free for public repos)

A new `merge` job assembles the per-platform digests into a multi-arch manifest list under the real tags after both build legs finish.

## Why

Every PR currently takes ~40 minutes for the build check (PR #6030 just took 40m21s; PR #6018 took 43m24s). Investigation showed the cause is **arm64 builds running under QEMU userspace emulation** on an x86 runner — `npm install`, Vite bundle, and Go compile all run ~5-10× slower under qemu, and buildkit serializes the two platforms in a single `docker buildx build` call. amd64 finishes in ~5 min; the arm64 leg drags the whole job to 35-40 min.

## Expected impact

| | Before | After |
|---|---|---|
| PR build wall-clock | 40 min | 5-7 min |
| Push-to-main wall-clock | 40 min | 5-7 min build + ~30s merge |
| Registry storage on PRs | 0 (already \`push: false\`) | 0 (still \`push=false\` on PRs) |
| Multi-arch manifest on main | yes | yes (assembled by merge job) |

## Pattern

This is the standard docker/build-push-action multi-platform matrix pattern:
1. \`build\` matrix → each leg builds one platform with \`outputs: type=image,push-by-digest=true\`
2. Each leg uploads its digest as a workflow artifact
3. \`merge\` job downloads both digests and runs \`docker buildx imagetools create\` to assemble the manifest list under the metadata-action tags
4. Deploys (\`deploy-vllm-d\`, \`deploy-pok-prod\`) now \`needs: merge\` instead of \`needs: build\` — the image they reference (\`image.tag=sha\`) is unchanged

## Other tweaks

- Per-arch GHA cache scopes (\`build-amd64\` / \`build-arm64\`) so the two legs don't evict each other's layers
- Removed \`docker/setup-qemu-action\` — no longer needed
- \`fail-fast: false\` so if one platform breaks the other still runs

## Test plan

- [ ] PR triggers both \`build (linux/amd64)\` and \`build (linux/arm64)\` checks; both pass in ~5 min each
- [ ] PR does NOT trigger \`merge\` (gated on \`github.event_name != 'pull_request'\`)
- [ ] After merge to main: \`build\` matrix runs, then \`merge\` runs, then deploys run
- [ ] \`docker buildx imagetools inspect ghcr.io/kubestellar/console:<sha>\` shows both platforms in the manifest list