### PR TITLE
test(freshness): assert RefreshIndicator props directly (#6269)

### DIFF
--- a/web/src/components/cards/__tests__/HelmValuesDiff.test.tsx
+++ b/web/src/components/cards/__tests__/HelmValuesDiff.test.tsx
@@ -72,6 +72,17 @@ vi.mock('../../../lib/cards/cardHooks', () => ({
   commonComparators: { string: () => () => 0, number: () => () => 0, statusOrder: () => () => 0, date: () => () => 0, boolean: () => () => 0 },
 }))
 
+// #6269: capture RefreshIndicator props so the freshness-indicator
+// contract (3-source oldest timestamp + demo-mode null + combined
+// isRefreshing) can be asserted directly on the rendered indicator.
+const refreshIndicatorProps = vi.fn()
+vi.mock('../../ui/RefreshIndicator', () => ({
+  RefreshIndicator: (props: { isRefreshing: boolean; lastUpdated: Date | null }) => {
+    refreshIndicatorProps(props)
+    return null
+  },
+}))
+
 import { HelmValuesDiff } from '../HelmValuesDiff'
 
 describe('HelmValuesDiff', () => {
@@ -137,7 +148,7 @@ describe('HelmValuesDiff', () => {
 
   // #6267: regression coverage for the freshness-indicator wiring
   // introduced in #6266 (3-source min timestamp + demo-mode suppression).
-  describe('freshness indicator wiring (#6265, #6267)', () => {
+  describe('freshness indicator wiring (#6265, #6267, #6269)', () => {
     it('reports isRefreshing=true when any source is refreshing', () => {
       // Only values is refreshing — combined isRefreshing must still be true
       mockHelmReleases.mockReturnValue({ releases: [], isLoading: false, isRefreshing: false, isDemoFallback: false, isFailed: false, consecutiveFailures: 0, error: null, lastRefresh: Date.now() })
@@ -162,6 +173,40 @@ describe('HelmValuesDiff', () => {
       render(<HelmValuesDiff />)
       const lastCall = mockUseCardLoadingState.mock.calls[mockUseCardLoadingState.mock.calls.length - 1][0]
       expect(lastCall.isRefreshing).toBe(false)
+    })
+
+    // #6269: assert directly on RefreshIndicator props rather than just
+    // the card-level isRefreshing — proves the 3-source min timestamp
+    // contract and demo-mode null contract are both honored.
+    it('passes the OLDEST of clusters/releases/values lastRefresh to RefreshIndicator', () => {
+      const OLDEST = 1_000_000_000_000
+      const MIDDLE = 2_000_000_000_000
+      const NEWEST = 3_000_000_000_000
+      mockUseClusters.mockReturnValue({ clusters: [], deduplicatedClusters: [], isLoading: false, isRefreshing: false, error: null, lastRefresh: NEWEST })
+      mockHelmReleases.mockReturnValue({ releases: [], isLoading: false, isRefreshing: false, isDemoFallback: false, isFailed: false, consecutiveFailures: 0, error: null, lastRefresh: MIDDLE })
+      mockHelmValues.mockReturnValue({ values: {}, isLoading: false, isRefreshing: false, isDemoFallback: false, isFailed: false, consecutiveFailures: 0, error: null, lastRefresh: OLDEST })
+      render(<HelmValuesDiff />)
+      const props = refreshIndicatorProps.mock.calls[refreshIndicatorProps.mock.calls.length - 1][0]
+      expect(props.lastUpdated).toEqual(new Date(OLDEST))
+    })
+
+    it('passes null lastUpdated when isDemoData is true (regardless of lastRefresh)', () => {
+      // Cache holds a fresh-looking lastRefresh from a prior live session — must be hidden
+      mockHelmReleases.mockReturnValue({ releases: [], isLoading: false, isRefreshing: false, isDemoFallback: true, isFailed: false, consecutiveFailures: 0, error: null, lastRefresh: Date.now() })
+      mockHelmValues.mockReturnValue({ values: {}, isLoading: false, isRefreshing: false, isDemoFallback: false, isFailed: false, consecutiveFailures: 0, error: null, lastRefresh: Date.now() })
+      mockUseClusters.mockReturnValue({ clusters: [], deduplicatedClusters: [], isLoading: false, isRefreshing: false, error: null, lastRefresh: Date.now() })
+      render(<HelmValuesDiff />)
+      const props = refreshIndicatorProps.mock.calls[refreshIndicatorProps.mock.calls.length - 1][0]
+      expect(props.lastUpdated).toBeNull()
+    })
+
+    it('passes isRefreshing=true to RefreshIndicator when values source is refreshing', () => {
+      mockHelmReleases.mockReturnValue({ releases: [], isLoading: false, isRefreshing: false, isDemoFallback: false, isFailed: false, consecutiveFailures: 0, error: null, lastRefresh: Date.now() })
+      mockHelmValues.mockReturnValue({ values: {}, isLoading: false, isRefreshing: true, isDemoFallback: false, isFailed: false, consecutiveFailures: 0, error: null, lastRefresh: Date.now() })
+      mockUseClusters.mockReturnValue({ clusters: [], deduplicatedClusters: [], isLoading: false, isRefreshing: false, error: null, lastRefresh: Date.now() })
+      render(<HelmValuesDiff />)
+      const props = refreshIndicatorProps.mock.calls[refreshIndicatorProps.mock.calls.length - 1][0]
+      expect(props.isRefreshing).toBe(true)
     })
   })
 })

--- a/web/src/components/cards/__tests__/NetworkOverview.test.tsx
+++ b/web/src/components/cards/__tests__/NetworkOverview.test.tsx
@@ -64,6 +64,18 @@ vi.mock('../../../lib/cards/cardHooks', () => ({
   commonComparators: { string: () => () => 0, number: () => () => 0, statusOrder: () => () => 0, date: () => () => 0, boolean: () => () => 0 },
 }))
 
+// #6269: capture RefreshIndicator props so the freshness-indicator
+// contract (oldest-of-two timestamps + demo-mode null + combined
+// isRefreshing) can be asserted directly on the rendered indicator,
+// not just on the card-level useCardLoadingState call.
+const refreshIndicatorProps = vi.fn()
+vi.mock('../../ui/RefreshIndicator', () => ({
+  RefreshIndicator: (props: { isRefreshing: boolean; lastUpdated: Date | null }) => {
+    refreshIndicatorProps(props)
+    return null
+  },
+}))
+
 import { NetworkOverview } from '../NetworkOverview'
 
 describe('NetworkOverview', () => {
@@ -144,7 +156,7 @@ describe('NetworkOverview', () => {
   // #6267: regression coverage for the freshness-indicator wiring
   // introduced in #6266 (oldest-of-two timestamps + demo-mode suppression
   // + clustersRefreshing in card-level state).
-  describe('freshness indicator wiring (#6265, #6267)', () => {
+  describe('freshness indicator wiring (#6265, #6267, #6269)', () => {
     it('reports clustersRefreshing OR servicesRefreshing to useCardLoadingState', () => {
       // Services not refreshing, clusters refreshing → card state must show isRefreshing=true
       mockServices.mockReturnValue({ services: [], isLoading: false, isRefreshing: false, isDemoFallback: false, isFailed: false, consecutiveFailures: 0, error: null, lastRefresh: Date.now() })
@@ -160,6 +172,36 @@ describe('NetworkOverview', () => {
       render(<NetworkOverview />)
       const lastCall = mockUseCardLoadingState.mock.calls[mockUseCardLoadingState.mock.calls.length - 1][0]
       expect(lastCall.isRefreshing).toBe(false)
+    })
+
+    // #6269: assert directly on RefreshIndicator props rather than just
+    // the card-level isRefreshing — the previous tests only proved the
+    // card animation flag was correct, not the timestamp/null contract.
+    it('passes the OLDER of clusters and services lastRefresh to RefreshIndicator', () => {
+      const OLDER = 1_000_000_000_000
+      const NEWER = 2_000_000_000_000
+      mockServices.mockReturnValue({ services: [], isLoading: false, isRefreshing: false, isDemoFallback: false, isFailed: false, consecutiveFailures: 0, error: null, lastRefresh: NEWER })
+      mockUseClusters.mockReturnValue({ clusters: [], deduplicatedClusters: [], isLoading: false, isRefreshing: false, error: null, lastRefresh: OLDER })
+      render(<NetworkOverview />)
+      const props = refreshIndicatorProps.mock.calls[refreshIndicatorProps.mock.calls.length - 1][0]
+      expect(props.lastUpdated).toEqual(new Date(OLDER))
+    })
+
+    it('passes null lastUpdated when isDemoFallback is true (regardless of lastRefresh)', () => {
+      // Cache holds a stale lastRefresh from a prior live session — must be hidden in demo mode
+      mockServices.mockReturnValue({ services: [], isLoading: false, isRefreshing: false, isDemoFallback: true, isFailed: false, consecutiveFailures: 0, error: null, lastRefresh: Date.now() })
+      mockUseClusters.mockReturnValue({ clusters: [], deduplicatedClusters: [], isLoading: false, isRefreshing: false, error: null, lastRefresh: Date.now() })
+      render(<NetworkOverview />)
+      const props = refreshIndicatorProps.mock.calls[refreshIndicatorProps.mock.calls.length - 1][0]
+      expect(props.lastUpdated).toBeNull()
+    })
+
+    it('passes isRefreshing=true to RefreshIndicator when clusters source is refreshing', () => {
+      mockServices.mockReturnValue({ services: [], isLoading: false, isRefreshing: false, isDemoFallback: false, isFailed: false, consecutiveFailures: 0, error: null, lastRefresh: Date.now() })
+      mockUseClusters.mockReturnValue({ clusters: [], deduplicatedClusters: [], isLoading: false, isRefreshing: true, error: null, lastRefresh: Date.now() })
+      render(<NetworkOverview />)
+      const props = refreshIndicatorProps.mock.calls[refreshIndicatorProps.mock.calls.length - 1][0]
+      expect(props.isRefreshing).toBe(true)
     })
   })
 })


### PR DESCRIPTION
## Summary

Copilot's review of #6268 noted that the new \"freshness indicator wiring\" tests proved the card-level \`isRefreshing\` flag was correct but didn't actually exercise the \`RefreshIndicator\` contract: oldest-of-N timestamp selection and demo-mode null suppression.

### Approach

Mock \`RefreshIndicator\` at the test level and capture its props via a spy. Assert directly on \`lastUpdated\` and \`isRefreshing\` rather than relying on the indirect \`useCardLoadingState\` signal.

### NetworkOverview gains 3 assertions

- OLDER of clusters/services \`lastRefresh\` is selected
- \`lastUpdated\` is null when \`isDemoFallback=true\`
- \`isRefreshing\` flows through when only clusters source is refreshing

### HelmValuesDiff gains 3 assertions

- OLDEST of clusters/releases/values \`lastRefresh\` is selected
- \`lastUpdated\` is null when \`isDemoData=true\`
- \`isRefreshing\` flows through when only values source is refreshing

Verified: **29/29** tests pass (was 23 before).

Closes #6269

## Test plan

- [x] 29 tests pass locally
- [x] \`npm run build\` clean
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)