### PR TITLE
fix(backend): address 4 Copilot review comments on #6287 (#6291)

### DIFF
--- a/pkg/api/handlers/feedback.go
+++ b/pkg/api/handlers/feedback.go
@@ -1071,6 +1071,14 @@ func (h *FeedbackHandler) GetNotifications(c *fiber.Ctx) error {
 	if limit > 100 {
 		limit = 100
 	}
+	// #6291: a caller passing limit<=0 previously returned 0 rows (SQLite
+	// treats LIMIT 0 as zero rows). After #6286 added clampLimit(limit)
+	// to the store, limit=0 would return 1 row instead — a silent
+	// semantic change. Treat any non-positive value as "use default" so
+	// the handler contract is preserved.
+	if limit <= 0 {
+		limit = 50
+	}
 
 	notifications, err := h.store.GetUserNotifications(userID, limit)
 	if err != nil {

--- a/pkg/store/persistence_config_test.go
+++ b/pkg/store/persistence_config_test.go
@@ -29,6 +29,26 @@ func TestPersistenceStore_LoadAndSave(t *testing.T) {
 		require.Equal(t, "primary-only", cfg.SyncMode)
 	})
 
+	// #6285/#6291: a config file containing literal JSON `null` is
+	// valid JSON that used to crash Load() with a nil-pointer panic
+	// (p.config became nil after Unmarshal, then the Namespace
+	// dereference panicked). Load() must now detect this and reset
+	// to the same defaults as the "file does not exist" branch.
+	t.Run("Load resets to defaults on literal null JSON (#6285)", func(t *testing.T) {
+		configPath := filepath.Join(t.TempDir(), "null.json")
+		require.NoError(t, os.WriteFile(configPath, []byte("null"), 0o600))
+
+		ps := NewPersistenceStore(configPath)
+		require.NotPanics(t, func() {
+			require.NoError(t, ps.Load())
+		}, "Load() must not panic on literal null JSON")
+
+		cfg := ps.GetConfig()
+		require.False(t, cfg.Enabled)
+		require.Equal(t, DefaultNamespace, cfg.Namespace)
+		require.Equal(t, "primary-only", cfg.SyncMode)
+	})
+
 	t.Run("Save and Load round-trip", func(t *testing.T) {
 		configPath := filepath.Join(t.TempDir(), "config.json")
 		ps := NewPersistenceStore(configPath)

--- a/pkg/store/sqlite.go
+++ b/pkg/store/sqlite.go
@@ -9,6 +9,7 @@ import (
 	"log/slog"
 	"os"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/google/uuid"
@@ -362,8 +363,16 @@ func (s *SQLiteStore) migrate() error {
 		"ALTER TABLE feature_requests ADD COLUMN latest_comment TEXT",
 	}
 	for _, migration := range migrations {
-		// Ignore errors - column may already exist
-		s.db.Exec(migration)
+		if _, err := s.db.Exec(migration); err != nil {
+			// #6291: distinguish "column already exists" (expected) from
+			// other errors (DB locked / read-only / corrupt). The former
+			// is how we get idempotent migrations; the latter is a real
+			// problem worth surfacing. SQLite returns "duplicate column
+			// name: X" for the expected case.
+			if !strings.Contains(err.Error(), "duplicate column name") {
+				slog.Warn("[SQLite] migration failed", "migration", migration, "error", err)
+			}
+		}
 	}
 
 	return nil
@@ -1158,22 +1167,22 @@ func (s *SQLiteStore) CreateFeatureRequest(request *models.FeatureRequest) error
 }
 
 func (s *SQLiteStore) GetFeatureRequest(id uuid.UUID) (*models.FeatureRequest, error) {
-	row := s.db.QueryRow(`SELECT id, user_id, title, description, request_type, github_issue_number, status, pr_number, pr_url, copilot_session_url, netlify_preview_url, closed_by_user, created_at, updated_at FROM feature_requests WHERE id = ?`, id.String())
+	row := s.db.QueryRow(`SELECT id, user_id, title, description, request_type, github_issue_number, status, pr_number, pr_url, copilot_session_url, netlify_preview_url, closed_by_user, latest_comment, created_at, updated_at FROM feature_requests WHERE id = ?`, id.String())
 	return s.scanFeatureRequest(row)
 }
 
 func (s *SQLiteStore) GetFeatureRequestByIssueNumber(issueNumber int) (*models.FeatureRequest, error) {
-	row := s.db.QueryRow(`SELECT id, user_id, title, description, request_type, github_issue_number, status, pr_number, pr_url, copilot_session_url, netlify_preview_url, closed_by_user, created_at, updated_at FROM feature_requests WHERE github_issue_number = ?`, issueNumber)
+	row := s.db.QueryRow(`SELECT id, user_id, title, description, request_type, github_issue_number, status, pr_number, pr_url, copilot_session_url, netlify_preview_url, closed_by_user, latest_comment, created_at, updated_at FROM feature_requests WHERE github_issue_number = ?`, issueNumber)
 	return s.scanFeatureRequest(row)
 }
 
 func (s *SQLiteStore) GetFeatureRequestByPRNumber(prNumber int) (*models.FeatureRequest, error) {
-	row := s.db.QueryRow(`SELECT id, user_id, title, description, request_type, github_issue_number, status, pr_number, pr_url, copilot_session_url, netlify_preview_url, closed_by_user, created_at, updated_at FROM feature_requests WHERE pr_number = ?`, prNumber)
+	row := s.db.QueryRow(`SELECT id, user_id, title, description, request_type, github_issue_number, status, pr_number, pr_url, copilot_session_url, netlify_preview_url, closed_by_user, latest_comment, created_at, updated_at FROM feature_requests WHERE pr_number = ?`, prNumber)
 	return s.scanFeatureRequest(row)
 }
 
 func (s *SQLiteStore) GetUserFeatureRequests(userID uuid.UUID) ([]models.FeatureRequest, error) {
-	rows, err := s.db.Query(`SELECT id, user_id, title, description, request_type, github_issue_number, status, pr_number, pr_url, copilot_session_url, netlify_preview_url, closed_by_user, created_at, updated_at FROM feature_requests WHERE user_id = ? ORDER BY created_at DESC`, userID.String())
+	rows, err := s.db.Query(`SELECT id, user_id, title, description, request_type, github_issue_number, status, pr_number, pr_url, copilot_session_url, netlify_preview_url, closed_by_user, latest_comment, created_at, updated_at FROM feature_requests WHERE user_id = ? ORDER BY created_at DESC`, userID.String())
 	if err != nil {
 		return nil, err
 	}
@@ -1191,7 +1200,7 @@ func (s *SQLiteStore) GetUserFeatureRequests(userID uuid.UUID) ([]models.Feature
 }
 
 func (s *SQLiteStore) GetAllFeatureRequests() ([]models.FeatureRequest, error) {
-	rows, err := s.db.Query(`SELECT id, user_id, title, description, request_type, github_issue_number, status, pr_number, pr_url, copilot_session_url, netlify_preview_url, closed_by_user, created_at, updated_at FROM feature_requests ORDER BY created_at DESC`)
+	rows, err := s.db.Query(`SELECT id, user_id, title, description, request_type, github_issue_number, status, pr_number, pr_url, copilot_session_url, netlify_preview_url, closed_by_user, latest_comment, created_at, updated_at FROM feature_requests ORDER BY created_at DESC`)
 	if err != nil {
 		return nil, err
 	}
@@ -1213,11 +1222,11 @@ func (s *SQLiteStore) scanFeatureRequest(row *sql.Row) (*models.FeatureRequest, 
 	var idStr, userIDStr string
 	var requestType, status string
 	var issueNumber, prNumber sql.NullInt64
-	var prURL, copilotSessionURL, previewURL sql.NullString
+	var prURL, copilotSessionURL, previewURL, latestComment sql.NullString
 	var closedByUser sql.NullInt64
 	var updatedAt sql.NullTime
 
-	err := row.Scan(&idStr, &userIDStr, &r.Title, &r.Description, &requestType, &issueNumber, &status, &prNumber, &prURL, &copilotSessionURL, &previewURL, &closedByUser, &r.CreatedAt, &updatedAt)
+	err := row.Scan(&idStr, &userIDStr, &r.Title, &r.Description, &requestType, &issueNumber, &status, &prNumber, &prURL, &copilotSessionURL, &previewURL, &closedByUser, &latestComment, &r.CreatedAt, &updatedAt)
 	if err == sql.ErrNoRows {
 		return nil, nil
 	}
@@ -1249,6 +1258,9 @@ func (s *SQLiteStore) scanFeatureRequest(row *sql.Row) (*models.FeatureRequest, 
 	if closedByUser.Valid {
 		r.ClosedByUser = closedByUser.Int64 == 1
 	}
+	if latestComment.Valid {
+		r.LatestComment = latestComment.String
+	}
 	if updatedAt.Valid {
 		r.UpdatedAt = &updatedAt.Time
 	}
@@ -1260,11 +1272,11 @@ func (s *SQLiteStore) scanFeatureRequestRow(rows *sql.Rows) (*models.FeatureRequ
 	var idStr, userIDStr string
 	var requestType, status string
 	var issueNumber, prNumber sql.NullInt64
-	var prURL, copilotSessionURL, previewURL sql.NullString
+	var prURL, copilotSessionURL, previewURL, latestComment sql.NullString
 	var closedByUser sql.NullInt64
 	var updatedAt sql.NullTime
 
-	err := rows.Scan(&idStr, &userIDStr, &r.Title, &r.Description, &requestType, &issueNumber, &status, &prNumber, &prURL, &copilotSessionURL, &previewURL, &closedByUser, &r.CreatedAt, &updatedAt)
+	err := rows.Scan(&idStr, &userIDStr, &r.Title, &r.Description, &requestType, &issueNumber, &status, &prNumber, &prURL, &copilotSessionURL, &previewURL, &closedByUser, &latestComment, &r.CreatedAt, &updatedAt)
 	if err != nil {
 		return nil, err
 	}
@@ -1292,6 +1304,9 @@ func (s *SQLiteStore) scanFeatureRequestRow(rows *sql.Rows) (*models.FeatureRequ
 	}
 	if closedByUser.Valid {
 		r.ClosedByUser = closedByUser.Int64 == 1
+	}
+	if latestComment.Valid {
+		r.LatestComment = latestComment.String
 	}
 	if updatedAt.Valid {
 		r.UpdatedAt = &updatedAt.Time


### PR DESCRIPTION
## Summary

4 real follow-up items from Copilot's review of the #6284/#6285/#6286 bundle (#6287).

### 1. \`latest_comment\` column not read back (#6284 follow-up)

#6287 added the column and the UPDATE that writes to it, but none of the 5 SELECT queries or the two scan helpers (\`scanFeatureRequest\`, \`scanFeatureRequestRow\`) included it. So \`models.FeatureRequest.LatestComment\` was never populated. Fixed all 5 queries + both scan helpers.

### 2. Migration loop silently swallowed every ALTER TABLE error

The loop ignored errors unconditionally. \"duplicate column name\" is expected (idempotent re-runs); everything else (DB locked / read-only / corrupt) now logs \`slog.Warn\` so real problems are visible.

### 3. GetUserNotifications semantic change (#6286 follow-up)

Adding \`clampLimit(limit)\` made \`limit=0\` return 1 row instead of 0, a silent contract change (SQLite treats \`LIMIT 0\` as zero rows; \`clampLimit\` floors to 1). Fixed in the handler: any non-positive limit now falls back to the default 50, matching the normal pagination pattern. The store-level clamp still defends against accidentally-negative limits reaching SQL.

### 4. Unit test for persistence null-JSON fix (#6285 follow-up)

New subtest \`Load_resets_to_defaults_on_literal_null_JSON_(#6285)\` asserts \`Load()\` does not panic on \`null\`, returns nil error, and resets to the same defaults as the \"file does not exist\" branch.

Closes #6291

## Test plan

- [x] \`go build ./...\` clean
- [x] \`go test ./pkg/store/...\` ok (new null-JSON subtest passes)
- [x] \`go test ./pkg/api/handlers/...\` ok
- [x] \`npm run build\` clean
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)