### PR TITLE
fix: abort cluster fetches on nav + reduce concurrency to prevent connection pool exhaustion

### DIFF
--- a/web/src/components/layout/Layout.tsx
+++ b/web/src/components/layout/Layout.tsx
@@ -2,6 +2,7 @@ import { ReactNode, Suspense, lazy, useState, useEffect, useRef } from 'react'
 import { useTranslation } from 'react-i18next'
 import { Link, useLocation } from 'react-router-dom'
 import { Box, Wifi, WifiOff, X, Settings, Rocket, RotateCcw, Check, Loader2, RefreshCw, Plug } from 'lucide-react'
+import { abortAllFetches } from '../../hooks/useCachedData'
 import { Button } from '../ui/Button'
 import { Navbar } from './navbar/index'
 import { Sidebar } from './Sidebar'
@@ -62,6 +63,9 @@ function NavigationProgress() {
 
   useEffect(() => {
     if (location.pathname !== prevPath.current) {
+      // Abort all in-flight cluster fetches so browser connections are
+      // freed immediately for the new page's lazy chunk and data.
+      abortAllFetches()
       setIsNavigating(true)
       prevPath.current = location.pathname
       const timer = setTimeout(() => setIsNavigating(false), CLOSE_ANIMATION_MS)

--- a/web/src/hooks/useCachedData.ts
+++ b/web/src/hooks/useCachedData.ts
@@ -73,6 +73,17 @@ const AGENT_HTTP_TIMEOUT_MS = 5_000
 /** Maximum number of pods to return from a prefetch query */
 const MAX_PREFETCH_PODS = 100
 
+// Global AbortController for all in-flight fetchAPI requests.
+// Aborting this cancels every pending cluster fetch, freeing browser
+// connections instantly so navigation and lazy chunks can load.
+let globalFetchController = new AbortController()
+
+/** Abort all in-flight fetchAPI requests (e.g. on route change). */
+export function abortAllFetches(): void {
+  globalFetchController.abort()
+  globalFetchController = new AbortController()
+}
+
 async function fetchAPI<T>(
   endpoint: string,
   params?: Record<string, string | number | undefined>
@@ -92,12 +103,18 @@ async function fetchAPI<T>(
   }
 
   const url = `/api/mcp/${endpoint}?${searchParams}`
+  // Combine the global abort signal with a per-request timeout.
+  // AbortSignal.any() fires if either signal triggers.
+  const signal = AbortSignal.any([
+    globalFetchController.signal,
+    AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS),
+  ])
   const response = await fetch(url, {
     method: 'GET',
     headers: {
       'Content-Type': 'application/json',
       Authorization: `Bearer ${token}` },
-    signal: AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS) })
+    signal })
 
   if (!response.ok) {
     throw new Error(`API error: ${response.status}`)

--- a/web/src/lib/utils/concurrency.ts
+++ b/web/src/lib/utils/concurrency.ts
@@ -11,8 +11,15 @@
  * overwhelmed.
  */
 
-/** Default maximum number of concurrent requests across clusters */
-export const DEFAULT_CLUSTER_CONCURRENCY = 8
+/**
+ * Default maximum number of concurrent requests across clusters.
+ *
+ * Browsers limit HTTP/1.1 connections to ~6 per origin. Setting this
+ * higher than 4 causes cluster fetches to exhaust the connection pool,
+ * blocking lazy chunk downloads, navigation, and SSE streams.
+ * Keep at 4 to leave headroom for page navigation and static assets.
+ */
+export const DEFAULT_CLUSTER_CONCURRENCY = 4
 
 /** Minimum allowed concurrency — at least one worker must run (#6851). */
 const MIN_CONCURRENCY = 1


### PR DESCRIPTION
## Summary
Fixes the "route changes but dashboard doesn't switch" issue when navigating away from Dashboard or My Clusters during initial data load.

### Root cause
Browsers limit HTTP/1.1 to ~6 connections per origin. With `DEFAULT_CLUSTER_CONCURRENCY=8` + SSE streams, all connections were occupied by cluster fetches. When the user clicked a sidebar link, the new page's lazy chunk and data requests queued behind stuck fetches (10s timeout each).

### Fix
1. **`abortAllFetches()`** — new function that cancels all pending `fetchAPI` requests via a shared `AbortController`. Called on every route change in `NavigationProgress`. This immediately frees connections.
2. **Concurrency 8 → 4** — leaves headroom for navigation, lazy chunks, SSE streams, and static assets.

### How it works
```
User clicks "My Clusters"
  → NavigationProgress detects pathname change
  → abortAllFetches() cancels all pending cluster fetches
  → browser connections freed instantly
  → Clusters.tsx chunk downloads immediately
  → page renders
```

## Test plan
- [ ] Login, land on Dashboard, immediately click My Clusters — should switch instantly
- [ ] Click between Dashboard, My Clusters, Cluster Admin, Sec. Compliance — all instant
- [ ] Data still loads correctly after navigation (aborted fetches are retried by auto-refresh)
- [ ] No console errors from aborted fetches (AbortError is expected and handled)

🤖 Generated with [Claude Code](https://claude.com/claude-code)