### PR TITLE
🐛 fix: VClusterStatus loading/error + test mock field (#7929 #7930)

### DIFF
--- a/web/src/components/cards/VClusterStatus.tsx
+++ b/web/src/components/cards/VClusterStatus.tsx
@@ -122,9 +122,11 @@ export function VClusterStatus({ config: _config }: VClusterStatusProps) {
   // arrives), and the error UI when the fetch fails with no cached instances.
   // Once we have data, keep showing it while background refreshes happen
   // (SWR-style) to avoid flicker (#7929 Copilot review on PR #7916).
-  const isLoading = isLive && isVClustersLoading && vclusterInstances.length === 0
+  const isVClusterLoading = isLive && isVClustersLoading
+  const hasData = vclusters.length > 0
+  const isLoading = isVClusterLoading && vclusterInstances.length === 0
   const hasError = isLive && !!vclustersError && vclusterInstances.length === 0
-  useCardLoadingState({ isLoading, hasAnyData: vclusters.length > 0, isDemoData: !isLive })
+  useCardLoadingState({ isLoading: isVClusterLoading && !hasData, hasAnyData: hasData, isDemoData: !isLive })
   const {
     items: paginatedVClusters, totalItems, currentPage, totalPages, itemsPerPage,
     goToPage, needsPagination, setItemsPerPage,

--- a/web/src/components/cards/VClusterStatus.tsx
+++ b/web/src/components/cards/VClusterStatus.tsx
@@ -98,7 +98,7 @@ export function VClusterStatus({ config: _config }: VClusterStatusProps) {
   const SORT_OPTIONS = SORT_OPTIONS_KEYS.map(opt => ({ value: opt.value, label: String(t(opt.labelKey)) }))
   const { isConnected } = useLocalAgent()
   const { isDemoMode } = useDemoMode()
-  const { vclusterInstances } = useLocalClusterTools()
+  const { vclusterInstances, isVClustersLoading, vclustersError } = useLocalClusterTools()
 
   // Use live agent data when connected and not in demo mode. When the agent
   // is connected but returns zero vclusters, we still treat that as live
@@ -117,9 +117,14 @@ export function VClusterStatus({ config: _config }: VClusterStatusProps) {
     return { totalVClusters: total, runningCount: running, pausedCount: paused, failedCount: failed }
   }, [vclusters])
 
-  const isLoading = false
-  const hasError = false
-  useCardLoadingState({ isLoading: false, hasAnyData: vclusters.length > 0, isDemoData: !isLive })
+  // Only surface loading/error for live fetches — demo mode is sync. Render
+  // the skeleton during the initial /vcluster/list fetch (before any data
+  // arrives), and the error UI when the fetch fails with no cached instances.
+  // Once we have data, keep showing it while background refreshes happen
+  // (SWR-style) to avoid flicker (#7929 Copilot review on PR #7916).
+  const isLoading = isLive && isVClustersLoading && vclusterInstances.length === 0
+  const hasError = isLive && !!vclustersError && vclusterInstances.length === 0
+  useCardLoadingState({ isLoading, hasAnyData: vclusters.length > 0, isDemoData: !isLive })
   const {
     items: paginatedVClusters, totalItems, currentPage, totalPages, itemsPerPage,
     goToPage, needsPagination, setItemsPerPage,

--- a/web/src/hooks/__tests__/useLocalClusterTools.test.ts
+++ b/web/src/hooks/__tests__/useLocalClusterTools.test.ts
@@ -69,7 +69,7 @@ function defaultConnectedFetch(url: RequestInfo | URL): Promise<Response> {
     return Promise.resolve(jsonResponse({ tools: [] }))
   }
   if (urlStr.includes('/vcluster/list')) {
-    return Promise.resolve(jsonResponse({ instances: [] }))
+    return Promise.resolve(jsonResponse({ vclusters: [] }))
   }
   if (urlStr.includes('/local-clusters')) {
     return Promise.resolve(jsonResponse({ clusters: [] }))
@@ -412,7 +412,7 @@ describe('useLocalClusterTools', () => {
         if (urlStr.includes('/local-cluster-tools')) {
           return Promise.resolve(jsonResponse({ tools: MOCK_TOOLS }))
         }
-        return Promise.resolve(jsonResponse({ clusters: [], instances: [] }))
+        return Promise.resolve(jsonResponse({ clusters: [], vclusters: [] }))
       })
 
       const { result } = renderHook(() => useLocalClusterTools())
@@ -431,7 +431,7 @@ describe('useLocalClusterTools', () => {
           return Promise.resolve(jsonResponse({ tools: [] }))
         }
         if (urlStr.includes('/vcluster/list')) {
-          return Promise.resolve(jsonResponse({ instances: [] }))
+          return Promise.resolve(jsonResponse({ vclusters: [] }))
         }
         if (urlStr.includes('/local-clusters')) {
           return Promise.resolve(jsonResponse({ clusters: MOCK_CLUSTERS }))
@@ -451,7 +451,7 @@ describe('useLocalClusterTools', () => {
       vi.mocked(fetch).mockImplementation((url) => {
         const urlStr = String(url)
         if (urlStr.includes('/vcluster/list')) {
-          return Promise.resolve(jsonResponse({ instances: MOCK_VCLUSTER_INSTANCES }))
+          return Promise.resolve(jsonResponse({ vclusters: MOCK_VCLUSTER_INSTANCES }))
         }
         return Promise.resolve(jsonResponse({ tools: [], clusters: [] }))
       })
@@ -470,7 +470,7 @@ describe('useLocalClusterTools', () => {
         if (urlStr.includes('/local-cluster-tools')) {
           return Promise.resolve(jsonResponse({ tools: MOCK_TOOLS }))
         }
-        return Promise.resolve(jsonResponse({ clusters: [], instances: [] }))
+        return Promise.resolve(jsonResponse({ clusters: [], vclusters: [] }))
       })
 
       const { result } = renderHook(() => useLocalClusterTools())
@@ -1254,7 +1254,7 @@ describe('useLocalClusterTools', () => {
           return Promise.resolve(jsonResponse({ tools: MOCK_TOOLS }))
         }
         if (urlStr.includes('/vcluster/list')) {
-          return Promise.resolve(jsonResponse({ instances: [] }))
+          return Promise.resolve(jsonResponse({ vclusters: [] }))
         }
         if (urlStr.includes('/local-clusters')) {
           return Promise.resolve(jsonResponse({ clusters: MOCK_CLUSTERS }))
@@ -1293,7 +1293,7 @@ describe('useLocalClusterTools', () => {
           return Promise.resolve(jsonResponse({ clusters: MOCK_CLUSTERS }))
         }
         if (urlStr.includes('/vcluster/list')) {
-          return Promise.resolve(jsonResponse({ instances: [] }))
+          return Promise.resolve(jsonResponse({ vclusters: [] }))
         }
         return Promise.resolve(jsonResponse({ tools: [] }))
       })
@@ -1322,7 +1322,7 @@ describe('useLocalClusterTools', () => {
           return Promise.resolve(jsonResponse({ tools: MOCK_TOOLS }))
         }
         if (urlStr.includes('/vcluster/list')) {
-          return Promise.resolve(jsonResponse({ instances: MOCK_VCLUSTER_INSTANCES }))
+          return Promise.resolve(jsonResponse({ vclusters: MOCK_VCLUSTER_INSTANCES }))
         }
         if (urlStr.includes('/local-clusters')) {
           return Promise.resolve(jsonResponse({ clusters: MOCK_CLUSTERS }))

--- a/web/src/hooks/useLocalClusterTools.ts
+++ b/web/src/hooks/useLocalClusterTools.ts
@@ -82,6 +82,11 @@ export function useLocalClusterTools() {
   // vCluster state
   const [vclusterInstances, setVclusterInstances] = useState<VClusterInstance[]>([])
   const [vclusterClusterStatus, setVclusterClusterStatus] = useState<VClusterClusterStatus[]>([])
+  // Dedicated loading/error state for /vcluster/list so the card can show a
+  // skeleton on initial fetch and surface agent failures instead of silently
+  // displaying stale or empty data (#7929 Copilot review on PR #7916).
+  const [isVClustersLoading, setIsVClustersLoading] = useState(false)
+  const [vclustersError, setVClustersError] = useState<string | null>(null)
   const [isConnecting, setIsConnecting] = useState<string | null>(null) // vcluster name being connected
   const [isDisconnecting, setIsDisconnecting] = useState<string | null>(null) // vcluster name being disconnected
 
@@ -283,15 +288,18 @@ export function useLocalClusterTools() {
     // In demo mode (without agent connected), show demo vcluster instances
     if (isDemoMode && !isConnected) {
       setVclusterInstances(DEMO_VCLUSTER_INSTANCES)
+      setVClustersError(null)
       setError(null)
       return
     }
 
     if (!isConnected) {
       setVclusterInstances([])
+      setVClustersError(null)
       return
     }
 
+    setIsVClustersLoading(true)
     try {
       const response = await fetch(`${LOCAL_AGENT_HTTP_URL}/vcluster/list`, {
         signal: AbortSignal.timeout(VCLUSTER_LIST_TIMEOUT_MS) })
@@ -301,11 +309,25 @@ export function useLocalClusterTools() {
         // handleVClusterList). Historically this read `data.instances`, which
         // was always undefined — live data silently fell back to [] (#7914).
         setVclusterInstances(data.vclusters || [])
+        setVClustersError(null)
         setError(null)
+      } else {
+        // Non-2xx: clear stale instances and surface the failure so the card
+        // can render an error state instead of silently showing empty or
+        // stale data (#7929 Copilot review).
+        const message = `vCluster list failed: HTTP ${response.status}`
+        console.error(message)
+        setVclusterInstances([])
+        setVClustersError(message)
       }
     } catch (err) {
+      const message = err instanceof Error ? err.message : 'Failed to fetch vCluster instances'
       console.error('Failed to fetch vCluster instances:', err)
+      setVclusterInstances([])
+      setVClustersError(message)
       setError('Failed to fetch vCluster instances')
+    } finally {
+      setIsVClustersLoading(false)
     }
   }, [isConnected, isDemoMode])
 
@@ -578,6 +600,8 @@ export function useLocalClusterTools() {
     // vCluster state and actions
     vclusterInstances,
     vclusterClusterStatus,
+    isVClustersLoading,
+    vclustersError,
     checkVClusterOnCluster,
     isConnecting,
     isDisconnecting,


### PR DESCRIPTION
## Summary

Three related follow-ups stemming from PR #7916 (vCluster Status live data):

1. **`useLocalClusterTools.fetchVClusters` error handling** — previously a non-2xx response left `vclusterInstances` and `error` unchanged, showing stale/empty data with no visible failure signal. Now clears instances, surfaces a `vclustersError` message, and tracks `isVClustersLoading` around the fetch.

2. **`VClusterStatus.tsx` wiring** — replaces hardcoded `isLoading = false` / `hasError = false` with the real loading/error state from the hook. The skeleton renders on initial `/vcluster/list` fetch, and the existing error UI (using the `vclusterStatus.loadFailed` i18n key already in the file) surfaces agent failures. SWR-style: once we have data we keep rendering it during background refreshes to avoid flicker.

3. **`useLocalClusterTools.test.ts` mock field** — updates `/vcluster/list` fetch mocks from `{ instances: [...] }` to `{ vclusters: [...] }` to match the real backend shape (`handleVClusterList` in `pkg/agent/server_operations.go`). Fixes the Coverage Suite failure for `"fetches vCluster instances on mount when connected"` — the old mock was silently coupled to the pre-#7916 bug where the hook read `data.instances`.

Fixes #7929
Fixes #7930

## Test plan

- [x] `npm run build` — passes
- [x] `npx vitest run src/hooks/__tests__/useLocalClusterTools.test.ts` — 94 passed / 1 skipped
- [x] `eslint` on touched files — clean (1 pre-existing warning on unrelated line)