### PR TITLE
🐛 fix: show real clusters on in-cluster deploy even when demo mode toggled on

### DIFF
--- a/web/src/hooks/mcp/shared.ts
+++ b/web/src/hooks/mcp/shared.ts
@@ -1,6 +1,6 @@
 import { api, isBackendUnavailable } from '../../lib/api'
 import { reportAgentDataError, reportAgentDataSuccess, isAgentUnavailable } from '../useLocalAgent'
-import { isDemoMode, isNetlifyDeployment, isDemoToken, hasRealToken, subscribeDemoMode } from '../../lib/demoMode'
+import { isDemoMode, isNetlifyDeployment, isDemoToken, subscribeDemoMode } from '../../lib/demoMode'
 import { isInClusterMode } from '../useBackendHealth'
 import { kubectlProxy } from '../../lib/kubectlProxy'
 import { registerCacheReset, triggerAllRefetches } from '../../lib/modeTransition'
@@ -1329,14 +1329,16 @@ export async function fullFetchClusters() {
   // Don't try to fetch from agent - user wants to see demo data, not live data.
   // This respects the user's explicit choice to enable demo mode.
   //
-  // EXCEPTION: When the console is deployed in-cluster AND the user has a real
-  // auth token, always fetch live cluster data. Otherwise UI elements like the
-  // Create Namespace cluster dropdown would list demo clusters (eks-prod-us-east-1,
-  // gke-staging, etc.) instead of the actual cluster the console is running in
-  // (e.g. vllm-d). This matches the GPU-reservations live-mode bypass pattern in
-  // GPUReservations.tsx.
-  const inClusterLive = isInClusterMode() && hasRealToken()
-  if (isDemoMode() && !inClusterLive) {
+  // EXCEPTION: When the console is deployed in-cluster (the backend reports
+  // `in_cluster: true`), always try to fetch live cluster data — including when
+  // demo mode is toggled on and/or the user only has a demo token. Otherwise UI
+  // elements like the Create Namespace cluster dropdown would list demo clusters
+  // (eks-prod-us-east-1, gke-staging, etc.) instead of the actual cluster the
+  // console is running in (e.g. vllm-d). If the live fetch fails (unauthenticated
+  // visitor, agent down, etc.) the downstream fallback logic will still show
+  // demo data. Localhost dev is unaffected because the Go backend only sets
+  // `in_cluster: true` when running as a pod.
+  if (isDemoMode() && !isInClusterMode()) {
     updateClusterCache({
       clusters: getDemoClusters(),
       isLoading: false,


### PR DESCRIPTION
## Summary

- Follow-up to #6215. That PR added a demo-mode bypass in \`fullFetchClusters()\` gated on \`isInClusterMode() && hasRealToken()\`. On the vllm-d deployment the fix worked for authenticated users with a real OAuth token — but **not** for sessions where demo mode had been toggled on (which is the exact state the bug was originally reported against). Those sessions still saw demo clusters (\`eks-prod-us-east-1\`, \`gke-staging\`, etc.) in the Create Namespace dropdown.
- Drop the \`hasRealToken()\` constraint: whenever the backend reports \`in_cluster: true\`, always try the live cluster fetch first. Unauthenticated visitors still fall through to the existing demo fallback further down (agent failure → \`isDemoMode() && isDemoToken()\` → \`getDemoClusters()\`). Localhost dev is unaffected because the Go backend only sets \`in_cluster: true\` when running as a pod.

## Verification
Verified on https://kc.apps.fmaas-vllm-d.fmaas.res.ibm.com with demo mode toggled on — Create Namespace now lists \`vllm-d\`, \`waldorf\`, \`pok-prod-01\`, etc. instead of the demo set.

## Test plan

- [ ] Deploy to vllm-d with demo-mode toggled ON. Create Namespace dropdown lists real clusters (vllm-d, etc.), not demo set.
- [ ] Deploy to vllm-d with demo-mode OFF (real OAuth). Create Namespace still lists real clusters (regression check for #6215).
- [ ] localhost dev with demo mode toggled on still shows demo clusters.
- [ ] console.kubestellar.io (Netlify) still shows demo clusters.