### PR TITLE
🐛 fix: address Copilot review on ArgoCD sync phase3c (#8040)

### DIFF
--- a/pkg/agent/endpoint_auth_test.go
+++ b/pkg/agent/endpoint_auth_test.go
@@ -143,6 +143,10 @@ const (
 	// endpointResolveDeps resolves workload dependencies (sensitive — walks RBAC/pods).
 	endpointResolveDeps = "/resolve-deps"
 
+	// endpointArgoCDSync triggers an ArgoCD Application sync (sensitive —
+	// mutating, editor-or-admin gated). Moved to kc-agent in #7993 Phase 3c.
+	endpointArgoCDSync = "/argocd/sync"
+
 	// testTokenValue is the shared secret used to configure auth in tests.
 	testTokenValue = "test-secret-token-42"
 
@@ -207,6 +211,7 @@ var sensitiveEndpoints = []struct {
 	{endpointResourceQuotas, "GET"},
 	{endpointLimitRanges, "GET"},
 	{endpointResolveDeps, "GET"},
+	{endpointArgoCDSync, "POST"},
 }
 
 // endpointsLackingAuth are endpoints that SHOULD require auth but currently
@@ -586,6 +591,7 @@ func resolveEndpointHandler(s *Server, path string) func(http.ResponseWriter, *h
 		endpointPredictionsStats:   s.handlePredictionsStats,
 		endpointDeviceAlerts:       s.handleDeviceAlerts,
 		endpointDeviceAlertsClear:  s.handleDeviceAlertsClear,
+		endpointArgoCDSync:         s.handleArgoCDSync,
 	}
 
 	return handlers[path]

--- a/pkg/agent/server_argocd.go
+++ b/pkg/agent/server_argocd.go
@@ -52,6 +52,10 @@ type agentArgoSyncRequest struct {
 // kubeconfig (#7993 Phase 3c).
 func (s *Server) handleArgoCDSync(w http.ResponseWriter, r *http.Request) {
 	s.setCORSHeaders(w, r)
+	// #8040: setCORSHeaders defaults Access-Control-Allow-Methods to
+	// "GET, OPTIONS" (pkg/agent/server_http.go). This endpoint is POST-only,
+	// so browsers would reject the CORS preflight without this override.
+	w.Header().Set("Access-Control-Allow-Methods", "POST, OPTIONS")
 	w.Header().Set("Content-Type", "application/json")
 	if r.Method == "OPTIONS" {
 		w.WriteHeader(http.StatusOK)
@@ -70,7 +74,8 @@ func (s *Server) handleArgoCDSync(w http.ResponseWriter, r *http.Request) {
 	var req agentArgoSyncRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		w.WriteHeader(http.StatusBadRequest)
-		writeJSON(w, map[string]interface{}{"error": "invalid request body", "success": false})
+		// #8040: match backend TriggerArgoSync error string casing exactly.
+		writeJSON(w, map[string]interface{}{"error": "Invalid request body", "success": false})
 		return
 	}
 
@@ -115,11 +120,12 @@ func (s *Server) handleArgoCDSync(w http.ResponseWriter, r *http.Request) {
 		argoServerURL := s.discoverArgoServerURL(r.Context(), req.Cluster)
 		if argoServerURL != "" {
 			if ok := tryArgoRESTSync(r.Context(), argoServerURL, argoToken, req.AppName); ok {
+				// #8040: success response shape mirrors backend TriggerArgoSync
+				// exactly — no extra `source` field.
 				writeJSON(w, map[string]interface{}{
 					"success": true,
 					"message": "Sync triggered via ArgoCD REST API",
 					"method":  "api",
-					"source":  "agent",
 				})
 				return
 			}
@@ -137,11 +143,11 @@ func (s *Server) handleArgoCDSync(w http.ResponseWriter, r *http.Request) {
 		if err != nil {
 			slog.Warn("[agent ArgoCD] CLI sync failed, falling back to annotation patching", "error", err, "output", string(output))
 		} else {
+			// #8040: success response shape mirrors backend TriggerArgoSync.
 			writeJSON(w, map[string]interface{}{
 				"success": true,
 				"message": "Sync triggered via ArgoCD CLI",
 				"method":  "cli",
-				"source":  "agent",
 			})
 			return
 		}
@@ -194,11 +200,11 @@ func (s *Server) handleArgoCDSync(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// #8040: success response shape mirrors backend TriggerArgoSync.
 	writeJSON(w, map[string]interface{}{
 		"success": true,
 		"message": "Sync triggered via Application resource annotation",
 		"method":  "annotation",
-		"source":  "agent",
 	})
 }
 
@@ -249,10 +255,24 @@ func tryArgoRESTSync(ctx context.Context, argoServerURL, argoToken, appName stri
 }
 
 // discoverArgoServerURL is the kc-agent equivalent of
-// pkg/api/handlers/gitops.go#discoverArgoServerURL. Walks the well-known
-// ArgoCD namespaces looking for the `argocd-server` service and returns its
-// in-cluster DNS URL, or "" if not found.
+// pkg/api/handlers/gitops.go#discoverArgoServerURL.
+//
+// #8040: kc-agent runs on the user's localhost (README notes 127.0.0.1:8585),
+// so the in-cluster DNS name (`argocd-server.<ns>.svc`) returned by the
+// backend-equivalent discovery is not reachable. Callers must therefore be
+// able to override the URL. Order of precedence:
+//  1. ARGOCD_SERVER_URL env var — explicit override, always wins when set.
+//  2. Walks the well-known ArgoCD namespaces for the `argocd-server` service
+//     and returns its in-cluster DNS URL (works when kc-agent is itself
+//     running inside the cluster or when a side-channel makes the DNS
+//     resolvable, e.g. kubectl port-forward or a mesh).
+//  3. Empty string if neither is available — the caller falls back to the
+//     CLI / annotation-patch strategies.
 func (s *Server) discoverArgoServerURL(ctx context.Context, cluster string) string {
+	if override := os.Getenv("ARGOCD_SERVER_URL"); override != "" {
+		return override
+	}
+
 	clientset, err := s.k8sClient.GetClient(cluster)
 	if err != nil {
 		slog.Warn("[agent ArgoCD] server discovery failed: cannot get client", "cluster", cluster, "error", err)
@@ -266,11 +286,14 @@ func (s *Server) discoverArgoServerURL(ctx context.Context, cluster string) stri
 		svc, err := clientset.CoreV1().Services(ns).Get(ctx, "argocd-server", metav1.GetOptions{})
 		if err == nil {
 			if len(svc.Spec.Ports) > 0 {
-				return fmt.Sprintf("https://%s.%s.svc:%d", svc.Name, svc.Namespace, svc.Spec.Ports[0].Port)
+				inClusterURL := fmt.Sprintf("https://%s.%s.svc:%d", svc.Name, svc.Namespace, svc.Spec.Ports[0].Port)
+				slog.Info("[agent ArgoCD] server discovery: found in-cluster service; set ARGOCD_SERVER_URL to override when running kc-agent on localhost",
+					"cluster", cluster, "url", inClusterURL)
+				return inClusterURL
 			}
 			slog.Warn("[agent ArgoCD] server discovery: argocd-server service has no ports", "namespace", ns)
 		}
 	}
-	slog.Info("[agent ArgoCD] server discovery: argocd-server service not found", "cluster", cluster)
+	slog.Info("[agent ArgoCD] server discovery: argocd-server service not found; set ARGOCD_SERVER_URL to point kc-agent at a reachable URL", "cluster", cluster)
 	return ""
 }


### PR DESCRIPTION
## Summary
Addresses Copilot review follow-ups from merged PR #8038 (phase3c kc-agent ArgoCD sync handler migration).

- **Response shape**: removed the extra `source: "agent"` field from all three success responses (REST, CLI, annotation) so the kc-agent `/argocd/sync` response mirrors the backend `TriggerArgoSync` response exactly.
- **Error casing**: body-parse error now reads `"Invalid request body"` (matches backend) instead of `"invalid request body"`.
- **Endpoint auth test**: `/argocd/sync` added to `pkg/agent/endpoint_auth_test.go` `sensitiveEndpoints` so `TestEndpointAuth_{SensitiveEndpointsRejectWithoutToken,SensitiveEndpointsAcceptValidToken,InvalidTokenRejected}` now exercise it.
- **`discoverArgoServerURL()` localhost fix**: kc-agent runs on the user's localhost, so the in-cluster DNS name returned by service discovery isn't reachable. Added an `ARGOCD_SERVER_URL` env-var override (precedence: override > in-cluster discovery > empty), with clearer log lines that tell operators to set the env var.
- **CORS methods override**: `setCORSHeaders()` defaults `Access-Control-Allow-Methods` to `"GET, OPTIONS"`. The POST-only `/argocd/sync` handler now overrides it to `"POST, OPTIONS"` immediately after calling `setCORSHeaders()`, matching the pattern used by every other POST-only handler in `pkg/agent/server_http.go`.

Fixes #8040

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./pkg/agent/... -count=1` passes (62s, including new `/argocd/sync` subtests in `TestEndpointAuth_*`)
- [x] `npm run build` passes (lint errors on unrelated files are preexisting)
- [x] `/argocd/sync` still auth-gated (verified via new `sensitiveEndpoints` entry)

🤖 Generated with [Claude Code](https://claude.com/claude-code)