### PR TITLE
🐛 fix: harden kc-agent workload HTTP handlers (Fixes #8019, Fixes #8021)

### DIFF
--- a/pkg/agent/endpoint_auth_test.go
+++ b/pkg/agent/endpoint_auth_test.go
@@ -62,6 +62,12 @@ const (
 	// endpointScale scales a deployment (sensitive — mutating).
 	endpointScale = "/scale"
 
+	// endpointWorkloadsDeploy deploys a workload to target clusters (sensitive — mutating).
+	endpointWorkloadsDeploy = "/workloads/deploy"
+
+	// endpointWorkloadsDelete deletes a workload from a cluster (sensitive — destructive mutation).
+	endpointWorkloadsDelete = "/workloads/delete"
+
 	// endpointProviderCheck checks provider availability (sensitive — reveals config).
 	endpointProviderCheck = "/provider-check"
 
@@ -174,6 +180,8 @@ var sensitiveEndpoints = []struct {
 	{endpointPods, "GET"},
 	{endpointNodes, "GET"},
 	{endpointScale, "POST"},
+	{endpointWorkloadsDeploy, "POST"},
+	{endpointWorkloadsDelete, "POST"},
 	{endpointProviderCheck, "GET"},
 	{endpointAutoUpdateStatus, "GET"},
 	{endpointKagentiAgents, "GET"},
@@ -558,6 +566,8 @@ func resolveEndpointHandler(s *Server, path string) func(http.ResponseWriter, *h
 		endpointPods:               s.handlePodsHTTP,
 		endpointNodes:              s.handleNodesHTTP,
 		endpointScale:              s.handleScaleHTTP,
+		endpointWorkloadsDeploy:    s.handleDeployWorkloadHTTP,
+		endpointWorkloadsDelete:    s.handleDeleteWorkloadHTTP,
 		endpointProviderCheck:      s.handleProviderCheck,
 		endpointAutoUpdateStatus:   s.handleAutoUpdateStatus,
 		endpointKagentiAgents:      s.handleKagentiAgents,

--- a/pkg/agent/server_http.go
+++ b/pkg/agent/server_http.go
@@ -1227,6 +1227,10 @@ func (s *Server) handleResolveDepsHTTP(w http.ResponseWriter, r *http.Request) {
 // GET-based mutations are rejected to prevent CSRF-style attacks (#4150).
 func (s *Server) handleScaleHTTP(w http.ResponseWriter, r *http.Request) {
 	s.setCORSHeaders(w, r)
+	// setCORSHeaders defaults Access-Control-Allow-Methods to "GET, OPTIONS".
+	// This is a mutating POST endpoint — browsers would otherwise reject the
+	// cross-origin POST preflight (#8019, #8021).
+	w.Header().Set("Access-Control-Allow-Methods", "POST, OPTIONS")
 	w.Header().Set("Content-Type", "application/json")
 	if r.Method == "OPTIONS" {
 		w.WriteHeader(http.StatusOK)
@@ -1250,14 +1254,6 @@ func (s *Server) handleScaleHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if s.k8sClient == nil {
-		writeJSON(w,map[string]interface{}{
-			"success": false,
-			"error":   "k8s client not initialized",
-		})
-		return
-	}
-
 	// The frontend (useWorkloads.useScaleWorkload) sends:
 	//   { workloadName, namespace, targetClusters: []string, replicas }
 	// Older agent callers used { cluster, namespace, name, replicas }.
@@ -1276,6 +1272,8 @@ func (s *Server) handleScaleHTTP(w http.ResponseWriter, r *http.Request) {
 		Namespace string `json:"namespace"`
 		Replicas  int32  `json:"replicas"`
 	}
+	// Cap request body to avoid OOM from oversized payloads (#8021).
+	r.Body = http.MaxBytesReader(w, r.Body, maxRequestBodyBytes)
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		w.WriteHeader(http.StatusBadRequest)
 		writeJSON(w,map[string]interface{}{
@@ -1307,9 +1305,51 @@ func (s *Server) handleScaleHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if name == "" || namespace == "" {
+		w.WriteHeader(http.StatusBadRequest)
 		writeJSON(w,map[string]interface{}{
 			"success": false,
 			"error":   "workloadName and namespace are required",
+		})
+		return
+	}
+
+	// Require at least one target cluster. An empty targetClusters used to
+	// be interpreted by MultiClusterClient.ScaleWorkload as "scale in every
+	// known cluster", which is surprising and dangerous for a mutating call
+	// driven by user input (#8019).
+	if len(targetClusters) == 0 {
+		w.WriteHeader(http.StatusBadRequest)
+		writeJSON(w,map[string]interface{}{
+			"success": false,
+			"error":   "at least one targetCluster (or legacy 'cluster') is required",
+		})
+		return
+	}
+
+	if err := validateDNS1123Label("namespace", namespace); err != nil {
+		w.WriteHeader(http.StatusBadRequest)
+		writeJSON(w,map[string]interface{}{"success": false, "error": err.Error()})
+		return
+	}
+	if err := validateDNS1123Label("workloadName", name); err != nil {
+		w.WriteHeader(http.StatusBadRequest)
+		writeJSON(w,map[string]interface{}{"success": false, "error": err.Error()})
+		return
+	}
+	for _, tc := range targetClusters {
+		if err := validateKubeContext(tc); err != nil {
+			w.WriteHeader(http.StatusBadRequest)
+			writeJSON(w,map[string]interface{}{"success": false, "error": fmt.Sprintf("targetCluster: %v", err)})
+			return
+		}
+	}
+
+	if s.k8sClient == nil {
+		// 503 so fetch callers hit their !res.ok branch (#8021).
+		w.WriteHeader(http.StatusServiceUnavailable)
+		writeJSON(w,map[string]interface{}{
+			"success": false,
+			"error":   "k8s client not initialized",
 		})
 		return
 	}
@@ -1347,6 +1387,8 @@ func (s *Server) handleScaleHTTP(w http.ResponseWriter, r *http.Request) {
 // prevent CSRF-style attacks (#4150 pattern, same as handleScaleHTTP).
 func (s *Server) handleDeployWorkloadHTTP(w http.ResponseWriter, r *http.Request) {
 	s.setCORSHeaders(w, r)
+	// setCORSHeaders defaults Methods to "GET, OPTIONS"; override for POST (#8021).
+	w.Header().Set("Access-Control-Allow-Methods", "POST, OPTIONS")
 	w.Header().Set("Content-Type", "application/json")
 	if r.Method == "OPTIONS" {
 		w.WriteHeader(http.StatusOK)
@@ -1370,14 +1412,6 @@ func (s *Server) handleDeployWorkloadHTTP(w http.ResponseWriter, r *http.Request
 		return
 	}
 
-	if s.k8sClient == nil {
-		writeJSON(w, map[string]interface{}{
-			"success": false,
-			"error":   "k8s client not initialized",
-		})
-		return
-	}
-
 	// Matches the backend's DeployWorkload request shape so the frontend can
 	// send the same payload to either endpoint during migration.
 	var req struct {
@@ -1393,6 +1427,7 @@ func (s *Server) handleDeployWorkloadHTTP(w http.ResponseWriter, r *http.Request
 		// to the anonymous marker used by MultiClusterClient.DeployWorkload.
 		DeployedBy string `json:"deployedBy,omitempty"`
 	}
+	r.Body = http.MaxBytesReader(w, r.Body, maxRequestBodyBytes)
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		w.WriteHeader(http.StatusBadRequest)
 		writeJSON(w, map[string]interface{}{
@@ -1423,6 +1458,38 @@ func (s *Server) handleDeployWorkloadHTTP(w http.ResponseWriter, r *http.Request
 		return
 	}
 
+	if err := validateDNS1123Label("workloadName", req.WorkloadName); err != nil {
+		w.WriteHeader(http.StatusBadRequest)
+		writeJSON(w, map[string]interface{}{"success": false, "error": err.Error()})
+		return
+	}
+	if err := validateDNS1123Label("namespace", req.Namespace); err != nil {
+		w.WriteHeader(http.StatusBadRequest)
+		writeJSON(w, map[string]interface{}{"success": false, "error": err.Error()})
+		return
+	}
+	if err := validateKubeContext(req.SourceCluster); err != nil {
+		w.WriteHeader(http.StatusBadRequest)
+		writeJSON(w, map[string]interface{}{"success": false, "error": fmt.Sprintf("sourceCluster: %v", err)})
+		return
+	}
+	for _, tc := range req.TargetClusters {
+		if err := validateKubeContext(tc); err != nil {
+			w.WriteHeader(http.StatusBadRequest)
+			writeJSON(w, map[string]interface{}{"success": false, "error": fmt.Sprintf("targetCluster: %v", err)})
+			return
+		}
+	}
+
+	if s.k8sClient == nil {
+		w.WriteHeader(http.StatusServiceUnavailable)
+		writeJSON(w, map[string]interface{}{
+			"success": false,
+			"error":   "k8s client not initialized",
+		})
+		return
+	}
+
 	opts := &k8s.DeployOptions{
 		DeployedBy: req.DeployedBy,
 		GroupName:  req.GroupName,
@@ -1446,11 +1513,15 @@ func (s *Server) handleDeployWorkloadHTTP(w http.ResponseWriter, r *http.Request
 		return
 	}
 
+	// Preserve dependencies and warnings from the MultiClusterClient response —
+	// the UI surfaces deploy warnings and dependency-action links (#8021).
 	writeJSON(w, map[string]interface{}{
 		"success":        result.Success,
 		"message":        result.Message,
 		"deployedTo":     result.DeployedTo,
 		"failedClusters": result.FailedClusters,
+		"dependencies":   result.Dependencies,
+		"warnings":       result.Warnings,
 		"source":         "agent",
 	})
 }
@@ -1466,6 +1537,8 @@ func (s *Server) handleDeployWorkloadHTTP(w http.ResponseWriter, r *http.Request
 // a POST with {cluster, namespace, name} in the body.
 func (s *Server) handleDeleteWorkloadHTTP(w http.ResponseWriter, r *http.Request) {
 	s.setCORSHeaders(w, r)
+	// setCORSHeaders defaults Methods to "GET, OPTIONS"; override for POST (#8021).
+	w.Header().Set("Access-Control-Allow-Methods", "POST, OPTIONS")
 	w.Header().Set("Content-Type", "application/json")
 	if r.Method == "OPTIONS" {
 		w.WriteHeader(http.StatusOK)
@@ -1489,19 +1562,12 @@ func (s *Server) handleDeleteWorkloadHTTP(w http.ResponseWriter, r *http.Request
 		return
 	}
 
-	if s.k8sClient == nil {
-		writeJSON(w, map[string]interface{}{
-			"success": false,
-			"error":   "k8s client not initialized",
-		})
-		return
-	}
-
 	var req struct {
 		Cluster   string `json:"cluster"`
 		Namespace string `json:"namespace"`
 		Name      string `json:"name"`
 	}
+	r.Body = http.MaxBytesReader(w, r.Body, maxRequestBodyBytes)
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		w.WriteHeader(http.StatusBadRequest)
 		writeJSON(w, map[string]interface{}{
@@ -1516,6 +1582,31 @@ func (s *Server) handleDeleteWorkloadHTTP(w http.ResponseWriter, r *http.Request
 		writeJSON(w, map[string]interface{}{
 			"success": false,
 			"error":   "cluster, namespace, and name are required",
+		})
+		return
+	}
+
+	if err := validateKubeContext(req.Cluster); err != nil {
+		w.WriteHeader(http.StatusBadRequest)
+		writeJSON(w, map[string]interface{}{"success": false, "error": fmt.Sprintf("cluster: %v", err)})
+		return
+	}
+	if err := validateDNS1123Label("namespace", req.Namespace); err != nil {
+		w.WriteHeader(http.StatusBadRequest)
+		writeJSON(w, map[string]interface{}{"success": false, "error": err.Error()})
+		return
+	}
+	if err := validateDNS1123Label("name", req.Name); err != nil {
+		w.WriteHeader(http.StatusBadRequest)
+		writeJSON(w, map[string]interface{}{"success": false, "error": err.Error()})
+		return
+	}
+
+	if s.k8sClient == nil {
+		w.WriteHeader(http.StatusServiceUnavailable)
+		writeJSON(w, map[string]interface{}{
+			"success": false,
+			"error":   "k8s client not initialized",
 		})
 		return
 	}

--- a/pkg/agent/workload_http_test.go
+++ b/pkg/agent/workload_http_test.go
@@ -1,0 +1,243 @@
+package agent
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// newWorkloadTestServer returns a minimal Server with an allowed origin but no
+// agentToken set — so validateToken always returns true and handlers exercise
+// their full validation path. k8sClient is nil so handlers return 503 once the
+// input is fully validated, which lets us assert on validation ordering
+// without needing a real MultiClusterClient.
+func newWorkloadTestServer() *Server {
+	return &Server{
+		allowedOrigins: []string{"http://localhost:3000"},
+		agentToken:     "",
+	}
+}
+
+func postJSON(handler http.HandlerFunc, path string, body interface{}) *httptest.ResponseRecorder {
+	buf, _ := json.Marshal(body)
+	req := httptest.NewRequest("POST", path, bytes.NewReader(buf))
+	req.Header.Set("Origin", "http://localhost:3000")
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	handler(w, req)
+	return w
+}
+
+// TestHandleScaleHTTP_NewShapeAccepted verifies the modern
+// { workloadName, targetClusters, namespace, replicas } payload passes
+// validation and reaches the nil-client path (503). This is the shape used by
+// useWorkloads.useScaleWorkload and is the primary contract going forward.
+func TestHandleScaleHTTP_NewShapeAccepted(t *testing.T) {
+	s := newWorkloadTestServer()
+
+	w := postJSON(s.handleScaleHTTP, "/scale", map[string]interface{}{
+		"workloadName":   "api-server",
+		"namespace":      "production",
+		"targetClusters": []string{"eks-prod-us-east-1"},
+		"replicas":       3,
+	})
+
+	if w.Code != http.StatusServiceUnavailable {
+		t.Fatalf("expected 503 for valid payload with nil client, got %d: %s", w.Code, w.Body.String())
+	}
+	if !strings.Contains(w.Body.String(), "k8s client not initialized") {
+		t.Errorf("expected k8s-client-not-initialized error, got %s", w.Body.String())
+	}
+}
+
+// TestHandleScaleHTTP_LegacyShapeAccepted ensures older direct agent callers
+// sending { cluster, name, namespace, replicas } still pass validation and
+// normalize to a single-element targetClusters slice. This is the #8019
+// backward-compat parity coverage Copilot called out.
+func TestHandleScaleHTTP_LegacyShapeAccepted(t *testing.T) {
+	s := newWorkloadTestServer()
+
+	w := postJSON(s.handleScaleHTTP, "/scale", map[string]interface{}{
+		"cluster":   "eks-prod-us-east-1",
+		"name":      "api-server",
+		"namespace": "production",
+		"replicas":  3,
+	})
+
+	if w.Code != http.StatusServiceUnavailable {
+		t.Fatalf("expected 503 (valid legacy payload → nil client), got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+// TestHandleScaleHTTP_RejectsEmptyTargetClusters verifies that sending neither
+// `targetClusters` nor the legacy `cluster` field is rejected as 400. Before
+// #8019 this would fall through to MultiClusterClient.ScaleWorkload, which
+// interprets an empty slice as "scale all known clusters" — a dangerous
+// implicit default for a mutating endpoint driven by user input.
+func TestHandleScaleHTTP_RejectsEmptyTargetClusters(t *testing.T) {
+	s := newWorkloadTestServer()
+
+	w := postJSON(s.handleScaleHTTP, "/scale", map[string]interface{}{
+		"workloadName": "api-server",
+		"namespace":    "production",
+		"replicas":     3,
+	})
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for missing targetClusters, got %d: %s", w.Code, w.Body.String())
+	}
+	if !strings.Contains(w.Body.String(), "targetCluster") {
+		t.Errorf("expected error mentioning targetCluster, got %s", w.Body.String())
+	}
+}
+
+// TestHandleScaleHTTP_RejectsNegativeReplicas ensures replicas<0 is still
+// rejected (regression guard — not a new behavior, but covered here so the
+// file owns all handleScaleHTTP contract tests in one place).
+func TestHandleScaleHTTP_RejectsNegativeReplicas(t *testing.T) {
+	s := newWorkloadTestServer()
+
+	w := postJSON(s.handleScaleHTTP, "/scale", map[string]interface{}{
+		"workloadName":   "api-server",
+		"namespace":      "production",
+		"targetClusters": []string{"eks-prod-us-east-1"},
+		"replicas":       -1,
+	})
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("expected 400 for negative replicas, got %d", w.Code)
+	}
+}
+
+// TestHandleScaleHTTP_RejectsInvalidNamespace verifies that a non-DNS-1123
+// namespace is rejected before hitting any k8s client call.
+func TestHandleScaleHTTP_RejectsInvalidNamespace(t *testing.T) {
+	s := newWorkloadTestServer()
+
+	w := postJSON(s.handleScaleHTTP, "/scale", map[string]interface{}{
+		"workloadName":   "api-server",
+		"namespace":      "Production", // uppercase → invalid DNS-1123 label
+		"targetClusters": []string{"eks-prod-us-east-1"},
+		"replicas":       3,
+	})
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("expected 400 for invalid namespace, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+// TestHandleScaleHTTP_RejectsPathTraversalCluster guards against
+// targetClusters entries containing ".." path-traversal sequences slipping
+// past validateKubeContext.
+func TestHandleScaleHTTP_RejectsPathTraversalCluster(t *testing.T) {
+	s := newWorkloadTestServer()
+
+	w := postJSON(s.handleScaleHTTP, "/scale", map[string]interface{}{
+		"workloadName":   "api-server",
+		"namespace":      "production",
+		"targetClusters": []string{"../etc/passwd"},
+		"replicas":       3,
+	})
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("expected 400 for path-traversal targetCluster, got %d", w.Code)
+	}
+}
+
+// TestHandleScaleHTTP_RejectsGET verifies CSRF protection — only POST is
+// allowed, GET returns 405 (#4150).
+func TestHandleScaleHTTP_RejectsGET(t *testing.T) {
+	s := newWorkloadTestServer()
+
+	req := httptest.NewRequest("GET", "/scale", nil)
+	req.Header.Set("Origin", "http://localhost:3000")
+	w := httptest.NewRecorder()
+	s.handleScaleHTTP(w, req)
+
+	if w.Code != http.StatusMethodNotAllowed {
+		t.Errorf("expected 405 for GET, got %d", w.Code)
+	}
+}
+
+// TestHandleScaleHTTP_CORSMethodsHeader verifies the POST-specific
+// Access-Control-Allow-Methods override runs, so the browser preflight
+// advertises POST and not the default "GET, OPTIONS" (#8021).
+func TestHandleScaleHTTP_CORSMethodsHeader(t *testing.T) {
+	s := newWorkloadTestServer()
+
+	req := httptest.NewRequest("OPTIONS", "/scale", nil)
+	req.Header.Set("Origin", "http://localhost:3000")
+	w := httptest.NewRecorder()
+	s.handleScaleHTTP(w, req)
+
+	methods := w.Header().Get("Access-Control-Allow-Methods")
+	if !strings.Contains(methods, "POST") {
+		t.Errorf("expected Access-Control-Allow-Methods to include POST, got %q", methods)
+	}
+}
+
+// TestHandleDeployWorkloadHTTP_CORSMethodsHeader — same guard as scale.
+func TestHandleDeployWorkloadHTTP_CORSMethodsHeader(t *testing.T) {
+	s := newWorkloadTestServer()
+
+	req := httptest.NewRequest("OPTIONS", "/workloads/deploy", nil)
+	req.Header.Set("Origin", "http://localhost:3000")
+	w := httptest.NewRecorder()
+	s.handleDeployWorkloadHTTP(w, req)
+
+	methods := w.Header().Get("Access-Control-Allow-Methods")
+	if !strings.Contains(methods, "POST") {
+		t.Errorf("expected Access-Control-Allow-Methods to include POST, got %q", methods)
+	}
+}
+
+// TestHandleDeleteWorkloadHTTP_CORSMethodsHeader — same guard as scale.
+func TestHandleDeleteWorkloadHTTP_CORSMethodsHeader(t *testing.T) {
+	s := newWorkloadTestServer()
+
+	req := httptest.NewRequest("OPTIONS", "/workloads/delete", nil)
+	req.Header.Set("Origin", "http://localhost:3000")
+	w := httptest.NewRecorder()
+	s.handleDeleteWorkloadHTTP(w, req)
+
+	methods := w.Header().Get("Access-Control-Allow-Methods")
+	if !strings.Contains(methods, "POST") {
+		t.Errorf("expected Access-Control-Allow-Methods to include POST, got %q", methods)
+	}
+}
+
+// TestHandleDeployWorkloadHTTP_RejectsInvalidSourceCluster confirms
+// validateKubeContext runs on sourceCluster.
+func TestHandleDeployWorkloadHTTP_RejectsInvalidSourceCluster(t *testing.T) {
+	s := newWorkloadTestServer()
+
+	w := postJSON(s.handleDeployWorkloadHTTP, "/workloads/deploy", map[string]interface{}{
+		"workloadName":   "api-server",
+		"namespace":      "production",
+		"sourceCluster":  "../traversal",
+		"targetClusters": []string{"eks-prod"},
+	})
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("expected 400 for invalid sourceCluster, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+// TestHandleDeleteWorkloadHTTP_RejectsInvalidCluster confirms
+// validateKubeContext runs on cluster.
+func TestHandleDeleteWorkloadHTTP_RejectsInvalidCluster(t *testing.T) {
+	s := newWorkloadTestServer()
+
+	w := postJSON(s.handleDeleteWorkloadHTTP, "/workloads/delete", map[string]interface{}{
+		"cluster":   "../bad",
+		"namespace": "production",
+		"name":      "api-server",
+	})
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("expected 400 for invalid cluster, got %d: %s", w.Code, w.Body.String())
+	}
+}

--- a/web/src/hooks/useWorkloads.ts
+++ b/web/src/hooks/useWorkloads.ts
@@ -60,6 +60,19 @@ function authHeaders(): Record<string, string> {
   return headers
 }
 
+// kc-agent mutating endpoints live on the user's local agent, not the hosted
+// Netlify backend. On console.kubestellar.io LOCAL_AGENT_HTTP_URL is an empty
+// string, which would turn `${LOCAL_AGENT_HTTP_URL}/workloads/delete` into a
+// relative path and 404 (plus a confusing non-JSON response). Throw early with
+// a clear message so the UI can surface "local agent required" instead of a
+// cryptic 404 (#8021).
+function requireLocalAgentHttp(action: string): string {
+  if (!LOCAL_AGENT_HTTP_URL) {
+    throw new Error(`${action} requires the local kc-agent; this browser is not connected to one.`)
+  }
+  return LOCAL_AGENT_HTTP_URL
+}
+
 
 function getDemoWorkloads(cluster?: string, namespace?: string): Workload[] {
   const workloads: Workload[] = [
@@ -322,7 +335,8 @@ export function useDeployWorkload() {
       // Deploy is a user-initiated mutation on managed clusters, so it must
       // run under the user's kubeconfig via kc-agent, not the backend pod SA.
       // See #7993 Phase 1 PR B.
-      const res = await fetch(`${LOCAL_AGENT_HTTP_URL}/workloads/deploy`, {
+      const agentBase = requireLocalAgentHttp('Deploying workloads')
+      const res = await fetch(`${agentBase}/workloads/deploy`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json', ...authHeaders() },
         body: JSON.stringify(request),
@@ -371,7 +385,8 @@ export function useScaleWorkload() {
       // Scaling is a user-initiated mutation on managed clusters, so it must
       // go through kc-agent (user's kubeconfig), not the backend's pod SA.
       // See #7993 Phase 1 PR A.
-      const res = await fetch(`${LOCAL_AGENT_HTTP_URL}/scale`, {
+      const agentBase = requireLocalAgentHttp('Scaling workloads')
+      const res = await fetch(`${agentBase}/scale`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json', ...authHeaders() },
         body: JSON.stringify(request),
@@ -421,7 +436,8 @@ export function useDeleteWorkload() {
       // kc-agent convention is POST-with-body (same as /scale) — the method
       // verb moves from DELETE-with-params to POST-with-body here.
       // See #7993 Phase 1 PR B.
-      const res = await fetch(`${LOCAL_AGENT_HTTP_URL}/workloads/delete`, {
+      const agentBase = requireLocalAgentHttp('Deleting workloads')
+      const res = await fetch(`${agentBase}/workloads/delete`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json', ...authHeaders() },
         body: JSON.stringify({


### PR DESCRIPTION
## Summary

Addresses Copilot review follow-ups #8019 (2 comments on merged #8010) and #8021 (12 comments on merged #8013) by hardening the kc-agent workload HTTP handlers and adding parity tests.

- **CORS**: override \`Access-Control-Allow-Methods: POST, OPTIONS\` on \`/scale\`, \`/workloads/deploy\`, \`/workloads/delete\` — the shared \`setCORSHeaders\` helper defaults to GET, so cross-origin POST preflights would otherwise fail.
- **Body caps**: wrap \`r.Body\` with \`http.MaxBytesReader(maxRequestBodyBytes)\` before JSON decode on all three handlers.
- **Input validation**: run \`validateDNS1123Label\` on namespace/workload/resource names and \`validateKubeContext\` on every cluster identifier (sourceCluster, targetClusters, cluster). Rejects path-traversal and unsafe characters before any k8s call.
- **Nil client**: return \`503 Service Unavailable\` (was a 200-body error JSON) so fetch callers hit \`!res.ok\`.
- **Scale empty targetClusters**: reject explicitly instead of implicitly fanning out to every known cluster via \`MultiClusterClient.ScaleWorkload\`.
- **Scale missing fields**: return \`400\` (was \`200\` body error) on empty \`workloadName\`/\`namespace\`.
- **Deploy response**: preserve \`dependencies\` and \`warnings\` from \`DeployResponse\` — the UI surfaces these.
- **Auth test coverage**: register \`/workloads/deploy\` and \`/workloads/delete\` in \`sensitiveEndpoints\` + \`resolveEndpointHandler\` so the auth table actually exercises them.
- **New parity tests** (\`pkg/agent/workload_http_test.go\`): new/legacy shape, empty \`targetClusters\`, negative replicas, invalid namespace, path-traversal cluster, GET rejection, CORS Methods-header guard.
- **Frontend**: throw a clear error in \`useWorkloads.ts\` when \`LOCAL_AGENT_HTTP_URL\` is empty (Netlify/hosted builds) so scale/deploy/delete don't silently 404 on relative paths.

Fixes #8019
Fixes #8021

## Test plan

- [x] \`go build ./...\` (pkg/agent)
- [x] \`go test ./pkg/agent -run 'TestHandleScale|TestHandleDeploy|TestHandleDelete|TestEndpointAuth' -count=1\` — green
- [x] \`npm run build\` — green
- [x] \`npm run lint\` — no new issues on touched files
- [ ] CI: build / lint / ui-ux-standard / Analyze JS / netlify preview