### PR TITLE
fix(freshness): normalize useClusters Date timestamp + correct test types (#6271)

### DIFF
--- a/web/src/components/cards/ClusterFocus.tsx
+++ b/web/src/components/cards/ClusterFocus.tsx
@@ -19,7 +19,12 @@ interface ClusterFocusProps {
 export function ClusterFocus({ config }: ClusterFocusProps) {
   const { t } = useTranslation(['cards', 'common'])
   const selectedCluster = config?.cluster
-  const { deduplicatedClusters: allClusters, isLoading: clustersLoading, isRefreshing: clustersRefreshing, isFailed, consecutiveFailures, lastRefresh: clustersLastRefresh } = useClusters()
+  const { deduplicatedClusters: allClusters, isLoading: clustersLoading, isRefreshing: clustersRefreshing, isFailed, consecutiveFailures, lastRefresh: clustersLastRefreshDate } = useClusters()
+  // #6271: useClusters returns Date|null; normalize to numeric epoch
+  // so it merges cleanly with the numeric `lastRefresh` from useCache.
+  const clustersLastRefresh: number | null = clustersLastRefreshDate instanceof Date
+    ? clustersLastRefreshDate.getTime()
+    : (typeof clustersLastRefreshDate === 'number' ? clustersLastRefreshDate : null)
   // #6217: destructure lastRefresh from each underlying hook so the card
   // can render a freshness indicator using the OLDEST timestamp (= the
   // staler half of the data the user is looking at).

--- a/web/src/components/cards/HelmValuesDiff.tsx
+++ b/web/src/components/cards/HelmValuesDiff.tsx
@@ -55,7 +55,12 @@ const SORT_OPTIONS = [
 
 export function HelmValuesDiff({ config }: HelmValuesDiffProps) {
   const { t } = useTranslation()
-  const { deduplicatedClusters: allClusters, isLoading: clustersLoading, isRefreshing: clustersRefreshing, isFailed: clustersFailed, consecutiveFailures: clustersFailures, lastRefresh: clustersLastRefresh } = useClusters()
+  const { deduplicatedClusters: allClusters, isLoading: clustersLoading, isRefreshing: clustersRefreshing, isFailed: clustersFailed, consecutiveFailures: clustersFailures, lastRefresh: clustersLastRefreshDate } = useClusters()
+  // #6271: useClusters returns Date|null; normalize to numeric epoch
+  // so it merges cleanly with the numeric `lastRefresh` from useCache.
+  const clustersLastRefresh: number | null = clustersLastRefreshDate instanceof Date
+    ? clustersLastRefreshDate.getTime()
+    : (typeof clustersLastRefreshDate === 'number' ? clustersLastRefreshDate : null)
   const [selectedCluster, setSelectedCluster] = useState<string>(config?.cluster || '')
   const [selectedRelease, setSelectedRelease] = useState<string>(config?.release || '')
   const { drillToHelm } = useDrillDownActions()

--- a/web/src/components/cards/NetworkOverview.tsx
+++ b/web/src/components/cards/NetworkOverview.tsx
@@ -11,7 +11,12 @@ import { ClusterStatusDot } from '../ui/ClusterStatusBadge'
 import { RefreshIndicator } from '../ui/RefreshIndicator'
 
 export function NetworkOverview() {
-  const { deduplicatedClusters: clusters, isLoading, isRefreshing: clustersRefreshing, lastRefresh: clustersLastRefresh } = useClusters()
+  const { deduplicatedClusters: clusters, isLoading, isRefreshing: clustersRefreshing, lastRefresh: clustersLastRefreshDate } = useClusters()
+  // #6271: useClusters returns lastRefresh as `Date | null`, but the
+  // freshness merge below expects a numeric epoch. Normalize once.
+  const clustersLastRefresh: number | null = clustersLastRefreshDate instanceof Date
+    ? clustersLastRefreshDate.getTime()
+    : (typeof clustersLastRefreshDate === 'number' ? clustersLastRefreshDate : null)
   const { services, isLoading: servicesLoading, isRefreshing, isDemoFallback, consecutiveFailures, isFailed, lastRefresh: servicesLastRefresh } = useCachedServices()
 
   const { selectedClusters, isAllClustersSelected } = useGlobalFilters()

--- a/web/src/components/cards/ResourceUsage.tsx
+++ b/web/src/components/cards/ResourceUsage.tsx
@@ -19,7 +19,11 @@ function ResourceUsageInternal() {
   const { t } = useTranslation(['cards', 'common'])
   // #6217: destructure lastRefresh so the card can render a freshness
   // indicator instead of leaving users guessing how stale the data is.
-  const { isLoading: clustersLoading, isRefreshing: clustersRefreshing, lastRefresh: clustersLastRefresh } = useClusters()
+  // #6271: useClusters returns Date|null; normalize to numeric epoch.
+  const { isLoading: clustersLoading, isRefreshing: clustersRefreshing, lastRefresh: clustersLastRefreshDate } = useClusters()
+  const clustersLastRefresh: number | null = clustersLastRefreshDate instanceof Date
+    ? clustersLastRefreshDate.getTime()
+    : (typeof clustersLastRefreshDate === 'number' ? clustersLastRefreshDate : null)
   const { nodes: allGPUNodes, isDemoFallback, isRefreshing: gpuRefreshing, lastRefresh: gpuLastRefresh } = useCachedGPUNodes()
   const { drillToResources } = useDrillDownActions()
   const { isDemoMode } = useDemoMode()

--- a/web/src/components/cards/__tests__/HelmValuesDiff.test.tsx
+++ b/web/src/components/cards/__tests__/HelmValuesDiff.test.tsx
@@ -182,7 +182,10 @@ describe('HelmValuesDiff', () => {
       const OLDEST = 1_000_000_000_000
       const MIDDLE = 2_000_000_000_000
       const NEWEST = 3_000_000_000_000
-      mockUseClusters.mockReturnValue({ clusters: [], deduplicatedClusters: [], isLoading: false, isRefreshing: false, error: null, lastRefresh: NEWEST })
+      // #6271: useClusters().lastRefresh is `Date | null` per shared.ts;
+      // useCachedHelm{Releases,Values}().lastRefresh is numeric epoch.
+      // Mocks must match the real types.
+      mockUseClusters.mockReturnValue({ clusters: [], deduplicatedClusters: [], isLoading: false, isRefreshing: false, error: null, lastRefresh: new Date(NEWEST) })
       mockHelmReleases.mockReturnValue({ releases: [], isLoading: false, isRefreshing: false, isDemoFallback: false, isFailed: false, consecutiveFailures: 0, error: null, lastRefresh: MIDDLE })
       mockHelmValues.mockReturnValue({ values: {}, isLoading: false, isRefreshing: false, isDemoFallback: false, isFailed: false, consecutiveFailures: 0, error: null, lastRefresh: OLDEST })
       render(<HelmValuesDiff />)

--- a/web/src/components/cards/__tests__/NetworkOverview.test.tsx
+++ b/web/src/components/cards/__tests__/NetworkOverview.test.tsx
@@ -180,8 +180,12 @@ describe('NetworkOverview', () => {
     it('passes the OLDER of clusters and services lastRefresh to RefreshIndicator', () => {
       const OLDER = 1_000_000_000_000
       const NEWER = 2_000_000_000_000
+      // #6271: useClusters().lastRefresh is `Date | null` per shared.ts,
+      // useCachedServices().lastRefresh is numeric epoch — mocks must
+      // match the real types, otherwise the source's normalization
+      // path isn't actually exercised.
       mockServices.mockReturnValue({ services: [], isLoading: false, isRefreshing: false, isDemoFallback: false, isFailed: false, consecutiveFailures: 0, error: null, lastRefresh: NEWER })
-      mockUseClusters.mockReturnValue({ clusters: [], deduplicatedClusters: [], isLoading: false, isRefreshing: false, error: null, lastRefresh: OLDER })
+      mockUseClusters.mockReturnValue({ clusters: [], deduplicatedClusters: [], isLoading: false, isRefreshing: false, error: null, lastRefresh: new Date(OLDER) })
       render(<NetworkOverview />)
       const props = refreshIndicatorProps.mock.calls[refreshIndicatorProps.mock.calls.length - 1][0]
       expect(props.lastUpdated).toEqual(new Date(OLDER))


### PR DESCRIPTION
## Summary

Copilot's review of #6270 caught a **real type mismatch hiding behind the new freshness-indicator tests**.

\`useClusters().lastRefresh\` is \`Date | null\` per \`web/src/hooks/mcp/shared.ts:70\`, but four cards were checking \`typeof clustersLastRefresh === 'number'\` and the tests were mocking it as a numeric epoch. The \`typeof === 'number'\` check is **always false for a Date**, so the cluster timestamp was silently dropped from the merge — meaning the \"OLDEST of N timestamps\" guarantee from #6266 was actually broken in production.

### What was happening

1. **Wrong UX**: stale cluster data was hidden behind a fresh-looking services/releases/values timestamp.
2. **False test confidence**: mocking as a number bypassed the broken \`typeof number\` filter and made the merge appear correct.

### Source fix (4 cards)

\`NetworkOverview\`, \`ResourceUsage\`, \`ClusterFocus\`, \`HelmValuesDiff\`:

\`\`\`ts
const { lastRefresh: clustersLastRefreshDate } = useClusters()
const clustersLastRefresh: number | null = clustersLastRefreshDate instanceof Date
  ? clustersLastRefreshDate.getTime()
  : (typeof clustersLastRefreshDate === 'number' ? clustersLastRefreshDate : null)
\`\`\`

The downstream merge code is unchanged.

### Test fix

Updated mocks in \`NetworkOverview.test.tsx\` and \`HelmValuesDiff.test.tsx\` to pass \`new Date(...)\` for \`useClusters()\` so the real types are used and the source's normalization path is actually exercised.

Verified: **29/29** tests pass with the corrected Date mocks.

Closes #6271

## Test plan

- [x] 29 tests pass with corrected types
- [x] \`npm run build\` clean
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)