### PR TITLE
fix(backend): 3 real backend bugs from @xonas1101 (#6284, #6285, #6286)

### DIFF
--- a/pkg/store/persistence_config.go
+++ b/pkg/store/persistence_config.go
@@ -141,6 +141,18 @@ func (p *PersistenceStore) Load() error {
 		return fmt.Errorf("failed to parse persistence config: %w", err)
 	}
 
+	// #6285: a config file containing literal JSON `null` is valid
+	// JSON and causes json.Unmarshal(data, &p.config) to set p.config
+	// to nil, which would panic on the namespace dereference below.
+	// Reset to defaults when that happens.
+	if p.config == nil {
+		p.config = &PersistenceConfig{
+			Enabled:   false,
+			Namespace: DefaultNamespace,
+			SyncMode:  "primary-only",
+		}
+	}
+
 	// Ensure namespace has a default
 	if p.config.Namespace == "" {
 		p.config.Namespace = DefaultNamespace

--- a/pkg/store/sqlite.go
+++ b/pkg/store/sqlite.go
@@ -229,6 +229,7 @@ func (s *SQLiteStore) migrate() error {
 		pr_url TEXT,
 		copilot_session_url TEXT,
 		netlify_preview_url TEXT,
+		latest_comment TEXT,
 		created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
 		updated_at DATETIME
 	);
@@ -356,6 +357,9 @@ func (s *SQLiteStore) migrate() error {
 		"ALTER TABLE users ADD COLUMN role TEXT DEFAULT 'viewer'",
 		"ALTER TABLE users ADD COLUMN slack_id TEXT",
 		"ALTER TABLE feature_requests ADD COLUMN closed_by_user INTEGER DEFAULT 0",
+		// #6284: UpdateFeatureRequestLatestComment writes to this column
+		// but it was never added to CREATE TABLE or migrations.
+		"ALTER TABLE feature_requests ADD COLUMN latest_comment TEXT",
 	}
 	for _, migration := range migrations {
 		// Ignore errors - column may already exist
@@ -1411,6 +1415,11 @@ func (s *SQLiteStore) CreateNotification(notification *models.Notification) erro
 }
 
 func (s *SQLiteStore) GetUserNotifications(userID uuid.UUID, limit int) ([]models.Notification, error) {
+	// #6286: clamp the limit to safe bounds before passing to SQL.
+	// SQLite treats negative LIMIT as "no limit", which would let a
+	// caller bypass resource controls and return arbitrarily large
+	// result sets. Match the card_history query's hardening.
+	limit = clampLimit(limit)
 	rows, err := s.db.Query(`SELECT id, user_id, feature_request_id, notification_type, title, message, read, created_at FROM notifications WHERE user_id = ? ORDER BY created_at DESC LIMIT ?`, userID.String(), limit)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
## Summary

Three independent backend bugs reported against \`pkg/store\` by @xonas1101. All three verified against source before fixing.

### #6284 — feature_requests.latest_comment column missing

\`UpdateFeatureRequestLatestComment\` at \`sqlite.go:1344\` runs:
\`\`\`sql
UPDATE feature_requests SET latest_comment = ?, updated_at = ? WHERE id = ?
\`\`\`
but \`latest_comment\` was never added to the CREATE TABLE (sqlite.go:219) or migrations list (sqlite.go:355). Any call to that method would fail at runtime with \"no such column: latest_comment\".

**Fix:** add the column to CREATE TABLE for fresh installs AND to the migrations list so existing databases get it via ALTER TABLE.

### #6285 — nil-pointer panic on null JSON in persistence config

\`persistence_config.go:140\` runs \`json.Unmarshal(data, &p.config)\` where \`p.config\` is already a \`*PersistenceConfig\`. If the config file contains literal JSON \`null\`, Unmarshal sets \`p.config\` to nil, and the subsequent dereference at line 145 (\`p.config.Namespace\`) panics.

**Fix:** after Unmarshal, detect nil and reset to defaults (matching the \"file does not exist\" branch above).

### #6286 — unbounded LIMIT in GetUserNotifications

\`sqlite.go:1414\` passes \`limit\` directly into SQL without calling \`clampLimit\`, unlike the analogous \`card_history\` query at line 920 which does \`limit = clampLimit(limit)\` first. SQLite treats negative LIMIT as \"no limit\", which lets a caller bypass resource controls.

**Fix:** add the same \`clampLimit\` call.

### Security screening

Reporter submitted three clean, independently verifiable bug reports with file:line pointers. I re-verified each claim against the source before fixing. No social engineering red flags, all fixes are defensive and don't introduce new attack surface.

Closes #6284
Closes #6285
Closes #6286

## Test plan

- [x] \`go build ./...\` clean
- [x] \`go vet ./pkg/store/...\` clean
- [x] \`npm run build\` (frontend) clean
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)