### PR TITLE
fix(missions): state reliability — schema, quota, cross-tab, generation guards + PR #6746 followups (#6664-#6672, #6749)

### DIFF
--- a/web/src/components/mission-control/useMissionControl.ts
+++ b/web/src/components/mission-control/useMissionControl.ts
@@ -24,6 +24,20 @@ import type {
 const STORAGE_KEY = 'kc_mission_control_state'
 // Wizard state expires after 7 days to avoid persisting abandoned mission drafts
 const WIZARD_STATE_TTL_MS = 7 * 24 * 60 * 60 * 1000
+/**
+ * #6664 — Schema version for persisted Mission Control state. Bump when the
+ * shape of `MissionControlState` changes in a backward-incompatible way.
+ * Mismatched versions are cleared silently on load so stale payloads from
+ * older builds never flow into downstream type-unsafe code paths.
+ */
+const PERSISTED_SCHEMA_VERSION = 1
+/**
+ * #6665 — Key used to surface a "your wizard draft may be lost" banner when
+ * persistState() hits a quota error. Stored as an ephemeral flag in
+ * sessionStorage so the next render of the Mission Control dialog can read
+ * and display it once.
+ */
+const QUOTA_BANNER_KEY = 'kc_mission_control_quota_error'
 
 // ---------------------------------------------------------------------------
 // #6379 — Project-name sanitization (prompt injection defence)
@@ -139,6 +153,20 @@ const MAX_FENCE_BODY = 50_000
 interface PersistedStateEntry {
   state: Partial<MissionControlState>
   savedAt: number
+  /** #6664 — Schema version; missing or mismatched means discard. */
+  schemaVersion?: number
+}
+
+/**
+ * #6664 — Guard predicate for persisted state. A structurally valid JSON
+ * value (`42`, `"null"`, `[]`, etc.) would otherwise slip past the bare
+ * `JSON.parse` check and crash at the `'savedAt' in entry` lookup below
+ * with `TypeError: Cannot use 'in' operator to search for 'savedAt' in 42`.
+ * The surrounding `try/catch` swallowed that error and silently wiped the
+ * user's wizard draft, so we fail explicitly here with a warning.
+ */
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
 }
 
 function loadPersistedState(): Partial<MissionControlState> | null {
@@ -150,9 +178,38 @@ function loadPersistedState(): Partial<MissionControlState> | null {
       if (isDemoMode()) return getDemoMissionControlState()
       return null
     }
-    const entry = JSON.parse(raw) as PersistedStateEntry | Partial<MissionControlState>
+    const parsedRaw: unknown = JSON.parse(raw)
+    // #6664 — Reject non-object top-level values (numbers, strings, arrays,
+    // null) before the `in` operator is used below. Clear the corrupt key so
+    // a second load doesn't keep hitting this path, and log a warning so
+    // users notice their wizard draft was discarded.
+    if (!isPlainObject(parsedRaw)) {
+      console.warn(
+        `[MissionControl] issue 6664 — persisted state at "${STORAGE_KEY}" is not a plain object ` +
+        `(typeof=${typeof parsedRaw}, isArray=${Array.isArray(parsedRaw)}); clearing.`,
+      )
+      try { localStorage.removeItem(STORAGE_KEY) } catch { /* ignore */ }
+      if (isDemoMode()) return getDemoMissionControlState()
+      return null
+    }
+    const entry = parsedRaw as unknown as PersistedStateEntry | Partial<MissionControlState>
     // Support both new format (with savedAt timestamp) and legacy format (plain state)
     if ('savedAt' in entry && typeof entry.savedAt === 'number') {
+      // #6664 — Schema-version check. Unknown or mismatched versions get
+      // cleared. Legacy entries without schemaVersion are still accepted so
+      // existing sessions don't lose work on the rollout of this fix.
+      if (
+        entry.schemaVersion !== undefined &&
+        entry.schemaVersion !== PERSISTED_SCHEMA_VERSION
+      ) {
+        console.warn(
+          `[MissionControl] issue 6664 — persisted schema version ${entry.schemaVersion} ` +
+          `does not match current ${PERSISTED_SCHEMA_VERSION}; clearing.`,
+        )
+        try { localStorage.removeItem(STORAGE_KEY) } catch { /* ignore */ }
+        if (isDemoMode()) return getDemoMissionControlState()
+        return null
+      }
       // Check TTL — discard wizard state older than WIZARD_STATE_TTL_MS
       if (Date.now() - entry.savedAt > WIZARD_STATE_TTL_MS) {
         localStorage.removeItem(STORAGE_KEY)
@@ -177,12 +234,66 @@ function loadPersistedState(): Partial<MissionControlState> | null {
   }
 }
 
+/**
+ * #6665 — Detect a DOMException that represents a storage quota error.
+ * Matches both the named exception and the legacy numeric code 22 used by
+ * older Safari/WebKit builds. Mirrors the pattern used in `saveMissions`.
+ */
+function isQuotaExceededError(e: unknown): boolean {
+  return (
+    e instanceof DOMException &&
+    (e.name === 'QuotaExceededError' ||
+      e.name === 'NS_ERROR_DOM_QUOTA_REACHED' ||
+      e.code === 22)
+  )
+}
+
 function persistState(state: MissionControlState) {
   try {
-    const entry: PersistedStateEntry = { state, savedAt: Date.now() }
+    const entry: PersistedStateEntry = {
+      state,
+      savedAt: Date.now(),
+      schemaVersion: PERSISTED_SCHEMA_VERSION }
     localStorage.setItem(STORAGE_KEY, JSON.stringify(entry))
+  } catch (e) {
+    // #6665 — Do not silently swallow quota errors. Log a warning naming
+    // the wizard so the user can see which draft was at risk, and surface
+    // an ephemeral flag in sessionStorage so the Mission Control dialog
+    // can show a one-time banner on its next render. sessionStorage is
+    // used (not localStorage) because the flag is only meaningful for the
+    // current tab — and because localStorage is, by construction, the
+    // thing that just failed.
+    if (isQuotaExceededError(e)) {
+      const title = state.title || '(untitled mission)'
+      console.warn(
+        `[MissionControl] issue 6665 — localStorage quota exceeded while ` +
+        `persisting Mission Control wizard state for "${title}". Your ` +
+        `in-progress draft is not being persisted and will be lost on ` +
+        `reload unless space is freed.`,
+      )
+      try {
+        sessionStorage.setItem(QUOTA_BANNER_KEY, title)
+      } catch {
+        // sessionStorage may also be full or unavailable — nothing we can do.
+      }
+    } else {
+      console.error('[MissionControl] Failed to persist state:', e)
+    }
+  }
+}
+
+/**
+ * #6665 — Read and clear the quota-error banner flag. Returns the mission
+ * title that was being persisted when the quota error fired, or `null` if
+ * no banner is pending. Called by the Mission Control dialog on mount.
+ */
+export function consumePersistQuotaBanner(): string | null {
+  try {
+    const v = sessionStorage.getItem(QUOTA_BANNER_KEY)
+    if (v !== null) sessionStorage.removeItem(QUOTA_BANNER_KEY)
+    return v
   } catch {
-    // quota exceeded — silently ignore
+    return null
   }
 }
 
@@ -217,7 +328,7 @@ function makeInitialState(persisted?: Partial<MissionControlState> | null): Miss
  * fenced ```json blocks and returns the first one containing that key.
  * Falls back to the first parseable block otherwise.
  */
-export function extractJSON<T>(text: string, requiredKey?: string): T | null {
+export function extractJSON<T>(text: string, requiredKey?: string, warnKey?: string): T | null {
   // #6727 — Bounded inner repetition prevents catastrophic backtracking on
   // malformed input (e.g. an open fence with tens of thousands of body chars
   // and no close fence). `{0,MAX_FENCE_BODY}` caps the engine's work per
@@ -251,7 +362,7 @@ export function extractJSON<T>(text: string, requiredKey?: string): T | null {
   // for balanced braces, then return the last valid (and largest) parse.
   // This avoids the old greedy regex which grabbed from the first { to the
   // last } and failed when prose contained intermediate braces.  (#5505)
-  const blocks = extractBalancedBlocks(text)
+  const blocks = extractBalancedBlocks(text, warnKey)
   let best: T | null = null
   let bestLen = 0
   for (const block of blocks) {
@@ -276,21 +387,48 @@ export function extractJSON<T>(text: string, requiredKey?: string): T | null {
 }
 
 /**
+ * #6749-D — Deduped warn set for the `extractBalancedBlocks` oversize
+ * guard. During Mission Control streaming, `extractJSON` is re-invoked on
+ * every debounced chunk, so logging the #6723 guard on every call produced
+ * a flood of identical warnings. The set is keyed by caller-supplied
+ * tokens (typically a mission ID) so the warning fires once per mission
+ * instead of once per chunk. Cleared by `reset()` above via
+ * `oversizedWarnedRef`, and by `resetOversizedWarnings()` exported below.
+ */
+const oversizedWarnSet = new Set<string>()
+export function resetOversizedWarnings(): void {
+  oversizedWarnSet.clear()
+}
+
+/**
  * Scan `text` for top-level balanced `{ ... }` and `[ ... ]` blocks.
  * Returns them in order of appearance.  Handles nested braces correctly so
  * `{ "a": { "b": 1 } }` is returned as one block, not two.
+ *
+ * `warnKey` (#6749-D) is an optional de-dup token for the oversized-input
+ * warning path: the same caller (e.g. one mission ID) only logs the guard
+ * message once, not on every streamed chunk. If omitted, a legacy
+ * always-log token is used so existing callers retain their warning.
  */
-function extractBalancedBlocks(text: string): string[] {
+function extractBalancedBlocks(text: string, warnKey?: string): string[] {
   // #6723 — Refuse pathological inputs. The scanner is worst-case O(n²)
   // on inputs with many unclosed openers, which freezes the main thread
   // on 10 MB garbage payloads. Return early with a console warning so
   // upstream callers fall back to their regex path or fenced-block path.
   if (text.length > MAX_BALANCED_BLOCKS_INPUT) {
-    console.warn(
-      `[useMissionControl] extractBalancedBlocks: input too large ` +
-      `(${text.length} chars > ${MAX_BALANCED_BLOCKS_INPUT}), skipping scan ` +
-      `to avoid main-thread block (#6723).`
-    )
+    const key = warnKey ?? '__legacy__'
+    // #6749-D — Only log the first oversized hit per warnKey. Subsequent
+    // calls with the same key (streaming re-parses of the same mission)
+    // silently return [] without spamming the console.
+    if (!oversizedWarnSet.has(key)) {
+      oversizedWarnSet.add(key)
+      console.warn(
+        `[useMissionControl] extractBalancedBlocks: input too large ` +
+        `(${text.length} chars > ${MAX_BALANCED_BLOCKS_INPUT}), skipping scan ` +
+        `to avoid main-thread block (#6723). Further oversized inputs for ` +
+        `key "${key}" will be suppressed until reset.`
+      )
+    }
     return []
   }
 
@@ -367,7 +505,7 @@ export function useMissionControl() {
   const [state, setState] = useState<MissionControlState>(() =>
     makeInitialState(loadPersistedState())
   )
-  const { startMission, sendMessage, missions } = useMissions()
+  const { startMission, sendMessage, missions, dismissMission } = useMissions()
   const { releases: helmReleases } = useHelmReleases()
   const { clusters, isLoading: clustersLoading, lastUpdated: clustersLastUpdated } = useClusters()
   const lastParsedContentRef = useRef('')
@@ -492,6 +630,13 @@ export function useMissionControl() {
 
   useEffect(() => {
     if (!planningMission) return
+    // #6670 — After reset, the wizard's `planningMissionId` is cleared but
+    // the old mission object may still live in the useMissions context and
+    // deliver late streamed messages. If the wizard no longer owns a
+    // planning mission, drop the parse so stale AI output cannot pollute
+    // the fresh wizard state with ghost projects/assignments.
+    if (!state.planningMissionId) return
+    if (planningMission.id !== state.planningMissionId) return
     // #6384 item 3 — Gate the expensive parse on the debounced value being
     // non-empty. While the stream is actively arriving, `useDebouncedValue`
     // keeps returning the stale (possibly empty) value until the stream
@@ -507,7 +652,11 @@ export function useMissionControl() {
 
     // Try to parse structured data from the latest AI message
     if (state.phase === 'define') {
-      const parsed = extractJSON<{ projects?: PayloadProject[] }>(latest.content, 'projects')
+      const parsed = extractJSON<{ projects?: PayloadProject[] }>(
+        latest.content,
+        'projects',
+        state.planningMissionId ?? undefined,
+      )
       // #6725 — Schema guard. The AI occasionally returns
       // `{ "projects": { ... } }` (object) instead of
       // `{ "projects": [ ... ] }` (array). Without this guard, downstream
@@ -559,7 +708,7 @@ export function useMissionControl() {
         assignments?: ClusterAssignment[]
         phases?: DeployPhase[]
         warnings?: string[]
-      }>(latest.content, 'assignments')
+      }>(latest.content, 'assignments', state.planningMissionId ?? undefined)
       // #6726 — Schema guard. Same class of crash as #6725 for projects:
       // the AI can return `{ "assignments": { ... } }` instead of an array,
       // which immediately crashes the `.map(a => a.clusterName)` below.
@@ -600,11 +749,36 @@ export function useMissionControl() {
   }, [debouncedAssistantContent, state.phase, state.planningMissionId, planningMission?.status])
 
   // Update streaming state from mission status
+  //
+  // #6669 — A mission can transition directly to 'failed' / 'cancelled' /
+  // 'blocked' without passing through 'running' first (e.g. immediate
+  // WebSocket error, preflight rejection). Previously the streaming flag
+  // was only cleared when the status was 'running' === false AFTER first
+  // going true; an error right out of the gate left `aiStreaming: true`
+  // for the full AI_SUGGEST_TIMEOUT_MS (30s) while the Phase 1 panel spun
+  // with no visible error. Clear the flag immediately on any terminal
+  // state so the UI surfaces the error in the same tick.
   useEffect(() => {
     if (!planningMission) return
-    const isStreaming = planningMission.status === 'running'
+    const status = planningMission.status
+    const TERMINAL_STATES: ReadonlySet<typeof status> = new Set([
+      'failed',
+      'completed',
+      'cancelled',
+      'blocked',
+    ] as const)
+    const isStreaming = status === 'running'
+    const isTerminal = TERMINAL_STATES.has(status)
     if (isStreaming !== state.aiStreaming) {
       setState((prev) => ({ ...prev, aiStreaming: isStreaming }))
+    } else if (isTerminal && state.aiStreaming) {
+      // Defensive second-pass: if the streaming flag is still true on a
+      // terminal status (no intermediate 'running' ever observed), force it
+      // false. The above branch already handles the common case via the
+      // `isStreaming !== state.aiStreaming` compare, but a status that
+      // skips 'running' entirely means the effect never ran with
+      // `isStreaming === true`, so we clear it explicitly here (#6669).
+      setState((prev) => ({ ...prev, aiStreaming: false }))
     }
   }, [planningMission?.status, state.aiStreaming])
 
@@ -1003,6 +1177,18 @@ Order phases by dependency — prerequisites first. Each phase completes before 
   // ---------------------------------------------------------------------------
 
   const reset = () => {
+    // #6670 — Also dismiss the in-flight planning mission so late stream
+    // responses cannot pollute the freshly reset wizard. Without this, the
+    // old mission object kept delivering assistant messages that the parse
+    // effect above would happily splice into the new wizard state.
+    const prevPlanningMissionId = state.planningMissionId
+    if (prevPlanningMissionId) {
+      try { dismissMission(prevPlanningMissionId) } catch { /* ignore */ }
+    }
+    // #6749-D — Reset the module-level oversized-warning dedupe set so the
+    // next planning mission can log its own first-hit warning instead of
+    // inheriting the suppressed state from a previous mission.
+    resetOversizedWarnings()
     localStorage.removeItem(STORAGE_KEY)
     lastParsedContentRef.current = ''
     setState(makeInitialState())

--- a/web/src/hooks/useDeployMissions.ts
+++ b/web/src/hooks/useDeployMissions.ts
@@ -499,7 +499,27 @@ export function useDeployMissions() {
                       logs: [logLine],
                     }
                   }
-                  return pendingOrFailed()
+                  // #6666 — Previously a sustained non-auth error (HTTP 500,
+                  // 502, 503, 504, etc.) would silently downgrade the mission
+                  // to `failed` after MAX_STATUS_FAILURES poll cycles with no
+                  // indication of why. Surface the HTTP status AND a short
+                  // response body excerpt in the cluster logs so operators
+                  // can see that the backend itself is returning errors and
+                  // distinguish "backend down" from "workload missing".
+                  let errBody = ''
+                  try {
+                    if (typeof (res as Response).clone === 'function') {
+                      errBody = (await (res as Response).clone().text()).slice(0, 200)
+                    } else if (typeof (res as Response).text === 'function') {
+                      errBody = (await (res as Response).text()).slice(0, 200)
+                    }
+                  } catch { /* body already consumed or unreadable */ }
+                  const pf = pendingOrFailed()
+                  const logLine = `Backend error HTTP ${res.status}${res.statusText ? ` ${res.statusText}` : ''}${errBody ? `: ${errBody}` : ''} (#6666)`
+                  return {
+                    ...pf,
+                    logs: pf.logs ? [...pf.logs, logLine] : [logLine],
+                  }
                 }
                 const data = await res.json()
                 // #5958 — If the workload no longer exists on the target cluster,

--- a/web/src/hooks/useMissions.tsx
+++ b/web/src/hooks/useMissions.tsx
@@ -169,6 +169,14 @@ export interface SavedMissionUpdates {
 const MissionContext = createContext<MissionContextValue | null>(null)
 
 const MISSIONS_STORAGE_KEY = 'kc_missions'
+/**
+ * #6668 — Window (ms) during which a `storage` event for MISSIONS_STORAGE_KEY
+ * is treated as an echo of our own write and ignored. Real browsers do not
+ * fire storage events in the same tab that made the write, so this is only
+ * a guard against test shims / polyfills. Kept tight so genuine cross-tab
+ * writes arriving within a few ms of a local write are still honored.
+ */
+const CROSS_TAB_ECHO_IGNORE_MS = 50
 const UNREAD_MISSIONS_KEY = 'kc_unread_missions'
 const SELECTED_AGENT_KEY = 'kc_selected_agent'
 
@@ -457,6 +465,17 @@ export function MissionProvider({ children }: { children: ReactNode }) {
   const [defaultAgent, setDefaultAgent] = useState<string | null>(null)
   const [agentsLoading, setAgentsLoading] = useState(false)
 
+  // #6667 — Tracks whether the provider has unmounted. All async completion
+  // handlers (WebSocket onclose, scheduled reconnect timers, fetch .then
+  // callbacks, etc.) must check this before calling setState, or React
+  // emits "cannot update state on unmounted component" warnings and in the
+  // worst case schedules a new reconnect setTimeout after the provider has
+  // been torn down. Set to true in the main cleanup effect below.
+  const unmountedRef = useRef(false)
+  // #6668 — Timestamp of the most recent local write to MISSIONS_STORAGE_KEY.
+  // Used by the storage event listener to suppress echoes of our own write
+  // in environments that (incorrectly) deliver same-tab storage events.
+  const lastWrittenAtRef = useRef<number>(0)
   const wsRef = useRef<WebSocket | null>(null)
   const pendingRequests = useRef<Map<string, string>>(new Map()) // requestId -> missionId
   // Track last stream timestamp per mission to detect tool-use gaps (for creating new chat bubbles)
@@ -571,10 +590,45 @@ export function MissionProvider({ children }: { children: ReactNode }) {
     trySend()
   }
 
-  // Save missions whenever they change
+  // Save missions whenever they change.
+  //
+  // #6668 — Cross-tab overwrite guard. Previously, two tabs each running
+  // their own MissionProvider would each unconditionally write their local
+  // state to `kc_missions` on every change. Tab A completes a mission and
+  // writes; Tab B's next render also writes its (older) state, erasing
+  // Tab A's completion. We mark our own writes with `lastWrittenAt` so
+  // the storage listener below can ignore echoes of our own write.
   useEffect(() => {
+    lastWrittenAtRef.current = Date.now()
     saveMissions(missions)
   }, [missions])
+
+  // #6668 — Listen for cross-tab mission updates. When another tab writes
+  // to `kc_missions`, re-load missions from storage so the completion or
+  // dismissal made in that tab is visible here too. The storage event does
+  // NOT fire in the same tab that made the write, so there is no echo
+  // loop. `lastWrittenAtRef` is still consulted as a belt-and-suspenders
+  // guard against pathological environments (test shims, polyfills) that
+  // echo their own writes.
+  useEffect(() => {
+    const onStorage = (e: StorageEvent) => {
+      if (e.key !== MISSIONS_STORAGE_KEY) return
+      if (e.newValue === null) return
+      // Ignore events fired within CROSS_TAB_ECHO_IGNORE_MS of our own
+      // write — guards against environments that echo storage events.
+      const sinceWrite = Date.now() - (lastWrittenAtRef.current ?? 0)
+      if (sinceWrite < CROSS_TAB_ECHO_IGNORE_MS) return
+      if (unmountedRef.current) return
+      try {
+        const reloaded = loadMissions()
+        setMissions(reloaded)
+      } catch (err) {
+        console.warn('[Missions] issue 6668 — failed to reload from cross-tab write:', err)
+      }
+    }
+    window.addEventListener('storage', onStorage)
+    return () => window.removeEventListener('storage', onStorage)
+  }, [])
 
   // Save unread IDs whenever they change
   useEffect(() => {
@@ -684,6 +738,14 @@ export function MissionProvider({ children }: { children: ReactNode }) {
     // In demo mode, skip WebSocket connection to avoid console errors
     if (getDemoMode()) {
       return Promise.reject(new Error('Agent unavailable in demo mode'))
+    }
+    // #6667 — Refuse to start a new connection if the provider has already
+    // unmounted. Without this guard, a setAgentsLoading(true) call below
+    // would fire on a torn-down component. Can happen when an `onclose`
+    // handler schedules a reconnect timer just before unmount; the timer
+    // still fires after the cleanup effect has run.
+    if (unmountedRef.current) {
+      return Promise.reject(new Error('MissionProvider unmounted'))
     }
 
     if (wsRef.current?.readyState === WebSocket.OPEN) {
@@ -907,6 +969,13 @@ export function MissionProvider({ children }: { children: ReactNode }) {
         wsRef.current.onclose = () => {
           clearTimeout(timeout)
           wsRef.current = null
+          // #6667 — If the provider has already unmounted, short-circuit
+          // everything below: do NOT set state, do NOT schedule a
+          // reconnect timer. The cleanup effect will have already cleared
+          // timers and nulled handlers, but `onclose` can still fire during
+          // teardown if the close was initiated here and the runtime
+          // delivers the event in the same tick.
+          if (unmountedRef.current) return
           setAgentsLoading(false) // Stop loading spinner on disconnect
           // Don't clear agents - keep them cached for display
           // Users can still see available agents even if temporarily disconnected
@@ -926,6 +995,12 @@ export function MissionProvider({ children }: { children: ReactNode }) {
             )
             wsReconnectTimer.current = setTimeout(() => {
               wsReconnectTimer.current = null
+              // #6667 — Belt-and-suspenders: re-check unmount status when
+              // the timer fires in case the cleanup effect ran between
+              // scheduling and firing. `ensureConnection` also checks
+              // this, but bailing here avoids an extra rejected promise
+              // in the console.
+              if (unmountedRef.current) return
               ensureConnection().catch((err: unknown) => {
                 console.error('[Missions] WebSocket reconnection failed:', err)
               })
@@ -2546,6 +2621,10 @@ Install the console locally with the KubeStellar Console agent to use AI mission
     const waitingInputTimeoutsRef = waitingInputTimeouts.current
     const wsSendRetryTimersRef = wsSendRetryTimers.current
     return () => {
+      // #6667 — Mark provider as unmounted BEFORE clearing timers, so any
+      // in-flight async callback that races cleanup sees this flag and
+      // bails without touching React state.
+      unmountedRef.current = true
       if (wsReconnectTimer.current) {
         clearTimeout(wsReconnectTimer.current)
         wsReconnectTimer.current = null

--- a/web/src/lib/cache/index.ts
+++ b/web/src/lib/cache/index.ts
@@ -899,10 +899,34 @@ class CacheStore<T> {
 
       const finalData = merge && hasCachedData ? merge(this.state.data, newData) : newData
 
+      // #6671 — Pre-save generation guard. Without this, a mode-transition
+      // that clears storage AFTER the fetch started but BEFORE this save
+      // call would see the stale fetch re-write `finalData` into storage
+      // (both sessionStorage AND the worker IDB), and the next hydration
+      // of this cache key would pick up cross-mode leaked data. The
+      // post-save check below is not enough: the sessionStorage write
+      // inside `saveToStorage` is synchronous, so the damage is done
+      // before the post-save check can see the new resetVersion.
+      if (this.resetVersion !== fetchVersion) {
+        this.fetchingRef = false
+        return
+      }
+
       await this.saveToStorage(finalData)
+      // #6671 — Re-check after saveToStorage resolves. A mode transition
+      // could have fired DURING the await above; in that case the save we
+      // just completed wrote stale data and we must clear it back out so
+      // the next mount doesn't rehydrate it. saveToStorage always writes
+      // both sessionStorage and the worker IDB, so we remove both.
+      if (this.resetVersion !== fetchVersion) {
+        try { sessionStorage.removeItem(SS_PREFIX + this.key) } catch { /* ignore */ }
+        cacheStorage.delete(this.key).catch(() => { /* ignore */ })
+        this.fetchingRef = false
+        return
+      }
       this.saveMeta({ consecutiveFailures: 0, lastSuccessfulRefresh: Date.now() })
 
-      // Final check after storage save
+      // Final check after meta save
       if (this.resetVersion !== fetchVersion) {
         this.fetchingRef = false
         return
@@ -932,7 +956,13 @@ class CacheStore<T> {
       // If a progressive fetcher pushed partial data via onProgress before
       // throwing, the state.data has been updated but never saved to storage.
       // Save it now so it survives page refresh.
-      if (hasData && this.persist) {
+      //
+      // #6672 — Generation guard on the error path. Previously a stale
+      // progressive fetch that failed after a mode transition would still
+      // persist its accumulated partial data here, re-leaking old-mode
+      // rows into storage and causing cross-mode hydration on next mount.
+      // Same class of race as #6671 on the success path.
+      if (hasData && this.persist && this.resetVersion === fetchVersion) {
         this.saveToStorage(this.state.data)
         this.initialDataLoaded = true
       }

--- a/web/src/lib/dynamic-cards/dynamicCardRegistry.ts
+++ b/web/src/lib/dynamic-cards/dynamicCardRegistry.ts
@@ -14,19 +14,70 @@ function notifyListeners() {
   listeners.forEach(fn => fn())
 }
 
+/**
+ * #6749-C (Copilot on PR #6746) — Upper bound (chars) on the total
+ * code-text length above which we skip the deep structural dedup check
+ * in `registerDynamicCard`. Serializing and comparing two ~200 KB
+ * `compiledCode` strings every time a card module is re-imported during
+ * HMR is measurably slow; at that size the dedup optimization costs more
+ * than the remount wave it was trying to prevent. Definitions larger than
+ * this just re-register and accept the notify — a cheap single remount
+ * beats an expensive JSON.stringify × 2 on every hot-reload.
+ */
+const DEDUP_MAX_CODE_LEN = 10_000
+
+/**
+ * #6749-C — Build a cheap structural fingerprint for dedup comparison.
+ * Uses primitive fields and the length of `sourceCode`/`compiledCode`
+ * instead of the full strings. A collision here only means we run the
+ * full JSON.stringify compare as a second pass — it does not cause a
+ * wrong-answer, only an extra check.
+ */
+function cheapFingerprint(def: DynamicCardDefinition): string {
+  // `def as unknown as Record<string, unknown>` so we can read the
+  // known optional fields without narrowing the public type.
+  const rec = def as unknown as Record<string, unknown>
+  const src = typeof rec.sourceCode === 'string' ? (rec.sourceCode as string).length : 0
+  const compiled = typeof rec.compiledCode === 'string' ? (rec.compiledCode as string).length : 0
+  return `${def.id}|${src}|${compiled}`
+}
+
 /** Register a dynamic card definition.
  *
  * #6712 — Id-based dedup: if a definition with the same id is already
- * registered AND structurally identical (same serialized shape), skip
- * the notifyListeners() call. During HMR, modules that register cards at
- * the top level can otherwise trigger a cascade of listener fires that
- * remount every consumer of the registry even though nothing changed.
+ * registered AND structurally identical, skip the notifyListeners() call.
+ * During HMR, modules that register cards at the top level can otherwise
+ * trigger a cascade of listener fires that remount every consumer of the
+ * registry even though nothing changed.
+ *
+ * #6749-C — Avoid the O(N) JSON.stringify compare on large definitions
+ * (Dynamic cards can carry compiled output in the hundreds of KB). First
+ * compare a cheap primitive fingerprint; only fall through to the full
+ * structural compare on fingerprint match AND when the payload is small
+ * enough that JSON.stringify × 2 is cheap. Oversized definitions just
+ * re-register unconditionally.
  */
 export function registerDynamicCard(def: DynamicCardDefinition): void {
   const existing = registry.get(def.id)
-  if (existing && JSON.stringify(existing) === JSON.stringify(def)) {
-    // No-op replace — avoid remount wave on HMR.
-    return
+  if (existing) {
+    const existingFp = cheapFingerprint(existing)
+    const defFp = cheapFingerprint(def)
+    if (existingFp === defFp) {
+      // Fingerprint match. Decide whether to run the full compare.
+      const rec = def as unknown as Record<string, unknown>
+      const compiledLen = typeof rec.compiledCode === 'string' ? (rec.compiledCode as string).length : 0
+      const sourceLen = typeof rec.sourceCode === 'string' ? (rec.sourceCode as string).length : 0
+      const totalLen = compiledLen + sourceLen
+      if (totalLen <= DEDUP_MAX_CODE_LEN) {
+        // Small enough — do the strict compare to confirm true equality.
+        if (JSON.stringify(existing) === JSON.stringify(def)) {
+          return // No-op replace — avoid remount wave on HMR.
+        }
+      }
+      // Large definitions: skip deep compare entirely and fall through
+      // to register + notify. A single remount is cheaper than the
+      // double stringify.
+    }
   }
   registry.set(def.id, def)
   notifyListeners()

--- a/web/src/lib/modals/useModalNavigation.ts
+++ b/web/src/lib/modals/useModalNavigation.ts
@@ -1,5 +1,24 @@
-import { useState, useEffect, useCallback } from 'react'
+import { useState, useEffect, useCallback, useMemo } from 'react'
 import { UseModalNavigationOptions, UseModalNavigationResult } from './types'
+
+/**
+ * #6749-B (Copilot on PR #6746) — Module-level stable no-op ref object
+ * used as a fallback when a `useModal` caller omits `modalRef`/`backdropRef`.
+ *
+ * Each consumer of `useModal` uses a `useMemo(() => ({current: null}), [])`
+ * locked once per component instance so the ref identity is stable across
+ * renders of that component. A module-level singleton would also be stable,
+ * but sharing it across components risks one component's focus-trap logic
+ * (if we ever switch away from always calling `.current = null`)
+ * trampling another component's ref target. Per-consumer useMemo is the
+ * safe middle ground: still stable, still isolated.
+ *
+ * The previous code created a fresh `{ current: null }` object literal on
+ * every render. Both `useModalBackdropClose` and `useModalFocusTrap`
+ * include `ref` in their effect dep arrays, so the effects re-ran on
+ * every render when the caller omitted a ref — detaching and reattaching
+ * event listeners hundreds of times during streaming renders.
+ */
 
 /**
  * useModalNavigation - Keyboard navigation hook for modals
@@ -213,8 +232,13 @@ export function useModal({
   // when `false`, the hook short-circuits and installs no listeners.
   //
   // Callers that pass no ref get a stable no-op ref object so the hook
-  // signature is satisfied.
-  const noopRef = { current: null } as React.RefObject<HTMLElement | null>
+  // signature is satisfied. The ref is memoized once per consumer so its
+  // identity is stable across renders — see the file-header note on
+  // #6749-B for why we do this via useMemo rather than a module singleton.
+  const noopRef = useMemo(
+    () => ({ current: null } as React.RefObject<HTMLElement | null>),
+    [],
+  )
   useModalBackdropClose(
     backdropRef ?? noopRef,
     isOpen && !!backdropRef && enableBackdropClose,

--- a/web/src/lib/unified/dashboard/UnifiedDashboard.tsx
+++ b/web/src/lib/unified/dashboard/UnifiedDashboard.tsx
@@ -88,10 +88,33 @@ export function UnifiedDashboard({
   // state, so add/remove/configure appeared to do nothing. We keep a local
   // `tabCards` map keyed by tab id, seeded from `config.tabs`, and route
   // mutations through it when `hasTabs` is true.
+  //
+  // #6749-A (Copilot on PR #6746) — Per-tab persistence. Previously the
+  // persistence effect short-circuited entirely when `hasTabs` was true,
+  // so tab-mode add/remove/reorder/configure changes were lost on reload.
+  // We now persist each tab's cards to its own localStorage slot keyed as
+  // `${storageKey}::tab::${tabId}::cards` and seed `tabCards` from those
+  // slots on mount when they exist. Non-tab dashboards keep using the
+  // original `storageKey`.
   const [tabCards, setTabCards] = useState<Record<string, DashboardCardPlacement[]>>(() => {
     if (!config.tabs) return {}
     const initial: Record<string, DashboardCardPlacement[]> = {}
-    for (const t of config.tabs) initial[t.id] = t.cards ?? []
+    for (const t of config.tabs) {
+      let seeded: DashboardCardPlacement[] | null = null
+      if (config.storageKey) {
+        try {
+          const slot = `${config.storageKey}::tab::${t.id}::cards`
+          const raw = localStorage.getItem(slot)
+          if (raw !== null) {
+            const parsed = JSON.parse(raw)
+            if (Array.isArray(parsed)) seeded = parsed
+          }
+        } catch {
+          // Ignore parse errors — fall through to config defaults
+        }
+      }
+      initial[t.id] = seeded ?? t.cards ?? []
+    }
     return initial
   })
 
@@ -122,8 +145,8 @@ export function UnifiedDashboard({
   // previous `cards.length > 0` guard caused "remove all cards → reload"
   // to restore defaults because we never wrote `[]` to storage.
   useEffect(() => {
-    // Skip persistence for tab-mode dashboards — their source of truth is
-    // `config.tabs[].cards`, not the flat `cards` state (#6709).
+    // Skip flat-cards persistence for tab-mode dashboards — tab-mode uses
+    // per-tab slots, handled by the effect below (#6749-A).
     if (hasTabs) return
     if (config.storageKey) {
       try {
@@ -133,6 +156,24 @@ export function UnifiedDashboard({
       }
     }
   }, [cards, config.storageKey, hasTabs])
+
+  // #6749-A — Persist per-tab cards to their own storage slots so tab-mode
+  // mutations survive a reload. Without this, the add/remove/reorder
+  // handlers wired through `mutateActiveCards` would update in-memory
+  // `tabCards` only, and the next mount would re-seed from `config.tabs`
+  // and erase the user's customization.
+  useEffect(() => {
+    if (!hasTabs) return
+    if (!config.storageKey) return
+    for (const [tabId, placements] of Object.entries(tabCards)) {
+      try {
+        const slot = `${config.storageKey}::tab::${tabId}::cards`
+        localStorage.setItem(slot, JSON.stringify(placements))
+      } catch {
+        // Ignore storage errors
+      }
+    }
+  }, [tabCards, config.storageKey, hasTabs])
 
   // #6709 — Helper that mutates either the active tab's cards or the flat
   // `cards` state, depending on dashboard mode. All card mutators go


### PR DESCRIPTION
## Summary

Mission Control + missions-provider state reliability fixes, plus the 4 Copilot review comments left on merged PR #6746.

### Mission state reliability (mrhapile + xonas1101)

- **#6664** `loadPersistedState()` rejects non-object top-level values before using the `in` operator, and checks a new `PERSISTED_SCHEMA_VERSION` field. Corrupt/mismatched payloads are cleared with a warning instead of silently wiping the wizard via the outer `catch`.
- **#6665** `persistState()` detects quota errors, logs a warn naming the mission, and surfaces a one-shot banner flag via `sessionStorage` (`kc_mission_control_quota_error`). New export `consumePersistQuotaBanner()` lets the dialog render a banner on next mount.
- **#6666** `useDeployMissions` non-auth HTTP error path appends `Backend error HTTP <status>: <body excerpt>` to cluster logs so a sustained 500 storm is visible.
- **#6667** New `unmountedRef` guards `ensureConnection`, the WS `onclose` reconnect-scheduling, and the reconnect-timer callback. Set `true` at top of cleanup effect.
- **#6668** New `storage` event listener on `kc_missions` reloads missions when another tab writes. Own writes timestamped via `lastWrittenAtRef`, suppressed within `CROSS_TAB_ECHO_IGNORE_MS` (50ms).
- **#6669** `aiStreaming` sync effect clears the flag on any terminal planning-mission status (`failed`/`completed`/`cancelled`/`blocked`) even when `running` was never observed.
- **#6670** `reset()` calls `dismissMission(planningMissionId)` and the parse effect bails when `state.planningMissionId` is null or mismatches `planningMission.id`.
- **#6671** `CacheStore.fetch` success path checks `resetVersion !== fetchVersion` BEFORE `saveToStorage` and again after the await; on mismatch deletes both sessionStorage snapshot and worker IDB entry.
- **#6672** Same generation guard on error path.

### PR #6746 Copilot followups (#6749)

- **UnifiedDashboard.tsx** Per-tab cards persisted to `${storageKey}::tab::${tabId}::cards`.
- **useModalNavigation.ts** `noopRef` via `useMemo` so identity is stable across renders.
- **dynamicCardRegistry.ts** Cheap fingerprint dedup; skip deep `JSON.stringify` compare on oversized defs (> 10KB).
- **useMissionControl.ts** `extractBalancedBlocks` takes `warnKey`; dedup oversize warning once per mission ID.

## Test plan

- [x] `npm run build` — passes
- [x] `npx vitest run <targeted>` — 7073 passed (one worker-pool undici flake in useAIPredictions unrelated; passes when run alone 48/48)
- [x] `npm run lint` — baseline count unchanged (86 pre-existing)
- [ ] Manual: fill localStorage to trigger quota, verify warn + banner flag
- [ ] Manual: open two tabs, complete mission in tab A, observe tab B reload

Fixes #6664
Fixes #6665
Fixes #6666
Fixes #6667
Fixes #6668
Fixes #6669
Fixes #6670
Fixes #6671
Fixes #6672
Fixes #6749