### PR TITLE
perf(dashboard): memoize context provider values to stop re-render cascade

### DIFF
--- a/web/src/components/cards/CardWrapper.tsx
+++ b/web/src/components/cards/CardWrapper.tsx
@@ -852,10 +852,19 @@ export function CardWrapper({
   void title
   void setLocalMessages
 
+  // #6149 — Memoize inline provider values so every CardWrapper re-render
+  // (there are dozens on every dashboard) does not invalidate the
+  // CardExpandedContext / ForceLiveContext consumers inside the card.
+  const cardExpandedValue = useMemo(
+    () => ({ isExpanded, containerSize }),
+    [isExpanded, containerSize]
+  )
+  const forceLiveValue = useMemo(() => !!forceLive, [forceLive])
+
   return (
     <CardTypeContext.Provider value={cardType}>
-    <CardExpandedContext.Provider value={{ isExpanded, containerSize }}>
-      <ForceLiveContext.Provider value={!!forceLive}>
+    <CardExpandedContext.Provider value={cardExpandedValue}>
+      <ForceLiveContext.Provider value={forceLiveValue}>
       <CardDataReportContext.Provider value={reportCtx}>
         <>
           {/* Outer wrapper for demo corner brackets (outside card border) */}

--- a/web/src/components/ui/Toast.tsx
+++ b/web/src/components/ui/Toast.tsx
@@ -1,4 +1,4 @@
-import { createContext, useContext, useState, useEffect, useRef, ReactNode } from 'react'
+import { createContext, useContext, useState, useEffect, useRef, useCallback, useMemo, ReactNode } from 'react'
 import { X, Check, AlertTriangle, Info } from 'lucide-react'
 import { cn } from '../../lib/cn'
 import { Button } from './Button'
@@ -30,7 +30,9 @@ export function ToastProvider({ children }: { children: ReactNode }) {
   const timeoutsRef = useRef<Map<string, number>>(new Map())
 
   const toastCounter = useRef(0)
-  const showToast = (message: string, type: ToastType = 'success') => {
+  // Auto-dismiss duration for transient toast notifications
+  const TOAST_AUTO_DISMISS_MS = 3_000
+  const showToast = useCallback((message: string, type: ToastType = 'success') => {
     const id = `toast-${Date.now()}-${++toastCounter.current}`
     setToasts((prev) => {
       // Deduplicate: skip if an identical message+type is already visible
@@ -38,17 +40,17 @@ export function ToastProvider({ children }: { children: ReactNode }) {
       return [...prev, { id, message, type }]
     })
 
-    // Auto-remove after 3 seconds (timeout is harmless if toast was deduplicated)
+    // Auto-remove after TOAST_AUTO_DISMISS_MS (timeout is harmless if toast was deduplicated)
     const timeoutId = window.setTimeout(() => {
       setToasts((prev) => prev.filter((t) => t.id !== id))
       if (timeoutsRef.current.has(id)) {
         timeoutsRef.current.delete(id)
       }
-    }, 3000)
+    }, TOAST_AUTO_DISMISS_MS)
     timeoutsRef.current.set(id, timeoutId)
-  }
+  }, [])
 
-  const removeToast = (id: string) => {
+  const removeToast = useCallback((id: string) => {
     setToasts((prev) => prev.filter((t) => t.id !== id))
     // Clear timeout if manually removed
     const timeoutId = timeoutsRef.current.get(id)
@@ -56,7 +58,7 @@ export function ToastProvider({ children }: { children: ReactNode }) {
       clearTimeout(timeoutId)
       timeoutsRef.current.delete(id)
     }
-  }
+  }, [])
 
   // Cleanup all timeouts on unmount
   useEffect(() => {
@@ -67,8 +69,12 @@ export function ToastProvider({ children }: { children: ReactNode }) {
     }
   }, [])
 
+  // #6149 — Stable context value so ToastProvider rendering (e.g. when
+  // toasts change) does not force a re-render of every useToast() consumer.
+  const contextValue = useMemo(() => ({ showToast }), [showToast])
+
   return (
-    <ToastContext.Provider value={{ showToast }}>
+    <ToastContext.Provider value={contextValue}>
       {children}
       <ToastContainer toasts={toasts} onRemove={removeToast} />
     </ToastContext.Provider>

--- a/web/src/hooks/useDrillDown.tsx
+++ b/web/src/hooks/useDrillDown.tsx
@@ -1,4 +1,4 @@
-import { createContext, useContext, useState, ReactNode } from 'react'
+import { createContext, useContext, useState, useCallback, useMemo, ReactNode } from 'react'
 import { emitDrillDownOpened, emitDrillDownClosed } from '../lib/analytics'
 
 // Types for drill-down navigation
@@ -96,22 +96,22 @@ export function DrillDownProvider({ children }: { children: ReactNode }) {
     stack: [],
     currentView: null })
 
-  const open = (view: DrillDownView) => {
+  const open = useCallback((view: DrillDownView) => {
     setState({
       isOpen: true,
       stack: [view],
       currentView: view })
     emitDrillDownOpened(view.type)
-  }
+  }, [])
 
-  const push = (view: DrillDownView) => {
+  const push = useCallback((view: DrillDownView) => {
     setState(prev => ({
       ...prev,
       stack: [...prev.stack, view],
       currentView: view }))
-  }
+  }, [])
 
-  const pop = () => {
+  const pop = useCallback(() => {
     setState(prev => {
       if (prev.stack.length <= 1) {
         return { isOpen: false, stack: [], currentView: null }
@@ -122,9 +122,9 @@ export function DrillDownProvider({ children }: { children: ReactNode }) {
         stack: newStack,
         currentView: newStack[newStack.length - 1] }
     })
-  }
+  }, [])
 
-  const goTo = (index: number) => {
+  const goTo = useCallback((index: number) => {
     setState(prev => {
       if (index < 0 || index >= prev.stack.length) return prev
       const newStack = prev.stack.slice(0, index + 1)
@@ -133,18 +133,18 @@ export function DrillDownProvider({ children }: { children: ReactNode }) {
         stack: newStack,
         currentView: newStack[newStack.length - 1] }
     })
-  }
+  }, [])
 
-  const close = () => {
+  const close = useCallback(() => {
     setState(prev => {
       if (prev.currentView) {
         emitDrillDownClosed(prev.currentView.type, prev.stack.length)
       }
       return { isOpen: false, stack: [], currentView: null }
     })
-  }
+  }, [])
 
-  const replace = (view: DrillDownView) => {
+  const replace = useCallback((view: DrillDownView) => {
     setState(prev => {
       const newStack = [...prev.stack.slice(0, -1), view]
       return {
@@ -152,10 +152,17 @@ export function DrillDownProvider({ children }: { children: ReactNode }) {
         stack: newStack,
         currentView: view }
     })
-  }
+  }, [])
+
+  // #6149 — Memoize the provider value so consumers don't re-render every
+  // time DrillDownProvider itself re-renders for an unrelated reason.
+  const contextValue = useMemo(
+    () => ({ state, open, push, pop, goTo, close, replace }),
+    [state, open, push, pop, goTo, close, replace]
+  )
 
   return (
-    <DrillDownContext.Provider value={{ state, open, push, pop, goTo, close, replace }}>
+    <DrillDownContext.Provider value={contextValue}>
       {children}
     </DrillDownContext.Provider>
   )

--- a/web/src/lib/auth.tsx
+++ b/web/src/lib/auth.tsx
@@ -1,4 +1,4 @@
-import { createContext, use, useState, useEffect, useCallback, useRef, ReactNode } from 'react'
+import { createContext, use, useState, useEffect, useCallback, useMemo, useRef, ReactNode } from 'react'
 import { checkOAuthConfigured, checkOAuthConfiguredWithRetry } from './api'
 import { dashboardSync } from './dashboards/dashboardSync'
 import { clearPermissionsCache } from '../hooks/usePermissions'
@@ -177,7 +177,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     return !hasToken || (hasToken && !hasCachedUser)
   })
 
-  const logout = () => {
+  const logout = useCallback(() => {
     emitLogout()
 
     // Invalidate the server-side session before clearing client state (#4751).
@@ -223,7 +223,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     clearClusterCacheOnLogout()
     // Disconnect presence WebSocket to stop transmitting stale auth tokens (#4936)
     disconnectPresence()
-  }
+  }, [])
 
   const setDemoMode = useCallback(() => {
     // If user explicitly disabled demo mode, respect their choice.
@@ -253,7 +253,6 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     // reflect demo state immediately — without this, the in-cluster banner won't
     // render because Layout's auto-demo-enable effect skips when isInClusterMode.
     setGlobalDemoMode(true)
-  // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 
   const refreshUser = useCallback(async (overrideToken?: string) => {
@@ -355,7 +354,25 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       if (!meResponse.ok) throw new Error(`/api/me returned ${meResponse.status}`)
       const userData = await meResponse.json().catch(() => null) as User | null
       if (!userData) throw new Error('Invalid JSON from /api/me')
-      setUser(userData)
+      // #6149 — Avoid triggering an AuthProvider re-render cascade when the
+      // background /api/me poll returns an identical user. Shallow-compare
+      // the fields that actually matter for downstream consumers.
+      setUser(prev => {
+        if (
+          prev &&
+          prev.id === userData.id &&
+          prev.github_id === userData.github_id &&
+          prev.github_login === userData.github_login &&
+          prev.email === userData.email &&
+          prev.avatar_url === userData.avatar_url &&
+          prev.role === userData.role &&
+          prev.onboarded === userData.onboarded &&
+          prev.slack_id === userData.slack_id
+        ) {
+          return prev
+        }
+        return userData
+      })
       cacheUser(userData)
       // #6067 — record when the cache was last validated so we can bound
       // how long it's trusted if the backend later becomes unreachable.
@@ -381,7 +398,16 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       const cacheAge = validatedAt ? Date.now() - validatedAt : Number.POSITIVE_INFINITY
       if (cachedUser && cacheAge <= MAX_CACHED_USER_AGE_MS) {
         console.warn('Backend unreachable, using cached user data (age ms):', cacheAge)
-        setUser(cachedUser)
+        // #6149 — Only call setUser when the cached user differs from
+        // current state. setUser with a brand-new object reference would
+        // otherwise trigger a provider-wide re-render on every background
+        // revalidate tick even when nothing changed.
+        setUser(prev => {
+          if (prev && prev.id === cachedUser.id && prev.github_login === cachedUser.github_login) {
+            return prev
+          }
+          return cachedUser
+        })
         setAnalyticsUserId(cachedUser.id)
         setAnalyticsUserProperties({ auth_mode: 'github-oauth' })
         return
@@ -397,7 +423,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     }
   }, [setDemoMode])
 
-  const login = async () => {
+  const login = useCallback(async () => {
     // Demo mode enabled via:
     // 1. Explicit environment variable VITE_DEMO_MODE=true
     // 2. Netlify deploy previews (deploy-preview-* hostnames) - safe because these are ephemeral test environments
@@ -430,9 +456,9 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     emitLogin('github-oauth')
     emitConversionStep(2, 'login', { method: 'github-oauth' })
     window.location.href = '/auth/github'
-  }
+  }, [setDemoMode])
 
-  const setToken = (newToken: string, onboarded: boolean) => {
+  const setToken = useCallback((newToken: string, onboarded: boolean) => {
     localStorage.setItem(STORAGE_KEY_TOKEN, newToken)
     setTokenState(newToken)
     // Clear stale cached user — refreshUser() will fetch and cache real data.
@@ -440,7 +466,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     // user persists in localStorage and the profile shows "No email set".
     cacheUser(null)
     setUser({ id: '', github_id: '', github_login: '', onboarded } as User)
-  }
+  }, [])
 
   // Periodically check if the JWT is nearing expiry and show a warning banner.
   // When the user clicks "Refresh Now", silently call /auth/refresh for a new token.
@@ -495,11 +521,11 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       })
     }
 
-    // Check once immediately, then every 60 seconds
+    // Check once immediately, then every EXPIRY_CHECK_INTERVAL_MS
     checkExpiry()
     const intervalId = setInterval(checkExpiry, EXPIRY_CHECK_INTERVAL_MS)
     return () => clearInterval(intervalId)
-  }, [token])
+  }, [token, logout])
 
   // Listen for token updates from silentRefresh() (dispatched via StorageEvent)
   // so the AuthProvider state stays in sync without a full page reload.
@@ -586,18 +612,26 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     return !isJWTExpired(token)
   })()
 
+  // #6149 — Memoize the context value so the AuthProvider doesn't cascade
+  // a re-render across EVERY consumer (dashboard, cards, layout, etc.) on
+  // every render of AuthProvider itself. Without this, the background
+  // BACKEND_REVALIDATE_INTERVAL_MS / EXPIRY_CHECK_INTERVAL_MS timers produce
+  // hundreds of spurious React commits during normal dashboard navigation.
+  const contextValue = useMemo<AuthContextType>(
+    () => ({
+      user,
+      token,
+      isAuthenticated,
+      isLoading,
+      login,
+      logout,
+      setToken,
+      refreshUser }),
+    [user, token, isAuthenticated, isLoading, login, logout, setToken, refreshUser]
+  )
+
   return (
-    <AuthContext.Provider
-      value={{
-        user,
-        token,
-        isAuthenticated,
-        isLoading,
-        login,
-        logout,
-        setToken,
-        refreshUser }}
-    >
+    <AuthContext.Provider value={contextValue}>
       {children}
     </AuthContext.Provider>
   )

--- a/web/src/lib/cardEvents.tsx
+++ b/web/src/lib/cardEvents.tsx
@@ -1,4 +1,4 @@
-import { createContext, useContext, useRef, type ReactNode } from 'react'
+import { createContext, useContext, useRef, useCallback, useMemo, type ReactNode } from 'react'
 
 // ============================================================================
 // Card Event Types
@@ -73,7 +73,7 @@ const CardEventContext = createContext<CardEventBus | null>(null)
 export function CardEventProvider({ children }: { children: ReactNode }) {
   const subscribersRef = useRef<Map<string, Set<EventCallback<CardEventType>>>>(new Map())
 
-  const publish = (event: CardEvent) => {
+  const publish = useCallback((event: CardEvent) => {
     const callbacks = subscribersRef.current.get(event.type)
     if (!callbacks) return
     for (const cb of callbacks) {
@@ -83,9 +83,9 @@ export function CardEventProvider({ children }: { children: ReactNode }) {
         console.error(`[CardEvents] Error in ${event.type} handler:`, err)
       }
     }
-  }
+  }, [])
 
-  const subscribe = <T extends CardEventType>(
+  const subscribe = useCallback(<T extends CardEventType>(
     type: T,
     callback: EventCallback<T>,
   ): (() => void) => {
@@ -101,10 +101,15 @@ export function CardEventProvider({ children }: { children: ReactNode }) {
         subscribersRef.current.delete(type)
       }
     }
-  }
+  }, [])
+
+  // #6149 — Stable context value — both publish and subscribe are now
+  // stable refs, so downstream useCardEvents() consumers no longer re-render
+  // on every CardEventProvider render.
+  const contextValue = useMemo(() => ({ publish, subscribe }), [publish, subscribe])
 
   return (
-    <CardEventContext.Provider value={{ publish, subscribe }}>
+    <CardEventContext.Provider value={contextValue}>
       {children}
     </CardEventContext.Provider>
   )


### PR DESCRIPTION
Fixes #6149.

## Problem

A single dashboard-to-dashboard navigation was producing **461 React commits** in the profiler (expected ~5). The flamegraph showed deeply-nested Context Providers re-rendering every `SortableCard` / `CardWrapper` on every tick of a background timer.

## Root cause

Several top-level Context Providers passed fresh object literals as the `value=` prop on every render:

- `AuthProvider` — the smoking gun. #6094 added `BACKEND_REVALIDATE_INTERVAL_MS = 30_000` and there is also an `EXPIRY_CHECK_INTERVAL_MS = 60_000` JWT expiry check. Each tick calls `setUser` / `setTokenState`, which re-renders `AuthProvider`, which constructs a brand-new `{ user, token, isAuthenticated, ... }` object. Since background `/api/me` revalidation returns the same user every time, none of those re-renders produce any visible change — but every consumer re-renders anyway.
- `MissionProvider`, `ToastProvider`, `DrillDownProvider`, `CardEventProvider` — all inline object literals wrapping the entire app.
- `CardExpandedContext` / `ForceLiveContext` inside `CardWrapper` — fresh inline objects per card per render.

## Changes

- `lib/auth.tsx`:
  - Wrap provider value in `useMemo`, stabilize `login` / `logout` / `setToken` with `useCallback`.
  - In `refreshUser`, shallow-compare the `/api/me` payload against current state before calling `setUser` — silences the 30s background revalidation cascade entirely when nothing changed.
  - Same bail-out for the stale-cache recovery path.
  - Remove a stale `eslint-disable-next-line` and add `logout` to the expiry `useEffect` deps now that its identity is stable.
- `hooks/useDrillDown.tsx`: wrap all actions in `useCallback`, memoize provider value.
- `components/ui/Toast.tsx`: wrap `showToast` / `removeToast` in `useCallback`, memoize provider value, promote hardcoded `3000` to `TOAST_AUTO_DISMISS_MS`.
- `lib/cardEvents.tsx`: wrap `publish` / `subscribe` in `useCallback`, memoize provider value.
- `components/cards/CardWrapper.tsx`: memoize `CardExpandedContext` and `ForceLiveContext` provider values.

`MissionProvider` was intentionally **not** touched in this PR — it has ~25 inline callbacks, a real fix requires `useCallback` on all of them and would significantly expand the diff. The AuthProvider fix alone should eliminate the dominant cascade.

## Verification

- `npm run build` — clean
- `npm run lint` — no new errors/warnings in changed files
- `vitest` auth + Toast + DrillDown + Login + AuthCallback: **161/161 pass**
- `vitest` card suite: **884/884 pass**
- Manual: read each changed provider and confirmed the `value` now has stable identity across re-renders that don't change underlying state.

## Expected impact

The 461 commits from Aarush's profiler flamegraph should drop to roughly ~5 for a dashboard-to-dashboard navigation, and the 30s / 60s background auth timers will no longer cause a tree-wide re-render when nothing has changed.