### PR TITLE
test(freshness): default beforeEach to non-demo mode for consistency (#6276)

### DIFF
--- a/web/src/components/cards/__tests__/HelmValuesDiff.test.tsx
+++ b/web/src/components/cards/__tests__/HelmValuesDiff.test.tsx
@@ -88,7 +88,12 @@ import { HelmValuesDiff } from '../HelmValuesDiff'
 describe('HelmValuesDiff', () => {
   beforeEach(() => {
     vi.clearAllMocks()
-    mockUseDemoMode.mockReturnValue({ isDemoMode: true, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() })
+    // #6276: default to non-demo mode in beforeEach. Tests that
+    // exercise demo behavior override `useDemoMode` and `isDemoFallback`
+    // explicitly. Defaulting to demo here meant `useDemoMode().isDemoMode`
+    // and `useCachedHelm{Releases,Values}().isDemoFallback` disagreed
+    // by default, which doesn't match production.
+    mockUseDemoMode.mockReturnValue({ isDemoMode: false, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() })
     mockUseCardLoadingState.mockReturnValue({ showSkeleton: false, showEmptyState: false, hasData: true, isRefreshing: false })
     mockHelmReleases.mockReturnValue({ releases: [], isLoading: false, isRefreshing: false, isDemoFallback: false, isFailed: false, consecutiveFailures: 0, error: null, lastRefresh: Date.now() })
     mockHelmValues.mockReturnValue({ values: {}, isLoading: false, isRefreshing: false, isDemoFallback: false, isFailed: false, consecutiveFailures: 0, error: null, lastRefresh: Date.now() })

--- a/web/src/components/cards/__tests__/NetworkOverview.test.tsx
+++ b/web/src/components/cards/__tests__/NetworkOverview.test.tsx
@@ -81,7 +81,14 @@ import { NetworkOverview } from '../NetworkOverview'
 describe('NetworkOverview', () => {
   beforeEach(() => {
     vi.clearAllMocks()
-    mockUseDemoMode.mockReturnValue({ isDemoMode: true, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() })
+    // #6276: default to non-demo mode in beforeEach. The tests that
+    // exercise demo behavior override `useDemoMode` and `isDemoFallback`
+    // explicitly. Defaulting to demo here meant `useDemoMode().isDemoMode`
+    // and `useCachedServices().isDemoFallback` disagreed by default,
+    // which doesn't match production (useCache flips isDemoFallback to
+    // true whenever a live fetch can't be served from a real backend
+    // and demo mode is on).
+    mockUseDemoMode.mockReturnValue({ isDemoMode: false, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() })
     mockUseCardLoadingState.mockReturnValue({ showSkeleton: false, showEmptyState: false, hasData: true, isRefreshing: false })
     mockServices.mockReturnValue({ services: [], isLoading: false, isRefreshing: false, isDemoFallback: false, isFailed: false, consecutiveFailures: 0, error: null, lastRefresh: Date.now() })
     mockUseClusters.mockReturnValue({ clusters: [], deduplicatedClusters: [], isLoading: false, isRefreshing: false, error: null, lastRefresh: new Date() })


### PR DESCRIPTION
## Summary

Copilot's review of #6274 caught an internal inconsistency in both \`NetworkOverview\` and \`HelmValuesDiff\` test setups: \`useDemoMode\` was mocked as \`isDemoMode: true\` in \`beforeEach\`, but the underlying cache hooks (\`useCachedServices\`, \`useCachedHelmReleases\`, \`useCachedHelmValues\`) had \`isDemoFallback: false\`. In production, when demo mode is on AND a live fetch can't be served from a real backend, \`useCache\` flips \`isDemoFallback\` to true — so the default mock state didn't match any real production scenario.

### Fix

Flip the default \`isDemoMode\` to \`false\` in both \`beforeEach\` blocks. The two existing \"renders correctly in demo mode\" tests already override \`useDemoMode\` explicitly so they're unaffected. The freshness indicator wiring tests already manage their own demo flags.

Verified: **29/29** tests pass (no behavior change, pure consistency fix).

Closes #6276

## Test plan

- [x] 29 tests pass locally
- [x] \`npm run build\` clean
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)