### PR TITLE
🐛 fix(ci): fullstack-smoke — remove DEV_MODE so `/` serves the built SPA

### DIFF
--- a/.github/workflows/fullstack-e2e.yml
+++ b/.github/workflows/fullstack-e2e.yml
@@ -67,12 +67,15 @@ jobs:
       - name: Start Go backend in background
         env:
           JWT_SECRET: ${{ env.DEV_JWT_SECRET }}
-          # Dev mode — do not require real OAuth creds. The Go backend reads
-          # DEV_MODE (see cmd/console/main.go and pkg/api/server.go); the
-          # previous CONSOLE_ENV value was ignored by the binary.
-          DEV_MODE: 'true'
           PORT: ${{ env.BACKEND_PORT }}
         run: |
+          # Intentionally NOT setting DEV_MODE=true — the whole point of
+          # fullstack-smoke is to exercise the production serving path where
+          # the Go binary serves ./web/dist/index.html directly (see
+          # pkg/api/server.go:1221-1240). With DEV_MODE=true the root route
+          # 307-redirects to FrontendURL (Vite), which isn't running in CI,
+          # so the Playwright page.goto on '/' sees ERR_CONNECTION_REFUSED
+          # while the /healthz + /api/version tests still pass (#6362).
           /tmp/console-binary > /tmp/console.log 2>&1 &
           echo $! > /tmp/console.pid
           echo "Backend PID: $(cat /tmp/console.pid)"


### PR DESCRIPTION
## Summary

The `Full-Stack E2E Smoke` workflow has been red on every PR because it starts the Go binary with `DEV_MODE=true`, which makes `GET /` 307-redirect to the Vite dev server (which isn't running in CI). Playwright's `page.goto('/')` then sees `ERR_CONNECTION_REFUSED`.

The whole point of this job (kubestellar/console#6362) is to exercise the **production** serving path — single Go binary serving the built `web/dist/` SPA. DEV_MODE bypasses exactly that path. The `/healthz` and `/api/version` assertions pass in both modes, which is why only one of three tests failed each run.

Removing `DEV_MODE=true` makes the server take the production branch (`preCompressedStatic("./web/dist")` + `SendFile("./web/dist/index.html")`) — which is what the test is written against.

## Test plan

- [ ] `Full-Stack E2E Smoke` job goes green on this PR (the only real verification — this is a workflow-file change, no local reproduction possible without rebuilding the full binary).

🤖 Generated with [Claude Code](https://claude.com/claude-code)