### PR TITLE
fix(ux): responsive overflow, empty-state consistency, tablet mission sidebar (6385-6394)

### DIFF
--- a/web/src/components/layout/Layout.tsx
+++ b/web/src/components/layout/Layout.tsx
@@ -497,7 +497,11 @@ export function Layout({ children: _children }: LayoutProps) {
           style={{
             marginLeft: isMobile ? 0 : sidebarWidthPx + SIDEBAR_CONTROLS_OFFSET_PX,
             marginRight: 'var(--mission-sidebar-width, 0px)' }}
-          className="relative flex-1 p-4 pb-24 md:p-6 md:pb-28 transition-[margin] duration-300 overflow-y-auto scroll-enhanced min-w-0"
+          // overflow-x-hidden prevents stray wide children from pushing the
+          // entire main column past the viewport at narrow breakpoints
+          // (issues 6385, 6387, 6394). Individual scrollable children
+          // (tables, code blocks) still scroll horizontally inside wrappers.
+          className="relative flex-1 p-4 pb-24 md:p-6 md:pb-28 transition-[margin] duration-300 overflow-y-auto overflow-x-hidden scroll-enhanced min-w-0"
         >
           <NavigationProgress />
           <Suspense fallback={<ContentLoadingSkeleton />}>

--- a/web/src/components/layout/mission-sidebar/MissionSidebar.tsx
+++ b/web/src/components/layout/mission-sidebar/MissionSidebar.tsx
@@ -59,6 +59,12 @@ const SIDEBAR_MAX_WIDTH = 800
 const SIDEBAR_DEFAULT_WIDTH = 480
 const SIDEBAR_WIDTH_KEY = 'ksc-mission-sidebar-width'
 
+// Tablet breakpoint matches Tailwind's `lg` (1024px). Below this width the
+// mission sidebar is rendered as an overlay (position: fixed without pushing
+// main content) so tablet layouts don't get squeezed below the min sidebar
+// width. See issues 6388 / 6394.
+const TABLET_BREAKPOINT_PX = 1024
+
 function loadSavedWidth(): number {
   const maxW = typeof window !== 'undefined'
     ? Math.min(SIDEBAR_MAX_WIDTH, window.innerWidth * 0.6)
@@ -89,19 +95,37 @@ export function MissionSidebar() {
   const [isResizing, setIsResizing] = useState(false)
   const latestWidthRef = useRef(sidebarWidth)
 
+  // Track tablet range (>= mobile but < lg). In this range the sidebar is
+  // rendered as an overlay that does NOT push main content — pushing at
+  // tablet widths squeezes main below the sidebar min width and can cause
+  // ~10px content overlap (issue 6388).
+  const [isTablet, setIsTablet] = useState(() => {
+    if (typeof window === 'undefined') return false
+    return window.innerWidth < TABLET_BREAKPOINT_PX
+  })
+  useEffect(() => {
+    const mq = window.matchMedia(`(max-width: ${TABLET_BREAKPOINT_PX - 1}px)`)
+    const onChange = (e: MediaQueryListEvent) => setIsTablet(e.matches)
+    setIsTablet(mq.matches)
+    mq.addEventListener('change', onChange)
+    return () => mq.removeEventListener('change', onChange)
+  }, [])
+
   // Publish sidebar width as a CSS custom property so Layout.tsx can
   // adjust main-content margins without needing context plumbing.
+  // On tablet (< 1024px) we publish 0 so the sidebar floats as an overlay.
   useEffect(() => {
     const root = document.documentElement
-    if (!isMobile && isSidebarOpen && !isSidebarMinimized && !isFullScreen) {
+    const isOverlayMode = isMobile || isTablet
+    if (!isOverlayMode && isSidebarOpen && !isSidebarMinimized && !isFullScreen) {
       root.style.setProperty('--mission-sidebar-width', `${sidebarWidth}px`)
-    } else if (!isMobile && isSidebarOpen && isSidebarMinimized && !isFullScreen) {
+    } else if (!isOverlayMode && isSidebarOpen && isSidebarMinimized && !isFullScreen) {
       root.style.setProperty('--mission-sidebar-width', '48px')
     } else {
       root.style.setProperty('--mission-sidebar-width', '0px')
     }
     return () => { root.style.removeProperty('--mission-sidebar-width') }
-  }, [isMobile, isSidebarOpen, isSidebarMinimized, isFullScreen, sidebarWidth])
+  }, [isMobile, isTablet, isSidebarOpen, isSidebarMinimized, isFullScreen, sidebarWidth])
 
   // Re-clamp sidebar width when viewport is resized
   useEffect(() => {
@@ -530,6 +554,14 @@ export function MissionSidebar() {
       {isMobile && isSidebarOpen && (
         <div
           className="fixed inset-0 bg-black/60 backdrop-blur-sm z-overlay md:hidden"
+          onClick={closeSidebar}
+        />
+      )}
+      {/* Tablet backdrop — the sidebar renders as an overlay at < lg so main
+          content isn't squeezed. A tap-out backdrop mirrors mobile UX (issue 6388). */}
+      {!isMobile && isTablet && isSidebarOpen && !isFullScreen && (
+        <div
+          className="fixed inset-0 bg-black/40 backdrop-blur-sm z-overlay lg:hidden"
           onClick={closeSidebar}
         />
       )}

--- a/web/src/components/services/Services.tsx
+++ b/web/src/components/services/Services.tsx
@@ -1,5 +1,7 @@
-import { AlertCircle } from 'lucide-react'
+import { AlertCircle, Server } from 'lucide-react'
+import { useNavigate } from 'react-router-dom'
 import { useClusters, useServices } from '../../hooks/useMCP'
+import { ROUTES } from '../../config/routes'
 import { useGlobalFilters } from '../../hooks/useGlobalFilters'
 import { useDrillDownActions } from '../../hooks/useDrillDown'
 import { useUniversalStats, createMergedStatValueGetter } from '../../hooks/useUniversalStats'
@@ -14,6 +16,7 @@ const SERVICES_CARDS_KEY = 'kubestellar-services-cards'
 const DEFAULT_SERVICES_CARDS = getDefaultCards('services')
 
 export function Services() {
+  const navigate = useNavigate()
   const { clusters, isLoading, isRefreshing: dataRefreshing, lastUpdated, refetch, error: clustersError } = useClusters()
   const { services, error: servicesError } = useServices()
   const error = clustersError || servicesError
@@ -90,8 +93,22 @@ export function Services() {
       lastUpdated={lastUpdated}
       hasData={reachableClusters.length > 0}
       emptyState={{
-        title: 'Services Dashboard',
-        description: 'Add cards to monitor Kubernetes services, endpoints, and network connectivity across your clusters.' }}
+        // Issues 6391/6392/6393: give the Services empty state actionable guidance.
+        // The primary CTA (add cards) is provided automatically by DashboardPage;
+        // we surface a secondary "Connect a cluster" action when there are no
+        // reachable clusters so the user knows what to do next.
+        title: reachableClusters.length === 0 ? 'No services yet' : 'Services Dashboard',
+        description: reachableClusters.length === 0
+          ? 'Connect a Kubernetes cluster to start monitoring services, endpoints, and network connectivity.'
+          : 'Add cards to monitor Kubernetes services, endpoints, and network connectivity across your clusters.',
+        secondaryAction: reachableClusters.length === 0
+          ? {
+              label: 'Connect a cluster',
+              icon: Server,
+              onClick: () => navigate(ROUTES.CLUSTERS),
+            }
+          : undefined,
+      }}
     >
       {/* Error Display */}
       {error && (

--- a/web/src/components/ui/EmptyState.tsx
+++ b/web/src/components/ui/EmptyState.tsx
@@ -1,0 +1,103 @@
+import { ReactNode } from 'react'
+import { Plus, LucideIcon } from 'lucide-react'
+
+/**
+ * Shared EmptyState component used across dashboard pages and lists.
+ *
+ * Standardizes:
+ *  - Visual style (dashed border, centered icon, title + description)
+ *  - Optional action button (CTA)
+ *  - Message conventions (title uses "No X yet" or "<Page> Dashboard" for
+ *    dashboard-card empty states; description offers a next step)
+ *
+ * Addresses issues 6391 (inconsistent messages), 6392 (Services empty
+ * state lacks CTA), and 6393 (mixed empty-state patterns).
+ */
+
+export interface EmptyStateAction {
+  /** Label rendered inside the button */
+  label: string
+  /** Click handler (mutually exclusive with href) */
+  onClick?: () => void
+  /** If provided, renders an anchor instead of a button */
+  href?: string
+  /** Optional icon rendered before the label (defaults to Plus) */
+  icon?: LucideIcon
+}
+
+export interface EmptyStateProps {
+  /** Icon rendered at top of the empty state */
+  icon?: ReactNode
+  /** Primary title (use a short, consistent phrase) */
+  title: string
+  /** Supporting description — explain what to do next */
+  description?: string
+  /** Optional call-to-action button */
+  action?: EmptyStateAction
+  /** Optional secondary action */
+  secondaryAction?: EmptyStateAction
+  /** Additional class names for the root container */
+  className?: string
+  /** Optional test id */
+  'data-testid'?: string
+}
+
+function ActionButton({ action, variant }: { action: EmptyStateAction, variant: 'primary' | 'secondary' }) {
+  const Icon = action.icon ?? Plus
+  const classes = variant === 'primary'
+    ? 'inline-flex items-center gap-2 px-4 py-2 text-sm font-medium bg-purple-500/20 text-purple-400 hover:bg-purple-500/30 rounded-lg transition-colors'
+    : 'inline-flex items-center gap-2 px-4 py-2 text-sm font-medium text-muted-foreground hover:text-foreground rounded-lg transition-colors'
+
+  if (action.href) {
+    return (
+      <a href={action.href} className={classes}>
+        <Icon className="w-4 h-4" aria-hidden="true" />
+        {action.label}
+      </a>
+    )
+  }
+  return (
+    <button type="button" onClick={action.onClick} className={classes}>
+      <Icon className="w-4 h-4" aria-hidden="true" />
+      {action.label}
+    </button>
+  )
+}
+
+export function EmptyState({
+  icon,
+  title,
+  description,
+  action,
+  secondaryAction,
+  className,
+  'data-testid': testId,
+}: EmptyStateProps) {
+  return (
+    <div
+      data-testid={testId ?? 'empty-state'}
+      className={
+        'glass p-8 rounded-lg border-2 border-dashed border-border/50 text-center ' +
+        (className ?? '')
+      }
+    >
+      {icon && (
+        <div className="flex justify-center mb-4" aria-hidden="true">
+          {icon}
+        </div>
+      )}
+      <h3 className="text-lg font-medium text-foreground mb-2">{title}</h3>
+      {description && (
+        <p className="text-muted-foreground text-sm max-w-md mx-auto mb-4">
+          {description}
+        </p>
+      )}
+      {(action || secondaryAction) && (
+        <div className="flex items-center justify-center gap-2 flex-wrap">
+          {action && <ActionButton action={action} variant="primary" />}
+          {secondaryAction && <ActionButton action={secondaryAction} variant="secondary" />}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/web/src/lib/dashboards/DashboardPage.tsx
+++ b/web/src/lib/dashboards/DashboardPage.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useRef, ReactNode } from 'react'
 import { useSearchParams, useLocation } from 'react-router-dom'
-import { Plus, LayoutGrid, ChevronDown, ChevronRight } from 'lucide-react'
+import { LayoutGrid, ChevronDown, ChevronRight } from 'lucide-react'
+import { EmptyState, EmptyStateAction } from '../../components/ui/EmptyState'
 import { getIcon } from '../icons'
 import {
   DndContext,
@@ -67,10 +68,13 @@ export interface DashboardPageProps {
   headerExtra?: ReactNode
   /** Extra content rendered on the right side of the header (e.g., action buttons) */
   rightExtra?: ReactNode
-  /** Empty state configuration for no cards */
+  /** Empty state configuration for no cards. An optional `action` (primary CTA)
+   *  and `secondaryAction` surface next-step guidance — see issue 6392. */
   emptyState?: {
     title: string
     description: string
+    action?: EmptyStateAction
+    secondaryAction?: EmptyStateAction
   }
   /** Whether this dashboard shows demo/mock data */
   isDemoData?: boolean
@@ -285,7 +289,12 @@ export function DashboardPage({
   const emptyDescription = emptyState?.description || `Add cards to monitor your ${title.toLowerCase()} across clusters.`
 
   return (
-    <div className="pt-16">
+    // `min-w-0 max-w-full` + overflow-x-hidden on the outer wrapper prevents
+    // wide inline content (tables, pre blocks, long URLs) from pushing the
+    // whole page past the viewport width at narrow breakpoints (issues 6385,
+    // 6387, 6394). Individual scrollable children (tables) still get their
+    // own horizontal scroll inside this clipped box.
+    <div className="pt-16 min-w-0 max-w-full overflow-x-hidden">
       {/* Header */}
       <DashboardHeader
         title={title}
@@ -341,22 +350,17 @@ export function DashboardPage({
         {showCards && (
           <>
             {cards.length === 0 ? (
-              <div className="glass p-8 rounded-lg border-2 border-dashed border-border/50 text-center">
-                <div className="flex justify-center mb-4">
-                  <Icon className="w-12 h-12 text-muted-foreground" />
-                </div>
-                <h3 className="text-lg font-medium text-foreground mb-2">{emptyTitle}</h3>
-                <p className="text-muted-foreground text-sm max-w-md mx-auto mb-4">
-                  {emptyDescription}
-                </p>
-                <button
-                  onClick={() => setShowAddCard(true)}
-                  className="inline-flex items-center gap-2 px-4 py-2 text-sm font-medium bg-purple-500/20 text-purple-400 hover:bg-purple-500/30 rounded-lg transition-colors"
-                >
-                  <Plus className="w-4 h-4" />
-                  Add Cards
-                </button>
-              </div>
+              <EmptyState
+                icon={<Icon className="w-12 h-12 text-muted-foreground" />}
+                title={emptyTitle}
+                description={emptyDescription}
+                action={emptyState?.action ?? {
+                  label: 'Add Cards',
+                  onClick: () => setShowAddCard(true),
+                }}
+                secondaryAction={emptyState?.secondaryAction}
+                data-testid="dashboard-empty-state"
+              />
             ) : (
               <DndContext
                 sensors={sensors}


### PR DESCRIPTION
Closes #6388
Closes #6391
Closes #6392
Closes #6393

## Summary

Batch response to the automated UX reports in 6385-6394. Several of the reported issues did not reproduce against the current codebase (the Navbar already has a full md/lg responsive ladder with an overflow sheet, DashboardPage already renders a single h1 via DashboardHeader, and DrillDownModal already renders breadcrumbs for nested views). Those are called out below.

## What changed

**Responsive overflow guard (defensive fix for 6385 / 6387 / 6394)**
- Layout.tsx: add overflow-x-hidden to the main content column alongside the existing overflow-y-auto + min-w-0. Stray wide children can no longer push the whole page past the viewport at narrow breakpoints; individual scrollable children (tables, code blocks) still scroll horizontally inside their own wrappers.
- DashboardPage.tsx: same min-w-0 max-w-full overflow-x-hidden treatment on the outer dashboard wrapper.

**Tablet mission sidebar overlay (closes 6388)**
- Below the Tailwind lg breakpoint (1024px), MissionSidebar now publishes --mission-sidebar-width: 0 so main content is not pushed. The sidebar renders as a fixed overlay like it already does on mobile, with a tap-out backdrop. Resolves the ~10px content overlap at 768px where main width would be clamped to 60% of viewport (below the 380px min sidebar width).

**Shared EmptyState component (closes 6391 / 6393)**
- New components/ui/EmptyState.tsx with icon / title / description / action / secondaryAction props.
- DashboardPage now renders its no-cards state via EmptyState and exposes action + secondaryAction through its emptyState prop so page components can attach next-step CTAs without duplicating the visual.

**Services empty-state CTA (closes 6392)**
- When there are no reachable clusters, Services page shows "No services yet - Connect a Kubernetes cluster..." with a "Connect a cluster" secondary action that navigates to /clusters. Primary "Add cards" action unchanged.

## Issues not addressed in this PR

- **6385 / 6386 / 6387 / 6394 (navbar / dashboard overflow)** - partially addressed. The Navbar already has hidden md:flex / hidden lg:flex plus a MoreVertical overflow sheet that kicks in below lg (see web/src/components/layout/navbar/Navbar.tsx), and the dashboard grid uses grid-cols-1 md:grid-cols-12. I could not reproduce the reported overflow against current code. The overflow-x-hidden guard in this PR is defensive; if the report is genuine, the real fix likely lives inside a specific dashboard card. Recommend tagging the reporter for a screenshot.
- **6389 (missing breadcrumb on deep pages)** - not a bug in current code. DrillDownModal already renders a full clickable breadcrumb stack for nested drill-downs, and /pods, /deployments, /services are themselves top-level routes where a single-item breadcrumb is meaningless. Recommend closing.
- **6390 (inconsistent heading hierarchy)** - not a bug. Every dashboard page uses DashboardPage -> DashboardHeader which renders exactly one h1 (data-testid dashboard-title). Settings.tsx has two h1s but they are mutually exclusive (hidden lg:block vs lg:hidden). Recommend closing.

## Verification

- npm run build - passes
- npm run lint - no new errors (baseline ~330 pre-existing)
- vitest src/test/ui-ux-standards.test.ts - 7/7 pass (ratchet unchanged)
- vitest src/lib/dashboards src/components/services src/components/layout - all pass (149 tests)

## Test plan

- [ ] Load /services in demo mode with no clusters and verify the "Connect a cluster" CTA renders
- [ ] Open the AI mission sidebar at 900px viewport and verify main content is not pushed or clipped
- [ ] Open the AI mission sidebar at 1200px and verify the existing push-content behavior still works
- [ ] Visit /dashboard, /clusters, /deploy, /settings at 375 / 768 / 1024 / 1440px and verify no horizontal page scroll