### PR TITLE
fix: Ensure frontend dependencies are installed before starting dev server in start-dev.sh

### DIFF
--- a/start-dev.sh
+++ b/start-dev.sh
@@ -83,6 +83,13 @@ fi
 
 cd "$SCRIPT_DIR"
 
+# Install frontend dependencies if they haven't been installed yet
+if [ -d "$SCRIPT_DIR/web" ] && [ ! -d "$SCRIPT_DIR/web/node_modules" ]; then
+    echo "Installing frontend dependencies..."
+    (cd web && npm install)
+    echo ""
+fi
+
 # Load shared port cleanup utilities (kill_project_port, verify_port_free)
 source "$SCRIPT_DIR/scripts/port-cleanup.sh"
 


### PR DESCRIPTION
Problem
Running ./start-dev.sh from a fresh git clone fails with vite: command not found because npm install is never executed.

The bootstrap block (lines 78-79) runs npm install only when cloning via curl — but when running ./start-dev.sh from an existing clone, web/package.json already exists so the bootstrap is skipped entirely.

Fix
Added a node_modules existence check after cd $SCRIPT_DIR. If web/node_modules is missing, runs npm install before starting services.

Closes https://github.com/kubestellar/console/issues/7937