### PR TITLE
fix: sidebar ESC propagation and agent selector z-index

### DIFF
--- a/web/src/components/agent/AgentSelector.tsx
+++ b/web/src/components/agent/AgentSelector.tsx
@@ -415,7 +415,7 @@ export function AgentSelector({ compact = false, className = '' }: AgentSelector
           ref={panelRef}
           role="listbox"
           aria-label={t('agent.selectAgent')}
-          className="fixed z-floating w-96 max-h-[calc(100vh-8rem)] rounded-lg bg-card border border-border shadow-lg overflow-hidden flex flex-col"
+          className="fixed z-modal w-96 max-h-[calc(100vh-8rem)] rounded-lg bg-card border border-border shadow-lg overflow-hidden flex flex-col"
           style={{ top: dropdownPos.top, right: dropdownPos.right }}
           onKeyDown={(e) => {
             if (e.key !== 'ArrowDown' && e.key !== 'ArrowUp') return

--- a/web/src/components/layout/mission-sidebar/MissionSidebar.tsx
+++ b/web/src/components/layout/mission-sidebar/MissionSidebar.tsx
@@ -486,23 +486,24 @@ export function MissionSidebar() {
 
   const pendingMission = pendingRunMissionId ? missions.find(m => m.id === pendingRunMissionId) : null
 
-  // Escape key: exit fullscreen first, then close sidebar
+  // Escape key: exit fullscreen first, then close sidebar.
+  // Skip when an overlay (MissionBrowser or MissionControlDialog) is open —
+  // those handle their own Escape and closing the sidebar behind them is wrong.
   useEffect(() => {
     const handleEscape = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') {
-        if (isFullScreen) {
-          setFullScreen(false)
-          // Only exit fullscreen — don't close sidebar (second Escape will close it)
-        } else if (isSidebarOpen) {
-          closeSidebar()
-        }
+      if (e.key !== 'Escape') return
+      if (showBrowser || showMissionControl) return
+      if (isFullScreen) {
+        setFullScreen(false)
+      } else if (isSidebarOpen) {
+        closeSidebar()
       }
     }
     if (isSidebarOpen) {
       document.addEventListener('keydown', handleEscape)
       return () => document.removeEventListener('keydown', handleEscape)
     }
-  }, [isSidebarOpen, isFullScreen, setFullScreen, closeSidebar])
+  }, [isSidebarOpen, isFullScreen, showBrowser, showMissionControl, setFullScreen, closeSidebar])
 
   // Count missions needing attention
   // Blocked missions are stuck waiting on user action (preflight failure,


### PR DESCRIPTION
## Summary
- **ESC key bug**: Pressing ESC when MissionBrowser or MissionControlDialog is open from the AI Missions sidebar closed both the overlay AND the sidebar. Now the sidebar's ESC handler skips when an overlay is active.
- **Agent selector z-index**: The AgentSelector dropdown used `z-floating` (250) but the sidebar uses `z-modal` (400), so the dropdown rendered behind the sidebar. Promoted to `z-modal`.

## Test plan
- [ ] Open AI Missions sidebar → open Mission Explorer → press ESC → only Mission Explorer closes, sidebar stays open
- [ ] Open AI Missions sidebar → open Mission Control → press ESC → only Mission Control closes, sidebar stays open
- [ ] Open AI Missions sidebar → press ESC → sidebar closes (no overlays open)
- [ ] Open AI Missions sidebar → click agent selector dropdown → dropdown appears ON TOP of sidebar
- [ ] Verify agent selector in navbar still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)