### PR TITLE
fix: security validation and multi-cluster preflight (#7171-#7179)

### DIFF
--- a/pkg/agent/prometheus.go
+++ b/pkg/agent/prometheus.go
@@ -80,6 +80,17 @@ func (s *Server) handlePrometheusQuery(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// SECURITY: Validate cluster and namespace against safe character sets to
+	// prevent SSRF and path-traversal via crafted query parameters (#7175).
+	if err := validateKubeContext(cluster); err != nil {
+		writePrometheusError(w, http.StatusBadRequest, fmt.Sprintf("invalid cluster parameter: %v", err))
+		return
+	}
+	if err := validateDNS1123Label("namespace", namespace); err != nil {
+		writePrometheusError(w, http.StatusBadRequest, fmt.Sprintf("invalid namespace parameter: %v", err))
+		return
+	}
+
 	// SECURITY: Length-limit the PromQL query to prevent arbitrarily expensive
 	// queries from consuming excessive Prometheus resources (#4721).
 	if len(query) > maxPromQLQueryLength {
@@ -94,6 +105,11 @@ func (s *Server) handlePrometheusQuery(w http.ResponseWriter, r *http.Request) {
 	serviceName := r.URL.Query().Get("service")
 	if serviceName == "" {
 		serviceName = prometheusServiceName
+	}
+	// SECURITY: Validate service name to prevent path traversal (#7175).
+	if err := validateDNS1123Label("service", serviceName); err != nil {
+		writePrometheusError(w, http.StatusBadRequest, fmt.Sprintf("invalid service parameter: %v", err))
+		return
 	}
 
 	config, err := s.k8sClient.GetRestConfig(cluster)

--- a/pkg/agent/server_ai.go
+++ b/pkg/agent/server_ai.go
@@ -561,7 +561,10 @@ func (s *Server) handleChatMessageStreaming(conn *websocket.Conn, msg protocol.M
 		// frontend's stream-inactivity timer from firing during long-running
 		// tool calls (e.g., `drasi init` which deploys Kubernetes components
 		// and can take several minutes with no output).
-		heartbeatDone := make(chan struct{})
+		// Use a buffered channel so close() never races with a pending
+		// send, preventing "send on closed channel" panics (#7179).
+		heartbeatDone := make(chan struct{}, 1)
+		var heartbeatOnce sync.Once
 		go func() {
 			ticker := time.NewTicker(missionHeartbeatInterval)
 			defer ticker.Stop()
@@ -584,7 +587,8 @@ func (s *Server) handleChatMessageStreaming(conn *websocket.Conn, msg protocol.M
 		}()
 		// Defer close so the heartbeat goroutine is always stopped,
 		// even if StreamChatWithProgress panics (#7001).
-		defer close(heartbeatDone)
+		// sync.Once ensures close is called exactly once (#7179).
+		defer heartbeatOnce.Do(func() { close(heartbeatDone) })
 
 		resp, err = streamingProvider.StreamChatWithProgress(ctx, chatReq, onChunk, onProgress)
 		if err != nil {

--- a/pkg/agent/server_operations.go
+++ b/pkg/agent/server_operations.go
@@ -1223,6 +1223,13 @@ func (s *Server) handleLocalClusters(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 
+		// SECURITY: Validate cluster name against DNS-1123 to prevent command
+		// injection via crafted names that flow into exec.Command args (#7171).
+		if err := validateDNS1123Label("cluster name", req.Name); err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+
 		// Create cluster in background and return immediately
 		go func() {
 			defer func() {
@@ -1277,6 +1284,12 @@ func (s *Server) handleLocalClusters(w http.ResponseWriter, r *http.Request) {
 		name := r.URL.Query().Get("name")
 		if tool == "" || name == "" {
 			http.Error(w, "tool and name query parameters are required", http.StatusBadRequest)
+			return
+		}
+
+		// SECURITY: Validate cluster name against DNS-1123 (#7171).
+		if err := validateDNS1123Label("cluster name", name); err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
 			return
 		}
 
@@ -1364,6 +1377,11 @@ func (s *Server) handleLocalClusterLifecycle(w http.ResponseWriter, r *http.Requ
 	}
 	if req.Tool == "" || req.Name == "" || req.Action == "" {
 		http.Error(w, "tool, name, and action are required", http.StatusBadRequest)
+		return
+	}
+	// SECURITY: Validate cluster name against DNS-1123 (#7171).
+	if err := validateDNS1123Label("cluster name", req.Name); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}
 	if req.Action != "start" && req.Action != "stop" && req.Action != "restart" {
@@ -1481,6 +1499,16 @@ func (s *Server) handleVClusterCreate(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// SECURITY: Validate name and namespace against DNS-1123 (#7171).
+	if err := validateDNS1123Label("vcluster name", req.Name); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	if err := validateDNS1123Label("namespace", req.Namespace); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
 	// Create vCluster in background and return immediately
 	go func() {
 		defer func() {
@@ -1549,6 +1577,15 @@ func (s *Server) handleVClusterConnect(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "name and namespace are required", http.StatusBadRequest)
 		return
 	}
+	// SECURITY: Validate name and namespace against DNS-1123 (#7171).
+	if err := validateDNS1123Label("vcluster name", req.Name); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	if err := validateDNS1123Label("namespace", req.Namespace); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
 
 	if err := s.localClusters.ConnectVCluster(req.Name, req.Namespace); err != nil {
 		slog.Error("[vCluster] failed to connect to vcluster", "name", req.Name, "error", err)
@@ -1597,6 +1634,15 @@ func (s *Server) handleVClusterDisconnect(w http.ResponseWriter, r *http.Request
 		http.Error(w, "name and namespace are required", http.StatusBadRequest)
 		return
 	}
+	// SECURITY: Validate name and namespace against DNS-1123 (#7171).
+	if err := validateDNS1123Label("vcluster name", req.Name); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	if err := validateDNS1123Label("namespace", req.Namespace); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
 
 	if err := s.localClusters.DisconnectVCluster(req.Name, req.Namespace); err != nil {
 		slog.Error("[vCluster] failed to disconnect from vcluster", "name", req.Name, "error", err)
@@ -1643,6 +1689,15 @@ func (s *Server) handleVClusterDelete(w http.ResponseWriter, r *http.Request) {
 	}
 	if req.Name == "" || req.Namespace == "" {
 		http.Error(w, "name and namespace are required", http.StatusBadRequest)
+		return
+	}
+	// SECURITY: Validate name and namespace against DNS-1123 (#7171).
+	if err := validateDNS1123Label("vcluster name", req.Name); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	if err := validateDNS1123Label("namespace", req.Namespace); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}
 

--- a/pkg/agent/validation.go
+++ b/pkg/agent/validation.go
@@ -1,0 +1,65 @@
+package agent
+
+import (
+	"fmt"
+	"regexp"
+)
+
+// dns1123LabelRegex matches valid Kubernetes DNS-1123 label names:
+// lowercase alphanumeric, may contain hyphens, 1-63 characters,
+// must start and end with an alphanumeric character.
+var dns1123LabelRegex = regexp.MustCompile(`^[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$`)
+
+// validateDNS1123Label checks that name conforms to Kubernetes DNS-1123 label
+// rules. Returns nil if valid, or an error describing the violation.
+// This MUST be called on all user-supplied cluster names, namespace names,
+// and similar identifiers before they are used in exec.Command arguments,
+// URL path construction, or kubeconfig context lookups (#7171, #7175).
+func validateDNS1123Label(field, value string) error {
+	if value == "" {
+		return fmt.Errorf("%s must not be empty", field)
+	}
+	if !dns1123LabelRegex.MatchString(value) {
+		return fmt.Errorf("%s %q is not a valid DNS-1123 label (must match %s)", field, value, dns1123LabelRegex.String())
+	}
+	return nil
+}
+
+// dns1123SubdomainRegex matches valid Kubernetes DNS-1123 subdomain names:
+// one or more DNS-1123 labels separated by dots, total max 253 characters.
+// This is used for cluster context names which may contain dots.
+var dns1123SubdomainRegex = regexp.MustCompile(`^[a-z0-9]([a-z0-9.-]{0,251}[a-z0-9])?$`)
+
+// validateKubeContext checks that a kubeconfig context name is safe for use
+// in command arguments and URL paths. Context names follow DNS-1123 subdomain
+// rules but may also contain colons, slashes, and underscores (common in
+// kubeconfig contexts like "arn:aws:..." or "gke_project_zone_cluster").
+// We reject path-traversal sequences and control characters.
+var unsafeContextChars = regexp.MustCompile(`[^a-zA-Z0-9._:/@-]`)
+
+func validateKubeContext(value string) error {
+	if value == "" {
+		return fmt.Errorf("context must not be empty")
+	}
+	if len(value) > 253 {
+		return fmt.Errorf("context name exceeds 253 characters")
+	}
+	if unsafeContextChars.MatchString(value) {
+		return fmt.Errorf("context %q contains invalid characters", value)
+	}
+	// Reject path traversal
+	if containsPathTraversal(value) {
+		return fmt.Errorf("context %q contains path traversal sequence", value)
+	}
+	return nil
+}
+
+// containsPathTraversal returns true if s contains ".." path traversal.
+func containsPathTraversal(s string) bool {
+	for i := 0; i < len(s)-1; i++ {
+		if s[i] == '.' && s[i+1] == '.' {
+			return true
+		}
+	}
+	return false
+}

--- a/web/src/hooks/useMissions.tsx
+++ b/web/src/hooks/useMissions.tsx
@@ -8,7 +8,7 @@ import { detectIssueSignature, findSimilarResolutionsStandalone, generateResolut
 import { LOCAL_AGENT_WS_URL, LOCAL_AGENT_HTTP_URL } from '../lib/constants'
 import { emitMissionStarted, emitMissionCompleted, emitMissionError, emitMissionRated } from '../lib/analytics'
 import { scanForMaliciousContent } from '../lib/missions/scanner/malicious'
-import { runPreflightCheck, type PreflightError } from '../lib/missions/preflightCheck'
+import { runPreflightCheck, type PreflightError, type PreflightResult } from '../lib/missions/preflightCheck'
 import { kubectlProxy } from '../lib/kubectlProxy'
 import { ConfirmMissionPromptDialog } from '../components/missions/ConfirmMissionPromptDialog'
 
@@ -2169,12 +2169,20 @@ The WebSocket connection to the agent at \`${LOCAL_AGENT_WS_URL}\` was lost and 
     params: { cluster?: string; context?: Record<string, unknown>; type?: string },
   ) => {
     const missionNeedsCluster = !!params.cluster || ['deploy', 'repair', 'upgrade'].includes(params.type || '')
-    const preflightPromise = missionNeedsCluster
-      ? runPreflightCheck(
-          (args, opts) => kubectlProxy.exec(args, opts),
-          params.cluster?.split(',')[0]?.trim(),
-        )
-      : Promise.resolve({ ok: true } as { ok: true })
+    // Run preflight on ALL target clusters, not just the first one (#7177).
+    const clusterContexts = params.cluster?.split(',').map(c => c.trim()).filter(Boolean) || []
+    const preflightPromise = missionNeedsCluster && clusterContexts.length > 0
+      ? Promise.all(
+          clusterContexts.map(ctx =>
+            runPreflightCheck((args, opts) => kubectlProxy.exec(args, opts), ctx)
+          )
+        ).then(results => {
+          const failed = results.find(r => !r.ok)
+          return failed || { ok: true as const }
+        })
+      : missionNeedsCluster
+        ? runPreflightCheck((args, opts) => kubectlProxy.exec(args, opts))
+        : Promise.resolve({ ok: true } as PreflightResult)
 
     preflightPromise.then(preflight => {
       if (!preflight.ok && 'error' in preflight && preflight.error) {


### PR DESCRIPTION
## Summary

- **Security (#7171, #7175)**: Add DNS-1123 input validation for all user-supplied cluster names, namespace names, and service names before they flow into `exec.Command` arguments or URL path construction. Prevents command injection in local cluster handlers and SSRF/path-traversal in the Prometheus proxy. Kubeconfig context names use a broader safe-character regex that accommodates cloud provider formats (ARN, GKE) while rejecting `..` traversal.
- **Panic (#7179)**: Guard `heartbeatDone` channel close with `sync.Once` and use a buffered channel to prevent "send on closed channel" panic when a streaming handler returns before the heartbeat goroutine observes `ctx.Done()`.
- **Preflight (#7177)**: Run preflight permission checks on **all** target clusters in multi-cluster missions instead of only the first one (`split(',')[0]`). If any cluster fails, the mission is blocked with the first failure's error.

Issues #7163, #7165, #7167, #7168, #7169, #7170, #7172, #7173, #7174 were triaged and verified. Several were already closed or already fixed in current code; the remainder are enhancement requests (retry logic, per-cluster status UI, readiness blocking) that require larger design work.

## Test plan

- [ ] `go build ./...` and `go vet ./...` pass
- [ ] `npm run build` passes
- [ ] Verify DNS-1123 validation rejects names with shell metacharacters, `..` sequences, and URL-encoded traversal
- [ ] Verify multi-cluster preflight runs checks on all clusters, not just the first
- [ ] Verify streaming chat with early cancellation does not panic

Fixes #7171, #7175, #7177, #7179

🤖 Generated with [Claude Code](https://claude.com/claude-code)