### PR TITLE
fix(rewards): address Copilot review on PR #6032

### DIFF
--- a/pkg/api/handlers/rewards_persistence.go
+++ b/pkg/api/handlers/rewards_persistence.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/gofiber/fiber/v2"
+	"github.com/google/uuid"
 
 	"github.com/kubestellar/console/pkg/api/middleware"
 	"github.com/kubestellar/console/pkg/store"
@@ -82,7 +83,7 @@ func toResponse(r *store.UserRewards) userRewardsResponse {
 // An empty return means the request is unauthenticated and the handler
 // should respond with 401.
 func resolveRewardsUserID(c *fiber.Ctx) string {
-	if id := middleware.GetUserID(c); id.String() != "00000000-0000-0000-0000-000000000000" {
+	if id := middleware.GetUserID(c); id != uuid.Nil {
 		return id.String()
 	}
 	if login := middleware.GetGitHubLogin(c); login != "" {
@@ -110,9 +111,11 @@ func (h *RewardsPersistenceHandler) GetUserRewards(c *fiber.Ctx) error {
 	return c.JSON(toResponse(rewards))
 }
 
-// putUserRewardsRequest is the request body for PUT /api/rewards/me. All
-// fields are optional; missing fields default to zero so clients can use
-// this endpoint to replace partial state without re-sending the whole row.
+// putUserRewardsRequest is the request body for PUT /api/rewards/me. PUT is
+// a FULL replace (idempotent upsert): callers must send the entire desired
+// row. Because the fields are non-pointer ints, the handler cannot tell
+// "field omitted" from "field explicitly 0", so there is no partial-update
+// semantics — any missing field becomes 0 in the stored row.
 type putUserRewardsRequest struct {
 	Coins       int `json:"coins"`
 	Points      int `json:"points"`

--- a/pkg/store/sqlite.go
+++ b/pkg/store/sqlite.go
@@ -1878,13 +1878,30 @@ func (s *SQLiteStore) IncrementUserCoins(userID string, delta int) (*UserRewards
 		return nil, errors.New("user_id is required")
 	}
 
-	tx, err := s.db.Begin()
+	// Same BEGIN IMMEDIATE pattern as AddUserTokenDelta — the default
+	// deferred transaction under WAL mode only grabs the write lock at the
+	// first INSERT, letting two concurrent goroutines both read the same
+	// stale balance and produce a torn update. Pin a connection and issue
+	// BEGIN IMMEDIATE manually so the write lock is held from the SELECT
+	// through the upsert.
+	ctx := context.Background()
+	conn, err := s.db.Conn(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("begin tx: %w", err)
+		return nil, fmt.Errorf("acquire conn: %w", err)
 	}
-	defer tx.Rollback() //nolint:errcheck // best-effort rollback on error paths
+	defer conn.Close() //nolint:errcheck // best-effort release back to pool
 
-	row := tx.QueryRow(
+	if _, err := conn.ExecContext(ctx, "BEGIN IMMEDIATE"); err != nil {
+		return nil, fmt.Errorf("begin immediate: %w", err)
+	}
+	committed := false
+	defer func() {
+		if !committed {
+			_, _ = conn.ExecContext(ctx, "ROLLBACK")
+		}
+	}()
+
+	row := conn.QueryRowContext(ctx,
 		`SELECT user_id, coins, points, level, bonus_points, last_daily_bonus_at, updated_at
 		 FROM user_rewards WHERE user_id = ?`, userID,
 	)
@@ -1919,7 +1936,7 @@ func (s *SQLiteStore) IncrementUserCoins(userID string, delta int) (*UserRewards
 		lastBonus = sql.NullTime{Time: *current.LastDailyBonusAt, Valid: true}
 	}
 
-	if _, err := tx.Exec(
+	if _, err := conn.ExecContext(ctx,
 		`INSERT INTO user_rewards (user_id, coins, points, level, bonus_points, last_daily_bonus_at, updated_at)
 		 VALUES (?, ?, ?, ?, ?, ?, ?)
 		 ON CONFLICT(user_id) DO UPDATE SET
@@ -1935,9 +1952,10 @@ func (s *SQLiteStore) IncrementUserCoins(userID string, delta int) (*UserRewards
 		return nil, fmt.Errorf("increment user coins: %w", err)
 	}
 
-	if err := tx.Commit(); err != nil {
-		return nil, fmt.Errorf("commit tx: %w", err)
+	if _, err := conn.ExecContext(ctx, "COMMIT"); err != nil {
+		return nil, fmt.Errorf("commit immediate tx: %w", err)
 	}
+	committed = true
 	return current, nil
 }
 
@@ -1953,13 +1971,27 @@ func (s *SQLiteStore) ClaimDailyBonus(userID string, bonusAmount int, minInterva
 		return nil, errors.New("bonusAmount must be non-negative")
 	}
 
-	tx, err := s.db.Begin()
+	// Same BEGIN IMMEDIATE pattern as AddUserTokenDelta — without it, two
+	// concurrent requests can both pass the cooldown check and each award
+	// the bonus before either commits, producing a double claim.
+	ctx := context.Background()
+	conn, err := s.db.Conn(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("begin tx: %w", err)
+		return nil, fmt.Errorf("acquire conn: %w", err)
 	}
-	defer tx.Rollback() //nolint:errcheck // best-effort rollback on error paths
+	defer conn.Close() //nolint:errcheck // best-effort release back to pool
 
-	row := tx.QueryRow(
+	if _, err := conn.ExecContext(ctx, "BEGIN IMMEDIATE"); err != nil {
+		return nil, fmt.Errorf("begin immediate: %w", err)
+	}
+	committed := false
+	defer func() {
+		if !committed {
+			_, _ = conn.ExecContext(ctx, "ROLLBACK")
+		}
+	}()
+
+	row := conn.QueryRowContext(ctx,
 		`SELECT user_id, coins, points, level, bonus_points, last_daily_bonus_at, updated_at
 		 FROM user_rewards WHERE user_id = ?`, userID,
 	)
@@ -1989,7 +2021,7 @@ func (s *SQLiteStore) ClaimDailyBonus(userID string, bonusAmount int, minInterva
 	current.UpdatedAt = now
 
 	lastBonus := sql.NullTime{Time: claimedAt, Valid: true}
-	if _, err := tx.Exec(
+	if _, err := conn.ExecContext(ctx,
 		`INSERT INTO user_rewards (user_id, coins, points, level, bonus_points, last_daily_bonus_at, updated_at)
 		 VALUES (?, ?, ?, ?, ?, ?, ?)
 		 ON CONFLICT(user_id) DO UPDATE SET
@@ -2005,9 +2037,10 @@ func (s *SQLiteStore) ClaimDailyBonus(userID string, bonusAmount int, minInterva
 		return nil, fmt.Errorf("claim daily bonus: %w", err)
 	}
 
-	if err := tx.Commit(); err != nil {
-		return nil, fmt.Errorf("commit tx: %w", err)
+	if _, err := conn.ExecContext(ctx, "COMMIT"); err != nil {
+		return nil, fmt.Errorf("commit immediate tx: %w", err)
 	}
+	committed = true
 	return current, nil
 }
 

--- a/pkg/store/user_rewards_test.go
+++ b/pkg/store/user_rewards_test.go
@@ -2,9 +2,12 @@ package store
 
 import (
 	"errors"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -20,6 +23,14 @@ const testDailyBonusInterval = 24 * time.Hour
 // testDailyBonusAmount is an arbitrary non-zero bonus used by the cooldown
 // tests to distinguish "awarded" from "skipped" branches.
 const testDailyBonusAmount = 50
+
+// Concurrency test constants — no magic numbers. 16 goroutines mirrors the
+// pattern from TestAddUserTokenDelta_ConcurrentIncrementsAreAtomic so the
+// two atomicity tests exercise the same level of contention.
+const (
+	testRewardsConcurrentWorkers = 16
+	testRewardsConcurrentDelta   = 3
+)
 
 func TestGetUserRewards_ReturnsZeroForNewUser(t *testing.T) {
 	store := newTestStore(t)
@@ -174,4 +185,77 @@ func TestClaimDailyBonus_AfterCooldownSucceedsAgain(t *testing.T) {
 	require.Equal(t, testDailyBonusAmount*2, got.BonusPoints)
 	require.NotNil(t, got.LastDailyBonusAt)
 	require.True(t, got.LastDailyBonusAt.Equal(laterEnough))
+}
+
+// TestIncrementUserCoins_ConcurrentIncrementsAreAtomic exercises the
+// BEGIN IMMEDIATE transaction envelope around IncrementUserCoins. Without
+// the write-locked transaction, concurrent read-modify-write sequences
+// would produce torn updates and a final balance less than
+// testRewardsConcurrentWorkers * testRewardsConcurrentDelta.
+func TestIncrementUserCoins_ConcurrentIncrementsAreAtomic(t *testing.T) {
+	store := newTestStore(t)
+
+	var wg sync.WaitGroup
+	wg.Add(testRewardsConcurrentWorkers)
+	for i := 0; i < testRewardsConcurrentWorkers; i++ {
+		go func() {
+			defer wg.Done()
+			_, err := store.IncrementUserCoins(testUserRewardsID, testRewardsConcurrentDelta)
+			assert.NoError(t, err)
+		}()
+	}
+	wg.Wait()
+
+	got, err := store.GetUserRewards(testUserRewardsID)
+	require.NoError(t, err)
+	wantTotal := testRewardsConcurrentWorkers * testRewardsConcurrentDelta
+	require.Equal(t, wantTotal, got.Coins, "concurrent deltas must sum without lost updates")
+	require.Equal(t, wantTotal, got.Points, "lifetime points must accumulate atomically too")
+}
+
+// TestClaimDailyBonus_ConcurrentClaimsOnlyOneWins verifies that when many
+// goroutines race to claim the daily bonus at the same instant, the
+// cooldown check is atomic with the upsert — exactly one goroutine must
+// succeed and the rest must see ErrDailyBonusUnavailable. Before the
+// BEGIN IMMEDIATE fix, multiple racing goroutines could all pass the
+// cooldown check and each award the bonus.
+func TestClaimDailyBonus_ConcurrentClaimsOnlyOneWins(t *testing.T) {
+	store := newTestStore(t)
+	now := time.Date(2026, 4, 10, 12, 0, 0, 0, time.UTC)
+
+	var successCount int64
+	var cooldownCount int64
+	var wg sync.WaitGroup
+	// start gate — release all goroutines at the same instant so the
+	// cooldown race is as tight as possible
+	start := make(chan struct{})
+	wg.Add(testRewardsConcurrentWorkers)
+	for i := 0; i < testRewardsConcurrentWorkers; i++ {
+		go func() {
+			defer wg.Done()
+			<-start
+			_, err := store.ClaimDailyBonus(testUserRewardsID, testDailyBonusAmount, testDailyBonusInterval, now)
+			if err == nil {
+				atomic.AddInt64(&successCount, 1)
+				return
+			}
+			if errors.Is(err, ErrDailyBonusUnavailable) {
+				atomic.AddInt64(&cooldownCount, 1)
+				return
+			}
+			assert.NoError(t, err, "unexpected error from ClaimDailyBonus")
+		}()
+	}
+	close(start)
+	wg.Wait()
+
+	require.Equal(t, int64(1), atomic.LoadInt64(&successCount), "exactly one claim must win")
+	require.Equal(t, int64(testRewardsConcurrentWorkers-1), atomic.LoadInt64(&cooldownCount), "all other claims must see ErrDailyBonusUnavailable")
+
+	// Final state — bonus awarded exactly once
+	got, err := store.GetUserRewards(testUserRewardsID)
+	require.NoError(t, err)
+	require.Equal(t, testDailyBonusAmount, got.BonusPoints, "bonus must be awarded exactly once")
+	require.NotNil(t, got.LastDailyBonusAt)
+	require.True(t, got.LastDailyBonusAt.Equal(now))
 }

--- a/web/src/lib/rewardsApi.ts
+++ b/web/src/lib/rewardsApi.ts
@@ -20,7 +20,7 @@ export interface UserRewardsRecord {
   points: number
   level: number
   bonus_points: number
-  /** RFC3339 timestamp; empty string when the daily bonus has never been claimed. */
+  /** RFC3339 timestamp; `undefined` when the daily bonus has never been claimed (server omits the field via `omitempty`). */
   last_daily_bonus_at?: string
   updated_at: string
 }


### PR DESCRIPTION
Fixes #6103

Addresses the 5 Copilot review comments left on merged PR #6032 (rewards persistence).

## Changes

1. **`pkg/store/sqlite.go` `IncrementUserCoins`** — replaces the default deferred SQLite transaction with the same pinned-connection + `BEGIN IMMEDIATE` pattern used by `AddUserTokenDelta`, so the read-modify-write sequence holds the write lock from the SELECT through the upsert. Concurrent callers can no longer produce torn updates.
2. **`pkg/store/sqlite.go` `ClaimDailyBonus`** — same `BEGIN IMMEDIATE` pattern so the cooldown check is atomic with the bonus upsert. Concurrent claims can no longer both pass the check and double-award.
3. **`pkg/api/handlers/rewards_persistence.go` `putUserRewardsRequest`** — the comment claimed PUT supports partial updates via zero defaults, but non-pointer ints make "omitted" indistinguishable from "explicitly 0". The comment now documents PUT as a full idempotent replace (no handler change).
4. **`pkg/api/handlers/rewards_persistence.go` `resolveRewardsUserID`** — replaces the hard-coded all-zero UUID string compare with the idiomatic `id != uuid.Nil` check.
5. **`web/src/lib/rewardsApi.ts` `UserRewardsRecord.last_daily_bonus_at`** — JSDoc now correctly says "undefined when never claimed" to match the server's `omitempty` behavior.

## Tests

- New 16-way concurrent test for `IncrementUserCoins` mirroring `TestAddUserTokenDelta_ConcurrentIncrementsAreAtomic` — verifies the final balance equals `workers * delta` with no lost updates.
- New 16-way concurrent test for `ClaimDailyBonus` using a start-gate channel so all workers race the cooldown check at once. Exactly one worker must succeed; the rest must see `ErrDailyBonusUnavailable`. Final state verifies the bonus was awarded exactly once.

## Verification

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./pkg/store/... -count=1` (all pass including new concurrent tests)
- [x] `cd web && npm run build`