### PR TITLE
fix: PR #6734 followups — comparator test, empty-string endpoint, install-map runtime validation (#6747, #6748)

### DIFF
--- a/web/src/lib/cards/__tests__/cardHooks.test.ts
+++ b/web/src/lib/cards/__tests__/cardHooks.test.ts
@@ -192,12 +192,52 @@ describe('commonComparators', () => {
       ).toBeLessThan(0)
     })
 
-    it('handles invalid dates (NaN comparison)', () => {
+    // #6748 — commonComparators.date now sorts invalid dates to the END of
+    // ascending order using Number.MAX_SAFE_INTEGER as a sentinel instead of
+    // producing NaN comparisons (which violated the Array.prototype.sort
+    // contract and caused non-deterministic ordering). See the date comparator
+    // definition in cardHooks.ts for the rationale.
+    it('sorts an invalid date AFTER a valid date in ascending order', () => {
       const result = compare(
         { createdAt: 'not-a-date' },
         { createdAt: '2024-01-01' }
       )
-      expect(Number.isNaN(result)).toBe(true)
+      expect(result).toBeGreaterThan(0)
+      expect(Number.isNaN(result)).toBe(false)
+    })
+
+    it('sorts a valid date BEFORE an invalid date in ascending order', () => {
+      const result = compare(
+        { createdAt: '2024-01-01' },
+        { createdAt: 'not-a-date' }
+      )
+      expect(result).toBeLessThan(0)
+      expect(Number.isNaN(result)).toBe(false)
+    })
+
+    it('treats two invalid dates as equal', () => {
+      const result = compare(
+        { createdAt: 'not-a-date' },
+        { createdAt: 'also-not-a-date' }
+      )
+      expect(result).toBe(0)
+    })
+
+    it('produces a stable deterministic sort order with invalid dates mixed in', () => {
+      const items = [
+        { createdAt: 'garbage' },
+        { createdAt: '2024-06-01' },
+        { createdAt: '2024-01-01' },
+        { createdAt: 'also-garbage' },
+      ]
+      const sorted = [...items].sort(compare)
+      // Valid dates first, in chronological order; invalid dates tail.
+      expect(sorted[0].createdAt).toBe('2024-01-01')
+      expect(sorted[1].createdAt).toBe('2024-06-01')
+      // Remaining two are the invalid entries (order between them is arbitrary
+      // but they must both trail the valid dates).
+      expect(['garbage', 'also-garbage']).toContain(sorted[2].createdAt)
+      expect(['garbage', 'also-garbage']).toContain(sorted[3].createdAt)
     })
   })
 })

--- a/web/src/lib/cards/cardInstallMap.ts
+++ b/web/src/lib/cards/cardInstallMap.ts
@@ -130,3 +130,4 @@ export function validateCardInstallMap(registeredCardTypes: readonly string[]): 
   }
   return unknown
 }
+

--- a/web/src/lib/widgets/__tests__/codeGenerator.test.ts
+++ b/web/src/lib/widgets/__tests__/codeGenerator.test.ts
@@ -298,6 +298,98 @@ describe('generator hardening', () => {
     }
   })
 
+  // #6747 — When a template's first stat/card exposes an empty-string
+  // apiEndpoint but a later entry has a valid one, the generator must pick
+  // the valid endpoint. Previously it picked the empty string and fell
+  // through to the "no resolvable endpoint" throw even though a valid
+  // endpoint was available.
+  it('skips empty-string endpoints and uses the first VALID endpoint', async () => {
+    const { WIDGET_TEMPLATES, WIDGET_STATS } = await import('../widgetRegistry')
+    const MIXED_ID = '__mixed_empty_first__'
+    const EMPTY_STAT_ID = '__empty_first_stat__'
+    const VALID_STAT_ID = '__valid_second_stat__'
+    const VALID_ENDPOINT = '/api/valid-second'
+    ;(WIDGET_STATS as Record<string, unknown>)[EMPTY_STAT_ID] = {
+      id: EMPTY_STAT_ID,
+      displayName: 'Empty First',
+      apiEndpoint: '',
+      dataPath: 'foo',
+      color: '#fff',
+      format: 'number',
+    }
+    ;(WIDGET_STATS as Record<string, unknown>)[VALID_STAT_ID] = {
+      id: VALID_STAT_ID,
+      displayName: 'Valid Second',
+      apiEndpoint: VALID_ENDPOINT,
+      dataPath: 'bar',
+      color: '#fff',
+      format: 'number',
+    }
+    ;(WIDGET_TEMPLATES as Record<string, unknown>)[MIXED_ID] = {
+      id: MIXED_ID,
+      displayName: 'Mixed',
+      description: 'empty first stat, valid second stat',
+      cards: [],
+      stats: [EMPTY_STAT_ID, VALID_STAT_ID],
+      layout: 'row',
+    }
+    try {
+      const code = generateTemplateWidget(MIXED_ID, 'http://localhost:8080')
+      // The curl command must use the valid endpoint, not an empty string.
+      expect(code).toContain(`http://localhost:8080${VALID_ENDPOINT}`)
+      // And must NOT contain the bug signature: an unterminated curl that
+      // ends with the base URL followed by whitespace/quote (i.e. empty path).
+      expect(code).not.toMatch(/curl -s[^"]*http:\/\/localhost:8080\s/)
+    } finally {
+      delete (WIDGET_TEMPLATES as Record<string, unknown>)[MIXED_ID]
+      delete (WIDGET_STATS as Record<string, unknown>)[EMPTY_STAT_ID]
+      delete (WIDGET_STATS as Record<string, unknown>)[VALID_STAT_ID]
+    }
+  })
+
+  // #6747 — When every stat in a template exposes an empty-string
+  // apiEndpoint, the generator must throw the clear "no resolvable data
+  // endpoint" error rather than silently producing a curl with a bare base
+  // URL.
+  it('throws when every endpoint is an empty string', async () => {
+    const { WIDGET_TEMPLATES, WIDGET_STATS } = await import('../widgetRegistry')
+    const ALL_EMPTY_ID = '__all_empty_endpoints__'
+    const EMPTY_A = '__empty_stat_a__'
+    const EMPTY_B = '__empty_stat_b__'
+    ;(WIDGET_STATS as Record<string, unknown>)[EMPTY_A] = {
+      id: EMPTY_A,
+      displayName: 'Empty A',
+      apiEndpoint: '',
+      dataPath: 'foo',
+      color: '#fff',
+      format: 'number',
+    }
+    ;(WIDGET_STATS as Record<string, unknown>)[EMPTY_B] = {
+      id: EMPTY_B,
+      displayName: 'Empty B',
+      apiEndpoint: '',
+      dataPath: 'bar',
+      color: '#fff',
+      format: 'number',
+    }
+    ;(WIDGET_TEMPLATES as Record<string, unknown>)[ALL_EMPTY_ID] = {
+      id: ALL_EMPTY_ID,
+      displayName: 'All Empty',
+      description: 'all stats have empty endpoints',
+      cards: [],
+      stats: [EMPTY_A, EMPTY_B],
+      layout: 'row',
+    }
+    try {
+      expect(() => generateTemplateWidget(ALL_EMPTY_ID, 'http://localhost:8080'))
+        .toThrow(/no resolvable data endpoint/)
+    } finally {
+      delete (WIDGET_TEMPLATES as Record<string, unknown>)[ALL_EMPTY_ID]
+      delete (WIDGET_STATS as Record<string, unknown>)[EMPTY_A]
+      delete (WIDGET_STATS as Record<string, unknown>)[EMPTY_B]
+    }
+  })
+
   it('throws a clear error when a stats-only template has no resolvable endpoint', async () => {
     const { WIDGET_TEMPLATES, WIDGET_STATS } = await import('../widgetRegistry')
     const STATS_ONLY_ID = '__stats_only_no_endpoint__'

--- a/web/src/lib/widgets/codeGenerator.ts
+++ b/web/src/lib/widgets/codeGenerator.ts
@@ -575,7 +575,16 @@ export function generateTemplateWidget(
   // `<apiEndpoint>undefined`, which silently 404'd at runtime. Fall back to
   // the first stat's endpoint when cards are empty, and throw a clear error
   // if nothing at all is resolvable so callers see the problem immediately.
-  const firstEndpoint = allEndpoints[0]
+  //
+  // #6747 — Skip empty-string endpoints when selecting the primary. Previously
+  // `allEndpoints[0]` could be `''` if the first card/stat exposed an empty
+  // apiEndpoint, which would then pass the `if (!firstEndpoint)` guard as
+  // falsy and throw even when a valid endpoint existed later in the list.
+  // Filter to non-empty strings so the first VALID endpoint wins.
+  const validEndpoints = allEndpoints.filter(
+    (ep): ep is string => typeof ep === 'string' && ep.length > 0,
+  )
+  const firstEndpoint = validEndpoints[0]
   if (!firstEndpoint) {
     throw new Error(
       `Template "${templateId}" has no resolvable data endpoint (no cards and no stat.apiEndpoint)`,

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -173,6 +173,23 @@ enableMocking()
     // Register unified card data hooks (background — ~300 KB chunk)
     import('./lib/unified/registerHooks').catch(() => { /* ignore — hook registration is non-critical */ })
 
+    // #6747 — Validate CARD_INSTALL_MAP keys against the live card registry
+    // at startup. The validator already logs a single console.warn listing
+    // any dead aliases (typos, cards retired from the registry but still
+    // present in the install map). We call it ONCE here from bootstrap so
+    // the check actually runs at runtime instead of only in tests. Dev-only
+    // so production bundles don't spend cycles on it.
+    if (import.meta.env.DEV) {
+      Promise.all([
+        import('./lib/cards/cardInstallMap'),
+        import('./config/cards'),
+      ])
+        .then(([{ validateCardInstallMap }, { getUnifiedCardTypes }]) => {
+          validateCardInstallMap(getUnifiedCardTypes())
+        })
+        .catch(() => { /* ignore — validation is non-critical diagnostic */ })
+    }
+
     // Prefetch route chunks for the user's top 5 most-visited dashboards.
     // Uses requestIdleCallback to avoid competing with initial render.
     prefetchTopDashboards(window.location.pathname)


### PR DESCRIPTION
## Summary

Three cleanups for PR #6734:

### 1. #6748 — commonComparators.date test failure
PR #6734 (#6702) changed the date comparator to sort invalid dates to the end of ascending order using Number.MAX_SAFE_INTEGER as a sentinel instead of letting NaN leak into Array.sort (which violates the sort contract). The existing handles-invalid-dates test still asserted the old NaN behavior and failed.

Replaced with four tests pinning the new contract:
- invalid date sorts AFTER a valid date
- valid date sorts BEFORE an invalid date
- two invalid dates compare equal
- mixed-array sort leaves valid dates chronologically with invalid entries at the tail

### 2. #6747 item A — codeGenerator.ts empty-string endpoint
generateTemplateWidget() previously picked allEndpoints[0] as the primary data source. If the first card/stat exposed apiEndpoint: '', the generator would pick that, fall through the falsy guard, and throw "no resolvable data endpoint" even when a later entry had a valid endpoint.

Fix: filter allEndpoints to non-empty strings before selection so the first VALID endpoint wins. Added two tests — mixed (empty first, valid second) uses the valid one, all-empty still throws the clear error.

### 3. #6747 item B — validateCardInstallMap had no runtime call site
PR #6734 (#6699) added validateCardInstallMap() to flag dead install-map aliases (typos, retired cards), but it was only invoked from tests.

Wired into main.tsx bootstrap in the post-render background block, gated on import.meta.env.DEV so production bundles skip it. Uses dynamic import() of cardInstallMap and config/cards so it stays off the critical-path chunk.

## Test plan
- [x] vitest run src/lib/cards src/lib/widgets src/test/ui-ux-standards.test.ts — 497 passed
- [x] npm run build — clean, post-build safety checks pass
- [x] npm run lint — no new errors/warnings from changed files
- [ ] CI build + lint + preview

Fixes #6747
Fixes #6748