### PR TITLE
🐛 fix: dedupe raw-hex comment skip + restore #NNNN refs in test (#8024)

### DIFF
--- a/web/src/test/ui-ux-standards.test.ts
+++ b/web/src/test/ui-ux-standards.test.ts
@@ -67,17 +67,17 @@ const COMPONENTS_DIR = path.resolve(
 //   301 → 302: #6308 MissionBrowser close button on right issue ref
 //   302 → 303: #6309 upgrade confirm dialog issue ref
 //   303 → 304: #6366 ratchet drift — pre-existing unaccounted-for raw hex from before 303 bump, not introduced by #6365
-//   304 → 306: issue 6774 loading/error states — reverted to 304 in issue 6778 (false positives from issue-ref comments rewritten to "issue NNNN" form)
-//   304 → 307: PR 6854 introduced 3 new hex refs (not real color violations)
-//   307 → 309: issue 6882 ratchet drift — pre-existing false positives from issue-ref comments
-//   309 → 313: PR 6977 introduced 4 new hex refs (terminal theme colors, widget export)
+//   304 → 306: issue #6774 loading/error states — reverted to 304 in issue #6778 (false positives from issue-ref comments)
+//   304 → 307: PR #6854 introduced 3 new hex refs (not real color violations)
+//   307 → 309: issue #6882 ratchet drift — pre-existing false positives from issue-ref comments
+//   309 → 313: PR #6977 introduced 4 new hex refs (terminal theme colors, widget export)
 //
 // When you bump this number, append a one-line entry above so future
 // bumps stay grep-able and reviewers can tell at a glance whether a
 // change is a real new violation or just a comment-level reference.
-//   313 → 319: PR 7085 mission state fixes — issue-ref comments misclassified as hex colors
-//   319 → 320: PR 7376 batch resolve — one new hex color reference
-//   320 → 265: issue 8000 — detector now skips comment lines outright,
+//   313 → 319: PR #7085 mission state fixes — issue-ref comments misclassified as hex colors
+//   319 → 320: PR #7376 batch resolve — one new hex color reference
+//   320 → 265: issue #8000 — detector now skips comment lines outright,
 //              eliminating all issue-ref false positives like "issue #7865"
 //              that incremented the ratchet over many previous bumps. The
 //              new baseline is the count of real `#RRGGBB` literals only.
@@ -174,8 +174,16 @@ function shouldSkipLine(line: string): boolean {
   // Skip empty lines
   if (stripped.length === 0) return true
 
-  // Skip comments
-  if (stripped.startsWith('//') || stripped.startsWith('/*') || stripped.startsWith('*')) return true
+  // Skip comments (line, block, block-continuation, and JSX `{/* ... */}`).
+  // Issue-ref tokens like `#7865` otherwise trip the raw-hex detector.
+  if (
+    stripped.startsWith('//') ||
+    stripped.startsWith('/*') ||
+    stripped.startsWith('*') ||
+    stripped.startsWith('{/*')
+  ) {
+    return true
+  }
 
   // Skip import statements
   if (stripped.startsWith('import ')) return true
@@ -239,20 +247,8 @@ function detectRawHex(line: string): ViolationCategory | null {
   if (isInSvgContext(stripped)) return null
   if (isInCanvasContext(stripped)) return null
 
-  // Skip comment lines outright (line comments, block-comment openers,
-  // block-comment continuation lines that start with `*`, and JSX
-  // `{/* ... */}` comments). Issue refs of the form `#NNNN` match the
-  // hex regex by accident and produced false-positive violations
-  // throughout the codebase — the detector should only police colors
-  // in live code, not prose (issue 8000).
-  if (
-    stripped.startsWith('//') ||
-    stripped.startsWith('/*') ||
-    stripped.startsWith('*') ||
-    stripped.startsWith('{/*')
-  ) {
-    return null
-  }
+  // Comment lines (including JSX `{/* ... */}`) are already filtered upstream
+  // by shouldSkipLine — duplicated here previously, removed to avoid drift.
 
   // Skip className attributes (Tailwind classes may contain color names, not hex)
   if (/className\s*=/.test(stripped) && !/#[0-9a-fA-F]{3,8}/.test(stripped)) return null


### PR DESCRIPTION
## Summary

Addresses both Copilot review comments left on merged PR #8009 (`fix(tests): exclude comment lines from raw-hex detector`).

### 1. `detectRawHex` duplicated `shouldSkipLine`'s comment filtering

Before #8009 shipped, the raw-hex detector had its own block skipping `//`, `/*`, `*`, and `{/* ...` comment prefixes — even though `shouldSkipLine()` was already called at the same call site (`ui-ux-standards.test.ts:370`) and filters three of those four prefixes upstream. Two parallel filters for the same thing is a drift hazard.

Fix: move `{/*` (JSX comment) into `shouldSkipLine`, so every detector — not just `detectRawHex` — automatically skips JSX comments, and delete the duplicate block from `detectRawHex`.

### 2. Bump-history entries lost their `#` prefix

PR #8009 rewrote the bump-history comments from `PR #NNNN` to `PR NNNN` / `issue NNNN` because the old `#NNNN` form was triggering false-positive raw-hex violations. Now that `shouldSkipLine` filters comment lines upstream, `#NNNN` in comments is safe again — and the rest of the file (e.g. line 88: `PRs #7832, #7857`) still uses the `#NNNN` form. Mixed styles meant half the refs got GitHub auto-linking and half didn't.

Fix: restore `#NNNN` in lines 70–72, 78–80 so the bump history is internally consistent and every PR/issue reference becomes a clickable link on GitHub.

## Fixes

- Fixes #8024

## Test plan

- [ ] CI Go + TS build green
- [ ] CI lint green
- [ ] `npm run test -- ui-ux-standards` still passes (the skip-logic move doesn't change what gets filtered; the detector no longer does it itself because shouldSkipLine now covers `{/*` before the detector runs)