### PR TITLE
🐛 fix: khushiiagrawal batch 2 triage (trivial reals from #8121-#8131)

### DIFF
--- a/pkg/agent/server_http.go
+++ b/pkg/agent/server_http.go
@@ -467,11 +467,8 @@ func (s *Server) handleDeploymentsHTTP(w http.ResponseWriter, r *http.Request) {
 	ctx, cancel := context.WithTimeout(r.Context(), agentDefaultTimeout)
 	defer cancel()
 
-	// If namespace not specified, get deployments from all namespaces
-	if namespace == "" {
-		namespace = ""
-	}
-
+	// An empty namespace is passed through to client-go's Deployments("")
+	// call, which lists deployments across all namespaces (#8121).
 	deployments, err := s.k8sClient.GetDeployments(ctx, cluster, namespace)
 	if err != nil {
 		slog.Warn("error fetching deployments", "error", err)

--- a/startup-oauth.sh
+++ b/startup-oauth.sh
@@ -279,7 +279,7 @@ cleanup() {
     kill $AGENT_LOOP_PID 2>/dev/null || true
     kill $AGENT_PID 2>/dev/null || true
     kill $WATCHDOG_PID 2>/dev/null || true
-    rm -f "$SHUTDOWN_FLAG" "$STAGE_FILE"
+    rm -f "$SHUTDOWN_FLAG" "$STAGE_FILE" "${AGENT_PID_FILE:-}"
     exit 0
 }
 trap cleanup SIGINT SIGTERM EXIT
@@ -346,6 +346,11 @@ AGENT_PID=""
 AGENT_LOOP_PID=""
 if [ -n "$KC_AGENT_BIN" ]; then
     echo -e "${GREEN}Starting kc-agent ($KC_AGENT_BIN)...${NC}"
+    # Pidfile written by the restart loop so the parent shell can target the
+    # exact kc-agent process instead of whoever happens to be on port 8585.
+    # Fixes #8127 — an unrelated process listening on :8585 was killed on Ctrl+C.
+    AGENT_PID_FILE="/tmp/.kc-agent-pid-$$"
+    : > "$AGENT_PID_FILE"
     (
         # Pass KUBECONFIG from .env / environment as --kubeconfig flag
         KC_AGENT_ARGS=()
@@ -355,6 +360,7 @@ if [ -n "$KC_AGENT_BIN" ]; then
         while true; do
             "$KC_AGENT_BIN" "${KC_AGENT_ARGS[@]}" &
             CHILD=$!
+            echo "$CHILD" > "$AGENT_PID_FILE"
             echo "[kc-agent] Started (PID $CHILD)"
             wait $CHILD
             EXIT_CODE=$?
@@ -366,8 +372,14 @@ if [ -n "$KC_AGENT_BIN" ]; then
         done
     ) &
     AGENT_LOOP_PID=$!
-    sleep 2
-    AGENT_PID=$(lsof -i :8585 -t 2>/dev/null | head -1)
+    # Give the loop a moment to spawn the child and write the pidfile.
+    AGENT_PID_WAIT_ATTEMPTS=10
+    AGENT_PID_WAIT_SLEEP_SECONDS=0.2
+    for _ in $(seq 1 $AGENT_PID_WAIT_ATTEMPTS); do
+        if [ -s "$AGENT_PID_FILE" ]; then break; fi
+        sleep "$AGENT_PID_WAIT_SLEEP_SECONDS"
+    done
+    AGENT_PID=$(cat "$AGENT_PID_FILE" 2>/dev/null || true)
 else
     echo -e "${YELLOW}Warning: kc-agent not found. Run 'make build' or install via brew.${NC}"
 fi


### PR DESCRIPTION
## Summary

Second batch from @khushiiagrawal today (11 issues filed 08:18-08:21 UTC on 2026-04-15). Each issue was verified individually against current code. Only the two trivially-valid items are batched here; the rest are closed with specific reasoning (not-a-bug, already fixed, out-of-scope refactor, or valid but deferred to preserve symmetry with sibling handlers).

## Fixed in this PR

### #8121 — `handleDeploymentsHTTP` no-op namespace block
`pkg/agent/server_http.go:470-473` had `if namespace == "" { namespace = "" }`. Empty namespace is already the correct sentinel that client-go's `Deployments("")` uses to list across all namespaces (verified in `pkg/k8s/client_resources.go:631`). Removed the dead block and replaced the stale comment with a pass-through note.

### #8127 — kc-agent PID captured via `lsof` can match unrelated process
`startup-oauth.sh:370` used `lsof -i :8585 -t` in the parent shell to capture the agent PID. If another process is on :8585, Ctrl+C would kill it. Now the restart-loop subshell writes the real `$CHILD` PID to a per-run pidfile (`/tmp/.kc-agent-pid-$$`) and the parent reads from there. Cleanup removes the pidfile.

## Per-issue outcomes

| # | Outcome | Reason |
|---|---|---|
| 8121 | FIXED | No-op namespace block removed |
| 8122 | closed invalid | `pump()` uses promise chaining; each `.then()` runs as a fresh microtask with no stack growth — no overflow risk |
| 8123 | closed deferred | Real cross-tab edge case; `handling401` safety timeout is a debounce, not a lockout. Deferred to a storage-event watcher PR |
| 8124 | closed already-fixed | `silentRefresh` already uses `credentials: 'same-origin'` (correct for the same-origin HttpOnly cookie flow post-#8107/#8113) |
| 8125 | closed deferred | Real concern but wrapping `authFetch` with `handle401()` changes response semantics for 31 callers; needs a dedicated PR with per-call audit |
| 8126 | closed not-a-bug | `--dev` flag semantics are intentional (Vite only); rename would break existing docs/scripts |
| 8127 | FIXED | Pidfile capture replaces lsof |
| 8128 | closed wontfix | Bootstrap-mode `safe_npm_install` runs before the repo clone is complete — it cannot source `scripts/port-cleanup.sh`. The duplication is structural |
| 8130 | closed out-of-scope | `sqlite.go` is 107KB but refactoring a god file is not a single-contributor-sized task; tracked under existing tech-debt backlog |
| 8131 | closed deferred | Valid concern (partial results lost on client disconnect) but `handleKagentCRDSummary` uses the same `r.Context()` parent. Both handlers should change together in a dedicated PR that mirrors #7931's Background-context pattern |

## Test plan

- [x] `go build ./...` passes
- [x] `go vet ./pkg/agent/...` passes
- [x] `bash -n startup-oauth.sh` passes
- [ ] Manual: Ctrl+C during local `startup-oauth.sh` still cleans up kc-agent
- [ ] Manual: `GET /deployments?cluster=c1` (no namespace) returns deployments from all namespaces

🤖 Generated with [Claude Code](https://claude.com/claude-code)