### PR TITLE
fix(domain): use *time.Time so omitempty actually omits zero values (#6759)

### DIFF
--- a/pkg/k8s/rbac.go
+++ b/pkg/k8s/rbac.go
@@ -63,13 +63,14 @@ func (m *MultiClusterClient) ListServiceAccounts(ctx context.Context, contextNam
 		key := sa.Namespace + "/" + sa.Name
 		roles := saRolesMap[key]
 
+		saCreatedAt := sa.CreationTimestamp.Time
 		result = append(result, models.K8sServiceAccount{
 			Name:      sa.Name,
 			Namespace: sa.Namespace,
 			Cluster:   contextName,
 			Secrets:   secrets,
 			Roles:     roles,
-			CreatedAt: sa.CreationTimestamp.Time,
+			CreatedAt: &saCreatedAt,
 		})
 	}
 
@@ -369,11 +370,12 @@ func (m *MultiClusterClient) CreateServiceAccount(ctx context.Context, contextNa
 		return nil, err
 	}
 
+	createdAt := created.CreationTimestamp.Time
 	return &models.K8sServiceAccount{
 		Name:      created.Name,
 		Namespace: created.Namespace,
 		Cluster:   contextName,
-		CreatedAt: created.CreationTimestamp.Time,
+		CreatedAt: &createdAt,
 	}, nil
 }
 
@@ -972,10 +974,12 @@ func parseOpenShiftUser(item unstructured.Unstructured, cluster string) models.O
 		user.Name = name
 	}
 
-	// Get creationTimestamp from metadata (parsed from RFC3339 string; zero value on parse failure)
+	// Get creationTimestamp from metadata (parsed from RFC3339 string).
+	// CreatedAt is a *time.Time so it stays nil on absence or parse failure,
+	// and `omitempty` in the JSON tag then actually omits it. See issue #6759.
 	if createdAt, found, _ := unstructured.NestedString(item.Object, "metadata", "creationTimestamp"); found {
 		if parsed, err := time.Parse(time.RFC3339, createdAt); err == nil {
-			user.CreatedAt = parsed
+			user.CreatedAt = &parsed
 		}
 	}
 

--- a/pkg/models/rbac.go
+++ b/pkg/models/rbac.go
@@ -40,12 +40,15 @@ type K8sUser struct {
 
 // OpenShiftUser represents an OpenShift user (users.user.openshift.io)
 type OpenShiftUser struct {
-	Name       string    `json:"name"`
-	FullName   string    `json:"fullName,omitempty"`
-	Identities []string  `json:"identities,omitempty"`
-	Groups     []string  `json:"groups,omitempty"`
-	Cluster    string    `json:"cluster"`
-	CreatedAt  time.Time `json:"createdAt,omitempty"`
+	Name       string   `json:"name"`
+	FullName   string   `json:"fullName,omitempty"`
+	Identities []string `json:"identities,omitempty"`
+	Groups     []string `json:"groups,omitempty"`
+	Cluster    string   `json:"cluster"`
+	// CreatedAt is a pointer so that `omitempty` actually omits it when unset.
+	// With a value-type time.Time, the JSON encoder never treats a zero-value
+	// struct as empty and would emit "0001-01-01T00:00:00Z". See issue #6759.
+	CreatedAt *time.Time `json:"createdAt,omitempty"`
 }
 
 // K8sRole represents a Kubernetes Role or ClusterRole
@@ -75,12 +78,14 @@ type K8sRoleBinding struct {
 
 // K8sServiceAccount represents a Kubernetes ServiceAccount with its bindings
 type K8sServiceAccount struct {
-	Name      string    `json:"name"`
-	Namespace string    `json:"namespace"`
-	Cluster   string    `json:"cluster"`
-	Secrets   []string  `json:"secrets,omitempty"`
-	Roles     []string  `json:"roles,omitempty"`
-	CreatedAt time.Time `json:"createdAt,omitempty"`
+	Name      string   `json:"name"`
+	Namespace string   `json:"namespace"`
+	Cluster   string   `json:"cluster"`
+	Secrets   []string `json:"secrets,omitempty"`
+	Roles     []string `json:"roles,omitempty"`
+	// CreatedAt is a pointer so that `omitempty` actually omits it when unset.
+	// See OpenShiftUser.CreatedAt and issue #6759.
+	CreatedAt *time.Time `json:"createdAt,omitempty"`
 }
 
 // ClusterPermissions represents current user's permissions on a cluster


### PR DESCRIPTION
Closes #6759

## Problem

Go's `encoding/json` never treats a struct value as "empty", so `time.Time` fields tagged with `omitempty` are **always** serialized — even when unset — producing `"0001-01-01T00:00:00Z"` on the wire. Copilot flagged three instances of this bug that all landed together in PR #6756:

- `pkg/models/rbac.go:48` — `OpenShiftUser.CreatedAt`
- `pkg/models/rbac.go:84` — `K8sServiceAccount.CreatedAt`
- `pkg/k8s/rbac.go:980` — `parseOpenShiftUser` leaves a zero time on parse failure, which then serializes as `0001-01-01T00:00:00Z` instead of being omitted

## Fix

Switch the two affected `CreatedAt` fields from `time.Time` to `*time.Time`. With pointers, `omitempty` actually works: `nil` is omitted.

- `pkg/models/rbac.go` — `OpenShiftUser.CreatedAt` and `K8sServiceAccount.CreatedAt` are now `*time.Time`
- `pkg/k8s/rbac.go` — producers take the address of the creation timestamp via a local variable
- `parseOpenShiftUser` — leaves `user.CreatedAt` as `nil` on parse failure, so the field is omitted from JSON instead of emitting `0001-01-01T00:00:00Z`

## Structs audited (from #6756)

| Struct | `omitempty` on `CreatedAt`? | Action |
|---|---|---|
| `OpenShiftUser` | yes | fixed (→ `*time.Time`) |
| `K8sServiceAccount` | yes | fixed (→ `*time.Time`) |
| `NamespaceDetails` | no (always present) | left as `time.Time` |
| `AuditLogEntry` | no (always present) | left as `time.Time` |

## Frontend impact

None. `web/src/types/users.ts` already declares `createdAt?: string` (optional) for both `OpenShiftUser` and `K8sServiceAccount`, so missing/null values from JSON are already handled.

`NamespaceDetails.createdAt` is unchanged, so `NamespaceCard` and `NamespaceManager` (which dereference it via `new Date(namespace.createdAt)`) are unaffected.

## Verification

- `go build ./...` — clean
- `go vet ./pkg/models/... ./pkg/k8s/...` — clean
- `cd web && npm run build` — clean (post-build safety checks pass)