### PR TITLE
fix(test): update 12 tests for PVC migration, async runAIDiagnosis, error propagation (#6921)

### DIFF
--- a/web/src/components/drilldown/views/__tests__/MultiClusterSummaryDrillDown.test.tsx
+++ b/web/src/components/drilldown/views/__tests__/MultiClusterSummaryDrillDown.test.tsx
@@ -42,6 +42,7 @@ vi.mock('../../../../hooks/useDrillDown', () => ({
 
 vi.mock('../../../../hooks/useCachedData', () => ({
   useCachedNodes: () => ({ nodes: [], lastRefresh: Date.now() }),
+  useCachedPVCs: () => ({ pvcs: [], lastRefresh: Date.now() }),
 }))
 
 import { MultiClusterSummaryDrillDown } from '../MultiClusterSummaryDrillDown'

--- a/web/src/contexts/AlertsContext.test.tsx
+++ b/web/src/contexts/AlertsContext.test.tsx
@@ -462,18 +462,18 @@ describe('rule management', () => {
 // ── Run AI Diagnosis ────────────────────────────────────────────────────────
 
 describe('runAIDiagnosis', () => {
-  it('returns null for non-existent alert id', () => {
+  it('returns null for non-existent alert id', async () => {
     const { result } = renderHook(() => useAlertsContext(), { wrapper })
 
     let missionId: string | null = null
-    act(() => {
-      missionId = result.current.runAIDiagnosis('non-existent')
+    await act(async () => {
+      missionId = await result.current.runAIDiagnosis('non-existent')
     })
 
     expect(missionId).toBeNull()
   })
 
-  it('starts a mission and sets aiDiagnosis on the alert', () => {
+  it('starts a mission and sets aiDiagnosis on the alert', async () => {
     const alert = makeAlert({ id: 'diagnose-me', ruleId: 'rule-1', status: 'firing' })
     // Make sure the rule exists
     const rule: AlertRule = {
@@ -494,8 +494,8 @@ describe('runAIDiagnosis', () => {
     const { result } = renderHook(() => useAlertsContext(), { wrapper })
 
     let missionId: string | null = null
-    act(() => {
-      missionId = result.current.runAIDiagnosis('diagnose-me')
+    await act(async () => {
+      missionId = await result.current.runAIDiagnosis('diagnose-me')
     })
 
     expect(missionId).toBe('mock-mission-id')

--- a/web/src/contexts/__tests__/AlertsContext.test.tsx
+++ b/web/src/contexts/__tests__/AlertsContext.test.tsx
@@ -37,7 +37,9 @@ vi.mock('../../lib/runbooks/executor', () => ({
 }))
 
 vi.mock('../../lib/utils/concurrency', () => ({
-  settledWithConcurrency: vi.fn((fns: (() => Promise<unknown>)[]) => Promise.all(fns.map(fn => fn()))),
+  settledWithConcurrency: vi.fn((fns: (() => Promise<unknown>)[]) =>
+    Promise.allSettled(fns.map(fn => fn()))
+  ),
 }))
 
 // Stub the lazy-loaded AlertsDataFetcher — calls onData with injected MCP data
@@ -377,7 +379,7 @@ describe('AlertsContext', () => {
 
   // ── 9. AI diagnosis ─────────────────────────────────────────────────
 
-  it('runs AI diagnosis and creates a mission', () => {
+  it('runs AI diagnosis and creates a mission', async () => {
     const seedAlert: Alert = {
       id: 'diag-1',
       ruleId: 'r-diag',
@@ -408,8 +410,8 @@ describe('AlertsContext', () => {
     const { result } = renderHook(() => useAlertsContext(), { wrapper })
 
     let missionId: string | null = null
-    act(() => {
-      missionId = result.current.runAIDiagnosis('diag-1')
+    await act(async () => {
+      missionId = await result.current.runAIDiagnosis('diag-1')
     })
 
     expect(missionId).toBe('mission-123')
@@ -427,12 +429,12 @@ describe('AlertsContext', () => {
     expect(alert.aiDiagnosis!.missionId).toBe('mission-123')
   })
 
-  it('returns null for AI diagnosis on non-existent alert', () => {
+  it('returns null for AI diagnosis on non-existent alert', async () => {
     const { result } = renderHook(() => useAlertsContext(), { wrapper })
 
     let missionId: string | null = null
-    act(() => {
-      missionId = result.current.runAIDiagnosis('non-existent')
+    await act(async () => {
+      missionId = await result.current.runAIDiagnosis('non-existent')
     })
 
     expect(missionId).toBeNull()
@@ -3767,8 +3769,8 @@ describe('AlertsContext — wave 2 deep coverage', () => {
     const { result } = renderHook(() => useAlertsContext(), { wrapper })
 
     let missionId: string | null = null
-    act(() => {
-      missionId = result.current.runAIDiagnosis('rb-diag')
+    await act(async () => {
+      missionId = await result.current.runAIDiagnosis('rb-diag')
     })
 
     expect(missionId).toBe('mission-123')
@@ -3841,8 +3843,8 @@ describe('AlertsContext — wave 2 deep coverage', () => {
     const { result } = renderHook(() => useAlertsContext(), { wrapper })
 
     let missionId: string | null = null
-    act(() => {
-      missionId = result.current.runAIDiagnosis('rb-fail-alert')
+    await act(async () => {
+      missionId = await result.current.runAIDiagnosis('rb-fail-alert')
     })
 
     // Should still create a mission even if runbook fails

--- a/web/src/hooks/__tests__/useUniversalStats.test.ts
+++ b/web/src/hooks/__tests__/useUniversalStats.test.ts
@@ -55,6 +55,10 @@ vi.mock('../useMCP', () => ({
   useGPUNodes: (...args: unknown[]) => mockUseGPUNodes(...args),
 }))
 
+vi.mock('../useCachedData', () => ({
+  useCachedPVCs: (...args: unknown[]) => mockUsePVCs(...args),
+}))
+
 vi.mock('../useAlerts', () => ({
   useAlerts: (...args: unknown[]) => mockUseAlerts(...args),
   useAlertRules: (...args: unknown[]) => mockUseAlertRules(...args),

--- a/web/src/hooks/mcp/__tests__/storage.test.ts
+++ b/web/src/hooks/mcp/__tests__/storage.test.ts
@@ -236,13 +236,13 @@ describe('usePVCs', () => {
     expect(result.current.error).toBeNull()
   })
 
-  it('returns empty PVCs with error: null on fetch failure', async () => {
+  it('returns empty PVCs with error message on fetch failure', async () => {
     mockApiGet.mockRejectedValue(new Error('fetch error'))
 
     const { result } = renderHook(() => usePVCs())
 
     await waitFor(() => expect(result.current.isLoading).toBe(false))
-    expect(result.current.error).toBeNull()
+    expect(result.current.error).toBe('fetch error')
   })
 })
 
@@ -310,14 +310,14 @@ describe('usePVs', () => {
     expect(mockApiGet.mock.calls.length).toBe(callsAfterPoll)
   })
 
-  it('returns empty list with error: null on fetch failure', async () => {
+  it('returns empty list with error message on fetch failure', async () => {
     mockApiGet.mockRejectedValue(new Error('network error'))
 
     const { result } = renderHook(() => usePVs())
 
     await waitFor(() => expect(result.current.isLoading).toBe(false))
     expect(result.current.pvs).toEqual([])
-    expect(result.current.error).toBeNull()
+    expect(result.current.error).toBe('network error')
   })
 })
 


### PR DESCRIPTION
Closes #6921

## Summary

- **MultiClusterSummaryDrillDown.test.tsx**: Added `useCachedPVCs` to the `useCachedData` mock (PR #6919 wired `useCachedPVCs()` into the component)
- **useUniversalStats.test.ts**: Added `useCachedData` mock with `useCachedPVCs` (PR #6919 switched from `usePVCs` to `useCachedPVCs`)
- **storage.test.ts**: Updated 2 error-handling assertions — errors are now propagated to callers instead of swallowed with `setError(null)` (PR #6896 behavior change)
- **AlertsContext.test.tsx** (both files): Changed `runAIDiagnosis` calls from sync `act()` to `await act(async () => await ...)` since PR #6920 made it `async` (awaits runbook execution)
- **AlertsContext `__tests__`**: Fixed `settledWithConcurrency` mock to use `Promise.allSettled` instead of `Promise.all` so it returns proper `PromiseSettledResult` objects (fixes CronJob GPU health tests)

## Test plan

- [x] All 5 test files pass: 562 passed, 2 skipped, 0 failed
- [x] `npm run build` passes with all post-build safety checks