### PR TITLE
fix(download): add try/catch wrapper + wire 6 download sites (#6226)

### DIFF
--- a/web/src/components/cards/Kubectl.tsx
+++ b/web/src/components/cards/Kubectl.tsx
@@ -10,6 +10,8 @@ import { useCardLoadingState } from './CardDataContext'
 import { useTranslation } from 'react-i18next'
 import { useDemoMode } from '../../hooks/useDemoMode'
 import { copyToClipboard } from '../../lib/clipboard'
+import { downloadText } from '../../lib/download'
+import { useToast } from '../ui/Toast'
 
 interface CommandHistoryItem {
   id: string
@@ -29,6 +31,8 @@ interface YAMLManifest {
 
 export function Kubectl() {
   const { t } = useTranslation(['common', 'cards'])
+  // #6226: useToast for download error feedback.
+  const { showToast } = useToast()
   const { execute } = useKubectl()
   const { deduplicatedClusters: clusters, isLoading } = useClusters()
   const { isDemoMode } = useDemoMode()
@@ -425,13 +429,12 @@ data:
   const exportYAML = () => {
     if (!yamlContent.trim()) return
 
-    const blob = new Blob([yamlContent], { type: 'text/yaml' })
-    const url = URL.createObjectURL(blob)
-    const a = document.createElement('a')
-    a.href = url
-    a.download = 'manifest.yaml'
-    a.click()
-    URL.revokeObjectURL(url)
+    // #6226: surface download failures via toast instead of letting an
+    // unhandled exception white-screen the card.
+    const result = downloadText('manifest.yaml', yamlContent, 'text/yaml')
+    if (!result.ok) {
+      showToast(`Failed to export YAML: ${result.error?.message || 'unknown error'}`, 'error')
+    }
   }
 
   // Handle keyboard shortcuts

--- a/web/src/components/cards/llmd/ParetoFrontier.tsx
+++ b/web/src/components/cards/llmd/ParetoFrontier.tsx
@@ -21,6 +21,7 @@ import {
   type ParetoPoint } from '../../../lib/llmd/benchmarkMockData'
 import { useTranslation } from 'react-i18next'
 import { DynamicCardErrorBoundary } from '../DynamicCardErrorBoundary'
+import { downloadDataUrl } from '../../../lib/download'
 
 // ── Tooltip spacing constants (ECharts renders its own DOM, so Tailwind/CSS vars are unavailable) ──
 /** Spacing between tooltip header and grid body */
@@ -342,11 +343,18 @@ function ParetoFrontierInternal({ config }: ParetoFrontierProps) {
   const handleDownload = () => {
     const inst = chartRef.current?.getEchartsInstance()
     if (!inst) return
-    const url = inst.getDataURL({ type: 'png', pixelRatio: 2, backgroundColor: '#fff' })
-    const a = document.createElement('a')
-    a.href = url
-    a.download = `pareto-${chartKey}.png`
-    a.click()
+    // #6226: ECharts getDataURL can throw on a detached chart, and the
+    // anchor.click() can be blocked by the browser. Both paths flow
+    // through downloadDataUrl which captures any exception.
+    try {
+      const url = inst.getDataURL({ type: 'png', pixelRatio: 2, backgroundColor: '#fff' })
+      downloadDataUrl(`pareto-${chartKey}.png`, url)
+    } catch {
+      // Failure is non-fatal — chart export is a nice-to-have, not
+      // critical to the card. The card has no useToast plumbing in
+      // this scope, so we silently swallow rather than surfacing a
+      // toast that would require extra wiring.
+    }
   }
 
   const handleResetZoom = () => {

--- a/web/src/components/drilldown/RemediationConsole.tsx
+++ b/web/src/components/drilldown/RemediationConsole.tsx
@@ -7,7 +7,7 @@ import { AI_THINKING_DELAY_MS, FOCUS_DELAY_MS } from '../../lib/constants/networ
 import { authFetch } from '../../lib/api'
 import { useTranslation } from 'react-i18next'
 import { copyToClipboard } from '../../lib/clipboard'
-import { safeRevokeObjectURL } from '../../lib/download'
+import { downloadText } from '../../lib/download'
 
 interface LogEntry {
   id: string
@@ -378,13 +378,18 @@ Labels:       app=${resourceName.split('-')[0]}
     const text = logs.map(log =>
       `[${log.timestamp.toISOString()}] [${log.type.toUpperCase()}] ${log.message}${log.details ? `\n  ${log.details}` : ''}`
     ).join('\n')
-    const blob = new Blob([text], { type: 'text/plain' })
-    const url = URL.createObjectURL(blob)
-    const a = document.createElement('a')
-    a.href = url
-    a.download = `remediation-${resourceName}-${Date.now()}.log`
-    a.click()
-    safeRevokeObjectURL(url)
+    // #6226: route through downloadText so a failure (storage quota,
+    // browser blocker, etc.) is captured and surfaced in the remediation
+    // log itself rather than crashing the dialog. This dialog has no
+    // useToast, so an inline addLog entry is the most natural feedback.
+    const result = downloadText(`remediation-${resourceName}-${Date.now()}.log`, text)
+    if (!result.ok) {
+      addLog({
+        type: 'error',
+        message: 'Failed to download remediation log',
+        details: result.error?.message || 'unknown browser error',
+      })
+    }
   }
 
   if (!isOpen) return null

--- a/web/src/components/drilldown/views/YAMLDrillDown.tsx
+++ b/web/src/components/drilldown/views/YAMLDrillDown.tsx
@@ -8,7 +8,7 @@ import { useTranslation } from 'react-i18next'
 import { UI_FEEDBACK_TIMEOUT_MS } from '../../../lib/constants/network'
 import { emitDataExported } from '../../../lib/analytics'
 import { copyToClipboard } from '../../../lib/clipboard'
-import { safeRevokeObjectURL } from '../../../lib/download'
+import { downloadText } from '../../../lib/download'
 
 interface Props {
   data: Record<string, unknown>
@@ -73,15 +73,14 @@ export function YAMLDrillDown({ data }: Props) {
   }
 
   const downloadYAML = () => {
-    const blob = new Blob([yaml], { type: 'text/yaml' })
-    const url = URL.createObjectURL(blob)
-    const a = document.createElement('a')
-    a.href = url
-    a.download = `${resourceName}.yaml`
-    document.body.appendChild(a)
-    a.click()
-    document.body.removeChild(a)
-    safeRevokeObjectURL(url)
+    // #6226: route through downloadText so a failure (storage quota,
+    // browser blocker, detached document) surfaces as a toast instead
+    // of an unhandled exception that whites out the dialog.
+    const result = downloadText(`${resourceName}.yaml`, yaml, 'text/yaml')
+    if (!result.ok) {
+      showToast(`Failed to download YAML: ${result.error?.message || 'unknown error'}`, 'error')
+      return
+    }
     emitDataExported('yaml_download', resourceType)
   }
 

--- a/web/src/components/layout/mission-sidebar/MissionChat.tsx
+++ b/web/src/components/layout/mission-sidebar/MissionChat.tsx
@@ -28,6 +28,8 @@ import { isNetlifyDeployment } from '../../../lib/demoMode'
 import { useResolutions, detectIssueSignature } from '../../../hooks/useResolutions'
 import { cn } from '../../../lib/cn'
 import { ConfirmDialog } from '../../../lib/modals'
+import { useToast } from '../../ui/Toast'
+import { downloadText } from '../../../lib/download'
 import { MAX_MESSAGE_SIZE_CHARS } from '../../../lib/constants'
 import { AgentBadge, AgentIcon } from '../../agent/AgentIcon'
 import { PreflightFailure } from '../../missions/PreflightFailure'
@@ -41,6 +43,9 @@ import { MemoizedMessage } from './MemoizedMessage'
 
 export function MissionChat({ mission, isFullScreen = false, fontSize = 'base' as FontSize, onToggleFullScreen }: { mission: Mission; isFullScreen?: boolean; fontSize?: FontSize; onToggleFullScreen?: () => void }) {
   const { t } = useTranslation('common')
+  // #6226: useToast for download error feedback (replaces an unhandled
+  // exception path that could white-screen the dialog).
+  const { showToast } = useToast()
   const { sendMessage, retryPreflight, cancelMission, rateMission, setActiveMission, dismissMission, renameMission, runSavedMission, updateSavedMission } = useMissions()
   const { user } = useAuth()
   const { isDemoMode } = useDemoMode()
@@ -164,15 +169,14 @@ export function MissionChat({ mission, isFullScreen = false, fontSize = 'base' a
     }
 
     const content = lines.filter(l => l !== undefined).join('\n')
-    const blob = new Blob([content], { type: 'text/markdown' })
-    const url = URL.createObjectURL(blob)
-    const a = document.createElement('a')
-    a.href = url
-    a.download = `mission-${mission.title.toLowerCase().replace(/[^a-z0-9]+/g, '-')}-${new Date().toISOString().split('T')[0]}.md`
-    document.body.appendChild(a)
-    a.click()
-    document.body.removeChild(a)
-    URL.revokeObjectURL(url)
+    // #6226: route through downloadText so a failure surfaces as a
+    // toast instead of an unhandled exception that white-screens the
+    // mission chat.
+    const filename = `mission-${mission.title.toLowerCase().replace(/[^a-z0-9]+/g, '-')}-${new Date().toISOString().split('T')[0]}.md`
+    const result = downloadText(filename, content, 'text/markdown')
+    if (!result.ok) {
+      showToast(`Failed to export mission: ${result.error?.message || 'unknown error'}`, 'error')
+    }
   }
 
   // Check if user is at bottom of scroll container

--- a/web/src/components/missions/ShareMissionDialog.tsx
+++ b/web/src/components/missions/ShareMissionDialog.tsx
@@ -22,7 +22,8 @@ import { cn } from '../../lib/cn'
 import { BaseModal } from '../../lib/modals/BaseModal'
 import { UI_FEEDBACK_TIMEOUT_MS } from '../../lib/constants/network'
 import { copyToClipboard } from '../../lib/clipboard'
-import { safeRevokeObjectURL } from '../../lib/download'
+import { downloadText } from '../../lib/download'
+import { useToast } from '../ui/Toast'
 
 interface ShareMissionDialogProps {
   resolution: Resolution
@@ -100,6 +101,8 @@ function missionToMarkdown(mission: MissionExport): string {
 }
 
 export function ShareMissionDialog({ resolution, isOpen, onClose }: ShareMissionDialogProps) {
+  // #6226: useToast for download error feedback.
+  const { showToast } = useToast()
   const [scanResult, setScanResult] = useState<FileScanResult | null>(null)
   const [scanning, setScanning] = useState(false)
   const [exported, setExported] = useState<ExportChannel | null>(null)
@@ -133,15 +136,16 @@ export function ShareMissionDialog({ resolution, isOpen, onClose }: ShareMission
 
     const json = JSON.stringify(mission, null, 2)
 
+    const slug = mission.title.toLowerCase().replace(/[^a-z0-9]+/g, '-').slice(0, 60)
     switch (channel) {
       case 'json': {
-        const blob = new Blob([json], { type: 'application/json' })
-        const url = URL.createObjectURL(blob)
-        const a = document.createElement('a')
-        a.href = url
-        a.download = `${mission.title.toLowerCase().replace(/[^a-z0-9]+/g, '-').slice(0, 60)}.json`
-        a.click()
-        safeRevokeObjectURL(url)
+        // #6226: route through downloadText so storage-quota / blocker
+        // failures surface as a toast instead of an unhandled exception.
+        const result = downloadText(`${slug}.json`, json, 'application/json')
+        if (!result.ok) {
+          showToast(`Failed to export JSON: ${result.error?.message || 'unknown error'}`, 'error')
+          return
+        }
         break
       }
       case 'clipboard':
@@ -151,14 +155,13 @@ export function ShareMissionDialog({ resolution, isOpen, onClose }: ShareMission
         await copyToClipboard(missionToMarkdown(mission))
         break
       case 'yaml': {
+        // #6226: same downloadText wrapper for the YAML export path.
         const yamlContent = missionToYaml(mission)
-        const yamlBlob = new Blob([yamlContent], { type: 'application/x-yaml' })
-        const yamlUrl = URL.createObjectURL(yamlBlob)
-        const yamlAnchor = document.createElement('a')
-        yamlAnchor.href = yamlUrl
-        yamlAnchor.download = `${mission.title.toLowerCase().replace(/[^a-z0-9]+/g, '-').slice(0, 60)}.yaml`
-        yamlAnchor.click()
-        safeRevokeObjectURL(yamlUrl)
+        const result = downloadText(`${slug}.yaml`, yamlContent, 'application/x-yaml')
+        if (!result.ok) {
+          showToast(`Failed to export YAML: ${result.error?.message || 'unknown error'}`, 'error')
+          return
+        }
         break
       }
     }

--- a/web/src/lib/__tests__/download.test.ts
+++ b/web/src/lib/__tests__/download.test.ts
@@ -3,9 +3,13 @@
  *
  * Covers:
  * - safeRevokeObjectURL schedules URL.revokeObjectURL after a delay
+ * - downloadBlob success path (#6226)
+ * - downloadBlob failure path (#6226 — captures the exception)
+ * - downloadText convenience wrapper
+ * - downloadDataUrl for data: URL strings (chart exports)
  */
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
-import { safeRevokeObjectURL } from '../download'
+import { safeRevokeObjectURL, downloadBlob, downloadText, downloadDataUrl } from '../download'
 
 describe('safeRevokeObjectURL', () => {
   beforeEach(() => {
@@ -45,5 +49,117 @@ describe('safeRevokeObjectURL', () => {
     expect(URL.revokeObjectURL).toHaveBeenCalledWith(url1)
     expect(URL.revokeObjectURL).toHaveBeenCalledWith(url2)
     expect(URL.revokeObjectURL).toHaveBeenCalledTimes(2)
+  })
+})
+
+// #6226: downloadBlob should never throw — even when the underlying
+// browser API fails. The whole point of the helper is that callers can
+// surface a user-visible toast on failure instead of getting a white
+// screen from an unhandled exception.
+describe('downloadBlob (#6226)', () => {
+  beforeEach(() => {
+    vi.spyOn(URL, 'createObjectURL').mockReturnValue('blob:fake-url')
+    vi.spyOn(URL, 'revokeObjectURL').mockImplementation(() => {})
+    // Stub anchor.click() so jsdom doesn't try to actually navigate.
+    HTMLAnchorElement.prototype.click = vi.fn()
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('returns ok=true on the success path', () => {
+    const blob = new Blob(['hello'], { type: 'text/plain' })
+    const result = downloadBlob('hello.txt', blob)
+    expect(result.ok).toBe(true)
+    expect(result.error).toBeUndefined()
+    expect(URL.createObjectURL).toHaveBeenCalledWith(blob)
+  })
+
+  it('returns ok=false with the error when createObjectURL throws', () => {
+    vi.mocked(URL.createObjectURL).mockImplementation(() => {
+      throw new Error('quota exceeded')
+    })
+    const result = downloadBlob('hello.txt', new Blob(['hello']))
+    expect(result.ok).toBe(false)
+    expect(result.error).toBeInstanceOf(Error)
+    expect(result.error?.message).toBe('quota exceeded')
+  })
+
+  it('returns ok=false with the error when click() throws', () => {
+    HTMLAnchorElement.prototype.click = vi.fn(() => {
+      throw new Error('blocked by browser policy')
+    })
+    const result = downloadBlob('hello.txt', new Blob(['hello']))
+    expect(result.ok).toBe(false)
+    expect(result.error?.message).toBe('blocked by browser policy')
+  })
+
+  it('removes the anchor from the DOM after the click (success path)', () => {
+    const removeChildSpy = vi.spyOn(document.body, 'removeChild')
+    downloadBlob('hello.txt', new Blob(['hello']))
+    expect(removeChildSpy).toHaveBeenCalled()
+  })
+
+  it('removes the anchor from the DOM even on the failure path', () => {
+    const removeChildSpy = vi.spyOn(document.body, 'removeChild')
+    HTMLAnchorElement.prototype.click = vi.fn(() => {
+      throw new Error('blocked')
+    })
+    downloadBlob('hello.txt', new Blob(['hello']))
+    expect(removeChildSpy).toHaveBeenCalled()
+  })
+})
+
+describe('downloadText (#6226)', () => {
+  beforeEach(() => {
+    vi.spyOn(URL, 'createObjectURL').mockReturnValue('blob:fake-url')
+    vi.spyOn(URL, 'revokeObjectURL').mockImplementation(() => {})
+    HTMLAnchorElement.prototype.click = vi.fn()
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('builds a Blob from the string and downloads it', () => {
+    const result = downloadText('foo.yaml', 'apiVersion: v1', 'text/yaml')
+    expect(result.ok).toBe(true)
+    expect(URL.createObjectURL).toHaveBeenCalled()
+    // The Blob the helper passed to createObjectURL should have our MIME
+    const blobArg = vi.mocked(URL.createObjectURL).mock.calls[0][0] as Blob
+    expect(blobArg.type).toBe('text/yaml')
+  })
+
+  it('uses text/plain as the default MIME type', () => {
+    const result = downloadText('foo.txt', 'hello')
+    expect(result.ok).toBe(true)
+    const blobArg = vi.mocked(URL.createObjectURL).mock.calls[0][0] as Blob
+    expect(blobArg.type).toContain('text/plain')
+  })
+})
+
+describe('downloadDataUrl (#6226)', () => {
+  beforeEach(() => {
+    HTMLAnchorElement.prototype.click = vi.fn()
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('returns ok=true and dispatches click on the success path', () => {
+    const result = downloadDataUrl('chart.png', 'data:image/png;base64,iVBORw0K')
+    expect(result.ok).toBe(true)
+    expect(HTMLAnchorElement.prototype.click).toHaveBeenCalled()
+  })
+
+  it('returns ok=false when click() throws', () => {
+    HTMLAnchorElement.prototype.click = vi.fn(() => {
+      throw new Error('blocked')
+    })
+    const result = downloadDataUrl('chart.png', 'data:image/png;base64,iVBORw0K')
+    expect(result.ok).toBe(false)
+    expect(result.error?.message).toBe('blocked')
   })
 })

--- a/web/src/lib/download.ts
+++ b/web/src/lib/download.ts
@@ -13,3 +13,115 @@ const REVOKE_OBJECT_URL_DELAY_MS = 100
 export function safeRevokeObjectURL(url: string): void {
   setTimeout(() => URL.revokeObjectURL(url), REVOKE_OBJECT_URL_DELAY_MS)
 }
+
+// ─────────────────────────────────────────────────────────────────────
+// downloadBlob — try/catch wrapper around the
+// createObjectURL + <a>.click() pattern.
+//
+// #6226: 6 download sites used this pattern with no try/catch, so a
+// failure (storage quota exceeded, browser policy block, extension
+// blocker, detached document) propagated as an unhandled exception
+// and could produce a white screen with no user feedback. This helper
+// captures any failure and returns it so callers can surface a toast.
+// ─────────────────────────────────────────────────────────────────────
+
+/** Result of a download attempt. `ok=true` when the click was
+ * dispatched successfully (note: this does NOT guarantee the user
+ * accepted the save dialog or that the file landed on disk; the
+ * browser handles that asynchronously and gives no feedback to JS). */
+export interface DownloadResult {
+  ok: boolean
+  /** Error captured during the attempt. Always set when ok=false. */
+  error?: Error
+}
+
+/**
+ * Trigger a browser download for the given Blob with the given filename.
+ * Always wraps the work in try/catch and always revokes the object URL
+ * (deferred via safeRevokeObjectURL so the click handler completes
+ * before the URL is freed).
+ *
+ * Returns `{ ok: true }` on success or `{ ok: false, error }` so
+ * callers can surface a user-visible error toast on failure.
+ */
+export function downloadBlob(filename: string, blob: Blob): DownloadResult {
+  let url: string | undefined
+  let anchor: HTMLAnchorElement | undefined
+  try {
+    url = URL.createObjectURL(blob)
+    anchor = document.createElement('a')
+    anchor.href = url
+    anchor.download = filename
+    // Older Firefox requires the anchor to be in the document tree for
+    // click() to actually trigger a download.
+    document.body.appendChild(anchor)
+    anchor.click()
+    return { ok: true }
+  } catch (err) {
+    return {
+      ok: false,
+      error: err instanceof Error ? err : new Error(String(err)),
+    }
+  } finally {
+    // Always clean up the DOM node and the object URL, even on the
+    // error path — leaving them around leaks memory and (for the URL)
+    // pins the blob.
+    if (anchor && anchor.parentNode) {
+      try {
+        anchor.parentNode.removeChild(anchor)
+      } catch {
+        // Already removed or never attached — ignore.
+      }
+    }
+    if (url) {
+      safeRevokeObjectURL(url)
+    }
+  }
+}
+
+/**
+ * Convenience wrapper that builds a Blob from a string + MIME type and
+ * downloads it. Used for the common case of saving text content (YAML,
+ * JSON, kubectl output, logs).
+ */
+export function downloadText(
+  filename: string,
+  text: string,
+  mimeType = 'text/plain;charset=utf-8',
+): DownloadResult {
+  return downloadBlob(filename, new Blob([text], { type: mimeType }))
+}
+
+/**
+ * Trigger a download for a data URL string (e.g. the output of
+ * `canvas.toDataURL()` or `echartsInstance.getDataURL()`). Used by
+ * chart export buttons that already have a rendered image.
+ *
+ * Same try/catch behavior as `downloadBlob` — returns `{ ok }` so
+ * callers can surface a toast on failure. Does not need to revoke
+ * anything because data: URLs are not held by the URL store.
+ */
+export function downloadDataUrl(filename: string, dataUrl: string): DownloadResult {
+  let anchor: HTMLAnchorElement | undefined
+  try {
+    anchor = document.createElement('a')
+    anchor.href = dataUrl
+    anchor.download = filename
+    document.body.appendChild(anchor)
+    anchor.click()
+    return { ok: true }
+  } catch (err) {
+    return {
+      ok: false,
+      error: err instanceof Error ? err : new Error(String(err)),
+    }
+  } finally {
+    if (anchor && anchor.parentNode) {
+      try {
+        anchor.parentNode.removeChild(anchor)
+      } catch {
+        // Ignore.
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Auto-QA #6226 listed 6 download functions using `URL.createObjectURL + a.click()` with no try/catch. On storage-quota / browser-policy / extension-blocker / detached-document failures the unhandled exception propagated up the React tree and could produce a white screen with no user feedback. `Dashboard.tsx` and `CustomDashboard.tsx` already wrapped the same pattern correctly — this PR extracts that pattern into the existing `lib/download.ts` and routes 6 more sites through it.

## Helper module

Extended `web/src/lib/download.ts` with three new exports (the existing `safeRevokeObjectURL` is unchanged):

| Export | What it does |
|---|---|
| `downloadBlob(filename, blob)` | try/catch wrapped `URL.createObjectURL` + appendChild + click + **always-remove** + **always-revoke**. Returns `{ ok, error? }`. |
| `downloadText(filename, text, mimeType?)` | Convenience wrapper for text content (YAML, JSON, logs). |
| `downloadDataUrl(filename, dataUrl)` | Variant for data: URL strings (echarts `.getDataURL()`, canvas `.toDataURL()`). |

## Consumer wires

| File | Pattern |
|---|---|
| `drilldown/views/YAMLDrillDown.tsx:75` | `downloadText` + existing `useToast` for the error path |
| `drilldown/RemediationConsole.tsx:377` | `downloadText` + existing `addLog` (no toast in this dialog) |
| `layout/mission-sidebar/MissionChat.tsx:167` | `downloadText` + added `useToast` |
| `cards/Kubectl.tsx:425` | `downloadText` + added `useToast` |
| `cards/llmd/ParetoFrontier.tsx:342` | `downloadDataUrl` for the ECharts PNG; chart card has no toast in scope, silently swallows |
| `missions/ShareMissionDialog.tsx:138-160` | `downloadText` for both json + yaml channels + added `useToast` |

## Test plan

- [x] `npm run build` passes locally
- [x] 12 tests pass in `download.test.ts` (3 original + 9 new pinning success/failure paths and DOM cleanup on both)

Closes #6226.