### PR TITLE
🐛 fix(kube-chess): address Copilot review on #7896 — dead branch + EP comment (#7901)

### DIFF
--- a/web/src/components/cards/KubeChess.tsx
+++ b/web/src/components/cards/KubeChess.tsx
@@ -77,6 +77,15 @@ function positionKey(state: {
   // when the side-to-move actually has a pawn that can legally capture on
   // it. Otherwise two positions that are identical apart from a "dangling"
   // EP square must be counted as the same position (#7894).
+  //
+  // We use a geometric "a side-to-move pawn sits diagonally behind the EP
+  // square" check. This matches the approximation used by Stockfish-style
+  // Zobrist hashing and is correct for every EP-capture that isn't blocked
+  // by a pin. Strict FIDE would also require that the capture doesn't
+  // leave own king in check; we accept that approximation to keep
+  // positionKey allocation-free and O(1) per call (#7901). The divergence
+  // is reachable only in contrived pin positions and won't change
+  // threefold detection in any realistic game.
   let ep = '-'
   if (state.enPassantTarget) {
     const { row: er, col: ec } = state.enPassantTarget
@@ -566,7 +575,12 @@ function minimax(state: GameState, depth: number, alpha: number, beta: number, m
   if (result === 'checkmate') {
     return maximizing ? -10000 + state.moveHistory.length : 10000 - state.moveHistory.length
   }
-  if (result === 'stalemate' || result === 'repetition') {
+  // `getGameResult` can only return `'repetition'` when `positionHistory` has
+  // accumulated three matching keys, but `makeMove` calls inside minimax run
+  // with `trackHistory=false` for perf — so the search tree never sees a
+  // repetition draw. Only `'stalemate'` is reachable here. Keeping the
+  // comment here so the omission is deliberate, not accidental (#7901).
+  if (result === 'stalemate') {
     return 0
   }
 


### PR DESCRIPTION
## Summary

Two follow-up Copilot comments on merged PR #7896:

1. **Dead minimax branch** — `minimax` returns 0 for \`result === 'repetition'\`, but \`makeMove\` inside search runs with \`trackHistory=false\` (by design, for perf). \`positionHistory\` never accumulates within the search tree, so \`getGameResult\` cannot return \`'repetition'\` during minimax. Removed the unreachable branch; left a comment so the omission is clearly intentional.

2. **EP approximation in positionKey** — The current check accepts an en-passant square whenever a side-to-move pawn is geometrically positioned to capture onto it. Strict FIDE also requires the capture to be legal (not leave own king in check from a pin). We accept this approximation — it's what Stockfish-style Zobrist hashing uses, keeps \`positionKey\` O(1) and allocation-free, and the divergence only shows up in contrived pin scenarios that don't affect practical repetition detection. Expanded the code comment to document the trade-off.

Fixes #7901

## Test plan
- [x] \`npm run build\` passes
- [x] Minimax search still finds mates + stalemates in existing positions
- [ ] Repetition detection unchanged from #7891 implementation