### PR TITLE
🐛 fix: two-click confirm to delete maintenance windows (#7932)

### DIFF
--- a/web/src/components/cards/MaintenanceWindows.tsx
+++ b/web/src/components/cards/MaintenanceWindows.tsx
@@ -1,6 +1,9 @@
-import { useState, useMemo, useEffect } from 'react'
+import { useState, useMemo, useEffect, useRef } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useClusters } from '../../hooks/useMCP'
+
+/** Two-click delete confirm window — matches AlertRules #5591 pattern */
+const DELETE_CONFIRM_TIMEOUT_MS = 3000
 
 interface MaintenanceWindow {
   id: string
@@ -94,10 +97,29 @@ export function MaintenanceWindows() {
     setFormData({ cluster: '', description: '', startTime: '', endTime: '', type: 'maintenance' })
   }
 
+  // Two-click delete: first click shows "Confirm?", second click deletes.
+  // Prevents accidental loss of scheduled maintenance windows (#7932).
+  const [pendingDeleteId, setPendingDeleteId] = useState<string | null>(null)
+  const deleteTimerRef = useRef<ReturnType<typeof setTimeout>>(undefined)
+  useEffect(() => () => clearTimeout(deleteTimerRef.current), [])
+
   const handleDelete = (id: string) => {
-    const updated = windows.filter(w => w.id !== id)
-    setWindows(updated)
-    saveWindows(updated)
+    if (pendingDeleteId === id) {
+      // Second click — confirmed
+      clearTimeout(deleteTimerRef.current)
+      setPendingDeleteId(null)
+      const updated = windows.filter(w => w.id !== id)
+      setWindows(updated)
+      saveWindows(updated)
+    } else {
+      // First click — enter confirm state with auto-reset
+      setPendingDeleteId(id)
+      clearTimeout(deleteTimerRef.current)
+      deleteTimerRef.current = setTimeout(
+        () => setPendingDeleteId(prev => prev === id ? null : prev),
+        DELETE_CONFIRM_TIMEOUT_MS
+      )
+    }
   }
 
   const typeColors: Record<string, string> = {
@@ -208,9 +230,15 @@ export function MaintenanceWindows() {
               </div>
               <button
                 onClick={() => handleDelete(w.id)}
-                className="opacity-0 group-hover:opacity-100 text-xs text-red-400 hover:text-red-300 px-1 transition-opacity"
+                title={pendingDeleteId === w.id ? 'Click again to confirm delete' : 'Delete maintenance window'}
+                aria-label={pendingDeleteId === w.id ? 'Confirm delete maintenance window' : 'Delete maintenance window'}
+                className={
+                  pendingDeleteId === w.id
+                    ? 'opacity-100 text-xs font-medium text-red-500 hover:text-red-400 px-1.5 py-0.5 rounded bg-red-500/10 border border-red-500/40 transition-opacity'
+                    : 'opacity-0 group-hover:opacity-100 text-xs text-red-400 hover:text-red-300 px-1 transition-opacity'
+                }
               >
-                ✕
+                {pendingDeleteId === w.id ? 'Confirm?' : '✕'}
               </button>
             </div>
           ))


### PR DESCRIPTION
## Summary

Auto-QA run #701 flagged `MaintenanceWindows.tsx` under "Delete actions without confirmation" (#7932). Verification against the actual code confirms it: the ✕ button at line 210 invokes `handleDelete` immediately with no guard, so a stray click wipes a scheduled maintenance window from localStorage.

**Fix:** adopt the two-click-with-auto-reset pattern `AlertRules.tsx` already uses (#5591). First click swaps the ✕ for a red "Confirm?" pill; a second click within 3s deletes; otherwise the confirm state resets silently. No new component, no extra modal.

## Auto-QA false-positive audit

I verified all 10 cited sites on #7932. Only MaintenanceWindows.tsx is a real bug. The other 9 were grep-heuristic false positives:

| Site | Verdict |
|---|---|
| `IssueActivityChart.tsx:447` | FP — `localStorage.removeItem()`, not a user delete |
| `ClusterCosts.tsx:218` | FP — `localStorage.removeItem()` in a `useEffect` |
| `UserManagement.tsx:480` | FP — prop pass-through; actual delete has `ConfirmDialog` (line 669) |
| `UserManagement.tsx:529` | FP — TypeScript interface definition |
| `ClusterGroups.tsx:275,278` | FP — interface + function signature; delete has `ConfirmDialog` (line 245, #5197) |
| `ClusterGroups.tsx:366` | FP — `onClick={onDelete}` where parent injects confirm-setter (line 230) |
| `MaintenanceWindows.tsx:97,210` | **REAL — fixed here** |
| `WorkloadDeployment.tsx:573` | FP — `localStorage.removeItem()` for a cluster filter key |
| `LLMdAIInsights.tsx` (forms w/o feedback) | FP — chat response is the feedback (rendered live in chatHistory) |

Per prior guidance (`feedback_auto_qa_false_positives.md`), Auto-QA DOM/delete heuristics should always be verified before fixing.

Fixes #7932

## Test plan

- [x] `npm run build` — passes
- [ ] Manual: schedule a window → first ✕ click shows "Confirm?" → second click within 3s deletes → click outside or wait 3s → confirm state clears