### PR TITLE
fix(services+perf): Copilot review followups (#6181, #6182)

### DIFF
--- a/.github/workflows/perf-ttfi.yml
+++ b/.github/workflows/perf-ttfi.yml
@@ -154,7 +154,7 @@ jobs:
           fi
 
   notify:
-    name: Notify on scheduled regression
+    name: Notify on regression (scheduled or manual dispatch)
     needs: all-cards-ttfi
     # File auto-issues on scheduled runs and manual dispatches (so we can
     # dry-run the full notifier pipeline without waiting for a cron tick).

--- a/web/src/components/cards/ServiceStatus.tsx
+++ b/web/src/components/cards/ServiceStatus.tsx
@@ -1,5 +1,5 @@
 import { Globe, Server, ExternalLink, ChevronRight } from 'lucide-react'
-import { useEffect, useMemo, useState } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 import type { Service } from '../../hooks/useMCP'
 import { useCachedServices } from '../../hooks/useCachedData'
 import { useDrillDownActions } from '../../hooks/useDrillDown'
@@ -20,7 +20,6 @@ import {
   SERVICES_CACHE_TTL_MS,
   SERVICES_CACHE_STALE_MS,
   MS_PER_SECOND,
-  TICK_INTERVAL_MS,
 } from '../../lib/constants/network'
 
 type SortByOption = 'type' | 'name' | 'namespace' | 'ports'
@@ -58,16 +57,46 @@ function getTypeColor(type: string) {
   }
 }
 
-/** Ticks to the current wall-clock `Date.now()` every TICK_INTERVAL_MS
- * while `enabled`. Computing `Date.now()` inside an effect (rather than
- * during render) keeps the component pure per React rules-of-hooks. */
-function useNowTick(enabled: boolean): number {
+/**
+ * Schedules at most two timeouts off `lastRefresh` — one for the
+ * stale-threshold transition and one for the TTL/expired transition —
+ * and re-renders the card only at those moments. Replaces the previous
+ * 1-second interval that re-rendered indefinitely while `lastRefresh`
+ * was truthy, even when the freshness badge was hidden (#6181).
+ *
+ * Returns the current wall-clock `Date.now()` snapshot, captured inside
+ * the effect so the component stays pure per react-hooks rules.
+ *
+ * Note: `lastRefresh` is checked with `!= null` (NOT a truthy check) so
+ * a `0` epoch timestamp would still be honored — the previous truthy
+ * guard would have wrongly treated `0` as "no refresh" (#6181).
+ */
+function useFreshnessClock(lastRefresh: number | null | undefined): number {
   const [now, setNow] = useState(() => Date.now())
+  // Re-render the card immediately when `lastRefresh` changes so the
+  // memoized cacheAgeMs reflects the new origin without waiting for a
+  // scheduled timeout.
+  const lastRefreshRef = useRef(lastRefresh)
   useEffect(() => {
-    if (!enabled) return
-    const id = window.setInterval(() => setNow(Date.now()), TICK_INTERVAL_MS)
-    return () => window.clearInterval(id)
-  }, [enabled])
+    if (lastRefreshRef.current !== lastRefresh) {
+      lastRefreshRef.current = lastRefresh
+      setNow(Date.now())
+    }
+    if (lastRefresh == null) return
+    const elapsed = Date.now() - lastRefresh
+    const msUntilStale = SERVICES_CACHE_STALE_MS - elapsed
+    const msUntilExpired = SERVICES_CACHE_TTL_MS - elapsed
+    const timers: number[] = []
+    if (msUntilStale > 0) {
+      timers.push(window.setTimeout(() => setNow(Date.now()), msUntilStale))
+    }
+    if (msUntilExpired > 0) {
+      timers.push(window.setTimeout(() => setNow(Date.now()), msUntilExpired))
+    }
+    return () => {
+      for (const id of timers) window.clearTimeout(id)
+    }
+  }, [lastRefresh])
   return now
 }
 
@@ -81,19 +110,25 @@ export function ServiceStatus() {
     isFailed,
     consecutiveFailures,
     lastRefresh,
-    error
+    error,
+    refetch,
   } = useCachedServices()
 
   const { drillToService } = useDrillDownActions()
 
-  // Issue #6162: enforce a hard TTL on the cached payload. If the data
-  // is older than SERVICES_CACHE_TTL_MS, treat it as empty so downstream
-  // logic triggers a refetch via the normal hook flow rather than
-  // rendering indefinitely-stale data. `now` is pulled from a ticking
-  // hook so we never call Date.now() during render (react-hooks purity).
-  const now = useNowTick(!!lastRefresh)
+  // Issue #6162: enforce a hard TTL on the cached payload. If the data is
+  // older than SERVICES_CACHE_TTL_MS, treat it as empty so the UI does not
+  // render indefinitely-stale data, AND proactively call refetch() so the
+  // card recovers even if the auto-refresh tick is paused or delayed
+  // (#6181). `now` is pulled from a freshness clock that schedules at most
+  // two timeouts (stale + expired) instead of ticking every second, so the
+  // card no longer re-renders forever while a fresh cache sits idle.
+  const now = useFreshnessClock(lastRefresh)
+  // `lastRefresh != null` instead of a truthy check so a `0` epoch
+  // timestamp is honored — a truthy guard would have produced a `null`
+  // age and silently disabled the freshness badge (#6181).
   const cacheAgeMs = useMemo(
-    () => (lastRefresh ? now - lastRefresh : null),
+    () => (lastRefresh != null ? now - lastRefresh : null),
     [now, lastRefresh],
   )
   const isExpired = cacheAgeMs !== null && cacheAgeMs > SERVICES_CACHE_TTL_MS
@@ -105,6 +140,20 @@ export function ServiceStatus() {
     () => (isExpired ? [] : rawServices),
     [isExpired, rawServices],
   )
+
+  // When the cache crosses the TTL, kick off a refetch so the card
+  // recovers even if the next scheduled auto-refresh is delayed (#6181).
+  // Guarded so we only refetch on the rising edge of expiry — not on
+  // every render while expired.
+  const wasExpiredRef = useRef(false)
+  useEffect(() => {
+    if (isExpired && !wasExpiredRef.current) {
+      wasExpiredRef.current = true
+      refetch?.()
+    } else if (!isExpired) {
+      wasExpiredRef.current = false
+    }
+  }, [isExpired, refetch])
 
   // Report data state to CardWrapper for failure badge rendering
   const hasData = services.length > 0
@@ -283,6 +332,11 @@ export function ServiceStatus() {
             // Centralized health derivation (#6164, #6165, #6166, #6167)
             const health: ServiceHealthStatus = deriveServiceHealth(service)
             const formattedPorts = formatServicePorts(service)
+            // When the backend did not report endpoint counts the card
+            // should say so explicitly rather than rendering a misleading
+            // "0 endpoints" that contradicts the unknown-status dot
+            // (#6181). `endpointsKnown` gates the count vs. unknown label.
+            const endpointsKnown = service.endpoints !== undefined
             const endpointCount = service.endpoints ?? 0
             return (
             <div
@@ -308,12 +362,21 @@ export function ServiceStatus() {
                   <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
                     <span className="truncate">{service.namespace}</span>
                     <ClusterBadge cluster={service.cluster || ''} size="sm" />
-                    <span className="truncate" title={t('serviceStatus.endpointsTooltip', '{{count}} ready endpoint(s)', { count: endpointCount })}>
-                      {t('serviceStatus.endpointsCount', {
-                        defaultValue: '{{count}} endpoints',
-                        count: endpointCount,
-                      })}
-                    </span>
+                    {endpointsKnown ? (
+                      <span className="truncate" title={t('serviceStatus.endpointsTooltip', '{{count}} ready endpoint(s)', { count: endpointCount })}>
+                        {t('serviceStatus.endpointsCount', {
+                          defaultValue: '{{count}} endpoints',
+                          count: endpointCount,
+                        })}
+                      </span>
+                    ) : (
+                      <span
+                        className="truncate text-muted-foreground/70"
+                        title={t('serviceStatus.endpointsUnknownTooltip', 'Endpoint count unavailable')}
+                      >
+                        {t('serviceStatus.endpointsUnknown', 'Endpoints unknown')}
+                      </span>
+                    )}
                   </div>
                 </div>
               </div>

--- a/web/src/lib/services/__tests__/serviceHealth.test.ts
+++ b/web/src/lib/services/__tests__/serviceHealth.test.ts
@@ -2,7 +2,6 @@ import { describe, it, expect } from 'vitest'
 import {
   deriveServiceHealth,
   isOrphaned,
-  hasInvalidSelector,
   hasSelector,
   formatServicePort,
   formatServicePorts,
@@ -97,23 +96,6 @@ describe('hasSelector', () => {
   })
   it('returns true when selector has at least one key', () => {
     expect(hasSelector({ selector: { app: 'web' } })).toBe(true)
-  })
-})
-
-describe('hasInvalidSelector (#6166)', () => {
-  it('flags a ClusterIP service with no selector', () => {
-    expect(hasInvalidSelector({ type: 'ClusterIP' })).toBe(true)
-  })
-  it('does not flag ExternalName services without a selector', () => {
-    expect(hasInvalidSelector({ type: 'ExternalName' })).toBe(false)
-  })
-  it('does not flag services with a populated selector', () => {
-    expect(
-      hasInvalidSelector({
-        type: 'ClusterIP',
-        selector: { app: 'web' },
-      }),
-    ).toBe(false)
   })
 })
 

--- a/web/src/lib/services/serviceHealth.ts
+++ b/web/src/lib/services/serviceHealth.ts
@@ -22,12 +22,6 @@ export type ServiceHealthStatus =
   | 'provisioning'   // LoadBalancer without an ingress address yet (#6153/#6167)
   | 'unknown'        // backend did not supply enough data to decide
 
-/** Service types that are allowed to have an empty selector. ExternalName
- * services intentionally forward DNS and never select pods. */
-const SELECTORLESS_SERVICE_TYPES: ReadonlySet<string> = new Set([
-  'ExternalName',
-])
-
 /** Zero endpoints sentinel — extracted so the comparison is named and
  * not a bare `=== 0` magic number. */
 const ZERO_ENDPOINTS = 0
@@ -51,14 +45,14 @@ export function isOrphaned(
   return svc.endpoints === ZERO_ENDPOINTS && hasSelector(svc)
 }
 
-/** `true` when a non-ExternalName service has an empty selector. This is
- * a configuration bug surfaced per #6166. */
-export function hasInvalidSelector(
-  svc: Pick<Service, 'selector' | 'type'>,
-): boolean {
-  if (SELECTORLESS_SERVICE_TYPES.has(svc.type)) return false
-  return !hasSelector(svc)
-}
+// Note: a previous iteration exported `hasInvalidSelector` which flagged
+// any non-ExternalName service with an empty selector as a configuration
+// bug. Kubernetes legitimately allows selector-less Services backed by
+// manually managed Endpoints/EndpointSlices (and headless services), so
+// the heuristic produced false positives. The function had no production
+// callers and was removed in PR #6181 follow-up — `deriveServiceHealth`
+// already handles the "no selector + zero endpoints" case correctly by
+// returning `unknown` rather than `orphaned`.
 
 /** Derive the health status for a service. The order of the checks is
  * significant — provisioning wins over orphaned so a LoadBalancer that


### PR DESCRIPTION
## Summary

Bundles all 6 Copilot review nits from #6181 (services health bundle, 5 comments on #6177) and #6182 (perf budget tighten, 1 comment on #6180).

### #6181 — ServiceStatus.tsx + serviceHealth.ts

1. **Replace 1s `setInterval` with scheduled timeouts.** `useNowTick` re-rendered the card every second indefinitely while a fresh cache sat idle. New `useFreshnessClock` schedules at most two `setTimeout`s per refresh — one at the stale threshold, one at the TTL — so the card only re-renders at the moments the badge can actually change.
2. **Proactive refetch on TTL crossing.** Rising-edge guarded so we don't refetch on every render while expired. Previously the card would sit empty until the next auto-refresh tick, which can be paused/delayed.
3. **`cacheAgeMs` uses `!= null` guard.** Truthy guard would have silently treated a `0` epoch timestamp as "no refresh".
4. **`Endpoints unknown` label when undefined.** Previously rendered `0 endpoints` even though `deriveServiceHealth` correctly returned `unknown` for the dot color — the count and the dot disagreed.
5. **Remove `hasInvalidSelector`.** Kubernetes legitimately allows selector-less Services backed by manually managed Endpoints/EndpointSlices and headless services; the heuristic produced false positives. Function had no production callers; `deriveServiceHealth` already handles the case correctly.

### #6182 — perf-ttfi.yml

6. **Rename the `notify` job** from `Notify on scheduled regression` to `Notify on regression (scheduled or manual dispatch)` to match the relaxed `if:` condition.

## Test plan

- [x] `npm run build` passes locally
- [x] `serviceHealth.test.ts` (17 tests) passes after removing `hasInvalidSelector` references

Closes #6181, closes #6182.