### PR TITLE
fix(missions): waiting_input recovery, cancel guard, runbook context, timeout restore (#6912-#6916)

### DIFF
--- a/web/src/contexts/AlertsContext.tsx
+++ b/web/src/contexts/AlertsContext.tsx
@@ -352,7 +352,7 @@ interface AlertsContextValue {
   acknowledgeAlerts: (alertIds: string[], acknowledgedBy?: string) => void
   resolveAlert: (alertId: string) => void
   deleteAlert: (alertId: string) => void
-  runAIDiagnosis: (alertId: string) => string | null
+  runAIDiagnosis: (alertId: string) => Promise<string | null> | string | null
   evaluateConditions: () => void
   createRule: (rule: Omit<AlertRule, 'id' | 'createdAt' | 'updatedAt'>) => AlertRule
   updateRule: (id: string, updates: Partial<AlertRule>) => void
@@ -963,8 +963,8 @@ export function AlertsProvider({ children }: { children: ReactNode }) {
     }
   }
 
-  // Run AI diagnosis on an alert
-  const runAIDiagnosis = (alertId: string) => {
+  // Run AI diagnosis on an alert (#6915 — include runbook evidence in prompt)
+  const runAIDiagnosis = async (alertId: string) => {
       const alert = alerts.find(a => a.id === alertId)
       if (!alert) return null
 
@@ -973,39 +973,42 @@ export function AlertsProvider({ children }: { children: ReactNode }) {
       const conditionType = rule?.condition.type
       const runbook = conditionType ? findRunbookForCondition(conditionType) : undefined
 
-      // If a runbook matches, execute it in the background to gather evidence
-      // and build an enriched prompt. Fall back to the default prompt otherwise.
-      const initialPrompt = `Please analyze this alert and provide diagnosis with suggestions:
+      const basePrompt = `Please analyze this alert and provide diagnosis with suggestions:
 
 Alert: ${alert.ruleName}
 Severity: ${alert.severity}
 Message: ${alert.message}
 Cluster: ${alert.cluster || 'N/A'}
 Resource: ${alert.resource || 'N/A'}
-Details: ${JSON.stringify(alert.details, null, 2)}
+Details: ${JSON.stringify(alert.details, null, 2)}`
+
+      // #6915 — If a runbook matches, execute it first and include the
+      // gathered evidence directly in the AI prompt so the diagnosis is
+      // grounded in real cluster data, not just the alert metadata.
+      let runbookEvidence = ''
+      if (runbook) {
+        try {
+          const result = await executeRunbook(runbook, {
+            cluster: alert.cluster,
+            namespace: alert.namespace,
+            resource: alert.resource,
+            resourceKind: alert.resourceKind,
+            alertMessage: alert.message })
+          if (result.enrichedPrompt) {
+            runbookEvidence = `\n\n--- Runbook Evidence (${runbook.title}) ---\n${result.enrichedPrompt}`
+            console.debug(`Runbook "${runbook.title}" gathered ${result.stepResults.length} evidence steps`)
+          }
+        } catch {
+          // Silent failure - runbook is best-effort enhancement
+        }
+      }
+
+      const initialPrompt = `${basePrompt}${runbookEvidence}
 
 Please provide:
 1. A summary of the issue
 2. The likely root cause
 3. Suggested actions to resolve this alert`
-
-      if (runbook) {
-        // Fire-and-forget: runbook evidence will enrich the AI prompt asynchronously
-        executeRunbook(runbook, {
-          cluster: alert.cluster,
-          namespace: alert.namespace,
-          resource: alert.resource,
-          resourceKind: alert.resourceKind,
-          alertMessage: alert.message }).then(result => {
-          if (result.enrichedPrompt) {
-            // The mission has already started; the enriched prompt will be
-            // available for subsequent AI interactions in the mission context.
-            console.debug(`Runbook "${runbook.title}" gathered ${result.stepResults.length} evidence steps`)
-          }
-        }).catch(() => {
-          // Silent failure - runbook is best-effort enhancement
-        })
-      }
 
       const missionId = startMission({
         title: `Diagnose: ${alert.ruleName}`,

--- a/web/src/hooks/useAlerts.ts
+++ b/web/src/hooks/useAlerts.ts
@@ -120,7 +120,7 @@ export function useAlerts() {
       acknowledgeAlerts: () => {},
       resolveAlert: () => {},
       deleteAlert: () => {},
-      runAIDiagnosis: (() => null) as (alertId: string) => string | null,
+      runAIDiagnosis: (() => null) as (alertId: string) => Promise<string | null> | string | null,
       evaluateConditions: () => {},
       isLoadingData: false,
       dataError: null as string | null }

--- a/web/src/hooks/useMissions.tsx
+++ b/web/src/hooks/useMissions.tsx
@@ -304,8 +304,9 @@ function loadMissions(): Mission[] {
             timestamp: new Date(msg.timestamp)
           }))
         }
-        // Mark running missions for reconnection - they'll be resumed when WS connects
-        if (mission.status === 'running') {
+        // Mark running/waiting_input missions for reconnection — they'll be
+        // resumed when WS connects (#6912, #6913).
+        if (mission.status === 'running' || mission.status === 'waiting_input') {
           return {
             ...mission,
             currentStep: 'Reconnecting...',
@@ -873,7 +874,7 @@ export function MissionProvider({ children }: { children: ReactNode }) {
 
           setMissions(prev => {
             const candidates = prev.filter(m =>
-              m.status === 'running' && m.context?.needsReconnect
+              (m.status === 'running' || m.status === 'waiting_input') && m.context?.needsReconnect
             )
 
             if (candidates.length > 0) {
@@ -947,6 +948,12 @@ export function MissionProvider({ children }: { children: ReactNode }) {
             return prev
           })
 
+          // #6916 — Track which reconnecting missions were in waiting_input
+          // so we can restart their timeout watchdog after resend.
+          const waitingInputMissionIds = new Set(
+            missionsToReconnect.filter(m => m.status === 'waiting_input').map(m => m.id)
+          )
+
           // Side effect: schedule reconnection OUTSIDE the state updater.
           // #6832 — Deduplicate by mission ID. React StrictMode may invoke the
           // state updater twice, pushing the same mission into the array twice.
@@ -971,6 +978,19 @@ export function MissionProvider({ children }: { children: ReactNode }) {
             }
             setTimeout(() => {
               dedupedMissions.forEach(mission => {
+                // #6914 — Check if the mission was cancelled during the
+                // reconnect delay. Without this guard, a user who cancels
+                // during the MISSION_RECONNECT_DELAY_MS window would still
+                // have their prompt resent to the backend.
+                if (cancelIntents.current.has(mission.id)) {
+                  finalizeCancellation(mission.id, 'Mission cancelled by user during reconnect.')
+                  return
+                }
+                const currentState = missionsRef.current.find(m => m.id === mission.id)
+                if (currentState && (currentState.status === 'cancelled' || currentState.status === 'failed' || currentState.status === 'cancelling')) {
+                  return
+                }
+
                 // Find the last user message to re-send
                 const userMessages = mission.messages.filter(msg => msg.role === 'user')
                 const lastUserMessage = userMessages[userMessages.length - 1]
@@ -1037,6 +1057,14 @@ export function MissionProvider({ children }: { children: ReactNode }) {
                       m.id === mId ? { ...m, status: 'failed', currentStep: 'WebSocket reconnect failed' } : m
                     ))
                   })
+
+                  // #6916 — Restart the waiting_input timeout watchdog for
+                  // missions that were in waiting_input before disconnect.
+                  // The original timer was cleared on disconnect; without
+                  // restarting it the mission could hang indefinitely.
+                  if (waitingInputMissionIds.has(mId)) {
+                    startWaitingInputTimeout(mId)
+                  }
                 }
               })
             }, MISSION_RECONNECT_DELAY_MS)
@@ -1125,7 +1153,7 @@ export function MissionProvider({ children }: { children: ReactNode }) {
 
 The WebSocket connection to the agent at \`${LOCAL_AGENT_WS_URL}\` was lost and reconnection attempts were exhausted. Please verify the agent is running and reachable, then retry the mission.`
               setMissions(prev => prev.map(m => {
-                if (pendingMissionIds.has(m.id) && m.status === 'running') {
+                if (pendingMissionIds.has(m.id) && (m.status === 'running' || m.status === 'waiting_input')) {
                   return {
                     ...m,
                     status: 'failed',
@@ -1143,11 +1171,11 @@ The WebSocket connection to the agent at \`${LOCAL_AGENT_WS_URL}\` was lost and 
                 return m
               }))
             } else {
-              // Transient disconnect — keep mission in 'running' but mark it
-              // as needing reconnect. The UI will show "Reconnecting..." and
-              // the onopen handler will resume the mission automatically.
+              // Transient disconnect — keep mission in 'running'/'waiting_input'
+              // but mark it as needing reconnect (#6912). The UI will show
+              // "Reconnecting..." and the onopen handler will resume the mission.
               setMissions(prev => prev.map(m => {
-                if (pendingMissionIds.has(m.id) && m.status === 'running') {
+                if (pendingMissionIds.has(m.id) && (m.status === 'running' || m.status === 'waiting_input')) {
                   return {
                     ...m,
                     currentStep: 'Reconnecting...',


### PR DESCRIPTION
Closes #6912
Closes #6913
Closes #6914
Closes #6915
Closes #6916

## Summary

- **#6912/#6913 — waiting_input recovery on disconnect/reload**: `loadMissions()` now marks `waiting_input` missions for reconnect (same as `running`). The `onopen` reconnect handler includes `waiting_input` in its candidate filter, and the `onclose` handler marks them with `needsReconnect`. Previously these missions became permanent zombies.
- **#6914 — cancel guard during reconnect delay**: The delayed reconnect resend now checks `cancelIntents` and current mission status before sending, so a mission cancelled during the `MISSION_RECONNECT_DELAY_MS` window is finalized instead of executed.
- **#6915 — runbook evidence in AI diagnosis prompt**: `runAIDiagnosis` is now async — it awaits `executeRunbook()` and injects the `enrichedPrompt` directly into the mission's initial prompt. Previously the runbook was fire-and-forget and its output was logged but never used.
- **#6916 — waiting_input timeout restored after reconnect**: After resending a reconnected mission that was in `waiting_input`, `startWaitingInputTimeout` is called to restart the watchdog. The original timer was cleared on disconnect and never restarted.

## Files changed

| File | Change |
|------|--------|
| `web/src/hooks/useMissions.tsx` | Reconnect recovery for waiting_input, cancel guard, timeout restart |
| `web/src/contexts/AlertsContext.tsx` | Await runbook, inject evidence into prompt, async signature |
| `web/src/hooks/useAlerts.ts` | Updated fallback type to match async signature |

## Test plan

- [ ] Start a mission, wait for `waiting_input`, disconnect WS — mission should show "Reconnecting..." and resume on reconnect
- [ ] Reload page during `waiting_input` — mission should reconnect or fail with clear message
- [ ] Cancel a mission during reconnect delay — mission should not execute
- [ ] Trigger alert diagnosis with a matching runbook — verify runbook evidence appears in mission prompt
- [ ] Disconnect during `waiting_input` and reconnect — timeout should fire after `WAITING_INPUT_TIMEOUT_MS` if no response