### PR TITLE
fix(perf+test): seed demo token in perf spec; bump auth test waitFor (#6175, #6176)

### DIFF
--- a/web/e2e/perf/react-commits.spec.ts
+++ b/web/e2e/perf/react-commits.spec.ts
@@ -33,12 +33,23 @@ const NAV_TARGET_URL_GLOB = '**/clusters'
 // rendered "Clusters" link in the KubeStellar sidebar without locking us to
 // a brittle CSS selector.
 const NAV_TARGET_LINK_NAME = /clusters/i
-// localStorage key that forces demo mode. The CI runner has no backend, so
-// without demo mode the app bounces to the login screen and the commit
-// counter never sees a real SPA navigation. This is the same toggle the
-// Settings page flips. See src/lib/constants/storage.ts STORAGE_KEY_DEMO_MODE.
+// localStorage keys+values that force demo mode AND seed the demo token. The
+// CI runner has no backend, so without BOTH set:
+//   - missing kc-demo-mode → app falls through to the login screen
+//   - missing token         → AuthProvider.refreshUser() runs
+//                             checkOAuthConfiguredWithRetry() (5 retries × 2s
+//                             = up to 10s of background re-renders) and the
+//                             commit counter measures auth-revalidate noise
+//                             instead of the SPA navigation cost (#6176).
+//
+// These mirror src/lib/constants/storage.ts:
+//   STORAGE_KEY_DEMO_MODE = 'kc-demo-mode'
+//   STORAGE_KEY_TOKEN     = 'token'
+//   DEMO_TOKEN_VALUE      = 'demo-token'
 const DEMO_MODE_STORAGE_KEY = 'kc-demo-mode'
 const DEMO_MODE_STORAGE_VALUE = 'true'
+const TOKEN_STORAGE_KEY = 'token'
+const DEMO_TOKEN_VALUE = 'demo-token'
 
 // The init script uses a named global so we can read it later from the page.
 const COMMIT_COUNTER_KEY = '__perfCommitCount'
@@ -95,15 +106,21 @@ test('react commits per navigation stays under budget', async ({ page }) => {
   // auth and serves canned data — exactly the same thing the Settings page
   // toggle does. See #6170.
   await page.addInitScript(
-    ({ storageKey, storageValue }) => {
+    ({ demoKey, demoValue, tokenKey, tokenValue }) => {
       try {
-        window.localStorage.setItem(storageKey, storageValue)
+        window.localStorage.setItem(demoKey, demoValue)
+        window.localStorage.setItem(tokenKey, tokenValue)
       } catch {
         // Ignore: happens when the test storage partition is not yet
         // available. The next page load will still see the attempt.
       }
     },
-    { storageKey: DEMO_MODE_STORAGE_KEY, storageValue: DEMO_MODE_STORAGE_VALUE },
+    {
+      demoKey: DEMO_MODE_STORAGE_KEY,
+      demoValue: DEMO_MODE_STORAGE_VALUE,
+      tokenKey: TOKEN_STORAGE_KEY,
+      tokenValue: DEMO_TOKEN_VALUE,
+    },
   )
 
   // Install the fake DevTools hook BEFORE any app script runs. React 19

--- a/web/src/lib/__tests__/auth.test.ts
+++ b/web/src/lib/__tests__/auth.test.ts
@@ -642,9 +642,18 @@ describe('AuthProvider', () => {
     // waiting on isLoading resolves BEFORE refreshUser's async catch block
     // has a chance to clear the token. Wait directly for the token to be
     // cleared by the stale-cache drop path instead.
-    await waitFor(() => {
-      expect(result.current.token).toBeNull()
-    })
+    //
+    // #6175 — bump the waitFor timeout from the default 1000ms to 5000ms.
+    // The default is enough locally but flakes in the coverage suite where
+    // istanbul instrumentation slows the async unwind (refreshUser →
+    // catch → setTokenState(null) → React commit) past 1s. 5s is generous
+    // and still completes in <100ms on a healthy run.
+    await waitFor(
+      () => {
+        expect(result.current.token).toBeNull()
+      },
+      { timeout: 5_000 },
+    )
 
     // Stale cache → session dropped (token cleared, user null)
     expect(result.current.token).toBeNull()


### PR DESCRIPTION
Fixes #6175, #6176. Two small but important follow-ups:

**#6176** — Copilot caught that the perf react-commits spec was setting `kc-demo-mode=true` but NOT seeding the token. Without a token, `AuthProvider.refreshUser()` runs `checkOAuthConfiguredWithRetry()` (5 retries × 2s = up to 10s of background revalidate noise) before settling. The commit counter was measuring auth-revalidate churn instead of the actual SPA navigation. Fix: also seed `STORAGE_KEY_TOKEN` with `DEMO_TOKEN_VALUE` in the same `addInitScript`.

**#6175** — auth.test.ts cache-staleness test reappeared as flaky in Coverage Suite #486. Test passes locally in <100ms but istanbul-instrumented runs slow the async unwind past the default `waitFor` timeout of 1000ms. Bumped that one waitFor to 5000ms — generous for the instrumented build, still completes fast on a healthy run.