### PR TITLE
fix: unblock navigation away from Dashboard and My Clusters

### DIFF
--- a/web/src/components/layout/Sidebar.tsx
+++ b/web/src/components/layout/Sidebar.tsx
@@ -367,7 +367,6 @@ export function Sidebar() {
           // Normal navigation mode
           <NavLink
             to={item.href}
-            reloadDocument
             onClick={() => emitSidebarNavigated(item.href)}
             onDoubleClick={(e) => handleDoubleClick(item, e)}
             onMouseEnter={() => prefetchDashboard(item.href)}

--- a/web/src/hooks/mcp/clusters.ts
+++ b/web/src/hooks/mcp/clusters.ts
@@ -66,9 +66,6 @@ export function useClusters() {
   const { isDemoMode } = useDemoMode()
 
   // Subscribe to shared cache updates.
-  // The setLocalState call here is an urgent setState, but notifyClusterSubscribers()
-  // wraps the fan-out in startTransition, so in practice every call to this
-  // handler is already inside a transition scope.
   useEffect(() => {
     const handleUpdate = (cache: ClusterCache) => {
       setLocalState(cache)

--- a/web/src/hooks/mcp/clusters.ts
+++ b/web/src/hooks/mcp/clusters.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback, useRef, startTransition } from 'react'
+import { useState, useEffect, useCallback, useRef } from 'react'
 import { api } from '../../lib/api'
 import { useDemoMode } from '../useDemoMode'
 import { isDemoMode } from '../../lib/demoMode'
@@ -65,24 +65,16 @@ export function useClusters() {
   // Track demo mode to re-fetch when it changes
   const { isDemoMode } = useDemoMode()
 
-  // Subscribe to shared cache updates
+  // Subscribe to shared cache updates.
+  // The setLocalState call here is an urgent setState, but notifyClusterSubscribers()
+  // wraps the fan-out in startTransition, so in practice every call to this
+  // handler is already inside a transition scope.
   useEffect(() => {
-    // Subscribe to updates.
-    // Wrap setLocalState in startTransition so cluster cache updates (which
-    // fire per-cluster during health checks and on every poll tick) become
-    // low-priority/interruptible. Without this, navigating away from Dashboard
-    // or My Clusters — both of which fan out many useClusters subscribers —
-    // gets starved because each health-check completion triggers a synchronous
-    // urgent re-render on every subscriber, blocking the router's transition.
     const handleUpdate = (cache: ClusterCache) => {
-      startTransition(() => {
-        setLocalState(cache)
-      })
+      setLocalState(cache)
     }
     // Sync with any updates that happened between initial render and effect.
-    // This first call is NOT wrapped in startTransition — we want the initial
-    // sync to be urgent so the component hydrates with correct data on mount.
-    setLocalState(clusterCache)
+    handleUpdate(clusterCache)
     clusterSubscribers.add(handleUpdate)
 
     return () => {

--- a/web/src/hooks/mcp/clusters.ts
+++ b/web/src/hooks/mcp/clusters.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback, useRef } from 'react'
+import { useState, useEffect, useCallback, useRef, startTransition } from 'react'
 import { api } from '../../lib/api'
 import { useDemoMode } from '../useDemoMode'
 import { isDemoMode } from '../../lib/demoMode'
@@ -67,12 +67,22 @@ export function useClusters() {
 
   // Subscribe to shared cache updates
   useEffect(() => {
-    // Subscribe to updates
+    // Subscribe to updates.
+    // Wrap setLocalState in startTransition so cluster cache updates (which
+    // fire per-cluster during health checks and on every poll tick) become
+    // low-priority/interruptible. Without this, navigating away from Dashboard
+    // or My Clusters — both of which fan out many useClusters subscribers —
+    // gets starved because each health-check completion triggers a synchronous
+    // urgent re-render on every subscriber, blocking the router's transition.
     const handleUpdate = (cache: ClusterCache) => {
-      setLocalState(cache)
+      startTransition(() => {
+        setLocalState(cache)
+      })
     }
-    // Sync with any updates that happened between initial render and effect
-    handleUpdate(clusterCache)
+    // Sync with any updates that happened between initial render and effect.
+    // This first call is NOT wrapped in startTransition — we want the initial
+    // sync to be urgent so the component hydrates with correct data on mount.
+    setLocalState(clusterCache)
     clusterSubscribers.add(handleUpdate)
 
     return () => {

--- a/web/src/hooks/mcp/shared.ts
+++ b/web/src/hooks/mcp/shared.ts
@@ -1,4 +1,3 @@
-import { startTransition } from 'react'
 import { api, isBackendUnavailable } from '../../lib/api'
 import { reportAgentDataError, reportAgentDataSuccess, isAgentUnavailable } from '../useLocalAgent'
 import { isDemoMode, isNetlifyDeployment, isDemoToken, subscribeDemoMode } from '../../lib/demoMode'
@@ -253,23 +252,9 @@ export let clusterCache: ClusterCache = {
 type ClusterSubscriber = (cache: ClusterCache) => void
 export const clusterSubscribers = new Set<ClusterSubscriber>()
 
-// Notify all subscribers of state change.
-//
-// Wrap the fan-out in React.startTransition so every subscriber's setState
-// becomes a transition-priority (interruptible) update. The cluster cache
-// fires many times per second under normal operation — every poll tick, every
-// per-cluster health-check completion, every WebSocket kubeconfig notification
-// — and without this wrap, each fan-out produces a burst of urgent renders
-// across every component using useClusters(). On pages with many cluster-aware
-// cards (Dashboard, My Clusters), that burst starves React Router's navigation
-// transition: the URL updates via history.push, but <Outlet> never commits the
-// new route because the tree is always busy re-rendering cluster subscribers.
-// Wrapping here (at the notify source) covers every subscriber uniformly so
-// individual hooks don't each have to remember to wrap their own setState.
+// Notify all subscribers of state change
 export function notifyClusterSubscribers() {
-  startTransition(() => {
-    clusterSubscribers.forEach(subscriber => subscriber(clusterCache))
-  })
+  clusterSubscribers.forEach(subscriber => subscriber(clusterCache))
 }
 
 /**

--- a/web/src/hooks/mcp/shared.ts
+++ b/web/src/hooks/mcp/shared.ts
@@ -1,3 +1,4 @@
+import { startTransition } from 'react'
 import { api, isBackendUnavailable } from '../../lib/api'
 import { reportAgentDataError, reportAgentDataSuccess, isAgentUnavailable } from '../useLocalAgent'
 import { isDemoMode, isNetlifyDeployment, isDemoToken, subscribeDemoMode } from '../../lib/demoMode'
@@ -252,9 +253,23 @@ export let clusterCache: ClusterCache = {
 type ClusterSubscriber = (cache: ClusterCache) => void
 export const clusterSubscribers = new Set<ClusterSubscriber>()
 
-// Notify all subscribers of state change
+// Notify all subscribers of state change.
+//
+// Wrap the fan-out in React.startTransition so every subscriber's setState
+// becomes a transition-priority (interruptible) update. The cluster cache
+// fires many times per second under normal operation — every poll tick, every
+// per-cluster health-check completion, every WebSocket kubeconfig notification
+// — and without this wrap, each fan-out produces a burst of urgent renders
+// across every component using useClusters(). On pages with many cluster-aware
+// cards (Dashboard, My Clusters), that burst starves React Router's navigation
+// transition: the URL updates via history.push, but <Outlet> never commits the
+// new route because the tree is always busy re-rendering cluster subscribers.
+// Wrapping here (at the notify source) covers every subscriber uniformly so
+// individual hooks don't each have to remember to wrap their own setState.
 export function notifyClusterSubscribers() {
-  clusterSubscribers.forEach(subscriber => subscriber(clusterCache))
+  startTransition(() => {
+    clusterSubscribers.forEach(subscriber => subscriber(clusterCache))
+  })
 }
 
 /**


### PR DESCRIPTION
## Summary
- Navigating away from Dashboard or My Clusters required two clicks (URL changed, content lagged) while Deploy (16 cards) navigated instantly.
- Root cause: `useClusters()` subscribers call `setLocalState(cache)` synchronously on every cache update — every poll tick, every per-cluster health-check completion, every WebSocket notification. That starves React Router v7's internal `startTransition`, blocking route commits.
- Deploy uses `useDeployments` (different cache, no per-item health fan-out), which is why it wasn't affected.
- Fix: wrap the subscriber's `setLocalState` in `startTransition` so cluster cache updates become interruptible. Initial sync on mount stays urgent.
- Also removes `reloadDocument` from the sidebar NavLink — a previous workaround that caused page blinking on every click.

## Test plan
- [ ] Navigate from Dashboard → Deploy, Clusters, Security, etc. (single click should commit)
- [ ] Navigate from My Clusters → other dashboards (single click)
- [ ] Verify no blinking on sidebar clicks
- [ ] Verify cluster cards on Dashboard still update from polling
- [ ] Verify health-check indicators on My Clusters still animate