### PR TITLE
fix(services): LoadBalancer drilldown, schema parity, cache TTL, endpoint count

### DIFF
--- a/web/src/components/cards/NetworkOverview.tsx
+++ b/web/src/components/cards/NetworkOverview.tsx
@@ -20,7 +20,7 @@ export function NetworkOverview() {
   const { services, isLoading: servicesLoading, isRefreshing, isDemoFallback, consecutiveFailures, isFailed, lastRefresh: servicesLastRefresh } = useCachedServices()
 
   const { selectedClusters, isAllClustersSelected } = useGlobalFilters()
-  const { drillToService } = useDrillDownActions()
+  const { drillToService, drillToAllServices } = useDrillDownActions()
 
   // Report card data state.
   // #6267: include clustersRefreshing so the card-level state matches
@@ -225,12 +225,13 @@ export function NetworkOverview() {
         <div
           className={`p-2 rounded-lg bg-blue-500/10 border border-blue-500/20 ${stats.loadBalancers > 0 ? 'cursor-pointer hover:bg-blue-500/20' : 'cursor-default'} transition-colors`}
           onClick={() => {
-            const svc = filteredServices.find(s => s.type === 'LoadBalancer')
-            if (svc?.cluster && svc?.namespace) {
-              drillToService(svc.cluster, svc.namespace, svc.name)
+            if (stats.loadBalancers > 0) {
+              drillToAllServices('LoadBalancer', {
+                services: filteredServices.filter(s => s.type === 'LoadBalancer'),
+              })
             }
           }}
-          title={stats.loadBalancers > 0 ? `${stats.loadBalancers} LoadBalancer service${stats.loadBalancers !== 1 ? 's' : ''} - Click to view` : 'No LoadBalancer services'}
+          title={stats.loadBalancers > 0 ? `${stats.loadBalancers} LoadBalancer service${stats.loadBalancers !== 1 ? 's' : ''} - Click to view all` : 'No LoadBalancer services'}
         >
           <div className="flex items-center gap-1.5 mb-1">
             <Globe className="w-3 h-3 text-blue-400" />
@@ -241,12 +242,13 @@ export function NetworkOverview() {
         <div
           className={`p-2 rounded-lg bg-purple-500/10 border border-purple-500/20 ${stats.nodePort > 0 ? 'cursor-pointer hover:bg-purple-500/20' : 'cursor-default'} transition-colors`}
           onClick={() => {
-            const svc = filteredServices.find(s => s.type === 'NodePort')
-            if (svc?.cluster && svc?.namespace) {
-              drillToService(svc.cluster, svc.namespace, svc.name)
+            if (stats.nodePort > 0) {
+              drillToAllServices('NodePort', {
+                services: filteredServices.filter(s => s.type === 'NodePort'),
+              })
             }
           }}
-          title={stats.nodePort > 0 ? `${stats.nodePort} NodePort service${stats.nodePort !== 1 ? 's' : ''} - Click to view` : 'No NodePort services'}
+          title={stats.nodePort > 0 ? `${stats.nodePort} NodePort service${stats.nodePort !== 1 ? 's' : ''} - Click to view all` : 'No NodePort services'}
         >
           <div className="flex items-center gap-1.5 mb-1">
             <Server className="w-3 h-3 text-purple-400" />
@@ -257,12 +259,13 @@ export function NetworkOverview() {
         <div
           className={`p-2 rounded-lg bg-green-500/10 border border-green-500/20 ${stats.clusterIP > 0 ? 'cursor-pointer hover:bg-green-500/20' : 'cursor-default'} transition-colors`}
           onClick={() => {
-            const svc = filteredServices.find(s => s.type === 'ClusterIP')
-            if (svc?.cluster && svc?.namespace) {
-              drillToService(svc.cluster, svc.namespace, svc.name)
+            if (stats.clusterIP > 0) {
+              drillToAllServices('ClusterIP', {
+                services: filteredServices.filter(s => s.type === 'ClusterIP'),
+              })
             }
           }}
-          title={stats.clusterIP > 0 ? `${stats.clusterIP} ClusterIP service${stats.clusterIP !== 1 ? 's' : ''} - Click to view` : 'No ClusterIP services'}
+          title={stats.clusterIP > 0 ? `${stats.clusterIP} ClusterIP service${stats.clusterIP !== 1 ? 's' : ''} - Click to view all` : 'No ClusterIP services'}
         >
           <div className="flex items-center gap-1.5 mb-1">
             <Server className="w-3 h-3 text-green-400" />
@@ -273,12 +276,13 @@ export function NetworkOverview() {
         <div
           className={`p-2 rounded-lg bg-orange-500/10 border border-orange-500/20 ${stats.externalName > 0 ? 'cursor-pointer hover:bg-orange-500/20' : 'cursor-default'} transition-colors`}
           onClick={() => {
-            const svc = filteredServices.find(s => s.type === 'ExternalName')
-            if (svc?.cluster && svc?.namespace) {
-              drillToService(svc.cluster, svc.namespace, svc.name)
+            if (stats.externalName > 0) {
+              drillToAllServices('ExternalName', {
+                services: filteredServices.filter(s => s.type === 'ExternalName'),
+              })
             }
           }}
-          title={stats.externalName > 0 ? `${stats.externalName} ExternalName service${stats.externalName !== 1 ? 's' : ''} - Click to view` : 'No ExternalName services'}
+          title={stats.externalName > 0 ? `${stats.externalName} ExternalName service${stats.externalName !== 1 ? 's' : ''} - Click to view all` : 'No ExternalName services'}
         >
           <div className="flex items-center gap-1.5 mb-1">
             <ExternalLink className="w-3 h-3 text-orange-400" />

--- a/web/src/components/cards/ServiceStatus.tsx
+++ b/web/src/components/cards/ServiceStatus.tsx
@@ -345,6 +345,10 @@ export function ServiceStatus() {
                 type: service.type,
                 ports: service.ports,
                 clusterIP: service.clusterIP,
+                externalIP: service.externalIP,
+                endpoints: service.endpoints,
+                lbStatus: service.lbStatus,
+                selector: service.selector,
               })}
               className="flex items-center justify-between p-2 rounded-lg bg-secondary/30 hover:bg-secondary/50 transition-colors cursor-pointer group gap-2"
             >

--- a/web/src/components/drilldown/DrillDownModal.tsx
+++ b/web/src/components/drilldown/DrillDownModal.tsx
@@ -23,6 +23,7 @@ const ArgoAppDrillDown = safeLazy(() => import('./views/ArgoAppDrillDown'), 'Arg
 const HelmReleaseDrillDown = safeLazy(() => import('./views/HelmReleaseDrillDown'), 'HelmReleaseDrillDown')
 const ConfigMapDrillDown = safeLazy(() => import('./views/ConfigMapDrillDown'), 'ConfigMapDrillDown')
 const BuildpackDrillDown = safeLazy(() => import('./views/BuildpackDrillDown'), 'BuildpackDrillDown')
+const ServiceDrillDown = safeLazy(() => import('./views/ServiceDrillDown'), 'default')
 const RBACDrillDown = safeLazy(() => import('./views/RBACDrillDown'), 'RBACDrillDown')
 const CostDrillDown = safeLazy(() => import('./views/CostDrillDown'), 'CostDrillDown')
 const ComplianceDrillDown = safeLazy(() => import('./views/ComplianceDrillDown'), 'ComplianceDrillDown')
@@ -128,6 +129,7 @@ const getViewIcon = (type: string) => {
     case 'configmap': return <FileText className="w-4 h-4 text-yellow-400" />
     case 'secret': return <Lock className="w-4 h-4 text-red-400" />
     case 'serviceaccount': return <User className="w-4 h-4 text-purple-400" />
+    case 'service': return <Layers className="w-4 h-4 text-cyan-400" />
     case 'pvc': return <HardDrive className="w-4 h-4 text-green-400" />
     case 'node': return <Cpu className="w-4 h-4 text-orange-400" />
     case 'gpu-node': return <Cpu className="w-4 h-4 text-purple-400" />
@@ -253,6 +255,8 @@ export function DrillDownModal() {
         return <ServiceAccountDrillDown data={data} />
       case 'pvc':
         return <PVCDrillDown data={data} />
+      case 'service':
+        return <ServiceDrillDown data={data} />
       // Phase 2 views
       case 'alert':
         return <AlertDrillDown data={data} />

--- a/web/src/components/drilldown/views/ServiceDrillDown.tsx
+++ b/web/src/components/drilldown/views/ServiceDrillDown.tsx
@@ -1,0 +1,487 @@
+import { useState, useEffect, useRef } from 'react'
+import { useLocalAgent } from '../../../hooks/useLocalAgent'
+import { LOCAL_AGENT_WS_URL } from '../../../lib/constants'
+import { useDrillDownActions } from '../../../hooks/useDrillDown'
+import { ClusterBadge } from '../../ui/ClusterBadge'
+import { Globe, Server, Info, Tag, Loader2, Copy, Check, ExternalLink, Activity } from 'lucide-react'
+import { cn } from '../../../lib/cn'
+import { UI_FEEDBACK_TIMEOUT_MS } from '../../../lib/constants/network'
+import { useTranslation } from 'react-i18next'
+import { copyToClipboard } from '../../../lib/clipboard'
+import {
+  deriveServiceHealth,
+  SERVICE_HEALTH_DOT_CLASSES,
+  SERVICE_HEALTH_LABELS,
+} from '../../../lib/services/serviceHealth'
+
+interface Props {
+  data: Record<string, unknown>
+}
+
+type TabType = 'overview' | 'endpoints' | 'describe' | 'yaml'
+
+/** Timeout for kubectl WebSocket commands (milliseconds) */
+const KUBECTL_TIMEOUT_MS = 10_000
+
+export default function ServiceDrillDown({ data }: Props) {
+  const { t } = useTranslation()
+  const cluster = data.cluster as string
+  const namespace = data.namespace as string
+  const serviceName = data.service as string
+  const { isConnected: agentConnected } = useLocalAgent()
+  const { drillToNamespace, drillToCluster, drillToPod } = useDrillDownActions()
+
+  const [activeTab, setActiveTab] = useState<TabType>('overview')
+  const [serviceType, setServiceType] = useState<string>((data.type as string) || 'ClusterIP')
+  const [clusterIP, setClusterIP] = useState<string>((data.clusterIP as string) || '')
+  const [externalIPs, setExternalIPs] = useState<string[]>((data.externalIPs as string[]) || (data.externalIP ? [data.externalIP as string] : []))
+  const [ports, setPorts] = useState<string[]>((data.ports as string[]) || [])
+  const [endpointCount, setEndpointCount] = useState<number | undefined>(data.endpoints as number | undefined)
+  const [lbStatus, setLbStatus] = useState<string>((data.lbStatus as string) || '')
+  const [selector, setSelector] = useState<Record<string, string> | null>((data.selector as Record<string, string>) || null)
+  const [labels, setLabels] = useState<Record<string, string> | null>(null)
+  const [, setAnnotations] = useState<Record<string, string> | null>(null)
+  const [endpointAddresses, setEndpointAddresses] = useState<Array<{ ip: string; nodeName?: string; targetRef?: string }>>([])
+  const [describeOutput, setDescribeOutput] = useState<string | null>(null)
+  const [describeLoading, setDescribeLoading] = useState(false)
+  const [yamlOutput, setYamlOutput] = useState<string | null>(null)
+  const [yamlLoading, setYamlLoading] = useState(false)
+  const [copiedField, setCopiedField] = useState<string | null>(null)
+  const [isLoading, setIsLoading] = useState(false)
+
+  // Helper to run kubectl commands
+  const runKubectl = (args: string[]): Promise<string> => {
+    return new Promise((resolve) => {
+      const ws = new WebSocket(LOCAL_AGENT_WS_URL)
+      const requestId = `kubectl-${Date.now()}-${Math.random().toString(36).slice(2)}`
+      let output = ''
+      const timeout = setTimeout(() => {
+        ws.close()
+        resolve(output || 'Command timed out')
+      }, KUBECTL_TIMEOUT_MS)
+
+      ws.onopen = () => {
+        ws.send(JSON.stringify({
+          id: requestId,
+          type: 'kubectl',
+          payload: { context: cluster, namespace, args },
+        }))
+      }
+      ws.onmessage = (evt) => {
+        try {
+          const msg = JSON.parse(evt.data)
+          if (msg.id === requestId) {
+            clearTimeout(timeout)
+            output = msg.payload?.output || msg.payload?.error || ''
+            ws.close()
+            resolve(output)
+          }
+        } catch { /* ignore */ }
+      }
+      ws.onerror = () => { clearTimeout(timeout); resolve('Agent connection error') }
+      ws.onclose = () => { clearTimeout(timeout); resolve(output || 'Connection closed') }
+    })
+  }
+
+  // Fetch service details on mount
+  const fetchedRef = useRef(false)
+  useEffect(() => {
+    if (!agentConnected || fetchedRef.current) return
+    fetchedRef.current = true
+    setIsLoading(true)
+
+    const fetchDetails = async () => {
+      try {
+        const raw = await runKubectl(['get', 'service', serviceName, '-n', namespace, '-o', 'json'])
+        const svc = JSON.parse(raw)
+        const spec = svc.spec || {}
+        const status = svc.status || {}
+
+        setServiceType(spec.type || 'ClusterIP')
+        setClusterIP(spec.clusterIP || '')
+        setPorts((spec.ports || []).map((p: { port: number; protocol?: string; nodePort?: number; name?: string }) => {
+          const base = p.nodePort ? `${p.port}:${p.nodePort}/${p.protocol || 'TCP'}` : `${p.port}/${p.protocol || 'TCP'}`
+          return p.name ? `${p.name}: ${base}` : base
+        }))
+
+        // External IPs: combine spec.externalIPs and status.loadBalancer.ingress
+        const allExternalIPs: string[] = []
+        if (spec.externalIPs) {
+          allExternalIPs.push(...spec.externalIPs)
+        }
+        const ingress = status.loadBalancer?.ingress || []
+        for (const entry of ingress) {
+          if (entry.ip) allExternalIPs.push(entry.ip)
+          else if (entry.hostname) allExternalIPs.push(entry.hostname)
+        }
+        setExternalIPs(allExternalIPs)
+
+        // LB status
+        if (spec.type === 'LoadBalancer') {
+          setLbStatus(ingress.length > 0 ? 'Ready' : 'Provisioning')
+        }
+
+        setSelector(spec.selector || null)
+        setLabels(svc.metadata?.labels || null)
+        setAnnotations(svc.metadata?.annotations || null)
+      } catch { /* ignore parse errors */ }
+
+      // Fetch endpoints
+      try {
+        const epRaw = await runKubectl(['get', 'endpoints', serviceName, '-n', namespace, '-o', 'json'])
+        const ep = JSON.parse(epRaw)
+        const addrs: Array<{ ip: string; nodeName?: string; targetRef?: string }> = []
+        for (const subset of (ep.subsets || [])) {
+          for (const addr of (subset.addresses || [])) {
+            addrs.push({
+              ip: addr.ip,
+              nodeName: addr.nodeName,
+              targetRef: addr.targetRef?.name,
+            })
+          }
+        }
+        setEndpointAddresses(addrs)
+        setEndpointCount(addrs.length)
+      } catch { /* ignore */ }
+
+      setIsLoading(false)
+    }
+
+    fetchDetails()
+  }, [agentConnected, cluster, namespace, serviceName])
+
+  const handleCopy = async (text: string, field: string) => {
+    const ok = await copyToClipboard(text)
+    if (ok) {
+      setCopiedField(field)
+      setTimeout(() => setCopiedField(null), UI_FEEDBACK_TIMEOUT_MS)
+    }
+  }
+
+  const health = deriveServiceHealth({
+    endpoints: endpointCount,
+    selector: selector || undefined,
+    lbStatus,
+    type: serviceType,
+  })
+
+  const tabs: { id: TabType; label: string }[] = [
+    { id: 'overview', label: t('drilldown.overview', 'Overview') },
+    { id: 'endpoints', label: t('drilldown.endpoints', 'Endpoints') },
+    { id: 'describe', label: t('drilldown.describe', 'Describe') },
+    { id: 'yaml', label: t('drilldown.yaml', 'YAML') },
+  ]
+
+  return (
+    <div className="space-y-4">
+      {/* Header */}
+      <div className="flex items-center gap-3">
+        <div className="p-2 rounded-lg bg-cyan-500/10">
+          {serviceType === 'LoadBalancer' ? (
+            <Globe className="w-5 h-5 text-blue-400" />
+          ) : serviceType === 'ExternalName' ? (
+            <ExternalLink className="w-5 h-5 text-orange-400" />
+          ) : (
+            <Server className="w-5 h-5 text-green-400" />
+          )}
+        </div>
+        <div>
+          <h2 className="text-lg font-semibold text-foreground">{serviceName}</h2>
+          <div className="flex items-center gap-2 text-sm text-muted-foreground">
+            <span
+              className="cursor-pointer hover:text-foreground"
+              onClick={() => drillToNamespace(cluster, namespace)}
+            >
+              {namespace}
+            </span>
+            <span>/</span>
+            <span
+              className="cursor-pointer hover:text-foreground"
+              onClick={() => drillToCluster(cluster)}
+            >
+              <ClusterBadge cluster={cluster} size="sm" />
+            </span>
+          </div>
+        </div>
+        <div className="ml-auto flex items-center gap-2">
+          {/* Health dot */}
+          <span
+            className={`w-3 h-3 rounded-full ${SERVICE_HEALTH_DOT_CLASSES[health]}`}
+            title={SERVICE_HEALTH_LABELS[health]}
+          />
+          <span className={cn(
+            'px-2 py-0.5 rounded text-xs',
+            serviceType === 'LoadBalancer' ? 'bg-blue-500/10 text-blue-400' :
+            serviceType === 'NodePort' ? 'bg-purple-500/10 text-purple-400' :
+            serviceType === 'ExternalName' ? 'bg-orange-500/10 text-orange-400' :
+            'bg-green-500/10 text-green-400'
+          )}>
+            {serviceType}
+          </span>
+          {lbStatus && (
+            <span className={cn(
+              'px-2 py-0.5 rounded text-xs',
+              lbStatus === 'Ready' ? 'bg-green-500/10 text-green-400' : 'bg-yellow-500/10 text-yellow-400'
+            )}>
+              {lbStatus}
+            </span>
+          )}
+        </div>
+      </div>
+
+      {/* Tabs */}
+      <div className="flex gap-1 border-b border-border">
+        {tabs.map(tab => (
+          <button
+            key={tab.id}
+            onClick={() => setActiveTab(tab.id)}
+            className={cn(
+              'px-3 py-2 text-sm transition-colors',
+              activeTab === tab.id
+                ? 'text-foreground border-b-2 border-primary'
+                : 'text-muted-foreground hover:text-foreground'
+            )}
+          >
+            {tab.label}
+          </button>
+        ))}
+      </div>
+
+      {/* Tab content */}
+      {activeTab === 'overview' && (
+        <div className="space-y-4">
+          {isLoading ? (
+            <div className="flex items-center gap-2 text-muted-foreground">
+              <Loader2 className="w-4 h-4 animate-spin" />
+              <span>Loading service details...</span>
+            </div>
+          ) : (
+            <>
+              {/* Key details grid */}
+              <div className="grid grid-cols-2 gap-3">
+                <InfoField
+                  label="Type"
+                  value={serviceType}
+                  icon={<Info className="w-3.5 h-3.5" />}
+                  onCopy={() => handleCopy(serviceType, 'type')}
+                  copied={copiedField === 'type'}
+                />
+                <InfoField
+                  label="Cluster IP"
+                  value={clusterIP || 'None'}
+                  icon={<Server className="w-3.5 h-3.5" />}
+                  onCopy={clusterIP ? () => handleCopy(clusterIP, 'clusterIP') : undefined}
+                  copied={copiedField === 'clusterIP'}
+                />
+                <InfoField
+                  label="External IPs"
+                  value={externalIPs.length > 0 ? externalIPs.join(', ') : 'None'}
+                  icon={<Globe className="w-3.5 h-3.5" />}
+                  onCopy={externalIPs.length > 0 ? () => handleCopy(externalIPs.join(', '), 'externalIP') : undefined}
+                  copied={copiedField === 'externalIP'}
+                />
+                <InfoField
+                  label="Endpoints"
+                  value={endpointCount !== undefined ? `${endpointCount} ready` : 'Unknown'}
+                  icon={<Activity className="w-3.5 h-3.5" />}
+                />
+              </div>
+
+              {/* Ports */}
+              {ports.length > 0 && (
+                <div className="p-3 rounded-lg bg-secondary/30">
+                  <div className="text-xs text-muted-foreground mb-2">Ports</div>
+                  <div className="flex flex-wrap gap-2">
+                    {ports.map((p, i) => (
+                      <span key={i} className="px-2 py-1 rounded text-xs bg-secondary text-foreground font-mono">
+                        {p}
+                      </span>
+                    ))}
+                  </div>
+                </div>
+              )}
+
+              {/* Selector */}
+              {selector && Object.keys(selector).length > 0 && (
+                <div className="p-3 rounded-lg bg-secondary/30">
+                  <div className="text-xs text-muted-foreground mb-2 flex items-center gap-1">
+                    <Tag className="w-3 h-3" />
+                    Selector
+                  </div>
+                  <div className="flex flex-wrap gap-2">
+                    {Object.entries(selector).map(([k, v]) => (
+                      <span key={k} className="px-2 py-1 rounded text-xs bg-primary/10 text-primary font-mono">
+                        {k}={v}
+                      </span>
+                    ))}
+                  </div>
+                </div>
+              )}
+
+              {/* Labels */}
+              {labels && Object.keys(labels).length > 0 && (
+                <div className="p-3 rounded-lg bg-secondary/30">
+                  <div className="text-xs text-muted-foreground mb-2 flex items-center gap-1">
+                    <Tag className="w-3 h-3" />
+                    Labels
+                  </div>
+                  <div className="flex flex-wrap gap-2">
+                    {Object.entries(labels).map(([k, v]) => (
+                      <span key={k} className="px-2 py-1 rounded text-xs bg-secondary text-muted-foreground font-mono">
+                        {k}={v}
+                      </span>
+                    ))}
+                  </div>
+                </div>
+              )}
+            </>
+          )}
+        </div>
+      )}
+
+      {activeTab === 'endpoints' && (
+        <div className="space-y-3">
+          {endpointAddresses.length === 0 ? (
+            <div className="text-sm text-muted-foreground text-center py-6">
+              No ready endpoints found for this service.
+            </div>
+          ) : (
+            endpointAddresses.map((addr, i) => (
+              <div
+                key={i}
+                className={cn(
+                  'flex items-center justify-between p-2 rounded-lg bg-secondary/30',
+                  addr.targetRef ? 'cursor-pointer hover:bg-secondary/50' : ''
+                )}
+                onClick={() => {
+                  if (addr.targetRef) {
+                    drillToPod(cluster, namespace, addr.targetRef)
+                  }
+                }}
+              >
+                <div className="flex items-center gap-2">
+                  <span className="w-2 h-2 rounded-full bg-green-500" />
+                  <span className="text-sm font-mono text-foreground">{addr.ip}</span>
+                </div>
+                <div className="flex items-center gap-2 text-xs text-muted-foreground">
+                  {addr.targetRef && (
+                    <span className="px-1.5 py-0.5 bg-cyan-500/10 text-cyan-400 rounded">
+                      {addr.targetRef}
+                    </span>
+                  )}
+                  {addr.nodeName && (
+                    <span className="px-1.5 py-0.5 bg-secondary rounded">
+                      {addr.nodeName}
+                    </span>
+                  )}
+                </div>
+              </div>
+            ))
+          )}
+        </div>
+      )}
+
+      {activeTab === 'describe' && (
+        <div>
+          {!describeOutput && !describeLoading && (
+            <button
+              onClick={async () => {
+                setDescribeLoading(true)
+                const output = await runKubectl(['describe', 'service', serviceName, '-n', namespace])
+                setDescribeOutput(output)
+                setDescribeLoading(false)
+              }}
+              className="px-3 py-1.5 bg-secondary hover:bg-secondary/80 text-foreground rounded-lg text-sm transition-colors"
+            >
+              Load Describe
+            </button>
+          )}
+          {describeLoading && (
+            <div className="flex items-center gap-2 text-muted-foreground">
+              <Loader2 className="w-4 h-4 animate-spin" />
+              Running kubectl describe...
+            </div>
+          )}
+          {describeOutput && (
+            <div className="relative">
+              <button
+                onClick={() => handleCopy(describeOutput, 'describe')}
+                className="absolute top-2 right-2 p-1 rounded bg-secondary hover:bg-secondary/80"
+                title="Copy"
+              >
+                {copiedField === 'describe' ? <Check className="w-3 h-3 text-green-400" /> : <Copy className="w-3 h-3" />}
+              </button>
+              <pre className="p-3 rounded-lg bg-secondary/30 text-xs font-mono text-foreground overflow-x-auto whitespace-pre-wrap max-h-[400px] overflow-y-auto">
+                {describeOutput}
+              </pre>
+            </div>
+          )}
+        </div>
+      )}
+
+      {activeTab === 'yaml' && (
+        <div>
+          {!yamlOutput && !yamlLoading && (
+            <button
+              onClick={async () => {
+                setYamlLoading(true)
+                const output = await runKubectl(['get', 'service', serviceName, '-n', namespace, '-o', 'yaml'])
+                setYamlOutput(output)
+                setYamlLoading(false)
+              }}
+              className="px-3 py-1.5 bg-secondary hover:bg-secondary/80 text-foreground rounded-lg text-sm transition-colors"
+            >
+              Load YAML
+            </button>
+          )}
+          {yamlLoading && (
+            <div className="flex items-center gap-2 text-muted-foreground">
+              <Loader2 className="w-4 h-4 animate-spin" />
+              Loading YAML...
+            </div>
+          )}
+          {yamlOutput && (
+            <div className="relative">
+              <button
+                onClick={() => handleCopy(yamlOutput, 'yaml')}
+                className="absolute top-2 right-2 p-1 rounded bg-secondary hover:bg-secondary/80"
+                title="Copy"
+              >
+                {copiedField === 'yaml' ? <Check className="w-3 h-3 text-green-400" /> : <Copy className="w-3 h-3" />}
+              </button>
+              <pre className="p-3 rounded-lg bg-secondary/30 text-xs font-mono text-foreground overflow-x-auto whitespace-pre-wrap max-h-[400px] overflow-y-auto">
+                {yamlOutput}
+              </pre>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}
+
+/** Reusable info field with optional copy button */
+function InfoField({ label, value, icon, onCopy, copied }: {
+  label: string
+  value: string
+  icon?: React.ReactNode
+  onCopy?: () => void
+  copied?: boolean
+}) {
+  return (
+    <div className="p-3 rounded-lg bg-secondary/30">
+      <div className="flex items-center gap-1.5 text-xs text-muted-foreground mb-1">
+        {icon}
+        {label}
+      </div>
+      <div className="flex items-center gap-2">
+        <span className="text-sm text-foreground truncate" title={value}>{value}</span>
+        {onCopy && (
+          <button onClick={onCopy} className="p-0.5 rounded hover:bg-secondary shrink-0" title="Copy">
+            {copied ? <Check className="w-3 h-3 text-green-400" /> : <Copy className="w-3 h-3 text-muted-foreground" />}
+          </button>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/web/src/components/network/Network.tsx
+++ b/web/src/components/network/Network.tsx
@@ -74,8 +74,13 @@ export function Network() {
         return { value: clusterIPServices, sublabel: 'internal only', onClick: drillToClusterIP, isClickable: clusterIPServices > 0 }
       case 'ingresses':
         return { value: '-', sublabel: 'ingresses', isClickable: false }
-      case 'endpoints':
-        return { value: filteredServices.length, sublabel: 'endpoints', isClickable: false }
+      case 'endpoints': {
+        // Sum actual ready endpoints across services (#7126) — not just service count
+        const totalEndpoints = filteredServices.reduce(
+          (sum, s) => sum + (s.endpoints ?? 0), 0
+        )
+        return { value: totalEndpoints, sublabel: 'endpoints', isClickable: false }
+      }
       default:
         return { value: '-', sublabel: '' }
     }

--- a/web/src/hooks/mcp/networking.ts
+++ b/web/src/hooks/mcp/networking.ts
@@ -8,7 +8,7 @@ import { kubectlProxy } from '../../lib/kubectlProxy'
 import { STORAGE_KEY_TOKEN } from '../../lib/constants'
 import { REFRESH_INTERVAL_MS, MIN_REFRESH_INDICATOR_MS, getEffectiveInterval, LOCAL_AGENT_URL, agentFetch, clusterCacheRef } from './shared'
 import { subscribePolling } from './pollingManager'
-import { MCP_HOOK_TIMEOUT_MS, DEPLOY_ABORT_TIMEOUT_MS } from '../../lib/constants/network'
+import { MCP_HOOK_TIMEOUT_MS, DEPLOY_ABORT_TIMEOUT_MS, SERVICES_CACHE_TTL_MS } from '../../lib/constants/network'
 import type { Service, Ingress, NetworkPolicy } from './types'
 
 // ---------------------------------------------------------------------------
@@ -55,6 +55,13 @@ function loadServicesCacheFromStorage(cacheKey: string): { data: Service[], time
       const parsed = JSON.parse(stored)
       if (parsed.key === cacheKey && parsed.data && parsed.data.length > 0) {
         const timestamp = parsed.timestamp ? new Date(parsed.timestamp) : new Date()
+        // Enforce cache TTL — discard stale entries so stale data is never
+        // served after a fetch failure (#7125)
+        const cacheAgeMs = Date.now() - timestamp.getTime()
+        if (cacheAgeMs > SERVICES_CACHE_TTL_MS) {
+          try { localStorage.removeItem(SERVICES_CACHE_KEY) } catch { /* ignore */ }
+          return null
+        }
         servicesCache = { data: parsed.data, timestamp, key: cacheKey }
         return { data: parsed.data, timestamp }
       }
@@ -205,14 +212,17 @@ export function useServices(cluster?: string, namespace?: string) {
 
         if (svcData && svcData.length >= 0) {
           const now = new Date()
-          // Map to Service format
+          // Map to Service format — include LB fields for schema parity (#7123, #7124, #7127)
           const mappedServices: Service[] = svcData.map(s => ({
             name: s.name,
             namespace: s.namespace,
             cluster: cluster,
             type: s.type,
             clusterIP: s.clusterIP,
+            externalIP: s.externalIP || undefined,
             ports: s.ports ? s.ports.split(', ') : [],
+            lbStatus: s.lbStatus || undefined,
+            selector: s.selector,
           }))
           servicesCache = { data: mappedServices, timestamp: now, key: cacheKey }
           setServices(mappedServices)
@@ -516,7 +526,7 @@ function getDemoServices(): Service[] {
     { name: 'redis', namespace: 'data', cluster: 'prod-east', type: 'ClusterIP', clusterIP: '10.96.30.20', ports: ['6379/TCP'], endpoints: 3, age: '40d' },
     { name: 'prometheus', namespace: 'monitoring', cluster: 'staging', type: 'ClusterIP', clusterIP: '10.96.40.10', ports: ['9090/TCP'], endpoints: 2, age: '20d' },
     { name: 'grafana', namespace: 'monitoring', cluster: 'staging', type: 'NodePort', clusterIP: '10.96.40.20', ports: ['3000:30300/TCP'], endpoints: 1, age: '20d' },
-    { name: 'ml-inference', namespace: 'ml', cluster: 'vllm-d', type: 'LoadBalancer', clusterIP: '10.96.50.10', externalIP: '34.56.78.90', ports: ['8080/TCP'], endpoints: 8, lbStatus: 'Ready', age: '15d' },
+    { name: 'ml-inference', namespace: 'ml', cluster: 'vllm-d', type: 'LoadBalancer', clusterIP: '10.96.50.10', externalIP: '34.56.78.90, 34.56.78.91', ports: ['8080/TCP'], endpoints: 8, lbStatus: 'Ready', age: '15d' },
     // A LoadBalancer service that is still provisioning — shows the
     // "Provisioning" label in the Services drawer instead of a blank
     // external IP (issue #6153).

--- a/web/src/lib/kubectlProxy.ts
+++ b/web/src/lib/kubectlProxy.ts
@@ -386,25 +386,48 @@ class KubectlProxy {
   /**
    * Get services from a cluster
    */
-  async getServices(context: string, namespace?: string): Promise<{ name: string; namespace: string; type: string; clusterIP: string; ports: string }[]> {
+  async getServices(context: string, namespace?: string): Promise<KubectlServiceResult[]> {
     const nsArg = namespace ? ['-n', namespace] : ['-A']
     const response = await this.exec(['get', 'services', ...nsArg, '-o', 'json'], { context, timeout: KUBECTL_EXTENDED_TIMEOUT_MS })
     if (response.exitCode !== 0) {
       throw new Error(response.error || 'Failed to get services')
     }
-    let data: { items?: Array<{ metadata: { name: string; namespace: string }; spec: { type: string; clusterIP: string; ports?: { port: number; protocol: string }[] } }> }
+    let data: { items?: KubeService[] }
     try {
       data = JSON.parse(response.output)
     } catch {
       throw new Error('Failed to parse kubectl output as JSON')
     }
-    return (data.items || []).map((svc: { metadata: { name: string; namespace: string }; spec: { type: string; clusterIP: string; ports?: { port: number; protocol: string }[] } }) => ({
-      name: svc.metadata.name,
-      namespace: svc.metadata.namespace,
-      type: svc.spec.type,
-      clusterIP: svc.spec.clusterIP || '',
-      ports: (svc.spec.ports || []).map(p => `${p.port}/${p.protocol}`).join(', '),
-    }))
+    return (data.items || []).map((svc: KubeService) => {
+      // Collect ALL external IPs from both spec.externalIPs and status.loadBalancer.ingress (#7124)
+      const allExternalIPs: string[] = []
+      if (svc.spec.externalIPs) {
+        allExternalIPs.push(...svc.spec.externalIPs)
+      }
+      const ingress = svc.status?.loadBalancer?.ingress || []
+      for (const entry of ingress) {
+        if (entry.ip) allExternalIPs.push(entry.ip)
+        else if (entry.hostname) allExternalIPs.push(entry.hostname)
+      }
+
+      // Determine LB status (#7123)
+      let lbStatus = ''
+      if (svc.spec.type === 'LoadBalancer') {
+        lbStatus = ingress.length > 0 ? 'Ready' : 'Provisioning'
+      }
+
+      return {
+        name: svc.metadata.name,
+        namespace: svc.metadata.namespace,
+        type: svc.spec.type,
+        clusterIP: svc.spec.clusterIP || '',
+        ports: (svc.spec.ports || []).map(p => `${p.port}/${p.protocol}`).join(', '),
+        externalIP: allExternalIPs.join(', '),
+        externalIPs: allExternalIPs,
+        lbStatus,
+        selector: svc.spec.selector,
+      }
+    })
   }
 
   /**
@@ -860,6 +883,40 @@ interface KubeEvent {
   count?: number
   firstTimestamp?: string
   lastTimestamp?: string
+}
+
+/** Shape of a Kubernetes Service object from `kubectl get services -o json` */
+interface KubeService {
+  metadata: { name: string; namespace: string; labels?: Record<string, string> }
+  spec: {
+    type: string
+    clusterIP: string
+    externalIPs?: string[]
+    ports?: Array<{ port: number; protocol: string; nodePort?: number; name?: string }>
+    selector?: Record<string, string>
+  }
+  status?: {
+    loadBalancer?: {
+      ingress?: Array<{ ip?: string; hostname?: string }>
+    }
+  }
+}
+
+/** Result of getServices — includes LB fields for schema parity (#7127) */
+export interface KubectlServiceResult {
+  name: string
+  namespace: string
+  type: string
+  clusterIP: string
+  ports: string
+  /** Comma-separated list of all external IPs/hostnames */
+  externalIP: string
+  /** Array of all external IPs/hostnames (#7124 — not truncated to first) */
+  externalIPs: string[]
+  /** 'Ready' | 'Provisioning' | '' — LoadBalancer provisioning state (#7123) */
+  lbStatus: string
+  /** Label selector for backing pods (#7127 — schema parity) */
+  selector?: Record<string, string>
 }
 
 interface KubeDeployment {


### PR DESCRIPTION
## Summary
- **#7121**: Create `ServiceDrillDown.tsx` with overview/endpoints/describe/YAML tabs; register `service` view type in `DrillDownModal` so `drillToService()` renders a proper detail view
- **#7122**: Fix NetworkOverview stat block clicks to drill to `all-services` with a type filter instead of navigating to a single arbitrary service
- **#7123**: Extend `kubectlProxy.getServices()` to extract `externalIP`, `lbStatus`, and `selector` from full JSON output in the kubectl fallback path
- **#7124**: Collect ALL external IPs from both `spec.externalIPs` and `status.loadBalancer.ingress[]` instead of truncating to index `[0]`
- **#7125**: Add TTL enforcement to localStorage services cache so stale data is discarded on load after fetch failures
- **#7126**: Fix Network dashboard endpoint stat to sum actual ready endpoints across services instead of counting service count
- **#7127**: Map LB-specific fields (`externalIP`, `lbStatus`, `selector`) in the kubectl fallback path so all three data sources (API, agent, kubectl) return a consistent Service shape

## Test plan
- [ ] Click a service row in ServiceStatus card and verify the drilldown modal shows service details (type, cluster IP, external IPs, ports, endpoints, selector)
- [ ] Click the LoadBalancer stat block in NetworkOverview and verify it opens a multi-cluster summary of all LB services
- [ ] Verify endpoint count on the Network dashboard reflects actual ready endpoints, not service count
- [ ] Verify `npm run build` passes
- [ ] Verify demo mode shows correct demo data including multi-IP LB services

Fixes #7121, #7122, #7123, #7124, #7125, #7126, #7127