### PR TITLE
fix: Job Status card + dynamic store reconcile + PR #6656 Copilot followups (#6675, #6681, #6689)

### DIFF
--- a/pkg/api/handlers/namespaces.go
+++ b/pkg/api/handlers/namespaces.go
@@ -236,10 +236,11 @@ func (h *NamespaceHandler) GrantNamespaceAccess(c *fiber.Ctx) error {
 		if err := validateDNSLabel("subjectName", req.SubjectName); err != nil {
 			return fiber.NewError(fiber.StatusBadRequest, err.Error())
 		}
-		if req.SubjectNS != "" {
-			if err := validateDNSLabel("subjectNamespace", req.SubjectNS); err != nil {
-				return fiber.NewError(fiber.StatusBadRequest, err.Error())
-			}
+		// #6675 Copilot followup: subjectNamespace is REQUIRED for
+		// ServiceAccount subjects per Kubernetes RBAC. Previously we
+		// only validated it when present.
+		if err := validateDNSLabel("subjectNamespace", req.SubjectNS); err != nil {
+			return fiber.NewError(fiber.StatusBadRequest, err.Error())
 		}
 	} else {
 		if req.SubjectName == "" {

--- a/pkg/api/handlers/rbac.go
+++ b/pkg/api/handlers/rbac.go
@@ -458,10 +458,13 @@ func (h *RBACHandler) CreateRoleBinding(c *fiber.Ctx) error {
 		if err := validateDNSLabel("subjectName", req.SubjectName); err != nil {
 			return fiber.NewError(fiber.StatusBadRequest, err.Error())
 		}
-		if req.SubjectNS != "" {
-			if err := validateDNSLabel("subjectNamespace", req.SubjectNS); err != nil {
-				return fiber.NewError(fiber.StatusBadRequest, err.Error())
-			}
+		// #6675 Copilot followup: subjectNamespace is REQUIRED for
+		// ServiceAccount subjects per Kubernetes RBAC. Previously we
+		// only validated it when present, so a missing namespace could
+		// slip through and fail later at the apiserver with a generic
+		// error.
+		if err := validateDNSLabel("subjectNamespace", req.SubjectNS); err != nil {
+			return fiber.NewError(fiber.StatusBadRequest, err.Error())
 		}
 	} else {
 		if req.SubjectName == "" {

--- a/pkg/api/handlers/validate_helpers.go
+++ b/pkg/api/handlers/validate_helpers.go
@@ -35,16 +35,17 @@ const (
 var dnsLabelRegex = regexp.MustCompile(`^[a-z0-9]([-a-z0-9]*[a-z0-9])?$`)
 
 // dnsSubdomainRegex matches an RFC 1123 DNS subdomain — a series of DNS
-// labels joined by dots. Used for role/clusterrole names which may contain
-// a group prefix (e.g. "system:aggregate-to-admin").
-// Note: Kubernetes role names can also contain ':' for system roles; we
-// accept that too because existing clusters rely on it.
+// labels joined by dots. Used for hostnames/domains. Role names may also
+// contain ':' (e.g. "system:controller:job-controller") but this regex
+// does NOT accept ':' — role-specific validation uses roleNameRegex below.
 var dnsSubdomainRegex = regexp.MustCompile(`^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$`)
 
 // roleNameRegex accepts a DNS subdomain OR a system-prefixed role name
-// like "system:admin" or "cluster-admin". Built by hand rather than
-// reusing dnsSubdomainRegex so we can allow a single ':' separator.
-var roleNameRegex = regexp.MustCompile(`^[a-z0-9]([-a-z0-9]*[a-z0-9])?(:[a-z0-9]([-a-z0-9]*[a-z0-9])?)?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$`)
+// with one or more ':' separators. Built-in Kubernetes ClusterRoles like
+// "system:controller:job-controller" have multiple ':' segments, so the
+// previous single-segment pattern incorrectly rejected valid role names.
+// #6675 Copilot followup: allow any number of `:label` segments.
+var roleNameRegex = regexp.MustCompile(`^[a-z0-9]([-a-z0-9]*[a-z0-9])?(:[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$`)
 
 // validateDNSLabel checks that s is a non-empty RFC 1123 DNS label suitable
 // for a Kubernetes object name (ServiceAccount, Namespace, RoleBinding, etc).

--- a/pkg/notifications/service.go
+++ b/pkg/notifications/service.go
@@ -7,12 +7,10 @@ import (
 	"sync"
 )
 
-// defaultSMTPPort is the submission port used when a configured port is
-// invalid. Set to the STARTTLS submission port (587) per RFC 6409.
-const defaultSMTPPort = 587
-
 // minSMTPPort / maxSMTPPort bound a valid TCP port number. Used to reject
 // SMTP port values that were parsed as 0 or out-of-range floats (#6636).
+// #6675 Copilot followup: the previously-declared `defaultSMTPPort` constant
+// was never referenced anywhere in the package and has been removed.
 const (
 	minSMTPPort = 1
 	maxSMTPPort = 65535
@@ -144,6 +142,11 @@ func parseSMTPPortConfig(config map[string]interface{}) (int, error) {
 	var port int
 	switch v := raw.(type) {
 	case float64:
+		// #6675 Copilot followup: reject non-integer floats (e.g. 587.9)
+		// instead of silently truncating to 587.
+		if v != float64(int(v)) {
+			return 0, fmt.Errorf("emailSMTPPort must be an integer (got %v)", v)
+		}
 		port = int(v)
 	case int:
 		port = v

--- a/pkg/notifications/webhook.go
+++ b/pkg/notifications/webhook.go
@@ -69,8 +69,16 @@ func NewWebhookNotifier(webhookURL string) (*WebhookNotifier, error) {
 		return nil, err
 	}
 	return &WebhookNotifier{
-		URL:        webhookURL,
-		HTTPClient: &http.Client{Timeout: webhookHTTPTimeout},
+		URL: webhookURL,
+		HTTPClient: &http.Client{
+			Timeout: webhookHTTPTimeout,
+			// #6675 Copilot followup: re-check the allowlist on every
+			// redirect hop. Without this a permitted host could 30x to
+			// an internal endpoint and the request would still be sent.
+			CheckRedirect: func(req *http.Request, _ []*http.Request) error {
+				return checkWebhookHostAllowed(req.URL.Hostname())
+			},
+		},
 	}, nil
 }
 

--- a/web/src/config/cards/job-status.ts
+++ b/web/src/config/cards/job-status.ts
@@ -102,7 +102,12 @@ export const jobStatusConfig: UnifiedCardConfig = {
   },
 
   // Metadata
-  isDemoData: true,
+  // #6689 — Was `true`, which pinned the card to demo rendering even when
+  // useJobs returned real data, causing a Demo badge + yellow outline
+  // on live data. Match daemonset-status / replicaset-status / hpa-status
+  // (which use `false`). The hook's own isDemoData signal (when present)
+  // still drives the Demo badge on fallback.
+  isDemoData: false,
   isLive: true,
 }
 

--- a/web/src/lib/dynamic-cards/__tests__/dynamicCardStore.test.ts
+++ b/web/src/lib/dynamic-cards/__tests__/dynamicCardStore.test.ts
@@ -20,6 +20,9 @@ vi.mock('../dynamicCardRegistry', () => ({
     mockCards.delete(id)
     return had
   }),
+  clearDynamicCards: vi.fn(() => {
+    mockCards.clear()
+  }),
 }))
 
 import {
@@ -68,6 +71,43 @@ describe('loadDynamicCards', () => {
     expect(() => loadDynamicCards()).not.toThrow()
     expect(spy).toHaveBeenCalled()
     spy.mockRestore()
+  })
+
+  // #6681: reconcile removals on reload. Previously loadDynamicCards was
+  // additive and left entries that had been removed from storage still
+  // registered in memory.
+  it('reconciles removals when storage shrinks between loads', () => {
+    const three = [
+      { id: 'a', title: 'A', tier: 'tier1' },
+      { id: 'b', title: 'B', tier: 'tier1' },
+      { id: 'c', title: 'C', tier: 'tier1' },
+    ]
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(three))
+    loadDynamicCards()
+    expect(mockCards.size).toBe(3)
+
+    const two = [
+      { id: 'a', title: 'A', tier: 'tier1' },
+      { id: 'b', title: 'B', tier: 'tier1' },
+    ]
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(two))
+    loadDynamicCards()
+
+    expect(mockCards.size).toBe(2)
+    expect(mockCards.has('a')).toBe(true)
+    expect(mockCards.has('b')).toBe(true)
+    expect(mockCards.has('c')).toBe(false)
+  })
+
+  it('clears the registry when storage has been emptied', () => {
+    const one = [{ id: 'only', title: 'Only', tier: 'tier1' }]
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(one))
+    loadDynamicCards()
+    expect(mockCards.size).toBe(1)
+
+    localStorage.removeItem(STORAGE_KEY)
+    loadDynamicCards()
+    expect(mockCards.size).toBe(0)
   })
 })
 

--- a/web/src/lib/dynamic-cards/__tests__/dynamicStatsStore.test.ts
+++ b/web/src/lib/dynamic-cards/__tests__/dynamicStatsStore.test.ts
@@ -19,6 +19,9 @@ vi.mock('../dynamicStatsRegistry', () => ({
     mockStats.delete(type)
     return had
   }),
+  clearDynamicStats: vi.fn(() => {
+    mockStats.clear()
+  }),
   toRecord: vi.fn((def: Record<string, unknown>) => def),
 }))
 
@@ -68,6 +71,43 @@ describe('loadDynamicStats', () => {
     expect(() => loadDynamicStats()).not.toThrow()
     expect(spy).toHaveBeenCalled()
     spy.mockRestore()
+  })
+
+  // #6681: reconcile removals on reload. Previously loadDynamicStats was
+  // additive and left entries that had been removed from storage still
+  // registered in memory.
+  it('reconciles removals when storage shrinks between loads', () => {
+    const three = [
+      { type: 'a', blocks: [{ label: 'A' }] },
+      { type: 'b', blocks: [{ label: 'B' }] },
+      { type: 'c', blocks: [{ label: 'C' }] },
+    ]
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(three))
+    loadDynamicStats()
+    expect(mockStats.size).toBe(3)
+
+    const two = [
+      { type: 'a', blocks: [{ label: 'A' }] },
+      { type: 'b', blocks: [{ label: 'B' }] },
+    ]
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(two))
+    loadDynamicStats()
+
+    expect(mockStats.size).toBe(2)
+    expect(mockStats.has('a')).toBe(true)
+    expect(mockStats.has('b')).toBe(true)
+    expect(mockStats.has('c')).toBe(false)
+  })
+
+  it('clears the registry when storage has been emptied', () => {
+    const one = [{ type: 'only', blocks: [{ label: 'Only' }] }]
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(one))
+    loadDynamicStats()
+    expect(mockStats.size).toBe(1)
+
+    localStorage.removeItem(STORAGE_KEY)
+    loadDynamicStats()
+    expect(mockStats.size).toBe(0)
   })
 })
 

--- a/web/src/lib/dynamic-cards/dynamicCardStore.ts
+++ b/web/src/lib/dynamic-cards/dynamicCardStore.ts
@@ -3,16 +3,32 @@ import {
   registerDynamicCard,
   getAllDynamicCards,
   unregisterDynamicCard,
+  clearDynamicCards,
 } from './dynamicCardRegistry'
 
 const STORAGE_KEY = 'kc-dynamic-cards'
 
-/** Load dynamic cards from localStorage and register them */
+/**
+ * Load dynamic cards from localStorage and register them.
+ *
+ * #6681 — Previously this only iterated stored entries and called
+ * registerDynamicCard for each, so entries that had been removed from
+ * localStorage since the last load were left stuck in the in-memory
+ * registry. We now perform an atomic replace: clear the registry and
+ * re-register from storage so removals propagate on reload.
+ */
 export function loadDynamicCards(): void {
   try {
     const raw = localStorage.getItem(STORAGE_KEY)
-    if (!raw) return
+    if (!raw) {
+      // Storage is empty — wipe the in-memory registry so a removed
+      // last-entry reconciles the same way multi-entry removals do.
+      clearDynamicCards()
+      return
+    }
     const defs: DynamicCardDefinition[] = JSON.parse(raw)
+    // Atomic replace: clear then re-register from storage.
+    clearDynamicCards()
     defs.forEach(def => registerDynamicCard(def))
   } catch (err) {
     console.error('[DynamicCardStore] Failed to load from localStorage:', err)

--- a/web/src/lib/dynamic-cards/dynamicStatsRegistry.ts
+++ b/web/src/lib/dynamic-cards/dynamicStatsRegistry.ts
@@ -38,6 +38,22 @@ export function unregisterDynamicStats(type: string): boolean {
   return true
 }
 
+/**
+ * Clear all dynamically-registered stats definitions.
+ *
+ * #6681 — Used by loadDynamicStats to reconcile removed entries: the store
+ * performs an atomic replace (clear then re-register from storage) so that
+ * definitions deleted from localStorage no longer linger in memory.
+ */
+export function clearDynamicStats(): void {
+  if (dynamicTypes.size === 0) return
+  for (const type of Array.from(dynamicTypes)) {
+    unregisterStats(type)
+  }
+  dynamicTypes.clear()
+  notifyListeners()
+}
+
 /** Get a dynamic stats definition */
 export function getDynamicStats(type: string): StatsDefinition | undefined {
   if (!dynamicTypes.has(type)) return undefined

--- a/web/src/lib/dynamic-cards/dynamicStatsStore.ts
+++ b/web/src/lib/dynamic-cards/dynamicStatsStore.ts
@@ -3,17 +3,29 @@ import {
   registerDynamicStats,
   getAllDynamicStats,
   unregisterDynamicStats,
+  clearDynamicStats,
   toRecord,
 } from './dynamicStatsRegistry'
 
 const STORAGE_KEY = 'kc-dynamic-stats'
 
-/** Load dynamic stats definitions from localStorage and register them */
+/**
+ * Load dynamic stats definitions from localStorage and register them.
+ *
+ * #6681 — Previously additive: entries that had been removed from storage
+ * since the last load stayed in the in-memory registry. We now perform an
+ * atomic replace (clear + re-register from storage) so removals propagate
+ * on reload, matching the behaviour of loadDynamicCards.
+ */
 export function loadDynamicStats(): void {
   try {
     const raw = localStorage.getItem(STORAGE_KEY)
-    if (!raw) return
+    if (!raw) {
+      clearDynamicStats()
+      return
+    }
     const defs: StatsDefinition[] = JSON.parse(raw)
+    clearDynamicStats()
     defs.forEach(def => registerDynamicStats(def))
   } catch (err) {
     console.error('[DynamicStatsStore] Failed to load from localStorage:', err)


### PR DESCRIPTION
## Summary

Three fixes in one PR:

### #6689 — Job Status card shows Demo badge on live data
`web/src/config/cards/job-status.ts` — `isDemoData: true` -> `false`.
Same regression pattern fixed in the wave11 workload-card PRs for DaemonSet / ReplicaSet / HPA / CronJob (#6642, #6645, #6647, #6654). The hook's own `isDemoData` signal still drives the Demo badge on fallback.

### #6681 — Re-loading from storage is additive, does not reconcile removals
`web/src/lib/dynamic-cards/dynamicCardStore.ts` and `dynamicStatsStore.ts` previously iterated stored entries and registered each one, but never cleared the in-memory registry. When storage shrank between loads, removed entries stayed stuck in memory.

Fixed both loaders to perform an atomic replace: clear then re-register from storage. Added a `clearDynamicStats` helper to mirror `clearDynamicCards`. New tests store 3 defs -> load, then store 2 -> load again, assert the 3rd is gone, plus an "empty storage wipes registry" case.

### #6675 — 7 Copilot review comments on merged PR #6656
All 7 addressed:

- **service.go**: removed unused `defaultSMTPPort` constant.
- **service.go**: `parseSMTPPortConfig` rejects non-integer floats (e.g. 587.9) instead of silently truncating.
- **webhook.go**: SSRF allowlist now enforced on every redirect hop via `http.Client.CheckRedirect`, not just the initial URL.
- **validate_helpers.go**: `roleNameRegex` now accepts multiple `:` segments so built-in ClusterRoles like `system:controller:job-controller` pass validation.
- **validate_helpers.go**: corrected the misleading `dnsSubdomainRegex` comment — it does NOT accept `:`, role validation uses `roleNameRegex`.
- **rbac.go**: `subjectNamespace` now REQUIRED when `subjectKind=ServiceAccount` (was only validated if present).
- **namespaces.go**: same ServiceAccount namespace-required fix.

## Test plan

- [x] `go build ./...` — clean
- [x] `go vet ./...` — clean
- [x] `go test ./pkg/api/handlers/ ./pkg/notifications/ -race -timeout 180s` — pass
- [x] `cd web && npm run build` — pass (postbuild safety checks green)
- [x] `npx vitest run src/config/cards src/lib/dynamic-cards src/test/ui-ux-standards.test.ts` — 1326 tests pass
- [x] `npm run lint` — no NEW errors in touched files (pre-existing lint errors in CompliancePerfTest.tsx etc. unchanged)

Fixes #6675
Fixes #6681
Fixes #6689
