### PR TITLE
fix: cache fresh-data check skipped fetch on storage hydration

### DIFF
--- a/web/src/lib/cache/index.ts
+++ b/web/src/lib/cache/index.ts
@@ -1232,9 +1232,11 @@ export function useCache<T>({
       // interval), skip the immediate fetch — the auto-refresh timer will
       // update it in the background. This prevents dashboard navigation from
       // blocking on multi-cluster fetches that hit unreachable clusters.
+      // The isRefreshing guard ensures hydrated-from-storage data (which starts
+      // with isRefreshing=true) always triggers a real fetch on first mount.
       const lastRefresh = state.lastRefresh
       const dataAge = lastRefresh ? Date.now() - lastRefresh : Infinity
-      const hasFreshData = !state.isLoading && dataAge < baseInterval
+      const hasFreshData = !state.isLoading && !state.isRefreshing && dataAge < baseInterval
       if (!hasFreshData) {
         refetch().catch(() => { /* errors handled inside CacheStore.fetch */ })
       }


### PR DESCRIPTION
## Summary
- The `hasFreshData` optimization from #7653 skipped the initial fetch when sessionStorage had recent data
- This broke merge functions and progressive fetchers because they never ran on mount
- Root cause: hydrated data has `isRefreshing=true` but the check only looked at `isLoading` and `dataAge`
- Fix: add `!state.isRefreshing` to the condition — hydrated data (isRefreshing=true) always fetches; completed in-session fetches (isRefreshing=false) correctly skip

## Test plan
- [x] `cache.test.ts` — 190 pass (was 3 failing)
- [x] `cache-coverage.test.ts` — 66 pass (was 4 failing)
- [x] All 256 cache tests pass
- [x] `npm run build` — passes

Fixes #7666

🤖 Generated with [Claude Code](https://claude.com/claude-code)