### PR TITLE
fix(cards): UpgradeStatus re-fetches after cluster upgrade (#6292)

### DIFF
--- a/web/src/components/cards/UpgradeStatus.tsx
+++ b/web/src/components/cards/UpgradeStatus.tsx
@@ -497,9 +497,26 @@ export function UpgradeStatus({ config: _config }: UpgradeStatusProps) {
       }
     }, RETRY_INTERVAL_MS)
 
+    // #6292: re-fetch ALL clusters on VERSION_CACHE_TTL so a successfully
+    // upgraded cluster reflects its new version. Without this loop,
+    // `fetchedClustersRef` kept the old cluster in the "already fetched,
+    // skip" set forever and the card showed the pre-upgrade version
+    // until the user navigated away and came back. Also clears the
+    // per-cluster version cache so `getCachedVersion()` re-fetches.
+    const refreshInterval = setInterval(() => {
+      if (!agentConnected) return
+      fetchedClustersRef.current.clear()
+      for (const c of allClusters) {
+        delete versionCache[c.name]
+      }
+      persistCache()
+      fetchVersions()
+    }, VERSION_CACHE_TTL)
+
     return () => {
       cancelled = true
       clearInterval(retryInterval)
+      clearInterval(refreshInterval)
     }
   }, [isDemoMode, agentConnected, allClusters])
 


### PR DESCRIPTION
## Summary

@xonas1101 reported that after upgrading a cluster, the \"Cluster Upgrade Status\" card keeps showing the old Kubernetes version and the \"Upgrade\" button remains visible.

### Root cause (verified against source)

The fetch effect at \`UpgradeStatus.tsx:442\` filters out clusters already in \`fetchedClustersRef.current\`:

\`\`\`tsx
const clustersToFetch = reachableClusters.filter(c =>
  !fetchedClustersRef.current.has(c.name) ||
  failedClustersRef.current.has(c.name))
\`\`\`

Once a cluster's version is successfully fetched, its name is added to \`fetchedClustersRef\` and **never removed except on component unmount**. The existing 15s retry interval only runs for FAILED clusters. There's no mechanism to revisit a cluster whose version has CHANGED (e.g. after an upgrade mission succeeded).

The file already declares \`VERSION_CACHE_TTL = 5 * 60 * 1000\` at the top, but nothing honored the TTL — the persistent \`versionCache\` was TTL-aware (\`getCachedVersion\` checks age), but the per-mount \`fetchedClustersRef\` deduping set was not.

### Fix

Add a second \`setInterval\` on \`VERSION_CACHE_TTL\` that:
1. Clears \`fetchedClustersRef\` so all clusters are eligible for re-fetching
2. Evicts the relevant entries from the persistent \`versionCache\`
3. Re-runs \`fetchVersions()\`

After an upgrade, the card now reflects the new version within the TTL window (5 minutes worst case).

Closes #6292

## Test plan

- [x] \`npm run build\` clean
- [ ] CI green
- [ ] Manual: trigger an upgrade mission, wait 5 min, verify the card updates

🤖 Generated with [Claude Code](https://claude.com/claude-code)