### PR TITLE
fix: PR #6503 aftermath — concurrency races, storage comment, feedback fetch, test (#6517, #6518)

### DIFF
--- a/pkg/api/handlers/feedback.go
+++ b/pkg/api/handlers/feedback.go
@@ -275,8 +275,18 @@ type QueueItem struct {
 // ListAllFeatureRequests returns all issues from GitHub as a queue
 // For untriaged issues that don't belong to the current user, title and description are redacted
 // Frontend will display these with blur effect
+//
+// PR #6518 item G — supports `?count_only=true` which returns a minimal
+// payload of just {id, status} pairs for every queue item. The navbar
+// FeatureRequestButton only needs closed-request IDs (to filter notifications
+// for the badge count) and does not render titles/descriptions/bodies on
+// mount, so requesting the full queue on every page load wastes bandwidth
+// and CPU. The lean response still requires the GitHub round-trip (we need
+// each issue's current status/labels) but avoids serializing bodies, titles,
+// and user-blurring logic the client doesn't consume.
 func (h *FeedbackHandler) ListAllFeatureRequests(c *fiber.Ctx) error {
 	userID := middleware.GetUserID(c)
+	countOnly := c.Query("count_only") == "true"
 
 	// Get current user's GitHub login for ownership comparison
 	user, _ := h.store.GetUser(userID)
@@ -386,6 +396,18 @@ func (h *FeedbackHandler) ListAllFeatureRequests(c *fiber.Ctx) error {
 
 		// Check if issue was closed by the current user (the one viewing the queue)
 		closedByUser := issue.State == "closed" && issue.ClosedBy != nil && issue.ClosedBy.Login == currentGitHubLogin
+
+		// PR #6518 item G — count_only responses carry only id + status, no
+		// titles or bodies. The client uses these to compute the navbar
+		// badge (which filters notifications by the set of closed-request
+		// IDs); nothing else is needed for that path.
+		if countOnly {
+			queueItems = append(queueItems, QueueItem{
+				ID:     fmt.Sprintf("gh-%s-%d", tagged.TargetRepo, issue.Number),
+				Status: status,
+			})
+			continue
+		}
 
 		queueItems = append(queueItems, QueueItem{
 			ID:                fmt.Sprintf("gh-%s-%d", tagged.TargetRepo, issue.Number),

--- a/pkg/k8s/client.go
+++ b/pkg/k8s/client.go
@@ -893,22 +893,35 @@ func (m *MultiClusterClient) RemoveContext(contextName string) error {
 // second watcher goroutine. Previously every call created a fresh
 // fsnotify.Watcher and watchLoop goroutine, orphaning the previous one.
 func (m *MultiClusterClient) StartWatching() error {
+	// PR #6518 item A — hold the lock across the check-and-set so two
+	// concurrent callers can't both see watching=false and both install a
+	// watcher (previous impl dropped the lock, created a fresh fsnotify
+	// watcher, then re-acquired — the loser leaked a watcher + goroutine).
 	m.mu.Lock()
 	if m.watching {
 		m.mu.Unlock()
 		slog.Info("kubeconfig watcher already running, skipping StartWatching")
 		return nil
 	}
+	// Reserve ownership immediately. If watcher construction fails below
+	// we roll this back before returning the error.
+	m.watching = true
 	m.mu.Unlock()
 
 	watcher, err := fsnotify.NewWatcher()
 	if err != nil {
+		m.mu.Lock()
+		m.watching = false
+		m.mu.Unlock()
 		return fmt.Errorf("failed to create watcher: %w", err)
 	}
 
 	// Watch the kubeconfig file
 	if err := watcher.Add(m.kubeconfig); err != nil {
 		watcher.Close()
+		m.mu.Lock()
+		m.watching = false
+		m.mu.Unlock()
 		return fmt.Errorf("failed to watch kubeconfig: %w", err)
 	}
 
@@ -926,7 +939,6 @@ func (m *MultiClusterClient) StartWatching() error {
 	// succeeded but watchLoop exited immediately because stopWatch was closed.
 	m.stopWatch = make(chan struct{})
 	m.stopWatchOnce = sync.Once{}
-	m.watching = true
 	// Snapshot for the goroutine so it reads a stable value even if a
 	// concurrent Stop+Start rotates m.stopWatch.
 	stopCh := m.stopWatch
@@ -955,14 +967,19 @@ func (m *MultiClusterClient) reloadAndNotify() {
 	}
 	slog.Info("Kubeconfig reloaded successfully")
 
-	// Re-add file watch — after atomic writes (rm+create or rename-over),
-	// the old inode-level watch is dead. This re-establishes it on the new inode.
-	if m.watcher != nil {
+	// PR #6518 item H — Re-add file watch under the lock. This runs from
+	// a debounce timer on a separate goroutine; without locking it races
+	// with StartWatching / StopWatching which mutate m.watcher. We also
+	// check m.watching so a Stop-then-timer-fires sequence doesn't touch
+	// a closed watcher.
+	m.mu.Lock()
+	if m.watching && m.watcher != nil {
 		_ = m.watcher.Remove(m.kubeconfig)
 		if err := m.watcher.Add(m.kubeconfig); err != nil {
 			slog.Warn("could not re-watch kubeconfig file", "error", err)
 		}
 	}
+	m.mu.Unlock()
 
 	// Notify listeners
 	m.mu.RLock()
@@ -1055,6 +1072,12 @@ func (m *MultiClusterClient) watchLoop(stopCh <-chan struct{}, watcher *fsnotify
 // The sync.Once guards the close; the watching flag prevents double-close
 // of the fsnotify watcher too.
 func (m *MultiClusterClient) StopWatching() {
+	// PR #6518 item B — hold the lock through once.Do so a concurrent
+	// Stop→Start that replaces m.stopWatchOnce cannot race with this Do.
+	// Previously we captured &m.stopWatchOnce then released the lock; a
+	// concurrent StartWatching could assign a fresh sync.Once to that
+	// address while this goroutine was still inside Do, producing a
+	// data race on the Once's internal state.
 	m.mu.Lock()
 	if !m.watching {
 		m.mu.Unlock()
@@ -1063,12 +1086,11 @@ func (m *MultiClusterClient) StopWatching() {
 	m.watching = false
 	stopCh := m.stopWatch
 	w := m.watcher
-	once := &m.stopWatchOnce
+	if stopCh != nil {
+		m.stopWatchOnce.Do(func() { close(stopCh) })
+	}
 	m.mu.Unlock()
 
-	if stopCh != nil {
-		once.Do(func() { close(stopCh) })
-	}
 	if w != nil {
 		w.Close()
 	}

--- a/pkg/k8s/watcher_lifecycle_test.go
+++ b/pkg/k8s/watcher_lifecycle_test.go
@@ -4,12 +4,19 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"sync"
 	"testing"
 	"time"
 
 	k8sruntime "k8s.io/apimachinery/pkg/runtime"
 	dynamicfake "k8s.io/client-go/dynamic/fake"
 )
+
+// concurrentStartCallers — number of goroutines used by the concurrency race
+// test for StartWatching. Chosen to be large enough that a naive unlocked
+// check-and-set would lose the race with high probability under `go test
+// -race`, while still completing quickly on CI.
+const concurrentStartCallers = 100
 
 // writeTempKubeconfig writes a minimal kubeconfig to a temp file and returns
 // its path. Used by the StartWatching/StopWatching lifecycle tests below.
@@ -167,6 +174,83 @@ func TestConsoleWatcher_Stop_DoubleCallSafe(t *testing.T) {
 
 	w.Stop()
 	w.Stop() // must not panic
+}
+
+// PR #6518 item A — StartWatching must be concurrency-safe. Many goroutines
+// calling StartWatching simultaneously must result in exactly one installed
+// watcher, not a race where the check-and-set gap lets two callers both
+// construct a fresh fsnotify.Watcher (leaking the loser). Run under
+// `go test -race` to catch unlocked mutation of m.watching / m.watcher.
+func TestMultiClusterClient_StartWatching_ConcurrentRace(t *testing.T) {
+	path := writeTempKubeconfig(t)
+	m, err := NewMultiClusterClient(path)
+	if err != nil {
+		t.Fatalf("NewMultiClusterClient: %v", err)
+	}
+
+	var wg sync.WaitGroup
+	errs := make(chan error, concurrentStartCallers)
+	start := make(chan struct{})
+	for i := 0; i < concurrentStartCallers; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			if e := m.StartWatching(); e != nil {
+				errs <- e
+			}
+		}()
+	}
+	close(start)
+	wg.Wait()
+	close(errs)
+	for e := range errs {
+		t.Fatalf("concurrent StartWatching error: %v", e)
+	}
+
+	// Exactly one watcher should be installed and watching must be true.
+	m.mu.Lock()
+	w := m.watcher
+	watching := m.watching
+	m.mu.Unlock()
+	if !watching {
+		t.Fatal("expected watching=true after concurrent StartWatching")
+	}
+	if w == nil {
+		t.Fatal("expected exactly one watcher to be installed")
+	}
+	m.StopWatching()
+}
+
+// PR #6518 item B — StopWatching must be concurrency-safe against
+// interleaved StartWatching calls that rotate m.stopWatchOnce. The previous
+// impl captured &m.stopWatchOnce then released the lock and called Do, which
+// raced with Start replacing the Once. Run under `go test -race`.
+func TestMultiClusterClient_StopStartRace(t *testing.T) {
+	path := writeTempKubeconfig(t)
+	m, err := NewMultiClusterClient(path)
+	if err != nil {
+		t.Fatalf("NewMultiClusterClient: %v", err)
+	}
+	if err := m.StartWatching(); err != nil {
+		t.Fatalf("initial StartWatching: %v", err)
+	}
+
+	var wg sync.WaitGroup
+	const cycles = 25 // kept modest because each cycle does real fsnotify I/O
+	for i := 0; i < cycles; i++ {
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			m.StopWatching()
+		}()
+		go func() {
+			defer wg.Done()
+			_ = m.StartWatching()
+		}()
+	}
+	wg.Wait()
+	m.StopWatching()
 }
 
 // Issue 6471 — The kubeconfig watcher must invoke onWatchError when an

--- a/web/e2e/Missions.spec.ts
+++ b/web/e2e/Missions.spec.ts
@@ -77,12 +77,18 @@ async function setupMissionsTest(page: Page) {
 
   // Mock GitHub mission listings used by the missions browser. An empty list
   // is fine for the dialog-renders test. Tests that need specific mission data
-  // must override this BEFORE setupMissionsTest() runs by using page.unroute()
-  // then re-registering — see the "project card" test below.
+  // must override this AFTER setupMissionsTest() runs by calling
+  // page.unroute('**/api/missions/list**') to drop this default handler, then
+  // registering a fresh page.route() with the desired response — see the
+  // "project card" test below.
   //
-  // #6474 — Previously we registered a second route handler inline in the
-  // specific test; the second registration does not override the first, so the
-  // empty-list handler won that race and the project-card test was dead.
+  // #6474 / PR #6518 item E — Previously we registered a second route handler
+  // inline in the specific test without unroute(); the second registration
+  // does NOT override the first — Playwright stacks handlers and matches in
+  // order, so the empty-list handler won that race and the project-card test
+  // was dead. Earlier comment incorrectly said "override BEFORE
+  // setupMissionsTest()" which was impossible (setupMissionsTest runs in
+  // beforeEach, before any test body).
   await page.route('**/api/missions/list**', (route) =>
     route.fulfill({
       status: 200,

--- a/web/package.json
+++ b/web/package.json
@@ -14,7 +14,7 @@
     "test": "vitest",
     "test:ui": "vitest --ui",
     "test:coverage": "vitest --coverage",
-    "test:e2e": "playwright test",
+    "test:e2e": "npm run build && playwright test",
     "test:e2e:ui": "playwright test --ui",
     "test:e2e:headed": "playwright test --headed",
     "test:e2e:debug": "playwright test --debug",

--- a/web/src/components/feedback/FeatureRequestButton.tsx
+++ b/web/src/components/feedback/FeatureRequestButton.tsx
@@ -13,7 +13,13 @@ export function FeatureRequestButton() {
   const { isOpen: isModalOpen, open: openModal, close: closeModal } = useModalState()
   const [initialRequestType, setInitialRequestType] = useState<RequestType | undefined>()
   const { notifications } = useNotifications()
-  const { requests } = useFeatureRequests()
+  // PR #6518 item G — this navbar button only needs the closed-request IDs
+  // to filter notifications for the badge count; it does not render any
+  // queue items, titles, or descriptions. Pass { countOnly: true } so the
+  // hook fetches the lean `?count_only=true` payload ({id, status} pairs).
+  // Consumers that render the full queue (FeatureRequestModal, Updates tab)
+  // must NOT pass this flag.
+  const { requests } = useFeatureRequests(undefined, { countOnly: true })
 
   // issue 6475 — Unify the navbar badge count with the Updates tab.
   // Previously the navbar used the raw `unreadCount` returned by

--- a/web/src/components/feedback/__tests__/FeatureRequestButton.test.tsx
+++ b/web/src/components/feedback/__tests__/FeatureRequestButton.test.tsx
@@ -32,8 +32,16 @@ vi.mock('react-i18next', () => ({
   Trans: ({ children }: { children: React.ReactNode }) => children,
 }))
 
+// PR #6518 / issue #6517 — FeatureRequestButton now consumes both
+// useNotifications AND useFeatureRequests (the unified badge-count fix for
+// issue 6475 filters notifications by the closed-status set). The previous
+// mock only provided useNotifications and returned `unreadCount` directly;
+// the component now uses `notifications`/`requests` arrays and re-computes
+// the count via useMemo. This mock returns the shape the component actually
+// reads today so `renders without crashing` holds.
 vi.mock('../../../hooks/useFeatureRequests', () => ({
-  useNotifications: () => ({ unreadCount: 0 }),
+  useNotifications: () => ({ notifications: [], unreadCount: 0 }),
+  useFeatureRequests: () => ({ requests: [] }),
 }))
 
 vi.mock('../../../lib/modals', () => ({

--- a/web/src/components/mission-control/useMissionControl.ts
+++ b/web/src/components/mission-control/useMissionControl.ts
@@ -101,7 +101,10 @@ export function buildInstallPromptForProject(
  * projects appear within one frame of the stream pausing.
  */
 const STREAM_JSON_DEBOUNCE_MS = 250
-/** #6468 — sessionStorage persist debounce window (ms). Coalesces bursts of state changes. */
+/** #6468 — localStorage persist debounce window (ms). Coalesces bursts of
+ * state changes before calling persistState(), which writes to localStorage
+ * (see STORAGE_KEY usage below). Earlier revision of this comment said
+ * "sessionStorage" which is incorrect — fixed in PR #6518 item D. */
 const PERSIST_STATE_DEBOUNCE_MS = 300
 
 // ---------------------------------------------------------------------------

--- a/web/src/components/missions/MissionBrowser.tsx
+++ b/web/src/components/missions/MissionBrowser.tsx
@@ -5,7 +5,7 @@
  * Sources: KubeStellar Community repo, GitHub repos with kubestellar-missions, local files.
  */
 
-import { useState, useEffect, useRef, useMemo } from 'react'
+import { useState, useEffect, useRef, useMemo, useCallback } from 'react'
 import {
   Search, X, Upload, Filter, Grid3X3, List, Sparkles, CheckCircle,
   Loader2, ExternalLink, RefreshCw } from 'lucide-react'
@@ -398,7 +398,11 @@ export function MissionBrowser({ isOpen, onClose, onImport, initialMission }: Mi
   // Track the latest selection to prevent stale async responses from overwriting
   const latestSelectionRef = useRef<string>('')
 
-  const selectCardMission = async (mission: MissionExport) => {
+  // PR #6518 item F — wrap in useCallback so the deep-link effect below can
+  // safely list it in its dependency array without thrashing every render.
+  // All captured references are either state setters (stable) or module-level
+  // imports (fetchMissionContent) — so the callback itself is stable.
+  const selectCardMission = useCallback(async (mission: MissionExport) => {
     // Use title + type as unique key (MissionExport has no id field)
     const selectionKey = `${mission.title}::${mission.type}`
     latestSelectionRef.current = selectionKey
@@ -427,7 +431,7 @@ export function MissionBrowser({ isOpen, onClose, onImport, initialMission }: Mi
         setIsMissionLoading(false)
       }
     }
-  }
+  }, [])
 
   // ============================================================================
   // Copy shareable link for a mission
@@ -548,11 +552,11 @@ export function MissionBrowser({ isOpen, onClose, onImport, initialMission }: Mi
     if (installerMissions.length === 0 && fixerMissions.length === 0 && activeTab !== 'installers') {
       setActiveTab('installers')
     }
-    // `selectCardMission` intentionally omitted — it's re-created every
-    // render and would cause this effect to thrash. We rely on the stable
-    // behavior: when data or `initialMission` changes, the effect runs and
-    // picks the best match using the current closure's selectCardMission.
-  }, [initialMission, isOpen, installerMissions, fixerMissions, selectedMission, activeTab])
+    // PR #6518 item F — `selectCardMission` is now wrapped in useCallback
+    // with an empty dep array, so it's a stable reference across renders.
+    // Including it in the dep array satisfies react-hooks/exhaustive-deps
+    // without causing the effect to re-run on every render.
+  }, [initialMission, isOpen, installerMissions, fixerMissions, selectedMission, activeTab, selectCardMission])
 
   // ============================================================================
   // Filtered installer & fixer lists

--- a/web/src/hooks/useFeatureRequests.ts
+++ b/web/src/hooks/useFeatureRequests.ts
@@ -235,14 +235,30 @@ function sortRequests(requests: FeatureRequest[], currentGitHubLogin: string): F
   return [...userRequests, ...otherRequests]
 }
 
+/**
+ * PR #6518 item G — Options for useFeatureRequests.
+ *
+ * `countOnly`: when true, the hook passes `?count_only=true` to
+ * `/api/feedback/queue`. The backend responds with a minimal payload of
+ * {id, status} pairs per issue — no titles, bodies, PR URLs, etc. The
+ * FeatureRequestButton navbar badge only needs the closed-ID set to filter
+ * notifications, so it can avoid fetching the full queue on every page load.
+ * Consumers that render queue items (FeatureRequestModal, etc.) must omit
+ * this flag so they receive the full response.
+ */
+export interface UseFeatureRequestsOptions {
+  countOnly?: boolean
+}
+
 // Feature Requests Hook
-export function useFeatureRequests(currentUserId?: string) {
+export function useFeatureRequests(currentUserId?: string, options?: UseFeatureRequestsOptions) {
   const [requests, setRequests] = useState<FeatureRequest[]>([])
   const [isLoading, setIsLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
   const [isSubmitting, setIsSubmitting] = useState(false)
   const [isRefreshing, setIsRefreshing] = useState(false)
   const isDemoMode = isDemoUser()
+  const countOnly = options?.countOnly === true
 
   const loadRequests = useCallback(async () => {
     // In demo mode, use mock data
@@ -254,8 +270,12 @@ export function useFeatureRequests(currentUserId?: string) {
     }
     try {
       setIsLoading(true)
-      // Fetch from queue endpoint to get all issues
-      const { data } = await api.get<FeatureRequest[]>('/api/feedback/queue')
+      // Fetch from queue endpoint to get all issues. When countOnly is set,
+      // the server returns {id, status} pairs only — enough to compute the
+      // navbar badge (filter notifications by closed request IDs) without
+      // fetching the full queue. See UseFeatureRequestsOptions above.
+      const url = countOnly ? '/api/feedback/queue?count_only=true' : '/api/feedback/queue'
+      const { data } = await api.get<FeatureRequest[]>(url)
       const safeData = Array.isArray(data) ? data : []
       const sorted = currentUserId ? sortRequests(safeData, currentUserId) : safeData
       setRequests(sorted)
@@ -265,7 +285,7 @@ export function useFeatureRequests(currentUserId?: string) {
     } finally {
       setIsLoading(false)
     }
-  }, [currentUserId])
+  }, [currentUserId, countOnly])
 
   useEffect(() => {
     loadRequests()


### PR DESCRIPTION
## Summary

Addresses the 8 Copilot comments on PR #6503 (wave7) plus the `FeatureRequestButton` test failure introduced by issue #6475.

### Go concurrency (`pkg/k8s/client.go`)
- **A. `StartWatching` race** — hold the lock across the check-and-set of `m.watching` so two concurrent callers cannot both construct a fresh `fsnotify.Watcher` and leak the loser.
- **B. `StopWatching` / `stopWatchOnce` aliasing** — call `stopWatchOnce.Do` while still holding `m.mu` so a concurrent Stop->Start that rotates `m.stopWatchOnce` cannot race.
- **H. `reloadAndNotify` timer race** — acquire `m.mu` before reading/mutating `m.watcher`, and skip the re-watch when `watching=false`.

Added two race-detector tests in `watcher_lifecycle_test.go`:
- `TestMultiClusterClient_StartWatching_ConcurrentRace` — 100 goroutines.
- `TestMultiClusterClient_StopStartRace` — 25 interleaved Stop/Start cycles.

### Frontend / docs / test
- **C.** `web/package.json`: `test:e2e` now runs `npm run build && playwright test`.
- **D.** `useMissionControl.ts`: `PERSIST_STATE_DEBOUNCE_MS` comment fixed (localStorage, not sessionStorage).
- **E.** `Missions.spec.ts`: corrected route-override ordering comment.
- **F.** `MissionBrowser.tsx`: wrap `selectCardMission` in `useCallback` and add to deep-link effect deps.
- **G.** `?count_only=true` support on `/api/feedback/queue` + `useFeatureRequests`. Navbar `FeatureRequestButton` now fetches lean `{id, status}` payload instead of full queue.

### #6517 — `FeatureRequestButton` "renders without crashing"
Mock now exposes `useFeatureRequests: () => ({ requests: [] })` to match the post-#6475 consumer.

## Test plan
- [x] `go build ./...` / `go vet ./...` clean
- [x] `go test ./pkg/k8s/ -race -timeout 180s` passes (incl. new race tests)
- [x] `cd web && npm run build` passes
- [x] vitest across feedback/missions/mission-control/ui-ux-standards: 74/74 pass
- [x] `npx playwright test --list` registers normally
- [x] `npm run lint`: identical 1062 problems before and after — zero new errors

Fixes #6517
Fixes #6518
