### PR TITLE
fix: Copilot follow-up from #6365 — e2e contracts, helm validation scope, workflow hygiene (#6366, #6367)

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -18,7 +18,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       # --- Node.js / Frontend ---
-      - name: Setup Node.js 20
+      - name: Setup Node.js 22
         uses: actions/setup-node@v4
         with:
           node-version: "22"
@@ -38,7 +38,7 @@ jobs:
         run: npx playwright install --with-deps chromium
 
       # --- Go / Backend ---
-      - name: Setup Go 1.23
+      - name: Setup Go 1.25
         uses: actions/setup-go@v5
         with:
           go-version: "1.25"

--- a/.github/workflows/fullstack-e2e.yml
+++ b/.github/workflows/fullstack-e2e.yml
@@ -67,8 +67,10 @@ jobs:
       - name: Start Go backend in background
         env:
           JWT_SECRET: ${{ env.DEV_JWT_SECRET }}
-          # Dev mode — do not require real OAuth creds
-          CONSOLE_ENV: 'development'
+          # Dev mode — do not require real OAuth creds. The Go backend reads
+          # DEV_MODE (see cmd/console/main.go and pkg/api/server.go); the
+          # previous CONSOLE_ENV value was ignored by the binary.
+          DEV_MODE: 'true'
           PORT: ${{ env.BACKEND_PORT }}
         run: |
           /tmp/console-binary > /tmp/console.log 2>&1 &

--- a/deploy/helm/kubestellar-console/templates/validation.yaml
+++ b/deploy/helm/kubestellar-console/templates/validation.yaml
@@ -18,15 +18,27 @@
   See: deploy/helm/kubestellar-console/README.md — "Secrets and configuration"
   (Bring-your-own caveat).
 
-  This template intentionally emits no Kubernetes resources: it only calls
-  `fail` on misconfiguration. A bare `{{- if false -}}{{- end -}}` pair
-  at the end keeps the file non-empty but produces zero YAML on success.
+  This template intentionally emits no Kubernetes resources: it only
+  calls `fail` on misconfiguration. On the happy path, every `if` block
+  below evaluates to false and the rendered output is empty, which is
+  what helm expects for a no-op template.
 */ -}}
 
 {{- if .Values.jwt.existingSecret -}}
 
-{{- /* GitHub OAuth inline values with no Secret to land in */ -}}
-{{- if and (or .Values.github.clientId .Values.github.clientSecret) (not .Values.github.existingSecret) -}}
+{{- /*
+  GitHub OAuth inline values with no Secret to land in.
+
+  The Deployment only references the chart-managed Secret's
+  `github-client-id` / `github-client-secret` keys when BOTH
+  `github.clientId` AND `github.clientSecret` are set AND
+  `github.existingSecret` is empty (see templates/deployment.yaml —
+  `else if and .Values.github.clientId .Values.github.clientSecret`).
+  That's the exact combination that breaks when `jwt.existingSecret`
+  suppresses the chart-managed Secret, so we validate the same
+  condition here.
+*/ -}}
+{{- if and (and .Values.github.clientId .Values.github.clientSecret) (not .Values.github.existingSecret) -}}
 {{- fail (printf "kubestellar-console: when jwt.existingSecret is set (%q), the chart does not render its own Secret. Inline github.clientId/github.clientSecret have nowhere to land. Set github.existingSecret to a pre-existing Secret containing the github-client-id and github-client-secret keys. See deploy/helm/kubestellar-console/README.md — 'Secrets and configuration' (Bring-your-own caveat)." .Values.jwt.existingSecret) -}}
 {{- end -}}
 

--- a/web/e2e/fullstack-smoke.spec.ts
+++ b/web/e2e/fullstack-smoke.spec.ts
@@ -36,10 +36,11 @@ test.describe('full-stack smoke (#6362)', () => {
     const res = await request.get(`${FULLSTACK_BASE}/healthz`)
     expect(res.status()).toBe(200)
     const body = await res.json()
-    // Contract: /healthz returns { status: "ok" | "starting" }; we only
-    // fail if it's missing or explicitly not-ok. "starting" is acceptable
-    // on a cold boot.
-    expect(['ok', 'starting']).toContain(body.status)
+    // Contract: pkg/api/server.go /healthz handler returns exactly
+    // { status: "ok" } during normal operation and { status: "shutting_down" }
+    // while draining. There is no "starting" state — the handler is
+    // registered synchronously before the listener comes up.
+    expect(['ok', 'shutting_down']).toContain(body.status)
   })
 
   test('root path serves the built frontend shell', async ({ page }) => {
@@ -55,8 +56,10 @@ test.describe('full-stack smoke (#6362)', () => {
     // the smallest round-trip that proves Go routing + handler wiring
     // without needing a live cluster or OAuth.
     const res = await request.get(`${FULLSTACK_BASE}/api/version`)
-    // 200 (public) or 401 (auth-required) both prove the handler exists;
-    // 404 would mean the route was dropped from Go routing.
-    expect([200, 401]).toContain(res.status())
+    // /api/version is registered before the auth middleware in
+    // pkg/api/server.go, so it is unconditionally public. A 401 here
+    // would mean the route order regressed; a 404 would mean the route
+    // was dropped from Go routing. Only 200 is acceptable.
+    expect(res.status()).toBe(200)
   })
 })

--- a/web/src/test/ui-ux-standards.test.ts
+++ b/web/src/test/ui-ux-standards.test.ts
@@ -66,11 +66,14 @@ const COMPONENTS_DIR = path.resolve(
 //   300 → 301: #6289 gauge readiness color inversion issue ref
 //   301 → 302: #6308 MissionBrowser close button on right issue ref
 //   302 → 303: #6309 upgrade confirm dialog issue ref
+//   303 → 304: #6366 ratchet drift — one unaccounted-for raw hex existed
+//               at the time of the 303 bump (pre-existing, not introduced
+//               by #6365), so the ratchet tripped on next CI run. Corrected.
 //
 // When you bump this number, append a one-line entry above so future
 // bumps stay grep-able and reviewers can tell at a glance whether a
 // change is a real new violation or just a comment-level reference.
-const EXPECTED_RAW_HEX_COUNT = 303
+const EXPECTED_RAW_HEX_COUNT = 304
 const EXPECTED_RAW_RGBA_COUNT = 104
 const EXPECTED_ARBITRARY_TW_COLOR_COUNT = 22
 const EXPECTED_INLINE_STYLE_COLOR_COUNT = 213


### PR DESCRIPTION
Closes #6366
Closes #6367

## Summary

Follow-up PR addressing the Coverage Suite ratchet failure and six Copilot review comments on #6365.

### 1. #6366 — UI/UX ratchet drift
`EXPECTED_RAW_HEX_COUNT` was 303 but the scanned count was 304 on current main. Diffing violation lists before and after #6365 shows zero new entries — the extra hex was pre-existing and the previous bump was off by one. Bumped to 304 with a bump-history entry.

### 2. /healthz contract check
pkg/api/server.go defines /healthz as `{status: "ok"}` or `{status: "shutting_down"}` — no "starting" state. Updated.

### 3. /api/version 401 acceptance
/api/version is registered before the JWT middleware and is unconditionally public. Removed 401 from the acceptable-status list — only 200 is valid.

### 4. GitHub validation condition too broad
The deployment template only references the chart-managed Secret's github-client-id/github-client-secret keys when BOTH github.clientId AND github.clientSecret are set AND github.existingSecret is empty. Tightened the `or` guard to `and`.

### 5. Header comment mismatch
Dropped the outdated claim about a `{{- if false -}}{{- end -}}` no-op block that never existed. helm lint is happy without it.

### 6. Bogus env var in fullstack-e2e.yml
CONSOLE_ENV=development is not read by the Go backend. Replaced with DEV_MODE=true.

### 7. Stale step names in copilot-setup-steps.yml
"Setup Go 1.23" → "Setup Go 1.25", "Setup Node.js 20" → "Setup Node.js 22".

## Local verification

- helm lint deploy/helm/kubestellar-console — pass
- helm template ... jwt.existingSecret=foo github.clientId=x github.clientSecret=y — FAIL as expected
- helm template ... jwt.existingSecret=foo github.existingSecret=bar — pass
- helm template ... jwt.existingSecret=foo github.clientId=x — pass (newly allowed)
- npx vitest run src/test/ui-ux-standards.test.ts — 7/7 pass
- npm run build — pass

## Test plan

- [ ] Coverage Suite ratchet test passes
- [ ] Full-Stack E2E Smoke workflow passes
- [ ] helm lint passes in CI