### PR TITLE
fix(gpu): utilization query limit, cancellable worker, per-reservation context (#6965-#6967)

### DIFF
--- a/pkg/api/gpu_utilization_worker.go
+++ b/pkg/api/gpu_utilization_worker.go
@@ -24,13 +24,22 @@ const (
 	fullUtilizationPct = 100.0
 )
 
+const (
+	// perReservationTimeoutDivisor divides the poll interval to derive a
+	// per-reservation collection timeout so that a single slow cluster
+	// cannot starve subsequent reservations (#6967).
+	perReservationTimeoutDivisor = 2
+)
+
 // GPUUtilizationWorker periodically collects GPU utilization data for active reservations
 type GPUUtilizationWorker struct {
-	store     store.Store
-	k8sClient *k8s.MultiClusterClient
-	interval  time.Duration
-	stopCh    chan struct{}
-	stopOnce  sync.Once // protects stopCh from double-close panic
+	store      store.Store
+	k8sClient  *k8s.MultiClusterClient
+	interval   time.Duration
+	stopCh     chan struct{}
+	stopOnce   sync.Once // protects stopCh from double-close panic
+	baseCtx    context.Context
+	baseCancel context.CancelFunc
 }
 
 // NewGPUUtilizationWorker creates a new GPU utilization worker
@@ -42,11 +51,14 @@ func NewGPUUtilizationWorker(s store.Store, k8sClient *k8s.MultiClusterClient) *
 		}
 	}
 
+	ctx, cancel := context.WithCancel(context.Background())
 	return &GPUUtilizationWorker{
-		store:     s,
-		k8sClient: k8sClient,
-		interval:  time.Duration(intervalMs) * time.Millisecond,
-		stopCh:    make(chan struct{}),
+		store:      s,
+		k8sClient:  k8sClient,
+		interval:   time.Duration(intervalMs) * time.Millisecond,
+		stopCh:     make(chan struct{}),
+		baseCtx:    ctx,
+		baseCancel: cancel,
 	}
 }
 
@@ -78,6 +90,7 @@ func (w *GPUUtilizationWorker) Start() {
 // only the first call actually closes the stop channel.
 func (w *GPUUtilizationWorker) Stop() {
 	w.stopOnce.Do(func() {
+		w.baseCancel() // cancel all in-flight Kubernetes API calls (#6966)
 		close(w.stopCh)
 	})
 }
@@ -98,12 +111,21 @@ func (w *GPUUtilizationWorker) collectUtilization() {
 		return
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), w.interval/2)
-	defer cancel()
+	// Per-reservation timeout so a slow cluster cannot starve others (#6967).
+	// Derived from w.baseCtx so Stop() cancels in-flight calls immediately (#6966).
+	perReservationTimeout := w.interval / time.Duration(perReservationTimeoutDivisor)
 
+	var wg sync.WaitGroup
 	for i := range reservations {
-		w.collectForReservation(ctx, &reservations[i])
+		wg.Add(1)
+		go func(r *models.GPUReservation) {
+			defer wg.Done()
+			ctx, cancel := context.WithTimeout(w.baseCtx, perReservationTimeout)
+			defer cancel()
+			w.collectForReservation(ctx, r)
+		}(&reservations[i])
 	}
+	wg.Wait()
 }
 
 // collectForReservation collects utilization for a single reservation

--- a/pkg/api/handlers/gpu.go
+++ b/pkg/api/handlers/gpu.go
@@ -421,7 +421,8 @@ func (h *GPUHandler) GetReservationUtilization(c *fiber.Ctx) error {
 		return authErr
 	}
 
-	snapshots, err := h.store.GetUtilizationSnapshots(id)
+	limit := c.QueryInt("limit", store.DefaultSnapshotQueryLimit)
+	snapshots, err := h.store.GetUtilizationSnapshots(id, limit)
 	if err != nil {
 		return fiber.NewError(fiber.StatusInternalServerError, "Failed to get utilization data")
 	}

--- a/pkg/store/sqlite.go
+++ b/pkg/store/sqlite.go
@@ -2064,10 +2064,13 @@ func (s *SQLiteStore) InsertUtilizationSnapshot(snapshot *models.GPUUtilizationS
 	return err
 }
 
-func (s *SQLiteStore) GetUtilizationSnapshots(reservationID string) ([]models.GPUUtilizationSnapshot, error) {
+func (s *SQLiteStore) GetUtilizationSnapshots(reservationID string, limit int) ([]models.GPUUtilizationSnapshot, error) {
+	if limit <= 0 {
+		limit = DefaultSnapshotQueryLimit
+	}
 	rows, err := s.db.Query(
-		`SELECT id, reservation_id, timestamp, gpu_utilization_pct, memory_utilization_pct, active_gpu_count, total_gpu_count FROM gpu_utilization_snapshots WHERE reservation_id = ? ORDER BY timestamp ASC`,
-		reservationID,
+		`SELECT id, reservation_id, timestamp, gpu_utilization_pct, memory_utilization_pct, active_gpu_count, total_gpu_count FROM gpu_utilization_snapshots WHERE reservation_id = ? ORDER BY timestamp DESC LIMIT ?`,
+		reservationID, limit,
 	)
 	if err != nil {
 		return nil, err
@@ -2086,6 +2089,11 @@ func (s *SQLiteStore) GetUtilizationSnapshots(reservationID string) ([]models.GP
 	}
 	return snapshots, rows.Err()
 }
+
+// DefaultSnapshotQueryLimit caps the number of rows returned by
+// GetUtilizationSnapshots to prevent unbounded result sets for
+// long-lived reservations (#6965). Configurable via the limit parameter.
+const DefaultSnapshotQueryLimit = 500
 
 // sqliteMaxVars is the maximum number of bind variables per SQL statement.
 // SQLite's default SQLITE_MAX_VARIABLE_NUMBER is 999; we use 500 as a safe

--- a/pkg/store/store.go
+++ b/pkg/store/store.go
@@ -167,7 +167,7 @@ type Store interface {
 
 	// GPU Utilization Snapshots
 	InsertUtilizationSnapshot(snapshot *models.GPUUtilizationSnapshot) error
-	GetUtilizationSnapshots(reservationID string) ([]models.GPUUtilizationSnapshot, error)
+	GetUtilizationSnapshots(reservationID string, limit int) ([]models.GPUUtilizationSnapshot, error)
 	GetBulkUtilizationSnapshots(reservationIDs []string) (map[string][]models.GPUUtilizationSnapshot, error)
 	DeleteOldUtilizationSnapshots(before time.Time) (int64, error)
 	ListActiveGPUReservations() ([]models.GPUReservation, error)

--- a/pkg/test/mock_store.go
+++ b/pkg/test/mock_store.go
@@ -176,7 +176,7 @@ func (m *MockStore) GetClusterReservedGPUCount(cluster string, excludeID *uuid.U
 func (m *MockStore) InsertUtilizationSnapshot(snapshot *models.GPUUtilizationSnapshot) error {
 	return nil
 }
-func (m *MockStore) GetUtilizationSnapshots(reservationID string) ([]models.GPUUtilizationSnapshot, error) {
+func (m *MockStore) GetUtilizationSnapshots(reservationID string, limit int) ([]models.GPUUtilizationSnapshot, error) {
 	return nil, nil
 }
 func (m *MockStore) GetBulkUtilizationSnapshots(reservationIDs []string) (map[string][]models.GPUUtilizationSnapshot, error) {


### PR DESCRIPTION
Closes #6965
Closes #6966
Closes #6967

## Summary

- **#6965**: `GetUtilizationSnapshots` now accepts a `limit` parameter (default `DefaultSnapshotQueryLimit = 500`) and appends `LIMIT ?` to the SQL query. The handler reads an optional `?limit=` query param.
- **#6966**: The worker stores a cancellable `baseCtx`; `Stop()` calls `baseCancel()` before closing `stopCh`, immediately cancelling all in-flight Kubernetes API calls.
- **#6967**: Each reservation gets its own goroutine with an independent `context.WithTimeout` derived from `baseCtx`, collected concurrently via `sync.WaitGroup`. A slow first cluster no longer starves subsequent reservations.

## Test plan

- [ ] `go build ./...` passes
- [ ] `go vet ./...` passes
- [ ] Verify utilization endpoint respects `?limit=` query param
- [ ] Verify `Stop()` cancels in-flight collection contexts
- [ ] Verify concurrent collection across multiple reservations