### PR TITLE
fix(auth): address Copilot review on PR #6074

### DIFF
--- a/pkg/api/handlers/auth.go
+++ b/pkg/api/handlers/auth.go
@@ -124,6 +124,8 @@ type AuthHandler struct {
 	devMode        bool
 	skipOnboarding bool
 	wsHub          SessionDisconnecter // optional — set via SetHub to disconnect WS sessions on logout
+	cleanupCtx     context.Context     // cancelled by Stop to terminate the OAuth state cleanup goroutine
+	cleanupCancel  context.CancelFunc  // call to stop the OAuth state cleanup goroutine
 }
 
 // NewAuthHandler creates a new auth handler
@@ -167,6 +169,7 @@ func NewAuthHandler(s store.Store, cfg AuthConfig) *AuthHandler {
 		slog.Info("[Auth] GitHub Enterprise configured", "oauthURL", ghURL, "apiBase", apiBase)
 	}
 
+	cleanupCtx, cleanupCancel := context.WithCancel(context.Background())
 	h := &AuthHandler{
 		store: s,
 		oauthConfig: &oauth2.Config{
@@ -185,6 +188,8 @@ func NewAuthHandler(s store.Store, cfg AuthConfig) *AuthHandler {
 		githubToken:    cfg.GitHubToken,
 		devMode:        cfg.DevMode,
 		skipOnboarding: cfg.SkipOnboarding,
+		cleanupCtx:     cleanupCtx,
+		cleanupCancel:  cleanupCancel,
 	}
 
 	// Periodically purge expired OAuth states from the persistent store so the
@@ -192,21 +197,42 @@ func NewAuthHandler(s store.Store, cfg AuthConfig) *AuthHandler {
 	// ConsumeOAuthState deletes individual rows on the happy path, but
 	// abandoned flows (user never returns to the callback) would otherwise
 	// linger until their expires_at passed with no cleanup.
-	go h.runOAuthStateCleanup()
+	//
+	// Skipped in DevMode (no real OAuth client configured) so unit tests
+	// that use DevMode handlers do not leak a background goroutine for
+	// the lifetime of the test process (#6125).
+	if cfg.GitHubClientID != "" {
+		go h.runOAuthStateCleanup()
+	}
 
 	return h
 }
 
+// Stop tears down any background goroutines started by the AuthHandler
+// (currently just the OAuth state cleanup ticker). Tests should call this
+// via t.Cleanup so each test exits without leaking the cleanup goroutine.
+// Production code does not need to call Stop — the goroutine intentionally
+// runs for the lifetime of the process.
+func (h *AuthHandler) Stop() {
+	if h.cleanupCancel != nil {
+		h.cleanupCancel()
+	}
+}
+
 // runOAuthStateCleanup ticks every oauthStateCleanupInterval and removes
-// expired OAuth state rows. It runs for the lifetime of the process — the
-// AuthHandler has no explicit Close hook, matching the existing pattern in
-// the old in-memory init() goroutine.
+// expired OAuth state rows. It exits when the cleanup context is cancelled
+// (via Stop) so tests do not leak the goroutine across t.Run boundaries.
 func (h *AuthHandler) runOAuthStateCleanup() {
 	ticker := time.NewTicker(oauthStateCleanupInterval)
 	defer ticker.Stop()
-	for range ticker.C {
-		if _, err := h.store.CleanupExpiredOAuthStates(); err != nil {
-			slog.Warn("[Auth] OAuth state cleanup failed", "error", err)
+	for {
+		select {
+		case <-h.cleanupCtx.Done():
+			return
+		case <-ticker.C:
+			if _, err := h.store.CleanupExpiredOAuthStates(); err != nil {
+				slog.Warn("[Auth] OAuth state cleanup failed", "error", err)
+			}
 		}
 	}
 }

--- a/pkg/api/handlers/auth_test.go
+++ b/pkg/api/handlers/auth_test.go
@@ -20,12 +20,17 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// setupAuthTest creates a fresh Fiber app and an AuthHandler with a mock store
+// setupAuthTest creates a fresh Fiber app and an AuthHandler with a mock store.
+//
+// The handler runs in DevMode (GitHubClientID == "") so NewAuthHandler skips
+// the OAuth state cleanup goroutine entirely (#6125) — there is no goroutine
+// to leak. Tests that need a real-OAuth handler should instantiate it
+// directly and call t.Cleanup(handler.Stop).
 func setupAuthTest() (*fiber.App, *test.MockStore, *AuthHandler) {
 	app := fiber.New()
 	mockStore := new(test.MockStore)
 	cfg := AuthConfig{
-		GitHubClientID: "", // Trigger DevMode
+		GitHubClientID: "", // Trigger DevMode (also skips cleanup goroutine)
 		JWTSecret:      "test-secret",
 		FrontendURL:    "http://frontend",
 		DevMode:        true,
@@ -168,20 +173,27 @@ func TestRefreshToken(t *testing.T) {
 }
 
 func TestGitHubLogin_Redirects(t *testing.T) {
-	app, _, _ := setupAuthTest()
+	// Use a fresh fiber.App directly — setupAuthTest() creates a DevMode
+	// handler we don't need here, and discarding it would either leak the
+	// cleanup goroutine (if we forgot to Stop it) or noise the test (#6125).
+	app := fiber.New()
 	// Use a real SQLiteStore so the handler can persist the OAuth state
 	// (the in-memory map was replaced by a store-backed write in #6028).
 	dbPath := filepath.Join(t.TempDir(), "github-login.db")
 	s, err := store.NewSQLiteStore(dbPath)
 	require.NoError(t, err)
 	defer s.Close()
-	// Override config to simulate existing OAuth credentials
+	// Override config to simulate existing OAuth credentials. Because
+	// GitHubClientID is non-empty NewAuthHandler will start the cleanup
+	// goroutine — t.Cleanup(handler.Stop) terminates it before the test
+	// returns so each test exits cleanly.
 	cfg := AuthConfig{
 		GitHubClientID: "client-id",
 		GitHubSecret:   "secret",
 		BackendURL:     "http://backend",
 	}
 	handler := NewAuthHandler(s, cfg)
+	t.Cleanup(handler.Stop)
 	app.Get("/auth/github", handler.GitHubLogin)
 
 	req, _ := http.NewRequest("GET", "/auth/github", nil)

--- a/pkg/store/oauth_states_test.go
+++ b/pkg/store/oauth_states_test.go
@@ -1,9 +1,12 @@
 package store
 
 import (
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -14,6 +17,12 @@ const oauthStateTestTTL = 5 * time.Minute
 // oauthStateExpiredTTL is a negative TTL used to force the state to be
 // "already expired" at the moment it is stored.
 const oauthStateExpiredTTL = -1 * time.Second
+
+// oauthStateConcurrentConsumers is the number of goroutines that race to
+// consume the same single-use state in TestConsumeOAuthState_ConcurrentSingleUse.
+// 16 is enough to reliably trigger the race window without making the test
+// flaky on slower CI runners.
+const oauthStateConcurrentConsumers = 16
 
 func TestOAuthStateRoundTrip(t *testing.T) {
 	s := newTestStore(t)
@@ -106,4 +115,56 @@ func TestOAuthStateSurvivesRestart(t *testing.T) {
 	ok, err := s2.ConsumeOAuthState(state)
 	require.NoError(t, err)
 	require.True(t, ok, "OAuth state should survive a process restart (#6028)")
+}
+
+// TestConsumeOAuthState_ConcurrentSingleUse exercises the race fix for
+// #6125: many goroutines race to consume the same state. Single-use
+// semantics require that exactly ONE call returns (true, nil) and every
+// other call returns (false, nil) — never two successes for the same
+// state. The fix uses a pinned connection with BEGIN IMMEDIATE plus a
+// RowsAffected cross-check inside the transaction.
+func TestConsumeOAuthState_ConcurrentSingleUse(t *testing.T) {
+	s := newTestStore(t)
+
+	const state = "state-concurrent-race"
+	require.NoError(t, s.StoreOAuthState(state, oauthStateTestTTL))
+
+	var (
+		wg        sync.WaitGroup
+		successes int64
+		failures  int64
+		errs      int64
+		start     = make(chan struct{})
+	)
+
+	wg.Add(oauthStateConcurrentConsumers)
+	for i := 0; i < oauthStateConcurrentConsumers; i++ {
+		go func() {
+			defer wg.Done()
+			<-start // align all goroutines to fire at the same instant
+			ok, err := s.ConsumeOAuthState(state)
+			if err != nil {
+				atomic.AddInt64(&errs, 1)
+				return
+			}
+			if ok {
+				atomic.AddInt64(&successes, 1)
+			} else {
+				atomic.AddInt64(&failures, 1)
+			}
+		}()
+	}
+	close(start)
+	wg.Wait()
+
+	assert.Equal(t, int64(0), atomic.LoadInt64(&errs), "no errors expected from concurrent consumes")
+	assert.Equal(t, int64(1), atomic.LoadInt64(&successes),
+		"exactly one consumer must win the race for a single-use OAuth state")
+	assert.Equal(t, int64(oauthStateConcurrentConsumers-1), atomic.LoadInt64(&failures),
+		"every other concurrent consumer must observe (false, nil)")
+
+	// The state row should be gone afterwards regardless of which consumer won.
+	ok, err := s.ConsumeOAuthState(state)
+	require.NoError(t, err)
+	require.False(t, ok, "state row must be deleted after the race resolves")
 }

--- a/pkg/store/sqlite.go
+++ b/pkg/store/sqlite.go
@@ -337,10 +337,12 @@ func (s *SQLiteStore) migrate() error {
 
 	-- OAuth state tokens (persisted so in-flight OAuth flows survive a
 	-- backend restart between /auth/login and /auth/callback — see issue #6028).
+	-- Time columns use DATETIME to match the rest of the schema
+	-- (revoked_tokens, user_rewards, etc.) and avoid driver-quirk surprises.
 	CREATE TABLE IF NOT EXISTS oauth_states (
 		state TEXT PRIMARY KEY,
-		created_at TIMESTAMP NOT NULL,
-		expires_at TIMESTAMP NOT NULL
+		created_at DATETIME NOT NULL,
+		expires_at DATETIME NOT NULL
 	);
 	CREATE INDEX IF NOT EXISTS idx_oauth_states_expires_at ON oauth_states(expires_at);
 	`
@@ -2239,16 +2241,35 @@ func (s *SQLiteStore) StoreOAuthState(state string, ttl time.Duration) error {
 //
 // Expired states are also deleted to keep the table lean, but the call still
 // returns false for them so the caller treats the flow as invalid.
+//
+// Concurrency: WAL-mode SQLite default-deferred transactions allow two
+// readers to both pass the SELECT before either DELETE runs, which without
+// the rows-affected check below would let both calls report success on the
+// same single-use token. We use a pinned connection with BEGIN IMMEDIATE
+// (same pattern as AddUserTokenDelta / IncrementUserCoins) so the
+// read-modify-write happens under a single write lock, AND we cross-check
+// `RowsAffected()` so a duplicate consume is reported as not-found rather
+// than success.
 func (s *SQLiteStore) ConsumeOAuthState(state string) (bool, error) {
-	tx, err := s.db.Begin()
+	ctx := context.Background()
+	conn, err := s.db.Conn(ctx)
 	if err != nil {
-		return false, err
+		return false, fmt.Errorf("acquire conn: %w", err)
 	}
-	// Rollback is a no-op after a successful Commit.
-	defer tx.Rollback()
+	defer conn.Close() //nolint:errcheck // best-effort release back to pool
+
+	if _, err := conn.ExecContext(ctx, "BEGIN IMMEDIATE"); err != nil {
+		return false, fmt.Errorf("begin immediate: %w", err)
+	}
+	committed := false
+	defer func() {
+		if !committed {
+			_, _ = conn.ExecContext(ctx, "ROLLBACK")
+		}
+	}()
 
 	var expiresAt time.Time
-	err = tx.QueryRow(
+	err = conn.QueryRowContext(ctx,
 		`SELECT expires_at FROM oauth_states WHERE state = ?`, state,
 	).Scan(&expiresAt)
 	if err != nil {
@@ -2258,15 +2279,29 @@ func (s *SQLiteStore) ConsumeOAuthState(state string) (bool, error) {
 		return false, err
 	}
 
-	// Delete unconditionally — whether the state is valid or expired, it should
-	// not be reusable after this call.
-	if _, err := tx.Exec(`DELETE FROM oauth_states WHERE state = ?`, state); err != nil {
+	// Delete unconditionally — whether the state is valid or expired, it
+	// should not be reusable after this call. RowsAffected guards against
+	// the race where another caller already consumed the same state in the
+	// window between our SELECT and DELETE: that caller will have removed
+	// the row, our DELETE affects 0 rows, and we report not-found.
+	res, err := conn.ExecContext(ctx, `DELETE FROM oauth_states WHERE state = ?`, state)
+	if err != nil {
 		return false, err
 	}
-	if err := tx.Commit(); err != nil {
+	affected, err := res.RowsAffected()
+	if err != nil {
 		return false, err
 	}
 
+	if _, err := conn.ExecContext(ctx, "COMMIT"); err != nil {
+		return false, fmt.Errorf("commit immediate tx: %w", err)
+	}
+	committed = true
+
+	if affected == 0 {
+		// Lost the race to a concurrent consumer of the same state.
+		return false, nil
+	}
 	return time.Now().Before(expiresAt), nil
 }
 


### PR DESCRIPTION
Fixes #6125. Three nits flagged on the merged OAuth state persistence PR:

1. **`ConsumeOAuthState` single-use race** — pinned conn + `BEGIN IMMEDIATE` + `RowsAffected` cross-check (same pattern as AddUserTokenDelta)
2. **`oauth_states` column type** — TIMESTAMP → DATETIME for consistency with the rest of the schema
3. **AuthHandler cleanup goroutine leaks across tests** — added `Stop()` + skip the goroutine when GitHubClientID is empty (DevMode)

Plus a regression test `TestConsumeOAuthState_ConcurrentSingleUse` (16 goroutines fired at the same state behind a start gate; exactly one must win).