### PR TITLE
fix: propagate isDemoData in ClusterAdmin universal stat fallback

### DIFF
--- a/web/src/components/cluster-admin/ClusterAdmin.tsx
+++ b/web/src/components/cluster-admin/ClusterAdmin.tsx
@@ -26,14 +26,15 @@ export function ClusterAdmin() {
 
   // Cluster-specific stats computed from the fast useClusters() cache.
   // nodes, warnings, pod_issues are provided by useUniversalStats (which
-  // reads from the shared cache lazily — no blocking multi-cluster fetch).
+  // shares a module-level cache with other dashboards — data is fetched
+  // once and reused, avoiding redundant multi-cluster requests).
   const getDashboardStatValue = (blockId: string): StatBlockValue => {
     switch (blockId) {
       case 'clusters': return { value: reachable.length, sublabel: 'reachable', isDemo: isDemoData }
       case 'healthy': return { value: healthy.length, sublabel: 'healthy', isDemo: isDemoData }
       case 'degraded': return { value: degraded.length, sublabel: 'degraded', isDemo: isDemoData }
       case 'offline': return { value: offline.length, sublabel: 'offline', isDemo: isDemoData }
-      default: return { value: '-' }
+      default: return { value: '-', isDemo: isDemoData }
     }
   }
 


### PR DESCRIPTION
## Summary
- Fix misleading comment in ClusterAdmin — `useUniversalStats` shares a module-level cache, not a lazy reader
- Pass `isDemo: isDemoData` in the `default:` case of `getDashboardStatValue` so `createMergedStatValueGetter` propagates demo state to universal stat blocks (nodes, warnings, pod_issues)

Without this fix, stat blocks that come from `useUniversalStats` (rather than the dashboard-specific getter) don't show the Demo badge when ClusterAdmin is in demo mode.

Fixes #7738

## Test plan
- [x] TypeScript type check passes
- [ ] CI build/lint passes
- [ ] In demo mode, ClusterAdmin stat blocks from universal stats show Demo badge