### PR TITLE
🐛 fix: populate RootCause in rule-based insight enrichments (#8090)

### DIFF
--- a/pkg/agent/insight_worker.go
+++ b/pkg/agent/insight_worker.go
@@ -361,33 +361,41 @@ func (w *InsightWorker) generateRuleBasedEnrichments(insights []InsightSummary) 
 		case "event-correlation":
 			e.Description = fmt.Sprintf("Correlated warning events detected across %d clusters: %s. Events in %s are occurring simultaneously, suggesting a shared underlying cause.",
 				len(insight.AffectedClusters), strings.Join(insight.AffectedClusters, ", "), insight.Title)
+			e.RootCause = "Multiple clusters reporting similar warning events simultaneously — likely shared infrastructure (DNS, storage, network), a synchronized change, or a common upstream dependency."
 			e.Remediation = "Investigate shared dependencies (DNS, storage, network) across the affected clusters. Check if a recent change was deployed to all clusters simultaneously."
 		case "cascade-impact":
 			e.Description = fmt.Sprintf("Cascading failure pattern detected: %s. Issues in one cluster are propagating to others, potentially through shared services or configuration.",
 				insight.Title)
+			e.RootCause = "Failure originating in one cluster is propagating via shared services or cross-cluster dependencies."
 			e.Remediation = "Identify the origin cluster and stabilize it first. Check circuit breakers and retry policies in cross-cluster communication."
 		case "config-drift":
 			e.Description = fmt.Sprintf("Configuration drift detected: %s. Workloads across clusters have diverged from their expected configuration, which can lead to inconsistent behavior.",
 				insight.Title)
+			e.RootCause = "Workloads have diverged from the intended configuration — manual changes, partial rollouts, or missing GitOps reconciliation."
 			e.Remediation = "Use GitOps tools (ArgoCD, Flux) to reconcile configurations. Compare current configs against the source of truth and plan a synchronized rollout."
 		case "resource-imbalance":
 			e.Description = fmt.Sprintf("Resource utilization imbalance detected across clusters. %s shows significant variation that may indicate scheduling or capacity issues.",
 				insight.Title)
+			e.RootCause = "Uneven scheduling or capacity across clusters — likely caused by autoscaler thresholds, node taints, or workload placement constraints."
 			e.Remediation = "Review cluster autoscaler settings and workload placement policies. Consider rebalancing workloads or adjusting resource quotas."
 		case "restart-correlation":
 			e.Description = fmt.Sprintf("Pod restart pattern detected: %s. The correlation suggests either an application-level bug or an infrastructure issue rather than isolated incidents.",
 				insight.Title)
+			e.RootCause = "Repeated restarts correlated in time — either an application bug triggered by shared input, or a node-level infrastructure issue."
 			e.Remediation = "Check pod logs for crash reasons. If the same workload restarts across clusters, investigate application bugs. If different workloads restart in one cluster, investigate node health."
 		case "cluster-delta":
 			e.Description = fmt.Sprintf("Significant differences detected between clusters: %s. These deltas may indicate inconsistent deployments or configuration drift.",
 				insight.Title)
+			e.RootCause = "Clusters are out of sync — deployment pipelines or manual operations have introduced divergence."
 			e.Remediation = "Review deployment pipelines to ensure all clusters receive the same updates. Check for manual changes that bypassed the standard deployment process."
 		case "rollout-tracker":
 			e.Description = fmt.Sprintf("Deployment rollout in progress: %s. Tracking progress across clusters to detect stuck or failed rollouts.",
 				insight.Title)
+			e.RootCause = "A deployment rollout is in progress and has not yet reached steady state across all clusters."
 			e.Remediation = "Monitor rollout progress. If any cluster is stuck, check pod events and resource availability. Consider pausing the rollout if failures are detected."
 		default:
 			e.Description = insight.Description
+			e.RootCause = "Rule-based pattern match — AI analysis unavailable, so the specific cause could not be determined."
 			e.Remediation = "Review the affected resources and clusters for potential issues."
 		}
 

--- a/pkg/agent/insight_worker_test.go
+++ b/pkg/agent/insight_worker_test.go
@@ -1,0 +1,59 @@
+package agent
+
+import (
+	"testing"
+)
+
+// TestGenerateRuleBasedEnrichmentsRootCause verifies that every category
+// handled by generateRuleBasedEnrichments populates a non-empty RootCause.
+// Regression coverage for #8090: rule-based enrichments previously left
+// RootCause empty while AI-generated enrichments populated it.
+func TestGenerateRuleBasedEnrichmentsRootCause(t *testing.T) {
+	cases := []struct {
+		name     string
+		category string
+	}{
+		{"event-correlation", "event-correlation"},
+		{"cascade-impact", "cascade-impact"},
+		{"config-drift", "config-drift"},
+		{"resource-imbalance", "resource-imbalance"},
+		{"restart-correlation", "restart-correlation"},
+		{"cluster-delta", "cluster-delta"},
+		{"rollout-tracker", "rollout-tracker"},
+		{"default", "some-unknown-category"},
+	}
+
+	w := &InsightWorker{}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			insights := []InsightSummary{{
+				ID:               "test-" + tc.category,
+				Category:         tc.category,
+				Title:            "Test insight",
+				Description:      "Test description",
+				Severity:         "warning",
+				AffectedClusters: []string{"cluster-a", "cluster-b"},
+			}}
+
+			enrichments := w.generateRuleBasedEnrichments(insights)
+			if len(enrichments) != 1 {
+				t.Fatalf("expected 1 enrichment, got %d", len(enrichments))
+			}
+
+			e := enrichments[0]
+			if e.RootCause == "" {
+				t.Errorf("category %q: RootCause is empty, expected a non-empty rule-based root cause", tc.category)
+			}
+			if e.Description == "" {
+				t.Errorf("category %q: Description is empty", tc.category)
+			}
+			if e.Remediation == "" {
+				t.Errorf("category %q: Remediation is empty", tc.category)
+			}
+			if e.Provider != "rules" {
+				t.Errorf("category %q: Provider = %q, want %q", tc.category, e.Provider, "rules")
+			}
+		})
+	}
+}


### PR DESCRIPTION
Fixes #8090

## Summary
Rule-based enrichments produced by `generateRuleBasedEnrichments` now populate `RootCause` for every insight category. Previously only `Description` and `Remediation` were set, so the field was always empty when no AI provider was available.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] New table-driven test verifies non-empty `RootCause` for each category
- [x] `go test ./pkg/agent/... -run Enrichment`

Thanks to @Pranjal6955 for the detailed report.