### PR TITLE
fix(cards): guard confirmStartUpgrade against double-click (#6320)

### DIFF
--- a/web/src/components/cards/UpgradeStatus.tsx
+++ b/web/src/components/cards/UpgradeStatus.tsx
@@ -534,6 +534,13 @@ export function UpgradeStatus({ config: _config }: UpgradeStatusProps) {
     prompt: string
   }
   const [pendingUpgrade, setPendingUpgrade] = useState<PendingUpgrade | null>(null)
+  // #6320: guards against double-clicking the Confirm button in the
+  // dialog. `setPendingUpgrade(null)` is async, so a second click that
+  // fires before React re-renders would still see `pendingUpgrade`
+  // non-null, pass the !pendingUpgrade guard, and call startMission
+  // again. A ref flipped synchronously at the top of the handler
+  // closes that window.
+  const startingMissionRef = useRef(false)
 
   const buildUpgradePrompt = (clusterName: string, currentVersion: string, targetVersion: string) =>
     `I want to upgrade the Kubernetes cluster "${clusterName}" from version ${currentVersion} to ${targetVersion}.
@@ -559,7 +566,14 @@ Please proceed step by step and ask for confirmation before making any changes.`
   }
 
   const confirmStartUpgrade = (editedPrompt: string) => {
-    if (!pendingUpgrade) return
+    // #6320: double-click guard. The two checks work together:
+    //   - startingMissionRef: synchronous; catches back-to-back clicks
+    //     inside a single React commit cycle.
+    //   - !pendingUpgrade: catches stale-closure invocations after
+    //     the dialog has been dismissed but a queued click is still
+    //     pending.
+    if (!pendingUpgrade || startingMissionRef.current) return
+    startingMissionRef.current = true
     const { clusterName, currentVersion, targetVersion } = pendingUpgrade
     startMission({
       title: `Upgrade ${clusterName}`,
@@ -572,6 +586,9 @@ Please proceed step by step and ask for confirmation before making any changes.`
         currentVersion,
         targetVersion } })
     setPendingUpgrade(null)
+    // Reset the ref on the next tick so a subsequent (new) upgrade
+    // mission can run normally.
+    setTimeout(() => { startingMissionRef.current = false }, 0)
   }
 
   // Apply global filters to get clusters, then build version data


### PR DESCRIPTION
## Summary

Copilot's review of #6316 noted that the new confirm-upgrade flow could start duplicate missions on a rapid double-click of the dialog's Confirm button: \`setPendingUpgrade(null)\` is async, so a second click that lands before React re-renders still sees \`pendingUpgrade\` non-null and passes the \`!pendingUpgrade\` guard.

### Fix

Add a synchronous \`startingMissionRef\` flipped at the top of \`confirmStartUpgrade\`. The two checks work together:

- \`startingMissionRef\`: catches back-to-back clicks inside a single React commit cycle (synchronous).
- \`!pendingUpgrade\`: catches stale-closure invocations after the dialog has been dismissed but a queued click is still pending.

The ref is reset on the next tick so subsequent (legitimate) new upgrade missions can run normally.

### Copilot's second item (tests)

Copilot also asked for unit tests for the new gating behavior. The existing UpgradeStatus tests are smoke tests with mocked \`useCardData\` returning empty items, so no \"Start Upgrade\" button is rendered — adding a proper click-interaction test requires a non-trivial rework of the mocks. Tracking as a separate followup; this PR keeps scope tight to the real bug.

Closes #6320

## Test plan

- [x] \`npm run build\` clean
- [ ] CI green
- [ ] Manual: rapid double-click the dialog Confirm button → only one mission starts

🤖 Generated with [Claude Code](https://claude.com/claude-code)