### PR TITLE
fix(backend): 5 more missing LIMIT clauses + WithoutCancel comment correction (#6598-#6602, #6600)

### DIFF
--- a/pkg/api/handlers/feedback.go
+++ b/pkg/api/handlers/feedback.go
@@ -32,6 +32,38 @@ import (
 // githubAPITimeout is the timeout for HTTP requests to the GitHub API.
 const githubAPITimeout = 10 * time.Second
 
+// feedbackMaxClientLimit is the largest page size a client may request on
+// feedback list endpoints. #6601/#6602: the handler rejects anything above
+// this; the store additionally clamps to its own internal ceiling.
+const feedbackMaxClientLimit = 2000
+
+// parsePageParams reads `limit` and `offset` query params with defense against
+// malformed or oversized requests. Returns (limit, offset, err). When limit is
+// absent/invalid, 0 is returned so the store applies its default. When limit
+// exceeds feedbackMaxClientLimit, a 400 error is returned. #6598-#6602.
+func parsePageParams(c *fiber.Ctx) (int, int, error) {
+	limit := 0
+	if raw := c.Query("limit"); raw != "" {
+		n, err := strconv.Atoi(raw)
+		if err != nil || n < 0 {
+			return 0, 0, fiber.NewError(fiber.StatusBadRequest, "invalid limit")
+		}
+		if n > feedbackMaxClientLimit {
+			return 0, 0, fiber.NewError(fiber.StatusBadRequest, "limit too large")
+		}
+		limit = n
+	}
+	offset := 0
+	if raw := c.Query("offset"); raw != "" {
+		n, err := strconv.Atoi(raw)
+		if err != nil || n < 0 {
+			return 0, 0, fiber.NewError(fiber.StatusBadRequest, "invalid offset")
+		}
+		offset = n
+	}
+	return limit, offset, nil
+}
+
 // resolveGitHubAPIBase returns the API base URL, honoring GITHUB_URL for GHE.
 // Returned value has no trailing slash. For public github.com, returns
 // "https://api.github.com". For GHE (e.g. GITHUB_URL=https://github.example.com),
@@ -270,7 +302,12 @@ func (h *FeedbackHandler) CreateFeatureRequest(c *fiber.Ctx) error {
 func (h *FeedbackHandler) ListFeatureRequests(c *fiber.Ctx) error {
 	userID := middleware.GetUserID(c)
 
-	requests, err := h.store.GetUserFeatureRequests(userID)
+	limit, offset, err := parsePageParams(c)
+	if err != nil {
+		return err
+	}
+
+	requests, err := h.store.GetUserFeatureRequests(userID, limit, offset)
 	if err != nil {
 		return fiber.NewError(fiber.StatusInternalServerError, "Failed to list feature requests")
 	}
@@ -814,7 +851,11 @@ func (h *FeedbackHandler) fetchGitHubIssuesFromRepo(githubLogin string, repoName
 
 // listLocalFeatureRequests falls back to local database when GitHub is unavailable
 func (h *FeedbackHandler) listLocalFeatureRequests(c *fiber.Ctx, userID uuid.UUID) error {
-	requests, err := h.store.GetAllFeatureRequests()
+	limit, offset, err := parsePageParams(c)
+	if err != nil {
+		return err
+	}
+	requests, err := h.store.GetAllFeatureRequests(limit, offset)
 	if err != nil {
 		return fiber.NewError(fiber.StatusInternalServerError, "Failed to list feature requests")
 	}

--- a/pkg/api/handlers/gitops.go
+++ b/pkg/api/handlers/gitops.go
@@ -1965,13 +1965,27 @@ func (h *GitOpsHandlers) findReleaseNamespace(ctx context.Context, cluster, rele
 const helmOperationTimeout = 10 * time.Minute
 
 // detachedHelmContext returns a context suitable for state-mutating helm
-// subprocesses (install, upgrade, uninstall, rollback). It preserves values
-// from the request context (deadlines-as-values, trace IDs, logging tags)
-// via context.WithoutCancel but drops cancellation propagation — otherwise a
-// user closing their browser tab mid-install would SIGKILL the helm process
-// and orphan the release in `pending-install`, deadlocking future operations
-// on that namespace until the release lock is cleared manually. A fresh
-// WithTimeout using helmOperationTimeout then caps the server-side lifetime.
+// subprocesses (install, upgrade, uninstall, rollback). The returned context
+// has these semantics:
+//
+//   - Values (trace IDs, logging tags, any other ctx.Value lookups) are
+//     inherited from the request context via context.WithoutCancel.
+//   - Cancellation is NOT inherited: when the client disconnects and the
+//     request context is cancelled, the helm subprocess keeps running.
+//     Otherwise a user closing their browser tab mid-install would SIGKILL
+//     the helm process and orphan the release in `pending-install`,
+//     deadlocking future operations on that namespace until the release
+//     lock is cleared manually.
+//   - The request context's deadline is NOT inherited either — context.WithoutCancel
+//     strips both cancellation and deadline. We then wrap the detached
+//     context in context.WithTimeout(helmOperationTimeout) so the detached
+//     operation still has a server-side ceiling independent of whatever
+//     deadline the client set.
+//
+// #6600: an earlier version of this comment incorrectly claimed WithoutCancel
+// preserves "deadlines-as-values" from the request context. It does not —
+// WithoutCancel preserves only Value lookups and explicitly drops both
+// cancellation and any deadline.
 //
 // Read-only operations (helm ls, helm get, helm history, helm template) must
 // NOT use this helper — they should remain bound to the request context so a

--- a/pkg/store/sqlite.go
+++ b/pkg/store/sqlite.go
@@ -73,6 +73,15 @@ func parseUUID(s string, field string) uuid.UUID {
 // This provides defense-in-depth against unbounded queries from internal callers.
 const maxSQLLimit = 1000
 
+// defaultPageLimit is the default page size for list queries when the caller
+// does not supply one (limit <= 0). #6598-#6602.
+const defaultPageLimit = 500
+
+// defaultAdminPageLimit is the default page size for admin list queries that
+// are hit on every dashboard load (e.g. GetAllFeatureRequests). Smaller than
+// defaultPageLimit because the admin UI pages through results. #6602.
+const defaultAdminPageLimit = 100
+
 // clampLimit ensures a SQL LIMIT parameter is within safe bounds (1 to maxSQLLimit).
 func clampLimit(limit int) int {
 	if limit < 1 {
@@ -82,6 +91,23 @@ func clampLimit(limit int) int {
 		return maxSQLLimit
 	}
 	return limit
+}
+
+// resolvePageLimit applies the supplied limit (falling back to fallback when
+// limit <= 0) and clamps the result to maxSQLLimit. #6598-#6602.
+func resolvePageLimit(limit, fallback int) int {
+	if limit <= 0 {
+		limit = fallback
+	}
+	return clampLimit(limit)
+}
+
+// resolvePageOffset clamps negative offsets to 0. #6598-#6602.
+func resolvePageOffset(offset int) int {
+	if offset < 0 {
+		return 0
+	}
+	return offset
 }
 
 // getEnvInt reads an integer from the environment, falling back to defaultVal.
@@ -991,8 +1017,14 @@ func (s *SQLiteStore) GetUserPendingSwaps(userID uuid.UUID) ([]models.PendingSwa
 	return swaps, rows.Err()
 }
 
-func (s *SQLiteStore) GetDueSwaps() ([]models.PendingSwap, error) {
-	rows, err := s.db.Query(`SELECT id, user_id, card_id, new_card_type, new_card_config, reason, swap_at, status, created_at FROM pending_swaps WHERE status = 'pending' AND swap_at <= ?`, time.Now())
+// GetDueSwaps returns pending swaps whose swap_at has arrived, ordered by
+// swap_at ascending so the oldest due swaps are processed first.
+// #6598: LIMIT/OFFSET prevent OOM when a scheduler outage leaves a large
+// backlog. Callers that need to drain the full backlog must page.
+func (s *SQLiteStore) GetDueSwaps(limit, offset int) ([]models.PendingSwap, error) {
+	lim := resolvePageLimit(limit, defaultPageLimit)
+	off := resolvePageOffset(offset)
+	rows, err := s.db.Query(`SELECT id, user_id, card_id, new_card_type, new_card_config, reason, swap_at, status, created_at FROM pending_swaps WHERE status = 'pending' AND swap_at <= ? ORDER BY swap_at ASC LIMIT ? OFFSET ?`, time.Now(), lim, off)
 	if err != nil {
 		return nil, err
 	}
@@ -1114,9 +1146,14 @@ func (s *SQLiteStore) RecordEvent(event *models.UserEvent) error {
 	return err
 }
 
-func (s *SQLiteStore) GetRecentEvents(userID uuid.UUID, since time.Duration) ([]models.UserEvent, error) {
+// GetRecentEvents returns a user's events within the given window, newest first.
+// #6599: LIMIT/OFFSET bound the read so a chatty client cannot force an
+// unbounded scan of user_events.
+func (s *SQLiteStore) GetRecentEvents(userID uuid.UUID, since time.Duration, limit, offset int) ([]models.UserEvent, error) {
 	cutoff := time.Now().Add(-since)
-	rows, err := s.db.Query(`SELECT id, user_id, event_type, card_id, metadata, created_at FROM user_events WHERE user_id = ? AND created_at >= ? ORDER BY created_at DESC`, userID.String(), cutoff)
+	lim := resolvePageLimit(limit, defaultPageLimit)
+	off := resolvePageOffset(offset)
+	rows, err := s.db.Query(`SELECT id, user_id, event_type, card_id, metadata, created_at FROM user_events WHERE user_id = ? AND created_at >= ? ORDER BY created_at DESC LIMIT ? OFFSET ?`, userID.String(), cutoff, lim, off)
 	if err != nil {
 		return nil, err
 	}
@@ -1181,8 +1218,12 @@ func (s *SQLiteStore) GetFeatureRequestByPRNumber(prNumber int) (*models.Feature
 	return s.scanFeatureRequest(row)
 }
 
-func (s *SQLiteStore) GetUserFeatureRequests(userID uuid.UUID) ([]models.FeatureRequest, error) {
-	rows, err := s.db.Query(`SELECT id, user_id, title, description, request_type, github_issue_number, status, pr_number, pr_url, copilot_session_url, netlify_preview_url, closed_by_user, latest_comment, created_at, updated_at FROM feature_requests WHERE user_id = ? ORDER BY created_at DESC`, userID.String())
+// GetUserFeatureRequests returns a user's feature requests, newest first.
+// #6601: LIMIT/OFFSET prevent unbounded per-user reads.
+func (s *SQLiteStore) GetUserFeatureRequests(userID uuid.UUID, limit, offset int) ([]models.FeatureRequest, error) {
+	lim := resolvePageLimit(limit, defaultPageLimit)
+	off := resolvePageOffset(offset)
+	rows, err := s.db.Query(`SELECT id, user_id, title, description, request_type, github_issue_number, status, pr_number, pr_url, copilot_session_url, netlify_preview_url, closed_by_user, latest_comment, created_at, updated_at FROM feature_requests WHERE user_id = ? ORDER BY created_at DESC LIMIT ? OFFSET ?`, userID.String(), lim, off)
 	if err != nil {
 		return nil, err
 	}
@@ -1199,8 +1240,14 @@ func (s *SQLiteStore) GetUserFeatureRequests(userID uuid.UUID) ([]models.Feature
 	return requests, rows.Err()
 }
 
-func (s *SQLiteStore) GetAllFeatureRequests() ([]models.FeatureRequest, error) {
-	rows, err := s.db.Query(`SELECT id, user_id, title, description, request_type, github_issue_number, status, pr_number, pr_url, copilot_session_url, netlify_preview_url, closed_by_user, latest_comment, created_at, updated_at FROM feature_requests ORDER BY created_at DESC`)
+// GetAllFeatureRequests returns the full feature_requests table, newest first.
+// #6602: LIMIT/OFFSET required. The admin dashboard hits this on every load,
+// so the default page size (defaultAdminPageLimit) is intentionally smaller
+// than the generic defaultPageLimit; callers that need more must page.
+func (s *SQLiteStore) GetAllFeatureRequests(limit, offset int) ([]models.FeatureRequest, error) {
+	lim := resolvePageLimit(limit, defaultAdminPageLimit)
+	off := resolvePageOffset(offset)
+	rows, err := s.db.Query(`SELECT id, user_id, title, description, request_type, github_issue_number, status, pr_number, pr_url, copilot_session_url, netlify_preview_url, closed_by_user, latest_comment, created_at, updated_at FROM feature_requests ORDER BY created_at DESC LIMIT ? OFFSET ?`, lim, off)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/store/store.go
+++ b/pkg/store/store.go
@@ -86,22 +86,35 @@ type Store interface {
 	// Pending Swaps
 	GetPendingSwap(id uuid.UUID) (*models.PendingSwap, error)
 	GetUserPendingSwaps(userID uuid.UUID) ([]models.PendingSwap, error)
-	GetDueSwaps() ([]models.PendingSwap, error)
+	// GetDueSwaps returns pending swaps whose swap_at time has arrived.
+	// #6598: limit/offset are required to prevent unbounded scans when the
+	// swap backlog grows large (e.g. scheduler outage). Pass 0 for limit to
+	// use the store default.
+	GetDueSwaps(limit, offset int) ([]models.PendingSwap, error)
 	CreatePendingSwap(swap *models.PendingSwap) error
 	UpdateSwapStatus(id uuid.UUID, status models.SwapStatus) error
 	SnoozeSwap(id uuid.UUID, newSwapAt time.Time) error
 
 	// User Events
 	RecordEvent(event *models.UserEvent) error
-	GetRecentEvents(userID uuid.UUID, since time.Duration) ([]models.UserEvent, error)
+	// GetRecentEvents returns a user's events within the given time window.
+	// #6599: limit/offset are required to bound event history reads.
+	// Pass 0 for limit to use the store default.
+	GetRecentEvents(userID uuid.UUID, since time.Duration, limit, offset int) ([]models.UserEvent, error)
 
 	// Feature Requests
 	CreateFeatureRequest(request *models.FeatureRequest) error
 	GetFeatureRequest(id uuid.UUID) (*models.FeatureRequest, error)
 	GetFeatureRequestByIssueNumber(issueNumber int) (*models.FeatureRequest, error)
 	GetFeatureRequestByPRNumber(prNumber int) (*models.FeatureRequest, error)
-	GetUserFeatureRequests(userID uuid.UUID) ([]models.FeatureRequest, error)
-	GetAllFeatureRequests() ([]models.FeatureRequest, error)
+	// GetUserFeatureRequests returns a user's feature requests, newest first.
+	// #6601: limit/offset required. Pass 0 for limit to use the store default.
+	GetUserFeatureRequests(userID uuid.UUID, limit, offset int) ([]models.FeatureRequest, error)
+	// GetAllFeatureRequests returns the global feature-request table, newest first.
+	// #6602: limit/offset required; admin dashboard uses a smaller default (100)
+	// because this is hit on every dashboard load. Pass 0 for limit to use the
+	// store default.
+	GetAllFeatureRequests(limit, offset int) ([]models.FeatureRequest, error)
 	UpdateFeatureRequest(request *models.FeatureRequest) error
 	UpdateFeatureRequestStatus(id uuid.UUID, status models.RequestStatus) error
 	CloseFeatureRequest(id uuid.UUID, closedByUser bool) error

--- a/pkg/test/mock_store.go
+++ b/pkg/test/mock_store.go
@@ -98,13 +98,15 @@ func (m *MockStore) GetPendingSwap(id uuid.UUID) (*models.PendingSwap, error) { 
 func (m *MockStore) GetUserPendingSwaps(userID uuid.UUID) ([]models.PendingSwap, error) {
 	return nil, nil
 }
-func (m *MockStore) GetDueSwaps() ([]models.PendingSwap, error)                    { return nil, nil }
+func (m *MockStore) GetDueSwaps(limit, offset int) ([]models.PendingSwap, error) {
+	return nil, nil
+}
 func (m *MockStore) CreatePendingSwap(swap *models.PendingSwap) error              { return nil }
 func (m *MockStore) UpdateSwapStatus(id uuid.UUID, status models.SwapStatus) error { return nil }
 func (m *MockStore) SnoozeSwap(id uuid.UUID, newSwapAt time.Time) error            { return nil }
 
 func (m *MockStore) RecordEvent(event *models.UserEvent) error { return nil }
-func (m *MockStore) GetRecentEvents(userID uuid.UUID, since time.Duration) ([]models.UserEvent, error) {
+func (m *MockStore) GetRecentEvents(userID uuid.UUID, since time.Duration, limit, offset int) ([]models.UserEvent, error) {
 	return nil, nil
 }
 
@@ -116,10 +118,12 @@ func (m *MockStore) GetFeatureRequestByIssueNumber(issueNumber int) (*models.Fea
 func (m *MockStore) GetFeatureRequestByPRNumber(prNumber int) (*models.FeatureRequest, error) {
 	return nil, nil
 }
-func (m *MockStore) GetUserFeatureRequests(userID uuid.UUID) ([]models.FeatureRequest, error) {
+func (m *MockStore) GetUserFeatureRequests(userID uuid.UUID, limit, offset int) ([]models.FeatureRequest, error) {
 	return nil, nil
 }
-func (m *MockStore) GetAllFeatureRequests() ([]models.FeatureRequest, error)   { return nil, nil }
+func (m *MockStore) GetAllFeatureRequests(limit, offset int) ([]models.FeatureRequest, error) {
+	return nil, nil
+}
 func (m *MockStore) UpdateFeatureRequest(request *models.FeatureRequest) error { return nil }
 func (m *MockStore) UpdateFeatureRequestStatus(id uuid.UUID, status models.RequestStatus) error {
 	return nil


### PR DESCRIPTION
## Summary

Adds `LIMIT ? OFFSET ?` to four unbounded store queries and corrects an inaccurate comment on `detachedHelmContext` from PR #6594.

### Store changes

- **#6598 `GetDueSwaps`** — added `(limit, offset int)`, orders by `swap_at ASC` so the oldest due swaps drain first under backlog.
- **#6599 `GetRecentEvents`** — added `(limit, offset int)`, bounds event history reads.
- **#6601 `GetUserFeatureRequests`** — added `(limit, offset int)`.
- **#6602 `GetAllFeatureRequests`** — added `(limit, offset int)`. Admin dashboard hits this on every load, so the default is a smaller `defaultAdminPageLimit` (100) vs the generic `defaultPageLimit` (500). Clients that need more must page.

New helpers/constants in `pkg/store/sqlite.go`:
- `defaultPageLimit = 500`
- `defaultAdminPageLimit = 100`
- `resolvePageLimit(limit, fallback)` — clamps to `maxSQLLimit`
- `resolvePageOffset(offset)` — clamps negative offsets to 0

### Handler changes (pkg/api/handlers/feedback.go)

- New `parsePageParams(c)` helper parses `?limit=&offset=` and rejects `limit > feedbackMaxClientLimit (2000)` with HTTP 400.
- `ListFeatureRequests` and `listLocalFeatureRequests` now honor the params.

### #6600 — detachedHelmContext comment fix

The comment on `detachedHelmContext` introduced in PR #6594 claimed `context.WithoutCancel` preserves *"deadlines-as-values"* from the request context. That is wrong — `context.WithoutCancel` preserves only `ctx.Value` lookups and explicitly drops both cancellation and any deadline.

Runtime semantics are still correct:
- Values (trace IDs, logging tags) are inherited
- Cancellation is NOT inherited (parent cancel does not propagate)
- The request context's deadline is NOT inherited
- `context.WithTimeout(helmOperationTimeout)` wraps the detached context so the operation still has a server-side ceiling

Only the comment was wrong; the fix is purely documentation.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./pkg/store/ ./pkg/api/handlers/ -race -timeout 180s`
- [x] `helm lint deploy/helm/kubestellar-console`

Fixes #6598
Fixes #6599
Fixes #6600
Fixes #6601
Fixes #6602