### PR TITLE
fix(missions): PR #6395 follow-ups — tool lifecycle types, cleanup, handler nullification, trim-before-validate (#6407, #6410)

### DIFF
--- a/web/src/components/mission-control/LaunchSequence.tsx
+++ b/web/src/components/mission-control/LaunchSequence.tsx
@@ -148,9 +148,16 @@ export function LaunchSequence({
 
         // Derive a safe display name for UI strings too — the title is
         // user-visible and we don't want a prompt-injection payload rendering
-        // in our own sidebar either.
-        const uiSafeDisplayName = isSafeProjectName(project.displayName)
-          ? project.displayName
+        // in our own sidebar either. #6410 — `isSafeProjectName` validates
+        // the TRIMMED value (see its impl), so we must trim first and use
+        // the trimmed value for BOTH validation and the rendered label.
+        // Otherwise `'  foo  '` would validate as the trimmed form but then
+        // render with the original leading/trailing whitespace.
+        const displayNameRaw = typeof project.displayName === 'string'
+          ? project.displayName.trim()
+          : ''
+        const uiSafeDisplayName = isSafeProjectName(displayNameRaw)
+          ? displayNameRaw
           : project.name
         const dryRunPrefix = state.isDryRun ? '[DRY RUN] ' : ''
         const clusterContext = `\n\n**Target cluster:** ${clusterName}`

--- a/web/src/components/mission-control/__tests__/useMissionControl.test.tsx
+++ b/web/src/components/mission-control/__tests__/useMissionControl.test.tsx
@@ -44,6 +44,18 @@ describe('isSafeProjectName (#6379)', () => {
     expect(isSafeProjectName('a'.repeat(PROJECT_NAME_MAX_LENGTH))).toBe(true)
     expect(isSafeProjectName('a'.repeat(PROJECT_NAME_MAX_LENGTH + 1))).toBe(false)
   })
+
+  it('accepts names that become valid after trimming (#6410)', () => {
+    // The implementation validates the trimmed form, so leading/trailing
+    // whitespace should not cause false rejections. Callers that render
+    // the name in the UI must also trim BEFORE passing it in (see the
+    // LaunchSequence `uiSafeDisplayName` wiring) so validation and display
+    // agree on which string they're talking about.
+    expect(isSafeProjectName('  foo  ')).toBe(true)
+    expect(isSafeProjectName('\tfalco\n')).toBe(true)
+    // Whitespace-only still fails (trimmed length is 0).
+    expect(isSafeProjectName('   ')).toBe(false)
+  })
 })
 
 describe('buildInstallPromptForProject (#6379)', () => {

--- a/web/src/components/mission-control/useMissionControl.ts
+++ b/web/src/components/mission-control/useMissionControl.ts
@@ -64,9 +64,12 @@ export function isSafeProjectName(name: unknown): name is string {
  * caller-supplied name in a triple-quoted "opaque literal" fence so the
  * agent treats it as a string value rather than as instructions (#6379).
  *
- * If the supplied name fails the allow-list check, falls back to a short
- * literal placeholder and records the raw value separately so it cannot
- * steer the agent.
+ * If the supplied name fails the allow-list check, substitutes the
+ * literal placeholder `[invalid-name]` for BOTH the name and displayName
+ * slots so the raw value is dropped entirely — it never appears in the
+ * generated prompt, so it cannot steer the agent. The displayName has its
+ * own independent check: if it's unsafe but the name is safe, the safe
+ * name is reused in the display slot.
  */
 export function buildInstallPromptForProject(
   name: string,

--- a/web/src/hooks/useMissions.test.tsx
+++ b/web/src/hooks/useMissions.test.tsx
@@ -3657,6 +3657,12 @@ describe('WebSocket auto-reconnect backoff arithmetic', () => {
   })
 
   it('resets backoff attempts on successful connection', async () => {
+    // #6375 / #6407 — The backoff counter is no longer reset on transport
+    // `onopen`. It's only reset once the first real application-layer frame
+    // arrives (see `connectionEstablished` ref + reset in
+    // `handleAgentMessage`). This test proves the connection works by
+    // delivering an `agents_list` frame before the second close, which is
+    // the cheapest app-level message to simulate.
     vi.useFakeTimers()
     try {
       const { result } = renderHook(() => useMissions(), { wrapper })
@@ -3667,9 +3673,19 @@ describe('WebSocket auto-reconnect backoff arithmetic', () => {
       act(() => { MockWebSocket.lastInstance?.simulateClose() })
       act(() => { vi.advanceTimersByTime(1_100) })
 
-      // Second connect succeeds -> should reset counter
+      // Second connect succeeds -> should reset counter, but ONLY after an
+      // application-layer frame arrives (not merely on `onopen`).
       const ws2 = MockWebSocket.lastInstance
       await act(async () => { ws2?.simulateOpen() })
+      // Deliver a real app-level frame — this is what now triggers the
+      // backoff reset per the #6375 fix.
+      act(() => {
+        ws2?.simulateMessage({
+          id: 'test-agents-list',
+          type: 'agents_list',
+          payload: { agents: [], defaultAgent: null },
+        })
+      })
 
       // Close again -> delay should be back to 1000ms (not 4000ms)
       act(() => { ws2?.simulateClose() })

--- a/web/src/hooks/useMissions.tsx
+++ b/web/src/hooks/useMissions.tsx
@@ -975,6 +975,17 @@ The WebSocket connection to the agent at \`${LOCAL_AGENT_WS_URL}\` was lost and 
           // #6376 — drop any tool-in-flight tracking for the dead socket;
           // the agent will re-report status after the reconnect.
           toolsInFlight.current.clear()
+          // #6410 — also clear the remaining per-mission tracking state so
+          // nothing is carried over from the dead socket. `waitingInputTimeouts`
+          // holds real setTimeout handles and must be clearTimeout'd first
+          // (just `.clear()` would leak the timers and they could fire after
+          // reconnect, flipping missions to `failed`).
+          for (const t of waitingInputTimeouts.current.values()) {
+            clearTimeout(t)
+          }
+          waitingInputTimeouts.current.clear()
+          lastStreamTimestamp.current.clear()
+          streamSplitCounter.current.clear()
           setAgentsLoading(false)
           reject(new Error('CONNECTION_FAILED'))
         }
@@ -1068,6 +1079,8 @@ The WebSocket connection to the agent at \`${LOCAL_AGENT_WS_URL}\` was lost and 
       if (mId === missionId) pendingRequests.current.delete(reqId)
     }
     lastStreamTimestamp.current.delete(missionId)
+    streamSplitCounter.current.delete(missionId) // #6410 — terminal state cleanup
+    toolsInFlight.current.delete(missionId) // #6410 — terminal state cleanup
     clearWaitingInputTimeout(missionId) // #5936
 
     setMissions(prev => prev.map(m => {
@@ -1183,20 +1196,35 @@ The WebSocket connection to the agent at \`${LOCAL_AGENT_WS_URL}\` was lost and 
 
     // #6376 — Track background tool-call lifecycle so the inactivity watchdog
     // can pause while a long-running Kubernetes tool is in flight. The agent
-    // protocol uses several frame names depending on the agent CLI flavour;
-    // count any tool-start frame as +1 and any matching tool-result frame as -1.
-    if (message.type === 'tool_exec' || message.type === 'tool_use' || message.type === 'tool_call') {
-      const prevCount = toolsInFlight.current.get(missionId) ?? 0
-      toolsInFlight.current.set(missionId, prevCount + 1)
-      // Bump last stream timestamp so a tool that fires right at the edge of
-      // the silence window doesn't trip the watchdog on the next interval.
-      lastStreamTimestamp.current.set(missionId, Date.now())
-    } else if (message.type === 'tool_result' || message.type === 'tool_done') {
-      const prevCount = toolsInFlight.current.get(missionId) ?? 0
-      const next = Math.max(0, prevCount - 1)
-      if (next === 0) toolsInFlight.current.delete(missionId)
-      else toolsInFlight.current.set(missionId, next)
-      lastStreamTimestamp.current.set(missionId, Date.now())
+    // protocol actually surfaces tool lifecycle events as `type: 'progress'`
+    // frames with tool metadata in the payload (see `onProgress` in
+    // pkg/agent/server_ai.go). A tool-start frame has `payload.tool` set and
+    // no `payload.output`; a tool-result frame has `payload.tool` set AND
+    // `payload.output` populated (truncated stdout). Count each shape as +1
+    // or -1 respectively. Earlier revisions of this code keyed on
+    // `tool_exec`/`tool_use`/`tool_call`/`tool_result`/`tool_done` message
+    // types that never reach the frontend — that branch was dead code.
+    if (message.type === 'progress') {
+      const progressPayload = (message.payload ?? {}) as {
+        tool?: string
+        output?: string
+      }
+      if (progressPayload.tool) {
+        if (progressPayload.output) {
+          // Tool completed — decrement.
+          const prevCount = toolsInFlight.current.get(missionId) ?? 0
+          const next = Math.max(0, prevCount - 1)
+          if (next === 0) toolsInFlight.current.delete(missionId)
+          else toolsInFlight.current.set(missionId, next)
+        } else {
+          // Tool started — increment.
+          const prevCount = toolsInFlight.current.get(missionId) ?? 0
+          toolsInFlight.current.set(missionId, prevCount + 1)
+        }
+        // Bump last stream timestamp so a tool that fires right at the edge
+        // of the silence window doesn't trip the watchdog on the next interval.
+        lastStreamTimestamp.current.set(missionId, Date.now())
+      }
     }
 
     setMissions(prev => prev.map(m => {
@@ -1376,6 +1404,10 @@ The WebSocket connection to the agent at \`${LOCAL_AGENT_WS_URL}\` was lost and 
         const payload = message.payload as ChatStreamPayload | { content?: string; output?: string }
         pendingRequests.current.delete(message.id)
         clearWaitingInputTimeout(missionId) // #5936 — result received, cancel watchdog
+        // #6410 — mission reached terminal state; drop its per-mission tracking.
+        streamSplitCounter.current.delete(missionId)
+        toolsInFlight.current.delete(missionId)
+        lastStreamTimestamp.current.delete(missionId)
         markMissionAsUnread(missionId)
 
         // Extract token usage if available
@@ -1464,6 +1496,10 @@ The WebSocket connection to the agent at \`${LOCAL_AGENT_WS_URL}\` was lost and 
         const payload = message.payload as { code?: string; message?: string }
         pendingRequests.current.delete(message.id)
         clearWaitingInputTimeout(missionId) // #5936 — terminal error, cancel watchdog
+        // #6410 — mission reached terminal state; drop its per-mission tracking.
+        streamSplitCounter.current.delete(missionId)
+        toolsInFlight.current.delete(missionId)
+        lastStreamTimestamp.current.delete(missionId)
         emitMissionError(m.type, payload.code || 'unknown', payload.message)
 
         // Create helpful error message based on error code
@@ -2297,6 +2333,9 @@ Install the console locally with the KubeStellar Console agent to use AI mission
       if (mId === missionId) pendingRequests.current.delete(reqId)
     }
     lastStreamTimestamp.current.delete(missionId)
+    // #6410 — mission is being removed from UI; drop per-mission tracking.
+    streamSplitCounter.current.delete(missionId)
+    toolsInFlight.current.delete(missionId)
     setMissions(prev => prev.filter(m => m.id !== missionId))
     if (activeMissionId === missionId) {
       setActiveMissionId(null)
@@ -2462,7 +2501,20 @@ Install the console locally with the KubeStellar Console agent to use AI mission
         clearTimeout(t)
       }
       waitingInputTimeoutsRef.clear()
-      wsRef.current?.close()
+      // #6410 — nullify handlers BEFORE close(). `onclose` is what schedules
+      // reconnection (see `wsReconnectTimer.current = setTimeout(...)` in
+      // ensureConnection); if we don't detach it, an unmounted provider can
+      // still enqueue reconnect attempts after tear-down. Detach the other
+      // handlers too so late events from the dying socket can't touch state
+      // on an unmounted component.
+      const dyingWs = wsRef.current
+      if (dyingWs) {
+        dyingWs.onopen = null
+        dyingWs.onmessage = null
+        dyingWs.onerror = null
+        dyingWs.onclose = null
+        dyingWs.close()
+      }
     }
   }, [])
 


### PR DESCRIPTION
Closes #6407
Closes #6410

## Summary

Follow-ups to merged PR #6395 — one test fix and six Copilot review comments.

### #6407 — useMissions backoff-reset test
The #6375 fix moved the reconnect-backoff reset from transport `onopen` to the first application-layer frame (`connectionEstablished` ref). The existing test expected the old behavior. Updated to deliver an `agents_list` frame between open and the second close, matching the new semantics.

### #6410 Copilot comments

**A. Tool lifecycle types** — The agent emits tool start/stop as `type: 'progress'` frames with `payload.tool` set (and `payload.output` populated on completion), per `pkg/agent/server_ai.go` `onProgress`. The prior code keyed on `tool_exec`/`tool_use`/`tool_call`/`tool_result`/`tool_done` message types that never reach the frontend — dead code. Switched `toolsInFlight` to the real wire format.

**B. onerror cleanup** — Also clears `waitingInputTimeouts` (clearTimeout each handle first so they don't fire after reconnect), `lastStreamTimestamp`, and `streamSplitCounter` alongside the existing `pendingRequests`/`toolsInFlight` clears.

**C. Unmount handler nullification** — Detach `onopen`/`onmessage`/`onerror`/`onclose` before `close()` on unmount so late events on the dying socket can't enqueue reconnect attempts on an unmounted provider.

**D. `buildInstallPromptForProject` doc/impl mismatch** — The old comment claimed the helper "records the raw value separately"; the implementation just substitutes `[invalid-name]`. Rewrote the comment to match.

**E. `uiSafeDisplayName` whitespace bug** — `isSafeProjectName` validates the *trimmed* form, so `'  foo  '` passed validation but rendered with original whitespace. Fix: trim `project.displayName` before validation and use the trimmed value for both validation and display. Adds a #6410 unit test.

**F. `streamSplitCounter` leak** — Per-mission entries now deleted at every terminal state transition (result, error, `finalizeCancellation`, `dismissMission`). Same fix applied to `toolsInFlight` and `lastStreamTimestamp` at the result/error paths for consistency.

## Test plan
- [x] `npx vitest run src/hooks/useMissions.test.tsx src/components/mission-control/__tests__/useMissionControl.test.tsx` — 295/295 passing
- [x] `npm run build` — passing
- [x] `npm run lint` — 330 errors, unchanged from baseline (zero new errors from this PR)