### PR TITLE
fix(auth): frontend hardening (#6055, #6058, #6061, #6065, #6066, #6067, #6069)

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -2,7 +2,8 @@ import { Suspense, useState, useEffect, useRef } from 'react'
 import { Routes, Route, Navigate, useNavigate, useLocation, useSearchParams } from 'react-router-dom'
 import { CardHistoryEntry } from './hooks/useCardHistory'
 import { Layout } from './components/layout/Layout'
-import { AuthProvider, useAuth } from './lib/auth'
+import { AuthProvider, useAuth, isJWTExpired } from './lib/auth'
+import { DEMO_TOKEN_VALUE } from './lib/constants'
 import { ThemeProvider } from './hooks/useTheme'
 import { BrandingProvider, useBranding } from './hooks/useBranding'
 import { DrillDownProvider } from './hooks/useDrillDown'
@@ -204,11 +205,13 @@ function ProtectedRoute({ children }: { children: React.ReactNode }) {
   const location = useLocation()
 
   if (isLoading) {
-    // If we have a token (likely authenticated), render children optimistically
-    // to avoid a blank flash. Auth resolves almost instantly from localStorage
-    // cache. The stale-while-revalidate pattern in AuthProvider means isLoading
-    // is only true when there's no cached user, so this is safe.
-    if (localStorage.getItem(STORAGE_KEY_TOKEN)) {
+    // #6058 — Optimistically render only when the token in localStorage is
+    // either the demo sentinel or a JWT that's still within its exp window.
+    // If the token is expired, showing protected children would leak content
+    // to an unauthenticated user during the brief refreshUser() window. In
+    // that case render nothing (a spinner placeholder) until auth resolves.
+    const storedToken = localStorage.getItem(STORAGE_KEY_TOKEN)
+    if (storedToken && (storedToken === DEMO_TOKEN_VALUE || !isJWTExpired(storedToken))) {
       return <>{children}</>
     }
     return null

--- a/web/src/lib/__tests__/auth-coverage.test.tsx
+++ b/web/src/lib/__tests__/auth-coverage.test.tsx
@@ -21,6 +21,8 @@ import React from 'react'
 
 vi.mock('../api', () => ({
   checkOAuthConfigured: vi.fn().mockResolvedValue({ backendUp: false, oauthConfigured: false }),
+  // #6055 — retry helper mirrors checkOAuthConfigured so tests don't hang on real setTimeout delays
+  checkOAuthConfiguredWithRetry: vi.fn().mockResolvedValue({ backendUp: false, oauthConfigured: false }),
 }))
 
 vi.mock('../dashboards/dashboardSync', () => ({
@@ -599,5 +601,183 @@ describe('token refresh non-ok response', () => {
 
     // Token should remain the original near-expiry token
     expect(localStorage.getItem(STORAGE_KEY_TOKEN)).toBe(nearExpiryToken)
+  })
+})
+
+// ============================================================================
+// #6058 — isJWTExpired helper + isAuthenticated getter
+// ============================================================================
+
+describe('isJWTExpired helper (#6058)', () => {
+  it('returns true for a JWT whose exp has passed', async () => {
+    const { isJWTExpired } = await import('../auth')
+    const MS_PER_SECOND = 1000
+    const PAST_SECONDS = 100
+    const nowSec = Math.floor(Date.now() / MS_PER_SECOND)
+    const expiredToken = makeJwt({ exp: nowSec - PAST_SECONDS })
+    expect(isJWTExpired(expiredToken)).toBe(true)
+  })
+
+  it('returns false for a JWT whose exp is in the future', async () => {
+    const { isJWTExpired } = await import('../auth')
+    const MS_PER_SECOND = 1000
+    const FUTURE_SECONDS = 3600
+    const nowSec = Math.floor(Date.now() / MS_PER_SECOND)
+    const freshToken = makeJwt({ exp: nowSec + FUTURE_SECONDS })
+    expect(isJWTExpired(freshToken)).toBe(false)
+  })
+
+  it('returns false for a non-JWT opaque token (cannot determine expiry)', async () => {
+    const { isJWTExpired } = await import('../auth')
+    expect(isJWTExpired('opaque-server-token')).toBe(false)
+  })
+
+  it('isAuthenticated returns false for an expired JWT (#6058)', async () => {
+    const MS_PER_SECOND = 1000
+    const PAST_SECONDS = 100
+    const nowSec = Math.floor(Date.now() / MS_PER_SECOND)
+    const expiredToken = makeJwt({ exp: nowSec - PAST_SECONDS })
+    localStorage.setItem(STORAGE_KEY_TOKEN, expiredToken)
+    const cachedUser = { id: 'u1', github_id: '1', github_login: 'test', onboarded: true }
+    localStorage.setItem(AUTH_USER_CACHE_KEY, JSON.stringify(cachedUser))
+
+    const mockFetch = vi.fn().mockResolvedValue({ ok: true, json: vi.fn().mockResolvedValue(cachedUser) })
+    vi.stubGlobal('fetch', mockFetch)
+
+    const { result } = await renderWithAuthProvider()
+    // Regardless of loading state, an expired token must never count as authenticated.
+    expect(result.current.isAuthenticated).toBe(false)
+  })
+})
+
+// ============================================================================
+// #6067 — cached user age bound
+// ============================================================================
+
+describe('cached user staleness bound (#6067)', () => {
+  const AUTH_USER_CACHE_VALIDATED_KEY = 'kc-user-cache-validated'
+  const FIVE_MIN_MS = 5 * 60 * 1_000
+
+  it('trusts cached user when validated within MAX_CACHED_USER_AGE_MS', async () => {
+    const cachedUser = { id: 'fresh', github_id: '1', github_login: 'fresh', onboarded: true }
+    localStorage.setItem(STORAGE_KEY_TOKEN, 'real-token')
+    localStorage.setItem(AUTH_USER_CACHE_KEY, JSON.stringify(cachedUser))
+    // Validated 1 minute ago — well within the 5-minute bound
+    const ONE_MIN_MS = 60 * 1_000
+    localStorage.setItem(AUTH_USER_CACHE_VALIDATED_KEY, String(Date.now() - ONE_MIN_MS))
+
+    const mockFetch = vi.fn().mockRejectedValue(new Error('Network error'))
+    vi.stubGlobal('fetch', mockFetch)
+
+    const { result } = await renderWithAuthProvider()
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+
+    expect(result.current.user).toEqual(cachedUser)
+    expect(result.current.token).toBe('real-token')
+  })
+
+  it('drops cached user when older than MAX_CACHED_USER_AGE_MS', async () => {
+    const cachedUser = { id: 'stale', github_id: '1', github_login: 'stale', onboarded: true }
+    localStorage.setItem(STORAGE_KEY_TOKEN, 'real-token')
+    localStorage.setItem(AUTH_USER_CACHE_KEY, JSON.stringify(cachedUser))
+    // Validated 10 minutes ago — past the 5-minute bound
+    const TEN_MIN_MS = 10 * 60 * 1_000
+    localStorage.setItem(AUTH_USER_CACHE_VALIDATED_KEY, String(Date.now() - TEN_MIN_MS))
+
+    const mockFetch = vi.fn().mockRejectedValue(new Error('Network error'))
+    vi.stubGlobal('fetch', mockFetch)
+
+    const { result } = await renderWithAuthProvider()
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+
+    // Stale cache → session dropped
+    expect(result.current.token).toBeNull()
+    expect(result.current.user).toBeNull()
+  })
+
+  it('writes validated timestamp after successful /api/me fetch', async () => {
+    const fetchedUser = { id: 'u1', github_id: '1', github_login: 'u1', onboarded: true }
+    localStorage.setItem(STORAGE_KEY_TOKEN, 'real-token')
+
+    const mockFetch = vi.fn().mockResolvedValue({ ok: true, json: vi.fn().mockResolvedValue(fetchedUser) })
+    vi.stubGlobal('fetch', mockFetch)
+
+    const before = Date.now()
+    await renderWithAuthProvider()
+    await waitFor(() => {
+      expect(localStorage.getItem(AUTH_USER_CACHE_VALIDATED_KEY)).not.toBeNull()
+    })
+    const validated = Number(localStorage.getItem(AUTH_USER_CACHE_VALIDATED_KEY))
+    expect(validated).toBeGreaterThanOrEqual(before)
+    expect(FIVE_MIN_MS).toBeGreaterThan(0) // sanity-reference the constant
+  })
+})
+
+// ============================================================================
+// #6065 — cross-tab logout
+// ============================================================================
+
+describe('cross-tab logout (#6065)', () => {
+  it('clears local state when storage event fires with newValue=null', async () => {
+    localStorage.setItem(STORAGE_KEY_TOKEN, 'demo-token')
+    localStorage.setItem('kc-demo-mode', 'true')
+
+    // Prevent jsdom navigation errors when the handler sets location.href
+    const originalLocation = window.location
+    delete (window as unknown as { location?: Location }).location
+    ;(window as unknown as { location: Partial<Location> }).location = {
+      ...originalLocation,
+      href: '/',
+      pathname: '/dashboard',
+    } as unknown as Location
+
+    const { result } = await renderWithAuthProvider()
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+
+    act(() => {
+      localStorage.removeItem(STORAGE_KEY_TOKEN)
+      window.dispatchEvent(new StorageEvent('storage', {
+        key: STORAGE_KEY_TOKEN,
+        newValue: null,
+      }))
+    })
+
+    expect(result.current.token).toBeNull()
+    expect(result.current.user).toBeNull()
+
+    ;(window as unknown as { location: Location }).location = originalLocation
+  })
+})
+
+// ============================================================================
+// #6069 — proactive logout on expiry
+// ============================================================================
+
+describe('proactive logout on expiry (#6069)', () => {
+  it('calls logout() when timeUntilExpiry drops below zero', async () => {
+    const MS_PER_SECOND = 1000
+    const TWO_MINUTES_SEC = 120
+    const nowSec = Math.floor(Date.now() / MS_PER_SECOND)
+    // Token expires in 2 minutes — inside the 30-minute warning threshold
+    const aboutToExpireToken = makeJwt({ exp: nowSec + TWO_MINUTES_SEC })
+
+    localStorage.setItem(STORAGE_KEY_TOKEN, aboutToExpireToken)
+    const cachedUser = { id: 'u1', github_id: '1', github_login: 'test', onboarded: true }
+    localStorage.setItem(AUTH_USER_CACHE_KEY, JSON.stringify(cachedUser))
+
+    const mockFetch = vi.fn().mockResolvedValue({ ok: true, json: vi.fn().mockResolvedValue(cachedUser) })
+    vi.stubGlobal('fetch', mockFetch)
+
+    const { result } = await renderWithAuthProvider()
+    await vi.advanceTimersByTimeAsync(100)
+
+    // Fast-forward past the token exp (2 min + buffer) and past the next
+    // checkExpiry interval (60s) so the proactive logout fires.
+    const THREE_MINUTES_MS = 3 * 60 * 1_000
+    await vi.advanceTimersByTimeAsync(THREE_MINUTES_MS)
+
+    // After expiry, the interval should have invoked logout() which clears
+    // the in-memory token.
+    expect(result.current.token).toBeNull()
   })
 })

--- a/web/src/lib/__tests__/auth-expand.test.ts
+++ b/web/src/lib/__tests__/auth-expand.test.ts
@@ -24,6 +24,8 @@ import React from 'react'
 
 vi.mock('../api', () => ({
   checkOAuthConfigured: vi.fn().mockResolvedValue({ backendUp: false, oauthConfigured: false }),
+  // #6055 — retry helper mirrors checkOAuthConfigured so tests don't hang on real setTimeout delays
+  checkOAuthConfiguredWithRetry: vi.fn().mockResolvedValue({ backendUp: false, oauthConfigured: false }),
 }))
 
 vi.mock('../dashboards/dashboardSync', () => ({
@@ -350,7 +352,7 @@ describe('showExpiryWarningBanner expanded', () => {
 // ============================================================================
 
 describe('AuthProvider expanded', () => {
-  it('refreshUser with real token: /api/me json() rejects', async () => {
+  it('refreshUser with real token drops session when /api/me json() rejects (#6067)', async () => {
     localStorage.setItem(STORAGE_KEY_TOKEN, 'real-jwt')
     const mockFetch = vi.fn().mockResolvedValue({
       ok: true,
@@ -361,11 +363,11 @@ describe('AuthProvider expanded', () => {
     const { result } = await renderWithAuthProvider()
     await waitFor(() => expect(result.current.isLoading).toBe(false))
 
-    // json() threw, so it falls to the catch block -> demo mode
-    expect(result.current.token).toBe('demo-token')
+    // json() rejected → invalid JSON → no cache → session dropped (not demo mode)
+    expect(result.current.token).toBeNull()
   })
 
-  it('refreshUser with real token: /api/me returns 500', async () => {
+  it('refreshUser with real token drops session when /api/me returns 500 (#6067)', async () => {
     localStorage.setItem(STORAGE_KEY_TOKEN, 'real-jwt')
     const mockFetch = vi.fn().mockResolvedValue({
       ok: false,
@@ -376,28 +378,39 @@ describe('AuthProvider expanded', () => {
     const { result } = await renderWithAuthProvider()
     await waitFor(() => expect(result.current.isLoading).toBe(false))
 
-    // Non-ok -> throws -> demo mode
-    expect(result.current.token).toBe('demo-token')
+    // Non-ok → throws → no cache → session dropped
+    expect(result.current.token).toBeNull()
   })
 
-  it('storage event with null newValue is ignored', async () => {
+  it('storage event with null newValue clears local auth state (#6065)', async () => {
     localStorage.setItem(STORAGE_KEY_TOKEN, 'demo-token')
     localStorage.setItem('kc-demo-mode', 'true')
+
+    // Stub window.location to avoid jsdom navigation errors on /login redirect
+    const originalLocation = window.location
+    delete (window as unknown as { location?: Location }).location
+    ;(window as unknown as { location: Partial<Location> }).location = {
+      ...originalLocation,
+      href: '/',
+      pathname: '/dashboard',
+    } as unknown as Location
 
     const { result } = await renderWithAuthProvider()
     await waitFor(() => expect(result.current.isLoading).toBe(false))
 
-    const tokenBefore = result.current.token
-
     act(() => {
+      localStorage.removeItem(STORAGE_KEY_TOKEN)
       window.dispatchEvent(new StorageEvent('storage', {
         key: STORAGE_KEY_TOKEN,
         newValue: null,
       }))
     })
 
-    // Should not change
-    expect(result.current.token).toBe(tokenBefore)
+    // Cross-tab logout mirrored locally
+    expect(result.current.token).toBeNull()
+    expect(result.current.user).toBeNull()
+
+    ;(window as unknown as { location: Location }).location = originalLocation
   })
 
   it('storage event with empty string newValue is ignored', async () => {

--- a/web/src/lib/__tests__/auth.test.ts
+++ b/web/src/lib/__tests__/auth.test.ts
@@ -17,6 +17,8 @@ import { renderHook, waitFor, act } from '@testing-library/react'
 
 vi.mock('../api', () => ({
   checkOAuthConfigured: vi.fn().mockResolvedValue({ backendUp: false, oauthConfigured: false }),
+  // #6055 — retry helper mirrors checkOAuthConfigured so tests don't hang on real setTimeout delays
+  checkOAuthConfiguredWithRetry: vi.fn().mockResolvedValue({ backendUp: false, oauthConfigured: false }),
 }))
 
 vi.mock('../dashboards/dashboardSync', () => ({
@@ -400,6 +402,8 @@ const demoMod = await import('../demoMode')
 
 // Cast to vi.Mock for type-safe mock API
 const mockCheckOAuth = apiMod.checkOAuthConfigured as unknown as ReturnType<typeof vi.fn>
+// #6055 — retry helper is the one auth.tsx actually calls on the no-token path
+const mockCheckOAuthWithRetry = apiMod.checkOAuthConfiguredWithRetry as unknown as ReturnType<typeof vi.fn>
 const mockClearCache = dashMod.dashboardSync.clearCache as unknown as ReturnType<typeof vi.fn>
 const mockEmitLogin = analyticsMod.emitLogin as unknown as ReturnType<typeof vi.fn>
 const mockEmitLogout = analyticsMod.emitLogout as unknown as ReturnType<typeof vi.fn>
@@ -427,6 +431,8 @@ describe('AuthProvider', () => {
     document.getElementById('session-banner-animation')?.remove()
     // Default: backend down, no OAuth
     mockCheckOAuth.mockResolvedValue({ backendUp: false, oauthConfigured: false })
+    // #6055 — default the retry helper to the same "backend down" result
+    mockCheckOAuthWithRetry.mockResolvedValue({ backendUp: false, oauthConfigured: false })
     // Mock global fetch for /api/me calls
     vi.stubGlobal('fetch', vi.fn())
   })
@@ -479,6 +485,11 @@ describe('AuthProvider', () => {
 
   it('does not auto-enable demo mode when backend is up with OAuth', async () => {
     mockCheckOAuth.mockResolvedValue({ backendUp: true, oauthConfigured: true })
+    mockCheckOAuthWithRetry.mockResolvedValue({ backendUp: true, oauthConfigured: true })
+    // #6066 — when backend is up with OAuth, refreshUser attempts the cookie-restore
+    // path via POST /auth/refresh. Mock it to fail so we fall through to "show login".
+    const mockFetch = vi.fn().mockResolvedValue({ ok: false, status: 401 })
+    vi.stubGlobal('fetch', mockFetch)
 
     const { result } = await renderWithAuthProvider()
 
@@ -495,6 +506,8 @@ describe('AuthProvider', () => {
 
   it('falls back to demo mode when checkOAuthConfigured throws', async () => {
     mockCheckOAuth.mockRejectedValue(new Error('network error'))
+    // #6055 — retry helper is what auth.tsx actually calls; mimic the underlying throw
+    mockCheckOAuthWithRetry.mockResolvedValue({ backendUp: false, oauthConfigured: false })
 
     const { result } = await renderWithAuthProvider()
 
@@ -589,10 +602,12 @@ describe('AuthProvider', () => {
 
   // ---------- refreshUser: real token, /api/me fails, cached user exists ----------
 
-  it('falls back to cached user when /api/me fails', async () => {
+  it('falls back to fresh cached user when /api/me fails (#6067)', async () => {
     const cachedUser = { id: 'cached-1', github_id: '1', github_login: 'cached', onboarded: true }
     localStorage.setItem(STORAGE_KEY_TOKEN, 'real-jwt-token')
     localStorage.setItem(AUTH_USER_CACHE_KEY, JSON.stringify(cachedUser))
+    // #6067 — cache was validated just now, so it's fresh and should be trusted
+    localStorage.setItem('kc-user-cache-validated', String(Date.now()))
 
     const mockFetch = vi.fn().mockRejectedValue(new Error('Network error'))
     vi.stubGlobal('fetch', mockFetch)
@@ -607,9 +622,33 @@ describe('AuthProvider', () => {
     expect(result.current.token).toBe('real-jwt-token')
   })
 
-  // ---------- refreshUser: real token, /api/me fails, no cache -> demo ----------
+  // ---------- #6067 — stale cache drops to login ----------
 
-  it('falls back to demo mode when /api/me fails and no cache', async () => {
+  it('drops session to login when /api/me fails and cache is stale (#6067)', async () => {
+    const cachedUser = { id: 'cached-1', github_id: '1', github_login: 'cached', onboarded: true }
+    localStorage.setItem(STORAGE_KEY_TOKEN, 'real-jwt-token')
+    localStorage.setItem(AUTH_USER_CACHE_KEY, JSON.stringify(cachedUser))
+    // Cache validated 1 hour ago — well past MAX_CACHED_USER_AGE_MS (5 min)
+    const ONE_HOUR_MS = 60 * 60 * 1_000
+    localStorage.setItem('kc-user-cache-validated', String(Date.now() - ONE_HOUR_MS))
+
+    const mockFetch = vi.fn().mockRejectedValue(new Error('Network error'))
+    vi.stubGlobal('fetch', mockFetch)
+
+    const { result } = await renderWithAuthProvider()
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false)
+    })
+
+    // Stale cache → session dropped (token cleared, user null)
+    expect(result.current.token).toBeNull()
+    expect(result.current.user).toBeNull()
+  })
+
+  // ---------- refreshUser: real token, /api/me fails, no cache -> drops session ----------
+
+  it('drops session when /api/me fails and no cache (#6067)', async () => {
     localStorage.setItem(STORAGE_KEY_TOKEN, 'real-jwt-token')
 
     const mockFetch = vi.fn().mockRejectedValue(new Error('Network error'))
@@ -621,13 +660,14 @@ describe('AuthProvider', () => {
       expect(result.current.isLoading).toBe(false)
     })
 
-    expect(result.current.token).toBe('demo-token')
-    expect(result.current.user?.id).toBe('demo-user')
+    // No cache → dropped to login (not demo mode anymore per #6067)
+    expect(result.current.token).toBeNull()
+    expect(result.current.user).toBeNull()
   })
 
   // ---------- refreshUser: real token, /api/me returns non-ok ----------
 
-  it('treats non-ok /api/me response as failure', async () => {
+  it('drops session when /api/me returns non-ok (#6067)', async () => {
     localStorage.setItem(STORAGE_KEY_TOKEN, 'real-jwt-token')
 
     const mockFetch = vi.fn().mockResolvedValue({
@@ -642,13 +682,13 @@ describe('AuthProvider', () => {
       expect(result.current.isLoading).toBe(false)
     })
 
-    // No cache -> demo mode fallback
-    expect(result.current.token).toBe('demo-token')
+    // No cache → session dropped
+    expect(result.current.token).toBeNull()
   })
 
   // ---------- refreshUser: real token, /api/me returns invalid JSON ----------
 
-  it('treats invalid JSON from /api/me as failure', async () => {
+  it('drops session when /api/me returns invalid JSON (#6067)', async () => {
     localStorage.setItem(STORAGE_KEY_TOKEN, 'real-jwt-token')
 
     const mockFetch = vi.fn().mockResolvedValue({
@@ -663,8 +703,8 @@ describe('AuthProvider', () => {
       expect(result.current.isLoading).toBe(false)
     })
 
-    // null userData -> demo mode fallback
-    expect(result.current.token).toBe('demo-token')
+    // null userData → session dropped
+    expect(result.current.token).toBeNull()
   })
 
   // ---------- logout ----------
@@ -898,10 +938,12 @@ describe('AuthProvider', () => {
 
   // ---------- refreshUser: /api/me returns non-ok status with cached user → use cache ----------
 
-  it('uses cached user when /api/me returns 403 status', async () => {
+  it('uses fresh cached user when /api/me returns 403 status (#6067)', async () => {
     const cachedUser = { id: 'cached-403', github_id: '403', github_login: 'cached403', onboarded: true }
     localStorage.setItem(STORAGE_KEY_TOKEN, 'real-jwt-token')
     localStorage.setItem(AUTH_USER_CACHE_KEY, JSON.stringify(cachedUser))
+    // Fresh cache — trusted by #6067 stale-cache bound
+    localStorage.setItem('kc-user-cache-validated', String(Date.now()))
 
     const mockFetch = vi.fn().mockResolvedValue({
       ok: false,
@@ -922,7 +964,7 @@ describe('AuthProvider', () => {
 
   // ---------- refreshUser: /api/me .json() throws → treats as invalid JSON ----------
 
-  it('falls back when /api/me returns ok but .json() throws', async () => {
+  it('drops session when /api/me returns ok but .json() throws (#6067)', async () => {
     localStorage.setItem(STORAGE_KEY_TOKEN, 'real-jwt-token')
 
     const mockFetch = vi.fn().mockResolvedValue({
@@ -937,8 +979,8 @@ describe('AuthProvider', () => {
       expect(result.current.isLoading).toBe(false)
     })
 
-    // .json().catch(() => null) returns null → "Invalid JSON from /api/me" → demo fallback
-    expect(result.current.token).toBe('demo-token')
+    // .json().catch(() => null) returns null → "Invalid JSON from /api/me" → session dropped
+    expect(result.current.token).toBeNull()
   })
 
   // ---------- refreshUser with overrideToken ----------
@@ -1035,26 +1077,42 @@ describe('AuthProvider', () => {
     expect(mockEmitConversionStep).toHaveBeenCalledWith(2, 'login', { method: 'demo' })
   })
 
-  // ---------- storage event: null newValue is ignored ----------
+  // ---------- storage event: null newValue clears local state (#6065) ----------
+  // Behavior changed in #6065 — previously `null` was ignored; now the other
+  // tab's logout is mirrored locally so both tabs end up logged out.
 
-  it('ignores storage events with null newValue', async () => {
+  it('clears local auth state when storage event fires with null newValue (#6065)', async () => {
     localStorage.setItem(STORAGE_KEY_TOKEN, 'demo-token')
     localStorage.setItem('kc-demo-mode', 'true')
+
+    // Stub window.location.href to avoid jsdom navigation noise
+    const originalLocation = window.location
+    delete (window as unknown as { location?: Location }).location
+    ;(window as unknown as { location: Partial<Location> }).location = {
+      ...originalLocation,
+      href: '/',
+      pathname: '/dashboard',
+    } as unknown as Location
 
     const { result } = await renderWithAuthProvider()
     await waitFor(() => expect(result.current.isLoading).toBe(false))
 
-    const tokenBefore = result.current.token
-
     act(() => {
+      // Clear the underlying storage first so the auth provider's null-newValue
+      // handler observes the same state a real cross-tab logout would present.
+      localStorage.removeItem(STORAGE_KEY_TOKEN)
       window.dispatchEvent(new StorageEvent('storage', {
         key: STORAGE_KEY_TOKEN,
         newValue: null,
       }))
     })
 
-    // Token should not change because newValue is null (falsy)
-    expect(result.current.token).toBe(tokenBefore)
+    // Local auth state must have been wiped
+    expect(result.current.token).toBeNull()
+    expect(result.current.user).toBeNull()
+
+    // Restore
+    ;(window as unknown as { location: Location }).location = originalLocation
   })
 
   // ---------- refreshUser: demo token, backend down, explicit demo → stay demo ----------

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -16,6 +16,8 @@ const BACKEND_CACHE_TTL_MS = 300_000
 /** Delay before redirecting to login after session expiry (lets user see the banner) */
 const SESSION_EXPIRY_REDIRECT_MS = 3_000
 const TOKEN_REFRESH_HEADER = 'X-Token-Refresh' // server signals when token should be refreshed
+/** Endpoint used to invalidate the HttpOnly auth cookie on the server side (#6061). */
+const AUTH_LOGOUT_ENDPOINT = '/auth/logout'
 
 // Public API paths that don't require authentication (served without JWT on the backend)
 const PUBLIC_API_PREFIXES = ['/api/missions/browse', '/api/missions/file']
@@ -64,6 +66,28 @@ function handle401(): void {
   showSessionExpiredBanner()
 
   emitSessionExpired()
+
+  // Fire-and-forget: invalidate the HttpOnly auth cookie on the server so that
+  // a stale cookie doesn't resurrect the session on the next page load (#6061).
+  // We pass credentials:'include' so the browser sends the cookie. We don't
+  // await the response and we ignore failures — the client-side clear below
+  // is the source of truth for logout.
+  const expiredToken = localStorage.getItem(STORAGE_KEY_TOKEN)
+  try {
+    const headers: Record<string, string> = { 'Content-Type': 'application/json' }
+    if (expiredToken && expiredToken !== DEMO_TOKEN_VALUE) {
+      headers['Authorization'] = `Bearer ${expiredToken}`
+    }
+    fetch(`${API_BASE}${AUTH_LOGOUT_ENDPOINT}`, {
+      method: 'POST',
+      headers,
+      credentials: 'include',
+    }).catch(() => {
+      // Backend unreachable — cookie will expire naturally
+    })
+  } catch {
+    // fetch() threw synchronously (very rare) — ignore
+  }
 
   // Clear auth state
   localStorage.removeItem(STORAGE_KEY_TOKEN)
@@ -197,6 +221,35 @@ export async function checkBackendAvailability(forceCheck = false): Promise<bool
   })()
 
   return backendCheckPromise
+}
+
+/** #6055 — number of retry attempts for checkOAuthConfiguredWithRetry during backend startup. */
+const OAUTH_STARTUP_RETRY_ATTEMPTS = 5
+/** #6055 — delay (ms) between retry attempts. */
+const OAUTH_STARTUP_RETRY_DELAY_MS = 2_000
+
+/**
+ * #6055 — Retry wrapper around checkOAuthConfigured() for bootstrap races
+ * where the frontend loads before the backend is accepting connections.
+ * Retries up to OAUTH_STARTUP_RETRY_ATTEMPTS times, sleeping
+ * OAUTH_STARTUP_RETRY_DELAY_MS between attempts, exiting early as soon as
+ * the backend comes up.
+ */
+export async function checkOAuthConfiguredWithRetry(): Promise<{ backendUp: boolean; oauthConfigured: boolean }> {
+  let lastResult: { backendUp: boolean; oauthConfigured: boolean } = { backendUp: false, oauthConfigured: false }
+  for (let attempt = 0; attempt < OAUTH_STARTUP_RETRY_ATTEMPTS; attempt++) {
+    try {
+      const result = await checkOAuthConfigured()
+      lastResult = result
+      if (result.backendUp) return result
+    } catch {
+      // swallow and retry
+    }
+    if (attempt < OAUTH_STARTUP_RETRY_ATTEMPTS - 1) {
+      await new Promise((resolve) => setTimeout(resolve, OAUTH_STARTUP_RETRY_DELAY_MS))
+    }
+  }
+  return lastResult
 }
 
 /**

--- a/web/src/lib/auth.tsx
+++ b/web/src/lib/auth.tsx
@@ -1,5 +1,5 @@
 import { createContext, use, useState, useEffect, useCallback, useRef, ReactNode } from 'react'
-import { checkOAuthConfigured } from './api'
+import { checkOAuthConfigured, checkOAuthConfiguredWithRetry } from './api'
 import { dashboardSync } from './dashboards/dashboardSync'
 import { clearPermissionsCache } from '../hooks/usePermissions'
 import { disconnectPresence } from '../hooks/useActiveUsers'
@@ -32,11 +32,21 @@ interface AuthContextType {
 }
 
 const AUTH_USER_CACHE_KEY = STORAGE_KEY_USER_CACHE
+/** Timestamp (ms) of the last successful /api/me round-trip — tracked so we
+ *  can bound how long cached user data is trusted when the backend is down (#6067). */
+const AUTH_USER_CACHE_VALIDATED_KEY = 'kc-user-cache-validated'
 
 // How often (in ms) to check if the JWT is nearing expiry
 const EXPIRY_CHECK_INTERVAL_MS = 60_000
 // Show a warning banner when the token expires within this many ms
 const EXPIRY_WARNING_THRESHOLD_MS = 30 * 60_000
+
+/** #6067 — maximum age of cached user data (5 min) before we force re-validation. */
+const MAX_CACHED_USER_AGE_MS = 5 * 60 * 1_000
+/** #6067 — interval for background re-validation when the backend is unreachable. */
+const BACKEND_REVALIDATE_INTERVAL_MS = 30_000
+/** Milliseconds per second — JWT `exp` is in seconds. */
+const MS_PER_SECOND = 1_000
 
 /**
  * Decode the expiry timestamp from a JWT without verifying signature.
@@ -51,12 +61,24 @@ function getJwtExpiryMs(token: string): number | null {
     const base64 = base64Url.replace(/-/g, '+').replace(/_/g, '/')
     const payload = JSON.parse(atob(base64))
     if (typeof payload.exp !== 'number') return null
-    const MS_PER_SECOND = 1000
     return payload.exp * MS_PER_SECOND
   } catch {
     return null
   }
 }
+
+/**
+ * #6058 — Return true only when a token is a *parseable* JWT whose `exp`
+ * has passed. For opaque / non-JWT tokens we return false (not expired)
+ * so we still attempt the /api/me call and let the backend decide. This
+ * avoids false-positive logouts for tokens that simply aren't JWTs.
+ */
+export function isJWTExpired(token: string): boolean {
+  const expiryMs = getJwtExpiryMs(token)
+  if (expiryMs === null) return false
+  return Date.now() >= expiryMs
+}
+
 
 /**
  * Inject a DOM-based warning banner when the session is about to expire.
@@ -237,19 +259,60 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   const refreshUser = useCallback(async (overrideToken?: string) => {
     const effectiveToken = overrideToken || localStorage.getItem(STORAGE_KEY_TOKEN)
     if (!effectiveToken) {
-      // Check if backend requires OAuth login — if so, show the login page instead
-      // of auto-enabling demo mode. For Helm installs (no OAuth), auto-demo gives
-      // the same instant-dashboard experience as console.kubestellar.io.
+      // #6055 — Retry the OAuth-configured probe during backend startup so we
+      // don't race the backend into demo mode when the server is still coming
+      // online. checkOAuthConfiguredWithRetry attempts up to
+      // OAUTH_STARTUP_RETRY_ATTEMPTS times before giving up.
+      let backendUp = false
+      let oauthConfigured = false
       try {
-        const { backendUp, oauthConfigured } = await checkOAuthConfigured()
-        if (backendUp && oauthConfigured) {
-          // OAuth configured — user should authenticate via login page
-          return
-        }
+        ({ backendUp, oauthConfigured } = await checkOAuthConfiguredWithRetry())
       } catch {
-        // Backend unreachable — fall through to demo mode
+        // Complete failure — fall through to demo mode
+      }
+
+      if (backendUp && oauthConfigured) {
+        // #6066 — If the user has a valid HttpOnly cookie from a previous
+        // session, /auth/refresh will mint a new JWT. Try that before showing
+        // the login page so a page reload can restore the session silently.
+        try {
+          const refreshResponse = await fetch('/auth/refresh', {
+            method: 'POST',
+            credentials: 'include',
+            headers: { 'Content-Type': 'application/json' },
+            signal: AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS),
+          })
+          if (refreshResponse.ok) {
+            const data = await refreshResponse.json().catch(() => null) as { token?: string } | null
+            if (data?.token && !isJWTExpired(data.token)) {
+              localStorage.setItem(STORAGE_KEY_TOKEN, data.token)
+              setTokenState(data.token)
+              // Re-enter refreshUser with the newly restored token so we can
+              // populate the user cache via /api/me.
+              await refreshUser(data.token)
+              return
+            }
+          }
+        } catch {
+          // Refresh failed — fall through to show login page
+        }
+        // OAuth configured + no valid cookie — show login page
+        return
       }
       setDemoMode()
+      return
+    }
+
+    // #6058 — If the token is a real JWT but already expired, don't attempt
+    // /api/me with it (which will just 401). Clear it and recurse so the
+    // no-token branch above can try restoring from the HttpOnly cookie.
+    if (effectiveToken !== DEMO_TOKEN_VALUE && isJWTExpired(effectiveToken)) {
+      localStorage.removeItem(STORAGE_KEY_TOKEN)
+      localStorage.removeItem(AUTH_USER_CACHE_KEY)
+      localStorage.removeItem(AUTH_USER_CACHE_VALIDATED_KEY)
+      setTokenState(null)
+      setUser(null)
+      await refreshUser()
       return
     }
 
@@ -294,26 +357,43 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       if (!userData) throw new Error('Invalid JSON from /api/me')
       setUser(userData)
       cacheUser(userData)
+      // #6067 — record when the cache was last validated so we can bound
+      // how long it's trusted if the backend later becomes unreachable.
+      try {
+        localStorage.setItem(AUTH_USER_CACHE_VALIDATED_KEY, String(Date.now()))
+      } catch {
+        // localStorage quota / private mode — cache will just be treated as fresh
+      }
       // Set anonymous analytics ID (SHA-256 hash — no PII)
       setAnalyticsUserId(userData.id)
       setAnalyticsUserProperties({ auth_mode: 'github-oauth' })
       // Detect developer running cloned repo with startup-oauth.sh
       emitDeveloperSession()
     } catch (error) {
-      // If the backend is temporarily unreachable but we have a real token,
-      // keep the token and use cached user data instead of destroying the
-      // session by falling back to demo mode.
+      // #6067 — If the backend is temporarily unreachable but we have a real
+      // token, keep the cached user ONLY if it's still fresh. Stale caches
+      // drop the user to login instead of silently trusting old data forever.
       const cachedUser = getCachedUser()
-      if (cachedUser) {
-        console.warn('Backend unreachable, using cached user data')
+      const validatedAtRaw = (() => {
+        try { return localStorage.getItem(AUTH_USER_CACHE_VALIDATED_KEY) } catch { return null }
+      })()
+      const validatedAt = validatedAtRaw ? Number(validatedAtRaw) : 0
+      const cacheAge = validatedAt ? Date.now() - validatedAt : Number.POSITIVE_INFINITY
+      if (cachedUser && cacheAge <= MAX_CACHED_USER_AGE_MS) {
+        console.warn('Backend unreachable, using cached user data (age ms):', cacheAge)
         setUser(cachedUser)
         setAnalyticsUserId(cachedUser.id)
         setAnalyticsUserProperties({ auth_mode: 'github-oauth' })
         return
       }
-      // No cached user — fall back to demo mode as last resort
-      console.error('Failed to fetch user and no cache, falling back to demo mode:', error)
-      setDemoMode()
+      // Cache is stale or missing — drop to login (clear token so the
+      // ProtectedRoute redirects and the user re-authenticates).
+      console.error('Failed to fetch user (cache stale or missing), dropping to login:', error)
+      localStorage.removeItem(STORAGE_KEY_TOKEN)
+      localStorage.removeItem(AUTH_USER_CACHE_KEY)
+      localStorage.removeItem(AUTH_USER_CACHE_VALIDATED_KEY)
+      setTokenState(null)
+      setUser(null)
     }
   }, [setDemoMode])
 
@@ -375,8 +455,17 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       if (expiryMs === null) return
 
       const timeUntilExpiry = expiryMs - Date.now()
-      if (timeUntilExpiry <= 0 || timeUntilExpiry > EXPIRY_WARNING_THRESHOLD_MS) {
-        // Token not near expiry (or already expired) — remove stale banner if present
+      // #6069 — Proactively log the user out the moment the token expires
+      // instead of waiting for the next 401 to surface. This prevents a
+      // window where the UI still looks authenticated but every API call
+      // returns 401.
+      if (timeUntilExpiry <= 0) {
+        document.getElementById('session-expiry-warning')?.remove()
+        logout()
+        return
+      }
+      if (timeUntilExpiry > EXPIRY_WARNING_THRESHOLD_MS) {
+        // Token not near expiry — remove stale banner if present
         document.getElementById('session-expiry-warning')?.remove()
         return
       }
@@ -416,7 +505,27 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   // so the AuthProvider state stays in sync without a full page reload.
   useEffect(() => {
     const handleStorageChange = (e: StorageEvent) => {
-      if (e.key === STORAGE_KEY_TOKEN && e.newValue && e.newValue !== DEMO_TOKEN_VALUE) {
+      if (e.key !== STORAGE_KEY_TOKEN) return
+      // #6065 — cross-tab logout: when another tab removes the token,
+      // `e.newValue` is null. Immediately clear local auth state and
+      // redirect to /login so both tabs end up logged out. Without this
+      // branch, the other tab silently keeps stale auth until the user
+      // triggers an API call that 401s.
+      if (e.newValue === null) {
+        setTokenState(null)
+        setUser(null)
+        cacheUser(null)
+        try {
+          localStorage.removeItem(AUTH_USER_CACHE_VALIDATED_KEY)
+        } catch { /* ignore */ }
+        document.getElementById('session-expiry-warning')?.remove()
+        // Only redirect if we're not already on the login page to avoid a loop
+        if (!window.location.pathname.startsWith('/login')) {
+          window.location.href = '/login'
+        }
+        return
+      }
+      if (e.newValue && e.newValue !== DEMO_TOKEN_VALUE) {
         setTokenState(e.newValue)
         // Remove the expiry warning banner since the token was just refreshed
         document.getElementById('session-expiry-warning')?.remove()
@@ -425,6 +534,29 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     window.addEventListener('storage', handleStorageChange)
     return () => window.removeEventListener('storage', handleStorageChange)
   }, [])
+
+  // #6067 — When the backend is unreachable, re-validate the cached user
+  // periodically. If validation continues to fail past MAX_CACHED_USER_AGE_MS,
+  // refreshUser() itself will drop the session. This background retry gives
+  // us an opportunity to recover without requiring the user to interact.
+  useEffect(() => {
+    if (!token || token === DEMO_TOKEN_VALUE) return
+    const intervalId = setInterval(() => {
+      // Only re-validate if the cache is getting close to stale
+      const validatedAtRaw = (() => {
+        try { return localStorage.getItem(AUTH_USER_CACHE_VALIDATED_KEY) } catch { return null }
+      })()
+      const validatedAt = validatedAtRaw ? Number(validatedAtRaw) : 0
+      const cacheAge = validatedAt ? Date.now() - validatedAt : Number.POSITIVE_INFINITY
+      // Only re-validate if cache is older than half the max age — otherwise
+      // we're spending cycles validating fresh data.
+      const REVALIDATE_AGE_THRESHOLD_MS = MAX_CACHED_USER_AGE_MS / 2
+      if (cacheAge >= REVALIDATE_AGE_THRESHOLD_MS) {
+        refreshUser().catch(() => { /* refreshUser handles its own errors */ })
+      }
+    }, BACKEND_REVALIDATE_INTERVAL_MS)
+    return () => clearInterval(intervalId)
+  }, [token, refreshUser])
 
   // Always attempt to resolve the user on mount — even with no token.
   // When there's no token, refreshUser() auto-enables demo mode so the user
@@ -444,12 +576,22 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     refreshUser().finally(() => setIsLoading(false))
   }, [refreshUser])
 
+  // #6058 — A real JWT that has already passed its `exp` must be treated as
+  // unauthenticated immediately, even before the background checkExpiry
+  // interval fires. Demo tokens (non-JWT sentinel values) are always valid
+  // as long as they're present.
+  const isAuthenticated = (() => {
+    if (!token) return false
+    if (token === DEMO_TOKEN_VALUE) return true
+    return !isJWTExpired(token)
+  })()
+
   return (
     <AuthContext.Provider
       value={{
         user,
         token,
-        isAuthenticated: !!token,
+        isAuthenticated,
         isLoading,
         login,
         logout,


### PR DESCRIPTION
Fixes #6055, #6058, #6061, #6065, #6066, #6067, #6069.

## Summary

Bundled frontend auth hardening covering 7 related issues. All changes are in `web/src/lib/auth.tsx`, `web/src/lib/api.ts`, and `web/src/App.tsx` (ProtectedRoute).

### #6055 — OAuth startup race into demo mode
Added `checkOAuthConfiguredWithRetry()` in `api.ts` that retries up to 5 times at 2s intervals. `refreshUser()` now uses it on the no-token path so backend startup is tolerated before we fall into demo mode.

### #6058 — Expired-token leakage
New `isJWTExpired()` helper decodes the JWT `exp` claim. `isAuthenticated` now returns false for expired JWTs, `refreshUser()` clears expired tokens and recurses into the cookie-restore path, and `ProtectedRoute` only optimistically renders children when the stored token is demo or still unexpired.

### #6061 — 401 leaves cookie active
`handle401()` now fires a fire-and-forget `POST /auth/logout` with `credentials:'include'` before the client-side wipe.

### #6065 — Multi-tab logout sync
The `storage` event handler now branches on `e.newValue === null` and mirrors the cross-tab logout locally (clear state + redirect to `/login`).

### #6066 — Restore session from valid cookie
When `refreshUser()` sees no token AND OAuth is configured, it now calls `POST /auth/refresh` with `credentials:'include'`. If the response returns a fresh JWT it stores it and recurses; otherwise falls through to show login.

### #6067 — Stale cached user
New `MAX_CACHED_USER_AGE_MS = 5 * 60 * 1000`. After each successful `/api/me` we write `kc-user-cache-validated = Date.now()`. On backend failure we only trust the cache when age is within the bound; stale caches drop the session. A 30s background interval re-validates when the cache is getting close to stale.

### #6069 — Expiry-detected only on API calls
The existing `EXPIRY_CHECK_INTERVAL_MS` interval now calls `logout()` when `timeUntilExpiry <= 0` instead of just removing the banner.

## Code quality

- Every numeric literal is a named constant with a comment (`OAUTH_STARTUP_RETRY_ATTEMPTS`, `OAUTH_STARTUP_RETRY_DELAY_MS`, `MAX_CACHED_USER_AGE_MS`, `BACKEND_REVALIDATE_INTERVAL_MS`, `MS_PER_SECOND`, `AUTH_LOGOUT_ENDPOINT`).
- Demo-mode behavior is preserved for installs where OAuth is not configured.
- No refactors outside the auth files.

## Test plan

- [x] Updated `web/src/lib/__tests__/auth.test.ts` and `auth-expand.test.ts` for the behavior changes in #6065 (null newValue) and #6067 (stale-cache drop instead of demo fallback).
- [x] Added new tests in `auth-coverage.test.tsx` for:
  - `isJWTExpired` helper (expired, fresh, opaque token, isAuthenticated getter)
  - #6067 fresh vs stale cache age bound and validated-timestamp write-through
  - #6065 cross-tab logout with `newValue=null`
  - #6069 proactive logout when timeUntilExpiry drops below zero
- [x] `npm run build` — passes (including post-build safety checks)
- [x] `npm run lint` — zero new errors (baseline 328 errors, 733 warnings -> 328 errors, 734 warnings; the single new warning is the `react-refresh/only-export-components` warning from exporting `isJWTExpired`, matching the existing export pattern in the file)
- [x] Full `vitest run src/lib/__tests__/` — 1502 passing (+10 over baseline), 1 pre-existing flake in `sseClient-expand2.test.ts` unrelated to this change

[AI] Generated by Claude Code.