### PR TITLE
fix: domain JSON case + CreatedAt typing + unified card types validation (#6625, #6626, #6754)

### DIFF
--- a/pkg/k8s/rbac.go
+++ b/pkg/k8s/rbac.go
@@ -69,7 +69,7 @@ func (m *MultiClusterClient) ListServiceAccounts(ctx context.Context, contextNam
 			Cluster:   contextName,
 			Secrets:   secrets,
 			Roles:     roles,
-			CreatedAt: sa.CreationTimestamp.Format(time.RFC3339),
+			CreatedAt: sa.CreationTimestamp.Time,
 		})
 	}
 
@@ -373,7 +373,7 @@ func (m *MultiClusterClient) CreateServiceAccount(ctx context.Context, contextNa
 		Name:      created.Name,
 		Namespace: created.Namespace,
 		Cluster:   contextName,
-		CreatedAt: created.CreationTimestamp.Format(time.RFC3339),
+		CreatedAt: created.CreationTimestamp.Time,
 	}, nil
 }
 
@@ -888,7 +888,7 @@ func (m *MultiClusterClient) ListNamespacesWithDetails(ctx context.Context, cont
 			Cluster:   contextName,
 			Status:    string(ns.Status.Phase),
 			Labels:    ns.Labels,
-			CreatedAt: ns.CreationTimestamp.Format(time.RFC3339),
+			CreatedAt: ns.CreationTimestamp.Time,
 		})
 	}
 	return namespaces, nil
@@ -918,7 +918,7 @@ func (m *MultiClusterClient) CreateNamespace(ctx context.Context, contextName, n
 		Cluster:   contextName,
 		Status:    string(created.Status.Phase),
 		Labels:    created.Labels,
-		CreatedAt: created.CreationTimestamp.Format(time.RFC3339),
+		CreatedAt: created.CreationTimestamp.Time,
 	}, nil
 }
 
@@ -972,9 +972,11 @@ func parseOpenShiftUser(item unstructured.Unstructured, cluster string) models.O
 		user.Name = name
 	}
 
-	// Get creationTimestamp from metadata
+	// Get creationTimestamp from metadata (parsed from RFC3339 string; zero value on parse failure)
 	if createdAt, found, _ := unstructured.NestedString(item.Object, "metadata", "creationTimestamp"); found {
-		user.CreatedAt = createdAt
+		if parsed, err := time.Parse(time.RFC3339, createdAt); err == nil {
+			user.CreatedAt = parsed
+		}
 	}
 
 	// Get fullName

--- a/pkg/models/rbac.go
+++ b/pkg/models/rbac.go
@@ -40,12 +40,12 @@ type K8sUser struct {
 
 // OpenShiftUser represents an OpenShift user (users.user.openshift.io)
 type OpenShiftUser struct {
-	Name       string   `json:"name"`
-	FullName   string   `json:"fullName,omitempty"`
-	Identities []string `json:"identities,omitempty"`
-	Groups     []string `json:"groups,omitempty"`
-	Cluster    string   `json:"cluster"`
-	CreatedAt  string   `json:"createdAt,omitempty"`
+	Name       string    `json:"name"`
+	FullName   string    `json:"fullName,omitempty"`
+	Identities []string  `json:"identities,omitempty"`
+	Groups     []string  `json:"groups,omitempty"`
+	Cluster    string    `json:"cluster"`
+	CreatedAt  time.Time `json:"createdAt,omitempty"`
 }
 
 // K8sRole represents a Kubernetes Role or ClusterRole
@@ -75,12 +75,12 @@ type K8sRoleBinding struct {
 
 // K8sServiceAccount represents a Kubernetes ServiceAccount with its bindings
 type K8sServiceAccount struct {
-	Name      string   `json:"name"`
-	Namespace string   `json:"namespace"`
-	Cluster   string   `json:"cluster"`
-	Secrets   []string `json:"secrets,omitempty"`
-	Roles     []string `json:"roles,omitempty"`
-	CreatedAt string   `json:"createdAt,omitempty"`
+	Name      string    `json:"name"`
+	Namespace string    `json:"namespace"`
+	Cluster   string    `json:"cluster"`
+	Secrets   []string  `json:"secrets,omitempty"`
+	Roles     []string  `json:"roles,omitempty"`
+	CreatedAt time.Time `json:"createdAt,omitempty"`
 }
 
 // ClusterPermissions represents current user's permissions on a cluster
@@ -140,7 +140,7 @@ type AuditLogEntry struct {
 	TargetType string    `json:"target_type"` // console_user, service_account, role_binding
 	TargetID   string    `json:"target_id"`
 	Details    string    `json:"details,omitempty"`
-	CreatedAt  time.Time `json:"created_at"`
+	CreatedAt  time.Time `json:"createdAt"`
 }
 
 // CanIRequest represents a request to check if user can perform an action
@@ -182,7 +182,7 @@ type NamespaceDetails struct {
 	Cluster   string            `json:"cluster"`
 	Status    string            `json:"status"`
 	Labels    map[string]string `json:"labels,omitempty"`
-	CreatedAt string            `json:"created_at"`
+	CreatedAt time.Time         `json:"createdAt"`
 }
 
 // CreateNamespaceRequest represents a request to create a namespace

--- a/web/src/components/namespaces/NamespaceCard.tsx
+++ b/web/src/components/namespaces/NamespaceCard.tsx
@@ -38,7 +38,7 @@ export function NamespaceCard({ namespace, isSelected, onSelect, onDelete, isSys
           </span>
         </div>
         <p className="text-sm text-muted-foreground">
-          Created {new Date(namespace.created_at).toLocaleDateString()}
+          Created {new Date(namespace.createdAt).toLocaleDateString()}
         </p>
       </div>
       {showCluster && <ClusterBadge cluster={namespace.cluster} size="sm" />}

--- a/web/src/components/namespaces/NamespaceManager.tsx
+++ b/web/src/components/namespaces/NamespaceManager.tsx
@@ -147,12 +147,12 @@ export function NamespaceManager() {
           if (response.ok) {
             const data = await response.json()
             if (data.namespaces && Array.isArray(data.namespaces)) {
-              clusterNamespaces = data.namespaces.map((ns: { name: string; status?: string; labels?: Record<string, string>; created_at?: string }) => ({
+              clusterNamespaces = data.namespaces.map((ns: { name: string; status?: string; labels?: Record<string, string>; createdAt?: string }) => ({
                 name: ns.name,
                 cluster,
                 status: ns.status || 'Active',
                 labels: ns.labels,
-                created_at: ns.created_at || new Date().toISOString() }))
+                createdAt: ns.createdAt || new Date().toISOString() }))
             }
           }
         } catch {
@@ -177,7 +177,7 @@ export function NamespaceManager() {
                 name: ns,
                 cluster,
                 status: 'Active',
-                created_at: new Date().toISOString() })
+                createdAt: new Date().toISOString() })
             })
           } catch {
             // API also failed - cluster is likely unreachable

--- a/web/src/components/namespaces/types.ts
+++ b/web/src/components/namespaces/types.ts
@@ -3,7 +3,7 @@ export interface NamespaceDetails {
   cluster: string
   status: string
   labels?: Record<string, string>
-  created_at: string
+  createdAt: string
 }
 
 export interface NamespaceAccessEntry {

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -183,9 +183,18 @@ enableMocking()
       Promise.all([
         import('./lib/cards/cardInstallMap'),
         import('./config/cards'),
+        import('./components/cards/cardRegistry'),
       ])
-        .then(([{ validateCardInstallMap }, { getUnifiedCardTypes }]) => {
-          validateCardInstallMap(getUnifiedCardTypes())
+        .then(([{ validateCardInstallMap }, { getUnifiedCardTypes }, { getRegisteredCardTypes }]) => {
+          // #6754 — validateCardInstallMap needs the union of config-based
+          // cards (getUnifiedCardTypes, from CARD_CONFIGS) AND component-only
+          // registered cards (getRegisteredCardTypes, from CARD_COMPONENTS).
+          // Using only config-based types would incorrectly flag component-only
+          // cards as install-map entries without a backing card type.
+          const knownTypes = Array.from(
+            new Set([...getUnifiedCardTypes(), ...getRegisteredCardTypes()]),
+          )
+          validateCardInstallMap(knownTypes)
         })
         .catch(() => { /* ignore — validation is non-critical diagnostic */ })
     }


### PR DESCRIPTION
## Summary

Fixes three related cleanup items.

### #6625 — Mixed camelCase/snake_case JSON keys for created-time fields
`pkg/models/rbac.go` mixed both conventions in the same package:
- `OpenShiftUser` / `K8sServiceAccount`: `json:"createdAt"`
- `NamespaceDetails` / `AuditLogEntry`: `json:"created_at"`

Standardized to camelCase (`createdAt`) to match the surrounding TS conventions in `web/src/types/users.ts` (which already uses `createdAt` for `OpenShiftUser` and `K8sServiceAccount`).

### #6626 — Inconsistent CreatedAt typing
In the same file: `OpenShiftUser`, `K8sServiceAccount`, and `NamespaceDetails` had `CreatedAt string`, while `AuditLogEntry` had `CreatedAt time.Time`. Standardized to `time.Time`.

- `pkg/k8s/rbac.go` producers now pass `metav1.Time.Time` directly instead of `.Format(time.RFC3339)` — JSON marshaling still emits an RFC3339 string on the wire so clients that accept camelCase dates see no change.
- `parseOpenShiftUser` parses the RFC3339 string from unstructured metadata into `time.Time` (zero value on parse failure).
- Frontend consumers updated for the `NamespaceDetails.created_at` → `createdAt` rename: `web/src/components/namespaces/types.ts`, `NamespaceCard.tsx`, `NamespaceManager.tsx`.

### #6754 — validateCardInstallMap missed component-only cards
Copilot review on merged PR #6752 noted that `main.tsx` called `validateCardInstallMap(getUnifiedCardTypes())`, where `getUnifiedCardTypes()` returns only `Object.keys(CARD_CONFIGS)` (config-based cards). Component-only registered cards (entries in `CARD_COMPONENTS` without a `CARD_CONFIGS` entry) were incorrectly flagged as dead install-map aliases.

Fix: pass the union of `getUnifiedCardTypes()` and `getRegisteredCardTypes()` (from `components/cards/cardRegistry`) so both config-based and component-only cards are recognized.

Closes #6625
Closes #6626
Closes #6754

## Test plan
- [x] `go build ./...` passes
- [x] `npm run build` passes (postbuild safety checks green)
- [x] `npm run lint`: 336 errors / 733 warnings — identical to baseline, no new issues