### PR TITLE
fix(deploy): switch vllm-d console storage to IBM VPC block (#7928)

### DIFF
--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -279,7 +279,8 @@ jobs:
             --set route.host=kc.apps.fmaas-vllm-d.fmaas.res.ibm.com \
             --set clusterName=vllm-d \
             --set-string enabledDashboards="dashboard\,clusters\,gpu-reservations\,llm-d-benchmarks\,ai-ml\,arcade" \
-            --set persistence.storageClass=ocs-storagecluster-cephfs \
+            --set persistence.storageClass=ibmc-vpc-block-10iops-tier \
+            --set backup.storageClass=ibmc-vpc-block-10iops-tier \
             --set rbac.namespaceCreationEnabled=true \
             --set securityContext.runAsUser=null \
             --set securityContext.runAsGroup=null \


### PR DESCRIPTION
## Summary

vllm-d cluster's Rook-Ceph OSDs are degraded (4 of 6 in \`Init:CrashLoopBackOff\` with \`encryption-open\` failing — LUKS unlock issue). Every PVC mount on \`ocs-storagecluster-cephfs\` hangs with \`MountVolume.MountDevice failed: ... operation with the given Volume ID ... already exists\` — the same error other tenants are seeing on this cluster.

Switch the vllm-d kc Helm release from \`ocs-storagecluster-cephfs\` to \`ibmc-vpc-block-10iops-tier\` (IBM Cloud VPC block, RWO, no Rook-Ceph dependency).

## What was done live (before this PR)
- Force-deleted stuck VolumeAttachments + Terminating pods
- Force-deleted both PVCs (cephfs was unmountable; data was unrecoverable)
- \`helm upgrade --reuse-values --set persistence.storageClass=ibmc-vpc-block-10iops-tier --set backup.storageClass=ibmc-vpc-block-10iops-tier\`
- Console pod is now Running on vllm-d; both PVCs bound on the new SC

This PR pins those flags into the workflow so the next push to main doesn't snap back to cephfs.

## Tradeoffs
- vllm-d's SQLite DB was lost (cephfs unreadable). Init container \`db-restore\` would normally recover from the latest backup — backups PVC was equally broken. Console fresh-starts on vllm-d.
- pok-prod cluster uses a separate StorageClass and is unaffected.

## Test plan
- [x] Manual helm upgrade succeeded; pod Running; PVCs bound on new SC
- [ ] CI build + deploy with this workflow change