### PR TITLE
fix(orbit): serialize saveToDisk with write lock + atomic rename (#8003)

### DIFF
--- a/pkg/api/handlers/orbit.go
+++ b/pkg/api/handlers/orbit.go
@@ -363,13 +363,19 @@ func (h *OrbitHandler) loadFromDisk() {
 }
 
 // saveToDisk persists all missions to the JSON data file.
+//
+// Takes an exclusive write lock so only one goroutine writes at a time.
+// Previously this used RLock(), which allowed the background scheduler
+// (checkDueMissions) and concurrent HTTP handlers to enter os.WriteFile
+// simultaneously and corrupt the orbit_missions.json file (issue 8003).
 func (h *OrbitHandler) saveToDisk() {
-	h.mu.RLock()
-	defer h.mu.RUnlock()
+	h.mu.Lock()
+	defer h.mu.Unlock()
 	h.saveToDiskLocked()
 }
 
-// saveToDiskLocked persists missions; caller must hold at least a read lock.
+// saveToDiskLocked persists missions. The caller must hold the write lock
+// (h.mu.Lock, not RLock) — concurrent entries would race on the file write.
 func (h *OrbitHandler) saveToDiskLocked() {
 	missions := make([]*OrbitMission, 0, len(h.missions))
 	for _, m := range h.missions {
@@ -389,7 +395,45 @@ func (h *OrbitHandler) saveToDiskLocked() {
 		return
 	}
 
-	if err := os.WriteFile(h.dataFile, data, 0o644); err != nil {
-		slog.Error("orbit: failed to write data file", "path", h.dataFile, "error", err)
+	// Atomic write: write to a temp file in the same directory and then
+	// rename over the target. Rename is atomic on the same filesystem, so
+	// a concurrent reader (or a crash mid-write) either sees the old
+	// complete file or the new complete file — never a partial one.
+	// Belt-and-braces alongside the write-lock switch above — if a future
+	// caller accidentally holds only a read lock, an interrupted write
+	// still can't leave behind a corrupted target file.
+	tmp, err := os.CreateTemp(dir, ".orbit_missions-*.json.tmp")
+	if err != nil {
+		slog.Error("orbit: failed to create temp data file", "dir", dir, "error", err)
+		return
+	}
+	tmpPath := tmp.Name()
+	// Best-effort cleanup if we bail out before the rename.
+	defer func() {
+		if _, err := os.Stat(tmpPath); err == nil {
+			_ = os.Remove(tmpPath)
+		}
+	}()
+	if _, err := tmp.Write(data); err != nil {
+		slog.Error("orbit: failed to write temp data file", "path", tmpPath, "error", err)
+		_ = tmp.Close()
+		return
+	}
+	if err := tmp.Sync(); err != nil {
+		slog.Error("orbit: failed to fsync temp data file", "path", tmpPath, "error", err)
+		_ = tmp.Close()
+		return
+	}
+	if err := tmp.Close(); err != nil {
+		slog.Error("orbit: failed to close temp data file", "path", tmpPath, "error", err)
+		return
+	}
+	if err := os.Chmod(tmpPath, 0o644); err != nil {
+		slog.Warn("orbit: failed to chmod temp data file", "path", tmpPath, "error", err)
+		// Non-fatal — proceed with rename; the file is still ours.
+	}
+	if err := os.Rename(tmpPath, h.dataFile); err != nil {
+		slog.Error("orbit: failed to rename temp data file", "from", tmpPath, "to", h.dataFile, "error", err)
+		return
 	}
 }


### PR DESCRIPTION
## Summary

Fixes #8003. \`OrbitHandler.saveToDisk()\` took a read lock (\`h.mu.RLock\`) before calling \`saveToDiskLocked()\`, which then ran \`os.WriteFile\` directly. Read locks allow concurrent entry, so the background scheduler (\`checkDueMissions\`) and any concurrent HTTP handler could both reach \`os.WriteFile\` at the same time and interleave their writes — producing a truncated or garbled \`orbit_missions.json\` that fails to Unmarshal on the next startup, losing the user's scheduled missions.

### Fixes (belt and braces)

1. **Write lock**: \`saveToDisk\` now takes \`h.mu.Lock()\` so only one goroutine can serialize + write at a time. Doc comment on \`saveToDiskLocked\` updated to say the caller must hold the write lock, not "at least a read lock".
2. **Atomic write**: marshal to a temp file in the same directory (\`os.CreateTemp\`), \`Sync\`, \`Close\`, \`Chmod\`, then \`os.Rename\` over the target. Rename is atomic on the same filesystem — a concurrent reader (or a crash mid-write) always sees either the old complete file or the new complete file, never a partial one. Even if a future caller accidentally holds the wrong lock, an interrupted write cannot leave a corrupted target behind.

Credit to @Va16hav07 for the detailed reproduction and diagnosis.

## Test plan
- [ ] \`go vet\` and \`go build\` on \`pkg/api/handlers/...\` (already green locally)
- [ ] Create multiple orbit missions, trigger several rapid \`POST /api/orbit/missions/:id/run\` while the auto-run scheduler is active, confirm \`orbit_missions.json\` stays well-formed and missions survive restart
- [ ] Temp-file cleanup works on error paths (marshal failure, write failure)