### PR TITLE
fix(perf): grant issues:write so reusable notify workflow can start

### DIFF
--- a/.github/workflows/perf-bundle-size.yml
+++ b/.github/workflows/perf-bundle-size.yml
@@ -16,7 +16,10 @@ on:
     - cron: '15 */2 * * *'
   workflow_dispatch: {}
 
-permissions: read-all
+permissions:
+  contents: read
+  actions: read
+  issues: write
 
 concurrency:
   group: perf-bundle-size

--- a/.github/workflows/perf-react-commits.yml
+++ b/.github/workflows/perf-react-commits.yml
@@ -15,7 +15,10 @@ on:
     - cron: '15 */2 * * *'
   workflow_dispatch: {}
 
-permissions: read-all
+permissions:
+  contents: read
+  actions: read
+  issues: write
 
 concurrency:
   group: perf-react-commits

--- a/.github/workflows/perf-ttfi.yml
+++ b/.github/workflows/perf-ttfi.yml
@@ -14,8 +14,14 @@ on:
     # `[perf-regression] ttfi-all-cards` issue via the reusable workflow.
     - cron: '15 */2 * * *'
 
-# Least-privilege: read-only by default; jobs declare write scopes individually
-permissions: read-all
+# Least-privilege: read + issues:write. issues:write is required at the
+# workflow level because the `notify` job calls the reusable
+# `_perf-regression-issue.yml` workflow, and reusable workflows cannot
+# receive more permissions than their caller.
+permissions:
+  contents: read
+  actions: read
+  issues: write
 
 env:
   CI: true


### PR DESCRIPTION
Fix startup_failure on all 3 perf workflows. Reusable _perf-regression-issue.yml needs issues:write; caller had read-all. See runs 24251302884, 24251307910, 24251312622.