### PR TITLE
fix(backend): notification service hardening + RBAC payload validation (#6627, #6633, #6635, #6636, #6638, #6639)

### DIFF
--- a/pkg/api/handlers/namespaces.go
+++ b/pkg/api/handlers/namespaces.go
@@ -71,8 +71,13 @@ func (h *NamespaceHandler) CreateNamespace(c *fiber.Ctx) error {
 		return fiber.NewError(fiber.StatusBadRequest, "Invalid request body")
 	}
 
-	if req.Cluster == "" || req.Name == "" {
-		return fiber.NewError(fiber.StatusBadRequest, "Cluster and name are required")
+	// #6627: explicit field-level validation. Previously empty/oversized
+	// names could reach the apiserver and return an opaque 500.
+	if err := validateClusterName("cluster", req.Cluster); err != nil {
+		return fiber.NewError(fiber.StatusBadRequest, err.Error())
+	}
+	if err := validateDNSLabel("name", req.Name); err != nil {
+		return fiber.NewError(fiber.StatusBadRequest, err.Error())
 	}
 
 	ctx, cancel := context.WithTimeout(c.Context(), nsWriteTimeout)
@@ -208,18 +213,51 @@ func (h *NamespaceHandler) GrantNamespaceAccess(c *fiber.Ctx) error {
 		return fiber.NewError(fiber.StatusBadRequest, "Namespace name required")
 	}
 
+	// Validate the namespace path parameter as a DNS label before doing any
+	// more work. #6627.
+	if err := validateDNSLabel("namespace", namespace); err != nil {
+		return fiber.NewError(fiber.StatusBadRequest, err.Error())
+	}
+
 	var req models.GrantNamespaceAccessRequest
 	if err := c.BodyParser(&req); err != nil {
 		return fiber.NewError(fiber.StatusBadRequest, "Invalid request body")
 	}
 
-	if req.Cluster == "" || req.SubjectKind == "" || req.SubjectName == "" {
-		return fiber.NewError(fiber.StatusBadRequest, "Cluster, subjectKind, and subjectName are required")
+	// #6627: explicit field-level validation replaces the previous
+	// non-empty-only check.
+	if err := validateClusterName("cluster", req.Cluster); err != nil {
+		return fiber.NewError(fiber.StatusBadRequest, err.Error())
+	}
+	if err := validateEnum("subjectKind", req.SubjectKind, []string{"User", "Group", "ServiceAccount"}); err != nil {
+		return fiber.NewError(fiber.StatusBadRequest, err.Error())
+	}
+	if req.SubjectKind == "ServiceAccount" {
+		if err := validateDNSLabel("subjectName", req.SubjectName); err != nil {
+			return fiber.NewError(fiber.StatusBadRequest, err.Error())
+		}
+		if req.SubjectNS != "" {
+			if err := validateDNSLabel("subjectNamespace", req.SubjectNS); err != nil {
+				return fiber.NewError(fiber.StatusBadRequest, err.Error())
+			}
+		}
+	} else {
+		if req.SubjectName == "" {
+			return fiber.NewError(fiber.StatusBadRequest, "subjectName is required")
+		}
+		if len(req.SubjectName) > maxK8sDNSSubdomainLen {
+			return fiber.NewError(fiber.StatusBadRequest, "subjectName too long")
+		}
 	}
 
 	// Default to admin role if not specified
 	if req.Role == "" {
 		req.Role = "admin"
+	}
+	// Role may be a shortcut ("admin"/"edit"/"view") or a custom role name.
+	// Validate as a role name either way.
+	if err := validateRoleName("role", req.Role); err != nil {
+		return fiber.NewError(fiber.StatusBadRequest, err.Error())
 	}
 
 	ctx, cancel := context.WithTimeout(c.Context(), nsWriteTimeout)

--- a/pkg/api/handlers/rbac.go
+++ b/pkg/api/handlers/rbac.go
@@ -381,8 +381,17 @@ func (h *RBACHandler) CreateServiceAccount(c *fiber.Ctx) error {
 		return fiber.NewError(fiber.StatusBadRequest, "Invalid request body")
 	}
 
-	if req.Name == "" || req.Namespace == "" || req.Cluster == "" {
-		return fiber.NewError(fiber.StatusBadRequest, "Name, namespace, and cluster are required")
+	// #6627: explicit field-level validation. Previously only non-empty
+	// checks were performed; a malformed name would be passed to the
+	// apiserver and return an opaque 500.
+	if err := validateDNSLabel("name", req.Name); err != nil {
+		return fiber.NewError(fiber.StatusBadRequest, err.Error())
+	}
+	if err := validateDNSLabel("namespace", req.Namespace); err != nil {
+		return fiber.NewError(fiber.StatusBadRequest, err.Error())
+	}
+	if err := validateClusterName("cluster", req.Cluster); err != nil {
+		return fiber.NewError(fiber.StatusBadRequest, err.Error())
 	}
 
 	ctx, cancel := context.WithTimeout(c.Context(), rbacWriteTimeout)
@@ -414,8 +423,50 @@ func (h *RBACHandler) CreateRoleBinding(c *fiber.Ctx) error {
 		return fiber.NewError(fiber.StatusBadRequest, "Invalid request body")
 	}
 
-	if req.Name == "" || req.Cluster == "" || req.RoleName == "" || req.SubjectName == "" {
-		return fiber.NewError(fiber.StatusBadRequest, "Missing required fields")
+	// #6627: explicit field-level validation. Previously only non-empty
+	// checks existed; empty subjectKind, out-of-range lengths, and invalid
+	// DNS labels were all silently accepted.
+	if err := validateDNSLabel("name", req.Name); err != nil {
+		return fiber.NewError(fiber.StatusBadRequest, err.Error())
+	}
+	if err := validateClusterName("cluster", req.Cluster); err != nil {
+		return fiber.NewError(fiber.StatusBadRequest, err.Error())
+	}
+	if err := validateRoleName("roleName", req.RoleName); err != nil {
+		return fiber.NewError(fiber.StatusBadRequest, err.Error())
+	}
+	// Namespace is empty for ClusterRoleBindings — only validate if present.
+	if req.Namespace != "" {
+		if err := validateDNSLabel("namespace", req.Namespace); err != nil {
+			return fiber.NewError(fiber.StatusBadRequest, err.Error())
+		}
+	}
+	// roleKind, subjectKind must be one of the known Kubernetes kinds.
+	if err := validateEnum("roleKind", req.RoleKind, []string{"Role", "ClusterRole"}); err != nil {
+		return fiber.NewError(fiber.StatusBadRequest, err.Error())
+	}
+	if err := validateEnum("subjectKind", string(req.SubjectKind), []string{"User", "Group", "ServiceAccount"}); err != nil {
+		return fiber.NewError(fiber.StatusBadRequest, err.Error())
+	}
+	// subjectName has different rules for SAs vs users/groups. For SA we
+	// enforce DNS label; for users/groups we only require non-empty +
+	// reasonable length since they can contain emails, colons, etc.
+	if req.SubjectKind == models.K8sSubjectServiceAccount {
+		if err := validateDNSLabel("subjectName", req.SubjectName); err != nil {
+			return fiber.NewError(fiber.StatusBadRequest, err.Error())
+		}
+		if req.SubjectNS != "" {
+			if err := validateDNSLabel("subjectNamespace", req.SubjectNS); err != nil {
+				return fiber.NewError(fiber.StatusBadRequest, err.Error())
+			}
+		}
+	} else {
+		if req.SubjectName == "" {
+			return fiber.NewError(fiber.StatusBadRequest, "subjectName is required")
+		}
+		if len(req.SubjectName) > maxK8sDNSSubdomainLen {
+			return fiber.NewError(fiber.StatusBadRequest, "subjectName too long")
+		}
 	}
 
 	ctx, cancel := context.WithTimeout(c.Context(), rbacWriteTimeout)

--- a/pkg/api/handlers/validate_helpers.go
+++ b/pkg/api/handlers/validate_helpers.go
@@ -1,0 +1,124 @@
+// Package handlers — input validation helpers shared by RBAC and namespace
+// handlers. Added for #6627: the RBAC/namespace request structs previously had
+// no field-level validation, so empty or malformed payloads silently relied on
+// downstream Kubernetes API checks. These helpers centralise the rules so every
+// handler rejects bad input at the HTTP boundary with a specific 400 error.
+package handlers
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+// Kubernetes name length limits. Per RFC 1123:
+//   - a DNS label (used for most resources like Pods, ServiceAccounts,
+//     Namespaces, RoleBindings) is at most 63 characters.
+//   - a DNS subdomain (used for things like object names in some APIs)
+//     is at most 253 characters.
+// We pick the stricter 63-char limit for Kubernetes object names since every
+// struct validated here creates a namespaced or cluster-scoped RBAC object.
+const (
+	// maxK8sDNSLabelLen is the maximum length of an RFC 1123 DNS label.
+	maxK8sDNSLabelLen = 63
+	// maxK8sDNSSubdomainLen is the maximum length of an RFC 1123 DNS subdomain.
+	maxK8sDNSSubdomainLen = 253
+	// maxRoleNameLen bounds the length of a Kubernetes Role/ClusterRole
+	// reference. The apiserver allows up to a DNS subdomain; we mirror that.
+	maxRoleNameLen = maxK8sDNSSubdomainLen
+)
+
+// dnsLabelRegex matches a valid RFC 1123 DNS label: lowercase alphanumerics
+// and dashes, starting and ending with an alphanumeric. This is the pattern
+// used by Kubernetes for most object names (validated server-side as well,
+// but we reject client-side to return specific 400s).
+var dnsLabelRegex = regexp.MustCompile(`^[a-z0-9]([-a-z0-9]*[a-z0-9])?$`)
+
+// dnsSubdomainRegex matches an RFC 1123 DNS subdomain — a series of DNS
+// labels joined by dots. Used for role/clusterrole names which may contain
+// a group prefix (e.g. "system:aggregate-to-admin").
+// Note: Kubernetes role names can also contain ':' for system roles; we
+// accept that too because existing clusters rely on it.
+var dnsSubdomainRegex = regexp.MustCompile(`^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$`)
+
+// roleNameRegex accepts a DNS subdomain OR a system-prefixed role name
+// like "system:admin" or "cluster-admin". Built by hand rather than
+// reusing dnsSubdomainRegex so we can allow a single ':' separator.
+var roleNameRegex = regexp.MustCompile(`^[a-z0-9]([-a-z0-9]*[a-z0-9])?(:[a-z0-9]([-a-z0-9]*[a-z0-9])?)?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$`)
+
+// validateDNSLabel checks that s is a non-empty RFC 1123 DNS label suitable
+// for a Kubernetes object name (ServiceAccount, Namespace, RoleBinding, etc).
+// Returns a user-facing error that names the field.
+func validateDNSLabel(field, s string) error {
+	if s == "" {
+		return fmt.Errorf("%s is required", field)
+	}
+	if len(s) > maxK8sDNSLabelLen {
+		return fmt.Errorf("%s must be at most %d characters", field, maxK8sDNSLabelLen)
+	}
+	if !dnsLabelRegex.MatchString(s) {
+		return fmt.Errorf("%s must be a valid DNS label (lowercase alphanumerics and '-', starting and ending with alphanumeric)", field)
+	}
+	return nil
+}
+
+// validateDNSSubdomain checks that s is a non-empty RFC 1123 DNS subdomain.
+// Used for fields that may legitimately contain dots (not currently used,
+// kept for future extensibility when we validate e.g. hostnames).
+func validateDNSSubdomain(field, s string) error {
+	if s == "" {
+		return fmt.Errorf("%s is required", field)
+	}
+	if len(s) > maxK8sDNSSubdomainLen {
+		return fmt.Errorf("%s must be at most %d characters", field, maxK8sDNSSubdomainLen)
+	}
+	if !dnsSubdomainRegex.MatchString(s) {
+		return fmt.Errorf("%s must be a valid DNS subdomain", field)
+	}
+	return nil
+}
+
+// validateClusterName is a looser validator for cluster IDs. Cluster names
+// in this codebase come from kubeconfig contexts and may contain dots,
+// dashes, slashes, and digits. We only enforce non-empty and length.
+func validateClusterName(field, s string) error {
+	if s == "" {
+		return fmt.Errorf("%s is required", field)
+	}
+	if len(s) > maxK8sDNSSubdomainLen {
+		return fmt.Errorf("%s must be at most %d characters", field, maxK8sDNSSubdomainLen)
+	}
+	if strings.ContainsAny(s, "\x00\n\r\t") {
+		return fmt.Errorf("%s contains invalid characters", field)
+	}
+	return nil
+}
+
+// validateRoleName accepts a Kubernetes Role/ClusterRole name. These may
+// contain a system: prefix and optional dots.
+func validateRoleName(field, s string) error {
+	if s == "" {
+		return fmt.Errorf("%s is required", field)
+	}
+	if len(s) > maxRoleNameLen {
+		return fmt.Errorf("%s must be at most %d characters", field, maxRoleNameLen)
+	}
+	if !roleNameRegex.MatchString(s) {
+		return fmt.Errorf("%s must be a valid Kubernetes role name", field)
+	}
+	return nil
+}
+
+// validateEnum checks that s is one of allowed (case-sensitive). Used for
+// fields like subjectKind, roleKind, and the namespace-access role shortcuts.
+func validateEnum(field, s string, allowed []string) error {
+	if s == "" {
+		return fmt.Errorf("%s is required", field)
+	}
+	for _, a := range allowed {
+		if s == a {
+			return nil
+		}
+	}
+	return fmt.Errorf("%s must be one of %s", field, strings.Join(allowed, ", "))
+}

--- a/pkg/api/handlers/validate_helpers_test.go
+++ b/pkg/api/handlers/validate_helpers_test.go
@@ -1,0 +1,113 @@
+package handlers
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestValidateDNSLabel exercises the common table of inputs covering empty,
+// too-long, invalid-char, leading/trailing dash, and valid cases. Each case
+// is independent so failures are easy to attribute. #6627.
+func TestValidateDNSLabel(t *testing.T) {
+	cases := []struct {
+		name    string
+		value   string
+		wantErr bool
+		errHint string
+	}{
+		{"valid simple", "foo", false, ""},
+		{"valid with dash", "foo-bar", false, ""},
+		{"valid with digits", "foo-123", false, ""},
+		{"empty", "", true, "required"},
+		{"uppercase", "Foo", true, "DNS label"},
+		{"underscore", "foo_bar", true, "DNS label"},
+		{"leading dash", "-foo", true, "DNS label"},
+		{"trailing dash", "foo-", true, "DNS label"},
+		{"space", "foo bar", true, "DNS label"},
+		{"too long", strings.Repeat("a", maxK8sDNSLabelLen+1), true, "at most"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validateDNSLabel("field", tc.value)
+			if tc.wantErr && err == nil {
+				t.Fatalf("expected error, got nil")
+			}
+			if !tc.wantErr && err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if tc.wantErr && !strings.Contains(err.Error(), tc.errHint) {
+				t.Fatalf("error %q does not contain hint %q", err.Error(), tc.errHint)
+			}
+		})
+	}
+}
+
+// TestValidateClusterName ensures we accept typical kubeconfig context
+// names and reject obviously hostile content (control characters).
+func TestValidateClusterName(t *testing.T) {
+	cases := []struct {
+		name    string
+		value   string
+		wantErr bool
+	}{
+		{"simple", "prod", false},
+		{"dotted", "prod.us-east-1.eks.amazonaws.com", false},
+		{"with slash", "arn:aws:eks:us-east-1:1234/cluster", false},
+		{"empty", "", true},
+		{"newline", "prod\nhacked", true},
+		{"tab", "prod\thacked", true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validateClusterName("cluster", tc.value)
+			if tc.wantErr && err == nil {
+				t.Fatalf("expected error")
+			}
+			if !tc.wantErr && err != nil {
+				t.Fatalf("unexpected: %v", err)
+			}
+		})
+	}
+}
+
+// TestValidateRoleName covers the system: prefix case plus the standard
+// DNS-subdomain shape.
+func TestValidateRoleName(t *testing.T) {
+	cases := []struct {
+		name    string
+		value   string
+		wantErr bool
+	}{
+		{"cluster-admin", "cluster-admin", false},
+		{"view", "view", false},
+		{"system prefixed", "system:admin", false},
+		{"dotted", "rbac.example.com", false},
+		{"empty", "", true},
+		{"uppercase", "Admin", true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validateRoleName("role", tc.value)
+			if tc.wantErr && err == nil {
+				t.Fatalf("expected error")
+			}
+			if !tc.wantErr && err != nil {
+				t.Fatalf("unexpected: %v", err)
+			}
+		})
+	}
+}
+
+// TestValidateEnum covers accept/reject and the empty-string required case.
+func TestValidateEnum(t *testing.T) {
+	allowed := []string{"User", "Group", "ServiceAccount"}
+	if err := validateEnum("subjectKind", "User", allowed); err != nil {
+		t.Fatalf("unexpected: %v", err)
+	}
+	if err := validateEnum("subjectKind", "pod", allowed); err == nil {
+		t.Fatalf("expected error for disallowed value")
+	}
+	if err := validateEnum("subjectKind", "", allowed); err == nil {
+		t.Fatalf("expected error for empty value")
+	}
+}

--- a/pkg/notifications/fixes_test.go
+++ b/pkg/notifications/fixes_test.go
@@ -1,0 +1,268 @@
+package notifications
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// ---------------------------------------------------------------------------
+// #6633 — webhook notifier
+// ---------------------------------------------------------------------------
+
+// TestWebhookNotifier_Send asserts that the notifier POSTs a JSON body
+// containing the alert payload and accepts any 2xx response.
+func TestWebhookNotifier_Send(t *testing.T) {
+	var gotBody []byte
+	var gotContentType string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotContentType = r.Header.Get("Content-Type")
+		gotBody, _ = io.ReadAll(r.Body)
+		w.WriteHeader(http.StatusAccepted) // 202 — ensures we accept non-200 2xx
+	}))
+	defer server.Close()
+
+	n, err := NewWebhookNotifier(server.URL)
+	require.NoError(t, err)
+
+	err = n.Send(Alert{
+		ID:       "alert-1",
+		RuleID:   "rule-1",
+		RuleName: "High CPU",
+		Severity: SeverityCritical,
+		Status:   "firing",
+		Message:  "CPU above 90%",
+		Cluster:  "prod-east",
+		FiredAt:  time.Now(),
+	})
+	require.NoError(t, err)
+	require.Equal(t, "application/json", gotContentType)
+
+	var body map[string]interface{}
+	require.NoError(t, json.Unmarshal(gotBody, &body))
+	require.Equal(t, "High CPU", body["alert"])
+	require.Equal(t, "critical", body["severity"])
+	require.Equal(t, "prod-east", body["cluster"])
+}
+
+// TestWebhookNotifier_NonSuccessStatus verifies we surface non-2xx as error.
+func TestWebhookNotifier_NonSuccessStatus(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer server.Close()
+
+	n, err := NewWebhookNotifier(server.URL)
+	require.NoError(t, err)
+
+	err = n.Send(Alert{RuleName: "X", Severity: SeverityInfo, FiredAt: time.Now()})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "status 500")
+}
+
+// TestWebhookNotifier_InvalidURL covers the fail-fast path in the ctor.
+func TestWebhookNotifier_InvalidURL(t *testing.T) {
+	cases := []string{"", "not-a-url", "ftp://example.com", "http://"}
+	for _, u := range cases {
+		_, err := NewWebhookNotifier(u)
+		require.Error(t, err, "expected error for URL %q", u)
+	}
+}
+
+// TestWebhookNotifier_HostAllowlist verifies the KC_WEBHOOK_ALLOWED_HOSTS
+// env var is enforced. Empty env = allow all; non-empty = strict allowlist.
+func TestWebhookNotifier_HostAllowlist(t *testing.T) {
+	const envKey = "KC_WEBHOOK_ALLOWED_HOSTS"
+	orig := os.Getenv(envKey)
+	t.Cleanup(func() { os.Setenv(envKey, orig) })
+
+	os.Setenv(envKey, "alerts.example.com")
+	_, err := NewWebhookNotifier("https://evil.example.org/hook")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "allowlist")
+
+	_, err = NewWebhookNotifier("https://alerts.example.com/hook")
+	require.NoError(t, err)
+}
+
+// TestService_WebhookChannel wires through SendAlertToChannels.
+func TestService_WebhookChannel(t *testing.T) {
+	var hit int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hit++
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	svc := NewService()
+	err := svc.SendAlertToChannels(Alert{RuleName: "r", FiredAt: time.Now()}, []NotificationChannel{
+		{
+			Type:    NotificationTypeWebhook,
+			Enabled: true,
+			Config:  map[string]interface{}{"webhookUrl": server.URL},
+		},
+	})
+	require.NoError(t, err)
+	require.Equal(t, 1, hit)
+}
+
+// ---------------------------------------------------------------------------
+// #6635 — concurrent access to notifiers map
+// ---------------------------------------------------------------------------
+
+// TestService_ConcurrentRegisterAndSend runs parallel Register/Send to ensure
+// the RWMutex prevents the concurrent-map-access panic. Runs best with -race.
+func TestService_ConcurrentRegisterAndSend(t *testing.T) {
+	svc := NewService()
+
+	// Seed with one valid notifier backed by a test HTTP server so Send
+	// has actual work to do without external network calls.
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+	svc.RegisterSlackNotifier("seed", server.URL, "#c")
+
+	const goroutineCount = 16   // parallel workers on each side
+	const iterations = 50       // ops per worker
+	var wg sync.WaitGroup
+	wg.Add(goroutineCount * 2)
+
+	for i := 0; i < goroutineCount; i++ {
+		i := i
+		go func() {
+			defer wg.Done()
+			for j := 0; j < iterations; j++ {
+				svc.RegisterSlackNotifier(
+					"worker"+string(rune('a'+i%26))+string(rune('a'+j%26)),
+					server.URL, "#c")
+			}
+		}()
+		go func() {
+			defer wg.Done()
+			for j := 0; j < iterations; j++ {
+				_ = svc.SendAlert(Alert{RuleName: "r", Severity: SeverityInfo, FiredAt: time.Now()})
+			}
+		}()
+	}
+	wg.Wait()
+}
+
+// ---------------------------------------------------------------------------
+// #6636 — SMTP port validation
+// ---------------------------------------------------------------------------
+
+// TestParseSMTPPortConfig covers missing, zero, negative, out-of-range, and
+// valid values. Uses table-driven style so failures pinpoint the bad input.
+func TestParseSMTPPortConfig(t *testing.T) {
+	cases := []struct {
+		name    string
+		cfg     map[string]interface{}
+		want    int
+		wantErr bool
+	}{
+		{"missing", map[string]interface{}{}, 0, true},
+		{"zero", map[string]interface{}{"emailSMTPPort": float64(0)}, 0, true},
+		{"negative", map[string]interface{}{"emailSMTPPort": float64(-1)}, 0, true},
+		{"too high", map[string]interface{}{"emailSMTPPort": float64(70000)}, 0, true},
+		{"wrong type", map[string]interface{}{"emailSMTPPort": "587"}, 0, true},
+		{"float 587", map[string]interface{}{"emailSMTPPort": float64(587)}, 587, false},
+		{"int 25", map[string]interface{}{"emailSMTPPort": 25}, 25, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := parseSMTPPortConfig(tc.cfg)
+			if tc.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, tc.want, got)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// #6638 — empty recipient filtering
+// ---------------------------------------------------------------------------
+
+// TestSplitAndCleanRecipients covers the specific regression: a trailing
+// comma in the recipient list must not produce an empty string in the
+// output slice.
+func TestSplitAndCleanRecipients(t *testing.T) {
+	cases := []struct {
+		in   string
+		want []string
+	}{
+		{"a@b.com", []string{"a@b.com"}},
+		{"a@b.com, c@d.com", []string{"a@b.com", "c@d.com"}},
+		{"a@b.com, ", []string{"a@b.com"}},
+		{" , a@b.com, , b@c.com ,", []string{"a@b.com", "b@c.com"}},
+		{"", []string{}},
+		{", , ,", []string{}},
+	}
+	for _, tc := range cases {
+		got := splitAndCleanRecipients(tc.in)
+		require.Equal(t, tc.want, got, "input=%q", tc.in)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// #6639 — OpsGenie close URL alias escaping
+// ---------------------------------------------------------------------------
+
+// TestOpsGenie_CloseAlert_EscapesAlias stands up a test server, points the
+// notifier's HTTP client at it, and asserts the path contains the escaped
+// alias. Rather than override the package-level opsgenieAlertsURL const we
+// intercept via a custom RoundTripper.
+func TestOpsGenie_CloseAlert_EscapesAlias(t *testing.T) {
+	var gotPath string
+	rt := roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		// EscapedPath() preserves the percent-encoding we put in the URL
+		// string (Path is the decoded form).
+		gotPath = req.URL.EscapedPath() + "?" + req.URL.RawQuery
+		return &http.Response{
+			StatusCode: http.StatusAccepted,
+			Body:       io.NopCloser(strings.NewReader("")),
+			Header:     make(http.Header),
+		}, nil
+	})
+	n := &OpsGenieNotifier{APIKey: "key", HTTPClient: &http.Client{Transport: rt}}
+
+	// Alias with reserved characters — '/' and space — that would break
+	// the URL path if concatenated unescaped.
+	err := n.closeAlert("rule/1::prod east")
+	require.NoError(t, err)
+	require.Contains(t, gotPath, "rule%2F1::prod%20east/close")
+
+	// Rejects obviously hostile content.
+	err = n.closeAlert("rule\n1")
+	require.Error(t, err)
+}
+
+// TestOpsGenie_CloseAlert_NoEscapeNeeded ensures simple aliases still work.
+func TestOpsGenie_CloseAlert_NoEscapeNeeded(t *testing.T) {
+	rt := roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(strings.NewReader("")),
+			Header:     make(http.Header),
+		}, nil
+	})
+	n := &OpsGenieNotifier{APIKey: "key", HTTPClient: &http.Client{Transport: rt}}
+	require.NoError(t, n.closeAlert("rule-1::prod"))
+}
+
+// roundTripFunc adapts a function to http.RoundTripper so tests can
+// intercept outbound requests without running a real HTTP server.
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(r *http.Request) (*http.Response, error) { return f(r) }

--- a/pkg/notifications/opsgenie.go
+++ b/pkg/notifications/opsgenie.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
+	"strings"
 	"time"
 )
 
@@ -121,7 +123,21 @@ func (o *OpsGenieNotifier) createAlert(alert Alert, alias string) error {
 }
 
 func (o *OpsGenieNotifier) closeAlert(alias string) error {
-	url := fmt.Sprintf("%s/%s/close?identifierType=alias", opsgenieAlertsURL, alias)
+	// #6639: the alias is concatenated from user-controlled fields (rule ID
+	// and cluster name) and may contain characters that are reserved in URL
+	// paths (spaces, '/', '?', '#'). PathEscape avoids targeting the wrong
+	// endpoint or producing a malformed request. Also reject obviously
+	// hostile content (newlines / null bytes) that would corrupt the
+	// outbound HTTP request.
+	if strings.ContainsAny(alias, "\x00\n\r") {
+		return fmt.Errorf("opsgenie alias contains invalid characters")
+	}
+	// url.PathEscape leaves '/' unencoded because the stdlib treats it as a
+	// path separator. For a single path segment that must NOT span into a
+	// new segment we also replace '/' ourselves — otherwise an alias like
+	// "rule/1::cluster" would corrupt the URL path.
+	escapedAlias := strings.ReplaceAll(url.PathEscape(alias), "/", "%2F")
+	closeURL := fmt.Sprintf("%s/%s/close?identifierType=alias", opsgenieAlertsURL, escapedAlias)
 
 	body := map[string]string{
 		"source": "KubeStellar Console",
@@ -132,7 +148,7 @@ func (o *OpsGenieNotifier) closeAlert(alias string) error {
 		return fmt.Errorf("failed to marshal opsgenie close: %w", err)
 	}
 
-	req, err := http.NewRequest("POST", url, bytes.NewBuffer(payload))
+	req, err := http.NewRequest("POST", closeURL, bytes.NewBuffer(payload))
 	if err != nil {
 		return fmt.Errorf("failed to create opsgenie close request: %w", err)
 	}

--- a/pkg/notifications/service.go
+++ b/pkg/notifications/service.go
@@ -4,10 +4,27 @@ import (
 	"fmt"
 	"log/slog"
 	"strings"
+	"sync"
 )
 
-// Service manages alert notifications
+// defaultSMTPPort is the submission port used when a configured port is
+// invalid. Set to the STARTTLS submission port (587) per RFC 6409.
+const defaultSMTPPort = 587
+
+// minSMTPPort / maxSMTPPort bound a valid TCP port number. Used to reject
+// SMTP port values that were parsed as 0 or out-of-range floats (#6636).
+const (
+	minSMTPPort = 1
+	maxSMTPPort = 65535
+)
+
+// Service manages alert notifications.
+//
+// #6635: all reads/writes of the notifiers map must be protected by mu.
+// Prior versions mutated and iterated the map without synchronisation,
+// which panicked under concurrent Register* / SendAlert* calls.
 type Service struct {
+	mu        sync.RWMutex
 	notifiers map[string]Notifier
 }
 
@@ -18,10 +35,29 @@ func NewService() *Service {
 	}
 }
 
+// register stores a notifier under id while holding the write lock.
+func (s *Service) register(id string, n Notifier) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.notifiers[id] = n
+}
+
+// snapshot returns a shallow copy of the notifiers map so callers can iterate
+// without holding the mutex (avoids holding the lock across network I/O).
+func (s *Service) snapshot() map[string]Notifier {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	out := make(map[string]Notifier, len(s.notifiers))
+	for k, v := range s.notifiers {
+		out[k] = v
+	}
+	return out
+}
+
 // RegisterSlackNotifier registers a Slack notifier
 func (s *Service) RegisterSlackNotifier(id, webhookURL, channel string) {
 	if webhookURL != "" {
-		s.notifiers[fmt.Sprintf("slack:%s", id)] = NewSlackNotifier(webhookURL, channel)
+		s.register(fmt.Sprintf("slack:%s", id), NewSlackNotifier(webhookURL, channel))
 		slog.Info("registered Slack notifier", "id", id)
 	}
 }
@@ -29,7 +65,7 @@ func (s *Service) RegisterSlackNotifier(id, webhookURL, channel string) {
 // RegisterPagerDutyNotifier registers a PagerDuty notifier
 func (s *Service) RegisterPagerDutyNotifier(id, routingKey string) {
 	if routingKey != "" {
-		s.notifiers[fmt.Sprintf("pagerduty:%s", id)] = NewPagerDutyNotifier(routingKey)
+		s.register(fmt.Sprintf("pagerduty:%s", id), NewPagerDutyNotifier(routingKey))
 		slog.Info("registered PagerDuty notifier", "id", id)
 	}
 }
@@ -37,7 +73,7 @@ func (s *Service) RegisterPagerDutyNotifier(id, routingKey string) {
 // RegisterOpsGenieNotifier registers an OpsGenie notifier
 func (s *Service) RegisterOpsGenieNotifier(id, apiKey string) {
 	if apiKey != "" {
-		s.notifiers[fmt.Sprintf("opsgenie:%s", id)] = NewOpsGenieNotifier(apiKey)
+		s.register(fmt.Sprintf("opsgenie:%s", id), NewOpsGenieNotifier(apiKey))
 		slog.Info("registered OpsGenie notifier", "id", id)
 	}
 }
@@ -45,24 +81,40 @@ func (s *Service) RegisterOpsGenieNotifier(id, apiKey string) {
 // RegisterEmailNotifier registers an email notifier
 func (s *Service) RegisterEmailNotifier(id, smtpHost string, smtpPort int, username, password, from, to string) {
 	if smtpHost != "" && from != "" && to != "" {
-		recipients := strings.Split(to, ",")
-		for i, r := range recipients {
-			recipients[i] = strings.TrimSpace(r)
+		recipients := splitAndCleanRecipients(to)
+		if len(recipients) == 0 {
+			slog.Warn("email notifier not registered: no valid recipients after trimming", "id", id)
+			return
 		}
-		s.notifiers[fmt.Sprintf("email:%s", id)] = NewEmailNotifier(smtpHost, smtpPort, username, password, from, recipients)
+		s.register(fmt.Sprintf("email:%s", id), NewEmailNotifier(smtpHost, smtpPort, username, password, from, recipients))
 		slog.Info("registered Email notifier", "id", id)
 	}
 }
 
+// RegisterWebhookNotifier registers a generic webhook notifier. #6633.
+func (s *Service) RegisterWebhookNotifier(id, webhookURL string) {
+	if webhookURL == "" {
+		return
+	}
+	n, err := NewWebhookNotifier(webhookURL)
+	if err != nil {
+		slog.Error("failed to register webhook notifier", "id", id, "error", err)
+		return
+	}
+	s.register(fmt.Sprintf("webhook:%s", id), n)
+	slog.Info("registered Webhook notifier", "id", id)
+}
+
 // SendAlert sends an alert to all configured notifiers
 func (s *Service) SendAlert(alert Alert) error {
-	if len(s.notifiers) == 0 {
+	notifiers := s.snapshot()
+	if len(notifiers) == 0 {
 		slog.Info("No notifiers configured, alert will not be sent externally")
 		return nil
 	}
 
 	var errors []string
-	for id, notifier := range s.notifiers {
+	for id, notifier := range notifiers {
 		if err := notifier.Send(alert); err != nil {
 			errMsg := fmt.Sprintf("failed to send notification via %s: %v", id, err)
 			slog.Error("failed to send notification", "notifier", id, "error", err)
@@ -77,6 +129,31 @@ func (s *Service) SendAlert(alert Alert) error {
 	}
 
 	return nil
+}
+
+// parseSMTPPortConfig extracts an SMTP port from a config map and validates
+// it is within [minSMTPPort, maxSMTPPort]. #6636: previously the value was
+// parsed as float64 and cast to int with no range check — 0 or missing
+// values produced a silently broken notifier. We now return an explicit
+// error so operators are told exactly what is wrong.
+func parseSMTPPortConfig(config map[string]interface{}) (int, error) {
+	raw, ok := config["emailSMTPPort"]
+	if !ok {
+		return 0, fmt.Errorf("emailSMTPPort is required (valid range %d-%d)", minSMTPPort, maxSMTPPort)
+	}
+	var port int
+	switch v := raw.(type) {
+	case float64:
+		port = int(v)
+	case int:
+		port = v
+	default:
+		return 0, fmt.Errorf("emailSMTPPort must be a number")
+	}
+	if port < minSMTPPort || port > maxSMTPPort {
+		return 0, fmt.Errorf("emailSMTPPort must be in %d-%d (got %d)", minSMTPPort, maxSMTPPort, port)
+	}
+	return port, nil
 }
 
 // SendAlertToChannels sends an alert to specific notification channels
@@ -104,17 +181,21 @@ func (s *Service) SendAlertToChannels(alert Alert, channels []NotificationChanne
 
 		case NotificationTypeEmail:
 			smtpHost, _ := channel.Config["emailSMTPHost"].(string)
-			smtpPortFloat, _ := channel.Config["emailSMTPPort"].(float64)
-			smtpPort := int(smtpPortFloat)
+			smtpPort, portErr := parseSMTPPortConfig(channel.Config)
+			if portErr != nil {
+				errors = append(errors, fmt.Sprintf("email channel %s: %v", channelID, portErr))
+				continue
+			}
 			username, _ := channel.Config["emailUsername"].(string)
 			password, _ := channel.Config["emailPassword"].(string)
 			from, _ := channel.Config["emailFrom"].(string)
 			to, _ := channel.Config["emailTo"].(string)
 
 			if smtpHost != "" && from != "" && to != "" {
-				recipients := strings.Split(to, ",")
-				for j, r := range recipients {
-					recipients[j] = strings.TrimSpace(r)
+				recipients := splitAndCleanRecipients(to)
+				if len(recipients) == 0 {
+					errors = append(errors, fmt.Sprintf("email channel %s: no valid recipients", channelID))
+					continue
 				}
 				notifier = NewEmailNotifier(smtpHost, smtpPort, username, password, from, recipients)
 			}
@@ -129,6 +210,18 @@ func (s *Service) SendAlertToChannels(alert Alert, channels []NotificationChanne
 			apiKey, _ := channel.Config["opsgenieApiKey"].(string)
 			if apiKey != "" {
 				notifier = NewOpsGenieNotifier(apiKey)
+			}
+
+		case NotificationTypeWebhook:
+			// #6633: webhook channel type was declared but not wired in.
+			webhookURL, _ := channel.Config["webhookUrl"].(string)
+			if webhookURL != "" {
+				n, err := NewWebhookNotifier(webhookURL)
+				if err != nil {
+					errors = append(errors, fmt.Sprintf("webhook channel %s: %v", channelID, err))
+					continue
+				}
+				notifier = n
 			}
 		}
 
@@ -165,8 +258,6 @@ func (s *Service) TestNotifier(notifierType string, config map[string]interface{
 
 	case NotificationTypeEmail:
 		smtpHost, _ := config["emailSMTPHost"].(string)
-		smtpPortFloat, _ := config["emailSMTPPort"].(float64)
-		smtpPort := int(smtpPortFloat)
 		username, _ := config["emailUsername"].(string)
 		password, _ := config["emailPassword"].(string)
 		from, _ := config["emailFrom"].(string)
@@ -175,10 +266,14 @@ func (s *Service) TestNotifier(notifierType string, config map[string]interface{
 		if smtpHost == "" || from == "" || to == "" {
 			return fmt.Errorf("SMTP host, from, and to are required")
 		}
+		smtpPort, err := parseSMTPPortConfig(config)
+		if err != nil {
+			return err
+		}
 
-		recipients := strings.Split(to, ",")
-		for i, r := range recipients {
-			recipients[i] = strings.TrimSpace(r)
+		recipients := splitAndCleanRecipients(to)
+		if len(recipients) == 0 {
+			return fmt.Errorf("no valid recipients after trimming")
 		}
 		notifier = NewEmailNotifier(smtpHost, smtpPort, username, password, from, recipients)
 
@@ -196,9 +291,37 @@ func (s *Service) TestNotifier(notifierType string, config map[string]interface{
 		}
 		notifier = NewOpsGenieNotifier(apiKey)
 
+	case NotificationTypeWebhook:
+		// #6633: webhook Test support.
+		webhookURL, _ := config["webhookUrl"].(string)
+		if webhookURL == "" {
+			return fmt.Errorf("webhook URL is required")
+		}
+		n, err := NewWebhookNotifier(webhookURL)
+		if err != nil {
+			return err
+		}
+		notifier = n
+
 	default:
 		return fmt.Errorf("unsupported notifier type: %s", notifierType)
 	}
 
 	return notifier.Test()
+}
+
+// splitAndCleanRecipients splits a comma-separated recipient list and drops
+// empty / whitespace-only entries. #6638: the previous implementation kept
+// empty strings in the slice which caused SMTP RCPT TO to fail on blank
+// addresses produced by inputs like "a@b.com, ".
+func splitAndCleanRecipients(raw string) []string {
+	parts := strings.Split(raw, ",")
+	out := make([]string, 0, len(parts))
+	for _, r := range parts {
+		r = strings.TrimSpace(r)
+		if r != "" {
+			out = append(out, r)
+		}
+	}
+	return out
 }

--- a/pkg/notifications/webhook.go
+++ b/pkg/notifications/webhook.go
@@ -1,0 +1,152 @@
+// Package notifications — webhook notifier (#6633).
+//
+// Implements a generic JSON webhook notifier for the NotificationTypeWebhook
+// channel type, which was previously declared in types.go but had no
+// corresponding implementation. POSTs a compact JSON payload with the alert
+// details to a configured URL.
+package notifications
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"strings"
+	"time"
+)
+
+const (
+	// webhookHTTPTimeout bounds the outbound HTTP call so a slow endpoint
+	// cannot block the alert pipeline.
+	webhookHTTPTimeout = 10 * time.Second
+	// webhookAllowedHostsEnv names the env var used for a comma-separated
+	// host allowlist. Empty (default) = no restriction (backwards compatible).
+	// Operators can set this to a small list like "alerts.example.com" to
+	// mitigate SSRF against internal endpoints (same pattern as #6416).
+	webhookAllowedHostsEnv = "KC_WEBHOOK_ALLOWED_HOSTS"
+)
+
+// WebhookNotifier POSTs a JSON alert payload to a configured URL.
+type WebhookNotifier struct {
+	URL        string
+	HTTPClient *http.Client
+}
+
+// webhookPayload is the JSON body sent on each alert.
+type webhookPayload struct {
+	Alert     string    `json:"alert"`
+	Severity  string    `json:"severity"`
+	Status    string    `json:"status"`
+	Cluster   string    `json:"cluster,omitempty"`
+	Namespace string    `json:"namespace,omitempty"`
+	Resource  string    `json:"resource,omitempty"`
+	Message   string    `json:"message,omitempty"`
+	Timestamp time.Time `json:"timestamp"`
+	RuleID    string    `json:"ruleId,omitempty"`
+	ID        string    `json:"id,omitempty"`
+}
+
+// NewWebhookNotifier validates the URL and returns a ready-to-use notifier.
+// Fails fast on malformed URLs and on hosts outside the (optional) allowlist.
+func NewWebhookNotifier(webhookURL string) (*WebhookNotifier, error) {
+	if webhookURL == "" {
+		return nil, fmt.Errorf("webhook URL is required")
+	}
+	u, err := url.Parse(webhookURL)
+	if err != nil {
+		return nil, fmt.Errorf("invalid webhook URL: %w", err)
+	}
+	if u.Scheme != "http" && u.Scheme != "https" {
+		return nil, fmt.Errorf("webhook URL must be http or https")
+	}
+	if u.Host == "" {
+		return nil, fmt.Errorf("webhook URL must have a host")
+	}
+	if err := checkWebhookHostAllowed(u.Hostname()); err != nil {
+		return nil, err
+	}
+	return &WebhookNotifier{
+		URL:        webhookURL,
+		HTTPClient: &http.Client{Timeout: webhookHTTPTimeout},
+	}, nil
+}
+
+// checkWebhookHostAllowed enforces the optional KC_WEBHOOK_ALLOWED_HOSTS
+// env allowlist. Empty env = allow all (default). This keeps the change
+// backwards compatible while giving operators a simple knob to block SSRF.
+func checkWebhookHostAllowed(host string) error {
+	raw := os.Getenv(webhookAllowedHostsEnv)
+	if raw == "" {
+		return nil
+	}
+	for _, allowed := range strings.Split(raw, ",") {
+		allowed = strings.TrimSpace(allowed)
+		if allowed == "" {
+			continue
+		}
+		if strings.EqualFold(allowed, host) {
+			return nil
+		}
+	}
+	return fmt.Errorf("webhook host %q not in %s allowlist", host, webhookAllowedHostsEnv)
+}
+
+// Send POSTs the alert as JSON to the configured webhook URL.
+func (w *WebhookNotifier) Send(alert Alert) error {
+	payload := webhookPayload{
+		Alert:     alert.RuleName,
+		Severity:  string(alert.Severity),
+		Status:    alert.Status,
+		Cluster:   alert.Cluster,
+		Namespace: alert.Namespace,
+		Resource:  alert.Resource,
+		Message:   alert.Message,
+		Timestamp: alert.FiredAt,
+		RuleID:    alert.RuleID,
+		ID:        alert.ID,
+	}
+
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return fmt.Errorf("failed to marshal webhook payload: %w", err)
+	}
+
+	req, err := http.NewRequest("POST", w.URL, bytes.NewBuffer(body))
+	if err != nil {
+		return fmt.Errorf("failed to create webhook request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("User-Agent", "KubeStellar-Console-Webhook/1.0")
+
+	resp, err := w.HTTPClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("failed to send webhook: %w", err)
+	}
+	defer func() {
+		// Drain body so the underlying TCP connection can be reused.
+		io.Copy(io.Discard, resp.Body)
+		resp.Body.Close()
+	}()
+
+	// Accept any 2xx response. Many webhook receivers return 200/202/204.
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return fmt.Errorf("webhook endpoint returned status %d", resp.StatusCode)
+	}
+	return nil
+}
+
+// Test sends a synthetic alert to verify configuration.
+func (w *WebhookNotifier) Test() error {
+	return w.Send(Alert{
+		ID:       "test-alert",
+		RuleID:   "test-rule",
+		RuleName: "KubeStellar Console Test Alert",
+		Severity: SeverityInfo,
+		Status:   "test",
+		Message:  "This is a test notification from KubeStellar Console",
+		FiredAt:  time.Now(),
+	})
+}


### PR DESCRIPTION
## Summary

Addresses 6 Go backend issues reported by @xonas1101 in pkg/notifications/ and pkg/api/handlers/ (rbac.go + namespaces.go).

- **#6627** — RBAC/namespace request structs had no field-level validation. Added centralised validate_helpers.go (DNS-label / DNS-subdomain / role-name / enum / cluster-name validators) and applied it at the handler boundary in CreateServiceAccount, CreateRoleBinding, CreateNamespace, and GrantNamespaceAccess. Rejects empty, too-long, invalid-char, and out-of-range payloads with specific 400 messages.
- **#6633** — NotificationTypeWebhook was declared but not implemented. Added pkg/notifications/webhook.go (WebhookNotifier) with JSON POST, 10s timeout, URL validation, and an optional KC_WEBHOOK_ALLOWED_HOSTS SSRF allowlist (empty = allow all, backwards compatible). Wired into SendAlertToChannels and TestNotifier.
- **#6635** — Service.notifiers map was read, written, and iterated without synchronisation. Added a sync.RWMutex; reads take a snapshot so the lock is never held across network I/O. Race-detector test spawns 16 goroutines each on Register and Send for 50 iterations.
- **#6636** — emailSMTPPort was cast from float64 to int with no range check. New parseSMTPPortConfig helper requires the field, accepts float64 or int, and validates 1 <= port <= 65535 with a specific error message.
- **#6638** — strings.Split(to, ",") preserved empty strings, causing SMTP RCPT TO failures on inputs like "a@b.com, ". New splitAndCleanRecipients drops empty/whitespace-only entries. Applied everywhere we parse email recipients.
- **#6639** — OpsGenie close-alert alias was concatenated into the URL path unescaped. Now uses url.PathEscape plus an explicit slash to %2F replacement (PathEscape leaves slash alone since it treats it as a path separator). Also rejects newlines, carriage returns, and null bytes in aliases.

Out of scope: pkg/store/ (another PR may be in flight there).

## Test plan

- [x] go build ./... — pass
- [x] go vet ./... — pass
- [x] go test ./pkg/notifications/ -race -timeout 180s — pass
- [x] go test ./pkg/api/handlers/ -race -timeout 180s -run 'TestValidate|TestRBAC' — pass
- [x] helm lint deploy/helm/kubestellar-console — pass
- [x] New tests: validate helper tables, webhook send/test/allowlist, concurrent Register+SendAlert, SMTP port table, recipient splitter table, OpsGenie alias escape.

Fixes #6627
Fixes #6633
Fixes #6635
Fixes #6636
Fixes #6638
Fixes #6639