### PR TITLE
🐛 fix: Copilot comment on namespaces race + GPU Usage Trend empty-nodes (#8079 #8081)

### DIFF
--- a/web/src/components/cards/GPUUsageTrend.tsx
+++ b/web/src/components/cards/GPUUsageTrend.tsx
@@ -5,6 +5,7 @@ import ReactECharts from 'echarts-for-react'
 import { useClusters } from '../../hooks/useMCP'
 import { useCachedGPUNodes } from '../../hooks/useCachedData'
 import { useGlobalFilters } from '../../hooks/useGlobalFilters'
+import { useMetricsHistory } from '../../hooks/useMetricsHistory'
 import { Skeleton, SkeletonStats } from '../ui/Skeleton'
 import { useCardLoadingState } from './CardDataContext'
 import { useTranslation } from 'react-i18next'
@@ -21,6 +22,19 @@ interface GPUDataPoint {
   available: number
   allocated: number
   free: number
+}
+
+// Shape we pass through the card's filter/aggregation pipeline. This matches
+// the live GPUNode shape for the fields we actually use (cluster, gpuType,
+// gpuCount, gpuAllocated). We normalize here so we can transparently fall
+// back to a recent metrics-history snapshot whose field name is `gpuTotal`
+// instead of `gpuCount` — see snapshot fallback below.
+interface EffectiveGPUNode {
+  name: string
+  cluster: string
+  gpuType?: string
+  gpuCount: number
+  gpuAllocated: number
 }
 
 type TimeRange = '15m' | '1h' | '6h' | '24h'
@@ -50,9 +64,43 @@ export function GPUUsageTrend() {
     consecutiveFailures } = useCachedGPUNodes()
   const { deduplicatedClusters: clusters } = useClusters()
   const { isDemoMode } = useDemoMode()
+  // Use the shared metrics-history snapshots as a last-known-good fallback
+  // when the live GPU-nodes fetch returns empty (intermittent API failure
+  // against a cluster that does have GPUs). Without this the card shows
+  // "No GPU Nodes" whenever a single poll fails — see GPU Inventory History
+  // card which already reads this same history and stays populated.
+  const { history: metricsHistory } = useMetricsHistory()
 
-  // Only show skeleton when no cached data exists
-  const hasData = gpuNodes.length > 0
+  // Fall back to the most recent snapshot's GPU nodes if the live list is
+  // empty. Snapshots use `gpuTotal`; we remap to `gpuCount` so downstream
+  // aggregation (currentTotals, filteredNodes) stays unchanged.
+  const effectiveGPUNodes: EffectiveGPUNode[] = useMemo(() => {
+    if (gpuNodes.length > 0) {
+      return gpuNodes.map(n => ({
+        name: n.name,
+        cluster: n.cluster,
+        gpuType: n.gpuType,
+        gpuCount: n.gpuCount,
+        gpuAllocated: n.gpuAllocated }))
+    }
+    // Search most-recent-first for a snapshot that actually has GPU data.
+    for (let i = metricsHistory.length - 1; i >= 0; i -= 1) {
+      const snap = metricsHistory[i]
+      const snapNodes = snap?.gpuNodes || []
+      if (snapNodes.length > 0) {
+        return snapNodes.map(g => ({
+          name: g.name,
+          cluster: g.cluster,
+          gpuType: g.gpuType,
+          gpuCount: g.gpuTotal,
+          gpuAllocated: g.gpuAllocated }))
+      }
+    }
+    return []
+  }, [gpuNodes, metricsHistory])
+
+  // Only show skeleton when no cached data exists (live OR snapshot fallback)
+  const hasData = effectiveGPUNodes.length > 0
   const isLoading = hookLoading && !hasData
   const { selectedClusters, isAllClustersSelected } = useGlobalFilters()
 
@@ -105,7 +153,7 @@ export function GPUUsageTrend() {
 
   // Get reachable clusters (those with GPU nodes)
   const gpuClusters = (() => {
-    const clusterNames = new Set(gpuNodes.map(n => normalizeClusterName(n.cluster)))
+    const clusterNames = new Set(effectiveGPUNodes.map(n => normalizeClusterName(n.cluster)))
     return clusters.filter(c => clusterNames.has(normalizeClusterName(c.name)) && c.reachable !== false)
   })()
 
@@ -115,7 +163,7 @@ export function GPUUsageTrend() {
   })()
 
   const filteredNodes = useMemo(() => {
-    let filtered = gpuNodes
+    let filtered: EffectiveGPUNode[] = effectiveGPUNodes
     if (!isAllClustersSelected) {
       filtered = filtered.filter(node => {
         const normalizedNodeCluster = normalizeClusterName(node.cluster)
@@ -139,7 +187,7 @@ export function GPUUsageTrend() {
       })
     }
     return filtered
-  }, [gpuNodes, selectedClusters, isAllClustersSelected, localClusterFilter])
+  }, [effectiveGPUNodes, selectedClusters, isAllClustersSelected, localClusterFilter])
 
   const toggleClusterFilter = (clusterName: string) => {
     setLocalClusterFilter(prev => {
@@ -271,7 +319,7 @@ export function GPUUsageTrend() {
     )
   }
 
-  if (gpuNodes.length === 0) {
+  if (effectiveGPUNodes.length === 0) {
     return (
       <div className="h-full flex flex-col content-loaded">
         <div className="flex items-center justify-end mb-3" />

--- a/web/src/components/cards/__tests__/GPUUsageTrend.test.tsx
+++ b/web/src/components/cards/__tests__/GPUUsageTrend.test.tsx
@@ -54,6 +54,11 @@ vi.mock('../../../hooks/useGlobalFilters', () => ({
   useGlobalFilters: () => ({ selectedClusters: [], isAllClustersSelected: true, selectedSeverities: [], isAllSeveritiesSelected: true, customFilter: '' }),
 }))
 
+const mockUseMetricsHistory = vi.fn()
+vi.mock('../../../hooks/useMetricsHistory', () => ({
+  useMetricsHistory: () => mockUseMetricsHistory(),
+}))
+
 import { GPUUsageTrend } from '../GPUUsageTrend'
 
 describe('GPUUsageTrend', () => {
@@ -63,6 +68,7 @@ describe('GPUUsageTrend', () => {
     mockUseCardLoadingState.mockReturnValue({ showSkeleton: false, showEmptyState: false, hasData: true, isRefreshing: false })
     mockGPUNodes.mockReturnValue({ nodes: [], isLoading: false, isRefreshing: false, isDemoFallback: false, isFailed: false, consecutiveFailures: 0, error: null, lastRefresh: Date.now() })
     mockUseClusters.mockReturnValue({ clusters: [], deduplicatedClusters: [], isLoading: false, isRefreshing: false, error: null, lastRefresh: Date.now() })
+    mockUseMetricsHistory.mockReturnValue({ history: [], captureNow: vi.fn(), clearHistory: vi.fn(), getClusterTrend: () => 'stable', getPodRestartTrend: () => 'stable', snapshotCount: 0 })
   })
 
   it('renders without crashing', () => {
@@ -113,6 +119,33 @@ describe('GPUUsageTrend', () => {
     mockGPUNodes.mockReturnValue({ nodes: [], isLoading: false, isRefreshing: false, isDemoFallback: true, isFailed: false, consecutiveFailures: 0, error: null, lastRefresh: Date.now() })
     render(<GPUUsageTrend />)
     expect(mockUseCardLoadingState).toHaveBeenCalled()
+  })
+
+  // Regression: when the live fetch returns zero nodes (intermittent failure)
+  // the card should fall back to the most-recent metrics-history snapshot so
+  // it stays populated instead of flashing "No GPU Nodes".
+  it('uses metrics-history snapshot fallback when live GPU nodes are empty', () => {
+    mockUseDemoMode.mockReturnValue({ isDemoMode: false, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() })
+    mockGPUNodes.mockReturnValue({ nodes: [], isLoading: false, isRefreshing: false, isDemoFallback: false, isFailed: true, consecutiveFailures: 2, error: 'boom', lastRefresh: Date.now() })
+    mockUseMetricsHistory.mockReturnValue({
+      history: [
+        {
+          timestamp: new Date().toISOString(),
+          clusters: [],
+          podIssues: [],
+          gpuNodes: [
+            { name: 'node-a', cluster: 'vllm-d', gpuType: 'NVIDIA H100', gpuAllocated: 2, gpuTotal: 8 },
+          ],
+        },
+      ],
+      captureNow: vi.fn(),
+      clearHistory: vi.fn(),
+      getClusterTrend: () => 'stable',
+      getPodRestartTrend: () => 'stable',
+      snapshotCount: 1 })
+    const { container } = render(<GPUUsageTrend />)
+    // Card should NOT show the empty-state message when fallback data exists.
+    expect(container.textContent).not.toContain('No GPU Nodes')
   })
 
 })

--- a/web/src/hooks/mcp/namespaces.ts
+++ b/web/src/hooks/mcp/namespaces.ts
@@ -120,7 +120,8 @@ export function useNamespaces(cluster?: string, forceLive = false) {
           timerId = setTimeout(() => resolve(null), NAMESPACE_FETCH_TIMEOUT_MS)
         })
         const nsData = await Promise.race([nsPromise, timeoutPromise])
-        // Clear the stray timer if nsPromise won the race.
+        // Clear the timer unconditionally. If nsPromise won, this cancels the
+        // pending timer; if the timer already fired, clearTimeout is a safe no-op.
         if (timerId !== null) clearTimeout(timerId)
 
         if (nsData && nsData.length > 0) {


### PR DESCRIPTION
## Summary

Two small unrelated fixes in one PR (different files, both tiny).

### 1. `useNamespaces` kubectl-proxy comment (#8079)

Copilot review on merged #8078 flagged a misleading comment:

```ts
const nsData = await Promise.race([nsPromise, timeoutPromise])
// Clear the stray timer if nsPromise won the race.
if (timerId !== null) clearTimeout(timerId)
```

The `clearTimeout` actually runs unconditionally — which is correct, because calling `clearTimeout` on an already-fired timer is a safe no-op. Only the comment was wrong. Rewrote it to describe what the code actually does.

### 2. GPU Usage Trend shows "No GPU Nodes" on intermittent poll failures (#8081)

Reported by @MikeSpreitzer: with kubectl configured against the vllm-d cluster, the **GPU Usage Trend** card shows "No GPU Nodes / refresh failed" while the **GPU Inventory History** card (same data source, same cluster, same user) still shows inventory.

**Root cause:** `GPUInventoryHistory` reads both the live `useCachedGPUNodes` result AND the `useMetricsHistory` snapshots persisted in localStorage, so when a live poll returns empty it still has data to render. `GPUUsageTrend` only read the live hook, so any empty response dropped straight to the empty state.

**Fix:** In `GPUUsageTrend`, when the live `gpuNodes` list is empty, fall back to the most-recent metrics-history snapshot whose `gpuNodes` list is non-empty. The snapshot shape uses `gpuTotal` instead of `gpuCount`, so we normalize to a small `EffectiveGPUNode` interface that matches the fields the card already consumes — downstream filter/aggregation code is unchanged. Added a regression test covering the empty-live / snapshot-present case.

`GPUInventoryHistory.tsx` is intentionally NOT touched — PR #8084 is editing it concurrently.

## Test plan

- [x] `cd web && npm run build` passes
- [x] `cd web && npm run lint` — no new errors on changed files (pre-existing `Date.now()` purity warning in `GPUUsageTrend.tsx` unchanged)
- [x] `npx vitest run namespaces` — 42 tests pass
- [x] `npx vitest run GPUUsageTrend` — 9 tests pass (1 new regression test added)

Fixes #8079
Fixes #8081