### PR TITLE
fix(gitops): drift bundle (#6155, #6156, #6157, #6158, #6159)

### DIFF
--- a/web/src/components/gitops/GitOps.test.tsx
+++ b/web/src/components/gitops/GitOps.test.tsx
@@ -1,9 +1,18 @@
 /// <reference types='@testing-library/jest-dom/vitest' />
-import { describe, it, expect, vi } from 'vitest'
-import { render, screen } from '@testing-library/react'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
 import { MemoryRouter } from 'react-router-dom'
 
 import '../../test/utils/setupMocks'
+
+// Wait budget for async detection flows.
+const ASYNC_WAIT_TIMEOUT_MS = 2000
+
+// Controls whether getDemoMode() returns true for the current test.
+// IMPORTANT: setupMocks mocks useDemoMode to always return true. We override
+// that below with `vi.doMock` inside a sync import shim so tests can flip
+// demo mode on/off per test case.
+let demoModeFlag = false
 
 vi.mock('../../lib/dashboards/DashboardPage', () => ({
   DashboardPage: ({ title, subtitle, children, beforeCards }: { title: string; subtitle?: string; children?: React.ReactNode; beforeCards?: React.ReactNode }) => (
@@ -16,9 +25,14 @@ vi.mock('../../lib/dashboards/DashboardPage', () => ({
   ),
 }))
 
+// Mutable clusters list so individual tests can exercise single vs multi
+// cluster attribution (#6157).
+let mockClusters: Array<{ name: string; context?: string }> = []
+
+const stableRefetch = vi.fn()
 vi.mock('../../hooks/useMCP', () => ({
   useClusters: () => ({
-    clusters: [], isRefreshing: false, refetch: vi.fn(),
+    clusters: mockClusters, isRefreshing: false, refetch: stableRefetch,
   }),
   useHelmReleases: () => ({ releases: [] }),
   useOperatorSubscriptions: () => ({ subscriptions: [] }),
@@ -39,15 +53,22 @@ vi.mock('../ui/Toast', () => ({
   useToast: () => ({ showToast: vi.fn() }),
 }))
 
+// The component uses both api.post (for detect-drift) and getDemoMode.
+const apiPostMock = vi.fn()
 vi.mock('../../lib/api', () => ({
-  api: { post: vi.fn() },
+  api: { post: (...args: unknown[]) => apiPostMock(...args) },
 }))
+
+// NOTE: setupMocks.ts already mocks '../../hooks/useDemoMode'. We override
+// getDemoMode at runtime in beforeEach below so each test can control the
+// demo-mode flag without racing vi.mock hoisting.
 
 vi.mock('react-i18next', () => ({
   useTranslation: () => ({ t: (key: string) => key, i18n: { language: 'en' } }),
 }))
 
 import { GitOps } from './GitOps'
+import * as useDemoModeModule from '../../hooks/useDemoMode'
 
 describe('GitOps Component', () => {
   const renderGitOps = () =>
@@ -56,6 +77,29 @@ describe('GitOps Component', () => {
         <GitOps />
       </MemoryRouter>
     )
+
+  beforeEach(() => {
+    demoModeFlag = false
+    mockClusters = []
+    apiPostMock.mockReset()
+    // Override setupMocks' forced-true getDemoMode with our flag. vi.spyOn
+    // replaces the export on the already-mocked module.
+    vi.spyOn(useDemoModeModule, 'getDemoMode').mockImplementation(() => demoModeFlag)
+    // Default: health check + detect-drift both succeed cleanly.
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(() =>
+        Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve({}),
+        })
+      )
+    )
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
 
   it('renders without crashing', () => {
     expect(() => renderGitOps()).not.toThrow()
@@ -75,5 +119,86 @@ describe('GitOps Component', () => {
   it('renders the integration info section', () => {
     renderGitOps()
     expect(screen.getByText('gitops.integrationTitle')).toBeInTheDocument()
+  })
+
+  // #6155 — in demo mode we must NOT be stuck in perpetual "checking".
+  it('does not leave cards stuck in checking state in demo mode (#6155)', async () => {
+    demoModeFlag = true
+    renderGitOps()
+    // In demo mode there is no detection pass, so "Checking..." must not
+    // persist. We assert that after render the checking label is not in the
+    // DOM for any of the apps.
+    await waitFor(
+      () => {
+        expect(screen.queryByText('gitops.checking')).not.toBeInTheDocument()
+      },
+      { timeout: ASYNC_WAIT_TIMEOUT_MS }
+    )
+  })
+
+  // #6156 — failed drift checks must render as a distinct error, not as
+  // "synced + healthy" (false green).
+  it('renders drift check failure as error state, not as synced (#6156)', async () => {
+    mockClusters = [{ name: 'only', context: 'only' }]
+    // health check ok, but api.post (detect-drift) throws.
+    apiPostMock.mockRejectedValue(new Error('backend exploded'))
+    renderGitOps()
+    await waitFor(
+      () => {
+        // api.post must have been called for each app config.
+        expect(apiPostMock).toHaveBeenCalled()
+      },
+      { timeout: ASYNC_WAIT_TIMEOUT_MS }
+    )
+    await waitFor(
+      () => {
+        expect(screen.getAllByText('gitops.driftCheckFailed').length).toBeGreaterThan(0)
+      },
+      { timeout: ASYNC_WAIT_TIMEOUT_MS }
+    )
+    // And the error details should be surfaced in the drift details list.
+    expect(screen.getAllByText(/backend exploded/).length).toBeGreaterThan(0)
+  })
+
+  // #6157 — multi-cluster attribution must not silently fall back to
+  // clusters[0]. With >1 clusters and no explicit target, apps render as
+  // "cluster: unknown".
+  it('marks cluster as unresolved when multiple clusters exist and none is configured (#6157)', async () => {
+    mockClusters = [
+      { name: 'cluster-a', context: 'cluster-a' },
+      { name: 'cluster-b', context: 'cluster-b' },
+    ]
+    apiPostMock.mockResolvedValue({ data: { drifted: false, resources: [] } })
+    renderGitOps()
+    await waitFor(
+      () => {
+        expect(screen.getAllByText('gitops.clusterUnresolved').length).toBeGreaterThan(0)
+      },
+      { timeout: ASYNC_WAIT_TIMEOUT_MS }
+    )
+    // And "cluster-a" (the old clusters[0] fallback) should NOT appear as
+    // an attributed cluster on any app row. It will still appear in the
+    // cluster-filter <option>, so we scope the query to <span> elements.
+    const attributedSpans = screen
+      .queryAllByText('cluster-a')
+      .filter((el) => el.tagName.toLowerCase() === 'span')
+    expect(attributedSpans.length).toBe(0)
+  })
+
+  // #6158 — lastSyncTime should NOT be fabricated on render. With the
+  // component rendering freshly-detected "synced" apps, we should see
+  // "gitops.unknown" (via getTimeAgo with undefined), not "gitops.justNow".
+  it('does not fabricate a recent lastSyncTime on render (#6158)', async () => {
+    mockClusters = [{ name: 'only', context: 'only' }]
+    apiPostMock.mockResolvedValue({ data: { drifted: false, resources: [] } })
+    renderGitOps()
+    await waitFor(
+      () => {
+        // "Just now" would be the old buggy behavior. Assert it never
+        // appears as the lastSync value for newly-detected apps.
+        expect(screen.queryByText(/justNow/)).not.toBeInTheDocument()
+      },
+      { timeout: ASYNC_WAIT_TIMEOUT_MS }
+    )
   })
 })

--- a/web/src/components/gitops/GitOps.tsx
+++ b/web/src/components/gitops/GitOps.tsx
@@ -28,15 +28,25 @@ interface GitOpsAppConfig {
 }
 
 // GitOps app with detected status
+// #6156 — 'error' is a distinct status so failed drift checks render as an
+// error (not a false-positive "synced + healthy").
 interface GitOpsApp extends GitOpsAppConfig {
-  syncStatus: 'synced' | 'out-of-sync' | 'unknown' | 'checking'
-  healthStatus: 'healthy' | 'degraded' | 'progressing' | 'missing'
+  syncStatus: 'synced' | 'out-of-sync' | 'unknown' | 'checking' | 'error'
+  healthStatus: 'healthy' | 'degraded' | 'progressing' | 'missing' | 'unknown'
+  // #6157 — marks apps whose cluster could not be resolved unambiguously
+  clusterAmbiguous?: boolean
   lastSyncTime?: string
   driftDetails?: string[]
 }
 
 // Drift detection result from API
+// #6156 — `status` explicitly captures the outcome so the UI never treats an
+// error as "not drifted". 'ok' = detection ran and returned a result; 'error'
+// = detection failed (network error, backend down, parsing error, etc.).
+type DriftStatus = 'ok' | 'error'
+
 interface DriftResult {
+  status: DriftStatus
   drifted: boolean
   resources: Array<{
     kind: string
@@ -91,7 +101,11 @@ export function GitOps() {
   const [syncedApps, setSyncedApps] = useState<Set<string>>(new Set())
   const [syncDialogApp, setSyncDialogApp] = useState<GitOpsApp | null>(null)
   const [driftResults, setDriftResults] = useState<Map<string, DriftResult>>(new Map())
-  const [isDetecting, setIsDetecting] = useState(true)
+  // #6155 — isDetecting starts `false`. The effect below flips it to `true`
+  // only when a real detection pass is about to run (non-demo mode AND
+  // backend healthy). Previously it defaulted to `true` and demo mode never
+  // cleared it, leaving every card stuck in "checking".
+  const [isDetecting, setIsDetecting] = useState(false)
   const [lastUpdated, setLastUpdated] = useState<Date | null>(null)
 
   // Cache helm releases count to prevent showing 0 during refresh
@@ -107,16 +121,26 @@ export function GitOps() {
   // short enough that users don't stare at "checking" for seconds (#3609).
   const DRIFT_HEALTHCHECK_TIMEOUT_MS = 3000
 
-  // #5953 — Apps no longer hardcode an empty cluster. Resolve a concrete
-  // cluster (first available healthy cluster) so the cluster filter actually
-  // matches. `selectedCluster` compares against `cluster.context ||
-  // cluster.name.split('/').pop()` in the <select> below, so we use the same
-  // shape here for consistency.
-  const resolveAppCluster = (preferred: string): string => {
-    if (preferred) return preferred
-    const first = clusters[0]
-    if (!first) return ''
-    return first.context || first.name.split('/').pop() || ''
+  // #6157 — Cluster resolution. Previously every app with an empty preferred
+  // cluster silently fell back to `clusters[0]`, making multi-cluster
+  // attribution wrong (every app appeared to target the first cluster).
+  //
+  // New semantics:
+  //   - If `preferred` is set, use it verbatim (explicit).
+  //   - If there is exactly one cluster available, use it (unambiguous).
+  //   - Otherwise return `{ cluster: '', ambiguous: true }` so the UI can
+  //     render the entry as "cluster: unknown" instead of silently picking
+  //     one. This preserves the display shape used by the <select> (context
+  //     || name.split('/').pop()).
+  const EXACTLY_ONE_CLUSTER = 1
+  const clusterDisplayName = (c: { context?: string; name: string }): string =>
+    c.context || c.name.split('/').pop() || ''
+  const resolveAppCluster = (preferred: string): { cluster: string; ambiguous: boolean } => {
+    if (preferred) return { cluster: preferred, ambiguous: false }
+    if (clusters.length === EXACTLY_ONE_CLUSTER) {
+      return { cluster: clusterDisplayName(clusters[0]), ambiguous: false }
+    }
+    return { cluster: '', ambiguous: clusters.length > EXACTLY_ONE_CLUSTER }
   }
 
   // #5952 — detectAllDrift is now a callable ref so the refresh button can
@@ -134,7 +158,14 @@ export function GitOps() {
   // Guard: verify backend is reachable first to avoid slow sequential failures
   // that block the UI and add latency (#3609).
   useEffect(() => {
-    if (getDemoMode()) return
+    // #6155 — In demo mode there is no backend; ensure isDetecting is false
+    // so cards do not stay stuck in the "checking" state forever. This uses
+    // the SAME setter the real exit path uses, rather than silently
+    // returning and leaving the previous value in place.
+    if (getDemoMode()) {
+      setIsDetecting(false)
+      return
+    }
 
     let cancelled = false
 
@@ -155,7 +186,10 @@ export function GitOps() {
 
       setIsDetecting(true)
       const results = new Map<string, DriftResult>()
-      const configs = getGitOpsAppConfigs().map(c => ({ ...c, cluster: resolveAppCluster(c.cluster) }))
+      const configs = getGitOpsAppConfigs().map(c => {
+        const resolved = resolveAppCluster(c.cluster)
+        return { ...c, cluster: resolved.cluster, clusterAmbiguous: resolved.ambiguous }
+      })
 
       // Run drift checks in parallel with individual timeouts instead of
       // sequential requests, reducing total latency significantly.
@@ -170,9 +204,25 @@ export function GitOps() {
             path: appConfig.path,
             namespace: appConfig.namespace,
             cluster: appConfig.cluster || undefined })
-          return { name: appConfig.name, result: { drifted: response.data.drifted, resources: response.data.resources || [] } as DriftResult }
-        } catch {
-          return { name: appConfig.name, result: { drifted: false, resources: [], error: 'Failed to detect drift' } as DriftResult }
+          return {
+            name: appConfig.name,
+            result: {
+              status: 'ok' as const,
+              drifted: response.data.drifted,
+              resources: response.data.resources || [] } satisfies DriftResult }
+        } catch (e) {
+          // #6156 — Failed drift checks MUST NOT be coerced to
+          // `drifted: false` — that rendered as "synced + healthy" (false
+          // green). Return status: 'error' so the UI can render a distinct
+          // error state.
+          const message = e instanceof Error ? e.message : 'Failed to detect drift'
+          return {
+            name: appConfig.name,
+            result: {
+              status: 'error' as const,
+              drifted: false,
+              resources: [],
+              error: message } satisfies DriftResult }
         }
       })
 
@@ -206,39 +256,80 @@ export function GitOps() {
       setSyncedApps(prev => new Set(prev).add(syncDialogApp.name))
       setDriftResults(prev => {
         const updated = new Map(prev)
-        updated.set(syncDialogApp.name, { drifted: false, resources: [] })
+        updated.set(syncDialogApp.name, { status: 'ok', drifted: false, resources: [] })
+        return updated
+      })
+      // #6158 — record the real time the sync completed; this is the ONLY
+      // place a lastSyncTime should be captured.
+      setSyncedAt(prev => {
+        const updated = new Map(prev)
+        updated.set(syncDialogApp.name, new Date().toISOString())
         return updated
       })
       showToast(`${syncDialogApp.name} synced successfully!`, 'success')
     }
   }
 
+  // Track when the user manually triggered a sync from this session, so the
+  // "last sync" timestamp is a real event (a sync that actually happened via
+  // this UI) rather than a timestamp fabricated on every render. #6158
+  const [syncedAt, setSyncedAt] = useState<Map<string, string>>(new Map())
+
   // Build apps list with real drift status
   const apps = useMemo(() => {
     // #5953 — Fill in a real cluster so the cluster filter below actually
     // matches. Without this, `app.cluster` was always "" and every app was
     // filtered out the moment a user selected a cluster.
-    const configs = getGitOpsAppConfigs().map(c => ({ ...c, cluster: resolveAppCluster(c.cluster) }))
+    // #6157 — resolveAppCluster now returns { cluster, ambiguous }.
+    const configs = getGitOpsAppConfigs().map(c => {
+      const resolved = resolveAppCluster(c.cluster)
+      return { ...c, cluster: resolved.cluster, clusterAmbiguous: resolved.ambiguous }
+    })
     return configs.map((config): GitOpsApp => {
+      // #6158 — lastSyncTime is ONLY set when the user actually synced via
+      // SyncDialog in this session. We never fabricate a timestamp on
+      // render. When unknown, the UI displays t('gitops.unknown').
+      const realSyncTime = syncedAt.get(config.name)
       if (syncedApps.has(config.name)) {
-        return { ...config, syncStatus: 'synced', healthStatus: 'healthy', lastSyncTime: new Date().toISOString(), driftDetails: undefined }
+        return { ...config, syncStatus: 'synced', healthStatus: 'healthy', lastSyncTime: realSyncTime, driftDetails: undefined }
       }
       if (isDetecting) {
         return { ...config, syncStatus: 'checking', healthStatus: 'progressing', lastSyncTime: undefined, driftDetails: undefined }
       }
       const drift = driftResults.get(config.name)
       if (drift) {
+        // #6156 — Render failed drift checks as a distinct error state.
+        if (drift.status === 'error') {
+          return {
+            ...config,
+            syncStatus: 'error',
+            healthStatus: 'unknown',
+            lastSyncTime: undefined,
+            driftDetails: drift.error ? [drift.error] : ['Failed to detect drift'] }
+        }
         const driftDetails = drift.resources.length > 0
           ? drift.resources.map(r => `${r.kind}/${r.name}: ${r.field || 'modified'}`)
-          : drift.error ? [drift.error] : undefined
-        return { ...config, syncStatus: drift.drifted ? 'out-of-sync' : 'synced', healthStatus: drift.drifted ? 'progressing' : 'healthy', lastSyncTime: new Date().toISOString(), driftDetails }
+          : undefined
+        return {
+          ...config,
+          syncStatus: drift.drifted ? 'out-of-sync' : 'synced',
+          healthStatus: drift.drifted ? 'progressing' : 'healthy',
+          // #6158 — do not fabricate a client-side timestamp here.
+          lastSyncTime: realSyncTime,
+          driftDetails }
       }
       return { ...config, syncStatus: 'unknown', healthStatus: 'missing', lastSyncTime: undefined, driftDetails: undefined }
     })
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [driftResults, isDetecting, syncedApps, clusters])
+  }, [driftResults, isDetecting, syncedApps, syncedAt, clusters])
 
-  const filteredApps = apps.map(app => syncedApps.has(app.name) ? { ...app, syncStatus: 'synced' as const, healthStatus: 'healthy' as const, driftDetails: undefined, lastSyncTime: new Date().toISOString() } : app)
+  // #6158 — no longer regenerates lastSyncTime here. The synced overlay only
+  // normalizes status fields; timestamps flow through from `apps`, which
+  // reads the real sync time from the `syncedAt` map.
+  const filteredApps = apps
+      .map(app => syncedApps.has(app.name)
+        ? { ...app, syncStatus: 'synced' as const, healthStatus: 'healthy' as const, driftDetails: undefined }
+        : app)
       .filter(app => {
         if (selectedCluster && app.cluster !== selectedCluster) return false
         if (statusFilter === 'synced' && app.syncStatus !== 'synced') return false
@@ -263,6 +354,8 @@ export function GitOps() {
       case 'synced': return 'text-green-400 bg-green-500/20'
       case 'out-of-sync': return 'text-yellow-400 bg-yellow-500/20'
       case 'checking': return 'text-blue-400 bg-blue-500/20'
+      // #6156 — distinct visual for error (red), not green.
+      case 'error': return 'text-red-400 bg-red-500/20'
       default: return 'text-muted-foreground bg-card'
     }
   }
@@ -272,6 +365,8 @@ export function GitOps() {
       case 'synced': return t('gitops.synced')
       case 'out-of-sync': return t('gitops.outOfSync')
       case 'checking': return t('gitops.checking')
+      // #6156 — distinct label for the error state (not "unknown").
+      case 'error': return t('gitops.driftCheckFailed')
       default: return t('gitops.unknown')
     }
   }
@@ -280,6 +375,9 @@ export function GitOps() {
     switch (status) {
       case 'healthy': return 'healthy'
       case 'progressing': return 'warning'
+      // #6156 — drift-check errors render as warning (not healthy/error
+      // green), so the user knows the state is unknown, not confirmed good.
+      case 'unknown': return 'warning'
       default: return 'error'
     }
   }
@@ -382,6 +480,15 @@ export function GitOps() {
                         <span className="flex items-center gap-1" title={t('gitops.targetCluster')}>
                           <span className="text-muted-foreground/50">→</span>
                           <span>{app.cluster}</span>
+                        </span>
+                      )}
+                      {/* #6157 — multiple clusters exist and no explicit
+                          target was configured; show "cluster: unknown"
+                          instead of silently attributing to clusters[0]. */}
+                      {!app.cluster && app.clusterAmbiguous && (
+                        <span className="flex items-center gap-1 text-yellow-400" title={t('gitops.targetCluster')}>
+                          <span className="text-muted-foreground/50">→</span>
+                          <span>{t('gitops.clusterUnresolved')}</span>
                         </span>
                       )}
                     </div>

--- a/web/src/components/gitops/SyncDialog.test.tsx
+++ b/web/src/components/gitops/SyncDialog.test.tsx
@@ -1,9 +1,16 @@
 /// <reference types='@testing-library/jest-dom/vitest' />
 import type React from 'react'
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
-import { render, screen } from '@testing-library/react'
+import { render, screen, waitFor } from '@testing-library/react'
 
 import '../../test/utils/setupMocks'
+
+// Expected endpoint hit by the component (regression for #6159 — the test
+// previously mocked `api.post`, but SyncDialog uses `fetch` directly, so the
+// mock was never exercised).
+const DETECT_DRIFT_ENDPOINT = '/api/gitops/detect-drift'
+// Wait budget for async state transitions inside the component.
+const ASYNC_WAIT_TIMEOUT_MS = 2000
 
 vi.mock('../../lib/modals', () => {
   const BaseModal = Object.assign(
@@ -17,33 +24,29 @@ vi.mock('../../lib/modals', () => {
   return { BaseModal }
 })
 
-vi.mock('../../lib/api', () => ({
-  api: { post: vi.fn() },
-}))
-
 vi.mock('react-i18next', () => ({
   useTranslation: () => ({ t: (key: string) => key, i18n: { language: 'en' } }),
 }))
 
 import { SyncDialog } from './SyncDialog'
 
+type FetchMock = ReturnType<typeof vi.fn>
+
+function makeFetchMock(impl: (url: string) => Promise<Response>): FetchMock {
+  return vi.fn((input: RequestInfo | URL) => {
+    const url = typeof input === 'string' ? input : input.toString()
+    return impl(url)
+  }) as FetchMock
+}
+
+function mockResponse(body: unknown, ok = true): Response {
+  return {
+    ok,
+    json: () => Promise.resolve(body),
+  } as unknown as Response
+}
+
 describe('SyncDialog Component', () => {
-  beforeEach(() => {
-    vi.stubGlobal(
-      'fetch',
-      vi.fn(() =>
-        Promise.resolve({
-          ok: true,
-          json: () => Promise.resolve({})
-        })
-      )
-    )
-  })
-
-  afterEach(() => {
-    vi.unstubAllGlobals()
-  })
-
   const defaultProps = {
     isOpen: true,
     onClose: vi.fn(),
@@ -55,14 +58,95 @@ describe('SyncDialog Component', () => {
     onSyncComplete: vi.fn(),
   }
 
+  let fetchMock: FetchMock
+
+  beforeEach(() => {
+    fetchMock = makeFetchMock(() =>
+      Promise.resolve(mockResponse({ drifted: false, resources: [] }))
+    )
+    vi.stubGlobal('fetch', fetchMock)
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    vi.clearAllMocks()
+  })
+
   it('renders without crashing when open', () => {
-    expect(() =>
-      render(<SyncDialog {...defaultProps} />)
-    ).not.toThrow()
+    expect(() => render(<SyncDialog {...defaultProps} />)).not.toThrow()
   })
 
   it('renders the app name in the dialog', () => {
     render(<SyncDialog {...defaultProps} />)
     expect(screen.getByText('GitOps Sync: test-app')).toBeInTheDocument()
+  })
+
+  // #6159 — substantive integration test: calls the real fetch endpoint the
+  // component actually uses (NOT `api.post`).
+  it('calls /api/gitops/detect-drift via fetch on open (success path)', async () => {
+    render(<SyncDialog {...defaultProps} />)
+    await waitFor(
+      () => {
+        expect(fetchMock).toHaveBeenCalled()
+      },
+      { timeout: ASYNC_WAIT_TIMEOUT_MS }
+    )
+    const calledUrl = fetchMock.mock.calls[0][0] as string
+    expect(calledUrl).toBe(DETECT_DRIFT_ENDPOINT)
+    const init = fetchMock.mock.calls[0][1] as RequestInit
+    expect(init.method).toBe('POST')
+    const body = JSON.parse(init.body as string)
+    expect(body.repoUrl).toBe(defaultProps.repoUrl)
+    expect(body.namespace).toBe(defaultProps.namespace)
+    expect(body.cluster).toBe(defaultProps.cluster)
+  })
+
+  // #6159 — error path: backend returns non-ok; component must surface the
+  // error, not silently swallow it.
+  it('renders error state when drift detection fails', async () => {
+    fetchMock = makeFetchMock(() =>
+      Promise.resolve(
+        mockResponse({ error: 'boom: backend down' }, false)
+      )
+    )
+    vi.stubGlobal('fetch', fetchMock)
+    render(<SyncDialog {...defaultProps} />)
+    await waitFor(
+      () => {
+        expect(screen.getByText(/boom: backend down/)).toBeInTheDocument()
+      },
+      { timeout: ASYNC_WAIT_TIMEOUT_MS }
+    )
+  })
+
+  // #6159 — drift-detected path: response with resources transitions the
+  // dialog into the plan phase and renders the drifted resources.
+  it('transitions to plan phase and lists drifted resources', async () => {
+    fetchMock = makeFetchMock(() =>
+      Promise.resolve(
+        mockResponse({
+          drifted: true,
+          resources: [
+            {
+              kind: 'Deployment',
+              name: 'frontend',
+              namespace: 'default',
+              field: 'replicas',
+              gitValue: '3',
+              clusterValue: '5',
+            },
+          ],
+        })
+      )
+    )
+    vi.stubGlobal('fetch', fetchMock)
+    render(<SyncDialog {...defaultProps} />)
+    await waitFor(
+      () => {
+        expect(screen.getByText(/frontend/)).toBeInTheDocument()
+      },
+      { timeout: ASYNC_WAIT_TIMEOUT_MS }
+    )
+    expect(screen.getByText(/Drift Detected/)).toBeInTheDocument()
   })
 })

--- a/web/src/locales/en/common.json
+++ b/web/src/locales/en/common.json
@@ -710,6 +710,8 @@
     "synced": "Synced",
     "outOfSync": "Out of Sync",
     "checking": "Checking...",
+    "driftCheckFailed": "Drift check failed",
+    "clusterUnresolved": "cluster: unknown",
     "appsConfigured": "apps configured",
     "helmReleases": "helm releases",
     "kustomizeApps": "kustomize apps",


### PR DESCRIPTION
Fixes #6155, #6156, #6157, #6158, #6159.

## Summary
Five related GitOps/drift issues were fixed together in `web/src/components/gitops/GitOps.tsx` and its test files.

- **#6155 Demo mode perpetual checking** — `isDetecting` now initializes to `false`, and the demo-mode early return explicitly calls `setIsDetecting(false)` so cards never stay stuck in the "checking" state when there is no backend.
- **#6156 Drift failures rendered as synced+healthy** — `DriftResult` now carries an explicit `status: 'ok' | 'error'`. The catch block constructs `{ status: 'error', drifted: false, error }` (no more "false green"). A new `syncStatus: 'error'` + `healthStatus: 'unknown'` pair renders a distinct red badge ("Drift check failed") and surfaces the error in the drift details list.
- **#6157 Multi-cluster attribution via `clusters[0]`** — `resolveAppCluster` now returns `{ cluster, ambiguous }`. If an app has no explicit target AND more than one cluster is available, the cluster is left empty and `clusterAmbiguous` is set, causing the row to render "cluster: unknown" instead of silently attributing to the first cluster.
- **#6158 `lastSyncTime` fabricated on render** — Removed both `new Date().toISOString()` sites (inside `apps` useMemo and `filteredApps` overlay). Added a `syncedAt: Map<string, string>` that is written ONLY inside `handleSyncComplete` — the one place a sync actually happened via this UI. Cards for freshly-detected apps now display "unknown" via `getTimeAgo`.
- **#6159 Shallow tests + wrong mock** — `SyncDialog.test.tsx` previously mocked `api.post`, but the component uses `fetch`. Rewrote to mock global `fetch` and added three substantive tests: success path (verifies endpoint + POST body), error path (verifies backend errors surface), and drift-detected path (verifies transition to plan phase with drifted resources). Also added regression tests to `GitOps.test.tsx` covering #6155 (demo mode exits checking), #6156 (drift failure renders error), #6157 (multi-cluster ambiguity), and #6158 (no fabricated "just now" timestamp).

## Test plan
- [x] `go build ./...`
- [x] `go test ./pkg/api/handlers/... -run GitOps`
- [x] `web && npm run build` (post-build safety checks pass)
- [x] `web && npx eslint src/components/gitops/` (0 errors)
- [x] `web && npx vitest run src/components/gitops/` — 13 tests pass
- [x] `web && npx vitest run src/test/no-magic-numbers.test.ts` passes (all new literals are named constants)
- [ ] CI build + lint + preview