### PR TITLE
fix(missions): deadlock, closure staleness, timer cleanup, test baseline (#7102-#7119)

### DIFF
--- a/web/src/components/mission-control/MissionControlDialog.tsx
+++ b/web/src/components/mission-control/MissionControlDialog.tsx
@@ -440,8 +440,8 @@ export function MissionControlDialog({ open, onClose }: MissionControlDialogProp
                   )}
                   {state.assignments.length > 0 && (
                     <span>
-                      → {state.assignments.filter((a) => a.projectNames.length > 0).length} cluster
-                      {state.assignments.filter((a) => a.projectNames.length > 0).length !== 1
+                      → {state.assignments.filter((a) => (a.projectNames ?? []).length > 0).length} cluster
+                      {state.assignments.filter((a) => (a.projectNames ?? []).length > 0).length !== 1
                         ? 's'
                         : ''}
                     </span>

--- a/web/src/components/mission-control/useMissionControl.ts
+++ b/web/src/components/mission-control/useMissionControl.ts
@@ -757,7 +757,9 @@ export function useMissionControl() {
   // NOTE (#6782): `extractJSON` is intentionally omitted from this dependency
   // array — it is a module-level pure function (not a closure over component
   // state), so it can never go stale. Adding it would be harmless but noisy.
-  }, [debouncedAssistantContent, state.phase, state.planningMissionId, planningMission?.status])
+  // #7113 — `planningMission?.messages?.length` triggers re-parse when a new
+  // message is appended but debounced content hasn't changed (final-token stall).
+  }, [debouncedAssistantContent, state.phase, state.planningMissionId, planningMission?.status, planningMission?.messages?.length])
 
   // Update streaming state from mission status
   //
@@ -1003,6 +1005,7 @@ Include real CNCF projects only. Consider dependencies between projects.`
     }
 
   const addProject = (project: PayloadProject) => {
+    bumpUserGeneration() // #7112 — invalidate in-flight AI streams on manual CRUD
     // Tag every explicit add as user-added so mergeProjects preserves it
     // across AI refinement cycles (#6465).
     const tagged: PayloadProject = { ...project, userAdded: true }
@@ -1014,18 +1017,21 @@ Include real CNCF projects only. Consider dependencies between projects.`
   }
 
   const removeProject = (name: string) => {
+    bumpUserGeneration() // #7112 — invalidate in-flight AI streams on manual CRUD
     setState((prev) => ({
       ...prev,
       projects: prev.projects.filter((p) => p.name !== name) }))
   }
 
   const updateProjectPriority = (name: string, priority: PayloadProject['priority']) => {
+      bumpUserGeneration() // #7112 — invalidate in-flight AI streams on manual CRUD
       setState((prev) => ({
         ...prev,
         projects: prev.projects.map((p) => (p.name === name ? { ...p, priority } : p)) }))
     }
 
   const replaceProject = (oldName: string, newProject: PayloadProject) => {
+      bumpUserGeneration() // #7112 — invalidate in-flight AI streams on manual CRUD
       setState((prev) => {
         // Preserve the original AI-suggested name for swap tracking
         const existing = prev.projects.find((p) => p.name === oldName)
@@ -1057,8 +1063,17 @@ Include real CNCF projects only. Consider dependencies between projects.`
   // ---------------------------------------------------------------------------
 
   const askAIForAssignments = (projects: PayloadProject[], clustersJson: string) => {
+      // #7111 — Synchronous ref guard (mirrors askAIForSuggestions). Two rapid
+      // clicks within one frame both pass the aiStreaming state check because
+      // that flag updates asynchronously via useEffect.
+      if (aiRequestInFlightRef.current) {
+        console.warn('[MissionControl] #7111 — askAIForAssignments already in flight (ref guard); ignoring')
+        return
+      }
+      aiRequestInFlightRef.current = true
       // #6406 — Early return if a planning request is already in flight.
       if (stateRef.current.aiStreaming) {
+        aiRequestInFlightRef.current = false
         console.warn('[MissionControl] issue 6406 — askAIForAssignments called while already streaming; ignoring')
         return
       }
@@ -1117,21 +1132,28 @@ Order phases by dependency — prerequisites first. Each phase completes before 
       // the parse effect can discard this response if the user has since
       // mutated state.
       lastDispatchedGenerationRef.current = userMutationGenerationRef.current
-      // If no planning mission exists (user went manual on Phase 1), start one
-      // so the AI assign button is not silently a no-op (#5502)
-      if (!missionId) {
-        missionId = startMission({
-          title: 'Mission Control Planning',
-          description: 'AI-assisted cluster assignment',
-          type: 'custom',
-          initialPrompt: prompt })
-        setState((prev) => ({
-          ...prev,
-          planningMissionId: missionId,
-          aiStreaming: true }))
-      } else {
-        sendMessage(missionId, prompt)
-        setState((prev) => ({ ...prev, aiStreaming: true }))
+      // #7117 — Wrap in try/catch (mirrors askAIForSuggestions #6811) so a
+      // synchronous throw doesn't leave aiStreaming stuck true.
+      try {
+        // If no planning mission exists (user went manual on Phase 1), start one
+        // so the AI assign button is not silently a no-op (#5502)
+        if (!missionId) {
+          missionId = startMission({
+            title: 'Mission Control Planning',
+            description: 'AI-assisted cluster assignment',
+            type: 'custom',
+            initialPrompt: prompt })
+          setState((prev) => ({
+            ...prev,
+            planningMissionId: missionId,
+            aiStreaming: true }))
+        } else {
+          sendMessage(missionId, prompt)
+          setState((prev) => ({ ...prev, aiStreaming: true }))
+        }
+      } catch (err) {
+        aiRequestInFlightRef.current = false
+        console.error('[MissionControl] #7117 — askAIForAssignments failed:', err)
       }
     }
 

--- a/web/src/hooks/useMissions.tsx
+++ b/web/src/hooks/useMissions.tsx
@@ -593,6 +593,10 @@ export function MissionProvider({ children }: { children: ReactNode }) {
   // `wsRef.current.send` on a dying socket (or worse, call the user-supplied
   // `onFailure` after the component tree had already gone away).
   const wsSendRetryTimers = useRef<Set<ReturnType<typeof setTimeout>>>(new Set())
+  // #7106 — Track per-mission status-update timers (STATUS_WAITING_DELAY_MS,
+  // STATUS_PROCESSING_DELAY_MS) so they can be cleared when a mission is
+  // cancelled, dismissed, or the provider unmounts.
+  const missionStatusTimers = useRef<Map<string, Set<ReturnType<typeof setTimeout>>>>(new Map())
 
   /**
    * Send a message over the WebSocket with retry logic.
@@ -717,6 +721,13 @@ export function MissionProvider({ children }: { children: ReactNode }) {
           lastStreamTimestamp.current.clear()
           toolsInFlight.current.clear()
           streamSplitCounter.current.clear()
+          // #7106 — Clear all per-mission status-update timers
+          for (const timers of missionStatusTimers.current.values()) {
+            for (const handle of timers) {
+              clearTimeout(handle)
+            }
+          }
+          missionStatusTimers.current.clear()
         } catch (err) {
           // #6767 — Message is issue-agnostic; this branch now covers
           // #6758, #6762, and #6767 follow-ups.
@@ -727,6 +738,16 @@ export function MissionProvider({ children }: { children: ReactNode }) {
       try {
         const reloaded = loadMissions()
         setMissions(reloaded)
+        // #7105 — Reconcile derived state against the reloaded mission list.
+        // A cross-tab deletion could leave activeMissionId pointing at a
+        // mission that no longer exists, or unreadMissionIds containing IDs
+        // for deleted missions (stale badge count).
+        const reloadedIds = new Set(reloaded.map(m => m.id))
+        setActiveMissionId(prev => (prev && !reloadedIds.has(prev) ? null : prev))
+        setUnreadMissionIds(prev => {
+          const next = new Set([...prev].filter(id => reloadedIds.has(id)))
+          return next.size === prev.size ? prev : next
+        })
       } catch (err) {
         console.warn('[Missions] issue 6668 — failed to reload from cross-tab write:', err)
       }
@@ -856,12 +877,6 @@ export function MissionProvider({ children }: { children: ReactNode }) {
     if (wsRef.current?.readyState === WebSocket.OPEN) {
       return Promise.resolve()
     }
-
-    // #7075 — Reset the reconnect counter when a new explicit connection is
-    // requested (e.g. user interaction after giveup). Without this, the first
-    // subsequent disconnect after a giveup instantly hits the max-retries
-    // threshold and the auto-reconnect is permanently locked out for the session.
-    wsReconnectAttempts.current = 0
 
     return new Promise<void>((resolve, reject) => {
       // Show loading state while connecting
@@ -1330,6 +1345,13 @@ The WebSocket connection to the agent at \`${LOCAL_AGENT_WS_URL}\` was lost and 
           waitingInputTimeouts.current.clear()
           lastStreamTimestamp.current.clear()
           streamSplitCounter.current.clear()
+          // #7106 — Clear status-update timers on WS error
+          for (const timers of missionStatusTimers.current.values()) {
+            for (const handle of timers) {
+              clearTimeout(handle)
+            }
+          }
+          missionStatusTimers.current.clear()
           setAgentsLoading(false)
           reject(new Error('CONNECTION_FAILED'))
         }
@@ -1350,6 +1372,17 @@ The WebSocket connection to the agent at \`${LOCAL_AGENT_WS_URL}\` was lost and 
         next.add(missionId)
         return next
       })
+    }
+  }
+
+  // #7106 — Clear tracked status-update timers for a mission.
+  const clearMissionStatusTimers = (missionId: string) => {
+    const timers = missionStatusTimers.current.get(missionId)
+    if (timers) {
+      for (const handle of timers) {
+        clearTimeout(handle)
+      }
+      missionStatusTimers.current.delete(missionId)
     }
   }
 
@@ -1426,6 +1459,7 @@ The WebSocket connection to the agent at \`${LOCAL_AGENT_WS_URL}\` was lost and 
     streamSplitCounter.current.delete(missionId) // #6410 — terminal state cleanup
     toolsInFlight.current.delete(missionId) // #6410 — terminal state cleanup
     clearWaitingInputTimeout(missionId) // #5936
+    clearMissionStatusTimers(missionId) // #7106 — cancel status-update timers
 
     setMissions(prev => prev.map(m => {
       if (m.id !== missionId) return m
@@ -2253,23 +2287,37 @@ The WebSocket connection to the agent at \`${LOCAL_AGENT_WS_URL}\` was lost and 
         ))
       })
 
+      // #7106 — Track status-update timers so they can be cleared on
+      // cancel/dismiss/unmount. Without this, delayed callbacks mutate
+      // state after the mission lifecycle has ended.
+      if (!missionStatusTimers.current.has(missionId)) {
+        missionStatusTimers.current.set(missionId, new Set())
+      }
+      const timers = missionStatusTimers.current.get(missionId)!
+
       // Update status after message is sent
-      setTimeout(() => {
+      const waitingHandle = setTimeout(() => {
+        timers.delete(waitingHandle)
+        if (unmountedRef.current) return
         setMissions(prev => prev.map(m =>
           m.id === missionId && m.currentStep === 'Connecting to agent...'
             ? { ...m, currentStep: 'Waiting for response...' }
             : m
         ))
       }, STATUS_WAITING_DELAY_MS)
+      timers.add(waitingHandle)
 
       // Update status while AI is processing
-      setTimeout(() => {
+      const processingHandle = setTimeout(() => {
+        timers.delete(processingHandle)
+        if (unmountedRef.current) return
         setMissions(prev => prev.map(m =>
           m.id === missionId && m.currentStep === 'Waiting for response...'
             ? { ...m, currentStep: `Processing with ${selectedAgentRef.current || 'AI'}...` }
             : m
         ))
       }, STATUS_PROCESSING_DELAY_MS)
+      timers.add(processingHandle)
     }).catch(() => {
       const errorContent = `**Local Agent Not Connected**
 
@@ -2726,6 +2774,8 @@ Install the console locally with the KubeStellar Console agent to use AI mission
     // #6410 — mission is being removed from UI; drop per-mission tracking.
     streamSplitCounter.current.delete(missionId)
     toolsInFlight.current.delete(missionId)
+    // #7106 — Clear status-update timers to prevent stale mutations
+    clearMissionStatusTimers(missionId)
     setMissions(prev => prev.filter(m => m.id !== missionId))
     if (activeMissionId === missionId) {
       setActiveMissionId(null)
@@ -2830,6 +2880,10 @@ Install the console locally with the KubeStellar Console agent to use AI mission
 
   // Connect to agent (for AgentSelector in navbar)
   const connectToAgent = () => {
+    // #7075 — Reset the reconnect counter on explicit user-initiated
+    // connection requests (e.g. clicking "Reconnect" after giveup).
+    // Moved from ensureConnection so auto-reconnect preserves backoff.
+    wsReconnectAttempts.current = 0
     ensureConnection().catch(err => {
       console.error('[Missions] Failed to connect to agent:', err)
     })
@@ -2867,6 +2921,7 @@ Install the console locally with the KubeStellar Console agent to use AI mission
     const streamSplitCounterRef = streamSplitCounter.current
     const waitingInputTimeoutsRef = waitingInputTimeouts.current
     const wsSendRetryTimersRef = wsSendRetryTimers.current
+    const missionStatusTimersRef = missionStatusTimers.current
     return () => {
       // #6667 — Mark provider as unmounted BEFORE clearing timers, so any
       // in-flight async callback that races cleanup sees this flag and
@@ -2902,6 +2957,13 @@ Install the console locally with the KubeStellar Console agent to use AI mission
         clearTimeout(t)
       }
       waitingInputTimeoutsRef.clear()
+      // #7106 — Clear all per-mission status-update timers
+      for (const timers of missionStatusTimersRef.values()) {
+        for (const handle of timers) {
+          clearTimeout(handle)
+        }
+      }
+      missionStatusTimersRef.clear()
       // #6410 — nullify handlers BEFORE close(). `onclose` is what schedules
       // reconnection (see `wsReconnectTimer.current = setTimeout(...)` in
       // ensureConnection); if we don't detach it, an unmounted provider can

--- a/web/src/test/ui-ux-standards.test.ts
+++ b/web/src/test/ui-ux-standards.test.ts
@@ -75,7 +75,8 @@ const COMPONENTS_DIR = path.resolve(
 // When you bump this number, append a one-line entry above so future
 // bumps stay grep-able and reviewers can tell at a glance whether a
 // change is a real new violation or just a comment-level reference.
-const EXPECTED_RAW_HEX_COUNT = 313
+//   313 → 319: PR #7085 mission state fixes — issue-ref comments misclassified as hex colors
+const EXPECTED_RAW_HEX_COUNT = 319
 const EXPECTED_RAW_RGBA_COUNT = 104
 const EXPECTED_ARBITRARY_TW_COLOR_COUNT = 22
 const EXPECTED_INLINE_STYLE_COLOR_COUNT = 213


### PR DESCRIPTION
Closes #7102
Closes #7103
Closes #7104
Closes #7105
Closes #7106
Closes #7107
Closes #7108
Closes #7109
Closes #7110
Closes #7111
Closes #7112
Closes #7113
Closes #7114
Closes #7115
Closes #7116
Closes #7117
Closes #7118
Closes #7119

## Summary

Fixes 18 mission-state issues across `useMissions.tsx`, `useMissionControl.ts`, `MissionControlDialog.tsx`, and the UI/UX ratchet test.

### Actual code fixes (7 issues with real bugs)

- **#7104** — Footer `a.projectNames.length` unguarded against legacy schemas missing `projectNames`; added nullish fallback
- **#7105** — Cross-tab storage reload did not reconcile `activeMissionId` or `unreadMissionIds`, leaving stale pointers/badges
- **#7106** — `executeMission` status-update timers were untracked; added `missionStatusTimers` ref with cleanup in cancel/dismiss/unmount/WS-error paths
- **#7111** — `askAIForAssignments` lacked the `aiRequestInFlightRef` synchronous guard; two rapid clicks could fire parallel AI requests
- **#7112** — `addProject`, `removeProject`, `updateProjectPriority`, `replaceProject` did not call `bumpUserGeneration()`; late AI responses could silently overwrite manual edits
- **#7113** — `extractJSON` effect was missing `planningMission?.messages?.length` in its dependency array
- **#7117** — `askAIForAssignments` had no try/catch; a synchronous throw left `aiStreaming` stuck true

### Test/backoff fix (1 issue)

- **#7119** — Moved `wsReconnectAttempts` reset from `ensureConnection` to `connectToAgent` so auto-reconnect backoff works correctly. Bumped hex ratchet baseline 313 -> 319.

### Already fixed in PR #7085 (10 issues)

#7102, #7103, #7107, #7108, #7109, #7110, #7114, #7115, #7116, #7118

## Test plan

- [x] `npm run build` passes
- [x] `npx vitest run src/hooks/useMissions.test.tsx` — all 282 tests pass
- [x] `npx vitest run src/test/ui-ux-standards.test.ts` — all 7 tests pass