### PR TITLE
fix: CSP blocked login-page 3D globe and SQLite cache worker WASM

### DIFF
--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -431,13 +431,26 @@ func (s *Server) setupMiddleware() {
 		const kcAgentLocalhost = "http://localhost:8585"    // kc-agent HTTP on localhost
 		const kcAgentLocalhostWS = "ws://localhost:8585"    // kc-agent WebSocket on localhost
 
+		// script-src includes 'wasm-unsafe-eval' because the SQLite cache
+		// worker compiles a WebAssembly module at runtime; without it the
+		// worker aborts, logs a noisy CompileError, and forces an IndexedDB
+		// fallback on every page load. 'wasm-unsafe-eval' is a narrower
+		// permission than 'unsafe-eval' — it allows WebAssembly.instantiate
+		// but still blocks JS eval/Function.
+		//
+		// connect-src includes https://cdn.jsdelivr.net because the login
+		// page's Three.js globe renders cluster labels via troika-three-text,
+		// which fetches a unicode font resolver from jsdelivr at runtime.
+		// Without it the font lookup throws, labels fail to render, and the
+		// globe initialization aborts — leaving the right side of the login
+		// page blank.
 		c.Set("Content-Security-Policy",
 			"default-src 'self'; "+
-				"script-src 'self' 'unsafe-inline' blob: https://www.googletagmanager.com; "+
+				"script-src 'self' 'unsafe-inline' 'wasm-unsafe-eval' blob: https://www.googletagmanager.com; "+
 				"worker-src 'self' blob:; "+
 				"style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; "+
 				"img-src 'self' data: https:; "+
-				"connect-src 'self' "+kcAgentLoopback+" "+kcAgentLoopbackWS+" "+kcAgentLocalhost+" "+kcAgentLocalhostWS+" https://www.google-analytics.com https://www.googletagmanager.com wss:; "+
+				"connect-src 'self' "+kcAgentLoopback+" "+kcAgentLoopbackWS+" "+kcAgentLocalhost+" "+kcAgentLocalhostWS+" https://www.google-analytics.com https://www.googletagmanager.com https://cdn.jsdelivr.net wss:; "+
 				"font-src 'self' data: https://fonts.gstatic.com; "+
 				"object-src 'none'; "+
 				"base-uri 'self'")


### PR DESCRIPTION
## Summary

Two CSP holes surfaced in the browser console on the login page:

1. **Three.js globe on login page was invisible** (right half of login was completely blank despite the canvas mounting). \`troika-three-text\` fetches a unicode font resolver from \`cdn.jsdelivr.net\` at runtime for cluster label rendering. \`connect-src\` didn't allow jsdelivr → fetch threw → globe initialization aborted before adding any scene objects.
   - Add \`https://cdn.jsdelivr.net\` to \`connect-src\`.

2. **SQLite cache worker couldn't compile its WASM module**: \`Compiling or instantiating WebAssembly module violates the following Content Security policy directive because 'unsafe-eval' is not an allowed source\`. The worker aborted and forced an IndexedDB fallback on every page load.
   - Add \`'wasm-unsafe-eval'\` to \`script-src\` — narrower than \`'unsafe-eval'\`; permits \`WebAssembly.instantiate\` but still blocks JS \`eval\`/\`Function\`.

Neither of these were regressions — they've been broken since CSP was first tightened. Found investigating why the globe wasn't showing on the login page.

## Test plan
- [ ] Login page right half shows the animated 3D globe
- [ ] Browser console: no \`Refused to connect ... cdn.jsdelivr.net\` errors
- [ ] Browser console: no \`CompileError: WebAssembly.instantiate violates ... 'unsafe-eval'\` errors
- [ ] No regression in login button flow