### PR TITLE
fix(cards): KubeKong barrels never spawned due to unstable callbacks (#6304)

### DIFF
--- a/web/src/components/cards/KubeKong.tsx
+++ b/web/src/components/cards/KubeKong.tsx
@@ -122,8 +122,15 @@ export function KubeKong(_props: CardComponentProps) {
     gameStateRef.current = { player, barrels }
   }, [player, barrels])
 
-  // Check if player is on a ladder
-  const getOnLadder = (x: number, y: number): Ladder | null => {
+  // Check if player is on a ladder.
+  // #6304: useCallback with [] so the reference is stable across
+  // renders. Previously this was a plain function redefined every
+  // render, which caused the game-loop useEffect (whose deps include
+  // this callback) to re-run on every render, clearing the
+  // setInterval and resetting `barrelSpawnCounter = 0` before it
+  // could reach the spawn threshold — so Kong never threw a single
+  // barrel. Reads only module-level constants, so [] is safe.
+  const getOnLadder = useCallback((x: number, y: number): Ladder | null => {
     const playerCenterX = x + PLAYER_WIDTH / 2
     for (const ladder of LADDERS) {
       if (Math.abs(playerCenterX - ladder.x - 10) < 12 &&
@@ -133,10 +140,10 @@ export function KubeKong(_props: CardComponentProps) {
       }
     }
     return null
-  }
+  }, [])
 
-  // Check platform collision for player
-  const checkPlatformCollision = (x: number, y: number, vy: number): { onGround: boolean; groundY: number } => {
+  // Check platform collision for player. Same #6304 fix reasoning.
+  const checkPlatformCollision = useCallback((x: number, y: number, vy: number): { onGround: boolean; groundY: number } => {
     const playerBottom = y + PLAYER_HEIGHT
     const playerCenterX = x + PLAYER_WIDTH / 2
 
@@ -149,7 +156,7 @@ export function KubeKong(_props: CardComponentProps) {
       }
     }
     return { onGround: false, groundY: y }
-  }
+  }, [])
 
   // Draw game
   const draw = useCallback(() => {


### PR DESCRIPTION
## Summary

@xonas1101 reported \"No barrels been thrown by kong\" on the KubeKong arcade card.

### Root cause (verified)

\`getOnLadder\` (KubeKong.tsx:126) and \`checkPlatformCollision\` (KubeKong.tsx:139) were plain function declarations inside the component body, so both got a fresh reference on every render. The game-loop \`useEffect\` at line 632 has them in its dep array:

\`\`\`ts
}, [isPlaying, gameOver, getOnLadder, checkPlatformCollision, level, lives])
\`\`\`

Every render re-ran the effect, cleared the old \`setInterval\`, started a new one, and reset the effect-local \`barrelSpawnCounter = 0\`. The game loop ticks every 33ms and the spawn threshold is 40-120 ticks (≈1.3-4s), but React re-renders happen much more often than that — so the counter **never reached the threshold** and Kong never threw a single barrel.

### Fix

Wrap both helpers in \`useCallback([])\`. They only read module-level constants (\`PLAYER_WIDTH\`, \`PLAYER_HEIGHT\`, \`LADDERS\`, \`PLATFORMS\`, \`getPlatformY\`) so \`[]\` is safe. The effect's dep array is unchanged; the refs it sees are now stable and the \`setInterval\` runs uninterrupted.

Closes #6304

## Test plan

- [x] \`npm run build\` clean
- [ ] CI green
- [ ] Manual: open KubeKong, start game, verify barrels spawn within ~2-4 seconds

🤖 Generated with [Claude Code](https://claude.com/claude-code)