### PR TITLE
fix(store): address Copilot nits from PR #6030

### DIFF
--- a/pkg/store/sqlite.go
+++ b/pkg/store/sqlite.go
@@ -81,7 +81,7 @@ type SQLiteStore struct {
 
 // NewSQLiteStore creates a new SQLite store
 func NewSQLiteStore(dbPath string) (*SQLiteStore, error) {
-	// DSN notes (modernc.org/sqlite accepts PRAGMAs via _pragma=key=value):
+	// DSN notes (modernc.org/sqlite accepts PRAGMAs via _pragma=key(value)):
 	//  - journal_mode=WAL enables Write-Ahead Logging so readers don't
 	//    block writers.
 	//  - synchronous=NORMAL is the recommended pairing with WAL for good

--- a/pkg/store/sqlite_test.go
+++ b/pkg/store/sqlite_test.go
@@ -417,12 +417,13 @@ func TestCreateCardWithLimit(t *testing.T) {
 		const concurrentInserters = 16
 
 		var (
-			wg            sync.WaitGroup
-			successes     int64
-			rejections    int64
-			otherErrs     int64
-			firstOtherErr atomic.Value
-			start         = make(chan struct{})
+			wg              sync.WaitGroup
+			successes       int64
+			rejections      int64
+			otherErrs       int64
+			firstOtherErrMu sync.Mutex
+			firstOtherErr   string
+			start           = make(chan struct{})
 		)
 
 		wg.Add(concurrentInserters)
@@ -443,16 +444,22 @@ func TestCreateCardWithLimit(t *testing.T) {
 					atomic.AddInt64(&rejections, 1)
 				default:
 					atomic.AddInt64(&otherErrs, 1)
-					firstOtherErr.CompareAndSwap(nil, err.Error())
+					firstOtherErrMu.Lock()
+					if firstOtherErr == "" {
+						firstOtherErr = err.Error()
+					}
+					firstOtherErrMu.Unlock()
 				}
 			}()
 		}
 		close(start)
 		wg.Wait()
 
-		if v := firstOtherErr.Load(); v != nil {
-			t.Logf("first unexpected error: %v", v)
+		firstOtherErrMu.Lock()
+		if firstOtherErr != "" {
+			t.Logf("first unexpected error: %s", firstOtherErr)
 		}
+		firstOtherErrMu.Unlock()
 		require.Zero(t, atomic.LoadInt64(&otherErrs), "no unexpected errors")
 		require.Equal(t, int64(cardLimitTest), atomic.LoadInt64(&successes),
 			"exactly cardLimitTest inserts should succeed under concurrency")


### PR DESCRIPTION
## Summary

Two small cleanups flagged by Copilot on the merged PR #6030 (the `CreateCardWithLimit` race fix).

## Changes

1. **`pkg/store/sqlite_test.go`** — replace `atomic.Value` with `sync.Mutex` + `string` for the `firstOtherErr` capture in `TestCreateCardWithLimit`. The original used `firstOtherErr.CompareAndSwap(nil, err.Error())` which works in practice but the API is fragile: the first call sets the concrete type, subsequent calls with a mismatched type panic. A plain mutex captures the same "first observed error" semantics with fewer sharp edges.

2. **`pkg/store/sqlite.go` DSN comment** — the comment said `modernc.org/sqlite accepts PRAGMAs via _pragma=key=value` but the actual DSN uses the `_pragma=key(value)` form (e.g. `_pragma=foreign_keys(on)`). Fixed the comment to match the code.

## Verification

```
go build ./...
go vet ./...
go test ./pkg/store/... -run CreateCardWithLimit -count=1   # pass
```

Fixes #6036