### PR TITLE
fix: mission cache safety, ValidateMission size limit, concurrency validation (#6820-#6822,#6851,#6852)

### DIFF
--- a/pkg/api/handlers/missions.go
+++ b/pkg/api/handlers/missions.go
@@ -66,6 +66,13 @@ const (
 	// Each entry stores a directory listing or file body.
 	missionsCacheMaxEntries = 256
 
+	// missionsValidateMaxBytes is a tighter payload cap for ValidateMission.
+	// Mission JSON documents are small structured metadata — legitimate payloads
+	// are well under 1 MiB. Accepting the full missionsMaxBodyBytes (10 MiB) for
+	// json.Unmarshal invites deeply-nested payloads that stress the decoder.
+	// Reject oversize validate requests early with 413 (#6820).
+	missionsValidateMaxBytes = 1 * 1024 * 1024 // 1 MiB
+
 	// slackMaxTextBytes is the maximum allowed size for the Text field in a
 	// SlackShareRequest. Slack messages are typically short; 10 KB is more
 	// than enough for any legitimate use. Without this cap a caller could
@@ -171,6 +178,9 @@ type missionsResponseCache struct {
 
 // get returns a cached entry if it exists and is within the given TTL.
 // Returns nil if no entry exists or the entry is expired.
+//
+// #6822 — Returns a shallow copy of the entry so callers cannot mutate
+// the shared cache data after the read lock is released.
 func (c *missionsResponseCache) get(key string, ttl time.Duration) *missionsCacheEntry {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
@@ -181,11 +191,14 @@ func (c *missionsResponseCache) get(key string, ttl time.Duration) *missionsCach
 	if time.Since(entry.fetchedAt) > ttl {
 		return nil
 	}
-	return entry
+	cp := *entry
+	return &cp
 }
 
 // getStale returns a cached entry even if expired, as long as it is within staleTTL.
 // Used to serve stale data when GitHub rate-limits us — better than an error.
+//
+// #6822 — Returns a shallow copy (same rationale as get).
 func (c *missionsResponseCache) getStale(key string, staleTTL time.Duration) *missionsCacheEntry {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
@@ -196,11 +209,20 @@ func (c *missionsResponseCache) getStale(key string, staleTTL time.Duration) *mi
 	if time.Since(entry.fetchedAt) > staleTTL {
 		return nil
 	}
-	return entry
+	cp := *entry
+	return &cp
 }
 
-// evictOldestLocked removes the single oldest entry from the cache. The caller
-// MUST hold c.mu in write mode. Returns true if an entry was evicted.
+// evictOldestLocked removes the single oldest entry from the cache.
+// Returns true if an entry was evicted.
+//
+// REQUIRES: c.mu held in WRITE mode by the caller (#6821).
+//
+// Currently called only from set(), which acquires c.mu.Lock() before
+// invoking this method. Any new call-site MUST hold the write lock —
+// this function reads and modifies c.entries, c.insertOrder, and
+// c.totalBytes without further synchronisation.
+//
 // #6841 — Uses the insertOrder slice for O(1) oldest-key lookup instead of
 // scanning the entire map on every eviction.
 func (c *missionsResponseCache) evictOldestLocked() bool {
@@ -683,7 +705,9 @@ func (h *MissionsHandler) ValidateMission(c *fiber.Ctx) error {
 	if len(body) == 0 {
 		return c.Status(400).JSON(fiber.Map{"valid": false, "errors": []string{"empty body"}})
 	}
-	if len(body) > missionsMaxBodyBytes {
+	// Use the tighter missionsValidateMaxBytes instead of the general
+	// missionsMaxBodyBytes — mission JSON metadata is always small (#6820).
+	if len(body) > missionsValidateMaxBytes {
 		return c.Status(413).JSON(fiber.Map{"valid": false, "errors": []string{"payload too large"}})
 	}
 

--- a/web/src/lib/utils/__tests__/concurrency.test.ts
+++ b/web/src/lib/utils/__tests__/concurrency.test.ts
@@ -256,6 +256,78 @@ describe('settledWithConcurrency', () => {
       expect(DEFAULT_CLUSTER_CONCURRENCY).toBe(EXPECTED_DEFAULT_CONCURRENCY)
     })
   })
+
+  describe('invalid concurrency inputs (#6851, #6852)', () => {
+    it('concurrency=0 still processes all tasks', async () => {
+      const tasks = Array.from({ length: MIXED_TASK_COUNT }, (_, i) =>
+        delayedTask(i, TICK_DELAY_MS),
+      )
+
+      const results = await settledWithConcurrency(tasks, 0)
+
+      expect(results).toHaveLength(MIXED_TASK_COUNT)
+      for (let i = 0; i < MIXED_TASK_COUNT; i++) {
+        expect(results[i].status).toBe('fulfilled')
+        if (results[i].status === 'fulfilled') {
+          expect(
+            (results[i] as PromiseSettledResult<number> & { status: 'fulfilled' }).value,
+          ).toBe(i)
+        }
+      }
+    })
+
+    it('negative concurrency still processes all tasks', async () => {
+      const tasks = Array.from({ length: MIXED_TASK_COUNT }, (_, i) =>
+        delayedTask(i, TICK_DELAY_MS),
+      )
+
+      const results = await settledWithConcurrency(tasks, -5)
+
+      expect(results).toHaveLength(MIXED_TASK_COUNT)
+      for (const r of results) {
+        expect(r.status).toBe('fulfilled')
+      }
+    })
+
+    it('NaN concurrency still processes all tasks', async () => {
+      const tasks = Array.from({ length: MIXED_TASK_COUNT }, (_, i) =>
+        delayedTask(i, TICK_DELAY_MS),
+      )
+
+      const results = await settledWithConcurrency(tasks, NaN)
+
+      expect(results).toHaveLength(MIXED_TASK_COUNT)
+      for (const r of results) {
+        expect(r.status).toBe('fulfilled')
+      }
+    })
+
+    it('Infinity concurrency still processes all tasks', async () => {
+      const tasks = Array.from({ length: MIXED_TASK_COUNT }, (_, i) =>
+        delayedTask(i, TICK_DELAY_MS),
+      )
+
+      const results = await settledWithConcurrency(tasks, Infinity)
+
+      expect(results).toHaveLength(MIXED_TASK_COUNT)
+      for (const r of results) {
+        expect(r.status).toBe('fulfilled')
+      }
+    })
+
+    it('fractional concurrency (0.5) is clamped to 1 and processes tasks', async () => {
+      const tasks = Array.from({ length: MIXED_TASK_COUNT }, (_, i) =>
+        delayedTask(i, TICK_DELAY_MS),
+      )
+
+      const results = await settledWithConcurrency(tasks, 0.5)
+
+      expect(results).toHaveLength(MIXED_TASK_COUNT)
+      for (const r of results) {
+        expect(r.status).toBe('fulfilled')
+      }
+    })
+  })
 })
 
 describe('mapSettledWithConcurrency', () => {

--- a/web/src/lib/utils/concurrency.ts
+++ b/web/src/lib/utils/concurrency.ts
@@ -14,6 +14,9 @@
 /** Default maximum number of concurrent requests across clusters */
 export const DEFAULT_CLUSTER_CONCURRENCY = 8
 
+/** Minimum allowed concurrency — at least one worker must run (#6851). */
+const MIN_CONCURRENCY = 1
+
 /**
  * Execute an array of async tasks with bounded concurrency, returning
  * results in the same format as `Promise.allSettled`.
@@ -22,7 +25,8 @@ export const DEFAULT_CLUSTER_CONCURRENCY = 8
  * queue, so fast-completing tasks do not leave workers idle.
  *
  * @param tasks   - Array of zero-arg async functions to execute
- * @param concurrency - Max tasks running at one time (default 8)
+ * @param concurrency - Max tasks running at one time (default 8).
+ *   Values less than 1, NaN, or non-finite are clamped to 1 (#6851).
  * @returns PromiseSettledResult array in the same order as `tasks`
  */
 export async function settledWithConcurrency<T>(
@@ -31,11 +35,17 @@ export async function settledWithConcurrency<T>(
 ): Promise<PromiseSettledResult<T>[]> {
   if (tasks.length === 0) return []
 
+  // Clamp invalid concurrency to a safe minimum so workers are always
+  // created and every task slot is populated (#6851).
+  const safeConcurrency = Number.isFinite(concurrency) && concurrency >= MIN_CONCURRENCY
+    ? Math.floor(concurrency)
+    : MIN_CONCURRENCY
+
   const results: PromiseSettledResult<T>[] = new Array(tasks.length)
   let cursor = 0
 
   const workers = Array.from(
-    { length: Math.min(concurrency, tasks.length) },
+    { length: Math.min(safeConcurrency, tasks.length) },
     async () => {
       while (cursor < tasks.length) {
         const idx = cursor++


### PR DESCRIPTION
Closes #6820
Closes #6821
Closes #6822
Closes #6851
Closes #6852

## Summary

- **#6820** — `ValidateMission` now enforces a tighter 1 MiB payload cap (`missionsValidateMaxBytes`) instead of the general 10 MiB `missionsMaxBodyBytes`, reducing risk from deeply nested JSON payloads.
- **#6821** — `evictOldestLocked` comment strengthened with explicit `REQUIRES: c.mu held in WRITE mode` annotation and documentation of the single call-site (`set()`).
- **#6822** — `cache.get()` and `cache.getStale()` now return shallow value copies (`cp := *entry; return &cp`) instead of direct pointers into the shared map, preventing callers from mutating cached data after the read lock is released.
- **#6851** — `settledWithConcurrency` clamps invalid concurrency values (0, negative, NaN, Infinity, fractional < 1) to a minimum of 1 so workers are always created and every task slot is populated.
- **#6852** — 5 new test cases for invalid concurrency inputs: 0, negative, NaN, Infinity, and fractional (0.5).

## Test plan

- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] `npm run build` passes
- [x] All 18 concurrency tests pass (13 existing + 5 new)
- [ ] CI build/lint passes