### PR TITLE
🐛 fix(tests): use t.TempDir() in TestMetricsHistory to stop nightly release flake (#7898, #7899)

### DIFF
--- a/pkg/agent/metrics_history_test.go
+++ b/pkg/agent/metrics_history_test.go
@@ -1,7 +1,6 @@
 package agent
 
 import (
-	"os"
 	"testing"
 	"time"
 
@@ -19,11 +18,13 @@ func TestMetricsHistory(t *testing.T) {
 	})
 	m.InjectClient("c1", fakek8s.NewSimpleClientset())
 
-	// 2. Setup MetricsHistory with temp dir
-	tmpDir := "/tmp/metrics-test"
-	os.RemoveAll(tmpDir)
-	os.MkdirAll(tmpDir, 0700)
-	defer os.RemoveAll(tmpDir)
+	// 2. Setup MetricsHistory with per-test temp dir.
+	// Previously this used a hardcoded "/tmp/metrics-test" which collided with
+	// concurrent CI runs and leftover state from prior jobs, producing
+	// intermittent `invalid character 'o' in literal null` parse errors when
+	// loadFromDisk read a partially-written or foreign JSON file. t.TempDir()
+	// is unique per test and auto-cleaned. Fixes #7898 / #7899.
+	tmpDir := t.TempDir()
 
 	mh := NewMetricsHistory(m, tmpDir)
 


### PR DESCRIPTION
## Summary

TestMetricsHistory used a hardcoded \`/tmp/metrics-test\` directory. In CI this collided with concurrent test runs and leftover state from prior jobs, producing intermittent:

\`\`\`
[MetricsHistory] error parsing history file error=\"invalid character 'o' in literal null (expecting 'u')\"
metrics_history_test.go:55: Expected 1 snapshot loaded from disk, got 0
\`\`\`

This failed the nightly **Release** workflow run [24383107176](https://github.com/kubestellar/console/actions/runs/24383107176) which in turn skipped \`release\` + \`helm-release\` and posted #7898 / #7899.

Switching to \`t.TempDir()\` — unique per test, Go-auto-cleaned.

Fixes #7898
Fixes #7899

## Test plan
- [x] \`go test ./pkg/agent/ -run TestMetricsHistory -v\` passes locally
- [ ] Nightly Release workflow passes on next scheduled run