### PR TITLE
✨ Add Keycloak monitoring card

### DIFF
--- a/web/src/components/cards/cardMetadata.ts
+++ b/web/src/components/cards/cardMetadata.ts
@@ -270,7 +270,8 @@ export const CARD_TITLES: Record<string, string> = {
   openfeature_status: 'OpenFeature',
   // OpenKruise advanced workloads
   openkruise_status: 'OpenKruise',
-
+  // Keycloak Identity & Access Management
+  keycloak_status: 'Keycloak',
   // KubeVela application delivery
   kubevela_status: 'KubeVela',
   // CloudEvents monitoring
@@ -557,6 +558,8 @@ export const CARD_DESCRIPTIONS: Record<string, string> = {
   deployment_rollout_tracker: 'Tracks deployment rollout progress across clusters.',
   // KEDA
   keda_status: 'KEDA (Kubernetes Event-Driven Autoscaling) automatically scales workloads based on external event sources like message queues, databases, or custom metrics. This card shows which workloads are being autoscaled, their current triggers, and queue depths.',
+  // Keycloak Identity & Access Management
+  keycloak_status: 'Keycloak is a CNCF-incubating open-source Identity and Access Management solution. This card monitors the Keycloak Operator health, realm status, active user sessions, and registered clients across your clusters.',
   // Karmada multi-cluster orchestration
   karmada_status: 'Karmada is a multi-cluster orchestration tool that propagates resources (Deployments, Services, etc.) across multiple clusters using placement policies. This card shows propagation status, member cluster health, and policy compliance.',
   kuberay_fleet: 'Discovers RayCluster, RayService, and RayJob CRDs across all connected clusters. Shows fleet-level Ray workload status including GPU allocations, serving endpoints, and job progress.',

--- a/web/src/components/cards/cardRegistry.ts
+++ b/web/src/components/cards/cardRegistry.ts
@@ -257,7 +257,8 @@ const ThanosStatus = safeLazy(() => import('./thanos_status'), 'ThanosStatus')
 const OpenFeatureStatus = safeLazy(() => import('./openfeature_status'), 'OpenFeatureStatus')
 // OpenKruise advanced workloads + sidecar injection card
 const OpenKruiseStatus = safeLazy(() => import('./openkruise_status'), 'OpenKruiseStatus')
-
+// Keycloak Identity & Access Management card
+const KeycloakStatus = safeLazy(() => import('./keycloak_status'), 'KeycloakStatus')
 // Inspektor Gadget cards
 const NetworkTraceCard = safeLazy(() => import('./gadget/NetworkTraceCard'), 'NetworkTraceCard')
 const DNSTraceCard = safeLazy(() => import('./gadget/DNSTraceCard'), 'DNSTraceCard')
@@ -577,7 +578,8 @@ const RAW_CARD_COMPONENTS: Record<string, CardComponent> = {
   openfeature_status: OpenFeatureStatus,
   // OpenKruise advanced workloads + sidecar injection
   openkruise_status: OpenKruiseStatus,
-
+  // Keycloak Identity & Access Management
+  keycloak_status: KeycloakStatus,
   // Inspektor Gadget cards
   network_trace: NetworkTraceCard,
   dns_trace: DNSTraceCard,
@@ -983,6 +985,8 @@ const CARD_CHUNK_PRELOADERS: Record<string, () => Promise<unknown>> = {
   openfeature_status: () => import('./openfeature_status'),
   // OpenKruise advanced workloads + sidecar injection
   openkruise_status: () => import('./openkruise_status'),
+  // Keycloak Identity & Access Management
+  keycloak_status: () => import('./keycloak_status'),
   // Flatcar Container Linux
   flatcar_status: () => import('./flatcar_status'),
   // CoreDNS
@@ -1157,6 +1161,7 @@ export const LIVE_DATA_CARDS = new Set([
   'keda_status',
   'crio_status',
   'strimzi_status',
+  'keycloak_status',
   'kubevela_status',
   // KubeRay, SLO, Failover, Trino - demo until detected
   'kuberay_fleet',
@@ -1320,7 +1325,8 @@ export const CARD_DEFAULT_WIDTHS: Record<string, number> = {
   openfeature_status: 6,
   // OpenKruise advanced workloads + sidecar injection
   openkruise_status: 6,
-
+  // Keycloak Identity & Access Management
+  keycloak_status: 6,
   // Multi-cluster insights cards
   cross_cluster_event_correlation: 6,
   cluster_delta_detector: 6,

--- a/web/src/components/cards/keycloak_status/KeycloakStatus.tsx
+++ b/web/src/components/cards/keycloak_status/KeycloakStatus.tsx
@@ -20,27 +20,26 @@ import type { KeycloakRealm, KeycloakRealmStatus } from './demoData'
 // Helpers
 // ---------------------------------------------------------------------------
 
+// Labels are resolved via t(`keycloak.${status}`) at render time so they go
+// through the i18n pipeline. Keys: keycloak.ready, keycloak.degraded,
+// keycloak.provisioning, keycloak.error — all defined in locales/en/cards.json.
 const STATUS_CONFIG: Record<
   KeycloakRealmStatus,
-  { label: string; color: string; icon: React.ReactNode }
+  { color: string; icon: React.ReactNode }
 > = {
   ready: {
-    label: 'Ready',
     color: 'text-green-400',
     icon: <CheckCircle className="w-3.5 h-3.5 text-green-400" />,
   },
   degraded: {
-    label: 'Degraded',
     color: 'text-yellow-400',
     icon: <AlertTriangle className="w-3.5 h-3.5 text-yellow-400" />,
   },
   provisioning: {
-    label: 'Provisioning',
     color: 'text-blue-400',
     icon: <Loader2 className="w-3.5 h-3.5 text-blue-400 animate-spin" />,
   },
   error: {
-    label: 'Error',
     color: 'text-red-400',
     icon: <XCircle className="w-3.5 h-3.5 text-red-400" />,
   },
@@ -106,7 +105,7 @@ function RealmRow({ realm }: { realm: KeycloakRealm }) {
             </span>
           )}
         </div>
-        <span className={`text-xs shrink-0 ${cfg.color}`}>{cfg.label}</span>
+        <span className={`text-xs shrink-0 ${cfg.color}`}>{t(`keycloak.${realm.status}`)}</span>
       </div>
 
       {/* Row 2: namespace + metrics */}

--- a/web/src/components/cards/keycloak_status/KeycloakStatus.tsx
+++ b/web/src/components/cards/keycloak_status/KeycloakStatus.tsx
@@ -1,0 +1,327 @@
+import { useState } from 'react'
+import {
+  CheckCircle,
+  AlertTriangle,
+  RefreshCw,
+  Shield,
+  XCircle,
+  Loader2,
+  Users,
+  Globe,
+  Key,
+} from 'lucide-react'
+import { useTranslation } from 'react-i18next'
+import { Skeleton, SkeletonStats, SkeletonList } from '../../ui/Skeleton'
+import { CardSearchInput } from '../../../lib/cards/CardComponents'
+import { useKeycloakStatus } from './useKeycloakStatus'
+import type { KeycloakRealm, KeycloakRealmStatus } from './demoData'
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const STATUS_CONFIG: Record<
+  KeycloakRealmStatus,
+  { label: string; color: string; icon: React.ReactNode }
+> = {
+  ready: {
+    label: 'Ready',
+    color: 'text-green-400',
+    icon: <CheckCircle className="w-3.5 h-3.5 text-green-400" />,
+  },
+  degraded: {
+    label: 'Degraded',
+    color: 'text-yellow-400',
+    icon: <AlertTriangle className="w-3.5 h-3.5 text-yellow-400" />,
+  },
+  provisioning: {
+    label: 'Provisioning',
+    color: 'text-blue-400',
+    icon: <Loader2 className="w-3.5 h-3.5 text-blue-400 animate-spin" />,
+  },
+  error: {
+    label: 'Error',
+    color: 'text-red-400',
+    icon: <XCircle className="w-3.5 h-3.5 text-red-400" />,
+  },
+}
+
+function useFormatRelativeTime() {
+  const { t } = useTranslation('cards')
+  return (isoString: string): string => {
+    const diff = Date.now() - new Date(isoString).getTime()
+    if (isNaN(diff) || diff < 0) return t('keycloak.syncedJustNow')
+    const minute = 60_000
+    const hour = 60 * minute
+    const day = 24 * hour
+    if (diff < minute) return t('keycloak.syncedJustNow')
+    if (diff < hour) return t('keycloak.syncedMinutesAgo', { count: Math.floor(diff / minute) })
+    if (diff < day) return t('keycloak.syncedHoursAgo', { count: Math.floor(diff / hour) })
+    return t('keycloak.syncedDaysAgo', { count: Math.floor(diff / day) })
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Sub-components
+// ---------------------------------------------------------------------------
+
+function StatTile({
+  icon,
+  label,
+  value,
+  colorClass,
+  borderClass,
+}: {
+  icon: React.ReactNode
+  label: string
+  value: number
+  colorClass: string
+  borderClass: string
+}) {
+  return (
+    <div className={`p-3 rounded-lg bg-secondary/30 border ${borderClass}`}>
+      <div className="flex items-center gap-2 mb-1">
+        {icon}
+        <span className={`text-xs ${colorClass}`}>{label}</span>
+      </div>
+      <span className="text-2xl font-bold text-foreground">{value.toLocaleString()}</span>
+    </div>
+  )
+}
+
+function RealmRow({ realm }: { realm: KeycloakRealm }) {
+  const { t } = useTranslation('cards')
+  const cfg = STATUS_CONFIG[realm.status]
+
+  return (
+    <div className="rounded-md bg-muted/30 px-3 py-2 space-y-1.5">
+      {/* Row 1: name + status */}
+      <div className="flex items-center justify-between gap-2">
+        <div className="flex items-center gap-1.5 min-w-0">
+          {cfg.icon}
+          <span className="text-xs font-medium truncate">{realm.name}</span>
+          {!realm.enabled && (
+            <span className="text-xs text-muted-foreground/60 shrink-0">
+              ({t('keycloak.disabled', 'disabled')})
+            </span>
+          )}
+        </div>
+        <span className={`text-xs shrink-0 ${cfg.color}`}>{cfg.label}</span>
+      </div>
+
+      {/* Row 2: namespace + metrics */}
+      <div className="flex items-center justify-between text-xs text-muted-foreground">
+        <span className="truncate">{realm.namespace}</span>
+        <div className="flex items-center gap-3 shrink-0 ml-2">
+          <span className="flex items-center gap-1">
+            <Users className="w-3 h-3" />
+            {realm.users.toLocaleString()}
+          </span>
+          <span className="flex items-center gap-1">
+            <Globe className="w-3 h-3" />
+            {realm.clients}
+          </span>
+          {realm.activeSessions > 0 && (
+            <span className="flex items-center gap-1 text-green-400">
+              <Key className="w-3 h-3" />
+              {realm.activeSessions}
+            </span>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Main component
+// ---------------------------------------------------------------------------
+
+export function KeycloakStatus() {
+  const { t } = useTranslation('cards')
+  const formatRelativeTime = useFormatRelativeTime()
+  const { data, isRefreshing, error, showSkeleton, showEmptyState } = useKeycloakStatus()
+  const [search, setSearch] = useState('')
+
+  const realms = data.realms || []
+  const operatorPods = data.operatorPods || { ready: 0, total: 0 }
+
+  // Derived stats
+  const stats = (() => {
+    return {
+      ready: realms.filter(r => r.status === 'ready').length,
+      issues: realms.filter(r => r.status === 'degraded' || r.status === 'error').length,
+    }
+  })()
+
+  // Filtered list (local search)
+  const filteredRealms = (() => {
+    if (!search.trim()) return realms
+    const q = search.toLowerCase()
+    return realms.filter(
+      r =>
+        r.name.toLowerCase().includes(q) ||
+        r.namespace.toLowerCase().includes(q),
+    )
+  })()
+
+  // ── Loading ───────────────────────────────────────────────────────────────
+  if (showSkeleton) {
+    return (
+      <div className="h-full flex flex-col min-h-card gap-4">
+        <div className="flex items-center justify-between">
+          <Skeleton variant="rounded" width={120} height={28} />
+          <Skeleton variant="rounded" width={80} height={20} />
+        </div>
+        <SkeletonStats className="grid-cols-4" />
+        <Skeleton variant="rounded" height={32} />
+        <SkeletonList items={3} className="flex-1" />
+      </div>
+    )
+  }
+
+  // ── Error ─────────────────────────────────────────────────────────────────
+  if (error && showEmptyState) {
+    return (
+      <div className="h-full flex flex-col items-center justify-center min-h-card text-muted-foreground gap-2">
+        <AlertTriangle className="w-6 h-6 text-red-400" />
+        <p className="text-sm text-red-400">
+          {t('keycloak.fetchError', 'Failed to fetch Keycloak status')}
+        </p>
+      </div>
+    )
+  }
+
+  // ── Not installed ──────────────────────────────────────────────────────────
+  if (data.health === 'not-installed') {
+    return (
+      <div className="h-full flex flex-col items-center justify-center min-h-card text-muted-foreground gap-2">
+        <Shield className="w-6 h-6 text-muted-foreground/50" />
+        <p className="text-sm font-medium">
+          {t('keycloak.notInstalled', 'Keycloak not detected')}
+        </p>
+        <p className="text-xs text-center max-w-xs">
+          {t(
+            'keycloak.notInstalledHint',
+            'No Keycloak operator pods found. Deploy the Keycloak Operator to manage realms and SSO.',
+          )}
+        </p>
+      </div>
+    )
+  }
+
+  const isHealthy = data.health === 'healthy'
+  const healthColorClass = isHealthy
+    ? 'bg-green-500/15 text-green-400'
+    : 'bg-yellow-500/15 text-yellow-400'
+
+  return (
+    <div className="h-full flex flex-col min-h-card content-loaded gap-4 overflow-hidden">
+      {/* ── Header: health badge + operator pods + last check ── */}
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-2">
+          <div
+            className={`flex items-center gap-2 px-3 py-1.5 rounded-full text-sm font-medium ${healthColorClass}`}
+          >
+            {isHealthy ? (
+              <CheckCircle className="w-4 h-4" />
+            ) : (
+              <AlertTriangle className="w-4 h-4" />
+            )}
+            {isHealthy
+              ? t('keycloak.healthy', 'Healthy')
+              : t('keycloak.degraded', 'Degraded')}
+          </div>
+          <span className="text-xs text-muted-foreground flex items-center gap-1">
+            <Shield className="w-3 h-3" />
+            {operatorPods.ready}/{operatorPods.total}{' '}
+            {t('keycloak.pods', 'pods')}
+          </span>
+        </div>
+        <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
+          <RefreshCw className={`w-3 h-3 ${isRefreshing ? 'animate-spin' : ''}`} />
+          <span>{formatRelativeTime(data.lastCheckTime)}</span>
+        </div>
+      </div>
+
+      {/* ── Stats grid ── */}
+      {realms.length > 0 && (
+        <div className="grid grid-cols-4 gap-2">
+          <StatTile
+            icon={<Globe className="w-4 h-4 text-blue-400" />}
+            label={t('keycloak.realms', 'Realms')}
+            value={realms.length}
+            colorClass="text-blue-400"
+            borderClass="border-blue-500/20"
+          />
+          <StatTile
+            icon={<CheckCircle className="w-4 h-4 text-green-400" />}
+            label={t('keycloak.ready', 'Ready')}
+            value={stats.ready}
+            colorClass="text-green-400"
+            borderClass="border-green-500/20"
+          />
+          <StatTile
+            icon={<Users className="w-4 h-4 text-cyan-400" />}
+            label={t('keycloak.sessions', 'Sessions')}
+            value={data.totalActiveSessions}
+            colorClass="text-cyan-400"
+            borderClass="border-cyan-500/20"
+          />
+          <StatTile
+            icon={<AlertTriangle className="w-4 h-4 text-red-400" />}
+            label={t('keycloak.issues', 'Issues')}
+            value={stats.issues}
+            colorClass="text-red-400"
+            borderClass="border-red-500/20"
+          />
+        </div>
+      )}
+
+      {/* ── Search ── */}
+      {realms.length > 0 && (
+        <CardSearchInput
+          value={search}
+          onChange={setSearch}
+          placeholder={t('keycloak.searchPlaceholder', 'Search realms…')}
+        />
+      )}
+
+      {/* ── Realm list ── */}
+      <div className="flex-1 space-y-2 overflow-y-auto">
+        {filteredRealms.length > 0 ? (
+          filteredRealms.map(realm => (
+            <RealmRow key={`${realm.namespace}/${realm.name}`} realm={realm} />
+          ))
+        ) : realms.length === 0 ? (
+          <div className="flex flex-col items-center justify-center h-full text-muted-foreground gap-1 py-6">
+            <Shield className="w-6 h-6 opacity-40" />
+            <p className="text-sm">{t('keycloak.noRealms', 'Operator running')}</p>
+            <p className="text-xs text-center">
+              {t(
+                'keycloak.noRealmsHint',
+                'Realm data requires the Keycloak CRD API.',
+              )}
+            </p>
+          </div>
+        ) : (
+          <div className="flex items-center justify-center py-6 text-xs text-muted-foreground">
+            {t('keycloak.noSearchResults', 'No realms match your search.')}
+          </div>
+        )}
+      </div>
+
+      {/* ── Footer: totals ── */}
+      {realms.length > 0 && (
+        <div className="pt-2 border-t border-border/50 text-xs text-muted-foreground flex gap-4">
+          <span>
+            {data.totalUsers.toLocaleString()} {t('keycloak.users', 'users')}
+          </span>
+          <span>
+            {data.totalClients} {t('keycloak.clients', 'clients')}
+          </span>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/web/src/components/cards/keycloak_status/KeycloakStatus.tsx
+++ b/web/src/components/cards/keycloak_status/KeycloakStatus.tsx
@@ -1,4 +1,3 @@
-import { useState } from 'react'
 import {
   CheckCircle,
   AlertTriangle,
@@ -13,6 +12,7 @@ import {
 import { useTranslation } from 'react-i18next'
 import { Skeleton, SkeletonStats, SkeletonList } from '../../ui/Skeleton'
 import { CardSearchInput } from '../../../lib/cards/CardComponents'
+import { useCardData } from '../../../lib/cards/cardHooks'
 import { useKeycloakStatus } from './useKeycloakStatus'
 import type { KeycloakRealm, KeycloakRealmStatus } from './demoData'
 
@@ -43,6 +43,15 @@ const STATUS_CONFIG: Record<
     color: 'text-red-400',
     icon: <XCircle className="w-3.5 h-3.5 text-red-400" />,
   },
+}
+
+type RealmSortKey = 'status' | 'name'
+
+const STATUS_SORT_ORDER: Record<KeycloakRealmStatus, number> = {
+  error: 0,
+  degraded: 1,
+  provisioning: 2,
+  ready: 3,
 }
 
 function useFormatRelativeTime() {
@@ -101,7 +110,7 @@ function RealmRow({ realm }: { realm: KeycloakRealm }) {
           <span className="text-xs font-medium truncate">{realm.name}</span>
           {!realm.enabled && (
             <span className="text-xs text-muted-foreground/60 shrink-0">
-              ({t('keycloak.disabled', 'disabled')})
+              ({t('keycloak.disabled')})
             </span>
           )}
         </div>
@@ -140,29 +149,35 @@ export function KeycloakStatus() {
   const { t } = useTranslation('cards')
   const formatRelativeTime = useFormatRelativeTime()
   const { data, isRefreshing, error, showSkeleton, showEmptyState } = useKeycloakStatus()
-  const [search, setSearch] = useState('')
 
   const realms = data.realms || []
   const operatorPods = data.operatorPods || { ready: 0, total: 0 }
 
-  // Derived stats
-  const stats = (() => {
-    return {
-      ready: realms.filter(r => r.status === 'ready').length,
-      issues: realms.filter(r => r.status === 'degraded' || r.status === 'error').length,
-    }
-  })()
+  // Derived stats are always computed from all realms, not the filtered slice
+  const stats = {
+    ready: realms.filter(r => r.status === 'ready').length,
+    issues: realms.filter(r => r.status === 'degraded' || r.status === 'error').length,
+  }
 
-  // Filtered list (local search)
-  const filteredRealms = (() => {
-    if (!search.trim()) return realms
-    const q = search.toLowerCase()
-    return realms.filter(
-      r =>
-        r.name.toLowerCase().includes(q) ||
-        r.namespace.toLowerCase().includes(q),
-    )
-  })()
+  const {
+    items: filteredRealms,
+    filters: { search, setSearch },
+  } = useCardData<KeycloakRealm, RealmSortKey>(realms, {
+    filter: {
+      searchFields: ['name', 'namespace'],
+      storageKey: 'keycloak-status',
+    },
+    sort: {
+      defaultField: 'status',
+      defaultDirection: 'asc',
+      comparators: {
+        status: (a, b) =>
+          (STATUS_SORT_ORDER[a.status] ?? 4) - (STATUS_SORT_ORDER[b.status] ?? 4),
+        name: (a, b) => a.name.localeCompare(b.name),
+      },
+    },
+    defaultLimit: 'unlimited',
+  })
 
   // ── Loading ───────────────────────────────────────────────────────────────
   if (showSkeleton) {
@@ -185,7 +200,7 @@ export function KeycloakStatus() {
       <div className="h-full flex flex-col items-center justify-center min-h-card text-muted-foreground gap-2">
         <AlertTriangle className="w-6 h-6 text-red-400" />
         <p className="text-sm text-red-400">
-          {t('keycloak.fetchError', 'Failed to fetch Keycloak status')}
+          {t('keycloak.fetchError')}
         </p>
       </div>
     )
@@ -197,13 +212,10 @@ export function KeycloakStatus() {
       <div className="h-full flex flex-col items-center justify-center min-h-card text-muted-foreground gap-2">
         <Shield className="w-6 h-6 text-muted-foreground/50" />
         <p className="text-sm font-medium">
-          {t('keycloak.notInstalled', 'Keycloak not detected')}
+          {t('keycloak.notInstalled')}
         </p>
         <p className="text-xs text-center max-w-xs">
-          {t(
-            'keycloak.notInstalledHint',
-            'No Keycloak operator pods found. Deploy the Keycloak Operator to manage realms and SSO.',
-          )}
+          {t('keycloak.notInstalledHint')}
         </p>
       </div>
     )
@@ -228,13 +240,13 @@ export function KeycloakStatus() {
               <AlertTriangle className="w-4 h-4" />
             )}
             {isHealthy
-              ? t('keycloak.healthy', 'Healthy')
-              : t('keycloak.degraded', 'Degraded')}
+              ? t('keycloak.healthy')
+              : t('keycloak.degraded')}
           </div>
           <span className="text-xs text-muted-foreground flex items-center gap-1">
             <Shield className="w-3 h-3" />
             {operatorPods.ready}/{operatorPods.total}{' '}
-            {t('keycloak.pods', 'pods')}
+            {t('keycloak.pods')}
           </span>
         </div>
         <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
@@ -248,28 +260,28 @@ export function KeycloakStatus() {
         <div className="grid grid-cols-4 gap-2">
           <StatTile
             icon={<Globe className="w-4 h-4 text-blue-400" />}
-            label={t('keycloak.realms', 'Realms')}
+            label={t('keycloak.realms')}
             value={realms.length}
             colorClass="text-blue-400"
             borderClass="border-blue-500/20"
           />
           <StatTile
             icon={<CheckCircle className="w-4 h-4 text-green-400" />}
-            label={t('keycloak.ready', 'Ready')}
+            label={t('keycloak.ready')}
             value={stats.ready}
             colorClass="text-green-400"
             borderClass="border-green-500/20"
           />
           <StatTile
             icon={<Users className="w-4 h-4 text-cyan-400" />}
-            label={t('keycloak.sessions', 'Sessions')}
+            label={t('keycloak.sessions')}
             value={data.totalActiveSessions}
             colorClass="text-cyan-400"
             borderClass="border-cyan-500/20"
           />
           <StatTile
             icon={<AlertTriangle className="w-4 h-4 text-red-400" />}
-            label={t('keycloak.issues', 'Issues')}
+            label={t('keycloak.issues')}
             value={stats.issues}
             colorClass="text-red-400"
             borderClass="border-red-500/20"
@@ -282,7 +294,7 @@ export function KeycloakStatus() {
         <CardSearchInput
           value={search}
           onChange={setSearch}
-          placeholder={t('keycloak.searchPlaceholder', 'Search realms…')}
+          placeholder={t('keycloak.searchPlaceholder')}
         />
       )}
 
@@ -295,17 +307,14 @@ export function KeycloakStatus() {
         ) : realms.length === 0 ? (
           <div className="flex flex-col items-center justify-center h-full text-muted-foreground gap-1 py-6">
             <Shield className="w-6 h-6 opacity-40" />
-            <p className="text-sm">{t('keycloak.noRealms', 'Operator running')}</p>
+            <p className="text-sm">{t('keycloak.noRealms')}</p>
             <p className="text-xs text-center">
-              {t(
-                'keycloak.noRealmsHint',
-                'Realm data requires the Keycloak CRD API.',
-              )}
+              {t('keycloak.noRealmsHint')}
             </p>
           </div>
         ) : (
           <div className="flex items-center justify-center py-6 text-xs text-muted-foreground">
-            {t('keycloak.noSearchResults', 'No realms match your search.')}
+            {t('keycloak.noSearchResults')}
           </div>
         )}
       </div>
@@ -314,10 +323,10 @@ export function KeycloakStatus() {
       {realms.length > 0 && (
         <div className="pt-2 border-t border-border/50 text-xs text-muted-foreground flex gap-4">
           <span>
-            {data.totalUsers.toLocaleString()} {t('keycloak.users', 'users')}
+            {data.totalUsers.toLocaleString()} {t('keycloak.users')}
           </span>
           <span>
-            {data.totalClients} {t('keycloak.clients', 'clients')}
+            {data.totalClients} {t('keycloak.clients')}
           </span>
         </div>
       )}

--- a/web/src/components/cards/keycloak_status/__tests__/KeycloakStatus.test.tsx
+++ b/web/src/components/cards/keycloak_status/__tests__/KeycloakStatus.test.tsx
@@ -146,8 +146,8 @@ describe('KeycloakStatus', () => {
       showEmptyState: false,
     })
     render(<KeycloakStatus />)
-    // Health badge
-    expect(screen.getByText('keycloak.degraded')).toBeTruthy()
+    // Health badge — "degraded" also appears on the staging realm row, so use getAllByText
+    expect(screen.getAllByText('keycloak.degraded').length).toBeGreaterThanOrEqual(1)
     // All five demo realms are visible
     expect(screen.getByText('master')).toBeTruthy()
     expect(screen.getByText('platform')).toBeTruthy()

--- a/web/src/components/cards/keycloak_status/__tests__/KeycloakStatus.test.tsx
+++ b/web/src/components/cards/keycloak_status/__tests__/KeycloakStatus.test.tsx
@@ -1,0 +1,172 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+
+// ---------------------------------------------------------------------------
+// Module mocks (must be before any imports that pull these in transitively)
+// ---------------------------------------------------------------------------
+
+vi.mock('../../../../lib/demoMode', () => ({
+  isDemoMode: () => true,
+  getDemoMode: () => true,
+  isNetlifyDeployment: false,
+  isDemoModeForced: false,
+  canToggleDemoMode: () => true,
+  setDemoMode: vi.fn(),
+  toggleDemoMode: vi.fn(),
+  subscribeDemoMode: () => () => {},
+  isDemoToken: () => true,
+  hasRealToken: () => false,
+  setDemoToken: vi.fn(),
+  isFeatureEnabled: () => true,
+}))
+
+vi.mock('../../../../hooks/useDemoMode', () => ({
+  getDemoMode: () => true,
+  default: () => true,
+  useDemoMode: () => ({ isDemoMode: true, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
+  hasRealToken: () => false,
+  isDemoModeForced: false,
+  isNetlifyDeployment: false,
+  canToggleDemoMode: () => true,
+  isDemoToken: () => true,
+  setDemoToken: vi.fn(),
+  setGlobalDemoMode: vi.fn(),
+}))
+
+vi.mock('../../../../lib/analytics', () => ({
+  emitNavigate: vi.fn(),
+  emitLogin: vi.fn(),
+  emitEvent: vi.fn(),
+  analyticsReady: Promise.resolve(),
+  emitAddCardModalOpened: vi.fn(),
+  emitCardExpanded: vi.fn(),
+  emitCardRefreshed: vi.fn(),
+}))
+
+vi.mock('../../../../hooks/useTokenUsage', () => ({
+  useTokenUsage: () => ({ usage: { total: 0, remaining: 0, used: 0 }, isLoading: false }),
+  tokenUsageTracker: {
+    getUsage: () => ({ total: 0, remaining: 0, used: 0 }),
+    trackRequest: vi.fn(),
+    getSettings: () => ({ enabled: false }),
+  },
+}))
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+    i18n: { language: 'en', changeLanguage: vi.fn() },
+  }),
+  Trans: ({ children }: { children: React.ReactNode }) => children,
+}))
+
+// ---------------------------------------------------------------------------
+// Subject under test
+// ---------------------------------------------------------------------------
+
+import { KeycloakStatus } from '../KeycloakStatus'
+import { KEYCLOAK_DEMO_DATA } from '../demoData'
+
+// ---------------------------------------------------------------------------
+// Mock the data hook so we control rendered state
+// ---------------------------------------------------------------------------
+
+vi.mock('../useKeycloakStatus', () => ({
+  useKeycloakStatus: vi.fn(),
+}))
+
+import { useKeycloakStatus } from '../useKeycloakStatus'
+
+const INITIAL_DATA = {
+  health: 'not-installed' as const,
+  operatorPods: { ready: 0, total: 0 },
+  realms: [],
+  totalClients: 0,
+  totalUsers: 0,
+  totalActiveSessions: 0,
+  lastCheckTime: new Date().toISOString(),
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('KeycloakStatus', () => {
+  it('renders skeleton while loading', () => {
+    vi.mocked(useKeycloakStatus).mockReturnValue({
+      data: INITIAL_DATA,
+      loading: true,
+      isRefreshing: false,
+      error: false,
+      consecutiveFailures: 0,
+      showSkeleton: true,
+      showEmptyState: false,
+    })
+    const { container } = render(<KeycloakStatus />)
+    // Skeleton renders pulsing divs, not realm rows
+    expect(container.querySelector('.animate-pulse')).toBeTruthy()
+  })
+
+  it('renders not-installed state when Keycloak is absent', () => {
+    vi.mocked(useKeycloakStatus).mockReturnValue({
+      data: INITIAL_DATA,
+      loading: false,
+      isRefreshing: false,
+      error: false,
+      consecutiveFailures: 0,
+      showSkeleton: false,
+      showEmptyState: false,
+    })
+    render(<KeycloakStatus />)
+    expect(screen.getByText('keycloak.notInstalled')).toBeTruthy()
+  })
+
+  it('renders error state when fetch fails and there is no data', () => {
+    vi.mocked(useKeycloakStatus).mockReturnValue({
+      data: INITIAL_DATA,
+      loading: false,
+      isRefreshing: false,
+      error: true,
+      consecutiveFailures: 3,
+      showSkeleton: false,
+      showEmptyState: true,
+    })
+    render(<KeycloakStatus />)
+    expect(screen.getByText('keycloak.fetchError')).toBeTruthy()
+  })
+
+  it('renders live data with health badge and realm list', () => {
+    vi.mocked(useKeycloakStatus).mockReturnValue({
+      data: KEYCLOAK_DEMO_DATA,
+      loading: false,
+      isRefreshing: false,
+      error: false,
+      consecutiveFailures: 0,
+      showSkeleton: false,
+      showEmptyState: false,
+    })
+    render(<KeycloakStatus />)
+    // Health badge
+    expect(screen.getByText('keycloak.degraded')).toBeTruthy()
+    // All five demo realms are visible
+    expect(screen.getByText('master')).toBeTruthy()
+    expect(screen.getByText('platform')).toBeTruthy()
+    expect(screen.getByText('staging')).toBeTruthy()
+    expect(screen.getByText('dev-sandbox')).toBeTruthy()
+    expect(screen.getByText('legacy-sso')).toBeTruthy()
+  })
+
+  it('renders without crashing', () => {
+    vi.mocked(useKeycloakStatus).mockReturnValue({
+      data: KEYCLOAK_DEMO_DATA,
+      loading: false,
+      isRefreshing: false,
+      error: false,
+      consecutiveFailures: 0,
+      showSkeleton: false,
+      showEmptyState: false,
+    })
+    const { container } = render(<KeycloakStatus />)
+    expect(container).toBeTruthy()
+  })
+})

--- a/web/src/components/cards/keycloak_status/__tests__/helpers.test.ts
+++ b/web/src/components/cards/keycloak_status/__tests__/helpers.test.ts
@@ -1,0 +1,146 @@
+import { describe, it, expect } from 'vitest'
+import { isKeycloakOperatorPod, isPodReady, parseKeycloakInstance } from '../useKeycloakStatus'
+
+// ---------------------------------------------------------------------------
+// isKeycloakOperatorPod
+// ---------------------------------------------------------------------------
+
+describe('isKeycloakOperatorPod', () => {
+  it('matches pod with app=keycloak-operator label', () => {
+    expect(isKeycloakOperatorPod({ labels: { app: 'keycloak-operator' } })).toBe(true)
+  })
+
+  it('matches pod with app.kubernetes.io/name=keycloak-operator label', () => {
+    expect(isKeycloakOperatorPod({
+      labels: { 'app.kubernetes.io/name': 'keycloak-operator' },
+    })).toBe(true)
+  })
+
+  it('matches pod with app.kubernetes.io/part-of=keycloak-operator label', () => {
+    expect(isKeycloakOperatorPod({
+      labels: { 'app.kubernetes.io/part-of': 'keycloak-operator' },
+    })).toBe(true)
+  })
+
+  it('matches pod whose name starts with keycloak-operator', () => {
+    expect(isKeycloakOperatorPod({ name: 'keycloak-operator-abc123-xyz' })).toBe(true)
+  })
+
+  it('does NOT match a plain keycloak app pod (too broad)', () => {
+    expect(isKeycloakOperatorPod({
+      name: 'keycloak-0',
+      labels: { app: 'keycloak', 'app.kubernetes.io/name': 'keycloak' },
+    })).toBe(false)
+  })
+
+  it('does NOT match unrelated keycloak-adjacent workloads', () => {
+    expect(isKeycloakOperatorPod({ name: 'keycloak-ui-deployment-abc' })).toBe(false)
+    expect(isKeycloakOperatorPod({ name: 'keycloak-proxy-xyz' })).toBe(false)
+  })
+
+  it('does NOT match a pod with no labels and unrelated name', () => {
+    expect(isKeycloakOperatorPod({ name: 'nginx-abc123', labels: {} })).toBe(false)
+  })
+
+  it('handles missing name and labels gracefully', () => {
+    expect(isKeycloakOperatorPod({})).toBe(false)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// isPodReady
+// ---------------------------------------------------------------------------
+
+describe('isPodReady', () => {
+  it('returns true for Running pod with all containers ready', () => {
+    expect(isPodReady({ status: 'Running', ready: '1/1' })).toBe(true)
+    expect(isPodReady({ status: 'Running', ready: '2/2' })).toBe(true)
+  })
+
+  it('returns false for Running pod with partial readiness', () => {
+    expect(isPodReady({ status: 'Running', ready: '0/1' })).toBe(false)
+    expect(isPodReady({ status: 'Running', ready: '1/2' })).toBe(false)
+  })
+
+  it('returns false for non-Running pod even if ready string looks good', () => {
+    expect(isPodReady({ status: 'Pending', ready: '1/1' })).toBe(false)
+    expect(isPodReady({ status: 'CrashLoopBackOff', ready: '1/1' })).toBe(false)
+  })
+
+  it('returns false for malformed ready string', () => {
+    expect(isPodReady({ status: 'Running', ready: 'bad' })).toBe(false)
+    expect(isPodReady({ status: 'Running', ready: '' })).toBe(false)
+  })
+
+  it('returns false when ready count is 0', () => {
+    expect(isPodReady({ status: 'Running', ready: '0/0' })).toBe(false)
+  })
+
+  it('handles missing fields gracefully', () => {
+    expect(isPodReady({})).toBe(false)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// parseKeycloakInstance
+// ---------------------------------------------------------------------------
+
+const BASE_ITEM = {
+  name: 'keycloak-sample',
+  namespace: 'keycloak',
+  cluster: 'local',
+}
+
+describe('parseKeycloakInstance', () => {
+  it('returns ready when Ready condition is True', () => {
+    const result = parseKeycloakInstance({
+      ...BASE_ITEM,
+      status: { conditions: [{ type: 'Ready', status: 'True' }] },
+    })
+    expect(result.status).toBe('ready')
+    expect(result.name).toBe('keycloak-sample')
+    expect(result.namespace).toBe('keycloak')
+  })
+
+  it('returns error when Ready condition is False', () => {
+    const result = parseKeycloakInstance({
+      ...BASE_ITEM,
+      status: { conditions: [{ type: 'Ready', status: 'False' }] },
+    })
+    expect(result.status).toBe('error')
+  })
+
+  it('returns degraded when HasErrors condition is True', () => {
+    const result = parseKeycloakInstance({
+      ...BASE_ITEM,
+      status: { conditions: [{ type: 'HasErrors', status: 'True' }] },
+    })
+    expect(result.status).toBe('degraded')
+  })
+
+  it('returns provisioning when no conditions exist yet', () => {
+    const result = parseKeycloakInstance({
+      ...BASE_ITEM,
+      status: { conditions: [] },
+    })
+    expect(result.status).toBe('provisioning')
+  })
+
+  it('returns provisioning when status is absent entirely', () => {
+    const result = parseKeycloakInstance({ ...BASE_ITEM })
+    expect(result.status).toBe('provisioning')
+  })
+
+  it('defaults enabled to true and numeric fields to 0', () => {
+    const result = parseKeycloakInstance({ ...BASE_ITEM })
+    expect(result.enabled).toBe(true)
+    expect(result.clients).toBe(0)
+    expect(result.users).toBe(0)
+    expect(result.activeSessions).toBe(0)
+  })
+
+  it('falls back namespace to empty string when absent', () => {
+    const result = parseKeycloakInstance({ name: 'test', cluster: 'local' })
+    expect(result.namespace).toBe('')
+  })
+})

--- a/web/src/components/cards/keycloak_status/demoData.ts
+++ b/web/src/components/cards/keycloak_status/demoData.ts
@@ -1,0 +1,112 @@
+/**
+ * Demo data for the Keycloak Identity & Access Management status card.
+ *
+ * Represents a typical production environment running the Keycloak Operator
+ * on Kubernetes. Used in demo mode or when no cluster is connected.
+ *
+ * Keycloak terminology:
+ * - Realm: an isolated IAM domain (users, clients, sessions)
+ * - Client: an application registered with Keycloak for SSO
+ * - Session: an active authenticated user session within a realm
+ *
+ * The five demo realms cover all four possible status states so every
+ * rendering branch is exercised in demo mode.
+ */
+
+/** Demo data shows as checked 30 seconds ago */
+const DEMO_LAST_CHECK_OFFSET_MS = 30_000
+
+export type KeycloakRealmStatus = 'ready' | 'provisioning' | 'degraded' | 'error'
+
+export interface KeycloakRealm {
+  name: string
+  namespace: string
+  status: KeycloakRealmStatus
+  /** Whether the realm is enabled for login */
+  enabled: boolean
+  /** Number of registered clients in this realm */
+  clients: number
+  /** Total users in this realm */
+  users: number
+  /** Currently active sessions in this realm */
+  activeSessions: number
+}
+
+export interface KeycloakDemoData {
+  health: 'healthy' | 'degraded' | 'not-installed'
+  operatorPods: {
+    ready: number
+    total: number
+  }
+  realms: KeycloakRealm[]
+  totalClients: number
+  totalUsers: number
+  totalActiveSessions: number
+  lastCheckTime: string
+}
+
+export const KEYCLOAK_DEMO_DATA: KeycloakDemoData = {
+  // One operator pod is down → degraded overall health
+  health: 'degraded',
+  operatorPods: { ready: 1, total: 2 },
+  realms: [
+    {
+      // The built-in admin realm — always present in every Keycloak installation
+      name: 'master',
+      namespace: 'keycloak',
+      status: 'ready',
+      enabled: true,
+      clients: 12,
+      users: 48,
+      activeSessions: 21,
+    },
+    {
+      // Primary production SSO realm serving the platform's end users
+      name: 'platform',
+      namespace: 'keycloak',
+      status: 'ready',
+      enabled: true,
+      clients: 24,
+      users: 2840,
+      activeSessions: 312,
+    },
+    {
+      // Staging realm — degraded due to misconfigured identity provider
+      name: 'staging',
+      namespace: 'keycloak-staging',
+      status: 'degraded',
+      enabled: true,
+      clients: 8,
+      users: 142,
+      activeSessions: 0,
+    },
+    {
+      // New dev realm currently being provisioned; login disabled until ready
+      name: 'dev-sandbox',
+      namespace: 'keycloak-dev',
+      status: 'provisioning',
+      enabled: false,
+      clients: 3,
+      users: 12,
+      activeSessions: 0,
+    },
+    {
+      // Legacy SSO realm in error state — database backend unreachable
+      name: 'legacy-sso',
+      namespace: 'keycloak',
+      status: 'error',
+      enabled: true,
+      clients: 5,
+      users: 203,
+      activeSessions: 0,
+    },
+  ],
+  // Totals must equal the sum of individual realm values:
+  // clients: 12 + 24 + 8 + 3 + 5 = 52
+  // users:   48 + 2840 + 142 + 12 + 203 = 3245
+  // sessions: 21 + 312 + 0 + 0 + 0 = 333
+  totalClients: 52,
+  totalUsers: 3245,
+  totalActiveSessions: 333,
+  lastCheckTime: new Date(Date.now() - DEMO_LAST_CHECK_OFFSET_MS).toISOString(),
+}

--- a/web/src/components/cards/keycloak_status/index.tsx
+++ b/web/src/components/cards/keycloak_status/index.tsx
@@ -1,0 +1,1 @@
+export { KeycloakStatus } from './KeycloakStatus'

--- a/web/src/components/cards/keycloak_status/useKeycloakStatus.ts
+++ b/web/src/components/cards/keycloak_status/useKeycloakStatus.ts
@@ -1,0 +1,248 @@
+import { useCache } from '../../../lib/cache'
+import { useCardLoadingState } from '../CardDataContext'
+import { KEYCLOAK_DEMO_DATA, type KeycloakDemoData, type KeycloakRealm } from './demoData'
+import { FETCH_DEFAULT_TIMEOUT_MS } from '../../../lib/constants'
+import { authFetch } from '../../../lib/api'
+
+export type KeycloakStatus = KeycloakDemoData
+
+const INITIAL_DATA: KeycloakStatus = {
+  health: 'not-installed',
+  operatorPods: { ready: 0, total: 0 },
+  realms: [],
+  totalClients: 0,
+  totalUsers: 0,
+  totalActiveSessions: 0,
+  lastCheckTime: new Date().toISOString(),
+}
+
+const CACHE_KEY = 'keycloak-status'
+
+// ---------------------------------------------------------------------------
+// Backend response types
+// ---------------------------------------------------------------------------
+
+interface BackendPodInfo {
+  name?: string
+  namespace?: string
+  status?: string
+  ready?: string
+  labels?: Record<string, string>
+}
+
+interface CRItem {
+  name: string
+  namespace?: string
+  cluster: string
+  status?: Record<string, unknown>
+  spec?: Record<string, unknown>
+  labels?: Record<string, string>
+}
+
+interface CRResponse {
+  items?: CRItem[]
+  isDemoData?: boolean
+}
+
+// ---------------------------------------------------------------------------
+// Pod detection helpers
+// ---------------------------------------------------------------------------
+
+function isKeycloakOperatorPod(pod: BackendPodInfo): boolean {
+  const labels = pod.labels ?? {}
+  const name = (pod.name ?? '').toLowerCase()
+  return (
+    labels['app'] === 'keycloak' ||
+    labels['app.kubernetes.io/name'] === 'keycloak' ||
+    labels['app.kubernetes.io/part-of'] === 'keycloak' ||
+    labels['app.kubernetes.io/component'] === 'keycloak' ||
+    // Name-prefix check kept deliberately narrow: only match the operator pod itself,
+    // not unrelated keycloak-adjacent workloads (keycloak-ui, keycloak-proxy, etc.)
+    name.startsWith('keycloak-operator')
+  )
+}
+
+function isPodReady(pod: BackendPodInfo): boolean {
+  const status = (pod.status ?? '').toLowerCase()
+  const ready = pod.ready ?? ''
+  if (status !== 'running') return false
+  const parts = ready.split('/')
+  if (parts.length !== 2) return false
+  return parts[0] === parts[1] && parseInt(parts[0], 10) > 0
+}
+
+// ---------------------------------------------------------------------------
+// CRD helpers
+// ---------------------------------------------------------------------------
+
+async function fetchCR(group: string, version: string, resource: string): Promise<CRItem[]> {
+  try {
+    const params = new URLSearchParams({ group, version, resource })
+    const resp = await authFetch(`/api/mcp/custom-resources?${params}`, {
+      headers: { Accept: 'application/json' },
+      signal: AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS),
+    })
+    if (!resp.ok) return []
+    const body: CRResponse = await resp.json()
+    return body.items ?? []
+  } catch {
+    return []
+  }
+}
+
+/** Parse a Keycloak CR (keycloak.org/v2alpha1 Keycloak) into a realm-like shape. */
+function parseKeycloakInstance(item: CRItem): KeycloakRealm {
+  const status = (item.status ?? {}) as Record<string, unknown>
+  const conditions = Array.isArray(status.conditions) ? status.conditions : []
+
+  let realmStatus: KeycloakRealm['status'] = 'ready'
+  for (const c of conditions) {
+    const cond = c as Record<string, unknown>
+    if (cond.type === 'Ready' && cond.status === 'False') {
+      realmStatus = 'error'
+      break
+    }
+    if (cond.type === 'HasErrors' && cond.status === 'True') {
+      realmStatus = 'degraded'
+      break
+    }
+  }
+
+  // Provisioning: no Ready condition yet
+  const hasReadyCondition = conditions.some(
+    (c: unknown) => (c as Record<string, unknown>).type === 'Ready',
+  )
+  if (!hasReadyCondition && realmStatus === 'ready') {
+    realmStatus = 'provisioning'
+  }
+
+  return {
+    name: item.name,
+    namespace: item.namespace ?? '',
+    status: realmStatus,
+    enabled: true,
+    clients: 0,
+    users: 0,
+    activeSessions: 0,
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Pod fetcher
+// ---------------------------------------------------------------------------
+
+async function fetchPods(url: string): Promise<BackendPodInfo[]> {
+  const resp = await fetch(url, {
+    headers: { Accept: 'application/json' },
+    signal: AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS),
+  })
+  if (!resp.ok) throw new Error(`HTTP ${resp.status}`)
+  const body: { pods?: BackendPodInfo[] } = await resp.json()
+  return Array.isArray(body?.pods) ? body.pods : []
+}
+
+// ---------------------------------------------------------------------------
+// Main fetcher
+// ---------------------------------------------------------------------------
+
+async function fetchKeycloakStatus(): Promise<KeycloakStatus> {
+  // Step 1: Detect Keycloak pods (label-filtered first, then full fallback)
+  const labeledPods = await fetchPods(
+    '/api/mcp/pods?labelSelector=app.kubernetes.io%2Fname%3Dkeycloak',
+  ).catch(() => [] as BackendPodInfo[])
+
+  const keycloakPods = labeledPods.length > 0
+    ? labeledPods.filter(isKeycloakOperatorPod)
+    : (await fetchPods('/api/mcp/pods').catch(() => [] as BackendPodInfo[])).filter(isKeycloakOperatorPod)
+
+  if (keycloakPods.length === 0) {
+    return {
+      ...INITIAL_DATA,
+      health: 'not-installed',
+      lastCheckTime: new Date().toISOString(),
+    }
+  }
+
+  const readyPods = keycloakPods.filter(isPodReady).length
+  const allReady = readyPods === keycloakPods.length
+
+  // Step 2: Fetch Keycloak CRs (best-effort)
+  const keycloakInstances = await fetchCR('keycloak.org', 'v2alpha1', 'keycloaks')
+
+  const realms = keycloakInstances.map(parseKeycloakInstance)
+
+  const totalClients = realms.reduce((sum, r) => sum + r.clients, 0)
+  const totalUsers = realms.reduce((sum, r) => sum + r.users, 0)
+  const totalActiveSessions = realms.reduce((sum, r) => sum + r.activeSessions, 0)
+
+  return {
+    health: allReady ? 'healthy' : 'degraded',
+    operatorPods: { ready: readyPods, total: keycloakPods.length },
+    realms,
+    totalClients,
+    totalUsers,
+    totalActiveSessions,
+    lastCheckTime: new Date().toISOString(),
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Hook
+// ---------------------------------------------------------------------------
+
+export interface UseKeycloakStatusResult {
+  data: KeycloakStatus
+  loading: boolean
+  isRefreshing: boolean
+  error: boolean
+  consecutiveFailures: number
+  showSkeleton: boolean
+  showEmptyState: boolean
+}
+
+export function useKeycloakStatus(): UseKeycloakStatusResult {
+  const {
+    data,
+    isLoading,
+    isRefreshing,
+    isFailed,
+    consecutiveFailures,
+    isDemoFallback,
+  } = useCache<KeycloakStatus>({
+    key: CACHE_KEY,
+    category: 'default',
+    initialData: INITIAL_DATA,
+    demoData: KEYCLOAK_DEMO_DATA,
+    persist: true,
+    fetcher: fetchKeycloakStatus,
+  })
+
+  const effectiveIsDemoData = isDemoFallback && !isLoading
+
+  // 'not-installed' is a valid, renderable state — the card shows its own
+  // "Keycloak not detected" UI. Treat it as hasAnyData so CardWrapper never
+  // shows a generic empty state in place of the card's own message.
+  const hasAnyData =
+    data.health === 'not-installed' ||
+    (data.operatorPods?.total ?? 0) > 0 ||
+    (data.realms || []).length > 0
+
+  const { showSkeleton, showEmptyState } = useCardLoadingState({
+    isLoading: isLoading && !hasAnyData,
+    isRefreshing,
+    hasAnyData,
+    isFailed,
+    consecutiveFailures,
+    isDemoData: effectiveIsDemoData,
+  })
+
+  return {
+    data,
+    loading: isLoading,
+    isRefreshing,
+    error: isFailed && !hasAnyData,
+    consecutiveFailures,
+    showSkeleton,
+    showEmptyState,
+  }
+}

--- a/web/src/components/cards/keycloak_status/useKeycloakStatus.ts
+++ b/web/src/components/cards/keycloak_status/useKeycloakStatus.ts
@@ -48,21 +48,22 @@ interface CRResponse {
 // Pod detection helpers
 // ---------------------------------------------------------------------------
 
-function isKeycloakOperatorPod(pod: BackendPodInfo): boolean {
+// Exported for unit testing.
+export function isKeycloakOperatorPod(pod: BackendPodInfo): boolean {
   const labels = pod.labels ?? {}
   const name = (pod.name ?? '').toLowerCase()
+  // Match only the Keycloak Operator itself, not generic Keycloak workloads
+  // (keycloak-ui, keycloak-proxy, etc.) which share the broad `app=keycloak` label.
   return (
-    labels['app'] === 'keycloak' ||
-    labels['app.kubernetes.io/name'] === 'keycloak' ||
-    labels['app.kubernetes.io/part-of'] === 'keycloak' ||
-    labels['app.kubernetes.io/component'] === 'keycloak' ||
-    // Name-prefix check kept deliberately narrow: only match the operator pod itself,
-    // not unrelated keycloak-adjacent workloads (keycloak-ui, keycloak-proxy, etc.)
+    labels['app'] === 'keycloak-operator' ||
+    labels['app.kubernetes.io/name'] === 'keycloak-operator' ||
+    labels['app.kubernetes.io/part-of'] === 'keycloak-operator' ||
     name.startsWith('keycloak-operator')
   )
 }
 
-function isPodReady(pod: BackendPodInfo): boolean {
+// Exported for unit testing.
+export function isPodReady(pod: BackendPodInfo): boolean {
   const status = (pod.status ?? '').toLowerCase()
   const ready = pod.ready ?? ''
   if (status !== 'running') return false
@@ -90,8 +91,8 @@ async function fetchCR(group: string, version: string, resource: string): Promis
   }
 }
 
-/** Parse a Keycloak CR (keycloak.org/v2alpha1 Keycloak) into a realm-like shape. */
-function parseKeycloakInstance(item: CRItem): KeycloakRealm {
+/** Parse a Keycloak CR (keycloak.org/v2alpha1 Keycloak) into a realm-like shape. Exported for unit testing. */
+export function parseKeycloakInstance(item: CRItem): KeycloakRealm {
   const status = (item.status ?? {}) as Record<string, unknown>
   const conditions = Array.isArray(status.conditions) ? status.conditions : []
 
@@ -146,14 +147,20 @@ async function fetchPods(url: string): Promise<BackendPodInfo[]> {
 // ---------------------------------------------------------------------------
 
 async function fetchKeycloakStatus(): Promise<KeycloakStatus> {
-  // Step 1: Detect Keycloak pods (label-filtered first, then full fallback)
+  // Step 1: Detect Keycloak Operator pods.
+  // First try a targeted label-selector query (fast, low noise). Errors here are
+  // swallowed — an auth/network failure on the narrow query falls through to the
+  // full-list fallback below, which propagates if it also fails so useCache can
+  // surface a proper error state instead of silently showing "not installed".
   const labeledPods = await fetchPods(
-    '/api/mcp/pods?labelSelector=app.kubernetes.io%2Fname%3Dkeycloak',
+    '/api/mcp/pods?labelSelector=app.kubernetes.io%2Fname%3Dkeycloak-operator',
   ).catch(() => [] as BackendPodInfo[])
 
   const keycloakPods = labeledPods.length > 0
     ? labeledPods.filter(isKeycloakOperatorPod)
-    : (await fetchPods('/api/mcp/pods').catch(() => [] as BackendPodInfo[])).filter(isKeycloakOperatorPod)
+    // Fallback: scan all pods — error propagates intentionally so the hook
+    // transitions to isFailed rather than misreporting "not-installed".
+    : (await fetchPods('/api/mcp/pods')).filter(isKeycloakOperatorPod)
 
   if (keycloakPods.length === 0) {
     return {

--- a/web/src/components/dashboard/shared/cardCatalog.ts
+++ b/web/src/components/dashboard/shared/cardCatalog.ts
@@ -244,6 +244,7 @@ export const CARD_CATALOG = {
     { type: 'vault_secrets', title: 'HashiCorp Vault', description: 'Secrets management, dynamic credentials, and encryption-as-a-service', visualization: 'status' },
     { type: 'external_secrets', title: 'External Secrets', description: 'Sync secrets from external providers (AWS, Azure, GCP, Vault)', visualization: 'status' },
     { type: 'cert_manager', title: 'Cert-Manager', description: 'TLS certificate lifecycle management with automatic renewal', visualization: 'status' },
+    { type: 'keycloak_status', title: 'Keycloak', description: 'Keycloak realm health, active user sessions, and registered clients', visualization: 'status' },
     { type: 'namespace_rbac', title: 'Access Controls', description: 'RBAC policies and permission auditing per namespace', visualization: 'table' },
   ],
   'Workload Detection': [
@@ -516,10 +517,17 @@ export function generateCardSuggestions(query: string): CardSuggestion[] {
     ]
   }
 
+  if (lowerQuery.includes('keycloak') || lowerQuery.includes('sso') || lowerQuery.includes('realm') || lowerQuery.includes('identity') || lowerQuery.includes('iam') || lowerQuery.includes('oauth') || lowerQuery.includes('oidc') || lowerQuery.includes('authentication')) {
+    return [
+      { type: 'keycloak_status', title: 'Keycloak', description: 'Keycloak realm health, active user sessions, and registered clients', visualization: 'status', config: {} },
+    ]
+  }
+
   if (lowerQuery.includes('user') || lowerQuery.includes('service account') || lowerQuery.includes('access') || lowerQuery.includes('permission')) {
     return [
       { type: 'user_management', title: 'User Management', description: 'Console users and Kubernetes RBAC', visualization: 'table', config: {} },
       { type: 'namespace_rbac', title: 'Namespace RBAC', description: 'Roles, bindings, service accounts', visualization: 'table', config: {} },
+      { type: 'keycloak_status', title: 'Keycloak', description: 'SSO realm health, user sessions, and registered clients', visualization: 'status', config: {} },
     ]
   }
 

--- a/web/src/config/cards/index.ts
+++ b/web/src/config/cards/index.ts
@@ -91,6 +91,7 @@ import { kubedleConfig } from './kubedle'
 import { kubescapeScanConfig } from './kubescape-scan'
 import { kubevirtStatusConfig } from './kubevirt-status'
 import { kustomizationStatusConfig } from './kustomization-status'
+import { keycloakStatusConfig } from './keycloak-status'
 import { kyvernoPoliciesConfig } from './kyverno-policies'
 import { limitRangeStatusConfig } from './limit-range-status'
 import { llmInferenceConfig } from './llm-inference'
@@ -257,6 +258,7 @@ export const CARD_CONFIGS: CardConfigRegistry = {
   kubescape_scan: kubescapeScanConfig,
   kubevirt_status: kubevirtStatusConfig,
   kustomization_status: kustomizationStatusConfig,
+  keycloak_status: keycloakStatusConfig,
   kyverno_policies: kyvernoPoliciesConfig,
   limit_range_status: limitRangeStatusConfig,
   llm_inference: llmInferenceConfig,

--- a/web/src/config/cards/keycloak-status.ts
+++ b/web/src/config/cards/keycloak-status.ts
@@ -1,0 +1,34 @@
+/**
+ * Keycloak Identity & Access Management Card Configuration
+ */
+import type { UnifiedCardConfig } from '../../lib/unified/types'
+
+export const keycloakStatusConfig: UnifiedCardConfig = {
+  type: 'keycloak_status',
+  title: 'Keycloak',
+  category: 'security',
+  description: 'Keycloak realm status, user sessions, and authentication flows.',
+  icon: 'Shield',
+  iconColor: 'text-orange-400',
+  defaultWidth: 6,
+  defaultHeight: 4,
+  dataSource: { type: 'hook', hook: 'useKeycloakStatus' },
+  filters: [
+    { field: 'search', type: 'text', placeholder: 'Search realms...', searchFields: ['name', 'namespace'], storageKey: 'keycloak-status' },
+  ],
+  content: {
+    type: 'list',
+    pageSize: 10,
+    columns: [
+      { field: 'name', header: 'Realm', primary: true, render: 'truncate' },
+      { field: 'namespace', header: 'Namespace', render: 'text', width: 120 },
+      { field: 'activeSessions', header: 'Sessions', render: 'number', width: 80 },
+      { field: 'status', header: 'Status', render: 'status-badge', width: 100 },
+    ],
+  },
+  emptyState: { icon: 'Shield', title: 'No Realms', message: 'No Keycloak realms found', variant: 'info' },
+  loadingState: { type: 'list', rows: 4 },
+  isDemoData: false,
+  isLive: true,
+}
+export default keycloakStatusConfig

--- a/web/src/lib/cards/cardInstallMap.ts
+++ b/web/src/lib/cards/cardInstallMap.ts
@@ -103,6 +103,8 @@ export const CARD_INSTALL_MAP: Record<string, CardInstallInfo> = {
 
   // OpenKruise
   openkruise_status: { project: 'OpenKruise', missionKey: 'install-openkruise', kbPaths: ['fixes/cncf-install/install-openkruise.json'] },
+  // Keycloak
+  keycloak_status: { project: 'Keycloak', missionKey: 'install-keycloak', kbPaths: ['fixes/cncf-install/install-keycloak.json'] },
 }
 
 /**

--- a/web/src/locales/en/cards.json
+++ b/web/src/locales/en/cards.json
@@ -3540,6 +3540,8 @@
     "syncedJustNow": "just now",
     "syncedMinutesAgo": "{{count}}m ago",
     "syncedHoursAgo": "{{count}}h ago",
-    "syncedDaysAgo": "{{count}}d ago"
+    "syncedDaysAgo": "{{count}}d ago",
+    "provisioning": "Provisioning",
+    "error": "Error"
   }
 }

--- a/web/src/locales/en/cards.json
+++ b/web/src/locales/en/cards.json
@@ -281,7 +281,8 @@
     "keda_status": "KEDA",
     "strimzi_status": "Strimzi",
     "kubevela_status": "KubeVela",
-    "cloudevents_status": "CloudEvents"
+    "cloudevents_status": "CloudEvents",
+    "keycloak_status": "Keycloak"
   },
   "descriptions": {
     "cluster_health": "Overall health status of all connected Kubernetes clusters.",
@@ -455,7 +456,8 @@
     "keda_status": "KEDA autoscaler status, scaled object metrics, and trigger queue depths.",
     "strimzi_status": "Strimzi Kafka cluster health, topic status, and consumer group lag.",
     "kubevela_status": "KubeVela application delivery, component status, and workflow progress.",
-    "cloudevents_status": "CloudEvents message flow, event source tracking, and delivery status."
+    "cloudevents_status": "CloudEvents message flow, event source tracking, and delivery status.",
+    "keycloak_status": "Keycloak realm health, active user sessions, and registered clients."
   },
   "categories": {
     "core": "Core",
@@ -3516,5 +3518,28 @@
         }
       }
     }
+  },
+  "keycloak": {
+    "healthy": "Healthy",
+    "degraded": "Degraded",
+    "notInstalled": "Keycloak not detected",
+    "notInstalledHint": "No Keycloak operator pods found. Deploy the Keycloak Operator to manage realms and SSO.",
+    "fetchError": "Failed to fetch Keycloak status",
+    "pods": "pods",
+    "realms": "Realms",
+    "ready": "Ready",
+    "sessions": "Sessions",
+    "issues": "Issues",
+    "users": "users",
+    "clients": "clients",
+    "disabled": "disabled",
+    "noRealms": "Operator running",
+    "noRealmsHint": "Realm data requires the Keycloak CRD API.",
+    "noSearchResults": "No realms match your search.",
+    "searchPlaceholder": "Search realms…",
+    "syncedJustNow": "just now",
+    "syncedMinutesAgo": "{{count}}m ago",
+    "syncedHoursAgo": "{{count}}h ago",
+    "syncedDaysAgo": "{{count}}d ago"
   }
 }


### PR DESCRIPTION
**New CNCF card?** This card was requested via [kubestellar/console-marketplace#40](https://github.com/kubestellar/console-marketplace/issues/40) and the companion marketplace PR is : https://github.com/kubestellar/console-marketplace/pull/110
                                                                                                                                                   
  ### 📌 Fixes                                                                                                                                     
                                                                                                                                                   
  Resolves [console-marketplace#40](https://github.com/kubestellar/console-marketplace/issues/40) - Implement Keycloak monitoring card             
  
  ---                                                                                                                                              
                  
  ### Summary of Changes

  - Implements a Keycloak Identity & Access Management status card for the KubeStellar dashboard                                                   
  - Detects the Keycloak Operator via Kubernetes label selectors (`app.kubernetes.io/name=keycloak`) with a CRD query fallback (`keycloak.org/v2alpha1`)                                                                                                                        
  - Displays operator pod health, per-realm status, active user sessions, and registered client counts
  - Gracefully handles three states: not installed, operator running without realms, and full realm data                                           
  - Falls back to realistic demo data (5 realms covering all 4 status variants) when no cluster is connected                                       
                                                                                                                                                   
  ---                                                                                                                                              
                                                                                                                                                   
  ### Changes Made

  - [x] Added `web/src/components/cards/keycloak_status/KeycloakStatus.tsx` — card component with health badge, stats grid (Realms / Ready /       
  Sessions / Issues), realm list with search, and footer totals
  - [x] Added `web/src/components/cards/keycloak_status/useKeycloakStatus.ts` — data hook using `useCache` with correct `isDemoData`/`isRefreshing`
   wiring and `hasAnyData` handling for not-installed state                                                                                        
  - [x] Added `web/src/components/cards/keycloak_status/demoData.ts` — 5 demo realms covering all status states (ready, degraded, provisioning,
  error)                                                                                                                                           
  - [x] Added `web/src/components/cards/keycloak_status/index.tsx` — barrel export
  - [x] Added `web/src/config/cards/keycloak-status.ts` — unified card config                                                                      
  - [x] Updated `cardRegistry.ts`, `cardMetadata.ts`, `config/cards/index.ts` — card registration
  - [x] Updated `web/src/components/dashboard/shared/cardCatalog.ts` — added to Add Cards modal under Data Compliance, with AI search hints for    
  keycloak/sso/realm/identity/iam/oauth/oidc                                                                                                       
  - [x] Updated `web/src/locales/en/cards.json` — all user-facing strings via `t()` (no hardcoded English)                                         
  - [x] Added `web/src/components/cards/keycloak_status/__tests__/KeycloakStatus.test.tsx` — 5 tests covering skeleton, not-installed, error, full 
  data, and smoke states                                                                                                                           
                                                                                                                                                   
  ---                                                                                                                                              
                  
  ### Checklist

  - [x] I used a coding agent (Claude Code) to generate/review this code                                                
  - [x] I have reviewed the project's contribution guidelines
  - [x] New cards target [console-marketplace](https://github.com/kubestellar/console-marketplace), not this repo                                  
  - [x] isDemoData is wired correctly (cards show Demo badge when using demo data)
  - [x] I have written unit tests for the changes (if applicable)                                                                                  
  - [x] I have tested the changes locally and ensured they work as expected
  - [x] All commits are signed with DCO (`git commit -s`)                                                                                          
                                                                                                                                
                                                                                                                                                   
  ---             

  ### 👀 Reviewer Notes                                                                                                                            
   
  - Pod detection uses label selectors first (`/api/mcp/pods?labelSelector=app.kubernetes.io%2Fname%3Dkeycloak`), falling back to a full pod scan filtered by standard Keycloak Operator labels only — no broad name substring matching
  - CRD query (`keycloak.org/v2alpha1 keycloaks`) is best-effort; if the CRD API is absent the card still shows operator pod health                
  - `hasAnyData` is `true` when `health === 'not-installed'` so CardWrapper never shows a generic empty state — the card renders its own "Keycloak not detected" message instead                                                                                                                    
  - Demo data covers all 4 realm status states so every rendering branch is exercised without a live cluster 