### PR TITLE
♻️ refactor(phase1): migrate workload deploy + delete to kc-agent (#7993)

### DIFF
--- a/pkg/agent/server.go
+++ b/pkg/agent/server.go
@@ -47,6 +47,12 @@ const (
 	maxQueryLimit       = 1000    // Upper bound for client-supplied limit query parameter
 	maxRequestBodyBytes = 1 << 20 // 1MB upper bound for request body reads
 
+	// deployedByAnonymousMarker is the default value recorded on workloads
+	// created via kc-agent when the caller did not supply a "deployedBy"
+	// identifier. Matches pkg/k8s/workload.go DeployOptions default
+	// ("anonymous") so resources created via either path look identical.
+	deployedByAnonymousMarker = "anonymous"
+
 	// missionExecutionTimeout is the maximum wall-clock time a single mission
 	// chat execution (AI provider call) is allowed to run before the context
 	// is cancelled and the frontend receives a timeout error.  This prevents
@@ -393,6 +399,10 @@ func (s *Server) Start() error {
 	mux.HandleFunc("/limitranges", s.handleLimitRangesHTTP)
 	mux.HandleFunc("/resolve-deps", s.handleResolveDepsHTTP)
 	mux.HandleFunc("/scale", s.handleScaleHTTP)
+	// Workload deploy and delete routes moved to kc-agent (#7993 Phase 1 PR B).
+	// These run under the user's kubeconfig instead of the backend pod SA.
+	mux.HandleFunc("/workloads/deploy", s.handleDeployWorkloadHTTP)
+	mux.HandleFunc("/workloads/delete", s.handleDeleteWorkloadHTTP)
 
 	// Rename context endpoint
 	mux.HandleFunc("/rename-context", s.handleRenameContextHTTP)

--- a/pkg/agent/server_http.go
+++ b/pkg/agent/server_http.go
@@ -1119,6 +1119,213 @@ func (s *Server) handleScaleHTTP(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
+// handleDeployWorkloadHTTP deploys a workload from a source cluster to one or
+// more target clusters via the shared pkg/k8s MultiClusterClient.DeployWorkload
+// method. The agent uses the user's kubeconfig rather than the backend's pod
+// ServiceAccount, so this endpoint is the user-kubeconfig path for
+// `/api/workloads/deploy` (#7993 Phase 1 PR B).
+//
+// Only POST with a JSON body is accepted; GET-based mutations are rejected to
+// prevent CSRF-style attacks (#4150 pattern, same as handleScaleHTTP).
+func (s *Server) handleDeployWorkloadHTTP(w http.ResponseWriter, r *http.Request) {
+	s.setCORSHeaders(w, r)
+	w.Header().Set("Content-Type", "application/json")
+	if r.Method == "OPTIONS" {
+		w.WriteHeader(http.StatusOK)
+		return
+	}
+
+	// SECURITY: Require auth — deploying is a mutating operation.
+	if !s.validateToken(r) {
+		w.WriteHeader(http.StatusUnauthorized)
+		writeJSON(w, map[string]string{"error": "unauthorized"})
+		return
+	}
+
+	// SECURITY: Only allow POST — GET mutations enable CSRF.
+	if r.Method != "POST" {
+		w.WriteHeader(http.StatusMethodNotAllowed)
+		writeJSON(w, map[string]interface{}{
+			"success": false,
+			"error":   "POST required",
+		})
+		return
+	}
+
+	if s.k8sClient == nil {
+		writeJSON(w, map[string]interface{}{
+			"success": false,
+			"error":   "k8s client not initialized",
+		})
+		return
+	}
+
+	// Matches the backend's DeployWorkload request shape so the frontend can
+	// send the same payload to either endpoint during migration.
+	var req struct {
+		WorkloadName   string   `json:"workloadName"`
+		Namespace      string   `json:"namespace"`
+		SourceCluster  string   `json:"sourceCluster"`
+		TargetClusters []string `json:"targetClusters"`
+		Replicas       int32    `json:"replicas,omitempty"`
+		GroupName      string   `json:"groupName,omitempty"`
+		// Optional informational annotation. The agent runs under the user's
+		// own kubeconfig so the "deployedBy" label is not security-relevant;
+		// it's only used to annotate created resources. If unset, falls back
+		// to the anonymous marker used by MultiClusterClient.DeployWorkload.
+		DeployedBy string `json:"deployedBy,omitempty"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		w.WriteHeader(http.StatusBadRequest)
+		writeJSON(w, map[string]interface{}{
+			"success": false,
+			"error":   "invalid request body",
+		})
+		return
+	}
+
+	if req.WorkloadName == "" {
+		w.WriteHeader(http.StatusBadRequest)
+		writeJSON(w, map[string]interface{}{"success": false, "error": "workloadName is required"})
+		return
+	}
+	if req.Namespace == "" {
+		w.WriteHeader(http.StatusBadRequest)
+		writeJSON(w, map[string]interface{}{"success": false, "error": "namespace is required"})
+		return
+	}
+	if req.SourceCluster == "" {
+		w.WriteHeader(http.StatusBadRequest)
+		writeJSON(w, map[string]interface{}{"success": false, "error": "sourceCluster is required"})
+		return
+	}
+	if len(req.TargetClusters) == 0 {
+		w.WriteHeader(http.StatusBadRequest)
+		writeJSON(w, map[string]interface{}{"success": false, "error": "at least one targetCluster is required"})
+		return
+	}
+
+	opts := &k8s.DeployOptions{
+		DeployedBy: req.DeployedBy,
+		GroupName:  req.GroupName,
+	}
+	if opts.DeployedBy == "" {
+		opts.DeployedBy = deployedByAnonymousMarker
+	}
+
+	ctx, cancel := context.WithTimeout(r.Context(), agentExtendedTimeout)
+	defer cancel()
+
+	result, err := s.k8sClient.DeployWorkload(ctx, req.SourceCluster, req.Namespace, req.WorkloadName, req.TargetClusters, req.Replicas, opts)
+	if err != nil {
+		slog.Warn("error deploying workload", "namespace", req.Namespace, "name", req.WorkloadName, "sourceCluster", req.SourceCluster, "targetClusters", req.TargetClusters, "error", err)
+		w.WriteHeader(http.StatusInternalServerError)
+		writeJSON(w, map[string]interface{}{
+			"success": false,
+			"error":   err.Error(),
+			"source":  "agent",
+		})
+		return
+	}
+
+	writeJSON(w, map[string]interface{}{
+		"success":        result.Success,
+		"message":        result.Message,
+		"deployedTo":     result.DeployedTo,
+		"failedClusters": result.FailedClusters,
+		"source":         "agent",
+	})
+}
+
+// handleDeleteWorkloadHTTP deletes a workload (Deployment / StatefulSet /
+// DaemonSet) from a single managed cluster via the shared pkg/k8s
+// MultiClusterClient.DeleteWorkload method. Runs under the user's kubeconfig
+// instead of the backend's pod ServiceAccount (#7993 Phase 1 PR B).
+//
+// Only POST with a JSON body is accepted. The backend previously used
+// `DELETE /api/workloads/:cluster/:namespace/:name`, but kc-agent's convention
+// is POST-with-body for all mutations (same as /scale), so the frontend sends
+// a POST with {cluster, namespace, name} in the body.
+func (s *Server) handleDeleteWorkloadHTTP(w http.ResponseWriter, r *http.Request) {
+	s.setCORSHeaders(w, r)
+	w.Header().Set("Content-Type", "application/json")
+	if r.Method == "OPTIONS" {
+		w.WriteHeader(http.StatusOK)
+		return
+	}
+
+	// SECURITY: Require auth — delete is a destructive mutating operation.
+	if !s.validateToken(r) {
+		w.WriteHeader(http.StatusUnauthorized)
+		writeJSON(w, map[string]string{"error": "unauthorized"})
+		return
+	}
+
+	// SECURITY: Only allow POST — GET mutations enable CSRF.
+	if r.Method != "POST" {
+		w.WriteHeader(http.StatusMethodNotAllowed)
+		writeJSON(w, map[string]interface{}{
+			"success": false,
+			"error":   "POST required",
+		})
+		return
+	}
+
+	if s.k8sClient == nil {
+		writeJSON(w, map[string]interface{}{
+			"success": false,
+			"error":   "k8s client not initialized",
+		})
+		return
+	}
+
+	var req struct {
+		Cluster   string `json:"cluster"`
+		Namespace string `json:"namespace"`
+		Name      string `json:"name"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		w.WriteHeader(http.StatusBadRequest)
+		writeJSON(w, map[string]interface{}{
+			"success": false,
+			"error":   "invalid request body",
+		})
+		return
+	}
+
+	if req.Cluster == "" || req.Namespace == "" || req.Name == "" {
+		w.WriteHeader(http.StatusBadRequest)
+		writeJSON(w, map[string]interface{}{
+			"success": false,
+			"error":   "cluster, namespace, and name are required",
+		})
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(r.Context(), agentExtendedTimeout)
+	defer cancel()
+
+	if err := s.k8sClient.DeleteWorkload(ctx, req.Cluster, req.Namespace, req.Name); err != nil {
+		slog.Warn("error deleting workload", "cluster", req.Cluster, "namespace", req.Namespace, "name", req.Name, "error", err)
+		w.WriteHeader(http.StatusInternalServerError)
+		writeJSON(w, map[string]interface{}{
+			"success": false,
+			"error":   err.Error(),
+			"source":  "agent",
+		})
+		return
+	}
+
+	writeJSON(w, map[string]interface{}{
+		"success":   true,
+		"message":   "Workload deleted successfully",
+		"cluster":   req.Cluster,
+		"namespace": req.Namespace,
+		"name":      req.Name,
+		"source":    "agent",
+	})
+}
+
 // handlePodsHTTP returns pods for a cluster/namespace
 func (s *Server) handlePodsHTTP(w http.ResponseWriter, r *http.Request) {
 	s.setCORSHeaders(w, r)

--- a/pkg/api/auth_sweep_test.go
+++ b/pkg/api/auth_sweep_test.go
@@ -67,8 +67,9 @@ func TestProtectedRoutes_UnauthenticatedReturn401(t *testing.T) {
 		// Workloads
 		{"GET", "/api/workloads"},
 		{"GET", "/api/workloads/capabilities"},
-		{"POST", "/api/workloads/deploy"},
-		// NOTE: /api/workloads/scale moved to kc-agent (#7993 Phase 1 PR A).
+		// NOTE: /api/workloads/deploy and /api/workloads/scale, and the DELETE
+		// /api/workloads/:cluster/:namespace/:name route all moved to kc-agent
+		// (#7993 Phase 1 PRs A and B).
 		// Gateway / MCS / GitOps read
 		{"GET", "/api/gateway/gateways"},
 		{"GET", "/api/gateway/httproutes"},

--- a/pkg/api/handlers/workloads.go
+++ b/pkg/api/handlers/workloads.go
@@ -120,89 +120,10 @@ func (h *WorkloadHandlers) GetWorkload(c *fiber.Ctx) error {
 	return c.JSON(workload)
 }
 
-// DeployWorkload deploys a workload to specified clusters
-// POST /api/workloads/deploy
-func (h *WorkloadHandlers) DeployWorkload(c *fiber.Ctx) error {
-	// Workload mutations require console admin (#5974).
-	if err := h.requireAdmin(c); err != nil {
-		return err
-	}
-
-	if h.k8sClient == nil {
-		return c.Status(503).JSON(fiber.Map{"error": "Kubernetes client not available"})
-	}
-
-	type DeployRequest struct {
-		WorkloadName   string   `json:"workloadName"`
-		Namespace      string   `json:"namespace"`
-		SourceCluster  string   `json:"sourceCluster"`
-		TargetClusters []string `json:"targetClusters"`
-		Replicas       int32    `json:"replicas,omitempty"`
-		GroupName      string   `json:"groupName,omitempty"`
-	}
-
-	var req DeployRequest
-	if err := c.BodyParser(&req); err != nil {
-		slog.Info("[Workloads] invalid request body", "error", err)
-		return c.Status(400).JSON(fiber.Map{"error": "invalid request"})
-	}
-
-	// Validate required fields
-	if req.WorkloadName == "" {
-		return c.Status(400).JSON(fiber.Map{"error": "workloadName is required"})
-	}
-	if req.Namespace == "" {
-		return c.Status(400).JSON(fiber.Map{"error": "namespace is required"})
-	}
-	if req.SourceCluster == "" {
-		// #5957 — reject missing sourceCluster with a clear 400 rather than
-		// letting it fall through and surface as a confusing downstream error.
-		return c.Status(400).JSON(fiber.Map{"error": "sourceCluster is required"})
-	}
-	if err := validateK8sName(req.SourceCluster, "sourceCluster"); err != nil {
-		return c.Status(400).JSON(fiber.Map{"error": err.Error()})
-	}
-	if len(req.TargetClusters) == 0 {
-		return c.Status(400).JSON(fiber.Map{"error": "at least one targetCluster is required"})
-	}
-	// Verify sourceCluster is actually known to the multi-cluster client (#5957).
-	// Catches typos and stale UI state before we attempt to read from the source.
-	if h.k8sClient != nil {
-		known := false
-		if clusters, _, cerr := h.k8sClient.HealthyClusters(c.Context()); cerr == nil {
-			for _, cl := range clusters {
-				if cl.Name == req.SourceCluster || cl.Context == req.SourceCluster {
-					known = true
-					break
-				}
-			}
-		}
-		if !known {
-			return c.Status(400).JSON(fiber.Map{"error": fmt.Sprintf("sourceCluster %q is not a known cluster", req.SourceCluster)})
-		}
-	}
-
-	// Extract authenticated user
-	deployedBy := "anonymous"
-	if login := middleware.GetGitHubLogin(c); login != "" {
-		deployedBy = login
-	}
-
-	opts := &k8s.DeployOptions{
-		DeployedBy: deployedBy,
-		GroupName:  req.GroupName,
-	}
-
-	ctx, cancel := context.WithTimeout(c.Context(), workloadWriteTimeout)
-	defer cancel()
-
-	result, err := h.k8sClient.DeployWorkload(ctx, req.SourceCluster, req.Namespace, req.WorkloadName, req.TargetClusters, req.Replicas, opts)
-	if err != nil {
-		return handleK8sError(c, err)
-	}
-
-	return c.JSON(result)
-}
+// NOTE: DeployWorkload moved to kc-agent (#7993 Phase 1 PR B).
+// The agent (pkg/agent/server_http.go handleDeployWorkloadHTTP) runs under
+// the user's kubeconfig instead of the backend pod SA and calls the same
+// shared pkg/k8s MultiClusterClient.DeployWorkload method.
 
 // ResolveDependencies returns the dependency tree for a workload without deploying (dry-run).
 // GET /api/workloads/resolve-deps/:cluster/:namespace/:name
@@ -1073,36 +994,10 @@ func buildClusterContextForAI(healthData []k8s.ClusterHealth) string {
 	return sb.String()
 }
 
-// DeleteWorkload deletes a workload from specified clusters
-// DELETE /api/workloads/:cluster/:namespace/:name
-func (h *WorkloadHandlers) DeleteWorkload(c *fiber.Ctx) error {
-	// Workload mutations require console admin (#5974).
-	if err := h.requireAdmin(c); err != nil {
-		return err
-	}
-
-	if h.k8sClient == nil {
-		return c.Status(503).JSON(fiber.Map{"error": "Kubernetes client not available"})
-	}
-
-	cluster := c.Params("cluster")
-	namespace := c.Params("namespace")
-	name := c.Params("name")
-
-	ctx, cancel := context.WithTimeout(c.Context(), workloadWriteTimeout)
-	defer cancel()
-
-	if err := h.k8sClient.DeleteWorkload(ctx, cluster, namespace, name); err != nil {
-		return handleK8sError(c, err)
-	}
-
-	return c.JSON(fiber.Map{
-		"message":   "Workload deleted successfully",
-		"cluster":   cluster,
-		"namespace": namespace,
-		"name":      name,
-	})
-}
+// NOTE: DeleteWorkload moved to kc-agent (#7993 Phase 1 PR B).
+// The agent (pkg/agent/server_http.go handleDeleteWorkloadHTTP) runs under
+// the user's kubeconfig instead of the backend pod SA and calls the same
+// shared pkg/k8s MultiClusterClient.DeleteWorkload method.
 
 // GetClusterCapabilities returns the capabilities of all clusters
 // GET /api/workloads/capabilities

--- a/pkg/api/handlers/workloads_test.go
+++ b/pkg/api/handlers/workloads_test.go
@@ -130,71 +130,9 @@ func TestGetWorkload(t *testing.T) {
 	assert.Equal(t, 404, respNotFound.StatusCode)
 }
 
-func TestDeployWorkload(t *testing.T) {
-	env := setupTestEnv(t)
-	handler := NewWorkloadHandlers(env.K8sClient, env.Hub, env.Store)
-	env.App.Post("/api/workloads/deploy", handler.DeployWorkload)
-
-	scheme := newK8sScheme()
-
-	// Source Deployment
-	srcDep := &appsv1.Deployment{
-		TypeMeta: metav1.TypeMeta{Kind: "Deployment", APIVersion: "apps/v1"},
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "src-app",
-			Namespace: "default",
-		},
-		Spec: appsv1.DeploymentSpec{
-			Replicas: func(i int32) *int32 { return &i }(1),
-			Template: corev1.PodTemplateSpec{
-				Spec: corev1.PodSpec{Containers: []corev1.Container{{Name: "c", Image: "nginx"}}},
-			},
-		},
-	}
-
-	injectDynamicClusterWithObjects(env, "source-cluster", scheme, []runtime.Object{srcDep})
-	targetDyn := injectDynamicClusterWithObjects(env, "target-cluster", scheme, nil)
-
-	// Payload
-	payload := map[string]interface{}{
-		"workloadName":   "src-app",
-		"namespace":      "default",
-		"sourceCluster":  "source-cluster",
-		"targetClusters": []string{"target-cluster"},
-		"replicas":       3,
-	}
-
-	data, _ := json.Marshal(payload)
-
-	req, err := http.NewRequest("POST", "/api/workloads/deploy", bytes.NewReader(data))
-	require.NoError(t, err)
-	require.NotNil(t, req)
-	req.Header.Set("Content-Type", "application/json")
-
-	resp, err := env.App.Test(req, 5000)
-	require.NoError(t, err)
-	require.NotNil(t, resp)
-	if resp.StatusCode != 200 {
-		body, _ := io.ReadAll(resp.Body)
-		t.Fatalf("Deploy returned %d: %s", resp.StatusCode, string(body))
-	}
-	assert.Equal(t, 200, resp.StatusCode)
-
-	// Verify result body
-	var result map[string]interface{}
-	json.NewDecoder(resp.Body).Decode(&result)
-	assert.Equal(t, true, result["success"])
-
-	// Verify deployment created in target
-	gvr := appsv1.SchemeGroupVersion.WithResource("deployments")
-	dep, err := targetDyn.Resource(gvr).Namespace("default").Get(context.Background(), "src-app", metav1.GetOptions{})
-	require.NoError(t, err)
-	assert.Equal(t, "src-app", dep.GetName())
-
-	// Check Replicas (int64 for unstructured)
-	spec := dep.Object["spec"].(map[string]interface{})
-	assert.Equal(t, int64(3), spec["replicas"])
-}
+// TestDeployWorkload was removed when /api/workloads/deploy moved to kc-agent
+// (#7993 Phase 1 PR B). Coverage of the underlying deploy logic is provided
+// by pkg/k8s workload tests exercising MultiClusterClient.DeployWorkload.
 
 func TestGetDeployStatus(t *testing.T) {
 	env := setupTestEnv(t)
@@ -231,28 +169,10 @@ func TestGetDeployStatus(t *testing.T) {
 // package (pkg/agent) which exercises handleScaleHTTP against the shared
 // pkg/k8s MultiClusterClient.ScaleWorkload method.
 
-func TestDeleteWorkload(t *testing.T) {
-	env := setupTestEnv(t)
-	handler := NewWorkloadHandlers(env.K8sClient, env.Hub, env.Store)
-	env.App.Delete("/api/workloads/:cluster/:namespace/:name", handler.DeleteWorkload)
-
-	// Inject a dynamic client for cluster "c1" with a deployment matching the
-	// delete request so the handler can resolve the cluster and find the resource.
-	scheme := newK8sScheme()
-	dep := &appsv1.Deployment{
-		ObjectMeta: metav1.ObjectMeta{Name: "del-app", Namespace: "default"},
-	}
-	injectDynamicClusterWithObjects(env, "c1", scheme, []runtime.Object{dep})
-
-	req, err := http.NewRequest("DELETE", "/api/workloads/c1/default/del-app", nil)
-	require.NoError(t, err)
-	require.NotNil(t, req)
-	resp, err := env.App.Test(req, 5000)
-
-	require.NoError(t, err)
-	require.NotNil(t, resp)
-	assert.Equal(t, 200, resp.StatusCode)
-}
+// TestDeleteWorkload was removed when the DELETE /api/workloads/... route
+// moved to kc-agent (#7993 Phase 1 PR B). Coverage of the underlying delete
+// logic is provided by pkg/k8s workload tests exercising
+// MultiClusterClient.DeleteWorkload.
 
 func TestClusterGroupsCRUD(t *testing.T) {
 	env := setupTestEnv(t)

--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -1069,10 +1069,10 @@ func (s *Server) setupRoutes() {
 	api.Get("/workloads/resolve-deps/:cluster/:namespace/:name", workloadHandlers.ResolveDependencies)
 	api.Get("/workloads/monitor/:cluster/:namespace/:name", workloadHandlers.MonitorWorkload)
 	api.Get("/workloads/:cluster/:namespace/:name", workloadHandlers.GetWorkload)
-	api.Post("/workloads/deploy", workloadHandlers.DeployWorkload)
-	// NOTE: /workloads/scale moved to kc-agent (#7993 Phase 1 PR A).
-	// The agent uses the user's kubeconfig instead of the backend pod SA.
-	api.Delete("/workloads/:cluster/:namespace/:name", workloadHandlers.DeleteWorkload)
+	// NOTE: /workloads/deploy, /workloads/scale, and the DELETE
+	// /workloads/:cluster/:namespace/:name route all moved to kc-agent
+	// (#7993 Phase 1 PRs A and B). The agent uses the user's kubeconfig
+	// instead of the backend pod SA for those mutating operations.
 
 	// Cluster Group routes
 	api.Get("/cluster-groups", workloadHandlers.ListClusterGroups)

--- a/web/src/hooks/useWorkloads.ts
+++ b/web/src/hooks/useWorkloads.ts
@@ -319,7 +319,10 @@ export function useDeployWorkload() {
     setError(null)
 
     try {
-      const res = await fetch('/api/workloads/deploy', {
+      // Deploy is a user-initiated mutation on managed clusters, so it must
+      // run under the user's kubeconfig via kc-agent, not the backend pod SA.
+      // See #7993 Phase 1 PR B.
+      const res = await fetch(`${LOCAL_AGENT_HTTP_URL}/workloads/deploy`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json', ...authHeaders() },
         body: JSON.stringify(request),
@@ -413,9 +416,19 @@ export function useDeleteWorkload() {
     setError(null)
 
     try {
-      const res = await fetch(`/api/workloads/${params.cluster}/${params.namespace}/${params.name}`, {
-        method: 'DELETE',
-        headers: authHeaders(),
+      // Delete is a destructive mutation on a managed cluster, so it must
+      // run under the user's kubeconfig via kc-agent, not the backend pod SA.
+      // kc-agent convention is POST-with-body (same as /scale) — the method
+      // verb moves from DELETE-with-params to POST-with-body here.
+      // See #7993 Phase 1 PR B.
+      const res = await fetch(`${LOCAL_AGENT_HTTP_URL}/workloads/delete`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', ...authHeaders() },
+        body: JSON.stringify({
+          cluster: params.cluster,
+          namespace: params.namespace,
+          name: params.name,
+        }),
         signal: AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS) })
       if (!res.ok) {
         const errorData = await res.json()


### PR DESCRIPTION
## Summary
- Add `handleDeployWorkloadHTTP` and `handleDeleteWorkloadHTTP` to kc-agent (`pkg/agent/server_http.go`), registered at `POST /workloads/deploy` and `POST /workloads/delete`.
- Migrate `useDeployWorkload` and `useDeleteWorkload` from the backend to `${LOCAL_AGENT_HTTP_URL}/workloads/*`. Delete's verb moves from `DELETE` with path params to `POST` with a JSON body to match the kc-agent convention (same as `/scale`).
- Delete `WorkloadHandlers.DeployWorkload` / `WorkloadHandlers.DeleteWorkload` handlers and their routes. The shared `pkg/k8s/workload.go` `MultiClusterClient.DeployWorkload` / `DeleteWorkload` methods stay — kc-agent uses them.

## Why
Part of #7993 Phase 1, following #8010 (scale migration). The backend's pod ServiceAccount must not be used for user-initiated k8s operations against managed clusters; those operations must run under the user's own kubeconfig via kc-agent. Since `MultiClusterClient.DeployWorkload` / `DeleteWorkload` already exist and kc-agent already owns a `*MultiClusterClient`, this is a thin handler wrapper (~200 lines in `server_http.go`) — the heavy bundling logic stays in `pkg/k8s`.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./pkg/agent/...` (pass)
- [x] `go test ./pkg/api/handlers/... -run 'TestListWorkloads|TestGetWorkload|TestGetDeployStatus'` (pass)
- [x] `npm run build` (web) — all post-build safety checks pass
- [x] Pre-existing main-branch failures (`TestRefreshToken`, `TestRecordFocus_BadBody_Returns400`, `TestClusterGroupsCRUD`) verified unchanged
- [ ] Manual smoke: deploy / delete a workload in the UI with a running kc-agent

Refs #7993