### PR TITLE
🐛 fix: vCluster disconnect targeting, kagenti fan-out, mission attention (#7921 #7915 #7918)

### DIFF
--- a/pkg/agent/kagenti.go
+++ b/pkg/agent/kagenti.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"log/slog"
 	"net/http"
+	"sync"
 	"time"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -14,6 +15,11 @@ import (
 
 const (
 	kagentiTimeout = 30 * time.Second
+	// kagentiSummaryPerCallTimeout is the per-call timeout used when the
+	// summary handler fans out its CRD queries concurrently. It mirrors
+	// kagentCRDPerCallTimeout so a single slow CRD cannot starve the
+	// others inside one shared 30-second budget (#7915).
+	kagentiSummaryPerCallTimeout = 15 * time.Second
 )
 
 // Kagenti CRD Group/Version/Resource definitions
@@ -453,9 +459,6 @@ func (s *Server) handleKagentiSummary(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	ctx, cancel := context.WithTimeout(r.Context(), kagentiTimeout)
-	defer cancel()
-
 	dynClient, err := s.k8sClient.GetDynamicClient(cluster)
 	if err != nil {
 		slog.Warn("error fetching kagenti summary", "error", err)
@@ -468,11 +471,32 @@ func (s *Server) handleKagentiSummary(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	var agentCount, readyAgents, buildCount, activeBuilds, toolCount, cardCount int
-	frameworks := map[string]int{}
+	// Fan the 4 CRD list calls out concurrently, each with its own
+	// per-call timeout, so a slow/unavailable CRD cannot starve the
+	// others within one shared 30-second context budget. This matches
+	// handleKagentCRDSummary's pattern (#7915).
+	var (
+		mu                                                       sync.Mutex
+		agentCount, readyAgents, buildCount, activeBuilds        int
+		toolCount, cardCount                                     int
+		frameworks                                               = map[string]int{}
+		wg                                                       sync.WaitGroup
+	)
+	const numKagentiCRDQueries = 4
+	wg.Add(numKagentiCRDQueries)
 
-	// Count agents
-	if agentList, err := dynClient.Resource(kagentiAgentGVR).List(ctx, metav1.ListOptions{}); err == nil {
+	// Count agents + collect frameworks
+	go func() {
+		defer wg.Done()
+		ctx, cancel := context.WithTimeout(r.Context(), kagentiSummaryPerCallTimeout)
+		defer cancel()
+		agentList, listErr := dynClient.Resource(kagentiAgentGVR).List(ctx, metav1.ListOptions{})
+		if listErr != nil {
+			slog.Warn("kagenti summary: agents query failed", "error", listErr)
+			return
+		}
+		mu.Lock()
+		defer mu.Unlock()
 		agentCount = len(agentList.Items)
 		for _, item := range agentList.Items {
 			statusMap, _ := item.Object["status"].(map[string]any)
@@ -490,10 +514,20 @@ func (s *Server) handleKagentiSummary(w http.ResponseWriter, r *http.Request) {
 				}
 			}
 		}
-	}
+	}()
 
 	// Count builds
-	if buildList, err := dynClient.Resource(kagentiBuildGVR).List(ctx, metav1.ListOptions{}); err == nil {
+	go func() {
+		defer wg.Done()
+		ctx, cancel := context.WithTimeout(r.Context(), kagentiSummaryPerCallTimeout)
+		defer cancel()
+		buildList, listErr := dynClient.Resource(kagentiBuildGVR).List(ctx, metav1.ListOptions{})
+		if listErr != nil {
+			slog.Warn("kagenti summary: builds query failed", "error", listErr)
+			return
+		}
+		mu.Lock()
+		defer mu.Unlock()
 		buildCount = len(buildList.Items)
 		for _, item := range buildList.Items {
 			statusMap, _ := item.Object["status"].(map[string]any)
@@ -504,17 +538,39 @@ func (s *Server) handleKagentiSummary(w http.ResponseWriter, r *http.Request) {
 				}
 			}
 		}
-	}
+	}()
 
 	// Count tools
-	if toolList, err := dynClient.Resource(kagentiToolGVR).List(ctx, metav1.ListOptions{}); err == nil {
+	go func() {
+		defer wg.Done()
+		ctx, cancel := context.WithTimeout(r.Context(), kagentiSummaryPerCallTimeout)
+		defer cancel()
+		toolList, listErr := dynClient.Resource(kagentiToolGVR).List(ctx, metav1.ListOptions{})
+		if listErr != nil {
+			slog.Warn("kagenti summary: tools query failed", "error", listErr)
+			return
+		}
+		mu.Lock()
+		defer mu.Unlock()
 		toolCount = len(toolList.Items)
-	}
+	}()
 
 	// Count cards
-	if cardList, err := dynClient.Resource(kagentiCardGVR).List(ctx, metav1.ListOptions{}); err == nil {
+	go func() {
+		defer wg.Done()
+		ctx, cancel := context.WithTimeout(r.Context(), kagentiSummaryPerCallTimeout)
+		defer cancel()
+		cardList, listErr := dynClient.Resource(kagentiCardGVR).List(ctx, metav1.ListOptions{})
+		if listErr != nil {
+			slog.Warn("kagenti summary: cards query failed", "error", listErr)
+			return
+		}
+		mu.Lock()
+		defer mu.Unlock()
 		cardCount = len(cardList.Items)
-	}
+	}()
+
+	wg.Wait()
 
 	json.NewEncoder(w).Encode(map[string]any{
 		"agentCount":   agentCount,

--- a/pkg/agent/local_clusters.go
+++ b/pkg/agent/local_clusters.go
@@ -674,12 +674,38 @@ func (m *LocalClusterManager) ConnectVCluster(name, namespace string) error {
 	return nil
 }
 
-// DisconnectVCluster disconnects from a vCluster
+// DisconnectVCluster disconnects from a vCluster by removing its kubeconfig
+// context entry. The plain `vcluster disconnect` command operates on the
+// current-context (last connected) regardless of arguments, so a user asking
+// to disconnect vCluster B could end up disconnecting A if A was the current
+// context (#7921).
+//
+// To disconnect a specific instance we look it up in `vcluster list --output
+// json` (which populates VClusterInstance.Context for connected entries),
+// then run `kubectl config delete-context <context>` on that exact entry.
+// This matches the ConnectVCluster path, which adds a context entry via
+// `vcluster connect --update-current=false` without changing current-context.
 func (m *LocalClusterManager) DisconnectVCluster(name, namespace string) error {
 	m.broadcastProgress("vcluster", name, "disconnecting",
 		fmt.Sprintf("Disconnecting from vCluster '%s'...", name), progressConnecting)
 
-	cmd := execCommand("vcluster", "disconnect")
+	instances, err := m.ListVClusters()
+	if err != nil {
+		return fmt.Errorf("vcluster disconnect failed: could not list vclusters to find target context: %w", err)
+	}
+
+	var targetContext string
+	for _, inst := range instances {
+		if inst.Name == name && inst.Namespace == namespace {
+			targetContext = inst.Context
+			break
+		}
+	}
+	if targetContext == "" {
+		return fmt.Errorf("vcluster disconnect failed: vcluster %q in namespace %q has no kubeconfig context (already disconnected?)", name, namespace)
+	}
+
+	cmd := execCommand("kubectl", "config", "delete-context", targetContext)
 	var stderr bytes.Buffer
 	cmd.Stderr = &stderr
 

--- a/web/src/components/layout/mission-sidebar/MissionSidebar.tsx
+++ b/web/src/components/layout/mission-sidebar/MissionSidebar.tsx
@@ -505,12 +505,14 @@ export function MissionSidebar() {
     }
   }, [isSidebarOpen, isFullScreen, showBrowser, showMissionControl, setFullScreen, closeSidebar])
 
-  // Count missions needing attention
-  // Blocked missions are stuck waiting on user action (preflight failure,
-  // missing credentials, RBAC denial). Surfacing them in the attention
-  // indicator ensures the user sees the required action (#5933).
+  // Count missions needing attention — statuses where the user must act.
+  // Blocked missions are stuck on preflight failure / missing credentials /
+  // RBAC denial (#5933). `failed` is deliberately excluded (#7918): failed
+  // missions are terminal and are filtered out of the active list by
+  // `isActiveMission`, so including them here produced a badge count the
+  // user could not reconcile with the visible active list.
   const needsAttention = missions.filter(m =>
-    m.status === 'waiting_input' || m.status === 'failed' || m.status === 'blocked'
+    m.status === 'waiting_input' || m.status === 'blocked'
   ).length
 
   const runningCount = missions.filter(m => m.status === 'running').length
@@ -1347,11 +1349,13 @@ export function MissionSidebarToggle() {
   const { missions, isSidebarOpen, openSidebar } = useMissions()
   const { isMobile } = useMobile()
 
-  // Blocked missions are stuck waiting on user action (preflight failure,
-  // missing credentials, RBAC denial). Surfacing them in the attention
-  // indicator ensures the user sees the required action (#5933).
+  // Blocked missions are stuck on preflight failure / missing credentials /
+  // RBAC denial (#5933). `failed` is deliberately excluded (#7918): failed
+  // missions are terminal and are filtered out of the active list by
+  // `isActiveMission`, so including them here produced a badge count the
+  // user could not reconcile with the visible active list.
   const needsAttention = missions.filter(m =>
-    m.status === 'waiting_input' || m.status === 'failed' || m.status === 'blocked'
+    m.status === 'waiting_input' || m.status === 'blocked'
   ).length
 
   const runningCount = missions.filter(m => m.status === 'running').length


### PR DESCRIPTION
## Summary

Three independent contributor-reported bugs, verified against code and bundled to avoid PR spam. Two related false-positive reports (#7917, #7919) were closed with evidence.

### pkg/agent/local_clusters.go — `DisconnectVCluster` (#7921)

Bare \`vcluster disconnect\` operates on the current-context (last connected), so clicking "Disconnect" on vcluster B could actually disconnect A. The connect path uses \`--update-current=false\`, so the fix mirrors that: look up the target in \`ListVClusters()\` and run \`kubectl config delete-context <context>\` on that exact entry.

### pkg/agent/kagenti.go — `handleKagentiSummary` fan-out (#7915)

4 sequential \`List(ctx)\` calls inside one shared 30-second budget — a slow Agents query starved Builds/Tools/Cards. Mirrors the existing \`handleKagentCRDSummary\` fan-out pattern: 4 goroutines, 15s per-call contexts, mutex-guarded shared counters, WaitGroup.

### web/src/.../MissionSidebar.tsx — attention-count mismatch (#7918)

\`needsAttention\` counted \`failed\` missions, but \`isActiveMission\` excludes \`failed\` → badge count never matched the visible active list. Removed \`failed\` from the filter at both call sites (inline sidebar + floating toggle). \`waiting_input\` and \`blocked\` remain — those are actionable.

## Verified but closed as not-planned

- **#7917** — claim was "kagenti handlers return 200 on GetDynamicClient error, inconsistent with kagent CRD handlers". Verified: all kagenti handlers (\`Agents\`/\`Builds\`/\`Cards\`/\`Tools\`/\`Summary\`) return **500 + JSON body**, same as kagent CRD handlers. Already consistent.
- **#7919** — claim was "heartbeat goroutine leaks for up to 30s after cancellation". Verified: the \`select\` already has \`ctx.Done()\` and \`heartbeatDone\` cases, so closing either channel exits on the next iteration (nanoseconds, not 30s). \`safeWrite\` short-circuits on closed/ctx.Err. No leak.

Fixes #7921
Fixes #7915
Fixes #7918

## Test plan

- [ ] \`go build ./...\` passes locally.
- [ ] \`npm run build\` passes locally.
- [ ] With two vclusters connected, disconnect-by-name on UI removes the requested context, not current-context.
- [ ] \`/kagenti/summary\` with one slow CRD still returns live counts for the other three.
- [ ] A failed mission no longer increments the sidebar attention badge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)