### PR TITLE
fix(freshness): address 4 Copilot review comments on #6262 (#6265)

### DIFF
--- a/web/src/components/cards/HelmValuesDiff.tsx
+++ b/web/src/components/cards/HelmValuesDiff.tsx
@@ -55,7 +55,7 @@ const SORT_OPTIONS = [
 
 export function HelmValuesDiff({ config }: HelmValuesDiffProps) {
   const { t } = useTranslation()
-  const { deduplicatedClusters: allClusters, isLoading: clustersLoading, isRefreshing: clustersRefreshing, isFailed: clustersFailed, consecutiveFailures: clustersFailures } = useClusters()
+  const { deduplicatedClusters: allClusters, isLoading: clustersLoading, isRefreshing: clustersRefreshing, isFailed: clustersFailed, consecutiveFailures: clustersFailures, lastRefresh: clustersLastRefresh } = useClusters()
   const [selectedCluster, setSelectedCluster] = useState<string>(config?.cluster || '')
   const [selectedRelease, setSelectedRelease] = useState<string>(config?.release || '')
   const { drillToHelm } = useDrillDownActions()
@@ -159,7 +159,8 @@ export function HelmValuesDiff({ config }: HelmValuesDiffProps) {
   const {
     values,
     isLoading: valuesLoading,
-    isRefreshing: valuesRefreshing } = useCachedHelmValues(
+    isRefreshing: valuesRefreshing,
+    lastRefresh: valuesLastRefresh } = useCachedHelmValues(
     selectedCluster || undefined,
     selectedRelease || undefined,
     selectedReleaseNamespace
@@ -291,10 +292,19 @@ export function HelmValuesDiff({ config }: HelmValuesDiffProps) {
           <span className="text-sm font-medium text-muted-foreground">
             {totalItems} values
           </span>
-          {/* part 5: freshness indicator. */}
+          {/* part 5: freshness indicator.
+              #6265: card composes data from THREE caches (clusters,
+              releases, values), so the indicator must reflect the OLDEST
+              of the three timestamps — not just releases. Hide entirely
+              in demo mode (useCache may preserve stale lastRefresh from
+              a prior live session). */}
           <RefreshIndicator
             isRefreshing={clustersRefreshing || releasesRefreshing || valuesRefreshing}
-            lastUpdated={typeof releasesLastRefresh === 'number' ? new Date(releasesLastRefresh) : null}
+            lastUpdated={(() => {
+              if (isDemoData) return null
+              const ts = [clustersLastRefresh, releasesLastRefresh, valuesLastRefresh].filter((t): t is number => typeof t === 'number')
+              return ts.length > 0 ? new Date(Math.min(...ts)) : null
+            })()}
             size="sm"
             showLabel={true}
             staleThresholdMinutes={5}

--- a/web/src/components/cards/NetworkOverview.tsx
+++ b/web/src/components/cards/NetworkOverview.tsx
@@ -11,7 +11,7 @@ import { ClusterStatusDot } from '../ui/ClusterStatusBadge'
 import { RefreshIndicator } from '../ui/RefreshIndicator'
 
 export function NetworkOverview() {
-  const { deduplicatedClusters: clusters, isLoading } = useClusters()
+  const { deduplicatedClusters: clusters, isLoading, isRefreshing: clustersRefreshing, lastRefresh: clustersLastRefresh } = useClusters()
   const { services, isLoading: servicesLoading, isRefreshing, isDemoFallback, consecutiveFailures, isFailed, lastRefresh: servicesLastRefresh } = useCachedServices()
 
   const { selectedClusters, isAllClustersSelected } = useGlobalFilters()
@@ -142,10 +142,24 @@ export function NetworkOverview() {
 
       {/* Controls */}
       <div className="flex items-center justify-between mb-4">
-        {/* part 5: freshness indicator. */}
+        {/* part 5: freshness indicator.
+            #6265: this card uses BOTH useClusters() and useCachedServices(),
+            so the indicator must reflect the OLDER of the two timestamps
+            (otherwise stale cluster health could appear fresh). Hide the
+            timestamp entirely in demo mode — useCache may preserve a
+            lastRefresh from a prior live session that doesn't reflect the
+            demo data being shown. */}
         <RefreshIndicator
-          isRefreshing={isRefreshing}
-          lastUpdated={typeof servicesLastRefresh === 'number' ? new Date(servicesLastRefresh) : null}
+          isRefreshing={isRefreshing || clustersRefreshing}
+          lastUpdated={(() => {
+            if (isDemoFallback) return null
+            const cl = typeof clustersLastRefresh === 'number' ? clustersLastRefresh : null
+            const sv = typeof servicesLastRefresh === 'number' ? servicesLastRefresh : null
+            if (cl !== null && sv !== null) return new Date(Math.min(cl, sv))
+            if (cl !== null) return new Date(cl)
+            if (sv !== null) return new Date(sv)
+            return null
+          })()}
           size="sm"
           showLabel={true}
           staleThresholdMinutes={5}

--- a/web/src/test/ui-ux-standards.test.ts
+++ b/web/src/test/ui-ux-standards.test.ts
@@ -61,11 +61,12 @@ const COMPONENTS_DIR = path.resolve(
 //   288 → 290: #6254 test fixes
 //   290 → 293: #6217 part 2 freshness indicator additions
 //   293 → 296: #6217 part 3 freshness additions
+//   296 → 298: #6265 copilot follow-up comment refs
 //
 // When you bump this number, append a one-line entry above so future
 // bumps stay grep-able and reviewers can tell at a glance whether a
 // change is a real new violation or just a comment-level reference.
-const EXPECTED_RAW_HEX_COUNT = 296
+const EXPECTED_RAW_HEX_COUNT = 298
 const EXPECTED_RAW_RGBA_COUNT = 104
 const EXPECTED_ARBITRARY_TW_COLOR_COUNT = 22
 const EXPECTED_INLINE_STYLE_COLOR_COUNT = 213


### PR DESCRIPTION
## Summary

Two underlying problems flagged by Copilot across \`NetworkOverview\` and \`HelmValuesDiff\`:

### 1. Multi-source coverage gap

Each card composes data from more than one cache, but the freshness indicator only reflected one timestamp.

| Card | Sources | Fix |
|---|---|---|
| \`NetworkOverview\` | \`useClusters()\` + \`useCachedServices()\` | \`Math.min(clustersLastRefresh, servicesLastRefresh)\` |
| \`HelmValuesDiff\` | \`useClusters()\` + \`useCachedHelmReleases()\` + \`useCachedHelmValues()\` | \`Math.min\` of all three |

The \`isRefreshing\` flags also include all sources so the spinner reflects any in-flight refresh.

### 2. Demo-mode stale timestamps

\`useCache()\` preserves \`lastRefresh\` across demo-mode toggle, so a card showing demo data could display \"Updated 3h ago\" from a prior live session. Both cards now pass \`null\` for \`lastUpdated\` when \`isDemoFallback\` / \`isDemoData\` is true.

(Same edge case as #6263, applied to the part 5 cards.)

Closes #6265

## Test plan

- [x] \`npm run build\` clean
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)