### PR TITLE
fix: PR #6755 followups — test regression + 5 Copilot comments (#6757, #6758)

### DIFF
--- a/web/src/components/mission-control/MissionControlDialog.tsx
+++ b/web/src/components/mission-control/MissionControlDialog.tsx
@@ -28,7 +28,7 @@ import {
 import { cn } from '../../lib/cn'
 import { Button } from '../ui/Button'
 import { useToast } from '../ui/Toast'
-import { useMissionControl } from './useMissionControl'
+import { useMissionControl, consumePersistQuotaBanner } from './useMissionControl'
 import { FixerDefinitionPanel } from './FixerDefinitionPanel'
 import { ClusterAssignmentPanel } from './ClusterAssignmentPanel'
 const FlightPlanBlueprint = lazy(() =>
@@ -111,6 +111,23 @@ export function MissionControlDialog({ open, onClose }: MissionControlDialogProp
     document.addEventListener('keydown', handleKeyDown)
     return () => document.removeEventListener('keydown', handleKeyDown)
   }, [open, handleKeyDown])
+
+  // #6758 (Copilot on PR #6755) — Surface a toast when a previous
+  // Mission Control session hit a QuotaExceededError while trying to
+  // persist its state. `consumePersistQuotaBanner()` reads and clears
+  // the session-storage flag set by the persistState writer in
+  // #6665, returning the mission title (or the literal `'(untitled)'`)
+  // that was being saved. Without this wiring the helper was dead
+  // code — the flag got written but nobody ever displayed it.
+  useEffect(() => {
+    if (!open) return
+    const pendingTitle = consumePersistQuotaBanner()
+    if (pendingTitle === null) return
+    showToast(
+      `Mission '${pendingTitle}' could not be persisted (browser storage quota exceeded). Your work is preserved in memory but will be lost on reload.`,
+      'warning',
+    )
+  }, [open, showToast])
 
   // #6403 — Surface a toast when stale cluster references are dropped from
   // persisted state. The hook already reconciles the state; we just notify

--- a/web/src/components/mission-control/useMissionControl.ts
+++ b/web/src/components/mission-control/useMissionControl.ts
@@ -393,7 +393,9 @@ export function extractJSON<T>(text: string, requiredKey?: string, warnKey?: str
  * a flood of identical warnings. The set is keyed by caller-supplied
  * tokens (typically a mission ID) so the warning fires once per mission
  * instead of once per chunk. Cleared by `reset()` above via
- * `oversizedWarnedRef`, and by `resetOversizedWarnings()` exported below.
+ * `resetOversizedWarnings()` (#6758: the old comment referenced a
+ * nonexistent `oversizedWarnedRef`; the actual mechanism is the exported
+ * helper below).
  */
 const oversizedWarnSet = new Set<string>()
 export function resetOversizedWarnings(): void {

--- a/web/src/hooks/__tests__/useDeployMissions.test.ts
+++ b/web/src/hooks/__tests__/useDeployMissions.test.ts
@@ -1496,8 +1496,13 @@ describe('useDeployMissions', () => {
 
     const cs = result.current.missions[0].clusterStatuses[0]
     expect(cs.status).toBe('pending')
-    // Should NOT have auth error message
-    expect(cs.logs).toBeUndefined()
+    // #6666 — Non-auth HTTP errors now append a "Backend error HTTP ..."
+    // log line so operators can see the backend is returning errors. The
+    // mission still stays in `pending` (not `failed`) and is NOT flagged
+    // as an auth error.
+    expect(cs.logs).toBeDefined()
+    expect(cs.logs?.some(l => /Backend error HTTP 500/.test(l))).toBe(true)
+    expect(cs.logs?.some(l => /Authentication failed/.test(l))).toBe(false)
   })
 
   // =========================================================================

--- a/web/src/hooks/useMissions.tsx
+++ b/web/src/hooks/useMissions.tsx
@@ -613,12 +613,28 @@ export function MissionProvider({ children }: { children: ReactNode }) {
   useEffect(() => {
     const onStorage = (e: StorageEvent) => {
       if (e.key !== MISSIONS_STORAGE_KEY) return
-      if (e.newValue === null) return
       // Ignore events fired within CROSS_TAB_ECHO_IGNORE_MS of our own
       // write — guards against environments that echo storage events.
+      // Applied BEFORE the newValue null-check so our own last-resort
+      // `localStorage.removeItem(kc_missions)` on quota error doesn't
+      // round-trip and clear our in-memory state.
       const sinceWrite = Date.now() - (lastWrittenAtRef.current ?? 0)
       if (sinceWrite < CROSS_TAB_ECHO_IGNORE_MS) return
       if (unmountedRef.current) return
+      // #6758 (Copilot on PR #6755) — When another tab calls
+      // `localStorage.removeItem(kc_missions)` (for example as a
+      // last-resort clear after a QuotaExceededError), `e.newValue` is
+      // `null`. The old code silently dropped that event and left this
+      // tab's local state out of sync with storage. Treat a remote
+      // removal as a remote reset: clear local missions to match.
+      if (e.newValue === null) {
+        try {
+          setMissions([])
+        } catch (err) {
+          console.warn('[Missions] issue 6758 — failed to apply cross-tab reset:', err)
+        }
+        return
+      }
       try {
         const reloaded = loadMissions()
         setMissions(reloaded)

--- a/web/src/lib/modals/useModalNavigation.ts
+++ b/web/src/lib/modals/useModalNavigation.ts
@@ -1,24 +1,31 @@
-import { useState, useEffect, useCallback, useMemo } from 'react'
+import { useState, useEffect, useCallback } from 'react'
 import { UseModalNavigationOptions, UseModalNavigationResult } from './types'
 
 /**
  * #6749-B (Copilot on PR #6746) — Module-level stable no-op ref object
  * used as a fallback when a `useModal` caller omits `modalRef`/`backdropRef`.
  *
- * Each consumer of `useModal` uses a `useMemo(() => ({current: null}), [])`
- * locked once per component instance so the ref identity is stable across
- * renders of that component. A module-level singleton would also be stable,
- * but sharing it across components risks one component's focus-trap logic
- * (if we ever switch away from always calling `.current = null`)
- * trampling another component's ref target. Per-consumer useMemo is the
- * safe middle ground: still stable, still isolated.
+ * A single shared `{ current: null }` singleton is safe here because
+ * `useModalBackdropClose` and `useModalFocusTrap` gate their behavior on
+ * the `enabled` flag (`!!backdropRef && enableBackdropClose` and
+ * `!!modalRef && enableFocusTrap`), so when a caller omits the real ref
+ * the hook short-circuits and never reads or writes `.current`. The
+ * shared object therefore can't be trampled by another consumer.
  *
- * The previous code created a fresh `{ current: null }` object literal on
- * every render. Both `useModalBackdropClose` and `useModalFocusTrap`
- * include `ref` in their effect dep arrays, so the effects re-ran on
- * every render when the caller omitted a ref — detaching and reattaching
- * event listeners hundreds of times during streaming renders.
+ * The previous code created a fresh `{ current: null }` object literal
+ * inside `useModal` on every render. Both `useModalBackdropClose` and
+ * `useModalFocusTrap` include `ref` in their effect dep arrays, so the
+ * effects re-ran on every render when the caller omitted a ref —
+ * detaching and reattaching event listeners hundreds of times during
+ * streaming renders. The module-level singleton makes that identity
+ * stable for free, with no per-component `useMemo` cost.
+ *
+ * #6758 (Copilot on PR #6755) — The previous comment claimed a
+ * module-level singleton but the implementation used `useMemo`. The
+ * module-level form actually achieves the stated intent and is cheaper,
+ * so this file now matches its header comment.
  */
+const NOOP_REF: React.RefObject<HTMLElement | null> = { current: null }
 
 /**
  * useModalNavigation - Keyboard navigation hook for modals
@@ -231,21 +238,17 @@ export function useModal({
   // renders. The behavior is gated inside each hook via the `isOpen` flag:
   // when `false`, the hook short-circuits and installs no listeners.
   //
-  // Callers that pass no ref get a stable no-op ref object so the hook
-  // signature is satisfied. The ref is memoized once per consumer so its
-  // identity is stable across renders — see the file-header note on
-  // #6749-B for why we do this via useMemo rather than a module singleton.
-  const noopRef = useMemo(
-    () => ({ current: null } as React.RefObject<HTMLElement | null>),
-    [],
-  )
+  // Callers that pass no ref get the module-level NOOP_REF singleton so
+  // the hook signature is satisfied without allocating a fresh object on
+  // every render. See the file-header note on #6749-B / #6758 for why
+  // sharing is safe here.
   useModalBackdropClose(
-    backdropRef ?? noopRef,
+    backdropRef ?? NOOP_REF,
     isOpen && !!backdropRef && enableBackdropClose,
     onClose,
   )
   useModalFocusTrap(
-    modalRef ?? noopRef,
+    modalRef ?? NOOP_REF,
     isOpen && !!modalRef && enableFocusTrap,
   )
 }

--- a/web/src/lib/unified/dashboard/UnifiedDashboard.tsx
+++ b/web/src/lib/unified/dashboard/UnifiedDashboard.tsx
@@ -268,6 +268,32 @@ export function UnifiedDashboard({
     if (config.storageKey) {
       try {
         localStorage.removeItem(config.storageKey)
+        // #6758 — Also clear per-tab card slots written by the effect
+        // at line ~165. Without this, Reset would restore the flat
+        // `cards` state but leave stale tab-mode placements in
+        // localStorage, which would reseed on the next mount and
+        // silently undo the reset for tab-mode dashboards.
+        const tabSlotPrefix = `${config.storageKey}::tab::`
+        const tabSlotSuffix = '::cards'
+        const keysToRemove: string[] = []
+        for (let i = 0; i < localStorage.length; i++) {
+          const k = localStorage.key(i)
+          if (k && k.startsWith(tabSlotPrefix) && k.endsWith(tabSlotSuffix)) {
+            keysToRemove.push(k)
+          }
+        }
+        for (const k of keysToRemove) {
+          localStorage.removeItem(k)
+        }
+        // Also clear the in-memory tabCards so the reset is visible
+        // immediately without a reload.
+        if (hasTabs) {
+          const seeded: Record<string, DashboardCardPlacement[]> = {}
+          for (const t of (config.tabs ?? [])) {
+            seeded[t.id] = t.cards ?? []
+          }
+          setTabCards(seeded)
+        }
       } catch {
         // Ignore storage errors
       }


### PR DESCRIPTION
Closes #6757
Closes #6758

## Summary

Two logical commits addressing followups from merged PR #6755.

### #6757 — Coverage Suite regression (test fix)

The `useDeployMissions > 'treats 500 as pending (not auth error)'` test broke because my #6666 fix in PR #6755 started appending a `Backend error HTTP <status>: <body>` line to cluster logs on non-auth HTTP errors. The source behavior is correct: a 500 should still keep the mission in `pending` (not flip to `failed`), but we now also surface a diagnostic log line so operators can tell the difference between 'backend down' and 'workload missing'. This was a test that needed updating, NOT a real regression in source.

Test now asserts:
- `status === 'pending'` (unchanged)
- `logs` contains `Backend error HTTP 500`
- `logs` does NOT contain `Authentication failed` (500 is not an auth error)

### #6758 — 5 Copilot review comments

1. **UnifiedDashboard.tsx reset** — extend `handleReset()` to enumerate and remove per-tab card slots. Without this, tab-mode dashboards reseed from stale localStorage on next mount and silently undo the reset.
2. **useModalNavigation.ts noopRef** — move to module-level singleton (NOOP_REF). Matches the file-header intent and drops per-component useMemo.
3. **useMissions.tsx storage listener** — handle `e.newValue === null` as a remote reset so cross-tab `removeItem('kc_missions')` (last-resort quota clear) propagates. lastWrittenAt echo guard still runs first.
4. **consumePersistQuotaBanner wiring** — call it in MissionControlDialog mount effect and show a warning toast. Was exported but never called.
5. **useMissionControl.ts comment** — correct stale reference to nonexistent `oversizedWarnedRef`; real mechanism is `resetOversizedWarnings()`.

## Test plan

- [x] npm run build passes locally
- [x] vitest run on targeted files — 997/997 pass
- [ ] CI build/lint/preview pass