### PR TITLE
🐛 fix: suppress spurious node alerts for unreachable clusters + alert drill-down clipping (#8085 #8086)

### DIFF
--- a/web/src/components/drilldown/DrillDownModal.tsx
+++ b/web/src/components/drilldown/DrillDownModal.tsx
@@ -1,4 +1,5 @@
 import { Component, useEffect, Suspense, type ReactNode, type ErrorInfo } from 'react'
+import { createPortal } from 'react-dom'
 import { safeLazy } from '../../lib/safeLazy'
 import { useTranslation } from 'react-i18next'
 import { Box, Server, Layers, Rocket, FileText, Zap, Cpu, Lock, User, Bell, Ship, GitBranch, Settings, Shield, Package, DollarSign, AlertTriangle, RefreshCw, HardDrive } from 'lucide-react'
@@ -306,7 +307,15 @@ export function DrillDownModal() {
     }
   }
 
-  return (
+  // Render the modal at document.body so it sits after the Layout sidebar
+  // in DOM order. Both the sidebar and drill-down use z-modal; with equal
+  // z-index the later sibling paints on top. Without the portal, the
+  // sidebar (rendered inside Layout, which mounts after DrillDownModal in
+  // the React tree) visually overlaps the drill-down's left edge — e.g.
+  // hiding the back button and the start of the breadcrumb on a narrow
+  // window. The portal guarantees drill-downs always render after the
+  // chrome regardless of where the component is mounted in the tree.
+  return createPortal(
     <div
       className="fixed inset-0 bg-black/60 backdrop-blur-sm flex items-center justify-center z-modal p-2 md:p-4"
       onClick={close}
@@ -406,6 +415,7 @@ export function DrillDownModal() {
           </div>
         )}
       </div>
-    </div>
+    </div>,
+    document.body
   )
 }

--- a/web/src/contexts/AlertsContext.tsx
+++ b/web/src/contexts/AlertsContext.tsx
@@ -248,6 +248,19 @@ const NOTIFICATION_COOLDOWN_MS = 300_000 // 5 minutes
  *  no 5-minute cooldown repeat for ongoing connectivity failures. */
 const PERSISTENT_CLUSTER_CONDITIONS = new Set(['certificate_error', 'cluster_unreachable'])
 
+/**
+ * When a cluster is unreachable we cannot observe its node / disk / memory
+ * state — any cached values are stale, last-known-good at best. Firing
+ * per-node alerts ("Node Not Ready", "Disk Pressure", "Memory Pressure")
+ * for such clusters produces misleading noise on top of the single
+ * authoritative "Cluster Unreachable" alert. This helper centralizes the
+ * reachability check so every node / cluster-health evaluator can skip
+ * unreachable clusters uniformly. See upstream bug report for the real-world
+ * "20 unreachable clusters → 40 spurious alerts" scenario. */
+function isClusterUnreachable(cluster: { reachable?: boolean }): boolean {
+  return cluster.reachable === false
+}
+
 /** Maximum age (ms) for dedup entries — evict stale entries older than this */
 const NOTIFICATION_DEDUP_MAX_AGE_MS = 86_400_000 // 24 hours
 
@@ -1132,7 +1145,14 @@ Please provide:
       }
     }
 
-  // Evaluate node ready condition — reads from refs for stable identity
+  // Evaluate node ready condition — reads from refs for stable identity.
+  //
+  // Unreachable clusters are skipped: their node state is unknown (we only
+  // have stale cached values) and pairing every "Cluster Unreachable" alert
+  // with a redundant "Node Not Ready" alert was reported as spurious noise
+  // by a user running 20+ offline clusters. Any already-firing node_ready
+  // alert for an unreachable cluster is auto-resolved so the list clears
+  // down to just the single authoritative Cluster Unreachable entry.
   const evaluateNodeReady = (rule: AlertRule) => {
       const currentClusters = clustersRef.current
       const relevantClusters = rule.condition.clusters?.length
@@ -1140,6 +1160,10 @@ Please provide:
         : currentClusters
 
       for (const cluster of relevantClusters) {
+        if (isClusterUnreachable(cluster)) {
+          queueAutoResolve(rule.id, cluster.name)
+          continue
+        }
         if (cluster.healthy === false) {
           createAlert(
             rule,
@@ -1347,6 +1371,12 @@ Please provide:
         : currentClusters
 
       for (const cluster of relevantClusters) {
+        // Skip unreachable clusters — cached issues are stale and pairing
+        // them with a Cluster Unreachable alert is misleading noise.
+        if (isClusterUnreachable(cluster)) {
+          queueAutoResolve(rule.id, cluster.name)
+          continue
+        }
         const diskPressureIssue = (cluster.issues || []).find(issue =>
           typeof issue === 'string' && issue.includes('DiskPressure')
         )
@@ -1402,6 +1432,12 @@ Please provide:
         : currentClusters
 
       for (const cluster of relevantClusters) {
+        // Skip unreachable clusters — cached issues are stale and pairing
+        // them with a Cluster Unreachable alert is misleading noise.
+        if (isClusterUnreachable(cluster)) {
+          queueAutoResolve(rule.id, cluster.name)
+          continue
+        }
         const memPressureIssue = (cluster.issues || []).find(issue =>
           typeof issue === 'string' && issue.includes('MemoryPressure')
         )

--- a/web/src/contexts/__tests__/AlertsContext.test.tsx
+++ b/web/src/contexts/__tests__/AlertsContext.test.tsx
@@ -678,6 +678,114 @@ describe('AlertsContext', () => {
     expect(resolved?.status).toBe('resolved')
   })
 
+  it('evaluateConditions: node_not_ready does not fire for unreachable clusters', async () => {
+    // Regression for the "20 unreachable clusters → 40 spurious alerts"
+    // report. When a cluster is unreachable we can't observe node state,
+    // so the per-node alert is misleading noise on top of the single
+    // Cluster Unreachable alert. See the commit message for upstream
+    // issue numbers.
+    const rule: AlertRule = {
+      id: 'nnr-skip-unreachable',
+      name: 'Node Not Ready',
+      description: '',
+      enabled: true,
+      condition: { type: 'node_not_ready' },
+      severity: 'warning',
+      channels: [],
+      aiDiagnose: false,
+      createdAt: '2024-01-01T00:00:00Z',
+      updatedAt: '2024-01-01T00:00:00Z',
+    }
+    localStorage.setItem('kc_alert_rules', JSON.stringify([rule]))
+    localStorage.setItem('kc_alerts', JSON.stringify([]))
+
+    // Unreachable cluster with cached healthy=false (stale data) and 3 nodes.
+    // The real-user scenario: last-known-good state indicates problems but
+    // we can no longer verify them because the cluster is offline.
+    mockMCPData = {
+      gpuNodes: [],
+      podIssues: [],
+      clusters: [{
+        name: 'offline-cluster',
+        healthy: false,
+        reachable: false,
+        nodeCount: 3,
+        errorType: 'timeout',
+        errorMessage: 'dial tcp: i/o timeout',
+      }],
+      isLoading: false,
+      error: null,
+    }
+
+    const { result } = renderHook(() => useAlertsContext(), { wrapper })
+    await act(async () => { vi.advanceTimersByTime(0) })
+
+    await act(async () => {
+      result.current.evaluateConditions()
+    })
+
+    // Zero Node Not Ready alerts for the unreachable cluster.
+    const nodeAlerts = result.current.alerts.filter(
+      a => a.ruleId === 'nnr-skip-unreachable' && a.status === 'firing'
+    )
+    expect(nodeAlerts.length).toBe(0)
+  })
+
+  it('evaluateConditions: node_not_ready auto-resolves stale alert when cluster becomes unreachable', async () => {
+    // A cluster that was previously firing a Node Not Ready alert becomes
+    // unreachable — the stale firing alert should auto-resolve so the user
+    // sees only the Cluster Unreachable entry.
+    const rule: AlertRule = {
+      id: 'nnr-stale-resolve',
+      name: 'Node Not Ready',
+      description: '',
+      enabled: true,
+      condition: { type: 'node_not_ready' },
+      severity: 'warning',
+      channels: [],
+      aiDiagnose: false,
+      createdAt: '2024-01-01T00:00:00Z',
+      updatedAt: '2024-01-01T00:00:00Z',
+    }
+    const firingAlert: Alert = {
+      id: 'nnr-pre-unreachable',
+      ruleId: 'nnr-stale-resolve',
+      ruleName: 'Node Not Ready',
+      severity: 'warning',
+      status: 'firing',
+      message: 'Cluster formerly-healthy has nodes not in Ready state',
+      details: {},
+      firedAt: '2024-01-01T00:00:00Z',
+      cluster: 'formerly-healthy',
+    }
+    localStorage.setItem('kc_alert_rules', JSON.stringify([rule]))
+    localStorage.setItem('kc_alerts', JSON.stringify([firingAlert]))
+
+    mockMCPData = {
+      gpuNodes: [],
+      podIssues: [],
+      clusters: [{
+        name: 'formerly-healthy',
+        healthy: false,
+        reachable: false,
+        nodeCount: 3,
+        errorType: 'network',
+      }],
+      isLoading: false,
+      error: null,
+    }
+
+    const { result } = renderHook(() => useAlertsContext(), { wrapper })
+    await act(async () => { vi.advanceTimersByTime(0) })
+
+    await act(async () => {
+      result.current.evaluateConditions()
+    })
+
+    const resolved = result.current.alerts.find(a => a.id === 'nnr-pre-unreachable')
+    expect(resolved?.status).toBe('resolved')
+  })
+
   // ── 15. Alert deduplication ──────────────────────────────────────────
 
   it('deduplicates alerts keeping the most recently fired entry', () => {


### PR DESCRIPTION
## Summary

Two bugs reported by @MikeSpreitzer, both in the alerts area.

### #8085 — Spurious "Node Not Ready" alerts for unreachable clusters

With 20 unreachable clusters the alert list was showing ~40 entries: half "Cluster Unreachable", half "Node Not Ready". The Node Not Ready ones are misleading — when a cluster is unreachable the console cannot observe node state, so any cached `healthy=false` value is stale (last-known-good at best) and the per-node alert just duplicates the authoritative Cluster Unreachable entry.

`AlertsContext.evaluateNodeReady`, `evaluateDiskPressure`, and `evaluateMemoryPressure` now short-circuit when a cluster is unreachable via a shared `isClusterUnreachable()` helper. Any stale firing alert for a cluster that has just gone unreachable is auto-resolved on the same evaluation pass so the list clears down to the single Cluster Unreachable entry.

### #8086 — Visual clipping in alert drill-down

On a 1262 px window with the sidebar expanded, pushing into a "Cluster Unreachable" alert showed the drill-down with its back button and the left edge of the breadcrumb hidden behind the sidebar.

**Root cause:** both `Layout`'s Sidebar and `DrillDownModal` use `z-modal` (400). DrillDownModal is mounted in `App.tsx` *before* the `Routes → Layout` tree, so in DOM order the sidebar paints after the modal. With equal z-index the later sibling wins, and the fixed-position sidebar covers the modal's left edge.

**Fix:** render DrillDownModal through `createPortal(..., document.body)` so it always lands at the end of the DOM, matching the existing `BaseModal` portal pattern. Keyboard shortcuts and context access continue to work across portals.

Fixes #8085
Fixes #8086

## Test plan

- [x] `npm run build` passes
- [x] `npm run lint` — no new errors in changed files
- [x] `npx vitest run AlertsContext` — 120 passed (added 2 new regression tests)
- [x] `npx vitest run DrillDownModal` — 4 passed
- [ ] Manual: open the alerts page with an unreachable cluster + cached `healthy=false`; confirm only the Cluster Unreachable entry appears, no Node Not Ready
- [ ] Manual: open the alerts page on a ~1260 px wide window, push into a Cluster Unreachable alert, confirm the back button and full breadcrumb are visible (no left-side clipping)

## Tests added

`web/src/contexts/__tests__/AlertsContext.test.tsx`:
1. `node_not_ready does not fire for unreachable clusters` — 1 unreachable cluster (`reachable: false`, `healthy: false`, 3 nodes) → 0 firing Node Not Ready alerts
2. `node_not_ready auto-resolves stale alert when cluster becomes unreachable` — pre-existing firing alert is auto-resolved when its cluster transitions to unreachable