### PR TITLE
fix(metrics): cluster comparison, node counts, GPU cache, completeness

### DIFF
--- a/pkg/api/handlers/mcp_resources.go
+++ b/pkg/api/handlers/mcp_resources.go
@@ -198,9 +198,12 @@ func (h *MCPHandlers) InstallGPUHealthCronJob(c *fiber.Ctx) error {
 		return c.Status(400).JSON(fiber.Map{"error": "invalid cron schedule format — expected 5-field cron expression (e.g. '*/15 * * * *')"})
 	}
 
-	// Validate tier range
+	// Validate tier range.
+	// Tier 1 — Critical, Tier 2 — Standard, Tier 3 — Full, Tier 4 — Deep (privileged).
+	// Must stay in sync with the frontend TIER_OPTIONS in ProactiveGPUNodeHealthMonitor.tsx
+	// and with InstallGPUHealthCronJob in pkg/k8s/client_gpu.go (issue #6110).
 	const minTier = 1
-	const maxTier = 3
+	const maxTier = 4
 	if body.Tier < minTier || body.Tier > maxTier {
 		return c.Status(400).JSON(fiber.Map{"error": fmt.Sprintf("tier must be between %d and %d", minTier, maxTier)})
 	}

--- a/web/src/components/cards/ResourceUsage.tsx
+++ b/web/src/components/cards/ResourceUsage.tsx
@@ -35,15 +35,28 @@ export function ResourceUsage() {
     return allGPUNodes.filter(n => clusterNames.has((n.cluster ?? '').split('/')[0]))
   })()
 
-  // Calculate totals from real cluster data
+  // Calculate totals from real cluster data.
+  // For the "used" numerator we prefer metrics-server actual usage (cpuUsageCores /
+  // memoryUsageGB) when it's available for the cluster, and only fall back to
+  // requests (cpuRequestsCores / memoryRequestsGB) when the metrics API hasn't
+  // reported yet. Previously this card was labeled "Resource Usage" but summed
+  // request values — which represents allocation, not usage (issue #6105).
   const totals = useMemo(() => {
     // Sum capacity from all clusters
     const totalCPUs = clusters.reduce((sum, c) => sum + (c.cpuCores || 0), 0)
     const totalMemoryGB = clusters.reduce((sum, c) => sum + (c.memoryGB || 0), 0)
 
-    // Sum requests (allocated resources) from all clusters
-    const usedCPUs = clusters.reduce((sum, c) => sum + (c.cpuRequestsCores || 0), 0)
-    const usedMemoryGB = clusters.reduce((sum, c) => sum + (c.memoryRequestsGB || 0), 0)
+    // Prefer actual usage from metrics-server; fall back to requests per-cluster.
+    const usedCPUs = clusters.reduce((sum, c) => {
+      const actual = c.cpuUsageCores
+      if (typeof actual === 'number' && c.metricsAvailable) return sum + actual
+      return sum + (c.cpuRequestsCores || 0)
+    }, 0)
+    const usedMemoryGB = clusters.reduce((sum, c) => {
+      const actual = c.memoryUsageGB
+      if (typeof actual === 'number' && c.metricsAvailable) return sum + actual
+      return sum + (c.memoryRequestsGB || 0)
+    }, 0)
 
     // Accelerator data by type
     const gpuOnly = gpuNodes.filter(n => !n.acceleratorType || n.acceleratorType === 'GPU')

--- a/web/src/components/cards/__tests__/ResourceUsage.test.tsx
+++ b/web/src/components/cards/__tests__/ResourceUsage.test.tsx
@@ -73,6 +73,10 @@ type ClusterStub = {
   memoryGB?: number
   cpuRequestsCores?: number
   memoryRequestsGB?: number
+  // Actual metrics-server usage (#6105)
+  cpuUsageCores?: number
+  memoryUsageGB?: number
+  metricsAvailable?: boolean
 }
 
 type GPUNodeStub = {
@@ -184,6 +188,47 @@ describe('ResourceUsage', () => {
       setupDefaults({ clusters: [{ name: 'c1', memoryGB: 0, memoryRequestsGB: 0 }] })
       render(<ResourceUsage />)
       expect(screen.getAllByTestId('gauge')[1]).toHaveAttribute('data-value', '0')
+    })
+
+    it('prefers actual metrics-server usage over requests when available (#6105)', () => {
+      // Requests say 8 cores / 80GB, but metrics-server says actual usage is
+      // 2 cores / 20GB. The card is labeled "Resource Usage" so it must
+      // display the actual usage, not the allocation.
+      setupDefaults({
+        clusters: [{
+          name: 'c1',
+          cpuCores: 10,
+          memoryGB: 100,
+          cpuRequestsCores: 8,
+          memoryRequestsGB: 80,
+          cpuUsageCores: 2,
+          memoryUsageGB: 20,
+          metricsAvailable: true }],
+      })
+      render(<ResourceUsage />)
+      const gauges = screen.getAllByTestId('gauge')
+      // 2 / 10 = 20%
+      expect(gauges[0]).toHaveAttribute('data-value', '20')
+      // 20 / 100 = 20%
+      expect(gauges[1]).toHaveAttribute('data-value', '20')
+    })
+
+    it('falls back to requests when metrics-server data is unavailable (#6105)', () => {
+      setupDefaults({
+        clusters: [{
+          name: 'c1',
+          cpuCores: 10,
+          memoryGB: 100,
+          cpuRequestsCores: 5,
+          memoryRequestsGB: 50,
+          // metricsAvailable omitted — simulating metrics-server not installed
+          cpuUsageCores: undefined,
+          memoryUsageGB: undefined }],
+      })
+      render(<ResourceUsage />)
+      const gauges = screen.getAllByTestId('gauge')
+      expect(gauges[0]).toHaveAttribute('data-value', '50')
+      expect(gauges[1]).toHaveAttribute('data-value', '50')
     })
   })
 

--- a/web/src/components/compute/ClusterComparisonPage.tsx
+++ b/web/src/components/compute/ClusterComparisonPage.tsx
@@ -1,9 +1,12 @@
 import { useSearchParams, useNavigate } from 'react-router-dom'
 import { ArrowLeft, Server, Cpu, MemoryStick, Box, Activity, AlertCircle, GitBranch } from 'lucide-react'
-import { useClusters, ClusterInfo } from '../../hooks/useMCP'
+import { useClusters, useNodes, ClusterInfo } from '../../hooks/useMCP'
 import { Skeleton } from '../ui/Skeleton'
 import { ROUTES } from '../../config/routes'
 import { useTranslation } from 'react-i18next'
+
+// Fallback string shown when a Kubernetes version cannot be resolved for a cluster (issue #6108).
+const K8S_VERSION_UNKNOWN = 'N/A'
 
 interface ClusterMetrics {
   cluster: ClusterInfo
@@ -16,6 +19,9 @@ export function ClusterComparisonPage() {
   const [searchParams] = useSearchParams()
   const navigate = useNavigate()
   const { deduplicatedClusters: clusters, isLoading } = useClusters()
+  // Nodes for all clusters — used to resolve the Kubernetes version for each
+  // cluster from one of its node's kubeletVersion (issue #6108).
+  const { nodes: allNodes } = useNodes()
 
   // Get cluster names from URL
   const clusterNames = (() => {
@@ -48,11 +54,16 @@ export function ClusterComparisonPage() {
     return new Set(values).size > 1
   }
 
-  // Get Kubernetes version from cluster
-  const getK8sVersion = (_cluster: ClusterInfo) => {
-    // ClusterInfo interface would need to be extended with a 'version' field containing K8s version
-    // Version can be obtained from K8s API server /version endpoint during cluster discovery
-    return 'N/A'
+  // Resolve Kubernetes version by looking up any node in the cluster and using
+  // its kubeletVersion. Aliases (e.g. deduped OpenShift long context names)
+  // are considered so we still match nodes fetched under a different context
+  // name (issue #6108).
+  const getK8sVersion = (cluster: ClusterInfo): string => {
+    const candidateNames = [cluster.name, ...(cluster.aliases || [])]
+    const nodeForCluster = allNodes.find(n =>
+      !!n.kubeletVersion && candidateNames.some(cn => n.cluster === cn || n.cluster?.startsWith(`${cn}/`))
+    )
+    return nodeForCluster?.kubeletVersion || K8S_VERSION_UNKNOWN
   }
 
   const handleBack = () => {
@@ -161,7 +172,15 @@ export function ClusterComparisonPage() {
                 {cluster.nodeCount || 0}
               </div>
               <div className="text-xs text-muted-foreground">
-                {cluster.healthy ? 'All healthy' : 'Issues detected'}
+                {/* Tri-state health display (issue #6109): show "Status unknown"
+                    for clusters whose health probe has not yet reported, and only
+                    show "Issues detected" for clusters that are explicitly not
+                    healthy. Previously, unknown status was conflated with unhealthy. */}
+                {cluster.healthUnknown || cluster.healthy === undefined
+                  ? 'Status unknown'
+                  : cluster.healthy
+                    ? 'All healthy'
+                    : 'Issues detected'}
               </div>
             </div>
 

--- a/web/src/components/compute/Compute.tsx
+++ b/web/src/components/compute/Compute.tsx
@@ -85,9 +85,14 @@ export function Compute() {
       .filter(node => isAllClustersSelected || globalSelectedClusters.includes(node.cluster.split('/')[0]))
       .reduce((sum, node) => sum + node.gpuCount, 0) }
 
-  // Check if we have any reachable clusters with actual data (not refreshing)
+  // Check if we have any reachable clusters with actual data (not refreshing).
+  // A cluster counts as "has data" as soon as nodeCount has been reported —
+  // even if the reported value is 0. Previously, valid zero-node clusters were
+  // treated as "no data" and rendered as '-' (issue #6106). Zero nodes is a
+  // meaningful value (e.g. a newly-provisioned cluster before any worker is
+  // attached), not a missing one.
   const hasActualData = filteredClusters.some(c =>
-    c.reachable !== false && c.nodeCount !== undefined && c.nodeCount > 0
+    c.reachable !== false && c.nodeCount !== undefined
   )
 
   // Cache the last known good stats to show during refresh

--- a/web/src/components/nodes/Nodes.tsx
+++ b/web/src/components/nodes/Nodes.tsx
@@ -1,4 +1,4 @@
-import { useRef, useEffect } from 'react'
+import { useEffect, useState } from 'react'
 import { AlertCircle } from 'lucide-react'
 import { useClusters, useGPUNodes } from '../../hooks/useMCP'
 import { useGlobalFilters } from '../../hooks/useGlobalFilters'
@@ -51,15 +51,33 @@ export function Nodes() {
     return totalMemoryGB > 0 ? Math.round((requestedMemory / totalMemoryGB) * 100) : 0
   })()
 
-  // Cache utilization values to prevent showing 0 during refresh
-  const cachedCpuUtil = useRef(currentCpuUtil)
-  const cachedMemoryUtil = useRef(currentMemoryUtil)
+  // Cache utilization values to avoid showing a transient 0 during refresh, but
+  // still propagate a genuine 0 once real data has been seen at least once
+  // (issue #6107). Previously the fallback used `value > 0 ? value : cached`
+  // which caused a node whose utilization legitimately dropped to 0 to keep
+  // displaying the previous non-zero value forever.
+  //
+  // We only treat a value as "real" when there is at least one reachable
+  // cluster that has actually reported capacity (totalCPU / totalMemoryGB > 0).
+  // Until then, any 0 we see is a placeholder, not a measurement.
+  const hasCpuCapacity = totalCPU > 0
+  const hasMemoryCapacity = totalMemoryGB > 0
+  const [cachedCpuUtil, setCachedCpuUtil] = useState<number | null>(null)
+  const [cachedMemoryUtil, setCachedMemoryUtil] = useState<number | null>(null)
+  // This effect intentionally calls setState to snapshot the last real value.
+  // react-hooks/set-state-in-effect flags this as a cascading-render pattern,
+  // but in this case the effect only fires when the capacity guards flip,
+  // so the cascade is bounded and the pattern is the simplest one compatible
+  // with the react-hooks/refs rule (which forbids reading `.current` during
+  // render).
+  /* eslint-disable react-hooks/set-state-in-effect */
   useEffect(() => {
-    if (currentCpuUtil > 0) cachedCpuUtil.current = currentCpuUtil
-    if (currentMemoryUtil > 0) cachedMemoryUtil.current = currentMemoryUtil
-  }, [currentCpuUtil, currentMemoryUtil])
-  const cpuUtilization = currentCpuUtil > 0 ? currentCpuUtil : cachedCpuUtil.current
-  const memoryUtilization = currentMemoryUtil > 0 ? currentMemoryUtil : cachedMemoryUtil.current
+    if (hasCpuCapacity) setCachedCpuUtil(currentCpuUtil)
+    if (hasMemoryCapacity) setCachedMemoryUtil(currentMemoryUtil)
+  }, [currentCpuUtil, currentMemoryUtil, hasCpuCapacity, hasMemoryCapacity])
+  /* eslint-enable react-hooks/set-state-in-effect */
+  const cpuUtilization = hasCpuCapacity ? currentCpuUtil : (cachedCpuUtil ?? 0)
+  const memoryUtilization = hasMemoryCapacity ? currentMemoryUtil : (cachedMemoryUtil ?? 0)
 
   // Stats value getter
   const getDashboardStatValue = (blockId: string): StatBlockValue => {

--- a/web/src/hooks/mcp/__tests__/clusters.test.ts
+++ b/web/src/hooks/mcp/__tests__/clusters.test.ts
@@ -880,8 +880,9 @@ describe('deduplicateClustersByServer — advanced', () => {
     expect(result).toHaveLength(1)
     // Should pick 'context-a' as primary (shorter, user-friendly)
     expect(result[0].name).toBe('context-a')
-    // Should merge best metrics: podCount=50 is higher than 20
-    expect(result[0].podCount).toBe(50)
+    // Primary's podCount wins (#6112): we no longer take Math.max, because
+    // that caused scale-downs to show stale over-counts.
+    expect(result[0].podCount).toBe(20)
     // Should keep cpuCores from the cluster that had them
     expect(result[0].cpuCores).toBe(16)
     // Should pick up cpuRequestsCores from the other cluster

--- a/web/src/hooks/mcp/__tests__/compute.test.ts
+++ b/web/src/hooks/mcp/__tests__/compute.test.ts
@@ -351,6 +351,42 @@ describe('useGPUNodes', () => {
     expect(result.current.nodes.find(n => n.name === 'cached-gpu')).toBeDefined()
   })
 
+  it('clears cached GPU nodes when a successful fetch returns an empty list (#6111)', async () => {
+    // Pre-load the cache with nodes that no longer exist upstream. Mark the
+    // cache lastUpdated as stale so the hook triggers a refetch on mount.
+    const stalenode = {
+      name: 'removed-gpu', cluster: 'c1',
+      gpuType: 'NVIDIA A100', gpuCount: 8, gpuAllocated: 4, acceleratorType: 'GPU' as const,
+    }
+    // CACHE_TTL_MS is 30_000 — go beyond it to force a stale refetch.
+    const STALE_OFFSET_MS = 120_000
+    updateGPUNodeCache({
+      nodes: [stalenode],
+      lastUpdated: new Date(Date.now() - STALE_OFFSET_MS),
+      isLoading: false,
+      isRefreshing: false,
+      error: null,
+      consecutiveFailures: 0,
+      lastRefresh: new Date(Date.now() - STALE_OFFSET_MS),
+    })
+    notifyGPUNodeSubscribers()
+
+    // Upstream now returns a successful empty response — the nodes were removed.
+    // Previously the cache protection logic refused to clear on empty, leaving
+    // stale nodes forever. The fix: distinguish "fetch succeeded but empty" from
+    // "fetch failed" and apply the empty result when the fetch succeeded.
+    mockFetchSSE.mockResolvedValue([])
+    // REST fallback also returns empty, in case SSE path isn't exercised
+    mockApiGet.mockResolvedValue({ data: { nodes: [] } })
+
+    const { result } = renderHook(() => useGPUNodes())
+
+    await waitFor(() => expect(mockFetchSSE).toHaveBeenCalled(), { timeout: 3000 })
+    await waitFor(() => expect(result.current.nodes.length).toBe(0), { timeout: 3000 })
+    expect(gpuNodeCache.nodes.length).toBe(0)
+    expect(result.current.error).toBeNull()
+  })
+
   it('uses demo GPU nodes when demo mode is enabled and no cached data exists', async () => {
     mockIsDemoMode.mockReturnValue(true)
     mockUseDemoMode.mockReturnValue({ isDemoMode: true })
@@ -475,9 +511,15 @@ describe('useNVIDIAOperators', () => {
 // ===========================================================================
 
 describe('updateGPUNodeCache', () => {
-  it('prevents clearing nodes when cache already has data', () => {
+  // NOTE: We used to have a "never allow clearing nodes if we have good data"
+  // guard inside updateGPUNodeCache. That guard was the root cause of #6111
+  // (stale GPU nodes persist forever after upstream removal). Cache-preservation
+  // across transient failures is now handled at the fetch site (fetchGPUNodes).
+  // These tests verify the new, corrected behavior.
+
+  it('applies empty nodes update when cache already has data (#6111)', () => {
     const existingNode = {
-      name: 'protected-gpu', cluster: 'c1',
+      name: 'to-remove-gpu', cluster: 'c1',
       gpuType: 'NVIDIA A100', gpuCount: 8, gpuAllocated: 4, acceleratorType: 'GPU' as const,
     }
     updateGPUNodeCache({
@@ -490,51 +532,39 @@ describe('updateGPUNodeCache', () => {
       lastRefresh: new Date(),
     })
 
-    // Attempt to set nodes to empty array — should be blocked
+    // Authoritative empty update — must actually clear the cache.
     updateGPUNodeCache({ nodes: [], error: 'some error' })
 
-    // Nodes must be preserved
-    expect(gpuNodeCache.nodes.length).toBe(1)
-    expect(gpuNodeCache.nodes[0].name).toBe('protected-gpu')
-    // Other fields from the update should still apply
+    expect(gpuNodeCache.nodes.length).toBe(0)
     expect(gpuNodeCache.error).toBe('some error')
   })
 
-  it('allows updating non-node fields even when node clearing is blocked', () => {
-    // Set up cache with existing data so the protection logic activates
+  it('applies non-node field updates alongside node updates', () => {
     const existingNode = {
-      name: 'protected-gpu', cluster: 'c1',
+      name: 'existing-gpu', cluster: 'c1',
       gpuType: 'NVIDIA A100', gpuCount: 8, gpuAllocated: 4, acceleratorType: 'GPU' as const,
     }
     updateGPUNodeCache({ nodes: [existingNode], lastUpdated: new Date() })
 
-    // Attempting to clear nodes while setting other fields should still apply the non-node updates
+    // Non-node fields (isLoading, error) should apply regardless of whether
+    // the node update is empty.
     updateGPUNodeCache({ nodes: [], isLoading: true, error: 'test-error' })
 
-    // Nodes remain protected (not cleared)
-    expect(gpuNodeCache.nodes.length).toBeGreaterThan(0)
-    // But other fields are updated
+    expect(gpuNodeCache.nodes.length).toBe(0)
     expect(gpuNodeCache.isLoading).toBe(true)
     expect(gpuNodeCache.error).toBe('test-error')
   })
 
-  it('allows setting empty nodes when cache has no existing data', () => {
-    // First, replace with known data, then replace with different data to empty
-    // We need the cache to be truly empty first. The only way is via the
-    // registerCacheReset callback which force-resets the cache.
-    // Instead, let's test with a fresh node that we can replace.
+  it('allows setting empty nodes from a populated cache', () => {
     const node = {
       name: 'temp-node', cluster: 'c1',
       gpuType: 'NVIDIA T4', gpuCount: 2, gpuAllocated: 1, acceleratorType: 'GPU' as const,
     }
-    // Replace existing nodes with temp-node
     updateGPUNodeCache({ nodes: [node] })
     expect(gpuNodeCache.nodes[0].name).toBe('temp-node')
 
-    // Now try setting empty — protection should block this since we have data
     updateGPUNodeCache({ nodes: [] })
-    expect(gpuNodeCache.nodes.length).toBeGreaterThan(0)
-    // This confirms the cache protection works regardless of what node was there
+    expect(gpuNodeCache.nodes.length).toBe(0)
   })
 
   it('allows replacing nodes with new non-empty data', () => {
@@ -1184,7 +1214,10 @@ describe('updateGPUNodeCache — protection logic', () => {
     gpuNodeCache.lastUpdated = null
   })
 
-  it('prevents clearing nodes when cache has data', () => {
+  it('applies empty nodes update when cache has data (#6111)', () => {
+    // Previously this tested the now-removed "never clear" guard inside
+    // updateGPUNodeCache. After the #6111 fix, the guard lives at the fetch
+    // site: updateGPUNodeCache applies whatever updates it receives.
     const existingNodes = [
       { name: 'n1', cluster: 'c1', gpuType: 'A100', gpuCount: 8, gpuAllocated: 4, acceleratorType: 'GPU' as const },
     ]
@@ -1192,8 +1225,7 @@ describe('updateGPUNodeCache — protection logic', () => {
 
     updateGPUNodeCache({ nodes: [], error: 'fetch failed' })
 
-    // Nodes should be preserved, error should be updated
-    expect(gpuNodeCache.nodes).toEqual(existingNodes)
+    expect(gpuNodeCache.nodes).toEqual([])
     expect(gpuNodeCache.error).toBe('fetch failed')
   })
 

--- a/web/src/hooks/mcp/__tests__/shared-coverage.test.ts
+++ b/web/src/hooks/mcp/__tests__/shared-coverage.test.ts
@@ -608,17 +608,20 @@ describe('shareMetricsBetweenSameServerClusters — storage and memory metrics',
 // deduplicateClustersByServer — request metrics cross-merge
 // ============================================================================
 describe('deduplicateClustersByServer — cross-merge scenarios', () => {
-  it('takes best individual nodeCount and podCount from group', () => {
+  it('uses primary cluster nodeCount/podCount — does not take max (#6112)', () => {
+    // Regression for #6112: previous behavior used Math.max which caused
+    // scale-downs to show stale over-counts. The primary is now authoritative.
     const NODE_A = 3
     const NODE_B = 10
     const POD_A = 50
     const POD_B = 20
+    // a has cpuCores so it sorts first (prefer cluster with metrics) and becomes primary.
     const a = makeCluster({ name: 'a', server: 'https://cross', nodeCount: NODE_A, podCount: POD_A, cpuCores: 8 })
     const b = makeCluster({ name: 'b', server: 'https://cross', nodeCount: NODE_B, podCount: POD_B, cpuCores: undefined })
 
     const result = deduplicateClustersByServer([a, b])
     expect(result).toHaveLength(1)
-    expect(result[0].nodeCount).toBe(NODE_B)
+    expect(result[0].nodeCount).toBe(NODE_A)
     expect(result[0].podCount).toBe(POD_A)
   })
 

--- a/web/src/hooks/mcp/__tests__/shared.test.ts
+++ b/web/src/hooks/mcp/__tests__/shared.test.ts
@@ -360,7 +360,10 @@ describe('deduplicateClustersByServer', () => {
     }
   })
 
-  it('merges best nodeCount and podCount from duplicates', () => {
+  it('uses the primary cluster nodeCount and podCount (does not take max) — #6112', () => {
+    // Regression for #6112: previously this code used Math.max(primary, alias)
+    // which caused scale-downs to show stale over-counts. Now the primary
+    // cluster is authoritative and aliases only fill in undefined fields.
     const NODE_COUNT_5 = 5
     const POD_COUNT_20 = 20
     const NODE_COUNT_8 = 8
@@ -368,8 +371,33 @@ describe('deduplicateClustersByServer', () => {
     const c1 = makeCluster({ name: 'c1', server: 'https://s1', nodeCount: NODE_COUNT_5, podCount: POD_COUNT_20 })
     const c2 = makeCluster({ name: 'c2', server: 'https://s1', nodeCount: NODE_COUNT_8, podCount: POD_COUNT_50 })
     const result = deduplicateClustersByServer([c1, c2])
+    // c1 sorts first (same length, stable) so it becomes primary; its counts win
+    expect(result[0].nodeCount).toBe(NODE_COUNT_5)
+    expect(result[0].podCount).toBe(POD_COUNT_20)
+  })
+
+  it('falls back to alias nodeCount/podCount when primary has none — #6112', () => {
+    const NODE_COUNT_8 = 8
+    const POD_COUNT_50 = 50
+    // Primary is chosen by sort; c1 is primary and has no nodeCount/podCount
+    // (makeCluster() defaults to 3 so we override explicitly).
+    const c1 = makeCluster({ name: 'c1', server: 'https://s1', nodeCount: undefined, podCount: undefined })
+    const c2 = makeCluster({ name: 'c2', server: 'https://s1', nodeCount: NODE_COUNT_8, podCount: POD_COUNT_50 })
+    const result = deduplicateClustersByServer([c1, c2])
     expect(result[0].nodeCount).toBe(NODE_COUNT_8)
     expect(result[0].podCount).toBe(POD_COUNT_50)
+  })
+
+  it('does not over-count after scale-down — #6112', () => {
+    // Scenario: upstream reports 3 nodes after a scale-down; a recent alias
+    // still has a cached 10. Old behavior returned 10 (Math.max). New behavior
+    // must return the primary's 3.
+    const NODES_AFTER_SCALE_DOWN = 3
+    const STALE_NODES_ON_ALIAS = 10
+    const primary = makeCluster({ name: 'prod', server: 'https://s1', nodeCount: NODES_AFTER_SCALE_DOWN })
+    const alias = makeCluster({ name: 'prod-long-context', server: 'https://s1', nodeCount: STALE_NODES_ON_ALIAS })
+    const result = deduplicateClustersByServer([primary, alias])
+    expect(result[0].nodeCount).toBe(NODES_AFTER_SCALE_DOWN)
   })
 
   it('marks healthy if any duplicate is healthy', () => {

--- a/web/src/hooks/mcp/clusters.ts
+++ b/web/src/hooks/mcp/clusters.ts
@@ -160,12 +160,38 @@ export function useClusters() {
     return result
   })()
 
+  // Completeness metadata for aggregated metrics (issue #6114). A cluster is
+  // "contributing" when it is reachable and has reported capacity data
+  // (cpuCores). Everything else is "missing" — either unreachable, still
+  // loading, or returning no metrics — so callers can decide whether an
+  // aggregate like "totalCPUs" is authoritative or partial. This is the v1
+  // seed for per-card completeness badges; a fuller rollout is tracked as
+  // follow-up work.
+  const metricsCompleteness = (() => {
+    const contributingClusters: string[] = []
+    const missingClusters: string[] = []
+    for (const c of deduplicatedClusters) {
+      const hasMetrics = typeof c.cpuCores === 'number' && c.cpuCores >= 0
+      if (c.reachable !== false && hasMetrics) {
+        contributingClusters.push(c.name)
+      } else {
+        missingClusters.push(c.name)
+      }
+    }
+    return {
+      contributingClusters,
+      missingClusters,
+      isComplete: missingClusters.length === 0 && contributingClusters.length > 0 }
+  })()
+
   return {
     // Raw clusters - all contexts including duplicates pointing to same server
     clusters: localState.clusters,
     // Deduplicated clusters - single cluster per server with aliases
     // Use this for metrics, stats, and aggregations to avoid double-counting
     deduplicatedClusters,
+    // Completeness metadata for aggregated metrics (issue #6114)
+    metricsCompleteness,
     isLoading: localState.isLoading,
     isRefreshing: localState.isRefreshing,
     lastUpdated: localState.lastUpdated,

--- a/web/src/hooks/mcp/compute.ts
+++ b/web/src/hooks/mcp/compute.ts
@@ -96,18 +96,18 @@ if (typeof window !== 'undefined') {
 }
 
 export function updateGPUNodeCache(updates: Partial<GPUNodeCache>) {
-  const prevCount = gpuNodeCache.nodes.length
-
-  // CRITICAL: Never allow clearing nodes if we have good data
-  // This prevents any code path from accidentally wiping the cache
-  if (updates.nodes !== undefined && updates.nodes.length === 0 && prevCount > 0) {
-    // Blocked: attempt to clear existing GPU node data — preserve it
-    // Remove nodes from updates to preserve existing data
-    const { nodes: _ignored, ...safeUpdates } = updates
-    gpuNodeCache = { ...gpuNodeCache, ...safeUpdates }
-  } else {
-    gpuNodeCache = { ...gpuNodeCache, ...updates }
-  }
+  // NOTE: We used to have a "CRITICAL: Never allow clearing nodes if we have
+  // good data" guard here that silently dropped any `nodes: []` update. That
+  // guard was the root cause of issue #6111 — when all GPU nodes were removed
+  // from a cluster, the cache would never update to reflect the new reality
+  // and the UI would keep showing stale nodes indefinitely.
+  //
+  // Cache-preservation across transient failures is now handled at the fetch
+  // site (`fetchGPUNodes`): only a successful empty response is applied; a
+  // failure keeps the existing cache untouched. Callers that intentionally
+  // clear the cache (e.g. resetGPUNodeCache) or that wish to apply an
+  // authoritative empty result are no longer silently ignored.
+  gpuNodeCache = { ...gpuNodeCache, ...updates }
 
   // Persist to localStorage when nodes are updated (and we have data)
   if (updates.nodes !== undefined && gpuNodeCache.nodes.length > 0) {
@@ -142,6 +142,12 @@ async function fetchGPUNodes(cluster?: string, _source?: string) {
 
     let newNodes: GPUNode[] = []
     let agentSucceeded = false
+    // Tracks whether at least one upstream source successfully returned a
+    // response for this fetch cycle — regardless of whether it contained any
+    // nodes. This is the signal we use to decide whether an empty result is a
+    // legitimate "no GPUs here any more" (clear the cache) or a transient
+    // failure (keep the stale cache). See issue #6111.
+    let fetchSucceeded = false
 
     // Try local agent first (works without backend running)
     if (!isAgentUnavailable()) {
@@ -157,6 +163,7 @@ async function fetchGPUNodes(cluster?: string, _source?: string) {
           const data = await response.json()
           newNodes = data.nodes || []
           agentSucceeded = true // Agent worked, even if it returned 0 nodes
+          fetchSucceeded = true
           reportAgentDataSuccess()
         } else {
           throw new Error('Local agent returned error')
@@ -186,11 +193,13 @@ async function fetchGPUNodes(cluster?: string, _source?: string) {
           },
         })
         newNodes = sseResult
+        fetchSucceeded = true
       } catch {
         // SSE failed, try REST fallback
         try {
           const { data } = await api.get<{ nodes: GPUNode[] }>(`/api/mcp/gpu-nodes?${params}`)
           newNodes = data.nodes || []
+          fetchSucceeded = true
         } catch {
           if (gpuNodeCache.nodes.length === 0) {
             throw new Error('Both SSE and REST failed')
@@ -199,18 +208,20 @@ async function fetchGPUNodes(cluster?: string, _source?: string) {
       }
     }
 
-    // Update with new data, but protect against replacing good data with empty results
-    // This prevents a failed refresh from wiping out valid cached GPU info
-    const currentCacheHasData = gpuNodeCache.nodes.length > 0
-    const newDataHasContent = newNodes.length > 0
-
-    // Only update cache if:
-    // 1. We got new data (newNodes.length > 0), OR
-    // 2. Cache was already empty (nothing to preserve)
-    // Never replace good cached data with empty results
-    const shouldUpdateCache = newDataHasContent || !currentCacheHasData
-
-    if (shouldUpdateCache && newDataHasContent) {
+    // Update with new data. Previously this code would refuse to overwrite a
+    // populated cache with an empty result, which caused the cache to retain
+    // stale GPU nodes long after they had been removed from the cluster
+    // (issue #6111). We now distinguish two cases:
+    //
+    //   a) `fetchSucceeded === true` — at least one upstream returned a valid
+    //      response (even an empty list). This is an authoritative "truth" and
+    //      we MUST apply it, including the empty-array case, so removed nodes
+    //      disappear.
+    //
+    //   b) `fetchSucceeded === false` — every upstream errored out. Keep the
+    //      stale cache so the UI doesn't flicker to empty on a transient
+    //      network failure.
+    if (fetchSucceeded) {
       updateGPUNodeCache({
         nodes: newNodes,
         lastUpdated: new Date(),

--- a/web/src/hooks/mcp/shared.ts
+++ b/web/src/hooks/mcp/shared.ts
@@ -535,7 +535,15 @@ export function deduplicateClustersByServer(clusters: ClusterInfo[]): ClusterInf
     const primary = sorted[0]
     const aliases = sorted.slice(1).map(c => c.name)
 
-    // Merge the best metrics from all duplicates
+    // Merge the best metrics from all duplicates.
+    //
+    // nodeCount and podCount are counts of live resources — NOT "max across all
+    // observations". Previously we took Math.max, which over-counted after a
+    // scale-down because the larger stale value from a previous sample kept
+    // winning (issue #6112). Instead, prefer the primary cluster's current
+    // values and only fall back to an alias value when the primary hasn't
+    // reported yet (nodeCount/podCount undefined). This gives us the freshest
+    // authoritative count without resurrecting stale numbers.
     let bestMetrics: Partial<ClusterInfo> = {}
     for (const cluster of (group || [])) {
       if (cluster.cpuCores && !bestMetrics.cpuCores) {
@@ -555,13 +563,23 @@ export function deduplicateClustersByServer(clusters: ClusterInfo[]): ClusterInf
           pvcBoundCount: cluster.pvcBoundCount,
         }
       }
-      // Take the best individual metrics
-      if ((cluster.nodeCount || 0) > (bestMetrics.nodeCount || 0)) {
-        bestMetrics.nodeCount = cluster.nodeCount
-      }
-      if ((cluster.podCount || 0) > (bestMetrics.podCount || 0)) {
-        bestMetrics.podCount = cluster.podCount
-      }
+    }
+    // Authoritative counts: use the primary cluster's values; only fall back to
+    // an alias when the primary has no value reported at all.
+    if (primary.nodeCount !== undefined) {
+      bestMetrics.nodeCount = primary.nodeCount
+    } else {
+      const alias = group.find(c => c !== primary && c.nodeCount !== undefined)
+      if (alias) bestMetrics.nodeCount = alias.nodeCount
+    }
+    if (primary.podCount !== undefined) {
+      bestMetrics.podCount = primary.podCount
+    } else {
+      const alias = group.find(c => c !== primary && c.podCount !== undefined)
+      if (alias) bestMetrics.podCount = alias.podCount
+    }
+    // Legacy merge loop preserved only for request metrics (below).
+    for (const cluster of (group || [])) {
       // Merge request metrics - these may come from a different cluster than capacity
       if (cluster.cpuRequestsCores && !bestMetrics.cpuRequestsCores) {
         bestMetrics.cpuRequestsMillicores = cluster.cpuRequestsMillicores

--- a/web/src/hooks/mcp/types.ts
+++ b/web/src/hooks/mcp/types.ts
@@ -175,6 +175,39 @@ export interface Deployment {
   annotations?: Record<string, string>
 }
 
+/**
+ * Tri-state metric value (issue #6113).
+ *
+ * Frontend code has historically conflated three very different situations into
+ * a single numeric 0: (a) the upstream returned "zero", (b) the upstream hasn't
+ * returned yet, and (c) the upstream doesn't know / isn't exposing this metric.
+ * This enum lets callers disambiguate explicitly.
+ *
+ * v1 use-site: see `AggregatedMetricCompleteness` below and
+ * `useClusters().metricsCompleteness`. A fuller migration of every card to
+ * tri-state values is tracked as follow-up work.
+ */
+export type MetricState = 'loading' | 'unknown' | 'value'
+
+export interface TriStateMetric<T = number> {
+  state: MetricState
+  value?: T
+}
+
+/**
+ * Metadata describing the completeness of an aggregated metric computed across
+ * multiple clusters (issue #6114). `contributingClusters` is the list of
+ * cluster names whose data was included in the aggregate, and `missingClusters`
+ * lists cluster names that should have contributed but didn't (unreachable,
+ * metrics-server unavailable, fetch error, etc.). `isComplete` is true only
+ * when `missingClusters` is empty.
+ */
+export interface AggregatedMetricCompleteness {
+  contributingClusters: string[]
+  missingClusters: string[]
+  isComplete: boolean
+}
+
 // AcceleratorType represents the category of accelerator
 export type AcceleratorType = 'GPU' | 'TPU' | 'AIU' | 'XPU'
 

--- a/web/src/lib/cards/cardHooks.ts
+++ b/web/src/lib/cards/cardHooks.ts
@@ -917,7 +917,9 @@ export interface UseChartFiltersResult {
   /** Available clusters for filtering (respects global filter, includes health info) */
   availableClusters: ClusterWithHealth[]
   /** Filtered cluster list based on global + local filters */
-  filteredClusters: { name: string; reachable?: boolean; cpuCores?: number; cpuRequestsCores?: number; memoryGB?: number; memoryRequestsGB?: number; podCount?: number; nodeCount?: number }[]
+  // cpuUsageCores/memoryUsageGB/metricsAvailable are needed so cards can
+  // distinguish actual metrics-server usage from allocated requests (#6105).
+  filteredClusters: { name: string; reachable?: boolean; cpuCores?: number; cpuRequestsCores?: number; memoryGB?: number; memoryRequestsGB?: number; podCount?: number; nodeCount?: number; cpuUsageCores?: number; memoryUsageGB?: number; metricsAvailable?: boolean }[]
   /** Whether cluster filter dropdown is showing */
   showClusterFilter: boolean
   /** Set cluster filter dropdown visibility */


### PR DESCRIPTION
## Summary

Bundled fix for 8 real metrics/aggregation bugs reported together, plus tiny
v1 seeds for two enhancement issues. All fixes touch the shared metrics/
aggregation layer, so one PR is simpler to review than 10 small ones.

## Per-issue verdict and fix

- **#6105** — ResourceUsage card used request values. **Fix:** prefer
  metrics-server actual usage (`cpuUsageCores` / `memoryUsageGB` when
  `metricsAvailable` is true) and fall back to requests only when metrics
  aren't reported. `filteredClusters` type on `useChartFilters` extended to
  carry the new fields. Tests added.

- **#6106** — Compute dashboard treated valid zero-node clusters as "no data".
  **Fix:** `hasActualData` now counts a cluster as having data whenever
  `nodeCount !== undefined`, not `nodeCount > 0`. Zero is a meaningful value.

- **#6107** — Nodes dashboard kept showing the previous utilization after it
  legitimately dropped to 0 (buggy ``value > 0 ? value : cached`` fallback).
  **Fix:** gate the cache on whether capacity has actually been reported,
  not on whether the utilization is non-zero. Cached values are stored in
  state (not a ref read during render) so the react-hooks lint rules pass.

- **#6108** — Cluster Comparison always showed Kubernetes version as N/A
  because ``getK8sVersion`` was a stub. **Fix:** use ``useNodes()`` at the
  page level and resolve each cluster's version via any node's
  ``kubeletVersion``, using aliases so deduplicated long OpenShift context
  names still match. Falls back to ``'N/A'`` only when no node reports a
  version.

- **#6109** — Unknown health shown as "Issues detected" (conflated with
  unhealthy). **Fix:** tri-state display — "Status unknown" when
  ``healthUnknown`` is true or ``healthy === undefined``, "All healthy" when
  ``healthy === true``, "Issues detected" only when explicitly unhealthy.

- **#6110** — Frontend dropdown allowed Tier 4 but backend validator rejected
  with 400 (``maxTier = 3``). Underlying ``InstallGPUHealthCronJob`` in
  ``pkg/k8s/client_gpu.go`` already accepted 1-4. **Fix:** bump handler
  ``maxTier`` to 4 with a cross-reference comment pointing to the frontend
  constant so they stay in sync.

- **#6111** — GPU node cache never cleared after all nodes were removed
  upstream. **Root cause:** ``updateGPUNodeCache`` had a "CRITICAL: Never
  allow clearing nodes" guard that silently dropped any ``nodes: []`` update.
  **Fix:** remove the over-aggressive guard and move cache preservation to
  the fetch site — ``fetchGPUNodes`` now tracks ``fetchSucceeded`` and only
  applies an empty result when at least one upstream responded successfully.
  Transient failures still keep the stale cache; authoritative empties now
  actually clear it. Tests updated (previously asserted the buggy guard).

- **#6112** — Cluster dedup over-counted nodes/pods after scale-down because
  ``bestMetrics`` was computed with ``Math.max(primary, alias)``. A stale
  larger value always won. **Fix:** primary cluster is now authoritative for
  ``nodeCount`` / ``podCount``; aliases only fill in ``undefined`` fields.
  Three regression tests cover primary-wins, alias-fallback, and a direct
  scale-down scenario.

- **#6113 (v1)** — Added ``MetricState`` tri-state enum and ``TriStateMetric``
  type in ``hooks/mcp/types.ts``. Full migration of cards to tri-state is
  tracked as follow-up.

- **#6114 (v1)** — Added ``AggregatedMetricCompleteness`` type and a
  ``metricsCompleteness`` field on ``useClusters()`` that lists contributing
  vs missing clusters for aggregated metrics. Per-card completeness badges
  are follow-up.

## Key tradeoffs

- The ``updateGPUNodeCache`` guard removal is the most invasive change: it
  deletes a ``CRITICAL: never clear`` comment. This is intentional — that
  guard was itself the root cause of #6111. Cache preservation across
  transient failures is now handled correctly at the fetch site instead.
- The dedup change is semantically different from the prior behavior. Some
  existing tests asserted the buggy ``Math.max`` output and were updated to
  reflect the correct primary-wins behavior with comments linking to #6112.
- ResourceUsage falls back to requests when ``metricsAvailable`` is not
  reported; this matches the old behavior for clusters without
  metrics-server, so nothing regresses for them.

## Test plan

- [x] ``go build ./...``
- [x] ``go vet ./...``
- [x] ``go test ./pkg/... -count=1``
- [x] ``npm run build``
- [x] ``npx tsc --noEmit``
- [x] ``npx eslint`` on all changed files (no new lint errors vs baseline)
- [x] ``vitest`` on ``src/hooks/mcp/__tests__/`` (all 87+302+90 passing)
- [x] ``vitest`` on ``src/components/cards/__tests__/ResourceUsage.test.tsx``
  (28 passing, incl. 2 new #6105 regression tests)
- [x] New regression tests for #6105, #6111, #6112 (3 scenarios)

🤖 Generated with [Claude Code](https://claude.com/claude-code)