### PR TITLE
test(freshness): tighten beforeEach comment + flip isDemoFallback in demo tests (#6278)

### DIFF
--- a/web/src/components/cards/__tests__/HelmValuesDiff.test.tsx
+++ b/web/src/components/cards/__tests__/HelmValuesDiff.test.tsx
@@ -88,11 +88,17 @@ import { HelmValuesDiff } from '../HelmValuesDiff'
 describe('HelmValuesDiff', () => {
   beforeEach(() => {
     vi.clearAllMocks()
-    // #6276: default to non-demo mode in beforeEach. Tests that
-    // exercise demo behavior override `useDemoMode` and `isDemoFallback`
-    // explicitly. Defaulting to demo here meant `useDemoMode().isDemoMode`
-    // and `useCachedHelm{Releases,Values}().isDemoFallback` disagreed
-    // by default, which doesn't match production.
+    // #6276/#6278: default both `useDemoMode().isDemoMode` and the
+    // cache hooks' `isDemoFallback` to false. In production, `useCache`
+    // (web/src/lib/cache/index.ts:1324) sets `isDemoFallback: true`
+    // whenever the user is being shown demo data instead of live cache
+    // results — that includes ALL of:
+    //   - shouldFallbackToDemo (a real fetch failed)
+    //   - !effectiveEnabled (caching disabled, e.g. demo-mode toggle on)
+    //   - showOptimisticDemo (first load while live fetch is pending)
+    // So `isDemoMode === true` AND `isDemoFallback === false` is not
+    // a state production ever produces. Tests that want demo behavior
+    // override BOTH explicitly.
     mockUseDemoMode.mockReturnValue({ isDemoMode: false, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() })
     mockUseCardLoadingState.mockReturnValue({ showSkeleton: false, showEmptyState: false, hasData: true, isRefreshing: false })
     mockHelmReleases.mockReturnValue({ releases: [], isLoading: false, isRefreshing: false, isDemoFallback: false, isFailed: false, consecutiveFailures: 0, error: null, lastRefresh: Date.now() })
@@ -112,7 +118,11 @@ describe('HelmValuesDiff', () => {
   })
 
   it('renders correctly in demo mode', () => {
+    // #6278: flip BOTH demo flags so the mock state matches what
+    // production actually produces (see beforeEach comment).
     mockUseDemoMode.mockReturnValue({ isDemoMode: true, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() })
+    mockHelmReleases.mockReturnValue({ releases: [], isLoading: false, isRefreshing: false, isDemoFallback: true, isFailed: false, consecutiveFailures: 0, error: null, lastRefresh: Date.now() })
+    mockHelmValues.mockReturnValue({ values: {}, isLoading: false, isRefreshing: false, isDemoFallback: true, isFailed: false, consecutiveFailures: 0, error: null, lastRefresh: Date.now() })
     const { container } = render(<HelmValuesDiff />)
     expect(container).toBeTruthy()
   })

--- a/web/src/components/cards/__tests__/NetworkOverview.test.tsx
+++ b/web/src/components/cards/__tests__/NetworkOverview.test.tsx
@@ -81,13 +81,17 @@ import { NetworkOverview } from '../NetworkOverview'
 describe('NetworkOverview', () => {
   beforeEach(() => {
     vi.clearAllMocks()
-    // #6276: default to non-demo mode in beforeEach. The tests that
-    // exercise demo behavior override `useDemoMode` and `isDemoFallback`
-    // explicitly. Defaulting to demo here meant `useDemoMode().isDemoMode`
-    // and `useCachedServices().isDemoFallback` disagreed by default,
-    // which doesn't match production (useCache flips isDemoFallback to
-    // true whenever a live fetch can't be served from a real backend
-    // and demo mode is on).
+    // #6276/#6278: default both `useDemoMode().isDemoMode` and the
+    // cache hooks' `isDemoFallback` to false. In production, `useCache`
+    // (web/src/lib/cache/index.ts:1324) sets `isDemoFallback: true`
+    // whenever the user is being shown demo data instead of live cache
+    // results — that includes ALL of:
+    //   - shouldFallbackToDemo (a real fetch failed)
+    //   - !effectiveEnabled (caching disabled, e.g. demo-mode toggle on)
+    //   - showOptimisticDemo (first load while live fetch is pending)
+    // So `isDemoMode === true` AND `isDemoFallback === false` is not
+    // a state production ever produces. Tests that want demo behavior
+    // override BOTH explicitly.
     mockUseDemoMode.mockReturnValue({ isDemoMode: false, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() })
     mockUseCardLoadingState.mockReturnValue({ showSkeleton: false, showEmptyState: false, hasData: true, isRefreshing: false })
     mockServices.mockReturnValue({ services: [], isLoading: false, isRefreshing: false, isDemoFallback: false, isFailed: false, consecutiveFailures: 0, error: null, lastRefresh: Date.now() })
@@ -121,7 +125,10 @@ describe('NetworkOverview', () => {
   })
 
   it('renders correctly in demo mode', () => {
+    // #6278: flip BOTH demo flags so the mock state matches what
+    // production actually produces (see beforeEach comment).
     mockUseDemoMode.mockReturnValue({ isDemoMode: true, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() })
+    mockServices.mockReturnValue({ services: [], isLoading: false, isRefreshing: false, isDemoFallback: true, isFailed: false, consecutiveFailures: 0, error: null, lastRefresh: Date.now() })
     const { container } = render(<NetworkOverview />)
     expect(container).toBeTruthy()
   })


### PR DESCRIPTION
## Summary

Copilot's review of #6277 caught two real issues:

### 1. Incomplete beforeEach comment

The comment said \`useCache\` flips \`isDemoFallback\` \"when a live fetch can't be served from a real backend and demo mode is on\". The actual logic at \`web/src/lib/cache/index.ts:1324\` is:

\`\`\`ts
isDemoFallback: shouldFallbackToDemo || !effectiveEnabled || showOptimisticDemo
\`\`\`

So it also flips for \`!effectiveEnabled\` (caching disabled, e.g. demo-mode toggle on) and \`showOptimisticDemo\` (first load with live fetch pending). Updated both test files' comments to enumerate all three branches.

### 2. Demo-mode tests didn't match production semantics

The \"renders correctly in demo mode\" tests flipped \`useDemoMode().isDemoMode\` to \`true\` but left \`isDemoFallback\` at the default \`false\`. Per item 1, that combination is not a state production ever produces. Both demo tests now flip \`isDemoFallback: true\` on the relevant cache hook mocks.

Verified: **29/29** tests still pass.

(Item 4 from Copilot's review — \"PR body should start with Fixes #N not Closes #N\" — is not actionable. \`Closes #N\` works fine in GitHub for auto-close, and #6276 was successfully auto-closed by #6277.)

Closes #6278

## Test plan

- [x] 29 tests pass with tightened mock states
- [x] \`npm run build\` clean
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)