### PR TITLE
fix(freshness): address Copilot review comments on #6239 (#6244)

### DIFF
--- a/web/src/components/cards/ClusterFocus.tsx
+++ b/web/src/components/cards/ClusterFocus.tsx
@@ -19,7 +19,7 @@ interface ClusterFocusProps {
 export function ClusterFocus({ config }: ClusterFocusProps) {
   const { t } = useTranslation(['cards', 'common'])
   const selectedCluster = config?.cluster
-  const { deduplicatedClusters: allClusters, isLoading: clustersLoading, isRefreshing: clustersRefreshing, isFailed, consecutiveFailures } = useClusters()
+  const { deduplicatedClusters: allClusters, isLoading: clustersLoading, isRefreshing: clustersRefreshing, isFailed, consecutiveFailures, lastRefresh: clustersLastRefresh } = useClusters()
   // #6217: destructure lastRefresh from each underlying hook so the card
   // can render a freshness indicator using the OLDEST timestamp (= the
   // staler half of the data the user is looking at).
@@ -130,12 +130,15 @@ export function ClusterFocus({ config }: ClusterFocusProps) {
         <div className="flex items-center gap-2 min-w-0 flex-1">
           <span className="text-sm font-medium text-foreground truncate">{clusterName}</span>
           <div className={`w-2 h-2 rounded-full shrink-0 ${cluster?.healthy ? 'bg-green-500' : 'bg-red-500'}`} />
-          {/* #6217: freshness indicator using the OLDEST of the 3 cache
-              timestamps so users see the staler half of the data. */}
+          {/* #6217: freshness indicator using the OLDEST of the 4 cache
+              timestamps so users see the staler half of the data.
+              #6244: include cluster cache timestamp — ClusterFocus reads
+              health/metrics from useClusters(), so excluding it could
+              misrepresent overall card freshness. */}
           <RefreshIndicator
-            isRefreshing={gpuRefreshing || podsRefreshing || deploymentsRefreshing}
+            isRefreshing={clustersRefreshing || gpuRefreshing || podsRefreshing || deploymentsRefreshing}
             lastUpdated={(() => {
-              const ts = [gpuLastRefresh, podsLastRefresh, deployLastRefresh].filter((t): t is number => t != null)
+              const ts = [clustersLastRefresh, gpuLastRefresh, podsLastRefresh, deployLastRefresh].filter((t): t is number => typeof t === 'number')
               return ts.length > 0 ? new Date(Math.min(...ts)) : null
             })()}
             size="sm"

--- a/web/src/components/cards/GPUNamespaceAllocations.tsx
+++ b/web/src/components/cards/GPUNamespaceAllocations.tsx
@@ -177,14 +177,19 @@ function GPUNamespaceAllocationsInternal({ config: _config }: GPUNamespaceAlloca
             {t('gpuNamespaceAllocations.gpusAcrossNamespaces', { gpus: totalGPUs, count: namespaceAllocations.length })}
           </StatusBadge>
           {/* #6217: freshness indicator. Use the OLDER of the two cache
-              timestamps so the user sees the staler half of the data. */}
+              timestamps so the user sees the staler half of the data.
+              #6244: explicit `typeof === 'number'` checks (truthy comparisons
+              would treat a `0` epoch timestamp as missing). */}
           <RefreshIndicator
             isRefreshing={gpuRefreshing || podsRefreshing}
-            lastUpdated={
-              gpuLastRefresh && podsLastRefresh
-                ? new Date(Math.min(gpuLastRefresh, podsLastRefresh))
-                : (gpuLastRefresh ? new Date(gpuLastRefresh) : (podsLastRefresh ? new Date(podsLastRefresh) : null))
-            }
+            lastUpdated={(() => {
+              const gp = typeof gpuLastRefresh === 'number' ? gpuLastRefresh : null
+              const po = typeof podsLastRefresh === 'number' ? podsLastRefresh : null
+              if (gp !== null && po !== null) return new Date(Math.min(gp, po))
+              if (gp !== null) return new Date(gp)
+              if (po !== null) return new Date(po)
+              return null
+            })()}
             size="sm"
             showLabel={true}
             staleThresholdMinutes={5}

--- a/web/src/components/cards/ResourceUsage.tsx
+++ b/web/src/components/cards/ResourceUsage.tsx
@@ -19,7 +19,7 @@ function ResourceUsageInternal() {
   const { t } = useTranslation(['cards', 'common'])
   // #6217: destructure lastRefresh so the card can render a freshness
   // indicator instead of leaving users guessing how stale the data is.
-  const { isLoading: clustersLoading, isRefreshing: clustersRefreshing } = useClusters()
+  const { isLoading: clustersLoading, isRefreshing: clustersRefreshing, lastRefresh: clustersLastRefresh } = useClusters()
   const { nodes: allGPUNodes, isDemoFallback, isRefreshing: gpuRefreshing, lastRefresh: gpuLastRefresh } = useCachedGPUNodes()
   const { drillToResources } = useDrillDownActions()
   const { isDemoMode } = useDemoMode()
@@ -164,10 +164,18 @@ function ResourceUsageInternal() {
               {t('common:common.nClusters', { count: clusters.length })}
             </span>
           )}
-          {/* #6217: freshness indicator. */}
+          {/* #6217: freshness indicator. #6244: use the OLDER of cluster
+              and GPU timestamps so the indicator reflects the staler source. */}
           <RefreshIndicator
             isRefreshing={clustersRefreshing || gpuRefreshing}
-            lastUpdated={gpuLastRefresh ? new Date(gpuLastRefresh) : null}
+            lastUpdated={(() => {
+              const cl = typeof clustersLastRefresh === 'number' ? clustersLastRefresh : null
+              const gp = typeof gpuLastRefresh === 'number' ? gpuLastRefresh : null
+              if (cl !== null && gp !== null) return new Date(Math.min(cl, gp))
+              if (cl !== null) return new Date(cl)
+              if (gp !== null) return new Date(gp)
+              return null
+            })()}
             size="sm"
             showLabel={true}
             staleThresholdMinutes={5}


### PR DESCRIPTION
## Summary

Addresses the 3 Copilot review comments left on merged PR #6239 (the freshness indicators batch). Each fix targets a subtle data-source coverage gap or `0`-timestamp edge case in `RefreshIndicator` wiring.

| Card | Issue | Fix |
|---|---|---|
| `ResourceUsage` | Used both `useClusters()` and GPU cache, but freshness only read `gpuLastRefresh`. | Now `Math.min(clustersLastRefresh, gpuLastRefresh)`. |
| `GPUNamespaceAllocations` | Nested ternary with `gpuLastRefresh && podsLastRefresh` would treat a `0` epoch as missing. | Explicit `typeof === 'number'` checks in an IIFE. |
| `ClusterFocus` | Reads cluster health/metrics from `useClusters()` but freshness only considered GPU/pod/deploy caches. | Includes `clustersLastRefresh` in the `Math.min` set and `clustersRefreshing` in `isRefreshing`. |

All three use `typeof === 'number'` filters so a `0` timestamp is preserved as the epoch (still very stale, but represented truthfully) instead of silently dropped.

Closes #6244

## Test plan

- [x] npm run build clean
- [ ] CI build/lint/preview pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)