### PR TITLE
fix(exec): log + count dropped stdin frames (#7995)

### DIFF
--- a/pkg/api/handlers/exec.go
+++ b/pkg/api/handlers/exec.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"log/slog"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/gofiber/contrib/websocket"
@@ -32,6 +33,21 @@ const execPingInterval = 30 * time.Second
 // the peer dead. Must be greater than execPingInterval so the deadline is always
 // in the future when a new ping is sent.
 const execPongTimeout = 45 * time.Second
+
+// execStdinDropCount counts stdin frames that were silently discarded because
+// stdinCh was full. #7995 — telemetry-first pass: we don't know how often this
+// actually fires in production, so observe before escalating the handling
+// (block-then-error-close is the planned follow-up if this counter is non-zero
+// in real traffic). Exposed via GetExecStdinDropCount for tests and any future
+// stats endpoint.
+var execStdinDropCount atomic.Uint64
+
+// GetExecStdinDropCount returns the cumulative number of stdin frames that
+// were dropped due to a full stdinCh buffer since process start. Exported for
+// tests and future stats reporting.
+func GetExecStdinDropCount() uint64 {
+	return execStdinDropCount.Load()
+}
 
 // execSessionRegistry tracks active exec sessions per user so that
 // CancelUserExecSessions can tear them down on logout (#6024).
@@ -477,7 +493,17 @@ func (h *ExecHandlers) HandleExec(c *websocket.Conn) {
 				select {
 				case stdinCh <- []byte(m.Data):
 				default:
-					// Drop if channel full
+					// #7995 — stdinCh is full, meaning the pod's stdin drain
+					// has fallen behind. Silently dropping the frame is the
+					// current behavior and can truncate pasted commands or
+					// scripts at arbitrary byte boundaries. Record telemetry
+					// so we can observe whether this actually fires in
+					// production before escalating to block-then-error-close.
+					dropped := execStdinDropCount.Add(1)
+					slog.Warn("[Exec] dropping stdin frame — channel full",
+						"bytes", len(m.Data),
+						"buffer", cap(stdinCh),
+						"total_drops", dropped)
 				}
 			case "resize":
 				if m.Cols > 0 && m.Rows > 0 {


### PR DESCRIPTION
## Summary

Telemetry-first pass on #7995. The exec stdinCh drop branch currently runs silently — we don't know how often it actually fires in real traffic. Before changing the behavior (the planned follow-up is "block up to 500ms, then error-close"), observe first.

Fixes #7995.

## Changes

- New package-level \`atomic.Uint64\` \`execStdinDropCount\` in \`pkg/api/handlers/exec.go\`.
- Drop branch now increments the counter and emits \`slog.Warn\` with the dropped frame size, channel capacity, and running drop total.
- \`GetExecStdinDropCount()\` exported for tests and any future stats endpoint.
- No behavior change — frames are still dropped. Only observation added.

+27 / -1, one file.

## Why telemetry-first

The worst-case scenario for stdin dropping is a pasted multi-line script getting truncated at a byte boundary, which can silently corrupt user input. The safe long-term fix (block-then-error-close) is a behavior change on the exec data path and needs staging validation. Cheap telemetry now tells us two things we don't currently know:

1. **Does it fire in normal operation?** If the counter stays at zero across real traffic for a week, the aggressive fix is not needed — the existing buffer is adequate and the drop branch is dead code for all practical purposes.
2. **What does the failure shape look like?** Frequency + frame size distribution tells us whether the issue is buffer-size tuning, a specific pod that's always slow, or a systemic problem.

Decision to escalate is data-driven from the metric trend.

## Test plan

- [x] \`go build ./...\` green
- [x] \`go vet ./pkg/api/handlers/...\` clean
- [ ] Smoke: open a Web Terminal, paste a small command, confirm it lands intact (expect no drop log)
- [ ] Smoke: paste a ~1 KB block, confirm it lands intact
- [ ] After merge: check backend logs for \`[Exec] dropping stdin frame\` occurrences over a week; review the counter trend before opening the follow-up escalation PR