### PR TITLE
fix(exec): address Copilot review on #7997 (#8002)

### DIFF
--- a/pkg/api/handlers/exec.go
+++ b/pkg/api/handlers/exec.go
@@ -34,12 +34,15 @@ const execPingInterval = 30 * time.Second
 // in the future when a new ping is sent.
 const execPongTimeout = 45 * time.Second
 
-// execStdinDropCount counts stdin frames that were silently discarded because
-// stdinCh was full. #7995 — telemetry-first pass: we don't know how often this
-// actually fires in production, so observe before escalating the handling
-// (block-then-error-close is the planned follow-up if this counter is non-zero
-// in real traffic). Exposed via GetExecStdinDropCount for tests and any future
-// stats endpoint.
+// execStdinDropCount counts stdin frames that were discarded because
+// stdinCh was full. PR 7995 added the counter and a rate-limited WARN log
+// so drops are no longer silent — the first drop in a session logs, then
+// further drops increment the counter and log only on power-of-two
+// boundaries to avoid log storms under sustained backpressure.
+// Telemetry-first pass: observe before escalating the handling
+// (block-then-error-close is the planned follow-up if this counter is
+// non-zero in real traffic). Exposed via GetExecStdinDropCount for tests
+// and any future stats endpoint.
 var execStdinDropCount atomic.Uint64
 
 // GetExecStdinDropCount returns the cumulative number of stdin frames that
@@ -469,6 +472,13 @@ func (h *ExecHandlers) HandleExec(c *websocket.Conn) {
 
 	// Start a goroutine to read WebSocket messages and route them
 	done := make(chan struct{})
+	// Per-session stdin-drop counter. Used to rate-limit the WARN log at
+	// the drop site so a backpressure burst doesn't flood the journal
+	// (Copilot review on issue 8002). Log the first drop, then log only on
+	// power-of-two boundaries (2, 4, 8, 16, ...) thereafter. The global
+	// execStdinDropCount is still incremented on every drop for accurate
+	// telemetry — only the per-line log is throttled.
+	var sessionStdinDrops uint64
 	go func() {
 		defer close(done)
 		defer close(stdinCh)
@@ -493,17 +503,28 @@ func (h *ExecHandlers) HandleExec(c *websocket.Conn) {
 				select {
 				case stdinCh <- []byte(m.Data):
 				default:
-					// #7995 — stdinCh is full, meaning the pod's stdin drain
-					// has fallen behind. Silently dropping the frame is the
-					// current behavior and can truncate pasted commands or
-					// scripts at arbitrary byte boundaries. Record telemetry
-					// so we can observe whether this actually fires in
-					// production before escalating to block-then-error-close.
-					dropped := execStdinDropCount.Add(1)
-					slog.Warn("[Exec] dropping stdin frame — channel full",
-						"bytes", len(m.Data),
-						"buffer", cap(stdinCh),
-						"total_drops", dropped)
+					// stdinCh is full, meaning the pod's stdin drain has
+					// fallen behind. Dropping the frame here can truncate
+					// pasted commands or scripts at arbitrary byte
+					// boundaries — PR 7995 added this counter + WARN so the
+					// drop is observable. Throttle the log to the first
+					// drop in a session and power-of-two session counts
+					// thereafter (Copilot review on issue 8002) so a
+					// sustained backpressure burst doesn't flood the
+					// journal. Telemetry-first pass: observe before
+					// escalating to block-then-error-close.
+					totalDrops := execStdinDropCount.Add(1)
+					sessionStdinDrops++
+					// Log when sessionStdinDrops is a power of two (1, 2,
+					// 4, 8, ...). `x & (x-1) == 0` is the standard
+					// power-of-two check.
+					if sessionStdinDrops&(sessionStdinDrops-1) == 0 {
+						slog.Warn("[Exec] dropping stdin frame — channel full",
+							"bytes", len(m.Data),
+							"buffer", cap(stdinCh),
+							"session_drops", sessionStdinDrops,
+							"total_drops", totalDrops)
+					}
 				}
 			case "resize":
 				if m.Cols > 0 && m.Rows > 0 {


### PR DESCRIPTION
## Summary

Addresses the two Copilot review comments on merged PR #7997 (issue #8002).

1. **Doc-comment accuracy** (\`pkg/api/handlers/exec.go:42\`): the comment on \`execStdinDropCount\` still said frames were "silently discarded", but #7995 added a WARN log at the drop site — drops are no longer silent. Reworded the comment to match.

2. **Log-volume bound** (\`pkg/api/handlers/exec.go:506\`): the WARN was logged on *every* dropped frame. Under sustained backpressure (client spamming stdin while the pod isn't draining), that produces an unbounded log stream. Rate-limit to the first drop in each session plus power-of-two session counts (1, 2, 4, 8, 16, ...) thereafter. The global counter still increments on every drop so cumulative telemetry is accurate — only the per-line log is throttled. The new \`session_drops\` field on the log line makes the rate-limiting visible.

## Test plan
- [ ] \`go vet\` + \`go build\` pass (local green)
- [ ] Smoke test: paste a large command into an exec terminal, confirm you see at most ~log2(N) lines instead of N