### PR TITLE
fix: missions back-button trap (#6145) + auth cache test (#6144)

### DIFF
--- a/web/src/components/layout/mission-sidebar/MissionSidebar.tsx
+++ b/web/src/components/layout/mission-sidebar/MissionSidebar.tsx
@@ -963,10 +963,14 @@ export function MissionSidebar() {
             </div>
           )}
           <div className="flex-1 flex flex-col min-h-0 min-w-0">
-            {/* Back to list if multiple missions.
-             * Count and visibility must match the list view's filter
-             * (saved + active) so list and chat headers agree (#6137). */}
-            {listTotalMissions > 1 && (
+            {/* Back to missions list.
+             * Always visible when an activeMission is set — this is the only
+             * UI path that clears activeMission. Previously this was gated on
+             * listTotalMissions > 1 (#6137), but that trapped users who
+             * filtered via missionSearchQuery down to a single result with
+             * no way to return to the full list (#6145). Safest fix: always
+             * show the button when activeMission != null. */}
+            {activeMission != null && (
               <button
                 onClick={() => setActiveMission(null)}
                 className="flex items-center gap-1 px-4 py-2 text-xs text-muted-foreground hover:text-foreground border-b border-border flex-shrink-0"

--- a/web/src/lib/__tests__/auth.test.ts
+++ b/web/src/lib/__tests__/auth.test.ts
@@ -637,8 +637,13 @@ describe('AuthProvider', () => {
 
     const { result } = await renderWithAuthProvider()
 
+    // #6144 — When a token AND cached user both exist in localStorage,
+    // AuthProvider starts with isLoading=false (stale-while-revalidate), so
+    // waiting on isLoading resolves BEFORE refreshUser's async catch block
+    // has a chance to clear the token. Wait directly for the token to be
+    // cleared by the stale-cache drop path instead.
     await waitFor(() => {
-      expect(result.current.isLoading).toBe(false)
+      expect(result.current.token).toBeNull()
     })
 
     // Stale cache → session dropped (token cleared, user null)


### PR DESCRIPTION
Fixes #6145, #6144.

## #6145 — Missions back-button trap on filter

`MissionSidebar.tsx` hid the "Back to missions" button when `listTotalMissions <= 1`. That's the only UI path that calls `setActiveMission(null)`, so if a user filtered via `missionSearchQuery` down to a single result, they were trapped — no way back to the full list.

**Fix:** Always show the button when `activeMission != null`, regardless of `listTotalMissions`. Added a comment explaining the history (originally gated in #6137 to hide the button when only one mission exists, but that interacts badly with search filtering).

## #6144 — auth.test.ts Coverage Suite failure

The test `"drops session to login when /api/me fails and cache is stale (#6067)"` (added in PR #6094) was waiting on `isLoading === false` before asserting `token` was null.

**Root cause:** `AuthProvider` initializes `isLoading` to `false` when BOTH a token AND a cached user exist in localStorage (stale-while-revalidate optimization, auth.tsx:171-178). The test sets both, so `waitFor(() => isLoading === false)` resolves immediately — BEFORE the async `refreshUser()` catch block runs `setTokenState(null)`. The assertion then reads the initial token.

**Fix:** The production behavior is correct (stale cache drops the session). The test needed to wait on the actual state change. Changed the waitFor to wait directly on `result.current.token` becoming null.

## Verification

- [x] `npx vitest run src/lib/__tests__/auth.test.ts` — 62 passed
- [x] `npx vitest run src/components/layout/mission-sidebar` — 5 passed
- [x] `npm run build` — clean
- [x] `npm run lint` — no new errors (only pre-existing warnings on unrelated files)