### PR TITLE
✨ feat(rewards): GitHub App attribution — unforgeable issue provenance

### DIFF
--- a/pkg/api/handlers/feedback.go
+++ b/pkg/api/handlers/feedback.go
@@ -167,6 +167,12 @@ type FeedbackHandler struct {
 	repoOwner     string
 	repoName      string
 	httpClient    *http.Client // shared HTTP client for connection reuse
+	// appTokenProvider is the kubestellar-console-bot GitHub App. When
+	// configured, issues are created authenticated as the App so the
+	// rewards classifier can distinguish console submissions from
+	// github.com submissions (anti-gaming). Nil means App auth is not
+	// configured and the handler falls back to the PAT in githubToken.
+	appTokenProvider *GitHubAppTokenProvider
 
 	prCacheMu   sync.RWMutex
 	prCache     []GitHubPR
@@ -191,12 +197,13 @@ func NewFeedbackHandler(s store.Store, cfg FeedbackConfig) *FeedbackHandler {
 			"Classic PAT: needs 'repo' scope. Fine-grained PAT: needs 'Issues' + 'Contents' read/write permissions.")
 	}
 	return &FeedbackHandler{
-		store:         s,
-		githubToken:   cfg.GitHubToken,
-		webhookSecret: cfg.WebhookSecret,
-		repoOwner:     cfg.RepoOwner,
-		repoName:      cfg.RepoName,
-		httpClient:    &http.Client{Timeout: githubAPITimeout},
+		store:            s,
+		githubToken:      cfg.GitHubToken,
+		webhookSecret:    cfg.WebhookSecret,
+		repoOwner:        cfg.RepoOwner,
+		repoName:         cfg.RepoName,
+		httpClient:       &http.Client{Timeout: githubAPITimeout},
+		appTokenProvider: NewGitHubAppTokenProvider(),
 	}
 }
 
@@ -1946,7 +1953,22 @@ func (h *FeedbackHandler) postGitHubIssue(repoOwner, repoName, title, body strin
 		return 0, "", err
 	}
 
-	req.Header.Set("Authorization", "Bearer "+h.getEffectiveToken())
+	// Prefer GitHub App installation token when available so the created
+	// issue is attributable via performed_via_github_app (anti-gaming on
+	// the rewards leaderboard). Falls back to the PAT if App auth isn't
+	// configured — see github_app_auth.go.
+	authToken := ""
+	if h.appTokenProvider != nil {
+		if tok, tokErr := h.appTokenProvider.Token(req.Context()); tokErr == nil {
+			authToken = tok
+		} else {
+			slog.Warn("[Feedback] GitHub App token unavailable — falling back to PAT", "error", tokErr)
+		}
+	}
+	if authToken == "" {
+		authToken = h.getEffectiveToken()
+	}
+	req.Header.Set("Authorization", "Bearer "+authToken)
 	req.Header.Set("Accept", "application/vnd.github.v3+json")
 	req.Header.Set("Content-Type", "application/json")
 

--- a/pkg/api/handlers/github_app_auth.go
+++ b/pkg/api/handlers/github_app_auth.go
@@ -1,0 +1,218 @@
+// GitHub App authentication for the kubestellar-console-bot App.
+//
+// Why this exists: the rewards leaderboard awards 300 pts for bugs and
+// 100 pts for features, but only when the issue was submitted through
+// the console UI. Users were gaming this by opening issues directly on
+// github.com with a `bug` label. To prevent that, the console backend
+// creates issues authenticated as a dedicated GitHub App; the rewards
+// classifier then checks GitHub's own `performed_via_github_app` field
+// on each issue — a field GitHub itself sets based on which credentials
+// authenticated the create call, unforgeable by regular users.
+//
+// This file provides a token provider that:
+//   1. Reads the App ID, Installation ID, and Private Key from env vars.
+//   2. Mints a short-lived (10 min) App JWT signed with the private key.
+//   3. Exchanges the JWT for a 60-min installation access token via the
+//      GitHub API.
+//   4. Caches the installation token and refreshes it ~5 min before
+//      expiry so callers always get a valid token without doing their
+//      own refresh logic.
+//
+// Fail-safe: if any of the three env vars is missing, tokenProvider
+// returns an empty token and the handler falls back to the legacy
+// FEEDBACK_GITHUB_TOKEN (PAT) path. The rewards classifier will then
+// treat those issues as web-UI submissions (50 pts), under-awarding
+// rather than over-awarding.
+
+package handlers
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"os"
+	"sync"
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
+)
+
+// ───────────────────────────────────────────────────────────────────────
+// Env var names
+// ───────────────────────────────────────────────────────────────────────
+
+// appIDEnv is the GitHub App ID (numeric string). Set by the console
+// deployment process; sourced from the KUBESTELLAR_CONSOLE_APP_ID repo
+// secret via the deploy workflow.
+const appIDEnv = "KUBESTELLAR_CONSOLE_APP_ID"
+
+// appInstallationIDEnv is the installation ID for the App on the target
+// account (numeric string). Sourced from KUBESTELLAR_CONSOLE_APP_INSTALLATION_ID.
+const appInstallationIDEnv = "KUBESTELLAR_CONSOLE_APP_INSTALLATION_ID"
+
+// appPrivateKeyEnv is the PEM-encoded RSA private key. Sourced from
+// KUBESTELLAR_CONSOLE_APP_PRIVATE_KEY — the whole file contents, newlines and all.
+const appPrivateKeyEnv = "KUBESTELLAR_CONSOLE_APP_PRIVATE_KEY"
+
+// appSlugEnv overrides the expected App slug that the rewards classifier
+// looks for on performed_via_github_app. Defaults to kubestellar-console-bot.
+// Useful in forks / enterprise deployments that rename the App.
+const appSlugEnv = "KUBESTELLAR_CONSOLE_APP_SLUG"
+
+// DefaultConsoleAppSlug is the expected slug of the App that authored
+// console-submitted issues. Rewards classifier checks this against the
+// performed_via_github_app.slug field on each issue.
+const DefaultConsoleAppSlug = "kubestellar-console-bot"
+
+// ───────────────────────────────────────────────────────────────────────
+// Token lifetimes
+// ───────────────────────────────────────────────────────────────────────
+
+// appJWTLifetime is how long the App JWT is valid. GitHub's max is 10
+// minutes; we use the max to minimize the rate of JWT minting.
+const appJWTLifetime = 9 * time.Minute
+
+// tokenRefreshMargin is how long before expiry we proactively refresh.
+// Installation tokens are 60-min; refreshing at 55 min gives callers a
+// 5-min safety buffer in case of clock skew or GitHub API blips.
+const tokenRefreshMargin = 5 * time.Minute
+
+// tokenMintTimeout caps the HTTP call to GitHub's /app/installations/:id/access_tokens.
+const tokenMintTimeout = 15 * time.Second
+
+// ───────────────────────────────────────────────────────────────────────
+// Provider
+// ───────────────────────────────────────────────────────────────────────
+
+// GitHubAppTokenProvider mints and caches installation access tokens for
+// the kubestellar-console-bot App. Safe for concurrent use.
+type GitHubAppTokenProvider struct {
+	appID          string
+	installationID string
+	privateKeyPEM  []byte
+	httpClient     *http.Client
+
+	mu          sync.Mutex
+	cachedToken string
+	expiresAt   time.Time
+}
+
+// NewGitHubAppTokenProvider reads credentials from the standard env vars
+// and returns a provider. Returns nil if any required var is missing —
+// caller should treat nil as "App auth disabled" and fall back to the
+// legacy PAT-based flow. Nil provider + feature flag off is the safe
+// default state during rollout.
+func NewGitHubAppTokenProvider() *GitHubAppTokenProvider {
+	appID := os.Getenv(appIDEnv)
+	installationID := os.Getenv(appInstallationIDEnv)
+	privateKey := os.Getenv(appPrivateKeyEnv)
+	if appID == "" || installationID == "" || privateKey == "" {
+		slog.Info("[GitHubApp] credentials not fully configured — falling back to PAT auth for feedback issues",
+			"app_id_set", appID != "",
+			"installation_id_set", installationID != "",
+			"private_key_set", privateKey != "")
+		return nil
+	}
+	slog.Info("[GitHubApp] token provider initialized",
+		"app_id", appID,
+		"installation_id", installationID)
+	return &GitHubAppTokenProvider{
+		appID:          appID,
+		installationID: installationID,
+		privateKeyPEM:  []byte(privateKey),
+		httpClient:     &http.Client{Timeout: tokenMintTimeout},
+	}
+}
+
+// Token returns a valid installation access token. Uses the cached token
+// if it's valid for at least tokenRefreshMargin; otherwise mints a fresh
+// one. Safe to call on every issue creation — the cache makes this
+// essentially free after the first mint.
+func (p *GitHubAppTokenProvider) Token(ctx context.Context) (string, error) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	if p.cachedToken != "" && time.Until(p.expiresAt) > tokenRefreshMargin {
+		return p.cachedToken, nil
+	}
+
+	tok, exp, err := p.mintInstallationToken(ctx)
+	if err != nil {
+		return "", err
+	}
+	p.cachedToken = tok
+	p.expiresAt = exp
+	return tok, nil
+}
+
+// ExpectedAppSlug returns the App slug the rewards classifier should
+// look for on performed_via_github_app.slug. Reads from the
+// KUBESTELLAR_CONSOLE_APP_SLUG env var, falling back to the default.
+func ExpectedAppSlug() string {
+	if v := os.Getenv(appSlugEnv); v != "" {
+		return v
+	}
+	return DefaultConsoleAppSlug
+}
+
+// mintInstallationToken does the JWT → installation token dance.
+func (p *GitHubAppTokenProvider) mintInstallationToken(ctx context.Context) (string, time.Time, error) {
+	appJWT, err := p.signAppJWT()
+	if err != nil {
+		return "", time.Time{}, fmt.Errorf("sign app JWT: %w", err)
+	}
+
+	url := fmt.Sprintf("%s/app/installations/%s/access_tokens", resolveGitHubAPIBase(), p.installationID)
+	req, err := http.NewRequestWithContext(ctx, "POST", url, nil)
+	if err != nil {
+		return "", time.Time{}, err
+	}
+	req.Header.Set("Authorization", "Bearer "+appJWT)
+	req.Header.Set("Accept", "application/vnd.github+json")
+	req.Header.Set("X-GitHub-Api-Version", "2022-11-28")
+
+	resp, err := p.httpClient.Do(req)
+	if err != nil {
+		return "", time.Time{}, fmt.Errorf("installation token request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusCreated {
+		body, _ := io.ReadAll(resp.Body)
+		return "", time.Time{}, fmt.Errorf("installation token request returned %d: %s", resp.StatusCode, string(body))
+	}
+
+	var result struct {
+		Token     string    `json:"token"`
+		ExpiresAt time.Time `json:"expires_at"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return "", time.Time{}, fmt.Errorf("decode installation token: %w", err)
+	}
+	if result.Token == "" {
+		return "", time.Time{}, fmt.Errorf("installation token response missing token field")
+	}
+	return result.Token, result.ExpiresAt, nil
+}
+
+// signAppJWT produces a short-lived JWT signed with the App private key.
+// This is the credential GitHub accepts to mint installation tokens.
+func (p *GitHubAppTokenProvider) signAppJWT() (string, error) {
+	key, err := jwt.ParseRSAPrivateKeyFromPEM(p.privateKeyPEM)
+	if err != nil {
+		return "", fmt.Errorf("parse RSA private key: %w", err)
+	}
+
+	now := time.Now()
+	claims := jwt.MapClaims{
+		// Issued-at slightly in the past to tolerate clock skew with GitHub.
+		"iat": now.Add(-60 * time.Second).Unix(),
+		"exp": now.Add(appJWTLifetime).Unix(),
+		"iss": p.appID,
+	}
+	token := jwt.NewWithClaims(jwt.SigningMethodRS256, claims)
+	return token.SignedString(key)
+}

--- a/pkg/api/handlers/github_app_auth_test.go
+++ b/pkg/api/handlers/github_app_auth_test.go
@@ -1,0 +1,173 @@
+package handlers
+
+import (
+	"os"
+	"testing"
+)
+
+func TestNewGitHubAppTokenProvider_MissingEnv(t *testing.T) {
+	// Ensure all three env vars are unset.
+	t.Setenv(appIDEnv, "")
+	t.Setenv(appInstallationIDEnv, "")
+	t.Setenv(appPrivateKeyEnv, "")
+
+	p := NewGitHubAppTokenProvider()
+	if p != nil {
+		t.Errorf("expected nil provider when env vars missing, got %v", p)
+	}
+}
+
+func TestNewGitHubAppTokenProvider_PartialEnv(t *testing.T) {
+	// Any missing var should result in nil (fail-safe).
+	cases := []struct {
+		name               string
+		appID              string
+		installationID     string
+		privateKey         string
+	}{
+		{"no private key", "123", "456", ""},
+		{"no app id", "", "456", "key"},
+		{"no installation id", "123", "", "key"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			t.Setenv(appIDEnv, c.appID)
+			t.Setenv(appInstallationIDEnv, c.installationID)
+			t.Setenv(appPrivateKeyEnv, c.privateKey)
+			if p := NewGitHubAppTokenProvider(); p != nil {
+				t.Errorf("expected nil provider for %s, got %v", c.name, p)
+			}
+		})
+	}
+}
+
+func TestExpectedAppSlug_Default(t *testing.T) {
+	os.Unsetenv(appSlugEnv)
+	if got := ExpectedAppSlug(); got != DefaultConsoleAppSlug {
+		t.Errorf("expected default slug %q, got %q", DefaultConsoleAppSlug, got)
+	}
+}
+
+func TestExpectedAppSlug_Override(t *testing.T) {
+	t.Setenv(appSlugEnv, "my-fork-bot")
+	if got := ExpectedAppSlug(); got != "my-fork-bot" {
+		t.Errorf("expected override to apply, got %q", got)
+	}
+}
+
+func TestIsConsoleAppSubmitted(t *testing.T) {
+	t.Setenv(appSlugEnv, "")
+	cases := []struct {
+		name string
+		app  *searchApp
+		want bool
+	}{
+		{"nil app", nil, false},
+		{"wrong slug", &searchApp{Slug: "dependabot"}, false},
+		{"empty slug", &searchApp{Slug: ""}, false},
+		{"matching slug", &searchApp{Slug: DefaultConsoleAppSlug}, true},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			item := searchItem{PerformedViaGitHubApp: c.app}
+			if got := isConsoleAppSubmitted(item); got != c.want {
+				t.Errorf("got %v, want %v", got, c.want)
+			}
+		})
+	}
+}
+
+func TestRequiresAppAttribution(t *testing.T) {
+	cases := []struct {
+		name      string
+		cutoff    string
+		createdAt string
+		want      bool
+	}{
+		{"no cutoff set → disabled", "", "2026-05-01T00:00:00Z", false},
+		{"issue before cutoff → grandfathered", "2026-04-13T00:00:00Z", "2026-04-01T00:00:00Z", false},
+		{"issue after cutoff → enforced", "2026-04-13T00:00:00Z", "2026-05-01T00:00:00Z", true},
+		{"malformed cutoff → fail-safe to disabled", "not-a-timestamp", "2026-05-01T00:00:00Z", false},
+		{"malformed created_at → fail-safe to disabled", "2026-04-13T00:00:00Z", "bogus", false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			t.Setenv(attributionEnforcementCutoffEnv, c.cutoff)
+			if got := requiresAppAttribution(c.createdAt); got != c.want {
+				t.Errorf("got %v, want %v", got, c.want)
+			}
+		})
+	}
+}
+
+func TestClassifyIssue_GrandfatheringBeforeCutoff(t *testing.T) {
+	// Phase 1: cutoff unset. Bug issues get 300 pts regardless of source.
+	t.Setenv(attributionEnforcementCutoffEnv, "")
+	item := searchItem{
+		Title:     "Bug: something broken",
+		CreatedAt: "2026-04-01T00:00:00Z",
+		Labels:    []searchLabel{{Name: "bug"}},
+		// No performed_via_github_app — github.com submission
+	}
+	c := classifyIssue(item)
+	if c.Points != pointsBugIssue {
+		t.Errorf("pre-cutoff bug should get %d pts, got %d", pointsBugIssue, c.Points)
+	}
+}
+
+func TestClassifyIssue_EnforcedAfterCutoff_AppSubmitted(t *testing.T) {
+	// Phase 2: cutoff set, issue is App-submitted → full points.
+	t.Setenv(attributionEnforcementCutoffEnv, "2026-04-13T00:00:00Z")
+	t.Setenv(appSlugEnv, "")
+	item := searchItem{
+		Title:                 "Bug: via console",
+		CreatedAt:             "2026-05-01T00:00:00Z",
+		Labels:                []searchLabel{{Name: "bug"}},
+		PerformedViaGitHubApp: &searchApp{Slug: DefaultConsoleAppSlug},
+	}
+	c := classifyIssue(item)
+	if c.Points != pointsBugIssue {
+		t.Errorf("App-submitted bug should get %d pts, got %d", pointsBugIssue, c.Points)
+	}
+}
+
+func TestClassifyIssue_EnforcedAfterCutoff_NotAppSubmitted(t *testing.T) {
+	// Phase 2: cutoff set, issue NOT App-submitted → dropped to 50 pts.
+	t.Setenv(attributionEnforcementCutoffEnv, "2026-04-13T00:00:00Z")
+	item := searchItem{
+		Title:     "Bug: via github.com",
+		CreatedAt: "2026-05-01T00:00:00Z",
+		Labels:    []searchLabel{{Name: "bug"}},
+		// No performed_via_github_app — github.com submission after cutoff
+	}
+	c := classifyIssue(item)
+	if c.Type != "issue_bug" {
+		t.Errorf("type should still be issue_bug, got %s", c.Type)
+	}
+	if c.Points != pointsOtherIssue {
+		t.Errorf("post-cutoff github.com bug should drop to %d pts, got %d", pointsOtherIssue, c.Points)
+	}
+}
+
+func TestClassifyIssue_EnforcedAfterCutoff_Feature(t *testing.T) {
+	t.Setenv(attributionEnforcementCutoffEnv, "2026-04-13T00:00:00Z")
+	// github.com feature after cutoff → 50 pts
+	github := searchItem{
+		Title:     "Feature: cool idea",
+		CreatedAt: "2026-05-01T00:00:00Z",
+		Labels:    []searchLabel{{Name: "enhancement"}},
+	}
+	if c := classifyIssue(github); c.Points != pointsOtherIssue {
+		t.Errorf("post-cutoff github.com feature should drop to %d, got %d", pointsOtherIssue, c.Points)
+	}
+	// App feature after cutoff → 100 pts
+	app := searchItem{
+		Title:                 "Feature: cool idea",
+		CreatedAt:             "2026-05-01T00:00:00Z",
+		Labels:                []searchLabel{{Name: "enhancement"}},
+		PerformedViaGitHubApp: &searchApp{Slug: DefaultConsoleAppSlug},
+	}
+	if c := classifyIssue(app); c.Points != pointsFeatureIssue {
+		t.Errorf("post-cutoff App feature should get %d, got %d", pointsFeatureIssue, c.Points)
+	}
+}

--- a/pkg/api/handlers/rewards.go
+++ b/pkg/api/handlers/rewards.go
@@ -7,6 +7,7 @@ import (
 	"log/slog"
 	"net/http"
 	"net/url"
+	"os"
 	"sync"
 	"time"
 
@@ -212,13 +213,28 @@ func (h *RewardsHandler) fetchUserRewards(login, token string) (*GitHubRewardsRe
 
 // searchItem is the subset of GitHub Search issue/PR item we care about.
 type searchItem struct {
-	Title       string        `json:"title"`
-	HTMLURL     string        `json:"html_url"`
-	Number      int           `json:"number"`
+	Title   string        `json:"title"`
+	HTMLURL string        `json:"html_url"`
+	Number  int           `json:"number"`
+	// CreatedAt is ISO-8601 — parsed by the rewards classifier to decide
+	// whether to enforce GitHub App attribution (issues created before
+	// the enforcement cutoff are grandfathered to keep the pre-App
+	// reward tier).
 	CreatedAt   string        `json:"created_at"`
 	Labels      []searchLabel `json:"labels"`
 	PullRequest *searchPRRef  `json:"pull_request,omitempty"`
 	RepoURL     string        `json:"repository_url"` // e.g. https://api.github.com/repos/kubestellar/console
+	// PerformedViaGitHubApp is GitHub-set and identifies which App (if
+	// any) authored the issue. Unforgeable by regular users — GitHub
+	// populates it server-side based on the credentials that made the
+	// create call. For console-submitted issues, slug is
+	// DefaultConsoleAppSlug (see github_app_auth.go). For issues opened
+	// directly on github.com, this field is nil.
+	PerformedViaGitHubApp *searchApp `json:"performed_via_github_app,omitempty"`
+}
+
+type searchApp struct {
+	Slug string `json:"slug"`
 }
 
 type searchLabel struct {
@@ -287,19 +303,83 @@ func (h *RewardsHandler) searchItems(login, itemType, token string) ([]searchIte
 	return allItems, nil
 }
 
-// classifyIssue determines the issue type based on labels.
+// attributionEnforcementCutoffEnv is the env var that flips on GitHub
+// App attribution enforcement for the rewards classifier. The value is
+// an RFC 3339 timestamp; only issues created STRICTLY AFTER this time
+// require performed_via_github_app.slug == kubestellar-console-bot to
+// get the console-tier reward (300/100 pts). Issues created before the
+// cutoff are grandfathered at their label-derived points.
+//
+// Rollout:
+//   Phase 1 (this PR, post-merge): leave env var unset. Behavior is
+//     identical to before — every bug label = 300 pts, every feature
+//     label = 100 pts, regardless of where the issue was created.
+//     Console issues start getting App attribution baked in.
+//   Phase 2 (after soak time): set CONSOLE_APP_ATTRIBUTION_CUTOFF to
+//     the merge timestamp. From that moment forward, new github.com
+//     issues drop to 50 pts; new console issues stay at 300/100.
+const attributionEnforcementCutoffEnv = "CONSOLE_APP_ATTRIBUTION_CUTOFF"
+
+// isConsoleAppSubmitted returns true when the issue was created by the
+// kubestellar-console-bot GitHub App. GitHub sets
+// performed_via_github_app server-side based on the credentials that
+// made the create call — unforgeable by regular users.
+func isConsoleAppSubmitted(item searchItem) bool {
+	if item.PerformedViaGitHubApp == nil {
+		return false
+	}
+	return item.PerformedViaGitHubApp.Slug == ExpectedAppSlug()
+}
+
+// requiresAppAttribution reports whether this issue is subject to the
+// App-attribution gate. Returns false for issues created before the
+// cutoff (grandfathered) and when the cutoff is not configured
+// (Phase 1 rollout: no enforcement).
+func requiresAppAttribution(createdAt string) bool {
+	cutoffStr := os.Getenv(attributionEnforcementCutoffEnv)
+	if cutoffStr == "" {
+		return false
+	}
+	cutoff, err := time.Parse(time.RFC3339, cutoffStr)
+	if err != nil {
+		slog.Warn("[rewards] invalid "+attributionEnforcementCutoffEnv+" — enforcement disabled", "value", cutoffStr, "error", err)
+		return false
+	}
+	created, err := time.Parse(time.RFC3339, createdAt)
+	if err != nil {
+		// Malformed issue timestamps are rare but non-fatal; default to
+		// grandfathering so we don't accidentally drop points on legit issues.
+		return false
+	}
+	return created.After(cutoff)
+}
+
+// classifyIssue determines the issue type and point value. After the
+// App-attribution cutoff, bug/feature labels only award console-tier
+// points when the issue was authored by the kubestellar-console-bot App.
+// Before the cutoff, all labels are awarded at their full rate.
 func classifyIssue(item searchItem) GitHubContribution {
 	typ := "issue_other"
 	points := pointsOtherIssue
+
+	// Attribution gate: after the cutoff, only App-created issues get
+	// the console-tier point values. See requiresAppAttribution.
+	enforce := requiresAppAttribution(item.CreatedAt)
+	consoleSubmitted := isConsoleAppSubmitted(item)
 
 	for _, label := range item.Labels {
 		switch label.Name {
 		case "bug", "kind/bug", "type/bug":
 			typ = "issue_bug"
-			points = pointsBugIssue
+			if !enforce || consoleSubmitted {
+				points = pointsBugIssue
+			}
+			// else: keep pointsOtherIssue (50) — github.com submission after cutoff
 		case "enhancement", "feature", "kind/feature", "type/feature":
 			typ = "issue_feature"
-			points = pointsFeatureIssue
+			if !enforce || consoleSubmitted {
+				points = pointsFeatureIssue
+			}
 		}
 	}
 


### PR DESCRIPTION
## Problem
Users were opening issues directly on github.com with a \`bug\` label for 300 pts (meant for UX-tested console submissions). No way to distinguish console submissions from web-UI ones. Supersedes #7854 (HMAC approach — had shared-secret issues).

## Fix
Route console-submitted issues through the \`kubestellar-console-bot\` GitHub App. GitHub itself stamps \`performed_via_github_app.slug\` server-side based on authentication — **unforgeable by regular users**. No shared secret on the backend for the rewards classifier to verify; the backend only needs the App private key (repo secret) to mint short-lived installation tokens for the creation side.

## Two-phase rollout (via \`CONSOLE_APP_ATTRIBUTION_CUTOFF\`)
- **Phase 1 (this merge)** — env var unset. All issues score by label as today. Console issues start accumulating App attribution in \`performed_via_github_app\`.
- **Phase 2 (after soak)** — set \`CONSOLE_APP_ATTRIBUTION_CUTOFF\` to an RFC 3339 timestamp. Issues created AFTER that require App attribution for 300/100 pts; github.com issues after the cutoff drop to 50. Pre-cutoff issues grandfathered.

## Required secrets (already set on kubestellar/console)
- \`KUBESTELLAR_CONSOLE_APP_ID\` = 3370029
- \`KUBESTELLAR_CONSOLE_APP_INSTALLATION_ID\` = 123750819
- \`KUBESTELLAR_CONSOLE_APP_PRIVATE_KEY\` (from \`gh secret set\`)

## Ops: injecting secrets into the backend
The backend must receive these three env vars at runtime. Deployment workflow should read the repo secrets and inject into the console pod's env. Today that likely means updating the Helm values / Kubernetes Secret with these three keys.

## Threat matrix
| Attack | Before | After Phase 2 |
|---|---|---|
| Open issue via github.com with \`bug\` label | 300 pts | 50 pts |
| Forge \`performed_via_github_app\` in issue body | — | 50 pts (GitHub sets this field, not user input) |
| Steal App private key | — | Attacker can create fake issues as App, UNTIL you rotate (GitHub UI → regenerate key) |

## Test plan
- [x] 16 unit tests pass (\`go test -run 'TestNewGitHubApp|TestExpectedApp|TestIsConsoleApp|TestRequiresApp|TestClassifyIssue' ./pkg/api/handlers/...\`)
- [x] Build clean
- [ ] Deploy, verify console issues show \`performed_via_github_app.slug = kubestellar-console-bot\` on GitHub
- [ ] After a few days of soak, set \`CONSOLE_APP_ATTRIBUTION_CUTOFF\` to flip on enforcement