### PR TITLE
🐛 fix: exec authz SAR error wrap + structured deny reason (#8140)

### DIFF
--- a/pkg/api/handlers/exec.go
+++ b/pkg/api/handlers/exec.go
@@ -199,22 +199,44 @@ var (
 	errExecRBACDenied = errors.New("exec denied by RBAC")
 )
 
+// execAuthzResult carries side information from authorizePodExec that the
+// caller needs to log, separately from the error return. Today the only
+// field is the deny reason, which is populated ONLY on errExecRBACDenied so
+// HandleExec can emit a structured `"reason"` log attribute (Copilot review
+// on #8139): pre-#8139 the deny reason was a dedicated slog key and
+// operators queried logs by it; #8139 accidentally embedded the reason in
+// the error string and lost the queryable attribute. Surfacing reason as a
+// separate field restores that contract without re-parsing error strings.
+//
+// reason is empty for all non-deny branches (nil error, missing subject,
+// nil authorizer, SAR call failure); callers must not rely on reason being
+// set unless errors.Is(err, errExecRBACDenied) is true.
+type execAuthzResult struct {
+	// reason is the human-readable deny explanation surfaced by the target
+	// cluster's apiserver (the `status.reason` field of the
+	// SubjectAccessReview response). Populated ONLY when the SAR returned
+	// allowed=false AND the apiserver supplied a reason string.
+	reason string
+}
+
 // authorizePodExec runs the pods/exec SubjectAccessReview against the target
-// cluster and returns nil if the user is allowed, or one of the sentinel
-// errors above on any fail-closed branch. The decision is intentionally
-// extracted from HandleExec so unit tests can exercise every branch against a
-// fake execAuthorizer without a live websocket (#8137, Copilot review on
-// #8134). HandleExec calls this after parsing the init message and writes
-// the appropriate websocket error frame on non-nil return.
+// cluster and returns a zero execAuthzResult with nil error if the user is
+// allowed, or one of the sentinel errors above on any fail-closed branch.
+// The decision is intentionally extracted from HandleExec so unit tests can
+// exercise every branch against a fake execAuthorizer without a live
+// websocket (#8137, Copilot review on #8134). HandleExec calls this after
+// parsing the init message and writes the appropriate websocket error frame
+// on non-nil return, and additionally logs result.reason under a structured
+// `"reason"` key on the deny branch (#8140).
 func (h *ExecHandlers) authorizePodExec(
 	ctx context.Context,
 	cluster, namespace, pod, githubLogin string,
-) error {
+) (execAuthzResult, error) {
 	if h.authorizer == nil {
-		return errExecAuthorizerUnavailable
+		return execAuthzResult{}, errExecAuthorizerUnavailable
 	}
 	if githubLogin == "" {
-		return errExecMissingUserSubject
+		return execAuthzResult{}, errExecMissingUserSubject
 	}
 
 	authzCtx, authzCancel := context.WithTimeout(ctx, execAuthzTimeout)
@@ -230,15 +252,20 @@ func (h *ExecHandlers) authorizePodExec(
 		pod,
 	)
 	if err != nil {
-		return fmt.Errorf("%w: %v", errExecSARFailed, err)
+		// Double-%w wrap (Go 1.20+) so callers can recover BOTH the
+		// errExecSARFailed sentinel AND the underlying SAR error via
+		// errors.Is — Copilot review on #8139 flagged that the pre-fix
+		// `%v` form silently broke the recoverable-underlying-error
+		// contract the surrounding tests documented.
+		return execAuthzResult{}, fmt.Errorf("%w: %w", errExecSARFailed, err)
 	}
 	if !allowed {
 		if reason == "" {
-			return errExecRBACDenied
+			return execAuthzResult{}, errExecRBACDenied
 		}
-		return fmt.Errorf("%w: %s", errExecRBACDenied, reason)
+		return execAuthzResult{reason: reason}, fmt.Errorf("%w: %s", errExecRBACDenied, reason)
 	}
-	return nil
+	return execAuthzResult{}, nil
 }
 
 // ExecHandlers handles pod exec API endpoints
@@ -491,7 +518,8 @@ func (h *ExecHandlers) HandleExec(c *websocket.Conn) {
 	// MUST deny the exec and return before touching the executor. The
 	// decision itself lives in authorizePodExec (#8137) so each branch has
 	// a dedicated unit test.
-	if err := h.authorizePodExec(execCtx, init.Cluster, init.Namespace, init.Pod, claims.GitHubLogin); err != nil {
+	authzResult, err := h.authorizePodExec(execCtx, init.Cluster, init.Namespace, init.Pod, claims.GitHubLogin)
+	if err != nil {
 		switch {
 		case errors.Is(err, errExecAuthorizerUnavailable):
 			slog.Error("[Exec] SECURITY: authorizer not configured — denying exec", "user", claims.GitHubLogin)
@@ -509,11 +537,16 @@ func (h *ExecHandlers) HandleExec(c *websocket.Conn) {
 			)
 			writeError(c, "failed to verify exec permission; request denied")
 		case errors.Is(err, errExecRBACDenied):
+			// Emit the deny reason under the structured `"reason"` key in
+			// addition to the wrapped error string (#8140). Operators query
+			// logs by the `reason` attribute; #8139 accidentally moved it
+			// into the error string only, which broke those queries.
 			slog.Warn("[Exec] SECURITY: pods/exec denied by RBAC",
 				"user", claims.GitHubLogin,
 				"cluster", init.Cluster,
 				"namespace", init.Namespace,
 				"pod", init.Pod,
+				"reason", authzResult.reason,
 				"error", err,
 			)
 			writeError(c, "user is not authorized to exec into this pod")

--- a/pkg/api/handlers/exec_test.go
+++ b/pkg/api/handlers/exec_test.go
@@ -136,7 +136,7 @@ func TestAuthorizePodExec_Allow(t *testing.T) {
 	fa := &fakeExecAuthorizer{allowed: true}
 	h := &ExecHandlers{authorizer: fa}
 
-	err := h.authorizePodExec(
+	res, err := h.authorizePodExec(
 		context.Background(),
 		testAuthorizePodExecCluster,
 		testAuthorizePodExecNamespace,
@@ -144,6 +144,7 @@ func TestAuthorizePodExec_Allow(t *testing.T) {
 		testAuthorizePodExecLogin,
 	)
 	require.NoError(t, err)
+	assert.Empty(t, res.reason, "allow path must not populate reason")
 	assert.Equal(t, 1, fa.calls)
 	assert.Equal(t, execUserSubjectPrefix+testAuthorizePodExecLogin, fa.calledUser)
 	assert.Equal(t, testAuthorizePodExecCluster, fa.calledContext)
@@ -153,14 +154,18 @@ func TestAuthorizePodExec_Allow(t *testing.T) {
 }
 
 // TestAuthorizePodExec_Deny verifies that allowed=false from the SAR maps to
-// errExecRBACDenied. The deny reason from the apiserver is surfaced in the
-// error string so operators can debug RBAC bindings.
+// errExecRBACDenied. The deny reason from the apiserver is surfaced BOTH in
+// the error string (for the wrapped error chain) AND on the separate
+// execAuthzResult.reason field (for the structured `"reason"` log attribute
+// #8140). Operators query logs by the `reason` key, so having it as a
+// dedicated field — not just an embedded substring of the error — is
+// load-bearing.
 func TestAuthorizePodExec_Deny(t *testing.T) {
 	const denyReason = "no RBAC binding"
 	fa := &fakeExecAuthorizer{allowed: false, reason: denyReason}
 	h := &ExecHandlers{authorizer: fa}
 
-	err := h.authorizePodExec(
+	res, err := h.authorizePodExec(
 		context.Background(),
 		testAuthorizePodExecCluster,
 		testAuthorizePodExecNamespace,
@@ -170,7 +175,30 @@ func TestAuthorizePodExec_Deny(t *testing.T) {
 	require.Error(t, err)
 	assert.ErrorIs(t, err, errExecRBACDenied)
 	assert.Contains(t, err.Error(), denyReason)
+	assert.Equal(t, denyReason, res.reason, "deny path must surface the reason on the result struct so HandleExec can log it as a structured attribute (#8140)")
+	assert.NotEmpty(t, res.reason, "deny path must produce a non-empty reason string distinct from the error (#8140)")
 	assert.Equal(t, 1, fa.calls, "the authorizer must still be consulted in the deny case")
+}
+
+// TestAuthorizePodExec_DenyNoReason verifies the deny branch where the
+// apiserver returned allowed=false but no reason string. In this case
+// authorizePodExec must still fail-closed with errExecRBACDenied, and the
+// result.reason field stays empty (callers cannot log a reason that does
+// not exist). Covers the `reason == ""` path that the non-empty case can't.
+func TestAuthorizePodExec_DenyNoReason(t *testing.T) {
+	fa := &fakeExecAuthorizer{allowed: false, reason: ""}
+	h := &ExecHandlers{authorizer: fa}
+
+	res, err := h.authorizePodExec(
+		context.Background(),
+		testAuthorizePodExecCluster,
+		testAuthorizePodExecNamespace,
+		testAuthorizePodExecPod,
+		testAuthorizePodExecLogin,
+	)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, errExecRBACDenied)
+	assert.Empty(t, res.reason, "empty apiserver reason must stay empty — callers must not synthesize one")
 }
 
 // TestAuthorizePodExec_NilAuthorizer verifies fail-closed when the
@@ -180,7 +208,7 @@ func TestAuthorizePodExec_Deny(t *testing.T) {
 func TestAuthorizePodExec_NilAuthorizer(t *testing.T) {
 	h := &ExecHandlers{authorizer: nil}
 
-	err := h.authorizePodExec(
+	res, err := h.authorizePodExec(
 		context.Background(),
 		testAuthorizePodExecCluster,
 		testAuthorizePodExecNamespace,
@@ -189,18 +217,21 @@ func TestAuthorizePodExec_NilAuthorizer(t *testing.T) {
 	)
 	require.Error(t, err)
 	assert.ErrorIs(t, err, errExecAuthorizerUnavailable)
+	assert.Empty(t, res.reason, "non-deny branches must not populate reason")
 }
 
 // TestAuthorizePodExec_SARError verifies fail-closed when the SAR call
 // errors out (apiserver unreachable, RBAC denies creating SARs, etc.).
-// The sentinel error is wrapped so both errExecSARFailed and the underlying
-// error are recoverable via errors.Is.
+// The sentinel error is double-%w-wrapped so BOTH errExecSARFailed AND the
+// underlying SAR error are recoverable via errors.Is — Copilot review on
+// #8139 caught that the pre-fix `%v` form silently broke the
+// recoverable-underlying-error contract this test documents.
 func TestAuthorizePodExec_SARError(t *testing.T) {
 	sentinel := errors.New("apiserver down")
 	fa := &fakeExecAuthorizer{err: sentinel}
 	h := &ExecHandlers{authorizer: fa}
 
-	err := h.authorizePodExec(
+	res, err := h.authorizePodExec(
 		context.Background(),
 		testAuthorizePodExecCluster,
 		testAuthorizePodExecNamespace,
@@ -208,8 +239,12 @@ func TestAuthorizePodExec_SARError(t *testing.T) {
 		testAuthorizePodExecLogin,
 	)
 	require.Error(t, err)
-	assert.ErrorIs(t, err, errExecSARFailed)
+	// Both the sentinel and the underlying SAR error must be recoverable
+	// via errors.Is — this is the double-%w contract (#8140).
+	require.ErrorIs(t, err, errExecSARFailed)
+	require.ErrorIs(t, err, sentinel, "underlying SAR error must be recoverable via errors.Is — double-%%w wrap (#8140)")
 	assert.Contains(t, err.Error(), sentinel.Error(), "underlying SAR error text should be surfaced for operator debugging")
+	assert.Empty(t, res.reason, "SAR-error branch must not populate reason")
 	assert.Equal(t, 1, fa.calls)
 }
 
@@ -221,7 +256,7 @@ func TestAuthorizePodExec_EmptyLogin(t *testing.T) {
 	fa := &fakeExecAuthorizer{allowed: true}
 	h := &ExecHandlers{authorizer: fa}
 
-	err := h.authorizePodExec(
+	res, err := h.authorizePodExec(
 		context.Background(),
 		testAuthorizePodExecCluster,
 		testAuthorizePodExecNamespace,
@@ -230,6 +265,7 @@ func TestAuthorizePodExec_EmptyLogin(t *testing.T) {
 	)
 	require.Error(t, err)
 	assert.ErrorIs(t, err, errExecMissingUserSubject)
+	assert.Empty(t, res.reason, "non-deny branches must not populate reason")
 	assert.Equal(t, 0, fa.calls, "empty login must fail-closed BEFORE the SAR call")
 }
 


### PR DESCRIPTION
## Summary

Follow-up to merged PR #8139 addressing three Copilot review comments.

- **`pkg/api/handlers/exec.go` `authorizePodExec` SAR-error branch**: switched `fmt.Errorf("%w: %v", ...)` to double-`%w` (Go 1.20+) so callers can recover BOTH `errExecSARFailed` AND the underlying SAR error via `errors.Is`. The pre-fix `%v` form silently broke the recoverable-underlying-error contract the surrounding tests documented.
- **`pkg/api/handlers/exec_test.go` `TestAuthorizePodExec_SARError`**: the test comment claimed the underlying SAR error was recoverable, but only the sentinel was asserted. Added `require.ErrorIs(t, err, sentinel)` so the double-`%w` contract is locked in by a test assertion rather than a comment.
- **`pkg/api/handlers/exec.go` `HandleExec` deny branch**: pre-#8139 logged the SAR deny reason under a structured `"reason"` slog key; #8139 accidentally moved it into the error string only, breaking operator log queries that filter on the `reason` attribute. To restore the structured field cleanly without parsing error strings, `authorizePodExec` now returns `(execAuthzResult, error)` where `execAuthzResult.reason` is populated ONLY on `errExecRBACDenied` (empty on every other branch). `HandleExec` passes `authzResult.reason` to `slog.String("reason", ...)` on deny, alongside the wrapped error.

## Tests

- `TestAuthorizePodExec_SARError` now asserts BOTH `errors.Is(err, errExecSARFailed)` AND `errors.Is(err, sentinel)` to lock in the double-wrap.
- `TestAuthorizePodExec_Deny` now asserts `res.reason == denyReason` (non-empty, distinct from the error) — the structured-log contract.
- New `TestAuthorizePodExec_DenyNoReason` covers the `reason == ""` subcase (apiserver denied but gave no reason string).
- All non-deny branches (allow, nil authorizer, missing subject, SAR failure, empty login) assert `res.reason` stays empty so callers never accidentally log a synthesized reason.

## Security

No change to the fail-closed decision. Every branch from #8134/#8137/#8139 still denies the exec before the executor is built. The `h.authorizer == nil` typed-nil guard from #8139 is untouched.

## Test plan

- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] `go test ./pkg/api/handlers/... -run Exec -count=1` — 13/13 pass
- [ ] CI build/lint/preview green

Fixes #8140