### PR TITLE
fix: duplicate React keys flooding console warnings

### DIFF
--- a/web/src/components/cards/EventStream.tsx
+++ b/web/src/components/cards/EventStream.tsx
@@ -260,7 +260,7 @@ function EventStreamInternal({ config }: { config?: EventStreamConfig }) {
 
             return (
               <div
-                key={`${event.cluster || 'unknown'}-${event.object}-${event.lastSeen || event.firstSeen || ''}-${event.reason}`}
+                key={`${event.cluster || 'unknown'}-${event.object}-${event.lastSeen || event.firstSeen || ''}-${event.reason}-${idx}`}
                 className={`flex items-start gap-3 p-3 rounded-lg hover:bg-secondary/40 transition-colors cursor-pointer group ${idx % 2 === 0 ? 'bg-secondary/10' : 'bg-secondary/25'}`}
                 onClick={() => handleEventClick(event)}
                 title={`Click to view details for ${event.object}`}

--- a/web/src/components/dashboard/Dashboard.tsx
+++ b/web/src/components/dashboard/Dashboard.tsx
@@ -645,8 +645,9 @@ export function Dashboard() {
         // ALWAYS preserve local-only cards (not yet persisted to backend)
         // This prevents losing cards when cache expires or user navigates back
         setLocalCards((prevCards) => {
-          // Keep local-only cards that aren't in the API response
-          const localOnlyCards = prevCards.filter(c => isLocalOnlyCard(c.id))
+          // Keep local-only cards that aren't already in the API response
+          const apiCardIds = new Set(apiCards.map(c => c.id))
+          const localOnlyCards = prevCards.filter(c => isLocalOnlyCard(c.id) && !apiCardIds.has(c.id))
           // If we have local-only cards, merge them with API cards
           if (localOnlyCards.length > 0) {
             return [...localOnlyCards, ...apiCards]


### PR DESCRIPTION
## Summary
- **Demo cards (demo-1 through demo-7)**: `loadDashboard` merged local-only cards with API fallback demo cards, but both sets had identical IDs. Now skips local cards already present in the API response.
- **EventStream events**: Same cluster/object/timestamp/reason produced identical keys. Append list index to guarantee uniqueness.

## Test plan
- [ ] Open console in demo mode, check browser console — no more "duplicate key" warnings
- [ ] Verify dashboard cards render correctly (no missing/duplicated cards)
- [ ] Check EventStream card shows all events without duplicates

🤖 Generated with [Claude Code](https://claude.com/claude-code)