### PR TITLE
fix: UX gaps in demo mode, agent messaging, feedback token, disconnect handling (#6338-#6342)

### DIFF
--- a/deploy/helm/kubestellar-console/templates/NOTES.txt
+++ b/deploy/helm/kubestellar-console/templates/NOTES.txt
@@ -1,0 +1,82 @@
+{{- /*
+NOTES.txt — shown to users after `helm install` / `helm upgrade`.
+
+Purpose (ref: kubestellar/console#6342): when a user sets any *.existingSecret
+to reference a pre-existing Kubernetes Secret but hasn't actually created it
+yet, the pod starts up in CreateContainerConfigError with no hint at what went
+wrong. Helm cannot query the cluster at template time to validate that the
+referenced Secret actually exists, so the best we can do is print an explicit,
+actionable checklist right after install with the exact `kubectl get secret`
+command the user should run to verify.
+*/ -}}
+{{ .Chart.Name }} {{ .Chart.Version }} — {{ include "kubestellar-console.fullname" . }}
+
+Access:
+  1. Get the service URL:
+     kubectl get svc {{ include "kubestellar-console.fullname" . }} -n {{ .Release.Namespace }}
+
+  2. Or port-forward for local access:
+     kubectl port-forward -n {{ .Release.Namespace }} svc/{{ include "kubestellar-console.fullname" . }} 8080:{{ .Values.service.port | default 8080 }}
+     Then open: http://localhost:8080
+
+{{- $anyExisting := false }}
+{{- if .Values.github.existingSecret }}{{ $anyExisting = true }}{{ end }}
+{{- if .Values.feedbackGithubToken.existingSecret }}{{ $anyExisting = true }}{{ end }}
+{{- if .Values.googleDrive.existingSecret }}{{ $anyExisting = true }}{{ end }}
+{{- if .Values.claude.existingSecret }}{{ $anyExisting = true }}{{ end }}
+{{- if .Values.jwt.existingSecret }}{{ $anyExisting = true }}{{ end }}
+
+{{- if $anyExisting }}
+
+IMPORTANT — pre-flight Secret validation
+=========================================
+This release references one or more pre-existing Kubernetes Secrets. Helm
+cannot verify that these Secrets exist at template time. If any referenced
+Secret is missing, the pod will fail to start with `CreateContainerConfigError`
+or `CreateContainerError`.
+
+Run the commands below to verify each referenced Secret exists BEFORE the pod
+rollout finishes. If any command returns "NotFound", create the Secret (or
+clear the corresponding `*.existingSecret` value so the chart renders its own).
+
+  {{- if .Values.github.existingSecret }}
+  # GitHub OAuth (github.existingSecret):
+  kubectl get secret {{ .Values.github.existingSecret }} -n {{ .Release.Namespace }}
+    # expected keys: {{ .Values.github.existingSecretKeys.clientId }}, {{ .Values.github.existingSecretKeys.clientSecret }}
+  {{- end }}
+  {{- if .Values.feedbackGithubToken.existingSecret }}
+  # Feedback/GitHub PAT (feedbackGithubToken.existingSecret):
+  kubectl get secret {{ .Values.feedbackGithubToken.existingSecret }} -n {{ .Release.Namespace }}
+    # expected key: {{ .Values.feedbackGithubToken.existingSecretKey }}
+  {{- end }}
+  {{- if .Values.googleDrive.existingSecret }}
+  # Google Drive API key (googleDrive.existingSecret):
+  kubectl get secret {{ .Values.googleDrive.existingSecret }} -n {{ .Release.Namespace }}
+    # expected key: {{ .Values.googleDrive.existingSecretKey }}
+  {{- end }}
+  {{- if .Values.claude.existingSecret }}
+  # Claude API key (claude.existingSecret):
+  kubectl get secret {{ .Values.claude.existingSecret }} -n {{ .Release.Namespace }}
+    # expected key: {{ .Values.claude.existingSecretKey }}
+  {{- end }}
+  {{- if .Values.jwt.existingSecret }}
+  # JWT signing key (jwt.existingSecret):
+  kubectl get secret {{ .Values.jwt.existingSecret }} -n {{ .Release.Namespace }}
+    # expected key: {{ .Values.jwt.existingSecretKey }}
+  {{- end }}
+
+Check rollout status:
+  kubectl rollout status deploy/{{ include "kubestellar-console.fullname" . }} -n {{ .Release.Namespace }}
+
+If the pod is stuck in CreateContainerConfigError, describe it to see which
+Secret is missing:
+  kubectl describe pod -n {{ .Release.Namespace }} -l app.kubernetes.io/instance={{ .Release.Name }}
+{{- else }}
+
+All secrets for this release are rendered by the chart itself — no external
+Secret objects are required. Check rollout status:
+  kubectl rollout status deploy/{{ include "kubestellar-console.fullname" . }} -n {{ .Release.Namespace }}
+{{- end }}
+
+Docs:   https://kubestellar.io/docs/console/readme
+Issues: https://github.com/kubestellar/console/issues

--- a/web/src/components/auth/Login.tsx
+++ b/web/src/components/auth/Login.tsx
@@ -147,6 +147,13 @@ export function Login() {
     return { ...UNKNOWN_ERROR_FALLBACK, message: `An unexpected error occurred during login (code: ${oauthError}).` }
   })()
   const branding = useBranding()
+  // True when the user lands on the Login page while visiting the hosted demo
+  // domain (e.g. "console.kubestellar.io"). Real GitHub OAuth is not configured
+  // at that origin, so we surface an explicit notice and disable the button to
+  // prevent a dead-end click-through (ref: #6338).
+  const isHostedDemoLogin = typeof window !== 'undefined'
+    && !!branding.hostedDomain
+    && window.location.hostname === branding.hostedDomain
 
   // Pre-compute random star positions so render stays pure (no Math.random() in JSX)
   const STAR_COUNT = 30
@@ -157,7 +164,8 @@ export function Login() {
       top: Math.random() * 100 + '%',
       animationDelay: Math.random() * 3 + 's' }))
 
-  // Auto-login for Netlify deploy previews or when backend has no OAuth configured
+  // Auto-login for Netlify deploy previews, the hosted demo domain, or when
+  // the backend has no OAuth configured.
   // Skip auto-login when there's an OAuth error so the user can see the troubleshooting info
   useEffect(() => {
     if (isLoading || isAuthenticated || oauthError) return
@@ -165,8 +173,14 @@ export function Login() {
     const isNetlifyPreview = window.location.hostname.includes('deploy-preview-') ||
       window.location.hostname.includes('netlify.app')
     const isDemoMode = import.meta.env.VITE_DEMO_MODE === 'true'
+    // Hosted demo domain from branding (e.g. "console.kubestellar.io") — there
+    // is no real OAuth backend at that origin, so auto-login with a demo user.
+    // This fixes the case where users visiting the hosted demo would otherwise
+    // see a "Sign in with GitHub" button that leads nowhere.
+    const hostedDomain = branding.hostedDomain
+    const isHostedDemo = !!hostedDomain && window.location.hostname === hostedDomain
 
-    if (isNetlifyPreview || isDemoMode) {
+    if (isNetlifyPreview || isDemoMode || isHostedDemo) {
       emitLogin('auto-netlify'); login()
       return
     }
@@ -178,7 +192,7 @@ export function Login() {
         emitLogin('auto-quickstart'); login()
       }
     }).catch(() => { /* checkOAuthConfigured always resolves — defensive catch */ })
-  }, [isLoading, isAuthenticated, login, oauthError])
+  }, [isLoading, isAuthenticated, login, oauthError, branding.hostedDomain])
 
   // Show loading while checking auth status
   if (isLoading) {
@@ -292,11 +306,36 @@ export function Login() {
             </p>
           </div>
 
+          {/* Hosted demo notice — shown when on the hosted demo domain so users
+              understand that GitHub OAuth is intentionally unavailable and that
+              they'll be auto-logged-in as a demo user. Ref: #6338. */}
+          {isHostedDemoLogin && (
+            <div className="mb-4 px-4 py-3 rounded-lg border border-purple-500/30 bg-purple-500/10 text-purple-200 text-xs">
+              <div className="font-medium text-purple-300 mb-1">Hosted demo</div>
+              <p className="text-purple-300/80">
+                Real GitHub sign-in is not available on the hosted demo. You'll be
+                signed in as a demo user automatically. To enable GitHub OAuth and
+                connect a real cluster,{' '}
+                <a
+                  href="https://github.com/kubestellar/console#quick-start"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="underline hover:text-purple-100"
+                >
+                  self-host the console
+                </a>
+                .
+              </p>
+            </div>
+          )}
+
           {/* GitHub login button */}
           <button
             data-testid="github-login-button"
-            onClick={() => { emitLogin('github'); login() }}
-            className="w-full flex items-center justify-center gap-3 bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 font-medium py-3 px-4 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-700 transition-all duration-200 hover:shadow-lg"
+            onClick={() => { if (!isHostedDemoLogin) { emitLogin('github'); login() } }}
+            disabled={isHostedDemoLogin}
+            title={isHostedDemoLogin ? 'Not available in the hosted demo — self-host to enable GitHub OAuth' : undefined}
+            className="w-full flex items-center justify-center gap-3 bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 font-medium py-3 px-4 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-700 transition-all duration-200 hover:shadow-lg disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:bg-white dark:disabled:hover:bg-gray-800 disabled:hover:shadow-none"
           >
             <Github className="w-5 h-5" />
             {t('login.continueWithGitHub')}

--- a/web/src/components/layout/navbar/AgentStatusIndicator.tsx
+++ b/web/src/components/layout/navbar/AgentStatusIndicator.tsx
@@ -283,7 +283,11 @@ export function AgentStatusIndicator() {
             })()}
             <p className="text-xs text-muted-foreground mt-1">
               {isDemoMode
-                ? t('agent.agentBypassedInDemo')
+                ? isDemoModeForced
+                  // Hosted demo (e.g. console.kubestellar.io): agent can never connect
+                  // from this origin, so point the user at the self-host path.
+                  ? t('agent.hostedDemoBypassed')
+                  : t('agent.agentBypassedInDemo')
                 : isDegraded
                 ? t('agent.connectedButErrors', { count: dataErrorCount })
                 : isConnected
@@ -293,6 +297,20 @@ export function AgentStatusIndicator() {
                 : t('agent.unableToConnect')
               }
             </p>
+            {/* When running on the hosted demo, surface a self-host link so
+                users who want real cluster data know where to go next. */}
+            {isDemoMode && isDemoModeForced && (
+              <p className="text-xs text-muted-foreground mt-1">
+                <a
+                  href="https://github.com/kubestellar/console#quick-start"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-purple-400 hover:text-purple-300 underline underline-offset-2"
+                >
+                  {t('agent.selfHostToConnect')}
+                </a>
+              </p>
+            )}
             {!isDemoMode && isDegraded && lastDataError && (
               <p className="text-xs text-yellow-400 mt-1">
                 {t('agent.lastError', { error: lastDataError })}

--- a/web/src/locales/en/common.json
+++ b/web/src/locales/en/common.json
@@ -1549,6 +1549,8 @@
     "clusterMode": "Cluster Mode",
     "localAgentDisconnectedLabel": "Local Agent: Disconnected",
     "agentBypassedInDemo": "Agent connection bypassed in demo mode",
+    "hostedDemoBypassed": "Agent not available in the hosted demo — self-host the console to connect a local agent and view real cluster data",
+    "selfHostToConnect": "Self-host the console to connect a cluster →",
     "connectedButErrors": "Connected but experiencing data errors ({{count}} in last minute)",
     "connectedButErrors_one": "Connected but experiencing data errors ({{count}} in last minute)",
     "connectedButErrors_other": "Connected but experiencing data errors ({{count}} in last minute)",


### PR DESCRIPTION
Closes #6338
Closes #6339
Closes #6340
Closes #6341
Closes #6342

Batches the five UX/validation gaps filed by @rishi-jat this morning — they all touch the same "hosted demo / self-host onboarding" user journey, so one PR is cleaner than five.

## Summary

### #6338 — Demo mode exposes non-functional features
- `web/src/components/auth/Login.tsx`: auto-login now triggers on the hosted demo domain from `branding.hostedDomain` (was: only Netlify preview / `*.netlify.app` hostnames). Users visiting `console.kubestellar.io` directly will no longer see a dead-end "Continue with GitHub" button.
- Added a "Hosted demo" notice above the login button when on the hosted domain, and disabled the button with a tooltip in case auto-login hasn't fired yet.

### #6339 — "Agent Not Connected" message not context-aware
- `web/src/components/layout/navbar/AgentStatusIndicator.tsx`: when `isDemoModeForced` is true (hosted demo), the dropdown now shows "Agent not available in the hosted demo — self-host the console to connect…" with an inline self-host link, instead of the generic `agentBypassedInDemo` string. Local-no-agent and misconfigured cases continue to use the existing messages.
- New translation keys: `agent.hostedDemoBypassed`, `agent.selfHostToConnect` (en only — other locales fall back to the key, which is acceptable for new strings).

### #6342 — OAuth enabled without validating required secrets
- New file: `deploy/helm/kubestellar-console/templates/NOTES.txt`. Prints a post-install pre-flight checklist when any `*.existingSecret` is set, with the exact `kubectl get secret <name> -n <ns>` command to verify the referenced Secret exists, plus a troubleshoot hint for `CreateContainerConfigError`. Helm can't query the cluster at template time, so NOTES.txt is the right place for this guidance (no way to `fail` at template time when the Secret is missing).
- Verified with `helm lint` and `helm install --dry-run` both with and without `github.existingSecret`.

### #6340 — Issue submission fails without FEEDBACK_GITHUB_TOKEN — ALREADY HANDLED
- `FeatureRequestModal.tsx` already polls `/api/github/token/status` when the modal opens, sets `feedbackTokenMissing`, disables the Submit button (`disabled={isSubmitting || feedbackTokenMissing}`), and renders an inline yellow warning banner with a link to Console Settings and GitHub token creation. The backend `POST /feedback/requests` also returns a 503 early when the token is missing.
- No code changes — included in this PR to close the issue alongside the batch.

### #6341 — UI does not handle backend disconnection — ALREADY HANDLED
- `web/src/hooks/useBackendHealth.ts` polls `/health` every 15s with a 4-failure threshold (≈60s of silence before marking disconnected), and `Layout.tsx` mounts a sticky banner via `showBackendBanner` / `showOfflineBanner`. The existing implementation already covers the `kubectl port-forward` drops case from the issue.
- No code changes — included in this PR to close the issue alongside the batch.

## Test plan

- [x] `npm run build` (frontend)
- [x] `helm lint deploy/helm/kubestellar-console`
- [x] `helm install --dry-run` with and without `github.existingSecret` — NOTES.txt renders in both modes
- [x] ESLint on touched files (`Login.tsx`, `AgentStatusIndicator.tsx`) — no new errors
- [ ] Manual: load `console.kubestellar.io/login` after deploy-preview merges and verify auto-login fires and the notice is visible if auto-login hasn't completed
- [ ] Manual: open the agent status dropdown on the hosted demo and verify the new wording + self-host link