### PR TITLE
fix(security): fail-closed on permission errors + test fix + redo pipeline (#6859-#6864)

### DIFF
--- a/pkg/api/handlers/rbac.go
+++ b/pkg/api/handlers/rbac.go
@@ -375,6 +375,21 @@ func (h *RBACHandler) GetClusterPermissions(c *fiber.Ctx) error {
 
 // CreateServiceAccount creates a new service account (cluster-admin only)
 func (h *RBACHandler) CreateServiceAccount(c *fiber.Ctx) error {
+	// #6860: Console-level authorization — only admin users may create
+	// service accounts. Without this, any authenticated console user could
+	// create SAs via the backend's privileged kubeconfig identity.
+	userID := middleware.GetUserID(c)
+	currentUser, err := h.store.GetUser(userID)
+	if err != nil || currentUser == nil {
+		return fiber.NewError(fiber.StatusUnauthorized, "Unauthorized")
+	}
+	if currentUser.Role != models.UserRoleAdmin {
+		slog.Warn("[rbac] SECURITY: non-admin attempted to create service account",
+			"user_id", currentUser.ID,
+			"github_login", currentUser.GitHubLogin)
+		return fiber.NewError(fiber.StatusForbidden, "Console admin role required")
+	}
+
 	if h.k8sClient == nil {
 		return fiber.NewError(fiber.StatusServiceUnavailable, "Kubernetes client not available")
 	}
@@ -400,9 +415,9 @@ func (h *RBACHandler) CreateServiceAccount(c *fiber.Ctx) error {
 	ctx, cancel := context.WithTimeout(c.Context(), rbacWriteTimeout)
 	defer cancel()
 
-	// Check if user has cluster-admin access
-	isAdmin, err := h.k8sClient.CheckClusterAdminAccess(ctx, req.Cluster)
-	if err != nil || !isAdmin {
+	// Check if user has cluster-admin access via Kubernetes RBAC too
+	isAdmin, kerr := h.k8sClient.CheckClusterAdminAccess(ctx, req.Cluster)
+	if kerr != nil || !isAdmin {
 		return fiber.NewError(fiber.StatusForbidden, "Cluster admin access required")
 	}
 
@@ -417,6 +432,21 @@ func (h *RBACHandler) CreateServiceAccount(c *fiber.Ctx) error {
 
 // CreateRoleBinding creates a new role binding (cluster-admin only)
 func (h *RBACHandler) CreateRoleBinding(c *fiber.Ctx) error {
+	// #6859: Console-level authorization — only admin users may create
+	// role bindings. Without this, any authenticated console user could
+	// escalate privileges via the backend's privileged kubeconfig identity.
+	userID := middleware.GetUserID(c)
+	currentUser, err := h.store.GetUser(userID)
+	if err != nil || currentUser == nil {
+		return fiber.NewError(fiber.StatusUnauthorized, "Unauthorized")
+	}
+	if currentUser.Role != models.UserRoleAdmin {
+		slog.Warn("[rbac] SECURITY: non-admin attempted to create role binding",
+			"user_id", currentUser.ID,
+			"github_login", currentUser.GitHubLogin)
+		return fiber.NewError(fiber.StatusForbidden, "Console admin role required")
+	}
+
 	if h.k8sClient == nil {
 		return fiber.NewError(fiber.StatusServiceUnavailable, "Kubernetes client not available")
 	}

--- a/web/src/hooks/__tests__/usePermissions.test.ts
+++ b/web/src/hooks/__tests__/usePermissions.test.ts
@@ -112,9 +112,9 @@ describe('usePermissions', () => {
     expect(fetch).not.toHaveBeenCalled()
   })
 
-  it('isClusterAdmin returns true for unknown cluster (assume admin when no data)', () => {
+  it('isClusterAdmin returns false for unknown cluster (fail-closed)', () => {
     const { result } = renderHook(() => usePermissions())
-    expect(result.current.isClusterAdmin('unknown')).toBe(true)
+    expect(result.current.isClusterAdmin('unknown')).toBe(false)
   })
 
   it('hasPermission returns false for unknown cluster', () => {
@@ -191,8 +191,8 @@ describe('usePermissions', () => {
 
     expect(result.current.isClusterAdmin('prod-cluster')).toBe(true)
     expect(result.current.isClusterAdmin('dev-cluster')).toBe(false)
-    // Unknown cluster still returns true (assume admin when no data)
-    expect(result.current.isClusterAdmin('nonexistent')).toBe(true)
+    // Unknown cluster returns false (fail-closed security)
+    expect(result.current.isClusterAdmin('nonexistent')).toBe(false)
   })
 
   it('hasPermission returns correct values for each permission type', async () => {
@@ -434,13 +434,13 @@ describe('useCanI', () => {
     expect(body.group).toBe('apps')
   })
 
-  it('returns allowed=true on non-OK response (graceful degradation)', async () => {
+  it('returns allowed=false on non-OK response (fail-closed security)', async () => {
     vi.mocked(isBackendUnavailable).mockReturnValue(false)
     localStorage.setItem(MOCKED_TOKEN_KEY, 'real-token')
     vi.spyOn(globalThis, 'fetch').mockImplementation(mockFetchError(403))
 
     const { result } = renderHook(() => useCanI())
-    let response = { allowed: false }
+    let response = { allowed: true }
     await act(async () => {
       response = await result.current.checkPermission({
         cluster: 'test',
@@ -449,18 +449,18 @@ describe('useCanI', () => {
       })
     })
 
-    // Non-OK responses gracefully degrade to allowed=true
-    expect(response.allowed).toBe(true)
+    // SECURITY: Non-OK responses fail-closed (deny permission)
+    expect(response.allowed).toBe(false)
     expect(result.current.checking).toBe(false)
   })
 
-  it('returns allowed=true on network error (graceful degradation)', async () => {
+  it('returns allowed=false on network error (fail-closed security)', async () => {
     vi.mocked(isBackendUnavailable).mockReturnValue(false)
     localStorage.setItem(MOCKED_TOKEN_KEY, 'real-token')
     vi.spyOn(globalThis, 'fetch').mockRejectedValue(new Error('fetch failed'))
 
     const { result } = renderHook(() => useCanI())
-    let response = { allowed: false }
+    let response = { allowed: true }
     await act(async () => {
       response = await result.current.checkPermission({
         cluster: 'test',
@@ -469,7 +469,8 @@ describe('useCanI', () => {
       })
     })
 
-    expect(response.allowed).toBe(true)
+    // SECURITY: Network errors fail-closed (deny permission)
+    expect(response.allowed).toBe(false)
     expect(result.current.checking).toBe(false)
   })
 

--- a/web/src/hooks/__tests__/useUndoRedo.test.ts
+++ b/web/src/hooks/__tests__/useUndoRedo.test.ts
@@ -68,6 +68,39 @@ describe('useUndoRedo', () => {
     })
     expect(result.current.undoCount).toBe(MAX_STACK)
   })
+
+  it('redo works when getCurrentState is provided', () => {
+    let current = 'state-c'
+    const onRestore = vi.fn((s: string) => { current = s })
+    const getCurrentState = () => current
+
+    const { result } = renderHook(() => useUndoRedo<string>(onRestore, getCurrentState))
+
+    // Push two states, then undo — redo should replay
+    act(() => { result.current.pushState('state-a') })
+    act(() => { result.current.pushState('state-b') })
+    // current is 'state-c', undo pops 'state-b' and saves 'state-c' to redo
+    act(() => { result.current.undo() })
+    expect(onRestore).toHaveBeenLastCalledWith('state-b')
+    expect(result.current.canRedo).toBe(true)
+    expect(result.current.redoCount).toBe(1)
+
+    // Redo should restore 'state-c'
+    act(() => { result.current.redo() })
+    expect(onRestore).toHaveBeenLastCalledWith('state-c')
+    expect(result.current.canRedo).toBe(false)
+    // Undo should still work after redo
+    expect(result.current.canUndo).toBe(true)
+  })
+
+  it('redo is non-functional without getCurrentState (backward compat)', () => {
+    const onRestore = vi.fn()
+    const { result } = renderHook(() => useUndoRedo<string>(onRestore))
+    act(() => { result.current.pushState('state-a') })
+    act(() => { result.current.undo() })
+    // Without getCurrentState, nothing is pushed to redo stack
+    expect(result.current.canRedo).toBe(false)
+  })
 })
 
 describe('useDashboardUndoRedo', () => {

--- a/web/src/hooks/usePermissions.ts
+++ b/web/src/hooks/usePermissions.ts
@@ -99,9 +99,11 @@ export function usePermissions() {
   }, [fetchPermissions])
 
   // Check if user is cluster admin for a specific cluster
-  // If permissions data is not available for a cluster, assume admin (don't show warning)
+  // SECURITY: If permissions data is not available (fetch failed, network error),
+  // deny access (fail-closed). Only assume admin when backend is explicitly
+  // unavailable (demo mode) or no token is present.
   const isClusterAdmin = (cluster: string): boolean => {
-    if (!permissions?.clusters?.[cluster]) return true // Assume admin if no data
+    if (!permissions?.clusters?.[cluster]) return false // Fail-closed: deny when no data
     return permissions.clusters[cluster].isClusterAdmin
   }
 
@@ -170,7 +172,7 @@ export function useCanI() {
   const [error, setError] = useState<string | null>(null)
 
   const checkPermission = async (request: CanIRequest): Promise<CanIResponse> => {
-    // Skip if backend is known to be unavailable
+    // Skip if backend is known to be unavailable (demo mode)
     if (isBackendUnavailable()) {
       return { allowed: true } // Assume allowed in demo mode
     }
@@ -190,16 +192,20 @@ export function useCanI() {
         signal: AbortSignal.timeout(5000) })
 
       if (!response.ok) {
-        // Silently fail on error - assume allowed in demo mode
-        return { allowed: true }
+        // SECURITY: fail-closed — deny permission when API returns error
+        const denied: CanIResponse = { allowed: false, reason: 'Permission check failed (API error)' }
+        setResult(denied)
+        return denied
       }
 
       const data: CanIResponse = await response.json()
       setResult(data)
       return data
     } catch {
-      // Silently fail - backend may be unavailable in demo mode
-      return { allowed: true }
+      // SECURITY: fail-closed — deny permission on network/timeout error
+      const denied: CanIResponse = { allowed: false, reason: 'Permission check failed (network error)' }
+      setResult(denied)
+      return denied
     } finally {
       setChecking(false)
     }

--- a/web/src/hooks/useUndoRedo.ts
+++ b/web/src/hooks/useUndoRedo.ts
@@ -30,6 +30,10 @@ export interface UseUndoRedoResult<T> {
 
 export function useUndoRedo<T>(
   onRestore: (state: T) => void,
+  /** Optional getter for the current state — enables the redo pipeline.
+   *  When provided, undo() captures the current state before restoring so
+   *  redo() can replay it. Without this, redo is non-functional. */
+  getCurrentState?: () => T,
 ): UseUndoRedoResult<T> {
   const undoStackRef = useRef<T[]>([])
   const redoStackRef = useRef<T[]>([])
@@ -52,28 +56,28 @@ export function useUndoRedo<T>(
   const undo = useCallback(() => {
     const prev = undoStackRef.current.pop()
     if (prev === undefined) return null
-    // We need the current state to push to redo — caller should
-    // use the onRestore callback to apply, and we save what's being
-    // replaced via the _currentStateRef (set by pushState).
-    // Actually, we need the "current" state before undo to push to redo.
-    // This requires cooperation: we store the state that onRestore is
-    // about to replace. The caller should call pushStateForRedo.
+    // Capture the current state before restoring so redo can replay it.
+    if (getCurrentState) {
+      redoStackRef.current.push(getCurrentState())
+    }
     setUndoCount(undoStackRef.current.length)
+    setRedoCount(redoStackRef.current.length)
     onRestore(prev)
     return prev
-  }, [onRestore])
+  }, [onRestore, getCurrentState])
 
   const redo = useCallback(() => {
     const next = redoStackRef.current.pop()
     if (next === undefined) return null
+    // Save current state back to undo stack so we can undo the redo
+    if (getCurrentState) {
+      undoStackRef.current.push(getCurrentState())
+    }
+    setUndoCount(undoStackRef.current.length)
     setRedoCount(redoStackRef.current.length)
     onRestore(next)
     return next
-  }, [onRestore])
-
-  // We need a way to capture the current state before undo so we can push it to redo.
-  // The pattern: caller calls `captureForUndo(currentState)` before applying undo.
-  // Better pattern: wrap undo/redo at the dashboard level where we have the current cards.
+  }, [onRestore, getCurrentState])
 
   return {
     undo,

--- a/web/src/test/ui-ux-standards.test.ts
+++ b/web/src/test/ui-ux-standards.test.ts
@@ -68,11 +68,12 @@ const COMPONENTS_DIR = path.resolve(
 //   302 → 303: #6309 upgrade confirm dialog issue ref
 //   303 → 304: #6366 ratchet drift — pre-existing unaccounted-for raw hex from before 303 bump, not introduced by #6365
 //   304 → 306: issue 6774 loading/error states — reverted to 304 in issue 6778 (false positives from issue-ref comments rewritten to "issue NNNN" form)
+//   304 → 307: PR 6854 introduced 3 new hex refs (not real color violations)
 //
 // When you bump this number, append a one-line entry above so future
 // bumps stay grep-able and reviewers can tell at a glance whether a
 // change is a real new violation or just a comment-level reference.
-const EXPECTED_RAW_HEX_COUNT = 304
+const EXPECTED_RAW_HEX_COUNT = 307
 const EXPECTED_RAW_RGBA_COUNT = 104
 const EXPECTED_ARBITRARY_TW_COLOR_COUNT = 22
 const EXPECTED_INLINE_STYLE_COLOR_COUNT = 213


### PR DESCRIPTION
## Summary

- **#6861**: `isClusterAdmin()` now returns `false` (deny) when permission data is missing, instead of `true` (admin assumption). Fail-open to fail-closed.
- **#6863**: `useCanI.checkPermission()` returns `{ allowed: false }` on API/network errors instead of `{ allowed: true }`. Fail-open to fail-closed. Demo mode still returns allowed=true.
- **#6859 / #6860**: `CreateRoleBinding` and `CreateServiceAccount` handlers now enforce console-level admin role check (`currentUser.Role == admin`) before the Kubernetes RBAC check. Prevents privilege escalation when backend uses a privileged kubeconfig identity.
- **#6856**: `useUndoRedo` generic hook now accepts optional `getCurrentState` callback. When provided, `undo()` captures current state to redo stack, making redo functional. Backward-compatible (no `getCurrentState` = old behavior).
- **#6864**: Bumped ratchet baseline `EXPECTED_RAW_HEX_COUNT` from 304 to 307 for false positives introduced by PR #6854.

Closes #6861
Closes #6863
Closes #6859
Closes #6860
Closes #6856
Closes #6864

## Test plan

- [x] `usePermissions.test.ts` — updated assertions for fail-closed behavior (56 tests pass)
- [x] `useUndoRedo.test.ts` — added redo pipeline tests with `getCurrentState`
- [x] `ui-ux-standards.test.ts` — ratchet test passes with bumped baseline
- [x] Go backend builds cleanly (`go build ./...`)
- [x] Frontend builds cleanly (`npm run build`)