### PR TITLE
fix(missions): clear remaining timer/intent refs on cross-tab reset + type-safe Set + log msg (#6767)

### DIFF
--- a/web/src/hooks/useMissions.tsx
+++ b/web/src/hooks/useMissions.tsx
@@ -654,16 +654,34 @@ export function MissionProvider({ children }: { children: ReactNode }) {
       if (e.newValue === null) {
         try {
           setMissions([])
-          setUnreadMissionIds(new Set())
+          // #6767 — `new Set()` defaults to `Set<any>`; keep type-safety by
+          // matching the `Set<string>` declaration of `unreadMissionIds`.
+          setUnreadMissionIds(new Set<string>())
           setActiveMissionId(null)
+          // #6767 — Clear ALL mission-derived refs, not just the three from
+          // #6762. Any ref keyed by missionId references missions that were
+          // just wiped; leaving them populated leaks timers and/or makes
+          // future messages target stale mission IDs.
           for (const timeout of cancelTimeouts.current.values()) {
             clearTimeout(timeout)
           }
           cancelTimeouts.current.clear()
+          // #6767 — Timeout handles must be cleared individually before
+          // dropping the Map, otherwise the watchdog fires against a
+          // non-existent mission.
+          for (const timeout of waitingInputTimeouts.current.values()) {
+            clearTimeout(timeout)
+          }
+          waitingInputTimeouts.current.clear()
+          cancelIntents.current.clear()
           pendingRequests.current.clear()
           lastStreamTimestamp.current.clear()
+          toolsInFlight.current.clear()
+          streamSplitCounter.current.clear()
         } catch (err) {
-          console.warn('[Missions] issue 6758 — failed to apply cross-tab reset:', err)
+          // #6767 — Message is issue-agnostic; this branch now covers
+          // #6758, #6762, and #6767 follow-ups.
+          console.warn('[Missions] Cross-tab remote reset detected — failed to clear local mission state to match:', err)
         }
         return
       }


### PR DESCRIPTION
Closes #6767

Copilot follow-up on merged PR #6763. The cross-tab remote reset branch (`e.newValue === null`) in `web/src/hooks/useMissions.tsx` had three nits:

## Changes

1. **Additional per-mission refs cleared.** Any `useRef<Map|Set>` keyed by missionId references missions that were just wiped; leaving them populated leaks timers or makes future messages target stale IDs. Added to the reset block:
   - `waitingInputTimeouts` — iterates handles via `clearTimeout` then `.clear()` (avoids leaked watchdog timers, #5936)
   - `cancelIntents` — `.clear()` (cancel-intent set keyed by missionId, #6370)
   - `toolsInFlight` — `.clear()` (per-mission open tool-call counter, #6376)
   - `streamSplitCounter` — `.clear()` (per-mission stream-split counter, #6378)

2. **Type-safe Set.** `setUnreadMissionIds(new Set())` defaulted to `Set<any>`; now explicitly typed `new Set<string>()` to match the state declaration.

3. **Issue-agnostic log message.** The warning previously said "issue 6758" but this branch now also handles #6762 and #6767. Reworded to be issue-agnostic.

## Verification

- `npm run build` passes
- `npx vitest run src/hooks/__tests__/useDeployMissions src/hooks/__tests__/useMissionSuggestions` — 96/96 passing

## Notes

`wsSendRetryTimers` is NOT per-mission (global WS send retry queue, #6629) and is intentionally left alone.