### PR TITLE
fix(security): mask Secret YAML tab + add ConfigMap reveal gate (#6209, #6211)

### DIFF
--- a/web/src/components/drilldown/views/ConfigMapDrillDown.tsx
+++ b/web/src/components/drilldown/views/ConfigMapDrillDown.tsx
@@ -3,11 +3,14 @@ import { useLocalAgent } from '../../../hooks/useLocalAgent'
 import { LOCAL_AGENT_WS_URL } from '../../../lib/constants'
 import { useDrillDownActions } from '../../../hooks/useDrillDown'
 import { ClusterBadge } from '../../ui/ClusterBadge'
-import { FileText, Code, Info, Tag, ChevronDown, ChevronUp, Loader2, Copy, Check, Layers, Server, Database } from 'lucide-react'
+import { FileText, Code, Info, Tag, ChevronDown, ChevronUp, Loader2, Copy, Check, Layers, Server, Database, Eye, EyeOff, Lock } from 'lucide-react'
 import { cn } from '../../../lib/cn'
 import { UI_FEEDBACK_TIMEOUT_MS } from '../../../lib/constants/network'
 import { useTranslation } from 'react-i18next'
 import { copyToClipboard } from '../../../lib/clipboard'
+// Reuse the YAML masking helper from SecretDrillDown — same `data:` block
+// shape from `kubectl get configmap -o yaml`, so the same regex applies.
+import { maskSecretYaml } from './SecretDrillDown'
 
 interface Props {
   data: Record<string, unknown>
@@ -32,6 +35,26 @@ export function ConfigMapDrillDown({ data }: Props) {
   const [labels, setLabels] = useState<Record<string, string> | null>(null)
   const [copiedField, setCopiedField] = useState<string | null>(null)
   const [showAllData, setShowAllData] = useState(false)
+  // Per-key reveal gate (#6211). ConfigMaps are NOT secrets, but teams
+  // routinely store connection strings, passwords, and TLS material in them
+  // so the value column needs the same opt-in reveal pattern that
+  // SecretDrillDown uses on its Data tab — defaulting to masked, requiring
+  // an explicit click to reveal. Unlike Secrets, ConfigMaps may legitimately
+  // hold non-sensitive config too, so we expose a "Reveal all" master toggle
+  // alongside the per-key buttons for the common case.
+  const [revealedKeys, setRevealedKeys] = useState<Set<string>>(new Set())
+  const [revealAll, setRevealAll] = useState(false)
+
+  const toggleReveal = (key: string) => {
+    setRevealedKeys(prev => {
+      const next = new Set(prev)
+      if (next.has(key)) next.delete(key)
+      else next.add(key)
+      return next
+    })
+  }
+
+  const isRevealed = (key: string) => revealAll || revealedKeys.has(key)
 
   // Helper to run kubectl commands
   const runKubectl = (args: string[]): Promise<string> => {
@@ -254,25 +277,54 @@ export function ConfigMapDrillDown({ data }: Props) {
 
         {activeTab === 'data' && (
           <div className="space-y-4">
+            {/* #6211: master reveal toggle for ConfigMaps. ConfigMaps often
+                hold non-sensitive config so a single "Reveal all" is more
+                ergonomic than the per-key dance, but we keep the per-key
+                buttons too for the case where a single sensitive value
+                hides among harmless ones. */}
+            <div className="p-3 rounded-lg bg-yellow-500/10 border border-yellow-500/20 text-sm text-yellow-400 flex items-center justify-between gap-2">
+              <div className="flex items-center gap-2">
+                <Lock className="w-4 h-4" />
+                ConfigMap values are hidden by default. Click the eye icon to reveal.
+              </div>
+              <button
+                onClick={() => setRevealAll(v => !v)}
+                className="px-2 py-1 rounded bg-yellow-500/20 hover:bg-yellow-500/30 text-xs text-yellow-300 flex items-center gap-1"
+              >
+                {revealAll ? <><EyeOff className="w-3 h-3" /> Mask all</> : <><Eye className="w-3 h-3" /> Reveal all</>}
+              </button>
+            </div>
             {dataEntries.length > 0 ? (
               <>
                 {displayedData.map(([key, value]) => (
                   <div key={key} className="rounded-lg bg-card/50 border border-border overflow-hidden">
                     <div className="flex items-center justify-between px-3 py-2 bg-yellow-500/10 border-b border-border">
                       <span className="font-mono text-sm text-yellow-400">{key}</span>
-                      <button
-                        onClick={() => handleCopy(`data-${key}`, value)}
-                        className="p-1 rounded hover:bg-secondary/50 text-muted-foreground hover:text-foreground"
-                      >
-                        {copiedField === `data-${key}` ? (
-                          <Check className="w-4 h-4 text-green-400" />
-                        ) : (
-                          <Copy className="w-4 h-4" />
-                        )}
-                      </button>
+                      <div className="flex items-center gap-1">
+                        <button
+                          onClick={() => toggleReveal(key)}
+                          className="p-1 rounded hover:bg-secondary/50 text-muted-foreground hover:text-foreground"
+                          aria-label={isRevealed(key) ? 'Mask value' : 'Reveal value'}
+                          title={isRevealed(key) ? 'Mask value' : 'Reveal value'}
+                        >
+                          {isRevealed(key) ? <EyeOff className="w-4 h-4" /> : <Eye className="w-4 h-4" />}
+                        </button>
+                        <button
+                          onClick={() => handleCopy(`data-${key}`, isRevealed(key) ? value : '••••••••••••••••')}
+                          className="p-1 rounded hover:bg-secondary/50 text-muted-foreground hover:text-foreground"
+                          aria-label={isRevealed(key) ? 'Copy value' : 'Reveal first to copy'}
+                          title={isRevealed(key) ? 'Copy value' : 'Reveal first to copy the actual value'}
+                        >
+                          {copiedField === `data-${key}` ? (
+                            <Check className="w-4 h-4 text-green-400" />
+                          ) : (
+                            <Copy className="w-4 h-4" />
+                          )}
+                        </button>
+                      </div>
                     </div>
                     <pre className="p-3 text-xs font-mono text-foreground whitespace-pre-wrap max-h-48 overflow-auto">
-                      {value}
+                      {isRevealed(key) ? value : '••••••••••••••••'}
                     </pre>
                   </div>
                 ))}
@@ -325,7 +377,17 @@ export function ConfigMapDrillDown({ data }: Props) {
         )}
 
         {activeTab === 'yaml' && (
-          <div>
+          <div className="space-y-3">
+            {/* #6211: same masking model the Data tab uses, applied to the
+                YAML view so that tab isn't a bypass for the per-key reveal.
+                ConfigMap YAML uses the same `data:` block shape as Secret
+                YAML, so we share the maskSecretYaml() helper. */}
+            <div className="p-3 rounded-lg bg-yellow-500/10 border border-yellow-500/20 text-sm text-yellow-400 flex items-center gap-2">
+              <Lock className="w-4 h-4" />
+              {revealAll
+                ? 'ConfigMap values are visible. Use "Mask all" on the Data tab to hide.'
+                : 'ConfigMap values are hidden by default. Use "Reveal all" on the Data tab to show.'}
+            </div>
             {yamlLoading ? (
               <div className="flex items-center justify-center py-12">
                 <Loader2 className="w-6 h-6 animate-spin text-primary" />
@@ -333,15 +395,22 @@ export function ConfigMapDrillDown({ data }: Props) {
               </div>
             ) : yamlOutput ? (
               <div className="relative">
-                <button
-                  onClick={() => handleCopy('yaml', yamlOutput)}
-                  className="absolute top-2 right-2 px-2 py-1 rounded bg-secondary/50 text-xs text-muted-foreground hover:text-foreground flex items-center gap-1"
-                >
-                  {copiedField === 'yaml' ? <><Check className="w-3 h-3 text-green-400" /> Copied</> : <><Copy className="w-3 h-3" /> Copy</>}
-                </button>
-                <pre className="p-4 rounded-lg bg-black/50 border border-border overflow-auto max-h-[60vh] text-xs text-foreground font-mono whitespace-pre-wrap">
-                  {yamlOutput}
-                </pre>
+                {(() => {
+                  const displayedYaml = revealAll ? yamlOutput : maskSecretYaml(yamlOutput)
+                  return (
+                    <>
+                      <button
+                        onClick={() => handleCopy('yaml', displayedYaml)}
+                        className="absolute top-2 right-2 px-2 py-1 rounded bg-secondary/50 text-xs text-muted-foreground hover:text-foreground flex items-center gap-1"
+                      >
+                        {copiedField === 'yaml' ? <><Check className="w-3 h-3 text-green-400" /> Copied</> : <><Copy className="w-3 h-3" /> Copy</>}
+                      </button>
+                      <pre className="p-4 rounded-lg bg-black/50 border border-border overflow-auto max-h-[60vh] text-xs text-foreground font-mono whitespace-pre-wrap">
+                        {displayedYaml}
+                      </pre>
+                    </>
+                  )
+                })()}
               </div>
             ) : (
               <div className="p-4 rounded-lg bg-yellow-500/10 border border-yellow-500/20 text-center">

--- a/web/src/components/drilldown/views/SecretDrillDown.tsx
+++ b/web/src/components/drilldown/views/SecretDrillDown.tsx
@@ -15,6 +15,88 @@ interface Props {
 
 type TabType = 'overview' | 'data' | 'describe' | 'yaml'
 
+/** Sentinel string used in place of secret values when the YAML tab is
+ * masked. Same width as the per-key reveal placeholder on the Data tab so
+ * masked YAML and masked Data look consistent. */
+const YAML_MASK_PLACEHOLDER = '••••••••••••••••'
+
+/**
+ * Mask the `data:` block of `kubectl get secret -o yaml` output (#6209).
+ *
+ * `kubectl get secret -o yaml` always emits the data block as:
+ *
+ *   data:
+ *     password: cGFzczEyMw==
+ *     username: dXNlcg==
+ *   kind: Secret
+ *
+ * That is — the `data:` line at indent 0, child entries at a deeper indent,
+ * and the block ends as soon as a sibling/parent key appears at the same or
+ * shallower indent than `data:`. We replace each child value with the
+ * placeholder while preserving the key name (so users can still see WHAT
+ * keys exist) and the surrounding YAML structure (so the document remains
+ * parseable for the eye).
+ *
+ * Also masks `stringData:` (kubectl emits this for secrets created with
+ * stringData) by the same rule.
+ *
+ * Regex-based intentionally — pulling in a YAML parser just for this would
+ * bloat the bundle and introduce parser ambiguity around the multi-document
+ * separator. The format from kubectl is stable and the test in
+ * SecretDrillDown.test.tsx pins it.
+ */
+export function maskSecretYaml(yaml: string): string {
+  if (!yaml) return yaml
+  const lines = yaml.split('\n')
+  const out: string[] = []
+  let inSensitiveBlock = false
+  let blockIndent = -1
+  for (const line of lines) {
+    // Detect the start of a sensitive block. The block header itself is
+    // emitted unchanged.
+    const blockHeaderMatch = line.match(/^(\s*)(data|stringData):\s*$/)
+    if (blockHeaderMatch) {
+      out.push(line)
+      inSensitiveBlock = true
+      blockIndent = blockHeaderMatch[1].length
+      continue
+    }
+    if (inSensitiveBlock) {
+      // Empty line — pass through, stay inside the block.
+      if (line.trim().length === 0) {
+        out.push(line)
+        continue
+      }
+      // Compute the indent of this line. If it's <= blockIndent and not
+      // empty, we've left the data block.
+      const indentMatch = line.match(/^(\s*)/)
+      const lineIndent = indentMatch ? indentMatch[1].length : 0
+      if (lineIndent <= blockIndent) {
+        inSensitiveBlock = false
+        blockIndent = -1
+        out.push(line)
+        continue
+      }
+      // Inside the block — mask the value, preserve the key. Match
+      //   <indent><key>: <value>
+      // The value can be a simple scalar, a quoted string, or absent (for
+      // a multiline `|` or `>` indicator on the next line). We only mask
+      // single-line scalar form, which is what kubectl emits.
+      const kvMatch = line.match(/^(\s*)([^:]+):\s*(.+)$/)
+      if (kvMatch) {
+        out.push(`${kvMatch[1]}${kvMatch[2]}: ${YAML_MASK_PLACEHOLDER}`)
+      } else {
+        // Defensive: line doesn't look like a key-value (could be a `|`
+        // continuation). Mask the entire content side to be safe.
+        out.push(`${' '.repeat(blockIndent + 2)}${YAML_MASK_PLACEHOLDER}`)
+      }
+      continue
+    }
+    out.push(line)
+  }
+  return out.join('\n')
+}
+
 export function SecretDrillDown({ data }: Props) {
   const { t } = useTranslation()
   const cluster = data.cluster as string
@@ -34,6 +116,11 @@ export function SecretDrillDown({ data }: Props) {
   const [copiedField, setCopiedField] = useState<string | null>(null)
   const [showAllData, setShowAllData] = useState(false)
   const [revealedKeys, setRevealedKeys] = useState<Set<string>>(new Set())
+  // YAML tab reveal state — defaults to MASKED so the `data:` block doesn't
+  // leak base64-encoded secrets the moment a user clicks the YAML tab
+  // (#6209). Mirrors the per-key reveal pattern on the Data tab — explicit
+  // user action required to see secrets.
+  const [yamlRevealed, setYamlRevealed] = useState(false)
 
   // Helper to run kubectl commands
   const runKubectl = (args: string[]): Promise<string> => {
@@ -369,7 +456,15 @@ export function SecretDrillDown({ data }: Props) {
         )}
 
         {activeTab === 'yaml' && (
-          <div>
+          <div className="space-y-3">
+            {/* #6209: same warning the Data tab uses, so the YAML tab is no
+                longer the easy bypass for the per-key reveal model. */}
+            <div className="p-3 rounded-lg bg-yellow-500/10 border border-yellow-500/20 text-sm text-yellow-400 flex items-center gap-2">
+              <Lock className="w-4 h-4" />
+              {yamlRevealed
+                ? 'Secret values are visible. Click the eye icon to mask.'
+                : 'Secret values are hidden by default. Click the eye icon to reveal.'}
+            </div>
             {yamlLoading ? (
               <div className="flex items-center justify-center py-12">
                 <Loader2 className="w-6 h-6 animate-spin text-primary" />
@@ -377,15 +472,35 @@ export function SecretDrillDown({ data }: Props) {
               </div>
             ) : yamlOutput ? (
               <div className="relative">
-                <button
-                  onClick={() => handleCopy('yaml', yamlOutput)}
-                  className="absolute top-2 right-2 px-2 py-1 rounded bg-secondary/50 text-xs text-muted-foreground hover:text-foreground flex items-center gap-1"
-                >
-                  {copiedField === 'yaml' ? <><Check className="w-3 h-3 text-green-400" /> Copied</> : <><Copy className="w-3 h-3" /> Copy</>}
-                </button>
-                <pre className="p-4 rounded-lg bg-black/50 border border-border overflow-auto max-h-[60vh] text-xs text-foreground font-mono whitespace-pre-wrap">
-                  {yamlOutput}
-                </pre>
+                {(() => {
+                  // Compute once per render so the Copy button puts the
+                  // SAME bytes onto the clipboard that the user is looking
+                  // at — masked when masked, raw when revealed (#6209).
+                  const displayedYaml = yamlRevealed ? yamlOutput : maskSecretYaml(yamlOutput)
+                  return (
+                    <>
+                      <div className="absolute top-2 right-2 flex items-center gap-1">
+                        <button
+                          onClick={() => setYamlRevealed(v => !v)}
+                          className="p-1 rounded bg-secondary/50 text-muted-foreground hover:text-foreground"
+                          aria-label={yamlRevealed ? 'Mask secret values' : 'Reveal secret values'}
+                          title={yamlRevealed ? 'Mask secret values' : 'Reveal secret values'}
+                        >
+                          {yamlRevealed ? <EyeOff className="w-4 h-4" /> : <Eye className="w-4 h-4" />}
+                        </button>
+                        <button
+                          onClick={() => handleCopy('yaml', displayedYaml)}
+                          className="px-2 py-1 rounded bg-secondary/50 text-xs text-muted-foreground hover:text-foreground flex items-center gap-1"
+                        >
+                          {copiedField === 'yaml' ? <><Check className="w-3 h-3 text-green-400" /> Copied</> : <><Copy className="w-3 h-3" /> Copy</>}
+                        </button>
+                      </div>
+                      <pre className="p-4 rounded-lg bg-black/50 border border-border overflow-auto max-h-[60vh] text-xs text-foreground font-mono whitespace-pre-wrap">
+                        {displayedYaml}
+                      </pre>
+                    </>
+                  )
+                })()}
               </div>
             ) : (
               <div className="p-4 rounded-lg bg-yellow-500/10 border border-yellow-500/20 text-center">

--- a/web/src/components/drilldown/views/__tests__/SecretDrillDown.test.tsx
+++ b/web/src/components/drilldown/views/__tests__/SecretDrillDown.test.tsx
@@ -48,11 +48,101 @@ vi.mock('../../../../lib/clipboard', () => ({
   copyToClipboard: vi.fn(),
 }))
 
-import { SecretDrillDown } from '../SecretDrillDown'
+import { SecretDrillDown, maskSecretYaml } from '../SecretDrillDown'
 
 describe('SecretDrillDown', () => {
   it('renders without crashing', () => {
     const { container } = render(<SecretDrillDown data={{ cluster: 'c1', namespace: 'ns1', secret: 'sec1' }} />)
     expect(container).toBeTruthy()
+  })
+})
+
+// #6209: maskSecretYaml replaces values inside `data:` and `stringData:`
+// blocks with a placeholder, while preserving keys, surrounding YAML
+// structure, and any sibling top-level keys.
+describe('maskSecretYaml (#6209)', () => {
+  const PLACEHOLDER = '••••••••••••••••'
+
+  it('masks values inside the data: block', () => {
+    const yaml = [
+      'apiVersion: v1',
+      'kind: Secret',
+      'metadata:',
+      '  name: my-secret',
+      'data:',
+      '  password: cGFzczEyMw==',
+      '  username: dXNlcg==',
+      'type: Opaque',
+    ].join('\n')
+    const masked = maskSecretYaml(yaml)
+    expect(masked).not.toContain('cGFzczEyMw==')
+    expect(masked).not.toContain('dXNlcg==')
+    expect(masked).toContain(`password: ${PLACEHOLDER}`)
+    expect(masked).toContain(`username: ${PLACEHOLDER}`)
+    // Surrounding YAML preserved
+    expect(masked).toContain('apiVersion: v1')
+    expect(masked).toContain('kind: Secret')
+    expect(masked).toContain('  name: my-secret')
+    expect(masked).toContain('type: Opaque')
+  })
+
+  it('masks values inside the stringData: block', () => {
+    const yaml = [
+      'apiVersion: v1',
+      'kind: Secret',
+      'stringData:',
+      '  api-key: super-secret',
+      'kind: Secret',
+    ].join('\n')
+    const masked = maskSecretYaml(yaml)
+    expect(masked).not.toContain('super-secret')
+    expect(masked).toContain(`api-key: ${PLACEHOLDER}`)
+  })
+
+  it('does not mask keys outside the data block', () => {
+    const yaml = [
+      'metadata:',
+      '  name: my-secret',
+      '  labels:',
+      '    app: web',
+      'data:',
+      '  password: aGVsbG8=',
+    ].join('\n')
+    const masked = maskSecretYaml(yaml)
+    // metadata.name and metadata.labels.app should be untouched
+    expect(masked).toContain('name: my-secret')
+    expect(masked).toContain('app: web')
+    expect(masked).toContain(`password: ${PLACEHOLDER}`)
+  })
+
+  it('handles a secret with no data block (empty/well-formed pass-through)', () => {
+    const yaml = [
+      'apiVersion: v1',
+      'kind: Secret',
+      'metadata:',
+      '  name: empty',
+      'type: Opaque',
+    ].join('\n')
+    expect(maskSecretYaml(yaml)).toBe(yaml)
+  })
+
+  it('returns empty string unchanged', () => {
+    expect(maskSecretYaml('')).toBe('')
+  })
+
+  it('exits the data block when a sibling top-level key appears', () => {
+    const yaml = [
+      'data:',
+      '  password: secret1',
+      '  username: secret2',
+      'metadata:',
+      '  name: should-not-mask',
+      'type: Opaque',
+    ].join('\n')
+    const masked = maskSecretYaml(yaml)
+    expect(masked).toContain(`password: ${PLACEHOLDER}`)
+    expect(masked).toContain(`username: ${PLACEHOLDER}`)
+    // metadata.name is OUTSIDE the data block — must remain visible
+    expect(masked).toContain('name: should-not-mask')
   })
 })

--- a/web/src/test/ui-ux-standards.test.ts
+++ b/web/src/test/ui-ux-standards.test.ts
@@ -49,13 +49,13 @@ const COMPONENTS_DIR = path.resolve(
  *
  * Set to generous initial values; calibrated after first run.
  */
-// 278 = 273 prior baseline + 5 issue-number references in JSX block comments
-// added by the services health bundle (#6162, #6164, #6165, #6167 — one
-// comment cites #6164/#6165 together, hence 5 occurrences across 4 lines).
-// The ratchet regex matches `#NNNN` as a hex literal, but these are GitHub
-// issue references, not colors. Bumping the baseline rather than rewriting
-// the regex to keep this PR scoped.
-const EXPECTED_RAW_HEX_COUNT = 278
+// 281 = 278 prior baseline + 3 issue-number references in JSX block comments
+// added by the secret/configmap masking bundle (#6209 cited 2x in
+// SecretDrillDown.tsx + ConfigMapDrillDown.tsx, #6211 cited 1x). The ratchet
+// regex matches `#NNNN` as a hex literal, but these are GitHub issue
+// references in code comments, not color literals. Same scoped-bump rationale
+// as the prior 273→278 increment.
+const EXPECTED_RAW_HEX_COUNT = 281
 const EXPECTED_RAW_RGBA_COUNT = 104
 const EXPECTED_ARBITRARY_TW_COLOR_COUNT = 22
 const EXPECTED_INLINE_STYLE_COLOR_COUNT = 213


### PR DESCRIPTION
## Summary

Two layered security gaps in the drill-down views, both reported by @aashu2006.

### #6209 — `SecretDrillDown` YAML tab unmasked

The Data tab carefully masked secret values as `••••••••••••••••` behind a per-key Eye/EyeOff reveal toggle, but the **YAML tab rendered the raw output of `kubectl get secret -o yaml` directly into a `<pre>`** with no masking. The `data:` block contains base64-encoded secret values that `atob()` reverses trivially, and the Copy button put the entire unmasked YAML on the clipboard in one click. The careful Data tab reveal model was bypassable with a single 'YAML' tab click.

**Fix:**
- New `maskSecretYaml(yaml)` helper at module scope. Walks the YAML line by line, finds `data:` and `stringData:` block headers, masks every key-value child line until a sibling/parent key at the same or shallower indent appears. Preserves keys (so users can still see WHAT is in the secret) and surrounding YAML structure. Regex-based intentionally — kubectl's output format is stable and now pinned by tests.
- New `yamlRevealed` state (default `false`). Eye/EyeOff toggle mirrors the Data tab pattern.
- Copy button copies the SAME bytes the user is looking at (masked when masked, raw when revealed).

### #6211 — `ConfigMapDrillDown` no masking

ConfigMaps aren't secrets, but teams routinely store connection strings, passwords, and TLS material in them. ConfigMapDrillDown had **no visibility gate at all** — every value plain text, Copy button straight to clipboard.

**Fix:**
- Per-key `revealedKeys` set + `revealAll` master toggle. The master button is added because ConfigMaps may legitimately hold non-sensitive config too and the per-key dance gets annoying for a 20-key config.
- Copy button respects the reveal state — clicking Copy on a hidden value copies the placeholder, not the real value (with a title hint).
- YAML tab masked using the SAME `maskSecretYaml()` helper from SecretDrillDown (kubectl emits ConfigMap YAML with the same `data:` block shape). Reveal state is bound to the master toggle so the two tabs stay consistent.

## Test plan

- [x] `npm run build` passes locally
- [x] 8 tests pass in `SecretDrillDown.test.tsx` + `ConfigMapDrillDown.test.tsx`
- [x] 6 new `maskSecretYaml` test cases pin the regex: data block, stringData block, sibling-key boundary, no-data pass-through, empty input, surrounding YAML preservation

Closes #6209, closes #6211.