### PR TITLE
🐛 fix: show real in-cluster clusters in Create Namespace (not demo list)

### DIFF
--- a/web/src/hooks/mcp/shared.ts
+++ b/web/src/hooks/mcp/shared.ts
@@ -1,6 +1,7 @@
 import { api, isBackendUnavailable } from '../../lib/api'
 import { reportAgentDataError, reportAgentDataSuccess, isAgentUnavailable } from '../useLocalAgent'
-import { isDemoMode, isNetlifyDeployment, isDemoToken, subscribeDemoMode } from '../../lib/demoMode'
+import { isDemoMode, isNetlifyDeployment, isDemoToken, hasRealToken, subscribeDemoMode } from '../../lib/demoMode'
+import { isInClusterMode } from '../useBackendHealth'
 import { kubectlProxy } from '../../lib/kubectlProxy'
 import { registerCacheReset, triggerAllRefetches } from '../../lib/modeTransition'
 import { resetFailuresForCluster, resetAllCacheFailures } from '../../lib/cache'
@@ -1327,7 +1328,15 @@ export async function fullFetchClusters() {
   // DEMO MODE: When user has explicitly enabled demo mode, use demo data immediately.
   // Don't try to fetch from agent - user wants to see demo data, not live data.
   // This respects the user's explicit choice to enable demo mode.
-  if (isDemoMode()) {
+  //
+  // EXCEPTION: When the console is deployed in-cluster AND the user has a real
+  // auth token, always fetch live cluster data. Otherwise UI elements like the
+  // Create Namespace cluster dropdown would list demo clusters (eks-prod-us-east-1,
+  // gke-staging, etc.) instead of the actual cluster the console is running in
+  // (e.g. vllm-d). This matches the GPU-reservations live-mode bypass pattern in
+  // GPUReservations.tsx.
+  const inClusterLive = isInClusterMode() && hasRealToken()
+  if (isDemoMode() && !inClusterLive) {
     updateClusterCache({
       clusters: getDemoClusters(),
       isLoading: false,


### PR DESCRIPTION
## Summary

- When the console is deployed in-cluster (e.g. on vllm-d) with a real OAuth token, the **Create Namespace** modal's cluster dropdown was listing demo clusters (`eks-prod-us-east-1`, `gke-staging`, `aks-dev-westeu`, etc.) instead of the actual in-cluster. The **Create GPU Reservation** dialog already showed the real cluster because `GPUReservations.tsx` bypasses demo mode via `gpuLiveMode = isInClusterMode && isAuthenticated && hasRealToken()`.
- This PR applies the same live-mode bypass at the shared cluster-fetch site (`fullFetchClusters` in `web/src/hooks/mcp/shared.ts`), so every card consuming `useClusters()` — Create Namespace, cluster filters, etc. — gets live cluster data when the console is running in-cluster with a real token. Demo toggle on localhost/Netlify is unaffected.

## Reported behavior
- Create Namespace dropdown showed 11+ demo clusters on the vllm-d deployment.
- Create GPU Reservation correctly showed `vllm-d — 18 available / 50 total GPUs`.

## Fix
`fullFetchClusters()` skips its `if (isDemoMode())` early-return when `isInClusterMode() && hasRealToken()`. Those two checks together are the same signal `GPUReservations.tsx` already uses.

## Test plan

- [ ] Deploy to vllm-d cluster; confirm the Create Namespace cluster dropdown lists `vllm-d` (not demo clusters).
- [ ] Confirm Create GPU Reservation still shows the vllm-d cluster (regression check).
- [ ] Verify localhost dev with demo mode toggled on still shows demo cluster list (no regression).
- [ ] Verify console.kubestellar.io (Netlify demo deploy) still shows demo clusters (Netlify is not in-cluster so the bypass doesn't trigger).