### PR TITLE
fix: resolve 7 cache test failures from fresh-data skip guard

### DIFF
--- a/web/src/lib/cache/__tests__/cache-coverage.test.ts
+++ b/web/src/lib/cache/__tests__/cache-coverage.test.ts
@@ -69,6 +69,10 @@ const CACHE_VERSION = 4
 const SS_PREFIX = 'kcc:'
 const META_PREFIX = 'kc_meta:'
 
+/** Offset (ms) to make seeded cache data older than any refresh interval,
+ *  ensuring the initial fetch is NOT skipped by the fresh-data guard (#7653). */
+const STALE_AGE_MS = 600_000
+
 async function importFresh() {
   vi.resetModules()
   return import('../index')
@@ -153,7 +157,7 @@ describe('clearAllInMemoryCaches', () => {
 describe('CacheStore.fetch() with merge function', () => {
   it('merges old and new data when merge is provided and cache exists', async () => {
     // Seed cache so store has cached data
-    seedSessionStorage('merge-test', [1, 2], Date.now())
+    seedSessionStorage('merge-test', [1, 2], Date.now() - STALE_AGE_MS)
 
     const { useCache } = await importFresh()
     const fetcher = vi.fn().mockResolvedValue([3, 4])
@@ -249,7 +253,7 @@ describe('CacheStore.fetch() with progressive fetcher', () => {
 
   it('saves partial data on progressive fetcher error', async () => {
     // Seed to give hasCachedData = true via session snapshot
-    seedSessionStorage('prog-error', [99], Date.now())
+    seedSessionStorage('prog-error', [99], Date.now() - STALE_AGE_MS)
 
     const { useCache } = await importFresh()
 
@@ -363,7 +367,7 @@ describe('CacheStore.fetch() error handling', () => {
 
 describe('CacheStore.fetch() empty data guard', () => {
   it('keeps cached data when fetcher returns empty and cache exists', async () => {
-    seedSessionStorage('empty-guard', [1, 2], Date.now())
+    seedSessionStorage('empty-guard', [1, 2], Date.now() - STALE_AGE_MS)
     const { useCache } = await importFresh()
 
     const fetcher = vi.fn().mockResolvedValue([])
@@ -409,7 +413,7 @@ describe('CacheStore.fetch() empty data guard', () => {
 
 describe('clearAndRefetch', () => {
   it('clears cache and triggers a new fetch', async () => {
-    seedSessionStorage('clear-refetch', [1], Date.now())
+    seedSessionStorage('clear-refetch', [1], Date.now() - STALE_AGE_MS)
     const { useCache } = await importFresh()
 
     let fetchCount = 0

--- a/web/src/lib/cache/__tests__/cache.test.ts
+++ b/web/src/lib/cache/__tests__/cache.test.ts
@@ -45,6 +45,10 @@ vi.mock('../workerRpc', () => ({
 // Helpers
 // ---------------------------------------------------------------------------
 
+/** Offset (ms) to make seeded cache data older than any refresh interval,
+ *  ensuring the initial fetch is NOT skipped by the fresh-data guard (#7653). */
+const STALE_AGE_MS = 600_000
+
 async function importFresh() {
   vi.resetModules()
   return import('../index')
@@ -1901,7 +1905,7 @@ describe('cache module', () => {
       const mod = await importFresh()
 
       const cachedData = ['existing-item']
-      seedSessionStorage('prog-empty', cachedData, Date.now())
+      seedSessionStorage('prog-empty', cachedData, Date.now() - STALE_AGE_MS)
 
       const fetcher = vi.fn().mockResolvedValue(['final-item'])
       const progressiveFetcher = vi.fn(async (onProgress: (d: string[]) => void) => {
@@ -1935,7 +1939,7 @@ describe('cache module', () => {
       setDemoMode(false)
       const mod = await importFresh()
 
-      seedSessionStorage('merge-test', ['old-1'], Date.now())
+      seedSessionStorage('merge-test', ['old-1'], Date.now() - STALE_AGE_MS)
 
       const fetcher = vi.fn().mockResolvedValue(['new-1'])
       const merge = vi.fn((old: string[], new_: string[]) => [...old, ...new_])
@@ -3041,7 +3045,7 @@ describe('cache module', () => {
       const mod = await importFresh()
 
       // Seed cache with existing data
-      seedSessionStorage('sse-empty-guard-1', ['cached-data'], Date.now())
+      seedSessionStorage('sse-empty-guard-1', ['cached-data'], Date.now() - STALE_AGE_MS)
 
       const progressiveFetcher = vi.fn(async (onProgress: (d: string[]) => void) => {
         // Push an empty array (should be ignored by isEquivalentToInitial guard)


### PR DESCRIPTION
## Summary
- PR #7653 added a fresh-data guard that skips the initial fetch when cached data is younger than the refresh interval
- 7 cache tests seeded `sessionStorage` with `Date.now()`, making data appear fresh — the fetcher was never called, breaking assertions on merge, progressive fetch, empty-data guard, and `clearAndRefetch`
- Fixed by using `Date.now() - STALE_AGE_MS` (600s) so seeded data is always considered stale and the fetch runs as expected

Fixes #7666

## Test plan
- [x] `npx vitest run src/lib/cache/__tests__/` — all 496 tests pass (0 failures)
- [x] `npm run build` — clean build, all post-build checks pass