### PR TITLE
fix: instant dashboard navigation — skip refetch when cache is fresh

### DIFF
--- a/web/src/lib/cache/index.ts
+++ b/web/src/lib/cache/index.ts
@@ -1227,10 +1227,17 @@ export function useCache<T>({
     // Only fetch immediately on initial mount or page navigation, NOT when
     // the effect re-fires due to consecutiveFailures/backoff interval changes.
     if (!isModeTransition && !initialFetchDoneRef.current && keepAliveActive) {
-      // Initial mount or page navigation remount — fetch immediately.
-      // Only mark done when we actually started a fetch (#5891).
       initialFetchDoneRef.current = true
-      refetch().catch(() => { /* errors handled inside CacheStore.fetch */ })
+      // If the shared cache already has fresh data (fetched within the refresh
+      // interval), skip the immediate fetch — the auto-refresh timer will
+      // update it in the background. This prevents dashboard navigation from
+      // blocking on multi-cluster fetches that hit unreachable clusters.
+      const lastRefresh = state.lastRefresh
+      const dataAge = lastRefresh ? Date.now() - lastRefresh : Infinity
+      const hasFreshData = !state.isLoading && dataAge < baseInterval
+      if (!hasFreshData) {
+        refetch().catch(() => { /* errors handled inside CacheStore.fetch */ })
+      }
     }
     // else: mode transition — triggerAllRefetches() will call refetch after skeleton timer
     // else: backoff re-fire — let the interval handle the next retry


### PR DESCRIPTION
## Summary
- Dashboard navigation (Cluster Admin, Security, etc.) was blocking 5-11+ seconds because `useCached*` hooks fired immediate multi-cluster refetches on every page mount
- Now skips the immediate fetch when the shared cache already has data fetched within the refresh interval
- The auto-refresh timer handles background updates transparently

### Before
| Route | Time |
|-------|------|
| / (Dashboard) | 759ms |
| /clusters | 1,073ms |
| /cluster-admin | **11,342ms** |
| /security | **4,449ms** |

### Expected After
All routes should render in <2s using cached data.

## Test plan
- [ ] Navigate between Dashboard, My Clusters, Cluster Admin, Sec. Compliance — all should switch instantly
- [ ] Data still refreshes in background (watch stats update after a few seconds)
- [ ] First load (cold cache) still fetches immediately
- [ ] Demo mode unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)