### PR TITLE
fix(freshness): add RefreshIndicator to 3 cards (#6217 part 4)

### DIFF
--- a/web/src/components/cards/DeploymentProgress.tsx
+++ b/web/src/components/cards/DeploymentProgress.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react'
 import { CheckCircle, Clock, XCircle, Loader2, Filter, ChevronRight, Server } from 'lucide-react'
 import { useCachedDeployments } from '../../hooks/useCachedData'
 import { ClusterBadge } from '../ui/ClusterBadge'
+import { RefreshIndicator } from '../ui/RefreshIndicator'
 import { CardClusterFilter, CardSearchInput } from '../../lib/cards/CardComponents'
 import { Pagination } from '../ui/Pagination'
 import { CardControls } from '../ui/CardControls'
@@ -85,7 +86,8 @@ export function DeploymentProgress({ config }: DeploymentProgressProps) {
     isDemoFallback,
     isFailed,
     consecutiveFailures,
-    error
+    error,
+    lastRefresh: deploymentsLastRefresh
   } = useCachedDeployments(cluster, namespace)
   const { drillToDeployment } = useDrillDownActions()
 
@@ -210,6 +212,14 @@ export function DeploymentProgress({ config }: DeploymentProgressProps) {
               {filters.localClusterFilter.length}/{filters.availableClusters.length}
             </span>
           )}
+          {/* part 4: freshness indicator. */}
+          <RefreshIndicator
+            isRefreshing={isRefreshing}
+            lastUpdated={typeof deploymentsLastRefresh === 'number' ? new Date(deploymentsLastRefresh) : null}
+            size="sm"
+            showLabel={true}
+            staleThresholdMinutes={5}
+          />
         </div>
         <div className="flex items-center gap-2">
           {/* Cluster Filter */}

--- a/web/src/components/cards/GitOpsDrift.tsx
+++ b/web/src/components/cards/GitOpsDrift.tsx
@@ -9,6 +9,7 @@ import { Pagination } from '../ui/Pagination'
 import { CardClusterFilter, CardSearchInput } from '../../lib/cards/CardComponents'
 import { useCardData } from '../../lib/cards/cardHooks'
 import { StatusBadge } from '../ui/StatusBadge'
+import { RefreshIndicator } from '../ui/RefreshIndicator'
 import { useCardLoadingState } from './CardDataContext'
 import { GitOpsDriftDetailModal } from './deploy/GitOpsDriftDetailModal'
 import { useTranslation } from 'react-i18next'
@@ -69,7 +70,8 @@ export function GitOpsDrift({ config }: GitOpsDriftProps) {
     error,
     isFailed,
     consecutiveFailures,
-    isDemoFallback: isDemoData } = useCachedGitOpsDrifts(cluster, namespace)
+    isDemoFallback: isDemoData,
+    lastRefresh: driftLastRefresh } = useCachedGitOpsDrifts(cluster, namespace)
   const { selectedSeverities, isAllSeveritiesSelected, customFilter } = useGlobalFilters()
 
   // Report loading state to CardWrapper for skeleton/refresh behavior
@@ -211,6 +213,14 @@ export function GitOpsDrift({ config }: GitOpsDriftProps) {
               {t('gitOpsDrift.nDrifts', { count: totalDrifts })}
             </span>
           )}
+          {/* part 4: freshness indicator. */}
+          <RefreshIndicator
+            isRefreshing={isRefreshing}
+            lastUpdated={typeof driftLastRefresh === 'number' ? new Date(driftLastRefresh) : null}
+            size="sm"
+            showLabel={true}
+            staleThresholdMinutes={5}
+          />
         </div>
         <div className="flex items-center gap-2">
           {/* Cluster Filter */}

--- a/web/src/components/cards/HardwareHealthCard.tsx
+++ b/web/src/components/cards/HardwareHealthCard.tsx
@@ -5,6 +5,7 @@ import { useCardLoadingState } from './CardDataContext'
 import { CardControlsRow, CardSearchInput, CardPaginationFooter, CardAIActions } from '../../lib/cards/CardComponents'
 import { ClusterBadge } from '../ui/ClusterBadge'
 import { StatusBadge } from '../ui/StatusBadge'
+import { RefreshIndicator } from '../ui/RefreshIndicator'
 import { useDrillDownActions } from '../../hooks/useDrillDown'
 import { useClusters } from '../../hooks/useMCP'
 import { useCachedHardwareHealth, type DeviceAlert, type NodeDeviceInventory, type DeviceCounts } from '../../hooks/useCachedData'
@@ -876,13 +877,18 @@ export function HardwareHealthCard() {
         needsPagination={currentNeedsPagination}
       />
 
-      {/* Last update */}
-      {lastUpdate && (
-        <div className="text-2xs text-muted-foreground text-center mt-2 flex items-center justify-center gap-1">
-          <RefreshCw className="w-3 h-3" />
-          Updated {lastUpdate.toLocaleTimeString()}
-        </div>
-      )}
+      {/* part 4: replaced bespoke "Updated HH:MM:SS" footer with the
+          standard RefreshIndicator so it matches the rest of the card
+          deck and shows a stale-data warning past 5 minutes. */}
+      <div className="mt-2 flex items-center justify-center">
+        <RefreshIndicator
+          isRefreshing={isRefreshing}
+          lastUpdated={lastUpdate}
+          size="sm"
+          showLabel={true}
+          staleThresholdMinutes={5}
+        />
+      </div>
     </div>
   )
 }


### PR DESCRIPTION
## Summary

Continues #6217 from parts 1-3 (#6239, #6256, #6259). Adds \`RefreshIndicator\` to three more cards:

| Card | Cache hook | Notes |
|---|---|---|
| \`GitOpsDrift\` | \`useCachedGitOpsDrifts\` | header right |
| \`HardwareHealthCard\` | \`useCachedHardwareHealth\` | **replaced** the bespoke \"Updated HH:MM:SS\" footer with the standard indicator (gains a stale-data warning past 5 min that the homemade footer didn't) |
| \`DeploymentProgress\` | \`useCachedDeployments\` | header right |

35 insertions across 3 files.

3 cards remaining for parts 5+.

## Test plan

- [x] \`npm run build\` clean
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)