### PR TITLE
docs(helm): replace fullname summary with source pointer (#6354)

### DIFF
--- a/deploy/helm/kubestellar-console/README.md
+++ b/deploy/helm/kubestellar-console/README.md
@@ -21,16 +21,13 @@ The chart has two modes for supplying secret material:
 
 1. **Chart-managed (default, easiest)** — pass values via `--set` or a values
    file; the chart renders a single Kubernetes Secret whose name is the
-   chart `fullname`. Following the standard Helm `fullname` template
-   convention, that resolves to:
-   - `fullnameOverride` if set, else
-   - `.Release.Name` if the release name already contains `kubestellar-console`
-     (e.g. `helm install kubestellar-console ./chart` → Secret name
-     `kubestellar-console`), else
-   - `{.Release.Name}-{nameOverride|kubestellar-console}` (e.g.
-     `helm install kc ./chart` → Secret name `kc-kubestellar-console`).
-   - In all three cases the final name is truncated at 63 characters for
-     DNS-label compliance.
+   chart `fullname`. The exact name depends on `fullnameOverride`,
+   `nameOverride`, and whether `.Release.Name` already contains the chart
+   name — the authoritative definition lives in
+   [`templates/_helpers.tpl`](./templates/_helpers.tpl) under
+   `"kubestellar-console.fullname"`. To see the exact name your values
+   produce, run `helm template . | head` and look for the `metadata.name`
+   of the rendered Secret.
 
    The Secret holds the JWT secret plus any of the other optional keys
    (`github-client-id`, `github-client-secret`, `google-drive-api-key`,


### PR DESCRIPTION
Closes #6354

Addresses the 2 Copilot comments on merged PR #6352 — and breaks the drift loop that has been running since PR #6332:

- #6332 → #6333: 7 Copilot comments on inline-summary inaccuracies
- #6336 → #6343: JWT regen bug + README inline-summary inaccuracies
- #6346 → #6348: lookup RBAC + 2 more inline-summary inaccuracies
- #6349 → #6350: one more inline-summary inaccuracy
- #6352 → #6354: 2 more inline-summary inaccuracies

Each round caught a different nuance of the `fullname` template I was trying to summarize (release-name-contains-chart-name, `nameOverride` interaction, `trunc 63 | trimSuffix "-"`, etc.). This is the exact pattern from `memory/feedback_no_summarized_semantics_in_comments.md`: don't summarize nontrivial cross-file logic, just point at the source.

Replaced the three-branch summary with:
- A pointer to `templates/_helpers.tpl`
- A `helm template . | head` incantation the reader can run to see the exact name their own values produce

The authoritative definition lives in one place and stays in sync automatically.