### PR TITLE
🐛 fix: GA4 mobile monitor sample-size floor (#8136)

### DIFF
--- a/.github/workflows/ga4-mobile-monitor.yml
+++ b/.github/workflows/ga4-mobile-monitor.yml
@@ -34,8 +34,12 @@ env:
   MIN_MOBILE_PCT: 5
   # Number of consecutive low-mobile days before alerting
   CONSECUTIVE_DAYS_THRESHOLD: 3
-  # Minimum total sessions/day to consider (skip very low-traffic days)
-  MIN_DAILY_SESSIONS: 10
+  # Minimum total sessions/day to consider (skip very low-traffic days).
+  # At <200 sessions/day, the 5% mobile threshold is dominated by sample-size
+  # noise — 1-2 users moves the percentage by 1-2 points, so the monitor flaps
+  # open/close daily. See issue #8136 for the data that motivated raising this
+  # floor from 10 to 200.
+  MIN_DAILY_SESSIONS: 200
   LOOKBACK_DAYS: 7
 
 permissions:
@@ -136,8 +140,12 @@ jobs:
             for (const date of sortedDates) {
               const day = dailyData.get(date);
               if (day.total < minDailySessions) {
-                // Skip low-traffic days (weekends, etc.)
+                // Skip low-traffic days: sample size too small to trust the
+                // mobile %. Reset the consecutive-low streak so skipped days
+                // do not silently chain together low-volume days that are
+                // actually noise (see #8136).
                 dailyReport.push({ date, mobilePct: null, sessions: day.total, skipped: true });
+                consecutiveLowDays = 0;
                 continue;
               }
 
@@ -166,7 +174,7 @@ jobs:
             console.log('─'.repeat(60));
             for (const d of dailyReport) {
               if (d.skipped) {
-                console.log(`  ${d.date}: skipped (${d.sessions} sessions < ${minDailySessions} threshold)`);
+                console.log(`  ${d.date}: skipped — ${d.sessions} sessions below ${minDailySessions} sample-size floor (mobile % unreliable)`);
               } else {
                 const flag = d.isLow ? ' ⚠️' : ' ✓';
                 console.log(`  ${d.date}: ${d.mobilePct}% mobile (${d.mobile}/${d.sessions})${flag}`);


### PR DESCRIPTION
## Summary

Raise `MIN_DAILY_SESSIONS` from **10** to **200** in `.github/workflows/ga4-mobile-monitor.yml`, and reset the consecutive-low streak when a day is skipped.

Fixes #8136

## Why

The monitor has been auto-opening and auto-closing the same issue on 5 consecutive days — #5705, #5998, #6335, #7913, #8136 — despite zero commits to mobile-sensitive files (`Sidebar.tsx`, `useMobile.ts`, `App.tsx`) since early April. The root cause is sample-size noise, not a mobile crash.

### The data from #8136

| Date | Mobile % | Mobile | Total |
|------|----------|--------|-------|
| 04/08 | 2.4% | 2 | 82 |
| 04/09 | 3.4% | 3 | 88 |
| 04/10 | 9.9% | 8 | 81 |
| 04/11 | 5.5% | 3 | 55 |
| 04/12 | 4.1% | 2 | 49 |
| 04/13 | 0.0% | 0 | 88 |
| 04/14 | 4.7% | 5 | 106 |
| 04/15 | 0.0% | 0 | 17 |

At 49-106 total sessions/day, a single mobile user is ~1-2% of daily traffic. The 5% threshold is meaningless at that scale: going from 2 mobile hits to 3 flips the day from "critical" to "healthy". The March 2026 render loop the monitor was built to catch was at ~20% baseline on much higher traffic — the pattern only holds when the denominator is large enough.

## What changed

1. `MIN_DAILY_SESSIONS: 10` → `MIN_DAILY_SESSIONS: 200` with a comment explaining the rationale and referencing this issue.
2. In the day loop, skipped days now reset `consecutiveLowDays = 0` so a skipped (low-volume) day cannot silently chain two real low-mobile days into a streak.
3. Updated the skip log line to say "below N sample-size floor (mobile % unreliable)" instead of just "below N threshold".

## Effect

- **Today:** every day in the current report falls under 200 total sessions, so the monitor will skip all of them and not open an issue. No signal → no false alarm.
- **Future:** once daily traffic grows past 200 sessions, the monitor resumes its original job of catching a mobile-specific regression like the March 20 Sidebar.tsx render loop.

## Verification

- Confirmed no recent commits to `web/src/components/Sidebar.tsx`, `web/src/App.tsx`, or `web/src/hooks/useMobile.ts` since before the flapping started.
- `useMobile.ts` uses a clean `matchMedia` listener with no render-loop risk.
- `npm run build` passes locally in an isolated worktree.
- Lint: pre-existing errors in `CompliancePerfTest.tsx` are unrelated (not touched in this PR).

## Test plan

- [ ] CI build + lint + preview pass
- [ ] Next scheduled run of `ga4-mobile-monitor.yml` logs "skipped — N sessions below 200 sample-size floor" for all days and does NOT create a new issue
- [ ] Existing #8136 remains open until traffic recovers or a human closes it (the auto-close path requires an eval that no longer runs at current volume, so this PR closes #8136 via `Fixes`)