### PR TITLE
🐛 fix: skip zero-total snapshots in GPU Inventory History (#8080)

### DIFF
--- a/web/src/components/cards/GPUInventoryHistory.tsx
+++ b/web/src/components/cards/GPUInventoryHistory.tsx
@@ -4,6 +4,7 @@ import {
   BarChart3, Table2, ChevronDown, ArrowUpDown } from 'lucide-react'
 import ReactECharts from 'echarts-for-react'
 import { useMetricsHistory } from '../../hooks/useMetricsHistory'
+import type { MetricsSnapshot } from '../../types/predictions'
 import { useCachedGPUNodes } from '../../hooks/useCachedData'
 import { useDemoMode } from '../../hooks/useDemoMode'
 import { useGlobalFilters } from '../../hooks/useGlobalFilters'
@@ -461,7 +462,7 @@ export function GPUInventoryHistory() {
       return generateDemoData()
     }
 
-    return (history || []).map(snapshot => {
+    const points = (history || []).map(snapshot => {
       const filtered = filterGPUNodes(snapshot.gpuNodes || [])
       const allocated = filtered.reduce((sum, g) => sum + (g.gpuAllocated || 0), 0)
       const total = filtered.reduce((sum, g) => sum + (g.gpuTotal || 0), 0)
@@ -488,6 +489,19 @@ export function GPUInventoryHistory() {
 
       return point
     })
+
+    // Defensive filter: if any point in the series has a non-zero total, drop
+    // points whose total is zero. A zero-total point next to non-zero points
+    // is almost always a transient GPU-fetch glitch that slipped through
+    // carry-forward protection in useMetricsHistory. Keeps the chart,
+    // stats, and trend math from showing misleading flapping zero bars.
+    // If EVERY point has total === 0 (legitimate no-GPU state) we leave the
+    // series alone so the empty-state paths still fire correctly.
+    const anyNonZero = points.some(p => p.total > 0)
+    if (anyNonZero) {
+      return points.filter(p => p.total > 0)
+    }
+    return points
   }, [history, showDemo, filterGPUNodes, chartMode])
 
   /** All GPU type keys present in chart data */
@@ -559,15 +573,24 @@ export function GPUInventoryHistory() {
 
   // ── Churn metrics ──────────────────────────────────────────────────
   const churnMetrics = useMemo<ChurnMetrics | null>(() => {
-    if (showDemo || (history || []).length < MIN_CHURN_SNAPSHOTS) return null
+    // Drop snapshots with zero total GPUs before diffing so transient empty
+    // captures don't show up as massive departure/arrival churn.
+    const churnHistory = (history || []).filter(s => {
+      const nodes = s.gpuNodes || []
+      if (nodes.length === 0) return false
+      const total = nodes.reduce((sum, g) => sum + (g.gpuTotal || 0), 0)
+      return total > 0
+    })
+
+    if (showDemo || churnHistory.length < MIN_CHURN_SNAPSHOTS) return null
 
     let totalArrivals = 0
     let totalDepartures = 0
     let diffCount = 0
 
-    for (let i = 1; i < (history || []).length; i++) {
-      const prev = filterGPUNodes((history || [])[i - 1].gpuNodes || [])
-      const curr = filterGPUNodes((history || [])[i].gpuNodes || [])
+    for (let i = 1; i < churnHistory.length; i++) {
+      const prev = filterGPUNodes(churnHistory[i - 1].gpuNodes || [])
+      const curr = filterGPUNodes(churnHistory[i].gpuNodes || [])
 
       // Per-node diffing captures churn even when allocations and frees cancel at aggregate level
       const prevMap: Record<string, number> = {}
@@ -631,7 +654,24 @@ export function GPUInventoryHistory() {
   const tableRows = (() => {
     if (showDemo) return generateDemoTableRows()
 
-    const latestSnapshot = (history || []).length > 0 ? (history || [])[(history || []).length - 1] : null
+    // Walk history from the end and pick the most recent snapshot whose
+    // total GPU count is non-zero. Falls back to the literal latest (even if
+    // zero) so genuine no-GPU clusters still render an empty table rather
+    // than a stale one.
+    let latestSnapshot: MetricsSnapshot | null = null
+    const hist = history || []
+    for (let i = hist.length - 1; i >= 0; i--) {
+      const s = hist[i]
+      const nodes = s.gpuNodes || []
+      const total = nodes.reduce((sum, g) => sum + (g.gpuTotal || 0), 0)
+      if (total > 0) {
+        latestSnapshot = s
+        break
+      }
+    }
+    if (!latestSnapshot && hist.length > 0) {
+      latestSnapshot = hist[hist.length - 1]
+    }
     if (!latestSnapshot) return []
 
     const filtered = filterGPUNodes(latestSnapshot.gpuNodes || [])

--- a/web/src/components/cards/__tests__/GPUInventoryHistory.test.tsx
+++ b/web/src/components/cards/__tests__/GPUInventoryHistory.test.tsx
@@ -49,7 +49,8 @@ vi.mock('../../../hooks/useGlobalFilters', () => ({
   useGlobalFilters: () => ({ selectedClusters: [], isAllClustersSelected: true, selectedSeverities: [], isAllSeveritiesSelected: true, customFilter: '' }),
 }))
 
-vi.mock('../../../hooks/useMetricsHistory', () => ({ useMetricsHistory: () => ({ history: [], isLoading: false }) }))
+const mockUseMetricsHistory = vi.fn(() => ({ history: [], isLoading: false }))
+vi.mock('../../../hooks/useMetricsHistory', () => ({ useMetricsHistory: () => mockUseMetricsHistory() }))
 
 import { GPUInventoryHistory } from '../GPUInventoryHistory'
 
@@ -59,6 +60,7 @@ describe('GPUInventoryHistory', () => {
     mockUseDemoMode.mockReturnValue({ isDemoMode: true, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() })
     mockUseCardLoadingState.mockReturnValue({ showSkeleton: false, showEmptyState: false, hasData: true, isRefreshing: false })
     mockGPUNodes.mockReturnValue({ nodes: [], isLoading: false, isRefreshing: false, isDemoFallback: false, isFailed: false, consecutiveFailures: 0, error: null, lastRefresh: Date.now() })
+    mockUseMetricsHistory.mockReturnValue({ history: [], isLoading: false })
   })
 
   it('renders without crashing', () => {
@@ -100,6 +102,29 @@ describe('GPUInventoryHistory', () => {
     mockGPUNodes.mockReturnValue({ nodes: [], isLoading: false, isRefreshing: false, isDemoFallback: true, isFailed: false, consecutiveFailures: 0, error: null, lastRefresh: Date.now() })
     render(<GPUInventoryHistory />)
     expect(mockUseCardLoadingState).toHaveBeenCalled()
+  })
+
+  it('renders without crashing when history contains a zero-total snapshot mixed with real data', () => {
+    // Regression guard for the flapping-zeros bug: a transient empty capture
+    // slipping through carry-forward should be filtered visually so the
+    // component still renders cleanly.
+    mockUseDemoMode.mockReturnValue({ isDemoMode: false, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() })
+    mockGPUNodes.mockReturnValue({
+      nodes: [{ name: 'node-a', cluster: 'cl-1', gpuType: 'H100', gpuAllocated: 2, gpuCount: 8 }],
+      isLoading: false, isRefreshing: false, isDemoFallback: false,
+      isFailed: false, consecutiveFailures: 0, error: null, lastRefresh: Date.now(),
+    })
+    mockUseMetricsHistory.mockReturnValue({
+      history: [
+        { timestamp: new Date(Date.now() - 30 * 60 * 1000).toISOString(), clusters: [], podIssues: [], gpuNodes: [{ name: 'node-a', cluster: 'cl-1', gpuType: 'H100', gpuAllocated: 2, gpuCount: 8, gpuTotal: 8, gpuAllocated_: 2 }] },
+        // Transient zero snapshot — must be filtered out of chart/stats
+        { timestamp: new Date(Date.now() - 20 * 60 * 1000).toISOString(), clusters: [], podIssues: [], gpuNodes: [] },
+        { timestamp: new Date(Date.now() - 10 * 60 * 1000).toISOString(), clusters: [], podIssues: [], gpuNodes: [{ name: 'node-a', cluster: 'cl-1', gpuType: 'H100', gpuAllocated: 3, gpuCount: 8, gpuTotal: 8, gpuAllocated_: 3 }] },
+      ],
+      isLoading: false,
+    })
+    const { container } = render(<GPUInventoryHistory />)
+    expect(container).toBeTruthy()
   })
 
 })

--- a/web/src/hooks/__tests__/useMetricsHistory.test.ts
+++ b/web/src/hooks/__tests__/useMetricsHistory.test.ts
@@ -789,6 +789,75 @@ describe('useMetricsHistory', () => {
     })
   })
 
+  // ── GPU carry-forward protection (issue referenced in commit/PR body) ──
+  describe('GPU carry-forward protection for transient empty fetches', () => {
+    it('carries forward last known gpuNodes when a single capture has empty GPUs', async () => {
+      // Seed with a snapshot that has real GPU nodes
+      mockClusters.push({ name: 'c1', cpuCores: 4, cpuUsageCores: 2, memoryGB: 8, memoryUsageGB: 4, nodeCount: 1, healthy: true })
+      mockGPUNodes.push({ name: 'gpu-node-1', cluster: 'c1', gpuType: 'NVIDIA H100', gpuAllocated: 3, gpuCount: 8 })
+
+      const { useMetricsHistory } = await importFresh()
+      const { result } = renderHook(() => useMetricsHistory())
+
+      // First capture: real GPU data
+      act(() => { result.current.captureNow() })
+      const firstLatest = result.current.history[result.current.history.length - 1]
+      expect(firstLatest.gpuNodes).toHaveLength(1)
+      expect(firstLatest.gpuNodes[0].gpuTotal).toBe(8)
+
+      // Simulate transient fetch failure: gpuNodes list goes empty
+      mockGPUNodes.length = 0
+
+      // Second capture: should carry forward the previous gpuNodes
+      act(() => { result.current.captureNow() })
+      const secondLatest = result.current.history[result.current.history.length - 1]
+      expect(secondLatest.gpuNodes).toHaveLength(1)
+      expect(secondLatest.gpuNodes[0].name).toBe('gpu-node-1')
+      expect(secondLatest.gpuNodes[0].gpuTotal).toBe(8)
+    })
+
+    it('eventually accepts empty GPU state after the carry-forward window expires', async () => {
+      // MAX_GPU_CARRY_FORWARD = 2 — after two empty captures, the third must reflect the empty state.
+      mockClusters.push({ name: 'c1', cpuCores: 4, cpuUsageCores: 2, memoryGB: 8, memoryUsageGB: 4, nodeCount: 1, healthy: true })
+      mockGPUNodes.push({ name: 'gpu-node-1', cluster: 'c1', gpuType: 'NVIDIA H100', gpuAllocated: 3, gpuCount: 8 })
+
+      const { useMetricsHistory } = await importFresh()
+      const { result } = renderHook(() => useMetricsHistory())
+
+      // Capture with real GPU data
+      act(() => { result.current.captureNow() })
+
+      // Now transition to empty GPU state
+      mockGPUNodes.length = 0
+
+      // Two empty captures — both should be carried-forward
+      act(() => { result.current.captureNow() })
+      act(() => { result.current.captureNow() })
+      const afterCarryForward = result.current.history[result.current.history.length - 1]
+      expect(afterCarryForward.gpuNodes).toHaveLength(1)
+
+      // Third consecutive empty capture — must accept the empty state
+      act(() => { result.current.captureNow() })
+      const afterWindow = result.current.history[result.current.history.length - 1]
+      expect(afterWindow.gpuNodes).toHaveLength(0)
+    })
+
+    it('does not carry-forward when previous snapshot also had empty gpuNodes', async () => {
+      // Non-GPU cluster: every capture has empty gpuNodes — must not carry forward.
+      mockClusters.push({ name: 'c1', cpuCores: 4, cpuUsageCores: 2, memoryGB: 8, memoryUsageGB: 4, nodeCount: 1, healthy: true })
+      // mockGPUNodes intentionally left empty
+
+      const { useMetricsHistory } = await importFresh()
+      const { result } = renderHook(() => useMetricsHistory())
+
+      act(() => { result.current.captureNow() })
+      act(() => { result.current.captureNow() })
+
+      const latest = result.current.history[result.current.history.length - 1]
+      expect(latest.gpuNodes).toHaveLength(0)
+    })
+  })
+
   describe('trend edge cases', () => {
     it('getClusterTrend returns "stable" for a non-existent cluster', async () => {
       const snaps = [

--- a/web/src/hooks/useMetricsHistory.ts
+++ b/web/src/hooks/useMetricsHistory.ts
@@ -10,10 +10,24 @@ const MAX_SNAPSHOTS = 1008 // 7 days at 10-min intervals (6 per hour * 24 hours 
 const CACHE_TTL_MS = 7 * 24 * 60 * 60 * 1000
 /** Maximum number of increasing-restart pods to include in AI context */
 const MAX_INCREASING_RESTART_PODS = 10
+/**
+ * Maximum consecutive snapshots whose empty GPU data will be carried-forward
+ * from the last known non-empty gpuNodes list. Prevents a transient GPU fetch
+ * glitch (SSE race, partial cluster reachability) from being persisted as a
+ * zero-total snapshot in GPU Inventory History while still allowing truly
+ * removed GPUs to reflect after ~2 intervals.
+ */
+const MAX_GPU_CARRY_FORWARD = 2
 
 // Singleton state - shared across all hook instances
 let snapshots: MetricsSnapshot[] = []
 const subscribers = new Set<(snapshots: MetricsSnapshot[]) => void>()
+/**
+ * Tracks how many consecutive captures have had an empty gpuNodes list while
+ * the last persisted snapshot still had GPU inventory. Used to carry-forward
+ * the last known gpuNodes for up to MAX_GPU_CARRY_FORWARD captures.
+ */
+let consecutiveEmptyGPUCaptures = 0
 
 // Initialize from localStorage
 if (typeof window !== 'undefined') {
@@ -97,6 +111,51 @@ function addSnapshot(snapshot: MetricsSnapshot) {
 }
 
 /**
+ * Applies carry-forward protection against transient empty gpuNodes results.
+ *
+ * When the current capture has an empty gpuNodes list but the most recent
+ * persisted snapshot still had GPU inventory, replace the empty list with the
+ * previous snapshot's gpuNodes — up to MAX_GPU_CARRY_FORWARD consecutive
+ * captures. This prevents transient fetch glitches from being persisted as
+ * zero-total snapshots that then render as flapping zero bars in GPU
+ * Inventory History.
+ *
+ * Returns the gpuNodes to use for the new snapshot.
+ */
+function applyGPUCarryForward(
+  currentGpuNodes: MetricsSnapshot['gpuNodes'],
+): MetricsSnapshot['gpuNodes'] {
+  // Non-empty current: no carry-forward needed, reset counter.
+  if (currentGpuNodes.length > 0) {
+    consecutiveEmptyGPUCaptures = 0
+    return currentGpuNodes
+  }
+
+  // Empty current. Look at the most recent persisted snapshot.
+  const lastSnapshot = snapshots.length > 0 ? snapshots[snapshots.length - 1] : null
+  const lastHadGPUs = !!lastSnapshot && (lastSnapshot.gpuNodes || []).length > 0
+
+  // No previous GPU data to carry forward — this is a legitimate "no GPUs"
+  // state (either a non-GPU cluster or the zero has already been persisted).
+  if (!lastHadGPUs) {
+    consecutiveEmptyGPUCaptures = 0
+    return currentGpuNodes
+  }
+
+  // Previous snapshot had GPUs, current is empty — likely a transient flap.
+  // Carry forward the previous gpuNodes, but only for a bounded number of
+  // consecutive captures so truly-removed GPUs eventually reflect in history.
+  if (consecutiveEmptyGPUCaptures < MAX_GPU_CARRY_FORWARD) {
+    consecutiveEmptyGPUCaptures += 1
+    return lastSnapshot.gpuNodes
+  }
+
+  // Exceeded the carry-forward window — accept the empty state as truth.
+  consecutiveEmptyGPUCaptures = 0
+  return currentGpuNodes
+}
+
+/**
  * Hook to manage metrics history for trend detection
  * Automatically captures snapshots every 10 minutes (configurable)
  */
@@ -176,6 +235,13 @@ export function useMetricsHistory() {
         return
       }
 
+      const mappedGpuNodes = (currentGpuNodes || []).map(g => ({
+        name: g.name,
+        cluster: g.cluster,
+        gpuType: g.gpuType || '',
+        gpuAllocated: g.gpuAllocated,
+        gpuTotal: g.gpuCount }))
+
       const snapshot: MetricsSnapshot = {
         timestamp: new Date().toISOString(),
         clusters: currentClusters.map(c => ({
@@ -190,12 +256,9 @@ export function useMetricsHistory() {
           cluster: p.cluster || '',
           restarts: p.restarts || 0,
           status: p.status || '' })),
-        gpuNodes: (currentGpuNodes || []).map(g => ({
-          name: g.name,
-          cluster: g.cluster,
-          gpuType: g.gpuType || '',
-          gpuAllocated: g.gpuAllocated,
-          gpuTotal: g.gpuCount })) }
+        // Apply carry-forward to smooth transient empty-GPU fetch results
+        // (see applyGPUCarryForward docstring).
+        gpuNodes: applyGPUCarryForward(mappedGpuNodes) }
 
       addSnapshot(snapshot)
       lastSnapshotRef.current = now
@@ -221,6 +284,13 @@ export function useMetricsHistory() {
   const captureNow = () => {
     if (clusters.length === 0) return
 
+    const mappedGpuNodes = (gpuNodes || []).map(g => ({
+      name: g.name,
+      cluster: g.cluster,
+      gpuType: g.gpuType || '',
+      gpuAllocated: g.gpuAllocated,
+      gpuTotal: g.gpuCount }))
+
     const snapshot: MetricsSnapshot = {
       timestamp: new Date().toISOString(),
       clusters: clusters.map(c => ({
@@ -234,12 +304,7 @@ export function useMetricsHistory() {
         cluster: p.cluster || '',
         restarts: p.restarts || 0,
         status: p.status || '' })),
-      gpuNodes: (gpuNodes || []).map(g => ({
-        name: g.name,
-        cluster: g.cluster,
-        gpuType: g.gpuType || '',
-        gpuAllocated: g.gpuAllocated,
-        gpuTotal: g.gpuCount })) }
+      gpuNodes: applyGPUCarryForward(mappedGpuNodes) }
 
     addSnapshot(snapshot)
     lastSnapshotRef.current = Date.now()
@@ -248,6 +313,7 @@ export function useMetricsHistory() {
   // Clear history
   const clearHistory = () => {
     snapshots = []
+    consecutiveEmptyGPUCaptures = 0
     notifySubscribers()
     persistSnapshots()
   }


### PR DESCRIPTION
## Summary

Transient empty GPU node fetches (SSE race, partial cluster reachability, brief kc-agent hiccups) were being persisted as `{total: 0}` snapshots in metrics history, which then rendered as flapping zero bars in the GPU Inventory History card.

This PR applies a belt-and-suspenders fix:

- **Source** (`useMetricsHistory.ts`): carry forward the last known `gpuNodes` for up to 2 consecutive captures when the current fetch comes back empty but the previous snapshot had GPU inventory. After the window expires we accept the empty state as truth so genuinely removed GPUs still reflect in history.
- **UI** (`GPUInventoryHistory.tsx`): defensively drop zero-total points from the chart, churn metrics, and latest-snapshot table when the series has any non-zero data. This also cleans up already-cached bad snapshots in existing users' localStorage.

Reported by @MikeSpreitzer (thank you!) on Firefox 149 / macOS 15.7.4 / console 0.3.20 against the vllm-d cluster. Related to his #8081 (GPU Usage Trend "No GPU Nodes" / refresh failed) — same underlying symptom of intermittent GPU fetch failures; that card is being addressed in a separate PR.

Fixes #8080

## Test plan

- [x] `npm run build` passes
- [x] `npm run lint` passes (no new errors in touched files)
- [x] `npx vitest run useMetricsHistory` — 55 tests pass, including 3 new carry-forward tests
- [x] `npx vitest run GPUInventoryHistory` — 8 tests pass, including a new zero-snapshot regression guard
- [ ] Mike to verify on vllm-d cluster after merge