### PR TITLE
refactor(phase2): split namespaces.go — migrate general create/delete, keep GPU reservation (#7993)

### DIFF
--- a/pkg/agent/server_http.go
+++ b/pkg/agent/server_http.go
@@ -267,7 +267,15 @@ func (s *Server) handleEventsHTTP(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w,map[string]interface{}{"events": events, "source": "agent"})
 }
 
-// handleNamespacesHTTP returns namespaces for a cluster
+// handleNamespacesHTTP serves namespace operations for a cluster. GET lists
+// namespaces (existing behavior). POST creates a namespace and DELETE removes
+// one — both are user-initiated mutations that run under the user's kubeconfig
+// via kc-agent instead of the backend's pod ServiceAccount (#7993 Phase 2).
+//
+// The GPU-reservation namespace-create path is NOT served here — it stays on
+// the backend at `/mcp/resourcequotas` with `ensure_namespace: true` (see
+// pkg/api/handlers/mcp_resources.go#CreateOrUpdateResourceQuota) because the
+// reservation operator owns quota semantics and needs pod-SA access.
 func (s *Server) handleNamespacesHTTP(w http.ResponseWriter, r *http.Request) {
 	s.setCORSHeaders(w, r)
 	w.Header().Set("Content-Type", "application/json")
@@ -284,13 +292,23 @@ func (s *Server) handleNamespacesHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if s.k8sClient == nil {
-		writeJSON(w,map[string]interface{}{"namespaces": []interface{}{}, "error": "k8s client not initialized"})
+		writeJSON(w, map[string]interface{}{"namespaces": []interface{}{}, "error": "k8s client not initialized"})
 		return
 	}
 
+	switch r.Method {
+	case http.MethodPost:
+		s.createNamespaceHTTP(w, r)
+		return
+	case http.MethodDelete:
+		s.deleteNamespaceHTTP(w, r)
+		return
+	}
+
+	// Default: GET list.
 	cluster := r.URL.Query().Get("cluster")
 	if cluster == "" {
-		writeJSON(w,map[string]interface{}{"namespaces": []interface{}{}, "error": "cluster parameter required"})
+		writeJSON(w, map[string]interface{}{"namespaces": []interface{}{}, "error": "cluster parameter required"})
 		return
 	}
 
@@ -304,7 +322,70 @@ func (s *Server) handleNamespacesHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	writeJSON(w,map[string]interface{}{"namespaces": namespaces, "source": "agent"})
+	writeJSON(w, map[string]interface{}{"namespaces": namespaces, "source": "agent"})
+}
+
+// createNamespaceHTTP handles POST /namespaces. Body shape matches the legacy
+// backend NamespaceHandler.CreateNamespace request so the frontend can migrate
+// with a pure URL swap.
+func (s *Server) createNamespaceHTTP(w http.ResponseWriter, r *http.Request) {
+	var req struct {
+		Cluster string            `json:"cluster"`
+		Name    string            `json:"name"`
+		Labels  map[string]string `json:"labels,omitempty"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		w.WriteHeader(http.StatusBadRequest)
+		writeJSON(w, map[string]interface{}{"success": false, "error": "invalid request body"})
+		return
+	}
+	if req.Cluster == "" {
+		w.WriteHeader(http.StatusBadRequest)
+		writeJSON(w, map[string]interface{}{"success": false, "error": "cluster is required"})
+		return
+	}
+	if req.Name == "" {
+		w.WriteHeader(http.StatusBadRequest)
+		writeJSON(w, map[string]interface{}{"success": false, "error": "name is required"})
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(r.Context(), agentExtendedTimeout)
+	defer cancel()
+
+	ns, err := s.k8sClient.CreateNamespace(ctx, req.Cluster, req.Name, req.Labels)
+	if err != nil {
+		slog.Warn("error creating namespace", "cluster", req.Cluster, "name", req.Name, "error", err)
+		w.WriteHeader(http.StatusInternalServerError)
+		writeJSON(w, map[string]interface{}{"success": false, "error": err.Error(), "source": "agent"})
+		return
+	}
+	writeJSON(w, map[string]interface{}{"success": true, "namespace": ns, "source": "agent"})
+}
+
+// deleteNamespaceHTTP handles DELETE /namespaces. Takes `cluster` and `name`
+// query parameters — kc-agent uses net/http mux so path params are not
+// available (matches the legacy `DELETE /api/namespaces/:name?cluster=<c>`
+// shape otherwise).
+func (s *Server) deleteNamespaceHTTP(w http.ResponseWriter, r *http.Request) {
+	cluster := r.URL.Query().Get("cluster")
+	name := r.URL.Query().Get("name")
+	if cluster == "" || name == "" {
+		w.WriteHeader(http.StatusBadRequest)
+		writeJSON(w, map[string]interface{}{"success": false, "error": "cluster and name query parameters are required"})
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(r.Context(), agentExtendedTimeout)
+	defer cancel()
+
+	if err := s.k8sClient.DeleteNamespace(ctx, cluster, name); err != nil {
+		slog.Warn("error deleting namespace", "cluster", cluster, "name", name, "error", err)
+		w.WriteHeader(http.StatusInternalServerError)
+		writeJSON(w, map[string]interface{}{"success": false, "error": err.Error(), "source": "agent"})
+		return
+	}
+	writeJSON(w, map[string]interface{}{"success": true, "cluster": cluster, "name": name, "source": "agent"})
 }
 
 // handleDeploymentsHTTP returns deployments for a cluster/namespace

--- a/pkg/api/auth_sweep_test.go
+++ b/pkg/api/auth_sweep_test.go
@@ -61,9 +61,10 @@ func TestProtectedRoutes_UnauthenticatedReturn401(t *testing.T) {
 		{"GET", "/api/rbac/bindings"},
 		{"GET", "/api/rbac/permissions"},
 		{"POST", "/api/rbac/can-i"},
-		// Namespace lifecycle
+		// Namespace lifecycle.
+		// NOTE: POST /api/namespaces and DELETE /api/namespaces/:name moved to
+		// kc-agent (#7993 Phase 2). Only the read endpoint remains here.
 		{"GET", "/api/namespaces"},
-		{"POST", "/api/namespaces"},
 		// Workloads
 		{"GET", "/api/workloads"},
 		{"GET", "/api/workloads/capabilities"},

--- a/pkg/api/handlers/namespaces.go
+++ b/pkg/api/handlers/namespaces.go
@@ -16,10 +16,12 @@ import (
 // nsDefaultTimeout is the per-cluster timeout for namespace queries.
 const nsDefaultTimeout = 15 * time.Second
 
-// nsWriteTimeout is the timeout for namespace write operations.
-const nsWriteTimeout = 15 * time.Second
-
-// NamespaceHandler handles namespace management operations
+// NamespaceHandler handles namespace read operations.
+//
+// Namespace and RoleBinding WRITE operations were removed in #7993 Phases 1.5
+// and 2 — they now run under the user's kubeconfig via kc-agent's
+// `/namespaces` and `/rolebindings` handlers instead of the backend's pod
+// ServiceAccount. See pkg/agent/server_http.go.
 type NamespaceHandler struct {
 	store     store.Store
 	k8sClient *k8s.MultiClusterClient
@@ -57,90 +59,6 @@ func (h *NamespaceHandler) ListNamespaces(c *fiber.Ctx) error {
 	}
 
 	return c.JSON(namespaces)
-}
-
-// CreateNamespace creates a new namespace
-func (h *NamespaceHandler) CreateNamespace(c *fiber.Ctx) error {
-	if h.k8sClient == nil {
-		return fiber.NewError(fiber.StatusServiceUnavailable, "Kubernetes client not available")
-	}
-
-	// Check if current user is console admin
-	currentUserID := middleware.GetUserID(c)
-	currentUser, err := h.store.GetUser(currentUserID)
-	if err != nil || currentUser == nil || currentUser.Role != models.UserRoleAdmin {
-		return fiber.NewError(fiber.StatusForbidden, "Console admin access required")
-	}
-
-	var req models.CreateNamespaceRequest
-	if err := c.BodyParser(&req); err != nil {
-		return fiber.NewError(fiber.StatusBadRequest, "Invalid request body")
-	}
-
-	// #6627: explicit field-level validation. Previously empty/oversized
-	// names could reach the apiserver and return an opaque 500.
-	if err := validateClusterName("cluster", req.Cluster); err != nil {
-		return fiber.NewError(fiber.StatusBadRequest, err.Error())
-	}
-	if err := validateDNSLabel("name", req.Name); err != nil {
-		return fiber.NewError(fiber.StatusBadRequest, err.Error())
-	}
-
-	ctx, cancel := context.WithTimeout(c.Context(), nsWriteTimeout)
-	defer cancel()
-
-	// Check if user has cluster-admin access on the target cluster
-	isAdmin, err := h.k8sClient.CheckClusterAdminAccess(ctx, req.Cluster)
-	if err != nil || !isAdmin {
-		return fiber.NewError(fiber.StatusForbidden, "Cluster admin access required on target cluster")
-	}
-
-	ns, err := h.k8sClient.CreateNamespace(ctx, req.Cluster, req.Name, req.Labels)
-	if err != nil {
-		slog.Error("[Namespaces] failed to create namespace", "error", err)
-		return fiber.NewError(fiber.StatusInternalServerError, "internal server error")
-	}
-
-	return c.JSON(fiber.Map{
-		"success":   true,
-		"namespace": ns,
-	})
-}
-
-// DeleteNamespace deletes a namespace
-func (h *NamespaceHandler) DeleteNamespace(c *fiber.Ctx) error {
-	if h.k8sClient == nil {
-		return fiber.NewError(fiber.StatusServiceUnavailable, "Kubernetes client not available")
-	}
-
-	// Check if current user is console admin
-	currentUserID := middleware.GetUserID(c)
-	currentUser, err := h.store.GetUser(currentUserID)
-	if err != nil || currentUser == nil || currentUser.Role != models.UserRoleAdmin {
-		return fiber.NewError(fiber.StatusForbidden, "Console admin access required")
-	}
-
-	cluster := c.Query("cluster")
-	name := c.Params("name")
-	if cluster == "" || name == "" {
-		return fiber.NewError(fiber.StatusBadRequest, "Cluster and namespace name are required")
-	}
-
-	ctx, cancel := context.WithTimeout(c.Context(), nsWriteTimeout)
-	defer cancel()
-
-	// Check if user has cluster-admin access on the target cluster
-	isAdmin, err := h.k8sClient.CheckClusterAdminAccess(ctx, cluster)
-	if err != nil || !isAdmin {
-		return fiber.NewError(fiber.StatusForbidden, "Cluster admin access required on target cluster")
-	}
-
-	if err := h.k8sClient.DeleteNamespace(ctx, cluster, name); err != nil {
-		slog.Error("[Namespaces] failed to delete namespace", "error", err)
-		return fiber.NewError(fiber.StatusInternalServerError, "internal server error")
-	}
-
-	return c.JSON(fiber.Map{"success": true})
 }
 
 // GetNamespaceAccess returns role bindings for a namespace.
@@ -199,129 +117,4 @@ func (h *NamespaceHandler) GetNamespaceAccess(c *fiber.Ctx) error {
 		"cluster":   cluster,
 		"bindings":  accessList,
 	})
-}
-
-// GrantNamespaceAccess grants access to a user/group/SA on a namespace
-func (h *NamespaceHandler) GrantNamespaceAccess(c *fiber.Ctx) error {
-	if h.k8sClient == nil {
-		return fiber.NewError(fiber.StatusServiceUnavailable, "Kubernetes client not available")
-	}
-
-	// Check if current user is console admin
-	currentUserID := middleware.GetUserID(c)
-	currentUser, err := h.store.GetUser(currentUserID)
-	if err != nil || currentUser == nil || currentUser.Role != models.UserRoleAdmin {
-		return fiber.NewError(fiber.StatusForbidden, "Console admin access required")
-	}
-
-	namespace := c.Params("name")
-	if namespace == "" {
-		return fiber.NewError(fiber.StatusBadRequest, "Namespace name required")
-	}
-
-	// Validate the namespace path parameter as a DNS label before doing any
-	// more work. #6627.
-	if err := validateDNSLabel("namespace", namespace); err != nil {
-		return fiber.NewError(fiber.StatusBadRequest, err.Error())
-	}
-
-	var req models.GrantNamespaceAccessRequest
-	if err := c.BodyParser(&req); err != nil {
-		return fiber.NewError(fiber.StatusBadRequest, "Invalid request body")
-	}
-
-	// #6627: explicit field-level validation replaces the previous
-	// non-empty-only check.
-	if err := validateClusterName("cluster", req.Cluster); err != nil {
-		return fiber.NewError(fiber.StatusBadRequest, err.Error())
-	}
-	if err := validateEnum("subjectKind", req.SubjectKind, []string{"User", "Group", "ServiceAccount"}); err != nil {
-		return fiber.NewError(fiber.StatusBadRequest, err.Error())
-	}
-	if req.SubjectKind == "ServiceAccount" {
-		if err := validateDNSLabel("subjectName", req.SubjectName); err != nil {
-			return fiber.NewError(fiber.StatusBadRequest, err.Error())
-		}
-		// #6675 Copilot followup: subjectNamespace is REQUIRED for
-		// ServiceAccount subjects per Kubernetes RBAC. Previously we
-		// only validated it when present.
-		if err := validateDNSLabel("subjectNamespace", req.SubjectNS); err != nil {
-			return fiber.NewError(fiber.StatusBadRequest, err.Error())
-		}
-	} else {
-		if req.SubjectName == "" {
-			return fiber.NewError(fiber.StatusBadRequest, "subjectName is required")
-		}
-		if len(req.SubjectName) > maxK8sDNSSubdomainLen {
-			return fiber.NewError(fiber.StatusBadRequest, "subjectName too long")
-		}
-	}
-
-	// Default to admin role if not specified
-	if req.Role == "" {
-		req.Role = "admin"
-	}
-	// Role may be a shortcut ("admin"/"edit"/"view") or a custom role name.
-	// Validate as a role name either way.
-	if err := validateRoleName("role", req.Role); err != nil {
-		return fiber.NewError(fiber.StatusBadRequest, err.Error())
-	}
-
-	ctx, cancel := context.WithTimeout(c.Context(), nsWriteTimeout)
-	defer cancel()
-
-	// Check if user has cluster-admin access on the target cluster
-	isAdmin, err := h.k8sClient.CheckClusterAdminAccess(ctx, req.Cluster)
-	if err != nil || !isAdmin {
-		return fiber.NewError(fiber.StatusForbidden, "Cluster admin access required on target cluster")
-	}
-
-	bindingName, err := h.k8sClient.GrantNamespaceAccess(ctx, req.Cluster, namespace, req)
-	if err != nil {
-		slog.Error("[Namespaces] failed to grant access", "error", err)
-		return fiber.NewError(fiber.StatusInternalServerError, "internal server error")
-	}
-
-	return c.JSON(fiber.Map{
-		"success":     true,
-		"roleBinding": bindingName,
-	})
-}
-
-// RevokeNamespaceAccess removes a role binding
-func (h *NamespaceHandler) RevokeNamespaceAccess(c *fiber.Ctx) error {
-	if h.k8sClient == nil {
-		return fiber.NewError(fiber.StatusServiceUnavailable, "Kubernetes client not available")
-	}
-
-	// Check if current user is console admin
-	currentUserID := middleware.GetUserID(c)
-	currentUser, err := h.store.GetUser(currentUserID)
-	if err != nil || currentUser == nil || currentUser.Role != models.UserRoleAdmin {
-		return fiber.NewError(fiber.StatusForbidden, "Console admin access required")
-	}
-
-	namespace := c.Params("name")
-	bindingName := c.Params("binding")
-	cluster := c.Query("cluster")
-
-	if cluster == "" || namespace == "" || bindingName == "" {
-		return fiber.NewError(fiber.StatusBadRequest, "Cluster, namespace, and binding name are required")
-	}
-
-	ctx, cancel := context.WithTimeout(c.Context(), nsWriteTimeout)
-	defer cancel()
-
-	// Check if user has cluster-admin access on the target cluster
-	isAdmin, err := h.k8sClient.CheckClusterAdminAccess(ctx, cluster)
-	if err != nil || !isAdmin {
-		return fiber.NewError(fiber.StatusForbidden, "Cluster admin access required on target cluster")
-	}
-
-	if err := h.k8sClient.DeleteRoleBinding(ctx, cluster, namespace, bindingName, false); err != nil {
-		slog.Error("[Namespaces] failed to revoke access", "error", err)
-		return fiber.NewError(fiber.StatusInternalServerError, "internal server error")
-	}
-
-	return c.JSON(fiber.Map{"success": true})
 }

--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -893,14 +893,13 @@ func (s *Server) setupRoutes() {
 	api.Get("/permissions/summary", rbac.GetPermissionsSummary)
 	api.Post("/rbac/can-i", rbac.CheckCanI)
 
-	// Namespace management routes (admin only)
+	// Namespace management routes (admin only).
+	// POST/DELETE /namespaces and POST/DELETE /namespaces/:name/access were
+	// migrated to kc-agent in #7993 Phases 1.5 and 2 — they now run under the
+	// user's kubeconfig instead of the backend pod ServiceAccount.
 	namespaces := handlers.NewNamespaceHandler(s.store, s.k8sClient)
 	api.Get("/namespaces", namespaces.ListNamespaces)
-	api.Post("/namespaces", namespaces.CreateNamespace)
-	api.Delete("/namespaces/:name", namespaces.DeleteNamespace)
 	api.Get("/namespaces/:name/access", namespaces.GetNamespaceAccess)
-	api.Post("/namespaces/:name/access", namespaces.GrantNamespaceAccess)
-	api.Delete("/namespaces/:name/access/:binding", namespaces.RevokeNamespaceAccess)
 
 	// Mission knowledge base routes (validate, share — protected)
 	missions.RegisterRoutes(api.Group("/missions"))

--- a/web/src/components/namespaces/CreateNamespaceModal.tsx
+++ b/web/src/components/namespaces/CreateNamespaceModal.tsx
@@ -2,8 +2,18 @@ import { useState } from 'react'
 import { Folder, UserPlus, Shield, X, Loader2 } from 'lucide-react'
 import { Button } from '../ui/Button'
 import { BaseModal, ConfirmDialog } from '../../lib/modals'
-import { api } from '../../lib/api'
 import { useTranslation } from 'react-i18next'
+import { LOCAL_AGENT_HTTP_URL, STORAGE_KEY_TOKEN } from '../../lib/constants'
+import { FETCH_DEFAULT_TIMEOUT_MS } from '../../lib/constants/network'
+
+// #7993 Phase 2: namespace create is a user-initiated write that must run
+// under the user's kubeconfig via kc-agent, not the backend pod ServiceAccount.
+function agentAuthHeaders(): Record<string, string> {
+  const token = localStorage.getItem(STORAGE_KEY_TOKEN)
+  const headers: Record<string, string> = { 'Content-Type': 'application/json' }
+  if (token) headers['Authorization'] = `Bearer ${token}`
+  return headers
+}
 
 const AVAILABLE_USERS = [
   'admin@example.com',
@@ -78,12 +88,24 @@ export function CreateNamespaceModal({ clusters, onClose, onCreated }: CreateNam
         labels['team'] = teamLabel
       }
 
-      await api.post('/api/namespaces', {
-        cluster,
-        name,
-        labels: Object.keys(labels).length > 0 ? labels : undefined,
-        initialAccess: initialAccess.length > 0 ? initialAccess : undefined,
+      // #7993 Phase 2: POST to kc-agent so the operation runs under the
+      // user's kubeconfig. kc-agent does not accept the `initialAccess` field;
+      // the legacy backend silently ignored it too, so no behavior is lost.
+      // Grants still flow through GrantAccessModal's POST /rolebindings call.
+      const res = await fetch(`${LOCAL_AGENT_HTTP_URL}/namespaces`, {
+        method: 'POST',
+        headers: agentAuthHeaders(),
+        body: JSON.stringify({
+          cluster,
+          name,
+          labels: Object.keys(labels).length > 0 ? labels : undefined,
+        }),
+        signal: AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS),
       })
+      if (!res.ok) {
+        const errorData = await res.json().catch(() => ({}))
+        throw new Error(errorData.error || `Failed to create namespace (HTTP ${res.status})`)
+      }
       onCreated(cluster)
     } catch (err: unknown) {
       const errorMessage = err instanceof Error ? err.message : 'Failed to create namespace'

--- a/web/src/components/namespaces/NamespaceManager.tsx
+++ b/web/src/components/namespaces/NamespaceManager.tsx
@@ -312,7 +312,22 @@ export function NamespaceManager() {
     if (!namespaceToDelete) return
 
     try {
-      await api.delete(`/api/namespaces/${encodeURIComponent(namespaceToDelete.name)}?cluster=${encodeURIComponent(namespaceToDelete.cluster)}`)
+      // #7993 Phase 2: namespace delete goes through kc-agent under the
+      // user's kubeconfig. kc-agent takes `name` as a query parameter since
+      // it uses the net/http mux (no URL path parameters).
+      const params = new URLSearchParams({
+        cluster: namespaceToDelete.cluster,
+        name: namespaceToDelete.name,
+      })
+      const res = await fetch(`${LOCAL_AGENT_HTTP_URL}/namespaces?${params}`, {
+        method: 'DELETE',
+        headers: { 'Content-Type': 'application/json', ...agentAuthHeaders() },
+        signal: AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS),
+      })
+      if (!res.ok) {
+        const errorData = await res.json().catch(() => ({ error: 'unknown error' }))
+        throw new Error(errorData.error || 'Failed to delete namespace')
+      }
       // Clear cache for this cluster and refresh
       namespaceCache.delete(namespaceToDelete.cluster)
       fetchNamespaces(true)


### PR DESCRIPTION
## Summary

Phase 2 of the pod-SA → kc-agent refactor (#7993). Migrates user-initiated namespace create/delete and namespace-scoped RoleBinding grant/revoke off the backend pod ServiceAccount and onto kc-agent's user-kubeconfig-backed handlers.

## What's moving

**Backend (pkg/api/handlers/namespaces.go) — removed:**
- ``CreateNamespace``
- ``DeleteNamespace``
- ``GrantNamespaceAccess``
- ``RevokeNamespaceAccess``

Their routes (``POST /api/namespaces``, ``DELETE /api/namespaces/:name``, ``POST /api/namespaces/:name/access``, ``DELETE /api/namespaces/:name/access/:binding``) are removed from ``pkg/api/server.go``. ``ListNamespaces`` and ``GetNamespaceAccess`` remain (read-only, slated for Phase 4.5).

**kc-agent (pkg/agent/server_http.go) — expanded:**
- ``/namespaces`` now handles ``GET`` / ``POST`` / ``DELETE``
- ``/rolebindings`` now handles ``GET`` / ``POST`` / ``DELETE``

Thin wrappers over existing ``pkg/k8s`` methods (``CreateNamespace``, ``DeleteNamespace``, ``GrantNamespaceAccess``, ``DeleteRoleBinding``). Request bodies mirror the legacy backend shape so the frontend only swaps URLs.

**Frontend:**
- ``CreateNamespaceModal.tsx`` — ``POST ${LOCAL_AGENT_HTTP_URL}/namespaces``
- ``NamespaceManager.tsx`` — ``DELETE`` for namespace and rolebinding revoke go to kc-agent
- ``GrantAccessModal.tsx`` — ``POST ${LOCAL_AGENT_HTTP_URL}/rolebindings?namespace=<ns>``

## What's staying on pod-SA (intentional)

- ``mcp_resources.go`` ``CreateOrUpdateResourceQuota`` with ``ensure_namespace: true`` — the GPU-reservation flow. Namespace creation here is an implementation detail of the reservation operator and stays pod-SA per the architectural split.

## Verification

- ``go build ./...`` — clean
- ``go test ./pkg/api/handlers/... ./pkg/agent/...`` — passes except for pre-existing ``TestRefreshToken`` and ``TestRecordFocus_BadBody_Returns400`` (in the known-broken allowlist)
- ``npm run build`` — clean
- ``npm run lint`` — 361 errors, unchanged from ``main`` (pre-existing)

## Test plan

- [ ] Verify namespace create from ``/namespaces`` page hits kc-agent (``127.0.0.1:8585``)
- [ ] Verify namespace delete hits kc-agent
- [ ] Verify ``GrantAccessModal`` grants go through kc-agent
- [ ] Verify revoke hits kc-agent
- [ ] Verify GPU reservation flow (``/gpu`` reserve) still succeeds via backend pod-SA

Refs #7993