### PR TITLE
fix(security): ShareToGitHub repo allowlist + sweeper architecture doc (#6439, #6440)

### DIFF
--- a/pkg/api/handlers/missions.go
+++ b/pkg/api/handlers/missions.go
@@ -8,6 +8,7 @@ import (
 	"log/slog"
 	"net/http"
 	"net/url"
+	"os"
 	"path"
 	"strings"
 	"sync"
@@ -74,6 +75,52 @@ const (
 	// small enough that a single process footprint stays predictable.
 	missionsCacheMaxBytes = 256 * 1024 * 1024 // 256 MiB
 )
+
+// missionsDefaultShareRepos is the built-in allowlist of repositories that
+// ShareToGitHub will create PRs against. Operators can extend this via the
+// KC_ALLOWED_SHARE_REPOS environment variable (comma-separated list of
+// `owner/repo` entries). #6439 — without an allowlist, a misbehaving client
+// could point the handler at any repository the user's PAT has write access
+// to, using the console's UI as a confused-deputy PR-creation service.
+// console-kb is the canonical destination because shared missions land in the
+// community mission library (the same repo GetMissionFile reads from).
+var missionsDefaultShareRepos = []string{
+	"kubestellar/console-kb",
+}
+
+// allowedShareRepoEnvVar is the environment variable name operators use to
+// extend the built-in share-repo allowlist at runtime without a code change.
+const allowedShareRepoEnvVar = "KC_ALLOWED_SHARE_REPOS"
+
+// resolveAllowedShareRepos returns the effective allowlist of `owner/repo`
+// destinations for ShareToGitHub. The built-in defaults are always included;
+// any entries from KC_ALLOWED_SHARE_REPOS are appended. Empty/whitespace
+// entries are ignored.
+func resolveAllowedShareRepos() []string {
+	allowed := make([]string, 0, len(missionsDefaultShareRepos)+1)
+	allowed = append(allowed, missionsDefaultShareRepos...)
+	if extra := os.Getenv(allowedShareRepoEnvVar); extra != "" {
+		for _, r := range strings.Split(extra, ",") {
+			r = strings.TrimSpace(r)
+			if r != "" {
+				allowed = append(allowed, r)
+			}
+		}
+	}
+	return allowed
+}
+
+// isRepoAllowedForShare reports whether the given `owner/repo` string is on
+// the effective ShareToGitHub allowlist. Comparison is exact (case-sensitive)
+// to match GitHub's own slug handling.
+func isRepoAllowedForShare(repo string) bool {
+	for _, allowed := range resolveAllowedShareRepos() {
+		if repo == allowed {
+			return true
+		}
+	}
+	return false
+}
 
 // missionsCacheEntry holds a cached GitHub API response (directory listing or file content).
 type missionsCacheEntry struct {
@@ -765,6 +812,19 @@ func (h *MissionsHandler) ShareToGitHub(c *fiber.Ctx) error {
 	}
 	if req.Repo == "" || req.FilePath == "" || req.Content == "" || req.Branch == "" {
 		return c.Status(400).JSON(fiber.Map{"error": "repo, filePath, content, and branch are required"})
+	}
+
+	// SECURITY #6439 — Enforce an allowlist on req.Repo. Without this, a
+	// misbehaving client could supply any owner/repo value and use the
+	// handler as a confused-deputy PR-creation service against whatever
+	// repositories the caller's PAT can write to. The default allowlist
+	// contains only `kubestellar/console-kb` (the canonical destination for
+	// shared missions); operators can append more via KC_ALLOWED_SHARE_REPOS.
+	if !isRepoAllowedForShare(req.Repo) {
+		return c.Status(400).JSON(fiber.Map{
+			"error":         "repo is not on the share allowlist",
+			"allowed_repos": resolveAllowedShareRepos(),
+		})
 	}
 
 	// SECURITY: Validate path and branch to prevent traversal/injection

--- a/pkg/api/handlers/missions_test.go
+++ b/pkg/api/handlers/missions_test.go
@@ -207,7 +207,7 @@ func TestMissions_ShareToSlack_InvalidWebhook(t *testing.T) {
 func TestMissions_ShareToGitHub_NoToken(t *testing.T) {
 	app, _ := setupMissionsTest()
 
-	payload := `{"repo":"kubestellar/console","filePath":"missions/test.yaml","content":"dGVzdA==","branch":"mission-test","message":"add mission"}`
+	payload := `{"repo":"kubestellar/console-kb","filePath":"missions/test.yaml","content":"dGVzdA==","branch":"mission-test","message":"add mission"}`
 	req, err := http.NewRequest("POST", "/api/missions/share/github", strings.NewReader(payload))
 	require.NoError(t, err)
 	req.Header.Set("Content-Type", "application/json")
@@ -215,6 +215,47 @@ func TestMissions_ShareToGitHub_NoToken(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, resp)
 	assert.Equal(t, http.StatusUnauthorized, resp.StatusCode)
+}
+
+// #6439 — ShareToGitHub must reject any repo not on the allowlist with 400.
+// Without this guard, a misbehaving client could use the handler as a
+// confused-deputy PR-creation service against any repository the caller's
+// PAT can write to.
+func TestMissions_ShareToGitHub_RepoNotAllowed(t *testing.T) {
+	app, _ := setupMissionsTest()
+
+	// A private repo the user might have a PAT for but that is NOT on the
+	// console's share allowlist. The handler must reject BEFORE making any
+	// GitHub API calls.
+	payload := `{"repo":"kubestellar/private-repo","filePath":"missions/test.yaml","content":"dGVzdA==","branch":"mission-test","message":"add mission"}`
+	req, err := http.NewRequest("POST", "/api/missions/share/github", strings.NewReader(payload))
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-GitHub-Token", "ghp_test123")
+	resp, err := app.Test(req, 5000)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+
+	var body map[string]interface{}
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&body))
+	assert.Contains(t, body["error"], "allowlist")
+}
+
+// #6439 — KC_ALLOWED_SHARE_REPOS env var lets operators extend the allowlist
+// at runtime without a code change. A repo added via the env var must pass
+// the allowlist check.
+func TestMissions_ShareToGitHub_AllowlistEnvVarExtension(t *testing.T) {
+	t.Setenv(allowedShareRepoEnvVar, "myorg/my-missions, anotherorg/repo")
+
+	// Defaults still work.
+	assert.True(t, isRepoAllowedForShare("kubestellar/console-kb"))
+	// Env-var entries work.
+	assert.True(t, isRepoAllowedForShare("myorg/my-missions"))
+	assert.True(t, isRepoAllowedForShare("anotherorg/repo"))
+	// Anything else is rejected.
+	assert.False(t, isRepoAllowedForShare("kubestellar/private-repo"))
+	assert.False(t, isRepoAllowedForShare("myorg/other-repo"))
 }
 
 func TestMissions_ShareToGitHub_Success(t *testing.T) {
@@ -256,7 +297,7 @@ func TestMissions_ShareToGitHub_Success(t *testing.T) {
 	app, handler := setupMissionsTest()
 	handler.githubAPIURL = mock.URL
 
-	payload := `{"repo":"kubestellar/console","filePath":"missions/test.yaml","content":"dGVzdA==","branch":"mission-test","message":"add mission"}`
+	payload := `{"repo":"kubestellar/console-kb","filePath":"missions/test.yaml","content":"dGVzdA==","branch":"mission-test","message":"add mission"}`
 	req, err := http.NewRequest("POST", "/api/missions/share/github", strings.NewReader(payload))
 	require.NoError(t, err)
 	req.Header.Set("Content-Type", "application/json")

--- a/web/src/hooks/useMissions.tsx
+++ b/web/src/hooks/useMissions.tsx
@@ -960,6 +960,16 @@ The WebSocket connection to the agent at \`${LOCAL_AGENT_WS_URL}\` was lost and 
         }
 
         wsRef.current.onerror = () => {
+          // #6440 — Architecture note for future readers who wonder why this
+          // sweeper doesn't filter by `agentId`: the console uses a SINGLE
+          // WebSocket connection to a SINGLE kc-agent process. There is no
+          // per-agent sub-connection and no `agentId` field on Mission
+          // objects. When this WS errors, by definition every in-flight
+          // mission on it is affected, so scoping the sweep by pending
+          // request (done below since #5851) is the correct granularity.
+          // If the backend ever grows a true multi-agent fan-out, the sweep
+          // must be re-scoped by agent — but until then, narrowing further
+          // would be incorrect, not safer.
           clearTimeout(timeout)
           // Forcibly close the socket and clear the ref to prevent zombie
           // connections. Nullify onclose first so the close doesn't trigger


### PR DESCRIPTION
Fixes #6439

## #6439 — ShareToGitHub repo allowlist (security)

**Finding**: The original bug report described a confused-deputy risk with an "org-scoped PAT", but the handler actually uses the caller's own `X-GitHub-Token`, so there is no server-side privilege escalation. However, the handler still had no allowlist on `req.Repo`, which means a misbehaving client could use the console as a PR-creation service against any repository the caller's PAT can write to. Worth fixing as defense-in-depth.

**Fix**:
- New `missionsDefaultShareRepos` allowlist (default: `kubestellar/console-kb`).
- Operators can extend via `KC_ALLOWED_SHARE_REPOS` env var.
- `ShareToGitHub` rejects non-allowlisted repos with `400 Bad Request` before any GitHub API call.
- New unit tests: `TestMissions_ShareToGitHub_RepoNotAllowed` and `TestMissions_ShareToGitHub_AllowlistEnvVarExtension`.

## #6440 — Sweeper architecture doc (not-a-bug)

**Finding**: The reported flaw does not exist:
1. No multi-agent architecture — no `agentId` field on `Mission` objects. Single WS to a single kc-agent.
2. The sweeper was already narrowed in #5851 — it only operates on `pendingRequests`, not all running missions.

**What I did**: Added a doc comment at the top of the `onerror` handler explaining the single-WS architecture so future readers do not re-raise the same concern. No behavioral change. Not claiming to fix #6440.

## Files changed

- `pkg/api/handlers/missions.go`
- `pkg/api/handlers/missions_test.go`
- `web/src/hooks/useMissions.tsx`

## Verification

- `go build ./...` pass
- `go test ./pkg/api/handlers/... -run TestMissions_ShareToGitHub` pass
- `cd web && npm run build` pass
- Lint: no new errors introduced