### PR TITLE
fix: promote error logs from Info to Warn/Error across 10 files

### DIFF
--- a/pkg/agent/config.go
+++ b/pkg/agent/config.go
@@ -2,6 +2,7 @@ package agent
 
 import (
 	"fmt"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"sync"
@@ -47,6 +48,7 @@ func GetConfigManager() *ConfigManager {
 	configManagerOnce.Do(func() {
 		homeDir, err := os.UserHomeDir()
 		if err != nil {
+			slog.Warn("[AgentConfig] HOME directory unavailable, falling back to current directory for config", "error", err)
 			homeDir = "."
 		}
 		configPath := filepath.Join(homeDir, configDirName, configFileName)

--- a/pkg/agent/kagent_crds.go
+++ b/pkg/agent/kagent_crds.go
@@ -142,7 +142,7 @@ func (s *Server) handleKagentCRDAgents(w http.ResponseWriter, r *http.Request) {
 
 	dynClient, err := s.k8sClient.GetDynamicClient(cluster)
 	if err != nil {
-		slog.Info("error fetching kagent agents for cluster request")
+		slog.Warn("error fetching kagent agents for cluster", "error", err)
 		w.WriteHeader(http.StatusInternalServerError)
 		json.NewEncoder(w).Encode(map[string]any{"agents": []any{}, "error": "internal server error"})
 		return
@@ -245,7 +245,7 @@ func (s *Server) handleKagentCRDTools(w http.ResponseWriter, r *http.Request) {
 
 	dynClient, err := s.k8sClient.GetDynamicClient(cluster)
 	if err != nil {
-		slog.Info("error fetching kagent tools for cluster request")
+		slog.Warn("error fetching kagent tools for cluster", "error", err)
 		w.WriteHeader(http.StatusInternalServerError)
 		json.NewEncoder(w).Encode(map[string]any{"tools": []any{}, "error": "internal server error"})
 		return
@@ -378,7 +378,7 @@ func (s *Server) handleKagentCRDModels(w http.ResponseWriter, r *http.Request) {
 
 	dynClient, err := s.k8sClient.GetDynamicClient(cluster)
 	if err != nil {
-		slog.Info("error fetching kagent models for cluster request")
+		slog.Warn("error fetching kagent models for cluster", "error", err)
 		w.WriteHeader(http.StatusInternalServerError)
 		json.NewEncoder(w).Encode(map[string]any{"models": []any{}, "error": "internal server error"})
 		return
@@ -504,7 +504,7 @@ func (s *Server) handleKagentCRDMemories(w http.ResponseWriter, r *http.Request)
 
 	dynClient, err := s.k8sClient.GetDynamicClient(cluster)
 	if err != nil {
-		slog.Info("error fetching kagent memories for cluster request")
+		slog.Warn("error fetching kagent memories for cluster", "error", err)
 		w.WriteHeader(http.StatusInternalServerError)
 		json.NewEncoder(w).Encode(map[string]any{"memories": []any{}, "error": "internal server error"})
 		return
@@ -576,7 +576,7 @@ func (s *Server) handleKagentCRDSummary(w http.ResponseWriter, r *http.Request) 
 
 	dynClient, err := s.k8sClient.GetDynamicClient(cluster)
 	if err != nil {
-		slog.Info("error fetching kagent CRD summary for cluster request")
+		slog.Warn("error fetching kagent CRD summary for cluster", "error", err)
 		w.WriteHeader(http.StatusInternalServerError)
 		json.NewEncoder(w).Encode(map[string]any{
 			"agentCount": 0, "toolServerCount": 0, "remoteMCPServerCount": 0,

--- a/pkg/agent/kagenti.go
+++ b/pkg/agent/kagenti.go
@@ -144,7 +144,7 @@ func (s *Server) handleKagentiAgents(w http.ResponseWriter, r *http.Request) {
 
 	dynClient, err := s.k8sClient.GetDynamicClient(cluster)
 	if err != nil {
-		slog.Info("error fetching agents", "error", err)
+		slog.Warn("error fetching agents", "error", err)
 		w.WriteHeader(http.StatusInternalServerError)
 		json.NewEncoder(w).Encode(map[string]any{"agents": []any{}, "error": "internal server error"})
 		return
@@ -228,7 +228,7 @@ func (s *Server) handleKagentiBuilds(w http.ResponseWriter, r *http.Request) {
 
 	dynClient, err := s.k8sClient.GetDynamicClient(cluster)
 	if err != nil {
-		slog.Info("error fetching builds", "error", err)
+		slog.Warn("error fetching builds", "error", err)
 		w.WriteHeader(http.StatusInternalServerError)
 		json.NewEncoder(w).Encode(map[string]any{"builds": []any{}, "error": "internal server error"})
 		return
@@ -307,7 +307,7 @@ func (s *Server) handleKagentiCards(w http.ResponseWriter, r *http.Request) {
 
 	dynClient, err := s.k8sClient.GetDynamicClient(cluster)
 	if err != nil {
-		slog.Info("error fetching cards", "error", err)
+		slog.Warn("error fetching cards", "error", err)
 		w.WriteHeader(http.StatusInternalServerError)
 		json.NewEncoder(w).Encode(map[string]any{"cards": []any{}, "error": "internal server error"})
 		return
@@ -384,7 +384,7 @@ func (s *Server) handleKagentiTools(w http.ResponseWriter, r *http.Request) {
 
 	dynClient, err := s.k8sClient.GetDynamicClient(cluster)
 	if err != nil {
-		slog.Info("error fetching tools", "error", err)
+		slog.Warn("error fetching tools", "error", err)
 		w.WriteHeader(http.StatusInternalServerError)
 		json.NewEncoder(w).Encode(map[string]any{"tools": []any{}, "error": "internal server error"})
 		return
@@ -458,7 +458,7 @@ func (s *Server) handleKagentiSummary(w http.ResponseWriter, r *http.Request) {
 
 	dynClient, err := s.k8sClient.GetDynamicClient(cluster)
 	if err != nil {
-		slog.Info("error fetching kagenti summary", "error", err)
+		slog.Warn("error fetching kagenti summary", "error", err)
 		w.WriteHeader(http.StatusInternalServerError)
 		json.NewEncoder(w).Encode(map[string]any{
 			"agentCount": 0, "readyAgents": 0, "buildCount": 0,

--- a/pkg/agent/server_http.go
+++ b/pkg/agent/server_http.go
@@ -84,7 +84,7 @@ func (s *Server) handleGPUNodesHTTP(w http.ResponseWriter, r *http.Request) {
 	if cluster != "" {
 		nodes, err := s.k8sClient.GetGPUNodes(ctx, cluster)
 		if err != nil {
-			slog.Info("error fetching nodes", "error", err)
+			slog.Warn("error fetching nodes", "error", err)
 			writeJSON(w,map[string]interface{}{"nodes": []interface{}{}, "error": "internal server error"})
 			return
 		}
@@ -93,7 +93,7 @@ func (s *Server) handleGPUNodesHTTP(w http.ResponseWriter, r *http.Request) {
 		// Query all clusters
 		clusters, err := s.k8sClient.ListClusters(ctx)
 		if err != nil {
-			slog.Info("error fetching nodes", "error", err)
+			slog.Warn("error fetching nodes", "error", err)
 			writeJSON(w,map[string]interface{}{"nodes": []interface{}{}, "error": "internal server error"})
 			return
 		}
@@ -155,7 +155,7 @@ func (s *Server) handleNodesHTTP(w http.ResponseWriter, r *http.Request) {
 		// Query specific cluster
 		nodes, err := s.k8sClient.GetNodes(ctx, cluster)
 		if err != nil {
-			slog.Info("error fetching nodes", "error", err)
+			slog.Warn("error fetching nodes", "error", err)
 			writeJSON(w,map[string]interface{}{"nodes": []interface{}{}, "error": "internal server error"})
 			return
 		}
@@ -164,7 +164,7 @@ func (s *Server) handleNodesHTTP(w http.ResponseWriter, r *http.Request) {
 		// Query all clusters
 		clusters, err := s.k8sClient.ListClusters(ctx)
 		if err != nil {
-			slog.Info("error fetching nodes", "error", err)
+			slog.Warn("error fetching nodes", "error", err)
 			writeJSON(w,map[string]interface{}{"nodes": []interface{}{}, "error": "internal server error"})
 			return
 		}
@@ -242,7 +242,7 @@ func (s *Server) handleEventsHTTP(w http.ResponseWriter, r *http.Request) {
 	// Get events from the cluster
 	events, err := s.k8sClient.GetEvents(ctx, cluster, namespace, limit)
 	if err != nil {
-		slog.Info("error fetching events", "error", err)
+		slog.Warn("error fetching events", "error", err)
 		writeJSON(w,map[string]interface{}{"events": []interface{}{}, "error": "internal server error"})
 		return
 	}
@@ -293,7 +293,7 @@ func (s *Server) handleNamespacesHTTP(w http.ResponseWriter, r *http.Request) {
 
 	namespaces, err := s.k8sClient.ListNamespacesWithDetails(ctx, cluster)
 	if err != nil {
-		slog.Info("error fetching namespaces", "error", err)
+		slog.Warn("error fetching namespaces", "error", err)
 		writeJSON(w,map[string]interface{}{"namespaces": []interface{}{}, "error": "internal server error"})
 		return
 	}
@@ -339,7 +339,7 @@ func (s *Server) handleDeploymentsHTTP(w http.ResponseWriter, r *http.Request) {
 
 	deployments, err := s.k8sClient.GetDeployments(ctx, cluster, namespace)
 	if err != nil {
-		slog.Info("error fetching deployments", "error", err)
+		slog.Warn("error fetching deployments", "error", err)
 		writeJSON(w,map[string]interface{}{"deployments": []interface{}{}, "error": "internal server error"})
 		return
 	}
@@ -374,7 +374,7 @@ func (s *Server) handleReplicaSetsHTTP(w http.ResponseWriter, r *http.Request) {
 	defer cancel()
 	replicasets, err := s.k8sClient.GetReplicaSets(ctx, cluster, namespace)
 	if err != nil {
-		slog.Info("error fetching replicasets", "error", err)
+		slog.Warn("error fetching replicasets", "error", err)
 		writeJSON(w,map[string]interface{}{"replicasets": []interface{}{}, "error": "internal server error"})
 		return
 	}
@@ -408,7 +408,7 @@ func (s *Server) handleStatefulSetsHTTP(w http.ResponseWriter, r *http.Request) 
 	defer cancel()
 	statefulsets, err := s.k8sClient.GetStatefulSets(ctx, cluster, namespace)
 	if err != nil {
-		slog.Info("error fetching statefulsets", "error", err)
+		slog.Warn("error fetching statefulsets", "error", err)
 		writeJSON(w,map[string]interface{}{"statefulsets": []interface{}{}, "error": "internal server error"})
 		return
 	}
@@ -442,7 +442,7 @@ func (s *Server) handleDaemonSetsHTTP(w http.ResponseWriter, r *http.Request) {
 	defer cancel()
 	daemonsets, err := s.k8sClient.GetDaemonSets(ctx, cluster, namespace)
 	if err != nil {
-		slog.Info("error fetching daemonsets", "error", err)
+		slog.Warn("error fetching daemonsets", "error", err)
 		writeJSON(w,map[string]interface{}{"daemonsets": []interface{}{}, "error": "internal server error"})
 		return
 	}
@@ -476,7 +476,7 @@ func (s *Server) handleCronJobsHTTP(w http.ResponseWriter, r *http.Request) {
 	defer cancel()
 	cronjobs, err := s.k8sClient.GetCronJobs(ctx, cluster, namespace)
 	if err != nil {
-		slog.Info("error fetching cronjobs", "error", err)
+		slog.Warn("error fetching cronjobs", "error", err)
 		writeJSON(w,map[string]interface{}{"cronjobs": []interface{}{}, "error": "internal server error"})
 		return
 	}
@@ -510,7 +510,7 @@ func (s *Server) handleIngressesHTTP(w http.ResponseWriter, r *http.Request) {
 	defer cancel()
 	ingresses, err := s.k8sClient.GetIngresses(ctx, cluster, namespace)
 	if err != nil {
-		slog.Info("error fetching ingresses", "error", err)
+		slog.Warn("error fetching ingresses", "error", err)
 		writeJSON(w,map[string]interface{}{"ingresses": []interface{}{}, "error": "internal server error"})
 		return
 	}
@@ -544,7 +544,7 @@ func (s *Server) handleNetworkPoliciesHTTP(w http.ResponseWriter, r *http.Reques
 	defer cancel()
 	policies, err := s.k8sClient.GetNetworkPolicies(ctx, cluster, namespace)
 	if err != nil {
-		slog.Info("error fetching networkpolicies", "error", err)
+		slog.Warn("error fetching networkpolicies", "error", err)
 		writeJSON(w,map[string]interface{}{"networkpolicies": []interface{}{}, "error": "internal server error"})
 		return
 	}
@@ -578,7 +578,7 @@ func (s *Server) handleServicesHTTP(w http.ResponseWriter, r *http.Request) {
 	defer cancel()
 	services, err := s.k8sClient.GetServices(ctx, cluster, namespace)
 	if err != nil {
-		slog.Info("error fetching services", "error", err)
+		slog.Warn("error fetching services", "error", err)
 		writeJSON(w,map[string]interface{}{"services": []interface{}{}, "error": "internal server error"})
 		return
 	}
@@ -612,7 +612,7 @@ func (s *Server) handleConfigMapsHTTP(w http.ResponseWriter, r *http.Request) {
 	defer cancel()
 	configmaps, err := s.k8sClient.GetConfigMaps(ctx, cluster, namespace)
 	if err != nil {
-		slog.Info("error fetching configmaps", "error", err)
+		slog.Warn("error fetching configmaps", "error", err)
 		writeJSON(w,map[string]interface{}{"configmaps": []interface{}{}, "error": "internal server error"})
 		return
 	}
@@ -648,7 +648,7 @@ func (s *Server) handleSecretsHTTP(w http.ResponseWriter, r *http.Request) {
 	defer cancel()
 	secrets, err := s.k8sClient.GetSecrets(ctx, cluster, namespace)
 	if err != nil {
-		slog.Info("error fetching secrets", "error", err)
+		slog.Warn("error fetching secrets", "error", err)
 		writeJSON(w,map[string]interface{}{"secrets": []interface{}{}, "error": "internal server error"})
 		return
 	}
@@ -682,7 +682,7 @@ func (s *Server) handleServiceAccountsHTTP(w http.ResponseWriter, r *http.Reques
 	defer cancel()
 	serviceaccounts, err := s.k8sClient.GetServiceAccounts(ctx, cluster, namespace)
 	if err != nil {
-		slog.Info("error fetching serviceaccounts", "error", err)
+		slog.Warn("error fetching serviceaccounts", "error", err)
 		writeJSON(w,map[string]interface{}{"serviceaccounts": []interface{}{}, "error": "internal server error"})
 		return
 	}
@@ -716,7 +716,7 @@ func (s *Server) handleJobsHTTP(w http.ResponseWriter, r *http.Request) {
 	defer cancel()
 	jobs, err := s.k8sClient.GetJobs(ctx, cluster, namespace)
 	if err != nil {
-		slog.Info("error fetching jobs", "error", err)
+		slog.Warn("error fetching jobs", "error", err)
 		writeJSON(w,map[string]interface{}{"jobs": []interface{}{}, "error": "internal server error"})
 		return
 	}
@@ -745,7 +745,7 @@ func (s *Server) handleHPAsHTTP(w http.ResponseWriter, r *http.Request) {
 	defer cancel()
 	hpas, err := s.k8sClient.GetHPAs(ctx, cluster, namespace)
 	if err != nil {
-		slog.Info("error fetching hpas", "error", err)
+		slog.Warn("error fetching hpas", "error", err)
 		writeJSON(w,map[string]interface{}{"hpas": []interface{}{}, "error": "internal server error"})
 		return
 	}
@@ -774,7 +774,7 @@ func (s *Server) handlePVCsHTTP(w http.ResponseWriter, r *http.Request) {
 	defer cancel()
 	pvcs, err := s.k8sClient.GetPVCs(ctx, cluster, namespace)
 	if err != nil {
-		slog.Info("error fetching pvcs", "error", err)
+		slog.Warn("error fetching pvcs", "error", err)
 		writeJSON(w,map[string]interface{}{"pvcs": []interface{}{}, "error": "internal server error"})
 		return
 	}
@@ -803,7 +803,7 @@ func (s *Server) handleRolesHTTP(w http.ResponseWriter, r *http.Request) {
 	defer cancel()
 	roles, err := s.k8sClient.ListRoles(ctx, cluster, namespace)
 	if err != nil {
-		slog.Info("error fetching roles", "error", err)
+		slog.Warn("error fetching roles", "error", err)
 		writeJSON(w,map[string]interface{}{"roles": []interface{}{}, "error": "internal server error"})
 		return
 	}
@@ -832,7 +832,7 @@ func (s *Server) handleRoleBindingsHTTP(w http.ResponseWriter, r *http.Request) 
 	defer cancel()
 	bindings, err := s.k8sClient.ListRoleBindings(ctx, cluster, namespace)
 	if err != nil {
-		slog.Info("error fetching rolebindings", "error", err)
+		slog.Warn("error fetching rolebindings", "error", err)
 		writeJSON(w,map[string]interface{}{"rolebindings": []interface{}{}, "error": "internal server error"})
 		return
 	}
@@ -861,7 +861,7 @@ func (s *Server) handleResourceQuotasHTTP(w http.ResponseWriter, r *http.Request
 	defer cancel()
 	quotas, err := s.k8sClient.GetResourceQuotas(ctx, cluster, namespace)
 	if err != nil {
-		slog.Info("error fetching resourcequotas", "error", err)
+		slog.Warn("error fetching resourcequotas", "error", err)
 		writeJSON(w,map[string]interface{}{"resourcequotas": []interface{}{}, "error": "internal server error"})
 		return
 	}
@@ -890,7 +890,7 @@ func (s *Server) handleLimitRangesHTTP(w http.ResponseWriter, r *http.Request) {
 	defer cancel()
 	ranges, err := s.k8sClient.GetLimitRanges(ctx, cluster, namespace)
 	if err != nil {
-		slog.Info("error fetching limitranges", "error", err)
+		slog.Warn("error fetching limitranges", "error", err)
 		writeJSON(w,map[string]interface{}{"limitranges": []interface{}{}, "error": "internal server error"})
 		return
 	}
@@ -929,7 +929,7 @@ func (s *Server) handleResolveDepsHTTP(w http.ResponseWriter, r *http.Request) {
 
 	kind, bundle, err := s.k8sClient.ResolveWorkloadDependencies(ctx, cluster, namespace, name)
 	if err != nil {
-		slog.Info("error resolving dependencies", "namespace", namespace, "name", name, "cluster", cluster, "error", err)
+		slog.Warn("error resolving dependencies", "namespace", namespace, "name", name, "cluster", cluster, "error", err)
 		writeJSON(w,map[string]interface{}{
 			"workload":     name,
 			"kind":         "Deployment",
@@ -1045,7 +1045,7 @@ func (s *Server) handleScaleHTTP(w http.ResponseWriter, r *http.Request) {
 
 	result, err := s.k8sClient.ScaleWorkload(ctx, namespace, name, []string{cluster}, replicas)
 	if err != nil {
-		slog.Info("error scaling resource", "namespace", namespace, "name", name, "cluster", cluster, "error", err)
+		slog.Warn("error scaling resource", "namespace", namespace, "name", name, "cluster", cluster, "error", err)
 		writeJSON(w,map[string]interface{}{
 			"success": false,
 			"error":   err.Error(),
@@ -1095,7 +1095,7 @@ func (s *Server) handlePodsHTTP(w http.ResponseWriter, r *http.Request) {
 
 	pods, err := s.k8sClient.GetPods(ctx, cluster, namespace)
 	if err != nil {
-		slog.Info("error fetching pods", "error", err)
+		slog.Warn("error fetching pods", "error", err)
 		writeJSON(w,map[string]interface{}{"pods": []interface{}{}, "error": "internal server error"})
 		return
 	}

--- a/pkg/api/handlers/console_persistence.go
+++ b/pkg/api/handlers/console_persistence.go
@@ -136,7 +136,7 @@ func (h *ConsolePersistenceHandlers) StartWatcher(ctx context.Context) error {
 
 	activeCluster, err := h.persistenceStore.GetActiveCluster(ctx)
 	if err != nil {
-		slog.Info("[ConsolePersistence] cannot start watcher", "error", err)
+		slog.Error("[ConsolePersistence] cannot start watcher", "error", err)
 		return err
 	}
 
@@ -197,7 +197,7 @@ func (h *ConsolePersistenceHandlers) UpdateConfig(c *fiber.Ctx) error {
 	}
 
 	if err := h.persistenceStore.UpdateConfig(config); err != nil {
-		slog.Info("[ConsolePersistence] bad request", "error", err)
+		slog.Warn("[ConsolePersistence] bad request", "error", err)
 		return c.Status(400).JSON(fiber.Map{"error": "invalid request"})
 	}
 
@@ -235,7 +235,7 @@ func (h *ConsolePersistenceHandlers) GetStatus(c *fiber.Ctx) error {
 func (h *ConsolePersistenceHandlers) ListManagedWorkloads(c *fiber.Ctx) error {
 	client, _, err := h.persistenceStore.GetActiveClient(c.Context())
 	if err != nil {
-		slog.Info("[ConsolePersistence] service unavailable", "error", err)
+		slog.Error("[ConsolePersistence] service unavailable", "error", err)
 		return c.Status(503).JSON(fiber.Map{"error": "service unavailable"})
 	}
 
@@ -258,7 +258,7 @@ func (h *ConsolePersistenceHandlers) GetManagedWorkload(c *fiber.Ctx) error {
 
 	client, _, err := h.persistenceStore.GetActiveClient(c.Context())
 	if err != nil {
-		slog.Info("[ConsolePersistence] service unavailable", "error", err)
+		slog.Error("[ConsolePersistence] service unavailable", "error", err)
 		return c.Status(503).JSON(fiber.Map{"error": "service unavailable"})
 	}
 
@@ -294,7 +294,7 @@ func (h *ConsolePersistenceHandlers) CreateManagedWorkload(c *fiber.Ctx) error {
 
 	client, _, err := h.persistenceStore.GetActiveClient(c.Context())
 	if err != nil {
-		slog.Info("[ConsolePersistence] service unavailable", "error", err)
+		slog.Error("[ConsolePersistence] service unavailable", "error", err)
 		return c.Status(503).JSON(fiber.Map{"error": "service unavailable"})
 	}
 
@@ -336,7 +336,7 @@ func (h *ConsolePersistenceHandlers) UpdateManagedWorkload(c *fiber.Ctx) error {
 
 	client, _, err := h.persistenceStore.GetActiveClient(c.Context())
 	if err != nil {
-		slog.Info("[ConsolePersistence] service unavailable", "error", err)
+		slog.Error("[ConsolePersistence] service unavailable", "error", err)
 		return c.Status(503).JSON(fiber.Map{"error": "service unavailable"})
 	}
 
@@ -367,7 +367,7 @@ func (h *ConsolePersistenceHandlers) DeleteManagedWorkload(c *fiber.Ctx) error {
 
 	client, _, err := h.persistenceStore.GetActiveClient(c.Context())
 	if err != nil {
-		slog.Info("[ConsolePersistence] service unavailable", "error", err)
+		slog.Error("[ConsolePersistence] service unavailable", "error", err)
 		return c.Status(503).JSON(fiber.Map{"error": "service unavailable"})
 	}
 
@@ -391,7 +391,7 @@ func (h *ConsolePersistenceHandlers) DeleteManagedWorkload(c *fiber.Ctx) error {
 func (h *ConsolePersistenceHandlers) ListClusterGroups(c *fiber.Ctx) error {
 	client, _, err := h.persistenceStore.GetActiveClient(c.Context())
 	if err != nil {
-		slog.Info("[ConsolePersistence] service unavailable", "error", err)
+		slog.Error("[ConsolePersistence] service unavailable", "error", err)
 		return c.Status(503).JSON(fiber.Map{"error": "service unavailable"})
 	}
 
@@ -414,7 +414,7 @@ func (h *ConsolePersistenceHandlers) GetClusterGroup(c *fiber.Ctx) error {
 
 	client, _, err := h.persistenceStore.GetActiveClient(c.Context())
 	if err != nil {
-		slog.Info("[ConsolePersistence] service unavailable", "error", err)
+		slog.Error("[ConsolePersistence] service unavailable", "error", err)
 		return c.Status(503).JSON(fiber.Map{"error": "service unavailable"})
 	}
 
@@ -448,7 +448,7 @@ func (h *ConsolePersistenceHandlers) CreateClusterGroup(c *fiber.Ctx) error {
 
 	client, _, err := h.persistenceStore.GetActiveClient(c.Context())
 	if err != nil {
-		slog.Info("[ConsolePersistence] service unavailable", "error", err)
+		slog.Error("[ConsolePersistence] service unavailable", "error", err)
 		return c.Status(503).JSON(fiber.Map{"error": "service unavailable"})
 	}
 
@@ -496,7 +496,7 @@ func (h *ConsolePersistenceHandlers) UpdateClusterGroup(c *fiber.Ctx) error {
 
 	client, _, err := h.persistenceStore.GetActiveClient(c.Context())
 	if err != nil {
-		slog.Info("[ConsolePersistence] service unavailable", "error", err)
+		slog.Error("[ConsolePersistence] service unavailable", "error", err)
 		return c.Status(503).JSON(fiber.Map{"error": "service unavailable"})
 	}
 
@@ -533,7 +533,7 @@ func (h *ConsolePersistenceHandlers) DeleteClusterGroup(c *fiber.Ctx) error {
 
 	client, _, err := h.persistenceStore.GetActiveClient(c.Context())
 	if err != nil {
-		slog.Info("[ConsolePersistence] service unavailable", "error", err)
+		slog.Error("[ConsolePersistence] service unavailable", "error", err)
 		return c.Status(503).JSON(fiber.Map{"error": "service unavailable"})
 	}
 
@@ -695,7 +695,7 @@ func clusterFilterNeedsNodes(filters []v1alpha1.ClusterFilter) bool {
 func (h *ConsolePersistenceHandlers) ListWorkloadDeployments(c *fiber.Ctx) error {
 	client, _, err := h.persistenceStore.GetActiveClient(c.Context())
 	if err != nil {
-		slog.Info("[ConsolePersistence] service unavailable", "error", err)
+		slog.Error("[ConsolePersistence] service unavailable", "error", err)
 		return c.Status(503).JSON(fiber.Map{"error": "service unavailable"})
 	}
 
@@ -718,7 +718,7 @@ func (h *ConsolePersistenceHandlers) GetWorkloadDeployment(c *fiber.Ctx) error {
 
 	client, _, err := h.persistenceStore.GetActiveClient(c.Context())
 	if err != nil {
-		slog.Info("[ConsolePersistence] service unavailable", "error", err)
+		slog.Error("[ConsolePersistence] service unavailable", "error", err)
 		return c.Status(503).JSON(fiber.Map{"error": "service unavailable"})
 	}
 
@@ -751,7 +751,7 @@ func (h *ConsolePersistenceHandlers) CreateWorkloadDeployment(c *fiber.Ctx) erro
 
 	client, _, err := h.persistenceStore.GetActiveClient(c.Context())
 	if err != nil {
-		slog.Info("[ConsolePersistence] service unavailable", "error", err)
+		slog.Error("[ConsolePersistence] service unavailable", "error", err)
 		return c.Status(503).JSON(fiber.Map{"error": "service unavailable"})
 	}
 
@@ -808,7 +808,7 @@ func (h *ConsolePersistenceHandlers) UpdateWorkloadDeploymentStatus(c *fiber.Ctx
 
 	client, _, err := h.persistenceStore.GetActiveClient(c.Context())
 	if err != nil {
-		slog.Info("[ConsolePersistence] service unavailable", "error", err)
+		slog.Error("[ConsolePersistence] service unavailable", "error", err)
 		return c.Status(503).JSON(fiber.Map{"error": "service unavailable"})
 	}
 
@@ -845,7 +845,7 @@ func (h *ConsolePersistenceHandlers) DeleteWorkloadDeployment(c *fiber.Ctx) erro
 
 	client, _, err := h.persistenceStore.GetActiveClient(c.Context())
 	if err != nil {
-		slog.Info("[ConsolePersistence] service unavailable", "error", err)
+		slog.Error("[ConsolePersistence] service unavailable", "error", err)
 		return c.Status(503).JSON(fiber.Map{"error": "service unavailable"})
 	}
 

--- a/pkg/api/handlers/custom_resources.go
+++ b/pkg/api/handlers/custom_resources.go
@@ -83,7 +83,7 @@ func (h *MCPHandlers) GetCustomResources(c *fiber.Ctx) error {
 	if cluster != "" {
 		items, err := h.listCR(c.Context(), cluster, namespace, gvr)
 		if err != nil {
-			slog.Info("custom-resources: cluster error", "cluster", cluster, "error", err)
+			slog.Warn("custom-resources: cluster error", "cluster", cluster, "error", err)
 			return c.Status(500).JSON(fiber.Map{"error": fmt.Sprintf("failed to list %s: %v", resource, err)})
 		}
 		return c.JSON(CustomResourceResponse{Items: items, IsDemoData: false})
@@ -92,7 +92,7 @@ func (h *MCPHandlers) GetCustomResources(c *fiber.Ctx) error {
 	// Fan-out across all healthy clusters
 	clusters, _, err := h.k8sClient.HealthyClusters(c.Context())
 	if err != nil {
-		slog.Info("custom-resources: HealthyClusters failed", "error", err)
+		slog.Warn("custom-resources: HealthyClusters failed", "error", err)
 		return c.Status(500).JSON(fiber.Map{"error": "internal server error"})
 	}
 

--- a/pkg/api/handlers/feedback.go
+++ b/pkg/api/handlers/feedback.go
@@ -2127,7 +2127,7 @@ func (h *FeedbackHandler) addPRComment(request *models.FeatureRequest, feedback 
 		if readErr != nil {
 			body = []byte("(failed to read response body)")
 		}
-		slog.Info("[Feedback] GitHub API error adding PR comment", "status", resp.StatusCode, "body", string(body))
+		slog.Warn("[Feedback] GitHub API error adding PR comment", "status", resp.StatusCode, "body", string(body))
 	}
 }
 

--- a/pkg/api/handlers/gitops.go
+++ b/pkg/api/handlers/gitops.go
@@ -277,7 +277,7 @@ func (h *GitOpsHandlers) ListHelmReleases(c *fiber.Ctx) error {
 
 		clusters, _, err := h.k8sClient.HealthyClusters(hcCtx)
 		if err != nil {
-			slog.Info("[GitOps] error listing healthy clusters for releases", "error", err)
+			slog.Error("[GitOps] error listing healthy clusters for releases", "error", err)
 			return c.Status(500).JSON(fiber.Map{"error": "internal server error", "releases": []HelmRelease{}})
 		}
 
@@ -368,7 +368,7 @@ func (h *GitOpsHandlers) ListKustomizations(c *fiber.Ctx) error {
 	if h.k8sClient != nil {
 		clusters, _, err := h.k8sClient.HealthyClusters(c.Context())
 		if err != nil {
-			slog.Info("[GitOps] error listing healthy clusters for kustomizations", "error", err)
+			slog.Error("[GitOps] error listing healthy clusters for kustomizations", "error", err)
 			return c.Status(500).JSON(fiber.Map{"error": "internal server error", "kustomizations": []Kustomization{}})
 		}
 
@@ -554,7 +554,7 @@ func (h *GitOpsHandlers) ListOperators(c *fiber.Ctx) error {
 	if h.k8sClient != nil {
 		clusters, _, err := h.k8sClient.HealthyClusters(c.Context())
 		if err != nil {
-			slog.Info("[GitOps] error listing healthy clusters for operators", "error", err)
+			slog.Error("[GitOps] error listing healthy clusters for operators", "error", err)
 			return c.Status(500).JSON(fiber.Map{"error": "internal server error", "operators": []Operator{}})
 		}
 
@@ -894,7 +894,7 @@ func (h *GitOpsHandlers) ListOperatorSubscriptions(c *fiber.Ctx) error {
 	if h.k8sClient != nil {
 		clusters, _, err := h.k8sClient.HealthyClusters(c.Context())
 		if err != nil {
-			slog.Info("[GitOps] error listing healthy clusters for subscriptions", "error", err)
+			slog.Error("[GitOps] error listing healthy clusters for subscriptions", "error", err)
 			return c.Status(500).JSON(fiber.Map{"error": "internal server error", "subscriptions": []OperatorSubscription{}})
 		}
 
@@ -2595,7 +2595,7 @@ func (h *GitOpsHandlers) TriggerArgoSync(c *fiber.Ctx) error {
 							"method":  "api",
 						})
 					}
-					slog.Info("[ArgoCD] API sync returned error status, falling back", "status", resp.StatusCode)
+					slog.Warn("[ArgoCD] API sync returned error status, falling back", "status", resp.StatusCode)
 				} else {
 					slog.Error("[ArgoCD] API sync failed, falling back", "error", err)
 				}

--- a/pkg/api/handlers/mcs.go
+++ b/pkg/api/handlers/mcs.go
@@ -207,7 +207,7 @@ func (h *MCSHandlers) CreateServiceExport(c *fiber.Ctx) error {
 
 	var req CreateServiceExportRequest
 	if err := c.BodyParser(&req); err != nil {
-		slog.Info("[MCS] invalid request body", "error", err)
+		slog.Warn("[MCS] invalid request body", "error", err)
 		return c.Status(400).JSON(fiber.Map{"error": "invalid request"})
 	}
 

--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -337,6 +337,8 @@ func NewServer(cfg Config) (*Server, error) {
 	if k8sClient != nil {
 		server.gpuUtilWorker = NewGPUUtilizationWorker(db, k8sClient)
 		server.gpuUtilWorker.Start()
+	} else {
+		slog.Info("[Server] GPU utilization worker skipped — no Kubernetes client available")
 	}
 
 	slog.Info("Server initialization complete")


### PR DESCRIPTION
## Summary

- **10 files** updated to promote `slog.Info` error logging to `slog.Warn` or `slog.Error`, making failures visible to alerting systems
- **5 kagent CRD** error logs now include the `error` value that was previously omitted, making failures diagnosable
- **GPU utilization worker** skip now logged so operators know monitoring is disabled
- **Agent config** HOME directory fallback now logged as a warning

## Issues

Fixes #7687, Fixes #7689, Fixes #7692, Fixes #7693, Fixes #7694, Fixes #7695, Fixes #7696, Fixes #7697, Fixes #7698, Fixes #7699, Fixes #7700

### Closed as by-design / not-a-bug

- #7676 (godotenv silent discard — intentional)
- #7679 (goroutines in NewServer — no data race)
- #7680 (settings migration non-fatal — by design)
- #7681 (BACKEND_URL validation — already guarded)
- #7682 (port range validation — OS catches it)
- #7685 (OAuth fallback — intentional dev mode)
- #7686 (CLAUDE_API_KEY validation — optional feature)
- #7688 (dashboard ID validation — user-defined)
- #7690 (start-dev.sh env validation — dev script)
- #7691 (startup-oauth.sh hardcoded ports — dev script)

### Closed with ai-needs-human label

- #7677 (JWT_SECRET min length — security decision)
- #7683 (ArgoCD TLS skip guard — security policy)
- #7684 (JWT revocation without JTI — migration risk)

## Test plan

- [x] go build ./... passes
- [x] go vet ./... passes
- [x] npm run build passes (frontend unchanged)
- [ ] Verify error logs appear at Warn/Error level in server output