### PR TITLE
🐛 fix(compliance): Overview tab default + informative, pagination reads as single control (#7892, #7893, #7895)

### DIFF
--- a/web/src/components/cards/compliance/ComplianceScoreBreakdownModal.tsx
+++ b/web/src/components/cards/compliance/ComplianceScoreBreakdownModal.tsx
@@ -189,7 +189,7 @@ function OverviewTab({ score, breakdown, scoreCtx, kubescapeData, kyvernoData }:
         <p className="text-xs text-muted-foreground mt-0.5">{scoreCtx.description}</p>
       </div>
 
-      {/* Aggregate stats — makes the Overview tab informative even when a single tool is connected. Fixes #7893. */}
+      {/* Aggregate stats — makes the Overview tab informative even when a single tool is connected. */}
       {totalChecks > 0 && (
         <div className="grid grid-cols-3 gap-3">
           <StatBox label="Total Checks" value={totalChecks} />

--- a/web/src/components/cards/compliance/ComplianceScoreBreakdownModal.tsx
+++ b/web/src/components/cards/compliance/ComplianceScoreBreakdownModal.tsx
@@ -41,17 +41,26 @@ const MODAL_TYPE = 'compliance_score'
 /** Maximum top failing items to show per tool */
 const MAX_TOP_FAILING = 5
 
+/** Tab id for the always-present Overview tab. */
+const OVERVIEW_TAB_ID = 'Overview'
+
+/** Score thresholds for color grading. Keep in sync with getScoreContext(). */
+const SCORE_GOOD_THRESHOLD = 80
+const SCORE_WARN_THRESHOLD = 60
+
 export function ComplianceScoreBreakdownModal({
   isOpen, onClose, score, breakdown, kubescapeData, kyvernoData }: ComplianceScoreBreakdownModalProps) {
   const toolNames = breakdown.map(b => b.name)
-  const [activeTab, setActiveTab] = useState(toolNames[0] || 'Overview')
+  // Default to Overview — clicking the percentage shows score context first,
+  // then users drill into per-tool tabs. Fixes #7892.
+  const [activeTab, setActiveTab] = useState(OVERVIEW_TAB_ID)
   const openTimeRef = useRef<number>(0)
 
   useEffect(() => {
     if (isOpen) {
       openTimeRef.current = Date.now()
       emitModalOpened(MODAL_TYPE, 'compliance_score')
-      setActiveTab(toolNames[0] || 'Overview')
+      setActiveTab(OVERVIEW_TAB_ID)
     }
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isOpen])
@@ -76,10 +85,9 @@ export function ComplianceScoreBreakdownModal({
     label: name,
     badge: String(breakdown.find(b => b.name === name)?.value ?? '—') + '%' }))
 
-  // Add overview tab if multiple tools
-  if (tabs.length > 1) {
-    tabs.unshift({ id: 'Overview', label: 'Overview', badge: `${score}%` })
-  }
+  // Always include Overview — it's the landing tab and summarizes the aggregate
+  // across all tools so the modal has context even with a single tool. Fixes #7893.
+  tabs.unshift({ id: OVERVIEW_TAB_ID, label: OVERVIEW_TAB_ID, badge: `${score}%` })
 
   return (
     <BaseModal isOpen={isOpen} onClose={handleClose} size="lg">
@@ -100,8 +108,14 @@ export function ComplianceScoreBreakdownModal({
         <BaseModal.Tabs tabs={tabs} activeTab={activeTab} onTabChange={handleTabChange} />
       )}
       <BaseModal.Content>
-        {activeTab === 'Overview' && (
-          <OverviewTab score={score} breakdown={breakdown} scoreCtx={scoreCtx} />
+        {activeTab === OVERVIEW_TAB_ID && (
+          <OverviewTab
+            score={score}
+            breakdown={breakdown}
+            scoreCtx={scoreCtx}
+            kubescapeData={kubescapeData}
+            kyvernoData={kyvernoData}
+          />
         )}
         {activeTab === 'Kubescape' && (
           kubescapeData
@@ -114,7 +128,7 @@ export function ComplianceScoreBreakdownModal({
             : <ToolDataUnavailable tool="Kyverno" />
         )}
         {/* Fallback for tools without detailed data */}
-        {activeTab !== 'Overview' && activeTab !== 'Kubescape' && activeTab !== 'Kyverno' && (
+        {activeTab !== OVERVIEW_TAB_ID && activeTab !== 'Kubescape' && activeTab !== 'Kyverno' && (
           <div className="text-center py-8 text-muted-foreground">
             <p className="text-sm">Score: {breakdown.find(b => b.name === activeTab)?.value}%</p>
             <p className="text-xs mt-1">Detailed breakdown not available for {activeTab}</p>
@@ -126,7 +140,32 @@ export function ComplianceScoreBreakdownModal({
   )
 }
 
-function OverviewTab({ score, breakdown, scoreCtx }: { score: number; breakdown: ToolBreakdown[]; scoreCtx: { label: string; color: string; description: string } }) {
+function OverviewTab({ score, breakdown, scoreCtx, kubescapeData, kyvernoData }: {
+  score: number
+  breakdown: ToolBreakdown[]
+  scoreCtx: { label: string; color: string; description: string }
+  kubescapeData?: ComplianceScoreBreakdownModalProps['kubescapeData']
+  kyvernoData?: ComplianceScoreBreakdownModalProps['kyvernoData']
+}) {
+  // Aggregate checks across tools to show a global total even when an individual tool is empty.
+  const kubescapeTotal = kubescapeData?.totalControls ?? 0
+  const kubescapePassed = kubescapeData?.passedControls ?? 0
+  const kubescapeFailed = kubescapeData?.failedControls ?? 0
+
+  const kyvernoTotal = kyvernoData?.totalPolicies ?? 0
+  const kyvernoFailed = kyvernoData?.totalViolations ?? 0
+  const kyvernoPassed = Math.max(0, kyvernoTotal - kyvernoFailed)
+
+  const totalChecks = kubescapeTotal + kyvernoTotal
+  const totalPassed = kubescapePassed + kyvernoPassed
+  const totalFailed = kubescapeFailed + kyvernoFailed
+
+  const scoreColorClass = score >= SCORE_GOOD_THRESHOLD
+    ? 'text-green-400'
+    : score >= SCORE_WARN_THRESHOLD
+      ? 'text-yellow-400'
+      : 'text-red-400'
+
   return (
     <div className="space-y-4">
       {/* Score gauge */}
@@ -137,7 +176,7 @@ function OverviewTab({ score, breakdown, scoreCtx }: { score: number; breakdown:
             <circle
               cx="18" cy="18" r="16" fill="none" stroke="currentColor" strokeWidth="3"
               strokeDasharray={`${score}, 100`}
-              className={score >= 80 ? 'text-green-400' : score >= 60 ? 'text-yellow-400' : 'text-red-400'}
+              className={scoreColorClass}
             />
           </svg>
           <div className="absolute inset-0 flex flex-col items-center justify-center">
@@ -150,25 +189,45 @@ function OverviewTab({ score, breakdown, scoreCtx }: { score: number; breakdown:
         <p className="text-xs text-muted-foreground mt-0.5">{scoreCtx.description}</p>
       </div>
 
+      {/* Aggregate stats — makes the Overview tab informative even when a single tool is connected. Fixes #7893. */}
+      {totalChecks > 0 && (
+        <div className="grid grid-cols-3 gap-3">
+          <StatBox label="Total Checks" value={totalChecks} />
+          <StatBox label="Passing" value={totalPassed} color="text-green-400" />
+          <StatBox label="Failing" value={totalFailed} color="text-red-400" />
+        </div>
+      )}
+
       {/* Per-tool bars */}
-      <div className="space-y-3">
-        {(breakdown || []).map(item => (
-          <div key={item.name} className="space-y-1">
-            <div className="flex items-center justify-between">
-              <span className="text-sm font-medium text-foreground">{item.name}</span>
-              <span className={`text-sm font-bold ${item.value >= 80 ? 'text-green-400' : item.value >= 60 ? 'text-yellow-400' : 'text-red-400'}`}>
-                {item.value}%
-              </span>
+      {breakdown && breakdown.length > 0 && (
+        <div className="space-y-3">
+          <h4 className="text-xs font-medium text-muted-foreground">By tool</h4>
+          {breakdown.map(item => (
+            <div key={item.name} className="space-y-1">
+              <div className="flex items-center justify-between">
+                <span className="text-sm font-medium text-foreground">{item.name}</span>
+                <span className={`text-sm font-bold ${item.value >= SCORE_GOOD_THRESHOLD ? 'text-green-400' : item.value >= SCORE_WARN_THRESHOLD ? 'text-yellow-400' : 'text-red-400'}`}>
+                  {item.value}%
+                </span>
+              </div>
+              <div className="h-2 rounded-full bg-secondary overflow-hidden">
+                <div
+                  className={`h-full rounded-full transition-all ${item.value >= SCORE_GOOD_THRESHOLD ? 'bg-green-400/60' : item.value >= SCORE_WARN_THRESHOLD ? 'bg-yellow-400/60' : 'bg-red-400/60'}`}
+                  style={{ width: `${item.value}%` }}
+                />
+              </div>
             </div>
-            <div className="h-2 rounded-full bg-secondary overflow-hidden">
-              <div
-                className={`h-full rounded-full transition-all ${item.value >= 80 ? 'bg-green-400/60' : item.value >= 60 ? 'bg-yellow-400/60' : 'bg-red-400/60'}`}
-                style={{ width: `${item.value}%` }}
-              />
-            </div>
-          </div>
-        ))}
-      </div>
+          ))}
+        </div>
+      )}
+
+      {/* Empty state — no tool data at all */}
+      {totalChecks === 0 && (!breakdown || breakdown.length === 0) && (
+        <div className="text-center py-4 text-muted-foreground">
+          <p className="text-sm">No compliance tools are reporting data.</p>
+          <p className="text-xs mt-1">Install Kubescape or Kyverno in a connected cluster to see detailed breakdowns.</p>
+        </div>
+      )}
     </div>
   )
 }

--- a/web/src/components/drilldown/views/ComplianceDrillDown.tsx
+++ b/web/src/components/drilldown/views/ComplianceDrillDown.tsx
@@ -421,7 +421,7 @@ export function ComplianceDrillDown({ data }: Props) {
           <div className="flex items-center gap-1">
             {/* First/Last use the single-glyph ChevronsLeft/ChevronsRight (double-chevron)
                 instead of two overlapping single chevrons — reads as one control instead of
-                two arrows side-by-side. Fixes #7895. */}
+                two arrows side-by-side. */}
             <button
               onClick={() => setPage(0)}
               disabled={page === 0}

--- a/web/src/components/drilldown/views/ComplianceDrillDown.tsx
+++ b/web/src/components/drilldown/views/ComplianceDrillDown.tsx
@@ -11,6 +11,7 @@ import { useTranslation } from 'react-i18next'
 import {
   Shield, CheckCircle, XCircle, AlertCircle, Info,
   ChevronUp, ChevronDown, ChevronLeft, ChevronRight,
+  ChevronsLeft, ChevronsRight,
   Search, X, Filter } from 'lucide-react'
 import { useTrestle, type OscalControlResult } from '../../../hooks/useTrestle'
 import { useGlobalFilters } from '../../../hooks/useGlobalFilters'
@@ -418,20 +419,24 @@ export function ComplianceDrillDown({ data }: Props) {
             Showing {page * PAGE_SIZE + 1}--{Math.min((page + 1) * PAGE_SIZE, sortedRows.length)} of {sortedRows.length} controls
           </span>
           <div className="flex items-center gap-1">
+            {/* First/Last use the single-glyph ChevronsLeft/ChevronsRight (double-chevron)
+                instead of two overlapping single chevrons — reads as one control instead of
+                two arrows side-by-side. Fixes #7895. */}
             <button
               onClick={() => setPage(0)}
               disabled={page === 0}
               className="p-1.5 rounded hover:bg-card/50 disabled:opacity-30 disabled:cursor-not-allowed transition-colors"
               title="First page"
+              aria-label="First page"
             >
-              <ChevronLeft className="w-4 h-4" />
-              <ChevronLeft className="w-4 h-4 -ml-3" />
+              <ChevronsLeft className="w-4 h-4" />
             </button>
             <button
               onClick={() => setPage(p => Math.max(0, p - 1))}
               disabled={page === 0}
               className="p-1.5 rounded hover:bg-card/50 disabled:opacity-30 disabled:cursor-not-allowed transition-colors"
               title="Previous page"
+              aria-label="Previous page"
             >
               <ChevronLeft className="w-4 h-4" />
             </button>
@@ -443,6 +448,7 @@ export function ComplianceDrillDown({ data }: Props) {
               disabled={page >= totalPages - 1}
               className="p-1.5 rounded hover:bg-card/50 disabled:opacity-30 disabled:cursor-not-allowed transition-colors"
               title="Next page"
+              aria-label="Next page"
             >
               <ChevronRight className="w-4 h-4" />
             </button>
@@ -451,9 +457,9 @@ export function ComplianceDrillDown({ data }: Props) {
               disabled={page >= totalPages - 1}
               className="p-1.5 rounded hover:bg-card/50 disabled:opacity-30 disabled:cursor-not-allowed transition-colors"
               title="Last page"
+              aria-label="Last page"
             >
-              <ChevronRight className="w-4 h-4" />
-              <ChevronRight className="w-4 h-4 -ml-3" />
+              <ChevronsRight className="w-4 h-4" />
             </button>
           </div>
         </div>


### PR DESCRIPTION
## Summary

Three UX fixes to the compliance dashboard experience, grouped because they all touch the same drill-down flow.

### Compliance Score modal (`ComplianceScoreBreakdownModal`)
- **Default to the Overview tab** when the modal opens, instead of the first tool tab. Clicking the compliance percentage is a request to see score context first; users drill into per-tool tabs afterward.
- **Always render the Overview tab**, not just when multiple tools are connected. A single-tool deployment still benefits from the aggregate view.
- **Aggregate stats in Overview** — Total Checks / Passing / Failing rolled up across Kubescape + Kyverno, plus a clear empty-state when no tools are reporting.

### Compliance drill-down pagination (`ComplianceDrillDown`)
- Replace the two overlapping `<ChevronLeft/>` / `<ChevronRight/>` icons used for First/Last page buttons with lucide's single-glyph `ChevronsLeft` / `ChevronsRight`. Reads as one control per button instead of "multiple arrows".
- Added `aria-label` to every pagination button.

Fixes #7892
Fixes #7893
Fixes #7895

## Test plan
- [x] `npm run build` passes locally
- [x] `npm run lint` no new warnings/errors on edited files
- [ ] Overview tab is active by default when opening the modal
- [ ] Overview renders aggregate stats when Kubescape/Kyverno data present
- [ ] Overview renders empty-state when no tool data
- [ ] Pagination First/Last buttons show a single double-chevron glyph