### PR TITLE
fix(events): cancel in-flight fetches in useWarningEvents

### DIFF
--- a/web/src/hooks/mcp/__tests__/events.test.ts
+++ b/web/src/hooks/mcp/__tests__/events.test.ts
@@ -757,4 +757,66 @@ describe('useWarningEvents', () => {
 
     expect(result.current.lastUpdated).toBeInstanceOf(Date)
   })
+
+  it('cancels in-flight fetches on refetch', async () => {
+    // Capture signals from each fetchSSE call so we can check abortion
+    const capturedSignals: AbortSignal[] = []
+    mockFetchSSE.mockImplementation((opts: { signal?: AbortSignal }) => {
+      if (opts.signal) capturedSignals.push(opts.signal)
+      return new Promise(() => {}) // never resolves, simulating in-flight
+    })
+
+    const { result } = renderHook(() => useWarningEvents())
+
+    // Wait for the first fetch to register its signal
+    await waitFor(() => expect(capturedSignals.length).toBeGreaterThanOrEqual(1))
+    const firstSignal = capturedSignals[0]
+    expect(firstSignal.aborted).toBe(false)
+
+    // Trigger a second refetch while the first is still in-flight
+    await act(async () => { result.current.refetch() })
+
+    // Wait for the second signal to be registered
+    await waitFor(() => expect(capturedSignals.length).toBeGreaterThanOrEqual(2))
+    const secondSignal = capturedSignals[capturedSignals.length - 1]
+
+    // The older fetch's signal must be aborted; the newer one is still active
+    expect(firstSignal.aborted).toBe(true)
+    expect(secondSignal.aborted).toBe(false)
+  })
+
+  it('does not setState after unmount', async () => {
+    // Hold the fetchSSE promise so we can resolve it after unmounting
+    let resolveFetch: (value: unknown[]) => void = () => {}
+    mockFetchSSE.mockImplementation((opts: { signal?: AbortSignal }) => {
+      return new Promise<unknown[]>((resolve) => {
+        resolveFetch = resolve
+        // If the signal fires abort, reject with AbortError like a real fetch
+        opts.signal?.addEventListener('abort', () => {
+          resolve([]) // treat as cancelled — no state update expected
+        })
+      })
+    })
+
+    const warnSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const { unmount } = renderHook(() => useWarningEvents())
+
+    // Unmount mid-fetch
+    unmount()
+
+    // Resolve the fetch after unmount — any setEvents calls afterward would warn
+    await act(async () => {
+      resolveFetch([
+        { type: 'Warning', reason: 'Late', message: 'late', object: 'Pod/l', namespace: 'ns', cluster: 'c', count: 1 },
+      ])
+      await new Promise(r => setTimeout(r, 0))
+    })
+
+    // React logs a warning on state updates after unmount — there should be none
+    const unmountWarnings = warnSpy.mock.calls.filter(call =>
+      typeof call[0] === 'string' && call[0].includes('unmounted')
+    )
+    expect(unmountWarnings).toHaveLength(0)
+    warnSpy.mockRestore()
+  })
 })

--- a/web/src/hooks/mcp/events.ts
+++ b/web/src/hooks/mcp/events.ts
@@ -269,6 +269,9 @@ let warningEventsCache: WarningEventsCache | null = null
 
 export function useWarningEvents(cluster?: string, namespace?: string, limit = 20) {
   const cacheKey = `warningEvents:${cluster || 'all'}:${namespace || 'all'}:${limit}`
+  // Track AbortController for cleanup on unmount
+  const abortControllerRef = useRef<AbortController | null>(null)
+  const isMountedRef = useRef(true)
   const { isDemoMode: demoMode } = useDemoMode()
   const initialMountRef = useRef(true)
 
@@ -317,6 +320,13 @@ export function useWarningEvents(cluster?: string, namespace?: string, limit = 2
       return
     }
 
+    // Abort any previous in-flight request
+    if (abortControllerRef.current) {
+      abortControllerRef.current.abort()
+    }
+    abortControllerRef.current = new AbortController()
+    const signal = abortControllerRef.current.signal
+
     // Use SSE streaming for progressive multi-cluster data
     try {
       const sseParams: Record<string, string> = {}
@@ -328,30 +338,51 @@ export function useWarningEvents(cluster?: string, namespace?: string, limit = 2
         url: '/api/mcp/events/warnings/stream',
         params: sseParams,
         itemsKey: 'events',
+        signal,
         onClusterData: (_clusterName, items) => {
+          if (signal.aborted || !isMountedRef.current) return
           setEvents(prev => [...prev, ...items].slice(0, limit))
           setIsLoading(false)
         },
       })
 
+      if (signal.aborted || !isMountedRef.current) return
       const now = new Date()
       warningEventsCache = { data: allEvents.slice(0, limit), timestamp: now, key: cacheKey }
       setEvents(allEvents.slice(0, limit))
       setError(null)
       setLastUpdated(now)
-    } catch {
+    } catch (err) {
+      // Use name check instead of instanceof to handle both Error and DOMException
+      // across all browser versions (DOMException may not extend Error in older Safari).
+      if ((err as { name?: string })?.name === 'AbortError') return
+      if (!isMountedRef.current) return
       if (!silent && !warningEventsCache) {
         setError('Failed to fetch warning events')
       }
     } finally {
-      setIsLoading(false)
-      if (!silent) {
-        setTimeout(() => setIsRefreshing(false), MIN_REFRESH_INDICATOR_MS)
-      } else {
-        setIsRefreshing(false)
+      if (isMountedRef.current && !signal.aborted) {
+        setIsLoading(false)
+        if (!silent) {
+          setTimeout(() => setIsRefreshing(false), MIN_REFRESH_INDICATOR_MS)
+        } else {
+          setIsRefreshing(false)
+        }
       }
     }
   }, [cluster, namespace, limit, cacheKey])
+
+  // Track mounted state for cleanup
+  useEffect(() => {
+    isMountedRef.current = true
+    return () => {
+      isMountedRef.current = false
+      // Abort any in-flight request on unmount
+      if (abortControllerRef.current) {
+        abortControllerRef.current.abort()
+      }
+    }
+  }, [])
 
   useEffect(() => {
     const hasCachedData = warningEventsCache && warningEventsCache.key === cacheKey


### PR DESCRIPTION
Fixes #6046.

## The bug

`useWarningEvents` in `web/src/hooks/mcp/events.ts` had a race condition: two overlapping `refetch()` calls could resolve out of order, and the older resolution's `setEvents(...)` call would overwrite the newer state. This could leave users looking at stale warning event data even after a fresh refresh completed.

## The fix

Mirrors the `AbortController` + `isMountedRef` pattern already used by the sibling `useEvents` hook in the same file:

- Add `abortControllerRef = useRef<AbortController | null>(null)` and `isMountedRef = useRef(true)`
- At the start of every fetch: abort the previous controller, create a new one, and pass its signal to `fetchSSE`
- Before every `setEvents(...)` / state update from a fetch resolution: guard with `signal.aborted` and `isMountedRef.current` checks
- On unmount: abort the in-flight controller and flip `isMountedRef` to `false`
- Silently swallow `AbortError` in the catch block (matching `useEvents`)

The public hook API is unchanged — only internals were modified. No refactoring of unrelated hooks in the same file.

## Tests

Added 2 tests to `web/src/hooks/mcp/__tests__/events.test.ts` in the existing `useWarningEvents` describe block:

- `cancels in-flight fetches on refetch` — fires two refetches, captures both signals, verifies the first is aborted and the second is not
- `does not setState after unmount` — unmounts mid-fetch, resolves the fetch afterward, verifies no React unmounted-setState warning

All 48 tests in `events.test.ts` pass.

## Verification

- `npm run build` passes
- `npx eslint src/hooks/mcp/events.ts src/hooks/mcp/__tests__/events.test.ts` clean
- `npx vitest run src/hooks/mcp/__tests__/events.test.ts` — 48/48 pass