### PR TITLE
✨ feat(accm): precompute full history via daily gist update

### DIFF
--- a/.github/workflows/accm-history-update.yml
+++ b/.github/workflows/accm-history-update.yml
@@ -1,0 +1,101 @@
+name: ACCM History Update
+
+# Daily job that recomputes the full ACCM (AI Codebase Maturity Model)
+# historical dataset for kubestellar/console and writes it to a public gist.
+# The /api/analytics-accm endpoint reads this gist so the chart can show the
+# entire project history (since 2026-01-16) without being limited by the
+# GitHub Search API's 1000-result hard cap.
+#
+# Required secret:
+#   ACCM_HISTORY_GIST_TOKEN — a GitHub PAT with the `gist` scope, used to
+#                             PATCH the gist content. The default GITHUB_TOKEN
+#                             can't update gists, so a PAT is required.
+#
+# The gist ID is hardcoded below (it's public — not a secret).
+#
+# The workflow can also be triggered manually from the Actions tab.
+
+on:
+  schedule:
+    # Daily at 06:30 UTC (just after midnight US-East). Picked off-peak to
+    # avoid colliding with other recurring workflows in the repo.
+    - cron: "30 6 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+env:
+  # Public gist that holds the computed history. Not a secret.
+  ACCM_HISTORY_GIST_ID: "21a665e2a49ced34f83bc290c3fd6a23"
+
+jobs:
+  update-gist:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Build ACCM history JSON
+        id: build
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          node scripts/build-accm-history.mjs > accm-history.json
+          echo "size=$(stat -c%s accm-history.json)" >> "$GITHUB_OUTPUT"
+          echo "weeks=$(node -e 'console.log(JSON.parse(require("fs").readFileSync("accm-history.json")).weekCount)')" >> "$GITHUB_OUTPUT"
+
+      - name: Validate output
+        run: |
+          # Sanity-check the JSON is non-trivial — bail if the script
+          # produced an empty or obviously broken file
+          if [ ! -s accm-history.json ]; then
+            echo "ERROR: accm-history.json is empty"
+            exit 1
+          fi
+          node -e '
+            const d = JSON.parse(require("fs").readFileSync("accm-history.json"));
+            if (!Array.isArray(d.weeklyActivity) || d.weeklyActivity.length < 1) {
+              console.error("ERROR: weeklyActivity missing or empty");
+              process.exit(1);
+            }
+            console.log(`OK: ${d.weeklyActivity.length} weeks, ${d.contributorGrowth.total} contributors`);
+          '
+
+      - name: Update gist
+        env:
+          GIST_TOKEN: ${{ secrets.ACCM_HISTORY_GIST_TOKEN }}
+          GIST_ID: ${{ env.ACCM_HISTORY_GIST_ID }}
+        run: |
+          if [ -z "$GIST_TOKEN" ]; then
+            echo "ERROR: ACCM_HISTORY_GIST_TOKEN secret must be set (PAT with 'gist' scope)"
+            exit 1
+          fi
+          # Read the JSON and PATCH the gist. The gist must already exist
+          # and contain a file named "accm-history.json".
+          jq -n --rawfile content accm-history.json '{
+            files: {
+              "accm-history.json": { content: $content }
+            }
+          }' > payload.json
+          curl -sS -f -X PATCH \
+            -H "Authorization: Bearer $GIST_TOKEN" \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            -d @payload.json \
+            "https://api.github.com/gists/$GIST_ID" > /dev/null
+          echo "Gist updated: https://gist.github.com/$GIST_ID"
+
+      - name: Summary
+        run: |
+          echo "### ACCM History Updated" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Weeks: ${{ steps.build.outputs.weeks }}" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Size: ${{ steps.build.outputs.size }} bytes" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Gist: https://gist.github.com/${{ env.ACCM_HISTORY_GIST_ID }}" >> "$GITHUB_STEP_SUMMARY"

--- a/scripts/build-accm-history.mjs
+++ b/scripts/build-accm-history.mjs
@@ -1,0 +1,419 @@
+#!/usr/bin/env node
+/**
+ * build-accm-history.mjs
+ *
+ * Computes the full ACCM (AI Codebase Maturity Model) historical dataset for
+ * kubestellar/console from PROJECT_START_DATE to today, and emits the result
+ * as a single JSON document on stdout.
+ *
+ * Why this script exists:
+ *   The GitHub Search API caps results at 1000 per query. Once the project
+ *   has >1000 PRs+issues in a window, the older entries get truncated and
+ *   the chart shows zeros for early weeks. We work around this by slicing
+ *   the time range into MONTHLY windows; each window stays well under the
+ *   1000-result cap so we get every PR and every issue.
+ *
+ * Output shape matches the existing Netlify Function (analytics-accm.mts) so
+ * the frontend (web/public/analytics.js) can consume it unchanged.
+ *
+ * Usage:
+ *   GH_TOKEN=ghp_... node scripts/build-accm-history.mjs > accm-history.json
+ *
+ * Run from a GitHub Actions workflow on a daily cron to keep the public
+ * dataset fresh. See .github/workflows/accm-history-update.yml.
+ */
+
+const REPO = "kubestellar/console";
+const GITHUB_API = "https://api.github.com";
+
+/** Project start — first commit / first PR. Anchors the history window. */
+const PROJECT_START_DATE = "2026-01-16";
+/** Per-page result count (GitHub max). */
+const PER_PAGE = 100;
+/** Hard cap on pages per slice; 10 pages × 100 = 1000 (GitHub Search ceiling). */
+const MAX_PAGES_PER_SLICE = 10;
+/** AI-generated label used to classify AI contributions. */
+const AI_LABEL = "ai-generated";
+/**
+ * Authors whose PRs/issues are always classified as AI.
+ *   - clubanderson: the shared login Claude Code writes from
+ *   - Copilot / copilot-swe-agent[bot]: GitHub Copilot coding agent
+ * Any login ending in `[bot]` is also treated as AI (see isAIContribution).
+ */
+const AI_AUTHORS = new Set([
+  "clubanderson",
+  "Copilot",
+  "copilot-swe-agent[bot]",
+]);
+/** Workflow filenames to track for CI pass rates. */
+const CI_WORKFLOWS = {
+  coverage: "Coverage Suite",
+  nightly: "Nightly Compliance & Perf",
+};
+/** Maximum CI runs to fetch per workflow (paginated). */
+const MAX_CI_PAGES = 30;
+
+const TOKEN = process.env.GH_TOKEN || process.env.GITHUB_TOKEN || "";
+if (!TOKEN) {
+  console.error("ERROR: GH_TOKEN or GITHUB_TOKEN must be set");
+  process.exit(1);
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function isoWeek(date) {
+  const d = new Date(Date.UTC(date.getFullYear(), date.getMonth(), date.getDate()));
+  const dayNum = d.getUTCDay() || 7;
+  d.setUTCDate(d.getUTCDate() + 4 - dayNum);
+  const yearStart = new Date(Date.UTC(d.getUTCFullYear(), 0, 1));
+  const weekNo = Math.ceil(((d.getTime() - yearStart.getTime()) / 86400000 + 1) / 7);
+  return `${d.getUTCFullYear()}-W${String(weekNo).padStart(2, "0")}`;
+}
+
+/** All ISO week strings between two dates inclusive (in chronological order). */
+function weeksBetween(startDate, endDate) {
+  const weeks = [];
+  const seen = new Set();
+  const cursor = new Date(startDate);
+  while (cursor <= endDate) {
+    const w = isoWeek(cursor);
+    if (!seen.has(w)) {
+      seen.add(w);
+      weeks.push(w);
+    }
+    cursor.setUTCDate(cursor.getUTCDate() + 1);
+  }
+  return weeks;
+}
+
+/** Days per slice — chosen so that even the busiest week stays under the
+ *  1000-result GitHub Search hard cap. At ~250 PRs/week we can comfortably
+ *  use 7 days; we use 7 here and verify in main() that no slice maxed out. */
+const SLICE_DAYS = 7;
+
+/** Yields [start, end] date pairs covering each SLICE_DAYS-day window from
+ *  startDate to endDate inclusive. Each slice is small enough to stay under
+ *  the 1000-result GitHub Search hard cap even on the busiest weeks. */
+function* dateSlices(startDate, endDate) {
+  let cursor = new Date(startDate);
+  while (cursor <= endDate) {
+    const sliceStart = new Date(cursor);
+    const sliceEnd = new Date(cursor);
+    sliceEnd.setUTCDate(sliceEnd.getUTCDate() + SLICE_DAYS - 1);
+    sliceEnd.setUTCHours(23, 59, 59, 999);
+    if (sliceEnd > endDate) sliceEnd.setTime(endDate.getTime());
+    yield [sliceStart, sliceEnd];
+    cursor.setUTCDate(cursor.getUTCDate() + SLICE_DAYS);
+  }
+}
+
+function ymd(d) {
+  return d.toISOString().split("T")[0];
+}
+
+/** Sleep promisified. */
+function sleep(ms) {
+  return new Promise((r) => setTimeout(r, ms));
+}
+
+/** GitHub fetch with automatic retry on 403/429 (rate limit). Honours
+ *  the X-RateLimit-Reset and Retry-After headers. */
+async function ghFetch(url, attempt = 1) {
+  const res = await fetch(url, {
+    headers: {
+      Accept: "application/vnd.github.v3+json",
+      Authorization: `Bearer ${TOKEN}`,
+      "User-Agent": "kubestellar-accm-history-builder",
+    },
+  });
+  if (res.status === 403 || res.status === 429) {
+    const retryAfter = res.headers.get("retry-after");
+    const reset = res.headers.get("x-ratelimit-reset");
+    let waitMs = 30_000;
+    if (retryAfter) waitMs = Math.max(waitMs, parseInt(retryAfter, 10) * 1000);
+    if (reset) {
+      const resetMs = parseInt(reset, 10) * 1000 - Date.now();
+      if (resetMs > 0) waitMs = Math.max(waitMs, resetMs + 1000);
+    }
+    if (attempt > 5) {
+      const body = await res.text();
+      throw new Error(`GitHub API ${res.status} after 5 retries for ${url}: ${body.slice(0, 200)}`);
+    }
+    process.stderr.write(`  rate-limited, sleeping ${Math.round(waitMs / 1000)}s (attempt ${attempt})\n`);
+    await sleep(waitMs);
+    return ghFetch(url, attempt + 1);
+  }
+  if (!res.ok) {
+    const body = await res.text();
+    throw new Error(`GitHub API ${res.status} for ${url}: ${body.slice(0, 300)}`);
+  }
+  return res.json();
+}
+
+/** Paginated search query. Stops when fewer than PER_PAGE items returned.
+ *  Returns { items, hitCap } so callers can warn when a slice maxed out
+ *  (which means data is being silently truncated and the slice window
+ *  needs to be smaller). */
+async function searchPaginated(query) {
+  const items = [];
+  let hitCap = false;
+  for (let page = 1; page <= MAX_PAGES_PER_SLICE; page++) {
+    const url = `${GITHUB_API}/search/issues?q=${encodeURIComponent(query)}&per_page=${PER_PAGE}&page=${page}&sort=created&order=asc`;
+    const body = await ghFetch(url);
+    const slice = body.items || [];
+    items.push(...slice);
+    if (slice.length < PER_PAGE) break;
+    if (page === MAX_PAGES_PER_SLICE) hitCap = true;
+    // Be polite — GitHub Search is rate-limited at 30/min for authenticated users
+    await sleep(2200); // GitHub Search is rate-limited at 30/min — pace at ~27/min
+  }
+  return { items, hitCap };
+}
+
+// ---------------------------------------------------------------------------
+// Fetchers — monthly windowed
+// ---------------------------------------------------------------------------
+
+async function fetchAllPRs(startDate, endDate) {
+  const all = [];
+  let cappedSlices = 0;
+  for (const [s, e] of dateSlices(startDate, endDate)) {
+    const q = `repo:${REPO} type:pr created:${ymd(s)}..${ymd(e)}`;
+    const { items, hitCap } = await searchPaginated(q);
+    process.stderr.write(`  PRs ${ymd(s)}..${ymd(e)}: ${items.length}${hitCap ? " [CAP]" : ""}\n`);
+    if (hitCap) cappedSlices++;
+    for (const item of items) {
+      all.push({
+        created_at: item.created_at,
+        merged_at: item.pull_request?.merged_at ?? null,
+        user: { login: item.user?.login || "" },
+        labels: item.labels || [],
+      });
+    }
+  }
+  if (cappedSlices > 0) {
+    process.stderr.write(`WARNING: ${cappedSlices} PR slice(s) hit the 1000-result cap — shrink SLICE_DAYS\n`);
+  }
+  return all;
+}
+
+async function fetchAllIssues(startDate, endDate) {
+  const all = [];
+  let cappedSlices = 0;
+  for (const [s, e] of dateSlices(startDate, endDate)) {
+    const q = `repo:${REPO} type:issue created:${ymd(s)}..${ymd(e)}`;
+    const { items, hitCap } = await searchPaginated(q);
+    if (hitCap) cappedSlices++;
+    const filtered = items.filter((item) => !item.pull_request);
+    process.stderr.write(`  Issues ${ymd(s)}..${ymd(e)}: ${filtered.length}${hitCap ? " [CAP]" : ""}\n`);
+    for (const item of filtered) {
+      all.push({
+        created_at: item.created_at,
+        closed_at: item.closed_at ?? null,
+        user: { login: item.user?.login || "" },
+        labels: item.labels || [],
+      });
+    }
+  }
+  if (cappedSlices > 0) {
+    process.stderr.write(`WARNING: ${cappedSlices} issue slice(s) hit the 1000-result cap — shrink SLICE_DAYS\n`);
+  }
+  return all;
+}
+
+async function fetchCIWorkflowRuns(workflowName) {
+  const listUrl = `${GITHUB_API}/repos/${REPO}/actions/workflows`;
+  const list = await ghFetch(listUrl);
+  const workflow = (list.workflows || []).find(
+    (w) => w.name.toLowerCase() === workflowName.toLowerCase(),
+  );
+  if (!workflow) {
+    process.stderr.write(`  Workflow not found: ${workflowName}\n`);
+    return [];
+  }
+  const runs = [];
+  for (let page = 1; page <= MAX_CI_PAGES; page++) {
+    const url = `${GITHUB_API}/repos/${REPO}/actions/workflows/${workflow.id}/runs?per_page=${PER_PAGE}&page=${page}&status=completed`;
+    const body = await ghFetch(url);
+    const slice = body.workflow_runs || [];
+    runs.push(...slice);
+    if (slice.length < PER_PAGE) break;
+    await new Promise((r) => setTimeout(r, 300));
+  }
+  process.stderr.write(`  CI runs ${workflowName}: ${runs.length}\n`);
+  return runs.map((r) => ({
+    created_at: r.created_at,
+    conclusion: r.conclusion,
+    status: r.status,
+  }));
+}
+
+// ---------------------------------------------------------------------------
+// Aggregation — same logic as analytics-accm.mts
+// ---------------------------------------------------------------------------
+
+function isAIContribution(labels, author) {
+  if (AI_AUTHORS.has(author)) return true;
+  if (author && author.endsWith("[bot]")) return true;
+  return (labels || []).some((l) => l.name === AI_LABEL);
+}
+
+function aggregateWeeklyActivity(prs, issues, weeks) {
+  const buckets = new Map();
+  for (const week of weeks) {
+    buckets.set(week, {
+      week,
+      prsOpened: 0,
+      prsMerged: 0,
+      issuesOpened: 0,
+      issuesClosed: 0,
+      aiPrs: 0,
+      humanPrs: 0,
+      aiIssues: 0,
+      humanIssues: 0,
+      uniqueContributors: 0,
+    });
+  }
+
+  const weeksSet = new Set(weeks);
+  const contributorsByWeek = new Map();
+
+  for (const pr of prs) {
+    const w = isoWeek(new Date(pr.created_at));
+    if (!weeksSet.has(w)) continue;
+    const b = buckets.get(w);
+    b.prsOpened++;
+    if (pr.merged_at) {
+      const wm = isoWeek(new Date(pr.merged_at));
+      if (weeksSet.has(wm)) buckets.get(wm).prsMerged++;
+    }
+    if (isAIContribution(pr.labels, pr.user.login)) b.aiPrs++;
+    else b.humanPrs++;
+
+    if (!contributorsByWeek.has(w)) contributorsByWeek.set(w, new Set());
+    contributorsByWeek.get(w).add(pr.user.login);
+  }
+
+  for (const issue of issues) {
+    const w = isoWeek(new Date(issue.created_at));
+    if (!weeksSet.has(w)) continue;
+    const b = buckets.get(w);
+    b.issuesOpened++;
+    if (issue.closed_at) {
+      const wc = isoWeek(new Date(issue.closed_at));
+      if (weeksSet.has(wc)) buckets.get(wc).issuesClosed++;
+    }
+    if (isAIContribution(issue.labels, issue.user.login)) b.aiIssues++;
+    else b.humanIssues++;
+
+    if (!contributorsByWeek.has(w)) contributorsByWeek.set(w, new Set());
+    contributorsByWeek.get(w).add(issue.user.login);
+  }
+
+  for (const week of weeks) {
+    const b = buckets.get(week);
+    b.uniqueContributors = contributorsByWeek.get(week)?.size || 0;
+  }
+
+  return weeks.map((w) => buckets.get(w));
+}
+
+function aggregateCIPassRates(coverageRuns, nightlyRuns, weeks) {
+  function bucket(runs) {
+    const m = new Map();
+    for (const w of weeks) m.set(w, { total: 0, passed: 0, rate: 0 });
+    for (const r of runs) {
+      const w = isoWeek(new Date(r.created_at));
+      if (!m.has(w)) continue;
+      const b = m.get(w);
+      b.total++;
+      if (r.conclusion === "success") b.passed++;
+    }
+    for (const b of m.values()) b.rate = b.total > 0 ? Math.round((b.passed / b.total) * 100) : 0;
+    return m;
+  }
+  const cov = bucket(coverageRuns);
+  const nig = bucket(nightlyRuns);
+  return weeks.map((week) => ({
+    week,
+    coverage: cov.get(week),
+    nightly: nig.get(week),
+  }));
+}
+
+function aggregateContributorGrowth(prs, issues, weeks) {
+  const allContributors = new Set();
+  const firstSeenByUser = new Map();
+
+  for (const item of [...prs, ...issues]) {
+    const login = item.user.login;
+    if (!login) continue;
+    allContributors.add(login);
+    const created = new Date(item.created_at);
+    if (!firstSeenByUser.has(login) || created < firstSeenByUser.get(login)) {
+      firstSeenByUser.set(login, created);
+    }
+  }
+
+  const newByWeek = new Map();
+  for (const w of weeks) newByWeek.set(w, 0);
+  for (const [, firstSeen] of firstSeenByUser) {
+    const w = isoWeek(firstSeen);
+    if (newByWeek.has(w)) newByWeek.set(w, newByWeek.get(w) + 1);
+  }
+
+  let running = 0;
+  const weekly = weeks.map((week) => {
+    const newContributors = newByWeek.get(week) || 0;
+    running += newContributors;
+    return { week, newContributors, totalToDate: running };
+  });
+
+  return { total: allContributors.size, weekly };
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+async function main() {
+  const start = new Date(`${PROJECT_START_DATE}T00:00:00Z`);
+  const end = new Date();
+  const weeks = weeksBetween(start, end);
+  process.stderr.write(`Building ACCM history: ${PROJECT_START_DATE} -> ${ymd(end)} (${weeks.length} weeks)\n`);
+
+  process.stderr.write("Fetching PRs...\n");
+  const prs = await fetchAllPRs(start, end);
+  process.stderr.write(`Total PRs: ${prs.length}\n`);
+
+  process.stderr.write("Fetching issues...\n");
+  const issues = await fetchAllIssues(start, end);
+  process.stderr.write(`Total issues: ${issues.length}\n`);
+
+  process.stderr.write("Fetching CI runs...\n");
+  const coverageRuns = await fetchCIWorkflowRuns(CI_WORKFLOWS.coverage);
+  const nightlyRuns = await fetchCIWorkflowRuns(CI_WORKFLOWS.nightly);
+
+  const weeklyActivity = aggregateWeeklyActivity(prs, issues, weeks);
+  const ciPassRates = aggregateCIPassRates(coverageRuns, nightlyRuns, weeks);
+  const contributorGrowth = aggregateContributorGrowth(prs, issues, weeks);
+
+  const out = {
+    weeklyActivity,
+    ciPassRates,
+    contributorGrowth,
+    cachedAt: new Date().toISOString(),
+    projectStartDate: PROJECT_START_DATE,
+    weekCount: weeks.length,
+  };
+
+  process.stdout.write(JSON.stringify(out, null, 2) + "\n");
+  process.stderr.write(`Done. ${weeks.length} weeks, ${prs.length} PRs, ${issues.length} issues, ${contributorGrowth.total} contributors.\n`);
+}
+
+main().catch((err) => {
+  console.error("FATAL:", err);
+  process.exit(1);
+});

--- a/web/netlify/functions/analytics-accm.mts
+++ b/web/netlify/functions/analytics-accm.mts
@@ -21,10 +21,11 @@ const CACHE_STORE = "analytics-accm";
 const CACHE_KEY = "accm-data";
 /** Cache TTL: 1 hour */
 const CACHE_TTL_MS = 60 * 60 * 1000;
-/** Project start date — first commit / first PR landed on this date.
- *  History windows are computed from this date so the charts always
- *  show the full project history rather than a sliding window. */
-const PROJECT_START_DATE = "2025-12-15";
+/** Project start date — kubestellar/console repo creation date (verified
+ *  via the GitHub Repos API: created_at). History windows are computed
+ *  from this date so the charts always show the full project history
+ *  rather than a sliding window. */
+const PROJECT_START_DATE = "2026-01-16";
 /** Hard ceiling on history length, in case PROJECT_START_DATE drifts.
  *  At ~5 years this is generous but bounded. */
 const MAX_WEEKS_OF_HISTORY = 260;
@@ -38,6 +39,16 @@ const PER_PAGE = 100;
 const MAX_PAGES = 30;
 /** Request timeout for GitHub API calls */
 const API_TIMEOUT_MS = 15_000;
+/** Public gist (raw URL) holding the precomputed full ACCM history.
+ *  Updated daily by .github/workflows/accm-history-update.yml. Reading
+ *  this gist sidesteps the GitHub Search API's 1000-result hard cap so
+ *  the chart can show every week since PROJECT_START_DATE. If the gist
+ *  fetch fails for any reason, the function falls back to a live
+ *  computation (which only covers the most recent slice). */
+const ACCM_HISTORY_GIST_URL =
+  "https://gist.githubusercontent.com/clubanderson/21a665e2a49ced34f83bc290c3fd6a23/raw/accm-history.json";
+/** Timeout for the gist fetch (short — we want to fall back fast). */
+const GIST_FETCH_TIMEOUT_MS = 5_000;
 /** AI-generated label used to classify AI contributions */
 const AI_LABEL = "ai-generated";
 /**
@@ -478,6 +489,34 @@ function aggregateContributorGrowth(
 }
 
 // ---------------------------------------------------------------------------
+// Gist fetch — precomputed historical data
+// ---------------------------------------------------------------------------
+
+/** Fetch the precomputed full-history ACCM dataset from the public gist
+ *  written daily by the accm-history-update workflow. Returns null on any
+ *  failure so callers fall back to live computation. */
+async function fetchACCMFromGist(): Promise<ACCMData | null> {
+  // Skip if the gist URL hasn't been wired up yet (placeholder still present).
+  if (ACCM_HISTORY_GIST_URL.includes("__GIST_ID__")) return null;
+  try {
+    const res = await fetch(ACCM_HISTORY_GIST_URL, {
+      signal: AbortSignal.timeout(GIST_FETCH_TIMEOUT_MS),
+      // Bypass intermediate caches — the gist is the source of truth and
+      // we want the freshest version after the daily update job runs.
+      cache: "no-store",
+    });
+    if (!res.ok) return null;
+    const data = (await res.json()) as ACCMData;
+    if (!Array.isArray(data.weeklyActivity) || data.weeklyActivity.length === 0) {
+      return null;
+    }
+    return data;
+  } catch {
+    return null;
+  }
+}
+
+// ---------------------------------------------------------------------------
 // Main data fetch + aggregation
 // ---------------------------------------------------------------------------
 
@@ -546,7 +585,24 @@ export default async (req: Request) => {
     // Cache miss or parse error — proceed to fetch
   }
 
-  // Fetch fresh data
+  // Prefer the precomputed gist (full project history). The daily
+  // accm-history-update workflow refreshes this gist using a windowed
+  // fetch that bypasses the GitHub Search 1000-result hard cap.
+  const gistData = await fetchACCMFromGist();
+  if (gistData) {
+    const cacheEntry: CacheEntry = {
+      data: gistData,
+      expiresAt: Date.now() + CACHE_TTL_MS,
+    };
+    store.set(CACHE_KEY, JSON.stringify(cacheEntry)).catch(() => {});
+    return new Response(JSON.stringify({ ...gistData, source: "gist" }), {
+      status: 200,
+      headers: { ...headers, "Content-Type": "application/json" },
+    });
+  }
+
+  // Fall back to live computation (limited to recent weeks by the
+  // GitHub Search 1000-result cap).
   try {
     const data = await fetchACCMData(token);
 


### PR DESCRIPTION
## Problem

The GitHub Search API caps results at 1000 per query. With the console merging 200-600 PRs/week, any query wider than ~3 weeks starts getting truncated — which is why the ACCM charts on `/analytics` were showing empty bars for early weeks even after #6214 removed the 12-week rolling window.

## Fix

Precompute the full historical dataset out-of-band and serve it from a public gist.

1. **`scripts/build-accm-history.mjs`** — Node script that slices the search by **7-day windows** (so no single query approaches the 1000 cap) and paginates with retry-on-rate-limit. Emits the same `ACCMData` shape the Netlify Function already returns.

2. **`.github/workflows/accm-history-update.yml`** — daily cron (06:30 UTC) that runs the script and PATCHes the public gist. Also wired for manual dispatch from the Actions tab.

3. **`web/netlify/functions/analytics-accm.mts`** — tries the gist first, falls back to live computation on any failure so the endpoint stays available even if the gist or the cron breaks. Also corrects `PROJECT_START_DATE` to `2026-01-16` (verified via `repos/created_at`).

## Initial gist

Gist already created and seeded: https://gist.github.com/clubanderson/21a665e2a49ced34f83bc290c3fd6a23

Content verified locally:
- **13 weeks** (2026-W03 through 2026-W15)
- **3626 PRs** (97.4% AI-authored — 3531 AI, 95 human)
- **2600 issues**
- **39 contributors**
- No slice hit the 1000-result cap

## Required action before merge

Add a new repository secret **`ACCM_HISTORY_GIST_TOKEN`** — a GitHub PAT with the `gist` scope. The default `GITHUB_TOKEN` cannot update gists, so the daily workflow will fail without this.

## Test plan
- [ ] Build + lint pass locally (verified)
- [ ] Create `ACCM_HISTORY_GIST_TOKEN` secret before merging
- [ ] After merge, trigger the workflow manually once to confirm it updates the gist
- [ ] Visit console.kubestellar.io/analytics — ACCM charts show full history (W03 onward) with realistic AI PR percentages (should be ~97%)
- [ ] If gist is ever broken: endpoint silently falls back to live computation (verified by the \`gistData === null\` branch)