### PR TITLE
🐛 fix(analytics): ACCM chart missing history + Copilot misclassified as human

### DIFF
--- a/web/netlify/functions/analytics-accm.mts
+++ b/web/netlify/functions/analytics-accm.mts
@@ -25,14 +25,28 @@ const CACHE_TTL_MS = 60 * 60 * 1000;
 const WEEKS_OF_HISTORY = 12;
 /** GitHub API results per page (max 100) */
 const PER_PAGE = 100;
-/** Max pages to fetch per endpoint (rate-limit guard) */
-const MAX_PAGES = 3;
+/**
+ * Max pages to fetch per endpoint. Bumped from 3 → 15 (1500 items) because
+ * recent activity can exceed 300 PRs in a single week, which caused every
+ * older week to show 0 activity in the chart — the 3-page window never
+ * escaped the most recent week.
+ */
+const MAX_PAGES = 15;
 /** Request timeout for GitHub API calls */
 const API_TIMEOUT_MS = 15_000;
 /** AI-generated label used to classify AI contributions */
 const AI_LABEL = "ai-generated";
-/** Authors whose PRs/issues are always AI-generated (Claude Code sessions) */
-const AI_AUTHORS = new Set(["clubanderson"]);
+/**
+ * Authors whose PRs/issues are always AI-generated.
+ *   - clubanderson: the shared login Claude Code writes from
+ *   - Copilot / copilot-swe-agent[bot]: GitHub Copilot coding agent
+ * Any login ending in `[bot]` is also treated as AI (see isAIContribution).
+ */
+const AI_AUTHORS = new Set([
+  "clubanderson",
+  "Copilot",
+  "copilot-swe-agent[bot]",
+]);
 
 /** Workflow filenames to track for CI pass rates */
 const CI_WORKFLOWS: Record<string, string> = {
@@ -276,7 +290,10 @@ async function fetchWorkflowRuns(
 // ---------------------------------------------------------------------------
 
 function isAIContribution(labels: { name: string }[], author: string): boolean {
-  return AI_AUTHORS.has(author) || (labels || []).some((l) => l.name === AI_LABEL);
+  // Known AI authors, any GitHub App/bot account, or PRs explicitly labeled.
+  if (AI_AUTHORS.has(author)) return true;
+  if (author && author.endsWith("[bot]")) return true;
+  return (labels || []).some((l) => l.name === AI_LABEL);
 }
 
 function aggregateWeeklyActivity(


### PR DESCRIPTION
## Summary

Two bugs in the ACCM (AI Codebase Maturity Model) section of /analytics, visible at a glance:

1. **Weekly PR/Issue chart only shows the current week.** Every older week renders as zero bars.
2. **AI vs Human split is wrong** — shows 43% human even though nearly all activity is AI-driven.

## Root causes

**(1) 3-page fetch window never escapes the current week.**
\`analytics-accm.mts\` paginates at \`MAX_PAGES = 3\` × \`PER_PAGE = 100\` = 300 items sorted by \`created desc\`. When the repo produces >300 PRs in one week (current activity), all 300 fall into W15 and older weeks get zero data. Bumped \`MAX_PAGES\` 3 → 15 (1500 items) so the 12-week history backfills.

**(2) Bot accounts classified as human.**
The classifier only matched \`clubanderson\`. Verified against live W15 data (300 PRs): 286 clubanderson + 9 **Copilot** + 5 real humans. The 9 Copilot PRs are what's showing as \"humans\".

Fix extends the classifier to:
- include \`Copilot\` and \`copilot-swe-agent[bot]\` explicitly
- treat any \`*[bot]\` login as AI (future-proofs against GitHub App bots)

## Test plan

Sanity-checked the logic locally:

| Author                     | classified |
|---|---|
| clubanderson               | ✅ AI |
| Copilot                    | ✅ AI |
| copilot-swe-agent[bot]     | ✅ AI |
| dependabot[bot]            | ✅ AI (new [bot] catch-all) |
| KumarADITHYA123            | ✅ Human (real drive-by) |
| label = \`ai-generated\`     | ✅ AI |

- [x] \`npm run build\` passes
- [ ] Manual: verify /analytics ACCM chart shows W04–W15 populated after Netlify Function cache expires (1h TTL)
- [ ] Manual: verify AI Contributions ≈ 98%+ after deploy