### PR TITLE
📊 feat(analytics): enrich ksc_mission_error with error_detail

### DIFF
--- a/web/src/hooks/useMissions.tsx
+++ b/web/src/hooks/useMissions.tsx
@@ -536,7 +536,13 @@ export function MissionProvider({ children }: { children: ReactNode }) {
           }
           lastStreamTimestamp.current.delete(m.id)
 
-          emitMissionError(m.type, isInactive ? 'mission_inactivity' : 'mission_timeout')
+          emitMissionError(
+            m.type,
+            isInactive ? 'mission_inactivity' : 'mission_timeout',
+            isInactive
+              ? `stalled_after_${Math.round((now - (lastStreamTs ?? now)) / 1000)}s`
+              : `elapsed_${Math.round(elapsed / 1000)}s`
+          )
 
           const errorContent = isInactive
             ? `**Agent Not Responding**\n\nThe AI agent started responding but stopped for over ${Math.round(MISSION_INACTIVITY_TIMEOUT_MS / 60_000)} minutes. This usually means the agent is stuck waiting for a tool call to return (e.g., a Kubernetes API call or APISIX gateway request that is not responding).\n\nYou can:\n- **Retry** the mission — the issue may be transient\n- **Check cluster connectivity** — ensure the target cluster API server is reachable\n- **Cancel** and try a simpler or more specific request`
@@ -901,7 +907,11 @@ The WebSocket connection to the agent at \`${LOCAL_AGENT_WS_URL}\` was lost and 
       lastStreamTimestamp.current.delete(missionId)
       setMissions(prev => prev.map(m => {
         if (m.id !== missionId || m.status !== 'waiting_input') return m
-        emitMissionError(m.type, 'waiting_input_timeout')
+        emitMissionError(
+          m.type,
+          'waiting_input_timeout',
+          `timeout_after_${Math.round(WAITING_INPUT_TIMEOUT_MS / 1000)}s`
+        )
         return {
           ...m,
           status: 'failed' as MissionStatus,
@@ -1272,7 +1282,7 @@ The WebSocket connection to the agent at \`${LOCAL_AGENT_WS_URL}\` was lost and 
         const payload = message.payload as { code?: string; message?: string }
         pendingRequests.current.delete(message.id)
         clearWaitingInputTimeout(missionId) // #5936 — terminal error, cancel watchdog
-        emitMissionError(m.type, payload.code || 'unknown')
+        emitMissionError(m.type, payload.code || 'unknown', payload.message)
 
         // Create helpful error message based on error code
         let errorContent = payload.message || 'Unknown error'
@@ -1494,7 +1504,11 @@ The WebSocket connection to the agent at \`${LOCAL_AGENT_WS_URL}\` was lost and 
             ]
           } : m
         ))
-        emitMissionError(params.type || 'custom', preflight.error?.code || 'preflight_unknown')
+        emitMissionError(
+          params.type || 'custom',
+          preflight.error?.code || 'preflight_unknown',
+          preflight.error?.message
+        )
         return
       }
 

--- a/web/src/lib/analytics.ts
+++ b/web/src/lib/analytics.ts
@@ -892,8 +892,23 @@ export function emitMissionCompleted(missionType: string, durationSec: number) {
   send('ksc_mission_completed', { mission_type: missionType, duration_sec: durationSec })
 }
 
-export function emitMissionError(missionType: string, errorCode: string) {
-  send('ksc_mission_error', { mission_type: missionType, error_code: errorCode })
+// Max characters to send in the error_detail dimension. GA4 caps event
+// parameter values at 100 chars, so anything longer is truncated to stay
+// within the limit while still surfacing the leading diagnostic text.
+const MISSION_ERROR_DETAIL_MAX_LEN = 100
+
+export function emitMissionError(
+  missionType: string,
+  errorCode: string,
+  errorDetail?: string
+) {
+  const trimmedDetail = errorDetail?.trim()
+  send('ksc_mission_error', {
+    mission_type: missionType,
+    error_code: errorCode,
+    error_detail: trimmedDetail
+      ? trimmedDetail.slice(0, MISSION_ERROR_DETAIL_MAX_LEN)
+      : '' })
 }
 
 export function emitMissionRated(missionType: string, rating: string) {


### PR DESCRIPTION
## Summary

Follow-up to #6232. Today's GA4 report showed 2 `ksc_mission_error` events with `error_code=execution_error` but **empty `error_detail`** — impossible to tell what actually broke without digging into backend logs.

### Changes
- **`emitMissionError`** now takes an optional `errorDetail` param. Trimmed and truncated to `MISSION_ERROR_DETAIL_MAX_LEN` (100 chars — GA4 event parameter value cap) so a long stack trace can't silently drop the whole dimension.
- **`useMissions.tsx`** plumbs real detail through the four call sites that have it:
  - Backend error responses → `payload.message`
  - Preflight failures → `preflight.error.message`
  - Mission timeout / inactivity → elapsed-time context (`elapsed_720s`, `stalled_after_480s`) so we can distinguish slow agents from stuck ones
  - Waiting-input timeout → configured timeout value
- `MissionLandingPage` call sites (`no_mission_specified`, `mission_not_found`) are already self-describing — no detail added.

Signature change is **backwards-compatible** — `errorDetail` is optional, so existing call sites and tests continue to work unchanged.

## Test plan
- [x] `npm run build` passes
- [x] `npm run lint` — no new errors or warnings in edited files
- [ ] Verify next `ksc_mission_error` in GA4 has a non-empty `error_detail` value
- [ ] Confirm backend error codes surface with their human-readable message (e.g., `execution_error` → "Failed to execute ai-helper")

## Related
- Depends on #6232 (the default-6 setState loop fix) for clean GA4 signal