### PR TITLE
fix(mobile): wave10 — chat min-h, orientation guard, hover-touch, safe-area (#6538, #6540-#6545)

### DIFF
--- a/web/src/components/layout/Sidebar.tsx
+++ b/web/src/components/layout/Sidebar.tsx
@@ -397,7 +397,7 @@ export function Sidebar() {
               )
             })()}
             {!isCollapsed && (
-              <span className="absolute right-5 top-1/2 -translate-y-1/2 flex items-center gap-1 opacity-0 group-hover:opacity-100 transition-opacity bg-background/80 backdrop-blur-sm rounded px-1">
+              <span className="absolute right-5 top-1/2 -translate-y-1/2 flex items-center gap-1 opacity-100 md:opacity-0 md:group-hover:opacity-100 transition-opacity bg-background/80 backdrop-blur-sm rounded px-1">
                 {!PROTECTED_SIDEBAR_IDS.includes(item.id) && (
                   <span
                     role="button"
@@ -450,7 +450,7 @@ export function Sidebar() {
           !isMobile && (config.collapsed ? 'p-3' : 'p-4'),
           // Mobile: slide off-screen when closed
           isMobile && 'p-4',
-          isMobile && !config.isMobileOpen && '-translate-x-full',
+          isMobile && !config.isMobileOpen && '-translate-x-full hidden md:flex',
           isMobile && config.isMobileOpen && 'translate-x-0'
         )}
         style={{ width: isMobile ? SIDEBAR_DEFAULT_WIDTH_PX : sidebarWidth }}>

--- a/web/src/components/layout/mission-sidebar/MissionChat.tsx
+++ b/web/src/components/layout/mission-sidebar/MissionChat.tsx
@@ -503,7 +503,7 @@ export function MissionChat({ mission, isFullScreen = false, fontSize = 'base' a
       <div
         ref={messagesContainerRef}
         onScroll={handleScroll}
-        className="flex-1 overflow-y-auto scroll-enhanced p-4 space-y-4 min-h-0 min-w-0"
+        className="flex-1 overflow-y-auto scroll-enhanced p-4 space-y-4 min-h-[150px] min-w-0"
       >
         {/* Inline Run button + editable mission description/steps for saved missions (#3917, #4273) */}
         {isSavedPreRun && (
@@ -797,7 +797,7 @@ export function MissionChat({ mission, isFullScreen = false, fontSize = 'base' a
 
       {/* Input / Actions — hidden when Run button is inline above */}
       {!isSavedPreRun && (
-      <div className="p-4 border-t border-border flex-shrink-0 bg-card min-w-0">
+      <div className="p-4 border-t border-border flex-shrink-0 bg-card min-w-0 pb-[max(1rem,env(safe-area-inset-bottom))]">
         {mission.status === 'cancelling' ? (
           <div className="flex items-center justify-center gap-2 py-3">
             <Loader2 className="w-4 h-4 animate-spin text-orange-400" />

--- a/web/src/components/mission-control/FlightPlanBlueprint.tsx
+++ b/web/src/components/mission-control/FlightPlanBlueprint.tsx
@@ -868,7 +868,7 @@ export function FlightPlanBlueprint({
       </div>
 
       {/* Main content: SVG left + Info panel right */}
-      <div className="flex-1 flex overflow-hidden">
+      <div className="flex-1 flex flex-col md:flex-row overflow-hidden">
         {/* SVG Blueprint */}
         <div className="flex-1 p-4 overflow-hidden relative">
           {/* Zoom & sidebar controls */}


### PR DESCRIPTION
## Summary

Wave 10 mobile UX fixes — small Tailwind-only changes.

- #6538 MissionChat messages container: min-h-[150px] so the scroll area does not collapse when empty
- #6540 Sidebar mobile: strict hidden md:flex guard when !isMobileOpen to prevent orientation-flip flash
- #6541 FlightPlanBlueprint main row: flex-col md:flex-row so SVG and info panel stack on mobile
- #6542 Sidebar Pin/Delete action icons: opacity-100 md:opacity-0 md:group-hover:opacity-100 (touch always visible, desktop hover-reveal)
- #6545 MissionChat input row: pb-[max(1rem,env(safe-area-inset-bottom))] so iOS home indicator does not cover input

Skipped (drifted / already fixed on main):
- #6544 resizer at Sidebar.tsx:626 already has hidden md:block and is guarded by !isMobile
- #6543 AgentStatusIndicator label already uses hidden sm:inline; there is no tooltip wrapper element

Fixes #6538
Fixes #6540
Fixes #6541
Fixes #6542
Fixes #6545

## Test plan

- [x] npm run build
- [x] npx vitest run src/test/ui-ux-standards.test.ts (7/7)
- [x] npm run lint — no new errors in touched files