### PR TITLE
fix(missions): consistent count in AI Missions list and chat views

### DIFF
--- a/web/src/components/layout/mission-sidebar/MissionSidebar.tsx
+++ b/web/src/components/layout/mission-sidebar/MissionSidebar.tsx
@@ -350,6 +350,16 @@ export function MissionSidebar() {
   const visibleActiveMissions = activeMissions.slice(0, visibleMissionCount)
   const hasMoreMissions = activeMissions.length > visibleMissionCount
 
+  /**
+   * Total missions actually rendered in the list view (saved + active).
+   * Used so the list header count and the chat view's "Back to missions"
+   * label agree on the same source of truth (#6134, #6135, #6136, #6137).
+   * Previously the chat button used `missions.length` (which included
+   * terminal completed/failed/cancelled missions that the list filters
+   * out via isActiveMission), producing a mismatch like "21 vs 24".
+   */
+  const listTotalMissions = savedMissions.length + activeMissions.length
+
   const handleImportMission = (mission: MissionExport) => {
     const missionType = mission.missionClass === 'install' ? 'deploy' as const
       : mission.type === 'troubleshoot' ? 'troubleshoot' as const
@@ -950,14 +960,16 @@ export function MissionSidebar() {
             </div>
           )}
           <div className="flex-1 flex flex-col min-h-0 min-w-0">
-            {/* Back to list if multiple missions */}
-            {missions.length > 1 && (
+            {/* Back to list if multiple missions.
+             * Count and visibility must match the list view's filter
+             * (saved + active) so list and chat headers agree (#6137). */}
+            {listTotalMissions > 1 && (
               <button
                 onClick={() => setActiveMission(null)}
                 className="flex items-center gap-1 px-4 py-2 text-xs text-muted-foreground hover:text-foreground border-b border-border flex-shrink-0"
               >
                 <ChevronLeft className="w-3 h-3" />
-                {t('missionSidebar.backToMissions', { count: missions.length })}
+                {t('missionSidebar.backToMissions', { count: listTotalMissions })}
               </button>
             )}
             <MissionChat mission={activeMission} isFullScreen={isFullScreen} fontSize={fontSize} onToggleFullScreen={() => setFullScreen(true)} />


### PR DESCRIPTION
## Summary

Fixes a set of related count/pagination bugs in the AI Missions sidebar where the list view and chat view disagreed on how many missions exist.

- Fixes #6134
- Fixes #6135
- Fixes #6136
- Fixes #6137

## Root cause

All four issues share a single root cause: the list view and the chat view's "Back to missions" button used different sources of truth.

- The **list view** filters missions through `isActiveMission` (excludes `completed`, `failed`, `cancelled`) and renders saved missions in a separate section.
- The **chat view's** Back button used the unfiltered `missions.length`.

So with 24 total missions (10 saved + 11 active + 3 terminal), the user would see:
- List header: `21` (saved + active)
- Chat back button: `24` (everything)
- Active section visible items: `11`

This produced the reported "21 vs 24" mismatch (#6136, #6137) and the perception that pagination/Load More were broken (#6134, #6135) — `MISSIONS_PAGE_SIZE` is already 20 and Load More already renders correctly when `hasMoreMissions` is true; users were just seeing a filtered subset.

## Fix

Introduce `listTotalMissions = savedMissions.length + activeMissions.length` as the single source of truth for what the list actually renders, and use it in the chat view's "Back to missions" button so both views agree.

`MISSIONS_PAGE_SIZE` (20) and the existing `hasMoreMissions` / Load More logic are unchanged — they were already correct.

## Files touched

- `web/src/components/layout/mission-sidebar/MissionSidebar.tsx`

## Test plan

- [x] `npm run build` passes
- [x] `npx eslint` clean on the modified file (no new warnings/errors)
- [x] `MissionSidebar.test.tsx` passes (4/4)
- [ ] Manual: open AI Missions sidebar, open a mission chat, confirm the "Back to missions (N)" count matches the list view header count