### PR TITLE
fix: agent selector and profile button heights to match h-9

### DIFF
--- a/web/src/components/agent/AgentSelector.tsx
+++ b/web/src/components/agent/AgentSelector.tsx
@@ -387,7 +387,7 @@ export function AgentSelector({ compact = false, className = '' }: AgentSelector
         aria-haspopup="listbox"
         aria-expanded={isOpen}
         className={cn(
-          'flex items-center gap-2 px-3 py-1.5 min-h-[44px] rounded-lg border transition-colors',
+          'flex items-center gap-2 px-3 py-1.5 h-9 rounded-lg border transition-colors',
           'bg-secondary/50 border-border hover:bg-secondary',
           isOpen && 'ring-1 ring-primary'
         )}

--- a/web/src/components/layout/UserProfileDropdown.tsx
+++ b/web/src/components/layout/UserProfileDropdown.tsx
@@ -127,17 +127,17 @@ export function UserProfileDropdown({ user, onLogout, onPreferences }: UserProfi
       {/* Trigger button */}
       <button
         onClick={toggleDropdown}
-        className="flex items-center gap-3 pl-3 border-l border-border hover:bg-secondary rounded-lg p-2 transition-colors"
+        className="flex items-center gap-2 pl-3 border-l border-border hover:bg-secondary rounded-lg p-1.5 h-9 transition-colors"
       >
         {user.avatar_url ? (
           <img
             src={user.avatar_url}
             alt={user.github_login}
-            className="w-8 h-8 rounded-full"
+            className="w-6 h-6 rounded-full"
           />
         ) : (
-          <div className="w-8 h-8 rounded-full bg-purple-900 flex items-center justify-center">
-            <User className="w-4 h-4 text-purple-400" />
+          <div className="w-6 h-6 rounded-full bg-purple-900 flex items-center justify-center">
+            <User className="w-3.5 h-3.5 text-purple-400" />
           </div>
         )}
         <div className="hidden sm:block text-left">


### PR DESCRIPTION
## Summary
- AgentSelector trigger button used `min-h-[44px]` (44px) — now `h-9` (36px)
- UserProfileDropdown used `p-2` with `w-8 h-8` avatar (48px effective) — now `p-1.5 h-9` with `w-6 h-6` avatar

Continues the navbar height normalization from #7639.

## Test plan
- [ ] All navbar buttons render at the same height
- [ ] Agent selector dropdown still opens correctly
- [ ] Profile dropdown still works, avatar still visible
- [ ] Mobile overflow menu unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)