### PR TITLE
fix: storage dashboard PVC count, PV stat, and failed count bugs

### DIFF
--- a/web/src/components/cards/PVCStatus.tsx
+++ b/web/src/components/cards/PVCStatus.tsx
@@ -2,6 +2,7 @@ import { useMemo } from 'react'
 import { CheckCircle, AlertTriangle, Clock } from 'lucide-react'
 import type { PVC } from '../../hooks/useMCP'
 import { useCachedPVCs } from '../../hooks/useCachedData'
+import { useGlobalFilters } from '../../hooks/useGlobalFilters'
 import { useDemoMode } from '../../hooks/useDemoMode'
 import { useCardLoadingState } from './CardDataContext'
 import { useCardData, commonComparators } from '../../lib/cards/cardHooks'
@@ -71,8 +72,16 @@ function getStatusColor(status: string) {
 
 function PVCStatusInternal() {
   const { t } = useTranslation(['common', 'cards'])
-  const { pvcs, isLoading, isRefreshing, error, consecutiveFailures, isFailed, isDemoFallback, lastRefresh } = useCachedPVCs()
+  const { pvcs: allPVCs, isLoading, isRefreshing, error, consecutiveFailures, isFailed, isDemoFallback, lastRefresh } = useCachedPVCs()
+  const { selectedClusters, isAllClustersSelected } = useGlobalFilters()
   const { isDemoMode: demoMode } = useDemoMode()
+
+  // Apply global cluster filters so PVC counts match the StorageOverview card (#7457).
+  // Previously this card ignored global filters, causing count discrepancies.
+  const pvcs = useMemo(() => {
+    if (isAllClustersSelected) return allPVCs
+    return allPVCs.filter(p => p.cluster && selectedClusters.includes(p.cluster))
+  }, [allPVCs, selectedClusters, isAllClustersSelected])
 
   // Report card data state (lastRefresh flows to CardWrapper header "Updated Xm ago")
   const hasData = pvcs.length > 0
@@ -151,11 +160,15 @@ function PVCStatusInternal() {
       )
     }
 
+    const bound = result.filter(p => p.status === 'Bound').length
+    const pending = result.filter(p => p.status === 'Pending').length
     return {
       total: result.length,
-      bound: result.filter(p => p.status === 'Bound').length,
-      pending: result.filter(p => p.status === 'Pending').length,
-      failed: result.filter(p => p.status === 'Lost').length,
+      bound,
+      pending,
+      // Count all PVCs that are neither Bound nor Pending as failed (#7464).
+      // Previously only 'Lost' was counted, missing 'Failed' and other error states.
+      failed: result.length - bound - pending,
     }
   }, [pvcs, localClusterFilter, search])
 

--- a/web/src/components/storage/Storage.tsx
+++ b/web/src/components/storage/Storage.tsx
@@ -228,6 +228,17 @@ export function Storage() {
           onClick: () => { setPVCModalFilter('Pending'); openPVCModal() },
           isClickable: hasDataToShow && (stats?.pendingPVCs || 0) > 0
         }
+      case 'pvs': {
+        // Count unique PVs from PVC data — each bound PVC references a PV.
+        // This is an approximation: real PV counts require a separate API call,
+        // but bound PVCs are the best proxy available from cached data.
+        const boundPVCount = filteredPVCs.filter(p => p.status === 'Bound').length
+        return {
+          value: formatStatValue(boundPVCount, hasDataToShow),
+          sublabel: 'persistent volumes (bound)',
+          isClickable: false,
+        }
+      }
       case 'storage_classes': {
         // Count unique storage classes from PVCs (shows storage classes in use)
         const uniqueStorageClasses = new Set(filteredPVCs.map(p => p.storageClass).filter(Boolean))


### PR DESCRIPTION
## Summary
- **#7457**: PVCStatus card now applies global cluster filters, matching StorageOverview card counts
- **#7461**: Storage dashboard `getDashboardStatValue` now handles `pvs` block ID so the PV stat card shows a value
- **#7464**: PVCStatus failed count now includes all non-Bound/non-Pending PVCs, not just `Lost`

Closed 17 other issues (>= #7456) with explanations:
- **#7456, #7459, #7463, #7468, #7469, #7472-7475**: Already fixed by existing guards (writeMu, unmountedRef, wsOpenEpoch, toolsInFlight floor check, quota pruning, timer cleanup)
- **#7465-7467, #7470-7471**: Not bugs (mixed-mode uses separate history arrays, no lastMissionsSigRef exists, timeout purge is by design, historyWithoutLastUser is correct, clearActiveTokenCategory is idempotent)
- **#7458, #7460, #7462**: Expected cache TTL behavior, not code bugs

## Test plan
- [ ] Verify PVCStatus card respects global cluster filter (select subset, check counts match StorageOverview)
- [ ] Verify PV stat block on Storage dashboard shows a value when bound PVCs exist
- [ ] Verify failed PVC count includes all non-Bound/non-Pending statuses
- [ ] `npm run build` passes
- [ ] `go build ./...` and `go vet ./...` pass