### PR TITLE
feat(missions): add + button in AI missions sidebar

### DIFF
--- a/web/src/components/layout/mission-sidebar/MissionSidebar.tsx
+++ b/web/src/components/layout/mission-sidebar/MissionSidebar.tsx
@@ -574,7 +574,9 @@ export function MissionSidebar() {
         <div className="flex items-center gap-1 min-w-0">
           {/* Optional toolbar buttons — clipped when sidebar is narrow */}
           <div className="flex items-center gap-1 overflow-hidden min-w-0 flex-shrink">
-            {/* New Mission Button */}
+            {/* New Mission Button — uses "+" for discoverability (#6095).
+                Styled with a purple accent and ring so it stands out from
+                the font-size Plus control and reads clearly as "add new". */}
             <button
               onClick={() => {
                 setShowNewMission(!showNewMission)
@@ -583,14 +585,15 @@ export function MissionSidebar() {
                 }
               }}
               className={cn(
-                "p-1.5 rounded transition-colors flex-shrink-0",
+                "p-1.5 rounded transition-colors flex-shrink-0 ring-1",
                 showNewMission
-                  ? "bg-primary text-primary-foreground"
-                  : "text-muted-foreground hover:text-foreground hover:bg-black/5 dark:hover:bg-white/10"
+                  ? "bg-primary text-primary-foreground ring-primary"
+                  : "bg-purple-500/10 text-purple-400 ring-purple-500/30 hover:bg-purple-500/20 hover:text-purple-300"
               )}
-              title={t('missionSidebar.startNewMission')}
+              aria-label={t('missionSidebar.newMissionButton')}
+              title={t('missionSidebar.newMissionButton')}
             >
-              <Sparkles className="w-4 h-4" />
+              <Plus className="w-4 h-4" />
             </button>
             {/* Browse Community Missions */}
             <button

--- a/web/src/locales/en/common.json
+++ b/web/src/locales/en/common.json
@@ -1620,6 +1620,7 @@
     "expandSidebar": "Expand sidebar",
     "aiMissions": "AI Missions",
     "startNewMission": "Start new mission",
+    "newMissionButton": "New mission",
     "decreaseFontSize": "Decrease font size",
     "increaseFontSize": "Increase font size",
     "exitFullScreen": "Exit full screen",


### PR DESCRIPTION
Fixes #6095. Reported by @xonas1101.

## Summary

The AI missions sidebar header already had a "new mission" toolbar button, but it used a Sparkles icon. New users don't intuitively associate Sparkles with "create a new thing" — the universal convention is a "+" symbol. This PR swaps the Sparkles icon for a Plus icon and styles it with a purple accent ring so it stands out clearly from the nearby font-size Plus control.

## Changes

- `web/src/components/layout/mission-sidebar/MissionSidebar.tsx`
  - Toolbar "new mission" button now renders a `Plus` icon instead of `Sparkles`
  - Added a purple ring/background accent so the button visually reads as "add new" and does not collide with the font-size Plus mini-control next to it
  - Added `aria-label` (was missing) for screen readers
  - Reuses the existing `setShowNewMission` handler — no duplicate action logic
- `web/src/locales/en/common.json`
  - New key `missionSidebar.newMissionButton: "New mission"` used for aria-label + tooltip

## Notes

- `Plus` was already imported from `lucide-react` for the font-size control, so no new imports
- The button still toggles the same inline new-mission composer that was already wired to the Sparkles button — no behavior change, only iconography/affordance
- Did not add a test: the existing `MissionSidebar.test.tsx` only verifies module exports (the full component has too many dependencies to render in isolation), and adding a render test is out of scope for this cosmetic fix

## Test plan

- [x] `npm run build` passes locally
- [x] `npx eslint` on the modified file — no new errors or warnings
- [ ] Visual verification: open the AI missions sidebar, confirm the Plus button appears in the header toolbar with a purple ring, and clicking it opens the new-mission composer
- [ ] Verify the Plus button and the font-size Plus control are visually distinguishable