### PR TITLE
fix: testing infra — real mission coverage, port alignment, allowlist case-fold (#6451, #6452, #6453)

### DIFF
--- a/pkg/api/handlers/missions.go
+++ b/pkg/api/handlers/missions.go
@@ -111,11 +111,30 @@ func resolveAllowedShareRepos() []string {
 }
 
 // isRepoAllowedForShare reports whether the given `owner/repo` string is on
-// the effective ShareToGitHub allowlist. Comparison is exact (case-sensitive)
-// to match GitHub's own slug handling.
+// the effective ShareToGitHub allowlist.
+//
+// #6453(B) — Comparison is case-INSENSITIVE. GitHub itself treats owner/repo
+// slugs as case-insensitive in both URLs and API calls, so we do the same here
+// to be forgiving of operator casing in KC_ALLOWED_SHARE_REPOS (e.g. a value
+// of `Kubestellar/Console-KB` will still match a request for
+// `kubestellar/console-kb`). Previously the check was exact-match, which was
+// stricter than GitHub's own handling and caused spurious 400s. See also
+// isRepoAllowedForShareWithList for the path that avoids re-parsing the env
+// var on every call.
 func isRepoAllowedForShare(repo string) bool {
-	for _, allowed := range resolveAllowedShareRepos() {
-		if repo == allowed {
+	return isRepoAllowedForShareWithList(repo, resolveAllowedShareRepos())
+}
+
+// isRepoAllowedForShareWithList is the inner, list-accepting form of
+// isRepoAllowedForShare. #6453(A) — ShareToGitHub resolves the allowlist once
+// per request and passes it through to this function for the membership check
+// AND for the error-response payload, avoiding a double call to
+// resolveAllowedShareRepos() (which re-parses KC_ALLOWED_SHARE_REPOS and could
+// observe a different value between calls if the env changes mid-request).
+func isRepoAllowedForShareWithList(repo string, allowed []string) bool {
+	repoLower := strings.ToLower(repo)
+	for _, a := range allowed {
+		if repoLower == strings.ToLower(a) {
 			return true
 		}
 	}
@@ -820,10 +839,18 @@ func (h *MissionsHandler) ShareToGitHub(c *fiber.Ctx) error {
 	// repositories the caller's PAT can write to. The default allowlist
 	// contains only `kubestellar/console-kb` (the canonical destination for
 	// shared missions); operators can append more via KC_ALLOWED_SHARE_REPOS.
-	if !isRepoAllowedForShare(req.Repo) {
+	//
+	// #6453(A) — Resolve the allowlist exactly ONCE per request and reuse it
+	// for both the membership check and the error-response payload. The
+	// previous version called resolveAllowedShareRepos() twice on the reject
+	// path, duplicating env parsing and creating a small race window where
+	// the error message could disagree with the check if KC_ALLOWED_SHARE_REPOS
+	// changed between the two calls.
+	allowedShareRepos := resolveAllowedShareRepos()
+	if !isRepoAllowedForShareWithList(req.Repo, allowedShareRepos) {
 		return c.Status(400).JSON(fiber.Map{
 			"error":         "repo is not on the share allowlist",
-			"allowed_repos": resolveAllowedShareRepos(),
+			"allowed_repos": allowedShareRepos,
 		})
 	}
 

--- a/pkg/api/handlers/missions_test.go
+++ b/pkg/api/handlers/missions_test.go
@@ -258,6 +258,26 @@ func TestMissions_ShareToGitHub_AllowlistEnvVarExtension(t *testing.T) {
 	assert.False(t, isRepoAllowedForShare("myorg/other-repo"))
 }
 
+// #6453(B) — Allowlist comparison must be case-insensitive. GitHub treats
+// owner/repo slugs as case-insensitive in URLs and API calls, so a request
+// for `Kubestellar/Console-KB` must match the default entry
+// `kubestellar/console-kb`. The previous exact-match check rejected this
+// (stricter than GitHub itself) and produced spurious 400s.
+func TestMissions_ShareToGitHub_AllowlistIsCaseInsensitive(t *testing.T) {
+	// Mixed-case request, lower-case allowlist entry — must match.
+	assert.True(t, isRepoAllowedForShare("Kubestellar/Console-KB"))
+	assert.True(t, isRepoAllowedForShare("KUBESTELLAR/CONSOLE-KB"))
+	assert.True(t, isRepoAllowedForShare("kubestellar/console-kb"))
+
+	// The reverse direction — upper-case env var entry, lower-case request.
+	t.Setenv(allowedShareRepoEnvVar, "MyOrg/My-Missions")
+	assert.True(t, isRepoAllowedForShare("myorg/my-missions"))
+	assert.True(t, isRepoAllowedForShare("MYORG/MY-MISSIONS"))
+
+	// Non-members are still rejected regardless of casing.
+	assert.False(t, isRepoAllowedForShare("Attacker/Evil-Repo"))
+}
+
 func TestMissions_ShareToGitHub_Success(t *testing.T) {
 	requestLog := map[string]int{}
 	mock := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/web/e2e/Missions.spec.ts
+++ b/web/e2e/Missions.spec.ts
@@ -1,8 +1,31 @@
 import { test, expect, Page } from '@playwright/test'
 
 /**
- * Sets up authentication and MCP mocks for missions tests
+ * Missions.spec.ts — E2E coverage for the AI Missions (Mission Control) feature.
+ *
+ * History: This file previously contained only dashboard-UI smoke tests
+ * (page title, cards grid, refresh button, viewport sizing) that matched the
+ * coverage already in Dashboard.spec.ts. Despite the "AI Missions" describe
+ * block, NONE of the old tests exercised any mission-related behavior, so
+ * #6451 flagged the file as dead coverage.
+ *
+ * This version replaces the dashboard smoke tests with real mission checks:
+ *   1. Mission Control dialog can be opened via the ?mission-control=open URL param
+ *      and renders with the correct role/label.
+ *   2. The dialog has a working close control (verifies the dialog is interactive,
+ *      not just painted into the DOM).
+ *   3. At least one mission project card renders when the missions browser is opened
+ *      via the ?browse=missions URL param (Phase 1 project cards).
+ *
+ * TODO(#6450): Once wave6b lands the `data-testid="mission-control-*"` attributes
+ * on MissionControlDialog and project cards, switch the role/name queries below
+ * to getByTestId() for stability. Tracking: https://github.com/kubestellar/console/issues/6450
  */
+
+// Test timing constants — Playwright defaults shadowed here so the intent is explicit.
+const DIALOG_VISIBLE_TIMEOUT_MS = 10_000 // dialogs open async after route hydration
+const CONTROL_VISIBLE_TIMEOUT_MS = 5_000 // interactive controls render after dialog open
+
 async function setupMissionsTest(page: Page) {
   // Mock authentication
   await page.route('**/api/me', (route) =>
@@ -19,7 +42,8 @@ async function setupMissionsTest(page: Page) {
     })
   )
 
-  // Mock MCP endpoints
+  // Mock MCP endpoints — return empty-ish data so mission-control panels don't
+  // error out trying to load cluster/pod state.
   await page.route('**/api/mcp/**', (route) => {
     const url = route.request().url()
     if (url.includes('/clusters')) {
@@ -51,7 +75,17 @@ async function setupMissionsTest(page: Page) {
     }
   })
 
-  // Mock local agent
+  // Mock GitHub mission listings used by the missions browser. An empty list
+  // is fine for the dialog-renders test; the project-card test overrides this.
+  await page.route('**/api/missions/list**', (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ items: [] }),
+    })
+  )
+
+  // Mock local agent so it does not block the dialog mount.
   await page.route('**/127.0.0.1:8585/**', (route) =>
     route.fulfill({
       status: 200,
@@ -60,15 +94,12 @@ async function setupMissionsTest(page: Page) {
     })
   )
 
-  // Set auth token
+  // Seed auth token + onboarded flag so the app doesn't bounce to /login.
   await page.goto('/login')
   await page.evaluate(() => {
     localStorage.setItem('token', 'test-token')
     localStorage.setItem('demo-user-onboarded', 'true')
   })
-
-  await page.goto('/')
-  await page.waitForLoadState('domcontentloaded')
 }
 
 test.describe('AI Missions', () => {
@@ -76,71 +107,63 @@ test.describe('AI Missions', () => {
     await setupMissionsTest(page)
   })
 
-  test.describe('Dashboard Display', () => {
-    test('displays dashboard page', async ({ page }) => {
-      await expect(page.getByTestId('dashboard-page')).toBeVisible({ timeout: 10000 })
-    })
+  test('Mission Control dialog opens via ?mission-control=open URL param', async ({ page }) => {
+    // Use the deep-link URL param the dialog listens for (see useMissionControl.ts).
+    await page.goto('/?mission-control=open')
+    await page.waitForLoadState('domcontentloaded')
 
-    test('shows cards grid', async ({ page }) => {
-      await expect(page.getByTestId('dashboard-page')).toBeVisible({ timeout: 10000 })
-      await expect(page.getByTestId('dashboard-cards-grid')).toBeVisible({ timeout: 5000 })
-    })
-
-    test('shows dashboard header', async ({ page }) => {
-      await expect(page.getByTestId('dashboard-page')).toBeVisible({ timeout: 10000 })
-      await expect(page.getByTestId('dashboard-header')).toBeVisible({ timeout: 5000 })
-    })
+    // The dialog renders with role="dialog" and an aria-label of "Mission Control"
+    // (or the current mission title if one is already loaded). See
+    // MissionControlDialog.tsx:170-172.
+    const dialog = page.getByRole('dialog', { name: /mission control/i })
+    await expect(dialog).toBeVisible({ timeout: DIALOG_VISIBLE_TIMEOUT_MS })
   })
 
-  test.describe('Dashboard Controls', () => {
-    test('has refresh button', async ({ page }) => {
-      await expect(page.getByTestId('dashboard-refresh-button')).toBeVisible({ timeout: 10000 })
-    })
+  test('Mission Control dialog exposes a close control', async ({ page }) => {
+    await page.goto('/?mission-control=open')
+    await page.waitForLoadState('domcontentloaded')
 
-    test('refresh button is clickable', async ({ page }) => {
-      await expect(page.getByTestId('dashboard-refresh-button')).toBeVisible({ timeout: 10000 })
+    const dialog = page.getByRole('dialog', { name: /mission control/i })
+    await expect(dialog).toBeVisible({ timeout: DIALOG_VISIBLE_TIMEOUT_MS })
 
-      await page.getByTestId('dashboard-refresh-button').click()
-
-      // Button should remain visible after click
-      await expect(page.getByTestId('dashboard-refresh-button')).toBeVisible()
-    })
+    // The dialog must expose an accessible close button (aria-label="Close Mission Control"
+    // on MissionControlDialog.tsx:280). This asserts the dialog is interactive,
+    // not merely mounted — a regression that painted an empty shell would fail here.
+    const closeButton = dialog.getByRole('button', { name: /close mission control/i })
+    await expect(closeButton).toBeVisible({ timeout: CONTROL_VISIBLE_TIMEOUT_MS })
+    await expect(closeButton).toBeEnabled()
   })
 
-  test.describe('Responsive Design', () => {
-    test('adapts to mobile viewport', async ({ page }) => {
-      await page.setViewportSize({ width: 375, height: 667 })
+  test('missions browser renders at least one project card', async ({ page }) => {
+    // Override the listing mock to return one known project. The missions
+    // browser opens in Phase 1 (project picker) and must surface this entry.
+    await page.route('**/api/missions/list**', (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          items: [
+            {
+              name: 'sample-mission',
+              path: 'missions/sample-mission.yaml',
+              sha: 'abc123',
+              type: 'file',
+            },
+          ],
+        }),
+      })
+    )
 
-      await expect(page.getByTestId('dashboard-page')).toBeVisible({ timeout: 10000 })
-    })
+    await page.goto('/?browse=missions')
+    await page.waitForLoadState('domcontentloaded')
 
-    test('adapts to tablet viewport', async ({ page }) => {
-      await page.setViewportSize({ width: 768, height: 1024 })
-
-      await expect(page.getByTestId('dashboard-page')).toBeVisible({ timeout: 10000 })
-    })
-  })
-
-  test.describe('Accessibility', () => {
-    test('page is keyboard navigable', async ({ page }) => {
-      await expect(page.getByTestId('dashboard-page')).toBeVisible({ timeout: 10000 })
-
-      // Tab through elements
-      for (let i = 0; i < 5; i++) {
-        await page.keyboard.press('Tab')
-      }
-
-      // Should have a focused element
-      const focused = page.locator(':focus')
-      await expect(focused).toBeVisible()
-    })
-
-    test('buttons have proper accessibility attributes', async ({ page }) => {
-      await expect(page.getByTestId('dashboard-page')).toBeVisible({ timeout: 10000 })
-
-      const accessibleButtons = page.locator('button[title], button[aria-label]')
-      const buttonCount = await accessibleButtons.count()
-      expect(buttonCount).toBeGreaterThanOrEqual(0)
-    })
+    // The missions browser renders each entry as a heading/button containing
+    // the mission name. If the Phase 1 panel regresses and renders no cards,
+    // this locator will fail instead of silently passing.
+    const missionEntry = page
+      .getByRole('dialog')
+      .getByText(/sample-mission/i)
+      .first()
+    await expect(missionEntry).toBeVisible({ timeout: DIALOG_VISIBLE_TIMEOUT_MS })
   })
 })

--- a/web/e2e/mission-control-dry-run.spec.ts
+++ b/web/e2e/mission-control-dry-run.spec.ts
@@ -119,7 +119,7 @@ async function setupAllMocks(page: Page) {
 async function seedAndOpenMC(page: Page, overrides: Record<string, unknown>) {
   await setupAllMocks(page)
 
-  await page.goto('http://localhost:8080/login')
+  await page.goto('/login')
   await page.waitForLoadState('domcontentloaded')
 
   await page.evaluate(
@@ -144,7 +144,7 @@ async function seedAndOpenMC(page: Page, overrides: Record<string, unknown>) {
     { mc: overrides, mcKey: MC_STORAGE_KEY }
   )
 
-  await page.goto('http://localhost:8080')
+  await page.goto('/')
   await page.waitForLoadState('networkidle', { timeout: DIALOG_TIMEOUT_MS })
   await expect(page.locator('body')).not.toBeEmpty({ timeout: DIALOG_TIMEOUT_MS })
 
@@ -165,7 +165,7 @@ async function seedAndOpenMC(page: Page, overrides: Record<string, unknown>) {
 async function navigateTo(page: Page) {
   await setupAllMocks(page)
 
-  await page.goto('http://localhost:8080/login')
+  await page.goto('/login')
   await page.waitForLoadState('domcontentloaded')
   await page.evaluate(() => {
     localStorage.setItem('token', 'demo-token')
@@ -176,7 +176,7 @@ async function navigateTo(page: Page) {
       email: 'demo@example.com', role: 'viewer', onboarded: true,
     }))
   })
-  await page.goto('http://localhost:8080')
+  await page.goto('/')
   await page.waitForLoadState('networkidle', { timeout: DIALOG_TIMEOUT_MS })
   await expect(page.locator('body')).not.toBeEmpty({ timeout: DIALOG_TIMEOUT_MS })
 }

--- a/web/e2e/mission-control-e2e.spec.ts
+++ b/web/e2e/mission-control-e2e.spec.ts
@@ -351,12 +351,12 @@ async function navigateToConsole(page: Page) {
   await setupAIMocks(page)
 
   // Set demo auth token to bypass OAuth login screen
-  await page.goto('http://localhost:8080/login')
+  await page.goto('/login')
   await page.waitForLoadState('domcontentloaded')
   await page.evaluate(() => {
     localStorage.setItem('token', 'demo-token')
   })
-  await page.goto('http://localhost:8080')
+  await page.goto('/')
   await page.waitForLoadState('domcontentloaded', { timeout: DIALOG_RENDER_TIMEOUT_MS })
   // Wait for React to hydrate and dashboard to render
   await page.waitForLoadState('networkidle', { timeout: DIALOG_RENDER_TIMEOUT_MS })
@@ -368,14 +368,14 @@ async function openMissionControl(page: Page) {
   if (await mcButton.isVisible({ timeout: 5000 }).catch(() => false)) {
     await mcButton.click()
   } else {
-    await page.goto('http://localhost:8080/?mission-control=open')
+    await page.goto('/?mission-control=open')
     await page.waitForLoadState('domcontentloaded', { timeout: DIALOG_RENDER_TIMEOUT_MS })
   }
   await expect(page.getByText('Define', { exact: false })).toBeVisible({ timeout: DIALOG_RENDER_TIMEOUT_MS })
 }
 
 async function openMissionBrowser(page: Page) {
-  await page.goto('http://localhost:8080/?browse=missions')
+  await page.goto('/?browse=missions')
   await page.waitForLoadState('domcontentloaded', { timeout: DIALOG_RENDER_TIMEOUT_MS })
   await expect(page.getByText('KubeStellar Community', { exact: false })).toBeVisible({ timeout: DIALOG_RENDER_TIMEOUT_MS })
 }

--- a/web/e2e/mission-control-kind-e2e.spec.ts
+++ b/web/e2e/mission-control-kind-e2e.spec.ts
@@ -225,7 +225,7 @@ async function setupAllMocks(page: Page) {
 async function seedAndOpenMC(page: Page, overrides: Record<string, unknown>) {
   await setupAllMocks(page)
 
-  await page.goto('http://localhost:8080/login')
+  await page.goto('/login')
   await page.waitForLoadState('domcontentloaded')
 
   await page.evaluate(
@@ -250,7 +250,7 @@ async function seedAndOpenMC(page: Page, overrides: Record<string, unknown>) {
     { mc: overrides, mcKey: MC_STORAGE_KEY }
   )
 
-  await page.goto('http://localhost:8080')
+  await page.goto('/')
   await page.waitForLoadState('networkidle', { timeout: DIALOG_TIMEOUT_MS })
   await expect(page.locator('body')).not.toBeEmpty({ timeout: DIALOG_TIMEOUT_MS })
 

--- a/web/e2e/mission-control-stress.spec.ts
+++ b/web/e2e/mission-control-stress.spec.ts
@@ -397,7 +397,7 @@ async function setupAllMocks(page: Page) {
 async function navigateTo(page: Page) {
   await setupAllMocks(page)
 
-  await page.goto('http://localhost:8080/login')
+  await page.goto('/login')
   await page.waitForLoadState('domcontentloaded')
   await page.evaluate(() => {
     localStorage.setItem('token', 'demo-token')
@@ -408,7 +408,7 @@ async function navigateTo(page: Page) {
       email: 'demo@example.com', role: 'viewer', onboarded: true,
     }))
   })
-  await page.goto('http://localhost:8080')
+  await page.goto('/')
   await page.waitForLoadState('networkidle', { timeout: DIALOG_TIMEOUT_MS })
   await expect(page.locator('body')).not.toBeEmpty({ timeout: DIALOG_TIMEOUT_MS })
 }
@@ -446,7 +446,7 @@ async function seedAndOpenMC(page: Page, overrides: Record<string, unknown>) {
   await setupAllMocks(page)
 
   // Go to login page to get same-origin localStorage access
-  await page.goto('http://localhost:8080/login')
+  await page.goto('/login')
   await page.waitForLoadState('domcontentloaded')
 
   // Seed token + demo mode + MC state BEFORE navigating to dashboard.
@@ -475,7 +475,7 @@ async function seedAndOpenMC(page: Page, overrides: Record<string, unknown>) {
   )
 
   // Navigate to dashboard — React mounts and reads seeded state
-  await page.goto('http://localhost:8080')
+  await page.goto('/')
   await page.waitForLoadState('networkidle', { timeout: DIALOG_TIMEOUT_MS })
   await expect(page.locator('body')).not.toBeEmpty({ timeout: DIALOG_TIMEOUT_MS })
 
@@ -497,7 +497,7 @@ async function ensureDashboard(page: Page) {
       email: 'demo@example.com', role: 'viewer', onboarded: true,
     }))
   })
-    await page.goto('http://localhost:8080')
+    await page.goto('/')
     await page.waitForLoadState('networkidle', { timeout: DIALOG_TIMEOUT_MS })
     await expect(page.locator('body')).not.toBeEmpty({ timeout: DIALOG_TIMEOUT_MS })
   }

--- a/web/playwright.config.ts
+++ b/web/playwright.config.ts
@@ -61,8 +61,15 @@ export default defineConfig({
 
   // Shared settings for all projects
   use: {
-    // Base URL for all tests
-    baseURL: process.env.PLAYWRIGHT_BASE_URL || 'http://localhost:5174',
+    // Base URL for all tests.
+    //
+    // #6452 — Default to the Go backend port (8080). In production the Go
+    // backend serves BOTH the API and the built frontend on 8080, which is
+    // also how startup-oauth.sh launches the console. Tests must match the
+    // real deployment, not a standalone vite dev server. Override with
+    // PLAYWRIGHT_BASE_URL=http://localhost:5174 if running against a detached
+    // vite dev server (e.g. for fast local UI iteration).
+    baseURL: process.env.PLAYWRIGHT_BASE_URL || 'http://localhost:8080',
 
     // Collect trace on first retry
     trace: 'on-first-retry',
@@ -122,16 +129,16 @@ export default defineConfig({
     },
   ],
 
-  // Web server config - starts dev server before tests
-  // Skip webServer if PLAYWRIGHT_BASE_URL is set (using existing server)
-  webServer: process.env.PLAYWRIGHT_BASE_URL
-    ? undefined
-    : {
-        command: 'npm run dev -- --port 5174',
-        url: 'http://localhost:5174',
-        reuseExistingServer: true,
-        timeout: 120000,
-      },
+  // Web server config - starts dev server before tests.
+  //
+  // #6452 — When PLAYWRIGHT_BASE_URL is not set, default to running against
+  // a pre-started Go backend on port 8080 (the real deployment topology).
+  // We do NOT launch vite here because the backend also serves the built
+  // frontend from the same port, and launching vite separately would mask
+  // server-routing bugs. Callers are expected to have run startup-oauth.sh
+  // or `go run .` first. If PLAYWRIGHT_BASE_URL explicitly points at 5174,
+  // the caller is using a vite dev server and is responsible for starting it.
+  webServer: undefined,
 
   // Output directory
   outputDir: 'test-results',


### PR DESCRIPTION
## Summary

Three testing-infrastructure / security-followup fixes in one PR.

### #6451 — Missions.spec.ts had zero mission coverage

web/e2e/Missions.spec.ts was titled "AI Missions" but its seven tests only exercised dashboard-page presence, cards-grid visibility, refresh button, mobile/tablet viewports, and keyboard focus — all already covered by Dashboard.spec.ts. Replaced with three real Mission Control tests:

1. Mission Control dialog opens via `?mission-control=open` URL param and renders with role=dialog + aria-label matching /mission control/i.
2. Dialog exposes an accessible close control (asserts interactivity, not just mount).
3. Missions browser (`?browse=missions`) renders at least one project card from /api/missions/list.

Each test can actually FAIL on regression (no `expect(true).toBe(true)` placeholders). Added TODO(#6450) pointing at the wave6b data-testid migration.

### #6452 — E2E port mismatch

playwright.config.ts had baseURL set to http://localhost:5174 (vite dev), but six mission-control specs hardcoded http://localhost:8080 (the Go backend). In production and under startup-oauth.sh the Go backend serves BOTH the API and the built frontend on 8080, so 5174 was wrong as a default.

- Default baseURL to http://localhost:8080, keep PLAYWRIGHT_BASE_URL env override.
- Drop the auto-launched `npm run dev -- --port 5174` webServer entry.
- Replace every hardcoded http://localhost:8080 goto() in mission-control-{stress,dry-run,kind-e2e,e2e}.spec.ts with relative paths.

### #6453 — Two Copilot comments on PR #6445

**A. missions.go:826** — ShareToGitHub called resolveAllowedShareRepos() twice on the reject path. Resolve once per request; pass through a new isRepoAllowedForShareWithList().

**B. missions.go:118** — Comment claimed comparison was exact "to match GitHubs own slug handling", but GitHub treats owner/repo slugs as case-INsensitive. Canonicalize both sides with strings.ToLower. Added TestMissions_ShareToGitHub_AllowlistIsCaseInsensitive.

## Test plan

- [x] go build ./... — pass
- [x] go test ./pkg/api/handlers/... -run TestMissions_ShareToGitHub — pass
- [x] npm run build — pass
- [x] npx playwright test --list — 3 new Missions.spec.ts tests register across all 5 browser projects
- [x] npx vitest run src/test/ui-ux-standards.test.ts — pass (7/7)
- [x] npm run lint — no NEW errors in touched files

## Coordination with wave6b

This PR intentionally avoids Mission Control component files and data-testid="mission-control-*" attributes being added by wave6b for #6450. Missions.spec.ts uses stable role/name queries; the TODO(#6450) tracks the eventual testid migration.

Fixes #6451
Fixes #6452
Fixes #6453