### PR TITLE
fix: resolve 4 dashboard sync issues (#7252-#7255)

### DIFF
--- a/web/src/components/dashboard/DashboardCards.tsx
+++ b/web/src/components/dashboard/DashboardCards.tsx
@@ -83,11 +83,13 @@ export function DashboardCards({
   }
 
   const handleApplyTemplate = (template: DashboardTemplate) => {
+    // Preserve per-card position (w/h) from the template definition (#7253)
     const newCards: DashboardCard[] = template.cards.map((card, idx) => ({
       id: `${card.card_type}-${Date.now()}-${idx}`,
       card_type: card.card_type,
       config: card.config || {},
       title: card.title,
+      position: card.position,
     }))
     onReplaceCards(newCards)
     templatesModal.close()

--- a/web/src/lib/dashboards/dashboardHooks.ts
+++ b/web/src/lib/dashboards/dashboardHooks.ts
@@ -154,12 +154,12 @@ export function useDashboardCards(
 
   const [isSyncing, setIsSyncing] = useState(false)
 
-  // Compute isCustomized by comparing current card types to defaults
+  // Compute isCustomized by comparing current card types AND order to defaults (#7255).
+  // Previous implementation sorted types before comparing, so pure reorder was invisible.
   const isCustomized = (() => {
     if (cards.length !== defaultCardInstances.length) return true
-    const currentTypes = cards.map(c => c.card_type).sort()
-    const defaultTypes = defaultCardInstances.map(c => c.card_type).sort()
-    return currentTypes.some((t, i) => t !== defaultTypes[i])
+    // Compare in order — reordering is a customization
+    return cards.some((c, i) => c.card_type !== defaultCardInstances[i].card_type)
   })()
 
   // On mount, sync with backend if authenticated
@@ -173,7 +173,9 @@ export function useDashboardCards(
       setIsSyncing(true)
       try {
         const backendCards = await dashboardSync.fullSync(storageKey)
-        if (backendCards && backendCards.length > 0) {
+        // null means fetch failed — leave local state alone.
+        // An array (even empty) means backend responded — accept it (#7254).
+        if (backendCards !== null) {
           setCards(backendCards)
         }
       } catch (err) {
@@ -300,7 +302,9 @@ export function useDashboardCards(
     setIsSyncing(true)
     try {
       const backendCards = await dashboardSync.fullSync(storageKey)
-      if (backendCards && backendCards.length > 0) {
+      // null means fetch failed — leave local state alone.
+      // An array (even empty) means backend responded — accept it (#7254).
+      if (backendCards !== null) {
         setCards(backendCards)
       }
     } catch (err) {

--- a/web/src/lib/dashboards/dashboardSync.ts
+++ b/web/src/lib/dashboards/dashboardSync.ts
@@ -183,10 +183,11 @@ class DashboardSyncService {
         const existingCard = currentCardMap.get(card.id)
 
         if (existingCard) {
-          // Update existing card
+          // Update existing card — include config so backend stays in sync (#7252)
           try {
             await api.put(`/api/cards/${card.id}`, {
               card_type: card.card_type,
+              config: card.config || {},
               position: card.position ? { ...card.position, x: 0, y: 0 } : { w: 4, h: 2, x: 0, y: 0 },
             })
           } catch {
@@ -221,12 +222,15 @@ class DashboardSyncService {
    */
   async fullSync(storageKey: string): Promise<DashboardCard[] | null> {
     const cards = await this.fetchCards(storageKey)
-    if (cards && cards.length > 0) {
-      // Update localStorage with backend data
-      localStorage.setItem(storageKey, JSON.stringify(cards))
-      return cards
+    if (cards === null) {
+      // Fetch failed (network error, not authenticated, etc.) — leave local state alone
+      return null
     }
-    return null
+    // Update localStorage with backend data, even when empty (#7254).
+    // An empty array means the backend dashboard has zero cards — clear local cache
+    // so stale cards do not reappear.
+    localStorage.setItem(storageKey, JSON.stringify(cards))
+    return cards
   }
 
   /**


### PR DESCRIPTION
## Summary

- **#7252**: Card config updates not synced for existing backend cards — added `config` to the PUT payload in `syncCardsToBackend`
- **#7253**: Template card layout sizes dropped on apply — preserved `position` field when mapping template cards
- **#7254**: Full sync cannot clear local layout when backend has zero cards — changed `fullSync` to write empty arrays to localStorage and callers to accept them
- **#7255**: Reordering cards does not count as customization — removed `.sort()` from the type comparison so order matters

Closes #7252, closes #7253, closes #7254, closes #7255

## Test plan

- [ ] Change a card's config, reload — verify backend has the updated config
- [ ] Apply a template with mixed w/h sizes — verify layout sizes are preserved
- [ ] Delete all cards on backend, trigger sync — verify local cache clears
- [ ] Reorder cards via drag-and-drop — verify "customized" indicator appears