### PR TITLE
🐛 fix: send chat final result with Background context (#7925)

### DIFF
--- a/pkg/agent/server_ai.go
+++ b/pkg/agent/server_ai.go
@@ -716,8 +716,13 @@ func (s *Server) handleChatMessageStreaming(conn *websocket.Conn, msg protocol.M
 		totalTokens = resp.TokenUsage.TotalTokens
 	}
 
-	// Send final result
-	safeWrite(ctx, protocol.Message{
+	// Send final result. Use context.Background() rather than the mission ctx
+	// because the mission's deadline can fire in the narrow window between the
+	// ctx.Err() check above and this write, silently dropping the final
+	// TypeResult message and leaving the client's chat bubble stuck in a
+	// "thinking" state (#7925). The error paths above already use
+	// context.Background() for the same reason — this matches that pattern.
+	safeWrite(context.Background(), protocol.Message{
 		ID:   msg.ID,
 		Type: protocol.TypeResult,
 		Payload: protocol.ChatStreamPayload{


### PR DESCRIPTION
## Summary

The final `TypeResult` message in `handleChatMessageStreaming` was being sent with the mission context (5-minute deadline) instead of `context.Background()`. If the deadline fired in the narrow window between the pre-flight `ctx.Err()` check and the final `safeWrite`, the result was silently dropped — leaving the client's chat bubble stuck in a "thinking" state with no error surfaced.

## The fix

Switch the final-result `safeWrite` call at `pkg/agent/server_ai.go:720` from `ctx` to `context.Background()`, matching the pattern already used by all four error paths in this handler (lines 642, 654, 670, 681, 690). Once we've decided the response is deliverable, a deadline race must not cancel delivery.

`safeWrite` still short-circuits on `closed.Load()`, so a genuinely-gone client socket is still handled correctly.

Fixes #7925

## Test plan

- [x] `go build ./...` — passes
- [ ] Existing tests run in CI