### PR TITLE
fix: events/alerts and namespace RBAC bugs (#7580-#7608)

### DIFF
--- a/pkg/k8s/rbac.go
+++ b/pkg/k8s/rbac.go
@@ -2,6 +2,8 @@ package k8s
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
 	"os"
 	"strings"
@@ -1033,10 +1035,14 @@ func (m *MultiClusterClient) GrantNamespaceAccess(ctx context.Context, contextNa
 	}
 	// Otherwise, use the role name as-is (custom role)
 
-	// Generate binding name
-	bindingName := fmt.Sprintf("%s-%s-%s", req.SubjectName, roleName, namespace)
-	// Sanitize the binding name (remove special characters)
-	bindingName = sanitizeK8sName(bindingName)
+	// Generate binding name with a hash suffix to avoid collisions after sanitization (#7608).
+	// Different inputs (e.g. "admin@foo.com" vs "admin-foo-com") can normalize to the same
+	// sanitized string, so we append a short hash of the raw components.
+	rawBindingKey := fmt.Sprintf("%s-%s-%s", req.SubjectName, roleName, namespace)
+	hashSuffixLen := 8 // Length of the hex hash suffix appended to binding names
+	hash := sha256.Sum256([]byte(rawBindingKey))
+	hashSuffix := hex.EncodeToString(hash[:])[:hashSuffixLen]
+	bindingName := sanitizeK8sName(rawBindingKey) + "-" + hashSuffix
 
 	subject := rbacv1.Subject{
 		Kind: req.SubjectKind,

--- a/web/src/components/alerts/AlertDetail.tsx
+++ b/web/src/components/alerts/AlertDetail.tsx
@@ -68,11 +68,12 @@ export function AlertDetail({ alert, onClose }: AlertDetailProps) {
     ? missions.find(m => m.id === alert.aiDiagnosis?.missionId)
     : null
 
-  // Cleanup timeouts on unmount
+  // Cleanup all timeouts (including diagnosis timer) on unmount
   useEffect(() => {
     return () => {
       timeoutsRef.current.forEach(clearTimeout)
       timeoutsRef.current = []
+      clearTimeout(diagnosisTimerRef.current)
     }
   }, [])
 

--- a/web/src/components/alerts/AlertRuleEditor.tsx
+++ b/web/src/components/alerts/AlertRuleEditor.tsx
@@ -58,8 +58,8 @@ export function AlertRuleEditor({ isOpen = true, rule, onSave, onCancel }: Alert
   const [conditionType, setAlertConditionType] = useState<AlertConditionType>(
     rule?.condition.type || 'gpu_usage'
   )
-  const [threshold, setThreshold] = useState(rule?.condition.threshold || 90)
-  const [duration, setDuration] = useState(rule?.condition.duration || 60)
+  const [threshold, setThreshold] = useState(rule?.condition.threshold ?? 90)
+  const [duration, setDuration] = useState(rule?.condition.duration ?? 60)
   const [selectedClusters, setSelectedClusters] = useState<string[]>(
     rule?.condition.clusters || []
   )
@@ -71,8 +71,8 @@ export function AlertRuleEditor({ isOpen = true, rule, onSave, onCancel }: Alert
   const [weatherCondition, setWeatherCondition] = useState<'severe_storm' | 'extreme_heat' | 'heavy_rain' | 'snow' | 'high_wind'>(
     rule?.condition.weatherCondition || 'severe_storm'
   )
-  const [temperatureThreshold, setTemperatureThreshold] = useState(rule?.condition.temperatureThreshold || 100)
-  const [windSpeedThreshold, setWindSpeedThreshold] = useState(rule?.condition.windSpeedThreshold || 40)
+  const [temperatureThreshold, setTemperatureThreshold] = useState(rule?.condition.temperatureThreshold ?? 100)
+  const [windSpeedThreshold, setWindSpeedThreshold] = useState(rule?.condition.windSpeedThreshold ?? 40)
 
   // Channels state
   const [channels, setChannels] = useState<AlertChannel[]>(
@@ -95,11 +95,16 @@ export function AlertRuleEditor({ isOpen = true, rule, onSave, onCancel }: Alert
          severity !== rule.severity || enabled !== rule.enabled ||
          aiDiagnose !== (rule.aiDiagnose ?? true) ||
          conditionType !== rule.condition.type ||
-         threshold !== (rule.condition.threshold || 90) ||
-         duration !== (rule.condition.duration || 60) ||
+         threshold !== (rule.condition.threshold ?? 90) ||
+         duration !== (rule.condition.duration ?? 60) ||
+         weatherCondition !== (rule.condition.weatherCondition || 'severe_storm') ||
+         temperatureThreshold !== (rule.condition.temperatureThreshold ?? 100) ||
+         windSpeedThreshold !== (rule.condition.windSpeedThreshold ?? 40) ||
          JSON.stringify(selectedClusters) !== JSON.stringify(rule.condition.clusters || []) ||
          JSON.stringify(channels) !== JSON.stringify(rule.channels || []))
-      : (name.trim() !== '' || description.trim() !== '')
+      : (name.trim() !== '' || description.trim() !== '' ||
+         severity !== 'warning' || conditionType !== 'gpu_usage' ||
+         selectedClusters.length > 0)
     if (hasChanges) {
       setShowDiscardConfirm(true)
       return

--- a/web/src/components/clusters/AddClusterDialog.tsx
+++ b/web/src/components/clusters/AddClusterDialog.tsx
@@ -227,6 +227,13 @@ export function AddClusterDialog({ open, onClose }: AddClusterDialogProps) {
     setConnectStep(step)
   }
 
+  // Clear stale close timers when the dialog is closed (#7593)
+  useEffect(() => {
+    if (!open) {
+      clearTimeout(closeTimerRef.current)
+    }
+  }, [open])
+
   if (!open) return null
 
   const tabs: { id: TabId; label: string; icon: React.ReactNode; disabled?: boolean }[] = [

--- a/web/src/components/clusters/components/NamespaceResources.tsx
+++ b/web/src/components/clusters/components/NamespaceResources.tsx
@@ -50,11 +50,13 @@ export function NamespaceResources({ clusterName, namespace, onClose }: Namespac
   const [expandedItems, setExpandedItems] = useState<Set<string>>(new Set())
   const [loadingTimedOut, setLoadingTimedOut] = useState(false)
 
-  // Timeout after 10 seconds to prevent infinite loading
+  // Reset timeout state when cluster or namespace changes, then re-arm
+  const LOADING_TIMEOUT_THRESHOLD_MS = 10_000 // Max wait before showing timed-out state
   useEffect(() => {
+    setLoadingTimedOut(false)
     const timer = setTimeout(() => {
       setLoadingTimedOut(true)
-    }, 10000)
+    }, LOADING_TIMEOUT_THRESHOLD_MS)
     return () => clearTimeout(timer)
   }, [clusterName, namespace])
 

--- a/web/src/components/drilldown/views/EventsDrillDown.tsx
+++ b/web/src/components/drilldown/views/EventsDrillDown.tsx
@@ -6,7 +6,7 @@ import { getDemoMode } from '../../../hooks/useDemoMode'
 import { useDrillDownActions } from '../../../hooks/useDrillDown'
 import { useTranslation } from 'react-i18next'
 import { FETCH_DEFAULT_TIMEOUT_MS } from '../../../lib/constants'
-import { POLL_INTERVAL_MS, UI_FEEDBACK_TIMEOUT_MS } from '../../../lib/constants/network'
+import { POLL_INTERVAL_MS, UI_FEEDBACK_TIMEOUT_MS, LOCAL_AGENT_HTTP_URL } from '../../../lib/constants/network'
 import { copyToClipboard } from '../../../lib/clipboard'
 
 interface ClusterEvent {
@@ -93,7 +93,7 @@ export function EventsDrillDown({ data }: Props) {
       }
       params.append('limit', '100')
 
-      const response = await fetch(`http://127.0.0.1:8585/events?${params}`, {
+      const response = await fetch(`${LOCAL_AGENT_HTTP_URL}/events?${params}`, {
         signal: AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS),
       })
       if (response.ok) {

--- a/web/src/components/drilldown/views/HelmReleaseDrillDown.tsx
+++ b/web/src/components/drilldown/views/HelmReleaseDrillDown.tsx
@@ -664,7 +664,7 @@ Please:
               </div>
             ) : releaseHistory && releaseHistory.length > 0 ? (
               <div className="space-y-2">
-                {releaseHistory.sort((a, b) => b.revision - a.revision).map((rev) => {
+                {[...releaseHistory].sort((a, b) => b.revision - a.revision).map((rev) => {
                   const revStatus = getStatusStyle(rev.status)
                   return (
                     <div

--- a/web/src/components/namespaces/CreateNamespaceModal.tsx
+++ b/web/src/components/namespaces/CreateNamespaceModal.tsx
@@ -109,7 +109,7 @@ export function CreateNamespaceModal({ clusters, onClose, onCreated }: CreateNam
   }
 
   const handleClose = () => {
-    if (name.trim() !== '' || teamLabel.trim() !== '') {
+    if (name.trim() !== '' || teamLabel.trim() !== '' || initialAccess.length > 0) {
       setShowDiscardConfirm(true)
       return
     }

--- a/web/src/components/namespaces/GrantAccessModal.tsx
+++ b/web/src/components/namespaces/GrantAccessModal.tsx
@@ -67,7 +67,7 @@ export function GrantAccessModal({ namespace, existingAccess, onClose, onGranted
     setError(null)
 
     try {
-      await api.post(`/api/namespaces/${namespace.name}/access`, {
+      await api.post(`/api/namespaces/${encodeURIComponent(namespace.name)}/access`, {
         cluster: namespace.cluster,
         subjectKind,
         subjectName,
@@ -239,7 +239,7 @@ export function GrantAccessModal({ namespace, existingAccess, onClose, onGranted
             variant="primary"
             size="lg"
             onClick={handleGrant}
-            disabled={!subjectName || granting}
+            disabled={!subjectName || granting || (subjectKind === 'ServiceAccount' && !subjectNS.trim())}
             icon={granting ? <Loader2 className="w-4 h-4 animate-spin" /> : undefined}
           >
             {granting ? 'Granting...' : 'Grant Access'}

--- a/web/src/components/namespaces/NamespaceManager.tsx
+++ b/web/src/components/namespaces/NamespaceManager.tsx
@@ -242,7 +242,7 @@ export function NamespaceManager() {
   const fetchAccess = useCallback(async (namespace: NamespaceDetails) => {
     setAccessLoading(true)
     try {
-      const response = await api.get<{ bindings: typeof accessEntries }>(`/api/namespaces/${namespace.name}/access?cluster=${namespace.cluster}`)
+      const response = await api.get<{ bindings: typeof accessEntries }>(`/api/namespaces/${encodeURIComponent(namespace.name)}/access?cluster=${encodeURIComponent(namespace.cluster)}`)
       setAccessEntries(response.data?.bindings || [])
     } catch (err) {
       console.error('Failed to fetch access:', err)
@@ -303,7 +303,7 @@ export function NamespaceManager() {
     if (!namespaceToDelete) return
 
     try {
-      await api.delete(`/api/namespaces/${namespaceToDelete.name}?cluster=${namespaceToDelete.cluster}`)
+      await api.delete(`/api/namespaces/${encodeURIComponent(namespaceToDelete.name)}?cluster=${encodeURIComponent(namespaceToDelete.cluster)}`)
       // Clear cache for this cluster and refresh
       namespaceCache.delete(namespaceToDelete.cluster)
       fetchNamespaces(true)
@@ -326,7 +326,7 @@ export function NamespaceManager() {
     }
 
     try {
-      await api.delete(`/api/namespaces/${selectedNamespace.name}/access/${binding.bindingName}?cluster=${selectedNamespace.cluster}`)
+      await api.delete(`/api/namespaces/${encodeURIComponent(selectedNamespace.name)}/access/${encodeURIComponent(binding.bindingName)}?cluster=${encodeURIComponent(selectedNamespace.cluster)}`)
       fetchAccess(selectedNamespace)
     } catch (err) {
       console.error('Failed to revoke access:', err)

--- a/web/src/components/rewards/GitHubInvite.tsx
+++ b/web/src/components/rewards/GitHubInvite.tsx
@@ -26,7 +26,10 @@ interface Invite {
 function loadInvites(): Invite[] {
   try {
     const stored = safeGetItem(INVITES_STORAGE_KEY)
-    return stored ? JSON.parse(stored) : []
+    if (!stored) return []
+    const parsed: unknown = JSON.parse(stored)
+    // Validate parsed data is actually an array (#7601)
+    return Array.isArray(parsed) ? parsed as Invite[] : []
   } catch {
     return []
   }
@@ -59,13 +62,15 @@ export function GitHubInviteModal({ isOpen, onClose }: GitHubInviteProps) {
     setError('')
 
     try {
+      // Trim first, then validate (#7600)
+      const trimmedUsername = username.trim()
+
       // Validate GitHub username format
-      if (!/^[a-zA-Z0-9](?:[a-zA-Z0-9]|-(?=[a-zA-Z0-9])){0,38}$/.test(username)) {
+      if (!/^[a-zA-Z0-9](?:[a-zA-Z0-9]|-(?=[a-zA-Z0-9])){0,38}$/.test(trimmedUsername)) {
         throw new Error('Invalid GitHub username format')
       }
 
       // Save the invite
-      const trimmedUsername = username.trim()
       saveInvite(trimmedUsername)
 
       // Award coins (one-time only)

--- a/web/src/components/shared/ConditionBadges.tsx
+++ b/web/src/components/shared/ConditionBadges.tsx
@@ -36,6 +36,11 @@ export function ConditionBadges({ conditions, className }: ConditionBadgesProps)
   )
 }
 
+/** Well-known node pressure conditions that indicate problems when True or Unknown */
+const PRESSURE_CONDITIONS = new Set([
+  'DiskPressure', 'MemoryPressure', 'PIDPressure', 'NetworkUnavailable',
+])
+
 /**
  * Get the appropriate style class for a condition badge
  */
@@ -48,12 +53,13 @@ export function getConditionStyle(condition: Condition): string {
       : 'bg-red-500/20 text-red-400'
   }
 
-  // Pressure conditions (DiskPressure, MemoryPressure, PIDPressure, NetworkUnavailable)
-  // These are bad when True
-  if (status === 'True') {
-    return 'bg-orange-500/20 text-orange-400'
+  // Pressure conditions are bad when True, and Unknown should be treated as a warning
+  if (PRESSURE_CONDITIONS.has(type)) {
+    if (status === 'True') return 'bg-orange-500/20 text-orange-400'
+    if (status === 'Unknown') return 'bg-yellow-500/20 text-yellow-400'
   }
 
+  // Non-pressure conditions with True status are not inherently problematic
   return 'bg-secondary text-muted-foreground'
 }
 
@@ -63,9 +69,7 @@ export function getConditionStyle(condition: Condition): string {
 export function hasConditionIssues(conditions: Condition[]): boolean {
   return conditions.some(c =>
     (c.type === 'Ready' && c.status !== 'True') ||
-    ((c.type === 'DiskPressure' || c.type === 'MemoryPressure' ||
-      c.type === 'PIDPressure' || c.type === 'NetworkUnavailable') &&
-      c.status === 'True')
+    (PRESSURE_CONDITIONS.has(c.type) && (c.status === 'True' || c.status === 'Unknown'))
   )
 }
 
@@ -76,9 +80,7 @@ export function getConditionIssuesSummary(conditions: Condition[]): string {
   return conditions
     .filter(c =>
       (c.type === 'Ready' && c.status !== 'True') ||
-      ((c.type === 'DiskPressure' || c.type === 'MemoryPressure' ||
-        c.type === 'PIDPressure' || c.type === 'NetworkUnavailable') &&
-        c.status === 'True')
+      (PRESSURE_CONDITIONS.has(c.type) && (c.status === 'True' || c.status === 'Unknown'))
     )
     .map(c => `${c.type}: ${c.status}${c.message ? ` - ${c.message}` : ''}`)
     .join(', ') || 'Unknown issues'

--- a/web/src/lib/modals/useModalNavigation.ts
+++ b/web/src/lib/modals/useModalNavigation.ts
@@ -72,11 +72,20 @@ export function useModalNavigation({
         return
       }
 
-      // Don't handle other keys if user is typing in an input
+      // Don't handle other keys if user is interacting with an input or interactive control
       if (
         e.target instanceof HTMLInputElement ||
         e.target instanceof HTMLTextAreaElement ||
-        (e.target instanceof HTMLElement && e.target.isContentEditable)
+        (e.target instanceof HTMLElement && (
+          e.target.isContentEditable ||
+          e.target.tagName === 'BUTTON' ||
+          e.target.tagName === 'A' ||
+          e.target.tagName === 'SELECT' ||
+          e.target.getAttribute('role') === 'button' ||
+          e.target.getAttribute('role') === 'link' ||
+          e.target.getAttribute('role') === 'option' ||
+          e.target.getAttribute('role') === 'menuitem'
+        ))
       ) {
         return
       }

--- a/web/tailwind.config.js
+++ b/web/tailwind.config.js
@@ -6,6 +6,13 @@ export default {
     "./.storybook/**/*.{ts,tsx}",
   ],
   darkMode: 'class',
+  // Safelist dynamic severity color classes built at runtime via template strings
+  // (e.g. bg-${color}-500/10, border-${color}-500/50, text-${color}-400)
+  safelist: [
+    { pattern: /^bg-(red|orange|blue|green|yellow|purple)-500\/\d+$/ },
+    { pattern: /^border-(red|orange|blue|green|yellow|purple)-500\/\d+$/ },
+    { pattern: /^text-(red|orange|blue|green|yellow|purple)-400$/ },
+  ],
   theme: {
     extend: {
       fontSize: {


### PR DESCRIPTION
## Summary

Batch fix for 29 issues (#7580-#7608). 17 bugs fixed, 12 closed as not-a-bug/by-design.

### Bugs fixed
- **#7580**: Replace hardcoded `127.0.0.1:8585` with `LOCAL_AGENT_HTTP_URL` constant in EventsDrillDown
- **#7581**: Copy array before `.sort()` in HelmReleaseDrillDown render path to avoid state mutation
- **#7582**: Skip Space/Backspace modal handler on buttons, links, selects, and ARIA interactive roles
- **#7585**: Use `??` instead of `||` for threshold/duration init to preserve legitimate zero values
- **#7586**: Add Tailwind safelist for dynamic severity color classes (`bg-${color}-500/10`, etc.)
- **#7587**: Include weather fields and new-rule state changes in unsaved-change detection
- **#7588**: Clean up `diagnosisTimerRef` on AlertDetail unmount
- **#7590**: Reset `loadingTimedOut` when cluster/namespace changes in NamespaceResources
- **#7593**: Clear stale close timers when AddClusterDialog `open` becomes false
- **#7595, #7597**: Treat `Unknown` status as warning for pressure conditions in ConditionBadges
- **#7600**: Trim username before regex validation in GitHubInvite
- **#7601**: Validate parsed invite storage is an array before use
- **#7605**: URL-encode cluster/namespace/binding names in namespace API calls
- **#7606**: Disable Grant Access button when ServiceAccount namespace is empty
- **#7607**: Include `initialAccess` entries in CreateNamespaceModal discard guard
- **#7608**: Append SHA-256 hash suffix to binding names to prevent post-sanitization collisions

### Closed as not-a-bug / by-design
#7583, #7584, #7589, #7591, #7592, #7594, #7596, #7598, #7599, #7602, #7603, #7604

Fixes #7580, Fixes #7581, Fixes #7582, Fixes #7585, Fixes #7586, Fixes #7587, Fixes #7588, Fixes #7590, Fixes #7593, Fixes #7595, Fixes #7597, Fixes #7600, Fixes #7601, Fixes #7605, Fixes #7606, Fixes #7607, Fixes #7608

## Test plan
- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] `npm run build` passes (TypeScript + Vite + post-build checks)
- [ ] Verify EventsDrillDown works in non-localhost environments
- [ ] Verify zero-duration alert rules load correctly in AlertRuleEditor
- [ ] Verify ConditionBadges shows yellow for Unknown pressure status
- [ ] Verify ServiceAccount grant requires namespace field