### PR TITLE
fix: raise navbar z-index so profile dropdown escapes its stacking context

### DIFF
--- a/web/src/components/layout/navbar/Navbar.tsx
+++ b/web/src/components/layout/navbar/Navbar.tsx
@@ -58,7 +58,7 @@ export function Navbar({ topOffset = 0 }: NavbarProps) {
   }, [location.pathname])
 
   return (
-    <nav data-tour="navbar" style={{ top: topOffset }} className="fixed left-0 right-0 h-16 glass z-50 px-3 md:px-6 flex items-center justify-between">
+    <nav data-tour="navbar" style={{ top: topOffset }} className="fixed left-0 right-0 h-16 glass z-toast px-3 md:px-6 flex items-center justify-between">
       {/* Left side: Hamburger + Logo — shrink-0 so logo is never compressed */}
       <div className="flex items-center gap-2 md:gap-3 shrink-0">
         {/* Hamburger menu - mobile only */}


### PR DESCRIPTION
## Summary

PR #7981 raised the \`UserProfileDropdown\` menu to \`z-toast\` (500) so it would sit above the Mission Sidebar (\`z-modal\`=400). That fix didn't take effect because the menu is a descendant of \`<nav class=\"z-50\">\`, and a stacking context created by the parent caps its children — \`z-toast\` on the inner menu couldn't escape the navbar's \`z-50\` ceiling.

Raise the navbar itself to \`z-toast\` so its descendants (profile dropdown, notifications, search suggestions) can actually sit above the Mission Sidebar.

## Test plan
- [ ] Open AI Missions sidebar
- [ ] Click profile avatar → dropdown visible over sidebar, all items clickable
- [ ] Verify notifications bell dropdown + search suggestions also behave correctly