### PR TITLE
fix(helm): set numeric runAsUser so Kind/Minikube/OpenShift can verify non-root (#6323)

### DIFF
--- a/deploy/helm/kubestellar-console/templates/deployment.yaml
+++ b/deploy/helm/kubestellar-console/templates/deployment.yaml
@@ -36,6 +36,13 @@ spec:
       initContainers:
         - name: db-restore
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          # #6323/#6324: init container uses the same image as the app
+          # container (`appuser`), so it needs the same numeric UID.
+          # Without this, the init container would also hit
+          # "container has runAsNonRoot and image has non-numeric user"
+          # on clusters enforcing PodSecurity restricted.
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
           command:
             - /bin/sh
             - -c

--- a/deploy/helm/kubestellar-console/values.yaml
+++ b/deploy/helm/kubestellar-console/values.yaml
@@ -35,6 +35,15 @@ podLabels: {}
 podSecurityContext: {}
 
 securityContext:
+  # #6323/#6324: must be a numeric UID (not `appuser`) so the kubelet
+  # can verify non-root without reading the image manifest. Matches
+  # the Dockerfile's `addgroup -g 1001 … adduser -u 1001 … appuser`
+  # + `USER appuser`. Without an explicit numeric runAsUser,
+  # Kubernetes blocks startup on Kind/Minikube/OpenShift with:
+  #   CreateContainerConfigError: container has runAsNonRoot
+  #   and image has non-numeric user (appuser)
+  runAsUser: 1001
+  runAsGroup: 1001
   runAsNonRoot: true
   readOnlyRootFilesystem: true
   capabilities:


### PR DESCRIPTION
## Summary

@rishi-jat reported (in #6323 and duplicate #6324) that installing the Helm chart on Kind/Minikube fails with:

\`\`\`
CreateContainerConfigError: container has runAsNonRoot and image has non-numeric user (appuser)
\`\`\`

### Root cause

The Dockerfile creates the runtime user **by name, not UID**:

\`\`\`Dockerfile
RUN addgroup -g 1001 -S appgroup && \\
    adduser -u 1001 -S appuser -G appgroup
USER appuser
\`\`\`

When \`securityContext.runAsNonRoot: true\` is set without a numeric \`runAsUser\`, the kubelet can't verify that \`appuser\` is non-root from the image manifest alone and blocks container startup. Same failure mode on OpenShift SCC.

### Fix

- **values.yaml** — add \`runAsUser: 1001\` + \`runAsGroup: 1001\` to \`securityContext\`, matching the Dockerfile's numeric UID/GID.
- **deployment.yaml** — apply the same \`securityContext\` to the \`db-restore\` init container, which uses the same image and had no securityContext at all. It would have hit the same failure on restricted PodSecurity namespaces.

Verified: \`helm template\` renders both containers with \`runAsUser: 1001\`, \`runAsGroup: 1001\`, \`runAsNonRoot: true\`.

Closes #6323
Closes #6324

## Test plan

- [x] \`helm template kc ./deploy/helm/kubestellar-console\` renders both containers correctly
- [x] \`helm template\` with \`backup.enabled=true backup.autoRestore=true\` includes init container securityContext
- [ ] CI green
- [ ] Manual: \`helm install\` on Kind succeeds without CreateContainerConfigError

🤖 Generated with [Claude Code](https://claude.com/claude-code)