### PR TITLE
fix: log levels, missing indexes, GPU update error (#7701-#7730)

### DIFF
--- a/cmd/console/main.go
+++ b/cmd/console/main.go
@@ -35,9 +35,11 @@ func main() {
 	flag.Parse()
 
 	if *version {
-		fmt.Printf("console version %s\n", api.Version)
+		fmt.Printf("console version %s\n", api.Version) //nolint:forbidigo // CLI --version flag output
 		os.Exit(0)
 	}
+
+	slog.Info("console starting", "version", api.Version)
 
 	// Watchdog mode: lightweight reverse proxy, no DB/k8s/MCP initialization
 	if *watchdog {

--- a/cmd/kc-agent/main.go
+++ b/cmd/kc-agent/main.go
@@ -33,15 +33,7 @@ func main() {
 		os.Exit(0)
 	}
 
-	fmt.Printf(`
- _  __   ____
-| |/ /  / ___|
-| ' /  | |
-| . \  | |___
-|_|\_\  \____|
-
-KubeStellar Console - Local Agent v%s
-`, agent.Version)
+	slog.Info("KubeStellar Console - Local Agent starting", "version", agent.Version)
 
 	// Parse comma-separated allowed origins from flag
 	var origins []string
@@ -67,7 +59,7 @@ KubeStellar Console - Local Agent v%s
 	signal.Notify(sigChan, syscall.SIGINT, syscall.SIGTERM)
 	go func() {
 		<-sigChan
-		fmt.Println("\nShutting down...")
+		slog.Info("Shutting down")
 		os.Exit(0)
 	}()
 

--- a/pkg/agent/registry.go
+++ b/pkg/agent/registry.go
@@ -2,6 +2,7 @@ package agent
 
 import (
 	"fmt"
+	"log/slog"
 	"os"
 	"sync"
 )
@@ -311,7 +312,7 @@ func InitializeProviders() error {
 	if defaultAgent := os.Getenv("DEFAULT_AGENT"); defaultAgent != "" {
 		if err := registry.SetDefault(defaultAgent); err != nil {
 			// Log warning but don't fail - will use first available
-			fmt.Printf("Warning: Could not set default agent %s: %v\n", defaultAgent, err)
+			slog.Warn("[Registry] could not set default agent", "agent", defaultAgent, "error", err)
 		}
 	}
 

--- a/pkg/agent/server_ai.go
+++ b/pkg/agent/server_ai.go
@@ -127,7 +127,7 @@ func (s *Server) handleWebSocket(w http.ResponseWriter, r *http.Request) {
 				defer func() { <-sem }() // release slot
 				defer func() {
 					if r := recover(); r != nil {
-						slog.Info("[Chat] recovered from panic in streaming handler", "panic", r)
+						slog.Error("[Chat] recovered from panic in streaming handler", "panic", r)
 						// Send error frame to the client so the frontend
 						// can display an error state instead of spinning forever.
 						if !closed.Load() {
@@ -157,7 +157,7 @@ func (s *Server) handleWebSocket(w http.ResponseWriter, r *http.Request) {
 				defer func() { <-sem }() // release slot
 				defer func() {
 					if r := recover(); r != nil {
-						slog.Info("[Kubectl] recovered from panic in message handler", "panic", r)
+						slog.Error("[Kubectl] recovered from panic in message handler", "panic", r)
 						// Notify the client about the panic so the UI can show an error
 						if !closed.Load() {
 							writeMu.Lock()
@@ -190,7 +190,7 @@ func (s *Server) handleWebSocket(w http.ResponseWriter, r *http.Request) {
 			func() {
 				defer func() {
 					if r := recover(); r != nil {
-						slog.Info("[WS] recovered from panic in synchronous handler", "panic", r, "msgType", msg.Type)
+						slog.Error("[WS] recovered from panic in synchronous handler", "panic", r, "msgType", msg.Type)
 						writeMu.Lock()
 						conn.SetWriteDeadline(time.Now().Add(wsWriteTimeout))
 						_ = conn.WriteJSON(protocol.Message{

--- a/pkg/agent/server_http.go
+++ b/pkg/agent/server_http.go
@@ -106,7 +106,7 @@ func (s *Server) handleGPUNodesHTTP(w http.ResponseWriter, r *http.Request) {
 				defer wg.Done()
 				defer func() {
 					if r := recover(); r != nil {
-						slog.Info("[GPUNodes] recovered from panic", "cluster", clusterName, "panic", r)
+						slog.Error("[GPUNodes] recovered from panic", "cluster", clusterName, "panic", r)
 					}
 				}()
 				clusterCtx, clusterCancel := context.WithTimeout(ctx, agentDefaultTimeout)
@@ -178,7 +178,7 @@ func (s *Server) handleNodesHTTP(w http.ResponseWriter, r *http.Request) {
 				defer wg.Done()
 				defer func() {
 					if r := recover(); r != nil {
-						slog.Info("[Nodes] recovered from panic", "cluster", clusterName, "panic", r)
+						slog.Error("[Nodes] recovered from panic", "cluster", clusterName, "panic", r)
 					}
 				}()
 				clusterCtx, clusterCancel := context.WithTimeout(ctx, agentDefaultTimeout)
@@ -1279,7 +1279,7 @@ func (s *Server) startBackendProcess() error {
 	go func() {
 		defer func() {
 			if r := recover(); r != nil {
-				slog.Info("[Backend] recovered from panic in process reaper", "panic", r)
+				slog.Error("[Backend] recovered from panic in process reaper", "panic", r)
 			}
 		}()
 		cmd.Wait()

--- a/pkg/agent/server_operations.go
+++ b/pkg/agent/server_operations.go
@@ -609,7 +609,7 @@ func (s *Server) handleProvidersHealth(w http.ResponseWriter, r *http.Request) {
 			defer wg.Done()
 			defer func() {
 				if r := recover(); r != nil {
-					slog.Info("[ProviderHealth] recovered from panic checking provider", "provider", providerID, "panic", r)
+					slog.Error("[ProviderHealth] recovered from panic checking provider", "provider", providerID, "panic", r)
 				}
 			}()
 			status := checkStatuspageHealth(client, url)
@@ -626,7 +626,7 @@ func (s *Server) handleProvidersHealth(w http.ResponseWriter, r *http.Request) {
 			defer wg.Done()
 			defer func() {
 				if r := recover(); r != nil {
-					slog.Info("[ProviderHealth] recovered from panic pinging provider", "provider", providerID, "panic", r)
+					slog.Error("[ProviderHealth] recovered from panic pinging provider", "provider", providerID, "panic", r)
 				}
 			}()
 			status := checkPingHealth(client, url)
@@ -1084,7 +1084,7 @@ func (s *Server) sendNativeNotification(alerts []DeviceAlert) {
 	go func() {
 		defer func() {
 			if r := recover(); r != nil {
-				slog.Info("[DeviceTracker] recovered from panic in notification", "panic", r)
+				slog.Error("[DeviceTracker] recovered from panic in notification", "panic", r)
 			}
 		}()
 
@@ -1254,7 +1254,7 @@ func (s *Server) handleLocalClusters(w http.ResponseWriter, r *http.Request) {
 		go func() {
 			defer func() {
 				if r := recover(); r != nil {
-					slog.Info("[LocalClusters] recovered from panic creating cluster", "cluster", req.Name, "panic", r)
+					slog.Error("[LocalClusters] recovered from panic creating cluster", "cluster", req.Name, "panic", r)
 				}
 			}()
 			if err := s.localClusters.CreateCluster(req.Tool, req.Name); err != nil {
@@ -1317,7 +1317,7 @@ func (s *Server) handleLocalClusters(w http.ResponseWriter, r *http.Request) {
 		go func() {
 			defer func() {
 				if r := recover(); r != nil {
-					slog.Info("[LocalClusters] recovered from panic deleting cluster", "cluster", name, "panic", r)
+					slog.Error("[LocalClusters] recovered from panic deleting cluster", "cluster", name, "panic", r)
 				}
 			}()
 			if err := s.localClusters.DeleteCluster(tool, name); err != nil {
@@ -1412,7 +1412,7 @@ func (s *Server) handleLocalClusterLifecycle(w http.ResponseWriter, r *http.Requ
 	go func() {
 		defer func() {
 			if r := recover(); r != nil {
-				slog.Info("[LocalClusters] recovered from panic during lifecycle action", "action", req.Action, "cluster", req.Name, "panic", r)
+				slog.Error("[LocalClusters] recovered from panic during lifecycle action", "action", req.Action, "cluster", req.Name, "panic", r)
 			}
 		}()
 
@@ -1533,7 +1533,7 @@ func (s *Server) handleVClusterCreate(w http.ResponseWriter, r *http.Request) {
 	go func() {
 		defer func() {
 			if r := recover(); r != nil {
-				slog.Info("[vCluster] recovered from panic creating vcluster", "name", req.Name, "panic", r)
+				slog.Error("[vCluster] recovered from panic creating vcluster", "name", req.Name, "panic", r)
 			}
 		}()
 		if err := s.localClusters.CreateVCluster(req.Name, req.Namespace); err != nil {
@@ -1725,7 +1725,7 @@ func (s *Server) handleVClusterDelete(w http.ResponseWriter, r *http.Request) {
 	go func() {
 		defer func() {
 			if r := recover(); r != nil {
-				slog.Info("[vCluster] recovered from panic deleting vcluster", "name", req.Name, "panic", r)
+				slog.Error("[vCluster] recovered from panic deleting vcluster", "name", req.Name, "panic", r)
 			}
 		}()
 		if err := s.localClusters.DeleteVCluster(req.Name, req.Namespace); err != nil {

--- a/pkg/agent/update_checker.go
+++ b/pkg/agent/update_checker.go
@@ -732,7 +732,7 @@ func (uc *UpdateChecker) restartViaStartupScript(repoPath string) {
 	logPath := repoPath + "/data/auto-update-restart.log"
 	logFile, err := os.OpenFile(logPath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0644)
 	if err != nil {
-		slog.Info("[AutoUpdate] cannot create restart log", "path", logPath, "error", err)
+		slog.Warn("[AutoUpdate] cannot create restart log", "path", logPath, "error", err)
 		logFile = nil
 	}
 
@@ -778,7 +778,7 @@ func (uc *UpdateChecker) restartViaStartupScript(repoPath string) {
 func (uc *UpdateChecker) selfUpdateFallback(repoPath string) {
 	currentBinary, err := os.Executable()
 	if err != nil {
-		slog.Info("[AutoUpdate] cannot determine kc-agent binary path", "error", err)
+		slog.Warn("[AutoUpdate] cannot determine kc-agent binary path", "error", err)
 		return
 	}
 

--- a/pkg/api/handlers/gateway.go
+++ b/pkg/api/handlers/gateway.go
@@ -58,7 +58,7 @@ func (h *GatewayHandlers) ListGateways(c *fiber.Ctx) error {
 	if err != nil {
 		// If we got partial results alongside errors, log and return what we have
 		if list != nil && len(list.Items) > 0 {
-			slog.Info("partial gateway list failure", "error", err)
+			slog.Warn("partial gateway list failure", "error", err)
 			return c.JSON(list)
 		}
 		return handleK8sError(c, err)
@@ -99,7 +99,7 @@ func (h *GatewayHandlers) ListHTTPRoutes(c *fiber.Ctx) error {
 	if err != nil {
 		// If we got partial results alongside errors, log and return what we have
 		if list != nil && len(list.Items) > 0 {
-			slog.Info("partial httproute list failure", "error", err)
+			slog.Warn("partial httproute list failure", "error", err)
 			return c.JSON(list)
 		}
 		return handleK8sError(c, err)

--- a/pkg/api/handlers/gpu.go
+++ b/pkg/api/handlers/gpu.go
@@ -351,6 +351,9 @@ func (h *GPUHandler) UpdateReservation(c *fiber.Ctx) error {
 		}
 		// Atomic capacity-checked update (#6957).
 		if err := h.store.UpdateGPUReservationWithCapacity(existing, capacity); err != nil {
+			if errors.Is(err, store.ErrGPUReservationNotFound) {
+				return fiber.NewError(fiber.StatusNotFound, "Reservation not found")
+			}
 			if errors.Is(err, store.ErrGPUQuotaExceeded) {
 				return fiber.NewError(fiber.StatusConflict,
 					fmt.Sprintf("Over-allocation: cluster %q would exceed capacity of %d GPUs", existing.Cluster, capacity))

--- a/pkg/api/handlers/mcp_resources.go
+++ b/pkg/api/handlers/mcp_resources.go
@@ -1459,7 +1459,7 @@ func (h *MCPHandlers) GetPodNetworkStats(c *fiber.Ctx) error {
 							continue
 						}
 					}
-					slog.Info("[MCP] network stats: list pods failed", "app", label, "cluster", clusterName, "error", listErr)
+					slog.Warn("[MCP] network stats: list pods failed", "app", label, "cluster", clusterName, "error", listErr)
 					continue
 				}
 

--- a/pkg/api/handlers/nightly_e2e.go
+++ b/pkg/api/handlers/nightly_e2e.go
@@ -801,7 +801,7 @@ func (h *NightlyE2EHandler) GetRunLogs(c *fiber.Ctx) error {
 
 	resp, err := h.httpClient.Do(req)
 	if err != nil {
-		slog.Info("[NightlyE2E] bad gateway", "error", err)
+		slog.Error("[NightlyE2E] bad gateway", "error", err)
 		return c.Status(fiber.StatusBadGateway).JSON(fiber.Map{"error": "bad gateway"})
 	}
 	defer resp.Body.Close()

--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -275,7 +275,7 @@ func NewServer(cfg Config) (*Server, error) {
 
 	// Initialize AI providers
 	if err := agent.InitializeProviders(); err != nil {
-		slog.Info("AI features disabled — add API keys in Settings to enable")
+		slog.Warn("AI features disabled — add API keys in Settings to enable", "error", err)
 	}
 
 	// Initialize MCP bridge (starts in background)
@@ -291,7 +291,7 @@ func NewServer(cfg Config) (*Server, error) {
 			defer cancel()
 			if err := bridge.Start(ctx); err != nil {
 				// MCP tools not installed — expected for local binary quickstart
-				slog.Info("MCP bridge not available (install kubestellar-ops/deploy plugins to enable)")
+				slog.Warn("MCP bridge not available (install kubestellar-ops/deploy plugins to enable)", "error", err)
 			} else {
 				slog.Info("MCP bridge started successfully")
 			}

--- a/pkg/k8s/rbac.go
+++ b/pkg/k8s/rbac.go
@@ -5,6 +5,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
+	"log/slog"
 	"os"
 	"strings"
 	"sync"
@@ -544,7 +545,8 @@ func (m *MultiClusterClient) CountServiceAccountsAllClusters(ctx context.Context
 			defer wg.Done()
 			count, err := m.countServiceAccountsInCluster(ctx, name)
 			if err != nil {
-				return // skip unreachable clusters, same as before
+				slog.Warn("[RBAC] service account count skipped for unreachable cluster", "cluster", name, "error", err)
+				return
 			}
 			mu.Lock()
 			total += count

--- a/pkg/store/sqlite.go
+++ b/pkg/store/sqlite.go
@@ -316,7 +316,8 @@ func (s *SQLiteStore) migrate() error {
 	CREATE INDEX IF NOT EXISTS idx_dashboards_user ON dashboards(user_id);
 	CREATE INDEX IF NOT EXISTS idx_cards_dashboard ON cards(dashboard_id);
 	CREATE INDEX IF NOT EXISTS idx_events_user_time ON user_events(user_id, created_at);
-	CREATE INDEX IF NOT EXISTS idx_pending_swaps_due ON pending_swaps(swap_at, status);
+	CREATE INDEX IF NOT EXISTS idx_card_history_user ON card_history(user_id, swapped_out_at DESC);
+	CREATE INDEX IF NOT EXISTS idx_pending_swaps_due ON pending_swaps(status, swap_at);
 
 	-- Feature requests from users (bugs/features submitted via console)
 	CREATE TABLE IF NOT EXISTS feature_requests (
@@ -333,6 +334,7 @@ func (s *SQLiteStore) migrate() error {
 		copilot_session_url TEXT,
 		netlify_preview_url TEXT,
 		latest_comment TEXT,
+		closed_by_user INTEGER DEFAULT 0,
 		created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
 		updated_at DATETIME
 	);
@@ -362,6 +364,8 @@ func (s *SQLiteStore) migrate() error {
 
 	CREATE INDEX IF NOT EXISTS idx_feature_requests_user ON feature_requests(user_id);
 	CREATE INDEX IF NOT EXISTS idx_feature_requests_status ON feature_requests(status);
+	CREATE INDEX IF NOT EXISTS idx_feature_requests_issue ON feature_requests(github_issue_number);
+	CREATE INDEX IF NOT EXISTS idx_feature_requests_pr ON feature_requests(pr_number);
 	CREATE INDEX IF NOT EXISTS idx_pr_feedback_request ON pr_feedback(feature_request_id);
 	CREATE INDEX IF NOT EXISTS idx_notifications_user ON notifications(user_id, read);
 
@@ -1774,6 +1778,10 @@ func (s *SQLiteStore) CreateGPUReservation(reservation *models.GPUReservation) e
 // error to HTTP 409 Conflict.
 var ErrGPUQuotaExceeded = errors.New("gpu cluster capacity exceeded")
 
+// ErrGPUReservationNotFound is returned when an update targets a
+// reservation ID that does not exist, so callers can return HTTP 404.
+var ErrGPUReservationNotFound = errors.New("gpu reservation not found")
+
 // CreateGPUReservationWithCapacity atomically enforces a cluster GPU
 // capacity cap and inserts the reservation in a single SQL statement.
 //
@@ -1930,6 +1938,13 @@ func (s *SQLiteStore) UpdateGPUReservationWithCapacity(reservation *models.GPURe
 		return fmt.Errorf("read rows affected: %w", err)
 	}
 	if rows == 0 {
+		// Distinguish "row not found" from "capacity exceeded": if the
+		// reservation does not exist at all, return ErrGPUReservationNotFound
+		// so the caller can map it to HTTP 404 instead of 409.
+		var exists int
+		if err := s.db.QueryRow(`SELECT 1 FROM gpu_reservations WHERE id = ?`, reservation.ID.String()).Scan(&exists); err != nil {
+			return ErrGPUReservationNotFound
+		}
 		return ErrGPUQuotaExceeded
 	}
 	return nil


### PR DESCRIPTION
## Summary
- **Log level corrections** (12 files): Panic recoveries promoted to `slog.Error`, operational errors to `slog.Warn`, dropped error values now included in log calls, `fmt.Printf` replaced with `slog` for structured logging visibility
- **Database indexes** (3 new, 1 reordered): `card_history(user_id)`, `feature_requests(github_issue_number)`, `feature_requests(pr_number)` added; `pending_swaps` index reordered from `(swap_at, status)` to `(status, swap_at)` for correct equality-first query pattern
- **Schema fix**: `closed_by_user` column promoted into `CREATE TABLE feature_requests` so new databases don't depend on migration ordering
- **GPU update error**: `UpdateGPUReservationWithCapacity` now distinguishes "not found" (HTTP 404) from "quota exceeded" (HTTP 409) when `RowsAffected==0`

Fixes #7701
Fixes #7702
Fixes #7703
Fixes #7704
Fixes #7705
Fixes #7706
Fixes #7707
Fixes #7708
Fixes #7709
Fixes #7710
Fixes #7711
Fixes #7712
Fixes #7713
Fixes #7714
Fixes #7715
Fixes #7716
Fixes #7717
Fixes #7718
Fixes #7727
Fixes #7730

## Issues closed separately (not code fixes)
#7719-#7726, #7728, #7729 — SQLite CHECK/FK constraints require table recreation (ALTER TABLE ADD CONSTRAINT not supported); migration transaction wrapping and error-code matching are acceptable trade-offs. Closing with comments.

## Test plan
- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] `npm run build` passes