### PR TITLE
fix: CardRequestDialog concurrent submission + ratchet false-positive cleanup (#6778)

### DIFF
--- a/web/src/components/clusters/ClusterDetailModal.tsx
+++ b/web/src/components/clusters/ClusterDetailModal.tsx
@@ -350,7 +350,7 @@ After I approve, help me execute the repairs step by step.`,
           </button>
         </div>
 
-        {/* Error banner when cluster health fetch fails (#6772) */}
+        {/* Error banner when cluster health fetch fails (issue 6772) */}
         {healthError && (
           <div className="mb-4 p-3 rounded-lg bg-red-500/20 border border-red-500/50 flex items-center gap-2 text-sm text-red-400">
             <AlertTriangle className="w-4 h-4 flex-shrink-0" />

--- a/web/src/components/mission-control/FlightPlanBlueprint.tsx
+++ b/web/src/components/mission-control/FlightPlanBlueprint.tsx
@@ -873,7 +873,7 @@ export function FlightPlanBlueprint({
         </div>
       </div>
 
-      {/* Error banner when cluster data fails to load (#6772) */}
+      {/* Error banner when cluster data fails to load (issue 6772) */}
       {/* TODO: error banner will activate once useClusters() propagates fetch errors */}
       {clustersError && (
         <div className="mx-6 mt-2 p-2 rounded-lg bg-red-500/20 border border-red-500/50 flex items-center gap-2 text-xs text-red-400">

--- a/web/src/components/missions/CardRequestDialog.tsx
+++ b/web/src/components/missions/CardRequestDialog.tsx
@@ -19,12 +19,12 @@ interface CardRequestDialogProps {
 export function CardRequestDialog({ missingProjects, onClose }: CardRequestDialogProps) {
   const { t } = useTranslation()
   const { showToast } = useToast()
-  const [submittingProject, setSubmittingProject] = useState<string | null>(null)
+  const [submittingProjects, setSubmittingProjects] = useState<Set<string>>(new Set())
   const [submitted, setSubmitted] = useState<Set<string>>(new Set())
   const [failedProjects, setFailedProjects] = useState<Set<string>>(new Set())
 
   const handleRequest = useCallback(async (project: string) => {
-    setSubmittingProject(project)
+    setSubmittingProjects(prev => new Set(prev).add(project))
     setFailedProjects(prev => { const next = new Set(prev); next.delete(project); return next })
     try {
       await api.post('/api/feedback/requests', {
@@ -39,7 +39,7 @@ export function CardRequestDialog({ missingProjects, onClose }: CardRequestDialo
       setFailedProjects(prev => new Set(prev).add(project))
       showToast('Could not submit request — try opening a GitHub issue directly', 'warning')
     } finally {
-      setSubmittingProject(null)
+      setSubmittingProjects(prev => { const next = new Set(prev); next.delete(project); return next })
     }
   }, [showToast])
 
@@ -71,7 +71,7 @@ export function CardRequestDialog({ missingProjects, onClose }: CardRequestDialo
             ) : failedProjects.has(project) ? (
               <button
                 onClick={() => handleRequest(project)}
-                disabled={submittingProject === project}
+                disabled={submittingProjects.has(project)}
                 className="flex items-center gap-1 px-2 py-1 text-[10px] font-medium text-red-400 hover:bg-red-500/10 rounded transition-colors"
               >
                 <Send className="w-2.5 h-2.5" />
@@ -80,15 +80,15 @@ export function CardRequestDialog({ missingProjects, onClose }: CardRequestDialo
             ) : (
               <button
                 onClick={() => handleRequest(project)}
-                disabled={submittingProject === project}
+                disabled={submittingProjects.has(project)}
                 className="flex items-center gap-1 px-2 py-1 text-[10px] font-medium text-primary hover:bg-primary/10 rounded transition-colors"
               >
-                {submittingProject === project ? (
+                {submittingProjects.has(project) ? (
                   <Loader2 className="w-2.5 h-2.5 animate-spin" />
                 ) : (
                   <Send className="w-2.5 h-2.5" />
                 )}
-                {submittingProject === project ? t('orbit.cardRequestSending') : t('orbit.cardRequestAction')}
+                {submittingProjects.has(project) ? t('orbit.cardRequestSending') : t('orbit.cardRequestAction')}
               </button>
             )}
           </div>

--- a/web/src/test/ui-ux-standards.test.ts
+++ b/web/src/test/ui-ux-standards.test.ts
@@ -67,12 +67,12 @@ const COMPONENTS_DIR = path.resolve(
 //   301 → 302: #6308 MissionBrowser close button on right issue ref
 //   302 → 303: #6309 upgrade confirm dialog issue ref
 //   303 → 304: #6366 ratchet drift — pre-existing unaccounted-for raw hex from before 303 bump, not introduced by #6365
-//   304 → 306: #6774 loading/error states added error banner hex colors (red/amber) in FlightPlanBlueprint + ClusterComparisonPage
+//   304 → 306: issue 6774 loading/error states — reverted to 304 in issue 6778 (false positives from issue-ref comments rewritten to "issue NNNN" form)
 //
 // When you bump this number, append a one-line entry above so future
 // bumps stay grep-able and reviewers can tell at a glance whether a
 // change is a real new violation or just a comment-level reference.
-const EXPECTED_RAW_HEX_COUNT = 306
+const EXPECTED_RAW_HEX_COUNT = 304
 const EXPECTED_RAW_RGBA_COUNT = 104
 const EXPECTED_ARBITRARY_TW_COLOR_COUNT = 22
 const EXPECTED_INLINE_STYLE_COLOR_COUNT = 213


### PR DESCRIPTION
Closes #6778

## Summary
- **CardRequestDialog concurrency**: Changed `submittingProject` (single string) to `submittingProjects` (Set) so each project's submit button is independently disabled/spinning — concurrent submissions no longer overwrite each other.
- **Ratchet false positives**: Rewrote 2 JSX comments from `(#6772)` to `(issue 6772)` in FlightPlanBlueprint.tsx and ClusterDetailModal.tsx — the `#6772` pattern looked like a hex color to the scanner.
- **Ratchet baseline**: Lowered `EXPECTED_RAW_HEX_COUNT` from 306 back to 304.

## Files changed
- `web/src/components/missions/CardRequestDialog.tsx` — Set-based concurrent submission state
- `web/src/components/mission-control/FlightPlanBlueprint.tsx` — issue-ref comment rewrite
- `web/src/components/clusters/ClusterDetailModal.tsx` — issue-ref comment rewrite
- `web/src/test/ui-ux-standards.test.ts` — ratchet baseline 306 → 304

## Verification
- `npm run build` passes
- `npx vitest run src/test/ui-ux-standards.test.ts` passes (7/7)