### PR TITLE
🐛 fix: frontend accepts cancel result as cancel ack (#8106)

### DIFF
--- a/web/src/hooks/useMissions.test.tsx
+++ b/web/src/hooks/useMissions.test.tsx
@@ -1782,6 +1782,52 @@ describe('cancelling mission receives terminal messages', () => {
     expect(result.current.missions.find(m => m.id === missionId)?.status).toBe('cancelled')
   })
 
+  // #8106 — The Go backend's handleCancelChat actually emits
+  // `type: "result"` with `{cancelled, sessionId}`. The frontend must accept
+  // this shape as a cancel acknowledgement; otherwise the mission stays stuck
+  // in `cancelling` until the client-side fallback timeout fires.
+  it('finalizes cancellation on result message with cancelled:true (handleCancelChat shape)', async () => {
+    const { result } = renderHook(() => useMissions(), { wrapper })
+    const { missionId } = await startMissionWithConnection(result)
+
+    act(() => { result.current.cancelMission(missionId) })
+    expect(result.current.missions.find(m => m.id === missionId)?.status).toBe('cancelling')
+
+    // Backend replies with the real handleCancelChat shape: a `result`
+    // message carrying `{cancelled, sessionId}` and keyed by the cancel
+    // request's own id (which is NOT in pendingRequests).
+    act(() => {
+      MockWebSocket.lastInstance?.simulateMessage({
+        id: `cancel-${Date.now()}`,
+        type: 'result',
+        payload: { cancelled: true, sessionId: missionId },
+      })
+    })
+
+    const mission = result.current.missions.find(m => m.id === missionId)
+    expect(mission?.status).toBe('cancelled')
+    expect(mission?.messages.some(m => m.content.includes('cancelled by user'))).toBe(true)
+  })
+
+  it('finalizes cancellation on result message with cancelled:false as failure', async () => {
+    const { result } = renderHook(() => useMissions(), { wrapper })
+    const { missionId } = await startMissionWithConnection(result)
+
+    act(() => { result.current.cancelMission(missionId) })
+
+    act(() => {
+      MockWebSocket.lastInstance?.simulateMessage({
+        id: `cancel-${Date.now()}`,
+        type: 'result',
+        payload: { cancelled: false, sessionId: missionId, message: 'no active session' },
+      })
+    })
+
+    const mission = result.current.missions.find(m => m.id === missionId)
+    expect(mission?.status).toBe('cancelled')
+    expect(mission?.messages.some(m => m.content.includes('cancellation failed') || m.content.includes('no active session'))).toBe(true)
+  })
+
   it('ignores non-terminal messages while cancelling (e.g., progress)', async () => {
     const { result } = renderHook(() => useMissions(), { wrapper })
     const { missionId, requestId } = await startMissionWithConnection(result)

--- a/web/src/hooks/useMissions.tsx
+++ b/web/src/hooks/useMissions.tsx
@@ -308,6 +308,17 @@ const MISSION_INACTIVITY_TIMEOUT_MS = 90_000 // 90 seconds of stream silence
  * frontend transitions the mission from 'cancelling' to 'failed' as a safety net.
  */
 const CANCEL_ACK_TIMEOUT_MS = 10_000 // 10 seconds
+
+/**
+ * WebSocket message types the frontend accepts as a dedicated cancel
+ * acknowledgement (#8106). Kept as named constants to avoid magic strings
+ * and to make the protocol contract easy to audit. The backend currently
+ * emits `result` messages with `{cancelled, sessionId}` shape instead, which
+ * is handled as a compatibility path in the message router.
+ */
+const CANCEL_ACK_MESSAGE_TYPE = 'cancel_ack'
+const CANCEL_CONFIRMED_MESSAGE_TYPE = 'cancel_confirmed'
+
 /**
  * Maximum time (ms) a mission may sit in 'waiting_input' with no new
  * assistant/result message before the frontend treats it as stuck and
@@ -1702,17 +1713,50 @@ The WebSocket connection to the agent at \`${LOCAL_AGENT_WS_URL}\` was lost and 
     // Handle cancel acknowledgment from backend — the cancel_chat request uses
     // a different ID format (cancel-*) so it won't be in pendingRequests. Match
     // the session ID from the payload instead.
-    if (message.type === 'cancel_ack' || message.type === 'cancel_confirmed') {
-      const payload = message.payload as { sessionId?: string; id?: string; success?: boolean; message?: string }
+    //
+    // #8106 — The WebSocket protocol is inconsistent here: the Go backend's
+    // `handleCancelChat` responds with `type: "result"` and payload
+    // `{ cancelled, sessionId }` rather than a dedicated `cancel_ack` type.
+    // Accept both shapes so missions transition out of `cancelling` immediately
+    // regardless of which message type the backend emits. Without this, cancel
+    // confirmations fall through to the generic result handler and get dropped
+    // (their `id` is `cancel-<ts>`, which is never registered in
+    // pendingRequests), leaving the mission stuck in `cancelling` until the
+    // client-side fallback timeout fires.
+    const isDedicatedCancelAck =
+      message.type === CANCEL_ACK_MESSAGE_TYPE ||
+      message.type === CANCEL_CONFIRMED_MESSAGE_TYPE
+    const isCancelResultMessage =
+      message.type === 'result' &&
+      !!message.payload &&
+      typeof message.payload === 'object' &&
+      'cancelled' in (message.payload as Record<string, unknown>) &&
+      'sessionId' in (message.payload as Record<string, unknown>)
+    if (isDedicatedCancelAck || isCancelResultMessage) {
+      const payload = message.payload as {
+        sessionId?: string
+        id?: string
+        success?: boolean
+        cancelled?: boolean
+        message?: string
+      }
       // #7310 — Backend may send `id` instead of `sessionId` in the cancel_ack
       // payload. Check both fields to avoid a permanent cancelling state lock.
       const cancelledMissionId = payload.sessionId || payload.id
       if (cancelledMissionId) {
-        if (payload.success === false) {
+        // Treat either `success === false` (cancel_ack shape) or
+        // `cancelled === false` (result shape from handleCancelChat) as a
+        // failed cancellation. Any other value means the backend confirmed
+        // the cancel.
+        const cancelFailed = payload.success === false || payload.cancelled === false
+        if (cancelFailed) {
           finalizeCancellation(cancelledMissionId, payload.message || 'Mission cancellation failed — the backend reported an error.')
         } else {
           finalizeCancellation(cancelledMissionId, 'Mission cancelled by user.')
         }
+        // Drop the pending request entry so the generic result handler below
+        // doesn't double-process this message.
+        pendingRequests.current.delete(message.id)
       }
       return
     }


### PR DESCRIPTION
Fixes #8106

## Root cause

The Go backend `handleCancelChat` (`pkg/agent/server_ai.go`) replies to a `cancel_chat` WebSocket request with:

```json
{ "id": "cancel-<ts>", "type": "result", "payload": { "cancelled": true, "sessionId": "<mission-id>" } }
```

The frontend cancel-ack handler in `useMissions.tsx` only matched dedicated `cancel_ack` / `cancel_confirmed` message types. The real `result` response fell through to the generic result router, which looks up the mission by `pendingRequests.get(message.id)` — and since the cancel request's id (`cancel-<ts>`) is never registered in `pendingRequests`, the lookup returned `undefined` and the handler silently returned. The mission stayed stuck in `cancelling` until the client-side fallback timeout fired, exactly matching the symptom in the bug report.

## Fix

Frontend-only compatibility fix — no WebSocket protocol change, so old clients keep working and the backend is untouched. The cancel-ack branch now also accepts `result` messages whose payload has the `{cancelled, sessionId}` shape:

- `cancelled: true` → `finalizeCancellation(id, 'Mission cancelled by user.')`
- `cancelled: false` → `finalizeCancellation(id, payload.message || 'Mission cancellation failed — the backend reported an error.')` (mirrors the existing `success === false` path for dedicated cancel acks)

Added named constants `CANCEL_ACK_MESSAGE_TYPE` and `CANCEL_CONFIRMED_MESSAGE_TYPE` for the message-type strings (no magic strings in the router).

## Test plan

- [x] `web && npm run build` passes
- [x] `go build ./... && go vet ./...` clean
- [x] `npx vitest run src/hooks/useMissions.test.tsx -t cancel` — 33 passing (including 2 new tests)
- [x] New test: `finalizes cancellation on result message with cancelled:true (handleCancelChat shape)`
- [x] New test: `finalizes cancellation on result message with cancelled:false as failure`
- [ ] Manual: start a mission, click Terminate Session, verify mission transitions immediately to `cancelled` (no 10s wait for the fallback timeout)

## Files changed

- `web/src/hooks/useMissions.tsx` — cancel-ack router accepts `result` shape; named constants
- `web/src/hooks/useMissions.test.tsx` — two new tests covering the backend's actual message shape