### PR TITLE
fix(security): replace regex YAML masker with shared js-yaml helper (#6231)

### DIFF
--- a/web/src/components/drilldown/views/ConfigMapDrillDown.tsx
+++ b/web/src/components/drilldown/views/ConfigMapDrillDown.tsx
@@ -8,9 +8,10 @@ import { cn } from '../../../lib/cn'
 import { UI_FEEDBACK_TIMEOUT_MS } from '../../../lib/constants/network'
 import { useTranslation } from 'react-i18next'
 import { copyToClipboard } from '../../../lib/clipboard'
-// Reuse the YAML masking helper from SecretDrillDown — same `data:` block
-// shape from `kubectl get configmap -o yaml`, so the same regex applies.
-import { maskSecretYaml } from './SecretDrillDown'
+// #6231: switched from the regex-based maskSecretYaml that lived in
+// SecretDrillDown to the shared js-yaml-based helper. Resource-agnostic
+// name + shared module + correct block-scalar handling.
+import { maskKubernetesYamlData } from '../../../lib/yamlMask'
 
 interface Props {
   data: Record<string, unknown>
@@ -282,10 +283,14 @@ export function ConfigMapDrillDown({ data }: Props) {
                 ergonomic than the per-key dance, but we keep the per-key
                 buttons too for the case where a single sensitive value
                 hides among harmless ones. */}
+            {/* #6231: warning text now reflects the current revealAll
+                state instead of always saying "hidden by default". */}
             <div className="p-3 rounded-lg bg-yellow-500/10 border border-yellow-500/20 text-sm text-yellow-400 flex items-center justify-between gap-2">
               <div className="flex items-center gap-2">
                 <Lock className="w-4 h-4" />
-                ConfigMap values are hidden by default. Click the eye icon to reveal.
+                {revealAll
+                  ? 'ConfigMap values are visible. Click "Mask all" to hide.'
+                  : 'ConfigMap values are hidden by default. Click the eye icon to reveal.'}
               </div>
               <button
                 onClick={() => setRevealAll(v => !v)}
@@ -381,7 +386,7 @@ export function ConfigMapDrillDown({ data }: Props) {
             {/* #6211: same masking model the Data tab uses, applied to the
                 YAML view so that tab isn't a bypass for the per-key reveal.
                 ConfigMap YAML uses the same `data:` block shape as Secret
-                YAML, so we share the maskSecretYaml() helper. */}
+                YAML, so we share the maskKubernetesYamlData() helper. */}
             <div className="p-3 rounded-lg bg-yellow-500/10 border border-yellow-500/20 text-sm text-yellow-400 flex items-center gap-2">
               <Lock className="w-4 h-4" />
               {revealAll
@@ -396,7 +401,7 @@ export function ConfigMapDrillDown({ data }: Props) {
             ) : yamlOutput ? (
               <div className="relative">
                 {(() => {
-                  const displayedYaml = revealAll ? yamlOutput : maskSecretYaml(yamlOutput)
+                  const displayedYaml = revealAll ? yamlOutput : maskKubernetesYamlData(yamlOutput)
                   return (
                     <>
                       <button

--- a/web/src/components/drilldown/views/SecretDrillDown.tsx
+++ b/web/src/components/drilldown/views/SecretDrillDown.tsx
@@ -15,87 +15,15 @@ interface Props {
 
 type TabType = 'overview' | 'data' | 'describe' | 'yaml'
 
-/** Sentinel string used in place of secret values when the YAML tab is
- * masked. Same width as the per-key reveal placeholder on the Data tab so
- * masked YAML and masked Data look consistent. */
-const YAML_MASK_PLACEHOLDER = '••••••••••••••••'
-
-/**
- * Mask the `data:` block of `kubectl get secret -o yaml` output (#6209).
- *
- * `kubectl get secret -o yaml` always emits the data block as:
- *
- *   data:
- *     password: cGFzczEyMw==
- *     username: dXNlcg==
- *   kind: Secret
- *
- * That is — the `data:` line at indent 0, child entries at a deeper indent,
- * and the block ends as soon as a sibling/parent key appears at the same or
- * shallower indent than `data:`. We replace each child value with the
- * placeholder while preserving the key name (so users can still see WHAT
- * keys exist) and the surrounding YAML structure (so the document remains
- * parseable for the eye).
- *
- * Also masks `stringData:` (kubectl emits this for secrets created with
- * stringData) by the same rule.
- *
- * Regex-based intentionally — pulling in a YAML parser just for this would
- * bloat the bundle and introduce parser ambiguity around the multi-document
- * separator. The format from kubectl is stable and the test in
- * SecretDrillDown.test.tsx pins it.
- */
-export function maskSecretYaml(yaml: string): string {
-  if (!yaml) return yaml
-  const lines = yaml.split('\n')
-  const out: string[] = []
-  let inSensitiveBlock = false
-  let blockIndent = -1
-  for (const line of lines) {
-    // Detect the start of a sensitive block. The block header itself is
-    // emitted unchanged.
-    const blockHeaderMatch = line.match(/^(\s*)(data|stringData):\s*$/)
-    if (blockHeaderMatch) {
-      out.push(line)
-      inSensitiveBlock = true
-      blockIndent = blockHeaderMatch[1].length
-      continue
-    }
-    if (inSensitiveBlock) {
-      // Empty line — pass through, stay inside the block.
-      if (line.trim().length === 0) {
-        out.push(line)
-        continue
-      }
-      // Compute the indent of this line. If it's <= blockIndent and not
-      // empty, we've left the data block.
-      const indentMatch = line.match(/^(\s*)/)
-      const lineIndent = indentMatch ? indentMatch[1].length : 0
-      if (lineIndent <= blockIndent) {
-        inSensitiveBlock = false
-        blockIndent = -1
-        out.push(line)
-        continue
-      }
-      // Inside the block — mask the value, preserve the key. Match
-      //   <indent><key>: <value>
-      // The value can be a simple scalar, a quoted string, or absent (for
-      // a multiline `|` or `>` indicator on the next line). We only mask
-      // single-line scalar form, which is what kubectl emits.
-      const kvMatch = line.match(/^(\s*)([^:]+):\s*(.+)$/)
-      if (kvMatch) {
-        out.push(`${kvMatch[1]}${kvMatch[2]}: ${YAML_MASK_PLACEHOLDER}`)
-      } else {
-        // Defensive: line doesn't look like a key-value (could be a `|`
-        // continuation). Mask the entire content side to be safe.
-        out.push(`${' '.repeat(blockIndent + 2)}${YAML_MASK_PLACEHOLDER}`)
-      }
-      continue
-    }
-    out.push(line)
-  }
-  return out.join('\n')
-}
+// #6231: the regex-based maskSecretYaml that used to live here had two
+// real bugs (block-scalar handling, false bundle-bloat claim about
+// js-yaml). Replaced by a shared js-yaml-based helper in lib/yamlMask.
+// Re-exported here for backward compat with any importer that might
+// still reference SecretDrillDown.maskSecretYaml; new code should
+// import maskKubernetesYamlData from '../../../lib/yamlMask' directly.
+import { maskKubernetesYamlData } from '../../../lib/yamlMask'
+/** @deprecated use `maskKubernetesYamlData` from `lib/yamlMask` */
+export const maskSecretYaml = maskKubernetesYamlData
 
 export function SecretDrillDown({ data }: Props) {
   const { t } = useTranslation()

--- a/web/src/components/drilldown/views/__tests__/ConfigMapDrillDown.test.tsx
+++ b/web/src/components/drilldown/views/__tests__/ConfigMapDrillDown.test.tsx
@@ -49,10 +49,87 @@ vi.mock('../../../../lib/clipboard', () => ({
 }))
 
 import { ConfigMapDrillDown } from '../ConfigMapDrillDown'
+import { maskKubernetesYamlData } from '../../../../lib/yamlMask'
 
 describe('ConfigMapDrillDown', () => {
   it('renders without crashing', () => {
     const { container } = render(<ConfigMapDrillDown data={{ cluster: 'c1', namespace: 'ns1', configmap: 'cm1' }} />)
     expect(container).toBeTruthy()
+  })
+})
+
+// #6231: ConfigMapDrillDown shares maskKubernetesYamlData with
+// SecretDrillDown for the YAML tab. The full helper test suite lives at
+// lib/__tests__/yamlMask.test.ts; the smoke tests below pin the
+// ConfigMap-specific behaviors that motivated #6211 + #6231.
+describe('ConfigMap YAML masking integration (#6211, #6231)', () => {
+  it('masks ConfigMap data values that may contain secrets-in-config', () => {
+    // Real ConfigMaps routinely hold connection strings, passwords,
+    // TLS certificates etc. The YAML tab must mask these by default.
+    const input = [
+      'apiVersion: v1',
+      'kind: ConfigMap',
+      'metadata:',
+      '  name: app-config',
+      '  namespace: production',
+      'data:',
+      '  database_url: postgresql://admin:hunter2@db.internal/prod',
+      '  redis_url: redis://:supersecret@cache.internal:6379',
+      '  log_level: info',
+    ].join('\n')
+
+    const masked = maskKubernetesYamlData(input)
+
+    // Sensitive values are masked
+    expect(masked).not.toContain('postgresql://admin:hunter2')
+    expect(masked).not.toContain('hunter2')
+    expect(masked).not.toContain('supersecret')
+    // Non-sensitive value (log_level: info) is ALSO masked because we
+    // can't distinguish sensitive from non-sensitive at this layer —
+    // safer to mask everything in data: and let the user reveal.
+    expect(masked).not.toContain('info\n')
+    // But all KEY names are preserved so the user can still see what's there
+    expect(masked).toContain('database_url')
+    expect(masked).toContain('redis_url')
+    expect(masked).toContain('log_level')
+    // ConfigMap metadata is intact
+    expect(masked).toContain('app-config')
+    expect(masked).toContain('production')
+    expect(masked).toContain('ConfigMap')
+  })
+
+  it('correctly masks a ConfigMap with a multi-line block-scalar value', () => {
+    // This is the original #6231 bug — ConfigMaps commonly hold
+    // multi-line config files (nginx.conf, fluentd.conf, certificates).
+    // The previous regex helper would emit malformed YAML for these.
+    const input = [
+      'apiVersion: v1',
+      'kind: ConfigMap',
+      'metadata:',
+      '  name: nginx-config',
+      'data:',
+      '  nginx.conf: |',
+      '    server {',
+      '      listen 80;',
+      '      location / {',
+      '        proxy_pass http://backend;',
+      '      }',
+      '    }',
+      '  port: "80"',
+    ].join('\n')
+
+    const masked = maskKubernetesYamlData(input)
+
+    // None of the nginx config body should leak in any form
+    expect(masked).not.toContain('proxy_pass')
+    expect(masked).not.toContain('http://backend')
+    expect(masked).not.toContain('listen 80')
+    // The output must be valid YAML — re-parse to prove no stray
+    // continuation lines remained.
+    const yamlLib = require('js-yaml')
+    expect(() => yamlLib.load(masked)).not.toThrow()
+    // Both keys still visible
+    expect(masked).toContain('nginx.conf')
+    expect(masked).toContain('port')
   })
 })

--- a/web/src/components/drilldown/views/__tests__/SecretDrillDown.test.tsx
+++ b/web/src/components/drilldown/views/__tests__/SecretDrillDown.test.tsx
@@ -57,92 +57,22 @@ describe('SecretDrillDown', () => {
   })
 })
 
-// #6209: maskSecretYaml replaces values inside `data:` and `stringData:`
-// blocks with a placeholder, while preserving keys, surrounding YAML
-// structure, and any sibling top-level keys.
-describe('maskSecretYaml (#6209)', () => {
-  const PLACEHOLDER = '••••••••••••••••'
-
-  it('masks values inside the data: block', () => {
-    const yaml = [
+// #6231: the regex-based maskSecretYaml that used to be pinned here was
+// replaced by a shared js-yaml-based helper in lib/yamlMask. The full
+// behavioral test suite (block scalars, multi-doc, parse-failure
+// sentinel, etc.) lives at lib/__tests__/yamlMask.test.ts. The
+// re-export from SecretDrillDown is kept for backward compat and is
+// smoke-tested below to confirm the alias still resolves.
+describe('maskSecretYaml backwards-compat re-export (#6231)', () => {
+  it('aliases the shared maskKubernetesYamlData helper', () => {
+    const input = [
       'apiVersion: v1',
       'kind: Secret',
-      'metadata:',
-      '  name: my-secret',
       'data:',
       '  password: cGFzczEyMw==',
-      '  username: dXNlcg==',
-      'type: Opaque',
     ].join('\n')
-    const masked = maskSecretYaml(yaml)
+    const masked = maskSecretYaml(input)
     expect(masked).not.toContain('cGFzczEyMw==')
-    expect(masked).not.toContain('dXNlcg==')
-    expect(masked).toContain(`password: ${PLACEHOLDER}`)
-    expect(masked).toContain(`username: ${PLACEHOLDER}`)
-    // Surrounding YAML preserved
-    expect(masked).toContain('apiVersion: v1')
-    expect(masked).toContain('kind: Secret')
-    expect(masked).toContain('  name: my-secret')
-    expect(masked).toContain('type: Opaque')
-  })
-
-  it('masks values inside the stringData: block', () => {
-    const yaml = [
-      'apiVersion: v1',
-      'kind: Secret',
-      'stringData:',
-      '  api-key: super-secret',
-      'kind: Secret',
-    ].join('\n')
-    const masked = maskSecretYaml(yaml)
-    expect(masked).not.toContain('super-secret')
-    expect(masked).toContain(`api-key: ${PLACEHOLDER}`)
-  })
-
-  it('does not mask keys outside the data block', () => {
-    const yaml = [
-      'metadata:',
-      '  name: my-secret',
-      '  labels:',
-      '    app: web',
-      'data:',
-      '  password: aGVsbG8=',
-    ].join('\n')
-    const masked = maskSecretYaml(yaml)
-    // metadata.name and metadata.labels.app should be untouched
-    expect(masked).toContain('name: my-secret')
-    expect(masked).toContain('app: web')
-    expect(masked).toContain(`password: ${PLACEHOLDER}`)
-  })
-
-  it('handles a secret with no data block (empty/well-formed pass-through)', () => {
-    const yaml = [
-      'apiVersion: v1',
-      'kind: Secret',
-      'metadata:',
-      '  name: empty',
-      'type: Opaque',
-    ].join('\n')
-    expect(maskSecretYaml(yaml)).toBe(yaml)
-  })
-
-  it('returns empty string unchanged', () => {
-    expect(maskSecretYaml('')).toBe('')
-  })
-
-  it('exits the data block when a sibling top-level key appears', () => {
-    const yaml = [
-      'data:',
-      '  password: secret1',
-      '  username: secret2',
-      'metadata:',
-      '  name: should-not-mask',
-      'type: Opaque',
-    ].join('\n')
-    const masked = maskSecretYaml(yaml)
-    expect(masked).toContain(`password: ${PLACEHOLDER}`)
-    expect(masked).toContain(`username: ${PLACEHOLDER}`)
-    // metadata.name is OUTSIDE the data block — must remain visible
-    expect(masked).toContain('name: should-not-mask')
+    expect(masked).toContain('••••••••••••••••')
   })
 })

--- a/web/src/lib/__tests__/yamlMask.test.ts
+++ b/web/src/lib/__tests__/yamlMask.test.ts
@@ -1,0 +1,222 @@
+import { describe, it, expect } from 'vitest'
+import { maskKubernetesYamlData, YAML_MASK_PLACEHOLDER } from '../yamlMask'
+
+/**
+ * Pin behavior of the resource-agnostic Kubernetes YAML masker.
+ * Replaces the earlier regex-based pinning in SecretDrillDown.test.tsx.
+ *
+ * Particularly important: the block-scalar correctness bug from #6231
+ * which the previous regex-based helper failed on (it would mask the
+ * key: line into a single-line scalar but still emit indented
+ * continuation lines that no longer belonged to any key).
+ */
+describe('maskKubernetesYamlData', () => {
+  it('masks values inside the data: block', () => {
+    const input = [
+      'apiVersion: v1',
+      'kind: Secret',
+      'metadata:',
+      '  name: my-secret',
+      'data:',
+      '  password: cGFzczEyMw==',
+      '  username: dXNlcg==',
+      'type: Opaque',
+      '',
+    ].join('\n')
+
+    const masked = maskKubernetesYamlData(input)
+
+    expect(masked).not.toContain('cGFzczEyMw==')
+    expect(masked).not.toContain('dXNlcg==')
+    expect(masked).toContain(YAML_MASK_PLACEHOLDER)
+    // Surrounding YAML preserved (parser may reformat slightly)
+    expect(masked).toContain('apiVersion: v1')
+    expect(masked).toContain('kind: Secret')
+    expect(masked).toContain('my-secret')
+    expect(masked).toContain('Opaque')
+    // Both keys present in the masked output
+    expect(masked).toContain('password')
+    expect(masked).toContain('username')
+  })
+
+  it('masks values inside the stringData: block', () => {
+    const input = [
+      'apiVersion: v1',
+      'kind: Secret',
+      'stringData:',
+      '  api-key: super-secret-12345',
+      '  api-key-2: another-very-secret-value',
+      'type: Opaque',
+    ].join('\n')
+
+    const masked = maskKubernetesYamlData(input)
+
+    expect(masked).not.toContain('super-secret-12345')
+    expect(masked).not.toContain('another-very-secret-value')
+    expect(masked).toContain(YAML_MASK_PLACEHOLDER)
+    expect(masked).toContain('api-key')
+  })
+
+  it('correctly masks block-scalar values (| literal) — #6231', () => {
+    // The KEY bug from #6231: the previous regex would mask the
+    // `cert: |` line into a single-line scalar but still emit (masked)
+    // continuation lines, leaving stray content.
+    const input = [
+      'apiVersion: v1',
+      'kind: Secret',
+      'data:',
+      '  cert: |',
+      '    -----BEGIN CERTIFICATE-----',
+      '    MIIBkTCB+wIJAJ...',
+      '    -----END CERTIFICATE-----',
+      'type: Opaque',
+    ].join('\n')
+
+    const masked = maskKubernetesYamlData(input)
+
+    // The certificate body must NOT appear in any form (raw or masked)
+    expect(masked).not.toContain('BEGIN CERTIFICATE')
+    expect(masked).not.toContain('MIIBkTCB')
+    expect(masked).not.toContain('END CERTIFICATE')
+    // The output must still be parseable as valid YAML — re-parse it
+    // to prove no stray indented lines were emitted.
+    expect(() => {
+      const yaml = require('js-yaml')
+      yaml.load(masked)
+    }).not.toThrow()
+    // Key name preserved
+    expect(masked).toContain('cert')
+    expect(masked).toContain(YAML_MASK_PLACEHOLDER)
+  })
+
+  it('correctly masks folded block scalar (> indicator)', () => {
+    const input = [
+      'data:',
+      '  message: >',
+      '    this is a folded',
+      '    multi-line value',
+      '    that should be masked',
+      'kind: Secret',
+    ].join('\n')
+
+    const masked = maskKubernetesYamlData(input)
+
+    expect(masked).not.toContain('this is a folded')
+    expect(masked).not.toContain('multi-line value')
+    expect(masked).not.toContain('should be masked')
+    expect(masked).toContain('message')
+    expect(masked).toContain(YAML_MASK_PLACEHOLDER)
+  })
+
+  it('does not mask keys outside the data block', () => {
+    const input = [
+      'metadata:',
+      '  name: my-secret',
+      '  labels:',
+      '    app: web',
+      '    tier: frontend',
+      'data:',
+      '  password: aGVsbG8=',
+    ].join('\n')
+
+    const masked = maskKubernetesYamlData(input)
+
+    expect(masked).toContain('my-secret')
+    expect(masked).toContain('app')
+    expect(masked).toContain('web')
+    expect(masked).toContain('frontend')
+    expect(masked).not.toContain('aGVsbG8=')
+  })
+
+  it('handles a resource with no data block (pass-through)', () => {
+    const input = [
+      'apiVersion: v1',
+      'kind: Secret',
+      'metadata:',
+      '  name: empty',
+      'type: Opaque',
+    ].join('\n')
+
+    const masked = maskKubernetesYamlData(input)
+
+    // No data → no masking → output is parseable and contains the
+    // same key info (parser may reformat, so don't assert byte-equal)
+    expect(masked).toContain('empty')
+    expect(masked).toContain('Opaque')
+    expect(masked).not.toContain(YAML_MASK_PLACEHOLDER)
+  })
+
+  it('returns empty string unchanged', () => {
+    expect(maskKubernetesYamlData('')).toBe('')
+  })
+
+  it('returns the parse-failure sentinel for malformed YAML (security default-deny)', () => {
+    // Deliberately malformed — js-yaml will reject this. The helper
+    // MUST NOT return the raw input; instead it must return a sentinel
+    // that hides the content so a parse failure cannot leak secrets.
+    const input = [
+      'data:',
+      '  password: cGFzczEyMw==',
+      '  username: not closed "',
+      ': : : : invalid',
+    ].join('\n')
+
+    const masked = maskKubernetesYamlData(input)
+
+    expect(masked).not.toContain('cGFzczEyMw==')
+    expect(masked).toContain(YAML_MASK_PLACEHOLDER)
+    // Sentinel includes a comment explaining what happened
+    expect(masked).toContain('parse error')
+  })
+
+  it('works for ConfigMap data blocks (same field name as Secret)', () => {
+    const input = [
+      'apiVersion: v1',
+      'kind: ConfigMap',
+      'metadata:',
+      '  name: app-config',
+      'data:',
+      '  database_url: postgresql://user:pass@host/db',
+      '  api_endpoint: https://api.example.com',
+    ].join('\n')
+
+    const masked = maskKubernetesYamlData(input)
+
+    expect(masked).not.toContain('postgresql://user:pass@host/db')
+    expect(masked).not.toContain('https://api.example.com')
+    expect(masked).toContain('database_url')
+    expect(masked).toContain('api_endpoint')
+    expect(masked).toContain(YAML_MASK_PLACEHOLDER)
+    expect(masked).toContain('app-config')
+  })
+
+  it('handles multi-document YAML', () => {
+    const input = [
+      'apiVersion: v1',
+      'kind: Secret',
+      'metadata:',
+      '  name: secret-1',
+      'data:',
+      '  key1: dmFsdWUx',
+      '---',
+      'apiVersion: v1',
+      'kind: Secret',
+      'metadata:',
+      '  name: secret-2',
+      'data:',
+      '  key2: dmFsdWUy',
+    ].join('\n')
+
+    const masked = maskKubernetesYamlData(input)
+
+    expect(masked).not.toContain('dmFsdWUx')
+    expect(masked).not.toContain('dmFsdWUy')
+    // Both documents masked, both names preserved
+    expect(masked).toContain('secret-1')
+    expect(masked).toContain('secret-2')
+    expect(masked).toContain('key1')
+    expect(masked).toContain('key2')
+    // Multi-doc separator preserved
+    expect(masked).toContain('---')
+  })
+})

--- a/web/src/lib/yamlMask.ts
+++ b/web/src/lib/yamlMask.ts
@@ -1,0 +1,133 @@
+/**
+ * Resource-agnostic YAML masking for Kubernetes drilldown views.
+ *
+ * Originally written inline in `SecretDrillDown.tsx` as a regex
+ * (`maskSecretYaml`) to mask the `data:` block in `kubectl get secret -o
+ * yaml` output. PR #6218 reused that helper for ConfigMaps; #6231 then
+ * caught two real bugs in the regex approach:
+ *
+ *   1. Block-scalar values (`key: |` / `key: >`) produced malformed
+ *      output. The regex masked the `key:` line into a single-line
+ *      scalar but then still emitted (masked) continuation lines,
+ *      leaving stray indented lines that no longer belonged to any key.
+ *   2. The regex doc claimed a YAML parser would "bloat the bundle",
+ *      but `js-yaml` is already a project dependency
+ *      (`web/src/lib/missions/fileParser.ts`,
+ *      `web/src/components/cards/WorkloadImportDialog.tsx`,
+ *      `web/src/components/missions/ShareMissionDialog.tsx`).
+ *
+ * This module replaces the regex with a `js-yaml`-based parse → walk →
+ * dump pipeline that:
+ *
+ *   - Correctly masks every key in `data:` and `stringData:` regardless
+ *     of whether the value is a single-line scalar, a `|` block scalar,
+ *     a `>` folded scalar, a quoted string, or a multi-line value.
+ *   - Preserves keys (so users can still see WHAT is in the resource)
+ *     and surrounding YAML structure (metadata, type, kind, etc.).
+ *   - Handles multi-document YAML (`---` separator) by walking each
+ *     document independently — useful for `kubectl get secret -o yaml`
+ *     when called against multiple secrets.
+ *   - Falls back to a hard-mask sentinel ("# masking parse error — full
+ *     content hidden") if `js-yaml` rejects the input. **This is
+ *     deliberate**: a parse failure on a security-critical helper must
+ *     never silently expose secrets, so we err on the side of hiding
+ *     everything.
+ *
+ * Reused by `SecretDrillDown.tsx` and `ConfigMapDrillDown.tsx`. Pinned
+ * by tests in `__tests__/yamlMask.test.ts`.
+ */
+
+import yaml from 'js-yaml'
+
+/** Sentinel string used in place of secret values when masking. Same
+ * width as the per-key reveal placeholder on the Data tabs so masked
+ * YAML and masked Data look consistent. */
+export const YAML_MASK_PLACEHOLDER = '••••••••••••••••'
+
+/** Hard-mask sentinel returned when js-yaml fails to parse the input.
+ * Comment-prefixed so the user sees an explanation in place of the
+ * real document. */
+const PARSE_FAILURE_SENTINEL = `# masking parse error — full content hidden\n${YAML_MASK_PLACEHOLDER}\n`
+
+/** Top-level field names whose values should be masked when rendering
+ * a Kubernetes resource. Both `data` and `stringData` are valid for
+ * Secrets; ConfigMaps use `data`. */
+const SENSITIVE_FIELDS: ReadonlySet<string> = new Set(['data', 'stringData'])
+
+/** Walk one parsed YAML document and replace every value inside the
+ * sensitive top-level fields with the placeholder. Mutates `doc` in
+ * place and returns it for convenience. The walk only descends one
+ * level past `data:` / `stringData:` because Kubernetes Secret and
+ * ConfigMap data fields are flat string→string maps. */
+function maskSensitiveFields(doc: unknown): unknown {
+  if (doc == null || typeof doc !== 'object' || Array.isArray(doc)) {
+    return doc
+  }
+  const obj = doc as Record<string, unknown>
+  for (const field of SENSITIVE_FIELDS) {
+    const block = obj[field]
+    if (block != null && typeof block === 'object' && !Array.isArray(block)) {
+      const masked: Record<string, string> = {}
+      for (const key of Object.keys(block as Record<string, unknown>)) {
+        masked[key] = YAML_MASK_PLACEHOLDER
+      }
+      obj[field] = masked
+    }
+  }
+  return obj
+}
+
+/**
+ * Mask the `data:` and `stringData:` blocks of a Kubernetes resource
+ * YAML document, returning a redumped YAML string with values
+ * replaced by the placeholder.
+ *
+ * Used by both Secret and ConfigMap drilldown YAML tabs. Replaces the
+ * earlier regex-based `maskSecretYaml` (#6231).
+ *
+ * @param yamlInput  Raw YAML from `kubectl get <resource> -o yaml`.
+ * @returns          Masked YAML, or a hard-mask sentinel if parsing
+ *                   fails. Empty input returns empty.
+ */
+export function maskKubernetesYamlData(yamlInput: string): string {
+  if (!yamlInput) return yamlInput
+
+  let docs: unknown[]
+  try {
+    // loadAll handles multi-document YAML transparently — single docs
+    // come back as a 1-element array. Use the safe loader (default in
+    // js-yaml v4) to avoid arbitrary code execution from custom tags.
+    docs = yaml.loadAll(yamlInput)
+  } catch {
+    // Parse failure on a security helper must never silently expose
+    // secrets — return the hard-mask sentinel so the user sees an
+    // explicit "this could not be safely masked" message.
+    return PARSE_FAILURE_SENTINEL
+  }
+
+  if (docs.length === 0) return yamlInput
+
+  try {
+    const maskedDocs = docs.map(maskSensitiveFields)
+    // dumpAll for multi-doc, single dump for single-doc, so we don't
+    // emit a stray `---` for single-resource YAML.
+    if (maskedDocs.length === 1) {
+      return yaml.dump(maskedDocs[0], {
+        // noRefs avoids emitting `&anchor` references for repeated
+        // values; the placeholder is repeated by design and we don't
+        // want kubectl-style YAML cluttered with `&id001`.
+        noRefs: true,
+        // lineWidth -1 keeps long values on one line so the masked
+        // output stays compact.
+        lineWidth: -1,
+      })
+    }
+    return maskedDocs
+      .map(d =>
+        yaml.dump(d, { noRefs: true, lineWidth: -1 }),
+      )
+      .join('---\n')
+  } catch {
+    return PARSE_FAILURE_SENTINEL
+  }
+}

--- a/web/src/test/ui-ux-standards.test.ts
+++ b/web/src/test/ui-ux-standards.test.ts
@@ -55,7 +55,7 @@ const COMPONENTS_DIR = path.resolve(
 // regex matches `#NNNN` as a hex literal, but these are GitHub issue
 // references in code comments, not color literals. Same scoped-bump rationale
 // as the prior 273→278 increment.
-const EXPECTED_RAW_HEX_COUNT = 287
+const EXPECTED_RAW_HEX_COUNT = 288
 const EXPECTED_RAW_RGBA_COUNT = 104
 const EXPECTED_ARBITRARY_TW_COLOR_COUNT = 22
 const EXPECTED_INLINE_STYLE_COLOR_COUNT = 213


### PR DESCRIPTION
## Summary

Copilot review on **#6218** caught 5 issues with the regex-based `maskSecretYaml` I shipped, including two real correctness bugs. This PR addresses all 5.

### The bugs

1. **Block-scalar values produced malformed output.** The regex masked `key: |` into a single-line scalar but still emitted (masked) continuation lines, leaving stray indented content that no longer belonged to any key. ConfigMaps routinely hold multi-line config (nginx.conf, fluentd.conf, certificates).
2. **False premise about bundle size.** I wrote that a YAML parser would 'bloat the bundle', but `js-yaml` is **already** a project dep — used by `fileParser.ts`, `WorkloadImportDialog.tsx`, `ShareMissionDialog.tsx`. Verified.
3. **Cross-view import coupling.** `ConfigMapDrillDown` imported `maskSecretYaml` from `SecretDrillDown`, coupling the two views and making the helper name misleading.
4. **ConfigMap warning text was always 'hidden by default'** even when `revealAll` was enabled.
5. **The PR body claimed ConfigMap tests** that didn't exist.

### Files

| File | Change |
|---|---|
| `web/src/lib/yamlMask.ts` (NEW) | Shared `maskKubernetesYamlData(yaml)` using `js-yaml.loadAll` → walk → dump. Handles single-line + `\|` + `>` + quoted + multi-line + multi-document YAML. **Default-deny on parse failure** — returns a hard-mask sentinel because a parser failure must NEVER silently expose secrets. |
| `web/src/lib/__tests__/yamlMask.test.ts` (NEW) | 10 test cases. Block-scalar test specifically re-parses the masked output to prove no stray lines remained. |
| `SecretDrillDown.tsx` | Removed inline regex; re-exports `maskKubernetesYamlData` under the old name with `@deprecated` for backward compat. |
| `ConfigMapDrillDown.tsx` | Imports from `lib/yamlMask` directly. Warning text flips between 'hidden'/'visible' based on `revealAll`. |
| `SecretDrillDown.test.tsx` | Dropped regex-pinned tests; kept a smoke test on the alias. |
| `ConfigMapDrillDown.test.tsx` | Added the tests the original PR body claimed: masks ConfigMap DSNs/URLs, and the block-scalar nginx.conf case that proves the #6231 bug is fixed. |

## Test plan

- [x] `npm run build` passes locally
- [x] 15 tests pass across the 3 affected test files
- [x] Block-scalar test re-parses the masked output to confirm no stray indented continuation lines

Closes #6231.