### PR TITLE
🐛 fix: batch-fix 6 real bugs from @khushiiagrawal scan

### DIFF
--- a/pkg/agent/kagenti.go
+++ b/pkg/agent/kagenti.go
@@ -5,13 +5,33 @@ import (
 	"encoding/json"
 	"log/slog"
 	"net/http"
+	"strings"
 	"sync"
 	"time"
 
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
+
+// isCRDNotInstalledErr reports whether err indicates that the requested
+// custom resource definition is not installed on the target cluster.
+// This is the only "not an error" condition the kagenti handlers should
+// suppress — every other failure (RBAC denied, timeout, etc.) must be
+// surfaced to the caller.
+func isCRDNotInstalledErr(err error) bool {
+	if err == nil {
+		return false
+	}
+	if _, ok := err.(*meta.NoKindMatchError); ok {
+		return true
+	}
+	msg := err.Error()
+	return strings.Contains(msg, "the server could not find the requested resource") ||
+		strings.Contains(msg, "no matches for kind")
+}
 
 const (
 	kagentiTimeout = 30 * time.Second
@@ -163,8 +183,13 @@ func (s *Server) handleKagentiAgents(w http.ResponseWriter, r *http.Request) {
 		list, err = dynClient.Resource(kagentiAgentGVR).List(ctx, metav1.ListOptions{})
 	}
 	if err != nil {
-		// CRD not installed is expected — return empty list, not error
-		json.NewEncoder(w).Encode(map[string]any{"agents": []any{}})
+		if apierrors.IsNotFound(err) || isCRDNotInstalledErr(err) {
+			json.NewEncoder(w).Encode(map[string]any{"agents": []any{}})
+			return
+		}
+		slog.Warn("error listing kagenti agents", "cluster", cluster, "error", err)
+		w.WriteHeader(http.StatusInternalServerError)
+		json.NewEncoder(w).Encode(map[string]any{"agents": []any{}, "error": err.Error()})
 		return
 	}
 
@@ -252,7 +277,13 @@ func (s *Server) handleKagentiBuilds(w http.ResponseWriter, r *http.Request) {
 		list, err = dynClient.Resource(kagentiBuildGVR).List(ctx, metav1.ListOptions{})
 	}
 	if err != nil {
-		json.NewEncoder(w).Encode(map[string]any{"builds": []any{}})
+		if apierrors.IsNotFound(err) || isCRDNotInstalledErr(err) {
+			json.NewEncoder(w).Encode(map[string]any{"builds": []any{}})
+			return
+		}
+		slog.Warn("error listing kagenti builds", "cluster", cluster, "error", err)
+		w.WriteHeader(http.StatusInternalServerError)
+		json.NewEncoder(w).Encode(map[string]any{"builds": []any{}, "error": err.Error()})
 		return
 	}
 
@@ -331,7 +362,13 @@ func (s *Server) handleKagentiCards(w http.ResponseWriter, r *http.Request) {
 		list, err = dynClient.Resource(kagentiCardGVR).List(ctx, metav1.ListOptions{})
 	}
 	if err != nil {
-		json.NewEncoder(w).Encode(map[string]any{"cards": []any{}})
+		if apierrors.IsNotFound(err) || isCRDNotInstalledErr(err) {
+			json.NewEncoder(w).Encode(map[string]any{"cards": []any{}})
+			return
+		}
+		slog.Warn("error listing kagenti cards", "cluster", cluster, "error", err)
+		w.WriteHeader(http.StatusInternalServerError)
+		json.NewEncoder(w).Encode(map[string]any{"cards": []any{}, "error": err.Error()})
 		return
 	}
 
@@ -408,7 +445,13 @@ func (s *Server) handleKagentiTools(w http.ResponseWriter, r *http.Request) {
 		list, err = dynClient.Resource(kagentiToolGVR).List(ctx, metav1.ListOptions{})
 	}
 	if err != nil {
-		json.NewEncoder(w).Encode(map[string]any{"tools": []any{}})
+		if apierrors.IsNotFound(err) || isCRDNotInstalledErr(err) {
+			json.NewEncoder(w).Encode(map[string]any{"tools": []any{}})
+			return
+		}
+		slog.Warn("error listing kagenti tools", "cluster", cluster, "error", err)
+		w.WriteHeader(http.StatusInternalServerError)
+		json.NewEncoder(w).Encode(map[string]any{"tools": []any{}, "error": err.Error()})
 		return
 	}
 

--- a/pkg/agent/local_clusters.go
+++ b/pkg/agent/local_clusters.go
@@ -481,27 +481,44 @@ func (m *LocalClusterManager) StartCluster(tool, name string) error {
 }
 
 func (m *LocalClusterManager) startKindCluster(name string) error {
-	// kind clusters run as Docker containers — start all containers with the cluster label
-	cmd := execCommand("docker", "start", name+"-control-plane")
-	var stderr bytes.Buffer
-	cmd.Stderr = &stderr
-	if err := cmd.Run(); err != nil {
-		return fmt.Errorf("failed to start kind cluster containers: %s", stderr.String())
+	containers, err := listKindContainers(name)
+	if err != nil {
+		return fmt.Errorf("failed to list kind cluster containers: %w", err)
 	}
-	// Also start any worker nodes
-	for i := 1; i <= 10; i++ {
-		workerName := fmt.Sprintf("%s-worker%s", name, func() string {
-			if i == 1 {
-				return ""
-			}
-			return fmt.Sprintf("%d", i)
-		}())
-		cmd := execCommand("docker", "start", workerName)
+	if len(containers) == 0 {
+		return fmt.Errorf("no containers found for kind cluster %q", name)
+	}
+	for _, c := range containers {
+		cmd := execCommand("docker", "start", c)
+		var stderr bytes.Buffer
+		cmd.Stderr = &stderr
 		if err := cmd.Run(); err != nil {
-			break // No more workers
+			return fmt.Errorf("failed to start container %q: %s", c, stderr.String())
 		}
 	}
 	return nil
+}
+
+// listKindContainers returns all Docker container names that belong to the
+// given kind cluster, by querying the kind cluster label. This avoids the
+// previous fixed-loop limit of 10 worker nodes.
+func listKindContainers(name string) ([]string, error) {
+	labelFilter := fmt.Sprintf("label=io.x-k8s.kind.cluster=%s", name)
+	cmd := execCommand("docker", "ps", "-a", "--filter", labelFilter, "--format", "{{.Names}}")
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return nil, fmt.Errorf("docker ps failed: %s", stderr.String())
+	}
+	var names []string
+	for _, line := range strings.Split(strings.TrimSpace(stdout.String()), "\n") {
+		line = strings.TrimSpace(line)
+		if line != "" {
+			names = append(names, line)
+		}
+	}
+	return names, nil
 }
 
 func (m *LocalClusterManager) startK3dCluster(name string) error {
@@ -546,24 +563,19 @@ func (m *LocalClusterManager) StopCluster(tool, name string) error {
 }
 
 func (m *LocalClusterManager) stopKindCluster(name string) error {
-	// kind clusters run as Docker containers — stop all containers with the cluster label
-	cmd := execCommand("docker", "stop", name+"-control-plane")
-	var stderr bytes.Buffer
-	cmd.Stderr = &stderr
-	if err := cmd.Run(); err != nil {
-		return fmt.Errorf("failed to stop kind cluster containers: %s", stderr.String())
+	containers, err := listKindContainers(name)
+	if err != nil {
+		return fmt.Errorf("failed to list kind cluster containers: %w", err)
 	}
-	// Also stop any worker nodes
-	for i := 1; i <= 10; i++ {
-		workerName := fmt.Sprintf("%s-worker%s", name, func() string {
-			if i == 1 {
-				return ""
-			}
-			return fmt.Sprintf("%d", i)
-		}())
-		cmd := execCommand("docker", "stop", workerName)
+	if len(containers) == 0 {
+		return fmt.Errorf("no containers found for kind cluster %q", name)
+	}
+	for _, c := range containers {
+		cmd := execCommand("docker", "stop", c)
+		var stderr bytes.Buffer
+		cmd.Stderr = &stderr
 		if err := cmd.Run(); err != nil {
-			break // No more workers
+			return fmt.Errorf("failed to stop container %q: %s", c, stderr.String())
 		}
 	}
 	return nil

--- a/pkg/agent/server_ai.go
+++ b/pkg/agent/server_ai.go
@@ -21,6 +21,16 @@ import (
 // to prevent resource exhaustion from bursty or malicious traffic (#7277).
 const maxWSGoroutines = 20
 
+// wsMaxMessageBytes caps the size of any single WebSocket frame the agent
+// will accept from a client. Without this, an authenticated client could
+// send arbitrarily large prompts that get forwarded to paid LLM APIs.
+const wsMaxMessageBytes = 1 << 20 // 1 MB
+
+// maxPromptChars caps the per-request prompt length forwarded to LLM
+// providers. Set well above interactive use but below the WebSocket frame
+// limit to keep cost and latency bounded.
+const maxPromptChars = 100_000
+
 func (s *Server) handleWebSocket(w http.ResponseWriter, r *http.Request) {
 	// Handle CORS preflight for Private Network Access (required by Chrome 104+)
 	if r.Method == http.MethodOptions {
@@ -48,6 +58,7 @@ func (s *Server) handleWebSocket(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	defer conn.Close()
+	conn.SetReadLimit(wsMaxMessageBytes)
 
 	wsc := &wsClient{}
 	s.clientsMux.Lock()
@@ -431,6 +442,12 @@ func (s *Server) handleChatMessageStreaming(conn *websocket.Conn, msg protocol.M
 
 	if req.Prompt == "" {
 		safeWrite(context.Background(), s.errorResponse(msg.ID, "empty_prompt", "Prompt cannot be empty"))
+		return
+	}
+
+	if len(req.Prompt) > maxPromptChars {
+		safeWrite(context.Background(), s.errorResponse(msg.ID, "prompt_too_large",
+			fmt.Sprintf("Prompt exceeds maximum length of %d characters", maxPromptChars)))
 		return
 	}
 

--- a/pkg/agent/server_http.go
+++ b/pkg/agent/server_http.go
@@ -285,11 +285,17 @@ func (s *Server) handleEventsHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Filter by object name if specified
+	// Filter by object name if specified. e.Object is formatted as
+	// "Kind/Name" (see pkg/k8s/client_resources.go); compare the Name
+	// segment exactly so a query like "my-app" does not match "my-app-v2".
 	if objectName != "" {
-		var filtered []k8s.Event
+		filtered := make([]k8s.Event, 0, len(events))
 		for _, e := range events {
-			if strings.Contains(e.Object, objectName) {
+			name := e.Object
+			if idx := strings.Index(name, "/"); idx >= 0 {
+				name = name[idx+1:]
+			}
+			if name == objectName {
 				filtered = append(filtered, e)
 			}
 		}

--- a/pkg/agent/server_operations.go
+++ b/pkg/agent/server_operations.go
@@ -694,7 +694,10 @@ func checkStatuspageHealth(client *http.Client, apiURL string) string {
 	if err != nil {
 		return "unknown"
 	}
-	defer resp.Body.Close()
+	defer func() {
+		io.Copy(io.Discard, resp.Body)
+		resp.Body.Close()
+	}()
 
 	if resp.StatusCode != http.StatusOK {
 		return "unknown"

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -174,12 +174,12 @@ try {
  * @param forceCheck - If true, ignores cache and always checks (used by login)
  */
 export async function checkBackendAvailability(forceCheck = false): Promise<boolean> {
-  // If we already know the status and it was checked recently, return it
+  // If we already know the status and it was checked recently, return it.
+  // The TTL gate must always run so a previously-available backend is
+  // re-probed periodically instead of being cached forever.
   if (!forceCheck && backendAvailable !== null) {
     const now = Date.now()
-    // If backend was already determined available, return immediately
-    // If unavailable, allow re-check after interval
-    if (backendAvailable || now - backendLastCheckTime < BACKEND_CHECK_INTERVAL) {
+    if (now - backendLastCheckTime < BACKEND_CHECK_INTERVAL) {
       return backendAvailable
     }
   }


### PR DESCRIPTION
## Summary

This PR batch-fixes 6 real bugs triaged out of a 17-issue scan filed by @khushiiagrawal. The other 11 issues were closed as not-a-bug after individual verification.

### Fixes

- **#8070 — WebSocket missing `SetReadLimit` (DoS hardening)** — `pkg/agent/server_ai.go`. Added `wsMaxMessageBytes = 1 MB` on the WebSocket connection right after `Upgrade`, plus an application-level `maxPromptChars = 100_000` check before forwarding chat prompts to the LLM provider. Closes the cost/DoS surface where an authenticated client could send arbitrarily large prompts.

- **#8057 — `startKindCluster` worker loop capped at 10** — `pkg/agent/local_clusters.go`. The old loop iterated `worker1..worker10` and broke on first error, so kind clusters with more than 10 workers (or non-default worker names) were silently skipped. Replaced with a label-scoped query: `docker ps -a --filter label=io.x-k8s.kind.cluster=<name>`. Same fix applied to the stop loop. Extracted into `listKindContainers` helper.

- **#8061 — `backendAvailable` positive cache never expires** — `web/src/lib/api.ts`. The TTL gate was bypassed by a `backendAvailable ||` short-circuit, so once the backend was determined available it was cached forever (a backend going down mid-session was never re-detected). Dropped the disjunct so the `BACKEND_CHECK_INTERVAL` gate always runs.

- **#8064 — `handleEventsHTTP` name filter uses `strings.Contains`** — `pkg/agent/server_http.go`. Filtering for events on `my-app` also returned events for `my-app-v2`, `my-app-canary`, etc. `Event.Object` is `Kind/Name` (see `pkg/k8s/client_resources.go`), so the fix splits on `/` and compares the Name segment exactly.

- **#8065 — `handleKagentiAgents` swallows CRD errors silently** — `pkg/agent/kagenti.go`. All four kagenti list handlers (agents, builds, cards, tools) collapsed every error into an empty list, silently hiding RBAC denials and timeouts. Added an `isCRDNotInstalledErr` helper that suppresses only `meta.NoKindMatchError` / "no matches for kind" / "the server could not find the requested resource", and surfaces every other error to the caller.

- **#8069 — `checkStatuspageHealth` never drains body** — `pkg/agent/server_operations.go`. `json.NewDecoder(resp.Body).Decode(...)` may leave trailing bytes, preventing the HTTP keepalive connection from being reused. Added `io.Copy(io.Discard, resp.Body)` before `resp.Body.Close()`.

Fixes #8057
Fixes #8061
Fixes #8064
Fixes #8065
Fixes #8069
Fixes #8070

## Test plan

- [x] `go build ./...` passes
- [x] `go vet ./...` clean
- [x] `go test ./pkg/agent/...` passes (existing suite, 62s)
- [x] `cd web && npm run build` passes (full vite build + post-build safety checks)
- [x] `cd web && npm run lint` baseline unchanged (1115 problems both before and after — none introduced by this PR)
- [x] `cd web && npx vitest run src/lib/__tests__/api.test.ts` — 45/45 tests pass
- [ ] Manual verification: kind cluster with 12 workers — start/stop now operates on all containers
- [ ] Manual verification: backend going down mid-session — frontend now re-checks after `BACKEND_CHECK_INTERVAL`
- [ ] Manual verification: events drill-down for `my-app` no longer matches `my-app-v2`