### PR TITLE
🐛 fix: Copilot nits on GPU Usage Trend staleness + subscription (#8129)

### DIFF
--- a/web/src/components/cards/GPUUsageTrend.tsx
+++ b/web/src/components/cards/GPUUsageTrend.tsx
@@ -130,12 +130,19 @@ export function GPUUsageTrend() {
     if (!isFailed && consecutiveFailures === 0) {
       return []
     }
-    const nowBucketed = stalenessTick * STALENESS_TICK_MS
+    // Use real `Date.now()` for the age computation so a snapshot that just
+    // crossed the staleness threshold is measured against true elapsed time
+    // rather than the start of the current minute bucket (which can be up to
+    // `STALENESS_TICK_MS - 1` ms smaller than real time and would effectively
+    // extend the staleness window). `stalenessTick` is still in the memo deps
+    // so the recompute fires on each bucket boundary.
+    void stalenessTick
+    const now = Date.now()
     for (let i = metricsHistory.length - 1; i >= 0; i -= 1) {
       const snap = metricsHistory[i]
       const snapNodes = snap?.gpuNodes || []
       if (snapNodes.length === 0) continue
-      const age = nowBucketed - new Date(snap.timestamp).getTime()
+      const age = now - new Date(snap.timestamp).getTime()
       if (age > GPU_SNAPSHOT_STALENESS_MS) {
         // History is ordered oldest→newest, so every earlier snapshot is
         // even older — we can stop scanning.

--- a/web/src/hooks/useMetricsHistory.ts
+++ b/web/src/hooks/useMetricsHistory.ts
@@ -179,8 +179,19 @@ function useSnapshotSubscription(): MetricsSnapshot[] {
     subscribers.add(handleUpdate)
     // Resync once right after subscribing: if the singleton received an
     // update between the initial lazy `useState` snapshot and this effect
-    // running, we'd otherwise miss it until the next notify.
-    setHistory([...snapshots])
+    // running, we'd otherwise miss it until the next notify. Use a functional
+    // update that bails out (returns the previous reference) when the snapshot
+    // set hasn't actually changed, so React skips the rerender on every mount
+    // in the common case where nothing landed between init and subscribe.
+    setHistory(prev => {
+      if (
+        prev.length === snapshots.length &&
+        prev.every((s, i) => s === snapshots[i])
+      ) {
+        return prev
+      }
+      return [...snapshots]
+    })
 
     return () => {
       subscribers.delete(handleUpdate)


### PR DESCRIPTION
Fixes #8129

Addresses two Copilot review comments from merged PR #8118.

## Summary

### 1. `useMetricsHistory.ts:184` — avoid unnecessary rerender on mount
The resync `setHistory([...snapshots])` right after subscribing was forcing a rerender on every mount even when no update landed between the lazy `useState` init and the effect running. Switched to a functional update that bails out (returns `prev`) when the snapshot set is unchanged, preserving the resync behavior but letting React skip the rerender in the common case.

### 2. `GPUUsageTrend.tsx:139` — age off by up to ~59s
`nowBucketed = stalenessTick * STALENESS_TICK_MS` is the start of the current minute bucket, so `age` could be up to `STALENESS_TICK_MS - 1` ms smaller than real elapsed time, effectively extending the staleness window beyond `GPU_SNAPSHOT_STALENESS_MS`. Now use real `Date.now()` for the age math while keeping `stalenessTick` in the `useMemo` deps (referenced via `void stalenessTick`) so the memo still recomputes on each bucket boundary.

## Test plan
- [x] `npm run build` passes
- [x] `npx vitest run GPUUsageTrend useMetricsHistory` — 67 tests pass
- [x] No new lint errors introduced in the edited files