### PR TITLE
🐛 fix: self-upgrade broadcasts progress:20 only after patch succeeds (#7976)

### DIFF
--- a/pkg/api/handlers/self_upgrade.go
+++ b/pkg/api/handlers/self_upgrade.go
@@ -358,16 +358,12 @@ func (h *SelfUpgradeHandler) TriggerUpgrade(c *fiber.Ctx) error {
 
 	slog.Info("[self-upgrade] upgrading deployment", "namespace", namespace, "deployment", dep.Name, "from", currentImage, "to", newImage)
 
-	// Broadcast progress to all WebSocket clients
-	h.hub.BroadcastAll(Message{
-		Type: "update_progress",
-		Data: map[string]any{
-			"status":   "running",
-			"step":     1,
-			"progress": 20,
-			"message":  fmt.Sprintf("Patching deployment image to %s", req.ImageTag),
-		},
-	})
+	// #7976: Do NOT broadcast a progress event here. Earlier versions emitted
+	// `progress: 20` with a "Patching deployment image to X" message BEFORE
+	// the Patch call, which gave clients a false "something already happened"
+	// signal when the patch subsequently failed (RBAC, API server error,
+	// etc.). Progress events must only fire after the state they describe is
+	// actually true — so we wait until Patch returns successfully.
 
 	// Build JSON patch to update the container image
 	patch := []map[string]any{
@@ -394,6 +390,9 @@ func (h *SelfUpgradeHandler) TriggerUpgrade(c *fiber.Ctx) error {
 	)
 	if err != nil {
 		slog.Error("[self-upgrade] patch failed", "error", err)
+		// Terminal error — no intermediate progress was claimed, so clients
+		// transition directly from "idle" to "failed" without a misleading
+		// 20% checkpoint.
 		h.hub.BroadcastAll(Message{
 			Type: "update_progress",
 			Data: map[string]any{
@@ -409,6 +408,19 @@ func (h *SelfUpgradeHandler) TriggerUpgrade(c *fiber.Ctx) error {
 
 	slog.Info("[self-upgrade] Deployment patched successfully, rollout starting")
 
+	// Broadcast progress: the patch has actually been applied. We emit step 1
+	// (image patched) and step 2 (waiting for rollout) back-to-back so the UI
+	// still sees a smooth progression, but neither event is sent unless the
+	// underlying state it describes is true.
+	h.hub.BroadcastAll(Message{
+		Type: "update_progress",
+		Data: map[string]any{
+			"status":   "running",
+			"step":     1,
+			"progress": 20,
+			"message":  fmt.Sprintf("Deployment image patched to %s", req.ImageTag),
+		},
+	})
 	// Broadcast success — the pod will be terminated shortly by the rollout
 	h.hub.BroadcastAll(Message{
 		Type: "update_progress",


### PR DESCRIPTION
## Summary

`SelfUpgradeHandler.TriggerUpgrade` emitted a `progress: 20` WebSocket message ("Patching deployment image to X") **before** calling `Deployments.Patch`. If the patch then failed (RBAC denial, API-server error, network issue, etc.), clients observed "20% — Patching..." immediately followed by a "failed" terminal event, leaving the misleading impression that something had already been mutated when nothing had.

This PR moves the broadcast to fire only **after** `Patch` returns successfully and rewords it in the past tense.

## Reproduction (before)

1. Deploy console without `selfUpgrade.enabled=true` (or with patch RBAC stripped).
2. As an admin user, POST `/api/self-upgrade/trigger` with a valid `imageTag`.
3. Open a WebSocket subscriber.

**Observed (buggy) sequence:**
```
{ status: "running", step: 1, progress: 20, message: "Patching deployment image to vX" }
{ status: "failed",                        message: "Failed to patch deployment", error: "...forbidden..." }
```
The 20% checkpoint is a lie — nothing was patched.

## After

**Failure path:**
```
{ status: "failed", message: "Failed to patch deployment", error: "...forbidden..." }
```
No intermediate progress claimed. UI transitions directly idle → failed.

**Success path:**
```
{ status: "running", step: 1, progress: 20, message: "Deployment image patched to vX" }
{ status: "running", step: 2, progress: 60, message: "Deployment patched — waiting for rollout" }
```
Both events describe states that are actually true at the moment of broadcast.

## Files changed

- `pkg/api/handlers/self_upgrade.go` — restructure `TriggerUpgrade` to broadcast `progress: 20` after the successful `Patch` call instead of before it.

Fixes #7976

## Test plan

- [x] `go build ./...` clean
- [x] `cd web && npm run build` clean
- [x] `npm run lint` — no new errors introduced (pre-existing errors in `CompliancePerfTest.tsx` / `UnifiedDashboardTest.tsx` unrelated)
- [ ] Manual: in a cluster without patch RBAC, trigger upgrade and confirm WS subscriber sees only the terminal `failed` event with no preceding `progress: 20`