### PR TITLE
feat(services): TTL, port names, orphaned detection, health indicators (#6162-#6167)

### DIFF
--- a/pkg/k8s/client.go
+++ b/pkg/k8s/client.go
@@ -405,6 +405,23 @@ type Deployment struct {
 	Annotations       map[string]string `json:"annotations,omitempty"`
 }
 
+// ServicePortDetail is a structured view of a ServicePort that preserves
+// the optional port name (issue #6163). The legacy Ports []string field is
+// retained for backwards compatibility; new code should prefer this.
+type ServicePortDetail struct {
+	// Name of the port as defined on the k8s ServicePort (may be empty).
+	// When present it is a well-known name like "http" or "metrics" that
+	// operators configure to identify a port across the cluster.
+	Name     string `json:"name,omitempty"`
+	// Port is the service-level port (spec.ports[].port).
+	Port     int32  `json:"port"`
+	// Protocol is TCP / UDP / SCTP.
+	Protocol string `json:"protocol,omitempty"`
+	// NodePort is the externally-exposed port for NodePort / LoadBalancer
+	// services. Zero for ClusterIP services.
+	NodePort int32  `json:"nodePort,omitempty"`
+}
+
 // Service represents a Kubernetes service
 type Service struct {
 	Name        string            `json:"name"`
@@ -413,7 +430,14 @@ type Service struct {
 	Type        string            `json:"type"` // ClusterIP, NodePort, LoadBalancer, ExternalName
 	ClusterIP   string            `json:"clusterIP,omitempty"`
 	ExternalIP  string            `json:"externalIP,omitempty"`
+	// Ports is the legacy flat string representation of the ports, kept
+	// for existing consumers. Format: "80/TCP" or "80:30080/TCP" when a
+	// NodePort is allocated. Prefer PortDetails for new code.
 	Ports       []string          `json:"ports,omitempty"`
+	// PortDetails is the structured representation of the ServicePorts
+	// including the optional name field (issue #6163). Same length and
+	// ordering as Ports.
+	PortDetails []ServicePortDetail `json:"portDetails,omitempty"`
 	// Endpoints is the number of ready backend addresses summed across all
 	// subsets of the matching core/v1 Endpoints object (i.e. actual pod
 	// endpoints backing the service, NOT the number of services themselves).
@@ -426,6 +450,12 @@ type Service struct {
 	// has been assigned) or LBStatusProvisioning (cloud provider has not yet
 	// provisioned an address). Issue #6153.
 	LBStatus    string            `json:"lbStatus,omitempty"`
+	// Selector is the label selector used by the service to match backing
+	// pods (corev1.ServiceSpec.Selector). Surfaced so the frontend can
+	// detect orphaned services (selector present but no matching pods,
+	// issue #6164) and services with an empty selector that are not
+	// ExternalName (config bug, issue #6166). nil for ExternalName.
+	Selector    map[string]string `json:"selector,omitempty"`
 	Age         string            `json:"age,omitempty"`
 	Labels      map[string]string `json:"labels,omitempty"`
 	Annotations map[string]string `json:"annotations,omitempty"`

--- a/pkg/k8s/client_resources.go
+++ b/pkg/k8s/client_resources.go
@@ -732,14 +732,23 @@ func (m *MultiClusterClient) GetServices(ctx context.Context, contextName, names
 
 	var result []Service
 	for _, svc := range services.Items {
-		// Build ports list
+		// Build ports list. We populate both the legacy flat []string
+		// form (existing consumers) and the structured PortDetails form
+		// which preserves the port Name (issue #6163).
 		var ports []string
+		var portDetails []ServicePortDetail
 		for _, p := range svc.Spec.Ports {
 			portStr := fmt.Sprintf("%d/%s", p.Port, p.Protocol)
 			if p.NodePort != 0 {
 				portStr = fmt.Sprintf("%d:%d/%s", p.Port, p.NodePort, p.Protocol)
 			}
 			ports = append(ports, portStr)
+			portDetails = append(portDetails, ServicePortDetail{
+				Name:     p.Name,
+				Port:     p.Port,
+				Protocol: string(p.Protocol),
+				NodePort: p.NodePort,
+			})
 		}
 
 		// Resolve external IP and LoadBalancer provisioning status.
@@ -779,8 +788,10 @@ func (m *MultiClusterClient) GetServices(ctx context.Context, contextName, names
 			ClusterIP:   svc.Spec.ClusterIP,
 			ExternalIP:  externalIP,
 			Ports:       ports,
+			PortDetails: portDetails,
 			Endpoints:   endpointReadyCounts[svc.Namespace+"/"+svc.Name],
 			LBStatus:    lbStatus,
+			Selector:    svc.Spec.Selector,
 			Age:         age,
 			Labels:      svc.Labels,
 			Annotations: svc.Annotations,

--- a/pkg/k8s/client_test.go
+++ b/pkg/k8s/client_test.go
@@ -845,6 +845,58 @@ func TestGetServices_EndpointsAndLoadBalancer(t *testing.T) {
 	}
 }
 
+// TestGetServices_PortDetailsAndSelector verifies issues #6163
+// (port names surfaced via PortDetails) and #6164/#6166 (selector
+// exposed so the frontend can detect orphaned / misconfigured services).
+func TestGetServices_PortDetailsAndSelector(t *testing.T) {
+	m, _ := NewMultiClusterClient("")
+
+	const (
+		httpPort       = int32(80)
+		metricsPort    = int32(9090)
+		expectedSelKey = "app"
+		expectedSelVal = "web"
+	)
+
+	svc := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{Name: "with-names", Namespace: "default"},
+		Spec: corev1.ServiceSpec{
+			Type:     corev1.ServiceTypeClusterIP,
+			Selector: map[string]string{expectedSelKey: expectedSelVal},
+			Ports: []corev1.ServicePort{
+				{Name: "http", Port: httpPort, Protocol: corev1.ProtocolTCP},
+				{Name: "metrics", Port: metricsPort, Protocol: corev1.ProtocolTCP},
+			},
+		},
+	}
+
+	fakeCS := k8sfake.NewSimpleClientset(svc)
+	m.clients["c1"] = fakeCS
+
+	svcs, err := m.GetServices(context.Background(), "c1", "default")
+	if err != nil {
+		t.Fatalf("GetServices failed: %v", err)
+	}
+	if len(svcs) != 1 {
+		t.Fatalf("expected 1 service, got %d", len(svcs))
+	}
+	got := svcs[0]
+
+	const expectedPortCount = 2
+	if len(got.PortDetails) != expectedPortCount {
+		t.Fatalf("expected %d port details, got %d", expectedPortCount, len(got.PortDetails))
+	}
+	if got.PortDetails[0].Name != "http" || got.PortDetails[0].Port != httpPort {
+		t.Errorf("port[0]: expected http/%d, got %s/%d", httpPort, got.PortDetails[0].Name, got.PortDetails[0].Port)
+	}
+	if got.PortDetails[1].Name != "metrics" || got.PortDetails[1].Port != metricsPort {
+		t.Errorf("port[1]: expected metrics/%d, got %s/%d", metricsPort, got.PortDetails[1].Name, got.PortDetails[1].Port)
+	}
+	if got.Selector[expectedSelKey] != expectedSelVal {
+		t.Errorf("selector: expected %s=%s, got %v", expectedSelKey, expectedSelVal, got.Selector)
+	}
+}
+
 func TestGetJobs(t *testing.T) {
 	m, _ := NewMultiClusterClient("")
 

--- a/web/src/components/cards/ServiceStatus.tsx
+++ b/web/src/components/cards/ServiceStatus.tsx
@@ -1,4 +1,5 @@
 import { Globe, Server, ExternalLink, ChevronRight } from 'lucide-react'
+import { useEffect, useMemo, useState } from 'react'
 import type { Service } from '../../hooks/useMCP'
 import { useCachedServices } from '../../hooks/useCachedData'
 import { useDrillDownActions } from '../../hooks/useDrillDown'
@@ -8,6 +9,19 @@ import { useCardLoadingState } from './CardDataContext'
 import { CardSearchInput, CardControlsRow, CardPaginationFooter } from '../../lib/cards/CardComponents'
 import { useCardData } from '../../lib/cards/cardHooks'
 import { useTranslation } from 'react-i18next'
+import {
+  deriveServiceHealth,
+  formatServicePorts,
+  SERVICE_HEALTH_DOT_CLASSES,
+  SERVICE_HEALTH_LABELS,
+  type ServiceHealthStatus,
+} from '../../lib/services/serviceHealth'
+import {
+  SERVICES_CACHE_TTL_MS,
+  SERVICES_CACHE_STALE_MS,
+  MS_PER_SECOND,
+  TICK_INTERVAL_MS,
+} from '../../lib/constants/network'
 
 type SortByOption = 'type' | 'name' | 'namespace' | 'ports'
 
@@ -44,19 +58,53 @@ function getTypeColor(type: string) {
   }
 }
 
+/** Ticks to the current wall-clock `Date.now()` every TICK_INTERVAL_MS
+ * while `enabled`. Computing `Date.now()` inside an effect (rather than
+ * during render) keeps the component pure per React rules-of-hooks. */
+function useNowTick(enabled: boolean): number {
+  const [now, setNow] = useState(() => Date.now())
+  useEffect(() => {
+    if (!enabled) return
+    const id = window.setInterval(() => setNow(Date.now()), TICK_INTERVAL_MS)
+    return () => window.clearInterval(id)
+  }, [enabled])
+  return now
+}
+
 export function ServiceStatus() {
   const { t } = useTranslation()
   const {
-    services,
+    services: rawServices,
     isLoading: hookLoading,
     isRefreshing,
     isDemoFallback,
     isFailed,
     consecutiveFailures,
+    lastRefresh,
     error
   } = useCachedServices()
 
   const { drillToService } = useDrillDownActions()
+
+  // Issue #6162: enforce a hard TTL on the cached payload. If the data
+  // is older than SERVICES_CACHE_TTL_MS, treat it as empty so downstream
+  // logic triggers a refetch via the normal hook flow rather than
+  // rendering indefinitely-stale data. `now` is pulled from a ticking
+  // hook so we never call Date.now() during render (react-hooks purity).
+  const now = useNowTick(!!lastRefresh)
+  const cacheAgeMs = useMemo(
+    () => (lastRefresh ? now - lastRefresh : null),
+    [now, lastRefresh],
+  )
+  const isExpired = cacheAgeMs !== null && cacheAgeMs > SERVICES_CACHE_TTL_MS
+  const isStale =
+    cacheAgeMs !== null &&
+    cacheAgeMs > SERVICES_CACHE_STALE_MS &&
+    !isExpired
+  const services = useMemo(
+    () => (isExpired ? [] : rawServices),
+    [isExpired, rawServices],
+  )
 
   // Report data state to CardWrapper for failure badge rendering
   const hasData = services.length > 0
@@ -156,7 +204,18 @@ export function ServiceStatus() {
       {/* Controls */}
       <div className="flex items-center justify-between mb-4">
         <div className="flex items-center gap-2">
-          {/* Cluster count indicator */}
+          {/* Cache freshness badge (#6162) */}
+          {isStale && cacheAgeMs !== null && (
+            <span
+              className="px-1.5 py-0.5 rounded text-2xs bg-yellow-500/10 text-yellow-400 border border-yellow-500/20"
+              title={t('serviceStatus.staleTooltip', 'Data older than the freshness threshold — refetching shortly')}
+            >
+              {t('serviceStatus.cachedAgo', {
+                defaultValue: 'Cached • {{seconds}}s ago',
+                seconds: Math.round(cacheAgeMs / MS_PER_SECOND),
+              })}
+            </span>
+          )}
         </div>
         <CardControlsRow
           clusterIndicator={{
@@ -220,7 +279,12 @@ export function ServiceStatus() {
             {error ? t('serviceStatus.loadError', 'Failed to load services') : searchQuery ? t('serviceStatus.noMatch', 'No matching services') : t('serviceStatus.noServices', 'No services found')}
           </div>
         ) : (
-          displayServices.map(service => (
+          displayServices.map(service => {
+            // Centralized health derivation (#6164, #6165, #6166, #6167)
+            const health: ServiceHealthStatus = deriveServiceHealth(service)
+            const formattedPorts = formatServicePorts(service)
+            const endpointCount = service.endpoints ?? 0
+            return (
             <div
               key={`${service.cluster}-${service.namespace}-${service.name}`}
               onClick={() => drillToService(service.cluster || '', service.namespace || '', service.name, {
@@ -231,19 +295,53 @@ export function ServiceStatus() {
               className="flex items-center justify-between p-2 rounded-lg bg-secondary/30 hover:bg-secondary/50 transition-colors cursor-pointer group gap-2"
             >
               <div className="flex items-center gap-2 min-w-0 flex-1">
+                {/* Connectivity dot — single source of truth via deriveServiceHealth (#6167) */}
+                <span
+                  className={`w-2 h-2 rounded-full shrink-0 ${SERVICE_HEALTH_DOT_CLASSES[health]}`}
+                  role="status"
+                  aria-label={SERVICE_HEALTH_LABELS[health]}
+                  title={SERVICE_HEALTH_LABELS[health]}
+                />
                 {getTypeIcon(service.type || 'ClusterIP')}
                 <div className="min-w-0 flex-1">
                   <div className="text-sm text-foreground truncate group-hover:text-cyan-400">{service.name}</div>
                   <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
                     <span className="truncate">{service.namespace}</span>
                     <ClusterBadge cluster={service.cluster || ''} size="sm" />
+                    <span className="truncate" title={t('serviceStatus.endpointsTooltip', '{{count}} ready endpoint(s)', { count: endpointCount })}>
+                      {t('serviceStatus.endpointsCount', {
+                        defaultValue: '{{count}} endpoints',
+                        count: endpointCount,
+                      })}
+                    </span>
                   </div>
                 </div>
               </div>
               <div className="flex items-center gap-2 shrink-0">
-                {service.ports && service.ports.length > 0 && (
-                  <span className="text-xs text-muted-foreground truncate max-w-[80px]">
-                    {(service.ports || []).join(', ')}
+                {formattedPorts.length > 0 && (
+                  <span
+                    className="text-xs text-muted-foreground truncate max-w-[140px]"
+                    title={formattedPorts.join(', ')}
+                  >
+                    {formattedPorts.join(', ')}
+                  </span>
+                )}
+                {/* Orphaned badge (#6164/#6165) */}
+                {health === 'orphaned' && (
+                  <span
+                    className="px-1.5 py-0.5 rounded text-2xs shrink-0 bg-red-500/10 text-red-400 border border-red-500/20"
+                    title={SERVICE_HEALTH_LABELS.orphaned}
+                  >
+                    {t('serviceStatus.orphanedBadge', 'Orphaned')}
+                  </span>
+                )}
+                {/* Provisioning badge (#6167) */}
+                {health === 'provisioning' && (
+                  <span
+                    className="px-1.5 py-0.5 rounded text-2xs shrink-0 bg-yellow-500/10 text-yellow-400 border border-yellow-500/20"
+                    title={SERVICE_HEALTH_LABELS.provisioning}
+                  >
+                    {t('serviceStatus.provisioningBadge', 'Provisioning')}
                   </span>
                 )}
                 <span className={`px-1.5 py-0.5 rounded text-xs shrink-0 ${getTypeColor(service.type || 'ClusterIP')}`}>
@@ -252,7 +350,8 @@ export function ServiceStatus() {
                 <ChevronRight className="w-4 h-4 text-muted-foreground opacity-0 group-hover:opacity-100 transition-opacity shrink-0" />
               </div>
             </div>
-          ))
+            )
+          })
         )}
       </div>
 

--- a/web/src/hooks/mcp/types.ts
+++ b/web/src/hooks/mcp/types.ts
@@ -335,6 +335,19 @@ export interface NodeInfo {
   unschedulable: boolean
 }
 
+/** Structured view of a ServicePort that preserves the port name
+ * (issue #6163). Matches pkg/k8s.ServicePortDetail. */
+export interface ServicePortDetail {
+  /** Optional name from the k8s ServicePort (e.g. "http", "metrics"). */
+  name?: string
+  /** Service-level port number. */
+  port: number
+  /** TCP / UDP / SCTP. */
+  protocol?: string
+  /** Externally exposed port for NodePort / LoadBalancer services. */
+  nodePort?: number
+}
+
 export interface Service {
   name: string
   namespace: string
@@ -342,7 +355,10 @@ export interface Service {
   type: string // ClusterIP, NodePort, LoadBalancer, ExternalName
   clusterIP?: string
   externalIP?: string
+  /** Legacy flat representation ("80/TCP" or "80:30080/TCP"). */
   ports?: string[]
+  /** Structured ports with optional names (issue #6163). Same order as `ports`. */
+  portDetails?: ServicePortDetail[]
   // Number of ready backend addresses (pods) currently associated with this
   // service via its core/v1 Endpoints object. Issue #6150: the Endpoints
   // dashboard stat sums this across services rather than counting services.
@@ -351,6 +367,10 @@ export interface Service {
   // services. 'Provisioning' when a LoadBalancer service has no ingress
   // IP/hostname yet, 'Ready' when it does. Issue #6153.
   lbStatus?: string
+  /** Label selector for backing pods. Used to detect orphaned services
+   * (issue #6164) and invalid empty selectors on non-ExternalName services
+   * (issue #6166). */
+  selector?: Record<string, string>
   age?: string
   labels?: Record<string, string>
   annotations?: Record<string, string>

--- a/web/src/lib/constants/network.ts
+++ b/web/src/lib/constants/network.ts
@@ -271,3 +271,30 @@ export const LB_STATUS_PROVISIONING = 'Provisioning'
 /** Wire value returned by the backend for a LoadBalancer service that has
  * an ingress IP/hostname assigned (matches k8s.LBStatusReady in Go). */
 export const LB_STATUS_READY = 'Ready'
+
+// ============================================================================
+// Services cache freshness (issue #6162)
+// ============================================================================
+
+/** Maximum age of a cached services payload before it must be discarded
+ * and refetched. The underlying cache layer refreshes on a shorter
+ * interval but this is the hard wall after which stale data is ignored
+ * on read. */
+export const SERVICES_CACHE_TTL_MS = 60_000
+
+/** Age threshold above which the services UI marks its data as stale
+ * (shown as a "Cached • Ns ago" / "Stale" badge). Strictly less than
+ * SERVICES_CACHE_TTL_MS. */
+export const SERVICES_CACHE_STALE_MS = 30_000
+
+/** Conversion factor from milliseconds to seconds, used when formatting
+ * the "Cached • Ns ago" label. */
+export const MS_PER_SECOND = 1_000
+
+// ============================================================================
+// Service port rendering (issue #6163)
+// ============================================================================
+
+/** Separator inserted between a port name and its port/protocol string
+ * when rendering a named port (e.g. `http: 80/TCP`). */
+export const PORT_NAME_SEPARATOR = ': '

--- a/web/src/lib/services/__tests__/serviceHealth.test.ts
+++ b/web/src/lib/services/__tests__/serviceHealth.test.ts
@@ -1,0 +1,166 @@
+import { describe, it, expect } from 'vitest'
+import {
+  deriveServiceHealth,
+  isOrphaned,
+  hasInvalidSelector,
+  hasSelector,
+  formatServicePort,
+  formatServicePorts,
+} from '../serviceHealth'
+import {
+  LB_STATUS_PROVISIONING,
+  LB_STATUS_READY,
+} from '../../constants/network'
+
+describe('deriveServiceHealth', () => {
+  it("returns 'healthy' when endpoints > 0", () => {
+    expect(
+      deriveServiceHealth({
+        type: 'ClusterIP',
+        endpoints: 3,
+        selector: { app: 'web' },
+      }),
+    ).toBe('healthy')
+  })
+
+  it("returns 'orphaned' when selector exists and endpoints === 0 (#6164/#6165)", () => {
+    expect(
+      deriveServiceHealth({
+        type: 'ClusterIP',
+        endpoints: 0,
+        selector: { app: 'missing' },
+      }),
+    ).toBe('orphaned')
+  })
+
+  it("returns 'provisioning' for a LoadBalancer without ingress (#6167)", () => {
+    expect(
+      deriveServiceHealth({
+        type: 'LoadBalancer',
+        endpoints: 0,
+        selector: { app: 'web' },
+        lbStatus: LB_STATUS_PROVISIONING,
+      }),
+    ).toBe('provisioning')
+  })
+
+  it("provisioning wins over orphaned when LB has zero endpoints", () => {
+    // A fresh LoadBalancer with no endpoints yet is NOT orphaned —
+    // it is still coming up.
+    expect(
+      isOrphaned({
+        endpoints: 0,
+        selector: { app: 'web' },
+        lbStatus: LB_STATUS_PROVISIONING,
+      }),
+    ).toBe(false)
+  })
+
+  it("returns 'healthy' for a ready LoadBalancer with endpoints", () => {
+    expect(
+      deriveServiceHealth({
+        type: 'LoadBalancer',
+        endpoints: 2,
+        selector: { app: 'web' },
+        lbStatus: LB_STATUS_READY,
+      }),
+    ).toBe('healthy')
+  })
+
+  it("returns 'unknown' when endpoints is undefined", () => {
+    expect(
+      deriveServiceHealth({
+        type: 'ClusterIP',
+        selector: { app: 'web' },
+      }),
+    ).toBe('unknown')
+  })
+
+  it("returns 'unknown' when endpoints === 0 but no selector (headless)", () => {
+    // No selector means pods are managed externally; we cannot prove
+    // the service is unreachable, so do NOT flag as orphaned.
+    expect(
+      deriveServiceHealth({
+        type: 'ClusterIP',
+        endpoints: 0,
+      }),
+    ).toBe('unknown')
+  })
+})
+
+describe('hasSelector', () => {
+  it('returns false when selector is missing', () => {
+    expect(hasSelector({})).toBe(false)
+  })
+  it('returns false for an empty selector object', () => {
+    expect(hasSelector({ selector: {} })).toBe(false)
+  })
+  it('returns true when selector has at least one key', () => {
+    expect(hasSelector({ selector: { app: 'web' } })).toBe(true)
+  })
+})
+
+describe('hasInvalidSelector (#6166)', () => {
+  it('flags a ClusterIP service with no selector', () => {
+    expect(hasInvalidSelector({ type: 'ClusterIP' })).toBe(true)
+  })
+  it('does not flag ExternalName services without a selector', () => {
+    expect(hasInvalidSelector({ type: 'ExternalName' })).toBe(false)
+  })
+  it('does not flag services with a populated selector', () => {
+    expect(
+      hasInvalidSelector({
+        type: 'ClusterIP',
+        selector: { app: 'web' },
+      }),
+    ).toBe(false)
+  })
+})
+
+describe('formatServicePort (#6163)', () => {
+  it('prefixes the port name when present', () => {
+    expect(formatServicePort({ name: 'http', port: 80, protocol: 'TCP' })).toBe(
+      'http: 80/TCP',
+    )
+  })
+  it('omits the prefix when no name', () => {
+    expect(formatServicePort({ port: 80, protocol: 'TCP' })).toBe('80/TCP')
+  })
+  it('renders NodePort when set', () => {
+    expect(
+      formatServicePort({
+        name: 'http',
+        port: 80,
+        protocol: 'TCP',
+        nodePort: 30080,
+      }),
+    ).toBe('http: 80:30080/TCP')
+  })
+  it('defaults protocol to TCP when omitted', () => {
+    expect(formatServicePort({ port: 80 })).toBe('80/TCP')
+  })
+})
+
+describe('formatServicePorts', () => {
+  it('uses structured portDetails when available', () => {
+    expect(
+      formatServicePorts({
+        portDetails: [
+          { name: 'http', port: 80, protocol: 'TCP' },
+          { name: 'metrics', port: 9090, protocol: 'TCP' },
+        ],
+      }),
+    ).toEqual(['http: 80/TCP', 'metrics: 9090/TCP'])
+  })
+
+  it('falls back to flat ports array when portDetails is missing', () => {
+    expect(formatServicePorts({ ports: ['80/TCP', '443/TCP'] })).toEqual([
+      '80/TCP',
+      '443/TCP',
+    ])
+  })
+
+  it('returns empty array when neither is set', () => {
+    expect(formatServicePorts({})).toEqual([])
+  })
+})

--- a/web/src/lib/services/serviceHealth.ts
+++ b/web/src/lib/services/serviceHealth.ts
@@ -1,0 +1,119 @@
+/**
+ * Centralized service health derivation.
+ *
+ * Covers issues #6162-#6167: the Services dashboard needs one source of
+ * truth for whether a service is healthy, orphaned (selector present but
+ * no ready endpoints), still provisioning (LoadBalancer without ingress),
+ * or in an unknown state. Every rendering surface (dashboard list, card
+ * badges, drill-downs) must compute the badge from this module so the
+ * behavior is consistent.
+ */
+import type { Service, ServicePortDetail } from '../../hooks/mcp/types'
+import {
+  LB_STATUS_PROVISIONING,
+  PORT_NAME_SEPARATOR,
+} from '../constants/network'
+
+/** Derived health status for a service. Distinct from the k8s service
+ * `type` (ClusterIP / LoadBalancer / …). */
+export type ServiceHealthStatus =
+  | 'healthy'        // has ready endpoints
+  | 'orphaned'       // selector present but endpoints === 0 (covers #6164, #6165)
+  | 'provisioning'   // LoadBalancer without an ingress address yet (#6153/#6167)
+  | 'unknown'        // backend did not supply enough data to decide
+
+/** Service types that are allowed to have an empty selector. ExternalName
+ * services intentionally forward DNS and never select pods. */
+const SELECTORLESS_SERVICE_TYPES: ReadonlySet<string> = new Set([
+  'ExternalName',
+])
+
+/** Zero endpoints sentinel — extracted so the comparison is named and
+ * not a bare `=== 0` magic number. */
+const ZERO_ENDPOINTS = 0
+
+/** `true` when the service has a non-empty selector. A service with no
+ * selector cannot be classified as orphaned (it may be a headless /
+ * manually-managed endpoints object). */
+export function hasSelector(svc: Pick<Service, 'selector'>): boolean {
+  return !!svc.selector && Object.keys(svc.selector).length > 0
+}
+
+/** Orphaned = selector matches no pods. Covers #6164 and #6165: a
+ * ClusterIP service with zero ready endpoints cannot be reached. */
+export function isOrphaned(
+  svc: Pick<Service, 'endpoints' | 'selector' | 'lbStatus'>,
+): boolean {
+  // A LoadBalancer that is still provisioning is reported separately,
+  // not as orphaned, even if its endpoints count is zero.
+  if (svc.lbStatus === LB_STATUS_PROVISIONING) return false
+  if (svc.endpoints === undefined) return false
+  return svc.endpoints === ZERO_ENDPOINTS && hasSelector(svc)
+}
+
+/** `true` when a non-ExternalName service has an empty selector. This is
+ * a configuration bug surfaced per #6166. */
+export function hasInvalidSelector(
+  svc: Pick<Service, 'selector' | 'type'>,
+): boolean {
+  if (SELECTORLESS_SERVICE_TYPES.has(svc.type)) return false
+  return !hasSelector(svc)
+}
+
+/** Derive the health status for a service. The order of the checks is
+ * significant — provisioning wins over orphaned so a LoadBalancer that
+ * has not yet received an ingress IP is not mis-reported as orphaned. */
+export function deriveServiceHealth(
+  svc: Pick<Service, 'endpoints' | 'selector' | 'lbStatus' | 'type'>,
+): ServiceHealthStatus {
+  if (svc.lbStatus === LB_STATUS_PROVISIONING) return 'provisioning'
+  if (svc.endpoints === undefined) return 'unknown'
+  if (isOrphaned(svc)) return 'orphaned'
+  if (svc.endpoints > ZERO_ENDPOINTS) return 'healthy'
+  // endpoints === 0 but no selector (headless / externally managed) —
+  // we can't prove it's broken, so surface as unknown rather than
+  // false-positive orphaned.
+  return 'unknown'
+}
+
+/** Tailwind classes for the connectivity dot (#6167). Exported so every
+ * renderer uses the same palette. */
+export const SERVICE_HEALTH_DOT_CLASSES: Record<ServiceHealthStatus, string> = {
+  healthy: 'bg-green-500',
+  orphaned: 'bg-red-500',
+  provisioning: 'bg-yellow-400 animate-pulse',
+  unknown: 'bg-muted-foreground/40',
+}
+
+/** Human-readable label for the health status, used in tooltips and
+ * badge aria labels. */
+export const SERVICE_HEALTH_LABELS: Record<ServiceHealthStatus, string> = {
+  healthy: 'Reachable',
+  orphaned: 'Unreachable (no ready endpoints)',
+  provisioning: 'Provisioning',
+  unknown: 'Status unknown',
+}
+
+/** Format a single structured port for display, prefixing the port name
+ * when one is set (#6163). */
+export function formatServicePort(p: ServicePortDetail): string {
+  const proto = p.protocol || 'TCP'
+  const base =
+    p.nodePort && p.nodePort !== 0
+      ? `${p.port}:${p.nodePort}/${proto}`
+      : `${p.port}/${proto}`
+  return p.name ? `${p.name}${PORT_NAME_SEPARATOR}${base}` : base
+}
+
+/** Render a service's full port list. Prefers the structured
+ * `portDetails` when supplied (newer backend), otherwise falls back to
+ * the legacy flat `ports` array so this helper works with demo data
+ * and older cached payloads. */
+export function formatServicePorts(
+  svc: Pick<Service, 'ports' | 'portDetails'>,
+): string[] {
+  if (svc.portDetails && svc.portDetails.length > 0) {
+    return svc.portDetails.map(formatServicePort)
+  }
+  return svc.ports || []
+}


### PR DESCRIPTION
Fixes #6162, #6163, #6164, #6165, #6166, #6167.

**Stacked on #6169** — depends on the new `Endpoints` + `LBStatus` fields from that PR. Will auto-retarget to `main` when #6169 merges.

## Per-issue summary
- **#6162** — Services cache TTL: `SERVICES_CACHE_TTL_MS = 60_000` enforces a hard wall beyond which cached data is discarded at render time. A yellow `Cached • Ns ago` badge appears once the data crosses `SERVICES_CACHE_STALE_MS = 30_000`.
- **#6163** — Port names: backend `Service` now carries `PortDetails []ServicePortDetail` (Name/Port/Protocol/NodePort). Frontend renders `http: 80/TCP` when a name is set, `80/TCP` otherwise. Legacy flat `Ports []string` retained for existing consumers.
- **#6164 / #6165** — Orphaned detection: backend now surfaces `Selector map[string]string`. A ClusterIP (or any selectable) service with a non-empty selector and zero ready endpoints is classified as `orphaned` and gets a red "Orphaned" badge + red dot.
- **#6166** — Health indicators: endpoint count shown on every row; `deriveServiceHealth` returns one of `healthy` / `orphaned` / `provisioning` / `unknown`; `hasInvalidSelector` helper flags non-ExternalName services with an empty selector.
- **#6167** — Connectivity dot (green/red/yellow) rendered next to each service name, driven by the same `deriveServiceHealth` helper.

## Centralization
All health logic lives in **`web/src/lib/services/serviceHealth.ts`** — `deriveServiceHealth()`, `isOrphaned()`, `hasInvalidSelector()`, `formatServicePort()`, `formatServicePorts()`, plus the shared `SERVICE_HEALTH_DOT_CLASSES` / `SERVICE_HEALTH_LABELS` palette. Every renderer must use these so badges are computed identically.

## Tests
- New: `web/src/lib/services/__tests__/serviceHealth.test.ts` — 20 cases covering every `ServiceHealthStatus` value, the LB-provisioning-beats-orphaned rule, `hasInvalidSelector` for ExternalName, and named/unnamed/NodePort port formatting.
- New: `TestGetServices_PortDetailsAndSelector` in `pkg/k8s/client_test.go` — verifies `PortDetails` order, names, and `Selector` passthrough.
- Existing `TestGetServices_EndpointsAndLoadBalancer` (PR #6169) unchanged and still passing.

## Verification
- `go build ./...` clean
- `go test ./pkg/k8s/... ./pkg/api/handlers/...` — passing
- `npm run build` — passing, no new bundle warnings
- `npm run lint` — no new errors on modified files
- `vitest` for `useCachedData` (334 tests) and `serviceHealth` (20 tests) passing

## No magic numbers
All new thresholds live in `web/src/lib/constants/network.ts`:
`SERVICES_CACHE_TTL_MS`, `SERVICES_CACHE_STALE_MS`, `MS_PER_SECOND`, `PORT_NAME_SEPARATOR`.