### PR TITLE
fix(storage): consistent PVC counts + disable non-functional drilldown clicks (#6809, #6810)

### DIFF
--- a/web/src/components/cards/PVCStatus.tsx
+++ b/web/src/components/cards/PVCStatus.tsx
@@ -1,8 +1,7 @@
 import { useMemo } from 'react'
-import { CheckCircle, AlertTriangle, Clock, ChevronRight } from 'lucide-react'
+import { CheckCircle, AlertTriangle, Clock } from 'lucide-react'
 import type { PVC } from '../../hooks/useMCP'
 import { useCachedPVCs } from '../../hooks/useCachedData'
-import { useDrillDownActions } from '../../hooks/useDrillDown'
 import { useDemoMode } from '../../hooks/useDemoMode'
 import { useCardLoadingState } from './CardDataContext'
 import { useCardData, commonComparators } from '../../lib/cards/cardHooks'
@@ -73,7 +72,6 @@ function getStatusColor(status: string) {
 function PVCStatusInternal() {
   const { t } = useTranslation(['common', 'cards'])
   const { pvcs, isLoading, isRefreshing, error, consecutiveFailures, isFailed, isDemoFallback, lastRefresh } = useCachedPVCs()
-  const { drillToPVC } = useDrillDownActions()
   const { isDemoMode: demoMode } = useDemoMode()
 
   // Report card data state (lastRefresh flows to CardWrapper header "Updated Xm ago")
@@ -256,19 +254,14 @@ function PVCStatusInternal() {
           displayPVCs.map(pvc => (
             <div
               key={`${pvc.cluster}-${pvc.namespace}-${pvc.name}`}
-              onClick={() => drillToPVC(pvc.cluster || '', pvc.namespace || '', pvc.name, {
-                status: pvc.status,
-                capacity: pvc.capacity,
-                storageClass: pvc.storageClass,
-                age: pvc.age,
-              })}
-              className="flex items-center justify-between p-2 rounded-lg bg-secondary/30 hover:bg-secondary/50 transition-colors cursor-pointer group"
+              className="flex items-center justify-between p-2 rounded-lg bg-secondary/30 transition-colors"
+              title="PVC drilldown not available"
             >
               <div className="flex items-center gap-2 min-w-0">
                 {getStatusIcon(pvc.status)}
                 {pvc.cluster && <ClusterBadge cluster={pvc.cluster} size="sm" />}
                 <div className="min-w-0">
-                  <div className="text-sm text-foreground truncate group-hover:text-purple-400">{pvc.name}</div>
+                  <div className="text-sm text-foreground truncate">{pvc.name}</div>
                   <div className="text-xs text-muted-foreground truncate">
                     {pvc.namespace}
                   </div>
@@ -288,7 +281,6 @@ function PVCStatusInternal() {
                     issues={[{ name: `PVC ${pvc.status}`, message: `PersistentVolumeClaim is in ${pvc.status} state${pvc.storageClass ? ` (storageClass: ${pvc.storageClass})` : ''}` }]}
                   />
                 )}
-                <ChevronRight className="w-4 h-4 text-muted-foreground opacity-0 group-hover:opacity-100 transition-opacity" />
               </div>
             </div>
           ))

--- a/web/src/components/cards/StorageOverview.tsx
+++ b/web/src/components/cards/StorageOverview.tsx
@@ -3,7 +3,6 @@ import { HardDrive, Database, CheckCircle, AlertTriangle, Clock, Server } from '
 import { useClusters } from '../../hooks/useMCP'
 import { useCachedPVCs } from '../../hooks/useCachedData'
 import { useGlobalFilters } from '../../hooks/useGlobalFilters'
-import { useDrillDownActions } from '../../hooks/useDrillDown'
 import { useCardLoadingState } from './CardDataContext'
 import { formatStat, formatStorageStat } from '../../lib/formatStats'
 import { CardClusterFilter } from '../../lib/cards/CardComponents'
@@ -17,7 +16,6 @@ export function StorageOverview() {
   const { pvcs, isLoading: pvcsLoading, isRefreshing: pvcsRefreshing, consecutiveFailures, isFailed, isDemoFallback } = useCachedPVCs()
 
   const { selectedClusters, isAllClustersSelected } = useGlobalFilters()
-  const { drillToPVC } = useDrillDownActions()
   const { isDemoMode } = useDemoMode()
 
   // Report card data state
@@ -159,13 +157,8 @@ export function StorageOverview() {
         </div>
 
         <div
-          className={`p-3 rounded-lg bg-blue-500/10 border border-blue-500/20 ${stats.totalPVCs > 0 ? 'cursor-pointer hover:bg-blue-500/20' : 'cursor-default'} transition-colors`}
-          onClick={() => {
-            if (filteredPVCs.length > 0 && filteredPVCs[0]?.cluster) {
-              drillToPVC(filteredPVCs[0].cluster, filteredPVCs[0].namespace, filteredPVCs[0].name)
-            }
-          }}
-          title={stats.totalPVCs > 0 ? `${stats.totalPVCs} Persistent Volume Claims - Click to view details` : 'No PVCs found'}
+          className="p-3 rounded-lg bg-blue-500/10 border border-blue-500/20 cursor-default transition-colors"
+          title={stats.totalPVCs > 0 ? `${stats.totalPVCs} Persistent Volume Claims` : 'No PVCs found'}
         >
           <div className="flex items-center gap-2 mb-1">
             <HardDrive className="w-4 h-4 text-blue-400" />
@@ -181,14 +174,8 @@ export function StorageOverview() {
       {/* PVC Status breakdown */}
       <div className="grid grid-cols-3 gap-2 mb-4">
         <div
-          className={`p-2 rounded-lg bg-green-500/10 border border-green-500/20 ${stats.boundPVCs > 0 ? 'cursor-pointer hover:bg-green-500/20' : 'cursor-default'} transition-colors`}
-          onClick={() => {
-            const boundPVC = filteredPVCs.find(p => p.status === 'Bound')
-            if (boundPVC?.cluster) {
-              drillToPVC(boundPVC.cluster, boundPVC.namespace, boundPVC.name)
-            }
-          }}
-          title={stats.boundPVCs > 0 ? `${stats.boundPVCs} PVC${stats.boundPVCs !== 1 ? 's' : ''} successfully bound - Click to view` : 'No bound PVCs'}
+          className="p-2 rounded-lg bg-green-500/10 border border-green-500/20 cursor-default transition-colors"
+          title={stats.boundPVCs > 0 ? `${stats.boundPVCs} PVC${stats.boundPVCs !== 1 ? 's' : ''} successfully bound` : 'No bound PVCs'}
         >
           <div className="flex items-center gap-1.5 mb-1">
             <CheckCircle className="w-3 h-3 text-green-400" />
@@ -197,14 +184,8 @@ export function StorageOverview() {
           <span className="text-lg font-bold text-foreground">{formatStat(stats.boundPVCs)}</span>
         </div>
         <div
-          className={`p-2 rounded-lg bg-yellow-500/10 border border-yellow-500/20 ${stats.pendingPVCs > 0 ? 'cursor-pointer hover:bg-yellow-500/20' : 'cursor-default'} transition-colors`}
-          onClick={() => {
-            const pendingPVC = filteredPVCs.find(p => p.status === 'Pending')
-            if (pendingPVC?.cluster) {
-              drillToPVC(pendingPVC.cluster, pendingPVC.namespace, pendingPVC.name)
-            }
-          }}
-          title={stats.pendingPVCs > 0 ? `${stats.pendingPVCs} PVC${stats.pendingPVCs !== 1 ? 's' : ''} pending - Click to view` : 'No pending PVCs'}
+          className="p-2 rounded-lg bg-yellow-500/10 border border-yellow-500/20 cursor-default transition-colors"
+          title={stats.pendingPVCs > 0 ? `${stats.pendingPVCs} PVC${stats.pendingPVCs !== 1 ? 's' : ''} pending` : 'No pending PVCs'}
         >
           <div className="flex items-center gap-1.5 mb-1">
             <Clock className="w-3 h-3 text-yellow-400" />
@@ -213,14 +194,8 @@ export function StorageOverview() {
           <span className="text-lg font-bold text-foreground">{formatStat(stats.pendingPVCs)}</span>
         </div>
         <div
-          className={`p-2 rounded-lg bg-red-500/10 border border-red-500/20 ${stats.failedPVCs > 0 ? 'cursor-pointer hover:bg-red-500/20' : 'cursor-default'} transition-colors`}
-          onClick={() => {
-            const failedPVC = filteredPVCs.find(p => p.status !== 'Bound' && p.status !== 'Pending')
-            if (failedPVC?.cluster) {
-              drillToPVC(failedPVC.cluster, failedPVC.namespace, failedPVC.name)
-            }
-          }}
-          title={stats.failedPVCs > 0 ? `${stats.failedPVCs} PVC${stats.failedPVCs !== 1 ? 's' : ''} in failed/lost state - Click to view` : 'No failed PVCs'}
+          className="p-2 rounded-lg bg-red-500/10 border border-red-500/20 cursor-default transition-colors"
+          title={stats.failedPVCs > 0 ? `${stats.failedPVCs} PVC${stats.failedPVCs !== 1 ? 's' : ''} in failed/lost state` : 'No failed PVCs'}
         >
           <div className="flex items-center gap-1.5 mb-1">
             <AlertTriangle className="w-3 h-3 text-red-400" />

--- a/web/src/components/cards/__tests__/PVCStatus.test.tsx
+++ b/web/src/components/cards/__tests__/PVCStatus.test.tsx
@@ -45,9 +45,8 @@ vi.mock('../../../hooks/useCachedData', () => ({
   useCachedPVCs: () => mockPVCs(),
 }))
 
-const mockDrillDown = vi.fn()
 vi.mock('../../../hooks/useDrillDown', () => ({
-  useDrillDownActions: () => mockDrillDown(),
+  useDrillDownActions: () => ({}),
 }))
 
 vi.mock('../../../lib/cards/cardHooks', () => ({
@@ -69,7 +68,6 @@ describe('PVCStatus', () => {
     mockUseDemoMode.mockReturnValue({ isDemoMode: true, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() })
     mockUseCardLoadingState.mockReturnValue({ showSkeleton: false, showEmptyState: false, hasData: true, isRefreshing: false })
     mockPVCs.mockReturnValue({ pvcs: [], isLoading: false, isRefreshing: false, isDemoFallback: false, isFailed: false, consecutiveFailures: 0, error: null, lastRefresh: Date.now() })
-    mockDrillDown.mockReturnValue({ drillToPVC: vi.fn() })
   })
 
   it('renders without crashing', () => {

--- a/web/src/components/cards/__tests__/StorageOverview.test.tsx
+++ b/web/src/components/cards/__tests__/StorageOverview.test.tsx
@@ -1,10 +1,8 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { render, screen, fireEvent } from '@testing-library/react'
+import { render, screen } from '@testing-library/react'
 import { StorageOverview } from '../StorageOverview'
 
 // ── Mocks ────────────────────────────────────────────────────────────────────
-
-const mockDrillToPVC = vi.fn()
 
 vi.mock('../../../hooks/useMCP', () => ({
   useClusters: () => ({
@@ -30,7 +28,7 @@ vi.mock('../../../hooks/useGlobalFilters', () => ({
 }))
 
 vi.mock('../../../hooks/useDrillDown', () => ({
-  useDrillDownActions: () => ({ drillToPVC: mockDrillToPVC }),
+  useDrillDownActions: () => ({}),
 }))
 
 vi.mock('../CardDataContext', () => ({
@@ -158,8 +156,8 @@ describe('StorageOverview', () => {
     })
   })
 
-  describe('Drill-down', () => {
-    it('calls drillToPVC when bound PVC tile clicked', async () => {
+  describe('PVC tiles', () => {
+    it('PVC status tiles are not clickable (no drilldown view)', async () => {
       const { useCachedPVCs } = await import('../../../hooks/useCachedData')
       vi.mocked(useCachedPVCs).mockReturnValue({
         pvcs: [{ cluster: 'cluster-1', namespace: 'default', name: 'pvc-1', status: 'Bound', storageClass: 'gp2' }],
@@ -170,8 +168,9 @@ describe('StorageOverview', () => {
         consecutiveFailures: 0,
       } as never)
       render(<StorageOverview />)
-      fireEvent.click(screen.getByText('storageOverview.bound').closest('div')!)
-      expect(mockDrillToPVC).toHaveBeenCalledWith('cluster-1', 'default', 'pvc-1')
+      const boundTile = screen.getByText('storageOverview.bound').closest('div')!
+      expect(boundTile.className).toContain('cursor-default')
+      expect(boundTile.className).not.toContain('cursor-pointer')
     })
   })
 

--- a/web/src/components/storage/Storage.tsx
+++ b/web/src/components/storage/Storage.tsx
@@ -1,8 +1,10 @@
 import { useState, useEffect, useRef } from 'react'
-import { Database, ExternalLink, AlertCircle } from 'lucide-react'
+import { Database, AlertCircle } from 'lucide-react'
 import { BaseModal, useModalState } from '../../lib/modals'
 import { useUniversalStats, createMergedStatValueGetter } from '../../hooks/useUniversalStats'
-import { useClusters, usePVCs, PVC } from '../../hooks/useMCP'
+import { useClusters } from '../../hooks/useMCP'
+import type { PVC } from '../../hooks/useMCP'
+import { useCachedPVCs } from '../../hooks/useCachedData'
 import { useGlobalFilters } from '../../hooks/useGlobalFilters'
 import { useDrillDownActions } from '../../hooks/useDrillDown'
 import { StatBlockValue } from '../ui/StatsOverview'
@@ -19,10 +21,9 @@ interface PVCListModalProps {
   pvcs: PVC[]
   title: string
   statusFilter?: 'Bound' | 'Pending' | 'all'
-  onSelectPVC: (cluster: string, namespace: string, name: string) => void
 }
 
-function PVCListModal({ isOpen, onClose, pvcs, title, statusFilter = 'all', onSelectPVC }: PVCListModalProps) {
+function PVCListModal({ isOpen, onClose, pvcs, title, statusFilter = 'all' }: PVCListModalProps) {
   const { t } = useTranslation()
   const [searchQuery, setSearchQuery] = useState('')
 
@@ -81,8 +82,8 @@ function PVCListModal({ isOpen, onClose, pvcs, title, statusFilter = 'all', onSe
             {filteredPVCs.map((pvc, idx) => (
               <div
                 key={`${pvc.cluster}-${pvc.namespace}-${pvc.name}-${idx}`}
-                onClick={() => pvc.cluster && onSelectPVC(pvc.cluster, pvc.namespace, pvc.name)}
-                className="glass p-3 rounded-lg cursor-pointer hover:bg-secondary/50 transition-colors"
+                className="glass p-3 rounded-lg transition-colors"
+                title="PVC drilldown not available"
               >
                 <div className="flex items-center justify-between">
                   <div className="flex items-center gap-3">
@@ -103,7 +104,6 @@ function PVCListModal({ isOpen, onClose, pvcs, title, statusFilter = 'all', onSe
                   </div>
                   <div className="flex items-center gap-2">
                     {pvc.cluster && <ClusterBadge cluster={pvc.cluster} size="sm" />}
-                    <ExternalLink className="w-4 h-4 text-muted-foreground" />
                   </div>
                 </div>
               </div>
@@ -125,9 +125,9 @@ export function Storage() {
   const {
     selectedClusters: globalSelectedClusters,
     isAllClustersSelected } = useGlobalFilters()
-  const { pvcs, error: pvcsError } = usePVCs()
+  const { pvcs, error: pvcsError } = useCachedPVCs()
   const error = clustersError || pvcsError
-  const { drillToPVC, drillToResources } = useDrillDownActions()
+  const { drillToResources } = useDrillDownActions()
   const { getStatValue: getUniversalStatValue } = useUniversalStats()
 
   // PVC List Modal state
@@ -278,10 +278,6 @@ export function Storage() {
         pvcs={filteredPVCs}
         title={pvcModalFilter === 'all' ? 'All PVCs' : pvcModalFilter === 'Bound' ? 'Bound PVCs' : 'Pending PVCs'}
         statusFilter={pvcModalFilter}
-        onSelectPVC={(cluster, namespace, name) => {
-          closePVCModal()
-          drillToPVC(cluster, namespace, name)
-        }}
       />
     </>
   )


### PR DESCRIPTION
Closes #6809
Closes #6810

## Summary

- **#6809 — Inconsistent storage counts**: `Storage.tsx` (the /storage page) used `usePVCs()` from `hooks/mcp/storage.ts` while the dashboard cards (`StorageOverview.tsx`, `PVCStatus.tsx`) used `useCachedPVCs()` from `hooks/useCachedData.ts`. These are independent hooks with different caching/polling strategies, causing PVC counts to diverge during partial refresh or failure. Fixed by switching `Storage.tsx` to `useCachedPVCs()` — single source of truth for all PVC data.

- **#6810 — PVC rows appear clickable but do nothing**: PVC list rows had `cursor-pointer`, `onClick` handlers, and a `ChevronRight` icon, but `DrillDownModal.renderView()` has no `case 'pvc':` — clicks opened a modal showing "Unknown view type". Fixed by removing click handlers, pointer cursor, and chevron icons from PVC rows in `PVCStatus.tsx`, `StorageOverview.tsx`, and `PVCListModal` (in `Storage.tsx`). Added `title="PVC drilldown not available"` tooltip.

## Test plan

- [x] `npm run build` passes
- [x] Updated `StorageOverview.test.tsx` — drilldown test replaced with "tiles are not clickable" assertion
- [x] Updated `PVCStatus.test.tsx` — removed drillDown mock dependency