### PR TITLE
fix(test): mock useToast in Kubectl + ShareMissionDialog tests (#6252)

### DIFF
--- a/web/src/components/cards/__tests__/Kubectl.test.tsx
+++ b/web/src/components/cards/__tests__/Kubectl.test.tsx
@@ -49,6 +49,14 @@ vi.mock('../../../hooks/useKubectl', () => ({ useKubectl: () => ({ execute: vi.f
 
 vi.mock('../../../lib/clipboard', () => ({ copyToClipboard: vi.fn() }))
 
+// #6252: Kubectl now calls useToast() (added by #6246 for download
+// error feedback). Mock the Toast module so tests don't need a
+// ToastProvider wrapper.
+vi.mock('../../ui/Toast', () => ({
+  useToast: () => ({ showToast: vi.fn() }),
+  ToastProvider: ({ children }: { children: React.ReactNode }) => children,
+}))
+
 import { Kubectl } from '../Kubectl'
 
 describe('Kubectl', () => {

--- a/web/src/components/missions/__tests__/ShareMissionDialog.test.tsx
+++ b/web/src/components/missions/__tests__/ShareMissionDialog.test.tsx
@@ -30,6 +30,14 @@ vi.mock('js-yaml', () => ({
   dump: vi.fn((obj: unknown) => JSON.stringify(obj)),
 }))
 
+// #6252: ShareMissionDialog now calls useToast() (added by #6246 for
+// download error feedback). Mock the Toast module so tests don't need
+// a ToastProvider wrapper.
+vi.mock('../../ui/Toast', () => ({
+  useToast: () => ({ showToast: vi.fn() }),
+  ToastProvider: ({ children }: { children: React.ReactNode }) => children,
+}))
+
 // ── Fixtures ─────────────────────────────────────────────────────────────
 
 const mockResolution: Resolution = {


### PR DESCRIPTION
## Summary

PR #6246 wired \`useToast()\` into \`Kubectl.tsx\` and \`ShareMissionDialog.tsx\` for download error feedback, but the existing tests didn't mock the Toast module. Coverage Suite #513 reported 18 failures all with the same root cause:

\`\`\`
Error: useToast must be used within a ToastProvider
\`\`\`

### Fix

Add \`vi.mock('../../ui/Toast', ...)\` to both test files. The mock returns a no-op \`showToast\` so the download paths still execute without needing a real \`<ToastProvider>\` wrapper.

Verified locally: \`npx vitest run Kubectl.test.tsx ShareMissionDialog.test.tsx\` → **18/18 passing**.

Closes #6252

## Test plan

- [x] 18 tests pass locally
- [x] \`npm run build\` clean
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)