### PR TITLE
fix(missions): phase/retry/sort/network edge cases + stale state (#6402-#6414)

### DIFF
--- a/web/src/components/mission-control/LaunchSequence.tsx
+++ b/web/src/components/mission-control/LaunchSequence.tsx
@@ -20,11 +20,35 @@ import { cn } from '../../lib/cn'
 import { Button } from '../ui/Button'
 import { useMissions } from '../../hooks/useMissions'
 import { loadMissionPrompt } from '../cards/multi-tenancy/missionLoader'
-import type { MissionControlState, PhaseProgress, PhaseStatus } from './types'
+import type { DeployPhase, MissionControlState, PhaseProgress, PhaseStatus } from './types'
 import { buildInstallPromptForProject, isSafeProjectName } from './useMissionControl'
 
 /** Terminal statuses that indicate a project is no longer in-flight */
 const TERMINAL_STATUSES: readonly string[] = ['completed', 'failed', 'skipped']
+
+/**
+ * #6408 — Fallback phase builder used when `state.phases` is empty but
+ * assignments still exist. Packs every assigned project into a single
+ * "Phase 1: Deploy" so `LaunchSequence` actually runs something instead of
+ * calling `onComplete()` on an empty list and telling the user the mission
+ * succeeded with zero deployments.
+ */
+function buildFallbackPhasesFromAssignments(
+  state: MissionControlState,
+): DeployPhase[] {
+  const projectNames: string[] = []
+  const seen = new Set<string>()
+  for (const a of state.assignments) {
+    for (const n of a.projectNames || []) {
+      if (!seen.has(n)) {
+        seen.add(n)
+        projectNames.push(n)
+      }
+    }
+  }
+  if (projectNames.length === 0) return []
+  return [{ phase: 1, name: 'Deploy', projectNames }]
+}
 
 interface LaunchSequenceProps {
   state: MissionControlState
@@ -74,10 +98,21 @@ export function LaunchSequence({
   const progressRef = useRef<PhaseProgress[]>(state.launchProgress)
   const startedMissions = useRef(new Set<string>())
 
+  // #6408 — If `state.phases` is empty but the user has assignments, rebuild
+  // a single deploy phase from those assignments instead of calling
+  // `onComplete()` on an empty list (which would congratulate the user for
+  // deploying zero things). If BOTH phases and assignments are empty, we
+  // fall through to the "no projects to deploy" error path below.
+  const effectivePhases = useMemo(() => {
+    if (state.phases.length > 0) return state.phases
+    return buildFallbackPhasesFromAssignments(state)
+  }, [state])
+  const hasNothingToDeploy = effectivePhases.length === 0
+
   /** Content-based signature for phase membership (#5508) */
   const phaseSignature = useMemo(
-    () => computePhaseSignature(state.phases),
-    [state.phases]
+    () => computePhaseSignature(effectivePhases),
+    [effectivePhases]
   )
 
   // Initialize progress from phases — keyed on content signature, not just length (#5508)
@@ -86,9 +121,9 @@ export function LaunchSequence({
       progressRef.current = state.launchProgress
       return
     }
-    if (state.phases.length === 0) return
+    if (effectivePhases.length === 0) return
 
-    const initial: PhaseProgress[] = state.phases.map((phase) => ({
+    const initial: PhaseProgress[] = effectivePhases.map((phase) => ({
       phase: phase.phase,
       status: 'pending' as PhaseStatus,
       projects: (phase.projectNames || []).map((name) => ({
@@ -222,8 +257,13 @@ export function LaunchSequence({
       progressRef.current = updated
       onUpdateProgress(updated)
 
+      // #6408 — Never call onComplete on an empty progress list. Without
+      // this guard, a launch triggered on zero phases (phases === [] and
+      // assignments === []) would fire onComplete immediately and show a
+      // bogus "Mission Complete!" celebration.
+      if (updated.length === 0) return
       // Check if all phases complete
-      if (updated.length > 0 && updated.every((p) => TERMINAL_STATUSES.includes(p.status))) {
+      if (updated.every((p) => TERMINAL_STATUSES.includes(p.status))) {
         onComplete()
       }
     }
@@ -232,6 +272,9 @@ export function LaunchSequence({
   /**
    * Wait for a specific phase to reach a terminal status.
    * Used by phased mode to gate sequential phase execution (#5506).
+   * #6405 — Returns the terminal status so the caller can distinguish
+   * "fully succeeded" from "terminally failed" and block dependent phases
+   * when a failure occurred.
    */
   const waitForPhaseCompletion = useCallback((phaseNum: number): Promise<PhaseStatus> => {
     return new Promise((resolve) => {
@@ -258,7 +301,7 @@ export function LaunchSequence({
 
     if (isYolo) {
       // Launch everything at once
-      for (const phase of (state.phases || [])) {
+      for (const phase of effectivePhases) {
         for (const projectName of (phase.projectNames || [])) {
           if (!startedMissions.current.has(projectName)) {
             startedMissions.current.add(projectName)
@@ -268,7 +311,7 @@ export function LaunchSequence({
       }
     } else {
       // Phased: launch phase N, wait for completion, then phase N+1 (#5506)
-      for (const phase of (state.phases || [])) {
+      for (const phase of effectivePhases) {
         updateProgress((prev) =>
           prev.map((p) =>
             p.phase === phase.phase ? { ...p, status: 'running' } : p
@@ -284,14 +327,24 @@ export function LaunchSequence({
         }
 
         // Wait for this phase to reach a terminal state before starting the next (#5506)
-        await waitForPhaseCompletion(phase.phase)
+        // #6405 — Only advance on a fully-succeeded phase. A `failed` status
+        // means at least one project in this phase is terminally failed and
+        // the user is looking at a "Retry Failed" button — we must NOT
+        // auto-advance to dependent phases from that state.
+        const result = await waitForPhaseCompletion(phase.phase)
+        if (result !== 'completed') {
+          // Block dependent phases. The Retry Failed button will re-invoke
+          // launchProject for the failed entries; if the retry succeeds, the
+          // user can manually proceed via the normal completion path.
+          break
+        }
       }
     }
   }
 
   // Auto-start on mount — keyed on content signature (#5508)
   useEffect(() => {
-    if (!isStarted && state.phases.length > 0) {
+    if (!isStarted && effectivePhases.length > 0) {
       startLaunch()
     }
   }, [phaseSignature])
@@ -301,6 +354,30 @@ export function LaunchSequence({
     (p) => p.status === 'completed' || p.status === 'failed' || p.status === 'skipped'
   )
   const allSuccess = progress.length > 0 && progress.every((p) => p.status === 'completed')
+
+  // #6408 — If the wizard landed on Launch with no phases AND no assignments,
+  // show an explicit error instead of auto-firing onComplete().
+  if (hasNothingToDeploy) {
+    return (
+      <div className="max-w-3xl mx-auto p-6 space-y-6">
+        <div className="text-center">
+          <div className="inline-flex p-3 rounded-2xl bg-amber-500/20 mb-3">
+            <AlertTriangle className="w-8 h-8 text-amber-400" />
+          </div>
+          <h2 className="text-2xl font-bold">No projects to deploy</h2>
+          <p className="text-sm text-muted-foreground mt-1">
+            Your mission has no cluster assignments. Go back to the Chart
+            Course phase to assign projects before launching.
+          </p>
+        </div>
+        <div className="flex justify-center gap-3 pt-2">
+          <Button variant="secondary" size="sm" onClick={() => onClose ? onClose() : onComplete()}>
+            Close
+          </Button>
+        </div>
+      </div>
+    )
+  }
 
   return (
     <div className="max-w-3xl mx-auto p-6 space-y-6">
@@ -332,14 +409,14 @@ export function LaunchSequence({
         <p className="text-sm text-muted-foreground mt-1">
           {allComplete
             ? 'All deployment phases have finished.'
-            : `Deploying ${state.projects.length} projects in ${state.phases.length} phases`}
+            : `Deploying ${state.projects.length} projects in ${effectivePhases.length} phases`}
         </p>
       </div>
 
       {/* Phase checklist */}
       <div className="space-y-4">
         {progress.map((phase) => {
-          const phaseDef = state.phases.find((p) => p.phase === phase.phase)
+          const phaseDef = effectivePhases.find((p) => p.phase === phase.phase)
           return (
             <motion.div
               key={phase.phase}

--- a/web/src/components/mission-control/MissionControlDialog.tsx
+++ b/web/src/components/mission-control/MissionControlDialog.tsx
@@ -93,6 +93,20 @@ export function MissionControlDialog({ open, onClose }: MissionControlDialogProp
     return () => document.removeEventListener('keydown', handleKeyDown)
   }, [open, handleKeyDown])
 
+  // #6403 — Surface a toast when stale cluster references are dropped from
+  // persisted state. The hook already reconciles the state; we just notify
+  // the user so they don't stare at a mysteriously-shrunk assignment list.
+  useEffect(() => {
+    if (!open) return
+    if (mc.staleClusterNames.length === 0) return
+    const names = mc.staleClusterNames.join(', ')
+    showToast(
+      `Unassigned ${mc.staleClusterNames.length} cluster(s) from your previous session that no longer exist: ${names}`,
+      'warning',
+    )
+    mc.acknowledgeStaleClusters()
+  }, [open, mc.staleClusterNames, showToast, mc])
+
   // Lock body scroll while modal is open so users cannot scroll the page behind it
   useEffect(() => {
     if (!open) return

--- a/web/src/components/mission-control/useMissionControl.ts
+++ b/web/src/components/mission-control/useMissionControl.ts
@@ -289,11 +289,79 @@ export function useMissionControl() {
   const { releases: helmReleases } = useHelmReleases()
   const { clusters } = useClusters()
   const lastParsedContentRef = useRef('')
+  // #6403 — Stale persisted state can reference clusters that were renamed or
+  // deleted between sessions. When the current cluster list loads, cross-check
+  // every referenced cluster name and drop assignments/targetClusters for
+  // clusters that no longer exist. The removed names are surfaced via
+  // `staleClusterNames` so the UI can show a banner exactly once.
+  const [staleClusterNames, setStaleClusterNames] = useState<string[]>([])
+  const staleReconcileDoneRef = useRef(false)
+  // #6404 — Sequence counter to discard late-arriving AI stream responses
+  // that would otherwise clobber manual assignments. The counter bumps on
+  // every phase change or manual mutation. When we dispatch an AI prompt,
+  // we snapshot the current counter; when the stream completes, we only
+  // apply the result if the counter hasn't advanced.
+  const userMutationGenerationRef = useRef(0)
+  const lastDispatchedGenerationRef = useRef(0)
+  const bumpUserGeneration = () => {
+    userMutationGenerationRef.current += 1
+  }
 
   // Persist on change (debounced via effect)
   useEffect(() => {
     persistState(state)
   }, [state])
+
+  // #6403 — Reconcile persisted cluster references against the current
+  // cluster list. Runs once after clusters have loaded (non-empty list or
+  // explicit empty-after-load). We can't tell "still loading" from "zero
+  // clusters" purely by length, so we gate on the first render where
+  // `clusters` is a non-null array — the first truthy load — and only
+  // reconcile if the persisted state actually references cluster names
+  // (an empty wizard has nothing to reconcile).
+  useEffect(() => {
+    if (staleReconcileDoneRef.current) return
+    if (!clusters) return
+    const hasReferences =
+      state.assignments.length > 0 || state.targetClusters.length > 0
+    if (!hasReferences) {
+      // Nothing to reconcile, but still mark done so we don't re-check.
+      staleReconcileDoneRef.current = true
+      return
+    }
+    const liveNames = new Set(clusters.map((c) => c.name))
+    const staleFromAssignments = state.assignments
+      .filter((a) => !liveNames.has(a.clusterName))
+      .map((a) => a.clusterName)
+    const staleFromTargets = state.targetClusters.filter((n) => !liveNames.has(n))
+    const allStale = Array.from(new Set([...staleFromAssignments, ...staleFromTargets]))
+    if (allStale.length === 0) {
+      staleReconcileDoneRef.current = true
+      return
+    }
+    staleReconcileDoneRef.current = true
+    // Reconciliation is a one-shot synchronization against external data
+    // (the live cluster list), not a react-to-user event, so setState in
+    // this effect is the right tool here. The ref guard above ensures it
+    // runs exactly once per load.
+    /* eslint-disable react-hooks/set-state-in-effect */
+    setStaleClusterNames(allStale)
+    setState((prev) => ({
+      ...prev,
+      assignments: prev.assignments.filter((a) => liveNames.has(a.clusterName)),
+      targetClusters: prev.targetClusters.filter((n) => liveNames.has(n)),
+      // Phases may reference projects on the removed clusters — clear phases
+      // so Flight Plan regenerates them from the surviving assignments.
+      phases: [] }))
+    /* eslint-enable react-hooks/set-state-in-effect */
+    console.warn(
+      `[MissionControl] #6403 — dropped ${allStale.length} stale cluster reference(s) from persisted state: ${allStale.join(', ')}`,
+    )
+  }, [clusters, state.assignments, state.targetClusters])
+
+  const acknowledgeStaleClusters = () => {
+    setStaleClusterNames([])
+  }
 
   // ---------------------------------------------------------------------------
   // AI conversation monitoring
@@ -375,6 +443,18 @@ export function useMissionControl() {
         warnings?: string[]
       }>(latest.content, 'assignments')
       if (parsed?.assignments) {
+        // #6404 — Discard late-arriving AI responses that would clobber
+        // manual assignments. If the user has mutated state (or changed
+        // phase) since this prompt was dispatched, drop the result.
+        if (
+          lastDispatchedGenerationRef.current !== userMutationGenerationRef.current
+        ) {
+          console.warn(
+            '[MissionControl] #6404 — discarding stale AI assignment stream (user mutated state after dispatch)',
+          )
+          lastParsedContentRef.current = latest.content
+          return
+        }
         lastParsedContentRef.current = latest.content
         setState((prev) => {
           const aiAssignments = parsed.assignments!
@@ -481,6 +561,14 @@ export function useMissionControl() {
 
   const askAIForSuggestions = (description: string, existingProjects: PayloadProject[] = []) => {
       const currentState = stateRef.current
+      // #6406 — Guard against rapid-click parallel requests. The button is
+      // already `disabled={aiStreaming}` in the UI, but keyboard users and
+      // rapid double-clicks can still land a second call before the state
+      // updates — so early-return here too (belt-and-suspenders).
+      if (currentState.aiStreaming) {
+        console.warn('[MissionControl] #6406 — askAIForSuggestions called while already streaming; ignoring')
+        return
+      }
       const currentHelmReleases = helmReleasesRef.current
       let missionId = currentState.planningMissionId
 
@@ -601,6 +689,11 @@ Include real CNCF projects only. Consider dependencies between projects.`
   // ---------------------------------------------------------------------------
 
   const askAIForAssignments = (projects: PayloadProject[], clustersJson: string) => {
+      // #6406 — Early return if a planning request is already in flight.
+      if (stateRef.current.aiStreaming) {
+        console.warn('[MissionControl] #6406 — askAIForAssignments called while already streaming; ignoring')
+        return
+      }
       let missionId = stateRef.current.planningMissionId
 
       const prompt = `The user selected these projects for deployment:
@@ -652,6 +745,10 @@ Return a JSON block:
 
 Order phases by dependency — prerequisites first. Each phase completes before the next starts.`
 
+      // #6404 — Snapshot the user-mutation generation at dispatch time so
+      // the parse effect can discard this response if the user has since
+      // mutated state.
+      lastDispatchedGenerationRef.current = userMutationGenerationRef.current
       // If no planning mission exists (user went manual on Phase 1), start one
       // so the AI assign button is not silently a no-op (#5502)
       if (!missionId) {
@@ -673,6 +770,7 @@ Order phases by dependency — prerequisites first. Each phase completes before 
   /** Move a project from one cluster to another (for drag-and-drop in blueprint) */
   const moveProjectToCluster = (projectName: string, fromCluster: string, toCluster: string) => {
       if (fromCluster === toCluster) return
+      bumpUserGeneration() // #6404 — manual mutation invalidates in-flight AI streams
       setState((prev) => ({
         ...prev,
         assignments: prev.assignments.map((a) => {
@@ -689,6 +787,7 @@ Order phases by dependency — prerequisites first. Each phase completes before 
     }
 
   const setAssignment = (clusterName: string, projectName: string, assigned: boolean) => {
+      bumpUserGeneration() // #6404 — manual mutation invalidates in-flight AI streams
       setState((prev) => {
         const assignments = [...prev.assignments]
         const idx = assignments.findIndex((a) => a.clusterName === clusterName)
@@ -724,6 +823,10 @@ Order phases by dependency — prerequisites first. Each phase completes before 
   // ---------------------------------------------------------------------------
 
   const setPhase = (phase: WizardPhase) => {
+    // #6404 — Phase transitions invalidate any in-flight AI stream: a
+    // response dispatched in Phase 2 must not silently overwrite Phase 3
+    // state after the user has advanced.
+    bumpUserGeneration()
     setState((prev) => ({ ...prev, phase }))
   }
 
@@ -876,10 +979,30 @@ Order phases by dependency — prerequisites first. Each phase completes before 
       const newAssignments = new Map<string, string[]>()
       availableClusters.forEach(c => newAssignments.set(c.name, []))
 
-      // Sort projects: required first, then recommended, then optional
-      const priorityOrder = { required: 0, recommended: 1, optional: 2 }
+      // Sort projects: required first, then recommended, then optional.
+      // #6402 — If the AI returns an unknown priority value (e.g.
+      // "highly-recommended"), `priorityOrder[p.priority]` is `undefined` and
+      // any arithmetic with it yields NaN, which makes `Array.sort` order
+      // nondeterministic. Fall back to MAX_SAFE_INTEGER so unknown priorities
+      // sort after all known values, and log a warning once per unknown value.
+      const priorityOrder: Record<string, number> = { required: 0, recommended: 1, optional: 2 }
+      const UNKNOWN_PRIORITY_RANK = Number.MAX_SAFE_INTEGER
+      const warnedUnknownPriorities = new Set<string>()
+      const rankPriority = (priority: string | undefined): number => {
+        const rank = priority !== undefined ? priorityOrder[priority] : undefined
+        if (rank === undefined) {
+          if (priority && !warnedUnknownPriorities.has(priority)) {
+            warnedUnknownPriorities.add(priority)
+            console.warn(
+              `[MissionControl] Unknown priority "${priority}" — treating as lowest (#6402)`,
+            )
+          }
+          return UNKNOWN_PRIORITY_RANK
+        }
+        return rank
+      }
       const sortedProjects = [...state.projects].sort(
-        (a, b) => (priorityOrder[a.priority] ?? 1) - (priorityOrder[b.priority] ?? 1)
+        (a, b) => rankPriority(a.priority) - rankPriority(b.priority)
       )
 
       for (const project of sortedProjects) {
@@ -981,6 +1104,9 @@ Order phases by dependency — prerequisites first. Each phase completes before 
     setGroundControlDashboardId,
     // Planning mission
     planningMission,
+    // #6403 — Stale cluster reconciliation
+    staleClusterNames,
+    acknowledgeStaleClusters,
     // Reset
     reset }
 }

--- a/web/src/hooks/__tests__/useDeployMissions.test.ts
+++ b/web/src/hooks/__tests__/useDeployMissions.test.ts
@@ -1482,6 +1482,101 @@ describe('useDeployMissions', () => {
   })
 
   // =========================================================================
+  // #6414: 403 with an RBAC body surfaces the permission message
+  // =========================================================================
+  it('surfaces RBAC permission message for 403 with a parseable body', async () => {
+    const startedAt = Date.now() - MIN_ACTIVE_MS - 1
+    const missions = [makeMission({
+      id: 'rbac-403', status: 'deploying', startedAt,
+      targetClusters: ['c1'],
+    })]
+    localStorage.setItem(MISSIONS_STORAGE_KEY, JSON.stringify(missions))
+
+    mockClusterCacheRef.clusters = []
+    // Build a Response-like mock with a .clone().text() chain returning a
+    // K8s-style Forbidden Status object. The hook should pull the message
+    // out rather than falling back to the legacy "token expired" line.
+    const rbacBody = JSON.stringify({
+      kind: 'Status',
+      reason: 'Forbidden',
+      message: 'deployments.apps is forbidden: User "alice" cannot list resource "deployments" in namespace "prod"',
+    })
+    const makeCloneable = () => ({
+      ok: false,
+      status: 403,
+      clone: () => ({ text: async () => rbacBody }),
+      text: async () => rbacBody,
+    })
+    global.fetch = vi.fn().mockResolvedValue(makeCloneable())
+
+    const { result } = renderHook(() => useDeployMissions())
+    await advancePastInitialPoll()
+
+    const cs = result.current.missions[0].clusterStatuses[0]
+    expect(cs.status).toBe('failed')
+    expect(cs.logs![0]).toContain('Permission denied')
+    expect(cs.logs![0]).toContain('cannot list')
+  })
+
+  // =========================================================================
+  // #6412: transient network failures do not flip the mission to failed
+  // =========================================================================
+  it('treats repeated pure-network failures as network-pending, not failed', async () => {
+    const missions = [makeMission({
+      id: 'net-blip', status: 'deploying',
+      startedAt: Date.now() - MIN_ACTIVE_MS - 1,
+      targetClusters: ['c1'],
+    })]
+    localStorage.setItem(MISSIONS_STORAGE_KEY, JSON.stringify(missions))
+
+    mockClusterCacheRef.clusters = []
+    // fetch throws on every call — simulates sustained network blackout
+    // that is still SHORT of the network-failure threshold.
+    global.fetch = vi.fn().mockRejectedValue(new Error('Network unreachable'))
+
+    const { result } = renderHook(() => useDeployMissions())
+    await advancePastInitialPoll()
+    // 6 more polls: with the old code this would have marked cluster failed.
+    for (let i = 0; i < 6; i++) await advancePollInterval()
+
+    const cs = result.current.missions[0].clusterStatuses[0]
+    // After 7 polls the HTTP failure count threshold (6) would have
+    // tripped; the network failure count threshold (60) has not.
+    expect(cs.status).toBe('pending')
+    expect(cs.networkFailureCount).toBeGreaterThanOrEqual(6)
+    // Status counter for HTTP errors stays at zero because these are
+    // network-level, not HTTP errors.
+    expect(cs.consecutiveFailures ?? 0).toBe(0)
+  })
+
+  // =========================================================================
+  // #6411: active-mission sort is deterministic for equal startedAt
+  // =========================================================================
+  it('orders missions deterministically when startedAt is identical', async () => {
+    const t = Date.now() - MIN_ACTIVE_MS - 1
+    const missions = [
+      makeMission({ id: 'mm-c', status: 'deploying', startedAt: t, targetClusters: ['c1'] }),
+      makeMission({ id: 'mm-a', status: 'deploying', startedAt: t, targetClusters: ['c1'] }),
+      makeMission({ id: 'mm-b', status: 'deploying', startedAt: t, targetClusters: ['c1'] }),
+    ]
+    localStorage.setItem(MISSIONS_STORAGE_KEY, JSON.stringify(missions))
+
+    mockClusterCacheRef.clusters = []
+    global.fetch = vi.fn().mockRejectedValue(new Error('not available'))
+
+    const { result } = renderHook(() => useDeployMissions())
+    await advancePastInitialPoll()
+
+    // All three share the same startedAt: tiebreaker should sort by id ascending.
+    const ids = result.current.missions.map(m => m.id)
+    expect(ids).toEqual(['mm-a', 'mm-b', 'mm-c'])
+
+    // Re-poll — order must be stable across polls.
+    await advancePollInterval()
+    expect(result.current.missions.map(m => m.id)).toEqual(['mm-a', 'mm-b', 'mm-c'])
+  })
+
+  // =========================================================================
   // 48. #5501: saveMissions preserves logs for partial missions
   // =========================================================================
   it('preserves logs for partial missions when persisting to localStorage', () => {

--- a/web/src/hooks/useDeployMissions.ts
+++ b/web/src/hooks/useDeployMissions.ts
@@ -81,8 +81,17 @@ export interface DeployClusterStatus {
   replicas: number
   readyReplicas: number
   logs?: string[]
-  /** Consecutive status-fetch failures — transitions to 'failed' after threshold */
+  /**
+   * Consecutive HTTP 4xx/5xx responses from the status endpoint — after
+   * MAX_STATUS_FAILURES we mark the cluster failed. #6412.
+   */
   consecutiveFailures?: number
+  /**
+   * Consecutive pure network failures (fetch threw, no HTTP response).
+   * Tracked separately so a transient VPN blip can't flip the mission into
+   * a terminal 'failed' state. #6412.
+   */
+  networkFailureCount?: number
 }
 
 export interface DeployMission {
@@ -111,8 +120,21 @@ const POLL_INTERVAL_MS = 5000
 const MAX_MISSIONS = 50
 /** Cache TTL: 5 minutes — stop polling completed missions after this duration */
 const CACHE_TTL_MS = 5 * 60 * 1000
-/** After this many consecutive status-fetch failures a cluster is marked failed */
+/** After this many consecutive HTTP error responses (4xx/5xx) a cluster is marked failed (#6412) */
 const MAX_STATUS_FAILURES = 6
+/**
+ * Separate threshold for pure network failures (no response, DNS failure,
+ * connection reset, TCP abort). #6412 — a 30s VPN blip must not mark a
+ * cluster failed; only a sustained outage should. We use a much higher
+ * threshold because network hiccups are legitimately transient.
+ */
+const MAX_NETWORK_FAILURES = 60
+/**
+ * Minimum time a mission stays in the "deploying" state before we're
+ * allowed to transition it to a terminal status. This gives the underlying
+ * K8s rollout a chance to actually appear in the API (#6409).
+ */
+const MIN_ACTIVE_MS = 10_000
 
 function loadMissions(): DeployMission[] {
   try {
@@ -232,17 +254,41 @@ export function useDeployMissions() {
               // Track consecutive failures from previous poll cycle
               const prevStatus = mission.clusterStatuses.find(cs => cs.cluster === cluster)
               const prevFailures = prevStatus?.consecutiveFailures ?? 0
+              const prevNetworkFailures = prevStatus?.networkFailureCount ?? 0
 
-              // Helper: build a "pending-or-failed" response depending on failure count
+              // Helper: build a "pending-or-failed" response based on HTTP-error failure count.
+              // #6412 — used only for genuine HTTP 4xx/5xx responses, not for
+              // network-level failures. Preserves networkFailureCount so a
+              // concurrent network blip doesn't reset its tally.
               const pendingOrFailed = (): DeployClusterStatus => {
                 const failures = prevFailures + 1
                 if (failures >= MAX_STATUS_FAILURES) {
                   return { cluster, status: 'failed', replicas: 0, readyReplicas: 0,
                     consecutiveFailures: failures,
-                    logs: [`Status unreachable after ${failures} consecutive attempts`] }
+                    networkFailureCount: prevNetworkFailures,
+                    logs: [`Status unreachable after ${failures} consecutive HTTP errors`] }
                 }
                 return { cluster, status: 'pending', replicas: 0, readyReplicas: 0,
-                  consecutiveFailures: failures }
+                  consecutiveFailures: failures,
+                  networkFailureCount: prevNetworkFailures }
+              }
+
+              // Helper: pure-network-failure response. #6412 — these should
+              // NOT count toward MAX_STATUS_FAILURES. We keep the mission
+              // pending through the blip; only a sustained outage
+              // (MAX_NETWORK_FAILURES polls) escalates to 'failed'. Preserves
+              // prevFailures so an HTTP-error streak in progress isn't reset.
+              const networkPending = (): DeployClusterStatus => {
+                const networkFailures = prevNetworkFailures + 1
+                if (networkFailures >= MAX_NETWORK_FAILURES) {
+                  return { cluster, status: 'failed', replicas: 0, readyReplicas: 0,
+                    consecutiveFailures: prevFailures,
+                    networkFailureCount: networkFailures,
+                    logs: [`Network unreachable after ${networkFailures} consecutive attempts`] }
+                }
+                return { cluster, status: 'pending', replicas: 0, readyReplicas: 0,
+                  consecutiveFailures: prevFailures,
+                  networkFailureCount: networkFailures }
               }
 
               // Try agent first (works when backend is down)
@@ -304,12 +350,52 @@ export function useDeployMissions() {
                   { headers: authHeaders(), signal: AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS) }
                 )
                 if (!res.ok) {
-                  // Surface auth failures explicitly instead of masking as "unreachable" (#5499)
+                  // Surface auth failures explicitly instead of masking as "unreachable" (#5499).
+                  // #6414 — Distinguish true auth failures (401, or 403 with
+                  // body indicating expired/invalid token) from RBAC denials
+                  // (403 with body describing a user/verb/resource combination).
                   if (res.status === HTTP_UNAUTHORIZED || res.status === HTTP_FORBIDDEN) {
+                    let bodyText = ''
+                    try {
+                      // Use .clone() when available so the body can also be
+                      // re-read elsewhere; fall back to .text() directly.
+                      if (typeof (res as Response).clone === 'function') {
+                        bodyText = await (res as Response).clone().text()
+                      } else if (typeof (res as Response).text === 'function') {
+                        bodyText = await (res as Response).text()
+                      }
+                    } catch { /* body already consumed or unreadable */ }
+                    // Parse a K8s Status object if the body is JSON.
+                    interface K8sStatusBody {
+                      reason?: string
+                      message?: string
+                      kind?: string
+                    }
+                    let parsed: K8sStatusBody | null = null
+                    if (bodyText) {
+                      try {
+                        parsed = JSON.parse(bodyText) as K8sStatusBody
+                      } catch { /* non-JSON body */ }
+                    }
+                    const reason = parsed?.reason ?? ''
+                    const message = parsed?.message ?? bodyText.slice(0, 200)
+                    // Only flag as "RBAC denial" when the body is clearly a
+                    // K8s Forbidden Status object. Without a parseable body
+                    // we fall through to the legacy "token may be expired"
+                    // wording (#5499) so bare-401/403 cases stay untouched.
+                    const looksLikeRBACDeny =
+                      res.status === HTTP_FORBIDDEN &&
+                      parsed !== null &&
+                      (reason === 'Forbidden' ||
+                        /cannot (?:list|get|watch|create|update|delete) /i.test(message))
+                    const logLine = looksLikeRBACDeny
+                      ? `Permission denied (HTTP ${res.status}): ${message || reason || 'forbidden'}`
+                      : `Authentication failed (HTTP ${res.status}) — token may be expired or revoked`
                     return {
                       cluster, status: 'failed' as const, replicas: 0, readyReplicas: 0,
                       consecutiveFailures: prevFailures + 1,
-                      logs: [`Authentication failed (HTTP ${res.status}) — token may be expired or revoked`],
+                      networkFailureCount: prevNetworkFailures,
+                      logs: [logLine],
                     }
                   }
                   return pendingOrFailed()
@@ -374,7 +460,10 @@ export function useDeployMissions() {
                   readyReplicas: data.readyReplicas ?? 0,
                   logs }
               } catch {
-                return pendingOrFailed()
+                // #6412 — fetch threw: network failure (no HTTP response).
+                // Track separately from HTTP errors so a transient VPN blip
+                // can't trip the 6-poll catastrophe threshold.
+                return networkPending()
               }
             })
           )
@@ -393,11 +482,29 @@ export function useDeployMissions() {
             missionStatus = 'partial'
           }
 
-          // Grace period: keep mission in deploying state for at least 10s
+          // Grace period: keep mission in deploying state for at least
+          // MIN_ACTIVE_MS so the backend has a chance to actually register
+          // the rollout. #6409 — if the computed status would be terminal
+          // but we're still inside the grace window, schedule a targeted
+          // re-poll at the exact moment the grace window expires, rather
+          // than waiting up to POLL_INTERVAL_MS for the next regular poll.
+          // This eliminates the observed 0–5s lag between the grace window
+          // closing and the UI flipping to the real status.
           const elapsed = Date.now() - mission.startedAt
-          const MIN_ACTIVE_MS = 10000
           if (isTerminalStatus(missionStatus) && elapsed < MIN_ACTIVE_MS) {
             missionStatus = 'deploying'
+            const remaining = MIN_ACTIVE_MS - elapsed
+            // Small fudge (50ms) so `elapsed` is definitely past MIN_ACTIVE_MS on re-entry
+            const GRACE_REPOLL_FUDGE_MS = 50
+            setTimeout(() => {
+              // Only re-poll if this mission still exists and is still non-terminal.
+              // The regular interval may have already run by now, which is fine
+              // — calling poll() again is idempotent.
+              const latest = missionsRef.current.find(m => m.id === mission.id)
+              if (latest && !isTerminalStatus(latest.status)) {
+                poll()
+              }
+            }, remaining + GRACE_REPOLL_FUDGE_MS)
           }
 
           return {
@@ -411,11 +518,19 @@ export function useDeployMissions() {
         })
       )
 
-      // Sort: active missions first (newest first), completed missions below (newest first)
+      // Sort: active missions first (newest first), completed missions below (newest first).
+      // #6411 — Add a deterministic tiebreaker on mission id. Without it,
+      // two missions with the same `startedAt` epoch ms reshuffle randomly
+      // on every poll because `Array.sort` is not guaranteed stable across
+      // all engines for `0` comparisons.
       const active = updated.filter(m => !isTerminalStatus(m.status))
       const completed = updated.filter(m => isTerminalStatus(m.status))
-      active.sort((a, b) => b.startedAt - a.startedAt)
-      completed.sort((a, b) => (b.completedAt ?? b.startedAt) - (a.completedAt ?? a.startedAt))
+      active.sort((a, b) => (b.startedAt - a.startedAt) || a.id.localeCompare(b.id))
+      completed.sort((a, b) => {
+        const aKey = a.completedAt ?? a.startedAt
+        const bKey = b.completedAt ?? b.startedAt
+        return (bKey - aKey) || a.id.localeCompare(b.id)
+      })
 
       setMissions([...active, ...completed])
     }


### PR DESCRIPTION
## Summary

Batch of 10 defensive fixes in Mission Control and the deploy-mission poll loop. Each scenario was verified against the current source before coding; none were already handled. See the commit message for per-issue details.

**useMissionControl.ts**
- `#6402` Priority sort — `Number.MAX_SAFE_INTEGER` fallback + one-time warning for unknown priority strings
- `#6403` Stale cluster ghosting — reconcile persisted state against live cluster list, drop ghost refs, surface via toast
- `#6404` Parallel-stream clobber — user-mutation generation counter discards late AI streams
- `#6406` Ask-AI race — early return in both `askAIFor*` handlers when `aiStreaming` is set

**LaunchSequence.tsx**
- `#6405` Retry phase mismatch — phased loop breaks on non-`completed` terminal status so failed phases block dependents
- `#6408` Empty phase bypass — rebuild a fallback phase from assignments; explicit "No projects to deploy" error otherwise

**useDeployMissions.ts**
- `#6409` Grace-period lag — targeted `setTimeout` at `MIN_ACTIVE_MS` expiry to re-poll
- `#6411` Unstable sort — `id.localeCompare` tiebreaker
- `#6412` 6-failed-ping catastrophe — network failures tracked separately from HTTP errors with a much higher threshold
- `#6414` Phantom auth masking — parse 403 body for K8s RBAC denials, surface permission message instead of generic "token expired"

## Test plan
- [x] `npm run build` passes
- [x] `npx vitest run` — 81/81 tests pass across `useDeployMissions` and `mission-control` suites
- [x] `npm run lint` on touched files — 0 new errors or warnings vs. baseline
- [x] New tests: `#6411` stable-sort, `#6412` network-pending, `#6414` RBAC message

Closes #6402
Closes #6403
Closes #6404
Closes #6405
Closes #6406
Closes #6408
Closes #6409
Closes #6411
Closes #6412
Closes #6414