### PR TITLE
🐛 fix: auth smoke test + Copilot followups on #8107 (#8110 #8108)

### DIFF
--- a/.github/workflows/auth-login-smoke.yml
+++ b/.github/workflows/auth-login-smoke.yml
@@ -3,14 +3,18 @@ name: Auth Login Smoke Test
 # Verifies the auth login contract by building and running the Go backend
 # in dev mode. No external dependencies — everything runs against localhost.
 #
-# Catches regressions like commit 25e464fa (#6593) which removed the
-# "token" field from /auth/refresh and broke login for 24 hours.
+# #6590 contract (enforced by #8107): the refreshed JWT is delivered
+# EXCLUSIVELY via the HttpOnly `kc_auth` cookie. The JSON body carries
+# only `{ refreshed: true, onboarded }` — any `token` field in the body
+# would be an XSS/extension-readable leak and must fail the smoke test.
 #
 # What it checks:
 #   1. /health returns JSON with status and oauth_configured fields
 #   2. GET /auth/github (dev mode, no OAuth client) sets a kc_auth cookie
-#   3. POST /auth/refresh with that cookie returns { token, onboarded }
-#      — the exact contract the frontend depends on
+#   3. POST /auth/refresh (cookie + CSRF header, NO Authorization) returns
+#      - response body with { refreshed: true, onboarded }
+#      - Set-Cookie: kc_auth=... (refreshed JWT)
+#      - NO `token` field in the body
 #
 # The test uses DEV_MODE (no GitHub OAuth credentials) so the backend
 # auto-creates a dev-user on /auth/github. This takes ~60 seconds.
@@ -112,32 +116,39 @@ jobs:
           echo "Got kc_auth cookie (${#KC_AUTH} chars)"
           echo "$KC_AUTH" > /tmp/kc_auth_token.txt
 
-      # ── 6. Test /auth/refresh contract ───────────────────────────
+      # ── 6. Test /auth/refresh contract (#6590) ───────────────────
+      # The refreshed JWT is delivered via the HttpOnly kc_auth cookie
+      # ONLY. The JSON body must NOT contain a `token` field — any such
+      # field is readable by XSS/extension content scripts and is the
+      # regression #8107 fixed. We drive this call exactly like the
+      # frontend does: cookie jar + CSRF header, no Authorization.
       - name: Test /auth/refresh contract
         run: |
-          KC_AUTH=$(cat /tmp/kc_auth_token.txt)
+          COOKIE_JAR=/tmp/cookies.txt
+          REFRESH_COOKIE_JAR=/tmp/cookies-after-refresh.txt
 
           echo "Testing POST /auth/refresh..."
           REFRESH_RESP=$(curl -sS --max-time 5 \
             -X POST \
-            -H "Authorization: Bearer $KC_AUTH" \
+            -b "$COOKIE_JAR" \
+            -c "$REFRESH_COOKIE_JAR" \
             -H "X-Requested-With: XMLHttpRequest" \
             http://localhost:8081/auth/refresh)
 
           echo "Response: $REFRESH_RESP"
 
-          # CONTRACT: response must contain "token" (non-empty string)
-          # This is the exact regression that broke us in commit 25e464fa (#6593)
-          HAS_TOKEN=$(echo "$REFRESH_RESP" | jq -r '.token // empty')
-          if [ -z "$HAS_TOKEN" ]; then
-            echo "::error::CONTRACT VIOLATION: /auth/refresh response missing 'token' field — OAuth login is BROKEN"
-            echo "This is the same regression as commit 25e464fa (#6593)."
+          # #6590 CONTRACT: response body MUST NOT contain a `token` field.
+          # Presence of `token` means the refreshed JWT is JS-readable,
+          # which is the XSS leak that #8107 fixed.
+          HAS_TOKEN=$(echo "$REFRESH_RESP" | jq 'has("token")')
+          if [ "$HAS_TOKEN" != "false" ]; then
+            echo "::error::CONTRACT VIOLATION: /auth/refresh response includes 'token' field — this is the #6590 XSS leak that #8107 fixed. Refreshed JWT must live in the HttpOnly kc_auth cookie only."
             echo "Response was: $REFRESH_RESP"
             exit 1
           fi
-          echo "token field present (${#HAS_TOKEN} chars)"
+          echo "token field absent from body (correct)"
 
-          # CONTRACT: response must contain "onboarded" (boolean)
+          # #6590 CONTRACT: response body MUST contain `onboarded` (boolean)
           HAS_ONBOARDED=$(echo "$REFRESH_RESP" | jq 'has("onboarded")')
           if [ "$HAS_ONBOARDED" != "true" ]; then
             echo "::error::CONTRACT VIOLATION: /auth/refresh response missing 'onboarded' field"
@@ -146,7 +157,7 @@ jobs:
           fi
           echo "onboarded field present"
 
-          # CONTRACT: response must contain "refreshed" (boolean, true)
+          # #6590 CONTRACT: response body MUST contain `refreshed: true`
           HAS_REFRESHED=$(echo "$REFRESH_RESP" | jq -r '.refreshed // empty')
           if [ "$HAS_REFRESHED" != "true" ]; then
             echo "::error::CONTRACT VIOLATION: /auth/refresh response missing 'refreshed' field"
@@ -154,6 +165,16 @@ jobs:
             exit 1
           fi
           echo "refreshed field present"
+
+          # #6590 CONTRACT: Set-Cookie must refresh the kc_auth cookie.
+          REFRESHED_KC_AUTH=$(grep -E '^[^#].*\skc_auth\s' "$REFRESH_COOKIE_JAR" 2>/dev/null | awk '{print $NF}' | tail -n1)
+          if [ -z "$REFRESHED_KC_AUTH" ]; then
+            echo "::error::CONTRACT VIOLATION: /auth/refresh did not set a new kc_auth cookie. The refreshed JWT must be delivered exclusively via the HttpOnly cookie."
+            echo "Cookie jar contents:"
+            cat "$REFRESH_COOKIE_JAR" || true
+            exit 1
+          fi
+          echo "kc_auth cookie refreshed (${#REFRESHED_KC_AUTH} chars)"
 
           echo ""
           echo "Auth login smoke test PASSED"
@@ -182,14 +203,20 @@ jobs:
               'The auth contract test failed against a local backend in dev mode.',
               'This means the `/auth/refresh` endpoint is not returning the expected response shape.',
               '',
-              '### What broke last time',
-              'Commit `25e464fa` (#6593) removed the `token` field from the response body.',
-              'Fixed in `be946db9`. See contract test in `auth_contract_test.go`.',
+              '### #6590 contract (enforced by #8107)',
+              'The refreshed JWT must be delivered EXCLUSIVELY via the HttpOnly `kc_auth` cookie.',
+              'The JSON body carries only `{ refreshed: true, onboarded }`. Any `token` field in the body',
+              'is an XSS/extension-readable leak and MUST fail this smoke test.',
               '',
               '### Action required',
               '1. Check the workflow run logs above for the specific failure',
-              '2. Verify the `/auth/refresh` response includes `token`, `onboarded`, and `refreshed`',
+              '2. Verify /auth/refresh:',
+              '   - body contains `refreshed: true` and `onboarded`',
+              '   - body does NOT contain `token`',
+              '   - response sets a fresh `kc_auth` HttpOnly cookie',
               '3. Run `go test ./pkg/api/handlers/ -run TestAuthRefreshContract` locally',
+              '4. DO NOT "fix" this by re-adding `token` to the response body — that is the #6590 regression',
+              '   and will be reverted.',
             ].join('\n');
 
             // Don't create duplicate issues

--- a/web/src/lib/__tests__/api.test.ts
+++ b/web/src/lib/__tests__/api.test.ts
@@ -4,6 +4,8 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 // Mocks — must be declared before importing the module under test
 // ---------------------------------------------------------------------------
 
+import { STORAGE_KEY_HAS_SESSION } from '../constants/storage'
+
 vi.mock('../constants', async (importOriginal) => {
   const actual = await importOriginal() as Record<string, unknown>
   return {
@@ -433,7 +435,7 @@ describe('api.ts', () => {
       expect(localStorage.getItem(STORAGE_KEY_TOKEN)).toBe('old-token')
       // Silent refresh also marks the persistent session hint so reloads
       // know to attempt cookie restoration.
-      expect(localStorage.getItem('kc-has-session')).toBe('true')
+      expect(localStorage.getItem(STORAGE_KEY_HAS_SESSION)).toBe('true')
     })
   })
 

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -331,10 +331,16 @@ class ApiClient {
     if (this.refreshInProgress) return
     this.refreshInProgress = (async () => {
       try {
+        // #8108 — /auth/refresh must NOT receive the Authorization header.
+        // Backend RefreshToken revokes the JTI of whatever bearer is presented
+        // before minting the replacement. Sending the stale localStorage token
+        // would revoke a token we still rely on for the rest of the session
+        // and race against the cookie delivery. Cookie-only flow: send the
+        // HttpOnly kc_auth cookie via credentials + CSRF header only.
         const response = await fetch(`${API_BASE}/auth/refresh`, {
           method: 'POST',
           headers: {
-            ...this.getHeaders(),
+            'Content-Type': 'application/json',
             // #6588 — CSRF gate on /auth/refresh
             'X-Requested-With': 'XMLHttpRequest',
           },

--- a/web/src/lib/auth.tsx
+++ b/web/src/lib/auth.tsx
@@ -562,14 +562,18 @@ export function AuthProvider({ children }: { children: ReactNode }) {
         const freshToken = localStorage.getItem(STORAGE_KEY_TOKEN)
         if (!freshToken || freshToken === DEMO_TOKEN_VALUE) return
         try {
+          // #8108 — Do NOT send Authorization to /auth/refresh. Backend
+          // RefreshToken revokes the JTI of the presented bearer before
+          // minting the replacement; sending `freshToken` would invalidate
+          // the token the rest of this page is still using. Cookie-only
+          // flow: rely on the HttpOnly kc_auth cookie + CSRF header.
           const response = await fetch('/auth/refresh', {
             method: 'POST',
             credentials: 'same-origin',
             headers: {
               'Content-Type': 'application/json',
               // #6588 — CSRF gate on /auth/refresh
-              'X-Requested-With': 'XMLHttpRequest',
-              Authorization: `Bearer ${freshToken}` },
+              'X-Requested-With': 'XMLHttpRequest' },
             signal: AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS) })
           if (response.ok) {
             // #6590 — /auth/refresh delivers the new JWT exclusively via the
@@ -688,19 +692,23 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   // so the rest of the app stops gating UI behind a Bearer token that no
   // longer needs to live in localStorage.
   const isAuthenticated = (() => {
-    if (token) {
-      if (token === DEMO_TOKEN_VALUE) return true
-      return !isJWTExpired(token)
-    }
-    // No JS-readable token: cookie session is valid iff we have a real user
-    // AND the persistent session hint is set (so we don't false-positive
-    // from a stale cached user record after logout).
+    // Demo sentinel wins unconditionally.
+    if (token === DEMO_TOKEN_VALUE) return true
+    // #8108 — The cookie-only session (user + kc-has-session) is authoritative
+    // and must be checked BEFORE falling back to the JS-readable token. Since
+    // /auth/refresh no longer populates localStorage (#6590), any pre-existing
+    // token will eventually cross its `exp` while the HttpOnly kc_auth cookie
+    // is still perfectly valid — previously that short-circuited to
+    // `false` here and logged the user out mid-session.
     if (user) {
       try {
-        return localStorage.getItem(STORAGE_KEY_HAS_SESSION) === 'true'
+        if (localStorage.getItem(STORAGE_KEY_HAS_SESSION) === 'true') return true
       } catch {
-        return false
+        // localStorage unavailable — fall through to the token check
       }
+    }
+    if (token) {
+      return !isJWTExpired(token)
     }
     return false
   })()


### PR DESCRIPTION
## Summary

Followup to #8107 addressing the critical auth smoke test failure (#8110) and the 4 Copilot review comments (#8108).

**#8110 is NOT a call to revert #8107.** The auto-generated issue body suggested re-adding `token` to the `/auth/refresh` response — that is exactly the #6590 XSS leak that #8107 fixed. The root cause is that the hourly smoke workflow was pinned to the pre-#6590 contract. This PR updates the workflow to enforce the real #6590 contract.

## #8110 — auth-login-smoke workflow

`.github/workflows/auth-login-smoke.yml` now enforces:
- Request is driven exactly like the frontend: `-b cookie-jar -H 'X-Requested-With: XMLHttpRequest'`, **no** `Authorization` header
- Body **MUST NOT** contain `token` (XSS/extension leak prevention)
- Body **MUST** contain `refreshed: true` and `onboarded`
- Response **MUST** set a fresh `kc_auth` HttpOnly cookie (that's where the refreshed JWT lives)
- Failure-issue body updated to warn future triagers not to "fix" by re-adding `token`

## #8108 — 4 Copilot review comments

1. **`web/src/lib/auth.tsx:572`** — banner "Refresh Now" /auth/refresh call no longer sends `Authorization`. Backend `RefreshToken` revokes the JTI of whatever bearer is presented; sending the stale `freshToken` invalidated the token the rest of the page was still using. Now uses `credentials: 'same-origin'` + CSRF header only.
2. **`web/src/lib/api.ts:339`** — `silentRefresh()` no longer spreads `this.getHeaders()` into /auth/refresh (which was leaking `Authorization`). Builds the headers object explicitly so only `Content-Type` and `X-Requested-With` go out.
3. **`web/src/lib/auth.tsx:705`** — `isAuthenticated` now checks the cookie-only path (`user + kc-has-session`) **before** the JS-readable token. Previously an expired pre-#6590 JWT in localStorage short-circuited to `false` and logged the user out mid-session even when the HttpOnly `kc_auth` cookie was still valid.
4. **`web/src/lib/__tests__/api.test.ts:436`** — replaced the hardcoded `'kc-has-session'` literal with the `STORAGE_KEY_HAS_SESSION` constant imported from `../constants/storage`.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./pkg/api/handlers/ -run TestAuthRefreshContract -v` — 2/2 pass
- [x] `npx vitest run src/lib/__tests__/api.test.ts` — 45/45 pass
- [x] `npx vitest run src/lib/__tests__/auth-coverage.test.tsx src/components/auth/__tests__/AuthCallback.contract.test.tsx src/test/auth-contract.test.ts` — 34/34 pass
- [x] `cd web && npm run build` — clean
- [x] `cd web && npm run lint` on changed files — 4 pre-existing `preserve-caught-error` errors in `api.ts`, unrelated to this PR (verified with stash)

Fixes #8110
Fixes #8108