### PR TITLE
fix(charts): rollout version ordering, progress calc, null gaps, delta scope, header sync (#6869-#6875)

### DIFF
--- a/web/src/components/cards/ClusterMetrics.tsx
+++ b/web/src/components/cards/ClusterMetrics.tsx
@@ -304,7 +304,9 @@ export function ClusterMetrics() {
       }
       clusterNames.forEach(name => {
         const clusterData = point.clusters?.[name]
-        entry[name] = clusterData ? clusterData[selectedMetric] : 0
+        // Use null for missing data so the chart renders gaps instead of
+        // artificial zero drops (#6874).
+        entry[name] = clusterData ? clusterData[selectedMetric] : null as unknown as number
       })
       return entry
     })
@@ -313,8 +315,18 @@ export function ClusterMetrics() {
   }, [history, selectedMetric, timeRange, chartMode])
 
   const config = metricConfig[selectedMetric]
-  // Use real current value if available, otherwise use last chart value
-  const currentValue = hasRealData ? realValues[selectedMetric] : (data[data.length - 1]?.value || 0)
+  // Use real current value if non-zero, otherwise fall back to the last
+  // known non-null chart value so the header stays in sync with the chart
+  // instead of showing a misleading 0 during temporary data loss (#6875).
+  const currentValue = (() => {
+    const live = hasRealData ? realValues[selectedMetric] : 0
+    if (live > 0) return live
+    // Walk backwards through chart data to find the last non-null value
+    for (let i = data.length - 1; i >= 0; i--) {
+      if (data[i]?.value != null && data[i].value > 0) return data[i].value
+    }
+    return 0
+  })()
 
   return (
     <div className="h-full flex flex-col">

--- a/web/src/components/cards/insights/ClusterDeltaDetector.tsx
+++ b/web/src/components/cards/insights/ClusterDeltaDetector.tsx
@@ -12,10 +12,8 @@ import { InsightDetailModal } from './InsightDetailModal'
 import type { MultiClusterInsight } from '../../../types/insights'
 
 
-/** Color for cluster A bars */
-const CLUSTER_A_COLOR = '#3b82f6'
-/** Color for cluster B bars */
-const CLUSTER_B_COLOR = '#f59e0b'
+/** Palette for multi-cluster bars (extends beyond 2 clusters, fixes #6873) */
+const CLUSTER_COLORS = ['#3b82f6', '#f59e0b', '#10b981', '#ef4444', '#8b5cf6', '#06b6d4', '#ec4899', '#84cc16']
 
 const SIGNIFICANCE_COLORS: Record<string, string> = {
   high: 'border-red-500/30 bg-red-500/5',
@@ -59,16 +57,25 @@ export function ClusterDeltaDetector() {
     )
   })()
 
-  const clusterPair = insight ? [...new Set(insight.affectedClusters)].slice(0, 2) : []
+  // Collect ALL unique cluster names from deltas, not just the first two (#6873)
+  const allClusters = useMemo(() => {
+    if (!insight?.deltas) return []
+    const names = new Set<string>()
+    for (const d of insight.deltas || []) {
+      if (typeof d.clusterA.value === 'number') names.add(d.clusterA.name)
+      if (typeof d.clusterB.value === 'number') names.add(d.clusterB.name)
+    }
+    return Array.from(names)
+  }, [insight])
 
   const chartOption = useMemo(() => {
-    if (numericDeltas.length === 0 || clusterPair.length !== 2) return {}
+    if (numericDeltas.length === 0 || allClusters.length < 2) return {}
     return {
       backgroundColor: 'transparent',
       grid: { left: 30, right: 10, top: 5, bottom: 20 },
       xAxis: {
         type: 'category' as const,
-        data: numericDeltas.map(d => d.dimension),
+        data: [...new Set(numericDeltas.map(d => d.dimension))],
         axisLabel: { fontSize: 9, color: CHART_TICK_COLOR },
         axisTick: { show: false },
         axisLine: { show: false },
@@ -86,22 +93,17 @@ export function ClusterDeltaDetector() {
         borderColor: (CHART_TOOLTIP_CONTENT_STYLE as Record<string, unknown>).borderColor as string,
         textStyle: { color: '#e0e0e0', fontSize: Number(CHART_TOOLTIP_FONT_SIZE_COMPACT.replace('px', '')) },
       },
-      series: [
-        {
-          name: clusterPair[0],
-          type: 'bar',
-          data: numericDeltas.map(d => (d as Record<string, unknown>)[clusterPair[0]]),
-          itemStyle: { color: CLUSTER_A_COLOR, borderRadius: [4, 4, 0, 0] },
-        },
-        {
-          name: clusterPair[1],
-          type: 'bar',
-          data: numericDeltas.map(d => (d as Record<string, unknown>)[clusterPair[1]]),
-          itemStyle: { color: CLUSTER_B_COLOR, borderRadius: [4, 4, 0, 0] },
-        },
-      ],
+      series: allClusters.map((clusterName, idx) => ({
+        name: clusterName,
+        type: 'bar' as const,
+        data: [...new Set(numericDeltas.map(d => d.dimension))].map(dim => {
+          const match = numericDeltas.find(d => d.dimension === dim && (d as Record<string, unknown>)[clusterName] !== undefined)
+          return match ? (match as Record<string, unknown>)[clusterName] as number : null
+        }),
+        itemStyle: { color: CLUSTER_COLORS[idx % CLUSTER_COLORS.length], borderRadius: [4, 4, 0, 0] },
+      })),
     }
-  }, [numericDeltas, clusterPair])
+  }, [numericDeltas, allClusters])
 
   if (!isLoading && deltaInsightsRaw.length === 0) {
     return (
@@ -158,22 +160,20 @@ export function ClusterDeltaDetector() {
             <span className="text-xs text-muted-foreground flex-1">{insight.description}</span>
           </div>
 
-          {/* Legend */}
-          {clusterPair.length === 2 && (
-            <div className="flex items-center gap-4">
-              <div className="flex items-center gap-1">
-                <div className="w-2.5 h-2.5 rounded-sm" style={{ backgroundColor: CLUSTER_A_COLOR }} />
-                <span className="text-2xs text-muted-foreground">{clusterPair[0]}</span>
-              </div>
-              <div className="flex items-center gap-1">
-                <div className="w-2.5 h-2.5 rounded-sm" style={{ backgroundColor: CLUSTER_B_COLOR }} />
-                <span className="text-2xs text-muted-foreground">{clusterPair[1]}</span>
-              </div>
+          {/* Legend — show all clusters, not just first two (#6873) */}
+          {allClusters.length >= 2 && (
+            <div className="flex items-center gap-4 flex-wrap">
+              {allClusters.map((name, idx) => (
+                <div key={name} className="flex items-center gap-1">
+                  <div className="w-2.5 h-2.5 rounded-sm" style={{ backgroundColor: CLUSTER_COLORS[idx % CLUSTER_COLORS.length] }} />
+                  <span className="text-2xs text-muted-foreground">{name}</span>
+                </div>
+              ))}
             </div>
           )}
 
           {/* Numeric deltas as bar chart */}
-          {numericDeltas.length > 0 && clusterPair.length === 2 && (
+          {numericDeltas.length > 0 && allClusters.length >= 2 && (
             <div className="h-32">
               <ReactECharts
                 option={chartOption}

--- a/web/src/hooks/useMultiClusterInsights.ts
+++ b/web/src/hooks/useMultiClusterInsights.ts
@@ -416,10 +416,10 @@ export function detectResourceImbalance(clusters: ClusterInfo[]): MultiClusterIn
 
   const insights: MultiClusterInsight[] = []
 
-  // CPU imbalance
+  // CPU imbalance — prefer actual usage over requests when available (#6872)
   const cpuPcts = healthy.map(c => ({
     name: c.name,
-    pct: pct(c.cpuRequestsCores || c.cpuUsageCores, c.cpuCores) }))
+    pct: pct(c.cpuUsageCores || c.cpuRequestsCores, c.cpuCores) }))
   const avgCpu = cpuPcts.reduce((sum, c) => sum + c.pct, 0) / cpuPcts.length
   const overloaded = cpuPcts.filter(c => c.pct - avgCpu > RESOURCE_IMBALANCE_THRESHOLD_PCT)
   const underloaded = cpuPcts.filter(c => avgCpu - c.pct > RESOURCE_IMBALANCE_THRESHOLD_PCT)
@@ -453,7 +453,7 @@ export function detectResourceImbalance(clusters: ClusterInfo[]): MultiClusterIn
     .filter(c => c.memoryGB && c.memoryGB > 0)
     .map(c => ({
       name: c.name,
-      pct: pct(c.memoryRequestsGB || c.memoryUsageGB, c.memoryGB) }))
+      pct: pct(c.memoryUsageGB || c.memoryRequestsGB, c.memoryGB) }))
 
   if (memPcts.length >= 2) {
     const avgMem = memPcts.reduce((sum, c) => sum + c.pct, 0) / memPcts.length
@@ -572,12 +572,35 @@ export function trackRolloutProgress(deployments: Deployment[]): MultiClusterIns
     const images = [...new Set((deps || []).map(d => d.image).filter(Boolean))]
     if (images.length < 2) continue
 
-    // Find the newest image (highest version or most common)
-    const imageCounts = new Map<string, number>()
-    for (const dep of (deps || [])) {
-      if (dep.image) imageCounts.set(dep.image, (imageCounts.get(dep.image) || 0) + 1)
-    }
-    const [newestImage] = Array.from(imageCounts.entries()).sort((a, b) => b[1] - a[1])[0]
+    // Find the newest image by semantic version ordering, falling back to
+    // creation timestamp when versions are not parseable (fixes #6869).
+    const newestImage = (() => {
+      /** Extract numeric version segments from a container image tag */
+      const parseVersion = (img: string): number[] | null => {
+        const match = img.match(/:v?(\d+(?:\.\d+)*)/)
+        if (!match) return null
+        return match[1].split('.').map(Number)
+      }
+      /** Compare two semver-style arrays: positive means a > b */
+      const compareVersions = (a: number[], b: number[]): number => {
+        const len = Math.max(a.length, b.length)
+        for (let k = 0; k < len; k++) {
+          const diff = (a[k] || 0) - (b[k] || 0)
+          if (diff !== 0) return diff
+        }
+        return 0
+      }
+      const uniqueImages = [...new Set((deps || []).map(d => d.image).filter((img): img is string => !!img))]
+      // Try semver ordering first
+      const parsed = uniqueImages.map(img => ({ img, ver: parseVersion(img) }))
+      const withVersion = parsed.filter(p => p.ver !== null) as { img: string; ver: number[] }[]
+      if (withVersion.length > 0) {
+        withVersion.sort((a, b) => compareVersions(b.ver, a.ver))
+        return withVersion[0].img
+      }
+      // Fallback: use lexicographic ordering of image tags (e.g. latest, nightly)
+      return uniqueImages.sort().reverse()[0]
+    })()
 
     const completed = (deps || []).filter(d => d.image === newestImage && d.cluster)
     const pending = (deps || []).filter(d => d.image !== newestImage && d.status !== 'failed' && d.cluster)
@@ -600,7 +623,12 @@ export function trackRolloutProgress(deployments: Deployment[]): MultiClusterIns
         metrics[`${dep.cluster}_progress`] = FULL_PROGRESS
         metrics[`${dep.cluster}_status`] = ROLLOUT_STATUS_COMPLETE
       } else {
-        metrics[`${dep.cluster}_progress`] = PARTIAL_PROGRESS
+        // Use actual readyReplicas/replicas ratio instead of a hardcoded
+        // placeholder, so the rollout tracker reflects real progress (#6871).
+        const actualProgress = dep.replicas > 0
+          ? Math.round((dep.readyReplicas / dep.replicas) * FULL_PROGRESS)
+          : 0
+        metrics[`${dep.cluster}_progress`] = actualProgress
         metrics[`${dep.cluster}_status`] = ROLLOUT_STATUS_IN_PROGRESS
       }
     }


### PR DESCRIPTION
Closes #6869
Closes #6871
Closes #6872
Closes #6873
Closes #6874
Closes #6875

## Summary

Fixes 6 data display bugs in insight cards and cluster metrics:

- **#6869 — Rollout version ordering**: Replaced frequency-based "newest image" detection with semantic version comparison. v2.0.0 is now correctly identified as the rollout target even when fewer clusters have it than v1.9.0.
- **#6871 — Fake 50% progress**: Replaced `PARTIAL_PROGRESS = 50` hardcode with actual `readyReplicas / replicas` ratio for in-progress rollout clusters.
- **#6872 — Requests vs usage**: Resource imbalance now prefers `cpuUsageCores` / `memoryUsageGB` over requests when available, preventing misleading imbalance from request-based calculations.
- **#6873 — Multi-cluster delta**: Chart and legend now render all clusters from the deltas, not just the first two. Color palette scales to 8 clusters.
- **#6874 — Missing data as 0**: Per-cluster chart data uses `null` instead of `0` for missing clusters so echarts renders gaps instead of false zero drops.
- **#6875 — Header vs chart mismatch**: Header falls back to last known non-null chart value during temporary data loss instead of showing misleading 0.

## Files changed

- `web/src/hooks/useMultiClusterInsights.ts` — #6869, #6871, #6872
- `web/src/components/cards/insights/ClusterDeltaDetector.tsx` — #6873
- `web/src/components/cards/ClusterMetrics.tsx` — #6874, #6875

## Test plan

- [ ] Verify rollout tracker shows correct target version with mixed version deployments
- [ ] Verify pending cluster progress reflects actual replica readiness
- [ ] Verify resource imbalance uses usage data when available
- [ ] Verify cluster delta chart shows all clusters (not just 2)
- [ ] Verify chart gaps appear for missing cluster data instead of 0 drops
- [ ] Verify header shows last known value during temporary data loss
- [ ] `npm run build` passes