### PR TITLE
fix(perf): scaffold permissions + real SPA navigation + 6 more Copilot nits (#6170)

### DIFF
--- a/.github/workflows/perf-bundle-size.yml
+++ b/.github/workflows/perf-bundle-size.yml
@@ -117,6 +117,16 @@ jobs:
     name: Notify on regression
     needs: bundle-size
     if: failure()
+    # Job-level permissions for the reusable workflow. A reusable workflow can
+    # never receive MORE permissions than its caller job, so this block is the
+    # documented way to guarantee `issues: write` reaches
+    # `_perf-regression-issue.yml` even if the workflow-level default is later
+    # tightened (e.g. to `read-all`). Without this, the auto-issue creator
+    # silently no-ops with a permission denied. See #6170.
+    permissions:
+      contents: read
+      issues: write
+      actions: read
     uses: ./.github/workflows/_perf-regression-issue.yml
     with:
       result-path: web/perf-result.json

--- a/.github/workflows/perf-react-commits.yml
+++ b/.github/workflows/perf-react-commits.yml
@@ -96,6 +96,16 @@ jobs:
     name: Notify on regression
     needs: react-commits
     if: failure()
+    # Job-level permissions for the reusable workflow. A reusable workflow can
+    # never receive MORE permissions than its caller job, so this block is the
+    # documented way to guarantee `issues: write` reaches
+    # `_perf-regression-issue.yml` even if the workflow-level default is later
+    # tightened (e.g. to `read-all`). Without this, the auto-issue creator
+    # silently no-ops with a permission denied. See #6170.
+    permissions:
+      contents: read
+      issues: write
+      actions: read
     uses: ./.github/workflows/_perf-regression-issue.yml
     with:
       result-path: web/perf-result.json

--- a/.github/workflows/perf-ttfi.yml
+++ b/.github/workflows/perf-ttfi.yml
@@ -83,8 +83,10 @@ jobs:
       - name: Write perf-result.json (scheduled runs only)
         # Only scheduled runs drive the auto-issue notifier. PR-time failures
         # already surface on the PR via the check status — no need to file
-        # extra issues there.
-        if: github.event_name == 'schedule'
+        # extra issues there. `always()` is required so this step still runs
+        # after the `Compare against baseline (hard fail)` step fails — that's
+        # exactly when we need the JSON written for the notify job. See #6170.
+        if: always() && github.event_name == 'schedule'
         working-directory: .
         env:
           LAST_SUCCESSFUL_SHA: ''
@@ -155,6 +157,16 @@ jobs:
     # Only file auto-issues on scheduled runs. PR failures already surface
     # as red checks on the PR — no need to open a bug there.
     if: failure() && github.event_name == 'schedule'
+    # Job-level permissions for the reusable workflow. A reusable workflow can
+    # never receive MORE permissions than its caller job, so this block is the
+    # documented way to guarantee `issues: write` reaches
+    # `_perf-regression-issue.yml` even if the workflow-level default is later
+    # tightened (e.g. to `read-all`). Without this, the auto-issue creator
+    # silently no-ops with a permission denied. See #6170.
+    permissions:
+      contents: read
+      issues: write
+      actions: read
     uses: ./.github/workflows/_perf-regression-issue.yml
     with:
       result-path: web/perf-result.json

--- a/scripts/perf-regression-issue.mjs
+++ b/scripts/perf-regression-issue.mjs
@@ -64,9 +64,26 @@ if (process.argv.includes('--help') || process.argv.includes('-h')) {
   showHelpAndExit()
 }
 
+// Fallback exit code when spawnSync cannot launch the binary at all
+// (e.g. `gh` not on PATH). We MUST NOT default to 0 here — that would make
+// a missing binary look like success and the script would "succeed"
+// without filing anything. See #6170.
+const SH_SPAWN_FAILURE_CODE = 1
+
 function sh(cmd, args, opts = {}) {
   const res = spawnSync(cmd, args, { encoding: 'utf8', ...opts })
-  return { stdout: (res.stdout || '').trim(), stderr: (res.stderr || '').trim(), code: res.status ?? 0 }
+  if (res.error) {
+    // spawnSync sets `error` and leaves `status === null` when the binary
+    // cannot be spawned. Surface that as a non-zero exit code so callers
+    // take the failure branch instead of treating it as success.
+    log(`failed to spawn ${cmd}: ${res.error.message}`)
+    return { stdout: '', stderr: res.error.message, code: SH_SPAWN_FAILURE_CODE }
+  }
+  return {
+    stdout: (res.stdout || '').trim(),
+    stderr: (res.stderr || '').trim(),
+    code: res.status ?? SH_SPAWN_FAILURE_CODE,
+  }
 }
 
 function log(msg) {
@@ -90,7 +107,11 @@ function readResult(resultPath) {
 function buildMergeLog(lastSuccessfulSha, headSha) {
   if (!lastSuccessfulSha || !headSha) return null
   const range = `${lastSuccessfulSha}..${headSha}`
-  const { stdout, code } = sh('git', ['log', range, '--format=- %h %s'])
+  // `--merges` filters to merge commits only — matches the "Merges since last
+  // successful run" header below and keeps the bisect window narrow enough to
+  // be actionable. Without this flag we'd dump every commit in the range.
+  // See #6170.
+  const { stdout, code } = sh('git', ['log', '--merges', range, '--format=- %h %s'])
   if (code !== 0 || !stdout) return null
   const lines = stdout.split('\n').filter(Boolean)
   if (lines.length === 0) return null

--- a/web/e2e/perf/react-commits.spec.ts
+++ b/web/e2e/perf/react-commits.spec.ts
@@ -26,6 +26,19 @@ import {
 const HOME_ROUTE = '/'
 // Target route for the navigation under measurement.
 const NAV_TARGET_ROUTE = '/clusters'
+// URL glob passed to waitForURL after the sidebar link click. Matches any
+// protocol/host with the target path.
+const NAV_TARGET_URL_GLOB = '**/clusters'
+// Case-insensitive accessible-name matcher for the sidebar link. Matches the
+// rendered "Clusters" link in the KubeStellar sidebar without locking us to
+// a brittle CSS selector.
+const NAV_TARGET_LINK_NAME = /clusters/i
+// localStorage key that forces demo mode. The CI runner has no backend, so
+// without demo mode the app bounces to the login screen and the commit
+// counter never sees a real SPA navigation. This is the same toggle the
+// Settings page flips. See src/lib/constants/storage.ts STORAGE_KEY_DEMO_MODE.
+const DEMO_MODE_STORAGE_KEY = 'kc-demo-mode'
+const DEMO_MODE_STORAGE_VALUE = 'true'
 
 // The init script uses a named global so we can read it later from the page.
 const COMMIT_COUNTER_KEY = '__perfCommitCount'
@@ -76,6 +89,23 @@ test.afterAll(() => {
 })
 
 test('react commits per navigation stays under budget', async ({ page }) => {
+  // Force demo mode BEFORE any app script runs. In CI there's no backend and
+  // no kc-agent, so without this the app would bounce to the login screen and
+  // the sidebar link we click below wouldn't exist. Demo mode short-circuits
+  // auth and serves canned data — exactly the same thing the Settings page
+  // toggle does. See #6170.
+  await page.addInitScript(
+    ({ storageKey, storageValue }) => {
+      try {
+        window.localStorage.setItem(storageKey, storageValue)
+      } catch {
+        // Ignore: happens when the test storage partition is not yet
+        // available. The next page load will still see the attempt.
+      }
+    },
+    { storageKey: DEMO_MODE_STORAGE_KEY, storageValue: DEMO_MODE_STORAGE_VALUE },
+  )
+
   // Install the fake DevTools hook BEFORE any app script runs. React 19
   // calls `onCommitFiberRoot` on every commit when the hook is present.
   await page.addInitScript(
@@ -99,6 +129,7 @@ test('react commits per navigation stays under budget', async ({ page }) => {
   )
 
   await page.goto(HOME_ROUTE)
+  await page.waitForLoadState('networkidle')
   await page.waitForTimeout(NAVIGATION_SETTLE_MS)
 
   // Reset counter — we only care about commits caused by the navigation.
@@ -106,7 +137,14 @@ test('react commits per navigation stays under budget', async ({ page }) => {
     ;(window as unknown as Record<string, number>)[key] = 0
   }, COMMIT_COUNTER_KEY)
 
-  await page.goto(NAV_TARGET_ROUTE)
+  // Real client-side navigation: click the sidebar link instead of calling
+  // `page.goto(NAV_TARGET_ROUTE)`. `page.goto` triggers a full document load,
+  // which would mount the entire React tree from scratch and measure the
+  // cold-mount cost — NOT the in-app SPA route transition that #6149 is
+  // about. Clicking the link exercises the React Router transition, which
+  // is exactly what we want to budget. See #6170.
+  await page.getByRole('link', { name: NAV_TARGET_LINK_NAME }).first().click()
+  await page.waitForURL(NAV_TARGET_URL_GLOB)
   await page.waitForTimeout(NAVIGATION_SETTLE_MS)
 
   const count = await page.evaluate(


### PR DESCRIPTION
Fixes #6170. Addresses 8 Copilot review comments left on the merged perf scaffold PR #6160. Several were **critical** — they blocked the auto-issue feature from working at all.

## Critical fixes

### 1. Reusable workflow permissions (3 of 8)
`perf-react-commits.yml`, `perf-bundle-size.yml`, `perf-ttfi.yml` — the `notify` job that calls `_perf-regression-issue.yml` had no job-level `permissions:` block. A reusable workflow cannot receive MORE permissions than its caller job, so `issues: write` from the reusable workflow was effectively capped by whatever the caller granted. If the workflow-level default is ever tightened (e.g. to `read-all`), the auto-issue creator silently no-ops with permission denied on every regression.

Fix: added a job-level permissions block on each `notify` job:
```yaml
permissions:
  contents: read
  issues: write
  actions: read
```

### 2. `page.goto` measured cold reload, not SPA navigation
`web/e2e/perf/react-commits.spec.ts` — the "navigation" was `page.goto('/clusters')`, which triggers a full document load and mounts the entire React tree from scratch. That measures cold-mount cost, NOT the in-app SPA route transition that #6149 was about.

Fix: click the sidebar link via `page.getByRole('link', { name: /clusters/i }).first().click()` then `waitForURL('**/clusters')`. Exercises the real React Router transition.

### 3. React-commits spec didn't mock auth
Same file — in CI there's no backend, so the app bounces to login and the sidebar link never renders.

Fix: force demo mode in `addInitScript` via `localStorage.setItem('kc-demo-mode', 'true')` (same toggle the Settings page flips). Simpler than route mocks.

### 4. `sh()` silent failure on missing binary
`scripts/perf-regression-issue.mjs` — `res.status ?? 0` turned a failed `spawnSync` (e.g. `gh` missing from PATH) into code 0. The script "succeeded" without filing anything.

Fix: detect `res.error`, log it, return a non-zero `SH_SPAWN_FAILURE_CODE`.

### 5. `buildMergeLog()` claimed merges, returned all commits
Same file — header said "Merges since last successful run" but `git log` was missing `--merges`. Added the flag so the bisect window stays narrow and actionable.

### 6. `perf-result.json` skipped when TTFI gate failed first
`perf-ttfi.yml` — the write step was gated on `github.event_name == 'schedule'` but not `always()`, so it skipped when the earlier "Compare against baseline (hard fail)" step failed. That's exactly when the notify job needs the JSON.

Fix: `if: always() && github.event_name == 'schedule'`. Upload step already had `always()`.

## Code quality

- All numeric/string literals are named constants (`SH_SPAWN_FAILURE_CODE`, `DEMO_MODE_STORAGE_KEY`, `NAV_TARGET_URL_GLOB`, `NAV_TARGET_LINK_NAME`, etc.)
- Every change has an inline comment explaining *why* and linking to #6170 or #6149
- Workflow YAML structure preserved; only the `notify` job and one TTFI step changed

## Test plan

- [x] `python3 yaml.safe_load_all` — all 4 perf workflow YAMLs parse
- [x] `node scripts/perf-regression-issue.mjs --help` — no crash, correct output
- [x] `npm run build` — passes locally, post-build safety checks green
- [ ] CI build/lint/preview green
- [ ] Next scheduled perf run (or manual `workflow_dispatch`) demonstrates the notify job no longer silently no-ops