### PR TITLE
fix(test): update rollout tests for semver ordering + ratchet baseline (#6882)

### DIFF
--- a/web/src/hooks/useMultiClusterInsights.test.ts
+++ b/web/src/hooks/useMultiClusterInsights.test.ts
@@ -703,8 +703,10 @@ describe('trackRolloutProgress', () => {
     expect(result[0].metrics!.failed).toBe(1)
   })
 
-  it("treats most common image as 'newest' (known behavior)", () => {
-    // Documents the known behavior: during canary, the old image is more common
+  it('treats highest semver image as newest', () => {
+    // PR #6878 switched from frequency-based to semver-based ordering.
+    // v2.0 is the highest semver, so it is "newest" even though v1.0
+    // is deployed to more clusters (the old canary scenario).
     const deps = [
       makeDeployment({ cluster: 'cluster-1', image: 'api:v1.0' }),
       makeDeployment({ cluster: 'cluster-2', image: 'api:v1.0' }),
@@ -712,9 +714,9 @@ describe('trackRolloutProgress', () => {
       makeDeployment({ cluster: 'cluster-4', image: 'api:v2.0' }), // canary
     ]
     const result = trackRolloutProgress(deps)
-    // The 'most common' image (v1.0) is treated as newest
-    expect(result[0].metrics!.completed).toBe(3)
-    expect(result[0].metrics!.pending).toBe(1)
+    // v2.0 is newest by semver — only cluster-4 is completed
+    expect(result[0].metrics!.completed).toBe(1)
+    expect(result[0].metrics!.pending).toBe(3)
   })
 
   it('verifies per-cluster completed/pending/failed breakdown', () => {
@@ -1286,14 +1288,15 @@ describe('trackRolloutProgress — regression', () => {
     expect(result).toHaveLength(1)
     const metrics = result[0].metrics!
 
-    // v1.0 is most common (2 of 3), so treated as "newest"
-    // cluster-1 has v2.0 (not newest, not failed) => pending, progress=50
-    expect(metrics['cluster-1_progress']).toBe(50)
-    expect(metrics['cluster-1_status']).toBe(1) // ROLLOUT_STATUS_IN_PROGRESS
+    // PR #6878: v2.0 is newest by semver (not frequency-based anymore)
+    // cluster-1 has v2.0 (newest) => completed, progress=100
+    expect(metrics['cluster-1_progress']).toBe(100)
+    expect(metrics['cluster-1_status']).toBe(2) // ROLLOUT_STATUS_COMPLETE
 
-    // cluster-2 has v1.0 (newest) => completed, progress=100
+    // cluster-2 has v1.0 (not newest, not failed) => pending
+    // Progress is based on readyReplicas/replicas ratio (3/3 = 100)
     expect(metrics['cluster-2_progress']).toBe(100)
-    expect(metrics['cluster-2_status']).toBe(2) // ROLLOUT_STATUS_COMPLETE
+    expect(metrics['cluster-2_status']).toBe(1) // ROLLOUT_STATUS_IN_PROGRESS
 
     // cluster-3 has status=failed => progress=0, status=3
     expect(metrics['cluster-3_progress']).toBe(0)
@@ -1320,7 +1323,7 @@ describe('trackRolloutProgress — regression', () => {
     const result = trackRolloutProgress(deps)
     expect(result).toHaveLength(1)
     const metrics = result[0].metrics!
-    // v2.0 is most common (2/3), cluster-3 has v1.0 with status=failed
+    // v2.0 is newest by semver, cluster-3 has v1.0 with status=failed
     // pending = deployments with non-newest image AND status !== 'failed' => 0
     expect(metrics.pending).toBe(0)
     expect(metrics.failed).toBe(1)

--- a/web/src/test/ui-ux-standards.test.ts
+++ b/web/src/test/ui-ux-standards.test.ts
@@ -69,11 +69,12 @@ const COMPONENTS_DIR = path.resolve(
 //   303 → 304: #6366 ratchet drift — pre-existing unaccounted-for raw hex from before 303 bump, not introduced by #6365
 //   304 → 306: issue 6774 loading/error states — reverted to 304 in issue 6778 (false positives from issue-ref comments rewritten to "issue NNNN" form)
 //   304 → 307: PR 6854 introduced 3 new hex refs (not real color violations)
+//   307 → 309: issue 6882 ratchet drift — pre-existing false positives from issue-ref comments
 //
 // When you bump this number, append a one-line entry above so future
 // bumps stay grep-able and reviewers can tell at a glance whether a
 // change is a real new violation or just a comment-level reference.
-const EXPECTED_RAW_HEX_COUNT = 307
+const EXPECTED_RAW_HEX_COUNT = 309
 const EXPECTED_RAW_RGBA_COUNT = 104
 const EXPECTED_ARBITRARY_TW_COLOR_COUNT = 22
 const EXPECTED_INLINE_STYLE_COLOR_COUNT = 213


### PR DESCRIPTION
Closes #6882

## Summary

- Updated `useMultiClusterInsights.test.ts` rollout tests to match semver-based image ordering introduced in PR #6878 (v2.0 is now "newest" by semver, not v1.0 by frequency)
- Renamed test from "treats most common image as 'newest' (known behavior)" to "treats highest semver image as newest"
- Updated per-cluster progress assertions: pending clusters now use actual readyReplicas/replicas ratio instead of hardcoded 50
- Bumped raw hex ratchet baseline from 307 to 309 in `ui-ux-standards.test.ts` (false positives from issue-reference comments)

## Test plan

- [x] `npx vitest run src/hooks/useMultiClusterInsights.test.ts` — all 85 tests pass
- [x] `npx vitest run src/test/ui-ux-standards.test.ts` — all 7 ratchet tests pass (was 3 failures)
- [x] `npm run build` — clean