### PR TITLE
fix: SQLite store safety — revoke, constants, limits, dead schema

### DIFF
--- a/pkg/api/handlers/swap.go
+++ b/pkg/api/handlers/swap.go
@@ -89,7 +89,7 @@ func (h *SwapHandler) SnoozeSwap(c *fiber.Ctx) error {
 	})
 
 	return c.JSON(fiber.Map{
-		"status":  "snoozed",
+		"status":  string(models.SwapStatusSnoozed),
 		"swap_at": newSwapAt,
 	})
 }

--- a/pkg/store/sqlite.go
+++ b/pkg/store/sqlite.go
@@ -327,7 +327,10 @@ func (s *SQLiteStore) migrate() error {
 		description TEXT NOT NULL,
 		request_type TEXT NOT NULL,
 		github_issue_number INTEGER,
-		github_issue_url TEXT,
+		-- NOTE: github_issue_url was removed (#7735) — it was never
+		-- populated or read by any INSERT/SELECT/UPDATE query.  The
+		-- handler's QueueItem.GitHubIssueURL is populated from the
+		-- live GitHub API, not from this table.
 		status TEXT DEFAULT 'submitted',
 		pr_number INTEGER,
 		pr_url TEXT,
@@ -887,8 +890,11 @@ func (s *SQLiteStore) GetCard(id uuid.UUID) (*models.Card, error) {
 	return s.scanCard(row)
 }
 
+// maxDashboardCards is the upper bound on cards returned per dashboard (#7733).
+const maxDashboardCards = 500
+
 func (s *SQLiteStore) GetDashboardCards(dashboardID uuid.UUID) ([]models.Card, error) {
-	rows, err := s.db.Query(`SELECT id, dashboard_id, card_type, config, position, last_summary, last_focus, created_at FROM cards WHERE dashboard_id = ? ORDER BY created_at`, dashboardID.String())
+	rows, err := s.db.Query(`SELECT id, dashboard_id, card_type, config, position, last_summary, last_focus, created_at FROM cards WHERE dashboard_id = ? ORDER BY created_at LIMIT ?`, dashboardID.String(), maxDashboardCards)
 	if err != nil {
 		return nil, err
 	}
@@ -1292,7 +1298,7 @@ func (s *SQLiteStore) UpdateSwapStatus(id uuid.UUID, status models.SwapStatus) e
 }
 
 func (s *SQLiteStore) SnoozeSwap(id uuid.UUID, newSwapAt time.Time) error {
-	_, err := s.db.Exec(`UPDATE pending_swaps SET swap_at = ?, status = 'snoozed' WHERE id = ?`, newSwapAt, id.String())
+	_, err := s.db.Exec(`UPDATE pending_swaps SET swap_at = ?, status = ? WHERE id = ?`, newSwapAt, string(models.SwapStatusSnoozed), id.String())
 	return err
 }
 
@@ -2255,9 +2261,11 @@ func boolToInt(b bool) int {
 // Token Revocation methods
 
 // RevokeToken persists a revoked token JTI with its expiration time.
+// INSERT OR IGNORE ensures re-revoking a token cannot silently extend
+// its expiry — the first revocation is authoritative (#7731).
 func (s *SQLiteStore) RevokeToken(jti string, expiresAt time.Time) error {
 	_, err := s.db.Exec(
-		`INSERT OR REPLACE INTO revoked_tokens (jti, expires_at) VALUES (?, ?)`,
+		`INSERT OR IGNORE INTO revoked_tokens (jti, expires_at) VALUES (?, ?)`,
 		jti, expiresAt,
 	)
 	return err
@@ -2891,9 +2899,12 @@ func (s *SQLiteStore) DeleteClusterGroup(name string) error {
 	return err
 }
 
+// maxClusterGroups is the upper bound on cluster groups returned (#7734).
+const maxClusterGroups = 200
+
 // ListClusterGroups returns all persisted cluster group definitions (#7013).
 func (s *SQLiteStore) ListClusterGroups() (map[string][]byte, error) {
-	rows, err := s.db.Query(`SELECT name, data FROM cluster_groups`)
+	rows, err := s.db.Query(`SELECT name, data FROM cluster_groups LIMIT ?`, maxClusterGroups)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Summary

- **#7731 RevokeToken**: Changed `INSERT OR REPLACE` to `INSERT OR IGNORE` so re-revoking a token cannot silently extend its expiry — the first revocation is authoritative.
- **#7732 SnoozeSwap**: Replaced hardcoded `'snoozed'` string literal in `SnoozeSwap` (sqlite.go) and `SnoozeSwap` handler response (swap.go) with `models.SwapStatusSnoozed` constant.
- **#7733 GetDashboardCards**: Added `LIMIT ?` with `maxDashboardCards = 500` named constant to prevent unbounded reads.
- **#7734 ListClusterGroups**: Added `LIMIT ?` with `maxClusterGroups = 200` named constant to prevent unbounded reads on BLOB table.
- **#7735 github_issue_url dead schema**: Removed the `github_issue_url TEXT` column from the `feature_requests` CREATE TABLE — it was never written to or read by any INSERT/SELECT/UPDATE query. The handler's `QueueItem.GitHubIssueURL` is populated from the live GitHub API, not from this table. Added an explanatory comment in the schema.

## Files changed

- `pkg/store/sqlite.go` — all 5 fixes
- `pkg/api/handlers/swap.go` — #7732 constant fix in handler response

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./pkg/store/...` — all store tests pass
- [ ] Verify token revocation idempotency (re-revoke doesn't change expiry)
- [ ] Verify snooze swap response uses correct status string
- [ ] Verify dashboard cards and cluster groups queries return bounded results

Fixes #7731, #7732, #7733, #7734, #7735