### PR TITLE
fix: rollout timeout, dryRun gate, review modal scope, points sync, mutation guards (#6360,#6442,#6455,#6481,#6857)

### DIFF
--- a/deploy/helm/kubestellar-console/templates/NOTES.txt
+++ b/deploy/helm/kubestellar-console/templates/NOTES.txt
@@ -65,8 +65,8 @@ clear the corresponding `*.existingSecret` value so the chart renders its own).
     # expected key: {{ .Values.jwt.existingSecretKey }}
   {{- end }}
 
-Check rollout status:
-  kubectl rollout status deploy/{{ include "kubestellar-console.fullname" . }} -n {{ .Release.Namespace }}
+Check rollout status (times out after 3 minutes to avoid blocking indefinitely):
+  kubectl rollout status deploy/{{ include "kubestellar-console.fullname" . }} -n {{ .Release.Namespace }} --timeout=180s
 
 If the pod is stuck in CreateContainerConfigError, describe it to see which
 Secret is missing:
@@ -74,8 +74,8 @@ Secret is missing:
 {{- else }}
 
 All secrets for this release are rendered by the chart itself — no external
-Secret objects are required. Check rollout status:
-  kubectl rollout status deploy/{{ include "kubestellar-console.fullname" . }} -n {{ .Release.Namespace }}
+Secret objects are required. Check rollout status (times out after 3 minutes to avoid blocking indefinitely):
+  kubectl rollout status deploy/{{ include "kubestellar-console.fullname" . }} -n {{ .Release.Namespace }} --timeout=180s
 {{- end }}
 
 Docs:   https://kubestellar.io/docs/console/readme

--- a/pkg/agent/protocol/messages.go
+++ b/pkg/agent/protocol/messages.go
@@ -99,6 +99,10 @@ type KubectlRequest struct {
 	Namespace string   `json:"namespace,omitempty"`
 	Args      []string `json:"args"`
 	Confirmed bool     `json:"confirmed,omitempty"` // must be true for destructive commands
+	// SessionID ties this kubectl request to a mission session so the server
+	// can enforce dry-run mode: if the session was started with dryRun=true,
+	// mutating commands are rejected at the server level. (#6442)
+	SessionID string `json:"sessionId,omitempty"`
 }
 
 // KubectlResponse is the response from kubectl commands
@@ -183,6 +187,12 @@ type ChatRequest struct {
 	Prompt    string        `json:"prompt"`
 	SessionID string        `json:"sessionId,omitempty"`
 	History   []ChatMessage `json:"history,omitempty"` // Previous messages for context
+	// DryRun is a server-enforced flag. When true, the kubectl proxy rejects
+	// mutating commands (apply, create, delete, etc.) for this session,
+	// preventing the AI agent from making real changes even if it ignores the
+	// prompt-level dry-run instructions. Read-only commands (get, describe,
+	// logs, etc.) remain allowed. (#6442)
+	DryRun bool `json:"dryRun,omitempty"`
 }
 
 // ChatStreamPayload is a streaming response chunk from chat

--- a/pkg/agent/server.go
+++ b/pkg/agent/server.go
@@ -134,6 +134,13 @@ type Server struct {
 	activeChatCtxs   map[string]context.CancelFunc
 	activeChatCtxsMu sync.Mutex
 
+	// dryRunSessions tracks session IDs that are in dry-run mode.
+	// When a session is in this set, the kubectl proxy rejects mutating
+	// commands for that session, enforcing dry-run at the server level
+	// regardless of what the AI agent decides to do. (#6442)
+	dryRunSessions   map[string]bool
+	dryRunSessionsMu sync.RWMutex
+
 	// Auto-update system
 	updateChecker *UpdateChecker
 
@@ -206,6 +213,7 @@ func NewServer(cfg Config) (*Server, error) {
 		sessionStart:   now,
 		todayDate:      now.Format("2006-01-02"),
 		activeChatCtxs: make(map[string]context.CancelFunc),
+		dryRunSessions: make(map[string]bool),
 	}
 
 	server.upgrader = websocket.Upgrader{

--- a/pkg/agent/server_ai.go
+++ b/pkg/agent/server_ai.go
@@ -235,6 +235,30 @@ func (s *Server) handleClustersMessage(msg protocol.Message) protocol.Message {
 	}
 }
 
+// readOnlyKubectlVerbs are kubectl subcommands that do not modify cluster state.
+// Used by the dry-run gate (#6442) to allow observation while blocking mutations.
+var readOnlyKubectlVerbs = map[string]bool{
+	"get":           true,
+	"describe":      true,
+	"logs":          true,
+	"top":           true,
+	"explain":       true,
+	"api-resources": true,
+	"api-versions":  true,
+	"version":       true,
+	"cluster-info":  true,
+	"auth":          true, // can-i, whoami — read-only checks
+}
+
+// isReadOnlyKubectlCommand returns true when the kubectl args represent a
+// read-only operation that is safe to execute even in dry-run mode.
+func isReadOnlyKubectlCommand(args []string) bool {
+	if len(args) == 0 {
+		return false
+	}
+	return readOnlyKubectlVerbs[strings.ToLower(args[0])]
+}
+
 // destructiveKubectlVerbs are kubectl subcommands that modify or destroy resources
 // and require explicit user confirmation before execution.
 var destructiveKubectlVerbs = map[string]bool{
@@ -276,6 +300,25 @@ func (s *Server) handleKubectlMessage(msg protocol.Message) protocol.Message {
 	var req protocol.KubectlRequest
 	if err := json.Unmarshal(payloadBytes, &req); err != nil {
 		return s.errorResponse(msg.ID, "invalid_payload", "Invalid kubectl request format")
+	}
+
+	// Server-enforced dry-run gate (#6442): if this kubectl request is
+	// associated with a session in dry-run mode, reject any mutating command.
+	// Read-only commands (get, describe, logs, etc.) remain allowed.
+	if req.SessionID != "" {
+		s.dryRunSessionsMu.RLock()
+		isDryRun := s.dryRunSessions[req.SessionID]
+		s.dryRunSessionsMu.RUnlock()
+		if isDryRun && !isReadOnlyKubectlCommand(req.Args) {
+			return protocol.Message{
+				ID:   msg.ID,
+				Type: protocol.TypeError,
+				Payload: protocol.ErrorPayload{
+					Code:    "dry_run_rejected",
+					Message: fmt.Sprintf("dry-run mode: mutating command %q not allowed", strings.Join(req.Args, " ")),
+				},
+			}
+		}
 	}
 
 	// Check for destructive commands that require confirmation
@@ -370,6 +413,21 @@ func (s *Server) handleChatMessageStreaming(conn *websocket.Conn, msg protocol.M
 		delete(s.activeChatCtxs, req.SessionID)
 		s.activeChatCtxsMu.Unlock()
 	}()
+
+	// Server-enforced dry-run gate (#6442): when the frontend sends
+	// dryRun=true, register the session so the kubectl proxy rejects
+	// mutating commands for this session regardless of what the AI decides.
+	if req.DryRun {
+		s.dryRunSessionsMu.Lock()
+		s.dryRunSessions[req.SessionID] = true
+		s.dryRunSessionsMu.Unlock()
+		defer func() {
+			s.dryRunSessionsMu.Lock()
+			delete(s.dryRunSessions, req.SessionID)
+			s.dryRunSessionsMu.Unlock()
+		}()
+		slog.Info("[Chat] dry-run mode enforced for session", "sessionID", req.SessionID)
+	}
 
 	// Determine which agent to use
 	agentName := req.Agent

--- a/web/src/components/cards/CardWrapper.tsx
+++ b/web/src/components/cards/CardWrapper.tsx
@@ -1477,6 +1477,7 @@ export function CardWrapper({
                   type: 'deploy',
                   cluster: clusters.length > 0 ? clusters.join(',') : undefined,
                   initialPrompt: editedPrompt,
+                  skipReview: true,
                 })
                 openSidebar()
               }}

--- a/web/src/components/layout/UserProfileDropdown.tsx
+++ b/web/src/components/layout/UserProfileDropdown.tsx
@@ -43,7 +43,7 @@ export function UserProfileDropdown({ user, onLogout, onPreferences }: UserProfi
     backendUp: false,
   })
   const dropdownRef = useRef<HTMLDivElement>(null)
-  const { totalCoins, awardCoins } = useRewards()
+  const { totalCoins, githubPoints, localCoins, bonusPoints, awardCoins } = useRewards()
   const { channel, installMethod } = useVersionCheck()
   const { t, i18n } = useTranslation()
 
@@ -200,7 +200,15 @@ export function UserProfileDropdown({ user, onLogout, onPreferences }: UserProfi
             >
               <Coins className="w-4 h-4 text-yellow-500" />
               <span className="text-muted-foreground">{t('profile.coins')}</span>
-              <span className="text-yellow-400 font-medium">{totalCoins.toLocaleString()}</span>
+              <span
+                className="text-yellow-400 font-medium"
+                title={[
+                  `Console activity: ${localCoins.toLocaleString()}`,
+                  githubPoints > 0 ? `GitHub contributions: ${githubPoints.toLocaleString()}` : null,
+                  bonusPoints > 0 ? `Bonus: ${bonusPoints.toLocaleString()}` : null,
+                  'Note: Docs leaderboard shows GitHub points only',
+                ].filter(Boolean).join('\n')}
+              >{totalCoins.toLocaleString()}</span>
               <span className={`text-2xs px-1.5 py-0.5 rounded-full ${getContributorLevel(totalCoins).current.bgClass} ${getContributorLevel(totalCoins).current.textClass}`}>
                 {getContributorLevel(totalCoins).current.name}
               </span>

--- a/web/src/components/layout/mission-sidebar/MissionSidebar.tsx
+++ b/web/src/components/layout/mission-sidebar/MissionSidebar.tsx
@@ -756,7 +756,8 @@ export function MissionSidebar() {
                     type: 'custom',
                     title: newMissionPrompt.slice(0, 50) + (newMissionPrompt.length > 50 ? '...' : ''),
                     description: newMissionPrompt,
-                    initialPrompt: newMissionPrompt })
+                    initialPrompt: newMissionPrompt,
+                    skipReview: true })
                   setNewMissionPrompt('')
                   setShowNewMission(false)
                 }
@@ -783,7 +784,8 @@ export function MissionSidebar() {
                         type: 'custom',
                         title: newMissionPrompt.slice(0, 50) + (newMissionPrompt.length > 50 ? '...' : ''),
                         description: newMissionPrompt,
-                        initialPrompt: newMissionPrompt })
+                        initialPrompt: newMissionPrompt,
+                        skipReview: true })
                       setNewMissionPrompt('')
                       setShowNewMission(false)
                     }

--- a/web/src/contexts/AlertsContext.tsx
+++ b/web/src/contexts/AlertsContext.tsx
@@ -458,10 +458,10 @@ export function AlertsProvider({ children }: { children: ReactNode }) {
       const currentClusters = clustersRef.current
       if (!currentClusters.length) return
 
+      // (#6857) Return { cluster, data } from each callback to avoid shared mutation.
       const API_BASE = import.meta.env.VITE_API_BASE_URL || ''
-      const results: Record<string, GPUHealthCheckResult[]> = {}
 
-      await settledWithConcurrency(
+      const settled = await settledWithConcurrency(
         currentClusters.map((cluster) => async () => {
           try {
             const resp = await fetch(
@@ -471,14 +471,22 @@ export function AlertsProvider({ children }: { children: ReactNode }) {
             if (resp.ok) {
               const data = await resp.json().catch(() => null)
               if (data?.results && data.results.length > 0) {
-                results[cluster.name] = data.results
+                return { cluster: cluster.name, data: data.results as GPUHealthCheckResult[] }
               }
             }
           } catch {
             // Silent — CronJob may not be installed on this cluster
           }
+          return null
         })
       )
+
+      const results: Record<string, GPUHealthCheckResult[]> = {}
+      for (const result of settled) {
+        if (result.status === 'fulfilled' && result.value) {
+          results[result.value.cluster] = result.value.data
+        }
+      }
 
       if (!unmounted) cronJobResultsRef.current = results
     }

--- a/web/src/hooks/useCachedData.ts
+++ b/web/src/hooks/useCachedData.ts
@@ -151,25 +151,29 @@ async function fetchFromAllClusters<T>(
   if (clusters.length === 0) {
     throw new Error('No clusters available (agent connecting or backend not authenticated)')
   }
-  const accumulated: T[] = []
-  let failedCount = 0
 
-  // Fetch from each cluster with bounded concurrency, progressively reporting results
+  // (#6857) Each callback returns its own tagged items instead of pushing
+  // into a shared accumulator. Results are aggregated after all tasks settle,
+  // eliminating the shared-mutation hazard across concurrent await points.
   const tasks = clusters.map((cluster) => async () => {
-    try {
-      const data = await fetchAPI<Record<string, T[]>>(endpoint, { ...params, cluster })
-      const items = data[resultKey] || []
-      const tagged = addClusterField ? items.map(item => ({ ...item, cluster })) : items
-      accumulated.push(...tagged)
-      onProgress?.([...accumulated])
-      return tagged
-    } catch {
-      failedCount++
-      throw new Error(`Cluster ${cluster} fetch failed`)
-    }
+    const data = await fetchAPI<Record<string, T[]>>(endpoint, { ...params, cluster })
+    const items = data[resultKey] || []
+    return addClusterField ? items.map(item => ({ ...item, cluster })) : items
   })
 
-  await settledWithConcurrency(tasks)
+  const settled = await settledWithConcurrency(tasks)
+
+  // Aggregate fulfilled results and count failures
+  const accumulated: T[] = []
+  let failedCount = 0
+  for (const result of settled) {
+    if (result.status === 'fulfilled') {
+      accumulated.push(...result.value)
+      onProgress?.([...accumulated])
+    } else {
+      failedCount++
+    }
+  }
 
   // If every cluster fetch failed, throw so callers can try agent fallback
   if (accumulated.length === 0 && clusters.length > 0 && failedCount === clusters.length) {

--- a/web/src/hooks/useCachedISO27001.ts
+++ b/web/src/hooks/useCachedISO27001.ts
@@ -265,18 +265,13 @@ async function fetchISO27001AuditViaKubectl(
   const clusters = getAgentClusters()
   if (clusters.length === 0) return []
 
-  // Each task returns its own findings array to avoid shared-state mutation.
-  // Progressive updates are built by collecting all fulfilled results so far.
-  const completed: ISO27001Finding[][] = []
-
+  // (#6857) Each callback returns its own findings; aggregation happens
+  // after all tasks settle to avoid mutating a shared accumulator.
   const tasks = clusters
     .filter(c => !cluster || c.name === cluster)
     .map(({ name, context }) => async () => {
       try {
-        const clusterFindings = await runISO27001ChecksForCluster(name, context || name)
-        completed.push(clusterFindings)
-        onProgress?.(completed.flat())
-        return clusterFindings
+        return await runISO27001ChecksForCluster(name, context || name)
       } catch (err) {
         console.error(`[ISO27001] Audit failed for cluster ${name}:`, err)
         return []
@@ -284,9 +279,16 @@ async function fetchISO27001AuditViaKubectl(
     })
 
   const results = await settledWithConcurrency(tasks)
-  return results
-    .filter((r): r is PromiseFulfilledResult<ISO27001Finding[]> => r.status === 'fulfilled')
-    .flatMap(r => r.value)
+
+  // Aggregate after settlement and report progress
+  const allFindings: ISO27001Finding[] = []
+  for (const result of results) {
+    if (result.status === 'fulfilled') {
+      allFindings.push(...result.value)
+      onProgress?.([...allFindings])
+    }
+  }
+  return allFindings
 }
 
 /**

--- a/web/src/hooks/useCachedLLMd.ts
+++ b/web/src/hooks/useCachedLLMd.ts
@@ -313,15 +313,11 @@ export async function fetchLLMdServers(
   clusters: string[],
   onProgress?: (partial: LLMdServer[]) => void
 ): Promise<LLMdServer[]> {
-  // useCache prevents calling fetchers in demo mode via effectiveEnabled
-  const accumulated: LLMdServer[] = []
-
+  // (#6857) Each callback returns its own items; aggregation happens after
+  // all tasks settle to avoid shared-mutation hazards.
   const tasks = clusters.map((cluster) => async () => {
     try {
-      const clusterServers = await fetchLLMdServersForCluster(cluster)
-      accumulated.push(...clusterServers)
-      onProgress?.([...accumulated])
-      return clusterServers
+      return await fetchLLMdServersForCluster(cluster)
     } catch (err) {
       // Suppress demo mode errors - they're expected when agent is unavailable
       const errMsg = err instanceof Error ? err.message : String(err)
@@ -332,7 +328,15 @@ export async function fetchLLMdServers(
     }
   })
 
-  await settledWithConcurrency(tasks)
+  const settled = await settledWithConcurrency(tasks)
+
+  const accumulated: LLMdServer[] = []
+  for (const result of settled) {
+    if (result.status === 'fulfilled') {
+      accumulated.push(...result.value)
+      onProgress?.([...accumulated])
+    }
+  }
   return accumulated
 }
 

--- a/web/src/hooks/useDataCompliance.ts
+++ b/web/src/hooks/useDataCompliance.ts
@@ -255,10 +255,18 @@ export function useDataCompliance() {
         totalClusters: allClusters.length,
         reachableClusters: clusters.length }
 
-      const clusterFailures: string[] = []
+      // (#6857) Return data from each callback to avoid shared mutation.
       const tasks = clusters.map(cluster => async () => {
-        try {
-          const data = await fetchClusterCompliance(cluster.name)
+        const data = await fetchClusterCompliance(cluster.name)
+        return { cluster: cluster.name, data }
+      })
+
+      const settled = await settledWithConcurrency(tasks)
+
+      const clusterFailures: string[] = []
+      for (const result of settled) {
+        if (result.status === 'fulfilled') {
+          const { data } = result.value
           aggregated.totalSecrets += data.secrets.total
           aggregated.opaqueSecrets += data.secrets.opaque
           aggregated.tlsSecrets += data.secrets.tls
@@ -268,12 +276,15 @@ export function useDataCompliance() {
           aggregated.roleBindings += data.roleBindings
           aggregated.clusterAdminBindings += data.clusterAdminBindings
           aggregated.totalNamespaces += data.namespaces
-        } catch {
-          clusterFailures.push(cluster.name)
+        } else {
+          // Extract cluster name from the task index — rejected tasks
+          // don't carry their cluster reference, so use the tasks array index
+          const idx = (settled as PromiseSettledResult<{ cluster: string; data: unknown }>[]).indexOf(result)
+          if (idx >= 0 && idx < clusters.length) {
+            clusterFailures.push(clusters[idx].name)
+          }
         }
-      })
-
-      await settledWithConcurrency(tasks)
+      }
 
       setPosture(aggregated)
       saveToCache(aggregated)

--- a/web/src/hooks/useKubescape.ts
+++ b/web/src/hooks/useKubescape.ts
@@ -352,23 +352,26 @@ export function useKubescape() {
     }
     setClustersChecked(0)
 
-    // Check all clusters with bounded concurrency, stream results progressively
-    const allStatuses: Record<string, KubescapeClusterStatus> = {}
-
+    // (#6857) Return { cluster, status } from each callback to avoid shared mutation.
     const tasks = (clusters || []).map(cluster => async () => {
       const status = await fetchSingleCluster(cluster)
-      allStatuses[cluster] = status
-      // Stream each result immediately — card re-renders progressively
       setStatuses(prev => ({ ...prev, [cluster]: status }))
       setClustersChecked(prev => prev + 1)
-      // Clear loading state once first cluster with data arrives
       if (!initialLoadDone.current && status.installed) {
         initialLoadDone.current = true
         setIsLoading(false)
       }
+      return { cluster, status }
     })
 
-    await settledWithConcurrency(tasks)
+    const settled = await settledWithConcurrency(tasks)
+
+    const allStatuses: Record<string, KubescapeClusterStatus> = {}
+    for (const result of settled) {
+      if (result.status === 'fulfilled') {
+        allStatuses[result.value.cluster] = result.value.status
+      }
+    }
 
     // Final: save complete cache and clear refresh state
     saveToCache(allStatuses)

--- a/web/src/hooks/useKyverno.ts
+++ b/web/src/hooks/useKyverno.ts
@@ -373,12 +373,12 @@ export function useKyverno() {
     }
     setClustersChecked(0)
 
-    // Check all clusters with bounded concurrency, stream results progressively
-    const allStatuses: Record<string, KyvernoClusterStatus> = {}
-
+    // (#6857) Each callback returns { cluster, status } instead of mutating
+    // a shared allStatuses object. React setState calls inside the callback
+    // are safe (batched by React) but the bracket-assignment was flagged by
+    // concurrent-mutation-safety.test.ts.
     const tasks = (clusters || []).map(cluster => async () => {
       const status = await fetchSingleCluster(cluster)
-      allStatuses[cluster] = status
       // Stream each result immediately — card re-renders progressively
       setStatuses(prev => ({ ...prev, [cluster]: status }))
       setClustersChecked(prev => prev + 1)
@@ -387,9 +387,18 @@ export function useKyverno() {
         initialLoadDone.current = true
         setIsLoading(false)
       }
+      return { cluster, status }
     })
 
-    await settledWithConcurrency(tasks)
+    const settled = await settledWithConcurrency(tasks)
+
+    // Aggregate after all tasks settle — no shared mutation during concurrency
+    const allStatuses: Record<string, KyvernoClusterStatus> = {}
+    for (const result of settled) {
+      if (result.status === 'fulfilled') {
+        allStatuses[result.value.cluster] = result.value.status
+      }
+    }
 
     // Final: save complete cache and clear refresh state
     const allErrored = Object.keys(allStatuses).length > 0 &&

--- a/web/src/hooks/useMissions.tsx
+++ b/web/src/hooks/useMissions.tsx
@@ -10,6 +10,7 @@ import { emitMissionStarted, emitMissionCompleted, emitMissionError, emitMission
 import { scanForMaliciousContent } from '../lib/missions/scanner/malicious'
 import { runPreflightCheck, type PreflightError } from '../lib/missions/preflightCheck'
 import { kubectlProxy } from '../lib/kubectlProxy'
+import { ConfirmMissionPromptDialog } from '../components/missions/ConfirmMissionPromptDialog'
 
 export type MissionStatus = 'pending' | 'running' | 'waiting_input' | 'completed' | 'failed' | 'saved' | 'blocked' | 'cancelling' | 'cancelled'
 
@@ -112,6 +113,17 @@ interface MissionContextValue {
   /** Whether AI is disabled (user selected 'none' or no agent) */
   isAIDisabled: boolean
 
+  /**
+   * Pending review state (#6455): when a mission is started without
+   * skipReview, it is stashed here so the UI can show the
+   * ConfirmMissionPromptDialog. Call `confirmPendingReview` with the
+   * (possibly edited) prompt to proceed, or `cancelPendingReview` to
+   * discard.
+   */
+  pendingReview: StartMissionParams | null
+  confirmPendingReview: (editedPrompt: string) => void
+  cancelPendingReview: () => void
+
   // Actions
   startMission: (params: StartMissionParams) => string
   saveMission: (params: SaveMissionParams) => string
@@ -144,6 +156,13 @@ interface StartMissionParams {
   context?: Record<string, unknown>
   /** When true, injects --dry-run=server instructions into the prompt */
   dryRun?: boolean
+  /**
+   * When true, skip the review-prompt dialog and start immediately.
+   * Defaults to false — all missions show the review dialog unless
+   * explicitly opted out (e.g., the sidebar text input where the user
+   * already composed the prompt). (#6455)
+   */
+  skipReview?: boolean
 }
 
 interface SaveMissionParams {
@@ -460,6 +479,10 @@ export function MissionProvider({ children }: { children: ReactNode }) {
   const [isSidebarOpen, setIsSidebarOpen] = useState(false)
   const [isSidebarMinimized, setIsSidebarMinimized] = useState(false)
   const [isFullScreen, setIsFullScreen] = useState(false)
+
+  // Pending review state (#6455): stash mission params here when the user
+  // needs to review/edit the prompt before the mission actually starts.
+  const [pendingReview, setPendingReview] = useState<StartMissionParams | null>(null)
   const [unreadMissionIds, setUnreadMissionIds] = useState<Set<string>>(() => loadUnreadMissionIds())
 
   // Agent state
@@ -2051,6 +2074,17 @@ The WebSocket connection to the agent at \`${LOCAL_AGENT_WS_URL}\` was lost and 
   }
 
   const startMission = (params: StartMissionParams): string => {
+    // (#6455) When skipReview is not set, stash the params so the UI can
+    // show ConfirmMissionPromptDialog for ALL mission types, not just
+    // install missions.  Callers that already present their own review
+    // dialog (e.g. CardWrapper install CTA) pass skipReview: true.
+    if (!params.skipReview) {
+      setPendingReview(params)
+      // Return empty — the real mission ID is generated when the user
+      // confirms via confirmPendingReview.
+      return ''
+    }
+
     const missionId = `mission-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`
 
     const { enhancedPrompt, matchedResolutions, isInstallMission } = buildEnhancedPrompt(params)
@@ -2101,7 +2135,7 @@ The WebSocket connection to the agent at \`${LOCAL_AGENT_WS_URL}\` was lost and 
   const executeMission = (
     missionId: string,
     enhancedPrompt: string,
-    params: { context?: Record<string, unknown>; type?: string },
+    params: { context?: Record<string, unknown>; type?: string; dryRun?: boolean },
   ) => {
     // #6384 item 1 (dup of #6381) — if a cancel intent is already set for
     // this missionId we must not clear it and proceed to send. This
@@ -2140,7 +2174,11 @@ The WebSocket connection to the agent at \`${LOCAL_AGENT_WS_URL}\` was lost and 
           sessionId: missionId,
           agent: selectedAgentRef.current || undefined,
           // Include mission context for the agent to use
-          context: params.context }
+          context: params.context,
+          // Server-enforced dry-run gate (#6442): when true, the backend
+          // tracks this session as dry-run and rejects mutating kubectl
+          // commands at the server level, not just in the prompt.
+          dryRun: params.dryRun || false }
       }), () => {
         setMissions(prev => prev.map(m =>
           m.id === missionId ? { ...m, status: 'failed', currentStep: 'WebSocket connection lost' } : m
@@ -2811,6 +2849,15 @@ Install the console locally with the KubeStellar Console agent to use AI mission
     }
   }, [])
 
+  // (#6455) Confirm or cancel the pending prompt review.
+  const confirmPendingReview = (editedPrompt: string) => {
+    if (!pendingReview) return
+    const params = { ...pendingReview, initialPrompt: editedPrompt, skipReview: true }
+    setPendingReview(null)
+    startMission(params)
+  }
+  const cancelPendingReview = () => setPendingReview(null)
+
   // #6730 — Memoize the context value so consumers of MissionContext don't
   // re-render on every render of MissionProvider. Prior to this fix, the
   // inline object literal created a fresh reference on every parent render,
@@ -2832,13 +2879,13 @@ Install the console locally with the KubeStellar Console agent to use AI mission
     retryPreflight, cancelMission, dismissMission, renameMission, rateMission,
     setActiveMission, markMissionAsRead, selectAgent, connectToAgent,
     toggleSidebar, openSidebar, closeSidebar, minimizeSidebar, expandSidebar,
-    handleSetFullScreen })
+    handleSetFullScreen, confirmPendingReview, cancelPendingReview })
   handlersRef.current = {
     startMission, saveMission, runSavedMission, updateSavedMission, sendMessage,
     retryPreflight, cancelMission, dismissMission, renameMission, rateMission,
     setActiveMission, markMissionAsRead, selectAgent, connectToAgent,
     toggleSidebar, openSidebar, closeSidebar, minimizeSidebar, expandSidebar,
-    handleSetFullScreen }
+    handleSetFullScreen, confirmPendingReview, cancelPendingReview }
   // Stable proxies. Created once via useMemo with an empty dep array; every
   // call forwards to the currently-live handler on `handlersRef.current`.
   const stableHandlers = useMemo(() => ({
@@ -2877,6 +2924,10 @@ Install the console locally with the KubeStellar Console agent to use AI mission
     expandSidebar: () => handlersRef.current.expandSidebar(),
     setFullScreen: (fullScreen: boolean) =>
       handlersRef.current.handleSetFullScreen(fullScreen),
+    confirmPendingReview: (editedPrompt: string) =>
+      handlersRef.current.confirmPendingReview(editedPrompt),
+    cancelPendingReview: () =>
+      handlersRef.current.cancelPendingReview(),
   }), [])
 
   const contextValue = useMemo(() => ({
@@ -2892,6 +2943,7 @@ Install the console locally with the KubeStellar Console agent to use AI mission
     defaultAgent,
     agentsLoading,
     isAIDisabled: selectedAgent === 'none' || !selectedAgent,
+    pendingReview,
     ...stableHandlers,
   }), [
     missions,
@@ -2904,12 +2956,25 @@ Install the console locally with the KubeStellar Console agent to use AI mission
     selectedAgent,
     defaultAgent,
     agentsLoading,
+    pendingReview,
     stableHandlers,
   ])
 
   return (
     <MissionContext.Provider value={contextValue}>
       {children}
+      {/* Global prompt-review dialog (#6455): shown for every mission that
+          does not opt out via skipReview: true. */}
+      {pendingReview && (
+        <ConfirmMissionPromptDialog
+          open={!!pendingReview}
+          missionTitle={pendingReview.title}
+          missionDescription={pendingReview.description}
+          initialPrompt={pendingReview.initialPrompt}
+          onCancel={cancelPendingReview}
+          onConfirm={confirmPendingReview}
+        />
+      )}
     </MissionContext.Provider>
   )
 }
@@ -2936,6 +3001,9 @@ const MISSIONS_FALLBACK: MissionContextValue = {
   defaultAgent: null,
   agentsLoading: false,
   isAIDisabled: true,
+  pendingReview: null,
+  confirmPendingReview: () => {},
+  cancelPendingReview: () => {},
   startMission: () => '',
   saveMission: () => '',
   runSavedMission: () => {},

--- a/web/src/hooks/useRBACFindings.ts
+++ b/web/src/hooks/useRBACFindings.ts
@@ -307,13 +307,10 @@ export function useRBACFindings() {
       }
       setError(null)
 
-      const allFindings: RBACFinding[] = []
-
-      // Check all clusters with bounded concurrency, stream results progressively
+      // (#6857) Return findings from each callback to avoid shared mutation.
       const tasks = clusters.map(cluster => async () => {
         const clusterFindings = await fetchSingleCluster(cluster)
-        allFindings.push(...clusterFindings)
-        // Stream each cluster's results immediately
+        // Stream each cluster's results immediately (React setState is safe)
         setFindings(prev => {
           const otherFindings = prev.filter(f => f.cluster !== cluster)
           return [...otherFindings, ...clusterFindings]
@@ -322,9 +319,17 @@ export function useRBACFindings() {
           initialLoadDone.current = true
           setIsLoading(false)
         }
+        return clusterFindings
       })
 
-      await settledWithConcurrency(tasks)
+      const settled = await settledWithConcurrency(tasks)
+
+      const allFindings: RBACFinding[] = []
+      for (const result of settled) {
+        if (result.status === 'fulfilled') {
+          allFindings.push(...result.value)
+        }
+      }
 
       saveToCache(allFindings)
       initialLoadDone.current = true

--- a/web/src/hooks/useTrestle.ts
+++ b/web/src/hooks/useTrestle.ts
@@ -427,19 +427,22 @@ export function useTrestle() {
       return
     }
 
-    // Real mode: check all clusters with bounded concurrency.
-    // Buffer results and apply a single state update at the end to prevent
-    // the card from flickering through intermediate states (#4266).
-    const allStatuses: Record<string, TrestleClusterStatus> = {}
-    let checked = 0
-
+    // (#6857) Return { cluster, status } from each callback to avoid shared mutation.
     const tasks = (clusterNames || []).map(cluster => async () => {
       const status = await fetchSingleCluster(cluster)
-      allStatuses[cluster] = status
-      checked++
+      return { cluster, status }
     })
 
-    await settledWithConcurrency(tasks)
+    const settled = await settledWithConcurrency(tasks)
+
+    const allStatuses: Record<string, TrestleClusterStatus> = {}
+    let checked = 0
+    for (const result of settled) {
+      if (result.status === 'fulfilled') {
+        allStatuses[result.value.cluster] = result.value.status
+        checked++
+      }
+    }
 
     if (mountedRef.current) {
       // If no cluster has Trestle installed, fall back to demo data so the

--- a/web/src/hooks/useTrivy.ts
+++ b/web/src/hooks/useTrivy.ts
@@ -283,23 +283,26 @@ export function useTrivy() {
     }
     setClustersChecked(0)
 
-    // Check all clusters with bounded concurrency, stream results progressively
-    const allStatuses: Record<string, TrivyClusterStatus> = {}
-
+    // (#6857) Return { cluster, status } from each callback to avoid shared mutation.
     const tasks = (clusters || []).map(cluster => async () => {
       const status = await fetchSingleCluster(cluster)
-      allStatuses[cluster] = status
-      // Stream each result immediately — card re-renders progressively
       setStatuses(prev => ({ ...prev, [cluster]: status }))
       setClustersChecked(prev => prev + 1)
-      // Clear loading state once first cluster with data arrives
       if (!initialLoadDone.current && status.installed) {
         initialLoadDone.current = true
         setIsLoading(false)
       }
+      return { cluster, status }
     })
 
-    await settledWithConcurrency(tasks)
+    const settled = await settledWithConcurrency(tasks)
+
+    const allStatuses: Record<string, TrivyClusterStatus> = {}
+    for (const result of settled) {
+      if (result.status === 'fulfilled') {
+        allStatuses[result.value.cluster] = result.value.status
+      }
+    }
 
     // Final: save complete cache and clear refresh state
     saveToCache(allStatuses)

--- a/web/src/test/concurrent-mutation-safety.test.ts
+++ b/web/src/test/concurrent-mutation-safety.test.ts
@@ -79,46 +79,16 @@ const SAFE_MUTATION_IDENTIFIERS = new Set([
  * update the constant.  If it fails because the count *increased*, you
  * introduced a new shared mutation — refactor to return values instead.
  */
-const EXPECTED_MUTATION_COUNT = 10
+const EXPECTED_MUTATION_COUNT = 0
 
 /**
  * Known files with shared-mutation violations.
  * Keyed by path relative to SRC_DIR (POSIX separators).
  * This list MUST ONLY SHRINK — never add new entries.
  */
-const KNOWN_VIOLATIONS: Record<string, string[]> = {
-  'hooks/useCachedData.ts': [
-    'accumulated.push(...tagged)',
-    'failedCount++',
-  ],
-  'hooks/useKyverno.ts': [
-    'allStatuses[cluster] = status',
-  ],
-  'hooks/useTrivy.ts': [
-    'allStatuses[cluster] = status',
-  ],
-  'hooks/useKubescape.ts': [
-    'allStatuses[cluster] = status',
-  ],
-  'hooks/useTrestle.ts': [
-    'allStatuses[cluster] = status',
-  ],
-  'hooks/useRBACFindings.ts': [
-    'allFindings[cluster] = findings',
-  ],
-  'hooks/useDataCompliance.ts': [
-    'aggregated.totalSecrets += data.secrets.total',
-  ],
-  'hooks/useCachedLLMd.ts': [
-    'accumulated.push(...tagged)',
-  ],
-  'contexts/AlertsContext.tsx': [
-    'results[cluster.name] = data.results',
-  ],
-  'hooks/useCachedISO27001.ts': [
-    'findings.push(...clusterFindings)',
-  ],
-}
+// All 10 original violations have been fixed in #6857.
+// Each callback now returns values; aggregation happens after settlement.
+const KNOWN_VIOLATIONS: Record<string, string[]> = {}
 
 // ── Helpers ─────────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
Closes #6360
Closes #6442
Closes #6455
Closes #6481
Closes #6857

## Summary

- **#6360** — Add `--timeout=180s` to `kubectl rollout status` in Helm NOTES.txt
- **#6442** — Server-enforced dry-run gate: `DryRun` on `ChatRequest`, `dryRunSessions` tracking, kubectl proxy rejects mutating commands for dry-run sessions
- **#6455** — Global `ConfirmMissionPromptDialog` for ALL mission types via `pendingReview` state; sidebar and CardWrapper install opt out via `skipReview: true`
- **#6481** — Points breakdown tooltip in profile dropdown: console activity, GitHub contributions, bonus
- **#6857** — Fix all 10 shared-mutation violations in concurrency callbacks; ratchet to 0

## Test plan

- [x] `go build ./...` and `go vet ./...` pass
- [x] `npm run build` passes
- [ ] Helm NOTES.txt shows timeout flag
- [ ] Dry-run missions send dryRun in WS payload
- [ ] Non-sidebar missions show review dialog
- [ ] Profile tooltip shows points breakdown
- [ ] concurrent-mutation-safety.test.ts passes with 0 violations