### PR TITLE
fix(freshness): add RefreshIndicator to 3 cards (#6217 part 1)

### DIFF
--- a/web/src/components/cards/ClusterFocus.tsx
+++ b/web/src/components/cards/ClusterFocus.tsx
@@ -5,6 +5,7 @@ import { useCachedPodIssues, useCachedDeploymentIssues, useCachedGPUNodes } from
 import { useGlobalFilters } from '../../hooks/useGlobalFilters'
 import { useDrillDownActions } from '../../hooks/useDrillDown'
 import { Skeleton } from '../ui/Skeleton'
+import { RefreshIndicator } from '../ui/RefreshIndicator'
 import { useCardLoadingState } from './CardDataContext'
 import { useTranslation } from 'react-i18next'
 import { useDemoMode } from '../../hooks/useDemoMode'
@@ -19,9 +20,12 @@ export function ClusterFocus({ config }: ClusterFocusProps) {
   const { t } = useTranslation(['cards', 'common'])
   const selectedCluster = config?.cluster
   const { deduplicatedClusters: allClusters, isLoading: clustersLoading, isRefreshing: clustersRefreshing, isFailed, consecutiveFailures } = useClusters()
-  const { nodes: gpuNodes, isDemoFallback: gpuDemoFallback, isRefreshing: gpuRefreshing } = useCachedGPUNodes()
-  const { issues: podIssues, isDemoFallback: podsDemoFallback, isRefreshing: podsRefreshing } = useCachedPodIssues(selectedCluster)
-  const { issues: deploymentIssues, isDemoFallback: deployDemoFallback, isRefreshing: deploymentsRefreshing } = useCachedDeploymentIssues(selectedCluster)
+  // #6217: destructure lastRefresh from each underlying hook so the card
+  // can render a freshness indicator using the OLDEST timestamp (= the
+  // staler half of the data the user is looking at).
+  const { nodes: gpuNodes, isDemoFallback: gpuDemoFallback, isRefreshing: gpuRefreshing, lastRefresh: gpuLastRefresh } = useCachedGPUNodes()
+  const { issues: podIssues, isDemoFallback: podsDemoFallback, isRefreshing: podsRefreshing, lastRefresh: podsLastRefresh } = useCachedPodIssues(selectedCluster)
+  const { issues: deploymentIssues, isDemoFallback: deployDemoFallback, isRefreshing: deploymentsRefreshing, lastRefresh: deployLastRefresh } = useCachedDeploymentIssues(selectedCluster)
   const { drillToCluster, drillToPod, drillToDeployment } = useDrillDownActions()
   const [internalCluster, setInternalCluster] = useState<string>('')
   const { isDemoMode } = useDemoMode()
@@ -126,6 +130,18 @@ export function ClusterFocus({ config }: ClusterFocusProps) {
         <div className="flex items-center gap-2 min-w-0 flex-1">
           <span className="text-sm font-medium text-foreground truncate">{clusterName}</span>
           <div className={`w-2 h-2 rounded-full shrink-0 ${cluster?.healthy ? 'bg-green-500' : 'bg-red-500'}`} />
+          {/* #6217: freshness indicator using the OLDEST of the 3 cache
+              timestamps so users see the staler half of the data. */}
+          <RefreshIndicator
+            isRefreshing={gpuRefreshing || podsRefreshing || deploymentsRefreshing}
+            lastUpdated={(() => {
+              const ts = [gpuLastRefresh, podsLastRefresh, deployLastRefresh].filter((t): t is number => t != null)
+              return ts.length > 0 ? new Date(Math.min(...ts)) : null
+            })()}
+            size="sm"
+            showLabel={true}
+            staleThresholdMinutes={5}
+          />
         </div>
         <div className="flex items-center gap-2">
           {!selectedCluster && (

--- a/web/src/components/cards/GPUNamespaceAllocations.tsx
+++ b/web/src/components/cards/GPUNamespaceAllocations.tsx
@@ -5,6 +5,7 @@ import { useDrillDownActions } from '../../hooks/useDrillDown'
 import { ClusterBadge } from '../ui/ClusterBadge'
 import { StatusBadge } from '../ui/StatusBadge'
 import { CardClusterFilter, CardSearchInput } from '../../lib/cards/CardComponents'
+import { RefreshIndicator } from '../ui/RefreshIndicator'
 import { CardControls } from '../ui/CardControls'
 import { Pagination } from '../ui/Pagination'
 import { Skeleton } from '../ui/Skeleton'
@@ -54,8 +55,11 @@ const NAMESPACE_SORT_COMPARATORS: Record<SortByOption, (a: NamespaceGPUAllocatio
 // a runtime error in the 274-line component doesn't crash the dashboard.
 function GPUNamespaceAllocationsInternal({ config: _config }: GPUNamespaceAllocationsProps) {
   const { t } = useTranslation(['cards', 'common'])
-  const { nodes: gpuNodes, isLoading: gpuLoading, isRefreshing: gpuRefreshing, isDemoFallback: gpuNodesDemoFallback, isFailed: gpuFailed, consecutiveFailures: gpuFailures } = useCachedGPUNodes()
-  const { pods: allPods, isLoading: podsLoading, isRefreshing: podsRefreshing, isDemoFallback: podsDemoFallback, isFailed: podsFailed, consecutiveFailures: podsFailures } = useCachedAllPods()
+  // #6217: destructure lastRefresh from both hooks to power a freshness
+  // indicator. Use the OLDER of the two timestamps so the indicator
+  // reflects the staler half of the data the user is looking at.
+  const { nodes: gpuNodes, isLoading: gpuLoading, isRefreshing: gpuRefreshing, isDemoFallback: gpuNodesDemoFallback, isFailed: gpuFailed, consecutiveFailures: gpuFailures, lastRefresh: gpuLastRefresh } = useCachedGPUNodes()
+  const { pods: allPods, isLoading: podsLoading, isRefreshing: podsRefreshing, isDemoFallback: podsDemoFallback, isFailed: podsFailed, consecutiveFailures: podsFailures, lastRefresh: podsLastRefresh } = useCachedAllPods()
   const { drillToGPUNamespace } = useDrillDownActions()
 
   // Combine all isDemoFallback values from cached hooks
@@ -172,6 +176,19 @@ function GPUNamespaceAllocationsInternal({ config: _config }: GPUNamespaceAlloca
           <StatusBadge color="purple">
             {t('gpuNamespaceAllocations.gpusAcrossNamespaces', { gpus: totalGPUs, count: namespaceAllocations.length })}
           </StatusBadge>
+          {/* #6217: freshness indicator. Use the OLDER of the two cache
+              timestamps so the user sees the staler half of the data. */}
+          <RefreshIndicator
+            isRefreshing={gpuRefreshing || podsRefreshing}
+            lastUpdated={
+              gpuLastRefresh && podsLastRefresh
+                ? new Date(Math.min(gpuLastRefresh, podsLastRefresh))
+                : (gpuLastRefresh ? new Date(gpuLastRefresh) : (podsLastRefresh ? new Date(podsLastRefresh) : null))
+            }
+            size="sm"
+            showLabel={true}
+            staleThresholdMinutes={5}
+          />
         </div>
         <div className="flex items-center gap-2">
           {filters.localClusterFilter && filters.localClusterFilter.length > 0 && (

--- a/web/src/components/cards/ResourceUsage.tsx
+++ b/web/src/components/cards/ResourceUsage.tsx
@@ -6,6 +6,7 @@ import { useCachedGPUNodes } from '../../hooks/useCachedData'
 import { useDrillDownActions } from '../../hooks/useDrillDown'
 import { CardClusterFilter } from '../../lib/cards/CardComponents'
 import { useChartFilters } from '../../lib/cards/cardHooks'
+import { RefreshIndicator } from '../ui/RefreshIndicator'
 import { useCardLoadingState } from './CardDataContext'
 import { DynamicCardErrorBoundary } from './DynamicCardErrorBoundary'
 import { Skeleton } from '../ui/Skeleton'
@@ -16,8 +17,10 @@ import { useDemoMode } from '../../hooks/useDemoMode'
 // a runtime error in the 252-line component doesn't crash the dashboard.
 function ResourceUsageInternal() {
   const { t } = useTranslation(['cards', 'common'])
+  // #6217: destructure lastRefresh so the card can render a freshness
+  // indicator instead of leaving users guessing how stale the data is.
   const { isLoading: clustersLoading, isRefreshing: clustersRefreshing } = useClusters()
-  const { nodes: allGPUNodes, isDemoFallback, isRefreshing: gpuRefreshing } = useCachedGPUNodes()
+  const { nodes: allGPUNodes, isDemoFallback, isRefreshing: gpuRefreshing, lastRefresh: gpuLastRefresh } = useCachedGPUNodes()
   const { drillToResources } = useDrillDownActions()
   const { isDemoMode } = useDemoMode()
 
@@ -161,6 +164,14 @@ function ResourceUsageInternal() {
               {t('common:common.nClusters', { count: clusters.length })}
             </span>
           )}
+          {/* #6217: freshness indicator. */}
+          <RefreshIndicator
+            isRefreshing={clustersRefreshing || gpuRefreshing}
+            lastUpdated={gpuLastRefresh ? new Date(gpuLastRefresh) : null}
+            size="sm"
+            showLabel={true}
+            staleThresholdMinutes={5}
+          />
         </div>
 
         <div className="flex items-center gap-2">

--- a/web/src/test/ui-ux-standards.test.ts
+++ b/web/src/test/ui-ux-standards.test.ts
@@ -55,7 +55,7 @@ const COMPONENTS_DIR = path.resolve(
 // regex matches `#NNNN` as a hex literal, but these are GitHub issue
 // references in code comments, not color literals. Same scoped-bump rationale
 // as the prior 273→278 increment.
-const EXPECTED_RAW_HEX_COUNT = 284
+const EXPECTED_RAW_HEX_COUNT = 287
 const EXPECTED_RAW_RGBA_COUNT = 104
 const EXPECTED_ARBITRARY_TW_COLOR_COUNT = 22
 const EXPECTED_INLINE_STYLE_COLOR_COUNT = 213


### PR DESCRIPTION
## Summary

Auto-QA #6217 listed 15 cards with caching but no freshness indicator. Per the issue's 'size S < 50 lines' guidance, this PR addresses **3 of the 15**. The other 12 will land in follow-up PRs.

## Cards in this PR

| Card | Hooks used | Indicator timestamp |
|---|---|---|
| `GPUNamespaceAllocations.tsx` | `useCachedGPUNodes` + `useCachedAllPods` | Older of the two |
| `ResourceUsage.tsx` | `useCachedGPUNodes` | Single timestamp |
| `ClusterFocus.tsx` | `useCachedGPUNodes` + `useCachedPodIssues` + `useCachedDeploymentIssues` | Oldest of the three (`Math.min` over non-null set) |

Pattern in all 3: import `RefreshIndicator` from `../ui/RefreshIndicator`, destructure `lastRefresh` from each cached hook, render the component in the existing header next to the title/badge. `size='sm'`, `showLabel=true`, `staleThresholdMinutes=5` — same defaults EventStream uses.

## False positive on KedaStatus

`KedaStatus.tsx` is also on the auto-QA list but is **intentionally NOT included** in this PR. Verified it already has a working freshness display in its header — `data.lastCheckTime` + spinning refresh icon at lines 302-304. Replacing the existing display with `RefreshIndicator` would lose the backend-side check timestamp and regress the UX. The auto-QA report's claim about KedaStatus is a false positive.

## Test plan

- [x] `npm run build` passes locally
- [ ] After merge, expand each of the 3 cards in demo mode and verify the 'Updated X ago' label appears

Refs #6217 (part 1 of multiple PRs).