### PR TITLE
fix(backend): 3 more missing LIMIT clauses + PR #6619 Copilot followups (#6595-#6597, #6621)

### DIFF
--- a/pkg/api/handlers/dashboard.go
+++ b/pkg/api/handlers/dashboard.go
@@ -46,7 +46,13 @@ func NewDashboardHandler(s store.Store) *DashboardHandler {
 // ListDashboards returns all dashboards for the current user
 func (h *DashboardHandler) ListDashboards(c *fiber.Ctx) error {
 	userID := middleware.GetUserID(c)
-	dashboards, err := h.store.GetUserDashboards(userID)
+	// #6596: bound the read. Same limit/offset contract as the feedback list
+	// endpoints — absent limit → store default, malformed/oversized → 400.
+	limit, offset, err := parsePageParams(c)
+	if err != nil {
+		return err
+	}
+	dashboards, err := h.store.GetUserDashboards(userID, limit, offset)
 	if err != nil {
 		return fiber.NewError(fiber.StatusInternalServerError, "Failed to list dashboards")
 	}

--- a/pkg/api/handlers/feedback.go
+++ b/pkg/api/handlers/feedback.go
@@ -34,13 +34,29 @@ const githubAPITimeout = 10 * time.Second
 
 // feedbackMaxClientLimit is the largest page size a client may request on
 // feedback list endpoints. #6601/#6602: the handler rejects anything above
-// this; the store additionally clamps to its own internal ceiling.
-const feedbackMaxClientLimit = 2000
+// this with HTTP 400.
+//
+// #6621: this is intentionally aligned to store.maxSQLLimit. Previously this
+// was 2000 while the store clamped to 1000, so a client could ask for 1500
+// and silently get 1000 rows back with no indication the page had been
+// truncated. Keeping both ceilings at the same value means a request for
+// more rows than the store can return is rejected up front with a clear
+// 400 instead of being silently clamped. If the store ceiling is ever
+// raised, raise this in lockstep.
+const feedbackMaxClientLimit = 1000
 
 // parsePageParams reads `limit` and `offset` query params with defense against
-// malformed or oversized requests. Returns (limit, offset, err). When limit is
-// absent/invalid, 0 is returned so the store applies its default. When limit
-// exceeds feedbackMaxClientLimit, a 400 error is returned. #6598-#6602.
+// malformed or oversized requests. Returns (limit, offset, err).
+//
+// Semantics (#6621):
+//   - limit absent       → returns 0 so the store applies its default.
+//   - limit malformed    → HTTP 400 "invalid limit" (non-integer or negative).
+//   - limit > ceiling    → HTTP 400 "limit too large" (exceeds
+//     feedbackMaxClientLimit, which is aligned to the store ceiling).
+//   - offset absent      → returns 0.
+//   - offset malformed   → HTTP 400 "invalid offset".
+//
+// #6598-#6602.
 func parsePageParams(c *fiber.Ctx) (int, int, error) {
 	limit := 0
 	if raw := c.Query("limit"); raw != "" {

--- a/pkg/api/handlers/rbac.go
+++ b/pkg/api/handlers/rbac.go
@@ -56,7 +56,15 @@ func (h *RBACHandler) ListConsoleUsers(c *fiber.Ctx) error {
 		return fiber.NewError(fiber.StatusForbidden, "Admin access required")
 	}
 
-	users, err := h.store.ListUsers()
+	// #6595: bound the read. ?limit=&offset= follow the same contract as the
+	// feedback list endpoints (see parsePageParams). Absent limit → store
+	// default; malformed/oversized limit → HTTP 400.
+	limit, offset, err := parsePageParams(c)
+	if err != nil {
+		return err
+	}
+
+	users, err := h.store.ListUsers(limit, offset)
 	if err != nil {
 		return fiber.NewError(fiber.StatusInternalServerError, "Failed to list users")
 	}

--- a/pkg/api/handlers/rbac_test.go
+++ b/pkg/api/handlers/rbac_test.go
@@ -30,7 +30,7 @@ func (s *rbacTestStore) GetUser(id uuid.UUID) (*models.User, error) {
 	return s.users[id], nil
 }
 
-func (s *rbacTestStore) ListUsers() ([]models.User, error) {
+func (s *rbacTestStore) ListUsers(limit, offset int) ([]models.User, error) {
 	if s.listUsersErr != nil {
 		return nil, s.listUsersErr
 	}

--- a/pkg/api/handlers/swap.go
+++ b/pkg/api/handlers/swap.go
@@ -25,7 +25,13 @@ func NewSwapHandler(s store.Store, hub *Hub) *SwapHandler {
 // ListPendingSwaps returns pending swaps for the current user
 func (h *SwapHandler) ListPendingSwaps(c *fiber.Ctx) error {
 	userID := middleware.GetUserID(c)
-	swaps, err := h.store.GetUserPendingSwaps(userID)
+	// #6597: bound the read. Same limit/offset contract as the feedback list
+	// endpoints — absent limit → store default, malformed/oversized → 400.
+	limit, offset, err := parsePageParams(c)
+	if err != nil {
+		return err
+	}
+	swaps, err := h.store.GetUserPendingSwaps(userID, limit, offset)
 	if err != nil {
 		return fiber.NewError(fiber.StatusInternalServerError, "Failed to list swaps")
 	}

--- a/pkg/store/sqlite.go
+++ b/pkg/store/sqlite.go
@@ -514,9 +514,15 @@ func (s *SQLiteStore) UpdateLastLogin(userID uuid.UUID) error {
 	return err
 }
 
-// ListUsers returns all users
-func (s *SQLiteStore) ListUsers() ([]models.User, error) {
-	rows, err := s.db.Query(`SELECT id, github_id, github_login, email, slack_id, avatar_url, role, onboarded, created_at, last_login FROM users ORDER BY created_at DESC`)
+// ListUsers returns a page of users ordered newest first.
+// #6595: limit/offset are required to prevent an unbounded full-table scan.
+// Pass 0 for limit to use the store default (defaultPageLimit). The secondary
+// ORDER BY id DESC is a stable tie-breaker for rows with identical created_at
+// timestamps so pagination is deterministic across calls.
+func (s *SQLiteStore) ListUsers(limit, offset int) ([]models.User, error) {
+	lim := resolvePageLimit(limit, defaultPageLimit)
+	off := resolvePageOffset(offset)
+	rows, err := s.db.Query(`SELECT id, github_id, github_login, email, slack_id, avatar_url, role, onboarded, created_at, last_login FROM users ORDER BY created_at DESC, id DESC LIMIT ? OFFSET ?`, lim, off)
 	if err != nil {
 		return nil, err
 	}
@@ -677,8 +683,16 @@ func (s *SQLiteStore) GetDashboard(id uuid.UUID) (*models.Dashboard, error) {
 	return s.scanDashboard(row)
 }
 
-func (s *SQLiteStore) GetUserDashboards(userID uuid.UUID) ([]models.Dashboard, error) {
-	rows, err := s.db.Query(`SELECT id, user_id, name, layout, is_default, created_at, updated_at FROM dashboards WHERE user_id = ? ORDER BY is_default DESC, created_at`, userID.String())
+// GetUserDashboards returns a page of a user's dashboards, default dashboard
+// first, then oldest-first within each group.
+// #6596: limit/offset are required to prevent an unbounded per-user read if a
+// user ever accumulates a pathological number of dashboards. Pass 0 for limit
+// to use the store default. ORDER BY includes an id ASC tie-breaker so rows
+// that share created_at paginate deterministically.
+func (s *SQLiteStore) GetUserDashboards(userID uuid.UUID, limit, offset int) ([]models.Dashboard, error) {
+	lim := resolvePageLimit(limit, defaultPageLimit)
+	off := resolvePageOffset(offset)
+	rows, err := s.db.Query(`SELECT id, user_id, name, layout, is_default, created_at, updated_at FROM dashboards WHERE user_id = ? ORDER BY is_default DESC, created_at ASC, id ASC LIMIT ? OFFSET ?`, userID.String(), lim, off)
 	if err != nil {
 		return nil, err
 	}
@@ -1069,8 +1083,16 @@ func (s *SQLiteStore) GetPendingSwap(id uuid.UUID) (*models.PendingSwap, error) 
 	return s.scanPendingSwap(row)
 }
 
-func (s *SQLiteStore) GetUserPendingSwaps(userID uuid.UUID) ([]models.PendingSwap, error) {
-	rows, err := s.db.Query(`SELECT id, user_id, card_id, new_card_type, new_card_config, reason, swap_at, status, created_at FROM pending_swaps WHERE user_id = ? AND status = 'pending' ORDER BY swap_at`, userID.String())
+// GetUserPendingSwaps returns a page of a user's pending swaps, oldest
+// swap_at first.
+// #6597: limit/offset are required so a user with a large backlog of pending
+// swaps cannot force an unbounded read. Pass 0 for limit to use the store
+// default. ORDER BY includes an id ASC tie-breaker so rows that share
+// swap_at paginate deterministically.
+func (s *SQLiteStore) GetUserPendingSwaps(userID uuid.UUID, limit, offset int) ([]models.PendingSwap, error) {
+	lim := resolvePageLimit(limit, defaultPageLimit)
+	off := resolvePageOffset(offset)
+	rows, err := s.db.Query(`SELECT id, user_id, card_id, new_card_type, new_card_config, reason, swap_at, status, created_at FROM pending_swaps WHERE user_id = ? AND status = 'pending' ORDER BY swap_at ASC, id ASC LIMIT ? OFFSET ?`, userID.String(), lim, off)
 	if err != nil {
 		return nil, err
 	}
@@ -1094,7 +1116,11 @@ func (s *SQLiteStore) GetUserPendingSwaps(userID uuid.UUID) ([]models.PendingSwa
 func (s *SQLiteStore) GetDueSwaps(limit, offset int) ([]models.PendingSwap, error) {
 	lim := resolvePageLimit(limit, defaultPageLimit)
 	off := resolvePageOffset(offset)
-	rows, err := s.db.Query(`SELECT id, user_id, card_id, new_card_type, new_card_config, reason, swap_at, status, created_at FROM pending_swaps WHERE status = 'pending' AND swap_at <= ? ORDER BY swap_at ASC LIMIT ? OFFSET ?`, time.Now(), lim, off)
+	// #6621: id ASC tie-breaker ensures pages are stable when multiple swaps
+	// share the same swap_at (common after batch scheduling). Without it,
+	// OFFSET paging could skip or duplicate rows as SQLite picks arbitrary
+	// tie-break order between calls.
+	rows, err := s.db.Query(`SELECT id, user_id, card_id, new_card_type, new_card_config, reason, swap_at, status, created_at FROM pending_swaps WHERE status = 'pending' AND swap_at <= ? ORDER BY swap_at ASC, id ASC LIMIT ? OFFSET ?`, time.Now(), lim, off)
 	if err != nil {
 		return nil, err
 	}
@@ -1223,7 +1249,10 @@ func (s *SQLiteStore) GetRecentEvents(userID uuid.UUID, since time.Duration, lim
 	cutoff := time.Now().Add(-since)
 	lim := resolvePageLimit(limit, defaultPageLimit)
 	off := resolvePageOffset(offset)
-	rows, err := s.db.Query(`SELECT id, user_id, event_type, card_id, metadata, created_at FROM user_events WHERE user_id = ? AND created_at >= ? ORDER BY created_at DESC LIMIT ? OFFSET ?`, userID.String(), cutoff, lim, off)
+	// #6621: id DESC tie-breaker ensures pages are stable when many events
+	// share the same created_at (common when clients burst-record events in
+	// the same millisecond). Without it, OFFSET paging could skip rows.
+	rows, err := s.db.Query(`SELECT id, user_id, event_type, card_id, metadata, created_at FROM user_events WHERE user_id = ? AND created_at >= ? ORDER BY created_at DESC, id DESC LIMIT ? OFFSET ?`, userID.String(), cutoff, lim, off)
 	if err != nil {
 		return nil, err
 	}
@@ -1288,12 +1317,15 @@ func (s *SQLiteStore) GetFeatureRequestByPRNumber(prNumber int) (*models.Feature
 	return s.scanFeatureRequest(row)
 }
 
-// GetUserFeatureRequests returns a user's feature requests, newest first.
+// GetUserFeatureRequests returns a page of a user's feature requests,
+// newest first.
 // #6601: LIMIT/OFFSET prevent unbounded per-user reads.
+// #6621: id DESC tie-breaker ensures OFFSET paging is stable when rows share
+// created_at (e.g. seeded data, bulk imports).
 func (s *SQLiteStore) GetUserFeatureRequests(userID uuid.UUID, limit, offset int) ([]models.FeatureRequest, error) {
 	lim := resolvePageLimit(limit, defaultPageLimit)
 	off := resolvePageOffset(offset)
-	rows, err := s.db.Query(`SELECT id, user_id, title, description, request_type, github_issue_number, status, pr_number, pr_url, copilot_session_url, netlify_preview_url, closed_by_user, latest_comment, created_at, updated_at FROM feature_requests WHERE user_id = ? ORDER BY created_at DESC LIMIT ? OFFSET ?`, userID.String(), lim, off)
+	rows, err := s.db.Query(`SELECT id, user_id, title, description, request_type, github_issue_number, status, pr_number, pr_url, copilot_session_url, netlify_preview_url, closed_by_user, latest_comment, created_at, updated_at FROM feature_requests WHERE user_id = ? ORDER BY created_at DESC, id DESC LIMIT ? OFFSET ?`, userID.String(), lim, off)
 	if err != nil {
 		return nil, err
 	}
@@ -1310,14 +1342,19 @@ func (s *SQLiteStore) GetUserFeatureRequests(userID uuid.UUID, limit, offset int
 	return requests, rows.Err()
 }
 
-// GetAllFeatureRequests returns the full feature_requests table, newest first.
+// GetAllFeatureRequests returns a single page of feature_requests, newest
+// first. Callers that need to walk the full table must page by passing
+// successive offsets; this function never returns more than `limit` rows
+// (clamped to maxSQLLimit) and applies the admin default when limit <= 0.
 // #6602: LIMIT/OFFSET required. The admin dashboard hits this on every load,
 // so the default page size (defaultAdminPageLimit) is intentionally smaller
-// than the generic defaultPageLimit; callers that need more must page.
+// than the generic defaultPageLimit.
+// #6621: id DESC tie-breaker ensures OFFSET paging is stable when rows share
+// created_at (e.g. seeded data, bulk imports).
 func (s *SQLiteStore) GetAllFeatureRequests(limit, offset int) ([]models.FeatureRequest, error) {
 	lim := resolvePageLimit(limit, defaultAdminPageLimit)
 	off := resolvePageOffset(offset)
-	rows, err := s.db.Query(`SELECT id, user_id, title, description, request_type, github_issue_number, status, pr_number, pr_url, copilot_session_url, netlify_preview_url, closed_by_user, latest_comment, created_at, updated_at FROM feature_requests ORDER BY created_at DESC LIMIT ? OFFSET ?`, lim, off)
+	rows, err := s.db.Query(`SELECT id, user_id, title, description, request_type, github_issue_number, status, pr_number, pr_url, copilot_session_url, netlify_preview_url, closed_by_user, latest_comment, created_at, updated_at FROM feature_requests ORDER BY created_at DESC, id DESC LIMIT ? OFFSET ?`, lim, off)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/store/sqlite_test.go
+++ b/pkg/store/sqlite_test.go
@@ -139,7 +139,8 @@ func TestUserCRUD(t *testing.T) {
 		createTestUser(t, s, "gh-list-1", "u1")
 		createTestUser(t, s, "gh-list-2", "u2")
 
-		users, err := s.ListUsers()
+		// #6595: ListUsers now requires limit/offset; 0 means store default.
+		users, err := s.ListUsers(0, 0)
 		require.NoError(t, err)
 		require.Len(t, users, 2)
 	})
@@ -247,7 +248,8 @@ func TestDashboardCRUD(t *testing.T) {
 			}))
 		}
 
-		dashboards, err := s.GetUserDashboards(u.ID)
+		// #6596: GetUserDashboards now requires limit/offset; 0 means default.
+		dashboards, err := s.GetUserDashboards(u.ID, 0, 0)
 		require.NoError(t, err)
 		require.Len(t, dashboards, 3)
 	})

--- a/pkg/store/store.go
+++ b/pkg/store/store.go
@@ -53,7 +53,10 @@ type Store interface {
 	CreateUser(user *models.User) error
 	UpdateUser(user *models.User) error
 	UpdateLastLogin(userID uuid.UUID) error
-	ListUsers() ([]models.User, error)
+	// ListUsers returns a page of users ordered newest first.
+	// #6595: limit/offset are required to prevent unbounded reads.
+	// Pass 0 for limit to use the store default.
+	ListUsers(limit, offset int) ([]models.User, error)
 	DeleteUser(id uuid.UUID) error
 	UpdateUserRole(userID uuid.UUID, role string) error
 	CountUsersByRole() (admins, editors, viewers int, err error)
@@ -65,7 +68,9 @@ type Store interface {
 
 	// Dashboards
 	GetDashboard(id uuid.UUID) (*models.Dashboard, error)
-	GetUserDashboards(userID uuid.UUID) ([]models.Dashboard, error)
+	// GetUserDashboards returns a page of a user's dashboards.
+	// #6596: limit/offset are required. Pass 0 for limit to use the default.
+	GetUserDashboards(userID uuid.UUID, limit, offset int) ([]models.Dashboard, error)
 	GetDefaultDashboard(userID uuid.UUID) (*models.Dashboard, error)
 	CreateDashboard(dashboard *models.Dashboard) error
 	UpdateDashboard(dashboard *models.Dashboard) error
@@ -86,7 +91,9 @@ type Store interface {
 
 	// Pending Swaps
 	GetPendingSwap(id uuid.UUID) (*models.PendingSwap, error)
-	GetUserPendingSwaps(userID uuid.UUID) ([]models.PendingSwap, error)
+	// GetUserPendingSwaps returns a page of a user's pending swaps.
+	// #6597: limit/offset are required. Pass 0 for limit to use the default.
+	GetUserPendingSwaps(userID uuid.UUID, limit, offset int) ([]models.PendingSwap, error)
 	// GetDueSwaps returns pending swaps whose swap_at time has arrived.
 	// #6598: limit/offset are required to prevent unbounded scans when the
 	// swap backlog grows large (e.g. scheduler outage). Pass 0 for limit to

--- a/pkg/test/mock_store.go
+++ b/pkg/test/mock_store.go
@@ -48,7 +48,7 @@ func (m *MockStore) UpdateLastLogin(userID uuid.UUID) error {
 
 // Implement other methods as needed or with empty mocks
 
-func (m *MockStore) ListUsers() ([]models.User, error)                  { return nil, nil }
+func (m *MockStore) ListUsers(limit, offset int) ([]models.User, error) { return nil, nil }
 func (m *MockStore) DeleteUser(id uuid.UUID) error                      { return nil }
 func (m *MockStore) UpdateUserRole(userID uuid.UUID, role string) error { return nil }
 func (m *MockStore) CountUsersByRole() (int, int, int, error)           { return 0, 0, 0, nil }
@@ -60,7 +60,9 @@ func (m *MockStore) GetOnboardingResponses(userID uuid.UUID) ([]models.Onboardin
 func (m *MockStore) SetUserOnboarded(userID uuid.UUID) error { return nil }
 
 func (m *MockStore) GetDashboard(id uuid.UUID) (*models.Dashboard, error)            { return nil, nil }
-func (m *MockStore) GetUserDashboards(userID uuid.UUID) ([]models.Dashboard, error)  { return nil, nil }
+func (m *MockStore) GetUserDashboards(userID uuid.UUID, limit, offset int) ([]models.Dashboard, error) {
+	return nil, nil
+}
 func (m *MockStore) GetDefaultDashboard(userID uuid.UUID) (*models.Dashboard, error) { return nil, nil }
 func (m *MockStore) CreateDashboard(dashboard *models.Dashboard) error               { return nil }
 func (m *MockStore) UpdateDashboard(dashboard *models.Dashboard) error               { return nil }
@@ -96,7 +98,7 @@ func (m *MockStore) GetUserCardHistory(userID uuid.UUID, limit int) ([]models.Ca
 }
 
 func (m *MockStore) GetPendingSwap(id uuid.UUID) (*models.PendingSwap, error) { return nil, nil }
-func (m *MockStore) GetUserPendingSwaps(userID uuid.UUID) ([]models.PendingSwap, error) {
+func (m *MockStore) GetUserPendingSwaps(userID uuid.UUID, limit, offset int) ([]models.PendingSwap, error) {
 	return nil, nil
 }
 func (m *MockStore) GetDueSwaps(limit, offset int) ([]models.PendingSwap, error) {


### PR DESCRIPTION
## Summary

Two bundled fixes against `pkg/store/sqlite.go` + `pkg/api/handlers/feedback.go` (plus handler/mock wiring).

### Missing LIMIT clauses — same pattern as PR #6619

- **#6595** `ListUsers` — now takes `(limit, offset)`; default 500, clamped to `maxSQLLimit` (1000).
- **#6596** `GetUserDashboards` — same.
- **#6597** `GetUserPendingSwaps` — same.

Store interface, SQLite impl, `MockStore`, the `rbacTestStore` override, and both sqlite test call sites are updated in lockstep. Handlers (`rbac.ListConsoleUsers`, `dashboard.ListDashboards`, `swap.ListPendingSwaps`) wire `?limit=&offset=` through the existing `parsePageParams` helper, matching the feedback list endpoints.

### PR #6619 Copilot followups (#6621)

- **`feedback.go` parsePageParams docstring** out of sync with behavior. Rewritten to spell out the four branches (absent → 0 default, malformed → 400, oversized → 400, offset malformed → 400).
- **`feedbackMaxClientLimit` (2000) > `maxSQLLimit` (1000)** meant a client requesting `limit=1500` was silently truncated to 1000 with no signal. Lowered the client ceiling to 1000 and documented the alignment in a comment. Requests above the store ceiling now fail fast with a clear 400 instead of being silently clamped.
- **Non-deterministic `ORDER BY` with OFFSET paging** in `GetDueSwaps`, `GetRecentEvents`, `GetUserFeatureRequests`, `GetAllFeatureRequests`. Added stable `id ASC`/`id DESC` tie-breakers to all four (and to the three newly paginated queries above) so rows with identical `swap_at`/`created_at` paginate deterministically.
- **Stale comment** on `GetAllFeatureRequests` claimed it returned the full table. Updated to describe the paging contract.

## Verification

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./pkg/store/ ./pkg/api/handlers/ -race -timeout 180s`
- [x] `helm lint deploy/helm/kubestellar-console`

## Test plan

- [ ] CI build + lint + preview pass
- [ ] Spot-check `/api/dashboards`, `/api/swaps/pending`, `/api/admin/users` honor `?limit=` / `?offset=`
- [ ] Spot-check invalid `?limit=abc` → 400, `?limit=5000` → 400

Fixes #6595
Fixes #6596
Fixes #6597
Fixes #6621