### PR TITLE
fix(frontend): mission-control cleanup leaks, deploy poll visibility, StatefulSet config (#6629-#6642)

### DIFF
--- a/web/src/components/mission-control/LaunchSequence.tsx
+++ b/web/src/components/mission-control/LaunchSequence.tsx
@@ -97,6 +97,17 @@ export function LaunchSequence({
   const [isStarted, setIsStarted] = useState(false)
   const progressRef = useRef<PhaseProgress[]>(state.launchProgress)
   const startedMissions = useRef(new Set<string>())
+  // #6632 — Track mount state so effects scheduled before unmount (phase
+  // initialization, mission monitor, auto-start) can't call onUpdateProgress
+  // or onComplete on a closed dialog. Without this, closing Mission Control
+  // mid-launch fired a cascade of stale progress updates on a dead tree.
+  const isMountedRef = useRef(true)
+  useEffect(() => {
+    isMountedRef.current = true
+    return () => {
+      isMountedRef.current = false
+    }
+  }, [])
 
   // #6408 — If `state.phases` is empty but the user has assignments, rebuild
   // a single deploy phase from those assignments instead of calling
@@ -131,6 +142,8 @@ export function LaunchSequence({
         status: 'pending' as const })) }))
     progressRef.current = initial
     startedMissions.current = new Set<string>()
+    // #6632 — guard against firing onUpdateProgress on a closed dialog
+    if (!isMountedRef.current) return
     setIsStarted(false)
     onUpdateProgress(initial)
   }, [phaseSignature])
@@ -138,6 +151,8 @@ export function LaunchSequence({
   const updateProgress = (updater: (prev: PhaseProgress[]) => PhaseProgress[]) => {
       const next = updater(progressRef.current)
       progressRef.current = next
+      // #6632 — Never call onUpdateProgress after the dialog has been closed.
+      if (!isMountedRef.current) return
       onUpdateProgress(next)
     }
 
@@ -262,6 +277,8 @@ export function LaunchSequence({
         ...phase,
         status: derivePhaseStatus(phase) }))
       progressRef.current = updated
+      // #6632 — Don't fire onUpdateProgress / onComplete on a closed dialog.
+      if (!isMountedRef.current) return
       onUpdateProgress(updated)
 
       // #6408 — Never call onComplete on an empty progress list. Without
@@ -307,15 +324,22 @@ export function LaunchSequence({
     const isYolo = state.deployMode === 'yolo'
 
     if (isYolo) {
-      // Launch everything at once
+      // Launch everything at once. #6634 — collect the promises and await
+      // them with Promise.allSettled so the yolo path doesn't swallow
+      // rejections or leave unhandled-rejection warnings in the console.
+      // launchProject has its own try/catch around the failing branch, but
+      // any future refactor that throws before that catch would otherwise
+      // go unnoticed.
+      const pending: Promise<void>[] = []
       for (const phase of effectivePhases) {
         for (const projectName of (phase.projectNames || [])) {
           if (!startedMissions.current.has(projectName)) {
             startedMissions.current.add(projectName)
-            launchProject(projectName, phase.phase)
+            pending.push(launchProject(projectName, phase.phase))
           }
         }
       }
+      await Promise.allSettled(pending)
     } else {
       // Phased: launch phase N, wait for completion, then phase N+1 (#5506)
       for (const phase of effectivePhases) {
@@ -454,11 +478,17 @@ export function LaunchSequence({
                     className="h-6 text-xs"
                     icon={<RotateCcw className="w-3 h-3" />}
                     onClick={() => {
+                      // #6634 — Track the retry promises so any rejection
+                      // is observed rather than dropped. Promise.allSettled
+                      // keeps the click handler from becoming `async` in a
+                      // JSX attribute (which confuses React type checks).
+                      const retries: Promise<void>[] = []
                       phase.projects.forEach((p) => {
                         if (p.status === 'failed') {
-                          launchProject(p.name, phase.phase)
+                          retries.push(launchProject(p.name, phase.phase))
                         }
                       })
+                      void Promise.allSettled(retries)
                     }}
                   >
                     Retry Failed

--- a/web/src/config/cards/statefulset-status.ts
+++ b/web/src/config/cards/statefulset-status.ts
@@ -102,7 +102,12 @@ export const statefulSetStatusConfig: UnifiedCardConfig = {
   },
 
   // Metadata
-  isDemoData: true,
+  // #6642 — Was `true`, which forced the card to render as demo data even
+  // when real StatefulSets were available. Match deployment-status /
+  // pod-status (which use `false`) so the card shows live data when the
+  // hook returns it and only falls back to demo mode when the hook's own
+  // isDemoData signal flips true.
+  isDemoData: false,
   isLive: true,
 }
 

--- a/web/src/hooks/useDeployMissions.ts
+++ b/web/src/hooks/useDeployMissions.ts
@@ -151,6 +151,42 @@ const MIN_ACTIVE_MS = 10_000
  * the very error message the user needs.
  */
 const LOG_RECOVERY_EXTRA_POLLS = 3
+/**
+ * #6640 — Max number of concurrent cluster-status HTTP requests across ALL
+ * active missions. Before this cap, a user with N missions × M target
+ * clusters would fire N*M fetches every POLL_INTERVAL_MS, which can DoS
+ * their own backend (especially when agent+REST fallbacks double up). We
+ * keep a generous ceiling — most users will never hit it — but it bounds
+ * the worst case.
+ */
+const DEPLOY_POLL_MAX_CONCURRENCY = 6
+
+/**
+ * Run async tasks with bounded concurrency. Returns results in the same
+ * order as `tasks`. Used by the deploy poller to cap in-flight HTTP
+ * requests across all missions × clusters. Kept inline to avoid adding a
+ * p-limit dependency for one caller.
+ */
+async function runWithConcurrency<T>(
+  tasks: ReadonlyArray<() => Promise<T>>,
+  limit: number,
+): Promise<T[]> {
+  const results: T[] = new Array(tasks.length)
+  let nextIndex = 0
+  const workerCount = Math.max(1, Math.min(limit, tasks.length))
+  const workers: Promise<void>[] = []
+  for (let w = 0; w < workerCount; w++) {
+    workers.push((async () => {
+      while (true) {
+        const i = nextIndex++
+        if (i >= tasks.length) return
+        results[i] = await tasks[i]()
+      }
+    })())
+  }
+  await Promise.all(workers)
+  return results
+}
 
 function loadMissions(): DeployMission[] {
   try {
@@ -256,8 +292,16 @@ export function useDeployMissions() {
       const current = missionsRef.current
       if (current.length === 0) return
 
-      const updated = await Promise.all(
-        current.map(async (mission) => {
+      // #6640 — Serialize missions and cap per-mission cluster concurrency
+      // via `runWithConcurrency`. Previously this was
+      // `Promise.all(current.map(... Promise.all(clusters.map(...))))`, which
+      // fires N_missions × N_clusters fetches simultaneously every poll
+      // cycle and can DoS the user's own backend under load. Missions are
+      // processed sequentially; clusters within a mission are capped at
+      // DEPLOY_POLL_MAX_CONCURRENCY in-flight at a time.
+      const updated: DeployMission[] = []
+      for (const mission of current) {
+        updated.push(await (async () => {
           const isCompleted = isTerminalStatus(mission.status)
           // #6415 — Track whether this poll cycle is "within the log-recovery
           // grace window". When true, we allow the normal poll body to run
@@ -284,8 +328,10 @@ export function useDeployMissions() {
 
           const pollCount = (mission.pollCount ?? 0) + 1
 
-          const statuses = await Promise.all(
-            mission.targetClusters.map(async (cluster): Promise<DeployClusterStatus> => {
+          // #6640 — Bounded concurrency over clusters. Each cluster task is
+          // wrapped in a thunk so runWithConcurrency can schedule them.
+          const clusterTasks: Array<() => Promise<DeployClusterStatus>> =
+            mission.targetClusters.map((cluster) => async (): Promise<DeployClusterStatus> => {
               // Track consecutive failures from previous poll cycle
               const prevStatus = mission.clusterStatuses.find(cs => cs.cluster === cluster)
               const prevFailures = prevStatus?.consecutiveFailures ?? 0
@@ -501,7 +547,7 @@ export function useDeployMissions() {
                 return networkPending()
               }
             })
-          )
+          const statuses = await runWithConcurrency(clusterTasks, DEPLOY_POLL_MAX_CONCURRENCY)
 
           // Determine overall mission status
           const allRunning = statuses.every(s => s.status === 'running')
@@ -564,8 +610,8 @@ export function useDeployMissions() {
             logRecoveryPolls: inRecoveryWindow
               ? (mission.logRecoveryPolls ?? 0) + 1
               : mission.logRecoveryPolls }
-        })
-      )
+        })())
+      }
 
       // Sort: active missions first (newest first), completed missions below (newest first).
       // #6411 — Add a deterministic tiebreaker on mission id. Without it,
@@ -584,11 +630,48 @@ export function useDeployMissions() {
       setMissions([...active, ...completed])
     }
 
-    // Poll on interval (first poll after 1s delay, then every POLL_INTERVAL_MS)
-    const initialTimeout = setTimeout(() => {
-      poll()
+    // Delay before the first poll fires after mount. Kept small so the UI
+    // updates quickly, but non-zero so the subscribe effect above has a
+    // chance to populate `missionsRef` before the first fetch.
+    const INITIAL_POLL_DELAY_MS = 1000
+    // Poll on interval (first poll after INITIAL_POLL_DELAY_MS, then every
+    // POLL_INTERVAL_MS) — but only while the tab is visible (#6641).
+    const startPolling = () => {
+      if (pollRef.current) return
       pollRef.current = setInterval(poll, POLL_INTERVAL_MS)
-    }, 1000)
+    }
+    const stopPolling = () => {
+      if (pollRef.current) {
+        clearInterval(pollRef.current)
+        pollRef.current = undefined
+      }
+    }
+    const initialTimeout = setTimeout(() => {
+      if (typeof document !== 'undefined' && document.visibilityState === 'hidden') {
+        // Tab started hidden — wait for visibilitychange to start polling.
+        return
+      }
+      poll()
+      startPolling()
+    }, INITIAL_POLL_DELAY_MS)
+
+    // #6641 — Page Visibility integration. When the tab is hidden, tear
+    // down the interval so background timers don't queue up (some browsers
+    // throttle but still accumulate ticks, and resuming the tab then
+    // dumps a burst of deferred poll() calls on the backend). On resume,
+    // fire one immediate poll to catch up, then restart the interval.
+    const onVisibilityChange = () => {
+      if (typeof document === 'undefined') return
+      if (document.visibilityState === 'hidden') {
+        stopPolling()
+      } else {
+        poll()
+        startPolling()
+      }
+    }
+    if (typeof document !== 'undefined') {
+      document.addEventListener('visibilitychange', onVisibilityChange)
+    }
 
     // issue 6427 — Snapshot the grace-repoll map reference inside the
     // effect body so the cleanup closure uses a captured handle rather
@@ -596,6 +679,9 @@ export function useDeployMissions() {
     const graceRepolls = graceRepollsRef.current
     return () => {
       clearTimeout(initialTimeout)
+      if (typeof document !== 'undefined') {
+        document.removeEventListener('visibilitychange', onVisibilityChange)
+      }
       if (pollRef.current) clearInterval(pollRef.current)
       // Cancel any outstanding grace-window re-polls so they don't fire
       // on an unmounted hook and call setMissions on a dead tree.

--- a/web/src/hooks/useMissions.tsx
+++ b/web/src/hooks/useMissions.tsx
@@ -535,6 +535,13 @@ export function MissionProvider({ children }: { children: ReactNode }) {
   // Delay between WebSocket send retries in milliseconds
   const WS_SEND_RETRY_DELAY_MS = 1000
 
+  // #6629 — Track in-flight wsSend retry timers so they can be cleared on
+  // unmount. Without this, a provider unmount while a retry was still
+  // pending would leak the setTimeout handle and could call
+  // `wsRef.current.send` on a dying socket (or worse, call the user-supplied
+  // `onFailure` after the component tree had already gone away).
+  const wsSendRetryTimers = useRef<Set<ReturnType<typeof setTimeout>>>(new Set())
+
   /**
    * Send a message over the WebSocket with retry logic.
    * Makes one immediate attempt, then retries up to WS_SEND_MAX_RETRIES
@@ -550,7 +557,12 @@ export function MissionProvider({ children }: { children: ReactNode }) {
       }
       if (retries < WS_SEND_MAX_RETRIES) {
         retries++
-        setTimeout(trySend, WS_SEND_RETRY_DELAY_MS)
+        // #6629 — ref-tracked so unmount cleanup can cancel pending retries.
+        const handle = setTimeout(() => {
+          wsSendRetryTimers.current.delete(handle)
+          trySend()
+        }, WS_SEND_RETRY_DELAY_MS)
+        wsSendRetryTimers.current.add(handle)
       } else {
         console.error('[Missions] WebSocket send failed after retries — socket not open')
         onFailure?.()
@@ -2532,11 +2544,18 @@ Install the console locally with the KubeStellar Console agent to use AI mission
     const lastStreamTimestampRef = lastStreamTimestamp.current
     const streamSplitCounterRef = streamSplitCounter.current
     const waitingInputTimeoutsRef = waitingInputTimeouts.current
+    const wsSendRetryTimersRef = wsSendRetryTimers.current
     return () => {
       if (wsReconnectTimer.current) {
         clearTimeout(wsReconnectTimer.current)
         wsReconnectTimer.current = null
       }
+      // #6629 — Cancel any in-flight wsSend retry timers so they don't
+      // fire on an unmounted provider or touch a dying socket.
+      for (const handle of wsSendRetryTimersRef) {
+        clearTimeout(handle)
+      }
+      wsSendRetryTimersRef.clear()
       // Clear all cancel acknowledgment timeouts
       for (const timeout of cancelTimeoutsRef.values()) {
         clearTimeout(timeout)


### PR DESCRIPTION
## Summary

Frontend hygiene pass across `useMissions`, `LaunchSequence`, `useDeployMissions`, and the StatefulSet card config.

### Mission Control (useMissions.tsx + LaunchSequence.tsx)

- **#6629** — `wsSend` retry `setTimeout` is now tracked in a ref-held `Set` and cleared in the existing provider-unmount cleanup. Previously an unmount while a retry was pending leaked the handle and could call `send` on a dying socket.
- **#6632** — `LaunchSequence` gains an `isMountedRef` so `phaseSignature` init, the mission-monitor effect, and `updateProgress` never fire `onUpdateProgress`/`onComplete` on a closed dialog.
- **#6634** — `launchProject` promises in yolo mode and the Retry Failed click handler are now collected into `Promise.allSettled` so rejections aren't swallowed as unhandled.

### Deploy polling (useDeployMissions.ts)

- **#6640** — Replaced nested `Promise.all(missions × clusters)` fan-out with a sequential mission loop plus a hand-rolled `runWithConcurrency` helper capped at `DEPLOY_POLL_MAX_CONCURRENCY = 6` in-flight cluster fetches. Prevents self-DoS on users with many active missions.
- **#6641** — Page Visibility integration. When the tab is hidden the poll interval is torn down; on resume we run one immediate `poll()` then restart the interval. An initially-hidden tab won't start polling until it becomes visible. Listener is removed on unmount.

### StatefulSet card (#6642)

- `statefulSetStatusConfig.isDemoData` was `true`, forcing the card into demo mode even when the hook returned real StatefulSets. Flipped to `false` to match `deployment-status` / `pod-status`; the hook's own `isDemoData` signal still drives the Demo badge + yellow outline when live data is unavailable. The existing `cluster-select` filter with `storageKey` already matches the scoping pattern used by deployment/daemonset cards, so no new `defaultCluster` field was needed.

## Not-a-bug / already fixed

- **#6630, #6631, #6637** — Reported as leaked `cancelTimeouts`, `waitingInputTimeouts`, and `wsReconnectTimer`. The existing provider-unmount cleanup `useEffect` (around `useMissions.tsx:2527-2575`) already iterates these maps and calls `clearTimeout`. No code changes required.

## Test plan

- [x] `cd web && npm run build` — passes (post-build safety checks green)
- [x] `npx vitest run src/hooks src/components/mission-control src/test/ui-ux-standards.test.ts` — all asserting tests pass
- [x] `npm run lint` — no new errors in changed files

Fixes #6629
Fixes #6632
Fixes #6634
Fixes #6640
Fixes #6641
Fixes #6642

Refs #6630 #6631 #6637 (already fixed in existing cleanup effect)
