### PR TITLE
♻️ refactor(phase1): migrate workload scale to kc-agent (#7993)

### DIFF
--- a/pkg/agent/server_http.go
+++ b/pkg/agent/server_http.go
@@ -1040,10 +1040,22 @@ func (s *Server) handleScaleHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// The frontend (useWorkloads.useScaleWorkload) sends:
+	//   { workloadName, namespace, targetClusters: []string, replicas }
+	// Older agent callers used { cluster, namespace, name, replicas }.
+	// Accept both shapes so we remain backward compatible while migrating
+	// /api/workloads/scale off the backend pod SA (#7993 Phase 1 PR A).
 	var req struct {
-		Cluster   string `json:"cluster"`
+		// New shape (frontend → agent)
+		WorkloadName   string   `json:"workloadName"`
+		TargetClusters []string `json:"targetClusters"`
+
+		// Legacy shape (kept for backward compat with existing direct agent callers)
+		Cluster string `json:"cluster"`
+		Name    string `json:"name"`
+
+		// Shared fields
 		Namespace string `json:"namespace"`
-		Name      string `json:"name"`
 		Replicas  int32  `json:"replicas"`
 	}
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
@@ -1055,13 +1067,17 @@ func (s *Server) handleScaleHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	var cluster, namespace, name string
-	var replicas int32
-
-	cluster = req.Cluster
-	namespace = req.Namespace
-	name = req.Name
-	replicas = req.Replicas
+	// Normalize the two shapes to a single (name, targetClusters) pair.
+	name := req.WorkloadName
+	if name == "" {
+		name = req.Name
+	}
+	targetClusters := req.TargetClusters
+	if len(targetClusters) == 0 && req.Cluster != "" {
+		targetClusters = []string{req.Cluster}
+	}
+	namespace := req.Namespace
+	replicas := req.Replicas
 
 	if replicas < 0 {
 		w.WriteHeader(http.StatusBadRequest)
@@ -1072,10 +1088,10 @@ func (s *Server) handleScaleHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if cluster == "" || namespace == "" || name == "" {
+	if name == "" || namespace == "" {
 		writeJSON(w,map[string]interface{}{
 			"success": false,
-			"error":   "cluster, namespace, and name are required",
+			"error":   "workloadName and namespace are required",
 		})
 		return
 	}
@@ -1083,9 +1099,9 @@ func (s *Server) handleScaleHTTP(w http.ResponseWriter, r *http.Request) {
 	ctx, cancel := context.WithTimeout(r.Context(), agentExtendedTimeout)
 	defer cancel()
 
-	result, err := s.k8sClient.ScaleWorkload(ctx, namespace, name, []string{cluster}, replicas)
+	result, err := s.k8sClient.ScaleWorkload(ctx, namespace, name, targetClusters, replicas)
 	if err != nil {
-		slog.Warn("error scaling resource", "namespace", namespace, "name", name, "cluster", cluster, "error", err)
+		slog.Warn("error scaling resource", "namespace", namespace, "name", name, "targetClusters", targetClusters, "error", err)
 		writeJSON(w,map[string]interface{}{
 			"success": false,
 			"error":   err.Error(),

--- a/pkg/api/auth_sweep_test.go
+++ b/pkg/api/auth_sweep_test.go
@@ -68,7 +68,7 @@ func TestProtectedRoutes_UnauthenticatedReturn401(t *testing.T) {
 		{"GET", "/api/workloads"},
 		{"GET", "/api/workloads/capabilities"},
 		{"POST", "/api/workloads/deploy"},
-		{"POST", "/api/workloads/scale"},
+		// NOTE: /api/workloads/scale moved to kc-agent (#7993 Phase 1 PR A).
 		// Gateway / MCS / GitOps read
 		{"GET", "/api/gateway/gateways"},
 		{"GET", "/api/gateway/httproutes"},

--- a/pkg/api/handlers/workloads.go
+++ b/pkg/api/handlers/workloads.go
@@ -1073,50 +1073,6 @@ func buildClusterContextForAI(healthData []k8s.ClusterHealth) string {
 	return sb.String()
 }
 
-// ScaleWorkload scales a workload in specified clusters
-// POST /api/workloads/scale
-func (h *WorkloadHandlers) ScaleWorkload(c *fiber.Ctx) error {
-	// Workload mutations require console admin (#5974).
-	if err := h.requireAdmin(c); err != nil {
-		return err
-	}
-
-	if h.k8sClient == nil {
-		return c.Status(503).JSON(fiber.Map{"error": "Kubernetes client not available"})
-	}
-
-	type ScaleRequest struct {
-		WorkloadName   string   `json:"workloadName"`
-		Namespace      string   `json:"namespace"`
-		TargetClusters []string `json:"targetClusters,omitempty"`
-		Replicas       int32    `json:"replicas"`
-	}
-
-	var req ScaleRequest
-	if err := c.BodyParser(&req); err != nil {
-		slog.Info("[Workloads] invalid request body", "error", err)
-		return c.Status(400).JSON(fiber.Map{"error": "invalid request"})
-	}
-
-	// Validate required fields
-	if req.WorkloadName == "" {
-		return c.Status(400).JSON(fiber.Map{"error": "workloadName is required"})
-	}
-	if req.Namespace == "" {
-		return c.Status(400).JSON(fiber.Map{"error": "namespace is required"})
-	}
-
-	ctx, cancel := context.WithTimeout(c.Context(), workloadWriteTimeout)
-	defer cancel()
-
-	result, err := h.k8sClient.ScaleWorkload(ctx, req.Namespace, req.WorkloadName, req.TargetClusters, req.Replicas)
-	if err != nil {
-		return handleK8sError(c, err)
-	}
-
-	return c.JSON(result)
-}
-
 // DeleteWorkload deletes a workload from specified clusters
 // DELETE /api/workloads/:cluster/:namespace/:name
 func (h *WorkloadHandlers) DeleteWorkload(c *fiber.Ctx) error {

--- a/pkg/api/handlers/workloads_test.go
+++ b/pkg/api/handlers/workloads_test.go
@@ -226,51 +226,10 @@ func TestGetDeployStatus(t *testing.T) {
 	assert.Equal(t, float64(3), status["readyReplicas"])
 }
 
-func TestScaleWorkload(t *testing.T) {
-	env := setupTestEnv(t)
-	handler := NewWorkloadHandlers(env.K8sClient, env.Hub, env.Store)
-	env.App.Post("/api/workloads/scale", handler.ScaleWorkload)
-
-	scheme := newK8sScheme()
-
-	// Inject a dynamic client with a Deployment so ScaleWorkload can find and patch it.
-	deploy := &appsv1.Deployment{
-		TypeMeta:   metav1.TypeMeta{Kind: "Deployment", APIVersion: "apps/v1"},
-		ObjectMeta: metav1.ObjectMeta{Name: "scale-app", Namespace: "default"},
-		Spec: appsv1.DeploymentSpec{
-			Replicas: func(i int32) *int32 { return &i }(1),
-			Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": "scale"}},
-			Template: corev1.PodTemplateSpec{
-				ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"app": "scale"}},
-				Spec:       corev1.PodSpec{Containers: []corev1.Container{{Name: "c", Image: "nginx"}}},
-			},
-		},
-	}
-	injectDynamicClusterWithObjects(env, "scale-cluster", scheme, []runtime.Object{deploy})
-
-	// Payload
-	payload := map[string]interface{}{
-		"workloadName":   "scale-app",
-		"namespace":      "default",
-		"targetClusters": []string{"scale-cluster"},
-		"replicas":       10,
-	}
-
-	data, _ := json.Marshal(payload)
-	req, err := http.NewRequest("POST", "/api/workloads/scale", bytes.NewReader(data))
-	require.NoError(t, err)
-	require.NotNil(t, req)
-	req.Header.Set("Content-Type", "application/json")
-
-	resp, err := env.App.Test(req, 5000)
-	require.NoError(t, err)
-	require.NotNil(t, resp)
-	assert.Equal(t, 200, resp.StatusCode)
-
-	var result map[string]interface{}
-	json.NewDecoder(resp.Body).Decode(&result)
-	assert.Equal(t, true, result["success"])
-}
+// TestScaleWorkload was removed when /api/workloads/scale moved to kc-agent
+// (#7993 Phase 1 PR A). The equivalent coverage now lives in the agent
+// package (pkg/agent) which exercises handleScaleHTTP against the shared
+// pkg/k8s MultiClusterClient.ScaleWorkload method.
 
 func TestDeleteWorkload(t *testing.T) {
 	env := setupTestEnv(t)

--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -1070,7 +1070,8 @@ func (s *Server) setupRoutes() {
 	api.Get("/workloads/monitor/:cluster/:namespace/:name", workloadHandlers.MonitorWorkload)
 	api.Get("/workloads/:cluster/:namespace/:name", workloadHandlers.GetWorkload)
 	api.Post("/workloads/deploy", workloadHandlers.DeployWorkload)
-	api.Post("/workloads/scale", workloadHandlers.ScaleWorkload)
+	// NOTE: /workloads/scale moved to kc-agent (#7993 Phase 1 PR A).
+	// The agent uses the user's kubeconfig instead of the backend pod SA.
 	api.Delete("/workloads/:cluster/:namespace/:name", workloadHandlers.DeleteWorkload)
 
 	// Cluster Group routes

--- a/web/src/hooks/useWorkloads.ts
+++ b/web/src/hooks/useWorkloads.ts
@@ -365,7 +365,10 @@ export function useScaleWorkload() {
     setError(null)
 
     try {
-      const res = await fetch('/api/workloads/scale', {
+      // Scaling is a user-initiated mutation on managed clusters, so it must
+      // go through kc-agent (user's kubeconfig), not the backend's pod SA.
+      // See #7993 Phase 1 PR A.
+      const res = await fetch(`${LOCAL_AGENT_HTTP_URL}/scale`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json', ...authHeaders() },
         body: JSON.stringify(request),


### PR DESCRIPTION
## Summary
- Migrate `useScaleWorkload` from `/api/workloads/scale` (backend pod SA) to `${LOCAL_AGENT_HTTP_URL}/scale` (user's kubeconfig via kc-agent).
- Delete `WorkloadHandlers.ScaleWorkload` and its route from the backend. The shared `pkg/k8s/workload.go` `MultiClusterClient.ScaleWorkload` method stays — kc-agent still uses it.

## Why
Part of #7993 Phase 1. The Go backend's pod ServiceAccount must not be used for user-initiated k8s operations against managed clusters; those operations must run under the user's own kubeconfig via kc-agent. Scale is the quickest win because `/scale` already exists in kc-agent.

## Test plan
- [x] go build ./...
- [x] go vet ./...
- [x] go test ./pkg/agent/...
- [x] go test ./pkg/api/handlers/... (TestDeploy/Delete/Get/List pass; pre-existing TestRefreshToken / TestRecordFocus_BadBody_Returns400 failures on main ignored)
- [x] npm run build (web)

Refs #7993