### PR TITLE
fix(handlers): cap io.ReadAll on upstream streams (#7963, #7964)

### DIFF
--- a/pkg/api/handlers/benchmarks.go
+++ b/pkg/api/handlers/benchmarks.go
@@ -16,6 +16,14 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
+// maxBenchmarkReportBytes caps the size of a single benchmark report we will
+// buffer from Google Drive. #7963 — previously downloadDriveFile called
+// io.ReadAll directly on the upstream body, so a huge or malicious file id
+// could OOM the server. 50 MiB is far larger than any real report (typical
+// reports are <1 MiB) but small enough to bound worst-case memory per
+// download.
+const maxBenchmarkReportBytes = 50 * 1024 * 1024 // 50 MiB
+
 // ---------------------------------------------------------------------------
 // v0.2 output structs — match the TypeScript BenchmarkReport interface
 // ---------------------------------------------------------------------------
@@ -876,14 +884,27 @@ func (h *BenchmarkHandlers) downloadDriveFile(fileID string) ([]byte, error) {
 	defer resp.Body.Close()
 
 	if resp.StatusCode != 200 {
-		body, readErr := io.ReadAll(resp.Body)
+		// #7963 — bound error-body reads too, so a non-200 status can't be
+		// used to force the parent to buffer an unbounded body.
+		body, readErr := io.ReadAll(io.LimitReader(resp.Body, maxBenchmarkReportBytes))
 		if readErr != nil {
 			body = []byte("(failed to read response body)")
 		}
 		return nil, fmt.Errorf("Drive download returned %d: %s", resp.StatusCode, string(body))
 	}
 
-	return io.ReadAll(resp.Body)
+	// #7963 — cap the download at maxBenchmarkReportBytes. io.LimitReader
+	// silently truncates, so pair with ReadAll and (below) explicitly check
+	// whether we hit the cap so callers see a real error rather than a
+	// partially-decoded report.
+	data, err := io.ReadAll(io.LimitReader(resp.Body, maxBenchmarkReportBytes+1))
+	if err != nil {
+		return nil, err
+	}
+	if int64(len(data)) > maxBenchmarkReportBytes {
+		return nil, fmt.Errorf("Drive download exceeded max size of %d bytes", maxBenchmarkReportBytes)
+	}
+	return data, nil
 }
 
 // ---------------------------------------------------------------------------

--- a/pkg/api/handlers/kagent_proxy.go
+++ b/pkg/api/handlers/kagent_proxy.go
@@ -11,6 +11,14 @@ import (
 	"github.com/kubestellar/console/pkg/kagent"
 )
 
+// maxAgentResponseBytes caps the size of a single agent response we will
+// buffer in-memory from a kagent/kagenti upstream. #7964 — previously the
+// proxy called io.ReadAll on the agent stream with no size limit, so one
+// adversarial or looping tool invocation could wedge the server on memory.
+// 10 MiB is far larger than any realistic agent reply and small enough to
+// keep worst-case memory per request bounded.
+const maxAgentResponseBytes = 10 * 1024 * 1024 // 10 MiB
+
 // KagentProxyHandler proxies requests to the kagent A2A endpoint.
 type KagentProxyHandler struct {
 	client *kagent.KagentClient // can be nil if kagent not detected
@@ -141,9 +149,18 @@ func (h *KagentProxyHandler) CallTool(c *fiber.Ctx) error {
 	}
 	defer stream.Close()
 
-	body, err := io.ReadAll(stream)
+	// #7964 — bound the agent response so one runaway invocation cannot
+	// force unbounded allocations. Read +1 past the cap so we can detect
+	// truncation and surface a real error instead of a silently-clipped
+	// result.
+	body, err := io.ReadAll(io.LimitReader(stream, maxAgentResponseBytes+1))
 	if err != nil {
 		return c.Status(fiber.StatusBadGateway).JSON(fiber.Map{"error": "failed to read agent response"})
+	}
+	if int64(len(body)) > maxAgentResponseBytes {
+		return c.Status(fiber.StatusBadGateway).JSON(fiber.Map{
+			"error": fmt.Sprintf("agent response exceeded max size of %d bytes", maxAgentResponseBytes),
+		})
 	}
 
 	return c.JSON(fiber.Map{

--- a/pkg/api/handlers/kagenti_provider_proxy.go
+++ b/pkg/api/handlers/kagenti_provider_proxy.go
@@ -141,9 +141,17 @@ func (h *KagentiProviderProxyHandler) CallTool(c *fiber.Ctx) error {
 	}
 	defer stream.Close()
 
-	body, err := io.ReadAll(stream)
+	// #7964 — bound the agent response so one runaway invocation cannot
+	// force unbounded allocations. Shares maxAgentResponseBytes with the
+	// kagent proxy since both expose the same A2A surface.
+	body, err := io.ReadAll(io.LimitReader(stream, maxAgentResponseBytes+1))
 	if err != nil {
 		return c.Status(fiber.StatusBadGateway).JSON(fiber.Map{"error": "failed to read agent response"})
+	}
+	if int64(len(body)) > maxAgentResponseBytes {
+		return c.Status(fiber.StatusBadGateway).JSON(fiber.Map{
+			"error": fmt.Sprintf("agent response exceeded max size of %d bytes", maxAgentResponseBytes),
+		})
 	}
 
 	return c.JSON(fiber.Map{


### PR DESCRIPTION
## Summary

Three upstream-body reads in handlers were unbounded `io.ReadAll` calls. One huge or adversarial response could OOM the server. Cap each with `io.LimitReader` and surface a real error on truncation.

Fixes #7963, #7964.

## Changes

- **benchmarks.go** `downloadDriveFile` → cap at `maxBenchmarkReportBytes = 50 MiB` (far larger than any real report; typical <1 MiB). Also bound the non-200 error-body read.
- **kagent_proxy.go** `CallTool` + **kagenti_provider_proxy.go** `CallTool` → cap at `maxAgentResponseBytes = 10 MiB`. Shared constant since both expose the same A2A surface.
- Read `cap+1` bytes to detect truncation, then explicit length check; returns a 502 with a real error instead of a silently-clipped result.

## Test plan
- [x] `go build ./...` green
- [x] `go vet ./pkg/api/handlers/...` clean
- [ ] Manual: hit the benchmarks endpoint with a real Drive file, confirm it still decodes
- [ ] Manual: hit a kagent tool call, confirm the response round-trips