### PR TITLE
fix(handlers): parallelize cluster fanout + propagate per-cluster errors (#7966, #7967, #7969, #7973)

### DIFF
--- a/pkg/api/handlers/admission_webhooks.go
+++ b/pkg/api/handlers/admission_webhooks.go
@@ -2,10 +2,12 @@ package handlers
 
 import (
 	"context"
+	"sync"
 	"time"
 
 	"github.com/gofiber/fiber/v2"
 	"github.com/kubestellar/console/pkg/k8s"
+	"golang.org/x/sync/errgroup"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -13,6 +15,16 @@ import (
 
 // webhookListTimeout is the timeout for listing webhooks across all clusters.
 const webhookListTimeout = 30 * time.Second
+
+// defaultClusterFanoutConcurrency bounds how many clusters a handler fans out
+// to in parallel. 4 matches the HTTP/1.1 keep-alive connection budget that
+// PR #7765 established (MaxConnsPerHost=4 per cluster transport): going wider
+// than 4 simultaneous list calls against the same kube-apiserver just queues
+// on the pooled TCP connections and provides no speedup while risking control
+// plane saturation on large fleets. The same budget is reused for every
+// per-cluster fanout (admission_webhooks, rbac service accounts, custom
+// resources) so we never double-book the transport pool.
+const defaultClusterFanoutConcurrency = 4
 
 // GVRs for webhook configurations
 var (
@@ -50,10 +62,14 @@ type WebhookSummary struct {
 	Cluster       string `json:"cluster"`
 }
 
-// WebhookListResponse is the response for GET /api/admission-webhooks
+// WebhookListResponse is the response for GET /api/admission-webhooks.
+// Errors maps cluster name -> error message for clusters whose webhook list
+// failed; the UI surfaces partial errors alongside successful results so a
+// single dead cluster no longer silently disappears from the view (#7967).
 type WebhookListResponse struct {
-	Webhooks   []WebhookSummary `json:"webhooks"`
-	IsDemoData bool             `json:"isDemoData"`
+	Webhooks   []WebhookSummary  `json:"webhooks"`
+	Errors     map[string]string `json:"errors,omitempty"`
+	IsDemoData bool              `json:"isDemoData"`
 }
 
 // statusServiceUnavailableWebhook uses fiber's standard constant for 503 responses.
@@ -82,40 +98,75 @@ func (h *WebhookHandlers) ListWebhooks(c *fiber.Ctx) error {
 	}
 
 	allWebhooks := make([]WebhookSummary, 0)
+	clusterErrors := make(map[string]string)
+	var mu sync.Mutex
+
+	// Fan out across clusters in parallel (#7966). errgroup.SetLimit bounds
+	// concurrency to the shared per-cluster HTTP/1.1 connection budget so
+	// we do not oversubscribe the transport pool established in PR #7765.
+	g, gctx := errgroup.WithContext(ctx)
+	g.SetLimit(defaultClusterFanoutConcurrency)
 
 	for _, cluster := range clusters {
-		client, err := h.k8sClient.GetDynamicClient(cluster.Name)
-		if err != nil {
-			continue
-		}
+		clusterName := cluster.Name
+		g.Go(func() error {
+			client, err := h.k8sClient.GetDynamicClient(clusterName)
+			if err != nil {
+				mu.Lock()
+				clusterErrors[clusterName] = err.Error()
+				mu.Unlock()
+				return nil
+			}
 
-		// Fetch validating webhooks
-		valList, err := client.Resource(validatingWebhookGVR).List(ctx, metav1.ListOptions{})
-		if err == nil {
-			for _, item := range valList.Items {
-				wh := parseWebhookFromUnstructured(&item, cluster.Name, "validating")
-				if wh != nil {
-					allWebhooks = append(allWebhooks, *wh)
+			localWebhooks := make([]WebhookSummary, 0)
+
+			// Fetch validating webhooks — per-cluster errors are collected
+			// into clusterErrors (#7967) instead of silently swallowed.
+			valList, valErr := client.Resource(validatingWebhookGVR).List(gctx, metav1.ListOptions{})
+			if valErr == nil {
+				for _, item := range valList.Items {
+					wh := parseWebhookFromUnstructured(&item, clusterName, "validating")
+					if wh != nil {
+						localWebhooks = append(localWebhooks, *wh)
+					}
 				}
 			}
-		}
 
-		// Fetch mutating webhooks
-		mutList, err := client.Resource(mutatingWebhookGVR).List(ctx, metav1.ListOptions{})
-		if err == nil {
-			for _, item := range mutList.Items {
-				wh := parseWebhookFromUnstructured(&item, cluster.Name, "mutating")
-				if wh != nil {
-					allWebhooks = append(allWebhooks, *wh)
+			// Fetch mutating webhooks
+			mutList, mutErr := client.Resource(mutatingWebhookGVR).List(gctx, metav1.ListOptions{})
+			if mutErr == nil {
+				for _, item := range mutList.Items {
+					wh := parseWebhookFromUnstructured(&item, clusterName, "mutating")
+					if wh != nil {
+						localWebhooks = append(localWebhooks, *wh)
+					}
 				}
 			}
-		}
+
+			mu.Lock()
+			defer mu.Unlock()
+			allWebhooks = append(allWebhooks, localWebhooks...)
+			switch {
+			case valErr != nil && mutErr != nil:
+				clusterErrors[clusterName] = "validating: " + valErr.Error() + "; mutating: " + mutErr.Error()
+			case valErr != nil:
+				clusterErrors[clusterName] = "validating: " + valErr.Error()
+			case mutErr != nil:
+				clusterErrors[clusterName] = "mutating: " + mutErr.Error()
+			}
+			return nil
+		})
 	}
+	_ = g.Wait() // per-cluster errors are non-fatal and collected in clusterErrors.
 
-	return c.JSON(WebhookListResponse{
+	resp := WebhookListResponse{
 		Webhooks:   allWebhooks,
 		IsDemoData: false,
-	})
+	}
+	if len(clusterErrors) > 0 {
+		resp.Errors = clusterErrors
+	}
+	return c.JSON(resp)
 }
 
 // parseWebhookFromUnstructured extracts webhook info from an unstructured object

--- a/pkg/api/handlers/custom_resources.go
+++ b/pkg/api/handlers/custom_resources.go
@@ -7,6 +7,7 @@ import (
 	"sync"
 
 	"github.com/gofiber/fiber/v2"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
@@ -22,8 +23,11 @@ type CustomResourceItem struct {
 }
 
 // CustomResourceResponse is the response for GET /api/mcp/custom-resources.
+// Errors maps cluster name -> error message for per-cluster failures (#7967,
+// #7973). Empty/missing when all fanned-out clusters succeeded.
 type CustomResourceResponse struct {
 	Items      []CustomResourceItem `json:"items"`
+	Errors     map[string]string    `json:"errors,omitempty"`
 	IsDemoData bool                 `json:"isDemoData"`
 }
 
@@ -84,7 +88,18 @@ func (h *MCPHandlers) GetCustomResources(c *fiber.Ctx) error {
 		items, err := h.listCR(c.Context(), cluster, namespace, gvr)
 		if err != nil {
 			slog.Warn("custom-resources: cluster error", "cluster", cluster, "error", err)
-			return c.Status(500).JSON(fiber.Map{"error": fmt.Sprintf("failed to list %s: %v", resource, err)})
+			// #7973: distinguish RBAC 403 (caller has no permission) from
+			// infrastructure 500 (apiserver unreachable, CRD not installed,
+			// etc.). Previously both were collapsed into a 500, which hid
+			// permission errors from the UI and made them look like server
+			// bugs.
+			if apierrors.IsForbidden(err) {
+				return c.Status(fiber.StatusForbidden).JSON(fiber.Map{
+					"error":   fmt.Sprintf("forbidden: %v", err),
+					"cluster": cluster,
+				})
+			}
+			return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{"error": fmt.Sprintf("failed to list %s: %v", resource, err)})
 		}
 		return c.JSON(CustomResourceResponse{Items: items, IsDemoData: false})
 	}
@@ -99,6 +114,7 @@ func (h *MCPHandlers) GetCustomResources(c *fiber.Ctx) error {
 	var wg sync.WaitGroup
 	var mu sync.Mutex
 	allItems := make([]CustomResourceItem, 0)
+	clusterErrors := make(map[string]string)
 
 	clusterCtx, clusterCancel := context.WithCancel(c.Context())
 	defer clusterCancel()
@@ -112,7 +128,22 @@ func (h *MCPHandlers) GetCustomResources(c *fiber.Ctx) error {
 
 			items, err := h.listCR(ctx, clusterName, namespace, gvr)
 			if err != nil {
-				// RBAC denied or CRD not installed on this cluster — skip silently
+				// #7973: propagate per-cluster errors instead of silently
+				// dropping them. Distinguish RBAC 403 from infrastructure
+				// errors and CRD-not-installed (NotFound) in the error tag
+				// so the UI can show something actionable.
+				mu.Lock()
+				switch {
+				case apierrors.IsForbidden(err):
+					clusterErrors[clusterName] = "forbidden: " + err.Error()
+				case apierrors.IsNotFound(err):
+					// CRD not installed on this cluster — common on multi-
+					// cluster fleets where only some clusters run an operator.
+					// Omit from errors map: not an actionable failure.
+				default:
+					clusterErrors[clusterName] = err.Error()
+				}
+				mu.Unlock()
 				return
 			}
 			if len(items) > 0 {
@@ -124,7 +155,11 @@ func (h *MCPHandlers) GetCustomResources(c *fiber.Ctx) error {
 	}
 
 	waitWithDeadline(&wg, clusterCancel, maxResponseDeadline)
-	return c.JSON(CustomResourceResponse{Items: allItems, IsDemoData: false})
+	resp := CustomResourceResponse{Items: allItems, IsDemoData: false}
+	if len(clusterErrors) > 0 {
+		resp.Errors = clusterErrors
+	}
+	return c.JSON(resp)
 }
 
 // listCR queries a single cluster for custom resource instances using the dynamic client.

--- a/pkg/api/handlers/rbac.go
+++ b/pkg/api/handlers/rbac.go
@@ -3,10 +3,12 @@ package handlers
 import (
 	"context"
 	"log/slog"
+	"sync"
 	"time"
 
 	"github.com/gofiber/fiber/v2"
 	"github.com/google/uuid"
+	"golang.org/x/sync/errgroup"
 
 	"github.com/kubestellar/console/pkg/api/middleware"
 	"github.com/kubestellar/console/pkg/k8s"
@@ -234,15 +236,50 @@ func (h *RBACHandler) ListK8sServiceAccounts(c *fiber.Ctx) error {
 	}
 
 	allSAs := make([]models.K8sServiceAccount, 0)
-	for _, cl := range clusters {
-		sas, err := h.k8sClient.ListServiceAccounts(ctx, cl.Name, namespace)
-		if err != nil {
-			continue // Skip clusters we can't access
-		}
-		allSAs = append(allSAs, sas...)
-	}
+	clusterErrors := make(map[string]string)
+	var mu sync.Mutex
 
-	return c.JSON(allSAs)
+	// Fan out across clusters in parallel (#7969). Concurrency is bounded by
+	// the shared per-cluster HTTP/1.1 connection budget established in
+	// PR #7765 so we do not oversubscribe the transport pool.
+	g, gctx := errgroup.WithContext(ctx)
+	g.SetLimit(defaultClusterFanoutConcurrency)
+
+	for _, cl := range clusters {
+		clusterName := cl.Name
+		g.Go(func() error {
+			sas, err := h.k8sClient.ListServiceAccounts(gctx, clusterName, namespace)
+			if err != nil {
+				mu.Lock()
+				clusterErrors[clusterName] = err.Error()
+				mu.Unlock()
+				return nil
+			}
+			mu.Lock()
+			allSAs = append(allSAs, sas...)
+			mu.Unlock()
+			return nil
+		})
+	}
+	_ = g.Wait() // per-cluster errors are non-fatal and collected in clusterErrors.
+
+	// Match the WebhookListResponse shape from admission_webhooks.go (#7967):
+	// include per-cluster errors alongside successful results so the UI can
+	// surface partial failures instead of silently dropping clusters.
+	return c.JSON(fiber.Map{
+		"serviceAccounts": allSAs,
+		"errors":          clusterErrorsOrNil(clusterErrors),
+	})
+}
+
+// clusterErrorsOrNil returns nil when the map is empty so JSON callers get
+// `null` (omitted by `omitempty`) instead of `{}`, matching the
+// WebhookListResponse.Errors convention in admission_webhooks.go.
+func clusterErrorsOrNil(m map[string]string) map[string]string {
+	if len(m) == 0 {
+		return nil
+	}
+	return m
 }
 
 // ListK8sRoles returns roles from clusters.


### PR DESCRIPTION
## Summary

Three cluster-fanout handlers were iterating clusters serially and silently dropping per-cluster errors. On a 10-cluster fleet this turned a 200ms list call into a 2s round-trip, and a single dead cluster caused whole entries to disappear from the UI without any indication.

### Fixes

- **#7966 / #7967 — `admission_webhooks.ListWebhooks`**: replaced the serial `for _, cluster := range clusters` loop with `errgroup` bounded by a new `defaultClusterFanoutConcurrency = 4` constant. 4 matches the HTTP/1.1 per-cluster connection budget established in PR #7765, so we do not oversubscribe the transport pool. Per-cluster errors are now collected into `WebhookListResponse.Errors` (optional `map[string]string`) instead of being swallowed under `_`.
- **#7969 — `rbac.ListK8sServiceAccounts` all-clusters path**: same errgroup + error propagation treatment. The response shape now carries `{serviceAccounts, errors}` on the all-clusters path — the frontend (`useUsers.ts`) always calls this with `?cluster=` so the shape change is backend-visible only.
- **#7973 — `custom_resources.GetCustomResources`**:
  - Single-cluster path uses `apierrors.IsForbidden(err)` to return **403** for RBAC denials vs **500** for infrastructure errors (previously collapsed together).
  - Fan-out path collects per-cluster errors into `CustomResourceResponse.Errors`, tagging `forbidden:` explicitly; `NotFound` (CRD not installed — common across multi-operator fleets) is still silently tolerated.

### Shared plumbing

New `defaultClusterFanoutConcurrency = 4` constant in `admission_webhooks.go` with a comment explaining the tie to PR #7765's HTTP/1.1 budget. Reused across `admission_webhooks.go` and `rbac.go`.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test ./pkg/api/handlers/... -run 'Webhook|ServiceAccount|CustomResource|RBAC'` green
- [x] `go test ./pkg/k8s/...` green
- [ ] CI: build/lint/analyze/pr-check/ts-null-safety/fullstack-smoke/coverage-gate/dco

## Fixes

Fixes #7966
Fixes #7967
Fixes #7969
Fixes #7973

Note: `TestRefreshToken` and `TestRecordFocus_BadBody_Returns400` fail on `main` independently of this PR — not touched here.