### PR TITLE
fix(backend): auth fail-closed, card limit invariants, error handling, context leaks (#6553-#6570)

### DIFF
--- a/pkg/api/handlers/auth.go
+++ b/pkg/api/handlers/auth.go
@@ -351,8 +351,12 @@ func (h *AuthHandler) devModeLogin(c *fiber.Ctx) error {
 		}
 	}
 
-	// Update last login
-	h.store.UpdateLastLogin(user.ID)
+	// Update last login. Failures here are non-fatal — login should succeed
+	// even if the last-login timestamp can't be written.
+	if err := h.store.UpdateLastLogin(user.ID); err != nil {
+		slog.Warn("[Auth] failed to update last-login timestamp (devMode)",
+			"user", user.ID, "error", err)
+	}
 
 	// Generate JWT
 	jwtToken, err := h.generateJWT(user)
@@ -481,8 +485,10 @@ func (h *AuthHandler) GitHubCallback(c *fiber.Ctx) error {
 		return h.oauthErrorRedirect(c, "csrf_validation_failed", "")
 	}
 
-	// Exchange code for token — use a context with timeout for resilience
-	ctx, cancel := context.WithTimeout(context.Background(), githubHTTPTimeout)
+	// Exchange code for token — use a context with timeout derived from the
+	// request context so that a client disconnect cancels the in-flight
+	// OAuth exchange instead of leaking the goroutine until timeout.
+	ctx, cancel := context.WithTimeout(c.UserContext(), githubHTTPTimeout)
 	defer cancel()
 	token, err := h.oauthConfig.Exchange(ctx, code)
 	if err != nil {
@@ -530,8 +536,12 @@ func (h *AuthHandler) GitHubCallback(c *fiber.Ctx) error {
 		}
 	}
 
-	// Update last login
-	h.store.UpdateLastLogin(user.ID)
+	// Update last login. Failures here are non-fatal — login should succeed
+	// even if the last-login timestamp can't be persisted.
+	if err := h.store.UpdateLastLogin(user.ID); err != nil {
+		slog.Warn("[Auth] failed to update last-login timestamp (oauth)",
+			"user", user.ID, "error", err)
+	}
 
 	// Generate JWT
 	jwtToken, err := h.generateJWT(user)

--- a/pkg/api/handlers/cards.go
+++ b/pkg/api/handlers/cards.go
@@ -3,6 +3,8 @@ package handlers
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
+	"log/slog"
 
 	"github.com/gofiber/fiber/v2"
 	"github.com/google/uuid"
@@ -303,13 +305,17 @@ func (h *CardHandler) RecordFocus(c *fiber.Ctx) error {
 		return fiber.NewError(fiber.StatusInternalServerError, "Failed to update focus")
 	}
 
-	// Also record as event
+	// Also record as event. Failures here are telemetry-only and must not
+	// fail the user request — but log structurally so the failure is visible.
 	event := &models.UserEvent{
 		UserID:    userID,
 		EventType: models.EventTypeCardFocus,
 		CardID:    &cardID,
 	}
-	h.store.RecordEvent(event)
+	if err := h.store.RecordEvent(event); err != nil {
+		slog.Warn("[cards] failed to record focus event",
+			"user", userID, "card", cardID, "error", err)
+	}
 
 	return c.JSON(fiber.Map{"status": "ok"})
 }
@@ -331,6 +337,10 @@ func (h *CardHandler) GetHistory(c *fiber.Ctx) error {
 	history, err := h.store.GetUserCardHistory(userID, limit)
 	if err != nil {
 		return fiber.NewError(fiber.StatusInternalServerError, "Failed to get history")
+	}
+	// Never marshal a Go nil slice as JSON null; clients expect [].
+	if history == nil {
+		history = []models.CardHistory{}
 	}
 	return c.JSON(history)
 }
@@ -378,6 +388,24 @@ func (h *CardHandler) MoveCard(c *fiber.Ctx) error {
 	targetDashboard, err := h.store.GetDashboard(targetDashboardID)
 	if err != nil || targetDashboard == nil || targetDashboard.UserID != userID {
 		return fiber.NewError(fiber.StatusForbidden, "Access denied to target dashboard")
+	}
+
+	// Enforce per-dashboard card limit on the TARGET before moving.
+	// Without this, a Move can push a dashboard over MaxCardsPerDashboard,
+	// bypassing the limit that CreateCardWithLimit enforces on create.
+	// Note: if the source and target are the same dashboard this is a no-op
+	// from a count perspective, but we still allow it.
+	if card.DashboardID != targetDashboardID {
+		targetCards, cErr := h.store.GetDashboardCards(targetDashboardID)
+		if cErr != nil {
+			return fiber.NewError(fiber.StatusInternalServerError, "Failed to check target dashboard capacity")
+		}
+		if len(targetCards) >= MaxCardsPerDashboard {
+			return fiber.NewError(
+				fiber.StatusBadRequest,
+				fmt.Sprintf("Target dashboard already has %d cards (limit %d)", len(targetCards), MaxCardsPerDashboard),
+			)
+		}
 	}
 
 	// Update the card's dashboard ID

--- a/pkg/api/handlers/cards_test.go
+++ b/pkg/api/handlers/cards_test.go
@@ -255,23 +255,37 @@ func TestGetHistory_ReturnsOK(t *testing.T) {
 // limit-reached, type-validation, and config-update paths without a real DB.
 type cardMutationStore struct {
 	*test.MockStore
-	dashboard    *models.Dashboard
-	card         *models.Card
-	createErr    error
-	createCalled bool
-	lastCreate   *models.Card
-	lastMaxCards int
-	updateErr    error
-	updateCalled bool
-	lastUpdate   *models.Card
+	dashboard      *models.Dashboard
+	dashboardByID  map[uuid.UUID]*models.Dashboard
+	dashboardCards map[uuid.UUID][]models.Card
+	card           *models.Card
+	createErr      error
+	createCalled   bool
+	lastCreate     *models.Card
+	lastMaxCards   int
+	updateErr      error
+	updateCalled   bool
+	lastUpdate     *models.Card
 }
 
 func (s *cardMutationStore) GetDashboard(id uuid.UUID) (*models.Dashboard, error) {
+	if s.dashboardByID != nil {
+		if d, ok := s.dashboardByID[id]; ok {
+			return d, nil
+		}
+	}
 	return s.dashboard, nil
 }
 
 func (s *cardMutationStore) GetCard(id uuid.UUID) (*models.Card, error) {
 	return s.card, nil
+}
+
+func (s *cardMutationStore) GetDashboardCards(dashboardID uuid.UUID) ([]models.Card, error) {
+	if s.dashboardCards != nil {
+		return s.dashboardCards[dashboardID], nil
+	}
+	return nil, nil
 }
 
 func (s *cardMutationStore) CreateCardWithLimit(card *models.Card, maxCards int) error {
@@ -327,7 +341,67 @@ func newCardMutationApp(
 	app.Post("/api/dashboards/:id/cards", handler.CreateCard)
 	app.Put("/api/cards/:id", handler.UpdateCard)
 	app.Delete("/api/cards/:id", handler.DeleteCard)
+	app.Post("/api/cards/:id/move", handler.MoveCard)
 	return app, wrapper, userID
+}
+
+// TestMoveCard_RejectsWhenTargetAtLimit verifies MoveCard refuses to push a
+// card into a dashboard that is already at MaxCardsPerDashboard (#6569).
+func TestMoveCard_RejectsWhenTargetAtLimit(t *testing.T) {
+	sourceDashID := uuid.New()
+	targetDashID := uuid.New()
+	cardID := uuid.New()
+
+	userID := uuid.New()
+	mockStore := new(test.MockStore)
+	mockStore.On("GetUser", userID).Return(&models.User{
+		ID:   userID,
+		Role: models.UserRoleAdmin,
+	}, nil).Maybe()
+
+	// Build a target dashboard already filled to MaxCardsPerDashboard.
+	fullCards := make([]models.Card, MaxCardsPerDashboard)
+	for i := range fullCards {
+		fullCards[i] = models.Card{ID: uuid.New(), DashboardID: targetDashID}
+	}
+
+	wrapper := &cardMutationStore{
+		MockStore: mockStore,
+		dashboardByID: map[uuid.UUID]*models.Dashboard{
+			sourceDashID: {ID: sourceDashID, UserID: userID},
+			targetDashID: {ID: targetDashID, UserID: userID},
+		},
+		dashboardCards: map[uuid.UUID][]models.Card{
+			targetDashID: fullCards,
+		},
+		card: &models.Card{
+			ID:          cardID,
+			DashboardID: sourceDashID,
+			CardType:    models.CardTypeClusterHealth,
+		},
+	}
+
+	hub := NewHub()
+	go hub.Run()
+	t.Cleanup(func() { hub.Close() })
+
+	handler := NewCardHandler(wrapper, hub)
+	app := fiber.New()
+	app.Use(func(c *fiber.Ctx) error {
+		c.Locals("userID", userID)
+		return c.Next()
+	})
+	app.Post("/api/cards/:id/move", handler.MoveCard)
+
+	body := `{"target_dashboard_id":"` + targetDashID.String() + `"}`
+	req, err := http.NewRequest("POST", "/api/cards/"+cardID.String()+"/move", strings.NewReader(body))
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := app.Test(req, fiberTestTimeout)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+	assert.False(t, wrapper.updateCalled, "store must not be updated when target is at limit")
 }
 
 // --- Viewer denial ---

--- a/pkg/api/handlers/console_persistence.go
+++ b/pkg/api/handlers/console_persistence.go
@@ -2,6 +2,7 @@ package handlers
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
 	"strings"
 	"time"
@@ -56,7 +57,15 @@ func (h *ConsolePersistenceHandlers) requireAdmin(c *fiber.Ctx) error {
 	}
 	currentUserID := middleware.GetUserID(c)
 	currentUser, err := h.userStore.GetUser(currentUserID)
-	if err != nil || currentUser == nil || currentUser.Role != "admin" {
+	if err != nil {
+		// Infrastructure failure — don't silently downgrade to a 403 which
+		// would mask a persistent DB outage and make this look like an
+		// authorization issue.
+		slog.Error("[ConsolePersistence] requireAdmin: failed to load user",
+			"user", currentUserID, "error", err)
+		return fiber.NewError(fiber.StatusInternalServerError, "Failed to verify admin role")
+	}
+	if currentUser == nil || currentUser.Role != "admin" {
 		return fiber.NewError(fiber.StatusForbidden, "Console admin access required")
 	}
 	return nil
@@ -85,7 +94,10 @@ func (h *ConsolePersistenceHandlers) checkClusterHealth(ctx context.Context, clu
 	return store.ClusterHealthUnknown
 }
 
-// getClusterClient returns a dynamic client for a cluster
+// getClusterClient returns a dynamic client and rest config for a cluster.
+// Previously the second return value was always nil, which would panic any
+// caller that dereferenced it. Return the real *rest.Config so the contract
+// matches the factory signature.
 func (h *ConsolePersistenceHandlers) getClusterClient(clusterName string) (dynamic.Interface, *rest.Config, error) {
 	if h.k8sClient == nil {
 		return nil, nil, fiber.NewError(503, "Kubernetes client not available")
@@ -96,7 +108,12 @@ func (h *ConsolePersistenceHandlers) getClusterClient(clusterName string) (dynam
 		return nil, nil, err
 	}
 
-	return client, nil, nil
+	cfg, err := h.k8sClient.GetRestConfig(clusterName)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to get rest config for cluster %q: %w", clusterName, err)
+	}
+
+	return client, cfg, nil
 }
 
 // StartWatcher starts the console resource watcher if persistence is enabled
@@ -241,6 +258,12 @@ func (h *ConsolePersistenceHandlers) GetManagedWorkload(c *fiber.Ctx) error {
 	if err != nil {
 		slog.Error("[ConsolePersistence] internal error", "error", err)
 		return c.Status(500).JSON(fiber.Map{"error": "internal server error"})
+	}
+	// A nil workload with nil error means the resource wasn't found.
+	// Return 404 instead of a 200 + JSON null so clients can distinguish
+	// "no such workload" from "empty payload".
+	if workload == nil {
+		return c.Status(404).JSON(fiber.Map{"error": "managed workload not found"})
 	}
 
 	return c.JSON(workload)
@@ -392,6 +415,10 @@ func (h *ConsolePersistenceHandlers) GetClusterGroup(c *fiber.Ctx) error {
 		slog.Error("[ConsolePersistence] internal error", "error", err)
 		return c.Status(500).JSON(fiber.Map{"error": "internal server error"})
 	}
+	// A nil group with nil error means the resource wasn't found.
+	if group == nil {
+		return c.Status(404).JSON(fiber.Map{"error": "cluster group not found"})
+	}
 
 	return c.JSON(group)
 }
@@ -428,7 +455,7 @@ func (h *ConsolePersistenceHandlers) CreateClusterGroup(c *fiber.Ctx) error {
 	group.CreationTimestamp = metav1.Now()
 
 	// Evaluate matched clusters
-	group.Status.MatchedClusters = h.evaluateClusterGroup(&group)
+	group.Status.MatchedClusters = h.evaluateClusterGroup(c.Context(), &group)
 	group.Status.MatchedClusterCount = len(group.Status.MatchedClusters)
 	now := metav1.Now()
 	group.Status.LastEvaluated = &now
@@ -470,7 +497,7 @@ func (h *ConsolePersistenceHandlers) UpdateClusterGroup(c *fiber.Ctx) error {
 	group.Namespace = namespace
 
 	// Re-evaluate matched clusters
-	group.Status.MatchedClusters = h.evaluateClusterGroup(&group)
+	group.Status.MatchedClusters = h.evaluateClusterGroup(c.Context(), &group)
 	group.Status.MatchedClusterCount = len(group.Status.MatchedClusters)
 	now := metav1.Now()
 	group.Status.LastEvaluated = &now
@@ -510,8 +537,11 @@ func (h *ConsolePersistenceHandlers) DeleteClusterGroup(c *fiber.Ctx) error {
 	return c.SendStatus(204)
 }
 
-// evaluateClusterGroup evaluates which clusters match a group's criteria
-func (h *ConsolePersistenceHandlers) evaluateClusterGroup(group *v1alpha1.ClusterGroup) []string {
+// evaluateClusterGroup evaluates which clusters match a group's criteria.
+// The context should be the inbound request context so that k8s calls are
+// cancelled when the client disconnects (previously used context.Background,
+// which leaked goroutines on cancellation).
+func (h *ConsolePersistenceHandlers) evaluateClusterGroup(ctx context.Context, group *v1alpha1.ClusterGroup) []string {
 	matched := make(map[string]bool)
 
 	// Add static members
@@ -521,7 +551,7 @@ func (h *ConsolePersistenceHandlers) evaluateClusterGroup(group *v1alpha1.Cluste
 
 	// Apply dynamic filters
 	if h.k8sClient != nil && len(group.Spec.DynamicFilters) > 0 {
-		clusters, err := h.k8sClient.ListClusters(context.Background())
+		clusters, err := h.k8sClient.ListClusters(ctx)
 		if err == nil {
 			// Get cached health data (no extra network calls).
 			// GetCachedHealth always returns a non-nil map; individual entries
@@ -532,7 +562,7 @@ func (h *ConsolePersistenceHandlers) evaluateClusterGroup(group *v1alpha1.Cluste
 			nodesByCluster := make(map[string][]k8s.NodeInfo)
 			if clusterFilterNeedsNodes(group.Spec.DynamicFilters) {
 				for _, cluster := range clusters {
-					nodes, nodeErr := h.k8sClient.GetNodes(context.Background(), cluster.Name)
+					nodes, nodeErr := h.k8sClient.GetNodes(ctx, cluster.Name)
 					if nodeErr == nil {
 						nodesByCluster[cluster.Name] = nodes
 					}

--- a/pkg/api/handlers/dashboard.go
+++ b/pkg/api/handlers/dashboard.go
@@ -2,6 +2,9 @@ package handlers
 
 import (
 	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
 	"time"
 
 	"github.com/gofiber/fiber/v2"
@@ -46,6 +49,10 @@ func (h *DashboardHandler) ListDashboards(c *fiber.Ctx) error {
 	dashboards, err := h.store.GetUserDashboards(userID)
 	if err != nil {
 		return fiber.NewError(fiber.StatusInternalServerError, "Failed to list dashboards")
+	}
+	// Never marshal a Go nil slice as JSON null; clients expect [].
+	if dashboards == nil {
+		dashboards = []models.Dashboard{}
 	}
 	return c.JSON(dashboards)
 }
@@ -138,6 +145,9 @@ func (h *DashboardHandler) UpdateDashboard(c *fiber.Ctx) error {
 	}
 
 	if input.Name != nil {
+		if strings.TrimSpace(*input.Name) == "" {
+			return fiber.NewError(fiber.StatusBadRequest, "Dashboard name cannot be empty")
+		}
 		dashboard.Name = *input.Name
 	}
 	if input.IsDefault != nil {
@@ -237,6 +247,16 @@ func (h *DashboardHandler) ImportDashboard(c *fiber.Ctx) error {
 		input.Name = "Imported Dashboard"
 	}
 
+	// Enforce the per-dashboard card limit BEFORE creating anything.
+	// This avoids a partial import that exceeds MaxCardsPerDashboard and
+	// avoids the need to rollback a large number of card rows.
+	if len(input.Cards) > MaxCardsPerDashboard {
+		return fiber.NewError(
+			fiber.StatusBadRequest,
+			fmt.Sprintf("Import payload contains %d cards, exceeds per-dashboard limit of %d", len(input.Cards), MaxCardsPerDashboard),
+		)
+	}
+
 	dashboard := &models.Dashboard{
 		UserID: userID,
 		Name:   input.Name,
@@ -253,9 +273,14 @@ func (h *DashboardHandler) ImportDashboard(c *fiber.Ctx) error {
 			Config:      ce.Config,
 			Position:    ce.Position,
 		}
-		if err := h.store.CreateCard(card); err != nil {
+		// Use CreateCardWithLimit to keep the invariant consistent with the
+		// regular AddCard path (closes TOCTOU against concurrent creates).
+		if err := h.store.CreateCardWithLimit(card, MaxCardsPerDashboard); err != nil {
 			// Rollback: delete the partially-created dashboard and any cards
 			_ = h.store.DeleteDashboard(dashboard.ID)
+			if errors.Is(err, store.ErrDashboardCardLimitReached) {
+				return fiber.NewError(fiber.StatusRequestEntityTooLarge, "Card limit reached during import")
+			}
 			return fiber.NewError(fiber.StatusInternalServerError, "Failed to create card")
 		}
 	}

--- a/pkg/api/handlers/dashboard_test.go
+++ b/pkg/api/handlers/dashboard_test.go
@@ -216,3 +216,32 @@ func TestImportDashboard_Success(t *testing.T) {
 	require.NoError(t, json.Unmarshal(respBody, &result))
 	assert.Equal(t, "Imported", result.Name)
 }
+
+// TestImportDashboard_ExceedsCardLimit verifies that an import payload
+// containing more than MaxCardsPerDashboard cards is rejected up-front with
+// a 400 instead of being partially imported (#6553).
+func TestImportDashboard_ExceedsCardLimit(t *testing.T) {
+	userID := uuid.New()
+	app, _, handler := setupDashboardTest(userID)
+	app.Post("/api/dashboards/import", handler.ImportDashboard)
+
+	var sb strings.Builder
+	sb.WriteString(`{"format":"kc-dashboard-v1","name":"TooBig","cards":[`)
+	// MaxCardsPerDashboard+1 minimal card entries
+	for i := 0; i < MaxCardsPerDashboard+1; i++ {
+		if i > 0 {
+			sb.WriteString(",")
+		}
+		sb.WriteString(`{"card_type":"note","position":{"x":0,"y":0,"w":1,"h":1}}`)
+	}
+	sb.WriteString(`]}`)
+
+	req, err := http.NewRequest("POST", "/api/dashboards/import", strings.NewReader(sb.String()))
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := app.Test(req, fiberTestTimeout)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+}
+

--- a/pkg/api/handlers/exec.go
+++ b/pkg/api/handlers/exec.go
@@ -42,22 +42,24 @@ const execMaxStdinBytes = 1 * 1024 * 1024 // 1 MB
 // infrequent and always short; an RWMutex would add complexity for no gain.
 var (
 	execSessionsMu sync.Mutex
-	execSessions   = make(map[uuid.UUID]map[int64]context.CancelFunc)
-	execSessionSeq int64 // monotonic id generator, guarded by execSessionsMu
+	execSessions = make(map[uuid.UUID]map[uint64]context.CancelFunc)
+	// execSessionSeq is a monotonic id generator guarded by execSessionsMu.
+	// uint64 so we don't wrap to negative at MaxInt64.
+	execSessionSeq uint64
 )
 
 // registerExecSession records cancel under userID and returns the assigned
 // session id. The session id is used by unregisterExecSession to remove the
 // specific entry when the session ends normally, so the map does not grow
 // unbounded across many sessions by the same user.
-func registerExecSession(userID uuid.UUID, cancel context.CancelFunc) int64 {
+func registerExecSession(userID uuid.UUID, cancel context.CancelFunc) uint64 {
 	execSessionsMu.Lock()
 	defer execSessionsMu.Unlock()
 	execSessionSeq++
 	id := execSessionSeq
 	sessions, ok := execSessions[userID]
 	if !ok {
-		sessions = make(map[int64]context.CancelFunc)
+		sessions = make(map[uint64]context.CancelFunc)
 		execSessions[userID] = sessions
 	}
 	sessions[id] = cancel
@@ -68,7 +70,7 @@ func registerExecSession(userID uuid.UUID, cancel context.CancelFunc) int64 {
 // handler's deferred cleanup on normal session end so the registry stays
 // bounded by the number of concurrently live exec sessions, not the total
 // lifetime count.
-func unregisterExecSession(userID uuid.UUID, id int64) {
+func unregisterExecSession(userID uuid.UUID, id uint64) {
 	execSessionsMu.Lock()
 	defer execSessionsMu.Unlock()
 	sessions, ok := execSessions[userID]
@@ -283,7 +285,7 @@ func (h *ExecHandlers) HandleExec(c *websocket.Conn) {
 	execCtx, execCancel := context.WithCancel(context.Background())
 	defer execCancel()
 
-	var execRegistrationID int64
+	var execRegistrationID uint64
 	if claims.UserID != uuid.Nil {
 		execRegistrationID = registerExecSession(claims.UserID, execCancel)
 		defer unregisterExecSession(claims.UserID, execRegistrationID)
@@ -378,7 +380,12 @@ func (h *ExecHandlers) HandleExec(c *websocket.Conn) {
 	}
 
 	// Send exec_started acknowledgment
-	startMsg, _ := json.Marshal(execMessage{Type: "exec_started"})
+	startMsg, mErr := json.Marshal(execMessage{Type: "exec_started"})
+	if mErr != nil {
+		slog.Error("[Exec] failed to marshal exec_started message", "error", mErr)
+		writeError(c, "internal error: failed to encode exec_started")
+		return
+	}
 	writeMu := &sync.Mutex{}
 	writeMu.Lock()
 	_ = c.WriteMessage(websocket.TextMessage, startMsg)
@@ -463,7 +470,11 @@ func (h *ExecHandlers) HandleExec(c *websocket.Conn) {
 		slog.Error("[Exec] stream ended with error", "error", execErr)
 	}
 
-	exitMsg, _ := json.Marshal(execMessage{Type: "exit", ExitCode: exitCode})
+	exitMsg, mErr := json.Marshal(execMessage{Type: "exit", ExitCode: exitCode})
+	if mErr != nil {
+		slog.Error("[Exec] failed to marshal exit message", "error", mErr, "exit_code", exitCode)
+		return
+	}
 	writeMu.Lock()
 	_ = c.WriteMessage(websocket.TextMessage, exitMsg)
 	writeMu.Unlock()

--- a/pkg/api/handlers/feedback.go
+++ b/pkg/api/handlers/feedback.go
@@ -31,6 +31,23 @@ import (
 // githubAPITimeout is the timeout for HTTP requests to the GitHub API.
 const githubAPITimeout = 10 * time.Second
 
+// resolveGitHubAPIBase returns the API base URL, honoring GITHUB_URL for GHE.
+// Returned value has no trailing slash. For public github.com, returns
+// "https://api.github.com". For GHE (e.g. GITHUB_URL=https://github.example.com),
+// returns "https://github.example.com/api/v3" per GHE conventions.
+func resolveGitHubAPIBase() string {
+	raw := strings.TrimSpace(os.Getenv("GITHUB_URL"))
+	if raw == "" {
+		return githubAPIBase
+	}
+	raw = strings.TrimRight(raw, "/")
+	// If the user already set GITHUB_URL to api.github.com, return as-is.
+	if strings.Contains(raw, "api.github.com") {
+		return raw
+	}
+	return raw + "/api/v3"
+}
+
 // screenshotUploadTimeout is a longer timeout for uploading base64 screenshots
 // to GitHub via the Contents API, which can be slow for large images.
 const screenshotUploadTimeout = 60 * time.Second
@@ -160,13 +177,24 @@ func (h *FeedbackHandler) CreateFeatureRequest(c *fiber.Ctx) error {
 	issueNumber, _, ssResult, err := h.createGitHubIssueInRepo(request, user, h.repoOwner, targetRepoName, input.Screenshots)
 	if err != nil {
 		slog.Error("[Feedback] failed to create GitHub issue", "error", err)
-		// Clean up the orphaned database record
-		h.store.CloseFeatureRequest(request.ID, false)
+		// Clean up the orphaned database record. Log but don't fail the
+		// outer error path on cleanup failure — the upstream GitHub error
+		// is the useful signal to return.
+		if cErr := h.store.CloseFeatureRequest(request.ID, false); cErr != nil {
+			slog.Warn("[Feedback] failed to close orphaned feature request",
+				"request_id", request.ID, "error", cErr)
+		}
 		return fiber.NewError(fiber.StatusBadGateway, fmt.Sprintf("Failed to create GitHub issue: %v", err))
 	}
 	request.GitHubIssueNumber = &issueNumber
 	request.Status = models.RequestStatusOpen
-	h.store.UpdateFeatureRequest(request)
+	// UpdateFeatureRequest writes user-visible state (issue number, status).
+	// A failure here means the client will see stale data — return 500.
+	if err := h.store.UpdateFeatureRequest(request); err != nil {
+		slog.Error("[Feedback] failed to persist GitHub issue number",
+			"request_id", request.ID, "issue", issueNumber, "error", err)
+		return fiber.NewError(fiber.StatusInternalServerError, "Failed to persist feature request state")
+	}
 
 	// Create notification for the user
 	notifTitle := "Request Submitted"
@@ -183,7 +211,10 @@ func (h *FeedbackHandler) CreateFeatureRequest(c *fiber.Ctx) error {
 		Message:          fmt.Sprintf("Your %s request '%s' has been submitted.", request.RequestType, request.Title),
 		ActionURL:        actionURL,
 	}
-	h.store.CreateNotification(notification)
+	if err := h.store.CreateNotification(notification); err != nil {
+		slog.Warn("[Feedback] failed to create issue notification",
+			"user", userID, "request_id", request.ID, "error", err)
+	}
 
 	// Return the request with screenshot upload status so the frontend can
 	// display an accurate message instead of always claiming success.
@@ -444,12 +475,16 @@ func (h *FeedbackHandler) CheckPreviewStatus(c *fiber.Ctx) error {
 		return c.JSON(fiber.Map{"status": "unavailable", "message": "GitHub not configured"})
 	}
 
-	client := &http.Client{Timeout: githubAPITimeout}
+	// Reuse the shared package-level client (connection pooling, keep-alive).
+	// Previously a new client was created per request which defeated pooling.
+	client := h.httpClient
 
-	// Query GitHub Deployments API for the Netlify deploy preview environment
+	// Query GitHub Deployments API for the Netlify deploy preview environment.
+	// Honor GITHUB_URL for GitHub Enterprise deployments.
 	envName := fmt.Sprintf("deploy-preview-%d", prNumber)
-	deploymentsURL := fmt.Sprintf("https://api.github.com/repos/%s/%s/deployments?environment=%s&per_page=1",
-		h.repoOwner, h.repoName, envName)
+	apiBase := resolveGitHubAPIBase()
+	deploymentsURL := fmt.Sprintf("%s/repos/%s/%s/deployments?environment=%s&per_page=1",
+		apiBase, h.repoOwner, h.repoName, envName)
 
 	req, err := http.NewRequest("GET", deploymentsURL, nil)
 	if err != nil {
@@ -480,8 +515,8 @@ func (h *FeedbackHandler) CheckPreviewStatus(c *fiber.Ctx) error {
 	}
 
 	// Fetch the latest status for this deployment
-	statusesURL := fmt.Sprintf("https://api.github.com/repos/%s/%s/deployments/%d/statuses?per_page=1",
-		h.repoOwner, h.repoName, deployments[0].ID)
+	statusesURL := fmt.Sprintf("%s/repos/%s/%s/deployments/%d/statuses?per_page=1",
+		apiBase, h.repoOwner, h.repoName, deployments[0].ID)
 
 	req2, err := http.NewRequest("GET", statusesURL, nil)
 	if err != nil {

--- a/pkg/api/handlers/sse.go
+++ b/pkg/api/handlers/sse.go
@@ -109,23 +109,25 @@ const sseCacheEvictInterval = 30 * time.Second
 // stream start/end) and reads (CancelUserSSEStreams on logout) are both
 // infrequent and always short; an RWMutex would add complexity for no gain.
 var (
-	sseSessionsMu  sync.Mutex
-	sseSessions    = make(map[uuid.UUID]map[int64]context.CancelFunc)
-	sseSessionSeq  int64 // monotonic id generator, guarded by sseSessionsMu
+	sseSessionsMu sync.Mutex
+	sseSessions   = make(map[uuid.UUID]map[uint64]context.CancelFunc)
+	// sseSessionSeq is a monotonic id generator guarded by sseSessionsMu.
+	// uint64 instead of int64 so we don't wrap to negative at MaxInt64.
+	sseSessionSeq uint64
 )
 
 // registerSSESession records cancel under userID and returns the assigned
 // session id. The session id is used by unregisterSSESession to remove the
 // specific entry when the stream ends normally, so the map does not grow
 // unbounded across many streams by the same user.
-func registerSSESession(userID uuid.UUID, cancel context.CancelFunc) int64 {
+func registerSSESession(userID uuid.UUID, cancel context.CancelFunc) uint64 {
 	sseSessionsMu.Lock()
 	defer sseSessionsMu.Unlock()
 	sseSessionSeq++
 	id := sseSessionSeq
 	sessions, ok := sseSessions[userID]
 	if !ok {
-		sessions = make(map[int64]context.CancelFunc)
+		sessions = make(map[uint64]context.CancelFunc)
 		sseSessions[userID] = sessions
 	}
 	sessions[id] = cancel
@@ -136,7 +138,7 @@ func registerSSESession(userID uuid.UUID, cancel context.CancelFunc) int64 {
 // handler's deferred cleanup on normal stream end so the registry stays
 // bounded by the number of concurrently live streams, not the total lifetime
 // count.
-func unregisterSSESession(userID uuid.UUID, id int64) {
+func unregisterSSESession(userID uuid.UUID, id uint64) {
 	sseSessionsMu.Lock()
 	defer sseSessionsMu.Unlock()
 	sessions, ok := sseSessions[userID]
@@ -212,18 +214,29 @@ func startSSECacheEvictor() {
 }
 
 func sseCacheGet(key string) interface{} {
-	sseCacheMu.Lock()
-	defer sseCacheMu.Unlock()
+	// Fast path: take a read lock for the common case (entry exists and is
+	// fresh). Previously this used an exclusive Lock which serialized every
+	// concurrent cache read.
+	sseCacheMu.RLock()
 	e, ok := sseCache[key]
 	if !ok {
+		sseCacheMu.RUnlock()
 		return nil
 	}
-	if time.Since(e.fetchedAt) >= sseCacheTTL {
-		// Delete expired entry on read to bound memory between eviction sweeps.
+	if time.Since(e.fetchedAt) < sseCacheTTL {
+		data := e.data
+		sseCacheMu.RUnlock()
+		return data
+	}
+	// Expired — upgrade to a write lock to delete. The background evictor
+	// also prunes expired entries, so losing the race here is harmless.
+	sseCacheMu.RUnlock()
+	sseCacheMu.Lock()
+	if e2, ok := sseCache[key]; ok && time.Since(e2.fetchedAt) >= sseCacheTTL {
 		delete(sseCache, key)
-		return nil
 	}
-	return e.data
+	sseCacheMu.Unlock()
+	return nil
 }
 
 func sseCacheSet(key string, data interface{}) {

--- a/pkg/api/handlers/websocket.go
+++ b/pkg/api/handlers/websocket.go
@@ -344,10 +344,15 @@ func (h *Hub) HandleConnection(conn *websocket.Conn) {
 		authenticated = true
 		slog.Info("[WebSocket] authenticated connection", "user", claims.GitHubLogin)
 	} else {
-		// No JWT secret configured - accept connection anyway for dev compatibility
-		userID = uuid.Nil
-		authenticated = true
-		slog.Warn("WARNING: WebSocket connection without JWT validation (JWT secret not configured)")
+		// SECURITY: Fail closed when no JWT secret is configured.
+		// Previously this accepted any connection, which silently disabled
+		// authentication in production if JWT_SECRET was unset.
+		slog.Error("SECURITY: WebSocket connection rejected — JWT secret not configured")
+		if wErr := conn.WriteJSON(Message{Type: "error", Data: map[string]string{"message": "server misconfigured: JWT secret not set"}}); wErr != nil {
+			slog.Error("[WebSocket] failed to send misconfig error", "error", wErr)
+		}
+		conn.Close()
+		return
 	}
 
 	if !authenticated {


### PR DESCRIPTION
## Summary

Defensive hardening across pkg/api/handlers from 17 bug reports by @aashu2006. Three security items plus eleven correctness/robustness fixes.

## Security (high priority)

- **#6562** websocket.go — fails closed when JWT_SECRET is empty (was silently auth-bypassed with userID=uuid.Nil).
- **#6553** dashboard.go ImportDashboard — validates card count up front and uses CreateCardWithLimit in the import loop.
- **#6569** cards.go MoveCard — rejects with 400 when target dashboard is at MaxCardsPerDashboard.

## Correctness

- **#6554** getClusterClient returns a real *rest.Config via GetRestConfig.
- **#6555** evaluateClusterGroup uses request context instead of context.Background.
- **#6556** RecordFocus logs telemetry errors.
- **#6557** UpdateLastLogin errors logged in devModeLogin and GitHubCallback.
- **#6558** CreateFeatureRequest error paths corrected (log cleanup, return 500 on persistence failure).
- **#6559** exec.go json.Marshal errors checked instead of sending nil WS messages.
- **#6560** sseCacheGet uses RLock fast path, upgrading to Lock only for the expired-delete branch.
- **#6561** UpdateDashboard rejects empty/whitespace-only name with 400.
- **#6563/#6564** CheckPreviewStatus reuses shared http.Client and honors GITHUB_URL for GHE via new resolveGitHubAPIBase helper.
- **#6565** OAuth token exchange derives context from c.UserContext().
- **#6566** requireAdmin distinguishes DB error (500) from auth failure (403).
- **#6567** GetManagedWorkload/GetClusterGroup return 404 when the resource is nil.
- **#6568** ListDashboards and GetHistory materialize empty slices so JSON is `[]` not `null`.
- **#6570** sseSessionSeq/execSessionSeq switched to uint64 so monotonic ids never wrap.

## Tests added

- TestImportDashboard_ExceedsCardLimit — verifies pre-create length check returns 400.
- TestMoveCard_RejectsWhenTargetAtLimit — verifies 400 and no UpdateCard call when target is full.

## Test plan

- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] `go test ./pkg/api/handlers/ -race -timeout 180s` passes
- [x] `go test ./pkg/... -timeout 300s` all packages pass
- [x] `helm lint deploy/helm/kubestellar-console` passes

Fixes #6553
Fixes #6554
Fixes #6555
Fixes #6556
Fixes #6557
Fixes #6558
Fixes #6559
Fixes #6560
Fixes #6561
Fixes #6562
Fixes #6563
Fixes #6564
Fixes #6565
Fixes #6566
Fixes #6567
Fixes #6568
Fixes #6569
Fixes #6570
