### PR TITLE
feat: add OpenYurt edge computing monitoring card

### DIFF
--- a/web/src/components/cards/cardMetadata.ts
+++ b/web/src/components/cards/cardMetadata.ts
@@ -282,6 +282,8 @@ export const CARD_TITLES: Record<string, string> = {
   deployment_rollout_tracker: 'Deployment Rollout Tracker',
   // KEDA
   keda_status: 'KEDA',
+  // OpenYurt edge computing
+  openyurt_status: 'OpenYurt',
   // Karmada multi-cluster orchestration
   karmada_status: 'Karmada',
   kuberay_fleet: 'KubeRay Fleet',
@@ -549,6 +551,8 @@ export const CARD_DESCRIPTIONS: Record<string, string> = {
   deployment_rollout_tracker: 'Tracks deployment rollout progress across clusters.',
   // KEDA
   keda_status: 'KEDA (Kubernetes Event-Driven Autoscaling) automatically scales workloads based on external event sources like message queues, databases, or custom metrics. This card shows which workloads are being autoscaled, their current triggers, and queue depths.',
+  // OpenYurt edge computing
+  openyurt_status: 'OpenYurt extends Kubernetes to edge computing scenarios. This card monitors edge node pools, node autonomy status, and Raven gateway connectivity between edge and cloud clusters.',
   // Karmada multi-cluster orchestration
   karmada_status: 'Karmada is a multi-cluster orchestration tool that propagates resources (Deployments, Services, etc.) across multiple clusters using placement policies. This card shows propagation status, member cluster health, and policy compliance.',
   kuberay_fleet: 'Discovers RayCluster, RayService, and RayJob CRDs across all connected clusters. Shows fleet-level Ray workload status including GPU allocations, serving endpoints, and job progress.',

--- a/web/src/components/cards/cardRegistry.ts
+++ b/web/src/components/cards/cardRegistry.ts
@@ -249,6 +249,8 @@ const TrinoGateway = safeLazy(() => import('./trino_gateway'), 'TrinoGateway')
 const ThanosStatus = safeLazy(() => import('./thanos_status'), 'ThanosStatus')
 // OpenFeature feature-flag management card
 const OpenFeatureStatus = safeLazy(() => import('./openfeature_status'), 'OpenFeatureStatus')
+// OpenYurt edge computing card
+const OpenYurtStatus = safeLazy(() => import('./openyurt_status'), 'OpenYurtStatus')
 
 // Inspektor Gadget cards
 const NetworkTraceCard = safeLazy(() => import('./gadget/NetworkTraceCard'), 'NetworkTraceCard')
@@ -552,6 +554,8 @@ const RAW_CARD_COMPONENTS: Record<string, CardComponent> = {
   kubevela_status: KubeVelaStatus,
   // Karmada multi-cluster orchestration
   karmada_status: KarmadaStatus,
+  // OpenYurt edge computing
+  openyurt_status: OpenYurtStatus,
   // KubeRay fleet monitoring
   kuberay_fleet: KubeRayFleet,
   // SLO compliance tracking
@@ -953,6 +957,8 @@ const CARD_CHUNK_PRELOADERS: Record<string, () => Promise<unknown>> = {
   kubevela_status: () => import('./kubevela_status'),
   // Karmada multi-cluster orchestration
   karmada_status: () => import('./karmada_status'),
+  // OpenYurt edge computing
+  openyurt_status: () => import('./openyurt_status'),
   kuberay_fleet: () => import('./kuberay_fleet'),
   slo_compliance: () => import('./slo_compliance'),
   failover_timeline: () => import('./failover_timeline'),
@@ -1136,6 +1142,7 @@ export const LIVE_DATA_CARDS = new Set([
   'crio_status',
   'strimzi_status',
   'kubevela_status',
+  'openyurt_status',
   // KubeRay, SLO, Failover, Trino - demo until detected
   'kuberay_fleet',
   'slo_compliance',
@@ -1275,6 +1282,8 @@ export const CARD_DEFAULT_WIDTHS: Record<string, number> = {
   quota_heatmap: 8,
   // KubeVela application delivery
   kubevela_status: 6,
+  // OpenYurt edge computing
+  openyurt_status: 6,
   // Flatcar Container Linux
   flatcar_status: 6,
   // Fluentd log collector

--- a/web/src/components/cards/openyurt_status/OpenYurtStatus.tsx
+++ b/web/src/components/cards/openyurt_status/OpenYurtStatus.tsx
@@ -1,0 +1,396 @@
+import { useState } from 'react'
+import {
+  CheckCircle,
+  AlertTriangle,
+  RefreshCw,
+  Cloud,
+  Radio,
+  XCircle,
+  Server,
+  Wifi,
+  WifiOff,
+  Shield,
+} from 'lucide-react'
+import { useTranslation } from 'react-i18next'
+import { Skeleton, SkeletonStats, SkeletonList } from '../../ui/Skeleton'
+import { CardSearchInput } from '../../../lib/cards/CardComponents'
+import { useOpenYurtStatus } from './useOpenYurtStatus'
+import type { OpenYurtNodePool, NodePoolStatus, NodePoolType, OpenYurtGateway, GatewayStatus } from './demoData'
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const POOL_STATUS_CONFIG: Record<
+  NodePoolStatus,
+  { label: string; color: string; icon: React.ReactNode }
+> = {
+  ready: {
+    label: 'Ready',
+    color: 'text-green-400',
+    icon: <CheckCircle className="w-3.5 h-3.5 text-green-400" />,
+  },
+  degraded: {
+    label: 'Degraded',
+    color: 'text-yellow-400',
+    icon: <AlertTriangle className="w-3.5 h-3.5 text-yellow-400" />,
+  },
+  'not-ready': {
+    label: 'Not Ready',
+    color: 'text-red-400',
+    icon: <XCircle className="w-3.5 h-3.5 text-red-400" />,
+  },
+}
+
+const POOL_TYPE_CONFIG: Record<
+  NodePoolType,
+  { label: string; icon: React.ReactNode }
+> = {
+  edge: {
+    label: 'Edge',
+    icon: <Radio className="w-3 h-3 text-purple-400" />,
+  },
+  cloud: {
+    label: 'Cloud',
+    icon: <Cloud className="w-3 h-3 text-blue-400" />,
+  },
+}
+
+const GATEWAY_STATUS_CONFIG: Record<
+  GatewayStatus,
+  { label: string; color: string; icon: React.ReactNode }
+> = {
+  connected: {
+    label: 'Connected',
+    color: 'text-green-400',
+    icon: <Wifi className="w-3 h-3 text-green-400" />,
+  },
+  disconnected: {
+    label: 'Disconnected',
+    color: 'text-red-400',
+    icon: <WifiOff className="w-3 h-3 text-red-400" />,
+  },
+  pending: {
+    label: 'Pending',
+    color: 'text-yellow-400',
+    icon: <RefreshCw className="w-3 h-3 text-yellow-400" />,
+  },
+}
+
+function useFormatRelativeTime() {
+  const { t } = useTranslation('cards')
+  return (isoString: string): string => {
+    const diff = Date.now() - new Date(isoString).getTime()
+    if (isNaN(diff) || diff < 0) return t('openyurt.syncedJustNow')
+    const minute = 60_000
+    const hour = 60 * minute
+    const day = 24 * hour
+    if (diff < minute) return t('openyurt.syncedJustNow')
+    if (diff < hour) return t('openyurt.syncedMinutesAgo', { count: Math.floor(diff / minute) })
+    if (diff < day) return t('openyurt.syncedHoursAgo', { count: Math.floor(diff / hour) })
+    return t('openyurt.syncedDaysAgo', { count: Math.floor(diff / day) })
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Sub-components
+// ---------------------------------------------------------------------------
+
+function StatTile({
+  icon,
+  label,
+  value,
+  colorClass,
+  borderClass,
+}: {
+  icon: React.ReactNode
+  label: string
+  value: number
+  colorClass: string
+  borderClass: string
+}) {
+  return (
+    <div className={`p-3 rounded-lg bg-secondary/30 border ${borderClass}`}>
+      <div className="flex items-center gap-2 mb-1">
+        {icon}
+        <span className={`text-xs ${colorClass}`}>{label}</span>
+      </div>
+      <span className="text-2xl font-bold text-foreground">{value}</span>
+    </div>
+  )
+}
+
+function NodeReadinessBar({
+  ready,
+  total,
+}: {
+  ready: number
+  total: number
+}) {
+  const pct = total > 0 ? Math.min((ready / total) * 100, 100) : 0
+  const allReady = ready === total && total > 0
+  return (
+    <div className="mt-1.5">
+      <div className="relative h-1.5 rounded-full bg-muted overflow-hidden">
+        <div
+          className={`absolute h-full rounded-full transition-all ${allReady ? 'bg-green-500' : 'bg-yellow-500'}`}
+          style={{ width: `${pct}%` }}
+        />
+      </div>
+    </div>
+  )
+}
+
+function NodePoolRow({ pool }: { pool: OpenYurtNodePool }) {
+  const { t } = useTranslation('cards')
+  const statusCfg = POOL_STATUS_CONFIG[pool.status]
+  const typeCfg = POOL_TYPE_CONFIG[pool.type]
+
+  return (
+    <div className="rounded-md bg-muted/30 px-3 py-2 space-y-1.5">
+      {/* Row 1: name + status + node count */}
+      <div className="flex items-center justify-between gap-2">
+        <div className="flex items-center gap-1.5 min-w-0">
+          {statusCfg.icon}
+          <span className="text-xs font-medium truncate">{pool.name}</span>
+        </div>
+        <div className="flex items-center gap-2 shrink-0">
+          <span className="text-xs text-muted-foreground">
+            {pool.readyNodes}/{pool.nodeCount} {t('openyurt.nodes', 'nodes')}
+          </span>
+          <span className={`text-xs ${statusCfg.color}`}>{statusCfg.label}</span>
+        </div>
+      </div>
+
+      {/* Row 2: pool type + autonomy */}
+      <div className="flex items-center justify-between text-xs text-muted-foreground">
+        <span className="flex items-center gap-1">
+          {typeCfg.icon}
+          {typeCfg.label}
+        </span>
+        {pool.autonomyEnabled && (
+          <span className="flex items-center gap-1 text-purple-400/80">
+            <Shield className="w-3 h-3" />
+            {t('openyurt.autonomous', 'Autonomous')}
+          </span>
+        )}
+      </div>
+
+      {/* Row 3: node readiness bar */}
+      <NodeReadinessBar ready={pool.readyNodes} total={pool.nodeCount} />
+    </div>
+  )
+}
+
+function GatewayRow({ gw }: { gw: OpenYurtGateway }) {
+  const cfg = GATEWAY_STATUS_CONFIG[gw.status]
+
+  return (
+    <div className="flex items-center justify-between gap-2 px-3 py-1.5 rounded-md bg-muted/20">
+      <div className="flex items-center gap-1.5 min-w-0">
+        {cfg.icon}
+        <span className="text-xs truncate">{gw.name}</span>
+        <span className="text-xs text-muted-foreground truncate">→ {gw.nodePool}</span>
+      </div>
+      <span className={`text-xs shrink-0 ${cfg.color}`}>{cfg.label}</span>
+    </div>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Main component
+// ---------------------------------------------------------------------------
+
+export function OpenYurtStatus() {
+  const { t } = useTranslation('cards')
+  const formatRelativeTime = useFormatRelativeTime()
+  const { data, isRefreshing, error, showSkeleton, showEmptyState } = useOpenYurtStatus()
+  const [search, setSearch] = useState('')
+
+  // Guard against undefined nested data
+  const nodePools = data.nodePools || []
+  const gateways = data.gateways || []
+  const controllerPods = data.controllerPods || { ready: 0, total: 0 }
+
+  // Derived stats
+  const stats = (() => {
+    return {
+      totalPools: nodePools.length,
+      readyPools: nodePools.filter(p => p.status === 'ready').length,
+      edgePools: nodePools.filter(p => p.type === 'edge').length,
+      connectedGateways: gateways.filter(g => g.status === 'connected').length,
+    }
+  })()
+
+  // Filtered list (local search)
+  const filteredPools = (() => {
+    if (!search.trim()) return nodePools
+    const q = search.toLowerCase()
+    return nodePools.filter(
+      p =>
+        p.name.toLowerCase().includes(q) ||
+        p.type.toLowerCase().includes(q) ||
+        p.status.toLowerCase().includes(q),
+    )
+  })()
+
+  // ── Loading ──────────────────────────────────────────────────────────────
+  if (showSkeleton) {
+    return (
+      <div className="h-full flex flex-col min-h-card gap-4">
+        <div className="flex items-center justify-between">
+          <Skeleton variant="rounded" width={120} height={28} />
+          <Skeleton variant="rounded" width={80} height={20} />
+        </div>
+        <SkeletonStats className="grid-cols-4" />
+        <Skeleton variant="rounded" height={32} />
+        <SkeletonList items={3} className="flex-1" />
+      </div>
+    )
+  }
+
+  // ── Error ─────────────────────────────────────────────────────────────────
+  if (error && showEmptyState) {
+    return (
+      <div className="h-full flex flex-col items-center justify-center min-h-card text-muted-foreground gap-2">
+        <AlertTriangle className="w-6 h-6 text-red-400" />
+        <p className="text-sm text-red-400">
+          {t('openyurt.fetchError', 'Failed to fetch OpenYurt status')}
+        </p>
+      </div>
+    )
+  }
+
+  // ── Not installed ─────────────────────────────────────────────────────────
+  if (data.health === 'not-installed') {
+    return (
+      <div className="h-full flex flex-col items-center justify-center min-h-card text-muted-foreground gap-2">
+        <Radio className="w-6 h-6 text-muted-foreground/50" />
+        <p className="text-sm font-medium">
+          {t('openyurt.notInstalled', 'OpenYurt not detected')}
+        </p>
+        <p className="text-xs text-center max-w-xs">
+          {t(
+            'openyurt.notInstalledHint',
+            'No OpenYurt controller pods found. Deploy OpenYurt to enable edge computing features.',
+          )}
+        </p>
+      </div>
+    )
+  }
+
+  const isHealthy = data.health === 'healthy'
+  const healthColorClass = isHealthy
+    ? 'bg-green-500/15 text-green-400'
+    : 'bg-yellow-500/15 text-yellow-400'
+
+  return (
+    <div className="h-full flex flex-col min-h-card content-loaded gap-4 overflow-hidden">
+      {/* ── Header: health badge + controller pods + last check ── */}
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-2">
+          <div
+            className={`flex items-center gap-2 px-3 py-1.5 rounded-full text-sm font-medium ${healthColorClass}`}
+          >
+            {isHealthy ? (
+              <CheckCircle className="w-4 h-4" />
+            ) : (
+              <AlertTriangle className="w-4 h-4" />
+            )}
+            {isHealthy
+              ? t('openyurt.healthy', 'Healthy')
+              : t('openyurt.degraded', 'Degraded')}
+          </div>
+          <span className="text-xs text-muted-foreground flex items-center gap-1">
+            <Server className="w-3 h-3" />
+            {controllerPods.ready}/{controllerPods.total}{' '}
+            {t('openyurt.controllerPods', 'pods')}
+          </span>
+        </div>
+        <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
+          <RefreshCw className={`w-3 h-3 ${isRefreshing ? 'animate-spin' : ''}`} />
+          <span>{formatRelativeTime(data.lastCheckTime)}</span>
+        </div>
+      </div>
+
+      {/* ── Stats grid ── */}
+      {nodePools.length > 0 && (
+        <div className="grid grid-cols-4 gap-2">
+          <StatTile
+            icon={<Server className="w-4 h-4 text-blue-400" />}
+            label={t('openyurt.totalNodes', 'Nodes')}
+            value={data.totalNodes}
+            colorClass="text-blue-400"
+            borderClass="border-blue-500/20"
+          />
+          <StatTile
+            icon={<Radio className="w-4 h-4 text-purple-400" />}
+            label={t('openyurt.edgePools', 'Edge Pools')}
+            value={stats.edgePools}
+            colorClass="text-purple-400"
+            borderClass="border-purple-500/20"
+          />
+          <StatTile
+            icon={<CheckCircle className="w-4 h-4 text-green-400" />}
+            label={t('openyurt.readyPools', 'Ready')}
+            value={stats.readyPools}
+            colorClass="text-green-400"
+            borderClass="border-green-500/20"
+          />
+          <StatTile
+            icon={<Wifi className="w-4 h-4 text-cyan-400" />}
+            label={t('openyurt.gateways', 'Gateways')}
+            value={stats.connectedGateways}
+            colorClass="text-cyan-400"
+            borderClass="border-cyan-500/20"
+          />
+        </div>
+      )}
+
+      {/* ── Search ── */}
+      {nodePools.length > 0 && (
+        <CardSearchInput
+          value={search}
+          onChange={setSearch}
+          placeholder={t('openyurt.searchPlaceholder', 'Search node pools…')}
+        />
+      )}
+
+      {/* ── Node pools list ── */}
+      <div className="flex-1 space-y-2 overflow-y-auto">
+        {filteredPools.length > 0 ? (
+          filteredPools.map(pool => (
+            <NodePoolRow key={pool.name} pool={pool} />
+          ))
+        ) : nodePools.length === 0 ? (
+          <div className="flex flex-col items-center justify-center h-full text-muted-foreground gap-1 py-6">
+            <Radio className="w-6 h-6 opacity-40" />
+            <p className="text-sm">{t('openyurt.noNodePools', 'Controller running')}</p>
+            <p className="text-xs text-center">
+              {t(
+                'openyurt.noNodePoolsHint',
+                'NodePool data requires the OpenYurt CRD API.',
+              )}
+            </p>
+          </div>
+        ) : (
+          <div className="flex items-center justify-center py-6 text-xs text-muted-foreground">
+            {t('openyurt.noSearchResults', 'No node pools match your search.')}
+          </div>
+        )}
+      </div>
+
+      {/* ── Footer: gateways summary ── */}
+      {gateways.length > 0 && (
+        <div className="pt-2 border-t border-border/50 space-y-1.5">
+          <div className="text-xs text-muted-foreground font-medium">
+            {t('openyurt.ravenGateways', 'Raven Gateways')}
+          </div>
+          {gateways.map(gw => (
+            <GatewayRow key={gw.name} gw={gw} />
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/web/src/components/cards/openyurt_status/demoData.ts
+++ b/web/src/components/cards/openyurt_status/demoData.ts
@@ -1,0 +1,130 @@
+/**
+ * Demo data for the OpenYurt edge computing status card.
+ *
+ * Represents a typical edge-cloud topology managed by OpenYurt with
+ * node pools, edge node autonomy, and Raven gateway connectivity.
+ * Used in demo mode or when no Kubernetes clusters are connected.
+ *
+ * OpenYurt terminology:
+ * - NodePool: logical grouping of nodes (edge or cloud)
+ * - Autonomy: edge nodes can operate independently when disconnected
+ * - Raven Gateway: cross-pool network tunnel for edge-cloud connectivity
+ */
+
+const DEMO_LAST_CHECK_OFFSET_MS = 45_000 // Demo data shows as checked 45 seconds ago
+
+export type NodePoolType = 'edge' | 'cloud'
+
+export type NodePoolStatus = 'ready' | 'degraded' | 'not-ready'
+
+export type GatewayStatus = 'connected' | 'disconnected' | 'pending'
+
+export interface OpenYurtNodePool {
+  name: string
+  type: NodePoolType
+  status: NodePoolStatus
+  /** Total number of nodes in the pool */
+  nodeCount: number
+  /** Number of nodes reporting Ready condition */
+  readyNodes: number
+  /** Whether autonomy is enabled for this pool */
+  autonomyEnabled: boolean
+}
+
+export interface OpenYurtGateway {
+  name: string
+  /** The node pool this gateway serves */
+  nodePool: string
+  status: GatewayStatus
+  /** Endpoint address (IP or hostname) */
+  endpoint: string
+}
+
+export interface OpenYurtDemoData {
+  health: 'healthy' | 'degraded' | 'not-installed'
+  controllerPods: {
+    ready: number
+    total: number
+  }
+  nodePools: OpenYurtNodePool[]
+  gateways: OpenYurtGateway[]
+  totalNodes: number
+  autonomousNodes: number
+  lastCheckTime: string
+}
+
+export const OPENYURT_DEMO_DATA: OpenYurtDemoData = {
+  health: 'degraded',
+  controllerPods: { ready: 2, total: 3 },
+  nodePools: [
+    {
+      name: 'cloud-pool',
+      type: 'cloud',
+      status: 'ready',
+      nodeCount: 3,
+      readyNodes: 3,
+      autonomyEnabled: false,
+    },
+    {
+      name: 'edge-beijing-1',
+      type: 'edge',
+      status: 'ready',
+      nodeCount: 5,
+      readyNodes: 5,
+      autonomyEnabled: true,
+    },
+    {
+      name: 'edge-shanghai-2',
+      type: 'edge',
+      status: 'degraded',
+      nodeCount: 4,
+      readyNodes: 3,
+      autonomyEnabled: true,
+    },
+    {
+      name: 'edge-shenzhen-3',
+      type: 'edge',
+      status: 'ready',
+      nodeCount: 6,
+      readyNodes: 6,
+      autonomyEnabled: true,
+    },
+    {
+      name: 'edge-hangzhou-4',
+      type: 'edge',
+      status: 'not-ready',
+      nodeCount: 2,
+      readyNodes: 0,
+      autonomyEnabled: true,
+    },
+  ],
+  gateways: [
+    {
+      name: 'gw-beijing-1',
+      nodePool: 'edge-beijing-1',
+      status: 'connected',
+      endpoint: '10.0.1.100',
+    },
+    {
+      name: 'gw-shanghai-2',
+      nodePool: 'edge-shanghai-2',
+      status: 'connected',
+      endpoint: '10.0.2.100',
+    },
+    {
+      name: 'gw-shenzhen-3',
+      nodePool: 'edge-shenzhen-3',
+      status: 'connected',
+      endpoint: '10.0.3.100',
+    },
+    {
+      name: 'gw-hangzhou-4',
+      nodePool: 'edge-hangzhou-4',
+      status: 'disconnected',
+      endpoint: '10.0.4.100',
+    },
+  ],
+  totalNodes: 20,
+  autonomousNodes: 17,
+  lastCheckTime: new Date(Date.now() - DEMO_LAST_CHECK_OFFSET_MS).toISOString(),
+}

--- a/web/src/components/cards/openyurt_status/index.ts
+++ b/web/src/components/cards/openyurt_status/index.ts
@@ -1,0 +1,1 @@
+export { OpenYurtStatus } from './OpenYurtStatus'

--- a/web/src/components/cards/openyurt_status/useOpenYurtStatus.ts
+++ b/web/src/components/cards/openyurt_status/useOpenYurtStatus.ts
@@ -1,0 +1,298 @@
+import { useCache } from '../../../lib/cache'
+import { useCardLoadingState } from '../CardDataContext'
+import { OPENYURT_DEMO_DATA, type OpenYurtDemoData, type OpenYurtNodePool, type NodePoolType, type NodePoolStatus, type GatewayStatus } from './demoData'
+import { FETCH_DEFAULT_TIMEOUT_MS } from '../../../lib/constants'
+import { authFetch } from '../../../lib/api'
+
+export type OpenYurtStatus = OpenYurtDemoData
+
+const INITIAL_DATA: OpenYurtStatus = {
+  health: 'not-installed',
+  controllerPods: { ready: 0, total: 0 },
+  nodePools: [],
+  gateways: [],
+  totalNodes: 0,
+  autonomousNodes: 0,
+  lastCheckTime: new Date().toISOString(),
+}
+
+const CACHE_KEY = 'openyurt-status'
+
+// ---------------------------------------------------------------------------
+// Backend response types
+// ---------------------------------------------------------------------------
+
+interface BackendPodInfo {
+  name?: string
+  namespace?: string
+  status?: string
+  ready?: string
+  labels?: Record<string, string>
+}
+
+interface CRItem {
+  name: string
+  namespace?: string
+  cluster: string
+  status?: Record<string, unknown>
+  spec?: Record<string, unknown>
+  labels?: Record<string, string>
+  annotations?: Record<string, string>
+}
+
+interface CRResponse {
+  items?: CRItem[]
+  isDemoData?: boolean
+}
+
+// ---------------------------------------------------------------------------
+// Pod helpers
+// ---------------------------------------------------------------------------
+
+function isOpenYurtControllerPod(pod: BackendPodInfo): boolean {
+  const labels = pod.labels ?? {}
+  const name = (pod.name ?? '').toLowerCase()
+  return (
+    labels['app'] === 'yurt-manager' ||
+    labels['app.kubernetes.io/name'] === 'openyurt' ||
+    labels['app.kubernetes.io/name'] === 'yurt-manager' ||
+    labels['app.kubernetes.io/part-of'] === 'openyurt' ||
+    name.startsWith('yurt-manager') ||
+    name.startsWith('yurt-controller-manager') ||
+    name.startsWith('yurt-hub') ||
+    name.startsWith('yurt-tunnel')
+  )
+}
+
+function isPodReady(pod: BackendPodInfo): boolean {
+  const status = (pod.status ?? '').toLowerCase()
+  const ready = pod.ready ?? ''
+  if (status !== 'running') return false
+  const parts = ready.split('/')
+  if (parts.length !== 2) return false
+  return parts[0] === parts[1] && parseInt(parts[0], 10) > 0
+}
+
+// ---------------------------------------------------------------------------
+// CRD helpers
+// ---------------------------------------------------------------------------
+
+async function fetchCR(group: string, version: string, resource: string): Promise<CRItem[]> {
+  try {
+    const params = new URLSearchParams({ group, version, resource })
+    const resp = await authFetch(`/api/mcp/custom-resources?${params}`, {
+      headers: { Accept: 'application/json' },
+      signal: AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS),
+    })
+    if (!resp.ok) return []
+    const body: CRResponse = await resp.json()
+    return body.items ?? []
+  } catch {
+    return []
+  }
+}
+
+// ---------------------------------------------------------------------------
+// NodePool parser
+// ---------------------------------------------------------------------------
+
+const KNOWN_POOL_TYPES = new Set<string>(['edge', 'cloud'])
+
+function parseNodePool(item: CRItem): OpenYurtNodePool {
+  const spec = (item.spec ?? {}) as Record<string, unknown>
+  const status = (item.status ?? {}) as Record<string, unknown>
+  const annotations = item.annotations ?? {}
+
+  // Pool type: spec.type or annotation
+  const rawType = (spec.type as string) ?? annotations['apps.openyurt.io/pool-type'] ?? 'edge'
+  const poolType: NodePoolType = KNOWN_POOL_TYPES.has(rawType) ? (rawType as NodePoolType) : 'edge'
+
+  // Node counts from status
+  const nodeCount = typeof status.readyNodeNum === 'number' && typeof status.unreadyNodeNum === 'number'
+    ? status.readyNodeNum + status.unreadyNodeNum
+    : typeof status.nodes === 'number'
+      ? status.nodes
+      : 0
+  const readyNodes = typeof status.readyNodeNum === 'number'
+    ? status.readyNodeNum
+    : nodeCount
+
+  // Derive pool status
+  let poolStatus: NodePoolStatus = 'ready'
+  if (nodeCount === 0 || readyNodes === 0) {
+    poolStatus = 'not-ready'
+  } else if (readyNodes < nodeCount) {
+    poolStatus = 'degraded'
+  }
+
+  // Autonomy enabled check
+  const autonomyEnabled = poolType === 'edge' ||
+    spec.autonomy === true ||
+    annotations['node.beta.openyurt.io/autonomy'] === 'true'
+
+  return {
+    name: item.name,
+    type: poolType,
+    status: poolStatus,
+    nodeCount,
+    readyNodes,
+    autonomyEnabled,
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Gateway parser
+// ---------------------------------------------------------------------------
+
+function parseGateway(item: CRItem): { name: string; nodePool: string; status: GatewayStatus; endpoint: string } {
+  const spec = (item.spec ?? {}) as Record<string, unknown>
+  const status = (item.status ?? {}) as Record<string, unknown>
+
+  const nodePool = (spec.nodePool as string) ??
+    (spec.proxyNodePool as string) ??
+    (item.labels?.['raven.openyurt.io/gateway-node-pool'] ?? '')
+
+  // Derive endpoint
+  const endpoints = Array.isArray(spec.endpoints) ? spec.endpoints : []
+  const endpoint = endpoints.length > 0
+    ? ((endpoints[0] as Record<string, unknown>).publicIP as string) ?? ''
+    : (spec.endpoint as string) ?? ''
+
+  // Derive status
+  const activeEndpoints = Array.isArray(status.activeEndpoints) ? status.activeEndpoints : []
+  const nodes = Array.isArray(status.nodes) ? status.nodes : []
+  let gwStatus: GatewayStatus = 'pending'
+  if (activeEndpoints.length > 0 || nodes.length > 0) {
+    gwStatus = 'connected'
+  } else if (status.phase === 'Disconnected' || status.phase === 'Failed') {
+    gwStatus = 'disconnected'
+  }
+
+  return {
+    name: item.name,
+    nodePool,
+    status: gwStatus,
+    endpoint,
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Pod fetcher
+// ---------------------------------------------------------------------------
+
+async function fetchPods(url: string): Promise<BackendPodInfo[]> {
+  const resp = await fetch(url, {
+    headers: { Accept: 'application/json' },
+    signal: AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS),
+  })
+  if (!resp.ok) throw new Error(`HTTP ${resp.status}`)
+  const body: { pods?: BackendPodInfo[] } = await resp.json()
+  return Array.isArray(body?.pods) ? body.pods : []
+}
+
+// ---------------------------------------------------------------------------
+// Main fetcher
+// ---------------------------------------------------------------------------
+
+async function fetchOpenYurtStatus(): Promise<OpenYurtStatus> {
+  // Step 1: Detect OpenYurt controller pods
+  const labeledPods = await fetchPods(
+    '/api/mcp/pods?labelSelector=app.kubernetes.io%2Fname%3Dyurt-manager',
+  )
+  const yurtPods = labeledPods.length > 0
+    ? labeledPods.filter(isOpenYurtControllerPod)
+    : (await fetchPods('/api/mcp/pods')).filter(isOpenYurtControllerPod)
+
+  if (yurtPods.length === 0) {
+    return {
+      ...INITIAL_DATA,
+      health: 'not-installed',
+      lastCheckTime: new Date().toISOString(),
+    }
+  }
+
+  const readyPods = yurtPods.filter(isPodReady).length
+  const allPodsReady = readyPods === yurtPods.length
+
+  // Step 2: Fetch NodePool and Gateway CRDs (best-effort, in parallel)
+  const [nodePoolItems, gatewayItems] = await Promise.all([
+    fetchCR('apps.openyurt.io', 'v1beta1', 'nodepools'),
+    fetchCR('raven.openyurt.io', 'v1beta1', 'gateways'),
+  ])
+
+  const nodePools = nodePoolItems.map(parseNodePool)
+  const gateways = gatewayItems.map(parseGateway)
+
+  // Compute aggregates
+  const totalNodes = nodePools.reduce((sum, np) => sum + np.nodeCount, 0)
+  const autonomousNodes = nodePools
+    .filter(np => np.autonomyEnabled)
+    .reduce((sum, np) => sum + np.nodeCount, 0)
+
+  const allPoolsReady = nodePools.length === 0 || nodePools.every(np => np.status === 'ready')
+  const health = allPodsReady && allPoolsReady ? 'healthy' : 'degraded'
+
+  return {
+    health,
+    controllerPods: { ready: readyPods, total: yurtPods.length },
+    nodePools,
+    gateways,
+    totalNodes,
+    autonomousNodes,
+    lastCheckTime: new Date().toISOString(),
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Hook
+// ---------------------------------------------------------------------------
+
+export interface UseOpenYurtStatusResult {
+  data: OpenYurtStatus
+  loading: boolean
+  isRefreshing: boolean
+  error: boolean
+  consecutiveFailures: number
+  showSkeleton: boolean
+  showEmptyState: boolean
+}
+
+export function useOpenYurtStatus(): UseOpenYurtStatusResult {
+  const {
+    data,
+    isLoading,
+    isRefreshing,
+    isFailed,
+    consecutiveFailures,
+    isDemoFallback,
+  } = useCache<OpenYurtStatus>({
+    key: CACHE_KEY,
+    category: 'default',
+    initialData: INITIAL_DATA,
+    demoData: OPENYURT_DEMO_DATA,
+    persist: true,
+    fetcher: fetchOpenYurtStatus,
+  })
+
+  const effectiveIsDemoData = isDemoFallback && !isLoading
+
+  const hasAnyData = (data.controllerPods?.total ?? 0) > 0 || (data.nodePools || []).length > 0
+
+  const { showSkeleton, showEmptyState } = useCardLoadingState({
+    isLoading,
+    hasAnyData,
+    isFailed,
+    consecutiveFailures,
+    isDemoData: effectiveIsDemoData,
+  })
+
+  return {
+    data,
+    loading: isLoading,
+    isRefreshing,
+    error: isFailed && !hasAnyData,
+    consecutiveFailures,
+    showSkeleton,
+    showEmptyState,
+  }
+}

--- a/web/src/components/dashboard/shared/cardCatalog.ts
+++ b/web/src/components/dashboard/shared/cardCatalog.ts
@@ -317,6 +317,7 @@ export const CARD_CATALOG = {
   ],
   'Orchestration': [
     { type: 'keda_status', title: 'KEDA', description: 'KEDA autoscaler status, scaled object metrics, and trigger queue depths', visualization: 'status' },
+    { type: 'openyurt_status', title: 'OpenYurt', description: 'OpenYurt edge node pools, autonomy status, and edge-cloud connectivity', visualization: 'status' },
     { type: 'kubevela_status', title: 'KubeVela', description: 'KubeVela application delivery, component status, and workflow progress', visualization: 'status' },
     { type: 'karmada_status', title: 'Karmada', description: 'Karmada multi-cluster resource propagation status, member clusters, and policy health', visualization: 'status' },
     { type: 'kuberay_fleet', title: 'KubeRay Fleet', description: 'KubeRay fleet monitoring — RayCluster, RayService, and RayJob status across all clusters with GPU allocation tracking', visualization: 'status' },

--- a/web/src/locales/en/cards.json
+++ b/web/src/locales/en/cards.json
@@ -278,6 +278,7 @@
     "fluentd_status": "Fluentd",
     "lima_status": "Lima",
     "keda_status": "KEDA",
+    "openyurt_status": "OpenYurt",
     "strimzi_status": "Strimzi",
     "kubevela_status": "KubeVela",
     "cloudevents_status": "CloudEvents"
@@ -451,6 +452,7 @@
     "fluentd_status": "Log pipeline status, buffer utilization, and output plugin health.",
     "lima_status": "Lima virtual machine instances and resource usage.",
     "keda_status": "KEDA autoscaler status, scaled object metrics, and trigger queue depths.",
+    "openyurt_status": "OpenYurt edge node pools, autonomy status, and edge-cloud connectivity.",
     "strimzi_status": "Strimzi Kafka cluster health, topic status, and consumer group lag.",
     "kubevela_status": "KubeVela application delivery, component status, and workflow progress.",
     "cloudevents_status": "CloudEvents message flow, event source tracking, and delivery status."
@@ -2840,6 +2842,29 @@
     "syncedDaysAgo": "{{count}}d ago",
     "queue": "queue",
     "target": "target"
+  },
+  "openyurt": {
+    "healthy": "Healthy",
+    "degraded": "Degraded",
+    "notInstalled": "OpenYurt not detected",
+    "notInstalledHint": "No OpenYurt controller pods found. Deploy OpenYurt to enable edge computing features.",
+    "fetchError": "Failed to fetch OpenYurt status",
+    "controllerPods": "pods",
+    "totalNodes": "Nodes",
+    "edgePools": "Edge Pools",
+    "readyPools": "Ready",
+    "gateways": "Gateways",
+    "nodes": "nodes",
+    "autonomous": "Autonomous",
+    "searchPlaceholder": "Search node pools\u2026",
+    "noNodePools": "Controller running",
+    "noNodePoolsHint": "NodePool data requires the OpenYurt CRD API.",
+    "noSearchResults": "No node pools match your search.",
+    "ravenGateways": "Raven Gateways",
+    "syncedJustNow": "just now",
+    "syncedMinutesAgo": "{{count}}m ago",
+    "syncedHoursAgo": "{{count}}h ago",
+    "syncedDaysAgo": "{{count}}d ago"
   },
   "strimziStatus": {
     "fetchError": "Failed to fetch Strimzi status",


### PR DESCRIPTION
## Summary

Implements the **OpenYurt Monitoring Card** (`openyurt_status`) for the KubeStellar Console, addressing [kubestellar/console-marketplace#52](https://github.com/kubestellar/console-marketplace/issues/52).

OpenYurt extends Kubernetes to edge computing scenarios. This card monitors:
- **Edge Node Pools** — pool type (edge/cloud), node readiness, and autonomy status
- **Raven Gateways** — cross-pool network tunnel connectivity between edge and cloud
- **Controller Health** — OpenYurt operator pod status

### New Files
| File | Description |
|------|-------------|
| `openyurt_status/demoData.ts` | Types (`OpenYurtNodePool`, `OpenYurtGateway`, `OpenYurtDemoData`) and realistic demo data with 5 node pools + 4 gateways |
| `openyurt_status/useOpenYurtStatus.ts` | Data fetching hook — detects yurt-manager pods, fetches `NodePool` CRDs (`apps.openyurt.io/v1beta1`) and `Gateway` CRDs (`raven.openyurt.io/v1beta1`) |
| `openyurt_status/OpenYurtStatus.tsx` | Card component — health badge, 4-stat grid, searchable pool list with autonomy indicators, Raven gateway footer |
| `openyurt_status/index.ts` | Barrel export for lazy loading |

### Modified Files
| File | Change |
|------|--------|
| `cardRegistry.ts` | Lazy import, `RAW_CARD_COMPONENTS` entry, dynamic import map, demo-exempt list, default width (6) |
| `cardMetadata.ts` | Title ("OpenYurt") and description |
| `cardCatalog.ts` | Added to Orchestration category in browse catalog |
| `cards.json` | Card title, description, and 18 component-specific i18n keys |

### Features
- Health badge header with controller pod count and refresh indicator
- 4-stat grid: Total Nodes, Edge Pools, Ready Pools, Connected Gateways
- Searchable node pool list with status icons, type badges (edge/cloud), autonomy indicators, and readiness bars
- Raven Gateway footer with per-gateway connection status
- Skeleton loading, error, empty, and not-installed states
- Full i18n support via `react-i18next`
- Demo mode with realistic edge-cloud topology data
- Properly wires `isDemoFallback` → `useCardLoadingState` for demo badge

### Conventions Followed
- All array operations guarded with `|| []`
- Named constants for magic numbers
- Semantic Tailwind classes (no raw hex colors)
- All user-facing strings use `t('openyurt.*')` i18n keys
- `authFetch` for authenticated API calls
- `AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS)` for all fetch calls

## Test Plan
- [ ] Toggle demo mode ON — verify the card shows mock data with 5 node pools and 4 gateways
- [ ] Toggle demo mode OFF — verify it shows real data (if OpenYurt is running) or "not installed" state
- [ ] Check for console errors in browser DevTools
- [ ] Verify the card renders in the dashboard grid
- [ ] Verify the card appears in the "Add Card" modal under Orchestration category
- [ ] Test search filtering on node pool names
- [ ] Verify skeleton loading state appears during data fetch
- [ ] TypeScript compilation passes with zero errors (verified)

Closes kubestellar/console-marketplace#52