### PR TITLE
🐛 fix(nodes): Node Conditions filter pill ring clipped top/bottom (#7881)

### DIFF
--- a/web/src/components/cards/NodeConditions.tsx
+++ b/web/src/components/cards/NodeConditions.tsx
@@ -179,7 +179,11 @@ export function NodeConditions() {
               onClick={() => setFilter(f)}
               title={`${filterLabels[f]}: ${count}`}
               className={`px-2 py-1 rounded-full transition-colors max-w-full truncate ${
-                filter === f ? colors[f] + ' ring-1 ring-current' : 'bg-muted/30 text-muted-foreground hover:bg-muted/50'
+                // ring-inset keeps the selected-state ring inside the pill's
+                // border-box so the parent `overflow-hidden` (kept to guard
+                // against long translated labels overflowing the card per
+                // #6457) doesn't clip the top/bottom 1px of the ring (#7881).
+                filter === f ? colors[f] + ' ring-1 ring-inset ring-current' : 'bg-muted/30 text-muted-foreground hover:bg-muted/50'
               }`}
             >
               {filterLabels[f]}: {count}


### PR DESCRIPTION
## Summary

The filter pills on the Node Conditions card (`NodeConditions.tsx`) have their selected-state ring clipped on the top and bottom.

Root cause: the pill `<button>` has `ring-1 ring-current` and the pill-row `<div>` has `overflow-hidden` (kept to prevent long translated labels overflowing the card per #6457). A non-inset ring renders outside the border-box, so the 1px strips above/below each pill get chopped off by the overflow guard.

Fix: add `ring-inset`. Ring draws inside the border-box, no layout shift, overflow guard preserved.

Reporter screenshot clearly shows the "Healthy: 3" green ring intact on left/right but flush at top/bottom.

## Test plan

- [x] `npm run build` passes locally
- [x] `eslint` clean on the file
- [ ] Visual: selected pill in Node Conditions card has a continuous border around all four edges
- [ ] CI (build + lint + preview) green

Fixes #7881

🤖 Generated with [Claude Code](https://claude.com/claude-code)