### PR TITLE
fix: CSP blocks login globe animation and Google Fonts

### DIFF
--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -428,11 +428,12 @@ func (s *Server) setupMiddleware() {
 
 		c.Set("Content-Security-Policy",
 			"default-src 'self'; "+
-				"script-src 'self' 'unsafe-inline' https://www.googletagmanager.com; "+
-				"style-src 'self' 'unsafe-inline'; "+
+				"script-src 'self' 'unsafe-inline' blob: https://www.googletagmanager.com; "+
+				"worker-src 'self' blob:; "+
+				"style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; "+
 				"img-src 'self' data: https:; "+
 				"connect-src 'self' "+kcAgentLoopback+" "+kcAgentLoopbackWS+" "+kcAgentLocalhost+" "+kcAgentLocalhostWS+" https://www.google-analytics.com https://www.googletagmanager.com wss:; "+
-				"font-src 'self' data:; "+
+				"font-src 'self' data: https://fonts.gstatic.com; "+
 				"object-src 'none'; "+
 				"base-uri 'self'")
 


### PR DESCRIPTION
## Summary
The Content-Security-Policy header was blocking:
1. **Three.js globe animation** on the login page — it creates web workers from `blob:` URLs which were not in `script-src` or `worker-src`
2. **Google Fonts** — the stylesheet from `fonts.googleapis.com` and font files from `fonts.gstatic.com` were blocked by `style-src` and `font-src`

### Changes to CSP
| Directive | Added |
|-----------|-------|
| `script-src` | `blob:` |
| `worker-src` | `'self' blob:` (new directive) |
| `style-src` | `https://fonts.googleapis.com` |
| `font-src` | `https://fonts.gstatic.com` |

## Test plan
- [ ] Login page shows 3D globe animation (wide viewport)
- [ ] Google Fonts load (Inter, JetBrains Mono)
- [ ] No CSP violations in browser console
- [ ] XSS protection still active (no `unsafe-eval`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)