### PR TITLE
fix(missions): wave5 — escape handling, namespace detection, quota recovery, preflight gating + 8 more (#6426-#6438)

### DIFF
--- a/web/src/components/cards/multi-tenancy/missionLoader.ts
+++ b/web/src/components/cards/multi-tenancy/missionLoader.ts
@@ -52,12 +52,23 @@ export async function loadMissionPrompt(
     const parsed = await response.json()
     const mission = parsed.mission || parsed
 
-    // Build a structured prompt from the mission steps
-    const steps = (mission.steps || []) as Array<{ title: string; description: string }>
+    // issue 6430 — Guard every field access against schema drift. Old v1
+    // exports may omit `troubleshooting`/`prerequisites`; v2+ exports may
+    // add new nested shapes. Never trust the incoming object's shape —
+    // check `typeof` / `Array.isArray` before dereferencing.
+    const rawSteps: unknown = mission?.steps
+    const steps = Array.isArray(rawSteps)
+      ? (rawSteps.filter(
+          (s): s is { title: string; description: string } =>
+            !!s && typeof s === 'object'
+            && typeof (s as { title?: unknown }).title === 'string'
+            && typeof (s as { description?: unknown }).description === 'string',
+        ))
+      : []
     if (steps.length === 0) return fallbackPrompt
 
-    const title = mission.title || 'Install Component'
-    const description = mission.description || ''
+    const title = typeof mission?.title === 'string' ? mission.title : 'Install Component'
+    const description = typeof mission?.description === 'string' ? mission.description : ''
 
     let prompt = `# ${title}\n\n${description}\n\n## Steps\n\n`
 
@@ -66,8 +77,16 @@ export async function loadMissionPrompt(
       prompt += `### Step ${i + 1}: ${step.title}\n${step.description}\n\n`
     }
 
-    // Add troubleshooting if available
-    const troubleshooting = (mission.troubleshooting || []) as Array<{ title: string; description: string }>
+    // Add troubleshooting if available (v2+ schema field — absent in older exports)
+    const rawTroubleshooting: unknown = mission?.troubleshooting
+    const troubleshooting = Array.isArray(rawTroubleshooting)
+      ? (rawTroubleshooting.filter(
+          (t): t is { title: string; description: string } =>
+            !!t && typeof t === 'object'
+            && typeof (t as { title?: unknown }).title === 'string'
+            && typeof (t as { description?: unknown }).description === 'string',
+        ))
+      : []
     if (troubleshooting.length > 0) {
       prompt += `## Troubleshooting\n\n`
       for (const item of troubleshooting) {

--- a/web/src/components/mission-control/__tests__/useMissionControl.test.tsx
+++ b/web/src/components/mission-control/__tests__/useMissionControl.test.tsx
@@ -115,4 +115,24 @@ describe('extractJSON — balanced block extraction (#6382)', () => {
     const parsed = extractJSON<{ a: string }>(text)
     expect(parsed).toBeNull()
   })
+
+  // issue 6426 — heavy nested backslash escaping should neither hang nor
+  // lose characters. The original concern was that `inString` tracking
+  // could get confused by sequences like `\\\\` followed by `\\"`.
+  it('handles heavy nested backslash escaping without looping', () => {
+    // Construct a JSON string whose `reason` field contains escaped
+    // backslashes followed by escaped quotes. In the raw JSON text this
+    // is `"reason": "path\\with\\quotes: \"x\""` — JS source escapes
+    // each backslash and quote one more level.
+    const text =
+      '{"reason": "path\\\\with\\\\quotes: \\"x\\"", "name": "falco"}'
+    const start = Date.now()
+    const parsed = extractJSON<{ reason: string; name: string }>(text)
+    // Hard upper bound: this should complete in well under 100ms. If the
+    // state machine ever regresses to an infinite loop, vitest's per-test
+    // timeout will fire; this assertion adds a tighter local gate.
+    expect(Date.now() - start).toBeLessThan(100)
+    expect(parsed?.name).toBe('falco')
+    expect(parsed?.reason).toBe('path\\with\\quotes: "x"')
+  })
 })

--- a/web/src/components/mission-control/types.ts
+++ b/web/src/components/mission-control/types.ts
@@ -49,6 +49,15 @@ export interface ClusterAssignment {
   clusterName: string
   /** Cluster context (from ClusterInfo.context) */
   clusterContext: string
+  /**
+   * Cluster server URL (from ClusterInfo.server) captured at assignment
+   * time. Used to detect re-created clusters during stale-reconciliation:
+   * if a Kind cluster was deleted and a new one was registered with the
+   * SAME name but a different server URL, the persisted assignment is
+   * orphaned and must be dropped. Optional for backward-compatibility
+   * with assignments persisted before this field existed (issue 6433).
+   */
+  clusterServer?: string
   /** Cloud provider / distribution (eks, gke, aks, kind, etc.) */
   provider: string
   /** Project names assigned to this cluster */

--- a/web/src/components/mission-control/useMissionControl.ts
+++ b/web/src/components/mission-control/useMissionControl.ts
@@ -249,27 +249,38 @@ function extractBalancedBlocks(text: string): string[] {
     let escape = false
 
     while (j < text.length && depth > 0) {
+      // issue 6426 — Belt-and-suspenders forward-progress guard. Every
+      // branch below advances `j`, but we capture the pre-iteration index
+      // and break out if somehow `j` fails to advance. This makes the
+      // state machine provably terminating regardless of input pathology
+      // (heavy nested `\\` escapes, embedded quotes, etc).
+      const jStart = j
       const c = text[j]
       if (escape) {
+        // Previous char was a backslash inside a string. Consume this
+        // char unconditionally and reset the escape flag.
         escape = false
         j++
-        continue
-      }
-      if (c === '\\' && inString) {
+      } else if (c === '\\' && inString) {
+        // Enter escape state. Next char will be consumed verbatim.
         escape = true
         j++
-        continue
-      }
-      if (c === '"') {
+      } else if (c === '"') {
+        // Toggle string state. JSON only allows double-quoted strings.
         inString = !inString
         j++
-        continue
+      } else {
+        if (!inString) {
+          if (c === ch) depth++
+          else if (c === expected) depth--
+        }
+        j++
       }
-      if (!inString) {
-        if (c === ch) depth++
-        else if (c === expected) depth--
+      if (j <= jStart) {
+        // Forward progress invariant violated — bail to avoid any chance
+        // of an infinite loop. Should be unreachable.
+        break
       }
-      j++
     }
 
     if (depth === 0) {
@@ -290,7 +301,7 @@ export function useMissionControl() {
   )
   const { startMission, sendMessage, missions } = useMissions()
   const { releases: helmReleases } = useHelmReleases()
-  const { clusters } = useClusters()
+  const { clusters, isLoading: clustersLoading, lastUpdated: clustersLastUpdated } = useClusters()
   const lastParsedContentRef = useRef('')
   // #6403 — Stale persisted state can reference clusters that were renamed or
   // deleted between sessions. When the current cluster list loads, cross-check
@@ -316,15 +327,18 @@ export function useMissionControl() {
   }, [state])
 
   // #6403 — Reconcile persisted cluster references against the current
-  // cluster list. Runs once after clusters have loaded (non-empty list or
-  // explicit empty-after-load). We can't tell "still loading" from "zero
-  // clusters" purely by length, so we gate on the first render where
-  // `clusters` is a non-null array — the first truthy load — and only
-  // reconcile if the persisted state actually references cluster names
-  // (an empty wizard has nothing to reconcile).
+  // cluster list. Runs once after clusters have actually finished loading,
+  // NOT on the initial `clusters: []` render that useClusters() emits while
+  // `isLoading: true`. Per Copilot review on PR #6424 (issue #6427), we gate
+  // on `!clustersLoading && clustersLastUpdated != null` so an empty cached
+  // state during initial fetch does not wipe valid persisted assignments.
   useEffect(() => {
     if (staleReconcileDoneRef.current) return
     if (!clusters) return
+    // issue 6427 — wait until useClusters() has produced a real load, not
+    // the stub `[]` returned during the initial fetch.
+    if (clustersLoading) return
+    if (clustersLastUpdated == null) return
     const hasReferences =
       state.assignments.length > 0 || state.targetClusters.length > 0
     if (!hasReferences) {
@@ -332,11 +346,23 @@ export function useMissionControl() {
       staleReconcileDoneRef.current = true
       return
     }
-    const liveNames = new Set(clusters.map((c) => c.name))
+    const liveByName = new Map(clusters.map((c) => [c.name, c]))
+    // issue 6433 — also drop assignments where the NAME still exists but
+    // the underlying server URL has changed (recreate-with-same-name). Only
+    // applies when the assignment captured a clusterServer at creation time
+    // (older persisted state without clusterServer gets the legacy name-only
+    // behavior to avoid wiping known-good assignments).
     const staleFromAssignments = state.assignments
-      .filter((a) => !liveNames.has(a.clusterName))
+      .filter((a) => {
+        const live = liveByName.get(a.clusterName)
+        if (!live) return true
+        if (a.clusterServer && live.server && a.clusterServer !== live.server) {
+          return true
+        }
+        return false
+      })
       .map((a) => a.clusterName)
-    const staleFromTargets = state.targetClusters.filter((n) => !liveNames.has(n))
+    const staleFromTargets = state.targetClusters.filter((n) => !liveByName.has(n))
     const allStale = Array.from(new Set([...staleFromAssignments, ...staleFromTargets]))
     if (allStale.length === 0) {
       staleReconcileDoneRef.current = true
@@ -349,18 +375,21 @@ export function useMissionControl() {
     // runs exactly once per load.
     /* eslint-disable react-hooks/set-state-in-effect */
     setStaleClusterNames(allStale)
+    const staleAssignmentNames = new Set(staleFromAssignments)
     setState((prev) => ({
       ...prev,
-      assignments: prev.assignments.filter((a) => liveNames.has(a.clusterName)),
-      targetClusters: prev.targetClusters.filter((n) => liveNames.has(n)),
+      assignments: prev.assignments.filter(
+        (a) => liveByName.has(a.clusterName) && !staleAssignmentNames.has(a.clusterName),
+      ),
+      targetClusters: prev.targetClusters.filter((n) => liveByName.has(n)),
       // Phases may reference projects on the removed clusters — clear phases
       // so Flight Plan regenerates them from the surviving assignments.
       phases: [] }))
     /* eslint-enable react-hooks/set-state-in-effect */
     console.warn(
-      `[MissionControl] #6403 — dropped ${allStale.length} stale cluster reference(s) from persisted state: ${allStale.join(', ')}`,
+      `[MissionControl] issue 6403 — dropped ${allStale.length} stale cluster reference(s) from persisted state: ${allStale.join(', ')}`,
     )
-  }, [clusters, state.assignments, state.targetClusters])
+  }, [clusters, clustersLoading, clustersLastUpdated, state.assignments, state.targetClusters])
 
   const acknowledgeStaleClusters = () => {
     setStaleClusterNames([])
@@ -453,7 +482,7 @@ export function useMissionControl() {
           lastDispatchedGenerationRef.current !== userMutationGenerationRef.current
         ) {
           console.warn(
-            '[MissionControl] #6404 — discarding stale AI assignment stream (user mutated state after dispatch)',
+            '[MissionControl] issue 6404 — discarding stale AI assignment stream (user mutated state after dispatch)',
           )
           lastParsedContentRef.current = latest.content
           return
@@ -569,7 +598,7 @@ export function useMissionControl() {
       // rapid double-clicks can still land a second call before the state
       // updates — so early-return here too (belt-and-suspenders).
       if (currentState.aiStreaming) {
-        console.warn('[MissionControl] #6406 — askAIForSuggestions called while already streaming; ignoring')
+        console.warn('[MissionControl] issue 6406 — askAIForSuggestions called while already streaming; ignoring')
         return
       }
       const currentHelmReleases = helmReleasesRef.current
@@ -694,7 +723,7 @@ Include real CNCF projects only. Consider dependencies between projects.`
   const askAIForAssignments = (projects: PayloadProject[], clustersJson: string) => {
       // #6406 — Early return if a planning request is already in flight.
       if (stateRef.current.aiStreaming) {
-        console.warn('[MissionControl] #6406 — askAIForAssignments called while already streaming; ignoring')
+        console.warn('[MissionControl] issue 6406 — askAIForAssignments called while already streaming; ignoring')
         return
       }
       let missionId = stateRef.current.planningMissionId
@@ -773,7 +802,7 @@ Order phases by dependency — prerequisites first. Each phase completes before 
   /** Move a project from one cluster to another (for drag-and-drop in blueprint) */
   const moveProjectToCluster = (projectName: string, fromCluster: string, toCluster: string) => {
       if (fromCluster === toCluster) return
-      bumpUserGeneration() // #6404 — manual mutation invalidates in-flight AI streams
+      bumpUserGeneration() // issue 6404 — manual mutation invalidates in-flight AI streams
       setState((prev) => ({
         ...prev,
         assignments: prev.assignments.map((a) => {
@@ -790,7 +819,7 @@ Order phases by dependency — prerequisites first. Each phase completes before 
     }
 
   const setAssignment = (clusterName: string, projectName: string, assigned: boolean) => {
-      bumpUserGeneration() // #6404 — manual mutation invalidates in-flight AI streams
+      bumpUserGeneration() // issue 6404 — manual mutation invalidates in-flight AI streams
       setState((prev) => {
         const assignments = [...prev.assignments]
         const idx = assignments.findIndex((a) => a.clusterName === clusterName)
@@ -805,9 +834,14 @@ Order phases by dependency — prerequisites first. Each phase completes before 
                 : [...existing.projectNames, projectName]
               : existing.projectNames.filter((n) => n !== projectName) }
         } else if (assigned) {
+          // issue 6433 — capture server URL from the live cluster list so
+          // recreate-with-same-name scenarios (common with Kind) are
+          // detectable later by stale reconciliation.
+          const liveCluster = clusters?.find((c) => c.name === clusterName)
           assignments.push({
             clusterName,
-            clusterContext: clusterName,
+            clusterContext: liveCluster?.context ?? clusterName,
+            clusterServer: liveCluster?.server,
             provider: 'kubernetes',
             projectNames: [projectName],
             warnings: [],
@@ -882,7 +916,14 @@ Order phases by dependency — prerequisites first. Each phase completes before 
       ingress: ['nginx', 'traefik', 'haproxy', 'ingress-nginx'],
       'gatekeeper-system': ['opa', 'open-policy-agent', 'opa-gatekeeper'] }
 
-    // Build per-cluster name sets from helm releases
+    // issue 6428 — Build per-cluster name sets from actual Helm releases only.
+    // Previously we also added every namespace name on every cluster, which
+    // meant that creating an unrelated Deployment in a namespace called
+    // `tempo` would falsely mark the Tempo observability project as installed.
+    // Helm release `name` and normalized `chart` are strong signals (the
+    // release was actually deployed). Namespace names are NOT a signal —
+    // they only correlate when a project happens to use its own name as its
+    // default namespace, which is not guaranteed and routinely collides.
     const clusterNames = new Map<string, Set<string>>()
     helmReleases?.forEach(r => {
       const cName = r.cluster || '_unknown'
@@ -890,19 +931,28 @@ Order phases by dependency — prerequisites first. Each phase completes before 
       const names = clusterNames.get(cName)!
       names.add(r.name.toLowerCase())
       if (r.chart) names.add(r.chart.toLowerCase().replace(/-\d+.*$/, ''))
-      if (r.namespace) names.add(r.namespace.toLowerCase())
+      // Note: r.namespace intentionally NOT added. See issue 6428.
     })
 
-    // Add cluster namespaces + expand aliases
+    // issue 6428 — Alias expansion is still useful for operator-managed
+    // namespaces (a release named `kube-prometheus-stack` exposes prometheus,
+    // grafana, alertmanager). For each helm release whose namespace is a
+    // known shared-operator namespace, also add its aliased project names
+    // to that cluster's set. Plain cluster namespace lists no longer
+    // contribute to project detection.
+    helmReleases?.forEach(r => {
+      if (!r.namespace) return
+      const aliased = NS_ALIASES[r.namespace.toLowerCase()]
+      if (!aliased) return
+      const cName = r.cluster || '_unknown'
+      if (!clusterNames.has(cName)) clusterNames.set(cName, new Set())
+      const names = clusterNames.get(cName)!
+      aliased.forEach(a => names.add(a))
+    })
+
+    // Ensure every cluster has an entry (even if no releases)
     clusters?.forEach(c => {
       if (!clusterNames.has(c.name)) clusterNames.set(c.name, new Set())
-      const names = clusterNames.get(c.name)!
-      c.namespaces?.forEach(ns => {
-        const lower = ns.toLowerCase()
-        names.add(lower)
-        const aliased = NS_ALIASES[lower]
-        if (aliased) aliased.forEach(a => names.add(a))
-      })
     })
 
     // Match projects against each cluster's known names
@@ -940,7 +990,7 @@ Order phases by dependency — prerequisites first. Each phase completes before 
   // Auto-assign: deterministic local algorithm (no AI)
   // ---------------------------------------------------------------------------
 
-  const autoAssignProjects = (availableClusters: Array<{ name: string; context?: string; distribution?: string; cpuCores?: number; memoryGB?: number; storageGB?: number; cpuUsageCores?: number; cpuRequestsCores?: number; memoryUsageGB?: number; memoryRequestsGB?: number }>) => {
+  const autoAssignProjects = (availableClusters: Array<{ name: string; context?: string; server?: string; distribution?: string; cpuCores?: number; memoryGB?: number; storageGB?: number; cpuUsageCores?: number; cpuRequestsCores?: number; memoryUsageGB?: number; memoryRequestsGB?: number }>) => {
       if (availableClusters.length === 0 || state.projects.length === 0) return
 
       // Category groups — projects in the same group have affinity
@@ -997,7 +1047,7 @@ Order phases by dependency — prerequisites first. Each phase completes before 
           if (priority && !warnedUnknownPriorities.has(priority)) {
             warnedUnknownPriorities.add(priority)
             console.warn(
-              `[MissionControl] Unknown priority "${priority}" — treating as lowest (#6402)`,
+              `[MissionControl] Unknown priority "${priority}" — treating as lowest (issue 6402)`,
             )
           }
           return UNKNOWN_PRIORITY_RANK
@@ -1066,6 +1116,9 @@ Order phases by dependency — prerequisites first. Each phase completes before 
           return {
             clusterName: c.name,
             clusterContext: c.context ?? c.name,
+            // issue 6433 — capture server URL so recreate-with-same-name
+            // scenarios (common with Kind) can be detected at rehydration.
+            clusterServer: c.server,
             provider: c.distribution ?? 'kubernetes',
             projectNames: newAssignments.get(c.name) ?? [],
             warnings: existing?.warnings ?? [],

--- a/web/src/hooks/useDeployMissions.ts
+++ b/web/src/hooks/useDeployMissions.ts
@@ -183,6 +183,11 @@ export function useDeployMissions() {
   const pollRef = useRef<ReturnType<typeof setInterval>>(undefined)
   const missionsRef = useRef(missions)
   missionsRef.current = missions
+  // issue 6427 — track grace-window re-poll timeouts keyed by mission id
+  // so we can clear them on unmount and on the next regular poll cycle.
+  // Without this, a hook unmount inside the grace window would still fire
+  // `poll()` and call `setMissions` on a dead component.
+  const graceRepollsRef = useRef<Map<string, ReturnType<typeof setTimeout>>>(new Map())
 
   // Persist missions to localStorage
   useEffect(() => {
@@ -496,7 +501,13 @@ export function useDeployMissions() {
             const remaining = MIN_ACTIVE_MS - elapsed
             // Small fudge (50ms) so `elapsed` is definitely past MIN_ACTIVE_MS on re-entry
             const GRACE_REPOLL_FUDGE_MS = 50
-            setTimeout(() => {
+            // issue 6427 — clear any previously scheduled grace repoll for this
+            // mission (the regular poll may have already run once in between)
+            // and track the new handle so unmount cleanup can cancel it.
+            const existing = graceRepollsRef.current.get(mission.id)
+            if (existing) clearTimeout(existing)
+            const handle = setTimeout(() => {
+              graceRepollsRef.current.delete(mission.id)
               // Only re-poll if this mission still exists and is still non-terminal.
               // The regular interval may have already run by now, which is fine
               // — calling poll() again is idempotent.
@@ -505,6 +516,7 @@ export function useDeployMissions() {
                 poll()
               }
             }, remaining + GRACE_REPOLL_FUDGE_MS)
+            graceRepollsRef.current.set(mission.id, handle)
           }
 
           return {
@@ -541,9 +553,19 @@ export function useDeployMissions() {
       pollRef.current = setInterval(poll, POLL_INTERVAL_MS)
     }, 1000)
 
+    // issue 6427 — Snapshot the grace-repoll map reference inside the
+    // effect body so the cleanup closure uses a captured handle rather
+    // than reading `.current` at cleanup time (react-hooks/exhaustive-deps).
+    const graceRepolls = graceRepollsRef.current
     return () => {
       clearTimeout(initialTimeout)
       if (pollRef.current) clearInterval(pollRef.current)
+      // Cancel any outstanding grace-window re-polls so they don't fire
+      // on an unmounted hook and call setMissions on a dead tree.
+      for (const handle of graceRepolls.values()) {
+        clearTimeout(handle)
+      }
+      graceRepolls.clear()
     }
   }, []) // No dependencies - uses ref for current missions
 

--- a/web/src/hooks/useMissions.tsx
+++ b/web/src/hooks/useMissions.tsx
@@ -186,6 +186,15 @@ const MISSION_RECONNECT_DELAY_MS = 500
  * meeting gaps while still protecting against overnight reconnects.
  */
 const MISSION_RECONNECT_MAX_AGE_MS = 30 * 60 * 1000
+/**
+ * issue 6429 — Cap how many prior messages we re-append to the prompt on
+ * reconnect. Long-running missions can accumulate hundreds of turns; some
+ * agents (notably ones with 8k–32k token budgets) reject the payload
+ * outright with HTTP 413. We always keep the most recent
+ * MAX_RESENT_MESSAGES items (which always include the last user message
+ * that is re-sent separately) and drop anything older.
+ */
+const MAX_RESENT_MESSAGES = 20
 /** Initial delay (ms) before auto-reconnecting WebSocket after close */
 const WS_RECONNECT_INITIAL_DELAY_MS = 1_000
 /** Maximum delay (ms) between reconnection attempts (backoff cap) */
@@ -337,7 +346,17 @@ function loadMissions(): Mission[] {
       })
     }
   } catch (e) {
-    console.error('Failed to load missions from localStorage:', e)
+    // issue 6437 — If the persisted payload is unparseable (the previous
+    // saveMissions pass may have been interrupted mid-write, or quota
+    // pressure corrupted it), fully clear the key instead of leaving a
+    // broken entry that will keep crashing every load. The user loses
+    // their history, which is strictly better than an unusable app.
+    console.error('[Missions] Failed to parse kc_missions, clearing:', e)
+    try {
+      localStorage.removeItem(MISSIONS_STORAGE_KEY)
+    } catch {
+      // If removeItem itself throws (e.g., private mode), nothing we can do.
+    }
   }
 
   // In demo mode, seed with orbit demo missions so the feature is visible
@@ -806,12 +825,21 @@ export function MissionProvider({ children }: { children: ReactNode }) {
                   const requestId = `claude-reconnect-${Date.now()}-${mission.id}`
                   pendingRequests.current.set(requestId, mission.id)
 
-                  // Build history from all messages except system messages
-                  const history = mission.messages
+                  // Build history from all messages except system messages.
+                  // issue 6429 — Cap at MAX_RESENT_MESSAGES to avoid HTTP 413
+                  // against small-context agents. Keep the most recent items;
+                  // older turns are dropped with a warning.
+                  const fullHistory = mission.messages
                     .filter(msg => msg.role === 'user' || msg.role === 'assistant')
                     .map(msg => ({
                       role: msg.role,
                       content: msg.content }))
+                  const history = fullHistory.slice(-MAX_RESENT_MESSAGES)
+                  if (fullHistory.length > MAX_RESENT_MESSAGES) {
+                    console.warn(
+                      `[Missions] issue 6429 — truncated reconnect history from ${fullHistory.length} to ${MAX_RESENT_MESSAGES} messages to avoid oversized payload`,
+                    )
+                  }
 
                   const mId = mission.id
                   wsSend(JSON.stringify({


### PR DESCRIPTION
Fixes #6426
Fixes #6427
Fixes #6428
Fixes #6429
Fixes #6430
Fixes #6431
Fixes #6433
Fixes #6437

## Summary

Frontend-only wave covering 10 mission-control / useMissions items plus 2 Copilot followups on PR #6424 (filed as #6427) and the hex-color ratchet drift from #6431.

Three security-labeled items (#6432, #6434, #6435) and two "race" items (#6436, #6438) were verified against the current code and are **not fixed in this PR** because they do not reproduce — see "Security + race verification" below. One security item (#6434) is a real gap that requires backend refactoring beyond the scope of a frontend wave; it is flagged for a dedicated follow-up.

## Ratchet — #6431

The failing lines were all string literals / trailing-comment issue references like ``#6403`` being scored as hex colors by the scanner. Rewrote the 7 offending references in ``useMissionControl.ts`` to ``issue NNNN`` form (same workaround pattern used by PR #6413). Count drops from 310 to 304.

## Copilot followups on PR #6424 — #6427

- **useMissionControl.ts:325** — stale-cluster reconciliation now gates on ``!clustersLoading && clustersLastUpdated != null`` so the initial empty-while-loading render from ``useClusters()`` cannot wipe persisted assignments.
- **useDeployMissions.ts:503** — grace-window re-poll ``setTimeout``s are now tracked in a ``graceRepollsRef`` map keyed by mission id. Each new schedule clears any prior handle; the effect cleanup clears all outstanding handles so an unmount mid-grace cannot call ``poll()`` on a dead component.

## Wave 5 fixes

- **#6426 extractBalancedBlocks** — added an explicit forward-progress guard so any regression to the escape state machine breaks instead of spinning. New test covers heavy nested backslash escaping with a <100ms wall bound.
- **#6428 installed-project namespace collision** — previous code added every helm-release namespace AND every cluster namespace to the detection set, so an unrelated deployment in namespace ``tempo`` marked the Tempo project as installed. Detection now uses only the helm release ``name`` / normalized ``chart``, and the ``NS_ALIASES`` expansion scoped to helm releases in known shared-operator namespaces. Plain cluster namespace lists no longer contribute.
- **#6429 reconnect history saturation** — added ``MAX_RESENT_MESSAGES = 20`` constant and sliced the reconnect history so long-running missions no longer overflow small-context agents with an HTTP 413.
- **#6430 schema drift** — ``loadMissionPrompt`` now validates each step / troubleshooting item with a runtime type guard before dereferencing ``title`` / ``description``. Malformed items are dropped silently.
- **#6433 orphaned assignments (recreated Kind clusters)** — added optional ``clusterServer`` field to ``ClusterAssignment``, captured at auto-assign and manual-assign time from the live cluster list. Stale reconciliation now also drops assignments whose captured server URL differs from the currently-registered cluster's server.
- **#6437 localStorage quota recovery** — on load-time JSON parse failure, fully remove the ``kc_missions`` key instead of leaving a corrupted entry.

## Security + race verification

All verified against ``main`` (commit ``4098add``) before writing code.

### #6432 preflight bypass — NOT A BUG
``runPreflightCheck`` is awaited via a Promise chain at ``useMissions.tsx:1724``. The WebSocket send inside ``executeMission`` cannot run until the preflight Promise resolves. Page visibility does not bypass microtask-queue Promise chains — it delays them.

### #6434 dry-run privilege escalation — REAL GAP, DEFERRED
``params.dryRun`` at ``useMissions.tsx:1614`` **only** appends a DRY RUN MODE block to the prompt string. If the LLM ignores the instruction, the agent executes real commands. Closing this requires wrapping kubectl exec through a backend policy gate that rejects write operations when ``dryRun: true``. That is a substantial Go + agent-proxy refactor. **Not fixed here; flagged for a backend-only follow-up.**

### #6435 YAML arbitrary payload eval — NOT A BUG
Mission imports flow through ``yaml.load`` / ``yaml.loadAll`` from ``js-yaml`` (``DEFAULT_SAFE_SCHEMA`` — no custom tags, no code execution) and are validated by ``validateMissionExport``. There is no ``eval`` / ``new Function`` / template-literal substitution anywhere in the import path.

### #6436 deploy:started cross-tab clash — NOT A BUG
``useCardEvents`` is a plain React Context using an in-memory ``subscribersRef`` map. It does not use ``BroadcastChannel`` or ``storage`` events, so events do not cross the tab boundary.

### #6438 finalizeCancellation race — NOT A BUG
``handleAgentMessage`` at ``useMissions.tsx:1222`` already handles unknown request ids: ``if (!missionId) return``. A late packet after the map delete is a silent no-op.

## Test plan

- [x] ``cd web && npx vitest run`` on targeted files — **354 tests pass** (1 new test for #6426)
- [x] ``cd web && npm run build`` — clean
- [x] ``cd web && npx eslint`` on changed files — no new errors