### PR TITLE
feat(clusters): surface remove-cluster button in cluster detail modal (#5901)

### DIFF
--- a/web/src/components/clusters/ClusterDetailModal.tsx
+++ b/web/src/components/clusters/ClusterDetailModal.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react'
-import { X, CheckCircle, AlertTriangle, WifiOff, Pencil, ChevronRight, ChevronDown, Layers, Server, Network, HardDrive, Box, FolderOpen, Loader2, Cpu, MemoryStick, Database, Wand2, Stethoscope, Wrench, Bot, ExternalLink } from 'lucide-react'
+import { X, CheckCircle, AlertTriangle, WifiOff, Pencil, Trash2, ChevronRight, ChevronDown, Layers, Server, Network, HardDrive, Box, FolderOpen, Loader2, Cpu, MemoryStick, Database, Wand2, Stethoscope, Wrench, Bot, ExternalLink } from 'lucide-react'
 import { BaseModal } from '../../lib/modals'
 import { useClusterHealth, usePodIssues, useDeploymentIssues, useGPUNodes, useNodes, useNamespaceStats, useDeployments, useClusters } from '../../hooks/useMCP'
 import { isClusterUnreachable, isClusterHealthy } from './utils'
@@ -90,9 +90,14 @@ interface ClusterDetailModalProps {
   clusterUser?: string  // Optional kubeconfig user for provider detection
   onClose: () => void
   onRename?: (clusterName: string) => void
+  /**
+   * Invoked when the user clicks "Remove cluster" on an unreachable cluster (#5901).
+   * Only rendered when the cluster is unreachable and backed by a kubeconfig context.
+   */
+  onRemove?: (clusterName: string) => void
 }
 
-export function ClusterDetailModal({ clusterName, clusterUser, onClose, onRename }: ClusterDetailModalProps) {
+export function ClusterDetailModal({ clusterName, clusterUser, onClose, onRename, onRemove }: ClusterDetailModalProps) {
   const { t } = useTranslation()
   const { health, isLoading } = useClusterHealth(clusterName)
   const { deduplicatedClusters, clusters: rawClusters } = useClusters()
@@ -325,6 +330,20 @@ After I approve, help me execute the repairs step by step.`,
                 <Pencil className="w-4 h-4" />
               </button>
             )}
+            {/* Remove cluster button — only for unreachable clusters (#5901).
+                Only shown for kubeconfig-backed clusters where the `/kubeconfig/remove`
+                endpoint can actually delete the entry. */}
+            {onRemove && isUnreachable && (clusterInfo?.source === 'kubeconfig' || !clusterInfo?.source) && (
+              <button
+                onClick={() => onRemove(clusterName)}
+                className="p-1.5 rounded hover:bg-red-500/20 text-muted-foreground hover:text-red-400"
+                title={t('cluster.removeCluster')}
+                aria-label={t('cluster.removeCluster')}
+                data-testid="cluster-detail-remove-button"
+              >
+                <Trash2 className="w-4 h-4" />
+              </button>
+            )}
           </div>
           <button onClick={onClose} className="text-muted-foreground hover:text-foreground">
             <X className="w-5 h-5" />
@@ -335,6 +354,34 @@ After I approve, help me execute the repairs step by step.`,
             external reachability (#5926) and freshness (#5927). */}
         {clusterInfo && (
           <ClusterStatusDetails cluster={clusterInfo} className="mb-4" />
+        )}
+
+        {/* Remove offline cluster affordance (#5901) —
+            surfaces the `/kubeconfig/remove` endpoint (added in #5658) as a
+            discoverable primary action on the cluster detail modal. Only shown
+            when the cluster is unreachable AND is kubeconfig-backed AND the
+            parent provided a remove handler. */}
+        {onRemove && isUnreachable && (clusterInfo?.source === 'kubeconfig' || !clusterInfo?.source) && (
+          <div className="mb-6 flex items-start gap-3 p-4 rounded-lg bg-red-500/5 border border-red-500/20">
+            <WifiOff className="w-5 h-5 text-red-400 flex-shrink-0 mt-0.5" aria-hidden="true" />
+            <div className="flex-1 min-w-0">
+              <h3 className="text-sm font-medium text-foreground mb-1">
+                {t('clusterDetail.offlineRemoveTitle')}
+              </h3>
+              <p className="text-xs text-muted-foreground">
+                {t('clusterDetail.offlineRemoveDesc')}
+              </p>
+            </div>
+            <Button
+              variant="danger"
+              size="sm"
+              onClick={() => onRemove(clusterName)}
+              icon={<Trash2 className="w-3.5 h-3.5" />}
+              data-testid="cluster-detail-remove-cta"
+            >
+              {t('cluster.removeCluster')}
+            </Button>
+          </div>
         )}
 
         {/* AI Actions */}

--- a/web/src/components/clusters/Clusters.tsx
+++ b/web/src/components/clusters/Clusters.tsx
@@ -424,6 +424,11 @@ export function Clusters() {
             setSelectedCluster(null)
             setRenamingCluster(name)
           }}
+          onRemove={isConnected ? (name) => {
+            // Close the detail modal first, then open the remove confirm (#5901).
+            setSelectedCluster(null)
+            setRemovingCluster(name)
+          } : undefined}
         />
       )}
 

--- a/web/src/locales/en/common.json
+++ b/web/src/locales/en/common.json
@@ -3016,6 +3016,8 @@
     "noIssuesToRepair": "No issues to repair",
     "askTitle": "Ask AI any question about this cluster",
     "renameCluster": "Rename cluster",
+    "offlineRemoveTitle": "Cluster is offline",
+    "offlineRemoveDesc": "This cluster cannot be reached. If the underlying cluster no longer exists, remove its kubeconfig entry to clean up your cluster list. This does not affect the cluster itself.",
     "openConsole": "Open {{provider}} console",
     "akaLabel": "aka:",
     "alsoKnownAs": "Also known as: {{aliases}}",


### PR DESCRIPTION
Fixes #5901.

## Background

#5908 already wired up the `RemoveClusterDialog` and the backend
`/kubeconfig/remove` endpoint (added in #5658), and exposed a small trash-icon
button in the cluster card header for offline/unreachable clusters. However,
@xonas1101 followed up on the issue saying *"The button is still not available
on offline clusters"* — the card-header trash icon is easy to miss, and users
who click into an offline cluster expect to find the remove affordance on the
**cluster detail modal**, which is where #5908 did not surface it.

## Changes

Add two discoverable remove affordances on `ClusterDetailModal`:

1. **Header icon** — a trash icon next to the existing Rename (pencil) button,
   matching the pattern used on the cluster card.
2. **Prominent offline banner** — a red `Cluster is offline` banner with a
   `Remove cluster` CTA placed just below the existing `ClusterStatusDetails`
   panel, so users who open the modal on an offline cluster see remediation
   immediately.

Both affordances reuse the same confirmation flow: clicking closes the detail
modal and opens the existing `RemoveClusterDialog`, which calls the existing
`handleRemoveCluster` handler in `Clusters.tsx`.

## Gating

The new buttons honor the same preconditions as the existing card button:

- `isUnreachable` — only shown for offline clusters
- `cluster.source === 'kubeconfig'` (or `undefined`) — only kubeconfig-backed
  entries can be removed via the endpoint
- `isConnected` (local agent) — the `onRemove` prop is only passed when the
  local agent is reachable, so the button hides in pure in-cluster/demo modes
  where the endpoint isn't available

## Backend

No backend changes. Reuses the existing `RemoveContext` handler wired to
`POST /kubeconfig/remove` on the local agent HTTP server
(`pkg/agent/server.go:376`, added in #5658).

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `cd web && npm run build`
- [x] `cd web && npx vitest run src/components/clusters/` — 77 tests pass
- [ ] Manual: click an offline cluster card → detail modal shows red banner with Remove button → click → confirm dialog → cluster disappears from list

🤖 Generated with [Claude Code](https://claude.com/claude-code)