### PR TITLE
🐛 fix(card-wrapper): prevent Resize/Height submenu overlap

### DIFF
--- a/web/src/components/cards/CardWrapper.tsx
+++ b/web/src/components/cards/CardWrapper.tsx
@@ -1149,7 +1149,10 @@ export function CardWrapper({
                       {onWidthChange && (
                         <div className="relative" ref={menuContainerRef}>
                           <button
-                            onClick={() => setShowResizeMenu(!showResizeMenu)}
+                            onClick={() => {
+                              setShowResizeMenu(!showResizeMenu)
+                              setShowHeightMenu(false)
+                            }}
                             className="w-full px-4 py-2 text-left text-sm text-muted-foreground hover:text-foreground hover:bg-secondary/50 flex items-center justify-between"
                             role="menuitem"
                             aria-haspopup="menu"
@@ -1206,7 +1209,10 @@ export function CardWrapper({
                       {onHeightChange && (
                         <div className="relative" ref={heightMenuContainerRef}>
                           <button
-                            onClick={() => setShowHeightMenu(!showHeightMenu)}
+                            onClick={() => {
+                              setShowHeightMenu(!showHeightMenu)
+                              setShowResizeMenu(false)
+                            }}
                             className="w-full px-4 py-2 text-left text-sm text-muted-foreground hover:text-foreground hover:bg-secondary/50 flex items-center justify-between"
                             role="menuitem"
                             aria-haspopup="menu"


### PR DESCRIPTION
## Summary
- In the card menu, clicking **Height** while the **Resize** submenu was open caused both submenus to render on top of each other.
- Fix: opening either submenu now closes the other, so only one is visible at a time.

## Test plan
- [ ] Open any card's ⋯ menu, click **Resize**, then click **Height** → only Height submenu shows.
- [ ] Click **Height** first, then **Resize** → only Resize submenu shows.
- [ ] Clicking the same submenu toggle twice still closes it.