### PR TITLE
fix(backend): auth gaps, race conditions, panic guards, selector injection (#6996-#7004)

### DIFF
--- a/pkg/agent/prediction_worker.go
+++ b/pkg/agent/prediction_worker.go
@@ -77,7 +77,7 @@ type PredictionWorker struct {
 	predictions []AIPrediction
 	providers   []string
 	lastRun     time.Time
-	running     bool
+	running     atomic.Bool
 	mu          sync.RWMutex
 	stopCh      chan struct{}
 	// stopOnce guards Stop() so that concurrent / repeated calls do not
@@ -192,13 +192,11 @@ func (w *PredictionWorker) GetPredictions() AIPredictionsResponse {
 // requires a larger refactor. See the doc comment on Stop() for the full
 // story around graceful shutdown and ctx propagation.
 func (w *PredictionWorker) TriggerAnalysis(providers []string) error {
-	w.mu.Lock()
-	if w.running {
-		w.mu.Unlock()
+	// Use atomic compare-and-swap to prevent concurrent runAnalysis
+	// executions without an unlocked window (#7002).
+	if !w.running.CompareAndSwap(false, true) {
 		return fmt.Errorf("analysis already in progress")
 	}
-	w.running = true
-	w.mu.Unlock()
 
 	go func() {
 		defer func() {
@@ -206,9 +204,7 @@ func (w *PredictionWorker) TriggerAnalysis(providers []string) error {
 				slog.Error("[PredictionWorker] panic in runAnalysis; recovered",
 					"panic", r)
 			}
-			w.mu.Lock()
-			w.running = false
-			w.mu.Unlock()
+			w.running.Store(false)
 		}()
 		w.runAnalysis(providers)
 	}()
@@ -218,9 +214,7 @@ func (w *PredictionWorker) TriggerAnalysis(providers []string) error {
 
 // IsAnalyzing returns whether analysis is currently running
 func (w *PredictionWorker) IsAnalyzing() bool {
-	w.mu.RLock()
-	defer w.mu.RUnlock()
-	return w.running
+	return w.running.Load()
 }
 
 // runLoop is the main background loop.
@@ -271,10 +265,8 @@ func (w *PredictionWorker) runLoop() {
 		w.mu.RUnlock()
 
 		if settings.AIEnabled {
-			w.mu.Lock()
-			if !w.running {
-				w.running = true
-				w.mu.Unlock()
+			// Use atomic CAS to prevent concurrent runAnalysis (#7002).
+			if w.running.CompareAndSwap(false, true) {
 				// #6673 — recover from panics in runAnalysis so the
 				// periodic loop survives a single bad run. Without this,
 				// a panic in any provider parser would permanently kill
@@ -289,10 +281,8 @@ func (w *PredictionWorker) runLoop() {
 					}()
 					w.runAnalysis(nil)
 				}()
-				w.mu.Lock()
-				w.running = false
+				w.running.Store(false)
 			}
-			w.mu.Unlock()
 		}
 
 		// Wait for next interval or stop signal using the reused timer.
@@ -311,6 +301,17 @@ func (w *PredictionWorker) runLoop() {
 				}
 			}
 			slog.Info("[PredictionWorker] Stopping")
+			return
+		case <-w.ctx.Done():
+			// Handle context cancellation during interval wait, mirroring
+			// the initial-delay select (#6998).
+			if !intervalTimer.Stop() {
+				select {
+				case <-intervalTimer.C:
+				default:
+				}
+			}
+			slog.Info("[PredictionWorker] Context cancelled during interval wait")
 			return
 		}
 	}

--- a/pkg/agent/server_ai.go
+++ b/pkg/agent/server_ai.go
@@ -582,9 +582,11 @@ func (s *Server) handleChatMessageStreaming(conn *websocket.Conn, msg protocol.M
 				}
 			}
 		}()
+		// Defer close so the heartbeat goroutine is always stopped,
+		// even if StreamChatWithProgress panics (#7001).
+		defer close(heartbeatDone)
 
 		resp, err = streamingProvider.StreamChatWithProgress(ctx, chatReq, onChunk, onProgress)
-		close(heartbeatDone)
 		if err != nil {
 			if ctx.Err() != nil {
 				// Distinguish timeout from user-initiated cancel (#2375)
@@ -599,7 +601,10 @@ func (s *Server) handleChatMessageStreaming(conn *websocket.Conn, msg protocol.M
 			}
 			slog.Error("[Chat] streaming execution error", "agent", agentName, "error", err)
 			code, msg2 := classifyProviderError(err)
-			safeWrite(ctx, s.errorResponse(msg.ID, code, msg2))
+			// Use background context so the error reaches the client even if
+			// the mission context expired between the ctx.Err() check above
+			// and this write (#6997).
+			safeWrite(context.Background(), s.errorResponse(msg.ID, code, msg2))
 			return
 		}
 
@@ -624,7 +629,9 @@ func (s *Server) handleChatMessageStreaming(conn *websocket.Conn, msg protocol.M
 			}
 			slog.Error("[Chat] execution error", "agent", agentName, "error", err)
 			code, msg2 := classifyProviderError(err)
-			safeWrite(ctx, s.errorResponse(msg.ID, code, msg2))
+			// Use background context so the error reaches the client even if
+			// the mission context expired (#6997).
+			safeWrite(context.Background(), s.errorResponse(msg.ID, code, msg2))
 			return
 		}
 	}
@@ -1240,6 +1247,17 @@ Command output:
 			"mode":  "mixed",
 		},
 	})
+
+	// Send TypeResult with Done:true so the UI clears the "Thinking..."
+	// spinner and unlocks the input, matching the regular streaming path (#6999).
+	safeWrite(protocol.Message{
+		ID:   msg.ID,
+		Type: protocol.TypeResult,
+		Payload: protocol.ChatStreamPayload{
+			SessionID: sessionID,
+			Done:      true,
+		},
+	})
 }
 
 // promptNeedsToolExecution checks if the prompt or history suggests command execution
@@ -1447,8 +1465,15 @@ func (s *Server) saveTokenUsage() {
 	}
 
 	path := getTokenUsagePath()
-	if err := os.WriteFile(path, data, agentFileMode); err != nil {
-		slog.Warn("could not save token usage", "error", err)
+	// Atomic write: write to a temp file then rename to avoid corruption
+	// when multiple goroutines persist concurrently (#6996).
+	tmpPath := path + ".tmp"
+	if err := os.WriteFile(tmpPath, data, agentFileMode); err != nil {
+		slog.Warn("could not write token usage temp file", "error", err)
+		return
+	}
+	if err := os.Rename(tmpPath, path); err != nil {
+		slog.Warn("could not rename token usage temp file", "error", err)
 	}
 }
 

--- a/pkg/agent/server_http.go
+++ b/pkg/agent/server_http.go
@@ -263,6 +263,12 @@ func (s *Server) handleNamespacesHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// SECURITY: Validate token when configured (#7000)
+	if !s.validateToken(r) {
+		http.Error(w, "Unauthorized", http.StatusUnauthorized)
+		return
+	}
+
 	if s.k8sClient == nil {
 		writeJSON(w,map[string]interface{}{"namespaces": []interface{}{}, "error": "k8s client not initialized"})
 		return
@@ -294,6 +300,12 @@ func (s *Server) handleDeploymentsHTTP(w http.ResponseWriter, r *http.Request) {
 
 	if r.Method == "OPTIONS" {
 		w.WriteHeader(http.StatusOK)
+		return
+	}
+
+	// SECURITY: Validate token when configured (#7000)
+	if !s.validateToken(r) {
+		http.Error(w, "Unauthorized", http.StatusUnauthorized)
 		return
 	}
 
@@ -335,6 +347,11 @@ func (s *Server) handleReplicaSetsHTTP(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 		return
 	}
+	// SECURITY: Validate token when configured (#7000)
+	if !s.validateToken(r) {
+		http.Error(w, "Unauthorized", http.StatusUnauthorized)
+		return
+	}
 	if s.k8sClient == nil {
 		writeJSON(w,map[string]interface{}{"replicasets": []interface{}{}, "error": "k8s client not initialized"})
 		return
@@ -362,6 +379,11 @@ func (s *Server) handleStatefulSetsHTTP(w http.ResponseWriter, r *http.Request) 
 	w.Header().Set("Content-Type", "application/json")
 	if r.Method == "OPTIONS" {
 		w.WriteHeader(http.StatusOK)
+		return
+	}
+	// SECURITY: Validate token when configured (#7000)
+	if !s.validateToken(r) {
+		http.Error(w, "Unauthorized", http.StatusUnauthorized)
 		return
 	}
 	if s.k8sClient == nil {
@@ -393,6 +415,11 @@ func (s *Server) handleDaemonSetsHTTP(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 		return
 	}
+	// SECURITY: Validate token when configured (#7000)
+	if !s.validateToken(r) {
+		http.Error(w, "Unauthorized", http.StatusUnauthorized)
+		return
+	}
 	if s.k8sClient == nil {
 		writeJSON(w,map[string]interface{}{"daemonsets": []interface{}{}, "error": "k8s client not initialized"})
 		return
@@ -420,6 +447,11 @@ func (s *Server) handleCronJobsHTTP(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 	if r.Method == "OPTIONS" {
 		w.WriteHeader(http.StatusOK)
+		return
+	}
+	// SECURITY: Validate token when configured (#7000)
+	if !s.validateToken(r) {
+		http.Error(w, "Unauthorized", http.StatusUnauthorized)
 		return
 	}
 	if s.k8sClient == nil {
@@ -451,6 +483,11 @@ func (s *Server) handleIngressesHTTP(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 		return
 	}
+	// SECURITY: Validate token when configured (#7000)
+	if !s.validateToken(r) {
+		http.Error(w, "Unauthorized", http.StatusUnauthorized)
+		return
+	}
 	if s.k8sClient == nil {
 		writeJSON(w,map[string]interface{}{"ingresses": []interface{}{}, "error": "k8s client not initialized"})
 		return
@@ -478,6 +515,11 @@ func (s *Server) handleNetworkPoliciesHTTP(w http.ResponseWriter, r *http.Reques
 	w.Header().Set("Content-Type", "application/json")
 	if r.Method == "OPTIONS" {
 		w.WriteHeader(http.StatusOK)
+		return
+	}
+	// SECURITY: Validate token when configured (#7000)
+	if !s.validateToken(r) {
+		http.Error(w, "Unauthorized", http.StatusUnauthorized)
 		return
 	}
 	if s.k8sClient == nil {
@@ -509,6 +551,11 @@ func (s *Server) handleServicesHTTP(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 		return
 	}
+	// SECURITY: Validate token when configured (#7000)
+	if !s.validateToken(r) {
+		http.Error(w, "Unauthorized", http.StatusUnauthorized)
+		return
+	}
 	if s.k8sClient == nil {
 		writeJSON(w,map[string]interface{}{"services": []interface{}{}, "error": "k8s client not initialized"})
 		return
@@ -536,6 +583,11 @@ func (s *Server) handleConfigMapsHTTP(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 	if r.Method == "OPTIONS" {
 		w.WriteHeader(http.StatusOK)
+		return
+	}
+	// SECURITY: Validate token when configured (#7000)
+	if !s.validateToken(r) {
+		http.Error(w, "Unauthorized", http.StatusUnauthorized)
 		return
 	}
 	if s.k8sClient == nil {
@@ -603,6 +655,11 @@ func (s *Server) handleServiceAccountsHTTP(w http.ResponseWriter, r *http.Reques
 		w.WriteHeader(http.StatusOK)
 		return
 	}
+	// SECURITY: Validate token when configured (#7000)
+	if !s.validateToken(r) {
+		http.Error(w, "Unauthorized", http.StatusUnauthorized)
+		return
+	}
 	if s.k8sClient == nil {
 		writeJSON(w,map[string]interface{}{"serviceaccounts": []interface{}{}, "error": "k8s client not initialized"})
 		return
@@ -630,6 +687,11 @@ func (s *Server) handleJobsHTTP(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 	if r.Method == "OPTIONS" {
 		w.WriteHeader(http.StatusOK)
+		return
+	}
+	// SECURITY: Validate token when configured (#7000)
+	if !s.validateToken(r) {
+		http.Error(w, "Unauthorized", http.StatusUnauthorized)
 		return
 	}
 	if s.k8sClient == nil {

--- a/pkg/agent/worker_lifecycle_test.go
+++ b/pkg/agent/worker_lifecycle_test.go
@@ -106,17 +106,13 @@ func TestPredictionWorker_TriggerAnalysisPanicRecovery(t *testing.T) {
 	// Simulate the panic path: flip running to true, then run the same
 	// deferred machinery TriggerAnalysis installs, then panic.
 	func() {
-		w.mu.Lock()
-		w.running = true
-		w.mu.Unlock()
+		w.running.Store(true)
 		defer func() {
 			if r := recover(); r != nil {
 				// Expected: we panicked on purpose below.
 				_ = r
 			}
-			w.mu.Lock()
-			w.running = false
-			w.mu.Unlock()
+			w.running.Store(false)
 		}()
 		panic("simulated runAnalysis panic")
 	}()

--- a/pkg/api/handlers/workloads.go
+++ b/pkg/api/handlers/workloads.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log/slog"
 	"math"
+	"regexp"
 	"sort"
 	"strconv"
 	"strings"
@@ -365,6 +366,10 @@ type ClusterGroup struct {
 const allHealthyClustersGroupName = "all-healthy-clusters"
 
 // In-memory cluster group store (persisted via frontend localStorage; backend is source of truth for labels)
+// validLabelValue matches Kubernetes label values: alphanumeric, '-', '_', '.'
+// up to 63 characters. Used to prevent label selector injection (#7004).
+var validLabelValue = regexp.MustCompile(`^[a-zA-Z0-9]([a-zA-Z0-9._-]{0,61}[a-zA-Z0-9])?$`)
+
 var (
 	clusterGroups   = make(map[string]ClusterGroup)
 	clusterGroupsMu sync.RWMutex
@@ -1094,7 +1099,12 @@ func (h *WorkloadHandlers) GetDeployLogs(c *fiber.Ctx) error {
 	cluster := c.Params("cluster")
 	namespace := c.Params("namespace")
 	name := c.Params("name")
-	tailLines := c.QueryInt("tail", 8)
+	const defaultTailLines = 8
+	tailLines := c.QueryInt("tail", defaultTailLines)
+	// Clamp to a safe range to prevent panic from negative slice indices (#7003).
+	if tailLines <= 0 {
+		tailLines = defaultTailLines
+	}
 
 	client, err := h.k8sClient.GetClient(cluster)
 	if err != nil {
@@ -1103,6 +1113,13 @@ func (h *WorkloadHandlers) GetDeployLogs(c *fiber.Ctx) error {
 
 	ctx, cancel := context.WithTimeout(c.Context(), workloadDeployLogsTimeout)
 	defer cancel()
+
+	// Validate workload name to prevent label selector injection (#7004).
+	// A crafted name like "foo,env=prod" would expand to "app=foo,env=prod"
+	// and match pods from unrelated workloads.
+	if !validLabelValue.MatchString(name) {
+		return c.Status(400).JSON(fiber.Map{"error": "invalid workload name"})
+	}
 
 	// Try label selector first: app=<name>
 	pods, err := client.CoreV1().Pods(namespace).List(ctx, metav1.ListOptions{


### PR DESCRIPTION
Closes #6996
Closes #6997
Closes #6998
Closes #6999
Closes #7000
Closes #7001
Closes #7002
Closes #7003
Closes #7004

## Summary

- **#6996** — Atomic token usage file write (tmp+rename) to prevent corruption under concurrent streaming sessions
- **#6997** — Use `context.Background()` for provider error response writes so errors reach the client when mission context expires
- **#6998** — Add `ctx.Done()` case to PredictionWorker interval-wait select to prevent goroutine stall on context cancellation
- **#6999** — Send `TypeResult` with `Done: true` after `TypeStreamEnd` in mixed-mode chat so the UI clears the spinner
- **#7000** — Add `validateToken` auth check to 12 HTTP handlers that were serving K8s data without authentication
- **#7001** — Defer `close(heartbeatDone)` so the heartbeat goroutine stops even if `StreamChatWithProgress` panics
- **#7002** — Replace `bool` running field with `atomic.Bool` + `CompareAndSwap` to eliminate the race window between check and `runAnalysis`
- **#7003** — Clamp negative `tail` query parameter to default to prevent panic from out-of-bounds slice access
- **#7004** — Validate workload name against Kubernetes label value regex before interpolating into label selector

## Test plan

- [ ] `go build ./...` passes
- [ ] `go vet ./...` passes
- [ ] Verify concurrent AI sessions no longer corrupt token usage file
- [ ] Verify mixed-mode chat clears "Thinking..." spinner after completion
- [ ] Verify unauthenticated calls to /namespaces, /deployments etc. return 401 when KC_AGENT_TOKEN is set
- [ ] Verify `?tail=-1` on deploy-logs returns default events instead of panicking
- [ ] Verify workload name with `,` in URL returns 400 instead of leaking cross-workload pods