### PR TITLE
fix(cluster-admin): show total cluster count to match other dashboards

### DIFF
--- a/web/src/components/cluster-admin/ClusterAdmin.tsx
+++ b/web/src/components/cluster-admin/ClusterAdmin.tsx
@@ -36,7 +36,13 @@ export function ClusterAdmin() {
   // once and reused, avoiding redundant multi-cluster requests).
   const getDashboardStatValue = (blockId: string): StatBlockValue => {
     switch (blockId) {
-      case 'clusters': return { value: reachable.length, sublabel: 'reachable', isDemo: isDemoData }
+      // Show TOTAL cluster count here to match Dashboard and My Clusters.
+      // The reachable/offline breakdown is already shown in the 'healthy' and
+      // 'offline' stat blocks — repeating it on the main 'clusters' block
+      // made the sidebar disagree with itself (ClusterAdmin showed 10 while
+      // My Clusters and Dashboard showed 12 for the same 12 physical clusters
+      // with 2 offline).
+      case 'clusters': return { value: clusters.length, sublabel: 'total', isDemo: isDemoData }
       case 'healthy': return { value: healthy.length, sublabel: 'healthy', isDemo: isDemoData }
       case 'degraded': return { value: degraded.length, sublabel: 'degraded', isDemo: isDemoData }
       case 'offline': return { value: offline.length, sublabel: 'offline', isDemo: isDemoData }


### PR DESCRIPTION
## Summary

ClusterAdmin's 'clusters' stat block showed \`reachable.length\` (10) while Dashboard and My Clusters show total (12) for the same fleet.

Two bugs fixed by one change:

1. **Sidebar/dashboard inconsistency** — clicking from My Clusters (12) to Cluster Admin (10) for the same physical fleet was confusing.
2. **Redundant information** — \`clusters = reachable = healthy + degraded\`. The 'healthy' and 'degraded' stat blocks sitting next to it already decomposed that total. With \`clusters = total\`, the main block shows the top-level count and the healthy/degraded/offline blocks form a proper decomposition (\`healthy + degraded + offline = total\`).

The reachable count is recoverable as \`total - offline\`, and the separate 'offline' stat block surfaces the unreachable count directly.

## Test plan
- [ ] My Clusters, Dashboard, Cluster Admin all show same top cluster count (12 in my fleet)
- [ ] ClusterAdmin 'Clusters' stat shows 'total' sublabel, not 'reachable'
- [ ] Healthy/Degraded/Offline still show correct breakdown