### PR TITLE
🐛 fix(rbac): grant create namespaces so GPU reservation "New namespace" works on vllm-d/pok-prod

### DIFF
--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -271,6 +271,7 @@ jobs:
             --set clusterName=vllm-d \
             --set-string enabledDashboards="dashboard\,clusters\,gpu-reservations\,llm-d-benchmarks\,ai-ml\,arcade" \
             --set persistence.storageClass=ocs-storagecluster-cephfs \
+            --set rbac.namespaceCreationEnabled=true \
             --atomic \
             --wait \
             --timeout 5m
@@ -351,6 +352,7 @@ jobs:
             --set route.host=kc-kubestellar-console-kubestellar-console.apps.pokprod001.ete14.res.ibm.com \
             --set clusterName=pok-prod-001 \
             --set-string enabledDashboards="dashboard\,clusters\,gpu-reservations\,llm-d-benchmarks\,ai-ml\,arcade" \
+            --set rbac.namespaceCreationEnabled=true \
             --atomic \
             --wait \
             --timeout 5m

--- a/deploy/helm/kubestellar-console/templates/clusterrole.yaml
+++ b/deploy/helm/kubestellar-console/templates/clusterrole.yaml
@@ -19,8 +19,16 @@ rules:
       - persistentvolumeclaims
       - persistentvolumes
       - limitranges
-      - namespaces
     verbs: ["get", "list", "watch"]
+
+  # Namespaces — read-only by default; add "create" when
+  # rbac.namespaceCreationEnabled is true so the GPU reservation form's
+  # "New namespace..." option can auto-provision a namespace via
+  # POST /api/mcp/resourcequotas with ensure_namespace: true.
+  - apiGroups: [""]
+    resources:
+      - namespaces
+    verbs: ["get", "list", "watch"{{- if .Values.rbac.namespaceCreationEnabled }}, "create"{{- end }}]
 
   # ResourceQuotas — full CRUD for GPU reservation enforcement,
   # or read-only when rbac.resourceQuotasReadOnly is true.

--- a/deploy/helm/kubestellar-console/values.yaml
+++ b/deploy/helm/kubestellar-console/values.yaml
@@ -20,9 +20,14 @@ serviceAccount:
 # its ServiceAccount for read-only cluster access + ResourceQuota CRUD.
 # Set resourceQuotasReadOnly to true to restrict ResourceQuota permissions
 # to read-only (disables GPU reservation enforcement).
+# Set namespaceCreationEnabled to true to grant the SA cluster-scoped
+# "create namespaces" — required when the GPU reservation form's
+# "New namespace..." option is used (otherwise that call 500s with
+# "namespaces is forbidden ... cannot create resource namespaces").
 rbac:
   create: true
   resourceQuotasReadOnly: false
+  namespaceCreationEnabled: false
 
 podAnnotations: {}
 podLabels: {}


### PR DESCRIPTION
## Summary

The GPU reservation form has a \"+ New namespace...\" option that POSTs to \`/api/mcp/resourcequotas\` with \`ensure_namespace: true\`. On vllm-d (and pok-prod, which runs the same chart) it currently 500s with:

\`\`\`
namespaces is forbidden: User \"system:serviceaccount:kc:kc-kubestellar-console\"
cannot create resource \"namespaces\" in API group \"\" at the cluster scope
\`\`\`

The ClusterRole granted only \`get/list/watch\` on namespaces. The date format fix in #6123 unblocked the reservation save path, which surfaced this follow-on namespace-creation failure — verified end-to-end against vllm-d earlier today.

## Changes

**Chart** (\`deploy/helm/kubestellar-console\`):
- Split \`namespaces\` out of the bulk read-only core/v1 rule into its own rule block so verbs can be extended conditionally without touching the 10 other read-only resources.
- Add \`rbac.namespaceCreationEnabled\` value, default \`false\`. When \`true\`, appends \`create\` to the namespaces verb list.

**Deploy workflow** (\`.github/workflows/build-deploy.yml\`):
- Pass \`--set rbac.namespaceCreationEnabled=true\` for both \`deploy-vllm-d\` and \`deploy-pok-prod\`. These are the environments where the GPU reservation form is actually used. Defaults stay read-only for third-party chart installs.

## Test plan

Rendered both code paths locally:

\`\`\`
default  → verbs: [get, list, watch]              (no regression)
enabled  → verbs: [get, list, watch, create]      (new)
\`\`\`

- [x] \`helm template\` renders cleanly in both states
- [x] Verified current vllm-d failure: \`namespaces is forbidden ... cannot create resource namespaces\`
- [ ] After deploy: re-run the GPU reservation e2e test with \"+ New namespace...\" and confirm the reservation + namespace + ResourceQuota all land
- [ ] Confirm existing deployments (non-vllm-d, non-pok-prod) still render the same ClusterRole (default path)

## Related
- #6123 — date format fix that unblocked the reservation save and exposed this bug