### PR TITLE
fix: 3 workload card configs (DaemonSet/ReplicaSet/HPA) + Copilot followups (#6644, #6645, #6647, #6654, #6655)

### DIFF
--- a/pkg/api/handlers/dashboard.go
+++ b/pkg/api/handlers/dashboard.go
@@ -43,7 +43,9 @@ func NewDashboardHandler(s store.Store) *DashboardHandler {
 	return &DashboardHandler{store: s}
 }
 
-// ListDashboards returns all dashboards for the current user
+// ListDashboards returns a page of dashboards for the current user.
+// Supports limit/offset query params via parsePageParams (#6596); a response
+// may therefore be a partial page. Absent limit yields the store default.
 func (h *DashboardHandler) ListDashboards(c *fiber.Ctx) error {
 	userID := middleware.GetUserID(c)
 	// #6596: bound the read. Same limit/offset contract as the feedback list

--- a/pkg/api/handlers/feedback.go
+++ b/pkg/api/handlers/feedback.go
@@ -32,9 +32,10 @@ import (
 // githubAPITimeout is the timeout for HTTP requests to the GitHub API.
 const githubAPITimeout = 10 * time.Second
 
-// feedbackMaxClientLimit is the largest page size a client may request on
-// feedback list endpoints. #6601/#6602: the handler rejects anything above
-// this with HTTP 400.
+// maxClientPageLimit is the largest page size a client may request on any
+// list endpoint that routes through parsePageParams (feedback, RBAC user
+// listing, dashboards, swaps). #6601/#6602: the handler rejects anything
+// above this with HTTP 400.
 //
 // #6621: this is intentionally aligned to store.maxSQLLimit. Previously this
 // was 2000 while the store clamped to 1000, so a client could ask for 1500
@@ -43,7 +44,11 @@ const githubAPITimeout = 10 * time.Second
 // more rows than the store can return is rejected up front with a clear
 // 400 instead of being silently clamped. If the store ceiling is ever
 // raised, raise this in lockstep.
-const feedbackMaxClientLimit = 1000
+//
+// #6644: name/comment were previously feedback-specific, but parsePageParams
+// is reused by non-feedback handlers. Renamed to maxClientPageLimit and
+// scoped the comment to all list endpoints.
+const maxClientPageLimit = 1000
 
 // parsePageParams reads `limit` and `offset` query params with defense against
 // malformed or oversized requests. Returns (limit, offset, err).
@@ -52,7 +57,7 @@ const feedbackMaxClientLimit = 1000
 //   - limit absent       → returns 0 so the store applies its default.
 //   - limit malformed    → HTTP 400 "invalid limit" (non-integer or negative).
 //   - limit > ceiling    → HTTP 400 "limit too large" (exceeds
-//     feedbackMaxClientLimit, which is aligned to the store ceiling).
+//     maxClientPageLimit, which is aligned to the store ceiling).
 //   - offset absent      → returns 0.
 //   - offset malformed   → HTTP 400 "invalid offset".
 //
@@ -64,7 +69,7 @@ func parsePageParams(c *fiber.Ctx) (int, int, error) {
 		if err != nil || n < 0 {
 			return 0, 0, fiber.NewError(fiber.StatusBadRequest, "invalid limit")
 		}
-		if n > feedbackMaxClientLimit {
+		if n > maxClientPageLimit {
 			return 0, 0, fiber.NewError(fiber.StatusBadRequest, "limit too large")
 		}
 		limit = n

--- a/pkg/api/handlers/rbac.go
+++ b/pkg/api/handlers/rbac.go
@@ -39,7 +39,10 @@ func NewRBACHandler(s store.Store, k8sClient *k8s.MultiClusterClient) *RBACHandl
 	return &RBACHandler{store: s, k8sClient: k8sClient}
 }
 
-// ListConsoleUsers returns all console users.
+// ListConsoleUsers returns a page of console users. Supports limit/offset
+// query params via parsePageParams (#6595); a response may therefore be a
+// partial page. Absent limit yields the store default page size.
+//
 // SECURITY: Restricted to admin users to prevent non-admin users from
 // enumerating all user records (#5458).
 func (h *RBACHandler) ListConsoleUsers(c *fiber.Ctx) error {

--- a/pkg/mcp/bridge_test.go
+++ b/pkg/mcp/bridge_test.go
@@ -76,15 +76,20 @@ func TestClient_Stop_Idempotent(t *testing.T) {
 	}, "third Stop must still not panic")
 }
 
-// TestBridge_Start_RollbackStopsStartedClients simulates a partial Start
-// failure where some clients were successfully assigned and then an error
-// was reported from another goroutine. Start must iterate those assigned
-// clients and call Stop on each one before returning (#6624). Because we
-// can't spawn real MCP binaries in unit tests, we verify the behavior by
-// directly asserting that Bridge.Stop is idempotent-safe on clients that
-// were manually assigned — and that Start's rollback path niles the
-// pointers.
-func TestBridge_Start_RollbackStopsStartedClients(t *testing.T) {
+// TestBridge_Stop_StopsAssignedClients validates the tail of Bridge.Start's
+// rollback path (#6624): once a client has been assigned to the bridge, a
+// subsequent Stop must call Stop on every assigned client and must be safe
+// to invoke repeatedly.
+//
+// #6655: this test was previously named and commented as if it exercised
+// Bridge.Start directly and asserted that the rollback nils out the client
+// pointers. Neither claim was accurate — we can't spawn real MCP binaries
+// in unit tests, Bridge.Stop does not nil client pointers (see bridge.go
+// Stop), and this test never invoked Start. The name and comment have been
+// corrected to describe what is actually asserted: that Stop is Start's
+// rollback primitive, that it tears down every assigned client, and that
+// it is idempotent.
+func TestBridge_Stop_StopsAssignedClients(t *testing.T) {
 	bridge := NewBridge(BridgeConfig{})
 
 	// Simulate two successfully started clients.

--- a/pkg/mcp/client.go
+++ b/pkg/mcp/client.go
@@ -58,7 +58,12 @@ func idKey(v interface{}) string {
 	case json.Number:
 		return t.String()
 	default:
-		return fmt.Sprintf("%v", t)
+		// #6655: align behavior with the docstring above — unsupported ID
+		// types are treated as "unroutable" and produce an empty key so
+		// callers drop the response instead of routing it via a bogus
+		// fmt.Sprintf key that could never match an outgoing request.
+		_ = t
+		return ""
 	}
 }
 

--- a/web/src/config/cards/daemonset-status.ts
+++ b/web/src/config/cards/daemonset-status.ts
@@ -104,7 +104,12 @@ export const daemonSetStatusConfig: UnifiedCardConfig = {
   },
 
   // Metadata
-  isDemoData: true,
+  // #6645 — Was `true`, which pinned the card to demo rendering even when
+  // useDaemonSets returned real data, causing a Demo badge + yellow outline
+  // on live data. Match statefulset-status / deployment-status / pod-status
+  // (which use `false`). The hook's own isDemoData signal (when present)
+  // still drives the Demo badge on fallback.
+  isDemoData: false,
   isLive: true,
 }
 

--- a/web/src/config/cards/hpa-status.ts
+++ b/web/src/config/cards/hpa-status.ts
@@ -110,7 +110,10 @@ export const hpaStatusConfig: UnifiedCardConfig = {
   },
 
   // Metadata
-  isDemoData: true,
+  // #6654 — Was `true`, which pinned the card to demo rendering even when
+  // useHPAs returned real data. Match statefulset-status / deployment-status
+  // / pod-status (which use `false`).
+  isDemoData: false,
   isLive: true,
 }
 

--- a/web/src/config/cards/replicaset-status.ts
+++ b/web/src/config/cards/replicaset-status.ts
@@ -97,7 +97,10 @@ export const replicaSetStatusConfig: UnifiedCardConfig = {
   },
 
   // Metadata
-  isDemoData: true,
+  // #6647 — Was `true`, which pinned the card to demo rendering even when
+  // useReplicaSets returned real data. Match statefulset-status /
+  // deployment-status / pod-status (which use `false`).
+  isDemoData: false,
   isLive: true,
 }
 


### PR DESCRIPTION
## Summary

Five issues in one PR.

**Workload card config bugs** (same class as #6642 StatefulSet Status, fixed in #6653):

- #6645 DaemonSet Status — flip isDemoData true -> false in web/src/config/cards/daemonset-status.ts
- #6647 ReplicaSet Status — same in web/src/config/cards/replicaset-status.ts
- #6654 HPA Status — same in web/src/config/cards/hpa-status.ts

All three configs had isDemoData: true alongside isLive: true, which pinned the card to demo rendering even when the backing hook returned real data. The render error called out in #6645/#6647 is plausibly a secondary symptom; the hooks and registerHooks wrappers are structurally identical to useStatefulSets / useUnifiedStatefulSets which is known-good after #6653.

**Copilot followups on merged PRs:**

- #6644 (3 comments on PR #6628):
  - feedback.go: rename feedbackMaxClientLimit -> maxClientPageLimit since parsePageParams is reused by non-feedback handlers; scope comment to all list endpoints.
  - rbac.go: ListConsoleUsers docstring said "returns all console users" but now applies limit/offset — correct the comment.
  - dashboard.go: ListDashboards docstring said "returns all dashboards" but now applies limit/offset — correct the comment.
- #6655 (2 comments on PR #6643):
  - client.go: idKey() default case returned fmt.Sprintf %v, contradicting the docstring which says unsupported types return empty. Return empty string so callers drop unroutable responses.
  - bridge_test.go: TestBridge_Start_RollbackStopsStartedClients was misnamed — it never called Start and Bridge.Stop does not nil client pointers. Renamed to TestBridge_Stop_StopsAssignedClients and rewrote the comment.

Fixes #6644
Fixes #6645
Fixes #6647
Fixes #6654
Fixes #6655

## Test plan

- [x] go build ./... passes
- [x] go vet ./... clean
- [x] go test ./pkg/mcp/... ./pkg/api/handlers/... -race -timeout 180s passes
- [x] npm run build passes
- [x] npx vitest run src/config/cards — 1224 tests pass
- [x] npx vitest run src/test/ui-ux-standards.test.ts — 7 tests pass
- [x] npm run lint introduces no new errors