### PR TITLE
fix(backend): nil-safety guards for 32 nilaway findings (#6848)

### DIFF
--- a/pkg/agent/device_tracker.go
+++ b/pkg/agent/device_tracker.go
@@ -194,7 +194,7 @@ func (t *DeviceTracker) scanDevices() {
 	}
 
 	if newAlerts && t.broadcast != nil {
-		t.broadcast("device_alerts_updated", t.GetAlerts())
+		t.broadcast("device_alerts_updated", t.GetAlerts()) //nolint:nilaway // broadcast nil-checked above
 	}
 }
 
@@ -418,11 +418,17 @@ func (t *DeviceTracker) checkForBoolDrop(key, nodeName, cluster, deviceType stri
 
 // GetAlerts returns all current device alerts
 func (t *DeviceTracker) GetAlerts() DeviceAlertsResponse {
+	if t == nil {
+		return DeviceAlertsResponse{Alerts: make([]DeviceAlert, 0)}
+	}
 	t.mu.RLock()
 	defer t.mu.RUnlock()
 
 	alerts := make([]DeviceAlert, 0, len(t.alerts))
 	for _, alert := range t.alerts {
+		if alert == nil {
+			continue
+		}
 		alerts = append(alerts, *alert)
 	}
 
@@ -435,6 +441,9 @@ func (t *DeviceTracker) GetAlerts() DeviceAlertsResponse {
 
 // GetNodeHistory returns device count history for a specific node
 func (t *DeviceTracker) GetNodeHistory(cluster, nodeName string) []DeviceSnapshot {
+	if t == nil {
+		return nil
+	}
 	t.mu.RLock()
 	defer t.mu.RUnlock()
 
@@ -464,6 +473,9 @@ type DeviceInventoryResponse struct {
 // GetInventory returns all tracked nodes with their device counts
 // Data is already deduplicated at scan time via DeduplicatedClusters
 func (t *DeviceTracker) GetInventory() DeviceInventoryResponse {
+	if t == nil {
+		return DeviceInventoryResponse{Nodes: make([]NodeDeviceInventory, 0)}
+	}
 	t.mu.RLock()
 	defer t.mu.RUnlock()
 
@@ -501,6 +513,9 @@ func (t *DeviceTracker) GetInventory() DeviceInventoryResponse {
 
 // ClearAlert manually clears an alert (e.g., after power cycle)
 func (t *DeviceTracker) ClearAlert(alertID string) bool {
+	if t == nil {
+		return false
+	}
 	t.mu.Lock()
 	defer t.mu.Unlock()
 

--- a/pkg/agent/kubectl.go
+++ b/pkg/agent/kubectl.go
@@ -265,10 +265,20 @@ func (k *KubectlProxy) validateArgs(args []string) bool {
 	return true
 }
 
-func (k *KubectlProxy) GetCurrentContext() string { return k.config.CurrentContext }
+func (k *KubectlProxy) GetCurrentContext() string {
+	if k == nil || k.config == nil {
+		return ""
+	}
+	return k.config.CurrentContext
+}
 
 // GetKubeconfigPath returns the path to the kubeconfig file
-func (k *KubectlProxy) GetKubeconfigPath() string { return k.kubeconfig }
+func (k *KubectlProxy) GetKubeconfigPath() string {
+	if k == nil {
+		return ""
+	}
+	return k.kubeconfig
+}
 
 // Reload reloads the kubeconfig from disk
 func (k *KubectlProxy) Reload() {

--- a/pkg/agent/kubectl_test.go
+++ b/pkg/agent/kubectl_test.go
@@ -678,6 +678,9 @@ current-context: ctx-b
 	}
 
 	ctxB := proxy.config.Contexts["ctx-b"]
+	if ctxB == nil {
+		t.Fatal("ctx-b context not found in config")
+	}
 	if ctxB.AuthInfo == "shared-user" {
 		t.Error("ctx-b should NOT reference the original 'shared-user' (different token)")
 	}
@@ -696,6 +699,9 @@ current-context: ctx-b
 
 	// Original user unchanged
 	origUser := proxy.config.AuthInfos["shared-user"]
+	if origUser == nil {
+		t.Fatal("shared-user AuthInfo not found in config")
+	}
 	if origUser.Token != "token-aaa" {
 		t.Errorf("original user token = %q, want token-aaa", origUser.Token)
 	}
@@ -727,6 +733,9 @@ func TestKubectlProxy_ImportKubeconfig_SameDataNoRename(t *testing.T) {
 
 	// Since data is identical, the context should keep the original name (no rename).
 	ctxB := proxy.config.Contexts["ctx-b"]
+	if ctxB == nil {
+		t.Fatal("ctx-b context not found in config")
+	}
 	if ctxB.Cluster != "shared-cluster" {
 		t.Errorf("ctx-b cluster = %q, want shared-cluster (same data, no rename needed)", ctxB.Cluster)
 	}

--- a/pkg/agent/registry.go
+++ b/pkg/agent/registry.go
@@ -197,7 +197,10 @@ func (r *Registry) promoteExecutingDefault() {
 
 	// Look for a better agent that actually executes commands
 	for name, provider := range r.providers {
-		if provider.IsAvailable() && !suggestOnlyAgents[name] &&
+		if provider == nil || !provider.IsAvailable() {
+			continue
+		}
+		if !suggestOnlyAgents[name] &&
 			provider.Capabilities().HasCapability(CapabilityToolExec) {
 			r.defaultAgent = name
 			return

--- a/pkg/api/handlers/auth_test.go
+++ b/pkg/api/handlers/auth_test.go
@@ -92,7 +92,10 @@ func TestDevModeLogin(t *testing.T) {
 // set so the handler does not reject it at the CSRF gate (#6588). Tests
 // that want to exercise the CSRF gate should build requests directly.
 func refreshReq(authHeader string) *http.Request {
-	req, _ := http.NewRequest("POST", "/auth/refresh", nil)
+	req, err := http.NewRequest("POST", "/auth/refresh", nil)
+	if err != nil {
+		panic(err)
+	}
 	req.Header.Set("X-Requested-With", "XMLHttpRequest")
 	if authHeader != "" {
 		req.Header.Set("Authorization", authHeader)
@@ -622,16 +625,20 @@ func TestLogout_RequiresCSRFHeader(t *testing.T) {
 	token, _ := handler.generateJWT(user)
 
 	// Without the CSRF header: 403.
-	req, _ := http.NewRequest("POST", "/auth/logout", nil)
+	req, err := http.NewRequest("POST", "/auth/logout", nil)
+	require.NoError(t, err)
 	req.Header.Set("Authorization", "Bearer "+token)
-	resp, _ := app.Test(req, 5000)
+	resp, err := app.Test(req, 5000)
+	require.NoError(t, err)
 	assert.Equal(t, http.StatusForbidden, resp.StatusCode)
 
 	// With the CSRF header: 200.
-	req2, _ := http.NewRequest("POST", "/auth/logout", nil)
+	req2, err := http.NewRequest("POST", "/auth/logout", nil)
+	require.NoError(t, err)
 	req2.Header.Set("Authorization", "Bearer "+token)
 	req2.Header.Set("X-Requested-With", "XMLHttpRequest")
-	resp2, _ := app.Test(req2, 5000)
+	resp2, err := app.Test(req2, 5000)
+	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp2.StatusCode)
 }
 
@@ -653,10 +660,12 @@ func TestLogout_ExpiredTokenIdempotent(t *testing.T) {
 	tok := jwt.NewWithClaims(jwt.SigningMethodHS256, expClaims)
 	signed, _ := tok.SignedString([]byte("test-secret"))
 
-	req, _ := http.NewRequest("POST", "/auth/logout", nil)
+	req, err := http.NewRequest("POST", "/auth/logout", nil)
+	require.NoError(t, err)
 	req.Header.Set("Authorization", "Bearer "+signed)
 	req.Header.Set("X-Requested-With", "XMLHttpRequest")
-	resp, _ := app.Test(req, 5000)
+	resp, err := app.Test(req, 5000)
+	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 
 	// The expired JTI must NOT have been added to the revocation store.

--- a/pkg/api/handlers/self_upgrade.go
+++ b/pkg/api/handlers/self_upgrade.go
@@ -221,6 +221,13 @@ func (h *SelfUpgradeHandler) TriggerUpgrade(c *fiber.Ctx) error {
 				Error: "unable to verify user role — access denied",
 			})
 		}
+		if user == nil {
+			slog.Warn("[self-upgrade] SECURITY: user not found for role check",
+				"user_id", userID)
+			return c.Status(fiber.StatusForbidden).JSON(SelfUpgradeTriggerResponse{
+				Error: "user not found — access denied",
+			})
+		}
 		if user.Role != models.UserRoleAdmin {
 			slog.Warn("[self-upgrade] SECURITY: non-admin user attempted self-upgrade",
 				"user_id", userID,

--- a/pkg/api/handlers/token_usage_test.go
+++ b/pkg/api/handlers/token_usage_test.go
@@ -82,7 +82,8 @@ func TestTokenUsageHandler_PutThenGetRoundTrip(t *testing.T) {
 		LastAgentSessionID: "session-put-1",
 	}
 	raw, _ := json.Marshal(body)
-	req, _ := http.NewRequest(http.MethodPost, "/api/token-usage/me", bytes.NewReader(raw))
+	req, err := http.NewRequest(http.MethodPost, "/api/token-usage/me", bytes.NewReader(raw))
+	require.NoError(t, err)
 	req.Header.Set("Content-Type", "application/json")
 	resp, err := app.Test(req, testTokenUsageFiberTimeoutMs)
 	require.NoError(t, err)
@@ -94,7 +95,8 @@ func TestTokenUsageHandler_PutThenGetRoundTrip(t *testing.T) {
 	assert.Equal(t, wantDiagnose, got.TokensByCategory["diagnose"])
 
 	// Re-fetch and confirm persistence.
-	getReq, _ := http.NewRequest(http.MethodGet, "/api/token-usage/me", nil)
+	getReq, err := http.NewRequest(http.MethodGet, "/api/token-usage/me", nil)
+	require.NoError(t, err)
 	getResp, err := app.Test(getReq, testTokenUsageFiberTimeoutMs)
 	require.NoError(t, err)
 	got2 := decodeTokenUsageResponse(t, getResp)
@@ -113,7 +115,8 @@ func TestTokenUsageHandler_DeltaIncrementsAtomically(t *testing.T) {
 			Delta:          d,
 			AgentSessionID: "session-delta-1",
 		})
-		req, _ := http.NewRequest(http.MethodPost, "/api/token-usage/delta", bytes.NewReader(body))
+		req, err := http.NewRequest(http.MethodPost, "/api/token-usage/delta", bytes.NewReader(body))
+		require.NoError(t, err)
 		req.Header.Set("Content-Type", "application/json")
 		resp, err := app.Test(req, testTokenUsageFiberTimeoutMs)
 		require.NoError(t, err)
@@ -121,7 +124,8 @@ func TestTokenUsageHandler_DeltaIncrementsAtomically(t *testing.T) {
 		resp.Body.Close()
 	}
 
-	getReq, _ := http.NewRequest(http.MethodGet, "/api/token-usage/me", nil)
+	getReq, err := http.NewRequest(http.MethodGet, "/api/token-usage/me", nil)
+	require.NoError(t, err)
 	getResp, err := app.Test(getReq, testTokenUsageFiberTimeoutMs)
 	require.NoError(t, err)
 	got := decodeTokenUsageResponse(t, getResp)
@@ -141,7 +145,8 @@ func TestTokenUsageHandler_DeltaSessionChangeSkipsAdd(t *testing.T) {
 		Delta:          delta1,
 		AgentSessionID: "session-A",
 	})
-	req1, _ := http.NewRequest(http.MethodPost, "/api/token-usage/delta", bytes.NewReader(body1))
+	req1, err := http.NewRequest(http.MethodPost, "/api/token-usage/delta", bytes.NewReader(body1))
+	require.NoError(t, err)
 	req1.Header.Set("Content-Type", "application/json")
 	resp1, err := app.Test(req1, testTokenUsageFiberTimeoutMs)
 	require.NoError(t, err)
@@ -153,7 +158,8 @@ func TestTokenUsageHandler_DeltaSessionChangeSkipsAdd(t *testing.T) {
 		Delta:          delta2,
 		AgentSessionID: "session-B",
 	})
-	req2, _ := http.NewRequest(http.MethodPost, "/api/token-usage/delta", bytes.NewReader(body2))
+	req2, err := http.NewRequest(http.MethodPost, "/api/token-usage/delta", bytes.NewReader(body2))
+	require.NoError(t, err)
 	req2.Header.Set("Content-Type", "application/json")
 	resp2, err := app.Test(req2, testTokenUsageFiberTimeoutMs)
 	require.NoError(t, err)
@@ -170,7 +176,8 @@ func TestTokenUsageHandler_DeltaRejectsNegative(t *testing.T) {
 		Delta:          -1,
 		AgentSessionID: "session-neg",
 	})
-	req, _ := http.NewRequest(http.MethodPost, "/api/token-usage/delta", bytes.NewReader(body))
+	req, err := http.NewRequest(http.MethodPost, "/api/token-usage/delta", bytes.NewReader(body))
+	require.NoError(t, err)
 	req.Header.Set("Content-Type", "application/json")
 	resp, err := app.Test(req, testTokenUsageFiberTimeoutMs)
 	require.NoError(t, err)
@@ -186,7 +193,8 @@ func TestTokenUsageHandler_DeltaRejectsOverLimit(t *testing.T) {
 		Delta:          maxTokenDeltaPerRequest + 1,
 		AgentSessionID: "session-big",
 	})
-	req, _ := http.NewRequest(http.MethodPost, "/api/token-usage/delta", bytes.NewReader(body))
+	req, err := http.NewRequest(http.MethodPost, "/api/token-usage/delta", bytes.NewReader(body))
+	require.NoError(t, err)
 	req.Header.Set("Content-Type", "application/json")
 	resp, err := app.Test(req, testTokenUsageFiberTimeoutMs)
 	require.NoError(t, err)
@@ -206,7 +214,8 @@ func TestTokenUsageHandler_PutRejectsTooManyCategories(t *testing.T) {
 		TokensByCategory:   cats,
 		LastAgentSessionID: "session-many",
 	})
-	req, _ := http.NewRequest(http.MethodPost, "/api/token-usage/me", bytes.NewReader(body))
+	req, err := http.NewRequest(http.MethodPost, "/api/token-usage/me", bytes.NewReader(body))
+	require.NoError(t, err)
 	req.Header.Set("Content-Type", "application/json")
 	resp, err := app.Test(req, testTokenUsageFiberTimeoutMs)
 	require.NoError(t, err)

--- a/pkg/k8s/events.go
+++ b/pkg/k8s/events.go
@@ -34,6 +34,9 @@ func EffectiveEventTime(e *corev1.Event) time.Time {
 // the fragile lexicographic comparison on mixed-timezone strings used
 // previously. See issue #6043.
 func SortEventsByLastSeenDesc(events []Event) {
+	if len(events) == 0 {
+		return
+	}
 	// Cache parsed times once to avoid O(n log n) reparsing inside the
 	// sort comparator.
 	parsed := make([]time.Time, len(events))

--- a/pkg/k8s/workload.go
+++ b/pkg/k8s/workload.go
@@ -1236,9 +1236,10 @@ func (m *MultiClusterClient) GetClusterCapabilities(ctx context.Context) (*v1alp
 		cap.GPUCount = totalGPUs
 
 		// Use capacity from first node as representative for CPU/Memory
-		// (nodes is guaranteed non-empty here — zero-node clusters are skipped above)
-		cap.CPUCapacity = nodes[0].CPUCapacity
-		cap.MemCapacity = nodes[0].MemoryCapacity
+		if len(nodes) > 0 {
+			cap.CPUCapacity = nodes[0].CPUCapacity
+			cap.MemCapacity = nodes[0].MemoryCapacity
+		}
 
 		capabilities = append(capabilities, cap)
 	}


### PR DESCRIPTION
Closes #6848 — Adds nil-safety guards for all 32 nilaway findings across 9 files. Supersedes Copilot PR #6849 (fails DCO).