### PR TITLE
🐛 fix(test): hard 5m timeout + process-group kill for agent tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,3 +59,12 @@ dev:
 ## lint: Run frontend linter
 lint:
 	cd web && npm run lint
+
+## test: Run all Go tests with a hard 5-minute timeout per package
+## Prevents zombie agent.test process leaks from ad-hoc test runs
+test:
+	go test -timeout 5m ./...
+
+## test-agent: Run agent tests only (most likely to leak subprocesses)
+test-agent:
+	go test -timeout 5m -v ./pkg/agent/...

--- a/pkg/agent/main_test.go
+++ b/pkg/agent/main_test.go
@@ -1,0 +1,51 @@
+package agent
+
+import (
+	"fmt"
+	"os"
+	"os/signal"
+	"syscall"
+	"testing"
+	"time"
+)
+
+// hardTestTimeout is a process-level safety net. If go test's own -timeout
+// flag is not passed (e.g. an ad-hoc `go test ./pkg/agent/...` from a CLI
+// session), this TestMain ensures the entire test binary exits after 5
+// minutes rather than leaking zombie agent.test processes that spawn
+// kubectl and Python subprocesses indefinitely.
+//
+// Context: on 2026-04-13, five leaked agent.test process trees accumulated
+// 4,370 child processes, exhausting the macOS process table and blocking
+// all fork() calls system-wide.
+const hardTestTimeout = 5 * time.Minute
+
+func TestMain(m *testing.M) {
+	// Kill the entire process group (not just this process) so any
+	// subprocess trees (kubectl, kc-agent, Python) are also reaped.
+	// On Unix, setting the process group to our PID lets us kill -PGID.
+	done := make(chan struct{})
+	go func() {
+		select {
+		case <-time.After(hardTestTimeout):
+			fmt.Fprintf(os.Stderr, "\n[TestMain] HARD TIMEOUT: agent tests exceeded %s — killing process group to prevent zombie leak\n", hardTestTimeout)
+			// Kill our process group
+			syscall.Kill(-syscall.Getpid(), syscall.SIGKILL)
+		case <-done:
+			// Tests finished normally
+		}
+	}()
+
+	// Also handle SIGINT/SIGTERM so Ctrl+C kills subprocesses too
+	sig := make(chan os.Signal, 1)
+	signal.Notify(sig, syscall.SIGINT, syscall.SIGTERM)
+	go func() {
+		<-sig
+		fmt.Fprintf(os.Stderr, "\n[TestMain] Signal received — killing process group\n")
+		syscall.Kill(-syscall.Getpid(), syscall.SIGKILL)
+	}()
+
+	code := m.Run()
+	close(done)
+	os.Exit(code)
+}


### PR DESCRIPTION
## Problem

On 2026-04-13, five leaked `agent.test` process trees accumulated **4,370 child processes** (kubectl, Python kc-agent probes), exhausting the macOS process table and blocking all `fork()` calls system-wide.

Root cause: ad-hoc `go test ./pkg/agent/...` from Claude Code sessions had no `-timeout` flag. When sessions were interrupted, the parent died but child `agent.test` processes were orphaned.

## Fix

1. **`pkg/agent/main_test.go`** — `TestMain` with a hard 5-minute timeout that kills the entire process group (`syscall.Kill(-PGID, SIGKILL)`) so all subprocess trees are reaped. Also handles SIGINT/SIGTERM.

2. **`Makefile`** — `make test` and `make test-agent` targets that always pass `-timeout 5m`.

## Test plan
- [x] `go vet ./pkg/agent/...` passes
- [ ] `go test -timeout 30s ./pkg/agent/... -run TestDeviceTracker` completes and exits cleanly