### PR TITLE
fix(sse): warning-events stream applies cluster/limit and surfaces per-cluster errors

### DIFF
--- a/pkg/api/handlers/sse.go
+++ b/pkg/api/handlers/sse.go
@@ -6,11 +6,40 @@ import (
 	"encoding/json"
 	"fmt"
 	"log/slog"
+	"strconv"
 	"sync"
 	"time"
 
 	"github.com/gofiber/fiber/v2"
+	"github.com/kubestellar/console/pkg/k8s"
 )
+
+// defaultWarningEventsLimit is the fallback row limit used by
+// GetWarningEventsStream when the client omits or sends an invalid `limit`
+// query parameter.
+const defaultWarningEventsLimit = 50
+
+// maxWarningEventsLimit is the upper bound the warning-events stream clamps
+// the `limit` query parameter to, preventing unbounded result sets from
+// starving the per-cluster fetch timeout.
+const maxWarningEventsLimit = 500
+
+// sseEventClusterData is the SSE event name used for per-cluster success payloads.
+const sseEventClusterData = "cluster_data"
+
+// sseEventClusterSkipped is the SSE event name used for clusters known to be
+// offline and therefore skipped before a fetch is attempted.
+const sseEventClusterSkipped = "cluster_skipped"
+
+// sseEventClusterError is the SSE event name used to surface per-cluster
+// fetch failures to the client (#6041). The payload is
+// {"cluster": "...", "error": "..."} and lets the UI mark individual
+// clusters as errored instead of silently dropping them.
+const sseEventClusterError = "cluster_error"
+
+// sseEventDone is the terminal SSE event fired once all per-cluster work has
+// completed (or the overall deadline has been reached).
+const sseEventDone = "done"
 
 // sseClusterStreamConfig describes a single streaming endpoint configuration.
 type sseClusterStreamConfig struct {
@@ -23,6 +52,10 @@ type sseClusterStreamConfig struct {
 	namespace string
 	// clusterTimeout is the per-cluster fetch timeout.
 	clusterTimeout time.Duration
+	// clusterFilter, when non-empty, restricts streaming to a single cluster
+	// (matched against ClusterInfo.Name). If the named cluster is not present
+	// in the dedupe set the handler responds with 404 (#6039).
+	clusterFilter string
 }
 
 // writeSSEEvent writes one SSE event to the buffered writer and flushes.
@@ -139,6 +172,41 @@ func streamClusters(
 		return c.Status(500).JSON(fiber.Map{"error": "internal server error"})
 	}
 
+	// Apply optional per-request cluster filter (#6039). If the caller asks
+	// for a specific cluster we only stream from that one — either from the
+	// healthy set or, if it's known offline, emit a single skipped event.
+	// Unknown cluster names return 404 so the client can distinguish "empty
+	// result" from "typo/stale reference".
+	if cfg.clusterFilter != "" {
+		filteredHealthy := make([]k8s.ClusterInfo, 0, 1)
+		filteredOffline := make([]k8s.ClusterInfo, 0, 1)
+		found := false
+		for _, cl := range healthy {
+			if cl.Name == cfg.clusterFilter {
+				filteredHealthy = append(filteredHealthy, cl)
+				found = true
+				break
+			}
+		}
+		if !found {
+			for _, cl := range offline {
+				if cl.Name == cfg.clusterFilter {
+					filteredOffline = append(filteredOffline, cl)
+					found = true
+					break
+				}
+			}
+		}
+		if !found {
+			return c.Status(404).JSON(fiber.Map{
+				"error":   "cluster not found",
+				"cluster": cfg.clusterFilter,
+			})
+		}
+		healthy = filteredHealthy
+		offline = filteredOffline
+	}
+
 	c.Set("Content-Type", "text/event-stream")
 	c.Set("Cache-Control", "no-cache")
 	c.Set("Connection", "keep-alive")
@@ -158,7 +226,7 @@ func streamClusters(
 
 		// Instantly emit skipped events for offline clusters
 		for _, cl := range offline {
-			writeSSEEvent(w, "cluster_skipped", fiber.Map{
+			writeSSEEvent(w, sseEventClusterSkipped, fiber.Map{
 				"cluster": cl.Name,
 				"reason":  "offline",
 			})
@@ -177,7 +245,7 @@ func streamClusters(
 			if cached := sseCacheGet(cacheKey); cached != nil {
 				mu.Lock()
 				completedClusters++
-				writeSSEEvent(w, "cluster_data", fiber.Map{
+				writeSSEEvent(w, sseEventClusterData, fiber.Map{
 					"cluster":   cl.Name,
 					cfg.demoKey: cached,
 					"source":    "cache",
@@ -210,8 +278,18 @@ func streamClusters(
 					if elapsed > 5*time.Second {
 						h.k8sClient.MarkSlow(clusterName)
 					}
+					// Surface the per-cluster failure to the client as an SSE
+					// event so the UI can mark the cluster as errored instead
+					// of silently dropping it (#6041). The existing
+					// `cluster_data` / `cluster_skipped` events are
+					// intentionally left unchanged — this is an additive
+					// event type.
 					mu.Lock()
 					completedClusters++
+					writeSSEEvent(w, sseEventClusterError, fiber.Map{
+						"cluster": clusterName,
+						"error":   fetchErr.Error(),
+					})
 					mu.Unlock()
 					return
 				}
@@ -225,7 +303,7 @@ func streamClusters(
 
 				mu.Lock()
 				completedClusters++
-				writeSSEEvent(w, "cluster_data", fiber.Map{
+				writeSSEEvent(w, sseEventClusterData, fiber.Map{
 					"cluster":   clusterName,
 					cfg.demoKey: data,
 					"source":    "k8s",
@@ -251,7 +329,7 @@ func streamClusters(
 		}
 
 		mu.Lock()
-		writeSSEEvent(w, "done", fiber.Map{
+		writeSSEEvent(w, sseEventDone, fiber.Map{
 			"totalClusters":     totalClusters,
 			"completedClusters": completedClusters,
 			"skippedOffline":    len(offline),
@@ -269,12 +347,12 @@ func streamDemoSSE(c *fiber.Ctx, dataKey string, demoData interface{}) error {
 	c.Set("Connection", "keep-alive")
 
 	c.Context().SetBodyStreamWriter(func(w *bufio.Writer) {
-		writeSSEEvent(w, "cluster_data", fiber.Map{
+		writeSSEEvent(w, sseEventClusterData, fiber.Map{
 			"cluster": "demo",
 			dataKey:   demoData,
 			"source":  "demo",
 		})
-		writeSSEEvent(w, "done", fiber.Map{
+		writeSSEEvent(w, sseEventDone, fiber.Map{
 			"totalClusters":     1,
 			"completedClusters": 1,
 		})
@@ -502,6 +580,14 @@ func (h *MCPHandlers) GetGPUNodeHealthStream(c *fiber.Ctx) error {
 }
 
 // GetWarningEventsStream streams warning events per cluster via SSE.
+//
+// Query parameters:
+//   - namespace: optional namespace filter (empty = all namespaces)
+//   - cluster:   optional cluster filter (#6039). When set, only that cluster
+//     is streamed; a 404 is returned if it is not present in the dedupe set.
+//   - limit:     optional per-cluster row cap (#6040). Falls back to
+//     defaultWarningEventsLimit on missing/invalid input and is clamped to
+//     maxWarningEventsLimit.
 func (h *MCPHandlers) GetWarningEventsStream(c *fiber.Ctx) error {
 	if isDemoMode(c) {
 		return streamDemoSSE(c, "events", getDemoWarningEvents())
@@ -511,13 +597,34 @@ func (h *MCPHandlers) GetWarningEventsStream(c *fiber.Ctx) error {
 	}
 
 	namespace := c.Query("namespace")
+	clusterFilter := c.Query("cluster")
+	limit := parseWarningEventsLimit(c.Query("limit"))
+
 	return streamClusters(c, h, sseClusterStreamConfig{
 		demoKey:        "events",
 		namespace:      namespace,
 		clusterTimeout: ssePerClusterTimeout,
+		clusterFilter:  clusterFilter,
 	}, func(ctx context.Context, cluster string) (interface{}, error) {
-		return h.k8sClient.GetWarningEvents(ctx, cluster, namespace, 50)
+		return h.k8sClient.GetWarningEvents(ctx, cluster, namespace, limit)
 	})
+}
+
+// parseWarningEventsLimit converts the `limit` query parameter to an int,
+// falling back to defaultWarningEventsLimit on missing/invalid input and
+// clamping the result to [1, maxWarningEventsLimit].
+func parseWarningEventsLimit(raw string) int {
+	if raw == "" {
+		return defaultWarningEventsLimit
+	}
+	n, err := strconv.Atoi(raw)
+	if err != nil || n <= 0 {
+		return defaultWarningEventsLimit
+	}
+	if n > maxWarningEventsLimit {
+		return maxWarningEventsLimit
+	}
+	return n
 }
 
 // GetJobsStream streams jobs per cluster via SSE.

--- a/pkg/api/handlers/sse_test.go
+++ b/pkg/api/handlers/sse_test.go
@@ -1,0 +1,176 @@
+package handlers
+
+import (
+	"errors"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	k8sfake "k8s.io/client-go/kubernetes/fake"
+	k8stesting "k8s.io/client-go/testing"
+)
+
+// sseTestTimeoutMs is the timeout (in milliseconds) passed to env.App.Test
+// for SSE endpoint requests. The streaming deadline inside the handler is
+// much larger (sseOverallDeadline) but tests only need enough time for the
+// fake client to return.
+const sseTestTimeoutMs = 15_000
+
+// seedWarningEvent returns a corev1.Event with Type=Warning that the fake
+// client will return when ListEvents is called. The reason is encoded into
+// the name so tests can differentiate per-cluster events.
+func seedWarningEvent(name, namespace string) *corev1.Event {
+	return &corev1.Event{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Type:    corev1.EventTypeWarning,
+		Reason:  name,
+		Message: name + " message",
+		InvolvedObject: corev1.ObjectReference{
+			Kind: "Pod",
+			Name: name + "-pod",
+		},
+	}
+}
+
+// injectTypedCluster registers a cluster in the fake MultiClusterClient with a
+// fresh fake.Clientset seeded with the given typed objects. Unlike
+// injectDynamicClusterWithObjects this does not register a dynamic client,
+// which is all the SSE warning-events handler needs.
+func injectTypedCluster(env *testEnv, cluster string, objs ...runtime.Object) *k8sfake.Clientset {
+	fc := k8sfake.NewSimpleClientset(objs...)
+	env.K8sClient.InjectClient(cluster, fc)
+	addClusterToRawConfig(env.K8sClient, cluster)
+	return fc
+}
+
+func readSSEBody(t *testing.T, resp *http.Response) string {
+	t.Helper()
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	return string(body)
+}
+
+// TestGetWarningEventsStream_AppliesClusterFilter verifies issue #6039:
+// when ?cluster=<name> is supplied, the stream only contains events from
+// that single cluster and not from the other registered clusters.
+func TestGetWarningEventsStream_AppliesClusterFilter(t *testing.T) {
+	env := setupTestEnv(t)
+
+	// Replace the default test-cluster with two clusters, each seeded with
+	// a distinct warning event so we can tell them apart in the stream.
+	injectTypedCluster(env, "cluster-a", seedWarningEvent("from-a", "default"))
+	injectTypedCluster(env, "cluster-b", seedWarningEvent("from-b", "default"))
+
+	handler := NewMCPHandlers(nil, env.K8sClient)
+	env.App.Get("/api/mcp/events/warnings/stream", handler.GetWarningEventsStream)
+
+	req, err := http.NewRequest(http.MethodGet, "/api/mcp/events/warnings/stream?cluster=cluster-a", nil)
+	require.NoError(t, err)
+
+	resp, err := env.App.Test(req, sseTestTimeoutMs)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	body := readSSEBody(t, resp)
+	assert.Contains(t, body, "\"cluster\":\"cluster-a\"", "cluster-a should be present in the stream")
+	assert.NotContains(t, body, "\"cluster\":\"cluster-b\"", "cluster-b must NOT appear when filter=cluster-a")
+	assert.Contains(t, body, "from-a", "cluster-a's warning event should be in the stream")
+	assert.NotContains(t, body, "from-b", "cluster-b's warning event must NOT be in the stream")
+}
+
+// TestGetWarningEventsStream_UnknownClusterReturns404 verifies that an
+// unknown ?cluster= value surfaces as a 404 instead of a silent empty stream.
+func TestGetWarningEventsStream_UnknownClusterReturns404(t *testing.T) {
+	env := setupTestEnv(t)
+	injectTypedCluster(env, "cluster-a")
+
+	handler := NewMCPHandlers(nil, env.K8sClient)
+	env.App.Get("/api/mcp/events/warnings/stream", handler.GetWarningEventsStream)
+
+	req, err := http.NewRequest(http.MethodGet, "/api/mcp/events/warnings/stream?cluster=does-not-exist", nil)
+	require.NoError(t, err)
+
+	resp, err := env.App.Test(req, sseTestTimeoutMs)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusNotFound, resp.StatusCode)
+}
+
+// TestGetWarningEventsStream_AppliesLimit verifies issue #6040:
+// the `limit` query parameter is honored by parseWarningEventsLimit and
+// clamped to [1, maxWarningEventsLimit], with fallback to
+// defaultWarningEventsLimit on missing/invalid input.
+func TestGetWarningEventsStream_AppliesLimit(t *testing.T) {
+	cases := []struct {
+		name string
+		raw  string
+		want int
+	}{
+		{"empty falls back to default", "", defaultWarningEventsLimit},
+		{"invalid falls back to default", "not-a-number", defaultWarningEventsLimit},
+		{"zero falls back to default", "0", defaultWarningEventsLimit},
+		{"negative falls back to default", "-7", defaultWarningEventsLimit},
+		{"valid value is returned as-is", "42", 42},
+		{"maxWarningEventsLimit is returned as-is", "500", maxWarningEventsLimit},
+		{"overflow is clamped to max", "9999", maxWarningEventsLimit},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			got := parseWarningEventsLimit(tc.raw)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
+// TestStreamClusters_EmitsClusterErrorOnFailure verifies issue #6041:
+// when a per-cluster fetch fails the handler now surfaces the failure as a
+// `cluster_error` SSE event instead of silently dropping it.
+func TestStreamClusters_EmitsClusterErrorOnFailure(t *testing.T) {
+	env := setupTestEnv(t)
+
+	// Inject two clusters: one that succeeds (with no events) and one whose
+	// fake client is wired to fail the list call.
+	injectTypedCluster(env, "cluster-ok", seedWarningEvent("ok-event", "default"))
+	failingClient := injectTypedCluster(env, "cluster-bad")
+	failingClient.PrependReactor("list", "events", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		return true, nil, errors.New("forced list error")
+	})
+
+	handler := NewMCPHandlers(nil, env.K8sClient)
+	env.App.Get("/api/mcp/events/warnings/stream", handler.GetWarningEventsStream)
+
+	req, err := http.NewRequest(http.MethodGet, "/api/mcp/events/warnings/stream", nil)
+	require.NoError(t, err)
+
+	resp, err := env.App.Test(req, sseTestTimeoutMs)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	body := readSSEBody(t, resp)
+
+	// The failing cluster must emit the new cluster_error event, carrying
+	// its name and the error message.
+	assert.Contains(t, body, "event: "+sseEventClusterError, "stream must contain cluster_error event")
+	assert.Contains(t, body, "\"cluster\":\"cluster-bad\"", "cluster_error payload must reference cluster-bad")
+	assert.Contains(t, body, "forced list error", "cluster_error payload must include the underlying error message")
+
+	// The healthy cluster must still produce a cluster_data event.
+	assert.Contains(t, body, "event: "+sseEventClusterData, "healthy cluster should still emit cluster_data")
+	assert.Contains(t, body, "\"cluster\":\"cluster-ok\"", "cluster-ok should appear as cluster_data")
+
+	// The final done event should still fire.
+	assert.Contains(t, body, "event: "+sseEventDone, "stream must end with done event")
+
+	// Existing event-name strings must be unchanged (regression guard).
+	assert.True(t, strings.Contains(body, "cluster_data"))
+	assert.True(t, strings.Contains(body, "done"))
+}


### PR DESCRIPTION
Fixes #6039, #6040, #6041.

## Summary
- **#6039** `GetWarningEventsStream` now parses the `cluster` query parameter and restricts streaming to that single cluster. Unknown cluster names return **404** so the client can distinguish "empty result" from "typo/stale reference". The filter is threaded through `sseClusterStreamConfig.clusterFilter` and applied once inside `streamClusters`.
- **#6040** `GetWarningEventsStream` now parses the `limit` query parameter via a new `parseWarningEventsLimit` helper: falls back to `defaultWarningEventsLimit` (50) on missing/invalid input and clamps to `maxWarningEventsLimit` (500). No more hardcoded literal.
- **#6041** `streamClusters` now emits an **additive** `cluster_error` SSE event on per-cluster fetch failures. The frontend can surface failed clusters in the UI instead of pretending everything succeeded. Existing `cluster_data`, `cluster_skipped`, and `done` event shapes are unchanged.

All SSE event names are extracted as named constants (`sseEventClusterData`, `sseEventClusterSkipped`, `sseEventClusterError`, `sseEventDone`) to keep shapes and names in sync across handlers. No magic numbers.

## New SSE event
```json
event: cluster_error
data: {"cluster":"cluster-a","error":"forced list error"}
```

## Tests
New `pkg/api/handlers/sse_test.go`:
- `TestGetWarningEventsStream_AppliesClusterFilter` — registers two clusters, requests `?cluster=cluster-a`, asserts only cluster-a's events appear.
- `TestGetWarningEventsStream_UnknownClusterReturns404` — asserts 404 on typo.
- `TestGetWarningEventsStream_AppliesLimit` — table test exercising empty/invalid/zero/negative/valid/max/overflow inputs against `parseWarningEventsLimit`.
- `TestStreamClusters_EmitsClusterErrorOnFailure` — injects a fake client whose `list events` reactor errors, verifies `cluster_error` event is emitted and `cluster_data` still fires for the healthy cluster.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./pkg/api/handlers/... -count=1`
- [ ] Manual: `curl -N 'http://localhost:8080/api/mcp/events/warnings/stream?cluster=<name>&limit=10'` and verify only that cluster streams
- [ ] Manual: trigger a known-broken cluster and verify `event: cluster_error` appears in the stream