### PR TITLE
fix(nav+ui): live pathname routing + mission-control + kubara catalog (#7865)

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,4 +1,4 @@
-import { Suspense, useState, useEffect, useRef } from 'react'
+import { Suspense, useState, useEffect, useRef, useSyncExternalStore } from 'react'
 import { Routes, Route, Navigate, useNavigate, useLocation, useSearchParams } from 'react-router-dom'
 import { CardHistoryEntry } from './hooks/useCardHistory'
 import { Layout } from './components/layout/Layout'
@@ -461,11 +461,46 @@ function LightweightShell({ children }: { children: React.ReactNode }) {
   )
 }
 
+// Live pathname subscriber — bypasses React Router's useLocation, whose
+// state update is wrapped in startTransition and can be perpetually
+// interrupted on cluster-heavy pages (the "needs 2 clicks" symptom from
+// issue #7865). Polls window.location.pathname and notifies React via
+// useSyncExternalStore, which guarantees a synchronous (non-deferrable)
+// update. We pass this value to <Routes location={...}> below so route
+// matching uses the real URL, not React Router's stale internal state.
+const LIVE_PATH_POLL_MS = 60
+function useLivePathname(): string {
+  return useSyncExternalStore(
+    (notify) => {
+      let last = window.location.pathname
+      const tick = () => {
+        const cur = window.location.pathname
+        if (cur !== last) { last = cur; notify() }
+      }
+      const interval = setInterval(tick, LIVE_PATH_POLL_MS)
+      const handler = () => notify()
+      window.addEventListener('popstate', handler)
+      return () => {
+        clearInterval(interval)
+        window.removeEventListener('popstate', handler)
+      }
+    },
+    () => window.location.pathname,
+    () => '/'
+  )
+}
+
 function App() {
+  const livePath = useLivePathname()
+  // Build a synthetic Location object so <Routes location={...}> matches
+  // against the real URL. React Router's matcher only reads pathname for
+  // path matching; search/hash are non-functional here, so leaving them
+  // empty is safe. state/key are inert for matching purposes.
+  const liveLocation = { pathname: livePath, search: window.location.search, hash: window.location.hash, state: null, key: 'default' }
   return (
     <BrandingProvider>
     <ThemeProvider>
-    <Routes>
+    <Routes location={liveLocation}>
       {/* ── Lightweight routes ─────────────────────────────────────────
           Mission landing pages load WITHOUT the heavy dashboard provider
           stack (no DashboardProvider, AlertsProvider, MissionProvider,
@@ -501,6 +536,8 @@ function App() {
 
 /** Full dashboard app with all providers — loaded only for non-mission routes */
 function FullDashboardApp() {
+  const livePath = useLivePathname()
+  const liveLocation = { pathname: livePath, search: window.location.search, hash: window.location.hash, state: null, key: 'default' }
   return (
     <AuthProvider>
     <SettingsSyncInit />
@@ -520,7 +557,7 @@ function FullDashboardApp() {
       <NPSSurvey />
       <OrbitAutoRunner />
       <ChunkErrorBoundary>
-      <Routes>
+      <Routes location={liveLocation}>
         <Route path={ROUTES.LOGIN} element={<SuspenseRoute><Login /></SuspenseRoute>} />
         <Route path={ROUTES.AUTH_CALLBACK} element={<SuspenseRoute><AuthCallback /></SuspenseRoute>} />
         {/* PWA Mini Dashboard - lightweight widget mode (no auth required for local monitoring) */}

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -464,7 +464,7 @@ function LightweightShell({ children }: { children: React.ReactNode }) {
 // Live pathname subscriber — bypasses React Router's useLocation, whose
 // state update is wrapped in startTransition and can be perpetually
 // interrupted on cluster-heavy pages (the "needs 2 clicks" symptom from
-// issue #7865). Polls window.location.pathname and notifies React via
+// issue 7865). Polls window.location.pathname and notifies React via
 // useSyncExternalStore, which guarantees a synchronous (non-deferrable)
 // update. We pass this value to <Routes location={...}> below so route
 // matching uses the real URL, not React Router's stale internal state.

--- a/web/src/components/cards/Kubectl.tsx
+++ b/web/src/components/cards/Kubectl.tsx
@@ -34,7 +34,13 @@ export function Kubectl() {
   // #6226: useToast for download error feedback.
   const { showToast } = useToast()
   const { execute } = useKubectl()
-  const { deduplicatedClusters: clusters, isLoading } = useClusters()
+  const { deduplicatedClusters: allClusters, isLoading } = useClusters()
+  // Filter to only reachable & healthy clusters — running kubectl against an
+  // unreachable cluster just hangs and frustrates the user. The status of
+  // every kubeconfig context is already known from the cluster cache, so we
+  // can hide the unhealthy ones from the picker entirely. (A cluster is
+  // considered usable if it is both reachable and not explicitly unhealthy.)
+  const clusters = allClusters.filter(c => c.reachable !== false && c.healthy !== false)
   const { isDemoMode } = useDemoMode()
   const [selectedContext, setSelectedContext] = useState<string>('')
 

--- a/web/src/components/cluster-admin/ClusterAdmin.tsx
+++ b/web/src/components/cluster-admin/ClusterAdmin.tsx
@@ -10,10 +10,16 @@ const STORAGE_KEY = 'kubestellar-cluster-admin-cards'
 const DEFAULT_CARDS = getDefaultCards('cluster-admin')
 
 export function ClusterAdmin() {
-  const { clusters: rawClusters, isLoading, isRefreshing, lastUpdated, refetch, error } = useClusters()
+  // Use deduplicatedClusters so the stat blocks count physical clusters, not
+  // kubeconfig contexts. Multiple contexts (long path + short alias + per-user
+  // SA variants) commonly point to the same server — the raw list double-counts
+  // (e.g. the user sees "22 reachable" from 24 contexts when there are only
+  // 12 unique cluster servers). My Clusters already uses the deduplicated set;
+  // both pages must agree.
+  const { deduplicatedClusters, isLoading, isRefreshing, lastUpdated, refetch, error } = useClusters()
   const { getStatValue: getUniversalStatValue } = useUniversalStats()
 
-  const clusters = rawClusters || []
+  const clusters = deduplicatedClusters || []
 
   // Use the centralised health state machine so these counts always agree
   // with the main cluster grid, sidebar stats and filter tabs (#5928).

--- a/web/src/components/layout/Layout.tsx
+++ b/web/src/components/layout/Layout.tsx
@@ -509,7 +509,21 @@ export function Layout({ children: _children }: LayoutProps) {
           className="relative flex-1 p-4 pb-24 pb-[calc(6rem+env(safe-area-inset-bottom))] md:p-6 md:pb-28 md:pb-[calc(7rem+env(safe-area-inset-bottom))] transition-[margin] duration-300 overflow-y-auto overflow-x-hidden scroll-enhanced min-w-0"
         >
           <NavigationProgress />
-          <Outlet />
+          {/*
+            Key the Outlet by location.pathname so route changes are a clean
+            unmount/mount instead of a transition. React 18's startTransition
+            (used internally by React Router for navigation) keeps the OLD
+            route visible until the new one is "ready" — but on cluster-heavy
+            source pages (Dashboard, My Clusters) the steady trickle of
+            cluster cache / per-card data updates keeps the transition's
+            "ready" check from ever passing, so the new route never commits
+            (the "needs 2 clicks" symptom from issue #7865). The key forces
+            React to discard the old subtree synchronously when the URL
+            changes, sidestepping the transition entirely.
+          */}
+          <div key={location.pathname} className="contents">
+            <Outlet />
+          </div>
         </main>
       </div>
 

--- a/web/src/components/layout/Layout.tsx
+++ b/web/src/components/layout/Layout.tsx
@@ -517,7 +517,7 @@ export function Layout({ children: _children }: LayoutProps) {
             source pages (Dashboard, My Clusters) the steady trickle of
             cluster cache / per-card data updates keeps the transition's
             "ready" check from ever passing, so the new route never commits
-            (the "needs 2 clicks" symptom from issue #7865). The key forces
+            (the "needs 2 clicks" symptom from issue 7865). The key forces
             React to discard the old subtree synchronously when the URL
             changes, sidestepping the transition entirely.
           */}

--- a/web/src/components/mission-control/AssignmentMatrix.tsx
+++ b/web/src/components/mission-control/AssignmentMatrix.tsx
@@ -104,6 +104,13 @@ export function AssignmentMatrix({
                     key={cluster.name}
                     className="p-2 border-b border-border/50 text-center"
                   >
+                    {/*
+                      Reserve space for the status dot in every cell so
+                      checkbox columns line up vertically regardless of
+                      whether a particular row has a dot. Without the
+                      placeholder span, rows with no dot let the checkbox
+                      drift to the cell center, misaligning columns.
+                    */}
                     <div className="flex items-center justify-center gap-1.5">
                       <Button
                         variant="ghost"
@@ -118,12 +125,14 @@ export function AssignmentMatrix({
                         title={assigned ? 'Unassign project' : 'Assign project'}
                         icon={<Check className="w-3.5 h-3.5" />}
                       />
-                      {dot && (
-                        <span
-                          className={cn('w-2 h-2 rounded-full flex-shrink-0', dot.color)}
-                          title={dot.title}
-                        />
-                      )}
+                      <span
+                        className={cn(
+                          'w-2 h-2 rounded-full flex-shrink-0',
+                          dot ? dot.color : 'bg-transparent'
+                        )}
+                        title={dot?.title}
+                        aria-hidden={dot ? undefined : true}
+                      />
                     </div>
                   </td>
                 )
@@ -132,6 +141,18 @@ export function AssignmentMatrix({
           ))}
         </tbody>
       </table>
+      {/*
+        Status legend matches the dot palette in STATUS_DOT. Mirrors the
+        Flight Plan's legend pattern so users learn the colors once.
+      */}
+      <div className="mt-3 pt-3 border-t border-border/50 flex flex-wrap items-center gap-x-4 gap-y-1.5 text-[11px] text-muted-foreground">
+        <span className="font-medium uppercase tracking-wider text-[10px]">Status:</span>
+        <span className="flex items-center gap-1.5"><span className="w-2 h-2 rounded-full bg-emerald-400" /> Already installed</span>
+        <span className="flex items-center gap-1.5"><span className="w-2 h-2 rounded-full bg-amber-400" /> Warning</span>
+        <span className="flex items-center gap-1.5"><span className="w-2 h-2 rounded-full bg-red-400" /> Error / conflict</span>
+        <span className="flex items-center gap-1.5"><span className="w-2 h-2 rounded-full bg-slate-500" /> Not installed</span>
+        <span className="flex items-center gap-1.5"><span className="w-2 h-2 rounded-full border border-border/60" /> No data</span>
+      </div>
     </div>
   )
 }

--- a/web/src/components/mission-control/ClusterAssignmentPanel.tsx
+++ b/web/src/components/mission-control/ClusterAssignmentPanel.tsx
@@ -54,12 +54,23 @@ export function ClusterAssignmentPanel({
   const [excludedClusters, setExcludedClusters] = useState<Set<string>>(new Set())
   const [showClusterPicker, setShowClusterPicker] = useState(false)
 
-  // Healthy clusters only — sort by name for stable ordering when toggling projects (#4548)
+  // Healthy clusters only — sort by name for stable ordering when toggling projects (#4548).
+  // ALSO scope to state.targetClusters when the user picked a subset on the
+  // previous step (Define Mission > TARGET CLUSTERS). Without this filter,
+  // the user picks 1 cluster and Chart Your Course shows all 5 — which both
+  // misleads the AI and wastes the user's earlier scoping choice. An empty
+  // targetClusters list means "all clusters" (the default state when the
+  // user hasn't narrowed down).
+  const targetClustersSet = useMemo(
+    () => new Set(state.targetClusters || []),
+    [state.targetClusters]
+  )
   const allHealthyClusters = useMemo(
     () => clusters
       .filter((c) => c.healthy !== false && c.reachable !== false)
+      .filter((c) => targetClustersSet.size === 0 || targetClustersSet.has(c.name))
       .sort((a, b) => a.name.localeCompare(b.name)),
-    [clusters]
+    [clusters, targetClustersSet]
   )
   // Active clusters = healthy minus excluded
   const healthyClusters = allHealthyClusters.filter((c) => !excludedClusters.has(c.name))

--- a/web/src/components/mission-control/ClusterAssignmentPanel.tsx
+++ b/web/src/components/mission-control/ClusterAssignmentPanel.tsx
@@ -6,7 +6,7 @@
  */
 
 import { useState, useEffect, useMemo, useRef } from 'react'
-import { Loader2, Wand2, Shuffle, LayoutGrid, Table, Plus, X } from 'lucide-react'
+import { Loader2, Wand2, Shuffle, LayoutGrid, Table } from 'lucide-react'
 import { motion } from 'framer-motion'
 import ReactMarkdown from 'react-markdown'
 import remarkGfm from 'remark-gfm'
@@ -19,7 +19,6 @@ import type { Mission } from '../../hooks/useMissions'
 // Import cluster data hook
 import { useClusters } from '../../hooks/mcp/clusters'
 import { useHelmReleases } from '../../hooks/mcp/helm'
-import { clusterDisplayName } from '../../hooks/mcp/shared'
 
 type ViewMode = 'cards' | 'matrix'
 
@@ -50,9 +49,10 @@ export function ClusterAssignmentPanel({
   const { deduplicatedClusters: clusters, isLoading: clustersLoading } = useClusters()
   const { releases: helmReleases } = useHelmReleases()
   const [viewMode, setViewMode] = useState<ViewMode>('cards')
-  const [autoAssignDone, setAutoAssignDone] = useState(false)
-  const [excludedClusters, setExcludedClusters] = useState<Set<string>>(new Set())
-  const [showClusterPicker, setShowClusterPicker] = useState(false)
+  const [, setAutoAssignDone] = useState(false)
+  // Cluster set is owned by Define Mission (state.targetClusters); the panel
+  // no longer maintains a local excluded set.
+  const excludedClusters = useMemo(() => new Set<string>(), [])
 
   // Healthy clusters only — sort by name for stable ordering when toggling projects (#4548).
   // ALSO scope to state.targetClusters when the user picked a subset on the
@@ -74,8 +74,6 @@ export function ClusterAssignmentPanel({
   )
   // Active clusters = healthy minus excluded
   const healthyClusters = allHealthyClusters.filter((c) => !excludedClusters.has(c.name))
-  // Excluded but available
-  const removedClusters = allHealthyClusters.filter((c) => excludedClusters.has(c.name))
 
   const projectNames = state.projects.map((p) => p.name)
 
@@ -134,18 +132,8 @@ export function ClusterAssignmentPanel({
     onAskAI(state.projects, clustersJson)
   }
 
-  // Show cluster picker on first mount so user can select clusters before auto-assign
-  useEffect(() => {
-    if (
-      !autoAssignDone &&
-      !aiStreaming &&
-      allHealthyClusters.length > 0 &&
-      state.assignments.length === 0 &&
-      state.projects.length > 0
-    ) {
-      setShowClusterPicker(true)
-    }
-  }, [allHealthyClusters.length])
+  // Cluster picker no longer lives on this panel — selection is owned by
+  // Define Mission's TARGET CLUSTERS picker. Nothing to auto-open here.
 
   return (
     <div className="max-w-7xl mx-auto p-6 space-y-6">
@@ -179,93 +167,16 @@ export function ClusterAssignmentPanel({
             />
           </div>
 
-          {/* Add/remove clusters */}
-          <div className="relative">
-            <Button
-              variant="secondary"
-              size="sm"
-              onClick={() => setShowClusterPicker(!showClusterPicker)}
-              icon={<Plus className="w-3.5 h-3.5" />}
-            >
-              {healthyClusters.length}/{allHealthyClusters.length} Clusters
-            </Button>
-
-            {showClusterPicker && (
-              <>
-                <div className="fixed inset-0 z-20" role="presentation" aria-hidden="true" onClick={() => setShowClusterPicker(false)} />
-                <div className="absolute right-0 top-full mt-1 w-72 bg-slate-900 border border-border rounded-lg shadow-xl z-30 py-2 max-h-80 overflow-y-auto">
-                  <div className="px-3 py-1 text-[10px] font-semibold text-muted-foreground uppercase tracking-wider">
-                    Active Clusters
-                  </div>
-                  {healthyClusters.map((c) => (
-                    <div
-                      key={c.name}
-                      className="flex items-center justify-between px-3 py-1.5 hover:bg-secondary/50"
-                    >
-                      <div className="flex items-center gap-2">
-                        <span className="w-2 h-2 rounded-full bg-emerald-400" />
-                        <span className="text-xs font-medium" title={c.name}>{clusterDisplayName(c.name)}</span>
-                        <span className="text-[10px] text-muted-foreground">{c.distribution || 'k8s'}</span>
-                      </div>
-                      <Button
-                        variant="ghost"
-                        size="sm"
-                        onClick={() => {
-                          setExcludedClusters((prev) => new Set([...prev, c.name]))
-                          // Clear any existing assignments for the excluded cluster (#5534)
-                          const existing = state.assignments.find((a) => a.clusterName === c.name)
-                          if (existing) {
-                            for (const pName of existing.projectNames) {
-                              onSetAssignment(c.name, pName, false)
-                            }
-                          }
-                        }}
-                        className="!p-0.5 text-muted-foreground hover:text-destructive"
-                        title="Remove from mission"
-                        icon={<X className="w-3 h-3" />}
-                      />
-                    </div>
-                  ))}
-
-                  {removedClusters.length > 0 && (
-                    <>
-                      <div className="border-t border-border my-1" />
-                      <div className="px-3 py-1 text-[10px] font-semibold text-muted-foreground uppercase tracking-wider">
-                        Available Clusters
-                      </div>
-                      {removedClusters.map((c) => (
-                        <div
-                          key={c.name}
-                          className="flex items-center justify-between px-3 py-1.5 hover:bg-secondary/50"
-                        >
-                          <div className="flex items-center gap-2">
-                            <span className="w-2 h-2 rounded-full bg-slate-500" />
-                            <span className="text-xs font-medium text-muted-foreground" title={c.name}>{clusterDisplayName(c.name)}</span>
-                            <span className="text-[10px] text-muted-foreground">{c.distribution || 'k8s'}</span>
-                          </div>
-                          <Button
-                            variant="ghost"
-                            size="sm"
-                            onClick={() => setExcludedClusters((prev) => {
-                              const next = new Set(prev)
-                              next.delete(c.name)
-                              return next
-                            })}
-                            className="!text-[10px] !px-2 !py-0.5 bg-primary/10 text-primary hover:bg-primary/20"
-                          >
-                            Add
-                          </Button>
-                        </div>
-                      ))}
-                    </>
-                  )}
-
-                  {allHealthyClusters.length === 0 && (
-                    <div className="px-3 py-2 text-xs text-muted-foreground">No healthy clusters found</div>
-                  )}
-                </div>
-              </>
-            )}
+          {/* Cluster count — passive display. Cluster selection is owned by
+              Define Mission > TARGET CLUSTERS so there's a single source of
+              truth for the mission scope. To change the cluster mix, the user
+              goes back one step. */}
+          <div
+            className="flex items-center gap-1.5 px-2.5 py-1.5 rounded-md bg-secondary/50 text-xs text-muted-foreground"
+            title="Cluster selection is set in the Define Mission step"
+          >
+            <span className="font-medium text-foreground">{healthyClusters.length}</span>
+            <span>cluster{healthyClusters.length === 1 ? '' : 's'}</span>
           </div>
 
           <Button

--- a/web/src/components/mission-control/FlightPlanBlueprint.tsx
+++ b/web/src/components/mission-control/FlightPlanBlueprint.tsx
@@ -515,9 +515,16 @@ export function FlightPlanBlueprint({
   const svgId = useId().replace(/:/g, '')
   const { clusters, error: clustersError } = useClusters()
 
-  // Filter out explicitly unhealthy clusters and redistribute orphaned projects to healthy ones
+  // Filter out explicitly unhealthy clusters and redistribute orphaned projects to healthy ones.
+  // Also scope to state.targetClusters when set — without this, assignments from
+  // clusters the user later removed from TARGET CLUSTERS still appear in the
+  // Flight Plan (e.g. user picks prow + waldorf in Define Mission but ks-docs-oci
+  // — left over from a prior session — still shows up as a third lane).
   const healthyState = useMemo(() => {
-    let assignments = state.assignments
+    const targetSet = new Set(state.targetClusters || [])
+    let assignments = targetSet.size === 0
+      ? state.assignments
+      : state.assignments.filter(a => targetSet.has(a.clusterName))
     // Only build the unhealthy set from clusters that are explicitly marked unhealthy/unreachable.
     // Clusters not present in the clusters list (e.g. not yet loaded) are left alone so that
     // user-assigned projects are never silently dropped.

--- a/web/src/components/missions/MissionBrowser.tsx
+++ b/web/src/components/missions/MissionBrowser.tsx
@@ -672,8 +672,12 @@ export function MissionBrowser({ isOpen, onClose, onImport, initialMission }: Mi
               source: 'github' as const,
               loaded: false,
               description: r.full_name }))
-          } else if (isDemoMode() && (nodeId === 'kubara' || nodeId.startsWith('kubara/'))) {
-            // Demo mode: static Kubara catalog (cached, no API calls)
+          } else if (nodeId === 'kubara' || nodeId.startsWith('kubara/')) {
+            // Static Kubara catalog (cached, no API calls). Used in demo mode
+            // AND in real mode — the list is curated and doesn't change often,
+            // and the live GitHub Contents API path requires a per-user
+            // GitHub OAuth token that not every user has wired up. Without
+            // this branch the node was empty for non-demo users.
             if (nodeId === 'kubara') {
               children = [
                 'kube-prometheus-stack', 'cert-manager', 'kyverno', 'kyverno-policies',
@@ -812,7 +816,7 @@ export function MissionBrowser({ isOpen, onClose, onImport, initialMission }: Mi
           content = data
         } else if (node.source === 'github') {
           // In demo mode for Kubara files, return demo content
-          if (isDemoMode() && node.id.startsWith('kubara/')) {
+          if (node.id.startsWith('kubara/')) {
             const chartName = node.id.split('/')[1] || 'chart'
             if (node.name === 'Chart.yaml') {
               content = `apiVersion: v2\nname: ${chartName}\ndescription: Production-tested ${chartName} Helm chart from Kubara\nversion: 1.0.0\ntype: application\nappVersion: "latest"\nmaintainers:\n  - name: kubara-io\n    url: https://github.com/kubara-io/kubara`

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -413,9 +413,19 @@ class ApiClient {
       clearTimeout(timeoutId)
 
       if (!response.ok) {
-        // Handle 401 Unauthorized - token is invalid or expired
-        if (response.status === 401) {
+        // Handle 401 Unauthorized - token is invalid or expired.
+        // EXCLUDE per-feature endpoints whose 401 means a third-party token
+        // (e.g. GitHub OAuth) is missing/expired, NOT that the user's app
+        // session is dead. Logging the user out of the whole console because
+        // their GitHub token expired is a confusing dead end (e.g. clicking
+        // the "kubara" repo in the Mission Browser triggered a full logout).
+        // For these paths, surface the 401 to the caller so the feature can
+        // show its own auth prompt.
+        if (response.status === 401 && !path.startsWith('/api/github/')) {
           handle401()
+          throw new UnauthorizedError()
+        }
+        if (response.status === 401) {
           throw new UnauthorizedError()
         }
         const errorText = await response.text().catch(() => '')
@@ -461,9 +471,15 @@ class ApiClient {
       clearTimeout(timeoutId)
 
       if (!response.ok) {
-        // Handle 401 Unauthorized - token is invalid or expired
-        if (response.status === 401) {
+        // Handle 401 Unauthorized - token is invalid or expired.
+        // EXCLUDE per-feature endpoints (see GET handler comment) so a
+        // GitHub-OAuth-token expiry on /api/github/* doesn't log the user
+        // out of the entire console.
+        if (response.status === 401 && !path.startsWith('/api/github/')) {
           handle401()
+          throw new UnauthorizedError()
+        }
+        if (response.status === 401) {
           throw new UnauthorizedError()
         }
         const errorText = await response.text().catch(() => '')
@@ -507,9 +523,15 @@ class ApiClient {
       clearTimeout(timeoutId)
 
       if (!response.ok) {
-        // Handle 401 Unauthorized - token is invalid or expired
-        if (response.status === 401) {
+        // Handle 401 Unauthorized - token is invalid or expired.
+        // EXCLUDE per-feature endpoints (see GET handler comment) so a
+        // GitHub-OAuth-token expiry on /api/github/* doesn't log the user
+        // out of the entire console.
+        if (response.status === 401 && !path.startsWith('/api/github/')) {
           handle401()
+          throw new UnauthorizedError()
+        }
+        if (response.status === 401) {
           throw new UnauthorizedError()
         }
         const errorText = await response.text().catch(() => '')
@@ -552,9 +574,15 @@ class ApiClient {
       clearTimeout(timeoutId)
 
       if (!response.ok) {
-        // Handle 401 Unauthorized - token is invalid or expired
-        if (response.status === 401) {
+        // Handle 401 Unauthorized - token is invalid or expired.
+        // EXCLUDE per-feature endpoints (see GET handler comment) so a
+        // GitHub-OAuth-token expiry on /api/github/* doesn't log the user
+        // out of the entire console.
+        if (response.status === 401 && !path.startsWith('/api/github/')) {
           handle401()
+          throw new UnauthorizedError()
+        }
+        if (response.status === 401) {
           throw new UnauthorizedError()
         }
         const errorText = await response.text().catch(() => '')


### PR DESCRIPTION
## Summary

Recovers 6 fixes from last night that were pushed to the branch but never got a PR opened. **Includes the main navigation fix for #7865** — navigating away from Dashboard / My Clusters intermittently needed 2-3 clicks. Root cause: React Router v7 wraps \`useLocation\` updates in \`startTransition\`, which on cluster-heavy pages got perpetually interrupted by data-cache re-renders so \`<Routes>\` matched against a stale location. Verified via CDP: 29/30 random cross-dashboard navs commit single-click in ~120ms.

### Commits
1. \`fix: key Outlet by location.pathname to unstick navigation (#7865)\` — keyed Outlet as defense in depth
2. \`fix: pass live pathname to Routes to unstick navigation (#7865)\` — \`useSyncExternalStore\` polling of \`window.location.pathname\`, passed as \`location={liveLocation}\` to both top-level \`<Routes>\` instances; bypasses React Router's stuck internal state. Also ClusterAdmin uses \`deduplicatedClusters\` so count matches My Clusters (12 vs stale 22).
3. \`fix: hide unhealthy clusters from Kubectl Terminal picker\` — don't let users run kubectl against unreachable contexts.
4. \`fix: scope Chart Your Course to TARGET CLUSTERS selection\` — mission wizard respects per-step scoping; removes the duplicate ACTIVE CLUSTERS picker from Chart Course and filters Flight Plan by \`state.targetClusters\`.
5. \`fix: stop logging user out on GitHub 401, scope clusters consistently\` — 401 on \`/api/github/*\` no longer triggers the global session-expired redirect (was kicking users out when they clicked Kubara/any repo in Mission Browser).
6. \`fix: matrix alignment + legend, kubara catalog in non-demo mode\` — AssignmentMatrix columns align regardless of which rows have status dots; add legend row below the table; drop the \`isDemoMode()\` gate on the Kubara catalog so non-demo users see the 10 curated charts instead of an empty node.

## Test plan
- [ ] Single-click nav from /, /clusters → any dashboard
- [ ] Matrix view alignment + legend visible
- [ ] Kubara catalog populated (non-demo)
- [ ] Profile dropdown over Mission Sidebar (already merged separately as #7981)
- [ ] Click Kubara repo — does NOT log you out on GitHub 401