### PR TITLE
🐛 fix: AI Missions list blank state (#8143)

### DIFF
--- a/web/src/components/layout/mission-sidebar/MissionSidebar.tsx
+++ b/web/src/components/layout/mission-sidebar/MissionSidebar.tsx
@@ -887,16 +887,16 @@ export function MissionSidebar() {
       )}
 
       {/*
-        #8143 — Empty-state gate uses `listTotalMissions` (saved + active) rather
-        than raw `missions.length`. Previously users whose mission history only
-        contained terminal entries (completed / failed / cancelled) fell through
-        this branch into the list view, which renders sections only for saved
-        and active missions. The result was a panel with no list items, no
-        empty-state message, and no CTA — i.e. "AI Missions list not visible"
-        (#8143). Gate on the visible-list total so those users see the CTA.
-        `missionSearchQuery` is excluded so a failed search still surfaces the
-        "no search results" branch below instead of this full-panel empty state.
-      */}
+       * Issue 8143 — Empty-state gate uses `listTotalMissions` (saved + active)
+       * rather than raw `missions.length`. Previously users whose mission history
+       * only contained terminal entries (completed / failed / cancelled) fell
+       * through this branch into the list view, which renders sections only for
+       * saved and active missions. The result was a panel with no list items, no
+       * empty-state message, and no CTA — i.e. "AI Missions list not visible".
+       * Gate on the visible-list total so those users see the CTA.
+       * `missionSearchQuery` is excluded so a failed search still surfaces the
+       * "no search results" branch below instead of this full-panel empty state.
+       */}
       {listTotalMissions === 0 && !missionSearchQuery && !activeMission ? (
         <div className="flex-1 flex flex-col items-center justify-center p-8 text-center">
           <Sparkles className="w-10 h-10 text-purple-400/60 mb-4" />

--- a/web/src/components/layout/mission-sidebar/MissionSidebar.tsx
+++ b/web/src/components/layout/mission-sidebar/MissionSidebar.tsx
@@ -886,7 +886,18 @@ export function MissionSidebar() {
         </div>
       )}
 
-      {missions.length === 0 ? (
+      {/*
+        #8143 — Empty-state gate uses `listTotalMissions` (saved + active) rather
+        than raw `missions.length`. Previously users whose mission history only
+        contained terminal entries (completed / failed / cancelled) fell through
+        this branch into the list view, which renders sections only for saved
+        and active missions. The result was a panel with no list items, no
+        empty-state message, and no CTA — i.e. "AI Missions list not visible"
+        (#8143). Gate on the visible-list total so those users see the CTA.
+        `missionSearchQuery` is excluded so a failed search still surfaces the
+        "no search results" branch below instead of this full-panel empty state.
+      */}
+      {listTotalMissions === 0 && !missionSearchQuery && !activeMission ? (
         <div className="flex-1 flex flex-col items-center justify-center p-8 text-center">
           <Sparkles className="w-10 h-10 text-purple-400/60 mb-4" />
           <p className="text-muted-foreground">{t('missionSidebar.noActiveMissions')}</p>


### PR DESCRIPTION
## Summary

Fixes #8143 — "AI Missions list not visible (blank state) despite missions existing"

The mission sidebar's full-panel empty state was gated on raw `missions.length === 0`. If a user's mission history contained **only terminal entries** (completed / failed / cancelled) and no saved or active missions, that branch was skipped and the component fell through to the list view, which only renders sections for saved and active missions. The result: a panel with no list items, no "No active missions" message, and no start-a-mission CTA — exactly matching the #8143 report.

## Fix

Gate the full-panel empty state on `listTotalMissions === 0` (saved + active, the same source of truth used by the header count after #5946/#6134). Also:

- Skip the branch when `missionSearchQuery` is set so the existing "no search results" sub-branch still fires.
- Skip the branch when an `activeMission` is set so a user drilling into a specific mission's chat still sees it.

## Repro note

This is a **defensive fix**. I could not reproduce the exact flow from the issue report on `console.kubestellar.io` — demo mode seeds 6 saved + 1 completed mission, so `listTotalMissions >= 6` there and the branch would never have tripped on the hosted site. The latent bug pattern is real, though: any non-demo deployment where a user has run missions that all reached terminal state would hit it, and the reporter's wording ("existing missions are not displayed") matches that symptom exactly.

## Test plan

- [ ] Build passes locally (verified)
- [ ] Sidebar with empty `missions` still shows the three-button CTA (unchanged)
- [ ] Sidebar with only `completed` missions now shows the CTA instead of a stripped panel
- [ ] Sidebar with saved missions still shows the saved section (unchanged)
- [ ] Sidebar with active missions still shows the active section (unchanged)
- [ ] Clicking a terminal mission in any surface (browser / history) still opens its chat view via `activeMission` pass-through