### PR TITLE
fix(freshness): add RefreshIndicator to 3 cards (#6217 part 3)

### DIFF
--- a/web/src/components/cards/DNSHealth.tsx
+++ b/web/src/components/cards/DNSHealth.tsx
@@ -1,6 +1,7 @@
 import { useTranslation } from 'react-i18next'
 import { useCachedPods } from '../../hooks/useCachedData'
 import { useCardLoadingState } from './CardDataContext'
+import { RefreshIndicator } from '../ui/RefreshIndicator'
 
 /** Namespaces that host DNS pods across distributions */
 const DNS_NAMESPACES = ['kube-system', 'openshift-dns']
@@ -11,7 +12,7 @@ const DNS_POD_PATTERNS = ['coredns', 'kube-dns', 'dns-default']
 export function DNSHealth() {
   const { t } = useTranslation('cards')
   // Fetch from all namespaces so we catch DNS pods in both kube-system and openshift-dns
-  const { pods, isLoading, isRefreshing, isDemoFallback, isFailed, consecutiveFailures } = useCachedPods()
+  const { pods, isLoading, isRefreshing, isDemoFallback, isFailed, consecutiveFailures, lastRefresh: podsLastRefresh } = useCachedPods()
   const hasData = pods.length > 0
   const { showSkeleton } = useCardLoadingState({
     isLoading: isLoading && !hasData,
@@ -60,8 +61,18 @@ export function DNSHealth() {
 
   return (
     <div className="space-y-2 p-1">
-      <div className="flex items-center gap-2 text-xs text-muted-foreground mb-1">
-        <span>{t('dnsHealth.podsSummary', { pods: dnsPods.length, clusters: byCluster.length })}</span>
+      <div className="flex items-center justify-between gap-2 mb-1">
+        <div className="flex items-center gap-2 text-xs text-muted-foreground">
+          <span>{t('dnsHealth.podsSummary', { pods: dnsPods.length, clusters: byCluster.length })}</span>
+        </div>
+        {/* #6217 part 3: freshness indicator. */}
+        <RefreshIndicator
+          isRefreshing={isRefreshing}
+          lastUpdated={typeof podsLastRefresh === 'number' ? new Date(podsLastRefresh) : null}
+          size="sm"
+          showLabel={true}
+          staleThresholdMinutes={5}
+        />
       </div>
       {byCluster.map(([cluster, clusterPods]) => {
         const running = clusterPods.filter(p => p.status === 'Running')

--- a/web/src/components/cards/DeploymentIssues.tsx
+++ b/web/src/components/cards/DeploymentIssues.tsx
@@ -6,6 +6,7 @@ import { useDrillDownActions } from '../../hooks/useDrillDown'
 import { ClusterBadge } from '../ui/ClusterBadge'
 import { LimitedAccessWarning } from '../ui/LimitedAccessWarning'
 import { StatusBadge } from '../ui/StatusBadge'
+import { RefreshIndicator } from '../ui/RefreshIndicator'
 import { useCardLoadingState } from './CardDataContext'
 import { DynamicCardErrorBoundary } from './DynamicCardErrorBoundary'
 import { useCardData, commonComparators } from '../../lib/cards/cardHooks'
@@ -47,7 +48,8 @@ function DeploymentIssuesInternal({ config }: DeploymentIssuesProps) {
     isDemoFallback,
     isFailed,
     consecutiveFailures,
-    error
+    error,
+    lastRefresh: issuesLastRefresh
   } = useCachedDeploymentIssues(clusterConfig, namespaceConfig)
 
   const { drillToDeployment } = useDrillDownActions()
@@ -157,6 +159,14 @@ function DeploymentIssuesInternal({ config }: DeploymentIssuesProps) {
           <StatusBadge color="red" title={t('deploymentIssues.issuesTitle', { count: rawIssues.length })}>
             {t('deploymentIssues.nIssues', { count: rawIssues.length })}
           </StatusBadge>
+          {/* #6217 part 3: freshness indicator. */}
+          <RefreshIndicator
+            isRefreshing={isRefreshing}
+            lastUpdated={typeof issuesLastRefresh === 'number' ? new Date(issuesLastRefresh) : null}
+            size="sm"
+            showLabel={true}
+            staleThresholdMinutes={5}
+          />
         </div>
         <CardControlsRow
           clusterIndicator={{

--- a/web/src/components/cards/GPUUtilization.tsx
+++ b/web/src/components/cards/GPUUtilization.tsx
@@ -2,6 +2,7 @@ import { useMemo, useState, useEffect, useRef } from 'react'
 import { TrendingUp, Clock, Server } from 'lucide-react'
 import { CardClusterFilter } from '../../lib/cards/CardComponents'
 import { Skeleton, SkeletonStats } from '../ui/Skeleton'
+import { RefreshIndicator } from '../ui/RefreshIndicator'
 import { useCardLoadingState } from './CardDataContext'
 import ReactECharts from 'echarts-for-react'
 import { useClusters } from '../../hooks/useMCP'
@@ -40,7 +41,8 @@ export function GPUUtilization() {
     isRefreshing,
     isDemoFallback,
     isFailed,
-    consecutiveFailures } = useCachedGPUNodes()
+    consecutiveFailures,
+    lastRefresh: gpuLastRefresh } = useCachedGPUNodes()
   const { deduplicatedClusters: clusters } = useClusters()
   const { isDemoMode } = useDemoMode()
 
@@ -268,6 +270,14 @@ export function GPUUtilization() {
               {localClusterFilter.length}/{availableClustersForFilter.length}
             </span>
           )}
+          {/* #6217 part 3: freshness indicator. */}
+          <RefreshIndicator
+            isRefreshing={isRefreshing}
+            lastUpdated={typeof gpuLastRefresh === 'number' ? new Date(gpuLastRefresh) : null}
+            size="sm"
+            showLabel={true}
+            staleThresholdMinutes={5}
+          />
         </div>
         <div className="flex items-center gap-2">
           <div className="flex items-center gap-1">

--- a/web/src/test/ui-ux-standards.test.ts
+++ b/web/src/test/ui-ux-standards.test.ts
@@ -60,11 +60,12 @@ const COMPONENTS_DIR = path.resolve(
 //   281 → 282 → 284 → 287 → 288: subsequent bundles
 //   288 → 290: #6254 test fixes
 //   290 → 293: #6217 part 2 freshness indicator additions
+//   293 → 296: #6217 part 3 freshness additions
 //
 // When you bump this number, append a one-line entry above so future
 // bumps stay grep-able and reviewers can tell at a glance whether a
 // change is a real new violation or just a comment-level reference.
-const EXPECTED_RAW_HEX_COUNT = 293
+const EXPECTED_RAW_HEX_COUNT = 296
 const EXPECTED_RAW_RGBA_COUNT = 104
 const EXPECTED_ARBITRARY_TW_COLOR_COUNT = 22
 const EXPECTED_INLINE_STYLE_COLOR_COUNT = 213


### PR DESCRIPTION
## Summary

Continues #6217 from parts 1 (#6239) and 2 (#6256). Adds \`RefreshIndicator\` to three more cards:

| Card | Cache hook | Position |
|---|---|---|
| \`GPUUtilization\` | \`useCachedGPUNodes\` | header left |
| \`DeploymentIssues\` | \`useCachedDeploymentIssues\` | header (next to status badge) |
| \`DNSHealth\` | \`useCachedPods\` | header right |

Same pattern: pull \`lastRefresh\` from the cache hook, render with \`staleThresholdMinutes=5\`, guard with \`typeof === 'number'\`.

36 insertions across 3 files (size S).

Refs #6217 (6 cards remaining for parts 4+).

## Test plan

- [x] \`npm run build\` clean
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)