### PR TITLE
fix: SQLite variable limit batching + honest PV messaging (#6888, #6807)

### DIFF
--- a/pkg/api/handlers/gpu.go
+++ b/pkg/api/handlers/gpu.go
@@ -17,8 +17,8 @@ import (
 )
 
 // bulkUtilizationsMaxIDs caps the number of reservation ids a single
-// GetBulkUtilizations request may ask for. Must stay <= the store-level
-// cap in GetBulkUtilizationSnapshots (#6605).
+// GetBulkUtilizations API request may ask for. This is a DoS guard at the
+// handler level; the store now batches IN clauses internally (#6888).
 const bulkUtilizationsMaxIDs = 500
 
 // ClusterCapacityProvider returns the total GPU capacity for a cluster
@@ -395,10 +395,9 @@ func (h *GPUHandler) GetBulkUtilizations(c *fiber.Ctx) error {
 	}
 
 	ids := strings.Split(idsParam, ",")
-	// #6605: reject oversized fan-outs at the API boundary. The store
-	// already enforces the same cap as defense-in-depth (ErrTooManyIDs),
-	// but a 400 here surfaces the mistake to the client immediately
-	// without touching the database.
+	// #6605: reject oversized fan-outs at the API boundary as a DoS
+	// guard. The store now batches IN clauses internally (#6888), but
+	// we still cap the API to avoid unbounded work.
 	if len(ids) > bulkUtilizationsMaxIDs {
 		return fiber.NewError(fiber.StatusBadRequest,
 			fmt.Sprintf("too many reservation ids: %d (max %d)", len(ids), bulkUtilizationsMaxIDs))

--- a/pkg/store/sqlite.go
+++ b/pkg/store/sqlite.go
@@ -1943,45 +1943,48 @@ func (s *SQLiteStore) GetUtilizationSnapshots(reservationID string) ([]models.GP
 	return snapshots, rows.Err()
 }
 
-// bulkUtilizationMaxIDs is the hard cap on the number of reservation ids a
-// single GetBulkUtilizationSnapshots call may fan out to. The handler layer
-// rejects anything larger at the API boundary (#6605); this constant is
-// the store-level defense-in-depth so an internal caller cannot bypass it.
-const bulkUtilizationMaxIDs = 500
+// sqliteMaxVars is the maximum number of bind variables per SQL statement.
+// SQLite's default SQLITE_MAX_VARIABLE_NUMBER is 999; we use 500 as a safe
+// batch size to stay well under that limit (#6888).
+const sqliteMaxVars = 500
 
 // bulkUtilizationMaxRows caps the number of rows returned in a single
 // GetBulkUtilizationSnapshots call. Each reservation typically has hours
 // to days of hourly snapshots, so 10k is well beyond any realistic view.
 const bulkUtilizationMaxRows = 10000
 
-// ErrTooManyIDs is returned by GetBulkUtilizationSnapshots when the caller
-// passed more ids than bulkUtilizationMaxIDs. Handlers should map this to
-// HTTP 400 Bad Request.
-var ErrTooManyIDs = errors.New("too many reservation ids")
-
 func (s *SQLiteStore) GetBulkUtilizationSnapshots(reservationIDs []string) (map[string][]models.GPUUtilizationSnapshot, error) {
 	result := make(map[string][]models.GPUUtilizationSnapshot)
 	if len(reservationIDs) == 0 {
 		return result, nil
 	}
-	// #6605: bound both the IN clause and the total row count. The previous
-	// implementation had no cap on either, so a client could pass thousands
-	// of ids in one request and walk the entire snapshots table. The
-	// handler (GetBulkUtilizations) also rejects > bulkUtilizationMaxIDs
-	// up front with a 400; this store-level check guards internal callers.
-	if len(reservationIDs) > bulkUtilizationMaxIDs {
-		return nil, ErrTooManyIDs
-	}
 
-	// Build parameterized query with placeholders
-	placeholders := ""
-	// +1 slot for the trailing LIMIT parameter.
-	args := make([]interface{}, 0, len(reservationIDs)+1)
-	for i, id := range reservationIDs {
-		if i > 0 {
-			placeholders += ", "
+	// #6888: batch the IN clause to respect SQLite's variable limit.
+	// Instead of rejecting requests with > sqliteMaxVars IDs, we chunk
+	// the input and merge results across batches.
+	for start := 0; start < len(reservationIDs); start += sqliteMaxVars {
+		end := start + sqliteMaxVars
+		if end > len(reservationIDs) {
+			end = len(reservationIDs)
 		}
-		placeholders += "?"
+		chunk := reservationIDs[start:end]
+
+		if err := s.queryUtilizationChunk(chunk, result); err != nil {
+			return nil, err
+		}
+	}
+	return result, nil
+}
+
+// queryUtilizationChunk executes a single batched query for a chunk of
+// reservation IDs and merges rows into the provided result map.
+func (s *SQLiteStore) queryUtilizationChunk(ids []string, result map[string][]models.GPUUtilizationSnapshot) error {
+	placeholders := strings.Repeat("?,", len(ids))
+	placeholders = placeholders[:len(placeholders)-1] // trim trailing comma
+
+	// +1 slot for the trailing LIMIT parameter.
+	args := make([]interface{}, 0, len(ids)+1)
+	for _, id := range ids {
 		args = append(args, id)
 	}
 	args = append(args, bulkUtilizationMaxRows)
@@ -1991,7 +1994,7 @@ func (s *SQLiteStore) GetBulkUtilizationSnapshots(reservationIDs []string) (map[
 		args...,
 	)
 	if err != nil {
-		return nil, err
+		return err
 	}
 	defer rows.Close()
 
@@ -2000,11 +2003,11 @@ func (s *SQLiteStore) GetBulkUtilizationSnapshots(reservationIDs []string) (map[
 		if err := rows.Scan(&snap.ID, &snap.ReservationID, &snap.Timestamp,
 			&snap.GPUUtilizationPct, &snap.MemoryUtilizationPct,
 			&snap.ActiveGPUCount, &snap.TotalGPUCount); err != nil {
-			return nil, err
+			return err
 		}
 		result[snap.ReservationID] = append(result[snap.ReservationID], snap)
 	}
-	return result, rows.Err()
+	return rows.Err()
 }
 
 func (s *SQLiteStore) DeleteOldUtilizationSnapshots(before time.Time) (int64, error) {

--- a/pkg/store/wave3_fixes_test.go
+++ b/pkg/store/wave3_fixes_test.go
@@ -253,17 +253,20 @@ func TestConsumeOAuthState_ContextCancelled(t *testing.T) {
 	require.Error(t, err, "cancelled ctx must surface as an error on ConsumeOAuthState")
 }
 
-// TestGetBulkUtilizationSnapshots_RejectsOversizedBatch pins #6605 at the
-// store level. The handler layer also rejects oversized fan-outs, but the
-// store must refuse them too so internal callers cannot bypass the cap.
-func TestGetBulkUtilizationSnapshots_RejectsOversizedBatch(t *testing.T) {
+// TestGetBulkUtilizationSnapshots_BatchesLargeRequests verifies that the
+// store batches large IN clauses instead of crashing (#6888). Previously
+// this test asserted rejection; now it asserts graceful batching.
+func TestGetBulkUtilizationSnapshots_BatchesLargeRequests(t *testing.T) {
 	s := newTestStore(t)
 
-	// Build an id slice one larger than the cap.
-	ids := make([]string, bulkUtilizationMaxIDs+1)
+	// Build an id slice larger than sqliteMaxVars to exercise batching.
+	ids := make([]string, sqliteMaxVars+1)
 	for i := range ids {
 		ids[i] = uuid.New().String()
 	}
-	_, err := s.GetBulkUtilizationSnapshots(ids)
-	require.ErrorIs(t, err, ErrTooManyIDs)
+	// Should succeed (empty result) rather than error.
+	result, err := s.GetBulkUtilizationSnapshots(ids)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Empty(t, result)
 }

--- a/web/src/components/cards/cardMetadata.ts
+++ b/web/src/components/cards/cardMetadata.ts
@@ -351,7 +351,7 @@ export const CARD_DESCRIPTIONS: Record<string, string> = {
   pod_logs: 'Live tail of container logs for any pod across your clusters.',
   pod_health_trend: 'Historical trend of pod health status over time.',
   resource_trend: 'Resource usage trends showing CPU and memory over time.',
-  storage_overview: 'Persistent volume and storage class overview.',
+  storage_overview: 'PVC and storage class overview across clusters.',
   pvc_status: 'Status of Persistent Volume Claims across clusters.',
   pv_status: 'Status of Persistent Volumes including capacity and binding.',
   resource_quota_status: 'Resource quota utilization and limits across namespaces.',

--- a/web/src/components/layout/SidebarCustomizer.tsx
+++ b/web/src/components/layout/SidebarCustomizer.tsx
@@ -128,7 +128,7 @@ const KNOWN_ROUTES: KnownRoute[] = [
   { href: '/security-posture', name: 'Security Posture', description: 'Security scanning, vulnerability assessment, and policy enforcement', icon: 'ShieldCheck', category: 'Core Dashboards' },
   { href: '/data-compliance', name: 'Data Compliance', description: 'GDPR, HIPAA, PCI-DSS, and SOC 2 data protection compliance', icon: 'Database', category: 'Core Dashboards' },
   { href: '/gpu-reservations', name: 'GPU Reservations', description: 'Schedule and manage GPU reservations with calendar and quota management', icon: 'Zap', category: 'Core Dashboards' },
-  { href: '/storage', name: 'Storage', description: 'Persistent volumes, storage classes, and capacity management', icon: 'HardDrive', category: 'Core Dashboards' },
+  { href: '/storage', name: 'Storage', description: 'PVCs, storage classes, and capacity management', icon: 'HardDrive', category: 'Core Dashboards' },
   { href: '/network', name: 'Network', description: 'Network policies, ingress, and service mesh configuration', icon: 'Network', category: 'Core Dashboards' },
   { href: '/arcade', name: 'Arcade', description: 'Kubernetes-themed arcade games for taking a break', icon: 'Gamepad2', category: 'Core Dashboards' },
   { href: '/deploy', name: 'KubeStellar Deploy', description: 'Deployment monitoring, GitOps, Helm releases, and ArgoCD', icon: 'Rocket', category: 'Core Dashboards' },

--- a/web/src/components/storage/Storage.tsx
+++ b/web/src/components/storage/Storage.tsx
@@ -258,7 +258,7 @@ export function Storage() {
         hasData={hasDataToShow}
         emptyState={{
           title: 'Storage Dashboard',
-          description: 'Add cards to monitor PersistentVolumes, StorageClasses, and storage utilization across your clusters.' }}
+          description: 'Add cards to monitor PVCs, StorageClasses, and storage utilization across your clusters.' }}
       >
         {/* Error Display */}
         {error && (

--- a/web/src/hooks/__tests__/useSearchIndex.test.ts
+++ b/web/src/hooks/__tests__/useSearchIndex.test.ts
@@ -1200,8 +1200,8 @@ describe('useSearchIndex', () => {
   // ── 67. Page items matched via description substring ───────────────────
 
   it('matches page items via description substring', () => {
-    // 'Persistent volumes' is in the Storage page description
-    const { result } = renderHook(() => useSearchIndex('Persistent volumes'))
+    // 'PVCs' is in the Storage page description
+    const { result } = renderHook(() => useSearchIndex('PVCs'))
     const flat = flattenResults(result.current.results)
     const pages = flat.filter(i => i.category === 'page')
     expect(pages.some(i => i.name === 'Storage')).toBe(true)

--- a/web/src/hooks/useSearchIndex.ts
+++ b/web/src/hooks/useSearchIndex.ts
@@ -294,7 +294,7 @@ const PAGE_ITEMS: SearchItem[] = [
   { id: 'page-clusters', name: 'My Clusters', description: 'Manage Kubernetes clusters', category: 'page', href: '/clusters', keywords: ['kubernetes', 'k8s', 'clusters'] },
   { id: 'page-workloads', name: 'Workloads', description: 'View deployments, pods, and workloads', category: 'page', href: '/workloads', keywords: ['deployment', 'pod', 'replica'] },
   { id: 'page-compute', name: 'Compute', description: 'Nodes, CPUs, GPUs, and compute resources', category: 'page', href: '/compute', keywords: ['node', 'cpu', 'gpu', 'tpu'] },
-  { id: 'page-storage', name: 'Storage', description: 'Persistent volumes and storage classes', category: 'page', href: '/storage', keywords: ['pvc', 'volume', 'disk'] },
+  { id: 'page-storage', name: 'Storage', description: 'PVCs, storage classes, and capacity management', category: 'page', href: '/storage', keywords: ['pvc', 'volume', 'disk'] },
   { id: 'page-network', name: 'Network', description: 'Services, ingress, and network policies', category: 'page', href: '/network', keywords: ['service', 'ingress', 'loadbalancer'] },
   { id: 'page-events', name: 'Events', description: 'Kubernetes cluster events', category: 'page', href: '/events', keywords: ['warning', 'error', 'log'] },
   { id: 'page-security', name: 'Security', description: 'RBAC, roles, and security policies', category: 'page', href: '/security', keywords: ['rbac', 'role', 'policy'] },

--- a/web/src/lib/widgets/widgetRegistry.ts
+++ b/web/src/lib/widgets/widgetRegistry.ts
@@ -179,7 +179,7 @@ export const WIDGET_CARDS: Record<string, WidgetCardDefinition> = {
   storage_overview: {
     cardType: 'storage_overview',
     displayName: 'Storage Overview',
-    description: 'Persistent volume and storage class overview',
+    description: 'PVC and storage class overview across clusters',
     apiEndpoints: ['/api/mcp/storage'],
     supportsTheme: true,
     minRefreshInterval: 60000,

--- a/web/src/locales/de/cards.json
+++ b/web/src/locales/de/cards.json
@@ -318,7 +318,7 @@
     "events_timeline": "Timeline chart of event frequency over time.",
     "pod_health_trend": "Historical trend of pod health status over time.",
     "resource_trend": "Resource usage trends showing CPU and memory over time.",
-    "storage_overview": "Persistent volume and storage class overview.",
+    "storage_overview": "PVC and storage class overview across clusters.",
     "pvc_status": "Status of Persistent Volume Claims across clusters.",
     "pv_status": "Status of Persistent Volumes including capacity and binding.",
     "resource_quota_status": "Resource quota utilization and limits across namespaces.",

--- a/web/src/locales/en/cards.json
+++ b/web/src/locales/en/cards.json
@@ -325,7 +325,7 @@
     "pod_logs": "Tail container logs for any pod across your clusters.",
     "pod_health_trend": "Historical trend of pod health status over time.",
     "resource_trend": "Resource usage trends showing CPU and memory over time.",
-    "storage_overview": "Persistent volume and storage class overview.",
+    "storage_overview": "PVC and storage class overview across clusters.",
     "pvc_status": "Status of Persistent Volume Claims across clusters.",
     "pv_status": "Status of Persistent Volumes including capacity and binding.",
     "resource_quota_status": "Resource quota utilization and limits across namespaces.",

--- a/web/src/locales/es/cards.json
+++ b/web/src/locales/es/cards.json
@@ -318,7 +318,7 @@
     "events_timeline": "Timeline chart of event frequency over time.",
     "pod_health_trend": "Historical trend of pod health status over time.",
     "resource_trend": "Resource usage trends showing CPU and memory over time.",
-    "storage_overview": "Persistent volume and storage class overview.",
+    "storage_overview": "PVC and storage class overview across clusters.",
     "pvc_status": "Status of Persistent Volume Claims across clusters.",
     "pv_status": "Status of Persistent Volumes including capacity and binding.",
     "resource_quota_status": "Resource quota utilization and limits across namespaces.",

--- a/web/src/locales/fr/cards.json
+++ b/web/src/locales/fr/cards.json
@@ -318,7 +318,7 @@
     "events_timeline": "Timeline chart of event frequency over time.",
     "pod_health_trend": "Historical trend of pod health status over time.",
     "resource_trend": "Resource usage trends showing CPU and memory over time.",
-    "storage_overview": "Persistent volume and storage class overview.",
+    "storage_overview": "PVC and storage class overview across clusters.",
     "pvc_status": "Status of Persistent Volume Claims across clusters.",
     "pv_status": "Status of Persistent Volumes including capacity and binding.",
     "resource_quota_status": "Resource quota utilization and limits across namespaces.",

--- a/web/src/locales/hi/cards.json
+++ b/web/src/locales/hi/cards.json
@@ -318,7 +318,7 @@
     "events_timeline": "Timeline chart of event frequency over time.",
     "pod_health_trend": "Historical trend of pod health status over time.",
     "resource_trend": "Resource usage trends showing CPU and memory over time.",
-    "storage_overview": "Persistent volume and storage class overview.",
+    "storage_overview": "PVC and storage class overview across clusters.",
     "pvc_status": "Status of Persistent Volume Claims across clusters.",
     "pv_status": "Status of Persistent Volumes including capacity and binding.",
     "resource_quota_status": "Resource quota utilization and limits across namespaces.",

--- a/web/src/locales/it/cards.json
+++ b/web/src/locales/it/cards.json
@@ -318,7 +318,7 @@
     "events_timeline": "Timeline chart of event frequency over time.",
     "pod_health_trend": "Historical trend of pod health status over time.",
     "resource_trend": "Resource usage trends showing CPU and memory over time.",
-    "storage_overview": "Persistent volume and storage class overview.",
+    "storage_overview": "PVC and storage class overview across clusters.",
     "pvc_status": "Status of Persistent Volume Claims across clusters.",
     "pv_status": "Status of Persistent Volumes including capacity and binding.",
     "resource_quota_status": "Resource quota utilization and limits across namespaces.",

--- a/web/src/locales/ja/cards.json
+++ b/web/src/locales/ja/cards.json
@@ -318,7 +318,7 @@
     "events_timeline": "Timeline chart of event frequency over time.",
     "pod_health_trend": "Historical trend of pod health status over time.",
     "resource_trend": "Resource usage trends showing CPU and memory over time.",
-    "storage_overview": "Persistent volume and storage class overview.",
+    "storage_overview": "PVC and storage class overview across clusters.",
     "pvc_status": "Status of Persistent Volume Claims across clusters.",
     "pv_status": "Status of Persistent Volumes including capacity and binding.",
     "resource_quota_status": "Resource quota utilization and limits across namespaces.",

--- a/web/src/locales/pt/cards.json
+++ b/web/src/locales/pt/cards.json
@@ -318,7 +318,7 @@
     "events_timeline": "Timeline chart of event frequency over time.",
     "pod_health_trend": "Historical trend of pod health status over time.",
     "resource_trend": "Resource usage trends showing CPU and memory over time.",
-    "storage_overview": "Persistent volume and storage class overview.",
+    "storage_overview": "PVC and storage class overview across clusters.",
     "pvc_status": "Status of Persistent Volume Claims across clusters.",
     "pv_status": "Status of Persistent Volumes including capacity and binding.",
     "resource_quota_status": "Resource quota utilization and limits across namespaces.",

--- a/web/src/locales/zh/cards.json
+++ b/web/src/locales/zh/cards.json
@@ -318,7 +318,7 @@
     "events_timeline": "Timeline chart of event frequency over time.",
     "pod_health_trend": "Historical trend of pod health status over time.",
     "resource_trend": "Resource usage trends showing CPU and memory over time.",
-    "storage_overview": "Persistent volume and storage class overview.",
+    "storage_overview": "PVC and storage class overview across clusters.",
     "pvc_status": "Status of Persistent Volume Claims across clusters.",
     "pv_status": "Status of Persistent Volumes including capacity and binding.",
     "resource_quota_status": "Resource quota utilization and limits across namespaces.",


### PR DESCRIPTION
Closes #6888
Closes #6807

## #6888 — SQLite max variable limit crash

`GetBulkUtilizationSnapshots` previously rejected requests with >500 reservation IDs (`ErrTooManyIDs`). Now it batches the `IN (?, ?, ...)` clause into chunks of `sqliteMaxVars` (500), executes each chunk separately, and merges results. This stays well under SQLite's 999-variable limit regardless of input size.

**Files**: `pkg/store/sqlite.go`, `pkg/store/wave3_fixes_test.go`, `pkg/api/handlers/gpu.go`

## #6807 — Storage page claims PV monitoring but only shows PVCs

Updated descriptions in the StorageOverview card metadata, widget registry, sidebar customizer, search index, locale files (all 9 languages), and the Storage page empty state to say "PVC" instead of "Persistent volume" where the underlying data is PVC-only. The separate PV Status card descriptions remain unchanged since that card fetches real PV data via `/api/mcp/pvs`.

**Files**: 15 TS/JSON files across `web/src/`