### PR TITLE
feat: add Drasi reactive graph dashboard

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -78,6 +78,7 @@ const ClusterAdmin = safeLazy(() => import('./components/cluster-admin/ClusterAd
 const CICD = safeLazy(() => import('./components/cicd/CICD'), 'CICD')
 const Insights = safeLazy(() => import('./components/insights/Insights'), 'Insights')
 const MultiTenancy = safeLazy(() => import('./components/multi-tenancy/MultiTenancy'), 'MultiTenancy')
+const Drasi = safeLazy(() => import('./components/drasi/Drasi'), 'Drasi')
 const Marketplace = safeLazy(() => import('./components/marketplace/Marketplace'), 'Marketplace')
 const MiniDashboard = safeLazy(() => import('./components/widget/MiniDashboard'), 'MiniDashboard')
 const Welcome = safeLazy(() => import('./pages/Welcome'), 'Welcome')
@@ -326,6 +327,7 @@ const ROUTE_TITLES: Record<string, string> = {
   '/karmada-ops': 'Karmada Ops',
   '/llm-d-benchmarks': 'llm-d Benchmarks',
   '/multi-tenancy': 'Multi-Tenancy',
+  '/drasi': 'Drasi',
   '/arcade': 'Arcade',
   '/marketplace': 'Marketplace',
   '/missions': 'Missions',
@@ -564,6 +566,7 @@ function FullDashboardApp() {
           <Route path={ROUTES.CI_CD} element={<SuspenseRoute><CICD /></SuspenseRoute>} />
           <Route path={ROUTES.INSIGHTS} element={<SuspenseRoute><Insights /></SuspenseRoute>} />
           <Route path={ROUTES.MULTI_TENANCY} element={<SuspenseRoute><MultiTenancy /></SuspenseRoute>} />
+          <Route path={ROUTES.DRASI} element={<SuspenseRoute><Drasi /></SuspenseRoute>} />
           <Route path={ROUTES.MARKETPLACE} element={<SuspenseRoute><Marketplace /></SuspenseRoute>} />
           {/* Dev test routes for unified framework validation */}
           <Route path={ROUTES.TEST_UNIFIED_CARD} element={<UnifiedCardTest />} />

--- a/web/src/components/cards/cardRegistry.ts
+++ b/web/src/components/cards/cardRegistry.ts
@@ -214,6 +214,10 @@ const KagentAgentDiscovery = safeLazy(() => _kagentBundle, 'KagentAgentDiscovery
 const KagentSecurity = safeLazy(() => _kagentBundle, 'KagentSecurity')
 const KagentTopology = safeLazy(() => _kagentBundle, 'KagentTopology')
 
+// Drasi reactive pipeline cards — barrel import
+const _drasiBundle = import('./drasi').catch(() => undefined as never)
+const DrasiReactiveGraph = safeLazy(() => _drasiBundle, 'DrasiReactiveGraph')
+
 const CrossplaneManagedResources = safeLazy(() => import('./crossplane-status/CrossplaneManagedResources'), 'CrossplaneManagedResources')
 // Cloud Native Buildpacks card
 // ISO 27001 Security Audit checklist card
@@ -576,6 +580,9 @@ const RAW_CARD_COMPONENTS: Record<string, CardComponent> = {
   process_trace: ProcessTraceCard,
   security_audit: SecurityAuditCard,
 
+  // Drasi reactive pipeline cards
+  drasi_reactive_graph: DrasiReactiveGraph,
+
   // LLM-d stunning visualization cards
   llmd_flow: LLMdFlow,
   kvcache_monitor: KVCacheMonitor,
@@ -888,6 +895,8 @@ const CARD_CHUNK_PRELOADERS: Record<string, () => Promise<unknown>> = {
   prow_ci_monitor: () => import('./workload-monitor'),
   github_ci_monitor: () => import('./workload-monitor'),
   cluster_health_monitor: () => import('./workload-monitor'),
+  // Drasi — barrel import
+  drasi_reactive_graph: () => import('./drasi'),
   // LLM-d visualization — barrel import loads all 7 cards in one module graph
   // resolution instead of 7 separate requests, reducing Vite transform overhead
   llmd_flow: () => import('./llmd'),
@@ -1244,6 +1253,9 @@ export const CARD_DEFAULT_WIDTHS: Record<string, number> = {
   kagent_agent_discovery: 4,
   kagent_security: 4,
   kagent_topology: 8,
+
+  // Drasi reactive pipeline cards
+  drasi_reactive_graph: 12,  // Full-width reactive graph
 
   // LLM-d stunning visualization cards
   llmd_flow: 8,           // Hero animated flow diagram

--- a/web/src/components/cards/drasi/DrasiReactiveGraph.tsx
+++ b/web/src/components/cards/drasi/DrasiReactiveGraph.tsx
@@ -1,0 +1,448 @@
+/**
+ * Drasi Reactive Graph Card
+ *
+ * Visualizes the Drasi reactive data pipeline:
+ * Sources (HTTP, Postgres) → Continuous Queries (Cypher) → Reactions (SSE)
+ * with animated data flow connections and a live results table.
+ *
+ * Uses live Drasi API data when available, demo data when in demo mode.
+ */
+import { useState, useEffect, useMemo, useCallback } from 'react'
+import { motion, AnimatePresence } from 'framer-motion'
+import {
+  Database, Globe, Search, Radio, ArrowRight,
+  Activity, TrendingDown, TrendingUp,
+} from 'lucide-react'
+import { useCardDemoState, useReportCardDataState } from '../CardDataContext'
+import { useCardExpanded } from '../CardWrapper'
+import { useDrasiResources } from '../../../hooks/useDrasiResources'
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/** How often to refresh animated data flow in ms */
+const FLOW_ANIMATION_INTERVAL_MS = 3000
+/** Maximum rows shown in the live results table */
+const MAX_LIVE_RESULT_ROWS = 7
+/** Number of animated flow dots per connection */
+const FLOW_DOT_COUNT = 3
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+type SourceKind = 'HTTP' | 'POSTGRES' | 'COSMOSDB' | 'GREMLIN' | 'SQL'
+type ReactionKind = 'SSE' | 'SIGNALR' | 'WEBHOOK' | 'KAFKA'
+
+interface DrasiSource {
+  id: string
+  name: string
+  kind: SourceKind
+  status: 'ready' | 'error' | 'pending'
+}
+
+interface DrasiQuery {
+  id: string
+  name: string
+  language: string // e.g. "CYPHER QUERY"
+  status: 'ready' | 'error' | 'pending'
+  /** IDs of sources this query reads from */
+  sourceIds: string[]
+}
+
+interface DrasiReaction {
+  id: string
+  name: string
+  kind: ReactionKind
+  status: 'ready' | 'error' | 'pending'
+  /** IDs of queries this reaction subscribes to */
+  queryIds: string[]
+}
+
+interface LiveResultRow {
+  changePercent: number
+  name: string
+  previousClose: number
+  price: number
+  symbol: string
+}
+
+interface DrasiPipelineData {
+  sources: DrasiSource[]
+  queries: DrasiQuery[]
+  reactions: DrasiReaction[]
+  liveResults: LiveResultRow[]
+  selectedQueryId: string | null
+}
+
+// ---------------------------------------------------------------------------
+// Demo data
+// ---------------------------------------------------------------------------
+
+function generateDemoData(): DrasiPipelineData {
+  const wave = Math.sin(Date.now() / 5000)
+
+  const sources: DrasiSource[] = [
+    { id: 'src-price-feed', name: 'price-feed', kind: 'HTTP', status: 'ready' },
+    { id: 'src-postgres-stocks', name: 'postgres-stocks', kind: 'POSTGRES', status: 'ready' },
+    { id: 'src-postgres-broker', name: 'postgres-broker', kind: 'POSTGRES', status: 'ready' },
+  ]
+
+  const queries: DrasiQuery[] = [
+    { id: 'q-watchlist', name: 'watchlist-query', language: 'CYPHER QUERY', status: 'ready', sourceIds: ['src-price-feed', 'src-postgres-stocks'] },
+    { id: 'q-portfolio', name: 'portfolio-query', language: 'CYPHER QUERY', status: 'ready', sourceIds: ['src-postgres-stocks', 'src-postgres-broker'] },
+    { id: 'q-top-gainers', name: 'top-gainers-query', language: 'CYPHER QUERY', status: 'ready', sourceIds: ['src-postgres-broker'] },
+    { id: 'q-top-losers', name: 'top-losers-query', language: 'CYPHER QUERY', status: 'ready', sourceIds: ['src-price-feed', 'src-postgres-stocks', 'src-postgres-broker'] },
+  ]
+
+  const reactions: DrasiReaction[] = [
+    { id: 'rx-sse', name: 'sse-stream', kind: 'SSE', status: 'ready', queryIds: ['q-watchlist', 'q-portfolio', 'q-top-gainers', 'q-top-losers'] },
+  ]
+
+  const baseStocks: Omit<LiveResultRow, 'changePercent' | 'price'>[] = [
+    { name: 'Constellation Energy', previousClose: 131.46, symbol: 'CEG' },
+    { name: 'Visa Inc.', previousClose: 370.28, symbol: 'V' },
+    { name: 'Chevron', previousClose: 167.67, symbol: 'CVX' },
+    { name: 'Caterpillar', previousClose: 381.26, symbol: 'CAT' },
+    { name: 'NVIDIA Corporation', previousClose: 124.28, symbol: 'NVDA' },
+    { name: 'Intel Corporation', previousClose: 44.37, symbol: 'INTC' },
+    { name: 'Apple Inc.', previousClose: 184.36, symbol: 'AAPL' },
+  ]
+
+  const liveResults: LiveResultRow[] = baseStocks.map(stock => {
+    const changePercent = parseFloat((-4 + Math.random() * 3 + wave * 2).toFixed(2))
+    const price = parseFloat((stock.previousClose * (1 + changePercent / 100)).toFixed(2))
+    return { ...stock, changePercent, price }
+  })
+
+  // Sort by changePercent ascending (top losers)
+  liveResults.sort((a, b) => a.changePercent - b.changePercent)
+
+  return {
+    sources,
+    queries,
+    reactions,
+    liveResults,
+    selectedQueryId: 'q-top-losers',
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Sub-components
+// ---------------------------------------------------------------------------
+
+/** Status indicator dot */
+function StatusDot({ status }: { status: 'ready' | 'error' | 'pending' }) {
+  const colors: Record<string, string> = {
+    ready: 'bg-green-400',
+    error: 'bg-red-400',
+    pending: 'bg-yellow-400',
+  }
+  return (
+    <motion.div
+      className={`w-2.5 h-2.5 rounded-full ${colors[status] || colors.pending}`}
+      animate={status === 'ready' ? { scale: [1, 1.3, 1] } : {}}
+      transition={{ repeat: Infinity, duration: 2, ease: 'easeInOut' }}
+    />
+  )
+}
+
+/** Icon for source type */
+function SourceIcon({ kind }: { kind: SourceKind }) {
+  switch (kind) {
+    case 'HTTP': return <Globe className="w-4 h-4 text-cyan-400" />
+    case 'POSTGRES': return <Database className="w-4 h-4 text-blue-400" />
+    case 'COSMOSDB': return <Database className="w-4 h-4 text-purple-400" />
+    default: return <Database className="w-4 h-4 text-slate-400" />
+  }
+}
+
+/** Icon for reaction type */
+function ReactionIcon({ kind }: { kind: ReactionKind }) {
+  switch (kind) {
+    case 'SSE': return <Radio className="w-4 h-4 text-emerald-400" />
+    case 'SIGNALR': return <Activity className="w-4 h-4 text-blue-400" />
+    case 'WEBHOOK': return <ArrowRight className="w-4 h-4 text-orange-400" />
+    default: return <Radio className="w-4 h-4 text-slate-400" />
+  }
+}
+
+/** Source node card */
+function SourceNode({ source }: { source: DrasiSource }) {
+  return (
+    <motion.div
+      className="bg-slate-800/80 border border-emerald-500/30 rounded-lg p-3 min-w-[140px]"
+      whileHover={{ scale: 1.03, borderColor: 'rgba(16,185,129,0.6)' }}
+      initial={{ opacity: 0, x: -20 }}
+      animate={{ opacity: 1, x: 0 }}
+    >
+      <div className="flex items-center gap-2 mb-1">
+        <SourceIcon kind={source.kind} />
+        <span className="text-white text-sm font-medium truncate">{source.name}</span>
+        <StatusDot status={source.status} />
+      </div>
+      <span className="text-xs text-muted-foreground uppercase tracking-wider">{source.kind}</span>
+    </motion.div>
+  )
+}
+
+/** Query node card */
+function QueryNode({ query, isSelected, onClick }: { query: DrasiQuery; isSelected: boolean; onClick: () => void }) {
+  return (
+    <motion.div
+      className={`bg-slate-800/80 border rounded-lg p-3 min-w-[140px] cursor-pointer transition-colors ${
+        isSelected ? 'border-cyan-400/60 ring-1 ring-cyan-400/30' : 'border-slate-600/40'
+      }`}
+      whileHover={{ scale: 1.03 }}
+      initial={{ opacity: 0, y: 20 }}
+      animate={{ opacity: 1, y: 0 }}
+      onClick={onClick}
+    >
+      <div className="flex items-center gap-2 mb-1">
+        <Search className="w-4 h-4 text-cyan-400" />
+        <span className="text-white text-sm font-medium truncate">{query.name}</span>
+        <StatusDot status={query.status} />
+      </div>
+      <span className="text-xs text-muted-foreground uppercase tracking-wider">{query.language}</span>
+    </motion.div>
+  )
+}
+
+/** Reaction node card */
+function ReactionNode({ reaction }: { reaction: DrasiReaction }) {
+  return (
+    <motion.div
+      className="bg-slate-800/80 border border-emerald-500/30 rounded-lg p-3 min-w-[120px]"
+      whileHover={{ scale: 1.03, borderColor: 'rgba(16,185,129,0.6)' }}
+      initial={{ opacity: 0, x: 20 }}
+      animate={{ opacity: 1, x: 0 }}
+    >
+      <div className="flex items-center gap-2 mb-1">
+        <ReactionIcon kind={reaction.kind} />
+        <span className="text-white text-sm font-medium truncate">{reaction.name}</span>
+        <StatusDot status={reaction.status} />
+      </div>
+      <span className="text-xs text-muted-foreground uppercase tracking-wider">{reaction.kind}</span>
+    </motion.div>
+  )
+}
+
+/** Animated connection line between nodes */
+function FlowConnection({ direction }: { direction: 'horizontal' | 'vertical' }) {
+  const isHorizontal = direction === 'horizontal'
+  return (
+    <div className={`flex ${isHorizontal ? 'flex-row items-center' : 'flex-col items-center'} gap-0`}>
+      {Array.from({ length: FLOW_DOT_COUNT }).map((_, i) => (
+        <motion.div
+          key={i}
+          className="w-1.5 h-1.5 rounded-full bg-emerald-400"
+          animate={{
+            opacity: [0.2, 1, 0.2],
+            scale: [0.6, 1.2, 0.6],
+          }}
+          transition={{
+            repeat: Infinity,
+            duration: 1.5,
+            delay: i * 0.3,
+            ease: 'easeInOut',
+          }}
+        />
+      ))}
+      <ArrowRight className={`w-3 h-3 text-emerald-400/60 ${isHorizontal ? '' : 'rotate-90'}`} />
+    </div>
+  )
+}
+
+/** Live results table for selected query */
+function LiveResultsTable({ results }: { results: LiveResultRow[] }) {
+  const displayResults = results.slice(0, MAX_LIVE_RESULT_ROWS)
+  const totalRows = results.length
+
+  return (
+    <motion.div
+      className="bg-slate-900/90 border border-slate-600/40 rounded-lg overflow-hidden"
+      initial={{ opacity: 0, y: 10 }}
+      animate={{ opacity: 1, y: 0 }}
+    >
+      {/* Header */}
+      <div className="px-3 py-2 border-b border-slate-700/50 flex items-center justify-between">
+        <div className="flex items-center gap-2">
+          <span className="text-xs font-medium text-cyan-400 uppercase">Live Results</span>
+          <motion.div
+            className="w-1.5 h-1.5 rounded-full bg-emerald-400"
+            animate={{ opacity: [1, 0.3, 1] }}
+            transition={{ repeat: Infinity, duration: 1.5 }}
+          />
+        </div>
+        <span className="text-xs text-muted-foreground">{totalRows} rows</span>
+      </div>
+
+      {/* Table */}
+      <div className="overflow-x-auto">
+        <table className="w-full text-xs">
+          <thead>
+            <tr className="border-b border-slate-700/30">
+              <th className="text-left px-3 py-1.5 text-muted-foreground font-medium">changePercent</th>
+              <th className="text-left px-3 py-1.5 text-muted-foreground font-medium">name</th>
+              <th className="text-right px-3 py-1.5 text-muted-foreground font-medium">previousClose</th>
+              <th className="text-right px-3 py-1.5 text-muted-foreground font-medium">price</th>
+              <th className="text-right px-3 py-1.5 text-muted-foreground font-medium">symbol</th>
+            </tr>
+          </thead>
+          <tbody>
+            <AnimatePresence mode="popLayout">
+              {displayResults.map((row, i) => (
+                <motion.tr
+                  key={`${row.symbol}-${i}`}
+                  className="border-b border-slate-800/50 hover:bg-slate-800/40"
+                  initial={{ opacity: 0, x: -10 }}
+                  animate={{ opacity: 1, x: 0 }}
+                  exit={{ opacity: 0, x: 10 }}
+                  transition={{ delay: i * 0.05 }}
+                >
+                  <td className="px-3 py-1.5">
+                    <span className={`font-mono flex items-center gap-1 ${
+                      row.changePercent < 0 ? 'text-red-400' : 'text-green-400'
+                    }`}>
+                      {row.changePercent < 0
+                        ? <TrendingDown className="w-3 h-3" />
+                        : <TrendingUp className="w-3 h-3" />}
+                      {row.changePercent.toFixed(2)}
+                    </span>
+                  </td>
+                  <td className="px-3 py-1.5 text-white truncate max-w-[160px]">{row.name}</td>
+                  <td className="px-3 py-1.5 text-muted-foreground font-mono text-right">{row.previousClose.toFixed(2)}</td>
+                  <td className="px-3 py-1.5 text-white font-mono text-right">{row.price.toFixed(2)}</td>
+                  <td className="px-3 py-1.5 text-cyan-400 font-mono text-right">{row.symbol}</td>
+                </motion.tr>
+              ))}
+            </AnimatePresence>
+          </tbody>
+        </table>
+      </div>
+    </motion.div>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Main component
+// ---------------------------------------------------------------------------
+
+export function DrasiReactiveGraph() {
+  const { shouldUseDemoData: isDemoMode, showDemoBadge } = useCardDemoState({ requires: 'none' })
+  const { isExpanded } = useCardExpanded()
+
+  // Live Drasi API data
+  const { data: liveData, isLoading, error } = useDrasiResources()
+
+  // Report demo state
+  useReportCardDataState({
+    isDemoData: showDemoBadge || (!liveData && !isLoading),
+    isFailed: !!error,
+    consecutiveFailures: error ? 1 : 0,
+    hasData: true,
+  })
+
+  const [selectedQueryId, setSelectedQueryId] = useState<string | null>('q-top-losers')
+  const [demoData, setDemoData] = useState<DrasiPipelineData>(generateDemoData)
+
+  // Refresh demo data periodically for animation
+  useEffect(() => {
+    if (!isDemoMode && liveData) return
+    const interval = setInterval(() => {
+      setDemoData(generateDemoData())
+    }, FLOW_ANIMATION_INTERVAL_MS)
+    return () => clearInterval(interval)
+  }, [isDemoMode, liveData])
+
+  // Choose data source
+  const pipelineData = useMemo<DrasiPipelineData>(() => {
+    if (liveData && !isDemoMode) {
+      return {
+        sources: liveData.sources,
+        queries: liveData.queries,
+        reactions: liveData.reactions,
+        liveResults: liveData.liveResults,
+        selectedQueryId: selectedQueryId || (liveData.queries[0]?.id ?? null),
+      }
+    }
+    return { ...demoData, selectedQueryId: selectedQueryId || demoData.selectedQueryId }
+  }, [liveData, isDemoMode, demoData, selectedQueryId])
+
+  const { sources, queries, reactions, liveResults } = pipelineData
+
+  const selectedQuery = queries.find(q => q.id === selectedQueryId)
+
+  const handleQueryClick = useCallback((queryId: string) => {
+    setSelectedQueryId(prev => prev === queryId ? null : queryId)
+  }, [])
+
+  return (
+    <div className={`h-full flex flex-col gap-3 p-4 ${isExpanded ? 'max-w-6xl mx-auto' : ''}`}>
+      {/* Pipeline graph */}
+      <div className="flex-1 min-h-0">
+        <div className="flex items-stretch gap-3 h-full">
+          {/* Sources column */}
+          <div className="flex flex-col gap-3 justify-center min-w-[150px]">
+            <div className="text-xs font-medium text-muted-foreground uppercase tracking-wider mb-1">Sources</div>
+            {sources.map(source => (
+              <SourceNode key={source.id} source={source} />
+            ))}
+          </div>
+
+          {/* Flow arrows: sources → queries */}
+          <div className="flex flex-col justify-center gap-3">
+            {sources.map(source => (
+              <FlowConnection key={`flow-s-${source.id}`} direction="horizontal" />
+            ))}
+          </div>
+
+          {/* Queries column */}
+          <div className="flex flex-col gap-3 justify-center min-w-[150px]">
+            <div className="text-xs font-medium text-muted-foreground uppercase tracking-wider mb-1">Continuous Queries</div>
+            {queries.map(query => (
+              <QueryNode
+                key={query.id}
+                query={query}
+                isSelected={query.id === selectedQueryId}
+                onClick={() => handleQueryClick(query.id)}
+              />
+            ))}
+          </div>
+
+          {/* Flow arrows: queries → reactions */}
+          <div className="flex flex-col justify-center gap-3">
+            {reactions.map(reaction => (
+              <FlowConnection key={`flow-r-${reaction.id}`} direction="horizontal" />
+            ))}
+          </div>
+
+          {/* Reactions column */}
+          <div className="flex flex-col gap-3 justify-center min-w-[120px]">
+            <div className="text-xs font-medium text-muted-foreground uppercase tracking-wider mb-1">Reactions</div>
+            {reactions.map(reaction => (
+              <ReactionNode key={reaction.id} reaction={reaction} />
+            ))}
+          </div>
+        </div>
+      </div>
+
+      {/* Live results table (shown when a query is selected) */}
+      {selectedQuery && liveResults.length > 0 && (
+        <div className="flex-shrink-0">
+          <LiveResultsTable
+            results={liveResults}
+          />
+        </div>
+      )}
+
+      {/* Empty state when no query selected */}
+      {!selectedQuery && (
+        <div className="flex-shrink-0 text-center py-4 text-sm text-muted-foreground">
+          Click a query node to view live results
+        </div>
+      )}
+    </div>
+  )
+}

--- a/web/src/components/cards/drasi/index.ts
+++ b/web/src/components/cards/drasi/index.ts
@@ -1,0 +1,7 @@
+/**
+ * Drasi Dashboard Cards
+ *
+ * Visualizations for Drasi reactive data pipelines.
+ */
+
+export { DrasiReactiveGraph } from './DrasiReactiveGraph'

--- a/web/src/components/dashboard/shared/cardCatalog.ts
+++ b/web/src/components/dashboard/shared/cardCatalog.ts
@@ -331,6 +331,9 @@ export const CARD_CATALOG = {
   'Streaming & Messaging': [
     { type: 'strimzi_status', title: 'Strimzi', description: 'Strimzi Kafka cluster health, topic status, and consumer group lag', visualization: 'status' },
   ],
+  'Drasi': [
+    { type: 'drasi_reactive_graph', title: 'Drasi Reactive Graph', description: 'Reactive data pipeline — sources, continuous queries, reactions, and live results with animated flow', visualization: 'status' },
+  ],
 } as const
 
 // ---------------------------------------------------------------------------

--- a/web/src/components/drasi/Drasi.tsx
+++ b/web/src/components/drasi/Drasi.tsx
@@ -1,0 +1,61 @@
+/**
+ * Drasi Dashboard Page
+ *
+ * Reactive data pipelines — visualize sources, continuous queries, and reactions.
+ */
+import { DashboardPage } from '../../lib/dashboards/DashboardPage'
+import { getDefaultCards } from '../../config/dashboards'
+import { RotatingTip } from '../ui/RotatingTip'
+import { StatBlockValue } from '../ui/StatsOverview'
+import { useDrasiResources } from '../../hooks/useDrasiResources'
+
+const DRASI_CARDS_KEY = 'kubestellar-drasi-cards'
+
+const DEFAULT_DRASI_CARDS = getDefaultCards('drasi')
+
+export function Drasi() {
+  const { data, isLoading, error } = useDrasiResources()
+
+  const hasRealData = !!data && (data.sources.length > 0 || data.queries.length > 0)
+  const isDemoData = !hasRealData && !isLoading
+
+  const getStatValue = (blockId: string): StatBlockValue => {
+    switch (blockId) {
+      case 'sources':
+        return { value: data?.sources.length ?? 0, sublabel: 'sources', isClickable: false, isDemo: isDemoData }
+      case 'queries':
+        return { value: data?.queries.length ?? 0, sublabel: 'continuous queries', isClickable: false, isDemo: isDemoData }
+      case 'reactions':
+        return { value: data?.reactions.length ?? 0, sublabel: 'reactions', isClickable: false, isDemo: isDemoData }
+      default:
+        return { value: '-' }
+    }
+  }
+
+  return (
+    <DashboardPage
+      title="Drasi"
+      subtitle="Reactive data pipelines and continuous queries"
+      icon="GitBranch"
+      rightExtra={<RotatingTip page="drasi" />}
+      storageKey={DRASI_CARDS_KEY}
+      defaultCards={DEFAULT_DRASI_CARDS}
+      statsType="drasi"
+      getStatValue={getStatValue}
+      isLoading={isLoading}
+      hasData={hasRealData}
+      isDemoData={isDemoData}
+      emptyState={{
+        title: 'No Drasi Pipelines',
+        description: 'Connect to a Drasi instance to visualize reactive data pipelines. Set VITE_DRASI_API_URL to your Drasi management API endpoint.',
+      }}
+    >
+      {error && (
+        <div className="mb-4 p-4 rounded-lg bg-red-500/10 border border-red-500/20 text-red-400">
+          <div className="font-medium">Error loading Drasi resources</div>
+          <div className="text-sm text-muted-foreground">{error}</div>
+        </div>
+      )}
+    </DashboardPage>
+  )
+}

--- a/web/src/components/layout/Sidebar.tsx
+++ b/web/src/components/layout/Sidebar.tsx
@@ -44,7 +44,7 @@ const HREF_TO_DASHBOARD_ID: Record<string, string> = {
   '/logs': 'logs', '/data-compliance': 'data-compliance', '/arcade': 'arcade',
   '/deploy': 'deploy', '/ai-agents': 'ai-agents',
   '/llm-d-benchmarks': 'llm-d-benchmarks', '/cluster-admin': 'cluster-admin',
-  '/insights': 'insights' }
+  '/insights': 'insights', '/drasi': 'drasi' }
 
 /** Prefix for custom dashboard routes */
 const CUSTOM_DASHBOARD_PREFIX = '/custom-dashboard/'

--- a/web/src/components/layout/SidebarCustomizer.tsx
+++ b/web/src/components/layout/SidebarCustomizer.tsx
@@ -140,6 +140,7 @@ const KNOWN_ROUTES: KnownRoute[] = [
   { href: '/karmada-ops', name: 'Karmada Ops', description: 'Multi-cluster orchestration, AI inference, and data platform operations', icon: 'Globe', category: 'Core Dashboards' },
   { href: '/cluster-admin', name: 'Cluster Admin', description: 'Multi-cluster operations, control plane health, node debugging, and infrastructure management', icon: 'ShieldAlert', category: 'Core Dashboards' },
   { href: '/multi-tenancy', name: 'Multi-Tenancy', description: 'Tenant isolation with OVN-Kubernetes, KubeFlex, K3s, and KubeVirt', icon: 'Users', category: 'Core Dashboards' },
+  { href: '/drasi', name: 'Drasi', description: 'Reactive data pipelines — sources, continuous queries, reactions, and live results', icon: 'GitBranch', category: 'Core Dashboards' },
   // Resource Pages
   { href: '/namespaces', name: 'Namespaces', description: 'Namespace management and resource allocation', icon: 'FolderTree', category: 'Resources' },
   { href: '/nodes', name: 'Nodes', description: 'Cluster node health and resource usage', icon: 'HardDrive', category: 'Resources' },

--- a/web/src/components/ui/StatsBlockDefinitions.ts
+++ b/web/src/components/ui/StatsBlockDefinitions.ts
@@ -56,6 +56,7 @@ export type DashboardStatsType =
   | 'multi-tenancy'
   | 'ci-cd'
   | 'karmada-ops'
+  | 'drasi'
 
 /**
  * Default stat blocks for the Clusters dashboard
@@ -331,6 +332,15 @@ export const MULTI_TENANCY_STAT_BLOCKS: StatBlockConfig[] = [
 ]
 
 /**
+ * Default stat blocks for the Drasi dashboard
+ */
+export const DRASI_STAT_BLOCKS: StatBlockConfig[] = [
+  { id: 'sources', name: 'Sources', icon: 'Database', visible: true, color: 'blue' },
+  { id: 'queries', name: 'Queries', icon: 'Search', visible: true, color: 'cyan' },
+  { id: 'reactions', name: 'Reactions', icon: 'Radio', visible: true, color: 'green' },
+]
+
+/**
  * Get all stat blocks across all dashboard types
  */
 export const ALL_STAT_BLOCKS: StatBlockConfig[] = (() => {
@@ -354,6 +364,7 @@ export const ALL_STAT_BLOCKS: StatBlockConfig[] = (() => {
     ...KAGENTI_STAT_BLOCKS,
     ...CLUSTER_ADMIN_STAT_BLOCKS,
     ...MULTI_TENANCY_STAT_BLOCKS,
+    ...DRASI_STAT_BLOCKS,
   ]
 
   // Deduplicate by ID
@@ -435,6 +446,8 @@ export function getDefaultStatBlocks(dashboardType: DashboardStatsType): StatBlo
       return MULTI_TENANCY_STAT_BLOCKS
     case 'ci-cd':
       return GITOPS_STAT_BLOCKS
+    case 'drasi':
+      return DRASI_STAT_BLOCKS
     default:
       return []
   }

--- a/web/src/config/cards/drasi-reactive-graph.ts
+++ b/web/src/config/cards/drasi-reactive-graph.ts
@@ -1,0 +1,22 @@
+/**
+ * Drasi Reactive Graph Card Configuration
+ */
+import type { UnifiedCardConfig } from '../../lib/unified/types'
+
+export const drasiReactiveGraphConfig: UnifiedCardConfig = {
+  type: 'drasi_reactive_graph',
+  title: 'Drasi Reactive Graph',
+  category: 'drasi',
+  description: 'Reactive data pipeline visualization — sources, continuous queries, reactions, and live results',
+  icon: 'GitBranch',
+  iconColor: 'text-emerald-400',
+  defaultWidth: 12,
+  defaultHeight: 5,
+  dataSource: { type: 'hook', hook: 'useDrasiResources' },
+  content: { type: 'custom' },
+  emptyState: { icon: 'GitBranch', title: 'No Drasi Pipelines', message: 'No Drasi sources, queries, or reactions found', variant: 'info' },
+  loadingState: { type: 'custom' },
+  isDemoData: false,
+  isLive: true,
+}
+export default drasiReactiveGraphConfig

--- a/web/src/config/cards/index.ts
+++ b/web/src/config/cards/index.ts
@@ -177,6 +177,7 @@ import { fleetComplianceHeatmapConfig } from './fleet-compliance-heatmap'
 import { complianceDriftConfig } from './compliance-drift'
 import { crossClusterPolicyComparisonConfig } from './cross-cluster-policy-comparison'
 import { recommendedPoliciesConfig } from './recommended-policies'
+import { drasiReactiveGraphConfig } from './drasi-reactive-graph'
 
 export const CARD_CONFIGS: CardConfigRegistry = {
   active_alerts: activeAlertsConfig,
@@ -344,6 +345,8 @@ export const CARD_CONFIGS: CardConfigRegistry = {
   compliance_drift: complianceDriftConfig,
   cross_cluster_policy_comparison: crossClusterPolicyComparisonConfig,
   recommended_policies: recommendedPoliciesConfig,
+  // Drasi cards
+  drasi_reactive_graph: drasiReactiveGraphConfig,
 }
 
 /**

--- a/web/src/config/dashboards/drasi.ts
+++ b/web/src/config/dashboards/drasi.ts
@@ -1,0 +1,25 @@
+/**
+ * Drasi Dashboard Configuration
+ *
+ * Reactive data pipelines — sources, continuous queries, and reactions.
+ */
+import type { UnifiedDashboardConfig } from '../../lib/unified/types'
+
+export const drasiDashboardConfig: UnifiedDashboardConfig = {
+  id: 'drasi',
+  name: 'Drasi',
+  subtitle: 'Reactive data pipelines and continuous queries',
+  route: '/drasi',
+  cards: [
+    { id: 'drasi-reactive-graph-1', cardType: 'drasi_reactive_graph', title: 'Drasi Reactive Graph', position: { w: 12, h: 5 } },
+  ],
+  features: {
+    dragDrop: true,
+    addCard: true,
+    autoRefresh: true,
+    autoRefreshInterval: 30000,
+  },
+  storageKey: 'drasi-dashboard-cards',
+}
+
+export default drasiDashboardConfig

--- a/web/src/config/dashboards/index.ts
+++ b/web/src/config/dashboards/index.ts
@@ -42,6 +42,7 @@ import { llmdBenchmarksDashboardConfig } from './llmd-benchmarks'
 import { clusterAdminDashboardConfig } from './cluster-admin'
 import { insightsDashboardConfig } from './insights'
 import { multiTenancyDashboardConfig } from './multi-tenancy'
+import { drasiDashboardConfig } from './drasi'
 
 /**
  * Registry of all unified dashboard configurations
@@ -78,6 +79,7 @@ export const DASHBOARD_CONFIGS: DashboardConfigRegistry = {
   'cluster-admin': clusterAdminDashboardConfig,
   insights: insightsDashboardConfig,
   'multi-tenancy': multiTenancyDashboardConfig,
+  drasi: drasiDashboardConfig,
 }
 
 /**
@@ -184,4 +186,5 @@ export {
   clusterAdminDashboardConfig,
   insightsDashboardConfig,
   multiTenancyDashboardConfig,
+  drasiDashboardConfig,
 }

--- a/web/src/config/routes.ts
+++ b/web/src/config/routes.ts
@@ -93,6 +93,9 @@ export const ROUTES = {
   // Multi-Tenancy
   MULTI_TENANCY: '/multi-tenancy',
 
+  // Drasi
+  DRASI: '/drasi',
+
   // Dev / test routes
   TEST_UNIFIED_CARD: '/test/unified-card',
   TEST_UNIFIED_STATS: '/test/unified-stats',

--- a/web/src/hooks/useDrasiResources.ts
+++ b/web/src/hooks/useDrasiResources.ts
@@ -1,0 +1,231 @@
+/**
+ * Hook for fetching Drasi resources (Sources, Continuous Queries, Reactions)
+ * from the Drasi API.
+ *
+ * Drasi exposes a REST API on its management endpoint:
+ *   GET /v1/sources
+ *   GET /v1/continuousQueries
+ *   GET /v1/reactions
+ *   GET /v1/continuousQueries/{id}/results  (for live result rows)
+ *
+ * When the Drasi API is unavailable, returns null so the card falls back
+ * to demo data.
+ */
+import { useState, useEffect, useCallback, useRef } from 'react'
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/** Polling interval for Drasi resource refresh */
+const DRASI_POLL_INTERVAL_MS = 10_000
+/** Default Drasi API base URL — override via VITE_DRASI_API_URL env var */
+const DRASI_API_BASE = import.meta.env.VITE_DRASI_API_URL as string | undefined
+
+// ---------------------------------------------------------------------------
+// Types (matching the card's expected shape)
+// ---------------------------------------------------------------------------
+
+type SourceKind = 'HTTP' | 'POSTGRES' | 'COSMOSDB' | 'GREMLIN' | 'SQL'
+type ReactionKind = 'SSE' | 'SIGNALR' | 'WEBHOOK' | 'KAFKA'
+
+interface DrasiSource {
+  id: string
+  name: string
+  kind: SourceKind
+  status: 'ready' | 'error' | 'pending'
+}
+
+interface DrasiQuery {
+  id: string
+  name: string
+  language: string
+  status: 'ready' | 'error' | 'pending'
+  sourceIds: string[]
+}
+
+interface DrasiReaction {
+  id: string
+  name: string
+  kind: ReactionKind
+  status: 'ready' | 'error' | 'pending'
+  queryIds: string[]
+}
+
+interface LiveResultRow {
+  changePercent: number
+  name: string
+  previousClose: number
+  price: number
+  symbol: string
+}
+
+export interface DrasiResourceData {
+  sources: DrasiSource[]
+  queries: DrasiQuery[]
+  reactions: DrasiReaction[]
+  liveResults: LiveResultRow[]
+}
+
+// ---------------------------------------------------------------------------
+// API response types (raw Drasi API shapes)
+// ---------------------------------------------------------------------------
+
+interface DrasiApiSource {
+  id?: string
+  metadata?: { name?: string }
+  spec?: { kind?: string; properties?: Record<string, unknown> }
+  status?: { available?: boolean; message?: string }
+}
+
+interface DrasiApiQuery {
+  id?: string
+  metadata?: { name?: string }
+  spec?: { mode?: string; query?: string; sources?: Array<{ name?: string; id?: string }> }
+  status?: { available?: boolean }
+}
+
+interface DrasiApiReaction {
+  id?: string
+  metadata?: { name?: string }
+  spec?: { kind?: string; queries?: Array<{ name?: string; id?: string }> }
+  status?: { available?: boolean }
+}
+
+// ---------------------------------------------------------------------------
+// Mappers
+// ---------------------------------------------------------------------------
+
+function mapStatus(available?: boolean): 'ready' | 'error' | 'pending' {
+  if (available === true) return 'ready'
+  if (available === false) return 'error'
+  return 'pending'
+}
+
+function mapSourceKind(kind?: string): SourceKind {
+  const normalized = (kind || '').toUpperCase()
+  if (normalized.includes('HTTP')) return 'HTTP'
+  if (normalized.includes('POSTGRES') || normalized.includes('PG')) return 'POSTGRES'
+  if (normalized.includes('COSMOS')) return 'COSMOSDB'
+  if (normalized.includes('GREMLIN')) return 'GREMLIN'
+  if (normalized.includes('SQL')) return 'SQL'
+  return 'POSTGRES'
+}
+
+function mapReactionKind(kind?: string): ReactionKind {
+  const normalized = (kind || '').toUpperCase()
+  if (normalized.includes('SSE')) return 'SSE'
+  if (normalized.includes('SIGNAL')) return 'SIGNALR'
+  if (normalized.includes('WEBHOOK') || normalized.includes('HTTP')) return 'WEBHOOK'
+  if (normalized.includes('KAFKA')) return 'KAFKA'
+  return 'SSE'
+}
+
+// ---------------------------------------------------------------------------
+// Hook
+// ---------------------------------------------------------------------------
+
+export function useDrasiResources(): {
+  data: DrasiResourceData | null
+  isLoading: boolean
+  error: string | null
+} {
+  const [data, setData] = useState<DrasiResourceData | null>(null)
+  const [isLoading, setIsLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const abortRef = useRef<AbortController | null>(null)
+
+  const fetchResources = useCallback(async () => {
+    if (!DRASI_API_BASE) {
+      // No Drasi API configured — card will use demo data
+      return
+    }
+
+    abortRef.current?.abort()
+    const controller = new AbortController()
+    abortRef.current = controller
+
+    setIsLoading(true)
+    try {
+      const [sourcesRes, queriesRes, reactionsRes] = await Promise.all([
+        fetch(`${DRASI_API_BASE}/v1/sources`, { signal: controller.signal }),
+        fetch(`${DRASI_API_BASE}/v1/continuousQueries`, { signal: controller.signal }),
+        fetch(`${DRASI_API_BASE}/v1/reactions`, { signal: controller.signal }),
+      ])
+
+      if (!sourcesRes.ok || !queriesRes.ok || !reactionsRes.ok) {
+        throw new Error('Drasi API returned non-OK status')
+      }
+
+      const rawSources: DrasiApiSource[] = await sourcesRes.json()
+      const rawQueries: DrasiApiQuery[] = await queriesRes.json()
+      const rawReactions: DrasiApiReaction[] = await reactionsRes.json()
+
+      const sources: DrasiSource[] = (rawSources || []).map(s => ({
+        id: s.id || s.metadata?.name || 'unknown',
+        name: s.metadata?.name || s.id || 'unknown',
+        kind: mapSourceKind(s.spec?.kind),
+        status: mapStatus(s.status?.available),
+      }))
+
+      const queries: DrasiQuery[] = (rawQueries || []).map(q => ({
+        id: q.id || q.metadata?.name || 'unknown',
+        name: q.metadata?.name || q.id || 'unknown',
+        language: (q.spec?.mode || 'CYPHER').toUpperCase() + ' QUERY',
+        status: mapStatus(q.status?.available),
+        sourceIds: (q.spec?.sources || []).map(s => s.id || s.name || ''),
+      }))
+
+      const reactions: DrasiReaction[] = (rawReactions || []).map(r => ({
+        id: r.id || r.metadata?.name || 'unknown',
+        name: r.metadata?.name || r.id || 'unknown',
+        kind: mapReactionKind(r.spec?.kind),
+        status: mapStatus(r.status?.available),
+        queryIds: (r.spec?.queries || []).map(q => q.id || q.name || ''),
+      }))
+
+      // Fetch live results from the first query (if any)
+      let liveResults: LiveResultRow[] = []
+      if (queries.length > 0) {
+        try {
+          const resultsRes = await fetch(
+            `${DRASI_API_BASE}/v1/continuousQueries/${queries[0].id}/results`,
+            { signal: controller.signal },
+          )
+          if (resultsRes.ok) {
+            const rawResults = await resultsRes.json()
+            liveResults = (rawResults || []).map((r: Record<string, unknown>) => ({
+              changePercent: Number(r.changePercent) || 0,
+              name: String(r.name || ''),
+              previousClose: Number(r.previousClose) || 0,
+              price: Number(r.price) || 0,
+              symbol: String(r.symbol || ''),
+            }))
+          }
+        } catch {
+          // Live results are optional — silently ignore
+        }
+      }
+
+      setData({ sources, queries, reactions, liveResults })
+      setError(null)
+    } catch (e) {
+      if ((e as Error).name !== 'AbortError') {
+        setError((e as Error).message || 'Failed to fetch Drasi resources')
+      }
+    } finally {
+      setIsLoading(false)
+    }
+  }, [])
+
+  useEffect(() => {
+    fetchResources()
+    const interval = setInterval(fetchResources, DRASI_POLL_INTERVAL_MS)
+    return () => {
+      clearInterval(interval)
+      abortRef.current?.abort()
+    }
+  }, [fetchResources])
+
+  return { data, isLoading, error }
+}

--- a/web/src/hooks/useSearchIndex.ts
+++ b/web/src/hooks/useSearchIndex.ts
@@ -81,6 +81,7 @@ const DASHBOARD_NAMES: Record<DashboardStatsType, string> = {
   'multi-tenancy': 'Multi-Tenancy',
   'ci-cd': 'CI/CD',
   'karmada-ops': 'Karmada Ops',
+  drasi: 'Drasi',
 }
 
 const DASHBOARD_ROUTES: Record<DashboardStatsType, string> = {
@@ -106,13 +107,14 @@ const DASHBOARD_ROUTES: Record<DashboardStatsType, string> = {
   'multi-tenancy': '/multi-tenancy',
   'ci-cd': '/ci-cd',
   'karmada-ops': '/karmada-ops',
+  drasi: '/drasi',
 }
 
 const ALL_STATS_DASHBOARD_TYPES: DashboardStatsType[] = [
   'dashboard', 'clusters', 'workloads', 'pods', 'gitops', 'storage',
   'network', 'security', 'compliance', 'data-compliance', 'compute',
   'events', 'cost', 'alerts', 'operators', 'deploy', 'ai-agents',
-  'cluster-admin', 'insights', 'ci-cd',
+  'cluster-admin', 'insights', 'ci-cd', 'drasi',
 ]
 
 // --- Dashboard storage keys → routes (for scanning placed cards) ---

--- a/web/src/lib/cards/types.ts
+++ b/web/src/lib/cards/types.ts
@@ -40,6 +40,7 @@ export type CardCategory =
   | 'ci-cd'
   | 'events'
   | 'insights'
+  | 'drasi'
 
 export interface CardDefinition {
   /** Unique card type identifier */


### PR DESCRIPTION
## Summary
- Adds a new **Drasi** dashboard at `/drasi` with a **Reactive Graph** card that visualizes Drasi's reactive data pipeline architecture
- Card shows Sources (HTTP, Postgres) → Continuous Queries (Cypher) → Reactions (SSE) with animated data flow connections and a live results table
- Includes demo data (stock trading pipeline) and live data support via `useDrasiResources` hook that polls the Drasi management API when `VITE_DRASI_API_URL` is set
- Full registration across all systems: routes, dashboard config, card config, card registry, sidebar, card catalog, stats blocks, search index

## What the card shows
Replicates the Drasi reactive graph visualization requested by the Drasi PM:
- **3 source nodes**: price-feed (HTTP), postgres-stocks, postgres-broker (Postgres)
- **4 query nodes**: watchlist-query, portfolio-query, top-gainers-query, top-losers-query (Cypher)
- **1 reaction node**: sse-stream (SSE)
- **Animated flow connections** between nodes
- **Live results table** showing stock data (changePercent, name, previousClose, price, symbol) when a query is clicked

## Test plan
- [ ] Navigate to `/drasi` dashboard — should render with demo data
- [ ] Verify card shows sources, queries, reactions with animated flow dots
- [ ] Click a query node to see live results table
- [ ] Verify card appears in Browse Cards dialog under "Drasi" category
- [ ] Verify "Drasi" appears in sidebar customizer
- [ ] Set `VITE_DRASI_API_URL` to a Drasi instance and verify live data

🤖 Generated with [Claude Code](https://claude.com/claude-code)