### PR TITLE
fix(backend): dashboard limits, cluster group persistence, validation, parallel queries (#7005-#7013)

### DIFF
--- a/pkg/api/handlers/cards.go
+++ b/pkg/api/handlers/cards.go
@@ -281,6 +281,13 @@ func (h *CardHandler) DeleteCard(c *fiber.Ctx) error {
 
 // RecordFocus records a card focus event
 func (h *CardHandler) RecordFocus(c *fiber.Ctx) error {
+	// Role check: RecordFocus writes to card_focus and the event log, so
+	// it is a mutating operation that must be restricted to editors/admins,
+	// consistent with CreateCard, UpdateCard, DeleteCard, MoveCard (#7011).
+	if err := h.requireEditorOrAdmin(c); err != nil {
+		return err
+	}
+
 	userID := middleware.GetUserID(c)
 	cardID, err := uuid.Parse(c.Params("id"))
 	if err != nil {

--- a/pkg/api/handlers/dashboard.go
+++ b/pkg/api/handlers/dashboard.go
@@ -15,6 +15,12 @@ import (
 	"github.com/kubestellar/console/pkg/store"
 )
 
+// MaxDashboardsPerUser is the hard limit on the number of dashboards a single
+// user may create. Prevents a runaway script from exhausting database storage
+// by creating unlimited dashboards, each of which may hold up to
+// MaxCardsPerDashboard cards (#7010).
+const MaxDashboardsPerUser = 50
+
 // DashboardExport is the portable format for sharing dashboards
 type DashboardExport struct {
 	Format       string             `json:"format"`
@@ -110,6 +116,16 @@ func (h *DashboardHandler) CreateDashboard(c *fiber.Ctx) error {
 
 	if input.Name == "" {
 		input.Name = "New Dashboard"
+	}
+
+	// Enforce per-user dashboard limit (#7010).
+	count, err := h.store.CountUserDashboards(userID)
+	if err != nil {
+		return fiber.NewError(fiber.StatusInternalServerError, "Failed to check dashboard count")
+	}
+	if count >= MaxDashboardsPerUser {
+		return fiber.NewError(fiber.StatusTooManyRequests,
+			fmt.Sprintf("Dashboard limit reached (%d), maximum is %d per user", count, MaxDashboardsPerUser))
 	}
 
 	dashboard := &models.Dashboard{
@@ -272,6 +288,17 @@ func (h *DashboardHandler) ImportDashboard(c *fiber.Ctx) error {
 	}
 	if err := h.store.CreateDashboard(dashboard); err != nil {
 		return fiber.NewError(fiber.StatusInternalServerError, "Failed to create dashboard")
+	}
+
+	// Validate card types before persisting any cards (#7009). Reject
+	// unknown types upfront so we never need a partial rollback.
+	for i, ce := range input.Cards {
+		if !isValidCardType(models.CardType(ce.CardType)) {
+			// Clean up the dashboard we just created before returning.
+			_ = h.store.DeleteDashboard(dashboard.ID)
+			return fiber.NewError(fiber.StatusBadRequest,
+				fmt.Sprintf("card[%d]: unknown card_type %q", i, ce.CardType))
+		}
 	}
 
 	for _, ce := range input.Cards {

--- a/pkg/api/handlers/onboarding.go
+++ b/pkg/api/handlers/onboarding.go
@@ -2,6 +2,7 @@ package handlers
 
 import (
 	"encoding/json"
+	"fmt"
 	"log/slog"
 	"strings"
 
@@ -11,6 +12,21 @@ import (
 	"github.com/kubestellar/console/pkg/api/middleware"
 	"github.com/kubestellar/console/pkg/models"
 	"github.com/kubestellar/console/pkg/store"
+)
+
+const (
+	// maxOnboardingResponses is the maximum number of responses accepted in a
+	// single SaveResponses call. Prevents a caller from posting unbounded data
+	// that would exhaust connection pools with individual writes (#7005).
+	maxOnboardingResponses = 50
+
+	// maxQuestionKeyLength is the maximum length of a QuestionKey field in an
+	// onboarding response (#7005).
+	maxQuestionKeyLength = 128
+
+	// maxAnswerLength is the maximum length of an Answer field in an onboarding
+	// response (#7005).
+	maxAnswerLength = 1024
 )
 
 // OnboardingHandler handles onboarding operations
@@ -38,6 +54,28 @@ func (h *OnboardingHandler) SaveResponses(c *fiber.Ctx) error {
 	}
 	if err := c.BodyParser(&responses); err != nil {
 		return fiber.NewError(fiber.StatusBadRequest, "Invalid request body")
+	}
+
+	// Cap the number of responses to prevent unbounded writes (#7005).
+	if len(responses) > maxOnboardingResponses {
+		return fiber.NewError(fiber.StatusBadRequest,
+			fmt.Sprintf("Too many responses (%d), maximum is %d", len(responses), maxOnboardingResponses))
+	}
+
+	// Validate field lengths before persisting anything (#7005).
+	for i, r := range responses {
+		if r.QuestionKey == "" {
+			return fiber.NewError(fiber.StatusBadRequest,
+				fmt.Sprintf("response[%d]: question_key is required", i))
+		}
+		if len(r.QuestionKey) > maxQuestionKeyLength {
+			return fiber.NewError(fiber.StatusBadRequest,
+				fmt.Sprintf("response[%d]: question_key exceeds %d characters", i, maxQuestionKeyLength))
+		}
+		if len(r.Answer) > maxAnswerLength {
+			return fiber.NewError(fiber.StatusBadRequest,
+				fmt.Sprintf("response[%d]: answer exceeds %d characters", i, maxAnswerLength))
+		}
 	}
 
 	for _, r := range responses {

--- a/pkg/api/handlers/workloads.go
+++ b/pkg/api/handlers/workloads.go
@@ -18,6 +18,7 @@ import (
 	"github.com/kubestellar/console/pkg/k8s"
 	"github.com/kubestellar/console/pkg/models"
 	"github.com/kubestellar/console/pkg/store"
+	"golang.org/x/sync/errgroup"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -370,6 +371,55 @@ var (
 	clusterGroupsMu sync.RWMutex
 )
 
+// LoadPersistedClusterGroups reloads cluster group definitions from the store
+// into the in-memory map on startup so they survive server restarts (#7013).
+func (h *WorkloadHandlers) LoadPersistedClusterGroups() {
+	if h.store == nil {
+		return
+	}
+	persisted, err := h.store.ListClusterGroups()
+	if err != nil {
+		slog.Error("[Workloads] failed to load persisted cluster groups", "error", err)
+		return
+	}
+	clusterGroupsMu.Lock()
+	defer clusterGroupsMu.Unlock()
+	for name, data := range persisted {
+		var g ClusterGroup
+		if err := json.Unmarshal(data, &g); err != nil {
+			slog.Error("[Workloads] failed to unmarshal persisted cluster group", "name", name, "error", err)
+			continue
+		}
+		clusterGroups[name] = g
+	}
+	slog.Info("[Workloads] loaded persisted cluster groups", "count", len(persisted))
+}
+
+// persistClusterGroup saves a cluster group to the store for durability (#7013).
+func (h *WorkloadHandlers) persistClusterGroup(name string, g ClusterGroup) {
+	if h.store == nil {
+		return
+	}
+	data, err := json.Marshal(g)
+	if err != nil {
+		slog.Error("[Workloads] failed to marshal cluster group for persistence", "name", name, "error", err)
+		return
+	}
+	if err := h.store.SaveClusterGroup(name, data); err != nil {
+		slog.Error("[Workloads] failed to persist cluster group", "name", name, "error", err)
+	}
+}
+
+// deletePersistedClusterGroup removes a cluster group from the store (#7013).
+func (h *WorkloadHandlers) deletePersistedClusterGroup(name string) {
+	if h.store == nil {
+		return
+	}
+	if err := h.store.DeleteClusterGroup(name); err != nil {
+		slog.Error("[Workloads] failed to delete persisted cluster group", "name", name, "error", err)
+	}
+}
+
 // ListClusterGroups returns all cluster groups
 // GET /api/cluster-groups
 func (h *WorkloadHandlers) ListClusterGroups(c *fiber.Ctx) error {
@@ -438,6 +488,9 @@ func (h *WorkloadHandlers) CreateClusterGroup(c *fiber.Ctx) error {
 	clusterGroups[group.Name] = group
 	clusterGroupsMu.Unlock()
 
+	// Persist to store so the group survives server restarts (#7013).
+	h.persistClusterGroup(group.Name, group)
+
 	// Label cluster nodes with group membership
 	if h.k8sClient != nil {
 		ctx, cancel := context.WithTimeout(c.Context(), workloadWriteTimeout)
@@ -488,6 +541,9 @@ func (h *WorkloadHandlers) UpdateClusterGroup(c *fiber.Ctx) error {
 	clusterGroups[name] = group
 	clusterGroupsMu.Unlock()
 
+	// Persist to store so the group survives server restarts (#7013).
+	h.persistClusterGroup(name, group)
+
 	// Remove labels from clusters no longer in the group
 	if existed && h.k8sClient != nil {
 		ctx, cancel := context.WithTimeout(c.Context(), workloadWriteTimeout)
@@ -521,7 +577,9 @@ func (h *WorkloadHandlers) UpdateClusterGroup(c *fiber.Ctx) error {
 			}
 		}
 		if len(labelErrors) > 0 {
-			return c.JSON(fiber.Map{
+			// Return 207 Multi-Status for partial success, consistent with
+			// CreateClusterGroup (#7006).
+			return c.Status(207).JSON(fiber.Map{
 				"group":    group,
 				"warnings": labelErrors,
 			})
@@ -549,6 +607,9 @@ func (h *WorkloadHandlers) DeleteClusterGroup(c *fiber.Ctx) error {
 	delete(clusterGroups, name)
 	clusterGroupsMu.Unlock()
 
+	// Remove from persistent store (#7013).
+	h.deletePersistedClusterGroup(name)
+
 	// Remove labels from all clusters in the deleted group
 	if existed && h.k8sClient != nil {
 		ctx, cancel := context.WithTimeout(c.Context(), workloadWriteTimeout)
@@ -562,7 +623,9 @@ func (h *WorkloadHandlers) DeleteClusterGroup(c *fiber.Ctx) error {
 			}
 		}
 		if len(labelErrors) > 0 {
-			return c.JSON(fiber.Map{
+			// Return 207 Multi-Status for partial success, consistent with
+			// CreateClusterGroup (#7007).
+			return c.Status(207).JSON(fiber.Map{
 				"message":  "Cluster group deleted with warnings",
 				"name":     name,
 				"warnings": labelErrors,
@@ -593,6 +656,11 @@ func (h *WorkloadHandlers) SyncClusterGroups(c *fiber.Ctx) error {
 	}
 
 	clusterGroupsMu.Lock()
+	// Capture old names so we can remove deleted groups from the store.
+	oldNames := make(map[string]bool, len(clusterGroups))
+	for n := range clusterGroups {
+		oldNames[n] = true
+	}
 	clusterGroups = make(map[string]ClusterGroup)
 	for _, g := range groups {
 		if g.Name == allHealthyClustersGroupName {
@@ -600,9 +668,25 @@ func (h *WorkloadHandlers) SyncClusterGroups(c *fiber.Ctx) error {
 		}
 		clusterGroups[g.Name] = g
 	}
+	// Capture count inside the lock to avoid a data race (#7008).
+	syncedCount := len(clusterGroups)
+	// Snapshot for persistence outside the lock.
+	toSave := make(map[string]ClusterGroup, syncedCount)
+	for n, g := range clusterGroups {
+		toSave[n] = g
+	}
 	clusterGroupsMu.Unlock()
 
-	return c.JSON(fiber.Map{"synced": len(clusterGroups)})
+	// Persist the new set and remove stale entries (#7013).
+	for n, g := range toSave {
+		h.persistClusterGroup(n, g)
+		delete(oldNames, n) // still exists
+	}
+	for n := range oldNames {
+		h.deletePersistedClusterGroup(n)
+	}
+
+	return c.JSON(fiber.Map{"synced": syncedCount})
 }
 
 // EvaluateClusterQuery evaluates a dynamic group query against current cluster state
@@ -647,16 +731,28 @@ func (h *WorkloadHandlers) EvaluateClusterQuery(c *fiber.Ctx) error {
 		}
 	}
 
-	// Fetch nodes only for deduplicated clusters
+	// Fetch nodes in parallel using errgroup instead of sequentially (#7012).
 	nodesByCluster := make(map[string][]k8s.NodeInfo)
 	needNodes := query.LabelSelector != "" || hasGPUFilter(query.Filters)
 	if needNodes {
+		var nodesMu sync.Mutex
+		g, gctx := errgroup.WithContext(ctx)
 		for _, cl := range dedupClusters {
-			nodes, err := h.k8sClient.GetNodes(ctx, cl.Name)
-			if err == nil {
-				nodesByCluster[cl.Name] = nodes
-			}
+			clName := cl.Name
+			g.Go(func() error {
+				nodes, err := h.k8sClient.GetNodes(gctx, clName)
+				if err != nil {
+					// Non-fatal: skip clusters that fail, matching original behavior.
+					slog.Warn("[Workloads] failed to get nodes for cluster", "cluster", clName, "error", err)
+					return nil
+				}
+				nodesMu.Lock()
+				nodesByCluster[clName] = nodes
+				nodesMu.Unlock()
+				return nil
+			})
 		}
+		_ = g.Wait() // errors are non-fatal (logged above)
 	}
 
 	matching := make([]string, 0)

--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -942,6 +942,8 @@ func (s *Server) setupRoutes() {
 
 	// Workload routes
 	workloadHandlers := handlers.NewWorkloadHandlers(s.k8sClient, s.hub, s.store)
+	// Reload persisted cluster groups on startup (#7013).
+	workloadHandlers.LoadPersistedClusterGroups()
 	api.Get("/workloads", workloadHandlers.ListWorkloads)
 	api.Get("/workloads/capabilities", workloadHandlers.GetClusterCapabilities)
 	api.Get("/workloads/policies", workloadHandlers.ListBindingPolicies)

--- a/pkg/store/sqlite.go
+++ b/pkg/store/sqlite.go
@@ -450,6 +450,12 @@ func (s *SQLiteStore) migrate() error {
 		expires_at DATETIME NOT NULL
 	);
 	CREATE INDEX IF NOT EXISTS idx_oauth_states_expires_at ON oauth_states(expires_at);
+
+	CREATE TABLE IF NOT EXISTS cluster_groups (
+		name TEXT PRIMARY KEY,
+		data BLOB NOT NULL,
+		updated_at DATETIME DEFAULT CURRENT_TIMESTAMP
+	);
 	`
 	_, err := s.db.Exec(schema)
 	if err != nil {
@@ -741,6 +747,14 @@ func (s *SQLiteStore) SetUserOnboarded(userID uuid.UUID) error {
 func (s *SQLiteStore) GetDashboard(id uuid.UUID) (*models.Dashboard, error) {
 	row := s.db.QueryRow(`SELECT id, user_id, name, layout, is_default, created_at, updated_at FROM dashboards WHERE id = ?`, id.String())
 	return s.scanDashboard(row)
+}
+
+// CountUserDashboards returns the total number of dashboards owned by a user.
+// Used to enforce the per-user dashboard limit (#7010).
+func (s *SQLiteStore) CountUserDashboards(userID uuid.UUID) (int, error) {
+	var count int
+	err := s.db.QueryRow(`SELECT COUNT(*) FROM dashboards WHERE user_id = ?`, userID.String()).Scan(&count)
+	return count, err
 }
 
 // GetUserDashboards returns a page of a user's dashboards, default dashboard
@@ -2844,4 +2858,40 @@ func (s *SQLiteStore) CleanupExpiredOAuthStates() (int64, error) {
 		return 0, err
 	}
 	return result.RowsAffected()
+}
+
+// SaveClusterGroup upserts a cluster group definition (#7013).
+func (s *SQLiteStore) SaveClusterGroup(name string, data []byte) error {
+	_, err := s.db.Exec(
+		`INSERT INTO cluster_groups (name, data, updated_at) VALUES (?, ?, CURRENT_TIMESTAMP)
+		 ON CONFLICT(name) DO UPDATE SET data = excluded.data, updated_at = CURRENT_TIMESTAMP`,
+		name, data,
+	)
+	return err
+}
+
+// DeleteClusterGroup removes a cluster group definition (#7013).
+func (s *SQLiteStore) DeleteClusterGroup(name string) error {
+	_, err := s.db.Exec(`DELETE FROM cluster_groups WHERE name = ?`, name)
+	return err
+}
+
+// ListClusterGroups returns all persisted cluster group definitions (#7013).
+func (s *SQLiteStore) ListClusterGroups() (map[string][]byte, error) {
+	rows, err := s.db.Query(`SELECT name, data FROM cluster_groups`)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	groups := make(map[string][]byte)
+	for rows.Next() {
+		var name string
+		var data []byte
+		if err := rows.Scan(&name, &data); err != nil {
+			return nil, err
+		}
+		groups[name] = data
+	}
+	return groups, rows.Err()
 }

--- a/pkg/store/store.go
+++ b/pkg/store/store.go
@@ -68,6 +68,9 @@ type Store interface {
 
 	// Dashboards
 	GetDashboard(id uuid.UUID) (*models.Dashboard, error)
+	// CountUserDashboards returns the total number of dashboards owned by a
+	// user. Used to enforce the per-user dashboard cap (#7010).
+	CountUserDashboards(userID uuid.UUID) (int, error)
 	// GetUserDashboards returns a page of a user's dashboards.
 	// #6596: limit/offset are required. Pass 0 for limit to use the default.
 	GetUserDashboards(userID uuid.UUID, limit, offset int) ([]models.Dashboard, error)
@@ -235,6 +238,13 @@ type Store interface {
 	// the BEGIN IMMEDIATE transaction if the browser disconnects.
 	ConsumeOAuthState(ctx context.Context, state string) (bool, error)
 	CleanupExpiredOAuthStates() (int64, error)
+
+	// Cluster Groups — persistent storage for cluster group definitions so they
+	// survive server restarts (#7013). The in-memory map is the runtime cache;
+	// these methods keep the SQLite table in sync.
+	SaveClusterGroup(name string, data []byte) error
+	DeleteClusterGroup(name string) error
+	ListClusterGroups() (map[string][]byte, error)
 
 	// Lifecycle
 	Close() error

--- a/pkg/test/mock_store.go
+++ b/pkg/test/mock_store.go
@@ -346,4 +346,27 @@ func (m *MockStore) ConsumeOAuthState(ctx context.Context, state string) (bool, 
 
 func (m *MockStore) CleanupExpiredOAuthStates() (int64, error) { return 0, nil }
 
+func (m *MockStore) CountUserDashboards(userID uuid.UUID) (int, error) {
+	args := m.Called(userID)
+	return args.Int(0), args.Error(1)
+}
+
+func (m *MockStore) SaveClusterGroup(name string, data []byte) error {
+	args := m.Called(name, data)
+	return args.Error(0)
+}
+
+func (m *MockStore) DeleteClusterGroup(name string) error {
+	args := m.Called(name)
+	return args.Error(0)
+}
+
+func (m *MockStore) ListClusterGroups() (map[string][]byte, error) {
+	args := m.Called()
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(map[string][]byte), args.Error(1)
+}
+
 func (m *MockStore) Close() error { return nil }


### PR DESCRIPTION
Closes #7005
Closes #7006
Closes #7007
Closes #7008
Closes #7009
Closes #7010
Closes #7011
Closes #7012
Closes #7013

## Summary

- **#7005**: `SaveResponses` now caps responses at 50, validates `QuestionKey` (max 128 chars) and `Answer` (max 1024 chars) lengths before persisting
- **#7006**: `UpdateClusterGroup` returns HTTP 207 Multi-Status on partial label failure, consistent with `CreateClusterGroup`
- **#7007**: `DeleteClusterGroup` returns HTTP 207 Multi-Status on partial label failure
- **#7008**: `SyncClusterGroups` captures `len(clusterGroups)` inside the write lock to prevent data race
- **#7009**: `ImportDashboard` validates card types against `isValidCardType` registry before persisting, matching `CreateCard` behavior
- **#7010**: `CreateDashboard` enforces `MaxDashboardsPerUser = 50` via new `CountUserDashboards` store method
- **#7011**: `RecordFocus` now calls `requireEditorOrAdmin` before writing to `card_focus` and event log
- **#7012**: `EvaluateClusterQuery` fetches nodes in parallel via `errgroup` instead of sequentially
- **#7013**: Cluster groups persisted to SQLite `cluster_groups` table; reloaded into in-memory map on server startup via `LoadPersistedClusterGroups`

## Test plan

- [ ] `go build ./...` and `go vet ./...` pass
- [ ] Existing tests pass (`go test ./pkg/...`)
- [ ] Verify SaveResponses rejects >50 responses and oversized fields
- [ ] Verify UpdateClusterGroup/DeleteClusterGroup return 207 on partial failure
- [ ] Verify cluster groups survive server restart
- [ ] Verify RecordFocus returns 403 for viewer-role users