### PR TITLE
fix(clusters): surface remove-cluster error and inject agent token (#6133)

### DIFF
--- a/web/src/components/clusters/Clusters.tsx
+++ b/web/src/components/clusters/Clusters.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect } from 'react'
 import { useSearchParams, useLocation, useNavigate } from 'react-router-dom'
 import { AlertTriangle, ChevronRight, ChevronDown, Server, Scissors } from 'lucide-react'
 import { useClusters, useGPUNodes, useNVIDIAOperators, refreshSingleCluster } from '../../hooks/useMCP'
+import { agentFetch } from '../../hooks/mcp/shared'
 import { ClusterDetailModal } from './ClusterDetailModal'
 import { AddClusterDialog } from './AddClusterDialog'
 import { EmptyClusterState } from './EmptyClusterState'
@@ -148,14 +149,20 @@ export function Clusters() {
 
   const handleRenameContext = async (oldName: string, newName: string) => {
     if (!isConnected) throw new Error('Local agent not connected')
-    const response = await fetch(`${LOCAL_AGENT_HTTP_URL}/rename-context`, {
+    // Use agentFetch so the Authorization: Bearer <KC_AGENT_TOKEN> header
+    // is injected — plain fetch() is rejected with 401 when the agent has
+    // a token configured (#6133).
+    const response = await agentFetch(`${LOCAL_AGENT_HTTP_URL}/rename-context`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ oldName, newName }),
       signal: AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS) })
     if (!response.ok) {
-      const data = await response.json().catch(() => ({})) as { message?: string }
-      throw new Error(data.message || 'Failed to rename context')
+      const data = await response.json().catch(() => ({})) as { error?: string; message?: string }
+      // Fall back to HTTP status so users see e.g. "HTTP 401: Unauthorized"
+      // instead of a silent generic error when the body has no message.
+      const fallback = `HTTP ${response.status}: ${response.statusText || 'Failed to rename context'}`
+      throw new Error(data.error || data.message || fallback)
     }
     refetch()
   }
@@ -164,17 +171,26 @@ export function Clusters() {
    * Remove an offline cluster's kubeconfig context (#5901).
    * Backend: `RemoveContext` in pkg/k8s/client.go (added in #5658). The agent
    * exposes it at POST /kubeconfig/remove on the localhost-only HTTP server.
+   *
+   * Uses agentFetch() to inject the KC_AGENT_TOKEN Authorization header;
+   * without this the kc-agent rejects the request with 401 Unauthorized
+   * whenever a token is configured, which manifested as a silent "Failed
+   * to remove cluster from kubeconfig" in the UI (#6133).
    */
   const handleRemoveCluster = async (contextName: string) => {
     if (!isConnected) throw new Error(t('cluster.removeClusterNoAgent'))
-    const response = await fetch(`${LOCAL_AGENT_HTTP_URL}/kubeconfig/remove`, {
+    const response = await agentFetch(`${LOCAL_AGENT_HTTP_URL}/kubeconfig/remove`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ context: contextName }),
       signal: AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS) })
     if (!response.ok) {
       const data = await response.json().catch(() => ({})) as { error?: string; message?: string }
-      throw new Error(data.error || data.message || t('cluster.removeClusterError'))
+      // Always surface the HTTP status if the body has no structured error,
+      // so the user sees "HTTP 401: Unauthorized" instead of the generic
+      // fallback — this was the root cause of #6133 being unactionable.
+      const fallback = `HTTP ${response.status}: ${response.statusText || t('cluster.removeClusterError')}`
+      throw new Error(data.error || data.message || fallback)
     }
     showToast(t('cluster.removeClusterSuccess', { name: contextName }), 'success')
     refetch()

--- a/web/src/components/clusters/components/RemoveClusterDialog.test.tsx
+++ b/web/src/components/clusters/components/RemoveClusterDialog.test.tsx
@@ -1,0 +1,91 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { RemoveClusterDialog } from './RemoveClusterDialog'
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}))
+
+// Mock BaseModal to render children directly (avoid portal complexity).
+vi.mock('../../../lib/modals', () => {
+  const Header = ({ title, onClose }: { title: string; onClose: () => void }) => (
+    <div>
+      <h2>{title}</h2>
+      <button onClick={onClose} aria-label="close-header">X</button>
+    </div>
+  )
+  const Content = ({ children }: { children: React.ReactNode }) => <div>{children}</div>
+  const Footer = ({ children }: { children: React.ReactNode }) => <div>{children}</div>
+
+  const BaseModal = ({ isOpen, children }: { isOpen: boolean; children: React.ReactNode }) => {
+    if (!isOpen) return null
+    return <div data-testid="modal">{children}</div>
+  }
+  BaseModal.Header = Header
+  BaseModal.Content = Content
+  BaseModal.Footer = Footer
+
+  return { BaseModal }
+})
+
+describe('RemoveClusterDialog', () => {
+  const defaultProps = {
+    isOpen: true,
+    contextName: 'kind-kubeflex',
+    displayName: 'kind-kubeflex',
+    onClose: vi.fn(),
+    onConfirm: vi.fn(),
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('renders the context name being removed', () => {
+    render(<RemoveClusterDialog {...defaultProps} />)
+    expect(screen.getByText('kind-kubeflex')).toBeInTheDocument()
+    expect(screen.getByText('cluster.removeClusterTitle')).toBeInTheDocument()
+  })
+
+  it('surfaces the underlying error message from onConfirm (regression: #6133)', async () => {
+    // The actual backend error — e.g. "HTTP 401: Unauthorized" when the
+    // Authorization header is missing — must be shown to the user instead
+    // of being swallowed by a generic "Failed to remove cluster" fallback.
+    const underlyingError = 'HTTP 401: Unauthorized'
+    const onConfirm = vi.fn().mockRejectedValue(new Error(underlyingError))
+    render(<RemoveClusterDialog {...defaultProps} onConfirm={onConfirm} />)
+
+    fireEvent.click(screen.getByLabelText('cluster.removeClusterConfirm'))
+
+    await waitFor(() => {
+      expect(screen.getByRole('alert')).toHaveTextContent(underlyingError)
+    })
+    // Dialog stays open so the user can read the error.
+    expect(defaultProps.onClose).not.toHaveBeenCalled()
+  })
+
+  it('surfaces backend "context not found" errors verbatim', async () => {
+    const backendError = 'context "kind-kubeflex" not found'
+    const onConfirm = vi.fn().mockRejectedValue(new Error(backendError))
+    render(<RemoveClusterDialog {...defaultProps} onConfirm={onConfirm} />)
+
+    fireEvent.click(screen.getByLabelText('cluster.removeClusterConfirm'))
+
+    await waitFor(() => {
+      expect(screen.getByRole('alert')).toHaveTextContent(backendError)
+    })
+  })
+
+  it('closes the dialog on successful removal', async () => {
+    const onConfirm = vi.fn().mockResolvedValue(undefined)
+    const onClose = vi.fn()
+    render(<RemoveClusterDialog {...defaultProps} onConfirm={onConfirm} onClose={onClose} />)
+
+    fireEvent.click(screen.getByLabelText('cluster.removeClusterConfirm'))
+
+    await waitFor(() => {
+      expect(onClose).toHaveBeenCalled()
+    })
+    expect(onConfirm).toHaveBeenCalledWith('kind-kubeflex')
+  })
+})


### PR DESCRIPTION
Fixes #6133.

## Root cause

The "Remove cluster" button for offline kubeconfig contexts (added in #6097 / #5901) called `fetch('/kubeconfig/remove')` on the kc-agent **without** injecting the `Authorization: Bearer <KC_AGENT_TOKEN>` header. Every other kc-agent call in the app goes through `agentFetch()` which auto-injects the token — this one was missed.

When a token was configured (the common case), the agent rejected the request with `401 Unauthorized`. The frontend code was:

```ts
throw new Error(data.error || data.message || t('cluster.removeClusterError'))
```

Even though the backend returned `{"error": "Unauthorized"}`, certain failure paths (CORS failures, body-read failures, network hiccups) produced a response whose body could not be parsed, and the user was left with only the opaque i18n fallback **"Failed to remove cluster from kubeconfig"** — giving nothing to diagnose with. This is exactly what @xonas1101 saw when trying to remove the offline `kind-kubeflex` context.

## Fix

1. **Use `agentFetch()`** for both `/kubeconfig/remove` and `/rename-context` so the `Bearer` token is injected automatically. Without this the agent rejects the request with 401 whenever `KC_AGENT_TOKEN` is set.
2. **Fall back to HTTP status** instead of the opaque i18n string, so the user sees e.g. `HTTP 401: Unauthorized` or `HTTP 400: Bad Request` when the response body is empty/malformed. The existing `RemoveClusterDialog` already surfaces `err.message` verbatim, so no dialog changes were needed.

## Tests

- New `RemoveClusterDialog.test.tsx` (4 tests, all green) verifies the dialog surfaces the underlying `Error.message` verbatim — both for `HTTP 401: Unauthorized` and for backend errors like `context "kind-kubeflex" not found` — and that it closes on success. This is the regression guard for #6133.
- All 81 existing cluster tests still pass.
- `go build ./...` and `go test ./pkg/agent/... ./pkg/k8s/...` green.
- `npm run build` green; the only `npm run lint` errors are pre-existing and unrelated to this PR (`CompliancePerfTest.tsx`, line 90 of `Clusters.tsx`, etc.).

## Test plan

- [ ] Configure `KC_AGENT_TOKEN` on the kc-agent
- [ ] Add an offline kubeconfig context (e.g. `kind-kubeflex` from a deleted kind cluster)
- [ ] Open the Clusters page and click the trash icon on the offline card
- [ ] Confirm removal → the context is removed from `~/.kube/config`
- [ ] If the agent is misconfigured or the context is the current context, the dialog now shows the actual backend error (e.g. `cannot remove the current context "kind-kubeflex"`) instead of a generic "Failed" message