### PR TITLE
fix(missions): clear unreadMissionIds on cross-tab remote reset (#6762)

### DIFF
--- a/web/src/hooks/useMissions.tsx
+++ b/web/src/hooks/useMissions.tsx
@@ -627,9 +627,41 @@ export function MissionProvider({ children }: { children: ReactNode }) {
       // `null`. The old code silently dropped that event and left this
       // tab's local state out of sync with storage. Treat a remote
       // removal as a remote reset: clear local missions to match.
+      //
+      // #6762 (Copilot on PR #6760) — A remote reset must also clear
+      // every piece of state that is logically derivative of `missions`;
+      // otherwise stale entries keep pointing at missions that no longer
+      // exist. Specifically:
+      //   - `unreadMissionIds` — IDs here reference mission IDs; leaving
+      //     them populated produces a non-zero `unreadMissionCount` badge
+      //     for missions that were just cleared.
+      //   - `activeMissionId` — a pointer into `missions`; must be
+      //     cleared so the sidebar / detail view doesn't dangle on a
+      //     deleted mission.
+      //   - `cancelTimeouts` (ref) — timeout handles keyed by mission ID
+      //     from in-flight cancel requests; the missions they reference
+      //     are gone, so clear them to avoid leaked timers firing
+      //     against non-existent state.
+      //   - `pendingRequests` (ref) — requestId → missionId map for
+      //     in-flight WS requests; the target missions are gone.
+      //   - `lastStreamTimestamp` (ref) — per-mission streaming gap
+      //     tracker, also keyed by mission ID.
+      //
+      // Persistent UI state (sidebar open / minimized / full-screen,
+      // selected agent, default agent) is intentionally NOT reset — it
+      // is not derivative of `missions` and should survive a remote
+      // mission wipe.
       if (e.newValue === null) {
         try {
           setMissions([])
+          setUnreadMissionIds(new Set())
+          setActiveMissionId(null)
+          for (const timeout of cancelTimeouts.current.values()) {
+            clearTimeout(timeout)
+          }
+          cancelTimeouts.current.clear()
+          pendingRequests.current.clear()
+          lastStreamTimestamp.current.clear()
         } catch (err) {
           console.warn('[Missions] issue 6758 — failed to apply cross-tab reset:', err)
         }


### PR DESCRIPTION
Closes #6762

## Problem

Copilot follow-up on merged PR #6760. In the cross-tab storage handler in `web/src/hooks/useMissions.tsx`, a remote `removeItem(kc_missions)` (e.g. another tab doing a last-resort clear after `QuotaExceededError`) was treated as a remote reset — but only `missions` was cleared. `unreadMissionIds` was left populated, so `unreadMissionCount` stayed non-zero and the unread badge pointed at missions that no longer existed. `activeMissionId` and several per-mission refs were also left dangling.

## Fix

In the same `e.newValue === null` branch (still inside the existing `CROSS_TAB_ECHO_IGNORE_MS` echo guard, so our own quota-clear `removeItem` can't round-trip), also reset every piece of state that is logically derivative of `missions`:

- `unreadMissionIds` — the direct bug from #6762
- `activeMissionId` — pointer into `missions`
- `cancelTimeouts` ref — `clearTimeout` each handle then `.clear()`
- `pendingRequests` ref — `requestId -> missionId` map
- `lastStreamTimestamp` ref — per-mission streaming gap tracker

Persistent UI state (sidebar open/minimized/fullscreen, selected agent, default agent) is intentionally NOT cleared — it is not derivative of `missions` and should survive a remote mission wipe.

There is no existing `clearMissions()` / `reset()` helper in the file to reuse, so the setters are inlined at the single call site (the cross-tab handler is the only place that needs this bulk reset today).

## Test plan

- [x] `npm run build` passes
- [x] `npx vitest run src/hooks/__tests__/useDeployMissions src/hooks/__tests__/useMissionSuggestions` — 96/96 passing
- [x] Echo guard (`CROSS_TAB_ECHO_IGNORE_MS`) still wraps the whole block — our own quota-clear `removeItem` won't wipe our state