### PR TITLE
fix: validate persisted AI mode + replace Sleep with context-aware timer (#6855, #6819)

### DIFF
--- a/pkg/api/handlers/missions.go
+++ b/pkg/api/handlers/missions.go
@@ -991,11 +991,21 @@ func (h *MissionsHandler) ShareToGitHub(c *fiber.Ctx) error {
 			}
 		}
 
-		// If this is not the last attempt, wait before retrying
+		// If this is not the last attempt, wait before retrying.
+		// Use select with context cancellation so the retry is
+		// abortable when the client disconnects (#6819).
 		if attempt < forkHeadSHAMaxRetries-1 {
 			slog.Info("[missions] fork HEAD SHA not yet available, retrying",
 				"attempt", attempt+1, "maxRetries", forkHeadSHAMaxRetries, "status", mainRefResp.StatusCode, "backoff", backoff)
-			time.Sleep(backoff)
+			select {
+			case <-time.After(backoff):
+				// backoff elapsed, continue to next attempt
+			case <-c.UserContext().Done():
+				return c.Status(fiber.StatusServiceUnavailable).JSON(fiber.Map{
+					"error": "request cancelled while waiting for fork to initialize",
+					"code":  "request_cancelled",
+				})
+			}
 			backoff = time.Duration(float64(backoff) * forkHeadSHABackoffMultiplier)
 		}
 	}

--- a/web/src/hooks/useAIMode.ts
+++ b/web/src/hooks/useAIMode.ts
@@ -48,14 +48,28 @@ const DESCRIPTIONS: Record<AIMode, string> = {
   high: 'Full AI assistance. Proactive suggestions, automatic issue analysis, card swaps based on cluster activity. Higher token usage.' }
 
 const STORAGE_KEY = 'kubestellar-ai-mode'
+const DEFAULT_AI_MODE: AIMode = 'medium'
+const VALID_AI_MODES: ReadonlySet<string> = new Set<AIMode>(['low', 'medium', 'high'])
+
+/** Validate a persisted value against the known-good AIMode enum. */
+function isValidAIMode(value: string | null): value is AIMode {
+  return value !== null && VALID_AI_MODES.has(value)
+}
 
 export function useAIMode() {
   const [mode, setModeState] = useState<AIMode>(() => {
     if (typeof window !== 'undefined') {
-      const stored = localStorage.getItem(STORAGE_KEY) as AIMode | null
-      return stored || 'medium'
+      const stored = localStorage.getItem(STORAGE_KEY)
+      if (isValidAIMode(stored)) {
+        return stored
+      }
+      // Clear invalid/stale value so it doesn't persist across reloads.
+      if (stored !== null) {
+        localStorage.removeItem(STORAGE_KEY)
+      }
+      return DEFAULT_AI_MODE
     }
-    return 'medium'
+    return DEFAULT_AI_MODE
   })
 
   // Persist mode changes


### PR DESCRIPTION
Closes #6855
Closes #6819

## Summary
- **#6855**: `useAIMode` now validates the localStorage value against `VALID_AI_MODES` before using it. Invalid/stale values are cleared and the hook falls back to `'medium'`, preventing crashes when `config.features` is accessed on an undefined config.
- **#6819**: Replaced `time.Sleep(backoff)` in `ShareToGitHub`'s fork-HEAD-SHA retry loop with `select` on `time.After(backoff)` + `c.UserContext().Done()`. The retry is now cancelled immediately when the client disconnects, preventing goroutine pool exhaustion under concurrent fork traffic.

## Test plan
- [ ] Set an invalid value in localStorage key `kubestellar-ai-mode` (e.g. `"turbo"`), reload — should fall back to `medium` without crash
- [ ] Verify AI mode toggle still persists and reads correctly for `low`, `medium`, `high`
- [ ] ShareToGitHub retry loop: cancel request mid-retry — should return 503 instead of blocking
- [ ] `go build ./...` and `go vet ./...` pass
- [ ] `npm run build` passes