### PR TITLE
fix: 8 issues — settings, XSS, tests, ARIA, perf

### DIFF
--- a/pkg/api/handlers/card_proxy.go
+++ b/pkg/api/handlers/card_proxy.go
@@ -209,10 +209,20 @@ func (h *CardProxyHandler) Proxy(c *fiber.Ctx) error {
 	// Log successful proxy requests for audit trail
 	slog.Info("[CardProxy] proxied request", "clientIP", c.IP(), "host", host, "status", resp.StatusCode, "bytes", len(body))
 
-	// Forward Content-Type
-	if ct := resp.Header.Get("Content-Type"); ct != "" {
-		c.Set("Content-Type", ct)
+	// Sanitize Content-Type to prevent reflected XSS (#7573).
+	// If the upstream returns HTML/XML/SVG, override to application/octet-stream
+	// so the browser never interprets attacker-controlled markup under our origin.
+	ct := resp.Header.Get("Content-Type")
+	if ct != "" {
+		ctLower := strings.ToLower(ct)
+		if strings.Contains(ctLower, "html") || strings.Contains(ctLower, "xml") || strings.Contains(ctLower, "svg") || strings.Contains(ctLower, "javascript") {
+			c.Set("Content-Type", "application/octet-stream")
+		} else {
+			c.Set("Content-Type", ct)
+		}
 	}
+	// Prevent MIME sniffing to block browsers from guessing a dangerous content type.
+	c.Set("X-Content-Type-Options", "nosniff")
 
 	// Forward CORS-safe headers that cards might need
 	for _, header := range []string{

--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -373,15 +373,17 @@ func (s *Server) setupMiddleware() {
 	// Recovery middleware
 	s.app.Use(recover.New())
 
-	// Gzip/Brotli compression for API responses only — static assets are pre-compressed at build time
+	// Gzip/Brotli compression for API responses only — static assets are pre-compressed at build time.
+	// The handler is created once and reused across requests (#7575).
+	compressHandler := compress.New(compress.Config{
+		Level: compress.LevelBestCompression,
+	})
 	s.app.Use(func(c *fiber.Ctx) error {
 		p := c.Path()
 		if strings.HasSuffix(p, ".js") || strings.HasSuffix(p, ".css") || strings.HasSuffix(p, ".wasm") || strings.HasSuffix(p, ".json") || strings.HasSuffix(p, ".svg") || strings.HasSuffix(p, ".woff2") {
 			return c.Next() // skip compress middleware — served pre-compressed with Content-Length
 		}
-		return compress.New(compress.Config{
-			Level: compress.LevelBestCompression,
-		})(c)
+		return compressHandler(c)
 	})
 
 	// Logger

--- a/pkg/settings/crypto.go
+++ b/pkg/settings/crypto.go
@@ -9,6 +9,7 @@ import (
 	"encoding/hex"
 	"fmt"
 	"os"
+	"path/filepath"
 )
 
 const (
@@ -45,13 +46,25 @@ func ensureKeyFile(path string) ([]byte, error) {
 		return nil, fmt.Errorf("failed to generate key: %w", err)
 	}
 
-	// Atomic write: write to a temp file then rename to prevent races
-	// when multiple processes start simultaneously.
+	// Atomic write: write to a unique temp file then hard-link to prevent
+	// races when multiple processes start simultaneously (#7577).
 	encoded := hex.EncodeToString(key)
-	tmpPath := path + ".tmp"
-	if err := os.WriteFile(tmpPath, []byte(encoded), keyFileMode); err != nil {
-		return nil, fmt.Errorf("failed to write temp keyfile %s: %w", tmpPath, err)
+	tmpFile, tmpErr := os.CreateTemp(filepath.Dir(path), ".keyfile-*.tmp")
+	if tmpErr != nil {
+		return nil, fmt.Errorf("failed to create temp keyfile: %w", tmpErr)
 	}
+	tmpPath := tmpFile.Name()
+	if _, writeErr := tmpFile.Write([]byte(encoded)); writeErr != nil {
+		tmpFile.Close()
+		os.Remove(tmpPath)
+		return nil, fmt.Errorf("failed to write temp keyfile %s: %w", tmpPath, writeErr)
+	}
+	if chmodErr := tmpFile.Chmod(keyFileMode); chmodErr != nil {
+		tmpFile.Close()
+		os.Remove(tmpPath)
+		return nil, fmt.Errorf("failed to chmod temp keyfile %s: %w", tmpPath, chmodErr)
+	}
+	tmpFile.Close()
 
 	// Use os.Link + os.Remove for atomic creation (fails if target already exists on most filesystems).
 	// If another process already created the key file, use theirs instead of overwriting.

--- a/pkg/settings/manager.go
+++ b/pkg/settings/manager.go
@@ -106,6 +106,24 @@ func (sm *SettingsManager) Load() error {
 		return fmt.Errorf("failed to parse settings: %w", err)
 	}
 
+	// Detect missing boolean fields in older settings files (#7572).
+	// Booleans deserialize to false when absent, which silently disables
+	// features whose default is true. We probe the raw JSON to distinguish
+	// "explicitly false" from "missing" and restore defaults only for
+	// the latter.
+	var rawSettings struct {
+		Settings json.RawMessage `json:"settings"`
+	}
+	var rawPredictions map[string]json.RawMessage
+	if json.Unmarshal(data, &rawSettings) == nil && rawSettings.Settings != nil {
+		var inner map[string]json.RawMessage
+		if json.Unmarshal(rawSettings.Settings, &inner) == nil {
+			if pRaw, ok := inner["predictions"]; ok {
+				_ = json.Unmarshal(pRaw, &rawPredictions)
+			}
+		}
+	}
+
 	// Merge with defaults for forward compatibility (new fields get defaults).
 	// Covers all nested structures so older settings files don't zero-out
 	// intended defaults (#7370).
@@ -118,6 +136,10 @@ func (sm *SettingsManager) Load() error {
 	}
 	if sf.Settings.Widget.SelectedWidget == "" {
 		sf.Settings.Widget.SelectedWidget = defaults.Settings.Widget.SelectedWidget
+	}
+	// Backfill boolean fields that default to true when absent from older files (#7572).
+	if _, found := rawPredictions["aiEnabled"]; !found {
+		sf.Settings.Predictions.AIEnabled = defaults.Settings.Predictions.AIEnabled
 	}
 	// Prediction defaults — backfill zero-valued nested fields
 	if sf.Settings.Predictions.Interval == 0 {
@@ -224,6 +246,8 @@ func (sm *SettingsManager) GetAll() (*AllSettings, error) {
 		Accessibility:       sm.settings.Settings.Accessibility,
 		Profile:             sm.settings.Settings.Profile,
 		Widget:              sm.settings.Settings.Widget,
+		AutoUpdateEnabled:   sm.settings.Settings.AutoUpdateEnabled,
+		AutoUpdateChannel:   sm.settings.Settings.AutoUpdateChannel,
 		APIKeys:             make(map[string]APIKeyEntry),
 		FeedbackGitHubToken: "",
 		Notifications:       NotificationSecrets{},
@@ -305,6 +329,8 @@ func (sm *SettingsManager) SaveAll(all *AllSettings) error {
 	sm.settings.Settings.Accessibility = all.Accessibility
 	sm.settings.Settings.Profile = all.Profile
 	sm.settings.Settings.Widget = all.Widget
+	sm.settings.Settings.AutoUpdateEnabled = all.AutoUpdateEnabled
+	sm.settings.Settings.AutoUpdateChannel = all.AutoUpdateChannel
 
 	// Encrypt API keys (only if non-empty)
 	if len(all.APIKeys) > 0 {

--- a/pkg/settings/types.go
+++ b/pkg/settings/types.go
@@ -26,6 +26,10 @@ type PlaintextSettings struct {
 	Accessibility AccessibilitySettings `json:"accessibility"`
 	Profile       ProfileSettings       `json:"profile"`
 	Widget        WidgetSettings        `json:"widget"`
+
+	// Auto-update configuration — persisted so user changes survive restarts (#7571).
+	AutoUpdateEnabled bool   `json:"autoUpdateEnabled"`
+	AutoUpdateChannel string `json:"autoUpdateChannel"`
 }
 
 // PredictionSettings mirrors the frontend PredictionSettings type

--- a/web/src/components/aiagents/AIAgents.tsx
+++ b/web/src/components/aiagents/AIAgents.tsx
@@ -62,6 +62,8 @@ export function AIAgents() {
           key={tab.id}
           onClick={() => !tab.disabled && setActiveTab(tab.id)}
           disabled={tab.disabled}
+          role="tab"
+          aria-selected={activeTab === tab.id}
           className={`flex items-center gap-2 px-4 py-2.5 text-sm font-medium transition-colors border-b-2 -mb-px ${
             activeTab === tab.id
               ? 'border-purple-500 text-foreground'

--- a/web/src/components/cards/ArgoCDApplications.tsx
+++ b/web/src/components/cards/ArgoCDApplications.tsx
@@ -279,6 +279,7 @@ function ArgoCDApplicationsInternal({ config }: ArgoCDApplicationsProps) {
           <button
             onClick={() => setSelectedFilter('all')}
             className="text-xs px-2 py-0.5 rounded bg-purple-500/20 text-purple-400 flex items-center gap-1"
+            aria-label={`Clear filter: ${selectedFilter === 'outOfSync' ? t('argoCDApplications.outOfSync') : t('argoCDApplications.unhealthy')}`}
           >
             {selectedFilter === 'outOfSync' ? t('argoCDApplications.outOfSync') : t('argoCDApplications.unhealthy')}
             <XCircle className="w-3 h-3" />

--- a/web/src/components/cards/Checkers.tsx
+++ b/web/src/components/cards/Checkers.tsx
@@ -723,6 +723,7 @@ export function Checkers(_props: CardComponentProps) {
             onClick={newGame}
             className="p-1.5 rounded hover:bg-secondary"
             title={t('checkers.newGame')}
+            aria-label={t('checkers.newGame')}
           >
             <RotateCcw className="w-4 h-4" />
           </button>

--- a/web/src/components/cards/ClusterComparison.tsx
+++ b/web/src/components/cards/ClusterComparison.tsx
@@ -167,6 +167,8 @@ function ClusterComparisonInternal({ config }: ClusterComparisonProps) {
                 : 'bg-secondary/50 text-muted-foreground hover:text-foreground'
             }`}
             title={c.name}
+            aria-label={`Toggle cluster ${c.name}`}
+            aria-pressed={selectedClusters.includes(c.name)}
           >
             {c.name}
           </button>

--- a/web/src/components/cards/FlappyPod.tsx
+++ b/web/src/components/cards/FlappyPod.tsx
@@ -250,6 +250,7 @@ export function FlappyPod(_props: CardComponentProps) {
           onClick={startGame}
           className="p-1.5 rounded hover:bg-secondary"
           title="New Game"
+          aria-label="New Game"
         >
           <RotateCcw className="w-4 h-4" />
         </button>

--- a/web/src/components/cards/PodSweeper.tsx
+++ b/web/src/components/cards/PodSweeper.tsx
@@ -278,6 +278,7 @@ function PodSweeperInternal(_props: CardComponentProps) {
             onClick={() => newGame()}
             className="p-1.5 rounded hover:bg-secondary"
             title="New Game"
+            aria-label="New Game"
           >
             <RotateCcw className="w-4 h-4" />
           </button>

--- a/web/src/components/cards/__tests__/PVCStatus.test.tsx
+++ b/web/src/components/cards/__tests__/PVCStatus.test.tsx
@@ -22,6 +22,7 @@ vi.mock('../../../hooks/useDemoMode', () => ({
 vi.mock('../../../lib/analytics', () => ({
   emitNavigate: vi.fn(), emitLogin: vi.fn(), emitEvent: vi.fn(), analyticsReady: Promise.resolve(),
   emitAddCardModalOpened: vi.fn(), emitCardExpanded: vi.fn(), emitCardRefreshed: vi.fn(), markErrorReported: vi.fn(),
+  emitError: vi.fn(),
 }))
 
 vi.mock('../../../hooks/useTokenUsage', () => ({
@@ -47,6 +48,10 @@ vi.mock('../../../hooks/useCachedData', () => ({
 
 vi.mock('../../../hooks/useDrillDown', () => ({
   useDrillDownActions: () => ({}),
+}))
+
+vi.mock('../../../hooks/useGlobalFilters', () => ({
+  useGlobalFilters: () => ({ selectedClusters: [], isAllClustersSelected: true }),
 }))
 
 vi.mock('../../../lib/cards/cardHooks', () => ({

--- a/web/src/components/rbac/CanIChecker.tsx
+++ b/web/src/components/rbac/CanIChecker.tsx
@@ -347,6 +347,7 @@ export function CanIChecker() {
                   <button
                     onClick={() => toggleUserGroup(group)}
                     className="hover:text-blue-200"
+                    aria-label={`Remove group ${group}`}
                   >
                     <X className="w-3 h-3" />
                   </button>
@@ -409,6 +410,7 @@ export function CanIChecker() {
           type="button"
           onClick={() => setShowAdvanced(!showAdvanced)}
           className="text-sm text-muted-foreground hover:text-foreground"
+          aria-expanded={showAdvanced}
         >
           {showAdvanced ? t('rbac.hideAdvanced') : t('rbac.showAdvanced')}
         </button>

--- a/web/src/contexts/AlertsContext.tsx
+++ b/web/src/contexts/AlertsContext.tsx
@@ -11,7 +11,7 @@ import type { GPUHealthCheckResult } from '../hooks/mcp/types'
 import type { NightlyGuideStatus } from '../lib/llmd/nightlyE2EDemoData'
 import type { AlertsMCPData } from './AlertsDataFetcher'
 import { STORAGE_KEY_AUTH_TOKEN, FETCH_DEFAULT_TIMEOUT_MS, STORAGE_KEY_NOTIFIED_ALERT_KEYS } from '../lib/constants'
-import { safeGet, safeSet, safeRemove, safeGetJSON, safeSetJSON } from '../lib/safeLocalStorage'
+import { safeGet, safeSet, safeRemove, safeGetJSON } from '../lib/safeLocalStorage'
 import { INITIAL_FETCH_DELAY_MS, POLL_INTERVAL_SLOW_MS, SECONDARY_FETCH_DELAY_MS, NIGHTLY_E2E_POLL_INTERVAL_MS } from '../lib/constants/network'
 import { PRESET_ALERT_RULES } from '../types/alerts'
 import { sendNotificationWithDeepLink } from '../hooks/useDeepLink'
@@ -282,9 +282,15 @@ function loadFromStorage<T>(key: string, defaultValue: T): T {
   return safeGetJSON(key, defaultValue)
 }
 
-// Save to localStorage
+// Save to localStorage with error logging (#7576).
+// Uses localStorage directly instead of safeSetJSON so errors are
+// observable rather than silently swallowed.
 function saveToStorage<T>(key: string, value: T): void {
-  safeSetJSON(key, value)
+  try {
+    localStorage.setItem(key, JSON.stringify(value))
+  } catch (e) {
+    console.error(`Failed to save ${key} to localStorage:`, e)
+  }
 }
 
 // Save alerts to localStorage with a hard cap and quota-exceeded handling.
@@ -301,8 +307,10 @@ function saveAlerts(alerts: Alert[]): void {
     toSave = [...firing, ...resolved]
   }
 
+  // Use localStorage.setItem directly instead of safeSet so that
+  // QuotaExceededError propagates to our own catch block (#7576).
   try {
-    safeSet(ALERTS_KEY, JSON.stringify(toSave))
+    localStorage.setItem(ALERTS_KEY, JSON.stringify(toSave))
   } catch (e) {
     // QuotaExceededError: DOMException with name 'QuotaExceededError', or legacy
     // browsers that use numeric code 22 instead of the named exception.
@@ -318,7 +326,7 @@ function saveAlerts(alerts: Alert[]): void {
         .slice(0, MAX_RESOLVED_ALERTS_AFTER_PRUNE)
       const pruned = [...firing, ...resolved]
       try {
-        safeSet(ALERTS_KEY, JSON.stringify(pruned))
+        localStorage.setItem(ALERTS_KEY, JSON.stringify(pruned))
       } catch (retryError) {
         console.error('[Alerts] localStorage still full after pruning, clearing alerts', retryError)
         safeRemove(ALERTS_KEY)

--- a/web/src/hooks/__tests__/useMarketplace.test.ts
+++ b/web/src/hooks/__tests__/useMarketplace.test.ts
@@ -84,6 +84,16 @@ function seedCache(items: MarketplaceItem[], presets?: MarketplaceItem[]) {
 
 function seedInstalledItems(map: Record<string, unknown>) {
   localStorage.setItem(INSTALLED_KEY, JSON.stringify(map))
+  // Trigger the cross-tab sync listener so the module-level
+  // installedSnapshot is refreshed from localStorage (#7574).
+  window.dispatchEvent(new StorageEvent('storage', { key: INSTALLED_KEY }))
+  // Mock the dashboards API so reconciliation doesn't remove seeded entries (#7574).
+  const dashboardIds = Object.values(map)
+    .filter((e: Record<string, unknown>) => e.dashboardId)
+    .map((e: Record<string, unknown>) => ({ id: e.dashboardId }))
+  if (dashboardIds.length > 0) {
+    mockApiGet.mockResolvedValue({ data: dashboardIds })
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -94,6 +104,8 @@ describe('useMarketplace', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     localStorage.clear()
+    // Default: api.get resolves with empty data so reconciliation doesn't throw (#7574)
+    mockApiGet.mockResolvedValue({ data: [] })
     // Default: fetch rejects so tests that don't need network don't hang
     vi.spyOn(globalThis, 'fetch').mockRejectedValue(new Error('not available'))
   })
@@ -598,7 +610,8 @@ describe('useMarketplace', () => {
       json: () => Promise.resolve(presetJson),
     } as Response)
     // GET /api/dashboards — return a list with a default dashboard.
-    mockApiGet.mockResolvedValueOnce({ data: [{ id: 'dash-default', is_default: true }, { id: 'dash-other' }] })
+    // Set as the persistent default so both reconciliation and installItem get the same data.
+    mockApiGet.mockResolvedValue({ data: [{ id: 'dash-default', is_default: true }, { id: 'dash-other' }] })
     // POST /api/dashboards/:id/cards — success.
     mockApiPost.mockResolvedValueOnce({ data: { id: 'persisted-card-id' } })
 
@@ -641,7 +654,8 @@ describe('useMarketplace', () => {
       ok: true,
       json: () => Promise.resolve(presetJson),
     } as Response)
-    mockApiGet.mockResolvedValueOnce({ data: [{ id: 'dash-default', is_default: true }] })
+    // Set as persistent default so both reconciliation and installItem get the same data.
+    mockApiGet.mockResolvedValue({ data: [{ id: 'dash-default', is_default: true }] })
     mockApiPost.mockRejectedValueOnce(new Error('backend exploded'))
 
     const { result } = renderHook(() => useMarketplace())

--- a/web/src/hooks/__tests__/useUniversalStats.test.ts
+++ b/web/src/hooks/__tests__/useUniversalStats.test.ts
@@ -59,6 +59,12 @@ vi.mock('../useCachedData', () => ({
   useCachedPVCs: (...args: unknown[]) => mockUsePVCs(...args),
 }))
 
+const mockUseIngresses = vi.fn(() => ({ ingresses: [] as unknown[], isLoading: false }))
+
+vi.mock('../mcp/networking', () => ({
+  useIngresses: (...args: unknown[]) => mockUseIngresses(...args),
+}))
+
 vi.mock('../useAlerts', () => ({
   useAlerts: (...args: unknown[]) => mockUseAlerts(...args),
   useAlertRules: (...args: unknown[]) => mockUseAlertRules(...args),
@@ -513,11 +519,25 @@ describe('useUniversalStats', () => {
       expect(getStatValue('clusterip')?.value).toBe(3)
     })
 
-    it('returns dash for ingresses (not implemented)', () => {
-      expect(getStatValue('ingresses')?.value).toBe('-')
+    it('returns ingress count from useIngresses hook', () => {
+      mockUseIngresses.mockReturnValue({ ingresses: [{ name: 'ing-1' }, { name: 'ing-2' }], isLoading: false })
+      expect(getStatValue('ingresses')?.value).toBe(2)
     })
 
-    it('endpoints mirrors total services count', () => {
+    it('returns zero ingresses when none exist', () => {
+      mockUseIngresses.mockReturnValue({ ingresses: [], isLoading: false })
+      expect(getStatValue('ingresses')?.value).toBe(0)
+    })
+
+    it('endpoints sums service endpoint counts', () => {
+      mockUseServices.mockReturnValue({
+        services: [
+          { type: 'ClusterIP', endpoints: 3 },
+          { type: 'ClusterIP', endpoints: 2 },
+          { type: 'NodePort', endpoints: 1 },
+        ],
+        isLoading: false,
+      })
       expect(getStatValue('endpoints')?.value).toBe(6)
     })
 

--- a/web/src/lib/widgets/styleConverter.ts
+++ b/web/src/lib/widgets/styleConverter.ts
@@ -332,11 +332,15 @@ const getStoredPosition = () => {
   try {
     const stored = localStorage.getItem(STORAGE_KEY);
     if (stored) return JSON.parse(stored);
-  } catch (e) {}
+  } catch (e) {
+    console.warn('[Widget] failed to load stored position:', e);
+  }
   return { top: 20, left: 20 };
 };
 const savePosition = (pos) => {
-  try { localStorage.setItem(STORAGE_KEY, JSON.stringify(pos)); } catch (e) {}
+  try { localStorage.setItem(STORAGE_KEY, JSON.stringify(pos)); } catch (e) {
+    console.warn('[Widget] failed to save position:', e);
+  }
 };
 let widgetPosition = getStoredPosition();
 


### PR DESCRIPTION
## Summary

- **#7571**: Persist `autoUpdateEnabled`/`autoUpdateChannel` in `PlaintextSettings` so they survive restarts
- **#7572**: Detect missing boolean fields (`aiEnabled`) in older settings files via raw JSON probing; restore defaults only when absent (not when explicitly `false`)
- **#7573**: Sanitize card proxy `Content-Type` — override HTML/XML/SVG/JS to `application/octet-stream` and add `X-Content-Type-Options: nosniff` to prevent reflected XSS
- **#7574**: Fix all 22 test failures — missing `useGlobalFilters`/`emitError` mocks in PVCStatus, `safeSet` swallowing errors in AlertsContext, stale `installedSnapshot` in useMarketplace, missing `useIngresses` mock in useUniversalStats
- **#7575**: Hoist `compress.New()` handler above the request path to avoid per-request allocation
- **#7576**: Replace silent `catch {}` in AlertsContext (`saveAlerts`, `saveToStorage`) and widget `styleConverter` with logged errors
- **#7577**: Use `os.CreateTemp` for unique temp filename during encryption key bootstrap to prevent collisions under concurrent processes
- **#7569**: Add `aria-label` to icon-only buttons in CanIChecker, PodSweeper, FlappyPod, Checkers, ArgoCDApplications, ClusterComparison; add `role="tab"` + `aria-selected` to AIAgents tabs

Fixes #7569
Fixes #7571
Fixes #7572
Fixes #7573
Fixes #7574
Fixes #7575
Fixes #7576
Fixes #7577

## Test plan
- [x] `go build ./...` and `go vet ./...` pass
- [x] `npm run build` passes
- [x] All 22 previously failing tests now pass (PVCStatus 9/9, AlertsContext 77/77, useMarketplace 46/46, useUniversalStats 286/286)