### PR TITLE
fix: raise profile dropdown z-index above Mission Sidebar

### DIFF
--- a/web/src/components/layout/UserProfileDropdown.tsx
+++ b/web/src/components/layout/UserProfileDropdown.tsx
@@ -151,7 +151,7 @@ export function UserProfileDropdown({ user, onLogout, onPreferences }: UserProfi
 
       {/* Dropdown menu */}
       {isOpen && (
-        <div id="profile-dropdown-menu" role="menu" className="absolute right-0 top-full mt-2 w-72 max-w-[calc(100vw-1rem)] bg-card border border-border rounded-xl shadow-2xl overflow-hidden z-50">
+        <div id="profile-dropdown-menu" role="menu" className="absolute right-0 top-full mt-2 w-72 max-w-[calc(100vw-1rem)] bg-card border border-border rounded-xl shadow-2xl overflow-hidden z-toast">
           {/* Header with avatar and name */}
           <div className="p-4 bg-secondary border-b border-border">
             <div className="flex items-center gap-3">


### PR DESCRIPTION
## Summary

When the AI Mission Sidebar is open, clicking the user avatar in the navbar opens the profile dropdown **behind** the sidebar, making it unreachable.

**Root cause**: \`UserProfileDropdown\` menu used plain Tailwind \`z-50\`, while \`MissionSidebar\` sits at \`z-modal\` (400). Sidebar wins because it's both later in DOM and has higher z.

**Fix**: switch the dropdown's class from \`z-50\` → \`z-toast\` (500). This token is already defined in the project's z-index scale as "always on top of modals", which matches the semantic need — a popover triggered from the navbar should sit above persistent panels like the mission sidebar.

## Test plan
- [ ] Open AI Missions sidebar
- [ ] Click user avatar in navbar — dropdown visible in front of sidebar
- [ ] All dropdown items clickable