### PR TITLE
fix(missions): WS guards, double-execution, stale reads, Go body drain (#6828-#6835)

### DIFF
--- a/pkg/api/handlers/missions.go
+++ b/pkg/api/handlers/missions.go
@@ -1003,7 +1003,11 @@ func (h *MissionsHandler) ShareToGitHub(c *fiber.Ctx) error {
 	}
 	defer branchResp.Body.Close()
 	if branchResp.StatusCode < 200 || branchResp.StatusCode >= 300 {
-		// 422 (Unprocessable Entity) means the branch already exists, which is acceptable
+		// 422 (Unprocessable Entity) means the branch already exists, which is acceptable.
+		// #6835 — Eagerly drain the response body so the underlying HTTP/1.1
+		// connection is returned to the pool immediately instead of waiting for
+		// the deferred Close at function return (which may be 3+ HTTP calls later).
+		io.Copy(io.Discard, branchResp.Body) //nolint:errcheck // best-effort drain
 		if branchResp.StatusCode != http.StatusUnprocessableEntity {
 			return c.Status(502).JSON(fiber.Map{"error": fmt.Sprintf("GitHub branch creation failed with status %d", branchResp.StatusCode)})
 		}

--- a/web/src/components/mission-control/MissionControlDialog.tsx
+++ b/web/src/components/mission-control/MissionControlDialog.tsx
@@ -167,7 +167,14 @@ export function MissionControlDialog({ open, onClose }: MissionControlDialogProp
   const canGoBack =
     state.phase === 'assign' || state.phase === 'blueprint'
 
+  // #6828 — Ref-based guard prevents double-click from skipping a phase.
+  // The guard resets after one React render cycle via useEffect.
+  const phaseAdvancingRef = useRef(false)
+  useEffect(() => { phaseAdvancingRef.current = false }, [state.phase])
+
   const handleNext = () => {
+    if (phaseAdvancingRef.current) return
+    phaseAdvancingRef.current = true
     if (state.phase === 'define') mc.setPhase('assign')
     else if (state.phase === 'assign') mc.setPhase('blueprint')
   }

--- a/web/src/components/mission-control/useMissionControl.ts
+++ b/web/src/components/mission-control/useMissionControl.ts
@@ -5,7 +5,7 @@
  * console-kb project index lookup, and localStorage persistence.
  */
 
-import { useState, useEffect, useRef, useMemo } from 'react'
+import { useState, useEffect, useRef, useMemo, useCallback } from 'react'
 import { useMissions } from '../../hooks/useMissions'
 import { useDebouncedValue } from '../../hooks/useDebouncedValue'
 import { useHelmReleases } from '../../hooks/mcp/helm'
@@ -525,9 +525,11 @@ export function useMissionControl() {
   // apply the result if the counter hasn't advanced.
   const userMutationGenerationRef = useRef(0)
   const lastDispatchedGenerationRef = useRef(0)
-  const bumpUserGeneration = () => {
+  // #6833 — Wrap in useCallback so consumers don't re-render on every
+  // parent render. The function only mutates a ref, so it has no deps.
+  const bumpUserGeneration = useCallback(() => {
     userMutationGenerationRef.current += 1
-  }
+  }, [])
 
   // issue 6468 / #6732 — Persist on change, debounced.
   // Previously this fired on EVERY state change, which during AI streaming,
@@ -872,7 +874,11 @@ export function useMissionControl() {
   // captures a stale planningMissionId or targetClusters from a previous render (#4547).
   const stateRef = useRef(state)
   const helmReleasesRef = useRef(helmReleases)
+  // #6834 — Dedicated ref for planningMissionId so askAIForSuggestions always
+  // reads the latest value, even when a prior setState hasn't been committed yet.
+  const planningMissionIdRef = useRef(state.planningMissionId)
   useEffect(() => { stateRef.current = state }, [state])
+  useEffect(() => { planningMissionIdRef.current = state.planningMissionId }, [state.planningMissionId])
   useEffect(() => { helmReleasesRef.current = helmReleases }, [helmReleases])
 
   const askAIForSuggestions = (description: string, existingProjects: PayloadProject[] = []) => {
@@ -886,7 +892,10 @@ export function useMissionControl() {
         return
       }
       const currentHelmReleases = helmReleasesRef.current
-      let missionId = currentState.planningMissionId
+      // #6834 — Read from the dedicated ref instead of stateRef to avoid a
+      // stale null when a prior setState (which set planningMissionId) hasn't
+      // been committed yet. This prevents creating a duplicate planning mission.
+      let missionId = planningMissionIdRef.current ?? currentState.planningMissionId
 
       const existingContext =
         existingProjects.length > 0
@@ -951,6 +960,9 @@ Include real CNCF projects only. Consider dependencies between projects.`
           description: 'AI-assisted fix planning',
           type: 'custom',
           initialPrompt: prompt })
+        // #6834 — Update the ref synchronously so a rapid second click reads
+        // the missionId before React commits the setState below.
+        planningMissionIdRef.current = missionId
         setState((prev) => ({
           ...prev,
           planningMissionId: missionId,

--- a/web/src/hooks/useMissions.tsx
+++ b/web/src/hooks/useMissions.tsx
@@ -945,10 +945,19 @@ export function MissionProvider({ children }: { children: ReactNode }) {
             return prev
           })
 
-          // Side effect: schedule reconnection OUTSIDE the state updater
-          if (missionsToReconnect.length > 0) {
+          // Side effect: schedule reconnection OUTSIDE the state updater.
+          // #6832 — Deduplicate by mission ID. React StrictMode may invoke the
+          // state updater twice, pushing the same mission into the array twice.
+          // Without dedup, two wsSend calls fire per reconnecting mission.
+          const seenIds = new Set<string>()
+          const dedupedMissions = missionsToReconnect.filter(m => {
+            if (seenIds.has(m.id)) return false
+            seenIds.add(m.id)
+            return true
+          })
+          if (dedupedMissions.length > 0) {
             setTimeout(() => {
-              missionsToReconnect.forEach(mission => {
+              dedupedMissions.forEach(mission => {
                 // Find the last user message to re-send
                 const userMessages = mission.messages.filter(msg => msg.role === 'user')
                 const lastUserMessage = userMessages[userMessages.length - 1]
@@ -1365,8 +1374,12 @@ The WebSocket connection to the agent at \`${LOCAL_AGENT_WS_URL}\` was lost and 
         : null
       const resolved = persistedAvailable ? persisted : (payload.selected || safeDefaultAgent || bestAvailable)
       setSelectedAgent(resolved)
-      // If we restored a persisted agent that differs from the server's selection, tell the server
+      // If we restored a persisted agent that differs from the server's selection, tell the server.
+      // #6831 — Persist the selection to localStorage at send time (not just on
+      // agent_selected ack) so a connection drop between send and ack doesn't
+      // silently revert the user's preferred agent on the next reconnect.
       if (persistedAvailable && persisted !== payload.selected && wsRef.current?.readyState === WebSocket.OPEN) {
+        localStorage.setItem(SELECTED_AGENT_KEY, persisted)
         wsRef.current.send(JSON.stringify({
           id: `select-agent-${Date.now()}`,
           type: 'select_agent',
@@ -1536,8 +1549,12 @@ The WebSocket connection to the agent at \`${LOCAL_AGENT_WS_URL}\` was lost and 
           lastStreamTimestamp.current.delete(missionId)
         }
 
-        if (lastMsg?.role === 'assistant' && !payload.done && m.status === 'running' && !hasGap) {
-          // Append to existing assistant message mid-stream (no gap detected)
+        if (lastMsg?.role === 'assistant' && !payload.done && (m.status === 'running' || m.status === 'waiting_input') && !hasGap) {
+          // Append to existing assistant message mid-stream (no gap detected).
+          // #6829 — Also allow appending when status is 'waiting_input': if
+          // stream_done arrived before the final content chunk (out-of-order
+          // delivery), the mission is already 'waiting_input' but we must still
+          // append the late chunk instead of creating a split bubble.
           return {
             ...m,
             status: 'running' as MissionStatus,


### PR DESCRIPTION
Closes #6828
Closes #6829
Closes #6831
Closes #6832
Closes #6833
Closes #6834
Closes #6835

**#6830 (cancelMission double-call)**: Already guarded — `cancelMission` returns early if `cancelTimeouts.current.has(missionId)` and the timeout is cleared before re-setting. No code change needed (false positive).

## Changes

### Go (`pkg/api/handlers/missions.go`)
- **#6835**: Eagerly drain response body on 422 branch-exists so the HTTP/1.1 connection returns to the pool immediately.

### TypeScript
- **#6828** (`MissionControlDialog.tsx`): Ref-based guard on `handleNext` prevents double-click from skipping a wizard phase.
- **#6829** (`useMissions.tsx`): Allow appending stream chunks when status is `waiting_input` so out-of-order `stream_done` doesn't create a split message bubble.
- **#6831** (`useMissions.tsx`): Persist agent selection to localStorage at send time so a connection drop between send and ack doesn't silently revert the preference.
- **#6832** (`useMissions.tsx`): Deduplicate `missionsToReconnect` by mission ID before scheduling reconnection to prevent double `wsSend` in React StrictMode.
- **#6833** (`useMissionControl.ts`): Wrap `bumpUserGeneration` in `useCallback` to prevent cascading re-renders.
- **#6834** (`useMissionControl.ts`): Track `planningMissionId` via a dedicated ref updated synchronously at assignment time so `askAIForSuggestions` never reads a stale null.

## Verification
- `go build ./...` — pass
- `go vet ./...` — pass
- `npm run build` — pass (includes tsc + vite + post-build safety checks)