### PR TITLE
🔒 fix(agent): require validateToken on RBAC/HPA/PVC/quota handlers (#7980 #7982)

### DIFF
--- a/pkg/agent/server_http.go
+++ b/pkg/agent/server_http.go
@@ -736,6 +736,11 @@ func (s *Server) handleHPAsHTTP(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 		return
 	}
+	// SECURITY: Validate token for HPAs endpoint
+	if !s.validateToken(r) {
+		http.Error(w, "Unauthorized", http.StatusUnauthorized)
+		return
+	}
 	if s.k8sClient == nil {
 		writeJSON(w,map[string]interface{}{"hpas": []interface{}{}, "error": "k8s client not initialized"})
 		return
@@ -763,6 +768,11 @@ func (s *Server) handlePVCsHTTP(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 	if r.Method == "OPTIONS" {
 		w.WriteHeader(http.StatusOK)
+		return
+	}
+	// SECURITY: Validate token for PVCs endpoint
+	if !s.validateToken(r) {
+		http.Error(w, "Unauthorized", http.StatusUnauthorized)
 		return
 	}
 	if s.k8sClient == nil {
@@ -794,6 +804,11 @@ func (s *Server) handleRolesHTTP(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 		return
 	}
+	// SECURITY: Validate token for Roles endpoint
+	if !s.validateToken(r) {
+		http.Error(w, "Unauthorized", http.StatusUnauthorized)
+		return
+	}
 	if s.k8sClient == nil {
 		writeJSON(w,map[string]interface{}{"roles": []interface{}{}, "error": "k8s client not initialized"})
 		return
@@ -821,6 +836,11 @@ func (s *Server) handleRoleBindingsHTTP(w http.ResponseWriter, r *http.Request) 
 	w.Header().Set("Content-Type", "application/json")
 	if r.Method == "OPTIONS" {
 		w.WriteHeader(http.StatusOK)
+		return
+	}
+	// SECURITY: Validate token for RoleBindings endpoint
+	if !s.validateToken(r) {
+		http.Error(w, "Unauthorized", http.StatusUnauthorized)
 		return
 	}
 	if s.k8sClient == nil {
@@ -852,6 +872,11 @@ func (s *Server) handleResourceQuotasHTTP(w http.ResponseWriter, r *http.Request
 		w.WriteHeader(http.StatusOK)
 		return
 	}
+	// SECURITY: Validate token for ResourceQuotas endpoint
+	if !s.validateToken(r) {
+		http.Error(w, "Unauthorized", http.StatusUnauthorized)
+		return
+	}
 	if s.k8sClient == nil {
 		writeJSON(w,map[string]interface{}{"resourcequotas": []interface{}{}, "error": "k8s client not initialized"})
 		return
@@ -879,6 +904,11 @@ func (s *Server) handleLimitRangesHTTP(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 	if r.Method == "OPTIONS" {
 		w.WriteHeader(http.StatusOK)
+		return
+	}
+	// SECURITY: Validate token for LimitRanges endpoint
+	if !s.validateToken(r) {
+		http.Error(w, "Unauthorized", http.StatusUnauthorized)
 		return
 	}
 	if s.k8sClient == nil {
@@ -909,6 +939,11 @@ func (s *Server) handleResolveDepsHTTP(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 	if r.Method == "OPTIONS" {
 		w.WriteHeader(http.StatusOK)
+		return
+	}
+	// SECURITY: Validate token for ResolveDeps endpoint
+	if !s.validateToken(r) {
+		http.Error(w, "Unauthorized", http.StatusUnauthorized)
 		return
 	}
 	if s.k8sClient == nil {


### PR DESCRIPTION
## Summary

Seven HTTP handlers in `pkg/agent/server_http.go` were reachable without a valid auth token because they never called `s.validateToken(r)`. This PR adds the canonical guard used by every other sensitive handler in the same file.

Handlers fixed:
- `handleHPAsHTTP`
- `handlePVCsHTTP`
- `handleRolesHTTP`
- `handleRoleBindingsHTTP`
- `handleResourceQuotasHTTP`
- `handleLimitRangesHTTP`
- `handleResolveDepsHTTP`

Each now rejects unauthenticated requests with `401 Unauthorized` after the `OPTIONS` short-circuit and before any `k8sClient` work — mirroring `handleSecretsHTTP` (line 628).

## Issues

- Closes #7980 (HPAs, PVCs)
- Closes #7982 (Roles, RoleBindings)

### Scope notes

**#7982 mentions `handleClusterRolesHTTP` / `handleClusterRoleBindingsHTTP`.** Those handlers do not exist in `pkg/agent/server_http.go`. ClusterRole/ClusterRoleBinding listing goes through a different path and is not affected by this class of bug. Only the namespaced `handleRolesHTTP` / `handleRoleBindingsHTTP` from the issue body are applicable here.

**ResourceQuotas, LimitRanges, and ResolveDeps were not named in either issue**, but they have the identical omission — a grep of `validateToken` calls jumps from `handleJobsHTTP` (line 706) to `handleScaleHTTP` (line 984), skipping all seven. Fixing them in the same pass avoids leaving known-vulnerable handlers behind the moment the named ones land.

## Test plan

- [x] `go build ./...` passes locally
- [ ] CI build + lint green
- [ ] Manual: `curl -i http://localhost:8585/api/agent/hpas?cluster=foo` without auth returns `401` (same as `/api/agent/secrets` today)