### PR TITLE
🐛 fix: Copilot follow-ups for #7985 (live location key, dedup pollers, tests) (#7991)

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,5 +1,6 @@
-import { Suspense, useState, useEffect, useRef, useSyncExternalStore } from 'react'
+import { Suspense, useState, useEffect, useMemo, useRef, useSyncExternalStore } from 'react'
 import { Routes, Route, Navigate, useNavigate, useLocation, useSearchParams } from 'react-router-dom'
+import type { Location } from 'react-router-dom'
 import { CardHistoryEntry } from './hooks/useCardHistory'
 import { Layout } from './components/layout/Layout'
 import { AuthProvider, useAuth, isJWTExpired } from './lib/auth'
@@ -492,11 +493,17 @@ function useLivePathname(): string {
 
 function App() {
   const livePath = useLivePathname()
-  // Build a synthetic Location object so <Routes location={...}> matches
-  // against the real URL. React Router's matcher only reads pathname for
-  // path matching; search/hash are non-functional here, so leaving them
-  // empty is safe. state/key are inert for matching purposes.
-  const liveLocation = { pathname: livePath, search: window.location.search, hash: window.location.hash, state: null, key: 'default' }
+  // Merge the real router location (which carries search/hash/state and —
+  // critically — a real `key` that changes on every navigation) with the
+  // live pathname. Hardcoding `key: 'default'` breaks effects across the
+  // app that fire on `location.key` change (Dashboard, Clusters, Compute
+  // re-fetch; Settings distinguishes direct load vs in-app nav via
+  // `location.key !== 'default'`).
+  const routerLocation = useLocation()
+  const liveLocation = useMemo(
+    () => ({ ...routerLocation, pathname: livePath }),
+    [routerLocation, livePath],
+  )
   return (
     <BrandingProvider>
     <ThemeProvider>
@@ -527,7 +534,7 @@ function App() {
 
       {/* ── Full dashboard routes ─────────────────────────────────────
           Everything else gets the full provider stack. */}
-      <Route path="*" element={<FullDashboardApp />} />
+      <Route path="*" element={<FullDashboardApp liveLocation={liveLocation} />} />
     </Routes>
     </ThemeProvider>
     </BrandingProvider>
@@ -535,9 +542,7 @@ function App() {
 }
 
 /** Full dashboard app with all providers — loaded only for non-mission routes */
-function FullDashboardApp() {
-  const livePath = useLivePathname()
-  const liveLocation = { pathname: livePath, search: window.location.search, hash: window.location.hash, state: null, key: 'default' }
+function FullDashboardApp({ liveLocation }: { liveLocation: Location }) {
   return (
     <AuthProvider>
     <SettingsSyncInit />

--- a/web/src/components/missions/MissionBrowser.tsx
+++ b/web/src/components/missions/MissionBrowser.tsx
@@ -815,7 +815,9 @@ export function MissionBrowser({ isOpen, onClose, onImport, initialMission }: Mi
           )
           content = data
         } else if (node.source === 'github') {
-          // In demo mode for Kubara files, return demo content
+          // Serve canned sample content for kubara/* nodes instead of hitting
+          // the GitHub Contents API — avoids per-file rate-limit burn when a
+          // user expands a chart tree.
           if (node.id.startsWith('kubara/')) {
             const chartName = node.id.split('/')[1] || 'chart'
             if (node.name === 'Chart.yaml') {

--- a/web/src/lib/__tests__/api.test.ts
+++ b/web/src/lib/__tests__/api.test.ts
@@ -362,6 +362,25 @@ describe('api.ts', () => {
       expect(localStorage.getItem(STORAGE_KEY_USER_CACHE)).toBeNull()
     })
 
+    // A 401 from /api/github/* means the GitHub OAuth token is missing or
+    // expired — NOT that the user's console session is dead. The caller
+    // (e.g. Mission Browser) needs to handle it with a feature-local prompt
+    // instead of the whole app logging out. See api.ts:418-427.
+    it('does not clear auth state on 401 from /api/github/*', async () => {
+      localStorage.setItem(STORAGE_KEY_TOKEN, 'valid-token')
+      localStorage.setItem(STORAGE_KEY_USER_CACHE, '{"id":1}')
+
+      vi.mocked(fetch)
+        .mockResolvedValueOnce(makeResponse({ status: 'ok' })) // health
+        .mockResolvedValueOnce(makeResponse({}, { status: 401 })) // 401 on github path
+
+      const { api, UnauthorizedError } = await importFresh()
+      await expect(api.get('/api/github/repos/foo/bar/contents/x')).rejects.toThrow(UnauthorizedError)
+
+      expect(localStorage.getItem(STORAGE_KEY_TOKEN)).toBe('valid-token')
+      expect(localStorage.getItem(STORAGE_KEY_USER_CACHE)).toBe('{"id":1}')
+    })
+
     it('handles 500 with error text', async () => {
       localStorage.setItem(STORAGE_KEY_TOKEN, 'valid-token')
       vi.mocked(fetch)


### PR DESCRIPTION
## Summary

Addresses the four Copilot review items on merged PR #7985:

1. **Preserve real `location.key`.** `App.tsx` was building `liveLocation` with a hardcoded `key: 'default'`, which broke effects that fire on `location.key` change (Dashboard/Clusters/Compute refetch, Settings distinguishing direct-load from in-app nav). Now spreads the real router location and overwrites only `pathname` with the live poller value.

2. **Dedupe `useLivePathname()`.** Both `App()` and `FullDashboardApp()` were each subscribing to the pathname poller and building their own `liveLocation`. Lifted `liveLocation` to `App()` and passed it down as a prop — one poller instead of two.

3. **Stale comment in `MissionBrowser.tsx:818`.** The old comment claimed this branch served canned content \"in demo mode,\" which was misleading — it runs unconditionally for `kubara/*` nodes. Replaced with the real rationale: avoid per-file GitHub Contents API rate-limit burn when expanding a chart tree.

4. **Test coverage for `/api/github/*` 401 exclusion.** Added a regression lock in `api.test.ts`: a 401 from `/api/github/*` must throw `UnauthorizedError` without clearing `STORAGE_KEY_TOKEN` or `STORAGE_KEY_USER_CACHE`. Guards `api.ts:424`, which is what kept clicking a kubara repo in the Mission Browser from logging the whole console out when the GitHub OAuth token expired.

Fixes #7991

## Test plan

- [ ] CI build + lint green
- [ ] CI unit tests green (new test in `web/src/lib/__tests__/api.test.ts`)
- [ ] Manual: navigate between dashboard routes, confirm Dashboard/Clusters/Compute cards still refetch on nav (location.key changes)
- [ ] Manual: direct-load Settings vs in-app nav to Settings — behavior should differ (location.key !== 'default' vs === 'default')