### PR TITLE
fix(ci): keep runAsNonRoot=true on OpenShift overrides (#6353)

### DIFF
--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -255,12 +255,15 @@ jobs:
             helm rollback ${{ env.HELM_RELEASE_NAME }} -n kc --wait --timeout 2m || true
           fi
 
-      # #6344: OpenShift SCC allocates a namespace-specific UID range and
-      # rejects pods whose runAsUser falls outside that range. The chart
-      # default (1001) is correct for Kind/Minikube but breaks OpenShift
-      # with a silent "Replicas: 0/1" timeout. The --set overrides below
-      # unset runAsUser/runAsGroup/runAsNonRoot so the SCC admission
-      # controller can inject its own values.
+      # #6344 / #6353: OpenShift SCC allocates a namespace-specific UID
+      # range and rejects pods whose runAsUser falls outside that range.
+      # The chart default (runAsUser=1001) is correct for Kind/Minikube
+      # but breaks OpenShift with a silent "Replicas: 0/1" timeout. The
+      # --set overrides below unset runAsUser/runAsGroup so the SCC
+      # admission controller can inject its own values. IMPORTANT:
+      # runAsNonRoot stays `true` (chart default) so PodSecurity
+      # "restricted" still accepts the pod — only the UID/GID numbers
+      # need to be null.
       - name: Deploy with Helm
         run: |
           helm upgrade --install ${{ env.HELM_RELEASE_NAME }} ./deploy/helm/kubestellar-console \
@@ -280,7 +283,6 @@ jobs:
             --set rbac.namespaceCreationEnabled=true \
             --set securityContext.runAsUser=null \
             --set securityContext.runAsGroup=null \
-            --set securityContext.runAsNonRoot=null \
             --atomic \
             --wait \
             --timeout 5m
@@ -346,10 +348,11 @@ jobs:
             helm rollback ${{ env.HELM_RELEASE_NAME }} -n kubestellar-console --wait --timeout 2m || true
           fi
 
-      # #6344: OpenShift SCC — see comment on the vllm-d Deploy with Helm
-      # step above. Same fix: unset runAsUser/runAsGroup/runAsNonRoot so
-      # the SCC admission controller can assign a namespace-appropriate
-      # UID instead of the chart default 1001.
+      # #6344 / #6353: OpenShift SCC — see comment on the vllm-d Deploy
+      # with Helm step above. Same fix: unset runAsUser/runAsGroup so the
+      # SCC admission controller can assign a namespace-appropriate UID.
+      # runAsNonRoot stays true so PodSecurity "restricted" still accepts
+      # the pod.
       - name: Deploy with Helm
         run: |
           helm upgrade --install ${{ env.HELM_RELEASE_NAME }} ./deploy/helm/kubestellar-console \
@@ -368,7 +371,6 @@ jobs:
             --set rbac.namespaceCreationEnabled=true \
             --set securityContext.runAsUser=null \
             --set securityContext.runAsGroup=null \
-            --set securityContext.runAsNonRoot=null \
             --atomic \
             --wait \
             --timeout 5m

--- a/deploy/helm/kubestellar-console/README.md
+++ b/deploy/helm/kubestellar-console/README.md
@@ -160,7 +160,7 @@ Common knobs:
 | `route.enabled` | `false` | OpenShift Route (alternative to Ingress). |
 | `persistence.enabled` | `true` | PVC for the SQLite database. |
 | `backup.enabled` | `true` | SQLite auto-backup CronJob + restore init container. |
-| `securityContext.runAsUser` | `1001` | Must be numeric for Kind/Minikube — see [#6323](https://github.com/kubestellar/console/issues/6323). On OpenShift, set this (and `runAsGroup`, `runAsNonRoot`) to `null` to let SCC assign the UID — see [#6344](https://github.com/kubestellar/console/issues/6344). |
+| `securityContext.runAsUser` | `1001` | Must be numeric for Kind/Minikube — see [#6323](https://github.com/kubestellar/console/issues/6323). On OpenShift, set this **and** `runAsGroup` to `null` to let SCC assign the UID — see [#6344](https://github.com/kubestellar/console/issues/6344). Leave `runAsNonRoot: true` as-is; PodSecurity `restricted` still requires it ([#6353](https://github.com/kubestellar/console/issues/6353)). |
 
 ## Troubleshooting
 
@@ -189,13 +189,14 @@ The chart default (`runAsUser: 1001`) is correct for Kind/Minikube but
 breaks OpenShift silently — the helm upgrade rolls back with no
 container-level error message.
 
-Fix: override the chart defaults to let SCC inject its own values:
+Fix: null out just the UID/GID numbers so SCC can inject its own values
+while keeping `runAsNonRoot: true` intact (PodSecurity `restricted` still
+requires it — see [#6353](https://github.com/kubestellar/console/issues/6353)):
 
 ```bash
 helm upgrade kc ./deploy/helm/kubestellar-console -n kubestellar-console \
   --set securityContext.runAsUser=null \
-  --set securityContext.runAsGroup=null \
-  --set securityContext.runAsNonRoot=null
+  --set securityContext.runAsGroup=null
 ```
 
 ### `container has runAsNonRoot and image has non-numeric user (appuser)`


### PR DESCRIPTION
Closes #6353

Addresses the 3 Copilot comments on merged PR #6351. #6344's fix unset THREE keys in the OpenShift deploys:

```
--set securityContext.runAsUser=null
--set securityContext.runAsGroup=null
--set securityContext.runAsNonRoot=null
```

Only the first two were actually needed. `runAsUser/runAsGroup=null` let SCC assign a namespace-appropriate UID. `runAsNonRoot=true` is the chart default and PodSecurity `restricted` still requires it — SCC doesn't override it, it just picks a UID inside the restricted range.

The deploy on `5f35f191` happened to succeed because SCC's mutating webhook put `runAsNonRoot: true` back before PodSecurity evaluated, but Copilot is right the workflow shouldn't rely on that ordering.

Also updated README config table and OpenShift troubleshooting snippet to drop the `runAsNonRoot=null` recommendation.