### PR TITLE
fix: useAIMode test update + askAI startMission try/catch (#6876, #6811)

### DIFF
--- a/web/src/components/mission-control/useMissionControl.ts
+++ b/web/src/components/mission-control/useMissionControl.ts
@@ -975,22 +975,30 @@ Return a JSON block with this exact structure:
 Include 3-8 projects. Mark the most critical as "required" and nice-to-haves as "recommended" or "optional".
 Include real CNCF projects only. Consider dependencies between projects.`
 
-      if (!missionId) {
-        missionId = startMission({
-          title: 'Mission Control Planning',
-          description: 'AI-assisted fix planning',
-          type: 'custom',
-          initialPrompt: prompt })
-        // #6834 — Update the ref synchronously so a rapid second click reads
-        // the missionId before React commits the setState below.
-        planningMissionIdRef.current = missionId
-        setState((prev) => ({
-          ...prev,
-          planningMissionId: missionId,
-          aiStreaming: true }))
-      } else {
-        sendMessage(missionId, prompt)
-        setState((prev) => ({ ...prev, aiStreaming: true }))
+      // #6811 — Wrap startMission/sendMessage in try/catch so a synchronous
+      // throw (e.g. demo mode, ensureConnection rejection) doesn't leave
+      // aiStreaming stuck true with no mission to clear it.
+      try {
+        if (!missionId) {
+          missionId = startMission({
+            title: 'Mission Control Planning',
+            description: 'AI-assisted fix planning',
+            type: 'custom',
+            initialPrompt: prompt })
+          // #6834 — Update the ref synchronously so a rapid second click reads
+          // the missionId before React commits the setState below.
+          planningMissionIdRef.current = missionId
+          setState((prev) => ({
+            ...prev,
+            planningMissionId: missionId,
+            aiStreaming: true }))
+        } else {
+          sendMessage(missionId, prompt)
+          setState((prev) => ({ ...prev, aiStreaming: true }))
+        }
+      } catch (err) {
+        aiRequestInFlightRef.current = false
+        console.error('[MissionControl] #6811 — askAIForSuggestions failed:', err)
       }
     }
 

--- a/web/src/hooks/__tests__/useAIMode.test.ts
+++ b/web/src/hooks/__tests__/useAIMode.test.ts
@@ -283,15 +283,14 @@ describe('useAIMode', () => {
 
   // ── Edge cases ────────────────────────────────────────────────────────
 
-  it('crashes when localStorage has an invalid (non-AIMode) value', () => {
+  it('gracefully falls back to "medium" when localStorage has an invalid (non-AIMode) value', () => {
     localStorage.setItem(STORAGE_KEY, 'invalid-mode')
-    // The hook does `stored || 'medium'` — an unrecognised string is truthy,
-    // so it is used as-is. The config lookup `AI_MODE_CONFIGS[mode]` returns
-    // undefined, causing a runtime error when accessing `.features`.
-    // This documents the current (unguarded) behaviour.
-    expect(() => {
-      renderHook(() => useAIMode())
-    }).toThrow()
+    // PR #6868 added validation: invalid values are cleared from localStorage
+    // and the hook falls back to the default 'medium' mode.
+    const { result } = renderHook(() => useAIMode())
+    expect(result.current.mode).toBe('medium')
+    // The invalid value should have been removed from localStorage
+    expect(localStorage.getItem(STORAGE_KEY)).not.toBe('invalid-mode')
   })
 
   it('falls back to "medium" when localStorage value is an empty string', () => {


### PR DESCRIPTION
Closes #6876
Closes #6811

## Summary

- **#6876**: Updated `useAIMode.test.ts` — the test expected a crash on invalid localStorage values, but PR #6868 added validation that gracefully falls back to `'medium'`. Test now asserts the fallback behavior and verifies the invalid value is cleared.
- **#6811**: Wrapped `startMission()` and `sendMessage()` calls in `askAIForSuggestions` with try/catch so synchronous failures (e.g. demo mode) don't leave `aiStreaming` stuck `true` for 30s with no mission to clear it.

## Test plan

- [x] `npx vitest run src/hooks/__tests__/useAIMode.test.ts` — 26/26 pass
- [x] `npm run build` — clean