### PR TITLE
fix(rbac): leave CreatedAt nil when CreationTimestamp is zero + parser test (#6764)

### DIFF
--- a/pkg/k8s/rbac.go
+++ b/pkg/k8s/rbac.go
@@ -63,14 +63,21 @@ func (m *MultiClusterClient) ListServiceAccounts(ctx context.Context, contextNam
 		key := sa.Namespace + "/" + sa.Name
 		roles := saRolesMap[key]
 
-		saCreatedAt := sa.CreationTimestamp.Time
+		// Leave CreatedAt nil when CreationTimestamp is zero so the JSON
+		// `omitempty` tag drops the field instead of emitting
+		// "0001-01-01T00:00:00Z" (fake clientset, partial metadata). See #6764.
+		var saCreatedAtPtr *time.Time
+		if !sa.CreationTimestamp.Time.IsZero() {
+			saCreatedAt := sa.CreationTimestamp.Time
+			saCreatedAtPtr = &saCreatedAt
+		}
 		result = append(result, models.K8sServiceAccount{
 			Name:      sa.Name,
 			Namespace: sa.Namespace,
 			Cluster:   contextName,
 			Secrets:   secrets,
 			Roles:     roles,
-			CreatedAt: &saCreatedAt,
+			CreatedAt: saCreatedAtPtr,
 		})
 	}
 
@@ -370,12 +377,19 @@ func (m *MultiClusterClient) CreateServiceAccount(ctx context.Context, contextNa
 		return nil, err
 	}
 
-	createdAt := created.CreationTimestamp.Time
+	// Leave CreatedAt nil when CreationTimestamp is zero so the JSON
+	// `omitempty` tag drops the field instead of emitting
+	// "0001-01-01T00:00:00Z" (fake clientset, partial metadata). See #6764.
+	var createdAtPtr *time.Time
+	if !created.CreationTimestamp.Time.IsZero() {
+		createdAt := created.CreationTimestamp.Time
+		createdAtPtr = &createdAt
+	}
 	return &models.K8sServiceAccount{
 		Name:      created.Name,
 		Namespace: created.Namespace,
 		Cluster:   contextName,
-		CreatedAt: &createdAt,
+		CreatedAt: createdAtPtr,
 	}, nil
 }
 

--- a/pkg/k8s/rbac_test.go
+++ b/pkg/k8s/rbac_test.go
@@ -4,10 +4,13 @@ import (
 	"context"
 	"testing"
 
+	"time"
+
 	authv1 "k8s.io/api/authorization/v1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/fake"
 	k8stesting "k8s.io/client-go/testing"
@@ -134,4 +137,64 @@ func TestRBAC_CheckClusterAdminAccess(t *testing.T) {
 	if !isAdmin {
 		t.Error("Expected cluster admin access")
 	}
+}
+
+// TestParseOpenShiftUser_CreatedAt verifies that parseOpenShiftUser leaves
+// CreatedAt nil when the creationTimestamp field is missing or unparseable,
+// and sets it to the parsed value on a valid RFC3339 string. See issue #6764.
+func TestParseOpenShiftUser_CreatedAt(t *testing.T) {
+	t.Run("missing creationTimestamp leaves CreatedAt nil", func(t *testing.T) {
+		item := unstructured.Unstructured{
+			Object: map[string]interface{}{
+				"metadata": map[string]interface{}{
+					"name": "alice",
+				},
+			},
+		}
+		user := parseOpenShiftUser(item, "c1")
+		if user.CreatedAt != nil {
+			t.Errorf("expected CreatedAt nil, got %v", user.CreatedAt)
+		}
+		if user.Name != "alice" {
+			t.Errorf("expected name alice, got %q", user.Name)
+		}
+	})
+
+	t.Run("unparseable creationTimestamp leaves CreatedAt nil", func(t *testing.T) {
+		item := unstructured.Unstructured{
+			Object: map[string]interface{}{
+				"metadata": map[string]interface{}{
+					"name":              "bob",
+					"creationTimestamp": "not-a-date",
+				},
+			},
+		}
+		user := parseOpenShiftUser(item, "c1")
+		if user.CreatedAt != nil {
+			t.Errorf("expected CreatedAt nil on parse failure, got %v", user.CreatedAt)
+		}
+	})
+
+	t.Run("valid RFC3339 creationTimestamp is parsed", func(t *testing.T) {
+		const ts = "2024-01-02T03:04:05Z"
+		item := unstructured.Unstructured{
+			Object: map[string]interface{}{
+				"metadata": map[string]interface{}{
+					"name":              "carol",
+					"creationTimestamp": ts,
+				},
+			},
+		}
+		user := parseOpenShiftUser(item, "c1")
+		if user.CreatedAt == nil {
+			t.Fatal("expected CreatedAt non-nil for valid RFC3339 input")
+		}
+		want, err := time.Parse(time.RFC3339, ts)
+		if err != nil {
+			t.Fatalf("setup: time.Parse: %v", err)
+		}
+		if !user.CreatedAt.Equal(want) {
+			t.Errorf("CreatedAt = %v, want %v", user.CreatedAt, want)
+		}
+	})
 }


### PR DESCRIPTION
Closes #6764

Copilot follow-up to merged PR #6761.

## Bugs
1. `ListServiceAccounts` (pkg/k8s/rbac.go ~L74) unconditionally took `&sa.CreationTimestamp.Time`, so a zero timestamp (fake clientset, partial metadata) serialized as `0001-01-01T00:00:00Z` instead of being dropped by `omitempty`.
2. `CreateServiceAccount` (~L379) had the same bug on the created object.
3. The new "leave nil on parse failure" behavior in `parseOpenShiftUser` (~L984) had no test coverage.

## Fix
Both producer sites now gate the pointer on `!t.IsZero()`, matching the pattern already used in `parseOpenShiftUser`.

## Tests
Added `TestParseOpenShiftUser_CreatedAt` with three subtests:
- missing `creationTimestamp` field -> `CreatedAt == nil`
- unparseable `creationTimestamp: "not-a-date"` -> `CreatedAt == nil`
- valid RFC3339 -> `CreatedAt != nil` and equal to parsed value

## Verify
- `go build ./...` clean
- `go test ./pkg/k8s/...` passes
- `go vet ./pkg/k8s/...` clean
- `web && npm run build` passes (frontend unaffected)