### PR TITLE
feat(perf): add idle commits-per-second gate to catch wall-clock cascades

### DIFF
--- a/.github/workflows/perf-react-commits-idle.yml
+++ b/.github/workflows/perf-react-commits-idle.yml
@@ -1,0 +1,115 @@
+name: Perf — React commits per second (idle)
+
+# Companion to perf-react-commits.yml. That workflow measures commits during
+# a sidebar navigation; this one measures the steady-state commits/sec after
+# the dashboard has fully settled with no user input. The two together catch
+# two distinct regression classes:
+#
+#   navigation gate (#6149): a cascade that runs during route transitions
+#   idle gate      (#6201): a cascade where a wall-clock interval, an
+#                            unstable provider value, or a sub-second tick
+#                            keeps re-rendering forever even at idle
+#
+# The idle case is invisible to the navigation gate because that gate only
+# watches the 2-second window after a click. Without this companion gate, a
+# regression that introduces a 1Hz ticker per card (the pattern that bit us
+# pre-#6184 in ServiceStatus.useNowTick) would happily report ~14 commits/nav
+# while accumulating ~30 commits/sec idle in the background.
+
+on:
+  schedule:
+    # Every 2 hours at :17 — offset from the navigation gate (:15) so the
+    # two specs don't compete for the same dev-server port at the exact
+    # same instant.
+    - cron: '17 */2 * * *'
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+  actions: read
+  issues: write
+
+concurrency:
+  group: perf-react-commits-idle
+  cancel-in-progress: true
+
+env:
+  PERF_SIGNAL: react-commits-idle
+
+jobs:
+  react-commits-idle:
+    name: React commits per second (idle)
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    defaults:
+      run:
+        working-directory: web
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+          cache-dependency-path: web/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install Playwright browser
+        run: npx playwright install --with-deps chromium
+
+      - name: Resolve last successful SHA
+        id: last-success
+        working-directory: .
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # Most recent successful run of THIS workflow on main, so the
+          # auto-issue script can build a merge window for the diff. Same
+          # best-effort pattern as perf-react-commits.yml.
+          LAST=$(gh run list \
+            --workflow="perf-react-commits-idle.yml" \
+            --branch=main \
+            --status=success \
+            --limit=1 \
+            --json headSha \
+            --jq '.[0].headSha // ""' || echo '')
+          echo "sha=${LAST}" >> "$GITHUB_OUTPUT"
+
+      - name: Run idle perf spec (dev server, hook enabled)
+        # PERF_DEV=1 flips e2e/perf/perf.config.ts to `npm run dev`. React 19
+        # only calls onCommitFiberRoot in dev mode, so this is the only build
+        # where the perf hook works.
+        env:
+          PERF_DEV: '1'
+          LAST_SUCCESSFUL_SHA: ${{ steps.last-success.outputs.sha }}
+        run: npx playwright test --config e2e/perf/perf.config.ts e2e/perf/react-commits-idle.spec.ts
+
+      - name: Upload perf result artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: perf-result-react-commits-idle
+          path: web/perf-result.json
+          if-no-files-found: warn
+          retention-days: 14
+
+  notify:
+    name: Notify on regression
+    needs: react-commits-idle
+    if: failure()
+    # Job-level permissions so the reusable workflow has issues:write even
+    # if workflow defaults are later tightened. See #6170.
+    permissions:
+      contents: read
+      issues: write
+      actions: read
+    uses: ./.github/workflows/_perf-regression-issue.yml
+    with:
+      result-path: web/perf-result.json
+      signal: react-commits-idle

--- a/web/e2e/perf/constants.ts
+++ b/web/e2e/perf/constants.ts
@@ -20,10 +20,32 @@ export const PERF_BUDGET_NAVIGATION_COMMITS = 20
 // without turning the test into a long-poll.
 export const NAVIGATION_SETTLE_MS = 2_000
 
+// Window size (ms) over which we measure the IDLE commit-per-second rate. The
+// test waits this long after the dashboard has fully settled, with no user
+// input, then divides commit count by IDLE_SAMPLE_WINDOW_MS / 1000.
+//
+// 15s is a deliberate choice: long enough to average out one-off cluster
+// poll responses (#6201), short enough to keep the perf workflow under 5min
+// total runtime.
+export const IDLE_SAMPLE_WINDOW_MS = 15_000
+
+// Max React commits per second allowed during idle on the dashboard. Local
+// dev measurement against a kc-agent + real clusters is ~3.6 commits/sec
+// (with React StrictMode dev double-render baked in, so the production cost
+// is ~1.8/sec). Budget is set to 8 commits/sec — generous headroom over the
+// observed baseline so legitimate growth (more cards, websocket events) is
+// allowed, while a regression that introduces a 1-second-tick cascade (the
+// pattern that previously bit us in #6149 and the post-#6184 followup
+// hunt 2026-04-10) gets caught immediately. The cascade I removed in
+// PR #6184 (`useNowTick` in ServiceStatus) ALONE was firing once per
+// second per visible service card, so this budget would have flagged it.
+export const PERF_BUDGET_IDLE_COMMITS_PER_SEC = 8
+
 // Signal slugs — must be unique across every perf workflow. These are used
 // verbatim in the perf-result.json file and as the `[perf-regression] <slug>`
 // de-dupe key in the auto-issue script.
 export const PERF_SIGNAL_REACT_COMMITS_NAV = 'react-commits-navigation'
+export const PERF_SIGNAL_REACT_COMMITS_IDLE = 'react-commits-idle'
 
 // Where specs drop their result JSON. The reusable workflow reads this exact
 // path via the PERF_RESULT_JSON env var.

--- a/web/e2e/perf/react-commits-idle.spec.ts
+++ b/web/e2e/perf/react-commits-idle.spec.ts
@@ -1,0 +1,162 @@
+import { test, expect } from '@playwright/test'
+import * as fs from 'node:fs'
+import * as path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import {
+  PERF_BUDGET_IDLE_COMMITS_PER_SEC,
+  IDLE_SAMPLE_WINDOW_MS,
+  NAVIGATION_SETTLE_MS,
+  PERF_SIGNAL_REACT_COMMITS_IDLE,
+} from './constants'
+
+/**
+ * Idle React-commit-rate perf gate.
+ *
+ * Companion to react-commits.spec.ts. That spec measures commits during a
+ * single SPA navigation; this one measures the **steady-state** commits/sec
+ * after the page has fully settled with no user input. The two together
+ * catch two distinct regression classes:
+ *
+ *  - navigation: a #6149-style cascade that runs during route transitions
+ *  - idle: a #6201-style cascade where a wall-clock interval, an unstable
+ *    provider value, or a sub-second tick keeps re-rendering the tree
+ *    forever even when nothing is happening
+ *
+ * The idle case is invisible to the navigation gate because that gate only
+ * watches the 2-second window after a sidebar click. A 1Hz ticker that
+ * fires forever would never be flagged by the navigation gate; it would
+ * happily report 14 commits per nav while accumulating ~30 commits/sec
+ * idle in the background. We need a separate signal for it.
+ *
+ * Same dev-server requirement as react-commits.spec.ts: React 19 only calls
+ * `onCommitFiberRoot` in dev mode, so this runs against `vite dev` via
+ * `PERF_DEV=1` in the workflow.
+ *
+ * See #6201 for the regression class this gate exists to catch.
+ */
+
+const HOME_ROUTE = '/'
+
+// localStorage keys+values that force demo mode AND seed the demo token.
+// Same rationale as react-commits.spec.ts: without both, the auth-revalidate
+// path runs and adds noise to the count. See #6176/#6178 for the original
+// fix on the navigation spec.
+const DEMO_MODE_STORAGE_KEY = 'kc-demo-mode'
+const DEMO_MODE_STORAGE_VALUE = 'true'
+const TOKEN_STORAGE_KEY = 'token'
+const DEMO_TOKEN_VALUE = 'demo-token'
+
+const COMMIT_COUNTER_KEY = '__perfCommitCount'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const WEB_DIR = path.resolve(__dirname, '../..')
+const REPO_ROOT = path.resolve(WEB_DIR, '..')
+const RESULT_FILE = path.join(REPO_ROOT, 'web', 'perf-result.json')
+
+interface PerfResult {
+  signal: string
+  displayName: string
+  value: number
+  budget: number
+  unit: string
+  context: Record<string, string | number | undefined>
+}
+
+let recordedRate = -1
+
+test.afterAll(() => {
+  if (recordedRate < 0) {
+    // Test never reached the measurement step — write a sentinel so the
+    // workflow surfaces the failure path.
+    recordedRate = Number.MAX_SAFE_INTEGER
+  }
+  const result: PerfResult = {
+    signal: PERF_SIGNAL_REACT_COMMITS_IDLE,
+    displayName: 'Dashboard idle React commits per second',
+    value: recordedRate,
+    budget: PERF_BUDGET_IDLE_COMMITS_PER_SEC,
+    unit: 'commits/sec',
+    context: {
+      sampleWindowMs: IDLE_SAMPLE_WINDOW_MS,
+      runId: process.env.GITHUB_RUN_ID,
+      runUrl:
+        process.env.GITHUB_SERVER_URL && process.env.GITHUB_REPOSITORY && process.env.GITHUB_RUN_ID
+          ? `${process.env.GITHUB_SERVER_URL}/${process.env.GITHUB_REPOSITORY}/actions/runs/${process.env.GITHUB_RUN_ID}`
+          : undefined,
+      headSha: process.env.GITHUB_SHA,
+      lastSuccessfulSha: process.env.LAST_SUCCESSFUL_SHA,
+    },
+  }
+  fs.mkdirSync(path.dirname(RESULT_FILE), { recursive: true })
+  fs.writeFileSync(RESULT_FILE, JSON.stringify(result, null, 2))
+})
+
+test('react idle commit rate stays under budget', async ({ page }) => {
+  await page.addInitScript(
+    ({ demoKey, demoValue, tokenKey, tokenValue }) => {
+      try {
+        window.localStorage.setItem(demoKey, demoValue)
+        window.localStorage.setItem(tokenKey, tokenValue)
+      } catch {
+        // Ignore — same as the navigation spec.
+      }
+    },
+    {
+      demoKey: DEMO_MODE_STORAGE_KEY,
+      demoValue: DEMO_MODE_STORAGE_VALUE,
+      tokenKey: TOKEN_STORAGE_KEY,
+      tokenValue: DEMO_TOKEN_VALUE,
+    },
+  )
+
+  // Install the fake DevTools hook BEFORE any app script runs. Same minimal
+  // shape the navigation spec uses — React 19 calls onCommitFiberRoot on
+  // every commit when supportsFiber is true.
+  await page.addInitScript(
+    ({ counterKey }) => {
+      const w = window as unknown as Record<string, unknown>
+      w[counterKey] = 0
+      const hook = {
+        supportsFiber: true,
+        renderers: new Map(),
+        onCommitFiberRoot: () => {
+          w[counterKey] = (w[counterKey] as number) + 1
+        },
+        onCommitFiberUnmount: () => {},
+        inject: () => 1,
+      }
+      ;(w as Record<string, unknown>).__REACT_DEVTOOLS_GLOBAL_HOOK__ = hook
+    },
+    { counterKey: COMMIT_COUNTER_KEY },
+  )
+
+  await page.goto(HOME_ROUTE)
+  await page.waitForLoadState('networkidle')
+  // Initial settle: let cold-mount + first data fetches finish before we
+  // start counting. Without this we'd be measuring mount + initial fetches
+  // (the ~44/sec phase), not steady state.
+  await page.waitForTimeout(NAVIGATION_SETTLE_MS)
+
+  // Reset counter to zero so we measure ONLY the idle window from here on.
+  await page.evaluate((key) => {
+    ;(window as unknown as Record<string, number>)[key] = 0
+  }, COMMIT_COUNTER_KEY)
+
+  // Sit idle for IDLE_SAMPLE_WINDOW_MS. No clicks, no navigation, no
+  // mouse movement — anything we do here would inject input events and
+  // contaminate the count.
+  await page.waitForTimeout(IDLE_SAMPLE_WINDOW_MS)
+
+  const commits = await page.evaluate(
+    (key) => (window as unknown as Record<string, number>)[key] ?? -1,
+    COMMIT_COUNTER_KEY,
+  )
+
+  const rate = commits / (IDLE_SAMPLE_WINDOW_MS / 1000)
+  recordedRate = rate
+
+  expect(
+    rate,
+    `Idle React commits/sec (${rate.toFixed(2)}, ${commits} commits over ${IDLE_SAMPLE_WINDOW_MS}ms) exceeded budget ${PERF_BUDGET_IDLE_COMMITS_PER_SEC}`,
+  ).toBeLessThanOrEqual(PERF_BUDGET_IDLE_COMMITS_PER_SEC)
+})


### PR DESCRIPTION
## Summary

While chasing the screenshot @clubanderson posted (#6149's React Profiler showing 461 commits), I confirmed the cold-mount cascade is gone (~130 commits now, down from 461 — the AuthProvider/DrillDown/Toast `useMemo` fixes from #6161 stuck) but discovered the existing react-commits perf gate has a **structural blind spot**: it only measures the 2-second window after a sidebar click.

A regression that introduces a wall-clock cascade — a `setInterval` ticker, an unstable provider value firing on a timer, a sub-second `useNowTick` — would be completely invisible to the navigation gate. The pre-#6184 `ServiceStatus.useNowTick(1s)` would have happily reported ~14 commits/nav while accumulating ~30 commits/sec in the background, and the gate would have shrugged.

## What changed

| File | Change |
|---|---|
| `web/e2e/perf/constants.ts` | New `IDLE_SAMPLE_WINDOW_MS` (15s) and `PERF_BUDGET_IDLE_COMMITS_PER_SEC` (8/sec). New signal slug `react-commits-idle` so the auto-issue dedup key is unique. |
| `web/e2e/perf/react-commits-idle.spec.ts` | New spec mirroring `react-commits.spec.ts`. Same demo-mode + token seed (avoids the auth-revalidate noise that #6178 fixed for the navigation gate), same fake DevTools hook installation, but instead of clicking a link it just sits idle for `IDLE_SAMPLE_WINDOW_MS` and reports `commits / window-seconds`. |
| `.github/workflows/perf-react-commits-idle.yml` | Companion workflow on the same 2-hour cron offset by 2 minutes (`:17` vs `:15`) so the two gates don't compete for the same dev-server port. Same reusable notify pipeline (`_perf-regression-issue.yml`), same job-level permissions block (the #6170 lesson). |

## How the budget was picked

Local-dev measurement against `kc-agent` + real clusters: **~3.6 commits/sec** with no visible work (no DOM text changes in 8s of idle). With React StrictMode dev double-render baked in, real production cost is ~1.8/sec. Budget set to **8/sec** — generous headroom over the observed baseline so legitimate growth (more cards, websocket events) is allowed, while a regression that introduces a 1Hz card-level ticker applied to ~10 visible cards would push past 8/sec immediately and trip the gate.

## Test plan

- [x] `npm run build` passes locally
- [ ] After merge, dispatch `perf-react-commits-idle.yml` once to confirm the new gate runs end-to-end and writes `perf-result.json` with a real measurement
- [ ] Verify the budget is reasonable against the CI demo-data dev build (no kc-agent / real clusters), which may be lower than the ~3.6/sec observed locally