### PR TITLE
🐛 fix(tests): update ComplianceScoreBreakdownModal tests for always-on Overview tab (#7904)

### DIFF
--- a/web/src/components/cards/ComplianceCards.test.tsx
+++ b/web/src/components/cards/ComplianceCards.test.tsx
@@ -394,9 +394,11 @@ describe('ComplianceScoreBreakdownModal', () => {
     expect(tabs[1]).toHaveTextContent('82%')
     expect(tabs[2]).toHaveTextContent('78%')
 
-    // Overview tab content: per-tool bars
-    expect(screen.getByText('Kubescape')).toBeInTheDocument()
-    expect(screen.getByText('Kyverno')).toBeInTheDocument()
+    // Overview tab content: per-tool bars. "Kubescape" and "Kyverno" each appear
+    // twice now — once as the tab label and once in the per-tool bar list — so
+    // use getAllByText.
+    expect(screen.getAllByText('Kubescape').length).toBeGreaterThanOrEqual(2)
+    expect(screen.getAllByText('Kyverno').length).toBeGreaterThanOrEqual(2)
   })
 
   it('renders Kubescape tab with controls stats and framework scores', async () => {
@@ -463,8 +465,8 @@ describe('ComplianceScoreBreakdownModal', () => {
     expect(screen.getByText(/Based on 4 violations across 20 policies/)).toBeInTheDocument()
   })
 
-  it('shows fallback message when tool data is not provided', async () => {
-    const _user = userEvent.setup()
+  it('shows fallback message when tool data is not provided (after clicking tool tab)', async () => {
+    const user = userEvent.setup()
 
     render(
       <ComplianceScoreBreakdownModal
@@ -476,13 +478,18 @@ describe('ComplianceScoreBreakdownModal', () => {
       />,
     )
 
-    // With only one tool, no Overview tab — Kubescape tab is active by default
-    // Since kubescapeData is undefined, should show fallback
+    // Since #7893, Overview is always the default landing tab — so the
+    // fallback for the Kubescape tool is only reached after the user clicks
+    // the Kubescape tab explicitly.
+    const kubescapeTab = screen.getByRole('tab', { name: /Kubescape/ })
+    await user.click(kubescapeTab)
+
+    // With kubescapeData undefined, the tool tab renders the fallback
     expect(screen.getByText('Kubescape data not available')).toBeInTheDocument()
     expect(screen.getByText('No data from connected clusters')).toBeInTheDocument()
   })
 
-  it('renders single-tool modal without Overview tab', () => {
+  it('renders single-tool modal with Overview + tool tabs (Overview landing)', () => {
     render(
       <ComplianceScoreBreakdownModal
         isOpen={true}
@@ -493,11 +500,16 @@ describe('ComplianceScoreBreakdownModal', () => {
       />,
     )
 
-    // Only 1 tool => no tabs rendered (tabs.length === 1 means no Overview added, and tabs only show if > 1)
-    expect(screen.queryByRole('tab')).not.toBeInTheDocument()
+    // Since #7893, Overview is always present — so a single-tool modal has
+    // 2 tabs (Overview + Kubescape), not 0.
+    const tabs = screen.getAllByRole('tab')
+    expect(tabs).toHaveLength(2)
+    expect(tabs[0]).toHaveTextContent('Overview')
+    expect(tabs[1]).toHaveTextContent('Kubescape')
 
-    // Content should show Kubescape data directly
-    expect(screen.getByText('Total Controls')).toBeInTheDocument()
+    // Overview tab is active by default — it shows aggregate stats derived
+    // from kubescapeData (100 controls / 82 passed / 18 failed).
+    expect(screen.getByText('Total Checks')).toBeInTheDocument()
     expect(screen.getByText('100')).toBeInTheDocument()
   })
 


### PR DESCRIPTION
## Summary

Updates three failing tests in `web/src/components/cards/ComplianceCards.test.tsx` that were invalidated by PR #7900 (commit `248b3f7b`). That PR made the Overview tab always-present as the landing tab and expanded `OverviewTab` to render aggregate StatBox grid from `kubescapeData`/`kyvernoData` props — these tests asserted the old behavior.

## What changed

1. **"renders Overview tab ... when multiple tools"** — `getByText('Kubescape')` / `getByText('Kyverno')` now find multiple matches (tab label + per-tool bar in Overview). Switched to `getAllByText` with a length check ≥ 2.

2. **"renders single-tool modal without Overview tab"** — Overview is now always present, so single-tool → 2 tabs (Overview + Kubescape). Renamed to "renders single-tool modal with Overview + tool tabs (Overview landing)" and inverted the assertion: check for 2 tabs with Overview first, and verify aggregate "Total Checks" on the landing Overview tab.

3. **"shows fallback message when tool data is not provided"** — Default active tab is now Overview, not Kubescape. Test clicks the Kubescape tab first to reach the `ToolDataUnavailable` fallback rendering.

All 12 tests in the file now pass locally. `npm run build` passes.

Fixes #7904

## Test plan

- [x] `npx vitest run src/components/cards/ComplianceCards.test.tsx` — 12/12 pass
- [x] `npm run build` passes
- [ ] Coverage Suite workflow re-run green