### PR TITLE
fix: Copilot follow-up from #6368 — condense bump history + generalize validation keys (#6369)

### DIFF
--- a/deploy/helm/kubestellar-console/templates/validation.yaml
+++ b/deploy/helm/kubestellar-console/templates/validation.yaml
@@ -39,22 +39,22 @@
   condition here.
 */ -}}
 {{- if and (and .Values.github.clientId .Values.github.clientSecret) (not .Values.github.existingSecret) -}}
-{{- fail (printf "kubestellar-console: when jwt.existingSecret is set (%q), the chart does not render its own Secret. Inline github.clientId/github.clientSecret have nowhere to land. Set github.existingSecret to a pre-existing Secret containing the github-client-id and github-client-secret keys. See deploy/helm/kubestellar-console/README.md — 'Secrets and configuration' (Bring-your-own caveat)." .Values.jwt.existingSecret) -}}
+{{- fail (printf "kubestellar-console: when jwt.existingSecret is set (%q), the chart does not render its own Secret. Inline github.clientId/github.clientSecret have nowhere to land. Set github.existingSecret to a pre-existing Secret, and either populate keys `%s` and `%s` or override them via github.existingSecretKeys.clientId / .clientSecret in values.yaml. See deploy/helm/kubestellar-console/README.md — 'Secrets and configuration' (Bring-your-own caveat)." .Values.jwt.existingSecret .Values.github.existingSecretKeys.clientId .Values.github.existingSecretKeys.clientSecret) -}}
 {{- end -}}
 
 {{- /* Claude API key inline with no Secret to land in */ -}}
 {{- if and .Values.claude.apiKey (not .Values.claude.existingSecret) -}}
-{{- fail (printf "kubestellar-console: when jwt.existingSecret is set (%q), claude.apiKey has no Secret to land in. Set claude.existingSecret to a pre-existing Secret containing the claude-api-key key. See deploy/helm/kubestellar-console/README.md — 'Secrets and configuration' (Bring-your-own caveat)." .Values.jwt.existingSecret) -}}
+{{- fail (printf "kubestellar-console: when jwt.existingSecret is set (%q), claude.apiKey has no Secret to land in. Set claude.existingSecret to a pre-existing Secret, and either populate key `%s` or override it via claude.existingSecretKey in values.yaml. See deploy/helm/kubestellar-console/README.md — 'Secrets and configuration' (Bring-your-own caveat)." .Values.jwt.existingSecret .Values.claude.existingSecretKey) -}}
 {{- end -}}
 
 {{- /* Google Drive API key inline with no Secret to land in */ -}}
 {{- if and .Values.googleDrive.apiKey (not .Values.googleDrive.existingSecret) -}}
-{{- fail (printf "kubestellar-console: when jwt.existingSecret is set (%q), googleDrive.apiKey has no Secret to land in. Set googleDrive.existingSecret to a pre-existing Secret containing the google-drive-api-key key. See deploy/helm/kubestellar-console/README.md — 'Secrets and configuration' (Bring-your-own caveat)." .Values.jwt.existingSecret) -}}
+{{- fail (printf "kubestellar-console: when jwt.existingSecret is set (%q), googleDrive.apiKey has no Secret to land in. Set googleDrive.existingSecret to a pre-existing Secret, and either populate key `%s` or override it via googleDrive.existingSecretKey in values.yaml. See deploy/helm/kubestellar-console/README.md — 'Secrets and configuration' (Bring-your-own caveat)." .Values.jwt.existingSecret .Values.googleDrive.existingSecretKey) -}}
 {{- end -}}
 
 {{- /* Feedback GitHub token inline with no Secret to land in */ -}}
 {{- if and .Values.feedbackGithubToken.token (not .Values.feedbackGithubToken.existingSecret) -}}
-{{- fail (printf "kubestellar-console: when jwt.existingSecret is set (%q), feedbackGithubToken.token has no Secret to land in. Set feedbackGithubToken.existingSecret to a pre-existing Secret containing the feedback-github-token key. See deploy/helm/kubestellar-console/README.md — 'Secrets and configuration' (Bring-your-own caveat)." .Values.jwt.existingSecret) -}}
+{{- fail (printf "kubestellar-console: when jwt.existingSecret is set (%q), feedbackGithubToken.token has no Secret to land in. Set feedbackGithubToken.existingSecret to a pre-existing Secret, and either populate key `%s` or override it via feedbackGithubToken.existingSecretKey in values.yaml. See deploy/helm/kubestellar-console/README.md — 'Secrets and configuration' (Bring-your-own caveat)." .Values.jwt.existingSecret .Values.feedbackGithubToken.existingSecretKey) -}}
 {{- end -}}
 
 {{- end -}}

--- a/web/src/test/ui-ux-standards.test.ts
+++ b/web/src/test/ui-ux-standards.test.ts
@@ -66,9 +66,7 @@ const COMPONENTS_DIR = path.resolve(
 //   300 → 301: #6289 gauge readiness color inversion issue ref
 //   301 → 302: #6308 MissionBrowser close button on right issue ref
 //   302 → 303: #6309 upgrade confirm dialog issue ref
-//   303 → 304: #6366 ratchet drift — one unaccounted-for raw hex existed
-//               at the time of the 303 bump (pre-existing, not introduced
-//               by #6365), so the ratchet tripped on next CI run. Corrected.
+//   303 → 304: #6366 ratchet drift — pre-existing unaccounted-for raw hex from before 303 bump, not introduced by #6365
 //
 // When you bump this number, append a one-line entry above so future
 // bumps stay grep-able and reviewers can tell at a glance whether a


### PR DESCRIPTION
Closes #6369

Two Copilot nits on merged PR #6368:

1. `ui-ux-standards.test.ts` bump-history entry 303 → 304 spanned 3 lines, breaking the grep-able one-line format. Condensed.
2. `validation.yaml` fail messages hard-coded Secret key names; generalized to show both the current default key name and the `*.existingSecretKey[s]` override path.

Verified `helm lint` + bad-combo fail message now includes both the actual key names and the override path.