### PR TITLE
fix(cards): EventStream honors config.limit over persisted state (#6070)

### DIFF
--- a/web/src/components/cards/EventStream.tsx
+++ b/web/src/components/cards/EventStream.tsx
@@ -1,5 +1,5 @@
 import { AlertTriangle, Info, XCircle, ChevronRight, Radio } from 'lucide-react'
-import { useMemo } from 'react'
+import { useEffect, useMemo } from 'react'
 import { useCachedEvents } from '../../hooks/useCachedData'
 import type { ClusterEvent } from '../../hooks/useMCP'
 import { useDrillDownActions } from '../../hooks/useDrillDown'
@@ -131,6 +131,23 @@ function EventStreamInternal({ config }: { config?: EventStreamConfig }) {
     },
     defaultLimit: displayLimit,
   })
+
+  // #6070: when the user explicitly sets `config.limit` via the card
+  // settings modal, it must override any persisted itemsPerPage from
+  // localStorage (storageKey 'event-stream'). `useCardData` only
+  // consumes `defaultLimit` on initial mount — after that, its state
+  // is sourced from localStorage. Without this effect, a user's
+  // configured limit was silently ignored whenever they'd previously
+  // used the in-card "show N" dropdown, which is exactly the
+  // "show field disregarded, causing a very long card" bug in #6070.
+  // The user's workaround (minimize + maximize to force remount) only
+  // helped transiently because on some remounts localStorage was still
+  // catching up — the config.limit was never the source of truth.
+  useEffect(() => {
+    if (typeof config?.limit === 'number' && config.limit > 0) {
+      setItemsPerPage(config.limit)
+    }
+  }, [config?.limit, setItemsPerPage])
 
   const { drillToEvents, drillToPod, drillToDeployment, drillToReplicaSet } = useDrillDownActions()
 


### PR DESCRIPTION
## Summary

@xonas1101 reported that the EventStream card ignores the user's configured \"show N\" limit, causing a very long card. The workaround (minimize then maximize) helped transiently but \"nvm its back again\".

### Root cause (verified)

\`useCardData\` seeds \`itemsPerPage\` from \`localStorage\` on mount (\`lib/cards/cardHooks.ts:440-442\`):

\`\`\`tsx
const [itemsPerPage, setItemsPerPageState] = useState<...>(
  () => readPersistedItemsPerPage(limitStorageKey) ?? defaultLimit,
)
\`\`\`

So \`defaultLimit\` (which EventStream was using to thread \`config.limit\` into the hook) is only consumed when \`localStorage['kubestellar-card-limit:event-stream']\` is empty. Once the user touches the in-card \"show N\" dropdown, localStorage is set and subsequent mounts ignore \`defaultLimit\` — \`config.limit\` from the settings modal never makes it into the rendered list.

### Fix

Add a \`useEffect\` in \`EventStream\` that calls \`setItemsPerPage(config.limit)\` whenever \`config.limit\` is explicitly set. This makes \`config.limit\` the source of truth when the user has configured it, and falls back to the persisted state otherwise. \`setItemsPerPage\` also writes through to localStorage so the config becomes the new persisted default.

Verified: **27/27** EventStream tests still pass.

Closes #6070

## Test plan

- [x] 27 EventStream tests pass
- [x] \`npm run build\` clean
- [ ] CI green
- [ ] Manual: set config.limit=10 in settings modal, verify card shows 10 rows on reload

🤖 Generated with [Claude Code](https://claude.com/claude-code)