### PR TITLE
fix(tests): exclude comment lines from raw-hex detector (#8000)

### DIFF
--- a/web/src/test/ui-ux-standards.test.ts
+++ b/web/src/test/ui-ux-standards.test.ts
@@ -75,9 +75,13 @@ const COMPONENTS_DIR = path.resolve(
 // When you bump this number, append a one-line entry above so future
 // bumps stay grep-able and reviewers can tell at a glance whether a
 // change is a real new violation or just a comment-level reference.
-//   313 → 319: PR #7085 mission state fixes — issue-ref comments misclassified as hex colors
-//   319 → 320: PR #7376 batch resolve — one new hex color reference
-const EXPECTED_RAW_HEX_COUNT = 320
+//   313 → 319: PR 7085 mission state fixes — issue-ref comments misclassified as hex colors
+//   319 → 320: PR 7376 batch resolve — one new hex color reference
+//   320 → 265: issue 8000 — detector now skips comment lines outright,
+//              eliminating all issue-ref false positives like "issue #7865"
+//              that incremented the ratchet over many previous bumps. The
+//              new baseline is the count of real `#RRGGBB` literals only.
+const EXPECTED_RAW_HEX_COUNT = 265
 const EXPECTED_RAW_RGBA_COUNT = 104
 const EXPECTED_ARBITRARY_TW_COLOR_COUNT = 22
 // Inline style color ratchet — bump history:
@@ -224,8 +228,9 @@ function isInCanvasContext(line: string): boolean {
 
 /**
  * Detect raw hex color values (#xxx, #xxxxxx, #xxxxxxxx).
- * Skips SVG contexts, canvas contexts, CSS var declarations, and string
- * template expressions.
+ * Skips SVG contexts, canvas contexts, CSS var declarations, string
+ * template expressions, and comments (which commonly contain issue
+ * refs like "#7865" that look like 4-digit hex colors — issue 8000).
  */
 function detectRawHex(line: string): ViolationCategory | null {
   const stripped = line.trim()
@@ -233,6 +238,21 @@ function detectRawHex(line: string): ViolationCategory | null {
   // Skip SVG and canvas contexts
   if (isInSvgContext(stripped)) return null
   if (isInCanvasContext(stripped)) return null
+
+  // Skip comment lines outright (line comments, block-comment openers,
+  // block-comment continuation lines that start with `*`, and JSX
+  // `{/* ... */}` comments). Issue refs of the form `#NNNN` match the
+  // hex regex by accident and produced false-positive violations
+  // throughout the codebase — the detector should only police colors
+  // in live code, not prose (issue 8000).
+  if (
+    stripped.startsWith('//') ||
+    stripped.startsWith('/*') ||
+    stripped.startsWith('*') ||
+    stripped.startsWith('{/*')
+  ) {
+    return null
+  }
 
   // Skip className attributes (Tailwind classes may contain color names, not hex)
   if (/className\s*=/.test(stripped) && !/#[0-9a-fA-F]{3,8}/.test(stripped)) return null


### PR DESCRIPTION
## Summary

Fixes #8000. The \`ui-ux-standards\` raw-hex detector regex \`/#[0-9a-fA-F]{3,8}\\b/\` matches 4-digit issue references like \`#7865\` in code comments by accident. Every ratchet bump for the last dozen PRs was chasing these false positives (see the bump history in \`web/src/test/ui-ux-standards.test.ts\`), and the auto-QA run that produced issue #8000 listed 25 "hardcoded hex colors" that were all just issue refs like \`#6058\`, \`#6271\`, etc. in \`//\` and \`{/* */}\` comments.

### Fix

Detector now skips any line whose trimmed prefix looks like a comment marker: \`//\`, \`/*\`, \` * \` (block-comment continuation), or \`{/*\` (JSX comment). Design-token enforcement still applies to live code, which is the only place it matters.

### Ratchet drop

Baseline drops 320 → 265 (the count of real \`#RRGGBB\` literals still in \`src/\`). Future bumps will reflect real color additions only, not prose. Bump log entry added so the drop is grep-able.

## Test plan
- [x] \`npx vitest run src/test/ui-ux-standards.test.ts\` — 7/7 tests pass
- [ ] CI ui-ux-standard gate passes