### PR TITLE
fix: batch security, timeout, and UX fixes (#7192-#7235)

### DIFF
--- a/pkg/agent/insight_worker.go
+++ b/pkg/agent/insight_worker.go
@@ -287,6 +287,17 @@ func parseEnrichmentResponse(response string, insights []InsightSummary) ([]AIIn
 		return nil, fmt.Errorf("JSON parse error: %w", err)
 	}
 
+	// If the JSON parsed but the expected "enrichments" key was absent, treat
+	// it as an error so the caller can fall back to rule-based enrichments (#7208).
+	if parsed.Enrichments == nil {
+		const previewLen = 200
+		preview := jsonStr
+		if len(preview) > previewLen {
+			preview = preview[:previewLen] + "..."
+		}
+		return nil, fmt.Errorf("response JSON lacks 'enrichments' key (preview: %s)", preview)
+	}
+
 	return parsed.Enrichments, nil
 }
 

--- a/pkg/agent/kubectl.go
+++ b/pkg/agent/kubectl.go
@@ -92,9 +92,22 @@ func (k *KubectlProxy) Execute(context, namespace string, args []string) protoco
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
 
+	// kubectlCommandTimeout prevents a hung kubectl call from blocking
+	// the handler indefinitely (e.g. unreachable apiserver) (#7206).
+	const kubectlCommandTimeout = 30 * time.Second
+	timer := time.AfterFunc(kubectlCommandTimeout, func() {
+		if cmd.Process != nil {
+			cmd.Process.Kill()
+		}
+	})
+
 	err := cmd.Run()
+	timedOut := !timer.Stop()
 	exitCode := 0
 	if err != nil {
+		if timedOut {
+			return protocol.KubectlResponse{ExitCode: 1, Error: fmt.Sprintf("kubectl timed out after %s", kubectlCommandTimeout)}
+		}
 		if exitErr, ok := err.(*exec.ExitError); ok {
 			exitCode = exitErr.ExitCode()
 		} else {
@@ -174,6 +187,18 @@ var allowedScaleResources = map[string]bool{
 	"sts":          true,
 }
 
+// allowedRolloutSubcommands restricts rollout to read-only operations (#7205).
+var allowedRolloutSubcommands = map[string]bool{
+	"status":  true,
+	"history": true,
+}
+
+// allowedAuthSubcommands restricts auth to read-only operations (#7204).
+var allowedAuthSubcommands = map[string]bool{
+	"can-i":  true,
+	"whoami": true,
+}
+
 // blockedConfigSubcommands are config subcommands that modify kubeconfig
 var blockedConfigSubcommands = map[string]bool{
 	"set":             true,
@@ -198,6 +223,28 @@ func (k *KubectlProxy) validateArgs(args []string) bool {
 	allowed, exists := AllowedKubectlCommands[command]
 	if !exists || !allowed {
 		return false
+	}
+
+	// Special case: rollout command - only allow read-only subcommands (#7205)
+	if command == "rollout" {
+		if len(args) < 2 {
+			return false // Need at least "rollout <subcommand>"
+		}
+		subcommand := strings.ToLower(args[1])
+		if !allowedRolloutSubcommands[subcommand] {
+			return false
+		}
+	}
+
+	// Special case: auth command - only allow read-only subcommands (#7204)
+	if command == "auth" {
+		if len(args) < 2 {
+			return false // Need at least "auth <subcommand>"
+		}
+		subcommand := strings.ToLower(args[1])
+		if !allowedAuthSubcommands[subcommand] {
+			return false
+		}
 	}
 
 	// Special case: config command - block mutation subcommands

--- a/pkg/agent/registry.go
+++ b/pkg/agent/registry.go
@@ -151,8 +151,30 @@ func (r *Registry) SetSelectedAgent(sessionID, agentName string) error {
 		return fmt.Errorf("provider %s is not available", agentName)
 	}
 
+	// Evict oldest entries when map exceeds a safety cap to prevent unbounded
+	// growth from sessions that never call RemoveSelectedAgent (#7209).
+	const maxSelectedAgentEntries = 10000
+	if len(r.selectedAgent) >= maxSelectedAgentEntries {
+		// Delete an arbitrary entry (map iteration order is random in Go).
+		for k := range r.selectedAgent {
+			delete(r.selectedAgent, k)
+			break
+		}
+	}
+
 	r.selectedAgent[sessionID] = agentName
 	return nil
+}
+
+// RemoveSelectedAgent cleans up the session entry from the selectedAgent map,
+// preventing unbounded growth when sessions disconnect (#7209).
+func (r *Registry) RemoveSelectedAgent(sessionID string) {
+	if r == nil || sessionID == "" {
+		return
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	delete(r.selectedAgent, sessionID)
 }
 
 // List returns all registered providers

--- a/pkg/agent/server_operations.go
+++ b/pkg/agent/server_operations.go
@@ -325,7 +325,7 @@ func (s *Server) handleGetKeysStatus(w http.ResponseWriter, r *http.Request) {
 // handleSetKey saves a new API key
 func (s *Server) handleSetKey(w http.ResponseWriter, r *http.Request) {
 	var req SetKeyRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+	if err := json.NewDecoder(io.LimitReader(r.Body, maxRequestBodyBytes)).Decode(&req); err != nil {
 		w.WriteHeader(http.StatusBadRequest)
 		json.NewEncoder(w).Encode(protocol.ErrorPayload{Code: "invalid_json", Message: "Invalid JSON body"})
 		return
@@ -766,7 +766,7 @@ func (s *Server) handlePredictionsAnalyze(w http.ResponseWriter, r *http.Request
 	// SECURITY: reject malformed JSON instead of silently using zero-value (#4156).
 	var req AIAnalysisRequest
 	if r.Body != nil {
-		if err := json.NewDecoder(r.Body).Decode(&req); err != nil && err != io.EOF {
+		if err := json.NewDecoder(io.LimitReader(r.Body, maxRequestBodyBytes)).Decode(&req); err != nil && err != io.EOF {
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusBadRequest)
 			json.NewEncoder(w).Encode(map[string]string{"error": "invalid JSON body"})
@@ -903,6 +903,12 @@ func (s *Server) handleMetricsHistory(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// SECURITY: require auth before returning sensitive metrics (#7223).
+	if !s.validateToken(r) {
+		http.Error(w, "Unauthorized", http.StatusUnauthorized)
+		return
+	}
+
 	if s.metricsHistory == nil {
 		json.NewEncoder(w).Encode(MetricsHistoryResponse{
 			Snapshots: []MetricsSnapshot{},
@@ -1019,6 +1025,12 @@ func (s *Server) handleDeviceInventory(w http.ResponseWriter, r *http.Request) {
 
 	if r.Method != "GET" {
 		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	// SECURITY: require auth before returning device inventory (#7228).
+	if !s.validateToken(r) {
+		http.Error(w, "Unauthorized", http.StatusUnauthorized)
 		return
 	}
 
@@ -1766,6 +1778,12 @@ func (s *Server) handleInsightsEnrich(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// SECURITY: require auth before triggering AI enrichment (#7231).
+	if !s.validateToken(r) {
+		http.Error(w, "Unauthorized", http.StatusUnauthorized)
+		return
+	}
+
 	if s.insightWorker == nil {
 		json.NewEncoder(w).Encode(InsightEnrichmentResponse{
 			Enrichments: []AIInsightEnrichment{},
@@ -1812,6 +1830,12 @@ func (s *Server) handleInsightsAI(w http.ResponseWriter, r *http.Request) {
 
 	if r.Method != "GET" {
 		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	// SECURITY: require auth before returning cached AI enrichments (#7233).
+	if !s.validateToken(r) {
+		http.Error(w, "Unauthorized", http.StatusUnauthorized)
 		return
 	}
 

--- a/pkg/agent/update_checker.go
+++ b/pkg/agent/update_checker.go
@@ -1383,13 +1383,18 @@ func runGitPullWithTimeout(repoPath string, timeout time.Duration) error {
 	return nil
 }
 
+// gitStashTimeout is the hard deadline for git stash operations.
+const gitStashTimeout = 60 * time.Second
+
 // gitStash stashes uncommitted changes if any exist. Returns true if a stash was created.
 func gitStash(repoPath string) bool {
 	if !hasUncommittedChanges(repoPath) {
 		return false
 	}
 	slog.Info("[AutoUpdate] Stashing uncommitted changes before update")
-	cmd := exec.Command("git", "stash", "push", "-m", "auto-update: stashed by kc-agent")
+	ctx, cancel := context.WithTimeout(context.Background(), gitStashTimeout)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, "git", "stash", "push", "-m", "auto-update: stashed by kc-agent")
 	cmd.Dir = repoPath
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
@@ -1403,7 +1408,9 @@ func gitStash(repoPath string) bool {
 // gitStashPop restores previously stashed changes.
 func gitStashPop(repoPath string) {
 	slog.Info("[AutoUpdate] Restoring stashed changes")
-	cmd := exec.Command("git", "stash", "pop")
+	ctx, cancel := context.WithTimeout(context.Background(), gitStashTimeout)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, "git", "stash", "pop")
 	cmd.Dir = repoPath
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
@@ -1487,10 +1494,14 @@ func rebuildGoBinaries(repoPath string) error {
 }
 
 func rollbackGit(repoPath, sha string) {
-	if sha == "" {
+	if sha == "" || repoPath == "" {
 		return
 	}
-	cmd := exec.Command("git", "reset", "--hard", sha)
+	// gitRollbackTimeout is the hard deadline for a rollback git-reset.
+	const gitRollbackTimeout = 30 * time.Second
+	ctx, cancel := context.WithTimeout(context.Background(), gitRollbackTimeout)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, "git", "reset", "--hard", sha)
 	cmd.Dir = repoPath
 	if err := cmd.Run(); err != nil {
 		slog.Error("[AutoUpdate] rollback failed", "sha", short(sha), "error", err)

--- a/web/src/hooks/mcp/workloads.ts
+++ b/web/src/hooks/mcp/workloads.ts
@@ -233,7 +233,8 @@ function savePodsCacheToStorage() {
 // ---------------------------------------------------------------------------
 
 export function usePods(cluster?: string, namespace?: string, sortBy: 'restarts' | 'name' = 'restarts', limit = 10) {
-  const cacheKey = `pods:${cluster || 'all'}:${namespace || 'all'}`
+  // Include sortBy and limit in cache key to prevent cross-view stale data (#7218)
+  const cacheKey = `pods:${cluster || 'all'}:${namespace || 'all'}:${sortBy}:${limit}`
 
   // Initialize from cache if available
   const getCachedData = () => {

--- a/web/src/hooks/useSearchIndex.ts
+++ b/web/src/hooks/useSearchIndex.ts
@@ -370,7 +370,9 @@ function matchesQuery(item: SearchItem, query: string): boolean {
 export function useSearchIndex(query: string) {
   const { clusters } = useClusters()
   const { deployments } = useDeployments()
-  const { pods } = usePods(undefined, undefined, 'name', 50)
+  // Search should index all available pods, not just a small subset (#7217).
+  const SEARCH_POD_LIMIT = 500
+  const { pods } = usePods(undefined, undefined, 'name', SEARCH_POD_LIMIT)
   const { services } = useServices()
   const { nodes } = useNodes()
   const { releases } = useHelmReleases()

--- a/web/src/lib/orbit/orbitTemplates.ts
+++ b/web/src/lib/orbit/orbitTemplates.ts
@@ -128,8 +128,10 @@ export const ORBIT_TEMPLATES: OrbitTemplate[] = [
  * or match any of the provided categories.
  */
 export function getApplicableOrbitTemplates(categories: string[]): OrbitTemplate[] {
-  return ORBIT_TEMPLATES.filter(template =>
-    template.applicableCategories.includes('*') ||
-    (categories || []).some(cat => template.applicableCategories.includes(cat))
-  )
+  return ORBIT_TEMPLATES.filter(template => {
+    if (template.applicableCategories.includes('*')) return true
+    // Case-insensitive category matching (#7232)
+    const lowerApplicable = template.applicableCategories.map(c => c.toLowerCase())
+    return (categories || []).some(cat => lowerApplicable.includes(cat.toLowerCase()))
+  })
 }

--- a/web/src/lib/orbit/projectCardMapping.ts
+++ b/web/src/lib/orbit/projectCardMapping.ts
@@ -117,7 +117,7 @@ export function getMonitoringCardsForProject(
   cncfProject?: string,
   category?: string,
 ): ProjectCardMappingResult {
-  const projectKey = cncfProject?.toLowerCase().replace(/\s+/g, '-')
+  const projectKey = cncfProject?.trim().toLowerCase().replace(/\s+/g, '-')
   const directCards = projectKey ? PROJECT_TO_CARDS[projectKey] : undefined
 
   if (directCards) {
@@ -125,7 +125,12 @@ export function getMonitoringCardsForProject(
     return { cards: merged, hasDirectMapping: true }
   }
 
-  const categoryCards = category ? CATEGORY_TO_CARDS[category] : undefined
+  // Case-insensitive category lookup (#7230): find the canonical key that
+  // matches the input regardless of casing.
+  const categoryKey = category
+    ? Object.keys(CATEGORY_TO_CARDS).find(k => k.toLowerCase() === category.toLowerCase())
+    : undefined
+  const categoryCards = categoryKey ? CATEGORY_TO_CARDS[categoryKey] : undefined
   if (categoryCards) {
     const merged = [...new Set([...BASELINE_CARDS, ...categoryCards])]
     return { cards: merged, hasDirectMapping: false }


### PR DESCRIPTION
## Summary

Fixes 17 issues from the #7192-#7235 range:

**Security (6):** Added `validateToken` to 4 unprotected handlers (#7223, #7228, #7231, #7233). Added `io.LimitReader` to 2 handlers missing body size limits (#7234, #7235). Gated kubectl `auth` and `rollout` to read-only subcommands (#7204, #7205).

**Reliability (4):** Added 30s timeout to `KubectlProxy.Execute` (#7206). Added 60s timeout to `gitStash`/`gitStashPop` (#7210). Guarded `rollbackGit` against empty `repoPath` + added timeout (#7211). Made `parseEnrichmentResponse` return an error when the `enrichments` key is missing (#7208).

**Memory (1):** Added eviction cap + `RemoveSelectedAgent` cleanup method to `Registry.selectedAgent` map (#7209).

**Frontend (5):** Case-insensitive orbit template (#7232) and card fallback (#7230) category matching. Whitespace trim on project names (#7229). Fixed usePods cache key to include sortBy/limit (#7218). Raised search pod limit from 50 to 500 (#7217).

## Test plan

- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] `npm run build` passes
- [x] Existing Go tests pass (kubectl, endpoint auth)

## Remaining issues in range (not fixed here)

Feature requests: #7198, #7199, #7202
Architecture-level changes: #7212-#7216, #7219-#7222, #7224-#7227
Test flake: #7203