### PR TITLE
security(dast): targeted CSP exception filter replaces blanket IGNORE (#6321)

### DIFF
--- a/.github/workflows/nightly-dast.yml
+++ b/.github/workflows/nightly-dast.yml
@@ -58,6 +58,20 @@ jobs:
       - name: Parse ZAP Results
         if: always()
         id: zap-results
+        env:
+          # #6321: documented CSP exceptions — intentional 'unsafe-*'
+          # directives that cannot be removed without breaking
+          # load-bearing features (dynamic-cards `new Function()` and
+          # React inline style props). See netlify.toml:148-168 for
+          # full rationale and compensating controls. This filter is
+          # the source of truth for "which CSP alerts are expected";
+          # adding to the list requires a PR review. Matching against
+          # the alert `name` field lets us silence ONLY these two
+          # sub-findings while still catching future CSP regressions
+          # under the same rule id 10055.
+          DOCUMENTED_CSP_EXCEPTIONS: |
+            CSP: script-src unsafe-eval
+            CSP: style-src unsafe-inline
         run: |
           # ZAP baseline outputs a summary to stdout; check for alerts
           ALERT_COUNT=0
@@ -66,10 +80,15 @@ jobs:
           LOW_COUNT=0
 
           if [ -f report_json.json ]; then
-            ALERT_COUNT=$(jq '[.site[].alerts[]] | length' report_json.json 2>/dev/null || echo 0)
-            HIGH_COUNT=$(jq '[.site[].alerts[] | select(.riskcode == "3")] | length' report_json.json 2>/dev/null || echo 0)
-            MEDIUM_COUNT=$(jq '[.site[].alerts[] | select(.riskcode == "2")] | length' report_json.json 2>/dev/null || echo 0)
-            LOW_COUNT=$(jq '[.site[].alerts[] | select(.riskcode == "1")] | length' report_json.json 2>/dev/null || echo 0)
+            # Build a jq filter that excludes each documented exception by name.
+            # We read the exception list from the env var so adding a new
+            # documented exception is a one-line YAML edit, not a jq rewrite.
+            EXCLUDE_JQ='[.site[].alerts[] | select(.name as $n | ($exceptions | split("\n") | map(select(length > 0)) | index($n) | not))]'
+
+            ALERT_COUNT=$(jq  --arg exceptions "$DOCUMENTED_CSP_EXCEPTIONS" "$EXCLUDE_JQ | length" report_json.json 2>/dev/null || echo 0)
+            HIGH_COUNT=$(jq   --arg exceptions "$DOCUMENTED_CSP_EXCEPTIONS" "$EXCLUDE_JQ | map(select(.riskcode == \"3\")) | length" report_json.json 2>/dev/null || echo 0)
+            MEDIUM_COUNT=$(jq --arg exceptions "$DOCUMENTED_CSP_EXCEPTIONS" "$EXCLUDE_JQ | map(select(.riskcode == \"2\")) | length" report_json.json 2>/dev/null || echo 0)
+            LOW_COUNT=$(jq    --arg exceptions "$DOCUMENTED_CSP_EXCEPTIONS" "$EXCLUDE_JQ | map(select(.riskcode == \"1\")) | length" report_json.json 2>/dev/null || echo 0)
           fi
 
           echo "alert_count=$ALERT_COUNT" >> "$GITHUB_OUTPUT"
@@ -86,12 +105,20 @@ jobs:
       - name: Generate Alert Summary
         if: always() && steps.zap-results.outputs.has_findings == 'true'
         id: zap-summary
+        env:
+          # #6321: keep the summary in sync with the parse step — if
+          # we've excluded a documented exception from the count, we
+          # shouldn't render it in the issue body either.
+          DOCUMENTED_CSP_EXCEPTIONS: |
+            CSP: script-src unsafe-eval
+            CSP: style-src unsafe-inline
         run: |
           SUMMARY=""
           if [ -f report_json.json ]; then
-            SUMMARY=$(jq -r '
+            SUMMARY=$(jq -r --arg exceptions "$DOCUMENTED_CSP_EXCEPTIONS" '
               [.site[].alerts[]
                | select(.riskcode == "2" or .riskcode == "3")
+               | select(.name as $n | ($exceptions | split("\n") | map(select(length > 0)) | index($n) | not))
                | "- **\(.riskdesc)**: \(.name) (\(.count) instance(s))"]
               | join("\n")
             ' report_json.json 2>/dev/null || echo "Could not parse alerts")

--- a/.github/zap-rules.tsv
+++ b/.github/zap-rules.tsv
@@ -19,30 +19,18 @@
 10050	IGNORE	Retrieved from Cache
 10109	IGNORE	Modern Web Application
 
-# CSP 'unsafe-eval' / 'unsafe-inline' — DOCUMENTED EXCEPTION (#6318)
+# CSP rule 10055: DO NOT blanket-IGNORE (#6321 follow-up to #6318).
+# The two current findings (script-src unsafe-eval + style-src
+# unsafe-inline) are documented exceptions in netlify.toml:148-168,
+# BUT rule 10055 covers EVERY CSP sub-alert, so IGNOREing it would
+# hide future CSP regressions (e.g. accidentally adding 'unsafe-eval'
+# to style-src, dropping object-src 'none', introducing a broad host
+# wildcard). Keep the rule active — the workflow now filters the two
+# specific finding NAMES in its JSON parse step
+# (.github/workflows/nightly-dast.yml) rather than silencing the
+# rule here. That preserves visibility for new CSP findings while
+# silencing only the documented exceptions.
 #
-# Both unsafe directives are intentional tradeoffs documented in
-# netlify.toml:148-168 and reviewed against the following constraints:
-#
-#   * script-src 'unsafe-eval' is required by the Tier 2 dynamic-cards
-#     feature — web/src/lib/dynamic-cards/compiler.ts uses `new Function()`
-#     to compile user-authored card modules at runtime. Removing
-#     'unsafe-eval' disables dynamic cards entirely.
-#
-#   * style-src 'unsafe-inline' is required because React renders
-#     `style={{}}` props as inline HTML style attributes. Removing it
-#     would require rewriting every inline style across the component
-#     tree (dozens of components).
-#
-# Compensating controls already in place:
-#   - Strict CSP for every other directive — no 'unsafe-*' for
-#     connect-src, img-src, object-src, base-uri, form-action, etc.
-#   - Explicit host allowlists for every third party (no scheme wildcards,
-#     no broad host globs).
-#   - The dynamic cards compiler runs untrusted code in a scoped scope
-#     with module-shape validation before execution.
-#
-# ZAP rule 10055 raises a sub-alert per unsafe directive; IGNORE
-# collapses them. Re-audit annually or whenever the dynamic-cards
-# feature changes. Nightly DAST #6318 was closed under this exception.
-10055	IGNORE	CSP (intentional unsafe-eval/unsafe-inline — see netlify.toml:148-168)
+# The rule is not listed below (no override) so ZAP treats it at its
+# default severity. The workflow filter, not this file, is now the
+# source of truth for "which CSP alerts are expected".


### PR DESCRIPTION
## Summary

Copilot's review of #6319 caught a real problem: \`10055 IGNORE\` in \`.github/zap-rules.tsv\` suppresses **all** ZAP alerts sharing rule id 10055, not just the documented unsafe-eval/unsafe-inline ones. That would hide future CSP regressions (e.g. accidentally adding \`'unsafe-eval'\` to style-src, dropping \`object-src 'none'\`, introducing a broad host wildcard).

### Fix

Move the exception from \`.github/zap-rules.tsv\` (blanket) to \`.github/workflows/nightly-dast.yml\` (targeted by alert **name**).

- **Parse step** — wraps the count jq filter in a \`select(.name not in DOCUMENTED_CSP_EXCEPTIONS)\` predicate. The exception list is an env var with one name per line; adding a new documented exception is a one-line YAML edit.
- **Summary step** — same filter so the issue body matches the counts.

Rule 10055 is now left WARN-level in the rules file with a comment pointing at the workflow filter as the source of truth.

### Verified against a synthetic report

| Finding | Expected |
|---|---|
| CSP: script-src unsafe-eval | filtered (documented) |
| CSP: style-src unsafe-inline | filtered (documented) |
| CSP: Missing object-src | **surfaces** (new) |
| Low unrelated | surfaces |

Result: \`MEDIUM_COUNT=1\` (missing object-src), \`LOW_COUNT=1\`, total 2 — exactly as expected.

Closes #6321

## Test plan

- [x] YAML parses
- [x] Synthetic ZAP report test passes (2 filtered, 2 surfaced)
- [ ] CI green
- [ ] Next nightly DAST run proves the exception still filters correctly against real output

🤖 Generated with [Claude Code](https://claude.com/claude-code)