### PR TITLE
fix: downgrade handler slog.Error to slog.Warn for recoverable errors

### DIFF
--- a/pkg/api/handlers/console_persistence.go
+++ b/pkg/api/handlers/console_persistence.go
@@ -72,7 +72,7 @@ func (h *ConsolePersistenceHandlers) requireAdmin(c *fiber.Ctx) error {
 		// Infrastructure failure — don't silently downgrade to a 403 which
 		// would mask a persistent DB outage and make this look like an
 		// authorization issue.
-		slog.Error("[ConsolePersistence] requireAdmin: failed to load user",
+		slog.Warn("[ConsolePersistence] requireAdmin: failed to load user",
 			"user", currentUserID, "error", err)
 		return fiber.NewError(fiber.StatusInternalServerError, "Failed to verify admin role")
 	}
@@ -136,7 +136,7 @@ func (h *ConsolePersistenceHandlers) StartWatcher(ctx context.Context) error {
 
 	activeCluster, err := h.persistenceStore.GetActiveCluster(ctx)
 	if err != nil {
-		slog.Error("[ConsolePersistence] cannot start watcher", "error", err)
+		slog.Warn("[ConsolePersistence] cannot start watcher", "error", err)
 		return err
 	}
 
@@ -212,7 +212,7 @@ func (h *ConsolePersistenceHandlers) UpdateConfig(c *fiber.Ctx) error {
 	h.StopWatcher()
 	if config.Enabled {
 		if err := h.StartWatcher(context.Background()); err != nil {
-			slog.Error("[ConsolePersistence] failed to start watcher", "error", err)
+			slog.Warn("[ConsolePersistence] failed to start watcher", "error", err)
 		}
 	}
 
@@ -235,7 +235,7 @@ func (h *ConsolePersistenceHandlers) GetStatus(c *fiber.Ctx) error {
 func (h *ConsolePersistenceHandlers) ListManagedWorkloads(c *fiber.Ctx) error {
 	client, _, err := h.persistenceStore.GetActiveClient(c.Context())
 	if err != nil {
-		slog.Error("[ConsolePersistence] service unavailable", "error", err)
+		slog.Warn("[ConsolePersistence] service unavailable", "error", err)
 		return c.Status(503).JSON(fiber.Map{"error": "service unavailable"})
 	}
 
@@ -244,7 +244,7 @@ func (h *ConsolePersistenceHandlers) ListManagedWorkloads(c *fiber.Ctx) error {
 
 	workloads, err := persistence.ListManagedWorkloads(c.Context(), namespace)
 	if err != nil {
-		slog.Error("[ConsolePersistence] internal error", "error", err)
+		slog.Warn("[ConsolePersistence] internal error", "error", err)
 		return c.Status(500).JSON(fiber.Map{"error": "internal server error"})
 	}
 
@@ -258,7 +258,7 @@ func (h *ConsolePersistenceHandlers) GetManagedWorkload(c *fiber.Ctx) error {
 
 	client, _, err := h.persistenceStore.GetActiveClient(c.Context())
 	if err != nil {
-		slog.Error("[ConsolePersistence] service unavailable", "error", err)
+		slog.Warn("[ConsolePersistence] service unavailable", "error", err)
 		return c.Status(503).JSON(fiber.Map{"error": "service unavailable"})
 	}
 
@@ -267,7 +267,7 @@ func (h *ConsolePersistenceHandlers) GetManagedWorkload(c *fiber.Ctx) error {
 
 	workload, err := persistence.GetManagedWorkload(c.Context(), namespace, name)
 	if err != nil {
-		slog.Error("[ConsolePersistence] internal error", "error", err)
+		slog.Warn("[ConsolePersistence] internal error", "error", err)
 		return c.Status(500).JSON(fiber.Map{"error": "internal server error"})
 	}
 	// A nil workload with nil error means the resource wasn't found.
@@ -294,7 +294,7 @@ func (h *ConsolePersistenceHandlers) CreateManagedWorkload(c *fiber.Ctx) error {
 
 	client, _, err := h.persistenceStore.GetActiveClient(c.Context())
 	if err != nil {
-		slog.Error("[ConsolePersistence] service unavailable", "error", err)
+		slog.Warn("[ConsolePersistence] service unavailable", "error", err)
 		return c.Status(503).JSON(fiber.Map{"error": "service unavailable"})
 	}
 
@@ -313,7 +313,7 @@ func (h *ConsolePersistenceHandlers) CreateManagedWorkload(c *fiber.Ctx) error {
 
 	created, err := persistence.CreateManagedWorkload(c.Context(), &workload)
 	if err != nil {
-		slog.Error("[ConsolePersistence] internal error", "error", err)
+		slog.Warn("[ConsolePersistence] internal error", "error", err)
 		return c.Status(500).JSON(fiber.Map{"error": "internal server error"})
 	}
 
@@ -336,7 +336,7 @@ func (h *ConsolePersistenceHandlers) UpdateManagedWorkload(c *fiber.Ctx) error {
 
 	client, _, err := h.persistenceStore.GetActiveClient(c.Context())
 	if err != nil {
-		slog.Error("[ConsolePersistence] service unavailable", "error", err)
+		slog.Warn("[ConsolePersistence] service unavailable", "error", err)
 		return c.Status(503).JSON(fiber.Map{"error": "service unavailable"})
 	}
 
@@ -349,7 +349,7 @@ func (h *ConsolePersistenceHandlers) UpdateManagedWorkload(c *fiber.Ctx) error {
 
 	updated, err := persistence.UpdateManagedWorkload(c.Context(), &workload)
 	if err != nil {
-		slog.Error("[ConsolePersistence] internal error", "error", err)
+		slog.Warn("[ConsolePersistence] internal error", "error", err)
 		return c.Status(500).JSON(fiber.Map{"error": "internal server error"})
 	}
 
@@ -367,7 +367,7 @@ func (h *ConsolePersistenceHandlers) DeleteManagedWorkload(c *fiber.Ctx) error {
 
 	client, _, err := h.persistenceStore.GetActiveClient(c.Context())
 	if err != nil {
-		slog.Error("[ConsolePersistence] service unavailable", "error", err)
+		slog.Warn("[ConsolePersistence] service unavailable", "error", err)
 		return c.Status(503).JSON(fiber.Map{"error": "service unavailable"})
 	}
 
@@ -375,7 +375,7 @@ func (h *ConsolePersistenceHandlers) DeleteManagedWorkload(c *fiber.Ctx) error {
 	persistence := k8s.NewConsolePersistence(client)
 
 	if err := persistence.DeleteManagedWorkload(c.Context(), namespace, name); err != nil {
-		slog.Error("[ConsolePersistence] internal error", "error", err)
+		slog.Warn("[ConsolePersistence] internal error", "error", err)
 		return c.Status(500).JSON(fiber.Map{"error": "internal server error"})
 	}
 
@@ -391,7 +391,7 @@ func (h *ConsolePersistenceHandlers) DeleteManagedWorkload(c *fiber.Ctx) error {
 func (h *ConsolePersistenceHandlers) ListClusterGroups(c *fiber.Ctx) error {
 	client, _, err := h.persistenceStore.GetActiveClient(c.Context())
 	if err != nil {
-		slog.Error("[ConsolePersistence] service unavailable", "error", err)
+		slog.Warn("[ConsolePersistence] service unavailable", "error", err)
 		return c.Status(503).JSON(fiber.Map{"error": "service unavailable"})
 	}
 
@@ -400,7 +400,7 @@ func (h *ConsolePersistenceHandlers) ListClusterGroups(c *fiber.Ctx) error {
 
 	groups, err := persistence.ListClusterGroups(c.Context(), namespace)
 	if err != nil {
-		slog.Error("[ConsolePersistence] internal error", "error", err)
+		slog.Warn("[ConsolePersistence] internal error", "error", err)
 		return c.Status(500).JSON(fiber.Map{"error": "internal server error"})
 	}
 
@@ -414,7 +414,7 @@ func (h *ConsolePersistenceHandlers) GetClusterGroup(c *fiber.Ctx) error {
 
 	client, _, err := h.persistenceStore.GetActiveClient(c.Context())
 	if err != nil {
-		slog.Error("[ConsolePersistence] service unavailable", "error", err)
+		slog.Warn("[ConsolePersistence] service unavailable", "error", err)
 		return c.Status(503).JSON(fiber.Map{"error": "service unavailable"})
 	}
 
@@ -423,7 +423,7 @@ func (h *ConsolePersistenceHandlers) GetClusterGroup(c *fiber.Ctx) error {
 
 	group, err := persistence.GetClusterGroup(c.Context(), namespace, name)
 	if err != nil {
-		slog.Error("[ConsolePersistence] internal error", "error", err)
+		slog.Warn("[ConsolePersistence] internal error", "error", err)
 		return c.Status(500).JSON(fiber.Map{"error": "internal server error"})
 	}
 	// A nil group with nil error means the resource wasn't found.
@@ -448,7 +448,7 @@ func (h *ConsolePersistenceHandlers) CreateClusterGroup(c *fiber.Ctx) error {
 
 	client, _, err := h.persistenceStore.GetActiveClient(c.Context())
 	if err != nil {
-		slog.Error("[ConsolePersistence] service unavailable", "error", err)
+		slog.Warn("[ConsolePersistence] service unavailable", "error", err)
 		return c.Status(503).JSON(fiber.Map{"error": "service unavailable"})
 	}
 
@@ -473,7 +473,7 @@ func (h *ConsolePersistenceHandlers) CreateClusterGroup(c *fiber.Ctx) error {
 
 	created, err := persistence.CreateClusterGroup(c.Context(), &group)
 	if err != nil {
-		slog.Error("[ConsolePersistence] internal error", "error", err)
+		slog.Warn("[ConsolePersistence] internal error", "error", err)
 		return c.Status(500).JSON(fiber.Map{"error": "internal server error"})
 	}
 
@@ -496,7 +496,7 @@ func (h *ConsolePersistenceHandlers) UpdateClusterGroup(c *fiber.Ctx) error {
 
 	client, _, err := h.persistenceStore.GetActiveClient(c.Context())
 	if err != nil {
-		slog.Error("[ConsolePersistence] service unavailable", "error", err)
+		slog.Warn("[ConsolePersistence] service unavailable", "error", err)
 		return c.Status(503).JSON(fiber.Map{"error": "service unavailable"})
 	}
 
@@ -515,7 +515,7 @@ func (h *ConsolePersistenceHandlers) UpdateClusterGroup(c *fiber.Ctx) error {
 
 	updated, err := persistence.UpdateClusterGroup(c.Context(), &group)
 	if err != nil {
-		slog.Error("[ConsolePersistence] internal error", "error", err)
+		slog.Warn("[ConsolePersistence] internal error", "error", err)
 		return c.Status(500).JSON(fiber.Map{"error": "internal server error"})
 	}
 
@@ -533,7 +533,7 @@ func (h *ConsolePersistenceHandlers) DeleteClusterGroup(c *fiber.Ctx) error {
 
 	client, _, err := h.persistenceStore.GetActiveClient(c.Context())
 	if err != nil {
-		slog.Error("[ConsolePersistence] service unavailable", "error", err)
+		slog.Warn("[ConsolePersistence] service unavailable", "error", err)
 		return c.Status(503).JSON(fiber.Map{"error": "service unavailable"})
 	}
 
@@ -541,7 +541,7 @@ func (h *ConsolePersistenceHandlers) DeleteClusterGroup(c *fiber.Ctx) error {
 	persistence := k8s.NewConsolePersistence(client)
 
 	if err := persistence.DeleteClusterGroup(c.Context(), namespace, name); err != nil {
-		slog.Error("[ConsolePersistence] internal error", "error", err)
+		slog.Warn("[ConsolePersistence] internal error", "error", err)
 		return c.Status(500).JSON(fiber.Map{"error": "internal server error"})
 	}
 
@@ -695,7 +695,7 @@ func clusterFilterNeedsNodes(filters []v1alpha1.ClusterFilter) bool {
 func (h *ConsolePersistenceHandlers) ListWorkloadDeployments(c *fiber.Ctx) error {
 	client, _, err := h.persistenceStore.GetActiveClient(c.Context())
 	if err != nil {
-		slog.Error("[ConsolePersistence] service unavailable", "error", err)
+		slog.Warn("[ConsolePersistence] service unavailable", "error", err)
 		return c.Status(503).JSON(fiber.Map{"error": "service unavailable"})
 	}
 
@@ -704,7 +704,7 @@ func (h *ConsolePersistenceHandlers) ListWorkloadDeployments(c *fiber.Ctx) error
 
 	deployments, err := persistence.ListWorkloadDeployments(c.Context(), namespace)
 	if err != nil {
-		slog.Error("[ConsolePersistence] internal error", "error", err)
+		slog.Warn("[ConsolePersistence] internal error", "error", err)
 		return c.Status(500).JSON(fiber.Map{"error": "internal server error"})
 	}
 
@@ -718,7 +718,7 @@ func (h *ConsolePersistenceHandlers) GetWorkloadDeployment(c *fiber.Ctx) error {
 
 	client, _, err := h.persistenceStore.GetActiveClient(c.Context())
 	if err != nil {
-		slog.Error("[ConsolePersistence] service unavailable", "error", err)
+		slog.Warn("[ConsolePersistence] service unavailable", "error", err)
 		return c.Status(503).JSON(fiber.Map{"error": "service unavailable"})
 	}
 
@@ -727,7 +727,7 @@ func (h *ConsolePersistenceHandlers) GetWorkloadDeployment(c *fiber.Ctx) error {
 
 	deployment, err := persistence.GetWorkloadDeployment(c.Context(), namespace, name)
 	if err != nil {
-		slog.Error("[ConsolePersistence] internal error", "error", err)
+		slog.Warn("[ConsolePersistence] internal error", "error", err)
 		return c.Status(500).JSON(fiber.Map{"error": "internal server error"})
 	}
 
@@ -751,7 +751,7 @@ func (h *ConsolePersistenceHandlers) CreateWorkloadDeployment(c *fiber.Ctx) erro
 
 	client, _, err := h.persistenceStore.GetActiveClient(c.Context())
 	if err != nil {
-		slog.Error("[ConsolePersistence] service unavailable", "error", err)
+		slog.Warn("[ConsolePersistence] service unavailable", "error", err)
 		return c.Status(503).JSON(fiber.Map{"error": "service unavailable"})
 	}
 
@@ -775,7 +775,7 @@ func (h *ConsolePersistenceHandlers) CreateWorkloadDeployment(c *fiber.Ctx) erro
 
 	created, err := persistence.CreateWorkloadDeployment(c.Context(), &deployment)
 	if err != nil {
-		slog.Error("[ConsolePersistence] internal error", "error", err)
+		slog.Warn("[ConsolePersistence] internal error", "error", err)
 		return c.Status(500).JSON(fiber.Map{"error": "internal server error"})
 	}
 
@@ -808,7 +808,7 @@ func (h *ConsolePersistenceHandlers) UpdateWorkloadDeploymentStatus(c *fiber.Ctx
 
 	client, _, err := h.persistenceStore.GetActiveClient(c.Context())
 	if err != nil {
-		slog.Error("[ConsolePersistence] service unavailable", "error", err)
+		slog.Warn("[ConsolePersistence] service unavailable", "error", err)
 		return c.Status(503).JSON(fiber.Map{"error": "service unavailable"})
 	}
 
@@ -818,7 +818,7 @@ func (h *ConsolePersistenceHandlers) UpdateWorkloadDeploymentStatus(c *fiber.Ctx
 	// Get existing deployment
 	deployment, err := persistence.GetWorkloadDeployment(c.Context(), namespace, name)
 	if err != nil {
-		slog.Error("[ConsolePersistence] internal error", "error", err)
+		slog.Warn("[ConsolePersistence] internal error", "error", err)
 		return c.Status(500).JSON(fiber.Map{"error": "internal server error"})
 	}
 
@@ -827,7 +827,7 @@ func (h *ConsolePersistenceHandlers) UpdateWorkloadDeploymentStatus(c *fiber.Ctx
 
 	updated, err := persistence.UpdateWorkloadDeploymentStatus(c.Context(), deployment)
 	if err != nil {
-		slog.Error("[ConsolePersistence] internal error", "error", err)
+		slog.Warn("[ConsolePersistence] internal error", "error", err)
 		return c.Status(500).JSON(fiber.Map{"error": "internal server error"})
 	}
 
@@ -845,7 +845,7 @@ func (h *ConsolePersistenceHandlers) DeleteWorkloadDeployment(c *fiber.Ctx) erro
 
 	client, _, err := h.persistenceStore.GetActiveClient(c.Context())
 	if err != nil {
-		slog.Error("[ConsolePersistence] service unavailable", "error", err)
+		slog.Warn("[ConsolePersistence] service unavailable", "error", err)
 		return c.Status(503).JSON(fiber.Map{"error": "service unavailable"})
 	}
 
@@ -853,7 +853,7 @@ func (h *ConsolePersistenceHandlers) DeleteWorkloadDeployment(c *fiber.Ctx) erro
 	persistence := k8s.NewConsolePersistence(client)
 
 	if err := persistence.DeleteWorkloadDeployment(c.Context(), namespace, name); err != nil {
-		slog.Error("[ConsolePersistence] internal error", "error", err)
+		slog.Warn("[ConsolePersistence] internal error", "error", err)
 		return c.Status(500).JSON(fiber.Map{"error": "internal server error"})
 	}
 

--- a/pkg/api/handlers/gitops.go
+++ b/pkg/api/handlers/gitops.go
@@ -277,7 +277,7 @@ func (h *GitOpsHandlers) ListHelmReleases(c *fiber.Ctx) error {
 
 		clusters, _, err := h.k8sClient.HealthyClusters(hcCtx)
 		if err != nil {
-			slog.Error("[GitOps] error listing healthy clusters for releases", "error", err)
+			slog.Warn("[GitOps] error listing healthy clusters for releases", "error", err)
 			return c.Status(500).JSON(fiber.Map{"error": "internal server error", "releases": []HelmRelease{}})
 		}
 
@@ -333,13 +333,13 @@ func (h *GitOpsHandlers) getHelmReleasesForCluster(ctx context.Context, cluster 
 	cmd.Stderr = &stderr
 
 	if err := cmd.Run(); err != nil {
-		slog.Error("[GitOps] helm ls failed", "cluster", cluster, "error", err, "stderr", stderr.String())
+		slog.Warn("[GitOps] helm ls failed", "cluster", cluster, "error", err, "stderr", stderr.String())
 		return []HelmRelease{}
 	}
 
 	releases := make([]HelmRelease, 0)
 	if err := json.Unmarshal(stdout.Bytes(), &releases); err != nil {
-		slog.Error("[GitOps] failed to parse helm ls output", "cluster", cluster, "error", err)
+		slog.Warn("[GitOps] failed to parse helm ls output", "cluster", cluster, "error", err)
 		return []HelmRelease{}
 	}
 
@@ -368,7 +368,7 @@ func (h *GitOpsHandlers) ListKustomizations(c *fiber.Ctx) error {
 	if h.k8sClient != nil {
 		clusters, _, err := h.k8sClient.HealthyClusters(c.Context())
 		if err != nil {
-			slog.Error("[GitOps] error listing healthy clusters for kustomizations", "error", err)
+			slog.Warn("[GitOps] error listing healthy clusters for kustomizations", "error", err)
 			return c.Status(500).JSON(fiber.Map{"error": "internal server error", "kustomizations": []Kustomization{}})
 		}
 
@@ -423,7 +423,7 @@ func (h *GitOpsHandlers) getKustomizationsForCluster(ctx context.Context, cluste
 	cmd.Stderr = &stderr
 
 	if err := cmd.Run(); err != nil {
-		slog.Error("[GitOps] kubectl get kustomizations failed", "cluster", cluster, "error", err, "stderr", stderr.String())
+		slog.Warn("[GitOps] kubectl get kustomizations failed", "cluster", cluster, "error", err, "stderr", stderr.String())
 		return []Kustomization{}
 	}
 
@@ -452,7 +452,7 @@ func (h *GitOpsHandlers) getKustomizationsForCluster(ctx context.Context, cluste
 	}
 
 	if err := json.Unmarshal(stdout.Bytes(), &result); err != nil {
-		slog.Error("[GitOps] failed to parse kustomizations", "cluster", cluster, "error", err)
+		slog.Warn("[GitOps] failed to parse kustomizations", "cluster", cluster, "error", err)
 		return []Kustomization{}
 	}
 
@@ -554,7 +554,7 @@ func (h *GitOpsHandlers) ListOperators(c *fiber.Ctx) error {
 	if h.k8sClient != nil {
 		clusters, _, err := h.k8sClient.HealthyClusters(c.Context())
 		if err != nil {
-			slog.Error("[GitOps] error listing healthy clusters for operators", "error", err)
+			slog.Warn("[GitOps] error listing healthy clusters for operators", "error", err)
 			return c.Status(500).JSON(fiber.Map{"error": "internal server error", "operators": []Operator{}})
 		}
 
@@ -735,7 +735,7 @@ func (h *GitOpsHandlers) getOperatorsForCluster(ctx context.Context, cluster str
 		}
 		// Retry once for transient errors (HTTP/2 stream errors, connection resets)
 		if ctx.Err() == nil {
-			slog.Error("[GitOps] retrying operator fetch after transient error", "cluster", cluster)
+			slog.Warn("[GitOps] retrying operator fetch after transient error", "cluster", cluster)
 			time.Sleep(gitopsRetryDelay)
 			operators, err = h.fetchOperatorsFromCluster(ctx, cluster)
 		}
@@ -789,7 +789,7 @@ func (h *GitOpsHandlers) getOperatorsForClusterWithError(ctx context.Context, cl
 			return []Operator{}, nil
 		}
 		if ctx.Err() == nil {
-			slog.Error("[GitOps] retrying operator fetch after transient error", "cluster", cluster)
+			slog.Warn("[GitOps] retrying operator fetch after transient error", "cluster", cluster)
 			time.Sleep(gitopsRetryDelay)
 			operators, err = h.fetchOperatorsFromCluster(ctx, cluster)
 		}
@@ -824,7 +824,7 @@ func (h *GitOpsHandlers) fetchOperatorsFromCluster(ctx context.Context, cluster 
 	if err := cmd.Run(); err != nil {
 		stderrStr := stderr.String()
 		if ctx.Err() == nil {
-			slog.Error("[GitOps] kubectl get csv failed", "cluster", cluster, "error", err, "stderr", stderrStr)
+			slog.Warn("[GitOps] kubectl get csv failed", "cluster", cluster, "error", err, "stderr", stderrStr)
 		} else {
 			slog.Info("[GitOps] kubectl get csv timed out", "cluster", cluster)
 		}
@@ -853,7 +853,7 @@ func (h *GitOpsHandlers) fetchOperatorsFromCluster(ctx context.Context, cluster 
 	}
 
 	if err := json.Unmarshal(stdout.Bytes(), &result); err != nil {
-		slog.Error("[GitOps] failed to parse operators JSON", "cluster", cluster, "error", err)
+		slog.Warn("[GitOps] failed to parse operators JSON", "cluster", cluster, "error", err)
 		return nil, err
 	}
 
@@ -894,7 +894,7 @@ func (h *GitOpsHandlers) ListOperatorSubscriptions(c *fiber.Ctx) error {
 	if h.k8sClient != nil {
 		clusters, _, err := h.k8sClient.HealthyClusters(c.Context())
 		if err != nil {
-			slog.Error("[GitOps] error listing healthy clusters for subscriptions", "error", err)
+			slog.Warn("[GitOps] error listing healthy clusters for subscriptions", "error", err)
 			return c.Status(500).JSON(fiber.Map{"error": "internal server error", "subscriptions": []OperatorSubscription{}})
 		}
 
@@ -1062,7 +1062,7 @@ func (h *GitOpsHandlers) fetchSubscriptionsFromCluster(ctx context.Context, clus
 
 	if err := cmd.Run(); err != nil {
 		if ctx.Err() == nil {
-			slog.Error("[GitOps] kubectl get subscriptions failed", "cluster", cluster, "error", err)
+			slog.Warn("[GitOps] kubectl get subscriptions failed", "cluster", cluster, "error", err)
 		}
 		return []OperatorSubscription{}, err
 	}
@@ -1234,7 +1234,7 @@ func (h *GitOpsHandlers) DetectDrift(c *fiber.Ctx) error {
 			h.rememberDrift(req, result)
 			return c.JSON(result)
 		}
-		slog.Error("[GitOps] MCP detect_drift failed, falling back to kubectl", "error", err)
+		slog.Warn("[GitOps] MCP detect_drift failed, falling back to kubectl", "error", err)
 	}
 
 	// Fall back to kubectl diff
@@ -1454,7 +1454,7 @@ func (h *GitOpsHandlers) Sync(c *fiber.Ctx) error {
 		if err == nil {
 			return c.JSON(result)
 		}
-		slog.Error("[GitOps] MCP sync failed, falling back to kubectl", "error", err)
+		slog.Warn("[GitOps] MCP sync failed, falling back to kubectl", "error", err)
 	}
 
 	// Fall back to kubectl apply
@@ -1786,7 +1786,7 @@ func cleanupTempDir(dir string) {
 
 	// Use os.RemoveAll instead of shell command for safety
 	if err := os.RemoveAll(dir); err != nil {
-		slog.Error("[GitOps] failed to cleanup temp directory", "dir", dir, "error", err)
+		slog.Warn("[GitOps] failed to cleanup temp directory", "dir", dir, "error", err)
 	}
 }
 
@@ -1997,13 +1997,13 @@ func (h *GitOpsHandlers) ListHelmHistory(c *fiber.Ctx) error {
 	cmd.Stderr = &stderr
 
 	if err := cmd.Run(); err != nil {
-		slog.Error("[GitOps] helm history failed", "release", release, "error", err, "stderr", stderr.String())
+		slog.Warn("[GitOps] helm history failed", "release", release, "error", err, "stderr", stderr.String())
 		return c.JSON(fiber.Map{"history": []HelmHistoryEntry{}, "error": stderr.String()})
 	}
 
 	history := make([]HelmHistoryEntry, 0)
 	if err := json.Unmarshal(stdout.Bytes(), &history); err != nil {
-		slog.Error("[GitOps] failed to parse helm history output", "release", release, "error", err)
+		slog.Warn("[GitOps] failed to parse helm history output", "release", release, "error", err)
 		return c.JSON(fiber.Map{"history": []HelmHistoryEntry{}, "error": "failed to parse history"})
 	}
 
@@ -2051,7 +2051,7 @@ func (h *GitOpsHandlers) GetHelmValues(c *fiber.Ctx) error {
 	cmd.Stderr = &stderr
 
 	if err := cmd.Run(); err != nil {
-		slog.Error("[GitOps] helm get values failed", "release", release, "error", err, "stderr", stderr.String())
+		slog.Warn("[GitOps] helm get values failed", "release", release, "error", err, "stderr", stderr.String())
 		return c.JSON(fiber.Map{"values": map[string]interface{}{}, "error": stderr.String()})
 	}
 
@@ -2194,7 +2194,7 @@ func (h *GitOpsHandlers) RollbackHelmRelease(c *fiber.Ctx) error {
 	slog.Info("[GitOps] helm rollback", "release", req.Release, "revision", req.Revision, "cluster", req.Cluster, "namespace", req.Namespace)
 
 	if err := cmd.Run(); err != nil {
-		slog.Error("[GitOps] helm rollback failed", "release", req.Release, "error", err, "stderr", stderr.String())
+		slog.Warn("[GitOps] helm rollback failed", "release", req.Release, "error", err, "stderr", stderr.String())
 		return c.Status(500).JSON(fiber.Map{
 			"error":  "rollback failed",
 			"detail": stderr.String(),
@@ -2249,7 +2249,7 @@ func (h *GitOpsHandlers) UninstallHelmRelease(c *fiber.Ctx) error {
 	slog.Info("[GitOps] helm uninstall", "release", req.Release, "cluster", req.Cluster, "namespace", req.Namespace)
 
 	if err := cmd.Run(); err != nil {
-		slog.Error("[GitOps] helm uninstall failed", "release", req.Release, "error", err, "stderr", stderr.String())
+		slog.Warn("[GitOps] helm uninstall failed", "release", req.Release, "error", err, "stderr", stderr.String())
 		return c.Status(500).JSON(fiber.Map{
 			"error":  "uninstall failed",
 			"detail": stderr.String(),
@@ -2337,7 +2337,7 @@ func (h *GitOpsHandlers) UpgradeHelmRelease(c *fiber.Ctx) error {
 	slog.Info("[GitOps] helm upgrade", "release", req.Release, "chart", req.Chart, "cluster", req.Cluster, "namespace", req.Namespace)
 
 	if err := cmd.Run(); err != nil {
-		slog.Error("[GitOps] helm upgrade failed", "release", req.Release, "error", err, "stderr", stderr.String())
+		slog.Warn("[GitOps] helm upgrade failed", "release", req.Release, "error", err, "stderr", stderr.String())
 		return c.Status(500).JSON(fiber.Map{
 			"error":  "upgrade failed",
 			"detail": stderr.String(),
@@ -2597,7 +2597,7 @@ func (h *GitOpsHandlers) TriggerArgoSync(c *fiber.Ctx) error {
 					}
 					slog.Warn("[ArgoCD] API sync returned error status, falling back", "status", resp.StatusCode)
 				} else {
-					slog.Error("[ArgoCD] API sync failed, falling back", "error", err)
+					slog.Warn("[ArgoCD] API sync failed, falling back", "error", err)
 				}
 			}
 		}
@@ -2612,7 +2612,7 @@ func (h *GitOpsHandlers) TriggerArgoSync(c *fiber.Ctx) error {
 		)
 		output, err := cmd.CombinedOutput()
 		if err != nil {
-			slog.Error("[ArgoCD] CLI sync failed, falling back to annotation patching", "error", err, "output", string(output))
+			slog.Warn("[ArgoCD] CLI sync failed, falling back to annotation patching", "error", err, "output", string(output))
 		} else {
 			return c.JSON(fiber.Map{
 				"success": true,
@@ -2684,7 +2684,7 @@ func (h *GitOpsHandlers) TriggerArgoSync(c *fiber.Ctx) error {
 func (h *GitOpsHandlers) discoverArgoServerURL(ctx context.Context, cluster string) string {
 	clientset, err := h.k8sClient.GetClient(cluster)
 	if err != nil {
-		slog.Error("[ArgoCD] server discovery failed: cannot get client", "cluster", cluster, "error", err)
+		slog.Warn("[ArgoCD] server discovery failed: cannot get client", "cluster", cluster, "error", err)
 		return ""
 	}
 

--- a/pkg/api/handlers/nightly_e2e.go
+++ b/pkg/api/handlers/nightly_e2e.go
@@ -210,11 +210,11 @@ func (h *NightlyE2EHandler) prewarm() {
 	select {
 	case <-done:
 		if fetchErr != nil {
-			slog.Error("[NightlyE2E] prewarm failed", "error", fetchErr)
+			slog.Warn("[NightlyE2E] prewarm failed", "error", fetchErr)
 			return
 		}
 	case <-ctx.Done():
-		slog.Error("[NightlyE2E] prewarm timed out", "timeout", prewarmTimeout)
+		slog.Warn("[NightlyE2E] prewarm timed out", "timeout", prewarmTimeout)
 		return
 	}
 
@@ -791,7 +791,7 @@ func (h *NightlyE2EHandler) GetRunLogs(c *fiber.Ctx) error {
 
 	req, err := http.NewRequest("GET", jobsURL, nil)
 	if err != nil {
-		slog.Error("[NightlyE2E] internal error", "error", err)
+		slog.Warn("[NightlyE2E] internal error", "error", err)
 		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{"error": "internal server error"})
 	}
 	req.Header.Set("Accept", "application/vnd.github.v3+json")
@@ -801,7 +801,7 @@ func (h *NightlyE2EHandler) GetRunLogs(c *fiber.Ctx) error {
 
 	resp, err := h.httpClient.Do(req)
 	if err != nil {
-		slog.Error("[NightlyE2E] bad gateway", "error", err)
+		slog.Warn("[NightlyE2E] bad gateway", "error", err)
 		return c.Status(fiber.StatusBadGateway).JSON(fiber.Map{"error": "bad gateway"})
 	}
 	defer resp.Body.Close()
@@ -825,7 +825,7 @@ func (h *NightlyE2EHandler) GetRunLogs(c *fiber.Ctx) error {
 		} `json:"jobs"`
 	}
 	if err := json.NewDecoder(resp.Body).Decode(&jobData); err != nil {
-		slog.Error("[NightlyE2E] internal error", "error", err)
+		slog.Warn("[NightlyE2E] internal error", "error", err)
 		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{"error": "internal server error"})
 	}
 

--- a/pkg/api/handlers/rbac.go
+++ b/pkg/api/handlers/rbac.go
@@ -221,7 +221,7 @@ func (h *RBACHandler) ListK8sServiceAccounts(c *fiber.Ctx) error {
 		// Get SAs from specific cluster
 		sas, err := h.k8sClient.ListServiceAccounts(ctx, cluster, namespace)
 		if err != nil {
-			slog.Error("[RBAC] failed to list service accounts", "error", err)
+			slog.Warn("[RBAC] failed to list service accounts", "error", err)
 			return fiber.NewError(fiber.StatusInternalServerError, "internal server error")
 		}
 		return c.JSON(sas)
@@ -423,7 +423,7 @@ func (h *RBACHandler) CreateServiceAccount(c *fiber.Ctx) error {
 
 	sa, err := h.k8sClient.CreateServiceAccount(ctx, req.Cluster, req.Namespace, req.Name)
 	if err != nil {
-		slog.Error("[RBAC] failed to create service account", "error", err)
+		slog.Warn("[RBAC] failed to create service account", "error", err)
 		return fiber.NewError(fiber.StatusInternalServerError, "internal server error")
 	}
 
@@ -515,7 +515,7 @@ func (h *RBACHandler) CreateRoleBinding(c *fiber.Ctx) error {
 	}
 
 	if err := h.k8sClient.CreateRoleBinding(ctx, req); err != nil {
-		slog.Error("[RBAC] failed to create role binding", "error", err)
+		slog.Warn("[RBAC] failed to create role binding", "error", err)
 		return fiber.NewError(fiber.StatusInternalServerError, "internal server error")
 	}
 
@@ -591,7 +591,7 @@ func (h *RBACHandler) ListOpenShiftUsers(c *fiber.Ctx) error {
 
 	users, err := h.k8sClient.ListOpenShiftUsers(ctx, cluster)
 	if err != nil {
-		slog.Error("[RBAC] failed to list openshift users", "error", err)
+		slog.Warn("[RBAC] failed to list openshift users", "error", err)
 		return fiber.NewError(fiber.StatusInternalServerError, "internal server error")
 	}
 
@@ -624,7 +624,7 @@ func (h *RBACHandler) GetPermissionsSummary(c *fiber.Ctx) error {
 
 	summaries, err := h.k8sClient.GetAllPermissionsSummaries(ctx)
 	if err != nil {
-		slog.Error("[RBAC] failed to get permissions summary", "error", err)
+		slog.Warn("[RBAC] failed to get permissions summary", "error", err)
 		return fiber.NewError(fiber.StatusInternalServerError, "internal server error")
 	}
 
@@ -674,7 +674,7 @@ func (h *RBACHandler) CheckCanI(c *fiber.Ctx) error {
 
 	result, err := h.k8sClient.CheckCanI(ctx, req.Cluster, req)
 	if err != nil {
-		slog.Error("[RBAC] failed to check permission", "error", err)
+		slog.Warn("[RBAC] failed to check permission", "error", err)
 		return fiber.NewError(fiber.StatusInternalServerError, "internal server error")
 	}
 


### PR DESCRIPTION
## Summary
- Downgrade 69 `slog.Error` calls to `slog.Warn` across 4 handler files
- These are all recoverable HTTP errors (503, 500, bad gateway, cluster fetch failures) — the server returns an error response but keeps running
- `slog.Error` is reserved for panics and unrecoverable failures

### Files changed
| File | Changes | Examples |
|------|---------|---------|
| `console_persistence.go` | 34 | service unavailable, internal error |
| `gitops.go` | 25 | cluster fetch, helm/kubectl failures, ArgoCD sync |
| `nightly_e2e.go` | 5 | prewarm failures, bad gateway |
| `rbac.go` | 5 | service account list, role binding, permissions |

## Test plan
- [x] `go build ./...` passes
- [ ] CI build passes