### PR TITLE
fix(clusters): address 2 Copilot review comments on #6290 (#6293)

### DIFF
--- a/web/src/components/clusters/Clusters.tsx
+++ b/web/src/components/clusters/Clusters.tsx
@@ -185,16 +185,15 @@ export function Clusters() {
       body: JSON.stringify({ context: contextName }),
       signal: AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS) })
     if (!response.ok) {
-      const data = await response.json().catch(() => ({})) as { error?: string; message?: string }
-      // #6288: a 404 specifically means the agent process answered but
-      // doesn't expose `/kubeconfig/remove`. The route was added in
-      // #5658, so the user is running an older kc-agent binary than
-      // the frontend expects. Surface an actionable message rather
-      // than the generic "HTTP 404: Not Found". Same scope as the
-      // #6133 follow-up for the 401 case.
+      // #6293: check for the 404-means-stale-agent case BEFORE attempting
+      // to parse the body. An old kc-agent returns a plain-text Go
+      // default 404 ("404 page not found") which is not JSON — reading
+      // it first would be a wasted round-trip. Same reason #6288 added
+      // the status-specific branch in the first place.
       if (response.status === 404) {
         throw new Error(t('cluster.removeClusterAgentTooOld'))
       }
+      const data = await response.json().catch(() => ({})) as { error?: string; message?: string }
       // Always surface the HTTP status if the body has no structured error,
       // so the user sees "HTTP 401: Unauthorized" instead of the generic
       // fallback — this was the root cause of #6133 being unactionable.

--- a/web/src/locales/en/common.json
+++ b/web/src/locales/en/common.json
@@ -2881,7 +2881,7 @@
     "removeClusterSuccess": "Removed cluster \"{{name}}\" from kubeconfig",
     "removeClusterError": "Failed to remove cluster from kubeconfig",
     "removeClusterNoAgent": "Local agent not connected",
-    "removeClusterAgentTooOld": "kc-agent does not expose /kubeconfig/remove. This route was added in kc-agent PR #5658 — please upgrade your kc-agent binary to the latest release."
+    "removeClusterAgentTooOld": "Your local kc-agent is out of date and doesn't support removing clusters from the kubeconfig. Please upgrade kc-agent to the latest release and try again."
   },
   "remediation": {
     "title": "AI Remediation Console",


### PR DESCRIPTION
## Summary

Two real Copilot review items from #6290.

### 1. User-facing message had internal PR references

The string introduced in #6290 was:

> kc-agent does not expose /kubeconfig/remove. This route was added in kc-agent PR #5658 — please upgrade your kc-agent binary to the latest release.

That's written for developers. PR numbers are brittle (the referenced PR could be renamed/squashed and the number stays) and the raw route path isn't meaningful to most users. Replaced with a purely actionable message:

> Your local kc-agent is out of date and doesn't support removing clusters from the kubeconfig. Please upgrade kc-agent to the latest release and try again.

### 2. Parse body AFTER checking status, not before

The old order parsed the response body first, then checked the status. An older kc-agent returns Go's default plain-text 404 body (\"404 page not found\") which is not JSON. The \`.catch(() => ({}))\` swallowed the syntax error but still consumed the body stream unnecessarily. Moved the 404 branch above \`.json()\`.

Closes #6293

## Test plan

- [x] \`npm run build\` clean
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)