### PR TITLE
🐛 fix(e2e): remove combined a11y test timeout + add list reporter

### DIFF
--- a/.github/workflows/nightly-ux-journeys.yml
+++ b/.github/workflows/nightly-ux-journeys.yml
@@ -62,7 +62,7 @@ jobs:
           done
 
       - name: Run UX journey tests
-        run: npx playwright test e2e/user-flows/ --project=chromium --reporter=html,./e2e/helpers/ux-reporter.ts
+        run: npx playwright test e2e/user-flows/ --project=chromium --reporter=list,html,./e2e/helpers/ux-reporter.ts
         env:
           PLAYWRIGHT_BASE_URL: "http://localhost:8080"
 
@@ -135,7 +135,7 @@ jobs:
           done
 
       - name: Run responsive + a11y tests
-        run: npx playwright test e2e/user-flows/responsive-layouts.spec.ts e2e/user-flows/a11y-audit.spec.ts --project=chromium
+        run: npx playwright test e2e/user-flows/responsive-layouts.spec.ts e2e/user-flows/a11y-audit.spec.ts --project=chromium --reporter=list,html
         env:
           PLAYWRIGHT_BASE_URL: "http://localhost:8080"
 

--- a/web/e2e/user-flows/a11y-audit.spec.ts
+++ b/web/e2e/user-flows/a11y-audit.spec.ts
@@ -84,32 +84,6 @@ for (const { path, label } of AUDIT_ROUTES) {
   })
 }
 
-test.describe('A11y Audit — Combined Summary', () => {
-  test('all audited pages have reasonable a11y scores', async ({ page }) => {
-    const pageSummaries: Array<{ route: string; total: number; critical: number }> = []
-
-    for (const { path } of AUDIT_ROUTES) {
-      await setupDemoAndNavigate(page, path)
-      await page.waitForLoadState('networkidle', { timeout: NETWORK_IDLE_TIMEOUT_MS }).catch(() => {})
-
-      const results = await new AxeBuilder({ page })
-        .withTags(['wcag2a', 'wcag2aa'])
-        .analyze()
-
-      const critical = results.violations.filter(
-        v => v.impact === 'critical' || v.impact === 'serious',
-      ).length
-
-      pageSummaries.push({ route: path, total: results.violations.length, critical })
-    }
-
-    // Attach combined summary
-    test.info().annotations.push({
-      type: 'ux-finding',
-      description: `A11y summary: ${pageSummaries.map(p => `${p.route}=${p.total} (${p.critical} crit)`).join(', ')}`,
-    })
-
-    // At least one page should have been scanned successfully
-    expect(pageSummaries.length).toBeGreaterThan(0)
-  })
-})
+// Combined summary removed — the sequential navigation through 4 routes in a
+// single test hits the 60s timeout in CI. Each route is already tested
+// individually above, and the ux-reporter aggregates findings across tests.


### PR DESCRIPTION
Follow-up to #7651/#7678. Removes the combined a11y summary test that timed out (sequential 4-route navigation in 60s) and adds list reporter so pass/fail counts show in CI logs.