### PR TITLE
🐛 fix(card-wrapper): height submenu position + close-menu state reset (#7869)

### DIFF
--- a/web/src/components/cards/CardWrapper.tsx
+++ b/web/src/components/cards/CardWrapper.tsx
@@ -624,6 +624,7 @@ export function CardWrapper({
   const [showResizeMenu, setShowResizeMenu] = useState(false)
   const [showHeightMenu, setShowHeightMenu] = useState(false)
   const [resizeMenuOnLeft, setResizeMenuOnLeft] = useState(false)
+  const [heightMenuOnLeft, setHeightMenuOnLeft] = useState(false)
   const heightMenuContainerRef = useRef<HTMLDivElement>(null)
   const [__timeRemaining, setTimeRemaining] = useState<number | null>(null)
   // Chat state reserved for future use
@@ -801,10 +802,11 @@ export function CardWrapper({
     }
   }
 
-  // Close resize submenu when main menu closes
+  // Close resize/height submenus when main menu closes (#7869)
   useEffect(() => {
     if (!showMenu) {
       setShowResizeMenu(false)
+      setShowHeightMenu(false)
       setMenuPosition(null)
     }
   }, [showMenu])
@@ -881,16 +883,27 @@ export function CardWrapper({
     return () => document.removeEventListener('mousedown', handleClickOutside)
   }, [showMenu])
 
-  // Calculate if resize submenu should be on the left side
+  // Calculate if Resize/Height submenu should flip to the left side.
+  // Height uses its own state so opening Height after Width recomputes position (#7869).
+  /** Submenu width — matches w-36 tailwind class (9rem = 144px). */
+  const SUBMENU_WIDTH_PX = 144
+  /** Right-edge margin before flipping submenu to the left side. */
+  const SUBMENU_EDGE_MARGIN_PX = 20
   useEffect(() => {
     if (showResizeMenu && menuContainerRef.current) {
       const rect = menuContainerRef.current.getBoundingClientRect()
-      const submenuWidth = 144 // w-36 = 9rem = 144px
-      const margin = 20
-      const shouldBeOnLeft = rect.right + submenuWidth + margin > window.innerWidth
+      const shouldBeOnLeft = rect.right + SUBMENU_WIDTH_PX + SUBMENU_EDGE_MARGIN_PX > window.innerWidth
       setResizeMenuOnLeft(shouldBeOnLeft)
     }
   }, [showResizeMenu])
+
+  useEffect(() => {
+    if (showHeightMenu && heightMenuContainerRef.current) {
+      const rect = heightMenuContainerRef.current.getBoundingClientRect()
+      const shouldBeOnLeft = rect.right + SUBMENU_WIDTH_PX + SUBMENU_EDGE_MARGIN_PX > window.innerWidth
+      setHeightMenuOnLeft(shouldBeOnLeft)
+    }
+  }, [showHeightMenu])
 
   // Silence unused variable warnings for future chat implementation
   void messages
@@ -1229,7 +1242,7 @@ export function CardWrapper({
                             <div
                               className={cn(
                                 'absolute top-0 w-36 glass rounded-lg py-1 z-20',
-                                resizeMenuOnLeft ? 'right-full mr-1' : 'left-full ml-1'
+                                heightMenuOnLeft ? 'right-full mr-1' : 'left-full ml-1'
                               )}
                               role="menu"
                               onKeyDown={(e) => {


### PR DESCRIPTION
## Summary

Addresses 2 Copilot review comments on merged PR #7866.

- **Height submenu position was stale**: `resizeMenuOnLeft` drove both Width and Height submenu flip-to-left logic, but was only recalculated when Width opened. Added `heightMenuOnLeft` with its own effect keyed on `showHeightMenu`.
- **Height submenu survived main menu close**: the close effect reset `showResizeMenu` but not `showHeightMenu`. Added `setShowHeightMenu(false)` alongside the existing reset.
- **Extracted magic numbers**: `144`/`20` → `SUBMENU_WIDTH_PX` / `SUBMENU_EDGE_MARGIN_PX`.

Fixes #7869

## Test plan

- [x] `npm run build` passes locally
- [x] `npm run lint` — no new CardWrapper findings
- [ ] Open card menu near the right edge of the viewport, open Height submenu first — should flip to the left.
- [ ] Open Width, then Height — Height should recompute its flip independently.
- [ ] Open Height submenu, click outside the card menu — both main menu and Height submenu should close.

🤖 Generated with [Claude Code](https://claude.com/claude-code)