### PR TITLE
fix: wave6b — Copilot followups + security posture + topology SWR + data-testids (#6443-#6450)

### DIFF
--- a/web/src/components/cards/kagent/KagentTopology.tsx
+++ b/web/src/components/cards/kagent/KagentTopology.tsx
@@ -140,7 +140,14 @@ function KagentTopologyInternal({ config }: { config?: Record<string, unknown> }
     return { nodes: nodesArr, edges: edgesArr }
   }, [agents, tools, models])
 
-  if (agentsLoading || toolsLoading || modelsLoading) {
+  // issue 6448 — Stale-while-revalidate: only show the blocking skeleton on
+  // the initial load. Once we have data cached, a background refresh should
+  // keep rendering the cached topology (the cache-level demo/refresh
+  // indicator already communicates that data is updating). Previously this
+  // unconditionally showed the skeleton on any hook `isLoading`, which
+  // hid the cached view during every refresh tick.
+  const anyLoading = agentsLoading || toolsLoading || modelsLoading
+  if (anyLoading && !hasData) {
     return (
       <div className="h-full flex flex-col min-h-card p-4 animate-pulse">
         <div className="flex-1 bg-secondary rounded-lg" />

--- a/web/src/components/cards/kagenti/KagentiSecurity.tsx
+++ b/web/src/components/cards/kagenti/KagentiSecurity.tsx
@@ -75,7 +75,10 @@ export function KagentiSecurity({ config }: { config?: Record<string, unknown> }
           </div>
           <div className="space-y-1">
             {unboundAgents.map((agent: KagentiCard) => (
-              <div key={`${agent.cluster}-${agent.name}`} className="flex items-center justify-between text-xs py-1 px-2 rounded bg-red-400/5 border border-red-400/10">
+              // issue 6449 — include namespace in the React key to avoid
+              // collisions when two cards share the same name across
+              // namespaces on the same cluster.
+              <div key={`${agent.cluster}:${agent.namespace}:${agent.name}`} className="flex items-center justify-between text-xs py-1 px-2 rounded bg-red-400/5 border border-red-400/10">
                 <div className="flex items-center gap-1.5">
                   <ShieldAlert className="w-3 h-3 text-red-400" />
                   <span className="text-foreground">{agent.agentName}</span>

--- a/web/src/components/cards/kagenti/KagentiSecurityPosture.tsx
+++ b/web/src/components/cards/kagenti/KagentiSecurityPosture.tsx
@@ -9,41 +9,62 @@ interface KagentiSecurityPostureProps {
   config?: { cluster?: string }
 }
 
+// issue 6446 — `identityBinding` is a string enum (`'strict' | 'permissive'
+// | 'none'`). Treating any truthy string as "bound" inflates the count
+// because the sentinel value `'none'` is truthy. Only these values count
+// as "bound". Hoisted to module scope so the useMemo dep array stays
+// stable.
+const BOUND_IDENTITY_STATES = new Set(['strict', 'permissive'])
+
 export function KagentiSecurityPosture({ config }: KagentiSecurityPostureProps) {
   const { isDemoMode } = useDemoMode()
   const {
     data: cards,
     isLoading: cardsLoading,
     consecutiveFailures: cardFailures,
+    isDemoFallback: cardsDemoFallback,
   } = useKagentiCards({ cluster: config?.cluster })
 
   const {
     data: agents,
     isLoading: agentsLoading,
     consecutiveFailures: agentFailures,
+    isDemoFallback: agentsDemoFallback,
   } = useKagentiAgents({ cluster: config?.cluster })
 
   const {
     data: tools,
     isLoading: toolsLoading,
     consecutiveFailures: toolFailures,
+    isDemoFallback: toolsDemoFallback,
   } = useKagentiTools({ cluster: config?.cluster })
 
   const isLoading = cardsLoading || agentsLoading || toolsLoading
   const hasAnyData = cards.length > 0 || agents.length > 0 || tools.length > 0
   const maxFailures = Math.max(cardFailures, agentFailures, toolFailures)
 
+  // issue 6447 — Demo state must reflect BOTH global demo mode AND any
+  // per-hook demo fallback (the card shows fallback demo data when the
+  // backend is unreachable). Before this fix, the yellow outline / Demo
+  // badge was missing whenever the global demo mode was off but one of
+  // the hooks had fallen back to demo data. See
+  // memory/console-isDemoData-wiring.md for the canonical pattern.
+  const anyDemoFallback =
+    cardsDemoFallback || agentsDemoFallback || toolsDemoFallback
+
   const { showSkeleton, showEmptyState } = useCardLoadingState({
     isLoading,
     hasAnyData,
     isFailed: maxFailures >= 3,
     consecutiveFailures: maxFailures,
-    isDemoData: isDemoMode,
+    isDemoData: isDemoMode || anyDemoFallback,
   })
 
   const security = useMemo(() => {
-    const boundCards = cards.filter(c => c.identityBinding)
-    const unboundCards = cards.filter(c => !c.identityBinding)
+    const isBound = (v: string | undefined) =>
+      !!v && BOUND_IDENTITY_STATES.has(v)
+    const boundCards = cards.filter(c => isBound(c.identityBinding))
+    const unboundCards = cards.filter(c => !isBound(c.identityBinding))
     const credentialedTools = tools.filter(t => t.hasCredential)
     const uncredentialedTools = tools.filter(t => !t.hasCredential)
 

--- a/web/src/components/mission-control/ClusterAssignmentPanel.tsx
+++ b/web/src/components/mission-control/ClusterAssignmentPanel.tsx
@@ -270,6 +270,7 @@ export function ClusterAssignmentPanel({
           <Button
             variant="secondary"
             size="sm"
+            data-testid="mission-control-ask-ai"
             onClick={handleAISuggest}
             disabled={aiStreaming || healthyClusters.length === 0}
             icon={
@@ -335,8 +336,8 @@ export function ClusterAssignmentPanel({
                       ] }
                   : aiAssignment
                 return (
+                <div key={cluster.name} data-testid={`mission-control-cluster-${cluster.name}`}>
                 <ClusterReadinessCard
-                  key={cluster.name}
                   cluster={cluster}
                   assignment={mergedAssignment}
                   onToggleProject={(name, assigned) =>
@@ -348,6 +349,7 @@ export function ClusterAssignmentPanel({
                   )}
                   installedOnCluster={installedOnCluster}
                 />
+                </div>
                 )
               })}
             </div>

--- a/web/src/components/mission-control/LaunchSequence.tsx
+++ b/web/src/components/mission-control/LaunchSequence.tsx
@@ -450,6 +450,7 @@ export function LaunchSequence({
                   <Button
                     variant="secondary"
                     size="sm"
+                    data-testid="mission-control-retry"
                     className="h-6 text-xs"
                     icon={<RotateCcw className="w-3 h-3" />}
                     onClick={() => {

--- a/web/src/components/mission-control/MissionControlDialog.tsx
+++ b/web/src/components/mission-control/MissionControlDialog.tsx
@@ -170,6 +170,7 @@ export function MissionControlDialog({ open, onClose }: MissionControlDialogProp
             role="dialog"
             aria-modal="true"
             aria-label={state.title || 'Mission Control'}
+            data-testid="mission-control-dialog"
             className="fixed z-modal flex flex-col bg-background rounded-xl border border-border shadow-2xl shadow-black/30 overflow-hidden"
             style={{
               inset: `${MODAL_INSET_PX}px`,
@@ -222,6 +223,7 @@ export function MissionControlDialog({ open, onClose }: MissionControlDialogProp
                         <ChevronRight className="w-3 h-3 text-muted-foreground/40 mx-1" />
                       )}
                       <button
+                        data-testid={`mission-control-phase-${i + 1}`}
                         onClick={() => {
                           if (i <= highestReached && !isLaunchOrComplete) mc.setPhase(step.key)
                         }}
@@ -276,6 +278,7 @@ export function MissionControlDialog({ open, onClose }: MissionControlDialogProp
                   variant="ghost"
                   size="sm"
                   onClick={onClose}
+                  data-testid="mission-control-cancel"
                   className="p-1.5 hover:bg-destructive/10 hover:text-destructive"
                   aria-label="Close Mission Control"
                   title="Close (Esc)"
@@ -413,6 +416,7 @@ export function MissionControlDialog({ open, onClose }: MissionControlDialogProp
                       <Button
                         variant="primary"
                         size="sm"
+                        data-testid="mission-control-launch"
                         onClick={() => {
                           mc.setDryRun(false)
                           mc.setPhase('launching')

--- a/web/src/components/mission-control/__tests__/useMissionControl.test.tsx
+++ b/web/src/components/mission-control/__tests__/useMissionControl.test.tsx
@@ -119,19 +119,21 @@ describe('extractJSON — balanced block extraction (#6382)', () => {
   // issue 6426 — heavy nested backslash escaping should neither hang nor
   // lose characters. The original concern was that `inString` tracking
   // could get confused by sequences like `\\\\` followed by `\\"`.
-  it('handles heavy nested backslash escaping without looping', () => {
+  //
+  // issue 6444(D) — Previously this test asserted `< 100ms` wall-clock
+  // runtime as an infinite-loop guard. That is flaky under CI load. The
+  // vitest default timeout (5s) already catches a true infinite loop,
+  // so we replace the time gate with structural assertions on the parse
+  // result.
+  it('handles heavy nested backslash escaping without losing characters', () => {
     // Construct a JSON string whose `reason` field contains escaped
     // backslashes followed by escaped quotes. In the raw JSON text this
     // is `"reason": "path\\with\\quotes: \"x\""` — JS source escapes
     // each backslash and quote one more level.
     const text =
       '{"reason": "path\\\\with\\\\quotes: \\"x\\"", "name": "falco"}'
-    const start = Date.now()
     const parsed = extractJSON<{ reason: string; name: string }>(text)
-    // Hard upper bound: this should complete in well under 100ms. If the
-    // state machine ever regresses to an infinite loop, vitest's per-test
-    // timeout will fire; this assertion adds a tighter local gate.
-    expect(Date.now() - start).toBeLessThan(100)
+    expect(parsed).not.toBeNull()
     expect(parsed?.name).toBe('falco')
     expect(parsed?.reason).toBe('path\\with\\quotes: "x"')
   })

--- a/web/src/components/mission-control/svg/ProjectNode.tsx
+++ b/web/src/components/mission-control/svg/ProjectNode.tsx
@@ -152,6 +152,7 @@ export function ProjectNode({
   return (
     <motion.g
       ref={dragRef}
+      data-testid={`mission-control-project-${name}`}
       initial={{ scale: 0, opacity: 0 }}
       animate={{ scale: 1, opacity: dimmed ? 0.15 : glow ? 1 : overlayDim }}
       transition={{

--- a/web/src/components/mission-control/useMissionControl.ts
+++ b/web/src/components/mission-control/useMissionControl.ts
@@ -278,7 +278,15 @@ function extractBalancedBlocks(text: string): string[] {
       }
       if (j <= jStart) {
         // Forward progress invariant violated — bail to avoid any chance
-        // of an infinite loop. Should be unreachable.
+        // of an infinite loop. Should be unreachable, but log a warning
+        // (#6444 item C) with a snippet of the offending input so future
+        // debugging can detect that this guard tripped.
+        const snippetStart = Math.max(0, i - 20)
+        const snippetEnd = Math.min(text.length, j + 20)
+        console.warn(
+          `[useMissionControl] extractBalancedBlocks: forward-progress guard tripped at i=${i}, j=${j}, ch=${ch}. ` +
+          `Input snippet: ${JSON.stringify(text.slice(snippetStart, snippetEnd))}`,
+        )
         break
       }
     }
@@ -934,12 +942,18 @@ Order phases by dependency — prerequisites first. Each phase completes before 
       // Note: r.namespace intentionally NOT added. See issue 6428.
     })
 
-    // issue 6428 — Alias expansion is still useful for operator-managed
+    // issue 6428 / 6444(B) — Alias expansion is useful for operator-managed
     // namespaces (a release named `kube-prometheus-stack` exposes prometheus,
-    // grafana, alertmanager). For each helm release whose namespace is a
-    // known shared-operator namespace, also add its aliased project names
-    // to that cluster's set. Plain cluster namespace lists no longer
-    // contribute to project detection.
+    // grafana, alertmanager). But we must NOT mark every aliased project as
+    // installed just because the namespace matches — that's what tripped
+    // Copilot's review on #6441. For example, a release named
+    // `loki` in namespace `monitoring` should not imply `grafana` is
+    // installed.
+    //
+    // Policy: an alias is added ONLY if we have actual evidence (release
+    // name or chart name) that contains the alias token as a substring.
+    // The namespace is treated as a disambiguation hint, not a license to
+    // expand unconditionally.
     helmReleases?.forEach(r => {
       if (!r.namespace) return
       const aliased = NS_ALIASES[r.namespace.toLowerCase()]
@@ -947,7 +961,18 @@ Order phases by dependency — prerequisites first. Each phase completes before 
       const cName = r.cluster || '_unknown'
       if (!clusterNames.has(cName)) clusterNames.set(cName, new Set())
       const names = clusterNames.get(cName)!
-      aliased.forEach(a => names.add(a))
+      const releaseName = (r.name || '').toLowerCase()
+      const chartName = (r.chart || '').toLowerCase()
+      aliased.forEach(a => {
+        // Only expand the alias if the release or chart actually references
+        // it. This turns "monitoring namespace" from a blanket claim into a
+        // disambiguation hint: kube-prometheus-stack → prometheus, grafana,
+        // alertmanager (all substring-matched), but a plain `loki` release
+        // does not pull in prometheus/grafana.
+        if (releaseName.includes(a) || chartName.includes(a)) {
+          names.add(a)
+        }
+      })
     })
 
     // Ensure every cluster has an entry (even if no releases)

--- a/web/src/hooks/useMissions.tsx
+++ b/web/src/hooks/useMissions.tsx
@@ -829,15 +829,33 @@ export function MissionProvider({ children }: { children: ReactNode }) {
                   // issue 6429 — Cap at MAX_RESENT_MESSAGES to avoid HTTP 413
                   // against small-context agents. Keep the most recent items;
                   // older turns are dropped with a warning.
+                  //
+                  // issue 6444(A) — Backends (see pkg/agent/provider_claudecode.go
+                  // buildPromptWithHistory) concatenate `history` then append
+                  // `prompt`. If the last user message is included in BOTH
+                  // `history` and `prompt`, it's seen twice by the model.
+                  // Exclude the trailing user turn from `history` so `prompt`
+                  // is the single source of truth for the new message.
                   const fullHistory = mission.messages
                     .filter(msg => msg.role === 'user' || msg.role === 'assistant')
                     .map(msg => ({
                       role: msg.role,
                       content: msg.content }))
-                  const history = fullHistory.slice(-MAX_RESENT_MESSAGES)
-                  if (fullHistory.length > MAX_RESENT_MESSAGES) {
+                  // Drop the trailing user message if it matches the one being
+                  // re-sent as `prompt` (it is, by construction, since we took
+                  // the last user message from the same list).
+                  const historyWithoutLastUser = (() => {
+                    for (let i = fullHistory.length - 1; i >= 0; i--) {
+                      if (fullHistory[i].role === 'user') {
+                        return [...fullHistory.slice(0, i), ...fullHistory.slice(i + 1)]
+                      }
+                    }
+                    return fullHistory
+                  })()
+                  const history = historyWithoutLastUser.slice(-MAX_RESENT_MESSAGES)
+                  if (historyWithoutLastUser.length > MAX_RESENT_MESSAGES) {
                     console.warn(
-                      `[Missions] issue 6429 — truncated reconnect history from ${fullHistory.length} to ${MAX_RESENT_MESSAGES} messages to avoid oversized payload`,
+                      `[Missions] issue 6429 — truncated reconnect history from ${historyWithoutLastUser.length} to ${MAX_RESENT_MESSAGES} messages to avoid oversized payload`,
                     )
                   }
 


### PR DESCRIPTION
Fixes #6443
Fixes #6444
Fixes #6446
Fixes #6447
Fixes #6448
Fixes #6449
Fixes #6450

Batch fix for wave6b feedback. One PR covers seven items.

## Summary

- **#6443** — ui-ux-standards hex-color ratchet: passes cleanly on fresh main (already resolved by the #6445 merge). No code change; flagged as transient.
- **#6444** — 4 Copilot review comments on #6441:
  - **(A)** `useMissions.tsx` reconnect payload: drop the trailing user message from `history` so backends that concatenate `history + prompt` (see `pkg/agent/provider_claudecode.go` `buildPromptWithHistory`) do not see the re-sent user message twice.
  - **(B)** `useMissionControl.ts` NS_ALIASES: only expand a namespace alias when the release's `name` or `chart` actually references the alias token. A plain `loki` release in `monitoring` no longer implies prometheus/grafana/alertmanager are installed — the namespace is now a disambiguation hint, not a blanket expansion.
  - **(C)** `useMissionControl.ts` `extractBalancedBlocks` forward-progress guard: log a `console.warn` with a snippet of the offending input if the guard trips, so future debugging is not silent.
  - **(D)** `useMissionControl.test.tsx`: replace the flaky `< 100ms` wall-clock assertion with structural parse-result assertions. vitest's default 5s per-test timeout already catches a true infinite loop.
- **#6446** — `KagentiSecurityPosture` treated any non-empty `identityBinding` (including the sentinel value `'none'`) as bound. Use an explicit `BOUND_IDENTITY_STATES` allowlist (`strict`, `permissive`).
- **#6447** — `KagentiSecurityPosture` did not wire per-hook `isDemoFallback` into `useCardLoadingState`, so the Demo badge and yellow outline disappeared whenever a kagenti hook fell back to demo data while global demo mode was off. Now propagates `isDemoFallback` from all three hooks.
- **#6448** — `KagentTopology` unconditionally returned the blocking skeleton whenever any underlying hook reported `isLoading`, hiding cached data on every refresh tick. Only show the skeleton when \`!hasData && isLoading\`.
- **#6449** — `KagentiSecurity` unbound-agents list used \`cluster + name\` as the React key, which collides when two agent cards share a name across namespaces in the same cluster. Key now includes namespace.
- **#6450** — Added `data-testid` attributes to the key Mission Control interactive / identifiable elements so e2e tests can select them stably: \`mission-control-dialog\`, \`mission-control-phase-{1..3}\`, \`mission-control-ask-ai\`, \`mission-control-launch\`, \`mission-control-cancel\`, \`mission-control-retry\`, \`mission-control-project-{name}\`, \`mission-control-cluster-{name}\`.

## Files changed

- `web/src/hooks/useMissions.tsx`
- `web/src/components/mission-control/useMissionControl.ts`
- `web/src/components/mission-control/__tests__/useMissionControl.test.tsx`
- `web/src/components/mission-control/MissionControlDialog.tsx`
- `web/src/components/mission-control/ClusterAssignmentPanel.tsx`
- `web/src/components/mission-control/LaunchSequence.tsx`
- `web/src/components/mission-control/svg/ProjectNode.tsx`
- `web/src/components/cards/kagent/KagentTopology.tsx`
- `web/src/components/cards/kagenti/KagentiSecurity.tsx`
- `web/src/components/cards/kagenti/KagentiSecurityPosture.tsx`

## Verification

- `npm run build` — passes (post-build safety checks green)
- `npx vitest run` on `ui-ux-standards.test.ts`, `useMissionControl.test.tsx`, `KagentiSecurity.test.tsx`, `KagentiSecurityPosture.test.tsx` — 23/23 passing
- `npm run lint` — no NEW errors introduced; pre-existing repo-wide errors/warnings unchanged

## Notes

- #6443 was included at the request of the reporter but is a not-a-bug on fresh `main`. If it recurs, please reopen with the specific file path that tripped the ratchet.
- The reconnect-history fix (6444 A) preserves the existing `MAX_RESENT_MESSAGES` cap and warning.