### PR TITLE
fix: cleanup leaks (useTokenUsage, useInsightEnrichment, UpgradeStatus) + #6203 tests

### DIFF
--- a/web/src/components/cards/UpgradeStatus.tsx
+++ b/web/src/components/cards/UpgradeStatus.tsx
@@ -82,6 +82,12 @@ function createVersionWsHandle(): VersionWsHandle {
   let connecting = false
   let destroyed = false
   const pendingRequests = new Map<string, (version: string | null) => void>()
+  /** Outstanding `setTimeout` handles created inside `ensureWs()` so
+   * `destroy()` can cancel them. Previously these were discarded, so the
+   * 10s connection timeout fired AFTER unmount and held stale closure
+   * references calling `clearInterval` and `reject` on already-settled
+   * promises (#6206). */
+  const pendingEnsureTimers = new Set<ReturnType<typeof setTimeout>>()
 
   function rejectAllPending() {
     pendingRequests.forEach((resolver) => resolver(null))
@@ -117,7 +123,16 @@ function createVersionWsHandle(): VersionWsHandle {
           if (destroyed) { clearInterval(checkInterval); reject(new Error('Handle destroyed')); return }
           if (ws?.readyState === WebSocket.OPEN) { clearInterval(checkInterval); resolve(ws) }
         }, 100)
-        setTimeout(() => { clearInterval(checkInterval); reject(new Error('WebSocket connection timeout')) }, WS_CONNECTION_TIMEOUT_MS)
+        // #6206: store the timeout handle so destroy() can cancel it.
+        // Without this, the timeout would fire after unmount, call
+        // clearInterval on a dead handle, and reject an already-settled
+        // promise — holding stale closure references for up to 10s.
+        const timeoutHandle = setTimeout(() => {
+          pendingEnsureTimers.delete(timeoutHandle)
+          clearInterval(checkInterval)
+          reject(new Error('WebSocket connection timeout'))
+        }, WS_CONNECTION_TIMEOUT_MS)
+        pendingEnsureTimers.add(timeoutHandle)
       })
     }
 
@@ -228,6 +243,10 @@ function createVersionWsHandle(): VersionWsHandle {
 
   function destroy() {
     destroyed = true
+    // Cancel any in-flight ensureWs() timeouts before closing the socket
+    // so their stale closures don't fire after unmount (#6206).
+    pendingEnsureTimers.forEach(t => clearTimeout(t))
+    pendingEnsureTimers.clear()
     closeWs()
   }
 

--- a/web/src/hooks/useInsightEnrichment.ts
+++ b/web/src/hooks/useInsightEnrichment.ts
@@ -42,6 +42,11 @@ let lastEnrichmentTime = 0
 let lastRequestHash = ''
 let wsConnection: WebSocket | null = null
 let wsReconnectAttempts = 0
+/** Tracked reconnect timer handle (#6205). Previously the reconnect
+ * `setTimeout` inside `onclose` discarded its handle, so the cleanup path
+ * could never cancel a pending reconnect — when the last subscriber
+ * unmounted, the reconnect loop kept firing into the void. */
+let wsReconnectTimer: ReturnType<typeof setTimeout> | null = null
 /** Set to false after receiving 404 — endpoint doesn't exist */
 let enrichmentEndpointAvailable = true
 const subscribers = new Set<() => void>()
@@ -157,13 +162,22 @@ function connectWebSocket(): void {
       wsReconnectAttempts++
       if (wsReconnectAttempts >= MAX_WS_RECONNECT_ATTEMPTS) return
       if (!isAgentConnected() || isAgentUnavailable()) return
+      // Don't schedule a reconnect if every subscriber has unmounted —
+      // the loop would keep firing forever otherwise (#6205).
+      if (subscribers.size === 0) return
 
       // Exponential backoff: 5s, 10s, 20s, 40s, 80s (capped at 2 min)
       const delay = Math.min(
         WS_BASE_RECONNECT_DELAY_MS * Math.pow(2, wsReconnectAttempts - 1),
         WS_MAX_RECONNECT_DELAY_MS,
       )
-      setTimeout(connectWebSocket, delay)
+      // #6205: store the handle so the cleanup path can cancel a pending
+      // reconnect. The previous version discarded this so the loop kept
+      // firing after the last subscriber unmounted.
+      wsReconnectTimer = setTimeout(() => {
+        wsReconnectTimer = null
+        connectWebSocket()
+      }, delay)
     }
 
     wsConnection.onerror = () => {
@@ -173,6 +187,28 @@ function connectWebSocket(): void {
   } catch {
     wsConnection = null
   }
+}
+
+/** Tear down the singleton WebSocket and any pending reconnect (#6204, #6205).
+ * Called when the last subscriber unmounts. Mirrors the `stopSingleton()`
+ * pattern used by useAIPredictions. */
+function disconnectWebSocket(): void {
+  if (wsReconnectTimer !== null) {
+    clearTimeout(wsReconnectTimer)
+    wsReconnectTimer = null
+  }
+  if (wsConnection) {
+    // Drop event handlers BEFORE closing so the close handler doesn't
+    // fire and immediately schedule another reconnect.
+    wsConnection.onopen = null
+    wsConnection.onmessage = null
+    wsConnection.onclose = null
+    wsConnection.onerror = null
+    try { wsConnection.close() } catch { /* ignore */ }
+    wsConnection = null
+  }
+  // Reset backoff so the next mount starts fresh.
+  wsReconnectAttempts = 0
 }
 
 // ── Public API ───────────────────────────────────────────────────────────
@@ -235,14 +271,24 @@ export function useInsightEnrichment(heuristicInsights: MultiClusterInsight[]): 
   const insightsRef = useRef(heuristicInsights)
   insightsRef.current = heuristicInsights
 
-  // Subscribe to enrichment changes
+  // Subscribe to enrichment changes. When the last subscriber unmounts,
+  // tear down the singleton WebSocket and cancel any pending reconnect
+  // (#6204, #6205) — without this, the singleton stays open forever and
+  // the reconnect loop keeps firing into the void.
   useEffect(() => {
     const subscriber = () => forceUpdate(n => n + 1)
     subscribers.add(subscriber)
-    return () => { subscribers.delete(subscriber) }
+    return () => {
+      subscribers.delete(subscriber)
+      if (subscribers.size === 0) {
+        disconnectWebSocket()
+      }
+    }
   }, [])
 
-  // Connect WebSocket on mount
+  // Connect WebSocket on mount. The teardown lives in the subscribers
+  // useEffect above so we don't double-disconnect when multiple consumers
+  // share the singleton — it only disconnects when subscribers.size === 0.
   useEffect(() => {
     connectWebSocket()
   }, [])

--- a/web/src/hooks/useTokenUsage.ts
+++ b/web/src/hooks/useTokenUsage.ts
@@ -314,25 +314,43 @@ async function flushPendingDeltas(): Promise<void> {
 // the unload — but only if the user is authenticated and there is something
 // pending. Browsers without sendBeacon fall back to the queued flush, which
 // will run if the user reopens the tab.
-if (typeof window !== 'undefined' && typeof navigator !== 'undefined') {
-  window.addEventListener('pagehide', () => {
-    if (backendUnauthenticated || pendingDeltas.size === 0) return
-    if (typeof navigator.sendBeacon !== 'function') return
-    for (const [category, delta] of pendingDeltas.entries()) {
-      if (delta <= 0) continue
-      const body = new Blob(
-        [JSON.stringify({ category, delta, agent_session_id: lastKnownSessionId ?? '' })],
-        { type: 'application/json' }
-      )
-      try {
-        navigator.sendBeacon('/api/token-usage/delta', body)
-      } catch {
-        // Ignore — best effort only.
-      }
+//
+// #6202: This used to register an anonymous arrow function as the listener,
+// which made it impossible to remove. Vite HMR re-evaluates this module on
+// every hot reload, so each reload accumulated another listener — closing
+// the tab would fire all N copies and send N duplicate beacons. Now uses a
+// named function reference and a module-level guard so re-evaluation under
+// HMR replaces the listener instead of stacking copies. The guard also
+// removes the prior listener using the captured reference (safe even if
+// the previous run is gone, removeEventListener is a no-op for unknowns).
+function flushPendingDeltasOnPagehide(): void {
+  if (backendUnauthenticated || pendingDeltas.size === 0) return
+  if (typeof navigator.sendBeacon !== 'function') return
+  for (const [category, delta] of pendingDeltas.entries()) {
+    if (delta <= 0) continue
+    const body = new Blob(
+      [JSON.stringify({ category, delta, agent_session_id: lastKnownSessionId ?? '' })],
+      { type: 'application/json' }
+    )
+    try {
+      navigator.sendBeacon('/api/token-usage/delta', body)
+    } catch {
+      // Ignore — best effort only.
     }
-    pendingDeltas.clear()
-    pendingDeltaTotal = 0
-  })
+  }
+  pendingDeltas.clear()
+  pendingDeltaTotal = 0
+}
+
+if (typeof window !== 'undefined' && typeof navigator !== 'undefined') {
+  // HMR cleanup — remove any stale listener from a previous module instance
+  // before installing the new one.
+  const existing = (window as unknown as { __kcTokenUsagePagehide?: () => void }).__kcTokenUsagePagehide
+  if (existing) {
+    window.removeEventListener('pagehide', existing)
+  }
+  window.addEventListener('pagehide', flushPendingDeltasOnPagehide)
+  ;(window as unknown as { __kcTokenUsagePagehide?: () => void }).__kcTokenUsagePagehide = flushPendingDeltasOnPagehide
 }
 
 // Initialize from localStorage

--- a/web/src/lib/cards/__tests__/cardHooks-variants.test.ts
+++ b/web/src/lib/cards/__tests__/cardHooks-variants.test.ts
@@ -576,6 +576,63 @@ describe('useCardData — additional coverage', () => {
     expect(result.current.items).toHaveLength(10)
   })
 
+  // ── localStorage persistence (#6203 follow-up to #6199 / #6070) ──────────
+  // The four tests below assert the round-trip added in #6199:
+  //   1. setItemsPerPage writes to kubestellar-card-limit:<key>
+  //   2. A subsequent renderHook reads it back as the initial value
+  //   3. Missing key falls back to defaultLimit
+  //   4. The literal 'unlimited' round-trips correctly
+
+  describe('itemsPerPage persistence to localStorage (#6203)', () => {
+    const STORAGE_PREFIX = 'kubestellar-card-limit:'
+    const STORAGE_KEY = 'test-persistence-card'
+
+    const persistConfig: CardDataConfig<TestItem, 'name' | 'value'> = {
+      ...config,
+      filter: { searchFields: ['name'], storageKey: STORAGE_KEY },
+    }
+
+    beforeEach(() => {
+      localStorage.removeItem(`${STORAGE_PREFIX}${STORAGE_KEY}`)
+    })
+
+    it('writes setItemsPerPage value through to localStorage', () => {
+      const { result } = renderHook(() => useCardData(items, persistConfig))
+      act(() => { result.current.setItemsPerPage(7) })
+      expect(localStorage.getItem(`${STORAGE_PREFIX}${STORAGE_KEY}`)).toBe('7')
+    })
+
+    it('reads persisted itemsPerPage as initial value on next mount', () => {
+      localStorage.setItem(`${STORAGE_PREFIX}${STORAGE_KEY}`, '8')
+      const { result } = renderHook(() => useCardData(items, persistConfig))
+      // Should be 8 from storage, NOT defaultLimit (5) from config
+      expect(result.current.itemsPerPage).toBe(8)
+    })
+
+    it('falls back to defaultLimit when no value is persisted', () => {
+      // No localStorage entry exists (cleared in beforeEach)
+      const { result } = renderHook(() => useCardData(items, persistConfig))
+      expect(result.current.itemsPerPage).toBe(5)
+    })
+
+    it('round-trips the literal "unlimited" value', () => {
+      const { result } = renderHook(() => useCardData(items, persistConfig))
+      act(() => { result.current.setItemsPerPage('unlimited') })
+      expect(localStorage.getItem(`${STORAGE_PREFIX}${STORAGE_KEY}`)).toBe('unlimited')
+      // Mount a fresh hook and check it reads back as 'unlimited'
+      const { result: result2 } = renderHook(() => useCardData(items, persistConfig))
+      expect(result2.current.itemsPerPage).toBe('unlimited')
+    })
+
+    it('does not persist when storageKey is missing', () => {
+      // config (without storageKey) should NOT touch localStorage
+      const { result } = renderHook(() => useCardData(items, config))
+      act(() => { result.current.setItemsPerPage(9) })
+      // No write should happen for the test-persistence-card key OR any other
+      expect(localStorage.getItem(`${STORAGE_PREFIX}${STORAGE_KEY}`)).toBeNull()
+    })
+  })
+
   it('goToPage clamps to min 1', () => {
     const { result } = renderHook(() => useCardData(items, config))
     act(() => { result.current.goToPage(-5) })


### PR DESCRIPTION
## Summary

Bundles all five issues filed by @aashu2006 against the same idle-cascade class I was hunting in #6201. Each is a distinct cleanup leak where a timer, listener, or websocket survives unmount and keeps firing state-update callbacks against dead components — exactly the pattern that produces a steady-state React commit floor.

### #6202 — `useTokenUsage.ts`: anonymous `pagehide` listener
Module-scope `window.addEventListener('pagehide', () => {...})` used an anonymous arrow function, so it could never be removed. Vite HMR re-evaluates the module on every hot reload, accumulating one listener per reload — closing the tab fired all N copies and sent N duplicate beacons. Fix: named `flushPendingDeltasOnPagehide` function + module-scope guard on `window.__kcTokenUsagePagehide` that removes the previous listener before installing the new one, so HMR replaces instead of stacking.

### #6204 + #6205 — `useInsightEnrichment.ts`: WebSocket + reconnect leak
Two related leaks in the same module-singleton WS pattern:
- **#6204**: `connectWebSocket()` was called inside a `useEffect` with no cleanup return. `wsConnection.close()` was never called. After all consumers unmounted, the WebSocket stayed `OPEN` until page unload. Fix: extracted `disconnectWebSocket()` (same shape as `useAIPredictions`'s `stopSingleton()`) and call it from the subscribers cleanup when `subscribers.size === 0`. Drops handlers BEFORE `close()` so the close handler doesn't immediately schedule another reconnect.
- **#6205**: The `onclose` handler scheduled a reconnect via `setTimeout(connectWebSocket, delay)` but discarded the handle. The cleanup path could never cancel a pending reconnect, so after the last subscriber unmounted the reconnect loop kept firing forever. Fix: store the handle on `wsReconnectTimer`, clear it in `disconnectWebSocket()`, and skip scheduling a reconnect entirely when `subscribers.size === 0`.

### #6206 — `UpgradeStatus.tsx`: leaked `setTimeout` in `ensureWs()`
Inside the `if (connecting)` branch, `setTimeout(() => { clearInterval; reject }, WS_CONNECTION_TIMEOUT_MS)` discarded its handle. `destroy()` only called `closeWs()` and `rejectAllPending()` — the orphaned timer still fired up to 10s after unmount, calling `clearInterval` and `reject` on already-settled promises and holding stale closure references. Fix: track all in-flight ensureWs() timers in a module-scope `pendingEnsureTimers: Set<Timer>`, add each new one on creation, and clear all of them in `destroy()` before `closeWs()`.

### #6203 — `useCardData` `itemsPerPage` persistence test coverage
Copilot review on #6199 noted the new read-init / write-through localStorage persistence in `useCardData` had no test coverage. Adds 5 tests under a new `'itemsPerPage persistence to localStorage (#6203)'` describe block:
1. `setItemsPerPage` writes through to localStorage
2. A subsequent `renderHook` reads the persisted value as initial
3. Missing key falls back to `defaultLimit`
4. The literal `'unlimited'` round-trips correctly
5. No write happens when `storageKey` is missing (graceful no-op)

## Test plan

- [x] `npm run build` passes locally
- [x] 130 tests pass in cardHooks-variants + useInsightEnrichment
- [x] 76 tests pass in useTokenUsage + useInsightEnrichment + UpgradeStatus
- [ ] After merge, the new `perf-react-commits-idle.yml` gate (PR #6201) should record a measurably lower idle commits/sec because the phantom unmount-survivor cascades are gone

Closes #6202, closes #6203, closes #6204, closes #6205, closes #6206.