### PR TITLE
fix(suggestions): chip dropdown closes on its own chevron click

### DIFF
--- a/web/src/components/dashboard/MissionSuggestions.test.tsx
+++ b/web/src/components/dashboard/MissionSuggestions.test.tsx
@@ -1,14 +1,77 @@
 import { describe, it, expect, vi, afterEach } from 'vitest'
+import { render, screen, fireEvent, cleanup } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
 import { MissionSuggestions } from './MissionSuggestions'
+import type { MissionSuggestion } from '../../hooks/useMissionSuggestions'
 
 // Spy on global timers to verify cleanup behavior (#4660)
 const addEventSpy = vi.spyOn(document, 'addEventListener')
 const removeEventSpy = vi.spyOn(document, 'removeEventListener')
 
+// --- Mocks ---------------------------------------------------------------
+
+const mockSuggestion: MissionSuggestion = {
+  id: 'test-suggestion-1',
+  type: 'restart',
+  title: 'Test Suggestion',
+  description: 'A test suggestion description',
+  priority: 'high',
+  action: {
+    type: 'ai',
+    target: 'fix it',
+    label: 'Investigate' },
+  context: {
+    details: ['detail one', 'detail two'] },
+  detectedAt: Date.now() }
+
+vi.mock('../../hooks/useMissionSuggestions', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../hooks/useMissionSuggestions')>()
+  return {
+    ...actual,
+    useMissionSuggestions: () => ({
+      suggestions: [mockSuggestion],
+      hasSuggestions: true,
+      stats: { critical: 0, high: 1, medium: 0, low: 0 } }) }
+})
+
+vi.mock('../../hooks/useSnoozedMissions', () => ({
+  useSnoozedMissions: () => ({
+    snoozeMission: vi.fn(),
+    dismissMission: vi.fn(),
+    getSnoozeRemaining: () => null,
+    snoozedMissions: [] }),
+  formatTimeRemaining: (n: number) => `${n}s` }))
+
+vi.mock('../../hooks/useMissions', () => ({
+  useMissions: () => ({ startMission: vi.fn() }) }))
+
+vi.mock('../../hooks/useLocalAgent', () => ({
+  useLocalAgent: () => ({ status: 'connected' }) }))
+
+vi.mock('../../hooks/useBackendHealth', () => ({
+  isInClusterMode: () => false }))
+
+vi.mock('../../hooks/useDemoMode', () => ({
+  useDemoMode: () => ({ isDemoMode: true }) }))
+
+vi.mock('../../lib/analytics', () => ({
+  emitMissionSuggestionsShown: vi.fn(),
+  emitMissionSuggestionActioned: vi.fn() }))
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, opts?: Record<string, unknown>) => {
+      if (opts && 'count' in opts) return `${key} ${opts.count}`
+      return key
+    } }) }))
+
 afterEach(() => {
   addEventSpy.mockClear()
   removeEventSpy.mockClear()
+  cleanup()
 })
+
+// --- Tests ---------------------------------------------------------------
 
 describe('MissionSuggestions Component', () => {
   it('exports MissionSuggestions component', () => {
@@ -28,5 +91,35 @@ describe('MissionSuggestions Component', () => {
     const handler = () => {}
     expect(() => document.removeEventListener('mousedown', handler)).not.toThrow()
     expect(() => document.removeEventListener('keydown', handler)).not.toThrow()
+  })
+
+  it('chip dropdown closes when clicking its own chevron (#6050)', async () => {
+    render(
+      <MemoryRouter>
+        <MissionSuggestions />
+      </MemoryRouter>
+    )
+
+    // Component renders in minimized state — find the chip by title
+    const chip = screen.getByRole('button', { name: /Test Suggestion/ })
+    expect(chip).toBeDefined()
+
+    // 1. Open the dropdown
+    fireEvent.click(chip)
+    expect(chip.getAttribute('aria-expanded')).toBe('true')
+    expect(screen.getByRole('menu')).toBeDefined()
+
+    // Allow the deferred setTimeout(0) to install the outside-click listener
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    // 2. Simulate the real-world sequence: a mousedown then click on the chip.
+    // Before the fix, the document-level mousedown listener would fire first,
+    // set expandedId=null, then the button's onClick would toggle it back open.
+    fireEvent.mouseDown(chip)
+    fireEvent.click(chip)
+
+    // 3. Dropdown should now be closed
+    expect(chip.getAttribute('aria-expanded')).toBe('false')
+    expect(screen.queryByRole('menu')).toBeNull()
   })
 })

--- a/web/src/components/dashboard/MissionSuggestions.tsx
+++ b/web/src/components/dashboard/MissionSuggestions.tsx
@@ -49,6 +49,12 @@ export function MissionSuggestions() {
   const [countdown, setCountdown] = useState(AUTO_COLLAPSE_SECONDS)
   const countdownRef = useRef<ReturnType<typeof setInterval> | null>(null)
   const analyticsEmittedRef = useRef(false)
+  // Refs to each chip trigger button, keyed by suggestion id.
+  // Used so the outside-click listener can ignore clicks on the trigger itself
+  // (the trigger's own onClick handles toggling). Without this, clicking the
+  // chevron to close races the listener, which sets expandedId=null first,
+  // then the onClick sees isExpanded=false and reopens the dropdown (#6050).
+  const triggerRefs = useRef<Map<string, HTMLButtonElement | null>>(new Map())
 
   // Check agent status for offline skeleton display
   const { status: agentStatus } = useLocalAgent()
@@ -119,6 +125,11 @@ export function MissionSuggestions() {
     const handleClickOutside = (e: MouseEvent) => {
       // Use the currently expanded ID to find the correct dropdown element
       const activeDropdown = document.getElementById(`mission-dropdown-${expandedId}`)
+      // Ignore clicks on the trigger button itself — its onClick handles
+      // toggling. Otherwise, clicking the chevron to close races this
+      // listener and the dropdown reopens (#6050).
+      const activeTrigger = triggerRefs.current.get(expandedId)
+      if (activeTrigger && activeTrigger.contains(e.target as Node)) return
       if (activeDropdown && !activeDropdown.contains(e.target as Node)) {
         setExpandedId(null)
       }
@@ -249,6 +260,10 @@ export function MissionSuggestions() {
             return (
               <div key={suggestion.id} className="relative">
                 <button
+                  ref={(el) => {
+                    if (el) triggerRefs.current.set(suggestion.id, el)
+                    else triggerRefs.current.delete(suggestion.id)
+                  }}
                   onClick={() => setExpandedId(isExpanded ? null : suggestion.id)}
                   aria-expanded={isExpanded}
                   aria-haspopup="menu"
@@ -404,6 +419,10 @@ export function MissionSuggestions() {
             <div key={suggestion.id} className="relative">
               {/* Compact chip */}
               <button
+                ref={(el) => {
+                  if (el) triggerRefs.current.set(suggestion.id, el)
+                  else triggerRefs.current.delete(suggestion.id)
+                }}
                 onClick={() => setExpandedId(isExpanded ? null : suggestion.id)}
                 className={`inline-flex items-center gap-1.5 px-2.5 py-1.5 rounded-lg border text-xs font-medium transition-all hover:brightness-110 ${CHIP_STYLE.border} ${CHIP_STYLE.bg} ${CHIP_STYLE.text}`}
               >


### PR DESCRIPTION
Fixes #6050.

## Problem

The per-suggestion chip dropdown in `MissionSuggestions` could not be closed by clicking its own ChevronDown trigger. Users saw the dropdown "drop again" instead of closing.

Root cause is a race between two handlers on the same click:

1. The outside-click `mousedown` listener fires FIRST. The chip trigger button lives OUTSIDE `#mission-dropdown-${expandedId}`, so the listener classifies the click as "outside" and sets `expandedId = null`.
2. THEN the chip button's `onClick` fires: `setExpandedId(isExpanded ? null : id)`. By now `isExpanded` is already `false` (state was just cleared), so it toggles back to `id` and the dropdown reopens.

The panel-level ChevronUp close in the header already works correctly and is unaffected.

## Fix

Option A from the issue description: exclude the trigger from outside-click detection.

- Added a `triggerRefs` map (`Map<string, HTMLButtonElement | null>`) keyed by suggestion id.
- Attached a ref callback to both chip trigger buttons (minimized inline view and expanded panel view).
- In the outside-click listener, if the event target is inside the active trigger, bail out and let the trigger's own `onClick` handle the toggle.

This is the more explicit option and doesn't change the `mousedown` vs `click` timing that the rest of the listener relies on.

## Test

Added a regression test in `MissionSuggestions.test.tsx`:

- Renders the component with mocked hooks
- Clicks the chip to open the dropdown (asserts `aria-expanded=true` and `role=menu` present)
- Waits for the deferred `setTimeout(0)` that installs the outside-click listener
- Fires `mouseDown` then `click` on the chip (the real-world sequence)
- Asserts the dropdown is closed (`aria-expanded=false`, no `role=menu`)

Before the fix, this test fails because the dropdown reopens.

## Verification

- `npm run build` passes
- `npx vitest run src/components/dashboard/MissionSuggestions.test.tsx` — 4/4 tests pass
- Lint on the changed file is clean (the one pre-existing lint error in this file is unrelated and is present on `main`)