### PR TITLE
🐛 fix: address Copilot review on namespace refactor (#8034)

### DIFF
--- a/pkg/agent/server_http.go
+++ b/pkg/agent/server_http.go
@@ -14,11 +14,43 @@ import (
 	"sync"
 	"time"
 
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+
 	"github.com/kubestellar/console/pkg/agent/protocol"
 	"github.com/kubestellar/console/pkg/k8s"
 	"github.com/kubestellar/console/pkg/models"
 	"github.com/kubestellar/console/pkg/settings"
 )
+
+// mapK8sErrorToHTTP translates a Kubernetes API error into the appropriate
+// HTTP status + sanitized user-facing message. Opaque 500s leak apiserver
+// internals; instead we map the well-known StatusError kinds so callers can
+// render sensible UI (e.g. "already exists" -> 409 with a friendly message).
+// Non-status errors fall through to 500 with a generic message — the real
+// error is still logged by the caller via slog.Warn. #8034 Copilot followup
+// to PR #8028.
+func mapK8sErrorToHTTP(err error) (int, string) {
+	switch {
+	case k8serrors.IsAlreadyExists(err):
+		return http.StatusConflict, err.Error()
+	case k8serrors.IsForbidden(err):
+		return http.StatusForbidden, err.Error()
+	case k8serrors.IsInvalid(err):
+		return http.StatusBadRequest, err.Error()
+	case k8serrors.IsNotFound(err):
+		return http.StatusNotFound, err.Error()
+	case k8serrors.IsUnauthorized(err):
+		return http.StatusUnauthorized, err.Error()
+	case k8serrors.IsConflict(err):
+		return http.StatusConflict, err.Error()
+	case k8serrors.IsTimeout(err), k8serrors.IsServerTimeout(err):
+		return http.StatusGatewayTimeout, err.Error()
+	case k8serrors.IsServiceUnavailable(err):
+		return http.StatusServiceUnavailable, err.Error()
+	default:
+		return http.StatusInternalServerError, "internal server error"
+	}
+}
 
 // writeJSON encodes v as JSON to w and logs any encoding error.
 // After headers have been written, the only safe action is to log the failure.
@@ -339,14 +371,19 @@ func (s *Server) createNamespaceHTTP(w http.ResponseWriter, r *http.Request) {
 		writeJSON(w, map[string]interface{}{"success": false, "error": "invalid request body"})
 		return
 	}
-	if req.Cluster == "" {
+	// #8034 Copilot followup: field-level validation. Previously cluster+name
+	// were only checked for emptiness and every other failure returned an
+	// opaque 500. Reject malformed input at the HTTP boundary so the UI can
+	// render a specific error and so we don't lean on the apiserver for
+	// validation.
+	if err := validateKubeContext(req.Cluster); err != nil {
 		w.WriteHeader(http.StatusBadRequest)
-		writeJSON(w, map[string]interface{}{"success": false, "error": "cluster is required"})
+		writeJSON(w, map[string]interface{}{"success": false, "error": err.Error()})
 		return
 	}
-	if req.Name == "" {
+	if err := validateDNS1123Label("name", req.Name); err != nil {
 		w.WriteHeader(http.StatusBadRequest)
-		writeJSON(w, map[string]interface{}{"success": false, "error": "name is required"})
+		writeJSON(w, map[string]interface{}{"success": false, "error": err.Error()})
 		return
 	}
 
@@ -356,8 +393,9 @@ func (s *Server) createNamespaceHTTP(w http.ResponseWriter, r *http.Request) {
 	ns, err := s.k8sClient.CreateNamespace(ctx, req.Cluster, req.Name, req.Labels)
 	if err != nil {
 		slog.Warn("error creating namespace", "cluster", req.Cluster, "name", req.Name, "error", err)
-		w.WriteHeader(http.StatusInternalServerError)
-		writeJSON(w, map[string]interface{}{"success": false, "error": err.Error(), "source": "agent"})
+		status, msg := mapK8sErrorToHTTP(err)
+		w.WriteHeader(status)
+		writeJSON(w, map[string]interface{}{"success": false, "error": msg, "source": "agent"})
 		return
 	}
 	writeJSON(w, map[string]interface{}{"success": true, "namespace": ns, "source": "agent"})
@@ -381,8 +419,9 @@ func (s *Server) deleteNamespaceHTTP(w http.ResponseWriter, r *http.Request) {
 
 	if err := s.k8sClient.DeleteNamespace(ctx, cluster, name); err != nil {
 		slog.Warn("error deleting namespace", "cluster", cluster, "name", name, "error", err)
-		w.WriteHeader(http.StatusInternalServerError)
-		writeJSON(w, map[string]interface{}{"success": false, "error": err.Error(), "source": "agent"})
+		status, msg := mapK8sErrorToHTTP(err)
+		w.WriteHeader(status)
+		writeJSON(w, map[string]interface{}{"success": false, "error": msg, "source": "agent"})
 		return
 	}
 	writeJSON(w, map[string]interface{}{"success": true, "cluster": cluster, "name": name, "source": "agent"})
@@ -1173,9 +1212,12 @@ func (s *Server) createRoleBindingHTTP(w http.ResponseWriter, r *http.Request) {
 		writeJSON(w, map[string]interface{}{"success": false, "error": "invalid request body"})
 		return
 	}
-	if req.Cluster == "" {
+	// #8034 Copilot followup: validate cluster context at the HTTP boundary
+	// so we return a specific 400 instead of passing empty/malformed values
+	// down to the apiserver and getting back an opaque 500.
+	if err := validateKubeContext(req.Cluster); err != nil {
 		w.WriteHeader(http.StatusBadRequest)
-		writeJSON(w, map[string]interface{}{"success": false, "error": "cluster is required"})
+		writeJSON(w, map[string]interface{}{"success": false, "error": err.Error()})
 		return
 	}
 	if req.SubjectKind == "" || req.SubjectName == "" {
@@ -1228,8 +1270,9 @@ func (s *Server) createRoleBindingHTTP(w http.ResponseWriter, r *http.Request) {
 
 	if err := s.k8sClient.CreateRoleBinding(ctx, k8sReq); err != nil {
 		slog.Warn("error creating role binding", "cluster", req.Cluster, "namespace", req.Namespace, "name", bindingName, "error", err)
-		w.WriteHeader(http.StatusInternalServerError)
-		writeJSON(w, map[string]interface{}{"success": false, "error": err.Error(), "source": "agent"})
+		status, msg := mapK8sErrorToHTTP(err)
+		w.WriteHeader(status)
+		writeJSON(w, map[string]interface{}{"success": false, "error": msg, "source": "agent"})
 		return
 	}
 	writeJSON(w, map[string]interface{}{"success": true, "roleBinding": bindingName, "source": "agent"})
@@ -1260,8 +1303,9 @@ func (s *Server) deleteRoleBindingHTTP(w http.ResponseWriter, r *http.Request) {
 
 	if err := s.k8sClient.DeleteRoleBinding(ctx, cluster, namespace, name, isCluster); err != nil {
 		slog.Warn("error deleting role binding", "cluster", cluster, "namespace", namespace, "name", name, "isCluster", isCluster, "error", err)
-		w.WriteHeader(http.StatusInternalServerError)
-		writeJSON(w, map[string]interface{}{"success": false, "error": err.Error(), "source": "agent"})
+		status, msg := mapK8sErrorToHTTP(err)
+		w.WriteHeader(status)
+		writeJSON(w, map[string]interface{}{"success": false, "error": msg, "source": "agent"})
 		return
 	}
 	writeJSON(w, map[string]interface{}{"success": true, "cluster": cluster, "namespace": namespace, "name": name, "isCluster": isCluster, "source": "agent"})

--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -893,7 +893,9 @@ func (s *Server) setupRoutes() {
 	api.Get("/permissions/summary", rbac.GetPermissionsSummary)
 	api.Post("/rbac/can-i", rbac.CheckCanI)
 
-	// Namespace management routes (admin only).
+	// Namespace read routes. GET /namespaces is viewer-or-above (see
+	// ListNamespaces's requireViewerOrAbove check) and
+	// GET /namespaces/:name/access is admin-only (see GetNamespaceAccess).
 	// POST/DELETE /namespaces and POST/DELETE /namespaces/:name/access were
 	// migrated to kc-agent in #7993 Phases 1.5 and 2 — they now run under the
 	// user's kubeconfig instead of the backend pod ServiceAccount.

--- a/web/src/components/namespaces/CreateNamespaceModal.tsx
+++ b/web/src/components/namespaces/CreateNamespaceModal.tsx
@@ -140,9 +140,9 @@ export function CreateNamespaceModal({ clusters, onClose, onCreated }: CreateNam
           </div>
 
           {/* #8034 Copilot followup: the initial-access UI was removed in the
-             namespace refactor (#8028) because kc-agent's POST /namespaces
-             handler does not accept an initialAccess field. Grants now flow
-             through GrantAccessModal after the namespace is created. */}
+            * namespace refactor (#8028) because kc-agent's POST /namespaces
+            * handler does not accept an initialAccess field. Grants now flow
+            * through GrantAccessModal after the namespace is created. */}
         </div>
       </BaseModal.Content>
 

--- a/web/src/components/namespaces/CreateNamespaceModal.tsx
+++ b/web/src/components/namespaces/CreateNamespaceModal.tsx
@@ -1,46 +1,15 @@
 import { useState } from 'react'
-import { Folder, UserPlus, Shield, X, Loader2 } from 'lucide-react'
+import { Folder, Loader2 } from 'lucide-react'
 import { Button } from '../ui/Button'
 import { BaseModal, ConfirmDialog } from '../../lib/modals'
 import { useTranslation } from 'react-i18next'
-import { LOCAL_AGENT_HTTP_URL, STORAGE_KEY_TOKEN } from '../../lib/constants'
-import { FETCH_DEFAULT_TIMEOUT_MS } from '../../lib/constants/network'
-
-// #7993 Phase 2: namespace create is a user-initiated write that must run
-// under the user's kubeconfig via kc-agent, not the backend pod ServiceAccount.
-function agentAuthHeaders(): Record<string, string> {
-  const token = localStorage.getItem(STORAGE_KEY_TOKEN)
-  const headers: Record<string, string> = { 'Content-Type': 'application/json' }
-  if (token) headers['Authorization'] = `Bearer ${token}`
-  return headers
-}
-
-const AVAILABLE_USERS = [
-  'admin@example.com',
-  'developer@example.com',
-  'operator@example.com',
-  'viewer@example.com',
-  'ci-bot@example.com',
-]
-
-const AVAILABLE_GROUPS = [
-  'developers',
-  'operators',
-  'viewers',
-  'platform-team',
-  'sre-team',
-]
+import { LOCAL_AGENT_HTTP_URL } from '../../lib/constants'
+import { authFetch } from '../../lib/api'
 
 interface CreateNamespaceModalProps {
   clusters: string[]
   onClose: () => void
   onCreated: (cluster: string) => void
-}
-
-interface InitialAccessEntry {
-  type: 'User' | 'Group'
-  name: string
-  role: 'cluster-admin' | 'admin' | 'edit' | 'view'
 }
 
 export function CreateNamespaceModal({ clusters, onClose, onCreated }: CreateNamespaceModalProps) {
@@ -50,31 +19,7 @@ export function CreateNamespaceModal({ clusters, onClose, onCreated }: CreateNam
   const [teamLabel, setTeamLabel] = useState('')
   const [creating, setCreating] = useState(false)
   const [error, setError] = useState<string | null>(null)
-  const [initialAccess, setInitialAccess] = useState<InitialAccessEntry[]>([])
-  const [showUserDropdown, setShowUserDropdown] = useState(false)
-  const [showGroupDropdown, setShowGroupDropdown] = useState(false)
-
-  const addUserAccess = (user: string) => {
-    if (!initialAccess.some(a => a.type === 'User' && a.name === user)) {
-      setInitialAccess([...initialAccess, { type: 'User', name: user, role: 'edit' }])
-    }
-    setShowUserDropdown(false)
-  }
-
-  const addGroupAccess = (group: string) => {
-    if (!initialAccess.some(a => a.type === 'Group' && a.name === group)) {
-      setInitialAccess([...initialAccess, { type: 'Group', name: group, role: 'edit' }])
-    }
-    setShowGroupDropdown(false)
-  }
-
-  const removeAccess = (index: number) => {
-    setInitialAccess(initialAccess.filter((_, i) => i !== index))
-  }
-
-  const updateAccessRole = (index: number, role: 'cluster-admin' | 'admin' | 'edit' | 'view') => {
-    setInitialAccess(initialAccess.map((a, i) => i === index ? { ...a, role } : a))
-  }
+  const [showDiscardConfirm, setShowDiscardConfirm] = useState(false)
 
   const handleCreate = async () => {
     if (!name || !cluster) return
@@ -89,18 +34,19 @@ export function CreateNamespaceModal({ clusters, onClose, onCreated }: CreateNam
       }
 
       // #7993 Phase 2: POST to kc-agent so the operation runs under the
-      // user's kubeconfig. kc-agent does not accept the `initialAccess` field;
-      // the legacy backend silently ignored it too, so no behavior is lost.
-      // Grants still flow through GrantAccessModal's POST /rolebindings call.
-      const res = await fetch(`${LOCAL_AGENT_HTTP_URL}/namespaces`, {
+      // user's kubeconfig. kc-agent does not accept an initialAccess field —
+      // grants flow through GrantAccessModal's POST /rolebindings call once
+      // the namespace exists. #8034 Copilot followup: switched the hand-rolled
+      // agentAuthHeaders() helper to authFetch() which handles token injection
+      // and the default fetch timeout.
+      const res = await authFetch(`${LOCAL_AGENT_HTTP_URL}/namespaces`, {
         method: 'POST',
-        headers: agentAuthHeaders(),
+        headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
           cluster,
           name,
           labels: Object.keys(labels).length > 0 ? labels : undefined,
         }),
-        signal: AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS),
       })
       if (!res.ok) {
         const errorData = await res.json().catch(() => ({}))
@@ -115,23 +61,13 @@ export function CreateNamespaceModal({ clusters, onClose, onCreated }: CreateNam
     }
   }
 
-  const availableUsers = AVAILABLE_USERS.filter(
-    u => !initialAccess.some(a => a.type === 'User' && a.name === u)
-  )
-
-  const availableGroups = AVAILABLE_GROUPS.filter(
-    g => !initialAccess.some(a => a.type === 'Group' && a.name === g)
-  )
-
-  const [showDiscardConfirm, setShowDiscardConfirm] = useState(false)
-
   const forceClose = () => {
     setShowDiscardConfirm(false)
     onClose()
   }
 
   const handleClose = () => {
-    if (name.trim() !== '' || teamLabel.trim() !== '' || initialAccess.length > 0) {
+    if (name.trim() !== '' || teamLabel.trim() !== '') {
       setShowDiscardConfirm(true)
       return
     }
@@ -203,145 +139,10 @@ export function CreateNamespaceModal({ clusters, onClose, onCreated }: CreateNam
             />
           </div>
 
-          {/* Initial Access Section */}
-          <div>
-            <label className="block text-sm font-medium text-muted-foreground mb-2">
-              Grant Initial Access (optional)
-            </label>
-
-            {/* Add User/Group buttons */}
-            <div className="flex gap-2 mb-3">
-              <div className="relative">
-                <button
-                  onClick={() => setShowUserDropdown(!showUserDropdown)}
-                  className="flex items-center gap-1 px-3 py-1.5 rounded-lg bg-blue-500/20 text-blue-400 hover:bg-blue-500/30 transition-colors text-sm"
-                >
-                  <UserPlus className="w-4 h-4" />
-                  Add User
-                </button>
-                {showUserDropdown && availableUsers.length > 0 && (
-                  <div
-                    role="listbox"
-                    aria-label="Select user"
-                    className="absolute z-10 top-full left-0 mt-1 w-48 bg-card border border-border rounded-lg shadow-lg max-h-48 overflow-y-auto"
-                    onKeyDown={(e) => {
-                      if (e.key !== 'ArrowDown' && e.key !== 'ArrowUp') return
-                      e.preventDefault()
-                      const items = e.currentTarget.querySelectorAll<HTMLElement>('[role="option"]')
-                      const idx = Array.from(items).indexOf(document.activeElement as HTMLElement)
-                      if (e.key === 'ArrowDown') items[Math.min(idx + 1, items.length - 1)]?.focus()
-                      else items[Math.max(idx - 1, 0)]?.focus()
-                    }}
-                  >
-                    {availableUsers.map(user => (
-                      <button
-                        key={user}
-                        role="option"
-                        aria-selected={false}
-                        onClick={() => addUserAccess(user)}
-                        className="w-full px-3 py-2 text-left text-sm text-white hover:bg-secondary/50 transition-colors"
-                      >
-                        {user}
-                      </button>
-                    ))}
-                  </div>
-                )}
-              </div>
-              <div className="relative">
-                <Button
-                  variant="accent"
-                  onClick={() => setShowGroupDropdown(!showGroupDropdown)}
-                  icon={<Shield className="w-4 h-4" />}
-                >
-                  Add Group
-                </Button>
-                {showGroupDropdown && availableGroups.length > 0 && (
-                  <div
-                    role="listbox"
-                    aria-label="Select group"
-                    className="absolute z-10 top-full left-0 mt-1 w-48 bg-card border border-border rounded-lg shadow-lg max-h-48 overflow-y-auto"
-                    onKeyDown={(e) => {
-                      if (e.key !== 'ArrowDown' && e.key !== 'ArrowUp') return
-                      e.preventDefault()
-                      const items = e.currentTarget.querySelectorAll<HTMLElement>('[role="option"]')
-                      const idx = Array.from(items).indexOf(document.activeElement as HTMLElement)
-                      if (e.key === 'ArrowDown') items[Math.min(idx + 1, items.length - 1)]?.focus()
-                      else items[Math.max(idx - 1, 0)]?.focus()
-                    }}
-                  >
-                    {availableGroups.map(group => (
-                      <button
-                        key={group}
-                        role="option"
-                        aria-selected={false}
-                        onClick={() => addGroupAccess(group)}
-                        className="w-full px-3 py-2 text-left text-sm text-white hover:bg-secondary/50 transition-colors"
-                      >
-                        {group}
-                      </button>
-                    ))}
-                  </div>
-                )}
-              </div>
-            </div>
-
-            {/* Close dropdowns overlay */}
-            {(showUserDropdown || showGroupDropdown) && (
-              <button
-                onClick={() => {
-                  setShowUserDropdown(false)
-                  setShowGroupDropdown(false)
-                }}
-                className="fixed inset-0 z-0"
-                aria-label="Close dropdown"
-              />
-            )}
-
-            {/* Selected access list */}
-            {initialAccess.length > 0 && (
-              <div className="space-y-2">
-                {initialAccess.map((entry, index) => (
-                  <div
-                    key={`${entry.type}-${entry.name}`}
-                    className="flex items-center justify-between p-2 rounded-lg bg-secondary/30"
-                  >
-                    <div className="flex items-center gap-2">
-                      <span className={`text-xs px-1.5 py-0.5 rounded ${
-                        entry.type === 'User' ? 'bg-blue-500/20 text-blue-400' : 'bg-purple-500/20 text-purple-400'
-                      }`}>
-                        {entry.type}
-                      </span>
-                      <span className="text-sm text-white">{entry.name}</span>
-                    </div>
-                    <div className="flex items-center gap-2">
-                      <select
-                        value={entry.role}
-                        onChange={(e) => updateAccessRole(index, e.target.value as 'cluster-admin' | 'admin' | 'edit' | 'view')}
-                        className="px-2 py-1 text-xs rounded bg-secondary border border-border text-white"
-                      >
-                        <option value="cluster-admin">{t('namespaces.roleFullAdmin')}</option>
-                        <option value="admin">{t('namespaces.roleAdminShort')}</option>
-                        <option value="edit">{t('common.edit')}</option>
-                        <option value="view">{t('common.view')}</option>
-                      </select>
-                      <button
-                        onClick={() => removeAccess(index)}
-                        className="p-1 rounded text-muted-foreground hover:text-red-400 hover:bg-red-500/10"
-                      >
-                        <X className="w-4 h-4" />
-                      </button>
-                    </div>
-                  </div>
-                ))}
-              </div>
-            )}
-
-            {initialAccess.length === 0 && (
-              <p className="text-xs text-muted-foreground">
-                No initial access configured. You can add users/groups after creation.
-              </p>
-            )}
-          </div>
+          {/* #8034 Copilot followup: the initial-access UI was removed in the
+             namespace refactor (#8028) because kc-agent's POST /namespaces
+             handler does not accept an initialAccess field. Grants now flow
+             through GrantAccessModal after the namespace is created. */}
         </div>
       </BaseModal.Content>
 

--- a/web/src/components/namespaces/GrantAccessModal.tsx
+++ b/web/src/components/namespaces/GrantAccessModal.tsx
@@ -3,18 +3,9 @@ import { Shield, Loader2 } from 'lucide-react'
 import { Button } from '../ui/Button'
 import { BaseModal, ConfirmDialog } from '../../lib/modals'
 import { useTranslation } from 'react-i18next'
-import { LOCAL_AGENT_HTTP_URL, STORAGE_KEY_TOKEN } from '../../lib/constants'
-import { FETCH_DEFAULT_TIMEOUT_MS } from '../../lib/constants/network'
+import { LOCAL_AGENT_HTTP_URL } from '../../lib/constants'
+import { authFetch } from '../../lib/api'
 import type { NamespaceDetails, NamespaceAccessEntry } from './types'
-
-// Bearer token header builder for local-agent requests. Mirrors the
-// per-file helpers in useWorkloads.ts and useUsers.ts. See #7993 Phase 1.5.
-function agentAuthHeaders(): Record<string, string> {
-  const token = localStorage.getItem(STORAGE_KEY_TOKEN)
-  const headers: Record<string, string> = {}
-  if (token) headers['Authorization'] = `Bearer ${token}`
-  return headers
-}
 
 const COMMON_SUBJECTS = {
   User: [
@@ -85,9 +76,12 @@ export function GrantAccessModal({ namespace, existingAccess, onClose, onGranted
       // this switches the only caller over. The agent's /rolebindings POST
       // handler accepts this shape directly and normalizes it into a full
       // CreateRoleBindingRequest before calling the shared pkg/k8s method.
-      const res = await fetch(`${LOCAL_AGENT_HTTP_URL}/rolebindings`, {
+      // #8034 Copilot followup: use authFetch() which already injects the
+      // Bearer token and applies the default fetch timeout, instead of a
+      // per-file agentAuthHeaders() helper.
+      const res = await authFetch(`${LOCAL_AGENT_HTTP_URL}/rolebindings`, {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json', ...agentAuthHeaders() },
+        headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
           cluster: namespace.cluster,
           namespace: namespace.name,
@@ -96,7 +90,6 @@ export function GrantAccessModal({ namespace, existingAccess, onClose, onGranted
           subjectNamespace: subjectKind === 'ServiceAccount' ? subjectNS : undefined,
           role,
         }),
-        signal: AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS),
       })
       if (!res.ok) {
         const errorData = await res.json().catch(() => ({ error: 'Failed to grant access' }))

--- a/web/src/components/namespaces/NamespaceManager.tsx
+++ b/web/src/components/namespaces/NamespaceManager.tsx
@@ -24,20 +24,11 @@ import { useGlobalFilters } from '../../hooks/useGlobalFilters'
 import { ClusterBadge } from '../ui/ClusterBadge'
 import { DashboardHeader } from '../shared/DashboardHeader'
 import { RotatingTip } from '../ui/RotatingTip'
-import { api } from '../../lib/api'
+import { api, authFetch } from '../../lib/api'
 import { useToast } from '../ui/Toast'
 import { useTranslation } from 'react-i18next'
-import { LOCAL_AGENT_HTTP_URL, STORAGE_KEY_TOKEN } from '../../lib/constants'
-import { FETCH_DEFAULT_TIMEOUT_MS, NAMESPACE_ABORT_TIMEOUT_MS } from '../../lib/constants/network'
-
-// Bearer token header builder for local-agent requests. Mirrors the
-// per-file helpers in useWorkloads.ts and useUsers.ts. See #7993 Phase 1.5.
-function agentAuthHeaders(): Record<string, string> {
-  const token = localStorage.getItem(STORAGE_KEY_TOKEN)
-  const headers: Record<string, string> = {}
-  if (token) headers['Authorization'] = `Bearer ${token}`
-  return headers
-}
+import { LOCAL_AGENT_HTTP_URL } from '../../lib/constants'
+import { NAMESPACE_ABORT_TIMEOUT_MS } from '../../lib/constants/network'
 import { NamespaceCard, NamespaceCardSkeleton } from './NamespaceCard'
 import { DeleteConfirmModal } from './DeleteConfirmModal'
 import { CreateNamespaceModal } from './CreateNamespaceModal'
@@ -319,10 +310,12 @@ export function NamespaceManager() {
         cluster: namespaceToDelete.cluster,
         name: namespaceToDelete.name,
       })
-      const res = await fetch(`${LOCAL_AGENT_HTTP_URL}/namespaces?${params}`, {
+      // #8034 Copilot followup: use authFetch() which already injects the
+      // Bearer token (skipping DEMO_TOKEN_VALUE) and applies the default
+      // fetch timeout, instead of a per-file agentAuthHeaders() helper.
+      const res = await authFetch(`${LOCAL_AGENT_HTTP_URL}/namespaces?${params}`, {
         method: 'DELETE',
-        headers: { 'Content-Type': 'application/json', ...agentAuthHeaders() },
-        signal: AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS),
+        headers: { 'Content-Type': 'application/json' },
       })
       if (!res.ok) {
         const errorData = await res.json().catch(() => ({ error: 'unknown error' }))
@@ -361,10 +354,10 @@ export function NamespaceManager() {
         namespace: selectedNamespace.name,
         name: binding.bindingName,
       })
-      const res = await fetch(`${LOCAL_AGENT_HTTP_URL}/rolebindings?${params}`, {
+      // #8034 Copilot followup: use authFetch() which already injects the
+      // Bearer token and applies the default fetch timeout.
+      const res = await authFetch(`${LOCAL_AGENT_HTTP_URL}/rolebindings?${params}`, {
         method: 'DELETE',
-        headers: agentAuthHeaders(),
-        signal: AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS),
       })
       if (!res.ok) {
         const errorData = await res.json().catch(() => ({ error: 'unknown error' }))


### PR DESCRIPTION
## Summary

Follow-up to the phase 2 namespace refactor merged in #8028, addressing the 8 Copilot review comments filed as #8034.

### Backend (`pkg/agent/server_http.go`)
- New `mapK8sErrorToHTTP` helper translates Kubernetes `StatusError` kinds (`IsAlreadyExists` → 409, `IsForbidden` → 403, `IsInvalid` → 400, `IsNotFound` → 404, plus unauthorized/conflict/timeout/unavailable) so the UI no longer sees opaque 500s from create-namespace / rolebinding-grant / rolebinding-revoke.
- `createNamespaceHTTP` now validates the cluster (kubeconfig context) and namespace name (DNS-1123 label) at the HTTP boundary and returns a specific 400 instead of relying on the apiserver.
- `createRoleBindingHTTP` validates `cluster` via `validateKubeContext` before dispatching.
- All four write handlers (namespace create/delete, rolebinding create/delete) route error responses through `mapK8sErrorToHTTP`.

### Routes comment (`pkg/api/server.go`)
- Correct the "admin only" comment: `GET /namespaces` is viewer-or-above and only `GET /namespaces/:name/access` is admin-only.

### Frontend namespace components
- `NamespaceManager.tsx`: move the `NAMESPACE_ABORT_TIMEOUT_MS` import to the top of the file with the other imports, drop the per-file `agentAuthHeaders()` helper, and route the DELETE calls to kc-agent through `authFetch()` from `lib/api` (which already handles token injection, `DEMO_TOKEN_VALUE`, and default fetch timeout).
- `CreateNamespaceModal.tsx`: replace `agentAuthHeaders` with `authFetch`, and remove the stale "Initial Access" UI + state. kc-agent's POST /namespaces doesn't accept an `initialAccess` field, so the legacy UI was building state that never made it into the POST payload. Grants still flow through `GrantAccessModal` after the namespace is created.
- `GrantAccessModal.tsx`: replace `agentAuthHeaders` with `authFetch`.

### Items addressed
1. `pkg/agent/server_http.go:366` — field validation + k8serrors status mapping for createNamespaceHTTP (also applied to deleteNamespaceHTTP).
2. `pkg/agent/server_http.go:1057` — k8serrors status mapping for createRoleBindingHTTP + deleteRoleBindingHTTP + cluster validation.
3. `web/src/components/namespaces/NamespaceManager.tsx:40-41` — NAMESPACE_ABORT_TIMEOUT_MS import moved to the top of the file.
4. `web/src/components/namespaces/NamespaceManager.tsx:40` — agentAuthHeaders replaced with authFetch.
5. `web/src/components/namespaces/CreateNamespaceModal.tsx:15` — agentAuthHeaders replaced with authFetch.
6. `web/src/components/namespaces/CreateNamespaceModal.tsx:103` — stale Initial Access UI + state removed.
7. `web/src/components/namespaces/GrantAccessModal.tsx:18` — agentAuthHeaders replaced with authFetch.
8. `pkg/api/server.go:896` — "admin only" comment corrected to reflect actual RBAC.

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./pkg/agent/... -count=1` passes (pre-existing unrelated handler test failure in `pkg/api/handlers` confirmed against main — not introduced here)
- [x] `cd web && npm run build` passes (including post-build safety checks)
- [x] `npm run lint` produces no new namespace warnings/errors (pre-existing warnings only)
- [x] `npx tsc --noEmit` clean on namespace files
- [ ] Manual: Create a namespace that already exists -> expect HTTP 409 + friendly message (not 500)
- [ ] Manual: Create namespace with invalid DNS label (e.g. `UPPER`) -> expect HTTP 400 at the HTTP boundary

Fixes #8034