### PR TITLE
fix: resolve 7 UI bugs (#7555, #7558, #7561-#7565)

### DIFF
--- a/web/src/components/agent/APIKeySettings.tsx
+++ b/web/src/components/agent/APIKeySettings.tsx
@@ -171,8 +171,14 @@ export function APIKeySettings({ isOpen, onClose }: APIKeySettingsProps) {
       })
 
       if (!response.ok) {
-        const data = await response.json()
-        throw new Error(data.message || t('agent.failedToSaveKey'))
+        let message = t('agent.failedToSaveKey')
+        try {
+          const data = await response.json()
+          message = data.message || message
+        } catch {
+          // Response body was not JSON — use default message
+        }
+        throw new Error(message)
       }
 
       // Success - refresh status and close edit mode
@@ -198,8 +204,14 @@ export function APIKeySettings({ isOpen, onClose }: APIKeySettingsProps) {
       })
 
       if (!response.ok) {
-        const data = await response.json()
-        throw new Error(data.message || t('agent.failedToDeleteKey'))
+        let message = t('agent.failedToDeleteKey')
+        try {
+          const data = await response.json()
+          message = data.message || message
+        } catch {
+          // Response body was not JSON — use default message
+        }
+        throw new Error(message)
       }
 
       await fetchKeysStatus()
@@ -342,15 +354,17 @@ export function APIKeySettings({ isOpen, onClose }: APIKeySettingsProps) {
                           <Trash2 className="w-4 h-4" />
                         </button>
                       )}
-                      <a
-                        href={PROVIDER_INFO[key.provider]?.docsUrl}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        className="p-1.5 hover:bg-secondary rounded transition-colors text-muted-foreground hover:text-foreground"
-                        title={t('agent.getApiKey')}
-                      >
-                        <ExternalLink className="w-4 h-4" />
-                      </a>
+                      {PROVIDER_INFO[key.provider]?.docsUrl && (
+                        <a
+                          href={PROVIDER_INFO[key.provider].docsUrl}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="p-1.5 hover:bg-secondary rounded transition-colors text-muted-foreground hover:text-foreground"
+                          title={t('agent.getApiKey')}
+                        >
+                          <ExternalLink className="w-4 h-4" />
+                        </a>
+                      )}
                     </div>
                   </div>
 

--- a/web/src/components/agent/AgentApprovalDialog.tsx
+++ b/web/src/components/agent/AgentApprovalDialog.tsx
@@ -5,21 +5,25 @@ import { AgentIcon } from './AgentIcon'
 
 const APPROVED_KEY = 'kc_agents_approved'
 
+/** In-memory fallback when localStorage is unavailable or full */
+let sessionApproved = false
+
 /** Check whether the user has already approved agent access. */
 export function hasApprovedAgents(): boolean {
   try {
-    return localStorage.getItem(APPROVED_KEY) === 'true'
+    return localStorage.getItem(APPROVED_KEY) === 'true' || sessionApproved
   } catch {
-    return false
+    return sessionApproved
   }
 }
 
 /** Record that the user has approved agent access. */
 export function setAgentsApproved(): void {
+  sessionApproved = true
   try {
     localStorage.setItem(APPROVED_KEY, 'true')
   } catch {
-    // storage full — treat as approved for this session
+    // storage full — sessionApproved already set above as fallback
   }
 }
 

--- a/web/src/components/agent/AgentSelector.tsx
+++ b/web/src/components/agent/AgentSelector.tsx
@@ -199,12 +199,25 @@ export function AgentSelector({ compact = false, className = '' }: AgentSelector
   }, [closeDropdown])
 
   // Compute dropdown position when opened (portal needs absolute screen coords)
+  // Recompute on resize/scroll so the menu stays attached to its trigger
   useEffect(() => {
-    if (isOpen && buttonRef.current) {
+    if (!isOpen) return
+
+    const updatePosition = () => {
+      if (!buttonRef.current) return
       const rect = buttonRef.current.getBoundingClientRect()
+      const DROPDOWN_GAP_PX = 4
       setDropdownPos({
-        top: rect.bottom + 4, // 4px gap (mt-1 equivalent)
+        top: rect.bottom + DROPDOWN_GAP_PX,
         right: window.innerWidth - rect.right })
+    }
+
+    updatePosition()
+    window.addEventListener('resize', updatePosition)
+    window.addEventListener('scroll', updatePosition, true)
+    return () => {
+      window.removeEventListener('resize', updatePosition)
+      window.removeEventListener('scroll', updatePosition, true)
     }
   }, [isOpen])
 

--- a/web/src/components/agent/agentSelectorUtils.ts
+++ b/web/src/components/agent/agentSelectorUtils.ts
@@ -29,24 +29,30 @@ export function buildVisibleAgents(
   }
 
   const { kagentAvailable, kagentiAvailable, selectedKagentAgent, selectedKagentiAgent } = backend
-  const inCluster: AgentInfo[] = [
-    {
+  const inCluster: AgentInfo[] = []
+
+  // Only add kagenti/kagent if not already present from the backend agent list
+  if (!merged.some(a => a.provider === 'kagenti')) {
+    inCluster.push({
       name: 'kagenti',
       displayName: selectedKagentiAgent ? `Kagenti (${selectedKagentiAgent.name})` : 'Kagenti',
       description: kagentiAvailable ? 'In-cluster AI agent via kagenti' : 'Install kagenti for in-cluster AI agents',
       provider: 'kagenti',
       available: kagentiAvailable,
       installMissionId: kagentiAvailable ? undefined : 'install-kagenti',
-    },
-    {
+    })
+  }
+  if (!merged.some(a => a.provider === 'kagent')) {
+    inCluster.push({
       name: 'kagent',
       displayName: selectedKagentAgent ? `Kagent (${selectedKagentAgent.name})` : 'Kagent',
       description: kagentAvailable ? 'In-cluster AI agent via kagent' : 'Install kagent for in-cluster AI agents',
       provider: 'kagent',
       available: kagentAvailable,
       installMissionId: kagentAvailable ? undefined : 'install-kagent',
-    },
-  ]
+    })
+  }
+
   return [...merged, ...inCluster]
 }
 

--- a/web/src/types/alerts.ts
+++ b/web/src/types/alerts.ts
@@ -314,7 +314,7 @@ export function formatCondition(condition: AlertCondition): string {
     case 'cpu_pressure':
       return `CPU usage > ${condition.threshold}%`
     case 'disk_pressure':
-      return `Disk usage > ${condition.threshold}%`
+      return condition.threshold != null ? `Disk usage > ${condition.threshold}%` : 'Node reporting DiskPressure condition'
     case 'dns_failure':
       return 'CoreDNS pods not ready or crashing'
     case 'certificate_error':

--- a/web/src/types/rewards.ts
+++ b/web/src/types/rewards.ts
@@ -337,7 +337,7 @@ export function getContributorLevel(totalCoins: number): {
   const rangeEnd = next.minCoins
   const coinsInRange = totalCoins - rangeStart
   const rangeSize = rangeEnd - rangeStart
-  const progress = Math.min(100, Math.round((coinsInRange / rangeSize) * 100))
+  const progress = Math.max(0, Math.min(100, Math.round((coinsInRange / rangeSize) * 100)))
   const coinsToNext = rangeEnd - totalCoins
 
   return { current, next, progress, coinsToNext }


### PR DESCRIPTION
## Summary

- **Disk pressure undefined threshold** — show descriptive fallback text instead of "undefined%"
- **Negative contributor progress** — clamp progress minimum to 0
- **Agent approval session fallback** — add in-memory flag when localStorage write fails
- **Duplicate kagent/kagenti entries** — check before appending synthetic entries
- **Unsafe API key response parsing** — guard `response.json()` with try-catch for non-JSON error bodies
- **Dropdown portal drift** — recompute position on window resize and scroll
- **Provider docs link undefined** — only render anchor when URL exists

## Closed as not-a-bug

- **#7556** — PROVIDER_PREREQUISITES keys already align with lookup chain
- **#7557** — string vs Date is intentional API-to-model conversion
- **#7559** — existing PR, not a bug

Fixes #7555
Fixes #7558
Fixes #7561
Fixes #7562
Fixes #7563
Fixes #7564
Fixes #7565

## Test plan
- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] `npm run build` passes