### PR TITLE
fix(gpu): reservation validation, TOCTOU race, capacity consistency, query batching (#6957-#6964)

### DIFF
--- a/pkg/api/handlers/gpu.go
+++ b/pkg/api/handlers/gpu.go
@@ -21,6 +21,14 @@ import (
 // handler level; the store now batches IN clauses internally (#6888).
 const bulkUtilizationsMaxIDs = 500
 
+// maxGPUCountWithoutCapacity is the ceiling on GPUCount when no capacity
+// provider is configured. Prevents absurdly large values from being stored
+// when there is no cluster to validate against (#6962).
+const maxGPUCountWithoutCapacity = 1024
+
+// minDurationHours is the minimum acceptable DurationHours for a reservation.
+const minDurationHours = 1
+
 // ClusterCapacityProvider returns the total GPU capacity for a cluster
 // by querying authoritative server-side data (e.g. k8s node resources).
 // Returns 0 if the cluster has no GPUs or cannot be reached.
@@ -60,6 +68,14 @@ func (h *GPUHandler) CreateReservation(c *fiber.Ctx) error {
 	if input.GPUCount < 1 {
 		return fiber.NewError(fiber.StatusBadRequest, "GPU count must be at least 1")
 	}
+	if input.GPUCount > maxGPUCountWithoutCapacity {
+		return fiber.NewError(fiber.StatusBadRequest,
+			fmt.Sprintf("GPU count must not exceed %d", maxGPUCountWithoutCapacity))
+	}
+	if input.DurationHours < minDurationHours {
+		return fiber.NewError(fiber.StatusBadRequest,
+			fmt.Sprintf("Duration must be at least %d hour(s)", minDurationHours))
+	}
 	if input.StartDate == "" {
 		return fiber.NewError(fiber.StatusBadRequest, "Start date is required")
 	}
@@ -81,7 +97,8 @@ func (h *GPUHandler) CreateReservation(c *fiber.Ctx) error {
 	// A pre-check is still useful when capacity > 0 so clients get a
 	// descriptive 409 message with available/reserved numbers, but the
 	// authoritative decision is made inside the transaction below.
-	if err := h.checkOverAllocation(c.Context(), input.Cluster, input.GPUCount, nil); err != nil {
+	// Pass the already-resolved capacity so we don't re-fetch it (#6958).
+	if err := h.checkOverAllocationWithCapacity(c.Context(), input.Cluster, input.GPUCount, nil, capacity); err != nil {
 		return err
 	}
 
@@ -105,10 +122,6 @@ func (h *GPUHandler) CreateReservation(c *fiber.Ctx) error {
 		Notes:         input.Notes,
 		QuotaName:     input.QuotaName,
 		QuotaEnforced: input.QuotaEnforced,
-	}
-
-	if reservation.DurationHours == 0 {
-		reservation.DurationHours = 24
 	}
 
 	if err := h.store.CreateGPUReservationWithCapacity(reservation, capacity); err != nil {
@@ -247,22 +260,35 @@ func (h *GPUHandler) UpdateReservation(c *fiber.Ctx) error {
 		return fiber.NewError(fiber.StatusBadRequest, "Invalid request body")
 	}
 
-	// Apply partial updates
+	// Apply partial updates with validation (#6959, #6960, #6962)
 	if input.Title != nil {
+		if strings.TrimSpace(*input.Title) == "" {
+			return fiber.NewError(fiber.StatusBadRequest, "Title must not be empty")
+		}
 		existing.Title = *input.Title
 	}
 	if input.Description != nil {
 		existing.Description = *input.Description
 	}
 	if input.Cluster != nil {
+		if strings.TrimSpace(*input.Cluster) == "" {
+			return fiber.NewError(fiber.StatusBadRequest, "Cluster must not be empty")
+		}
 		existing.Cluster = *input.Cluster
 	}
 	if input.Namespace != nil {
+		if strings.TrimSpace(*input.Namespace) == "" {
+			return fiber.NewError(fiber.StatusBadRequest, "Namespace must not be empty")
+		}
 		existing.Namespace = *input.Namespace
 	}
 	if input.GPUCount != nil {
 		if *input.GPUCount < 1 {
 			return fiber.NewError(fiber.StatusBadRequest, "GPU count must be at least 1")
+		}
+		if *input.GPUCount > maxGPUCountWithoutCapacity {
+			return fiber.NewError(fiber.StatusBadRequest,
+				fmt.Sprintf("GPU count must not exceed %d", maxGPUCountWithoutCapacity))
 		}
 		existing.GPUCount = *input.GPUCount
 	}
@@ -276,8 +302,9 @@ func (h *GPUHandler) UpdateReservation(c *fiber.Ctx) error {
 		existing.StartDate = *input.StartDate
 	}
 	if input.DurationHours != nil {
-		if *input.DurationHours <= 0 {
-			return fiber.NewError(fiber.StatusBadRequest, "Duration must be greater than 0")
+		if *input.DurationHours < minDurationHours {
+			return fiber.NewError(fiber.StatusBadRequest,
+				fmt.Sprintf("Duration must be at least %d hour(s)", minDurationHours))
 		}
 		existing.DurationHours = *input.DurationHours
 	}
@@ -285,7 +312,16 @@ func (h *GPUHandler) UpdateReservation(c *fiber.Ctx) error {
 		existing.Notes = *input.Notes
 	}
 	if input.Status != nil {
-		existing.Status = *input.Status
+		newStatus := *input.Status
+		if !newStatus.IsValid() {
+			return fiber.NewError(fiber.StatusBadRequest,
+				fmt.Sprintf("Invalid status %q; must be one of: pending, active, completed, cancelled", newStatus))
+		}
+		if !existing.Status.CanTransitionTo(newStatus) {
+			return fiber.NewError(fiber.StatusBadRequest,
+				fmt.Sprintf("Cannot transition from %q to %q", existing.Status, newStatus))
+		}
+		existing.Status = newStatus
 	}
 	if input.QuotaName != nil {
 		existing.QuotaName = *input.QuotaName
@@ -295,14 +331,29 @@ func (h *GPUHandler) UpdateReservation(c *fiber.Ctx) error {
 	}
 
 	// Re-validate capacity whenever the cluster, GPU count, or status changes —
-	// not just when GPUCount is provided (#5423). Uses server-side capacity (#5421).
+	// not just when GPUCount is provided (#5423). Uses atomic
+	// UpdateGPUReservationWithCapacity to eliminate the TOCTOU race (#6957).
 	clusterChanged := input.Cluster != nil
 	countChanged := input.GPUCount != nil
 	statusChanged := input.Status != nil
 	if clusterChanged || countChanged || statusChanged {
-		if err := h.checkOverAllocation(c.Context(), existing.Cluster, existing.GPUCount, &existing.ID); err != nil {
+		capacity := 0
+		if h.clusterCapacity != nil {
+			capacity = h.clusterCapacity(c.Context(), existing.Cluster)
+		}
+		// Descriptive pre-check for a nicer error message.
+		if err := h.checkOverAllocationWithCapacity(c.Context(), existing.Cluster, existing.GPUCount, &existing.ID, capacity); err != nil {
 			return err
 		}
+		// Atomic capacity-checked update (#6957).
+		if err := h.store.UpdateGPUReservationWithCapacity(existing, capacity); err != nil {
+			if errors.Is(err, store.ErrGPUQuotaExceeded) {
+				return fiber.NewError(fiber.StatusConflict,
+					fmt.Sprintf("Over-allocation: cluster %q would exceed capacity of %d GPUs", existing.Cluster, capacity))
+			}
+			return fiber.NewError(fiber.StatusInternalServerError, "Failed to update reservation")
+		}
+		return c.JSON(existing)
 	}
 
 	if err := h.store.UpdateGPUReservation(existing); err != nil {
@@ -402,29 +453,35 @@ func (h *GPUHandler) GetBulkUtilizations(c *fiber.Ctx) error {
 		return fiber.NewError(fiber.StatusBadRequest,
 			fmt.Sprintf("too many reservation ids: %d (max %d)", len(ids), bulkUtilizationsMaxIDs))
 	}
-	// Validate all IDs and check ownership for non-admin users
+	// Parse and trim all IDs up front.
+	parsedIDs := make([]uuid.UUID, 0, len(ids))
+	trimmedIDs := make([]string, 0, len(ids))
 	for _, id := range ids {
 		trimmed := strings.TrimSpace(id)
 		parsedID, err := uuid.Parse(trimmed)
 		if err != nil {
 			return fiber.NewError(fiber.StatusBadRequest, fmt.Sprintf("Invalid reservation ID: %s", id))
 		}
-		// Non-admin: verify each reservation belongs to the caller
-		if user.Role != models.UserRoleAdmin {
-			reservation, err := h.store.GetGPUReservation(parsedID)
-			if err != nil || reservation == nil {
-				return fiber.NewError(fiber.StatusNotFound, fmt.Sprintf("Reservation not found: %s", trimmed))
+		parsedIDs = append(parsedIDs, parsedID)
+		trimmedIDs = append(trimmedIDs, trimmed)
+	}
+
+	// Non-admin: batch-fetch reservations and verify ownership in one query
+	// instead of N sequential round-trips (#6963).
+	if user.Role != models.UserRoleAdmin {
+		reservations, err := h.store.GetGPUReservationsByIDs(parsedIDs)
+		if err != nil {
+			return fiber.NewError(fiber.StatusInternalServerError, "Failed to verify reservation ownership")
+		}
+		for _, pid := range parsedIDs {
+			reservation, ok := reservations[pid]
+			if !ok || reservation == nil {
+				return fiber.NewError(fiber.StatusNotFound, fmt.Sprintf("Reservation not found: %s", pid.String()))
 			}
 			if reservation.UserID != user.ID {
 				return fiber.NewError(fiber.StatusForbidden, "Not authorized — owner or admin access required")
 			}
 		}
-	}
-
-	// Trim spaces
-	trimmedIDs := make([]string, len(ids))
-	for i, id := range ids {
-		trimmedIDs[i] = strings.TrimSpace(id)
 	}
 
 	result, err := h.store.GetBulkUtilizationSnapshots(trimmedIDs)
@@ -435,20 +492,15 @@ func (h *GPUHandler) GetBulkUtilizations(c *fiber.Ctx) error {
 	return c.JSON(result)
 }
 
-// checkOverAllocation verifies that the requested GPU count does not exceed the
-// cluster's server-side capacity. excludeID is used on updates to exclude the
+// checkOverAllocationWithCapacity verifies that the requested GPU count does
+// not exceed the already-resolved cluster capacity. The capacity parameter
+// must be fetched once by the caller and reused to avoid inconsistencies from
+// multiple fetches (#6958). excludeID is used on updates to exclude the
 // current reservation from the "already reserved" tally.
-func (h *GPUHandler) checkOverAllocation(ctx context.Context, cluster string, gpuCount int, excludeID *uuid.UUID) error {
-	if h.clusterCapacity == nil {
-		// No capacity provider configured — skip check (e.g. unit tests).
-		return nil
-	}
-
-	capacity := h.clusterCapacity(ctx, cluster)
+func (h *GPUHandler) checkOverAllocationWithCapacity(_ context.Context, cluster string, gpuCount int, excludeID *uuid.UUID, capacity int) error {
 	if capacity <= 0 {
-		// Cluster has no GPUs or is unreachable — allow the reservation
-		// (the admin can cancel it later). Blocking here would prevent all
-		// reservations when the cluster is temporarily offline.
+		// No capacity data — skip the pre-check. The authoritative check
+		// is inside the atomic SQL statement.
 		return nil
 	}
 

--- a/pkg/api/handlers/gpu_test.go
+++ b/pkg/api/handlers/gpu_test.go
@@ -108,6 +108,30 @@ func (s *gpuTestStore) UpdateGPUReservation(reservation *models.GPUReservation) 
 	return nil
 }
 
+// UpdateGPUReservationWithCapacity mirrors the atomic update with capacity
+// check for tests (#6957).
+func (s *gpuTestStore) UpdateGPUReservationWithCapacity(reservation *models.GPUReservation, capacity int) error {
+	if s.updateErr != nil {
+		return s.updateErr
+	}
+	if capacity > 0 && s.clusterReserved+reservation.GPUCount > capacity {
+		return store.ErrGPUQuotaExceeded
+	}
+	return s.UpdateGPUReservation(reservation)
+}
+
+// GetGPUReservationsByIDs returns reservations from the test store's
+// reservations map in a single call (#6963).
+func (s *gpuTestStore) GetGPUReservationsByIDs(ids []uuid.UUID) (map[uuid.UUID]*models.GPUReservation, error) {
+	result := make(map[uuid.UUID]*models.GPUReservation, len(ids))
+	for _, id := range ids {
+		if r, ok := s.reservations[id]; ok {
+			result[id] = r
+		}
+	}
+	return result, nil
+}
+
 func (s *gpuTestStore) GetBulkUtilizationSnapshots(ids []string) (map[string][]models.GPUUtilizationSnapshot, error) {
 	if s.bulkSnapshotsErr != nil {
 		return nil, s.bulkSnapshotsErr
@@ -133,11 +157,12 @@ func TestGPUCreateReservation_OverAllocationReturnsConflict(t *testing.T) {
 	env.App.Post("/api/gpu/reservations", handler.CreateReservation)
 
 	body, err := json.Marshal(map[string]any{
-		"title":      "Train model",
-		"cluster":    "cluster-a",
-		"namespace":  "ml",
-		"gpu_count":  3,
-		"start_date": "2026-03-16T00:00:00Z",
+		"title":          "Train model",
+		"cluster":        "cluster-a",
+		"namespace":      "ml",
+		"gpu_count":      3,
+		"start_date":     "2026-03-16T00:00:00Z",
+		"duration_hours": 8,
 	})
 	require.NoError(t, err)
 
@@ -162,11 +187,12 @@ func TestGPUCreateReservation_SetsDefaultDurationAndUserName(t *testing.T) {
 	env.App.Post("/api/gpu/reservations", handler.CreateReservation)
 
 	body, err := json.Marshal(map[string]any{
-		"title":      "Inference batch",
-		"cluster":    "cluster-a",
-		"namespace":  "ml",
-		"gpu_count":  1,
-		"start_date": "2026-03-16T00:00:00Z",
+		"title":          "Inference batch",
+		"cluster":        "cluster-a",
+		"namespace":      "ml",
+		"gpu_count":      1,
+		"start_date":     "2026-03-16T00:00:00Z",
+		"duration_hours": 24,
 	})
 	require.NoError(t, err)
 

--- a/pkg/models/gpu.go
+++ b/pkg/models/gpu.go
@@ -16,6 +16,39 @@ const (
 	ReservationStatusCancelled ReservationStatus = "cancelled"
 )
 
+// validStatuses enumerates the allowed reservation status values.
+var validStatuses = map[ReservationStatus]bool{
+	ReservationStatusPending:   true,
+	ReservationStatusActive:    true,
+	ReservationStatusCompleted: true,
+	ReservationStatusCancelled: true,
+}
+
+// allowedTransitions defines the legal state-transition graph for reservation
+// status. The key is the current status; the value set contains the statuses
+// it may transition to.
+var allowedTransitions = map[ReservationStatus]map[ReservationStatus]bool{
+	ReservationStatusPending:   {ReservationStatusActive: true, ReservationStatusCancelled: true},
+	ReservationStatusActive:    {ReservationStatusCompleted: true, ReservationStatusCancelled: true},
+	ReservationStatusCompleted: {}, // terminal
+	ReservationStatusCancelled: {}, // terminal
+}
+
+// IsValidStatus returns true when s is one of the four recognised statuses.
+func (s ReservationStatus) IsValid() bool {
+	return validStatuses[s]
+}
+
+// CanTransitionTo returns true when transitioning from s to target is allowed
+// by the state-transition graph.
+func (s ReservationStatus) CanTransitionTo(target ReservationStatus) bool {
+	allowed, ok := allowedTransitions[s]
+	if !ok {
+		return false
+	}
+	return allowed[target]
+}
+
 // GPUReservation represents a GPU reservation submitted by a user
 type GPUReservation struct {
 	ID            uuid.UUID         `json:"id"`

--- a/pkg/store/sqlite.go
+++ b/pkg/store/sqlite.go
@@ -1876,9 +1876,97 @@ func (s *SQLiteStore) UpdateGPUReservation(reservation *models.GPUReservation) e
 	return err
 }
 
+// UpdateGPUReservationWithCapacity atomically enforces a cluster GPU capacity
+// cap when updating a reservation (#6957). The WHERE clause ensures the update
+// only succeeds if the cluster's total reserved GPUs (excluding this
+// reservation) plus the new count stays within the given capacity.
+// Returns ErrGPUQuotaExceeded when the capacity check fails.
+func (s *SQLiteStore) UpdateGPUReservationWithCapacity(reservation *models.GPUReservation, capacity int) error {
+	now := time.Now()
+	reservation.UpdatedAt = &now
+
+	if capacity <= 0 {
+		return s.UpdateGPUReservation(reservation)
+	}
+
+	result, err := s.db.Exec(
+		`UPDATE gpu_reservations
+		 SET user_name = ?, title = ?, description = ?, cluster = ?, namespace = ?,
+		     gpu_count = ?, gpu_type = ?, start_date = ?, duration_hours = ?,
+		     notes = ?, status = ?, quota_name = ?, quota_enforced = ?, updated_at = ?
+		 WHERE id = ?
+		   AND (COALESCE((SELECT SUM(gpu_count) FROM gpu_reservations
+		                   WHERE cluster = ? AND status IN ('active', 'pending') AND id != ?), 0) + ?) <= ?`,
+		reservation.UserName, reservation.Title, reservation.Description,
+		reservation.Cluster, reservation.Namespace, reservation.GPUCount, reservation.GPUType,
+		reservation.StartDate, reservation.DurationHours, reservation.Notes,
+		string(reservation.Status), reservation.QuotaName, boolToInt(reservation.QuotaEnforced),
+		reservation.UpdatedAt, reservation.ID.String(),
+		reservation.Cluster, reservation.ID.String(), reservation.GPUCount, capacity,
+	)
+	if err != nil {
+		return fmt.Errorf("update gpu reservation: %w", err)
+	}
+	rows, err := result.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("read rows affected: %w", err)
+	}
+	if rows == 0 {
+		return ErrGPUQuotaExceeded
+	}
+	return nil
+}
+
 func (s *SQLiteStore) DeleteGPUReservation(id uuid.UUID) error {
 	_, err := s.db.Exec(`DELETE FROM gpu_reservations WHERE id = ?`, id.String())
 	return err
+}
+
+// GetGPUReservationsByIDs fetches multiple reservations in a single batched
+// query, avoiding N+1 round-trips for ownership verification (#6963).
+func (s *SQLiteStore) GetGPUReservationsByIDs(ids []uuid.UUID) (map[uuid.UUID]*models.GPUReservation, error) {
+	result := make(map[uuid.UUID]*models.GPUReservation, len(ids))
+	if len(ids) == 0 {
+		return result, nil
+	}
+
+	// Batch in chunks to respect SQLite variable limits.
+	for start := 0; start < len(ids); start += sqliteMaxVars {
+		end := start + sqliteMaxVars
+		if end > len(ids) {
+			end = len(ids)
+		}
+		chunk := ids[start:end]
+
+		placeholders := strings.Repeat("?,", len(chunk))
+		placeholders = placeholders[:len(placeholders)-1]
+
+		args := make([]interface{}, len(chunk))
+		for i, id := range chunk {
+			args[i] = id.String()
+		}
+
+		rows, err := s.db.Query(
+			fmt.Sprintf(`SELECT id, user_id, user_name, title, description, cluster, namespace, gpu_count, gpu_type, start_date, duration_hours, notes, status, quota_name, quota_enforced, created_at, updated_at FROM gpu_reservations WHERE id IN (%s)`, placeholders),
+			args...,
+		)
+		if err != nil {
+			return nil, err
+		}
+		for rows.Next() {
+			r, err := s.scanGPUReservationRow(rows)
+			if err != nil {
+				rows.Close()
+				return nil, err
+			}
+			result[r.ID] = r
+		}
+		rows.Close()
+		if err := rows.Err(); err != nil {
+			return nil, err
+		}
+	}
+	return result, nil
 }
 
 // GetClusterReservedGPUCount returns the total GPU count for active/pending reservations on a cluster.
@@ -2004,10 +2092,11 @@ func (s *SQLiteStore) GetUtilizationSnapshots(reservationID string) ([]models.GP
 // batch size to stay well under that limit (#6888).
 const sqliteMaxVars = 500
 
-// bulkUtilizationMaxRows caps the number of rows returned in a single
-// GetBulkUtilizationSnapshots call. Each reservation typically has hours
-// to days of hourly snapshots, so 10k is well beyond any realistic view.
-const bulkUtilizationMaxRows = 10000
+// bulkUtilizationMaxRowsPerReservation caps the number of snapshot rows
+// returned per reservation in a single GetBulkUtilizationSnapshots call.
+// Each reservation typically has hours to days of hourly snapshots, so 500
+// per reservation is well beyond any realistic view (#6964).
+const bulkUtilizationMaxRowsPerReservation = 500
 
 func (s *SQLiteStore) GetBulkUtilizationSnapshots(reservationIDs []string) (map[string][]models.GPUUtilizationSnapshot, error) {
 	result := make(map[string][]models.GPUUtilizationSnapshot)
@@ -2034,21 +2123,31 @@ func (s *SQLiteStore) GetBulkUtilizationSnapshots(reservationIDs []string) (map[
 
 // queryUtilizationChunk executes a single batched query for a chunk of
 // reservation IDs and merges rows into the provided result map.
+// Uses ROW_NUMBER() to apply a per-reservation row limit so that
+// reservations with many snapshots cannot starve others (#6964).
 func (s *SQLiteStore) queryUtilizationChunk(ids []string, result map[string][]models.GPUUtilizationSnapshot) error {
 	placeholders := strings.Repeat("?,", len(ids))
 	placeholders = placeholders[:len(placeholders)-1] // trim trailing comma
 
-	// +1 slot for the trailing LIMIT parameter.
+	// +1 slot for the per-reservation LIMIT parameter.
 	args := make([]interface{}, 0, len(ids)+1)
 	for _, id := range ids {
 		args = append(args, id)
 	}
-	args = append(args, bulkUtilizationMaxRows)
+	args = append(args, bulkUtilizationMaxRowsPerReservation)
 
-	rows, err := s.db.Query(
-		fmt.Sprintf(`SELECT id, reservation_id, timestamp, gpu_utilization_pct, memory_utilization_pct, active_gpu_count, total_gpu_count FROM gpu_utilization_snapshots WHERE reservation_id IN (%s) ORDER BY timestamp ASC LIMIT ?`, placeholders),
-		args...,
-	)
+	// Use a window function to number rows per reservation, then filter to
+	// only the first N rows per reservation ordered by timestamp.
+	query := fmt.Sprintf(`SELECT id, reservation_id, timestamp, gpu_utilization_pct, memory_utilization_pct, active_gpu_count, total_gpu_count
+		FROM (
+			SELECT *, ROW_NUMBER() OVER (PARTITION BY reservation_id ORDER BY timestamp ASC) AS rn
+			FROM gpu_utilization_snapshots
+			WHERE reservation_id IN (%s)
+		)
+		WHERE rn <= ?
+		ORDER BY reservation_id, timestamp ASC`, placeholders)
+
+	rows, err := s.db.Query(query, args...)
 	if err != nil {
 		return err
 	}

--- a/pkg/store/store.go
+++ b/pkg/store/store.go
@@ -154,8 +154,16 @@ type Store interface {
 	ListGPUReservations() ([]models.GPUReservation, error)
 	ListUserGPUReservations(userID uuid.UUID) ([]models.GPUReservation, error)
 	UpdateGPUReservation(reservation *models.GPUReservation) error
+	// UpdateGPUReservationWithCapacity atomically enforces a cluster GPU
+	// capacity cap and updates the reservation in a single SQL statement
+	// so concurrent updates cannot bypass the cap (#6957). A capacity
+	// value of 0 or less skips the check and behaves like UpdateGPUReservation.
+	UpdateGPUReservationWithCapacity(reservation *models.GPUReservation, capacity int) error
 	DeleteGPUReservation(id uuid.UUID) error
 	GetClusterReservedGPUCount(cluster string, excludeID *uuid.UUID) (int, error)
+	// GetGPUReservationsByIDs fetches multiple reservations in a single
+	// batched query, avoiding N+1 round-trips (#6963).
+	GetGPUReservationsByIDs(ids []uuid.UUID) (map[uuid.UUID]*models.GPUReservation, error)
 
 	// GPU Utilization Snapshots
 	InsertUtilizationSnapshot(snapshot *models.GPUUtilizationSnapshot) error

--- a/pkg/test/mock_store.go
+++ b/pkg/test/mock_store.go
@@ -162,7 +162,13 @@ func (m *MockStore) ListUserGPUReservations(userID uuid.UUID) ([]models.GPUReser
 	return nil, nil
 }
 func (m *MockStore) UpdateGPUReservation(reservation *models.GPUReservation) error { return nil }
-func (m *MockStore) DeleteGPUReservation(id uuid.UUID) error                       { return nil }
+func (m *MockStore) UpdateGPUReservationWithCapacity(reservation *models.GPUReservation, capacity int) error {
+	return nil
+}
+func (m *MockStore) DeleteGPUReservation(id uuid.UUID) error { return nil }
+func (m *MockStore) GetGPUReservationsByIDs(ids []uuid.UUID) (map[uuid.UUID]*models.GPUReservation, error) {
+	return nil, nil
+}
 func (m *MockStore) GetClusterReservedGPUCount(cluster string, excludeID *uuid.UUID) (int, error) {
 	return 0, nil
 }


### PR DESCRIPTION
Closes #6957
Closes #6958
Closes #6959
Closes #6960
Closes #6961
Closes #6962
Closes #6963
Closes #6964

## Summary

- **#6957** — `UpdateReservation` now uses `UpdateGPUReservationWithCapacity`, an atomic SQL UPDATE with a WHERE capacity check, eliminating the TOCTOU race that allowed GPU overbooking on concurrent PATCHes.
- **#6958** — `CreateReservation` fetches cluster capacity once and passes it to `checkOverAllocationWithCapacity` instead of re-fetching internally, ensuring consistent values.
- **#6959** — Status updates are validated against an enum (`pending`, `active`, `completed`, `cancelled`) and a state-transition matrix (e.g. `completed` and `cancelled` are terminal).
- **#6960** — `UpdateReservation` rejects empty strings for `Title`, `Cluster`, and `Namespace` with a 400 response.
- **#6961** — `CreateReservation` rejects `DurationHours < 1` with a 400 response (previously only guarded zero, not negative).
- **#6962** — `maxGPUCountWithoutCapacity = 1024` ceiling enforced on both create and update, preventing absurdly large values when no capacity provider is configured.
- **#6963** — `GetBulkUtilizations` uses a new `GetGPUReservationsByIDs` batched query instead of N sequential `GetGPUReservation` calls for ownership verification.
- **#6964** — `queryUtilizationChunk` uses `ROW_NUMBER() OVER (PARTITION BY reservation_id)` for per-reservation row limits instead of a global LIMIT that starved later reservations.

## Files changed

- `pkg/models/gpu.go` — status validation helpers (`IsValid`, `CanTransitionTo`)
- `pkg/store/store.go` — new interface methods
- `pkg/store/sqlite.go` — `UpdateGPUReservationWithCapacity`, `GetGPUReservationsByIDs`, per-reservation LIMIT
- `pkg/api/handlers/gpu.go` — all handler-level validation and atomic update wiring
- `pkg/api/handlers/gpu_test.go` — test store methods + test fixes
- `pkg/test/mock_store.go` — mock implementations

## Test plan

- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] All GPU handler tests pass (`TestGPUCreateReservation_*`, `TestGPUUpdateReservation_*`, `TestGPUBulkUtilizations_*`)
- [x] Store tests pass
- [ ] CI build/lint