### PR TITLE
fix: consolidated PAT row, admin role, KPI 0%-when-zero, single cache read (#6212, #6220)

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,15 +97,27 @@ Open http://localhost:8080 in your **Windows** browser — WSL2 forwards `localh
 
 ## GitHub authentication
 
-The console references three different GitHub credentials and they are **not interchangeable** (#6190). Most users need **none** of them — the hosted demo works without any GitHub auth at all. Use this table to pick what (if anything) applies to you:
+The console uses **two** GitHub credentials (#6190). Most users need **neither** — the hosted demo works without any GitHub auth at all.
 
-| Credential | What it does | Where it lives | When you need it |
-|---|---|---|---|
-| **GitHub OAuth App** (`GITHUB_CLIENT_ID` + `GITHUB_CLIENT_SECRET`) | Sign-in for the **self-hosted** console at `localhost:8080` | `.env` file at the repo root | Only if you self-host the console AND want user sign-in. Skip for the hosted demo. |
-| **GitHub PAT in Settings UI** | Powers nightly E2E status, community activity, leaderboard widgets | Persisted by the **console backend** via `POST /api/github/token` (`pkg/api/handlers/github_proxy.go`) to the encrypted local settings file at `~/.kc/settings.json`. Not browser-only and not stored on the kc-agent. Only works when self-hosting — the hosted Netlify demo has no writable local backend, so the Settings page cannot persist a token there. | Optional. Adds GitHub-powered widgets to your **self-hosted** dashboard. |
-| **`FEEDBACK_GITHUB_TOKEN`** | Lets the `/issue` page open GitHub issues for you | `.env` file at the repo root | Optional. Only needed if you want users to file issues from inside the console. Without it, `/issue` returns `503 Issue submission is not available`. |
+| Credential | What it does | When you need it |
+|---|---|---|
+| **GitHub OAuth App** (`GITHUB_CLIENT_ID` + `GITHUB_CLIENT_SECRET`) | Sign-in for the **self-hosted** console at `localhost:8080` | Only if you self-host the console AND want user sign-in. Skip for the hosted demo. |
+| **Consolidated GitHub PAT** (a.k.a. `FeedbackGitHubToken`) | Same single PAT powers everything: nightly E2E status, community activity, leaderboard widgets, and the `/issue` page that opens GitHub issues | Optional. Without it, `/issue` returns `503 Issue submission is not available` and the GitHub-powered dashboard widgets fall back to demo data. |
 
 **Minimum to get started**: nothing — hit [console.kubestellar.io](https://console.kubestellar.io). Everything above is opt-in.
+
+### Setting the consolidated PAT
+
+There are two equivalent ways to supply this PAT — pick one. Both write to the same field (`FeedbackGitHubToken` in `pkg/api/handlers/feedback.go` and `pkg/api/handlers/github_proxy.go`), so you don't need to set both:
+
+1. **`.env` file at the repo root** — set on startup, no UI step needed:
+   ```
+   FEEDBACK_GITHUB_TOKEN=ghp_…
+   ```
+
+2. **Settings UI** (self-hosted only, **admin role required**) — visit Settings → GitHub Token → paste. The UI POSTs to `/api/github/token` which is gated on the console `admin` role and returns `403 Console admin access required` for non-admin users (verified in `pkg/api/handlers/github_proxy.go:214`). Persisted to `~/.kc/settings.json` by the backend.
+
+The hosted Netlify demo cannot persist a PAT — it has no writable local backend — so Settings UI saves don't work there. Use the env-var path for self-hosting.
 
 ### Setting up GitHub OAuth (self-hosted only)
 
@@ -134,17 +146,11 @@ If you self-host the console and want sign-in:
 
 Open http://localhost:8080 and sign in with GitHub. For Kubernetes deployments, pass `--github-oauth` to `deploy.sh` instead.
 
-### `FEEDBACK_GITHUB_TOKEN` scopes
+### Consolidated PAT scopes
 
-Add a [Personal Access Token](https://github.com/settings/tokens) to `.env`:
-
-```
-FEEDBACK_GITHUB_TOKEN=your-github-personal-access-token
-```
-
-The token needs **either**:
+Whichever path you used above (env var or Settings UI), the [Personal Access Token](https://github.com/settings/tokens) needs **either**:
 - A **classic** PAT with the `repo` scope, **or**
-- A **fine-grained** PAT with both **Issues: Read & Write** *and* **Contents: Read & Write** (verified against `pkg/api/handlers/feedback.go` — Contents is required, not just Issues).
+- A **fine-grained** PAT with both **Issues: Read & Write** *and* **Contents: Read & Write** (verified against `pkg/api/handlers/feedback.go:71` — Contents is required, not just Issues).
 
 ## AI configuration
 

--- a/web/public/analytics.js
+++ b/web/public/analytics.js
@@ -943,18 +943,23 @@
         const aiPrs = accm.weeklyActivity.reduce((s, w) => s + (w.aiPrs || 0), 0);
         const humanPrs = accm.weeklyActivity.reduce((s, w) => s + (w.humanPrs || 0), 0);
         const totalPrs = aiPrs + humanPrs;
+        // #6220: with the previous `100 - aiPrPct` math, totalPrs===0 made
+        // the Human KPI render as "100%" with "0 of 0 PRs" — both forced to
+        // 0% in the empty case avoids that confusing display.
         const aiPrPct = totalPrs > 0 ? Math.round((aiPrs / totalPrs) * 100) : 0;
+        const humanPrPct = totalPrs > 0 ? 100 - aiPrPct : 0;
 
         const aiIssues = accm.weeklyActivity.reduce((s, w) => s + (w.aiIssues || 0), 0);
         const humanIssues = accm.weeklyActivity.reduce((s, w) => s + (w.humanIssues || 0), 0);
         const totalIssues = aiIssues + humanIssues;
         const aiIssuePct = totalIssues > 0 ? Math.round((aiIssues / totalIssues) * 100) : 0;
+        const humanIssuePct = totalIssues > 0 ? 100 - aiIssuePct : 0;
 
         html += '<div class="kpi-grid">';
         html += `<div class="kpi-card"><div class="kpi-label">AI-Authored PRs</div><div class="kpi-value" style="color:var(--purple)">${aiPrPct}%</div><div class="kpi-change flat">${aiPrs} of ${totalPrs} PRs</div></div>`;
-        html += `<div class="kpi-card"><div class="kpi-label">Human-Authored PRs</div><div class="kpi-value" style="color:var(--cyan)">${100 - aiPrPct}%</div><div class="kpi-change flat">${humanPrs} of ${totalPrs} PRs</div></div>`;
+        html += `<div class="kpi-card"><div class="kpi-label">Human-Authored PRs</div><div class="kpi-value" style="color:var(--cyan)">${humanPrPct}%</div><div class="kpi-change flat">${humanPrs} of ${totalPrs} PRs</div></div>`;
         html += `<div class="kpi-card"><div class="kpi-label">AI-Filed Issues</div><div class="kpi-value" style="color:var(--purple)">${aiIssuePct}%</div><div class="kpi-change flat">${aiIssues} of ${totalIssues} issues</div></div>`;
-        html += `<div class="kpi-card"><div class="kpi-label">Human-Filed Issues</div><div class="kpi-value" style="color:var(--cyan)">${100 - aiIssuePct}%</div><div class="kpi-change flat">${humanIssues} of ${totalIssues} issues</div></div>`;
+        html += `<div class="kpi-card"><div class="kpi-label">Human-Filed Issues</div><div class="kpi-value" style="color:var(--cyan)">${humanIssuePct}%</div><div class="kpi-change flat">${humanIssues} of ${totalIssues} issues</div></div>`;
 
         if (accm.contributorGrowth) {
           html += `<div class="kpi-card"><div class="kpi-label">Total Contributors</div><div class="kpi-value">${accm.contributorGrowth.total}</div></div>`;

--- a/web/src/hooks/useMediumBlog.ts
+++ b/web/src/hooks/useMediumBlog.ts
@@ -75,11 +75,18 @@ export function useMediumBlog() {
   // Read the cache synchronously during initial render via lazy useState
   // initializers. This avoids calling setState inside the effect for the
   // cache-hit path (react-hooks/set-state-in-effect).
-  const [posts, setPosts] = useState<BlogPost[]>(() => readCache()?.posts ?? [])
+  //
+  // #6220: previously each useState initializer called readCache() — three
+  // round-trips through sessionStorage.getItem + JSON.parse on every mount,
+  // and a tiny race window if the cache changed between calls. Read once
+  // into a useRef-like stable holder that all three lazy initializers
+  // capture from the same closure.
+  const [initialCache] = useState<CacheEntry | null>(() => readCache())
+  const [posts, setPosts] = useState<BlogPost[]>(() => initialCache?.posts ?? [])
   const [channelUrl, setChannelUrl] = useState<string>(
-    () => readCache()?.channelUrl ?? 'https://medium.com/@kubestellar'
+    () => initialCache?.channelUrl ?? 'https://medium.com/@kubestellar'
   )
-  const [loading, setLoading] = useState(() => readCache() === null)
+  const [loading, setLoading] = useState(() => initialCache === null)
 
   useEffect(() => {
     // If we already populated state from a fresh cache entry, nothing to do.


### PR DESCRIPTION
## Summary

Two small Copilot review followups, both verified against source before changing.

### #6212 — Copilot review on #6207 (README round 4)

**Two factual errors I introduced in #6207, caught and corrected.**

1. The README treated 'GitHub PAT in Settings UI' and `FEEDBACK_GITHUB_TOKEN` as separate, 'not interchangeable' credentials. **Wrong.** Verified against `pkg/api/handlers/github_proxy.go:92,238`: both paths write to the **single** `FeedbackGitHubToken` field on `AllSettings`, which is consumed by the github proxy, feedback issue creation, missions, and rewards. They are TWO WAYS TO SUPPLY THE SAME TOKEN. Merged the table rows into one 'Consolidated GitHub PAT' row + new 'Setting the consolidated PAT' subsection.
2. The Settings UI `POST /api/github/token` endpoint requires the console `admin` role and returns 403 otherwise. Verified at `pkg/api/handlers/github_proxy.go:214`. The README implied any self-hosted user could persist the PAT. Documented the admin requirement.

### #6220 — Copilot review on #6214 (analytics + cache)

1. **`web/public/analytics.js:957`** — KPI percentages for Human PRs/Issues were `100 - aiPct`. With `totalPrs===0`, `aiPct` is forced to 0, so the Human KPI rendered as **100%** with the change line **'0 of 0 PRs'**. New `humanPrPct`/`humanIssuePct` variables also force to 0 in the empty case.
2. **`web/src/hooks/useMediumBlog.ts:78-82`** — `readCache()` was called THREE times during initial render (one per `useState` lazy initializer). Read once into a captured `initialCache` and derive all three from the same snapshot.

## Test plan

- [x] `npm run build` passes locally

Closes #6212, closes #6220.