### PR TITLE
fix: OPA install buttons, RBAC name length, and 4 Copilot review items (#7617, #7090)

### DIFF
--- a/pkg/k8s/rbac.go
+++ b/pkg/k8s/rbac.go
@@ -1039,10 +1039,22 @@ func (m *MultiClusterClient) GrantNamespaceAccess(ctx context.Context, contextNa
 	// Different inputs (e.g. "admin@foo.com" vs "admin-foo-com") can normalize to the same
 	// sanitized string, so we append a short hash of the raw components.
 	rawBindingKey := fmt.Sprintf("%s-%s-%s", req.SubjectName, roleName, namespace)
-	hashSuffixLen := 8 // Length of the hex hash suffix appended to binding names
+	const hashSuffixLen = 8  // Length of the hex hash suffix appended to binding names
+	const k8sNameMaxLen = 63 // Maximum length of a Kubernetes resource name
 	hash := sha256.Sum256([]byte(rawBindingKey))
 	hashSuffix := hex.EncodeToString(hash[:])[:hashSuffixLen]
-	bindingName := sanitizeK8sName(rawBindingKey) + "-" + hashSuffix
+	sanitized := sanitizeK8sName(rawBindingKey)
+	// Leave room for "-" separator + hash suffix so the final name stays within k8sNameMaxLen
+	hashSuffixTotalLen := 1 + hashSuffixLen // dash separator + hex hash
+	maxBaseLen := k8sNameMaxLen - hashSuffixTotalLen
+	if len(sanitized) > maxBaseLen {
+		sanitized = sanitized[:maxBaseLen]
+		// Trim trailing dashes/dots left by truncation
+		for len(sanitized) > 0 && (sanitized[len(sanitized)-1] == '-' || sanitized[len(sanitized)-1] == '.') {
+			sanitized = sanitized[:len(sanitized)-1]
+		}
+	}
+	bindingName := sanitized + "-" + hashSuffix
 
 	subject := rbacv1.Subject{
 		Kind: req.SubjectKind,

--- a/web/src/components/alerts/AlertRuleEditor.tsx
+++ b/web/src/components/alerts/AlertRuleEditor.tsx
@@ -21,6 +21,12 @@ const TEMPERATURE_MAX = 150 // Maximum temperature in Fahrenheit
 const WIND_SPEED_MIN = 1 // Minimum wind speed in mph
 const WIND_SPEED_MAX = 200 // Maximum wind speed in mph
 
+// Default values for new alert rules (used in unsaved-changes detection)
+const DEFAULT_THRESHOLD = 90 // Default GPU/memory threshold percentage
+const DEFAULT_DURATION_SECS = 60 // Default condition duration in seconds
+const DEFAULT_TEMPERATURE_F = 100 // Default temperature threshold in Fahrenheit
+const DEFAULT_WIND_SPEED_MPH = 40 // Default wind speed threshold in mph
+
 interface AlertRuleEditorProps {
   isOpen?: boolean
   rule?: AlertRule // If editing existing rule
@@ -58,8 +64,8 @@ export function AlertRuleEditor({ isOpen = true, rule, onSave, onCancel }: Alert
   const [conditionType, setAlertConditionType] = useState<AlertConditionType>(
     rule?.condition.type || 'gpu_usage'
   )
-  const [threshold, setThreshold] = useState(rule?.condition.threshold ?? 90)
-  const [duration, setDuration] = useState(rule?.condition.duration ?? 60)
+  const [threshold, setThreshold] = useState(rule?.condition.threshold ?? DEFAULT_THRESHOLD)
+  const [duration, setDuration] = useState(rule?.condition.duration ?? DEFAULT_DURATION_SECS)
   const [selectedClusters, setSelectedClusters] = useState<string[]>(
     rule?.condition.clusters || []
   )
@@ -71,8 +77,8 @@ export function AlertRuleEditor({ isOpen = true, rule, onSave, onCancel }: Alert
   const [weatherCondition, setWeatherCondition] = useState<'severe_storm' | 'extreme_heat' | 'heavy_rain' | 'snow' | 'high_wind'>(
     rule?.condition.weatherCondition || 'severe_storm'
   )
-  const [temperatureThreshold, setTemperatureThreshold] = useState(rule?.condition.temperatureThreshold ?? 100)
-  const [windSpeedThreshold, setWindSpeedThreshold] = useState(rule?.condition.windSpeedThreshold ?? 40)
+  const [temperatureThreshold, setTemperatureThreshold] = useState(rule?.condition.temperatureThreshold ?? DEFAULT_TEMPERATURE_F)
+  const [windSpeedThreshold, setWindSpeedThreshold] = useState(rule?.condition.windSpeedThreshold ?? DEFAULT_WIND_SPEED_MPH)
 
   // Channels state
   const [channels, setChannels] = useState<AlertChannel[]>(
@@ -95,16 +101,21 @@ export function AlertRuleEditor({ isOpen = true, rule, onSave, onCancel }: Alert
          severity !== rule.severity || enabled !== rule.enabled ||
          aiDiagnose !== (rule.aiDiagnose ?? true) ||
          conditionType !== rule.condition.type ||
-         threshold !== (rule.condition.threshold ?? 90) ||
-         duration !== (rule.condition.duration ?? 60) ||
+         threshold !== (rule.condition.threshold ?? DEFAULT_THRESHOLD) ||
+         duration !== (rule.condition.duration ?? DEFAULT_DURATION_SECS) ||
          weatherCondition !== (rule.condition.weatherCondition || 'severe_storm') ||
-         temperatureThreshold !== (rule.condition.temperatureThreshold ?? 100) ||
-         windSpeedThreshold !== (rule.condition.windSpeedThreshold ?? 40) ||
+         temperatureThreshold !== (rule.condition.temperatureThreshold ?? DEFAULT_TEMPERATURE_F) ||
+         windSpeedThreshold !== (rule.condition.windSpeedThreshold ?? DEFAULT_WIND_SPEED_MPH) ||
          JSON.stringify(selectedClusters) !== JSON.stringify(rule.condition.clusters || []) ||
          JSON.stringify(channels) !== JSON.stringify(rule.channels || []))
       : (name.trim() !== '' || description.trim() !== '' ||
-         severity !== 'warning' || conditionType !== 'gpu_usage' ||
-         selectedClusters.length > 0)
+         severity !== 'warning' || !enabled || aiDiagnose !== true ||
+         conditionType !== 'gpu_usage' ||
+         threshold !== DEFAULT_THRESHOLD || duration !== DEFAULT_DURATION_SECS ||
+         weatherCondition !== 'severe_storm' ||
+         temperatureThreshold !== DEFAULT_TEMPERATURE_F ||
+         windSpeedThreshold !== DEFAULT_WIND_SPEED_MPH ||
+         selectedClusters.length > 0 || channels.length > 0)
     if (hasChanges) {
       setShowDiscardConfirm(true)
       return

--- a/web/src/components/cards/OPAPolicies.tsx
+++ b/web/src/components/cards/OPAPolicies.tsx
@@ -731,7 +731,7 @@ Let's start by discussing what kind of policy I need.`,
               <button
                 key={cluster.name}
                 onClick={() => status?.installed && !isOffline && handleShowViolations(cluster.name)}
-                disabled={isOffline || !status?.installed || isInitialLoading}
+                disabled={isOffline || isInitialLoading}
                 className={`w-full text-left p-2.5 rounded-lg bg-secondary/30 transition-colors ${
                   !isOffline && status?.installed && !isInitialLoading
                     ? 'hover:bg-secondary/50 cursor-pointer group'

--- a/web/src/components/shared/ConditionBadges.tsx
+++ b/web/src/components/shared/ConditionBadges.tsx
@@ -14,8 +14,9 @@ interface ConditionBadgesProps {
 
 /**
  * Displays Kubernetes resource conditions as colored badges.
- * Ready=True is green, pressure conditions with True are orange warnings,
- * and Ready=False or other issues are red.
+ * Ready=True is green, Ready=False is red.
+ * Pressure conditions (DiskPressure, MemoryPressure, etc.): True=orange, Unknown=yellow.
+ * Non-pressure/non-Ready conditions use a muted style.
  */
 export function ConditionBadges({ conditions, className }: ConditionBadgesProps) {
   return (

--- a/web/src/lib/modals/useModalNavigation.ts
+++ b/web/src/lib/modals/useModalNavigation.ts
@@ -72,19 +72,14 @@ export function useModalNavigation({
         return
       }
 
-      // Don't handle other keys if user is interacting with an input or interactive control
+      // Don't handle other keys if user is interacting with an input or interactive control.
+      // Use closest() so child elements (e.g. <span>/<svg> inside a <button>) are caught too.
       if (
         e.target instanceof HTMLInputElement ||
         e.target instanceof HTMLTextAreaElement ||
         (e.target instanceof HTMLElement && (
           e.target.isContentEditable ||
-          e.target.tagName === 'BUTTON' ||
-          e.target.tagName === 'A' ||
-          e.target.tagName === 'SELECT' ||
-          e.target.getAttribute('role') === 'button' ||
-          e.target.getAttribute('role') === 'link' ||
-          e.target.getAttribute('role') === 'option' ||
-          e.target.getAttribute('role') === 'menuitem'
+          (e.target as HTMLElement).closest('button, a, select, [role="button"], [role="link"], [role="option"], [role="menuitem"]')
         ))
       ) {
         return

--- a/web/tailwind.config.js
+++ b/web/tailwind.config.js
@@ -12,6 +12,9 @@ export default {
     { pattern: /^bg-(red|orange|blue|green|yellow|purple)-500\/\d+$/ },
     { pattern: /^border-(red|orange|blue|green|yellow|purple)-500\/\d+$/ },
     { pattern: /^text-(red|orange|blue|green|yellow|purple)-400$/ },
+    { pattern: /^bg-(red|orange|blue|green|yellow|purple)-500\/\d+$/, variants: ['hover'] },
+    { pattern: /^border-(red|orange|blue|green|yellow|purple)-500\/\d+$/, variants: ['hover'] },
+    { pattern: /^text-(red|orange|blue|green|yellow|purple)-400$/, variants: ['hover'] },
   ],
   theme: {
     extend: {


### PR DESCRIPTION
## Summary
- **OPA card install buttons** (#7090): The "Install with AI Mission" `<span>` was inside a disabled `<button>` — browser ignores all click events on disabled buttons. Removed `!status?.installed` from the disabled condition.
- **RBAC binding name overflow**: `sanitizeK8sName()` truncates to 63 chars, but then 9 more chars (dash + 8-char hash) were appended, producing names up to 72 chars. Now reserves space for the suffix before truncating.
- **Modal keydown guard**: Used `closest()` instead of checking `e.target` directly, so child elements (e.g. `<svg>` inside `<button>`) are caught.
- **AlertRuleEditor unsaved-changes**: Added missing threshold, duration, weather, and channel fields to the new-rule dirty check.
- **Tailwind safelist**: Added `hover:` variant patterns for dynamic severity color classes.
- **ConditionBadges doc comment**: Updated to match actual behavior (pressure=orange/yellow, non-pressure=muted).

Fixes #7617
Fixes #7090

## Test plan
- [ ] OPA card "Install with AI Mission" link is clickable when OPA is not installed
- [ ] RBAC binding names stay within 63 chars even for long subject names
- [ ] Modal Backspace/Space keys don't fire when focus is on a child of a button
- [ ] AlertRuleEditor shows discard-confirm when threshold/duration changed on new rule
- [ ] `hover:bg-red-500/20` etc. classes are present in production CSS
- [ ] Build passes: `npm run build`