### PR TITLE
🐛 fix: GitOps drift-check test failure from namespace refactor (#8049)

### DIFF
--- a/web/src/components/gitops/GitOps.test.tsx
+++ b/web/src/components/gitops/GitOps.test.tsx
@@ -8,6 +8,12 @@ import '../../test/utils/setupMocks'
 // Wait budget for async detection flows.
 const ASYNC_WAIT_TIMEOUT_MS = 2000
 
+// #7993 Phase 4 (#8044): GitOps.tsx no longer calls `api.post`; it now
+// fetches kc-agent's drift-detect endpoint directly. We match the fetch URL
+// by suffix so the test stays agnostic of LOCAL_AGENT_HTTP_URL's host.
+const DETECT_DRIFT_PATH_SUFFIX = '/gitops/detect-drift'
+const HEALTH_CHECK_PATH = '/api/health'
+
 // Controls whether getDemoMode() returns true for the current test.
 // IMPORTANT: setupMocks mocks useDemoMode to always return true. We override
 // that below with `vi.doMock` inside a sync import shim so tests can flip
@@ -53,11 +59,11 @@ vi.mock('../ui/Toast', () => ({
   useToast: () => ({ showToast: vi.fn() }),
 }))
 
-// The component uses both api.post (for detect-drift) and getDemoMode.
-const apiPostMock = vi.fn()
-vi.mock('../../lib/api', () => ({
-  api: { post: (...args: unknown[]) => apiPostMock(...args) },
-}))
+// Per-test handler for the drift-detect fetch call. beforeEach resets to a
+// successful empty response; individual tests override to simulate failures
+// or a drifted result.
+type DriftFetchResponse = { ok: boolean; body: unknown }
+let driftFetchHandler: () => DriftFetchResponse | Promise<DriftFetchResponse>
 
 // NOTE: setupMocks.ts already mocks '../../hooks/useDemoMode'. We override
 // getDemoMode at runtime in beforeEach below so each test can control the
@@ -81,19 +87,26 @@ describe('GitOps Component', () => {
   beforeEach(() => {
     demoModeFlag = false
     mockClusters = []
-    apiPostMock.mockReset()
+    // Default: drift detection succeeds with no drift. Tests override.
+    driftFetchHandler = () => ({ ok: true, body: { drifted: false, resources: [] } })
     // Override setupMocks' forced-true getDemoMode with our flag. vi.spyOn
     // replaces the export on the already-mocked module.
     vi.spyOn(useDemoModeModule, 'getDemoMode').mockImplementation(() => demoModeFlag)
-    // Default: health check + detect-drift both succeed cleanly.
+    // Route-aware fetch mock. Health check always succeeds; detect-drift
+    // delegates to the per-test handler.
     vi.stubGlobal(
       'fetch',
-      vi.fn(() =>
-        Promise.resolve({
-          ok: true,
-          json: () => Promise.resolve({}),
-        })
-      )
+      vi.fn(async (input: RequestInfo | URL) => {
+        const url = typeof input === 'string' ? input : input.toString()
+        if (url.includes(DETECT_DRIFT_PATH_SUFFIX)) {
+          const { ok, body } = await driftFetchHandler()
+          return { ok, json: () => Promise.resolve(body) } as unknown as Response
+        }
+        if (url.includes(HEALTH_CHECK_PATH)) {
+          return { ok: true, json: () => Promise.resolve({}) } as unknown as Response
+        }
+        return { ok: true, json: () => Promise.resolve({}) } as unknown as Response
+      })
     )
   })
 
@@ -140,16 +153,11 @@ describe('GitOps Component', () => {
   // "synced + healthy" (false green).
   it('renders drift check failure as error state, not as synced (#6156)', async () => {
     mockClusters = [{ name: 'only', context: 'only' }]
-    // health check ok, but api.post (detect-drift) throws.
-    apiPostMock.mockRejectedValue(new Error('backend exploded'))
+    // Health check ok, but the detect-drift fetch throws.
+    driftFetchHandler = () => {
+      throw new Error('backend exploded')
+    }
     renderGitOps()
-    await waitFor(
-      () => {
-        // api.post must have been called for each app config.
-        expect(apiPostMock).toHaveBeenCalled()
-      },
-      { timeout: ASYNC_WAIT_TIMEOUT_MS }
-    )
     await waitFor(
       () => {
         expect(screen.getAllByText('gitops.driftCheckFailed').length).toBeGreaterThan(0)
@@ -168,7 +176,7 @@ describe('GitOps Component', () => {
       { name: 'cluster-a', context: 'cluster-a' },
       { name: 'cluster-b', context: 'cluster-b' },
     ]
-    apiPostMock.mockResolvedValue({ data: { drifted: false, resources: [] } })
+    driftFetchHandler = () => ({ ok: true, body: { drifted: false, resources: [] } })
     renderGitOps()
     await waitFor(
       () => {
@@ -190,7 +198,7 @@ describe('GitOps Component', () => {
   // "gitops.unknown" (via getTimeAgo with undefined), not "gitops.justNow".
   it('does not fabricate a recent lastSyncTime on render (#6158)', async () => {
     mockClusters = [{ name: 'only', context: 'only' }]
-    apiPostMock.mockResolvedValue({ data: { drifted: false, resources: [] } })
+    driftFetchHandler = () => ({ ok: true, body: { drifted: false, resources: [] } })
     renderGitOps()
     await waitFor(
       () => {


### PR DESCRIPTION
## Summary
Fixes the `GitOps.test.tsx > renders drift check failure as error state` test that started failing after PR #8044 (phase 4 gitops migration, commit 74da9465).

**Root cause: test regression, not code regression.** PR #8044 migrated `GitOps.tsx` from the shared `api.post` helper to direct `fetch` against kc-agent's `/gitops/detect-drift` endpoint, but `GitOps.test.tsx` was still mocking `api.post`. The #6156 test called `apiPostMock.mockRejectedValue(new Error('backend exploded'))`, but the component never calls `api.post` anymore — so the dead mock had no effect, the global fetch mock returned `ok: true, json: {}` for every URL, and the component rendered each app as `synced` (the exact regression the test was written to prevent).

The GitOps component itself still correctly renders failed drift checks as a distinct error state (`syncStatus: 'error'` → `gitops.driftCheckFailed` label with red styling).

**Fix:** replace `apiPostMock` with a route-aware fetch mock plus a per-test `driftFetchHandler` that can simulate success / throw / drifted-response. Migrated the #6156, #6157, and #6158 tests to set `driftFetchHandler` instead of `apiPostMock`. All 8 tests in the suite now pass.

Fixes #8049

## Test plan
- [x] `npx vitest run src/components/gitops/GitOps.test.tsx` — 8/8 pass
- [x] `npm run build` — clean
- [x] `npm run lint` — no new issues from this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)