### PR TITLE
fix(test): update shared.test demo branch + bump hex ratchet (#6254)

### DIFF
--- a/web/src/hooks/mcp/__tests__/shared.test.ts
+++ b/web/src/hooks/mcp/__tests__/shared.test.ts
@@ -1237,8 +1237,17 @@ describe('fullFetchClusters', () => {
     vi.restoreAllMocks()
   })
 
-  it('returns demo clusters when isDemoMode() is true', async () => {
+  it('returns demo clusters when isDemoMode() is true and demo token is set', async () => {
+    // #6243 dropped the unconditional demo-mode short-circuit. Demo data
+    // is now returned only when:
+    //   1) Netlify forced demo, OR
+    //   2) fetchClusterListFromAgent() returns null AND
+    //      isDemoMode() && isDemoToken() are both true.
+    // Tests must mock both flags AND make agent fetch fail so the demo
+    // fallback branch fires.
     mockIsDemoMode.mockReturnValue(true)
+    mockIsDemoToken.mockReturnValue(true)
+    globalThis.fetch = vi.fn().mockRejectedValue(new Error('agent down'))
     await fullFetchClusters()
     expect(clusterCache.clusters.length).toBeGreaterThan(0)
     expect(clusterCache.isLoading).toBe(false)

--- a/web/src/test/ui-ux-standards.test.ts
+++ b/web/src/test/ui-ux-standards.test.ts
@@ -55,7 +55,7 @@ const COMPONENTS_DIR = path.resolve(
 // regex matches `#NNNN` as a hex literal, but these are GitHub issue
 // references in code comments, not color literals. Same scoped-bump rationale
 // as the prior 273→278 increment.
-const EXPECTED_RAW_HEX_COUNT = 288
+const EXPECTED_RAW_HEX_COUNT = 290
 const EXPECTED_RAW_RGBA_COUNT = 104
 const EXPECTED_ARBITRARY_TW_COLOR_COUNT = 22
 const EXPECTED_INLINE_STYLE_COLOR_COUNT = 213


### PR DESCRIPTION
## Summary

Coverage Suite #517 reported 20 failures from PR #6243 (drop racy demo-mode early-return). 18 of them were the same useToast failures already covered by #6253 (test ran on an earlier sha). The remaining 2 are real test/source mismatches.

### Real fixes

**`shared.test.ts > fullFetchClusters > returns demo clusters when isDemoMode() is true`**

The test relied on the unconditional demo-mode short-circuit that #6243 removed. The new path requires both \`isDemoMode()\` AND \`isDemoToken()\` to be true *and* needs agent fetch to fail so the demo fallback branch fires. Mock \`mockIsDemoToken\` true and stub \`globalThis.fetch\` to reject. Test renamed to \"...is true and demo token is set\" for clarity.

**`ui-ux-standards.test.ts`**

\`EXPECTED_RAW_HEX_COUNT\` ratchet bumped 288 → 290 to absorb two new \`#NNNN\` issue-reference comments.

Verified: \`npx vitest run shared.test.ts ui-ux-standards.test.ts\` → **166/166 passing**.

Closes #6254

## Test plan

- [x] 166 tests pass locally
- [x] \`npm run build\` clean
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)