### PR TITLE
fix(event-stream): honor user-configured limit + persist 'show' dropdown (#6070)

### DIFF
--- a/web/src/components/cards/EventStream.tsx
+++ b/web/src/components/cards/EventStream.tsx
@@ -1,4 +1,5 @@
 import { AlertTriangle, Info, XCircle, ChevronRight, Radio } from 'lucide-react'
+import { useMemo } from 'react'
 import { useCachedEvents } from '../../hooks/useCachedData'
 import type { ClusterEvent } from '../../hooks/useMCP'
 import { useDrillDownActions } from '../../hooks/useDrillDown'
@@ -20,9 +21,32 @@ const SORT_OPTIONS = [
   { value: 'type' as const, label: 'Type' },
 ]
 
-function EventStreamInternal() {
+/** Default API fetch ceiling — large enough to give pagination headroom but
+ * not so large that the JSON payload becomes wasteful. Used when the user
+ * has not configured a `limit` for this card. */
+const DEFAULT_API_FETCH_LIMIT = 100
+
+/** Default page size for the in-card "show N" dropdown when the user has
+ * not configured a `limit` for this card. */
+const DEFAULT_DISPLAY_LIMIT = 5
+
+interface EventStreamConfig {
+  /** User-configurable max events from the Configure Card modal. Drives BOTH
+   * the API fetch ceiling and the initial in-card "show N" dropdown
+   * selection. Without this wiring (#6070) EventStream silently dropped the
+   * user's preference and rendered with the hardcoded defaults. */
+  limit?: number
+  /** Filter to warning/error events only. Surfaced in the same modal section. */
+  warningsOnly?: boolean
+}
+
+function EventStreamInternal({ config }: { config?: EventStreamConfig }) {
   const { t } = useTranslation()
   const { isDemoMode } = useDemoMode()
+  const userLimit =
+    typeof config?.limit === 'number' && config.limit > 0 ? config.limit : null
+  const apiFetchLimit = userLimit ?? DEFAULT_API_FETCH_LIMIT
+  const displayLimit = userLimit ?? DEFAULT_DISPLAY_LIMIT
   // Fetch more events from API to enable pagination (using cached data hook)
   const {
     events: rawEvents,
@@ -33,13 +57,23 @@ function EventStreamInternal() {
     error,
     isFailed,
     consecutiveFailures,
-  } = useCachedEvents(undefined, undefined, { limit: 100, category: 'realtime' })
+  } = useCachedEvents(undefined, undefined, { limit: apiFetchLimit, category: 'realtime' })
+
+  // Apply the warningsOnly user-config filter (#6070 follow-up — same modal
+  // section, also previously dropped because EventStream ignored its config).
+  const filteredRawEvents = useMemo(
+    () =>
+      config?.warningsOnly
+        ? rawEvents.filter(e => e.type === 'Warning' || e.type === 'Error')
+        : rawEvents,
+    [rawEvents, config?.warningsOnly],
+  )
 
   // Report state to CardWrapper for refresh animation
   const { showSkeleton, showEmptyState } = useCardLoadingState({
     isLoading: hookLoading,
     isDemoData: isDemoMode || isDemoFallback,
-    hasAnyData: rawEvents.length > 0,
+    hasAnyData: filteredRawEvents.length > 0,
     isFailed,
     consecutiveFailures,
     isRefreshing,
@@ -74,7 +108,7 @@ function EventStreamInternal() {
     },
     containerRef,
     containerStyle,
-  } = useCardData<ClusterEvent, SortByOption>(rawEvents, {
+  } = useCardData<ClusterEvent, SortByOption>(filteredRawEvents, {
     filter: {
       searchFields: ['message', 'object', 'namespace', 'type'],
       clusterField: 'cluster',
@@ -95,7 +129,7 @@ function EventStreamInternal() {
         type: commonComparators.string('type'),
       },
     },
-    defaultLimit: 5,
+    defaultLimit: displayLimit,
   })
 
   const { drillToEvents, drillToPod, drillToDeployment, drillToReplicaSet } = useDrillDownActions()
@@ -254,10 +288,10 @@ function EventStreamInternal() {
   )
 }
 
-export function EventStream() {
+export function EventStream({ config }: { config?: Record<string, unknown> } = {}) {
   return (
     <DynamicCardErrorBoundary cardId="EventStream">
-      <EventStreamInternal />
+      <EventStreamInternal config={config as EventStreamConfig | undefined} />
     </DynamicCardErrorBoundary>
   )
 }

--- a/web/src/lib/cards/cardHooks.ts
+++ b/web/src/lib/cards/cardHooks.ts
@@ -90,6 +90,47 @@ export interface UseCardFiltersResult<T> {
 
 const LOCAL_FILTER_STORAGE_PREFIX = 'kubestellar-card-filter:'
 
+/**
+ * localStorage prefix for the per-card "show N items" dropdown selection.
+ * Persisting this fixes #6070 — without it, the user picks "show 5" but on
+ * remount the value resets to whatever `defaultLimit` the card passed in,
+ * which (combined with cards that ignore their config prop entirely) made
+ * cards render with way more rows than the user asked for.
+ */
+const LOCAL_LIMIT_STORAGE_PREFIX = 'kubestellar-card-limit:'
+
+/** Read a persisted itemsPerPage value for a card. Returns null if missing,
+ * unparseable, or no storageKey provided. Accepts the literal string
+ * 'unlimited' as a valid value. */
+function readPersistedItemsPerPage(
+  storageKey: string | undefined,
+): number | 'unlimited' | null {
+  if (!storageKey) return null
+  try {
+    const raw = localStorage.getItem(`${LOCAL_LIMIT_STORAGE_PREFIX}${storageKey}`)
+    if (raw == null) return null
+    if (raw === 'unlimited') return 'unlimited'
+    const n = Number(raw)
+    return Number.isFinite(n) && n > 0 ? n : null
+  } catch {
+    return null
+  }
+}
+
+/** Persist an itemsPerPage value. No-op when storageKey is missing or
+ * localStorage throws (private mode, quota, SSR). */
+function writePersistedItemsPerPage(
+  storageKey: string | undefined,
+  value: number | 'unlimited',
+): void {
+  if (!storageKey) return
+  try {
+    localStorage.setItem(`${LOCAL_LIMIT_STORAGE_PREFIX}${storageKey}`, String(value))
+  } catch {
+    // Ignore — non-fatal.
+  }
+}
+
 export function useCardFilters<T>(
   items: T[],
   config: FilterConfig<T>
@@ -392,7 +433,20 @@ export function useCardData<T, S extends string = string>(
   // Guard against undefined config — dynamic/custom cards may pass undefined at runtime
   const safeConfig = config ?? ({} as CardDataConfig<T, S>)
   const { filter: filterConfig, sort: sortConfig, defaultLimit = 5 } = safeConfig
-  const [itemsPerPage, setItemsPerPage] = useState<number | 'unlimited'>(defaultLimit)
+  // Persist the "show N" dropdown selection per card so it survives remounts
+  // (#6070). The storageKey is the same identifier used by the cluster filter
+  // persistence above, so each card type gets its own slot.
+  const limitStorageKey = filterConfig?.storageKey
+  const [itemsPerPage, setItemsPerPageState] = useState<number | 'unlimited'>(
+    () => readPersistedItemsPerPage(limitStorageKey) ?? defaultLimit,
+  )
+  const setItemsPerPage = useCallback(
+    (limit: number | 'unlimited') => {
+      setItemsPerPageState(limit)
+      writePersistedItemsPerPage(limitStorageKey, limit)
+    },
+    [limitStorageKey],
+  )
   const [currentPage, setCurrentPage] = useState(1)
 
   // Apply filters


### PR DESCRIPTION
## Summary

@xonas1101 reported (#6070) that the 'show' field on the Event Stream card is being disregarded, making the card render very long. Workaround was to collapse + re-expand the card, but the regression comes back. Two layered bugs found and fixed.

### Bug 1: EventStream.tsx ignored its `config` prop entirely

The component signature was `function EventStreamInternal()` with no props, so the user-configurable **Max Events** field at `ConfigureCardModal.tsx:474` was plumbed all the way through the dashboard layout but silently dropped. Same root cause for the `warningsOnly` boolean from the same modal section — also had no effect.

**Fix:**
- Accept `{ config }` and read `config.limit` and `config.warningsOnly`
- Use `config.limit` as both the API fetch ceiling and the initial in-card 'show N' dropdown selection
- Apply `warningsOnly` as a real filter
- Fall back to `DEFAULT_API_FETCH_LIMIT` (100) and `DEFAULT_DISPLAY_LIMIT` (5) named constants when not configured

### Bug 2: `useCardData` never persisted `itemsPerPage`

Initial state was `useState(defaultLimit)` with no localStorage round-trip, so whatever the user picked from the in-card 'show N' dropdown was lost on every remount.

**Fix:**
- New `LOCAL_LIMIT_STORAGE_PREFIX` (`kubestellar-card-limit:`) and read/write helpers keyed on the existing `storageKey` already used by the cluster-filter persistence
- `useState` now reads the persisted value first, falling back to `defaultLimit`
- `setItemsPerPage` wrapped in a `useCallback` that writes through to localStorage
- Both helpers gracefully handle missing storageKey, missing value, unparseable values, and the literal `'unlimited'`
- **General fix that benefits every card using `useCardData`**, not just EventStream

## Test plan

- [x] `npm run build` passes locally
- [x] All 27 `EventStream.test.tsx` tests pass
- [x] All 180 `cardHooks` tests pass

Closes #6070.