### PR TITLE
fix: resolve issues #7404-#7426 (alerts, clipboard, navbar, meta, mocks)

### DIFF
--- a/web/src/components/layout/navbar/Navbar.tsx
+++ b/web/src/components/layout/navbar/Navbar.tsx
@@ -139,7 +139,7 @@ export function Navbar({ topOffset = 0 }: NavbarProps) {
           {!isSidebarOpen && (
             <button
               onClick={openSidebar}
-              className="relative flex items-center gap-1.5 px-3 py-1.5 text-sm font-medium rounded-lg transition-colors bg-purple-500/10 hover:bg-purple-500/20 text-purple-400 border border-purple-500/20"
+              className="relative flex items-center gap-1.5 px-3 py-1.5 min-h-[44px] text-sm font-medium rounded-lg transition-colors bg-purple-500/10 hover:bg-purple-500/20 text-purple-400 border border-purple-500/20"
               aria-label={t('missionSidebar.openAIMissions')}
               title={t('missionSidebar.openAIMissions')}
             >

--- a/web/src/contexts/AlertsContext.tsx
+++ b/web/src/contexts/AlertsContext.tsx
@@ -11,6 +11,7 @@ import type { GPUHealthCheckResult } from '../hooks/mcp/types'
 import type { NightlyGuideStatus } from '../lib/llmd/nightlyE2EDemoData'
 import type { AlertsMCPData } from './AlertsDataFetcher'
 import { STORAGE_KEY_AUTH_TOKEN, FETCH_DEFAULT_TIMEOUT_MS, STORAGE_KEY_NOTIFIED_ALERT_KEYS } from '../lib/constants'
+import { safeGet, safeSet, safeRemove, safeGetJSON, safeSetJSON } from '../lib/safeLocalStorage'
 import { INITIAL_FETCH_DELAY_MS, POLL_INTERVAL_SLOW_MS, SECONDARY_FETCH_DELAY_MS, NIGHTLY_E2E_POLL_INTERVAL_MS } from '../lib/constants/network'
 import { PRESET_ALERT_RULES } from '../types/alerts'
 import { sendNotificationWithDeepLink } from '../hooks/useDeepLink'
@@ -253,7 +254,7 @@ const NOTIFICATION_DEDUP_MAX_AGE_MS = 86_400_000 // 24 hours
 /** Load persisted notification dedup map from localStorage (key → timestamp) */
 function loadNotifiedAlertKeys(): Map<string, number> {
   try {
-    const stored = localStorage.getItem(STORAGE_KEY_NOTIFIED_ALERT_KEYS)
+    const stored = safeGet(STORAGE_KEY_NOTIFIED_ALERT_KEYS)
     if (stored) {
       return new Map(JSON.parse(stored) as [string, number][])
     }
@@ -270,7 +271,7 @@ function saveNotifiedAlertKeys(keys: Map<string, number>): void {
     for (const [key, ts] of keys) {
       if (now - ts > NOTIFICATION_DEDUP_MAX_AGE_MS) keys.delete(key)
     }
-    localStorage.setItem(STORAGE_KEY_NOTIFIED_ALERT_KEYS, JSON.stringify([...keys.entries()]))
+    safeSet(STORAGE_KEY_NOTIFIED_ALERT_KEYS, JSON.stringify([...keys.entries()]))
   } catch {
     // localStorage full or unavailable
   }
@@ -278,24 +279,12 @@ function saveNotifiedAlertKeys(keys: Map<string, number>): void {
 
 // Load from localStorage
 function loadFromStorage<T>(key: string, defaultValue: T): T {
-  try {
-    const stored = localStorage.getItem(key)
-    if (stored) {
-      return JSON.parse(stored)
-    }
-  } catch (e) {
-    console.error(`Failed to load ${key} from localStorage:`, e)
-  }
-  return defaultValue
+  return safeGetJSON(key, defaultValue)
 }
 
 // Save to localStorage
 function saveToStorage<T>(key: string, value: T): void {
-  try {
-    localStorage.setItem(key, JSON.stringify(value))
-  } catch (e) {
-    console.error(`Failed to save ${key} to localStorage:`, e)
-  }
+  safeSetJSON(key, value)
 }
 
 // Save alerts to localStorage with a hard cap and quota-exceeded handling.
@@ -313,7 +302,7 @@ function saveAlerts(alerts: Alert[]): void {
   }
 
   try {
-    localStorage.setItem(ALERTS_KEY, JSON.stringify(toSave))
+    safeSet(ALERTS_KEY, JSON.stringify(toSave))
   } catch (e) {
     // QuotaExceededError: DOMException with name 'QuotaExceededError', or legacy
     // browsers that use numeric code 22 instead of the named exception.
@@ -329,10 +318,10 @@ function saveAlerts(alerts: Alert[]): void {
         .slice(0, MAX_RESOLVED_ALERTS_AFTER_PRUNE)
       const pruned = [...firing, ...resolved]
       try {
-        localStorage.setItem(ALERTS_KEY, JSON.stringify(pruned))
+        safeSet(ALERTS_KEY, JSON.stringify(pruned))
       } catch (retryError) {
         console.error('[Alerts] localStorage still full after pruning, clearing alerts', retryError)
-        localStorage.removeItem(ALERTS_KEY)
+        safeRemove(ALERTS_KEY)
       }
     } else {
       console.error(`Failed to save ${ALERTS_KEY} to localStorage:`, e)
@@ -454,7 +443,7 @@ export function AlertsProvider({ children }: { children: ReactNode }) {
   useEffect(() => {
     let unmounted = false
     const fetchCronJobResults = async () => {
-      const token = localStorage.getItem(STORAGE_KEY_AUTH_TOKEN)
+      const token = safeGet(STORAGE_KEY_AUTH_TOKEN)
       if (!token || unmounted) return
       const currentClusters = clustersRef.current
       if (!currentClusters.length) return
@@ -907,7 +896,7 @@ export function AlertsProvider({ children }: { children: ReactNode }) {
   // Send notifications for an alert (best-effort, silent on auth failures)
   const sendNotifications = async (alert: Alert, channels: AlertChannel[]) => {
     try {
-      const token = localStorage.getItem(STORAGE_KEY_AUTH_TOKEN)
+      const token = safeGet(STORAGE_KEY_AUTH_TOKEN)
       // Skip notification if not authenticated - notifications require login
       if (!token) return
 
@@ -942,7 +931,7 @@ export function AlertsProvider({ children }: { children: ReactNode }) {
   const sendBatchedNotifications = async (items: Array<{ alert: Alert; channels: AlertChannel[] }>) => {
     if (items.length === 0) return
     try {
-      const token = localStorage.getItem(STORAGE_KEY_AUTH_TOKEN)
+      const token = safeGet(STORAGE_KEY_AUTH_TOKEN)
       if (!token) return
 
       const API_BASE = import.meta.env.VITE_API_BASE_URL || ''

--- a/web/src/mocks/browser.ts
+++ b/web/src/mocks/browser.ts
@@ -70,10 +70,12 @@ declare global {
   }
 }
 
-// Apply a scenario by name
+// Apply a scenario by name — resets previous scenario handlers first
+// to prevent stale overrides from shadowing new expectations (#7420).
 export function applyScenario(name: keyof typeof scenarios) {
   const scenarioHandlers = scenarios[name]
   if (scenarioHandlers) {
+    worker.resetHandlers()
     worker.use(...scenarioHandlers)
   }
 }

--- a/web/src/mocks/handlers.ts
+++ b/web/src/mocks/handlers.ts
@@ -186,9 +186,23 @@ const currentUser = {
   onboarded: true,
 }
 
-// Stored card configurations for sharing tests
+// Stored card configurations for sharing tests.
+// Capped to prevent unbounded memory growth in long-running sessions (#7418).
+/** Maximum number of entries in each in-memory share registry */
+const MAX_SHARE_REGISTRY_ENTRIES = 500
 const savedCards: Record<string, unknown> = {}
 const sharedDashboards: Record<string, unknown> = {}
+
+/** Evict oldest entries when registry exceeds MAX_SHARE_REGISTRY_ENTRIES */
+function pruneRegistry(registry: Record<string, unknown>) {
+  const keys = Object.keys(registry)
+  if (keys.length > MAX_SHARE_REGISTRY_ENTRIES) {
+    const excess = keys.length - MAX_SHARE_REGISTRY_ENTRIES
+    for (let i = 0; i < excess; i++) {
+      delete registry[keys[i]]
+    }
+  }
+}
 
 export const handlers = [
   // ── Analytics passthrough ─────────────────────────────────────────
@@ -463,6 +477,7 @@ export const handlers = [
     const body = (await request.json()) as { id: string; config: unknown }
     const shareId = `card-${Date.now()}`
     savedCards[shareId] = body
+    pruneRegistry(savedCards)
     return HttpResponse.json({
       success: true,
       shareId,
@@ -492,6 +507,7 @@ export const handlers = [
     const body = (await request.json()) as { name: string; config: unknown }
     const shareId = `dashboard-${Date.now()}`
     sharedDashboards[shareId] = body
+    pruneRegistry(sharedDashboards)
     return HttpResponse.json({
       success: true,
       shareId,

--- a/web/src/pages/FromHeadlamp.tsx
+++ b/web/src/pages/FromHeadlamp.tsx
@@ -115,7 +115,7 @@ const CLUSTER_PORTFORWARD_STEPS: InstallStep[] = [
     title: 'Port-forward and open',
     commands: [
       'kubectl port-forward svc/kc-kubestellar-console 8080:8080',
-      'open http://localhost:8080',
+      '# Then open http://localhost:8080 in your browser',
     ],
     description: 'Access the console locally. Great for evaluation or single-user access.' },
 ]
@@ -219,14 +219,16 @@ function DeploymentSection() {
   }
 
   const copyCommands = async (commands: string[], step: number) => {
-    const text = commands.join('\n')
-    await copyToClipboard(text)
+    const text = commands.filter(c => !c.startsWith('#') && c !== '').join('\n')
+    const ok = await copyToClipboard(text)
+    if (!ok) return
     const key = `${activeTab}-${step}`
     setCopiedStep(key)
     clearTimeout(copiedTimerRef.current)
     copiedTimerRef.current = setTimeout(() => setCopiedStep(null), COPY_FEEDBACK_MS)
-    emitFromHeadlampCommandCopy(activeTab, step, commands[0])
-    emitInstallCommandCopied('from_headlamp', commands[0])
+    const firstCommand = commands.find(c => !c.startsWith('#') && c !== '') ?? commands[0]
+    emitFromHeadlampCommandCopy(activeTab, step, firstCommand)
+    emitInstallCommandCopied('from_headlamp', firstCommand)
   }
 
   const steps = activeTab === 'localhost'

--- a/web/src/pages/FromHolmesGPT.tsx
+++ b/web/src/pages/FromHolmesGPT.tsx
@@ -191,12 +191,14 @@ export function FromHolmesGPT() {
   }, [])
 
   const copyCommands = async (commands: string[], step: number) => {
-    const text = commands.join('\n')
-    await copyToClipboard(text)
+    const text = commands.filter(c => !c.startsWith('#') && c !== '').join('\n')
+    const ok = await copyToClipboard(text)
+    if (!ok) return
     setCopiedStep(`step-${step}`)
     clearTimeout(copiedTimerRef.current)
     copiedTimerRef.current = setTimeout(() => setCopiedStep(null), COPY_FEEDBACK_MS)
-    emitInstallCommandCopied('from_holmesgpt', commands[0])
+    const firstCommand = commands.find(c => !c.startsWith('#') && c !== '') ?? commands[0]
+    emitInstallCommandCopied('from_holmesgpt', firstCommand)
   }
 
   return (

--- a/web/src/pages/FromLens.tsx
+++ b/web/src/pages/FromLens.tsx
@@ -112,7 +112,7 @@ const CLUSTER_PORTFORWARD_STEPS: InstallStep[] = [
     title: 'Port-forward and open',
     commands: [
       'kubectl port-forward svc/kc-kubestellar-console 8080:8080',
-      'open http://localhost:8080',
+      '# Then open http://localhost:8080 in your browser',
     ],
     description: 'Access the console locally. Great for evaluation or single-user access.' },
 ]
@@ -231,14 +231,16 @@ function DeploymentSection() {
   }
 
   const copyCommands = async (commands: string[], step: number) => {
-    const text = commands.join('\n')
-    await copyToClipboard(text)
+    const text = commands.filter(c => !c.startsWith('#') && c !== '').join('\n')
+    const ok = await copyToClipboard(text)
+    if (!ok) return
     const key = `${activeTab}-${step}`
     setCopiedStep(key)
     clearTimeout(copiedTimerRef.current)
     copiedTimerRef.current = setTimeout(() => setCopiedStep(null), COPY_FEEDBACK_MS)
-    emitFromLensCommandCopy(activeTab, step, commands[0])
-    emitInstallCommandCopied('from_lens', commands[0])
+    const firstCommand = commands.find(c => !c.startsWith('#') && c !== '') ?? commands[0]
+    emitFromLensCommandCopy(activeTab, step, firstCommand)
+    emitInstallCommandCopied('from_lens', firstCommand)
   }
 
   const steps = activeTab === 'localhost'

--- a/web/src/pages/Welcome.tsx
+++ b/web/src/pages/Welcome.tsx
@@ -116,8 +116,11 @@ export function Welcome() {
   const ref = searchParams.get('ref') || 'direct'
 
   useEffect(() => {
-    document.title = PAGE_TITLE
+    const prevTitle = document.title
     const metaDesc = document.querySelector('meta[name="description"]')
+    const prevDescription = metaDesc?.getAttribute('content') ?? ''
+
+    document.title = PAGE_TITLE
     if (metaDesc) {
       metaDesc.setAttribute('content', META_DESCRIPTION)
     } else {
@@ -127,6 +130,14 @@ export function Welcome() {
       document.head.appendChild(meta)
     }
     emitWelcomeViewed(ref)
+
+    // Restore previous title and meta description on unmount so they don't
+    // leak into other routes during SPA navigation (#7423).
+    return () => {
+      document.title = prevTitle
+      const desc = document.querySelector('meta[name="description"]')
+      if (desc) desc.setAttribute('content', prevDescription)
+    }
   }, [ref])
 
   return (

--- a/web/src/pages/WhiteLabel.tsx
+++ b/web/src/pages/WhiteLabel.tsx
@@ -240,13 +240,15 @@ function DeploymentSection() {
 
   const copyCommands = async (commands: string[], step: number) => {
     const text = commands.filter(c => !c.startsWith('#') && c !== '').join('\n')
-    await copyToClipboard(text)
+    const ok = await copyToClipboard(text)
+    if (!ok) return
     const key = `${activeTab}-${step}`
     setCopiedStep(key)
     clearTimeout(copiedTimerRef.current)
     copiedTimerRef.current = setTimeout(() => setCopiedStep(null), COPY_FEEDBACK_MS)
-    emitWhiteLabelCommandCopy(activeTab, step, commands[0])
-    emitInstallCommandCopied('white_label', commands[0])
+    const firstCommand = commands.find(c => !c.startsWith('#') && c !== '') ?? commands[0]
+    emitWhiteLabelCommandCopy(activeTab, step, firstCommand)
+    emitInstallCommandCopied('white_label', firstCommand)
   }
 
   const steps = activeTab === 'binary'


### PR DESCRIPTION
## Summary

Fixes 8 bugs from issues #7404-#7426:

- **#7404** AlertsContext.tsx uses raw `localStorage` without environment guards -- replaced with `safeLocalStorage` wrappers to prevent crashes in SSR/non-browser environments
- **#7405** Navbar AI Missions button missing `min-h-[44px]` causing inconsistent button heights
- **#7418** In-memory share registries in MSW handlers grow without bounds -- added 500-entry cap with FIFO eviction
- **#7420** `applyScenario` stacks handlers instead of replacing -- now calls `resetHandlers()` first
- **#7423** Welcome page meta description leaks into other routes during SPA navigation -- restored on unmount
- **#7424** macOS-only `open http://localhost:8080` command in FromLens/FromHeadlamp -- replaced with cross-platform comment
- **#7425** `copyToClipboard` return value ignored -- now checks success before showing feedback and firing analytics
- **#7426** Analytics logs `commands[0]` which may be a comment line -- now finds first non-comment command

Remaining issues (#7406-#7415, #7417, #7419, #7421) are either storage-layer design concerns, test infrastructure enhancements, or require deeper investigation and will be addressed separately.

Closes #7404, closes #7405, closes #7418, closes #7420, closes #7423, closes #7424, closes #7425, closes #7426

## Test plan
- [ ] Verify build passes (`npm run build`)
- [ ] Confirm navbar buttons are uniform height
- [ ] Test clipboard copy on a page where permission is denied -- should not show success
- [ ] Navigate to Welcome page and back -- meta description should not persist
- [ ] Verify install steps show comment instead of macOS `open` command