### PR TITLE
🐛 fix(blog,accm): public blog fallback + split AI metric + full project history

### DIFF
--- a/web/netlify/functions/analytics-accm.mts
+++ b/web/netlify/functions/analytics-accm.mts
@@ -21,17 +21,21 @@ const CACHE_STORE = "analytics-accm";
 const CACHE_KEY = "accm-data";
 /** Cache TTL: 1 hour */
 const CACHE_TTL_MS = 60 * 60 * 1000;
-/** Number of weeks of history to return */
-const WEEKS_OF_HISTORY = 12;
+/** Project start date — first commit / first PR landed on this date.
+ *  History windows are computed from this date so the charts always
+ *  show the full project history rather than a sliding window. */
+const PROJECT_START_DATE = "2025-12-15";
+/** Hard ceiling on history length, in case PROJECT_START_DATE drifts.
+ *  At ~5 years this is generous but bounded. */
+const MAX_WEEKS_OF_HISTORY = 260;
 /** GitHub API results per page (max 100) */
 const PER_PAGE = 100;
 /**
- * Max pages to fetch per endpoint. Bumped from 3 → 15 (1500 items) because
- * recent activity can exceed 300 PRs in a single week, which caused every
- * older week to show 0 activity in the chart — the 3-page window never
- * escaped the most recent week.
+ * Max pages to fetch per endpoint. With the full project history window
+ * (~18+ weeks at the time of writing) and recent weeks exceeding 300 PRs,
+ * we need a generous page cap to avoid older weeks rendering as 0.
  */
-const MAX_PAGES = 15;
+const MAX_PAGES = 30;
 /** Request timeout for GitHub API calls */
 const API_TIMEOUT_MS = 15_000;
 /** AI-generated label used to classify AI contributions */
@@ -143,6 +147,27 @@ function lastNWeeks(n: number): string[] {
   return weeks;
 }
 
+/** Number of milliseconds in one week */
+const MS_PER_WEEK = 7 * 24 * 60 * 60 * 1000;
+
+/** Number of weeks between PROJECT_START_DATE and today, capped at
+ *  MAX_WEEKS_OF_HISTORY. Always returns at least 1. */
+function weeksSinceProjectStart(): number {
+  const start = new Date(PROJECT_START_DATE);
+  const elapsedMs = Date.now() - start.getTime();
+  const weeks = Math.ceil(elapsedMs / MS_PER_WEEK) + 1;
+  return Math.max(1, Math.min(MAX_WEEKS_OF_HISTORY, weeks));
+}
+
+/** Days between PROJECT_START_DATE and today, used as the GitHub
+ *  search `since` window. Always returns at least 1. */
+function daysSinceProjectStart(): number {
+  const start = new Date(PROJECT_START_DATE);
+  const elapsedMs = Date.now() - start.getTime();
+  const days = Math.ceil(elapsedMs / (24 * 60 * 60 * 1000));
+  return Math.max(1, days);
+}
+
 /** Fetch paginated results from GitHub REST API */
 async function fetchPaginated<T>(
   url: string,
@@ -207,10 +232,10 @@ interface WorkflowRunItem {
   status: string;
 }
 
-/** Fetch recently created PRs (last ~90 days to cover 12 weeks) */
+/** Fetch PRs created since the project start date */
 async function fetchRecentPRs(token: string): Promise<PRItem[]> {
   const since = new Date();
-  since.setDate(since.getDate() - 90);
+  since.setDate(since.getDate() - daysSinceProjectStart());
   const sinceStr = since.toISOString().split("T")[0];
 
   // Use search API to get PRs with label info
@@ -231,10 +256,10 @@ async function fetchRecentPRs(token: string): Promise<PRItem[]> {
   });
 }
 
-/** Fetch recently created/closed issues (last ~90 days) */
+/** Fetch issues created since the project start date */
 async function fetchRecentIssues(token: string): Promise<IssueItem[]> {
   const since = new Date();
-  since.setDate(since.getDate() - 90);
+  since.setDate(since.getDate() - daysSinceProjectStart());
   const sinceStr = since.toISOString().split("T")[0];
 
   // Search for issues (excluding PRs)
@@ -275,7 +300,7 @@ async function fetchWorkflowRuns(
 
   // Fetch runs for this workflow
   const since = new Date();
-  since.setDate(since.getDate() - 90);
+  since.setDate(since.getDate() - daysSinceProjectStart());
   const sinceStr = since.toISOString().split("T")[0];
 
   const runsUrl = `${GITHUB_API}/repos/${REPO}/actions/workflows/${workflow.id}/runs?created=>${sinceStr}&status=completed`;
@@ -457,7 +482,7 @@ function aggregateContributorGrowth(
 // ---------------------------------------------------------------------------
 
 async function fetchACCMData(token: string): Promise<ACCMData> {
-  const weeks = lastNWeeks(WEEKS_OF_HISTORY);
+  const weeks = lastNWeeks(weeksSinceProjectStart());
 
   // Fetch all data in parallel
   const [prs, issues, coverageRuns, nightlyRuns] = await Promise.all([

--- a/web/public/analytics.js
+++ b/web/public/analytics.js
@@ -936,22 +936,33 @@
       }
 
       // ── 2b. AI vs Human Contributions (Level 5: Self-Sustaining) ──
+      // Split into PRs (AI-authored code) and Issues (typically user-filed
+      // bug reports). Lumping them together hides the fact that nearly all
+      // code is AI-written while most issues are human-filed.
       if (accm.weeklyActivity && accm.weeklyActivity.length > 0) {
-        const totalAi = accm.weeklyActivity.reduce((s, w) => s + (w.aiPrs || 0) + (w.aiIssues || 0), 0);
-        const totalHuman = accm.weeklyActivity.reduce((s, w) => s + (w.humanPrs || 0) + (w.humanIssues || 0), 0);
-        const total = totalAi + totalHuman;
-        const aiPct = total > 0 ? Math.round((totalAi / total) * 100) : 0;
+        const aiPrs = accm.weeklyActivity.reduce((s, w) => s + (w.aiPrs || 0), 0);
+        const humanPrs = accm.weeklyActivity.reduce((s, w) => s + (w.humanPrs || 0), 0);
+        const totalPrs = aiPrs + humanPrs;
+        const aiPrPct = totalPrs > 0 ? Math.round((aiPrs / totalPrs) * 100) : 0;
+
+        const aiIssues = accm.weeklyActivity.reduce((s, w) => s + (w.aiIssues || 0), 0);
+        const humanIssues = accm.weeklyActivity.reduce((s, w) => s + (w.humanIssues || 0), 0);
+        const totalIssues = aiIssues + humanIssues;
+        const aiIssuePct = totalIssues > 0 ? Math.round((aiIssues / totalIssues) * 100) : 0;
 
         html += '<div class="kpi-grid">';
-        html += `<div class="kpi-card"><div class="kpi-label">AI Contributions</div><div class="kpi-value" style="color:var(--purple)">${aiPct}%</div><div class="kpi-change flat">${totalAi} of ${total} total</div></div>`;
-        html += `<div class="kpi-card"><div class="kpi-label">Human Contributions</div><div class="kpi-value" style="color:var(--cyan)">${100 - aiPct}%</div><div class="kpi-change flat">${totalHuman} of ${total} total</div></div>`;
+        html += `<div class="kpi-card"><div class="kpi-label">AI-Authored PRs</div><div class="kpi-value" style="color:var(--purple)">${aiPrPct}%</div><div class="kpi-change flat">${aiPrs} of ${totalPrs} PRs</div></div>`;
+        html += `<div class="kpi-card"><div class="kpi-label">Human-Authored PRs</div><div class="kpi-value" style="color:var(--cyan)">${100 - aiPrPct}%</div><div class="kpi-change flat">${humanPrs} of ${totalPrs} PRs</div></div>`;
+        html += `<div class="kpi-card"><div class="kpi-label">AI-Filed Issues</div><div class="kpi-value" style="color:var(--purple)">${aiIssuePct}%</div><div class="kpi-change flat">${aiIssues} of ${totalIssues} issues</div></div>`;
+        html += `<div class="kpi-card"><div class="kpi-label">Human-Filed Issues</div><div class="kpi-value" style="color:var(--cyan)">${100 - aiIssuePct}%</div><div class="kpi-change flat">${humanIssues} of ${totalIssues} issues</div></div>`;
 
         if (accm.contributorGrowth) {
           html += `<div class="kpi-card"><div class="kpi-label">Total Contributors</div><div class="kpi-value">${accm.contributorGrowth.total}</div></div>`;
         }
         html += '</div>';
 
-        html += '<div class="chart-card"><h3>AI vs Human Contributions</h3><div class="chart-wrapper"><canvas id="accmAiChart"></canvas></div></div>';
+        html += '<div class="chart-card"><h3>AI vs Human PRs</h3><div class="chart-wrapper"><canvas id="accmAiPrChart"></canvas></div></div>';
+        html += '<div class="chart-card"><h3>AI vs Human Issues</h3><div class="chart-wrapper"><canvas id="accmAiIssueChart"></canvas></div></div>';
       }
 
       // ── 2c. CI Pass Rates (Level 4: Adaptive) ──
@@ -1000,20 +1011,38 @@
         }
       }
 
-      // AI vs Human — stacked area
+      // AI vs Human PRs — stacked area
       if (accm.weeklyActivity && accm.weeklyActivity.length > 0) {
-        const ctx = document.getElementById('accmAiChart');
+        const ctx = document.getElementById('accmAiPrChart');
         if (ctx) {
           new Chart(ctx, {
             type: 'line',
             data: {
               labels: accm.weeklyActivity.map(w => w.week),
               datasets: [
-                { label: 'AI (PRs + Issues)', data: accm.weeklyActivity.map(w => (w.aiPrs || 0) + (w.aiIssues || 0)), borderColor: '#a855f7', backgroundColor: 'rgba(168, 85, 247, 0.2)', fill: true, tension: 0.3 },
-                { label: 'Human (PRs + Issues)', data: accm.weeklyActivity.map(w => (w.humanPrs || 0) + (w.humanIssues || 0)), borderColor: '#06b6d4', backgroundColor: 'rgba(6, 182, 212, 0.2)', fill: true, tension: 0.3 },
+                { label: 'AI PRs', data: accm.weeklyActivity.map(w => w.aiPrs || 0), borderColor: '#a855f7', backgroundColor: 'rgba(168, 85, 247, 0.2)', fill: true, tension: 0.3 },
+                { label: 'Human PRs', data: accm.weeklyActivity.map(w => w.humanPrs || 0), borderColor: '#06b6d4', backgroundColor: 'rgba(6, 182, 212, 0.2)', fill: true, tension: 0.3 },
               ],
             },
-            options: { ...chartOpts, scales: { ...chartOpts.scales, y: { ...chartOpts.scales.y, stacked: true, title: { display: true, text: 'Contributions', color: '#9ca3af' } } } },
+            options: { ...chartOpts, scales: { ...chartOpts.scales, y: { ...chartOpts.scales.y, stacked: true, title: { display: true, text: 'PRs', color: '#9ca3af' } } } },
+          });
+        }
+      }
+
+      // AI vs Human Issues — stacked area
+      if (accm.weeklyActivity && accm.weeklyActivity.length > 0) {
+        const ctx = document.getElementById('accmAiIssueChart');
+        if (ctx) {
+          new Chart(ctx, {
+            type: 'line',
+            data: {
+              labels: accm.weeklyActivity.map(w => w.week),
+              datasets: [
+                { label: 'AI Issues', data: accm.weeklyActivity.map(w => w.aiIssues || 0), borderColor: '#a855f7', backgroundColor: 'rgba(168, 85, 247, 0.2)', fill: true, tension: 0.3 },
+                { label: 'Human Issues', data: accm.weeklyActivity.map(w => w.humanIssues || 0), borderColor: '#06b6d4', backgroundColor: 'rgba(6, 182, 212, 0.2)', fill: true, tension: 0.3 },
+              ],
+            },
+            options: { ...chartOpts, scales: { ...chartOpts.scales, y: { ...chartOpts.scales.y, stacked: true, title: { display: true, text: 'Issues', color: '#9ca3af' } } } },
           });
         }
       }

--- a/web/src/hooks/useMediumBlog.ts
+++ b/web/src/hooks/useMediumBlog.ts
@@ -18,6 +18,13 @@ const CACHE_KEY = 'ks-medium-blog-cache'
 const CACHE_TTL_MS = 60 * 60 * 1000
 /** Fetch timeout for Medium blog API call (10 seconds) */
 const BLOG_FETCH_TIMEOUT_MS = 10_000
+/** Local relative endpoint — Go backend / Netlify Function */
+const LOCAL_BLOG_ENDPOINT = '/api/medium/blog'
+/** Public fallback used when the local endpoint is unreachable
+ *  (e.g. Vite dev server with no Go backend, or a self-hosted install
+ *  whose backend hasn't been started yet). The endpoint is public and
+ *  CORS-enabled. */
+const PUBLIC_BLOG_FALLBACK_URL = 'https://console.kubestellar.io/api/medium/blog'
 
 interface CacheEntry {
   posts: BlogPost[]
@@ -65,37 +72,50 @@ function writeCache(posts: BlogPost[], channelUrl: string): void {
  * Results are cached in sessionStorage for 1 hour.
  */
 export function useMediumBlog() {
-  const [posts, setPosts] = useState<BlogPost[]>([])
-  const [channelUrl, setChannelUrl] = useState('https://medium.com/@kubestellar')
-  const [loading, setLoading] = useState(true)
+  // Read the cache synchronously during initial render via lazy useState
+  // initializers. This avoids calling setState inside the effect for the
+  // cache-hit path (react-hooks/set-state-in-effect).
+  const [posts, setPosts] = useState<BlogPost[]>(() => readCache()?.posts ?? [])
+  const [channelUrl, setChannelUrl] = useState<string>(
+    () => readCache()?.channelUrl ?? 'https://medium.com/@kubestellar'
+  )
+  const [loading, setLoading] = useState(() => readCache() === null)
 
   useEffect(() => {
-    const cached = readCache()
-    if (cached) {
-      setPosts(cached.posts)
-      setChannelUrl(cached.channelUrl)
-      setLoading(false)
-      return
-    }
+    // If we already populated state from a fresh cache entry, nothing to do.
+    if (readCache() !== null) return
 
     let cancelled = false
 
+    async function fetchFrom(url: string): Promise<BlogResponse> {
+      const resp = await fetch(url, {
+        signal: AbortSignal.timeout(BLOG_FETCH_TIMEOUT_MS),
+      })
+      if (!resp.ok) throw new Error(`HTTP ${resp.status}`)
+      return resp.json()
+    }
+
     async function fetchBlog() {
+      let data: BlogResponse | null = null
       try {
-        const resp = await fetch('/api/medium/blog', {
-          signal: AbortSignal.timeout(BLOG_FETCH_TIMEOUT_MS),
-        })
-        if (!resp.ok) throw new Error(`HTTP ${resp.status}`)
-        const data: BlogResponse = await resp.json()
-        if (cancelled) return
+        data = await fetchFrom(LOCAL_BLOG_ENDPOINT)
+      } catch {
+        // Local endpoint unreachable (no backend / Vite-only dev / self-hosted
+        // without the Go server). Fall back to the public production endpoint
+        // so the blog section still renders.
+        try {
+          data = await fetchFrom(PUBLIC_BLOG_FALLBACK_URL)
+        } catch {
+          // Both failed — silently leave the section empty.
+        }
+      }
+      if (cancelled) return
+      if (data) {
         setPosts(data.posts || [])
         setChannelUrl(data.channelUrl)
         writeCache(data.posts || [], data.channelUrl)
-      } catch {
-        // Silently fail — the blog section just won't render
-      } finally {
-        if (!cancelled) setLoading(false)
       }
+      setLoading(false)
     }
 
     fetchBlog()


### PR DESCRIPTION
## Summary

Three fixes bundled (each ~surgical, all touch the Learn / ACCM analytics surface):

1. **`useMediumBlog.ts` — public production fallback**
   When the local `/api/medium/blog` endpoint is unreachable, fall back to `https://console.kubestellar.io/api/medium/blog` (CORS-enabled, public, returns the right shape). Covers: Vite-only dev with no Go backend, self-hosted installs whose backend isn't running, and **stale backends predating PR #5277** (which is the case I hit on my own dev box — backend was started before the Medium route was added, so all requests fell through to a 401). Also switched the cache-hit path to lazy `useState` initializers so we don't call `setState` inside the effect.

2. **`web/public/analytics.js` — split the AI vs Human metric**
   The single \"AI Contributions: 59%\" KPI was lumping PRs and issues together, hiding the fact that PRs are overwhelmingly AI-authored while issues are overwhelmingly human-filed bug reports. Split into four KPIs (AI-Authored PRs, Human-Authored PRs, AI-Filed Issues, Human-Filed Issues) and split the AI-vs-Human chart into a PR chart and an Issue chart.

3. **`web/netlify/functions/analytics-accm.mts` — full project history**
   Replaced \`WEEKS_OF_HISTORY = 12\` and the three \`since.setDate(... -90)\` callsites with a \`PROJECT_START_DATE = '2025-12-15'\` computation. ACCM charts now show the full project history (Dec 2025 → today) instead of a sliding 12-week window. Bumped \`MAX_PAGES\` 15 → 30 since the longer window will hit the page cap on busy weeks. Capped at \`MAX_WEEKS_OF_HISTORY = 260\` for safety.

## Test plan
- [ ] Local: kill backend, hit Vite at 5174, open Learn dropdown — blog posts now appear (via prod fallback)
- [ ] Local: with backend running, blog posts still appear (local hit)
- [ ] /admin/analytics on console.kubestellar.io: ACCM section shows 4 KPIs (PRs and Issues split), 2 line charts (PRs / Issues), and history extending back to W51 of 2025
- [ ] No regressions in lint/build (verified locally)