### PR TITLE
fix(errors-drilldown): recover from stuck loading state after restart

### DIFF
--- a/web/src/lib/__tests__/safeLazy.test.ts
+++ b/web/src/lib/__tests__/safeLazy.test.ts
@@ -42,4 +42,28 @@ describe('safeLazy', () => {
       expect((e as Error).message).toContain('chunk may be stale')
     }
   })
+
+  // Regression for #6098: a hung dynamic import (e.g. during a backend
+  // restart) must not leave the Suspense fallback stuck on a spinner.
+  // Each attempt must race against a timeout so the loader eventually
+  // rejects and feeds into the retry + error-boundary recovery.
+  it('rejects when the dynamic import hangs past the per-attempt timeout', async () => {
+    const LazyComp = safeLazy(
+      () => new Promise<{ HangingComp: () => null }>(() => {
+        /* never resolves — simulates a hung chunk fetch */
+      }),
+      'HangingComp',
+    )
+
+    const loader = (LazyComp as unknown as { _init: unknown; _payload: { _result: () => Promise<unknown> } })._payload._result
+    try {
+      await loader()
+      expect.fail('should have rejected due to timeout')
+    } catch (e: unknown) {
+      expect((e as Error).message).toContain('HangingComp')
+      expect((e as Error).message).toMatch(/timed out|unreachable|restarting/i)
+    }
+  // Retries add delay between attempts on top of the per-attempt timeout,
+  // so give the test plenty of headroom before vitest's default 5s cap.
+  }, 60_000)
 })

--- a/web/src/lib/safeLazy.ts
+++ b/web/src/lib/safeLazy.ts
@@ -4,6 +4,15 @@ import { lazy, type ComponentType } from 'react'
 const LAZY_IMPORT_MAX_RETRIES = 2
 /** Base delay in ms between retry attempts (doubles each retry via exponential backoff) */
 const LAZY_IMPORT_RETRY_BASE_MS = 1_000
+/**
+ * Per-attempt timeout for a dynamic import. If the backend that serves the
+ * chunk is restarting (#6098), the native `import()` has no built-in timeout
+ * and can hang indefinitely, leaving the Suspense fallback stuck on a
+ * "loading" spinner until the user manually closes and reopens the view.
+ * Racing the import against this timeout turns a hang into a recoverable
+ * rejection that feeds into the existing retry + error-boundary recovery.
+ */
+const LAZY_IMPORT_ATTEMPT_TIMEOUT_MS = 8_000
 
 /**
  * Safe wrapper around React.lazy() for named exports.
@@ -18,14 +27,34 @@ const LAZY_IMPORT_RETRY_BASE_MS = 1_000
  *    auto-reload recovery instead of silently crashing.
  * 2. Retries the import with exponential backoff on network/chunk errors (#4933)
  *    so transient failures don't crash the app.
+ * 3. Races each import attempt against a timeout (#6098) so a hung dynamic
+ *    import (e.g. during a backend restart) becomes a recoverable rejection
+ *    instead of leaving the Suspense fallback stuck on a loading spinner.
  */
 export function safeLazy<T extends Record<string, unknown>>(
   importFn: () => Promise<T>,
   exportName: keyof T & string,
 ): ReturnType<typeof lazy> {
   return lazy(() => {
+    const importWithTimeout = (): Promise<T> => {
+      let timeoutId: ReturnType<typeof setTimeout> | undefined
+      const timeoutPromise = new Promise<T>((_, reject) => {
+        timeoutId = setTimeout(() => {
+          reject(
+            new Error(
+              `Dynamic import for "${exportName}" timed out after ${LAZY_IMPORT_ATTEMPT_TIMEOUT_MS}ms — ` +
+              'the chunk server may be unreachable or restarting.',
+            ),
+          )
+        }, LAZY_IMPORT_ATTEMPT_TIMEOUT_MS)
+      })
+      return Promise.race([importFn(), timeoutPromise]).finally(() => {
+        if (timeoutId !== undefined) clearTimeout(timeoutId)
+      })
+    }
+
     const attemptImport = (retriesLeft: number): Promise<{ default: ComponentType<Record<string, unknown>> }> =>
-      importFn()
+      importWithTimeout()
         .then((m) => {
           // When an eagerly-loaded bundle uses .catch(() => undefined) to suppress
           // unhandled rejections, a stale-chunk failure resolves the promise to


### PR DESCRIPTION
Fixes #6098. Reported by @xonas1101.

## Problem

After a backend/agent restart, clicking the errors stat block (or any other drill-down whose view is lazy-loaded) left the modal stuck on the Suspense loading spinner for a long time. Closing and reopening the modal made it render normally.

## Root cause

All drill-down views are lazy-loaded via `safeLazy` → `React.lazy(() => import(...))`. The native `import()` has no built-in timeout, so if the chunk server is temporarily unreachable (e.g. the Go backend is restarting), the dynamic import just hangs. `React.lazy` keeps the Suspense fallback up indefinitely while the promise stays pending. Only when the user happened to close and reopen the modal after the backend came back online did the cached import resolve.

## Fix

Race each import attempt in `safeLazy` against a per-attempt timeout (`LAZY_IMPORT_ATTEMPT_TIMEOUT_MS = 8_000`). If the import hasn't settled in that window, reject with a descriptive error. The existing `.catch` already retries the import with exponential backoff and ultimately feeds into `ChunkErrorBoundary`, so a hung import now becomes a recoverable rejection instead of a silent stuck spinner.

- Named constant with a comment — no magic number.
- No behavior change for imports that resolve normally.
- Adds a regression test: passes a never-resolving `importFn`, asserts the loader rejects with a timeout error mentioning the export name.

## Files

- `web/src/lib/safeLazy.ts` — add `LAZY_IMPORT_ATTEMPT_TIMEOUT_MS` constant and `importWithTimeout` wrapper, race each attempt.
- `web/src/lib/__tests__/safeLazy.test.ts` — add timeout regression test.

## Verification

- `npm run build` — passes, post-build safety checks OK.
- `npm run lint` — no new errors introduced in changed files (1060 pre-existing issues elsewhere).
- `npx vitest run src/lib/__tests__/safeLazy.test.ts` — all 4 tests pass (including the new timeout test).