### PR TITLE
fix(mobile): 16 touch-target + scroll + dvh + wrap fixes (#6519-#6537)

### DIFF
--- a/web/src/components/layout/Layout.tsx
+++ b/web/src/components/layout/Layout.tsx
@@ -462,14 +462,14 @@ export function Layout({ children: _children }: LayoutProps) {
             <div className="flex items-center gap-2 shrink-0">
               <Link
                 to="/settings"
-                className="flex items-center gap-1 text-xs px-2 py-0.5 bg-orange-500/20 hover:bg-orange-500/30 text-orange-400 rounded transition-colors whitespace-nowrap"
+                className="flex items-center gap-1 text-xs px-2 py-2 bg-orange-500/20 hover:bg-orange-500/30 text-orange-400 rounded transition-colors whitespace-nowrap"
               >
                 <Settings className="w-3 h-3" />
                 <span className="hidden sm:inline">{t('navigation.settings')}</span>
               </Link>
               <button
                 onClick={toggleDemoMode}
-                className="text-xs px-2 py-0.5 bg-orange-500/20 hover:bg-orange-500/30 text-orange-400 rounded transition-colors whitespace-nowrap"
+                className="text-xs px-2 py-2 bg-orange-500/20 hover:bg-orange-500/30 text-orange-400 rounded transition-colors whitespace-nowrap"
               >
                 <span className="hidden sm:inline">{t('layout.switchTo')} </span>{t('layout.demo')}
               </button>
@@ -502,7 +502,7 @@ export function Layout({ children: _children }: LayoutProps) {
           // entire main column past the viewport at narrow breakpoints
           // (issues 6385, 6387, 6394). Individual scrollable children
           // (tables, code blocks) still scroll horizontally inside wrappers.
-          className="relative flex-1 p-4 pb-24 md:p-6 md:pb-28 transition-[margin] duration-300 overflow-y-auto overflow-x-hidden scroll-enhanced min-w-0"
+          className="relative flex-1 p-4 pb-[calc(6rem+env(safe-area-inset-bottom))] md:p-6 md:pb-[calc(7rem+env(safe-area-inset-bottom))] transition-[margin] duration-300 overflow-y-auto overflow-x-hidden scroll-enhanced min-w-0"
         >
           <NavigationProgress />
           <Suspense fallback={<ContentLoadingSkeleton />}>

--- a/web/src/components/layout/Sidebar.tsx
+++ b/web/src/components/layout/Sidebar.tsx
@@ -358,7 +358,7 @@ export function Sidebar() {
                   if (e.key === 'Escape') { setEditingItemId(null); setEditingName('') }
                 }}
                 autoFocus
-                className="flex-1 bg-transparent border-b border-purple-500 outline-none text-foreground text-sm min-w-0"
+                className="w-[150px] md:w-full flex-1 flex-shrink bg-transparent border-b border-purple-500 outline-none text-foreground text-sm min-w-0"
               />
             )}
             {!isCollapsed && <GripVertical className="w-3.5 h-3.5 text-muted-foreground/50 flex-shrink-0" />}
@@ -484,7 +484,7 @@ export function Sidebar() {
 
         {/* Snoozed card swaps */}
         {!isCollapsed && (
-          <div data-tour="snoozed">
+          <div data-tour="snoozed" className="min-w-0">
             <SnoozedCards
               onApplySwap={handleApplySwap}
               onApplyRecommendation={handleApplyRecommendation}

--- a/web/src/components/layout/mission-sidebar/MissionChat.tsx
+++ b/web/src/components/layout/mission-sidebar/MissionChat.tsx
@@ -369,7 +369,7 @@ export function MissionChat({ mission, isFullScreen = false, fontSize = 'base' a
       <div className="flex flex-col flex-1 min-h-0 min-w-0">
       {/* Header */}
       <div className="p-4 border-b border-border flex-shrink-0">
-        <div className="flex items-center gap-2 mb-2">
+        <div className="flex flex-wrap items-center gap-2 mb-2">
           <TypeIcon className="w-5 h-5 text-primary" />
           {isEditingTitle ? (
             <div className="flex items-center gap-1 flex-1 min-w-0">
@@ -816,7 +816,7 @@ export function MissionChat({ mission, isFullScreen = false, fontSize = 'base' a
               />
               <button
                 disabled
-                className="flex-shrink-0 px-3 py-2 bg-primary text-primary-foreground rounded-lg disabled:opacity-50 disabled:cursor-not-allowed"
+                className="flex-shrink-0 px-3 py-3 min-h-[44px] bg-primary text-primary-foreground rounded-lg disabled:opacity-50 disabled:cursor-not-allowed"
                 title={t('missionChat.sendWillQueue')}
               >
                 <Send className="w-4 h-4" />
@@ -825,7 +825,7 @@ export function MissionChat({ mission, isFullScreen = false, fontSize = 'base' a
             <div className="flex items-center justify-end">
               <button
                 onClick={() => cancelMission(mission.id)}
-                className="flex items-center gap-1.5 text-xs text-red-400 hover:text-red-300 px-2 py-1 rounded hover:bg-red-500/10 transition-colors"
+                className="flex items-center gap-1.5 text-xs text-red-400 hover:text-red-300 py-2.5 px-3 min-h-[44px] rounded hover:bg-red-500/10 transition-colors"
                 data-testid="terminate-session-inline-btn"
               >
                 <StopCircle className="w-3 h-3" />
@@ -935,7 +935,7 @@ export function MissionChat({ mission, isFullScreen = false, fontSize = 'base' a
               <button
                 onClick={handleSend}
                 disabled={!input.trim()}
-                className="px-3 py-2 rounded-lg bg-primary text-primary-foreground hover:bg-primary/90 disabled:opacity-30 transition-colors"
+                className="px-3 py-3 min-h-[44px] rounded-lg bg-primary text-primary-foreground hover:bg-primary/90 disabled:opacity-30 transition-colors"
               >
                 <Send className="w-4 h-4" />
               </button>
@@ -998,7 +998,7 @@ export function MissionChat({ mission, isFullScreen = false, fontSize = 'base' a
               <button
                 onClick={handleSend}
                 disabled={!input.trim()}
-                className="flex-shrink-0 px-3 py-2 bg-primary text-primary-foreground rounded-lg hover:bg-primary/80 disabled:opacity-50 disabled:cursor-not-allowed"
+                className="flex-shrink-0 px-3 py-3 min-h-[44px] bg-primary text-primary-foreground rounded-lg hover:bg-primary/80 disabled:opacity-50 disabled:cursor-not-allowed"
               >
                 <Send className="w-4 h-4" />
               </button>
@@ -1026,7 +1026,7 @@ export function MissionChat({ mission, isFullScreen = false, fontSize = 'base' a
               <button
                 onClick={handleSend}
                 disabled={!input.trim()}
-                className="flex-shrink-0 px-3 py-2 bg-primary text-primary-foreground rounded-lg hover:bg-primary/80 disabled:opacity-50 disabled:cursor-not-allowed"
+                className="flex-shrink-0 px-3 py-3 min-h-[44px] bg-primary text-primary-foreground rounded-lg hover:bg-primary/80 disabled:opacity-50 disabled:cursor-not-allowed"
               >
                 <Send className="w-4 h-4" />
               </button>

--- a/web/src/components/layout/mission-sidebar/MissionSidebar.tsx
+++ b/web/src/components/layout/mission-sidebar/MissionSidebar.tsx
@@ -586,7 +586,7 @@ export function MissionSidebar() {
           "fixed bg-card border-border z-modal flex flex-col overflow-hidden shadow-2xl",
           !isResizing && "transition-[width,top,border,transform] duration-300 ease-in-out",
           // Mobile: bottom sheet
-          isMobile && "inset-x-0 bottom-0 rounded-t-2xl border-t max-h-[80vh]",
+          isMobile && "inset-x-0 bottom-0 rounded-t-2xl border-t max-h-[80dvh]",
           isMobile && !isSidebarOpen && "translate-y-full pointer-events-none",
           isMobile && isSidebarOpen && "translate-y-0",
           // Desktop: right sidebar
@@ -723,7 +723,7 @@ export function MissionSidebar() {
             ))}
             <button
               onClick={closeSidebar}
-              className="p-1 rounded transition-colors hover:bg-black/5 dark:hover:bg-white/10"
+              className="min-w-[44px] min-h-[44px] p-2 rounded transition-colors hover:bg-black/5 dark:hover:bg-white/10 flex items-center justify-center"
               title={t('missionSidebar.closeSidebar')}
             >
               <X className="w-5 h-5 text-muted-foreground" />

--- a/web/src/components/layout/navbar/Navbar.tsx
+++ b/web/src/components/layout/navbar/Navbar.tsx
@@ -172,7 +172,7 @@ export function Navbar({ topOffset = 0 }: NavbarProps) {
           {/* Theme toggle */}
           <button
             onClick={toggleTheme}
-            className="p-2 hover:bg-secondary rounded-lg transition-colors"
+            className="p-2 shrink-0 hover:bg-secondary rounded-lg transition-colors"
             title={t('navbar.themeToggle', { theme })}
           >
             {theme === 'dark' ? (
@@ -189,10 +189,10 @@ export function Navbar({ topOffset = 0 }: NavbarProps) {
         </div>
 
         {/* Overflow menu — visible below lg for items hidden at narrow widths */}
-        <div className="relative lg:hidden">
+        <div className="relative lg:hidden shrink-0">
           <button
             onClick={() => setShowMobileMore(!showMobileMore)}
-            className="p-2 hover:bg-secondary rounded-lg transition-colors"
+            className="p-2 min-w-[44px] min-h-[44px] hover:bg-secondary rounded-lg transition-colors"
             aria-label={t('navbar.moreOptions')}
           >
             <MoreVertical className="w-5 h-5 text-muted-foreground" />
@@ -205,14 +205,14 @@ export function Navbar({ topOffset = 0 }: NavbarProps) {
                 onClick={() => setShowMobileMore(false)}
               />
               {/* Bottom sheet menu on mobile */}
-              <div className={`fixed ${isMobile ? 'inset-x-0 bottom-0 rounded-t-2xl max-h-[60vh]' : 'right-4 w-64 rounded-lg'} bg-card border border-border shadow-xl z-modal overflow-hidden`} style={isMobile ? undefined : { top: topOffset + NAVBAR_HEIGHT_PX }}>
+              <div className={`fixed ${isMobile ? 'inset-x-0 bottom-0 rounded-t-2xl max-h-[60dvh]' : 'right-4 w-64 rounded-lg'} bg-card border border-border shadow-xl z-modal overflow-hidden`} style={isMobile ? undefined : { top: topOffset + NAVBAR_HEIGHT_PX }}>
                 {/* Drag handle for mobile */}
                 {isMobile && (
                   <div className="flex justify-center py-2">
                     <div className="w-10 h-1 bg-muted-foreground/30 rounded-full" />
                   </div>
                 )}
-                <div className={`${isMobile ? 'max-h-[calc(60vh-24px)]' : ''} overflow-y-auto py-2`}>
+                <div className={`${isMobile ? 'max-h-[calc(60dvh-24px)]' : ''} overflow-y-auto py-2`}>
                   {/* Search on mobile */}
                   <div className="px-3 py-2 sm:hidden">
                     <Suspense fallback={null}><SearchDropdown /></Suspense>
@@ -241,8 +241,8 @@ export function Navbar({ topOffset = 0 }: NavbarProps) {
                         className="relative flex items-center gap-2 w-full px-3 py-2 text-sm font-medium rounded-lg transition-colors bg-purple-500/10 hover:bg-purple-500/20 text-purple-400"
                         aria-label={t('missionSidebar.openAIMissions')}
                       >
-                        <Sparkles className="w-4 h-4" />
-                        <span>{t('missionSidebar.aiMissions')}</span>
+                        <Sparkles className="w-4 h-4 shrink-0" />
+                        <span className="truncate min-w-0">{t('missionSidebar.aiMissions')}</span>
                         {missionsNeedingAttention > 0 && (
                           <span className="flex items-center justify-center w-5 h-5 text-[10px] font-bold bg-purple-500 text-white rounded-full animate-pulse">
                             {missionsNeedingAttention}

--- a/web/src/components/mission-control/ClusterAssignmentPanel.tsx
+++ b/web/src/components/mission-control/ClusterAssignmentPanel.tsx
@@ -354,12 +354,14 @@ export function ClusterAssignmentPanel({
               })}
             </div>
           ) : (
-            <AssignmentMatrix
-              projects={state.projects}
-              clusters={healthyClusters}
-              assignments={state.assignments}
-              onToggle={onSetAssignment}
-            />
+            <div className="max-w-full overflow-x-auto">
+              <AssignmentMatrix
+                projects={state.projects}
+                clusters={healthyClusters}
+                assignments={state.assignments}
+                onToggle={onSetAssignment}
+              />
+            </div>
           )}
 
           {/* Phase summary */}

--- a/web/src/components/mission-control/FlightPlanBlueprint.tsx
+++ b/web/src/components/mission-control/FlightPlanBlueprint.tsx
@@ -926,7 +926,7 @@ export function FlightPlanBlueprint({
 
           <div
             ref={svgContainerRef}
-            className="w-full h-full overflow-auto"
+            className="w-full max-w-full h-full overflow-x-auto overflow-y-auto"
             style={{ cursor: zoom > 1 ? 'grab' : 'default' }}
             onMouseDown={handlePanStart}
           >

--- a/web/src/components/missions/MissionDetailView.tsx
+++ b/web/src/components/missions/MissionDetailView.tsx
@@ -146,7 +146,7 @@ function StepCard({ step, index, accentColor }: { step: MissionStep; index: numb
             )}
             {block.code && (
               <div className="relative mt-2 mb-2">
-                <pre className="p-3 rounded-lg bg-background text-xs text-foreground font-mono border border-border overflow-x-auto whitespace-pre-wrap">
+                <pre className="max-w-[85vw] p-3 rounded-lg bg-background text-xs text-foreground font-mono border border-border overflow-x-auto whitespace-pre-wrap">
                   {block.code}
                 </pre>
                 <CopyButton text={block.code} />
@@ -159,7 +159,7 @@ function StepCard({ step, index, accentColor }: { step: MissionStep; index: numb
         ))}
         {step.command && (
           <div className="relative mt-2">
-            <pre className="block p-2 rounded bg-background text-xs text-foreground font-mono border border-border whitespace-pre-wrap overflow-x-auto">
+            <pre className="max-w-[85vw] block p-2 rounded bg-background text-xs text-foreground font-mono border border-border whitespace-pre-wrap overflow-x-auto">
               {step.command}
             </pre>
             <CopyButton text={step.command} />
@@ -170,7 +170,7 @@ function StepCard({ step, index, accentColor }: { step: MissionStep; index: numb
             <div className="flex items-center gap-1.5 mb-1">
               <span className="text-[10px] font-medium text-muted-foreground uppercase tracking-wider">YAML</span>
             </div>
-            <pre className="p-3 rounded-lg bg-background text-xs text-foreground font-mono border border-border overflow-x-auto whitespace-pre-wrap">
+            <pre className="max-w-[85vw] p-3 rounded-lg bg-background text-xs text-foreground font-mono border border-border overflow-x-auto whitespace-pre-wrap">
               {step.yaml}
             </pre>
             <CopyButton text={step.yaml} />


### PR DESCRIPTION
Wave 9 mobile-UX cleanup from @mrhapile.

## Fixed
Fixes #6519
Fixes #6520
Fixes #6521
Fixes #6522
Fixes #6523
Fixes #6524
Fixes #6525
Fixes #6527
Fixes #6528
Fixes #6529
Fixes #6532
Fixes #6533
Fixes #6534
Fixes #6535
Fixes #6536
Fixes #6537

## Skipped
- #6530 ClusterFilterPanel — chip containers already use flex-wrap.
- #6531 FeatureRequestModal:185 — line drift, modal h2 has no truncate.

## Verification
- npm run build — passes
- vitest ui-ux-standards — 7/7 pass
- npm run lint — no new errors