### PR TITLE
fix: resolve endpoint stats, ingress display, and settings import defaults

### DIFF
--- a/pkg/settings/manager.go
+++ b/pkg/settings/manager.go
@@ -459,7 +459,8 @@ func (sm *SettingsManager) ImportEncrypted(data []byte) error {
 	}
 
 	// Import plaintext settings, then merge defaults for any missing nested
-	// values so that an incomplete import doesn't zero-out intended defaults (#7372).
+	// values so that an incomplete import doesn't zero-out intended defaults
+	// (#7372, #7501).
 	sm.settings.Settings = imported.Settings
 	defaults := DefaultSettings()
 	if sm.settings.Settings.AIMode == "" {
@@ -470,6 +471,47 @@ func (sm *SettingsManager) ImportEncrypted(data []byte) error {
 	}
 	if sm.settings.Settings.Widget.SelectedWidget == "" {
 		sm.settings.Settings.Widget.SelectedWidget = defaults.Settings.Widget.SelectedWidget
+	}
+
+	// Merge nested Prediction defaults when the imported file omits them (#7501)
+	dp := defaults.Settings.Predictions
+	p := &sm.settings.Settings.Predictions
+	if p.Interval == 0 {
+		p.Interval = dp.Interval
+	}
+	if p.MinConfidence == 0 {
+		p.MinConfidence = dp.MinConfidence
+	}
+	if p.MaxPredictions == 0 {
+		p.MaxPredictions = dp.MaxPredictions
+	}
+	if p.Thresholds.HighRestartCount == 0 {
+		p.Thresholds.HighRestartCount = dp.Thresholds.HighRestartCount
+	}
+	if p.Thresholds.CPUPressure == 0 {
+		p.Thresholds.CPUPressure = dp.Thresholds.CPUPressure
+	}
+	if p.Thresholds.MemoryPressure == 0 {
+		p.Thresholds.MemoryPressure = dp.Thresholds.MemoryPressure
+	}
+	if p.Thresholds.GPUMemoryPressure == 0 {
+		p.Thresholds.GPUMemoryPressure = dp.Thresholds.GPUMemoryPressure
+	}
+
+	// Merge nested TokenUsage defaults when the imported file omits them (#7501)
+	dt := defaults.Settings.TokenUsage
+	t := &sm.settings.Settings.TokenUsage
+	if t.Limit == 0 {
+		t.Limit = dt.Limit
+	}
+	if t.WarningThreshold == 0 {
+		t.WarningThreshold = dt.WarningThreshold
+	}
+	if t.CriticalThreshold == 0 {
+		t.CriticalThreshold = dt.CriticalThreshold
+	}
+	if t.StopThreshold == 0 {
+		t.StopThreshold = dt.StopThreshold
 	}
 
 	// Import encrypted fields only if the key fingerprint matches

--- a/web/src/components/network/Network.tsx
+++ b/web/src/components/network/Network.tsx
@@ -1,5 +1,6 @@
 import { AlertCircle } from 'lucide-react'
 import { useServices } from '../../hooks/useMCP'
+import { useIngresses } from '../../hooks/mcp/networking'
 import { useUniversalStats, createMergedStatValueGetter } from '../../hooks/useUniversalStats'
 import { useGlobalFilters } from '../../hooks/useGlobalFilters'
 import { useDrillDownActions } from '../../hooks/useDrillDown'
@@ -16,6 +17,7 @@ const DEFAULT_NETWORK_CARDS = getDefaultCards('network')
 
 export function Network() {
   const { services, isLoading: servicesLoading, isRefreshing: servicesRefreshing, lastUpdated, refetch, error } = useServices()
+  const { ingresses } = useIngresses()
 
   const {
     selectedClusters: globalSelectedClusters,
@@ -27,6 +29,11 @@ export function Network() {
   // Filter services based on global cluster selection
   const filteredServices = services.filter(s =>
     isAllClustersSelected || (s.cluster && globalSelectedClusters.includes(s.cluster))
+  )
+
+  // Filter ingresses based on global cluster selection (#7518)
+  const filteredIngresses = (ingresses || []).filter(i =>
+    isAllClustersSelected || (i.cluster && globalSelectedClusters.includes(i.cluster))
   )
 
   // Calculate service stats
@@ -73,7 +80,7 @@ export function Network() {
       case 'clusterip':
         return { value: clusterIPServices, sublabel: 'internal only', onClick: drillToClusterIP, isClickable: clusterIPServices > 0 }
       case 'ingresses':
-        return { value: '-', sublabel: 'ingresses', isClickable: false }
+        return { value: filteredIngresses.length, sublabel: 'ingresses', isClickable: false }
       case 'endpoints': {
         // Sum actual ready endpoints across services (#7126) — not just service count
         const totalEndpoints = filteredServices.reduce(

--- a/web/src/components/services/Services.tsx
+++ b/web/src/components/services/Services.tsx
@@ -1,6 +1,7 @@
 import { AlertCircle, Server } from 'lucide-react'
 import { useNavigate } from 'react-router-dom'
 import { useClusters, useServices } from '../../hooks/useMCP'
+import { useIngresses } from '../../hooks/mcp/networking'
 import { ROUTES } from '../../config/routes'
 import { useGlobalFilters } from '../../hooks/useGlobalFilters'
 import { useDrillDownActions } from '../../hooks/useDrillDown'
@@ -19,6 +20,7 @@ export function Services() {
   const navigate = useNavigate()
   const { clusters, isLoading, isRefreshing: dataRefreshing, lastUpdated, refetch, error: clustersError } = useClusters()
   const { services, error: servicesError } = useServices()
+  const { ingresses } = useIngresses()
   const error = clustersError || servicesError
 
   const { drillToAllServices, drillToAllClusters } = useDrillDownActions()
@@ -66,8 +68,13 @@ export function Services() {
         return { value: nodePortServices, sublabel: 'NodePort', onClick: () => drillToAllServices('nodeport'), isClickable: nodePortServices > 0 }
       case 'clusterip':
         return { value: clusterIPServices, sublabel: 'ClusterIP', onClick: () => drillToAllServices('clusterip'), isClickable: clusterIPServices > 0 }
-      case 'ingresses':
-        return { value: 0, sublabel: 'ingresses', isClickable: false }
+      case 'ingresses': {
+        // Show actual ingress count instead of hardcoded 0 (#7517)
+        const allIngresses = (ingresses || []).filter(i =>
+          isAllClustersSelected || globalSelectedClusters.includes(i.cluster || '')
+        )
+        return { value: allIngresses.length, sublabel: 'ingresses', isClickable: false }
+      }
       case 'endpoints':
         return { value: totalEndpoints, sublabel: 'endpoints', onClick: () => drillToAllServices(), isClickable: totalEndpoints > 0 }
       default:

--- a/web/src/config/cards/ingress-status.ts
+++ b/web/src/config/cards/ingress-status.ts
@@ -30,7 +30,7 @@ export const ingressStatusConfig: UnifiedCardConfig = {
       field: 'search',
       type: 'text',
       placeholder: 'Search ingresses...',
-      searchFields: ['name', 'namespace', 'cluster', 'host'],
+      searchFields: ['name', 'namespace', 'cluster', 'hosts'],
       storageKey: 'ingress-status',
     },
     {
@@ -65,7 +65,7 @@ export const ingressStatusConfig: UnifiedCardConfig = {
         render: 'truncate',
       },
       {
-        field: 'host',
+        field: 'hosts',
         header: 'Host',
         render: 'text',
         width: 150,

--- a/web/src/hooks/useUniversalStats.ts
+++ b/web/src/hooks/useUniversalStats.ts
@@ -11,6 +11,7 @@ import {
   useOperatorSubscriptions,
   useOperators,
   useGPUNodes } from './useMCP'
+import { useIngresses } from './mcp/networking'
 import { useCachedPVCs } from './useCachedData'
 import { useAlerts, useAlertRules } from './useAlerts'
 import { StatBlockValue } from '../components/ui/StatsOverview'
@@ -55,6 +56,7 @@ export function useUniversalStats() {
   const { subscriptions: operatorSubscriptions } = useOperatorSubscriptions()
   const { operators } = useOperators()
   const { nodes: gpuNodes } = useGPUNodes()
+  const { ingresses } = useIngresses()
   const { stats: alertStats } = useAlerts()
   const { rules: alertRules } = useAlertRules()
 
@@ -226,10 +228,17 @@ export function useUniversalStats() {
         return { value: npCount, sublabel: 'node-level access', onClick: () => drillToAllServices('NodePort'), isClickable: npCount > 0 }
       case 'clusterip':
         return { value: cipCount, sublabel: 'internal only', onClick: () => drillToAllServices('ClusterIP'), isClickable: cipCount > 0 }
-      case 'ingresses':
-        return { value: '-', sublabel: 'ingresses', isClickable: false }
-      case 'endpoints':
-        return { value: allServices.length, sublabel: 'endpoints', isClickable: false }
+      case 'ingresses': {
+        const allIngresses = ingresses || []
+        return { value: allIngresses.length, sublabel: 'ingresses', isClickable: false }
+      }
+      case 'endpoints': {
+        // Sum actual ready endpoints across services (#7514) — not service count
+        const totalEndpoints = allServices.reduce(
+          (sum, s) => sum + (s.endpoints ?? 0), 0
+        )
+        return { value: totalEndpoints, sublabel: 'endpoints', isClickable: false }
+      }
 
       // ══════════════════════════════════════════
       // Security stats


### PR DESCRIPTION
## Summary
- **#7501**: `ImportEncrypted` now merges all nested Prediction and TokenUsage defaults (thresholds, intervals, limits) instead of only AIMode/Theme/Widget
- **#7514/#7515/#7516**: Endpoints stat sums actual ready endpoint addresses instead of counting services
- **#7517/#7518**: Ingress stat on Network and Services dashboards uses real `useIngresses` data instead of hardcoded 0/'-'
- **#7519**: Ingress Status card host column reads `hosts[]` array field and search includes it

## Test plan
- [ ] Verify `go build ./...` and `go vet ./...` pass
- [ ] Verify `npm run build` passes
- [ ] Import a settings backup with missing prediction fields and confirm defaults are restored
- [ ] Check Network dashboard Endpoints stat reflects actual pod-backed endpoints
- [ ] Check Network/Services dashboard Ingress stat reflects real ingress count
- [ ] Check Ingress Status card shows host values and search by host works