### PR TITLE
fix: frontend hook safety — WebSocket dedup, timer cleanup, abort handling

### DIFF
--- a/web/src/hooks/useActiveUsers.ts
+++ b/web/src/hooks/useActiveUsers.ts
@@ -53,6 +53,8 @@ const stateSubscribers = new Set<(state: { loading?: boolean; error?: boolean })
 let presenceWs: WebSocket | null = null
 let presenceStarted = false
 let presencePingInterval: ReturnType<typeof setInterval> | null = null
+/** Pending reconnect timer for the presence WebSocket — prevents duplicate connections (#7784) */
+let presenceReconnectTimer: ReturnType<typeof setTimeout> | null = null
 
 // Netlify heartbeat state (serverless mode)
 let heartbeatStarted = false
@@ -76,6 +78,7 @@ export function __resetForTest(): void {
   subscribers.clear()
   stateSubscribers.clear()
   if (presencePingInterval) { clearInterval(presencePingInterval); presencePingInterval = null }
+  if (presenceReconnectTimer) { clearTimeout(presenceReconnectTimer); presenceReconnectTimer = null }
   if (presenceWs) { presenceWs.onclose = null; presenceWs.close(); presenceWs = null }
   presenceStarted = false
   if (heartbeatTimeoutId) { clearTimeout(heartbeatTimeoutId); heartbeatTimeoutId = null }
@@ -140,6 +143,10 @@ function stopHeartbeat() {
 
 // Tear down presence WebSocket connection
 function stopPresenceConnection() {
+  if (presenceReconnectTimer) {
+    clearTimeout(presenceReconnectTimer)
+    presenceReconnectTimer = null
+  }
   if (presencePingInterval) {
     clearInterval(presencePingInterval)
     presencePingInterval = null
@@ -199,8 +206,11 @@ function startPresenceConnection() {
 
     presenceWs.onclose = () => {
       if (presencePingInterval) clearInterval(presencePingInterval)
+      // Clear any pending reconnect before scheduling a new one (#7784)
+      if (presenceReconnectTimer) clearTimeout(presenceReconnectTimer)
       // Reconnect after delay
-      setTimeout(() => {
+      presenceReconnectTimer = setTimeout(() => {
+        presenceReconnectTimer = null
         if (presenceStarted && localStorage.getItem(STORAGE_KEY_TOKEN)) connect()
       }, WS_RECONNECT_DELAY)
     }

--- a/web/src/hooks/useCardRecommendations.ts
+++ b/web/src/hooks/useCardRecommendations.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback, useRef } from 'react'
+import { useState, useEffect, useCallback } from 'react'
 import { usePodIssues, useDeploymentIssues, useWarningEvents, useGPUNodes, useClusters, useSecurityIssues } from './useMCP'
 import { useAIMode } from './useAIMode'
 import { RECOMMENDATION_INTERVAL_MS } from '../lib/constants/network'
@@ -164,14 +164,11 @@ export function useCardRecommendations(currentCardTypes: string[]) {
     securityIssues,
   ])
 
-  // Re-analyze when data changes — use ref to prevent loops from
-  // hook data returning new array references on every render
-  const recInitRef = useRef(false)
+  // Re-analyze immediately when dependencies change.
+  // useCallback ensures analyzeAndRecommend has a stable identity unless
+  // its captured data actually changes, so this won't loop (#7786).
   useEffect(() => {
-    if (!recInitRef.current) {
-      recInitRef.current = true
-      analyzeAndRecommend()
-    }
+    analyzeAndRecommend()
   }, [analyzeAndRecommend])
 
   // Re-analyze periodically

--- a/web/src/hooks/useClusterProgress.ts
+++ b/web/src/hooks/useClusterProgress.ts
@@ -30,11 +30,15 @@ export interface ClusterProgress {
 export function useClusterProgress() {
   const [progress, setProgress] = useState<ClusterProgress | null>(null)
   const wsRef = useRef<WebSocket | null>(null)
+  /** Track reconnect timer in a ref so cleanup can clear timers scheduled by onclose (#7785) */
+  const reconnectTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
 
   useEffect(() => {
-    let reconnectTimer: ReturnType<typeof setTimeout>
+    let unmounted = false
 
     function connect() {
+      if (unmounted) return
+
       try {
         const ws = new WebSocket(LOCAL_AGENT_WS_URL)
         wsRef.current = ws
@@ -52,7 +56,8 @@ export function useClusterProgress() {
 
         ws.onclose = () => {
           wsRef.current = null
-          reconnectTimer = setTimeout(connect, WS_RECONNECT_DELAY_MS)
+          if (unmounted) return
+          reconnectTimerRef.current = setTimeout(connect, WS_RECONNECT_DELAY_MS)
         }
 
         ws.onerror = () => {
@@ -60,14 +65,19 @@ export function useClusterProgress() {
         }
       } catch {
         // Agent not available, retry later
-        reconnectTimer = setTimeout(connect, WS_RECONNECT_DELAY_MS)
+        if (unmounted) return
+        reconnectTimerRef.current = setTimeout(connect, WS_RECONNECT_DELAY_MS)
       }
     }
 
     connect()
 
     return () => {
-      clearTimeout(reconnectTimer)
+      unmounted = true
+      if (reconnectTimerRef.current) {
+        clearTimeout(reconnectTimerRef.current)
+        reconnectTimerRef.current = null
+      }
       if (wsRef.current) {
         wsRef.current.close()
         wsRef.current = null

--- a/web/src/hooks/usePrometheusMetrics.ts
+++ b/web/src/hooks/usePrometheusMetrics.ts
@@ -151,7 +151,11 @@ export function usePrometheusMetrics(
       setMetrics(null)
       setError(e instanceof Error ? e.message : 'Unknown error')
     } finally {
-      if (!controller.signal.aborted) {
+      // Reset loading if this controller is still the active one.
+      // If a newer fetchMetrics call superseded us, abortRef.current
+      // points to the new controller — skip to avoid clearing its loading state.
+      // If cleanup aborted us (unmount), still clear loading to avoid stuck state (#7787).
+      if (abortRef.current === controller || controller.signal.aborted) {
         setLoading(false)
       }
     }

--- a/web/src/hooks/useSelfUpgrade.ts
+++ b/web/src/hooks/useSelfUpgrade.ts
@@ -43,6 +43,9 @@ export function useSelfUpgrade() {
   const [restartElapsed, setRestartElapsed] = useState(0)
 
   const pollAbortRef = useRef<AbortController | null>(null)
+  /** Track active polling interval IDs to prevent duplicate loops (#7789) */
+  const pollIntervalRef = useRef<ReturnType<typeof setInterval> | null>(null)
+  const tickIntervalRef = useRef<ReturnType<typeof setInterval> | null>(null)
 
   /** Fetch self-upgrade availability from the backend */
   const checkStatus = useCallback(async () => {
@@ -65,8 +68,16 @@ export function useSelfUpgrade() {
     }
   }, [])
 
+  /** Elapsed-seconds tick interval (ms) */
+  const ELAPSED_TICK_MS = 1_000
+
   /** Poll /health until the backend responds, then reload the page */
   const pollForRestart = () => {
+    // Clear any existing polling loops before starting new ones (#7789)
+    if (pollIntervalRef.current) { clearInterval(pollIntervalRef.current); pollIntervalRef.current = null }
+    if (tickIntervalRef.current) { clearInterval(tickIntervalRef.current); tickIntervalRef.current = null }
+    pollAbortRef.current?.abort()
+
     setIsRestarting(true)
     setRestartComplete(false)
     setRestartError(null)
@@ -77,47 +88,50 @@ export function useSelfUpgrade() {
 
     const startTime = Date.now()
 
-    const tick = setInterval(() => {
-      setRestartElapsed(Math.floor((Date.now() - startTime) / 1000))
-    }, 1000)
+    tickIntervalRef.current = setInterval(() => {
+      setRestartElapsed(Math.floor((Date.now() - startTime) / ELAPSED_TICK_MS))
+    }, ELAPSED_TICK_MS)
 
-    const poll = setInterval(async () => {
+    // Use a non-async wrapper to prevent unhandled promise rejections from setInterval (#7788)
+    pollIntervalRef.current = setInterval(() => {
       if (controller.signal.aborted) {
-        clearInterval(poll)
-        clearInterval(tick)
+        if (pollIntervalRef.current) { clearInterval(pollIntervalRef.current); pollIntervalRef.current = null }
+        if (tickIntervalRef.current) { clearInterval(tickIntervalRef.current); tickIntervalRef.current = null }
         return
       }
 
       // Timed out waiting
       if (Date.now() - startTime > RESTART_POLL_MAX_MS) {
-        clearInterval(poll)
-        clearInterval(tick)
+        if (pollIntervalRef.current) { clearInterval(pollIntervalRef.current); pollIntervalRef.current = null }
+        if (tickIntervalRef.current) { clearInterval(tickIntervalRef.current); tickIntervalRef.current = null }
         setIsRestarting(false)
         setRestartError('The console did not come back within the expected time. Try refreshing manually.')
         return
       }
 
-      try {
-        const resp = await fetch('/health', {
-          signal: AbortSignal.timeout(RESTART_HEALTH_TIMEOUT_MS) })
-        if (resp.ok) {
-          clearInterval(poll)
-          clearInterval(tick)
-          setIsRestarting(false)
-          setRestartComplete(true)
-          // Auto-reload after a brief pause so the user sees the success state
-          setTimeout(() => window.location.reload(), RELOAD_DELAY_MS)
+      void (async () => {
+        try {
+          const resp = await fetch('/health', {
+            signal: AbortSignal.timeout(RESTART_HEALTH_TIMEOUT_MS) })
+          if (resp.ok) {
+            if (pollIntervalRef.current) { clearInterval(pollIntervalRef.current); pollIntervalRef.current = null }
+            if (tickIntervalRef.current) { clearInterval(tickIntervalRef.current); tickIntervalRef.current = null }
+            setIsRestarting(false)
+            setRestartComplete(true)
+            // Auto-reload after a brief pause so the user sees the success state
+            setTimeout(() => window.location.reload(), RELOAD_DELAY_MS)
+          }
+        } catch {
+          // Expected — pod is still restarting
         }
-      } catch {
-        // Expected — pod is still restarting
-      }
+      })()
     }, RESTART_POLL_INTERVAL_MS)
 
     // Cleanup on unmount
     return () => {
       controller.abort()
-      clearInterval(poll)
-      clearInterval(tick)
+      if (pollIntervalRef.current) { clearInterval(pollIntervalRef.current); pollIntervalRef.current = null }
+      if (tickIntervalRef.current) { clearInterval(tickIntervalRef.current); tickIntervalRef.current = null }
     }
   }
 
@@ -163,6 +177,8 @@ export function useSelfUpgrade() {
   /** Cancel restart polling (e.g. user navigates away) */
   const cancelRestartPoll = () => {
     pollAbortRef.current?.abort()
+    if (pollIntervalRef.current) { clearInterval(pollIntervalRef.current); pollIntervalRef.current = null }
+    if (tickIntervalRef.current) { clearInterval(tickIntervalRef.current); tickIntervalRef.current = null }
     setIsRestarting(false)
   }
 
@@ -175,6 +191,8 @@ export function useSelfUpgrade() {
   useEffect(() => {
     return () => {
       pollAbortRef.current?.abort()
+      if (pollIntervalRef.current) { clearInterval(pollIntervalRef.current); pollIntervalRef.current = null }
+      if (tickIntervalRef.current) { clearInterval(tickIntervalRef.current); tickIntervalRef.current = null }
     }
   }, [])
 


### PR DESCRIPTION
## Summary

- **#7784** — `presenceWs.onclose` reconnect dedup: track the reconnect timer in a module-level variable and clear it before scheduling a new one, preventing duplicate WebSocket connections
- **#7785** — `useClusterProgress` reconnect timer leak: move reconnect timer to a ref and add an `unmounted` flag so `onclose` cannot schedule reconnects after cleanup runs
- **#7786** — `useCardRecommendations` recInitRef guard: remove the ref-based guard that permanently suppressed re-analysis when dependencies changed; `useCallback` already provides identity stability
- **#7787** — `usePrometheusMetrics` loading stuck on abort: update the `finally` block to call `setLoading(false)` when the controller is aborted, preventing permanently stuck loading state
- **#7788** — `useSelfUpgrade` async setInterval: wrap the async polling body with `void (async () => { try {...} catch {...} })()` to prevent unhandled promise rejections
- **#7789** — `useSelfUpgrade` polling loop accumulation: track interval IDs in refs and clear previous intervals before creating new ones in `pollForRestart`

## Test plan

- [ ] TypeScript type check passes (`npx tsc --noEmit`)
- [ ] Production build passes (`npm run build`)
- [ ] Verify presence WebSocket reconnects only once after disconnection (no duplicate connections in Network tab)
- [ ] Verify cluster progress WebSocket cleans up properly on component unmount
- [ ] Verify card recommendations update when underlying data changes
- [ ] Verify Prometheus metrics loading state resets after abort
- [ ] Verify self-upgrade polling doesn't accumulate intervals on repeated triggers

Fixes #7784, #7785, #7786, #7787, #7788, #7789

🤖 Generated with [Claude Code](https://claude.com/claude-code)