### PR TITLE
fix(backend): ListArgoApplications uses DeduplicatedClusters + idempotent Shutdown (#6476, #6478)

### DIFF
--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -15,6 +15,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"time"
 
@@ -147,6 +148,7 @@ type Server struct {
 	shuttingDown        int32        // atomic flag: 1 during graceful shutdown
 	gpuUtilWorker       *GPUUtilizationWorker
 	done                chan struct{} // closed on Shutdown to stop background goroutines
+	shutdownOnce        sync.Once     // ensures Shutdown is idempotent (#6478)
 }
 
 // NewServer creates a new API server. It starts a temporary loading page
@@ -1281,37 +1283,46 @@ func waitForPortRelease(port int, timeout time.Duration) error {
 // Shutdown gracefully shuts down the server.
 // Sets shuttingDown flag first so /health returns "shutting_down"
 // before services are torn down, giving the frontend time to notice.
+//
+// Shutdown is idempotent (#6478): subsequent calls are no-ops. Previously a
+// second call panicked with "close of closed channel" when close(s.done)
+// was invoked a second time.
 func (s *Server) Shutdown() error {
-	atomic.StoreInt32(&s.shuttingDown, 1)
+	var shutdownErr error
+	s.shutdownOnce.Do(func() {
+		atomic.StoreInt32(&s.shuttingDown, 1)
 
-	// Signal background goroutines (orbit scheduler, etc.) to stop.
-	close(s.done)
+		// Signal background goroutines (orbit scheduler, etc.) to stop.
+		close(s.done)
 
-	// If Shutdown is called before Start, the temporary loading server
-	// is still running and holding the port. Shut it down first.
-	if s.loadingSrv != nil {
-		ctx, cancel := context.WithTimeout(context.Background(), serverHealthTimeout)
-		defer cancel()
-		s.loadingSrv.Shutdown(ctx)
-		s.loadingSrv = nil
-	}
-
-	if s.gpuUtilWorker != nil {
-		s.gpuUtilWorker.Stop()
-	}
-	s.hub.Close()
-	if s.k8sClient != nil {
-		s.k8sClient.StopWatching()
-	}
-	if s.bridge != nil {
-		if err := s.bridge.Stop(); err != nil {
-			slog.Error("[Server] MCP bridge shutdown error", "error", err)
+		// If Shutdown is called before Start, the temporary loading server
+		// is still running and holding the port. Shut it down first.
+		if s.loadingSrv != nil {
+			ctx, cancel := context.WithTimeout(context.Background(), serverHealthTimeout)
+			defer cancel()
+			s.loadingSrv.Shutdown(ctx)
+			s.loadingSrv = nil
 		}
-	}
-	if err := s.store.Close(); err != nil {
-		return err
-	}
-	return s.app.Shutdown()
+
+		if s.gpuUtilWorker != nil {
+			s.gpuUtilWorker.Stop()
+		}
+		s.hub.Close()
+		if s.k8sClient != nil {
+			s.k8sClient.StopWatching()
+		}
+		if s.bridge != nil {
+			if err := s.bridge.Stop(); err != nil {
+				slog.Error("[Server] MCP bridge shutdown error", "error", err)
+			}
+		}
+		if err := s.store.Close(); err != nil {
+			shutdownErr = err
+			return
+		}
+		shutdownErr = s.app.Shutdown()
+	})
+	return shutdownErr
 }
 
 func customErrorHandler(c *fiber.Ctx, err error) error {

--- a/pkg/api/shutdown_test.go
+++ b/pkg/api/shutdown_test.go
@@ -1,0 +1,59 @@
+package api
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/gofiber/fiber/v2"
+
+	"github.com/kubestellar/console/pkg/api/handlers"
+	"github.com/kubestellar/console/pkg/store"
+)
+
+// TestShutdown_Idempotent is a regression test for #6478. Previously
+// Server.Shutdown closed s.done directly, so a second call panicked with
+// "close of closed channel". The fix wraps teardown in sync.Once so
+// subsequent calls are no-ops.
+func TestShutdown_Idempotent(t *testing.T) {
+	// Build a minimal Server with only the dependencies Shutdown touches.
+	// k8sClient, bridge, gpuUtilWorker, loadingSrv are nil-guarded in
+	// Shutdown so we can leave them unset. hub, store, and app must be
+	// non-nil.
+	dbPath := filepath.Join(t.TempDir(), "shutdown-test.db")
+	sqliteStore, err := store.NewSQLiteStore(dbPath)
+	if err != nil {
+		t.Fatalf("failed to open sqlite store: %v", err)
+	}
+
+	s := &Server{
+		app:   fiber.New(),
+		store: sqliteStore,
+		hub:   handlers.NewHub(),
+		done:  make(chan struct{}),
+	}
+
+	// First call tears everything down.
+	if err := s.Shutdown(); err != nil {
+		t.Fatalf("first Shutdown returned error: %v", err)
+	}
+
+	// done must be closed after the first call. A receive on a closed
+	// channel returns immediately with the zero value.
+	select {
+	case <-s.done:
+		// expected
+	default:
+		t.Fatalf("expected s.done to be closed after first Shutdown")
+	}
+
+	// Second call must NOT panic (#6478). Before the fix this panicked
+	// with "close of closed channel" inside Shutdown.
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("second Shutdown panicked: %v", r)
+		}
+	}()
+	if err := s.Shutdown(); err != nil {
+		t.Fatalf("second Shutdown returned error: %v", err)
+	}
+}

--- a/pkg/k8s/argocd.go
+++ b/pkg/k8s/argocd.go
@@ -36,12 +36,17 @@ var argoTimestampLayouts = []string{
 // ListArgoApplications lists all ArgoCD Application resources across all clusters.
 // If ArgoCD CRDs are not installed on a cluster, that cluster is silently skipped.
 func (m *MultiClusterClient) ListArgoApplications(ctx context.Context) (*v1alpha1.ArgoApplicationList, error) {
-	m.mu.RLock()
-	clusters := make([]string, 0, len(m.clients))
-	for name := range m.clients {
-		clusters = append(clusters, name)
+	// Use DeduplicatedClusters so newly-added kubeconfig contexts (hot reload)
+	// are picked up immediately, instead of snapshotting m.clients which only
+	// contains contexts whose clients have already been lazily created (#6476).
+	dedupClusters, err := m.DeduplicatedClusters(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list clusters: %w", err)
 	}
-	m.mu.RUnlock()
+	clusters := make([]string, 0, len(dedupClusters))
+	for _, c := range dedupClusters {
+		clusters = append(clusters, c.Name)
+	}
 
 	var wg sync.WaitGroup
 	var mu sync.Mutex
@@ -190,12 +195,17 @@ func parseArgoTimeAgo(timeStr string) string {
 // ListArgoApplicationSets lists all ArgoCD ApplicationSet resources across all clusters.
 // If ArgoCD CRDs are not installed on a cluster, that cluster is silently skipped.
 func (m *MultiClusterClient) ListArgoApplicationSets(ctx context.Context) (*v1alpha1.ArgoApplicationSetList, error) {
-	m.mu.RLock()
-	clusters := make([]string, 0, len(m.clients))
-	for name := range m.clients {
-		clusters = append(clusters, name)
+	// Use DeduplicatedClusters so newly-added kubeconfig contexts (hot reload)
+	// are picked up immediately, instead of snapshotting m.clients which only
+	// contains contexts whose clients have already been lazily created (#6476).
+	dedupClusters, err := m.DeduplicatedClusters(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list clusters: %w", err)
 	}
-	m.mu.RUnlock()
+	clusters := make([]string, 0, len(dedupClusters))
+	for _, c := range dedupClusters {
+		clusters = append(clusters, c.Name)
+	}
 
 	var wg sync.WaitGroup
 	var mu sync.Mutex

--- a/pkg/k8s/argocd_test.go
+++ b/pkg/k8s/argocd_test.go
@@ -1,0 +1,150 @@
+package k8s
+
+import (
+	"context"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	dynfake "k8s.io/client-go/dynamic/fake"
+	"k8s.io/client-go/tools/clientcmd/api"
+
+	"github.com/kubestellar/console/pkg/api/v1alpha1"
+)
+
+// newArgoApp builds a minimal unstructured ArgoCD Application object.
+func newArgoApp(name, ns string) *unstructured.Unstructured {
+	return &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "argoproj.io/v1alpha1",
+			"kind":       "Application",
+			"metadata": map[string]interface{}{
+				"name":      name,
+				"namespace": ns,
+			},
+			"spec":   map[string]interface{}{},
+			"status": map[string]interface{}{},
+		},
+	}
+}
+
+// argoGVRMap is the minimal GVR→ListKind mapping needed by the fake
+// dynamic client to serve ArgoCD Application / ApplicationSet list calls.
+func argoGVRMap() map[schema.GroupVersionResource]string {
+	return map[schema.GroupVersionResource]string{
+		v1alpha1.ArgoApplicationGVR:    "ApplicationList",
+		v1alpha1.ArgoApplicationSetGVR: "ApplicationSetList",
+	}
+}
+
+// TestListArgoApplications_SeesNewContextAfterHotReload is a regression test
+// for #6476. Previously ListArgoApplications snapshotted m.clients under a
+// read lock, so contexts added to the kubeconfig after startup (hot reload)
+// were silently dropped until their kubernetes client was lazily created on
+// some other code path. After the fix it iterates DeduplicatedClusters() and
+// lets GetDynamicClient lazily pick up newly-added contexts.
+func TestListArgoApplications_SeesNewContextAfterHotReload(t *testing.T) {
+	m, _ := NewMultiClusterClient("")
+
+	// Start with ONE context (c1) — this simulates the state right after
+	// startup with one cluster loaded. c1's kubernetes client has not been
+	// created yet, so m.clients is empty. The old code would have returned
+	// zero clusters here.
+	m.rawConfig = &api.Config{
+		Contexts: map[string]*api.Context{
+			"c1": {Cluster: "cl1"},
+		},
+		Clusters: map[string]*api.Cluster{
+			"cl1": {Server: "https://cluster-1.example"},
+		},
+	}
+
+	// Pre-seed dynamic clients so ListArgoApplicationsForCluster's
+	// GetDynamicClient call finds a cached entry (no real config needed).
+	scheme := runtime.NewScheme()
+	gvrMap := argoGVRMap()
+	m.dynamicClients["c1"] = dynfake.NewSimpleDynamicClientWithCustomListKinds(
+		scheme, gvrMap, newArgoApp("app-c1", "argocd"),
+	)
+
+	// Hot reload: a new context (c2) is added to the kubeconfig. Its
+	// kubernetes client is NOT in m.clients — which is exactly the
+	// condition that triggered #6476.
+	m.rawConfig.Contexts["c2"] = &api.Context{Cluster: "cl2"}
+	m.rawConfig.Clusters["cl2"] = &api.Cluster{Server: "https://cluster-2.example"}
+	m.dynamicClients["c2"] = dynfake.NewSimpleDynamicClientWithCustomListKinds(
+		scheme, gvrMap, newArgoApp("app-c2", "argocd"),
+	)
+
+	// Note: m.clients is intentionally left empty. The old implementation
+	// would produce zero results; the new one must see both clusters.
+	if len(m.clients) != 0 {
+		t.Fatalf("precondition: expected m.clients empty to simulate no-lazy-client state, got %d", len(m.clients))
+	}
+
+	got, err := m.ListArgoApplications(context.Background())
+	if err != nil {
+		t.Fatalf("ListArgoApplications returned error: %v", err)
+	}
+
+	if got.TotalCount != 2 {
+		t.Errorf("expected 2 apps across both contexts, got %d (items=%+v)", got.TotalCount, got.Items)
+	}
+
+	seen := map[string]bool{}
+	for _, app := range got.Items {
+		seen[app.Cluster] = true
+	}
+	if !seen["c1"] || !seen["c2"] {
+		t.Errorf("expected apps from both c1 and c2, got clusters=%v", seen)
+	}
+}
+
+// TestListArgoApplicationSets_SeesNewContextAfterHotReload mirrors the above
+// for the ApplicationSets list path, which had the same m.clients snapshot
+// bug (#6476).
+func TestListArgoApplicationSets_SeesNewContextAfterHotReload(t *testing.T) {
+	m, _ := NewMultiClusterClient("")
+
+	m.rawConfig = &api.Config{
+		Contexts: map[string]*api.Context{
+			"c1": {Cluster: "cl1"},
+			"c2": {Cluster: "cl2"},
+		},
+		Clusters: map[string]*api.Cluster{
+			"cl1": {Server: "https://cluster-1.example"},
+			"cl2": {Server: "https://cluster-2.example"},
+		},
+	}
+
+	scheme := runtime.NewScheme()
+	gvrMap := argoGVRMap()
+
+	appSet := func(name string) *unstructured.Unstructured {
+		return &unstructured.Unstructured{
+			Object: map[string]interface{}{
+				"apiVersion": "argoproj.io/v1alpha1",
+				"kind":       "ApplicationSet",
+				"metadata": map[string]interface{}{
+					"name":      name,
+					"namespace": "argocd",
+				},
+				"spec": map[string]interface{}{},
+			},
+		}
+	}
+
+	m.dynamicClients["c1"] = dynfake.NewSimpleDynamicClientWithCustomListKinds(scheme, gvrMap, appSet("as-c1"))
+	m.dynamicClients["c2"] = dynfake.NewSimpleDynamicClientWithCustomListKinds(scheme, gvrMap, appSet("as-c2"))
+
+	// m.clients is empty — pre-fix, the ListArgoApplicationSets loop would
+	// iterate nothing.
+	got, err := m.ListArgoApplicationSets(context.Background())
+	if err != nil {
+		t.Fatalf("ListArgoApplicationSets returned error: %v", err)
+	}
+	if got.TotalCount != 2 {
+		t.Errorf("expected 2 applicationsets across both contexts, got %d", got.TotalCount)
+	}
+}


### PR DESCRIPTION
## Summary

Two small Go backend fixes shipped together.

### #6476 — ListArgoApplications uses stale m.clients snapshot
`ListArgoApplications` and `ListArgoApplicationSets` (in `pkg/k8s/argocd.go`) built their cluster list by snapshot-copying `m.clients` under a read lock. `m.clients` only contains contexts whose kubernetes client has already been lazily created — so a context added to the kubeconfig **after** startup (hot reload) was silently dropped from ArgoCD listings until some other code path happened to create its client.

Fix: iterate `m.DeduplicatedClusters(ctx)` (the canonical cluster-iteration path — see `feedback_dedupe_clusters.md`) and let `ListArgoApplicationsForCluster` → `GetDynamicClient` lazily create the client for newly-added contexts. Matches the pattern already used in `pkg/k8s/workload.go`.

### #6478 — Server shutdown not idempotent
`Server.Shutdown` closed `s.done` directly. A second call panicked with `close of closed channel`. Wrapped the whole teardown in `sync.Once` (new `shutdownOnce` field) so subsequent calls are safe no-ops, and threaded the return error through the closure.

## Regression tests

- `TestListArgoApplications_SeesNewContextAfterHotReload` — seeds `rawConfig` with two contexts, leaves `m.clients` empty, pre-seeds dynamic fakes, asserts both clusters' apps appear. Pre-fix would have returned 0.
- `TestListArgoApplicationSets_SeesNewContextAfterHotReload` — same shape for the ApplicationSets path.
- `TestShutdown_Idempotent` — constructs a minimal Server with a temp sqlite store, fiber app, and hub; calls `Shutdown()` twice; asserts no panic on the second call and that `s.done` is closed after the first.

## Verification

- `go build ./...` pass
- `go vet ./...` pass
- `go test ./... -race -timeout 180s` pass (all packages)

Fixes #6476
Fixes #6478