### PR TITLE
fix(a11y+errors): wire isFailed in 5 cards, add aria-labels in 4 cards (#6219, #6222)

### DIFF
--- a/web/src/components/cards/ClusterGroups.tsx
+++ b/web/src/components/cards/ClusterGroups.tsx
@@ -553,7 +553,7 @@ function CreateGroupForm({ availableClusters, clusterHealthMap, onSave, onCancel
     <div className="rounded-lg border border-blue-500/40 bg-blue-500/5 p-3 space-y-3">
       <div className="flex items-center justify-between">
         <span className="text-xs font-medium text-blue-400">{t('cards:clusterGroups.newClusterGroup')}</span>
-        <button onClick={onCancel} className="p-2 hover:bg-gray-900/10 dark:hover:bg-white/10 rounded min-h-11 min-w-11 flex items-center justify-center">
+        <button onClick={onCancel} aria-label={t('common:common.cancel')} className="p-2 hover:bg-gray-900/10 dark:hover:bg-white/10 rounded min-h-11 min-w-11 flex items-center justify-center">
           <X className="w-3.5 h-3.5 text-muted-foreground" />
         </button>
       </div>
@@ -918,6 +918,7 @@ function QueryBuilder({
                 {/* Remove */}
                 <button
                   onClick={() => onRemoveFilter(i)}
+                  aria-label={t('cards:clusterGroups.removeFilter', 'Remove filter')}
                   className="p-0.5 rounded hover:bg-red-500/20 text-muted-foreground hover:text-red-400"
                 >
                   <X className="w-3 h-3" />
@@ -1055,7 +1056,7 @@ function EditGroupForm({ group, availableClusters, clusterHealthMap, onSave, onC
     <div className="rounded-lg border border-yellow-500/40 bg-yellow-500/5 p-3 space-y-3">
       <div className="flex items-center justify-between">
         <span className="text-xs font-medium text-yellow-400">{t('common:common.edit')}: {group.name}</span>
-        <button onClick={onCancel} className="p-2 hover:bg-gray-900/10 dark:hover:bg-white/10 rounded min-h-11 min-w-11 flex items-center justify-center">
+        <button onClick={onCancel} aria-label={t('common:common.cancel')} className="p-2 hover:bg-gray-900/10 dark:hover:bg-white/10 rounded min-h-11 min-w-11 flex items-center justify-center">
           <X className="w-3.5 h-3.5 text-muted-foreground" />
         </button>
       </div>

--- a/web/src/components/cards/ClusterLocations.tsx
+++ b/web/src/components/cards/ClusterLocations.tsx
@@ -434,7 +434,7 @@ export function ClusterLocations({ config: _config }: ClusterLocationsProps) {
               className="flex-1 px-2 py-1 text-xs bg-secondary rounded border border-border text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-purple-500/50"
             />
             {searchFilter && (
-              <button onClick={() => setSearchFilter('')} className="text-muted-foreground hover:text-foreground">
+              <button onClick={() => setSearchFilter('')} aria-label={t('common:common.clearSearch', 'Clear search')} className="text-muted-foreground hover:text-foreground">
                 <X className="w-3 h-3" />
               </button>
             )}

--- a/web/src/components/cards/ComplianceCards.tsx
+++ b/web/src/components/cards/ComplianceCards.tsx
@@ -196,7 +196,10 @@ export function TrivyScan({ config: _config }: CardConfig) {
   })()
 
   const hasData = installed || isDemoData
-  useCardLoadingState({ isLoading: isLoading && !hasData, isRefreshing, hasAnyData: hasData, isDemoData })
+  // #6219: surface failure state. `hasErrors` from useTrivy means at least
+  // one cluster's scan errored — wire it through as isFailed so CardWrapper
+  // can show the error path immediately instead of a stale-data fallthrough.
+  useCardLoadingState({ isLoading: isLoading && !hasData, isRefreshing, hasAnyData: hasData, isDemoData, isFailed: hasErrors })
 
   // Detect degraded state: installed but no reports generated (excludes clusters with errors)
   const isDegraded = (() => {
@@ -414,7 +417,8 @@ export function KubescapeScan({ config: _config }: CardConfig) {
   }, [statuses, aggregated, selectedClusters])
 
   const ksHasData = installed || isDemoData
-  useCardLoadingState({ isLoading: isLoading && !ksHasData, isRefreshing, hasAnyData: ksHasData, isDemoData })
+  // #6219: surface failure state via the same `hasErrors` field useKubescape exposes.
+  useCardLoadingState({ isLoading: isLoading && !ksHasData, isRefreshing, hasAnyData: ksHasData, isDemoData, isFailed: hasErrors })
 
   // Detect degraded state: installed but no scan data produced (excludes clusters with errors)
   const isDegraded = (() => {
@@ -735,7 +739,8 @@ export function PolicyViolations({ config: _config }: CardConfig) {
   const participatingClusters = Object.values(kyvernoStatuses).filter(s => s.installed).map(s => s.cluster)
 
   const hasData = violations.length > 0 || kyvernoDemoData
-  useCardLoadingState({ isLoading: kyvernoLoading && !hasData, isRefreshing: kyvernoRefreshing, hasAnyData: hasData, isDemoData: kyvernoDemoData })
+  // #6219: surface kyverno fetch failures.
+  useCardLoadingState({ isLoading: kyvernoLoading && !hasData, isRefreshing: kyvernoRefreshing, hasAnyData: hasData, isDemoData: kyvernoDemoData, isFailed: kyvernoHasErrors })
 
   if (violations.length === 0 && !kyvernoDemoData) {
     // Still scanning — show loading state instead of definitive empty state
@@ -885,8 +890,8 @@ export function PolicyViolations({ config: _config }: CardConfig) {
 
 export function ComplianceScore({ config: _config }: CardConfig) {
   const { t } = useTranslation(['common', 'cards'])
-  const { statuses: kubescapeStatuses, aggregated: kubescapeAgg, isLoading: ksLoading, isDemoData: ksDemoData, installed: ksInstalled, clustersChecked: ksChecked, totalClusters: ksTotal } = useKubescape()
-  const { statuses: kyvernoStatuses, isLoading: kyLoading, isDemoData: kyDemoData, installed: kyInstalled, clustersChecked: kyChecked, totalClusters: kyTotal } = useKyverno()
+  const { statuses: kubescapeStatuses, aggregated: kubescapeAgg, isLoading: ksLoading, isDemoData: ksDemoData, installed: ksInstalled, hasErrors: ksHasErrors, clustersChecked: ksChecked, totalClusters: ksTotal } = useKubescape()
+  const { statuses: kyvernoStatuses, isLoading: kyLoading, isDemoData: kyDemoData, installed: kyInstalled, hasErrors: kyHasErrors, clustersChecked: kyChecked, totalClusters: kyTotal } = useKyverno()
   const { selectedClusters } = useGlobalFilters()
   const { startMission } = useMissions()
   const [showBreakdown, setShowBreakdown] = useState(false)
@@ -979,7 +984,10 @@ export function ComplianceScore({ config: _config }: CardConfig) {
   }
 
   const scoreHasData = !usingFallback || isDemoData
-  useCardLoadingState({ isLoading: isLoading && !scoreHasData, hasAnyData: scoreHasData, isDemoData })
+  // #6219: card is failed when both Kubescape and Kyverno had errors
+  // (single-tool failure still produces a meaningful partial score).
+  const scoreFailed = ksHasErrors && kyHasErrors
+  useCardLoadingState({ isLoading: isLoading && !scoreHasData, hasAnyData: scoreHasData, isDemoData, isFailed: scoreFailed })
 
   const scoreCtx = getScoreContext(score)
 

--- a/web/src/components/cards/FleetComplianceHeatmap.tsx
+++ b/web/src/components/cards/FleetComplianceHeatmap.tsx
@@ -219,7 +219,11 @@ export function FleetComplianceHeatmap({ config: _config }: CardConfig) {
     }
   }
 
-  useCardLoadingState({ isLoading: isLoading && !isDemoData, isRefreshing, hasAnyData: true, isDemoData })
+  // #6219: pass `hasError` through as `isFailed` so CardWrapper enters its
+  // error render path when all 3 underlying hooks (kyverno, trivy,
+  // kubescape) finished but found no clusters to scan / no installations.
+  // hasError is computed above from `clustersChecked` totals.
+  useCardLoadingState({ isLoading: isLoading && !isDemoData, isRefreshing, hasAnyData: true, isDemoData, isFailed: hasError })
 
   const rows = useMemo((): HeatmapRow[] => {
     // Collect all cluster names from compliance hooks + useClusters fallback

--- a/web/src/components/cards/Kubedle.tsx
+++ b/web/src/components/cards/Kubedle.tsx
@@ -369,7 +369,7 @@ export function Kubedle(_props: CardComponentProps) {
           <div className="bg-card border border-border rounded-lg p-4 max-w-sm">
             <div className="flex items-center justify-between mb-3">
               <h3 className="font-bold text-foreground">How to Play</h3>
-              <button onClick={() => setShowHelp(false)}>
+              <button onClick={() => setShowHelp(false)} aria-label="Close help">
                 <X className="w-4 h-4" />
               </button>
             </div>
@@ -401,7 +401,7 @@ export function Kubedle(_props: CardComponentProps) {
           <div className="bg-card border border-border rounded-lg p-4 max-w-sm w-full">
             <div className="flex items-center justify-between mb-3">
               <h3 className="font-bold text-foreground">Statistics</h3>
-              <button onClick={() => setShowStats(false)}>
+              <button onClick={() => setShowStats(false)} aria-label="Close statistics">
                 <X className="w-4 h-4" />
               </button>
             </div>

--- a/web/src/components/cards/NamespaceMonitor.tsx
+++ b/web/src/components/cards/NamespaceMonitor.tsx
@@ -502,7 +502,7 @@ export function NamespaceMonitor({ config: _config }: CardComponentProps) {
     }`}>
       <div className="flex items-center justify-between p-3 border-b border-border">
         <span className="text-sm font-medium text-foreground">Recent Changes</span>
-        <button onClick={() => setShowChangesPanel(false)} className="p-2 hover:bg-secondary rounded min-h-11 min-w-11 flex items-center justify-center">
+        <button onClick={() => setShowChangesPanel(false)} aria-label="Close recent changes panel" className="p-2 hover:bg-secondary rounded min-h-11 min-w-11 flex items-center justify-center">
           <X className="w-4 h-4 text-muted-foreground" />
         </button>
       </div>

--- a/web/src/components/cards/kagent/KagentSecurity.tsx
+++ b/web/src/components/cards/kagent/KagentSecurity.tsx
@@ -8,17 +8,28 @@ export function KagentSecurity({ config }: { config?: Record<string, unknown> })
   const {
     data: agents,
     isLoading: agentsLoading,
-    isDemoFallback: agentsDemo } = useKagentCRDAgents({ cluster })
+    isDemoFallback: agentsDemo,
+    isFailed: agentsFailed,
+    consecutiveFailures: agentsFails } = useKagentCRDAgents({ cluster })
   const {
     data: tools,
     isLoading: toolsLoading,
-    isDemoFallback: toolsDemo } = useKagentCRDTools({ cluster })
+    isDemoFallback: toolsDemo,
+    isFailed: toolsFailed,
+    consecutiveFailures: toolsFails } = useKagentCRDTools({ cluster })
 
   const hasData = agents.length > 0 || tools.length > 0
+  // #6219: surface failure state. We treat the card as failed only when
+  // BOTH hooks are failing — partial failure still leaves a useful summary.
+  const isFailed = agentsFailed && toolsFailed
+  const consecutiveFailures = Math.max(agentsFails || 0, toolsFails || 0)
   useCardLoadingState({
     isLoading: (agentsLoading || toolsLoading) && !hasData,
     hasAnyData: hasData,
-    isDemoData: agentsDemo || toolsDemo })
+    isDemoData: agentsDemo || toolsDemo,
+    isFailed,
+    consecutiveFailures,
+  })
 
   const stats = useMemo(() => {
     const totalAgents = agents.length

--- a/web/src/components/cards/kagent/KagentTopology.tsx
+++ b/web/src/components/cards/kagent/KagentTopology.tsx
@@ -34,15 +34,22 @@ interface TopoEdge {
 export function KagentTopology({ config }: { config?: Record<string, unknown> }) {
   const { t } = useTranslation('cards')
   const cluster = config?.cluster as string | undefined
-  const { data: agents, isLoading: agentsLoading, isDemoFallback: agentsDemo } = useKagentCRDAgents({ cluster })
-  const { data: tools, isLoading: toolsLoading, isDemoFallback: toolsDemo } = useKagentCRDTools({ cluster })
-  const { data: models, isLoading: modelsLoading, isDemoFallback: modelsDemo } = useKagentCRDModels({ cluster })
+  const { data: agents, isLoading: agentsLoading, isDemoFallback: agentsDemo, isFailed: agentsFailed, consecutiveFailures: agentsFails } = useKagentCRDAgents({ cluster })
+  const { data: tools, isLoading: toolsLoading, isDemoFallback: toolsDemo, isFailed: toolsFailed, consecutiveFailures: toolsFails } = useKagentCRDTools({ cluster })
+  const { data: models, isLoading: modelsLoading, isDemoFallback: modelsDemo, isFailed: modelsFailed, consecutiveFailures: modelsFails } = useKagentCRDModels({ cluster })
 
   const hasData = agents.length > 0 || tools.length > 0 || models.length > 0
+  // #6219: surface failure state to CardWrapper. We treat the card as
+  // failed when ALL three CRD hooks are failing — partial failure of one
+  // hook still leaves a useful topology.
+  const isFailed = agentsFailed && toolsFailed && modelsFailed
+  const consecutiveFailures = Math.max(agentsFails || 0, toolsFails || 0, modelsFails || 0)
   useCardLoadingState({
     isLoading: (agentsLoading || toolsLoading || modelsLoading) && !hasData,
     hasAnyData: hasData,
     isDemoData: agentsDemo || toolsDemo || modelsDemo,
+    isFailed,
+    consecutiveFailures,
   })
 
   const { nodes, edges } = useMemo(() => {

--- a/web/src/components/cards/weather/Weather.tsx
+++ b/web/src/components/cards/weather/Weather.tsx
@@ -185,7 +185,9 @@ export function Weather({ config }: { config?: WeatherConfig }) {
   const currentWeather = weatherData.current
   const forecast = weatherData.forecast
   const hourlyForecast = weatherData.hourly
-  useCardLoadingState({ isLoading, isRefreshing, hasAnyData: !!currentWeather, isDemoData: isDemoFallback, lastRefresh })
+  // #6219: pass isFailed through so CardWrapper enters its error render path
+  // immediately on a failed fetch instead of waiting for CARD_LOADING_TIMEOUT_MS.
+  useCardLoadingState({ isLoading, isRefreshing, hasAnyData: !!currentWeather, isDemoData: isDemoFallback, isFailed, lastRefresh })
 
   // Save locations to localStorage whenever they change
   useEffect(() => {


### PR DESCRIPTION
## Summary

Two card hygiene issues from @aashu2006, both small surgical fixes across multiple files.

### #6219 — `isFailed` not passed to `useCardLoadingState`
5 cards destructured or could compute `isFailed` from their data hooks but never passed it to `useCardLoadingState`. Result: `CardWrapper` never entered its error render path on failed fetches; the card either showed stale data silently or waited for `CARD_LOADING_TIMEOUT_MS` to expire before showing 'Loading timed out'. Users could not distinguish a failed fetch from a slow one.

| File | Fix |
|---|---|
| `weather/Weather.tsx` | `isFailed` was already destructured from `useCache`, just added it to the `useCardLoadingState` options |
| `FleetComplianceHeatmap.tsx` | Passed local `hasError` (computed from kyverno/trivy/kubescape `clustersChecked` totals) through as `isFailed` |
| `ComplianceCards.tsx` (4 of 5 sites) | Destructured `hasErrors` from `useTrivy`/`useKubescape`/`useKyverno` and passed through. `ComplianceScore` requires BOTH tools to fail (partial failure leaves a useful score). Falco intentionally skipped — its call site is documented as "no live data hook yet, isLoading: false always" |
| `kagent/KagentTopology.tsx` | Destructured `isFailed` + `consecutiveFailures` from all 3 `useKagentCRD` hooks; card is failed only when ALL three fail |
| `kagent/KagentSecurity.tsx` | Same pattern as KagentTopology, requires BOTH hooks to fail |

`NetworkUtils.tsx` is **intentionally skipped** — the issue claimed it needs `isFailed` wiring but the file is purely client-side ping/port checks against external URLs with no backend hook to fail. The 'stale data silently or times out' diagnosis from the issue doesn't match this code path.

### #6222 — icon-only buttons missing `aria-label`
8 icon-only `<button>` elements across 4 files render only an `<X />` icon with no `aria-label`. Screen readers announced these as 'button' with no context. Added an `aria-label` (or i18n key) to each:

| File | Sites | Labels |
|---|---|---|
| `ClusterGroups.tsx` | 3 (new group cancel, remove filter, edit cancel) | `t('common:common.cancel')` / 'Remove filter' |
| `NamespaceMonitor.tsx` | 1 (close changes panel) | 'Close recent changes panel' |
| `ClusterLocations.tsx` | 1 (clear search) | `t('common:common.clearSearch')` |
| `Kubedle.tsx` | 2 (close help/stats modals) | 'Close help' / 'Close statistics' |

## Test plan

- [x] `npm run build` passes locally

Closes #6219 (with NetworkUtils caveat documented), closes #6222.