### PR TITLE
fix(kagenti): preserve replicas=0 to distinguish paused from absent (#7943)

### DIFF
--- a/pkg/agent/kagenti.go
+++ b/pkg/agent/kagenti.go
@@ -184,8 +184,13 @@ func (s *Server) handleKagentiAgents(w http.ResponseWriter, r *http.Request) {
 			a.Framework = nestedString(specMap, "framework")
 			a.Protocol = nestedString(specMap, "protocol")
 			a.Image = nestedString(specMap, "image")
-			a.Replicas = nestedInt64(specMap, "replicas")
-			if a.Replicas == 0 {
+			// Distinguish "field absent" (operator defaults to 1) from
+			// "field explicitly set to 0" (agent intentionally paused).
+			// nestedInt64 collapses both into 0, so call the underlying
+			// helper directly and respect the found flag. See issue #7943.
+			if replicas, found, err := unstructured.NestedInt64(specMap, "replicas"); err == nil && found {
+				a.Replicas = replicas
+			} else {
 				a.Replicas = 1
 			}
 		}


### PR DESCRIPTION
## Summary

Fixes #7943 — paused Kagenti agents (replicas explicitly set to 0) were being misreported as "Degraded (0/1)" because `nestedInt64` returns 0 for both "field absent" and "field explicitly 0", and the caller forced any 0 back to 1.

## Change

In `pkg/agent/kagenti.go`, call `unstructured.NestedInt64` directly and honor the `found` flag:

- not found -> default to 1 (operator default)
- found, value == 0 -> keep 0 (paused)
- found, value > 0 -> keep the value

Inline (no new helper) since this is the only call site that needs the distinction.

## Test plan

- [x] `go build ./...` passes locally
- [ ] CI build/lint green
- [ ] Paused agent (replicas: 0) now renders as 0/0 instead of 0/1
- [ ] Agent without a replicas field still defaults to 1