### PR TITLE
fix(storage): show stats when nodeCount is zero + StorageOverview test (#6808, #6885)

### DIFF
--- a/web/src/components/cards/StorageOverview.tsx
+++ b/web/src/components/cards/StorageOverview.tsx
@@ -88,9 +88,10 @@ export function StorageOverview() {
       clustersWithStorage: filteredClusters.filter(c => (c.storageGB || 0) > 0).length }
   }, [filteredClusters, filteredPVCs])
 
-  // Check if we have real data from reachable clusters
+  // Check if we have real data from reachable clusters — storage data is valid
+  // regardless of nodeCount (#6808)
   const hasRealData = !isLoading && filteredClusters.length > 0 &&
-    filteredClusters.some(c => c.reachable !== false && c.storageGB !== undefined && c.nodeCount !== undefined && c.nodeCount > 0)
+    filteredClusters.some(c => c.reachable !== false && c.storageGB !== undefined)
 
   if (showSkeleton) {
     return (

--- a/web/src/components/cards/__tests__/StorageOverview.test.tsx
+++ b/web/src/components/cards/__tests__/StorageOverview.test.tsx
@@ -168,9 +168,12 @@ describe('StorageOverview', () => {
         consecutiveFailures: 0,
       } as never)
       render(<StorageOverview />)
-      const boundTile = screen.getByText('storageOverview.bound').closest('div')!
-      expect(boundTile.className).toContain('cursor-default')
-      expect(boundTile.className).not.toContain('cursor-pointer')
+      // The text is inside a nested div; walk up to the tile container that carries the cursor class
+      const boundLabel = screen.getByText('storageOverview.bound')
+      // The tile div is the one with border/bg classes — two levels up from the label span
+      const tileDivs = boundLabel.closest('[class*="border"]')!
+      expect(tileDivs.className).toContain('cursor-default')
+      expect(tileDivs.className).not.toContain('cursor-pointer')
     })
   })
 

--- a/web/src/components/storage/Storage.tsx
+++ b/web/src/components/storage/Storage.tsx
@@ -157,9 +157,10 @@ export function Storage() {
     boundPVCs: filteredPVCs.filter(p => p.status === 'Bound').length,
     pendingPVCs: filteredPVCs.filter(p => p.status === 'Pending').length }
 
-  // Check if we have actual data (not just loading state)
+  // Check if we have actual data (not just loading state) — storage data is valid
+  // regardless of nodeCount (#6808)
   const hasActualData = filteredClusters.some(c =>
-    c.reachable !== false && c.storageGB !== undefined && c.nodeCount !== undefined && c.nodeCount > 0
+    c.reachable !== false && (c.storageGB !== undefined || pvcs.length > 0)
   )
 
   // Cache the last known good stats to show during refresh


### PR DESCRIPTION
Closes #6808
Partial fix for #6885 (1 of 4 test failures; other 3 fixed by PR #6884)

## Changes

- **Storage.tsx**: Removed `nodeCount > 0` from `hasActualData` check — storage stats now display when `storageGB` is defined or PVCs exist, regardless of node count.
- **StorageOverview.tsx**: Same fix for `hasRealData` — removed `nodeCount` gating so the card renders storage data for clusters with zero nodes.
- **StorageOverview.test.tsx**: Fixed PVC tile clickability test — query now finds the tile container element (with `border` class) instead of the nearest `div`, which was an inner wrapper without `cursor-default`.

## Test plan

- [x] `npx vitest run src/components/cards/__tests__/StorageOverview.test.tsx` — 9/9 pass
- [x] `npm run build` — clean