### PR TITLE
🐛 fix(mc,auth): dedupe Active Clusters picker + suppress spurious user-info toast

### DIFF
--- a/web/src/components/auth/AuthCallback.tsx
+++ b/web/src/components/auth/AuthCallback.tsx
@@ -20,7 +20,10 @@ export function AuthCallback() {
   const [searchParams] = useSearchParams()
   const { setToken, refreshUser } = useAuth()
   const { showToast } = useToast()
-  const [status, setStatus] = useState(t('authCallback.signingIn'))
+  // Initial status reflects the work the effect is about to do, so we can
+  // skip calling setStatus synchronously inside the effect body
+  // (react-hooks/set-state-in-effect).
+  const [status, setStatus] = useState(() => t('authCallback.fetchingUserInfo'))
   const hasProcessed = useRef(false)
   const errorTimerRef = useRef<ReturnType<typeof setTimeout>>(undefined)
 
@@ -48,7 +51,14 @@ export function AuthCallback() {
     if (returnTo) safeRemoveItem(RETURN_TO_KEY)
     const destination = returnTo || getLastRoute() || ROUTES.HOME
 
-    setStatus(t('authCallback.fetchingUserInfo'))
+    // Track whether the component is still mounted and whether the token
+    // exchange actually succeeded. If `setToken` ran, the user is logged in
+    // — a later `refreshUser` failure is non-fatal and must NOT trigger
+    // the "failed to fetch user info" warning toast or the navigate-to-login,
+    // both of which were leaking through during the StrictMode double-mount
+    // race and after legitimate token exchanges (#6214 follow-up).
+    let cancelled = false
+    let tokenExchangeSucceeded = false
 
     // Exchange the HttpOnly cookie for a token via /auth/refresh
     const controller = new AbortController()
@@ -71,14 +81,27 @@ export function AuthCallback() {
         const isOnboarded = data.onboarded ?? onboarded
         setToken(token, isOnboarded)
         emitGitHubConnected()
+        tokenExchangeSucceeded = true
 
         return refreshUser(token)
       })
       .then(() => {
+        if (cancelled) return
         navigate(destination)
       })
       .catch((_err) => {
         clearTimeout(timeoutId)
+        if (cancelled) return
+
+        // Token exchange already succeeded — user is authenticated. The only
+        // thing that failed was the follow-up refreshUser() call, which the
+        // auth context will retry on demand. Proceed to the destination
+        // silently rather than bouncing back to login with a misleading toast.
+        if (tokenExchangeSucceeded) {
+          navigate(destination)
+          return
+        }
+
         showToast(t('authCallback.failedToFetchUser'), 'warning')
         setStatus(t('authCallback.completingSignIn'))
         errorTimerRef.current = setTimeout(() => {
@@ -86,7 +109,11 @@ export function AuthCallback() {
         }, NAVIGATE_AFTER_ERROR_DELAY_MS)
       })
 
-    return () => clearTimeout(errorTimerRef.current)
+    return () => {
+      cancelled = true
+      clearTimeout(timeoutId)
+      clearTimeout(errorTimerRef.current)
+    }
   }, [searchParams, setToken, refreshUser, navigate, showToast, t])
 
   return (

--- a/web/src/components/mission-control/ClusterAssignmentPanel.tsx
+++ b/web/src/components/mission-control/ClusterAssignmentPanel.tsx
@@ -42,7 +42,12 @@ export function ClusterAssignmentPanel({
   aiStreaming,
   planningMission,
   installedOnCluster = new Map() }: ClusterAssignmentPanelProps) {
-  const { clusters, isLoading: clustersLoading } = useClusters()
+  // Use deduplicatedClusters so multiple kubeconfig contexts pointing at the
+  // same physical cluster (e.g. several user identities for the same
+  // OpenShift API server) collapse into a single picker entry. Using the raw
+  // `clusters` field surfaces every context, which produced rows like
+  // "Andrew.Anderson@ibm.com" repeated four times.
+  const { deduplicatedClusters: clusters, isLoading: clustersLoading } = useClusters()
   const { releases: helmReleases } = useHelmReleases()
   const [viewMode, setViewMode] = useState<ViewMode>('cards')
   const [autoAssignDone, setAutoAssignDone] = useState(false)


### PR DESCRIPTION
## Summary

Two related UX fixes:

1. **Active Clusters picker** in `ClusterAssignmentPanel.tsx` was using the raw \`clusters\` field from \`useClusters()\` instead of \`deduplicatedClusters\`. Multiple OpenShift kubeconfig contexts pointing at the same API server (one per user identity) produced rows like \`Andrew.Anderson@ibm.com\` repeated 4 times. Switching to \`deduplicatedClusters\` collapses them into one entry per physical cluster — same dedupe used everywhere else for metrics. The 'short names then switched to long names' flicker the user observed was the polling interval bringing in raw cluster context names mid-render.

2. **AuthCallback toast race** — the 'Failed to fetch user info, proceeding anyway' warning was firing on successful logins. Two root causes:
   - **StrictMode double-mount race**: cleanup cleared the navigate-to-login timer but the toast was already visible. Added a \`cancelled\` flag.
   - **Token-exchange-succeeded race**: \`setToken\` succeeded but the follow-up \`refreshUser\` call failed (transient network blip). User is authenticated, sees their username, but the catch was firing the misleading warning. Now: track \`tokenExchangeSucceeded\` and proceed silently to destination instead of warning + bouncing to login.

Also clears the abort timeout in cleanup, and uses a lazy \`useState\` initial value to satisfy react-hooks/set-state-in-effect.

## Test plan
- [ ] Mission Control: open chart-course dropdown → Active Clusters list shows distinct cluster names, no user-identity duplicates
- [ ] Login flow: complete OAuth → no spurious 'Failed to fetch user info' toast
- [ ] Login flow with simulated transient \`/api/auth/me\` failure: user lands on destination page silently rather than bouncing to login
- [ ] Build + lint pass locally