### PR TITLE
fix(helm): preserve JWT secret across upgrades + BYO-secret accuracy (#6343)

### DIFF
--- a/deploy/helm/kubestellar-console/README.md
+++ b/deploy/helm/kubestellar-console/README.md
@@ -20,12 +20,28 @@ Helm chart for deploying the KubeStellar Console to a Kubernetes cluster.
 The chart has two modes for supplying secret material:
 
 1. **Chart-managed (default, easiest)** — pass values via `--set` or a values
-   file; the chart renders a Kubernetes Secret named after the release
-   (`{release-name}-kubestellar-console`) containing whatever you supplied.
-   If `jwt.secret` is not set, the chart auto-generates a 64-character
-   random value on first install.
+   file; the chart renders a single Kubernetes Secret named after the release
+   (`{release-name}-kubestellar-console`) that holds the JWT secret plus any
+   of the other optional keys (`github-client-id`, `github-client-secret`,
+   `google-drive-api-key`, `claude-api-key`, `feedback-github-token`) you
+   supplied via values.
+   - If `jwt.secret` is not set, the chart auto-generates a 64-character
+     random value on first install and then **preserves it across `helm
+     upgrade`** by looking up the existing Secret ([#6343](https://github.com/kubestellar/console/issues/6343)).
+     This means JWT session cookies survive chart upgrades without forcing
+     all users to sign in again.
 2. **Bring-your-own** — create Secrets yourself before `helm install` and
    reference them via `*.existingSecret` values.
+   - **Important:** the chart renders its own Secret only when
+     `jwt.existingSecret` is empty. If you're going BYO, set
+     `jwt.existingSecret` AND put every other secret key (github, claude,
+     google-drive, feedback-github-token) in that same Secret — don't mix
+     inline `github.clientId` values with `jwt.existingSecret`, because no
+     chart-managed Secret is rendered in that path and the inline values
+     have nowhere to land.
+   - You can point each `*.existingSecret` at the same Secret; the
+     per-field `existingSecretKey` / `existingSecretKeys.*` values let you
+     override the key name so one Secret can hold all of them.
 
 ### Values that accept secret material
 

--- a/deploy/helm/kubestellar-console/templates/secret.yaml
+++ b/deploy/helm/kubestellar-console/templates/secret.yaml
@@ -1,4 +1,19 @@
 {{- if not .Values.jwt.existingSecret }}
+{{- /*
+  #6343: preserve the JWT secret across `helm upgrade`. Without the lookup
+  below, `randAlphaNum 64` re-rolls on every upgrade and invalidates every
+  existing session cookie, forcing all users to sign in again. Helm's
+  `lookup` is only valid against a live cluster (returns `nil` on dry-run
+  and first-install template), so the fallback chain is:
+    1. user-supplied jwt.secret (explicit, reproducible)
+    2. existing Secret's jwt-secret (upgrade path — keeps JWTs stable)
+    3. fresh randAlphaNum 64 (first install only)
+*/}}
+{{- $existing := lookup "v1" "Secret" .Release.Namespace (include "kubestellar-console.fullname" .) }}
+{{- $existingJwt := "" }}
+{{- if and $existing $existing.data }}
+{{-   $existingJwt = index $existing.data "jwt-secret" | default "" }}
+{{- end }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -7,7 +22,13 @@ metadata:
     {{- include "kubestellar-console.labels" . | nindent 4 }}
 type: Opaque
 data:
-  jwt-secret: {{ (.Values.jwt.secret | default (randAlphaNum 64)) | b64enc | quote }}
+  {{- if .Values.jwt.secret }}
+  jwt-secret: {{ .Values.jwt.secret | b64enc | quote }}
+  {{- else if $existingJwt }}
+  jwt-secret: {{ $existingJwt | quote }}
+  {{- else }}
+  jwt-secret: {{ randAlphaNum 64 | b64enc | quote }}
+  {{- end }}
   {{- if and .Values.github.clientId .Values.github.clientSecret }}
   github-client-id: {{ .Values.github.clientId | b64enc | quote }}
   github-client-secret: {{ .Values.github.clientSecret | b64enc | quote }}


### PR DESCRIPTION
Closes #6343

Addresses the 2 Copilot review comments filed on merged PR #6336.

## 1. Real bug: JWT secret re-rolls on every `helm upgrade`

Previously, `templates/secret.yaml` used:

```yaml
jwt-secret: {{ (.Values.jwt.secret | default (randAlphaNum 64)) | b64enc | quote }}
```

`randAlphaNum` renders a fresh value on every `helm upgrade`, which silently invalidates every existing session cookie and forces all users to sign in again. This had been a latent footgun since the chart was first written.

Fixed with Helm's `lookup`:

- If `.Values.jwt.secret` is set, use it.
- Otherwise look up the existing release-fullname Secret on the cluster and reuse its `jwt-secret` data key.
- If neither is available (first install / dry-run / `helm template`), fall back to `randAlphaNum 64`.

## 2. README accuracy: BYO-secret gate

The README glossed over the fact that the chart-managed Secret is gated *solely* on `jwt.existingSecret`. If a user sets `jwt.existingSecret` but leaves inline `github.clientId` / `github.clientSecret` values in place, those values silently go nowhere. Rewrote the BYO bullet to make this explicit.

## Test plan

- [x] `helm lint` passes
- [x] `helm template` renders a `randAlphaNum` JWT on dry-run (lookup returns nil)
- [ ] Verify on a live cluster that `helm upgrade` preserves the JWT (next deploy run on main will exercise this)