### PR TITLE
🐛 fix: reword misleading 'Broadcast success' comment in self-upgrade (#8045)

### DIFF
--- a/pkg/api/handlers/self_upgrade.go
+++ b/pkg/api/handlers/self_upgrade.go
@@ -421,7 +421,9 @@ func (h *SelfUpgradeHandler) TriggerUpgrade(c *fiber.Ctx) error {
 			"message":  fmt.Sprintf("Deployment image patched to %s", req.ImageTag),
 		},
 	})
-	// Broadcast success — the pod will be terminated shortly by the rollout
+	// Broadcast progress: patch applied, waiting for rollout (step 2 / 60%).
+	// This is a "running" progress update, not a terminal success event — the
+	// real success broadcast happens once the deployment rollout completes.
 	h.hub.BroadcastAll(Message{
 		Type: "update_progress",
 		Data: map[string]any{


### PR DESCRIPTION
## Summary
Addresses the single Copilot review comment from merged PR #8041. The comment at `self_upgrade.go:424` said "Broadcast success", but the event is actually a running progress update (step 2 / 60%), not a terminal success event. Reworded to reflect the actual semantics.

Fixes #8045

## Test plan
- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] Comment-only change — no behavior change

🤖 Generated with [Claude Code](https://claude.com/claude-code)