### PR TITLE
refactor(phase3e): migrate GPU health cronjob install/uninstall to kc-agent (#7993)

### DIFF
--- a/pkg/agent/server.go
+++ b/pkg/agent/server.go
@@ -433,6 +433,13 @@ func (s *Server) Start() error {
 	// pkg/agent/server_argocd.go.
 	mux.HandleFunc("/argocd/sync", s.handleArgoCDSync)
 
+	// GPU health CronJob install/uninstall moved to kc-agent (#7993 Phase 3e).
+	// The shared pkg/k8s.MultiClusterClient methods create the CronJob plus
+	// the RBAC bundle — kc-agent runs under the user's kubeconfig. Backend
+	// handlers are deleted in this same PR along with the frontend migration.
+	// Route in pkg/agent/server_gpu_health.go.
+	mux.HandleFunc("/gpu-health-cronjob", s.handleGPUHealthCronJob)
+
 	// Rename context endpoint
 	mux.HandleFunc("/rename-context", s.handleRenameContextHTTP)
 

--- a/pkg/agent/server_gpu_health.go
+++ b/pkg/agent/server_gpu_health.go
@@ -1,0 +1,167 @@
+package agent
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"regexp"
+	"strings"
+)
+
+// GPU-health CronJob install/uninstall handlers (#7993 Phase 3e). User-initiated
+// tooling installs like this CronJob + RBAC bundle must run under the user's
+// kubeconfig via kc-agent, not the backend pod ServiceAccount.
+
+// Tier range for the GPU health check. Must stay in sync with the frontend
+// TIER_OPTIONS in ProactiveGPUNodeHealthMonitor.tsx and with the backend's
+// InstallGPUHealthCronJob validator in pkg/api/handlers/mcp_resources.go
+// (issue #6110).
+const (
+	minGPUHealthTier = 1 // Critical
+	maxGPUHealthTier = 4 // Deep (privileged)
+)
+
+// cronFieldCount is the number of fields in a standard cron expression.
+// (minute, hour, day-of-month, month, day-of-week)
+const cronFieldCount = 5
+
+// maxCronFieldLen caps the length of a single cron field to prevent abuse.
+const maxCronFieldLen = 64
+
+// cronFieldPattern matches a single standard cron field. Matches the backend
+// validation.go#cronFieldPattern exactly.
+var cronFieldPattern = regexp.MustCompile(`^[0-9*/,\-LW#?]+$`)
+
+// isValidCronScheduleAgent mirrors pkg/api/handlers/validation.go's
+// isValidCronSchedule. Re-implemented here because pkg/agent cannot import
+// pkg/api/handlers. Kept lockstep until the backend handler is removed.
+func isValidCronScheduleAgent(schedule string) bool {
+	fields := strings.Fields(schedule)
+	if len(fields) != cronFieldCount {
+		return false
+	}
+	for _, f := range fields {
+		if len(f) > maxCronFieldLen {
+			return false
+		}
+		if !cronFieldPattern.MatchString(f) {
+			return false
+		}
+	}
+	return true
+}
+
+// handleGPUHealthCronJob serves POST (install) and DELETE (uninstall) for the
+// GPU health-check CronJob + associated RBAC. Both paths shell through
+// s.k8sClient (MultiClusterClient) which, in kc-agent, uses the user's
+// kubeconfig.
+func (s *Server) handleGPUHealthCronJob(w http.ResponseWriter, r *http.Request) {
+	s.setCORSHeaders(w, r)
+	w.Header().Set("Content-Type", "application/json")
+
+	if r.Method == "OPTIONS" {
+		w.WriteHeader(http.StatusOK)
+		return
+	}
+	if !s.validateToken(r) {
+		http.Error(w, "Unauthorized", http.StatusUnauthorized)
+		return
+	}
+	if s.k8sClient == nil {
+		w.WriteHeader(http.StatusServiceUnavailable)
+		writeJSON(w, map[string]string{"error": "No cluster access"})
+		return
+	}
+
+	switch r.Method {
+	case http.MethodPost:
+		s.gpuHealthCronJobInstall(w, r)
+	case http.MethodDelete:
+		s.gpuHealthCronJobUninstall(w, r)
+	default:
+		w.WriteHeader(http.StatusMethodNotAllowed)
+		writeJSON(w, map[string]string{"error": "POST or DELETE required"})
+	}
+}
+
+// gpuHealthCronJobInstall handles POST /gpu-health-cronjob. Mirrors the
+// backend MCPHandlers.InstallGPUHealthCronJob request body and validation.
+func (s *Server) gpuHealthCronJobInstall(w http.ResponseWriter, r *http.Request) {
+	var body struct {
+		Cluster   string `json:"cluster"`
+		Namespace string `json:"namespace"`
+		Schedule  string `json:"schedule"`
+		Tier      int    `json:"tier"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		w.WriteHeader(http.StatusBadRequest)
+		writeJSON(w, map[string]string{"error": "Invalid request body"})
+		return
+	}
+	if body.Cluster == "" {
+		w.WriteHeader(http.StatusBadRequest)
+		writeJSON(w, map[string]string{"error": "cluster is required"})
+		return
+	}
+	if body.Schedule != "" && !isValidCronScheduleAgent(body.Schedule) {
+		w.WriteHeader(http.StatusBadRequest)
+		writeJSON(w, map[string]string{"error": "invalid cron schedule format — expected 5-field cron expression (e.g. '*/15 * * * *')"})
+		return
+	}
+	if body.Tier < minGPUHealthTier || body.Tier > maxGPUHealthTier {
+		w.WriteHeader(http.StatusBadRequest)
+		writeJSON(w, map[string]string{"error": fmt.Sprintf("tier must be between %d and %d", minGPUHealthTier, maxGPUHealthTier)})
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(r.Context(), agentExtendedTimeout)
+	defer cancel()
+
+	if err := s.k8sClient.InstallGPUHealthCronJob(ctx, body.Cluster, body.Namespace, body.Schedule, body.Tier); err != nil {
+		slog.Warn("[agent] GPU health cronjob install failed", "cluster", body.Cluster, "error", err)
+		w.WriteHeader(http.StatusInternalServerError)
+		writeJSON(w, map[string]interface{}{"error": err.Error(), "source": "agent"})
+		return
+	}
+	writeJSON(w, map[string]interface{}{
+		"success": true,
+		"message": fmt.Sprintf("GPU health CronJob installed on %s (tier %d)", body.Cluster, body.Tier),
+		"source":  "agent",
+	})
+}
+
+// gpuHealthCronJobUninstall handles DELETE /gpu-health-cronjob. Mirrors the
+// backend MCPHandlers.UninstallGPUHealthCronJob request body.
+func (s *Server) gpuHealthCronJobUninstall(w http.ResponseWriter, r *http.Request) {
+	var body struct {
+		Cluster   string `json:"cluster"`
+		Namespace string `json:"namespace"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		w.WriteHeader(http.StatusBadRequest)
+		writeJSON(w, map[string]string{"error": "Invalid request body"})
+		return
+	}
+	if body.Cluster == "" {
+		w.WriteHeader(http.StatusBadRequest)
+		writeJSON(w, map[string]string{"error": "cluster is required"})
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(r.Context(), agentDefaultTimeout)
+	defer cancel()
+
+	if err := s.k8sClient.UninstallGPUHealthCronJob(ctx, body.Cluster, body.Namespace); err != nil {
+		slog.Warn("[agent] GPU health cronjob uninstall failed", "cluster", body.Cluster, "error", err)
+		w.WriteHeader(http.StatusInternalServerError)
+		writeJSON(w, map[string]interface{}{"error": err.Error(), "source": "agent"})
+		return
+	}
+	writeJSON(w, map[string]interface{}{
+		"success": true,
+		"message": fmt.Sprintf("GPU health CronJob removed from %s", body.Cluster),
+		"source":  "agent",
+	})
+}

--- a/pkg/api/handlers/mcp_resources.go
+++ b/pkg/api/handlers/mcp_resources.go
@@ -176,94 +176,13 @@ func (h *MCPHandlers) GetGPUHealthCronJobStatus(c *fiber.Ctx) error {
 	return c.JSON(fiber.Map{"status": status})
 }
 
-// InstallGPUHealthCronJob installs the GPU health check CronJob on a cluster
-func (h *MCPHandlers) InstallGPUHealthCronJob(c *fiber.Ctx) error {
-	// SECURITY (#7493): mutating endpoint requires editor or admin role.
-	if err := requireEditorOrAdmin(c, h.store); err != nil {
-		return err
-	}
-
-	if isDemoMode(c) {
-		return c.JSON(fiber.Map{"success": true, "message": "CronJob installed (demo mode)"})
-	}
-
-	if h.k8sClient == nil {
-		return c.Status(503).JSON(fiber.Map{"error": "No cluster access"})
-	}
-
-	var body struct {
-		Cluster   string `json:"cluster"`
-		Namespace string `json:"namespace"`
-		Schedule  string `json:"schedule"`
-		Tier      int    `json:"tier"`
-	}
-	if err := c.BodyParser(&body); err != nil {
-		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"error": "Invalid request body"})
-	}
-	if body.Cluster == "" {
-		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"error": "cluster is required"})
-	}
-
-	// Validate cron schedule format (5-field standard cron expression)
-	if body.Schedule != "" && !isValidCronSchedule(body.Schedule) {
-		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"error": "invalid cron schedule format — expected 5-field cron expression (e.g. '*/15 * * * *')"})
-	}
-
-	// Validate tier range.
-	// Tier 1 — Critical, Tier 2 — Standard, Tier 3 — Full, Tier 4 — Deep (privileged).
-	// Must stay in sync with the frontend TIER_OPTIONS in ProactiveGPUNodeHealthMonitor.tsx
-	// and with InstallGPUHealthCronJob in pkg/k8s/client_gpu.go (issue #6110).
-	const minTier = 1
-	const maxTier = 4
-	if body.Tier < minTier || body.Tier > maxTier {
-		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"error": fmt.Sprintf("tier must be between %d and %d", minTier, maxTier)})
-	}
-
-	ctx, cancel := context.WithTimeout(c.Context(), mcpExtendedTimeout)
-	defer cancel()
-
-	if err := h.k8sClient.InstallGPUHealthCronJob(ctx, body.Cluster, body.Namespace, body.Schedule, body.Tier); err != nil {
-		return handleK8sError(c, err)
-	}
-
-	return c.JSON(fiber.Map{"success": true, "message": fmt.Sprintf("GPU health CronJob installed on %s (tier %d)", body.Cluster, body.Tier)})
-}
-
-// UninstallGPUHealthCronJob removes the GPU health check CronJob from a cluster
-func (h *MCPHandlers) UninstallGPUHealthCronJob(c *fiber.Ctx) error {
-	// SECURITY (#7494): destructive endpoint requires editor or admin role.
-	if err := requireEditorOrAdmin(c, h.store); err != nil {
-		return err
-	}
-
-	if isDemoMode(c) {
-		return c.JSON(fiber.Map{"success": true, "message": "CronJob removed (demo mode)"})
-	}
-
-	if h.k8sClient == nil {
-		return c.Status(503).JSON(fiber.Map{"error": "No cluster access"})
-	}
-
-	var body struct {
-		Cluster   string `json:"cluster"`
-		Namespace string `json:"namespace"`
-	}
-	if err := c.BodyParser(&body); err != nil {
-		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"error": "Invalid request body"})
-	}
-	if body.Cluster == "" {
-		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"error": "cluster is required"})
-	}
-
-	ctx, cancel := context.WithTimeout(c.Context(), mcpDefaultTimeout)
-	defer cancel()
-
-	if err := h.k8sClient.UninstallGPUHealthCronJob(ctx, body.Cluster, body.Namespace); err != nil {
-		return handleK8sError(c, err)
-	}
-
-	return c.JSON(fiber.Map{"success": true, "message": fmt.Sprintf("GPU health CronJob removed from %s", body.Cluster)})
-}
+// InstallGPUHealthCronJob and UninstallGPUHealthCronJob were removed in #7993
+// Phase 3e — these user-initiated tooling installs now go through kc-agent at
+// `/gpu-health-cronjob` (POST/DELETE), which runs under the user's own
+// kubeconfig instead of the backend pod ServiceAccount. The shared
+// pkg/k8s.MultiClusterClient.InstallGPUHealthCronJob /
+// UninstallGPUHealthCronJob methods stay — kc-agent calls them. See
+// pkg/agent/server_gpu_health.go.
 
 // GetGPUHealthCronJobResults returns the latest health check results from the ConfigMap.
 // This is the endpoint used by the AlertsContext to evaluate gpu_health_cronjob conditions.

--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -928,8 +928,9 @@ func (s *Server) setupRoutes() {
 	api.Get("/mcp/gpu-nodes", mcpHandlers.GetGPUNodes)
 	api.Get("/mcp/gpu-nodes/health", mcpHandlers.GetGPUNodeHealth)
 	api.Get("/mcp/gpu-nodes/health/cronjob", mcpHandlers.GetGPUHealthCronJobStatus)
-	api.Post("/mcp/gpu-nodes/health/cronjob", mcpHandlers.InstallGPUHealthCronJob)
-	api.Delete("/mcp/gpu-nodes/health/cronjob", mcpHandlers.UninstallGPUHealthCronJob)
+	// POST and DELETE /mcp/gpu-nodes/health/cronjob moved to kc-agent
+	// (#7993 Phase 3e). The agent exposes /gpu-health-cronjob with the same
+	// body shape, running under the user's kubeconfig.
 	api.Get("/mcp/gpu-nodes/health/cronjob/results", mcpHandlers.GetGPUHealthCronJobResults)
 	api.Get("/mcp/nvidia-operators", mcpHandlers.GetNVIDIAOperatorStatus)
 	api.Get("/mcp/nodes", mcpHandlers.GetNodes)

--- a/web/src/hooks/__tests__/useCachedData.test.ts
+++ b/web/src/hooks/__tests__/useCachedData.test.ts
@@ -4109,10 +4109,14 @@ describe('useCachedData', () => {
       vi.unstubAllGlobals()
     })
 
-    it('install calls authFetch with POST and refetches', async () => {
+    // #7993 Phase 3e: GPU health cronjob install/uninstall routes through
+    // kc-agent (global `fetch` with LOCAL_AGENT_HTTP_URL), not the backend
+    // `authFetch`. Tests mock `global.fetch` accordingly.
+    it('install calls kc-agent with POST and refetches', async () => {
       const mockRefetch = vi.fn().mockResolvedValue(undefined)
       mockUseCache.mockReturnValue(makeCacheResult(null, { refetch: mockRefetch }))
-      mockAuthFetch.mockResolvedValue({ ok: true })
+      const fetchMock = vi.fn().mockResolvedValue({ ok: true })
+      vi.stubGlobal('fetch', fetchMock)
 
       const { renderHook, act } = await import('@testing-library/react')
       const { useGPUHealthCronJob } = await loadModule()
@@ -4122,8 +4126,8 @@ describe('useCachedData', () => {
         await result.current.install({ namespace: 'gpu-health', schedule: '*/5 * * * *', tier: 3 })
       })
 
-      expect(mockAuthFetch).toHaveBeenCalledWith(
-        '/api/mcp/gpu-nodes/health/cronjob',
+      expect(fetchMock).toHaveBeenCalledWith(
+        expect.stringContaining('/gpu-health-cronjob'),
         expect.objectContaining({ method: 'POST' })
       )
       expect(mockRefetch).toHaveBeenCalled()
@@ -4133,11 +4137,12 @@ describe('useCachedData', () => {
     it('install sets error on non-ok response', async () => {
       const mockRefetch = vi.fn()
       mockUseCache.mockReturnValue(makeCacheResult(null, { refetch: mockRefetch }))
-      mockAuthFetch.mockResolvedValue({
+      const fetchMock = vi.fn().mockResolvedValue({
         ok: false,
         status: 500,
         text: vi.fn().mockResolvedValue('Server Error'),
       })
+      vi.stubGlobal('fetch', fetchMock)
 
       const { renderHook, act } = await import('@testing-library/react')
       const { useGPUHealthCronJob } = await loadModule()
@@ -4147,13 +4152,15 @@ describe('useCachedData', () => {
         await result.current.install()
       })
 
-      expect(mockAuthFetch).toHaveBeenCalled()
+      expect(fetchMock).toHaveBeenCalled()
       expect(result.current.error).toBe('Server Error')
       unmount()
     })
 
     it('install does nothing when no cluster', async () => {
       mockUseCache.mockReturnValue(makeCacheResult(null, { refetch: vi.fn() }))
+      const fetchMock = vi.fn()
+      vi.stubGlobal('fetch', fetchMock)
 
       const { renderHook, act } = await import('@testing-library/react')
       const { useGPUHealthCronJob } = await loadModule()
@@ -4163,14 +4170,15 @@ describe('useCachedData', () => {
         await result.current.install()
       })
 
-      expect(mockAuthFetch).not.toHaveBeenCalled()
+      expect(fetchMock).not.toHaveBeenCalled()
       unmount()
     })
 
-    it('uninstall calls authFetch with DELETE', async () => {
+    it('uninstall calls kc-agent with DELETE', async () => {
       const mockRefetch = vi.fn().mockResolvedValue(undefined)
       mockUseCache.mockReturnValue(makeCacheResult(null, { refetch: mockRefetch }))
-      mockAuthFetch.mockResolvedValue({ ok: true })
+      const fetchMock = vi.fn().mockResolvedValue({ ok: true })
+      vi.stubGlobal('fetch', fetchMock)
 
       const { renderHook, act } = await import('@testing-library/react')
       const { useGPUHealthCronJob } = await loadModule()
@@ -4180,8 +4188,8 @@ describe('useCachedData', () => {
         await result.current.uninstall({ namespace: 'gpu-health' })
       })
 
-      expect(mockAuthFetch).toHaveBeenCalledWith(
-        '/api/mcp/gpu-nodes/health/cronjob',
+      expect(fetchMock).toHaveBeenCalledWith(
+        expect.stringContaining('/gpu-health-cronjob'),
         expect.objectContaining({ method: 'DELETE' })
       )
       expect(mockRefetch).toHaveBeenCalled()
@@ -4190,11 +4198,12 @@ describe('useCachedData', () => {
 
     it('uninstall sets error on non-ok response', async () => {
       mockUseCache.mockReturnValue(makeCacheResult(null, { refetch: vi.fn() }))
-      mockAuthFetch.mockResolvedValue({
+      const fetchMock = vi.fn().mockResolvedValue({
         ok: false,
         status: 400,
         text: vi.fn().mockResolvedValue('Bad Request'),
       })
+      vi.stubGlobal('fetch', fetchMock)
 
       const { renderHook, act } = await import('@testing-library/react')
       const { useGPUHealthCronJob } = await loadModule()
@@ -4204,13 +4213,15 @@ describe('useCachedData', () => {
         await result.current.uninstall()
       })
 
-      expect(mockAuthFetch).toHaveBeenCalled()
+      expect(fetchMock).toHaveBeenCalled()
       expect(result.current.error).toBe('Bad Request')
       unmount()
     })
 
     it('uninstall does nothing when no cluster', async () => {
       mockUseCache.mockReturnValue(makeCacheResult(null, { refetch: vi.fn() }))
+      const fetchMock = vi.fn()
+      vi.stubGlobal('fetch', fetchMock)
 
       const { renderHook, act } = await import('@testing-library/react')
       const { useGPUHealthCronJob } = await loadModule()
@@ -4220,13 +4231,15 @@ describe('useCachedData', () => {
         await result.current.uninstall()
       })
 
-      expect(mockAuthFetch).not.toHaveBeenCalled()
+      expect(fetchMock).not.toHaveBeenCalled()
       unmount()
     })
 
     it('install handles missing token', async () => {
       mockUseCache.mockReturnValue(makeCacheResult(null, { refetch: vi.fn() }))
       localStorage.removeItem('kc_token')
+      const fetchMock = vi.fn()
+      vi.stubGlobal('fetch', fetchMock)
 
       const { renderHook, act } = await import('@testing-library/react')
       const { useGPUHealthCronJob } = await loadModule()
@@ -4236,8 +4249,8 @@ describe('useCachedData', () => {
         await result.current.install()
       })
 
-      // Should not call authFetch because getToken() returns null -> throws
-      expect(mockAuthFetch).not.toHaveBeenCalled()
+      // Should not call fetch because getToken() returns null -> throws.
+      expect(fetchMock).not.toHaveBeenCalled()
       expect(result.current.error).toBe('No authentication token')
       unmount()
     })

--- a/web/src/hooks/useCachedData.ts
+++ b/web/src/hooks/useCachedData.ts
@@ -1420,7 +1420,10 @@ export function useGPUHealthCronJob(cluster?: string) {
     try {
       const token = getToken()
       if (!token) throw new Error('No authentication token')
-      const response = await authFetch('/api/mcp/gpu-nodes/health/cronjob', {
+      // #7993 Phase 3e: GPU health cronjob install is a user-initiated
+      // tooling install. It runs through kc-agent under the user's own
+      // kubeconfig instead of the backend pod ServiceAccount.
+      const response = await fetch(`${LOCAL_AGENT_HTTP_URL}/gpu-health-cronjob`, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
@@ -1450,7 +1453,9 @@ export function useGPUHealthCronJob(cluster?: string) {
     try {
       const token = getToken()
       if (!token) throw new Error('No authentication token')
-      const response = await authFetch('/api/mcp/gpu-nodes/health/cronjob', {
+      // #7993 Phase 3e: GPU health cronjob uninstall goes through kc-agent
+      // under the user's own kubeconfig.
+      const response = await fetch(`${LOCAL_AGENT_HTTP_URL}/gpu-health-cronjob`, {
         method: 'DELETE',
         headers: {
           'Content-Type': 'application/json',


### PR DESCRIPTION
## Summary

Phase 3e of the pod-SA -> kc-agent refactor (#7993). Migrates the GPU health-check CronJob install/uninstall flow off the backend pod ServiceAccount.

## What's moving

**Backend (pkg/api/handlers/mcp_resources.go) — removed:**
- ``InstallGPUHealthCronJob``
- ``UninstallGPUHealthCronJob``

Routes ``POST /api/mcp/gpu-nodes/health/cronjob`` and ``DELETE /api/mcp/gpu-nodes/health/cronjob`` are removed from ``pkg/api/server.go``. ``GET`` routes for status and results stay (read endpoints — Phase 4.5 scope).

**kc-agent (new file pkg/agent/server_gpu_health.go):**
- ``/gpu-health-cronjob`` handles POST (install) and DELETE (uninstall) via ``MultiClusterClient.InstallGPUHealthCronJob`` / ``UninstallGPUHealthCronJob``.
- Mirrors backend request body shapes and validation exactly (cluster required, schedule 5-field cron, tier 1-4).
- ``isValidCronScheduleAgent`` re-implemented inside ``pkg/agent`` because the agent cannot import ``pkg/api/handlers``. Kept in lockstep until those validators are shared.

**Frontend:**
- ``web/src/hooks/useCachedData.ts`` ``useGPUHealthCronJob.install`` and ``.uninstall`` now ``fetch(``${LOCAL_AGENT_HTTP_URL}/gpu-health-cronjob\`)`` instead of ``authFetch('/api/mcp/gpu-nodes/health/cronjob')``.
- ``useCachedData.test.ts`` updated — 7 tests switched from mocking ``authFetch`` to mocking ``global.fetch`` via ``vi.stubGlobal``. All 16 ``useGPUHealthCronJob`` tests pass.

## Bonus verification

Also verified the Phase 1 node-label claim — the ``kubestellar.io/group`` label is set inside ``pkg/k8s.DeployWorkload`` (workload.go:940) via ``opts.GroupName``, which kc-agent's ``handleDeployWorkloadHTTP`` already forwards. The claim in the Phase 1 report was correct; no fix needed.

## Verification

- ``go build ./...`` — clean
- ``go test ./pkg/api/handlers/... ./pkg/agent/...`` — passes except pre-existing ``TestRefreshToken``
- ``npm run build`` — clean
- ``npx vitest run src/hooks/__tests__/useCachedData.test.ts -t useGPUHealthCronJob`` — 16 pass

Refs #7993