### PR TITLE
fix(missions): MissionBrowser close button on right, matching BaseModal (#6308)

### DIFF
--- a/web/src/components/missions/MissionBrowser.tsx
+++ b/web/src/components/missions/MissionBrowser.tsx
@@ -1170,14 +1170,6 @@ export function MissionBrowser({ isOpen, onClose, onImport, initialMission }: Mi
       {/* Top bar: search + filters */}
       {/* ================================================================== */}
       <div className="flex items-center gap-3 px-4 py-3 bg-card border-b border-border">
-        <button
-          onClick={onClose}
-          className="p-2 rounded-lg hover:bg-secondary text-muted-foreground hover:text-foreground transition-colors"
-          title="Close (Esc)"
-        >
-          <X className="w-5 h-5" />
-        </button>
-
         <div className="flex-1 relative">
           <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-muted-foreground" />
           <input
@@ -1232,6 +1224,19 @@ export function MissionBrowser({ isOpen, onClose, onImport, initialMission }: Mi
             <List className="w-4 h-4" />
           </button>
         </div>
+
+        {/* #6308: close button moved to the RIGHT end of the top bar to
+            match every other modal in the app (BaseModal etc). Having
+            it on the left was a confusing one-off — users trained to
+            close modals via the top-right X were not finding it. */}
+        <button
+          onClick={onClose}
+          className="p-2 rounded-lg hover:bg-secondary text-muted-foreground hover:text-foreground transition-colors"
+          title="Close (Esc)"
+          aria-label="Close mission browser"
+        >
+          <X className="w-5 h-5" />
+        </button>
       </div>
 
       {/* Filter bar — constrained height on mobile with scroll */}

--- a/web/src/test/ui-ux-standards.test.ts
+++ b/web/src/test/ui-ux-standards.test.ts
@@ -64,11 +64,12 @@ const COMPONENTS_DIR = path.resolve(
 //   296 → 298: #6265 copilot follow-up comment refs
 //   298 → 300: #6273 followup comment refs
 //   300 → 301: #6289 gauge readiness color inversion issue ref
+//   301 → 302: #6308 MissionBrowser close button on right issue ref
 //
 // When you bump this number, append a one-line entry above so future
 // bumps stay grep-able and reviewers can tell at a glance whether a
 // change is a real new violation or just a comment-level reference.
-const EXPECTED_RAW_HEX_COUNT = 301
+const EXPECTED_RAW_HEX_COUNT = 302
 const EXPECTED_RAW_RGBA_COUNT = 104
 const EXPECTED_ARBITRARY_TW_COLOR_COUNT = 22
 const EXPECTED_INLINE_STYLE_COLOR_COUNT = 213


### PR DESCRIPTION
## Summary

@xonas1101 reported that the Community Missions browser has its close button on the **left** of the top bar while every other modal in the app has it on the **right**. Confirmed: \`BaseModal.tsx:198-212\` puts the X inside the \"Right side\" div, and \`MissionBrowser.tsx:1173-1179\` was placing it *before* the search input. This is inconsistent and easy to misclick when trying to focus the search input.

### Fix

Move the close button to the right end of the top bar, after the grid/list view-mode toggle. Same styling and behavior; added an \`aria-label\` while editing the JSX. No functional change.

Closes #6308

## Test plan

- [x] \`npm run build\` clean
- [ ] CI green
- [ ] Manual: open Community Missions, verify X is on the right

🤖 Generated with [Claude Code](https://claude.com/claude-code)