### PR TITLE
fix(clusters): show actionable error when kc-agent is too old to remove (#6288)

### DIFF
--- a/web/src/components/clusters/Clusters.tsx
+++ b/web/src/components/clusters/Clusters.tsx
@@ -186,6 +186,15 @@ export function Clusters() {
       signal: AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS) })
     if (!response.ok) {
       const data = await response.json().catch(() => ({})) as { error?: string; message?: string }
+      // #6288: a 404 specifically means the agent process answered but
+      // doesn't expose `/kubeconfig/remove`. The route was added in
+      // #5658, so the user is running an older kc-agent binary than
+      // the frontend expects. Surface an actionable message rather
+      // than the generic "HTTP 404: Not Found". Same scope as the
+      // #6133 follow-up for the 401 case.
+      if (response.status === 404) {
+        throw new Error(t('cluster.removeClusterAgentTooOld'))
+      }
       // Always surface the HTTP status if the body has no structured error,
       // so the user sees "HTTP 401: Unauthorized" instead of the generic
       // fallback — this was the root cause of #6133 being unactionable.

--- a/web/src/locales/en/common.json
+++ b/web/src/locales/en/common.json
@@ -2880,7 +2880,8 @@
     "removeClusterRemoving": "Removing...",
     "removeClusterSuccess": "Removed cluster \"{{name}}\" from kubeconfig",
     "removeClusterError": "Failed to remove cluster from kubeconfig",
-    "removeClusterNoAgent": "Local agent not connected"
+    "removeClusterNoAgent": "Local agent not connected",
+    "removeClusterAgentTooOld": "kc-agent does not expose /kubeconfig/remove. This route was added in kc-agent PR #5658 — please upgrade your kc-agent binary to the latest release."
   },
   "remediation": {
     "title": "AI Remediation Console",


### PR DESCRIPTION
## Summary

The \"Remove offline cluster\" UI was surfacing generic \"HTTP 404: Not Found\" when the kc-agent process was running but didn't expose the \`/kubeconfig/remove\` route.

**Root cause:** the route was added in #5658. Users running an older kc-agent binary get a vanilla 404 from Go's \`http.ServeMux\` when the frontend hits it. The generic HTTP-status fallback (added by #6133) wasn't actionable — users can't tell whether the context was wrong, the agent was wedged, or the agent was simply out of date.

### Fix

Detect \`response.status === 404\` specifically and throw a localized message that explains the likely cause and the remedy (\"upgrade your kc-agent to the latest release\"). Same shape as the #6133 401 fix.

Added i18n key \`cluster.removeClusterAgentTooOld\` in \`web/src/locales/en/common.json\`. Other locales fall back to English until translated.

Closes #6288

## Test plan

- [x] \`npm run build\` clean
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)