### PR TITLE
fix(ui): z-index stacking audit, stat block SWR, points unification (#6481, #6485, #6486-#6498)

### DIFF
--- a/web/src/components/agent/AgentSelector.tsx
+++ b/web/src/components/agent/AgentSelector.tsx
@@ -402,7 +402,7 @@ export function AgentSelector({ compact = false, className = '' }: AgentSelector
           ref={panelRef}
           role="listbox"
           aria-label={t('agent.selectAgent')}
-          className="fixed z-dropdown w-96 max-h-[calc(100vh-8rem)] rounded-lg bg-card border border-border shadow-lg overflow-hidden flex flex-col"
+          className="fixed z-[250] w-96 max-h-[calc(100vh-8rem)] rounded-lg bg-card border border-border shadow-lg overflow-hidden flex flex-col"
           style={{ top: dropdownPos.top, right: dropdownPos.right }}
           onKeyDown={(e) => {
             if (e.key !== 'ArrowDown' && e.key !== 'ArrowUp') return

--- a/web/src/components/cluster-admin/ClusterAdmin.tsx
+++ b/web/src/components/cluster-admin/ClusterAdmin.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useRef } from 'react'
 import { useClusters } from '../../hooks/useMCP'
 import { useCachedPodIssues, useCachedWarningEvents, useCachedNodes } from '../../hooks/useCachedData'
 import { useUniversalStats, createMergedStatValueGetter } from '../../hooks/useUniversalStats'
@@ -12,9 +13,9 @@ const DEFAULT_CARDS = getDefaultCards('cluster-admin')
 
 export function ClusterAdmin() {
   const { clusters: rawClusters, isLoading, isRefreshing, lastUpdated, refetch, error } = useClusters()
-  const { issues: rawPodIssues } = useCachedPodIssues()
-  const { events: rawWarningEvents } = useCachedWarningEvents()
-  const { nodes: rawNodes } = useCachedNodes()
+  const { issues: rawPodIssues, isLoading: isLoadingPodIssues } = useCachedPodIssues()
+  const { events: rawWarningEvents, isLoading: isLoadingWarnings } = useCachedWarningEvents()
+  const { nodes: rawNodes, isLoading: isLoadingNodes } = useCachedNodes()
   const { getStatValue: getUniversalStatValue } = useUniversalStats()
 
   // Guard all arrays against undefined to prevent crashes when APIs return 404/500/empty
@@ -22,6 +23,25 @@ export function ClusterAdmin() {
   const podIssues = rawPodIssues || []
   const warningEvents = rawWarningEvents || []
   const nodes = rawNodes || []
+
+  // Stale-while-revalidate: remember the last non-zero values for Nodes/Warnings
+  // so refreshes don't flash 0 → final value (issue #6485). During a refresh,
+  // the underlying hooks briefly return empty arrays before the new fetch resolves.
+  const lastNodeCountRef = useRef(0)
+  const lastWarningCountRef = useRef(0)
+  const lastPodIssueCountRef = useRef(0)
+  useEffect(() => {
+    if (!isLoadingNodes && nodes.length > 0) lastNodeCountRef.current = nodes.length
+  }, [isLoadingNodes, nodes.length])
+  useEffect(() => {
+    if (!isLoadingWarnings && warningEvents.length > 0) lastWarningCountRef.current = warningEvents.length
+  }, [isLoadingWarnings, warningEvents.length])
+  useEffect(() => {
+    if (!isLoadingPodIssues && podIssues.length > 0) lastPodIssueCountRef.current = podIssues.length
+  }, [isLoadingPodIssues, podIssues.length])
+  const displayNodeCount = nodes.length > 0 ? nodes.length : lastNodeCountRef.current
+  const displayWarningCount = warningEvents.length > 0 ? warningEvents.length : lastWarningCountRef.current
+  const displayPodIssueCount = podIssues.length > 0 ? podIssues.length : lastPodIssueCountRef.current
 
   // Use the centralised health state machine so these counts always agree
   // with the main cluster grid, sidebar stats and filter tabs (#5928).
@@ -38,9 +58,9 @@ export function ClusterAdmin() {
       case 'healthy': return { value: healthy.length, sublabel: 'healthy', isDemo: isDemoData }
       case 'degraded': return { value: degraded.length, sublabel: 'degraded', isDemo: isDemoData }
       case 'offline': return { value: offline.length, sublabel: 'offline', isDemo: isDemoData }
-      case 'nodes': return { value: nodes.length, sublabel: 'total nodes', isDemo: isDemoData }
-      case 'warnings': return { value: warningEvents.length, sublabel: 'warnings', isDemo: isDemoData }
-      case 'pod_issues': return { value: podIssues.length, sublabel: 'pod issues', isDemo: isDemoData }
+      case 'nodes': return { value: displayNodeCount, sublabel: 'total nodes', isDemo: isDemoData }
+      case 'warnings': return { value: displayWarningCount, sublabel: 'warnings', isDemo: isDemoData }
+      case 'pod_issues': return { value: displayPodIssueCount, sublabel: 'pod issues', isDemo: isDemoData }
       default: return { value: '-' }
     }
   }

--- a/web/src/components/layout/Layout.tsx
+++ b/web/src/components/layout/Layout.tsx
@@ -250,7 +250,8 @@ export function Layout({ children: _children }: LayoutProps) {
 
   // Banner stacking: each banner's top offset depends on how many banners above it are visible.
   // Dev bar (20px) → Navbar (64px) → Banners (36px each).
-  // Z-index hierarchy: Navbar + dropdowns (z-50) > Network banner (z-40) > Demo banner (z-30) > In-cluster / Offline banner (z-20)
+  // Z-index hierarchy: Sidebar/Modals (z-modal=400) > Navbar + dropdowns (z-50) > Network banner (z-40) > Demo banner (z-30) > In-cluster / Offline banner (z-20)
+  // Sidebar/MissionSidebar/Mobile menus escalated to z-modal so they sit above their overlays/banners (issues #6486/#6488/#6489/#6490/#6493).
   // Stack order: Network (top) → Demo → In-cluster agent / Agent Offline (bottom)
   const networkBannerTop = NAVBAR_HEIGHT_PX
   const demoBannerTop = NAVBAR_HEIGHT_PX + (showNetworkBanner ? BANNER_HEIGHT_PX : 0)
@@ -533,7 +534,7 @@ export function Layout({ children: _children }: LayoutProps) {
 
       {/* Backend connection lost snackbar — fixed bottom center */}
       {showBackendBanner && (
-        <div className="fixed bottom-6 left-1/2 -translate-x-1/2 z-50 animate-in fade-in slide-in-from-bottom-2 duration-300">
+        <div className="fixed bottom-6 left-1/2 -translate-x-1/2 z-toast animate-in fade-in slide-in-from-bottom-2 duration-300">
           <div className={cn(
             "flex items-center gap-2 px-4 py-3 rounded-lg border shadow-lg text-sm",
             backendDown
@@ -581,7 +582,7 @@ export function Layout({ children: _children }: LayoutProps) {
       )}
       {/* Startup snackbar — non-blocking info while backend initializes */}
       {showStartupSnackbar && (
-        <div className="fixed bottom-6 left-1/2 -translate-x-1/2 z-50 animate-in fade-in slide-in-from-bottom-2 duration-300">
+        <div className="fixed bottom-6 left-1/2 -translate-x-1/2 z-toast animate-in fade-in slide-in-from-bottom-2 duration-300">
           <div className="flex items-center gap-3 px-4 py-3 rounded-lg border shadow-lg text-sm bg-blue-950/90 border-blue-800/50 text-blue-200">
             <Loader2 className="w-4 h-4 animate-spin text-blue-400" />
             <span>{t('layout.startingUp')}</span>
@@ -591,7 +592,7 @@ export function Layout({ children: _children }: LayoutProps) {
 
       {/* Version changed snackbar — persistent until user reloads */}
       {versionChanged && !showStartupSnackbar && !showBackendBanner && (
-        <div className="fixed bottom-6 left-1/2 -translate-x-1/2 z-50 animate-in fade-in slide-in-from-bottom-2 duration-300">
+        <div className="fixed bottom-6 left-1/2 -translate-x-1/2 z-toast animate-in fade-in slide-in-from-bottom-2 duration-300">
           <div className="flex items-center gap-3 px-4 py-3 rounded-lg border shadow-lg text-sm bg-blue-950/90 border-blue-800/50 text-blue-200">
             <RefreshCw className="w-4 h-4 text-blue-400" />
             <span>{t('layout.newVersionAvailable')}</span>

--- a/web/src/components/layout/Sidebar.tsx
+++ b/web/src/components/layout/Sidebar.tsx
@@ -444,7 +444,7 @@ export function Sidebar() {
         onMouseEnter={handleSidebarMouseEnter}
         onMouseLeave={handleSidebarMouseLeave}
         className={cn(
-          'fixed left-0 top-16 bottom-0 glass border-r border-border/50 overflow-y-auto scroll-enhanced z-40',
+          'fixed left-0 top-16 bottom-0 glass border-r border-border/50 overflow-y-auto scroll-enhanced z-modal',
           !isResizing && 'transition-all duration-300',
           // Desktop: respect collapsed state
           !isMobile && (config.collapsed ? 'p-3' : 'p-4'),
@@ -626,7 +626,7 @@ export function Sidebar() {
         <div
           onMouseDown={handleResizeStart}
           className={cn(
-            "fixed bottom-0 cursor-col-resize z-sticky hover:bg-purple-500/30 transition-colors",
+            "fixed bottom-0 cursor-col-resize z-sticky hover:bg-purple-500/30 transition-colors hidden md:block",
             isResizing && "bg-purple-500/50"
           )}
           style={{ top: 160, left: sidebarWidth - 3, width: 6 }}

--- a/web/src/components/layout/mission-sidebar/MissionSidebar.tsx
+++ b/web/src/components/layout/mission-sidebar/MissionSidebar.tsx
@@ -518,7 +518,7 @@ export function MissionSidebar() {
     return (
       <div
         className={cn(
-        "fixed top-16 right-0 bottom-0 w-12 bg-card/95 backdrop-blur-sm border-l border-border shadow-xl z-40 flex flex-col items-center py-4",
+        "fixed top-16 right-0 bottom-0 w-12 bg-card/95 backdrop-blur-sm border-l border-border shadow-xl z-modal flex flex-col items-center py-4",
         "transition-transform duration-300 ease-in-out",
         !isSidebarOpen && "translate-x-full pointer-events-none"
       )}>
@@ -569,7 +569,7 @@ export function MissionSidebar() {
       <div
         data-tour="ai-missions"
         className={cn(
-          "fixed bg-card border-border z-40 flex flex-col overflow-hidden shadow-2xl",
+          "fixed bg-card border-border z-modal flex flex-col overflow-hidden shadow-2xl",
           !isResizing && "transition-[width,top,border,transform] duration-300 ease-in-out",
           // Mobile: bottom sheet
           isMobile && "inset-x-0 bottom-0 rounded-t-2xl border-t max-h-[80vh]",

--- a/web/src/components/layout/navbar/Navbar.tsx
+++ b/web/src/components/layout/navbar/Navbar.tsx
@@ -205,7 +205,7 @@ export function Navbar({ topOffset = 0 }: NavbarProps) {
                 onClick={() => setShowMobileMore(false)}
               />
               {/* Bottom sheet menu on mobile */}
-              <div className={`fixed ${isMobile ? 'inset-x-0 bottom-0 rounded-t-2xl max-h-[60vh]' : 'right-4 w-64 rounded-lg'} bg-card border border-border shadow-xl z-50 overflow-hidden`} style={isMobile ? undefined : { top: topOffset + NAVBAR_HEIGHT_PX }}>
+              <div className={`fixed ${isMobile ? 'inset-x-0 bottom-0 rounded-t-2xl max-h-[60vh]' : 'right-4 w-64 rounded-lg'} bg-card border border-border shadow-xl z-modal overflow-hidden`} style={isMobile ? undefined : { top: topOffset + NAVBAR_HEIGHT_PX }}>
                 {/* Drag handle for mobile */}
                 {isMobile && (
                   <div className="flex justify-center py-2">

--- a/web/src/components/ui/FeatureHintTooltip.tsx
+++ b/web/src/components/ui/FeatureHintTooltip.tsx
@@ -31,7 +31,7 @@ export function FeatureHintTooltip({
 }: FeatureHintTooltipProps) {
   return (
     <div
-      className={`absolute z-50 ${PLACEMENT_CLASSES[placement]} animate-in fade-in slide-in-from-top-1 duration-300`}
+      className={`absolute z-toast ${PLACEMENT_CLASSES[placement]} animate-in fade-in slide-in-from-top-1 duration-300`}
       role="tooltip"
     >
       <div className="flex items-center gap-2 px-3 py-2 rounded-lg glass border border-purple-500/30 bg-purple-500/10 shadow-lg w-72">


### PR DESCRIPTION
## Summary

Frontend wave 8 — 12 issues, all z-index / stacking context cleanup plus a stat-block stale-while-revalidate fix.

### z-index stacking fixes
Uses the existing semantic z-index scale in tailwind.config.js (dropdown=100, sticky=200, overlay=300, modal=400, toast=500).

- **#6486** — Sidebar.tsx: escalate aside from z-40 -> z-modal so mobile sidebar sits above its z-overlay backdrop (touches no longer trapped).
- **#6488** — MissionSidebar.tsx: both the minimized collapsed rail and the main aside go from z-40 -> z-modal so they escape their own z-overlay backdrops.
- **#6489** — Navbar.tsx: mobile overflow bottom-sheet menu z-50 -> z-modal.
- **#6490** — Network banner at z-40 no longer traps sidebar because sidebar is now z-modal (400). Resolved transitively by #6486; Layout.tsx comment updated to reflect the new hierarchy.
- **#6491** — Demo banner stays at z-30. Modal at z-modal (400) already covers it — no additional change needed. Not-a-bug under the new hierarchy.
- **#6492** — Sidebar.tsx: resize handle already guarded by !isMobile; added hidden md:block as CSS-level belt-and-suspenders so it cannot render on mobile.
- **#6493** — MissionChat suggestion overlay trapped inside z-40 sidebar: subsumed by the sidebar -> z-modal escalation. No code change needed (no z-50 overlay at the referenced line).
- **#6494** — AgentSelector.tsx: dropdown z-dropdown (100) < sticky header z-sticky (200). Promoted to z-[250] (above sticky, below overlay).
- **#6496** — FeatureHintTooltip.tsx: z-50 -> z-toast so navbar tooltips render above the network banner.
- **#6498** — Layout.tsx: all three connection-lost / startup / version-changed snackbars z-50 -> z-toast so they remain visible inside modal workflows.

### Other frontend bugs

- **#6485** — Cluster Admin Nodes/Warnings/pod-issues stat blocks flickered 0 -> final value on refresh because the underlying useCached* hooks briefly returned empty arrays during re-fetch. Fixed with refs (updated via effect) that remember the last non-zero count and display those during refresh — classic stale-while-revalidate.

- **#6481** — **Deferred / needs cross-repo change.** Verified data sources:
  - Console reads /api/rewards/github?login=X -> total_points (useGitHubRewards.ts).
  - Docs leaderboard was moved to kubestellar/docs (PRs docs#1226, docs#1227, console#1642) and has its own implementation / cache.
  - Point mismatches cannot be resolved within the console repo alone; requires a follow-up in kubestellar/docs to use the same /api/rewards/github endpoint or the same points formula from a shared backend source of truth.

## Files changed

- web/src/components/layout/Sidebar.tsx
- web/src/components/layout/mission-sidebar/MissionSidebar.tsx
- web/src/components/layout/navbar/Navbar.tsx
- web/src/components/layout/Layout.tsx
- web/src/components/agent/AgentSelector.tsx
- web/src/components/ui/FeatureHintTooltip.tsx
- web/src/components/cluster-admin/ClusterAdmin.tsx

## Test plan

- [x] npm run build — passes
- [x] npx vitest run src/test/ui-ux-standards.test.ts — 7/7 pass
- [x] npm run lint — no new errors in touched files (pre-existing errors in unrelated pages remain)
- [ ] Manual: open mobile sidebar, mobile overflow menu, mission sidebar — verify touches don't pass through and they sit above their backdrops
- [ ] Manual: trigger backend disconnect with a modal open — verify snackbar visible above modal
- [ ] Manual: open agent picker while sticky navbar is scrolled — verify dropdown not clipped

## Not fixed / deferred

- **#6481** — requires kubestellar/docs change to unify data source.
- **#6491** — already resolved under the existing hierarchy. Not-a-bug.

Fixes #6485
Fixes #6486
Fixes #6488
Fixes #6489
Fixes #6490
Fixes #6492
Fixes #6493
Fixes #6494
Fixes #6496
Fixes #6498