### PR TITLE
⚡ perf: split clusterCache into data + UI caches (#7865)

### DIFF
--- a/web/src/hooks/mcp/__tests__/clusters.test.ts
+++ b/web/src/hooks/mcp/__tests__/clusters.test.ts
@@ -34,6 +34,12 @@ vi.mock('../shared', async () => {
     get clusterSubscribers() {
       return m.clusterSubscribers
     },
+    get dataSubscribers() {
+      return m.dataSubscribers
+    },
+    get uiSubscribers() {
+      return m.uiSubscribers
+    },
     get sharedWebSocket() {
       return m.sharedWebSocket
     },
@@ -61,6 +67,10 @@ vi.mock('../shared', async () => {
     clearClusterFailure: m.clearClusterFailure,
     cleanupSharedWebSocket: m.cleanupSharedWebSocket,
     subscribeClusterCache: m.subscribeClusterCache,
+    subscribeClusterData: m.subscribeClusterData,
+    subscribeClusterUI: m.subscribeClusterUI,
+    notifyClusterDataSubscribers: m.notifyClusterDataSubscribers,
+    notifyClusterUISubscribers: m.notifyClusterUISubscribers,
     clusterCacheRef: m.clusterCacheRef,
     // Stubbed to prevent real network calls
     fetchSingleClusterHealth: mockFetchSingleClusterHealth,
@@ -98,6 +108,8 @@ vi.mock('../../useLocalAgent', () => ({
 import { useMCPStatus, useClusters, useClusterHealth } from '../clusters'
 import {
   clusterSubscribers,
+  dataSubscribers,
+  uiSubscribers,
   updateClusterCache,
   setInitialFetchStarted,
   sharedWebSocket,
@@ -130,6 +142,8 @@ const EMPTY_CACHE = {
 function resetSharedState() {
   localStorage.clear()
   clusterSubscribers.clear()
+  dataSubscribers.clear()
+  uiSubscribers.clear()
   setInitialFetchStarted(false)
   sharedWebSocket.ws = null
   sharedWebSocket.connecting = false
@@ -142,6 +156,8 @@ function resetSharedState() {
   updateClusterCache({ ...EMPTY_CACHE })
   // Clear subscriptions that updateClusterCache may have notified
   clusterSubscribers.clear()
+  dataSubscribers.clear()
+  uiSubscribers.clear()
 }
 
 // ===========================================================================
@@ -451,17 +467,24 @@ describe('Shared cache / pub-sub', () => {
   })
 
   it('subscriber count matches mounted hook instances', () => {
-    expect(clusterSubscribers.size).toBe(0)
+    // After the data/UI split (#7865), each useClusters instance registers
+    // one data subscriber AND one UI subscriber, so the per-slice count
+    // equals the number of mounted hooks.
+    expect(dataSubscribers.size).toBe(0)
+    expect(uiSubscribers.size).toBe(0)
 
     const { unmount: u1 } = renderHook(() => useClusters())
     const { unmount: u2 } = renderHook(() => useClusters())
-    expect(clusterSubscribers.size).toBe(2)
+    expect(dataSubscribers.size).toBe(2)
+    expect(uiSubscribers.size).toBe(2)
 
     u1()
-    expect(clusterSubscribers.size).toBe(1)
+    expect(dataSubscribers.size).toBe(1)
+    expect(uiSubscribers.size).toBe(1)
 
     u2()
-    expect(clusterSubscribers.size).toBe(0)
+    expect(dataSubscribers.size).toBe(0)
+    expect(uiSubscribers.size).toBe(0)
   })
 })
 

--- a/web/src/hooks/mcp/clusters.ts
+++ b/web/src/hooks/mcp/clusters.ts
@@ -10,7 +10,8 @@ import {
   CLUSTER_POLL_INTERVAL_MS,
   getEffectiveInterval,
   clusterCache,
-  clusterSubscribers,
+  subscribeClusterData,
+  subscribeClusterUI,
   connectSharedWebSocket,
   fullFetchClusters,
   initialFetchStarted,
@@ -23,8 +24,24 @@ import {
   clearClusterFailure,
   setInitialFetchStarted,
   setHealthCheckFailures } from './shared'
-import type { ClusterCache } from './shared'
+import type { ClusterInfo } from './types'
 import { subscribePolling } from './pollingManager'
+
+/** Data slice returned by useClusters — heavy, arrives via startTransition. */
+interface ClusterDataSlice {
+  clusters: ClusterInfo[]
+  lastUpdated: Date | null
+  consecutiveFailures: number
+  isFailed: boolean
+}
+
+/** UI-indicator slice returned by useClusters — small, arrives urgently. */
+interface ClusterUISlice {
+  isLoading: boolean
+  isRefreshing: boolean
+  error: string | null
+  lastRefresh: Date | null
+}
 
 // Hook to get MCP status
 export function useMCPStatus() {
@@ -60,22 +77,52 @@ export function useMCPStatus() {
 }
 
 export function useClusters() {
-  // Local state that syncs with shared cache
-  const [localState, setLocalState] = useState<ClusterCache>(clusterCache)
+  // Split local state into data + UI slices (#7865).
+  // Data updates arrive via startTransition (interruptible) and drive the
+  // heavy re-render; UI updates arrive urgently so the refresh spinner
+  // commits on every fetch tick. Merged back into a single return value
+  // below for consumer backward compatibility.
+  const [dataState, setDataState] = useState<ClusterDataSlice>(() => ({
+    clusters: clusterCache.clusters,
+    lastUpdated: clusterCache.lastUpdated,
+    consecutiveFailures: clusterCache.consecutiveFailures,
+    isFailed: clusterCache.isFailed,
+  }))
+  const [uiState, setUIState] = useState<ClusterUISlice>(() => ({
+    isLoading: clusterCache.isLoading,
+    isRefreshing: clusterCache.isRefreshing,
+    error: clusterCache.error,
+    lastRefresh: clusterCache.lastRefresh,
+  }))
   // Track demo mode to re-fetch when it changes
   const { isDemoMode } = useDemoMode()
 
-  // Subscribe to shared cache updates.
+  // Subscribe to shared cache updates — two subscriptions, one per slice.
   useEffect(() => {
-    const handleUpdate = (cache: ClusterCache) => {
-      setLocalState(cache)
+    const handleData = (cache: typeof clusterCache) => {
+      setDataState({
+        clusters: cache.clusters,
+        lastUpdated: cache.lastUpdated,
+        consecutiveFailures: cache.consecutiveFailures,
+        isFailed: cache.isFailed,
+      })
+    }
+    const handleUI = (cache: typeof clusterCache) => {
+      setUIState({
+        isLoading: cache.isLoading,
+        isRefreshing: cache.isRefreshing,
+        error: cache.error,
+        lastRefresh: cache.lastRefresh,
+      })
     }
     // Sync with any updates that happened between initial render and effect.
-    handleUpdate(clusterCache)
-    clusterSubscribers.add(handleUpdate)
-
+    handleData(clusterCache)
+    handleUI(clusterCache)
+    const unsubData = subscribeClusterData(handleData)
+    const unsubUI = subscribeClusterUI(handleUI)
     return () => {
-      clusterSubscribers.delete(handleUpdate)
+      unsubData()
+      unsubUI()
     }
   }, [])
 
@@ -153,7 +200,7 @@ export function useClusters() {
   // Use this for metrics, stats, and counts to avoid double-counting
   const deduplicatedClusters = (() => {
     // First share metrics between clusters with same server (so short names get metrics from long names)
-    const sharedMetricsClusters = shareMetricsBetweenSameServerClusters(localState.clusters)
+    const sharedMetricsClusters = shareMetricsBetweenSameServerClusters(dataState.clusters)
     const result = deduplicateClustersByServer(sharedMetricsClusters)
 
     return result
@@ -185,20 +232,20 @@ export function useClusters() {
 
   return {
     // Raw clusters - all contexts including duplicates pointing to same server
-    clusters: localState.clusters,
+    clusters: dataState.clusters,
     // Deduplicated clusters - single cluster per server with aliases
     // Use this for metrics, stats, and aggregations to avoid double-counting
     deduplicatedClusters,
     // Completeness metadata for aggregated metrics (issue #6114)
     metricsCompleteness,
-    isLoading: localState.isLoading,
-    isRefreshing: localState.isRefreshing,
-    lastUpdated: localState.lastUpdated,
-    error: localState.error,
+    isLoading: uiState.isLoading,
+    isRefreshing: uiState.isRefreshing,
+    lastUpdated: dataState.lastUpdated,
+    error: uiState.error,
     refetch,
-    consecutiveFailures: localState.consecutiveFailures,
-    isFailed: localState.isFailed,
-    lastRefresh: localState.lastRefresh }
+    consecutiveFailures: dataState.consecutiveFailures,
+    isFailed: dataState.isFailed,
+    lastRefresh: uiState.lastRefresh }
 }
 
 // Hook to get cluster health - uses kubectl proxy for direct cluster access

--- a/web/src/hooks/mcp/shared.ts
+++ b/web/src/hooks/mcp/shared.ts
@@ -1,3 +1,4 @@
+import { startTransition } from 'react'
 import { api, isBackendUnavailable } from '../../lib/api'
 import { reportAgentDataError, reportAgentDataSuccess, isAgentUnavailable } from '../useLocalAgent'
 import { isDemoMode, isNetlifyDeployment, isDemoToken, subscribeDemoMode } from '../../lib/demoMode'
@@ -58,15 +59,57 @@ export function agentFetch(input: RequestInfo | URL, init?: RequestInit): Promis
 // ============================================================================
 // Shared Cluster State - ensures all useClusters() consumers see the same data
 // ============================================================================
+//
+// NOTE (#7865): the cache is internally split into two slices so that heavy
+// cluster-data updates can be wrapped in React.startTransition() (interruptible,
+// yielding to SPA navigation) while small UI-indicator updates stay urgent
+// (so the refresh spinner on the logo reliably paints on → off). See the
+// `dataSubscribers` / `uiSubscribers` split below.
+//
+// The public `ClusterCache` shape is kept as a single merged object so all
+// existing consumers (`useClusters()`, `clusterCache.clusters.find(...)`, etc.)
+// continue to work unchanged.
 export interface ClusterCache {
+  // --- Data slice (heavy; notified inside startTransition) ---
   clusters: ClusterInfo[]
   lastUpdated: Date | null
+  consecutiveFailures: number
+  isFailed: boolean
+  // --- UI slice (tiny; notified urgently, outside startTransition) ---
   isLoading: boolean
   isRefreshing: boolean
   error: string | null
-  consecutiveFailures: number
-  isFailed: boolean
   lastRefresh: Date | null
+}
+
+/** Fields that belong to the heavy data slice. Source of truth for the split. */
+const DATA_FIELDS: ReadonlyArray<keyof ClusterCache> = [
+  'clusters',
+  'lastUpdated',
+  'consecutiveFailures',
+  'isFailed',
+]
+
+/** Fields that belong to the tiny UI-indicator slice. */
+const UI_FIELDS: ReadonlyArray<keyof ClusterCache> = [
+  'isLoading',
+  'isRefreshing',
+  'error',
+  'lastRefresh',
+]
+
+function updatesTouchData(updates: Partial<ClusterCache>): boolean {
+  for (const field of DATA_FIELDS) {
+    if (field in updates) return true
+  }
+  return false
+}
+
+function updatesTouchUI(updates: Partial<ClusterCache>): boolean {
+  for (const field of UI_FIELDS) {
+    if (field in updates) return true
+  }
+  return false
 }
 
 // Cache cluster distribution in localStorage to prevent logo flickering on page load
@@ -248,13 +291,61 @@ export let clusterCache: ClusterCache = {
   lastRefresh: storedClusters.length > 0 ? new Date() : null,
 }
 
-// Subscribers that get notified when cluster data changes
+// Subscribers that get notified when cluster state changes.
+// Split into two sets (#7865):
+//  - dataSubscribers: notified inside React.startTransition(), so navigation
+//    can pre-empt the heavy re-render that a new cluster list triggers.
+//  - uiSubscribers: notified urgently (outside startTransition) so the
+//    refresh-spinner / loading flags always commit and paint immediately.
 type ClusterSubscriber = (cache: ClusterCache) => void
-export const clusterSubscribers = new Set<ClusterSubscriber>()
+export const dataSubscribers = new Set<ClusterSubscriber>()
+export const uiSubscribers = new Set<ClusterSubscriber>()
 
-// Notify all subscribers of state change
+/**
+ * Back-compat alias for the pre-split single subscriber set. Subscribers
+ * added here receive BOTH data and UI updates (same as the old behavior),
+ * but the notification path still honors the split (startTransition for
+ * data, urgent for UI). New code should prefer `dataSubscribers` or
+ * `uiSubscribers` directly, or the `subscribeClusterCache*` helpers below.
+ */
+export const clusterSubscribers: Set<ClusterSubscriber> = new Set<ClusterSubscriber>()
+
+/** Notify only data subscribers, wrapped in startTransition (interruptible). */
+export function notifyClusterDataSubscribers() {
+  const snapshot = clusterCache
+  startTransition(() => {
+    dataSubscribers.forEach(subscriber => subscriber(snapshot))
+  })
+}
+
+/** Notify only UI subscribers, urgently (outside startTransition). */
+export function notifyClusterUISubscribers() {
+  const snapshot = clusterCache
+  uiSubscribers.forEach(subscriber => subscriber(snapshot))
+}
+
+/**
+ * Back-compat: notify every legacy subscriber exactly once. Legacy
+ * subscribers (added to `clusterSubscribers`) receive both data and UI
+ * updates on a single call, so we fire them here — NOT inside
+ * `notifyClusterDataSubscribers` / `notifyClusterUISubscribers`, which
+ * would double-notify them whenever both slices change. Data-subscriber
+ * notification still goes through `startTransition` via the split APIs.
+ *
+ * Used by code paths that mutate the cache directly (not via
+ * updateClusterCache) — see `updateSingleClusterInCache`,
+ * `refreshSingleCluster`, HMR reset, and mode-transition / demo-toggle
+ * handlers.
+ */
 export function notifyClusterSubscribers() {
-  clusterSubscribers.forEach(subscriber => subscriber(clusterCache))
+  const snapshot = clusterCache
+  // Urgent leg — UI subscribers + legacy (merged) subscribers.
+  uiSubscribers.forEach(subscriber => subscriber(snapshot))
+  clusterSubscribers.forEach(subscriber => subscriber(snapshot))
+  // Interruptible leg — only the heavy-data subscribers.
+  startTransition(() => {
+    dataSubscribers.forEach(subscriber => subscriber(snapshot))
+  })
 }
 
 /**
@@ -353,14 +444,20 @@ if (typeof window !== 'undefined') {
   })
 }
 
-// Debounced notification for batching rapid updates (prevents flashing during health checks)
+// Debounced notification for batching rapid updates (prevents flashing during health checks).
+// This path is used by `updateSingleClusterInCache`, which mutates the heavy
+// `clusters` array, so we dispatch to DATA subscribers inside startTransition.
+// Legacy merged subscribers also receive the update (urgent) so the
+// pre-split contract is preserved.
 let notifyTimeout: ReturnType<typeof setTimeout> | null = null
 export function notifyClusterSubscribersDebounced() {
   if (notifyTimeout) {
     clearTimeout(notifyTimeout)
   }
   notifyTimeout = setTimeout(() => {
-    notifyClusterSubscribers()
+    const snapshot = clusterCache
+    clusterSubscribers.forEach(subscriber => subscriber(snapshot))
+    notifyClusterDataSubscribers()
     notifyTimeout = null
   }, CLUSTER_NOTIFY_DEBOUNCE_MS)
 }
@@ -378,7 +475,29 @@ export function updateClusterCache(updates: Partial<ClusterCache>) {
     updateDistributionCache(updates.clusters)
   }
   clusterCache = { ...clusterCache, ...updates }
-  notifyClusterSubscribers()
+
+  // Route notifications based on which slice the updates touch (#7865).
+  // UI fires first (urgent) so spinner on/off commits immediately, then
+  // data fires inside startTransition so navigation can pre-empt the
+  // heavy re-render caused by a new cluster list.
+  const touchesUI = updatesTouchUI(updates)
+  const touchesData = updatesTouchData(updates)
+  if (touchesUI) {
+    notifyClusterUISubscribers()
+  }
+  if (touchesData) {
+    notifyClusterDataSubscribers()
+  }
+  // Legacy merged subscribers are fired exactly once per updateClusterCache
+  // call so the pre-split contract (one notify per update) is preserved.
+  if (touchesUI || touchesData) {
+    const snapshot = clusterCache
+    clusterSubscribers.forEach(subscriber => subscriber(snapshot))
+  } else {
+    // If the updates somehow touch neither slice, fall back to notifying
+    // every subscriber so nothing gets silently dropped.
+    notifyClusterSubscribers()
+  }
 
   // When clusters become available for the first time, reset all cache
   // failures and trigger immediate refetch. This fixes the race condition
@@ -839,6 +958,8 @@ if (import.meta.hot) {
       lastRefresh: null,
     }
     clusterSubscribers.clear()
+    dataSubscribers.clear()
+    uiSubscribers.clear()
   })
 }
 
@@ -1627,10 +1748,24 @@ export const clusterCacheRef = {
   },
 }
 
-// Subscribe to cluster cache changes (for modules that need reactive updates)
+// Subscribe to cluster cache changes (for modules that need reactive updates).
+// Back-compat API: receives BOTH data and UI updates. Prefer the split
+// variants below for new code.
 export function subscribeClusterCache(callback: (cache: ClusterCache) => void): () => void {
   clusterSubscribers.add(callback)
   return () => clusterSubscribers.delete(callback)
+}
+
+/** Subscribe to heavy cluster-data updates only (notifications are interruptible). */
+export function subscribeClusterData(callback: (cache: ClusterCache) => void): () => void {
+  dataSubscribers.add(callback)
+  return () => dataSubscribers.delete(callback)
+}
+
+/** Subscribe to tiny UI-indicator updates only (notifications are urgent). */
+export function subscribeClusterUI(callback: (cache: ClusterCache) => void): () => void {
+  uiSubscribers.add(callback)
+  return () => uiSubscribers.delete(callback)
 }
 
 // Setter functions for module-level state (ES modules can't assign to imported bindings)


### PR DESCRIPTION
## Summary
Splits `clusterCache` into two caches so SPA navigation stays responsive without breaking the refresh-spinner animation.

- `dataSubscribers` — heavy cluster payloads (`clusters[]`, `lastUpdated`, `consecutiveFailures`, `isFailed`). Subscribers called inside `React.startTransition()` → interruptible, nav stays snappy.
- `uiSubscribers` — small UI state (`isLoading`, `isRefreshing`, `error`, `lastRefresh`). Subscribers called urgently so the spinner animation paints immediately.

`updateClusterCache()` routes each partial update to the right slice based on which fields it touches. The back-compat `clusterSubscribers` Set is preserved and fired exactly once per update so existing direct consumers (tests, `operators.ts`, etc.) continue to work unchanged. `useClusters()` now keeps two independent `useState` slices and merges them back into a single return value, so the split is invisible to its consumers.

Prior attempt (#7833) wrapped the single-cache notifier in `startTransition`, which unblocked nav but starved the spinner — the `isRefreshing: true → false` transition at the end of each fetch got perpetually superseded by the next fetch's "start" update. This PR is the proper split-by-slice fix.

Fixes #7865

## Test plan
- [x] `npm run build` / `npx tsc --noEmit` pass
- [x] Lint clean on touched files (`src/hooks/mcp/shared.ts`, `src/hooks/mcp/clusters.ts`, `src/hooks/mcp/__tests__/clusters.test.ts`)
- [x] Targeted unit tests pass: `shared.test.ts`, `shared-coverage.test.ts`, `clusters.test.ts`, `operators.test.ts` — 346/346
- [ ] Manual: navigate between Dashboard / My Clusters and other dashboards during a cluster refresh — commit <300ms (verify via CDP)
- [ ] Manual: refresh spinner animates on every fetch, never stuck on or off
- [ ] Manual: cluster cards still update after navigation completes

🤖 Generated with [Claude Code](https://claude.com/claude-code)