### PR TITLE
fix(cards): prevent setState loops in DeploymentIssues + DeploymentProgress (#6119)

### DIFF
--- a/web/src/components/cards/DeploymentIssues.tsx
+++ b/web/src/components/cards/DeploymentIssues.tsx
@@ -1,3 +1,4 @@
+import { useMemo } from 'react'
 import { AlertTriangle, AlertCircle, Clock, Scale, CheckCircle } from 'lucide-react'
 import type { TFunction } from 'i18next'
 import { useCachedDeploymentIssues } from '../../hooks/useCachedData'
@@ -28,6 +29,31 @@ const SORT_OPTIONS_KEYS: ReadonlyArray<{ value: SortByOption; labelKey: SortTran
 interface DeploymentIssuesProps {
   config?: Record<string, unknown>
 }
+
+// #6119: hoist to module scope so the reference is stable across renders.
+// Passing an inline filter/sort object into useCardData invalidates its
+// internal useMemo deps every render and caused "Maximum update depth
+// exceeded" on the deployments card. Same pattern as #6232's
+// DeploymentStatus fix.
+const CARD_DATA_FILTER_CONFIG = {
+  searchFields: ['name', 'namespace', 'cluster', 'reason', 'message'] as (keyof DeploymentIssue)[],
+  clusterField: 'cluster' as keyof DeploymentIssue,
+  storageKey: 'deployment-issues',
+} as const
+
+const CARD_DATA_SORT_CONFIG = {
+  defaultField: 'status' as const,
+  defaultDirection: 'asc' as const,
+  comparators: {
+    status: (a: DeploymentIssue, b: DeploymentIssue) =>
+      (a.reason || '').localeCompare(b.reason || ''),
+    name: commonComparators.string<DeploymentIssue>('name'),
+    cluster: (a: DeploymentIssue, b: DeploymentIssue) =>
+      (a.cluster || '').localeCompare(b.cluster || ''),
+  },
+} as const
+
+const DEFAULT_PAGE_LIMIT = 5
 
 const getIssueIcon = (status: string, t: TFunction<readonly ['cards', 'common']>): { icon: typeof AlertCircle; tooltip: string } => {
   if (status.includes('Unavailable')) return { icon: AlertCircle, tooltip: t('deploymentIssues.tooltipUnavailable') }
@@ -64,6 +90,18 @@ function DeploymentIssuesInternal({ config }: DeploymentIssuesProps) {
     isFailed,
     consecutiveFailures })
 
+  // #6119: memoized empty deps — the filter/sort config is hoisted to
+  // module scope, so the outer object is stable across renders. Matches
+  // the #6232 DeploymentStatus fix.
+  const cardDataConfig = useMemo(
+    () => ({
+      filter: CARD_DATA_FILTER_CONFIG,
+      sort: CARD_DATA_SORT_CONFIG,
+      defaultLimit: DEFAULT_PAGE_LIMIT,
+    }),
+    [],
+  )
+
   // Use shared card data hook for filtering, sorting, and pagination
   const {
     items: issues,
@@ -90,19 +128,7 @@ function DeploymentIssuesInternal({ config }: DeploymentIssuesProps) {
       sortDirection,
       setSortDirection },
     containerRef,
-    containerStyle } = useCardData<DeploymentIssue, SortByOption>(rawIssues, {
-    filter: {
-      searchFields: ['name', 'namespace', 'cluster', 'reason', 'message'],
-      clusterField: 'cluster',
-      storageKey: 'deployment-issues' },
-    sort: {
-      defaultField: 'status',
-      defaultDirection: 'asc',
-      comparators: {
-        status: (a, b) => (a.reason || '').localeCompare(b.reason || ''),
-        name: commonComparators.string('name'),
-        cluster: (a, b) => (a.cluster || '').localeCompare(b.cluster || '') } },
-    defaultLimit: 5 })
+    containerStyle } = useCardData<DeploymentIssue, SortByOption>(rawIssues, cardDataConfig)
 
   const handleDeploymentClick = (issue: DeploymentIssue) => {
     if (!issue.cluster) {

--- a/web/src/components/cards/DeploymentProgress.tsx
+++ b/web/src/components/cards/DeploymentProgress.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useMemo, useState } from 'react'
 import { CheckCircle, Clock, XCircle, Loader2, Filter, ChevronRight, Server } from 'lucide-react'
 import { useCachedDeployments } from '../../hooks/useCachedData'
 import { ClusterBadge } from '../ui/ClusterBadge'
@@ -75,6 +75,24 @@ const SORT_COMPARATORS: Record<SortByOption, (a: Deployment, b: Deployment) => n
   name: commonComparators.string<Deployment>('name'),
   cluster: commonComparators.string<Deployment>('cluster') }
 
+// #6119: hoist to module scope so the reference is stable across renders.
+// Inline useCardData filter/sort objects caused "Maximum update depth
+// exceeded" on the deployments card — same pattern as #6232's
+// DeploymentStatus fix.
+const CARD_DATA_FILTER_CONFIG = {
+  searchFields: ['name', 'namespace', 'cluster'] as (keyof Deployment)[],
+  clusterField: 'cluster' as keyof Deployment,
+  storageKey: 'deployment-progress',
+} as const
+
+const CARD_DATA_SORT_CONFIG = {
+  defaultField: 'status' as SortByOption,
+  defaultDirection: 'asc' as SortDirection,
+  comparators: SORT_COMPARATORS,
+} as const
+
+const DEFAULT_PAGE_LIMIT = 5
+
 export function DeploymentProgress({ config }: DeploymentProgressProps) {
   const { t } = useTranslation()
   const cluster = config?.cluster
@@ -114,11 +132,26 @@ export function DeploymentProgress({ config }: DeploymentProgressProps) {
     deploying: progressingDeployments.filter((d) => d.status === 'deploying').length,
     failed: progressingDeployments.filter((d) => d.status === 'failed').length }
 
-  // Apply card-specific status filter before passing to useCardData
-  const statusFilteredDeployments = (() => {
+  // Apply card-specific status filter before passing to useCardData.
+  // #6119: memoized so the array reference is stable across renders when
+  // the source data and filter are unchanged — otherwise downstream
+  // useMemo dependencies in useCardData invalidate every render. Same
+  // pattern as #6232's DeploymentStatus fix.
+  const statusFilteredDeployments = useMemo(() => {
     if (statusFilter === 'all') return progressingDeployments
     return progressingDeployments.filter((d) => d.status === statusFilter)
-  })()
+  }, [progressingDeployments, statusFilter])
+
+  // #6119: stable config reference for useCardData; filter/sort/limit
+  // shapes are hoisted to module scope above.
+  const cardDataConfig = useMemo(
+    () => ({
+      filter: CARD_DATA_FILTER_CONFIG,
+      sort: CARD_DATA_SORT_CONFIG,
+      defaultLimit: DEFAULT_PAGE_LIMIT,
+    }),
+    [],
+  )
 
   // useCardData handles: global filters, local cluster filter, search, sort, pagination
   const {
@@ -133,16 +166,7 @@ export function DeploymentProgress({ config }: DeploymentProgressProps) {
     filters,
     sorting,
     containerRef,
-    containerStyle } = useCardData<Deployment, SortByOption>(statusFilteredDeployments, {
-    filter: {
-      searchFields: ['name', 'namespace', 'cluster'] as (keyof Deployment)[],
-      clusterField: 'cluster' as keyof Deployment,
-      storageKey: 'deployment-progress' },
-    sort: {
-      defaultField: 'status' as SortByOption,
-      defaultDirection: 'asc' as SortDirection,
-      comparators: SORT_COMPARATORS },
-    defaultLimit: 5 })
+    containerStyle } = useCardData<Deployment, SortByOption>(statusFilteredDeployments, cardDataConfig)
 
   // Handle filter changes (reset page)
   const handleFilterChange = (newFilter: StatusFilter) => {


### PR DESCRIPTION
## Summary

@xonas1101 reopened #6119 (\"this wasn't fixed\") with a \"Maximum update depth exceeded\" Card Render Error on the deployments card. The prior fix (#6232) addressed the same pattern in \`DeploymentStatus\` but two sibling cards still had it.

### Root cause (same as #6232)

Inline filter/sort config objects passed into \`useCardData\` invalidate the hook's internal \`useMemo\` deps every render, cascading into a \`useLayoutEffect\` in \`useReportCardDataState\` that reports new state, which triggers a re-render, which creates a new inline object, etc.

### Fixes

**DeploymentIssues.tsx** — inline filter+sort+defaultLimit object at the useCardData call site. Hoisted filter/sort to module scope (\`CARD_DATA_FILTER_CONFIG\` / \`CARD_DATA_SORT_CONFIG\`) and memoized the outer config with \`useMemo(..., [])\`.

**DeploymentProgress.tsx** — same inline config, PLUS an IIFE \`statusFilteredDeployments\` that returned a new filtered array reference on every render. Wrapped in \`useMemo([progressingDeployments, statusFilter])\`.

Closes #6119

## Test plan

- [x] \`npm run build\` clean
- [x] DeploymentStatus tests (30/30) still pass
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)