### PR TITLE
fix(freshness): wire clustersRefreshing into NetworkOverview card state + add tests (#6267)

### DIFF
--- a/web/src/components/cards/NetworkOverview.tsx
+++ b/web/src/components/cards/NetworkOverview.tsx
@@ -17,11 +17,15 @@ export function NetworkOverview() {
   const { selectedClusters, isAllClustersSelected } = useGlobalFilters()
   const { drillToService } = useDrillDownActions()
 
-  // Report card data state
+  // Report card data state.
+  // #6267: include clustersRefreshing so the card-level state matches
+  // the freshness indicator's combined refresh signal — otherwise a
+  // cluster cache refresh would tick the indicator without ticking the
+  // CardWrapper refresh animation.
   const combinedLoading = isLoading || servicesLoading
   const { showSkeleton, showEmptyState } = useCardLoadingState({
     isLoading: combinedLoading,
-    isRefreshing,
+    isRefreshing: isRefreshing || clustersRefreshing,
     isDemoData: isDemoFallback,
     hasAnyData: services.length > 0,
     isFailed,

--- a/web/src/components/cards/__tests__/HelmValuesDiff.test.tsx
+++ b/web/src/components/cards/__tests__/HelmValuesDiff.test.tsx
@@ -135,4 +135,33 @@ describe('HelmValuesDiff', () => {
     expect(mockUseCardLoadingState).toHaveBeenCalled()
   })
 
+  // #6267: regression coverage for the freshness-indicator wiring
+  // introduced in #6266 (3-source min timestamp + demo-mode suppression).
+  describe('freshness indicator wiring (#6265, #6267)', () => {
+    it('reports isRefreshing=true when any source is refreshing', () => {
+      // Only values is refreshing — combined isRefreshing must still be true
+      mockHelmReleases.mockReturnValue({ releases: [], isLoading: false, isRefreshing: false, isDemoFallback: false, isFailed: false, consecutiveFailures: 0, error: null, lastRefresh: Date.now() })
+      mockHelmValues.mockReturnValue({ values: {}, isLoading: false, isRefreshing: true, isDemoFallback: false, isFailed: false, consecutiveFailures: 0, error: null, lastRefresh: Date.now() })
+      mockUseClusters.mockReturnValue({ clusters: [], deduplicatedClusters: [], isLoading: false, isRefreshing: false, error: null, lastRefresh: Date.now() })
+      render(<HelmValuesDiff />)
+      const lastCall = mockUseCardLoadingState.mock.calls[mockUseCardLoadingState.mock.calls.length - 1][0]
+      expect(lastCall.isRefreshing).toBe(true)
+    })
+
+    it('reports isRefreshing=true when clusters source is refreshing', () => {
+      mockUseClusters.mockReturnValue({ clusters: [], deduplicatedClusters: [], isLoading: false, isRefreshing: true, error: null, lastRefresh: Date.now() })
+      render(<HelmValuesDiff />)
+      const lastCall = mockUseCardLoadingState.mock.calls[mockUseCardLoadingState.mock.calls.length - 1][0]
+      expect(lastCall.isRefreshing).toBe(true)
+    })
+
+    it('reports isRefreshing=false when all 3 sources are quiet', () => {
+      mockHelmReleases.mockReturnValue({ releases: [], isLoading: false, isRefreshing: false, isDemoFallback: false, isFailed: false, consecutiveFailures: 0, error: null, lastRefresh: Date.now() })
+      mockHelmValues.mockReturnValue({ values: {}, isLoading: false, isRefreshing: false, isDemoFallback: false, isFailed: false, consecutiveFailures: 0, error: null, lastRefresh: Date.now() })
+      mockUseClusters.mockReturnValue({ clusters: [], deduplicatedClusters: [], isLoading: false, isRefreshing: false, error: null, lastRefresh: Date.now() })
+      render(<HelmValuesDiff />)
+      const lastCall = mockUseCardLoadingState.mock.calls[mockUseCardLoadingState.mock.calls.length - 1][0]
+      expect(lastCall.isRefreshing).toBe(false)
+    })
+  })
 })

--- a/web/src/components/cards/__tests__/NetworkOverview.test.tsx
+++ b/web/src/components/cards/__tests__/NetworkOverview.test.tsx
@@ -141,4 +141,25 @@ describe('NetworkOverview', () => {
     expect(mockUseCardLoadingState).toHaveBeenCalled()
   })
 
+  // #6267: regression coverage for the freshness-indicator wiring
+  // introduced in #6266 (oldest-of-two timestamps + demo-mode suppression
+  // + clustersRefreshing in card-level state).
+  describe('freshness indicator wiring (#6265, #6267)', () => {
+    it('reports clustersRefreshing OR servicesRefreshing to useCardLoadingState', () => {
+      // Services not refreshing, clusters refreshing → card state must show isRefreshing=true
+      mockServices.mockReturnValue({ services: [], isLoading: false, isRefreshing: false, isDemoFallback: false, isFailed: false, consecutiveFailures: 0, error: null, lastRefresh: Date.now() })
+      mockUseClusters.mockReturnValue({ clusters: [], deduplicatedClusters: [], isLoading: false, isRefreshing: true, error: null, lastRefresh: Date.now() })
+      render(<NetworkOverview />)
+      const lastCall = mockUseCardLoadingState.mock.calls[mockUseCardLoadingState.mock.calls.length - 1][0]
+      expect(lastCall.isRefreshing).toBe(true)
+    })
+
+    it('reports isRefreshing=false when neither source is refreshing', () => {
+      mockServices.mockReturnValue({ services: [], isLoading: false, isRefreshing: false, isDemoFallback: false, isFailed: false, consecutiveFailures: 0, error: null, lastRefresh: Date.now() })
+      mockUseClusters.mockReturnValue({ clusters: [], deduplicatedClusters: [], isLoading: false, isRefreshing: false, error: null, lastRefresh: Date.now() })
+      render(<NetworkOverview />)
+      const lastCall = mockUseCardLoadingState.mock.calls[mockUseCardLoadingState.mock.calls.length - 1][0]
+      expect(lastCall.isRefreshing).toBe(false)
+    })
+  })
 })


### PR DESCRIPTION
## Summary

Three Copilot review comments on #6266 — **one real bug**, two test gaps.

### Real bug

\`NetworkOverview\`'s \`RefreshIndicator\` was driven by \`isRefreshing || clustersRefreshing\`, but the matching \`useCardLoadingState({ isRefreshing })\` call only passed the services-cache flag. So a cluster cache refresh would tick the indicator without ticking the card-level refresh animation. Fixed by passing the same combined value.

### Test additions

* **NetworkOverview.test.tsx** — new \"freshness indicator wiring\" block pinning the combined-refresh contract: clusters-refreshing alone should report \`isRefreshing=true\`, both-quiet should report \`false\`.
* **HelmValuesDiff.test.tsx** — same pattern with three sources (clusters, releases, values). Three new assertions cover values-only, clusters-only, and all-quiet.

Verified: **23/23** tests pass locally.

Closes #6267

## Test plan

- [x] 23 tests pass locally
- [x] \`npm run build\` clean
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)