### PR TITLE
fix(test): preserve real exports in useTokenUsage test constants mock

### DIFF
--- a/web/src/hooks/__tests__/useTokenUsage.test.ts
+++ b/web/src/hooks/__tests__/useTokenUsage.test.ts
@@ -22,13 +22,21 @@ vi.mock('../useDemoMode', () => ({
   getDemoMode: mockGetDemoMode,
 }))
 
-vi.mock('../../lib/constants', () => ({
-  LOCAL_AGENT_HTTP_URL: 'http://localhost:8585',
-}))
+vi.mock('../../lib/constants', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../lib/constants')>()
+  return {
+    ...actual,
+    LOCAL_AGENT_HTTP_URL: 'http://localhost:8585',
+  }
+})
 
-vi.mock('../../lib/constants/network', () => ({
-  QUICK_ABORT_TIMEOUT_MS: 2000,
-}))
+vi.mock('../../lib/constants/network', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../lib/constants/network')>()
+  return {
+    ...actual,
+    QUICK_ABORT_TIMEOUT_MS: 2000,
+  }
+})
 
 import { useTokenUsage, setActiveTokenCategory, clearActiveTokenCategory, getActiveTokenCategories, addCategoryTokens } from '../useTokenUsage'
 import type { TokenCategory } from '../useTokenUsage'


### PR DESCRIPTION
Fixes #6115

## Problem
`web/src/hooks/__tests__/useTokenUsage.test.ts` failed to load with:
```
No "STORAGE_KEY_DEMO_MODE" export is defined on the "../../lib/constants" mock
```
(and after adding that, `MCP_HOOK_TIMEOUT_MS`, etc.)

## Root cause
The test mocked `../../lib/constants` and `../../lib/constants/network` with factory returns that only exported the specific constants the test wanted. The constants barrel (`index.ts`) uses `export * from './network'` etc., so downstream modules in the transitive import chain (useTokenUsage -> analytics -> demoMode, api, tokenUsageApi) that read other constants through the same barrel all broke at module load.

## Fix
Switch both `vi.mock` calls to the `importOriginal` form so the real exports are preserved and only the intended values are overridden. This is drift-proof against future additions to the constants barrel.

```ts
vi.mock('../../lib/constants', async (importOriginal) => {
  const actual = await importOriginal<typeof import('../../lib/constants')>()
  return { ...actual, LOCAL_AGENT_HTTP_URL: 'http://localhost:8585' }
})
```

## Verification
```
$ npx vitest run src/hooks/__tests__/useTokenUsage.test.ts
 Test Files  1 passed (1)
      Tests  53 passed (53)
```