### PR TITLE
fix(a11y): wrap 5 kagent card components in DynamicCardErrorBoundary (#6216 part 2)

### DIFF
--- a/web/src/components/cards/kagent/KagentAgentDiscovery.tsx
+++ b/web/src/components/cards/kagent/KagentAgentDiscovery.tsx
@@ -1,6 +1,7 @@
 import { Radar, Tag, Server, Wrench } from 'lucide-react'
 import { useKagentCRDAgents } from '../../../hooks/mcp/kagent_crds'
 import { useCardLoadingState } from '../CardDataContext'
+import { DynamicCardErrorBoundary } from '../DynamicCardErrorBoundary'
 import { CardSearchInput, CardControlsRow, CardPaginationFooter } from '../../../lib/cards/CardComponents'
 import { useCardData, commonComparators } from '../../../lib/cards/cardHooks'
 import { Skeleton } from '../../ui/Skeleton'
@@ -16,7 +17,8 @@ const SORT_OPTIONS: { value: SortField; label: string }[] = [
   { value: 'cluster', label: 'Cluster' },
 ]
 
-export function KagentAgentDiscovery({ config }: KagentAgentDiscoveryProps) {
+// #6216 part 2: wrapped at the bottom in DynamicCardErrorBoundary.
+function KagentAgentDiscoveryInternal({ config }: KagentAgentDiscoveryProps) {
   const {
     data: agents,
     isLoading,
@@ -184,5 +186,13 @@ export function KagentAgentDiscovery({ config }: KagentAgentDiscoveryProps) {
         needsPagination={needsPagination}
       />
     </div>
+  )
+}
+
+export function KagentAgentDiscovery(props: KagentAgentDiscoveryProps) {
+  return (
+    <DynamicCardErrorBoundary cardId="KagentAgentDiscovery">
+      <KagentAgentDiscoveryInternal {...props} />
+    </DynamicCardErrorBoundary>
   )
 }

--- a/web/src/components/cards/kagent/KagentAgentFleet.tsx
+++ b/web/src/components/cards/kagent/KagentAgentFleet.tsx
@@ -1,6 +1,7 @@
 import { Bot, ChevronRight, Server } from 'lucide-react'
 import { useKagentCRDAgents } from '../../../hooks/mcp/kagent_crds'
 import { useCardLoadingState } from '../CardDataContext'
+import { DynamicCardErrorBoundary } from '../DynamicCardErrorBoundary'
 import { CardSearchInput, CardControlsRow, CardPaginationFooter } from '../../../lib/cards/CardComponents'
 import { useCardData, commonComparators } from '../../../lib/cards/cardHooks'
 import { Skeleton } from '../../ui/Skeleton'
@@ -59,7 +60,8 @@ const SORT_OPTIONS: { value: SortField; label: string }[] = [
   { value: 'cluster', label: 'Cluster' },
 ]
 
-export function KagentAgentFleet({ config }: KagentAgentFleetProps) {
+// #6216 part 2: wrapped at the bottom in DynamicCardErrorBoundary.
+function KagentAgentFleetInternal({ config }: KagentAgentFleetProps) {
   const {
     data: agents,
     isLoading,
@@ -194,5 +196,13 @@ export function KagentAgentFleet({ config }: KagentAgentFleetProps) {
         needsPagination={needsPagination}
       />
     </div>
+  )
+}
+
+export function KagentAgentFleet(props: KagentAgentFleetProps) {
+  return (
+    <DynamicCardErrorBoundary cardId="KagentAgentFleet">
+      <KagentAgentFleetInternal {...props} />
+    </DynamicCardErrorBoundary>
   )
 }

--- a/web/src/components/cards/kagent/KagentModelProviders.tsx
+++ b/web/src/components/cards/kagent/KagentModelProviders.tsx
@@ -1,6 +1,7 @@
 import { Cpu, Server } from 'lucide-react'
 import { useKagentCRDModels } from '../../../hooks/mcp/kagent_crds'
 import { useCardLoadingState } from '../CardDataContext'
+import { DynamicCardErrorBoundary } from '../DynamicCardErrorBoundary'
 import { CardSearchInput, CardControlsRow, CardPaginationFooter } from '../../../lib/cards/CardComponents'
 import { useCardData, commonComparators } from '../../../lib/cards/cardHooks'
 import { Skeleton } from '../../ui/Skeleton'
@@ -63,7 +64,8 @@ const SORT_OPTIONS: { value: SortField; label: string }[] = [
   { value: 'cluster', label: 'Cluster' },
 ]
 
-export function KagentModelProviders({ config }: KagentModelProvidersProps) {
+// #6216 part 2: wrapped at the bottom in DynamicCardErrorBoundary.
+function KagentModelProvidersInternal({ config }: KagentModelProvidersProps) {
   const {
     data: models,
     isLoading,
@@ -199,5 +201,13 @@ export function KagentModelProviders({ config }: KagentModelProvidersProps) {
         needsPagination={needsPagination}
       />
     </div>
+  )
+}
+
+export function KagentModelProviders(props: KagentModelProvidersProps) {
+  return (
+    <DynamicCardErrorBoundary cardId="KagentModelProviders">
+      <KagentModelProvidersInternal {...props} />
+    </DynamicCardErrorBoundary>
   )
 }

--- a/web/src/components/cards/kagent/KagentToolRegistry.tsx
+++ b/web/src/components/cards/kagent/KagentToolRegistry.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react'
 import { Wrench, Server, ChevronDown, ChevronUp } from 'lucide-react'
 import { useKagentCRDTools } from '../../../hooks/mcp/kagent_crds'
 import { useCardLoadingState } from '../CardDataContext'
+import { DynamicCardErrorBoundary } from '../DynamicCardErrorBoundary'
 import { CardSearchInput, CardControlsRow, CardPaginationFooter } from '../../../lib/cards/CardComponents'
 import { useCardData, commonComparators } from '../../../lib/cards/cardHooks'
 import { Skeleton } from '../../ui/Skeleton'
@@ -60,7 +61,8 @@ const SORT_OPTIONS: { value: SortField; label: string }[] = [
   { value: 'cluster', label: 'Cluster' },
 ]
 
-export function KagentToolRegistry({ config }: KagentToolRegistryProps) {
+// #6216 part 2: wrapped at the bottom in DynamicCardErrorBoundary.
+function KagentToolRegistryInternal({ config }: KagentToolRegistryProps) {
   const [expandedTool, setExpandedTool] = useState<string | null>(null)
 
   const {
@@ -220,5 +222,13 @@ export function KagentToolRegistry({ config }: KagentToolRegistryProps) {
         needsPagination={needsPagination}
       />
     </div>
+  )
+}
+
+export function KagentToolRegistry(props: KagentToolRegistryProps) {
+  return (
+    <DynamicCardErrorBoundary cardId="KagentToolRegistry">
+      <KagentToolRegistryInternal {...props} />
+    </DynamicCardErrorBoundary>
   )
 }

--- a/web/src/components/cards/kagent/KagentTopology.tsx
+++ b/web/src/components/cards/kagent/KagentTopology.tsx
@@ -2,6 +2,7 @@ import { useMemo } from 'react'
 import { Bot, Wrench, Cpu } from 'lucide-react'
 import { useKagentCRDAgents, useKagentCRDTools, useKagentCRDModels } from '../../../hooks/mcp/kagent_crds'
 import { useCardLoadingState } from '../CardDataContext'
+import { DynamicCardErrorBoundary } from '../DynamicCardErrorBoundary'
 import { useTranslation } from 'react-i18next'
 import {
   KAGENT_RUNTIME_PYTHON, KAGENT_RUNTIME_GO, KAGENT_RUNTIME_BYO,
@@ -31,7 +32,10 @@ interface TopoEdge {
   type: 'agent-tool' | 'agent-model'
 }
 
-export function KagentTopology({ config }: { config?: Record<string, unknown> }) {
+// #6216 part 2: wrapped at the bottom of the file in DynamicCardErrorBoundary
+// so a runtime error in the 234-line topology renderer doesn't crash the
+// dashboard. Same pattern as #6237 part 1.
+function KagentTopologyInternal({ config }: { config?: Record<string, unknown> }) {
   const { t } = useTranslation('cards')
   const cluster = config?.cluster as string | undefined
   const { data: agents, isLoading: agentsLoading, isDemoFallback: agentsDemo } = useKagentCRDAgents({ cluster })
@@ -230,5 +234,13 @@ export function KagentTopology({ config }: { config?: Record<string, unknown> })
         </svg>
       </div>
     </div>
+  )
+}
+
+export function KagentTopology(props: { config?: Record<string, unknown> }) {
+  return (
+    <DynamicCardErrorBoundary cardId="KagentTopology">
+      <KagentTopologyInternal {...props} />
+    </DynamicCardErrorBoundary>
   )
 }


### PR DESCRIPTION
## Summary

Follow-up to **#6237** (part 1, which wrapped PodSweeper, ClusterComparison, FluentdStatus, GPUNamespaceAllocations, ResourceUsage). #6216 listed 10 total cards needing ErrorBoundary; this PR completes the remaining 5 kagent cards using the same rename + wrap pattern.

## Wrapped

| Card | Lines | Notes |
|---|---|---|
| `KagentTopology.tsx` | 234 | SVG topology renderer |
| `KagentAgentDiscovery.tsx` | 188 | paginated agent search |
| `KagentModelProviders.tsx` | 203 | model provider grid |
| `KagentAgentFleet.tsx` | 198 | paginated agent fleet table |
| `KagentToolRegistry.tsx` | 224 | paginated tool registry |

Each file: rename inner function to `<Name>Internal`, add a thin `<Name>(props)` wrapper that returns `<DynamicCardErrorBoundary>` around the internal. Same pattern `EventStream` and #6237 use, ~6 LOC per file.

## Test plan

- [x] `npm run build` passes locally

Closes #6216.