### PR TITLE
fix(reconcile): phase enum, error sanitize, timeout, test isolation (#6935)

### DIFF
--- a/pkg/api/handlers/console_persistence.go
+++ b/pkg/api/handlers/console_persistence.go
@@ -769,8 +769,14 @@ func (h *ConsolePersistenceHandlers) CreateWorkloadDeployment(c *fiber.Ctx) erro
 	}
 
 	// Kick off reconciliation in a background goroutine. Use a detached
-	// context so reconciliation survives after the HTTP response is sent.
-	go h.reconcileDeployment(context.Background(), created)
+	// context with a timeout so reconciliation survives after the HTTP
+	// response is sent but cannot block indefinitely.
+	const reconcileTimeout = 5 * time.Minute // max wall-clock for full reconciliation
+	reconcileCtx, reconcileCancel := context.WithTimeout(context.Background(), reconcileTimeout)
+	go func() {
+		defer reconcileCancel()
+		h.reconcileDeployment(reconcileCtx, created)
+	}()
 
 	return c.Status(201).JSON(created)
 }
@@ -849,13 +855,13 @@ func (h *ConsolePersistenceHandlers) DeleteWorkloadDeployment(c *fiber.Ctx) erro
 //  2. Resolves target clusters (from targetGroupRef or targetClusters)
 //  3. Deploys manifests to each target cluster via the multi-cluster client
 //  4. Updates WorkloadDeployment.Status with per-cluster progress
-//  5. Re-queues on transient errors with bounded retries
-//  6. Persists terminal state (Succeeded / Failed)
+//  5. Persists terminal state (Complete / Failed) — no retry on failure
 func (h *ConsolePersistenceHandlers) reconcileDeployment(ctx context.Context, wd *v1alpha1.WorkloadDeployment) {
 	slog.Info("[ConsolePersistence] reconciling deployment",
 		"namespace", wd.Namespace, "name", wd.Name)
 
-	// Helper: persist status update, logging on error.
+	// Helper: persist status update, logging on error. Captures the returned
+	// resourceVersion so subsequent updates don't conflict.
 	updateStatus := func(wd *v1alpha1.WorkloadDeployment) {
 		client, _, err := h.persistenceStore.GetActiveClient(ctx)
 		if err != nil {
@@ -863,10 +869,15 @@ func (h *ConsolePersistenceHandlers) reconcileDeployment(ctx context.Context, wd
 			return
 		}
 		persistence := k8s.NewConsolePersistence(client)
-		if _, err := persistence.UpdateWorkloadDeploymentStatus(ctx, wd); err != nil {
+		updated, err := persistence.UpdateWorkloadDeploymentStatus(ctx, wd)
+		if err != nil {
 			slog.Error("[reconcile] failed to update deployment status",
 				"name", wd.Name, "error", err)
+			return
 		}
+		// Propagate the new resourceVersion so the next update won't hit a
+		// 409 Conflict from the API server.
+		wd.ResourceVersion = updated.ResourceVersion
 	}
 
 	// Transition to InProgress
@@ -909,6 +920,12 @@ func (h *ConsolePersistenceHandlers) reconcileDeployment(ctx context.Context, wd
 	updateStatus(wd)
 
 	// ---- Step 3: Deploy to each target cluster ----
+	if h.k8sClient == nil {
+		slog.Error("[reconcile] k8sClient is nil, cannot deploy workload", "name", wd.Name)
+		h.setTerminalStatus(wd, "Failed", "Internal error: multi-cluster client not configured", updateStatus)
+		return
+	}
+
 	ref := workload.Spec.WorkloadRef
 	replicas := int32(0)
 	if workload.Spec.Replicas != nil {
@@ -964,10 +981,10 @@ func (h *ConsolePersistenceHandlers) reconcileDeployment(ctx context.Context, wd
 			cs.Phase = "Failed"
 			cs.Progress = "0%"
 			if err != nil {
-				cs.Message = err.Error()
-			} else {
-				cs.Message = "Deployment failed"
+				slog.Error("[reconcile] cluster deployment failed",
+					"cluster", cs.Cluster, "name", wd.Name, "error", err)
 			}
+			cs.Message = "Deployment failed"
 			failedCount++
 		} else {
 			// Not in either list — mark as skipped
@@ -980,7 +997,7 @@ func (h *ConsolePersistenceHandlers) reconcileDeployment(ctx context.Context, wd
 
 	// ---- Step 5: Determine terminal phase ----
 	if failedCount == 0 {
-		h.setTerminalStatus(wd, "Succeeded",
+		h.setTerminalStatus(wd, "Complete",
 			fmt.Sprintf("All %d clusters deployed successfully", succeededCount), updateStatus)
 	} else if succeededCount > 0 {
 		// Partial success — still mark as Failed so clients know action is needed,
@@ -988,15 +1005,16 @@ func (h *ConsolePersistenceHandlers) reconcileDeployment(ctx context.Context, wd
 		h.setTerminalStatus(wd, "Failed",
 			fmt.Sprintf("Partial deployment: %d succeeded, %d failed", succeededCount, failedCount), updateStatus)
 	} else {
-		msg := fmt.Sprintf("All %d clusters failed", failedCount)
 		if err != nil {
-			msg = fmt.Sprintf("All %d clusters failed: %v", failedCount, err)
+			slog.Error("[reconcile] all clusters failed",
+				"name", wd.Name, "failedCount", failedCount, "error", err)
 		}
-		h.setTerminalStatus(wd, "Failed", msg, updateStatus)
+		h.setTerminalStatus(wd, "Failed",
+			fmt.Sprintf("All %d clusters failed", failedCount), updateStatus)
 	}
 }
 
-// setTerminalStatus sets the deployment to a terminal phase (Succeeded/Failed),
+// setTerminalStatus sets the deployment to a terminal phase (Complete/Failed),
 // records a completion timestamp and a history entry, then persists the status.
 func (h *ConsolePersistenceHandlers) setTerminalStatus(
 	wd *v1alpha1.WorkloadDeployment,

--- a/pkg/api/handlers/reconcile_deployment_test.go
+++ b/pkg/api/handlers/reconcile_deployment_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 
 	"github.com/kubestellar/console/pkg/api/v1alpha1"
-	"github.com/kubestellar/console/pkg/k8s"
 	"github.com/kubestellar/console/pkg/store"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -28,12 +27,13 @@ func setupReconcileEnv(t *testing.T, persistenceObjects ...runtime.Object) (*Con
 	// Build a persistence store that points at "persist-cluster"
 	configPath := filepath.Join(t.TempDir(), "persistence.json")
 	ps := store.NewPersistenceStore(configPath)
-	_ = ps.UpdateConfig(store.PersistenceConfig{
+	err := ps.UpdateConfig(store.PersistenceConfig{
 		Enabled:        true,
 		PrimaryCluster: "persist-cluster",
 		Namespace:      "test-ns",
 		SyncMode:       "primary-only",
 	})
+	require.NoError(t, err)
 	// Wire the client factory to return our fake dynamic client
 	ps.SetClientFactory(func(_ string) (dynamic.Interface, *rest.Config, error) {
 		return fakeDyn, nil, nil
@@ -42,12 +42,12 @@ func setupReconcileEnv(t *testing.T, persistenceObjects ...runtime.Object) (*Con
 		return store.ClusterHealthHealthy
 	})
 
-	// Build a MultiClusterClient (used for the actual deployment step)
-	k8sClient, _ := k8s.NewMultiClusterClient("")
-
+	// k8sClient is nil for unit tests — reconciliation tests exercise the
+	// error/failure paths that result from a nil client, avoiding any
+	// dependency on a real kubeconfig or live cluster.
 	h := &ConsolePersistenceHandlers{
 		persistenceStore: ps,
-		k8sClient:        k8sClient,
+		k8sClient:        nil,
 	}
 
 	return h, fakeDyn
@@ -260,9 +260,9 @@ func TestReconcileDeployment_WorkloadNotFound(t *testing.T) {
 	assert.Contains(t, wd.Status.History[0].Message, "ManagedWorkload")
 }
 
-func TestReconcileDeployment_DeployFailsAllClusters(t *testing.T) {
-	// When the source cluster is unreachable, DeployWorkload fails and all
-	// target clusters should be marked Failed.
+func TestReconcileDeployment_DeployFailsNilClient(t *testing.T) {
+	// When k8sClient is nil (no kubeconfig available), reconciliation should
+	// mark the deployment Failed without panicking.
 	mw := &v1alpha1.ManagedWorkload{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: v1alpha1.GroupVersion.String(),
@@ -302,12 +302,7 @@ func TestReconcileDeployment_DeployFailsAllClusters(t *testing.T) {
 
 	assert.Equal(t, "Failed", wd.Status.Phase)
 	assert.NotNil(t, wd.Status.CompletedAt)
-	// Should have per-cluster statuses
-	assert.Len(t, wd.Status.ClusterStatuses, 2)
-	for _, cs := range wd.Status.ClusterStatuses {
-		assert.Equal(t, "Failed", cs.Phase)
-	}
-	assert.Equal(t, "0/2 clusters", wd.Status.Progress)
+	assert.Contains(t, wd.Status.History[0].Message, "multi-cluster client not configured")
 }
 
 func TestSetTerminalStatus(t *testing.T) {
@@ -327,10 +322,10 @@ func TestSetTerminalStatus(t *testing.T) {
 		updateCalled = true
 	}
 
-	h.setTerminalStatus(wd, "Succeeded", "All done", updateFn)
+	h.setTerminalStatus(wd, "Complete", "All done", updateFn)
 
 	assert.True(t, updateCalled)
-	assert.Equal(t, "Succeeded", wd.Status.Phase)
+	assert.Equal(t, "Complete", wd.Status.Phase)
 	assert.NotNil(t, wd.Status.CompletedAt)
 	assert.Len(t, wd.Status.History, 1)
 	assert.Equal(t, 1, wd.Status.History[0].Revision)


### PR DESCRIPTION
Closes #6935

## Summary

Addresses all 8 Copilot review comments from PR #6934 (WorkloadDeployment reconciliation loop):

1. **Phase "Succeeded" -> "Complete"**: Aligned with CRD enum `{Pending, InProgress, Paused, Complete, Failed, Cancelled}`
2. **Error leak in ClusterStatuses[].message**: Replaced `err.Error()` with generic `"Deployment failed"`; full error logged server-side
3. **Docstring accuracy**: Removed false claim about retry/requeue; now documents "no retry -- marks Failed immediately"
4. **context.Background() timeout**: Added `context.WithTimeout` with named `reconcileTimeout` constant (5 min)
5. **Test uses real kubeconfig**: Set `k8sClient` to nil; added nil guard in `reconcileDeployment` to fail gracefully
6. **Test ignores UpdateConfig error**: Added `require.NoError(t, err)`
7. **Test asserts "Succeeded"**: Updated to `"Complete"`
8. **updateStatus ignores resourceVersion**: Now captures returned object and propagates `ResourceVersion` to `wd`

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./pkg/api/handlers/...` passes
- [x] `go vet ./...` passes