### PR TITLE
🐛 fix: GlobeAnimation falls back gracefully when WebGL init is delayed (#8004)

### DIFF
--- a/web/src/components/animations/globe/GlobeAnimation.tsx
+++ b/web/src/components/animations/globe/GlobeAnimation.tsx
@@ -18,12 +18,34 @@ interface GlobeAnimationProps {
 /** Simulated loading delay before revealing the 3-D globe in milliseconds */
 const GLOBE_LOAD_DELAY_MS = 1000
 
-/** Check if WebGL is available — returns false in headless browsers and CI */
+/** Delay between WebGL context acquisition retries in milliseconds.
+ *  In containerized production environments the GPU rendering context
+ *  can be momentarily unavailable while the page is hydrating and
+ *  lazy chunks are still resolving, so we poll for a short window
+ *  before giving up and showing the static fallback. */
+const WEBGL_RETRY_INTERVAL_MS = 100
+
+/** Maximum number of WebGL detection attempts before falling back.
+ *  WEBGL_RETRY_INTERVAL_MS * WEBGL_MAX_RETRIES = total wait window. */
+const WEBGL_MAX_RETRIES = 20
+
+/** WebGL detection result. */
+type WebGLState = "checking" | "available" | "unavailable"
+
+/** Check if WebGL is available — returns false in headless browsers and CI.
+ *  We intentionally do NOT use `instanceof WebGLRenderingContext` because in
+ *  some containerized/SSR-hydrated environments the global constructor is
+ *  briefly undefined or comes from a different realm than the context object,
+ *  which causes the check to return false even when WebGL is functional. */
 function isWebGLAvailable(): boolean {
   try {
-    const canvas = document.createElement('canvas')
-    const gl = canvas.getContext('webgl2') || canvas.getContext('webgl') || canvas.getContext('experimental-webgl')
-    return gl instanceof WebGLRenderingContext || gl instanceof WebGL2RenderingContext
+    if (typeof document === "undefined") return false
+    const canvas = document.createElement("canvas")
+    const gl =
+      canvas.getContext("webgl2") ||
+      canvas.getContext("webgl") ||
+      canvas.getContext("experimental-webgl")
+    return gl !== null && typeof gl === "object"
   } catch {
     return false
   }
@@ -40,17 +62,51 @@ const GlobeAnimation = ({
   style = {},
 }: GlobeAnimationProps) => {
   const [isLoaded, setIsLoaded] = useState(false)
-  const [hasWebGL] = useState(isWebGLAvailable)
+  const [webGLState, setWebGLState] = useState<WebGLState>("checking")
+
+  // Poll for WebGL availability after mount. Retries handle the production
+  // race where the canvas/GPU context is not ready on the first tick after
+  // hydration in containerized deployments.
+  useEffect(() => {
+    let attempts = 0
+    let cancelled = false
+
+    const check = () => {
+      if (cancelled) return
+      if (isWebGLAvailable()) {
+        setWebGLState("available")
+        return
+      }
+      attempts += 1
+      if (attempts >= WEBGL_MAX_RETRIES) {
+        setWebGLState("unavailable")
+        return
+      }
+      window.setTimeout(check, WEBGL_RETRY_INTERVAL_MS)
+    }
+
+    check()
+    return () => {
+      cancelled = true
+    }
+  }, [])
 
   useEffect(() => {
-    if (!hasWebGL) return
+    if (webGLState !== "available") return
     // Simulate loading delay to show progressive animation
     const timer = setTimeout(() => {
       setIsLoaded(true)
     }, GLOBE_LOAD_DELAY_MS)
 
     return () => clearTimeout(timer)
-  }, [hasWebGL])
+  }, [webGLState])
+
+  const hasWebGL = webGLState === "available"
+  const webGLFailed = webGLState === "unavailable"
+  // Hide the loader once the globe is loaded OR once we've decided to show
+  // the static fallback — otherwise the spinner sits forever on top of the
+  // gradient fallback circle in production.
+  const showLoaderNow = showLoader && !isLoaded && !webGLFailed
 
   return (
     <div
@@ -58,15 +114,19 @@ const GlobeAnimation = ({
       style={{ width, height, ...style }}
     >
       {/* Loader */}
-      {showLoader && !isLoaded && (
+      {showLoaderNow && (
         <div className="absolute inset-0 flex items-center justify-center bg-transparent z-10">
           <GlobeLoader />
         </div>
       )}
 
-      {/* Three.js Canvas — skipped when WebGL is unavailable (headless browsers, CI) */}
-      {!hasWebGL ? (
-        <div className="absolute inset-0 flex items-center justify-center">
+      {/* Static fallback — shown whenever WebGL is unavailable after retries
+          (headless browsers, CI, GPU-less containers, denied contexts). */}
+      {webGLFailed ? (
+        <div
+          className="absolute inset-0 flex items-center justify-center"
+          data-testid="globe-fallback"
+        >
           <div className="w-32 h-32 rounded-full bg-gradient-to-br from-purple-500/20 to-blue-500/20 border border-purple-500/30" />
         </div>
       ) : null}


### PR DESCRIPTION
## Root cause

- `GlobeAnimation` detected WebGL once via `useState(isWebGLAvailable)`, so the check ran during the very first render — before the canvas/GPU context is ready in containerized production deployments where lazy chunks are still resolving.
- The detection used `instanceof WebGLRenderingContext`, which can return `false` even when WebGL is functional in environments where the global constructor is briefly undefined or the context object comes from a different realm than the global ctor (observed in production cluster deploys, not in `npm run dev`).
- Once that initial detection fell through to `false`, the loader rendered indefinitely on top of the static fallback because the loader was gated only on `!isLoaded`, never on the WebGL failure state. Result: spinner-forever in some envs, blank canvas in others, fallback gradient circle never visible.

## Fix

- Replace one-shot detection with a polled retry after mount — `WEBGL_MAX_RETRIES * WEBGL_RETRY_INTERVAL_MS` gives a 2s window for the GPU/canvas context to come online.
- Drop the realm-fragile `instanceof` check in favor of a truthy context-object test (matches what three.js / `@react-three/fiber` actually need).
- Track three explicit states (`checking | available | unavailable`) and hide the loader once we've decided to show the static fallback, so the gradient circle actually appears when WebGL never becomes available.
- Guard against `document` being undefined for SSR safety.
- All timing values are named constants with comments. No feature flag — root-cause fix.

## Verification

- `cd web && npm run build` — passes (post-build safety checks pass).
- `cd web && npx eslint src/components/animations/globe/GlobeAnimation.tsx` — clean. Pre-existing lint errors elsewhere in the tree are unrelated to this change.
- Visual dev-server check skipped in this container (no display); behavior preserved for the happy path because `webGLState` resolves to `available` on the first poll in browsers where WebGL is immediately ready, restoring the previous render path identically.

Fixes #8004