### PR TITLE
✨ feat: add OpenRouter as AI provider (#7999)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -60,8 +60,18 @@ GOOGLE_API_KEY=
 # Model selection (optional - default: gemini-2.0-flash)
 GEMINI_MODEL=
 
+# OpenRouter API (https://openrouter.ai/keys)
+# Unified OpenAI-compatible gateway to Anthropic, OpenAI, Google, Meta,
+# Mistral, Qwen and other models via a single API key.
+OPENROUTER_API_KEY=
+# Model selection (optional - default: openai/gpt-4o-mini). See
+# https://openrouter.ai/models for the full catalog.
+OPENROUTER_MODEL=
+# Optional base URL override for self-hosted OpenRouter proxies.
+OPENROUTER_BASE_URL=
+
 # Default AI agent (optional - auto-detected based on available keys)
-# Options: claude, openai, gemini
+# Options: claude, openai, gemini, openrouter
 DEFAULT_AGENT=
 
 # ===========================================

--- a/pkg/agent/config.go
+++ b/pkg/agent/config.go
@@ -302,6 +302,8 @@ func getEnvKeyForProvider(provider string) string {
 		return "RAYCAST_API_KEY"
 	case "open-webui":
 		return "OPEN_WEBUI_API_KEY"
+	case "openrouter":
+		return "OPENROUTER_API_KEY"
 	case "goose":
 		return "GOOSE_PROVIDER"
 	default:
@@ -323,6 +325,8 @@ func getModelEnvKeyForProvider(provider string) string {
 		return "CODEIUM_MODEL"
 	case "open-webui":
 		return "OPEN_WEBUI_MODEL"
+	case "openrouter":
+		return "OPENROUTER_MODEL"
 	case "goose":
 		return "GOOSE_MODEL"
 	default:

--- a/pkg/agent/provider_openai_compat.go
+++ b/pkg/agent/provider_openai_compat.go
@@ -11,20 +11,35 @@ import (
 	"strings"
 )
 
-// chatViaOpenAICompatible sends a chat request to an OpenAI-compatible endpoint
+// openAICompatMaxTokens is the default max_tokens value for non-streaming and
+// streaming chat requests against OpenAI-compatible endpoints. Chosen to match
+// the original hardcoded value used by the OpenAI, OpenWebUI and other OpenAI-
+// compatible providers.
+const openAICompatMaxTokens = 4096
+
+// chatViaOpenAICompatible sends a chat request to an OpenAI-compatible endpoint.
+// For endpoints that need extra request headers (e.g. OpenRouter's HTTP-Referer
+// and X-Title) or a default model, use chatViaOpenAICompatibleWithHeaders.
 func chatViaOpenAICompatible(ctx context.Context, req *ChatRequest, providerKey, endpoint, agentName string) (*ChatResponse, error) {
+	return chatViaOpenAICompatibleWithHeaders(ctx, req, providerKey, endpoint, agentName, "", nil)
+}
+
+// chatViaOpenAICompatibleWithHeaders is like chatViaOpenAICompatible but lets
+// the caller inject a default model (used when neither env nor config sets
+// one) and additional request headers such as HTTP-Referer / X-Title.
+func chatViaOpenAICompatibleWithHeaders(ctx context.Context, req *ChatRequest, providerKey, endpoint, agentName, defaultModel string, extraHeaders map[string]string) (*ChatResponse, error) {
 	cm := GetConfigManager()
 	apiKey := cm.GetAPIKey(providerKey)
 	if apiKey == "" {
 		return nil, fmt.Errorf("API key not configured for provider %s", providerKey)
 	}
-	model := cm.GetModel(providerKey, "")
+	model := cm.GetModel(providerKey, defaultModel)
 
 	messages := buildOpenAIMessages(req)
 
 	body := map[string]any{
 		"messages":   messages,
-		"max_tokens": 4096,
+		"max_tokens": openAICompatMaxTokens,
 	}
 	if model != "" {
 		body["model"] = model
@@ -41,6 +56,12 @@ func chatViaOpenAICompatible(ctx context.Context, req *ChatRequest, providerKey,
 	}
 	httpReq.Header.Set("Content-Type", "application/json")
 	httpReq.Header.Set("Authorization", "Bearer "+apiKey)
+	for k, v := range extraHeaders {
+		if k == "" || v == "" {
+			continue
+		}
+		httpReq.Header.Set(k, v)
+	}
 
 	resp, err := newAIProviderHTTPClient().Do(httpReq)
 	if err != nil {
@@ -86,20 +107,28 @@ func chatViaOpenAICompatible(ctx context.Context, req *ChatRequest, providerKey,
 	}, nil
 }
 
-// streamViaOpenAICompatible streams a chat response from an OpenAI-compatible endpoint
+// streamViaOpenAICompatible streams a chat response from an OpenAI-compatible
+// endpoint. For endpoints that need extra request headers or a default model,
+// use streamViaOpenAICompatibleWithHeaders.
 func streamViaOpenAICompatible(ctx context.Context, req *ChatRequest, providerKey, endpoint, agentName string, onChunk func(chunk string)) (*ChatResponse, error) {
+	return streamViaOpenAICompatibleWithHeaders(ctx, req, providerKey, endpoint, agentName, "", onChunk, nil)
+}
+
+// streamViaOpenAICompatibleWithHeaders is like streamViaOpenAICompatible but
+// lets the caller inject a default model and additional request headers.
+func streamViaOpenAICompatibleWithHeaders(ctx context.Context, req *ChatRequest, providerKey, endpoint, agentName, defaultModel string, onChunk func(chunk string), extraHeaders map[string]string) (*ChatResponse, error) {
 	cm := GetConfigManager()
 	apiKey := cm.GetAPIKey(providerKey)
 	if apiKey == "" {
 		return nil, fmt.Errorf("API key not configured for provider %s", providerKey)
 	}
-	model := cm.GetModel(providerKey, "")
+	model := cm.GetModel(providerKey, defaultModel)
 
 	messages := buildOpenAIMessages(req)
 
 	body := map[string]any{
 		"messages":   messages,
-		"max_tokens": 4096,
+		"max_tokens": openAICompatMaxTokens,
 		"stream":     true,
 	}
 	if model != "" {
@@ -117,6 +146,12 @@ func streamViaOpenAICompatible(ctx context.Context, req *ChatRequest, providerKe
 	}
 	httpReq.Header.Set("Content-Type", "application/json")
 	httpReq.Header.Set("Authorization", "Bearer "+apiKey)
+	for k, v := range extraHeaders {
+		if k == "" || v == "" {
+			continue
+		}
+		httpReq.Header.Set(k, v)
+	}
 
 	resp, err := newAIProviderHTTPClient().Do(httpReq)
 	if err != nil {

--- a/pkg/agent/provider_openrouter.go
+++ b/pkg/agent/provider_openrouter.go
@@ -1,0 +1,109 @@
+package agent
+
+import (
+	"context"
+	"os"
+)
+
+// OpenRouter exposes an OpenAI-compatible chat completions API that fans out
+// to Anthropic, OpenAI, Google, Meta, Mistral, Qwen and other models via a
+// single API key. See https://openrouter.ai/docs for details.
+//
+// Because the wire format is OpenAI-compatible, the provider reuses the
+// shared chatViaOpenAICompatible* helpers. The only OpenRouter-specific bits
+// are (a) the default base URL, (b) a curated default model suited to chat /
+// reasoning tasks, and (c) two optional headers OpenRouter uses to attribute
+// requests on its public leaderboard.
+
+const (
+	// openRouterProviderKey is the config-manager key used for the API key
+	// and model preference on disk and in the env-var lookup tables.
+	openRouterProviderKey = "openrouter"
+
+	// openRouterDefaultBaseURL is the public OpenRouter v1 base URL.
+	// It can be overridden with the OPENROUTER_BASE_URL environment
+	// variable for self-hosted / enterprise OpenRouter installs.
+	openRouterDefaultBaseURL = "https://openrouter.ai/api/v1"
+
+	// openRouterChatCompletionsPath is appended to the base URL to form the
+	// OpenAI-compatible chat completions endpoint.
+	openRouterChatCompletionsPath = "/chat/completions"
+
+	// openRouterDefaultModel is a sensible, inexpensive, widely-available
+	// default. Users can pick any model listed at https://openrouter.ai/models
+	// via the OPENROUTER_MODEL env var or the settings UI.
+	openRouterDefaultModel = "openai/gpt-4o-mini"
+
+	// openRouterRefererHeader and openRouterTitleHeader are optional
+	// attribution headers that OpenRouter uses for its public leaderboard
+	// (https://openrouter.ai/docs#headers). They are harmless to send.
+	openRouterRefererHeader = "HTTP-Referer"
+	openRouterTitleHeader   = "X-Title"
+
+	// openRouterRefererValue and openRouterTitleValue are the attribution
+	// strings sent on each request.
+	openRouterRefererValue = "https://console.kubestellar.io"
+	openRouterTitleValue   = "KubeStellar Console"
+)
+
+// OpenRouterProvider implements AIProvider for OpenRouter (https://openrouter.ai).
+type OpenRouterProvider struct {
+	baseURL string
+}
+
+// NewOpenRouterProvider constructs a provider using the default base URL,
+// overridable via OPENROUTER_BASE_URL.
+func NewOpenRouterProvider() *OpenRouterProvider {
+	baseURL := openRouterDefaultBaseURL
+	if v := os.Getenv("OPENROUTER_BASE_URL"); v != "" {
+		baseURL = v
+	}
+	return &OpenRouterProvider{baseURL: baseURL}
+}
+
+func (o *OpenRouterProvider) Name() string        { return "openrouter" }
+func (o *OpenRouterProvider) DisplayName() string { return "OpenRouter" }
+func (o *OpenRouterProvider) Provider() string    { return "openrouter" }
+func (o *OpenRouterProvider) Description() string {
+	return "OpenRouter - unified access to Anthropic, OpenAI, Google, Meta, Mistral and Qwen models via a single API key"
+}
+
+func (o *OpenRouterProvider) IsAvailable() bool {
+	// Dynamic check so keys added via settings take effect without a restart.
+	return GetConfigManager().IsKeyAvailable(openRouterProviderKey)
+}
+
+func (o *OpenRouterProvider) Capabilities() ProviderCapability {
+	return CapabilityChat
+}
+
+// endpoint returns the fully qualified chat completions URL.
+func (o *OpenRouterProvider) endpoint() string {
+	base := o.baseURL
+	if base == "" {
+		base = openRouterDefaultBaseURL
+	}
+	return base + openRouterChatCompletionsPath
+}
+
+// extraHeaders returns the optional attribution headers OpenRouter uses.
+func (o *OpenRouterProvider) extraHeaders() map[string]string {
+	return map[string]string{
+		openRouterRefererHeader: openRouterRefererValue,
+		openRouterTitleHeader:   openRouterTitleValue,
+	}
+}
+
+// Chat sends a message and returns the complete response.
+func (o *OpenRouterProvider) Chat(ctx context.Context, req *ChatRequest) (*ChatResponse, error) {
+	return chatViaOpenAICompatibleWithHeaders(
+		ctx, req, openRouterProviderKey, o.endpoint(), o.Name(), openRouterDefaultModel, o.extraHeaders(),
+	)
+}
+
+// StreamChat sends a message and streams the response.
+func (o *OpenRouterProvider) StreamChat(ctx context.Context, req *ChatRequest, onChunk func(chunk string)) (*ChatResponse, error) {
+	return streamViaOpenAICompatibleWithHeaders(
+		ctx, req, openRouterProviderKey, o.endpoint(), o.Name(), openRouterDefaultModel, onChunk, o.extraHeaders(),
+	)
+}

--- a/pkg/agent/provider_openrouter_test.go
+++ b/pkg/agent/provider_openrouter_test.go
@@ -1,0 +1,89 @@
+package agent
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestOpenRouterProvider_Basics(t *testing.T) {
+	p := NewOpenRouterProvider()
+
+	if p.Name() != "openrouter" {
+		t.Errorf("Expected 'openrouter', got %q", p.Name())
+	}
+	if p.DisplayName() != "OpenRouter" {
+		t.Errorf("Expected 'OpenRouter', got %q", p.DisplayName())
+	}
+	if p.Provider() != "openrouter" {
+		t.Errorf("Expected 'openrouter', got %q", p.Provider())
+	}
+	if p.Description() == "" {
+		t.Error("Description should not be empty")
+	}
+}
+
+func TestOpenRouterProvider_Capabilities(t *testing.T) {
+	p := &OpenRouterProvider{}
+
+	if p.Capabilities()&CapabilityChat == 0 {
+		t.Error("Expected CapabilityChat to be set")
+	}
+}
+
+func TestOpenRouterProvider_Interface(t *testing.T) {
+	var _ AIProvider = &OpenRouterProvider{}
+}
+
+// TestOpenRouterProvider_DefaultBaseURL ensures NewOpenRouterProvider uses the
+// public OpenRouter endpoint when OPENROUTER_BASE_URL is not set.
+func TestOpenRouterProvider_DefaultBaseURL(t *testing.T) {
+	t.Setenv("OPENROUTER_BASE_URL", "")
+	p := NewOpenRouterProvider()
+
+	got := p.endpoint()
+	want := openRouterDefaultBaseURL + openRouterChatCompletionsPath
+	if got != want {
+		t.Errorf("endpoint() = %q, want %q", got, want)
+	}
+}
+
+// TestOpenRouterProvider_BaseURLOverride ensures OPENROUTER_BASE_URL overrides
+// the default (useful for self-hosted proxies).
+func TestOpenRouterProvider_BaseURLOverride(t *testing.T) {
+	override := "https://proxy.example.com/v1"
+	t.Setenv("OPENROUTER_BASE_URL", override)
+	p := NewOpenRouterProvider()
+
+	got := p.endpoint()
+	if !strings.HasPrefix(got, override) {
+		t.Errorf("endpoint() = %q, expected prefix %q", got, override)
+	}
+	if !strings.HasSuffix(got, openRouterChatCompletionsPath) {
+		t.Errorf("endpoint() = %q, expected suffix %q", got, openRouterChatCompletionsPath)
+	}
+}
+
+// TestOpenRouterProvider_AttributionHeaders ensures the leaderboard headers
+// are set to the documented console values and nothing else.
+func TestOpenRouterProvider_AttributionHeaders(t *testing.T) {
+	p := &OpenRouterProvider{}
+	h := p.extraHeaders()
+
+	if h[openRouterRefererHeader] != openRouterRefererValue {
+		t.Errorf("missing %s=%q", openRouterRefererHeader, openRouterRefererValue)
+	}
+	if h[openRouterTitleHeader] != openRouterTitleValue {
+		t.Errorf("missing %s=%q", openRouterTitleHeader, openRouterTitleValue)
+	}
+}
+
+// TestGetEnvKeyForProvider_OpenRouter guards the env-var mapping used by
+// ConfigManager.GetAPIKey so OPENROUTER_API_KEY continues to be honored.
+func TestGetEnvKeyForProvider_OpenRouter(t *testing.T) {
+	if got := getEnvKeyForProvider("openrouter"); got != "OPENROUTER_API_KEY" {
+		t.Errorf("getEnvKeyForProvider(openrouter) = %q, want %q", got, "OPENROUTER_API_KEY")
+	}
+	if got := getModelEnvKeyForProvider("openrouter"); got != "OPENROUTER_MODEL" {
+		t.Errorf("getModelEnvKeyForProvider(openrouter) = %q, want %q", got, "OPENROUTER_MODEL")
+	}
+}

--- a/pkg/agent/server_operations.go
+++ b/pkg/agent/server_operations.go
@@ -410,6 +410,8 @@ func (s *Server) validateAPIKeyValue(provider, apiKey string) (bool, error) {
 		return validateOpenAIKey(ctx, apiKey)
 	case "gemini", "google":
 		return validateGeminiKey(ctx, apiKey)
+	case "openrouter":
+		return validateOpenRouterKey(ctx, apiKey)
 	default:
 		// For IDE/app providers (cursor, windsurf, cline, etc.)
 		// we accept the key without validation since we don't have
@@ -433,7 +435,7 @@ func (s *Server) refreshProviderAvailability() {
 // This should be called on server startup to detect invalid keys early
 func (s *Server) ValidateAllKeys() {
 	cm := GetConfigManager()
-	providers := []string{"claude", "openai", "gemini", "cursor", "vscode", "windsurf", "cline", "jetbrains", "zed", "continue", "raycast", "open-webui"}
+	providers := []string{"claude", "openai", "gemini", "openrouter", "cursor", "vscode", "windsurf", "cline", "jetbrains", "zed", "continue", "raycast", "open-webui"}
 
 	for _, provider := range providers {
 		if cm.HasAPIKey(provider) {
@@ -512,6 +514,41 @@ func validateOpenAIKey(ctx context.Context, apiKey string) (bool, error) {
 		// Invalid key — return (false, nil) so ValidateAllKeys caches the
 		// result and doesn't re-fire a live /v1/models request on every
 		// kc-agent startup (#7923). Matches validateClaudeKey behavior.
+		return false, nil
+	}
+	body, readErr := io.ReadAll(resp.Body)
+	if readErr != nil {
+		body = []byte("(failed to read response body)")
+	}
+	return false, fmt.Errorf("API error: %s", string(body))
+}
+
+// openRouterValidationURL is the OpenRouter models listing endpoint. It
+// returns 200 for any valid API key and 401 otherwise, so it's a cheap way
+// to check credentials without spending tokens on a chat completion.
+const openRouterValidationURL = "https://openrouter.ai/api/v1/models"
+
+// validateOpenRouterKey tests an OpenRouter API key by hitting the models
+// listing endpoint. Mirrors validateOpenAIKey semantics: a 200 means valid,
+// 401 means invalid (cached as (false, nil) so we don't re-fire on every
+// startup — see #7923).
+func validateOpenRouterKey(ctx context.Context, apiKey string) (bool, error) {
+	req, err := http.NewRequestWithContext(ctx, "GET", openRouterValidationURL, nil)
+	if err != nil {
+		return false, err
+	}
+	req.Header.Set("Authorization", "Bearer "+apiKey)
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return false, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusOK {
+		return true, nil
+	}
+	if resp.StatusCode == http.StatusUnauthorized {
 		return false, nil
 	}
 	body, readErr := io.ReadAll(resp.Body)

--- a/web/src/components/agent/APIKeySettings.tsx
+++ b/web/src/components/agent/APIKeySettings.tsx
@@ -82,6 +82,10 @@ const PROVIDER_INFO: Record<string, { docsUrl: string; placeholder: string }> = 
     docsUrl: AI_PROVIDER_DOCS['open-webui'],
     placeholder: 'owui-...',
   },
+  openrouter: {
+    docsUrl: AI_PROVIDER_DOCS.openrouter,
+    placeholder: 'sk-or-...',
+  },
 }
 
 // Map backend provider key names to AgentIcon provider values
@@ -99,6 +103,7 @@ function providerToIconMap(provider: string): string {
     continue: 'continue',
     raycast: 'raycast',
     'open-webui': 'open-webui',
+    openrouter: 'openrouter',
   }
   return map[provider] || provider
 }

--- a/web/src/components/agent/AgentIcon.tsx
+++ b/web/src/components/agent/AgentIcon.tsx
@@ -140,6 +140,19 @@ export function AgentIcon({ provider, className = 'w-5 h-5' }: AgentIconProps) {
           <circle cx="12" cy="11" r="2" fill="white" />
         </svg>
       )
+    case 'openrouter':
+      return (
+        <svg className={className} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+          {/* OpenRouter icon - stylized router / fan-out (multiple model destinations) */}
+          <circle cx="4" cy="12" r="2" className="fill-sky-500 stroke-sky-500" />
+          <circle cx="20" cy="5" r="2" className="fill-sky-400 stroke-sky-400" />
+          <circle cx="20" cy="12" r="2" className="fill-sky-400 stroke-sky-400" />
+          <circle cx="20" cy="19" r="2" className="fill-sky-400 stroke-sky-400" />
+          <path d="M6 12 L18 5" className="stroke-sky-500" />
+          <path d="M6 12 L18 12" className="stroke-sky-500" />
+          <path d="M6 12 L18 19" className="stroke-sky-500" />
+        </svg>
+      )
     case 'bob':
       return (
         <svg className={className} viewBox="0 0 100 100" fill="none">

--- a/web/src/config/externalApis.ts
+++ b/web/src/config/externalApis.ts
@@ -46,6 +46,7 @@ export const AI_PROVIDER_DOCS = {
   continue: 'https://continue.dev',
   raycast: 'https://raycast.com',
   'open-webui': 'https://github.com/open-webui/open-webui',
+  openrouter: 'https://openrouter.ai/keys',
 } as const
 
 /**

--- a/web/src/locales/en/common.json
+++ b/web/src/locales/en/common.json
@@ -220,7 +220,7 @@
     },
     "apiKeys": {
       "title": "AI Provider Keys",
-      "subtitle": "Configure API keys for Claude, OpenAI, and Gemini",
+      "subtitle": "Configure API keys for Claude, OpenAI, Gemini, and OpenRouter",
       "securityNote": "API keys are stored securely on your local machine in ~/.kc/config.yaml and are never sent to our servers.",
       "manageKeys": "Manage API Keys"
     },

--- a/web/src/types/agent.ts
+++ b/web/src/types/agent.ts
@@ -18,6 +18,7 @@ export type AgentProvider =
   | 'continue'        // Continue.dev
   | 'raycast'         // Raycast
   | 'open-webui'      // Open WebUI
+  | 'openrouter'      // OpenRouter (https://openrouter.ai) — unified OpenAI-compatible gateway
   | 'bob'             // Bob (discovery-only)
   | 'block'           // Goose (Block Inc)
   | 'github-cli'      // GitHub Copilot CLI


### PR DESCRIPTION
## Summary
Adds OpenRouter (https://openrouter.ai) as a first-class AI provider alongside Anthropic, OpenAI, and Gemini. OpenRouter uses an OpenAI-compatible endpoint, so the implementation reuses the shared `chatViaOpenAICompatible*` helpers with a configurable base URL, default model, and optional attribution headers.

Users can now access Llama, Mistral, Qwen, Anthropic, OpenAI and Google models through a single API key without juggling provider accounts.

## Changes
**Backend (`pkg/agent`)**
- New `OpenRouterProvider` (`provider_openrouter.go`) that reuses the shared OpenAI-compatible chat/stream helpers.
- Shared helpers (`provider_openai_compat.go`) gain a `defaultModel` parameter and an `extraHeaders` map so OpenRouter can pass `HTTP-Referer` / `X-Title` without breaking existing callers. All other callers (`openwebui`, `cursor`, `cline`, etc.) continue to work unchanged via a thin shim.
- `ConfigManager` learns the `OPENROUTER_API_KEY` and `OPENROUTER_MODEL` env var mappings.
- New `validateOpenRouterKey` hits `/api/v1/models` (mirrors `validateOpenAIKey` semantics: 200 = valid, 401 = cached invalid, matches #7923).
- `ValidateAllKeys` now probes OpenRouter on startup.
- No hardcoded API keys or fallback literals — strictly env / config only.
- All literal values (`max_tokens`, base URL, model name, header names/values, endpoint path) live in named `const`s with comments.

**Frontend (`web/src`)**
- `AgentProvider` type, `AI_PROVIDER_DOCS`, `PROVIDER_INFO` and `providerToIconMap` all learn about `openrouter`.
- New OpenRouter icon case in `AgentIcon.tsx`.
- Settings subtitle string mentions OpenRouter.

**Config**
- `.env.example` documents `OPENROUTER_API_KEY`, `OPENROUTER_MODEL` and `OPENROUTER_BASE_URL` (optional, for self-hosted proxies).

**Tests**
- `provider_openrouter_test.go` covers basics, capabilities, interface compliance, default + override base URLs, attribution headers, and the env-var mapping.

## Demo mode
Provider reports `IsAvailable() == false` until a key is configured, so AI features fall back to their existing demo-data paths — no special casing required.

Fixes #7999

## Test plan
- [x] Backend builds (`go build ./...`)
- [x] Backend tests pass (`go test ./pkg/agent/...`)
- [x] Frontend builds (`npm run build`)
- [x] Frontend lint (no new errors or warnings introduced)
- [ ] Provider appears in settings dropdown once backend `handleGetKeysStatus` opts API providers back in (currently intentionally hidden for all API-only providers)
- [ ] API key input persists and loads from storage
- [ ] Requests with `OPENROUTER_API_KEY` set hit `openrouter.ai/api/v1/chat/completions`
- [ ] Demo mode fallback works when no key is set

🤖 Generated with [Claude Code](https://claude.com/claude-code)