### PR TITLE
fix(missions): unmount safety, keydown capture, ref assignment, test isolation (#6785-#6789)

### DIFF
--- a/web/src/components/mission-control/LaunchSequence.tsx
+++ b/web/src/components/mission-control/LaunchSequence.tsx
@@ -300,24 +300,38 @@ export function LaunchSequence({
    * "fully succeeded" from "terminally failed" and block dependent phases
    * when a failure occurred.
    */
-  const waitForPhaseCompletion = useCallback((phaseNum: number): Promise<PhaseStatus> => {
-    return new Promise((resolve) => {
+  const waitForPhaseCompletion = useCallback((phaseNum: number, signal?: AbortSignal): Promise<PhaseStatus> => {
+    return new Promise((resolve, reject) => {
       /** Poll interval in ms — checks progressRef for phase terminal state */
       const PHASE_POLL_INTERVAL_MS = 500
+      let timer: ReturnType<typeof setTimeout> | null = null
+
+      const onAbort = () => {
+        if (timer !== null) clearTimeout(timer)
+        reject(new DOMException('Phase wait aborted', 'AbortError'))
+      }
+
+      if (signal?.aborted) {
+        onAbort()
+        return
+      }
+      signal?.addEventListener('abort', onAbort, { once: true })
+
       const check = () => {
         const phase = progressRef.current.find((p) => p.phase === phaseNum)
         if (phase && TERMINAL_STATUSES.includes(phase.status)) {
+          signal?.removeEventListener('abort', onAbort)
           resolve(phase.status)
           return
         }
-        setTimeout(check, PHASE_POLL_INTERVAL_MS)
+        timer = setTimeout(check, PHASE_POLL_INTERVAL_MS)
       }
       check()
     })
   }, [])
 
   // Execute the launch sequence
-  const startLaunch = async () => {
+  const startLaunch = async (abortSignal?: AbortSignal) => {
     if (isStarted) return
     setIsStarted(true)
 
@@ -362,7 +376,7 @@ export function LaunchSequence({
         // means at least one project in this phase is terminally failed and
         // the user is looking at a "Retry Failed" button — we must NOT
         // auto-advance to dependent phases from that state.
-        const result = await waitForPhaseCompletion(phase.phase)
+        const result = await waitForPhaseCompletion(phase.phase, abortSignal)
         if (result !== 'completed') {
           // Block dependent phases. The Retry Failed button will re-invoke
           // launchProject for the failed entries; if the retry succeeds, the
@@ -374,10 +388,17 @@ export function LaunchSequence({
   }
 
   // Auto-start on mount — keyed on content signature (#5508)
+  // #6785 — AbortController cancels waitForPhaseCompletion polling on unmount
+  // so leaked timers and stale setState calls cannot occur.
   useEffect(() => {
+    const controller = new AbortController()
     if (!isStarted && effectivePhases.length > 0) {
-      startLaunch()
+      startLaunch(controller.signal).catch((err: unknown) => {
+        if (err instanceof DOMException && err.name === 'AbortError') return
+        throw err
+      })
     }
+    return () => { controller.abort() }
   }, [phaseSignature])
 
   const progress = state.launchProgress.length > 0 ? state.launchProgress : progressRef.current

--- a/web/src/components/mission-control/MissionControlDialog.tsx
+++ b/web/src/components/mission-control/MissionControlDialog.tsx
@@ -106,10 +106,11 @@ export function MissionControlDialog({ open, onClose }: MissionControlDialogProp
     setHighestReached(prev => Math.max(prev, currentStepIndex))
   }, [currentStepIndex])
 
+  // #6787 — Use capture phase so child stopPropagation cannot swallow Escape
   useEffect(() => {
     if (!open) return
-    document.addEventListener('keydown', handleKeyDown)
-    return () => document.removeEventListener('keydown', handleKeyDown)
+    document.addEventListener('keydown', handleKeyDown, { capture: true })
+    return () => document.removeEventListener('keydown', handleKeyDown, { capture: true })
   }, [open, handleKeyDown])
 
   // #6758 (Copilot on PR #6755) — Surface a toast when a previous

--- a/web/src/components/mission-control/__tests__/useMissionControl.test.tsx
+++ b/web/src/components/mission-control/__tests__/useMissionControl.test.tsx
@@ -5,14 +5,22 @@
  *  - #6383 empty-projects filter in extractJSON
  */
 
-import { describe, it, expect } from 'vitest'
+import { afterEach, describe, it, expect } from 'vitest'
 import {
   isSafeProjectName,
   buildInstallPromptForProject,
   extractJSON,
   mergeProjects,
   PROJECT_NAME_MAX_LENGTH,
+  resetOversizedWarnings,
 } from '../useMissionControl'
+
+// #6788 — Clear module-level singleton between tests to prevent pollution.
+// `oversizedWarnSet` is module-scoped; without this, a test that triggers an
+// oversize warning suppresses the warning in all subsequent tests.
+afterEach(() => {
+  resetOversizedWarnings()
+})
 import type { PayloadProject } from '../types'
 
 const makeProject = (overrides: Partial<PayloadProject>): PayloadProject => ({

--- a/web/src/components/mission-control/useMissionControl.ts
+++ b/web/src/components/mission-control/useMissionControl.ts
@@ -547,6 +547,7 @@ export function useMissionControl() {
   // on `!clustersLoading && clustersLastUpdated != null` so an empty cached
   // state during initial fetch does not wipe valid persisted assignments.
   useEffect(() => {
+    let isMounted = true
     if (staleReconcileDoneRef.current) return
     if (!clusters) return
     // issue 6427 — wait until useClusters() has produced a real load, not
@@ -587,6 +588,8 @@ export function useMissionControl() {
     // (the live cluster list), not a react-to-user event, so setState in
     // this effect is the right tool here. The ref guard above ensures it
     // runs exactly once per load.
+    // #6786 — isMounted guard prevents setState after unmount.
+    if (!isMounted) return
     /* eslint-disable react-hooks/set-state-in-effect */
     setStaleClusterNames(allStale)
     const staleAssignmentNames = new Set(staleFromAssignments)
@@ -603,6 +606,7 @@ export function useMissionControl() {
     console.warn(
       `[MissionControl] issue 6403 — dropped ${allStale.length} stale cluster reference(s) from persisted state: ${allStale.join(', ')}`,
     )
+    return () => { isMounted = false }
   }, [clusters, clustersLoading, clustersLastUpdated, state.assignments, state.targetClusters])
 
   const acknowledgeStaleClusters = () => {

--- a/web/src/hooks/useMissions.tsx
+++ b/web/src/hooks/useMissions.tsx
@@ -501,19 +501,19 @@ export function MissionProvider({ children }: { children: ReactNode }) {
   // Prevents missions from getting stuck in 'waiting_input' indefinitely if
   // the backend never delivers a final result message.
   const waitingInputTimeouts = useRef<Map<string, ReturnType<typeof setTimeout>>>(new Map())
-  // Ref to always hold the latest missions state — avoids stale closure in sendMessage (#3322)
+  // Refs to always hold the latest values — avoids stale closures in callbacks.
+  // #6789 — Ref writes belong in useEffect, not the component body, to avoid
+  // impure render functions in React concurrent mode.
   const missionsRef = useRef<Mission[]>(missions)
-  missionsRef.current = missions
-  // Refs to always hold the latest activeMissionId and isSidebarOpen — avoids stale closures in markMissionAsUnread
   const activeMissionIdRef = useRef(activeMissionId)
-  activeMissionIdRef.current = activeMissionId
   const isSidebarOpenRef = useRef(isSidebarOpen)
-  isSidebarOpenRef.current = isSidebarOpen
-  // Refs to always hold the latest selectedAgent and defaultAgent — avoids stale closures in startMission/executeMission (#4228)
   const selectedAgentRef = useRef(selectedAgent)
-  selectedAgentRef.current = selectedAgent
   const defaultAgentRef = useRef(defaultAgent)
-  defaultAgentRef.current = defaultAgent
+  useEffect(() => { missionsRef.current = missions }, [missions])
+  useEffect(() => { activeMissionIdRef.current = activeMissionId }, [activeMissionId])
+  useEffect(() => { isSidebarOpenRef.current = isSidebarOpen }, [isSidebarOpen])
+  useEffect(() => { selectedAgentRef.current = selectedAgent }, [selectedAgent])
+  useEffect(() => { defaultAgentRef.current = defaultAgent }, [defaultAgent])
   // Ref to always hold the latest handleAgentMessage — avoids reconnecting WebSocket when the handler changes
   const handleAgentMessageRef = useRef<(message: { id: string; type: string; payload?: unknown }) => void>(() => {})
   // Ref to track pending WebSocket reconnection timeout so it can be cleared on unmount (#3318)


### PR DESCRIPTION
Closes #6785
Closes #6786
Closes #6787
Closes #6788
Closes #6789

## Summary

Five mission-area cleanups from @mrhapile's issue batch:

- **#6785** `LaunchSequence.tsx`: `waitForPhaseCompletion` now accepts an `AbortSignal`. The calling `useEffect` creates an `AbortController` and aborts on cleanup, preventing leaked `setTimeout` polling and stale `setState` after unmount.
- **#6786** `useMissionControl.ts`: Reconciliation `useEffect` adds an `isMounted` flag (set `false` in cleanup) to guard `setState` calls against post-unmount execution.
- **#6787** `MissionControlDialog.tsx`: Escape keydown listener uses `{ capture: true }` so child elements that `stopPropagation` on keydown cannot swallow the Escape handler.
- **#6788** `useMissionControl.test.tsx`: Added `afterEach(() => resetOversizedWarnings())` to clear the module-level `oversizedWarnSet` singleton between test cases, preventing cross-test pollution.
- **#6789** `useMissions.tsx`: Moved ref assignments (`missionsRef`, `activeMissionIdRef`, `isSidebarOpenRef`, `selectedAgentRef`, `defaultAgentRef`) from the component body into `useEffect` hooks for React concurrent mode render purity.

## Test plan

- [x] `npm run build` passes
- [x] `vitest run` on mission-control + useDeployMissions + useMissionSuggestions: 124/124 pass
- [ ] CI build/lint