### PR TITLE
fix(a11y): MissionControlDialog focus trap, aria-live regions, keyboard nav for SVG/stepper/dropdown (#6738-#6745)

### DIFF
--- a/web/src/components/layout/mission-sidebar/MissionChat.tsx
+++ b/web/src/components/layout/mission-sidebar/MissionChat.tsx
@@ -450,8 +450,19 @@ export function MissionChat({ mission, isFullScreen = false, fontSize = 'base' a
                 : t('missionChat.terminateSession', { defaultValue: 'Terminate Session' })}
             </button>
           )}
-          <div className={cn('flex items-center gap-1', config.color)}>
-            <StatusIcon className={cn('w-4 h-4', (mission.status === 'running' || mission.status === 'cancelling') && 'animate-spin')} />
+          {/* issue 6741 — aria-live=polite so status transitions (running → completed,
+              blocked, failed, etc.) are announced by screen readers. */}
+          <div
+            className={cn('flex items-center gap-1', config.color)}
+            role="status"
+            aria-live="polite"
+            aria-atomic="true"
+            aria-label={`Mission status: ${config.label}`}
+          >
+            <StatusIcon
+              className={cn('w-4 h-4', (mission.status === 'running' || mission.status === 'cancelling') && 'animate-spin')}
+              aria-hidden="true"
+            />
             <span className="text-xs">{config.label}</span>
           </div>
         </div>
@@ -500,9 +511,16 @@ export function MissionChat({ mission, isFullScreen = false, fontSize = 'base' a
       )}
 
       {/* Messages - using memoized component for better scroll performance */}
+      {/* issue 6740 — role=log + aria-live=polite so screen readers announce streaming AI
+          tokens as they arrive. aria-atomic=false keeps announcements incremental. */}
       <div
         ref={messagesContainerRef}
         onScroll={handleScroll}
+        role="log"
+        aria-live="polite"
+        aria-atomic="false"
+        aria-relevant="additions text"
+        aria-label="Mission chat messages"
         className="flex-1 overflow-y-auto scroll-enhanced p-4 space-y-4 min-h-[150px] min-w-0"
       >
         {/* Inline Run button + editable mission description/steps for saved missions (#3917, #4273) */}

--- a/web/src/components/layout/mission-sidebar/MissionSidebar.tsx
+++ b/web/src/components/layout/mission-sidebar/MissionSidebar.tsx
@@ -565,10 +565,14 @@ export function MissionSidebar() {
   return (
     <>
       {/* Mobile backdrop */}
+      {/* issue 6742 — tabIndex=-1 removes the backdrop from the Tab order, aria-hidden
+          hides it from assistive tech. The sidebar itself handles close semantics. */}
       {isMobile && isSidebarOpen && (
         <div
           className="fixed inset-0 bg-black/60 backdrop-blur-sm z-overlay md:hidden"
           onClick={closeSidebar}
+          tabIndex={-1}
+          aria-hidden="true"
         />
       )}
       {/* Tablet backdrop — the sidebar renders as an overlay at < lg so main
@@ -577,6 +581,8 @@ export function MissionSidebar() {
         <div
           className="fixed inset-0 bg-black/40 backdrop-blur-sm z-overlay lg:hidden"
           onClick={closeSidebar}
+          tabIndex={-1}
+          aria-hidden="true"
         />
       )}
 

--- a/web/src/components/mission-control/MissionControlDialog.tsx
+++ b/web/src/components/mission-control/MissionControlDialog.tsx
@@ -10,7 +10,8 @@
  * Phase 3: Flight Plan (SVG blueprint + deploy)
  */
 
-import { useEffect, useCallback, useState, lazy, Suspense } from 'react'
+import { useEffect, useCallback, useRef, useState, lazy, Suspense } from 'react'
+import { useModalFocusTrap } from '../../lib/modals/useModalNavigation'
 import { motion, AnimatePresence } from 'framer-motion'
 import {
   X,
@@ -67,10 +68,28 @@ const PHASE_STEPS: {
   },
 ]
 
+/** Fallback a11y label when the user hasn't entered a mission title yet (issue 6745) */
+const DEFAULT_DIALOG_ARIA_LABEL = 'Mission control dialog'
+
 export function MissionControlDialog({ open, onClose }: MissionControlDialogProps) {
   const mc = useMissionControl()
   const { showToast } = useToast()
   const { state } = mc
+  // issue 6738 — Ref used by useModalFocusTrap to keep Tab/Shift+Tab inside the dialog
+  const dialogRef = useRef<HTMLDivElement>(null)
+  useModalFocusTrap(dialogRef, open)
+  // issue 6738 — Restore focus to the element that opened the dialog on close
+  const previouslyFocusedRef = useRef<HTMLElement | null>(null)
+  useEffect(() => {
+    if (open) {
+      previouslyFocusedRef.current = document.activeElement as HTMLElement | null
+      return
+    }
+    const prev = previouslyFocusedRef.current
+    if (prev && typeof prev.focus === 'function') {
+      prev.focus()
+    }
+  }, [open])
 
   // Escape to close
   const handleKeyDown = useCallback(
@@ -167,9 +186,10 @@ export function MissionControlDialog({ open, onClose }: MissionControlDialogProp
 
           {/* ── Modal panel ───────────────────────────────────────── */}
           <motion.div
+            ref={dialogRef}
             role="dialog"
             aria-modal="true"
-            aria-label={state.title || 'Mission Control'}
+            aria-label={state.title || DEFAULT_DIALOG_ARIA_LABEL}
             data-testid="mission-control-dialog"
             className="fixed z-modal flex flex-col bg-background rounded-xl border border-border shadow-2xl shadow-black/30 overflow-hidden"
             style={{
@@ -212,7 +232,23 @@ export function MissionControlDialog({ open, onClose }: MissionControlDialogProp
               </div>
 
               {/* ── Stepper ─────────────────────────────────────────── */}
-              <nav className="hidden md:flex items-center gap-1">
+              {/* issue 6739 — role=tablist + Arrow key handling so the stepper is keyboard navigable,
+                  especially on mobile where there's no persistent Next/Back focus path. */}
+              <nav
+                className="hidden md:flex items-center gap-1"
+                role="tablist"
+                aria-label="Mission control phases"
+                onKeyDown={(e) => {
+                  if (isLaunching || isComplete) return
+                  if (e.key !== 'ArrowLeft' && e.key !== 'ArrowRight') return
+                  e.preventDefault()
+                  const delta = e.key === 'ArrowRight' ? 1 : -1
+                  const nextIdx = Math.max(0, Math.min(highestReached, currentStepIndex + delta))
+                  if (nextIdx !== currentStepIndex) {
+                    mc.setPhase(PHASE_STEPS[nextIdx].key)
+                  }
+                }}
+              >
                 {PHASE_STEPS.map((step, i) => {
                   const isCurrent = step.key === state.phase
                   const isPast = currentStepIndex > i
@@ -220,10 +256,17 @@ export function MissionControlDialog({ open, onClose }: MissionControlDialogProp
                   return (
                     <div key={step.key} className="flex items-center gap-1">
                       {i > 0 && (
-                        <ChevronRight className="w-3 h-3 text-muted-foreground/40 mx-1" />
+                        <ChevronRight
+                          className="w-3 h-3 text-muted-foreground/40 mx-1"
+                          aria-hidden="true"
+                        />
                       )}
                       <button
                         data-testid={`mission-control-phase-${i + 1}`}
+                        role="tab"
+                        aria-selected={isCurrent}
+                        aria-controls={`mission-control-phase-panel-${step.key}`}
+                        tabIndex={isCurrent ? 0 : -1}
                         onClick={() => {
                           if (i <= highestReached && !isLaunchOrComplete) mc.setPhase(step.key)
                         }}
@@ -288,7 +331,11 @@ export function MissionControlDialog({ open, onClose }: MissionControlDialogProp
             </header>
 
             {/* ── Content ────────────────────────────────────────────── */}
-            <div className="flex-1 overflow-hidden">
+            <div
+              className="flex-1 overflow-hidden"
+              id={`mission-control-phase-panel-${state.phase}`}
+              role="tabpanel"
+            >
               <AnimatePresence mode="wait">
                 {state.phase === 'define' && (
                   <PhaseWrapper key="define">

--- a/web/src/components/mission-control/PayloadCard.tsx
+++ b/web/src/components/mission-control/PayloadCard.tsx
@@ -3,7 +3,7 @@
  * Shows GitHub avatar, maturity badge, category gradient, priority, and remove button.
  */
 
-import { useState, useRef } from 'react'
+import { useState, useRef, useEffect } from 'react'
 import { createPortal } from 'react-dom'
 import { motion } from 'framer-motion'
 import { X, Star, ChevronDown, ArrowLeftRight } from 'lucide-react'
@@ -63,6 +63,20 @@ export function PayloadCard({ project, onRemove, onUpdatePriority, onHover, onCl
   const [imgFailed, setImgFailed] = useState(false)
   const [showPriorityMenu, setShowPriorityMenu] = useState(false)
   const [showDeps, setShowDeps] = useState(false)
+
+  // issue 6743 — Dismiss the priority dropdown when the user presses Escape. Without
+  // this, keyboard users had no way to close the menu once opened.
+  useEffect(() => {
+    if (!showPriorityMenu) return
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        e.stopPropagation()
+        setShowPriorityMenu(false)
+      }
+    }
+    document.addEventListener('keydown', handleKeyDown)
+    return () => document.removeEventListener('keydown', handleKeyDown)
+  }, [showPriorityMenu])
   const depRef = useRef<HTMLSpanElement>(null)
   const gradient = getCategoryGradient(project.category)
   const maturity = project.maturity ? MATURITY_CONFIG[project.maturity] : null

--- a/web/src/components/mission-control/svg/ClusterZone.tsx
+++ b/web/src/components/mission-control/svg/ClusterZone.tsx
@@ -158,16 +158,32 @@ export function ClusterZone({
   const showNetwork = overlay === 'network'
   const showSecurity = overlay === 'security'
 
+  // issue 6744 — Stable hover payload reused by mouse + keyboard handlers
+  const hoverInfo = {
+    name, provider, nodeCount, cpuCores, cpuUsage,
+    memGB, memUsage, storageGB, gpuCount, tpuCount,
+    pvcCount, pvcBoundCount, podCount, rect,
+  }
+
   return (
     <motion.g
       initial={{ opacity: 0, scale: 0.9 }}
       animate={{ opacity: 1, scale: 1 }}
       transition={{ duration: 0.5, delay: index * 0.15 }}
-      onMouseEnter={() => onHover?.({
-        name, provider, nodeCount, cpuCores, cpuUsage,
-        memGB, memUsage, storageGB, gpuCount, tpuCount,
-        pvcCount, pvcBoundCount, podCount, rect,
-      })}
+      /* issue 6744 — Make cluster zones keyboard-focusable so screen-reader /
+         keyboard users can navigate the SVG blueprint. */
+      tabIndex={0}
+      role="button"
+      aria-label={`Cluster ${name}${provider ? `, provider ${provider}` : ''}${nodeCount != null ? `, ${nodeCount} nodes` : ''}`}
+      onFocus={() => onHover?.(hoverInfo)}
+      onBlur={() => onHover?.(null)}
+      onKeyDown={(e) => {
+        if (e.key === 'Enter' || e.key === ' ') {
+          e.preventDefault()
+          onHover?.(hoverInfo)
+        }
+      }}
+      onMouseEnter={() => onHover?.(hoverInfo)}
       onMouseLeave={() => onHover?.(null)}
     >
       {/* Zone background — fully opaque */}

--- a/web/src/components/mission-control/svg/ProjectNode.tsx
+++ b/web/src/components/mission-control/svg/ProjectNode.tsx
@@ -149,6 +149,13 @@ export function ProjectNode({
     }
   }, [name, _onDragStart, _onDragEnd])
 
+  // issue 6744 — Memoized hover info so focus/blur/keydown handlers can share a stable payload
+  const hoverInfo = {
+    name, displayName, category, status, isRequired, installed,
+    reason, dependencies, kbPath, maturity, priority,
+    cx, cy, radius,
+  }
+
   return (
     <motion.g
       ref={dragRef}
@@ -160,11 +167,21 @@ export function ProjectNode({
         opacity: { duration: 0.1 },
       }}
       style={{ transformOrigin: `${cx}px ${cy}px`, pointerEvents: 'all' as const }}
-      onMouseEnter={() => onHover?.({
-        name, displayName, category, status, isRequired, installed,
-        reason, dependencies, kbPath, maturity, priority,
-        cx, cy, radius,
-      })}
+      /* issue 6744 — SVG nodes must opt in to keyboard focus explicitly. tabIndex=0
+         makes the group focusable; role=button + aria-label expose it to AT;
+         Enter/Space surfaces the same hover payload mouse users see. */
+      tabIndex={0}
+      role="button"
+      aria-label={`${displayName} — ${category}${installed ? ', installed' : ''}${isRequired ? ', required' : ''}`}
+      onFocus={() => onHover?.(hoverInfo)}
+      onBlur={() => onHover?.(null)}
+      onKeyDown={(e) => {
+        if (e.key === 'Enter' || e.key === ' ') {
+          e.preventDefault()
+          onHover?.(hoverInfo)
+        }
+      }}
+      onMouseEnter={() => onHover?.(hoverInfo)}
       onMouseLeave={() => onHover?.(null)}
     >
       {/* Invisible hit target — ensures mouse events fire even when dimmed */}


### PR DESCRIPTION
## Summary

Eight surgical accessibility fixes across Mission Control. No behavior changes for mouse users; adds keyboard + screen-reader parity.

Fixes #6738
Fixes #6739
Fixes #6740
Fixes #6741
Fixes #6742
Fixes #6743
Fixes #6744
Fixes #6745

## Changes

- **#6738** MissionControlDialog uses useModalFocusTrap + restores focus to the opener on close.
- **#6739** Stepper exposes role=tablist with per-tab role=tab/aria-selected/roving tabIndex; ArrowLeft/Right navigates within highestReached.
- **#6740** MissionChat messages container: role=log aria-live=polite aria-atomic=false for streaming AI tokens.
- **#6741** Mission status indicator: role=status aria-live=polite announces transitions.
- **#6742** MissionSidebar mobile+tablet backdrops get tabIndex=-1 + aria-hidden=true.
- **#6743** PayloadCard priority dropdown dismisses on Escape.
- **#6744** ProjectNode + ClusterZone SVG groups: tabIndex=0, role=button, descriptive aria-label, Enter/Space/focus surface hover payload.
- **#6745** Dialog aria-label falls back to "Mission control dialog" when title empty.

## Test plan

- [x] npm run build passes
- [x] vitest mission-control + ui-ux-standards passes (32/32)
- [x] npm run lint no new errors in modified files
- [ ] Manual: Tab cycles inside dialog; cannot reach page behind
- [ ] Manual: ArrowLeft/Right on stepper moves between reachable phases
- [ ] Manual: Escape dismisses PayloadCard priority dropdown
- [ ] Manual: VoiceOver announces streaming chat tokens + mission status changes
- [ ] Manual: Tab lands on SVG cluster/project nodes; Enter/Space shows info panel