### PR TITLE
🐛 fix: namespace dropdown regression on GPU reservation (#3945)

### DIFF
--- a/web/src/components/gpu/GPUReservations.tsx
+++ b/web/src/components/gpu/GPUReservations.tsx
@@ -231,6 +231,21 @@ export function GPUReservations() {
     return Object.values(clusterMap).filter(c => c.totalGPUs > 0)
   })()
 
+  // Namespaces known to have existing reservations, grouped by cluster.
+  // Fallback source for the Create Reservation dropdown when useNamespaces()
+  // can't surface a namespace (e.g. user lacks cluster-wide list RBAC AND
+  // the namespace has no running pods, so neither health-check discovery
+  // nor the /api/mcp/pods-based REST fallback sees it). See #3945.
+  const knownNamespacesByCluster = useMemo(() => {
+    const out: Record<string, string[]> = {}
+    for (const r of (allReservations || [])) {
+      if (!r.cluster || !r.namespace) continue
+      if (!out[r.cluster]) out[r.cluster] = []
+      if (!out[r.cluster].includes(r.namespace)) out[r.cluster].push(r.namespace)
+    }
+    return out
+  }, [allReservations])
+
   // GPU stats
   const stats = useMemo(() => {
     const totalGPUs = nodes.reduce((sum, n) => sum + n.gpuCount, 0)
@@ -652,6 +667,7 @@ export function GPUReservations() {
         user={user}
         prefillDate={prefillDate}
         forceLive={gpuLiveMode}
+        knownNamespacesByCluster={knownNamespacesByCluster}
         onSave={async (input) => {
           if (editingReservation) {
             await apiUpdateReservation(editingReservation.id, input as UpdateGPUReservationInput)

--- a/web/src/components/gpu/ReservationFormModal.tsx
+++ b/web/src/components/gpu/ReservationFormModal.tsx
@@ -101,6 +101,7 @@ export function ReservationFormModal({
   user,
   prefillDate,
   forceLive,
+  knownNamespacesByCluster,
   onSave,
   onActivate,
   onSaved,
@@ -114,6 +115,15 @@ export function ReservationFormModal({
   prefillDate?: string | null
   /** When true, skip demo mode fallback for namespace list */
   forceLive?: boolean
+  /**
+   * Map of cluster name → namespaces known to have existing reservations.
+   * Provided by GPUReservations as a belt-and-suspenders fallback for
+   * #3945: even if `useNamespaces()` misses a namespace (because the
+   * user lacks cluster-wide list RBAC and it has no running pods), any
+   * namespace the user has previously reserved in will still surface in
+   * the dropdown.
+   */
+  knownNamespacesByCluster?: Record<string, string[]>
   onSave: (input: CreateGPUReservationInput | UpdateGPUReservationInput) => Promise<string | void>
   onActivate: (id: string) => Promise<void>
   onSaved: () => void
@@ -194,10 +204,18 @@ export function ReservationFormModal({
 
   const { namespaces: rawNamespaces } = useNamespaces(cluster || undefined, forceLive)
 
+  // Union the hook result with namespaces from existing reservations on
+  // this cluster. See `knownNamespacesByCluster` prop doc (#3945).
+  const mergedRawNamespaces = (() => {
+    const knownForCluster = (cluster && knownNamespacesByCluster?.[cluster]) || []
+    if (knownForCluster.length === 0) return rawNamespaces
+    return Array.from(new Set<string>([...rawNamespaces, ...knownForCluster])).sort()
+  })()
+
   // Filter out system namespaces from the dropdown
   const FILTERED_NS_PREFIXES = ['openshift-', 'kube-']
   const FILTERED_NS_EXACT = ['default', 'kube-system', 'kube-public', 'kube-node-lease']
-  const clusterNamespaces = rawNamespaces.filter(ns =>
+  const clusterNamespaces = mergedRawNamespaces.filter(ns =>
       !FILTERED_NS_PREFIXES.some(prefix => ns.startsWith(prefix)) &&
       !FILTERED_NS_EXACT.includes(ns)
     )

--- a/web/src/hooks/mcp/__tests__/namespaces.test.ts
+++ b/web/src/hooks/mcp/__tests__/namespaces.test.ts
@@ -131,6 +131,46 @@ describe('useNamespaces', () => {
     expect(result.current.namespaces).toContain('monitoring')
   })
 
+  // #3945 regression: agent tier must also merge with cluster cache so
+  // namespaces discovered via health-check fallbacks (pods/events/deploys)
+  // still appear when the agent returns an incomplete list (e.g. user
+  // lacks cluster-wide `list namespaces` RBAC on some cluster).
+  it('merges cluster cache namespaces with local agent response (#3945)', async () => {
+    mockIsAgentUnavailable.mockReturnValue(false)
+    mockClusterCacheRef.clusters = [
+      { name: 'my-cluster', context: 'ctx', namespaces: ['cache-only-ns', 'fma-mspreitz'] },
+    ]
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ namespaces: [{ name: 'agent-seen-ns' }] }),
+    })
+
+    const { result } = renderHook(() => useNamespaces('my-cluster'))
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+    // Union of agent response and cached namespaces
+    expect(result.current.namespaces).toContain('agent-seen-ns')
+    expect(result.current.namespaces).toContain('cache-only-ns')
+    expect(result.current.namespaces).toContain('fma-mspreitz')
+  })
+
+  // #3945 regression: kubectl proxy tier must also merge with cluster cache.
+  it('merges cluster cache namespaces with kubectl proxy response (#3945)', async () => {
+    mockIsAgentUnavailable.mockReturnValue(false)
+    // Agent fails → tier 2 (kubectl proxy) runs
+    globalThis.fetch = vi.fn().mockRejectedValue(new Error('agent error'))
+    mockClusterCacheRef.clusters = [
+      { name: 'my-cluster', context: 'ctx', namespaces: ['fma-mspreitz'] },
+    ]
+    mockKubectlProxy.getNamespaces.mockResolvedValue(['proxy-ns-1'])
+
+    const { result } = renderHook(() => useNamespaces('my-cluster'))
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+    expect(result.current.namespaces).toContain('proxy-ns-1')
+    expect(result.current.namespaces).toContain('fma-mspreitz')
+  })
+
   it('falls back to REST API when agent fails', async () => {
     mockIsAgentUnavailable.mockReturnValue(true)
     const fakePods = [

--- a/web/src/hooks/mcp/namespaces.ts
+++ b/web/src/hooks/mcp/namespaces.ts
@@ -10,6 +10,29 @@ import type { PodInfo, NamespaceStats } from './types'
 // Use a generous timeout to avoid aborting valid but slow requests.
 const NAMESPACE_FETCH_TIMEOUT_MS = 45000
 
+// mergeWithClusterCache unions `fetched` with any namespaces the cluster
+// cache has recorded for `cluster`. PR #3962 originally applied this merge
+// only to the REST fallback tier, but tiers 1/2 (kc-agent HTTP, kubectl
+// proxy) can also return lists that are missing user namespaces — e.g. a
+// caller without cluster-wide `list namespaces` gets a 403 that short-
+// circuits the List() call, or the agent surfaces only namespaces with
+// running pods. Unioning with the cache at every tier ensures namespaces
+// discovered during cluster-health checks still appear in the dropdown
+// (#3945 regression fix). See useNamespaces callers for the consumer.
+function mergeWithClusterCache(fetched: string[], cluster: string): string[] {
+  const set = new Set<string>()
+  for (const ns of fetched) {
+    if (ns) set.add(ns)
+  }
+  const cachedCluster = clusterCacheRef.clusters.find(c => c.name === cluster)
+  if (cachedCluster?.namespaces) {
+    for (const ns of cachedCluster.namespaces) {
+      if (ns) set.add(ns)
+    }
+  }
+  return Array.from(set).sort()
+}
+
 // When forceLive is true, skip demo mode fallback and always query the real API.
 // Used by GPU Reservations to show live namespaces when running in-cluster with OAuth.
 export function useNamespaces(cluster?: string, forceLive = false) {
@@ -72,7 +95,8 @@ export function useNamespaces(cluster?: string, forceLive = false) {
           if (nsData.length > 0) {
             // Extract just the namespace names
             const nsNames = nsData.map((ns: { name?: string; Name?: string }) => ns.name || ns.Name || '').filter(Boolean)
-            setNamespaces(nsNames)
+            // Merge with cluster cache — see mergeWithClusterCache (#3945).
+            setNamespaces(mergeWithClusterCache(nsNames, cluster))
             setError(null)
             setIsLoading(false)
             reportAgentDataSuccess()
@@ -97,7 +121,8 @@ export function useNamespaces(cluster?: string, forceLive = false) {
         const nsData = await Promise.race([nsPromise, timeoutPromise])
 
         if (nsData && nsData.length > 0) {
-          setNamespaces(nsData)
+          // Merge with cluster cache — see mergeWithClusterCache (#3945).
+          setNamespaces(mergeWithClusterCache(nsData, cluster))
           setError(null)
           setIsLoading(false)
           return
@@ -107,33 +132,22 @@ export function useNamespaces(cluster?: string, forceLive = false) {
       }
     }
 
-    // Fall back to REST API — merge pod-based namespaces with cluster cache
-    // to include namespaces that have no running pods (#3945)
+    // Fall back to REST API — pod-based discovery, then union with the
+    // cluster cache via mergeWithClusterCache (#3945).
     try {
-      const nsSet = new Set<string>()
-
-      // Seed with cluster cache namespaces (discovered during health checks)
-      // so namespaces without pods still appear in the dropdown
-      const cachedCluster = clusterCacheRef.clusters.find(c => c.name === cluster)
-      if (cachedCluster?.namespaces) {
-        for (const ns of cachedCluster.namespaces) {
-          nsSet.add(ns)
-        }
-      }
-
-      // Also add namespaces from pods (may discover recently created namespaces
-      // that the cache hasn't seen yet)
+      const podNs: string[] = []
       try {
         const { data } = await api.get<{ pods: PodInfo[] }>(`/api/mcp/pods?cluster=${encodeURIComponent(cluster)}`)
         for (const pod of (data.pods || [])) {
-          if (pod.namespace) nsSet.add(pod.namespace)
+          if (pod.namespace) podNs.push(pod.namespace)
         }
       } catch {
-        // Non-fatal: we may still have cache namespaces above
+        // Non-fatal: cluster-cache namespaces may still surface below
       }
 
-      if (nsSet.size > 0) {
-        setNamespaces(Array.from(nsSet).sort())
+      const merged = mergeWithClusterCache(podNs, cluster)
+      if (merged.length > 0) {
+        setNamespaces(merged)
         setError(null)
       } else {
         setNamespaces(['default', 'kube-system'])


### PR DESCRIPTION
## Summary

PR #3962 (merged 2026-03-31) originally fixed the GPU reservation namespace dropdown not showing namespaces without running pods. @MikeSpreitzer reopened #3945 on 2026-04-15 with a fresh screenshot: his namespace `fma-mspreitz` on the vllm-d cluster no longer appears in the dropdown when creating a new reservation.

## Root cause

The fix in #3962 was applied to only one of three fetch tiers in `useNamespaces()`. The hook tries three tiers in order:

1. kc-agent HTTP (`${LOCAL_AGENT_URL}/namespaces`)
2. kubectl proxy via WebSocket
3. REST fallback (`/api/mcp/pods` — pod-based discovery)

PR #3962 added the cluster-cache merge to **tier 3 only**. Whichever tier returns a non-empty list **wins and short-circuits** — so when tier 1 or tier 2 succeeds with an incomplete list (missing `fma-mspreitz` because the user lacks cluster-wide `list namespaces` RBAC, or because the namespace has no running pods), the merge never runs and the dropdown appears broken.

Secondary issue: even the cluster-cache itself is pod-based in the unlucky case. `detectClusterDistribution()` in `hooks/mcp/shared.ts` falls back to `pods`/`events`/`deployments` endpoints when kubectl cluster-wide namespace list fails. An empty namespace with no pods, events or deployments will never appear via any of these paths.

## Fix (belt + suspenders)

1. **`web/src/hooks/mcp/namespaces.ts`** — extract `mergeWithClusterCache()` helper and call it at **all three** fetch tiers, not just tier 3. Every tier now unions its result with `clusterCacheRef` namespaces before `setNamespaces()`, so any namespace discovered during cluster health checks surfaces regardless of which tier won the race.
2. **`web/src/components/gpu/ReservationFormModal.tsx`** — accept a new `knownNamespacesByCluster` prop and union it into the dropdown options. This is a final fallback that works even when every namespace-discovery path fails: any namespace the user has previously reserved against is known to the GPU reservations store, so it must be selectable when creating a new reservation.
3. **`web/src/components/gpu/GPUReservations.tsx`** — compute `knownNamespacesByCluster` from `allReservations` and pass it down to the modal.
4. **`web/src/hooks/mcp/__tests__/namespaces.test.ts`** — add two regression tests that exercise the cluster-cache merge at the agent and kubectl-proxy tiers (previously only tier 3 had this coverage).

## Why the #3962 fix worked at the time but not now

Mike probably had running workloads in `fma-mspreitz` when #3962 shipped, so the pod-based discovery in tier 3 (and the cluster-cache pods fallback) happened to surface the namespace. Once the pods went away (reservation ended / user scaled down), the namespace became invisible to every pod-based path and the original half-fix stopped covering his case. No new code broke anything — the #3962 fix was architecturally incomplete.

## Test plan

- [x] `npm run build` passes
- [x] `npx vitest run src/hooks/mcp/__tests__/namespaces.test.ts` — 42 tests pass (including 2 new regression tests)
- [x] `npx vitest run src/components/gpu/GPUReservations.test.tsx` — passes
- [x] `go build ./...` passes
- [x] No new lint errors in touched files

### For @MikeSpreitzer to verify on vllm-d

1. Pull this branch once merged.
2. Open GPU Reservations and click **New Reservation**.
3. Select the vllm-d cluster.
4. In the Namespace dropdown, `fma-mspreitz` should appear (either because the hook merged it in via cluster cache, or because you have an existing reservation there and the new `knownNamespacesByCluster` prop surfaces it).
5. If it still doesn't appear, please share:
   - Output of `kubectl auth can-i list namespaces --all-namespaces` against vllm-d with your kubeconfig context.
   - The kc-agent logs from around the time you open the modal (`kc-agent` logs `error fetching namespaces` if `Namespaces().List()` fails).
   - Browser devtools Network tab filtered by `namespaces` to see what tier 1 / tier 2 / tier 3 return.

Fixes #3945

🤖 Generated with [Claude Code](https://claude.com/claude-code)