### PR TITLE
fix: cache invalid OpenAI/Gemini API key validation results

### DIFF
--- a/pkg/agent/server_operations.go
+++ b/pkg/agent/server_operations.go
@@ -509,7 +509,7 @@ func validateOpenAIKey(ctx context.Context, apiKey string) (bool, error) {
 		return true, nil
 	}
 	if resp.StatusCode == http.StatusUnauthorized {
-		return false, fmt.Errorf("invalid API key")
+		return false, nil // Invalid key - no error so it gets cached by ValidateAllKeys
 	}
 	body, readErr := io.ReadAll(resp.Body)
 	if readErr != nil {
@@ -537,7 +537,7 @@ func validateGeminiKey(ctx context.Context, apiKey string) (bool, error) {
 		return true, nil
 	}
 	if resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusForbidden {
-		return false, fmt.Errorf("invalid API key")
+		return false, nil // Invalid key - no error so it gets cached by ValidateAllKeys
 	}
 	body, readErr := io.ReadAll(resp.Body)
 	if readErr != nil {


### PR DESCRIPTION
Fixes #7923

## Problem

 and  return  for HTTP 401/403 responses. In , any non-nil error skips caching:



This means invalid OpenAI/Gemini keys trigger a live API request on every startup, while invalid Claude keys (which correctly return ) are cached after the first check.

## Fix

Changed both  and  to return  for definitive auth failures (401/403), matching the existing  pattern.