### PR TITLE
fix(ui): + button spacing (#6132) and Console Studio overlap in full-screen (#6130)

### DIFF
--- a/web/src/components/dashboard/FloatingDashboardActions.tsx
+++ b/web/src/components/dashboard/FloatingDashboardActions.tsx
@@ -63,7 +63,7 @@ export function FloatingDashboardActions({
   canRedo = false,
 }: FloatingDashboardActionsProps) {
   const { t } = useTranslation()
-  const { isSidebarOpen, isSidebarMinimized } = useMissions()
+  const { isSidebarOpen, isSidebarMinimized, isFullScreen: isMissionFullScreen } = useMissions()
   const { isMobile } = useMobile()
   const [searchParams, setSearchParams] = useSearchParams()
   const fabHint = useFeatureHints('fab-add')
@@ -139,6 +139,11 @@ export function FloatingDashboardActions({
       onResetToDefaults()
     }
   }
+
+  // Hide the Console Studio FAB when the AI Mission sidebar is expanded to
+  // full-screen (#6130). In full-screen mode the mission list and chat UI
+  // cover the whole viewport, and the FAB would overlap them.
+  if (isMissionFullScreen) return null
 
   const showResetOption = isCustomized && (onReset || onResetToDefaults)
   const menuBtnClass = "flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium text-muted-foreground hover:text-foreground hover:bg-secondary rounded-md transition-colors whitespace-nowrap"

--- a/web/src/components/layout/mission-sidebar/MissionSidebar.tsx
+++ b/web/src/components/layout/mission-sidebar/MissionSidebar.tsx
@@ -585,7 +585,10 @@ export function MissionSidebar() {
                 }
               }}
               className={cn(
-                "p-1.5 rounded transition-colors flex-shrink-0 ring-1",
+                // mr-2 gives the accented "+ New mission" button breathing room
+                // from the adjacent toolbar group (#6132) so it doesn't visually
+                // merge with the Globe/Rocket icons next to it.
+                "p-1.5 mr-2 rounded transition-colors flex-shrink-0 ring-1",
                 showNewMission
                   ? "bg-primary text-primary-foreground ring-primary"
                   : "bg-purple-500/10 text-purple-400 ring-purple-500/30 hover:bg-purple-500/20 hover:text-purple-300"


### PR DESCRIPTION
Fixes #6132
Fixes #6130

## Summary

Two small UI fixes bundled into one PR.

### #6132 — "+ New mission" button needs breathing room
Reported by @xonas1101 as follow-up to #6101. The accented "+" button in the `MissionSidebar` header toolbar was too tightly packed against the adjacent Globe / Rocket icons. Added `mr-2` to the button so it stands apart from the rest of the toolbar group while keeping the existing Tailwind rhythm (the other icons remain `gap-1`).

### #6130 — Console Studio FAB overlaps full-screen mission UI
Reported by @ghanshyam2005singh (first issue, welcome!). When the AI Mission sidebar is expanded to full-screen (`isFullScreen`), the mission list and chat UI cover the whole viewport, but the floating Console Studio (Palette) button kept rendering on top of them.

`FloatingDashboardActions` now also reads `isFullScreen` from `useMissions()` and returns `null` when the mission view is full-screen. No layout math, no `pointer-events` hack — the FAB simply isn't mounted while full-screen is active, and it reappears when the user exits full-screen.

## Test plan
- [x] `npm run build` passes
- [x] `npm run lint` — no new errors/warnings on the touched files
- [ ] Visual: open mission sidebar, verify the + button has visible spacing from the Globe icon
- [ ] Visual: expand an AI Mission to full-screen, verify the Console Studio FAB is gone; exit full-screen and verify it returns