### PR TITLE
fix(cards): EventStream comment accuracy + Kubedle guess dictionary check (#6305, #6306)

### DIFF
--- a/web/src/components/cards/EventStream.tsx
+++ b/web/src/components/cards/EventStream.tsx
@@ -133,16 +133,18 @@ function EventStreamInternal({ config }: { config?: EventStreamConfig }) {
   })
 
   // #6070: when the user explicitly sets `config.limit` via the card
-  // settings modal, it must override any persisted itemsPerPage from
-  // localStorage (storageKey 'event-stream'). `useCardData` only
-  // consumes `defaultLimit` on initial mount — after that, its state
-  // is sourced from localStorage. Without this effect, a user's
-  // configured limit was silently ignored whenever they'd previously
-  // used the in-card "show N" dropdown, which is exactly the
-  // "show field disregarded, causing a very long card" bug in #6070.
-  // The user's workaround (minimize + maximize to force remount) only
-  // helped transiently because on some remounts localStorage was still
-  // catching up — the config.limit was never the source of truth.
+  // settings modal, it must override the persisted itemsPerPage that
+  // `useCardData` seeds from localStorage (key
+  // `kubestellar-card-limit:event-stream`, which matches the
+  // `storageKey: 'event-stream'` passed below). `useCardData` reads
+  // that key once during the initial useState and never re-consults
+  // `defaultLimit` after the first mount, so a user's configured
+  // limit was silently ignored whenever they'd previously touched
+  // the in-card "show N" dropdown. That's the "show field
+  // disregarded, causing a very long card" bug. The minimize-then-
+  // maximize workaround only appeared to help because the remount
+  // happened to land before a state update — config.limit was never
+  // the source of truth.
   useEffect(() => {
     if (typeof config?.limit === 'number' && config.limit > 0) {
       setItemsPerPage(config.limit)

--- a/web/src/components/cards/Kubedle.tsx
+++ b/web/src/components/cards/Kubedle.tsx
@@ -33,6 +33,12 @@ const FALLBACK_WORDS = [
 
 const WORDS = WORD_LIST.length >= 20 ? WORD_LIST : FALLBACK_WORDS
 
+// #6306: Set of valid guesses (the same pool used for target words).
+// The original submit handler only checked `length === 5` and accepted
+// any random letters as a guess, letting players burn rows with junk
+// like "XXXXX". Lookup in a Set is O(1); words are already uppercased.
+const VALID_GUESSES = new Set(WORDS)
+
 // Get today's word (deterministic based on date)
 function getTodaysWord(): string {
   const today = new Date()
@@ -170,6 +176,23 @@ export function Kubedle(_props: CardComponentProps) {
       if (currentGuess.length !== 5) {
         setShake(true)
         setMessage('Not enough letters')
+        if (shakeTimeoutRef.current) clearTimeout(shakeTimeoutRef.current)
+        shakeTimeoutRef.current = setTimeout(() => {
+          setShake(false)
+          setMessage('')
+          shakeTimeoutRef.current = null
+        }, 500)
+        return
+      }
+
+      // #6306: reject guesses that aren't in the word pool. Previously
+      // any 5-letter string was accepted, so players could type junk
+      // like "XXXXX" and burn a row. The word pool is the same set
+      // used to pick the target, so every valid target is a valid
+      // guess. Ties into the existing "Not enough letters" shake UX.
+      if (!VALID_GUESSES.has(currentGuess)) {
+        setShake(true)
+        setMessage('Not in word list')
         if (shakeTimeoutRef.current) clearTimeout(shakeTimeoutRef.current)
         shakeTimeoutRef.current = setTimeout(() => {
           setShake(false)


### PR DESCRIPTION
## Summary

Two small card fixes bundled.

### #6305 — EventStream comment accuracy (Copilot review of #6301)

Rewrote the localStorage-related comment that was factually wrong in two ways:

1. It said the storage key was \`event-stream\`, but the actual key is \`kubestellar-card-limit:event-stream\` (the \`LOCAL_LIMIT_STORAGE_PREFIX\` is applied by the shared hook).
2. It said localStorage was \"catching up\" during minimize/maximize. localStorage is synchronous — there's no catch-up period. The real reason the workaround appeared to help is that a remount occasionally landed before the next state update, briefly matching \`defaultLimit\`; it was never a reliable fix.

### #6306 — Kubedle accepts non-dictionary words as guesses

The submit handler only checked \`currentGuess.length === 5\`, so any random 5-letter string (\"XXXXX\", \"ZZZZZ\") was accepted, letting players burn guess rows with junk. Added a \`VALID_GUESSES\` set built from the same word pool used to pick the target, plus a \"Not in word list\" shake branch that reuses the existing \"Not enough letters\" UX. Real target words are a subset of \`VALID_GUESSES\` so there's no chance of rejecting a legitimate target.

Closes #6305
Closes #6306

## Test plan

- [x] \`npm run build\` clean
- [ ] CI green
- [ ] Manual: type \"XXXXX\" in Kubedle → shake + \"Not in word list\"

🤖 Generated with [Claude Code](https://claude.com/claude-code)