### PR TITLE
fix(auth): backend auth edges (#6056, #6063, #6064)

### DIFF
--- a/pkg/api/handlers/auth.go
+++ b/pkg/api/handlers/auth.go
@@ -357,6 +357,34 @@ func (h *AuthHandler) devModeLogin(c *fiber.Ctx) error {
 	return c.Redirect(redirectURL, fiber.StatusTemporaryRedirect)
 }
 
+// hasValidAuthCookie reports whether the incoming request carries a kc_auth
+// cookie that parses as a non-expired, non-revoked JWT under the handler's
+// signing secret. It is used by GitHubCallback (#6064) to recover from CSRF
+// state-validation failures when the user is already authenticated: a stale
+// OAuth tab, a browser back-button replay, or a server restart that cleared
+// the in-memory state store should not force a user with a live session
+// back through the login flow. Any parse error, validity failure, missing
+// claims, or revocation check failure causes this helper to return false so
+// the caller falls through to the normal error path.
+func (h *AuthHandler) hasValidAuthCookie(c *fiber.Ctx) bool {
+	cookieToken := c.Cookies(jwtCookieName)
+	if cookieToken == "" {
+		return false
+	}
+	parsed, err := middleware.ParseJWT(cookieToken, h.jwtSecret)
+	if err != nil || parsed == nil || !parsed.Valid {
+		return false
+	}
+	claims, ok := parsed.Claims.(*middleware.UserClaims)
+	if !ok {
+		return false
+	}
+	if claims.ID != "" && middleware.IsTokenRevoked(claims.ID) {
+		return false
+	}
+	return true
+}
+
 // oauthErrorRedirect builds a redirect URL to the login page with a structured error.
 // The error code is always present; detail is optional human-readable context.
 func (h *AuthHandler) oauthErrorRedirect(c *fiber.Ctx, errorCode, detail string) error {
@@ -420,6 +448,21 @@ func (h *AuthHandler) GitHubCallback(c *fiber.Ctx) error {
 	// (Safari blocks cookies in OAuth redirect flows, so we use server-side state)
 	state := c.Query("state")
 	if state == "" || !validateAndConsumeOAuthState(state) {
+		// #6064 — State validation can fail for reasons that are entirely
+		// benign from the user's perspective: a stale OAuth tab left open
+		// from a previous session, a server restart that cleared the
+		// in-memory state store (#6034 addresses the root cause), or a
+		// duplicate back-button submission. In all of these cases, if the
+		// browser is already carrying a valid kc_auth cookie, the user is
+		// effectively still signed in — bouncing them to an error page
+		// forces a pointless re-login. Instead, when the incoming request
+		// carries a non-expired, non-revoked JWT cookie, short-circuit to
+		// the frontend root so the existing session is preserved.
+		if h.hasValidAuthCookie(c) {
+			slog.Info("[Auth] CSRF state invalid but user already has valid cookie, recovering to /")
+			c.Set("Cache-Control", "no-store")
+			return c.Redirect(h.frontendURL+"/", fiber.StatusTemporaryRedirect)
+		}
 		slog.Error("[Auth] CSRF validation failed: invalid or expired state token")
 		return h.oauthErrorRedirect(c, "csrf_validation_failed", "")
 	}

--- a/pkg/api/handlers/auth_test.go
+++ b/pkg/api/handlers/auth_test.go
@@ -296,5 +296,119 @@ func TestClassifyExchangeError(t *testing.T) {
 	})
 }
 
+// TestGitHubCallback_RecoversFromValidCookieOnStateFailure covers #6064:
+// when CSRF state validation fails (stale OAuth tab, server restart that
+// cleared the in-memory state store, etc.) the callback must check whether
+// the request already carries a valid kc_auth cookie. If so, it should
+// redirect to "/" and preserve the live session instead of bouncing the
+// user to the error page and forcing a pointless re-login. If the cookie
+// is missing, expired, or signed with a different secret, the classic
+// error redirect still applies.
+func TestGitHubCallback_RecoversFromValidCookieOnStateFailure(t *testing.T) {
+	app, _, handler := setupAuthTest()
+	app.Get("/auth/callback", handler.GitHubCallback)
+
+	const (
+		validCookieLifetime = time.Hour
+		expiredCookieAge    = -1 * time.Hour
+	)
+
+	t.Run("valid cookie + invalid state redirects to /", func(t *testing.T) {
+		user := &models.User{ID: uuid.New(), GitHubLogin: "already-signed-in"}
+		cookieToken, err := handler.generateJWT(user)
+		assert.NoError(t, err)
+
+		req, _ := http.NewRequest("GET", "/auth/callback?code=123&state=bogus", nil)
+		req.AddCookie(&http.Cookie{Name: jwtCookieName, Value: cookieToken})
+
+		resp, err := app.Test(req, 5000)
+		assert.NoError(t, err)
+		assert.Equal(t, http.StatusTemporaryRedirect, resp.StatusCode)
+
+		loc, _ := resp.Location()
+		assert.Equal(t, "/", loc.Path,
+			"valid cookie should recover to frontend root, not error page")
+		assert.NotContains(t, loc.String(), "error=csrf_validation_failed",
+			"error page must not be used when a valid session cookie is present")
+	})
+
+	t.Run("missing cookie + invalid state redirects to error page", func(t *testing.T) {
+		req, _ := http.NewRequest("GET", "/auth/callback?code=123&state=bogus", nil)
+
+		resp, err := app.Test(req, 5000)
+		assert.NoError(t, err)
+		assert.Equal(t, http.StatusTemporaryRedirect, resp.StatusCode)
+
+		loc, _ := resp.Location()
+		assert.Contains(t, loc.String(), "error=csrf_validation_failed")
+	})
+
+	t.Run("expired cookie + invalid state redirects to error page", func(t *testing.T) {
+		// Cookie parses but is expired — the recovery path must NOT engage.
+		expiredClaims := middleware.UserClaims{
+			UserID:      uuid.New(),
+			GitHubLogin: "stale",
+			RegisteredClaims: jwt.RegisteredClaims{
+				ExpiresAt: jwt.NewNumericDate(time.Now().Add(expiredCookieAge)),
+			},
+		}
+		expiredJWT := jwt.NewWithClaims(jwt.SigningMethodHS256, expiredClaims)
+		expiredSigned, _ := expiredJWT.SignedString([]byte("test-secret"))
+
+		req, _ := http.NewRequest("GET", "/auth/callback?code=123&state=bogus", nil)
+		req.AddCookie(&http.Cookie{Name: jwtCookieName, Value: expiredSigned})
+
+		resp, err := app.Test(req, 5000)
+		assert.NoError(t, err)
+		assert.Equal(t, http.StatusTemporaryRedirect, resp.StatusCode)
+
+		loc, _ := resp.Location()
+		assert.Contains(t, loc.String(), "error=csrf_validation_failed",
+			"expired cookie must not trigger the #6064 recovery path")
+	})
+
+	t.Run("cookie signed with wrong secret + invalid state redirects to error page", func(t *testing.T) {
+		// Cookie is non-expired but signed with a different secret — ParseJWT
+		// must reject it, so the recovery path must NOT engage.
+		forgedClaims := middleware.UserClaims{
+			UserID:      uuid.New(),
+			GitHubLogin: "forged",
+			RegisteredClaims: jwt.RegisteredClaims{
+				ExpiresAt: jwt.NewNumericDate(time.Now().Add(validCookieLifetime)),
+			},
+		}
+		forgedJWT := jwt.NewWithClaims(jwt.SigningMethodHS256, forgedClaims)
+		forgedSigned, _ := forgedJWT.SignedString([]byte("not-the-real-secret"))
+
+		req, _ := http.NewRequest("GET", "/auth/callback?code=123&state=bogus", nil)
+		req.AddCookie(&http.Cookie{Name: jwtCookieName, Value: forgedSigned})
+
+		resp, err := app.Test(req, 5000)
+		assert.NoError(t, err)
+		assert.Equal(t, http.StatusTemporaryRedirect, resp.StatusCode)
+
+		loc, _ := resp.Location()
+		assert.Contains(t, loc.String(), "error=csrf_validation_failed",
+			"wrong-secret cookie must not trigger the #6064 recovery path")
+	})
+
+	t.Run("empty state + valid cookie still recovers to /", func(t *testing.T) {
+		// state missing entirely (not just invalid) should also recover.
+		user := &models.User{ID: uuid.New(), GitHubLogin: "empty-state"}
+		cookieToken, err := handler.generateJWT(user)
+		assert.NoError(t, err)
+
+		req, _ := http.NewRequest("GET", "/auth/callback?code=123", nil)
+		req.AddCookie(&http.Cookie{Name: jwtCookieName, Value: cookieToken})
+
+		resp, err := app.Test(req, 5000)
+		assert.NoError(t, err)
+		assert.Equal(t, http.StatusTemporaryRedirect, resp.StatusCode)
+
+		loc, _ := resp.Location()
+		assert.Equal(t, "/", loc.Path)
+	})
+}
+
 // We cannot easily test successful GitHubCallback flow without mocking oauth lib
 // or doing extensive interface extraction, but we covered the error paths above.

--- a/pkg/api/middleware/auth.go
+++ b/pkg/api/middleware/auth.go
@@ -235,6 +235,11 @@ func IsTokenRevoked(jti string) bool {
 // Must match the name used in handlers/auth.go.
 const jwtCookieName = "kc_auth"
 
+// bearerScheme is the RFC 6750 authentication scheme prefix (with trailing
+// space) for the Authorization header. Extracted as a constant so the
+// middleware and any helpers agree on the exact prefix to strip.
+const bearerScheme = "Bearer "
+
 // JWTAuth creates JWT authentication middleware.
 // Token resolution order: Authorization header -> HttpOnly cookie -> _token query param (SSE only).
 func JWTAuth(secret string) fiber.Handler {
@@ -242,11 +247,31 @@ func JWTAuth(secret string) fiber.Handler {
 		authHeader := c.Get("Authorization")
 		var tokenString string
 
-		if authHeader != "" {
-			tokenString = strings.TrimPrefix(authHeader, "Bearer ")
-			if tokenString == authHeader {
-				slog.Info("[Auth] invalid authorization format", "path", c.Path())
-				return fiber.NewError(fiber.StatusUnauthorized, "Invalid authorization format")
+		// Parse the Authorization header. Any of the following structurally
+		// malformed inputs are treated the same as an empty header and fall
+		// through to the cookie path (#6063):
+		//   - non-empty header without the "Bearer " prefix (e.g. "garbage")
+		//   - "Bearer" with no trailing space or token
+		//   - "Bearer " with only whitespace after the scheme
+		//   - a header consisting entirely of whitespace
+		// Previously any of these returned 401 immediately, which stranded
+		// clients that had a perfectly valid kc_auth cookie (the session was
+		// live, but a broken/legacy fetch wrapper was stamping nonsense into
+		// the header). The companion #6026 path handles the different case
+		// of a structurally valid header that fails to parse.
+		trimmedHeader := strings.TrimSpace(authHeader)
+		if trimmedHeader != "" {
+			if strings.HasPrefix(trimmedHeader, bearerScheme) {
+				candidate := strings.TrimSpace(strings.TrimPrefix(trimmedHeader, bearerScheme))
+				if candidate != "" {
+					tokenString = candidate
+				}
+			}
+			// If we got here with tokenString still empty, the header was
+			// structurally malformed — keep going and let the cookie path
+			// (and the downstream "missing authorization" check) decide.
+			if tokenString == "" {
+				slog.Info("[Auth] malformed authorization header, trying cookie", "path", c.Path())
 			}
 		}
 

--- a/pkg/api/middleware/auth_test.go
+++ b/pkg/api/middleware/auth_test.go
@@ -287,6 +287,63 @@ func TestJWTAuth_StaleHeaderFallsBackToCookie(t *testing.T) {
 	})
 }
 
+// TestJWTAuth_MalformedHeaderFallsBackToCookie covers #6063: a structurally
+// invalid Authorization header (no Bearer prefix, "Bearer" with no token,
+// whitespace-only, etc.) must be treated the same as an empty header — the
+// middleware should fall through to the kc_auth cookie path instead of
+// immediately returning 401. Previously a client that had a perfectly valid
+// cookie session would be bounced to login if any misbehaving layer stamped
+// a garbage Authorization header onto its fetch, which is the exact bug
+// being fixed.
+func TestJWTAuth_MalformedHeaderFallsBackToCookie(t *testing.T) {
+	secret := "test-secret"
+	app := fiber.New()
+	app.Get("/protected", JWTAuth(secret), func(c *fiber.Ctx) error {
+		return c.SendString("success")
+	})
+
+	// All of these header values are structurally malformed. With a valid
+	// cookie attached, each request should succeed (200) because the
+	// malformed header is ignored and the cookie is consumed instead.
+	malformedHeaders := []struct {
+		name  string
+		value string
+	}{
+		{"no bearer prefix", "garbage"},
+		{"basic auth instead", "Basic dXNlcjpwYXNz"},
+		{"bearer keyword only no space", "Bearer"},
+		{"bearer keyword with space no token", "Bearer "},
+		{"bearer with only whitespace token", "Bearer    "},
+		{"whitespace only header", "   "},
+		{"lowercase bearer prefix", "bearer sometoken"},
+	}
+
+	for _, tc := range malformedHeaders {
+		tc := tc
+		t.Run(tc.name+" with valid cookie succeeds", func(t *testing.T) {
+			validCookieToken, _ := generateTestToken(secret, time.Now().Add(time.Hour))
+			req := httptest.NewRequest("GET", "/protected", nil)
+			req.Header.Set("Authorization", tc.value)
+			req.AddCookie(&http.Cookie{Name: jwtCookieName, Value: validCookieToken})
+
+			resp, err := app.Test(req, 5000)
+			assert.NoError(t, err)
+			assert.Equal(t, 200, resp.StatusCode,
+				"malformed header %q must fall through to cookie path (#6063)", tc.value)
+		})
+
+		t.Run(tc.name+" with no cookie still 401", func(t *testing.T) {
+			req := httptest.NewRequest("GET", "/protected", nil)
+			req.Header.Set("Authorization", tc.value)
+
+			resp, err := app.Test(req, 5000)
+			assert.NoError(t, err)
+			assert.Equal(t, 401, resp.StatusCode,
+				"malformed header %q with no cookie must still fail", tc.value)
+		})
+	}
+}
+
 func TestValidateJWT(t *testing.T) {
 	secret := "test-secret"
 

--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -419,6 +419,18 @@ setInterval(async function(){try{var r=await fetch('/healthz');if(r.ok){var d=aw
 </body>
 </html>`
 
+// oauthConfigured reports whether the server has a usable GitHub OAuth
+// configuration. Both the client ID AND the client secret must be present
+// — a partial config (one without the other) is unusable because the
+// token-exchange step cannot authenticate to GitHub without the secret,
+// and the health probe must not report such an install as OAuth-ready
+// (#6056). Prior to the fix this returned true as soon as the client ID
+// was set, which caused downstream UIs to show a "GitHub login" button
+// that was guaranteed to fail on click.
+func (s *Server) oauthConfigured() bool {
+	return s.config.GitHubClientID != "" && s.config.GitHubSecret != ""
+}
+
 func (s *Server) setupRoutes() {
 	// Minimal probe endpoint for load balancers and k8s liveness checks.
 	// Returns only status — no configuration metadata.
@@ -461,7 +473,7 @@ func (s *Server) setupRoutes() {
 		resp := fiber.Map{
 			"status":           healthStatus,
 			"version":          Version,
-			"oauth_configured": s.config.GitHubClientID != "",
+			"oauth_configured": s.oauthConfigured(),
 			"in_cluster":       inCluster,
 			"install_method":   detectInstallMethod(inCluster),
 			"project":          s.config.ConsoleProject,

--- a/pkg/api/server_test.go
+++ b/pkg/api/server_test.go
@@ -1,0 +1,63 @@
+package api
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestHealth_OAuthConfiguredRequiresBothIdAndSecret covers #6056: the
+// /health endpoint must report oauth_configured=true ONLY when BOTH the
+// GitHub client ID AND the client secret are present. A partial config
+// (id set but no secret, or vice versa) is unusable for OAuth — the token
+// exchange step needs the secret to authenticate to GitHub — so the probe
+// must not lie to the frontend about OAuth readiness. The helper lives on
+// Server so we exercise it directly without spinning up the full server
+// with DB, k8s, hub, etc.
+func TestHealth_OAuthConfiguredRequiresBothIdAndSecret(t *testing.T) {
+	cases := []struct {
+		name     string
+		clientID string
+		secret   string
+		want     bool
+	}{
+		{
+			name:     "both empty",
+			clientID: "",
+			secret:   "",
+			want:     false,
+		},
+		{
+			name:     "id only (the #6056 regression case)",
+			clientID: "client-id",
+			secret:   "",
+			want:     false,
+		},
+		{
+			name:     "secret only",
+			clientID: "",
+			secret:   "shhh",
+			want:     false,
+		},
+		{
+			name:     "both set",
+			clientID: "client-id",
+			secret:   "shhh",
+			want:     true,
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			s := &Server{
+				config: Config{
+					GitHubClientID: tc.clientID,
+					GitHubSecret:   tc.secret,
+				},
+			}
+			assert.Equal(t, tc.want, s.oauthConfigured(),
+				"oauth_configured must require both client id and secret (#6056)")
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Three small, independent backend auth fixes.

### #6056 — `/health` reports `oauth_configured: true` with no secret

`pkg/api/server.go` only checked `GitHubClientID != ""`. A config with an ID but no secret is unusable — the OAuth token exchange needs the secret — so the probe was lying to the frontend, which then renders a GitHub login button that is guaranteed to fail on click. Fix: require BOTH `GitHubClientID` and `GitHubSecret`. Logic extracted into `Server.oauthConfigured()` for direct unit testing.

### #6063 — Malformed `Authorization` header blocks cookie auth

`pkg/api/middleware/auth.go` returned 401 immediately when `Authorization` was present but not `Bearer <token>` (e.g. `garbage`, `Bearer` with no token, whitespace). A client with a perfectly valid `kc_auth` cookie would be bounced to login because some misbehaving layer stamped a bad header onto the fetch. Fix: treat any structurally malformed header the same as an empty header and fall through to the cookie path. This is the complement to #6026 (stale-but-valid-format header fallback, landed in #6031). Accepted malformed patterns now fall through: no Bearer prefix, `Bearer` with no token, `Bearer ` with only whitespace, whitespace-only headers, lowercase `bearer`.

### #6064 — OAuth callback ignores valid existing cookie on state failure

`pkg/api/handlers/auth.go` unconditionally redirected to `/login?error=csrf_validation_failed` when `validateAndConsumeOAuthState` failed. The user may already have a live session — the failed state is a stale OAuth tab, a back-button replay, or a server restart that cleared the in-memory store. Fix: on state failure, check for a non-expired, non-revoked `kc_auth` cookie via a new `hasValidAuthCookie` helper that uses `middleware.ParseJWT` + `IsTokenRevoked`. If valid, redirect to `/` and preserve the session. If missing/expired/forged, the classic error redirect applies. Complements #6034 which fixes the root cause of state loss on the server side; both should land.

## Test plan

- [x] `pkg/api/middleware/auth_test.go` — `TestJWTAuth_MalformedHeaderFallsBackToCookie` covers 7 malformed header variants, each tested with and without a valid cookie.
- [x] `pkg/api/handlers/auth_test.go` — `TestGitHubCallback_RecoversFromValidCookieOnStateFailure` covers: valid cookie + bogus state → `/`, missing cookie → error page, expired cookie → error page, wrong-secret cookie → error page, empty state → `/`.
- [x] `pkg/api/server_test.go` (new) — `TestHealth_OAuthConfiguredRequiresBothIdAndSecret` covers all four id/secret presence combinations.
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./pkg/... -count=1` (all packages green)
- [ ] CI: build / lint / preview

## Notes

- No magic numbers. Test lifetimes use named `const`s (`validCookieLifetime`, `expiredCookieAge`).
- Existing error message strings preserved on the unchanged paths.
- Touches only the three files the bugs live in plus their test files (and a new `server_test.go`).
- Does not touch unrelated handlers.

Fixes #6056
Fixes #6063
Fixes #6064