### PR TITLE
fix(test): revert shared mock regression, localize concurrency fixes (#6924)

### DIFF
--- a/web/src/hooks/__tests__/useKubescape.test.ts
+++ b/web/src/hooks/__tests__/useKubescape.test.ts
@@ -50,7 +50,7 @@ vi.mock('../../lib/modeTransition', () => ({
 
 vi.mock('../../lib/utils/concurrency', () => ({
   settledWithConcurrency: vi.fn(async (tasks: Array<() => Promise<unknown>>) =>
-    Promise.all(tasks.map((t) => t()))
+    Promise.allSettled(tasks.map((t) => t()))
   ),
 }))
 

--- a/web/src/hooks/__tests__/useTrivy.test.ts
+++ b/web/src/hooks/__tests__/useTrivy.test.ts
@@ -50,7 +50,7 @@ vi.mock('../../lib/modeTransition', () => ({
 
 vi.mock('../../lib/utils/concurrency', () => ({
   settledWithConcurrency: vi.fn(async (tasks: Array<() => Promise<unknown>>) =>
-    Promise.all(tasks.map((t) => t()))
+    Promise.allSettled(tasks.map((t) => t()))
   ),
 }))
 

--- a/web/src/hooks/useCachedData.ts
+++ b/web/src/hooks/useCachedData.ts
@@ -330,19 +330,22 @@ async function fetchPodIssuesViaAgent(namespace?: string, onProgress?: (partial:
   if (isAgentUnavailable()) return []
   const clusters = getAgentClusters()
   if (clusters.length === 0) return []
-  const accumulated: PodIssue[] = []
 
   const tasks = clusters.map(({ name, context }) => async () => {
     const ctx = context || name
     const issues = await kubectlProxy.getPodIssues(ctx, namespace)
     // Always use the short name — kubectlProxy returns context path as cluster
-    const tagged = issues.map(i => ({ ...i, cluster: name }))
-    accumulated.push(...tagged)
-    onProgress?.([...accumulated])
-    return tagged
+    return issues.map(i => ({ ...i, cluster: name }))
   })
 
-  await settledWithConcurrency(tasks)
+  const settled = await settledWithConcurrency(tasks)
+  const accumulated: PodIssue[] = []
+  for (const result of settled) {
+    if (result.status === 'fulfilled') {
+      accumulated.push(...result.value)
+      onProgress?.([...accumulated])
+    }
+  }
   return accumulated
 }
 
@@ -351,7 +354,6 @@ async function fetchDeploymentsViaAgent(namespace?: string, onProgress?: (partia
   if (isAgentUnavailable()) return []
   const clusters = getAgentClusters()
   if (clusters.length === 0) return []
-  const accumulated: Deployment[] = []
 
   const tasks = clusters.map(({ name, context }) => async () => {
     const params = new URLSearchParams()
@@ -371,15 +373,19 @@ async function fetchDeploymentsViaAgent(namespace?: string, onProgress?: (partia
     const data = await response.json().catch(() => null)
     if (!data) throw new Error('Invalid JSON response from agent')
     // Always use the short name — agent echoes back context path as cluster
-    const tagged = ((data.deployments || []) as Deployment[]).map(d => ({
+    return ((data.deployments || []) as Deployment[]).map(d => ({
       ...d,
       cluster: name }))
-    accumulated.push(...tagged)
-    onProgress?.([...accumulated])
-    return tagged
   })
 
-  await settledWithConcurrency(tasks)
+  const settled = await settledWithConcurrency(tasks)
+  const accumulated: Deployment[] = []
+  for (const result of settled) {
+    if (result.status === 'fulfilled') {
+      accumulated.push(...result.value)
+      onProgress?.([...accumulated])
+    }
+  }
   return accumulated
 }
 
@@ -925,7 +931,6 @@ async function fetchWorkloadsFromAgent(onProgress?: (partial: Workload[]) => voi
   const clusters = clusterCacheRef.clusters
     .filter(c => c.reachable !== false && !c.name.includes('/'))
   if (clusters.length === 0) return null
-  const accumulated: Workload[] = []
 
   const tasks = clusters.map(({ name, context }) => async () => {
     const params = new URLSearchParams()
@@ -941,7 +946,7 @@ async function fetchWorkloadsFromAgent(onProgress?: (partial: Workload[]) => voi
     if (!res.ok) throw new Error(`Agent ${res.status}`)
     const data = await res.json().catch(() => null)
     if (!data) throw new Error('Invalid JSON response from agent')
-    const tagged = ((data.deployments || []) as Array<Record<string, unknown>>).map(d => {
+    return ((data.deployments || []) as Array<Record<string, unknown>>).map(d => {
       const st = String(d.status || 'running')
       let ws: Workload['status'] = 'Running'
       if (st === 'failed') ws = 'Failed'
@@ -959,12 +964,16 @@ async function fetchWorkloadsFromAgent(onProgress?: (partial: Workload[]) => voi
         image: String(d.image || ''),
         createdAt: new Date().toISOString() }
     })
-    accumulated.push(...tagged)
-    onProgress?.([...accumulated])
-    return tagged
   })
 
-  await settledWithConcurrency(tasks)
+  const settled = await settledWithConcurrency(tasks)
+  const accumulated: Workload[] = []
+  for (const result of settled) {
+    if (result.status === 'fulfilled') {
+      accumulated.push(...result.value)
+      onProgress?.([...accumulated])
+    }
+  }
   return accumulated.length > 0 ? accumulated : null
 }
 
@@ -1053,7 +1062,6 @@ async function fetchSecurityIssuesViaKubectl(cluster?: string, namespace?: strin
   if (clusters.length === 0) return []
 
   const severityOrder: Record<string, number> = { critical: 0, high: 1, medium: 2, low: 3, info: 4 }
-  const accumulated: SecurityIssue[] = []
 
   const tasks = clusters
     .filter(c => !cluster || c.name === cluster)
@@ -1123,14 +1131,18 @@ async function fetchSecurityIssuesViaKubectl(cluster?: string, namespace?: strin
         }
       }
 
-      accumulated.push(...issues)
-      // Sort accumulated and report progress
-      accumulated.sort((a, b) => (severityOrder[a.severity] || 5) - (severityOrder[b.severity] || 5))
-      onProgress?.([...accumulated])
       return issues
     })
 
-  await settledWithConcurrency(tasks)
+  const settled = await settledWithConcurrency(tasks)
+  const accumulated: SecurityIssue[] = []
+  for (const result of settled) {
+    if (result.status === 'fulfilled') {
+      accumulated.push(...result.value)
+      accumulated.sort((a, b) => (severityOrder[a.severity] || 5) - (severityOrder[b.severity] || 5))
+      onProgress?.([...accumulated])
+    }
+  }
   // Final sort
   return accumulated.sort((a, b) => (severityOrder[a.severity] || 5) - (severityOrder[b.severity] || 5))
 }

--- a/web/src/hooks/useCachedLLMd.ts
+++ b/web/src/hooks/useCachedLLMd.ts
@@ -394,8 +394,6 @@ export async function fetchLLMdModels(
   onProgress?: (partial: LLMdModel[]) => void
 ): Promise<LLMdModel[]> {
   // useCache prevents calling fetchers in demo mode via effectiveEnabled
-  const accumulated: LLMdModel[] = []
-
   const tasks = clusters.map((cluster) => async () => {
     try {
       const response = await kubectlProxy.exec(['get', 'inferencepools', '-A', '-o', 'json'], { context: cluster, timeout: KUBECTL_EXTENDED_TIMEOUT_MS })
@@ -413,8 +411,6 @@ export async function fetchLLMdModels(
           status: hasAccepted ? 'loaded' : 'stopped',
         })
       }
-      accumulated.push(...clusterModels)
-      onProgress?.([...accumulated])
       return clusterModels
     } catch (err) {
       // Suppress demo mode errors - they're expected when agent is unavailable
@@ -426,7 +422,14 @@ export async function fetchLLMdModels(
     }
   })
 
-  await settledWithConcurrency(tasks)
+  const settled = await settledWithConcurrency(tasks)
+  const accumulated: LLMdModel[] = []
+  for (const result of settled) {
+    if (result.status === 'fulfilled') {
+      accumulated.push(...result.value)
+      onProgress?.([...accumulated])
+    }
+  }
   return accumulated
 }
 

--- a/web/src/hooks/useMissions.test.tsx
+++ b/web/src/hooks/useMissions.test.tsx
@@ -108,6 +108,7 @@ const defaultParams = {
   description: 'Pod crash investigation',
   type: 'troubleshoot' as const,
   initialPrompt: 'Fix the pod crash',
+  skipReview: true,
 }
 
 /** Start a mission and simulate the WebSocket opening so the mission moves to 'running'. */

--- a/web/src/test/concurrent-mutation-safety.test.ts
+++ b/web/src/test/concurrent-mutation-safety.test.ts
@@ -435,6 +435,11 @@ describe('Concurrent Mutation Safety Scan', () => {
   })
 
   describe('Shared mutation detection per file', () => {
+    if (violationsByFile.size === 0) {
+      it('no shared mutations detected', () => {
+        expect(violationsByFile.size).toBe(0)
+      })
+    }
     for (const [rel, fileViolations] of violationsByFile) {
       it(`${rel}: shared mutations inside concurrency callbacks`, () => {
         if (KNOWN_VIOLATIONS[rel]) return // grandfathered


### PR DESCRIPTION
Closes #6924

## Summary
- **158 useMissions.test.tsx failures**: PR #6920 added a `skipReview` gate to `startMission` that stashes params into `pendingReview` state instead of creating missions when `skipReview` is not set. Test `defaultParams` did not include `skipReview: true`, so all missions silently returned empty string without being created. Fixed by adding `skipReview: true` to `defaultParams`.
- **2 cache test failures** (useKubescape, useTrivy): PR #6920 refactored these hooks to consume `Promise.allSettled`-shaped results (`{status, value}`) from `settledWithConcurrency`, but the test mocks still used `Promise.all` (which returns plain values). Fixed by updating mocks to `Promise.allSettled`.
- **3 concurrent-mutation-safety failures**: 4 functions in `useCachedData.ts` and 1 in `useCachedLLMd.ts` still mutated a shared `accumulated` array inside `settledWithConcurrency` callbacks. Refactored all 5 to return values from callbacks and aggregate after settlement. Also added empty-suite guard for when zero violations exist.

## Root cause
All regressions trace to PR #6920 (`8f6ed485`), not PR #6923 as initially suspected. PR #6923 only made localized AlertsContext test changes.

## Test plan
- [x] `npx vitest run` — 759 files passed, 15,192 tests passed, 0 failures
- [x] `npx vitest run src/hooks/useMissions.test.tsx` — 282/282 passed
- [x] `npx vitest run src/hooks/__tests__/useKubescape.test.ts` — 42/42 passed
- [x] `npx vitest run src/hooks/__tests__/useTrivy.test.ts` — 44/44 passed
- [x] `npx vitest run src/test/concurrent-mutation-safety.test.ts` — 7/7 passed