### PR TITLE
🐛 fix: GPUUsageTrend fallback staleness + read-only metrics history (#8099)

### DIFF
--- a/web/src/components/cards/GPUUsageTrend.tsx
+++ b/web/src/components/cards/GPUUsageTrend.tsx
@@ -5,7 +5,7 @@ import ReactECharts from 'echarts-for-react'
 import { useClusters } from '../../hooks/useMCP'
 import { useCachedGPUNodes } from '../../hooks/useCachedData'
 import { useGlobalFilters } from '../../hooks/useGlobalFilters'
-import { useMetricsHistory } from '../../hooks/useMetricsHistory'
+import { useMetricsHistoryReadOnly } from '../../hooks/useMetricsHistory'
 import { Skeleton, SkeletonStats } from '../ui/Skeleton'
 import { useCardLoadingState } from './CardDataContext'
 import { useTranslation } from 'react-i18next'
@@ -16,6 +16,16 @@ import {
   CHART_AXIS_STROKE,
   CHART_TOOLTIP_CONTENT_STYLE,
   CHART_TICK_COLOR } from '../../lib/constants'
+
+/**
+ * Maximum age of a metrics-history snapshot we're willing to use as a
+ * fallback when the live GPU-nodes fetch returns empty. Snapshots older than
+ * this are treated as stale and skipped (the card will render its empty
+ * state instead of showing days-old inventory). 30 minutes matches the
+ * `MAX_AGE_MS` used by this card's own on-screen chart history so the two
+ * windows stay consistent.
+ */
+const GPU_SNAPSHOT_STALENESS_MS = 30 * 60 * 1000 // 30 min
 
 interface GPUDataPoint {
   time: string
@@ -69,10 +79,17 @@ export function GPUUsageTrend() {
   // against a cluster that does have GPUs). Without this the card shows
   // "No GPU Nodes" whenever a single poll fails — see GPU Inventory History
   // card which already reads this same history and stays populated.
-  const { history: metricsHistory } = useMetricsHistory()
+  //
+  // We use the read-only variant here so this card does NOT add a second
+  // round of MCP polling (useGPUNodes) or a second capture `setInterval`.
+  // The driver `useMetricsHistory()` is hosted elsewhere (GPU Inventory
+  // History) and publishes updates through the shared singleton.
+  const { history: metricsHistory } = useMetricsHistoryReadOnly()
 
-  // Fall back to the most recent snapshot's GPU nodes if the live list is
-  // empty. Snapshots use `gpuTotal`; we remap to `gpuCount` so downstream
+  // Fall back to the most recent snapshot's GPU nodes only when the live
+  // fetch has actually tried and come up empty (not during the initial
+  // loading skeleton), and only for snapshots within the staleness window.
+  // Snapshots use `gpuTotal`; we remap to `gpuCount` so downstream
   // aggregation (currentTotals, filteredNodes) stays unchanged.
   const effectiveGPUNodes: EffectiveGPUNode[] = useMemo(() => {
     if (gpuNodes.length > 0) {
@@ -83,21 +100,36 @@ export function GPUUsageTrend() {
         gpuCount: n.gpuCount,
         gpuAllocated: n.gpuAllocated }))
     }
-    // Search most-recent-first for a snapshot that actually has GPU data.
+    // Don't fall back during the initial load — the card will show its
+    // skeleton while `hookLoading` is true. We only want the fallback once
+    // the hook has settled into an empty / failed state.
+    if (hookLoading && !isFailed && consecutiveFailures === 0) {
+      return []
+    }
+    // Search most-recent-first for a snapshot that actually has GPU data
+    // AND is within the staleness window. Older snapshots are skipped so
+    // we never surface days-old inventory as "current".
+    // eslint-disable-next-line react-hooks/purity -- Date.now() is required to compute snapshot age; this memo re-runs whenever metricsHistory updates so staleness stays accurate.
+    const now = Date.now()
     for (let i = metricsHistory.length - 1; i >= 0; i -= 1) {
       const snap = metricsHistory[i]
       const snapNodes = snap?.gpuNodes || []
-      if (snapNodes.length > 0) {
-        return snapNodes.map(g => ({
-          name: g.name,
-          cluster: g.cluster,
-          gpuType: g.gpuType,
-          gpuCount: g.gpuTotal,
-          gpuAllocated: g.gpuAllocated }))
+      if (snapNodes.length === 0) continue
+      const age = now - new Date(snap.timestamp).getTime()
+      if (age > GPU_SNAPSHOT_STALENESS_MS) {
+        // History is ordered oldest→newest, so every earlier snapshot is
+        // even older — we can stop scanning.
+        break
       }
+      return snapNodes.map(g => ({
+        name: g.name,
+        cluster: g.cluster,
+        gpuType: g.gpuType,
+        gpuCount: g.gpuTotal,
+        gpuAllocated: g.gpuAllocated }))
     }
     return []
-  }, [gpuNodes, metricsHistory])
+  }, [gpuNodes, metricsHistory, hookLoading, isFailed, consecutiveFailures])
 
   // Only show skeleton when no cached data exists (live OR snapshot fallback)
   const hasData = effectiveGPUNodes.length > 0

--- a/web/src/components/cards/__tests__/GPUUsageTrend.test.tsx
+++ b/web/src/components/cards/__tests__/GPUUsageTrend.test.tsx
@@ -57,6 +57,11 @@ vi.mock('../../../hooks/useGlobalFilters', () => ({
 const mockUseMetricsHistory = vi.fn()
 vi.mock('../../../hooks/useMetricsHistory', () => ({
   useMetricsHistory: () => mockUseMetricsHistory(),
+  // GPUUsageTrend uses the read-only variant to avoid duplicate MCP polling
+  // and stacked capture intervals. We expose the same mock data for both so
+  // existing tests that seed `mockUseMetricsHistory` continue to cover the
+  // card's fallback path.
+  useMetricsHistoryReadOnly: () => ({ history: mockUseMetricsHistory().history }),
 }))
 
 import { GPUUsageTrend } from '../GPUUsageTrend'

--- a/web/src/hooks/useMetricsHistory.ts
+++ b/web/src/hooks/useMetricsHistory.ts
@@ -156,23 +156,20 @@ function applyGPUCarryForward(
 }
 
 /**
- * Hook to manage metrics history for trend detection
- * Automatically captures snapshots every 10 minutes (configurable)
+ * Internal: subscribes a React state setter to the singleton `snapshots`
+ * array and to `HISTORY_CHANGED_EVENT` / `storage` cross-tab updates.
+ *
+ * Used by both `useMetricsHistory` (the driver that also captures snapshots)
+ * and `useMetricsHistoryReadOnly` (the passive reader that does not poll
+ * MCP or run a capture interval). Keeping the subscription code in one place
+ * ensures both variants stay in sync when the singleton is updated.
  */
-export function useMetricsHistory() {
-  const [history, setHistory] = useState<MetricsSnapshot[]>(snapshots)
-  const { deduplicatedClusters: clusters } = useClusters()
-  const { issues: podIssues } = usePodIssues()
-  const { nodes: gpuNodes } = useGPUNodes()
-  const lastSnapshotRef = useRef<number>(0)
-
-  // Keep volatile data in refs so the interval effect doesn't reset (#5781)
-  const clustersRef = useRef(clusters)
-  const podIssuesRef = useRef(podIssues)
-  const gpuNodesRef = useRef(gpuNodes)
-  clustersRef.current = clusters
-  podIssuesRef.current = podIssues
-  gpuNodesRef.current = gpuNodes
+function useSnapshotSubscription(): MetricsSnapshot[] {
+  // Initialize lazily from the current singleton so we pick up any captures
+  // that happened before this hook mounted (e.g., module-load from
+  // localStorage, or another hook instance already running). The subscribe
+  // effect below keeps us in sync after that.
+  const [history, setHistory] = useState<MetricsSnapshot[]>(() => [...snapshots])
 
   // Subscribe to shared state updates
   useEffect(() => {
@@ -180,7 +177,6 @@ export function useMetricsHistory() {
       setHistory([...newSnapshots])
     }
     subscribers.add(handleUpdate)
-    setHistory([...snapshots])
 
     return () => {
       subscribers.delete(handleUpdate)
@@ -212,6 +208,34 @@ export function useMetricsHistory() {
       window.removeEventListener('storage', handleStorage)
     }
   }, [])
+
+  return history
+}
+
+/**
+ * Hook to manage metrics history for trend detection
+ * Automatically captures snapshots every 10 minutes (configurable)
+ *
+ * This is the "driver" variant: it polls MCP for clusters, pod issues, and
+ * GPU nodes and runs a capture `setInterval` per instance. Use this in ONE
+ * place per app (e.g., GPU Inventory History) — additional consumers should
+ * use `useMetricsHistoryReadOnly()` to avoid duplicate polling and stacked
+ * capture intervals.
+ */
+export function useMetricsHistory() {
+  const history = useSnapshotSubscription()
+  const { deduplicatedClusters: clusters } = useClusters()
+  const { issues: podIssues } = usePodIssues()
+  const { nodes: gpuNodes } = useGPUNodes()
+  const lastSnapshotRef = useRef<number>(0)
+
+  // Keep volatile data in refs so the interval effect doesn't reset (#5781)
+  const clustersRef = useRef(clusters)
+  const podIssuesRef = useRef(podIssues)
+  const gpuNodesRef = useRef(gpuNodes)
+  clustersRef.current = clusters
+  podIssuesRef.current = podIssues
+  gpuNodesRef.current = gpuNodes
 
   // Auto-capture snapshots at configured interval.
   // Reads volatile data from refs so the interval stays stable across MCP polls (#5781).
@@ -377,6 +401,27 @@ export function useMetricsHistory() {
     getClusterTrend,
     getPodRestartTrend,
     snapshotCount: history.length }
+}
+
+/**
+ * Read-only variant of `useMetricsHistory`.
+ *
+ * Subscribes to the singleton snapshots state (so it reflects updates from
+ * whichever component hosts the driver `useMetricsHistory()`), but:
+ *   - Does NOT call `useClusters`, `usePodIssues`, or `useGPUNodes` (no
+ *     duplicate MCP polling).
+ *   - Does NOT set up a capture `setInterval` (no stacked timers).
+ *
+ * Use this in secondary consumers (e.g., cards that want a last-known-good
+ * GPU-node snapshot as a fallback) so they can share history with the
+ * driver instance without doubling up on polling or captures.
+ *
+ * Returns `{ history }` only — callers that need `captureNow`, trend helpers,
+ * or `clearHistory` must use the driver hook `useMetricsHistory()` instead.
+ */
+export function useMetricsHistoryReadOnly(): { history: MetricsSnapshot[] } {
+  const history = useSnapshotSubscription()
+  return { history }
 }
 
 /**


### PR DESCRIPTION
Fixes #8099

## Summary
Follow-up to PR #8095 addressing 2 Copilot review comments on `GPUUsageTrend.tsx`:

1. **Staleness guard on snapshot fallback** — `effectiveGPUNodes` was accepting any historical snapshot with GPU data, even days-old ones. Now only uses snapshots within the last 30 minutes (`GPU_SNAPSHOT_STALENESS_MS`) and only when the live fetch has actually come up empty after at least one attempt (not during initial loading).
2. **Read-only metrics history hook** — `useMetricsHistory()` internally polls `useGPUNodes` and sets up its own capture `setInterval`. Using it in a second card was duplicating polling and adding a redundant capture timer. Added a new `useMetricsHistoryReadOnly()` that only subscribes to the singleton snapshots state, with no live polling and no capture interval. `GPUUsageTrend` now uses the read-only variant; `GPUInventoryHistory` (the original driver) continues to use the full `useMetricsHistory`.

Comment 3 (`Fixes #` line placement in the PR body) is addressed by this PR's own body structure.

## Test plan
- [x] `npm run build`
- [x] `npm run lint`
- [x] `npx vitest run GPUUsageTrend useMetricsHistory`
- [x] Manual: with live GPU data → no fallback. With empty live + recent snapshot → fallback shows. With empty live + snapshot older than 30 min → no fallback (card shows empty state).
- [x] No increased GPU polling: `useMetricsHistoryReadOnly` does not call `useGPUNodes`.