### PR TITLE
fix: update test mocks for onSettled callback + remove double-count bug

### DIFF
--- a/web/src/hooks/__tests__/useCachedData.test.ts
+++ b/web/src/hooks/__tests__/useCachedData.test.ts
@@ -74,7 +74,17 @@ vi.mock('../../lib/constants/network', async (importOriginal) => {
 } })
 
 vi.mock('../../lib/utils/concurrency', () => ({
-  settledWithConcurrency: (...args: unknown[]) => mockSettledWithConcurrency(...args),
+  settledWithConcurrency: async (...args: unknown[]) => {
+    const result = await mockSettledWithConcurrency(...args)
+    // Invoke the onSettled callback (3rd arg) so the production code's
+    // accumulation logic runs.  Without this, tests that use mockResolvedValue
+    // silently skip the callback and return empty results.
+    const onSettled = args[2] as ((r: PromiseSettledResult<unknown>, i: number) => void) | undefined
+    if (onSettled && Array.isArray(result)) {
+      result.forEach((r: PromiseSettledResult<unknown>, i: number) => onSettled(r, i))
+    }
+    return result
+  },
 }))
 
 vi.mock('../useCachedProw', () => ({

--- a/web/src/hooks/__tests__/useCachedISO27001.test.ts
+++ b/web/src/hooks/__tests__/useCachedISO27001.test.ts
@@ -49,7 +49,14 @@ vi.mock('../useLocalAgent', () => ({
 }))
 
 vi.mock('../../lib/utils/concurrency', () => ({
-  settledWithConcurrency: (...args: unknown[]) => mockSettledWithConcurrency(...args),
+  settledWithConcurrency: async (...args: unknown[]) => {
+    const result = await mockSettledWithConcurrency(...args)
+    const onSettled = args[2] as ((r: PromiseSettledResult<unknown>, i: number) => void) | undefined
+    if (onSettled && Array.isArray(result)) {
+      result.forEach((r: PromiseSettledResult<unknown>, i: number) => onSettled(r, i))
+    }
+    return result
+  },
 }))
 
 // ---------------------------------------------------------------------------

--- a/web/src/hooks/__tests__/useCachedLLMd.test.ts
+++ b/web/src/hooks/__tests__/useCachedLLMd.test.ts
@@ -40,7 +40,14 @@ vi.mock('../../lib/constants/network', async (importOriginal) => {
 })
 
 vi.mock('../../lib/utils/concurrency', () => ({
-  settledWithConcurrency: (...args: unknown[]) => mockSettledWithConcurrency(...args),
+  settledWithConcurrency: async (...args: unknown[]) => {
+    const result = await mockSettledWithConcurrency(...args)
+    const onSettled = args[2] as ((r: PromiseSettledResult<unknown>, i: number) => void) | undefined
+    if (onSettled && Array.isArray(result)) {
+      result.forEach((r: PromiseSettledResult<unknown>, i: number) => onSettled(r, i))
+    }
+    return result
+  },
 }))
 
 // ---------------------------------------------------------------------------

--- a/web/src/hooks/useCachedData.ts
+++ b/web/src/hooks/useCachedData.ts
@@ -167,7 +167,7 @@ async function fetchFromAllClusters<T>(
   const accumulated: T[] = []
   let failedCount = 0
 
-  const settled = await settledWithConcurrency(tasks, undefined, (result) => {
+  await settledWithConcurrency(tasks, undefined, (result) => {
     if (result.status === 'fulfilled') {
       accumulated.push(...result.value)
       onProgress?.([...accumulated])
@@ -175,17 +175,6 @@ async function fetchFromAllClusters<T>(
       failedCount++
     }
   })
-
-  // Final aggregation pass for callers that don't use onProgress
-  if (accumulated.length === 0) {
-    for (const result of settled) {
-      if (result.status === 'fulfilled') {
-        accumulated.push(...result.value)
-      } else {
-        failedCount++
-      }
-    }
-  }
 
   // If every cluster fetch failed, throw so callers can try agent fallback
   if (accumulated.length === 0 && clusters.length > 0 && failedCount === clusters.length) {


### PR DESCRIPTION
PR #7640 added an onSettled callback to settledWithConcurrency but test mocks did not invoke the callback, causing 74 test failures. Updates vi.mock wrappers in 3 test files and removes the redundant aggregation pass that double-counted failedCount.

Fixes #7645