### PR TITLE
test(freshness): correct beforeEach comment to match actual useCache logic (#6280)

### DIFF
--- a/web/src/components/cards/__tests__/HelmValuesDiff.test.tsx
+++ b/web/src/components/cards/__tests__/HelmValuesDiff.test.tsx
@@ -88,17 +88,24 @@ import { HelmValuesDiff } from '../HelmValuesDiff'
 describe('HelmValuesDiff', () => {
   beforeEach(() => {
     vi.clearAllMocks()
-    // #6276/#6278: default both `useDemoMode().isDemoMode` and the
-    // cache hooks' `isDemoFallback` to false. In production, `useCache`
-    // (web/src/lib/cache/index.ts:1324) sets `isDemoFallback: true`
-    // whenever the user is being shown demo data instead of live cache
-    // results — that includes ALL of:
-    //   - shouldFallbackToDemo (a real fetch failed)
-    //   - !effectiveEnabled (caching disabled, e.g. demo-mode toggle on)
-    //   - showOptimisticDemo (first load while live fetch is pending)
-    // So `isDemoMode === true` AND `isDemoFallback === false` is not
-    // a state production ever produces. Tests that want demo behavior
-    // override BOTH explicitly.
+    // #6276/#6278/#6280: default both `useDemoMode().isDemoMode` and
+    // the cache hooks' `isDemoFallback` to false. In production,
+    // `useCache` (web/src/lib/cache/index.ts:1324) sets
+    // `isDemoFallback: true` via:
+    //     shouldFallbackToDemo || !effectiveEnabled || showOptimisticDemo
+    // where:
+    //   - shouldFallbackToDemo: live fetch returned an EMPTY array AND
+    //     the hook was created with `demoWhenEmpty: true`.
+    //   - !effectiveEnabled: caching is disabled. `effectiveEnabled =
+    //     enabled && (!demoMode || liveInDemoMode)`. So this fires when
+    //     demoMode is on AND the hook did NOT opt into liveInDemoMode.
+    //   - showOptimisticDemo: first load while a demoWhenEmpty fetch is
+    //     pending.
+    // The combination `isDemoMode === true && isDemoFallback === false`
+    // IS reachable in production for hooks that pass `liveInDemoMode:
+    // true`, but useCachedHelm{Releases,Values} don't, so for these
+    // tests defaulting to non-demo and overriding `useDemoMode` +
+    // `isDemoFallback` together is the production-faithful state.
     mockUseDemoMode.mockReturnValue({ isDemoMode: false, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() })
     mockUseCardLoadingState.mockReturnValue({ showSkeleton: false, showEmptyState: false, hasData: true, isRefreshing: false })
     mockHelmReleases.mockReturnValue({ releases: [], isLoading: false, isRefreshing: false, isDemoFallback: false, isFailed: false, consecutiveFailures: 0, error: null, lastRefresh: Date.now() })

--- a/web/src/components/cards/__tests__/NetworkOverview.test.tsx
+++ b/web/src/components/cards/__tests__/NetworkOverview.test.tsx
@@ -81,17 +81,27 @@ import { NetworkOverview } from '../NetworkOverview'
 describe('NetworkOverview', () => {
   beforeEach(() => {
     vi.clearAllMocks()
-    // #6276/#6278: default both `useDemoMode().isDemoMode` and the
-    // cache hooks' `isDemoFallback` to false. In production, `useCache`
-    // (web/src/lib/cache/index.ts:1324) sets `isDemoFallback: true`
-    // whenever the user is being shown demo data instead of live cache
-    // results — that includes ALL of:
-    //   - shouldFallbackToDemo (a real fetch failed)
-    //   - !effectiveEnabled (caching disabled, e.g. demo-mode toggle on)
-    //   - showOptimisticDemo (first load while live fetch is pending)
-    // So `isDemoMode === true` AND `isDemoFallback === false` is not
-    // a state production ever produces. Tests that want demo behavior
-    // override BOTH explicitly.
+    // #6276/#6278/#6280: default both `useDemoMode().isDemoMode` and
+    // the cache hooks' `isDemoFallback` to false. In production,
+    // `useCache` (web/src/lib/cache/index.ts:1324) sets
+    // `isDemoFallback: true` via:
+    //     shouldFallbackToDemo || !effectiveEnabled || showOptimisticDemo
+    // where:
+    //   - shouldFallbackToDemo: live fetch returned an EMPTY array AND
+    //     the hook was created with `demoWhenEmpty: true` (used for
+    //     "demo until X is installed" cards like Kagenti).
+    //   - !effectiveEnabled: caching is disabled. `effectiveEnabled =
+    //     enabled && (!demoMode || liveInDemoMode)`. So this fires when
+    //     demoMode is on AND the hook did NOT opt into liveInDemoMode.
+    //   - showOptimisticDemo: first load while a demoWhenEmpty fetch is
+    //     pending.
+    // The combination `isDemoMode === true && isDemoFallback === false`
+    // IS reachable in production: hooks that pass `liveInDemoMode: true`
+    // (e.g. LLM-d benchmark cards backed by serverless functions) keep
+    // `effectiveEnabled` true while demo mode is on. NetworkOverview
+    // and HelmValuesDiff don't use that opt-in, so for these tests
+    // defaulting to non-demo and overriding `useDemoMode` +
+    // `isDemoFallback` together is the production-faithful state.
     mockUseDemoMode.mockReturnValue({ isDemoMode: false, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() })
     mockUseCardLoadingState.mockReturnValue({ showSkeleton: false, showEmptyState: false, hasData: true, isRefreshing: false })
     mockServices.mockReturnValue({ services: [], isLoading: false, isRefreshing: false, isDemoFallback: false, isFailed: false, consecutiveFailures: 0, error: null, lastRefresh: Date.now() })


### PR DESCRIPTION
## Summary

Copilot's review of #6279 caught two real inaccuracies in my beforeEach comment block. Verified both against \`web/src/lib/cache/index.ts\` before fixing.

### 1. \`shouldFallbackToDemo\` description was wrong

I described it as \"a real fetch failed\". Reading lines 1299-1300:

\`\`\`ts
const shouldFallbackToDemo = effectiveEnabled && demoWhenEmpty && stableDemoData !== undefined
  && !state.isLoading && Array.isArray(state.data) && (state.data as unknown[]).length === 0
\`\`\`

It's actually \"a SUCCESSFUL live fetch that returned EMPTY results, on hooks created with \`demoWhenEmpty: true\`\" (used for \"demo until X is installed\" cards like Kagenti). It has nothing to do with fetch failure.

### 2. \`isDemoMode=true && isDemoFallback=false\` IS reachable in production

I claimed it wasn't. Wrong. Line 1106:

\`\`\`ts
const effectiveEnabled = enabled && (!demoMode || liveInDemoMode)
\`\`\`

Hooks that pass \`liveInDemoMode: true\` (e.g. LLM-d benchmark cards backed by serverless functions) keep \`effectiveEnabled\` true while demo mode is on — so they CAN have \`isDemoMode=true\` and \`isDemoFallback=false\` simultaneously.

### Fix

Updated both comments to enumerate the actual conditions accurately and call out that NetworkOverview / HelmValuesDiff don't use \`liveInDemoMode\`, which is why their tests can safely use the default-and-override pattern.

Verified: **29/29** tests still pass (pure comment-only changes).

Closes #6280

## Test plan

- [x] 29 tests pass
- [x] \`npm run build\` clean
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)