### PR TITLE
fix: Copilot followups — SWR, z-index semantic, error wrapping, aggregator, env test, nil ctx, wave9 nits (#6539, #6547, #6548)

### DIFF
--- a/pkg/api/v1alpha1/mcs_types.go
+++ b/pkg/api/v1alpha1/mcs_types.go
@@ -87,16 +87,29 @@ type Condition struct {
 	LastTransitionTime time.Time `json:"lastTransitionTime,omitempty"`
 }
 
+// MCSClusterError records a per-cluster failure during a multi-cluster
+// ServiceExport/ServiceImport aggregation. Mirrors the handler-level
+// ClusterError type used for the /api/service-exports endpoint (#6483),
+// and is reported in-band so callers can distinguish "no exports" from
+// "cluster could not be queried" (#6547).
+type MCSClusterError struct {
+	Cluster   string `json:"cluster"`
+	ErrorType string `json:"errorType,omitempty"`
+	Message   string `json:"message"`
+}
+
 // ServiceExportList is a list of ServiceExports
 type ServiceExportList struct {
-	Items      []ServiceExport `json:"items"`
-	TotalCount int             `json:"totalCount"`
+	Items         []ServiceExport   `json:"items"`
+	TotalCount    int               `json:"totalCount"`
+	ClusterErrors []MCSClusterError `json:"clusterErrors,omitempty"`
 }
 
 // ServiceImportList is a list of ServiceImports
 type ServiceImportList struct {
-	Items      []ServiceImport `json:"items"`
-	TotalCount int             `json:"totalCount"`
+	Items         []ServiceImport   `json:"items"`
+	TotalCount    int               `json:"totalCount"`
+	ClusterErrors []MCSClusterError `json:"clusterErrors,omitempty"`
 }
 
 // ClusterServiceSummary provides a per-cluster summary of MCS resources

--- a/pkg/k8s/client_health.go
+++ b/pkg/k8s/client_health.go
@@ -414,8 +414,10 @@ func (m *MultiClusterClient) GetAllClusterHealth(ctx context.Context) ([]Cluster
 	select {
 	case <-waitCh:
 	case <-deadlineCtx.Done():
-		// Global deadline exceeded — give stragglers a brief grace window so
-		// the goroutine records its own result before we synthesize a timeout.
+		// Global deadline exceeded — any slots still marked !done will be
+		// synthesized as timeout entries in the loop below. We do not wait
+		// any additional grace period here; doing so would extend the caller's
+		// effective timeout beyond deadlineCtx. (#6547)
 	}
 
 	now := time.Now().Format(time.RFC3339)

--- a/pkg/k8s/mcs.go
+++ b/pkg/k8s/mcs.go
@@ -50,6 +50,11 @@ func (m *MultiClusterClient) ListServiceExports(ctx context.Context) (*v1alpha1.
 	var wg sync.WaitGroup
 	var mu sync.Mutex
 	exports := make([]v1alpha1.ServiceExport, 0)
+	// Per-cluster error accumulator — must not silently drop whole clusters
+	// on a real error now that ListServiceExportsForCluster correctly returns
+	// non-CRD-missing errors (#6547). Mirrors the handler-level ClusterErrors
+	// pattern used by /api/service-exports (#6483).
+	clusterErrors := make([]v1alpha1.MCSClusterError, 0)
 
 	for _, clusterName := range clusters {
 		wg.Add(1)
@@ -58,6 +63,13 @@ func (m *MultiClusterClient) ListServiceExports(ctx context.Context) (*v1alpha1.
 
 			clusterExports, err := m.ListServiceExportsForCluster(ctx, cluster, "")
 			if err != nil {
+				mu.Lock()
+				clusterErrors = append(clusterErrors, v1alpha1.MCSClusterError{
+					Cluster:   cluster,
+					ErrorType: "list_failed",
+					Message:   err.Error(),
+				})
+				mu.Unlock()
 				return
 			}
 
@@ -70,8 +82,9 @@ func (m *MultiClusterClient) ListServiceExports(ctx context.Context) (*v1alpha1.
 	wg.Wait()
 
 	return &v1alpha1.ServiceExportList{
-		Items:      exports,
-		TotalCount: len(exports),
+		Items:         exports,
+		TotalCount:    len(exports),
+		ClusterErrors: clusterErrors,
 	}, nil
 }
 
@@ -144,6 +157,8 @@ func (m *MultiClusterClient) ListServiceImports(ctx context.Context) (*v1alpha1.
 	var wg sync.WaitGroup
 	var mu sync.Mutex
 	imports := make([]v1alpha1.ServiceImport, 0)
+	// Per-cluster error accumulator — see ListServiceExports for rationale (#6547).
+	clusterErrors := make([]v1alpha1.MCSClusterError, 0)
 
 	for _, clusterName := range clusters {
 		wg.Add(1)
@@ -152,6 +167,13 @@ func (m *MultiClusterClient) ListServiceImports(ctx context.Context) (*v1alpha1.
 
 			clusterImports, err := m.ListServiceImportsForCluster(ctx, cluster, "")
 			if err != nil {
+				mu.Lock()
+				clusterErrors = append(clusterErrors, v1alpha1.MCSClusterError{
+					Cluster:   cluster,
+					ErrorType: "list_failed",
+					Message:   err.Error(),
+				})
+				mu.Unlock()
 				return
 			}
 
@@ -164,8 +186,9 @@ func (m *MultiClusterClient) ListServiceImports(ctx context.Context) (*v1alpha1.
 	wg.Wait()
 
 	return &v1alpha1.ServiceImportList{
-		Items:      imports,
-		TotalCount: len(imports),
+		Items:         imports,
+		TotalCount:    len(imports),
+		ClusterErrors: clusterErrors,
 	}, nil
 }
 

--- a/pkg/k8s/rbac.go
+++ b/pkg/k8s/rbac.go
@@ -771,6 +771,13 @@ type userNamespaceCtxKey struct{}
 // calling into k8s client helpers so namespace probing prefers the user's
 // own namespace (#6512).
 func WithUserNamespace(ctx context.Context, ns string) context.Context {
+	// Guard against a nil parent ctx — context.WithValue panics on nil.
+	// userNamespaceFromContext already tolerates a nil ctx, so stay
+	// symmetric and fall back to a background context if a caller hands
+	// us nil (#6547).
+	if ctx == nil {
+		ctx = context.Background()
+	}
 	if ns == "" {
 		return ctx
 	}

--- a/pkg/k8s/wave8c_regression_test.go
+++ b/pkg/k8s/wave8c_regression_test.go
@@ -3,7 +3,6 @@ package k8s
 import (
 	"context"
 	"errors"
-	"os"
 	"testing"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -95,7 +94,11 @@ func TestBuildProbeNamespaces(t *testing.T) {
 		}
 	})
 	t.Run("user namespace dedup with default", func(t *testing.T) {
-		os.Unsetenv(probeNamespacesEnvVar)
+		// Use t.Setenv("") to clear the env var for the duration of this
+		// subtest; Go auto-restores it on cleanup so parallel tests that
+		// read the same variable don't flake (#6547). os.Unsetenv mutated
+		// global process state without restoration.
+		t.Setenv(probeNamespacesEnvVar, "")
 		got := buildProbeNamespaces("default")
 		// "default" should appear only once and be first
 		count := 0

--- a/pkg/k8s/workload.go
+++ b/pkg/k8s/workload.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -479,13 +480,20 @@ func (m *MultiClusterClient) GetWorkload(ctx context.Context, cluster, namespace
 		obj, getErr := dynamicClient.Resource(k.gvr).Namespace(namespace).Get(ctx, name, metav1.GetOptions{})
 		if getErr != nil {
 			if apierrors.IsNotFound(getErr) {
-				// Expected — try the next kind.
+				// Expected — this kind doesn't have an object with that name. Try next.
 				continue
 			}
-			// Unexpected error (auth, network, server). Fall back to the
-			// old list-based path so the caller never regresses to a hard
-			// failure just because one kind happened to be unavailable.
-			return m.getWorkloadByList(ctx, cluster, namespace, name)
+			if apimeta.IsNoMatchError(getErr) {
+				// The cluster doesn't know about this GVR (older k8s, CRD missing,
+				// or discovery cache stale). Fall back to the legacy list-based
+				// path which handles kind-availability gracefully. (#6547)
+				return m.getWorkloadByList(ctx, cluster, namespace, name)
+			}
+			// Real error (auth, network, server). Do NOT silently fall through
+			// to the list path — that path logs-and-swallows list errors and
+			// would turn an auth failure into a false "not found". Return it
+			// so callers can surface the underlying problem. (#6547)
+			return nil, fmt.Errorf("get %s/%s in %s: %w", k.gvr.Resource, name, namespace, getErr)
 		}
 		list := &unstructured.UnstructuredList{Items: []unstructured.Unstructured{*obj}}
 		parsed := k.parser(list, cluster)
@@ -691,8 +699,10 @@ func (m *MultiClusterClient) DeployWorkload(ctx context.Context, sourceCluster, 
 						// Genuine "does not exist" — the Create error is authoritative.
 						lastErr = fmt.Errorf("cluster %s: create failed: %w", targetCluster, err)
 					} else {
-						// Non-NotFound Get error (network, auth, server) — surface both.
-						lastErr = fmt.Errorf("cluster %s: create failed: %w; also get failed: %v", targetCluster, err, getErr)
+						// Non-NotFound Get error (network, auth, server) — surface
+						// BOTH errors with %w so callers can errors.Is/As either
+						// one. Go 1.20+ supports multi-error %w. (#6547)
+						lastErr = fmt.Errorf("cluster %s: create failed: %w; also get failed: %w", targetCluster, err, getErr)
 					}
 					mu.Unlock()
 					return

--- a/web/src/components/agent/AgentSelector.tsx
+++ b/web/src/components/agent/AgentSelector.tsx
@@ -402,7 +402,7 @@ export function AgentSelector({ compact = false, className = '' }: AgentSelector
           ref={panelRef}
           role="listbox"
           aria-label={t('agent.selectAgent')}
-          className="fixed z-[250] w-96 max-h-[calc(100vh-8rem)] rounded-lg bg-card border border-border shadow-lg overflow-hidden flex flex-col"
+          className="fixed z-floating w-96 max-h-[calc(100vh-8rem)] rounded-lg bg-card border border-border shadow-lg overflow-hidden flex flex-col"
           style={{ top: dropdownPos.top, right: dropdownPos.right }}
           onKeyDown={(e) => {
             if (e.key !== 'ArrowDown' && e.key !== 'ArrowUp') return

--- a/web/src/components/cluster-admin/ClusterAdmin.tsx
+++ b/web/src/components/cluster-admin/ClusterAdmin.tsx
@@ -24,24 +24,36 @@ export function ClusterAdmin() {
   const warningEvents = rawWarningEvents || []
   const nodes = rawNodes || []
 
-  // Stale-while-revalidate: remember the last non-zero values for Nodes/Warnings
-  // so refreshes don't flash 0 → final value (issue #6485). During a refresh,
+  // Stale-while-revalidate: remember the last observed values for Nodes/Warnings/Pod
+  // Issues so refreshes don't flash 0 → final value (issue #6485). During a refresh,
   // the underlying hooks briefly return empty arrays before the new fetch resolves.
-  const lastNodeCountRef = useRef(0)
-  const lastWarningCountRef = useRef(0)
-  const lastPodIssueCountRef = useRef(0)
+  //
+  // Copilot fix (#6539): the fallback is ONLY applied while a load is in-flight and
+  // we have a prior non-null value. Once loading completes, we trust the fetch result
+  // even when it is zero — otherwise legitimate "all warnings cleared" / "all pod
+  // issues resolved" transitions are masked by the last non-zero value.
+  const lastNodeCountRef = useRef<number | null>(null)
+  const lastWarningCountRef = useRef<number | null>(null)
+  const lastPodIssueCountRef = useRef<number | null>(null)
   useEffect(() => {
-    if (!isLoadingNodes && nodes.length > 0) lastNodeCountRef.current = nodes.length
+    if (!isLoadingNodes) lastNodeCountRef.current = nodes.length
   }, [isLoadingNodes, nodes.length])
   useEffect(() => {
-    if (!isLoadingWarnings && warningEvents.length > 0) lastWarningCountRef.current = warningEvents.length
+    if (!isLoadingWarnings) lastWarningCountRef.current = warningEvents.length
   }, [isLoadingWarnings, warningEvents.length])
   useEffect(() => {
-    if (!isLoadingPodIssues && podIssues.length > 0) lastPodIssueCountRef.current = podIssues.length
+    if (!isLoadingPodIssues) lastPodIssueCountRef.current = podIssues.length
   }, [isLoadingPodIssues, podIssues.length])
-  const displayNodeCount = nodes.length > 0 ? nodes.length : lastNodeCountRef.current
-  const displayWarningCount = warningEvents.length > 0 ? warningEvents.length : lastWarningCountRef.current
-  const displayPodIssueCount = podIssues.length > 0 ? podIssues.length : lastPodIssueCountRef.current
+  const displayNodeCount =
+    isLoadingNodes && lastNodeCountRef.current != null ? lastNodeCountRef.current : nodes.length
+  const displayWarningCount =
+    isLoadingWarnings && lastWarningCountRef.current != null
+      ? lastWarningCountRef.current
+      : warningEvents.length
+  const displayPodIssueCount =
+    isLoadingPodIssues && lastPodIssueCountRef.current != null
+      ? lastPodIssueCountRef.current
+      : podIssues.length
 
   // Use the centralised health state machine so these counts always agree
   // with the main cluster grid, sidebar stats and filter tabs (#5928).

--- a/web/src/components/layout/Layout.tsx
+++ b/web/src/components/layout/Layout.tsx
@@ -502,7 +502,11 @@ export function Layout({ children: _children }: LayoutProps) {
           // entire main column past the viewport at narrow breakpoints
           // (issues 6385, 6387, 6394). Individual scrollable children
           // (tables, code blocks) still scroll horizontally inside wrappers.
-          className="relative flex-1 p-4 pb-[calc(6rem+env(safe-area-inset-bottom))] md:p-6 md:pb-[calc(7rem+env(safe-area-inset-bottom))] transition-[margin] duration-300 overflow-y-auto overflow-x-hidden scroll-enhanced min-w-0"
+          // pb-24/pb-28 is the baseline so browsers without env() support
+          // still get valid bottom padding; the calc(...env()) variants
+          // extend it by the safe-area inset when supported. If the whole
+          // calc() value were invalid it would drop padding entirely (#6548).
+          className="relative flex-1 p-4 pb-24 pb-[calc(6rem+env(safe-area-inset-bottom))] md:p-6 md:pb-28 md:pb-[calc(7rem+env(safe-area-inset-bottom))] transition-[margin] duration-300 overflow-y-auto overflow-x-hidden scroll-enhanced min-w-0"
         >
           <NavigationProgress />
           <Suspense fallback={<ContentLoadingSkeleton />}>

--- a/web/src/components/layout/Sidebar.tsx
+++ b/web/src/components/layout/Sidebar.tsx
@@ -358,7 +358,7 @@ export function Sidebar() {
                   if (e.key === 'Escape') { setEditingItemId(null); setEditingName('') }
                 }}
                 autoFocus
-                className="w-[150px] md:w-full flex-1 flex-shrink bg-transparent border-b border-purple-500 outline-none text-foreground text-sm min-w-0"
+                className="w-[150px] md:w-full md:flex-1 shrink bg-transparent border-b border-purple-500 outline-none text-foreground text-sm min-w-0"
               />
             )}
             {!isCollapsed && <GripVertical className="w-3.5 h-3.5 text-muted-foreground/50 flex-shrink-0" />}

--- a/web/src/components/layout/mission-sidebar/MissionSidebar.tsx
+++ b/web/src/components/layout/mission-sidebar/MissionSidebar.tsx
@@ -586,7 +586,9 @@ export function MissionSidebar() {
           "fixed bg-card border-border z-modal flex flex-col overflow-hidden shadow-2xl",
           !isResizing && "transition-[width,top,border,transform] duration-300 ease-in-out",
           // Mobile: bottom sheet
-          isMobile && "inset-x-0 bottom-0 rounded-t-2xl border-t max-h-[80dvh]",
+          // vh fallback before dvh so browsers without dynamic-viewport-unit
+          // support still cap the sheet height (#6548).
+          isMobile && "inset-x-0 bottom-0 rounded-t-2xl border-t max-h-[80vh] max-h-[80dvh]",
           isMobile && !isSidebarOpen && "translate-y-full pointer-events-none",
           isMobile && isSidebarOpen && "translate-y-0",
           // Desktop: right sidebar

--- a/web/src/components/layout/navbar/Navbar.tsx
+++ b/web/src/components/layout/navbar/Navbar.tsx
@@ -205,14 +205,14 @@ export function Navbar({ topOffset = 0 }: NavbarProps) {
                 onClick={() => setShowMobileMore(false)}
               />
               {/* Bottom sheet menu on mobile */}
-              <div className={`fixed ${isMobile ? 'inset-x-0 bottom-0 rounded-t-2xl max-h-[60dvh]' : 'right-4 w-64 rounded-lg'} bg-card border border-border shadow-xl z-modal overflow-hidden`} style={isMobile ? undefined : { top: topOffset + NAVBAR_HEIGHT_PX }}>
+              <div className={`fixed ${isMobile ? 'inset-x-0 bottom-0 rounded-t-2xl max-h-[60vh] max-h-[60dvh]' : 'right-4 w-64 rounded-lg'} bg-card border border-border shadow-xl z-modal overflow-hidden`} style={isMobile ? undefined : { top: topOffset + NAVBAR_HEIGHT_PX }}>
                 {/* Drag handle for mobile */}
                 {isMobile && (
                   <div className="flex justify-center py-2">
                     <div className="w-10 h-1 bg-muted-foreground/30 rounded-full" />
                   </div>
                 )}
-                <div className={`${isMobile ? 'max-h-[calc(60dvh-24px)]' : ''} overflow-y-auto py-2`}>
+                <div className={`${isMobile ? 'max-h-[calc(60vh-24px)] max-h-[calc(60dvh-24px)]' : ''} overflow-y-auto py-2`}>
                   {/* Search on mobile */}
                   <div className="px-3 py-2 sm:hidden">
                     <Suspense fallback={null}><SearchDropdown /></Suspense>

--- a/web/tailwind.config.js
+++ b/web/tailwind.config.js
@@ -62,6 +62,8 @@ export default {
        *
        * z-dropdown (100) — Popovers, dropdowns, tooltips, floating panels
        * z-sticky   (200) — Sticky headers, floating action buttons
+       * z-floating (250) — Portaled floating menus that must sit above sticky headers
+       *                    but below non-modal overlays (e.g. agent selector dropdown)
        * z-overlay  (300) — Non-modal backdrops (mobile sidebar, notification dimmer)
        * z-modal    (400) — All modals and dialogs
        * z-toast    (500) — Toast notifications (always on top of modals)
@@ -72,6 +74,7 @@ export default {
       zIndex: {
         dropdown: '100',
         sticky: '200',
+        floating: '250',
         overlay: '300',
         modal: '400',
         toast: '500',


### PR DESCRIPTION
## Summary

Addresses Copilot review comments from three prior waves.

### #6539 (PR #6516 followups)
- **ClusterAdmin SWR**: gate fallback on `isLoading && lastValue != null` so legitimate zero transitions (all warnings cleared, all pod issues resolved) are no longer masked by the last non-zero count
- **AgentSelector z-index**: replace arbitrary `z-[250]` with new semantic `z-floating` token added to `tailwind.config.js` between `z-sticky` (200) and `z-overlay` (300) for portaled floating menus

### #6547 (PR #6526 followups)
- **workload.go GetWorkload**: only fall through to the list-based path on NotFound (try next kind) or NoMatchError (GVR missing). Real errors (auth, network, server) are now wrapped and returned instead of swallowed
- **workload.go create/update**: wrap BOTH create and get errors with %w (Go 1.20+ multi-error) so callers can errors.Is/As either one
- **client_health.go**: correct the "grace window" comment — we do not wait past deadlineCtx; stragglers are synthesized as timeout entries in the subsequent loop
- **mcs.go aggregators**: add per-cluster error accumulator. Failed clusters surface in ClusterErrors on the response list types (new MCSClusterError type on v1alpha1) instead of being silently dropped. Mirrors the handler-level #6483 pattern
- **wave8c_regression_test.go**: replace os.Unsetenv with t.Setenv("") so the env var is auto-restored after the subtest
- **rbac.go WithUserNamespace**: guard nil parent ctx, falling back to context.Background() (symmetric with userNamespaceFromContext)

### #6548 (PR #6546 wave9 mobile followups)
- **Sidebar.tsx**: replace invalid flex-shrink utility with shrink; gate flex-1 on md: so it doesn't override the intended fixed w-[150px] on mobile
- **Navbar.tsx**: add max-h-[60vh] fallback before max-h-[60dvh] on the mobile more-menu sheet
- **MissionSidebar.tsx**: same vh fallback for max-h-[80dvh] bottom sheet
- **Layout.tsx**: add pb-24 / md:pb-28 baseline before the calc(env(...)) arbitrary values so browsers without env() support still get valid bottom padding

## Verification
- go build ./... — pass
- go vet ./... — pass
- go test ./pkg/k8s/ -race -timeout 180s — pass
- cd web && npm run build — pass
- npx vitest run src/components/cluster-admin src/components/agent src/test/ui-ux-standards.test.ts — 37/37 pass
- npm run lint — no new errors in touched files

Fixes #6539
Fixes #6547
Fixes #6548