### PR TITLE
fix(ux): confirm AI mission prompt before starting cluster upgrade (#6309)

### DIFF
--- a/web/src/components/cards/UpgradeStatus.tsx
+++ b/web/src/components/cards/UpgradeStatus.tsx
@@ -4,6 +4,7 @@ import { useClusters } from '../../hooks/useMCP'
 import { useGlobalFilters } from '../../hooks/useGlobalFilters'
 import { useDrillDownActions } from '../../hooks/useDrillDown'
 import { useMissions } from '../../hooks/useMissions'
+import { ConfirmMissionPromptDialog } from '../missions/ConfirmMissionPromptDialog'
 import { useLocalAgent } from '../../hooks/useLocalAgent'
 import { useDemoMode } from '../../hooks/useDemoMode'
 import { useCardData, commonComparators } from '../../lib/cards/cardHooks'
@@ -520,13 +521,22 @@ export function UpgradeStatus({ config: _config }: UpgradeStatusProps) {
     }
   }, [isDemoMode, agentConnected, allClusters])
 
-  const handleStartUpgrade = (clusterName: string, currentVersion: string, targetVersion: string) => {
-    startMission({
-      title: `Upgrade ${clusterName}`,
-      description: `Upgrade from ${currentVersion} to ${targetVersion}`,
-      type: 'upgrade',
-      cluster: clusterName,
-      initialPrompt: `I want to upgrade the Kubernetes cluster "${clusterName}" from version ${currentVersion} to ${targetVersion}.
+  // #6309: show the prompt-confirmation dialog before starting the
+  // upgrade mission. Previously, clicking "Start Upgrade" launched
+  // the AI agent immediately with no chance for the user to review
+  // or edit the prompt — a critical-function click with no gate.
+  // The ConfirmMissionPromptDialog was added in #5913 for exactly
+  // this pattern (installer flows); here we reuse it for upgrades.
+  interface PendingUpgrade {
+    clusterName: string
+    currentVersion: string
+    targetVersion: string
+    prompt: string
+  }
+  const [pendingUpgrade, setPendingUpgrade] = useState<PendingUpgrade | null>(null)
+
+  const buildUpgradePrompt = (clusterName: string, currentVersion: string, targetVersion: string) =>
+    `I want to upgrade the Kubernetes cluster "${clusterName}" from version ${currentVersion} to ${targetVersion}.
 
 Please help me with this upgrade by:
 1. First checking the cluster's current state and any prerequisites
@@ -535,11 +545,33 @@ Please help me with this upgrade by:
 4. Performing the upgrade with proper monitoring
 5. Validating the upgrade was successful
 
-Please proceed step by step and ask for confirmation before making any changes.`,
+Please proceed step by step and ask for confirmation before making any changes.`
+
+  const handleStartUpgrade = (clusterName: string, currentVersion: string, targetVersion: string) => {
+    // Stage the upgrade in pending state — the dialog below will call
+    // confirmStartUpgrade (with the possibly-edited prompt) or cancel.
+    setPendingUpgrade({
+      clusterName,
+      currentVersion,
+      targetVersion,
+      prompt: buildUpgradePrompt(clusterName, currentVersion, targetVersion),
+    })
+  }
+
+  const confirmStartUpgrade = (editedPrompt: string) => {
+    if (!pendingUpgrade) return
+    const { clusterName, currentVersion, targetVersion } = pendingUpgrade
+    startMission({
+      title: `Upgrade ${clusterName}`,
+      description: `Upgrade from ${currentVersion} to ${targetVersion}`,
+      type: 'upgrade',
+      cluster: clusterName,
+      initialPrompt: editedPrompt,
       context: {
         clusterName,
         currentVersion,
         targetVersion } })
+    setPendingUpgrade(null)
   }
 
   // Apply global filters to get clusters, then build version data
@@ -752,6 +784,18 @@ Please proceed step by step and ask for confirmation before making any changes.`
         onPageChange={goToPage}
         needsPagination={needsPagination}
       />
+
+      {/* #6309: confirm prompt before running the upgrade mission. */}
+      {pendingUpgrade && (
+        <ConfirmMissionPromptDialog
+          open={true}
+          missionTitle={`Upgrade ${pendingUpgrade.clusterName}`}
+          missionDescription={`Upgrade from ${pendingUpgrade.currentVersion} to ${pendingUpgrade.targetVersion}`}
+          initialPrompt={pendingUpgrade.prompt}
+          onCancel={() => setPendingUpgrade(null)}
+          onConfirm={confirmStartUpgrade}
+        />
+      )}
     </div>
   )
 }

--- a/web/src/test/ui-ux-standards.test.ts
+++ b/web/src/test/ui-ux-standards.test.ts
@@ -65,11 +65,12 @@ const COMPONENTS_DIR = path.resolve(
 //   298 → 300: #6273 followup comment refs
 //   300 → 301: #6289 gauge readiness color inversion issue ref
 //   301 → 302: #6308 MissionBrowser close button on right issue ref
+//   302 → 303: #6309 upgrade confirm dialog issue ref
 //
 // When you bump this number, append a one-line entry above so future
 // bumps stay grep-able and reviewers can tell at a glance whether a
 // change is a real new violation or just a comment-level reference.
-const EXPECTED_RAW_HEX_COUNT = 302
+const EXPECTED_RAW_HEX_COUNT = 303
 const EXPECTED_RAW_RGBA_COUNT = 104
 const EXPECTED_ARBITRARY_TW_COLOR_COUNT = 22
 const EXPECTED_INLINE_STYLE_COLOR_COUNT = 213


### PR DESCRIPTION
## Summary

@xonas1101 reported that clicking the \"Start Upgrade\" button on the UpgradeStatus card triggered a critical function (full Kubernetes cluster upgrade via AI agent) with **zero user validation** — no confirmation, no way to review or edit the prompt that would be sent.

### Fix

\`ConfirmMissionPromptDialog\` already exists (added in #5913 for the Install-via-AI flows). Reused it here: clicking \"Start Upgrade\" now stages the upgrade in a \`pendingUpgrade\` state, which mounts the dialog pre-filled with the upgrade prompt. The user can:

- Review the mission title, description, and full prompt
- Edit the prompt before confirming
- Cancel without any mission being started

Only after **Confirm** is clicked does \`startMission()\` actually run.

Closes #6309

## Test plan

- [x] \`npm run build\` clean
- [ ] CI green
- [ ] Manual: click \"Start Upgrade\" on a cluster → confirm dialog opens → cancel closes it without starting mission

🤖 Generated with [Claude Code](https://claude.com/claude-code)