### PR TITLE
fix: resolve conflicting padding classes on profile button

### DIFF
--- a/web/src/components/layout/UserProfileDropdown.tsx
+++ b/web/src/components/layout/UserProfileDropdown.tsx
@@ -127,7 +127,7 @@ export function UserProfileDropdown({ user, onLogout, onPreferences }: UserProfi
       {/* Trigger button */}
       <button
         onClick={toggleDropdown}
-        className="flex items-center gap-2 pl-3 border-l border-border hover:bg-secondary rounded-lg p-1.5 h-9 transition-colors"
+        className="flex items-center gap-2 border-l border-border hover:bg-secondary rounded-lg px-3 py-1.5 h-9 transition-colors"
       >
         {user.avatar_url ? (
           <img


### PR DESCRIPTION
pl-3 was overridden by p-1.5 (both set padding-left). Replace with explicit px-3 py-1.5 so horizontal padding is 0.75rem and vertical is 0.375rem as intended.

Fixes #7650