### PR TITLE
fix(drasi): narrow node blocks for more trunk-line breathing room

### DIFF
--- a/web/src/components/cards/drasi/DrasiReactiveGraph.tsx
+++ b/web/src/components/cards/drasi/DrasiReactiveGraph.tsx
@@ -35,8 +35,10 @@ const FLOW_DOT_CYCLE_S = 2
 const LINE_STROKE_WIDTH_PX = 1.2
 /** Flow dot radius in pixels */
 const FLOW_DOT_RADIUS_PX = 3
-/** Horizontal gap reserved for trunk lines between columns (px) */
-const TRUNK_GAP_PX = 42
+/** Max node-card width so the trunk/branch lines have breathing room */
+const NODE_MAX_WIDTH_PX = 220
+/** Max width for the queries column (wider to fit nested results table) */
+const QUERY_MAX_WIDTH_PX = 300
 
 // ---------------------------------------------------------------------------
 // Types
@@ -936,7 +938,13 @@ export function DrasiReactiveGraph() {
         <div
           className="relative grid h-full"
           style={{
-            gridTemplateColumns: `minmax(0, 1fr) ${TRUNK_GAP_PX}px minmax(0, 2fr) ${TRUNK_GAP_PX}px minmax(0, 1fr)`,
+            // Blocks are capped at explicit max widths so the 1fr trunk
+            // columns absorb the remaining width — gives the SVG flow
+            // lines + animated dots plenty of horizontal room.
+            gridTemplateColumns:
+              `minmax(0, ${NODE_MAX_WIDTH_PX}px) minmax(40px, 1fr) ` +
+              `minmax(0, ${QUERY_MAX_WIDTH_PX}px) minmax(40px, 1fr) ` +
+              `minmax(0, ${NODE_MAX_WIDTH_PX}px)`,
             zIndex: 1,
           }}
         >


### PR DESCRIPTION
## Summary
Blocks were filling their full 1fr/2fr grid columns with only a ~42px sliver between them for the trunk lines and animated flow dots. Cap each block column at an explicit max width and let trunk columns grow with 1fr so the SVG lines + dots get more horizontal space.

- Source/reaction columns: max 220px
- Queries column: max 300px (wider for the nested results table)
- Trunk columns: min 40px, 1fr

🤖 Generated with [Claude Code](https://claude.com/claude-code)