### PR TITLE
feat: HTTPS/HTTP2 watchdog — eliminate connection pool exhaustion

### DIFF
--- a/cmd/console/main.go
+++ b/cmd/console/main.go
@@ -31,6 +31,7 @@ func main() {
 	dbPath := flag.String("db", "", "Database path (default: ./data/console.db)")
 	watchdog := flag.Bool("watchdog", false, "Run as watchdog reverse proxy (serves fallback page when backend is down)")
 	backendPort := flag.Int("backend-port", watchdogDefaultBackendPort, "Backend port for watchdog to proxy to")
+	tlsEnabled := flag.Bool("tls", false, "Enable HTTPS/HTTP2 on watchdog (auto-generates self-signed cert)")
 	version := flag.Bool("version", false, "Print version and exit")
 	flag.Parse()
 
@@ -48,6 +49,7 @@ func main() {
 		cfg := WatchdogConfig{
 			ListenPort:  listenPort,
 			BackendPort: *backendPort,
+			TLS:         *tlsEnabled,
 		}
 		if err := runWatchdog(cfg); err != nil {
 			slog.Error("watchdog error", "error", err)

--- a/cmd/console/watchdog.go
+++ b/cmd/console/watchdog.go
@@ -2,15 +2,23 @@ package main
 
 import (
 	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
 	"encoding/json"
+	"encoding/pem"
 	"fmt"
 	"log/slog"
+	"math/big"
 	"net"
 	"net/http"
 	"net/http/httputil"
 	"net/url"
 	"os"
 	"os/signal"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"sync/atomic"
@@ -37,10 +45,18 @@ const (
 	watchdogStageFile           = "/tmp/.kc-startup-stage"
 )
 
+const (
+	watchdogTLSDir      = "./data/tls"
+	watchdogTLSCertFile = "cert.pem"
+	watchdogTLSKeyFile  = "key.pem"
+	watchdogTLSCertLife = 365 * 24 * time.Hour // 1 year
+)
+
 // WatchdogConfig holds configuration for the watchdog reverse proxy.
 type WatchdogConfig struct {
 	ListenPort  int
 	BackendPort int
+	TLS         bool
 }
 
 // runWatchdog starts the watchdog reverse proxy. It proxies all traffic to the
@@ -81,6 +97,11 @@ func runWatchdog(cfg WatchdogConfig) error {
 		MaxIdleConnsPerHost:   watchdogMaxIdleConnsPerHost,
 		IdleConnTimeout:       watchdogIdleConnTimeout,
 	}
+
+	// Flush SSE events immediately instead of buffering.
+	// Without this, Server-Sent Events are held in the proxy buffer
+	// and only forwarded when the buffer fills or the connection closes.
+	proxy.FlushInterval = -1
 
 	// Custom error handler: serve fallback page on connection failures.
 	// Only mark backend unhealthy on hard connection errors (refused, reset, EOF).
@@ -190,11 +211,97 @@ func runWatchdog(cfg WatchdogConfig) error {
 		srv.Shutdown(shutdownCtx)
 	}()
 
-	slog.Info("[Watchdog] listening", "addr", addr, "backend", backendURL.String())
-	if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
-		return fmt.Errorf("watchdog listen error: %w", err)
+	if cfg.TLS {
+		certFile, keyFile, tlsErr := ensureTLSCert()
+		if tlsErr != nil {
+			return fmt.Errorf("TLS cert generation failed: %w", tlsErr)
+		}
+		slog.Info("[Watchdog] listening (HTTPS/H2)", "addr", addr, "backend", backendURL.String())
+		if err := srv.ListenAndServeTLS(certFile, keyFile); err != nil && err != http.ErrServerClosed {
+			return fmt.Errorf("watchdog TLS listen error: %w", err)
+		}
+	} else {
+		slog.Info("[Watchdog] listening (HTTP/1.1)", "addr", addr, "backend", backendURL.String())
+		if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+			return fmt.Errorf("watchdog listen error: %w", err)
+		}
 	}
 	return nil
+}
+
+// ensureTLSCert returns paths to a TLS cert and key. Order of precedence:
+//  1. TLS_CERT_FILE / TLS_KEY_FILE env vars (user-supplied cert)
+//  2. Existing cert in ./data/tls/ (reuse previous auto-generated cert)
+//  3. Auto-generate a self-signed ECDSA P-256 cert for localhost
+func ensureTLSCert() (certFile, keyFile string, err error) {
+	// Allow user-supplied certs via environment variables
+	if envCert := os.Getenv("TLS_CERT_FILE"); envCert != "" {
+		envKey := os.Getenv("TLS_KEY_FILE")
+		if envKey == "" {
+			return "", "", fmt.Errorf("TLS_CERT_FILE set but TLS_KEY_FILE is missing")
+		}
+		slog.Info("[Watchdog] using user-supplied TLS cert", "cert", envCert, "key", envKey)
+		return envCert, envKey, nil
+	}
+
+	certFile = filepath.Join(watchdogTLSDir, watchdogTLSCertFile)
+	keyFile = filepath.Join(watchdogTLSDir, watchdogTLSKeyFile)
+
+	// Reuse existing cert if present
+	if _, statErr := os.Stat(certFile); statErr == nil {
+		if _, statErr2 := os.Stat(keyFile); statErr2 == nil {
+			slog.Info("[Watchdog] reusing existing TLS cert", "cert", certFile)
+			return certFile, keyFile, nil
+		}
+	}
+
+	slog.Info("[Watchdog] generating self-signed TLS cert for localhost")
+	if mkdirErr := os.MkdirAll(watchdogTLSDir, 0700); mkdirErr != nil {
+		return "", "", mkdirErr
+	}
+
+	key, genErr := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if genErr != nil {
+		return "", "", genErr
+	}
+
+	serial, _ := rand.Int(rand.Reader, new(big.Int).Lsh(big.NewInt(1), 128))
+	template := &x509.Certificate{
+		SerialNumber: serial,
+		Subject:      pkix.Name{Organization: []string{"KubeStellar Console (dev)"}},
+		NotBefore:    time.Now(),
+		NotAfter:     time.Now().Add(watchdogTLSCertLife),
+		KeyUsage:     x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		DNSNames:     []string{"localhost"},
+		IPAddresses:  []net.IP{net.ParseIP("127.0.0.1"), net.ParseIP("::1")},
+	}
+
+	certDER, certErr := x509.CreateCertificate(rand.Reader, template, template, &key.PublicKey, key)
+	if certErr != nil {
+		return "", "", certErr
+	}
+
+	certOut, fileErr := os.Create(certFile)
+	if fileErr != nil {
+		return "", "", fileErr
+	}
+	pem.Encode(certOut, &pem.Block{Type: "CERTIFICATE", Bytes: certDER})
+	certOut.Close()
+
+	keyDER, marshalErr := x509.MarshalECPrivateKey(key)
+	if marshalErr != nil {
+		return "", "", marshalErr
+	}
+	keyOut, fileErr2 := os.Create(keyFile)
+	if fileErr2 != nil {
+		return "", "", fileErr2
+	}
+	pem.Encode(keyOut, &pem.Block{Type: "EC PRIVATE KEY", Bytes: keyDER})
+	keyOut.Close()
+
+	slog.Info("[Watchdog] TLS cert generated", "cert", certFile, "key", keyFile)
+	return certFile, keyFile, nil
 }
 
 // checkBackendHealth performs a single health check against the backend.

--- a/startup-oauth.sh
+++ b/startup-oauth.sh
@@ -381,7 +381,12 @@ if [ "$USE_DEV_SERVER" = true ]; then
     if [ "$WATCHDOG_RUNNING" = false ]; then
         write_stage "watchdog"
         echo -e "${GREEN}Starting watchdog on port 8080...${NC}"
-        GOWORK=off go run ./cmd/console --watchdog --backend-port "$BACKEND_LISTEN_PORT" &
+        TLS_FLAG=""
+if [ "${TLS_ENABLED:-}" = "true" ]; then
+    TLS_FLAG="--tls"
+    echo -e "${GREEN}  HTTPS/H2 enabled (TLS_ENABLED=true)${NC}"
+fi
+GOWORK=off go run ./cmd/console --watchdog $TLS_FLAG --backend-port "$BACKEND_LISTEN_PORT" &
         WATCHDOG_PID=$!
         sleep 1
     fi
@@ -418,7 +423,12 @@ else
     if [ "$WATCHDOG_RUNNING" = false ]; then
         write_stage "watchdog"
         echo -e "${GREEN}Starting watchdog on port 8080...${NC}"
-        GOWORK=off go run ./cmd/console --watchdog --backend-port "$BACKEND_LISTEN_PORT" &
+        TLS_FLAG=""
+if [ "${TLS_ENABLED:-}" = "true" ]; then
+    TLS_FLAG="--tls"
+    echo -e "${GREEN}  HTTPS/H2 enabled (TLS_ENABLED=true)${NC}"
+fi
+GOWORK=off go run ./cmd/console --watchdog $TLS_FLAG --backend-port "$BACKEND_LISTEN_PORT" &
         WATCHDOG_PID=$!
         sleep 1
     fi


### PR DESCRIPTION
## Summary
Replaces #3204 (closed — stale/contaminated).

Adds opt-in HTTPS/HTTP2 to the watchdog reverse proxy. HTTP/2 multiplexes all browser requests over a single TCP connection, eliminating the 6-connection HTTP/1.1 limit that causes slow dashboard switching when cluster fetches are in-flight.

### What changes for users
- **Nothing by default** — HTTP/1.1 continues to work as before
- **Opt-in**: Add `TLS_ENABLED=true` to `.env` to enable HTTPS/H2
- **Custom certs**: Set `TLS_CERT_FILE` and `TLS_KEY_FILE` env vars for non-localhost deployments
- Auto-generates a self-signed ECDSA P-256 cert for localhost on first run (stored in `data/tls/`, already gitignored)

### Technical changes
- `cmd/console/watchdog.go`: TLS cert generation, `ListenAndServeTLS`, `FlushInterval = -1` for SSE
- `cmd/console/main.go`: `--tls` flag
- `startup-oauth.sh`: Passes `--tls` when `TLS_ENABLED=true`

### Why opt-in (not default)
Switching to HTTPS changes the URL scheme from `http://` to `https://`, which breaks existing GitHub OAuth callback URLs. Making it opt-in avoids a breaking change.

## Test plan
- [ ] Default startup (no TLS_ENABLED) works exactly as before
- [ ] With `TLS_ENABLED=true`: browser shows h2 protocol in DevTools
- [ ] Self-signed cert auto-generated in `data/tls/`
- [ ] SSE streams multiplex without blocking
- [ ] `TLS_CERT_FILE` + `TLS_KEY_FILE` overrides work
- [ ] OAuth flow works with HTTPS callback URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)