### PR TITLE
fix: encoding/escaping, Rules of Hooks, registry membership, PredictionWorker race, compiler tests (#6694-#6708)

### DIFF
--- a/pkg/agent/prediction_worker.go
+++ b/pkg/agent/prediction_worker.go
@@ -7,6 +7,7 @@ import (
 	"log/slog"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/google/uuid"
@@ -94,7 +95,11 @@ type PredictionWorker struct {
 
 	// Token tracking callback
 	trackTokens        func(usage *ProviderTokenUsage)
-	loggedClusterError bool // suppress repeated "no kubeconfig" errors
+	// loggedClusterError suppresses repeated "no kubeconfig" errors. This is
+	// read/written from runAnalysis, which can be invoked concurrently from
+	// the ticker goroutine and from on-demand Trigger() callers, so it must
+	// be accessed atomically to avoid a data race.
+	loggedClusterError atomic.Bool
 }
 
 // NewPredictionWorker creates a new prediction worker
@@ -255,8 +260,9 @@ func (w *PredictionWorker) runAnalysis(specificProviders []string) {
 
 	clusterData, err := w.gatherClusterData(ctx)
 	if err != nil {
-		if !w.loggedClusterError {
-			w.loggedClusterError = true
+		// CompareAndSwap returns true exactly once (first false->true flip),
+		// so the slog.Info fires at most once across concurrent callers.
+		if w.loggedClusterError.CompareAndSwap(false, true) {
 			slog.Info("[PredictionWorker] cluster data unavailable (will retry silently)", "error", err)
 		}
 		return

--- a/pkg/mcp/client.go
+++ b/pkg/mcp/client.go
@@ -62,7 +62,6 @@ func idKey(v interface{}) string {
 		// types are treated as "unroutable" and produce an empty key so
 		// callers drop the response instead of routing it via a bogus
 		// fmt.Sprintf key that could never match an outgoing request.
-		_ = t
 		return ""
 	}
 }

--- a/web/src/components/ui/StatsOverview.tsx
+++ b/web/src/components/ui/StatsOverview.tsx
@@ -463,14 +463,24 @@ export function StatsOverview({
     window.dispatchEvent(new CustomEvent('kubestellar-settings-changed'))
   }
 
-  // Manage collapsed state with localStorage persistence
+  // Manage collapsed state with localStorage persistence.
+  // Storage key ends in "-stats-collapsed", so the stored value represents
+  // the COLLAPSED state (true = collapsed). Previously this file stored
+  // `isExpanded` under the same key, which inverted across reloads and
+  // disagreed with sibling components that use the collapsed sense.
   const storageKey = collapsedStorageKey || `kubestellar-${dashboardType}-stats-collapsed`
-  const [isExpanded, setIsExpanded] = useState(() => safeGetJSON<boolean>(storageKey) ?? defaultExpanded)
+  const [isExpanded, setIsExpanded] = useState(() => {
+    const savedCollapsed = safeGetJSON<boolean>(storageKey)
+    return savedCollapsed === null || savedCollapsed === undefined
+      ? defaultExpanded
+      : !savedCollapsed
+  })
 
   const toggleExpanded = () => {
     const newValue = !isExpanded
     setIsExpanded(newValue)
-    safeSetJSON(storageKey, newValue)
+    // Store COLLAPSED state to match the storage-key semantics.
+    safeSetJSON(storageKey, !newValue)
   }
 
   // Dynamic grid columns based on visible blocks

--- a/web/src/config/__tests__/learningVideos.test.ts
+++ b/web/src/config/__tests__/learningVideos.test.ts
@@ -23,4 +23,21 @@ describe('YouTube URL helpers', () => {
     expect(YOUTUBE_PLAYLIST_URL).toContain('youtube.com/playlist')
     expect(YOUTUBE_PLAYLIST_URL).toContain('list=')
   })
+
+  // #6696 / #6698 — video ids that happen to contain URL-reserved
+  // characters must not be able to break out of the intended path or
+  // inject extra query parameters into the watch URL.
+  it('getYouTubeThumbnailUrl encodes path separators and special characters', () => {
+    const url = getYouTubeThumbnailUrl('foo/bar?baz#qux')
+    expect(url).toBe('/api/youtube/thumbnail/foo%2Fbar%3Fbaz%23qux')
+    expect(url).not.toContain('foo/bar')
+  })
+
+  it('getYouTubeWatchUrl encodes ampersands so extra query params cannot be injected', () => {
+    const url = getYouTubeWatchUrl('abc&malicious=1')
+    // The raw & must not appear — otherwise 'malicious=1' would become a
+    // second query param.
+    expect(url).toBe('https://www.youtube.com/watch?v=abc%26malicious%3D1')
+    expect(url).not.toContain('&malicious')
+  })
 })

--- a/web/src/config/__tests__/routes.test.ts
+++ b/web/src/config/__tests__/routes.test.ts
@@ -53,6 +53,19 @@ describe('Route helper functions', () => {
     expect(route).not.toContain(':id')
   })
 
+  // #6695 / #6698 — dashboard ids with URL-reserved characters must be
+  // encoded so they can't break out of the path or inject a query/fragment.
+  it('getCustomDashboardRoute encodes path separators, query, fragment, percent', () => {
+    const route = getCustomDashboardRoute('a/b?c#d%e')
+    expect(route).not.toContain(':id')
+    // Each reserved char should be percent-encoded in the output.
+    expect(route).toContain('a%2Fb%3Fc%23d%25e')
+    // And the raw characters should not leak through.
+    expect(route).not.toContain('a/b')
+    expect(route).not.toContain('?c')
+    expect(route).not.toContain('#d')
+  })
+
   it('getLoginWithError includes encoded error param', () => {
     const route = getLoginWithError('token expired')
     expect(route).toContain('/login?error=')

--- a/web/src/config/cards/index.ts
+++ b/web/src/config/cards/index.ts
@@ -400,7 +400,9 @@ export function getCardConfig(cardType: string): UnifiedCardConfig | undefined {
 }
 
 export function hasUnifiedConfig(cardType: string): boolean {
-  return cardType in CARD_CONFIGS
+  // Use hasOwnProperty to avoid false positives from inherited Object.prototype
+  // keys such as 'toString', 'constructor', '__proto__', etc.
+  return Object.prototype.hasOwnProperty.call(CARD_CONFIGS, cardType)
 }
 
 export function getUnifiedCardTypes(): string[] {

--- a/web/src/config/learningVideos.ts
+++ b/web/src/config/learningVideos.ts
@@ -7,10 +7,14 @@
  */
 
 export const getYouTubeThumbnailUrl = (videoId: string) =>
-  `/api/youtube/thumbnail/${videoId}`
+  // Encode the videoId so stray characters like '/', '?', '#', or '..' can't
+  // break out of the thumbnail path or produce an invalid URL.
+  `/api/youtube/thumbnail/${encodeURIComponent(videoId)}`
 
 export const getYouTubeWatchUrl = (videoId: string) =>
-  `https://www.youtube.com/watch?v=${videoId}`
+  // Encode the videoId so it can't tamper with the query string (e.g. a
+  // videoId containing '&foo=bar' would inject extra params).
+  `https://www.youtube.com/watch?v=${encodeURIComponent(videoId)}`
 
 export const YOUTUBE_PLAYLIST_URL =
   'https://www.youtube.com/playlist?list=PL1ALKGr_qZKc-xehA_8iUCdiKsCo6p6nD'

--- a/web/src/config/routes.ts
+++ b/web/src/config/routes.ts
@@ -105,7 +105,9 @@ export const ROUTES = {
  * Helper function to create a custom dashboard route with ID
  */
 export function getCustomDashboardRoute(id: string): string {
-  return ROUTES.CUSTOM_DASHBOARD.replace(':id', id)
+  // Encode the id so special characters like '/', '?', '#', '%' don't break
+  // the URL or enable path traversal into unrelated routes.
+  return ROUTES.CUSTOM_DASHBOARD.replace(':id', encodeURIComponent(id))
 }
 
 /**

--- a/web/src/lib/cards/CardRuntime.tsx
+++ b/web/src/lib/cards/CardRuntime.tsx
@@ -36,7 +36,7 @@
  * ```
  */
 
-import { ReactNode } from 'react'
+import { ReactNode, useState } from 'react'
 import { getIcon } from '../icons'
 import { CardDefinition, CardColumnDefinition } from './types'
 import { useCardData, SortDirection } from './cardHooks'
@@ -125,6 +125,17 @@ registerRenderer('percentage', (value) => (
   <span className="font-mono text-sm">{Number(value).toFixed(1)}%</span>
 ))
 
+// Allowlist for column alignment values — keeps unvalidated user config from
+// producing garbage Tailwind classes like "text-foo" that silently drop styles.
+const VALID_ALIGN_VALUES = ['left', 'center', 'right'] as const
+type ValidAlign = (typeof VALID_ALIGN_VALUES)[number]
+const DEFAULT_ALIGN: ValidAlign = 'left'
+function normalizeAlign(align: string | undefined): ValidAlign {
+  return (VALID_ALIGN_VALUES as readonly string[]).includes(align ?? '')
+    ? (align as ValidAlign)
+    : DEFAULT_ALIGN
+}
+
 // ============================================================================
 // CardRuntime Props
 // ============================================================================
@@ -164,9 +175,22 @@ export function CardRuntime({ definition, config: _config, title }: CardRuntimeP
     emptyState,
     loadingState } = definition
 
-  // Get the data hook (fall back to noop so hooks are always called unconditionally)
-  const useDataHook = dataHookRegistry.get(dataSource.hook) || noopDataHook
-  const hookMissing = !dataHookRegistry.has(dataSource.hook)
+  // Rules of Hooks require the same hook be called every render for the life
+  // of this component instance. If we re-read dataHookRegistry on each render,
+  // a hook that gets registered (or unregistered) between renders would change
+  // which function is called — and different registered hooks call different
+  // numbers of inner hooks, which violates the Rules of Hooks and crashes
+  // React. Snapshot the resolved hook on first render via lazy useState so the
+  // same function is called for the entire component lifetime. If callers need
+  // to pick up a newly-registered hook, they should remount CardRuntime with a
+  // new `key` prop (e.g. key={dataSource.hook}).
+  const [{ useDataHook, hookMissing }] = useState(() => {
+    const resolved = dataHookRegistry.get(dataSource.hook)
+    return {
+      useDataHook: resolved || noopDataHook,
+      hookMissing: !resolved,
+    }
+  })
 
   // Call the data hook
   const {
@@ -332,7 +356,7 @@ export function CardRuntime({ definition, config: _config, title }: CardRuntimeP
                   {columns?.map(col => (
                     <th
                       key={col.field}
-                      className={`px-2 py-1.5 text-xs font-medium text-muted-foreground text-${col.align || 'left'}`}
+                      className={`px-2 py-1.5 text-xs font-medium text-muted-foreground text-${normalizeAlign(col.align)}`}
                       style={col.width ? { width: col.width } : undefined}
                     >
                       {col.header}
@@ -350,7 +374,7 @@ export function CardRuntime({ definition, config: _config, title }: CardRuntimeP
                     {columns?.map(col => (
                       <td
                         key={col.field}
-                        className={`px-2 py-2 text-${col.align || 'left'}`}
+                        className={`px-2 py-2 text-${normalizeAlign(col.align)}`}
                       >
                         {renderCell(item, col)}
                       </td>

--- a/web/src/lib/cards/__tests__/cardInstallMap.test.ts
+++ b/web/src/lib/cards/__tests__/cardInstallMap.test.ts
@@ -1,5 +1,5 @@
-import { describe, it, expect } from 'vitest'
-import { CARD_INSTALL_MAP } from '../cardInstallMap'
+import { describe, it, expect, vi } from 'vitest'
+import { CARD_INSTALL_MAP, validateCardInstallMap } from '../cardInstallMap'
 
 describe('CARD_INSTALL_MAP', () => {
   it('is a non-empty record', () => {
@@ -126,6 +126,41 @@ describe('CARD_INSTALL_MAP', () => {
       for (const path of info.kbPaths) {
         expect(path).toMatch(/^fixes\//)
       }
+    }
+  })
+})
+
+// #6699 — validateCardInstallMap flags install-map keys that don't match a
+// registered card type so dead aliases get surfaced instead of rotting.
+describe('validateCardInstallMap', () => {
+  it('returns an empty list when every key is registered', () => {
+    const known = Object.keys(CARD_INSTALL_MAP)
+    const unknown = validateCardInstallMap(known)
+    expect(unknown).toEqual([])
+  })
+
+  it('reports keys that are missing from the registered set', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    try {
+      // Pretend only a single key is registered — every other key should
+      // come back as unknown.
+      const unknown = validateCardInstallMap(['opa_policies'])
+      expect(unknown.length).toBeGreaterThan(0)
+      expect(unknown).not.toContain('opa_policies')
+      // Validator logs exactly once with the offending keys.
+      expect(warn).toHaveBeenCalledTimes(1)
+    } finally {
+      warn.mockRestore()
+    }
+  })
+
+  it('does not warn when every key is registered', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    try {
+      validateCardInstallMap(Object.keys(CARD_INSTALL_MAP))
+      expect(warn).not.toHaveBeenCalled()
+    } finally {
+      warn.mockRestore()
     }
   })
 })

--- a/web/src/lib/cards/cardHooks.ts
+++ b/web/src/lib/cards/cardHooks.ts
@@ -711,10 +711,17 @@ export const commonComparators = {
     return (order[aStatus] ?? 999) - (order[bStatus] ?? 999)
   },
 
-  /** Compare dates (ISO strings or Date objects) */
+  /** Compare dates (ISO strings or Date objects).
+   * Invalid dates (NaN) are sorted to the END of the list in ascending order
+   * so valid, chronological data stays front-loaded. We use
+   * Number.MAX_SAFE_INTEGER as the sentinel rather than 0 so that legitimate
+   * epoch-zero timestamps still sort before invalid values. */
   date: <T>(field: keyof T) => (a: T, b: T) => {
-    const aDate = new Date(a[field] as string | Date).getTime()
-    const bDate = new Date(b[field] as string | Date).getTime()
+    const INVALID_DATE_SENTINEL = Number.MAX_SAFE_INTEGER
+    const aRaw = new Date(a[field] as string | Date).getTime()
+    const bRaw = new Date(b[field] as string | Date).getTime()
+    const aDate = Number.isNaN(aRaw) ? INVALID_DATE_SENTINEL : aRaw
+    const bDate = Number.isNaN(bRaw) ? INVALID_DATE_SENTINEL : bRaw
     return aDate - bDate
   } }
 

--- a/web/src/lib/cards/cardInstallMap.ts
+++ b/web/src/lib/cards/cardInstallMap.ts
@@ -101,3 +101,32 @@ export const CARD_INSTALL_MAP: Record<string, CardInstallInfo> = {
   // Knative
   knative_services: { project: 'Knative', missionKey: 'install-knative', kbPaths: ['fixes/cncf-install/install-knative.json'] },
 }
+
+/**
+ * Validate CARD_INSTALL_MAP keys against the set of actually-registered
+ * card types. Logs a single warning for each dead alias. Intended to be
+ * called once at app bootstrap (dev builds only) so typos and cards that
+ * were removed from the registry but left behind in the install map are
+ * surfaced instead of silently rotting.
+ *
+ * @param registeredCardTypes full list of card type ids currently registered
+ *        (e.g. the result of `getUnifiedCardTypes()` from config/cards/index).
+ * @returns array of install-map keys that do NOT correspond to a registered card.
+ */
+export function validateCardInstallMap(registeredCardTypes: readonly string[]): string[] {
+  const known = new Set(registeredCardTypes)
+  const unknown: string[] = []
+  for (const key of Object.keys(CARD_INSTALL_MAP)) {
+    if (!known.has(key)) {
+      unknown.push(key)
+    }
+  }
+  if (unknown.length > 0 && typeof console !== 'undefined') {
+    // eslint-disable-next-line no-console
+    console.warn(
+      `[cardInstallMap] ${unknown.length} install-map key(s) do not match any registered card type:`,
+      unknown,
+    )
+  }
+  return unknown
+}

--- a/web/src/lib/stats/StatsRuntime.tsx
+++ b/web/src/lib/stats/StatsRuntime.tsx
@@ -168,12 +168,23 @@ export function StatsRuntime({
   // Get visible blocks (respect visible flag)
   const visibleBlocks = blocks.filter((b) => b.visible !== false)
 
-  // Manage collapsed state with localStorage persistence
+  // Manage collapsed state with localStorage persistence.
+  // The storage key says "collapsed", so the stored value represents
+  // collapsed state (true = collapsed). Previously this file stored
+  // `isExpanded` under the "-stats-collapsed" key, which meant the toggle
+  // read back inverted after a reload and sibling components
+  // (UnifiedStatsSection) that DID store the collapsed sense disagreed on
+  // the same key. Read and write both now use the collapsed sense.
   const storageKey = collapsedStorageKey || `kubestellar-${type}-stats-collapsed`
   const [isExpanded, setIsExpanded] = useState(() => {
     try {
       const saved = localStorage.getItem(storageKey)
-      return saved !== null ? JSON.parse(saved) : (defaultCollapsed ? false : defaultExpanded)
+      if (saved !== null) {
+        const parsed = JSON.parse(saved) as boolean
+        // parsed represents COLLAPSED state
+        return !parsed
+      }
+      return defaultCollapsed ? false : defaultExpanded
     } catch {
       return defaultCollapsed ? false : defaultExpanded
     }
@@ -183,7 +194,8 @@ export function StatsRuntime({
     const newValue = !isExpanded
     setIsExpanded(newValue)
     try {
-      localStorage.setItem(storageKey, JSON.stringify(newValue))
+      // Store COLLAPSED state to match the storage-key semantics.
+      localStorage.setItem(storageKey, JSON.stringify(!newValue))
     } catch {
       // Ignore storage errors
     }

--- a/web/src/lib/stats/__tests__/StatsRuntime-coverage.test.tsx
+++ b/web/src/lib/stats/__tests__/StatsRuntime-coverage.test.tsx
@@ -201,12 +201,14 @@ describe('StatsRuntime collapse', () => {
     render(<StatsRuntime definition={def} getStatValue={getStatValue} />)
 
     const toggleBtn = screen.getByText('Test Stats')
+    // Starts expanded; first click collapses it, so collapsed=true is stored.
     fireEvent.click(toggleBtn)
 
-    expect(localStorage.getItem(storageKey)).toBe('false')
-
-    fireEvent.click(toggleBtn)
     expect(localStorage.getItem(storageKey)).toBe('true')
+
+    // Second click expands it, so collapsed=false is stored.
+    fireEvent.click(toggleBtn)
+    expect(localStorage.getItem(storageKey)).toBe('false')
   })
 
   it('uses custom collapsedStorageKey', () => {
@@ -223,9 +225,10 @@ describe('StatsRuntime collapse', () => {
     )
 
     const toggleBtn = screen.getByText('Test Stats')
+    // Starts expanded; first click collapses, so collapsed=true is stored.
     fireEvent.click(toggleBtn)
 
-    expect(localStorage.getItem(customKey)).toBe('false')
+    expect(localStorage.getItem(customKey)).toBe('true')
   })
 
   it('reads initial collapsed state from localStorage', () => {
@@ -233,12 +236,12 @@ describe('StatsRuntime collapse', () => {
     const getStatValue = (): StatBlockValue => ({ value: 99 })
     const storageKey = 'kubestellar-saved-state-stats-collapsed'
 
-    // Pre-set collapsed state
-    localStorage.setItem(storageKey, 'false')
+    // Pre-set collapsed state (true = collapsed)
+    localStorage.setItem(storageKey, 'true')
 
     render(<StatsRuntime definition={def} getStatValue={getStatValue} />)
 
-    // Should be collapsed because localStorage says false
+    // Should be collapsed because localStorage says collapsed=true
     expect(screen.queryByText('99')).toBeNull()
   })
 

--- a/web/src/lib/unified/stats/UnifiedStatsSection.tsx
+++ b/web/src/lib/unified/stats/UnifiedStatsSection.tsx
@@ -24,12 +24,22 @@ export function UnifiedStatsSection({
   isLoading = false,
   lastUpdated,
   className = '' }: UnifiedStatsSectionProps) {
-  // Collapsed state with localStorage persistence
+  // Collapsed state with localStorage persistence.
+  // The storage key name says "collapsed", so the stored value represents
+  // collapsed state (true = collapsed). Historically the read path here
+  // interpreted the saved value as `isExpanded` while the write path stored
+  // `!isExpanded` — they disagreed, so reloading the page showed the inverse
+  // of the last toggle. Keep read and write aligned with the name of the key.
   const storageKey = config.storageKey || `kubestellar-${config.type}-stats-collapsed`
   const [isExpanded, setIsExpanded] = useState(() => {
     try {
       const saved = localStorage.getItem(storageKey)
-      return saved !== null ? JSON.parse(saved) : !config.defaultCollapsed
+      if (saved !== null) {
+        const parsed = JSON.parse(saved) as boolean
+        // parsed represents COLLAPSED state
+        return !parsed
+      }
+      return !config.defaultCollapsed
     } catch {
       return !config.defaultCollapsed
     }

--- a/web/src/lib/widgets/__tests__/codeGenerator.test.ts
+++ b/web/src/lib/widgets/__tests__/codeGenerator.test.ts
@@ -240,3 +240,128 @@ describe('getWidgetFilename', () => {
     expect(getWidgetFilename(config)).toBe('widget.jsx')
   })
 })
+
+// --- Regression tests for #6703, #6704, #6705, #6706 -----------------------
+// These cover:
+//  - #6705: generated JSX must not allow a user-controlled display name to
+//    inject executable markup.
+//  - #6703: template widgets that contain ONLY stats (no cards) must not
+//    produce an invalid curl command.
+//  - #6704: stat data-path extraction must support bracket/index notation.
+//  - #6706: the widget test suite was missing both #6703 and #6704 before
+//    this change.
+
+describe('generator hardening', () => {
+  // Minimal snapshot of the module-under-test so we can inject a hostile
+  // card displayName without touching the shared WIDGET_CARDS registry at
+  // runtime. Using vi.doMock would require isolateModules gymnastics — we
+  // instead exploit the fact that WIDGET_CARDS is mutable at test time.
+  it('does not inject executable <script> into generated JSX when title has HTML (default card branch)', async () => {
+    const { WIDGET_CARDS } = await import('../widgetRegistry')
+    const HOSTILE_TYPE = '__hostile_test_card__'
+    const HOSTILE_TITLE = '</div><script>alert(1)</script>'
+    // Use a card type that falls through to the default render branch in
+    // generateCardRenderFunction — that's the branch that interpolates the
+    // title directly into the JSX source.
+    ;(WIDGET_CARDS as Record<string, unknown>)[HOSTILE_TYPE] = {
+      type: HOSTILE_TYPE,
+      displayName: HOSTILE_TITLE,
+      description: 'test only',
+      apiEndpoints: ['/api/test'],
+    }
+    try {
+      const code = generateCardWidget(HOSTILE_TYPE, 'http://localhost:8080')
+      // Strip every single- and double-quoted string literal and every
+      // line/block comment, then assert the generated source has no live
+      // <script> markup left behind. The hostile title only gets emitted
+      // inside a `{"..."}` JSX expression (JSON.stringify), so after
+      // scrubbing string literals it must be gone. If the implementation
+      // regresses and interpolates the title raw into JSX, the
+      // <script> tag will survive the scrub and this test will catch it.
+      const scrubbed = code
+        // strip block comments
+        .replace(/\/\*[\s\S]*?\*\//g, '')
+        // strip line comments
+        .replace(/\/\/.*$/gm, '')
+        // strip double-quoted strings
+        .replace(/"(?:[^"\\]|\\.)*"/g, '""')
+        // strip single-quoted strings
+        .replace(/'(?:[^'\\]|\\.)*'/g, "''")
+        // strip template literals
+        .replace(/`(?:[^`\\]|\\.)*`/g, '``')
+      expect(scrubbed).not.toContain('<script')
+      expect(scrubbed).not.toContain('alert(1)')
+      // And it should round-trip through JSON.stringify inside braces.
+      expect(code).toContain(JSON.stringify(HOSTILE_TITLE))
+    } finally {
+      delete (WIDGET_CARDS as Record<string, unknown>)[HOSTILE_TYPE]
+    }
+  })
+
+  it('throws a clear error when a stats-only template has no resolvable endpoint', async () => {
+    const { WIDGET_TEMPLATES, WIDGET_STATS } = await import('../widgetRegistry')
+    const STATS_ONLY_ID = '__stats_only_no_endpoint__'
+    const BROKEN_STAT_ID = '__broken_stat__'
+    ;(WIDGET_STATS as Record<string, unknown>)[BROKEN_STAT_ID] = {
+      id: BROKEN_STAT_ID,
+      displayName: 'Broken',
+      apiEndpoint: '', // missing endpoint is the failure mode under test
+      dataPath: 'foo',
+      color: '#fff',
+      format: 'number',
+    }
+    ;(WIDGET_TEMPLATES as Record<string, unknown>)[STATS_ONLY_ID] = {
+      id: STATS_ONLY_ID,
+      displayName: 'Stats Only',
+      description: 'test only',
+      cards: [],
+      stats: [BROKEN_STAT_ID],
+      layout: 'row',
+    }
+    try {
+      expect(() => generateTemplateWidget(STATS_ONLY_ID, 'http://localhost:8080'))
+        .toThrow(/no resolvable data endpoint/)
+    } finally {
+      delete (WIDGET_TEMPLATES as Record<string, unknown>)[STATS_ONLY_ID]
+      delete (WIDGET_STATS as Record<string, unknown>)[BROKEN_STAT_ID]
+    }
+  })
+
+  it('generated stat widget extractor supports bracket/index notation for dataPath', async () => {
+    const { WIDGET_STATS } = await import('../widgetRegistry')
+    const BRACKET_STAT_ID = '__bracket_stat__'
+    ;(WIDGET_STATS as Record<string, unknown>)[BRACKET_STAT_ID] = {
+      id: BRACKET_STAT_ID,
+      displayName: 'Bracket Stat',
+      apiEndpoint: '/api/test',
+      dataPath: 'items[0].foo.bar',
+      color: '#fff',
+      format: 'number',
+    }
+    try {
+      const code = generateStatWidget([BRACKET_STAT_ID], 'http://localhost:8080')
+      // The generated getData helper should NOT be the naive split('.')
+      // that would produce src['items[0]'] and always return 0.
+      expect(code).not.toMatch(/path\.split\('\.'\)\.reduce\(/)
+      // It should include the bracket-normalization we introduced.
+      expect(code).toMatch(/replace\(\/\\\[/)
+      // The dataPath must still be passed through literally.
+      expect(code).toContain("getData('items[0].foo.bar', data)")
+
+      // And functionally: evaluate the generated helper to confirm it
+      // walks bracket notation correctly. We extract the helper by name
+      // and eval it in isolation.
+      const helperMatch = code.match(/const getData = \(path, src\) => \{[\s\S]*?\n {2}\};/)
+      expect(helperMatch).toBeTruthy()
+      const getData = new Function(`${helperMatch![0]}; return getData;`)() as (
+        path: string,
+        src: unknown,
+      ) => unknown
+      const sample = { items: [{ foo: { bar: 42 } }] }
+      expect(getData('items[0].foo.bar', sample)).toBe(42)
+      expect(getData('missing.path', sample)).toBe(0)
+    } finally {
+      delete (WIDGET_STATS as Record<string, unknown>)[BRACKET_STAT_ID]
+    }
+  })
+})

--- a/web/src/lib/widgets/codeGenerator.ts
+++ b/web/src/lib/widgets/codeGenerator.ts
@@ -419,20 +419,27 @@ ${wrapOpen}
         </div>${wrapClose}
 };`
 
-    default:
+    default: {
+      // Emit the title as a JSX *text node* (braced string expression) rather
+      // than interpolating it raw into the JSX source. That way, even if a
+      // user-controlled displayName contains markup like
+      // `</div><script>alert(1)</script>`, React renders it as plain text and
+      // escapes it instead of compiling it as live JSX.
+      const safeTitleExpr = `{${JSON.stringify(title)}}`
       return `
 export const render = ({ output }) => {${parseBlock}
 
   if (error) {${wrapOpen}
-        <div style={styles.cardTitle}>${title}</div>
+        <div style={styles.cardTitle}>${safeTitleExpr}</div>
         <span style={{color: styles.colors.error}}>Error: {error}</span>${wrapClose}
   }
 ${wrapOpen}
-        <div style={styles.cardTitle}>${title}</div>
+        <div style={styles.cardTitle}>${safeTitleExpr}</div>
         <pre style={{fontSize: '10px', overflow: 'auto', maxHeight: '100px'}}>
           {JSON.stringify(data, null, 2)}
         </pre>${wrapClose}
 };`
+    }
   }
 }
 
@@ -490,10 +497,23 @@ export const render = ({ output }) => {
     return <div style={styles.row}><span style={{color: styles.colors.error}}>Error</span></div>;
   }
 
-  // Extract values from API responses
+  // Extract values from API responses.
+  // Supports dotted paths ('a.b.c') AND bracket notation for array/numeric
+  // index access ('items[0].foo.bar'). Without the bracket handling, a path
+  // like 'items[0]' would be walked as src['items[0]'] which is always
+  // undefined and silently returns 0, making stat widgets look broken.
   const getData = (path, src) => {
     try {
-      return path.split('.').reduce((o, k) => o[k], src) || 0;
+      const tokens = String(path)
+        .replace(/\\[(\\w+)\\]/g, '.$1')
+        .split('.')
+        .filter(Boolean);
+      let cur = src;
+      for (const t of tokens) {
+        if (cur == null) return 0;
+        cur = cur[t];
+      }
+      return cur ?? 0;
     } catch {
       return 0;
     }
@@ -549,8 +569,19 @@ export function generateTemplateWidget(
     }
   })
 
-  // For templates, use the first endpoint (primary data source)
-  const curlUrl = `${apiEndpoint}${allEndpoints[0]}`
+  // For templates, use the first endpoint (primary data source). Templates
+  // that contain ONLY stats (no cards) and whose stats expose no
+  // apiEndpoint previously produced a curl command of the form
+  // `<apiEndpoint>undefined`, which silently 404'd at runtime. Fall back to
+  // the first stat's endpoint when cards are empty, and throw a clear error
+  // if nothing at all is resolvable so callers see the problem immediately.
+  const firstEndpoint = allEndpoints[0]
+  if (!firstEndpoint) {
+    throw new Error(
+      `Template "${templateId}" has no resolvable data endpoint (no cards and no stat.apiEndpoint)`,
+    )
+  }
+  const curlUrl = `${apiEndpoint}${firstEndpoint}`
 
   return `/**
  * ${template.displayName} Widget


### PR DESCRIPTION
## Summary

Fifteen-issue fixup wave across widget codegen, card runtime, route/YouTube helpers, stats persistence, and a Go race. Security-adjacent encoding fixes, one Rules-of-Hooks correction, one data race, plus compiler/test gaps.

## Fixes

- Fixes #6694 — PredictionWorker.loggedClusterError race (now atomic.Bool + CompareAndSwap)
- Fixes #6695 — getCustomDashboardRoute: encode id
- Fixes #6696 — YouTube URL helpers: encode videoId
- Fixes #6697 — hasUnifiedConfig: hasOwnProperty instead of in
- Fixes #6698 — tests for #6695 and #6696 encoding
- Fixes #6699 — validateCardInstallMap() surfaces dead install-map keys
- Fixes #6700 — CardRuntime snapshots the data hook via lazy useState so Rules of Hooks can't break across renders
- Fixes #6701 — column align values validated against left/center/right allowlist
- Fixes #6702 — date comparator treats NaN as MAX_SAFE_INTEGER (sorts to end, stable)
- Fixes #6703 — template widget throws when no endpoint is resolvable (stats-only-with-no-endpoint case)
- Fixes #6704 — generated stat widget extractor supports bracket notation (items[0].foo.bar)
- Fixes #6705 — generated JSX emits titles as JSON.stringify(...) brace expressions so hostile displayNames cannot inject live <script>
- Fixes #6706 — regression tests for #6703 and #6704
- Fixes #6707 — drop _ = t noop line in pkg/mcp/client.go
- Fixes #6708 — stats collapsed-state persistence now matches the '-stats-collapsed' key semantics across StatsRuntime, StatsOverview, and UnifiedStatsSection

## Test plan

- [x] npm run build (green, post-build safety checks pass)
- [x] vitest run on touched suites — 236 passed
- [x] full src/lib + src/components + ui-ux-standards suite — 6523 passed (one pre-existing flaky kubectlProxy timer test under concurrency, unrelated)
- [x] go build ./... / go vet ./... — clean
- [x] go test ./pkg/agent/... ./pkg/mcp/... -race -timeout 180s — pass
- [x] eslint on touched files — no new errors