### PR TITLE
🐛 fix: Copilot followup on GPU Usage Trend read-only hook (#8114)

### DIFF
--- a/web/src/components/cards/GPUUsageTrend.tsx
+++ b/web/src/components/cards/GPUUsageTrend.tsx
@@ -27,6 +27,16 @@ import {
  */
 const GPU_SNAPSHOT_STALENESS_MS = 30 * 60 * 1000 // 30 min
 
+/**
+ * Bucket size for the staleness-tick that forces the fallback memo to
+ * re-evaluate as time passes. Without this, a snapshot accepted as fresh
+ * can remain displayed indefinitely because the memo's deps never change.
+ * Rounding `Date.now()` to this bucket means the memo only recomputes when
+ * the bucket boundary crosses — roughly once per minute — which is plenty
+ * of precision for a 30-minute staleness window.
+ */
+const STALENESS_TICK_MS = 60_000
+
 interface GPUDataPoint {
   time: string
   available: number
@@ -86,11 +96,20 @@ export function GPUUsageTrend() {
   // History) and publishes updates through the shared singleton.
   const { history: metricsHistory } = useMetricsHistoryReadOnly()
 
-  // Fall back to the most recent snapshot's GPU nodes only when the live
-  // fetch has actually tried and come up empty (not during the initial
-  // loading skeleton), and only for snapshots within the staleness window.
-  // Snapshots use `gpuTotal`; we remap to `gpuCount` so downstream
-  // aggregation (currentTotals, filteredNodes) stays unchanged.
+  // Staleness-tick: a time-bucket derived from Date.now() rounded to
+  // STALENESS_TICK_MS. Included in the `effectiveGPUNodes` memo deps so the
+  // memo re-evaluates on every bucket boundary, which lets a snapshot that
+  // was "fresh" when first shown transition to "stale" as the clock advances.
+  const [stalenessTick, setStalenessTick] = useState<number>(
+    () => Math.floor(Date.now() / STALENESS_TICK_MS),
+  )
+  useEffect(() => {
+    const intervalId = setInterval(() => {
+      setStalenessTick(Math.floor(Date.now() / STALENESS_TICK_MS))
+    }, STALENESS_TICK_MS)
+    return () => clearInterval(intervalId)
+  }, [])
+
   const effectiveGPUNodes: EffectiveGPUNode[] = useMemo(() => {
     if (gpuNodes.length > 0) {
       return gpuNodes.map(n => ({
@@ -101,21 +120,22 @@ export function GPUUsageTrend() {
         gpuAllocated: n.gpuAllocated }))
     }
     // Don't fall back during the initial load — the card will show its
-    // skeleton while `hookLoading` is true. We only want the fallback once
-    // the hook has settled into an empty / failed state.
+    // skeleton while `hookLoading` is true.
     if (hookLoading && !isFailed && consecutiveFailures === 0) {
       return []
     }
-    // Search most-recent-first for a snapshot that actually has GPU data
-    // AND is within the staleness window. Older snapshots are skipped so
-    // we never surface days-old inventory as "current".
-    // eslint-disable-next-line react-hooks/purity -- Date.now() is required to compute snapshot age; this memo re-runs whenever metricsHistory updates so staleness stays accurate.
-    const now = Date.now()
+    // Only fall back when the live fetch actually failed. A successful fetch
+    // that returned an empty list is a legitimate "cluster has no GPUs" state
+    // and must NOT be masked by stale history.
+    if (!isFailed && consecutiveFailures === 0) {
+      return []
+    }
+    const nowBucketed = stalenessTick * STALENESS_TICK_MS
     for (let i = metricsHistory.length - 1; i >= 0; i -= 1) {
       const snap = metricsHistory[i]
       const snapNodes = snap?.gpuNodes || []
       if (snapNodes.length === 0) continue
-      const age = now - new Date(snap.timestamp).getTime()
+      const age = nowBucketed - new Date(snap.timestamp).getTime()
       if (age > GPU_SNAPSHOT_STALENESS_MS) {
         // History is ordered oldest→newest, so every earlier snapshot is
         // even older — we can stop scanning.
@@ -129,7 +149,7 @@ export function GPUUsageTrend() {
         gpuAllocated: g.gpuAllocated }))
     }
     return []
-  }, [gpuNodes, metricsHistory, hookLoading, isFailed, consecutiveFailures])
+  }, [gpuNodes, metricsHistory, hookLoading, isFailed, consecutiveFailures, stalenessTick])
 
   // Only show skeleton when no cached data exists (live OR snapshot fallback)
   const hasData = effectiveGPUNodes.length > 0

--- a/web/src/hooks/__tests__/useMetricsHistory.test.ts
+++ b/web/src/hooks/__tests__/useMetricsHistory.test.ts
@@ -1202,6 +1202,82 @@ describe('useMetricsHistory', () => {
     })
   })
 
+  describe('useMetricsHistoryReadOnly', () => {
+    const INITIAL_CAPTURE_DELAY_MS = 5000
+    const TEN_MINUTES_MS = 10 * 60 * 1000
+
+    it('does not start a capture timer (read-only)', async () => {
+      mockClusters.push({
+        name: 'readonly-cluster',
+        cpuCores: 4,
+        cpuUsageCores: 2,
+        memoryGB: 8,
+        memoryUsageGB: 4,
+        nodeCount: 1,
+        healthy: true,
+      })
+
+      const { useMetricsHistoryReadOnly } = await importFresh()
+      const { result } = renderHook(() => useMetricsHistoryReadOnly())
+
+      const startTime = Date.now()
+      act(() => {
+        vi.setSystemTime(startTime + INITIAL_CAPTURE_DELAY_MS + TEN_MINUTES_MS)
+        vi.advanceTimersByTime(INITIAL_CAPTURE_DELAY_MS + TEN_MINUTES_MS)
+      })
+
+      // Singleton snapshot count stays at 0 — the read-only hook is not
+      // driving the capture interval.
+      expect(result.current.history).toHaveLength(0)
+      const stored = JSON.parse(localStorage.getItem(STORAGE_KEY) || '[]')
+      expect(stored).toHaveLength(0)
+    })
+
+    it('stays in sync with the singleton when the driver captures a snapshot', async () => {
+      mockClusters.push({
+        name: 'driver-cluster',
+        cpuCores: 4,
+        cpuUsageCores: 2,
+        memoryGB: 8,
+        memoryUsageGB: 4,
+        nodeCount: 1,
+        healthy: true,
+      })
+
+      const { useMetricsHistory, useMetricsHistoryReadOnly } = await importFresh()
+      const { result: driver } = renderHook(() => useMetricsHistory())
+      const { result: reader } = renderHook(() => useMetricsHistoryReadOnly())
+
+      expect(reader.current.history).toHaveLength(0)
+
+      act(() => {
+        driver.current.captureNow()
+      })
+
+      // Read-only hook must reflect the driver's snapshot via the subscriber
+      // pattern, without doing any MCP polling or capture of its own.
+      expect(reader.current.history.length).toBeGreaterThanOrEqual(1)
+      expect(driver.current.history.length).toBe(reader.current.history.length)
+    })
+
+    it('reflects HISTORY_CHANGED_EVENT updates (cross-tab sync)', async () => {
+      const { useMetricsHistoryReadOnly } = await importFresh()
+      const { result } = renderHook(() => useMetricsHistoryReadOnly())
+
+      expect(result.current.history).toHaveLength(0)
+
+      // Simulate another tab writing to localStorage and firing the event.
+      const snap = makeSnapshot({ timestamp: new Date().toISOString() })
+      localStorage.setItem(STORAGE_KEY, JSON.stringify([snap]))
+
+      act(() => {
+        window.dispatchEvent(new Event(HISTORY_CHANGED_EVENT))
+      })
+
+      expect(result.current.history).toHaveLength(1)
+    })
+  })
+
   describe('cleanup on unmount', () => {
     it('removes subscriber on unmount to prevent memory leaks', async () => {
       const { useMetricsHistory } = await importFresh()

--- a/web/src/hooks/useMetricsHistory.ts
+++ b/web/src/hooks/useMetricsHistory.ts
@@ -177,6 +177,10 @@ function useSnapshotSubscription(): MetricsSnapshot[] {
       setHistory([...newSnapshots])
     }
     subscribers.add(handleUpdate)
+    // Resync once right after subscribing: if the singleton received an
+    // update between the initial lazy `useState` snapshot and this effect
+    // running, we'd otherwise miss it until the next notify.
+    setHistory([...snapshots])
 
     return () => {
       subscribers.delete(handleUpdate)


### PR DESCRIPTION
Fixes #8114

Addresses the 4 Copilot review comments on merged PR #8111.

## Fixes

1. **GPUUsageTrend.tsx — staleness memo never re-evaluates as time passes**
   Added a `stalenessTick` state driven by `setInterval(STALENESS_TICK_MS = 60_000)` and included it in the `effectiveGPUNodes` memo deps. The tick is a `Date.now()` bucket rounded to the interval, so the memo recomputes on each minute boundary and a snapshot accepted as "fresh" correctly transitions to "stale" as the clock advances.

2. **useMetricsHistory.ts — `useSnapshotSubscription` missed updates landing between initial render and subscribe-effect**
   Inside the subscription `useEffect`, after `subscribers.add(handleUpdate)`, call `setHistory([...snapshots])` once to capture any updates that hit the singleton between the lazy `useState` initializer and the effect running.

3. **useMetricsHistory.ts — `useMetricsHistoryReadOnly` had no direct unit tests**
   Added a new `describe('useMetricsHistoryReadOnly', …)` block in `useMetricsHistory.test.ts` with three tests:
   - Advances fake timers past the 5 s initial-capture delay + a full 10 min interval, asserts the singleton count and persisted snapshots stay at zero (read-only does not drive captures).
   - Renders the read-only hook alongside the driver, calls `driver.captureNow()`, asserts the read-only `history` updates via the shared subscriber list.
   - Dispatches `HISTORY_CHANGED_EVENT` after a cross-tab localStorage write and asserts the read-only hook reflects the new snapshot.

4. **GPUUsageTrend.tsx — snapshot fallback incorrectly masked legitimate "no GPUs" state**
   The fallback now only activates when `isFailed || consecutiveFailures > 0`. A successful fetch that returns an empty list is trusted as the truth and the card renders its empty state.

## Verification

- `npm run build` — passes (post-build safety checks OK)
- `npm run lint` — passes
- `npx vitest run GPUUsageTrend useMetricsHistory` — 67/67 tests pass (includes 3 new `useMetricsHistoryReadOnly` tests)

🤖 Generated with Claude Code