### PR TITLE
🐛 fix: address Copilot review on namespace dropdown PR (#8056)

### DIFF
--- a/web/src/components/gpu/GPUReservations.tsx
+++ b/web/src/components/gpu/GPUReservations.tsx
@@ -235,14 +235,23 @@ export function GPUReservations() {
   // Fallback source for the Create Reservation dropdown when useNamespaces()
   // can't surface a namespace (e.g. user lacks cluster-wide list RBAC AND
   // the namespace has no running pods, so neither health-check discovery
-  // nor the /api/mcp/pods-based REST fallback sees it). See #3945.
+  // nor the /api/mcp/pods-based REST fallback sees it).
   const knownNamespacesByCluster = useMemo(() => {
-    const out: Record<string, string[]> = {}
+    // Use a Map<string, Set<string>> to dedupe in O(1) per entry.
+    const byCluster = new Map<string, Set<string>>()
     for (const r of (allReservations || [])) {
       if (!r.cluster || !r.namespace) continue
-      if (!out[r.cluster]) out[r.cluster] = []
-      if (!out[r.cluster].includes(r.namespace)) out[r.cluster].push(r.namespace)
+      let set = byCluster.get(r.cluster)
+      if (!set) {
+        set = new Set<string>()
+        byCluster.set(r.cluster, set)
+      }
+      set.add(r.namespace)
     }
+    const out: Record<string, string[]> = {}
+    byCluster.forEach((set, cluster) => {
+      out[cluster] = Array.from(set)
+    })
     return out
   }, [allReservations])
 

--- a/web/src/components/gpu/ReservationFormModal.tsx
+++ b/web/src/components/gpu/ReservationFormModal.tsx
@@ -117,11 +117,11 @@ export function ReservationFormModal({
   forceLive?: boolean
   /**
    * Map of cluster name → namespaces known to have existing reservations.
-   * Provided by GPUReservations as a belt-and-suspenders fallback for
-   * #3945: even if `useNamespaces()` misses a namespace (because the
-   * user lacks cluster-wide list RBAC and it has no running pods), any
-   * namespace the user has previously reserved in will still surface in
-   * the dropdown.
+   * Union'd with the `useNamespaces()` result as a fallback when the fetch
+   * tiers don't return them (e.g. user lacks cluster-wide list RBAC and the
+   * namespace has no running pods). System namespaces (default, kube-system,
+   * kube-*, openshift-*, etc.) are still filtered out of the dropdown
+   * regardless of what this prop contains.
    */
   knownNamespacesByCluster?: Record<string, string[]>
   onSave: (input: CreateGPUReservationInput | UpdateGPUReservationInput) => Promise<string | void>
@@ -205,12 +205,12 @@ export function ReservationFormModal({
   const { namespaces: rawNamespaces } = useNamespaces(cluster || undefined, forceLive)
 
   // Union the hook result with namespaces from existing reservations on
-  // this cluster. See `knownNamespacesByCluster` prop doc (#3945).
-  const mergedRawNamespaces = (() => {
+  // this cluster. Memoized to avoid re-allocating on every keystroke.
+  const mergedRawNamespaces = useMemo(() => {
     const knownForCluster = (cluster && knownNamespacesByCluster?.[cluster]) || []
     if (knownForCluster.length === 0) return rawNamespaces
     return Array.from(new Set<string>([...rawNamespaces, ...knownForCluster])).sort()
-  })()
+  }, [rawNamespaces, cluster, knownNamespacesByCluster])
 
   // Filter out system namespaces from the dropdown
   const FILTERED_NS_PREFIXES = ['openshift-', 'kube-']

--- a/web/src/hooks/mcp/namespaces.ts
+++ b/web/src/hooks/mcp/namespaces.ts
@@ -110,24 +110,28 @@ export function useNamespaces(cluster?: string, forceLive = false) {
 
     // Try kubectl proxy as fallback
     if (!isAgentUnavailable()) {
+      let timerId: ReturnType<typeof setTimeout> | null = null
       try {
         const clusterInfo = clusterCacheRef.clusters.find(c => c.name === cluster)
         const kubectlContext = clusterInfo?.context || cluster
 
         const nsPromise = kubectlProxy.getNamespaces(kubectlContext)
-        const timeoutPromise = new Promise<null>((resolve) =>
-          setTimeout(() => resolve(null), NAMESPACE_FETCH_TIMEOUT_MS)
-        )
+        const timeoutPromise = new Promise<null>((resolve) => {
+          timerId = setTimeout(() => resolve(null), NAMESPACE_FETCH_TIMEOUT_MS)
+        })
         const nsData = await Promise.race([nsPromise, timeoutPromise])
+        // Clear the stray timer if nsPromise won the race.
+        if (timerId !== null) clearTimeout(timerId)
 
         if (nsData && nsData.length > 0) {
-          // Merge with cluster cache — see mergeWithClusterCache (#3945).
+          // Merge with cluster cache — see mergeWithClusterCache.
           setNamespaces(mergeWithClusterCache(nsData, cluster))
           setError(null)
           setIsLoading(false)
           return
         }
       } catch (err) {
+        if (timerId !== null) clearTimeout(timerId)
         console.error(`[useNamespaces] kubectl proxy failed for ${cluster}:`, err)
       }
     }


### PR DESCRIPTION
## Summary

Follow-up to merged PR #8054 (fix for issue #3945). Addresses 4 Copilot review comments left on that PR.

### 1. `ReservationFormModal.tsx` — `mergedRawNamespaces` re-allocates on every render
Before: computed via an IIFE so the `Set` allocation + `.sort()` ran on every keystroke in the form.
After: wrapped in `useMemo` keyed on `[rawNamespaces, cluster, knownNamespacesByCluster]`. The parent (`GPUReservations`) already memoizes `knownNamespacesByCluster`, so reference equality holds.

### 2. `ReservationFormModal.tsx` — misleading `knownNamespacesByCluster` JSDoc
Before: said any previously-reserved namespace would "still surface in the dropdown".
After: accurately states that system namespaces (`default`, `kube-system`, `kube-*`, `openshift-*`, etc.) are still filtered out of the dropdown regardless of what this prop contains. (The filter is correct — system namespaces should stay filtered — so only the docstring was wrong.)

### 3. `GPUReservations.tsx` — O(n²) dedup in `knownNamespacesByCluster`
Before: nested loop with `Array.includes` for each reservation → O(n²) worst case.
After: accumulates into a `Map<string, Set<string>>` during the loop (O(1) dedup per entry), then converts to `Record<string, string[]>` via `Map.forEach`.

### 4. `useNamespaces` kubectl-proxy tier — `setTimeout` never cleared when `nsPromise` wins the race
Before: `timeoutPromise` called `setTimeout` but never captured the id, so when `nsPromise` resolved first the stray timer lived for up to `NAMESPACE_FETCH_TIMEOUT_MS` (45s) after the hook had already returned.
After: capture `timerId` in an outer `let`, set it inside the `Promise` executor, and `clearTimeout` it in both the success path (after `Promise.race` resolves) and the `catch` path. This matches the pattern the local-agent tier above already uses.

## Test plan
- [x] `web && npx vitest run src/hooks/mcp/__tests__/namespaces.test.ts` — 42 passed
- [x] `web && npx vitest run src/components/gpu/` — 2 passed
- [x] `web && npm run build` — passes, all post-build safety checks green
- [x] `web && npm run lint` — no new errors introduced in the 3 touched files (pre-existing warnings unrelated)

Fixes #8056

Parent PR: #8054
Original issue: #3945