### PR TITLE
fix: resolve issues #7393-#7402 (MCP shutdown, diagnosis lock, tests)

### DIFF
--- a/pkg/mcp/bridge.go
+++ b/pkg/mcp/bridge.go
@@ -308,14 +308,18 @@ func (b *Bridge) GetDeployTools() []Tool {
 
 // ListClusters returns all discovered clusters
 func (b *Bridge) ListClusters(ctx context.Context) ([]ClusterInfo, error) {
+	// #7393 — Snapshot the client reference under a short RLock so the
+	// potentially long-running RPC does not block Stop() from acquiring
+	// the write lock.
 	b.mu.RLock()
-	defer b.mu.RUnlock()
+	client := b.opsClient
+	b.mu.RUnlock()
 
-	if b.opsClient == nil {
+	if client == nil {
 		return nil, fmt.Errorf("ops client not available")
 	}
 
-	result, err := b.opsClient.CallTool(ctx, "list_clusters", map[string]interface{}{
+	result, err := client.CallTool(ctx, "list_clusters", map[string]interface{}{
 		"source": "all",
 	})
 	if err != nil {
@@ -328,9 +332,10 @@ func (b *Bridge) ListClusters(ctx context.Context) ([]ClusterInfo, error) {
 // GetClusterHealth returns health status for a cluster
 func (b *Bridge) GetClusterHealth(ctx context.Context, cluster string) (*ClusterHealth, error) {
 	b.mu.RLock()
-	defer b.mu.RUnlock()
+	client := b.opsClient
+	b.mu.RUnlock()
 
-	if b.opsClient == nil {
+	if client == nil {
 		return nil, fmt.Errorf("ops client not available")
 	}
 
@@ -339,7 +344,7 @@ func (b *Bridge) GetClusterHealth(ctx context.Context, cluster string) (*Cluster
 		args["cluster"] = cluster
 	}
 
-	result, err := b.opsClient.CallTool(ctx, "get_cluster_health", args)
+	result, err := client.CallTool(ctx, "get_cluster_health", args)
 	if err != nil {
 		return nil, err
 	}
@@ -350,9 +355,10 @@ func (b *Bridge) GetClusterHealth(ctx context.Context, cluster string) (*Cluster
 // GetPods returns pods for a namespace/cluster
 func (b *Bridge) GetPods(ctx context.Context, cluster, namespace, labelSelector string) ([]PodInfo, error) {
 	b.mu.RLock()
-	defer b.mu.RUnlock()
+	client := b.opsClient
+	b.mu.RUnlock()
 
-	if b.opsClient == nil {
+	if client == nil {
 		return nil, fmt.Errorf("ops client not available")
 	}
 
@@ -367,7 +373,7 @@ func (b *Bridge) GetPods(ctx context.Context, cluster, namespace, labelSelector 
 		args["label_selector"] = labelSelector
 	}
 
-	result, err := b.opsClient.CallTool(ctx, "get_pods", args)
+	result, err := client.CallTool(ctx, "get_pods", args)
 	if err != nil {
 		return nil, err
 	}
@@ -378,9 +384,10 @@ func (b *Bridge) GetPods(ctx context.Context, cluster, namespace, labelSelector 
 // FindPodIssues returns pods with issues
 func (b *Bridge) FindPodIssues(ctx context.Context, cluster, namespace string) ([]PodIssue, error) {
 	b.mu.RLock()
-	defer b.mu.RUnlock()
+	client := b.opsClient
+	b.mu.RUnlock()
 
-	if b.opsClient == nil {
+	if client == nil {
 		return nil, fmt.Errorf("ops client not available")
 	}
 
@@ -392,7 +399,7 @@ func (b *Bridge) FindPodIssues(ctx context.Context, cluster, namespace string) (
 		args["namespace"] = namespace
 	}
 
-	result, err := b.opsClient.CallTool(ctx, "find_pod_issues", args)
+	result, err := client.CallTool(ctx, "find_pod_issues", args)
 	if err != nil {
 		return nil, err
 	}
@@ -403,9 +410,10 @@ func (b *Bridge) FindPodIssues(ctx context.Context, cluster, namespace string) (
 // GetEvents returns events from a cluster
 func (b *Bridge) GetEvents(ctx context.Context, cluster, namespace string, limit int) ([]Event, error) {
 	b.mu.RLock()
-	defer b.mu.RUnlock()
+	client := b.opsClient
+	b.mu.RUnlock()
 
-	if b.opsClient == nil {
+	if client == nil {
 		return nil, fmt.Errorf("ops client not available")
 	}
 
@@ -420,7 +428,7 @@ func (b *Bridge) GetEvents(ctx context.Context, cluster, namespace string, limit
 		args["limit"] = limit
 	}
 
-	result, err := b.opsClient.CallTool(ctx, "get_events", args)
+	result, err := client.CallTool(ctx, "get_events", args)
 	if err != nil {
 		return nil, err
 	}
@@ -431,9 +439,10 @@ func (b *Bridge) GetEvents(ctx context.Context, cluster, namespace string, limit
 // GetWarningEvents returns warning events from a cluster
 func (b *Bridge) GetWarningEvents(ctx context.Context, cluster, namespace string, limit int) ([]Event, error) {
 	b.mu.RLock()
-	defer b.mu.RUnlock()
+	client := b.opsClient
+	b.mu.RUnlock()
 
-	if b.opsClient == nil {
+	if client == nil {
 		return nil, fmt.Errorf("ops client not available")
 	}
 
@@ -448,7 +457,7 @@ func (b *Bridge) GetWarningEvents(ctx context.Context, cluster, namespace string
 		args["limit"] = limit
 	}
 
-	result, err := b.opsClient.CallTool(ctx, "get_warning_events", args)
+	result, err := client.CallTool(ctx, "get_warning_events", args)
 	if err != nil {
 		return nil, err
 	}
@@ -459,13 +468,14 @@ func (b *Bridge) GetWarningEvents(ctx context.Context, cluster, namespace string
 // CallOpsTool calls any ops tool by name
 func (b *Bridge) CallOpsTool(ctx context.Context, name string, args map[string]interface{}) (*CallToolResult, error) {
 	b.mu.RLock()
-	defer b.mu.RUnlock()
+	client := b.opsClient
+	b.mu.RUnlock()
 
-	if b.opsClient == nil {
+	if client == nil {
 		return nil, fmt.Errorf("ops client not available")
 	}
 
-	return b.opsClient.CallTool(ctx, name, args)
+	return client.CallTool(ctx, name, args)
 }
 
 // GetGadgetTools returns the list of available gadget tools
@@ -482,25 +492,27 @@ func (b *Bridge) GetGadgetTools() []Tool {
 // CallGadgetTool calls any gadget tool by name
 func (b *Bridge) CallGadgetTool(ctx context.Context, name string, args map[string]interface{}) (*CallToolResult, error) {
 	b.mu.RLock()
-	defer b.mu.RUnlock()
+	client := b.gadgetClient
+	b.mu.RUnlock()
 
-	if b.gadgetClient == nil {
+	if client == nil {
 		return nil, fmt.Errorf("gadget client not available")
 	}
 
-	return b.gadgetClient.CallTool(ctx, name, args)
+	return client.CallTool(ctx, name, args)
 }
 
 // CallDeployTool calls any deploy tool by name
 func (b *Bridge) CallDeployTool(ctx context.Context, name string, args map[string]interface{}) (*CallToolResult, error) {
 	b.mu.RLock()
-	defer b.mu.RUnlock()
+	client := b.deployClient
+	b.mu.RUnlock()
 
-	if b.deployClient == nil {
+	if client == nil {
 		return nil, fmt.Errorf("deploy client not available")
 	}
 
-	return b.deployClient.CallTool(ctx, name, args)
+	return client.CallTool(ctx, name, args)
 }
 
 // Helper functions to parse tool results
@@ -514,12 +526,12 @@ func (b *Bridge) parseClustersResult(result *CallToolResult) ([]ClusterInfo, err
 	}
 
 	// Parse the text content as JSON
+	// #7399 — Surface unmarshal errors instead of silently returning empty slices
 	clusters := make([]ClusterInfo, 0)
 	for _, content := range result.Content {
 		if content.Type == "text" {
 			if err := json.Unmarshal([]byte(content.Text), &clusters); err != nil {
-				slog.Warn("[MCP] failed to parse clusters JSON — returning empty result", "error", err)
-				return b.parseClustersFromText(content.Text), nil
+				return nil, fmt.Errorf("failed to parse clusters response: %w", err)
 			}
 		}
 	}
@@ -562,12 +574,12 @@ func (b *Bridge) parsePodsResult(result *CallToolResult) ([]PodInfo, error) {
 		return nil, fmt.Errorf("tool error: %s", result.Content[0].Text)
 	}
 
+	// #7399 — Surface unmarshal errors instead of silently returning empty slices
 	pods := make([]PodInfo, 0)
 	for _, content := range result.Content {
 		if content.Type == "text" {
 			if err := json.Unmarshal([]byte(content.Text), &pods); err != nil {
-				slog.Warn("[MCP] failed to parse pods JSON — returning empty result", "error", err)
-				return []PodInfo{}, nil
+				return nil, fmt.Errorf("failed to parse pods response: %w", err)
 			}
 		}
 	}
@@ -582,12 +594,12 @@ func (b *Bridge) parsePodIssuesResult(result *CallToolResult) ([]PodIssue, error
 		return nil, fmt.Errorf("tool error: %s", result.Content[0].Text)
 	}
 
+	// #7399 — Surface unmarshal errors instead of silently returning empty slices
 	issues := make([]PodIssue, 0)
 	for _, content := range result.Content {
 		if content.Type == "text" {
 			if err := json.Unmarshal([]byte(content.Text), &issues); err != nil {
-				slog.Warn("[MCP] failed to parse pod issues JSON — returning empty result", "error", err)
-				return []PodIssue{}, nil
+				return nil, fmt.Errorf("failed to parse pod issues response: %w", err)
 			}
 		}
 	}
@@ -602,12 +614,12 @@ func (b *Bridge) parseEventsResult(result *CallToolResult) ([]Event, error) {
 		return nil, fmt.Errorf("tool error: %s", result.Content[0].Text)
 	}
 
+	// #7399 — Surface unmarshal errors instead of silently returning empty slices
 	events := make([]Event, 0)
 	for _, content := range result.Content {
 		if content.Type == "text" {
 			if err := json.Unmarshal([]byte(content.Text), &events); err != nil {
-				slog.Warn("[MCP] failed to parse events JSON — returning empty result", "error", err)
-				return []Event{}, nil
+				return nil, fmt.Errorf("failed to parse events response: %w", err)
 			}
 		}
 	}

--- a/pkg/mcp/client.go
+++ b/pkg/mcp/client.go
@@ -231,8 +231,30 @@ func (c *Client) Start(ctx context.Context) error {
 // example, once by Bridge.Start rollback and once by Bridge.Stop (#6623).
 func (c *Client) Stop() error {
 	c.stopOnce.Do(func() {
+		// #7397 — Reset readiness flag so health checks stop reporting the
+		// client as available after the process has been killed.
+		c.ready.Store(false)
+
 		// Signal readResponses goroutine to exit
 		close(c.done)
+
+		// #7398 — Actively fail all in-flight RPC calls so callers unblock
+		// immediately instead of waiting for context timeout.
+		c.mu.Lock()
+		for key, ch := range c.pending {
+			select {
+			case ch <- &Response{
+				JSONRPC: "2.0",
+				Error: &Error{
+					Code:    -32000,
+					Message: "client stopped",
+				},
+			}:
+			default:
+			}
+			delete(c.pending, key)
+		}
+		c.mu.Unlock()
 
 		// Close stdin pipe to send EOF to the server process
 		if c.stdin != nil {
@@ -396,6 +418,10 @@ func (c *Client) send(req Request) error {
 
 	// Use a dedicated write mutex so a blocked write cannot starve
 	// callers that only need c.mu for the pending map (#6944).
+	//
+	// #7395 — If the write blocks past the timeout, close stdin to
+	// unblock the goroutine so it releases writeMu instead of holding
+	// it forever. The goroutine always unlocks writeMu via defer.
 	type writeResult struct{ err error }
 	ch := make(chan writeResult, 1)
 
@@ -413,6 +439,11 @@ func (c *Client) send(req Request) error {
 		}
 		return nil
 	case <-time.After(stdinWriteTimeout):
+		// Close stdin to unblock the stuck Write goroutine — this causes
+		// Write to return with an error, releasing writeMu via defer.
+		if c.stdin != nil {
+			c.stdin.Close()
+		}
 		return fmt.Errorf("stdin write timed out after %s (child process may have stopped)", stdinWriteTimeout)
 	case <-c.done:
 		return fmt.Errorf("client stopped while writing to stdin")

--- a/web/src/contexts/AlertsContext.test.tsx
+++ b/web/src/contexts/AlertsContext.test.tsx
@@ -186,12 +186,14 @@ describe('initial state', () => {
 
 describe('stats calculation', () => {
   it('computes correct stats from mixed alert states', () => {
+    // #7396 — Each alert needs a unique ruleId (or unique cluster) so
+    // deduplicateAlerts does not collapse them into a single entry.
     const alerts = [
-      makeAlert({ id: 'f1', status: 'firing', severity: 'critical' }),
-      makeAlert({ id: 'f2', status: 'firing', severity: 'warning' }),
-      makeAlert({ id: 'f3', status: 'firing', severity: 'info' }),
-      makeAlert({ id: 'r1', status: 'resolved', severity: 'critical', resolvedAt: new Date().toISOString() }),
-      makeAlert({ id: 'a1', status: 'firing', severity: 'warning', acknowledgedAt: new Date().toISOString() }),
+      makeAlert({ id: 'f1', ruleId: 'r-f1', status: 'firing', severity: 'critical' }),
+      makeAlert({ id: 'f2', ruleId: 'r-f2', status: 'firing', severity: 'warning' }),
+      makeAlert({ id: 'f3', ruleId: 'r-f3', status: 'firing', severity: 'info' }),
+      makeAlert({ id: 'r1', ruleId: 'r-r1', status: 'resolved', severity: 'critical', resolvedAt: new Date().toISOString() }),
+      makeAlert({ id: 'a1', ruleId: 'r-a1', status: 'firing', severity: 'warning', acknowledgedAt: new Date().toISOString() }),
     ]
     localStorage.setItem('kc_alerts', JSON.stringify(alerts))
 

--- a/web/src/contexts/AlertsContext.tsx
+++ b/web/src/contexts/AlertsContext.tsx
@@ -991,12 +991,15 @@ export function AlertsProvider({ children }: { children: ReactNode }) {
       if (diagnosisInFlightRef.current.has(alertId)) return null
       diagnosisInFlightRef.current.add(alertId)
 
-      // Look up matching runbook for this alert condition type
-      const rule = rules.find(r => r.id === alert.ruleId)
-      const conditionType = rule?.condition.type
-      const runbook = conditionType ? findRunbookForCondition(conditionType) : undefined
+      // #7401 — Wrap entire async flow in try/finally so the in-flight
+      // flag is always cleared, even if an unexpected error occurs.
+      try {
+        // Look up matching runbook for this alert condition type
+        const rule = rules.find(r => r.id === alert.ruleId)
+        const conditionType = rule?.condition.type
+        const runbook = conditionType ? findRunbookForCondition(conditionType) : undefined
 
-      const basePrompt = `Please analyze this alert and provide diagnosis with suggestions:
+        const basePrompt = `Please analyze this alert and provide diagnosis with suggestions:
 
 Alert: ${alert.ruleName}
 Severity: ${alert.severity}
@@ -1005,67 +1008,67 @@ Cluster: ${alert.cluster || 'N/A'}
 Resource: ${alert.resource || 'N/A'}
 Details: ${JSON.stringify(alert.details, null, 2)}`
 
-      // #6915 — If a runbook matches, execute it first and include the
-      // gathered evidence directly in the AI prompt so the diagnosis is
-      // grounded in real cluster data, not just the alert metadata.
-      let runbookEvidence = ''
-      if (runbook) {
-        try {
-          const result = await executeRunbook(runbook, {
-            cluster: alert.cluster,
-            namespace: alert.namespace,
-            resource: alert.resource,
-            resourceKind: alert.resourceKind,
-            alertMessage: alert.message })
-          if (result.enrichedPrompt) {
-            runbookEvidence = `\n\n--- Runbook Evidence (${runbook.title}) ---\n${result.enrichedPrompt}`
-            console.debug(`Runbook "${runbook.title}" gathered ${result.stepResults.length} evidence steps`)
+        // #6915 — If a runbook matches, execute it first and include the
+        // gathered evidence directly in the AI prompt so the diagnosis is
+        // grounded in real cluster data, not just the alert metadata.
+        let runbookEvidence = ''
+        if (runbook) {
+          try {
+            const result = await executeRunbook(runbook, {
+              cluster: alert.cluster,
+              namespace: alert.namespace,
+              resource: alert.resource,
+              resourceKind: alert.resourceKind,
+              alertMessage: alert.message })
+            if (result.enrichedPrompt) {
+              runbookEvidence = `\n\n--- Runbook Evidence (${runbook.title}) ---\n${result.enrichedPrompt}`
+              console.debug(`Runbook "${runbook.title}" gathered ${result.stepResults.length} evidence steps`)
+            }
+          } catch {
+            // Silent failure - runbook is best-effort enhancement
           }
-        } catch {
-          // Silent failure - runbook is best-effort enhancement
         }
-      }
 
-      const initialPrompt = `${basePrompt}${runbookEvidence}
+        const initialPrompt = `${basePrompt}${runbookEvidence}
 
 Please provide:
 1. A summary of the issue
 2. The likely root cause
 3. Suggested actions to resolve this alert`
 
-      const missionId = startMission({
-        title: `Diagnose: ${alert.ruleName}`,
-        description: `Analyzing alert on ${alert.cluster || 'cluster'}`,
-        type: 'troubleshoot',
-        cluster: alert.cluster,
-        initialPrompt,
-        context: {
-          alertId,
-          alertType: alert.ruleName,
-          details: alert.details,
-          runbookId: runbook?.id } })
+        const missionId = startMission({
+          title: `Diagnose: ${alert.ruleName}`,
+          description: `Analyzing alert on ${alert.cluster || 'cluster'}`,
+          type: 'troubleshoot',
+          cluster: alert.cluster,
+          initialPrompt,
+          context: {
+            alertId,
+            alertType: alert.ruleName,
+            details: alert.details,
+            runbookId: runbook?.id } })
 
-      setAlerts(prev =>
-        prev.map(a =>
-          a.id === alertId
-            ? {
-                ...a,
-                aiDiagnosis: {
-                  summary: 'AI is analyzing this alert...',
-                  rootCause: '',
-                  suggestions: [],
-                  missionId,
-                  analyzedAt: new Date().toISOString() } }
-            : a
+        setAlerts(prev =>
+          prev.map(a =>
+            a.id === alertId
+              ? {
+                  ...a,
+                  aiDiagnosis: {
+                    summary: 'AI is analyzing this alert...',
+                    rootCause: '',
+                    suggestions: [],
+                    missionId,
+                    analyzedAt: new Date().toISOString() } }
+              : a
+          )
         )
-      )
 
-      // #7341 — Clear in-flight flag once the mission is set up.
-      // The diagnosis placeholder is now in the alert, so the UI will
-      // prevent re-triggering via the missionId check.
-      diagnosisInFlightRef.current.delete(alertId)
-
-      return missionId
+        return missionId
+      } finally {
+        // #7401 — Always clear in-flight flag so the alert is never
+        // permanently locked from future diagnosis attempts.
+        diagnosisInFlightRef.current.delete(alertId)
+      }
     }
 
   // #7337 — Reconcile AI diagnosis results back into alerts when the

--- a/web/src/contexts/__tests__/AlertsContext.test.tsx
+++ b/web/src/contexts/__tests__/AlertsContext.test.tsx
@@ -337,12 +337,14 @@ describe('AlertsContext', () => {
   // ── 7. Stats computation ─────────────────────────────────────────────
 
   it('computes correct alert statistics', () => {
+    // #7396 — Each alert needs a unique ruleId so deduplicateAlerts does
+    // not collapse them into a single entry.
     const alerts: Alert[] = [
-      { id: 's1', ruleId: 'r1', ruleName: 'A', severity: 'critical', status: 'firing', message: '', details: {}, firedAt: '2024-01-01T00:00:00Z' },
-      { id: 's2', ruleId: 'r1', ruleName: 'A', severity: 'warning', status: 'firing', message: '', details: {}, firedAt: '2024-01-01T00:00:00Z' },
-      { id: 's3', ruleId: 'r1', ruleName: 'A', severity: 'info', status: 'firing', message: '', details: {}, firedAt: '2024-01-01T00:00:00Z' },
-      { id: 's4', ruleId: 'r1', ruleName: 'A', severity: 'warning', status: 'resolved', message: '', details: {}, firedAt: '2024-01-01T00:00:00Z', resolvedAt: '2024-01-02T00:00:00Z' },
-      { id: 's5', ruleId: 'r1', ruleName: 'A', severity: 'critical', status: 'firing', message: '', details: {}, firedAt: '2024-01-01T00:00:00Z', acknowledgedAt: '2024-01-01T01:00:00Z' },
+      { id: 's1', ruleId: 'r-s1', ruleName: 'A', severity: 'critical', status: 'firing', message: '', details: {}, firedAt: '2024-01-01T00:00:00Z' },
+      { id: 's2', ruleId: 'r-s2', ruleName: 'A', severity: 'warning', status: 'firing', message: '', details: {}, firedAt: '2024-01-01T00:00:00Z' },
+      { id: 's3', ruleId: 'r-s3', ruleName: 'A', severity: 'info', status: 'firing', message: '', details: {}, firedAt: '2024-01-01T00:00:00Z' },
+      { id: 's4', ruleId: 'r-s4', ruleName: 'A', severity: 'warning', status: 'resolved', message: '', details: {}, firedAt: '2024-01-01T00:00:00Z', resolvedAt: '2024-01-02T00:00:00Z' },
+      { id: 's5', ruleId: 'r-s5', ruleName: 'A', severity: 'critical', status: 'firing', message: '', details: {}, firedAt: '2024-01-01T00:00:00Z', acknowledgedAt: '2024-01-01T01:00:00Z' },
     ]
     localStorage.setItem('kc_alerts', JSON.stringify(alerts))
 

--- a/web/src/hooks/mcp/__tests__/compute.test.ts
+++ b/web/src/hooks/mcp/__tests__/compute.test.ts
@@ -208,14 +208,16 @@ describe('useNodes', () => {
     expect(result.current.error).toBeNull()
   })
 
-  it('falls back to cluster-cache placeholder node data when available', async () => {
+  it('returns empty nodes on SSE failure even when cluster cache has data (#7351)', async () => {
+    // #7396 — After #7351, SSE failure returns empty state instead of
+    // fabricating placeholder nodes from cluster cache.
     mockFetchSSE.mockRejectedValue(new Error('SSE failed'))
     mockClusterCacheRef.clusters = [{ name: 'test-cluster', nodeCount: 3, cpuCores: 12, memoryGB: 48 }]
 
     const { result } = renderHook(() => useNodes('test-cluster'))
 
     await waitFor(() => expect(result.current.isLoading).toBe(false))
-    expect(result.current.nodes.length).toBeGreaterThan(0)
+    expect(result.current.nodes).toEqual([])
     expect(result.current.error).toBeNull()
   })
 
@@ -915,7 +917,9 @@ describe('useNodes — empty cluster handling', () => {
     expect(result.current.error).toBeNull()
   })
 
-  it('builds placeholder from cluster cache with cpuCores and memoryGB', async () => {
+  it('returns empty on SSE failure — no placeholder fabrication (#7351)', async () => {
+    // #7396 — After #7351, placeholder node fabrication was removed.
+    // SSE failure returns empty state regardless of cluster cache.
     mockFetchSSE.mockRejectedValue(new Error('SSE failed'))
     mockClusterCacheRef.clusters = [
       { name: 'cached-cluster', nodeCount: 5, cpuCores: 32, memoryGB: 128 },
@@ -924,10 +928,8 @@ describe('useNodes — empty cluster handling', () => {
     const { result } = renderHook(() => useNodes('cached-cluster'))
 
     await waitFor(() => expect(result.current.isLoading).toBe(false))
-    expect(result.current.nodes.length).toBe(1)
-    expect(result.current.nodes[0].cpuCapacity).toBe('32')
-    expect(result.current.nodes[0].memoryCapacity).toBe('128Gi')
-    expect(result.current.nodes[0].status).toBe('Ready')
+    expect(result.current.nodes).toEqual([])
+    expect(result.current.error).toBeNull()
   })
 
   it('returns empty when cluster cache has nodeCount=0', async () => {

--- a/web/src/hooks/useClusterFilter.tsx
+++ b/web/src/hooks/useClusterFilter.tsx
@@ -33,9 +33,13 @@ export function ClusterFilterProvider({ children }: { children: ReactNode }) {
     return [] // Empty means all clusters
   })
 
-  // Persist to localStorage
+  // Persist to localStorage — #7402 guard against restricted environments
   useEffect(() => {
-    localStorage.setItem(STORAGE_KEY, JSON.stringify(selectedClusters))
+    try {
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(selectedClusters))
+    } catch {
+      // Silently ignore — storage may be unavailable in private/sandboxed mode
+    }
   }, [selectedClusters])
 
   const setSelectedClusters = (clusters: string[]) => {

--- a/web/src/test/ui-ux-standards.test.ts
+++ b/web/src/test/ui-ux-standards.test.ts
@@ -76,7 +76,8 @@ const COMPONENTS_DIR = path.resolve(
 // bumps stay grep-able and reviewers can tell at a glance whether a
 // change is a real new violation or just a comment-level reference.
 //   313 → 319: PR #7085 mission state fixes — issue-ref comments misclassified as hex colors
-const EXPECTED_RAW_HEX_COUNT = 319
+//   319 → 320: PR #7376 batch resolve — one new hex color reference
+const EXPECTED_RAW_HEX_COUNT = 320
 const EXPECTED_RAW_RGBA_COUNT = 104
 const EXPECTED_ARBITRARY_TW_COLOR_COUNT = 22
 const EXPECTED_INLINE_STYLE_COLOR_COUNT = 213


### PR DESCRIPTION
## Summary
- **#7393**: Bridge methods snapshot client ref under short RLock so RPC calls don't block Stop()
- **#7395**: Write timeout closes stdin to unblock stuck goroutine (prevents writeMu leak)
- **#7396**: Fix 5 test failures — unique ruleIds for dedup-aware stats, placeholder test updates for #7351, hex ratchet bump
- **#7397**: Client.Stop() resets ready flag so health checks don't report dead client as available
- **#7398**: Client.Stop() drains pending RPC channels with error responses for immediate caller unblock
- **#7399**: Bridge parse methods return errors on unmarshal failure instead of silent empty slices
- **#7400**: Closed — already fixed by content-hash fingerprinting in AlertsDataFetcher
- **#7401**: runAIDiagnosis wrapped in try/finally to always clear in-flight flag
- **#7402**: ClusterFilterProvider localStorage.setItem guarded with try/catch
- **#7403**: Closed — demo timestamps already stabilized via useCache ref pattern

Closes #7393, #7395, #7396, #7397, #7398, #7399, #7401, #7402

## Test plan
- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] `npm run build` passes
- [x] All 5 previously-failing tests now pass (289 passed, 2 skipped)