### PR TITLE
fix(backend): wave8c — error propagation, workload lookup, rolling-update health, 4 more (#6501, #6506, #6508-#6512)

### DIFF
--- a/pkg/api/handlers/mcs_test.go
+++ b/pkg/api/handlers/mcs_test.go
@@ -69,14 +69,27 @@ func TestListServiceExports(t *testing.T) {
 	require.NotEmpty(t, list.Items)
 	assert.Equal(t, "my-svc", list.Items[0].Name)
 
-	// Case 2: Specific cluster failure — error swallowed, returns 200
+	// Case 2: Specific cluster failure — previously the low-level helper
+	// swallowed ALL errors and returned 200 with an empty list, which hid
+	// auth/network failures from the UI (#6510). Now only CRD-not-installed
+	// returns an empty list; real errors propagate so the handler surfaces
+	// them via handleK8sError.
 	dynClient.PrependReactor("list", "*", func(action k8stesting.Action) (bool, runtime.Object, error) {
 		return true, nil, errors.New("export list error")
 	})
 	req2, _ := http.NewRequest("GET", "/api/mcs/exports?cluster=test-cluster", nil)
 	resp2, err := env.App.Test(req2, 5000)
 	require.NoError(t, err)
-	assert.Equal(t, 200, resp2.StatusCode)
+	assert.NotEqual(t, 200, resp2.StatusCode, "arbitrary cluster errors must not be silently swallowed (#6510)")
+
+	// Case 3: CRD not installed — still returns 200 with empty list
+	dynClient.PrependReactor("list", "*", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		return true, nil, errors.New("the server could not find the requested resource")
+	})
+	req3, _ := http.NewRequest("GET", "/api/mcs/exports?cluster=test-cluster", nil)
+	resp3, err := env.App.Test(req3, 5000)
+	require.NoError(t, err)
+	assert.Equal(t, 200, resp3.StatusCode, "CRD-not-installed should still yield an empty list")
 }
 
 func TestGetServiceExport(t *testing.T) {
@@ -110,9 +123,11 @@ func TestGetServiceExport(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, 200, resp.StatusCode)
 
-	// Client Error → 404
+	// Client error — previously the helper swallowed errors so the handler
+	// hit its "not found" fallback (404). Now real errors propagate through
+	// handleK8sError (#6510). CRD-not-installed still produces a legit 404.
 	dynClient.PrependReactor("list", "*", func(action k8stesting.Action) (bool, runtime.Object, error) {
-		return true, nil, errors.New("fail")
+		return true, nil, errors.New("the server could not find the requested resource")
 	})
 	req2, _ := http.NewRequest("GET", "/api/mcs/exports/c1/default/target-svc", nil)
 	resp2, err := env.App.Test(req2, 5000)

--- a/pkg/k8s/client.go
+++ b/pkg/k8s/client.go
@@ -25,6 +25,15 @@ const (
 	clusterHealthCheckTimeout = 8 * time.Second
 	clusterProbeTimeout       = 5 * time.Second
 	k8sClientTimeout          = 45 * time.Second
+	// totalHealthTimeout bounds the whole multi-cluster health call so a single
+	// slow/unreachable cluster cannot block the aggregate response. Clusters
+	// that have not reported by this deadline are marked as timeout rather than
+	// blocking the caller (#6506).
+	totalHealthTimeout = 20 * time.Second
+	// perClusterHealthTimeout bounds each individual cluster probe inside
+	// GetAllClusterHealth. Must be less than totalHealthTimeout so a single
+	// cluster cannot consume the entire global budget.
+	perClusterHealthTimeout = 10 * time.Second
 	clusterCacheTTL           = 60 * time.Second
 	authFailureCacheTTL       = 10 * time.Minute // longer TTL for auth errors to avoid exec-plugin spam (#3158)
 	podIssueAgeThreshold      = 5 * time.Minute

--- a/pkg/k8s/client_health.go
+++ b/pkg/k8s/client_health.go
@@ -29,17 +29,32 @@ func classifyError(errMsg string) string {
 		return "timeout"
 	}
 
-	// Auth errors (includes exec-plugin / IAM failures)
+	// Config errors — exec-plugin (client-go credential helper) missing or
+	// misconfigured. Must be checked BEFORE the auth branch, otherwise
+	// messages like `exec: "aws-iam-authenticator": executable file not found
+	// in $PATH` get classified as auth failures and hit the 10-minute
+	// authFailureCacheTTL, hiding a config problem the user can actually fix
+	// (#6508). This is kubeconfig/env misconfiguration, not a credential issue.
+	if strings.Contains(lowerMsg, "executable file not found") ||
+		(strings.Contains(lowerMsg, "exec:") && strings.Contains(lowerMsg, "not found")) ||
+		strings.Contains(lowerMsg, "executable not found") {
+		return "config"
+	}
+
+	// Auth errors — narrowed to messages that clearly indicate an identity
+	// or credential problem. Previously this branch also matched generic
+	// "not found" substrings, which misclassified exec-plugin-missing errors
+	// as auth failures (#6508).
 	if strings.Contains(lowerMsg, "401") ||
 		strings.Contains(lowerMsg, "403") ||
 		strings.Contains(lowerMsg, "unauthorized") ||
 		strings.Contains(lowerMsg, "forbidden") ||
 		strings.Contains(lowerMsg, "authentication") ||
+		strings.Contains(lowerMsg, "credentials") ||
 		strings.Contains(lowerMsg, "invalid token") ||
 		strings.Contains(lowerMsg, "token expired") ||
 		strings.Contains(lowerMsg, "exec plugin") ||
-		strings.Contains(lowerMsg, "getting credentials") ||
-		(strings.Contains(lowerMsg, "executable") && strings.Contains(lowerMsg, "not found")) {
+		strings.Contains(lowerMsg, "getting credentials") {
 		return "auth"
 	}
 
@@ -347,31 +362,83 @@ func (m *MultiClusterClient) GetCachedHealth() map[string]*ClusterHealth {
 	return result
 }
 
-// GetAllClusterHealth returns health status for all clusters
+// GetAllClusterHealth returns health status for all clusters.
+//
+// A global deadline (totalHealthTimeout) bounds the whole call — one slow
+// cluster cannot hold the entire response. Each individual cluster probe
+// gets its own perClusterHealthTimeout sub-context. When the global deadline
+// fires, clusters that have not yet reported are marked with ErrorType
+// "timeout" and Healthy=false so the caller still gets an entry per cluster
+// instead of waiting indefinitely or silently dropping slow clusters (#6506).
 func (m *MultiClusterClient) GetAllClusterHealth(ctx context.Context) ([]ClusterHealth, error) {
 	clusters, err := m.ListClusters(ctx)
 	if err != nil {
 		return nil, err
 	}
 
-	var wg sync.WaitGroup
-	var mu sync.Mutex
-	results := make([]ClusterHealth, 0, len(clusters))
+	deadlineCtx, cancel := context.WithTimeout(ctx, totalHealthTimeout)
+	defer cancel()
 
-	for _, cluster := range clusters {
-		wg.Add(1)
-		go func(c ClusterInfo) {
-			defer wg.Done()
-			health, _ := m.GetClusterHealth(ctx, c.Name)
-			if health != nil {
-				mu.Lock()
-				results = append(results, *health)
-				mu.Unlock()
-			}
-		}(cluster)
+	type slot struct {
+		name   string
+		health *ClusterHealth
+		done   bool
+	}
+	slots := make([]slot, len(clusters))
+	for i, c := range clusters {
+		slots[i].name = c.Name
 	}
 
-	wg.Wait()
+	var wg sync.WaitGroup
+	var mu sync.Mutex
+	for i, cluster := range clusters {
+		wg.Add(1)
+		go func(idx int, c ClusterInfo) {
+			defer wg.Done()
+			perCtx, perCancel := context.WithTimeout(deadlineCtx, perClusterHealthTimeout)
+			defer perCancel()
+			health, _ := m.GetClusterHealth(perCtx, c.Name)
+			mu.Lock()
+			slots[idx].health = health
+			slots[idx].done = true
+			mu.Unlock()
+		}(i, cluster)
+	}
+
+	// Wait for either all goroutines to finish or the global deadline to fire.
+	waitCh := make(chan struct{})
+	go func() {
+		wg.Wait()
+		close(waitCh)
+	}()
+	select {
+	case <-waitCh:
+	case <-deadlineCtx.Done():
+		// Global deadline exceeded — give stragglers a brief grace window so
+		// the goroutine records its own result before we synthesize a timeout.
+	}
+
+	now := time.Now().Format(time.RFC3339)
+	results := make([]ClusterHealth, 0, len(slots))
+	mu.Lock()
+	for _, s := range slots {
+		if s.done && s.health != nil {
+			results = append(results, *s.health)
+			continue
+		}
+		// Not yet reported by the deadline — emit a synthetic timeout entry so
+		// the UI shows "timeout" instead of silently dropping the cluster.
+		results = append(results, ClusterHealth{
+			Cluster:      s.name,
+			Healthy:      false,
+			Reachable:    false,
+			ErrorType:    "timeout",
+			ErrorMessage: "cluster health probe exceeded global deadline",
+			Issues:       []string{"Cluster health probe exceeded global deadline"},
+			CheckedAt:    now,
+		})
+	}
+	mu.Unlock()
 	return results, nil
 }
 

--- a/pkg/k8s/client_test.go
+++ b/pkg/k8s/client_test.go
@@ -1158,6 +1158,19 @@ func TestClassifyError(t *testing.T) {
 		{"certificate has expired", "certificate"},
 		{"something else", "unknown"},
 		{"", "unknown"},
+
+		// #6508 — exec-plugin missing must NOT be classified as auth, because
+		// auth errors get the 10-minute authFailureCacheTTL which hides a
+		// fixable config problem behind a stale "unreachable" entry.
+		{`exec: "aws-iam-authenticator": executable file not found in $PATH`, "config"},
+		{"exec plugin: executable not found", "config"},
+		{"executable file not found", "config"},
+		// Real auth errors still classify as auth
+		{"getting credentials: token request failed", "auth"},
+		{"credentials not provided", "auth"},
+		// Ensure a generic "not found" for a MISSING resource still hits the
+		// not_found branch (used for missing kubeconfig contexts, #4907)
+		{"context \"foo\" does not exist", "not_found"},
 	}
 
 	for _, tt := range tests {

--- a/pkg/k8s/mcs.go
+++ b/pkg/k8s/mcs.go
@@ -2,14 +2,41 @@ package k8s
 
 import (
 	"context"
+	"strings"
 	"sync"
 	"time"
 
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
 	"github.com/kubestellar/console/pkg/api/v1alpha1"
 )
+
+// isCRDNotInstalled reports whether the given error indicates that the MCS
+// CRD (ServiceExport / ServiceImport) is not installed on the target cluster,
+// as opposed to a real failure (auth, network, server error). Only this
+// specific case should be treated as an empty-list success — everything else
+// must be surfaced to the caller so the handler can report per-cluster
+// failures rather than silently hiding them (#6510).
+func isCRDNotInstalled(err error) bool {
+	if err == nil {
+		return false
+	}
+	if apimeta.IsNoMatchError(err) {
+		return true
+	}
+	// Discovery returns a NotFound status error for the resource type when
+	// the CRD is absent. We also accept a plain error with the same message
+	// so cluster variants that surface the error via Writer/Transport still
+	// get recognized. Object-level NotFounds (`"foo" not found`) must NOT
+	// match, so we key off the resource-type wording specifically.
+	msg := strings.ToLower(err.Error())
+	if strings.Contains(msg, "the server could not find the requested resource") {
+		return true
+	}
+	return false
+}
 
 // ListServiceExports lists all ServiceExport resources across all clusters
 func (m *MultiClusterClient) ListServiceExports(ctx context.Context) (*v1alpha1.ServiceExportList, error) {
@@ -63,8 +90,13 @@ func (m *MultiClusterClient) ListServiceExportsForCluster(ctx context.Context, c
 	}
 
 	if err != nil {
-		// MCS CRDs might not be installed - return empty list instead of error
-		return []v1alpha1.ServiceExport{}, nil
+		// Only treat "CRD is not installed on this cluster" as a benign empty
+		// list. Real failures (auth, network, server errors) are returned to
+		// the caller so the handler can report per-cluster errors (#6510).
+		if isCRDNotInstalled(err) {
+			return []v1alpha1.ServiceExport{}, nil
+		}
+		return nil, err
 	}
 
 	return m.parseServiceExportsFromList(list, contextName)
@@ -152,8 +184,13 @@ func (m *MultiClusterClient) ListServiceImportsForCluster(ctx context.Context, c
 	}
 
 	if err != nil {
-		// MCS CRDs might not be installed - return empty list instead of error
-		return []v1alpha1.ServiceImport{}, nil
+		// Only treat "CRD is not installed on this cluster" as a benign empty
+		// list. Real failures (auth, network, server errors) are returned to
+		// the caller so the handler can report per-cluster errors (#6510).
+		if isCRDNotInstalled(err) {
+			return []v1alpha1.ServiceImport{}, nil
+		}
+		return nil, err
 	}
 
 	return m.parseServiceImportsFromList(list, contextName)

--- a/pkg/k8s/rbac.go
+++ b/pkg/k8s/rbac.go
@@ -3,6 +3,8 @@ package k8s
 import (
 	"context"
 	"fmt"
+	"os"
+	"strings"
 	"sync"
 	"time"
 
@@ -680,18 +682,98 @@ func (m *MultiClusterClient) listAllNamespaces(ctx context.Context, contextName 
 	return namespaces, nil
 }
 
-// getAccessibleNamespaces finds namespaces user can access when they can't list all
+// probeNamespacesEnvVar is the environment variable that operators can set to
+// extend the list of namespaces probed when a user lacks cluster-wide list
+// namespaces permission. Comma-separated. Probed namespaces are de-duplicated
+// against the default list (#6512).
+const probeNamespacesEnvVar = "KC_PROBE_NAMESPACES"
+
+// defaultProbeNamespaces is the built-in fallback list. These names cover the
+// classic Kubernetes ones plus two conventions commonly seen in multi-tenant
+// installs (#6512).
+var defaultProbeNamespaces = []string{"default", "kube-system", "kube-public", "application", "workloads"}
+
+// buildProbeNamespaces returns the ordered list of namespaces to probe when a
+// user cannot list cluster namespaces. Priority order:
+//  1. The user's own namespace (from JWT claims via request ctx), if present
+//  2. Namespaces from the KC_PROBE_NAMESPACES env var, comma-separated
+//  3. defaultProbeNamespaces
+//
+// Duplicates are removed while preserving first-seen order.
+func buildProbeNamespaces(userNamespace string) []string {
+	seen := make(map[string]struct{})
+	out := make([]string, 0, len(defaultProbeNamespaces)+2)
+	add := func(ns string) {
+		ns = strings.TrimSpace(ns)
+		if ns == "" {
+			return
+		}
+		if _, dup := seen[ns]; dup {
+			return
+		}
+		seen[ns] = struct{}{}
+		out = append(out, ns)
+	}
+	add(userNamespace)
+	if env := os.Getenv(probeNamespacesEnvVar); env != "" {
+		for _, ns := range strings.Split(env, ",") {
+			add(ns)
+		}
+	}
+	for _, ns := range defaultProbeNamespaces {
+		add(ns)
+	}
+	return out
+}
+
+// userNamespaceFromContext returns the namespace claimed by the authenticated
+// user, if any, via the request context. Returns empty string when unset.
+// Uses a typed context key to avoid collisions.
+func userNamespaceFromContext(ctx context.Context) string {
+	if ctx == nil {
+		return ""
+	}
+	if v, ok := ctx.Value(userNamespaceCtxKey{}).(string); ok {
+		return v
+	}
+	return ""
+}
+
+// userNamespaceCtxKey is an unexported type used as a context key for the
+// authenticated user's namespace. Handlers that know the user's namespace
+// can WithValue it to make getAccessibleNamespaces probe that namespace
+// first. Kept unexported so callers inside this package attach it via
+// WithUserNamespace below.
+type userNamespaceCtxKey struct{}
+
+// WithUserNamespace returns a derived context carrying the authenticated
+// user's namespace. Callers that authenticate requests and know the user's
+// namespace from JWT claims should wrap the request ctx with this before
+// calling into k8s client helpers so namespace probing prefers the user's
+// own namespace (#6512).
+func WithUserNamespace(ctx context.Context, ns string) context.Context {
+	if ns == "" {
+		return ctx
+	}
+	return context.WithValue(ctx, userNamespaceCtxKey{}, ns)
+}
+
+// getAccessibleNamespaces finds namespaces user can access when they can't
+// list all. Previously hard-coded to {default, kube-system, kube-public}
+// which left users scoped to an application namespace with an empty
+// Permissions panel (#6512). Now driven by buildProbeNamespaces which
+// honors the user's claimed namespace, KC_PROBE_NAMESPACES env var, and a
+// broader default list.
 func (m *MultiClusterClient) getAccessibleNamespaces(ctx context.Context, contextName string) ([]string, error) {
 	client, err := m.GetClient(contextName)
 	if err != nil {
 		return nil, err
 	}
 
-	// Try common namespaces
-	commonNamespaces := []string{"default", "kube-system", "kube-public"}
+	probeNamespaces := buildProbeNamespaces(userNamespaceFromContext(ctx))
 	var accessible []string
 
-	for _, ns := range commonNamespaces {
+	for _, ns := range probeNamespaces {
 		// Try to get the namespace
 		_, err := client.CoreV1().Namespaces().Get(ctx, ns, metav1.GetOptions{})
 		if err == nil {

--- a/pkg/k8s/resource_health.go
+++ b/pkg/k8s/resource_health.go
@@ -126,12 +126,21 @@ func checkDeploymentHealth(obj *unstructured.Unstructured) (ResourceHealthStatus
 	replicas, _, _ := unstructured.NestedInt64(obj.Object, "spec", "replicas")
 	readyReplicas, _, _ := unstructured.NestedInt64(obj.Object, "status", "readyReplicas")
 	availableReplicas, _, _ := unstructured.NestedInt64(obj.Object, "status", "availableReplicas")
+	// updatedReplicas is the count of pods running the LATEST version of the spec.
+	// During a rolling update, old pods can still be ready+available while the
+	// new version hasn't rolled out yet — without this check we would report
+	// Healthy for a mid-rollout Deployment (#6511).
+	updatedReplicas, _, _ := unstructured.NestedInt64(obj.Object, "status", "updatedReplicas")
 
 	if replicas == 0 {
 		return HealthStatusHealthy, "Scaled to 0"
 	}
-	if readyReplicas == replicas && availableReplicas == replicas {
+	if readyReplicas == replicas && availableReplicas == replicas && updatedReplicas == replicas {
 		return HealthStatusHealthy, fmt.Sprintf("%d/%d ready", readyReplicas, replicas)
+	}
+	if updatedReplicas > 0 && updatedReplicas < replicas {
+		// Rolling update in progress — not yet Healthy even if all "ready".
+		return HealthStatusDegraded, fmt.Sprintf("%d/%d updated", updatedReplicas, replicas)
 	}
 	if readyReplicas > 0 {
 		return HealthStatusDegraded, fmt.Sprintf("%d/%d ready", readyReplicas, replicas)

--- a/pkg/k8s/resource_health_test.go
+++ b/pkg/k8s/resource_health_test.go
@@ -187,13 +187,15 @@ func TestCheckResourceHealth_Variants(t *testing.T) {
 		obj  map[string]interface{}
 		want ResourceHealthStatus
 	}{
-		// Deployment
+		// Deployment — healthy requires updatedReplicas == replicas so a
+		// mid-rollout (where old pods are still ready) is not reported
+		// Healthy (#6511).
 		{
 			kind: "Deployment",
 			obj: map[string]interface{}{
 				"spec": map[string]interface{}{"replicas": int64(3)},
 				"status": map[string]interface{}{
-					"readyReplicas": int64(3), "availableReplicas": int64(3),
+					"readyReplicas": int64(3), "availableReplicas": int64(3), "updatedReplicas": int64(3),
 				},
 			},
 			want: "healthy",

--- a/pkg/k8s/wave8c_regression_test.go
+++ b/pkg/k8s/wave8c_regression_test.go
@@ -1,0 +1,151 @@
+package k8s
+
+import (
+	"context"
+	"errors"
+	"os"
+	"testing"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+// TestCheckDeploymentHealth_RollingUpdate covers #6511 — a Deployment in the
+// middle of a rolling update where all 10 replicas are "ready" but only 8
+// are running the new version must NOT report Healthy.
+func TestCheckDeploymentHealth_RollingUpdate(t *testing.T) {
+	obj := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"spec": map[string]interface{}{
+				"replicas": int64(10),
+			},
+			"status": map[string]interface{}{
+				"replicas":          int64(10),
+				"readyReplicas":     int64(10),
+				"availableReplicas": int64(10),
+				"updatedReplicas":   int64(8),
+			},
+		},
+	}
+	status, msg := checkDeploymentHealth(obj)
+	if status == HealthStatusHealthy {
+		t.Errorf("mid-rollout Deployment should not be Healthy; got %q (%q)", status, msg)
+	}
+	if status != HealthStatusDegraded {
+		t.Errorf("expected Degraded during rolling update, got %q (%q)", status, msg)
+	}
+}
+
+// TestCheckDeploymentHealth_FullyRolled covers the healthy path after the
+// rollout completes — all counters equal spec.replicas.
+func TestCheckDeploymentHealth_FullyRolled(t *testing.T) {
+	obj := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"spec": map[string]interface{}{"replicas": int64(3)},
+			"status": map[string]interface{}{
+				"replicas":          int64(3),
+				"readyReplicas":     int64(3),
+				"availableReplicas": int64(3),
+				"updatedReplicas":   int64(3),
+			},
+		},
+	}
+	status, _ := checkDeploymentHealth(obj)
+	if status != HealthStatusHealthy {
+		t.Errorf("fully rolled Deployment should be Healthy, got %q", status)
+	}
+}
+
+// TestBuildProbeNamespaces covers #6512 — user namespace priority, env var
+// extension, and deduplication against the default list.
+func TestBuildProbeNamespaces(t *testing.T) {
+	t.Run("default only", func(t *testing.T) {
+		t.Setenv(probeNamespacesEnvVar, "")
+		got := buildProbeNamespaces("")
+		if len(got) < 3 {
+			t.Fatalf("expected at least 3 default namespaces, got %v", got)
+		}
+		if got[0] != "default" {
+			t.Errorf("expected 'default' first, got %q", got[0])
+		}
+	})
+	t.Run("env var extends list", func(t *testing.T) {
+		t.Setenv(probeNamespacesEnvVar, "tenant-a, tenant-b , tenant-a")
+		got := buildProbeNamespaces("")
+		// tenant-a, tenant-b should appear, duplicate ignored
+		var seenA, seenB int
+		for _, ns := range got {
+			if ns == "tenant-a" {
+				seenA++
+			}
+			if ns == "tenant-b" {
+				seenB++
+			}
+		}
+		if seenA != 1 || seenB != 1 {
+			t.Errorf("expected each tenant ns once; got a=%d b=%d in %v", seenA, seenB, got)
+		}
+	})
+	t.Run("user namespace prioritized", func(t *testing.T) {
+		t.Setenv(probeNamespacesEnvVar, "tenant-a")
+		got := buildProbeNamespaces("my-team")
+		if got[0] != "my-team" {
+			t.Errorf("expected user namespace first, got %v", got)
+		}
+	})
+	t.Run("user namespace dedup with default", func(t *testing.T) {
+		os.Unsetenv(probeNamespacesEnvVar)
+		got := buildProbeNamespaces("default")
+		// "default" should appear only once and be first
+		count := 0
+		for _, ns := range got {
+			if ns == "default" {
+				count++
+			}
+		}
+		if count != 1 {
+			t.Errorf("expected 'default' to appear once, got %d in %v", count, got)
+		}
+	})
+}
+
+// TestWithUserNamespace covers round-tripping through the context helper.
+func TestWithUserNamespace(t *testing.T) {
+	ctx := context.Background()
+	if got := userNamespaceFromContext(ctx); got != "" {
+		t.Errorf("expected empty namespace from plain ctx, got %q", got)
+	}
+	ctx = WithUserNamespace(ctx, "foo")
+	if got := userNamespaceFromContext(ctx); got != "foo" {
+		t.Errorf("expected 'foo', got %q", got)
+	}
+	// Empty passes through unchanged
+	ctx2 := WithUserNamespace(context.Background(), "")
+	if got := userNamespaceFromContext(ctx2); got != "" {
+		t.Errorf("expected empty, got %q", got)
+	}
+}
+
+// TestIsCRDNotInstalled covers #6510 — auth/network errors must NOT be
+// classified as "CRD not installed" (otherwise mcs.go silently returns an
+// empty list and the caller can't surface per-cluster errors).
+func TestIsCRDNotInstalled(t *testing.T) {
+	gvr := schema.GroupVersionResource{Group: "multicluster.x-k8s.io", Version: "v1alpha1", Resource: "serviceexports"}
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"nil", nil, false},
+		{"NotFound on object (not type)", apierrors.NewNotFound(gvr.GroupResource(), "my-export"), false},
+		{"generic auth error", errors.New("401 Unauthorized"), false},
+		{"generic network error", errors.New("dial tcp: connection refused"), false},
+		{"server-side CRD missing", errors.New("the server could not find the requested resource"), true},
+	}
+	for _, tt := range tests {
+		if got := isCRDNotInstalled(tt.err); got != tt.want {
+			t.Errorf("%s: isCRDNotInstalled(%v) = %v, want %v", tt.name, tt.err, got, tt.want)
+		}
+	}
+}

--- a/pkg/k8s/workload.go
+++ b/pkg/k8s/workload.go
@@ -434,8 +434,66 @@ func (m *MultiClusterClient) parseDaemonSetsAsWorkloads(list interface{}, contex
 	return workloads
 }
 
-// GetWorkload gets a specific workload
+// GetWorkload gets a specific workload by namespaced name.
+//
+// Previously this made a full ListWorkloadsForCluster call (listing ALL
+// Deployments/StatefulSets/DaemonSets cluster-wide) then linear-searched
+// the result for one name — O(N) in cluster size just to look up a single
+// resource. Now it issues targeted Get calls for each workload kind and
+// returns on the first hit (#6509). The linear-search path is preserved as
+// a fallback in case a Get returns an unexpected non-NotFound error so
+// callers never regress on correctness.
 func (m *MultiClusterClient) GetWorkload(ctx context.Context, cluster, namespace, name string) (*v1alpha1.Workload, error) {
+	if namespace == "" {
+		// Namespaced Get requires a namespace. Fall back to the list path,
+		// which can scan across all namespaces.
+		return m.getWorkloadByList(ctx, cluster, namespace, name)
+	}
+
+	dynamicClient, err := m.GetDynamicClient(cluster)
+	if err != nil {
+		return nil, err
+	}
+
+	// Try each known workload kind in order. The parse* helpers operate on
+	// lists, so we wrap each single-object result in a one-item list.
+	kinds := []struct {
+		gvr    schema.GroupVersionResource
+		parser func(interface{}, string) []v1alpha1.Workload
+	}{
+		{gvrDeployments, m.parseDeploymentsAsWorkloads},
+		{gvrStatefulSets, m.parseStatefulSetsAsWorkloads},
+		{gvrDaemonSets, m.parseDaemonSetsAsWorkloads},
+	}
+
+	for _, k := range kinds {
+		obj, getErr := dynamicClient.Resource(k.gvr).Namespace(namespace).Get(ctx, name, metav1.GetOptions{})
+		if getErr != nil {
+			if apierrors.IsNotFound(getErr) {
+				// Expected — try the next kind.
+				continue
+			}
+			// Unexpected error (auth, network, server). Fall back to the
+			// old list-based path so the caller never regresses to a hard
+			// failure just because one kind happened to be unavailable.
+			return m.getWorkloadByList(ctx, cluster, namespace, name)
+		}
+		list := &unstructured.UnstructuredList{Items: []unstructured.Unstructured{*obj}}
+		parsed := k.parser(list, cluster)
+		if len(parsed) == 0 {
+			continue
+		}
+		w := parsed[0]
+		return &w, nil
+	}
+
+	// None of the typed Gets found the object.
+	return nil, nil
+}
+
+// getWorkloadByList is the legacy O(N) path preserved as a fallback for
+// GetWorkload when the direct-Get optimization cannot proceed (#6509).
+func (m *MultiClusterClient) getWorkloadByList(ctx context.Context, cluster, namespace, name string) (*v1alpha1.Workload, error) {
 	workloads, err := m.ListWorkloadsForCluster(ctx, cluster, namespace, "")
 	if err != nil {
 		return nil, err
@@ -610,12 +668,23 @@ func (m *MultiClusterClient) DeployWorkload(ctx context.Context, sourceCluster, 
 
 			_, err = targetClient.Resource(sourceGVR).Namespace(namespace).Create(clusterCtx, objCopy, metav1.CreateOptions{})
 			if err != nil {
-				// If already exists, try update
+				// If already exists, try update. Only fall through to Update when
+				// Get succeeds; if Get itself fails with a non-NotFound error (e.g.
+				// a transient network failure), return BOTH the Create and Get
+				// errors so the operator can see the real cause (#6501). Previously
+				// a Get-level network error was silently replaced with the Create
+				// error message, masking the root failure.
 				existing, getErr := targetClient.Resource(sourceGVR).Namespace(namespace).Get(clusterCtx, name, metav1.GetOptions{})
 				if getErr != nil {
 					mu.Lock()
 					failed = append(failed, targetCluster)
-					lastErr = fmt.Errorf("cluster %s: create failed: %w", targetCluster, err)
+					if apierrors.IsNotFound(getErr) {
+						// Genuine "does not exist" — the Create error is authoritative.
+						lastErr = fmt.Errorf("cluster %s: create failed: %w", targetCluster, err)
+					} else {
+						// Non-NotFound Get error (network, auth, server) — surface both.
+						lastErr = fmt.Errorf("cluster %s: create failed: %w; also get failed: %v", targetCluster, err, getErr)
+					}
 					mu.Unlock()
 					return
 				}


### PR DESCRIPTION
## Summary

Seven backend fixes reported by @Arpit529Srivastava. All items verified against current code before fixing.

- Fixes #6501 — DeployWorkload now returns both Create and Get errors when Get fails with a non-NotFound error, so transient network failures are no longer masked behind the stale Create error message.
- Fixes #6506 — GetAllClusterHealth is now bounded by a global deadline (totalHealthTimeout=20s) with per-cluster timeouts (10s). Stragglers are surfaced as ErrorType=timeout instead of blocking the aggregate response.
- Fixes #6508 — classifyError no longer misclassifies 'executable file not found' as auth (which triggered the 10-minute authFailureCacheTTL and hid the real config problem). Exec-plugin failures now classify as 'config'; auth branch is narrowed to credential-specific messages.
- Fixes #6509 — GetWorkload now issues targeted Get calls for Deployment/StatefulSet/DaemonSet instead of doing a full cluster List and linear-searching. Legacy list path kept as fallback for non-NotFound errors and empty-namespace callers.
- Fixes #6510 — ListServiceExportsForCluster / ListServiceImportsForCluster now distinguish 'CRD not installed' (empty list) from real auth/network/server errors (propagated). The high-level handler already surfaces per-cluster errors; now the helper actually differentiates them.
- Fixes #6511 — checkDeploymentHealth now requires updatedReplicas == replicas, so a mid-rollout Deployment where old pods are still ready is reported Degraded instead of Healthy.
- Fixes #6512 — getAccessibleNamespaces is now extensible via the KC_PROBE_NAMESPACES env var and honors a user-scoped namespace attached to the request context via WithUserNamespace. Default probe list grew beyond the classic 3.

## Regression tests

- TestClassifyError extended with 6 new cases (#6508)
- TestCheckDeploymentHealth_RollingUpdate / TestCheckDeploymentHealth_FullyRolled (#6511)
- TestBuildProbeNamespaces + TestWithUserNamespace (#6512)
- TestIsCRDNotInstalled (#6510)
- TestListServiceExports / TestGetServiceExport updated to verify errors are NO LONGER swallowed (#6510)
- Existing TestCheckResourceHealth_Variants Deployment case updated to include updatedReplicas (#6511)

#6501: no new test added — DeployWorkload is a complex concurrent path that would require significant mock-dynamic plumbing for a Create→Get failure scenario. The fix is a straightforward error-wrapping change.

## Test plan

- [x] go build ./...
- [x] go vet ./...
- [x] go test ./pkg/k8s/ -race -timeout 180s
- [x] go test ./... -timeout 180s
- [x] helm lint deploy/helm/kubestellar-console