### PR TITLE
fix: deploy validation, JSON extraction, multi-cluster context (#7180-#7201)

### DIFF
--- a/pkg/api/handlers/console_persistence.go
+++ b/pkg/api/handlers/console_persistence.go
@@ -1015,9 +1015,12 @@ func (h *ConsolePersistenceHandlers) reconcileDeployment(ctx context.Context, wd
 			cs.Message = "Deployment failed"
 			failedCount++
 		} else {
-			// Not in either list — mark as skipped
-			cs.Phase = "Skipped"
-			cs.Message = "Cluster was not processed"
+			// Not in either list — cluster was in targets but not reported by
+			// DeployWorkload in either deployedTo or failedClusters. Flag as
+			// NotProcessed (distinct from intentional skip) so operators can
+			// investigate why deployment logic missed this cluster (#7186).
+			cs.Phase = "NotProcessed"
+			cs.Message = "Cluster was targeted but not processed by deployer — possible deployment logic gap"
 		}
 	}
 
@@ -1116,6 +1119,16 @@ func (h *ConsolePersistenceHandlers) resolveTargetClusters(
 	// Add explicit target clusters
 	for _, c := range wd.Spec.TargetClusters {
 		clusterSet[c] = true
+	}
+
+	// #7180/#7199 — Warn when both targetClusters and targetGroupRef are
+	// specified. The two sources are merged silently which can lead to
+	// unexpected clusters being included in the deployment.
+	if len(wd.Spec.TargetClusters) > 0 && wd.Spec.TargetGroupRef != nil && wd.Spec.TargetGroupRef.Name != "" {
+		slog.Warn("[reconcile] WorkloadDeployment specifies both targetClusters and targetGroupRef — clusters will be merged",
+			"name", wd.Name, "namespace", wd.Namespace,
+			"explicitClusters", strings.Join(wd.Spec.TargetClusters, ","),
+			"groupRef", wd.Spec.TargetGroupRef.Name)
 	}
 
 	// Resolve from ClusterGroup if referenced

--- a/web/src/components/mission-control/MissionControlDialog.tsx
+++ b/web/src/components/mission-control/MissionControlDialog.tsx
@@ -504,6 +504,15 @@ export function MissionControlDialog({ open, onClose }: MissionControlDialogProp
                         size="sm"
                         data-testid="mission-control-launch"
                         onClick={() => {
+                          // #7190 — Block launch when no clusters have project assignments.
+                          // This can happen when the user excludes all clusters in Phase 2.
+                          const hasAssignedClusters = state.assignments.some(
+                            (a) => (a.projectNames ?? []).length > 0
+                          )
+                          if (!hasAssignedClusters) {
+                            showToast('No clusters have project assignments. Go back to Chart Course to assign projects before launching.', 'warning')
+                            return
+                          }
                           mc.setDryRun(false)
                           mc.setPhase('launching')
                         }}
@@ -516,6 +525,14 @@ export function MissionControlDialog({ open, onClose }: MissionControlDialogProp
                         variant="secondary"
                         size="sm"
                         onClick={() => {
+                          // #7190 — Same validation as Deploy button above
+                          const hasAssignedClusters = state.assignments.some(
+                            (a) => (a.projectNames ?? []).length > 0
+                          )
+                          if (!hasAssignedClusters) {
+                            showToast('No clusters have project assignments. Go back to Chart Course to assign projects before launching.', 'warning')
+                            return
+                          }
                           mc.setDryRun(true)
                           mc.setPhase('launching')
                         }}

--- a/web/src/hooks/useMissions.tsx
+++ b/web/src/hooks/useMissions.tsx
@@ -2061,7 +2061,13 @@ The WebSocket connection to the agent at \`${LOCAL_AGENT_WS_URL}\` was lost and 
       if (clusterList.length === 1) {
         enhancedPrompt = `Target cluster: ${clusterList[0]}\nIMPORTANT: All kubectl commands MUST use --context=${clusterList[0]}\n\n${enhancedPrompt}`
       } else {
-        enhancedPrompt = `Target clusters: ${clusterList.join(', ')}\nIMPORTANT: Perform the following on each cluster using their respective kubectl contexts.\n\n${enhancedPrompt}`
+        // #7188/#7198 — Inject explicit per-cluster context instructions so
+        // the agent uses the correct kubectl context for each cluster instead
+        // of defaulting to the first one.
+        const perClusterInstructions = clusterList
+          .map((c, i) => `  ${i + 1}. Cluster "${c}": use --context=${c}`)
+          .join('\n')
+        enhancedPrompt = `Target clusters: ${clusterList.join(', ')}\nIMPORTANT: Perform the following on EACH cluster using its respective kubectl context:\n${perClusterInstructions}\n\n${enhancedPrompt}`
       }
     }
 

--- a/web/src/lib/ai/__tests__/extractJson.test.ts
+++ b/web/src/lib/ai/__tests__/extractJson.test.ts
@@ -85,4 +85,31 @@ describe('extractJsonFromMarkdown', () => {
     const result = extractJsonFromMarkdown(text)
     expect(result.data).toEqual({ new: true })
   })
+
+  // #7189 — Bracket citations like [1] should not be treated as JSON
+  it('does not treat prose citation [1] as JSON', () => {
+    const text = 'According to source [1], the answer is {"result":"success"}'
+    const result = extractJsonFromMarkdown(text)
+    expect(result.data).toEqual({ result: 'success' })
+  })
+
+  it('does not treat numbered list references like [2, 3] as JSON', () => {
+    const text = 'See references [2, 3] for details. Here is the config: {"port":8080}'
+    const result = extractJsonFromMarkdown(text)
+    expect(result.data).toEqual({ port: 8080 })
+  })
+
+  it('returns error when only bare citation arrays exist', () => {
+    const text = 'According to [1] and [2], no JSON here.'
+    const result = extractJsonFromMarkdown(text)
+    expect(result.data).toBeNull()
+    expect(result.error).toBeTruthy()
+  })
+
+  // #7191 — Prefer last JSON object when multiple appear in prose
+  it('prefers last JSON object in mixed prose', () => {
+    const text = 'Old config: {"version":1} — Updated config: {"version":2}'
+    const result = extractJsonFromMarkdown(text)
+    expect(result.data).toEqual({ version: 2 })
+  })
 })

--- a/web/src/lib/ai/extractJson.ts
+++ b/web/src/lib/ai/extractJson.ts
@@ -104,7 +104,14 @@ export function extractJsonFromMarkdown<T = unknown>(text: string): ExtractResul
   }
 
   // Strategy 3: Find ALL JSON objects/arrays in the text via brace depth
-  // matching — try each candidate until one parses successfully
+  // matching. Collect all parseable candidates and prefer the LAST valid
+  // object/array — AI models often provide a corrected or updated JSON
+  // block later in the response (#7191). Additionally, skip bare arrays
+  // that look like prose citations (e.g. `[1]`, `[2, 3]`) to avoid
+  // treating numbered references as JSON data (#7189).
+  let lastObject: T | null = null
+  let lastArray: T | null = null
+
   for (let pos = 0; pos < text.length; pos++) {
     const ch = text[pos]
     if (ch !== '{' && ch !== '[') continue
@@ -113,12 +120,28 @@ export function extractJsonFromMarkdown<T = unknown>(text: string): ExtractResul
     if (candidate) {
       const parsed = tryParse<T>(candidate)
       if (parsed !== null) {
-        return { data: parsed, error: null }
+        if (ch === '{') {
+          lastObject = parsed
+        } else {
+          // #7189 — Skip bare arrays of only primitive numbers/strings that
+          // are likely prose citations like [1], [2, 3], or [a]. Only accept
+          // arrays that contain objects or are reasonably complex.
+          const arr = parsed as unknown[]
+          const isBarePrimitive = Array.isArray(arr) && arr.length > 0 &&
+            arr.every(item => typeof item === 'number' || typeof item === 'string')
+          if (!isBarePrimitive) {
+            lastArray = parsed
+          }
+        }
       }
       // Skip past this candidate and keep searching
       pos += candidate.length - 1
     }
   }
+
+  // Prefer objects over arrays (objects are more likely to be structured data)
+  if (lastObject !== null) return { data: lastObject, error: null }
+  if (lastArray !== null) return { data: lastArray, error: null }
 
   return { data: null, error: 'Could not extract valid JSON from AI response.' }
 }


### PR DESCRIPTION
## Summary
- **#7189/#7191**: `extractJson` now skips prose citations like `[1]` and prefers the last valid JSON fragment (not the first), fixing stale-data and false-parse bugs
- **#7186**: Ambiguous "Skipped" cluster status changed to "NotProcessed" with descriptive message
- **#7180/#7199**: Warning logged when both `targetClusters` and `targetGroupRef` are specified (silent merge)
- **#7190**: Deploy/Dry Run buttons now blocked when no clusters have assignments
- **#7188/#7198**: Multi-cluster prompts inject explicit `--context=` per cluster

## Closed as already fixed
#7184 (sidebar overlap — icons are positioned outside sidebar), #7185 (retry already scoped to failed), #7187/#7200 (localStorage reconciliation exists), #7193 (no string booleans found)

## Closed as feature requests
#7192, #7194, #7195, #7196, #7197, #7201

## Test plan
- [x] `go build ./...` and `go vet ./...` pass
- [x] `npm run build` passes
- [x] 18/18 extractJson tests pass (4 new)

Fixes #7180, #7186, #7188, #7189, #7190, #7191, #7198, #7199