### PR TITLE
feat(setup): add Windows (WSL2) section to in-app agent setup modals (#6185 follow-up)

### DIFF
--- a/web/src/components/agent/AgentSetupDialog.tsx
+++ b/web/src/components/agent/AgentSetupDialog.tsx
@@ -21,16 +21,23 @@ export function AgentSetupDialog() {
   const [show, setShow] = useState(false)
   const [copiedMacOS, setCopiedMacOS] = useState(false)
   const [copiedLinux, setCopiedLinux] = useState(false)
+  const [copiedWindows, setCopiedWindows] = useState(false)
   const copiedTimerRef = useRef<ReturnType<typeof setTimeout>>(undefined)
   const copiedLinuxTimerRef = useRef<ReturnType<typeof setTimeout>>(undefined)
+  const copiedWindowsTimerRef = useRef<ReturnType<typeof setTimeout>>(undefined)
 
   const macOSInstallCommand = 'brew tap kubestellar/tap && brew install kc-agent && kc-agent'
-  const linuxBuildCommand = 'git clone https://github.com/kubestellar/console.git && cd console && go build -o bin/kc-agent ./cmd/kc-agent && ./bin/kc-agent'
+  const linuxBuildCommand = 'git clone https://github.com/kubestellar/console.git && cd console && mkdir -p bin && go build -o bin/kc-agent ./cmd/kc-agent && ./bin/kc-agent'
+  // #6185: Windows users run inside WSL2 — same build path as Linux but
+  // with apt prereqs first. The README already covers this; the in-app
+  // modal had no Windows option until rishi-jat's follow-up.
+  const windowsBuildCommand = 'sudo apt-get update && sudo apt-get install -y software-properties-common curl git && sudo add-apt-repository -y ppa:longsleep/golang-backports && sudo apt-get update && sudo apt-get install -y golang-1.25 && git clone https://github.com/kubestellar/console.git && cd console && mkdir -p bin && go build -o bin/kc-agent ./cmd/kc-agent && ./bin/kc-agent'
 
   useEffect(() => {
     return () => {
       clearTimeout(copiedTimerRef.current)
       clearTimeout(copiedLinuxTimerRef.current)
+      clearTimeout(copiedWindowsTimerRef.current)
     }
   }, [])
 
@@ -71,6 +78,7 @@ export function AgentSetupDialog() {
   }, [status, isConnected])
 
   const [showLinux, setShowLinux] = useState(false)
+  const [showWindows, setShowWindows] = useState(false)
 
   const copyMacOS = async () => {
     await copyToClipboard(macOSInstallCommand)
@@ -84,6 +92,13 @@ export function AgentSetupDialog() {
     setCopiedLinux(true)
     clearTimeout(copiedLinuxTimerRef.current)
     copiedLinuxTimerRef.current = setTimeout(() => setCopiedLinux(false), UI_FEEDBACK_TIMEOUT_MS)
+  }
+
+  const copyWindows = async () => {
+    await copyToClipboard(windowsBuildCommand)
+    setCopiedWindows(true)
+    clearTimeout(copiedWindowsTimerRef.current)
+    copiedWindowsTimerRef.current = setTimeout(() => setCopiedWindows(false), UI_FEEDBACK_TIMEOUT_MS)
   }
 
   const handleSnooze = () => {
@@ -157,6 +172,41 @@ export function AgentSetupDialog() {
                 </button>
               </div>
               <p className="text-xs text-muted-foreground">{t('agentSetup.linuxBrewAlternative')}</p>
+            </div>
+          )}
+        </div>
+
+        {/* Windows (WSL2) Install Option (collapsible) — #6185 */}
+        <div className="mt-2">
+          <button
+            onClick={() => setShowWindows(!showWindows)}
+            className="flex items-center gap-1.5 text-xs text-purple-400 hover:text-purple-300 transition-colors"
+          >
+            {showWindows ? <ChevronDown className="w-3.5 h-3.5" /> : <ChevronRight className="w-3.5 h-3.5" />}
+            {t('agentSetup.windowsInstructions', 'Windows (WSL2) instructions')}
+          </button>
+          {showWindows && (
+            <div className="mt-2 rounded-lg border border-purple-500/20 bg-purple-500/5 p-3 space-y-2">
+              <p className="text-xs text-muted-foreground">
+                {t(
+                  'agentSetup.windowsBuildDesc',
+                  'Native Windows is not supported (the install scripts and kc-agent are POSIX shell + Go). Install WSL2 with Ubuntu first ("wsl --install -d Ubuntu" in PowerShell), then run this single command inside the WSL shell. Open http://localhost:8080 in your Windows browser — WSL2 forwards localhost automatically.',
+                )}
+              </p>
+              <div className="flex items-center gap-2">
+                <code className="flex-1 rounded bg-muted px-3 py-1.5 text-xs font-mono text-foreground select-all overflow-x-auto">
+                  {windowsBuildCommand}
+                </code>
+                <button
+                  onClick={copyWindows}
+                  className="shrink-0 rounded bg-primary px-3 py-1.5 text-xs font-medium text-primary-foreground hover:bg-primary/90"
+                >
+                  {copiedWindows ? t('agentSetup.copied') : t('agentSetup.copy')}
+                </button>
+              </div>
+              <p className="text-xs text-muted-foreground">
+                {t('agentSetup.windowsReadmeRef', 'See README → Windows (WSL2) for the step-by-step version of this command.')}
+              </p>
             </div>
           )}
         </div>

--- a/web/src/components/setup/InClusterAgentDialog.tsx
+++ b/web/src/components/setup/InClusterAgentDialog.tsx
@@ -12,18 +12,25 @@ interface InClusterAgentDialogProps {
 }
 
 const BREW_INSTALL_CMD = 'brew tap kubestellar/tap && brew install kc-agent && kc-agent'
-const BUILD_FROM_SOURCE_CMD = 'git clone https://github.com/kubestellar/console.git && cd console && go build -o bin/kc-agent ./cmd/kc-agent && ./bin/kc-agent'
+const BUILD_FROM_SOURCE_CMD = 'git clone https://github.com/kubestellar/console.git && cd console && mkdir -p bin && go build -o bin/kc-agent ./cmd/kc-agent && ./bin/kc-agent'
+// #6185: Windows users run inside WSL2. Same Linux build path with apt
+// prereqs prepended (software-properties-common for add-apt-repository,
+// the longsleep PPA for current Go, then the standard build-from-source
+// command). The README has the step-by-step version of this.
+const WINDOWS_WSL_INSTALL_CMD = 'sudo apt-get update && sudo apt-get install -y software-properties-common curl git && sudo add-apt-repository -y ppa:longsleep/golang-backports && sudo apt-get update && sudo apt-get install -y golang-1.25 && git clone https://github.com/kubestellar/console.git && cd console && mkdir -p bin && go build -o bin/kc-agent ./cmd/kc-agent && ./bin/kc-agent'
 const DOCS_URL = 'https://console-docs.kubestellar.io'
 
 /** Step key ranges: 100–199 = install section, 200–299 = CORS section */
 const COPY_KEY_BREW = 100
 const COPY_KEY_BUILD = 101
+const COPY_KEY_WSL = 102
 const COPY_KEY_CORS_ENV = 200
 const COPY_KEY_CORS_FLAG = 201
 
 export function InClusterAgentDialog({ isOpen, onClose }: InClusterAgentDialogProps) {
   const [copiedStep, setCopiedStep] = useState<number | null>(null)
   const [showBuildFromSource, setShowBuildFromSource] = useState(false)
+  const [showWindowsWsl, setShowWindowsWsl] = useState(false)
   const [showCorsDetails, setShowCorsDetails] = useState(false)
   const copiedTimerRef = useRef<ReturnType<typeof setTimeout>>(undefined)
 
@@ -122,7 +129,7 @@ export function InClusterAgentDialog({ isOpen, onClose }: InClusterAgentDialogPr
                     ) : (
                       <ChevronRight className="w-3.5 h-3.5" />
                     )}
-                    Or build from source (requires Go 1.24+)
+                    Or build from source (Linux, requires Go 1.25+)
                   </button>
                   {showBuildFromSource && (
                     <div className="mt-2 rounded-lg border border-purple-500/20 bg-purple-500/5 p-3 space-y-2">
@@ -136,6 +143,47 @@ export function InClusterAgentDialog({ isOpen, onClose }: InClusterAgentDialogPr
                           title="Copy command"
                         >
                           {copiedStep === COPY_KEY_BUILD ? (
+                            <Check className="w-3.5 h-3.5 text-green-400" />
+                          ) : (
+                            <Copy className="w-3.5 h-3.5" />
+                          )}
+                        </button>
+                      </div>
+                    </div>
+                  )}
+                </div>
+
+                {/* Windows (WSL2) Install Option (collapsible) — #6185 */}
+                <div className="mt-2">
+                  <button
+                    onClick={() => setShowWindowsWsl(!showWindowsWsl)}
+                    className="flex items-center gap-1.5 text-xs text-purple-400 hover:text-purple-300 transition-colors"
+                  >
+                    {showWindowsWsl ? (
+                      <ChevronDown className="w-3.5 h-3.5" />
+                    ) : (
+                      <ChevronRight className="w-3.5 h-3.5" />
+                    )}
+                    Windows (WSL2)
+                  </button>
+                  {showWindowsWsl && (
+                    <div className="mt-2 rounded-lg border border-purple-500/20 bg-purple-500/5 p-3 space-y-2">
+                      <p className="text-xs text-muted-foreground">
+                        Native Windows isn&apos;t supported. Install WSL2 with Ubuntu first
+                        (<code className="px-1 rounded bg-muted">wsl --install -d Ubuntu</code> in PowerShell), then
+                        run this single command inside the WSL shell. Open <code className="px-1 rounded bg-muted">http://localhost:8080</code> in
+                        your Windows browser when done — WSL2 forwards localhost automatically.
+                      </p>
+                      <div className="flex items-center gap-2">
+                        <code className="flex-1 rounded bg-muted px-3 py-1.5 text-xs font-mono text-foreground select-all overflow-x-auto">
+                          {WINDOWS_WSL_INSTALL_CMD}
+                        </code>
+                        <button
+                          onClick={() => handleCopy(WINDOWS_WSL_INSTALL_CMD, COPY_KEY_WSL)}
+                          className="shrink-0 p-1.5 rounded hover:bg-muted text-muted-foreground hover:text-foreground transition-colors"
+                          title="Copy command"
+                        >
+                          {copiedStep === COPY_KEY_WSL ? (
                             <Check className="w-3.5 h-3.5 text-green-400" />
                           ) : (
                             <Copy className="w-3.5 h-3.5" />

--- a/web/src/test/ui-ux-standards.test.ts
+++ b/web/src/test/ui-ux-standards.test.ts
@@ -55,7 +55,7 @@ const COMPONENTS_DIR = path.resolve(
 // regex matches `#NNNN` as a hex literal, but these are GitHub issue
 // references in code comments, not color literals. Same scoped-bump rationale
 // as the prior 273→278 increment.
-const EXPECTED_RAW_HEX_COUNT = 282
+const EXPECTED_RAW_HEX_COUNT = 284
 const EXPECTED_RAW_RGBA_COUNT = 104
 const EXPECTED_ARBITRARY_TW_COLOR_COUNT = 22
 const EXPECTED_INLINE_STYLE_COLOR_COUNT = 213


### PR DESCRIPTION
## Summary

@rishi-jat reported (#6185) that the README install instructions had no Windows path. That was fixed in #6187/#6193/#6194/#6197/#6207, but **the README is only one surface** — the in-app modals that show up when users first try to set up kc-agent had no Windows option either. This PR closes that gap.

## What changed

**`AgentSetupDialog.tsx`** (the welcome modal that auto-shows when no agent is connected):
- New `windowsBuildCommand` constant — single-line WSL command (apt prereqs + longsleep PPA + golang-1.25 + git clone + `mkdir -p bin` + go build)
- New Windows (WSL2) collapsible section parallel to the Linux one, with the same Copy/Copied button pattern
- Linux build command also updated to include `mkdir -p bin` (#6196 caught this for the README)

**`InClusterAgentDialog.tsx`** (the in-cluster connect dialog):
- New `WINDOWS_WSL_INSTALL_CMD` constant + collapsible Windows (WSL2) section parallel to the build-from-source one
- Linux build-from-source label bumped from 'Go 1.24+' → 'Go 1.25+' to match `go.mod`
- Linux build command also adds `mkdir -p bin`

Both Windows sections include:
- The one-time PowerShell prerequisite (`wsl --install -d Ubuntu`) described inline
- A note that `http://localhost:8080` just works in the Windows browser (WSL2 localhost forwarding)
- A pointer back to the README's step-by-step version

**Result:** README + in-app modals are now consistent for the four supported install paths: macOS Homebrew, Linux build-from-source, **Windows WSL2 build**, in-cluster deploy.

## Test plan

- [x] `npm run build` passes locally
- [ ] After merge: open the console with no kc-agent running → AgentSetupDialog auto-shows → click 'Windows (WSL2) instructions' → verify the section expands and the Copy button works
- [ ] Same flow for InClusterAgentDialog (triggered from cluster picker)

Refs #6185.