### PR TITLE
fix(backend): SSE/WS safety, exec goroutine join, nightly E2E hardening (#7041-#7057)

### DIFF
--- a/pkg/api/handlers/exec.go
+++ b/pkg/api/handlers/exec.go
@@ -501,6 +501,15 @@ func (h *ExecHandlers) HandleExec(c *websocket.Conn) {
 
 	execErr := executor.StreamWithContext(execCtx, streamOpts)
 
+	// #7047 — Close the terminal size queue channel so the SPDY executor's
+	// internal goroutine calling Next() receives nil and terminates.
+	close(sizeQueue.ch)
+
+	// #7048 — Wait for the reader goroutine to finish before writing the
+	// exit message, ensuring cleanup ordering (close(stdinCh), execCancel)
+	// happens before the handler returns.
+	<-done
+
 	// Send exit message
 	exitCode := 0
 	if execErr != nil {

--- a/pkg/api/handlers/feedback.go
+++ b/pkg/api/handlers/feedback.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/gofiber/fiber/v2"
 	"github.com/google/uuid"
+	"golang.org/x/sync/singleflight"
 
 	"github.com/kubestellar/console/pkg/api/middleware"
 	"github.com/kubestellar/console/pkg/models"
@@ -31,6 +32,10 @@ import (
 
 // githubAPITimeout is the timeout for HTTP requests to the GitHub API.
 const githubAPITimeout = 10 * time.Second
+
+// githubAPIBase is the default public GitHub API base URL.
+// Used as the fallback by resolveGitHubAPIBase() when GITHUB_URL is unset.
+const githubAPIBase = "https://api.github.com"
 
 // maxClientPageLimit is the largest page size a client may request on any
 // list endpoint that routes through parsePageParams (feedback, RBAC user
@@ -158,6 +163,8 @@ type FeedbackHandler struct {
 	prCacheMu   sync.RWMutex
 	prCache     []GitHubPR
 	prCacheTime time.Time
+	// #7057 — singleflight group coalesces concurrent cold-cache PR fetches.
+	prFetchGroup singleflight.Group
 }
 
 // FeedbackConfig holds configuration for the feedback handler
@@ -731,6 +738,9 @@ func (h *FeedbackHandler) fetchLinkedPRs(issues []GitHubIssue) map[int]GitHubPR 
 
 // getCachedOrFetchPRs returns cached PR data if fresh, otherwise fetches
 // from the GitHub API with pagination and caches the result.
+//
+// #7057 — Uses singleflight to coalesce concurrent cold-cache fetches into
+// a single set of paginated GitHub PR API calls.
 func (h *FeedbackHandler) getCachedOrFetchPRs() []GitHubPR {
 	h.prCacheMu.RLock()
 	if h.prCache != nil && time.Since(h.prCacheTime) < prCacheTTL {
@@ -740,24 +750,31 @@ func (h *FeedbackHandler) getCachedOrFetchPRs() []GitHubPR {
 	}
 	h.prCacheMu.RUnlock()
 
-	var allPRs []GitHubPR
-	for _, state := range []string{"open", "closed"} {
-		prs := h.fetchPRPages(state)
-		allPRs = append(allPRs, prs...)
-	}
+	v, _, _ := h.prFetchGroup.Do("prs", func() (interface{}, error) {
+		var allPRs []GitHubPR
+		for _, state := range []string{"open", "closed"} {
+			prs := h.fetchPRPages(state)
+			allPRs = append(allPRs, prs...)
+		}
 
-	h.prCacheMu.Lock()
-	// Re-check: another goroutine may have populated the cache while we fetched.
-	if h.prCache != nil && time.Since(h.prCacheTime) < prCacheTTL {
-		cached := h.prCache
+		h.prCacheMu.Lock()
+		// Re-check: another goroutine may have populated the cache while we fetched.
+		if h.prCache != nil && time.Since(h.prCacheTime) < prCacheTTL {
+			cached := h.prCache
+			h.prCacheMu.Unlock()
+			return cached, nil
+		}
+		h.prCache = allPRs
+		h.prCacheTime = time.Now()
 		h.prCacheMu.Unlock()
-		return cached
-	}
-	h.prCache = allPRs
-	h.prCacheTime = time.Now()
-	h.prCacheMu.Unlock()
 
-	return allPRs
+		return allPRs, nil
+	})
+
+	if prs, ok := v.([]GitHubPR); ok {
+		return prs
+	}
+	return nil
 }
 
 // fetchPRPages fetches up to maxPRPages pages of PRs for the given state,

--- a/pkg/api/handlers/nightly_e2e.go
+++ b/pkg/api/handlers/nightly_e2e.go
@@ -2,6 +2,7 @@
 package handlers
 
 import (
+	"context"
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
@@ -14,19 +15,23 @@ import (
 	"time"
 
 	"github.com/gofiber/fiber/v2"
+	"golang.org/x/sync/singleflight"
 )
 
 const (
 	nightlyCacheIdleTTL   = 5 * time.Minute  // cache when no jobs running
 	nightlyCacheActiveTTL = 2 * time.Minute  // cache when jobs are in progress
 	imageCacheTTL         = 30 * time.Minute // image tags change less frequently
-	nightlyRunsPerPage    = 7
-	githubAPIBase         = "https://api.github.com"
+	nightlyRunsPerPage = 7
 
 	failureReasonGPU  = "gpu_unavailable"
 	failureReasonTest = "test_failure"
 
-	maxLogBytes     = 200_000          // 200KB tail per job log
+	// maxErrorBodyBytes is the maximum number of bytes to read from GitHub error
+	// response bodies. Prevents unbounded memory consumption on large HTML error
+	// pages during outages (#7055).
+	maxErrorBodyBytes = 10_000 // 10 KB
+	maxLogBytes       = 200_000 // 200KB tail per job log
 	logCacheTTL     = 10 * time.Minute // immutable once run completes
 	maxLogFetchJobs = 5                // limit concurrent job log fetches
 
@@ -120,6 +125,9 @@ type NightlyE2EHandler struct {
 	mu       sync.RWMutex
 	cache    *NightlyE2EResponse
 	cacheExp time.Time
+	// #7053 — singleflight group coalesces concurrent cold-cache GetRuns
+	// callers into a single fetchAll call.
+	fetchGroup singleflight.Group
 
 	logMu       sync.RWMutex
 	logCache    map[string]*RunLogsResponse // key: "repo/runId"
@@ -185,17 +193,17 @@ func NewNightlyE2EHandler(githubToken string) *NightlyE2EHandler {
 }
 
 func (h *NightlyE2EHandler) prewarm() {
-	// Use a timeout to prevent this goroutine from blocking indefinitely
-	// if the GitHub API is slow or unreachable.
-	timer := time.NewTimer(prewarmTimeout)
-	defer timer.Stop()
+	// #7052 — Use a cancellable context so that on timeout, all goroutines
+	// spawned by fetchAll are cancelled instead of abandoned.
+	ctx, cancel := context.WithTimeout(context.Background(), prewarmTimeout)
+	defer cancel()
 
 	done := make(chan struct{})
 	var resp *NightlyE2EResponse
 	var fetchErr error
 
 	go func() {
-		resp, fetchErr = h.fetchAll()
+		resp, fetchErr = h.fetchAllWithContext(ctx)
 		close(done)
 	}()
 
@@ -205,7 +213,7 @@ func (h *NightlyE2EHandler) prewarm() {
 			slog.Error("[NightlyE2E] prewarm failed", "error", fetchErr)
 			return
 		}
-	case <-timer.C:
+	case <-ctx.Done():
 		slog.Error("[NightlyE2E] prewarm timed out", "timeout", prewarmTimeout)
 		return
 	}
@@ -233,13 +241,17 @@ func (h *NightlyE2EHandler) GetRuns(c *fiber.Ctx) error {
 	}
 	h.mu.RUnlock()
 
-	// Fetch fresh data
-	resp, err := h.fetchAll()
+	// #7053 — Use singleflight to coalesce concurrent cold-cache fetches
+	// into a single fetchAll call, preventing N × 17+ goroutine fan-out.
+	v, err, _ := h.fetchGroup.Do("runs", func() (interface{}, error) {
+		return h.fetchAll()
+	})
 	if err != nil {
 		return c.Status(fiber.StatusBadGateway).JSON(fiber.Map{
 			"error": fmt.Sprintf("failed to fetch nightly E2E data: %v", err),
 		})
 	}
+	resp := v.(*NightlyE2EResponse)
 
 	// Use shorter cache TTL when any jobs are in progress
 	ttl := nightlyCacheIdleTTL
@@ -257,16 +269,31 @@ func (h *NightlyE2EHandler) GetRuns(c *fiber.Ctx) error {
 }
 
 func (h *NightlyE2EHandler) fetchAll() (*NightlyE2EResponse, error) {
+	return h.fetchAllWithContext(context.Background())
+}
+
+// fetchAllWithContext is the context-aware version of fetchAll (#7052).
+// When ctx is cancelled, HTTP requests made by sub-goroutines will be
+// interrupted instead of running to completion.
+func (h *NightlyE2EHandler) fetchAllWithContext(ctx context.Context) (*NightlyE2EResponse, error) {
 	type result struct {
 		idx  int
 		runs []NightlyRun
 		err  error
 	}
 
-	// Fetch workflow runs and guide images concurrently
+	// Fetch workflow runs and guide images concurrently.
+	// #7052 — Check context before spawning goroutines and bail early on
+	// cancellation so prewarm timeouts don't leave goroutines running.
 	ch := make(chan result, len(nightlyWorkflows))
 	for i, wf := range nightlyWorkflows {
 		go func(idx int, wf NightlyWorkflow) {
+			select {
+			case <-ctx.Done():
+				ch <- result{idx: idx, err: ctx.Err()}
+				return
+			default:
+			}
 			runs, err := h.fetchWorkflowRuns(wf)
 			ch <- result{idx: idx, runs: runs, err: err}
 		}(i, wf)
@@ -333,7 +360,7 @@ func (h *NightlyE2EHandler) fetchAll() (*NightlyE2EResponse, error) {
 
 func (h *NightlyE2EHandler) fetchWorkflowRuns(wf NightlyWorkflow) ([]NightlyRun, error) {
 	url := fmt.Sprintf("%s/repos/%s/actions/workflows/%s/runs?per_page=%d",
-		githubAPIBase, wf.Repo, wf.WorkflowFile, nightlyRunsPerPage)
+		resolveGitHubAPIBase(), wf.Repo, wf.WorkflowFile, nightlyRunsPerPage)
 
 	req, err := http.NewRequest("GET", url, nil)
 	if err != nil {
@@ -355,7 +382,8 @@ func (h *NightlyE2EHandler) fetchWorkflowRuns(wf NightlyWorkflow) ([]NightlyRun,
 		return []NightlyRun{}, nil
 	}
 	if resp.StatusCode != http.StatusOK {
-		body, readErr := io.ReadAll(resp.Body)
+		// #7055 — Use LimitReader to prevent unbounded memory on large error pages.
+		body, readErr := io.ReadAll(io.LimitReader(resp.Body, maxErrorBodyBytes))
 		if readErr != nil {
 			body = []byte("(failed to read response body)")
 		}
@@ -405,16 +433,24 @@ func (h *NightlyE2EHandler) fetchWorkflowRuns(wf NightlyWorkflow) ([]NightlyRun,
 	return runs, nil
 }
 
+// maxConcurrentClassify limits concurrent detectGPUFailure calls to prevent
+// unbounded goroutine fan-out when many runs fail simultaneously (#7056).
+const maxConcurrentClassify = 5
+
 // classifyFailures fetches jobs for failed runs and sets FailureReason.
+// #7056 — Uses a semaphore to cap concurrent GitHub API calls.
 func (h *NightlyE2EHandler) classifyFailures(repo string, runs []NightlyRun) {
 	var wg sync.WaitGroup
+	sem := make(chan struct{}, maxConcurrentClassify)
 	for i := range runs {
 		if runs[i].Conclusion == nil || *runs[i].Conclusion != "failure" {
 			continue
 		}
 		wg.Add(1)
+		sem <- struct{}{}
 		go func(idx int) {
 			defer wg.Done()
+			defer func() { <-sem }()
 			runs[idx].FailureReason = h.detectGPUFailure(repo, runs[idx].ID)
 		}(i)
 	}
@@ -424,7 +460,7 @@ func (h *NightlyE2EHandler) classifyFailures(repo string, runs []NightlyRun) {
 // detectGPUFailure checks if a run failed due to GPU unavailability.
 func (h *NightlyE2EHandler) detectGPUFailure(repo string, runID int64) string {
 	url := fmt.Sprintf("%s/repos/%s/actions/runs/%d/jobs?per_page=30",
-		githubAPIBase, repo, runID)
+		resolveGitHubAPIBase(), repo, runID)
 
 	req, err := http.NewRequest("GET", url, nil)
 	if err != nil {
@@ -565,7 +601,7 @@ type treeEntry struct {
 // fetchGuideYAMLFiles fetches the repo tree and returns YAML files under guides/
 // that are likely to contain image references (values.yaml, decode.yaml, etc.).
 func (h *NightlyE2EHandler) fetchGuideYAMLFiles() []treeEntry {
-	url := fmt.Sprintf("%s/repos/%s/git/trees/main?recursive=1", githubAPIBase, imageRepo)
+	url := fmt.Sprintf("%s/repos/%s/git/trees/main?recursive=1", resolveGitHubAPIBase(), imageRepo)
 
 	req, err := http.NewRequest("GET", url, nil)
 	if err != nil {
@@ -621,7 +657,7 @@ func (h *NightlyE2EHandler) fetchGuideYAMLFiles() []treeEntry {
 
 // fetchBlob fetches a git blob's content by SHA and returns it decoded.
 func (h *NightlyE2EHandler) fetchBlob(sha string) string {
-	url := fmt.Sprintf("%s/repos/%s/git/blobs/%s", githubAPIBase, imageRepo, sha)
+	url := fmt.Sprintf("%s/repos/%s/git/blobs/%s", resolveGitHubAPIBase(), imageRepo, sha)
 
 	req, err := http.NewRequest("GET", url, nil)
 	if err != nil {
@@ -751,7 +787,7 @@ func (h *NightlyE2EHandler) GetRunLogs(c *fiber.Ctx) error {
 
 	// Fetch jobs for this run
 	jobsURL := fmt.Sprintf("%s/repos/%s/actions/runs/%d/jobs?per_page=30",
-		githubAPIBase, repo, runID)
+		resolveGitHubAPIBase(), repo, runID)
 
 	req, err := http.NewRequest("GET", jobsURL, nil)
 	if err != nil {
@@ -771,7 +807,8 @@ func (h *NightlyE2EHandler) GetRunLogs(c *fiber.Ctx) error {
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		body, readErr := io.ReadAll(resp.Body)
+		// #7055 — Use LimitReader to prevent unbounded memory on large error pages.
+		body, readErr := io.ReadAll(io.LimitReader(resp.Body, maxErrorBodyBytes))
 		if readErr != nil {
 			body = []byte("(failed to read response body)")
 		}
@@ -838,7 +875,7 @@ func (h *NightlyE2EHandler) GetRunLogs(c *fiber.Ctx) error {
 // fetchJobLog fetches the plain-text log for a single GitHub Actions job,
 // truncated to the last maxLogBytes bytes (failure info is at the tail).
 func (h *NightlyE2EHandler) fetchJobLog(repo string, jobID int64) string {
-	logURL := fmt.Sprintf("%s/repos/%s/actions/jobs/%d/logs", githubAPIBase, repo, jobID)
+	logURL := fmt.Sprintf("%s/repos/%s/actions/jobs/%d/logs", resolveGitHubAPIBase(), repo, jobID)
 
 	req, err := http.NewRequest("GET", logURL, nil)
 	if err != nil {

--- a/pkg/api/handlers/sse.go
+++ b/pkg/api/handlers/sse.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"log/slog"
 	"strconv"
+	"strings"
 	"sync"
 	"time"
 
@@ -14,6 +15,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/kubestellar/console/pkg/api/middleware"
 	"github.com/kubestellar/console/pkg/k8s"
+	"golang.org/x/sync/singleflight"
 )
 
 // defaultWarningEventsLimit is the fallback row limit used by
@@ -62,13 +64,19 @@ type sseClusterStreamConfig struct {
 
 // writeSSEEvent writes one SSE event to the buffered writer and flushes.
 // Returns an error if the write or flush fails (e.g., client disconnected).
+//
+// #7050 — eventName is sanitized by stripping \n and \r to prevent SSE frame
+// injection if a future caller inadvertently passes user-controlled input.
 func writeSSEEvent(w *bufio.Writer, eventName string, data interface{}) error {
+	// Sanitize eventName: strip characters that would break the SSE wire format.
+	sanitized := strings.NewReplacer("\n", "", "\r", "").Replace(eventName)
+
 	jsonData, err := json.Marshal(data)
 	if err != nil {
 		slog.Error("[SSE] marshal error", "error", err)
 		return fmt.Errorf("marshal: %w", err)
 	}
-	if _, err := fmt.Fprintf(w, "event: %s\ndata: %s\n\n", eventName, jsonData); err != nil {
+	if _, err := fmt.Fprintf(w, "event: %s\ndata: %s\n\n", sanitized, jsonData); err != nil {
 		return fmt.Errorf("write: %w", err)
 	}
 	if err := w.Flush(); err != nil {
@@ -188,6 +196,9 @@ var (
 	// sseCacheEvictDone is closed to stop the background evictor goroutine
 	// on server shutdown or in tests, preventing goroutine leaks (#6956).
 	sseCacheEvictDone = make(chan struct{})
+	// #7045 — singleflight group coalesces concurrent cold-cache fetches for
+	// the same cache key into a single Kubernetes API call.
+	sseFetchGroup singleflight.Group
 )
 
 type sseCacheEntry struct {
@@ -411,10 +422,10 @@ func streamClusters(
 		// Spawn goroutines only for healthy/unknown clusters
 		var wg sync.WaitGroup
 		for _, cl := range healthy {
-			// Include namespace in cache key to prevent cross-namespace
-			// data leakage when the same cluster is queried for different
-			// namespaces (#4151).
-			cacheKey := cfg.demoKey + ":" + cl.Name + ":" + cfg.namespace
+			// #7044 — Include user ID in cache key to prevent cross-user data
+			// leakage between different roles (e.g. admin vs viewer).
+			// Also includes namespace to prevent cross-namespace data leakage (#4151).
+			cacheKey := userID.String() + ":" + cfg.demoKey + ":" + cl.Name + ":" + cfg.namespace
 
 			// Check response cache — serve instantly if fresh
 			if cached := sseCacheGet(cacheKey); cached != nil {
@@ -448,7 +459,15 @@ func streamClusters(
 				defer cancel()
 
 				start := time.Now()
-				data, fetchErr := fetchFn(ctx, clusterName)
+				// #7045 — Use singleflight to coalesce concurrent cold-cache
+				// fetches for the same cache key into one Kubernetes API call.
+				v, fetchErr, _ := sseFetchGroup.Do(cKey, func() (interface{}, error) {
+					return fetchFn(ctx, clusterName)
+				})
+				var data interface{}
+				if fetchErr == nil {
+					data = v
+				}
 				elapsed := time.Since(start)
 
 				if fetchErr != nil {
@@ -638,7 +657,14 @@ func (h *MCPHandlers) GetEventsStream(c *fiber.Ctx) error {
 	}
 
 	namespace := c.Query("namespace")
-	limit := c.QueryInt("limit", 50)
+	limit := c.QueryInt("limit", defaultWarningEventsLimit)
+	// #7046 — Clamp to maxWarningEventsLimit to prevent unbounded result sets.
+	if limit <= 0 {
+		limit = defaultWarningEventsLimit
+	}
+	if limit > maxWarningEventsLimit {
+		limit = maxWarningEventsLimit
+	}
 
 	return streamClusters(c, h, sseClusterStreamConfig{
 		demoKey:        "events",

--- a/pkg/api/handlers/websocket.go
+++ b/pkg/api/handlers/websocket.go
@@ -153,8 +153,13 @@ func (h *Hub) Run() {
 			slog.Info("[WebSocket] client disconnected", "user", client.userID)
 
 		case msg := <-h.broadcast:
+			// #7049 — Copy the slice contents under the lock so concurrent
+			// unregister/DisconnectUser mutations cannot modify the underlying
+			// array while we iterate.
 			h.mu.RLock()
-			clients := h.userIndex[msg.userID]
+			orig := h.userIndex[msg.userID]
+			clients := make([]*Client, len(orig))
+			copy(clients, orig)
 			h.mu.RUnlock()
 
 			for _, client := range clients {
@@ -173,9 +178,22 @@ func (h *Hub) Run() {
 
 // Close shuts down the hub. It is safe to call multiple times;
 // only the first call actually closes the done channel.
+//
+// #7042 — Close every client.send channel so writer goroutines unblock
+// immediately instead of waiting for TCP connections to be forcibly closed.
+// Previously only Run's unregister case closed send channels, but Run exits
+// as soon as h.done is closed — leaving every writer goroutine stranded.
 func (h *Hub) Close() {
 	h.closeOnce.Do(func() {
 		close(h.done)
+
+		h.mu.Lock()
+		for client := range h.clients {
+			close(client.send)
+			delete(h.clients, client)
+		}
+		h.userIndex = make(map[uuid.UUID][]*Client)
+		h.mu.Unlock()
 	})
 }
 
@@ -238,12 +256,18 @@ func (h *Hub) DisconnectUser(userID uuid.UUID) {
 	h.mu.RUnlock()
 
 	for _, client := range clients {
-		// Send a close message so the client knows the session was terminated.
-		// Best-effort: if the conn is already closed by a peer error, the
-		// write will fail silently.
-		_ = client.conn.WriteMessage(websocket.CloseMessage,
-			websocket.FormatCloseMessage(websocket.CloseNormalClosure, "session invalidated"))
-		client.closeConn()
+		// #7041 — Send a sentinel value through the client's send channel so the
+		// writer goroutine sends the close frame itself, maintaining single-writer
+		// semantics. Previously DisconnectUser called conn.WriteMessage directly,
+		// racing the writer goroutine and violating gorilla/websocket's
+		// one-concurrent-writer rule.
+		select {
+		case client.send <- nil: // nil sentinel triggers close in writer
+		default:
+			// Channel full — force-close the connection so the reader/writer
+			// goroutines exit on their next I/O call.
+			client.closeConn()
+		}
 	}
 	slog.Info("[WebSocket] disconnected all connections for user", "user", userID, "count", len(clients))
 }
@@ -463,6 +487,13 @@ func (h *Hub) HandleConnection(conn *websocket.Conn) {
 			select {
 			case msg, ok := <-client.send:
 				if !ok {
+					return
+				}
+				// #7041 — nil sentinel from DisconnectUser: send a close frame
+				// from the writer goroutine (single-writer semantics) and exit.
+				if msg == nil {
+					_ = conn.WriteMessage(websocket.CloseMessage,
+						websocket.FormatCloseMessage(websocket.CloseNormalClosure, "session invalidated"))
 					return
 				}
 				if err := conn.WriteMessage(websocket.TextMessage, msg); err != nil {

--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -1319,6 +1319,10 @@ func (s *Server) Shutdown() error {
 			s.gpuUtilWorker.Stop()
 		}
 		s.hub.Close()
+		// #7043 — stop the SSE cache evictor goroutine that was started
+		// lazily by sseCacheSet. Without this the goroutine leaks after
+		// server shutdown.
+		handlers.StopSSECacheEvictor()
 		// #6578 — stop the token revocation cleanup goroutine so tests
 		// and embedded usage don't leak it across Server lifecycles.
 		middleware.ShutdownTokenRevocation()


### PR DESCRIPTION
Closes #7041
Closes #7042
Closes #7043
Closes #7044
Closes #7045
Closes #7046
Closes #7047
Closes #7048
Closes #7049
Closes #7050
Closes #7052
Closes #7053
Closes #7054
Closes #7055
Closes #7056
Closes #7057

## Summary

**SSE/WebSocket (8 issues):**
- **#7041** — DisconnectUser sends nil sentinel through client.send channel so the writer goroutine sends the close frame (single-writer semantics)
- **#7042** — Hub.Close() closes every client.send channel so writer goroutines unblock immediately
- **#7043** — Server.Shutdown() calls StopSSECacheEvictor() to stop the background evictor
- **#7044** — SSE cache key includes user ID to prevent cross-user data leakage
- **#7045** — SSE cold-cache fetches use singleflight to coalesce concurrent K8s API calls
- **#7046** — GetEventsStream clamps limit to maxWarningEventsLimit (500)
- **#7049** — Hub broadcast copies client slice under RLock before iterating
- **#7050** — writeSSEEvent strips newlines from eventName to prevent SSE frame injection

**Exec (2 issues):**
- **#7047** — Close terminalSizeQueue channel after StreamWithContext returns
- **#7048** — Wait for reader goroutine before writing exit message

**Nightly E2E + Caching (6 issues):**
- **#7052** — prewarm() uses context cancellation instead of abandoned goroutines
- **#7053** — GetRuns() uses singleflight for cold-cache coalescing
- **#7054** — All GitHub API calls use resolveGitHubAPIBase() for GHE support
- **#7055** — Error response bodies use io.LimitReader (10 KB cap)
- **#7056** — classifyFailures uses semaphore (max 5 concurrent)
- **#7057** — getCachedOrFetchPRs uses singleflight for cold-cache coalescing

## Test plan
- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [ ] CI build/lint pass