### PR TITLE
fix(helm): security hardening, backup safety, probe timeouts, ratchet baseline (#6978-#6994)

### DIFF
--- a/deploy/helm/kubestellar-console/templates/clusterrole.yaml
+++ b/deploy/helm/kubestellar-console/templates/clusterrole.yaml
@@ -66,7 +66,8 @@ rules:
       - horizontalpodautoscalers
     verbs: ["get", "list", "watch"]
 
-  # RBAC v1 - read-only (for RBAC analysis features)
+  {{- if .Values.rbac.rbacInspectionEnabled }}
+  # RBAC v1 - read-only (for RBAC analysis features, opt-out via rbac.rbacInspectionEnabled)
   - apiGroups: ["rbac.authorization.k8s.io"]
     resources:
       - roles
@@ -74,6 +75,7 @@ rules:
       - rolebindings
       - clusterrolebindings
     verbs: ["get", "list", "watch"]
+  {{- end }}
 
   # Authorization - permission checks
   - apiGroups: ["authorization.k8s.io"]
@@ -149,9 +151,11 @@ rules:
       - serviceimports
     verbs: ["get", "list", "watch"]
 
-  # OpenShift user API - read-only
+  {{- if .Values.rbac.openshiftUserAccess }}
+  # OpenShift user API - read-only (opt-in via rbac.openshiftUserAccess)
   - apiGroups: ["user.openshift.io"]
     resources:
       - users
     verbs: ["get", "list", "watch"]
+  {{- end }}
 {{- end }}

--- a/deploy/helm/kubestellar-console/templates/cronjob-db-backup.yaml
+++ b/deploy/helm/kubestellar-console/templates/cronjob-db-backup.yaml
@@ -15,7 +15,8 @@ spec:
       template:
         metadata:
           labels:
-            {{- include "kubestellar-console.selectorLabels" . | nindent 12 }}
+            app.kubernetes.io/name: {{ include "kubestellar-console.name" . }}
+            app.kubernetes.io/instance: {{ .Release.Name }}
             app.kubernetes.io/component: db-backup
         spec:
           restartPolicy: OnFailure
@@ -33,6 +34,8 @@ spec:
               # container-level securityContext as the main deployment.
               securityContext:
                 {{- toYaml .Values.securityContext | nindent 16 }}
+              resources:
+                {{- toYaml .Values.backup.resources | nindent 16 }}
               command:
                 - /bin/sh
                 - -c
@@ -45,9 +48,9 @@ spec:
 
                   mkdir -p "$BACKUP_DIR"
 
-                  # Use SQLite .backup for a consistent snapshot (safe even if DB is in use)
+                  # Use SQLite .backup for a consistent, WAL-safe snapshot
                   if [ -f "$DB_PATH" ]; then
-                    cp "$DB_PATH" "$BACKUP_DIR/console-$TIMESTAMP.db"
+                    sqlite3 "$DB_PATH" ".backup '$BACKUP_DIR/console-$TIMESTAMP.db'"
                     echo "Backup created: $BACKUP_DIR/console-$TIMESTAMP.db"
                   else
                     echo "ERROR: Database file not found at $DB_PATH"

--- a/deploy/helm/kubestellar-console/templates/deployment.yaml
+++ b/deploy/helm/kubestellar-console/templates/deployment.yaml
@@ -21,6 +21,7 @@ spec:
       {{- end }}
       labels:
         {{- include "kubestellar-console.labels" . | nindent 8 }}
+        app.kubernetes.io/component: server
         {{- with .Values.podLabels }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
@@ -30,6 +31,7 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       serviceAccountName: {{ include "kubestellar-console.serviceAccountName" . }}
+      automountServiceAccountToken: true
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       {{- if and .Values.backup.enabled .Values.backup.autoRestore }}
@@ -83,7 +85,7 @@ spec:
 
               echo "Restoring from backup: $LATEST (${BACKUP_SIZE} bytes)"
               mkdir -p "$(dirname "$DB_PATH")"
-              cp "$LATEST" "$DB_PATH"
+              cp "$LATEST" "${DB_PATH}.tmp" && mv "${DB_PATH}.tmp" "$DB_PATH"
               echo "Restore complete"
           volumeMounts:
             - name: data
@@ -120,12 +122,14 @@ spec:
               port: http
             initialDelaySeconds: 10
             periodSeconds: 10
+            timeoutSeconds: 5
           readinessProbe:
             httpGet:
               path: {{ if .Values.watchdog.enabled }}/watchdog/ready{{ else }}/healthz{{ end }}
               port: http
             initialDelaySeconds: 5
             periodSeconds: 5
+            timeoutSeconds: 5
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           env:
@@ -137,10 +141,10 @@ spec:
             {{- end }}
             - name: DATABASE_PATH
               value: {{ .Values.database.sqlitePath | quote }}
-            {{- if .Values.route.enabled }}
+            {{- if and .Values.route.enabled .Values.route.host }}
             - name: FRONTEND_URL
               value: "https://{{ .Values.route.host }}"
-            {{- else if .Values.ingress.enabled }}
+            {{- else if and .Values.ingress.enabled .Values.ingress.hosts }}
             - name: FRONTEND_URL
               value: "https://{{ (index .Values.ingress.hosts 0).host }}"
             {{- end }}
@@ -267,6 +271,20 @@ spec:
                   fieldPath: metadata.namespace
             - name: HELM_RELEASE_NAME
               value: {{ .Release.Name | quote }}
+            {{- if .Values.ai.defaultMode }}
+            - name: AI_DEFAULT_MODE
+              value: {{ .Values.ai.defaultMode | quote }}
+            {{- end }}
+            {{- if .Values.ai.tokenLimits.enabled }}
+            - name: AI_TOKEN_LIMITS_ENABLED
+              value: "true"
+            - name: AI_MONTHLY_TOKEN_LIMIT
+              value: {{ .Values.ai.tokenLimits.monthlyLimit | quote }}
+            - name: AI_TOKEN_WARNING_THRESHOLD
+              value: {{ .Values.ai.tokenLimits.warningThreshold | quote }}
+            - name: AI_TOKEN_CRITICAL_THRESHOLD
+              value: {{ .Values.ai.tokenLimits.criticalThreshold | quote }}
+            {{- end }}
             {{- if .Values.selfUpgrade.enabled }}
             - name: SELF_UPGRADE_ENABLED
               value: "true"

--- a/deploy/helm/kubestellar-console/templates/networkpolicy.yaml
+++ b/deploy/helm/kubestellar-console/templates/networkpolicy.yaml
@@ -11,8 +11,29 @@ spec:
       {{- include "kubestellar-console.selectorLabels" . | nindent 6 }}
   policyTypes:
     - Ingress
+    - Egress
   ingress:
     - ports:
         - port: {{ .Values.service.port | default 8080 }}
           protocol: TCP
+      {{- with .Values.networkPolicy.ingressFrom }}
+      from:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+  egress:
+    # Allow DNS resolution
+    - ports:
+        - port: 53
+          protocol: UDP
+        - port: 53
+          protocol: TCP
+    # Allow HTTPS to Kubernetes API and external services
+    - ports:
+        - port: 443
+          protocol: TCP
+        - port: 6443
+          protocol: TCP
+    {{- with .Values.networkPolicy.extraEgress }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
 {{- end }}

--- a/deploy/helm/kubestellar-console/templates/pdb.yaml
+++ b/deploy/helm/kubestellar-console/templates/pdb.yaml
@@ -6,7 +6,13 @@ metadata:
   labels:
     {{- include "kubestellar-console.labels" . | nindent 4 }}
 spec:
-  minAvailable: {{ .Values.podDisruptionBudget.minAvailable | default 1 }}
+  {{- if .Values.podDisruptionBudget.maxUnavailable }}
+  maxUnavailable: {{ .Values.podDisruptionBudget.maxUnavailable }}
+  {{- else if .Values.podDisruptionBudget.minAvailable }}
+  minAvailable: {{ .Values.podDisruptionBudget.minAvailable }}
+  {{- else }}
+  maxUnavailable: 1
+  {{- end }}
   selector:
     matchLabels:
       {{- include "kubestellar-console.selectorLabels" . | nindent 6 }}

--- a/deploy/helm/kubestellar-console/templates/self-upgrade-role.yaml
+++ b/deploy/helm/kubestellar-console/templates/self-upgrade-role.yaml
@@ -11,5 +11,7 @@ rules:
   - apiGroups: ["apps"]
     resources:
       - deployments
+    resourceNames:
+      - {{ include "kubestellar-console.fullname" . }}
     verbs: ["get", "list", "patch"]
 {{- end }}

--- a/deploy/helm/kubestellar-console/templates/service.yaml
+++ b/deploy/helm/kubestellar-console/templates/service.yaml
@@ -13,3 +13,4 @@ spec:
       name: http
   selector:
     {{- include "kubestellar-console.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: server

--- a/deploy/helm/kubestellar-console/values.yaml
+++ b/deploy/helm/kubestellar-console/values.yaml
@@ -2,7 +2,7 @@ replicaCount: 1
 
 image:
   repository: ghcr.io/kubestellar/console
-  pullPolicy: IfNotPresent
+  pullPolicy: Always
   tag: ""  # Defaults to chart appVersion ("latest"); overridden at release time
 
 imagePullSecrets: []
@@ -11,7 +11,7 @@ fullnameOverride: ""
 
 serviceAccount:
   create: true
-  automount: true
+  automount: false
   annotations: {}
   name: ""
 
@@ -28,6 +28,8 @@ rbac:
   create: true
   resourceQuotasReadOnly: false
   namespaceCreationEnabled: false
+  openshiftUserAccess: false
+  rbacInspectionEnabled: true
 
 podAnnotations: {}
 podLabels: {}
@@ -181,6 +183,14 @@ backup:
   failedJobsHistoryLimit: 3
   # Auto-restore: if the main DB is empty or missing, restore from latest backup
   autoRestore: true
+  # Resource limits for backup CronJob container
+  resources:
+    limits:
+      cpu: 200m
+      memory: 256Mi
+    requests:
+      cpu: 50m
+      memory: 64Mi
 
 # kubestellar binaries configuration
 kubestellar:
@@ -231,10 +241,16 @@ affinity: {}
 
 networkPolicy:
   enabled: false
+  # Restrict which pods/namespaces can reach the console (from: selector)
+  # Example: [{ namespaceSelector: { matchLabels: { name: ingress } } }]
+  ingressFrom: []
+  # Additional egress rules beyond DNS and HTTPS/API
+  extraEgress: []
 
 podDisruptionBudget:
   enabled: false
-  minAvailable: 1
+  # Use maxUnavailable (safe with single replica) instead of minAvailable
+  maxUnavailable: 1
 
 # Watchdog reverse proxy — serves a branded "Reconnecting..." page when backend is down
 watchdog:

--- a/web/src/test/ui-ux-standards.test.ts
+++ b/web/src/test/ui-ux-standards.test.ts
@@ -70,11 +70,12 @@ const COMPONENTS_DIR = path.resolve(
 //   304 → 306: issue 6774 loading/error states — reverted to 304 in issue 6778 (false positives from issue-ref comments rewritten to "issue NNNN" form)
 //   304 → 307: PR 6854 introduced 3 new hex refs (not real color violations)
 //   307 → 309: issue 6882 ratchet drift — pre-existing false positives from issue-ref comments
+//   309 → 313: PR 6977 introduced 4 new hex refs (terminal theme colors, widget export)
 //
 // When you bump this number, append a one-line entry above so future
 // bumps stay grep-able and reviewers can tell at a glance whether a
 // change is a real new violation or just a comment-level reference.
-const EXPECTED_RAW_HEX_COUNT = 309
+const EXPECTED_RAW_HEX_COUNT = 313
 const EXPECTED_RAW_RGBA_COUNT = 104
 const EXPECTED_ARBITRARY_TW_COLOR_COUNT = 22
 const EXPECTED_INLINE_STYLE_COLOR_COUNT = 213


### PR DESCRIPTION
Closes #6978
Closes #6979
Closes #6980
Closes #6981
Closes #6983
Closes #6984
Closes #6985
Closes #6986
Closes #6987
Closes #6988
Closes #6989
Closes #6990
Closes #6991
Closes #6992
Closes #6993
Closes #6994

## Summary

**15 Helm chart fixes** (all reported by @aashu2006) plus **1 ratchet test baseline update**:

| Issue | Fix |
|-------|-----|
| #6978 | Add `resourceNames` to self-upgrade Role (restricts patch to own Deployment) |
| #6979 | Add `app.kubernetes.io/component: server` label to Deployment pods; Service selector now excludes backup CronJob pods |
| #6981 | Replace `cp` with `sqlite3 .backup` for WAL-safe database backups |
| #6983 | Guard `FRONTEND_URL` env var — skip when `route.host` is empty |
| #6984 | Guard `ingress.hosts` index access to prevent panic on empty list |
| #6985 | Add `backup.resources` with default CPU/memory limits for CronJob container |
| #6986 | Default `serviceAccount.automount` to `false`; explicitly mount token in Deployment |
| #6987 | Gate OpenShift user enumeration behind `rbac.openshiftUserAccess: false` |
| #6988 | Gate RBAC topology access behind `rbac.rbacInspectionEnabled: true` |
| #6989 | Add Egress policy (DNS + HTTPS/API) and `ingressFrom` selector to NetworkPolicy |
| #6990 | Add `timeoutSeconds: 5` to liveness and readiness probes |
| #6991 | Wire `ai.defaultMode` and `ai.tokenLimits.*` to container env vars |
| #6992 | Change default `pullPolicy` to `Always` (appVersion is "latest") |
| #6993 | Use atomic `cp` + `mv` in initContainer restore to prevent corruption |
| #6994 | Change PDB default from `minAvailable: 1` to `maxUnavailable: 1` |
| #6980 | Bump `EXPECTED_RAW_HEX_COUNT` from 309 to 313 (PR #6977 drift) |

## Test plan

- [x] `helm template ./deploy/helm/kubestellar-console` renders without errors
- [x] `npm run build` passes
- [x] `npx vitest run src/test/ui-ux-standards.test.ts` passes (7/7)