### PR TITLE
🐛 fix: 5 UI feedback reports from @aashu2006 (#8011 #8012 #8014 #8017 #8018)

### DIFF
--- a/web/src/components/cards/ActiveAlerts.tsx
+++ b/web/src/components/cards/ActiveAlerts.tsx
@@ -58,18 +58,29 @@ type SortField = 'severity' | 'time'
 
 export function ActiveAlerts() {
   const { t } = useTranslation('cards')
-  const { activeAlerts, acknowledgedAlerts, stats, acknowledgeAlert, runAIDiagnosis } = useAlerts()
+  const {
+    activeAlerts,
+    acknowledgedAlerts,
+    stats,
+    acknowledgeAlert,
+    runAIDiagnosis,
+    isLoadingData,
+    dataError,
+  } = useAlerts()
   const { selectedSeverities, isAllSeveritiesSelected, customFilter } = useGlobalFilters()
   const { isDemoMode } = useDemoMode()
 
-  // Report state to CardWrapper for refresh animation and demo badge
+  // Report real fetch state so CardWrapper shows the refresh spinner on reload (#8011)
+  // and the error badge when the underlying MCP data bridge fails (#8014).
+  const hasAnyData = activeAlerts.length > 0 || acknowledgedAlerts.length > 0
   useCardLoadingState({
-    isLoading: false,
-    isRefreshing: false,
-    hasAnyData: activeAlerts.length > 0 || acknowledgedAlerts.length > 0,
+    isLoading: isLoadingData && !hasAnyData,
+    isRefreshing: isLoadingData && hasAnyData,
+    hasAnyData,
     isDemoData: isDemoMode,
-    isFailed: false,
-    consecutiveFailures: 0,
+    isFailed: Boolean(dataError),
+    consecutiveFailures: dataError ? 1 : 0,
+    errorMessage: dataError ?? undefined,
   })
   const { drillToAlert } = useDrillDownActions()
   const { missions, setActiveMission, openSidebar } = useMissions()

--- a/web/src/components/cards/OpenCostOverview.tsx
+++ b/web/src/components/cards/OpenCostOverview.tsx
@@ -44,7 +44,9 @@ const DEMO_NAMESPACE_COSTS: NamespaceCost[] = [
 function OpenCostOverviewInternal({ config: _config }: OpenCostOverviewProps) {
   const { t } = useTranslation('common')
   const { drillToCost } = useDrillDownActions()
-  useReportCardDataState({ hasData: true, isFailed: false, consecutiveFailures: 0, isDemoData: false })
+  // No live OpenCost integration yet — the card always renders DEMO_NAMESPACE_COSTS,
+  // so flag it as demo data to get the yellow outline + Demo badge (#8012).
+  useReportCardDataState({ hasData: true, isFailed: false, consecutiveFailures: 0, isDemoData: true })
 
   const {
     items: filteredCosts,

--- a/web/src/components/missions/MissionLandingPage.tsx
+++ b/web/src/components/missions/MissionLandingPage.tsx
@@ -191,7 +191,7 @@ function DashboardMockup() {
   return (
     <div className="absolute inset-0 overflow-hidden opacity-30 blur-[2px]">
       {/* Sidebar */}
-      <div className="absolute left-0 top-0 bottom-0 w-[52px] bg-[#0f1218] border-r border-white/5">
+      <div className="absolute left-0 top-0 bottom-0 w-[52px] bg-card border-r border-white/5">
         {/* Logo area */}
         <div className="h-12 flex items-center justify-center border-b border-white/5">
           <div className="w-6 h-6 rounded bg-purple-500/30" />
@@ -217,7 +217,7 @@ function DashboardMockup() {
         {/* Card grid */}
         <div className="grid grid-cols-3 gap-3">
           {/* Large card */}
-          <div className="col-span-2 h-48 rounded-xl bg-[#111318] border border-white/5 p-4">
+          <div className="col-span-2 h-48 rounded-xl bg-card border border-white/5 p-4">
             <div className="w-24 h-3 rounded bg-white/8 mb-3" />
             <div className="grid grid-cols-4 gap-2 h-32">
               {Array.from({ length: 4 }).map((_, i) => (
@@ -229,7 +229,7 @@ function DashboardMockup() {
             </div>
           </div>
           {/* Tall card */}
-          <div className="row-span-2 rounded-xl bg-[#111318] border border-white/5 p-4">
+          <div className="row-span-2 rounded-xl bg-card border border-white/5 p-4">
             <div className="w-20 h-3 rounded bg-white/8 mb-3" />
             {Array.from({ length: 6 }).map((_, i) => (
               <div key={i} className="flex items-center gap-2 mb-2">
@@ -239,11 +239,11 @@ function DashboardMockup() {
             ))}
           </div>
           {/* Bottom row cards */}
-          <div className="h-40 rounded-xl bg-[#111318] border border-white/5 p-4">
+          <div className="h-40 rounded-xl bg-card border border-white/5 p-4">
             <div className="w-16 h-3 rounded bg-white/8 mb-3" />
             <div className="h-24 rounded bg-gradient-to-t from-blue-500/5 to-transparent" />
           </div>
-          <div className="h-40 rounded-xl bg-[#111318] border border-white/5 p-4">
+          <div className="h-40 rounded-xl bg-card border border-white/5 p-4">
             <div className="w-20 h-3 rounded bg-white/8 mb-3" />
             <div className="flex gap-1 h-24 items-end">
               {Array.from({ length: 12 }).map((_, i) => (
@@ -259,7 +259,7 @@ function DashboardMockup() {
       </div>
 
       {/* Dim overlay to darken the mockup */}
-      <div className="absolute inset-0 bg-[#0a0a0a]/40" />
+      <div className="absolute inset-0 bg-background/40" />
     </div>
   )
 }
@@ -339,12 +339,12 @@ export function MissionLandingPage() {
     : EMPTY_TAB_HEIGHT_PX
 
   return (
-    <div className="min-h-screen bg-[#0a0a0a] relative overflow-hidden">
+    <div className="min-h-screen bg-background relative overflow-hidden">
       {/* Blurred dashboard mockup background — visual curiosity driver */}
       <DashboardMockup />
 
       {/* Header bar */}
-      <div className="relative z-10 flex items-center justify-between px-6 py-4 border-b border-white/5 bg-[#0a0a0a]/60 backdrop-blur-sm">
+      <div className="relative z-10 flex items-center justify-between px-6 py-4 border-b border-white/5 bg-background/60 backdrop-blur-sm">
         <div className="flex items-center gap-3">
           <svg className="w-7 h-7" viewBox="0 0 24 24" fill="none" stroke="#7c3aed" strokeWidth="1.5">
             <path d="M12 2L2 7l10 5 10-5-10-5zM2 17l10 5 10-5M2 12l10 5 10-5"/>
@@ -387,7 +387,7 @@ export function MissionLandingPage() {
         ) : mission ? (
           <div className="w-full max-w-2xl">
             {/* Mission card */}
-            <div className="bg-[#111318]/95 backdrop-blur-xl border border-white/10 rounded-2xl shadow-2xl shadow-black/50 overflow-hidden">
+            <div className="bg-card/95 backdrop-blur-xl border border-white/10 rounded-2xl shadow-2xl shadow-black/50 overflow-hidden">
               {/* Card header */}
               <div className="p-6 pb-4">
                 <div className="flex items-center gap-2 mb-3">

--- a/web/src/components/onboarding/Onboarding.tsx
+++ b/web/src/components/onboarding/Onboarding.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react'
 import { useNavigate } from 'react-router-dom'
+import { useTranslation } from 'react-i18next'
 import { ChevronRight, ChevronLeft, Check, GripVertical, ArrowUp, ArrowDown } from 'lucide-react'
 import { api } from '../../lib/api'
 import { useAuth } from '../../lib/auth'
@@ -14,6 +15,14 @@ interface Question {
   description?: string
   options: string[]
   rankedChoice?: boolean
+}
+
+// English option strings below are the stable IDs stored in `answers` and
+// posted to /api/onboarding/responses — they must NOT change. Display labels
+// are looked up in cards.json via slugOption() so translations can override
+// them without touching the stored value (#8017).
+function slugOption(option: string): string {
+  return option.toLowerCase().replace(/[^a-z0-9]+/g, '_').replace(/^_|_$/g, '')
 }
 
 const questions: Question[] = [
@@ -63,12 +72,23 @@ const questions: Question[] = [
 export function Onboarding() {
   const navigate = useNavigate()
   const { refreshUser } = useAuth()
+  const { t } = useTranslation('cards')
   const [currentStep, setCurrentStep] = useState(0)
   const [answers, setAnswers] = useState<Record<string, string | string[]>>({})
   const [isSubmitting, setIsSubmitting] = useState(false)
 
   const currentQuestion = questions[currentStep]
   const progress = ((currentStep + 1) / questions.length) * 100
+
+  // Translate a question option using slug-based keys with English fallback.
+  const tOption = (questionKey: string, option: string) =>
+    t(`onboarding.questions.${questionKey}.options.${slugOption(option)}`, { defaultValue: option })
+  const tQuestion = (q: Question) =>
+    t(`onboarding.questions.${q.key}.question`, { defaultValue: q.question })
+  const tDescription = (q: Question) =>
+    q.description
+      ? t(`onboarding.questions.${q.key}.description`, { defaultValue: q.description })
+      : undefined
 
   // Initialize ranked choice answers with default order
   const getRankedOrder = (): string[] => {
@@ -148,7 +168,7 @@ export function Onboarding() {
         navigate(ROUTES.HOME)
       } else {
         // Real user: show error message so they are not stranded
-        const message = err instanceof Error ? err.message : 'Failed to complete onboarding. Please try again.'
+        const message = err instanceof Error ? err.message : t('onboarding.errorFallback')
         setErrorMessage(message)
       }
     } finally {
@@ -160,7 +180,7 @@ export function Onboarding() {
   const canProceed = currentQuestion.rankedChoice || answers[currentQuestion.key]
 
   return (
-    <div className="min-h-screen bg-[#0a0a0a] flex items-center justify-center p-4">
+    <div className="min-h-screen bg-background flex items-center justify-center p-4">
       {/* Star field */}
       <div className="star-field">
         {Array.from({ length: 30 }).map((_, i) => (
@@ -187,7 +207,7 @@ export function Onboarding() {
         <div className="mb-8">
           <div className="flex items-center justify-between mb-2">
             <span className="text-sm text-muted-foreground">
-              Step {currentStep + 1} of {questions.length}
+              {t('onboarding.stepProgress', { current: currentStep + 1, total: questions.length })}
             </span>
             <span className="text-sm text-muted-foreground">{Math.round(progress)}%</span>
           </div>
@@ -201,9 +221,9 @@ export function Onboarding() {
 
         {/* Question card */}
         <div className="glass rounded-2xl p-8 animate-fade-in-up">
-          <h2 className="text-2xl font-bold text-foreground mb-2">{currentQuestion.question}</h2>
+          <h2 className="text-2xl font-bold text-foreground mb-2">{tQuestion(currentQuestion)}</h2>
           {currentQuestion.description && (
-            <div className="text-muted-foreground mb-6">{currentQuestion.description}</div>
+            <div className="text-muted-foreground mb-6">{tDescription(currentQuestion)}</div>
           )}
 
           {/* Options - Single select or Ranked Choice */}
@@ -220,7 +240,7 @@ export function Onboarding() {
                       {index + 1}
                     </span>
                   </div>
-                  <span className="flex-1 text-foreground">{option}</span>
+                  <span className="flex-1 text-foreground">{tOption(currentQuestion.key, option)}</span>
                   <div className="flex gap-1">
                     <Button
                       variant="ghost"
@@ -228,7 +248,7 @@ export function Onboarding() {
                       onClick={() => handleRankMove(index, 'up')}
                       disabled={index === 0}
                       icon={<ArrowUp className="w-4 h-4 text-muted-foreground" aria-hidden="true" />}
-                      aria-label={`Move ${option} up`}
+                      aria-label={t('onboarding.moveUp', { option: tOption(currentQuestion.key, option) })}
                     />
                     <Button
                       variant="ghost"
@@ -236,7 +256,7 @@ export function Onboarding() {
                       onClick={() => handleRankMove(index, 'down')}
                       disabled={index === getRankedOrder().length - 1}
                       icon={<ArrowDown className="w-4 h-4 text-muted-foreground" aria-hidden="true" />}
-                      aria-label={`Move ${option} down`}
+                      aria-label={t('onboarding.moveDown', { option: tOption(currentQuestion.key, option) })}
                     />
                   </div>
                 </div>
@@ -244,26 +264,29 @@ export function Onboarding() {
             </div>
           ) : (
             <div className="grid gap-3">
-              {currentQuestion.options.map((option) => (
-                <button
-                  key={option}
-                  onClick={() => handleSelect(option)}
-                  className={`w-full p-4 rounded-xl text-left transition-all duration-200 ${
-                    answers[currentQuestion.key] === option
-                      ? 'bg-purple-500/20 border-2 border-purple-500 text-foreground'
-                      : 'bg-secondary/50 border-2 border-transparent hover:bg-secondary hover:border-purple-500/30 text-muted-foreground'
-                  }`}
-                  aria-label={`Select ${option}`}
-                  aria-pressed={answers[currentQuestion.key] === option}
-                >
-                  <div className="flex items-center justify-between">
-                    <span>{option}</span>
-                    {answers[currentQuestion.key] === option && (
-                      <Check className="w-5 h-5 text-purple-400" />
-                    )}
-                  </div>
-                </button>
-              ))}
+              {currentQuestion.options.map((option) => {
+                const label = tOption(currentQuestion.key, option)
+                return (
+                  <button
+                    key={option}
+                    onClick={() => handleSelect(option)}
+                    className={`w-full p-4 rounded-xl text-left transition-all duration-200 ${
+                      answers[currentQuestion.key] === option
+                        ? 'bg-purple-500/20 border-2 border-purple-500 text-foreground'
+                        : 'bg-secondary/50 border-2 border-transparent hover:bg-secondary hover:border-purple-500/30 text-muted-foreground'
+                    }`}
+                    aria-label={t('onboarding.selectOption', { option: label })}
+                    aria-pressed={answers[currentQuestion.key] === option}
+                  >
+                    <div className="flex items-center justify-between">
+                      <span>{label}</span>
+                      {answers[currentQuestion.key] === option && (
+                        <Check className="w-5 h-5 text-purple-400" />
+                      )}
+                    </div>
+                  </button>
+                )
+              })}
             </div>
           )}
 
@@ -283,7 +306,7 @@ export function Onboarding() {
               disabled={currentStep === 0}
               icon={<ChevronLeft className="w-4 h-4" />}
             >
-              Back
+              {t('onboarding.back')}
             </Button>
 
             {isLastStep ? (
@@ -295,7 +318,7 @@ export function Onboarding() {
                 loading={isSubmitting}
                 iconRight={!isSubmitting ? <Check className="w-4 h-4" /> : undefined}
               >
-                {isSubmitting ? 'Creating dashboard...' : 'Complete Setup'}
+                {isSubmitting ? t('onboarding.creating') : t('onboarding.complete')}
               </Button>
             ) : (
               <Button
@@ -305,7 +328,7 @@ export function Onboarding() {
                 disabled={!canProceed}
                 iconRight={<ChevronRight className="w-4 h-4" />}
               >
-                Continue
+                {t('onboarding.continue')}
               </Button>
             )}
           </div>

--- a/web/src/locales/en/cards.json
+++ b/web/src/locales/en/cards.json
@@ -3392,5 +3392,86 @@
     "prs": "PRs",
     "refresh": "Refresh",
     "showingDemo": "showing demo data"
+  },
+  "onboarding": {
+    "stepProgress": "Step {{current}} of {{total}}",
+    "back": "Back",
+    "continue": "Continue",
+    "complete": "Complete Setup",
+    "creating": "Creating dashboard...",
+    "errorFallback": "Failed to complete onboarding. Please try again.",
+    "moveUp": "Move {{option}} up",
+    "moveDown": "Move {{option}} down",
+    "selectOption": "Select {{option}}",
+    "questions": {
+      "role": {
+        "question": "What's your primary role?",
+        "description": "This helps us customize your dashboard",
+        "options": {
+          "sre": "SRE",
+          "devops": "DevOps",
+          "platform_engineer": "Platform Engineer",
+          "developer": "Developer",
+          "dba": "DBA",
+          "network_engineer": "Network Engineer"
+        }
+      },
+      "focus_layer": {
+        "question": "Which layer do you focus on most?",
+        "description": "We'll prioritize relevant information",
+        "options": {
+          "infrastructure_nodes_storage": "Infrastructure (nodes, storage)",
+          "platform_k8s_operators": "Platform (K8s, operators)",
+          "application": "Application",
+          "database": "Database",
+          "network": "Network"
+        }
+      },
+      "cluster_count": {
+        "question": "How many clusters do you typically manage?",
+        "options": {
+          "1_3": "1-3",
+          "4_10": "4-10",
+          "10_50": "10-50",
+          "50": "50+"
+        }
+      },
+      "daily_challenges": {
+        "question": "Rank your daily challenges by priority",
+        "description": "Drag to reorder - most important at top",
+        "options": {
+          "troubleshooting_issues": "Troubleshooting issues",
+          "deployments": "Deployments",
+          "capacity_planning": "Capacity planning",
+          "security_compliance": "Security/compliance",
+          "upgrades": "Upgrades"
+        }
+      },
+      "gitops": {
+        "question": "Do you use GitOps?",
+        "options": {
+          "yes_heavily": "Yes, heavily",
+          "sometimes": "Sometimes",
+          "no": "No"
+        }
+      },
+      "monitoring_priorities": {
+        "question": "Rank what monitoring matters most",
+        "description": "Drag to reorder - most important at top",
+        "options": {
+          "availability": "Availability",
+          "performance": "Performance",
+          "cost": "Cost",
+          "security": "Security"
+        }
+      },
+      "gpu_workloads": {
+        "question": "Do you manage GPU workloads?",
+        "options": {
+          "yes": "Yes",
+          "no": "No"
+        }
+      }
+    }
   }
 }


### PR DESCRIPTION
## Summary

Five UI feedback reports from @aashu2006 (submitted via the in-app "Submit feedback" flow), bundled.

### #8011 + #8014 — ActiveAlerts hardcoded its loading/failure state

`ActiveAlerts.tsx` called `useCardLoadingState({ isLoading: false, isRefreshing: false, isFailed: false, consecutiveFailures: 0 })` with every field pinned to `false`/`0`, even though `useAlerts()` already returns `isLoadingData` and `dataError` from the MCP data bridge. Result:

- No refresh-spinner feedback when data is being fetched (#8011)
- No failure badge even when the MCP bridge times out or errors (#8014)

Fix: destructure `isLoadingData` and `dataError` from the hook and wire them through. `isLoading` fires when there's no cached data yet, `isRefreshing` fires on subsequent loads when there's already data on screen, and `isFailed`/`errorMessage` map from `dataError`.

### #8012 — OpenCostOverview silently pretended demo data was live

`OpenCostOverview.tsx` always renders `DEMO_NAMESPACE_COSTS` (the card has no live OpenCost integration wired up yet), but called `useReportCardDataState({ isDemoData: false })`. So users saw a realistic-looking `$3680 / production` row with no Demo badge and no yellow outline, and had no way to tell the card wasn't reporting their real cluster spend.

One-line fix: flip to `isDemoData: true`. When the live OpenCost endpoint is eventually wired up this flag should be driven by whether the fetch succeeded, same pattern as the other cards.

### #8017 — Onboarding.tsx didn't run user-facing text through `t()`

The entire onboarding flow — 7 questions, their descriptions, ~30 option labels, progress label (`Step X of Y`), nav buttons (Back/Continue/Complete Setup/Creating dashboard…), and every `aria-label` — was hardcoded English. Switching languages had no effect on the first-run experience.

Fix: added an `onboarding.*` block to `locales/en/cards.json` and wired `useTranslation('cards')` through the component. All strings now use `t()` with `defaultValue: englishString` as the fallback, so unmatched keys in other locales fall through to English cleanly.

**Backend compatibility preserved**: the `options: string[]` arrays stay English — they're the stable IDs posted to `/api/onboarding/responses`. Only the display labels route through `t()` via a `slugOption()` helper that maps e.g. `"Platform Engineer"` → `onboarding.questions.role.options.platform_engineer`. `answers` payloads are byte-identical to before.

### #8018 — Hardcoded dark hex colors didn't respect theme

Found 9 hex-color Tailwind arbitrary values in `Onboarding.tsx` and `MissionLandingPage.tsx` (`bg-[#0a0a0a]`, `bg-[#0f1218]`, `bg-[#111318]` plus opacity variants). In light mode these stayed pitch-black. Replaced with semantic classes (`bg-background`, `bg-card`) that read from the CSS variable theme system per `CLAUDE.md` styling rules.

**Out of scope**: `MissionLandingPage.tsx` also has a large number of `text-white/N` and `border-white/N` uses that don't adapt cleanly to light themes. Those are aesthetically subtle enough to ship as-is — a follow-up can convert them to `text-foreground/N` / `border-border/N` if it becomes a real complaint.

### Closed as not reproducible (separate)

- **#8015** (lists behave inconsistently) — spot-checked the dynamic list components; all use proper React `key={}`. Closed with a request for a concrete repro.
- **#8016** (perf degrades over time in dev mode) — audited `setInterval` call sites; all clean up properly. Closed with a request for a Performance recording.

## Fixes

- Fixes #8011
- Fixes #8012
- Fixes #8014
- Fixes #8017
- Fixes #8018

## Test plan

- [ ] CI Go + TS build green
- [ ] CI lint green
- [ ] Manual: open Active Alerts card with AlertsProvider stuck in loading → refresh icon spinning (not frozen)
- [ ] Manual: force `dataError` in AlertsContext → error indicator visible
- [ ] Manual: open Cost Overview card → yellow Demo badge + outline visible
- [ ] Manual: switch theme to light → Onboarding and Mission landing pages use the light background (not black)
- [ ] Manual: switch language → Onboarding strings change (currently all locales fall back to English, so this is a no-op — verified structure is ready for future translations)