### PR TITLE
fix: test regression, Copilot cleanup, error boundary, poll stop, cache eviction, Content-Type (#6838-#6845)

### DIFF
--- a/pkg/api/handlers/missions.go
+++ b/pkg/api/handlers/missions.go
@@ -160,10 +160,13 @@ type missionsCacheEntry struct {
 // The cache key is the full request URL. Entries are evicted (oldest-first) when
 // either the entry count exceeds missionsCacheMaxEntries or the total byte size
 // exceeds missionsCacheMaxBytes (#6417).
+// #6841 — insertOrder tracks keys in insertion order for O(1) oldest-key lookup
+// during eviction, replacing the previous O(n) map scan.
 type missionsResponseCache struct {
-	mu         sync.RWMutex
-	entries    map[string]*missionsCacheEntry
-	totalBytes int
+	mu          sync.RWMutex
+	entries     map[string]*missionsCacheEntry
+	insertOrder []string
+	totalBytes  int
 }
 
 // get returns a cached entry if it exists and is within the given TTL.
@@ -198,23 +201,20 @@ func (c *missionsResponseCache) getStale(key string, staleTTL time.Duration) *mi
 
 // evictOldestLocked removes the single oldest entry from the cache. The caller
 // MUST hold c.mu in write mode. Returns true if an entry was evicted.
+// #6841 — Uses the insertOrder slice for O(1) oldest-key lookup instead of
+// scanning the entire map on every eviction.
 func (c *missionsResponseCache) evictOldestLocked() bool {
-	var oldestKey string
-	var oldestTime time.Time
-	for k, v := range c.entries {
-		if oldestKey == "" || v.fetchedAt.Before(oldestTime) {
-			oldestKey = k
-			oldestTime = v.fetchedAt
+	for len(c.insertOrder) > 0 {
+		oldestKey := c.insertOrder[0]
+		c.insertOrder = c.insertOrder[1:]
+		if prev, ok := c.entries[oldestKey]; ok {
+			c.totalBytes -= len(prev.body)
+			delete(c.entries, oldestKey)
+			return true
 		}
+		// Key was already deleted (e.g. overwritten by set); skip to next.
 	}
-	if oldestKey == "" {
-		return false
-	}
-	if prev, ok := c.entries[oldestKey]; ok {
-		c.totalBytes -= len(prev.body)
-	}
-	delete(c.entries, oldestKey)
-	return true
+	return false
 }
 
 // set stores a response in the cache, evicting older entries until both the
@@ -230,6 +230,8 @@ func (c *missionsResponseCache) set(key string, entry *missionsCacheEntry) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	// If the key already exists, account for its old size before replacing.
+	// Note: we do NOT remove from insertOrder here; evictOldestLocked skips
+	// stale entries that are no longer in the map.
 	if prev, ok := c.entries[key]; ok {
 		c.totalBytes -= len(prev.body)
 		delete(c.entries, key)
@@ -241,6 +243,7 @@ func (c *missionsResponseCache) set(key string, entry *missionsCacheEntry) {
 		}
 	}
 	c.entries[key] = entry
+	c.insertOrder = append(c.insertOrder, key)
 	c.totalBytes += entrySize
 }
 
@@ -1029,6 +1032,7 @@ func (h *MissionsHandler) ShareToGitHub(c *fiber.Ctx) error {
 	}
 	fileReq.Header.Set("Authorization", "Bearer "+token)
 	fileReq.Header.Set("Accept", "application/vnd.github.v3+json")
+	fileReq.Header.Set("Content-Type", "application/json") // #6842 — required by GitHub Contents API
 	fileResp, err := h.httpClient.Do(fileReq)
 	if err != nil {
 		return c.Status(502).JSON(fiber.Map{"error": "failed to commit file"})

--- a/web/src/components/mission-control/LaunchSequence.tsx
+++ b/web/src/components/mission-control/LaunchSequence.tsx
@@ -217,20 +217,13 @@ export function LaunchSequence({
         // that if any future refactor introduces a throw between the two
         // calls, the missionId is still captured in progress (preventing an
         // orphaned mission ref).
-        let missionId: string | undefined
-        try {
-          missionId = startMission({
-            title: `${dryRunPrefix}Install ${uiSafeDisplayName}`,
-            description: `${state.isDryRun ? 'Dry-run validation' : 'Automated install'} of ${uiSafeDisplayName} as part of Mission Control deployment`,
-            type: 'deploy',
-            cluster: clusterName,
-            initialPrompt: prompt + clusterContext,
-            dryRun: state.isDryRun })
-        } catch (startErr) {
-          // If startMission itself throws (e.g. state mutation error), mark
-          // the project failed immediately instead of silently swallowing.
-          throw new Error(`startMission failed for ${projectName}: ${String(startErr)}`)
-        }
+        const missionId = startMission({
+          title: `${dryRunPrefix}Install ${uiSafeDisplayName}`,
+          description: `${state.isDryRun ? 'Dry-run validation' : 'Automated install'} of ${uiSafeDisplayName} as part of Mission Control deployment`,
+          type: 'deploy',
+          cluster: clusterName,
+          initialPrompt: prompt + clusterContext,
+          dryRun: state.isDryRun })
 
         // Update with missionId — placed immediately after startMission in
         // the same try block so the id is always persisted into progressRef.

--- a/web/src/components/mission-control/MissionControlDialog.tsx
+++ b/web/src/components/mission-control/MissionControlDialog.tsx
@@ -28,6 +28,7 @@ import {
 import { cn } from '../../lib/cn'
 import { Button } from '../ui/Button'
 import { useToast } from '../ui/Toast'
+import { ChunkErrorBoundary } from '../ChunkErrorBoundary'
 import { useMissionControl, consumePersistQuotaBanner } from './useMissionControl'
 import { FixerDefinitionPanel } from './FixerDefinitionPanel'
 import { ClusterAssignmentPanel } from './ClusterAssignmentPanel'
@@ -161,7 +162,10 @@ export function MissionControlDialog({ open, onClose }: MissionControlDialogProp
 
   const canAdvance =
     (state.phase === 'define' && state.projects.length > 0 && !state.aiStreaming) ||
-    (state.phase === 'assign' && state.assignments.some((a) => a.projectNames.length > 0)) ||
+    (state.phase === 'assign' && (
+      state.assignments.some((a) => a.projectNames.length > 0) ||
+      state.targetClusters.length > 0
+    )) ||
     state.phase === 'blueprint'
 
   const canGoBack =
@@ -395,15 +399,17 @@ export function MissionControlDialog({ open, onClose }: MissionControlDialogProp
                 )}
                 {state.phase === 'blueprint' && (
                   <PhaseWrapper key="blueprint">
-                    <Suspense fallback={null}>
-                      <FlightPlanBlueprint
-                        state={state}
-                        onOverlayChange={mc.setOverlay}
-                        onDeployModeChange={mc.setDeployMode}
-                        onMoveProject={mc.moveProjectToCluster}
-                        installedProjects={mc.installedProjects}
-                      />
-                    </Suspense>
+                    <ChunkErrorBoundary>
+                      <Suspense fallback={null}>
+                        <FlightPlanBlueprint
+                          state={state}
+                          onOverlayChange={mc.setOverlay}
+                          onDeployModeChange={mc.setDeployMode}
+                          onMoveProject={mc.moveProjectToCluster}
+                          installedProjects={mc.installedProjects}
+                        />
+                      </Suspense>
+                    </ChunkErrorBoundary>
                   </PhaseWrapper>
                 )}
                 {(isLaunching || isComplete) && (

--- a/web/src/hooks/__tests__/useDeployMissions.test.ts
+++ b/web/src/hooks/__tests__/useDeployMissions.test.ts
@@ -1199,9 +1199,9 @@ describe('useDeployMissions', () => {
   })
 
   // =========================================================================
-  // 38. Agent fetch returns not-ok => falls through to REST
+  // 38. Agent fetch returns not-ok => counts as pending/failed (no REST fallback)
   // =========================================================================
-  it('falls to REST when agent fetch returns non-ok response', async () => {
+  it('counts agent non-ok as pending failure without falling to REST', async () => {
     const startedAt = Date.now() - MIN_ACTIVE_MS - 1
     const missions = [makeMission({
       id: 'agent-not-ok', status: 'deploying', startedAt,
@@ -1211,26 +1211,27 @@ describe('useDeployMissions', () => {
 
     mockClusterCacheRef.clusters = [{ name: 'c1', context: 'ctx-c1' }]
 
-    let callCount = 0
-    global.fetch = vi.fn().mockImplementation((url: string) => {
-      callCount++
-      if (callCount === 1) return Promise.resolve({ ok: false, status: 500 })
-      if (typeof url === 'string' && url.includes('/api/workloads/deploy-status/')) {
-        return Promise.resolve({
-          ok: true,
-          json: () => Promise.resolve({
-            status: 'Running', replicas: 1, readyReplicas: 1,
-          }),
-        })
-      }
-      return Promise.reject(new Error('unexpected'))
+    global.fetch = vi.fn().mockImplementation(() => {
+      // Agent returns non-OK — should NOT fall through to REST
+      return Promise.resolve({ ok: false, status: 500 })
     })
 
     const { result } = renderHook(() => useDeployMissions())
 
     await advancePastInitialPoll()
 
-    expect(result.current.missions[0].status).toBe('orbit')
+    // #6816 — Agent non-ok now returns pendingOrFailed() immediately;
+    // the cluster stays pending (first failure) and never hits REST.
+    const clusterStatus = result.current.missions[0].clusterStatuses[0]
+    expect(clusterStatus.status).toBe('pending')
+    expect(clusterStatus.consecutiveFailures).toBe(1)
+
+    // Verify no REST call was made (only the agent call)
+    const calls = (global.fetch as ReturnType<typeof vi.fn>).mock.calls
+    const restCalls = calls.filter((c: unknown[]) =>
+      typeof c[0] === 'string' && (c[0] as string).includes('/api/workloads/deploy-status/')
+    )
+    expect(restCalls).toHaveLength(0)
   })
 
   // =========================================================================

--- a/web/src/hooks/useDeployMissions.ts
+++ b/web/src/hooks/useDeployMissions.ts
@@ -406,12 +406,6 @@ export function useDeployMissions() {
                     // Without this guard, res.json() on an HTML body throws
                     // SyntaxError and the agent failure is invisible to the
                     // consecutive-failure counter.
-                    // #6816 — If the agent returns a non-OK response (4xx/5xx
-                    // or a proxy HTML error page), count it as a failure
-                    // instead of silently falling through to the REST path.
-                    // Without this guard, res.json() on an HTML body throws
-                    // SyntaxError and the agent failure is invisible to the
-                    // consecutive-failure counter.
                     if (!res.ok) {
                       return pendingOrFailed()
                     }
@@ -685,7 +679,17 @@ export function useDeployMissions() {
         return (bKey - aKey) || a.id.localeCompare(b.id)
       })
 
-      setMissions([...active, ...completed])
+      const allMissions = [...active, ...completed]
+      setMissions(allMissions)
+
+      // #6840 — If every mission is in a terminal state, stop polling to
+      // avoid wasting network and compute on completed deployments.
+      if (allMissions.length > 0 && allMissions.every(m => isTerminalStatus(m.status))) {
+        if (pollRef.current) {
+          clearInterval(pollRef.current)
+          pollRef.current = undefined
+        }
+      }
     }
 
     // Delay before the first poll fires after mount. Kept small so the UI


### PR DESCRIPTION
Closes #6844
Closes #6845
Closes #6838
Closes #6839
Closes #6840
Closes #6841
Closes #6842

## Summary

- **#6844**: Update test #38 — agent non-ok now returns `pendingOrFailed()` immediately per #6816 change, no REST fallback
- **#6845**: Remove duplicated `#6816` comment block in `useDeployMissions.ts`; simplify redundant nested try/catch in `LaunchSequence.tsx`
- **#6838**: Wrap lazy-loaded `FlightPlanBlueprint` in `ChunkErrorBoundary` so chunk load failures show recovery UI
- **#6839**: Add `state.targetClusters.length > 0` as alternative `canAdvance` condition for Phase 2
- **#6840**: Stop polling interval when all missions reach terminal status
- **#6841**: Replace O(n) map scan in `evictOldestLocked` with insertion-order slice for O(1) eviction
- **#6842**: Add `Content-Type: application/json` header to ShareToGitHub commit step

## Test plan

- [x] `go build ./...` and `go vet ./...` pass
- [x] `npm run build` passes
- [x] `npx vitest run src/hooks/__tests__/useDeployMissions.test.ts` — all 52 tests pass
- [ ] CI build/lint pass