### PR TITLE
feat(perf): generalized perf-regression auto-issue scaffold + 3 signals

### DIFF
--- a/.github/workflows/_perf-regression-issue.yml
+++ b/.github/workflows/_perf-regression-issue.yml
@@ -1,0 +1,75 @@
+name: _perf regression issue (reusable)
+
+# Reusable "file/update a perf-regression issue" workflow. Any perf job can
+# call this after writing a perf-result.json — the script handles dedupe via
+# the issue title prefix `[perf-regression] <signal>`.
+#
+# The caller MUST upload the perf-result.json as an artifact named
+# `perf-result-<signal>` before invoking this workflow. This workflow
+# downloads the artifact, then runs scripts/perf-regression-issue.mjs.
+#
+# Usage:
+#   jobs:
+#     perf:
+#       runs-on: ubuntu-latest
+#       steps:
+#         - run: ./run-the-perf-test.sh  # writes web/perf-result.json
+#         - uses: actions/upload-artifact@v4
+#           if: always()
+#           with:
+#             name: perf-result-react-commits-navigation
+#             path: web/perf-result.json
+#     notify:
+#       if: failure()
+#       needs: perf
+#       uses: ./.github/workflows/_perf-regression-issue.yml
+#       with:
+#         result-path: web/perf-result.json
+#         signal: react-commits-navigation
+
+on:
+  workflow_call:
+    inputs:
+      result-path:
+        description: Path (relative to repo root) where the script should find the result JSON after artifact download.
+        required: true
+        type: string
+      signal:
+        description: Signal slug — used to locate the uploaded artifact (perf-result-<signal>) and for logging.
+        required: true
+        type: string
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  notify:
+    name: File/update perf regression issue
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          # Need history so the script can `git log lastSuccessful..HEAD`
+          fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      - name: Download perf result artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: perf-result-${{ inputs.signal }}
+          # Land the file at its original path relative to repo root.
+          path: ${{ github.workspace }}
+
+      - name: File or update perf regression issue
+        env:
+          PERF_RESULT_JSON: ${{ inputs.result-path }}
+          PERF_SIGNAL: ${{ inputs.signal }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: node scripts/perf-regression-issue.mjs

--- a/.github/workflows/perf-bundle-size.yml
+++ b/.github/workflows/perf-bundle-size.yml
@@ -1,0 +1,120 @@
+name: Perf — Bundle size
+
+# Every 2 hours we build the prod bundle and measure the total gzipped size
+# of the JS chunks in dist/assets. If it blows the budget, the reusable
+# auto-issue workflow files/updates an issue.
+#
+# Budget derivation:
+#   At branch point (2026-04-10) the total gzipped JS size was ~2,930,697
+#   bytes (~2.80 MB). PERF_BUDGET_BUNDLE_GZIP_BYTES is set ~10% above that
+#   (3,225,000 bytes ≈ 3.08 MB) so normal feature work has headroom but a
+#   genuine bloat regression (new heavy dep, missed code-split) trips it.
+#   Re-baseline by updating the env var below after a deliberate bump.
+
+on:
+  schedule:
+    - cron: '15 */2 * * *'
+  workflow_dispatch: {}
+
+permissions: read-all
+
+concurrency:
+  group: perf-bundle-size
+  cancel-in-progress: true
+
+env:
+  PERF_SIGNAL: bundle-gzip-bytes
+  # ~10% headroom over the 2026-04-10 baseline of 2,930,697 bytes.
+  PERF_BUDGET_BUNDLE_GZIP_BYTES: '3225000'
+
+jobs:
+  bundle-size:
+    name: JS bundle gzipped size
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+          cache-dependency-path: web/package-lock.json
+
+      - name: Install dependencies
+        working-directory: web
+        run: npm ci
+
+      - name: Build
+        working-directory: web
+        run: npm run build
+
+      - name: Resolve last successful SHA
+        id: last-success
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          LAST=$(gh run list \
+            --workflow="perf-bundle-size.yml" \
+            --branch=main \
+            --status=success \
+            --limit=1 \
+            --json headSha \
+            --jq '.[0].headSha // ""' || echo '')
+          echo "sha=${LAST}" >> "$GITHUB_OUTPUT"
+
+      - name: Measure and gate bundle size
+        id: measure
+        env:
+          LAST_SUCCESSFUL_SHA: ${{ steps.last-success.outputs.sha }}
+        run: |
+          set -euo pipefail
+          TOTAL=$(find web/dist/assets -name '*.js' -exec gzip -c {} + | wc -c)
+          # wc -c emits leading whitespace on macOS / some BSDs — strip it.
+          TOTAL=$(echo "$TOTAL" | tr -d '[:space:]')
+          BUDGET="${PERF_BUDGET_BUNDLE_GZIP_BYTES}"
+          echo "Total gzipped JS: ${TOTAL} bytes (budget ${BUDGET})"
+
+          RUN_URL="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+          cat > web/perf-result.json <<EOF
+          {
+            "signal": "bundle-gzip-bytes",
+            "displayName": "Total gzipped JS bundle size",
+            "value": ${TOTAL},
+            "budget": ${BUDGET},
+            "unit": "bytes",
+            "context": {
+              "runId": "${GITHUB_RUN_ID}",
+              "runUrl": "${RUN_URL}",
+              "headSha": "${GITHUB_SHA}",
+              "lastSuccessfulSha": "${LAST_SUCCESSFUL_SHA}"
+            }
+          }
+          EOF
+
+          if [ "$TOTAL" -gt "$BUDGET" ]; then
+            echo "::error::Bundle size ${TOTAL} exceeds budget ${BUDGET}"
+            exit 1
+          fi
+
+      - name: Upload perf result artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: perf-result-bundle-gzip-bytes
+          path: web/perf-result.json
+          if-no-files-found: warn
+          retention-days: 14
+
+  notify:
+    name: Notify on regression
+    needs: bundle-size
+    if: failure()
+    uses: ./.github/workflows/_perf-regression-issue.yml
+    with:
+      result-path: web/perf-result.json
+      signal: bundle-gzip-bytes

--- a/.github/workflows/perf-react-commits.yml
+++ b/.github/workflows/perf-react-commits.yml
@@ -1,0 +1,99 @@
+name: Perf — React commits per navigation
+
+# Every 2 hours we measure React commits during a dashboard navigation.
+# If the count blows the PERF_BUDGET_NAVIGATION_COMMITS budget, the test
+# fails and the _perf-regression-issue reusable workflow files/updates an
+# issue tagged `[perf-regression] react-commits-navigation`.
+#
+# This was carved off #6149 — one reusable auto-issue scaffold for all perf
+# signals, not duplicated logic in every workflow.
+
+on:
+  schedule:
+    # Every 2 hours at :15 past the hour. Offset from :00 to avoid the
+    # 0 * * * * thundering herd on the scheduler.
+    - cron: '15 */2 * * *'
+  workflow_dispatch: {}
+
+permissions: read-all
+
+concurrency:
+  group: perf-react-commits
+  cancel-in-progress: true
+
+# Signal slug must match the value in web/e2e/perf/constants.ts and is used
+# as the artifact name suffix the reusable notify workflow reads.
+env:
+  PERF_SIGNAL: react-commits-navigation
+
+jobs:
+  react-commits:
+    name: React commits per navigation
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    defaults:
+      run:
+        working-directory: web
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+          cache-dependency-path: web/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install Playwright browser
+        run: npx playwright install --with-deps chromium
+
+      - name: Resolve last successful SHA
+        id: last-success
+        working-directory: .
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # Look up the most recent successful run of this workflow on main
+          # so the auto-issue script can build a merge window. Best-effort;
+          # falls back to empty if the API call fails or there's no prior
+          # green run yet.
+          LAST=$(gh run list \
+            --workflow="perf-react-commits.yml" \
+            --branch=main \
+            --status=success \
+            --limit=1 \
+            --json headSha \
+            --jq '.[0].headSha // ""' || echo '')
+          echo "sha=${LAST}" >> "$GITHUB_OUTPUT"
+
+      - name: Run react-commits perf spec (dev server, hook enabled)
+        # PERF_DEV=1 flips e2e/perf/perf.config.ts to `npm run dev`, which is
+        # the only mode where React DevTools global hooks get honored.
+        env:
+          PERF_DEV: '1'
+          LAST_SUCCESSFUL_SHA: ${{ steps.last-success.outputs.sha }}
+        run: npx playwright test --config e2e/perf/perf.config.ts e2e/perf/react-commits.spec.ts
+
+      - name: Upload perf result artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: perf-result-react-commits-navigation
+          path: web/perf-result.json
+          if-no-files-found: warn
+          retention-days: 14
+
+  notify:
+    name: Notify on regression
+    needs: react-commits
+    if: failure()
+    uses: ./.github/workflows/_perf-regression-issue.yml
+    with:
+      result-path: web/perf-result.json
+      signal: react-commits-navigation

--- a/.github/workflows/perf-ttfi.yml
+++ b/.github/workflows/perf-ttfi.yml
@@ -8,12 +8,18 @@ on:
       - 'scripts/perf-test.sh'
       - '.github/workflows/perf-ttfi.yml'
   workflow_dispatch:
+  schedule:
+    # Every 2 hours at :15 — same cadence as perf-react-commits and
+    # perf-bundle-size. On scheduled runs ONLY, a failure files a
+    # `[perf-regression] ttfi-all-cards` issue via the reusable workflow.
+    - cron: '15 */2 * * *'
 
 # Least-privilege: read-only by default; jobs declare write scopes individually
 permissions: read-all
 
 env:
   CI: true
+  PERF_SIGNAL: ttfi-all-cards
 
 jobs:
   all-cards-ttfi:
@@ -68,6 +74,50 @@ jobs:
           CI_TOLERANCE_PCT: '15'
         run: node e2e/perf/compare-ttfi.mjs
 
+      - name: Write perf-result.json (scheduled runs only)
+        # Only scheduled runs drive the auto-issue notifier. PR-time failures
+        # already surface on the PR via the check status — no need to file
+        # extra issues there.
+        if: github.event_name == 'schedule'
+        working-directory: .
+        env:
+          LAST_SUCCESSFUL_SHA: ''
+        run: |
+          set -euo pipefail
+          REPORT="web/e2e/test-results/ttfi-report.json"
+          if [ ! -f "$REPORT" ]; then
+            echo "::warning::$REPORT missing; skipping perf-result.json"
+            exit 0
+          fi
+          # TTFI report schema: { summary: { worstCardTtfi, budgetMs } }
+          VALUE=$(node -e "const r=require('./${REPORT}');process.stdout.write(String((r.summary&&r.summary.worstCardTtfi)||0))")
+          BUDGET=$(node -e "const r=require('./${REPORT}');process.stdout.write(String((r.summary&&r.summary.budgetMs)||0))")
+          RUN_URL="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+          cat > web/perf-result.json <<EOF
+          {
+            "signal": "ttfi-all-cards",
+            "displayName": "Worst-case card TTFI",
+            "value": ${VALUE},
+            "budget": ${BUDGET},
+            "unit": "ms",
+            "context": {
+              "runId": "${GITHUB_RUN_ID}",
+              "runUrl": "${RUN_URL}",
+              "headSha": "${GITHUB_SHA}",
+              "lastSuccessfulSha": "${LAST_SUCCESSFUL_SHA}"
+            }
+          }
+          EOF
+
+      - name: Upload perf result artifact (scheduled runs only)
+        if: always() && github.event_name == 'schedule'
+        uses: actions/upload-artifact@v4
+        with:
+          name: perf-result-ttfi-all-cards
+          path: web/perf-result.json
+          if-no-files-found: warn
+          retention-days: 14
+
       - name: Upload TTFI artifacts
         if: always()
         uses: actions/upload-artifact@v4
@@ -92,3 +142,14 @@ jobs:
           if [ -f "e2e/test-results/ttfi-regression.md" ]; then
             cat e2e/test-results/ttfi-regression.md >> $GITHUB_STEP_SUMMARY
           fi
+
+  notify:
+    name: Notify on scheduled regression
+    needs: all-cards-ttfi
+    # Only file auto-issues on scheduled runs. PR failures already surface
+    # as red checks on the PR — no need to open a bug there.
+    if: failure() && github.event_name == 'schedule'
+    uses: ./.github/workflows/_perf-regression-issue.yml
+    with:
+      result-path: web/perf-result.json
+      signal: ttfi-all-cards

--- a/scripts/perf-regression-issue.mjs
+++ b/scripts/perf-regression-issue.mjs
@@ -1,0 +1,226 @@
+#!/usr/bin/env node
+/**
+ * perf-regression-issue.mjs
+ *
+ * Shared "the perf budget was blown, file/update an issue" notifier used by
+ * every perf workflow. The workflow drops a JSON result file at the path
+ * given in PERF_RESULT_JSON, then calls this script. We:
+ *
+ *   1. Read the JSON result.
+ *   2. Look for an existing open issue whose title starts with
+ *      "[perf-regression] <signal>".
+ *   3. If found, append a comment with the new numbers. Otherwise, file a
+ *      fresh issue with the standard labels.
+ *
+ * The body always includes: value vs budget, the run URL, the head SHA, and
+ * (when both SHAs are known) the list of merges between last-successful and
+ * current HEAD — that's the blame window.
+ *
+ * This script NEVER fails the build. The workflow that called it has already
+ * decided to fail; our job is to notify, not re-litigate.
+ */
+
+import { readFileSync, existsSync } from 'node:fs'
+import { spawnSync } from 'node:child_process'
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const ISSUE_TITLE_PREFIX = '[perf-regression]'
+const ISSUE_LABELS = ['kind/bug', 'priority/high', 'triage/accepted', 'perf-regression']
+// Upper bound on merge-window lines in the issue body. More than this and the
+// issue body gets noisy and less actionable.
+const MAX_MERGE_LOG_LINES = 50
+// Exit code we always return. Non-zero would mask the workflow's own failure.
+const EXIT_OK = 0
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function showHelpAndExit() {
+  process.stdout.write(
+    [
+      'Usage: node scripts/perf-regression-issue.mjs',
+      '',
+      'Reads PERF_RESULT_JSON (path to a perf result JSON file) and files or',
+      'updates a GitHub issue tagged "[perf-regression] <signal>".',
+      '',
+      'Required env:',
+      '  PERF_RESULT_JSON   path to the JSON result file written by the workflow',
+      '',
+      'Optional env:',
+      '  GH_REPO            override gh --repo (defaults to the current repo)',
+      '',
+      'Always exits 0.',
+      '',
+    ].join('\n'),
+  )
+  process.exit(EXIT_OK)
+}
+
+if (process.argv.includes('--help') || process.argv.includes('-h')) {
+  showHelpAndExit()
+}
+
+function sh(cmd, args, opts = {}) {
+  const res = spawnSync(cmd, args, { encoding: 'utf8', ...opts })
+  return { stdout: (res.stdout || '').trim(), stderr: (res.stderr || '').trim(), code: res.status ?? 0 }
+}
+
+function log(msg) {
+  process.stdout.write(`[perf-regression-issue] ${msg}\n`)
+}
+
+function readResult(resultPath) {
+  if (!existsSync(resultPath)) {
+    log(`PERF_RESULT_JSON=${resultPath} not found; nothing to do.`)
+    process.exit(EXIT_OK)
+  }
+  try {
+    const raw = readFileSync(resultPath, 'utf8')
+    return JSON.parse(raw)
+  } catch (err) {
+    log(`Failed to parse ${resultPath}: ${err?.message || err}`)
+    process.exit(EXIT_OK)
+  }
+}
+
+function buildMergeLog(lastSuccessfulSha, headSha) {
+  if (!lastSuccessfulSha || !headSha) return null
+  const range = `${lastSuccessfulSha}..${headSha}`
+  const { stdout, code } = sh('git', ['log', range, '--format=- %h %s'])
+  if (code !== 0 || !stdout) return null
+  const lines = stdout.split('\n').filter(Boolean)
+  if (lines.length === 0) return null
+  const truncated = lines.length > MAX_MERGE_LOG_LINES
+  const shown = lines.slice(0, MAX_MERGE_LOG_LINES).join('\n')
+  return truncated
+    ? `${shown}\n- ... (${lines.length - MAX_MERGE_LOG_LINES} more commits truncated)`
+    : shown
+}
+
+function buildBody(result) {
+  const { signal, displayName, value, budget, unit, context = {} } = result
+  const lines = []
+  lines.push(`## ${displayName} regressed`)
+  lines.push('')
+  lines.push(`**Signal:** \`${signal}\``)
+  lines.push(`**Measured:** ${value} ${unit}`)
+  lines.push(`**Budget:** ${budget} ${unit}`)
+  lines.push(`**Delta:** ${value - budget} ${unit} over budget`)
+  lines.push('')
+  if (context.runUrl) {
+    lines.push(`**Run:** ${context.runUrl}`)
+  } else if (context.runId) {
+    lines.push(`**Run ID:** ${context.runId}`)
+  }
+  if (context.headSha) {
+    lines.push(`**Head SHA:** \`${context.headSha}\``)
+  }
+  if (context.navigatedTo) {
+    lines.push(`**Navigated to:** \`${context.navigatedTo}\``)
+  }
+  lines.push('')
+
+  const mergeLog = buildMergeLog(context.lastSuccessfulSha, context.headSha)
+  if (mergeLog) {
+    lines.push(`### Merges since last successful run (\`${String(context.lastSuccessfulSha).slice(0, 7)}..${String(context.headSha).slice(0, 7)}\`)`)
+    lines.push('')
+    lines.push(mergeLog)
+    lines.push('')
+  }
+
+  lines.push('---')
+  lines.push('_Auto-filed by `scripts/perf-regression-issue.mjs`. Dedupes on title prefix._')
+  return lines.join('\n')
+}
+
+function findExistingIssue(signal, repoFlag) {
+  // gh issue list --search uses GitHub search syntax; the literal title prefix
+  // must be quoted so the hyphen/brackets don't get interpreted.
+  const titleNeedle = `${ISSUE_TITLE_PREFIX} ${signal}`
+  const args = [
+    'issue',
+    'list',
+    '--state',
+    'open',
+    '--search',
+    `"${titleNeedle}" in:title`,
+    '--json',
+    'number,title',
+    '--limit',
+    '20',
+  ]
+  if (repoFlag) args.push('--repo', repoFlag)
+  const { stdout, code, stderr } = sh('gh', args)
+  if (code !== 0) {
+    log(`gh issue list failed: ${stderr}`)
+    return null
+  }
+  try {
+    const items = JSON.parse(stdout || '[]')
+    const match = items.find((i) => typeof i.title === 'string' && i.title.startsWith(titleNeedle))
+    return match ? match.number : null
+  } catch (err) {
+    log(`Failed to parse gh issue list output: ${err?.message || err}`)
+    return null
+  }
+}
+
+function commentIssue(number, body, repoFlag) {
+  const args = ['issue', 'comment', String(number), '--body', body]
+  if (repoFlag) args.push('--repo', repoFlag)
+  const { code, stderr } = sh('gh', args)
+  if (code !== 0) log(`gh issue comment failed: ${stderr}`)
+  else log(`Commented on issue #${number}`)
+}
+
+function createIssue(signal, displayName, body, repoFlag) {
+  const title = `${ISSUE_TITLE_PREFIX} ${signal}: ${displayName}`
+  const args = [
+    'issue',
+    'create',
+    '--title',
+    title,
+    '--body',
+    body,
+    '--label',
+    ISSUE_LABELS.join(','),
+  ]
+  if (repoFlag) args.push('--repo', repoFlag)
+  const { stdout, code, stderr } = sh('gh', args)
+  if (code !== 0) log(`gh issue create failed: ${stderr}`)
+  else log(`Created issue: ${stdout}`)
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+function main() {
+  const resultPath = process.env.PERF_RESULT_JSON
+  if (!resultPath) {
+    log('PERF_RESULT_JSON not set; nothing to do.')
+    process.exit(EXIT_OK)
+  }
+
+  const result = readResult(resultPath)
+  if (!result || !result.signal || !result.displayName) {
+    log('Result JSON missing required fields (signal, displayName); skipping.')
+    process.exit(EXIT_OK)
+  }
+
+  const repoFlag = process.env.GH_REPO || ''
+  const body = buildBody(result)
+  const existing = findExistingIssue(result.signal, repoFlag)
+  if (existing) {
+    commentIssue(existing, body, repoFlag)
+  } else {
+    createIssue(result.signal, result.displayName, body, repoFlag)
+  }
+  process.exit(EXIT_OK)
+}
+
+main()

--- a/web/e2e/perf/constants.ts
+++ b/web/e2e/perf/constants.ts
@@ -1,0 +1,27 @@
+/**
+ * Shared constants for perf regression tests.
+ *
+ * Any named literal used by a perf spec (budgets, settle times, signal slugs)
+ * belongs here so the assertions, the JSON result file, and the reusable
+ * auto-issue workflow all agree on the same values.
+ */
+
+// Max number of React commits allowed during a SPA navigation. 50 is a
+// generous ceiling — a healthy route change should be well under 20. The
+// current (buggy) count is ~461 (tracked by #6149); this is the gate that
+// flips red when the regression reappears.
+export const PERF_BUDGET_NAVIGATION_COMMITS = 50
+
+// How long to let the UI settle after a navigation before we snapshot
+// the commit counter. 2s is enough for cached dashboards + router transitions
+// without turning the test into a long-poll.
+export const NAVIGATION_SETTLE_MS = 2_000
+
+// Signal slugs — must be unique across every perf workflow. These are used
+// verbatim in the perf-result.json file and as the `[perf-regression] <slug>`
+// de-dupe key in the auto-issue script.
+export const PERF_SIGNAL_REACT_COMMITS_NAV = 'react-commits-navigation'
+
+// Where specs drop their result JSON. The reusable workflow reads this exact
+// path via the PERF_RESULT_JSON env var.
+export const PERF_RESULT_PATH = 'web/perf-result.json'

--- a/web/e2e/perf/react-commits.spec.ts
+++ b/web/e2e/perf/react-commits.spec.ts
@@ -1,0 +1,122 @@
+import { test, expect } from '@playwright/test'
+import * as fs from 'node:fs'
+import * as path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import {
+  PERF_BUDGET_NAVIGATION_COMMITS,
+  NAVIGATION_SETTLE_MS,
+  PERF_SIGNAL_REACT_COMMITS_NAV,
+} from './constants'
+
+/**
+ * React-commits-per-navigation perf gate.
+ *
+ * Counts how many React commits happen during a single SPA navigation by
+ * installing a fake `__REACT_DEVTOOLS_GLOBAL_HOOK__` BEFORE the app bundle
+ * loads. The real DevTools hook is gated on non-prod (dev / preview with
+ * __DEV__), so this file runs against the vite dev server via PERF_DEV=1
+ * in the workflow.
+ *
+ * Writes a perf-result.json that the reusable auto-issue workflow picks up.
+ *
+ * See #6149 for the regression this gate exists to catch.
+ */
+
+// Where the landing route settles. '/' bounces to the default dashboard.
+const HOME_ROUTE = '/'
+// Target route for the navigation under measurement.
+const NAV_TARGET_ROUTE = '/clusters'
+
+// The init script uses a named global so we can read it later from the page.
+const COMMIT_COUNTER_KEY = '__perfCommitCount'
+
+// Resolve the repo root so we can write perf-result.json at a stable path
+// regardless of where playwright was launched from.
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const WEB_DIR = path.resolve(__dirname, '../..')
+const REPO_ROOT = path.resolve(WEB_DIR, '..')
+const RESULT_FILE = path.join(REPO_ROOT, 'web', 'perf-result.json')
+
+interface PerfResult {
+  signal: string
+  displayName: string
+  value: number
+  budget: number
+  unit: string
+  context: Record<string, string | number | undefined>
+}
+
+let recordedCommits = -1
+
+test.afterAll(() => {
+  if (recordedCommits < 0) {
+    // Test never ran far enough to record — still write a result so the
+    // workflow can surface the failure path.
+    recordedCommits = Number.MAX_SAFE_INTEGER
+  }
+  const result: PerfResult = {
+    signal: PERF_SIGNAL_REACT_COMMITS_NAV,
+    displayName: 'Dashboard navigation React commits',
+    value: recordedCommits,
+    budget: PERF_BUDGET_NAVIGATION_COMMITS,
+    unit: 'commits',
+    context: {
+      navigatedTo: NAV_TARGET_ROUTE,
+      runId: process.env.GITHUB_RUN_ID,
+      runUrl:
+        process.env.GITHUB_SERVER_URL && process.env.GITHUB_REPOSITORY && process.env.GITHUB_RUN_ID
+          ? `${process.env.GITHUB_SERVER_URL}/${process.env.GITHUB_REPOSITORY}/actions/runs/${process.env.GITHUB_RUN_ID}`
+          : undefined,
+      headSha: process.env.GITHUB_SHA,
+      lastSuccessfulSha: process.env.LAST_SUCCESSFUL_SHA,
+    },
+  }
+  fs.mkdirSync(path.dirname(RESULT_FILE), { recursive: true })
+  fs.writeFileSync(RESULT_FILE, JSON.stringify(result, null, 2))
+})
+
+test('react commits per navigation stays under budget', async ({ page }) => {
+  // Install the fake DevTools hook BEFORE any app script runs. React 19
+  // calls `onCommitFiberRoot` on every commit when the hook is present.
+  await page.addInitScript(
+    ({ counterKey }) => {
+      const w = window as unknown as Record<string, unknown>
+      w[counterKey] = 0
+      // Minimal shape React looks for. supportsFiber must be true; the
+      // renderer id returned from inject is unused here.
+      const hook = {
+        supportsFiber: true,
+        renderers: new Map(),
+        onCommitFiberRoot: () => {
+          w[counterKey] = (w[counterKey] as number) + 1
+        },
+        onCommitFiberUnmount: () => {},
+        inject: () => 1,
+      }
+      ;(w as Record<string, unknown>).__REACT_DEVTOOLS_GLOBAL_HOOK__ = hook
+    },
+    { counterKey: COMMIT_COUNTER_KEY },
+  )
+
+  await page.goto(HOME_ROUTE)
+  await page.waitForTimeout(NAVIGATION_SETTLE_MS)
+
+  // Reset counter — we only care about commits caused by the navigation.
+  await page.evaluate((key) => {
+    ;(window as unknown as Record<string, number>)[key] = 0
+  }, COMMIT_COUNTER_KEY)
+
+  await page.goto(NAV_TARGET_ROUTE)
+  await page.waitForTimeout(NAVIGATION_SETTLE_MS)
+
+  const count = await page.evaluate(
+    (key) => (window as unknown as Record<string, number>)[key] ?? -1,
+    COMMIT_COUNTER_KEY,
+  )
+  recordedCommits = count
+
+  expect(
+    count,
+    `React commits during navigation (${count}) exceeded budget ${PERF_BUDGET_NAVIGATION_COMMITS}`,
+  ).toBeLessThanOrEqual(PERF_BUDGET_NAVIGATION_COMMITS)
+})


### PR DESCRIPTION
## Summary

One reusable perf-regression auto-issue mechanism, plus three signals wired up to it on launch. Any future perf signal just drops a JSON file and calls the reusable workflow — no more duplicating issue-creation logic per workflow.

## The scaffold

- **\`scripts/perf-regression-issue.mjs\`** — reads \`PERF_RESULT_JSON\`, dedupes by \`[perf-regression] <signal>\` title prefix, either files a fresh issue or comments on the existing one with value vs budget, run URL, head SHA, and the list of merges between \`lastSuccessfulSha..headSha\` (the blame window). Always exits 0 — it's a notifier, the workflow already decided to fail.
- **\`.github/workflows/_perf-regression-issue.yml\`** — \`workflow_call\` reusable job. Callers upload their \`web/perf-result.json\` as an artifact named \`perf-result-<signal>\`, then reference this workflow with \`uses:\` under an \`if: failure()\` job. Permissions: \`contents: read, issues: write\`.

JSON schema:

\`\`\`json
{
  "signal": "react-commits-navigation",
  "displayName": "Dashboard navigation React commits",
  "value": 461,
  "budget": 50,
  "unit": "commits",
  "context": { "runId": "...", "runUrl": "...", "headSha": "...", "lastSuccessfulSha": "..." }
}
\`\`\`

## Signals plugged in

1. **React commits per navigation** (\`perf-react-commits.yml\`, every 2h) — Playwright spec installs a fake \`__REACT_DEVTOOLS_GLOBAL_HOOK__\` via \`addInitScript\` BEFORE the app bundle loads (React DevTools gates on non-prod, so it runs against \`npm run dev\` via \`PERF_DEV=1\`). Navigates \`/\` → \`/clusters\`, resets the counter between, and gates on \`PERF_BUDGET_NAVIGATION_COMMITS = 50\` (centralized in \`web/e2e/perf/constants.ts\`).
2. **Bundle size** (\`perf-bundle-size.yml\`, every 2h) — builds the prod bundle, sums gzipped bytes of \`dist/assets/*.js\`, gates against \`PERF_BUDGET_BUNDLE_GZIP_BYTES = 3,225,000\` (~3.08 MB). Baseline at branch point was 2,930,697 bytes; 10% headroom so normal feature work doesn't flap, but a real bloat (heavy dep, missed code-split) trips it.
3. **Lighthouse TTFI** (\`perf-ttfi.yml\`, extended) — added \`schedule: cron '15 */2 * * *'\` alongside the existing PR trigger, plus a \`notify\` job that fires **only** on \`failure() && github.event_name == 'schedule'\`. PR-time behavior is unchanged — PR failures already surface as red checks on the PR, no need to file issues there.

## Budget (runner minutes)

~360 runner-min/month per signal × 3 signals ≈ ~1100 min/month, well under the 2000-min free tier.

## Expected first-run behavior

The first cron runs of \`perf-react-commits\` will fail because of the open #6149 regression (~461 commits vs the 50 budget). That's the point — they'll auto-file \`[perf-regression] react-commits-navigation\` via the new scaffold and stay red until #6149 lands. Bundle-size and TTFI start green.

## Test plan

- [x] All four YAML files parse cleanly (\`yaml.safe_load_all\`)
- [x] \`node scripts/perf-regression-issue.mjs --help\` runs without syntax errors
- [x] End-to-end smoke test of the script with a stubbed \`gh\` on PATH — it finds the dedupe search result, builds the body, and calls \`gh issue create\`
- [x] \`npx tsc --noEmit\` clean for \`web/e2e/perf/react-commits.spec.ts\` and \`constants.ts\`
- [x] \`npm run build\` still passes
- [ ] First scheduled run after merge (will intentionally fail due to #6149 and exercise the auto-issue path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)