### PR TITLE
🐛 fix: promptNeedsToolExecution heuristic, clusters TTL, vcluster current-context (#8074 #8075 #8076)

### DIFF
--- a/pkg/agent/kubectl.go
+++ b/pkg/agent/kubectl.go
@@ -28,6 +28,14 @@ const (
 
 	// kubectlRenameTimeout bounds the kubectl config rename-context command. (#7279)
 	kubectlRenameTimeout = 30 * time.Second
+
+	// kubectlReloadMinInterval is the minimum time between kubeconfig file
+	// re-reads driven by ReloadIfStale. handleClustersHTTP is polled by the
+	// frontend and previously called Reload() on every request, which does a
+	// full disk read + YAML parse. Two seconds is short enough to feel
+	// responsive after the user adds a context, long enough to absorb bursty
+	// polling. (#8075)
+	kubectlReloadMinInterval = 2 * time.Second
 )
 
 // execCommand allows mocking exec.Command for testing
@@ -40,6 +48,7 @@ type KubectlProxy struct {
 	mu         sync.RWMutex // guards config against concurrent read/write (#7259)
 	kubeconfig string
 	config     *api.Config
+	lastReload time.Time // wall time of last successful Reload, for ReloadIfStale (#8075)
 }
 
 func NewKubectlProxy(kubeconfig string) (*KubectlProxy, error) {
@@ -366,8 +375,36 @@ func (k *KubectlProxy) Reload() {
 	if err == nil {
 		k.mu.Lock()
 		k.config = config
+		k.lastReload = time.Now()
 		k.mu.Unlock()
 	}
+}
+
+// ReloadIfStale reloads the kubeconfig from disk only if the previous reload
+// was more than minInterval ago. This absorbs bursty polling from frontend
+// callers (e.g. handleClustersHTTP) without skipping updates after the user
+// adds a context. Returns true if a fresh load was performed. (#8075)
+func (k *KubectlProxy) ReloadIfStale(minInterval time.Duration) bool {
+	k.mu.RLock()
+	fresh := !k.lastReload.IsZero() && time.Since(k.lastReload) < minInterval
+	k.mu.RUnlock()
+	if fresh {
+		return false
+	}
+	config, err := clientcmd.LoadFromFile(k.kubeconfig)
+	if err != nil {
+		// Record the attempt even on failure so a broken kubeconfig doesn't
+		// cause a hot loop of LoadFromFile calls on every request.
+		k.mu.Lock()
+		k.lastReload = time.Now()
+		k.mu.Unlock()
+		return false
+	}
+	k.mu.Lock()
+	k.config = config
+	k.lastReload = time.Now()
+	k.mu.Unlock()
+	return true
 }
 
 // reloadLocked reloads the kubeconfig from disk without acquiring the mutex.

--- a/pkg/agent/kubectl_test.go
+++ b/pkg/agent/kubectl_test.go
@@ -9,6 +9,7 @@ import (
 	"strconv"
 	"strings"
 	"testing"
+	"time"
 
 	"k8s.io/client-go/tools/clientcmd/api"
 )
@@ -943,5 +944,57 @@ func TestKubectlProxy_TestClusterConnection_Unreachable(t *testing.T) {
 	}
 	if result.Error == "" {
 		t.Error("Expected error message for unreachable server")
+	}
+}
+
+// TestKubectlProxy_ReloadIfStale verifies that repeated calls within the TTL
+// window skip the disk read, while a call after the TTL performs one. (#8075)
+func TestKubectlProxy_ReloadIfStale(t *testing.T) {
+	dir := t.TempDir()
+	kubeconfigPath := filepath.Join(dir, "config")
+	// Minimal valid kubeconfig — just enough for clientcmd.LoadFromFile
+	// to succeed and populate k.config.
+	const minimalKubeconfig = `apiVersion: v1
+kind: Config
+clusters:
+- name: c1
+  cluster:
+    server: https://example.invalid
+users:
+- name: u1
+  user: {}
+contexts:
+- name: ctx1
+  context:
+    cluster: c1
+    user: u1
+current-context: ctx1
+`
+	if err := os.WriteFile(kubeconfigPath, []byte(minimalKubeconfig), 0o600); err != nil {
+		t.Fatalf("write kubeconfig: %v", err)
+	}
+
+	proxy, err := NewKubectlProxy(kubeconfigPath)
+	if err != nil {
+		t.Fatalf("NewKubectlProxy: %v", err)
+	}
+
+	// First call with a nonzero TTL should perform the reload because
+	// lastReload is zero-valued on a fresh proxy.
+	const testTTL = 50 * time.Millisecond
+	if !proxy.ReloadIfStale(testTTL) {
+		t.Errorf("first ReloadIfStale returned false; expected true (lastReload is zero)")
+	}
+
+	// Second call immediately after should skip — within TTL window.
+	if proxy.ReloadIfStale(testTTL) {
+		t.Errorf("second ReloadIfStale returned true; expected false (within TTL window)")
+	}
+
+	// With a zero/negative TTL, the throttle should always expire, i.e. a
+	// fresh load is performed. This also guards against a regression where
+	// lastReload == now skips forever due to a non-strict comparison.
+	if !proxy.ReloadIfStale(0) {
+		t.Errorf("ReloadIfStale(0) returned false; expected true")
 	}
 }

--- a/pkg/agent/local_clusters.go
+++ b/pkg/agent/local_clusters.go
@@ -784,6 +784,20 @@ func (m *LocalClusterManager) DisconnectVCluster(name, namespace string) error {
 		return fmt.Errorf("vcluster disconnect failed: vcluster %q in namespace %q has no kubeconfig context (already disconnected?)", name, namespace)
 	}
 
+	// If the target context is currently active, unset current-context before
+	// deleting. Otherwise kubectl is left pointing at a stale reference and
+	// subsequent commands fail with `current-context is "<deleted>", but does
+	// not exist`. This happens when a user manually ran `kubectl config
+	// use-context <vcluster-ctx>` between connect and disconnect. (#8076)
+	currentCmd := execCommand("kubectl", "config", "current-context")
+	currentOut, currentErr := currentCmd.Output()
+	if currentErr == nil && strings.TrimSpace(string(currentOut)) == targetContext {
+		unsetCmd := execCommand("kubectl", "config", "unset", "current-context")
+		// Best-effort: a failure here shouldn't block the delete, the user
+		// can always re-pick a context manually.
+		_ = unsetCmd.Run()
+	}
+
 	cmd := execCommand("kubectl", "config", "delete-context", targetContext)
 	var stderr bytes.Buffer
 	cmd.Stderr = &stderr

--- a/pkg/agent/local_clusters_test.go
+++ b/pkg/agent/local_clusters_test.go
@@ -3,6 +3,7 @@ package agent
 import (
 	"os/exec"
 	"strings"
+	"sync"
 	"testing"
 )
 
@@ -136,5 +137,126 @@ func TestLocalClusterManager_CreateCluster_ErrorContainsDetails(t *testing.T) {
 	// The error should contain the actual stderr output, not a generic message
 	if !strings.Contains(err.Error(), "cluster already exists") {
 		t.Errorf("Expected error to contain stderr output 'cluster already exists', got %q", err.Error())
+	}
+}
+
+// TestDisconnectVCluster_UnsetsCurrentContextWhenActive verifies that
+// DisconnectVCluster unsets current-context before deleting when the target
+// vcluster context is the active kubectl context. Regression for #8076.
+func TestDisconnectVCluster_UnsetsCurrentContextWhenActive(t *testing.T) {
+	oldExecCommand := execCommand
+	defer func() { execCommand = oldExecCommand }()
+
+	const targetCtx = "vcluster_demo_ns1_mgmt"
+	const vclusterName = "demo"
+	const vclusterNamespace = "ns1"
+	// Minimal JSON mirroring `vcluster list --output json` so ListVClusters
+	// returns a single connected instance with Context == targetCtx.
+	vclusterListJSON := `[{"Name":"` + vclusterName + `","Namespace":"` + vclusterNamespace +
+		`","Status":"Running","Connected":true,"Context":"` + targetCtx + `"}]`
+
+	var mu sync.Mutex
+	calls := make([]string, 0)
+	record := func(args ...string) {
+		mu.Lock()
+		defer mu.Unlock()
+		calls = append(calls, strings.Join(args, " "))
+	}
+
+	execCommand = func(name string, arg ...string) *exec.Cmd {
+		all := append([]string{name}, arg...)
+		record(all...)
+		switch {
+		case name == "vcluster" && len(arg) > 0 && arg[0] == "list":
+			return exec.Command("sh", "-c", "printf '%s' '"+vclusterListJSON+"'")
+		case name == "kubectl" && len(arg) >= 2 && arg[0] == "config" && arg[1] == "current-context":
+			return exec.Command("echo", targetCtx)
+		case name == "kubectl" && len(arg) >= 3 && arg[0] == "config" && arg[1] == "unset" && arg[2] == "current-context":
+			return exec.Command("true")
+		case name == "kubectl" && len(arg) >= 3 && arg[0] == "config" && arg[1] == "delete-context":
+			return exec.Command("true")
+		}
+		return exec.Command("echo", "ok")
+	}
+
+	m := NewLocalClusterManager(nil)
+	if err := m.DisconnectVCluster(vclusterName, vclusterNamespace); err != nil {
+		t.Fatalf("DisconnectVCluster returned unexpected error: %v", err)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	// Find the indices of the unset and delete-context calls; unset must
+	// precede delete-context.
+	unsetIdx, deleteIdx := -1, -1
+	for i, c := range calls {
+		if strings.Contains(c, "kubectl config unset current-context") {
+			unsetIdx = i
+		}
+		if strings.Contains(c, "kubectl config delete-context") {
+			deleteIdx = i
+		}
+	}
+	if unsetIdx == -1 {
+		t.Fatalf("expected `kubectl config unset current-context` to be called; calls=%v", calls)
+	}
+	if deleteIdx == -1 {
+		t.Fatalf("expected `kubectl config delete-context` to be called; calls=%v", calls)
+	}
+	if unsetIdx >= deleteIdx {
+		t.Errorf("expected unset-current-context to precede delete-context; unsetIdx=%d deleteIdx=%d calls=%v",
+			unsetIdx, deleteIdx, calls)
+	}
+}
+
+// TestDisconnectVCluster_DoesNotUnsetWhenDifferentContextActive verifies that
+// DisconnectVCluster does NOT touch current-context when the active context
+// is something other than the target vcluster. (#8076)
+func TestDisconnectVCluster_DoesNotUnsetWhenDifferentContextActive(t *testing.T) {
+	oldExecCommand := execCommand
+	defer func() { execCommand = oldExecCommand }()
+
+	const targetCtx = "vcluster_demo_ns1_mgmt"
+	const otherCtx = "kind-main"
+	const vclusterName = "demo"
+	const vclusterNamespace = "ns1"
+	vclusterListJSON := `[{"Name":"` + vclusterName + `","Namespace":"` + vclusterNamespace +
+		`","Status":"Running","Connected":true,"Context":"` + targetCtx + `"}]`
+
+	var mu sync.Mutex
+	calls := make([]string, 0)
+	record := func(args ...string) {
+		mu.Lock()
+		defer mu.Unlock()
+		calls = append(calls, strings.Join(args, " "))
+	}
+
+	execCommand = func(name string, arg ...string) *exec.Cmd {
+		all := append([]string{name}, arg...)
+		record(all...)
+		switch {
+		case name == "vcluster" && len(arg) > 0 && arg[0] == "list":
+			return exec.Command("sh", "-c", "printf '%s' '"+vclusterListJSON+"'")
+		case name == "kubectl" && len(arg) >= 2 && arg[0] == "config" && arg[1] == "current-context":
+			return exec.Command("echo", otherCtx)
+		case name == "kubectl" && len(arg) >= 3 && arg[0] == "config" && arg[1] == "unset" && arg[2] == "current-context":
+			return exec.Command("true")
+		case name == "kubectl" && len(arg) >= 3 && arg[0] == "config" && arg[1] == "delete-context":
+			return exec.Command("true")
+		}
+		return exec.Command("echo", "ok")
+	}
+
+	m := NewLocalClusterManager(nil)
+	if err := m.DisconnectVCluster(vclusterName, vclusterNamespace); err != nil {
+		t.Fatalf("DisconnectVCluster returned unexpected error: %v", err)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	for _, c := range calls {
+		if strings.Contains(c, "kubectl config unset current-context") {
+			t.Errorf("did not expect unset current-context; calls=%v", calls)
+		}
 	}
 }

--- a/pkg/agent/server_ai.go
+++ b/pkg/agent/server_ai.go
@@ -1339,9 +1339,35 @@ Command output:
 	})
 }
 
-// promptNeedsToolExecution checks if the prompt or history suggests command execution
+// promptNeedsToolExecution checks if the prompt or history suggests command execution.
+//
+// This is a cheap heuristic used to decide whether to route a chat message to a
+// tool-capable agent (claude-code, codex, gemini-cli) or a plain conversational
+// agent. A previous implementation relied on `strings.Contains` of a flat
+// keyword list, which misrouted declarative/interrogative prompts like
+// "How do I delete a namespace?" (contains "delete") and "yes, that is correct"
+// (retry-keyword "yes" matched via Contains). See #8074.
 func (s *Server) promptNeedsToolExecution(prompt string) bool {
 	prompt = strings.ToLower(prompt)
+	trimmed := strings.TrimSpace(prompt)
+
+	// Declarative/interrogative prefixes that indicate an explanatory question,
+	// not a tool-execution request. Return false regardless of later keywords
+	// so "How do I delete a namespace?" is not routed to a tool-capable agent
+	// just because it contains the word "delete". (#8074)
+	questionPrefixes := []string{
+		"how do", "how can", "how should", "how to",
+		"what is", "what are", "what does", "what's the",
+		"why ", "when ", "where ", "which ",
+		"explain ", "tell me ", "describe how", "describe what",
+		"can you explain", "could you explain",
+	}
+	for _, prefix := range questionPrefixes {
+		if strings.HasPrefix(trimmed, prefix) {
+			return false
+		}
+	}
+
 	// Keywords that suggest command execution is needed
 	executionKeywords := []string{
 		"run ", "execute", "kubectl", "helm", "check ", "show me", "get ",
@@ -1355,10 +1381,28 @@ func (s *Server) promptNeedsToolExecution(prompt string) bool {
 			return true
 		}
 	}
-	// Also check for retry/continuation requests which imply tool execution
-	retryKeywords := []string{"try again", "retry", "do it", "run it", "execute it", "yes", "proceed", "go ahead", "please do"}
+
+	// Retry/continuation requests that imply tool execution. These must match
+	// as whole tokens rather than substrings so "yes" does not match
+	// "yesterday" and "do it" does not match "do itemize". We check exact-match
+	// on the trimmed prompt plus a space-bounded Contains check for phrases
+	// embedded in longer sentences ("try again please"). (#8074)
+	retryKeywords := []string{
+		"try again", "retry", "do it", "run it", "execute it",
+		"yes", "proceed", "go ahead", "please do",
+	}
+	paddedPrompt := " " + trimmed + " "
 	for _, keyword := range retryKeywords {
-		if strings.Contains(prompt, keyword) {
+		if trimmed == keyword {
+			return true
+		}
+		if strings.Contains(paddedPrompt, " "+keyword+" ") {
+			return true
+		}
+		if strings.Contains(paddedPrompt, " "+keyword+",") {
+			return true
+		}
+		if strings.Contains(paddedPrompt, " "+keyword+".") {
 			return true
 		}
 	}

--- a/pkg/agent/server_http.go
+++ b/pkg/agent/server_http.go
@@ -83,7 +83,10 @@ func (s *Server) handleClustersHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	s.kubectl.Reload()
+	// Throttled reload: the frontend polls this endpoint and a full disk read
+	// per request was wasteful. ReloadIfStale skips the load when the in-memory
+	// snapshot is younger than kubectlReloadMinInterval. (#8075)
+	s.kubectl.ReloadIfStale(kubectlReloadMinInterval)
 	clusters, current := s.kubectl.ListContexts()
 	writeJSON(w, protocol.ClustersPayload{Clusters: clusters, Current: current})
 }

--- a/pkg/agent/server_test.go
+++ b/pkg/agent/server_test.go
@@ -2470,8 +2470,27 @@ func TestServer_PromptNeedsToolExecution(t *testing.T) {
 		{"I understand now", false},
 		{"good job", false},
 		{"", false},
-		// Note: "explain deployments" and "how does helm work?" would return true
-		// because they contain "deploy" and "helm" substrings
+
+		// Question-prefix prompts must short-circuit to false even if they
+		// contain execution keywords as substrings. Regression for #8074
+		// where "How do I delete a namespace?" was routed to a tool-capable
+		// agent because it contained "delete".
+		{"How do I delete a namespace?", false},
+		{"how can I scale a deployment?", false},
+		{"what is the difference between delete and force-delete?", false},
+		{"why is my pod stuck?", false},
+		{"explain how rollout restart works", false},
+		{"tell me about kubectl get pods", false},
+
+		// Imperative commands must still route to tool execution.
+		{"delete namespace foo", true},
+		{"kubectl get pods", true},
+
+		// Exact retry keyword "yes" still routes, but "yesterday" must not.
+		// Regression for #8074 where retryKeywords used Contains, so any
+		// sentence with "yes" as a substring (e.g. "yesterday") matched.
+		{"yesterday the pod crashed", false},
+		{"yes, please do", true},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary

Three small but real bugs in `pkg/agent` from @khushiiagrawal's batch report.

### Bug 1: `promptNeedsToolExecution` naive keyword matching (#8074)
Declarative/interrogative prompts like `"How do I delete a namespace?"` were routed to tool-capable agents because the keyword list used `strings.Contains` on `"delete"`. Similarly `"yesterday the pod crashed"` matched the `"yes"` retry keyword.

**Fix:** Early-return question-prefix check (`"how do"`, `"what is"`, `"explain "`, etc.) before the keyword loop, and tighten retry matching to word-boundary (space/punctuation/exact) so `"yes"` no longer matches substrings of `"yesterday"`.

### Bug 2: `handleClustersHTTP` reload-every-request (#8075)
The frontend polls this endpoint, and each call did a full kubeconfig disk read + YAML parse via `s.kubectl.Reload()`.

**Fix:** New `KubectlProxy.ReloadIfStale(minInterval)` with a 2s TTL (`kubectlReloadMinInterval` — named constant with comment). Bursty polling only triggers one real reload per window. Users adding a new context still see it within 2s.

### Bug 3: `DisconnectVCluster` dangling `current-context` (#8076)
If the user had run `kubectl config use-context <vcluster-ctx>` between connect and disconnect, `kubectl config delete-context` left the kubeconfig with a stale `current-context` pointing to the deleted entry, so subsequent `kubectl` commands failed with `current-context is \"X\", but does not exist`.

**Fix:** Before deleting, probe `kubectl config current-context`. If it matches the target, run `kubectl config unset current-context` (best-effort; failures don't block the delete).

## Test plan
- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] New test cases in `TestServer_PromptNeedsToolExecution` cover question-prefix false positives (including the \"yesterday\" regression) and the imperative path still routes correctly.
- [x] New `TestKubectlProxy_ReloadIfStale` covers first-call / within-TTL / expired-TTL paths using a real temp kubeconfig file.
- [x] New `TestDisconnectVCluster_UnsetsCurrentContextWhenActive` verifies `unset current-context` is invoked **before** `delete-context`.
- [x] New `TestDisconnectVCluster_DoesNotUnsetWhenDifferentContextActive` verifies the unset is skipped when the active context is something else.
- [x] Full `go test ./pkg/agent/...` passes (62s).
- [x] `cd web && npm run build` passes.
- [x] Pre-existing `TestRecordFocus_BadBody_Returns400` failure in `pkg/api/handlers` is unrelated (confirmed against clean `origin/main` checkout).

## Constraints honored
- No magic numbers: `kubectlReloadMinInterval = 2 * time.Second` with comment explaining the choice.
- DCO signoff on the commit.
- No `Co-Authored-By`.
- Only `pkg/agent/**` files touched.

Fixes #8074
Fixes #8075
Fixes #8076