### PR TITLE
fix(drilldown): invert Gauge colors for ReplicaSet readiness (#6289)

### DIFF
--- a/web/src/components/drilldown/views/ReplicaSetDrillDown.tsx
+++ b/web/src/components/drilldown/views/ReplicaSetDrillDown.tsx
@@ -253,7 +253,11 @@ export function ReplicaSetDrillDown({ data }: Props) {
                   </div>
                 </div>
                 <div className="flex items-center gap-4">
-                  <Gauge value={readyReplicas} max={replicas} size="sm" />
+                  {/* #6289: readiness is a health metric where high is good
+                      (100% ready == healthy). Without invertColors the default
+                      thresholds paint ≥90% red, so a perfectly-healthy
+                      ReplicaSet showed a red gauge labeled "100%". */}
+                  <Gauge value={readyReplicas} max={replicas} size="sm" invertColors={true} />
                   <div className="text-right">
                     <div className="text-2xl font-bold text-foreground">{readyReplicas}/{replicas}</div>
                     <div className="text-xs text-muted-foreground">{t('drilldown.fields.replicasReady')}</div>

--- a/web/src/test/ui-ux-standards.test.ts
+++ b/web/src/test/ui-ux-standards.test.ts
@@ -63,11 +63,12 @@ const COMPONENTS_DIR = path.resolve(
 //   293 → 296: #6217 part 3 freshness additions
 //   296 → 298: #6265 copilot follow-up comment refs
 //   298 → 300: #6273 followup comment refs
+//   300 → 301: #6289 gauge readiness color inversion issue ref
 //
 // When you bump this number, append a one-line entry above so future
 // bumps stay grep-able and reviewers can tell at a glance whether a
 // change is a real new violation or just a comment-level reference.
-const EXPECTED_RAW_HEX_COUNT = 300
+const EXPECTED_RAW_HEX_COUNT = 301
 const EXPECTED_RAW_RGBA_COUNT = 104
 const EXPECTED_ARBITRARY_TW_COLOR_COUNT = 22
 const EXPECTED_INLINE_STYLE_COLOR_COUNT = 213


### PR DESCRIPTION
## Summary

@xonas1101 reported that the ReplicaSet drill-down shows the readiness gauge in **red** at 100% (1/1 replicas healthy). Screenshot in the issue confirms: the \"100%\" text and the semicircle arc both rendered in the error-red palette.

### Root cause

\`<Gauge value={readyReplicas} max={replicas} size=\"sm\" />\` in \`ReplicaSetDrillDown.tsx:256\` uses the default \`invertColors=false\`. With the default thresholds (warning=70, critical=90) the Gauge paints high values red — correct for \"bad when high\" metrics like CPU/memory usage, but inverted for health/readiness. The Gauge component already supports the correct semantics via \`invertColors: true\`, which paints 100% green, 50% yellow, 0% red (see \`web/src/components/charts/Gauge.tsx:34-36\`).

### Fix

Pass \`invertColors={true}\` at the call site. Only this one Gauge usage is affected — the other drilldown Gauge in \`GPUNodeDrillDown\` shows allocated/total (capacity usage, high legitimately means bad) and is left as-is.

Closes #6289

## Test plan

- [x] \`npm run build\` clean
- [ ] CI green
- [ ] Visual: screenshot after fix shows green gauge

🤖 Generated with [Claude Code](https://claude.com/claude-code)