### PR TITLE
fix(e2e): address Copilot review comments from PR #7768

### DIFF
--- a/web/e2e/helpers/ux-assertions.ts
+++ b/web/e2e/helpers/ux-assertions.ts
@@ -149,7 +149,11 @@ export function collectConsoleErrors(page: Page): () => void {
     /Failed to load resource/i,
     /Cross-Origin Request Blocked/i,
     /CORS policy/i,
-    /Access-Control-Allow-Origin/i,
+    // Narrowed: only allow Access-Control errors from known demo/local origins
+    // to avoid masking unrelated issues that mention this header.
+    /Access-Control-Allow-Origin.*localhost/i,
+    /Access-Control-Allow-Origin.*127\.0\.0\.1/i,
+    /Access-Control-Allow-Origin.*kubestellar\.io/i,
     /Notification permission/i,
     /validateDOMNesting/i,
     /act\(\)/i,

--- a/web/e2e/user-flows/find-and-search.spec.ts
+++ b/web/e2e/user-flows/find-and-search.spec.ts
@@ -1,6 +1,6 @@
 import { test, expect } from '@playwright/test'
 import { setupDemoAndNavigate, ELEMENT_VISIBLE_TIMEOUT_MS } from '../helpers/setup'
-import { assertNoLayoutOverflow, collectConsoleErrors } from '../helpers/ux-assertions'
+import { assertNoLayoutOverflow } from '../helpers/ux-assertions'
 
 /** Viewport dimensions for mobile tests */
 const MOBILE_WIDTH = 375
@@ -15,16 +15,18 @@ const GIBBERISH_QUERY = 'zxqwvbn9876543'
 test.describe('Find and Search — "I need to find something"', () => {
   test('keyboard shortcut opens global search', async ({ page }) => {
     await setupDemoAndNavigate(page, '/')
-    // Try both Ctrl+K (Linux/Windows CI) and Meta+K (Mac) —
-    // whichever the platform supports
+    // global-search-input is always visible in the navbar; we validate the
+    // shortcut by checking that the search dropdown (results panel) becomes
+    // visible after the keypress.
+    const searchResults = page.getByTestId('global-search-results')
+    // Try Ctrl+K (Linux/Windows CI)
     await page.keyboard.press('Control+k')
-    const searchInput = page.getByTestId('global-search-input')
-    const opened = await searchInput.isVisible({ timeout: 2_000 }).catch(() => false)
-    if (!opened) {
+    const openedCtrl = await searchResults.isVisible({ timeout: 2_000 }).catch(() => false)
+    if (!openedCtrl) {
       // Fallback: try Meta+K (Mac)
       await page.keyboard.press('Meta+k')
     }
-    await expect(searchInput).toBeVisible({ timeout: ELEMENT_VISIBLE_TIMEOUT_MS })
+    await expect(searchResults).toBeVisible({ timeout: ELEMENT_VISIBLE_TIMEOUT_MS })
   })
 
   test('clicking search bar focuses input', async ({ page }) => {

--- a/web/e2e/user-flows/keyboard-navigation.spec.ts
+++ b/web/e2e/user-flows/keyboard-navigation.spec.ts
@@ -87,13 +87,16 @@ test.describe('Keyboard Navigation', () => {
   })
 
   test('Escape closes open modal (search)', async ({ page }) => {
+    // global-search-input is always visible in the navbar; track the dropdown
+    // results panel (global-search-results) to determine open/closed state.
+    const searchResults = page.getByTestId('global-search-results')
+
     // Try both Ctrl+K and Meta+K to open search (platform-dependent)
     await page.keyboard.press('Control+k')
-    const searchInput = page.getByTestId('global-search-input')
-    let opened = await searchInput.isVisible({ timeout: 2_000 }).catch(() => false)
+    let opened = await searchResults.isVisible({ timeout: 2_000 }).catch(() => false)
     if (!opened) {
       await page.keyboard.press('Meta+k')
-      opened = await searchInput.isVisible({ timeout: 2_000 }).catch(() => false)
+      opened = await searchResults.isVisible({ timeout: 2_000 }).catch(() => false)
     }
     if (!opened) {
       // Fallback: click the search area directly
@@ -101,13 +104,13 @@ test.describe('Keyboard Navigation', () => {
       const hasSearch = await searchArea.isVisible({ timeout: 2_000 }).catch(() => false)
       if (hasSearch) {
         await searchArea.click()
-        opened = await searchInput.isVisible({ timeout: 2_000 }).catch(() => false)
+        opened = await searchResults.isVisible({ timeout: 2_000 }).catch(() => false)
       }
     }
-    if (!opened) { test.skip(true, 'Could not open search via keyboard or click'); return }
+    if (!opened) { test.skip(true, 'Could not open search dropdown via keyboard or click'); return }
 
     await page.keyboard.press('Escape')
-    await expect(searchInput).not.toBeVisible({ timeout: MODAL_TIMEOUT_MS })
+    await expect(searchResults).not.toBeVisible({ timeout: MODAL_TIMEOUT_MS })
   })
 
   test('Escape closes settings modal', async ({ page }) => {


### PR DESCRIPTION
## Summary

Follow-up to PR #7768 to address 4 Copilot review comments that were flagged after merge.

## Changes

### 1. Remove unused import (`find-and-search.spec.ts`)
`collectConsoleErrors` was imported but not used after PR #7768 changes. Removed to fix TypeScript/ESLint `no-unused-vars`.

### 2. Fix keyboard shortcut test (`find-and-search.spec.ts`)
The keyboard shortcut test was checking `global-search-input.isVisible()` to determine if Ctrl/Meta+K worked, but that input is always visible in the navbar. Updated to check `global-search-results` (the dropdown panel) instead — this correctly reflects whether the shortcut activated search.

### 3. Fix Escape-closes-search test (`keyboard-navigation.spec.ts`)
Same root cause — the test checked `expect(searchInput).not.toBeVisible()` after Escape, which always passes since the input is always visible. Updated to check `global-search-results` for both open/close detection.

### 4. Narrow CORS allowlist regex (`ux-assertions.ts`)
The `/Access-Control-Allow-Origin/i` pattern was too broad and would mask unrelated issues mentioning that header. Replaced with three specific patterns matching only known demo/local origins: `localhost`, `127.0.0.1`, and `kubestellar.io`.

## Test plan
- [ ] Build passes (`npm run build`)
- [ ] E2E tests run (Playwright; non-blocking)

Fixes #7772