### PR TITLE
fix(ci): override runAsUser=null on OpenShift deploys so SCC can assign UID (#6344)

### DIFF
--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -255,6 +255,12 @@ jobs:
             helm rollback ${{ env.HELM_RELEASE_NAME }} -n kc --wait --timeout 2m || true
           fi
 
+      # #6344: OpenShift SCC allocates a namespace-specific UID range and
+      # rejects pods whose runAsUser falls outside that range. The chart
+      # default (1001) is correct for Kind/Minikube but breaks OpenShift
+      # with a silent "Replicas: 0/1" timeout. The --set overrides below
+      # unset runAsUser/runAsGroup/runAsNonRoot so the SCC admission
+      # controller can inject its own values.
       - name: Deploy with Helm
         run: |
           helm upgrade --install ${{ env.HELM_RELEASE_NAME }} ./deploy/helm/kubestellar-console \
@@ -272,6 +278,9 @@ jobs:
             --set-string enabledDashboards="dashboard\,clusters\,gpu-reservations\,llm-d-benchmarks\,ai-ml\,arcade" \
             --set persistence.storageClass=ocs-storagecluster-cephfs \
             --set rbac.namespaceCreationEnabled=true \
+            --set securityContext.runAsUser=null \
+            --set securityContext.runAsGroup=null \
+            --set securityContext.runAsNonRoot=null \
             --atomic \
             --wait \
             --timeout 5m
@@ -337,6 +346,10 @@ jobs:
             helm rollback ${{ env.HELM_RELEASE_NAME }} -n kubestellar-console --wait --timeout 2m || true
           fi
 
+      # #6344: OpenShift SCC — see comment on the vllm-d Deploy with Helm
+      # step above. Same fix: unset runAsUser/runAsGroup/runAsNonRoot so
+      # the SCC admission controller can assign a namespace-appropriate
+      # UID instead of the chart default 1001.
       - name: Deploy with Helm
         run: |
           helm upgrade --install ${{ env.HELM_RELEASE_NAME }} ./deploy/helm/kubestellar-console \
@@ -353,6 +366,9 @@ jobs:
             --set clusterName=pok-prod-001 \
             --set-string enabledDashboards="dashboard\,clusters\,gpu-reservations\,llm-d-benchmarks\,ai-ml\,arcade" \
             --set rbac.namespaceCreationEnabled=true \
+            --set securityContext.runAsUser=null \
+            --set securityContext.runAsGroup=null \
+            --set securityContext.runAsNonRoot=null \
             --atomic \
             --wait \
             --timeout 5m

--- a/deploy/helm/kubestellar-console/README.md
+++ b/deploy/helm/kubestellar-console/README.md
@@ -152,7 +152,7 @@ Common knobs:
 | `route.enabled` | `false` | OpenShift Route (alternative to Ingress). |
 | `persistence.enabled` | `true` | PVC for the SQLite database. |
 | `backup.enabled` | `true` | SQLite auto-backup CronJob + restore init container. |
-| `securityContext.runAsUser` | `1001` | Must be numeric — see [#6323](https://github.com/kubestellar/console/issues/6323). |
+| `securityContext.runAsUser` | `1001` | Must be numeric for Kind/Minikube — see [#6323](https://github.com/kubestellar/console/issues/6323). On OpenShift, set this (and `runAsGroup`, `runAsNonRoot`) to `null` to let SCC assign the UID — see [#6344](https://github.com/kubestellar/console/issues/6344). |
 
 ## Troubleshooting
 
@@ -170,6 +170,24 @@ so the deployment controller respawns it:
 
 ```bash
 kubectl -n kubestellar-console delete pod -l app.kubernetes.io/name=kubestellar-console
+```
+
+### OpenShift pod stuck `Replicas: 0/1` / `context deadline exceeded`
+
+OpenShift's `restricted` / `restricted-v2` SCC allocates a
+namespace-specific UID range and rejects pods whose `runAsUser` falls
+outside that range ([#6344](https://github.com/kubestellar/console/issues/6344)).
+The chart default (`runAsUser: 1001`) is correct for Kind/Minikube but
+breaks OpenShift silently — the helm upgrade rolls back with no
+container-level error message.
+
+Fix: override the chart defaults to let SCC inject its own values:
+
+```bash
+helm upgrade kc ./deploy/helm/kubestellar-console -n kubestellar-console \
+  --set securityContext.runAsUser=null \
+  --set securityContext.runAsGroup=null \
+  --set securityContext.runAsNonRoot=null
 ```
 
 ### `container has runAsNonRoot and image has non-numeric user (appuser)`


### PR DESCRIPTION
Closes #6344

## Root cause

The deploy streak that started at 2026-04-11 08:16 UTC and persisted across 4 subsequent commits (`e05e6fb7`, `2c654e42`, `c1a0b426`, `a6d4b111`) was caused by the chart default `securityContext.runAsUser: 1001` that #6329 added to fix Kind/Minikube.

On `pok-prod` and `vllm-d`, the target clusters are OpenShift. OpenShift's `restricted` / `restricted-v2` SCC allocates a **namespace-specific UID range** (e.g. `1000710000-1000719999`) and rejects pods whose explicit `runAsUser` falls outside that range — **silently**, with no container-level error message. The helm upgrade just spins for 5 minutes and rolls back with `Replicas: 0/1 / context deadline exceeded`.

Last known-good deploy was `a2967b09` at 08:00 UTC, right before #6329 landed. Every push-to-main deploy after that failed with the identical pattern.

## Fix

Override the chart defaults in the two OpenShift `Deploy with Helm` steps:

```yaml
--set securityContext.runAsUser=null \
--set securityContext.runAsGroup=null \
--set securityContext.runAsNonRoot=null \
```

This unsets the values so SCC's pod mutation webhook can inject its own namespace-appropriate UID/GID. Kind/Minikube and other non-SCC clusters still get the `runAsUser: 1001` chart default untouched — nothing changes for them.

Also added a matching troubleshooting section to the chart README so OpenShift operators outside the CI workflow (#6344 will hit everyone running this on OpenShift, not just pok-prod/vllm-d) find the workaround.

## Test plan

- [x] `helm lint` passes
- [x] `.github/workflows/build-deploy.yml` parses as valid YAML
- [ ] Post-merge deploy to vllm-d succeeds
- [ ] Post-merge deploy to pok-prod succeeds