### PR TITLE
fix(freshness): add RefreshIndicator to last 2 cards (#6217 part 5)

### DIFF
--- a/web/src/components/cards/HelmValuesDiff.tsx
+++ b/web/src/components/cards/HelmValuesDiff.tsx
@@ -7,6 +7,7 @@ import { useDrillDownActions } from '../../hooks/useDrillDown'
 import { useGlobalFilters } from '../../hooks/useGlobalFilters'
 import { Skeleton } from '../ui/Skeleton'
 import { ClusterBadge } from '../ui/ClusterBadge'
+import { RefreshIndicator } from '../ui/RefreshIndicator'
 import { useCardData, commonComparators } from '../../lib/cards/cardHooks'
 import { CardSearchInput, CardControlsRow, CardPaginationFooter } from '../../lib/cards/CardComponents'
 import { useCardLoadingState } from './CardDataContext'
@@ -127,7 +128,7 @@ export function HelmValuesDiff({ config }: HelmValuesDiffProps) {
   }, [globalSelectedClusters, isAllClustersSelected])
 
   // Fetch ALL Helm releases from all clusters once (not per-cluster)
-  const { releases: allHelmReleases, isLoading: releasesLoading, isRefreshing: releasesRefreshing, isDemoFallback: isDemoData } = useCachedHelmReleases()
+  const { releases: allHelmReleases, isLoading: releasesLoading, isRefreshing: releasesRefreshing, isDemoFallback: isDemoData, lastRefresh: releasesLastRefresh } = useCachedHelmReleases()
 
   // Auto-select first cluster and release in demo mode
   useEffect(() => {
@@ -290,6 +291,14 @@ export function HelmValuesDiff({ config }: HelmValuesDiffProps) {
           <span className="text-sm font-medium text-muted-foreground">
             {totalItems} values
           </span>
+          {/* part 5: freshness indicator. */}
+          <RefreshIndicator
+            isRefreshing={clustersRefreshing || releasesRefreshing || valuesRefreshing}
+            lastUpdated={typeof releasesLastRefresh === 'number' ? new Date(releasesLastRefresh) : null}
+            size="sm"
+            showLabel={true}
+            staleThresholdMinutes={5}
+          />
         </div>
         <div className="flex items-center gap-2">
           {/* Cluster count indicator */}

--- a/web/src/components/cards/NetworkOverview.tsx
+++ b/web/src/components/cards/NetworkOverview.tsx
@@ -8,10 +8,11 @@ import { useCardLoadingState } from './CardDataContext'
 import { CardClusterFilter } from '../../lib/cards/CardComponents'
 import { useChartFilters } from '../../lib/cards/cardHooks'
 import { ClusterStatusDot } from '../ui/ClusterStatusBadge'
+import { RefreshIndicator } from '../ui/RefreshIndicator'
 
 export function NetworkOverview() {
   const { deduplicatedClusters: clusters, isLoading } = useClusters()
-  const { services, isLoading: servicesLoading, isRefreshing, isDemoFallback, consecutiveFailures, isFailed } = useCachedServices()
+  const { services, isLoading: servicesLoading, isRefreshing, isDemoFallback, consecutiveFailures, isFailed, lastRefresh: servicesLastRefresh } = useCachedServices()
 
   const { selectedClusters, isAllClustersSelected } = useGlobalFilters()
   const { drillToService } = useDrillDownActions()
@@ -141,7 +142,14 @@ export function NetworkOverview() {
 
       {/* Controls */}
       <div className="flex items-center justify-between mb-4">
-        <div />
+        {/* part 5: freshness indicator. */}
+        <RefreshIndicator
+          isRefreshing={isRefreshing}
+          lastUpdated={typeof servicesLastRefresh === 'number' ? new Date(servicesLastRefresh) : null}
+          size="sm"
+          showLabel={true}
+          staleThresholdMinutes={5}
+        />
         <div className="flex items-center gap-2">
           {/* Cluster count indicator */}
           {localClusterFilter.length > 0 && (


### PR DESCRIPTION
## Summary

Final part of #6217. Adds \`RefreshIndicator\` to the last two cards from the auto-QA list:

| Card | Cache hook | Position |
|---|---|---|
| \`NetworkOverview\` | \`useCachedServices\` | header left |
| \`HelmValuesDiff\` | \`useCachedHelmReleases\` (uses combined refresh from clusters/releases/values) | header next to \"{N} values\" label |

This completes the freshness-indicator pass across all 14 cards from the auto-QA finding (KedaStatus was excluded since it already had one).

### #6217 series total

| Part | PR | Cards |
|---|---|---|
| 1 | #6239 | GPUNamespaceAllocations, ResourceUsage, ClusterFocus |
| 2 | #6256 | QuotaHeatmap, ISO27001Audit, ClusterChangelog |
| 3 | #6259 | GPUUtilization, DeploymentIssues, DNSHealth |
| 4 | #6261 | GitOpsDrift, HardwareHealthCard, DeploymentProgress |
| 5 | this | NetworkOverview, HelmValuesDiff |

Closes #6217

## Test plan

- [x] \`npm run build\` clean
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)