### PR TITLE
docs: add Windows (WSL2) setup section to README (#6185)

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,32 @@ brew tap kubestellar/tap && brew install kc-agent   # macOS
 go build -o bin/kc-agent ./cmd/kc-agent && ./bin/kc-agent  # Linux (Go 1.24+)
 ```
 
+### Windows (WSL2)
+
+The console install scripts and `kc-agent` are POSIX shell + Go, so they run unchanged inside WSL2. Native Windows (PowerShell / CMD) is not supported — install [WSL2 with Ubuntu](https://learn.microsoft.com/windows/wsl/install) and run everything from the WSL shell:
+
+```powershell
+# In PowerShell — one-time setup
+wsl --install -d Ubuntu
+```
+
+Then from inside the Ubuntu/WSL shell:
+
+```bash
+# Prerequisites (Go 1.24+, curl, git)
+sudo apt-get update && sudo apt-get install -y golang-go curl git
+
+# Same install command as macOS / Linux
+curl -sSL https://raw.githubusercontent.com/kubestellar/console/main/start.sh | bash
+
+# kc-agent built from source (no Homebrew formula on WSL)
+git clone https://github.com/kubestellar/console.git
+cd console
+go build -o bin/kc-agent ./cmd/kc-agent && ./bin/kc-agent
+```
+
+Open http://localhost:8080 in your **Windows** browser — WSL2 forwards `localhost` automatically. Tracked by [#6185](https://github.com/kubestellar/console/issues/6185).
+
 ## GitHub OAuth
 
 1. **Create a [GitHub OAuth App](https://github.com/settings/developers)**


### PR DESCRIPTION
## Summary

Adds a **Windows (WSL2)** subsection to the README's Install section so Windows users have a clear, supported path. Tracked by #6185 (reported by @rishi-jat via the in-app feedback flow).

The supported approach is WSL2 + Ubuntu — the install scripts and `kc-agent` are POSIX shell + Go and run unchanged inside WSL2. Native PowerShell/CMD is not supported because porting the bash install scripts to PowerShell would double the maintenance surface for a path that WSL2 makes redundant.

The new section walks through:

- One-time `wsl --install -d Ubuntu` from PowerShell
- apt prerequisites (`golang-go`, `curl`, `git`)
- The same `curl | bash` install command as macOS/Linux
- Building `kc-agent` from source (no Homebrew formula on WSL)
- A note that `http://localhost:8080` just works from the Windows browser since WSL2 forwards localhost

Closes #6185.