### PR TITLE
fix(services): endpoint count, LB pending IP, multi-cluster zero aggregation (#6150, #6153, #6154)

### DIFF
--- a/pkg/api/handlers/mcp_workloads.go
+++ b/pkg/api/handlers/mcp_workloads.go
@@ -331,6 +331,17 @@ func (h *MCPHandlers) GetServices(c *fiber.Ctx) error {
 			var wg sync.WaitGroup
 			var mu sync.Mutex
 			allServices := make([]k8s.Service, 0)
+			// clusterCounts represents every cluster we contacted, even
+			// those that returned zero services. Issue #6154: clusters
+			// with zero services used to be completely omitted from the
+			// aggregation response, which caused the frontend to think
+			// the cluster did not exist rather than displaying "0
+			// services". We now always include the cluster with its
+			// service count.
+			clusterCounts := make(map[string]int, len(clusters))
+			for _, cl := range clusters {
+				clusterCounts[cl.Name] = 0
+			}
 			clusterTimeout := mcpDefaultTimeout
 
 			clusterCtx, clusterCancel := context.WithCancel(c.Context())
@@ -344,16 +355,41 @@ func (h *MCPHandlers) GetServices(c *fiber.Ctx) error {
 					defer cancel()
 
 					services, err := h.k8sClient.GetServices(ctx, clusterName, namespace)
-					if err == nil && len(services) > 0 {
-						mu.Lock()
-						allServices = append(allServices, services...)
-						mu.Unlock()
+					if err != nil {
+						return
 					}
+					mu.Lock()
+					// Record the per-cluster count even when zero so
+					// the response always represents every cluster.
+					clusterCounts[clusterName] = len(services)
+					if len(services) > 0 {
+						allServices = append(allServices, services...)
+					}
+					mu.Unlock()
 				}(cl.Name)
 			}
 
 			waitWithDeadline(&wg, clusterCancel, maxResponseDeadline)
-			return c.JSON(fiber.Map{"services": allServices, "source": "k8s"})
+
+			// Serialize per-cluster counts as a stable slice so the
+			// frontend can iterate it without worrying about map
+			// ordering.
+			type clusterServiceCount struct {
+				Cluster  string `json:"cluster"`
+				Services int    `json:"services"`
+			}
+			counts := make([]clusterServiceCount, 0, len(clusters))
+			for _, cl := range clusters {
+				counts = append(counts, clusterServiceCount{
+					Cluster:  cl.Name,
+					Services: clusterCounts[cl.Name],
+				})
+			}
+			return c.JSON(fiber.Map{
+				"services":      allServices,
+				"clusterCounts": counts,
+				"source":        "k8s",
+			})
 		}
 
 		ctx, cancel := context.WithTimeout(c.Context(), mcpDefaultTimeout)

--- a/pkg/k8s/client.go
+++ b/pkg/k8s/client.go
@@ -414,10 +414,34 @@ type Service struct {
 	ClusterIP   string            `json:"clusterIP,omitempty"`
 	ExternalIP  string            `json:"externalIP,omitempty"`
 	Ports       []string          `json:"ports,omitempty"`
+	// Endpoints is the number of ready backend addresses summed across all
+	// subsets of the matching core/v1 Endpoints object (i.e. actual pod
+	// endpoints backing the service, NOT the number of services themselves).
+	// Issue #6150: the Services dashboard stat should sum this value across
+	// services instead of counting services.
+	Endpoints int `json:"endpoints"`
+	// LBStatus describes the provisioning state of a LoadBalancer service.
+	// For non-LoadBalancer services this is the empty string. For a
+	// LoadBalancer service this is either LBStatusReady (ingress IP/hostname
+	// has been assigned) or LBStatusProvisioning (cloud provider has not yet
+	// provisioned an address). Issue #6153.
+	LBStatus    string            `json:"lbStatus,omitempty"`
 	Age         string            `json:"age,omitempty"`
 	Labels      map[string]string `json:"labels,omitempty"`
 	Annotations map[string]string `json:"annotations,omitempty"`
 }
+
+// LoadBalancer provisioning status values. Defined as exported constants so
+// the frontend/backend agree on the wire format and there are no magic
+// strings sprinkled through the code.
+const (
+	// LBStatusProvisioning means the service is type=LoadBalancer but the
+	// cloud provider has not yet populated status.loadBalancer.ingress.
+	LBStatusProvisioning = "Provisioning"
+	// LBStatusReady means status.loadBalancer.ingress has at least one
+	// IP or hostname populated.
+	LBStatusReady = "Ready"
+)
 
 // Job represents a Kubernetes job
 type Job struct {

--- a/pkg/k8s/client_resources.go
+++ b/pkg/k8s/client_resources.go
@@ -714,6 +714,22 @@ func (m *MultiClusterClient) GetServices(ctx context.Context, contextName, names
 		return nil, err
 	}
 
+	// Fetch the corresponding core/v1 Endpoints objects so we can report the
+	// real number of ready addresses backing each service. We list in the
+	// same namespace scope as the Services list call so the result set is
+	// comparable. If this call fails we still return services with
+	// Endpoints=0 rather than failing the whole request (issue #6150).
+	endpointReadyCounts := make(map[string]int) // key: "<namespace>/<name>"
+	if epList, epErr := client.CoreV1().Endpoints(namespace).List(ctx, metav1.ListOptions{}); epErr == nil {
+		for _, ep := range epList.Items {
+			ready := 0
+			for _, subset := range ep.Subsets {
+				ready += len(subset.Addresses)
+			}
+			endpointReadyCounts[ep.Namespace+"/"+ep.Name] = ready
+		}
+	}
+
 	var result []Service
 	for _, svc := range services.Items {
 		// Build ports list
@@ -726,8 +742,14 @@ func (m *MultiClusterClient) GetServices(ctx context.Context, contextName, names
 			ports = append(ports, portStr)
 		}
 
-		// Get external IP
+		// Resolve external IP and LoadBalancer provisioning status.
+		// For LoadBalancer services, if status.loadBalancer.ingress is
+		// empty we mark the service as Provisioning and leave ExternalIP
+		// blank (issue #6153). status.loadBalancer.ingress.ip takes
+		// precedence over hostname, and spec.externalIPs (statically
+		// assigned) overrides both.
 		externalIP := ""
+		lbStatus := ""
 		if len(svc.Status.LoadBalancer.Ingress) > 0 {
 			if svc.Status.LoadBalancer.Ingress[0].IP != "" {
 				externalIP = svc.Status.LoadBalancer.Ingress[0].IP
@@ -737,6 +759,13 @@ func (m *MultiClusterClient) GetServices(ctx context.Context, contextName, names
 		}
 		if len(svc.Spec.ExternalIPs) > 0 {
 			externalIP = svc.Spec.ExternalIPs[0]
+		}
+		if svc.Spec.Type == corev1.ServiceTypeLoadBalancer {
+			if externalIP == "" {
+				lbStatus = LBStatusProvisioning
+			} else {
+				lbStatus = LBStatusReady
+			}
 		}
 
 		// Calculate age
@@ -750,6 +779,8 @@ func (m *MultiClusterClient) GetServices(ctx context.Context, contextName, names
 			ClusterIP:   svc.Spec.ClusterIP,
 			ExternalIP:  externalIP,
 			Ports:       ports,
+			Endpoints:   endpointReadyCounts[svc.Namespace+"/"+svc.Name],
+			LBStatus:    lbStatus,
 			Age:         age,
 			Labels:      svc.Labels,
 			Annotations: svc.Annotations,

--- a/pkg/k8s/client_test.go
+++ b/pkg/k8s/client_test.go
@@ -741,6 +741,110 @@ func TestGetServices(t *testing.T) {
 	}
 }
 
+// TestGetServices_EndpointsAndLoadBalancer verifies the fix for
+// issue #6150 (endpoint count is based on the actual core/v1 Endpoints
+// object, not the number of services) and issue #6153 (LoadBalancer
+// services with no ingress populated are reported as Provisioning).
+func TestGetServices_EndpointsAndLoadBalancer(t *testing.T) {
+	m, _ := NewMultiClusterClient("")
+
+	// Service with two ready backend addresses across two subsets.
+	svcWithEndpoints := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{Name: "with-eps", Namespace: "default"},
+		Spec: corev1.ServiceSpec{
+			Type:  corev1.ServiceTypeClusterIP,
+			Ports: []corev1.ServicePort{{Port: 80}},
+		},
+	}
+	epsForSvc := &corev1.Endpoints{
+		ObjectMeta: metav1.ObjectMeta{Name: "with-eps", Namespace: "default"},
+		Subsets: []corev1.EndpointSubset{
+			{Addresses: []corev1.EndpointAddress{{IP: "10.0.0.1"}, {IP: "10.0.0.2"}}},
+			{Addresses: []corev1.EndpointAddress{{IP: "10.0.0.3"}}},
+		},
+	}
+
+	// Service with a matching Endpoints object that has zero addresses.
+	svcNoPods := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{Name: "no-pods", Namespace: "default"},
+		Spec: corev1.ServiceSpec{
+			Type:  corev1.ServiceTypeClusterIP,
+			Ports: []corev1.ServicePort{{Port: 80}},
+		},
+	}
+	epsNoPods := &corev1.Endpoints{
+		ObjectMeta: metav1.ObjectMeta{Name: "no-pods", Namespace: "default"},
+		Subsets:    nil,
+	}
+
+	// LoadBalancer service that is still being provisioned (no ingress).
+	svcLBPending := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{Name: "lb-pending", Namespace: "default"},
+		Spec: corev1.ServiceSpec{
+			Type:  corev1.ServiceTypeLoadBalancer,
+			Ports: []corev1.ServicePort{{Port: 80}},
+		},
+	}
+
+	// LoadBalancer service that has an ingress IP assigned.
+	svcLBReady := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{Name: "lb-ready", Namespace: "default"},
+		Spec: corev1.ServiceSpec{
+			Type:  corev1.ServiceTypeLoadBalancer,
+			Ports: []corev1.ServicePort{{Port: 80}},
+		},
+		Status: corev1.ServiceStatus{
+			LoadBalancer: corev1.LoadBalancerStatus{
+				Ingress: []corev1.LoadBalancerIngress{{IP: "203.0.113.9"}},
+			},
+		},
+	}
+
+	fakeCS := k8sfake.NewSimpleClientset(
+		svcWithEndpoints, epsForSvc,
+		svcNoPods, epsNoPods,
+		svcLBPending,
+		svcLBReady,
+	)
+	m.clients["c1"] = fakeCS
+
+	svcs, err := m.GetServices(context.Background(), "c1", "default")
+	if err != nil {
+		t.Fatalf("GetServices failed: %v", err)
+	}
+
+	byName := map[string]Service{}
+	for _, s := range svcs {
+		byName[s.Name] = s
+	}
+
+	// Expected endpoint counts per the fix for #6150.
+	const (
+		expectedWithEpsCount = 3 // 2 + 1 addresses across two subsets
+		expectedNoPodsCount  = 0
+	)
+	if got := byName["with-eps"].Endpoints; got != expectedWithEpsCount {
+		t.Errorf("with-eps: expected %d endpoints, got %d", expectedWithEpsCount, got)
+	}
+	if got := byName["no-pods"].Endpoints; got != expectedNoPodsCount {
+		t.Errorf("no-pods: expected %d endpoints, got %d", expectedNoPodsCount, got)
+	}
+
+	// Fix for #6153: LB without ingress = Provisioning, blank externalIP.
+	if got := byName["lb-pending"].LBStatus; got != LBStatusProvisioning {
+		t.Errorf("lb-pending: expected LBStatus %q, got %q", LBStatusProvisioning, got)
+	}
+	if got := byName["lb-pending"].ExternalIP; got != "" {
+		t.Errorf("lb-pending: expected empty ExternalIP, got %q", got)
+	}
+	if got := byName["lb-ready"].LBStatus; got != LBStatusReady {
+		t.Errorf("lb-ready: expected LBStatus %q, got %q", LBStatusReady, got)
+	}
+	if got := byName["lb-ready"].ExternalIP; got != "203.0.113.9" {
+		t.Errorf("lb-ready: expected ExternalIP 203.0.113.9, got %q", got)
+	}
+}
+
 func TestGetJobs(t *testing.T) {
 	m, _ := NewMultiClusterClient("")
 

--- a/web/src/components/clusters/components/NamespaceResources.tsx
+++ b/web/src/components/clusters/components/NamespaceResources.tsx
@@ -4,6 +4,14 @@ import { usePods, useDeployments, useServices, useJobs, useHPAs, useConfigMaps, 
 import { useDrillDownActions } from '../../../hooks/useDrillDown'
 import { useTranslation } from 'react-i18next'
 import { StatusBadge } from '../../ui/StatusBadge'
+import {
+  LB_PROVISIONING_LABEL,
+  LB_STATUS_PROVISIONING,
+} from '../../../lib/constants/network'
+
+/** Service type string emitted by the backend for LoadBalancer services.
+ * Defined as a constant to avoid magic strings. */
+const SERVICE_TYPE_LOAD_BALANCER = 'LoadBalancer'
 
 type ResourceKind = 'Pod' | 'Deployment' | 'Service' | 'Job' | 'HPA' | 'ConfigMap' | 'Secret' | 'ServiceAccount' | 'PVC'
 
@@ -121,15 +129,36 @@ export function NamespaceResources({ clusterName, namespace, onClose }: Namespac
       data: { status: pod.status, ready: pod.ready, restarts: pod.restarts, node: pod.node, age: pod.age }
     }))
 
-    services.forEach(svc => resources.push({
-      kind: 'Service',
-      name: svc.name,
-      namespace: svc.namespace,
-      status: svc.type,
-      statusColor: 'cyan',
-      detail: (svc.ports ?? []).slice(0, 2).join(', '),
-      data: { type: svc.type, clusterIP: svc.clusterIP, externalIP: svc.externalIP, ports: svc.ports, age: svc.age }
-    }))
+    services.forEach(svc => {
+      // Issue #6153: for LoadBalancer services with no ingress IP/
+      // hostname assigned yet, display 'Provisioning' instead of an
+      // empty string. We treat either the explicit lbStatus flag from
+      // the backend OR a LoadBalancer type with a missing externalIP
+      // (for older backends that do not set lbStatus) as provisioning.
+      const isPendingLB =
+        svc.type === SERVICE_TYPE_LOAD_BALANCER &&
+        (svc.lbStatus === LB_STATUS_PROVISIONING || !svc.externalIP)
+      const externalIPDisplay = isPendingLB
+        ? LB_PROVISIONING_LABEL
+        : svc.externalIP
+      resources.push({
+        kind: 'Service',
+        name: svc.name,
+        namespace: svc.namespace,
+        status: svc.type,
+        statusColor: 'cyan',
+        detail: (svc.ports ?? []).slice(0, 2).join(', '),
+        data: {
+          type: svc.type,
+          clusterIP: svc.clusterIP,
+          externalIP: externalIPDisplay,
+          endpoints: svc.endpoints,
+          lbStatus: svc.lbStatus,
+          ports: svc.ports,
+          age: svc.age,
+        },
+      })
+    })
 
     jobs.forEach(job => resources.push({
       kind: 'Job',

--- a/web/src/components/services/Services.tsx
+++ b/web/src/components/services/Services.tsx
@@ -38,6 +38,15 @@ export function Services() {
   const loadBalancers = filteredServices.filter(s => s.type === 'LoadBalancer').length
   const nodePortServices = filteredServices.filter(s => s.type === 'NodePort').length
   const clusterIPServices = filteredServices.filter(s => s.type === 'ClusterIP').length
+  // Issue #6150: "Endpoints" stat must reflect the actual number of
+  // ready backend addresses (pods) across all services, not the number
+  // of services. Each service's `endpoints` field is the sum of ready
+  // addresses from its core/v1 Endpoints object as populated by the
+  // backend. Services with no matching pods contribute 0.
+  const totalEndpoints = filteredServices.reduce(
+    (sum, svc) => sum + (svc.endpoints ?? 0),
+    0,
+  )
 
   // Stats value getter
   const getDashboardStatValue = (blockId: string): StatBlockValue => {
@@ -57,7 +66,7 @@ export function Services() {
       case 'ingresses':
         return { value: 0, sublabel: 'ingresses', isClickable: false }
       case 'endpoints':
-        return { value: totalServices, sublabel: 'endpoints', onClick: () => drillToAllServices(), isClickable: totalServices > 0 }
+        return { value: totalEndpoints, sublabel: 'endpoints', onClick: () => drillToAllServices(), isClickable: totalEndpoints > 0 }
       default:
         return { value: 0 }
     }

--- a/web/src/hooks/mcp/networking.ts
+++ b/web/src/hooks/mcp/networking.ts
@@ -505,15 +505,25 @@ export function useNetworkPolicies(cluster?: string, namespace?: string) {
 }
 
 function getDemoServices(): Service[] {
+  // Demo services populate `endpoints` (ready backend address count) and
+  // `lbStatus` so the Endpoints stat and LoadBalancer provisioning UI
+  // have realistic demo data for issues #6150 and #6153.
   return [
-    { name: 'kubernetes', namespace: 'default', cluster: 'prod-east', type: 'ClusterIP', clusterIP: '10.96.0.1', ports: ['443/TCP'], age: '45d' },
-    { name: 'api-gateway', namespace: 'production', cluster: 'prod-east', type: 'LoadBalancer', clusterIP: '10.96.10.50', externalIP: '52.14.123.45', ports: ['80/TCP', '443/TCP'], age: '30d' },
-    { name: 'frontend', namespace: 'web', cluster: 'prod-east', type: 'ClusterIP', clusterIP: '10.96.20.100', ports: ['3000/TCP'], age: '25d' },
-    { name: 'postgres', namespace: 'data', cluster: 'prod-east', type: 'ClusterIP', clusterIP: '10.96.30.10', ports: ['5432/TCP'], age: '40d' },
-    { name: 'redis', namespace: 'data', cluster: 'prod-east', type: 'ClusterIP', clusterIP: '10.96.30.20', ports: ['6379/TCP'], age: '40d' },
-    { name: 'prometheus', namespace: 'monitoring', cluster: 'staging', type: 'ClusterIP', clusterIP: '10.96.40.10', ports: ['9090/TCP'], age: '20d' },
-    { name: 'grafana', namespace: 'monitoring', cluster: 'staging', type: 'NodePort', clusterIP: '10.96.40.20', ports: ['3000:30300/TCP'], age: '20d' },
-    { name: 'ml-inference', namespace: 'ml', cluster: 'vllm-d', type: 'LoadBalancer', clusterIP: '10.96.50.10', externalIP: '34.56.78.90', ports: ['8080/TCP'], age: '15d' },
+    { name: 'kubernetes', namespace: 'default', cluster: 'prod-east', type: 'ClusterIP', clusterIP: '10.96.0.1', ports: ['443/TCP'], endpoints: 3, age: '45d' },
+    { name: 'api-gateway', namespace: 'production', cluster: 'prod-east', type: 'LoadBalancer', clusterIP: '10.96.10.50', externalIP: '52.14.123.45', ports: ['80/TCP', '443/TCP'], endpoints: 4, lbStatus: 'Ready', age: '30d' },
+    { name: 'frontend', namespace: 'web', cluster: 'prod-east', type: 'ClusterIP', clusterIP: '10.96.20.100', ports: ['3000/TCP'], endpoints: 6, age: '25d' },
+    { name: 'postgres', namespace: 'data', cluster: 'prod-east', type: 'ClusterIP', clusterIP: '10.96.30.10', ports: ['5432/TCP'], endpoints: 1, age: '40d' },
+    { name: 'redis', namespace: 'data', cluster: 'prod-east', type: 'ClusterIP', clusterIP: '10.96.30.20', ports: ['6379/TCP'], endpoints: 3, age: '40d' },
+    { name: 'prometheus', namespace: 'monitoring', cluster: 'staging', type: 'ClusterIP', clusterIP: '10.96.40.10', ports: ['9090/TCP'], endpoints: 2, age: '20d' },
+    { name: 'grafana', namespace: 'monitoring', cluster: 'staging', type: 'NodePort', clusterIP: '10.96.40.20', ports: ['3000:30300/TCP'], endpoints: 1, age: '20d' },
+    { name: 'ml-inference', namespace: 'ml', cluster: 'vllm-d', type: 'LoadBalancer', clusterIP: '10.96.50.10', externalIP: '34.56.78.90', ports: ['8080/TCP'], endpoints: 8, lbStatus: 'Ready', age: '15d' },
+    // A LoadBalancer service that is still provisioning — shows the
+    // "Provisioning" label in the Services drawer instead of a blank
+    // external IP (issue #6153).
+    { name: 'new-edge-gw', namespace: 'production', cluster: 'prod-east', type: 'LoadBalancer', clusterIP: '10.96.10.60', ports: ['80/TCP', '443/TCP'], endpoints: 0, lbStatus: 'Provisioning', age: '2m' },
+    // A service whose pods are not yet ready — 0 endpoints even though
+    // the service itself exists (issue #6150).
+    { name: 'orphaned-svc', namespace: 'data', cluster: 'staging', type: 'ClusterIP', clusterIP: '10.96.30.99', ports: ['8080/TCP'], endpoints: 0, age: '5m' },
   ]
 }
 

--- a/web/src/hooks/mcp/types.ts
+++ b/web/src/hooks/mcp/types.ts
@@ -343,6 +343,14 @@ export interface Service {
   clusterIP?: string
   externalIP?: string
   ports?: string[]
+  // Number of ready backend addresses (pods) currently associated with this
+  // service via its core/v1 Endpoints object. Issue #6150: the Endpoints
+  // dashboard stat sums this across services rather than counting services.
+  endpoints?: number
+  // LoadBalancer provisioning state. Empty string for non-LoadBalancer
+  // services. 'Provisioning' when a LoadBalancer service has no ingress
+  // IP/hostname yet, 'Ready' when it does. Issue #6153.
+  lbStatus?: string
   age?: string
   labels?: Record<string, string>
   annotations?: Record<string, string>

--- a/web/src/lib/constants/network.ts
+++ b/web/src/lib/constants/network.ts
@@ -253,3 +253,21 @@ export const TOOLTIP_HIDE_DELAY_MS = 50
 
 /** Maximum number of characters allowed in a single mission chat message */
 export const MAX_MESSAGE_SIZE_CHARS = 10_000
+
+// ============================================================================
+// Service / LoadBalancer labels
+// ============================================================================
+
+/** Display label for a LoadBalancer service whose cloud provider has not yet
+ * assigned an external IP or hostname. Issue #6153 — previously the UI
+ * showed a blank / dash value which was indistinguishable from a provisioned
+ * service with no ingress. */
+export const LB_PROVISIONING_LABEL = 'Provisioning'
+
+/** Wire value returned by the backend for a LoadBalancer service that is
+ * still being provisioned (matches k8s.LBStatusProvisioning in Go). */
+export const LB_STATUS_PROVISIONING = 'Provisioning'
+
+/** Wire value returned by the backend for a LoadBalancer service that has
+ * an ingress IP/hostname assigned (matches k8s.LBStatusReady in Go). */
+export const LB_STATUS_READY = 'Ready'


### PR DESCRIPTION
## Summary

Bundled fix for three Services / Network dashboard bugs reported by @aaradhychinche-alt.

### Fixes #6150 — Endpoints stat showed service count, not endpoint count
The Services dashboard "Endpoints" stat was using `services.length`, which means every new service incremented the count regardless of whether it had any ready backend pods.

**Fix:** `pkg/k8s/client_resources.go` now fetches the corresponding core/v1 `Endpoints` objects in the same namespace scope as the `Services` list call and populates a new `Endpoints int` field on each `Service` (sum of ready addresses across all subsets). The frontend `Services.tsx` sums `svc.endpoints` across filtered services instead of counting them.

### Fixes #6153 — LoadBalancer external IP shown before provisioning
LoadBalancer services with no `status.loadBalancer.ingress` were displayed with a blank external IP, indistinguishable from a provisioned service with no address.

**Fix:** New exported constants `k8s.LBStatusProvisioning` / `k8s.LBStatusReady` (Go) and `LB_PROVISIONING_LABEL` / `LB_STATUS_PROVISIONING` / `LB_STATUS_READY` (TS) keep the backend and frontend in sync. `GetServices` now emits `lbStatus: "Provisioning"` with an empty `externalIP` until the cloud provider populates the ingress. `NamespaceResources.tsx` renders the `LB_PROVISIONING_LABEL` constant instead of a blank value. Demo data includes a new `new-edge-gw` LB in the provisioning state for easy repro.

### Fixes #6154 — Zero-service clusters skipped in multi-cluster aggregation
`GetServices` (handler) had `if err == nil && len(services) > 0` guarding the merge, so a cluster that returned zero services was silently dropped from the response — the frontend then had no way to know the cluster existed.

**Fix:** `pkg/api/handlers/mcp_workloads.go` now always records the per-cluster count (zero included) and returns a new `clusterCounts` array in the response alongside the flat `services` list. Clusters that return an error are still omitted to preserve the prior error-hiding semantics, but healthy clusters with zero services are always represented.

## Code quality
- All new numeric/string literals live as named constants (no magic values).
- Backend test added: `TestGetServices_EndpointsAndLoadBalancer` covering endpoint summation (3 addresses across 2 subsets), zero-endpoint services, pending LB, and ready LB.
- Existing tests unchanged and passing.

## Test plan
- [x] `go build ./...`
- [x] `go test ./pkg/k8s/... ./pkg/api/handlers/... -count=1`
- [x] `npm run build`
- [x] `npm run lint` (no new errors from this PR)
- [x] `npx vitest run` for networking + services tests (76 passed)
- [ ] Manual: hit `/services` in demo mode and confirm Endpoints stat sums real values, and that `new-edge-gw` shows "Provisioning" in the namespace drill-down.

Fixes #6150
Fixes #6153
Fixes #6154