### PR TITLE
fix: githubGet body drain, askAI guard, WS timer cleanup, toolsInFlight floor (#6823,#6827,#6836,#6837)

### DIFF
--- a/pkg/api/handlers/missions.go
+++ b/pkg/api/handlers/missions.go
@@ -411,6 +411,9 @@ func (h *MissionsHandler) githubGet(url string, clientToken string) (*http.Respo
 	// retry without auth — the target repo is public
 	if hasToken && (resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusForbidden || resp.StatusCode == http.StatusNotFound) {
 		slog.Info("[missions] GitHub token returned error, retrying without auth", "status", resp.StatusCode, "url", url)
+		// #6823 — Drain the body before closing so the underlying TCP
+		// connection is returned to the pool for reuse (HTTP/1.1 keep-alive).
+		io.Copy(io.Discard, resp.Body) //nolint:errcheck // best-effort drain
 		resp.Body.Close()
 		retryReq, err := http.NewRequest("GET", url, nil)
 		if err != nil {

--- a/web/src/components/mission-control/useMissionControl.ts
+++ b/web/src/components/mission-control/useMissionControl.ts
@@ -782,6 +782,9 @@ export function useMissionControl() {
     const isTerminal = TERMINAL_STATES.has(status)
     if (isStreaming !== state.aiStreaming) {
       setState((prev) => ({ ...prev, aiStreaming: isStreaming }))
+      // #6827 — Clear the synchronous guard when streaming ends so a new
+      // request can be initiated.
+      if (!isStreaming) aiRequestInFlightRef.current = false
     } else if (isTerminal && state.aiStreaming) {
       // Defensive second-pass: if the streaming flag is still true on a
       // terminal status (no intermediate 'running' ever observed), force it
@@ -790,6 +793,7 @@ export function useMissionControl() {
       // skips 'running' entirely means the effect never ran with
       // `isStreaming === true`, so we clear it explicitly here (#6669).
       setState((prev) => ({ ...prev, aiStreaming: false }))
+      aiRequestInFlightRef.current = false // #6827
     }
   }, [planningMission?.status, state.aiStreaming])
 
@@ -802,6 +806,7 @@ export function useMissionControl() {
     const timer = setTimeout(() => {
       setState((prev) => {
         if (!prev.aiStreaming) return prev
+        aiRequestInFlightRef.current = false // #6827
         return { ...prev, aiStreaming: false }
       })
     }, AI_SUGGEST_TIMEOUT_MS)
@@ -873,6 +878,11 @@ export function useMissionControl() {
   // Without this, the first click on "Suggest" can be a no-op because the callback
   // captures a stale planningMissionId or targetClusters from a previous render (#4547).
   const stateRef = useRef(state)
+  // #6827 — Synchronous guard to prevent double-invocation of askAIForSuggestions.
+  // The stateRef-based guard (aiStreaming) is updated via useEffect (async), so two
+  // rapid Enter keystrokes within a single frame can both pass it. This ref is set
+  // synchronously at the top of askAIForSuggestions and cleared when streaming ends.
+  const aiRequestInFlightRef = useRef(false)
   const helmReleasesRef = useRef(helmReleases)
   // #6834 — Dedicated ref for planningMissionId so askAIForSuggestions always
   // reads the latest value, even when a prior setState hasn't been committed yet.
@@ -882,12 +892,23 @@ export function useMissionControl() {
   useEffect(() => { helmReleasesRef.current = helmReleases }, [helmReleases])
 
   const askAIForSuggestions = (description: string, existingProjects: PayloadProject[] = []) => {
+      // #6827 — Synchronous ref guard: two rapid Enter keystrokes in a single
+      // frame can both pass the stateRef.current.aiStreaming check below because
+      // that ref is updated via useEffect (runs after render). This ref is set
+      // immediately (synchronously) so the second call sees it and bails.
+      if (aiRequestInFlightRef.current) {
+        console.warn('[MissionControl] #6827 — askAIForSuggestions already in flight (ref guard); ignoring')
+        return
+      }
+      aiRequestInFlightRef.current = true
+
       const currentState = stateRef.current
       // #6406 — Guard against rapid-click parallel requests. The button is
       // already `disabled={aiStreaming}` in the UI, but keyboard users and
       // rapid double-clicks can still land a second call before the state
       // updates — so early-return here too (belt-and-suspenders).
       if (currentState.aiStreaming) {
+        aiRequestInFlightRef.current = false
         console.warn('[MissionControl] issue 6406 — askAIForSuggestions called while already streaming; ignoring')
         return
       }

--- a/web/src/hooks/useMissions.tsx
+++ b/web/src/hooks/useMissions.tsx
@@ -956,6 +956,17 @@ export function MissionProvider({ children }: { children: ReactNode }) {
             return true
           })
           if (dedupedMissions.length > 0) {
+            // #6837 — Optimistically seed toolsInFlight for every resumed
+            // mission so the inactivity watchdog knows a tool *may* be
+            // running. Without this, a tool_result arriving for a tool whose
+            // tool_start was lost (pre-reconnect) would decrement from 0,
+            // and the watchdog would be active during a legitimately
+            // long-running tool call. The count resets to the real value
+            // once the first tool_start or tool_result frame arrives.
+            const OPTIMISTIC_TOOLS_IN_FLIGHT = 1
+            for (const mission of dedupedMissions) {
+              toolsInFlight.current.set(mission.id, OPTIMISTIC_TOOLS_IN_FLIGHT)
+            }
             setTimeout(() => {
               dedupedMissions.forEach(mission => {
                 // Find the last user message to re-send
@@ -1087,6 +1098,14 @@ export function MissionProvider({ children }: { children: ReactNode }) {
             )
           }
 
+          // #6836 — Cancel pending wsSend retry timers so they don't fire
+          // on the dead socket. The main unmount effect also clears these,
+          // but onclose fires on transient disconnects (not just unmount).
+          for (const handle of wsSendRetryTimers.current) {
+            clearTimeout(handle)
+          }
+          wsSendRetryTimers.current.clear()
+
           // Transient disconnect handling (#5929): instead of failing running
           // missions immediately, mark them with needsReconnect so that the
           // auto-reconnect loop (above) can resume them once the WebSocket
@@ -1190,6 +1209,12 @@ The WebSocket connection to the agent at \`${LOCAL_AGENT_WS_URL}\` was lost and 
           // branch above wasn't entered. Late responses from the dead
           // socket must not be misattributed.
           pendingRequests.current.clear()
+          // #6836 — Cancel pending wsSend retry timers on error so they
+          // don't fire on the dead/closed socket.
+          for (const handle of wsSendRetryTimers.current) {
+            clearTimeout(handle)
+          }
+          wsSendRetryTimers.current.clear()
           // #6376 — drop any tool-in-flight tracking for the dead socket;
           // the agent will re-report status after the reconnect.
           toolsInFlight.current.clear()


### PR DESCRIPTION
Closes #6823
Closes #6827
Closes #6836
Closes #6837

## Changes

- **#6823 (Go)**: Drain `resp.Body` before `Close()` in `githubGet` retry path so the TCP connection returns to the HTTP/1.1 keep-alive pool instead of being discarded.
- **#6827 (useMissionControl)**: Add synchronous `useRef` guard (`aiRequestInFlightRef`) to `askAIForSuggestions`. The existing `stateRef.current.aiStreaming` check is updated via `useEffect` (async), so two rapid Enter keystrokes within a single frame could both pass it. The ref is set immediately and cleared when streaming ends.
- **#6836 (useMissions)**: Clear `wsSendRetryTimers` in both `onclose` and `onerror` WebSocket handlers. Previously only the main unmount `useEffect` cleared them, so retry timers surviving a transient disconnect could fire on a dead socket and invoke `onFailure` on an unmounted component.
- **#6837 (useMissions)**: Seed `toolsInFlight` optimistically (count=1) for every mission being resumed on reconnect. Without this, a `tool_result` arriving for a tool whose `tool_start` was lost during disconnect would find count=0, and the inactivity watchdog would remain active during a legitimately long-running tool call.

## Verification

- `go build ./...` and `go vet ./...` pass
- `npm run build` passes (tsc + vite + post-build safety checks)
- No overlap with PR #6847 (that PR touched `useDeployMissions.ts`, `LaunchSequence.tsx`, `MissionControlDialog.tsx`; this PR touches `missions.go` githubGet, `useMissionControl.ts` askAI, `useMissions.tsx` WS handlers)