### PR TITLE
fix(perf): tighten react-commits budget to 20, allow TTFI manual dispatch notify

### DIFF
--- a/.github/workflows/perf-ttfi.yml
+++ b/.github/workflows/perf-ttfi.yml
@@ -80,13 +80,15 @@ jobs:
           CI_TOLERANCE_PCT: '15'
         run: node e2e/perf/compare-ttfi.mjs
 
-      - name: Write perf-result.json (scheduled runs only)
-        # Only scheduled runs drive the auto-issue notifier. PR-time failures
-        # already surface on the PR via the check status — no need to file
-        # extra issues there. `always()` is required so this step still runs
-        # after the `Compare against baseline (hard fail)` step fails — that's
-        # exactly when we need the JSON written for the notify job. See #6170.
-        if: always() && github.event_name == 'schedule'
+      - name: Write perf-result.json (scheduled + manual dispatch)
+        # Scheduled runs drive the auto-issue notifier in production; manual
+        # dispatches need it too so we can dry-run the full notify pipeline
+        # without waiting for a cron tick. PR-time failures already surface on
+        # the PR via the check status, so PR runs are still excluded.
+        # `always()` is required so this step still runs after the
+        # `Compare against baseline (hard fail)` step fails — that's exactly
+        # when we need the JSON written for the notify job. See #6170.
+        if: always() && (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch')
         working-directory: .
         env:
           LAST_SUCCESSFUL_SHA: ''
@@ -117,8 +119,8 @@ jobs:
           }
           EOF
 
-      - name: Upload perf result artifact (scheduled runs only)
-        if: always() && github.event_name == 'schedule'
+      - name: Upload perf result artifact (scheduled + manual dispatch)
+        if: always() && (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch')
         uses: actions/upload-artifact@v4
         with:
           name: perf-result-ttfi-all-cards
@@ -154,9 +156,10 @@ jobs:
   notify:
     name: Notify on scheduled regression
     needs: all-cards-ttfi
-    # Only file auto-issues on scheduled runs. PR failures already surface
-    # as red checks on the PR — no need to open a bug there.
-    if: failure() && github.event_name == 'schedule'
+    # File auto-issues on scheduled runs and manual dispatches (so we can
+    # dry-run the full notifier pipeline without waiting for a cron tick).
+    # PR failures still excluded — they already surface as red checks on the PR.
+    if: failure() && (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch')
     # Job-level permissions for the reusable workflow. A reusable workflow can
     # never receive MORE permissions than its caller job, so this block is the
     # documented way to guarantee `issues: write` reaches

--- a/web/e2e/perf/constants.ts
+++ b/web/e2e/perf/constants.ts
@@ -6,11 +6,14 @@
  * auto-issue workflow all agree on the same values.
  */
 
-// Max number of React commits allowed during a SPA navigation. 50 is a
-// generous ceiling — a healthy route change should be well under 20. The
-// current (buggy) count is ~461 (tracked by #6149); this is the gate that
-// flips red when the regression reappears.
-export const PERF_BUDGET_NAVIGATION_COMMITS = 50
+// Max number of React commits allowed during a SPA navigation. The post-fix
+// measurement (after #6161 stabilized AuthProvider value + #6178 seeded the
+// demo token so the perf spec doesn't measure auth-revalidate noise) is 13
+// commits for a real /clusters navigation. Budget is set to 20 — that's the
+// observed 13 plus 7 commits of headroom for legitimate growth, while still
+// catching any regression that pushes us back toward the ~461-commit cascade
+// tracked by #6149.
+export const PERF_BUDGET_NAVIGATION_COMMITS = 20
 
 // How long to let the UI settle after a navigation before we snapshot
 // the commit counter. 2s is enough for cached dashboards + router transitions


### PR DESCRIPTION
## Summary

Two follow-ups after #6178 landed the demo-token seed in the perf spec.

### 1. Tighten \`PERF_BUDGET_NAVIGATION_COMMITS\` from 50 to 20

With #6161 stabilizing \`AuthProvider\` and #6178 seeding the demo token so the perf spec doesn't measure auth-revalidate noise, the **real** \`/clusters\` navigation now costs **13 React commits** (run [24254066899](https://github.com/kubestellar/console/actions/runs/24254066899)).

Budget 20 = observed 13 + 7 commits headroom. Still catches any regression that pushes us back toward the ~461-commit cascade tracked by #6149.

### 2. \`perf-ttfi.yml\`: allow \`workflow_dispatch\` to drive notify

Relax the schedule-only gates on the result-write step, the artifact-upload step, and the notify job so manual dispatches can dry-run the full notifier pipeline end-to-end without waiting for a cron tick. PR runs are still excluded — failures already surface as red checks on the PR.

The other two perf workflows (\`perf-react-commits.yml\`, \`perf-bundle-size.yml\`) already allow manual dispatch through.

## Test plan

- [x] \`npm run build\` passes locally
- [x] Real perf run measured 13 commits at 50 budget — new budget of 20 is comfortably above
- [ ] After merge, dispatch \`perf-react-commits.yml\` once more to confirm budget 20 still passes
- [ ] After merge, dispatch \`perf-ttfi.yml\` manually to verify the notify pipeline fires end-to-end