### PR TITLE
fix: add kc-agent URLs to CSP connect-src

### DIFF
--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -412,12 +412,24 @@ func (s *Server) setupMiddleware() {
 		// Content-Security-Policy: restrict script/style sources to self and
 		// known analytics/CDN origins. 'unsafe-inline' is required for Vite
 		// dev mode injected styles and inline event handlers in the SPA.
+		//
+		// connect-src includes the local kc-agent (port 8585) for both HTTP
+		// and WebSocket on 127.0.0.1 and localhost. Without these, the
+		// browser blocks all frontend→agent communication because the agent
+		// runs on a different port than the backend (cross-origin).
+		// See: web/src/lib/constants/network.ts (LOCAL_AGENT_HTTP_URL,
+		// LOCAL_AGENT_WS_URL) for the exact URLs the frontend uses.
+		const kcAgentLoopback = "http://127.0.0.1:8585"    // kc-agent HTTP on loopback IP
+		const kcAgentLoopbackWS = "ws://127.0.0.1:8585"    // kc-agent WebSocket on loopback IP
+		const kcAgentLocalhost = "http://localhost:8585"    // kc-agent HTTP on localhost
+		const kcAgentLocalhostWS = "ws://localhost:8585"    // kc-agent WebSocket on localhost
+
 		c.Set("Content-Security-Policy",
 			"default-src 'self'; "+
 				"script-src 'self' 'unsafe-inline' https://www.googletagmanager.com; "+
 				"style-src 'self' 'unsafe-inline'; "+
 				"img-src 'self' data: https:; "+
-				"connect-src 'self' https://www.google-analytics.com https://www.googletagmanager.com wss:; "+
+				"connect-src 'self' "+kcAgentLoopback+" "+kcAgentLoopbackWS+" "+kcAgentLocalhost+" "+kcAgentLocalhostWS+" https://www.google-analytics.com https://www.googletagmanager.com wss:; "+
 				"font-src 'self' data:; "+
 				"object-src 'none'; "+
 				"base-uri 'self'")


### PR DESCRIPTION
## Summary

The Content-Security-Policy `connect-src` directive in `pkg/api/server.go` only allowed `'self'` (port 8080) and `wss:`, which blocked **all** frontend communication with the local kc-agent running on port 8585. This is because:

1. `'self'` only matches the same origin (port 8080) — port 8585 is cross-origin
2. `wss:` only matches **secure** WebSocket — the agent uses plain `ws://`
3. No explicit entry existed for `http://127.0.0.1:8585` or `ws://127.0.0.1:8585`

This single CSP misconfiguration is the root cause for 5 open issues.

### Changes

- Added named constants for the four kc-agent CSP origins (HTTP + WS on both `127.0.0.1` and `localhost`)
- Added all four to the `connect-src` directive
- Added comments explaining why these are needed and pointing to `web/src/lib/constants/network.ts` where the frontend URLs are defined
- Verified Netlify CSP (`netlify.toml`) does **not** need changes — it has no kc-agent since there's no local agent on Netlify deployments

Fixes #7610
Fixes #7611
Fixes #7612
Fixes #7613
Fixes #7614