### PR TITLE
fix: add RBAC role checks to unprotected API endpoints

### DIFF
--- a/pkg/api/handlers/custom_resources.go
+++ b/pkg/api/handlers/custom_resources.go
@@ -40,6 +40,12 @@ type CustomResourceResponse struct {
 // Kubernetes RBAC controls access — if the user's kubeconfig cannot list the
 // resource, the per-cluster query silently returns zero items.
 func (h *MCPHandlers) GetCustomResources(c *fiber.Ctx) error {
+	// SECURITY (#7487): custom resource listing can expose sensitive spec/status
+	// data; require a valid console role (viewer or above).
+	if err := requireViewerOrAbove(c, h.store); err != nil {
+		return err
+	}
+
 	if isDemoMode(c) {
 		return c.JSON(CustomResourceResponse{Items: []CustomResourceItem{}, IsDemoData: true})
 	}

--- a/pkg/api/handlers/mcp.go
+++ b/pkg/api/handlers/mcp.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/kubestellar/console/pkg/k8s"
 	"github.com/kubestellar/console/pkg/mcp"
+	"github.com/kubestellar/console/pkg/store"
 )
 
 // maxResponseDeadline is the maximum time any multi-cluster REST handler will
@@ -144,13 +145,15 @@ func (t *clusterErrorTracker) annotate(resp fiber.Map) fiber.Map {
 type MCPHandlers struct {
 	bridge    *mcp.Bridge
 	k8sClient *k8s.MultiClusterClient
+	store     store.Store
 }
 
 // NewMCPHandlers creates a new MCP handlers instance
-func NewMCPHandlers(bridge *mcp.Bridge, k8sClient *k8s.MultiClusterClient) *MCPHandlers {
+func NewMCPHandlers(bridge *mcp.Bridge, k8sClient *k8s.MultiClusterClient, s store.Store) *MCPHandlers {
 	return &MCPHandlers{
 		bridge:    bridge,
 		k8sClient: k8sClient,
+		store:     s,
 	}
 }
 

--- a/pkg/api/handlers/mcp_resources.go
+++ b/pkg/api/handlers/mcp_resources.go
@@ -178,6 +178,11 @@ func (h *MCPHandlers) GetGPUHealthCronJobStatus(c *fiber.Ctx) error {
 
 // InstallGPUHealthCronJob installs the GPU health check CronJob on a cluster
 func (h *MCPHandlers) InstallGPUHealthCronJob(c *fiber.Ctx) error {
+	// SECURITY (#7493): mutating endpoint requires editor or admin role.
+	if err := requireEditorOrAdmin(c, h.store); err != nil {
+		return err
+	}
+
 	if isDemoMode(c) {
 		return c.JSON(fiber.Map{"success": true, "message": "CronJob installed (demo mode)"})
 	}
@@ -226,6 +231,11 @@ func (h *MCPHandlers) InstallGPUHealthCronJob(c *fiber.Ctx) error {
 
 // UninstallGPUHealthCronJob removes the GPU health check CronJob from a cluster
 func (h *MCPHandlers) UninstallGPUHealthCronJob(c *fiber.Ctx) error {
+	// SECURITY (#7494): destructive endpoint requires editor or admin role.
+	if err := requireEditorOrAdmin(c, h.store); err != nil {
+		return err
+	}
+
 	if isDemoMode(c) {
 		return c.JSON(fiber.Map{"success": true, "message": "CronJob removed (demo mode)"})
 	}
@@ -824,6 +834,13 @@ func (h *MCPHandlers) GetLimitRanges(c *fiber.Ctx) error {
 
 // CreateOrUpdateResourceQuota creates or updates a ResourceQuota
 func (h *MCPHandlers) CreateOrUpdateResourceQuota(c *fiber.Ctx) error {
+	// SECURITY (#7490, #7492): mutating endpoint requires editor or admin role.
+	// This also covers the ensure_namespace path (#7492) since the whole handler
+	// is gated before any namespace or quota creation occurs.
+	if err := requireEditorOrAdmin(c, h.store); err != nil {
+		return err
+	}
+
 	var req struct {
 		Cluster         string            `json:"cluster"`
 		Name            string            `json:"name"`
@@ -885,6 +902,11 @@ func (h *MCPHandlers) CreateOrUpdateResourceQuota(c *fiber.Ctx) error {
 
 // DeleteResourceQuota deletes a ResourceQuota
 func (h *MCPHandlers) DeleteResourceQuota(c *fiber.Ctx) error {
+	// SECURITY (#7491): destructive endpoint requires editor or admin role.
+	if err := requireEditorOrAdmin(c, h.store); err != nil {
+		return err
+	}
+
 	cluster := c.Query("cluster")
 	namespace := c.Query("namespace")
 	name := c.Query("name")
@@ -1074,6 +1096,12 @@ func validateToolName(name string, allowedTools map[string]bool) error {
 
 // CallOpsTool calls a kubestellar-ops tool
 func (h *MCPHandlers) CallOpsTool(c *fiber.Ctx) error {
+	// SECURITY (#7495): tool-call endpoint can expose sensitive cluster data;
+	// require at least editor role to invoke tools.
+	if err := requireEditorOrAdmin(c, h.store); err != nil {
+		return err
+	}
+
 	if h.bridge == nil {
 		return c.Status(503).JSON(fiber.Map{"error": "MCP bridge not available"})
 	}

--- a/pkg/api/handlers/mcp_test.go
+++ b/pkg/api/handlers/mcp_test.go
@@ -73,7 +73,7 @@ func TestWaitWithDeadline_CancelledOnDeadline(t *testing.T) {
 
 func TestMCPGetPods_DemoModeReturnsDemoData(t *testing.T) {
 	env := setupTestEnv(t)
-	handler := NewMCPHandlers(nil, env.K8sClient)
+	handler := NewMCPHandlers(nil, env.K8sClient, nil)
 	env.App.Get("/api/mcp/pods", handler.GetPods)
 
 	req, err := http.NewRequest("GET", "/api/mcp/pods", nil)
@@ -99,7 +99,7 @@ func TestMCPGetPods_DemoModeReturnsDemoData(t *testing.T) {
 
 func TestMCPGetPods_NoClusterAccessReturns503(t *testing.T) {
 	env := setupTestEnv(t)
-	handler := NewMCPHandlers(nil, nil)
+	handler := NewMCPHandlers(nil, nil, nil)
 	env.App.Get("/api/mcp/pods", handler.GetPods)
 
 	req, err := http.NewRequest("GET", "/api/mcp/pods", nil)
@@ -116,7 +116,7 @@ func TestMCPGetPods_NoClusterAccessReturns503(t *testing.T) {
 
 func TestMCPGetPods_SingleClusterEmptyIsArray(t *testing.T) {
 	env := setupTestEnv(t)
-	handler := NewMCPHandlers(nil, env.K8sClient)
+	handler := NewMCPHandlers(nil, env.K8sClient, nil)
 	env.App.Get("/api/mcp/pods", handler.GetPods)
 
 	req, err := http.NewRequest("GET", "/api/mcp/pods?cluster=test-cluster", nil)
@@ -137,7 +137,7 @@ func TestMCPGetPods_SingleClusterEmptyIsArray(t *testing.T) {
 
 func TestMCPGetPods_InternalErrorIsSanitized(t *testing.T) {
 	env := setupTestEnv(t)
-	handler := NewMCPHandlers(nil, env.K8sClient)
+	handler := NewMCPHandlers(nil, env.K8sClient, nil)
 	env.App.Get("/api/mcp/pods", handler.GetPods)
 
 	k8sClient, err := env.K8sClient.GetClient("test-cluster")
@@ -166,7 +166,7 @@ func TestMCPGetPods_InternalErrorIsSanitized(t *testing.T) {
 
 func TestMCPGetPods_NetworkErrorReturnsUnavailable(t *testing.T) {
 	env := setupTestEnv(t)
-	handler := NewMCPHandlers(nil, env.K8sClient)
+	handler := NewMCPHandlers(nil, env.K8sClient, nil)
 	env.App.Get("/api/mcp/pods", handler.GetPods)
 
 	k8sClient, err := env.K8sClient.GetClient("test-cluster")
@@ -196,7 +196,7 @@ func TestMCPGetPods_NetworkErrorReturnsUnavailable(t *testing.T) {
 
 func TestMCPGetDaemonSets_SingleClusterEmptyIsArray(t *testing.T) {
 	env := setupTestEnv(t)
-	handler := NewMCPHandlers(nil, env.K8sClient)
+	handler := NewMCPHandlers(nil, env.K8sClient, nil)
 	env.App.Get("/api/mcp/daemonsets", handler.GetDaemonSets)
 
 	req, err := http.NewRequest("GET", "/api/mcp/daemonsets?cluster=test-cluster", nil)
@@ -217,7 +217,7 @@ func TestMCPGetDaemonSets_SingleClusterEmptyIsArray(t *testing.T) {
 
 func TestMCPGetEvents_SingleClusterEmptyIsArray(t *testing.T) {
 	env := setupTestEnv(t)
-	handler := NewMCPHandlers(nil, env.K8sClient)
+	handler := NewMCPHandlers(nil, env.K8sClient, nil)
 	env.App.Get("/api/mcp/events", handler.GetEvents)
 
 	req, err := http.NewRequest("GET", "/api/mcp/events?cluster=test-cluster&limit=10", nil)
@@ -239,7 +239,7 @@ func TestMCPGetEvents_SingleClusterEmptyIsArray(t *testing.T) {
 
 func TestMCPGetEvents_NetworkErrorReturnsUnavailable(t *testing.T) {
 	env := setupTestEnv(t)
-	handler := NewMCPHandlers(nil, env.K8sClient)
+	handler := NewMCPHandlers(nil, env.K8sClient, nil)
 	env.App.Get("/api/mcp/events", handler.GetEvents)
 
 	k8sClient, err := env.K8sClient.GetClient("test-cluster")
@@ -268,7 +268,7 @@ func TestMCPGetEvents_NetworkErrorReturnsUnavailable(t *testing.T) {
 
 func TestMCPGetNodes_NetworkErrorReturnsUnavailable(t *testing.T) {
 	env := setupTestEnv(t)
-	handler := NewMCPHandlers(nil, env.K8sClient)
+	handler := NewMCPHandlers(nil, env.K8sClient, nil)
 	env.App.Get("/api/mcp/nodes", handler.GetNodes)
 
 	k8sClient, err := env.K8sClient.GetClient("test-cluster")
@@ -297,7 +297,7 @@ func TestMCPGetNodes_NetworkErrorReturnsUnavailable(t *testing.T) {
 
 func TestMCPGetPods_AuthErrorReturnsUnavailable(t *testing.T) {
 	env := setupTestEnv(t)
-	handler := NewMCPHandlers(nil, env.K8sClient)
+	handler := NewMCPHandlers(nil, env.K8sClient, nil)
 	env.App.Get("/api/mcp/pods", handler.GetPods)
 
 	k8sClient, err := env.K8sClient.GetClient("test-cluster")

--- a/pkg/api/handlers/mcp_validate_test.go
+++ b/pkg/api/handlers/mcp_validate_test.go
@@ -12,7 +12,7 @@ import (
 
 func TestMCPValidation_InvalidClusterNameRejects(t *testing.T) {
 	env := setupTestEnv(t)
-	handler := NewMCPHandlers(nil, env.K8sClient)
+	handler := NewMCPHandlers(nil, env.K8sClient, nil)
 	env.App.Get("/api/mcp/pods", handler.GetPods)
 
 	// Special characters in cluster name should be rejected
@@ -30,7 +30,7 @@ func TestMCPValidation_InvalidClusterNameRejects(t *testing.T) {
 
 func TestMCPValidation_InvalidNamespaceRejects(t *testing.T) {
 	env := setupTestEnv(t)
-	handler := NewMCPHandlers(nil, env.K8sClient)
+	handler := NewMCPHandlers(nil, env.K8sClient, nil)
 	env.App.Get("/api/mcp/pods", handler.GetPods)
 
 	// Namespace with uppercase letters should be rejected
@@ -48,7 +48,7 @@ func TestMCPValidation_InvalidNamespaceRejects(t *testing.T) {
 
 func TestMCPValidation_ValidClusterAccepted(t *testing.T) {
 	env := setupTestEnv(t)
-	handler := NewMCPHandlers(nil, env.K8sClient)
+	handler := NewMCPHandlers(nil, env.K8sClient, nil)
 	env.App.Get("/api/mcp/pods", handler.GetPods)
 
 	// Valid k8s name should work normally
@@ -62,7 +62,7 @@ func TestMCPValidation_ValidClusterAccepted(t *testing.T) {
 
 func TestMCPValidation_EmptyParamsAccepted(t *testing.T) {
 	env := setupTestEnv(t)
-	handler := NewMCPHandlers(nil, env.K8sClient)
+	handler := NewMCPHandlers(nil, env.K8sClient, nil)
 	env.App.Get("/api/mcp/pods", handler.GetPods)
 
 	// No cluster/namespace params (query all) should work
@@ -76,7 +76,7 @@ func TestMCPValidation_EmptyParamsAccepted(t *testing.T) {
 
 func TestMCPValidation_InvalidWorkloadTypeRejects(t *testing.T) {
 	env := setupTestEnv(t)
-	handler := NewMCPHandlers(nil, env.K8sClient)
+	handler := NewMCPHandlers(nil, env.K8sClient, nil)
 	env.App.Get("/api/mcp/workloads", handler.GetWorkloads)
 
 	req, err := http.NewRequest("GET", "/api/mcp/workloads?type=InvalidType", nil)
@@ -93,7 +93,7 @@ func TestMCPValidation_InvalidWorkloadTypeRejects(t *testing.T) {
 
 func TestMCPValidation_ValidWorkloadTypeAccepted(t *testing.T) {
 	env := setupTestEnv(t)
-	handler := NewMCPHandlers(nil, env.K8sClient)
+	handler := NewMCPHandlers(nil, env.K8sClient, nil)
 	env.App.Get("/api/mcp/workloads", handler.GetWorkloads)
 
 	for _, wt := range []string{"", "Deployment", "StatefulSet", "DaemonSet"} {
@@ -113,7 +113,7 @@ func TestMCPValidation_ValidWorkloadTypeAccepted(t *testing.T) {
 
 func TestMCPValidation_InvalidLabelSelectorRejects(t *testing.T) {
 	env := setupTestEnv(t)
-	handler := NewMCPHandlers(nil, env.K8sClient)
+	handler := NewMCPHandlers(nil, env.K8sClient, nil)
 	env.App.Get("/api/mcp/pods", handler.GetPods)
 
 	// Semicolons should be rejected
@@ -131,7 +131,7 @@ func TestMCPValidation_InvalidLabelSelectorRejects(t *testing.T) {
 
 func TestMCPValidation_EventsLimitTooHighRejects(t *testing.T) {
 	env := setupTestEnv(t)
-	handler := NewMCPHandlers(nil, env.K8sClient)
+	handler := NewMCPHandlers(nil, env.K8sClient, nil)
 	env.App.Get("/api/mcp/events", handler.GetEvents)
 
 	req, err := http.NewRequest("GET", "/api/mcp/events?limit=99999", nil)
@@ -148,7 +148,7 @@ func TestMCPValidation_EventsLimitTooHighRejects(t *testing.T) {
 
 func TestMCPValidation_DemoModeBypassesValidation(t *testing.T) {
 	env := setupTestEnv(t)
-	handler := NewMCPHandlers(nil, env.K8sClient)
+	handler := NewMCPHandlers(nil, env.K8sClient, nil)
 	env.App.Get("/api/mcp/pods", handler.GetPods)
 
 	// Even with invalid params, demo mode should succeed (validation runs after demo check)
@@ -167,7 +167,7 @@ func TestMCPValidation_DemoModeBypassesValidation(t *testing.T) {
 
 func TestMCPValidation_ClusterWithDotsAccepted(t *testing.T) {
 	env := setupTestEnv(t)
-	handler := NewMCPHandlers(nil, env.K8sClient)
+	handler := NewMCPHandlers(nil, env.K8sClient, nil)
 	env.App.Get("/api/mcp/nodes", handler.GetNodes)
 
 	// Cluster names with dots (e.g. "api.cluster.example.com") should be valid

--- a/pkg/api/handlers/namespaces.go
+++ b/pkg/api/handlers/namespaces.go
@@ -32,6 +32,12 @@ func NewNamespaceHandler(s store.Store, k8sClient *k8s.MultiClusterClient) *Name
 
 // ListNamespaces returns namespaces for a cluster
 func (h *NamespaceHandler) ListNamespaces(c *fiber.Ctx) error {
+	// SECURITY (#7485): namespace listing exposes cluster structure; require a
+	// valid console role (viewer or above).
+	if err := requireViewerOrAbove(c, h.store); err != nil {
+		return err
+	}
+
 	if h.k8sClient == nil {
 		return fiber.NewError(fiber.StatusServiceUnavailable, "Kubernetes client not available")
 	}

--- a/pkg/api/handlers/pod_logs_test.go
+++ b/pkg/api/handlers/pod_logs_test.go
@@ -21,7 +21,7 @@ const podLogsTestTimeoutMS = 5000
 // visitor opens the site without a real cluster (issue #6045).
 func TestMCPGetPodLogs_DemoModeReturnsDemoData(t *testing.T) {
 	env := setupTestEnv(t)
-	handler := NewMCPHandlers(nil, env.K8sClient)
+	handler := NewMCPHandlers(nil, env.K8sClient, nil)
 	env.App.Get("/api/mcp/pods/logs", handler.GetPodLogs)
 
 	req, err := http.NewRequest("GET", "/api/mcp/pods/logs", nil)
@@ -49,7 +49,7 @@ func TestMCPGetPodLogs_DemoModeReturnsDemoData(t *testing.T) {
 // refuses requests missing any of cluster/namespace/pod.
 func TestMCPGetPodLogs_MissingParamsReturns400(t *testing.T) {
 	env := setupTestEnv(t)
-	handler := NewMCPHandlers(nil, env.K8sClient)
+	handler := NewMCPHandlers(nil, env.K8sClient, nil)
 	env.App.Get("/api/mcp/pods/logs", handler.GetPodLogs)
 
 	req, err := http.NewRequest("GET", "/api/mcp/pods/logs?cluster=test-cluster", nil)
@@ -68,7 +68,7 @@ func TestMCPGetPodLogs_MissingParamsReturns400(t *testing.T) {
 // returns 503 when there is no k8s client at all (degraded mode).
 func TestMCPGetPodLogs_NoClusterAccessReturns503(t *testing.T) {
 	env := setupTestEnv(t)
-	handler := NewMCPHandlers(nil, nil)
+	handler := NewMCPHandlers(nil, nil, nil)
 	env.App.Get("/api/mcp/pods/logs", handler.GetPodLogs)
 
 	req, err := http.NewRequest(
@@ -94,7 +94,7 @@ func TestMCPGetPodLogs_NoClusterAccessReturns503(t *testing.T) {
 // `{logs, source: "k8s"}` so the frontend can parse it.
 func TestMCPGetPodLogs_FakeClientReturnsLogs(t *testing.T) {
 	env := setupTestEnv(t)
-	handler := NewMCPHandlers(nil, env.K8sClient)
+	handler := NewMCPHandlers(nil, env.K8sClient, nil)
 	env.App.Get("/api/mcp/pods/logs", handler.GetPodLogs)
 
 	req, err := http.NewRequest(
@@ -122,7 +122,7 @@ func TestMCPGetPodLogs_FakeClientReturnsLogs(t *testing.T) {
 // ever called.
 func TestMCPGetPodLogs_TailExceedsMaxReturns400(t *testing.T) {
 	env := setupTestEnv(t)
-	handler := NewMCPHandlers(nil, env.K8sClient)
+	handler := NewMCPHandlers(nil, env.K8sClient, nil)
 	env.App.Get("/api/mcp/pods/logs", handler.GetPodLogs)
 
 	// mcpMaxTailLines is 10_000 — request 10x that.

--- a/pkg/api/handlers/rbac.go
+++ b/pkg/api/handlers/rbac.go
@@ -650,6 +650,12 @@ func (h *RBACHandler) GetPermissionsSummary(c *fiber.Ctx) error {
 
 // CheckCanI checks if the current user can perform an action
 func (h *RBACHandler) CheckCanI(c *fiber.Ctx) error {
+	// SECURITY (#7488): permission checks require a valid console role to
+	// prevent unauthenticated probing of backend capabilities.
+	if err := requireViewerOrAbove(c, h.store); err != nil {
+		return err
+	}
+
 	if h.k8sClient == nil {
 		return fiber.NewError(fiber.StatusServiceUnavailable, "Kubernetes client not available")
 	}

--- a/pkg/api/handlers/sse.go
+++ b/pkg/api/handlers/sse.go
@@ -887,6 +887,12 @@ func (h *MCPHandlers) GetConfigMapsStream(c *fiber.Ctx) error {
 
 // GetSecretsStream streams secrets per cluster via SSE.
 func (h *MCPHandlers) GetSecretsStream(c *fiber.Ctx) error {
+	// SECURITY (#7486): secrets stream exposes continuous secret metadata;
+	// require a valid console role (viewer or above).
+	if err := requireViewerOrAbove(c, h.store); err != nil {
+		return err
+	}
+
 	if isDemoMode(c) {
 		return streamDemoSSE(c, "secrets", getDemoSecrets())
 	}

--- a/pkg/api/handlers/sse_test.go
+++ b/pkg/api/handlers/sse_test.go
@@ -74,7 +74,7 @@ func TestGetWarningEventsStream_AppliesClusterFilter(t *testing.T) {
 	injectTypedCluster(env, "cluster-a", seedWarningEvent("from-a", "default"))
 	injectTypedCluster(env, "cluster-b", seedWarningEvent("from-b", "default"))
 
-	handler := NewMCPHandlers(nil, env.K8sClient)
+	handler := NewMCPHandlers(nil, env.K8sClient, nil)
 	env.App.Get("/api/mcp/events/warnings/stream", handler.GetWarningEventsStream)
 
 	req, err := http.NewRequest(http.MethodGet, "/api/mcp/events/warnings/stream?cluster=cluster-a", nil)
@@ -97,7 +97,7 @@ func TestGetWarningEventsStream_UnknownClusterReturns404(t *testing.T) {
 	env := setupTestEnv(t)
 	injectTypedCluster(env, "cluster-a")
 
-	handler := NewMCPHandlers(nil, env.K8sClient)
+	handler := NewMCPHandlers(nil, env.K8sClient, nil)
 	env.App.Get("/api/mcp/events/warnings/stream", handler.GetWarningEventsStream)
 
 	req, err := http.NewRequest(http.MethodGet, "/api/mcp/events/warnings/stream?cluster=does-not-exist", nil)
@@ -149,7 +149,7 @@ func TestStreamClusters_EmitsClusterErrorOnFailure(t *testing.T) {
 		return true, nil, errors.New("forced list error")
 	})
 
-	handler := NewMCPHandlers(nil, env.K8sClient)
+	handler := NewMCPHandlers(nil, env.K8sClient, nil)
 	env.App.Get("/api/mcp/events/warnings/stream", handler.GetWarningEventsStream)
 
 	req, err := http.NewRequest(http.MethodGet, "/api/mcp/events/warnings/stream", nil)

--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -726,7 +726,7 @@ func (s *Server) setupRoutes() {
 	s.app.Get("/api/ping", publicLimiter, handlers.PingHandler)
 
 	// MCP handlers (used in protected routes below)
-	mcpHandlers := handlers.NewMCPHandlers(s.bridge, s.k8sClient)
+	mcpHandlers := handlers.NewMCPHandlers(s.bridge, s.k8sClient, s.store)
 	// SECURITY FIX: All MCP routes are now protected regardless of dev mode
 	// Dev mode only affects things like frontend URLs and default users,
 	// NOT authentication requirements


### PR DESCRIPTION
## Summary
- Adds `store.Store` to `MCPHandlers` so console-level RBAC (admin/editor/viewer) can be enforced on MCP endpoints
- Mutating endpoints (GPU CronJob install/uninstall, ResourceQuota create/update/delete, tool calls) now require **editor or admin** role
- Sensitive read endpoints (namespace list, secrets stream, custom resources, can-i) now require **viewer or above** role
- Tests updated to pass the new `store` parameter (nil = dev/demo mode, role check skipped)

## Issues fixed
Closes #7485, #7486, #7487, #7488, #7490, #7491, #7492, #7493, #7494, #7495

## Test plan
- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] `npm run build` passes
- [ ] Verify unauthenticated requests still return 401
- [ ] Verify viewer-role users can access read endpoints but not mutating ones
- [ ] Verify editor/admin-role users can access mutating endpoints