### PR TITLE
🐛 fix: extend auth regression test + update useDeleteWorkload test for kc-agent (#8006 #8020)

### DIFF
--- a/pkg/agent/endpoint_auth_test.go
+++ b/pkg/agent/endpoint_auth_test.go
@@ -116,6 +116,27 @@ const (
 	// endpointDeviceAlertsClear clears a device alert (sensitive — mutating).
 	endpointDeviceAlertsClear = "/device/alerts/clear"
 
+	// endpointHPAs lists HorizontalPodAutoscalers (sensitive — reveals infra).
+	endpointHPAs = "/hpas"
+
+	// endpointPVCs lists PersistentVolumeClaims (sensitive — reveals infra).
+	endpointPVCs = "/pvcs"
+
+	// endpointRoles lists Kubernetes Roles (sensitive — RBAC posture).
+	endpointRoles = "/roles"
+
+	// endpointRoleBindings lists Kubernetes RoleBindings (sensitive — RBAC posture).
+	endpointRoleBindings = "/rolebindings"
+
+	// endpointResourceQuotas lists ResourceQuotas (sensitive — reveals infra).
+	endpointResourceQuotas = "/resourcequotas"
+
+	// endpointLimitRanges lists LimitRanges (sensitive — reveals infra).
+	endpointLimitRanges = "/limitranges"
+
+	// endpointResolveDeps resolves workload dependencies (sensitive — walks RBAC/pods).
+	endpointResolveDeps = "/resolve-deps"
+
 	// testTokenValue is the shared secret used to configure auth in tests.
 	testTokenValue = "test-secret-token-42"
 
@@ -171,6 +192,13 @@ var sensitiveEndpoints = []struct {
 	{endpointPredictionsStats, "GET"},
 	{endpointDeviceAlerts, "GET"},
 	{endpointDeviceAlertsClear, "POST"},
+	{endpointHPAs, "GET"},
+	{endpointPVCs, "GET"},
+	{endpointRoles, "GET"},
+	{endpointRoleBindings, "GET"},
+	{endpointResourceQuotas, "GET"},
+	{endpointLimitRanges, "GET"},
+	{endpointResolveDeps, "GET"},
 }
 
 // endpointsLackingAuth are endpoints that SHOULD require auth but currently

--- a/web/src/hooks/__tests__/useWorkloads.test.ts
+++ b/web/src/hooks/__tests__/useWorkloads.test.ts
@@ -537,7 +537,7 @@ describe('useScaleWorkload', () => {
 // ---------------------------------------------------------------------------
 
 describe('useDeleteWorkload', () => {
-  it('sends DELETE request and calls onSuccess', async () => {
+  it('sends POST to kc-agent /workloads/delete and calls onSuccess', async () => {
     vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
       new Response('{}', { status: 200, headers: { 'Content-Type': 'application/json' } })
     )
@@ -556,10 +556,18 @@ describe('useDeleteWorkload', () => {
     expect(result.current.isLoading).toBe(false)
     expect(result.current.error).toBeNull()
 
-    // Verify the URL includes cluster/namespace/name path segments
+    // Phase 1 PR B (#7993/#8013) moved delete off the backend REST path
+    // and onto kc-agent to run under the user's kubeconfig. The verb is
+    // now POST-with-body (mirroring /scale), not DELETE-with-params.
     const fetchSpy = globalThis.fetch as ReturnType<typeof vi.fn>
-    const callUrl = fetchSpy.mock.calls[0]?.[0] as string
-    expect(callUrl).toBe('/api/workloads/prod/production/api-server')
+    const [callUrl, callInit] = fetchSpy.mock.calls[0] as [string, RequestInit]
+    expect(callUrl).toBe('http://127.0.0.1:8585/workloads/delete')
+    expect(callInit.method).toBe('POST')
+    expect(JSON.parse(callInit.body as string)).toEqual({
+      cluster: 'prod',
+      namespace: 'production',
+      name: 'api-server',
+    })
   })
 
   it('handles delete failure with error body', async () => {


### PR DESCRIPTION
## Summary

Two test fixes flagged by auto-generated follow-up issues.

### #8006 — auth regression test gap (from merged #8001)

`#8001` added `validateToken` to seven handlers in `pkg/agent/server_http.go`:
`handleHPAsHTTP`, `handlePVCsHTTP`, `handleRolesHTTP`, `handleRoleBindingsHTTP`,
`handleResourceQuotasHTTP`, `handleLimitRangesHTTP`, `handleResolveDepsHTTP`.

But `pkg/agent/endpoint_auth_test.go` — the regression suite whose whole purpose is to make future auth regressions a test failure — still did not have those endpoints in its `sensitiveEndpoints` table. Copilot caught it on the merged PR.

Add seven endpoint constants plus seven table entries. Now any regression that removes `validateToken` from those handlers fails three tests (`_no_auth`, `_with_auth`, `_bad_token` matrix).

### #8020 — useDeleteWorkload test assertion drift (from merged #8013)

`#8013` (Phase 1 PR B of umbrella #7993) moved workload delete off the backend pod SA onto kc-agent so that destructive mutations run under the user's kubeconfig instead of the pod service account. As part of that, the verb flipped from DELETE-with-params (`/api/workloads/:cluster/:ns/:name`) to POST-with-body (`\${LOCAL_AGENT_HTTP_URL}/workloads/delete` — mirroring `/scale`).

`useWorkloads.test.ts` still asserted the old REST-DELETE URL, which is why Coverage Suite run #714 failed with:

```
useDeleteWorkload sends DELETE request and calls onSuccess
```

Update the assertion to match the new shape: URL `http://127.0.0.1:8585/workloads/delete`, `method: 'POST'`, and a JSON body of `{ cluster, namespace, name }`. Rename the test to \"sends POST to kc-agent /workloads/delete\" so it reads accurately.

## Fixes

- Fixes #8006
- Fixes #8020

## Test plan

- [ ] CI unit tests green on `useWorkloads.test.ts`
- [ ] CI Go tests green on `endpoint_auth_test.go` (sensitive endpoint matrix × 3 test functions × 7 new entries)