### PR TITLE
🐛 fix: detect local AI agent in Repair/Diagnose checks (#8093)

### DIFF
--- a/web/src/components/cards/console-missions/shared.test.tsx
+++ b/web/src/components/cards/console-missions/shared.test.tsx
@@ -1,0 +1,86 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook } from '@testing-library/react'
+import React from 'react'
+import { MemoryRouter } from 'react-router-dom'
+import { useApiKeyCheck, ANTHROPIC_KEY_STORAGE } from './shared'
+
+// ── External module mocks ─────────────────────────────────────────────────────
+
+const mockUseMissions = vi.fn()
+vi.mock('../../../hooks/useMissions', () => ({
+  useMissions: () => mockUseMissions(),
+}))
+
+const mockIsAgentConnected = vi.fn()
+vi.mock('../../../hooks/useLocalAgent', () => ({
+  isAgentConnected: () => mockIsAgentConnected(),
+}))
+
+vi.mock('../../ui/Toast', () => ({
+  useToast: () => ({ showToast: vi.fn() }),
+}))
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+const wrapper = ({ children }: { children: React.ReactNode }) => (
+  <MemoryRouter>{children}</MemoryRouter>
+)
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  localStorage.clear()
+  // Default: no WS-reported agents, no stored key.
+  mockUseMissions.mockReturnValue({
+    agents: [],
+    selectedAgent: null,
+  })
+  mockIsAgentConnected.mockReturnValue(false)
+})
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe('useApiKeyCheck.hasAvailableAgent', () => {
+  it('returns true when a local kc-agent is connected (#8093)', () => {
+    // Repro for #8093: Mike has bob-Andersons-Office connected via kc-agent
+    // but no API keys configured and no agents in the WS list yet. Repair
+    // button should still proceed.
+    mockIsAgentConnected.mockReturnValue(true)
+
+    const { result } = renderHook(() => useApiKeyCheck(), { wrapper })
+
+    expect(result.current.hasAvailableAgent()).toBe(true)
+  })
+
+  it('returns true when an agent in the WS list is available', () => {
+    mockUseMissions.mockReturnValue({
+      agents: [{ name: 'claude', available: true }],
+      selectedAgent: 'claude',
+    })
+
+    const { result } = renderHook(() => useApiKeyCheck(), { wrapper })
+
+    expect(result.current.hasAvailableAgent()).toBe(true)
+  })
+
+  it('returns true when an Anthropic API key is in localStorage', () => {
+    localStorage.setItem(ANTHROPIC_KEY_STORAGE, 'sk-ant-test-key')
+
+    const { result } = renderHook(() => useApiKeyCheck(), { wrapper })
+
+    expect(result.current.hasAvailableAgent()).toBe(true)
+  })
+
+  it('returns false with no local agent, no WS agents, and no API key', () => {
+    const { result } = renderHook(() => useApiKeyCheck(), { wrapper })
+
+    expect(result.current.hasAvailableAgent()).toBe(false)
+  })
+
+  it('returns false when only an empty/whitespace API key is present', () => {
+    localStorage.setItem(ANTHROPIC_KEY_STORAGE, '   ')
+
+    const { result } = renderHook(() => useApiKeyCheck(), { wrapper })
+
+    expect(result.current.hasAvailableAgent()).toBe(false)
+  })
+})

--- a/web/src/components/cards/console-missions/shared.tsx
+++ b/web/src/components/cards/console-missions/shared.tsx
@@ -1,19 +1,37 @@
 import { useState, useEffect } from 'react'
 import { Bot } from 'lucide-react'
+import { useNavigate } from 'react-router-dom'
 import { useMissions } from '../../../hooks/useMissions'
+import { isAgentConnected } from '../../../hooks/useLocalAgent'
 import { useToast } from '../../ui/Toast'
+import { getSettingsWithHash } from '../../../config/routes'
 
 export const ANTHROPIC_KEY_STORAGE = 'kubestellar-anthropic-key'
+
+// Hash anchor for the API Keys section on the Settings page.
+// Matches `id="api-keys-settings"` in components/settings/sections/APIKeysSection.tsx.
+// Settings.tsx scrolls to the matching element on mount when the URL hash is set.
+const SETTINGS_API_KEYS_HASH = 'api-keys-settings'
 
 // Hook to check if any AI agent is available (API-based or CLI-based)
 export function useApiKeyCheck() {
   const { showToast } = useToast()
+  const navigate = useNavigate()
   const [showKeyPrompt, setShowKeyPrompt] = useState(false)
-  const { agents, selectedAgent, openSidebar } = useMissions()
+  const { agents, selectedAgent } = useMissions()
 
   // Check if any agent is available (bob, claude CLI, or API-based)
   const hasAvailableAgent = () => {
-    // First check if any agent in the list is available
+    // #8093 — A locally-connected kc-agent (the same thing the top-nav AI badge
+    // reports as "Connected") is sufficient to run AI-powered actions like the
+    // Cluster Health "Repair" button. The useMissions WebSocket-derived agents
+    // list can be empty even when the local agent is healthy (e.g. before the
+    // WS handshake completes, or when the agent only exposes API providers
+    // without a CLI agent), so we check the local-agent HTTP health state too.
+    if (isAgentConnected()) {
+      return true
+    }
+    // Then check if any agent in the WS-reported list is available
     if (agents.some(a => a.available)) {
       return true
     }
@@ -41,8 +59,10 @@ export function useApiKeyCheck() {
 
   const goToSettings = () => {
     setShowKeyPrompt(false)
-    // Open the sidebar which has agent settings
-    openSidebar()
+    // #8093 — Previously this opened the AI Missions sidebar, which has no
+    // agent selector. Route directly to Settings → API Keys instead so users
+    // can configure a provider when no agent is detected.
+    navigate(getSettingsWithHash(SETTINGS_API_KEYS_HASH))
   }
 
   const dismissPrompt = () => {


### PR DESCRIPTION
Fixes #8093

## Summary
- `useApiKeyCheck.hasAvailableAgent` only checked the `useMissions` agents list and the Anthropic API key in localStorage. It did not detect a locally-connected kc-agent (the same thing the top-nav AI badge reports as Connected), so the Repair button on Cluster Health falsely prompted 'AI Agent Required' when Mike had a running local agent.
- Now treats a reachable local agent as an available agent before falling through to the API-key check.
- 'Select Agent' button in the prompt modal now navigates to Settings → API Keys instead of the AI Missions sidebar (which has no agent selector).

## Test plan
- [x] Manual: Repair/Diagnose buttons with only a local agent connected — previously blocked, now proceeds
- [x] Manual: Repair/Diagnose with neither local agent nor API key — still shows the prompt
- [x] New unit tests in `shared.test.tsx` cover all four `hasAvailableAgent` paths
- [x] `npm run build`
- [x] `npm run lint` (no new errors introduced)

Thanks to @MikeSpreitzer for the bug report.