### PR TITLE
fix: address Copilot review on PR #6031

### DIFF
--- a/pkg/api/handlers/exec.go
+++ b/pkg/api/handlers/exec.go
@@ -272,6 +272,23 @@ func (h *ExecHandlers) HandleExec(c *websocket.Conn) {
 	// Clear read deadline after successful auth
 	c.SetReadDeadline(time.Time{})
 
+	// Create the cancellable context and register it BEFORE any of the long-
+	// running setup (init message read, k8s client lookup, executor build).
+	// Without this, there is a race window: the user authenticates, then
+	// logs out before the registration call below, and CancelUserExecSessions
+	// has nothing to cancel — the about-to-start exec session leaks past
+	// logout. Registering up-front shrinks the window to roughly zero
+	// because the context is already in the per-user registry when the
+	// long-running operations begin (#6075).
+	execCtx, execCancel := context.WithCancel(context.Background())
+	defer execCancel()
+
+	var execRegistrationID int64
+	if claims.UserID != uuid.Nil {
+		execRegistrationID = registerExecSession(claims.UserID, execCancel)
+		defer unregisterExecSession(claims.UserID, execRegistrationID)
+	}
+
 	if h.k8sClient == nil {
 		writeError(c, "No Kubernetes client available")
 		return
@@ -381,20 +398,9 @@ func (h *ExecHandlers) HandleExec(c *websocket.Conn) {
 	// Send initial terminal size
 	sizeQueue.ch <- remotecommand.TerminalSize{Width: init.Cols, Height: init.Rows}
 
-	// Create a cancellable context so that when the WebSocket client disconnects,
-	// the exec stream is cancelled promptly — preventing goroutine and SPDY leaks.
-	execCtx, execCancel := context.WithCancel(context.Background())
-	defer execCancel()
-
-	// Register this cancel with the per-user exec session registry so a later
-	// Logout call can tear the stream down even though /ws/exec is not tracked
-	// by the WebSocket Hub (#6024). Only register when we have a real userID —
-	// in dev/demo without a valid UserID claim there is nothing to key on.
-	var execRegistrationID int64
-	if claims.UserID != uuid.Nil {
-		execRegistrationID = registerExecSession(claims.UserID, execCancel)
-		defer unregisterExecSession(claims.UserID, execRegistrationID)
-	}
+	// execCtx / execCancel were created up-front (right after JWT validation)
+	// so the registry is populated before any long-running setup. See the
+	// comment above for the race-window rationale (#6075).
 
 	// Start a goroutine to read WebSocket messages and route them
 	done := make(chan struct{})

--- a/pkg/api/handlers/gitops.go
+++ b/pkg/api/handlers/gitops.go
@@ -2339,12 +2339,6 @@ func (h *GitOpsHandlers) TriggerArgoSync(c *fiber.Ctx) error {
 	if err := requireEditorOrAdmin(c, h.userStore); err != nil {
 		return err
 	}
-	if h.k8sClient == nil {
-		return c.Status(503).JSON(fiber.Map{
-			"error":   "Kubernetes client not configured",
-			"success": false,
-		})
-	}
 
 	var req struct {
 		AppName   string `json:"appName"`
@@ -2358,6 +2352,10 @@ func (h *GitOpsHandlers) TriggerArgoSync(c *fiber.Ctx) error {
 		})
 	}
 
+	// Body-shape validation runs BEFORE the k8s client availability check
+	// so RBAC + body-shape errors surface to the caller even when the
+	// cluster connection is unavailable. Mirrors the Sync /
+	// UpgradeHelmRelease ordering and is what the #6022 RBAC tests assume.
 	if req.AppName == "" || req.Cluster == "" {
 		return c.Status(400).JSON(fiber.Map{
 			"error":   "appName and cluster are required",
@@ -2370,6 +2368,13 @@ func (h *GitOpsHandlers) TriggerArgoSync(c *fiber.Ctx) error {
 	}
 	if err := validateK8sName(req.Cluster, "cluster"); err != nil {
 		return c.Status(400).JSON(fiber.Map{"error": err.Error(), "success": false})
+	}
+
+	if h.k8sClient == nil {
+		return c.Status(503).JSON(fiber.Map{
+			"error":   "Kubernetes client not configured",
+			"success": false,
+		})
 	}
 
 	// Default namespace for ArgoCD applications

--- a/pkg/api/handlers/gitops_test.go
+++ b/pkg/api/handlers/gitops_test.go
@@ -167,6 +167,12 @@ func gitopsMutationCases() []mutationCase {
 			body: `{}`,
 			wire: func(app *fiber.App, h *GitOpsHandlers, p string) { app.Post(p, h.RollbackHelmRelease) },
 		},
+		{
+			name: "argocd-sync",
+			path: "/api/gitops/argocd/sync",
+			body: `{}`,
+			wire: func(app *fiber.App, h *GitOpsHandlers, p string) { app.Post(p, h.TriggerArgoSync) },
+		},
 	}
 }
 


### PR DESCRIPTION
## Summary

Two cleanups flagged by Copilot on the merged security bundle PR #6031.

## 1. exec.go race window

**Where:** \`pkg/api/handlers/exec.go\` (around the original line 393)

**Problem:** the exec context + registry registration happened only AFTER reading the init message, looking up the k8s client + REST config, and building the SPDY executor. If the user logged out during that ~hundreds-of-ms window, \`CancelUserExecSessions\` had nothing to cancel — the about-to-start exec session leaked past logout.

**Fix:** move \`execCtx, execCancel := context.WithCancel(...)\` and the \`registerExecSession()\` call to immediately after JWT validation, before any of the long-running setup. Registration now happens essentially synchronously with the first byte the handler receives, so a follow-up \`Logout\` always finds and cancels the in-flight session.

## 2. gitops_test.go missing argocd-sync coverage

**Where:** \`pkg/api/handlers/gitops_test.go:148\`

**Problem:** \`gitopsMutationCases\` covered \`sync\`, \`helm-upgrade\`, \`helm-uninstall\`, \`helm-rollback\` but NOT \`/api/gitops/argocd/sync\`, even though \`TriggerArgoSync\` was gated by \`requireEditorOrAdmin\` in PR #6031 (#6022).

**Fix:** added an \`argocd-sync\` entry. Adding the case surfaced a pre-existing ordering bug in \`TriggerArgoSync\`: the k8s client nil check ran BEFORE body parsing and required-field validation, so a request with valid auth + valid body shape would 503 instead of returning the 400 the matrix expects. **Reordered** \`TriggerArgoSync\` to: body-parse → required-fields → \`validateK8sName\` → \`k8sClient\` check — matching the \`Sync\` / \`UpgradeHelmRelease\` conventions.

## Verification

\`\`\`
go build ./...
go vet ./...
go test ./pkg/... -count=1   # all pass including the new argocd-sync RBAC matrix
\`\`\`

Fixes #6075