### PR TITLE
fix: null guards on messages, agents, fork, assignments, PVC classification (#6792-#6805)

### DIFF
--- a/pkg/api/handlers/missions.go
+++ b/pkg/api/handlers/missions.go
@@ -941,8 +941,8 @@ func (h *MissionsHandler) ShareToGitHub(c *fiber.Ctx) error {
 		return c.Status(502).JSON(fiber.Map{"error": "failed to decode fork response"})
 	}
 	forkFullName, _ := forkData["full_name"].(string)
-	if forkFullName == "" {
-		return c.Status(502).JSON(fiber.Map{"error": "fork response missing full_name"})
+	if forkFullName == "" || !strings.Contains(forkFullName, "/") {
+		return c.Status(502).JSON(fiber.Map{"error": "fork response missing or malformed full_name"})
 	}
 
 	// Detect the target repo's default branch (e.g. "main", "master", or custom).
@@ -955,6 +955,30 @@ func (h *MissionsHandler) ShareToGitHub(c *fiber.Ctx) error {
 		}
 	} else if db, ok := forkData["default_branch"].(string); ok && db != "" {
 		defaultBranch = db
+	}
+
+	// #6795 — If neither parent nor fork carried default_branch, query the
+	// upstream repo directly so we don't assume "main" for repos that use
+	// "master", "trunk", etc.
+	if defaultBranch == "main" {
+		upstreamURL := fmt.Sprintf("%s/repos/%s", h.githubAPIURL, req.Repo)
+		upstreamReq, err := http.NewRequest("GET", upstreamURL, nil)
+		if err == nil {
+			upstreamReq.Header.Set("Authorization", "Bearer "+token)
+			upstreamReq.Header.Set("Accept", "application/vnd.github.v3+json")
+			upstreamResp, err := h.httpClient.Do(upstreamReq)
+			if err == nil {
+				defer upstreamResp.Body.Close()
+				if upstreamResp.StatusCode == http.StatusOK {
+					var repoData map[string]interface{}
+					if json.NewDecoder(upstreamResp.Body).Decode(&repoData) == nil {
+						if db, ok := repoData["default_branch"].(string); ok && db != "" {
+							defaultBranch = db
+						}
+					}
+				}
+			}
+		}
 	}
 
 	// Step 2: Get HEAD SHA from fork's default branch, then create new branch ref.

--- a/web/src/components/cards/PVCStatus.tsx
+++ b/web/src/components/cards/PVCStatus.tsx
@@ -155,7 +155,7 @@ function PVCStatusInternal() {
       total: result.length,
       bound: result.filter(p => p.status === 'Bound').length,
       pending: result.filter(p => p.status === 'Pending').length,
-      failed: result.filter(p => !['Bound', 'Pending'].includes(p.status)).length,
+      failed: result.filter(p => p.status === 'Lost').length,
     }
   }, [pvcs, localClusterFilter, search])
 

--- a/web/src/components/mission-control/MissionControlDialog.tsx
+++ b/web/src/components/mission-control/MissionControlDialog.tsx
@@ -163,7 +163,7 @@ export function MissionControlDialog({ open, onClose }: MissionControlDialogProp
   const canAdvance =
     (state.phase === 'define' && state.projects.length > 0 && !state.aiStreaming) ||
     (state.phase === 'assign' && (
-      state.assignments.some((a) => a.projectNames.length > 0) ||
+      state.assignments.some((a) => (a.projectNames ?? []).length > 0) ||
       state.targetClusters.length > 0
     )) ||
     state.phase === 'blueprint'

--- a/web/src/components/mission-control/useMissionControl.ts
+++ b/web/src/components/mission-control/useMissionControl.ts
@@ -626,7 +626,7 @@ export function useMissionControl() {
   // when streaming appends to it (messages.length stays the same during streaming)
   const latestAssistantContent = useMemo(() => {
     if (!planningMission) return ''
-    const msgs = planningMission.messages.filter((m) => m.role === 'assistant')
+    const msgs = (planningMission.messages ?? []).filter((m) => m.role === 'assistant')
     return msgs[msgs.length - 1]?.content ?? ''
   }, [planningMission?.messages])
 
@@ -651,7 +651,7 @@ export function useMissionControl() {
     // pauses for STREAM_JSON_DEBOUNCE_MS, so we effectively skip parsing
     // mid-burst. The old comment referenced a non-existent length check.
     if (!debouncedAssistantContent) return
-    const assistantMsgs = planningMission.messages.filter((m) => m.role === 'assistant')
+    const assistantMsgs = (planningMission.messages ?? []).filter((m) => m.role === 'assistant')
     const latest = assistantMsgs[assistantMsgs.length - 1]
     if (!latest) return
 

--- a/web/src/hooks/useMissions.tsx
+++ b/web/src/hooks/useMissions.tsx
@@ -299,7 +299,7 @@ function loadMissions(): Mission[] {
           ...m,
           createdAt: new Date(m.createdAt),
           updatedAt: new Date(m.updatedAt),
-          messages: m.messages.map(msg => ({
+          messages: (m.messages ?? []).map(msg => ({
             ...msg,
             timestamp: new Date(msg.timestamp)
           }))
@@ -434,7 +434,9 @@ function loadUnreadMissionIds(): Set<string> {
   try {
     const stored = localStorage.getItem(UNREAD_MISSIONS_KEY)
     if (stored) {
-      return new Set(JSON.parse(stored))
+      const parsed = JSON.parse(stored)
+      if (!Array.isArray(parsed)) return new Set()
+      return new Set(parsed)
     }
   } catch (e) {
     console.error('Failed to load unread missions from localStorage:', e)
@@ -1368,7 +1370,7 @@ The WebSocket connection to the agent at \`${LOCAL_AGENT_WS_URL}\` was lost and 
       const payload = message.payload as AgentsListPayload
       // Sanitize agent metadata — strip interactive prompt artifacts that leak
       // from terminal-based agents (e.g. copilot-cli) into description fields (#5482).
-      const sanitizedAgents = payload.agents.map(agent => ({
+      const sanitizedAgents = (payload.agents ?? []).map(agent => ({
         ...agent,
         description: stripInteractiveArtifacts(agent.description),
         displayName: stripInteractiveArtifacts(agent.displayName),
@@ -1379,17 +1381,18 @@ The WebSocket connection to the agent at \`${LOCAL_AGENT_WS_URL}\` was lost and 
       // If persisted is 'none' but an agent IS available, auto-select it
       // so AI mode is on by default when the agent is present.
       const persisted = localStorage.getItem(SELECTED_AGENT_KEY)
-      const hasAvailableAgent = payload.agents.some(a => a.available)
-      const persistedAvailable = persisted && persisted !== 'none' && payload.agents.some(a => a.name === persisted && a.available)
+      const agents = payload.agents ?? []
+      const hasAvailableAgent = agents.some(a => a.available)
+      const persistedAvailable = persisted && persisted !== 'none' && agents.some(a => a.name === persisted && a.available)
 
       // When auto-selecting, prefer agents that execute commands directly over
       // agents that only suggest commands (e.g. copilot-cli). Interactive/suggest-only
       // agents produce terminal prompts instead of executing missions (#3609, #5481).
       const INTERACTIVE_AGENTS = new Set(['copilot-cli', 'gh-copilot'])
       const bestAvailable = hasAvailableAgent
-        ? (payload.agents.find(a => a.available && ((a.capabilities ?? 0) & AgentCapabilityToolExec) !== 0 && !INTERACTIVE_AGENTS.has(a.name))?.name
-          || payload.agents.find(a => a.available && !INTERACTIVE_AGENTS.has(a.name))?.name
-          || payload.agents.find(a => a.available)?.name
+        ? (agents.find(a => a.available && ((a.capabilities ?? 0) & AgentCapabilityToolExec) !== 0 && !INTERACTIVE_AGENTS.has(a.name))?.name
+          || agents.find(a => a.available && !INTERACTIVE_AGENTS.has(a.name))?.name
+          || agents.find(a => a.available)?.name
           || null)
         : null
       // Filter the backend's defaultAgent if it is interactive — fall through to


### PR DESCRIPTION
Closes #6792
Closes #6793
Closes #6795
Closes #6796
Closes #6797
Closes #6799
Closes #6802
Closes #6803
Closes #6805

## Summary

Adds missing null/type guards across TypeScript and Go to prevent runtime crashes from corrupted localStorage, malformed WebSocket payloads, and unexpected GitHub API responses. Also fixes PVC failure classification.

### TypeScript (useMissions.tsx, useMissionControl.ts, MissionControlDialog.tsx)
- **#6792/#6799**: `(m.messages ?? []).map()` in `loadMissions` — prevents TypeError when localStorage has a mission with missing messages array
- **#6793**: `(payload.agents ?? []).map()` — guards against malformed `agents_list` WebSocket message crashing MissionProvider
- **#6796**: `(a.projectNames ?? []).length` in `canAdvance` — handles legacy persisted state without projectNames
- **#6797**: `(planningMission.messages ?? []).filter()` in both memo and effect — handles corrupted messages after reload
- **#6802**: `Array.isArray()` check before `new Set()` in `loadUnreadMissionIds` — prevents TypeError on non-iterable parse result

### Go (missions.go)
- **#6795**: When fork response lacks default_branch in both parent and top-level fields, queries upstream repo directly instead of assuming "main"
- **#6805**: Validates `forkFullName` contains "/" before splitting, returning 502 early on malformed response

### PVC Classification (PVCStatus.tsx)
- **#6803**: Failed count now only includes `Lost` status (actual K8s failure phase) instead of all non-Bound/non-Pending states

## Test plan
- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] `npm run build` passes
- [ ] CI build/lint