### PR TITLE
fix(backend): GPU metrics races, proxy safety, connection reuse, cache stampede (#7015-#7025)

### DIFF
--- a/pkg/agent/metrics_history.go
+++ b/pkg/agent/metrics_history.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"strconv"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/kubestellar/console/pkg/k8s"
@@ -67,10 +68,11 @@ type MetricsHistory struct {
 	k8sClient          *k8s.MultiClusterClient
 	snapshots          []MetricsSnapshot
 	mu                 sync.RWMutex
+	diskMu             sync.Mutex // serializes saveToDisk calls (#7017)
 	stopCh             chan struct{}
 	dataDir            string
-	loggedClusterError bool  // suppress repeated "no kubeconfig" errors
-	lastPersistError   error // last saveToDisk error, nil on success (#5553)
+	loggedClusterError atomic.Bool // suppress repeated "no kubeconfig" errors (#7015)
+	lastPersistError   error       // last saveToDisk error, nil on success (#5553)
 }
 
 // NewMetricsHistory creates a new metrics history manager
@@ -178,8 +180,8 @@ func (mh *MetricsHistory) captureSnapshot() error {
 	// Get cluster health
 	healthList, err := mh.k8sClient.GetAllClusterHealth(ctx)
 	if err != nil {
-		if !mh.loggedClusterError {
-			mh.loggedClusterError = true
+		if !mh.loggedClusterError.Load() {
+			mh.loggedClusterError.Store(true)
 			slog.Info("[MetricsHistory] cluster data unavailable (will retry silently)", "error", err)
 		}
 	} else {
@@ -202,12 +204,16 @@ func (mh *MetricsHistory) captureSnapshot() error {
 		}
 	}
 
-	// Get pod issues from all clusters
+	// Get pod issues and GPU nodes from all clusters.
+	// If ListClusters fails, skip GPU metrics entirely instead of saving
+	// a zeroed snapshot that masks the error (#7016).
 	clusters, err := mh.k8sClient.ListClusters(ctx)
-	if err == nil {
+	if err != nil {
+		slog.Error("[MetricsHistory] ListClusters failed, skipping pod/GPU metrics for this snapshot", "error", err)
+	} else {
 		for _, cluster := range clusters {
-			pods, err := mh.k8sClient.FindPodIssues(ctx, cluster.Context, "")
-			if err != nil {
+			pods, podErr := mh.k8sClient.FindPodIssues(ctx, cluster.Context, "")
+			if podErr != nil {
 				continue
 			}
 			for _, p := range pods {
@@ -221,7 +227,7 @@ func (mh *MetricsHistory) captureSnapshot() error {
 		}
 	}
 
-	// Get GPU nodes from all clusters
+	// Get GPU nodes from all clusters (only if ListClusters succeeded)
 	for _, cluster := range clusters {
 		gpuNodes, err := mh.k8sClient.GetGPUNodes(ctx, cluster.Context)
 		if err != nil {
@@ -242,12 +248,20 @@ func (mh *MetricsHistory) captureSnapshot() error {
 	mh.mu.Lock()
 	mh.snapshots = append(mh.snapshots, snapshot)
 
-	// Trim old snapshots (keep last 7 days)
+	// Trim old snapshots (keep last 7 days).
+	// Snapshots with unparseable timestamps are kept and logged (#7018)
+	// rather than silently dropped, so historical data is not destroyed.
 	cutoff := time.Now().Add(-time.Duration(snapshotRetentionHrs) * time.Hour)
 	trimmed := make([]MetricsSnapshot, 0, len(mh.snapshots))
 	for _, s := range mh.snapshots {
-		ts, err := time.Parse(time.RFC3339, s.Timestamp)
-		if err == nil && ts.After(cutoff) {
+		ts, parseErr := time.Parse(time.RFC3339, s.Timestamp)
+		if parseErr != nil {
+			slog.Warn("[MetricsHistory] snapshot has unparseable timestamp, keeping data",
+				"timestamp", s.Timestamp, "error", parseErr)
+			trimmed = append(trimmed, s)
+			continue
+		}
+		if ts.After(cutoff) {
 			trimmed = append(trimmed, s)
 		}
 	}
@@ -260,8 +274,10 @@ func (mh *MetricsHistory) captureSnapshot() error {
 	mh.snapshots = trimmed
 	mh.mu.Unlock()
 
-	// Persist to disk
-	go mh.saveToDisk()
+	// Persist to disk synchronously — concurrent goroutines caused JSON
+	// corruption via interleaved writes (#7017). The diskMu serializes
+	// saves without holding mh.mu during the actual file I/O.
+	mh.saveToDisk()
 
 	slog.Info("[MetricsHistory] captured snapshot", "clusters", len(snapshot.Clusters), "podIssues", len(snapshot.PodIssues), "gpuNodes", len(snapshot.GPUNodes))
 
@@ -269,7 +285,12 @@ func (mh *MetricsHistory) captureSnapshot() error {
 }
 
 // saveToDisk persists history to disk and tracks the last error for health checks (#5553).
+// Writes are serialized by diskMu and use atomic file swap (write-to-temp then
+// os.Rename) to prevent corruption from incomplete writes (#7017).
 func (mh *MetricsHistory) saveToDisk() {
+	mh.diskMu.Lock()
+	defer mh.diskMu.Unlock()
+
 	mh.mu.RLock()
 	data, err := json.Marshal(mh.snapshots)
 	mh.mu.RUnlock()
@@ -292,8 +313,39 @@ func (mh *MetricsHistory) saveToDisk() {
 	}
 
 	filePath := filepath.Join(mh.dataDir, metricsHistoryFile)
-	if err := os.WriteFile(filePath, data, metricsFileMode); err != nil {
-		slog.Error("[MetricsHistory] error writing history file", "error", err)
+
+	// Atomic write: write to a temp file, then rename to avoid partial writes.
+	tmpFile, err := os.CreateTemp(mh.dataDir, "metrics_history_*.tmp")
+	if err != nil {
+		slog.Error("[MetricsHistory] error creating temp file", "error", err)
+		mh.mu.Lock()
+		mh.lastPersistError = err
+		mh.mu.Unlock()
+		return
+	}
+	tmpPath := tmpFile.Name()
+
+	if _, err := tmpFile.Write(data); err != nil {
+		tmpFile.Close()
+		os.Remove(tmpPath)
+		slog.Error("[MetricsHistory] error writing temp file", "error", err)
+		mh.mu.Lock()
+		mh.lastPersistError = err
+		mh.mu.Unlock()
+		return
+	}
+	if err := tmpFile.Close(); err != nil {
+		os.Remove(tmpPath)
+		slog.Error("[MetricsHistory] error closing temp file", "error", err)
+		mh.mu.Lock()
+		mh.lastPersistError = err
+		mh.mu.Unlock()
+		return
+	}
+
+	if err := os.Rename(tmpPath, filePath); err != nil {
+		os.Remove(tmpPath)
+		slog.Error("[MetricsHistory] error renaming temp file to history file", "error", err)
 		mh.mu.Lock()
 		mh.lastPersistError = err
 		mh.mu.Unlock()
@@ -330,12 +382,19 @@ func (mh *MetricsHistory) loadFromDisk() {
 		return
 	}
 
-	// Filter out old snapshots
+	// Filter out old snapshots; keep snapshots with unparseable timestamps
+	// and log a warning so operators can investigate (#7018).
 	cutoff := time.Now().Add(-time.Duration(snapshotRetentionHrs) * time.Hour)
 	filtered := make([]MetricsSnapshot, 0)
 	for _, s := range snapshots {
-		ts, err := time.Parse(time.RFC3339, s.Timestamp)
-		if err == nil && ts.After(cutoff) {
+		ts, parseErr := time.Parse(time.RFC3339, s.Timestamp)
+		if parseErr != nil {
+			slog.Warn("[MetricsHistory] loaded snapshot has unparseable timestamp, keeping data",
+				"timestamp", s.Timestamp, "error", parseErr)
+			filtered = append(filtered, s)
+			continue
+		}
+		if ts.After(cutoff) {
 			filtered = append(filtered, s)
 		}
 	}

--- a/pkg/agent/prediction_metrics.go
+++ b/pkg/agent/prediction_metrics.go
@@ -115,27 +115,56 @@ func sanitizeLabel(value string, allowed map[string]bool) string {
 	return "other"
 }
 
-// SetActivePredictions updates the gauge of active predictions
+// SetActivePredictions updates the gauge of active predictions.
+// Instead of Reset() + repopulate (which creates a window where all values
+// are zero, causing false alerts on Prometheus scrape), we compute the new
+// label set, delete stale labels, and set updated values atomically (#7025).
 func SetActivePredictions(predictions []AIPrediction) {
-	// Reset all gauges
-	predictionsActive.Reset()
-
 	// Count by type, severity, source — sanitize labels to prevent unbounded cardinality
-	counts := make(map[string]float64)
+	newCounts := make(map[string]float64)
 	for _, p := range predictions {
 		category := sanitizeLabel(p.Category, allowedCategories)
 		severity := sanitizeLabel(p.Severity, allowedSeverities)
 		key := category + "|" + severity + "|ai"
-		counts[key]++
+		newCounts[key]++
 	}
 
-	for key, count := range counts {
+	// Set or update values for current predictions first (before deleting stale).
+	// This ensures a scrape never sees all-zero.
+	for key, count := range newCounts {
 		parts := splitKey(key)
 		if len(parts) == 3 {
 			predictionsActive.WithLabelValues(parts[0], parts[1], parts[2]).Set(count)
 		}
 	}
+
+	// Delete label sets that are no longer present.
+	// Track which label sets existed previously so we can remove stale ones.
+	activePredictionsMu.Lock()
+	previousKeys := activePredictionsKeys
+	activePredictionsKeys = make(map[string]bool, len(newCounts))
+	for key := range newCounts {
+		activePredictionsKeys[key] = true
+	}
+	activePredictionsMu.Unlock()
+
+	for key := range previousKeys {
+		if _, exists := newCounts[key]; !exists {
+			// Remove stale label set
+			parts := splitKey(key)
+			if len(parts) == 3 {
+				predictionsActive.DeleteLabelValues(parts[0], parts[1], parts[2])
+			}
+		}
+	}
 }
+
+// activePredictionsMu protects activePredictionsKeys.
+var activePredictionsMu sync.Mutex
+
+// activePredictionsKeys tracks the label-set keys from the last SetActivePredictions
+// call so stale series can be deleted without a full Reset (#7025).
+var activePredictionsKeys = make(map[string]bool)
 
 // RecordFeedback records prediction feedback in metrics
 func RecordFeedback(feedback, provider string) {

--- a/pkg/agent/prometheus.go
+++ b/pkg/agent/prometheus.go
@@ -7,10 +7,19 @@ import (
 	"log/slog"
 	"net/http"
 	"net/url"
+	"sync"
 	"time"
 
 	"k8s.io/client-go/rest"
 )
+
+// promClientCache reuses http.Client instances keyed by cluster API server URL.
+// Creating a new TLS transport per Prometheus query leaks connections and
+// performs redundant TLS handshakes (#7024).
+var promClientCache struct {
+	sync.RWMutex
+	clients map[string]*http.Client
+}
 
 const (
 	prometheusQueryTimeout = 10 * time.Second
@@ -109,17 +118,13 @@ func (s *Server) handlePrometheusQuery(w http.ResponseWriter, r *http.Request) {
 
 	fullURL := fmt.Sprintf("%s%s?%s", config.Host, proxyPath, params.Encode())
 
-	// Create an HTTP client with the cluster's TLS/auth config
-	transport, err := rest.TransportFor(config)
+	// Reuse an HTTP client per cluster API server URL to avoid creating a new
+	// TLS transport (and leaking connections) on every query (#7024).
+	client, err := getOrCreatePromClient(config)
 	if err != nil {
 		writePrometheusError(w, http.StatusInternalServerError,
 			fmt.Sprintf("failed to create transport: %v", err))
 		return
-	}
-
-	client := &http.Client{
-		Transport: transport,
-		Timeout:   prometheusQueryTimeout,
 	}
 
 	resp, err := client.Get(fullURL)
@@ -135,4 +140,43 @@ func (s *Server) handlePrometheusQuery(w http.ResponseWriter, r *http.Request) {
 	if _, copyErr := io.Copy(w, resp.Body); copyErr != nil {
 		slog.Error("failed to stream Prometheus response", "error", copyErr)
 	}
+}
+
+// getOrCreatePromClient returns a cached http.Client for the given REST config,
+// keyed by the API server Host URL. Clients are created once and reused to
+// avoid per-query TLS handshakes and connection leaks (#7024).
+func getOrCreatePromClient(config *rest.Config) (*http.Client, error) {
+	key := config.Host
+
+	promClientCache.RLock()
+	if promClientCache.clients != nil {
+		if c, ok := promClientCache.clients[key]; ok {
+			promClientCache.RUnlock()
+			return c, nil
+		}
+	}
+	promClientCache.RUnlock()
+
+	// Miss — create under write lock (double-check)
+	promClientCache.Lock()
+	defer promClientCache.Unlock()
+
+	if promClientCache.clients == nil {
+		promClientCache.clients = make(map[string]*http.Client)
+	}
+	if c, ok := promClientCache.clients[key]; ok {
+		return c, nil
+	}
+
+	transport, err := rest.TransportFor(config)
+	if err != nil {
+		return nil, err
+	}
+
+	client := &http.Client{
+		Transport: transport,
+		Timeout:   prometheusQueryTimeout,
+	}
+	promClientCache.clients[key] = client
+	return client, nil
 }

--- a/pkg/api/gpu_utilization_worker.go
+++ b/pkg/api/gpu_utilization_worker.go
@@ -152,23 +152,23 @@ func (w *GPUUtilizationWorker) collectForReservation(ctx context.Context, reserv
 		gpuNodeNames[node.Name] = true
 	}
 
-	// Count pods on GPU nodes and GPU resource requests
+	// Count pods with explicit GPU resource requests (#7020).
+	// Only pods that explicitly request GPU resources are counted.
+	// Non-GPU system pods (node-exporter, kube-proxy, etc.) on GPU nodes
+	// are excluded to prevent inflating utilization metrics.
 	var activeGPUCount int
 	for _, pod := range pods {
 		if pod.Status != "Running" {
 			continue
 		}
-		// Check if pod requests GPUs or is on a GPU node
 		podGPUs := 0
 		for _, c := range pod.Containers {
 			podGPUs += c.GPURequested
 		}
 		if podGPUs > 0 {
 			activeGPUCount += podGPUs
-		} else if gpuNodeNames[pod.Node] {
-			// Pod on a GPU node but no explicit GPU request — count as 1 GPU in use
-			activeGPUCount++
 		}
+		// Removed: counting non-GPU pods on GPU nodes as 1 GPU each (#7020)
 	}
 
 	// Cap active count to reservation total
@@ -189,7 +189,7 @@ func (w *GPUUtilizationWorker) collectForReservation(ctx context.Context, reserv
 		ReservationID:        reservation.ID.String(),
 		Timestamp:            time.Now(),
 		GPUUtilizationPct:    gpuUtilPct,
-		MemoryUtilizationPct: gpuUtilPct, // Use same value when no memory metrics available
+		MemoryUtilizationPct: 0, // Memory metrics require a metrics-server; 0 indicates unavailable (#7019)
 		ActiveGPUCount:       activeGPUCount,
 		TotalGPUCount:        totalGPUs,
 	}

--- a/pkg/api/handlers/analytics_proxy.go
+++ b/pkg/api/handlers/analytics_proxy.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/gofiber/fiber/v2"
+	"golang.org/x/sync/singleflight"
 )
 
 var analyticsClient = &http.Client{Timeout: 10 * time.Second}
@@ -37,6 +38,11 @@ const (
 
 	// umamiUpstreamBase is the external Umami instance that the proxy relays to.
 	umamiUpstreamBase = "https://analytics.kubestellar.io"
+
+	// maxProxyResponseBytes is the maximum upstream response body size the proxy
+	// will buffer. Prevents multi-GB memory exhaustion from malicious or
+	// misconfigured upstreams (#7022).
+	maxProxyResponseBytes = 10 * 1024 * 1024 // 10 MB
 )
 
 // gtagCache holds a server-side cache of the gtag.js script to avoid
@@ -48,6 +54,10 @@ var gtagCache struct {
 	fetchedAt   time.Time
 	queryString string // cache key — different measurement IDs get different scripts
 }
+
+// scriptFetchGroup coalesces concurrent cold-cache fetches into a single
+// upstream request, preventing cache stampede on the CDN (#7021).
+var scriptFetchGroup singleflight.Group
 
 // GA4ScriptProxy proxies the gtag.js script through the console's own domain
 // so that ad blockers do not block it. The response is cached server-side
@@ -68,35 +78,48 @@ func GA4ScriptProxy(c *fiber.Ctx) error {
 	}
 	gtagCache.RUnlock()
 
-	// Cache miss — fetch from Google
-	target := "https://www.googletagmanager.com/gtag/js?" + qs
-	resp, err := analyticsClient.Get(target)
+	// Cache miss — use singleflight to coalesce concurrent fetches (#7021)
+	type gtagResult struct {
+		body        []byte
+		contentType string
+		statusCode  int
+	}
+	val, err, _ := scriptFetchGroup.Do("gtag:"+qs, func() (interface{}, error) {
+		target := "https://www.googletagmanager.com/gtag/js?" + qs
+		resp, fetchErr := analyticsClient.Get(target)
+		if fetchErr != nil {
+			slog.Error("[GA4] failed to fetch gtag.js", "error", fetchErr)
+			return nil, fetchErr
+		}
+		defer resp.Body.Close()
+
+		body, readErr := io.ReadAll(io.LimitReader(resp.Body, maxProxyResponseBytes))
+		if readErr != nil {
+			return nil, readErr
+		}
+
+		ct := resp.Header.Get("Content-Type")
+
+		// Update cache on success
+		if resp.StatusCode == http.StatusOK {
+			gtagCache.Lock()
+			gtagCache.body = body
+			gtagCache.contentType = ct
+			gtagCache.fetchedAt = time.Now()
+			gtagCache.queryString = qs
+			gtagCache.Unlock()
+		}
+
+		return &gtagResult{body: body, contentType: ct, statusCode: resp.StatusCode}, nil
+	})
 	if err != nil {
-		slog.Error("[GA4] failed to fetch gtag.js", "error", err)
 		return c.SendStatus(fiber.StatusBadGateway)
 	}
-	defer resp.Body.Close()
 
-	body, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return c.SendStatus(fiber.StatusBadGateway)
-	}
-
-	ct := resp.Header.Get("Content-Type")
-
-	// Update cache
-	if resp.StatusCode == http.StatusOK {
-		gtagCache.Lock()
-		gtagCache.body = body
-		gtagCache.contentType = ct
-		gtagCache.fetchedAt = time.Now()
-		gtagCache.queryString = qs
-		gtagCache.Unlock()
-	}
-
-	c.Set("Content-Type", ct)
+	result := val.(*gtagResult)
+	c.Set("Content-Type", result.contentType)
 	c.Set("Cache-Control", "public, max-age=3600")
-	return c.Status(resp.StatusCode).Send(body)
+	return c.Status(result.statusCode).Send(result.body)
 }
 
 // GA4CollectProxy proxies GA4 event collection requests through the console's
@@ -173,7 +196,7 @@ func GA4CollectProxy(c *fiber.Ctx) error {
 		return c.SendStatus(fiber.StatusBadGateway)
 	}
 	defer resp.Body.Close()
-	body, err := io.ReadAll(resp.Body)
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxProxyResponseBytes))
 	if err != nil {
 		return c.SendStatus(fiber.StatusBadGateway)
 	}
@@ -273,34 +296,47 @@ func UmamiScriptProxy(c *fiber.Ctx) error {
 	}
 	umamiScriptCache.RUnlock()
 
-	// Cache miss — fetch from upstream Umami instance
-	target := umamiUpstreamBase + "/ksc"
-	resp, err := analyticsClient.Get(target)
+	// Cache miss — use singleflight to coalesce concurrent fetches (#7021)
+	type umamiResult struct {
+		body        []byte
+		contentType string
+		statusCode  int
+	}
+	val, err, _ := scriptFetchGroup.Do("umami", func() (interface{}, error) {
+		target := umamiUpstreamBase + "/ksc"
+		resp, fetchErr := analyticsClient.Get(target)
+		if fetchErr != nil {
+			slog.Error("[Umami] failed to fetch tracking script", "error", fetchErr)
+			return nil, fetchErr
+		}
+		defer resp.Body.Close()
+
+		body, readErr := io.ReadAll(io.LimitReader(resp.Body, maxProxyResponseBytes))
+		if readErr != nil {
+			return nil, readErr
+		}
+
+		ct := resp.Header.Get("Content-Type")
+
+		// Update cache on success
+		if resp.StatusCode == http.StatusOK {
+			umamiScriptCache.Lock()
+			umamiScriptCache.body = body
+			umamiScriptCache.contentType = ct
+			umamiScriptCache.fetchedAt = time.Now()
+			umamiScriptCache.Unlock()
+		}
+
+		return &umamiResult{body: body, contentType: ct, statusCode: resp.StatusCode}, nil
+	})
 	if err != nil {
-		slog.Error("[Umami] failed to fetch tracking script", "error", err)
 		return c.SendStatus(fiber.StatusBadGateway)
 	}
-	defer resp.Body.Close()
 
-	body, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return c.SendStatus(fiber.StatusBadGateway)
-	}
-
-	ct := resp.Header.Get("Content-Type")
-
-	// Update cache on success
-	if resp.StatusCode == http.StatusOK {
-		umamiScriptCache.Lock()
-		umamiScriptCache.body = body
-		umamiScriptCache.contentType = ct
-		umamiScriptCache.fetchedAt = time.Now()
-		umamiScriptCache.Unlock()
-	}
-
-	c.Set("Content-Type", ct)
+	result := val.(*umamiResult)
+	c.Set("Content-Type", result.contentType)
 	c.Set("Cache-Control", "public, max-age=3600")
-	return c.Status(resp.StatusCode).Send(body)
+	return c.Status(result.statusCode).Send(result.body)
 }
 
 // UmamiCollectProxy relays Umami event payloads to the upstream instance.
@@ -342,7 +378,7 @@ func UmamiCollectProxy(c *fiber.Ctx) error {
 		return c.SendStatus(fiber.StatusBadGateway)
 	}
 	defer resp.Body.Close()
-	body, err := io.ReadAll(resp.Body)
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxProxyResponseBytes))
 	if err != nil {
 		return c.SendStatus(fiber.StatusBadGateway)
 	}

--- a/pkg/api/handlers/gpu.go
+++ b/pkg/api/handlers/gpu.go
@@ -21,6 +21,10 @@ import (
 // handler level; the store now batches IN clauses internally (#6888).
 const bulkUtilizationsMaxIDs = 500
 
+// maxSnapshotQueryLimit caps the ?limit query parameter for utilization
+// snapshots, preventing requests for billions of rows that exhaust memory (#7023).
+const maxSnapshotQueryLimit = 10_000
+
 // maxGPUCountWithoutCapacity is the ceiling on GPUCount when no capacity
 // provider is configured. Prevents absurdly large values from being stored
 // when there is no cluster to validate against (#6962).
@@ -422,6 +426,10 @@ func (h *GPUHandler) GetReservationUtilization(c *fiber.Ctx) error {
 	}
 
 	limit := c.QueryInt("limit", store.DefaultSnapshotQueryLimit)
+	// Clamp to upper bound to prevent unbounded row requests (#7023).
+	if limit <= 0 || limit > maxSnapshotQueryLimit {
+		limit = store.DefaultSnapshotQueryLimit
+	}
 	snapshots, err := h.store.GetUtilizationSnapshots(id, limit)
 	if err != nil {
 		return fiber.NewError(fiber.StatusInternalServerError, "Failed to get utilization data")


### PR DESCRIPTION
Closes #7015
Closes #7016
Closes #7017
Closes #7018
Closes #7019
Closes #7020
Closes #7021
Closes #7022
Closes #7023
Closes #7024
Closes #7025

## Summary

- **#7015**: Replace `loggedClusterError bool` with `atomic.Bool` to eliminate data race
- **#7016**: Surface `ListClusters` error and skip GPU/pod metrics instead of saving zeroed snapshot
- **#7017**: Serialize `saveToDisk` with `diskMu` and use atomic file swap (`os.Rename`) to prevent JSON corruption
- **#7018**: Log warning for unparseable timestamps instead of silently dropping snapshots
- **#7019**: Set `MemoryUtilizationPct` to 0 when no memory metrics available (was incorrectly mirroring GPU compute)
- **#7020**: Only count pods with explicit GPU resource requests; exclude non-GPU system pods on GPU nodes
- **#7021**: Add `singleflight` guard to GA4/Umami script proxy to coalesce cold-cache fetches
- **#7022**: Wrap all `io.ReadAll` with `io.LimitReader` (10 MB cap) to prevent memory exhaustion
- **#7023**: Clamp snapshot query `?limit` to `maxSnapshotQueryLimit=10000`
- **#7024**: Cache `http.Client` per cluster API server URL to reuse TLS connections
- **#7025**: Replace `predictionsActive.Reset()` with set-then-delete-stale to eliminate zeroed scrape window

## Test plan

- [ ] `go build ./...` passes
- [ ] `go vet ./...` passes
- [ ] Run with `-race` flag to verify no data races on `loggedClusterError`
- [ ] Verify GPU utilization no longer counts system pods
- [ ] Verify `MemoryUtilizationPct` is 0 when no memory metrics available
- [ ] Verify analytics proxy returns cached script on concurrent requests
- [ ] Verify `?limit=999999999` is clamped to default