### PR TITLE
fix(freshness): hide ClusterFocus + ResourceUsage timestamps in demo mode + tighten test mocks (#6273)

### DIFF
--- a/web/src/components/cards/ClusterFocus.tsx
+++ b/web/src/components/cards/ClusterFocus.tsx
@@ -139,10 +139,14 @@ export function ClusterFocus({ config }: ClusterFocusProps) {
               timestamps so users see the staler half of the data.
               #6244: include cluster cache timestamp — ClusterFocus reads
               health/metrics from useClusters(), so excluding it could
-              misrepresent overall card freshness. */}
+              misrepresent overall card freshness.
+              #6273: hide the timestamp entirely in demo mode — useCache
+              preserves lastRefresh from prior live sessions, which would
+              show "Updated X ago" against demo data. */}
           <RefreshIndicator
             isRefreshing={clustersRefreshing || gpuRefreshing || podsRefreshing || deploymentsRefreshing}
             lastUpdated={(() => {
+              if (isDemoMode || gpuDemoFallback || podsDemoFallback || deployDemoFallback) return null
               const ts = [clustersLastRefresh, gpuLastRefresh, podsLastRefresh, deployLastRefresh].filter((t): t is number => typeof t === 'number')
               return ts.length > 0 ? new Date(Math.min(...ts)) : null
             })()}

--- a/web/src/components/cards/ResourceUsage.tsx
+++ b/web/src/components/cards/ResourceUsage.tsx
@@ -169,10 +169,14 @@ function ResourceUsageInternal() {
             </span>
           )}
           {/* #6217: freshness indicator. #6244: use the OLDER of cluster
-              and GPU timestamps so the indicator reflects the staler source. */}
+              and GPU timestamps so the indicator reflects the staler source.
+              #6273: hide the timestamp in demo mode — useCache preserves
+              lastRefresh from prior live sessions, which would show
+              "Updated X ago" against demo data. */}
           <RefreshIndicator
             isRefreshing={clustersRefreshing || gpuRefreshing}
             lastUpdated={(() => {
+              if (isDemoMode || isDemoFallback) return null
               const cl = typeof clustersLastRefresh === 'number' ? clustersLastRefresh : null
               const gp = typeof gpuLastRefresh === 'number' ? gpuLastRefresh : null
               if (cl !== null && gp !== null) return new Date(Math.min(cl, gp))

--- a/web/src/components/cards/__tests__/HelmValuesDiff.test.tsx
+++ b/web/src/components/cards/__tests__/HelmValuesDiff.test.tsx
@@ -92,7 +92,7 @@ describe('HelmValuesDiff', () => {
     mockUseCardLoadingState.mockReturnValue({ showSkeleton: false, showEmptyState: false, hasData: true, isRefreshing: false })
     mockHelmReleases.mockReturnValue({ releases: [], isLoading: false, isRefreshing: false, isDemoFallback: false, isFailed: false, consecutiveFailures: 0, error: null, lastRefresh: Date.now() })
     mockHelmValues.mockReturnValue({ values: {}, isLoading: false, isRefreshing: false, isDemoFallback: false, isFailed: false, consecutiveFailures: 0, error: null, lastRefresh: Date.now() })
-    mockUseClusters.mockReturnValue({ clusters: [], deduplicatedClusters: [], isLoading: false, isRefreshing: false, error: null, lastRefresh: Date.now() })
+    mockUseClusters.mockReturnValue({ clusters: [], deduplicatedClusters: [], isLoading: false, isRefreshing: false, error: null, lastRefresh: new Date() })
     mockDrillDown.mockReturnValue({ drillToHelm: vi.fn() })
   })
 
@@ -134,7 +134,7 @@ describe('HelmValuesDiff', () => {
   it('renders with cluster data available', () => {
     mockUseClusters.mockReturnValue({
       clusters: [{ name: 'prod-cluster', healthy: true, reachable: true, nodeCount: 3, podCount: 10, cpuCores: 8, memoryGB: 16, cpuRequestsCores: 4, memoryRequestsGB: 8 }], deduplicatedClusters: [{ name: 'prod-cluster', healthy: true, reachable: true, nodeCount: 3, podCount: 10, cpuCores: 8, memoryGB: 16, cpuRequestsCores: 4, memoryRequestsGB: 8 }],
-      isLoading: false, isRefreshing: false, error: null, lastRefresh: Date.now(),
+      isLoading: false, isRefreshing: false, error: null, lastRefresh: new Date(),
     })
     const { container } = render(<HelmValuesDiff />)
     expect(container).toBeTruthy()
@@ -153,14 +153,14 @@ describe('HelmValuesDiff', () => {
       // Only values is refreshing — combined isRefreshing must still be true
       mockHelmReleases.mockReturnValue({ releases: [], isLoading: false, isRefreshing: false, isDemoFallback: false, isFailed: false, consecutiveFailures: 0, error: null, lastRefresh: Date.now() })
       mockHelmValues.mockReturnValue({ values: {}, isLoading: false, isRefreshing: true, isDemoFallback: false, isFailed: false, consecutiveFailures: 0, error: null, lastRefresh: Date.now() })
-      mockUseClusters.mockReturnValue({ clusters: [], deduplicatedClusters: [], isLoading: false, isRefreshing: false, error: null, lastRefresh: Date.now() })
+      mockUseClusters.mockReturnValue({ clusters: [], deduplicatedClusters: [], isLoading: false, isRefreshing: false, error: null, lastRefresh: new Date() })
       render(<HelmValuesDiff />)
       const lastCall = mockUseCardLoadingState.mock.calls[mockUseCardLoadingState.mock.calls.length - 1][0]
       expect(lastCall.isRefreshing).toBe(true)
     })
 
     it('reports isRefreshing=true when clusters source is refreshing', () => {
-      mockUseClusters.mockReturnValue({ clusters: [], deduplicatedClusters: [], isLoading: false, isRefreshing: true, error: null, lastRefresh: Date.now() })
+      mockUseClusters.mockReturnValue({ clusters: [], deduplicatedClusters: [], isLoading: false, isRefreshing: true, error: null, lastRefresh: new Date() })
       render(<HelmValuesDiff />)
       const lastCall = mockUseCardLoadingState.mock.calls[mockUseCardLoadingState.mock.calls.length - 1][0]
       expect(lastCall.isRefreshing).toBe(true)
@@ -169,7 +169,7 @@ describe('HelmValuesDiff', () => {
     it('reports isRefreshing=false when all 3 sources are quiet', () => {
       mockHelmReleases.mockReturnValue({ releases: [], isLoading: false, isRefreshing: false, isDemoFallback: false, isFailed: false, consecutiveFailures: 0, error: null, lastRefresh: Date.now() })
       mockHelmValues.mockReturnValue({ values: {}, isLoading: false, isRefreshing: false, isDemoFallback: false, isFailed: false, consecutiveFailures: 0, error: null, lastRefresh: Date.now() })
-      mockUseClusters.mockReturnValue({ clusters: [], deduplicatedClusters: [], isLoading: false, isRefreshing: false, error: null, lastRefresh: Date.now() })
+      mockUseClusters.mockReturnValue({ clusters: [], deduplicatedClusters: [], isLoading: false, isRefreshing: false, error: null, lastRefresh: new Date() })
       render(<HelmValuesDiff />)
       const lastCall = mockUseCardLoadingState.mock.calls[mockUseCardLoadingState.mock.calls.length - 1][0]
       expect(lastCall.isRefreshing).toBe(false)
@@ -197,7 +197,7 @@ describe('HelmValuesDiff', () => {
       // Cache holds a fresh-looking lastRefresh from a prior live session — must be hidden
       mockHelmReleases.mockReturnValue({ releases: [], isLoading: false, isRefreshing: false, isDemoFallback: true, isFailed: false, consecutiveFailures: 0, error: null, lastRefresh: Date.now() })
       mockHelmValues.mockReturnValue({ values: {}, isLoading: false, isRefreshing: false, isDemoFallback: false, isFailed: false, consecutiveFailures: 0, error: null, lastRefresh: Date.now() })
-      mockUseClusters.mockReturnValue({ clusters: [], deduplicatedClusters: [], isLoading: false, isRefreshing: false, error: null, lastRefresh: Date.now() })
+      mockUseClusters.mockReturnValue({ clusters: [], deduplicatedClusters: [], isLoading: false, isRefreshing: false, error: null, lastRefresh: new Date() })
       render(<HelmValuesDiff />)
       const props = refreshIndicatorProps.mock.calls[refreshIndicatorProps.mock.calls.length - 1][0]
       expect(props.lastUpdated).toBeNull()
@@ -206,7 +206,7 @@ describe('HelmValuesDiff', () => {
     it('passes isRefreshing=true to RefreshIndicator when values source is refreshing', () => {
       mockHelmReleases.mockReturnValue({ releases: [], isLoading: false, isRefreshing: false, isDemoFallback: false, isFailed: false, consecutiveFailures: 0, error: null, lastRefresh: Date.now() })
       mockHelmValues.mockReturnValue({ values: {}, isLoading: false, isRefreshing: true, isDemoFallback: false, isFailed: false, consecutiveFailures: 0, error: null, lastRefresh: Date.now() })
-      mockUseClusters.mockReturnValue({ clusters: [], deduplicatedClusters: [], isLoading: false, isRefreshing: false, error: null, lastRefresh: Date.now() })
+      mockUseClusters.mockReturnValue({ clusters: [], deduplicatedClusters: [], isLoading: false, isRefreshing: false, error: null, lastRefresh: new Date() })
       render(<HelmValuesDiff />)
       const props = refreshIndicatorProps.mock.calls[refreshIndicatorProps.mock.calls.length - 1][0]
       expect(props.isRefreshing).toBe(true)

--- a/web/src/components/cards/__tests__/NetworkOverview.test.tsx
+++ b/web/src/components/cards/__tests__/NetworkOverview.test.tsx
@@ -84,7 +84,7 @@ describe('NetworkOverview', () => {
     mockUseDemoMode.mockReturnValue({ isDemoMode: true, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() })
     mockUseCardLoadingState.mockReturnValue({ showSkeleton: false, showEmptyState: false, hasData: true, isRefreshing: false })
     mockServices.mockReturnValue({ services: [], isLoading: false, isRefreshing: false, isDemoFallback: false, isFailed: false, consecutiveFailures: 0, error: null, lastRefresh: Date.now() })
-    mockUseClusters.mockReturnValue({ clusters: [], deduplicatedClusters: [], isLoading: false, isRefreshing: false, error: null, lastRefresh: Date.now() })
+    mockUseClusters.mockReturnValue({ clusters: [], deduplicatedClusters: [], isLoading: false, isRefreshing: false, error: null, lastRefresh: new Date() })
     mockDrillDown.mockReturnValue({ drillToNetwork: vi.fn() })
   })
 
@@ -141,7 +141,7 @@ describe('NetworkOverview', () => {
   it('renders with cluster data available', () => {
     mockUseClusters.mockReturnValue({
       clusters: [{ name: 'prod-cluster', healthy: true, reachable: true, nodeCount: 3, podCount: 10, cpuCores: 8, memoryGB: 16, cpuRequestsCores: 4, memoryRequestsGB: 8 }], deduplicatedClusters: [{ name: 'prod-cluster', healthy: true, reachable: true, nodeCount: 3, podCount: 10, cpuCores: 8, memoryGB: 16, cpuRequestsCores: 4, memoryRequestsGB: 8 }],
-      isLoading: false, isRefreshing: false, error: null, lastRefresh: Date.now(),
+      isLoading: false, isRefreshing: false, error: null, lastRefresh: new Date(),
     })
     const { container } = render(<NetworkOverview />)
     expect(container).toBeTruthy()
@@ -160,7 +160,7 @@ describe('NetworkOverview', () => {
     it('reports clustersRefreshing OR servicesRefreshing to useCardLoadingState', () => {
       // Services not refreshing, clusters refreshing → card state must show isRefreshing=true
       mockServices.mockReturnValue({ services: [], isLoading: false, isRefreshing: false, isDemoFallback: false, isFailed: false, consecutiveFailures: 0, error: null, lastRefresh: Date.now() })
-      mockUseClusters.mockReturnValue({ clusters: [], deduplicatedClusters: [], isLoading: false, isRefreshing: true, error: null, lastRefresh: Date.now() })
+      mockUseClusters.mockReturnValue({ clusters: [], deduplicatedClusters: [], isLoading: false, isRefreshing: true, error: null, lastRefresh: new Date() })
       render(<NetworkOverview />)
       const lastCall = mockUseCardLoadingState.mock.calls[mockUseCardLoadingState.mock.calls.length - 1][0]
       expect(lastCall.isRefreshing).toBe(true)
@@ -168,7 +168,7 @@ describe('NetworkOverview', () => {
 
     it('reports isRefreshing=false when neither source is refreshing', () => {
       mockServices.mockReturnValue({ services: [], isLoading: false, isRefreshing: false, isDemoFallback: false, isFailed: false, consecutiveFailures: 0, error: null, lastRefresh: Date.now() })
-      mockUseClusters.mockReturnValue({ clusters: [], deduplicatedClusters: [], isLoading: false, isRefreshing: false, error: null, lastRefresh: Date.now() })
+      mockUseClusters.mockReturnValue({ clusters: [], deduplicatedClusters: [], isLoading: false, isRefreshing: false, error: null, lastRefresh: new Date() })
       render(<NetworkOverview />)
       const lastCall = mockUseCardLoadingState.mock.calls[mockUseCardLoadingState.mock.calls.length - 1][0]
       expect(lastCall.isRefreshing).toBe(false)
@@ -194,7 +194,7 @@ describe('NetworkOverview', () => {
     it('passes null lastUpdated when isDemoFallback is true (regardless of lastRefresh)', () => {
       // Cache holds a stale lastRefresh from a prior live session — must be hidden in demo mode
       mockServices.mockReturnValue({ services: [], isLoading: false, isRefreshing: false, isDemoFallback: true, isFailed: false, consecutiveFailures: 0, error: null, lastRefresh: Date.now() })
-      mockUseClusters.mockReturnValue({ clusters: [], deduplicatedClusters: [], isLoading: false, isRefreshing: false, error: null, lastRefresh: Date.now() })
+      mockUseClusters.mockReturnValue({ clusters: [], deduplicatedClusters: [], isLoading: false, isRefreshing: false, error: null, lastRefresh: new Date() })
       render(<NetworkOverview />)
       const props = refreshIndicatorProps.mock.calls[refreshIndicatorProps.mock.calls.length - 1][0]
       expect(props.lastUpdated).toBeNull()
@@ -202,7 +202,7 @@ describe('NetworkOverview', () => {
 
     it('passes isRefreshing=true to RefreshIndicator when clusters source is refreshing', () => {
       mockServices.mockReturnValue({ services: [], isLoading: false, isRefreshing: false, isDemoFallback: false, isFailed: false, consecutiveFailures: 0, error: null, lastRefresh: Date.now() })
-      mockUseClusters.mockReturnValue({ clusters: [], deduplicatedClusters: [], isLoading: false, isRefreshing: true, error: null, lastRefresh: Date.now() })
+      mockUseClusters.mockReturnValue({ clusters: [], deduplicatedClusters: [], isLoading: false, isRefreshing: true, error: null, lastRefresh: new Date() })
       render(<NetworkOverview />)
       const props = refreshIndicatorProps.mock.calls[refreshIndicatorProps.mock.calls.length - 1][0]
       expect(props.isRefreshing).toBe(true)

--- a/web/src/test/ui-ux-standards.test.ts
+++ b/web/src/test/ui-ux-standards.test.ts
@@ -62,11 +62,12 @@ const COMPONENTS_DIR = path.resolve(
 //   290 → 293: #6217 part 2 freshness indicator additions
 //   293 → 296: #6217 part 3 freshness additions
 //   296 → 298: #6265 copilot follow-up comment refs
+//   298 → 300: #6273 followup comment refs
 //
 // When you bump this number, append a one-line entry above so future
 // bumps stay grep-able and reviewers can tell at a glance whether a
 // change is a real new violation or just a comment-level reference.
-const EXPECTED_RAW_HEX_COUNT = 298
+const EXPECTED_RAW_HEX_COUNT = 300
 const EXPECTED_RAW_RGBA_COUNT = 104
 const EXPECTED_ARBITRARY_TW_COLOR_COUNT = 22
 const EXPECTED_INLINE_STYLE_COLOR_COUNT = 213


### PR DESCRIPTION
## Summary

Copilot's review of #6272 caught **two real bugs** and **two test consistency gaps**:

### 1-2. Real source bugs

Now that #6271 made cluster timestamps actually flow through the merge (they were silently dropped before because of the broken \`typeof === 'number'\` filter), \`ClusterFocus\` and \`ResourceUsage\` started showing \"Updated X ago\" against demo data — because \`useCache\` preserves \`lastRefresh\` from prior live sessions.

Both cards now return \`null\` for \`lastUpdated\` when any of the relevant demo flags are true.

### 3-4. Test consistency

Most \`mockUseClusters.mockReturnValue\` calls in NetworkOverview / HelmValuesDiff tests still passed \`Date.now()\` (number); only the new freshness tests used \`new Date(...)\`. The production type is \`Date | null\`, so **all** mocks should match — otherwise the source's normalization path is only exercised in one test.

Verified: 29 freshness tests + 38 ClusterFocus/ResourceUsage tests passing.

Closes #6273

## Test plan

- [x] 29 + 38 = 67 tests pass locally
- [x] \`npm run build\` clean
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)