### PR TITLE
fix(agent): drain Statuspage response body after JSON decode

### DIFF
--- a/pkg/agent/server_operations.go
+++ b/pkg/agent/server_operations.go
@@ -708,6 +708,11 @@ func checkStatuspageHealth(client *http.Client, apiURL string) string {
 	if err := json.NewDecoder(resp.Body).Decode(&data); err != nil {
 		return "unknown"
 	}
+	// Drain any unread portion of the body so the underlying TCP connection
+	// can be returned to the pool instead of held open until the HTTP client
+	// timeout fires. Statuspage payloads include fields we don't decode,
+	// which left the decoder stopped mid-stream.
+	_, _ = io.Copy(io.Discard, resp.Body)
 
 	switch data.Status.Indicator {
 	case "none":

--- a/pkg/agent/server_test.go
+++ b/pkg/agent/server_test.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"os/exec"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -2219,6 +2220,49 @@ func TestCheckStatuspageHealth(t *testing.T) {
 				t.Errorf("checkStatuspageHealth() = %s, want %s", result, tt.expected)
 			}
 		})
+	}
+}
+
+// TestCheckStatuspageHealth_DrainsBody verifies that checkStatuspageHealth
+// reads the entire response body even when the JSON decoder only consumes
+// the `status` field. Without draining, the underlying TCP connection is
+// held open until the HTTP client timeout, slowly exhausting the pool.
+func TestCheckStatuspageHealth_DrainsBody(t *testing.T) {
+	// Deliberately include extra fields AFTER `status` so the JSON decoder
+	// stops reading before EOF. If the body isn't drained, the bytes
+	// after `status` remain in the socket buffer.
+	response := `{"status":{"indicator":"none"},"components":[],"incidents":[],"scheduled_maintenances":[],"page":{"id":"x","name":"y","url":"z"}}`
+
+	var readCount int64
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		n, _ := io.WriteString(w, response)
+		atomic.StoreInt64(&readCount, int64(n))
+	}))
+	defer srv.Close()
+
+	client := srv.Client()
+	result := checkStatuspageHealth(client, srv.URL)
+	if result != "operational" {
+		t.Fatalf("checkStatuspageHealth() = %s, want operational", result)
+	}
+
+	// Issue a second request on the same client. If the first response's
+	// body was drained, the client should reuse the connection without
+	// waiting for a timeout. We assert the second call completes promptly
+	// as a proxy for the connection being returned to the pool.
+	start := time.Now()
+	result = checkStatuspageHealth(client, srv.URL)
+	elapsed := time.Since(start)
+	if result != "operational" {
+		t.Fatalf("second call: checkStatuspageHealth() = %s, want operational", result)
+	}
+	if elapsed > 2*time.Second {
+		t.Errorf("second call took %s; expected connection reuse (<2s)", elapsed)
+	}
+
+	if atomic.LoadInt64(&readCount) == 0 {
+		t.Error("server never wrote a response — test setup bug")
 	}
 }
 


### PR DESCRIPTION
## Summary

Addresses #8069. `checkStatuspageHealth` in `pkg/agent/server_operations.go` was calling `json.NewDecoder(resp.Body).Decode(&data)`, which stops reading as soon as the top-level `status` field is consumed. Statuspage payloads include `components`, `incidents`, `scheduled_maintenances`, and `page` fields after `status`, so those bytes stayed in the socket buffer and the underlying TCP connection could not be returned to the keep-alive pool until the HTTP client timeout fired.

Under sustained `/providers/health` polling this slowly exhausted the connection pool.

## Fix

One line: `io.Copy(io.Discard, resp.Body)` after `Decode`, before `defer resp.Body.Close()` runs. The error is intentionally discarded (`_, _ =`) because we're already past the meaningful JSON and only care about freeing the connection.

## Test plan

- [x] `go test ./pkg/agent/ -run TestCheckStatuspageHealth` — all pre-existing cases still pass
- [x] Added `TestCheckStatuspageHealth_DrainsBody` — uses a realistic multi-field Statuspage response, asserts a second call on the same client completes in <2s as a proxy for connection reuse, and sanity-checks the server actually wrote bytes
- [x] `go build ./...` clean
- [x] `go vet ./pkg/agent/...` clean

Closes #8069