### PR TITLE
fix(agent): Windows build — guard Setpgid + syscall.Exec with build tags (#6297)

### DIFF
--- a/pkg/agent/restart_unix.go
+++ b/pkg/agent/restart_unix.go
@@ -1,0 +1,28 @@
+//go:build !windows
+
+// Platform-specific helpers for the auto-update restart path.
+// Unix implementation uses Setpgid (to detach the restart script so it
+// survives the parent process exit) and syscall.Exec (to replace the
+// kc-agent binary atomically in the fallback path).
+//
+// See restart_windows.go for the Windows equivalents (#6297).
+package agent
+
+import (
+	"os/exec"
+	"syscall"
+)
+
+// setDetachedProcessGroup detaches the child into a new process group so
+// it survives the parent exiting (Setpgid). On Windows this is a no-op.
+func setDetachedProcessGroup(cmd *exec.Cmd) {
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+}
+
+// execReplace replaces the current process image with the given binary.
+// Unix uses `syscall.Exec` which preserves PID and does not return on
+// success. Windows cannot replace a running process — see the Windows
+// implementation for the fallback behavior.
+func execReplace(binary string, args, env []string) error {
+	return syscall.Exec(binary, args, env)
+}

--- a/pkg/agent/restart_windows.go
+++ b/pkg/agent/restart_windows.go
@@ -1,0 +1,33 @@
+//go:build windows
+
+// Platform-specific helpers for the auto-update restart path.
+// Windows implementation — #6297.
+//
+// Windows does not have POSIX process groups or a syscall.Exec equivalent
+// that replaces the running process image in place. These helpers become
+// no-ops / best-effort fallbacks on Windows so kc-agent at least compiles
+// on that platform. The auto-update flow itself is still expected to run
+// primarily on Unix hosts where the startup-oauth.sh script lives.
+package agent
+
+import (
+	"fmt"
+	"os/exec"
+)
+
+// setDetachedProcessGroup is a no-op on Windows. The parent exits a few
+// moments after spawning the child, and Windows lets the child keep
+// running on its own as long as it has its own stdio handles (which the
+// caller already redirects to a log file).
+func setDetachedProcessGroup(_ *exec.Cmd) {
+	// intentionally empty
+}
+
+// execReplace is unsupported on Windows because CreateProcess cannot
+// replace the current process image in place. The Unix-only selfUpdateFallback
+// path that calls this helper is effectively a no-op on Windows: kc-agent
+// logs the failure and continues running the old binary until the user
+// restarts manually.
+func execReplace(_ string, _, _ []string) error {
+	return fmt.Errorf("execReplace is not supported on Windows — user must restart kc-agent manually to apply the update")
+}

--- a/pkg/agent/update_checker.go
+++ b/pkg/agent/update_checker.go
@@ -14,7 +14,6 @@ import (
 	"strings"
 	"sync"
 	"sync/atomic"
-	"syscall"
 	"time"
 )
 
@@ -735,7 +734,9 @@ func (uc *UpdateChecker) restartViaStartupScript(repoPath string) {
 		cmd.Stdout = logFile
 		cmd.Stderr = logFile
 	}
-	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	// #6297: Setpgid is Unix-only; routed through a build-tagged helper
+	// (restart_unix.go / restart_windows.go) so kc-agent compiles on Windows.
+	setDetachedProcessGroup(cmd)
 
 	if err := cmd.Start(); err != nil {
 		slog.Error("[AutoUpdate] failed to spawn startup-oauth.sh", "error", err)
@@ -780,11 +781,14 @@ func (uc *UpdateChecker) selfUpdateFallback(repoPath string) {
 		slog.Error("[AutoUpdate] backend restart failed", "error", err)
 	}
 
-	// Re-exec with the same args — replaces this process atomically
-	if err := syscall.Exec(currentBinary, os.Args, os.Environ()); err != nil {
+	// Re-exec with the same args — replaces this process atomically on Unix.
+	// #6297: Windows can't replace the current process image in place;
+	// execReplace returns an error there and kc-agent logs it and keeps
+	// running the old binary until the user restarts manually.
+	if err := execReplace(currentBinary, os.Args, os.Environ()); err != nil {
 		slog.Error("[AutoUpdate] exec into new kc-agent failed", "error", err)
 	}
-	// If exec succeeds, this line is never reached
+	// If exec succeeds on Unix, this line is never reached
 }
 
 func (uc *UpdateChecker) checkReleaseChannel(channel string) {


### PR DESCRIPTION
## Summary

@rishi-jat reported that \`go build ./cmd/kc-agent\` fails on Windows:

\`\`\`
pkg/agent/update_checker.go:738: unknown field Setpgid in syscall.SysProcAttr
\`\`\`

### Root cause (verified)

Two Unix-only syscall usages in \`pkg/agent/update_checker.go\`:

- **line 738** (\`restartViaStartupScript\`): \`cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}\`. \`Setpgid\` is POSIX-only and doesn't exist in the Windows \`SysProcAttr\` struct.
- **line 784** (\`selfUpdateFallback\`): \`syscall.Exec(...)\`. Unix-only; Windows has no \"replace current process image in place\" primitive.

### Fix

Split both operations into two build-tagged helper files:

| File | Build tag | Behavior |
|---|---|---|
| \`pkg/agent/restart_unix.go\` | \`!windows\` | Real implementations: \`Setpgid: true\` + \`syscall.Exec\` |
| \`pkg/agent/restart_windows.go\` | \`windows\` | \`setDetachedProcessGroup\` = no-op (the caller already redirects stdio to a file, which is enough for survival across parent exit on Windows). \`execReplace\` returns an error; kc-agent logs it and keeps running. Windows users must restart manually to apply auto-updates. |

\`update_checker.go\` now calls the helpers instead of referencing \`syscall\` directly. Removed the now-unused \`\"syscall\"\` import.

Closes #6297

## Test plan

- [x] \`go build ./...\` (Unix, arm64 darwin) — clean
- [x] \`GOOS=windows go build ./...\` — clean
- [x] \`go vet ./pkg/agent/...\` — clean
- [x] \`GOOS=windows go vet ./pkg/agent/...\` — clean
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)