### PR TITLE
fix: resolve storage dashboard bugs (#7478, #7479, #7480)

### DIFF
--- a/web/src/components/cards/StorageOverview.tsx
+++ b/web/src/components/cards/StorageOverview.tsx
@@ -51,7 +51,7 @@ export function StorageOverview() {
     return globalFilteredClusters.filter(c => localClusterFilter.includes(c.name))
   })()
 
-  // Filter PVCs by selection
+  // Filter PVCs by selection and reachability (must match Storage page logic)
   const filteredPVCs = (() => {
     let result = pvcs
     if (!isAllClustersSelected) {
@@ -60,6 +60,11 @@ export function StorageOverview() {
     if (localClusterFilter.length > 0) {
       result = result.filter(p => p.cluster && localClusterFilter.includes(p.cluster))
     }
+    // Exclude PVCs from unreachable clusters to match Storage page totals (#7479)
+    result = result.filter(p => {
+      const cluster = clusters.find(c => c.name === p.cluster)
+      return cluster?.reachable !== false
+    })
     return result
   })()
 

--- a/web/src/components/drilldown/views/PodDrillDown.tsx
+++ b/web/src/components/drilldown/views/PodDrillDown.tsx
@@ -1138,14 +1138,11 @@ Please proceed step by step and ask for confirmation before making any changes.`
       setSecrets(Array.from(secretRefs))
 
       // Extract PVC references from volumes
+      // Use a K8s-valid name pattern to avoid capturing quotes or YAML artifacts
+      const K8S_NAME_PATTERN = '[a-z0-9][a-z0-9._-]*[a-z0-9]|[a-z0-9]'
       const pvcRefs = new Set<string>()
-      const pvcMatches = podYaml.matchAll(/persistentVolumeClaim:\s*\n\s*claimName:\s*(\S+)/g)
+      const pvcMatches = podYaml.matchAll(new RegExp(`claimName:\\s*"?(${K8S_NAME_PATTERN})"?`, 'g'))
       for (const match of pvcMatches) {
-        if (match[1]) pvcRefs.add(match[1])
-      }
-      // Also check direct claimName pattern
-      const claimNameMatches = podYaml.matchAll(/claimName:\s*(\S+)/g)
-      for (const match of claimNameMatches) {
         if (match[1]) pvcRefs.add(match[1])
       }
       setPvcs(Array.from(pvcRefs))

--- a/web/src/components/storage/Storage.tsx
+++ b/web/src/components/storage/Storage.tsx
@@ -158,9 +158,10 @@ export function Storage() {
     pendingPVCs: filteredPVCs.filter(p => p.status === 'Pending').length }
 
   // Check if we have actual data (not just loading state) — storage data is valid
-  // regardless of nodeCount (#6808)
+  // regardless of nodeCount (#6808). Use filteredPVCs (not global pvcs) so that
+  // clusters with no PVCs in the current selection show empty state (#7478)
   const hasActualData = filteredClusters.some(c =>
-    c.reachable !== false && (c.storageGB !== undefined || pvcs.length > 0)
+    c.reachable !== false && (c.storageGB !== undefined || filteredPVCs.length > 0)
   )
 
   // Cache the last known good stats to show during refresh


### PR DESCRIPTION
## Summary

- **#7478**: Storage page showed data for clusters with no PVCs because `hasActualData` checked global `pvcs.length` instead of filtered. Fixed to use `filteredPVCs.length`.
- **#7479**: StorageOverview card excluded unreachable-cluster filtering, causing totals to differ from Storage page. Added reachability filter to match.
- **#7480**: Pod drilldown PVC name extraction used greedy `\S+` regex, capturing quotes/YAML artifacts. Replaced with K8s-valid name pattern and removed redundant duplicate regex.

Closes #7478, closes #7479, closes #7480

## Test plan
- [ ] Select a cluster with no PVCs; verify Storage page shows empty state
- [ ] Make a cluster unreachable; verify Storage page and overview card show same totals
- [ ] View pod with quoted PVC claimName in YAML; verify correct name displayed

🤖 Generated with [Claude Code](https://claude.com/claude-code)