### PR TITLE
fix(events): use EventTime over deprecated LastTimestamp; time-typed multi-cluster sort

### DIFF
--- a/pkg/api/handlers/mcp_cluster.go
+++ b/pkg/api/handlers/mcp_cluster.go
@@ -3,7 +3,6 @@ package handlers
 import (
 	"context"
 	"log/slog"
-	"sort"
 	"sync"
 
 	"github.com/gofiber/fiber/v2"
@@ -281,10 +280,10 @@ func (h *MCPHandlers) GetEvents(c *fiber.Ctx) error {
 
 			waitWithDeadline(&wg, clusterCancel, maxResponseDeadline)
 
-			// Sort by timestamp (most recent first) and limit total
-			sort.Slice(allEvents, func(i, j int) bool {
-				return allEvents[i].LastSeen > allEvents[j].LastSeen
-			})
+			// Sort by LastSeen parsed as time (most recent first).
+			// Lexicographic string compare is unreliable across timezones
+			// and empty values (see issue #6043).
+			k8s.SortEventsByLastSeenDesc(allEvents)
 			if len(allEvents) > limit {
 				allEvents = allEvents[:limit]
 			}
@@ -384,10 +383,10 @@ func (h *MCPHandlers) GetWarningEvents(c *fiber.Ctx) error {
 
 			waitWithDeadline(&wg, clusterCancel, maxResponseDeadline)
 
-			// Sort by timestamp (most recent first) and limit total
-			sort.Slice(allEvents, func(i, j int) bool {
-				return allEvents[i].LastSeen > allEvents[j].LastSeen
-			})
+			// Sort by LastSeen parsed as time (most recent first).
+			// Lexicographic string compare is unreliable across timezones
+			// and empty values (see issue #6043).
+			k8s.SortEventsByLastSeenDesc(allEvents)
 			if len(allEvents) > limit {
 				allEvents = allEvents[:limit]
 			}

--- a/pkg/api/handlers/mcp_cluster_test.go
+++ b/pkg/api/handlers/mcp_cluster_test.go
@@ -1,0 +1,63 @@
+package handlers
+
+import (
+	"testing"
+
+	"github.com/kubestellar/console/pkg/k8s"
+)
+
+// TestMultiClusterEventSortOrder verifies that the helper used by
+// GetEvents/GetWarningEvents to merge results from multiple clusters sorts
+// by time instead of by string comparison. See issue #6043.
+func TestMultiClusterEventSortOrder(t *testing.T) {
+	// Mixed timezones and a zero LastSeen that previously broke the
+	// lexicographic compare. Expected order by actual instant (descending):
+	//   cluster-c  (2024-06-01T13:30:00+00:00  -> 13:30 UTC)
+	//   cluster-a  (2024-06-01T09:00:00-04:00  -> 13:00 UTC)
+	//   cluster-b  (2024-06-01T12:00:00Z       -> 12:00 UTC)
+	//   cluster-d  (empty LastSeen, zero time  -> last)
+	allEvents := []k8s.Event{
+		{Cluster: "cluster-b", Reason: "B", LastSeen: "2024-06-01T12:00:00Z"},
+		{Cluster: "cluster-a", Reason: "A", LastSeen: "2024-06-01T09:00:00-04:00"},
+		{Cluster: "cluster-d", Reason: "D", LastSeen: ""},
+		{Cluster: "cluster-c", Reason: "C", LastSeen: "2024-06-01T13:30:00+00:00"},
+	}
+
+	k8s.SortEventsByLastSeenDesc(allEvents)
+
+	wantOrder := []string{"cluster-c", "cluster-a", "cluster-b", "cluster-d"}
+	for i, want := range wantOrder {
+		if allEvents[i].Cluster != want {
+			t.Errorf("position %d: got cluster %q, want %q (full order: %+v)",
+				i, allEvents[i].Cluster, want, clusterNames(allEvents))
+		}
+	}
+}
+
+// TestMultiClusterEventSortStability confirms that already-sorted input is
+// left untouched and that the sort is stable for equal timestamps.
+func TestMultiClusterEventSortStability(t *testing.T) {
+	ts := "2024-06-01T12:00:00Z"
+	events := []k8s.Event{
+		{Cluster: "first", Reason: "A", LastSeen: ts},
+		{Cluster: "second", Reason: "B", LastSeen: ts},
+		{Cluster: "third", Reason: "C", LastSeen: ts},
+	}
+
+	k8s.SortEventsByLastSeenDesc(events)
+
+	wantOrder := []string{"first", "second", "third"}
+	for i, want := range wantOrder {
+		if events[i].Cluster != want {
+			t.Errorf("stable sort broken at %d: got %q, want %q", i, events[i].Cluster, want)
+		}
+	}
+}
+
+func clusterNames(events []k8s.Event) []string {
+	names := make([]string, len(events))
+	for i, e := range events {
+		names[i] = e.Cluster
+	}
+	return names
+}

--- a/pkg/api/handlers/workloads.go
+++ b/pkg/api/handlers/workloads.go
@@ -1149,13 +1149,14 @@ func (h *WorkloadHandlers) GetDeployLogs(c *fiber.Ctx) error {
 		}
 	}
 
-	// Sort events by actual timestamp (newest last) (#3718)
+	// Sort events by actual timestamp (newest last) (#3718, #6042).
+	// Prefer modern EventTime; fall back to LastTimestamp then CreationTimestamp.
 	sort.Slice(allEvents, func(i, j int) bool {
-		ti := allEvents[i].LastTimestamp.Time
+		ti := k8s.EffectiveEventTime(&allEvents[i])
 		if ti.IsZero() {
 			ti = allEvents[i].CreationTimestamp.Time
 		}
-		tj := allEvents[j].LastTimestamp.Time
+		tj := k8s.EffectiveEventTime(&allEvents[j])
 		if tj.IsZero() {
 			tj = allEvents[j].CreationTimestamp.Time
 		}
@@ -1184,7 +1185,7 @@ func (h *WorkloadHandlers) GetDeployLogs(c *fiber.Ctx) error {
 
 // formatEvent formats a k8s event into a compact log line for mission display.
 func formatEvent(ev corev1.Event) string {
-	ts := ev.LastTimestamp.Time
+	ts := k8s.EffectiveEventTime(&ev)
 	if ts.IsZero() {
 		ts = ev.CreationTimestamp.Time
 	}

--- a/pkg/k8s/client_resources.go
+++ b/pkg/k8s/client_resources.go
@@ -260,9 +260,10 @@ func (m *MultiClusterClient) GetEvents(ctx context.Context, contextName, namespa
 		return nil, err
 	}
 
-	// Sort by last timestamp descending
+	// Sort by effective event time descending (prefers modern EventTime,
+	// falls back to LastTimestamp for older clusters). See issue #6042.
 	sort.Slice(events.Items, func(i, j int) bool {
-		return events.Items[i].LastTimestamp.After(events.Items[j].LastTimestamp.Time)
+		return EffectiveEventTime(&events.Items[i]).After(EffectiveEventTime(&events.Items[j]))
 	})
 
 	var result []Event
@@ -270,6 +271,8 @@ func (m *MultiClusterClient) GetEvents(ctx context.Context, contextName, namespa
 		if limit > 0 && i >= limit {
 			break
 		}
+		evt := event
+		lastSeen := EffectiveEventTime(&evt)
 		e := Event{
 			Type:      event.Type,
 			Reason:    event.Reason,
@@ -278,13 +281,13 @@ func (m *MultiClusterClient) GetEvents(ctx context.Context, contextName, namespa
 			Namespace: event.Namespace,
 			Cluster:   contextName,
 			Count:     event.Count,
-			Age:       formatDuration(time.Since(event.LastTimestamp.Time)),
+		}
+		if !lastSeen.IsZero() {
+			e.Age = formatDuration(time.Since(lastSeen))
+			e.LastSeen = lastSeen.Format(time.RFC3339)
 		}
 		if !event.FirstTimestamp.IsZero() {
 			e.FirstSeen = event.FirstTimestamp.Time.Format(time.RFC3339)
-		}
-		if !event.LastTimestamp.IsZero() {
-			e.LastSeen = event.LastTimestamp.Time.Format(time.RFC3339)
 		}
 		result = append(result, e)
 	}
@@ -306,9 +309,10 @@ func (m *MultiClusterClient) GetWarningEvents(ctx context.Context, contextName, 
 		return nil, err
 	}
 
-	// Sort by last timestamp descending
+	// Sort by effective event time descending (prefers modern EventTime,
+	// falls back to LastTimestamp for older clusters). See issue #6042.
 	sort.Slice(events.Items, func(i, j int) bool {
-		return events.Items[i].LastTimestamp.After(events.Items[j].LastTimestamp.Time)
+		return EffectiveEventTime(&events.Items[i]).After(EffectiveEventTime(&events.Items[j]))
 	})
 
 	var result []Event
@@ -316,6 +320,8 @@ func (m *MultiClusterClient) GetWarningEvents(ctx context.Context, contextName, 
 		if limit > 0 && i >= limit {
 			break
 		}
+		evt := event
+		lastSeen := EffectiveEventTime(&evt)
 		e := Event{
 			Type:      event.Type,
 			Reason:    event.Reason,
@@ -324,13 +330,13 @@ func (m *MultiClusterClient) GetWarningEvents(ctx context.Context, contextName, 
 			Namespace: event.Namespace,
 			Cluster:   contextName,
 			Count:     event.Count,
-			Age:       formatDuration(time.Since(event.LastTimestamp.Time)),
+		}
+		if !lastSeen.IsZero() {
+			e.Age = formatDuration(time.Since(lastSeen))
+			e.LastSeen = lastSeen.Format(time.RFC3339)
 		}
 		if !event.FirstTimestamp.IsZero() {
 			e.FirstSeen = event.FirstTimestamp.Time.Format(time.RFC3339)
-		}
-		if !event.LastTimestamp.IsZero() {
-			e.LastSeen = event.LastTimestamp.Time.Format(time.RFC3339)
 		}
 		result = append(result, e)
 	}

--- a/pkg/k8s/events.go
+++ b/pkg/k8s/events.go
@@ -1,0 +1,62 @@
+package k8s
+
+import (
+	"sort"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+// EffectiveEventTime returns the most recent observation timestamp for a
+// Kubernetes Event, preferring the modern EventTime (events.k8s.io/v1) and
+// falling back to the deprecated LastTimestamp, then FirstTimestamp, for
+// older clusters.
+//
+// Modern kubelets populate only EventTime and leave LastTimestamp as the
+// zero metav1.Time{}. Reading LastTimestamp directly causes recent events to
+// appear at the Unix epoch and sort incorrectly. See issue #6042.
+func EffectiveEventTime(e *corev1.Event) time.Time {
+	if e == nil {
+		return time.Time{}
+	}
+	if !e.EventTime.IsZero() {
+		return e.EventTime.Time
+	}
+	if !e.LastTimestamp.IsZero() {
+		return e.LastTimestamp.Time
+	}
+	return e.FirstTimestamp.Time
+}
+
+// SortEventsByLastSeenDesc sorts Events in-place by their LastSeen RFC3339
+// string interpreted as time.Time, newest first. Unparseable or empty
+// LastSeen values sort to the end (treated as the zero time). This avoids
+// the fragile lexicographic comparison on mixed-timezone strings used
+// previously. See issue #6043.
+func SortEventsByLastSeenDesc(events []Event) {
+	// Cache parsed times once to avoid O(n log n) reparsing inside the
+	// sort comparator.
+	parsed := make([]time.Time, len(events))
+	for i := range events {
+		if events[i].LastSeen == "" {
+			continue
+		}
+		if t, err := time.Parse(time.RFC3339, events[i].LastSeen); err == nil {
+			parsed[i] = t
+		}
+	}
+
+	indices := make([]int, len(events))
+	for i := range indices {
+		indices[i] = i
+	}
+	sort.SliceStable(indices, func(i, j int) bool {
+		return parsed[indices[i]].After(parsed[indices[j]])
+	})
+
+	sorted := make([]Event, len(events))
+	for newIdx, oldIdx := range indices {
+		sorted[newIdx] = events[oldIdx]
+	}
+	copy(events, sorted)
+}

--- a/pkg/k8s/events_test.go
+++ b/pkg/k8s/events_test.go
@@ -1,0 +1,122 @@
+package k8s
+
+import (
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestEffectiveEventTime(t *testing.T) {
+	// Canonical reference times for the test cases.
+	var (
+		eventT = time.Date(2024, 6, 1, 12, 0, 0, 0, time.UTC)
+		lastT  = time.Date(2024, 6, 1, 11, 0, 0, 0, time.UTC)
+		firstT = time.Date(2024, 6, 1, 10, 0, 0, 0, time.UTC)
+	)
+
+	tests := []struct {
+		name  string
+		event *corev1.Event
+		want  time.Time
+	}{
+		{
+			name: "prefers EventTime when populated",
+			event: &corev1.Event{
+				EventTime:      metav1.MicroTime{Time: eventT},
+				LastTimestamp:  metav1.Time{Time: lastT},
+				FirstTimestamp: metav1.Time{Time: firstT},
+			},
+			want: eventT,
+		},
+		{
+			name: "falls back to LastTimestamp when EventTime is zero",
+			event: &corev1.Event{
+				LastTimestamp:  metav1.Time{Time: lastT},
+				FirstTimestamp: metav1.Time{Time: firstT},
+			},
+			want: lastT,
+		},
+		{
+			name: "falls back to FirstTimestamp when EventTime and LastTimestamp are zero",
+			event: &corev1.Event{
+				FirstTimestamp: metav1.Time{Time: firstT},
+			},
+			want: firstT,
+		},
+		{
+			name:  "returns zero time when all timestamps are zero",
+			event: &corev1.Event{},
+			want:  time.Time{},
+		},
+		{
+			name:  "nil event returns zero time",
+			event: nil,
+			want:  time.Time{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := EffectiveEventTime(tt.event)
+			if !got.Equal(tt.want) {
+				t.Errorf("EffectiveEventTime() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSortEventsByLastSeenDesc(t *testing.T) {
+	// Fixed reference instants so the test is deterministic.
+	newest := "2024-06-01T12:00:00Z"
+	middle := "2024-06-01T11:00:00Z"
+	oldest := "2024-06-01T10:00:00Z"
+
+	events := []Event{
+		{Reason: "Old", LastSeen: oldest},
+		{Reason: "Newest", LastSeen: newest},
+		{Reason: "Empty", LastSeen: ""},
+		{Reason: "Middle", LastSeen: middle},
+		{Reason: "Garbage", LastSeen: "not-a-date"},
+	}
+
+	SortEventsByLastSeenDesc(events)
+
+	if events[0].Reason != "Newest" {
+		t.Errorf("expected Newest first, got %q", events[0].Reason)
+	}
+	if events[1].Reason != "Middle" {
+		t.Errorf("expected Middle second, got %q", events[1].Reason)
+	}
+	if events[2].Reason != "Old" {
+		t.Errorf("expected Old third, got %q", events[2].Reason)
+	}
+	// Empty and Garbage LastSeen both parse to zero time; they sort last.
+	lastTwo := map[string]bool{events[3].Reason: true, events[4].Reason: true}
+	if !lastTwo["Empty"] || !lastTwo["Garbage"] {
+		t.Errorf("expected Empty and Garbage in trailing positions, got %q, %q",
+			events[3].Reason, events[4].Reason)
+	}
+}
+
+func TestSortEventsByLastSeenDesc_MixedTimezones(t *testing.T) {
+	// Lexicographic comparison would get this wrong: the -04:00 string sorts
+	// before "Z" but is actually the more recent instant.
+	events := []Event{
+		{Reason: "Z-formatted", LastSeen: "2024-06-01T12:00:00Z"},
+		{Reason: "Offset-formatted", LastSeen: "2024-06-01T09:00:00-04:00"}, // = 13:00 UTC
+	}
+
+	SortEventsByLastSeenDesc(events)
+
+	if events[0].Reason != "Offset-formatted" {
+		t.Errorf("time-typed sort must rank 13:00 UTC before 12:00 UTC; got %q first",
+			events[0].Reason)
+	}
+}
+
+func TestSortEventsByLastSeenDesc_EmptySlice(t *testing.T) {
+	var events []Event
+	SortEventsByLastSeenDesc(events) // must not panic
+}


### PR DESCRIPTION
Fixes #6042, #6043.

## #6042 — Events sorted/displayed via deprecated `LastTimestamp`

`corev1.Event.LastTimestamp` is deprecated in favor of `EventTime`
(events.k8s.io/v1). Modern kubelets only populate `EventTime`, leaving
`LastTimestamp` as the zero `metav1.Time{}`. Reading `LastTimestamp`
directly causes recent events to appear at the Unix epoch and sort
incorrectly.

**Fix:** New helper `k8s.EffectiveEventTime(*corev1.Event) time.Time` in a
new `pkg/k8s/events.go`, which prefers `EventTime`, then falls back to
`LastTimestamp`, then `FirstTimestamp`. Replaced all `.LastTimestamp`
references in:

- `pkg/k8s/client_resources.go` — `GetEvents` and `GetWarningEvents` sort,
  age computation, and the JSON wire `lastSeen` field now all flow through
  the helper.
- `pkg/api/handlers/workloads.go` — `getDeploymentLogs` event sort and
  `formatEvent` log-line timestamp.

## #6043 — Multi-cluster event merge used string comparison

`pkg/api/handlers/mcp_cluster.go` merged per-cluster event results with
`sort.Slice(allEvents, ... allEvents[i].LastSeen > allEvents[j].LastSeen)`
— `LastSeen` is an RFC3339 *string*, and lexicographic order breaks across
timezones, empty values, and format drift.

**Fix:** New helper `k8s.SortEventsByLastSeenDesc([]Event)` which parses
each `LastSeen` to `time.Time` once (avoiding O(n log n) reparsing in the
comparator) and uses a stable sort on cached instants. Empty/invalid
`LastSeen` values sort to the end.

## Tests

- `pkg/k8s/events_test.go` (new) — `TestEffectiveEventTime` covers
  EventTime preferred, LastTimestamp fallback, FirstTimestamp fallback,
  all-zero, and nil; plus sort tests including a mixed-timezone case that
  would fail the old string compare.
- `pkg/api/handlers/mcp_cluster_test.go` (new) — verifies multi-cluster
  merge sort across mixed timezones, empty LastSeen values, and stability
  on equal instants.

## Verification

```
go build ./...        # pass
go vet ./...          # pass
go test ./pkg/... -count=1  # all green
```

## Code quality

- No magic numbers. All timestamps in tests are named/fixed.
- Helper lives in its own `pkg/k8s/events.go` so it can be reused by both
  `pkg/k8s` and `pkg/api/handlers`.
- Existing `TestGetEvents*` cases in `pkg/k8s/client_test.go` still pass
  unchanged because the helper gracefully falls back to `LastTimestamp`.