### PR TITLE
fix(analytics): replace inline onclick with addEventListener (CSP)

### DIFF
--- a/web/public/analytics.html
+++ b/web/public/analytics.html
@@ -373,7 +373,7 @@
       </label>
       <span id="cache-status"></span>
       <span class="status-dot" id="status-dot"></span>
-      <button class="refresh-btn" id="refresh-btn" onclick="loadData(true)">Refresh</button>
+      <button class="refresh-btn" id="refresh-btn" type="button">Refresh</button>
     </div>
   </div>
 

--- a/web/public/analytics.js
+++ b/web/public/analytics.js
@@ -824,6 +824,14 @@
     // Reload when filter toggle changes
     document.getElementById('include-localhost').addEventListener('change', () => loadData(true));
 
+    // Wire the Refresh button via addEventListener so the strict CSP
+    // (script-src without 'unsafe-inline' in netlify.toml) does not block
+    // the click handler. The HTML used to have onclick="loadData(true)"
+    // inline; that was refused by the browser even after the main script
+    // moved to an external file in PR #6127. Copilot caught this in the
+    // post-merge review (#6138).
+    document.getElementById('refresh-btn').addEventListener('click', () => loadData(true));
+
     // Auto-refresh every 15 minutes
     const AUTO_REFRESH_MS = 15 * 60 * 1000;
     setInterval(() => loadData(true), AUTO_REFRESH_MS);


### PR DESCRIPTION
Fixes #6138. Re-do of the followup to PR #6127 — my earlier fix went to a branch already merged. The CSP in netlify.toml has `script-src` without `'unsafe-inline'` which blocks inline event handlers; the Refresh button still had `onclick="loadData(true)"` inline. Replaced with `addEventListener` in analytics.js.