### PR TITLE
fix(ui): add dark mode variants to 20 light-only components (#6939)

### DIFF
--- a/web/src/components/cards/CardChat.tsx
+++ b/web/src/components/cards/CardChat.tsx
@@ -206,7 +206,7 @@ export function CardChat({
                   {message.role === 'assistant' && (
                     <button
                       onClick={() => handleCopy(message.id, message.content)}
-                      className="p-1 rounded hover:bg-white/10"
+                      className="p-1 rounded hover:bg-black/10 dark:hover:bg-white/10"
                     >
                       {copiedId === message.id ? (
                         <CheckCircle className="w-3 h-3 text-green-400" />

--- a/web/src/components/cards/ClusterCosts.tsx
+++ b/web/src/components/cards/ClusterCosts.tsx
@@ -57,7 +57,7 @@ const SORT_OPTIONS_KEYS: ReadonlyArray<{ value: SortByOption; labelKey: SortTran
 
 // Cloud provider icons (simple text badges for now, could be SVG logos)
 const PROVIDER_ICONS: Record<CloudProvider, { color: string; bg: string; short: string }> = {
-  estimate: { color: 'text-muted-foreground', bg: 'bg-gray-500/20', short: 'EST' },
+  estimate: { color: 'text-muted-foreground', bg: 'bg-gray-500/20 dark:bg-gray-400/15', short: 'EST' },
   aws: { color: 'text-orange-400', bg: 'bg-orange-500/20', short: 'AWS' },
   gcp: { color: 'text-blue-400', bg: 'bg-blue-500/20', short: 'GCP' },
   azure: { color: 'text-blue-400', bg: 'bg-blue-500/20', short: 'AZR' },

--- a/web/src/components/cards/Game2048.tsx
+++ b/web/src/components/cards/Game2048.tsx
@@ -18,7 +18,7 @@ const TILE_COLORS: Record<number, { bg: string; text: string }> = {
   64: { bg: 'bg-cyan-600/80', text: 'text-white' },
   128: { bg: 'bg-green-500/80', text: 'text-white' },
   256: { bg: 'bg-green-600/80', text: 'text-white' },
-  512: { bg: 'bg-yellow-500/80', text: 'text-black' },
+  512: { bg: 'bg-yellow-500/80', text: 'text-black dark:text-black' },
   1024: { bg: 'bg-orange-500/80', text: 'text-white' },
   2048: { bg: 'bg-purple-500/80', text: 'text-white' },
   4096: { bg: 'bg-purple-500/80', text: 'text-white' },

--- a/web/src/components/cards/MatchGame.tsx
+++ b/web/src/components/cards/MatchGame.tsx
@@ -301,7 +301,7 @@ export function MatchGame(_props: CardComponentProps) {
               className={`px-2 py-0.5 rounded text-xs font-medium transition-colors ${
                 difficulty === d
                   ? 'bg-purple-500 text-white'
-                  : 'bg-white/5 hover:bg-white/10 text-muted-foreground'
+                  : 'bg-black/5 dark:bg-white/5 hover:bg-black/10 dark:hover:bg-white/10 text-muted-foreground'
               }`}
             >
               {d.charAt(0).toUpperCase() + d.slice(1)}
@@ -324,14 +324,14 @@ export function MatchGame(_props: CardComponentProps) {
           <div className="flex gap-1">
             <button
               onClick={togglePause}
-              className="p-0.5 rounded bg-white/5 hover:bg-white/10 transition-colors"
+              className="p-0.5 rounded bg-black/5 dark:bg-white/5 hover:bg-black/10 dark:hover:bg-white/10 transition-colors"
               title={isPaused ? 'Resume' : 'Pause'}
             >
               {isPaused ? <Play className="w-3.5 h-3.5" /> : <Pause className="w-3.5 h-3.5" />}
             </button>
             <button
               onClick={resetGame}
-              className="p-0.5 rounded bg-white/5 hover:bg-white/10 transition-colors"
+              className="p-0.5 rounded bg-black/5 dark:bg-white/5 hover:bg-black/10 dark:hover:bg-white/10 transition-colors"
               title={t('common.reset')}
             >
               <RotateCcw className="w-3.5 h-3.5" />
@@ -413,7 +413,7 @@ export function MatchGame(_props: CardComponentProps) {
                   
                   {/* Card front */}
                   <div className={`card-face absolute inset-0 backface-hidden rotate-y-180 ${
-                    card.matched ? 'bg-green-500/20 border-green-500/30' : 'bg-white/10 border-white/20'
+                    card.matched ? 'bg-green-500/20 border-green-500/30' : 'bg-black/10 dark:bg-white/10 border-black/20 dark:border-white/20'
                   } border-2 rounded flex items-center justify-center`}>
                     <Icon className={`w-6 h-6 ${icon?.color || 'text-blue-400'}`} />
                   </div>
@@ -432,7 +432,7 @@ export function MatchGame(_props: CardComponentProps) {
             <div className="text-base font-bold">Paused</div>
             <button
               onClick={togglePause}
-              className="mt-2 px-3 py-1.5 text-sm bg-white/10 hover:bg-white/20 rounded-lg transition-colors"
+              className="mt-2 px-3 py-1.5 text-sm bg-black/10 dark:bg-white/10 hover:bg-black/20 dark:hover:bg-white/20 rounded-lg transition-colors"
             >
               Resume
             </button>

--- a/web/src/components/cards/kagent/KagentAgentDiscovery.tsx
+++ b/web/src/components/cards/kagent/KagentAgentDiscovery.tsx
@@ -169,7 +169,7 @@ function KagentAgentDiscoveryInternal({ config }: KagentAgentDiscoveryProps) {
             <span className={`inline-flex items-center px-1.5 py-0.5 text-2xs font-medium rounded border ${
               agent.agentType === 'Declarative'
                 ? 'bg-blue-500/10 text-blue-400 border-blue-500/20'
-                : 'bg-gray-500/10 text-gray-400 border-gray-500/20'
+                : 'bg-gray-500/10 text-gray-600 dark:text-gray-400 border-gray-500/20'
             }`}>
               {agent.agentType}
             </span>

--- a/web/src/components/cards/kagent/KagentAgentFleet.tsx
+++ b/web/src/components/cards/kagent/KagentAgentFleet.tsx
@@ -20,7 +20,7 @@ function StatusBadge({ status }: { status: string }) {
           ? 'bg-yellow-500/15 text-yellow-400 border-yellow-500/20'
           : status === 'Failed'
             ? 'bg-red-500/15 text-red-400 border-red-500/20'
-            : 'bg-gray-500/15 text-muted-foreground border-gray-500/20'
+            : 'bg-gray-500/15 dark:bg-gray-400/15 text-muted-foreground border-gray-500/20 dark:border-gray-400/20'
   return (
     <span className={`inline-flex items-center px-1.5 py-0.5 text-2xs font-medium rounded border ${classes}`}>
       {status}
@@ -31,7 +31,7 @@ function StatusBadge({ status }: { status: string }) {
 function TypeBadge({ agentType }: { agentType: string }) {
   const classes = agentType === 'Declarative'
     ? 'bg-blue-500/10 text-blue-400 border-blue-500/20'
-    : 'bg-gray-500/10 text-gray-400 border-gray-500/20'
+    : 'bg-gray-500/10 text-gray-600 dark:text-gray-400 border-gray-500/20'
   return (
     <span className={`inline-flex items-center px-1.5 py-0.5 text-2xs font-medium rounded border ${classes}`}>
       {agentType}

--- a/web/src/components/cards/kagent/KagentModelProviders.tsx
+++ b/web/src/components/cards/kagent/KagentModelProviders.tsx
@@ -18,7 +18,7 @@ function StatusBadge({ status }: { status: string }) {
         ? 'bg-yellow-500/15 text-yellow-400 border-yellow-500/20'
         : status === 'Failed'
           ? 'bg-red-500/15 text-red-400 border-red-500/20'
-          : 'bg-gray-500/15 text-muted-foreground border-gray-500/20'
+          : 'bg-gray-500/15 dark:bg-gray-400/15 text-muted-foreground border-gray-500/20 dark:border-gray-400/20'
   return (
     <span className={`inline-flex items-center px-1.5 py-0.5 text-2xs font-medium rounded border ${classes}`}>
       {status}
@@ -41,12 +41,12 @@ const PROVIDER_COLORS: Record<string, string> = {
   Anthropic: 'bg-yellow-500/10 text-yellow-400 border-yellow-500/20',
   OpenAI: 'bg-green-500/10 text-green-400 border-green-500/20',
   Gemini: 'bg-blue-500/10 text-blue-400 border-blue-500/20',
-  Ollama: 'bg-gray-500/10 text-gray-400 border-gray-500/20',
+  Ollama: 'bg-gray-500/10 text-gray-600 dark:text-gray-400 border-gray-500/20',
   AzureOpenAI: 'bg-purple-500/10 text-purple-400 border-purple-500/20',
 }
 
 function ProviderBadge({ provider }: { provider: string }) {
-  const classes = PROVIDER_COLORS[provider] || 'bg-gray-500/10 text-gray-400 border-gray-500/20'
+  const classes = PROVIDER_COLORS[provider] || 'bg-gray-500/10 text-gray-600 dark:text-gray-400 border-gray-500/20'
   return (
     <span className={`inline-flex items-center px-1.5 py-0.5 text-2xs font-medium rounded border ${classes}`}>
       {provider}

--- a/web/src/components/cards/kagent/KagentToolRegistry.tsx
+++ b/web/src/components/cards/kagent/KagentToolRegistry.tsx
@@ -19,7 +19,7 @@ function StatusBadge({ status }: { status: string }) {
         ? 'bg-yellow-500/15 text-yellow-400 border-yellow-500/20'
         : status === 'Failed'
           ? 'bg-red-500/15 text-red-400 border-red-500/20'
-          : 'bg-gray-500/15 text-muted-foreground border-gray-500/20'
+          : 'bg-gray-500/15 dark:bg-gray-400/15 text-muted-foreground border-gray-500/20 dark:border-gray-400/20'
   return (
     <span className={`inline-flex items-center px-1.5 py-0.5 text-2xs font-medium rounded border ${classes}`}>
       {status}
@@ -40,11 +40,11 @@ function KindBadge({ kind }: { kind: string }) {
 
 function ProtocolBadge({ protocol }: { protocol: string }) {
   const colorMap: Record<string, string> = {
-    stdio: 'bg-gray-500/10 text-gray-400 border-gray-500/20',
+    stdio: 'bg-gray-500/10 text-gray-600 dark:text-gray-400 border-gray-500/20',
     sse: 'bg-blue-500/10 text-blue-400 border-blue-500/20',
     streamableHTTP: 'bg-emerald-500/10 text-emerald-400 border-emerald-500/20',
   }
-  const classes = colorMap[protocol] || 'bg-gray-500/10 text-gray-400 border-gray-500/20'
+  const classes = colorMap[protocol] || 'bg-gray-500/10 text-gray-600 dark:text-gray-400 border-gray-500/20'
   return (
     <span className={`inline-flex items-center px-1.5 py-0.5 text-2xs font-medium rounded border ${classes}`}>
       {protocol}
@@ -201,7 +201,7 @@ function KagentToolRegistryInternal({ config }: KagentToolRegistryProps) {
               {isExpanded && toolCount > 0 && (
                 <div className="ml-8 mr-2 mb-1 space-y-0.5">
                   {tool.discoveredTools.map(dt => (
-                    <div key={dt.name} className="text-xs text-muted-foreground flex items-center gap-1.5 px-2 py-0.5 rounded bg-white/5">
+                    <div key={dt.name} className="text-xs text-muted-foreground flex items-center gap-1.5 px-2 py-0.5 rounded bg-black/5 dark:bg-white/5">
                       <span className="text-cyan-400/80 font-mono">{dt.name}</span>
                       {dt.description && <span className="truncate">{dt.description}</span>}
                     </div>


### PR DESCRIPTION
Closes #6939

## Summary
- Added `dark:` Tailwind variants to 20 light-only color classes across 8 components
- Kagent badges (AgentDiscovery, ModelProviders, AgentFleet, ToolRegistry): added `dark:text-` and `dark:bg-`/`dark:border-` variants for gray fallback/unknown status badges
- MatchGame: replaced `bg-white/N` with `bg-black/N dark:bg-white/N` for buttons, card faces, and pause overlay
- Game2048: ensured `text-black` on tile 512 is explicit for both modes
- CardChat: added `dark:hover:bg-white/10` alongside light-mode `hover:bg-black/10`
- ClusterCosts: added `dark:bg-gray-400/15` to estimate provider badge

## Approach
Followed existing PayloadCard.tsx dark mode pattern. Used `bg-black/N` as the light-mode counterpart to `bg-white/N`, and `text-gray-600 dark:text-gray-400` for readable gray text in both modes. Inline style findings (HardwareLeaderboard, LLMdFlow, PDDisaggregation) are theme-aware via JS constants and were not changed.

## Test plan
- [x] `npm run build` passes
- [ ] Visual check in KubeStellar Light and GitHub Light themes
- [ ] Visual check in default dark theme