### PR TITLE
fix(dashboard): pin scroll position drifts after navigating back (#7944)

### DIFF
--- a/web/src/hooks/useLastRoute.ts
+++ b/web/src/hooks/useLastRoute.ts
@@ -74,12 +74,16 @@ export function useLastRoute() {
   // Save scroll position for a given path immediately (no debounce).
   // Snaps to the nearest card top boundary so restoration shows full cards.
   // Also saves the card title for robust restore across layout shifts.
-  const saveScrollPositionNow = useCallback((path: string) => {
+  //
+  // `scrollTopOverride` lets callers (e.g. pathname-change cleanup) supply a
+  // known-good scroll value captured before KeepAlive hid the content. The
+  // live container.scrollTop can clamp to 0 while the DOM is being hidden.
+  const saveScrollPositionNow = useCallback((path: string, scrollTopOverride?: number) => {
     try {
       if (isRestoringRef.current) return
       const container = getScrollContainer()
       if (!container) return
-      const scrollTop = container.scrollTop
+      const scrollTop = scrollTopOverride ?? container.scrollTop
 
       const positions = getScrollPositions()
 
@@ -94,26 +98,37 @@ export function useLastRoute() {
       // Find the first card visible at the viewport top.
       // Cards are in a grid so multiple cards can share the same row.
       // We want the first card (left-most in DOM) on the row nearest
-      // the viewport top, using a 20px tolerance for breathing room.
-      //
-      // OPTIMIZATION: Only check the first few cards to avoid forced reflow
-      // on every card. Most users don't scroll past the first ~10 cards.
+      // the viewport top, using a tolerance for breathing room.
+      const CARD_ROW_TOLERANCE_PX = 20
+      const CARD_BREATHING_ROOM_PX = 12
+      const CARD_ROW_EPSILON_PX = 2
+      // Cap iterations so a pathological dashboard can't stall the save.
+      // The loop early-exits at the first card past scrollTop, so this only
+      // bounds the degenerate case where every visible card is above the fold.
+      const MAX_CARDS_TO_CHECK = 100
       let snapped = scrollTop
       let cardTitle: string | undefined
       const cards = container.querySelectorAll('[data-tour="card"]')
-      const maxCardsToCheck = Math.min(cards.length, 12) // Only check first 12 cards
-      if (maxCardsToCheck > 0) {
+      if (cards.length > 0) {
         const containerRect = container.getBoundingClientRect()
         // Find the last row whose top is at or above the viewport top + tolerance.
         // Then pick the FIRST card on that row (first in DOM order).
         let bestRowTop = -1
         let bestCard: Element | null = null
-        for (let i = 0; i < maxCardsToCheck; i++) {
+        // `bestCardHidden` flags the KeepAlive case: getBoundingClientRect
+        // returns zeros for display:none elements, so we may have "matched"
+        // a hidden card at position 0. In that case, fall back to the saved
+        // cardTitle preserved by the caller rather than wiping it.
+        let anyMeasurable = false
+        const upperBound = Math.min(cards.length, MAX_CARDS_TO_CHECK)
+        for (let i = 0; i < upperBound; i++) {
           const cardRect = cards[i].getBoundingClientRect()
+          if (cardRect.height === 0 && cardRect.width === 0) continue
+          anyMeasurable = true
           const cardAbsTop = cardRect.top - containerRect.top + scrollTop
-          if (cardAbsTop <= scrollTop + 20) {
-            // New row detected (position differs by more than 2px from last row)
-            if (Math.abs(cardAbsTop - bestRowTop) > 2) {
+          if (cardAbsTop <= scrollTop + CARD_ROW_TOLERANCE_PX) {
+            // New row detected (differs by more than epsilon from last row)
+            if (Math.abs(cardAbsTop - bestRowTop) > CARD_ROW_EPSILON_PX) {
               bestRowTop = cardAbsTop
               bestCard = cards[i] // first card on this new row
             }
@@ -123,9 +138,16 @@ export function useLastRoute() {
           }
         }
         if (bestCard && bestRowTop >= 0) {
-          snapped = Math.max(0, bestRowTop - 12) // 12px breathing room above card
+          snapped = Math.max(0, bestRowTop - CARD_BREATHING_ROOM_PX)
           const titleEl = bestCard.querySelector('h3')
           if (titleEl) cardTitle = titleEl.textContent?.trim()
+        } else if (!anyMeasurable) {
+          // Cards are all hidden (KeepAlive). Preserve prior cardTitle so
+          // the next visit can restore by title instead of by stale pixel.
+          const existing = positions[path]
+          if (typeof existing === 'object' && existing) {
+            cardTitle = existing.cardTitle
+          }
         }
       }
 
@@ -231,17 +253,14 @@ export function useLastRoute() {
     // On cleanup (path change), save scroll position of the page being left.
     // Use the ref value — KeepAlive sets display:none on old content before
     // cleanup runs, which clamps container.scrollTop. The ref has the real value.
+    // We route through saveScrollPositionNow so the cardTitle snap is preserved:
+    // without it, the entry loses its title and the next restore falls back to
+    // a pixel value that drifts as content above the cards lazy-loads (#7944).
     const scrollRef = scrollTopByPathRef.current
     return () => {
       const refScroll = scrollRef[location.pathname]
       if (refScroll !== undefined && refScroll > 0) {
-        try {
-          const positions = getScrollPositions()
-          positions[location.pathname] = { position: refScroll }
-          localStorage.setItem(SCROLL_POSITIONS_KEY, JSON.stringify(positions))
-        } catch {
-          // Ignore localStorage errors
-        }
+        saveScrollPositionNow(location.pathname, refScroll)
       } else {
         saveScrollPositionNow(location.pathname)
       }


### PR DESCRIPTION
## Summary

Fixes #7944. Pin button works, but the restored scroll position drifts: each round-trip through another dashboard shows the pinned card slightly higher up the page than the last visit.

## Root cause

useLastRoute.ts has two ways the scroll position is persisted:

- scroll-debounce save — saveScrollPositionNow snaps to the nearest card row and stores { position, cardTitle }. cardTitle is what makes restore robust against layout shifts.
- pathname-cleanup save — the effect that fires when you navigate away was writing { position: refScroll } directly to localStorage, dropping the cardTitle.

On the next visit, restoreScrollPosition sees no cardTitle and falls back to the raw pixel value. Because content above the card grid lazy-loads (StatsOverview, GettingStartedBanner, DemoToLocalCTA, PostConnectBanner), the pixel value points at a slightly different card each time, and the drift is cumulative.

Reproduced live on the running console with CDP:

1. Pin the main Dashboard, scroll to Deployment Status (row top ~1695) → saved { position: 1683, cardTitle: "Cluster Metrics" }
2. Click any sidebar link (/compliance) → storage becomes { position: 1606 } — cardTitle wiped, position drifted by −77 (outgoing route clamped its scroll as KeepAlive hid it).
3. Navigate back → restore uses pixel-only, content has shifted again, the pinned card is no longer at the viewport top.

## Fix

- saveScrollPositionNow now accepts an optional scrollTopOverride so the pathname-cleanup can supply the real pre-clamp scroll from scrollTopByPathRef. The override flows through the existing card-snap logic, which recomputes and stores cardTitle.
- The cleanup effect routes through saveScrollPositionNow(path, refScroll) instead of writing a bare {position} entry.
- When every card is hidden (KeepAlive has already applied display:none), the snap loop picks nothing. In that case, preserve whatever cardTitle is already in storage rather than wiping it.

Also removes the maxCardsToCheck = 12 cap in favour of a 100-card ceiling. The cap was a premature optimisation — the loop already early-exits at the first card past the viewport top, so the only iterations it bounded were the degenerate every-card-above-the-fold case. On that dashboard the saved cardTitle was always card #11, so even a 12-card dashboard couldn't remember positions past the middle.

Magic numbers in the snap logic (20px row tolerance, 12px breathing room, 2px row epsilon) are now named constants.

## Test plan
- [x] npm run build — green, all post-build safety checks pass
- [ ] Manual: pin /, scroll to Deployment Status, navigate to /compliance, navigate back → card stays at viewport top
- [ ] Manual: repeat round-trip through multiple dashboards → pinned position stable across visits
- [ ] Manual: pin a dashboard with >12 cards, scroll past card #12, navigate away and back → deep scroll restores correctly