### PR TITLE
fix(storage): surface PV API errors instead of silent empty state (#6806)

### DIFF
--- a/web/src/components/cards/StorageOverview.tsx
+++ b/web/src/components/cards/StorageOverview.tsx
@@ -13,7 +13,7 @@ import { useDemoMode } from '../../hooks/useDemoMode'
 export function StorageOverview() {
   const { t } = useTranslation(['cards', 'common'])
   const { deduplicatedClusters: clusters, isLoading, isRefreshing: clustersRefreshing } = useClusters()
-  const { pvcs, isLoading: pvcsLoading, isRefreshing: pvcsRefreshing, consecutiveFailures, isFailed, isDemoFallback } = useCachedPVCs()
+  const { pvcs, isLoading: pvcsLoading, isRefreshing: pvcsRefreshing, consecutiveFailures, isFailed, isDemoFallback, error: pvcsError } = useCachedPVCs()
 
   const { selectedClusters, isAllClustersSelected } = useGlobalFilters()
   const { isDemoMode } = useDemoMode()
@@ -138,6 +138,14 @@ export function StorageOverview() {
 
         </div>
       </div>
+
+      {/* Error banner */}
+      {pvcsError && (
+        <div className="mb-3 p-2 rounded-lg bg-red-500/10 border border-red-500/30 text-xs text-red-400 flex items-center gap-2">
+          <AlertTriangle className="w-3.5 h-3.5 flex-shrink-0" />
+          <span>{t('storageOverview.fetchError', { defaultValue: 'Failed to load PVC data: {{error}}', error: pvcsError })}</span>
+        </div>
+      )}
 
       {/* Main stats */}
       <div className="grid grid-cols-2 gap-3 mb-4">

--- a/web/src/hooks/mcp/storage.ts
+++ b/web/src/hooks/mcp/storage.ts
@@ -280,15 +280,13 @@ export function usePVCs(cluster?: string, namespace?: string) {
       setLastUpdated(now)
       setConsecutiveFailures(0)
       setLastRefresh(now)
-    } catch {
+    } catch (err: unknown) {
       if (!isMountedRef.current) return
-      // Keep stale data on error
+      const message = err instanceof Error ? err.message : 'Failed to fetch PVCs'
       setConsecutiveFailures(prev => prev + 1)
       setLastRefresh(new Date())
       if (!silent && !pvcsCache) {
-        // Don't show error - PVCs are optional, some clusters may have none
-        setError(null)
-        setPVCs([])
+        setError(message)
       }
     } finally {
       if (isMountedRef.current) {
@@ -384,12 +382,11 @@ export function usePVs(cluster?: string) {
       setPVs(data.pvs || [])
       setError(null)
       setConsecutiveFailures(0)
-    } catch {
+    } catch (err: unknown) {
       if (isMountedRef.current) {
-        // Don't show error - PVs are optional
-        setError(null)
+        const message = err instanceof Error ? err.message : 'Failed to fetch PVs'
+        setError(message)
         setConsecutiveFailures(prev => prev + 1)
-        setPVs([])
       }
     } finally {
       if (isMountedRef.current) {


### PR DESCRIPTION
Closes #6806

## Summary
- **usePVs hook**: Error catch block was calling `setError(null)` with comment "PVs are optional" — now propagates the actual error message
- **usePVCs hook**: API fallback catch block was calling `setError(null)` and resetting to empty array — now propagates the error message instead of hiding it
- **StorageOverview card**: Added inline red error banner that displays when PVC fetch fails, using `AlertTriangle` icon and the error message

## Test plan
- [ ] Break PV API endpoint and verify error banner appears in StorageOverview card
- [ ] Verify PVCStatus card shows "Failed to load PVCs" text when API fails
- [ ] Verify normal operation still works (no false errors when API is healthy)
- [ ] Verify `consecutiveFailures` / `isFailed` still triggers card-level error state after 3 failures