### PR TITLE
fix: prefetch sidebar chunks eagerly — instant dashboard switching

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -97,7 +97,7 @@ const CompliancePerfTest = safeLazy(() => import('./pages/CompliancePerfTest'), 
 import { DASHBOARD_CHUNKS } from './lib/dashboardChunks'
 
 // Always prefetched regardless of enabled dashboards
-const ALWAYS_PREFETCH = new Set(['dashboard', 'settings', 'clusters'])
+const ALWAYS_PREFETCH = new Set(['dashboard', 'settings', 'clusters', 'cluster-admin', 'security', 'deploy'])
 
 // Prefetch lazy route chunks after initial page load.
 // Batched to avoid overwhelming the Vite dev server with simultaneous
@@ -108,8 +108,17 @@ if (typeof window !== 'undefined') {
 
   const prefetchRoutes = async () => {
     // Wait for the enabled dashboards list from /health so we only
-    // prefetch chunks the user will actually see.
-    await fetchEnabledDashboards()
+    // prefetch chunks the user will actually see. Timeout after 2s
+    // and prefetch all chunks — better to over-prefetch than leave
+    // chunks uncached and block navigation.
+    try {
+      await Promise.race([
+        fetchEnabledDashboards(),
+        new Promise((_, reject) => setTimeout(() => reject(new Error('timeout')), 2000)),
+      ])
+    } catch {
+      // Timeout or error — fall through to prefetch all
+    }
     const enabledIds = getEnabledDashboardIds()
 
     // null = show all dashboards, otherwise only enabled + always-needed


### PR DESCRIPTION
## Summary
Dashboard navigation appeared to require "double clicking" — the URL changed immediately but content stayed showing the old page for several seconds until the destination's lazy JS chunk finished downloading.

### Root cause
The lazy chunk download was blocked by the browser's 6-connection HTTP/1.1 pool being occupied by cluster data fetches. `fetchEnabledDashboards()` also stalled, preventing the prefetch from running at all.

### Fix
1. Add `cluster-admin`, `security`, `deploy` to `ALWAYS_PREFETCH` so their chunks cache at startup
2. Add 2s timeout to `fetchEnabledDashboards()` — falls through to prefetch all chunks if connection pool is busy

## Test plan
- [ ] Login, immediately click any sidebar dashboard — switches instantly
- [ ] No "stuck on old page" behavior
- [ ] Check DevTools Network — chunks should load during startup, not on click

🤖 Generated with [Claude Code](https://claude.com/claude-code)