### PR TITLE
test(auth): contract tests to prevent /auth/refresh response regression

### DIFF
--- a/pkg/api/handlers/auth_contract_test.go
+++ b/pkg/api/handlers/auth_contract_test.go
@@ -1,0 +1,95 @@
+package handlers
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/kubestellar/console/pkg/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestAuthRefreshContract_TokenInResponseBody is a CONTRACT test.
+// The AuthCallback frontend component requires the "token" field in
+// the /auth/refresh response. Removing it breaks OAuth login.
+// See: commit 25e464fa (broke it), commit be946db9 (fixed it).
+// DO NOT remove this test without updating AuthCallback.tsx.
+func TestAuthRefreshContract_TokenInResponseBody(t *testing.T) {
+	app, mockStore, handler := setupAuthTest()
+	app.Post("/auth/refresh", handler.RefreshToken)
+
+	// 1. Create a mock user and generate a valid JWT.
+	uid := uuid.New()
+	user := &models.User{ID: uid, GitHubLogin: "contract-test-user", Onboarded: true}
+	token, err := handler.generateJWT(user)
+	require.NoError(t, err, "generateJWT must succeed")
+
+	// 2. Setup mock: GetUser returns the user.
+	mockStore.On("GetUser", uid).Return(user, nil).Once()
+
+	// 3. POST /auth/refresh with Authorization header + CSRF header.
+	req := refreshReq("Bearer " + token)
+	resp, err := app.Test(req, 5000)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, resp.StatusCode,
+		"refresh must return 200 for a valid token")
+
+	// 4. Decode and validate the response body.
+	var body map[string]interface{}
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&body),
+		"response body must be valid JSON")
+
+	// CONTRACT: "token" field must be present and non-empty.
+	// AuthCallback.tsx does: const token = data.token
+	// If this assertion fails, OAuth login is broken.
+	tokenVal, hasToken := body["token"]
+	assert.True(t, hasToken,
+		"CONTRACT VIOLATION: response must contain 'token' field — "+
+			"AuthCallback.tsx depends on it for OAuth login")
+	tokenStr, ok := tokenVal.(string)
+	assert.True(t, ok && tokenStr != "",
+		"CONTRACT VIOLATION: 'token' must be a non-empty string")
+
+	// CONTRACT: "onboarded" field must be present and boolean.
+	// AuthCallback.tsx does: const isOnboarded = data.onboarded ?? onboarded
+	onboardedVal, hasOnboarded := body["onboarded"]
+	assert.True(t, hasOnboarded,
+		"CONTRACT VIOLATION: response must contain 'onboarded' field — "+
+			"AuthCallback.tsx depends on it")
+	_, isBool := onboardedVal.(bool)
+	assert.True(t, isBool,
+		"CONTRACT VIOLATION: 'onboarded' must be a boolean")
+}
+
+// TestAuthRefreshContract_OnboardedFalse verifies the contract holds when
+// the user has NOT completed onboarding (onboarded=false).
+func TestAuthRefreshContract_OnboardedFalse(t *testing.T) {
+	app, mockStore, handler := setupAuthTest()
+	app.Post("/auth/refresh", handler.RefreshToken)
+
+	uid := uuid.New()
+	user := &models.User{ID: uid, GitHubLogin: "new-user", Onboarded: false}
+	token, err := handler.generateJWT(user)
+	require.NoError(t, err)
+
+	mockStore.On("GetUser", uid).Return(user, nil).Once()
+
+	req := refreshReq("Bearer " + token)
+	resp, err := app.Test(req, 5000)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	var body map[string]interface{}
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&body))
+
+	// Token must still be present regardless of onboarded status.
+	tokenVal, hasToken := body["token"]
+	assert.True(t, hasToken, "token must be in response even when onboarded=false")
+	tokenStr, ok := tokenVal.(string)
+	assert.True(t, ok && tokenStr != "", "token must be non-empty")
+
+	assert.Equal(t, false, body["onboarded"],
+		"onboarded must reflect user's actual status")
+}

--- a/web/src/components/auth/__tests__/AuthCallback.contract.test.tsx
+++ b/web/src/components/auth/__tests__/AuthCallback.contract.test.tsx
@@ -1,0 +1,172 @@
+/**
+ * AuthCallback CONTRACT tests
+ *
+ * These tests verify that AuthCallback correctly handles the /auth/refresh
+ * response contract. The backend MUST return { token: string, onboarded: boolean }
+ * for OAuth login to work.
+ *
+ * See: commit 25e464fa (broke the contract), commit be946db9 (restored it).
+ * DO NOT remove these tests without also updating the backend RefreshToken handler.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, waitFor } from '@testing-library/react'
+import { MemoryRouter, Routes, Route } from 'react-router-dom'
+import type { ReactNode } from 'react'
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+const mockNavigate = vi.fn()
+const mockSetToken = vi.fn()
+const mockRefreshUser = vi.fn().mockResolvedValue(undefined)
+const mockShowToast = vi.fn()
+
+vi.mock('react-router-dom', async (importOriginal) => {
+  const actual = await importOriginal() as Record<string, unknown>
+  return {
+    ...actual,
+    useNavigate: () => mockNavigate,
+  }
+})
+
+vi.mock('../../../lib/auth', () => ({
+  useAuth: () => ({
+    setToken: mockSetToken,
+    refreshUser: mockRefreshUser,
+  }),
+}))
+
+vi.mock('../../ui/Toast', () => ({
+  useToast: () => ({ showToast: mockShowToast }),
+}))
+
+vi.mock('../../../hooks/useLastRoute', () => ({
+  getLastRoute: () => null,
+}))
+
+vi.mock('../../../config/routes', () => ({
+  ROUTES: { HOME: '/' },
+  getLoginWithError: (err: string) => `/login?error=${err}`,
+}))
+
+vi.mock('../../../lib/analytics', () => ({
+  emitGitHubConnected: vi.fn(),
+}))
+
+vi.mock('../../../lib/utils/localStorage', () => ({
+  safeGetItem: () => null,
+  safeRemoveItem: vi.fn(),
+}))
+
+// Must import AFTER mocks are set up
+import { AuthCallback } from '../AuthCallback'
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Render AuthCallback inside a MemoryRouter with optional search params */
+function renderAuthCallback(search = '') {
+  return render(
+    <MemoryRouter initialEntries={[`/auth/callback${search}`]}>
+      <Routes>
+        <Route path="/auth/callback" element={<AuthCallback />} />
+      </Routes>
+    </MemoryRouter>,
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Setup / Teardown
+// ---------------------------------------------------------------------------
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  // Reset the hasProcessed ref by clearing module state
+  vi.stubGlobal('fetch', vi.fn())
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('AuthCallback /auth/refresh contract', () => {
+  it('navigates to home when response has { token, onboarded: true }', async () => {
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ token: 'jwt-xxx', onboarded: true }),
+    })
+    vi.stubGlobal('fetch', mockFetch)
+
+    renderAuthCallback()
+
+    await waitFor(() => {
+      expect(mockSetToken).toHaveBeenCalledWith('jwt-xxx', true)
+    })
+
+    await waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalledWith('/')
+    })
+  })
+
+  it('navigates to login error when response has { refreshed: true } but no token', async () => {
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ refreshed: true }),
+    })
+    vi.stubGlobal('fetch', mockFetch)
+
+    renderAuthCallback()
+
+    await waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalledWith('/login?error=token_exchange_failed')
+    })
+  })
+
+  it('navigates to login error on 401 response', async () => {
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 401,
+    })
+    vi.stubGlobal('fetch', mockFetch)
+
+    renderAuthCallback()
+
+    await waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalledWith('/login?error=token_exchange_failed')
+    })
+  })
+
+  it('navigates to login error on 403 response', async () => {
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 403,
+    })
+    vi.stubGlobal('fetch', mockFetch)
+
+    renderAuthCallback()
+
+    await waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalledWith('/login?error=token_exchange_failed')
+    })
+  })
+
+  it('passes onboarded=false correctly when user is not onboarded', async () => {
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ token: 'jwt-new-user', onboarded: false }),
+    })
+    vi.stubGlobal('fetch', mockFetch)
+
+    renderAuthCallback()
+
+    await waitFor(() => {
+      expect(mockSetToken).toHaveBeenCalledWith('jwt-new-user', false)
+    })
+  })
+})

--- a/web/src/test/auth-contract.test.ts
+++ b/web/src/test/auth-contract.test.ts
@@ -1,0 +1,107 @@
+/**
+ * Cross-Stack Auth Contract Test
+ *
+ * Verifies that the Go backend and TypeScript frontend agree on the
+ * /auth/refresh response shape. If either side changes the field name,
+ * this test fails BEFORE the code ships.
+ *
+ * See: commit 25e464fa (broke the contract), commit be946db9 (fixed it).
+ * DO NOT remove this test without coordinating both sides.
+ *
+ * Run: npx vitest run src/test/auth-contract.test.ts
+ */
+import { describe, it, expect } from 'vitest'
+import * as fs from 'node:fs'
+import * as path from 'node:path'
+
+// ── Paths ───────────────────────────────────────────────────────────────────
+
+// process.cwd() is the web/ directory when vitest runs; go up one level.
+const REPO_ROOT = path.resolve(process.cwd(), '..')
+
+const AUTH_HANDLER_PATH = path.join(
+  REPO_ROOT,
+  'pkg/api/handlers/auth.go',
+)
+
+const AUTH_CALLBACK_PATH = path.join(
+  REPO_ROOT,
+  'web/src/components/auth/AuthCallback.tsx',
+)
+
+// ── Tests ───────────────────────────────────────────────────────────────────
+
+describe('Cross-stack /auth/refresh contract', () => {
+  it('both files exist', () => {
+    expect(
+      fs.existsSync(AUTH_HANDLER_PATH),
+      `Backend handler missing: ${AUTH_HANDLER_PATH}`,
+    ).toBe(true)
+    expect(
+      fs.existsSync(AUTH_CALLBACK_PATH),
+      `Frontend callback missing: ${AUTH_CALLBACK_PATH}`,
+    ).toBe(true)
+  })
+
+  it('backend RefreshToken returns "token" in the JSON response', () => {
+    const authGo = fs.readFileSync(AUTH_HANDLER_PATH, 'utf-8')
+
+    // The RefreshToken handler uses fiber.Map{ "token": newToken, ... }
+    // We verify the string "token" appears in a fiber.Map near RefreshToken.
+    const refreshFnStart = authGo.indexOf('func (h *AuthHandler) RefreshToken')
+    expect(refreshFnStart).toBeGreaterThan(-1)
+
+    // Grab the function body (until the next top-level func or EOF)
+    const afterFn = authGo.slice(refreshFnStart)
+    const nextFuncIdx = afterFn.indexOf('\nfunc ', 1)
+    const fnBody = nextFuncIdx > 0
+      ? afterFn.slice(0, nextFuncIdx)
+      : afterFn
+
+    // The response MUST include "token" in a fiber.Map
+    expect(
+      fnBody,
+      'CONTRACT VIOLATION: RefreshToken must return "token" in fiber.Map — ' +
+      'AuthCallback.tsx depends on data.token for OAuth login',
+    ).toMatch(/"token"/)
+  })
+
+  it('frontend AuthCallback reads data.token from the response', () => {
+    const callbackTsx = fs.readFileSync(AUTH_CALLBACK_PATH, 'utf-8')
+
+    // AuthCallback must reference data.token (the field from /auth/refresh)
+    expect(
+      callbackTsx,
+      'CONTRACT VIOLATION: AuthCallback must read data.token — ' +
+      'this is the JWT returned by /auth/refresh',
+    ).toMatch(/data\.token/)
+  })
+
+  it('frontend AuthCallback throws when token is missing', () => {
+    const callbackTsx = fs.readFileSync(AUTH_CALLBACK_PATH, 'utf-8')
+
+    // AuthCallback must have a guard like: if (!token) throw ...
+    // This ensures a missing token field is treated as an error, not silently ignored.
+    expect(
+      callbackTsx,
+      'AuthCallback must throw/reject when token is missing from response',
+    ).toMatch(/(!token|token.*throw|No token)/)
+  })
+
+  it('backend and frontend agree on the "onboarded" field', () => {
+    const authGo = fs.readFileSync(AUTH_HANDLER_PATH, 'utf-8')
+    const callbackTsx = fs.readFileSync(AUTH_CALLBACK_PATH, 'utf-8')
+
+    // Backend must include "onboarded" in the response
+    expect(
+      authGo,
+      'Backend must return "onboarded" in /auth/refresh response',
+    ).toMatch(/"onboarded"/)
+
+    // Frontend must read data.onboarded
+    expect(
+      callbackTsx,
+      'Frontend must read data.onboarded from /auth/refresh response',
+    ).toMatch(/data\.onboarded|\.onboarded/)
+  })
+})


### PR DESCRIPTION
## Summary

- Adds Go contract test (`auth_contract_test.go`) verifying `/auth/refresh` returns `token` (non-empty string) and `onboarded` (bool) in the response body
- Adds Vitest component test (`AuthCallback.contract.test.tsx`) verifying AuthCallback handles valid responses, missing tokens, 401, and 403 correctly
- Adds cross-stack file test (`auth-contract.test.ts`) that reads both `auth.go` and `AuthCallback.tsx` source files and asserts both sides reference the same contract fields

These three layers prevent regressions like commit `25e464fa` which removed the `token` field from the `/auth/refresh` response as a "security measure" but broke OAuth login for 24 hours (fixed in `be946db9`).

## Test plan

- [x] `go test ./pkg/api/handlers/... -run Contract -v` — 2 tests pass
- [x] `npx vitest run src/components/auth/__tests__/AuthCallback.contract.test.tsx` — 5 tests pass
- [x] `npx vitest run src/test/auth-contract.test.ts` — 5 tests pass
- [x] `npm run build` — clean build, no debug logging