### PR TITLE
♿ fix(drasi): flow-dot SMIL animation ignores prefers-reduced-motion (#7885)

### DIFF
--- a/web/src/components/cards/drasi/DrasiReactiveGraph.tsx
+++ b/web/src/components/cards/drasi/DrasiReactiveGraph.tsx
@@ -11,7 +11,7 @@
  * Uses live Drasi API data when available, demo data when in demo mode.
  */
 import React, { useState, useEffect, useMemo, useCallback, useRef, useLayoutEffect } from 'react'
-import { motion, AnimatePresence } from 'framer-motion'
+import { motion, AnimatePresence, useReducedMotion } from 'framer-motion'
 import {
   Database, Globe, Search, Radio,
   TrendingDown, TrendingUp, Maximize2, Pin, Square, X, Settings,
@@ -364,7 +364,11 @@ const TRAFFIC_PATTERNS: ReadonlyArray<ReadonlyArray<number>> = [
 ]
 
 function FlowLine({ d, dashed, active = true, delay = 0, lineKey = '' }: FlowLineProps & { lineKey?: string }) {
-  const isAnimated = active && !dashed
+  // SVG SMIL <animateMotion> is NOT controlled by the global
+  // `@media (prefers-reduced-motion: reduce)` CSS rules, so we must gate
+  // the animated flow dots behind a JS check of the user preference (#7885).
+  const prefersReducedMotion = useReducedMotion()
+  const isAnimated = active && !dashed && !prefersReducedMotion
   // Per-line cycle duration varies so flows aren't synchronized.
   const lineDur = FLOW_DOT_CYCLE_S + seededRand(lineKey, 1) * 3  // 5s–8s
   // Pick a traffic pattern deterministically from the line key.


### PR DESCRIPTION
## Summary

SVG SMIL `<animateMotion>` on the Drasi graph flow-dots is not controlled by the global `@media (prefers-reduced-motion: reduce)` CSS rules in `web/src/index.css`. Users who set *Reduce motion* in their OS were still seeing continuously animating dots along the edges.

## Change

- Import `useReducedMotion` from `framer-motion` (already a dependency)
- In `FlowLine`, OR the user preference into the existing `isAnimated` guard so the animated `<circle>` / `<animateMotion>` elements are skipped when reduced motion is preferred
- The edge path itself still renders — graph structure remains readable

## Test plan

- [x] `npm run build` — clean
- [x] `npx eslint src/components/cards/drasi/DrasiReactiveGraph.tsx` — no new errors (1 pre-existing `set-state-in-effect` error on main, unchanged)
- [ ] Enable *Reduce motion* in OS settings → open Drasi card → verify flow dots are absent while lines still draw

Fixes #7885

🤖 Generated with [Claude Code](https://claude.com/claude-code)