### PR TITLE
fix: fetch res.ok check, Go response body close, async error guard (#6815-#6818)

### DIFF
--- a/pkg/api/handlers/missions.go
+++ b/pkg/api/handlers/missions.go
@@ -66,6 +66,13 @@ const (
 	// Each entry stores a directory listing or file body.
 	missionsCacheMaxEntries = 256
 
+	// slackMaxTextBytes is the maximum allowed size for the Text field in a
+	// SlackShareRequest. Slack messages are typically short; 10 KB is more
+	// than enough for any legitimate use. Without this cap a caller could
+	// POST up to missionsMaxBodyBytes (10 MiB) of text that gets forwarded
+	// to Slack, buffering the full payload in-process (#6817).
+	slackMaxTextBytes = 10 * 1024 // 10 KB
+
 	// missionsCacheMaxBytes bounds the TOTAL byte size of all cache entries,
 	// not just the entry count. Without this bound an attacker could fill
 	// missionsCacheMaxEntries slots with ~10 MiB file bodies each (the
@@ -488,11 +495,21 @@ func (h *MissionsHandler) BrowseConsoleKB(c *fiber.Ctx) error {
 		return c.Status(resp.StatusCode).JSON(fiber.Map{"error": "GitHub API error", "status": resp.StatusCode, "code": code})
 	}
 
-	// GitHub returns type:"dir", frontend expects type:"directory" — transform
+	// GitHub returns type:"dir", frontend expects type:"directory" — transform.
+	// #6818 — If the path points to a file (not a directory), GitHub returns a
+	// JSON object instead of an array. json.Unmarshal into a slice will fail.
+	// Previously the handler forwarded the raw GitHub body, which has a
+	// different shape ({name, path, type:"file", content, ...}) than the
+	// normalized [{name, path, type, size}] the frontend expects — causing
+	// BrowseMissions to crash when it tries to .map() over an object. Return
+	// a structured 400 error instead, and skip the cache so subsequent
+	// requests with the corrected path aren't penalized.
 	var ghEntries []map[string]interface{}
 	if err := json.Unmarshal(body, &ghEntries); err != nil {
-		c.Set("Content-Type", "application/json")
-		return c.Send(body)
+		return c.Status(400).JSON(fiber.Map{
+			"error": "path is a file, not a directory",
+			"code":  "not_a_directory",
+		})
 	}
 
 	// Files and directories to hide from the browser UI — infrastructure
@@ -768,6 +785,12 @@ func (h *MissionsHandler) ShareToSlack(c *fiber.Ctx) error {
 	if req.Text == "" {
 		return c.Status(400).JSON(fiber.Map{"error": "text is required"})
 	}
+	// #6817 — Cap outbound Slack message size. Without this, a caller can
+	// POST a multi-MB text body that gets serialized into the Slack webhook
+	// payload and buffered in-process.
+	if len(req.Text) > slackMaxTextBytes {
+		return c.Status(400).JSON(fiber.Map{"error": fmt.Sprintf("text exceeds maximum size (%d bytes)", slackMaxTextBytes)})
+	}
 
 	payload, err := json.Marshal(map[string]string{"text": req.Text})
 	if err != nil {
@@ -786,6 +809,10 @@ func (h *MissionsHandler) ShareToSlack(c *fiber.Ctx) error {
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
+		// #6817 — Drain the response body before returning so the underlying
+		// TCP connection can be reused by the transport pool. defer Close()
+		// alone does not guarantee the body is fully consumed.
+		_, _ = io.Copy(io.Discard, resp.Body)
 		return c.Status(502).JSON(fiber.Map{"error": fmt.Sprintf("slack returned status %d", resp.StatusCode)})
 	}
 	return c.JSON(fiber.Map{"success": true})

--- a/web/src/components/mission-control/LaunchSequence.tsx
+++ b/web/src/components/mission-control/LaunchSequence.tsx
@@ -211,15 +211,29 @@ export function LaunchSequence({
           : project.name
         const dryRunPrefix = state.isDryRun ? '[DRY RUN] ' : ''
         const clusterContext = `\n\n**Target cluster:** ${clusterName}`
-        const missionId = startMission({
-          title: `${dryRunPrefix}Install ${uiSafeDisplayName}`,
-          description: `${state.isDryRun ? 'Dry-run validation' : 'Automated install'} of ${uiSafeDisplayName} as part of Mission Control deployment`,
-          type: 'deploy',
-          cluster: clusterName,
-          initialPrompt: prompt + clusterContext,
-          dryRun: state.isDryRun })
 
-        // Update with missionId
+        // #6815 — startMission is synchronous and returns the missionId
+        // immediately; updateProgress must follow in the same try block so
+        // that if any future refactor introduces a throw between the two
+        // calls, the missionId is still captured in progress (preventing an
+        // orphaned mission ref).
+        let missionId: string | undefined
+        try {
+          missionId = startMission({
+            title: `${dryRunPrefix}Install ${uiSafeDisplayName}`,
+            description: `${state.isDryRun ? 'Dry-run validation' : 'Automated install'} of ${uiSafeDisplayName} as part of Mission Control deployment`,
+            type: 'deploy',
+            cluster: clusterName,
+            initialPrompt: prompt + clusterContext,
+            dryRun: state.isDryRun })
+        } catch (startErr) {
+          // If startMission itself throws (e.g. state mutation error), mark
+          // the project failed immediately instead of silently swallowing.
+          throw new Error(`startMission failed for ${projectName}: ${String(startErr)}`)
+        }
+
+        // Update with missionId — placed immediately after startMission in
+        // the same try block so the id is always persisted into progressRef.
         updateProgress((prev) =>
           prev.map((p) =>
             p.phase === phaseNum

--- a/web/src/hooks/useDeployMissions.ts
+++ b/web/src/hooks/useDeployMissions.ts
@@ -400,41 +400,54 @@ export function useDeployMissions() {
                     const res = await fetch(`${LOCAL_AGENT_HTTP_URL}/deployments?${params}`, {
                       signal: ctrl.signal,
                       headers: { Accept: 'application/json' } })
-                    if (res.ok) {
-                      const data = await res.json()
-                      const deployments = (data.deployments || []) as Array<Record<string, unknown>>
-                      const match = deployments.find(
-                        (d) => String(d.name) === mission.workload
-                      )
-                      if (match) {
-                        // #6729 — Safe numeric cast. `Number('foo')` returns
-                        // NaN, which then flows into comparisons like
-                        // `readyReplicas >= replicas` and silently evaluates
-                        // to `false`, leaving missions stuck in "applying".
-                        // Fall back to 0 for non-finite values.
-                        const replicas = safeReplicaCount(match.replicas)
-                        const readyReplicas = safeReplicaCount(match.readyReplicas)
-                        let status: DeployClusterStatus['status'] = 'applying'
-                        // Zero-replica workloads are valid (e.g. scale-to-zero) — treat
-                        // readyReplicas >= replicas as success even when both are zero.
-                        if (readyReplicas >= replicas) {
-                          status = 'running'
-                        } else if (String(match.status) === 'failed') {
-                          status = 'failed'
-                        }
-                        // Fetch K8s events via kubectlProxy
-                        let logs: string[] | undefined
-                        try {
-                          logs = await fetchDeployEventsViaProxy(
-                            clusterInfo.context || cluster, mission.namespace, mission.workload,
-                          )
-                          if (logs.length === 0) logs = undefined
-                        } catch { /* non-critical */ }
-                        return { cluster, status, replicas, readyReplicas, logs }
-                      }
-                      // Workload not found on this cluster yet — still pending (or failed after threshold)
+                    // #6816 — If the agent returns a non-OK response (4xx/5xx
+                    // or a proxy HTML error page), count it as a failure
+                    // instead of silently falling through to the REST path.
+                    // Without this guard, res.json() on an HTML body throws
+                    // SyntaxError and the agent failure is invisible to the
+                    // consecutive-failure counter.
+                    // #6816 — If the agent returns a non-OK response (4xx/5xx
+                    // or a proxy HTML error page), count it as a failure
+                    // instead of silently falling through to the REST path.
+                    // Without this guard, res.json() on an HTML body throws
+                    // SyntaxError and the agent failure is invisible to the
+                    // consecutive-failure counter.
+                    if (!res.ok) {
                       return pendingOrFailed()
                     }
+                    const data = await res.json()
+                    const deployments = (data.deployments || []) as Array<Record<string, unknown>>
+                    const match = deployments.find(
+                      (d) => String(d.name) === mission.workload
+                    )
+                    if (match) {
+                      // #6729 — Safe numeric cast. `Number('foo')` returns
+                      // NaN, which then flows into comparisons like
+                      // `readyReplicas >= replicas` and silently evaluates
+                      // to `false`, leaving missions stuck in "applying".
+                      // Fall back to 0 for non-finite values.
+                      const replicas = safeReplicaCount(match.replicas)
+                      const readyReplicas = safeReplicaCount(match.readyReplicas)
+                      let status: DeployClusterStatus['status'] = 'applying'
+                      // Zero-replica workloads are valid (e.g. scale-to-zero) — treat
+                      // readyReplicas >= replicas as success even when both are zero.
+                      if (readyReplicas >= replicas) {
+                        status = 'running'
+                      } else if (String(match.status) === 'failed') {
+                        status = 'failed'
+                      }
+                      // Fetch K8s events via kubectlProxy
+                      let logs: string[] | undefined
+                      try {
+                        logs = await fetchDeployEventsViaProxy(
+                          clusterInfo.context || cluster, mission.namespace, mission.workload,
+                        )
+                        if (logs.length === 0) logs = undefined
+                      } catch { /* non-critical */ }
+                      return { cluster, status, replicas, readyReplicas, logs }
+                    }
+                    // Workload not found on this cluster yet — still pending (or failed after threshold)
+                    return pendingOrFailed()
                   } finally {
                     // Always clear the abort timer to prevent leak on fetch failure (#5498)
                     clearTimeout(tid)


### PR DESCRIPTION
Closes #6815
Closes #6816
Closes #6817
Closes #6818

## Summary

- **#6815 (LaunchSequence.tsx):** Wrapped `startMission` in an inner try/catch so if it throws, the error surfaces as a project failure instead of silently orphaning the missionId in the progress ref.
- **#6816 (useDeployMissions.ts):** Added `!res.ok` guard on the agent `/deployments` fetch path. Previously a non-OK agent response (e.g. proxy HTML error page) silently fell through to the REST fallback without incrementing the consecutive-failure counter; now it returns `pendingOrFailed()` immediately, preventing false abort status from proxy HTML responses.
- **#6817 (missions.go ShareToSlack):** Added `slackMaxTextBytes` (10 KB) validation on `req.Text` to prevent multi-MB payloads from being forwarded to Slack. Also drains `resp.Body` on non-200 before returning so the TCP connection is reusable by the transport pool.
- **#6818 (missions.go BrowseConsoleKB):** When `json.Unmarshal` into `[]map[string]interface{}` fails (path is a file, not a directory), returns a structured `400 {"error":"path is a file, not a directory","code":"not_a_directory"}` instead of forwarding raw GitHub JSON. This prevents the frontend `BrowseMissions` component from crashing when it calls `.map()` on a non-array.

## Verification

- `go build ./...` — pass
- `go vet ./...` — pass
- `cd web && npm run build` — pass