### PR TITLE
fix: gitops helm install detached ctx + github.com API base + sseCacheGet refresh race (#6591, #6592)

### DIFF
--- a/pkg/api/handlers/feedback.go
+++ b/pkg/api/handlers/feedback.go
@@ -12,6 +12,7 @@ import (
 	"io"
 	"log/slog"
 	"net/http"
+	"net/url"
 	"os"
 	"regexp"
 	"strconv"
@@ -35,17 +36,51 @@ const githubAPITimeout = 10 * time.Second
 // Returned value has no trailing slash. For public github.com, returns
 // "https://api.github.com". For GHE (e.g. GITHUB_URL=https://github.example.com),
 // returns "https://github.example.com/api/v3" per GHE conventions.
+//
+// #6591: Previously, any non-empty GITHUB_URL that didn't literally contain
+// "api.github.com" was treated as GHE and had "/api/v3" appended. An operator
+// who set the natural vanity value GITHUB_URL=https://github.com ended up with
+// https://github.com/api/v3, which doesn't exist — github.com's API lives at
+// api.github.com. Recognize public github.com (with or without scheme, with
+// or without www.) as a special case.
 func resolveGitHubAPIBase() string {
 	raw := strings.TrimSpace(os.Getenv("GITHUB_URL"))
 	if raw == "" {
 		return githubAPIBase
 	}
-	raw = strings.TrimRight(raw, "/")
-	// If the user already set GITHUB_URL to api.github.com, return as-is.
-	if strings.Contains(raw, "api.github.com") {
-		return raw
+	// Special case: public github.com → api.github.com. Handle bare hosts
+	// ("github.com") as well as fully-qualified URLs ("https://github.com").
+	if host, err := extractHost(raw); err == nil {
+		switch host {
+		case "github.com", "www.github.com", "api.github.com":
+			return "https://api.github.com"
+		}
 	}
-	return raw + "/api/v3"
+	// Otherwise assume GitHub Enterprise Server: <base>/api/v3.
+	trimmed := strings.TrimRight(raw, "/")
+	if strings.HasSuffix(trimmed, "/api/v3") {
+		return trimmed
+	}
+	return trimmed + "/api/v3"
+}
+
+// extractHost parses a GITHUB_URL value (which may be a bare host like
+// "github.com" or a full URL like "https://ghe.example.com/foo") and returns
+// the lowercased hostname. It is tolerant of missing schemes.
+func extractHost(raw string) (string, error) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return "", fmt.Errorf("empty URL")
+	}
+	// url.Parse treats bare hosts as Path, so inject a scheme if missing.
+	if !strings.Contains(raw, "://") {
+		raw = "https://" + raw
+	}
+	u, err := url.Parse(raw)
+	if err != nil {
+		return "", err
+	}
+	return strings.ToLower(u.Hostname()), nil
 }
 
 // screenshotUploadTimeout is a longer timeout for uploading base64 screenshots

--- a/pkg/api/handlers/feedback_test.go
+++ b/pkg/api/handlers/feedback_test.go
@@ -368,3 +368,30 @@ func TestWebhook_InvalidJSON_Returns400(t *testing.T) {
 	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
 	assert.Contains(t, body, "Invalid JSON payload")
 }
+
+// TestResolveGitHubAPIBase covers #6591: GITHUB_URL=https://github.com was
+// being treated as GHE and rewritten to https://github.com/api/v3, which
+// doesn't exist. Public github.com must resolve to api.github.com, while
+// GHE hosts keep the /api/v3 suffix.
+func TestResolveGitHubAPIBase(t *testing.T) {
+	cases := []struct {
+		name string
+		env  string
+		want string
+	}{
+		{"empty defaults to public api", "", "https://api.github.com"},
+		{"fully qualified github.com", "https://github.com", "https://api.github.com"},
+		{"bare host github.com", "github.com", "https://api.github.com"},
+		{"www.github.com", "https://www.github.com", "https://api.github.com"},
+		{"already api.github.com", "https://api.github.com", "https://api.github.com"},
+		{"GHE bare URL gets /api/v3", "https://ghe.example.com", "https://ghe.example.com/api/v3"},
+		{"GHE URL already has /api/v3", "https://ghe.example.com/api/v3", "https://ghe.example.com/api/v3"},
+		{"GHE URL with trailing slash", "https://ghe.example.com/", "https://ghe.example.com/api/v3"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("GITHUB_URL", tc.env)
+			assert.Equal(t, tc.want, resolveGitHubAPIBase())
+		})
+	}
+}

--- a/pkg/api/handlers/gitops.go
+++ b/pkg/api/handlers/gitops.go
@@ -1956,8 +1956,32 @@ func (h *GitOpsHandlers) findReleaseNamespace(ctx context.Context, cluster, rele
 // Helm Write Operations
 // ============================================================================
 
-/** helmWriteTimeout is the timeout for helm write operations (rollback, uninstall, upgrade). */
-const helmWriteTimeout = 60 * time.Second
+// helmOperationTimeout is the server-side ceiling for detached helm write
+// operations. #6592: helm install/upgrade/uninstall/rollback must complete
+// even when the HTTP client disconnects mid-flight, so we run them in a
+// context that's decoupled from the Fiber request context. Must be generous
+// enough for large charts with many hooks/CRDs to finish, yet bounded so a
+// wedged helm subprocess can't run forever.
+const helmOperationTimeout = 10 * time.Minute
+
+// detachedHelmContext returns a context suitable for state-mutating helm
+// subprocesses (install, upgrade, uninstall, rollback). It preserves values
+// from the request context (deadlines-as-values, trace IDs, logging tags)
+// via context.WithoutCancel but drops cancellation propagation — otherwise a
+// user closing their browser tab mid-install would SIGKILL the helm process
+// and orphan the release in `pending-install`, deadlocking future operations
+// on that namespace until the release lock is cleared manually. A fresh
+// WithTimeout using helmOperationTimeout then caps the server-side lifetime.
+//
+// Read-only operations (helm ls, helm get, helm history, helm template) must
+// NOT use this helper — they should remain bound to the request context so a
+// disconnected client cancels the work promptly. See #6592.
+func detachedHelmContext(c *fiber.Ctx) (context.Context, context.CancelFunc) {
+	return context.WithTimeout(
+		context.WithoutCancel(c.UserContext()),
+		helmOperationTimeout,
+	)
+}
 
 // HelmRollbackRequest is the request body for rolling back a release
 type HelmRollbackRequest struct {
@@ -2015,7 +2039,9 @@ func (h *GitOpsHandlers) RollbackHelmRelease(c *fiber.Ctx) error {
 		args = append(args, "--kube-context", req.Cluster)
 	}
 
-	ctx, cancel := context.WithTimeout(c.Context(), helmWriteTimeout)
+	// #6592: detach from the request context so a disconnected client doesn't
+	// SIGKILL helm mid-rollback and leave the release in a broken state.
+	ctx, cancel := detachedHelmContext(c)
 	defer cancel()
 
 	cmd := exec.CommandContext(ctx, "helm", args...)
@@ -2068,7 +2094,9 @@ func (h *GitOpsHandlers) UninstallHelmRelease(c *fiber.Ctx) error {
 		args = append(args, "--kube-context", req.Cluster)
 	}
 
-	ctx, cancel := context.WithTimeout(c.Context(), helmWriteTimeout)
+	// #6592: detach from the request context so a disconnected client doesn't
+	// SIGKILL helm mid-uninstall and leave dangling resources / release lock.
+	ctx, cancel := detachedHelmContext(c)
 	defer cancel()
 
 	cmd := exec.CommandContext(ctx, "helm", args...)
@@ -2133,7 +2161,9 @@ func (h *GitOpsHandlers) UpgradeHelmRelease(c *fiber.Ctx) error {
 		args = append(args, "--kube-context", req.Cluster)
 	}
 
-	ctx, cancel := context.WithTimeout(c.Context(), helmWriteTimeout)
+	// #6592: detach from the request context so a disconnected client doesn't
+	// SIGKILL helm mid-upgrade and leave the release in `pending-upgrade`.
+	ctx, cancel := detachedHelmContext(c)
 	defer cancel()
 
 	cmd := exec.CommandContext(ctx, "helm", args...)

--- a/pkg/api/handlers/sse.go
+++ b/pkg/api/handlers/sse.go
@@ -230,9 +230,20 @@ func sseCacheGet(key string) interface{} {
 	}
 	// Expired — upgrade to a write lock to delete. The background evictor
 	// also prunes expired entries, so losing the race here is harmless.
+	//
+	// #6591: Between releasing the RLock and acquiring the write Lock, another
+	// goroutine may have refreshed the entry via sseCacheSet. Re-check under
+	// the write lock and, if the entry is now fresh, return it instead of
+	// dropping a freshly-populated value on the floor (which would force the
+	// caller to re-fetch unnecessarily).
 	sseCacheMu.RUnlock()
 	sseCacheMu.Lock()
-	if e2, ok := sseCache[key]; ok && time.Since(e2.fetchedAt) >= sseCacheTTL {
+	if e2, ok := sseCache[key]; ok {
+		if time.Since(e2.fetchedAt) < sseCacheTTL {
+			data := e2.data
+			sseCacheMu.Unlock()
+			return data
+		}
 		delete(sseCache, key)
 	}
 	sseCacheMu.Unlock()


### PR DESCRIPTION
## Summary

Three bugs across pkg/api/handlers/:

1. **#6592 — GitOps helm mutating ops cancelled on client disconnect.** exec.CommandContext for helm upgrade/uninstall/rollback was bound to the Fiber request context. A user closing their browser tab mid-flight sent SIGKILL to the helm subprocess, stranding the release in pending-upgrade / pending-install and deadlocking the namespace. Introduces detachedHelmContext() which combines context.WithoutCancel (preserves trace/log values) with a fresh WithTimeout(helmOperationTimeout = 10m) so the subprocess survives client disconnects but still has a server-side ceiling. Read-only paths (helm ls, get, history, template) keep the request-scoped context so a disconnect still cancels them.

2. **#6591A — resolveGitHubAPIBase mishandles GITHUB_URL=https://github.com.** Previously any non-empty value that didn't literally contain api.github.com got /api/v3 appended, so the vanity setting https://github.com resolved to the nonexistent https://github.com/api/v3. Now parses the host and special-cases github.com / www.github.com / api.github.com to api.github.com. GHE hosts keep their /api/v3 behavior. New TestResolveGitHubAPIBase table test.

3. **#6591B — sseCacheGet drops refreshed entries on write-lock upgrade race.** Between releasing the RLock and acquiring the write Lock another goroutine could refresh the expired entry via sseCacheSet. The previous code unconditionally deleted it and returned nil. Re-check under the write lock and return the refreshed entry if fresh.

## Test plan

- [x] go build ./...
- [x] go vet ./...
- [x] go test ./pkg/api/handlers/ -race -timeout 180s
- [x] helm lint deploy/helm/kubestellar-console
- [x] New TestResolveGitHubAPIBase covers empty, bare/scheme github.com, www., api., GHE bare, GHE /api/v3, trailing slash

Fixes #6591
Fixes #6592