### PR TITLE
fix: update useDeleteWorkload test for kc-agent migration

### DIFF
--- a/web/src/hooks/__tests__/useWorkloads.test.ts
+++ b/web/src/hooks/__tests__/useWorkloads.test.ts
@@ -556,10 +556,18 @@ describe('useDeleteWorkload', () => {
     expect(result.current.isLoading).toBe(false)
     expect(result.current.error).toBeNull()
 
-    // Verify the URL includes cluster/namespace/name path segments
+    // After #8013, delete goes through kc-agent as POST with JSON body
     const fetchSpy = globalThis.fetch as ReturnType<typeof vi.fn>
     const callUrl = fetchSpy.mock.calls[0]?.[0] as string
-    expect(callUrl).toBe('/api/workloads/prod/production/api-server')
+    expect(callUrl).toBe('http://127.0.0.1:8585/workloads/delete')
+
+    const callOpts = fetchSpy.mock.calls[0]?.[1] as RequestInit
+    expect(callOpts.method).toBe('POST')
+    expect(JSON.parse(callOpts.body as string)).toEqual({
+      cluster: 'prod',
+      namespace: 'production',
+      name: 'api-server',
+    })
   })
 
   it('handles delete failure with error body', async () => {


### PR DESCRIPTION
## Problem

PR #8013 refactored `useDeleteWorkload` to route through kc-agent (POST to `LOCAL_AGENT_HTTP_URL/workloads/delete` with JSON body), but the test still expected the old DELETE → `/api/workloads/:cluster/:namespace/:name` pattern.

**Failing test:** `useDeleteWorkload sends DELETE request and calls onSuccess`



## Fix

Updated the test assertion to match the new kc-agent routing:

- **URL**: `http://127.0.0.1:8585/workloads/delete` (not REST API path)
- **Method**: POST (not DELETE)
- **Body**: JSON with `{ cluster, namespace, name }`

## Verification

All 26 tests pass:
```
✓ useDeleteWorkload > sends DELETE request and calls onSuccess 4ms
✓ useDeleteWorkload > handles delete failure with error body 3ms
✓ useDeleteWorkload > uses generic message when error body has no error field 2ms
```

Fixes #8020