### PR TITLE
fix(freshness): hide RefreshIndicator timestamp in demo mode (#6263)

### DIFF
--- a/web/src/components/cards/DeploymentProgress.tsx
+++ b/web/src/components/cards/DeploymentProgress.tsx
@@ -212,10 +212,13 @@ export function DeploymentProgress({ config }: DeploymentProgressProps) {
               {filters.localClusterFilter.length}/{filters.availableClusters.length}
             </span>
           )}
-          {/* part 4: freshness indicator. */}
+          {/* part 4: freshness indicator.
+              followup: hide timestamp in demo mode — `useCachedDeployments`
+              can preserve `lastRefresh` from a prior live session, which
+              would show a misleading "Updated X ago" against demo data. */}
           <RefreshIndicator
             isRefreshing={isRefreshing}
-            lastUpdated={typeof deploymentsLastRefresh === 'number' ? new Date(deploymentsLastRefresh) : null}
+            lastUpdated={isDemoFallback || typeof deploymentsLastRefresh !== 'number' ? null : new Date(deploymentsLastRefresh)}
             size="sm"
             showLabel={true}
             staleThresholdMinutes={5}

--- a/web/src/components/cards/GitOpsDrift.tsx
+++ b/web/src/components/cards/GitOpsDrift.tsx
@@ -213,10 +213,13 @@ export function GitOpsDrift({ config }: GitOpsDriftProps) {
               {t('gitOpsDrift.nDrifts', { count: totalDrifts })}
             </span>
           )}
-          {/* part 4: freshness indicator. */}
+          {/* part 4: freshness indicator.
+              followup: hide timestamp in demo mode — `useCachedGitOpsDrifts`
+              can preserve `lastRefresh` from a prior live session, which
+              would show a misleading "Updated X ago" against demo data. */}
           <RefreshIndicator
             isRefreshing={isRefreshing}
-            lastUpdated={typeof driftLastRefresh === 'number' ? new Date(driftLastRefresh) : null}
+            lastUpdated={isDemoData || typeof driftLastRefresh !== 'number' ? null : new Date(driftLastRefresh)}
             size="sm"
             showLabel={true}
             staleThresholdMinutes={5}

--- a/web/src/components/cards/HardwareHealthCard.tsx
+++ b/web/src/components/cards/HardwareHealthCard.tsx
@@ -879,11 +879,14 @@ export function HardwareHealthCard() {
 
       {/* part 4: replaced bespoke "Updated HH:MM:SS" footer with the
           standard RefreshIndicator so it matches the rest of the card
-          deck and shows a stale-data warning past 5 minutes. */}
+          deck and shows a stale-data warning past 5 minutes.
+          part 4 followup: hide the timestamp in demo mode — the cache
+          can preserve `lastUpdate` from a prior live session, which
+          would show a misleading "Updated 3h ago" against demo data. */}
       <div className="mt-2 flex items-center justify-center">
         <RefreshIndicator
           isRefreshing={isRefreshing}
-          lastUpdated={lastUpdate}
+          lastUpdated={isDemoFallback ? null : lastUpdate}
           size="sm"
           showLabel={true}
           staleThresholdMinutes={5}


### PR DESCRIPTION
## Summary

Copilot's review of #6261 caught the same edge case in three cards: when the cached hook returns \`isDemoFallback: true\` (or \`isDemoData\` for GitOpsDrift), the cache may still hold a \`lastRefresh\` from a prior live session. The \`RefreshIndicator\` would then show \"Updated X ago\" — a misleading live timestamp against demo data that isn't actually being refreshed.

### Fix

Pass \`null\` for \`lastUpdated\` when the demo flag is true. Refreshing spinner still shows if demo data is loading; no stale timestamp.

| Card | Demo flag |
|---|---|
| \`HardwareHealthCard\` | \`isDemoFallback\` |
| \`GitOpsDrift\` | \`isDemoData\` (already aliased) |
| \`DeploymentProgress\` | \`isDemoFallback\` |

Closes #6263

## Test plan

- [x] \`npm run build\` clean
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)