### PR TITLE
fix: notification subsystem hardening (7534-7537)

### DIFF
--- a/pkg/notifications/email.go
+++ b/pkg/notifications/email.go
@@ -155,11 +155,27 @@ func (e *EmailNotifier) Test() error {
 	return e.Send(testAlert)
 }
 
-// buildMessage constructs the full email message with headers
+// sanitizeHeaderValue strips CR/LF characters from a value destined for an
+// SMTP header. Without this, attacker-controlled content in From, To, or
+// Subject could inject additional headers or alter message structure (#7535).
+func sanitizeHeaderValue(v string) string {
+	r := strings.NewReplacer("\r", "", "\n", "")
+	return r.Replace(v)
+}
+
+// buildMessage constructs the full email message with headers.
+// All dynamic values are sanitized to prevent header injection (#7535).
 func (e *EmailNotifier) buildMessage(subject, body string) string {
-	msg := fmt.Sprintf("From: %s\r\n", e.From)
-	msg += fmt.Sprintf("To: %s\r\n", strings.Join(e.To, ", "))
-	msg += fmt.Sprintf("Subject: %s\r\n", subject)
+	safeFrom := sanitizeHeaderValue(e.From)
+	safeTo := make([]string, len(e.To))
+	for i, addr := range e.To {
+		safeTo[i] = sanitizeHeaderValue(addr)
+	}
+	safeSubject := sanitizeHeaderValue(subject)
+
+	msg := fmt.Sprintf("From: %s\r\n", safeFrom)
+	msg += fmt.Sprintf("To: %s\r\n", strings.Join(safeTo, ", "))
+	msg += fmt.Sprintf("Subject: %s\r\n", safeSubject)
 	msg += "MIME-Version: 1.0\r\n"
 	msg += "Content-Type: text/html; charset=UTF-8\r\n"
 	msg += "\r\n"

--- a/pkg/notifications/opsgenie.go
+++ b/pkg/notifications/opsgenie.go
@@ -48,7 +48,13 @@ func (o *OpsGenieNotifier) Send(alert Alert) error {
 		return fmt.Errorf("opsgenie API key not configured")
 	}
 
+	// Build a dedup alias that includes the alert ID when RuleID or Cluster
+	// is empty, preventing unrelated alerts from sharing the same alias and
+	// causing incorrect deduplication or resolving the wrong incident (#7536).
 	alias := alert.RuleID + "::" + alert.Cluster
+	if alert.RuleID == "" || alert.Cluster == "" {
+		alias = alert.ID + "::" + alert.RuleID + "::" + alert.Cluster
+	}
 
 	if alert.Status == "resolved" {
 		return o.closeAlert(alias)

--- a/pkg/notifications/service.go
+++ b/pkg/notifications/service.go
@@ -76,9 +76,18 @@ func (s *Service) RegisterOpsGenieNotifier(id, apiKey string) {
 	}
 }
 
-// RegisterEmailNotifier registers an email notifier
+// RegisterEmailNotifier registers an email notifier.
+// The SMTP port is validated against [minSMTPPort, maxSMTPPort] to catch
+// misconfiguration at registration time rather than deferring failure
+// until send time (#7537).
 func (s *Service) RegisterEmailNotifier(id, smtpHost string, smtpPort int, username, password, from, to string) {
 	if smtpHost != "" && from != "" && to != "" {
+		if smtpPort < minSMTPPort || smtpPort > maxSMTPPort {
+			slog.Warn("email notifier not registered: invalid SMTP port",
+				"id", id, "port", smtpPort,
+				"validRange", fmt.Sprintf("%d-%d", minSMTPPort, maxSMTPPort))
+			return
+		}
 		recipients := splitAndCleanRecipients(to)
 		if len(recipients) == 0 {
 			slog.Warn("email notifier not registered: no valid recipients after trimming", "id", id)

--- a/pkg/notifications/types.go
+++ b/pkg/notifications/types.go
@@ -56,8 +56,8 @@ type NotificationConfig struct {
 	EmailUsername   string `json:"emailUsername,omitempty"`
 	EmailPassword   string `json:"emailPassword,omitempty"`
 	WebhookURL          string `json:"webhookUrl,omitempty"`
-	PagerDutyRoutingKey string `json:"pagerDutyRoutingKey,omitempty"`
-	OpsGenieAPIKey      string `json:"opsGenieApiKey,omitempty"`
+	PagerDutyRoutingKey string `json:"pagerdutyRoutingKey,omitempty"`
+	OpsGenieAPIKey      string `json:"opsgenieApiKey,omitempty"`
 }
 
 // Notifier is the interface for sending notifications


### PR DESCRIPTION
## Summary
- **#7537**: `RegisterEmailNotifier` now validates SMTP port against `[1, 65535]` at registration time, matching the validation already in `parseSMTPPortConfig`
- **#7536**: OpsGenie alias includes alert ID as fallback when RuleID or Cluster is empty, preventing alias collisions (mirrors PagerDuty's existing logic)
- **#7535**: `buildMessage` sanitizes From/To/Subject by stripping CR/LF to prevent SMTP header injection
- **#7534**: `NotificationConfig` JSON tags changed from `pagerDutyRoutingKey`/`opsGenieApiKey` to `pagerdutyRoutingKey`/`opsgenieApiKey` to match frontend and service.go usage

Closes #7534, closes #7535, closes #7536, closes #7537

## Test plan
- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] `go test ./pkg/notifications/... -race` passes
- [x] `npm run build` passes (frontend unaffected)