### PR TITLE
fix(backend): SSE goroutine safety, MCP error propagation, notification persistence (#6945-#6956)

### DIFF
--- a/pkg/api/handlers/feedback.go
+++ b/pkg/api/handlers/feedback.go
@@ -1412,7 +1412,10 @@ func (h *FeedbackHandler) handleIssueEvent(payload map[string]interface{}) error
 				return nil
 			}
 
-			h.store.UpdateFeatureRequestStatus(request.ID, info.status)
+			if err := h.store.UpdateFeatureRequestStatus(request.ID, info.status); err != nil {
+				slog.Error("[Webhook] failed to update status", "issue", issueNumber, "error", err)
+				return nil
+			}
 			h.createNotification(
 				request.UserID,
 				&request.ID,
@@ -1462,7 +1465,10 @@ func (h *FeedbackHandler) handleAIProcessingComplete(issueNumber int, issueURL s
 	}
 
 	// Update status to unable to fix (needs human review)
-	h.store.UpdateFeatureRequestStatus(request.ID, models.RequestStatusUnableToFix)
+	if err := h.store.UpdateFeatureRequestStatus(request.ID, models.RequestStatusUnableToFix); err != nil {
+		slog.Error("[Webhook] failed to update unable-to-fix status", "issue", issueNumber, "error", err)
+		return nil
+	}
 
 	// Get the most recent bot comment to summarize the status
 	summary := h.getLatestBotComment(issueNumber, h.resolveRepoName(request.TargetRepo))
@@ -1471,7 +1477,10 @@ func (h *FeedbackHandler) handleAIProcessingComplete(issueNumber int, issueURL s
 	}
 
 	// Store the latest comment on the request
-	h.store.UpdateFeatureRequestLatestComment(request.ID, summary)
+	if err := h.store.UpdateFeatureRequestLatestComment(request.ID, summary); err != nil {
+		slog.Error("[Webhook] failed to update latest comment", "issue", issueNumber, "error", err)
+		return nil
+	}
 
 	// Create notification
 	h.createNotification(
@@ -1499,7 +1508,10 @@ func (h *FeedbackHandler) handleIssueClosed(issueNumber int, issueURL string, is
 	}
 
 	// Update status to closed (closed externally, not by the user via console)
-	h.store.CloseFeatureRequest(request.ID, false)
+	if err := h.store.CloseFeatureRequest(request.ID, false); err != nil {
+		slog.Error("[Webhook] failed to close feature request", "issue", issueNumber, "error", err)
+		return nil
+	}
 
 	// Get close reason from state_reason if available
 	stateReason, _ := issue["state_reason"].(string)
@@ -1646,8 +1658,14 @@ func (h *FeedbackHandler) handlePREvent(payload map[string]interface{}) error {
 	switch action {
 	case "opened", "synchronize", "ready_for_review":
 		// Update request with PR info and set status to fix_ready
-		h.store.UpdateFeatureRequestPR(requestID, prNumber, prURL)
-		h.store.UpdateFeatureRequestStatus(requestID, models.RequestStatusFixReady)
+		if err := h.store.UpdateFeatureRequestPR(requestID, prNumber, prURL); err != nil {
+			slog.Error("[Webhook] failed to update PR info", "pr", prNumber, "error", err)
+			return nil
+		}
+		if err := h.store.UpdateFeatureRequestStatus(requestID, models.RequestStatusFixReady); err != nil {
+			slog.Error("[Webhook] failed to update fix_ready status", "pr", prNumber, "error", err)
+			return nil
+		}
 		if action == "opened" {
 			h.createNotification(request.UserID, &requestID, models.NotificationTypeFixReady,
 				fmt.Sprintf("PR #%d Created", prNumber),
@@ -1658,7 +1676,10 @@ func (h *FeedbackHandler) handlePREvent(payload map[string]interface{}) error {
 	case "closed":
 		merged, _ := pr["merged"].(bool)
 		if merged {
-			h.store.UpdateFeatureRequestStatus(requestID, models.RequestStatusFixComplete)
+			if err := h.store.UpdateFeatureRequestStatus(requestID, models.RequestStatusFixComplete); err != nil {
+				slog.Error("[Webhook] failed to update fix_complete status", "pr", prNumber, "error", err)
+				return nil
+			}
 			h.createNotification(request.UserID, &requestID, models.NotificationTypeFixComplete,
 				fmt.Sprintf("PR #%d Merged", prNumber),
 				fmt.Sprintf("The fix for '%s' has been merged!", request.Title),

--- a/pkg/api/handlers/mcp_resources.go
+++ b/pkg/api/handlers/mcp_resources.go
@@ -40,6 +40,7 @@ func (h *MCPHandlers) GetGPUNodes(c *fiber.Ctx) error {
 			var mu sync.Mutex
 			allNodes := make([]k8s.GPUNode, 0)
 			clusterTimeout := mcpExtendedTimeout // Increased for large GPU clusters
+			var errTracker clusterErrorTracker
 
 			clusterCtx, clusterCancel := context.WithCancel(c.Context())
 			defer clusterCancel()
@@ -52,7 +53,9 @@ func (h *MCPHandlers) GetGPUNodes(c *fiber.Ctx) error {
 					defer cancel()
 
 					nodes, err := h.k8sClient.GetGPUNodes(ctx, clusterName)
-					if err == nil && len(nodes) > 0 {
+					if err != nil {
+						errTracker.add(clusterName, err)
+					} else if len(nodes) > 0 {
 						mu.Lock()
 						allNodes = append(allNodes, nodes...)
 						mu.Unlock()
@@ -61,7 +64,7 @@ func (h *MCPHandlers) GetGPUNodes(c *fiber.Ctx) error {
 			}
 
 			waitWithDeadline(&wg, clusterCancel, maxResponseDeadline)
-			return c.JSON(fiber.Map{"nodes": allNodes, "source": "k8s"})
+			return c.JSON(errTracker.annotate(fiber.Map{"nodes": allNodes, "source": "k8s"}))
 		}
 
 		ctx, cancel := context.WithTimeout(c.Context(), mcpExtendedTimeout)
@@ -102,6 +105,7 @@ func (h *MCPHandlers) GetGPUNodeHealth(c *fiber.Ctx) error {
 			var mu sync.Mutex
 			allNodes := make([]k8s.GPUNodeHealthStatus, 0)
 			clusterTimeout := mcpExtendedTimeout
+			var errTracker clusterErrorTracker
 
 			clusterCtx, clusterCancel := context.WithCancel(c.Context())
 			defer clusterCancel()
@@ -114,7 +118,9 @@ func (h *MCPHandlers) GetGPUNodeHealth(c *fiber.Ctx) error {
 					defer cancel()
 
 					nodes, err := h.k8sClient.GetGPUNodeHealth(ctx, clusterName)
-					if err == nil && len(nodes) > 0 {
+					if err != nil {
+						errTracker.add(clusterName, err)
+					} else if len(nodes) > 0 {
 						mu.Lock()
 						allNodes = append(allNodes, nodes...)
 						mu.Unlock()
@@ -123,7 +129,7 @@ func (h *MCPHandlers) GetGPUNodeHealth(c *fiber.Ctx) error {
 			}
 
 			waitWithDeadline(&wg, clusterCancel, maxResponseDeadline)
-			return c.JSON(fiber.Map{"nodes": allNodes, "source": "k8s"})
+			return c.JSON(errTracker.annotate(fiber.Map{"nodes": allNodes, "source": "k8s"}))
 		}
 
 		ctx, cancel := context.WithTimeout(c.Context(), mcpExtendedTimeout)
@@ -302,6 +308,7 @@ func (h *MCPHandlers) GetNVIDIAOperatorStatus(c *fiber.Ctx) error {
 			var mu sync.Mutex
 			allStatus := make([]*k8s.NVIDIAOperatorStatus, 0)
 			clusterTimeout := mcpDefaultTimeout
+			var errTracker clusterErrorTracker
 
 			clusterCtx, clusterCancel := context.WithCancel(c.Context())
 			defer clusterCancel()
@@ -314,7 +321,9 @@ func (h *MCPHandlers) GetNVIDIAOperatorStatus(c *fiber.Ctx) error {
 					defer cancel()
 
 					status, err := h.k8sClient.GetNVIDIAOperatorStatus(ctx, clusterName)
-					if err == nil && (status.GPUOperator != nil || status.NetworkOperator != nil) {
+					if err != nil {
+						errTracker.add(clusterName, err)
+					} else if status.GPUOperator != nil || status.NetworkOperator != nil {
 						mu.Lock()
 						allStatus = append(allStatus, status)
 						mu.Unlock()
@@ -323,7 +332,7 @@ func (h *MCPHandlers) GetNVIDIAOperatorStatus(c *fiber.Ctx) error {
 			}
 
 			waitWithDeadline(&wg, clusterCancel, maxResponseDeadline)
-			return c.JSON(fiber.Map{"operators": allStatus, "source": "k8s"})
+			return c.JSON(errTracker.annotate(fiber.Map{"operators": allStatus, "source": "k8s"}))
 		}
 
 		ctx, cancel := context.WithTimeout(c.Context(), mcpDefaultTimeout)
@@ -364,6 +373,7 @@ func (h *MCPHandlers) GetConfigMaps(c *fiber.Ctx) error {
 			var mu sync.Mutex
 			allConfigMaps := make([]k8s.ConfigMap, 0)
 			clusterTimeout := mcpDefaultTimeout
+			var errTracker clusterErrorTracker
 
 			clusterCtx, clusterCancel := context.WithCancel(c.Context())
 			defer clusterCancel()
@@ -376,7 +386,9 @@ func (h *MCPHandlers) GetConfigMaps(c *fiber.Ctx) error {
 					defer cancel()
 
 					configmaps, err := h.k8sClient.GetConfigMaps(ctx, clusterName, namespace)
-					if err == nil && len(configmaps) > 0 {
+					if err != nil {
+						errTracker.add(clusterName, err)
+					} else if len(configmaps) > 0 {
 						mu.Lock()
 						allConfigMaps = append(allConfigMaps, configmaps...)
 						mu.Unlock()
@@ -385,7 +397,7 @@ func (h *MCPHandlers) GetConfigMaps(c *fiber.Ctx) error {
 			}
 
 			waitWithDeadline(&wg, clusterCancel, maxResponseDeadline)
-			return c.JSON(fiber.Map{"configmaps": allConfigMaps, "source": "k8s"})
+			return c.JSON(errTracker.annotate(fiber.Map{"configmaps": allConfigMaps, "source": "k8s"}))
 		}
 
 		ctx, cancel := context.WithTimeout(c.Context(), mcpDefaultTimeout)
@@ -429,6 +441,7 @@ func (h *MCPHandlers) GetSecrets(c *fiber.Ctx) error {
 			var mu sync.Mutex
 			allSecrets := make([]k8s.Secret, 0)
 			clusterTimeout := mcpDefaultTimeout
+			var errTracker clusterErrorTracker
 
 			clusterCtx, clusterCancel := context.WithCancel(c.Context())
 			defer clusterCancel()
@@ -441,7 +454,9 @@ func (h *MCPHandlers) GetSecrets(c *fiber.Ctx) error {
 					defer cancel()
 
 					secrets, err := h.k8sClient.GetSecrets(ctx, clusterName, namespace)
-					if err == nil && len(secrets) > 0 {
+					if err != nil {
+						errTracker.add(clusterName, err)
+					} else if len(secrets) > 0 {
 						mu.Lock()
 						allSecrets = append(allSecrets, secrets...)
 						mu.Unlock()
@@ -450,7 +465,7 @@ func (h *MCPHandlers) GetSecrets(c *fiber.Ctx) error {
 			}
 
 			waitWithDeadline(&wg, clusterCancel, maxResponseDeadline)
-			return c.JSON(fiber.Map{"secrets": allSecrets, "source": "k8s"})
+			return c.JSON(errTracker.annotate(fiber.Map{"secrets": allSecrets, "source": "k8s"}))
 		}
 
 		ctx, cancel := context.WithTimeout(c.Context(), mcpDefaultTimeout)
@@ -494,6 +509,7 @@ func (h *MCPHandlers) GetServiceAccounts(c *fiber.Ctx) error {
 			var mu sync.Mutex
 			allServiceAccounts := make([]k8s.ServiceAccount, 0)
 			clusterTimeout := mcpDefaultTimeout
+			var errTracker clusterErrorTracker
 
 			clusterCtx, clusterCancel := context.WithCancel(c.Context())
 			defer clusterCancel()
@@ -506,7 +522,9 @@ func (h *MCPHandlers) GetServiceAccounts(c *fiber.Ctx) error {
 					defer cancel()
 
 					serviceAccounts, err := h.k8sClient.GetServiceAccounts(ctx, clusterName, namespace)
-					if err == nil && len(serviceAccounts) > 0 {
+					if err != nil {
+						errTracker.add(clusterName, err)
+					} else if len(serviceAccounts) > 0 {
 						mu.Lock()
 						allServiceAccounts = append(allServiceAccounts, serviceAccounts...)
 						mu.Unlock()
@@ -515,7 +533,7 @@ func (h *MCPHandlers) GetServiceAccounts(c *fiber.Ctx) error {
 			}
 
 			waitWithDeadline(&wg, clusterCancel, maxResponseDeadline)
-			return c.JSON(fiber.Map{"serviceAccounts": allServiceAccounts, "source": "k8s"})
+			return c.JSON(errTracker.annotate(fiber.Map{"serviceAccounts": allServiceAccounts, "source": "k8s"}))
 		}
 
 		ctx, cancel := context.WithTimeout(c.Context(), mcpDefaultTimeout)
@@ -559,6 +577,7 @@ func (h *MCPHandlers) GetPVCs(c *fiber.Ctx) error {
 			var mu sync.Mutex
 			allPVCs := make([]k8s.PVC, 0)
 			clusterTimeout := mcpDefaultTimeout
+			var errTracker clusterErrorTracker
 
 			clusterCtx, clusterCancel := context.WithCancel(c.Context())
 			defer clusterCancel()
@@ -571,7 +590,9 @@ func (h *MCPHandlers) GetPVCs(c *fiber.Ctx) error {
 					defer cancel()
 
 					pvcs, err := h.k8sClient.GetPVCs(ctx, clusterName, namespace)
-					if err == nil && len(pvcs) > 0 {
+					if err != nil {
+						errTracker.add(clusterName, err)
+					} else if len(pvcs) > 0 {
 						mu.Lock()
 						allPVCs = append(allPVCs, pvcs...)
 						mu.Unlock()
@@ -580,7 +601,7 @@ func (h *MCPHandlers) GetPVCs(c *fiber.Ctx) error {
 			}
 
 			waitWithDeadline(&wg, clusterCancel, maxResponseDeadline)
-			return c.JSON(fiber.Map{"pvcs": allPVCs, "source": "k8s"})
+			return c.JSON(errTracker.annotate(fiber.Map{"pvcs": allPVCs, "source": "k8s"}))
 		}
 
 		ctx, cancel := context.WithTimeout(c.Context(), mcpDefaultTimeout)
@@ -622,6 +643,7 @@ func (h *MCPHandlers) GetPVs(c *fiber.Ctx) error {
 			var mu sync.Mutex
 			allPVs := make([]k8s.PV, 0)
 			clusterTimeout := mcpDefaultTimeout
+			var errTracker clusterErrorTracker
 
 			clusterCtx, clusterCancel := context.WithCancel(c.Context())
 			defer clusterCancel()
@@ -634,7 +656,9 @@ func (h *MCPHandlers) GetPVs(c *fiber.Ctx) error {
 					defer cancel()
 
 					pvs, err := h.k8sClient.GetPVs(ctx, clusterName)
-					if err == nil && len(pvs) > 0 {
+					if err != nil {
+						errTracker.add(clusterName, err)
+					} else if len(pvs) > 0 {
 						mu.Lock()
 						allPVs = append(allPVs, pvs...)
 						mu.Unlock()
@@ -643,7 +667,7 @@ func (h *MCPHandlers) GetPVs(c *fiber.Ctx) error {
 			}
 
 			waitWithDeadline(&wg, clusterCancel, maxResponseDeadline)
-			return c.JSON(fiber.Map{"pvs": allPVs, "source": "k8s"})
+			return c.JSON(errTracker.annotate(fiber.Map{"pvs": allPVs, "source": "k8s"}))
 		}
 
 		ctx, cancel := context.WithTimeout(c.Context(), mcpDefaultTimeout)
@@ -687,6 +711,7 @@ func (h *MCPHandlers) GetResourceQuotas(c *fiber.Ctx) error {
 			var mu sync.Mutex
 			allQuotas := make([]k8s.ResourceQuota, 0)
 			clusterTimeout := mcpDefaultTimeout
+			var errTracker clusterErrorTracker
 
 			clusterCtx, clusterCancel := context.WithCancel(c.Context())
 			defer clusterCancel()
@@ -699,7 +724,9 @@ func (h *MCPHandlers) GetResourceQuotas(c *fiber.Ctx) error {
 					defer cancel()
 
 					quotas, err := h.k8sClient.GetResourceQuotas(ctx, clusterName, namespace)
-					if err == nil && len(quotas) > 0 {
+					if err != nil {
+						errTracker.add(clusterName, err)
+					} else if len(quotas) > 0 {
 						mu.Lock()
 						allQuotas = append(allQuotas, quotas...)
 						mu.Unlock()
@@ -708,7 +735,7 @@ func (h *MCPHandlers) GetResourceQuotas(c *fiber.Ctx) error {
 			}
 
 			waitWithDeadline(&wg, clusterCancel, maxResponseDeadline)
-			return c.JSON(fiber.Map{"resourceQuotas": allQuotas, "source": "k8s"})
+			return c.JSON(errTracker.annotate(fiber.Map{"resourceQuotas": allQuotas, "source": "k8s"}))
 		}
 
 		ctx, cancel := context.WithTimeout(c.Context(), mcpDefaultTimeout)
@@ -752,6 +779,7 @@ func (h *MCPHandlers) GetLimitRanges(c *fiber.Ctx) error {
 			var mu sync.Mutex
 			allRanges := make([]k8s.LimitRange, 0)
 			clusterTimeout := mcpDefaultTimeout
+			var errTracker clusterErrorTracker
 
 			clusterCtx, clusterCancel := context.WithCancel(c.Context())
 			defer clusterCancel()
@@ -764,7 +792,9 @@ func (h *MCPHandlers) GetLimitRanges(c *fiber.Ctx) error {
 					defer cancel()
 
 					ranges, err := h.k8sClient.GetLimitRanges(ctx, clusterName, namespace)
-					if err == nil && len(ranges) > 0 {
+					if err != nil {
+						errTracker.add(clusterName, err)
+					} else if len(ranges) > 0 {
 						mu.Lock()
 						allRanges = append(allRanges, ranges...)
 						mu.Unlock()
@@ -773,7 +803,7 @@ func (h *MCPHandlers) GetLimitRanges(c *fiber.Ctx) error {
 			}
 
 			waitWithDeadline(&wg, clusterCancel, maxResponseDeadline)
-			return c.JSON(fiber.Map{"limitRanges": allRanges, "source": "k8s"})
+			return c.JSON(errTracker.annotate(fiber.Map{"limitRanges": allRanges, "source": "k8s"}))
 		}
 
 		ctx, cancel := context.WithTimeout(c.Context(), mcpDefaultTimeout)
@@ -1121,6 +1151,7 @@ func (h *MCPHandlers) GetFlatcarNodes(c *fiber.Ctx) error {
 			var wg sync.WaitGroup
 			var mu sync.Mutex
 			allNodes := make([]k8s.FlatcarNodeInfo, 0)
+			var errTracker clusterErrorTracker
 
 			clusterCtx, clusterCancel := context.WithCancel(c.Context())
 			defer clusterCancel()
@@ -1133,7 +1164,9 @@ func (h *MCPHandlers) GetFlatcarNodes(c *fiber.Ctx) error {
 					defer cancel()
 
 					nodes, err := h.k8sClient.GetFlatcarNodes(ctx, clusterName)
-					if err == nil && len(nodes) > 0 {
+					if err != nil {
+						errTracker.add(clusterName, err)
+					} else if len(nodes) > 0 {
 						mu.Lock()
 						allNodes = append(allNodes, nodes...)
 						mu.Unlock()
@@ -1142,7 +1175,7 @@ func (h *MCPHandlers) GetFlatcarNodes(c *fiber.Ctx) error {
 			}
 
 			waitWithDeadline(&wg, clusterCancel, maxResponseDeadline)
-			return c.JSON(fiber.Map{"nodes": allNodes, "source": "k8s"})
+			return c.JSON(errTracker.annotate(fiber.Map{"nodes": allNodes, "source": "k8s"}))
 		}
 
 		// Single cluster query
@@ -1184,6 +1217,7 @@ func (h *MCPHandlers) GetIngresses(c *fiber.Ctx) error {
 			var mu sync.Mutex
 			allItems := make([]k8s.Ingress, 0)
 			clusterTimeout := mcpDefaultTimeout
+			var errTracker clusterErrorTracker
 
 			clusterCtx, clusterCancel := context.WithCancel(c.Context())
 			defer clusterCancel()
@@ -1196,7 +1230,9 @@ func (h *MCPHandlers) GetIngresses(c *fiber.Ctx) error {
 					defer cancel()
 
 					items, err := h.k8sClient.GetIngresses(ctx, clusterName, namespace)
-					if err == nil && len(items) > 0 {
+					if err != nil {
+						errTracker.add(clusterName, err)
+					} else if len(items) > 0 {
 						mu.Lock()
 						allItems = append(allItems, items...)
 						mu.Unlock()
@@ -1205,7 +1241,7 @@ func (h *MCPHandlers) GetIngresses(c *fiber.Ctx) error {
 			}
 
 			waitWithDeadline(&wg, clusterCancel, maxResponseDeadline)
-			return c.JSON(fiber.Map{"ingresses": allItems, "source": "k8s"})
+			return c.JSON(errTracker.annotate(fiber.Map{"ingresses": allItems, "source": "k8s"}))
 		}
 
 		ctx, cancel := context.WithTimeout(c.Context(), mcpDefaultTimeout)
@@ -1249,6 +1285,7 @@ func (h *MCPHandlers) GetNetworkPolicies(c *fiber.Ctx) error {
 			var mu sync.Mutex
 			allItems := make([]k8s.NetworkPolicy, 0)
 			clusterTimeout := mcpDefaultTimeout
+			var errTracker clusterErrorTracker
 
 			clusterCtx, clusterCancel := context.WithCancel(c.Context())
 			defer clusterCancel()
@@ -1261,7 +1298,9 @@ func (h *MCPHandlers) GetNetworkPolicies(c *fiber.Ctx) error {
 					defer cancel()
 
 					items, err := h.k8sClient.GetNetworkPolicies(ctx, clusterName, namespace)
-					if err == nil && len(items) > 0 {
+					if err != nil {
+						errTracker.add(clusterName, err)
+					} else if len(items) > 0 {
 						mu.Lock()
 						allItems = append(allItems, items...)
 						mu.Unlock()
@@ -1270,7 +1309,7 @@ func (h *MCPHandlers) GetNetworkPolicies(c *fiber.Ctx) error {
 			}
 
 			waitWithDeadline(&wg, clusterCancel, maxResponseDeadline)
-			return c.JSON(fiber.Map{"networkpolicies": allItems, "source": "k8s"})
+			return c.JSON(errTracker.annotate(fiber.Map{"networkpolicies": allItems, "source": "k8s"}))
 		}
 
 		ctx, cancel := context.WithTimeout(c.Context(), mcpDefaultTimeout)
@@ -1360,6 +1399,7 @@ func (h *MCPHandlers) GetPodNetworkStats(c *fiber.Ctx) error {
 	var wg sync.WaitGroup
 	var mu sync.Mutex
 	allStats := make([]PodNetworkStats, 0)
+	var errTracker clusterErrorTracker
 
 	clusterCtx, clusterCancel := context.WithCancel(c.Context())
 	defer clusterCancel()
@@ -1374,7 +1414,7 @@ func (h *MCPHandlers) GetPodNetworkStats(c *fiber.Ctx) error {
 
 			client, clientErr := h.k8sClient.GetClient(clusterName)
 			if clientErr != nil {
-				slog.Info("[MCP] network stats: cannot get client", "cluster", clusterName, "error", clientErr)
+				errTracker.add(clusterName, clientErr)
 				return
 			}
 
@@ -1428,7 +1468,7 @@ func (h *MCPHandlers) GetPodNetworkStats(c *fiber.Ctx) error {
 	}
 
 	waitWithDeadline(&wg, clusterCancel, maxResponseDeadline)
-	return c.JSON(fiber.Map{"stats": allStats, "source": "k8s"})
+	return c.JSON(errTracker.annotate(fiber.Map{"stats": allStats, "source": "k8s"}))
 }
 
 // kubeletStatsSummary is a minimal representation of the kubelet /stats/summary response.

--- a/pkg/api/handlers/mcp_workloads.go
+++ b/pkg/api/handlers/mcp_workloads.go
@@ -136,6 +136,7 @@ func (h *MCPHandlers) FindPodIssues(c *fiber.Ctx) error {
 			var mu sync.Mutex
 			allIssues := make([]k8s.PodIssue, 0)
 			clusterTimeout := mcpExtendedTimeout
+			var errTracker clusterErrorTracker
 
 			clusterCtx, clusterCancel := context.WithCancel(c.Context())
 			defer clusterCancel()
@@ -148,7 +149,9 @@ func (h *MCPHandlers) FindPodIssues(c *fiber.Ctx) error {
 					defer cancel()
 
 					issues, err := h.k8sClient.FindPodIssues(ctx, clusterName, namespace)
-					if err == nil && len(issues) > 0 {
+					if err != nil {
+						errTracker.add(clusterName, err)
+					} else if len(issues) > 0 {
 						mu.Lock()
 						allIssues = append(allIssues, issues...)
 						mu.Unlock()
@@ -157,7 +160,7 @@ func (h *MCPHandlers) FindPodIssues(c *fiber.Ctx) error {
 			}
 
 			waitWithDeadline(&wg, clusterCancel, maxResponseDeadline)
-			return c.JSON(fiber.Map{"issues": allIssues, "source": "k8s"})
+			return c.JSON(errTracker.annotate(fiber.Map{"issues": allIssues, "source": "k8s"}))
 		}
 
 		ctx, cancel := context.WithTimeout(c.Context(), mcpDefaultTimeout)
@@ -203,6 +206,7 @@ func (h *MCPHandlers) FindDeploymentIssues(c *fiber.Ctx) error {
 			var mu sync.Mutex
 			allIssues := make([]k8s.DeploymentIssue, 0)
 			clusterTimeout := mcpDefaultTimeout
+			var errTracker clusterErrorTracker
 
 			clusterCtx, clusterCancel := context.WithCancel(c.Context())
 			defer clusterCancel()
@@ -215,7 +219,9 @@ func (h *MCPHandlers) FindDeploymentIssues(c *fiber.Ctx) error {
 					defer cancel()
 
 					issues, err := h.k8sClient.FindDeploymentIssues(ctx, clusterName, namespace)
-					if err == nil && len(issues) > 0 {
+					if err != nil {
+						errTracker.add(clusterName, err)
+					} else if len(issues) > 0 {
 						mu.Lock()
 						allIssues = append(allIssues, issues...)
 						mu.Unlock()
@@ -224,7 +230,7 @@ func (h *MCPHandlers) FindDeploymentIssues(c *fiber.Ctx) error {
 			}
 
 			waitWithDeadline(&wg, clusterCancel, maxResponseDeadline)
-			return c.JSON(fiber.Map{"issues": allIssues, "source": "k8s"})
+			return c.JSON(errTracker.annotate(fiber.Map{"issues": allIssues, "source": "k8s"}))
 		}
 
 		ctx, cancel := context.WithTimeout(c.Context(), mcpDefaultTimeout)

--- a/pkg/api/handlers/sse.go
+++ b/pkg/api/handlers/sse.go
@@ -185,6 +185,9 @@ var (
 	sseCache     = map[string]*sseCacheEntry{}
 	sseCacheMu   sync.RWMutex
 	sseCacheOnce sync.Once
+	// sseCacheEvictDone is closed to stop the background evictor goroutine
+	// on server shutdown or in tests, preventing goroutine leaks (#6956).
+	sseCacheEvictDone = make(chan struct{})
 )
 
 type sseCacheEntry struct {
@@ -194,23 +197,40 @@ type sseCacheEntry struct {
 
 // startSSECacheEvictor launches a background goroutine (once) that periodically
 // deletes expired entries from sseCache so memory doesn't grow without bound.
+// The goroutine exits when sseCacheEvictDone is closed (#6956).
 func startSSECacheEvictor() {
 	sseCacheOnce.Do(func() {
 		go func() {
 			ticker := time.NewTicker(sseCacheEvictInterval)
 			defer ticker.Stop()
-			for range ticker.C {
-				now := time.Now()
-				sseCacheMu.Lock()
-				for k, e := range sseCache {
-					if now.Sub(e.fetchedAt) >= sseCacheTTL {
-						delete(sseCache, k)
+			for {
+				select {
+				case <-sseCacheEvictDone:
+					return
+				case <-ticker.C:
+					now := time.Now()
+					sseCacheMu.Lock()
+					for k, e := range sseCache {
+						if now.Sub(e.fetchedAt) >= sseCacheTTL {
+							delete(sseCache, k)
+						}
 					}
+					sseCacheMu.Unlock()
 				}
-				sseCacheMu.Unlock()
 			}
 		}()
 	})
+}
+
+// StopSSECacheEvictor signals the background evictor goroutine to exit.
+// Safe to call multiple times. Intended for server shutdown and tests (#6956).
+func StopSSECacheEvictor() {
+	select {
+	case <-sseCacheEvictDone:
+		// Already closed
+	default:
+		close(sseCacheEvictDone)
+	}
 }
 
 func sseCacheGet(key string) interface{} {
@@ -443,11 +463,14 @@ func streamClusters(
 					// intentionally left unchanged — this is an additive
 					// event type.
 					mu.Lock()
-					completedClusters++
-					emitEvent(sseEventClusterError, fiber.Map{
+					if !emitEvent(sseEventClusterError, fiber.Map{
 						"cluster": clusterName,
 						"error":   fetchErr.Error(),
-					})
+					}) {
+						mu.Unlock()
+						return
+					}
+					completedClusters++
 					mu.Unlock()
 					return
 				}
@@ -460,12 +483,15 @@ func streamClusters(
 				}
 
 				mu.Lock()
-				completedClusters++
-				emitEvent(sseEventClusterData, fiber.Map{
+				if !emitEvent(sseEventClusterData, fiber.Map{
 					"cluster":   clusterName,
 					cfg.demoKey: data,
 					"source":    "k8s",
-				})
+				}) {
+					mu.Unlock()
+					return
+				}
+				completedClusters++
 				mu.Unlock()
 			}(cl.Name, cacheKey)
 		}
@@ -481,9 +507,14 @@ func streamClusters(
 		case <-done:
 			// All healthy clusters finished
 		case <-streamCtx.Done():
-			slog.Info("[SSE] stream context done, sending partial results", "error", streamCtx.Err())
+			slog.Info("[SSE] stream context done, waiting for goroutines", "error", streamCtx.Err())
 			// Cancel all in-flight goroutines immediately.
 			streamCancel()
+			// Wait for goroutines to finish before emitting the done
+			// event or returning from the callback. This prevents:
+			//  - cluster_data events arriving after done (#6952)
+			//  - writes to a recycled response writer (#6953)
+			<-done
 		}
 
 		mu.Lock()
@@ -505,15 +536,20 @@ func streamDemoSSE(c *fiber.Ctx, dataKey string, demoData interface{}) error {
 	c.Set("Connection", "keep-alive")
 
 	c.Context().SetBodyStreamWriter(func(w *bufio.Writer) {
-		writeSSEEvent(w, sseEventClusterData, fiber.Map{
+		if err := writeSSEEvent(w, sseEventClusterData, fiber.Map{
 			"cluster": "demo",
 			dataKey:   demoData,
 			"source":  "demo",
-		})
-		writeSSEEvent(w, sseEventDone, fiber.Map{
+		}); err != nil {
+			slog.Info("[SSE] demo stream write failed", "event", sseEventClusterData, "error", err)
+			return
+		}
+		if err := writeSSEEvent(w, sseEventDone, fiber.Map{
 			"totalClusters":     1,
 			"completedClusters": 1,
-		})
+		}); err != nil {
+			slog.Info("[SSE] demo stream write failed", "event", sseEventDone, "error", err)
+		}
 	})
 
 	return nil

--- a/pkg/mcp/client.go
+++ b/pkg/mcp/client.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"log/slog"
 	"os/exec"
 	"sync"
 	"sync/atomic"
@@ -397,7 +398,7 @@ func (c *Client) readResponses() {
 				case <-c.done:
 					// Client is stopping; suppress read errors
 				default:
-					fmt.Printf("[%s] read error: %v\n", c.name, err)
+					slog.Error("[MCP] read error", "client", c.name, "error", err)
 				}
 			}
 			return

--- a/pkg/store/sqlite.go
+++ b/pkg/store/sqlite.go
@@ -356,6 +356,7 @@ func (s *SQLiteStore) migrate() error {
 		title TEXT NOT NULL,
 		message TEXT NOT NULL,
 		read INTEGER DEFAULT 0,
+		action_url TEXT NOT NULL DEFAULT '',
 		created_at DATETIME DEFAULT CURRENT_TIMESTAMP
 	);
 
@@ -463,6 +464,9 @@ func (s *SQLiteStore) migrate() error {
 		// #6284: UpdateFeatureRequestLatestComment writes to this column
 		// but it was never added to CREATE TABLE or migrations.
 		"ALTER TABLE feature_requests ADD COLUMN latest_comment TEXT",
+		// #6949: ActionURL was declared in the Notification model but never
+		// persisted — the column, INSERT, and SELECT all omitted it.
+		"ALTER TABLE notifications ADD COLUMN action_url TEXT NOT NULL DEFAULT ''",
 	}
 	for i, migration := range migrations {
 		if _, err := s.db.Exec(migration); err != nil {
@@ -1643,10 +1647,10 @@ func (s *SQLiteStore) CreateNotification(notification *models.Notification) erro
 		featureRequestID = &str
 	}
 
-	_, err := s.db.Exec(`INSERT INTO notifications (id, user_id, feature_request_id, notification_type, title, message, read, created_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+	_, err := s.db.Exec(`INSERT INTO notifications (id, user_id, feature_request_id, notification_type, title, message, read, action_url, created_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 		notification.ID.String(), notification.UserID.String(), featureRequestID,
 		string(notification.NotificationType), notification.Title, notification.Message,
-		boolToInt(notification.Read), notification.CreatedAt)
+		boolToInt(notification.Read), notification.ActionURL, notification.CreatedAt)
 	return err
 }
 
@@ -1656,7 +1660,7 @@ func (s *SQLiteStore) GetUserNotifications(userID uuid.UUID, limit int) ([]model
 	// caller bypass resource controls and return arbitrarily large
 	// result sets. Match the card_history query's hardening.
 	limit = clampLimit(limit)
-	rows, err := s.db.Query(`SELECT id, user_id, feature_request_id, notification_type, title, message, read, created_at FROM notifications WHERE user_id = ? ORDER BY created_at DESC LIMIT ?`, userID.String(), limit)
+	rows, err := s.db.Query(`SELECT id, user_id, feature_request_id, notification_type, title, message, read, action_url, created_at FROM notifications WHERE user_id = ? ORDER BY created_at DESC LIMIT ?`, userID.String(), limit)
 	if err != nil {
 		return nil, err
 	}
@@ -1670,7 +1674,7 @@ func (s *SQLiteStore) GetUserNotifications(userID uuid.UUID, limit int) ([]model
 		var notificationType string
 		var read int
 
-		if err := rows.Scan(&idStr, &userIDStr, &featureRequestID, &notificationType, &n.Title, &n.Message, &read, &n.CreatedAt); err != nil {
+		if err := rows.Scan(&idStr, &userIDStr, &featureRequestID, &notificationType, &n.Title, &n.Message, &read, &n.ActionURL, &n.CreatedAt); err != nil {
 			return nil, err
 		}
 

--- a/pkg/store/store.go
+++ b/pkg/store/store.go
@@ -138,7 +138,9 @@ type Store interface {
 	CreateNotification(notification *models.Notification) error
 	GetUserNotifications(userID uuid.UUID, limit int) ([]models.Notification, error)
 	GetUnreadNotificationCount(userID uuid.UUID) (int, error)
-	MarkNotificationRead(id uuid.UUID) error
+	// MarkNotificationRead was intentionally removed from the public interface
+	// (#6950). The unscoped method allows any user to mark any other user's
+	// notification as read. Use MarkNotificationReadByUser instead.
 	MarkNotificationReadByUser(id uuid.UUID, userID uuid.UUID) error
 	MarkAllNotificationsRead(userID uuid.UUID) error
 

--- a/pkg/test/mock_store.go
+++ b/pkg/test/mock_store.go
@@ -148,7 +148,6 @@ func (m *MockStore) GetUserNotifications(userID uuid.UUID, limit int) ([]models.
 	return nil, nil
 }
 func (m *MockStore) GetUnreadNotificationCount(userID uuid.UUID) (int, error) { return 0, nil }
-func (m *MockStore) MarkNotificationRead(id uuid.UUID) error                         { return nil }
 func (m *MockStore) MarkNotificationReadByUser(id uuid.UUID, userID uuid.UUID) error { return nil }
 func (m *MockStore) MarkAllNotificationsRead(userID uuid.UUID) error                 { return nil }
 


### PR DESCRIPTION
Closes #6945
Closes #6946
Closes #6947
Closes #6948
Closes #6949
Closes #6950
Closes #6951
Closes #6952
Closes #6953
Closes #6954
Closes #6955
Closes #6956

## Summary

**SSE/Streaming (#6952-#6956):**
- Wait for all cluster goroutines via `<-done` before emitting the terminal `done` event, preventing post-done writes and response writer corruption on connection reuse
- Check `emitEvent` return value in goroutines; skip `completedClusters` increment on write failure so the done event count is accurate
- Check `writeSSEEvent` errors in `streamDemoSSE` and log/return on failure
- Add `sseCacheEvictDone` channel and `StopSSECacheEvictor()` so the background evictor goroutine can be stopped on server shutdown or in tests

**MCP/Multi-cluster (#6945-#6948):**
- Add `clusterErrorTracker` to `FindPodIssues` and `FindDeploymentIssues` in mcp_workloads.go, matching the existing `GetPods` pattern
- Add `clusterErrorTracker` to all 13 multi-cluster handlers in mcp_resources.go (GetGPUNodes, GetGPUNodeHealth, GetNVIDIAOperatorStatus, GetConfigMaps, GetSecrets, GetServiceAccounts, GetPVCs, GetPVs, GetResourceQuotas, GetLimitRanges, GetFlatcarNodes, GetIngresses, GetNetworkPolicies) plus GetPodNetworkStats
- Replace `fmt.Printf` with `slog.Error` in MCP client `readResponses()`

**Notifications/Store (#6949-#6951):**
- Add `action_url` column to notifications table schema, INSERT, SELECT, and add an ALTER TABLE migration for existing databases
- Remove `MarkNotificationRead(id)` from public `Store` interface -- only the ownership-scoped `MarkNotificationReadByUser` remains exposed
- Check all 5+ store mutation errors in webhook handlers before firing notifications

## Test plan
- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] `go test ./pkg/store/...` passes
- [x] Pre-existing test failures (TestRefreshToken, pkg/notifications) confirmed unrelated