### PR TITLE
fix(reconcile): detach status ctx, consistent failure status, test coverage (#6937)

### DIFF
--- a/pkg/api/handlers/console_persistence.go
+++ b/pkg/api/handlers/console_persistence.go
@@ -17,6 +17,14 @@ import (
 	"k8s.io/client-go/rest"
 )
 
+// workloadDeployer abstracts the DeployWorkload call so reconciliation can be
+// tested with a fake deployer that returns per-cluster failures.
+type workloadDeployer interface {
+	DeployWorkload(ctx context.Context, sourceCluster, namespace, name string,
+		targetClusters []string, replicas int32, opts *k8s.DeployOptions,
+	) (*v1alpha1.DeployResponse, error)
+}
+
 // ConsolePersistenceHandlers handles console persistence API endpoints
 type ConsolePersistenceHandlers struct {
 	persistenceStore *store.PersistenceStore
@@ -24,6 +32,9 @@ type ConsolePersistenceHandlers struct {
 	watcher          *k8s.ConsoleWatcher
 	hub              *Hub
 	userStore        store.Store
+	// deployer is used by reconcileDeployment. When nil, k8sClient is used.
+	// Tests can inject a fake to exercise per-cluster failure paths.
+	deployer workloadDeployer
 }
 
 // NewConsolePersistenceHandlers creates a new console persistence handlers instance
@@ -860,16 +871,20 @@ func (h *ConsolePersistenceHandlers) reconcileDeployment(ctx context.Context, wd
 	slog.Info("[ConsolePersistence] reconciling deployment",
 		"namespace", wd.Namespace, "name", wd.Name)
 
+	// statusCtx is decoupled from the reconcile context so that status writes
+	// succeed even when reconcileCtx times out or is cancelled.
+	statusCtx := context.WithoutCancel(ctx)
+
 	// Helper: persist status update, logging on error. Captures the returned
 	// resourceVersion so subsequent updates don't conflict.
 	updateStatus := func(wd *v1alpha1.WorkloadDeployment) {
-		client, _, err := h.persistenceStore.GetActiveClient(ctx)
+		client, _, err := h.persistenceStore.GetActiveClient(statusCtx)
 		if err != nil {
 			slog.Error("[reconcile] failed to get client for status update", "error", err)
 			return
 		}
 		persistence := k8s.NewConsolePersistence(client)
-		updated, err := persistence.UpdateWorkloadDeploymentStatus(ctx, wd)
+		updated, err := persistence.UpdateWorkloadDeploymentStatus(statusCtx, wd)
 		if err != nil {
 			slog.Error("[reconcile] failed to update deployment status",
 				"name", wd.Name, "error", err)
@@ -920,8 +935,21 @@ func (h *ConsolePersistenceHandlers) reconcileDeployment(ctx context.Context, wd
 	updateStatus(wd)
 
 	// ---- Step 3: Deploy to each target cluster ----
-	if h.k8sClient == nil {
+	deployer := h.deployer
+	if deployer == nil && h.k8sClient != nil {
+		deployer = h.k8sClient
+	}
+	if deployer == nil {
 		slog.Error("[reconcile] k8sClient is nil, cannot deploy workload", "name", wd.Name)
+		// Mark every cluster as Failed so ClusterStatuses are consistent with
+		// the terminal Failed phase (not left in Pending).
+		now := metav1.Now()
+		for i := range wd.Status.ClusterStatuses {
+			wd.Status.ClusterStatuses[i].Phase = "Failed"
+			wd.Status.ClusterStatuses[i].Message = "Multi-cluster client not configured"
+			wd.Status.ClusterStatuses[i].CompletedAt = &now
+		}
+		wd.Status.Progress = fmt.Sprintf("0/%d clusters", len(targets))
 		h.setTerminalStatus(wd, "Failed", "Internal error: multi-cluster client not configured", updateStatus)
 		return
 	}
@@ -936,7 +964,7 @@ func (h *ConsolePersistenceHandlers) reconcileDeployment(ctx context.Context, wd
 		DeployedBy: "console-reconciler",
 	}
 
-	result, err := h.k8sClient.DeployWorkload(
+	result, err := deployer.DeployWorkload(
 		ctx,
 		workload.Spec.SourceCluster,
 		workload.Spec.SourceNamespace,

--- a/pkg/api/handlers/reconcile_deployment_test.go
+++ b/pkg/api/handlers/reconcile_deployment_test.go
@@ -2,10 +2,12 @@ package handlers
 
 import (
 	"context"
+	"fmt"
 	"path/filepath"
 	"testing"
 
 	"github.com/kubestellar/console/pkg/api/v1alpha1"
+	"github.com/kubestellar/console/pkg/k8s"
 	"github.com/kubestellar/console/pkg/store"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -303,6 +305,152 @@ func TestReconcileDeployment_DeployFailsNilClient(t *testing.T) {
 	assert.Equal(t, "Failed", wd.Status.Phase)
 	assert.NotNil(t, wd.Status.CompletedAt)
 	assert.Contains(t, wd.Status.History[0].Message, "multi-cluster client not configured")
+
+	// Verify per-cluster statuses are Failed, not left in Pending (#6937).
+	require.Len(t, wd.Status.ClusterStatuses, 2)
+	for _, cs := range wd.Status.ClusterStatuses {
+		assert.Equal(t, "Failed", cs.Phase, "cluster %s should be Failed", cs.Cluster)
+		assert.NotNil(t, cs.CompletedAt, "cluster %s should have CompletedAt", cs.Cluster)
+		assert.Contains(t, cs.Message, "not configured")
+	}
+	assert.Equal(t, "0/2 clusters", wd.Status.Progress)
+}
+
+// fakeDeployer implements workloadDeployer for testing per-cluster failure paths.
+type fakeDeployer struct {
+	resp *v1alpha1.DeployResponse
+	err  error
+}
+
+func (f *fakeDeployer) DeployWorkload(_ context.Context, _, _, _ string,
+	_ []string, _ int32, _ *k8s.DeployOptions,
+) (*v1alpha1.DeployResponse, error) {
+	return f.resp, f.err
+}
+
+func TestReconcileDeployment_DeployPerClusterFailures(t *testing.T) {
+	// When DeployWorkload returns per-cluster failures, each ClusterStatus
+	// must reflect the failure and the overall phase should be Failed.
+	mw := &v1alpha1.ManagedWorkload{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: v1alpha1.GroupVersion.String(),
+			Kind:       "ManagedWorkload",
+		},
+		ObjectMeta: metav1.ObjectMeta{Name: "my-app", Namespace: "test-ns"},
+		Spec: v1alpha1.ManagedWorkloadSpec{
+			SourceCluster:   "source-cluster",
+			SourceNamespace: "default",
+			WorkloadRef: v1alpha1.WorkloadReference{
+				Kind: "Deployment",
+				Name: "nginx",
+			},
+		},
+	}
+	mwU, _ := mw.ToUnstructured()
+
+	wd := &v1alpha1.WorkloadDeployment{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: v1alpha1.GroupVersion.String(),
+			Kind:       "WorkloadDeployment",
+		},
+		ObjectMeta: metav1.ObjectMeta{Name: "wd-partial", Namespace: "test-ns"},
+		Spec: v1alpha1.WorkloadDeploymentSpec{
+			WorkloadRef:    v1alpha1.ResourceReference{Name: "my-app"},
+			TargetClusters: []string{"cluster-ok", "cluster-fail"},
+		},
+		Status: v1alpha1.WorkloadDeploymentStatus{
+			Phase: "Pending",
+		},
+	}
+	wdU, _ := wd.ToUnstructured()
+
+	h, _ := setupReconcileEnv(t, mwU, wdU)
+
+	// Inject a fake deployer that reports cluster-fail as failed.
+	h.deployer = &fakeDeployer{
+		resp: &v1alpha1.DeployResponse{
+			DeployedTo:     []string{"cluster-ok"},
+			FailedClusters: []string{"cluster-fail"},
+		},
+		err: fmt.Errorf("partial failure"),
+	}
+
+	h.reconcileDeployment(context.Background(), wd)
+
+	// Overall should be Failed (partial).
+	assert.Equal(t, "Failed", wd.Status.Phase)
+	assert.NotNil(t, wd.Status.CompletedAt)
+	assert.Contains(t, wd.Status.History[0].Message, "1 succeeded")
+	assert.Contains(t, wd.Status.History[0].Message, "1 failed")
+
+	// Per-cluster statuses
+	require.Len(t, wd.Status.ClusterStatuses, 2)
+	statusMap := make(map[string]v1alpha1.ClusterRolloutStatus)
+	for _, cs := range wd.Status.ClusterStatuses {
+		statusMap[cs.Cluster] = cs
+	}
+	assert.Equal(t, "Complete", statusMap["cluster-ok"].Phase)
+	assert.Equal(t, "Failed", statusMap["cluster-fail"].Phase)
+	assert.Equal(t, "1/2 clusters", wd.Status.Progress)
+}
+
+func TestReconcileDeployment_DeployAllClustersFail(t *testing.T) {
+	// When DeployWorkload returns an error with no result, all clusters
+	// should be marked Failed.
+	mw := &v1alpha1.ManagedWorkload{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: v1alpha1.GroupVersion.String(),
+			Kind:       "ManagedWorkload",
+		},
+		ObjectMeta: metav1.ObjectMeta{Name: "my-app", Namespace: "test-ns"},
+		Spec: v1alpha1.ManagedWorkloadSpec{
+			SourceCluster:   "source-cluster",
+			SourceNamespace: "default",
+			WorkloadRef: v1alpha1.WorkloadReference{
+				Kind: "Deployment",
+				Name: "nginx",
+			},
+		},
+	}
+	mwU, _ := mw.ToUnstructured()
+
+	wd := &v1alpha1.WorkloadDeployment{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: v1alpha1.GroupVersion.String(),
+			Kind:       "WorkloadDeployment",
+		},
+		ObjectMeta: metav1.ObjectMeta{Name: "wd-allfail", Namespace: "test-ns"},
+		Spec: v1alpha1.WorkloadDeploymentSpec{
+			WorkloadRef:    v1alpha1.ResourceReference{Name: "my-app"},
+			TargetClusters: []string{"cluster-a", "cluster-b"},
+		},
+		Status: v1alpha1.WorkloadDeploymentStatus{
+			Phase: "Pending",
+		},
+	}
+	wdU, _ := wd.ToUnstructured()
+
+	h, _ := setupReconcileEnv(t, mwU, wdU)
+
+	// Inject a fake deployer that fails entirely (nil result).
+	h.deployer = &fakeDeployer{
+		resp: nil,
+		err:  fmt.Errorf("source cluster unreachable"),
+	}
+
+	h.reconcileDeployment(context.Background(), wd)
+
+	assert.Equal(t, "Failed", wd.Status.Phase)
+	assert.NotNil(t, wd.Status.CompletedAt)
+	assert.Contains(t, wd.Status.History[0].Message, "All 2 clusters failed")
+
+	// Every cluster must be Failed, not Pending.
+	require.Len(t, wd.Status.ClusterStatuses, 2)
+	for _, cs := range wd.Status.ClusterStatuses {
+		assert.Equal(t, "Failed", cs.Phase, "cluster %s should be Failed", cs.Cluster)
+		assert.NotNil(t, cs.CompletedAt, "cluster %s should have CompletedAt", cs.Cluster)
+	}
+	assert.Equal(t, "0/2 clusters", wd.Status.Progress)
 }
 
 func TestSetTerminalStatus(t *testing.T) {


### PR DESCRIPTION
Closes #6937

## Summary

Addresses 3 Copilot review comments from merged PR #6936:

1. **Status context detached from reconcile context** — `updateStatus` now uses `context.WithoutCancel(ctx)` so status persistence succeeds even when the reconcile context times out or is cancelled.

2. **Nil k8sClient sets ClusterStatuses to Failed** — When `k8sClient` is nil, every `ClusterStatus` is now explicitly set to `Failed` with a message before calling `setTerminalStatus`, preventing an inconsistent state where the overall phase is Failed but per-cluster statuses remain Pending.

3. **New per-cluster failure tests** — Introduced a `workloadDeployer` interface and `fakeDeployer` test double. Two new tests exercise partial and total cluster failure paths, verifying `ClusterStatuses`, `Progress`, and `History` are all set correctly. The existing nil-client test now also asserts on per-cluster statuses.

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./pkg/api/handlers/...` — all reconcile tests pass
- [x] `go vet ./...` clean