### PR TITLE
🐛 fix: correct self-upgrade progress comment accuracy (#8050)

### DIFF
--- a/pkg/api/handlers/self_upgrade.go
+++ b/pkg/api/handlers/self_upgrade.go
@@ -421,9 +421,10 @@ func (h *SelfUpgradeHandler) TriggerUpgrade(c *fiber.Ctx) error {
 			"message":  fmt.Sprintf("Deployment image patched to %s", req.ImageTag),
 		},
 	})
-	// Broadcast progress: patch applied, waiting for rollout (step 2 / 60%).
-	// This is a "running" progress update, not a terminal success event — the
-	// real success broadcast happens once the deployment rollout completes.
+	// Step 2 / 60%: last broadcast this handler emits. The rollout completes
+	// asynchronously and terminates this pod mid-request, so no terminal
+	// success event is sent over this hub — clients detect completion by
+	// polling /health (see web/src/hooks/useSelfUpgrade.ts:pollForRestart).
 	h.hub.BroadcastAll(Message{
 		Type: "update_progress",
 		Data: map[string]any{


### PR DESCRIPTION
## Summary

Follow-up to Copilot review on #8048 (commit `009a139e`).

In #8048 I reworded the `// Broadcast success — the pod will be terminated shortly by the rollout` comment in `pkg/api/handlers/self_upgrade.go` to a 3-line explanation that claimed:

> This is a "running" progress update, not a terminal success event — the real success broadcast happens once the deployment rollout completes.

The Copilot reviewer correctly pointed out that this claim is **false**. `self_upgrade.go` emits exactly three `update_progress` broadcasts over the hub:

1. `status: "failed"` on patch error (terminal error)
2. `status: "running"`, step 1, 20% (image patched)
3. `status: "running"`, step 2, 60% (waiting for rollout)

…and then the handler returns HTTP 200. There is no watcher, no goroutine, and no sibling handler that emits a terminal `success` / `done` event on rollout completion — the pod simply gets terminated by the rollout mid-response. The actual terminal signal for the frontend comes from client-side `/health` polling in `useSelfUpgrade.pollForRestart`, not from a WebSocket broadcast.

## Change

Reworded the comment at line ~424 to accurately describe what actually happens:

```go
// Step 2 / 60%: last broadcast this handler emits. The rollout completes
// asynchronously and terminates this pod mid-request, so no terminal
// success event is sent over this hub — clients detect completion by
// polling /health (see web/src/hooks/useSelfUpgrade.ts:pollForRestart).
```

Comment-only change. No logic touched.

Fixes #8050

## Test plan

- [x] `go build ./...` passes
- [x] `cd web && npm run build` passes
- [x] `cd web && npm run lint` — no new errors or warnings (comment-only change)