### PR TITLE
fix: Go backend safety — drain resp, deep copy, error propagation

### DIFF
--- a/pkg/agent/server_http.go
+++ b/pkg/agent/server_http.go
@@ -112,7 +112,12 @@ func (s *Server) handleGPUNodesHTTP(w http.ResponseWriter, r *http.Request) {
 				clusterCtx, clusterCancel := context.WithTimeout(ctx, agentDefaultTimeout)
 				defer clusterCancel()
 				nodes, err := s.k8sClient.GetGPUNodes(clusterCtx, clusterName)
-				if err == nil && len(nodes) > 0 {
+				if err != nil {
+					// #7750: Log per-cluster errors so GPU metric gaps are diagnosable.
+					slog.Warn("[GPUNodes] failed to list GPU nodes for cluster", "cluster", clusterName, "error", err)
+					return
+				}
+				if len(nodes) > 0 {
 					mu.Lock()
 					allNodes = append(allNodes, nodes...)
 					mu.Unlock()

--- a/pkg/api/handlers/gitops.go
+++ b/pkg/api/handlers/gitops.go
@@ -7,6 +7,7 @@ import (
 	"crypto/tls"
 	"encoding/json"
 	"fmt"
+	"io"
 	"log/slog"
 	"net/http"
 	"net/url"
@@ -713,9 +714,12 @@ func (h *GitOpsHandlers) getOperatorsForCluster(ctx context.Context, cluster str
 			ttl = operatorCacheEmptyTTL
 		}
 		if time.Since(entry.fetchedAt) < ttl {
-			operators := entry.operators
+			// #7748: Return a defensive copy so callers cannot mutate
+			// the cache's backing array.
+			result := make([]Operator, len(entry.operators))
+			copy(result, entry.operators)
 			operatorCacheMu.RUnlock()
-			return operators
+			return result
 		}
 	}
 	operatorCacheMu.RUnlock()
@@ -772,9 +776,12 @@ func (h *GitOpsHandlers) getOperatorsForClusterWithError(ctx context.Context, cl
 			ttl = operatorCacheEmptyTTL
 		}
 		if time.Since(entry.fetchedAt) < ttl {
-			operators := entry.operators
+			// #7748: Return a defensive copy so callers cannot mutate
+			// the cache's backing array.
+			result := make([]Operator, len(entry.operators))
+			copy(result, entry.operators)
 			operatorCacheMu.RUnlock()
-			return operators, nil
+			return result, nil
 		}
 	}
 	operatorCacheMu.RUnlock()
@@ -1040,9 +1047,14 @@ func (h *GitOpsHandlers) getSubscriptionsForClusterWithError(ctx context.Context
 	return subs, nil
 }
 
-// getSubscriptionsForCluster gets OLM subscriptions for a specific cluster using jsonpath
+// getSubscriptionsForCluster gets OLM subscriptions for a specific cluster using jsonpath.
+// #7749: Errors are logged instead of silently discarded so cluster failures
+// are distinguishable from empty results in server logs.
 func (h *GitOpsHandlers) getSubscriptionsForCluster(ctx context.Context, cluster string) []OperatorSubscription {
-	subs, _ := h.fetchSubscriptionsFromCluster(ctx, cluster)
+	subs, err := h.fetchSubscriptionsFromCluster(ctx, cluster)
+	if err != nil {
+		slog.Warn("[GitOps] subscription fetch failed for cluster", "cluster", cluster, "error", err)
+	}
 	return subs
 }
 
@@ -2328,8 +2340,12 @@ func (h *GitOpsHandlers) UpgradeHelmRelease(c *fiber.Ctx) error {
 		tmpFile.Close()
 
 		args = append(args, "-f", tmpFile.Name())
-		// Rebuild command with values file
+		// Rebuild command with values file.
+		// #7747: Create fresh buffers — the previous stdout/stderr were
+		// assigned to the old cmd instance and must not be reused.
 		cmd = exec.CommandContext(ctx, "helm", args...)
+		stdout.Reset()
+		stderr.Reset()
 		cmd.Stdout = &stdout
 		cmd.Stderr = &stderr
 	}
@@ -2587,7 +2603,12 @@ func (h *GitOpsHandlers) TriggerArgoSync(c *fiber.Ctx) error {
 				}
 				resp, err := client.Do(httpReq)
 				if err == nil {
-					defer resp.Body.Close()
+					// #7746: Drain the response body before closing to avoid
+					// HTTP connection pool exhaustion from partially-read bodies.
+					defer func() {
+						_, _ = io.Copy(io.Discard, resp.Body)
+						resp.Body.Close()
+					}()
 					if resp.StatusCode >= 200 && resp.StatusCode < 300 {
 						return c.JSON(fiber.Map{
 							"success": true,

--- a/pkg/k8s/client_health.go
+++ b/pkg/k8s/client_health.go
@@ -395,6 +395,15 @@ func (m *MultiClusterClient) GetAllClusterHealth(ctx context.Context) ([]Cluster
 		wg.Add(1)
 		go func(idx int, c ClusterInfo) {
 			defer wg.Done()
+			// #7751: Check for context cancellation before starting an
+			// expensive health probe. Without this, goroutines that haven't
+			// begun probing yet still launch full k8s API calls even after
+			// the global deadline fires, leaking until the probe completes.
+			select {
+			case <-deadlineCtx.Done():
+				return
+			default:
+			}
 			perCtx, perCancel := context.WithTimeout(deadlineCtx, perClusterHealthTimeout)
 			defer perCancel()
 			health, _ := m.GetClusterHealth(perCtx, c.Name)

--- a/pkg/settings/crypto.go
+++ b/pkg/settings/crypto.go
@@ -64,6 +64,14 @@ func ensureKeyFile(path string) ([]byte, error) {
 		os.Remove(tmpPath)
 		return nil, fmt.Errorf("failed to chmod temp keyfile %s: %w", tmpPath, chmodErr)
 	}
+	// #7752: fsync before close/link so the key data is durable on disk.
+	// Without this, a crash between write and link could leave a zero-length
+	// or corrupt key file that breaks all encrypted settings on next start.
+	if syncErr := tmpFile.Sync(); syncErr != nil {
+		tmpFile.Close()
+		os.Remove(tmpPath)
+		return nil, fmt.Errorf("failed to fsync temp keyfile %s: %w", tmpPath, syncErr)
+	}
 	tmpFile.Close()
 
 	// Use os.Link + os.Remove for atomic creation (fails if target already exists on most filesystems).


### PR DESCRIPTION
## Summary

Fixes 7 Go backend safety bugs:

- **#7746** — ArgoCD sync response body not drained before close, causing HTTP connection pool exhaustion. Fixed by adding `io.Copy(io.Discard, resp.Body)` before close.
- **#7747** — Helm upgrade handler reused stdout/stderr buffers when rebuilding `exec.Command` with a values file. Fixed by calling `buf.Reset()` before reassigning to the new command.
- **#7748** — Operator cache returned the internal slice reference directly, allowing callers to mutate the cache. Fixed by returning a defensive `copy()` of the slice.
- **#7749** — `getSubscriptionsForCluster` silently discarded the fetch error (`subs, _ := ...`), making cluster failures indistinguishable from empty results. Fixed by logging the error with `slog.Warn`.
- **#7750** — GPU node handler goroutine silently ignored per-cluster pod list errors, leading to unexplained GPU metric gaps. Fixed by logging with `slog.Warn`.
- **#7751** — `GetAllClusterHealth` goroutines did not check `ctx.Done()` before starting expensive health probes. After the global deadline fired, goroutines that hadn't started yet would still launch full k8s API calls. Fixed by adding a `select` guard at goroutine entry.
- **#7752** — Encryption key file was written without `fsync` before `os.Link`, risking a zero-length or corrupt key file on crash. Fixed by calling `tmpFile.Sync()` before close.

## Test plan

- [x] `go build ./...` passes
- [ ] Verify ArgoCD sync still works (manual or integration test)
- [ ] Verify helm upgrade with values file produces correct output
- [ ] Verify operator list returns expected data (cache correctness)
- [ ] Check server logs show subscription fetch errors when clusters are down
- [ ] Check server logs show GPU node errors when clusters are unreachable
- [ ] Verify cluster health endpoint returns within deadline even with slow clusters

Fixes #7746, #7747, #7748, #7749, #7750, #7751, #7752

🤖 Generated with [Claude Code](https://claude.com/claude-code)