### PR TITLE
feat: remaining loading states, PVC drilldown, list drilldowns, unified storage source (#6772,#6812,#6813,#6814)

### DIFF
--- a/web/src/components/cards/ISO27001Audit.tsx
+++ b/web/src/components/cards/ISO27001Audit.tsx
@@ -188,14 +188,25 @@ export function ISO27001Audit({ config }: ISO27001AuditProps) {
     return <CardSkeleton rows={5} showHeader showSearch />
   }
 
-  // 9. Empty state
+  // 9. Error state — shown when fetch failed, even if there's stale data (#6772)
+  if (isFailed && !hasData) {
+    return (
+      <div className="h-full flex flex-col items-center justify-center text-center p-4">
+        <AlertTriangle className="w-8 h-8 text-red-400 mb-2" />
+        <p className="text-sm font-medium text-foreground">{t('cards:iso27001Audit.failedToLoad', 'Failed to load audit data')}</p>
+        <p className="text-xs text-muted-foreground mt-1">{t('cards:iso27001Audit.checkAgent', 'Check agent connectivity and cluster access')}</p>
+      </div>
+    )
+  }
+
+  // 10. Empty state
   if (showEmptyState || (!isLoading && rawFindings.length === 0)) {
     if (isFailed) {
       return (
         <div className="h-full flex flex-col items-center justify-center text-center p-4">
           <AlertTriangle className="w-8 h-8 text-red-400 mb-2" />
-          <p className="text-sm font-medium text-foreground">Failed to load audit data</p>
-          <p className="text-xs text-muted-foreground mt-1">Check agent connectivity and cluster access</p>
+          <p className="text-sm font-medium text-foreground">{t('cards:iso27001Audit.failedToLoad', 'Failed to load audit data')}</p>
+          <p className="text-xs text-muted-foreground mt-1">{t('cards:iso27001Audit.checkAgent', 'Check agent connectivity and cluster access')}</p>
         </div>
       )
     }

--- a/web/src/components/clusters/components/NamespaceResources.tsx
+++ b/web/src/components/clusters/components/NamespaceResources.tsx
@@ -1,6 +1,7 @@
 import { useState, useMemo, useEffect } from 'react'
 import { ChevronRight, ChevronDown, Box, Layers, Network, List, GitBranch, Activity, Briefcase, Lock, Settings, Loader2, User, HardDrive, AlertCircle } from 'lucide-react'
-import { usePods, useDeployments, useServices, useJobs, useHPAs, useConfigMaps, useSecrets, useServiceAccounts, usePVCs } from '../../../hooks/useMCP'
+import { usePods, useDeployments, useServices, useJobs, useHPAs, useConfigMaps, useSecrets, useServiceAccounts } from '../../../hooks/useMCP'
+import { useCachedPVCs } from '../../../hooks/useCachedData'
 import { useDrillDownActions } from '../../../hooks/useDrillDown'
 import { useTranslation } from 'react-i18next'
 import { StatusBadge } from '../../ui/StatusBadge'
@@ -31,7 +32,7 @@ export function NamespaceResources({ clusterName, namespace, onClose }: Namespac
   const { configmaps, isLoading: configmapsLoading } = useConfigMaps(clusterName, namespace)
   const { secrets, isLoading: secretsLoading } = useSecrets(clusterName, namespace)
   const { serviceAccounts, isLoading: serviceAccountsLoading } = useServiceAccounts(clusterName, namespace)
-  const { pvcs, isLoading: pvcsLoading } = usePVCs(clusterName, namespace)
+  const { pvcs, isLoading: pvcsLoading } = useCachedPVCs(clusterName, namespace)
 
   const {
     drillToPod,

--- a/web/src/components/drilldown/DrillDownModal.tsx
+++ b/web/src/components/drilldown/DrillDownModal.tsx
@@ -1,7 +1,7 @@
 import { Component, useEffect, Suspense, type ReactNode, type ErrorInfo } from 'react'
 import { safeLazy } from '../../lib/safeLazy'
 import { useTranslation } from 'react-i18next'
-import { Box, Server, Layers, Rocket, FileText, Zap, Cpu, Lock, User, Bell, Ship, GitBranch, Settings, Shield, Package, DollarSign, AlertTriangle, RefreshCw } from 'lucide-react'
+import { Box, Server, Layers, Rocket, FileText, Zap, Cpu, Lock, User, Bell, Ship, GitBranch, Settings, Shield, Package, DollarSign, AlertTriangle, RefreshCw, HardDrive } from 'lucide-react'
 import { useDrillDown } from '../../hooks/useDrillDown'
 import { useMobile } from '../../hooks/useMobile'
 // Lazy load large components (>300 lines) for better performance
@@ -26,6 +26,7 @@ const BuildpackDrillDown = safeLazy(() => import('./views/BuildpackDrillDown'), 
 const RBACDrillDown = safeLazy(() => import('./views/RBACDrillDown'), 'RBACDrillDown')
 const CostDrillDown = safeLazy(() => import('./views/CostDrillDown'), 'CostDrillDown')
 const ComplianceDrillDown = safeLazy(() => import('./views/ComplianceDrillDown'), 'ComplianceDrillDown')
+const PVCDrillDown = safeLazy(() => import('./views/PVCDrillDown'), 'PVCDrillDown')
 
 const EventsDrillDown = safeLazy(() => import('./views/EventsDrillDown'), 'EventsDrillDown')
 
@@ -127,6 +128,7 @@ const getViewIcon = (type: string) => {
     case 'configmap': return <FileText className="w-4 h-4 text-yellow-400" />
     case 'secret': return <Lock className="w-4 h-4 text-red-400" />
     case 'serviceaccount': return <User className="w-4 h-4 text-purple-400" />
+    case 'pvc': return <HardDrive className="w-4 h-4 text-green-400" />
     case 'node': return <Cpu className="w-4 h-4 text-orange-400" />
     case 'gpu-node': return <Cpu className="w-4 h-4 text-purple-400" />
     case 'gpu-namespace': return <Box className="w-4 h-4 text-purple-400" />
@@ -249,6 +251,8 @@ export function DrillDownModal() {
         return <SecretDrillDown data={data} />
       case 'serviceaccount':
         return <ServiceAccountDrillDown data={data} />
+      case 'pvc':
+        return <PVCDrillDown data={data} />
       // Phase 2 views
       case 'alert':
         return <AlertDrillDown data={data} />

--- a/web/src/components/drilldown/views/ClusterDrillDown.tsx
+++ b/web/src/components/drilldown/views/ClusterDrillDown.tsx
@@ -1,7 +1,8 @@
 import { useEffect, useState } from 'react'
 import { ChevronRight, ChevronDown, Server, Box, Layers, Database, Network, HardDrive, Search, AlertTriangle, XCircle } from 'lucide-react'
 import { StatusBadge } from '../../ui/StatusBadge'
-import { useClusterHealth, usePodIssues, useDeploymentIssues, useGPUNodes, useNodes, useNamespaces, useDeployments, useServices, usePVCs, useEvents } from '../../../hooks/useMCP'
+import { useClusterHealth, usePodIssues, useDeploymentIssues, useGPUNodes, useNodes, useNamespaces, useDeployments, useServices, useEvents } from '../../../hooks/useMCP'
+import { useCachedPVCs } from '../../../hooks/useCachedData'
 import { useDrillDownActions } from '../../../hooks/useDrillDown'
 import { StatusIndicator } from '../../charts/StatusIndicator'
 import { Gauge } from '../../charts/Gauge'
@@ -46,7 +47,7 @@ export function ClusterDrillDown({ data }: Props) {
   const { namespaces: allNamespaces } = useNamespaces(clusterName)
   const { deployments: allDeployments } = useDeployments(clusterName)
   const { services: allServices } = useServices(clusterName)
-  const { pvcs: allPVCs } = usePVCs(clusterName)
+  const { pvcs: allPVCs } = useCachedPVCs(clusterName)
   const { events: clusterEvents, isLoading: eventsLoading } = useEvents(clusterName, undefined, 10)
 
   // Toggle section expansion

--- a/web/src/components/drilldown/views/MultiClusterSummaryDrillDown.tsx
+++ b/web/src/components/drilldown/views/MultiClusterSummaryDrillDown.tsx
@@ -3,7 +3,7 @@ import { Search, Server, Layers, Rocket, Box, Settings as SettingsIcon, AlertCir
 import { useClusterData } from '../../../hooks/useClusterData'
 import { useDrillDownActions } from '../../../hooks/useDrillDown'
 import type { DrillDownViewType } from '../../../hooks/useDrillDown'
-import { useCachedNodes } from '../../../hooks/useCachedData'
+import { useCachedNodes, useCachedPVCs } from '../../../hooks/useCachedData'
 import { useTranslation } from 'react-i18next'
 import { formatRelativeTime } from '../../../lib/formatters'
 
@@ -159,6 +159,7 @@ export function MultiClusterSummaryDrillDown({ data, viewType }: MultiClusterSum
   const { t } = useTranslation()
   const { clusters, deduplicatedClusters, pods, deployments, events, helmReleases, operatorSubscriptions, securityIssues } = useClusterData()
   const { nodes: rawCachedNodes, lastRefresh: nodesLastRefresh } = useCachedNodes()
+  const { pvcs: cachedPVCs } = useCachedPVCs()
   // Guard against undefined to prevent crashes when APIs return 404/500/empty
   const cachedNodes = rawCachedNodes || []
   // Convert epoch ms to ISO string for the freshness indicator
@@ -172,7 +173,7 @@ export function MultiClusterSummaryDrillDown({ data, viewType }: MultiClusterSum
 
   const {
     drillToCluster, drillToNamespace, drillToDeployment, drillToPod,
-    drillToNode, drillToEvents, drillToHelm, drillToOperator
+    drillToNode, drillToEvents, drillToHelm, drillToOperator, drillToPVC
   } = useDrillDownActions()
 
   const filter = data.filter as string | undefined
@@ -271,14 +272,16 @@ export function MultiClusterSummaryDrillDown({ data, viewType }: MultiClusterSum
             gpuCount: 0, // Placeholder - actual GPU data would come from GPU nodes hook
             status: 'available' }))
       case 'all-storage':
-        // Storage from clusters with storage info
-        return clusters
-          .filter(c => c.storageGB && c.storageGB > 0)
-          .map(c => ({
-            name: `pvc-${c.name}`,
-            cluster: c.name,
-            status: 'Bound',
-            storageGB: c.storageGB }))
+        // Use real PVC data from useCachedPVCs (#6813)
+        return (cachedPVCs || []).map(pvc => ({
+          name: pvc.name,
+          namespace: pvc.namespace,
+          cluster: pvc.cluster || '',
+          status: pvc.status || 'Unknown',
+          capacity: pvc.capacity,
+          storageClass: pvc.storageClass,
+          accessModes: pvc.accessModes,
+          volumeName: pvc.volumeName }))
       case 'all-jobs':
         // Jobs approximation from pods
         return pods
@@ -292,7 +295,7 @@ export function MultiClusterSummaryDrillDown({ data, viewType }: MultiClusterSum
       default:
         return []
     }
-  }, [viewType, clusters, deduplicatedClusters, pods, deployments, events, helmReleases, operatorSubscriptions, securityIssues, cachedNodes])
+  }, [viewType, clusters, deduplicatedClusters, pods, deployments, events, helmReleases, operatorSubscriptions, securityIssues, cachedNodes, cachedPVCs])
 
   // Apply initial filter from data prop
   const preFilteredItems = (() => {
@@ -384,6 +387,9 @@ export function MultiClusterSummaryDrillDown({ data, viewType }: MultiClusterSum
         break
       case 'all-security':
         drillToPod(cluster, namespace, (item.pod as string) || name, item)
+        break
+      case 'all-storage':
+        drillToPVC(cluster, namespace, name, item)
         break
       default:
         // Generic fallback - try pod if nothing else matches

--- a/web/src/components/drilldown/views/NamespaceDrillDown.tsx
+++ b/web/src/components/drilldown/views/NamespaceDrillDown.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react'
 import { ChevronRight, Search, Box, Network, HardDrive, Layers, Server } from 'lucide-react'
-import { usePodIssues, useDeploymentIssues, useEvents, useDeployments, useServices, usePVCs, usePods } from '../../../hooks/useMCP'
+import { usePodIssues, useDeploymentIssues, useEvents, useDeployments, useServices, usePods } from '../../../hooks/useMCP'
+import { useCachedPVCs } from '../../../hooks/useCachedData'
 import { useDrillDownActions } from '../../../hooks/useDrillDown'
 import { ClusterBadge } from '../../ui/ClusterBadge'
 import { StatusIndicator } from '../../charts/StatusIndicator'
@@ -33,7 +34,7 @@ export function NamespaceDrillDown({ data }: Props) {
   const clusterShort = cluster.split('/').pop() || cluster
   const { deployments: allDeployments } = useDeployments(clusterShort, namespace)
   const { services: allServices } = useServices(clusterShort, namespace)
-  const { pvcs: allPVCs } = usePVCs(clusterShort, namespace)
+  const { pvcs: allPVCs } = useCachedPVCs(clusterShort, namespace)
   const { pods: allPods } = usePods(clusterShort, namespace)
 
   const podIssues = allPodIssues.filter(p => p.namespace === namespace)

--- a/web/src/components/drilldown/views/PVCDrillDown.tsx
+++ b/web/src/components/drilldown/views/PVCDrillDown.tsx
@@ -1,0 +1,414 @@
+import { useState, useEffect, useRef } from 'react'
+import { useLocalAgent } from '../../../hooks/useLocalAgent'
+import { LOCAL_AGENT_WS_URL } from '../../../lib/constants'
+import { useDrillDownActions } from '../../../hooks/useDrillDown'
+import { ClusterBadge } from '../../ui/ClusterBadge'
+import { HardDrive, Code, Info, Tag, Loader2, Copy, Check, Layers, Server, Database } from 'lucide-react'
+import { cn } from '../../../lib/cn'
+import { UI_FEEDBACK_TIMEOUT_MS } from '../../../lib/constants/network'
+import { useTranslation } from 'react-i18next'
+import { copyToClipboard } from '../../../lib/clipboard'
+
+interface Props {
+  data: Record<string, unknown>
+}
+
+type TabType = 'overview' | 'describe' | 'yaml'
+
+/** Timeout for kubectl WebSocket commands (milliseconds) */
+const KUBECTL_TIMEOUT_MS = 10_000
+
+export function PVCDrillDown({ data }: Props) {
+  const { t } = useTranslation()
+  const cluster = data.cluster as string
+  const namespace = data.namespace as string
+  const pvcName = data.pvc as string
+  const { isConnected: agentConnected } = useLocalAgent()
+  const { drillToNamespace, drillToCluster } = useDrillDownActions()
+
+  const [activeTab, setActiveTab] = useState<TabType>('overview')
+  const [status, setStatus] = useState<string>(data.status as string || '')
+  const [capacity, setCapacity] = useState<string>(data.capacity as string || '')
+  const [accessModes, setAccessModes] = useState<string[]>((data.accessModes as string[]) || [])
+  const [storageClass, setStorageClass] = useState<string>(data.storageClass as string || '')
+  const [volumeName, setVolumeName] = useState<string>(data.volumeName as string || '')
+  const [volumeMode, setVolumeMode] = useState<string>('')
+  const [labels, setLabels] = useState<Record<string, string> | null>(null)
+  const [annotations, setAnnotations] = useState<Record<string, string> | null>(null)
+  const [describeOutput, setDescribeOutput] = useState<string | null>(null)
+  const [describeLoading, setDescribeLoading] = useState(false)
+  const [yamlOutput, setYamlOutput] = useState<string | null>(null)
+  const [yamlLoading, setYamlLoading] = useState(false)
+  const [copiedField, setCopiedField] = useState<string | null>(null)
+  const [isLoading, setIsLoading] = useState(false)
+
+  // Helper to run kubectl commands
+  const runKubectl = (args: string[]): Promise<string> => {
+    return new Promise((resolve) => {
+      const ws = new WebSocket(LOCAL_AGENT_WS_URL)
+      const requestId = `kubectl-${Date.now()}-${Math.random().toString(36).slice(2)}`
+      let output = ''
+
+      const timeout = setTimeout(() => {
+        ws.close()
+        resolve(output || '')
+      }, KUBECTL_TIMEOUT_MS)
+
+      ws.onopen = () => {
+        ws.send(JSON.stringify({
+          id: requestId,
+          type: 'kubectl',
+          payload: { context: cluster, args }
+        }))
+      }
+      ws.onmessage = (event) => {
+        const msg = JSON.parse(event.data)
+        if (msg.id === requestId && msg.payload?.output) {
+          output = msg.payload.output
+        }
+        clearTimeout(timeout)
+        ws.close()
+        resolve(output)
+      }
+      ws.onerror = () => {
+        clearTimeout(timeout)
+        ws.close()
+        resolve(output || '')
+      }
+    })
+  }
+
+  // Fetch PVC data from cluster
+  const fetchData = async () => {
+    if (!agentConnected) return
+
+    setIsLoading(true)
+    try {
+      const output = await runKubectl(['get', 'pvc', pvcName, '-n', namespace, '-o', 'json'])
+      if (output) {
+        const pvc = JSON.parse(output)
+        setStatus(pvc.status?.phase || '')
+        setCapacity(pvc.status?.capacity?.storage || pvc.spec?.resources?.requests?.storage || '')
+        setAccessModes(pvc.spec?.accessModes || [])
+        setStorageClass(pvc.spec?.storageClassName || '')
+        setVolumeName(pvc.spec?.volumeName || '')
+        setVolumeMode(pvc.spec?.volumeMode || 'Filesystem')
+        setLabels(pvc.metadata?.labels || null)
+        setAnnotations(pvc.metadata?.annotations || null)
+      }
+    } catch {
+      // Parse error — keep data from props
+    } finally {
+      setIsLoading(false)
+    }
+  }
+
+  const fetchedRef = useRef(false)
+  useEffect(() => {
+    if (!fetchedRef.current) {
+      fetchedRef.current = true
+      void fetchData()
+    }
+  }, [agentConnected])
+
+  const fetchDescribe = async () => {
+    if (!agentConnected || describeLoading) return
+    setDescribeLoading(true)
+    const output = await runKubectl(['describe', 'pvc', pvcName, '-n', namespace])
+    setDescribeOutput(output || 'No output received')
+    setDescribeLoading(false)
+  }
+
+  const fetchYaml = async () => {
+    if (!agentConnected || yamlLoading) return
+    setYamlLoading(true)
+    const output = await runKubectl(['get', 'pvc', pvcName, '-n', namespace, '-o', 'yaml'])
+    setYamlOutput(output || 'No output received')
+    setYamlLoading(false)
+  }
+
+  const handleCopy = async (text: string, field: string) => {
+    const ok = await copyToClipboard(text)
+    if (ok) {
+      setCopiedField(field)
+      setTimeout(() => setCopiedField(null), UI_FEEDBACK_TIMEOUT_MS)
+    }
+  }
+
+  const CopyButton = ({ text, field }: { text: string; field: string }) => (
+    <button
+      onClick={() => void handleCopy(text, field)}
+      className="p-1 rounded hover:bg-secondary/50 text-muted-foreground hover:text-foreground transition-colors"
+      title="Copy to clipboard"
+    >
+      {copiedField === field ? <Check className="w-3.5 h-3.5 text-green-400" /> : <Copy className="w-3.5 h-3.5" />}
+    </button>
+  )
+
+  const statusColor = (() => {
+    const s = status?.toLowerCase() || ''
+    if (s === 'bound') return 'bg-green-500/20 text-green-400'
+    if (s === 'pending') return 'bg-yellow-500/20 text-yellow-400'
+    if (s === 'lost') return 'bg-red-500/20 text-red-400'
+    return 'bg-gray-500/20 text-gray-400'
+  })()
+
+  const tabs: { id: TabType; label: string; icon: typeof Info }[] = [
+    { id: 'overview', label: t('drilldown.overview', 'Overview'), icon: Info },
+    { id: 'describe', label: t('drilldown.describe', 'Describe'), icon: Code },
+    { id: 'yaml', label: 'YAML', icon: Code },
+  ]
+
+  return (
+    <div className="space-y-4">
+      {/* Header */}
+      <div className="flex items-start justify-between">
+        <div className="flex items-center gap-3">
+          <div className="w-10 h-10 rounded-lg bg-green-500/20 flex items-center justify-center">
+            <HardDrive className="w-5 h-5 text-green-400" />
+          </div>
+          <div>
+            <div className="flex items-center gap-2">
+              <h2 className="text-lg font-semibold text-foreground">{pvcName}</h2>
+              {status && (
+                <span className={cn('px-2 py-0.5 rounded-full text-xs font-medium', statusColor)}>
+                  {status}
+                </span>
+              )}
+              {isLoading && <Loader2 className="w-4 h-4 animate-spin text-muted-foreground" />}
+            </div>
+            <div className="flex items-center gap-2 mt-0.5">
+              <button
+                onClick={() => drillToCluster(cluster)}
+                className="text-sm text-muted-foreground hover:text-foreground transition-colors"
+              >
+                <ClusterBadge cluster={cluster} size="sm" />
+              </button>
+              <span className="text-muted-foreground">/</span>
+              <button
+                onClick={() => drillToNamespace(cluster, namespace)}
+                className="flex items-center gap-1 text-sm text-purple-400 hover:text-purple-300 transition-colors"
+              >
+                <Layers className="w-3.5 h-3.5" />
+                {namespace}
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {/* Tabs */}
+      <div className="flex gap-1 border-b border-border">
+        {tabs.map(tab => (
+          <button
+            key={tab.id}
+            onClick={() => {
+              setActiveTab(tab.id)
+              if (tab.id === 'describe' && !describeOutput) void fetchDescribe()
+              if (tab.id === 'yaml' && !yamlOutput) void fetchYaml()
+            }}
+            className={cn(
+              'flex items-center gap-1.5 px-3 py-2 text-sm font-medium border-b-2 transition-colors',
+              activeTab === tab.id
+                ? 'border-primary text-foreground'
+                : 'border-transparent text-muted-foreground hover:text-foreground'
+            )}
+          >
+            <tab.icon className="w-3.5 h-3.5" />
+            {tab.label}
+          </button>
+        ))}
+      </div>
+
+      {/* Tab content */}
+      {activeTab === 'overview' && (
+        <div className="space-y-4">
+          {/* Key details grid */}
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+            <div className="space-y-3">
+              <h3 className="text-sm font-medium text-foreground flex items-center gap-1.5">
+                <Info className="w-4 h-4 text-blue-400" />
+                {t('drilldown.details', 'Details')}
+              </h3>
+              <div className="space-y-2 text-sm">
+                <div className="flex items-center justify-between py-1.5 border-b border-border/50">
+                  <span className="text-muted-foreground">{t('drilldown.status', 'Status')}</span>
+                  <span className={cn('px-2 py-0.5 rounded text-xs font-medium', statusColor)}>
+                    {status || 'Unknown'}
+                  </span>
+                </div>
+                <div className="flex items-center justify-between py-1.5 border-b border-border/50">
+                  <span className="text-muted-foreground">{t('drilldown.capacity', 'Capacity')}</span>
+                  <div className="flex items-center gap-1">
+                    <span className="text-foreground font-mono">{capacity || 'N/A'}</span>
+                    {capacity && <CopyButton text={capacity} field="capacity" />}
+                  </div>
+                </div>
+                <div className="flex items-center justify-between py-1.5 border-b border-border/50">
+                  <span className="text-muted-foreground">{t('drilldown.accessModes', 'Access Modes')}</span>
+                  <div className="flex items-center gap-1">
+                    {(accessModes || []).length > 0 ? (
+                      <div className="flex gap-1">
+                        {accessModes.map(mode => (
+                          <span key={mode} className="px-1.5 py-0.5 rounded bg-blue-500/20 text-blue-400 text-xs font-mono">
+                            {mode}
+                          </span>
+                        ))}
+                      </div>
+                    ) : (
+                      <span className="text-muted-foreground">N/A</span>
+                    )}
+                  </div>
+                </div>
+                <div className="flex items-center justify-between py-1.5 border-b border-border/50">
+                  <span className="text-muted-foreground">{t('drilldown.volumeMode', 'Volume Mode')}</span>
+                  <span className="text-foreground">{volumeMode || 'Filesystem'}</span>
+                </div>
+              </div>
+            </div>
+
+            <div className="space-y-3">
+              <h3 className="text-sm font-medium text-foreground flex items-center gap-1.5">
+                <Database className="w-4 h-4 text-green-400" />
+                {t('drilldown.storageInfo', 'Storage Info')}
+              </h3>
+              <div className="space-y-2 text-sm">
+                <div className="flex items-center justify-between py-1.5 border-b border-border/50">
+                  <span className="text-muted-foreground">{t('drilldown.storageClass', 'Storage Class')}</span>
+                  <div className="flex items-center gap-1">
+                    <span className="text-foreground font-mono">{storageClass || 'default'}</span>
+                    {storageClass && <CopyButton text={storageClass} field="storageClass" />}
+                  </div>
+                </div>
+                <div className="flex items-center justify-between py-1.5 border-b border-border/50">
+                  <span className="text-muted-foreground">{t('drilldown.boundVolume', 'Bound Volume')}</span>
+                  <div className="flex items-center gap-1">
+                    <span className="text-foreground font-mono text-xs">{volumeName || 'Unbound'}</span>
+                    {volumeName && <CopyButton text={volumeName} field="volumeName" />}
+                  </div>
+                </div>
+                <div className="flex items-center justify-between py-1.5 border-b border-border/50">
+                  <span className="text-muted-foreground">{t('drilldown.cluster', 'Cluster')}</span>
+                  <button
+                    onClick={() => drillToCluster(cluster)}
+                    className="flex items-center gap-1 text-blue-400 hover:text-blue-300 transition-colors"
+                  >
+                    <Server className="w-3.5 h-3.5" />
+                    <span className="text-xs">{cluster}</span>
+                  </button>
+                </div>
+                <div className="flex items-center justify-between py-1.5 border-b border-border/50">
+                  <span className="text-muted-foreground">{t('drilldown.namespace', 'Namespace')}</span>
+                  <button
+                    onClick={() => drillToNamespace(cluster, namespace)}
+                    className="flex items-center gap-1 text-purple-400 hover:text-purple-300 transition-colors"
+                  >
+                    <Layers className="w-3.5 h-3.5" />
+                    <span className="text-xs">{namespace}</span>
+                  </button>
+                </div>
+              </div>
+            </div>
+          </div>
+
+          {/* Labels */}
+          {labels && Object.keys(labels).length > 0 && (
+            <div className="space-y-2">
+              <h3 className="text-sm font-medium text-foreground flex items-center gap-1.5">
+                <Tag className="w-4 h-4 text-yellow-400" />
+                {t('drilldown.labels', 'Labels')}
+              </h3>
+              <div className="flex flex-wrap gap-1.5">
+                {Object.entries(labels).map(([key, value]) => (
+                  <span key={key} className="px-2 py-1 rounded bg-secondary/50 text-xs font-mono text-foreground">
+                    {key}={value}
+                  </span>
+                ))}
+              </div>
+            </div>
+          )}
+
+          {/* Annotations */}
+          {annotations && Object.keys(annotations).length > 0 && (
+            <div className="space-y-2">
+              <h3 className="text-sm font-medium text-foreground flex items-center gap-1.5">
+                <Tag className="w-4 h-4 text-muted-foreground" />
+                {t('drilldown.annotations', 'Annotations')}
+              </h3>
+              <div className="space-y-1">
+                {Object.entries(annotations).map(([key, value]) => (
+                  <div key={key} className="flex items-start gap-2 text-xs">
+                    <span className="font-mono text-muted-foreground break-all">{key}</span>
+                    <span className="text-foreground break-all">{value}</span>
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
+        </div>
+      )}
+
+      {activeTab === 'describe' && (
+        <div className="space-y-2">
+          {!agentConnected ? (
+            <div className="text-center py-8 text-muted-foreground">
+              <p className="text-sm">{t('drilldown.agentRequiredDescribe', 'Connect kc-agent to run kubectl describe')}</p>
+            </div>
+          ) : describeLoading ? (
+            <div className="flex items-center justify-center py-8">
+              <Loader2 className="w-5 h-5 animate-spin text-muted-foreground" />
+            </div>
+          ) : describeOutput ? (
+            <div className="relative">
+              <button
+                onClick={() => void handleCopy(describeOutput, 'describe')}
+                className="absolute top-2 right-2 p-1.5 rounded bg-secondary/80 hover:bg-secondary text-muted-foreground hover:text-foreground transition-colors"
+              >
+                {copiedField === 'describe' ? <Check className="w-4 h-4 text-green-400" /> : <Copy className="w-4 h-4" />}
+              </button>
+              <pre className="p-4 rounded-lg bg-secondary/30 border border-border text-xs font-mono text-foreground overflow-x-auto whitespace-pre-wrap max-h-[50vh]">
+                {describeOutput}
+              </pre>
+            </div>
+          ) : (
+            <div className="text-center py-8 text-muted-foreground">
+              <p className="text-sm">{t('drilldown.clickToFetchDescribe', 'Loading describe output...')}</p>
+            </div>
+          )}
+        </div>
+      )}
+
+      {activeTab === 'yaml' && (
+        <div className="space-y-2">
+          {!agentConnected ? (
+            <div className="text-center py-8 text-muted-foreground">
+              <p className="text-sm">{t('drilldown.agentRequiredYaml', 'Connect kc-agent to view YAML')}</p>
+            </div>
+          ) : yamlLoading ? (
+            <div className="flex items-center justify-center py-8">
+              <Loader2 className="w-5 h-5 animate-spin text-muted-foreground" />
+            </div>
+          ) : yamlOutput ? (
+            <div className="relative">
+              <button
+                onClick={() => void handleCopy(yamlOutput, 'yaml')}
+                className="absolute top-2 right-2 p-1.5 rounded bg-secondary/80 hover:bg-secondary text-muted-foreground hover:text-foreground transition-colors"
+              >
+                {copiedField === 'yaml' ? <Check className="w-4 h-4 text-green-400" /> : <Copy className="w-4 h-4" />}
+              </button>
+              <pre className="p-4 rounded-lg bg-secondary/30 border border-border text-xs font-mono text-foreground overflow-x-auto whitespace-pre-wrap max-h-[50vh]">
+                {yamlOutput}
+              </pre>
+            </div>
+          ) : (
+            <div className="text-center py-8 text-muted-foreground">
+              <p className="text-sm">{t('drilldown.clickToFetchYaml', 'Loading YAML...')}</p>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}
+
+export default PVCDrillDown

--- a/web/src/components/layout/navbar/AgentStatusIndicator.tsx
+++ b/web/src/components/layout/navbar/AgentStatusIndicator.tsx
@@ -182,6 +182,20 @@ export function AgentStatusIndicator() {
     ? { bg: 'bg-blue-500/10 text-blue-400 hover:bg-blue-500/20', dot: 'bg-blue-400', label: t('agent.cluster'), Icon: Server, title: t('agent.inClusterModeTitle') }
     : { bg: 'bg-red-500/10 text-red-400 hover:bg-red-500/20', dot: 'bg-red-400', label: t('agent.offline'), Icon: WifiOff, title: t('agent.localAgentDisconnected') }
 
+  // Loading state: show spinner while initial agent status is resolving (#6772)
+  if (stableStatus === 'connecting' && !showAsDemoMode && !isInClusterMode) {
+    return (
+      <div className="relative" ref={agentRef}>
+        <div className={cn('flex items-center justify-center gap-2 px-3 py-1.5 rounded-lg whitespace-nowrap', 'bg-yellow-500/10 text-yellow-400')}>
+          <Loader2 className="w-4 h-4 animate-spin" />
+          <span className="text-xs font-medium hidden sm:inline whitespace-nowrap">
+            {t('agent.connecting')}
+          </span>
+        </div>
+      </div>
+    )
+  }
+
   return (
     <div className="relative" ref={agentRef}>
       <button

--- a/web/src/hooks/useUniversalStats.ts
+++ b/web/src/hooks/useUniversalStats.ts
@@ -3,7 +3,6 @@ import {
   usePodIssues,
   useDeployments,
   useDeploymentIssues,
-  usePVCs,
   useServices,
   useEvents,
   useWarningEvents,
@@ -12,6 +11,7 @@ import {
   useOperatorSubscriptions,
   useOperators,
   useGPUNodes } from './useMCP'
+import { useCachedPVCs } from './useCachedData'
 import { useAlerts, useAlertRules } from './useAlerts'
 import { StatBlockValue } from '../components/ui/StatsOverview'
 import { useDrillDownActions } from './useDrillDown'
@@ -46,7 +46,7 @@ export function useUniversalStats() {
   const { issues: podIssues } = usePodIssues()
   const { deployments } = useDeployments()
   const { issues: deploymentIssues } = useDeploymentIssues()
-  const { pvcs } = usePVCs()
+  const { pvcs } = useCachedPVCs()
   const { services } = useServices()
   const { events } = useEvents(undefined, undefined, 100)
   const { events: warningEvents } = useWarningEvents(undefined, undefined, 100)


### PR DESCRIPTION
Closes #6772
Closes #6812
Closes #6813
Closes #6814

## Summary

- **#6772**: Add explicit error state to ISO27001Audit when fetch fails with no cached data; add loading spinner to AgentStatusIndicator during initial connection
- **#6812**: New `PVCDrillDown` view with Overview (status, capacity, access modes, storage class, bound PV, labels, annotations), Describe, and YAML tabs. Registered in `DrillDownModal` with icon and breadcrumb support
- **#6813**: Replace placeholder storage items in `MultiClusterSummaryDrillDown` with real PVC data from `useCachedPVCs`; add `drillToPVC` click handler so list items open the new PVC detail view
- **#6814**: Migrate all remaining `usePVCs()` call sites to `useCachedPVCs()`: `useUniversalStats`, `ClusterDrillDown`, `NamespaceDrillDown`, `NamespaceResources`

## Test plan
- [ ] Build passes (`npm run build`)
- [ ] Click a PVC in any resource list — PVC drilldown opens with details
- [ ] Click "PVCs" stat block — list view shows real PVC data with click-through
- [ ] Disconnect agent — ISO27001Audit shows error state
- [ ] Agent connecting on fresh load — AgentStatusIndicator shows spinner