### PR TITLE
fix(ci): only open issues for Build failures on main

### DIFF
--- a/.github/workflows/workflow-failure-issue.yml
+++ b/.github/workflows/workflow-failure-issue.yml
@@ -35,7 +35,8 @@ jobs:
       github.event.workflow_run.conclusion == 'failure' &&
       (github.event.workflow_run.event == 'schedule' ||
        github.event.workflow_run.event == 'workflow_dispatch' ||
-       github.event.workflow_run.name == 'Build and Deploy KC')
+       (github.event.workflow_run.name == 'Build and Deploy KC' &&
+        github.event.workflow_run.head_branch == 'main'))
     steps:
       - name: Check for existing open issue
         id: check


### PR DESCRIPTION
Restrict the Build and Deploy KC workflow failure monitor to only create issues when the failure occurs on main, not on PR branches. PR branch build failures are expected CI behavior. Fixes #7643