### PR TITLE
fix(ci): address Copilot review on nightly dev-login retry loop (#7941)

### DIFF
--- a/.github/workflows/nightly-dashboard-health.yml
+++ b/.github/workflows/nightly-dashboard-health.yml
@@ -60,19 +60,32 @@ jobs:
           # The previous /health poll could succeed before Fiber had fully
           # bound the listener, so the subsequent curl returned empty/non-JSON
           # and jq died with a parse error (#7897). Waiting on the real
-          # endpoint avoids the race and keeps retries bounded to 30s.
+          # endpoint avoids the race (#7941).
+          #
+          # Retry budget: MAX_TRIES * (CURL_MAX_TIME + SLEEP_SECONDS) = worst case.
+          # 10 * (2 + 1) = 30s total, matching the original intent.
+          MAX_TRIES=10         # number of poll attempts
+          CURL_MAX_TIME=2      # seconds per curl attempt
+          SLEEP_SECONDS=1      # seconds between attempts
+          MAX_RESP_CHARS=200   # chars of last response to echo in error message
           LOGIN_RESP=""
           TOKEN=""
-          for i in $(seq 1 30); do
-            LOGIN_RESP=$(curl -sS --max-time 2 http://localhost:8081/auth/dev-login 2>/dev/null || true)
+          for i in $(seq 1 "$MAX_TRIES"); do
+            # Keep stderr so curl errors surface in the diagnostic line below.
+            # (-S is dropped intentionally: previously "curl -sS ... 2>/dev/null"
+            # silently discarded the very output -S was meant to emit.)
+            LOGIN_RESP=$(curl -s --max-time "$CURL_MAX_TIME" http://localhost:8081/auth/dev-login || true)
             if [ -n "$LOGIN_RESP" ] && [ "${LOGIN_RESP:0:1}" = "{" ]; then
               TOKEN=$(echo "$LOGIN_RESP" | jq -r '.token // empty' 2>/dev/null || true)
               if [ -n "$TOKEN" ]; then break; fi
             fi
-            sleep 1
+            sleep "$SLEEP_SECONDS"
           done
           if [ -z "$TOKEN" ]; then
-            echo "::error::Could not get dev-user token after 30s (last response: ${LOGIN_RESP:0:200})"
+            # Sanitize for GitHub Actions log commands: strip CR/LF and
+            # percent-encode '%' so ::error:: is not mangled by HTML responses.
+            SAFE_RESP=$(printf '%s' "${LOGIN_RESP:0:$MAX_RESP_CHARS}" | tr -d '\r\n' | sed 's/%/%25/g')
+            echo "::error::Could not get dev-user token after ${MAX_TRIES} tries (~30s) (last response: ${SAFE_RESP})"
             kill $PID 2>/dev/null; exit 1
           fi
           REFRESH_RESP=$(curl -sS --max-time 5 -X POST \


### PR DESCRIPTION
## Summary
Addresses the three Copilot review comments on the retry loop in `.github/workflows/nightly-dashboard-health.yml` from merged PR #7940.

- **Line 67 (`curl -sS ... 2>/dev/null`)** — `-S` is meant to show curl errors on stderr, but `2>/dev/null` discarded exactly that output. Switched to plain `-s` and dropped the stderr redirect so curl errors now surface in the diagnostic `LOGIN_RESP` line.
- **Line 72 (retry budget)** — the old comment claimed "retries bounded to 30s" but 30 iterations of `curl --max-time 2 + sleep 1` could take up to ~90s. Reduced `MAX_TRIES` from 30 to 10 so worst-case is `10 * (2 + 1) = 30s`, matching the documented intent. Per-iteration numbers are now named constants (`MAX_TRIES`, `CURL_MAX_TIME`, `SLEEP_SECONDS`, `MAX_RESP_CHARS`) with inline comments — no magic numbers.
- **Line 75 (sanitize error payload)** — `LOGIN_RESP` may contain CR/LF or `%` characters (especially while the loading server is still serving HTML), which mangle GitHub Actions `::error::` log commands. Added `tr -d '\r\n' | sed 's/%/%25/g'` before embedding the response.

Closes #7941
Refs #7940

## Test plan
- [x] `bash -n` on the extracted run block (passes)
- [ ] CI: build, lint, pr-check, ts-null-safety, fullstack-smoke, dco