### PR TITLE
fix: marketplace state sync, operator error surfacing, frontend globals (#7539-#7554)

### DIFF
--- a/pkg/api/handlers/gitops.go
+++ b/pkg/api/handlers/gitops.go
@@ -493,7 +493,10 @@ type OperatorSubscription struct {
 	InstallPlanApproval string `json:"installPlanApproval"`
 	CurrentCSV          string `json:"currentCSV"`
 	InstalledCSV        string `json:"installedCSV,omitempty"`
-	Cluster             string `json:"cluster,omitempty"`
+	// PendingUpgrade is set when installedCSV differs from currentCSV,
+	// indicating an upgrade is waiting for approval (#7548).
+	PendingUpgrade string `json:"pendingUpgrade,omitempty"`
+	Cluster        string `json:"cluster,omitempty"`
 }
 
 // Operator/subscription timeouts — CSV queries take 90-100s for clusters with
@@ -510,6 +513,11 @@ const (
 	gitopsLookupTimeout           = 10 * time.Second
 	gitopsDefaultTimeout          = 30 * time.Second
 )
+
+// operatorCacheEmptyTTL is a shorter cache TTL used for empty results from
+// permanent errors (e.g. "no OLM"). This ensures that after installing OLM
+// the operators appear within 30s instead of waiting the full 5-minute TTL (#7549).
+const operatorCacheEmptyTTL = 30 * time.Second
 
 // operatorCacheEntry holds cached operators for a single cluster.
 type operatorCacheEntry struct {
@@ -533,8 +541,12 @@ func (h *GitOpsHandlers) ListOperators(c *fiber.Ctx) error {
 	if cluster != "" {
 		ctx, cancel := context.WithTimeout(c.Context(), operatorPerClusterTimeout)
 		defer cancel()
-		operators := h.getOperatorsForCluster(ctx, cluster)
-		return c.JSON(fiber.Map{"operators": operators})
+		operators, fetchErr := h.getOperatorsForClusterWithError(ctx, cluster)
+		resp := fiber.Map{"operators": operators}
+		if fetchErr != nil {
+			resp["clusterErrors"] = []string{fmt.Sprintf("%s: %v", cluster, fetchErr)}
+		}
+		return c.JSON(resp)
 	}
 
 	// Query all clusters in parallel — operators are slow, so we wait for all
@@ -549,6 +561,9 @@ func (h *GitOpsHandlers) ListOperators(c *fiber.Ctx) error {
 		var wg sync.WaitGroup
 		var mu sync.Mutex
 		allOperators := make([]Operator, 0)
+		// #7544: Surface per-cluster errors so the frontend can indicate
+		// which clusters failed rather than showing a silent empty state.
+		var clusterErrors []string
 
 		overallCtx, overallCancel := context.WithTimeout(c.Context(), operatorRestOverallTimeout)
 		defer overallCancel()
@@ -562,17 +577,24 @@ func (h *GitOpsHandlers) ListOperators(c *fiber.Ctx) error {
 				ctx, cancel := context.WithTimeout(overallCtx, operatorPerClusterTimeout)
 				defer cancel()
 
-				operators := h.getOperatorsForCluster(ctx, clusterName)
-				if len(operators) > 0 {
-					mu.Lock()
-					allOperators = append(allOperators, operators...)
-					mu.Unlock()
+				operators, fetchErr := h.getOperatorsForClusterWithError(ctx, clusterName)
+				mu.Lock()
+				if fetchErr != nil {
+					clusterErrors = append(clusterErrors, fmt.Sprintf("%s: %v", clusterName, fetchErr))
 				}
+				if len(operators) > 0 {
+					allOperators = append(allOperators, operators...)
+				}
+				mu.Unlock()
 			}(cl.Name)
 		}
 
 		wg.Wait()
-		return c.JSON(fiber.Map{"operators": allOperators})
+		resp := fiber.Map{"operators": allOperators}
+		if len(clusterErrors) > 0 {
+			resp["clusterErrors"] = clusterErrors
+		}
+		return c.JSON(resp)
 	}
 
 	// Fallback to default context
@@ -642,16 +664,23 @@ func (h *GitOpsHandlers) StreamOperators(c *fiber.Ctx) error {
 				ctx, cancel := context.WithTimeout(context.Background(), operatorPerClusterTimeout)
 				defer cancel()
 
-				operators := h.getOperatorsForCluster(ctx, clusterName)
+				operators, fetchErr := h.getOperatorsForClusterWithError(ctx, clusterName)
 				mu.Lock()
 				completedClusters++
-				// Always send cluster_data — even for empty clusters so the
-				// frontend sees progress and knows the stream is alive.
-				writeSSEEvent(w, "cluster_data", fiber.Map{
-					"cluster":   clusterName,
-					"operators": operators,
-					"source":    "k8s",
-				})
+				// #7546: Emit cluster_error when a fetch fails so the frontend
+				// can distinguish "no operators" from "query failed".
+				if fetchErr != nil {
+					writeSSEEvent(w, sseEventClusterError, fiber.Map{
+						"cluster": clusterName,
+						"error":   fetchErr.Error(),
+					})
+				} else {
+					writeSSEEvent(w, "cluster_data", fiber.Map{
+						"cluster":   clusterName,
+						"operators": operators,
+						"source":    "k8s",
+					})
+				}
 				mu.Unlock()
 			}(cl.Name)
 		}
@@ -675,19 +704,26 @@ func (h *GitOpsHandlers) getOperatorsForCluster(ctx context.Context, cluster str
 		cacheKey = "__default__"
 	}
 
-	// Check cache first
+	// Check cache first. Use shorter TTL for empty results so that newly
+	// installed OLM operators appear quickly (#7549, #7550).
 	operatorCacheMu.RLock()
-	if entry, ok := operatorCacheData[cacheKey]; ok && time.Since(entry.fetchedAt) < operatorCacheTTL {
-		operators := entry.operators
-		operatorCacheMu.RUnlock()
-		return operators
+	if entry, ok := operatorCacheData[cacheKey]; ok {
+		ttl := operatorCacheTTL
+		if len(entry.operators) == 0 {
+			ttl = operatorCacheEmptyTTL
+		}
+		if time.Since(entry.fetchedAt) < ttl {
+			operators := entry.operators
+			operatorCacheMu.RUnlock()
+			return operators
+		}
 	}
 	operatorCacheMu.RUnlock()
 
 	// Cache miss — fetch from cluster with retry for transient errors
 	operators, err := h.fetchOperatorsFromCluster(ctx, cluster)
 	if err != nil {
-		// Permanent errors (cluster lacks OLM) — cache empty result
+		// Permanent errors (cluster lacks OLM) — cache empty result with short TTL
 		if _, ok := err.(errPermanent); ok {
 			operatorCacheMu.Lock()
 			operatorCacheData[cacheKey] = &operatorCacheEntry{
@@ -719,6 +755,53 @@ func (h *GitOpsHandlers) getOperatorsForCluster(ctx context.Context, cluster str
 	operatorCacheMu.Unlock()
 
 	return operators
+}
+
+// getOperatorsForClusterWithError returns operators plus any fetch error so
+// callers can surface per-cluster failures (#7544, #7546).
+func (h *GitOpsHandlers) getOperatorsForClusterWithError(ctx context.Context, cluster string) ([]Operator, error) {
+	cacheKey := cluster
+	if cacheKey == "" {
+		cacheKey = "__default__"
+	}
+
+	operatorCacheMu.RLock()
+	if entry, ok := operatorCacheData[cacheKey]; ok {
+		ttl := operatorCacheTTL
+		if len(entry.operators) == 0 {
+			ttl = operatorCacheEmptyTTL
+		}
+		if time.Since(entry.fetchedAt) < ttl {
+			operators := entry.operators
+			operatorCacheMu.RUnlock()
+			return operators, nil
+		}
+	}
+	operatorCacheMu.RUnlock()
+
+	operators, err := h.fetchOperatorsFromCluster(ctx, cluster)
+	if err != nil {
+		if _, ok := err.(errPermanent); ok {
+			operatorCacheMu.Lock()
+			operatorCacheData[cacheKey] = &operatorCacheEntry{operators: []Operator{}, fetchedAt: time.Now()}
+			operatorCacheMu.Unlock()
+			// Permanent (no OLM) is not a user-visible error
+			return []Operator{}, nil
+		}
+		if ctx.Err() == nil {
+			slog.Error("[GitOps] retrying operator fetch after transient error", "cluster", cluster)
+			time.Sleep(gitopsRetryDelay)
+			operators, err = h.fetchOperatorsFromCluster(ctx, cluster)
+		}
+	}
+	if err != nil {
+		return []Operator{}, err
+	}
+
+	operatorCacheMu.Lock()
+	operatorCacheData[cacheKey] = &operatorCacheEntry{operators: operators, fetchedAt: time.Now()}
+	operatorCacheMu.Unlock()
+	return operators, nil
 }
 
 // errPermanent wraps an error to indicate it should be cached (e.g., cluster lacks OLM).
@@ -800,8 +883,12 @@ func (h *GitOpsHandlers) ListOperatorSubscriptions(c *fiber.Ctx) error {
 	if cluster != "" {
 		ctx, cancel := context.WithTimeout(c.Context(), subscriptionPerClusterTimeout)
 		defer cancel()
-		subs := h.getSubscriptionsForCluster(ctx, cluster)
-		return c.JSON(fiber.Map{"subscriptions": subs})
+		subs, fetchErr := h.getSubscriptionsForClusterWithError(ctx, cluster)
+		resp := fiber.Map{"subscriptions": subs}
+		if fetchErr != nil {
+			resp["clusterErrors"] = []string{fmt.Sprintf("%s: %v", cluster, fetchErr)}
+		}
+		return c.JSON(resp)
 	}
 
 	if h.k8sClient != nil {
@@ -814,6 +901,9 @@ func (h *GitOpsHandlers) ListOperatorSubscriptions(c *fiber.Ctx) error {
 		var wg sync.WaitGroup
 		var mu sync.Mutex
 		allSubs := make([]OperatorSubscription, 0)
+		// #7545: Surface per-cluster errors so the frontend can indicate
+		// which clusters failed rather than showing a silent empty state.
+		var clusterErrors []string
 
 		for _, cl := range clusters {
 			wg.Add(1)
@@ -824,17 +914,24 @@ func (h *GitOpsHandlers) ListOperatorSubscriptions(c *fiber.Ctx) error {
 				ctx, cancel := context.WithTimeout(c.Context(), subscriptionPerClusterTimeout)
 				defer cancel()
 
-				subs := h.getSubscriptionsForCluster(ctx, clusterName)
-				if len(subs) > 0 {
-					mu.Lock()
-					allSubs = append(allSubs, subs...)
-					mu.Unlock()
+				subs, fetchErr := h.getSubscriptionsForClusterWithError(ctx, clusterName)
+				mu.Lock()
+				if fetchErr != nil {
+					clusterErrors = append(clusterErrors, fmt.Sprintf("%s: %v", clusterName, fetchErr))
 				}
+				if len(subs) > 0 {
+					allSubs = append(allSubs, subs...)
+				}
+				mu.Unlock()
 			}(cl.Name)
 		}
 
 		wg.Wait()
-		return c.JSON(fiber.Map{"subscriptions": allSubs})
+		resp := fiber.Map{"subscriptions": allSubs}
+		if len(clusterErrors) > 0 {
+			resp["clusterErrors"] = clusterErrors
+		}
+		return c.JSON(resp)
 	}
 
 	ctx, cancel := context.WithTimeout(c.Context(), subscriptionPerClusterTimeout)
@@ -902,14 +999,23 @@ func (h *GitOpsHandlers) StreamOperatorSubscriptions(c *fiber.Ctx) error {
 				ctx, cancel := context.WithTimeout(context.Background(), subscriptionPerClusterTimeout)
 				defer cancel()
 
-				subs := h.getSubscriptionsForCluster(ctx, clusterName)
+				subs, fetchErr := h.getSubscriptionsForClusterWithError(ctx, clusterName)
 				mu.Lock()
 				completedClusters++
-				writeSSEEvent(w, "cluster_data", fiber.Map{
-					"cluster":       clusterName,
-					"subscriptions": subs,
-					"source":        "k8s",
-				})
+				// #7546: Emit cluster_error when a fetch fails so the frontend
+				// can distinguish "no subscriptions" from "query failed".
+				if fetchErr != nil {
+					writeSSEEvent(w, sseEventClusterError, fiber.Map{
+						"cluster": clusterName,
+						"error":   fetchErr.Error(),
+					})
+				} else {
+					writeSSEEvent(w, "cluster_data", fiber.Map{
+						"cluster":       clusterName,
+						"subscriptions": subs,
+						"source":        "k8s",
+					})
+				}
 				mu.Unlock()
 			}(cl.Name)
 		}
@@ -924,8 +1030,25 @@ func (h *GitOpsHandlers) StreamOperatorSubscriptions(c *fiber.Ctx) error {
 	return nil
 }
 
+// getSubscriptionsForClusterWithError wraps getSubscriptionsForCluster and
+// surfaces the fetch error so callers can report per-cluster failures (#7545).
+func (h *GitOpsHandlers) getSubscriptionsForClusterWithError(ctx context.Context, cluster string) ([]OperatorSubscription, error) {
+	subs, err := h.fetchSubscriptionsFromCluster(ctx, cluster)
+	if err != nil {
+		return []OperatorSubscription{}, err
+	}
+	return subs, nil
+}
+
 // getSubscriptionsForCluster gets OLM subscriptions for a specific cluster using jsonpath
 func (h *GitOpsHandlers) getSubscriptionsForCluster(ctx context.Context, cluster string) []OperatorSubscription {
+	subs, _ := h.fetchSubscriptionsFromCluster(ctx, cluster)
+	return subs
+}
+
+// fetchSubscriptionsFromCluster is the underlying implementation that returns
+// both the subscription list and any error encountered.
+func (h *GitOpsHandlers) fetchSubscriptionsFromCluster(ctx context.Context, cluster string) ([]OperatorSubscription, error) {
 	jsonpathExpr := `{range .items[*]}{.metadata.name}{"\t"}{.metadata.namespace}{"\t"}{.spec.channel}{"\t"}{.spec.source}{"\t"}{.spec.installPlanApproval}{"\t"}{.status.currentCSV}{"\t"}{.status.installedCSV}{"\n"}{end}`
 	args := []string{"get", "subscriptions.operators.coreos.com", "-A", "-o", "jsonpath=" + jsonpathExpr}
 	if cluster != "" {
@@ -941,12 +1064,12 @@ func (h *GitOpsHandlers) getSubscriptionsForCluster(ctx context.Context, cluster
 		if ctx.Err() == nil {
 			slog.Error("[GitOps] kubectl get subscriptions failed", "cluster", cluster, "error", err)
 		}
-		return []OperatorSubscription{}
+		return []OperatorSubscription{}, err
 	}
 
 	output := strings.TrimSpace(stdout.String())
 	if output == "" {
-		return []OperatorSubscription{}
+		return []OperatorSubscription{}, nil
 	}
 
 	lines := strings.Split(output, "\n")
@@ -971,11 +1094,16 @@ func (h *GitOpsHandlers) getSubscriptionsForCluster(ctx context.Context, cluster
 		}
 		if len(fields) > 6 {
 			sub.InstalledCSV = fields[6]
+			// #7548: When installedCSV lags behind currentCSV, there is a
+			// pending upgrade waiting for approval (Manual installPlanApproval).
+			if sub.InstalledCSV != "" && sub.InstalledCSV != sub.CurrentCSV {
+				sub.PendingUpgrade = sub.CurrentCSV
+			}
 		}
 		subs = append(subs, sub)
 	}
 
-	return subs
+	return subs, nil
 }
 
 // StreamHelmReleases streams helm releases per cluster via SSE

--- a/web/src/hooks/mcp/operators.ts
+++ b/web/src/hooks/mcp/operators.ts
@@ -199,9 +199,12 @@ export function useOperators(cluster?: string) {
           setConsecutiveFailures(0)
           setLastRefresh(Date.now())
         }
-      } catch {
+      } catch (err) {
         if (!controller.signal.aborted) {
-          setError(null)
+          // #7547: Surface the error message so the UI can show it instead
+          // of silently displaying an empty state.
+          const msg = err instanceof Error ? err.message : 'Failed to fetch operators'
+          setError(msg)
           setConsecutiveFailures(prev => prev + 1)
         }
       }
@@ -357,9 +360,12 @@ export function useOperatorSubscriptions(cluster?: string) {
           setConsecutiveFailures(0)
           setLastRefresh(Date.now())
         }
-      } catch {
+      } catch (err) {
         if (!controller.signal.aborted) {
-          setError(null)
+          // #7547: Surface the error message so the UI can show it instead
+          // of silently displaying an empty state.
+          const msg = err instanceof Error ? err.message : 'Failed to fetch subscriptions'
+          setError(msg)
           setConsecutiveFailures(prev => prev + 1)
         }
       }

--- a/web/src/hooks/useMarketplace.ts
+++ b/web/src/hooks/useMarketplace.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback, useRef, useMemo } from 'react'
+import { useState, useEffect, useCallback, useRef, useMemo, useSyncExternalStore } from 'react'
 import { api } from '../lib/api'
 import { addCustomTheme, removeCustomTheme } from '../lib/themes'
 import { emitMarketplaceInstall, emitMarketplaceRemove, emitMarketplaceInstallFailed } from '../lib/analytics'
@@ -142,6 +142,32 @@ function saveInstalled(map: InstalledMap): void {
   }
 }
 
+// ── Cross-tab sync (#7542) ────────────────────────────────────────────
+// Listeners are notified whenever the installed-items map changes so that
+// other browser tabs (or multiple useMarketplace mounts) stay in sync.
+let installedSnapshot = loadInstalled()
+const installedListeners = new Set<() => void>()
+
+function subscribeInstalled(cb: () => void) {
+  installedListeners.add(cb)
+  return () => { installedListeners.delete(cb) }
+}
+
+function getInstalledSnapshot(): InstalledMap { return installedSnapshot }
+const emptyInstalledMap: InstalledMap = {}
+
+function notifyInstalledChange() {
+  installedSnapshot = loadInstalled()
+  installedListeners.forEach(cb => cb())
+}
+
+// Listen for cross-tab localStorage changes (#7542)
+if (typeof window !== 'undefined') {
+  window.addEventListener('storage', (e) => {
+    if (e.key === INSTALLED_KEY) notifyInstalledChange()
+  })
+}
+
 export interface InstallResult {
   type: MarketplaceItemType
   data?: unknown
@@ -155,7 +181,8 @@ export function useMarketplace() {
   const [selectedTag, setSelectedTag] = useState<string | null>(null)
   const [selectedType, setSelectedType] = useState<MarketplaceItemType | null>(null)
   const [showHelpWanted, setShowHelpWanted] = useState(false)
-  const [installedItems, setInstalledItems] = useState<InstalledMap>(loadInstalled)
+  // Use cross-tab-aware external store for installed items (#7542)
+  const installedItems: InstalledMap = useSyncExternalStore(subscribeInstalled, getInstalledSnapshot, () => emptyInstalledMap)
 
   const fetchRegistry = useCallback(async (skipCache = false) => {
     setIsLoading(true)
@@ -199,32 +226,65 @@ export function useMarketplace() {
         // Cache write failed — non-critical
       }
     } catch (err) {
-      setError(err instanceof Error ? err.message : 'Failed to load marketplace')
-      setItems([])
+      // #7543: On fetch failure, keep cached/current items with a stale indicator
+      // instead of clearing to empty which falsely implies no items exist.
+      const staleMsg = err instanceof Error ? err.message : 'Failed to load marketplace'
+      setError(staleMsg)
+      // Only fall back to empty if we truly have nothing to show
+      if (items.length === 0) {
+        try {
+          const cached = localStorage.getItem(CACHE_KEY)
+          if (cached) {
+            const parsed: CachedRegistry = JSON.parse(cached)
+            setItems(mergeRegistryItems(parsed.data))
+          }
+        } catch { /* no cached fallback available */ }
+      }
     } finally {
       setIsLoading(false)
     }
-  }, [])
+  }, [items.length])
 
   useEffect(() => {
     fetchRegistry()
   }, [fetchRegistry])
 
+  // #7539: Reconcile installed-dashboard state against the backend so items
+  // deleted outside the marketplace are no longer shown as "installed".
+  const reconcileRef = useRef(false)
+  useEffect(() => {
+    if (reconcileRef.current) return
+    reconcileRef.current = true
+
+    const dashboardEntries = (Object.entries(installedItems) as [string, InstalledEntry][]).filter(
+      ([, entry]) => entry.type === 'dashboard' && entry.dashboardId
+    )
+    if (dashboardEntries.length === 0) return
+
+    api.get<{ id: string }[]>('/api/dashboards').then(({ data: dashboards }) => {
+      const ids = new Set((dashboards || []).map(d => d.id))
+      let changed = false
+      for (const [itemId, entry] of dashboardEntries) {
+        if (entry.dashboardId && !ids.has(entry.dashboardId)) {
+          markUninstalled(itemId)
+          changed = true
+        }
+      }
+      if (changed) notifyInstalledChange()
+    }).catch(() => { /* reconciliation is best-effort */ })
+  }, []) // eslint-disable-line react-hooks/exhaustive-deps
+
   const markInstalled = (itemId: string, entry: InstalledEntry) => {
-    setInstalledItems(prev => {
-      const next = { ...prev, [itemId]: entry }
-      saveInstalled(next)
-      return next
-    })
+    const next = { ...installedSnapshot, [itemId]: entry }
+    saveInstalled(next)
+    notifyInstalledChange()
   }
 
   const markUninstalled = (itemId: string) => {
-    setInstalledItems(prev => {
-      const next = { ...prev }
-      delete next[itemId]
-      saveInstalled(next)
-      return next
-    })
+    const next = { ...installedSnapshot }
+    delete next[itemId]
+    saveInstalled(next)
+    notifyInstalledChange()
   }
 
   const isInstalled = (itemId: string): boolean => {
@@ -328,7 +388,14 @@ export function useMarketplace() {
     if (!entry) return
 
     if (entry.type === 'dashboard' && entry.dashboardId) {
-      await api.delete(`/api/dashboards/${entry.dashboardId}`)
+      // #7540: Gracefully handle already-deleted resources — treat 404 as success
+      try {
+        await api.delete(`/api/dashboards/${entry.dashboardId}`)
+      } catch (e: unknown) {
+        const is404 = e instanceof Error && e.message.includes('404')
+        if (!is404) throw e
+        // Resource already gone — proceed with local cleanup
+      }
     }
 
     if (entry.type === 'theme') {
@@ -336,6 +403,7 @@ export function useMarketplace() {
       window.dispatchEvent(new Event('kc-custom-themes-changed'))
     }
 
+    // #7541: Always clear local state regardless of dashboardId presence
     markUninstalled(item.id)
     emitMarketplaceRemove(item.type)
   }

--- a/web/src/pages/AllCardsPerfTest.tsx
+++ b/web/src/pages/AllCardsPerfTest.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react'
+import React, { useEffect, useMemo } from 'react'
 import { CardWrapper } from '../components/cards/CardWrapper'
 import { DEMO_DATA_CARDS, getCardComponent, getRegisteredCardTypes } from '../components/cards/cardRegistry'
 import { formatCardTitle } from '../lib/formatCardTitle'
@@ -63,7 +63,11 @@ class CardErrorBoundary extends React.Component<CardErrorBoundaryProps, CardErro
 }
 
 export function AllCardsPerfTest() {
-  const params = new URLSearchParams(window.location.search)
+  // #7554: Guard window access for SSR / Node test paths
+  const params = useMemo(
+    () => new URLSearchParams(typeof window !== 'undefined' ? window.location.search : ''),
+    []
+  )
   const batch = Math.max(0, parsePositiveInt(params.get('batch'), 1) - 1)
   const batchSize = parsePositiveInt(params.get('size'), DEFAULT_BATCH_SIZE)
 
@@ -75,20 +79,25 @@ export function AllCardsPerfTest() {
     []
   )
 
-  const selected = (() => {
+  const selected = useMemo(() => {
     const start = batch * batchSize
     const items = allCardTypes.slice(start, start + batchSize)
     return items.map((cardType, idx) => ({
       cardType,
       cardId: `ttfi-${batch}-${idx}-${cardType}` }))
-  })()
+  }, [batch, batchSize, allCardTypes])
 
-  window.__TTFI_MANIFEST__ = {
-    allCardTypes,
-    totalCards: allCardTypes.length,
-    batch,
-    batchSize,
-    selected }
+  // #7552: Move global mutation into useEffect so it runs once after render
+  // instead of on every render pass (React Strict Mode calls render twice).
+  useEffect(() => {
+    if (typeof window === 'undefined') return
+    window.__TTFI_MANIFEST__ = {
+      allCardTypes,
+      totalCards: allCardTypes.length,
+      batch,
+      batchSize,
+      selected }
+  }, [allCardTypes, batch, batchSize, selected])
 
   return (
     <div className="p-4">

--- a/web/src/pages/Welcome.tsx
+++ b/web/src/pages/Welcome.tsx
@@ -108,17 +108,50 @@ const DIFFERENTIATORS = [
 ]
 
 /* ------------------------------------------------------------------ */
+/*  Ref parameter sanitization (#7551)                                 */
+/* ------------------------------------------------------------------ */
+
+/** Maximum length for the ref analytics dimension to prevent high-cardinality pollution */
+const REF_MAX_LENGTH = 64
+
+/** Allowed ref values — anything outside this set is normalized to "other" */
+const ALLOWED_REFS = new Set([
+  'direct',
+  'github',
+  'cncf',
+  'kubecon',
+  'twitter',
+  'linkedin',
+  'medium',
+  'docs',
+  'hackernews',
+  'reddit',
+  'youtube',
+])
+
+/** Normalize the raw ?ref= query parameter to a safe analytics value */
+function sanitizeRef(raw: string | null): string {
+  if (!raw) return 'direct'
+  const normalized = raw.toLowerCase().replace(/[^a-z0-9_-]/g, '').slice(0, REF_MAX_LENGTH)
+  if (!normalized) return 'direct'
+  // Allow known refs and any intern-NN utm_term pattern
+  if (ALLOWED_REFS.has(normalized) || /^intern-\d{1,3}$/.test(normalized)) return normalized
+  return 'other'
+}
+
+/* ------------------------------------------------------------------ */
 /*  Main page component                                                */
 /* ------------------------------------------------------------------ */
 
 export function Welcome() {
   const [searchParams] = useSearchParams()
-  const ref = searchParams.get('ref') || 'direct'
+  const ref = sanitizeRef(searchParams.get('ref'))
 
   useEffect(() => {
     const prevTitle = document.title
     const metaDesc = document.querySelector('meta[name="description"]')
     const prevDescription = metaDesc?.getAttribute('content') ?? ''
+    const createdTag = !metaDesc
 
     document.title = PAGE_TITLE
     if (metaDesc) {
@@ -133,10 +166,18 @@ export function Welcome() {
 
     // Restore previous title and meta description on unmount so they don't
     // leak into other routes during SPA navigation (#7423).
+    // #7553: If we created the tag (none existed before), remove it entirely
+    // instead of leaving an empty description tag behind.
     return () => {
       document.title = prevTitle
       const desc = document.querySelector('meta[name="description"]')
-      if (desc) desc.setAttribute('content', prevDescription)
+      if (desc) {
+        if (createdTag) {
+          desc.remove()
+        } else {
+          desc.setAttribute('content', prevDescription)
+        }
+      }
     }
   }, [ref])
 


### PR DESCRIPTION
Fixes #7539
Fixes #7540
Fixes #7541
Fixes #7542
Fixes #7543
Fixes #7544
Fixes #7545
Fixes #7546
Fixes #7547
Fixes #7548
Fixes #7549
Fixes #7550
Fixes #7551
Fixes #7552
Fixes #7553
Fixes #7554

## Summary

### Marketplace (#7539-#7543)
- **#7539**: Reconcile installed-dashboard state against backend on mount
- **#7540**: Gracefully handle 404 when removing already-deleted resources
- **#7541**: Always clear local state on remove regardless of dashboardId
- **#7542**: Cross-tab sync via useSyncExternalStore + storage event
- **#7543**: Preserve cached items on fetch failure instead of clearing

### Operators (#7544-#7550)
- **#7544/#7545**: Surface per-cluster errors via clusterErrors in REST responses
- **#7546**: Emit cluster_error SSE events for failed fetches
- **#7547**: Surface error messages in hooks instead of suppressing
- **#7548**: Derive pendingUpgrade when installedCSV differs from currentCSV
- **#7549/#7550**: Shorter cache TTL (30s) for empty results

### Frontend (#7551-#7554)
- **#7551**: Allowlist/normalize ref query param for analytics
- **#7552**: Move window.__TTFI_MANIFEST__ to useEffect
- **#7553**: Remove created meta tag on unmount
- **#7554**: SSR-guard window.location access

## Verification
- go build/vet pass
- npm run build pass (tsc + vite + post-build checks)