### PR TITLE
fix: harden store, crypto, gitops, and GPU error handling (#7731-#7754)

### DIFF
--- a/pkg/api/handlers/gitops.go
+++ b/pkg/api/handlers/gitops.go
@@ -7,6 +7,7 @@ import (
 	"crypto/tls"
 	"encoding/json"
 	"fmt"
+	"io"
 	"log/slog"
 	"net/http"
 	"net/url"
@@ -713,9 +714,12 @@ func (h *GitOpsHandlers) getOperatorsForCluster(ctx context.Context, cluster str
 			ttl = operatorCacheEmptyTTL
 		}
 		if time.Since(entry.fetchedAt) < ttl {
-			operators := entry.operators
+			// Return a copy so callers cannot mutate the cache's backing array (#7748).
+			src := entry.operators
+			cpy := make([]Operator, len(src))
+			copy(cpy, src)
 			operatorCacheMu.RUnlock()
-			return operators
+			return cpy
 		}
 	}
 	operatorCacheMu.RUnlock()
@@ -1042,7 +1046,10 @@ func (h *GitOpsHandlers) getSubscriptionsForClusterWithError(ctx context.Context
 
 // getSubscriptionsForCluster gets OLM subscriptions for a specific cluster using jsonpath
 func (h *GitOpsHandlers) getSubscriptionsForCluster(ctx context.Context, cluster string) []OperatorSubscription {
-	subs, _ := h.fetchSubscriptionsFromCluster(ctx, cluster)
+	subs, err := h.fetchSubscriptionsFromCluster(ctx, cluster)
+	if err != nil {
+		slog.Warn("[GitOps] failed to fetch subscriptions for cluster", "cluster", cluster, "error", err)
+	}
 	return subs
 }
 
@@ -2328,7 +2335,9 @@ func (h *GitOpsHandlers) UpgradeHelmRelease(c *fiber.Ctx) error {
 		tmpFile.Close()
 
 		args = append(args, "-f", tmpFile.Name())
-		// Rebuild command with values file
+		// Rebuild command with values file; reset buffers to avoid mixed output (#7747).
+		stdout.Reset()
+		stderr.Reset()
 		cmd = exec.CommandContext(ctx, "helm", args...)
 		cmd.Stdout = &stdout
 		cmd.Stderr = &stderr
@@ -2595,6 +2604,8 @@ func (h *GitOpsHandlers) TriggerArgoSync(c *fiber.Ctx) error {
 							"method":  "api",
 						})
 					}
+					// Drain body so the HTTP connection can be returned to the pool (#7746).
+					io.Copy(io.Discard, resp.Body)
 					slog.Warn("[ArgoCD] API sync returned error status, falling back", "status", resp.StatusCode)
 				} else {
 					slog.Error("[ArgoCD] API sync failed, falling back", "error", err)

--- a/pkg/k8s/client_gpu.go
+++ b/pkg/k8s/client_gpu.go
@@ -31,7 +31,10 @@ func (m *MultiClusterClient) GetGPUNodes(ctx context.Context, contextName string
 
 	// Fetch all pods once upfront to calculate accelerator allocations per node
 	// This is much faster than querying pods per-node for large clusters
-	allPods, _ := client.CoreV1().Pods("").List(ctx, metav1.ListOptions{})
+	allPods, podListErr := client.CoreV1().Pods("").List(ctx, metav1.ListOptions{})
+	if podListErr != nil {
+		slog.Warn("[GPU] failed to list pods for accelerator allocation; GPU utilization may be inaccurate", "error", podListErr)
+	}
 	// Track allocations by node and accelerator type
 	gpuAllocationByNode := make(map[string]int) // GPU allocations
 	tpuAllocationByNode := make(map[string]int) // TPU allocations
@@ -326,13 +329,19 @@ func (m *MultiClusterClient) GetGPUNodeHealth(ctx context.Context, contextName s
 	}
 
 	// 4. Find non-running pods for stuck pod detection (exclude Succeeded/Running)
-	allPods, _ := client.CoreV1().Pods("").List(ctx, metav1.ListOptions{})
+	allPods, podErr := client.CoreV1().Pods("").List(ctx, metav1.ListOptions{})
+	if podErr != nil {
+		slog.Warn("[GPU] failed to list pods for stuck-pod detection", "error", podErr)
+	}
 
 	// 5. Get warning events from the last hour for GPU reset detection
 	oneHourAgo := time.Now().Add(-1 * time.Hour)
-	events, _ := client.CoreV1().Events("").List(ctx, metav1.ListOptions{
+	events, evtErr := client.CoreV1().Events("").List(ctx, metav1.ListOptions{
 		FieldSelector: "type=Warning",
 	})
+	if evtErr != nil {
+		slog.Warn("[GPU] failed to list warning events for GPU reset detection", "error", evtErr)
+	}
 
 	// 6. Build health status for each GPU node
 	checkedAt := time.Now().UTC().Format(time.RFC3339)

--- a/pkg/settings/crypto.go
+++ b/pkg/settings/crypto.go
@@ -64,6 +64,13 @@ func ensureKeyFile(path string) ([]byte, error) {
 		os.Remove(tmpPath)
 		return nil, fmt.Errorf("failed to chmod temp keyfile %s: %w", tmpPath, chmodErr)
 	}
+	// Flush data to stable storage before the atomic rename so that a crash
+	// between write and rename cannot leave a truncated key file (#7752).
+	if syncErr := tmpFile.Sync(); syncErr != nil {
+		tmpFile.Close()
+		os.Remove(tmpPath)
+		return nil, fmt.Errorf("failed to fsync temp keyfile %s: %w", tmpPath, syncErr)
+	}
 	tmpFile.Close()
 
 	// Use os.Link + os.Remove for atomic creation (fails if target already exists on most filesystems).

--- a/pkg/store/sqlite.go
+++ b/pkg/store/sqlite.go
@@ -888,7 +888,9 @@ func (s *SQLiteStore) GetCard(id uuid.UUID) (*models.Card, error) {
 }
 
 func (s *SQLiteStore) GetDashboardCards(dashboardID uuid.UUID) ([]models.Card, error) {
-	rows, err := s.db.Query(`SELECT id, dashboard_id, card_type, config, position, last_summary, last_focus, created_at FROM cards WHERE dashboard_id = ? ORDER BY created_at`, dashboardID.String())
+	// Defense-in-depth LIMIT matching the per-dashboard cap enforced at insert time (#7733).
+	const maxCardsLimit = 200
+	rows, err := s.db.Query(`SELECT id, dashboard_id, card_type, config, position, last_summary, last_focus, created_at FROM cards WHERE dashboard_id = ? ORDER BY created_at LIMIT ?`, dashboardID.String(), maxCardsLimit)
 	if err != nil {
 		return nil, err
 	}
@@ -1292,7 +1294,7 @@ func (s *SQLiteStore) UpdateSwapStatus(id uuid.UUID, status models.SwapStatus) e
 }
 
 func (s *SQLiteStore) SnoozeSwap(id uuid.UUID, newSwapAt time.Time) error {
-	_, err := s.db.Exec(`UPDATE pending_swaps SET swap_at = ?, status = 'snoozed' WHERE id = ?`, newSwapAt, id.String())
+	_, err := s.db.Exec(`UPDATE pending_swaps SET swap_at = ?, status = ? WHERE id = ?`, newSwapAt, string(models.SwapStatusSnoozed), id.String())
 	return err
 }
 
@@ -2257,7 +2259,7 @@ func boolToInt(b bool) int {
 // RevokeToken persists a revoked token JTI with its expiration time.
 func (s *SQLiteStore) RevokeToken(jti string, expiresAt time.Time) error {
 	_, err := s.db.Exec(
-		`INSERT OR REPLACE INTO revoked_tokens (jti, expires_at) VALUES (?, ?)`,
+		`INSERT OR IGNORE INTO revoked_tokens (jti, expires_at) VALUES (?, ?)`,
 		jti, expiresAt,
 	)
 	return err
@@ -2893,7 +2895,9 @@ func (s *SQLiteStore) DeleteClusterGroup(name string) error {
 
 // ListClusterGroups returns all persisted cluster group definitions (#7013).
 func (s *SQLiteStore) ListClusterGroups() (map[string][]byte, error) {
-	rows, err := s.db.Query(`SELECT name, data FROM cluster_groups`)
+	// Cap the number of cluster groups loaded per call to prevent memory exhaustion (#7734).
+	const maxClusterGroupsLimit = 500
+	rows, err := s.db.Query(`SELECT name, data FROM cluster_groups LIMIT ?`, maxClusterGroupsLimit)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Summary

Batch fix for issues #7731 through #7754 (excluding #7736, #7738 already closed).

**Code fixes (10 issues):**
- **#7731**: `RevokeToken` uses `INSERT OR IGNORE` instead of `INSERT OR REPLACE` to prevent expiry extension (**touches auth — flagged with `ai-needs-human`**)
- **#7732**: `SnoozeSwap` uses `models.SwapStatusSnoozed` constant instead of hardcoded string
- **#7733**: `GetDashboardCards` adds defense-in-depth `LIMIT 200`
- **#7734**: `ListClusterGroups` adds `LIMIT 500` to prevent memory exhaustion on BLOB table
- **#7746**: Drain ArgoCD response body on non-2xx to prevent connection pool exhaustion
- **#7747**: Reset helm stdout/stderr buffers before second command reuse
- **#7748**: Deep-copy operator cache slice to prevent concurrent backing-array mutation
- **#7749**: Log subscription fetch errors instead of discarding with blank identifier
- **#7750**: Log pod/event list errors in GPU handlers instead of silently discarding
- **#7752**: Add `fsync` before atomic rename in encryption key file creation

**Issues to close separately (3 issues):**
- **#7735**: `github_issue_url` column is populated at the API layer from GitHub data, not from DB writes. Removing would break existing databases. Harmless dead column.
- **#7751**: The `wg.Wait()` goroutine is bounded by the number of probes (one per cluster). It is not a leak — it exits when probes finish. The pattern is standard Go concurrency.
- **#7754**: Auto-QA enhancement affecting 50+ UI files. Not a bug — animation consistency improvement for a future PR.

Fixes #7731
Fixes #7732
Fixes #7733
Fixes #7734
Fixes #7746
Fixes #7747
Fixes #7748
Fixes #7749
Fixes #7750
Fixes #7752

## Test plan
- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] `npm run build` passes
- [ ] Verify `RevokeToken` with duplicate JTI does not extend expiry
- [ ] Verify `SnoozeSwap` writes correct status constant
- [ ] Verify operator cache returns independent slices under concurrent access