### PR TITLE
fix(dashboard): minimized cards reflow grid instead of leaving dead space

### DIFF
--- a/web/src/components/dashboard/CustomDashboard.tsx
+++ b/web/src/components/dashboard/CustomDashboard.tsx
@@ -28,6 +28,7 @@ import { useSidebarConfig } from '../../hooks/useSidebarConfig'
 import { useToast } from '../ui/Toast'
 import { CardWrapper } from '../cards/CardWrapper'
 import { CARD_COMPONENTS } from '../cards/cardRegistry'
+import { useCardCollapse } from '../../lib/cards/cardHooks'
 import { safeGetJSON, safeSetJSON, safeRemoveItem } from '../../lib/utils/localStorage'
 import { ROUTES } from '../../config/routes'
 import { AddCardModal } from './AddCardModal'
@@ -65,6 +66,15 @@ const NARROW_MAX = 1023
 /** Minimum card column span at narrow viewports */
 const MIN_NARROW_COLS = 6
 
+/**
+ * Minimum pixel height a non-collapsed sortable card cell should occupy.
+ * Mirrors the legacy `auto-rows-[minmax(180px,auto)]` baseline so expanded
+ * cards keep their previous look now that the grid container uses
+ * `auto-rows-min` (which is required so collapsed cards can shrink and let
+ * neighbours pack upward — see issue #6072).
+ */
+const EXPANDED_CARD_MIN_HEIGHT_PX = 180
+
 // Sortable card component
 interface SortableCardProps {
   card: Card
@@ -101,10 +111,17 @@ function SortableCard({ card, onConfigure, onRemove, onWidthChange, isDragging, 
 
   const effectiveW = isNarrowRange && (card.position?.w || 4) < MIN_NARROW_COLS ? MIN_NARROW_COLS : (card.position?.w || 4)
 
+  // Read collapse state so the cell can drop its minimum height when the
+  // card is collapsed (#6072). Without this, the grid leaves dead space
+  // under collapsed cards because every cell is forced to the expanded
+  // baseline height.
+  const { isCollapsed } = useCardCollapse(card.id)
+
   const style = {
     transform: CSS.Transform.toString(transform),
     transition,
     gridColumn: `span ${effectiveW}`,
+    minHeight: isCollapsed ? undefined : `${EXPANDED_CARD_MIN_HEIGHT_PX}px`,
     opacity: isDragging ? 0.5 : 1 }
 
   const CardComponent = CARD_COMPONENTS[card.card_type]
@@ -644,7 +661,7 @@ export function CustomDashboard() {
           onDragEnd={handleDragEnd}
         >
           <SortableContext items={cards.map(c => c.id)} strategy={rectSortingStrategy}>
-            <div className="grid grid-cols-1 md:grid-cols-12 gap-2 auto-rows-[minmax(180px,auto)]">
+            <div className="grid grid-cols-1 md:grid-cols-12 gap-2 auto-rows-min grid-flow-dense">
               {cards.map((card, index) => (
                 <SortableCard
                   key={card.id}

--- a/web/src/components/dashboard/Dashboard.tsx
+++ b/web/src/components/dashboard/Dashboard.tsx
@@ -1078,12 +1078,20 @@ export function Dashboard() {
         onDragCancel={handleDragCancel}
       >
         <SortableContext items={localCards.map(c => c.id)} strategy={rectSortingStrategy}>
+          {/*
+            auto-rows-min lets rows shrink to their content so a collapsed
+            card (which only shows its header) does not leave a tall empty
+            grid row behind it (#6072). Each non-collapsed sortable card
+            sets its own `minHeight` inline to preserve the legacy expanded
+            baseline height. `grid-flow-dense` allows later cards to
+            backfill empty cells freed up by collapsed neighbours.
+          */}
           <div
             data-testid="dashboard-cards-grid"
             data-tour="dashboard"
             role="grid"
             aria-label="Dashboard cards"
-            className={`grid grid-cols-1 md:grid-cols-12 gap-2 auto-rows-[minmax(180px,auto)] ${showDragHint ? 'animate-shimmy' : ''}`}
+            className={`grid grid-cols-1 md:grid-cols-12 gap-2 auto-rows-min grid-flow-dense ${showDragHint ? 'animate-shimmy' : ''}`}
           >
             {localCards.map((card, index) => (
               <SortableCard

--- a/web/src/components/dashboard/SharedSortableCard.tsx
+++ b/web/src/components/dashboard/SharedSortableCard.tsx
@@ -4,8 +4,25 @@ import { useSortable } from '@dnd-kit/sortable'
 import { CSS } from '@dnd-kit/utilities'
 import { CardWrapper } from '../cards/CardWrapper'
 import { CARD_COMPONENTS, DEMO_DATA_CARDS, LIVE_DATA_CARDS } from '../cards/cardRegistry'
+import { useCardCollapse } from '../../lib/cards/cardHooks'
 import { formatCardTitle } from '../../lib/formatCardTitle'
 import type { Card } from './dashboardUtils'
+
+/**
+ * Number of grid rows a collapsed card occupies (#6072). Collapsed cards
+ * only show their header, so they shrink to a single row regardless of the
+ * card's stored `position.h`. The original `position.h` is preserved on the
+ * card model and reapplied when the card is expanded again.
+ */
+const COLLAPSED_CARD_ROW_SPAN = 1
+
+/**
+ * Minimum pixel height a non-collapsed sortable card cell should occupy.
+ * Mirrors the legacy `auto-rows-[minmax(180px,auto)]` baseline so expanded
+ * cards keep their previous look when the grid container itself uses
+ * `auto-rows-min` (which is required so collapsed cards can shrink).
+ */
+const EXPANDED_CARD_MIN_HEIGHT_PX = 180
 
 interface SortableCardProps {
   card: Card
@@ -78,11 +95,21 @@ export const SortableCard = memo(function SortableCard({ card, onConfigure, onRe
   const posH = card.position?.h || 2
   const effectiveW = isNarrow && posW < MIN_NARROW_COLS ? MIN_NARROW_COLS : posW
 
+  // Read the card's collapse state so the grid cell shrinks to a single row
+  // when the card is collapsed (#6072). The original `posH` stays untouched
+  // on the card model — expanding restores the full row span.
+  const { isCollapsed } = useCardCollapse(card.id)
+  const effectiveRowSpan = isCollapsed ? COLLAPSED_CARD_ROW_SPAN : posH
+
   const style = {
     transform: CSS.Transform.toString(transform),
     transition,
     gridColumn: `span ${effectiveW}`,
-    gridRow: `span ${posH}`,
+    gridRow: `span ${effectiveRowSpan}`,
+    // Only enforce the legacy minimum height when expanded; collapsed cards
+    // must be free to shrink to their header height so neighbouring rows can
+    // pack upward instead of leaving dead space.
+    minHeight: isCollapsed ? undefined : `${EXPANDED_CARD_MIN_HEIGHT_PX}px`,
     opacity: isDragging ? 0.5 : 1,
   }
 

--- a/web/src/lib/cards/cardHooks.ts
+++ b/web/src/lib/cards/cardHooks.ts
@@ -441,6 +441,24 @@ export function useCardData<T, S extends string = string>(
 const COLLAPSED_STORAGE_KEY = 'kubestellar-collapsed-cards'
 
 /**
+ * Module-level subscriber set so multiple `useCardCollapse` instances for the
+ * same `cardId` stay in sync when one of them toggles. Without this, calling
+ * the hook from both `SortableCard` (for grid layout) and `CardWrapper`
+ * (for the actual collapse UI) would leave them out of sync — collapsing the
+ * card via the chevron button would not update the grid row span (#6072).
+ */
+const collapseSubscribers = new Set<() => void>()
+
+function subscribeToCollapseChanges(listener: () => void): () => void {
+  collapseSubscribers.add(listener)
+  return () => { collapseSubscribers.delete(listener) }
+}
+
+function notifyCollapseSubscribers() {
+  collapseSubscribers.forEach((listener) => listener())
+}
+
+/**
  * Get all collapsed card IDs from localStorage
  */
 function getCollapsedCards(): Set<string> {
@@ -454,7 +472,8 @@ function getCollapsedCards(): Set<string> {
 }
 
 /**
- * Save collapsed card IDs to localStorage
+ * Save collapsed card IDs to localStorage and notify all hook subscribers so
+ * that components reading the same card's collapse state stay in sync.
  */
 function saveCollapsedCards(collapsed: Set<string>) {
   try {
@@ -462,6 +481,7 @@ function saveCollapsedCards(collapsed: Set<string>) {
   } catch {
     // Silently ignore quota errors or private browsing restrictions
   }
+  notifyCollapseSubscribers()
 }
 
 export interface UseCardCollapseResult {
@@ -492,6 +512,21 @@ export function useCardCollapse(
     const collapsed = getCollapsedCards()
     return collapsed.has(cardId) || defaultCollapsed
   })
+
+  // Subscribe to module-level collapse changes so multiple hook instances
+  // for the same cardId stay in sync (#6072 — grid row span needs to react
+  // when the chevron button inside CardWrapper toggles collapse). Only the
+  // persisted localStorage value drives this sync — `defaultCollapsed` is
+  // intentionally not consulted here so that an explicit user expand/collapse
+  // is never overwritten by the seed default after the first toggle.
+  useEffect(() => {
+    const sync = () => {
+      const collapsed = getCollapsedCards()
+      const next = collapsed.has(cardId)
+      setIsCollapsedState((prev) => (prev === next ? prev : next))
+    }
+    return subscribeToCollapseChanges(sync)
+  }, [cardId])
 
   const setCollapsed = (collapsed: boolean) => {
     setIsCollapsedState(collapsed)


### PR DESCRIPTION
Fixes #6072. Reported by @xonas1101 with a screenshot showing roughly 300px of dead space underneath two minimized cards (Cluster Metrics + Event Stream) while the next row of cards stayed pinned to the original 2-row track.

## Root cause

The dashboard card grid container used:

```
auto-rows-[minmax(180px,auto)]
```

and each `SortableCard` set `gridRow: span ${posH}` (defaulting to 2). When a card was collapsed via the chevron button in `CardWrapper`, only the inner content was hidden — the grid cell still spanned 2 rows of at least 180px each, so the cell stayed ~360px tall and cards in later rows could not pack upward.

## Fix

- `Dashboard.tsx` and `CustomDashboard.tsx` grids now use `auto-rows-min grid-flow-dense` so rows shrink to their content and later cards can backfill empty cells freed up by collapsed neighbours.
- The legacy 180px floor moves to each non-collapsed sortable card cell as an inline `minHeight` named via `EXPANDED_CARD_MIN_HEIGHT_PX`, so expanded cards keep their previous baseline look.
- `SharedSortableCard` (used by `Dashboard.tsx`) now reads `useCardCollapse(card.id)` and clamps the grid row span to `COLLAPSED_CARD_ROW_SPAN = 1` when the card is collapsed. The card model's `position.h` is never mutated, so expanding the card restores its full row span.
- The local `SortableCard` in `CustomDashboard.tsx` does the same `minHeight` toggle (it never sets `gridRow` so it only needs the height fix).
- `useCardCollapse` now uses a small module-level subscriber set so multiple hook instances for the same `cardId` stay in sync. Without this, the wrapper's collapse state would not update when the user clicked the chevron button inside `CardWrapper`, because each hook instance kept its own local `useState`.

## Constants (no magic numbers)

- `COLLAPSED_CARD_ROW_SPAN = 1` (in `SharedSortableCard.tsx`)
- `EXPANDED_CARD_MIN_HEIGHT_PX = 180` (in `SharedSortableCard.tsx` and `CustomDashboard.tsx`)

## Persistence

Collapsed state already persists per-card in `localStorage` under `kubestellar-collapsed-cards` (`useCardCollapse`). This change does not touch that storage layer beyond adding the in-memory subscriber set; persistence behavior is unchanged.

## Verification

- `npm run build` passes locally (post-build safety checks all green).
- `npm run lint` problem count is unchanged from `main` (1061 problems, 0 introduced by this change).
- `vitest run cardHooks.test.ts SharedSortableCard.test.tsx Dashboard.test.tsx CustomDashboard.test.tsx` all pass (75 tests).

## Test plan

- [ ] On a dashboard with at least 4 cards in 2 rows, collapse the two top-row cards via the chevron button.
- [ ] Confirm the cards in the second row pack upward immediately (no dead space).
- [ ] Expand a collapsed card and confirm the original height/row span is restored.
- [ ] Reload the page and confirm collapsed state persists per card.