### PR TITLE
♻️ refactor(phase1.5): migrate RBAC handlers to kc-agent (#7993)

### DIFF
--- a/pkg/agent/server_http.go
+++ b/pkg/agent/server_http.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/kubestellar/console/pkg/agent/protocol"
 	"github.com/kubestellar/console/pkg/k8s"
+	"github.com/kubestellar/console/pkg/models"
 	"github.com/kubestellar/console/pkg/settings"
 )
 
@@ -660,7 +661,11 @@ func (s *Server) handleSecretsHTTP(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w,map[string]interface{}{"secrets": secrets, "source": "agent"})
 }
 
-// handleServiceAccountsHTTP returns service accounts for a cluster/namespace
+// handleServiceAccountsHTTP serves ServiceAccount operations for a
+// cluster/namespace. GET reads the list (existing behavior). POST creates a
+// new ServiceAccount, and DELETE removes one — both are user-initiated
+// mutations that run under the user's kubeconfig via kc-agent rather than the
+// backend's pod ServiceAccount (#7993 Phase 1.5 PR A).
 func (s *Server) handleServiceAccountsHTTP(w http.ResponseWriter, r *http.Request) {
 	s.setCORSHeaders(w, r)
 	w.Header().Set("Content-Type", "application/json")
@@ -674,13 +679,22 @@ func (s *Server) handleServiceAccountsHTTP(w http.ResponseWriter, r *http.Reques
 		return
 	}
 	if s.k8sClient == nil {
-		writeJSON(w,map[string]interface{}{"serviceaccounts": []interface{}{}, "error": "k8s client not initialized"})
+		writeJSON(w, map[string]interface{}{"serviceaccounts": []interface{}{}, "error": "k8s client not initialized"})
 		return
 	}
+	switch r.Method {
+	case http.MethodPost:
+		s.createServiceAccountHTTP(w, r)
+		return
+	case http.MethodDelete:
+		s.deleteServiceAccountHTTP(w, r)
+		return
+	}
+	// Default: GET list
 	cluster := r.URL.Query().Get("cluster")
 	namespace := r.URL.Query().Get("namespace")
 	if cluster == "" {
-		writeJSON(w,map[string]interface{}{"serviceaccounts": []interface{}{}, "error": "cluster parameter required"})
+		writeJSON(w, map[string]interface{}{"serviceaccounts": []interface{}{}, "error": "cluster parameter required"})
 		return
 	}
 	ctx, cancel := context.WithTimeout(r.Context(), agentDefaultTimeout)
@@ -691,7 +705,67 @@ func (s *Server) handleServiceAccountsHTTP(w http.ResponseWriter, r *http.Reques
 		writeJSONError(w, http.StatusServiceUnavailable, "cluster temporarily unavailable")
 		return
 	}
-	writeJSON(w,map[string]interface{}{"serviceaccounts": serviceaccounts, "source": "agent"})
+	writeJSON(w, map[string]interface{}{"serviceaccounts": serviceaccounts, "source": "agent"})
+}
+
+// createServiceAccountHTTP handles POST /serviceaccounts. The request body
+// shape matches pkg/models.CreateServiceAccountRequest so the frontend
+// migration from POST /api/rbac/service-accounts to
+// POST ${LOCAL_AGENT_HTTP_URL}/serviceaccounts is a pure URL swap.
+// Returns the created ServiceAccount as JSON on success.
+func (s *Server) createServiceAccountHTTP(w http.ResponseWriter, r *http.Request) {
+	var req struct {
+		Name      string `json:"name"`
+		Namespace string `json:"namespace"`
+		Cluster   string `json:"cluster"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		w.WriteHeader(http.StatusBadRequest)
+		writeJSON(w, map[string]interface{}{"success": false, "error": "invalid request body"})
+		return
+	}
+	if req.Cluster == "" || req.Namespace == "" || req.Name == "" {
+		w.WriteHeader(http.StatusBadRequest)
+		writeJSON(w, map[string]interface{}{"success": false, "error": "cluster, namespace, and name are required"})
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(r.Context(), agentExtendedTimeout)
+	defer cancel()
+
+	sa, err := s.k8sClient.CreateServiceAccount(ctx, req.Cluster, req.Namespace, req.Name)
+	if err != nil {
+		slog.Warn("error creating service account", "cluster", req.Cluster, "namespace", req.Namespace, "name", req.Name, "error", err)
+		w.WriteHeader(http.StatusInternalServerError)
+		writeJSON(w, map[string]interface{}{"success": false, "error": err.Error(), "source": "agent"})
+		return
+	}
+	writeJSON(w, sa)
+}
+
+// deleteServiceAccountHTTP handles DELETE /serviceaccounts. The cluster,
+// namespace, and name are read from the query string (e.g.
+// DELETE /serviceaccounts?cluster=prod&namespace=default&name=my-sa).
+func (s *Server) deleteServiceAccountHTTP(w http.ResponseWriter, r *http.Request) {
+	cluster := r.URL.Query().Get("cluster")
+	namespace := r.URL.Query().Get("namespace")
+	name := r.URL.Query().Get("name")
+	if cluster == "" || namespace == "" || name == "" {
+		w.WriteHeader(http.StatusBadRequest)
+		writeJSON(w, map[string]interface{}{"success": false, "error": "cluster, namespace, and name query parameters are required"})
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(r.Context(), agentExtendedTimeout)
+	defer cancel()
+
+	if err := s.k8sClient.DeleteServiceAccount(ctx, cluster, namespace, name); err != nil {
+		slog.Warn("error deleting service account", "cluster", cluster, "namespace", namespace, "name", name, "error", err)
+		w.WriteHeader(http.StatusInternalServerError)
+		writeJSON(w, map[string]interface{}{"success": false, "error": err.Error(), "source": "agent"})
+		return
+	}
+	writeJSON(w, map[string]interface{}{"success": true, "cluster": cluster, "namespace": namespace, "name": name, "source": "agent"})
 }
 
 // handleJobsHTTP returns jobs for a cluster/namespace
@@ -830,7 +904,11 @@ func (s *Server) handleRolesHTTP(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w,map[string]interface{}{"roles": roles, "source": "agent"})
 }
 
-// handleRoleBindingsHTTP returns RoleBindings for a cluster/namespace
+// handleRoleBindingsHTTP serves RoleBinding operations for a
+// cluster/namespace. GET reads the list (existing behavior). POST creates a
+// new RoleBinding or ClusterRoleBinding, and DELETE removes one — both are
+// user-initiated mutations that run under the user's kubeconfig via kc-agent
+// rather than the backend's pod ServiceAccount (#7993 Phase 1.5 PR A).
 func (s *Server) handleRoleBindingsHTTP(w http.ResponseWriter, r *http.Request) {
 	s.setCORSHeaders(w, r)
 	w.Header().Set("Content-Type", "application/json")
@@ -844,13 +922,22 @@ func (s *Server) handleRoleBindingsHTTP(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 	if s.k8sClient == nil {
-		writeJSON(w,map[string]interface{}{"rolebindings": []interface{}{}, "error": "k8s client not initialized"})
+		writeJSON(w, map[string]interface{}{"rolebindings": []interface{}{}, "error": "k8s client not initialized"})
 		return
 	}
+	switch r.Method {
+	case http.MethodPost:
+		s.createRoleBindingHTTP(w, r)
+		return
+	case http.MethodDelete:
+		s.deleteRoleBindingHTTP(w, r)
+		return
+	}
+	// Default: GET list
 	cluster := r.URL.Query().Get("cluster")
 	namespace := r.URL.Query().Get("namespace")
 	if cluster == "" {
-		writeJSON(w,map[string]interface{}{"rolebindings": []interface{}{}, "error": "cluster parameter required"})
+		writeJSON(w, map[string]interface{}{"rolebindings": []interface{}{}, "error": "cluster parameter required"})
 		return
 	}
 	ctx, cancel := context.WithTimeout(r.Context(), agentDefaultTimeout)
@@ -861,7 +948,138 @@ func (s *Server) handleRoleBindingsHTTP(w http.ResponseWriter, r *http.Request) 
 		writeJSONError(w, http.StatusServiceUnavailable, "cluster temporarily unavailable")
 		return
 	}
-	writeJSON(w,map[string]interface{}{"rolebindings": bindings, "source": "agent"})
+	writeJSON(w, map[string]interface{}{"rolebindings": bindings, "source": "agent"})
+}
+
+// createRoleBindingHTTP handles POST /rolebindings. The body shape matches
+// pkg/models.CreateRoleBindingRequest so frontend callers migrate from
+// POST /api/rbac/bindings to POST ${LOCAL_AGENT_HTTP_URL}/rolebindings with a
+// pure URL swap.
+//
+// It also accepts the GrantNamespaceAccess shape used by
+// NamespaceManager/GrantAccessModal (cluster, subjectKind, subjectName,
+// subjectNamespace, role, namespace) so namespace-access grants route
+// through the same endpoint. Namespace-access bodies are normalized into a
+// full RoleBinding spec before delegating to the shared pkg/k8s
+// MultiClusterClient.CreateRoleBinding method.
+func (s *Server) createRoleBindingHTTP(w http.ResponseWriter, r *http.Request) {
+	// Accept a union of both shapes. Fields common to both (cluster,
+	// namespace, subjectName, subjectNamespace) are shared; shape-specific
+	// fields are read from dedicated fields. The grant-access path sets
+	// `role` and leaves `name`/`roleName` unset; the rbac/bindings path sets
+	// `name`/`roleName`/`roleKind`/`subjectKind` and may omit `role`.
+	var req struct {
+		Name        string `json:"name,omitempty"`
+		Namespace   string `json:"namespace,omitempty"`
+		Cluster     string `json:"cluster"`
+		IsCluster   bool   `json:"isCluster,omitempty"`
+		RoleName    string `json:"roleName,omitempty"`
+		RoleKind    string `json:"roleKind,omitempty"`
+		SubjectKind string `json:"subjectKind"`
+		SubjectName string `json:"subjectName"`
+		SubjectNS   string `json:"subjectNamespace,omitempty"`
+		// Role is only set by GrantNamespaceAccess callers; shortcut
+		// ("admin"/"edit"/"view") or a custom role name. Ignored when
+		// roleName is supplied.
+		Role string `json:"role,omitempty"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		w.WriteHeader(http.StatusBadRequest)
+		writeJSON(w, map[string]interface{}{"success": false, "error": "invalid request body"})
+		return
+	}
+	if req.Cluster == "" {
+		w.WriteHeader(http.StatusBadRequest)
+		writeJSON(w, map[string]interface{}{"success": false, "error": "cluster is required"})
+		return
+	}
+	if req.SubjectKind == "" || req.SubjectName == "" {
+		w.WriteHeader(http.StatusBadRequest)
+		writeJSON(w, map[string]interface{}{"success": false, "error": "subjectKind and subjectName are required"})
+		return
+	}
+
+	// Fill in defaults for the grant-namespace-access shape.
+	roleName := req.RoleName
+	if roleName == "" {
+		roleName = req.Role
+	}
+	roleKind := req.RoleKind
+	if roleKind == "" {
+		// grant-access shortcuts ("admin"/"edit"/"view") map to
+		// ClusterRoles in stock Kubernetes; custom role names default to
+		// ClusterRole as well since GrantNamespaceAccess historically used
+		// ClusterRole (see pkg/k8s/rbac.go GrantNamespaceAccess).
+		roleKind = "ClusterRole"
+	}
+	if roleName == "" {
+		w.WriteHeader(http.StatusBadRequest)
+		writeJSON(w, map[string]interface{}{"success": false, "error": "roleName (or role) is required"})
+		return
+	}
+
+	// Synthesize a binding name when the caller didn't provide one (the
+	// grant-access shape doesn't include it). Format mirrors what the
+	// backend GrantNamespaceAccess used: <subject>-<role>-<namespace>.
+	bindingName := req.Name
+	if bindingName == "" {
+		bindingName = fmt.Sprintf("%s-%s-%s", req.SubjectName, roleName, req.Namespace)
+	}
+
+	k8sReq := models.CreateRoleBindingRequest{
+		Name:        bindingName,
+		Namespace:   req.Namespace,
+		Cluster:     req.Cluster,
+		IsCluster:   req.IsCluster,
+		RoleName:    roleName,
+		RoleKind:    roleKind,
+		SubjectKind: models.K8sSubjectKind(req.SubjectKind),
+		SubjectName: req.SubjectName,
+		SubjectNS:   req.SubjectNS,
+	}
+
+	ctx, cancel := context.WithTimeout(r.Context(), agentExtendedTimeout)
+	defer cancel()
+
+	if err := s.k8sClient.CreateRoleBinding(ctx, k8sReq); err != nil {
+		slog.Warn("error creating role binding", "cluster", req.Cluster, "namespace", req.Namespace, "name", bindingName, "error", err)
+		w.WriteHeader(http.StatusInternalServerError)
+		writeJSON(w, map[string]interface{}{"success": false, "error": err.Error(), "source": "agent"})
+		return
+	}
+	writeJSON(w, map[string]interface{}{"success": true, "roleBinding": bindingName, "source": "agent"})
+}
+
+// deleteRoleBindingHTTP handles DELETE /rolebindings. Cluster, namespace,
+// name, and an optional isCluster flag are read from the query string.
+// When isCluster=true the handler deletes a ClusterRoleBinding and namespace
+// is ignored.
+func (s *Server) deleteRoleBindingHTTP(w http.ResponseWriter, r *http.Request) {
+	cluster := r.URL.Query().Get("cluster")
+	namespace := r.URL.Query().Get("namespace")
+	name := r.URL.Query().Get("name")
+	isCluster := r.URL.Query().Get("isCluster") == "true"
+	if cluster == "" || name == "" {
+		w.WriteHeader(http.StatusBadRequest)
+		writeJSON(w, map[string]interface{}{"success": false, "error": "cluster and name query parameters are required"})
+		return
+	}
+	if !isCluster && namespace == "" {
+		w.WriteHeader(http.StatusBadRequest)
+		writeJSON(w, map[string]interface{}{"success": false, "error": "namespace query parameter is required for non-cluster bindings"})
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(r.Context(), agentExtendedTimeout)
+	defer cancel()
+
+	if err := s.k8sClient.DeleteRoleBinding(ctx, cluster, namespace, name, isCluster); err != nil {
+		slog.Warn("error deleting role binding", "cluster", cluster, "namespace", namespace, "name", name, "isCluster", isCluster, "error", err)
+		w.WriteHeader(http.StatusInternalServerError)
+		writeJSON(w, map[string]interface{}{"success": false, "error": err.Error(), "source": "agent"})
+		return
+	}
+	writeJSON(w, map[string]interface{}{"success": true, "cluster": cluster, "namespace": namespace, "name": name, "isCluster": isCluster, "source": "agent"})
 }
 
 // handleResourceQuotasHTTP returns ResourceQuotas for a cluster/namespace

--- a/pkg/api/auth_sweep_test.go
+++ b/pkg/api/auth_sweep_test.go
@@ -54,12 +54,12 @@ func TestProtectedRoutes_UnauthenticatedReturn401(t *testing.T) {
 		{"POST", "/api/mcp/tools/ops/call"},
 		{"POST", "/api/mcp/tools/deploy/call"},
 		// RBAC read + mutate
+		// NOTE: POST /api/rbac/service-accounts and POST /api/rbac/bindings
+		// moved to kc-agent (#7993 Phase 1.5 PR A).
 		{"GET", "/api/rbac/users"},
 		{"GET", "/api/rbac/roles"},
 		{"GET", "/api/rbac/bindings"},
 		{"GET", "/api/rbac/permissions"},
-		{"POST", "/api/rbac/service-accounts"},
-		{"POST", "/api/rbac/bindings"},
 		{"POST", "/api/rbac/can-i"},
 		// Namespace lifecycle
 		{"GET", "/api/namespaces"},

--- a/pkg/api/handlers/rbac.go
+++ b/pkg/api/handlers/rbac.go
@@ -22,9 +22,6 @@ const rbacAnalysisTimeout = 60 * time.Second
 // rbacDefaultTimeout is the per-cluster timeout for standard RBAC queries.
 const rbacDefaultTimeout = 15 * time.Second
 
-// rbacWriteTimeout is the timeout for RBAC write operations.
-const rbacWriteTimeout = 15 * time.Second
-
 // parseUUID parses a UUID string
 func parseUUID(s string) (uuid.UUID, error) {
 	return uuid.Parse(s)
@@ -410,154 +407,13 @@ func (h *RBACHandler) GetClusterPermissions(c *fiber.Ctx) error {
 	return c.JSON(perms)
 }
 
-// CreateServiceAccount creates a new service account (cluster-admin only)
-func (h *RBACHandler) CreateServiceAccount(c *fiber.Ctx) error {
-	// #6860: Console-level authorization — only admin users may create
-	// service accounts. Without this, any authenticated console user could
-	// create SAs via the backend's privileged kubeconfig identity.
-	userID := middleware.GetUserID(c)
-	currentUser, err := h.store.GetUser(userID)
-	if err != nil || currentUser == nil {
-		return fiber.NewError(fiber.StatusUnauthorized, "Unauthorized")
-	}
-	if currentUser.Role != models.UserRoleAdmin {
-		slog.Warn("[rbac] SECURITY: non-admin attempted to create service account",
-			"user_id", currentUser.ID,
-			"github_login", currentUser.GitHubLogin)
-		return fiber.NewError(fiber.StatusForbidden, "Console admin role required")
-	}
-
-	if h.k8sClient == nil {
-		return fiber.NewError(fiber.StatusServiceUnavailable, "Kubernetes client not available")
-	}
-
-	var req models.CreateServiceAccountRequest
-	if err := c.BodyParser(&req); err != nil {
-		return fiber.NewError(fiber.StatusBadRequest, "Invalid request body")
-	}
-
-	// #6627: explicit field-level validation. Previously only non-empty
-	// checks were performed; a malformed name would be passed to the
-	// apiserver and return an opaque 500.
-	if err := validateDNSLabel("name", req.Name); err != nil {
-		return fiber.NewError(fiber.StatusBadRequest, err.Error())
-	}
-	if err := validateDNSLabel("namespace", req.Namespace); err != nil {
-		return fiber.NewError(fiber.StatusBadRequest, err.Error())
-	}
-	if err := validateClusterName("cluster", req.Cluster); err != nil {
-		return fiber.NewError(fiber.StatusBadRequest, err.Error())
-	}
-
-	ctx, cancel := context.WithTimeout(c.Context(), rbacWriteTimeout)
-	defer cancel()
-
-	// Check if user has cluster-admin access via Kubernetes RBAC too
-	isAdmin, kerr := h.k8sClient.CheckClusterAdminAccess(ctx, req.Cluster)
-	if kerr != nil || !isAdmin {
-		return fiber.NewError(fiber.StatusForbidden, "Cluster admin access required")
-	}
-
-	sa, err := h.k8sClient.CreateServiceAccount(ctx, req.Cluster, req.Namespace, req.Name)
-	if err != nil {
-		slog.Warn("[RBAC] failed to create service account", "error", err)
-		return fiber.NewError(fiber.StatusInternalServerError, "internal server error")
-	}
-
-	return c.JSON(sa)
-}
-
-// CreateRoleBinding creates a new role binding (cluster-admin only)
-func (h *RBACHandler) CreateRoleBinding(c *fiber.Ctx) error {
-	// #6859: Console-level authorization — only admin users may create
-	// role bindings. Without this, any authenticated console user could
-	// escalate privileges via the backend's privileged kubeconfig identity.
-	userID := middleware.GetUserID(c)
-	currentUser, err := h.store.GetUser(userID)
-	if err != nil || currentUser == nil {
-		return fiber.NewError(fiber.StatusUnauthorized, "Unauthorized")
-	}
-	if currentUser.Role != models.UserRoleAdmin {
-		slog.Warn("[rbac] SECURITY: non-admin attempted to create role binding",
-			"user_id", currentUser.ID,
-			"github_login", currentUser.GitHubLogin)
-		return fiber.NewError(fiber.StatusForbidden, "Console admin role required")
-	}
-
-	if h.k8sClient == nil {
-		return fiber.NewError(fiber.StatusServiceUnavailable, "Kubernetes client not available")
-	}
-
-	var req models.CreateRoleBindingRequest
-	if err := c.BodyParser(&req); err != nil {
-		return fiber.NewError(fiber.StatusBadRequest, "Invalid request body")
-	}
-
-	// #6627: explicit field-level validation. Previously only non-empty
-	// checks existed; empty subjectKind, out-of-range lengths, and invalid
-	// DNS labels were all silently accepted.
-	if err := validateDNSLabel("name", req.Name); err != nil {
-		return fiber.NewError(fiber.StatusBadRequest, err.Error())
-	}
-	if err := validateClusterName("cluster", req.Cluster); err != nil {
-		return fiber.NewError(fiber.StatusBadRequest, err.Error())
-	}
-	if err := validateRoleName("roleName", req.RoleName); err != nil {
-		return fiber.NewError(fiber.StatusBadRequest, err.Error())
-	}
-	// Namespace is empty for ClusterRoleBindings — only validate if present.
-	if req.Namespace != "" {
-		if err := validateDNSLabel("namespace", req.Namespace); err != nil {
-			return fiber.NewError(fiber.StatusBadRequest, err.Error())
-		}
-	}
-	// roleKind, subjectKind must be one of the known Kubernetes kinds.
-	if err := validateEnum("roleKind", req.RoleKind, []string{"Role", "ClusterRole"}); err != nil {
-		return fiber.NewError(fiber.StatusBadRequest, err.Error())
-	}
-	if err := validateEnum("subjectKind", string(req.SubjectKind), []string{"User", "Group", "ServiceAccount"}); err != nil {
-		return fiber.NewError(fiber.StatusBadRequest, err.Error())
-	}
-	// subjectName has different rules for SAs vs users/groups. For SA we
-	// enforce DNS label; for users/groups we only require non-empty +
-	// reasonable length since they can contain emails, colons, etc.
-	if req.SubjectKind == models.K8sSubjectServiceAccount {
-		if err := validateDNSLabel("subjectName", req.SubjectName); err != nil {
-			return fiber.NewError(fiber.StatusBadRequest, err.Error())
-		}
-		// #6675 Copilot followup: subjectNamespace is REQUIRED for
-		// ServiceAccount subjects per Kubernetes RBAC. Previously we
-		// only validated it when present, so a missing namespace could
-		// slip through and fail later at the apiserver with a generic
-		// error.
-		if err := validateDNSLabel("subjectNamespace", req.SubjectNS); err != nil {
-			return fiber.NewError(fiber.StatusBadRequest, err.Error())
-		}
-	} else {
-		if req.SubjectName == "" {
-			return fiber.NewError(fiber.StatusBadRequest, "subjectName is required")
-		}
-		if len(req.SubjectName) > maxK8sDNSSubdomainLen {
-			return fiber.NewError(fiber.StatusBadRequest, "subjectName too long")
-		}
-	}
-
-	ctx, cancel := context.WithTimeout(c.Context(), rbacWriteTimeout)
-	defer cancel()
-
-	// Check if user has cluster-admin access
-	isAdmin, err := h.k8sClient.CheckClusterAdminAccess(ctx, req.Cluster)
-	if err != nil || !isAdmin {
-		return fiber.NewError(fiber.StatusForbidden, "Cluster admin access required")
-	}
-
-	if err := h.k8sClient.CreateRoleBinding(ctx, req); err != nil {
-		slog.Warn("[RBAC] failed to create role binding", "error", err)
-		return fiber.NewError(fiber.StatusInternalServerError, "internal server error")
-	}
-
-	return c.JSON(fiber.Map{"success": true})
-}
+// NOTE: CreateServiceAccount and CreateRoleBinding moved to kc-agent
+// (#7993 Phase 1.5 PR A). The frontend now POSTs to
+// ${LOCAL_AGENT_HTTP_URL}/serviceaccounts and
+// ${LOCAL_AGENT_HTTP_URL}/rolebindings so these mutations run under the
+// user's kubeconfig instead of the backend pod's ServiceAccount. The shared
+// pkg/k8s MultiClusterClient.CreateServiceAccount and
+// MultiClusterClient.CreateRoleBinding methods stay — kc-agent uses them.
 
 // ListK8sUsers returns all unique users/subjects from role bindings.
 // SECURITY: Restricted to admin users to prevent non-admin users from

--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -885,8 +885,11 @@ func (s *Server) setupRoutes() {
 	api.Get("/rbac/roles", rbac.ListK8sRoles)
 	api.Get("/rbac/bindings", rbac.ListK8sRoleBindings)
 	api.Get("/rbac/permissions", rbac.GetClusterPermissions)
-	api.Post("/rbac/service-accounts", rbac.CreateServiceAccount)
-	api.Post("/rbac/bindings", rbac.CreateRoleBinding)
+	// NOTE: POST /api/rbac/service-accounts and POST /api/rbac/bindings moved
+	// to kc-agent (#7993 Phase 1.5 PR A). The frontend now POSTs to
+	// ${LOCAL_AGENT_HTTP_URL}/serviceaccounts and
+	// ${LOCAL_AGENT_HTTP_URL}/rolebindings so the mutation runs under the
+	// user's kubeconfig instead of the backend pod's ServiceAccount.
 	api.Get("/permissions/summary", rbac.GetPermissionsSummary)
 	api.Post("/rbac/can-i", rbac.CheckCanI)
 

--- a/web/src/components/namespaces/GrantAccessModal.tsx
+++ b/web/src/components/namespaces/GrantAccessModal.tsx
@@ -2,9 +2,19 @@ import { useState } from 'react'
 import { Shield, Loader2 } from 'lucide-react'
 import { Button } from '../ui/Button'
 import { BaseModal, ConfirmDialog } from '../../lib/modals'
-import { api } from '../../lib/api'
 import { useTranslation } from 'react-i18next'
+import { LOCAL_AGENT_HTTP_URL, STORAGE_KEY_TOKEN } from '../../lib/constants'
+import { FETCH_DEFAULT_TIMEOUT_MS } from '../../lib/constants/network'
 import type { NamespaceDetails, NamespaceAccessEntry } from './types'
+
+// Bearer token header builder for local-agent requests. Mirrors the
+// per-file helpers in useWorkloads.ts and useUsers.ts. See #7993 Phase 1.5.
+function agentAuthHeaders(): Record<string, string> {
+  const token = localStorage.getItem(STORAGE_KEY_TOKEN)
+  const headers: Record<string, string> = {}
+  if (token) headers['Authorization'] = `Bearer ${token}`
+  return headers
+}
 
 const COMMON_SUBJECTS = {
   User: [
@@ -67,13 +77,31 @@ export function GrantAccessModal({ namespace, existingAccess, onClose, onGranted
     setError(null)
 
     try {
-      await api.post(`/api/namespaces/${encodeURIComponent(namespace.name)}/access`, {
-        cluster: namespace.cluster,
-        subjectKind,
-        subjectName,
-        subjectNamespace: subjectKind === 'ServiceAccount' ? subjectNS : undefined,
-        role,
+      // Granting namespace access creates a RoleBinding on a managed cluster,
+      // so it must run under the user's kubeconfig via kc-agent, not the
+      // backend pod ServiceAccount. See #7993 Phase 1.5 PR A. The backend
+      // POST /api/namespaces/:name/access route still exists and will be
+      // removed as part of Phase 2 once all frontend callers are migrated —
+      // this switches the only caller over. The agent's /rolebindings POST
+      // handler accepts this shape directly and normalizes it into a full
+      // CreateRoleBindingRequest before calling the shared pkg/k8s method.
+      const res = await fetch(`${LOCAL_AGENT_HTTP_URL}/rolebindings`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', ...agentAuthHeaders() },
+        body: JSON.stringify({
+          cluster: namespace.cluster,
+          namespace: namespace.name,
+          subjectKind,
+          subjectName,
+          subjectNamespace: subjectKind === 'ServiceAccount' ? subjectNS : undefined,
+          role,
+        }),
+        signal: AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS),
       })
+      if (!res.ok) {
+        const errorData = await res.json().catch(() => ({ error: 'Failed to grant access' }))
+        throw new Error(errorData.error || 'Failed to grant access')
+      }
       onGranted()
     } catch (err: unknown) {
       const errorMessage = err instanceof Error ? err.message : 'Failed to grant access'

--- a/web/src/components/namespaces/NamespaceManager.tsx
+++ b/web/src/components/namespaces/NamespaceManager.tsx
@@ -27,8 +27,17 @@ import { RotatingTip } from '../ui/RotatingTip'
 import { api } from '../../lib/api'
 import { useToast } from '../ui/Toast'
 import { useTranslation } from 'react-i18next'
-import { LOCAL_AGENT_HTTP_URL } from '../../lib/constants'
-import { NAMESPACE_ABORT_TIMEOUT_MS } from '../../lib/constants/network'
+import { LOCAL_AGENT_HTTP_URL, STORAGE_KEY_TOKEN } from '../../lib/constants'
+import { FETCH_DEFAULT_TIMEOUT_MS, NAMESPACE_ABORT_TIMEOUT_MS } from '../../lib/constants/network'
+
+// Bearer token header builder for local-agent requests. Mirrors the
+// per-file helpers in useWorkloads.ts and useUsers.ts. See #7993 Phase 1.5.
+function agentAuthHeaders(): Record<string, string> {
+  const token = localStorage.getItem(STORAGE_KEY_TOKEN)
+  const headers: Record<string, string> = {}
+  if (token) headers['Authorization'] = `Bearer ${token}`
+  return headers
+}
 import { NamespaceCard, NamespaceCardSkeleton } from './NamespaceCard'
 import { DeleteConfirmModal } from './DeleteConfirmModal'
 import { CreateNamespaceModal } from './CreateNamespaceModal'
@@ -326,7 +335,26 @@ export function NamespaceManager() {
     }
 
     try {
-      await api.delete(`/api/namespaces/${encodeURIComponent(selectedNamespace.name)}/access/${encodeURIComponent(binding.bindingName)}?cluster=${encodeURIComponent(selectedNamespace.cluster)}`)
+      // Revoking namespace access deletes a RoleBinding on a managed cluster,
+      // so it must run under the user's kubeconfig via kc-agent, not the
+      // backend pod ServiceAccount. See #7993 Phase 1.5 PR A. The backend
+      // DELETE /api/namespaces/:name/access/:binding route still exists and
+      // will be removed as part of Phase 2 once all frontend callers are
+      // migrated — this switches the only caller over.
+      const params = new URLSearchParams({
+        cluster: selectedNamespace.cluster,
+        namespace: selectedNamespace.name,
+        name: binding.bindingName,
+      })
+      const res = await fetch(`${LOCAL_AGENT_HTTP_URL}/rolebindings?${params}`, {
+        method: 'DELETE',
+        headers: agentAuthHeaders(),
+        signal: AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS),
+      })
+      if (!res.ok) {
+        const errorData = await res.json().catch(() => ({ error: 'unknown error' }))
+        throw new Error(errorData.error || 'Failed to revoke access')
+      }
       fetchAccess(selectedNamespace)
     } catch (err) {
       console.error('Failed to revoke access:', err)

--- a/web/src/hooks/__tests__/useUsers.test.ts
+++ b/web/src/hooks/__tests__/useUsers.test.ts
@@ -654,10 +654,19 @@ describe('useK8sServiceAccounts', () => {
     )
   })
 
-  it('createServiceAccount calls POST and appends to local state', async () => {
+  it('createServiceAccount POSTs to kc-agent and appends to local state', async () => {
+    // #7993 Phase 1.5 PR A: createServiceAccount routes through kc-agent
+    // (POST ${LOCAL_AGENT_HTTP_URL}/serviceaccounts) so the mutation runs
+    // under the user's kubeconfig, not the backend pod SA. The old
+    // api.post('/api/rbac/service-accounts', ...) call is gone.
     mockGet.mockResolvedValue({ data: [] })
     const newSA = { name: 'new-sa', namespace: 'default', cluster: 'prod' }
-    mockPost.mockResolvedValue({ data: newSA })
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(JSON.stringify(newSA), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      })
+    )
 
     const { useK8sServiceAccounts } = await getHooks()
     const { result } = renderHook(() => useK8sServiceAccounts('prod'))
@@ -673,11 +682,9 @@ describe('useK8sServiceAccounts', () => {
       expect(created).toEqual(newSA)
     })
 
-    expect(mockPost).toHaveBeenCalledWith('/api/rbac/service-accounts', {
-      name: 'new-sa',
-      namespace: 'default',
-      cluster: 'prod',
-    })
+    expect(fetchSpy).toHaveBeenCalled()
+    const callUrl = fetchSpy.mock.calls[0]?.[0] as string
+    expect(callUrl).toContain('/serviceaccounts')
     expect(result.current.serviceAccounts).toHaveLength(1)
     expect(result.current.serviceAccounts[0].name).toBe('new-sa')
   })
@@ -924,7 +931,10 @@ describe('useK8sRoleBindings', () => {
     expect(result.current.bindings).toEqual([])
   })
 
-  it('createRoleBinding calls POST and refetches', async () => {
+  it('createRoleBinding POSTs to kc-agent and refetches', async () => {
+    // #7993 Phase 1.5 PR A: createRoleBinding routes through kc-agent
+    // (POST ${LOCAL_AGENT_HTTP_URL}/rolebindings) so the mutation runs under
+    // the user's kubeconfig, not the backend pod SA.
     const initialBindings = [
       {
         name: 'existing',
@@ -950,7 +960,12 @@ describe('useK8sRoleBindings', () => {
           },
         ],
       })
-    mockPost.mockResolvedValue({ data: {} })
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(JSON.stringify({ success: true }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      })
+    )
 
     const { useK8sRoleBindings } = await getHooks()
     const { result } = renderHook(() => useK8sRoleBindings('prod'))
@@ -971,13 +986,9 @@ describe('useK8sRoleBindings', () => {
       expect(ok).toBe(true)
     })
 
-    expect(mockPost).toHaveBeenCalledWith(
-      '/api/rbac/bindings',
-      expect.objectContaining({
-        name: 'new-binding',
-        cluster: 'prod',
-      }),
-    )
+    expect(fetchSpy).toHaveBeenCalled()
+    const callUrl = fetchSpy.mock.calls[0]?.[0] as string
+    expect(callUrl).toContain('/rolebindings')
 
     await waitFor(() => expect(result.current.bindings).toHaveLength(2))
   })
@@ -1313,9 +1324,15 @@ describe('useK8sRoleBindings — additional coverage', () => {
     expect(mockGet).not.toHaveBeenCalled()
   })
 
-  it('createRoleBinding calls POST and refetches bindings', async () => {
+  it('createRoleBinding POSTs to kc-agent and refetches bindings', async () => {
+    // #7993 Phase 1.5 PR A: createRoleBinding routes through kc-agent.
     mockGet.mockResolvedValue({ data: [] })
-    mockPost.mockResolvedValue({ data: {} })
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(JSON.stringify({ success: true }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      })
+    )
 
     const { useK8sRoleBindings } = await getHooks()
     const { result } = renderHook(() => useK8sRoleBindings('prod'))
@@ -1334,10 +1351,16 @@ describe('useK8sRoleBindings — additional coverage', () => {
       expect(ok).toBe(true)
     })
 
-    expect(mockPost).toHaveBeenCalledWith('/api/rbac/bindings', expect.objectContaining({
+    expect(fetchSpy).toHaveBeenCalled()
+    const callUrl = fetchSpy.mock.calls[0]?.[0] as string
+    expect(callUrl).toContain('/rolebindings')
+    // Verify the body was POSTed as JSON with the original fields preserved.
+    const callInit = fetchSpy.mock.calls[0]?.[1] as RequestInit | undefined
+    expect(callInit?.method).toBe('POST')
+    expect(JSON.parse(String(callInit?.body))).toMatchObject({
       name: 'test-binding',
       roleName: 'edit',
-    }))
+    })
   })
 
   it('silently fails on API error', async () => {

--- a/web/src/hooks/useUsers.ts
+++ b/web/src/hooks/useUsers.ts
@@ -2,6 +2,8 @@ import { useState, useEffect, useCallback } from 'react'
 import { api } from '../lib/api'
 import { mapSettledWithConcurrency } from '../lib/utils/concurrency'
 import { getDemoMode } from './useDemoMode'
+import { LOCAL_AGENT_HTTP_URL, STORAGE_KEY_TOKEN } from '../lib/constants'
+import { FETCH_DEFAULT_TIMEOUT_MS } from '../lib/constants/network'
 import type {
   ConsoleUser,
   K8sServiceAccount,
@@ -14,6 +16,18 @@ import type {
   UserRole,
   CreateServiceAccountRequest,
   CreateRoleBindingRequest } from '../types/users'
+
+// agentAuthHeaders attaches the local-agent Bearer token when one is stored.
+// The token is optional — the agent accepts unauthenticated requests from
+// allowed origins when KC_AGENT_TOKEN is unset — so we simply omit the
+// Authorization header when no token is configured. Mirrors authHeaders() in
+// useWorkloads.ts.
+function agentAuthHeaders(): Record<string, string> {
+  const token = localStorage.getItem(STORAGE_KEY_TOKEN)
+  const headers: Record<string, string> = {}
+  if (token) headers['Authorization'] = `Bearer ${token}`
+  return headers
+}
 
 // Demo data for console users
 function getDemoConsoleUsers(): ConsoleUser[] {
@@ -477,7 +491,20 @@ export function useK8sServiceAccounts(cluster?: string, namespace?: string) {
   }, [fetchServiceAccounts])
 
   const createServiceAccount = async (req: CreateServiceAccountRequest) => {
-    const { data } = await api.post<K8sServiceAccount>('/api/rbac/service-accounts', req)
+    // Creating a ServiceAccount is a user-initiated mutation on a managed
+    // cluster, so it must run under the user's kubeconfig via kc-agent, not
+    // the backend pod ServiceAccount. See #7993 Phase 1.5 PR A.
+    const res = await fetch(`${LOCAL_AGENT_HTTP_URL}/serviceaccounts`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', ...agentAuthHeaders() },
+      body: JSON.stringify(req),
+      signal: AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS),
+    })
+    if (!res.ok) {
+      const errorData = await res.json().catch(() => ({ error: 'unknown error' }))
+      throw new Error(errorData.error || 'Failed to create service account')
+    }
+    const data = (await res.json()) as K8sServiceAccount
     setServiceAccounts((prev) => [...prev, data])
     return data
   }
@@ -627,7 +654,19 @@ export function useK8sRoleBindings(cluster: string, namespace?: string, includeS
   }, [fetchBindings])
 
   const createRoleBinding = async (req: CreateRoleBindingRequest) => {
-    await api.post('/api/rbac/bindings', req)
+    // Creating a RoleBinding is a user-initiated RBAC mutation, so it must
+    // run under the user's kubeconfig via kc-agent, not the backend pod
+    // ServiceAccount. See #7993 Phase 1.5 PR A.
+    const res = await fetch(`${LOCAL_AGENT_HTTP_URL}/rolebindings`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', ...agentAuthHeaders() },
+      body: JSON.stringify(req),
+      signal: AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS),
+    })
+    if (!res.ok) {
+      const errorData = await res.json().catch(() => ({ error: 'unknown error' }))
+      throw new Error(errorData.error || 'Failed to create role binding')
+    }
     await fetchBindings()
     return true
   }


### PR DESCRIPTION
## Summary

Phase 1.5 PR A of the pod-SA -> kc-agent refactor. User-initiated RBAC mutations must run under the user's kubeconfig via kc-agent, not the backend pod ServiceAccount.

- `pkg/agent/server_http.go`: `handleServiceAccountsHTTP` and `handleRoleBindingsHTTP` now dispatch on HTTP method. GET preserves existing list behavior; POST creates a SA or RoleBinding; DELETE removes one. Both call the existing shared `*MultiClusterClient` methods in `pkg/k8s/rbac.go` -- no duplication.
- `web/src/hooks/useUsers.ts`: `createServiceAccount` and `createRoleBinding` now POST to `${LOCAL_AGENT_HTTP_URL}/serviceaccounts` and `${LOCAL_AGENT_HTTP_URL}/rolebindings`.
- `web/src/components/namespaces/GrantAccessModal.tsx`: `handleGrant` now POSTs to `${LOCAL_AGENT_HTTP_URL}/rolebindings` with the namespace-access shape. Agent normalizes this into a full `CreateRoleBindingRequest` before delegating to `pkg/k8s`.
- `web/src/components/namespaces/NamespaceManager.tsx`: `handleRevokeAccess` now DELETEs to `${LOCAL_AGENT_HTTP_URL}/rolebindings` with `cluster/namespace/name` query parameters.
- `pkg/api/handlers/rbac.go`: removed `CreateServiceAccount` and `CreateRoleBinding` backend handlers (and the now-unused `rbacWriteTimeout` constant).
- `pkg/api/server.go`: removed `POST /api/rbac/service-accounts` and `POST /api/rbac/bindings` route registrations.
- `pkg/api/auth_sweep_test.go`: dropped the two removed mutate entries from the auth sweep list.

The shared `pkg/k8s/rbac.go` methods (`CreateServiceAccount`, `CreateRoleBinding`, `DeleteServiceAccount`, `DeleteRoleBinding`) stay untouched -- kc-agent uses them. The backend `GrantNamespaceAccess` / `RevokeNamespaceAccess` Fiber handlers stay for now and will be removed as part of Phase 2 (namespaces split) once this frontend migration stabilizes.

No functional change for users.

Refs #7993.

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./pkg/api/...` passes (ignoring the pre-existing `TestRefreshToken`, `TestRecordFocus_BadBody_Returns400`, `TestClusterGroupsCRUD`, and dashboard-mock failures that exist on `main`)
- [x] `go test ./pkg/agent/...` passes
- [x] `npm run build` passes (post-build safety checks all green)
- [x] `npx vitest run src/hooks/__tests__/useUsers.test.ts` -- 75 passed
- [x] `npx vitest related run useUsers.ts NamespaceManager.tsx GrantAccessModal.tsx` -- 616 passed across 51 test files