### PR TITLE
fix(security): rate limiting, CSP/HSTS headers, body limits, analytics origin (#7028-#7040)

### DIFF
--- a/pkg/api/handlers/analytics_proxy.go
+++ b/pkg/api/handlers/analytics_proxy.go
@@ -212,37 +212,59 @@ func ga4RealMeasurementID() string {
 	return id
 }
 
+// isAllowedNetlifyHost returns true if host is a KubeStellar Netlify preview
+// deployment. Only the project's own deploy-preview subdomains are accepted;
+// the blanket *.netlify.app wildcard is intentionally NOT used because any
+// attacker-controlled Netlify site would pass that check (#7032).
+func isAllowedNetlifyHost(host string) bool {
+	// Production: kubestellar-console.netlify.app
+	if host == "kubestellar-console.netlify.app" {
+		return true
+	}
+	// Deploy previews: deploy-preview-<N>--kubestellar-console.netlify.app
+	if strings.HasSuffix(host, "--kubestellar-console.netlify.app") {
+		return true
+	}
+	return false
+}
+
 // isAllowedOrigin checks if the request comes from an allowed hostname.
 // In addition to the explicit allowlist, same-origin requests are always
 // permitted — this ensures OpenShift and other dynamic deployments work
 // without maintaining an exhaustive hostname list.
+//
+// Security: only the Origin header is checked — Referer is not used because
+// it is trivially forgeable by non-browser HTTP clients (#7031).
 func isAllowedOrigin(c *fiber.Ctx) bool {
-	requestHost := stripPort(c.Hostname())
-
 	origin := c.Get("Origin")
-	if origin != "" {
-		if u, err := url.Parse(origin); err == nil {
-			host := stripPort(u.Hostname())
-			if allowedOrigins[host] || strings.HasSuffix(host, ".netlify.app") || host == requestHost {
-				return true
-			}
-		}
+	if origin == "" {
+		// Reject requests without an Origin header. Browsers always send Origin
+		// for XHR/fetch cross-origin requests. Requests without it are likely
+		// from non-browser clients attempting to bypass origin checks (#7031).
+		return false
 	}
 
-	referer := c.Get("Referer")
-	if referer != "" {
-		if u, err := url.Parse(referer); err == nil {
-			host := stripPort(u.Hostname())
-			if allowedOrigins[host] || strings.HasSuffix(host, ".netlify.app") || host == requestHost {
-				return true
-			}
-		}
+	u, err := url.Parse(origin)
+	if err != nil {
+		return false
+	}
+	host := stripPort(u.Hostname())
+
+	// Explicit allowlist
+	if allowedOrigins[host] {
+		return true
 	}
 
-	// Reject requests with neither Origin nor Referer — browsers always send
-	// at least one for XHR/fetch. Requests without either are likely from
-	// non-browser clients bypassing origin checks.
-	return false
+	// KubeStellar Netlify previews only (#7032)
+	if isAllowedNetlifyHost(host) {
+		return true
+	}
+
+	// Same-origin: the Origin host matches the request's Host header.
+	// This ensures OpenShift and other dynamic deployments work without
+	// maintaining an exhaustive hostname list.
+	requestHost := stripPort(c.Hostname())
+	return host == requestHost
 }
 
 // stripPort removes the port from a hostname (e.g., "localhost:5174" → "localhost").

--- a/pkg/api/handlers/github_proxy.go
+++ b/pkg/api/handlers/github_proxy.go
@@ -5,6 +5,7 @@ import (
 	"log/slog"
 	"net/http"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/gofiber/fiber/v2"
@@ -27,6 +28,10 @@ const (
 	githubProxyMaxRequestsPerMinute = 30
 	// githubProxyBurstSize allows short bursts above the steady-state rate.
 	githubProxyBurstSize = 5
+	// maxGitHubResponseBytes caps the size of GitHub API response bodies that
+	// the proxy will buffer, preventing memory exhaustion from large list
+	// endpoints or crafted query parameters (#7035).
+	maxGitHubResponseBytes = 10 * 1024 * 1024 // 10 MB
 )
 
 // githubProxyAPIBase is the base URL for proxied GitHub API requests.
@@ -35,12 +40,32 @@ var githubProxyAPIBase = getEnvOrDefault("GITHUB_API_BASE_URL", githubProxyAPIBa
 
 var githubProxyClient = &http.Client{Timeout: githubProxyTimeout}
 
-// githubProxyLimiter enforces a global rate limit on outbound GitHub API calls
-// to prevent a single runaway client from exhausting the shared PAT quota.
-var githubProxyLimiter = rate.NewLimiter(
-	rate.Every(time.Minute/githubProxyMaxRequestsPerMinute),
-	githubProxyBurstSize,
-)
+// githubProxyLimiters enforces a per-user rate limit on outbound GitHub API
+// calls so that one user cannot exhaust the shared PAT quota for everyone
+// (#7034). Each user (identified by JWT user ID) gets their own bucket.
+var githubProxyLimiters struct {
+	sync.Mutex
+	m map[string]*rate.Limiter
+}
+
+func init() {
+	githubProxyLimiters.m = make(map[string]*rate.Limiter)
+}
+
+// getGitHubProxyLimiter returns or creates a per-user rate limiter.
+func getGitHubProxyLimiter(userID string) *rate.Limiter {
+	githubProxyLimiters.Lock()
+	defer githubProxyLimiters.Unlock()
+	if lim, ok := githubProxyLimiters.m[userID]; ok {
+		return lim
+	}
+	lim := rate.NewLimiter(
+		rate.Every(time.Minute/githubProxyMaxRequestsPerMinute),
+		githubProxyBurstSize,
+	)
+	githubProxyLimiters.m[userID] = lim
+	return lim
+}
 
 // allowedGitHubPrefixes restricts which GitHub API paths can be proxied.
 // Only read-only endpoints actually needed by the frontend are permitted.
@@ -112,9 +137,15 @@ func (h *GitHubProxyHandler) resolveToken() string {
 // Proxy handles GET /api/github/* by forwarding to api.github.com/*.
 // Only GET requests are allowed (read-only proxy).
 func (h *GitHubProxyHandler) Proxy(c *fiber.Ctx) error {
-	// Rate-limit outbound GitHub API calls to protect the shared PAT quota.
-	if !githubProxyLimiter.Allow() {
-		slog.Warn("[GitHubProxy] rate limit exceeded, rejecting request")
+	// Rate-limit outbound GitHub API calls per user to protect the shared PAT
+	// quota. Each user gets their own 30 req/min bucket (#7034).
+	uid := middleware.GetUserID(c)
+	limiterKey := uid.String()
+	if limiterKey == "00000000-0000-0000-0000-000000000000" {
+		limiterKey = c.IP() // fallback — should not happen behind JWTAuth
+	}
+	if !getGitHubProxyLimiter(limiterKey).Allow() {
+		slog.Warn("[GitHubProxy] rate limit exceeded, rejecting request", "user", limiterKey)
 		return c.Status(fiber.StatusTooManyRequests).JSON(fiber.Map{
 			"error": "GitHub proxy rate limit exceeded — try again shortly",
 		})
@@ -196,7 +227,7 @@ func (h *GitHubProxyHandler) Proxy(c *fiber.Ctx) error {
 	}
 	defer resp.Body.Close()
 
-	body, err := io.ReadAll(resp.Body)
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxGitHubResponseBytes))
 	if err != nil {
 		return c.Status(fiber.StatusBadGateway).JSON(fiber.Map{
 			"error": "Failed to read GitHub API response",

--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -47,6 +47,14 @@ const (
 	portReleasePollInterval = 50 * time.Millisecond
 	defaultDevFrontendURL   = "http://localhost:5174"
 	defaultProdFrontendURL  = "http://localhost:8080"
+
+	// apiDefaultBodyLimit is the per-route body-size limit enforced by the
+	// bodyGuard middleware on all API routes except feedback screenshot uploads.
+	apiDefaultBodyLimit = 1 * 1024 * 1024 // 1 MB — sufficient for JSON API requests
+
+	// feedbackBodyLimit is the global Fiber BodyLimit, elevated to support
+	// base64-encoded screenshot uploads in POST /api/feedback/requests.
+	feedbackBodyLimit = 20 * 1024 * 1024 // 20 MB — base64 screenshot uploads
 )
 
 // Version is the build version, injected via ldflags at build time.
@@ -200,19 +208,38 @@ func NewServer(cfg Config) (*Server, error) {
 	middleware.InitTokenRevocation(db)
 
 	// Create Fiber app
-	// feedbackBodyLimit is elevated globally to 20 MB to support base64-encoded
-	// screenshot uploads in the POST /api/feedback/requests endpoint. Non-feedback
-	// POST routes are protected by a tighter per-route body-size middleware
-	// (apiDefaultBodyLimit) to limit memory pressure from oversized requests.
-	const feedbackBodyLimit = 20 * 1024 * 1024 // 20 MB — base64 screenshot uploads
+	// trustedProxyCIDRs are the RFC-1918 and link-local ranges typical of
+	// Kubernetes ingress controllers, cloud load-balancers, and service meshes.
+	// When EnableTrustedProxyCheck is true, Fiber only honours X-Forwarded-For /
+	// X-Real-Ip from source IPs within these CIDRs, so c.IP() returns the real
+	// client IP instead of the proxy's IP (#7028).
+	trustedProxyCIDRs := []string{
+		"10.0.0.0/8",     // RFC-1918 Class A private
+		"172.16.0.0/12",  // RFC-1918 Class B private
+		"192.168.0.0/16", // RFC-1918 Class C private
+		"fc00::/7",       // IPv6 ULA
+		"127.0.0.0/8",    // loopback
+		"::1/128",        // IPv6 loopback
+	}
+
+	// BodyLimit is set to feedbackBodyLimit (20 MB) because the feedback endpoint
+	// accepts base64-encoded screenshot uploads. Per-route enforcement is done by
+	// bodyGuard middleware (1 MB for most routes) and analyticsBodyGuard (64 KB).
+	// Fiber buffers up to BodyLimit before middleware runs, so a concurrent flood
+	// of max-size bodies can still cause memory pressure (#7039). ReadTimeout (30s)
+	// bounds the buffering window; for stricter enforcement, deploy behind an
+	// ingress controller with its own body-size limit (e.g. nginx client_max_body_size).
 	app := fiber.New(fiber.Config{
-		ErrorHandler:    customErrorHandler,
-		ReadBufferSize:  16384,
-		WriteBufferSize: 16384,
-		BodyLimit:       feedbackBodyLimit,
-		ReadTimeout:     30 * time.Second,
-		WriteTimeout:    5 * time.Minute, // large static assets on slow networks
-		IdleTimeout:     2 * time.Minute,
+		ErrorHandler:            customErrorHandler,
+		ReadBufferSize:          16384,
+		WriteBufferSize:         16384,
+		BodyLimit:               feedbackBodyLimit,
+		ReadTimeout:             30 * time.Second,
+		WriteTimeout:            5 * time.Minute, // large static assets on slow networks
+		IdleTimeout:             2 * time.Minute,
+		EnableTrustedProxyCheck: true,
+		TrustedProxies:          trustedProxyCIDRs,
+		ProxyHeader:             "X-Forwarded-For",
 	})
 
 	// WebSocket hub
@@ -372,13 +399,36 @@ func (s *Server) setupMiddleware() {
 		AllowCredentials: true,
 	}))
 
-	// Security headers
+	// Security headers (#7037 CSP, #7038 HSTS)
 	s.app.Use(func(c *fiber.Ctx) error {
 		c.Set("X-Content-Type-Options", "nosniff")
 		c.Set("X-Frame-Options", "DENY")
 		c.Set("X-XSS-Protection", "0") // Disabled per OWASP — modern browsers don't need it and it can introduce vulnerabilities
 		c.Set("Referrer-Policy", "strict-origin-when-cross-origin")
 		c.Set("Permissions-Policy", "camera=(), microphone=(), geolocation=()")
+
+		// Content-Security-Policy: restrict script/style sources to self and
+		// known analytics/CDN origins. 'unsafe-inline' is required for Vite
+		// dev mode injected styles and inline event handlers in the SPA.
+		c.Set("Content-Security-Policy",
+			"default-src 'self'; "+
+				"script-src 'self' 'unsafe-inline' https://www.googletagmanager.com; "+
+				"style-src 'self' 'unsafe-inline'; "+
+				"img-src 'self' data: https:; "+
+				"connect-src 'self' https://www.google-analytics.com https://www.googletagmanager.com wss:; "+
+				"font-src 'self' data:; "+
+				"object-src 'none'; "+
+				"base-uri 'self'")
+
+		// Strict-Transport-Security: instruct browsers to always use HTTPS.
+		// Only emitted when the request arrived over TLS (or via a TLS-terminating
+		// proxy) to avoid breaking local HTTP development (#7038).
+		if c.Protocol() == "https" {
+			const hstsMaxAgeSec = 63072000 // 2 years in seconds
+			c.Set("Strict-Transport-Security",
+				fmt.Sprintf("max-age=%d; includeSubDomains", hstsMaxAgeSec))
+		}
+
 		return c.Next()
 	})
 }
@@ -568,6 +618,7 @@ func (s *Server) setupRoutes() {
 			return c.IP()
 		},
 		LimitReached: func(c *fiber.Ctx) error {
+			c.Set("Retry-After", strconv.Itoa(int(authLimiterWindow.Seconds()))) // #7040
 			return c.Status(429).JSON(fiber.Map{"error": "too many requests, try again later"})
 		},
 	})
@@ -588,8 +639,34 @@ func (s *Server) setupRoutes() {
 	s.app.Post("/auth/refresh", authLimiter, jwtAuth, auth.RefreshToken)
 	s.app.Post("/auth/logout", authLimiter, jwtAuth, auth.Logout)
 
+	// Public endpoint rate limiter — loose limit to prevent DoS on unauthenticated
+	// routes (active-users, ping, nightly-e2e, youtube, medium, analytics) (#7029).
+	publicLimiterMaxRequests := 60        // max requests per window per IP
+	publicLimiterWindow := 1 * time.Minute // sliding window duration
+	publicLimiter := limiter.New(limiter.Config{
+		Max:        publicLimiterMaxRequests,
+		Expiration: publicLimiterWindow,
+		KeyGenerator: func(c *fiber.Ctx) string {
+			return c.IP()
+		},
+		LimitReached: func(c *fiber.Ctx) error {
+			c.Set("Retry-After", strconv.Itoa(int(publicLimiterWindow.Seconds()))) // #7040
+			return c.Status(429).JSON(fiber.Map{"error": "too many requests, try again later"})
+		},
+	})
+
+	// analyticsBodyLimit constrains analytics proxy POST bodies at the Fiber level
+	// so oversized payloads are rejected before full buffering (#7030).
+	const analyticsBodyLimit = 64 * 1024 // 64 KB — analytics payloads are small JSON/query strings
+	analyticsBodyGuard := func(c *fiber.Ctx) error {
+		if len(c.Body()) > analyticsBodyLimit {
+			return fiber.ErrRequestEntityTooLarge
+		}
+		return c.Next()
+	}
+
 	// Active users endpoint (public — returns only aggregate counts, no sensitive data)
-	s.app.Get("/api/active-users", func(c *fiber.Ctx) error {
+	s.app.Get("/api/active-users", publicLimiter, func(c *fiber.Ctx) error {
 		wsUsers := s.hub.GetActiveUsersCount()
 		demoSessions := s.hub.GetDemoSessionCount()
 		wsTotalConns := s.hub.GetTotalConnectionsCount()
@@ -613,7 +690,7 @@ func (s *Server) setupRoutes() {
 	// Active users heartbeat endpoint (for demo mode session counting)
 	// This is unauthenticated telemetry — session IDs are validated for length
 	// and the total number of unique sessions is capped to prevent inflation.
-	s.app.Post("/api/active-users", func(c *fiber.Ctx) error {
+	s.app.Post("/api/active-users", publicLimiter, func(c *fiber.Ctx) error {
 		var body struct {
 			SessionID string `json:"sessionId"`
 		}
@@ -633,19 +710,20 @@ func (s *Server) setupRoutes() {
 	// Public API routes (no auth — only non-sensitive, publicly-available data)
 	// Nightly E2E status is public GitHub Actions data, safe for desktop widgets
 	nightlyE2EPublic := handlers.NewNightlyE2EHandler(s.config.GitHubToken)
-	s.app.Get("/api/public/nightly-e2e/runs", nightlyE2EPublic.GetRuns)
-	s.app.Get("/api/public/nightly-e2e/run-logs", nightlyE2EPublic.GetRunLogs)
+	s.app.Get("/api/public/nightly-e2e/runs", publicLimiter, nightlyE2EPublic.GetRuns)
+	s.app.Get("/api/public/nightly-e2e/run-logs", publicLimiter, nightlyE2EPublic.GetRunLogs)
 
 	// Analytics proxies (public — no auth required, have their own origin validation)
-	// MUST be registered before the /api group so JWTAuth middleware doesn't intercept them
-	s.app.All("/api/m", handlers.GA4CollectProxy)
-	s.app.Get("/api/gtag", handlers.GA4ScriptProxy)
-	s.app.Get("/api/ksc", handlers.UmamiScriptProxy)
-	s.app.Post("/api/send", handlers.UmamiCollectProxy)
+	// MUST be registered before the /api group so JWTAuth middleware doesn't intercept them.
+	// Protected by publicLimiter (#7029) and analyticsBodyGuard (#7030).
+	s.app.All("/api/m", publicLimiter, analyticsBodyGuard, handlers.GA4CollectProxy)
+	s.app.Get("/api/gtag", publicLimiter, handlers.GA4ScriptProxy)
+	s.app.Get("/api/ksc", publicLimiter, handlers.UmamiScriptProxy)
+	s.app.Post("/api/send", publicLimiter, analyticsBodyGuard, handlers.UmamiCollectProxy)
 
 	// Network ping proxy (public — lightweight server-side HTTP HEAD for latency measurement)
 	// Avoids browser no-cors limitations that produce unreliable results
-	s.app.Get("/api/ping", handlers.PingHandler)
+	s.app.Get("/api/ping", publicLimiter, handlers.PingHandler)
 
 	// MCP handlers (used in protected routes below)
 	mcpHandlers := handlers.NewMCPHandlers(s.bridge, s.k8sClient)
@@ -654,17 +732,23 @@ func (s *Server) setupRoutes() {
 	// NOT authentication requirements
 
 	// YouTube playlist (public — proxies to YouTube RSS feed, cached 1h)
-	s.app.Get("/api/youtube/playlist", handlers.YouTubePlaylistHandler)
-	s.app.Get("/api/youtube/thumbnail/:id", handlers.YouTubeThumbnailProxy)
+	s.app.Get("/api/youtube/playlist", publicLimiter, handlers.YouTubePlaylistHandler)
+	s.app.Get("/api/youtube/thumbnail/:id", publicLimiter, handlers.YouTubeThumbnailProxy)
 
 	// Medium blog (public — proxies to Medium RSS feed, cached 1h)
-	s.app.Get("/api/medium/blog", handlers.MediumBlogHandler)
+	s.app.Get("/api/medium/blog", publicLimiter, handlers.MediumBlogHandler)
 
 	// Mission knowledge base browse/file (public — proxies to public GitHub repo)
 	missions := handlers.NewMissionsHandler()
 	missions.RegisterPublicRoutes(s.app.Group("/api/missions"))
 
 	// API routes (protected) — with rate limiting
+	//
+	// NOTE (#7033): Both authLimiter and apiLimiter use Fiber's default in-process
+	// memory storage. In a multi-replica Kubernetes deployment each pod maintains
+	// an independent counter, so the effective limit is `max × N` where N is the
+	// pod count. A shared Redis/Valkey storage backend is recommended for strict
+	// enforcement across replicas but is out of scope for this change.
 	apiLimiterMaxRequests := 200        // max requests per window per IP
 	apiLimiterWindow := 1 * time.Minute // sliding window duration
 	apiLimiter := limiter.New(limiter.Config{
@@ -674,16 +758,14 @@ func (s *Server) setupRoutes() {
 			return c.IP()
 		},
 		LimitReached: func(c *fiber.Ctx) error {
+			c.Set("Retry-After", strconv.Itoa(int(apiLimiterWindow.Seconds()))) // #7040
 			return c.Status(429).JSON(fiber.Map{"error": "too many requests, try again later"})
 		},
 	})
-	// Body-size guard: enforce a 1 MB limit on all API routes except the
-	// feedback creation endpoint which accepts large base64 screenshot payloads
-	// (up to the global 20 MB Fiber BodyLimit).
-	const apiDefaultBodyLimit = 1 * 1024 * 1024 // 1 MB — sufficient for JSON API requests
+	// bodyGuard: enforce apiDefaultBodyLimit (1 MB) on all API routes except the
+	// feedback creation endpoint which accepts large base64 screenshot payloads.
 	bodyGuard := func(c *fiber.Ctx) error {
 		if c.Method() == fiber.MethodPost && c.Path() == "/api/feedback/requests" {
-			// Allow the elevated feedbackBodyLimit (checked by Fiber global config)
 			return c.Next()
 		}
 		if len(c.Body()) > apiDefaultBodyLimit {


### PR DESCRIPTION
Closes #7028
Closes #7029
Closes #7030
Closes #7031
Closes #7032
Closes #7033
Closes #7034
Closes #7035
Closes #7037
Closes #7038
Closes #7039
Closes #7040

## Summary

- **#7028** — Configure Fiber `EnableTrustedProxyCheck` + `TrustedProxies` with RFC-1918/loopback CIDRs and `ProxyHeader: X-Forwarded-For` so `c.IP()` returns the real client IP behind Kubernetes ingress
- **#7029** — Add `publicLimiter` (60 req/min per IP) to all 12 unauthenticated endpoints: active-users, nightly-e2e, analytics proxies, ping, youtube, medium
- **#7030** — Add `analyticsBodyGuard` (64 KB) middleware to analytics POST routes (`/api/m`, `/api/send`)
- **#7031** — Remove `Referer` header fallback from `isAllowedOrigin`; only `Origin` header is checked
- **#7032** — Replace `*.netlify.app` wildcard with exact match on `kubestellar-console.netlify.app` and `deploy-preview-*--kubestellar-console.netlify.app`
- **#7033** — Document in-memory rate limiter multi-pod limitation (Redis out of scope)
- **#7034** — Replace global `githubProxyLimiter` with per-user rate limiting keyed on JWT user ID
- **#7035** — Wrap `io.ReadAll` with `io.LimitReader(resp.Body, 10MB)` on GitHub proxy responses
- **#7037** — Add `Content-Security-Policy` header: `default-src 'self'` with allowlisted script/connect/img sources
- **#7038** — Add `Strict-Transport-Security: max-age=63072000; includeSubDomains` on HTTPS responses only
- **#7039** — Document that Fiber global BodyLimit remains at 20 MB for feedback uploads; bodyGuard enforces 1 MB on other routes; recommend ingress-level body-size limit for strict enforcement
- **#7040** — Add `Retry-After` header (window seconds) to all three rate limiter `LimitReached` handlers

## Test plan

- [ ] `go build ./...` passes
- [ ] `go vet ./...` passes
- [ ] Verify analytics proxy rejects requests without Origin header
- [ ] Verify analytics proxy rejects non-kubestellar Netlify origins
- [ ] Verify 429 responses include Retry-After header
- [ ] Verify CSP and HSTS headers present in responses