### PR TITLE
fix(ui): xonas reported issues bundle

### DIFF
--- a/web/src/components/alerts/Alerts.test.tsx
+++ b/web/src/components/alerts/Alerts.test.tsx
@@ -32,6 +32,7 @@ vi.mock('../../hooks/useMCP', () => ({
 vi.mock('../../hooks/useDrillDown', () => ({
   useDrillDownActions: () => ({
     drillToAlert: vi.fn(),
+    drillToAllAlerts: vi.fn(),
   }),
 }))
 

--- a/web/src/components/alerts/Alerts.tsx
+++ b/web/src/components/alerts/Alerts.tsx
@@ -20,7 +20,7 @@ export function Alerts() {
   const { stats, evaluateConditions } = useAlerts()
   const { rules } = useAlertRules()
   const { isRefreshing: dataRefreshing, refetch, error } = useClusters()
-  const { drillToAlert } = useDrillDownActions()
+  const { drillToAllAlerts } = useDrillDownActions()
   const { getStatValue: getUniversalStatValue } = useUniversalStats()
 
   // Local state for last updated time
@@ -42,11 +42,17 @@ export function Alerts() {
   // Stats value getter
   const getDashboardStatValue = (blockId: string): StatBlockValue => {
     const disabledRulesCount = rules.filter(r => !r.enabled).length
+    // The stat blocks below represent *counts* of alerts, so they should
+    // open the multi-alert list drill-down (`all-alerts`) rather than the
+    // single-alert detail view. The single-alert view (#6116) was rendering
+    // an empty modal because it expected alert-specific fields that don't
+    // exist on an aggregate. Using drillToAllAlerts with a status filter
+    // shows a proper filtered list.
     const drillToFiringAlert = () => {
-      drillToAlert('all', undefined, 'Active Alerts', { status: 'firing', count: stats.firing })
+      drillToAllAlerts('firing', { count: stats.firing })
     }
     const drillToResolvedAlert = () => {
-      drillToAlert('all', undefined, 'Resolved Alerts', { status: 'resolved', count: stats.resolved })
+      drillToAllAlerts('resolved', { count: stats.resolved })
     }
 
     switch (blockId) {

--- a/web/src/components/charts/Gauge.tsx
+++ b/web/src/components/charts/Gauge.tsx
@@ -82,10 +82,14 @@ export function Gauge({
             }}
           />
         </svg>
-        {/* Value display */}
+        {/* Value display.
+         * When the unit is a percent sign, display the computed percentage
+         * (value/max*100). Otherwise display the raw value (e.g. "3" GPUs).
+         * Fixes #6117/#6119 where a 1/1 Healthy ReplicaSet rendered "1%"
+         * instead of "100%" because the raw value was shown with a "%" unit. */}
         <div className="absolute inset-0 flex items-end justify-center pb-1">
           <span className={`font-bold ${s.fontSize} ${color.text}`}>
-            {Math.round(safeValue)}
+            {unit === '%' ? Math.round(percentage) : Math.round(safeValue)}
             <span className="text-sm text-muted-foreground">{unit}</span>
           </span>
         </div>

--- a/web/src/components/feedback/FeatureRequestModal.tsx
+++ b/web/src/components/feedback/FeatureRequestModal.tsx
@@ -316,13 +316,21 @@ export function FeatureRequestModal({ isOpen, onClose, initialTab, initialReques
     }
   }
 
-  /** Save current form content as a draft (new or update existing) */
+  /** Save current form content as a draft (new or update existing).
+   * Screenshots are persisted as base64 data URIs (the preview field
+   * produced by FileReader.readAsDataURL) so they survive a full
+   * reload. The File object itself cannot be serialized. #6102
+   */
   const handleSaveDraft = () => {
     if (description.trim().length < 5) {
       showToast('Draft is too short to save', 'error')
       return
     }
-    const id = saveDraft({ requestType, targetRepo, description }, editingDraftId || undefined)
+    const screenshotDataURIs = screenshots.map(s => s.preview)
+    const id = saveDraft(
+      { requestType, targetRepo, description, screenshots: screenshotDataURIs },
+      editingDraftId || undefined,
+    )
     if (id) {
       setEditingDraftId(id)
       showToast(editingDraftId ? 'Draft updated' : 'Draft saved', 'success')
@@ -335,6 +343,14 @@ export function FeatureRequestModal({ isOpen, onClose, initialTab, initialReques
     setTargetRepo(draft.targetRepo)
     setDescription(draft.description)
     setEditingDraftId(draft.id)
+    // Restore screenshots from the draft. We recreate a minimal File
+    // stub (the upload pipeline only needs `preview`; the `file` field
+    // is used for displaying size/name in the uploader UI). #6102
+    const restoredScreenshots = (draft.screenshots || []).map((preview, idx) => ({
+      file: new File([], `draft-screenshot-${idx + 1}.png`, { type: 'image/png' }),
+      preview,
+    }))
+    setScreenshots(restoredScreenshots)
     setActiveTab('submit')
     showToast('Draft loaded into editor', 'success')
   }

--- a/web/src/hooks/__tests__/useClusterData.test.ts
+++ b/web/src/hooks/__tests__/useClusterData.test.ts
@@ -14,7 +14,7 @@ import { renderHook } from '@testing-library/react'
 // ---------------------------------------------------------------------------
 
 const mockUseClusters = vi.fn()
-const mockUsePods = vi.fn()
+const mockUseAllPods = vi.fn()
 const mockUseDeployments = vi.fn()
 const mockUseNamespaces = vi.fn()
 const mockUseEvents = vi.fn()
@@ -24,7 +24,7 @@ const mockUseSecurityIssues = vi.fn()
 
 vi.mock('../useMCP', () => ({
   useClusters: () => mockUseClusters(),
-  usePods: () => mockUsePods(),
+  useAllPods: () => mockUseAllPods(),
   useDeployments: () => mockUseDeployments(),
   useNamespaces: () => mockUseNamespaces(),
   useEvents: () => mockUseEvents(),
@@ -43,7 +43,7 @@ function setDefaults(overrides: Record<string, unknown> = {}) {
     clusters: overrides.clusters ?? [{ name: 'c1' }],
     deduplicatedClusters: overrides.deduplicatedClusters ?? [{ name: 'c1' }],
   })
-  mockUsePods.mockReturnValue({ pods: overrides.pods ?? [{ name: 'p1' }] })
+  mockUseAllPods.mockReturnValue({ pods: overrides.pods ?? [{ name: 'p1' }] })
   mockUseDeployments.mockReturnValue({ deployments: overrides.deployments ?? [{ name: 'd1' }] })
   mockUseNamespaces.mockReturnValue({ namespaces: overrides.namespaces ?? [{ name: 'ns1' }] })
   mockUseEvents.mockReturnValue({ events: overrides.events ?? [{ reason: 'Scheduled' }] })
@@ -81,7 +81,7 @@ describe('useClusterData', () => {
   // 2. Coalesces undefined upstream values to empty arrays
   it('coalesces undefined upstream values to empty arrays', async () => {
     mockUseClusters.mockReturnValue({ clusters: undefined, deduplicatedClusters: undefined })
-    mockUsePods.mockReturnValue({ pods: undefined })
+    mockUseAllPods.mockReturnValue({ pods: undefined })
     mockUseDeployments.mockReturnValue({ deployments: undefined })
     mockUseNamespaces.mockReturnValue({ namespaces: undefined })
     mockUseEvents.mockReturnValue({ events: undefined })
@@ -120,7 +120,7 @@ describe('useClusterData', () => {
 
   // 4. Mixed defined and undefined inputs
   it('handles mixed defined and undefined upstream values', async () => {
-    mockUsePods.mockReturnValue({ pods: undefined })
+    mockUseAllPods.mockReturnValue({ pods: undefined })
     mockUseEvents.mockReturnValue({ events: undefined })
     // Rest keep their defaults from setDefaults()
 

--- a/web/src/hooks/useClusterData.ts
+++ b/web/src/hooks/useClusterData.ts
@@ -8,11 +8,14 @@
  * in consumers that call .map(), .filter(), .flatMap(), .join(), etc.
  */
 
-import { useClusters, usePods, useDeployments, useNamespaces, useEvents, useHelmReleases, useOperatorSubscriptions, useSecurityIssues } from './useMCP'
+import { useClusters, useAllPods, useDeployments, useNamespaces, useEvents, useHelmReleases, useOperatorSubscriptions, useSecurityIssues } from './useMCP'
 
 export function useClusterData() {
   const { clusters, deduplicatedClusters } = useClusters()
-  const { pods } = usePods()
+  // Use useAllPods (no pagination limit) so the multi-cluster drill-down
+  // sees every pod. usePods() defaults to limit=10 and was causing the
+  // stat block (total pod count) and drill-down list to disagree. #6100
+  const { pods } = useAllPods()
   const { deployments } = useDeployments()
   const { namespaces } = useNamespaces()
   const { events } = useEvents()

--- a/web/src/hooks/useFeedbackDrafts.ts
+++ b/web/src/hooks/useFeedbackDrafts.ts
@@ -35,6 +35,13 @@ export interface FeedbackDraft {
   savedAt: string
   /** ISO timestamp of when the draft was last updated */
   updatedAt: string
+  /**
+   * Attached screenshots as base64 data URIs so they survive a full
+   * reload. We can't put `File`/`Blob` objects in localStorage, but the
+   * paste/drop/file-picker flow already yields data URIs via FileReader,
+   * so we persist those directly. (#6102)
+   */
+  screenshots?: string[]
 }
 
 /** Read drafts from localStorage, returning an empty array on failure */
@@ -84,7 +91,12 @@ export function useFeedbackDrafts() {
 
   /** Save a new draft or update an existing one. Returns the draft id. */
   const saveDraft = (
-    draft: { requestType: RequestType; targetRepo: TargetRepo; description: string },
+    draft: {
+      requestType: RequestType
+      targetRepo: TargetRepo
+      description: string
+      screenshots?: string[]
+    },
     existingId?: string,
   ): string | null => {
     if (draft.description.trim().length < MIN_DRAFT_LENGTH) return null


### PR DESCRIPTION
Bundle of fixes for issues reported by @xonas1101.

## Fixes

### #6117 / #6119 — Gauge horseshoe shows wrong percentage
A 1/1 Healthy ReplicaSet rendered "1%" on the horseshoe graph because the Gauge component displayed the raw value with a "%" unit. Fix: when unit is "%", display the computed percentage (value/max*100). Raw-value callers (GPU counts etc.) use unit="" and are unaffected.

### #6100 — Pods stat block vs drilldown mismatch
The "Pods" stat block showed 23 while the drilldown listed only 10, because `useClusterData` called `usePods()` which defaults to `limit=10`. Fix: switch to `useAllPods()` (no limit) so the drilldown sees every pod.

### #6116 — Resolved errors drilldown modal shows no info
The Resolved/Active alert stat blocks opened the single-alert detail view (`drillToAlert`), which rendered empty because an aggregate stat has no alert-specific fields. Fix: these counts now open the multi-alert list view (`drillToAllAlerts`) with a status filter.

### #6102 — Screenshots not persisted into draft bug reports
Saving a draft dropped any attached screenshots because the draft schema did not include them. Fix: added a `screenshots` field (base64 data URIs) to `FeedbackDraft`, and updated `FeatureRequestModal` to save the previews and restore them when loading a draft.

## Skipped

### #6070 — Event Stream "show field disregarded"
No clear root cause from static inspection. The pagination/limit wiring in EventStream looks correct; the symptom ("card long on first mount, fine after minimize/maximize") hints at a measurement race that can't be pinned without a runtime repro. Leaving open for needs-info.

## Verification
- `npm run build` passes
- All touched unit tests pass (Gauge, Alerts, useClusterData, useFeedbackDrafts, MultiClusterSummaryDrillDown)

🤖 Generated with [Claude Code](https://claude.com/claude-code)