### PR TITLE
fix: accessibility, Netlify timeouts, CronJob card, and Copilot reviews

### DIFF
--- a/web/e2e/user-flows/find-and-search.spec.ts
+++ b/web/e2e/user-flows/find-and-search.spec.ts
@@ -1,6 +1,6 @@
 import { test, expect } from '@playwright/test'
 import { setupDemoAndNavigate, ELEMENT_VISIBLE_TIMEOUT_MS } from '../helpers/setup'
-import { assertNoLayoutOverflow, collectConsoleErrors } from '../helpers/ux-assertions'
+import { assertNoLayoutOverflow } from '../helpers/ux-assertions'
 
 /** Viewport dimensions for mobile tests */
 const MOBILE_WIDTH = 375

--- a/web/netlify/functions/affiliate-clicks.mts
+++ b/web/netlify/functions/affiliate-clicks.mts
@@ -72,9 +72,15 @@ async function fetchAffiliateClicks(): Promise<Record<string, AffiliateData>> {
   }
 
   // Decode base64 service account JSON
-  const credentials = JSON.parse(
-    Buffer.from(serviceAccountB64, "base64").toString("utf-8")
-  );
+  let credentials: Record<string, unknown>;
+  try {
+    credentials = JSON.parse(
+      Buffer.from(serviceAccountB64, "base64").toString("utf-8")
+    );
+  } catch {
+    console.error("GA4_SERVICE_ACCOUNT_JSON is not valid base64-encoded JSON");
+    return {};
+  }
   const auth = new google.auth.GoogleAuth({
     credentials,
     scopes: ["https://www.googleapis.com/auth/analytics.readonly"],

--- a/web/netlify/functions/bonus-points.mts
+++ b/web/netlify/functions/bonus-points.mts
@@ -17,6 +17,9 @@ const BONUS_TITLE_REGEX = /^\[bonus\]\s+@(\S+)\s+\+(\d+)\s*(.*)/i;
 /** Cache TTL — 15 minutes */
 const CACHE_TTL_MS = 15 * 60 * 1000;
 
+/** Timeout for GitHub API requests */
+const GITHUB_API_TIMEOUT_MS = 10_000;
+
 interface BonusEntry {
   issue_number: number;
   points: number;
@@ -60,7 +63,14 @@ async function fetchAllBonusIssues(): Promise<Record<string, BonusEntry[]>> {
   }
 
   const url = `https://api.github.com/repos/${BONUS_REPO}/issues?labels=${BONUS_LABEL}&state=all&per_page=100&creator=${BONUS_AUTHORIZED_USER}`;
-  const res = await fetch(url, { headers });
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), GITHUB_API_TIMEOUT_MS);
+  let res: Response;
+  try {
+    res = await fetch(url, { headers, signal: controller.signal });
+  } finally {
+    clearTimeout(timeoutId);
+  }
   if (!res.ok) {
     throw new Error(`GitHub API ${res.status}`);
   }

--- a/web/netlify/functions/youtube-thumbnail.mts
+++ b/web/netlify/functions/youtube-thumbnail.mts
@@ -14,6 +14,9 @@ const YOUTUBE_VIDEO_ID_LEN = 11;
  */
 const DEFAULT_THUMBNAIL_MAX_BYTES = 1200;
 
+/** Timeout for fetching thumbnails from YouTube CDN */
+const YOUTUBE_CDN_TIMEOUT_MS = 10_000;
+
 export default async (req: Request) => {
   const url = new URL(req.url);
   const videoId = url.pathname.split("/").pop() || "";
@@ -28,9 +31,17 @@ export default async (req: Request) => {
   }
 
   try {
-    const resp = await fetch(
-      `https://img.youtube.com/vi/${videoId}/mqdefault.jpg`
-    );
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), YOUTUBE_CDN_TIMEOUT_MS);
+    let resp: Response;
+    try {
+      resp = await fetch(
+        `https://img.youtube.com/vi/${videoId}/mqdefault.jpg`,
+        { signal: controller.signal }
+      );
+    } finally {
+      clearTimeout(timeoutId);
+    }
 
     if (!resp.ok) {
       return new Response("thumbnail not found", { status: 404 });

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -105,6 +105,8 @@ const ALWAYS_PREFETCH = new Set(['dashboard', 'settings', 'clusters', 'cluster-a
 if (typeof window !== 'undefined') {
   const PREFETCH_BATCH_SIZE = 8
   const PREFETCH_BATCH_DELAY = 50
+  /** Max wait (ms) for the enabled-dashboards list before prefetching all chunks */
+  const PREFETCH_DASHBOARD_TIMEOUT_MS = 2_000
 
   const prefetchRoutes = async () => {
     // Wait for the enabled dashboards list from /health so we only
@@ -112,9 +114,12 @@ if (typeof window !== 'undefined') {
     // and prefetch all chunks — better to over-prefetch than leave
     // chunks uncached and block navigation.
     try {
+      let timeoutId: ReturnType<typeof setTimeout> | undefined
       await Promise.race([
-        fetchEnabledDashboards(),
-        new Promise((_, reject) => setTimeout(() => reject(new Error('timeout')), 2000)),
+        fetchEnabledDashboards().finally(() => clearTimeout(timeoutId)),
+        new Promise<never>((_, reject) => {
+          timeoutId = setTimeout(() => reject(new Error('timeout')), PREFETCH_DASHBOARD_TIMEOUT_MS)
+        }),
       ])
     } catch {
       // Timeout or error — fall through to prefetch all

--- a/web/src/components/dashboard/CreateDashboardModal.tsx
+++ b/web/src/components/dashboard/CreateDashboardModal.tsx
@@ -105,10 +105,11 @@ function CreateDashboardModalInner({
 
         {/* Dashboard name input */}
         <div className="mb-4">
-          <label className="block text-sm font-medium text-foreground mb-2">
+          <label htmlFor="create-dashboard-name" className="block text-sm font-medium text-foreground mb-2">
             {t('dashboard.create.nameLabel')}
           </label>
           <input
+            id="create-dashboard-name"
             ref={inputRef}
             type="text"
             value={name}
@@ -121,10 +122,11 @@ function CreateDashboardModalInner({
 
         {/* Description input (optional) */}
         <div className="mb-6">
-          <label className="block text-sm font-medium text-foreground mb-2">
+          <label htmlFor="create-dashboard-description" className="block text-sm font-medium text-foreground mb-2">
             {t('dashboard.create.descriptionLabel')} <span className="text-muted-foreground font-normal">{t('dashboard.create.optional')}</span>
           </label>
           <textarea
+            id="create-dashboard-description"
             value={description}
             onChange={(e) => setDescription(e.target.value)}
             placeholder={t('dashboard.create.descriptionPlaceholder')}

--- a/web/src/components/layout/UserProfileDropdown.tsx
+++ b/web/src/components/layout/UserProfileDropdown.tsx
@@ -127,6 +127,9 @@ export function UserProfileDropdown({ user, onLogout, onPreferences }: UserProfi
       {/* Trigger button */}
       <button
         onClick={toggleDropdown}
+        aria-expanded={isOpen}
+        aria-haspopup="true"
+        aria-controls="profile-dropdown-menu"
         className="flex items-center gap-2 border-l border-border hover:bg-secondary rounded-lg px-3 py-1.5 h-9 transition-colors"
       >
         {user.avatar_url ? (
@@ -148,7 +151,7 @@ export function UserProfileDropdown({ user, onLogout, onPreferences }: UserProfi
 
       {/* Dropdown menu */}
       {isOpen && (
-        <div className="absolute right-0 top-full mt-2 w-72 max-w-[calc(100vw-1rem)] bg-card border border-border rounded-xl shadow-2xl overflow-hidden z-50">
+        <div id="profile-dropdown-menu" role="menu" className="absolute right-0 top-full mt-2 w-72 max-w-[calc(100vw-1rem)] bg-card border border-border rounded-xl shadow-2xl overflow-hidden z-50">
           {/* Header with avatar and name */}
           <div className="p-4 bg-secondary border-b border-border">
             <div className="flex items-center gap-3">

--- a/web/src/components/ui/Input.tsx
+++ b/web/src/components/ui/Input.tsx
@@ -1,4 +1,4 @@
-import { type InputHTMLAttributes, type ReactNode, type Ref } from 'react'
+import { type InputHTMLAttributes, type ReactNode, type Ref, useId } from 'react'
 import { cn } from '../../lib/cn'
 
 type InputSize = 'sm' | 'md' | 'lg'
@@ -32,6 +32,8 @@ interface InputProps extends InputHTMLAttributes<HTMLInputElement> {
   trailingIcon?: ReactNode
   /** When true, applies red border and focus ring to indicate a validation error */
   error?: boolean
+  /** Error message displayed below the input and linked via aria-describedby */
+  errorMessage?: string
   ref?: Ref<HTMLInputElement>
 }
 
@@ -40,49 +42,62 @@ export function Input({
   leadingIcon,
   trailingIcon,
   error,
+  errorMessage,
   disabled,
   className,
   ref,
   ...props
 }: InputProps) {
+  const generatedId = useId()
+  const errorId = errorMessage ? `${generatedId}-error` : undefined
+
   return (
-    <div className="relative">
-      {leadingIcon && (
-        <span
-          aria-hidden="true"
-          className="pointer-events-none absolute inset-y-0 left-0 flex items-center pl-2.5 text-muted-foreground"
-        >
-          {leadingIcon}
-        </span>
-      )}
-
-      <input
-        ref={ref}
-        disabled={disabled}
-        aria-invalid={error ? true : undefined}
-        className={cn(
-          'w-full rounded-lg border bg-secondary text-foreground transition-colors',
-          'placeholder:text-muted-foreground',
-          'focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-background',
-          'disabled:opacity-50 disabled:cursor-not-allowed',
-          error
-            ? 'border-red-500 focus:ring-red-500'
-            : 'border-border focus:ring-ring',
-          SIZE_MAP[inputSize],
-          leadingIcon && ICON_LEFT_PADDING[inputSize],
-          trailingIcon && ICON_RIGHT_PADDING[inputSize],
-          className,
+    <div>
+      <div className="relative">
+        {leadingIcon && (
+          <span
+            aria-hidden="true"
+            className="pointer-events-none absolute inset-y-0 left-0 flex items-center pl-2.5 text-muted-foreground"
+          >
+            {leadingIcon}
+          </span>
         )}
-        {...props}
-      />
 
-      {trailingIcon && (
-        <span
-          aria-hidden="true"
-          className="pointer-events-none absolute inset-y-0 right-0 flex items-center pr-2.5 text-muted-foreground"
-        >
-          {trailingIcon}
-        </span>
+        <input
+          ref={ref}
+          disabled={disabled}
+          aria-invalid={error ? true : undefined}
+          aria-describedby={errorId}
+          className={cn(
+            'w-full rounded-lg border bg-secondary text-foreground transition-colors',
+            'placeholder:text-muted-foreground',
+            'focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-background',
+            'disabled:opacity-50 disabled:cursor-not-allowed',
+            error
+              ? 'border-red-500 focus:ring-red-500'
+              : 'border-border focus:ring-ring',
+            SIZE_MAP[inputSize],
+            leadingIcon && ICON_LEFT_PADDING[inputSize],
+            trailingIcon && ICON_RIGHT_PADDING[inputSize],
+            className,
+          )}
+          {...props}
+        />
+
+        {trailingIcon && (
+          <span
+            aria-hidden="true"
+            className="pointer-events-none absolute inset-y-0 right-0 flex items-center pr-2.5 text-muted-foreground"
+          >
+            {trailingIcon}
+          </span>
+        )}
+      </div>
+
+      {errorMessage && (
+        <p id={errorId} className="mt-1 text-xs text-red-500" role="alert">
+          {errorMessage}
+        </p>
       )}
     </div>
   )

--- a/web/src/components/ui/Pagination.tsx
+++ b/web/src/components/ui/Pagination.tsx
@@ -141,8 +141,9 @@ export function Pagination({
         {/* Items per page selector */}
         {showItemsPerPage && onItemsPerPageChange && (
           <div className="flex items-center gap-2">
-            <span className="text-muted-foreground">{t('pagination.perPage')}</span>
+            <label htmlFor="pagination-per-page" className="text-muted-foreground">{t('pagination.perPage')}</label>
             <select
+              id="pagination-per-page"
               value={itemsPerPage}
               onChange={(e) => onItemsPerPageChange(Number(e.target.value))}
               className="px-2 py-1 rounded bg-secondary border border-border text-foreground text-sm"

--- a/web/src/config/cards/cronjob-status.ts
+++ b/web/src/config/cards/cronjob-status.ts
@@ -100,8 +100,9 @@ export const cronJobStatusConfig: UnifiedCardConfig = {
     showSearch: true,
   },
 
-  // Metadata
-  isDemoData: true,
+  // Metadata — isDemoData is NOT hardcoded; the unified card system derives it
+  // from the data source hook at runtime. Hardcoding it caused the Demo badge to
+  // always appear even when live cluster data was fetched (#7791).
   isLive: true,
 }
 

--- a/web/src/lib/modals/BaseModal.tsx
+++ b/web/src/lib/modals/BaseModal.tsx
@@ -38,7 +38,7 @@
  * ```
  */
 
-import { ReactNode, useRef } from 'react'
+import { ReactNode, createContext, useContext, useId, useRef } from 'react'
 import { createPortal } from 'react-dom'
 import { X, ChevronLeft } from 'lucide-react'
 import { useModalNavigation, useModalFocusTrap } from './useModalNavigation'
@@ -71,6 +71,9 @@ const HEIGHT_CLASSES: Record<ModalSize, string> = {
   full: 'min-h-[95vh] max-h-[calc(100vh-2rem)]',
 }
 
+// React Context so ModalHeader can receive the generated title ID
+const ModalTitleIdContext = createContext<string | undefined>(undefined)
+
 // ============================================================================
 // BaseModal Component
 // ============================================================================
@@ -87,6 +90,7 @@ export function BaseModal({
 }: BaseModalProps) {
   const backdropRef = useRef<HTMLDivElement>(null)
   const modalRef = useRef<HTMLDivElement>(null)
+  const titleId = useId()
 
   // Set up keyboard navigation (ESC and Space/Backspace to close)
   useModalNavigation({
@@ -125,10 +129,13 @@ export function BaseModal({
           ref={modalRef}
           role="dialog"
           aria-modal="true"
+          aria-labelledby={titleId}
           className={`glass w-full ${SIZE_CLASSES[size]} ${HEIGHT_CLASSES[size]} rounded-xl flex flex-col overflow-hidden ${className}`}
           onClick={(e) => e.stopPropagation()}
         >
-          {children}
+          <ModalTitleIdContext.Provider value={titleId}>
+            {children}
+          </ModalTitleIdContext.Provider>
         </div>
       </div>
     </div>,
@@ -151,6 +158,8 @@ function ModalHeader({
   extra,
   children,
 }: ModalHeaderProps) {
+  const titleId = useContext(ModalTitleIdContext)
+
   return (
     <div className="flex flex-col border-b border-border">
       {/* Main header row */}
@@ -177,7 +186,7 @@ function ModalHeader({
 
           {/* Title and description */}
           <div className="min-w-0 flex-1">
-            <h2 className="text-lg font-semibold text-foreground truncate">
+            <h2 id={titleId} className="text-lg font-semibold text-foreground truncate">
               {title}
             </h2>
             {description && (


### PR DESCRIPTION
## Summary

- **ARIA accessibility** (#7809-#7813): BaseModal gets `aria-labelledby`, UserProfileDropdown trigger gets `aria-expanded`/`aria-haspopup`/`aria-controls`, CreateDashboardModal form inputs get `htmlFor`/`id` label associations, Input.tsx gets `aria-describedby` for error messages, Pagination "Per page" label gets linked to its select element
- **Netlify function hardening** (#7804-#7806): AbortController timeouts on GitHub API and YouTube CDN fetches, JSON.parse wrapped in try/catch for affiliate-clicks service account decoding
- **CronJob card** (#7791): Removed hardcoded `isDemoData: true` from config that caused Demo badge to always show even when live cluster data was fetched
- **Copilot review follow-ups** (#7792, #7772): Extracted prefetch timeout to named constant + cleared dangling timer in App.tsx, removed unused `collectConsoleErrors` import in find-and-search E2E test

**Note on #7777**: All four Copilot comments (DEV_MODE=true redirect, `/health` vs `/healthz` readiness check) were already addressed in the current workflow file — both desktop and mobile jobs already use `/healthz` with `"status":"ok"` validation. No changes needed.

## Test plan

- [ ] `npm run build` passes (verified locally)
- [ ] BaseModal title is accessible via screen reader (aria-labelledby points to h2)
- [ ] UserProfileDropdown announces expanded state to assistive technology
- [ ] CronJob card no longer shows Demo badge when live data is available
- [ ] bonus-points and youtube-thumbnail functions time out instead of hanging
- [ ] affiliate-clicks function returns empty object on malformed service account JSON

Fixes #7804, #7805, #7806, #7809, #7810, #7811, #7812, #7813, #7791, #7792, #7772, #7777

Generated with [Claude Code](https://claude.ai/claude-code)