### PR TITLE
fix(demo): restore install/fix/Mission Control entries to Saved Missions

### DIFF
--- a/web/src/mocks/demoMissions.ts
+++ b/web/src/mocks/demoMissions.ts
@@ -42,13 +42,18 @@ export interface DemoMission {
 }
 
 export const DEMO_MISSIONS: DemoMission[] = [
-  // ── Completed Install Mission ─────────────────────────────────────
+  // ── Saved Install Mission (showcased in Saved Missions) ───────────
+  // status: 'saved' so the AI Missions panel shows install-class missions
+  // alongside the orbit ones. Was 'completed' until #5962 added 'completed'
+  // to INACTIVE_MISSION_STATUSES, which had the side effect of hiding all
+  // 4 'completed' demo missions from both the Active and Saved sections —
+  // the showcase intent (#5341) was lost.
   {
     id: 'demo-install-prometheus',
     title: 'Install Prometheus Stack',
     description: 'Deploy the kube-prometheus-stack for cluster monitoring and alerting.',
     type: 'deploy',
-    status: 'completed',
+    status: 'saved',
     cluster: 'eks-prod-us-east-1',
     feedback: 'positive',
     createdAt: daysAgo(3),
@@ -73,13 +78,14 @@ export const DEMO_MISSIONS: DemoMission[] = [
     ],
   },
 
-  // ── Completed Fix Mission ─────────────────────────────────────────
+  // ── Saved Fix Mission (showcased in Saved Missions) ───────────────
+  // Same showcase rationale as demo-install-prometheus above (#5962 fix).
   {
     id: 'demo-fix-crashloop',
     title: 'Fix CrashLoopBackOff on api-gateway',
     description: 'Diagnose and resolve CrashLoopBackOff on the api-gateway deployment in production.',
     type: 'troubleshoot',
-    status: 'completed',
+    status: 'saved',
     cluster: 'eks-prod-us-east-1',
     feedback: 'positive',
     createdAt: daysAgo(1),
@@ -96,13 +102,17 @@ export const DEMO_MISSIONS: DemoMission[] = [
     ],
   },
 
-  // ── Mission Control (completed deploy) ────────────────────────────
+  // ── Saved Mission Control (showcased in Saved Missions) ───────────
+  // Same showcase rationale as the install/fix entries above (#5962 fix).
+  // demo-planning-mission below stays 'completed' on purpose — it's the
+  // hidden AI conversation referenced internally by demo mission-control
+  // state and should NOT appear in the user-facing Saved Missions list.
   {
     id: 'demo-mission-control',
     title: 'Mission Control: Security Stack',
     description: 'Deploy Falco + Trivy + Kyverno across production clusters.',
     type: 'deploy',
-    status: 'completed',
+    status: 'saved',
     feedback: null,
     createdAt: hoursAgo(12),
     updatedAt: hoursAgo(12),


### PR DESCRIPTION
## Summary

PR **#5962** (merged 2026-04-10 03:07 EDT) added `'completed'` to `INACTIVE_MISSION_STATUSES` so the Active mission counter would stop over-counting terminal missions. That fix is correct for real missions, but it had a **side effect on the demo data showcase from #5341**: the four demo missions tagged `status: 'completed'` (`demo-install-prometheus`, `demo-fix-crashloop`, `demo-mission-control`, `demo-planning-mission`) disappeared from BOTH the Active list (now excluded by `isActiveMission`) AND the Saved Missions list (which requires `status === 'saved'`).

Result: the AI Missions panel today only shows the 3 orbit missions (Health Check, Cert Rotation, Version Drift) — the `install` / `fix` / `Mission Control` breadth the showcase exists to demonstrate vanished overnight. Reported by @clubanderson with a screenshot of the panel.

## Fix

Flip the three **user-visible** demo missions from `'completed'` to `'saved'` so they reappear in the Saved Missions section:

| ID | Showcases |
|---|---|
| `demo-install-prometheus` | Install class |
| `demo-fix-crashloop` | Fix class |
| `demo-mission-control` | Mission Control class |

`demo-planning-mission` stays `'completed'` on purpose — it's referenced by `web/src/components/mission-control/demoState.ts:155` as `planningMissionId` (the hidden AI conversation backing the Mission Control flow) and should NOT appear in the user-facing Saved Missions list.

## Test plan

- [x] `npm run build` passes locally
- [x] 287 mission tests pass
- [ ] After merge, demo mode should show 6 entries in Saved Missions (3 install/fix/MC + 3 orbits)