### PR TITLE
fix: Copilot followups — StartWatching fsnotify race, countOnly types, e2e selectors, mergeProjects AI refinement test (#6573, #6574)

### DIFF
--- a/pkg/api/handlers/feedback.go
+++ b/pkg/api/handlers/feedback.go
@@ -272,6 +272,20 @@ type QueueItem struct {
 	UpdatedAt         string `json:"updated_at,omitempty"`
 }
 
+// QueueItemCount — minimal shape returned by ListAllFeatureRequests when
+// count_only=true. Only the navbar badge (and the closed-request set it
+// filters against) consumes this path, so we serialize just id + status
+// instead of every QueueItem field as empty strings.
+//
+// PR #6573 item E — a standalone struct is preferable to sprinkling
+// ,omitempty on QueueItem because the full QueueItem shape is consumed
+// by the queue UI which DOES want zero-value title/description rendered
+// as "" (blurred placeholder for untriaged items), not omitted entirely.
+type QueueItemCount struct {
+	ID     string `json:"id"`
+	Status string `json:"status"`
+}
+
 // ListAllFeatureRequests returns all issues from GitHub as a queue
 // For untriaged issues that don't belong to the current user, title and description are redacted
 // Frontend will display these with blur effect
@@ -329,7 +343,10 @@ func (h *FeedbackHandler) ListAllFeatureRequests(c *fiber.Ctx) error {
 
 	// Convert to queue items
 	// Note: preview URLs are fetched on-demand via CheckPreviewStatus endpoint
+	// PR #6573 item E — countOnly returns []QueueItemCount (id + status only)
+	// instead of a []QueueItem full of empty strings. See QueueItemCount type.
 	queueItems := make([]QueueItem, 0, len(taggedIssues))
+	queueItemCounts := make([]QueueItemCount, 0, len(taggedIssues))
 	for _, tagged := range taggedIssues {
 		issue := tagged.GitHubIssue
 		// Determine status based on labels
@@ -397,12 +414,12 @@ func (h *FeedbackHandler) ListAllFeatureRequests(c *fiber.Ctx) error {
 		// Check if issue was closed by the current user (the one viewing the queue)
 		closedByUser := issue.State == "closed" && issue.ClosedBy != nil && issue.ClosedBy.Login == currentGitHubLogin
 
-		// PR #6518 item G — count_only responses carry only id + status, no
-		// titles or bodies. The client uses these to compute the navbar
-		// badge (which filters notifications by the set of closed-request
-		// IDs); nothing else is needed for that path.
+		// PR #6518 item G / #6573 item E — count_only responses carry only
+		// id + status, no titles or bodies. The client uses these to compute
+		// the navbar badge (which filters notifications by the set of
+		// closed-request IDs); nothing else is needed for that path.
 		if countOnly {
-			queueItems = append(queueItems, QueueItem{
+			queueItemCounts = append(queueItemCounts, QueueItemCount{
 				ID:     fmt.Sprintf("gh-%s-%d", tagged.TargetRepo, issue.Number),
 				Status: status,
 			})
@@ -428,6 +445,9 @@ func (h *FeedbackHandler) ListAllFeatureRequests(c *fiber.Ctx) error {
 		})
 	}
 
+	if countOnly {
+		return c.JSON(queueItemCounts)
+	}
 	return c.JSON(queueItems)
 }
 

--- a/pkg/k8s/client.go
+++ b/pkg/k8s/client.go
@@ -893,35 +893,31 @@ func (m *MultiClusterClient) RemoveContext(contextName string) error {
 // second watcher goroutine. Previously every call created a fresh
 // fsnotify.Watcher and watchLoop goroutine, orphaning the previous one.
 func (m *MultiClusterClient) StartWatching() error {
-	// PR #6518 item A — hold the lock across the check-and-set so two
-	// concurrent callers can't both see watching=false and both install a
-	// watcher (previous impl dropped the lock, created a fresh fsnotify
-	// watcher, then re-acquired — the loser leaked a watcher + goroutine).
+	// PR #6518 item A + #6573 item A — hold the lock for the ENTIRE setup,
+	// not just the check-and-set. Previous impl set watching=true, released
+	// the lock, then did fsnotify.NewWatcher()+Add. A second caller arriving
+	// during that window saw watching=true and returned nil immediately —
+	// but the first caller's watcher might still fail setup, leaving the
+	// struct in a broken state after the second caller already declared
+	// success. Holding the lock across fsnotify setup is acceptable because
+	// setup is fast (microseconds) and StartWatching is only called at
+	// startup / after a Stop, not on any hot path.
 	m.mu.Lock()
+	defer m.mu.Unlock()
+
 	if m.watching {
-		m.mu.Unlock()
 		slog.Info("kubeconfig watcher already running, skipping StartWatching")
 		return nil
 	}
-	// Reserve ownership immediately. If watcher construction fails below
-	// we roll this back before returning the error.
-	m.watching = true
-	m.mu.Unlock()
 
 	watcher, err := fsnotify.NewWatcher()
 	if err != nil {
-		m.mu.Lock()
-		m.watching = false
-		m.mu.Unlock()
 		return fmt.Errorf("failed to create watcher: %w", err)
 	}
 
 	// Watch the kubeconfig file
 	if err := watcher.Add(m.kubeconfig); err != nil {
 		watcher.Close()
-		m.mu.Lock()
-		m.watching = false
-		m.mu.Unlock()
 		return fmt.Errorf("failed to watch kubeconfig: %w", err)
 	}
 
@@ -931,7 +927,6 @@ func (m *MultiClusterClient) StartWatching() error {
 		slog.Warn("could not watch kubeconfig directory", "error", err)
 	}
 
-	m.mu.Lock()
 	m.watcher = watcher
 	// issue 6472 — Recreate stopWatch and reset the once on every Start so
 	// Stop→Start sequences actually work. Previously Start only initialized
@@ -943,7 +938,11 @@ func (m *MultiClusterClient) StartWatching() error {
 	// concurrent Stop+Start rotates m.stopWatch.
 	stopCh := m.stopWatch
 	w := m.watcher
-	m.mu.Unlock()
+	// Only flip watching=true after setup has fully succeeded. A concurrent
+	// caller arriving before this line sees watching=false and will block
+	// on m.mu until we return; by then setup is complete (or rolled back
+	// via the error path, leaving watching=false for a clean retry).
+	m.watching = true
 
 	go m.watchLoop(stopCh, w)
 	slog.Info("watching kubeconfig for changes", "path", m.kubeconfig)

--- a/pkg/k8s/watcher_lifecycle_test.go
+++ b/pkg/k8s/watcher_lifecycle_test.go
@@ -2,6 +2,7 @@ package k8s
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"path/filepath"
 	"sync"
@@ -191,6 +192,12 @@ func TestMultiClusterClient_StartWatching_ConcurrentRace(t *testing.T) {
 	var wg sync.WaitGroup
 	errs := make(chan error, concurrentStartCallers)
 	start := make(chan struct{})
+	// PR #6573 item A — assert that EVERY successful StartWatching caller
+	// observes m.watcher != nil immediately after its own call returns. The
+	// previous impl released the lock before running fsnotify setup, so a
+	// second caller could see watching=true and return nil while m.watcher
+	// was still nil. With the lock now held across setup, any StartWatching
+	// return means setup has fully completed (or cleanly rolled back).
 	for i := 0; i < concurrentStartCallers; i++ {
 		wg.Add(1)
 		go func() {
@@ -198,6 +205,15 @@ func TestMultiClusterClient_StartWatching_ConcurrentRace(t *testing.T) {
 			<-start
 			if e := m.StartWatching(); e != nil {
 				errs <- e
+				return
+			}
+			// Setup must be complete before ANY caller returns nil.
+			m.mu.Lock()
+			wInstalled := m.watcher
+			watching := m.watching
+			m.mu.Unlock()
+			if !watching || wInstalled == nil {
+				errs <- fmt.Errorf("StartWatching returned nil but watcher not yet installed (watching=%v, watcher=%v)", watching, wInstalled != nil)
 			}
 		}()
 	}
@@ -238,6 +254,7 @@ func TestMultiClusterClient_StopStartRace(t *testing.T) {
 
 	var wg sync.WaitGroup
 	const cycles = 25 // kept modest because each cycle does real fsnotify I/O
+	startErrs := make(chan error, cycles)
 	for i := 0; i < cycles; i++ {
 		wg.Add(2)
 		go func() {
@@ -246,10 +263,19 @@ func TestMultiClusterClient_StopStartRace(t *testing.T) {
 		}()
 		go func() {
 			defer wg.Done()
-			_ = m.StartWatching()
+			// PR #6573 item D — assert no fsnotify error escapes. The
+			// previous test swallowed errors with `_ =`, so a resource
+			// exhaustion failure would have let the test pass vacuously.
+			if e := m.StartWatching(); e != nil {
+				startErrs <- e
+			}
 		}()
 	}
 	wg.Wait()
+	close(startErrs)
+	for e := range startErrs {
+		t.Fatalf("StartWatching error during Stop/Start race: %v", e)
+	}
 	m.StopWatching()
 }
 

--- a/web/e2e/Dashboard.spec.ts
+++ b/web/e2e/Dashboard.spec.ts
@@ -367,36 +367,38 @@ test.describe('Dashboard Page', () => {
         timeout: 10000,
       })
 
-      // Look for any element with data-testid containing "cluster-count"
-      // OR any stat-value element that displays the expected number. Use
-      // a pattern rather than an exact testid because cards vary.
-      const countEl = page
-        .locator(
-          `[data-testid*="cluster-count"], [data-testid*="total-clusters"]`
-        )
-        .first()
-
-      const hasCountEl = await countEl.isVisible().catch(() => false)
-      if (hasCountEl) {
-        // #6507(D) — assert the exact text on the count element, not
-        // toContainText. Prevents false positives like "30" matching "3".
-        await expect(countEl).toHaveText(
-          new RegExp(`^\\s*${EXPECTED_CLUSTER_COUNT}\\s*$`)
+      // PR #6574 items A+B — target the StatBlock for `clusters` directly
+      // via the new `stat-block-${id}` testid. Previously this spec looked
+      // for `cluster-count` / `total-clusters` testids that didn't exist
+      // on StatsOverview.tsx at all, so the `hasCountEl` check always fell
+      // through to the structural fallback. Now we address the block
+      // directly and use a word-boundary regex so the count can't
+      // false-positive on substrings (e.g. "3" matching inside "30 nodes").
+      const clusterStatBlock = page.getByTestId('stat-block-clusters').first()
+      const hasStatBlock = await clusterStatBlock.isVisible().catch(() => false)
+      if (hasStatBlock) {
+        // Word-boundary match: the StatBlock wraps the numeric value in a
+        // div with header text ("Clusters") and optional sublabel, so we
+        // can't use toHaveText (which would match the whole block). A
+        // word-bounded regex keeps this precise without requiring a deeper
+        // DOM drill-down into every display mode (numeric/gauge/ring/etc).
+        await expect(clusterStatBlock).toContainText(
+          new RegExp(`\\b${EXPECTED_CLUSTER_COUNT}\\b`)
         )
       } else {
-        // #6507(D) — Structural fallback. Previously this matched freeform
-        // body text, which is vacuously true for phrases like
-        // "3 nodes in 3 clusters" even when the cluster count is wrong.
-        // Instead, locate an element whose aria-label / data-testid / text
-        // is explicitly about cluster count, and assert its exact text.
+        // PR #6574 item B — Structural fallback. If the clusters StatBlock
+        // isn't mounted (e.g. user hid it via StatsConfig), try an aria
+        // role=status element that explicitly labels itself as a cluster
+        // count. Use a word-boundary regex, not toContainText(String(n)),
+        // so "3" can't silently match "30 nodes in 3 clusters".
         const countByLabel = page
           .getByRole('status')
           .filter({ hasText: /cluster/i })
           .first()
         const labelVisible = await countByLabel.isVisible().catch(() => false)
         if (labelVisible) {
-          await expect(countByLabel).toContainText(
-            String(EXPECTED_CLUSTER_COUNT)
+          await expect(countByLabel).toHaveText(
+            new RegExp(`\\b${EXPECTED_CLUSTER_COUNT}\\b`)
           )
         } else {
           // Last-resort: no element identifies itself as a cluster count.
@@ -404,8 +406,7 @@ test.describe('Dashboard Page', () => {
           // all. Fail explicitly with a descriptive message.
           throw new Error(
             'Dashboard did not expose a cluster-count element (no ' +
-              '[data-testid*="cluster-count"], [data-testid*="total-clusters"], ' +
-              'or role=status with "cluster" text).'
+              '[data-testid="stat-block-clusters"] or role=status with "cluster" text).'
           )
         }
       }

--- a/web/src/components/feedback/FeatureRequestButton.tsx
+++ b/web/src/components/feedback/FeatureRequestButton.tsx
@@ -19,7 +19,10 @@ export function FeatureRequestButton() {
   // hook fetches the lean `?count_only=true` payload ({id, status} pairs).
   // Consumers that render the full queue (FeatureRequestModal, Updates tab)
   // must NOT pass this flag.
-  const { requests } = useFeatureRequests(undefined, { countOnly: true })
+  // PR #6573 item B — use the lean `summaries` return (typed as
+  // FeatureRequestSummary[]) instead of `requests`. The count_only endpoint
+  // only sends {id, status}, so the full FeatureRequest[] type was a lie.
+  const { summaries } = useFeatureRequests(undefined, { countOnly: true })
 
   // issue 6475 — Unify the navbar badge count with the Updates tab.
   // Previously the navbar used the raw `unreadCount` returned by
@@ -31,13 +34,13 @@ export function FeatureRequestButton() {
   // here so the navbar matches.
   const unreadCount = useMemo(() => {
     const closedIds = new Set(
-      (requests || []).filter(r => r.status === 'closed').map(r => r.id)
+      (summaries || []).filter(r => r.status === 'closed').map(r => r.id)
     )
     return (notifications || [])
       .filter(n => !closedIds.has(n.feature_request_id || ''))
       .filter(n => !n.read)
       .length
-  }, [notifications, requests])
+  }, [notifications, summaries])
 
   // Auto-open modal when navigated from /issue, /feedback, /feature routes
   useEffect(() => {

--- a/web/src/components/mission-control/__tests__/useMissionControl.test.tsx
+++ b/web/src/components/mission-control/__tests__/useMissionControl.test.tsx
@@ -208,4 +208,67 @@ describe('mergeProjects — user-added preservation (#6465)', () => {
     const names = merged.map((p) => p.name).sort()
     expect(names).toEqual(['cilium', 'falco', 'kyverno', 'opa'])
   })
+
+  // PR #6574 item C — #6507(A) gated the "keep existing entry verbatim"
+  // branch on `prev.userAdded || prev.category === 'Custom'`, so AI-only
+  // entries (neither flag set) must now ACCEPT incoming AI refinements of
+  // the same name instead of echoing the stale copy. Previously there was
+  // no test for this leg — the fix could silently regress to the old
+  // always-preserve behavior without any red vitest.
+  it('accepts incoming AI refinement of an AI-only project (replaces existing entry)', () => {
+    // Existing state: a single AI-suggested project — not userAdded, not
+    // category:'Custom'. The AI re-asks with an updated version of the
+    // same project (new priority, new category, new notes). The refined
+    // entry must REPLACE the original, not be dropped in favor of it.
+    const existing: PayloadProject[] = [
+      makeProject({
+        name: 'istio',
+        category: 'Service Mesh',
+        priority: 'optional',
+      }),
+    ]
+    const incoming: PayloadProject[] = [
+      makeProject({
+        name: 'istio',
+        category: 'Networking',
+        priority: 'required',
+      }),
+    ]
+
+    const merged = mergeProjects(existing, incoming)
+    expect(merged).toHaveLength(1)
+    // Refinement wins: new category + new priority.
+    expect(merged[0].category).toBe('Networking')
+    expect(merged[0].priority).toBe('required')
+    // And it must NOT have been marked userAdded by the merge itself.
+    expect(merged[0].userAdded).not.toBe(true)
+  })
+
+  it('keeps user-added projects pinned even when AI refines a same-named entry', () => {
+    // Contrast with the test above: same shape, but `userAdded: true`
+    // on the existing entry means the refinement is IGNORED and the
+    // user's version is preserved verbatim.
+    const existing: PayloadProject[] = [
+      makeProject({
+        name: 'istio',
+        category: 'Service Mesh',
+        priority: 'optional',
+        userAdded: true,
+      }),
+    ]
+    const incoming: PayloadProject[] = [
+      makeProject({
+        name: 'istio',
+        category: 'Networking',
+        priority: 'required',
+      }),
+    ]
+
+    const merged = mergeProjects(existing, incoming)
+    expect(merged).toHaveLength(1)
+    // User version wins.
+    expect(merged[0].category).toBe('Service Mesh')
+    expect(merged[0].priority).toBe('optional')
+    expect(merged[0].userAdded).toBe(true)
+  })
 })

--- a/web/src/components/ui/StatsOverview.tsx
+++ b/web/src/components/ui/StatsOverview.tsx
@@ -225,6 +225,12 @@ const StatBlock = memo(function StatBlock({ block, data, hasData, isLoading, his
 
   return (
     <div
+      // PR #6574 item A — stable data-testid hooks for e2e selectors. The
+      // Dashboard spec asserts cluster-count values; without these hooks it
+      // was grepping the page body for digits and false-positiving on
+      // substrings (e.g. "3" matching "30 nodes"). Hook name is scoped by
+      // block id so each stat is individually addressable.
+      data-testid={`stat-block-${block.id}`}
       className={`group relative glass p-4 rounded-lg min-h-[100px] ${isLoading ? 'animate-pulse' : ''} ${isClickable ? 'cursor-pointer hover:bg-secondary/50' : ''} ${isDemo ? 'border border-yellow-500/30 bg-yellow-500/5 shadow-[0_0_12px_rgba(234,179,8,0.15)]' : ''} transition-colors`}
       onClick={() => isClickable && data.onClick?.()}
     >

--- a/web/src/hooks/__tests__/useFeatureRequests.test.ts
+++ b/web/src/hooks/__tests__/useFeatureRequests.test.ts
@@ -298,6 +298,50 @@ describe('useFeatureRequests', () => {
     expect(result.current.isSubmitting).toBe(false)
   })
 
+  // PR #6573 item C — the navbar button uses `{ countOnly: true }` to fetch
+  // a lean `{id, status}` payload. Verify the hook hits the count_only URL
+  // and exposes the lean list via `summaries`, separately from the full
+  // `requests` state (which must stay empty in count_only mode so nothing
+  // accidentally reads hallucinated title/description fields).
+  it('countOnly option fetches count_only URL and populates summaries, not requests', async () => {
+    localStorage.setItem('kc-auth-token', 'real-jwt-token')
+    const countPayload = [
+      { id: 'gh-console-42', status: 'closed' },
+      { id: 'gh-console-56', status: 'feasibility_study' },
+      { id: 'gh-docs-17', status: 'open' },
+    ]
+    vi.mocked(api.get).mockResolvedValue({ data: countPayload })
+
+    const { result } = renderHook(() => useFeatureRequests(undefined, { countOnly: true }))
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+
+    // Must have hit the lean URL — NOT the full queue URL.
+    expect(api.get).toHaveBeenCalledWith('/api/feedback/queue?count_only=true')
+    // Lean results land in summaries, typed as {id, status}.
+    expect(result.current.summaries).toHaveLength(3)
+    expect(result.current.summaries[0]).toEqual({ id: 'gh-console-42', status: 'closed' })
+    // Full requests stays empty so no consumer reads stale/empty title fields.
+    expect(result.current.requests).toEqual([])
+  })
+
+  it('countOnly derives closed-id set consumers can use for navbar badge filter', async () => {
+    localStorage.setItem('kc-auth-token', 'real-jwt-token')
+    const countPayload = [
+      { id: 'gh-console-1', status: 'closed' },
+      { id: 'gh-console-2', status: 'open' },
+      { id: 'gh-console-3', status: 'closed' },
+    ]
+    vi.mocked(api.get).mockResolvedValue({ data: countPayload })
+
+    const { result } = renderHook(() => useFeatureRequests(undefined, { countOnly: true }))
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+
+    const closedIds = new Set(result.current.summaries.filter(r => r.status === 'closed').map(r => r.id))
+    expect(closedIds.has('gh-console-1')).toBe(true)
+    expect(closedIds.has('gh-console-2')).toBe(false)
+    expect(closedIds.has('gh-console-3')).toBe(true)
+  })
+
   it('closeRequest only updates the matching request, leaves others unchanged', async () => {
     localStorage.setItem('kc-auth-token', 'real-jwt-token')
     const req1 = { id: 'r1', title: 'Keep', description: 'd', request_type: 'bug', user_id: 'u1', status: 'open', created_at: '2024-01-01' }

--- a/web/src/hooks/useFeatureRequests.ts
+++ b/web/src/hooks/useFeatureRequests.ts
@@ -250,9 +250,26 @@ export interface UseFeatureRequestsOptions {
   countOnly?: boolean
 }
 
+/**
+ * PR #6573 item B — Lean shape returned by the `?count_only=true` endpoint.
+ * Only `id` and `status` are present; every other field on FeatureRequest is
+ * guaranteed empty on the wire, so we use a dedicated type instead of
+ * shoehorning the full FeatureRequest type onto a partial payload.
+ */
+export interface FeatureRequestSummary {
+  id: string
+  status: RequestStatus
+}
+
 // Feature Requests Hook
 export function useFeatureRequests(currentUserId?: string, options?: UseFeatureRequestsOptions) {
   const [requests, setRequests] = useState<FeatureRequest[]>([])
+  // PR #6573 item B — countOnly responses get their own lean-typed state
+  // slot instead of being cast into FeatureRequest[]. The wire payload only
+  // carries {id, status}, so every other field would be undefined on the
+  // full type — a footgun for any consumer that wandered in expecting
+  // title/description/etc. to be populated.
+  const [summaries, setSummaries] = useState<FeatureRequestSummary[]>([])
   const [isLoading, setIsLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
   const [isSubmitting, setIsSubmitting] = useState(false)
@@ -263,22 +280,28 @@ export function useFeatureRequests(currentUserId?: string, options?: UseFeatureR
   const loadRequests = useCallback(async () => {
     // In demo mode, use mock data
     if (isDemoUser()) {
-      const sorted = currentUserId ? sortRequests(DEMO_FEATURE_REQUESTS, currentUserId) : DEMO_FEATURE_REQUESTS
-      setRequests(sorted)
+      if (countOnly) {
+        setSummaries(DEMO_FEATURE_REQUESTS.map(r => ({ id: r.id, status: r.status })))
+      } else {
+        const sorted = currentUserId ? sortRequests(DEMO_FEATURE_REQUESTS, currentUserId) : DEMO_FEATURE_REQUESTS
+        setRequests(sorted)
+      }
       setIsLoading(false)
       return
     }
     try {
       setIsLoading(true)
-      // Fetch from queue endpoint to get all issues. When countOnly is set,
-      // the server returns {id, status} pairs only — enough to compute the
-      // navbar badge (filter notifications by closed request IDs) without
-      // fetching the full queue. See UseFeatureRequestsOptions above.
-      const url = countOnly ? '/api/feedback/queue?count_only=true' : '/api/feedback/queue'
-      const { data } = await api.get<FeatureRequest[]>(url)
-      const safeData = Array.isArray(data) ? data : []
-      const sorted = currentUserId ? sortRequests(safeData, currentUserId) : safeData
-      setRequests(sorted)
+      if (countOnly) {
+        // PR #6573 item B — lean endpoint returns {id, status} only. Type
+        // it that way instead of pretending to hydrate a FeatureRequest[].
+        const { data } = await api.get<FeatureRequestSummary[]>('/api/feedback/queue?count_only=true')
+        setSummaries(Array.isArray(data) ? data : [])
+      } else {
+        const { data } = await api.get<FeatureRequest[]>('/api/feedback/queue')
+        const safeData = Array.isArray(data) ? data : []
+        const sorted = currentUserId ? sortRequests(safeData, currentUserId) : safeData
+        setRequests(sorted)
+      }
       setError(null)
     } catch {
       // Silently fail - backend may be unavailable in demo mode
@@ -353,6 +376,10 @@ export function useFeatureRequests(currentUserId?: string, options?: UseFeatureR
 
   return {
     requests,
+    // PR #6573 item B — populated only when `countOnly` option is set.
+    // Consumers that passed countOnly should read `summaries`; consumers
+    // that need the full queue should read `requests`.
+    summaries,
     isLoading,
     isRefreshing,
     error,


### PR DESCRIPTION
## Summary

Addresses 8 Copilot review comments across two recently-merged PRs.

### #6573 — PR #6552 followups
- **StartWatching fsnotify race (client.go)** — The prior fix released m.mu before running fsnotify.NewWatcher() + Add, so a second caller could see watching=true and return nil while setup was still in-flight. Now holds the lock across the entire setup (fast path, microseconds), and only flips watching=true after setup has fully succeeded.
- **ConcurrentRace test** — Each caller now asserts m.watcher != nil immediately after its own StartWatching() returns, actively proving setup is complete before any caller returns nil.
- **StopStartRace test** — No longer swallows StartWatching errors with `_ =`; a resource-exhaustion failure would have passed vacuously.
- **count_only QueueItem types (feedback.go)** — The count_only branch now returns []QueueItemCount{ID, Status} instead of a []QueueItem full of empty strings. New struct avoids ,omitempty side effects on existing callers.
- **countOnly hook type mismatch** — useFeatureRequests now has a dedicated FeatureRequestSummary type and a new `summaries` return value for count-only mode. No more pretending to hydrate FeatureRequest[] from a {id, status} payload.
- **countOnly hook tests** — New vitest coverage for the count_only URL and the summaries state slot.

### #6574 — PR #6572 followups
- **Missing testids** — Added `data-testid="stat-block-${id}"` on StatsOverview.tsx so the e2e spec can address individual stat blocks. Previous selectors (cluster-count, total-clusters) never existed on this component.
- **toContainText false-positive** — Dashboard.spec.ts now uses a word-boundary regex (\b3\b) instead of toContainText(String(3)), which could match "3" inside "30 nodes".
- **mergeProjects AI-refinement test** — New test for the #6507A gate: an AI-only existing entry (neither userAdded nor category:Custom) must accept an incoming AI refinement. Paired with an explicit userAdded=true counter-test.

## Verification
- go build ./... / go vet ./... — pass
- go test ./pkg/k8s/ ./pkg/api/handlers/ -race -timeout 180s — pass
- npm run build — pass
- npx vitest run src/components/mission-control src/hooks/__tests__/useFeatureRequests.test.ts src/test/ui-ux-standards.test.ts — 82/82 pass
- npx playwright test --list — registers
- npm run lint — no NEW errors in touched files

Fixes #6573
Fixes #6574