### PR TITLE
fix: agent security, auto-update, config races (#7236-#7249)

### DIFF
--- a/pkg/agent/config.go
+++ b/pkg/agent/config.go
@@ -96,11 +96,15 @@ func (cm *ConfigManager) Load() error {
 	return nil
 }
 
-// Save writes the config to disk with secure permissions
+// Save writes the config to disk with secure permissions.
 func (cm *ConfigManager) Save() error {
 	cm.mu.Lock()
 	defer cm.mu.Unlock()
+	return cm.saveLocked()
+}
 
+// saveLocked writes config to disk. Caller MUST hold cm.mu.
+func (cm *ConfigManager) saveLocked() error {
 	// Ensure directory exists with secure permissions
 	configDir := filepath.Dir(cm.configPath)
 	if err := os.MkdirAll(configDir, configDirMode); err != nil {
@@ -160,41 +164,33 @@ func (cm *ConfigManager) GetModel(provider, defaultModel string) string {
 	return defaultModel
 }
 
-// SetAPIKey stores an API key for a provider
+// SetAPIKey stores an API key for a provider. The lock is held across
+// both the map mutation and the disk write to prevent lost updates (#7245).
 func (cm *ConfigManager) SetAPIKey(provider, apiKey string) error {
-	func() {
-		cm.mu.Lock()
-		defer cm.mu.Unlock()
-		agentConfig := cm.config.Agents[provider]
-		agentConfig.APIKey = apiKey
-		cm.config.Agents[provider] = agentConfig
-	}()
-
-	return cm.Save()
+	cm.mu.Lock()
+	defer cm.mu.Unlock()
+	agentConfig := cm.config.Agents[provider]
+	agentConfig.APIKey = apiKey
+	cm.config.Agents[provider] = agentConfig
+	return cm.saveLocked()
 }
 
-// SetModel stores a model preference for a provider
+// SetModel stores a model preference for a provider.
 func (cm *ConfigManager) SetModel(provider, model string) error {
-	func() {
-		cm.mu.Lock()
-		defer cm.mu.Unlock()
-		agentConfig := cm.config.Agents[provider]
-		agentConfig.Model = model
-		cm.config.Agents[provider] = agentConfig
-	}()
-
-	return cm.Save()
+	cm.mu.Lock()
+	defer cm.mu.Unlock()
+	agentConfig := cm.config.Agents[provider]
+	agentConfig.Model = model
+	cm.config.Agents[provider] = agentConfig
+	return cm.saveLocked()
 }
 
-// RemoveAPIKey removes the API key for a provider
+// RemoveAPIKey removes the API key for a provider.
 func (cm *ConfigManager) RemoveAPIKey(provider string) error {
-	func() {
-		cm.mu.Lock()
-		defer cm.mu.Unlock()
-		delete(cm.config.Agents, provider)
-	}()
-
-	return cm.Save()
+	cm.mu.Lock()
+	defer cm.mu.Unlock()
+	delete(cm.config.Agents, provider)
+	return cm.saveLocked()
 }
 
 // HasAPIKey checks if a provider has an API key configured (env or config)
@@ -252,19 +248,19 @@ func (cm *ConfigManager) GetDefaultAgent() string {
 	return cm.config.DefaultAgent
 }
 
-// SetDefaultAgent sets the default agent
+// SetDefaultAgent sets the default agent.
 func (cm *ConfigManager) SetDefaultAgent(agent string) error {
-	func() {
-		cm.mu.Lock()
-		defer cm.mu.Unlock()
-		cm.config.DefaultAgent = agent
-	}()
-
-	return cm.Save()
+	cm.mu.Lock()
+	defer cm.mu.Unlock()
+	cm.config.DefaultAgent = agent
+	return cm.saveLocked()
 }
 
-// GetConfigPath returns the path to the config file
+// GetConfigPath returns the path to the config file.
+// Reads under lock to avoid a data race with SetConfigPath (#7246).
 func (cm *ConfigManager) GetConfigPath() string {
+	cm.mu.RLock()
+	defer cm.mu.RUnlock()
 	return cm.configPath
 }
 

--- a/pkg/agent/kagenti.go
+++ b/pkg/agent/kagenti.go
@@ -134,6 +134,7 @@ func (s *Server) handleKagentiAgents(w http.ResponseWriter, r *http.Request) {
 	cluster := r.URL.Query().Get("cluster")
 	namespace := r.URL.Query().Get("namespace")
 	if cluster == "" {
+		w.WriteHeader(http.StatusBadRequest)
 		json.NewEncoder(w).Encode(map[string]any{"agents": []any{}, "error": "cluster parameter required"})
 		return
 	}
@@ -144,6 +145,7 @@ func (s *Server) handleKagentiAgents(w http.ResponseWriter, r *http.Request) {
 	dynClient, err := s.k8sClient.GetDynamicClient(cluster)
 	if err != nil {
 		slog.Info("error fetching agents", "error", err)
+		w.WriteHeader(http.StatusInternalServerError)
 		json.NewEncoder(w).Encode(map[string]any{"agents": []any{}, "error": "internal server error"})
 		return
 	}
@@ -216,6 +218,7 @@ func (s *Server) handleKagentiBuilds(w http.ResponseWriter, r *http.Request) {
 	cluster := r.URL.Query().Get("cluster")
 	namespace := r.URL.Query().Get("namespace")
 	if cluster == "" {
+		w.WriteHeader(http.StatusBadRequest)
 		json.NewEncoder(w).Encode(map[string]any{"builds": []any{}, "error": "cluster parameter required"})
 		return
 	}
@@ -226,6 +229,7 @@ func (s *Server) handleKagentiBuilds(w http.ResponseWriter, r *http.Request) {
 	dynClient, err := s.k8sClient.GetDynamicClient(cluster)
 	if err != nil {
 		slog.Info("error fetching builds", "error", err)
+		w.WriteHeader(http.StatusInternalServerError)
 		json.NewEncoder(w).Encode(map[string]any{"builds": []any{}, "error": "internal server error"})
 		return
 	}
@@ -293,6 +297,7 @@ func (s *Server) handleKagentiCards(w http.ResponseWriter, r *http.Request) {
 	cluster := r.URL.Query().Get("cluster")
 	namespace := r.URL.Query().Get("namespace")
 	if cluster == "" {
+		w.WriteHeader(http.StatusBadRequest)
 		json.NewEncoder(w).Encode(map[string]any{"cards": []any{}, "error": "cluster parameter required"})
 		return
 	}
@@ -303,6 +308,7 @@ func (s *Server) handleKagentiCards(w http.ResponseWriter, r *http.Request) {
 	dynClient, err := s.k8sClient.GetDynamicClient(cluster)
 	if err != nil {
 		slog.Info("error fetching cards", "error", err)
+		w.WriteHeader(http.StatusInternalServerError)
 		json.NewEncoder(w).Encode(map[string]any{"cards": []any{}, "error": "internal server error"})
 		return
 	}
@@ -368,6 +374,7 @@ func (s *Server) handleKagentiTools(w http.ResponseWriter, r *http.Request) {
 	cluster := r.URL.Query().Get("cluster")
 	namespace := r.URL.Query().Get("namespace")
 	if cluster == "" {
+		w.WriteHeader(http.StatusBadRequest)
 		json.NewEncoder(w).Encode(map[string]any{"tools": []any{}, "error": "cluster parameter required"})
 		return
 	}
@@ -378,6 +385,7 @@ func (s *Server) handleKagentiTools(w http.ResponseWriter, r *http.Request) {
 	dynClient, err := s.k8sClient.GetDynamicClient(cluster)
 	if err != nil {
 		slog.Info("error fetching tools", "error", err)
+		w.WriteHeader(http.StatusInternalServerError)
 		json.NewEncoder(w).Encode(map[string]any{"tools": []any{}, "error": "internal server error"})
 		return
 	}
@@ -440,6 +448,7 @@ func (s *Server) handleKagentiSummary(w http.ResponseWriter, r *http.Request) {
 
 	cluster := r.URL.Query().Get("cluster")
 	if cluster == "" {
+		w.WriteHeader(http.StatusBadRequest)
 		json.NewEncoder(w).Encode(map[string]any{"error": "cluster parameter required"})
 		return
 	}
@@ -450,6 +459,7 @@ func (s *Server) handleKagentiSummary(w http.ResponseWriter, r *http.Request) {
 	dynClient, err := s.k8sClient.GetDynamicClient(cluster)
 	if err != nil {
 		slog.Info("error fetching kagenti summary", "error", err)
+		w.WriteHeader(http.StatusInternalServerError)
 		json.NewEncoder(w).Encode(map[string]any{
 			"agentCount": 0, "readyAgents": 0, "buildCount": 0,
 			"activeBuilds": 0, "toolCount": 0, "cardCount": 0,

--- a/pkg/agent/local_clusters.go
+++ b/pkg/agent/local_clusters.go
@@ -307,8 +307,30 @@ func (m *LocalClusterManager) listMinikubeClusters() []LocalCluster {
 	return clusters
 }
 
+// dns1123LabelRegexp matches valid DNS-1123 labels (RFC 1123 section 2.1).
+// Max 63 chars, lowercase alphanumeric, may contain hyphens but not at
+// start or end.
+var dns1123LabelRegexp = regexp.MustCompile(`^[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$`)
+
+// validateClusterName ensures the name is a valid DNS-1123 label before
+// any exec call runs, preventing orphaned Docker containers from partial
+// creates and flag-injection edge cases (#7249).
+func validateClusterName(name string) error {
+	if name == "" {
+		return fmt.Errorf("cluster name must not be empty")
+	}
+	if !dns1123LabelRegexp.MatchString(name) {
+		return fmt.Errorf("cluster name %q is not a valid DNS-1123 label (lowercase alphanumeric and hyphens, 1-63 chars, no leading/trailing hyphens)", name)
+	}
+	return nil
+}
+
 // CreateCluster creates a new local cluster with phased progress broadcasting
 func (m *LocalClusterManager) CreateCluster(tool, name string) error {
+	if err := validateClusterName(name); err != nil {
+		return err
+	}
+
 	// Phase 1: Validating prerequisites
 	m.broadcastProgress(tool, name, "validating", "Checking prerequisites...", progressValidating)
 
@@ -366,6 +388,9 @@ func (m *LocalClusterManager) createMinikubeCluster(name string) error {
 
 // StartCluster starts a stopped local cluster with phased progress broadcasting
 func (m *LocalClusterManager) StartCluster(tool, name string) error {
+	if err := validateClusterName(name); err != nil {
+		return err
+	}
 	m.broadcastProgress(tool, name, "validating", fmt.Sprintf("Preparing to start cluster '%s'...", name), progressValidating)
 
 	m.broadcastProgress(tool, name, "starting", fmt.Sprintf("Starting %s cluster '%s'...", tool, name), progressCreating)
@@ -428,6 +453,9 @@ func (m *LocalClusterManager) startMinikubeCluster(name string) error {
 
 // StopCluster stops a running local cluster with phased progress broadcasting
 func (m *LocalClusterManager) StopCluster(tool, name string) error {
+	if err := validateClusterName(name); err != nil {
+		return err
+	}
 	m.broadcastProgress(tool, name, "validating", fmt.Sprintf("Preparing to stop cluster '%s'...", name), progressValidating)
 
 	m.broadcastProgress(tool, name, "stopping", fmt.Sprintf("Stopping %s cluster '%s'...", tool, name), progressCreating)
@@ -490,6 +518,9 @@ func (m *LocalClusterManager) stopMinikubeCluster(name string) error {
 
 // DeleteCluster deletes a local cluster with phased progress broadcasting
 func (m *LocalClusterManager) DeleteCluster(tool, name string) error {
+	if err := validateClusterName(name); err != nil {
+		return err
+	}
 	// Phase 1: Validating
 	m.broadcastProgress(tool, name, "validating", fmt.Sprintf("Preparing to delete cluster '%s'...", name), progressValidating)
 

--- a/pkg/agent/metrics_history.go
+++ b/pkg/agent/metrics_history.go
@@ -70,6 +70,7 @@ type MetricsHistory struct {
 	mu                 sync.RWMutex
 	diskMu             sync.Mutex // serializes saveToDisk calls (#7017)
 	stopCh             chan struct{}
+	stopOnce           sync.Once  // prevents double-close panic on stopCh (#7244)
 	dataDir            string
 	loggedClusterError atomic.Bool // suppress repeated "no kubeconfig" errors (#7015)
 	lastPersistError   error       // last saveToDisk error, nil on success (#5553)
@@ -108,9 +109,12 @@ func (mh *MetricsHistory) Start(interval time.Duration) {
 	go mh.runLoop(interval)
 }
 
-// Stop gracefully shuts down the history manager
+// Stop gracefully shuts down the history manager. It is safe to call
+// multiple times — the channel is only closed once (#7244).
 func (mh *MetricsHistory) Stop() {
-	close(mh.stopCh)
+	mh.stopOnce.Do(func() {
+		close(mh.stopCh)
+	})
 }
 
 // GetSnapshots returns all snapshots

--- a/pkg/agent/prometheus.go
+++ b/pkg/agent/prometheus.go
@@ -1,6 +1,8 @@
 package agent
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -162,7 +164,10 @@ func (s *Server) handlePrometheusQuery(w http.ResponseWriter, r *http.Request) {
 // keyed by the API server Host URL. Clients are created once and reused to
 // avoid per-query TLS handshakes and connection leaks (#7024).
 func getOrCreatePromClient(config *rest.Config) (*http.Client, error) {
-	key := config.Host
+	// Key on a hash of identity-bearing fields so two kubeconfigs pointing
+	// at the same Host but carrying different credentials get distinct
+	// cached clients (#7248).
+	key := promCacheKey(config)
 
 	promClientCache.RLock()
 	if promClientCache.clients != nil {
@@ -195,4 +200,21 @@ func getOrCreatePromClient(config *rest.Config) (*http.Client, error) {
 	}
 	promClientCache.clients[key] = client
 	return client, nil
+}
+
+// promCacheKey builds a stable cache key from identity-bearing fields of a
+// rest.Config. Using only Host would collide when two kubeconfigs point at
+// the same API server with different credentials (#7248).
+func promCacheKey(config *rest.Config) string {
+	h := sha256.New()
+	h.Write([]byte(config.Host))
+	h.Write([]byte{0}) // separator
+	h.Write([]byte(config.BearerToken))
+	h.Write([]byte{0})
+	h.Write(config.TLSClientConfig.CertData)
+	h.Write([]byte{0})
+	h.Write(config.TLSClientConfig.CAData)
+	h.Write([]byte{0})
+	h.Write([]byte(config.Impersonate.UserName))
+	return config.Host + "/" + hex.EncodeToString(h.Sum(nil))[:16]
 }

--- a/pkg/agent/server_operations.go
+++ b/pkg/agent/server_operations.go
@@ -826,7 +826,7 @@ func (s *Server) handlePredictionsFeedback(w http.ResponseWriter, r *http.Reques
 	}
 
 	var req PredictionFeedbackRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+	if err := json.NewDecoder(io.LimitReader(r.Body, maxRequestBodyBytes)).Decode(&req); err != nil {
 		http.Error(w, "Invalid request body", http.StatusBadRequest)
 		return
 	}
@@ -983,7 +983,7 @@ func (s *Server) handleDeviceAlertsClear(w http.ResponseWriter, r *http.Request)
 	var req struct {
 		AlertID string `json:"alertId"`
 	}
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+	if err := json.NewDecoder(io.LimitReader(r.Body, maxRequestBodyBytes)).Decode(&req); err != nil {
 		http.Error(w, "Invalid request body", http.StatusBadRequest)
 		return
 	}
@@ -1092,9 +1092,17 @@ func (s *Server) sendNativeNotification(alerts []DeviceAlert) {
 			}
 		}
 
-		// Fallback: osascript (no click-to-open support on macOS)
+		// Fallback: osascript (no click-to-open support on macOS).
+		// Sanitize inputs to prevent AppleScript injection via crafted
+		// Kubernetes labels (#7238). Backslash and double-quote are the
+		// only characters that can escape an AppleScript string literal.
+		sanitize := func(s string) string {
+			s = strings.ReplaceAll(s, `\`, `\\`)
+			s = strings.ReplaceAll(s, `"`, `\"`)
+			return s
+		}
 		script := fmt.Sprintf(`display notification "%s" with title "%s" sound name "Glass"`,
-			message, title)
+			sanitize(message), sanitize(title))
 		cmd := exec.Command("osascript", "-e", script)
 		if err := cmd.Run(); err != nil {
 			slog.Error("[DeviceTracker] failed to send notification", "error", err)

--- a/pkg/agent/update_checker.go
+++ b/pkg/agent/update_checker.go
@@ -864,8 +864,8 @@ func (uc *UpdateChecker) executeBinaryUpdate(release *githubReleaseInfo) {
 		return
 	}
 
-	// Download to temp file
-	tmpFile := fmt.Sprintf("/tmp/kc-update-%s.tar.gz", release.TagName)
+	// Download to temp file — use os.TempDir() for cross-platform support (#7239).
+	tmpFile := filepath.Join(os.TempDir(), fmt.Sprintf("kc-update-%s.tar.gz", release.TagName))
 	if err := downloadFile(assetURL, tmpFile); err != nil {
 		uc.recordError(fmt.Sprintf("download failed: %v", err))
 		uc.broadcast("update_progress", UpdateProgressPayload{
@@ -882,12 +882,35 @@ func (uc *UpdateChecker) executeBinaryUpdate(release *githubReleaseInfo) {
 		Progress: 50,
 	})
 
-	// Extract to staging directory
-	stagingDir := "/tmp/kc-update-staging"
-	os.RemoveAll(stagingDir)
-	os.MkdirAll(stagingDir, 0755)
+	// Extract to staging directory — use os.TempDir() for cross-platform support (#7239).
+	stagingDir := filepath.Join(os.TempDir(), "kc-update-staging")
+	if err := os.RemoveAll(stagingDir); err != nil {
+		uc.recordError(fmt.Sprintf("failed to clean staging dir: %v", err))
+		uc.broadcast("update_progress", UpdateProgressPayload{
+			Status:  "failed",
+			Message: "Failed to prepare staging directory",
+			Error:   err.Error(),
+		})
+		return
+	}
+	// stagingDirMode is the permission bits for the update staging directory.
+	const stagingDirMode = 0755
+	if err := os.MkdirAll(stagingDir, stagingDirMode); err != nil {
+		uc.recordError(fmt.Sprintf("failed to create staging dir: %v", err))
+		uc.broadcast("update_progress", UpdateProgressPayload{
+			Status:  "failed",
+			Message: "Failed to prepare staging directory",
+			Error:   err.Error(),
+		})
+		return
+	}
 
-	extractCmd := exec.Command("tar", "xzf", tmpFile, "-C", stagingDir)
+	// extractTimeout bounds the tar extraction to prevent hanging on corrupt
+	// archives or stalled I/O (#7241).
+	const extractTimeout = 5 * time.Minute
+	extractCtx, extractCancel := context.WithTimeout(context.Background(), extractTimeout)
+	defer extractCancel()
+	extractCmd := exec.CommandContext(extractCtx, "tar", "xzf", tmpFile, "-C", stagingDir)
 	if err := extractCmd.Run(); err != nil {
 		uc.recordError(fmt.Sprintf("extract failed: %v", err))
 		uc.broadcast("update_progress", UpdateProgressPayload{
@@ -916,8 +939,10 @@ func (uc *UpdateChecker) executeBinaryUpdate(release *githubReleaseInfo) {
 		return
 	}
 
-	// Replace with new binary
-	if err := os.Rename(stagingDir+"/console", consolePath); err != nil {
+	// Replace with new binary. os.Rename fails with EXDEV when staging
+	// and target are on different filesystems (#7242), so fall back to
+	// copy+sync when rename returns a *os.LinkError.
+	if err := renameOrCopy(filepath.Join(stagingDir, "console"), consolePath); err != nil {
 		// Attempt to restore the backup before returning
 		if rbErr := os.Rename(consolePath+".backup", consolePath); rbErr != nil {
 			slog.Error("[AutoUpdate] backup restore failed after rename error", "error", rbErr)
@@ -1281,6 +1306,53 @@ func fetchGitHubReleases() ([]githubReleaseInfo, error) {
 	return releases, nil
 }
 
+// renameOrCopy attempts os.Rename first. When that fails with EXDEV
+// (cross-device link — common when /tmp is tmpfs), it falls back to a
+// copy-then-remove strategy so auto-update works regardless of filesystem
+// layout (#7242).
+func renameOrCopy(src, dst string) error {
+	err := os.Rename(src, dst)
+	if err == nil {
+		return nil
+	}
+	// If not a cross-device error, return immediately.
+	if !strings.Contains(err.Error(), "cross-device") &&
+		!strings.Contains(err.Error(), "invalid cross-device link") {
+		return err
+	}
+
+	slog.Info("[AutoUpdate] rename failed with EXDEV, falling back to copy", "src", src, "dst", dst)
+
+	in, openErr := os.Open(src)
+	if openErr != nil {
+		return fmt.Errorf("copy fallback: open source: %w", openErr)
+	}
+	defer in.Close()
+
+	// copyBinaryMode is the permission bits for the copied binary during update.
+	const copyBinaryMode = 0755
+	out, createErr := os.OpenFile(dst, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, copyBinaryMode)
+	if createErr != nil {
+		return fmt.Errorf("copy fallback: create dest: %w", createErr)
+	}
+
+	if _, cpErr := io.Copy(out, in); cpErr != nil {
+		out.Close()
+		return fmt.Errorf("copy fallback: copy data: %w", cpErr)
+	}
+	if syncErr := out.Sync(); syncErr != nil {
+		out.Close()
+		return fmt.Errorf("copy fallback: sync: %w", syncErr)
+	}
+	if closeErr := out.Close(); closeErr != nil {
+		return fmt.Errorf("copy fallback: close: %w", closeErr)
+	}
+
+	// Best-effort cleanup of the source file.
+	os.Remove(src)
+	return nil
+}
+
 func hasUncommittedChanges(repoPath string) bool {
 	if repoPath == "" {
 		return false
@@ -1292,16 +1364,6 @@ func hasUncommittedChanges(repoPath string) bool {
 		return true // assume dirty on error
 	}
 	return len(strings.TrimSpace(string(out))) > 0
-}
-
-func runGitPull(repoPath string) error {
-	// Use --ff-only instead of --rebase to avoid "Cannot rebase onto multiple branches"
-	// error when git worktrees exist (common with Claude Code users).
-	cmd := exec.Command("git", "pull", "--ff-only", "origin", "main")
-	cmd.Dir = repoPath
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
-	return cmd.Run()
 }
 
 // runGitPullWithTimeout runs git pull with a hard timeout to prevent hanging on network issues.


### PR DESCRIPTION
## Summary

Fixes 14 issues (#7236-#7249) across the Go agent backend:

**Security (commit 1):**
- **DoS via unbounded body** (#7236, #7237): Added `io.LimitReader` to `handlePredictionsFeedback` and `handleDeviceAlertsClear`
- **AppleScript injection** (#7238): Sanitize `"` and `\` in osascript string interpolation to prevent code execution via crafted K8s labels
- **HTTP status on errors** (#7247): All 10 error paths in `kagenti.go` now set 400/500 status codes instead of returning 200
- **Prometheus cache collision** (#7248): Cache key now includes credential hash, preventing cross-tenant credential leaks
- **Cluster name validation** (#7249): RFC 1123 regex validation on Create/Start/Stop/Delete before any exec call

**Auto-update robustness (commit 2):**
- **Windows paths** (#7239): Replaced hardcoded `/tmp` with `os.TempDir()`
- **Staging dir errors** (#7240): Check errors from `os.RemoveAll`/`os.MkdirAll`
- **Extract timeout** (#7241): 5-minute `context.WithTimeout` on tar extraction
- **Cross-device rename** (#7242): `renameOrCopy` fallback when `os.Rename` returns EXDEV
- **Dead code** (#7243): Removed unused `runGitPull` function

**Concurrency (commit 3):**
- **Config race** (#7245): `SetAPIKey`/`SetModel`/`RemoveAPIKey`/`SetDefaultAgent` now hold lock across mutation + `saveLocked()`
- **GetConfigPath race** (#7246): Added `RLock` to match `SetConfigPath`'s write lock
- **MetricsHistory panic** (#7244): `sync.Once` guard on `Stop()` to prevent double-close panic

## Test plan
- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [ ] CI build/lint

Closes #7236, closes #7237, closes #7238, closes #7239, closes #7240, closes #7241, closes #7242, closes #7243, closes #7244, closes #7245, closes #7246, closes #7247, closes #7248, closes #7249