### PR TITLE
chore(ci): post-merge verifier comments instead of reopening issues

### DIFF
--- a/.github/workflows/post-merge-verify.yml
+++ b/.github/workflows/post-merge-verify.yml
@@ -261,13 +261,16 @@ jobs:
           # Comment on PR
           gh pr comment "$PR" --repo "${{ github.repository }}" --body "$BODY" || true
 
-          # On failure: reopen original issue + create regression issue + assign Copilot
+          # On failure: comment on (but do NOT reopen) the original issue,
+          # then create a regression issue + assign Copilot for follow-up.
+          # Playwright is non-blocking on this repo (per the merge gate),
+          # so reopening would create noise that drowns out real fixes.
           if [ "$STATUS" = "failed" ]; then
-            # Reopen the original issue if it was closed by this PR
+            # Comment on the original issue without reopening it
             if [ -n "$ISSUE" ]; then
-              echo "Reopening original issue #$ISSUE..."
-              gh issue reopen "$ISSUE" --repo "${{ github.repository }}" \
-                --comment "⚠️ Reopening: post-merge Playwright verification **failed** after PR #$PR merged. The fix may not be working as expected. [See test report]($RUN_URL)" \
+              echo "Commenting on original issue #$ISSUE (no reopen)..."
+              gh issue comment "$ISSUE" --repo "${{ github.repository }}" \
+                --body "⚠️ Post-merge Playwright verification **failed** after PR #$PR merged. The fix shipped, but Playwright flagged an issue — see [test report]($RUN_URL). A regression issue will be filed for follow-up." \
                 || true
             fi
 


### PR DESCRIPTION
## Summary

The post-merge Playwright verification workflow (\`.github/workflows/post-merge-verify.yml\`) was auto-reopening every closed-by-PR issue whenever any Playwright spec failed against production.

Playwright is **non-blocking** on this repo — the merge gate is \`build\`/\`lint\`/\`preview\` only (per CLAUDE.md). So those reopens were turning every flaky spec into a fresh "is the fix really shipped?" round-trip, drowning the queue.

### Change

`gh issue reopen` → `gh issue comment`. The issue stays closed (the fix did ship), but still gets a visible note linking the failing run. The separate regression-issue + Copilot auto-assign path is preserved — that's a real signal worth keeping.

### Recently witnessed false reopens this was creating

- #6240 (already fixed by #6245)
- #6226 (already fixed by #6246)
- #6225 (already fixed by #6242)
- #6231 (already fixed by #6241)

All four closed within minutes of being reopened because the underlying fix was already merged.

## Test plan

- [ ] Workflow YAML parses
- [ ] Next merge with a Playwright failure comments instead of reopening

🤖 Generated with [Claude Code](https://claude.com/claude-code)