### PR TITLE
fix: Navbar/Sidebar touch targets + PR #6477 Copilot followups (#6499, #6500, #6502, #6504, #6505, #6507)

### DIFF
--- a/web/e2e/Dashboard.spec.ts
+++ b/web/e2e/Dashboard.spec.ts
@@ -256,6 +256,14 @@ test.describe('Dashboard Page', () => {
     const EXPECTED_CLUSTER_COUNT = 3
 
     test.beforeEach(async ({ page }) => {
+      // #6507(C) — The outer `Dashboard Page` describe's beforeEach
+      // (setupDashboardTest) already registered handlers for **/api/me and
+      // **/api/mcp/**. Unroute them here so our deterministic payload is the
+      // ONLY source of data for these Data Accuracy tests — otherwise the
+      // outer mock with 2 clusters could race with our EXPECTED_CLUSTER_COUNT.
+      await page.unroute('**/api/me')
+      await page.unroute('**/api/mcp/**')
+
       // Mock authentication
       await page.route('**/api/me', (route) =>
         route.fulfill({
@@ -370,16 +378,36 @@ test.describe('Dashboard Page', () => {
 
       const hasCountEl = await countEl.isVisible().catch(() => false)
       if (hasCountEl) {
-        await expect(countEl).toContainText(String(EXPECTED_CLUSTER_COUNT))
+        // #6507(D) — assert the exact text on the count element, not
+        // toContainText. Prevents false positives like "30" matching "3".
+        await expect(countEl).toHaveText(
+          new RegExp(`^\\s*${EXPECTED_CLUSTER_COUNT}\\s*$`)
+        )
       } else {
-        // Fallback: assert that the exact expected count appears somewhere
-        // on the dashboard page alongside the word "cluster". This still
-        // fails vacuously only if BOTH the count and the word are absent
-        // — in which case the dashboard isn't reporting clusters at all,
-        // which is itself a regression worth catching.
-        const pageText = await page.textContent('body')
-        expect(pageText).toContain(String(EXPECTED_CLUSTER_COUNT))
-        expect((pageText || '').toLowerCase()).toContain('cluster')
+        // #6507(D) — Structural fallback. Previously this matched freeform
+        // body text, which is vacuously true for phrases like
+        // "3 nodes in 3 clusters" even when the cluster count is wrong.
+        // Instead, locate an element whose aria-label / data-testid / text
+        // is explicitly about cluster count, and assert its exact text.
+        const countByLabel = page
+          .getByRole('status')
+          .filter({ hasText: /cluster/i })
+          .first()
+        const labelVisible = await countByLabel.isVisible().catch(() => false)
+        if (labelVisible) {
+          await expect(countByLabel).toContainText(
+            String(EXPECTED_CLUSTER_COUNT)
+          )
+        } else {
+          // Last-resort: no element identifies itself as a cluster count.
+          // That's a regression — the dashboard isn't reporting clusters at
+          // all. Fail explicitly with a descriptive message.
+          throw new Error(
+            'Dashboard did not expose a cluster-count element (no ' +
+              '[data-testid*="cluster-count"], [data-testid*="total-clusters"], ' +
+              'or role=status with "cluster" text).'
+          )
+        }
       }
     })
 

--- a/web/src/components/agent/AgentSelector.tsx
+++ b/web/src/components/agent/AgentSelector.tsx
@@ -374,7 +374,7 @@ export function AgentSelector({ compact = false, className = '' }: AgentSelector
         aria-haspopup="listbox"
         aria-expanded={isOpen}
         className={cn(
-          'flex items-center gap-2 px-3 py-1.5 rounded-lg border transition-colors',
+          'flex items-center gap-2 px-3 py-1.5 min-h-[44px] rounded-lg border transition-colors',
           'bg-secondary/50 border-border hover:bg-secondary',
           isOpen && 'ring-1 ring-primary'
         )}

--- a/web/src/components/layout/Sidebar.tsx
+++ b/web/src/components/layout/Sidebar.tsx
@@ -601,7 +601,7 @@ export function Sidebar() {
               }
             }}
             aria-expanded={!config.collapsed}
-            className="p-1.5 rounded-full border border-border bg-background text-muted-foreground hover:text-foreground hover:bg-black/5 dark:hover:bg-white/10 shadow-md transition-colors"
+            className="hidden md:flex items-center justify-center min-h-[44px] min-w-[44px] p-1.5 rounded-full border border-border bg-background text-muted-foreground hover:text-foreground hover:bg-black/5 dark:hover:bg-white/10 shadow-md transition-colors"
             title={config.collapsed ? t('layout.sidebar.expandSidebar') : t('layout.sidebar.collapseSidebar')}
           >
             {config.collapsed ? <ChevronRight className="w-3.5 h-3.5" aria-hidden="true" /> : <ChevronLeft className="w-3.5 h-3.5" aria-hidden="true" />}

--- a/web/src/components/layout/navbar/Navbar.tsx
+++ b/web/src/components/layout/navbar/Navbar.tsx
@@ -64,7 +64,7 @@ export function Navbar({ topOffset = 0 }: NavbarProps) {
         {/* Hamburger menu - mobile only */}
         <button
           onClick={toggleMobileSidebar}
-          className="p-2 md:hidden rounded-lg transition-colors hover:bg-black/5 dark:hover:bg-white/10"
+          className="p-2 min-w-[44px] min-h-[44px] flex md:hidden items-center justify-center rounded-lg transition-colors hover:bg-black/5 dark:hover:bg-white/10"
           aria-label={config.isMobileOpen ? t('navbar.closeMenu') : t('navbar.openMenu')}
         >
           {config.isMobileOpen ? (
@@ -86,7 +86,7 @@ export function Navbar({ topOffset = 0 }: NavbarProps) {
         <button
           type="button"
           onClick={() => navigate(ROUTES.HOME)}
-          className="hidden lg:flex flex-col leading-tight hover:opacity-80 transition-opacity text-left"
+          className="hidden lg:flex flex-col leading-tight justify-center min-h-[44px] hover:opacity-80 transition-opacity text-left"
           aria-label={t('navbar.goHome')}
         >
           <span className="text-base md:text-lg font-semibold text-foreground">{branding.appName}</span>
@@ -172,7 +172,7 @@ export function Navbar({ topOffset = 0 }: NavbarProps) {
           {/* Theme toggle */}
           <button
             onClick={toggleTheme}
-            className="p-2 shrink-0 hover:bg-secondary rounded-lg transition-colors"
+            className="p-2 min-w-[44px] min-h-[44px] flex items-center justify-center shrink-0 hover:bg-secondary rounded-lg transition-colors"
             title={t('navbar.themeToggle', { theme })}
           >
             {theme === 'dark' ? (

--- a/web/src/components/mission-control/__tests__/useMissionControl.test.tsx
+++ b/web/src/components/mission-control/__tests__/useMissionControl.test.tsx
@@ -172,7 +172,7 @@ describe('mergeProjects — user-added preservation (#6465)', () => {
     const merged = mergeProjects(existing, incoming)
     const names = merged.map((p) => p.name).sort()
 
-    // All 3 user-added survive (falco + opa), plus helm (echoed) and
+    // Both user-added projects survive (falco + opa), plus helm (echoed) and
     // argo (new AI suggestion) = 4 total.
     expect(names).toEqual(['argo', 'falco', 'helm', 'opa'])
   })

--- a/web/src/components/mission-control/useMissionControl.ts
+++ b/web/src/components/mission-control/useMissionControl.ts
@@ -1290,9 +1290,16 @@ export function mergeProjects(
   for (const p of incoming) {
     const prev = existingMap.get(p.name)
     if (prev) {
-      // User wins: keep existing entry (and its userAdded/originalName/
-      // priority customizations) rather than overwriting with AI's version.
-      result.push(prev)
+      // #6507(A) — Only preserve existing entry verbatim when it's user-added
+      // (manual add / swap / library pick). For AI-suggested entries, accept
+      // the incoming AI version so the AI can refine its own prior suggestions
+      // (e.g. priority / category / notes updates) on re-ask.
+      const isUserAdded = prev.userAdded === true || prev.category === 'Custom'
+      if (isUserAdded) {
+        result.push(prev)
+      } else {
+        result.push(p)
+      }
     } else {
       result.push(p)
     }


### PR DESCRIPTION
## Summary

Two bundled fix groups:

### Touch targets (mrhapile a11y audit)
Five Navbar/Sidebar interactive elements were below the 44x44 minimum touch target:

- **#6499** Navbar hamburger — min-w/h 44px + flex centering
- **#6500** Navbar logo text link — min-h 44px + justify-center (logo itself already had min-w/h 44px)
- **#6502** Sidebar collapse toggle — min-w/h 44px and explicit hidden md:flex so tablet touch never sees the small target even if the !isMobile JS guard changes
- **#6504** AgentSelector trigger — min-h 44px on the dropdown button (was py-1.5 ~28px)
- **#6505** Navbar theme toggle — min-w/h 44px + flex centering

### PR #6477 Copilot followups (#6507)

- **A.** mergeProjects: only preserve the prev project verbatim when userAdded === true (or category === Custom). For AI-suggested projects, accept the incoming AI version so the AI can refine its own prior non-custom suggestions on re-ask.
- **B.** useMissionControl.test.tsx:176 comment fix: said "3 user-added survive" but the fixture has 2 (falco + opa).
- **C.** Dashboard.spec.ts Data Accuracy describe: unroute api/me and api/mcp/** at the start of the nested beforeEach so the outer describe 2-cluster mock cannot race with the deterministic EXPECTED_CLUSTER_COUNT payload.
- **D.** Dashboard.spec.ts EXPECTED_CLUSTER_COUNT assertion: replaced freeform body-text match (false-positives on "3 nodes in 3 clusters") with exact-text match on the count element, a targeted role=status locator, or an explicit failure.

Fixes #6499
Fixes #6500
Fixes #6502
Fixes #6504
Fixes #6505
Fixes #6507

## Test plan
- [x] npm run build passes
- [x] vitest run useMissionControl.test.tsx — 17/17 pass
- [x] vitest run ui-ux-standards.test.ts — 7/7 pass
- [x] playwright test --list registers 5010 tests
- [x] npm run lint — no new errors introduced (pre-existing errors unchanged)