### PR TITLE
refactor(stats): dedupe stat-block configs into a central registry

### DIFF
--- a/web/src/components/ui/StatsBlockDefinitions.ts
+++ b/web/src/components/ui/StatsBlockDefinitions.ts
@@ -1,6 +1,15 @@
 /**
- * Stat block definitions for all dashboard types
- * This file contains only data definitions with no heavy dependencies
+ * Stat block definitions for all dashboard types.
+ *
+ * Every stat block whose id appears on more than one dashboard MUST come
+ * from STAT_BLOCK_REGISTRY. That way a block like "clusters" renders with
+ * the same icon, name, and color everywhere it appears. Dashboards used to
+ * re-declare blocks inline, which drifted (clusters was Server/purple on
+ * some dashboards, Server/cyan on Pods, Server/blue on Operators). The
+ * registry eliminates that drift.
+ *
+ * If a block is unique to one dashboard, it can stay as an inline literal
+ * in that dashboard's array.
  */
 
 /**
@@ -59,34 +68,102 @@ export type DashboardStatsType =
   | 'drasi'
 
 /**
+ * Canonical definition for a stat block.
+ * The registry stores everything except `visible`, which is chosen per
+ * dashboard (a block can be hidden by default on one dashboard and visible
+ * on another).
+ */
+type CanonicalBlock = Omit<StatBlockConfig, 'visible'>
+
+/**
+ * Central registry of stat blocks shared across dashboards.
+ * Adding a block here once guarantees it renders the same on every
+ * dashboard that uses it. A block unique to a single dashboard can stay
+ * as an inline literal in that dashboard's array instead of living here.
+ */
+export const STAT_BLOCK_REGISTRY = {
+  // ── Cluster / fleet ──────────────────────────────────────────────
+  clusters:   { id: 'clusters',   name: 'Clusters',   icon: 'Server',       color: 'purple' },
+  healthy:    { id: 'healthy',    name: 'Healthy',    icon: 'CheckCircle2', color: 'green' },
+  unhealthy:  { id: 'unhealthy',  name: 'Unhealthy',  icon: 'XCircle',      color: 'red' },
+  unreachable:{ id: 'unreachable',name: 'Offline',    icon: 'WifiOff',      color: 'yellow' },
+  degraded:   { id: 'degraded',   name: 'Degraded',   icon: 'AlertTriangle',color: 'orange' },
+  offline:    { id: 'offline',    name: 'Offline',    icon: 'WifiOff',      color: 'red' },
+
+  // ── Compute ──────────────────────────────────────────────────────
+  nodes:      { id: 'nodes',      name: 'Nodes',      icon: 'Box',          color: 'cyan' },
+  cpus:       { id: 'cpus',       name: 'CPUs',       icon: 'Cpu',          color: 'blue' },
+  memory:     { id: 'memory',     name: 'Memory',     icon: 'MemoryStick',  color: 'green' },
+  storage:    { id: 'storage',    name: 'Storage',    icon: 'HardDrive',    color: 'purple' },
+  gpus:       { id: 'gpus',       name: 'GPUs',       icon: 'Zap',          color: 'yellow' },
+  tpus:       { id: 'tpus',       name: 'TPUs',       icon: 'Sparkles',     color: 'cyan' },
+  aius:       { id: 'aius',       name: 'AIUs',       icon: 'Cpu',          color: 'blue' },
+  xpus:       { id: 'xpus',       name: 'XPUs',       icon: 'Zap',          color: 'green' },
+
+  // ── Workloads ────────────────────────────────────────────────────
+  pods:         { id: 'pods',         name: 'Pods',         icon: 'Layers',       color: 'blue' },
+  deployments:  { id: 'deployments',  name: 'Deployments',  icon: 'Layers',       color: 'blue' },
+  namespaces:   { id: 'namespaces',   name: 'Namespaces',   icon: 'FolderTree',   color: 'purple' },
+
+  // ── Issues / alerts ──────────────────────────────────────────────
+  pod_issues: { id: 'pod_issues', name: 'Pod Issues', icon: 'AlertOctagon', color: 'red' },
+  warnings:   { id: 'warnings',   name: 'Warnings',   icon: 'AlertTriangle',color: 'yellow' },
+  errors:     { id: 'errors',     name: 'Errors',     icon: 'XCircle',      color: 'red' },
+  critical:   { id: 'critical',   name: 'Critical',   icon: 'AlertCircle',  color: 'red' },
+  pending:    { id: 'pending',    name: 'Pending',    icon: 'Clock',        color: 'yellow' },
+
+  // ── GitOps / Deploy ──────────────────────────────────────────────
+  helm:         { id: 'helm',         name: 'Helm Releases', icon: 'Package',     color: 'purple' },
+  operators:    { id: 'operators',    name: 'Operators',     icon: 'Settings',    color: 'purple' },
+
+  // ── Compliance ───────────────────────────────────────────────────
+  pci_score:  { id: 'pci_score',  name: 'PCI DSS',    icon: 'ShieldCheck',  color: 'purple' },
+} as const satisfies Record<string, CanonicalBlock>
+
+/** Known registry ids. */
+export type StatBlockId = keyof typeof STAT_BLOCK_REGISTRY
+
+/**
+ * Build a StatBlockConfig from the registry, picking visibility per
+ * dashboard (defaults to true). Use this instead of repeating
+ * `{ id, name, icon, color, visible }` literals — the whole point of
+ * the registry is that id/name/icon/color are canonical across
+ * dashboards.
+ */
+export function block(id: StatBlockId, visible = true): StatBlockConfig {
+  const canonical = STAT_BLOCK_REGISTRY[id]
+  return { ...canonical, visible }
+}
+
+/**
  * Default stat blocks for the Clusters dashboard
  */
 export const CLUSTERS_STAT_BLOCKS: StatBlockConfig[] = [
-  { id: 'clusters', name: 'Clusters', icon: 'Server', visible: true, color: 'purple' },
-  { id: 'healthy', name: 'Healthy', icon: 'CheckCircle2', visible: true, color: 'green' },
-  { id: 'unhealthy', name: 'Unhealthy', icon: 'XCircle', visible: true, color: 'red' },
-  { id: 'unreachable', name: 'Offline', icon: 'WifiOff', visible: true, color: 'yellow' },
-  { id: 'nodes', name: 'Nodes', icon: 'Box', visible: true, color: 'cyan' },
-  { id: 'cpus', name: 'CPUs', icon: 'Cpu', visible: true, color: 'blue' },
-  { id: 'memory', name: 'Memory', icon: 'MemoryStick', visible: true, color: 'green' },
-  { id: 'storage', name: 'Storage', icon: 'HardDrive', visible: true, color: 'purple' },
-  { id: 'gpus', name: 'GPUs', icon: 'Zap', visible: true, color: 'yellow' },
-  { id: 'tpus', name: 'TPUs', icon: 'Sparkles', visible: false, color: 'cyan' },
-  { id: 'aius', name: 'AIUs', icon: 'Cpu', visible: false, color: 'blue' },
-  { id: 'xpus', name: 'XPUs', icon: 'Zap', visible: false, color: 'green' },
-  { id: 'pods', name: 'Pods', icon: 'Layers', visible: true, color: 'purple' },
+  block('clusters'),
+  block('healthy'),
+  block('unhealthy'),
+  block('unreachable'),
+  block('nodes'),
+  block('cpus'),
+  block('memory'),
+  block('storage'),
+  block('gpus'),
+  block('tpus', false),
+  block('aius', false),
+  block('xpus', false),
+  block('pods'),
 ]
 
 /**
  * Default stat blocks for the Workloads dashboard
  */
 export const WORKLOADS_STAT_BLOCKS: StatBlockConfig[] = [
-  { id: 'namespaces', name: 'Namespaces', icon: 'FolderOpen', visible: true, color: 'purple' },
-  { id: 'critical', name: 'Critical', icon: 'AlertCircle', visible: true, color: 'red' },
+  block('namespaces'),
+  block('critical'),
   { id: 'warning', name: 'Warning', icon: 'AlertTriangle', visible: true, color: 'yellow' },
-  { id: 'healthy', name: 'Healthy', icon: 'CheckCircle2', visible: true, color: 'green' },
-  { id: 'deployments', name: 'Deployments', icon: 'Layers', visible: true, color: 'blue' },
-  { id: 'pod_issues', name: 'Pod Issues', icon: 'AlertOctagon', visible: true, color: 'orange' },
+  block('healthy'),
+  block('deployments'),
+  block('pod_issues'),
   { id: 'deployment_issues', name: 'Deploy Issues', icon: 'XCircle', visible: true, color: 'red' },
 ]
 
@@ -95,11 +172,11 @@ export const WORKLOADS_STAT_BLOCKS: StatBlockConfig[] = [
  */
 export const PODS_STAT_BLOCKS: StatBlockConfig[] = [
   { id: 'total_pods', name: 'Total Pods', icon: 'Box', visible: true, color: 'purple' },
-  { id: 'healthy', name: 'Healthy', icon: 'CheckCircle2', visible: true, color: 'green' },
+  block('healthy'),
   { id: 'issues', name: 'Issues', icon: 'AlertCircle', visible: true, color: 'red' },
-  { id: 'pending', name: 'Pending', icon: 'Clock', visible: true, color: 'yellow' },
+  block('pending'),
   { id: 'restarts', name: 'High Restarts', icon: 'RotateCcw', visible: true, color: 'orange' },
-  { id: 'clusters', name: 'Clusters', icon: 'Server', visible: true, color: 'cyan' },
+  block('clusters'),
 ]
 
 /**
@@ -107,12 +184,12 @@ export const PODS_STAT_BLOCKS: StatBlockConfig[] = [
  */
 export const GITOPS_STAT_BLOCKS: StatBlockConfig[] = [
   { id: 'total', name: 'Total', icon: 'Package', visible: true, color: 'purple' },
-  { id: 'helm', name: 'Helm', icon: 'Ship', visible: true, color: 'blue' },
+  block('helm'),
   { id: 'kustomize', name: 'Kustomize', icon: 'Layers', visible: true, color: 'cyan' },
-  { id: 'operators', name: 'Operators', icon: 'Settings', visible: true, color: 'purple' },
+  block('operators'),
   { id: 'deployed', name: 'Deployed', icon: 'CheckCircle2', visible: true, color: 'green' },
   { id: 'failed', name: 'Failed', icon: 'XCircle', visible: true, color: 'red' },
-  { id: 'pending', name: 'Pending', icon: 'Clock', visible: true, color: 'blue' },
+  block('pending'),
   { id: 'other', name: 'Other', icon: 'MoreHorizontal', visible: true, color: 'gray' },
 ]
 
@@ -123,7 +200,7 @@ export const STORAGE_STAT_BLOCKS: StatBlockConfig[] = [
   { id: 'ephemeral', name: 'Ephemeral', icon: 'HardDrive', visible: true, color: 'purple' },
   { id: 'pvcs', name: 'PVCs', icon: 'Database', visible: true, color: 'blue' },
   { id: 'bound', name: 'Bound', icon: 'CheckCircle2', visible: true, color: 'green' },
-  { id: 'pending', name: 'Pending', icon: 'Clock', visible: true, color: 'yellow' },
+  block('pending'),
   { id: 'storage_classes', name: 'Storage Classes', icon: 'Layers', visible: true, color: 'cyan' },
 ]
 
@@ -140,11 +217,14 @@ export const NETWORK_STAT_BLOCKS: StatBlockConfig[] = [
 ]
 
 /**
- * Default stat blocks for the Security dashboard
+ * Default stat blocks for the Security dashboard.
+ * `issues` here is deliberately NOT from the registry — Security's
+ * "issues" means security findings (ShieldAlert), which is a different
+ * semantic from Pods' generic "issues" (AlertCircle).
  */
 export const SECURITY_STAT_BLOCKS: StatBlockConfig[] = [
   { id: 'issues', name: 'Issues', icon: 'ShieldAlert', visible: true, color: 'purple' },
-  { id: 'critical', name: 'Critical', icon: 'AlertCircle', visible: true, color: 'red' },
+  block('critical'),
   { id: 'high', name: 'High', icon: 'AlertTriangle', visible: true, color: 'red' },
   { id: 'medium', name: 'Medium', icon: 'AlertTriangle', visible: true, color: 'yellow' },
   { id: 'low', name: 'Low', icon: 'Info', visible: true, color: 'blue' },
@@ -165,7 +245,7 @@ export const COMPLIANCE_STAT_BLOCKS: StatBlockConfig[] = [
   // Framework compliance scores
   { id: 'cis_score', name: 'CIS', icon: 'ShieldCheck', visible: true, color: 'cyan' },
   { id: 'nsa_score', name: 'NSA', icon: 'ShieldCheck', visible: true, color: 'blue' },
-  { id: 'pci_score', name: 'PCI DSS', icon: 'ShieldCheck', visible: true, color: 'purple' },
+  block('pci_score'),
 
   // Policy enforcement
   { id: 'gatekeeper_violations', name: 'Gatekeeper', icon: 'ShieldAlert', visible: true, color: 'orange' },
@@ -199,10 +279,11 @@ export const DATA_COMPLIANCE_STAT_BLOCKS: StatBlockConfig[] = [
   { id: 'audit_enabled', name: 'Audit', icon: 'FileText', visible: true, color: 'purple' },
   { id: 'retention_days', name: 'Retention', icon: 'Calendar', visible: true, color: 'blue' },
 
-  // Framework scores
+  // Framework scores — pci_score reuses the registry canonical; other
+  // framework scores are unique to this dashboard so they stay inline.
   { id: 'gdpr_score', name: 'GDPR', icon: 'Globe', visible: true, color: 'blue' },
   { id: 'hipaa_score', name: 'HIPAA', icon: 'Heart', visible: true, color: 'red' },
-  { id: 'pci_score', name: 'PCI-DSS', icon: 'CreditCard', visible: true, color: 'orange' },
+  block('pci_score'),
   { id: 'soc2_score', name: 'SOC 2', icon: 'ShieldCheck', visible: true, color: 'cyan' },
 ]
 
@@ -210,12 +291,12 @@ export const DATA_COMPLIANCE_STAT_BLOCKS: StatBlockConfig[] = [
  * Default stat blocks for the Compute dashboard
  */
 export const COMPUTE_STAT_BLOCKS: StatBlockConfig[] = [
-  { id: 'nodes', name: 'Nodes', icon: 'Server', visible: true, color: 'purple' },
-  { id: 'cpus', name: 'CPUs', icon: 'Cpu', visible: true, color: 'blue' },
-  { id: 'memory', name: 'Memory', icon: 'MemoryStick', visible: true, color: 'green' },
-  { id: 'gpus', name: 'GPUs', icon: 'Zap', visible: true, color: 'yellow' },
-  { id: 'tpus', name: 'TPUs', icon: 'Sparkles', visible: true, color: 'orange' },
-  { id: 'pods', name: 'Pods', icon: 'Layers', visible: true, color: 'cyan' },
+  block('nodes'),
+  block('cpus'),
+  block('memory'),
+  block('gpus'),
+  block('tpus'),
+  block('pods'),
   { id: 'cpu_util', name: 'CPU Util', icon: 'Activity', visible: true, color: 'blue' },
   { id: 'memory_util', name: 'Memory Util', icon: 'Activity', visible: true, color: 'green' },
 ]
@@ -225,8 +306,8 @@ export const COMPUTE_STAT_BLOCKS: StatBlockConfig[] = [
  */
 export const EVENTS_STAT_BLOCKS: StatBlockConfig[] = [
   { id: 'total', name: 'Total Events', icon: 'Activity', visible: true, color: 'purple' },
-  { id: 'warnings', name: 'Warnings', icon: 'AlertTriangle', visible: true, color: 'yellow' },
-  { id: 'errors', name: 'Errors', icon: 'XCircle', visible: true, color: 'red' },
+  block('warnings'),
+  block('errors'),
   { id: 'normal', name: 'Normal', icon: 'Info', visible: true, color: 'blue' },
   { id: 'recent', name: 'Recent (1h)', icon: 'Clock', visible: true, color: 'cyan' },
 ]
@@ -248,7 +329,7 @@ export const COST_STAT_BLOCKS: StatBlockConfig[] = [
  */
 export const ALERTS_STAT_BLOCKS: StatBlockConfig[] = [
   { id: 'firing', name: 'Firing', icon: 'AlertCircle', visible: true, color: 'red' },
-  { id: 'pending', name: 'Pending', icon: 'Clock', visible: true, color: 'yellow' },
+  block('pending'),
   { id: 'resolved', name: 'Resolved', icon: 'CheckCircle2', visible: true, color: 'green' },
   { id: 'rules_enabled', name: 'Rules Enabled', icon: 'Shield', visible: true, color: 'blue' },
   { id: 'rules_disabled', name: 'Rules Disabled', icon: 'ShieldOff', visible: true, color: 'gray' },
@@ -258,40 +339,40 @@ export const ALERTS_STAT_BLOCKS: StatBlockConfig[] = [
  * Default stat blocks for the main Dashboard
  */
 export const DASHBOARD_STAT_BLOCKS: StatBlockConfig[] = [
-  { id: 'clusters', name: 'Clusters', icon: 'Server', visible: true, color: 'purple' },
-  { id: 'healthy', name: 'Healthy', icon: 'CheckCircle2', visible: true, color: 'green' },
-  { id: 'pods', name: 'Pods', icon: 'Layers', visible: true, color: 'blue' },
-  { id: 'nodes', name: 'Nodes', icon: 'Box', visible: true, color: 'cyan' },
-  { id: 'namespaces', name: 'Namespaces', icon: 'FolderTree', visible: true, color: 'purple' },
-  { id: 'errors', name: 'Errors', icon: 'XCircle', visible: true, color: 'red' },
+  block('clusters'),
+  block('healthy'),
+  block('pods'),
+  block('nodes'),
+  block('namespaces'),
+  block('errors'),
 ]
 
 /**
  * Default stat blocks for the Operators dashboard
  */
 export const OPERATORS_STAT_BLOCKS: StatBlockConfig[] = [
-  { id: 'operators', name: 'Total', icon: 'Settings', visible: true, color: 'purple' },
+  block('operators'),
   { id: 'installed', name: 'Installed', icon: 'CheckCircle2', visible: true, color: 'green' },
   { id: 'installing', name: 'Installing', icon: 'RefreshCw', visible: true, color: 'blue' },
   { id: 'failing', name: 'Failing', icon: 'XCircle', visible: true, color: 'red' },
   { id: 'upgrades', name: 'Upgrades', icon: 'ArrowUpCircle', visible: true, color: 'orange' },
   { id: 'subscriptions', name: 'Subscriptions', icon: 'Newspaper', visible: true, color: 'blue' },
   { id: 'crds', name: 'CRDs', icon: 'FileCode', visible: true, color: 'cyan' },
-  { id: 'clusters', name: 'Clusters', icon: 'Server', visible: true, color: 'blue' },
+  block('clusters'),
 ]
 
 /**
  * Default stat blocks for the Deploy dashboard
  */
 export const DEPLOY_STAT_BLOCKS: StatBlockConfig[] = [
-  { id: 'deployments', name: 'Deployments', icon: 'Ship', visible: true, color: 'blue' },
-  { id: 'healthy', name: 'Healthy', icon: 'CheckCircle2', visible: true, color: 'green' },
+  block('deployments'),
+  block('healthy'),
   { id: 'progressing', name: 'Progressing', icon: 'Clock', visible: true, color: 'cyan' },
   { id: 'failed', name: 'Failed', icon: 'XCircle', visible: true, color: 'red' },
-  { id: 'helm', name: 'Helm Releases', icon: 'Package', visible: true, color: 'purple' },
+  block('helm'),
   { id: 'argocd', name: 'ArgoCD Apps', icon: 'Workflow', visible: true, color: 'orange' },
-  { id: 'namespaces', name: 'Namespaces', icon: 'FolderOpen', visible: true, color: 'cyan' },
-  { id: 'clusters', name: 'Clusters', icon: 'Server', visible: true, color: 'purple' },
+  block('namespaces'),
+  block('clusters'),
 ]
 
 /**
@@ -309,13 +390,13 @@ export const KAGENTI_STAT_BLOCKS: StatBlockConfig[] = [
  * Default stat blocks for the Cluster Admin dashboard
  */
 export const CLUSTER_ADMIN_STAT_BLOCKS: StatBlockConfig[] = [
-  { id: 'clusters', name: 'Clusters', icon: 'Server', visible: true, color: 'purple' },
-  { id: 'healthy', name: 'Healthy', icon: 'CheckCircle2', visible: true, color: 'green' },
-  { id: 'degraded', name: 'Degraded', icon: 'AlertTriangle', visible: true, color: 'orange' },
-  { id: 'offline', name: 'Offline', icon: 'WifiOff', visible: true, color: 'red' },
-  { id: 'nodes', name: 'Nodes', icon: 'Box', visible: true, color: 'cyan' },
-  { id: 'warnings', name: 'Warnings', icon: 'AlertCircle', visible: true, color: 'yellow' },
-  { id: 'pod_issues', name: 'Pod Issues', icon: 'AlertOctagon', visible: true, color: 'red' },
+  block('clusters'),
+  block('healthy'),
+  block('degraded'),
+  block('offline'),
+  block('nodes'),
+  block('warnings'),
+  block('pod_issues'),
   { id: 'alerts_firing', name: 'Alerts', icon: 'Bell', visible: true, color: 'orange' },
 ]
 
@@ -338,6 +419,27 @@ export const DRASI_STAT_BLOCKS: StatBlockConfig[] = [
   { id: 'sources', name: 'Sources', icon: 'Database', visible: true, color: 'blue' },
   { id: 'queries', name: 'Queries', icon: 'Search', visible: true, color: 'cyan' },
   { id: 'reactions', name: 'Reactions', icon: 'Radio', visible: true, color: 'green' },
+]
+
+/**
+ * Default stat blocks for the AI Agents dashboard
+ */
+export const AI_AGENTS_STAT_BLOCKS: StatBlockConfig[] = [
+  { id: 'agents', name: 'Agents', icon: 'Bot', visible: true, color: 'purple' },
+  { id: 'tools', name: 'MCP Tools', icon: 'Wrench', visible: true, color: 'cyan' },
+  { id: 'builds', name: 'Builds', icon: 'Hammer', visible: true, color: 'blue' },
+  block('clusters'),
+  { id: 'spiffe', name: 'SPIFFE', icon: 'ShieldCheck', visible: true, color: 'orange' },
+]
+
+/**
+ * Default stat blocks for the Insights dashboard
+ */
+export const INSIGHTS_STAT_BLOCKS: StatBlockConfig[] = [
+  block('clusters'),
+  { id: 'insights', name: 'Insights', icon: 'Lightbulb', visible: true, color: 'blue' },
+  block('critical'),
+  block('warnings'),
 ]
 
 /**
@@ -365,39 +467,20 @@ export const ALL_STAT_BLOCKS: StatBlockConfig[] = (() => {
     ...CLUSTER_ADMIN_STAT_BLOCKS,
     ...MULTI_TENANCY_STAT_BLOCKS,
     ...DRASI_STAT_BLOCKS,
+    ...AI_AGENTS_STAT_BLOCKS,
+    ...INSIGHTS_STAT_BLOCKS,
   ]
 
   // Deduplicate by ID
   const uniqueBlocks = new Map<string, StatBlockConfig>()
-  for (const block of allBlocks) {
-    if (!uniqueBlocks.has(block.id)) {
-      uniqueBlocks.set(block.id, block)
+  for (const b of allBlocks) {
+    if (!uniqueBlocks.has(b.id)) {
+      uniqueBlocks.set(b.id, b)
     }
   }
 
   return Array.from(uniqueBlocks.values())
 })()
-
-/**
- * Default stat blocks for the AI Agents dashboard
- */
-export const AI_AGENTS_STAT_BLOCKS: StatBlockConfig[] = [
-  { id: 'agents', name: 'Agents', icon: 'Bot', visible: true, color: 'purple' },
-  { id: 'tools', name: 'MCP Tools', icon: 'Wrench', visible: true, color: 'cyan' },
-  { id: 'builds', name: 'Builds', icon: 'Hammer', visible: true, color: 'blue' },
-  { id: 'clusters', name: 'Clusters', icon: 'Server', visible: true, color: 'green' },
-  { id: 'spiffe', name: 'SPIFFE', icon: 'ShieldCheck', visible: true, color: 'orange' },
-]
-
-/**
- * Default stat blocks for the Insights dashboard
- */
-export const INSIGHTS_STAT_BLOCKS: StatBlockConfig[] = [
-  { id: 'clusters', name: 'Clusters', icon: 'Server', visible: true, color: 'purple' },
-  { id: 'insights', name: 'Insights', icon: 'Lightbulb', visible: true, color: 'blue' },
-  { id: 'critical', name: 'Critical', icon: 'AlertTriangle', visible: true, color: 'red' },
-  { id: 'warnings', name: 'Warnings', icon: 'AlertCircle', visible: true, color: 'yellow' },
-]
 
 /**
  * Get default stat blocks for a specific dashboard type


### PR DESCRIPTION
## Summary

Every dashboard's stat-block array used to re-declare blocks inline. Blocks with the same id had drifted across dashboards — \`clusters\` was \`Server/purple\` on most pages, \`Server/cyan\` on Pods, \`Server/blue\` on Operators, \`Server/green\` on AI Agents, etc. Every new dashboard risked new inconsistencies caught only by eye review.

This PR introduces \`STAT_BLOCK_REGISTRY\`: a central \`Record<id, CanonicalBlock>\` for every block that appears on more than one dashboard. Added a \`block(id, visible = true)\` helper that spreads the canonical config and sets visibility per-dashboard. Every \`*_STAT_BLOCKS\` array now calls \`block(...)\` for shared ids; inline literals are reserved for blocks unique to a single dashboard.

## Concrete inconsistencies fixed

| id | before | after |
|---|---|---|
| \`clusters\` | Server/purple \| Server/cyan \| Server/blue \| Server/green (4 variants) | Server/purple everywhere |
| \`nodes\` | Box/cyan \| Server/purple | Box/cyan everywhere |
| \`namespaces\` | FolderTree/purple \| FolderOpen/purple \| FolderOpen/cyan | FolderTree/purple everywhere |
| \`pods\` | Layers/purple \| Layers/blue \| Layers/cyan | Layers/blue everywhere |
| \`deployments\` | Layers/blue \| Ship/blue | Layers/blue everywhere |
| \`pod_issues\` | AlertOctagon/orange \| AlertOctagon/red | AlertOctagon/red everywhere |
| \`helm\` | Ship/blue \| Package/purple | Package/purple everywhere |
| \`warnings\` | AlertTriangle/yellow \| AlertCircle/yellow | AlertTriangle/yellow everywhere |
| \`pci_score\` | ShieldCheck/purple \| CreditCard/orange | ShieldCheck/purple everywhere |
| \`tpus\` | cyan (Clusters) \| orange (Compute), visible drift | cyan canonical, per-dashboard visibility |

## Kept inline (different semantics, same id)
- \`security:issues\` (ShieldAlert) vs \`pods:issues\` (AlertCircle) — different kinds of issues
- \`gitops:total\` (resources) vs \`events:total\` (events)

## Adding a new dashboard

Reference existing ids from \`STAT_BLOCK_REGISTRY\` via \`block('id')\` — drift is now impossible. Add a new canonical block only if it's genuinely shared.

## Test plan
- [ ] Build passes
- [ ] Clusters stat on Dashboard, My Clusters, Cluster Admin, Pods, Operators, AI Agents, Deploy all show Server/purple with identical styling
- [ ] No regression on any dashboard's visible stat-block set