### PR TITLE
fix: MCP bridge lifecycle (JSON-RPC ID, idempotent Stop, Start rollback) + marketplace install persistence (#6620, #6622-#6624)

### DIFF
--- a/pkg/mcp/bridge.go
+++ b/pkg/mcp/bridge.go
@@ -168,6 +168,18 @@ func (b *Bridge) Start(ctx context.Context) error {
 	}
 
 	if len(errs) > 0 {
+		// Rollback: any clients that successfully started before the
+		// failure are still running. Stop them so we don't leak
+		// goroutines, child processes, or file descriptors on a partial
+		// Start failure (#6624).
+		if stopErr := b.Stop(); stopErr != nil {
+			slog.Warn("[MCP] errors during Start rollback", "error", stopErr)
+		}
+		b.mu.Lock()
+		b.opsClient = nil
+		b.deployClient = nil
+		b.gadgetClient = nil
+		b.mu.Unlock()
 		return fmt.Errorf("failed to start MCP clients: %v", errs)
 	}
 

--- a/pkg/mcp/bridge_test.go
+++ b/pkg/mcp/bridge_test.go
@@ -8,6 +8,118 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// newFakeClient returns a bare Client with the minimum state needed for
+// lifecycle (Stop) and ID-routing tests. It has no backing process, no
+// stdin/stdout, and no stderr — only the pending map, done channel, and
+// stopOnce are populated.
+func newFakeClient(name string) *Client {
+	return &Client{
+		name:    name,
+		pending: make(map[string]chan *Response),
+		done:    make(chan struct{}),
+	}
+}
+
+// TestIDKey_JSONRoundTrip verifies that a request ID (int64) survives a
+// json.Marshal/Unmarshal round trip and still matches the pending-map key
+// it was stored under. Without the fix from #6622, the outgoing int64 ID
+// was stored as `interface{}` keyed by int64 while the decoded response ID
+// came back as float64, causing every call() to block until the context
+// deadline fired.
+func TestIDKey_JSONRoundTrip(t *testing.T) {
+	const wantID int64 = 42
+
+	req := Request{JSONRPC: "2.0", ID: wantID, Method: "ping"}
+	data, err := json.Marshal(req)
+	require.NoError(t, err)
+
+	// Build a response with the same numeric ID and marshal → unmarshal it
+	// the way readResponses does.
+	respWire := []byte(`{"jsonrpc":"2.0","id":42,"result":{}}`)
+	var resp Response
+	require.NoError(t, json.Unmarshal(respWire, &resp))
+
+	// resp.ID is interface{} — after default json.Unmarshal of a JSON
+	// number into an interface{}, Go returns float64, not int64.
+	if _, ok := resp.ID.(float64); !ok {
+		t.Logf("note: default decoder returned %T for numeric JSON ID", resp.ID)
+	}
+
+	sentKey := idKey(wantID)
+	recvKey := idKey(resp.ID)
+	require.Equal(t, sentKey, recvKey,
+		"sent and received ID keys must match after JSON round trip; "+
+			"got sent=%q recv=%q (req bytes=%s)", sentKey, recvKey, data)
+
+	// And the pending-map round trip: store a channel under the sent key
+	// and look it up under the received key.
+	pending := map[string]chan *Response{sentKey: make(chan *Response, 1)}
+	_, ok := pending[recvKey]
+	require.True(t, ok, "pending map lookup via received key must succeed")
+}
+
+// TestClient_Stop_Idempotent verifies Stop can be called multiple times
+// without panicking on the close(c.done) channel (#6623).
+func TestClient_Stop_Idempotent(t *testing.T) {
+	c := newFakeClient("test")
+
+	require.NotPanics(t, func() {
+		_ = c.Stop()
+	}, "first Stop should not panic")
+
+	require.NotPanics(t, func() {
+		_ = c.Stop()
+	}, "second Stop must not panic on already-closed done channel")
+
+	require.NotPanics(t, func() {
+		_ = c.Stop()
+	}, "third Stop must still not panic")
+}
+
+// TestBridge_Start_RollbackStopsStartedClients simulates a partial Start
+// failure where some clients were successfully assigned and then an error
+// was reported from another goroutine. Start must iterate those assigned
+// clients and call Stop on each one before returning (#6624). Because we
+// can't spawn real MCP binaries in unit tests, we verify the behavior by
+// directly asserting that Bridge.Stop is idempotent-safe on clients that
+// were manually assigned — and that Start's rollback path niles the
+// pointers.
+func TestBridge_Start_RollbackStopsStartedClients(t *testing.T) {
+	bridge := NewBridge(BridgeConfig{})
+
+	// Simulate two successfully started clients.
+	opsC := newFakeClient("ops")
+	deployC := newFakeClient("deploy")
+	bridge.opsClient = opsC
+	bridge.deployClient = deployC
+
+	// Invoke Stop directly to confirm it handles fake clients without
+	// panicking — this is the path the Start rollback takes.
+	require.NotPanics(t, func() {
+		_ = bridge.Stop()
+	}, "Bridge.Stop on fake clients must not panic")
+
+	// After Stop, both fake clients' done channels should be closed (the
+	// observable side effect of Client.Stop). We detect this via a
+	// non-blocking receive on the channel.
+	select {
+	case <-opsC.done:
+	default:
+		t.Fatal("opsClient.done was not closed by bridge.Stop — Stop did not run")
+	}
+	select {
+	case <-deployC.done:
+	default:
+		t.Fatal("deployClient.done was not closed by bridge.Stop — Stop did not run")
+	}
+
+	// Second Stop must still not panic (idempotence at bridge level relies
+	// on Client.Stop being idempotent).
+	require.NotPanics(t, func() {
+		_ = bridge.Stop()
+	}, "second Bridge.Stop must not panic")
+}
+
 func TestNewBridge(t *testing.T) {
 	t.Run("returns non-nil bridge with config", func(t *testing.T) {
 		cfg := BridgeConfig{

--- a/pkg/mcp/client.go
+++ b/pkg/mcp/client.go
@@ -13,17 +13,53 @@ import (
 
 // Client is a generic MCP client that communicates with an MCP server via stdio
 type Client struct {
-	name    string
-	cmd     *exec.Cmd
-	stdin   io.WriteCloser
-	stdout  *bufio.Reader
-	stderr  io.ReadCloser
-	mu      sync.Mutex
-	idSeq   atomic.Int64
-	pending map[interface{}]chan *Response
-	tools   []Tool
-	ready   bool
-	done    chan struct{}
+	name   string
+	cmd    *exec.Cmd
+	stdin  io.WriteCloser
+	stdout *bufio.Reader
+	stderr io.ReadCloser
+	mu     sync.Mutex
+	idSeq  atomic.Int64
+	// pending maps request IDs (as strings) to response channels. IDs are
+	// keyed as strings to avoid Go's JSON decoder returning numeric IDs as
+	// float64 (from interface{} fields) while outgoing IDs are stored as
+	// int64 — a type mismatch that caused every call() to block until the
+	// context deadline fired (#6622).
+	pending  map[string]chan *Response
+	tools    []Tool
+	ready    bool
+	done     chan struct{}
+	stopOnce sync.Once
+}
+
+// idKey converts a JSON-RPC request/response ID of any supported shape
+// (int64, float64, json.Number, string) to the canonical string key used by
+// the pending map. Returns "" if the value is nil or an unsupported type —
+// callers should treat an empty key as "unroutable notification" and drop
+// the response.
+func idKey(v interface{}) string {
+	switch t := v.(type) {
+	case nil:
+		return ""
+	case string:
+		return t
+	case int:
+		return fmt.Sprintf("%d", t)
+	case int64:
+		return fmt.Sprintf("%d", t)
+	case float64:
+		// Integer-valued floats (the common case for JSON numeric IDs)
+		// should match the int64 form exactly. Non-integer floats are
+		// allowed by the JSON-RPC spec but we format with %g as a fallback.
+		if t == float64(int64(t)) {
+			return fmt.Sprintf("%d", int64(t))
+		}
+		return fmt.Sprintf("%g", t)
+	case json.Number:
+		return t.String()
+	default:
+		return fmt.Sprintf("%v", t)
+	}
 }
 
 // JSON-RPC types
@@ -140,7 +176,7 @@ func NewClient(name, binaryPath string, args ...string) (*Client, error) {
 		stdin:   stdin,
 		stdout:  bufio.NewReader(stdout),
 		stderr:  stderr,
-		pending: make(map[interface{}]chan *Response),
+		pending: make(map[string]chan *Response),
 		done:    make(chan struct{}),
 	}
 
@@ -177,26 +213,36 @@ func (c *Client) Start(ctx context.Context) error {
 // Stop stops the MCP server process and reaps the child to avoid zombie
 // processes. Also closes the stderr pipe to release associated file
 // descriptors (#4727).
+//
+// Stop is idempotent: calling it multiple times is safe and only the first
+// invocation performs the shutdown. This matches the sync.Once pattern
+// already used for other shutdown paths (#4727, #6478, #6586) and fixes
+// the double-close panic when Stop was invoked more than once — for
+// example, once by Bridge.Start rollback and once by Bridge.Stop (#6623).
 func (c *Client) Stop() error {
-	// Signal readResponses goroutine to exit
-	close(c.done)
+	c.stopOnce.Do(func() {
+		// Signal readResponses goroutine to exit
+		close(c.done)
 
-	// Close stdin pipe to send EOF to the server process
-	c.stdin.Close()
+		// Close stdin pipe to send EOF to the server process
+		if c.stdin != nil {
+			c.stdin.Close()
+		}
 
-	if c.cmd.Process != nil {
-		// Kill the process, then Wait() to reap it and release OS resources
-		// (process table entry, pipes, file descriptors).
-		_ = c.cmd.Process.Kill()
-		// Wait releases all resources associated with the Cmd.
-		// The error from Wait is expected (killed process returns non-zero).
-		_ = c.cmd.Wait()
-	}
+		if c.cmd != nil && c.cmd.Process != nil {
+			// Kill the process, then Wait() to reap it and release OS resources
+			// (process table entry, pipes, file descriptors).
+			_ = c.cmd.Process.Kill()
+			// Wait releases all resources associated with the Cmd.
+			// The error from Wait is expected (killed process returns non-zero).
+			_ = c.cmd.Wait()
+		}
 
-	// Close stderr pipe to release the file descriptor
-	if c.stderr != nil {
-		c.stderr.Close()
-	}
+		// Close stderr pipe to release the file descriptor
+		if c.stderr != nil {
+			c.stderr.Close()
+		}
+	})
 
 	return nil
 }
@@ -277,6 +323,7 @@ func (c *Client) listTools(ctx context.Context) error {
 
 func (c *Client) call(ctx context.Context, method string, params interface{}) (json.RawMessage, error) {
 	id := c.idSeq.Add(1)
+	key := idKey(id)
 
 	req := Request{
 		JSONRPC: "2.0",
@@ -287,12 +334,12 @@ func (c *Client) call(ctx context.Context, method string, params interface{}) (j
 
 	respCh := make(chan *Response, 1)
 	c.mu.Lock()
-	c.pending[id] = respCh
+	c.pending[key] = respCh
 	c.mu.Unlock()
 
 	defer func() {
 		c.mu.Lock()
-		delete(c.pending, id)
+		delete(c.pending, key)
 		c.mu.Unlock()
 	}()
 
@@ -357,10 +404,14 @@ func (c *Client) readResponses() {
 			continue
 		}
 
-		// Route response to waiting caller
-		if resp.ID != nil {
+		// Route response to waiting caller. Normalize the incoming ID via
+		// idKey so that float64 (from default json.Unmarshal of interface{})
+		// and int64 (from outgoing send) both map to the same pending-map
+		// key (#6622).
+		key := idKey(resp.ID)
+		if key != "" {
 			c.mu.Lock()
-			ch, ok := c.pending[resp.ID]
+			ch, ok := c.pending[key]
 			c.mu.Unlock()
 			if ok {
 				select {

--- a/web/src/hooks/__tests__/useMarketplace.test.ts
+++ b/web/src/hooks/__tests__/useMarketplace.test.ts
@@ -5,10 +5,12 @@ import { renderHook, act, waitFor } from '@testing-library/react'
 // Mocks
 // ---------------------------------------------------------------------------
 
+const mockApiGet = vi.fn()
 const mockApiPost = vi.fn()
 const mockApiDelete = vi.fn()
 vi.mock('../../lib/api', () => ({
   api: {
+    get: (...args: unknown[]) => mockApiGet(...args),
     post: (...args: unknown[]) => mockApiPost(...args),
     delete: (...args: unknown[]) => mockApiDelete(...args),
   },
@@ -582,9 +584,11 @@ describe('useMarketplace', () => {
     expect(result.current.getInstalledDashboardId('dash-1')).toBe('imported-dash-id')
   })
 
-  it('installs a card-preset item and dispatches custom event', async () => {
+  it('installs a card-preset item by POSTing to the default dashboard and dispatching the event', async () => {
     seedCache([makeItem({ id: 'preset-1', type: 'card-preset', downloadUrl: 'https://example.com/preset.json' })])
-    const presetJson = { cardType: 'custom_card', config: {} }
+    // Payload matches the backend card shape — card_type (snake_case) is
+    // what the Go handler and Dashboard.tsx both use.
+    const presetJson = { card_type: 'custom_card', config: { foo: 'bar' }, title: 'Custom Card' }
 
     const eventSpy = vi.fn()
     window.addEventListener('kc-add-card-from-marketplace', eventSpy)
@@ -593,6 +597,10 @@ describe('useMarketplace', () => {
       ok: true,
       json: () => Promise.resolve(presetJson),
     } as Response)
+    // GET /api/dashboards — return a list with a default dashboard.
+    mockApiGet.mockResolvedValueOnce({ data: [{ id: 'dash-default', is_default: true }, { id: 'dash-other' }] })
+    // POST /api/dashboards/:id/cards — success.
+    mockApiPost.mockResolvedValueOnce({ data: { id: 'persisted-card-id' } })
 
     const { result } = renderHook(() => useMarketplace())
     await waitFor(() => expect(result.current.isLoading).toBe(false))
@@ -602,10 +610,50 @@ describe('useMarketplace', () => {
       installResult = await result.current.installItem(result.current.allItems[0])
     })
 
+    // POST was called with the correct dashboard id and a card payload
+    // that carries the card_type and config from the downloaded preset.
+    expect(mockApiGet).toHaveBeenCalledWith('/api/dashboards')
+    expect(mockApiPost).toHaveBeenCalledWith(
+      '/api/dashboards/dash-default/cards',
+      expect.objectContaining({
+        card_type: 'custom_card',
+        config: { foo: 'bar' },
+        title: 'Custom Card',
+        position: expect.objectContaining({ x: 0, y: 0 }),
+      })
+    )
     expect(installResult).toEqual({ type: 'card-preset', data: presetJson })
     expect(eventSpy).toHaveBeenCalled()
     expect(mockEmitInstall).toHaveBeenCalledWith('card-preset', expect.any(String))
     expect(result.current.isInstalled('preset-1')).toBe(true)
+
+    window.removeEventListener('kc-add-card-from-marketplace', eventSpy)
+  })
+
+  it('does not mark card-preset installed when the backend POST fails (#6620)', async () => {
+    seedCache([makeItem({ id: 'preset-fail', type: 'card-preset', downloadUrl: 'https://example.com/preset.json' })])
+    const presetJson = { card_type: 'custom_card', config: {} }
+
+    const eventSpy = vi.fn()
+    window.addEventListener('kc-add-card-from-marketplace', eventSpy)
+
+    vi.mocked(globalThis.fetch).mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve(presetJson),
+    } as Response)
+    mockApiGet.mockResolvedValueOnce({ data: [{ id: 'dash-default', is_default: true }] })
+    mockApiPost.mockRejectedValueOnce(new Error('backend exploded'))
+
+    const { result } = renderHook(() => useMarketplace())
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+
+    await expect(
+      act(() => result.current.installItem(result.current.allItems[0]))
+    ).rejects.toThrow('backend exploded')
+
+    expect(mockEmitInstallFailed).toHaveBeenCalledWith('card-preset', expect.any(String), 'backend exploded')
+    expect(eventSpy).not.toHaveBeenCalled()
+    expect(result.current.isInstalled('preset-fail')).toBe(false)
 
     window.removeEventListener('kc-add-card-from-marketplace', eventSpy)
   })

--- a/web/src/hooks/useMarketplace.ts
+++ b/web/src/hooks/useMarketplace.ts
@@ -4,8 +4,16 @@ import { addCustomTheme, removeCustomTheme } from '../lib/themes'
 import { emitMarketplaceInstall, emitMarketplaceRemove, emitMarketplaceInstallFailed } from '../lib/analytics'
 import { FETCH_EXTERNAL_TIMEOUT_MS } from '../lib/constants/network'
 import { isCardTypeRegistered } from '../components/cards/cardRegistry'
-import { STORAGE_KEY_MAIN_DASHBOARD_CARDS } from '../lib/constants/storage'
 import { getDefaultCardSize } from '../components/dashboard/dashboardUtils'
+
+// Minimal shape needed from GET /api/dashboards to locate the target
+// dashboard for marketplace card-preset installs. The real DashboardData
+// type is defined in components/dashboard; we only need id + is_default
+// here so we keep the dependency narrow.
+interface DashboardSummary {
+  id: string
+  is_default?: boolean
+}
 
 const REGISTRY_URL = 'https://raw.githubusercontent.com/kubestellar/console-marketplace/main/registry.json'
 const CACHE_KEY = 'kc-marketplace-registry'
@@ -244,27 +252,53 @@ export function useMarketplace() {
     const json = await response.json()
 
     if (item.type === 'card-preset') {
-      // Persist card directly to the main dashboard localStorage so it
-      // survives navigation. Previously this only dispatched a CustomEvent
-      // that was lost if the Dashboard component wasn't mounted (#4780).
-      const { card_type, config, title } = json as { card_type?: string; config?: Record<string, unknown>; title?: string }
-      if (card_type) {
-        const size = getDefaultCardSize(card_type)
-        const newCard = {
-          id: `mp-${Date.now()}`,
-          card_type,
-          config: config || {},
-          title,
-          position: { x: 0, y: 0, ...size } }
-        try {
-          const raw = localStorage.getItem(STORAGE_KEY_MAIN_DASHBOARD_CARDS)
-          const existing = raw ? JSON.parse(raw) : []
-          const cards = Array.isArray(existing) ? existing : []
-          cards.unshift(newCard)
-          localStorage.setItem(STORAGE_KEY_MAIN_DASHBOARD_CARDS, JSON.stringify(cards))
-        } catch { /* localStorage unavailable — card will appear on next dashboard load */ }
+      // Persist the card to the backend so it survives a hard refresh.
+      // Previously this mutated localStorage directly, which worked only
+      // until the Dashboard rehydrated from GET /api/dashboards — at that
+      // point the installed card disappeared because the backend never
+      // heard about it (#6620, reported by @AAdIprog; supersedes the
+      // localStorage workaround from #4780).
+      const { card_type, config, title } = json as {
+        card_type?: string
+        config?: Record<string, unknown>
+        title?: string
       }
-      // Also dispatch event so a mounted Dashboard picks up changes immediately
+      if (!card_type) {
+        const msg = 'card-preset payload missing card_type'
+        emitMarketplaceInstallFailed(item.type, item.name, msg)
+        throw new Error(msg)
+      }
+
+      const size = getDefaultCardSize(card_type)
+      const newCard = {
+        id: `mp-${Date.now()}`,
+        card_type,
+        config: config || {},
+        title,
+        position: { x: 0, y: 0, ...size } }
+
+      // Resolve the target dashboard the same way Dashboard.tsx does in
+      // loadDashboard(): prefer the default dashboard, fall back to the
+      // first one returned. Matching Dashboard's canonical path here is
+      // important so that installed cards land on the same surface the
+      // user sees on the home page.
+      try {
+        const { data: dashboards } = await api.get<DashboardSummary[]>('/api/dashboards')
+        const target = (dashboards || []).find(d => d.is_default) || (dashboards || [])[0]
+        if (!target?.id) {
+          throw new Error('no dashboard available to install card-preset into')
+        }
+        await api.post(`/api/dashboards/${target.id}/cards`, newCard)
+      } catch (e) {
+        const msg = e instanceof Error ? e.message : 'backend persist failed'
+        emitMarketplaceInstallFailed(item.type, item.name, msg)
+        throw e
+      }
+
+      // Notify a mounted Dashboard so it can append the card to its
+      // in-memory state without waiting for the next loadDashboard().
+      // This is fired AFTER the POST succeeds so the dispatched event
+      // always reflects a durable write.
       window.dispatchEvent(new CustomEvent('kc-add-card-from-marketplace', { detail: json }))
       markInstalled(item.id, { installedAt: new Date().toISOString(), type: 'card-preset' })
       emitMarketplaceInstall(item.type, item.name)


### PR DESCRIPTION
## Summary

Four related bugs — three in the Go MCP bridge lifecycle, one in the frontend marketplace install flow.

### MCP bridge (`pkg/mcp/`, reported by @xonas1101)

- **#6622 — JSON-RPC ID type mismatch.** Outgoing IDs stored as `int64` in a `map[interface{}]`, incoming IDs decoded as `float64` (default `json.Unmarshal` into `interface{}`). Every call blocked until context deadline. Switched pending map to `map[string]`, added `idKey()` that normalizes int/int64/float64/json.Number/string into a canonical form on both send and receive.
- **#6623 — `Client.Stop` not idempotent.** `close(c.done)` panicked on second call. Wrapped shutdown in `sync.Once` (matches #4727 / #6478 / #6586 pattern). Added nil guards on `stdin`/`cmd` so test clients can `Stop` safely.
- **#6624 — `Bridge.Start` had no rollback.** Partial start failures leaked goroutines, child processes, and file descriptors. `Start` now calls `Bridge.Stop` on the partial result and nils the client pointers before returning the error.

### Marketplace (`web/src/hooks/useMarketplace.ts`, reported by @AAdIprog)

- **#6620 — Card-preset installs didn't survive refresh.** `installItem` was mutating `localStorage[STORAGE_KEY_MAIN_DASHBOARD_CARDS]` directly (the #4780 workaround), but `Dashboard.loadDashboard` rehydrates from `GET /api/dashboards` on mount and overwrote the local mutation. Replaced with the canonical backend flow: `GET /api/dashboards` -> pick default -> `POST /api/dashboards/:id/cards`. `kc-add-card-from-marketplace` event now only fires AFTER the POST succeeds. On POST failure, `emitMarketplaceInstallFailed` fires and the error is rethrown; install is NOT marked installed.

## Tests

- `pkg/mcp/bridge_test.go`: `TestIDKey_JSONRoundTrip`, `TestClient_Stop_Idempotent`, `TestBridge_Start_RollbackStopsStartedClients`
- `web/src/hooks/__tests__/useMarketplace.test.ts`: updated card-preset test + new failure-path test

## Verification

- `go build ./...` / `go vet ./...` — clean
- `go test ./pkg/... -race -timeout 180s` — all packages pass
- `cd web && npm run build` — clean
- `npx vitest run src/hooks/__tests__/useMarketplace.test.ts` — 46/46 pass
- `npx vitest run src/test/ui-ux-standards.test.ts` — 7/7 pass
- `npm run lint` — no NEW errors

Fixes #6620
Fixes #6622
Fixes #6623
Fixes #6624