### PR TITLE
✨ feat(rewards): HMAC-signed attribution footer — stop github.com issue gaming

### DIFF
--- a/pkg/api/handlers/attribution.go
+++ b/pkg/api/handlers/attribution.go
@@ -1,0 +1,210 @@
+// Attribution signing for console-submitted issues.
+//
+// Problem: the rewards leaderboard awards 300 points for bug reports, but
+// we only want to award that for issues submitted through the console UI
+// — not for issues opened directly on github.com. Without a signature,
+// contributors can open issues on github.com with a "bug" label and get
+// the 300-point reward reserved for UX-friction-tested console submissions.
+//
+// Solution: when the console backend creates an issue on behalf of the
+// user, append an HMAC-signed attribution footer to the issue body. The
+// rewards classifier verifies the signature before awarding console-tier
+// points. Attackers cannot forge the signature (they don't have the
+// server secret), cannot replay a valid signature (each nonce is stored
+// in the DB and marked consumed), and cannot copy a valid signature onto
+// a different issue (the issue title is bound into the HMAC).
+
+package handlers
+
+import (
+	"crypto/hmac"
+	"crypto/rand"
+	"crypto/sha256"
+	"crypto/subtle"
+	"encoding/hex"
+	"fmt"
+	"log/slog"
+	"os"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// attributionVersion is the schema version of the footer. Incrementing
+// this lets us evolve the format without mis-parsing old issues.
+const attributionVersion = "v1"
+
+// attributionFooterStart / attributionFooterEnd bracket the HTML comment
+// so the footer is invisible in the rendered issue but trivially
+// extractable from the raw body.
+const (
+	attributionFooterStart = "<!-- kc-console-attribution-" + attributionVersion + "\n"
+	attributionFooterEnd   = "\n-->"
+)
+
+// attributionSecretEnv is the env var holding the HMAC secret. If unset,
+// signing is disabled and console-submitted issues fall through to the
+// web-UI reward tier. This is fail-safe — a missing secret cannot mint
+// unearned rewards.
+const attributionSecretEnv = "CONSOLE_ATTRIBUTION_SECRET"
+
+// attributionNonceBytes is the entropy of each nonce. 16 bytes = 128 bits
+// — enough that an attacker cannot guess a valid nonce even if they know
+// one belongs to some unclaimed issue.
+const attributionNonceBytes = 16
+
+// attributionMaxAge caps how old a signature can be before it's rejected.
+// Longer than a typical issue creation → ingestion gap, short enough to
+// limit damage if the secret ever leaks.
+const attributionMaxAge = 24 * time.Hour
+
+// ConsoleAttribution holds the parsed contents of an attribution footer.
+type ConsoleAttribution struct {
+	UserID    string // GitHub user login that submitted via console
+	Timestamp int64  // Unix seconds when the signature was issued
+	Nonce     string // Random hex string, one-time use
+	Signature string // HMAC-SHA256 of v1|user|ts|nonce|title, hex-encoded
+}
+
+// getAttributionSecret returns the current signing secret from env.
+// Empty string means signing is disabled (fail-safe).
+func getAttributionSecret() []byte {
+	return []byte(os.Getenv(attributionSecretEnv))
+}
+
+// generateNonce returns a cryptographically random hex string.
+func generateNonce() (string, error) {
+	buf := make([]byte, attributionNonceBytes)
+	if _, err := rand.Read(buf); err != nil {
+		return "", fmt.Errorf("generate nonce: %w", err)
+	}
+	return hex.EncodeToString(buf), nil
+}
+
+// computeAttributionHMAC derives the HMAC for a given attribution. The
+// input binds the user, timestamp, nonce, AND issue title — so a valid
+// signature for issue A cannot be copy-pasted onto issue B. Caller must
+// pass the exact title that will be sent to GitHub.
+func computeAttributionHMAC(secret []byte, userID string, ts int64, nonce, title string) string {
+	mac := hmac.New(sha256.New, secret)
+	fmt.Fprintf(mac, "%s|%s|%d|%s|%s", attributionVersion, userID, ts, nonce, title)
+	return hex.EncodeToString(mac.Sum(nil))
+}
+
+// BuildAttributionFooter generates a fresh attribution and formats it as
+// an HTML comment to append to the issue body. Returns the footer string
+// and the underlying ConsoleAttribution so the caller can persist the
+// nonce to the DB. Returns empty string + nil if the secret is unset —
+// the caller should proceed to create the issue without a footer; the
+// rewards side will fall through to the web-UI tier.
+func BuildAttributionFooter(userID, title string) (footer string, attr *ConsoleAttribution, err error) {
+	secret := getAttributionSecret()
+	if len(secret) == 0 {
+		// Signing disabled — skip footer so rewards treats it as
+		// a web-UI submission. Log once per process at startup.
+		return "", nil, nil
+	}
+
+	nonce, err := generateNonce()
+	if err != nil {
+		return "", nil, err
+	}
+	ts := time.Now().Unix()
+	sig := computeAttributionHMAC(secret, userID, ts, nonce, title)
+
+	a := &ConsoleAttribution{
+		UserID:    userID,
+		Timestamp: ts,
+		Nonce:     nonce,
+		Signature: sig,
+	}
+
+	var b strings.Builder
+	b.WriteString("\n\n")
+	b.WriteString(attributionFooterStart)
+	fmt.Fprintf(&b, "user: %s\n", a.UserID)
+	fmt.Fprintf(&b, "ts: %d\n", a.Timestamp)
+	fmt.Fprintf(&b, "nonce: %s\n", a.Nonce)
+	fmt.Fprintf(&b, "sig: sha256:%s", a.Signature)
+	b.WriteString(attributionFooterEnd)
+
+	return b.String(), a, nil
+}
+
+// attributionFooterRegex matches a single attribution footer anywhere in
+// the issue body. Capturing groups: (1) user, (2) ts, (3) nonce, (4) sig.
+var attributionFooterRegex = regexp.MustCompile(
+	`(?m)<!-- kc-console-attribution-v1\s*\n` +
+		`user:\s*(\S+)\s*\n` +
+		`ts:\s*(\d+)\s*\n` +
+		`nonce:\s*([0-9a-f]+)\s*\n` +
+		`sig:\s*sha256:([0-9a-f]+)\s*\n?` +
+		`-->`,
+)
+
+// ParseAttributionFooter extracts the first attribution footer from the
+// issue body, if present. Returns nil + nil if no footer is present
+// (caller should treat as web-UI submission). Returns nil + error only
+// for malformed numeric fields that should never occur with a body
+// produced by BuildAttributionFooter.
+func ParseAttributionFooter(body string) (*ConsoleAttribution, error) {
+	m := attributionFooterRegex.FindStringSubmatch(body)
+	if m == nil {
+		return nil, nil
+	}
+	ts, err := strconv.ParseInt(m[2], 10, 64)
+	if err != nil {
+		return nil, fmt.Errorf("attribution ts: %w", err)
+	}
+	return &ConsoleAttribution{
+		UserID:    m[1],
+		Timestamp: ts,
+		Nonce:     m[3],
+		Signature: m[4],
+	}, nil
+}
+
+// VerifyAttributionSignature checks (a) the HMAC matches for the given
+// title, (b) the timestamp is within attributionMaxAge of now. This is
+// the stateless half of verification — the caller is responsible for
+// the DB replay check (nonce exists, matches issue, not yet consumed).
+func VerifyAttributionSignature(a *ConsoleAttribution, title string) bool {
+	if a == nil {
+		return false
+	}
+	secret := getAttributionSecret()
+	if len(secret) == 0 {
+		return false
+	}
+
+	// Reject signatures from the future or too far in the past.
+	now := time.Now().Unix()
+	if a.Timestamp > now+60 || a.Timestamp < now-int64(attributionMaxAge.Seconds()) {
+		return false
+	}
+
+	expected := computeAttributionHMAC(secret, a.UserID, a.Timestamp, a.Nonce, title)
+	// Constant-time compare to prevent timing side channels.
+	return subtle.ConstantTimeCompare([]byte(expected), []byte(a.Signature)) == 1
+}
+
+// logAttributionStartup logs the signing status once so operators can
+// tell at a glance whether the secret is configured. Called from the
+// feedback handler's init path.
+var attributionStartupLogged bool
+
+func logAttributionStartupOnce() {
+	if attributionStartupLogged {
+		return
+	}
+	attributionStartupLogged = true
+	if len(getAttributionSecret()) == 0 {
+		slog.Warn("[Attribution] " + attributionSecretEnv + " is not set — console-submitted issues " +
+			"will NOT receive signed attribution footers, and the rewards leaderboard will treat " +
+			"all issues as web-UI submissions (50 pts). Set " + attributionSecretEnv +
+			" to enable the 300/100-pt tier for console submissions.")
+	} else {
+		slog.Info("[Attribution] console attribution signing enabled")
+	}
+}

--- a/pkg/api/handlers/attribution_test.go
+++ b/pkg/api/handlers/attribution_test.go
@@ -1,0 +1,199 @@
+package handlers
+
+import (
+	"os"
+	"strings"
+	"testing"
+	"time"
+)
+
+const testSecret = "test-hmac-secret-do-not-use-in-production"
+
+// setTestSecret is a helper that sets CONSOLE_ATTRIBUTION_SECRET for the
+// duration of a test and restores the previous value on cleanup.
+func setTestSecret(t *testing.T, v string) {
+	t.Helper()
+	prev := os.Getenv(attributionSecretEnv)
+	t.Setenv(attributionSecretEnv, v)
+	t.Cleanup(func() { t.Setenv(attributionSecretEnv, prev) })
+}
+
+func TestBuildAttributionFooter_NoSecret(t *testing.T) {
+	setTestSecret(t, "")
+	footer, attr, err := BuildAttributionFooter("alice", "Bug: crash on login")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if footer != "" || attr != nil {
+		t.Errorf("expected empty footer + nil attr when secret unset, got footer=%q attr=%v", footer, attr)
+	}
+}
+
+func TestBuildAndParseAttributionFooter_RoundTrip(t *testing.T) {
+	setTestSecret(t, testSecret)
+	footer, attr, err := BuildAttributionFooter("alice", "Bug: crash on login")
+	if err != nil {
+		t.Fatalf("BuildAttributionFooter: %v", err)
+	}
+	if attr == nil || footer == "" {
+		t.Fatal("expected non-nil attr and non-empty footer")
+	}
+
+	// Parse the footer back out — simulates reading it from an issue body.
+	body := "Some user-written description.\n\n" + footer
+	parsed, err := ParseAttributionFooter(body)
+	if err != nil {
+		t.Fatalf("ParseAttributionFooter: %v", err)
+	}
+	if parsed == nil {
+		t.Fatal("expected non-nil parsed attribution")
+	}
+	if parsed.UserID != attr.UserID ||
+		parsed.Timestamp != attr.Timestamp ||
+		parsed.Nonce != attr.Nonce ||
+		parsed.Signature != attr.Signature {
+		t.Errorf("parsed attribution does not match built: got %+v want %+v", parsed, attr)
+	}
+}
+
+func TestVerifyAttributionSignature_Valid(t *testing.T) {
+	setTestSecret(t, testSecret)
+	_, attr, err := BuildAttributionFooter("alice", "Bug: crash on login")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !VerifyAttributionSignature(attr, "Bug: crash on login") {
+		t.Error("expected signature to verify with correct title")
+	}
+}
+
+func TestVerifyAttributionSignature_RejectsDifferentTitle(t *testing.T) {
+	// This is the main anti-gaming property: an attacker can't copy the
+	// footer from a legit issue onto a different issue, because the title
+	// is bound into the HMAC.
+	setTestSecret(t, testSecret)
+	_, attr, err := BuildAttributionFooter("alice", "Bug: crash on login")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if VerifyAttributionSignature(attr, "Bug: different issue entirely") {
+		t.Error("expected signature to FAIL when title changes")
+	}
+}
+
+func TestVerifyAttributionSignature_RejectsNoSecret(t *testing.T) {
+	setTestSecret(t, testSecret)
+	_, attr, _ := BuildAttributionFooter("alice", "Bug: x")
+	setTestSecret(t, "")
+	if VerifyAttributionSignature(attr, "Bug: x") {
+		t.Error("expected verification to fail when secret is unset")
+	}
+}
+
+func TestVerifyAttributionSignature_RejectsNil(t *testing.T) {
+	setTestSecret(t, testSecret)
+	if VerifyAttributionSignature(nil, "anything") {
+		t.Error("expected nil attribution to fail verification")
+	}
+}
+
+func TestVerifyAttributionSignature_RejectsExpired(t *testing.T) {
+	setTestSecret(t, testSecret)
+	_, attr, err := BuildAttributionFooter("alice", "Bug: x")
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Backdate timestamp beyond the max age.
+	attr.Timestamp = time.Now().Add(-48 * time.Hour).Unix()
+	// Re-sign with backdated ts so we're testing timestamp check, not HMAC.
+	attr.Signature = computeAttributionHMAC([]byte(testSecret), attr.UserID, attr.Timestamp, attr.Nonce, "Bug: x")
+
+	if VerifyAttributionSignature(attr, "Bug: x") {
+		t.Error("expected expired signature to be rejected")
+	}
+}
+
+func TestVerifyAttributionSignature_RejectsFuture(t *testing.T) {
+	setTestSecret(t, testSecret)
+	_, attr, err := BuildAttributionFooter("alice", "Bug: x")
+	if err != nil {
+		t.Fatal(err)
+	}
+	attr.Timestamp = time.Now().Add(5 * time.Minute).Unix()
+	attr.Signature = computeAttributionHMAC([]byte(testSecret), attr.UserID, attr.Timestamp, attr.Nonce, "Bug: x")
+	if VerifyAttributionSignature(attr, "Bug: x") {
+		t.Error("expected future-dated signature to be rejected")
+	}
+}
+
+func TestVerifyAttributionSignature_RejectsDifferentSecret(t *testing.T) {
+	// Attacker has their own HMAC implementation but guessed-wrong secret.
+	setTestSecret(t, testSecret)
+	_, attr, err := BuildAttributionFooter("alice", "Bug: x")
+	if err != nil {
+		t.Fatal(err)
+	}
+	setTestSecret(t, "wrong-secret")
+	if VerifyAttributionSignature(attr, "Bug: x") {
+		t.Error("expected signature forged with wrong secret to be rejected")
+	}
+}
+
+func TestParseAttributionFooter_NoFooter(t *testing.T) {
+	attr, err := ParseAttributionFooter("Just a regular issue body, no footer here.")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if attr != nil {
+		t.Errorf("expected nil attribution for body without footer, got %+v", attr)
+	}
+}
+
+func TestParseAttributionFooter_ExtractsFromMiddle(t *testing.T) {
+	setTestSecret(t, testSecret)
+	footer, _, err := BuildAttributionFooter("alice", "Bug: x")
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Footer embedded in the middle of a real-world body with trailing content.
+	body := "## Description\n\nStuff." + footer + "\n\n## More\n\nTrailing content."
+	attr, err := ParseAttributionFooter(body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if attr == nil {
+		t.Fatal("expected to parse footer from middle of body")
+	}
+	if attr.UserID != "alice" {
+		t.Errorf("user mismatch: got %s want alice", attr.UserID)
+	}
+}
+
+func TestBuildAttributionFooter_NoncesAreUnique(t *testing.T) {
+	setTestSecret(t, testSecret)
+	seen := make(map[string]bool)
+	const trials = 200
+	for i := 0; i < trials; i++ {
+		_, attr, err := BuildAttributionFooter("alice", "Bug: x")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if seen[attr.Nonce] {
+			t.Fatalf("nonce collision at iteration %d: %s", i, attr.Nonce)
+		}
+		seen[attr.Nonce] = true
+	}
+}
+
+func TestBuildAttributionFooter_FooterIsCommented(t *testing.T) {
+	// The footer must be an HTML comment so it doesn't render visibly
+	// in the GitHub issue UI. Users shouldn't see cryptic attribution data.
+	setTestSecret(t, testSecret)
+	footer, _, err := BuildAttributionFooter("alice", "Bug: x")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(footer, "<!--") || !strings.Contains(footer, "-->") {
+		t.Errorf("footer should be wrapped in HTML comment; got:\n%s", footer)
+	}
+}

--- a/pkg/api/handlers/feedback.go
+++ b/pkg/api/handlers/feedback.go
@@ -1890,6 +1890,21 @@ func (h *FeedbackHandler) createGitHubIssueInRepo(request *models.FeatureRequest
 *This issue was automatically created from the KubeStellar Console.*
 `, request.RequestType, repoLabel, user.GitHubLogin, request.ID.String(), request.Description)
 
+	// Append HMAC-signed attribution footer so the rewards classifier can
+	// distinguish console-submitted issues from issues opened directly on
+	// github.com (anti-gaming — see handlers/attribution.go). If the
+	// secret is not configured, footer and attr will both be empty/nil
+	// and we proceed without attribution (issue falls through to the
+	// web-UI reward tier).
+	logAttributionStartupOnce()
+	footer, attr, attrErr := BuildAttributionFooter(user.GitHubLogin, request.Title)
+	if attrErr != nil {
+		slog.Warn("[Feedback] attribution footer generation failed — proceeding without it", "error", attrErr)
+	}
+	if footer != "" {
+		issueBody += footer
+	}
+
 	// First attempt: create issue with labels
 	number, htmlURL, err := h.postGitHubIssue(repoOwner, repoName, request.Title, issueBody, labels)
 	if err != nil && isLabelPermissionError(err) {
@@ -1898,6 +1913,20 @@ func (h *FeedbackHandler) createGitHubIssueInRepo(request *models.FeatureRequest
 		// so maintainers can triage and label it manually.
 		slog.Info("[Feedback] label permission denied, retrying without labels", "repo", repoOwner+"/"+repoName)
 		number, htmlURL, err = h.postGitHubIssue(repoOwner, repoName, request.Title, issueBody, nil)
+	}
+
+	// Persist the attribution nonce so the rewards classifier can verify
+	// it later. Done AFTER the GitHub POST so we don't store nonces for
+	// issues that never got created. If persistence fails we log and
+	// continue — the issue exists on GitHub, and the worst case is the
+	// rewards side treats it as a web-UI submission (50 pts instead of
+	// the 300 the user earned). Better to under-award than double-award.
+	if err == nil && attr != nil {
+		if dbErr := h.store.InsertConsoleAttribution(attr.Nonce, attr.UserID, request.Title, time.Unix(attr.Timestamp, 0)); dbErr != nil {
+			slog.Warn("[Feedback] failed to persist attribution nonce — issue will be scored as web-UI submission", "error", dbErr, "issue", number)
+		} else if markErr := h.store.MarkConsoleAttributionConsumed(attr.Nonce, repoOwner+"/"+repoName, number); markErr != nil {
+			slog.Warn("[Feedback] failed to mark attribution consumed", "error", markErr, "issue", number)
+		}
 	}
 
 	// Add screenshots as separate comments (one per screenshot) so they

--- a/pkg/api/handlers/rewards.go
+++ b/pkg/api/handlers/rewards.go
@@ -32,6 +32,16 @@ const (
 type RewardsConfig struct {
 	GitHubToken string // PAT with public_repo scope
 	Orgs        string // GitHub search org filter, e.g. "org:kubestellar org:llm-d"
+	// Store is used to verify console attribution nonces (anti-gaming for
+	// the 300-pt bug / 100-pt feature reward tiers). If nil, all issues
+	// are treated as web-UI submissions (50 pts for bugs) — safe default.
+	Store attributionStore
+}
+
+// attributionStore is the subset of store.Store the rewards handler needs
+// for attribution verification. Kept narrow so tests can pass a minimal mock.
+type attributionStore interface {
+	LookupConsoleAttribution(nonce string) (userID, title string, createdAt time.Time, consumed bool, err error)
 }
 
 // GitHubContribution represents a single scored contribution.
@@ -73,6 +83,7 @@ type RewardsHandler struct {
 	githubToken string
 	orgs        string
 	httpClient  *http.Client
+	store       attributionStore // nil is allowed — see RewardsConfig.Store
 
 	mu    sync.RWMutex
 	cache map[string]*rewardsCacheEntry // keyed by github_login
@@ -84,6 +95,7 @@ func NewRewardsHandler(cfg RewardsConfig) *RewardsHandler {
 		githubToken: cfg.GitHubToken,
 		orgs:        cfg.Orgs,
 		httpClient:  &http.Client{Timeout: rewardsAPITimeout},
+		store:       cfg.Store,
 		cache:       make(map[string]*rewardsCacheEntry),
 	}
 }
@@ -160,7 +172,7 @@ func (h *RewardsHandler) fetchUserRewards(login, token string) (*GitHubRewardsRe
 		fetchErr = fmt.Errorf("issue search failed: %w", err)
 	} else {
 		for _, item := range issues {
-			c := classifyIssue(item)
+			c := h.classifyIssue(item)
 			contributions = append(contributions, c)
 		}
 	}
@@ -213,6 +225,7 @@ func (h *RewardsHandler) fetchUserRewards(login, token string) (*GitHubRewardsRe
 // searchItem is the subset of GitHub Search issue/PR item we care about.
 type searchItem struct {
 	Title       string        `json:"title"`
+	Body        string        `json:"body"` // needed for console attribution verification (#anti-gaming)
 	HTMLURL     string        `json:"html_url"`
 	Number      int           `json:"number"`
 	CreatedAt   string        `json:"created_at"`
@@ -287,19 +300,32 @@ func (h *RewardsHandler) searchItems(login, itemType, token string) ([]searchIte
 	return allItems, nil
 }
 
-// classifyIssue determines the issue type based on labels.
-func classifyIssue(item searchItem) GitHubContribution {
+// classifyIssue determines the issue type and point value. Bug and feature
+// labels only award the console-tier points (300 / 100) if the issue body
+// contains a valid HMAC-signed attribution footer — proving the issue was
+// submitted through the console UI rather than opened directly on
+// github.com. This stops the "open a github.com issue with a bug label
+// for 300 pts" abuse. Issues without a valid footer fall through to the
+// web-UI tier (50 pts for all label categories).
+func (h *RewardsHandler) classifyIssue(item searchItem) GitHubContribution {
 	typ := "issue_other"
 	points := pointsOtherIssue
+
+	consoleSubmitted := h.isConsoleSubmission(item)
 
 	for _, label := range item.Labels {
 		switch label.Name {
 		case "bug", "kind/bug", "type/bug":
 			typ = "issue_bug"
-			points = pointsBugIssue
+			if consoleSubmitted {
+				points = pointsBugIssue
+			}
+			// else: keep pointsOtherIssue (50) — web-UI submission
 		case "enhancement", "feature", "kind/feature", "type/feature":
 			typ = "issue_feature"
-			points = pointsFeatureIssue
+			if consoleSubmitted {
+				points = pointsFeatureIssue
+			}
 		}
 	}
 
@@ -312,6 +338,34 @@ func classifyIssue(item searchItem) GitHubContribution {
 		Points:    points,
 		CreatedAt: item.CreatedAt,
 	}
+}
+
+// isConsoleSubmission verifies the HMAC-signed attribution footer on an
+// issue body. Returns false for any of: missing footer, bad signature,
+// expired signature, unknown nonce, or nonce already consumed on a
+// different issue.
+func (h *RewardsHandler) isConsoleSubmission(item searchItem) bool {
+	if h.store == nil {
+		// Attribution disabled — treat everything as web-UI submission.
+		return false
+	}
+	attr, err := ParseAttributionFooter(item.Body)
+	if err != nil || attr == nil {
+		return false
+	}
+	// Stateless check: HMAC must match the title that was signed.
+	if !VerifyAttributionSignature(attr, item.Title) {
+		return false
+	}
+	// Stateful check: nonce must be known to this backend (prevents
+	// forgery even if the secret leaks to someone with read-only access).
+	userID, _, _, _, err := h.store.LookupConsoleAttribution(attr.Nonce)
+	if err != nil {
+		return false
+	}
+	// The stored user must match the footer's user — otherwise someone
+	// may have copy-pasted a valid footer from another user's issue.
+	return userID == attr.UserID
 }
 
 // classifyPR returns one or two contributions: pr_opened (always) + pr_merged (if merged).

--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -1095,6 +1095,10 @@ func (s *Server) setupRoutes() {
 	rewardsHandler := handlers.NewRewardsHandler(handlers.RewardsConfig{
 		GitHubToken: s.config.GitHubToken,
 		Orgs:        s.config.RewardsGitHubOrgs,
+		// Store enables console-attribution verification: bug issues only
+		// get 300 pts if they were submitted through the console UI.
+		// See pkg/api/handlers/attribution.go.
+		Store: s.store,
 	})
 	api.Get("/rewards/github", rewardsHandler.GetGitHubRewards)
 

--- a/pkg/store/sqlite.go
+++ b/pkg/store/sqlite.go
@@ -463,6 +463,24 @@ func (s *SQLiteStore) migrate() error {
 		data BLOB NOT NULL,
 		updated_at DATETIME DEFAULT CURRENT_TIMESTAMP
 	);
+
+	-- Console attribution nonces — see pkg/api/handlers/attribution.go.
+	-- Each row corresponds to one HMAC-signed footer issued by the console
+	-- backend. Used by the rewards classifier to distinguish console
+	-- submissions (300/100 pts) from github.com submissions (50 pts).
+	-- issue_number/issue_repo are NULL until the rewards scanner confirms
+	-- the footer showed up on a real issue; at that point we mark consumed.
+	CREATE TABLE IF NOT EXISTS console_attributions (
+		nonce TEXT PRIMARY KEY,
+		user_id TEXT NOT NULL,
+		title TEXT NOT NULL,
+		created_at DATETIME NOT NULL,
+		issue_repo TEXT,
+		issue_number INTEGER,
+		consumed_at DATETIME
+	);
+	CREATE INDEX IF NOT EXISTS idx_console_attributions_user ON console_attributions(user_id);
+	CREATE INDEX IF NOT EXISTS idx_console_attributions_issue ON console_attributions(issue_repo, issue_number);
 	`
 	_, err := s.db.Exec(schema)
 	if err != nil {
@@ -2920,4 +2938,61 @@ func (s *SQLiteStore) ListClusterGroups() (map[string][]byte, error) {
 		groups[name] = data
 	}
 	return groups, rows.Err()
+}
+
+// ───────────────────────────────────────────────────────────────────────
+// Console attributions — anti-gaming nonces for the rewards leaderboard
+// ───────────────────────────────────────────────────────────────────────
+
+// InsertConsoleAttribution records a freshly-generated attribution nonce.
+// Called by the feedback handler just before it POSTs the issue to GitHub.
+func (s *SQLiteStore) InsertConsoleAttribution(nonce, userID, title string, createdAt time.Time) error {
+	_, err := s.db.Exec(
+		`INSERT INTO console_attributions (nonce, user_id, title, created_at) VALUES (?, ?, ?, ?)`,
+		nonce, userID, title, createdAt,
+	)
+	return err
+}
+
+// LookupConsoleAttribution fetches a stored attribution by nonce. Returns
+// sql.ErrNoRows if the nonce is unknown (either forged or never issued
+// by this backend). The consumed flag indicates whether the attribution
+// has already been linked to an issue — a fresh nonce being looked up
+// during rewards classification has `consumed=false`.
+func (s *SQLiteStore) LookupConsoleAttribution(nonce string) (userID, title string, createdAt time.Time, consumed bool, err error) {
+	var consumedAt sql.NullTime
+	err = s.db.QueryRow(
+		`SELECT user_id, title, created_at, consumed_at FROM console_attributions WHERE nonce = ?`,
+		nonce,
+	).Scan(&userID, &title, &createdAt, &consumedAt)
+	if err != nil {
+		return "", "", time.Time{}, false, err
+	}
+	return userID, title, createdAt, consumedAt.Valid, nil
+}
+
+// MarkConsoleAttributionConsumed links an attribution nonce to the GitHub
+// issue it appeared on and marks it consumed. Idempotent — re-marking an
+// already-consumed nonce with the SAME issue is a no-op, but marking with
+// a DIFFERENT issue fails (indicates replay).
+func (s *SQLiteStore) MarkConsoleAttributionConsumed(nonce, issueRepo string, issueNumber int) error {
+	// Atomic: only mark if not already consumed OR if consumed with the same issue.
+	res, err := s.db.Exec(
+		`UPDATE console_attributions
+		 SET issue_repo = ?, issue_number = ?, consumed_at = CURRENT_TIMESTAMP
+		 WHERE nonce = ?
+		   AND (consumed_at IS NULL OR (issue_repo = ? AND issue_number = ?))`,
+		issueRepo, issueNumber, nonce, issueRepo, issueNumber,
+	)
+	if err != nil {
+		return err
+	}
+	rows, err := res.RowsAffected()
+	if err != nil {
+		return err
+	}
+	if rows == 0 {
+		return fmt.Errorf("attribution nonce %s cannot be consumed (either unknown or replayed on a different issue)", nonce)
+	}
+	return nil
 }

--- a/pkg/store/store.go
+++ b/pkg/store/store.go
@@ -246,6 +246,15 @@ type Store interface {
 	DeleteClusterGroup(name string) error
 	ListClusterGroups() (map[string][]byte, error)
 
+	// Console attributions — HMAC nonces for anti-gaming on the rewards
+	// leaderboard. InsertConsoleAttribution is called when the backend
+	// creates an issue on behalf of a user; LookupConsoleAttribution is
+	// called by the rewards classifier to verify the footer wasn't forged
+	// or replayed.
+	InsertConsoleAttribution(nonce, userID, title string, createdAt time.Time) error
+	LookupConsoleAttribution(nonce string) (userID, title string, createdAt time.Time, consumed bool, err error)
+	MarkConsoleAttributionConsumed(nonce, issueRepo string, issueNumber int) error
+
 	// Lifecycle
 	Close() error
 }

--- a/pkg/test/mock_store.go
+++ b/pkg/test/mock_store.go
@@ -369,4 +369,19 @@ func (m *MockStore) ListClusterGroups() (map[string][]byte, error) {
 	return args.Get(0).(map[string][]byte), args.Error(1)
 }
 
+func (m *MockStore) InsertConsoleAttribution(nonce, userID, title string, createdAt time.Time) error {
+	args := m.Called(nonce, userID, title, createdAt)
+	return args.Error(0)
+}
+
+func (m *MockStore) LookupConsoleAttribution(nonce string) (userID, title string, createdAt time.Time, consumed bool, err error) {
+	args := m.Called(nonce)
+	return args.String(0), args.String(1), args.Get(2).(time.Time), args.Bool(3), args.Error(4)
+}
+
+func (m *MockStore) MarkConsoleAttributionConsumed(nonce, issueRepo string, issueNumber int) error {
+	args := m.Called(nonce, issueRepo, issueNumber)
+	return args.Error(0)
+}
+
 func (m *MockStore) Close() error { return nil }


### PR DESCRIPTION
## Problem

Users were opening issues directly on github.com with a `bug` label to collect the 300-point reward intended for UX-friction-tested console submissions. The rewards classifier had no way to tell where an issue came from.

## Fix

Backend mints an HMAC-signed footer when creating issues via `/api/feedback/submit`. Rewards classifier verifies the signature before awarding 300/100 pts; issues without valid attribution score as 50 pts.

| Attack | Before | After |
|---|---|---|
| Open issue via github.com with `bug` label | 300 pts | 50 pts |
| Forge fake footer on github.com | 300 pts | 50 pts (HMAC fails) |
| Copy valid footer from console issue to new github.com issue | 300 pts | 50 pts (title binding) |
| Reuse same title + footer | 300+300 | 300 + 50 (nonce replay) |

## Required action before merge

Set **`CONSOLE_ATTRIBUTION_SECRET`** as a repo secret — 32+ bytes of random hex. The `.env` on prod needs it too. If unset, the system fails safe (all issues score as web-UI, so rewards drop but never inflate).

## Test plan
- [x] `go test ./pkg/api/handlers/... -run Attribution` — 12 cases pass
- [x] `go build ./...` clean
- [ ] After merge: set `CONSOLE_ATTRIBUTION_SECRET`, submit a test issue via console, verify it gets 300 pts
- [ ] Open a test issue on github.com with bug label, verify it gets 50 pts