### PR TITLE
fix(test): update EXPECTED_DEFAULT_CONCURRENCY to 4 in concurrency test

### DIFF
--- a/web/src/lib/utils/__tests__/concurrency.test.ts
+++ b/web/src/lib/utils/__tests__/concurrency.test.ts
@@ -36,8 +36,12 @@ const TICK_DELAY_MS = 5
 /** Number of tasks for the concurrency-limit stress test */
 const CONCURRENCY_STRESS_TASK_COUNT = 30
 
-/** Expected default concurrency from the module */
-const EXPECTED_DEFAULT_CONCURRENCY = 8
+/**
+ * Expected default concurrency from the module.
+ * Reduced from 8 to 4 in PR #7765 to leave headroom for browser connection
+ * pool limits (~6 connections per origin for HTTP/1.1).
+ */
+const EXPECTED_DEFAULT_CONCURRENCY = 4
 
 /** Sentinel value returned by successful tasks */
 const SUCCESS_SENTINEL = 'ok'


### PR DESCRIPTION
## Summary

PR #7765 reduced `DEFAULT_CLUSTER_CONCURRENCY` from 8 to 4 to leave headroom in the browser connection pool (~6 connections per origin for HTTP/1.1). The expected constant in the test file was not updated, causing the "uses DEFAULT_CLUSTER_CONCURRENCY when no concurrency param given" assertion to fail.

This updates `EXPECTED_DEFAULT_CONCURRENCY` from `8` to `4` and adds a comment explaining the rationale (browser connection pool limit).

## Changes
- `web/src/lib/utils/__tests__/concurrency.test.ts`: update `EXPECTED_DEFAULT_CONCURRENCY` from 8 to 4, add explanatory comment

## Test plan
- [ ] Vitest coverage suite passes locally (all 18 concurrency tests pass)

Fixes #7769