### PR TITLE
✨ feat: allow multi-type GPU reservations (#8144)

### DIFF
--- a/pkg/api/handlers/gpu.go
+++ b/pkg/api/handlers/gpu.go
@@ -121,12 +121,18 @@ func (h *GPUHandler) CreateReservation(c *fiber.Ctx) error {
 		Namespace:     input.Namespace,
 		GPUCount:      input.GPUCount,
 		GPUType:       input.GPUType,
+		GPUTypes:      input.GPUTypes,
 		StartDate:     input.StartDate,
 		DurationHours: input.DurationHours,
 		Notes:         input.Notes,
 		QuotaName:     input.QuotaName,
 		QuotaEnforced: input.QuotaEnforced,
 	}
+	// #8144: reconcile legacy single + new multi fields. NormalizeGPUTypes
+	// is idempotent and handles all combinations (legacy-only, multi-only,
+	// both, neither) uniformly. Called here so validation and capacity
+	// checks see the canonical shape before the store call below.
+	reservation.NormalizeGPUTypes()
 
 	if err := h.store.CreateGPUReservationWithCapacity(reservation, capacity); err != nil {
 		if errors.Is(err, store.ErrGPUQuotaExceeded) {
@@ -298,7 +304,22 @@ func (h *GPUHandler) UpdateReservation(c *fiber.Ctx) error {
 	}
 	if input.GPUType != nil {
 		existing.GPUType = *input.GPUType
+		// Legacy singular write clears any previously-stored multi list
+		// so the two fields cannot drift out of sync. If the caller
+		// also sent GPUTypes, the block below re-overwrites with the
+		// authoritative list.
+		existing.GPUTypes = nil
 	}
+	if input.GPUTypes != nil {
+		// #8144: copy-by-value so later caller mutations of the input
+		// slice cannot retroactively change the stored reservation.
+		copied := make([]string, len(*input.GPUTypes))
+		copy(copied, *input.GPUTypes)
+		existing.GPUTypes = copied
+	}
+	// Normalize after any type-related write so GPUType and GPUTypes
+	// stay in lock-step before the store call.
+	existing.NormalizeGPUTypes()
 	if input.StartDate != nil {
 		if _, err := time.Parse(time.RFC3339, *input.StartDate); err != nil {
 			return fiber.NewError(fiber.StatusBadRequest, "Start date must be RFC 3339 format (e.g. 2024-01-15T09:00:00Z)")

--- a/pkg/api/handlers/gpu.go
+++ b/pkg/api/handlers/gpu.go
@@ -128,7 +128,7 @@ func (h *GPUHandler) CreateReservation(c *fiber.Ctx) error {
 		QuotaName:     input.QuotaName,
 		QuotaEnforced: input.QuotaEnforced,
 	}
-	// #8144: reconcile legacy single + new multi fields. NormalizeGPUTypes
+	// Reconcile legacy single + new multi fields. NormalizeGPUTypes
 	// is idempotent and handles all combinations (legacy-only, multi-only,
 	// both, neither) uniformly. Called here so validation and capacity
 	// checks see the canonical shape before the store call below.
@@ -311,7 +311,7 @@ func (h *GPUHandler) UpdateReservation(c *fiber.Ctx) error {
 		existing.GPUTypes = nil
 	}
 	if input.GPUTypes != nil {
-		// #8144: copy-by-value so later caller mutations of the input
+		// Copy-by-value so later caller mutations of the input
 		// slice cannot retroactively change the stored reservation.
 		copied := make([]string, len(*input.GPUTypes))
 		copy(copied, *input.GPUTypes)

--- a/pkg/models/gpu.go
+++ b/pkg/models/gpu.go
@@ -56,17 +56,17 @@ func (s ReservationStatus) CanTransitionTo(target ReservationStatus) bool {
 
 // GPUReservation represents a GPU reservation submitted by a user.
 //
-// #8144: GPUType (singular) is the legacy single-type field kept for
+// GPUType (singular) is the legacy single-type field kept for
 // backwards compatibility with existing rows and external consumers.
 // GPUTypes (plural) is the authoritative list of acceptable GPU types for
 // a reservation — an empty list means "any GPU is acceptable", a single
 // entry behaves exactly like the old single-type reservation, and two
-// or more entries implement the multi-type-preference request from
-// issue #8144 (Mike Spreitzer).
+// or more entries implement the multi-type-preference feature
+// (Mike Spreitzer).
 //
 // Serialization & migration rules:
 //   - On write, GPUType mirrors GPUTypes[0] (or "" when GPUTypes is empty)
-//     so pre-#8144 readers still see a meaningful value.
+//     so pre-multitype readers still see a meaningful value.
 //   - On read from persistent storage, if GPUTypes is empty but GPUType
 //     is set, GPUTypes is synthesized as []string{GPUType}. This keeps
 //     existing rows usable without a destructive migration.
@@ -80,7 +80,7 @@ type GPUReservation struct {
 	Namespace     string            `json:"namespace"`
 	GPUCount      int               `json:"gpu_count"`
 	GPUType       string            `json:"gpu_type"`  // legacy single-type (mirrors GPUTypes[0]).
-	GPUTypes      []string          `json:"gpu_types"` // #8144: acceptable GPU types.
+	GPUTypes      []string          `json:"gpu_types"` // multi-type: acceptable GPU types.
 	StartDate     string            `json:"start_date"`
 	DurationHours int               `json:"duration_hours"`
 	Notes         string            `json:"notes"`
@@ -92,7 +92,7 @@ type GPUReservation struct {
 }
 
 // NormalizeGPUTypes reconciles the legacy single-type field (GPUType) with
-// the multi-type field (GPUTypes) added in #8144. It is idempotent and
+// the multi-type field (GPUTypes) added for gpu-multitype. It is idempotent and
 // safe to call on any GPUReservation value regardless of whether the
 // caller populated one, both, or neither field:
 //
@@ -153,7 +153,7 @@ func (r *GPUReservation) MatchesNodeGPUType(nodeGPUType string) bool {
 
 // CreateGPUReservationInput is the input for creating a GPU reservation.
 //
-// Both GPUType (legacy single) and GPUTypes (#8144 multi) are accepted
+// Both GPUType (legacy single) and GPUTypes (multi-type) are accepted
 // so existing API clients continue to work unchanged. If both are set,
 // GPUTypes takes precedence; if only GPUType is set, it is promoted to
 // a one-element GPUTypes. See NormalizeGPUTypes for the canonical
@@ -187,7 +187,7 @@ type GPUUtilizationSnapshot struct {
 
 // UpdateGPUReservationInput is the input for updating a GPU reservation.
 //
-// #8144: GPUTypes is a pointer to a slice so the handler can distinguish
+// GPUTypes is a pointer to a slice so the handler can distinguish
 // "caller did not send this field" (nil) from "caller explicitly sent
 // an empty list meaning any-type" (non-nil but empty). Both GPUType and
 // GPUTypes are accepted; when both are supplied, GPUTypes takes

--- a/pkg/models/gpu.go
+++ b/pkg/models/gpu.go
@@ -1,6 +1,7 @@
 package models
 
 import (
+	"strings"
 	"time"
 
 	"github.com/google/uuid"
@@ -53,7 +54,22 @@ func (s ReservationStatus) CanTransitionTo(target ReservationStatus) bool {
 	return allowed[target]
 }
 
-// GPUReservation represents a GPU reservation submitted by a user
+// GPUReservation represents a GPU reservation submitted by a user.
+//
+// #8144: GPUType (singular) is the legacy single-type field kept for
+// backwards compatibility with existing rows and external consumers.
+// GPUTypes (plural) is the authoritative list of acceptable GPU types for
+// a reservation — an empty list means "any GPU is acceptable", a single
+// entry behaves exactly like the old single-type reservation, and two
+// or more entries implement the multi-type-preference request from
+// issue #8144 (Mike Spreitzer).
+//
+// Serialization & migration rules:
+//   - On write, GPUType mirrors GPUTypes[0] (or "" when GPUTypes is empty)
+//     so pre-#8144 readers still see a meaningful value.
+//   - On read from persistent storage, if GPUTypes is empty but GPUType
+//     is set, GPUTypes is synthesized as []string{GPUType}. This keeps
+//     existing rows usable without a destructive migration.
 type GPUReservation struct {
 	ID            uuid.UUID         `json:"id"`
 	UserID        uuid.UUID         `json:"user_id"`
@@ -63,7 +79,8 @@ type GPUReservation struct {
 	Cluster       string            `json:"cluster"`
 	Namespace     string            `json:"namespace"`
 	GPUCount      int               `json:"gpu_count"`
-	GPUType       string            `json:"gpu_type"`
+	GPUType       string            `json:"gpu_type"`  // legacy single-type (mirrors GPUTypes[0]).
+	GPUTypes      []string          `json:"gpu_types"` // #8144: acceptable GPU types.
 	StartDate     string            `json:"start_date"`
 	DurationHours int               `json:"duration_hours"`
 	Notes         string            `json:"notes"`
@@ -74,20 +91,87 @@ type GPUReservation struct {
 	UpdatedAt     *time.Time        `json:"updated_at,omitempty"`
 }
 
-// CreateGPUReservationInput is the input for creating a GPU reservation
+// NormalizeGPUTypes reconciles the legacy single-type field (GPUType) with
+// the multi-type field (GPUTypes) added in #8144. It is idempotent and
+// safe to call on any GPUReservation value regardless of whether the
+// caller populated one, both, or neither field:
+//
+//   - If GPUTypes is non-empty, GPUType is set to GPUTypes[0] so legacy
+//     consumers keep working.
+//   - If GPUTypes is empty but GPUType is non-empty, GPUTypes is seeded
+//     with the single legacy value.
+//   - Duplicate and empty-string entries are removed while preserving
+//     first-seen order so the "primary" type stays stable.
+func (r *GPUReservation) NormalizeGPUTypes() {
+	if len(r.GPUTypes) == 0 && r.GPUType != "" {
+		r.GPUTypes = []string{r.GPUType}
+	}
+	if len(r.GPUTypes) == 0 {
+		r.GPUType = ""
+		return
+	}
+	seen := make(map[string]bool, len(r.GPUTypes))
+	deduped := make([]string, 0, len(r.GPUTypes))
+	for _, t := range r.GPUTypes {
+		if t == "" || seen[t] {
+			continue
+		}
+		seen[t] = true
+		deduped = append(deduped, t)
+	}
+	r.GPUTypes = deduped
+	if len(r.GPUTypes) > 0 {
+		r.GPUType = r.GPUTypes[0]
+	} else {
+		r.GPUType = ""
+	}
+}
+
+// MatchesNodeGPUType returns true when a node advertising the given GPU
+// type satisfies this reservation's type preference. An empty GPUTypes
+// list is treated as "any type is acceptable" — this preserves the
+// original single-type behaviour for reservations that never specified
+// a type. When GPUTypes is populated, the node type must match at
+// least one entry (case-insensitive substring match, mirroring how the
+// frontend renders type labels like "NVIDIA A100-SXM4-80GB").
+func (r *GPUReservation) MatchesNodeGPUType(nodeGPUType string) bool {
+	if len(r.GPUTypes) == 0 {
+		return true
+	}
+	needle := strings.ToLower(nodeGPUType)
+	for _, t := range r.GPUTypes {
+		if t == "" {
+			continue
+		}
+		hay := strings.ToLower(t)
+		if hay == needle || strings.Contains(needle, hay) || strings.Contains(hay, needle) {
+			return true
+		}
+	}
+	return false
+}
+
+// CreateGPUReservationInput is the input for creating a GPU reservation.
+//
+// Both GPUType (legacy single) and GPUTypes (#8144 multi) are accepted
+// so existing API clients continue to work unchanged. If both are set,
+// GPUTypes takes precedence; if only GPUType is set, it is promoted to
+// a one-element GPUTypes. See NormalizeGPUTypes for the canonical
+// reconciliation rule.
 type CreateGPUReservationInput struct {
-	Title          string `json:"title" validate:"required,min=3,max=200"`
-	Description    string `json:"description" validate:"max=2000"`
-	Cluster        string `json:"cluster" validate:"required"`
-	Namespace      string `json:"namespace" validate:"required"`
-	GPUCount       int    `json:"gpu_count" validate:"required,min=1"`
-	GPUType        string `json:"gpu_type"`
-	StartDate      string `json:"start_date" validate:"required"`
-	DurationHours  int    `json:"duration_hours" validate:"min=1"`
-	Notes          string `json:"notes" validate:"max=2000"`
-	QuotaName      string `json:"quota_name"`
-	QuotaEnforced  bool   `json:"quota_enforced"`
-	MaxClusterGPUs int    `json:"max_cluster_gpus"`
+	Title          string   `json:"title" validate:"required,min=3,max=200"`
+	Description    string   `json:"description" validate:"max=2000"`
+	Cluster        string   `json:"cluster" validate:"required"`
+	Namespace      string   `json:"namespace" validate:"required"`
+	GPUCount       int      `json:"gpu_count" validate:"required,min=1"`
+	GPUType        string   `json:"gpu_type"`
+	GPUTypes       []string `json:"gpu_types"`
+	StartDate      string   `json:"start_date" validate:"required"`
+	DurationHours  int      `json:"duration_hours" validate:"min=1"`
+	Notes          string   `json:"notes" validate:"max=2000"`
+	QuotaName      string   `json:"quota_name"`
+	QuotaEnforced  bool     `json:"quota_enforced"`
+	MaxClusterGPUs int      `json:"max_cluster_gpus"`
 }
 
 // GPUUtilizationSnapshot records a point-in-time GPU usage measurement for a reservation
@@ -101,7 +185,13 @@ type GPUUtilizationSnapshot struct {
 	TotalGPUCount        int       `json:"total_gpu_count"`
 }
 
-// UpdateGPUReservationInput is the input for updating a GPU reservation
+// UpdateGPUReservationInput is the input for updating a GPU reservation.
+//
+// #8144: GPUTypes is a pointer to a slice so the handler can distinguish
+// "caller did not send this field" (nil) from "caller explicitly sent
+// an empty list meaning any-type" (non-nil but empty). Both GPUType and
+// GPUTypes are accepted; when both are supplied, GPUTypes takes
+// precedence. See NormalizeGPUTypes.
 type UpdateGPUReservationInput struct {
 	Title          *string            `json:"title,omitempty"`
 	Description    *string            `json:"description,omitempty"`
@@ -109,6 +199,7 @@ type UpdateGPUReservationInput struct {
 	Namespace      *string            `json:"namespace,omitempty"`
 	GPUCount       *int               `json:"gpu_count,omitempty"`
 	GPUType        *string            `json:"gpu_type,omitempty"`
+	GPUTypes       *[]string          `json:"gpu_types,omitempty"`
 	StartDate      *string            `json:"start_date,omitempty"`
 	DurationHours  *int               `json:"duration_hours,omitempty"`
 	Notes          *string            `json:"notes,omitempty"`

--- a/pkg/models/models_test.go
+++ b/pkg/models/models_test.go
@@ -222,7 +222,7 @@ func TestGPUReservation_JSONSerialization(t *testing.T) {
 }
 
 // TestGPUReservation_NormalizeGPUTypes_LegacyPromotion pins the back-compat
-// path used for reservations created before #8144 — the migration
+// path used for reservations created before gpu-multitype — the migration
 // leaves gpu_types empty and the scan must promote gpu_type into a
 // one-element list so callers always see a populated GPUTypes slice.
 func TestGPUReservation_NormalizeGPUTypes_LegacyPromotion(t *testing.T) {
@@ -267,7 +267,7 @@ func TestGPUReservation_NormalizeGPUTypes_Empty(t *testing.T) {
 }
 
 // TestGPUReservation_MatchesNodeGPUType exercises the node-matching
-// contract for the #8144 multi-type case: a reservation listing
+// contract for the multi-type case: a reservation listing
 // {A100, H100} must accept a node advertising either, but reject a
 // node advertising a third type.
 func TestGPUReservation_MatchesNodeGPUType(t *testing.T) {

--- a/pkg/models/models_test.go
+++ b/pkg/models/models_test.go
@@ -221,6 +221,92 @@ func TestGPUReservation_JSONSerialization(t *testing.T) {
 	require.Equal(t, "active", m["status"])
 }
 
+// TestGPUReservation_NormalizeGPUTypes_LegacyPromotion pins the back-compat
+// path used for reservations created before #8144 — the migration
+// leaves gpu_types empty and the scan must promote gpu_type into a
+// one-element list so callers always see a populated GPUTypes slice.
+func TestGPUReservation_NormalizeGPUTypes_LegacyPromotion(t *testing.T) {
+	r := GPUReservation{GPUType: "NVIDIA A100"}
+	r.NormalizeGPUTypes()
+	require.Equal(t, []string{"NVIDIA A100"}, r.GPUTypes)
+	require.Equal(t, "NVIDIA A100", r.GPUType)
+}
+
+// TestGPUReservation_NormalizeGPUTypes_MultiMirrors pins the forward path:
+// once a multi-type reservation is created, the legacy singular field
+// must mirror GPUTypes[0] so pre-migration clients keep reading a
+// meaningful value.
+func TestGPUReservation_NormalizeGPUTypes_MultiMirrors(t *testing.T) {
+	r := GPUReservation{GPUTypes: []string{"NVIDIA A100", "NVIDIA H100"}}
+	r.NormalizeGPUTypes()
+	require.Equal(t, []string{"NVIDIA A100", "NVIDIA H100"}, r.GPUTypes)
+	require.Equal(t, "NVIDIA A100", r.GPUType)
+}
+
+// TestGPUReservation_NormalizeGPUTypes_Dedup ensures duplicate and empty
+// entries in the incoming list are scrubbed while preserving first-seen
+// order — required so GPUType stays stable across normalize calls.
+func TestGPUReservation_NormalizeGPUTypes_Dedup(t *testing.T) {
+	r := GPUReservation{GPUTypes: []string{"A100", "", "A100", "H100", ""}}
+	r.NormalizeGPUTypes()
+	require.Equal(t, []string{"A100", "H100"}, r.GPUTypes)
+	require.Equal(t, "A100", r.GPUType)
+}
+
+// TestGPUReservation_NormalizeGPUTypes_Empty covers the "no preference"
+// case: neither singular nor multi is set. Both fields should stay
+// zero-valued and the reservation must behave as any-GPU-acceptable.
+func TestGPUReservation_NormalizeGPUTypes_Empty(t *testing.T) {
+	r := GPUReservation{}
+	r.NormalizeGPUTypes()
+	require.Empty(t, r.GPUTypes)
+	require.Equal(t, "", r.GPUType)
+	// Any-type reservation matches every node.
+	require.True(t, r.MatchesNodeGPUType("NVIDIA A100"))
+	require.True(t, r.MatchesNodeGPUType(""))
+}
+
+// TestGPUReservation_MatchesNodeGPUType exercises the node-matching
+// contract for the #8144 multi-type case: a reservation listing
+// {A100, H100} must accept a node advertising either, but reject a
+// node advertising a third type.
+func TestGPUReservation_MatchesNodeGPUType(t *testing.T) {
+	r := GPUReservation{GPUTypes: []string{"NVIDIA A100", "NVIDIA H100"}}
+	r.NormalizeGPUTypes()
+	require.True(t, r.MatchesNodeGPUType("NVIDIA A100-SXM4-80GB"))
+	require.True(t, r.MatchesNodeGPUType("NVIDIA H100 PCIe"))
+	require.False(t, r.MatchesNodeGPUType("NVIDIA V100"))
+	require.False(t, r.MatchesNodeGPUType("AMD MI250"))
+}
+
+// TestGPUReservation_JSONRoundTrip_MultiType pins the wire format: a
+// reservation with two types must serialize with both fields and
+// deserialize back into the same shape so frontend and Netlify
+// consumers can rely on gpu_types being present.
+func TestGPUReservation_JSONRoundTrip_MultiType(t *testing.T) {
+	original := GPUReservation{
+		UserName:      "alice",
+		Title:         "Multi-type Training",
+		Cluster:       "gpu-cluster-1",
+		Namespace:     "ml",
+		GPUCount:      4,
+		GPUType:       "NVIDIA A100",
+		GPUTypes:      []string{"NVIDIA A100", "NVIDIA H100"},
+		DurationHours: 24,
+		Status:        ReservationStatusPending,
+	}
+	original.NormalizeGPUTypes()
+
+	data, err := json.Marshal(original)
+	require.NoError(t, err)
+
+	var decoded GPUReservation
+	require.NoError(t, json.Unmarshal(data, &decoded))
+
+	require.Equal(t, []string{"NVIDIA A100", "NVIDIA H100"}, decoded.GPUTypes)
+	require.Equal(t, "NVIDIA A100", decoded.GPUType)
+}
+
 func TestK8sSubjectKind_Constants(t *testing.T) {
 	require.Equal(t, K8sSubjectKind("User"), K8sSubjectUser)
 	require.Equal(t, K8sSubjectKind("Group"), K8sSubjectGroup)

--- a/pkg/store/sqlite.go
+++ b/pkg/store/sqlite.go
@@ -383,7 +383,7 @@ func (s *SQLiteStore) migrate() error {
 		namespace TEXT NOT NULL,
 		gpu_count INTEGER NOT NULL,
 		gpu_type TEXT DEFAULT '',
-		-- #8144: JSON-encoded []string of acceptable GPU types. Empty
+		-- Multi-type: JSON-encoded []string of acceptable GPU types. Empty
 		-- string means "no preference" (any type); a one-element list is
 		-- equivalent to the legacy single-type behaviour. The legacy
 		-- gpu_type column is kept alongside and mirrors gpu_types[0].
@@ -485,7 +485,7 @@ func (s *SQLiteStore) migrate() error {
 		// #6949: ActionURL was declared in the Notification model but never
 		// persisted — the column, INSERT, and SELECT all omitted it.
 		"ALTER TABLE notifications ADD COLUMN action_url TEXT NOT NULL DEFAULT ''",
-		// #8144: multi-type GPU reservations. gpu_types is a JSON-encoded
+		// Multi-type GPU reservations. gpu_types is a JSON-encoded
 		// []string of acceptable GPU types. The legacy gpu_type column is
 		// still populated (mirrors gpu_types[0]) so pre-migration clients
 		// continue to read meaningful values, and pre-migration rows are
@@ -1771,7 +1771,7 @@ func (s *SQLiteStore) MarkAllNotificationsRead(userID uuid.UUID) error {
 // GPU Reservation methods
 
 // encodeGPUTypes serializes the multi-type preference list into the JSON
-// form persisted in the gpu_reservations.gpu_types column (#8144). An
+// form persisted in the gpu_reservations.gpu_types column (gpu-multitype). An
 // empty or nil list becomes an empty string, which is what the schema
 // default emits for pre-migration rows — this keeps the round trip
 // idempotent and lets a NULL/empty column decode back to "no preference".
@@ -2107,7 +2107,7 @@ func (s *SQLiteStore) scanGPUReservation(row *sql.Row) (*models.GPUReservation, 
 	if updatedAt.Valid {
 		r.UpdatedAt = &updatedAt.Time
 	}
-	// #8144: decode multi-type list and promote legacy single-type
+	// Decode multi-type list and promote legacy single-type
 	// reservations to a one-element list so callers always see a
 	// populated GPUTypes slice.
 	r.GPUTypes = decodeGPUTypes(gpuTypesRaw)
@@ -2137,7 +2137,7 @@ func (s *SQLiteStore) scanGPUReservationRow(rows *sql.Rows) (*models.GPUReservat
 	if updatedAt.Valid {
 		r.UpdatedAt = &updatedAt.Time
 	}
-	// #8144: see scanGPUReservation — same normalization logic.
+	// See scanGPUReservation — same normalization logic.
 	r.GPUTypes = decodeGPUTypes(gpuTypesRaw)
 	r.NormalizeGPUTypes()
 	return &r, nil

--- a/pkg/store/sqlite.go
+++ b/pkg/store/sqlite.go
@@ -383,6 +383,11 @@ func (s *SQLiteStore) migrate() error {
 		namespace TEXT NOT NULL,
 		gpu_count INTEGER NOT NULL,
 		gpu_type TEXT DEFAULT '',
+		-- #8144: JSON-encoded []string of acceptable GPU types. Empty
+		-- string means "no preference" (any type); a one-element list is
+		-- equivalent to the legacy single-type behaviour. The legacy
+		-- gpu_type column is kept alongside and mirrors gpu_types[0].
+		gpu_types TEXT NOT NULL DEFAULT '',
 		start_date TEXT NOT NULL,
 		duration_hours INTEGER DEFAULT 24,
 		notes TEXT DEFAULT '',
@@ -480,6 +485,12 @@ func (s *SQLiteStore) migrate() error {
 		// #6949: ActionURL was declared in the Notification model but never
 		// persisted — the column, INSERT, and SELECT all omitted it.
 		"ALTER TABLE notifications ADD COLUMN action_url TEXT NOT NULL DEFAULT ''",
+		// #8144: multi-type GPU reservations. gpu_types is a JSON-encoded
+		// []string of acceptable GPU types. The legacy gpu_type column is
+		// still populated (mirrors gpu_types[0]) so pre-migration clients
+		// continue to read meaningful values, and pre-migration rows are
+		// transparently promoted to a one-element list on read.
+		"ALTER TABLE gpu_reservations ADD COLUMN gpu_types TEXT NOT NULL DEFAULT ''",
 	}
 	for i, migration := range migrations {
 		if _, err := s.db.Exec(migration); err != nil {
@@ -1759,6 +1770,42 @@ func (s *SQLiteStore) MarkAllNotificationsRead(userID uuid.UUID) error {
 
 // GPU Reservation methods
 
+// encodeGPUTypes serializes the multi-type preference list into the JSON
+// form persisted in the gpu_reservations.gpu_types column (#8144). An
+// empty or nil list becomes an empty string, which is what the schema
+// default emits for pre-migration rows — this keeps the round trip
+// idempotent and lets a NULL/empty column decode back to "no preference".
+func encodeGPUTypes(types []string) string {
+	if len(types) == 0 {
+		return ""
+	}
+	b, err := json.Marshal(types)
+	if err != nil {
+		// Marshaling a []string cannot realistically fail, but if it
+		// does we fall back to an empty encoding rather than
+		// corrupting the row. The legacy gpu_type column still
+		// carries the primary type as a safety net.
+		return ""
+	}
+	return string(b)
+}
+
+// decodeGPUTypes is the inverse of encodeGPUTypes. Empty/whitespace/
+// non-JSON values decode to nil so callers can rely on
+// NormalizeGPUTypes to promote the legacy gpu_type column into a
+// single-element list on read.
+func decodeGPUTypes(raw string) []string {
+	trimmed := strings.TrimSpace(raw)
+	if trimmed == "" {
+		return nil
+	}
+	var out []string
+	if err := json.Unmarshal([]byte(trimmed), &out); err != nil {
+		return nil
+	}
+	return out
+}
+
 func (s *SQLiteStore) CreateGPUReservation(reservation *models.GPUReservation) error {
 	if reservation.ID == uuid.Nil {
 		reservation.ID = uuid.New()
@@ -1767,11 +1814,13 @@ func (s *SQLiteStore) CreateGPUReservation(reservation *models.GPUReservation) e
 	if reservation.Status == "" {
 		reservation.Status = models.ReservationStatusPending
 	}
+	reservation.NormalizeGPUTypes()
+	gpuTypesEncoded := encodeGPUTypes(reservation.GPUTypes)
 
-	_, err := s.db.Exec(`INSERT INTO gpu_reservations (id, user_id, user_name, title, description, cluster, namespace, gpu_count, gpu_type, start_date, duration_hours, notes, status, quota_name, quota_enforced, created_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+	_, err := s.db.Exec(`INSERT INTO gpu_reservations (id, user_id, user_name, title, description, cluster, namespace, gpu_count, gpu_type, gpu_types, start_date, duration_hours, notes, status, quota_name, quota_enforced, created_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 		reservation.ID.String(), reservation.UserID.String(), reservation.UserName,
 		reservation.Title, reservation.Description, reservation.Cluster, reservation.Namespace,
-		reservation.GPUCount, reservation.GPUType, reservation.StartDate, reservation.DurationHours,
+		reservation.GPUCount, reservation.GPUType, gpuTypesEncoded, reservation.StartDate, reservation.DurationHours,
 		reservation.Notes, string(reservation.Status), reservation.QuotaName,
 		boolToInt(reservation.QuotaEnforced), reservation.CreatedAt)
 	return err
@@ -1818,14 +1867,16 @@ func (s *SQLiteStore) CreateGPUReservationWithCapacity(reservation *models.GPURe
 		// the existing ClusterCapacityProvider==nil handler behaviour.
 		return s.CreateGPUReservation(reservation)
 	}
+	reservation.NormalizeGPUTypes()
+	gpuTypesEncoded := encodeGPUTypes(reservation.GPUTypes)
 
 	result, err := s.db.Exec(
-		`INSERT INTO gpu_reservations (id, user_id, user_name, title, description, cluster, namespace, gpu_count, gpu_type, start_date, duration_hours, notes, status, quota_name, quota_enforced, created_at)
-		 SELECT ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?
+		`INSERT INTO gpu_reservations (id, user_id, user_name, title, description, cluster, namespace, gpu_count, gpu_type, gpu_types, start_date, duration_hours, notes, status, quota_name, quota_enforced, created_at)
+		 SELECT ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?
 		 WHERE (COALESCE((SELECT SUM(gpu_count) FROM gpu_reservations WHERE cluster = ? AND status IN ('active', 'pending')), 0) + ?) <= ?`,
 		reservation.ID.String(), reservation.UserID.String(), reservation.UserName,
 		reservation.Title, reservation.Description, reservation.Cluster, reservation.Namespace,
-		reservation.GPUCount, reservation.GPUType, reservation.StartDate, reservation.DurationHours,
+		reservation.GPUCount, reservation.GPUType, gpuTypesEncoded, reservation.StartDate, reservation.DurationHours,
 		reservation.Notes, string(reservation.Status), reservation.QuotaName,
 		boolToInt(reservation.QuotaEnforced), reservation.CreatedAt,
 		reservation.Cluster, reservation.GPUCount, capacity,
@@ -1844,7 +1895,7 @@ func (s *SQLiteStore) CreateGPUReservationWithCapacity(reservation *models.GPURe
 }
 
 func (s *SQLiteStore) GetGPUReservation(id uuid.UUID) (*models.GPUReservation, error) {
-	row := s.db.QueryRow(`SELECT id, user_id, user_name, title, description, cluster, namespace, gpu_count, gpu_type, start_date, duration_hours, notes, status, quota_name, quota_enforced, created_at, updated_at FROM gpu_reservations WHERE id = ?`, id.String())
+	row := s.db.QueryRow(`SELECT id, user_id, user_name, title, description, cluster, namespace, gpu_count, gpu_type, gpu_types, start_date, duration_hours, notes, status, quota_name, quota_enforced, created_at, updated_at FROM gpu_reservations WHERE id = ?`, id.String())
 	return s.scanGPUReservation(row)
 }
 
@@ -1859,7 +1910,7 @@ func (s *SQLiteStore) ListGPUReservations() ([]models.GPUReservation, error) {
 	// #6604: bound the result set. The UI has no expectation of seeing
 	// more than a few hundred reservations at once; if an operator ever
 	// needs a full dump they can query the DB directly.
-	rows, err := s.db.Query(`SELECT id, user_id, user_name, title, description, cluster, namespace, gpu_count, gpu_type, start_date, duration_hours, notes, status, quota_name, quota_enforced, created_at, updated_at FROM gpu_reservations ORDER BY start_date DESC LIMIT ?`, gpuReservationsMaxRows)
+	rows, err := s.db.Query(`SELECT id, user_id, user_name, title, description, cluster, namespace, gpu_count, gpu_type, gpu_types, start_date, duration_hours, notes, status, quota_name, quota_enforced, created_at, updated_at FROM gpu_reservations ORDER BY start_date DESC LIMIT ?`, gpuReservationsMaxRows)
 	if err != nil {
 		return nil, err
 	}
@@ -1878,7 +1929,7 @@ func (s *SQLiteStore) ListGPUReservations() ([]models.GPUReservation, error) {
 
 func (s *SQLiteStore) ListUserGPUReservations(userID uuid.UUID) ([]models.GPUReservation, error) {
 	// #6604: same defense-in-depth LIMIT as ListGPUReservations.
-	rows, err := s.db.Query(`SELECT id, user_id, user_name, title, description, cluster, namespace, gpu_count, gpu_type, start_date, duration_hours, notes, status, quota_name, quota_enforced, created_at, updated_at FROM gpu_reservations WHERE user_id = ? ORDER BY start_date DESC LIMIT ?`, userID.String(), gpuReservationsMaxRows)
+	rows, err := s.db.Query(`SELECT id, user_id, user_name, title, description, cluster, namespace, gpu_count, gpu_type, gpu_types, start_date, duration_hours, notes, status, quota_name, quota_enforced, created_at, updated_at FROM gpu_reservations WHERE user_id = ? ORDER BY start_date DESC LIMIT ?`, userID.String(), gpuReservationsMaxRows)
 	if err != nil {
 		return nil, err
 	}
@@ -1898,10 +1949,12 @@ func (s *SQLiteStore) ListUserGPUReservations(userID uuid.UUID) ([]models.GPURes
 func (s *SQLiteStore) UpdateGPUReservation(reservation *models.GPUReservation) error {
 	now := time.Now()
 	reservation.UpdatedAt = &now
+	reservation.NormalizeGPUTypes()
+	gpuTypesEncoded := encodeGPUTypes(reservation.GPUTypes)
 
-	_, err := s.db.Exec(`UPDATE gpu_reservations SET user_name = ?, title = ?, description = ?, cluster = ?, namespace = ?, gpu_count = ?, gpu_type = ?, start_date = ?, duration_hours = ?, notes = ?, status = ?, quota_name = ?, quota_enforced = ?, updated_at = ? WHERE id = ?`,
+	_, err := s.db.Exec(`UPDATE gpu_reservations SET user_name = ?, title = ?, description = ?, cluster = ?, namespace = ?, gpu_count = ?, gpu_type = ?, gpu_types = ?, start_date = ?, duration_hours = ?, notes = ?, status = ?, quota_name = ?, quota_enforced = ?, updated_at = ? WHERE id = ?`,
 		reservation.UserName, reservation.Title, reservation.Description,
-		reservation.Cluster, reservation.Namespace, reservation.GPUCount, reservation.GPUType,
+		reservation.Cluster, reservation.Namespace, reservation.GPUCount, reservation.GPUType, gpuTypesEncoded,
 		reservation.StartDate, reservation.DurationHours, reservation.Notes,
 		string(reservation.Status), reservation.QuotaName, boolToInt(reservation.QuotaEnforced),
 		reservation.UpdatedAt, reservation.ID.String())
@@ -1920,17 +1973,19 @@ func (s *SQLiteStore) UpdateGPUReservationWithCapacity(reservation *models.GPURe
 	if capacity <= 0 {
 		return s.UpdateGPUReservation(reservation)
 	}
+	reservation.NormalizeGPUTypes()
+	gpuTypesEncoded := encodeGPUTypes(reservation.GPUTypes)
 
 	result, err := s.db.Exec(
 		`UPDATE gpu_reservations
 		 SET user_name = ?, title = ?, description = ?, cluster = ?, namespace = ?,
-		     gpu_count = ?, gpu_type = ?, start_date = ?, duration_hours = ?,
+		     gpu_count = ?, gpu_type = ?, gpu_types = ?, start_date = ?, duration_hours = ?,
 		     notes = ?, status = ?, quota_name = ?, quota_enforced = ?, updated_at = ?
 		 WHERE id = ?
 		   AND (COALESCE((SELECT SUM(gpu_count) FROM gpu_reservations
 		                   WHERE cluster = ? AND status IN ('active', 'pending') AND id != ?), 0) + ?) <= ?`,
 		reservation.UserName, reservation.Title, reservation.Description,
-		reservation.Cluster, reservation.Namespace, reservation.GPUCount, reservation.GPUType,
+		reservation.Cluster, reservation.Namespace, reservation.GPUCount, reservation.GPUType, gpuTypesEncoded,
 		reservation.StartDate, reservation.DurationHours, reservation.Notes,
 		string(reservation.Status), reservation.QuotaName, boolToInt(reservation.QuotaEnforced),
 		reservation.UpdatedAt, reservation.ID.String(),
@@ -1986,7 +2041,7 @@ func (s *SQLiteStore) GetGPUReservationsByIDs(ids []uuid.UUID) (map[uuid.UUID]*m
 		}
 
 		rows, err := s.db.Query(
-			fmt.Sprintf(`SELECT id, user_id, user_name, title, description, cluster, namespace, gpu_count, gpu_type, start_date, duration_hours, notes, status, quota_name, quota_enforced, created_at, updated_at FROM gpu_reservations WHERE id IN (%s)`, placeholders),
+			fmt.Sprintf(`SELECT id, user_id, user_name, title, description, cluster, namespace, gpu_count, gpu_type, gpu_types, start_date, duration_hours, notes, status, quota_name, quota_enforced, created_at, updated_at FROM gpu_reservations WHERE id IN (%s)`, placeholders),
 			args...,
 		)
 		if err != nil {
@@ -2032,9 +2087,10 @@ func (s *SQLiteStore) scanGPUReservation(row *sql.Row) (*models.GPUReservation, 
 	var idStr, userIDStr, status string
 	var quotaEnforced int
 	var updatedAt sql.NullTime
+	var gpuTypesRaw string
 
 	err := row.Scan(&idStr, &userIDStr, &r.UserName, &r.Title, &r.Description,
-		&r.Cluster, &r.Namespace, &r.GPUCount, &r.GPUType, &r.StartDate,
+		&r.Cluster, &r.Namespace, &r.GPUCount, &r.GPUType, &gpuTypesRaw, &r.StartDate,
 		&r.DurationHours, &r.Notes, &status, &r.QuotaName, &quotaEnforced,
 		&r.CreatedAt, &updatedAt)
 	if err == sql.ErrNoRows {
@@ -2051,6 +2107,11 @@ func (s *SQLiteStore) scanGPUReservation(row *sql.Row) (*models.GPUReservation, 
 	if updatedAt.Valid {
 		r.UpdatedAt = &updatedAt.Time
 	}
+	// #8144: decode multi-type list and promote legacy single-type
+	// reservations to a one-element list so callers always see a
+	// populated GPUTypes slice.
+	r.GPUTypes = decodeGPUTypes(gpuTypesRaw)
+	r.NormalizeGPUTypes()
 	return &r, nil
 }
 
@@ -2059,9 +2120,10 @@ func (s *SQLiteStore) scanGPUReservationRow(rows *sql.Rows) (*models.GPUReservat
 	var idStr, userIDStr, status string
 	var quotaEnforced int
 	var updatedAt sql.NullTime
+	var gpuTypesRaw string
 
 	err := rows.Scan(&idStr, &userIDStr, &r.UserName, &r.Title, &r.Description,
-		&r.Cluster, &r.Namespace, &r.GPUCount, &r.GPUType, &r.StartDate,
+		&r.Cluster, &r.Namespace, &r.GPUCount, &r.GPUType, &gpuTypesRaw, &r.StartDate,
 		&r.DurationHours, &r.Notes, &status, &r.QuotaName, &quotaEnforced,
 		&r.CreatedAt, &updatedAt)
 	if err != nil {
@@ -2075,6 +2137,9 @@ func (s *SQLiteStore) scanGPUReservationRow(rows *sql.Rows) (*models.GPUReservat
 	if updatedAt.Valid {
 		r.UpdatedAt = &updatedAt.Time
 	}
+	// #8144: see scanGPUReservation — same normalization logic.
+	r.GPUTypes = decodeGPUTypes(gpuTypesRaw)
+	r.NormalizeGPUTypes()
 	return &r, nil
 }
 
@@ -2223,7 +2288,7 @@ func (s *SQLiteStore) DeleteOldUtilizationSnapshots(before time.Time) (int64, er
 func (s *SQLiteStore) ListActiveGPUReservations() ([]models.GPUReservation, error) {
 	// #6604: same defense-in-depth LIMIT as ListGPUReservations.
 	rows, err := s.db.Query(
-		`SELECT id, user_id, user_name, title, description, cluster, namespace, gpu_count, gpu_type, start_date, duration_hours, notes, status, quota_name, quota_enforced, created_at, updated_at FROM gpu_reservations WHERE status IN ('active', 'pending') ORDER BY start_date DESC LIMIT ?`,
+		`SELECT id, user_id, user_name, title, description, cluster, namespace, gpu_count, gpu_type, gpu_types, start_date, duration_hours, notes, status, quota_name, quota_enforced, created_at, updated_at FROM gpu_reservations WHERE status IN ('active', 'pending') ORDER BY start_date DESC LIMIT ?`,
 		gpuReservationsMaxRows,
 	)
 	if err != nil {

--- a/pkg/store/wave3_fixes_test.go
+++ b/pkg/store/wave3_fixes_test.go
@@ -150,6 +150,87 @@ func TestCreateGPUReservationWithCapacity_AtomicQuotaCheck(t *testing.T) {
 		"stored reserved total must never exceed cluster capacity (#6612)")
 }
 
+// gpuMultiTypeA100 and gpuMultiTypeH100 are the two GPU types used by the
+// #8144 round-trip tests. Named constants instead of inline literals so
+// the "reservation accepts A100 OR H100" assertions read clearly.
+const (
+	gpuMultiTypeA100 = "NVIDIA A100"
+	gpuMultiTypeH100 = "NVIDIA H100"
+	gpuMultiTypeV100 = "NVIDIA V100"
+)
+
+// TestGPUReservation_MultiType_RoundTrip exercises the #8144 schema
+// change: a reservation created with two accepted GPU types must
+// round-trip through SQLite and come back as the same two-element list,
+// and the legacy single-type field must mirror the primary type so
+// pre-migration clients still see a meaningful value.
+func TestGPUReservation_MultiType_RoundTrip(t *testing.T) {
+	s := newTestStore(t)
+	owner := createTestUser(t, s, "multi-type-owner", "multi-type")
+
+	r := &models.GPUReservation{
+		UserID:        owner.ID,
+		UserName:      owner.GitHubLogin,
+		Title:         "Multi-type training",
+		Cluster:       "cluster-multi",
+		Namespace:     "ml",
+		GPUCount:      2,
+		GPUTypes:      []string{gpuMultiTypeA100, gpuMultiTypeH100},
+		StartDate:     time.Now().Format(time.RFC3339),
+		DurationHours: 1,
+	}
+	require.NoError(t, s.CreateGPUReservation(r))
+	require.NotEqual(t, uuid.Nil, r.ID)
+
+	// Read back through the same path the API handler uses.
+	fetched, err := s.GetGPUReservation(r.ID)
+	require.NoError(t, err)
+	require.NotNil(t, fetched)
+	assert.Equal(t, []string{gpuMultiTypeA100, gpuMultiTypeH100}, fetched.GPUTypes,
+		"both accepted GPU types must survive the round trip (#8144)")
+	assert.Equal(t, gpuMultiTypeA100, fetched.GPUType,
+		"legacy singular field must mirror GPUTypes[0] for pre-migration clients")
+
+	// Matching: nodes advertising either accepted type must pass, a node
+	// advertising a third type must be rejected.
+	assert.True(t, fetched.MatchesNodeGPUType(gpuMultiTypeA100),
+		"reservation accepts a node with its first accepted type")
+	assert.True(t, fetched.MatchesNodeGPUType(gpuMultiTypeH100),
+		"reservation accepts a node with its second accepted type")
+	assert.False(t, fetched.MatchesNodeGPUType(gpuMultiTypeV100),
+		"reservation rejects a node whose type is not in the accepted list")
+}
+
+// TestGPUReservation_LegacySingleType_BackCompat pins the migration's
+// back-compat guarantee: a reservation written via the legacy singular
+// GPUType field (simulating a pre-#8144 row) must read back as a
+// one-element GPUTypes list so new frontend code can rely on
+// GPUTypes always being populated.
+func TestGPUReservation_LegacySingleType_BackCompat(t *testing.T) {
+	s := newTestStore(t)
+	owner := createTestUser(t, s, "legacy-owner", "legacy")
+
+	r := &models.GPUReservation{
+		UserID:        owner.ID,
+		UserName:      owner.GitHubLogin,
+		Title:         "Legacy single type",
+		Cluster:       "cluster-legacy",
+		Namespace:     "ml",
+		GPUCount:      1,
+		GPUType:       gpuMultiTypeA100, // legacy singular; no GPUTypes
+		StartDate:     time.Now().Format(time.RFC3339),
+		DurationHours: 1,
+	}
+	require.NoError(t, s.CreateGPUReservation(r))
+
+	fetched, err := s.GetGPUReservation(r.ID)
+	require.NoError(t, err)
+	require.NotNil(t, fetched)
+	assert.Equal(t, []string{gpuMultiTypeA100}, fetched.GPUTypes,
+		"legacy gpu_type must be promoted to a one-element GPUTypes list")
+	assert.Equal(t, gpuMultiTypeA100, fetched.GPUType)
+}
+
 // TestCreateGPUReservationWithCapacity_ZeroCapacityFallsThrough pins the
 // documented behaviour: when the capacity provider is unavailable (nil or
 // returns zero), CreateGPUReservationWithCapacity must behave identically

--- a/pkg/store/wave3_fixes_test.go
+++ b/pkg/store/wave3_fixes_test.go
@@ -151,7 +151,7 @@ func TestCreateGPUReservationWithCapacity_AtomicQuotaCheck(t *testing.T) {
 }
 
 // gpuMultiTypeA100 and gpuMultiTypeH100 are the two GPU types used by the
-// #8144 round-trip tests. Named constants instead of inline literals so
+// gpu-multitype round-trip tests. Named constants instead of inline literals so
 // the "reservation accepts A100 OR H100" assertions read clearly.
 const (
 	gpuMultiTypeA100 = "NVIDIA A100"
@@ -159,7 +159,7 @@ const (
 	gpuMultiTypeV100 = "NVIDIA V100"
 )
 
-// TestGPUReservation_MultiType_RoundTrip exercises the #8144 schema
+// TestGPUReservation_MultiType_RoundTrip exercises the gpu-multitype schema
 // change: a reservation created with two accepted GPU types must
 // round-trip through SQLite and come back as the same two-element list,
 // and the legacy single-type field must mirror the primary type so
@@ -187,7 +187,7 @@ func TestGPUReservation_MultiType_RoundTrip(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, fetched)
 	assert.Equal(t, []string{gpuMultiTypeA100, gpuMultiTypeH100}, fetched.GPUTypes,
-		"both accepted GPU types must survive the round trip (#8144)")
+		"both accepted GPU types must survive the round trip")
 	assert.Equal(t, gpuMultiTypeA100, fetched.GPUType,
 		"legacy singular field must mirror GPUTypes[0] for pre-migration clients")
 
@@ -203,7 +203,7 @@ func TestGPUReservation_MultiType_RoundTrip(t *testing.T) {
 
 // TestGPUReservation_LegacySingleType_BackCompat pins the migration's
 // back-compat guarantee: a reservation written via the legacy singular
-// GPUType field (simulating a pre-#8144 row) must read back as a
+// GPUType field (simulating a pre-multitype row) must read back as a
 // one-element GPUTypes list so new frontend code can rely on
 // GPUTypes always being populated.
 func TestGPUReservation_LegacySingleType_BackCompat(t *testing.T) {

--- a/web/src/components/cards/slo_compliance/SLOCompliance.tsx
+++ b/web/src/components/cards/slo_compliance/SLOCompliance.tsx
@@ -113,7 +113,7 @@ export function SLOCompliance() {
           return (
             <DonutGauge
               key={target.metric}
-              // Issue #5991: do not manually truncate the label with
+              // Do not manually truncate the label with
               // .split(' ').slice(0, 2).join(' '). That loses meaningful
               // content in non-English locales (and even English phrases
               // like "P99 Latency (API)"). The DonutGauge label span

--- a/web/src/components/gpu/GPUReservations.tsx
+++ b/web/src/components/gpu/GPUReservations.tsx
@@ -197,6 +197,10 @@ export function GPUReservations() {
         (r.cluster ?? '').toLowerCase().includes(term) ||
         (r.status ?? '').toLowerCase().includes(term) ||
         (r.gpu_type && r.gpu_type.toLowerCase().includes(term)) ||
+        // #8144: match against any accepted GPU type so searching
+        // for "H100" finds multi-type reservations that list H100
+        // among their acceptable alternatives.
+        (r.gpu_types && r.gpu_types.some(t => t.toLowerCase().includes(term))) ||
         (r.description && r.description.toLowerCase().includes(term)) ||
         (r.notes && r.notes.toLowerCase().includes(term))
       )

--- a/web/src/components/gpu/GPUReservations.tsx
+++ b/web/src/components/gpu/GPUReservations.tsx
@@ -197,7 +197,7 @@ export function GPUReservations() {
         (r.cluster ?? '').toLowerCase().includes(term) ||
         (r.status ?? '').toLowerCase().includes(term) ||
         (r.gpu_type && r.gpu_type.toLowerCase().includes(term)) ||
-        // #8144: match against any accepted GPU type so searching
+        // Match against any accepted GPU type so searching
         // for "H100" finds multi-type reservations that list H100
         // among their acceptable alternatives.
         (r.gpu_types && r.gpu_types.some(t => t.toLowerCase().includes(term))) ||

--- a/web/src/components/gpu/GPUReservationsTab.tsx
+++ b/web/src/components/gpu/GPUReservationsTab.tsx
@@ -167,12 +167,30 @@ export function GPUReservationsTab({
                     <div className="text-sm font-medium text-foreground">{r.gpu_count}</div>
                   </div>
                 </div>
-                {r.gpu_type && (
-                  <div className="p-2 rounded bg-secondary/30">
-                    <div className="text-xs text-muted-foreground">{t('common:common.type')}</div>
-                    <div className="text-sm font-medium text-foreground truncate">{r.gpu_type}</div>
-                  </div>
-                )}
+                {/* #8144: display the full accepted-types list when a
+                    reservation permits more than one GPU type. Falls
+                    back to the legacy singular field for pre-migration
+                    rows so existing reservations keep their label. */}
+                {(() => {
+                  const acceptedTypes =
+                    r.gpu_types && r.gpu_types.length > 0
+                      ? r.gpu_types
+                      : r.gpu_type
+                      ? [r.gpu_type]
+                      : []
+                  if (acceptedTypes.length === 0) return null
+                  return (
+                    <div className="p-2 rounded bg-secondary/30">
+                      <div className="text-xs text-muted-foreground">{t('common:common.type')}</div>
+                      <div
+                        className="text-sm font-medium text-foreground truncate"
+                        title={acceptedTypes.join(', ')}
+                      >
+                        {acceptedTypes.join(', ')}
+                      </div>
+                    </div>
+                  )
+                })()}
                 <div className="p-2 rounded bg-secondary/30">
                   <div className="text-xs text-muted-foreground">{t('common:common.start')}</div>
                   <div className="text-sm font-medium text-foreground">{(r.start_date || '').split('T')[0]}</div>

--- a/web/src/components/gpu/GPUReservationsTab.tsx
+++ b/web/src/components/gpu/GPUReservationsTab.tsx
@@ -96,7 +96,7 @@ export function GPUReservationsTab({
         <div className={'glass p-8 rounded-lg text-center'}>
           <Settings2 className="w-12 h-12 mx-auto mb-3 text-muted-foreground opacity-50" />
           {/*
-            Issue #5991: do not manually truncate translation output with
+            Do not manually truncate translation output with
             .split('"')[0]. That assumes an English-shaped string containing
             a literal double quote and silently drops text in locales whose
             translated string has no such quote. Use a dedicated short key
@@ -167,7 +167,7 @@ export function GPUReservationsTab({
                     <div className="text-sm font-medium text-foreground">{r.gpu_count}</div>
                   </div>
                 </div>
-                {/* #8144: display the full accepted-types list when a
+                {/* Display the full accepted-types list when a
                     reservation permits more than one GPU type. Falls
                     back to the legacy singular field for pre-migration
                     rows so existing reservations keep their label. */}

--- a/web/src/components/gpu/ReservationFormModal.tsx
+++ b/web/src/components/gpu/ReservationFormModal.tsx
@@ -137,11 +137,11 @@ export function ReservationFormModal({
   const [title, setTitle] = useState(editingReservation?.title || '')
   const [description, setDescription] = useState(editingReservation?.description || '')
   const [gpuCount, setGpuCount] = useState(editingReservation ? String(editingReservation.gpu_count) : '')
-  // #8144: multi-type preference. `gpuPreferences` holds the list of
+  // Multi-type preference. `gpuPreferences` holds the list of
   // acceptable GPU types for this reservation — an empty array is
   // "no preference" (any type is acceptable), a one-element array is
   // the legacy single-type behaviour, and two or more entries implement
-  // the feature requested in kubestellar/console#8144 by
+  // the multi-type-preference feature requested by
   // @MikeSpreitzer. Seeded from both the legacy `gpu_type` string and
   // the new `gpu_types` array via `normalizeGpuTypes` so edits of
   // existing pre-migration reservations keep their type.
@@ -168,7 +168,7 @@ export function ReservationFormModal({
       title: editingReservation?.title || '',
       description: editingReservation?.description || '',
       gpuCount: editingReservation ? String(editingReservation.gpu_count) : '',
-      // #8144: snapshot the multi-type preference list so dirty
+      // Snapshot the multi-type preference list so dirty
       // detection can see a type-only edit. Sorted so order churn
       // does not trip a false positive.
       gpuPreferences: [...normalizeGpuTypes(editingReservation)].sort(),
@@ -196,7 +196,7 @@ export function ReservationFormModal({
     if (title !== initialSnapshot.title) return true
     if (description !== initialSnapshot.description) return true
     if (gpuCount !== initialSnapshot.gpuCount) return true
-    // #8144: compare the sorted multi-type list. Order is intentionally
+    // Compare the sorted multi-type list. Order is intentionally
     // ignored because the form renders the same set regardless of
     // toggle order — only membership matters for dirty detection.
     const currentGpuPrefSorted = [...gpuPreferences].sort()
@@ -305,7 +305,7 @@ export function ReservationFormModal({
       // Backend requires RFC 3339; <input type="date"> only emits YYYY-MM-DD,
       // so normalize to midnight UTC before sending.
       const rfc3339StartDate = toRFC3339StartDate(startDate)
-      // #8144: canonical list of accepted GPU types. An empty list is
+      // Canonical list of accepted GPU types. An empty list is
       // "no preference" (server-side: any GPU acceptable). If the user
       // left every type toggled off but the cluster only has one type,
       // fall back to that single type so the back-compat path with
@@ -316,7 +316,7 @@ export function ReservationFormModal({
           : clusterGPUTypes.length === 1 && clusterGPUTypes[0]?.type
           ? [clusterGPUTypes[0].type]
           : []
-      // Legacy singular mirror — kept for pre-#8144 clients still
+      // Legacy singular mirror — kept for pre-multitype clients still
       // reading `gpu_type`. See CLAUDE.md back-compat rule.
       const primaryGpuType = gpuTypesList[0] || ''
       if (editingReservation) {
@@ -548,12 +548,11 @@ export function ReservationFormModal({
               className="w-full px-3 py-2 rounded-lg bg-secondary border border-border text-foreground placeholder:text-muted-foreground" />
           </div>
 
-          {/* GPU Type Selection — #8144: multi-select. Toggling a type
+          {/* GPU Type Selection — multi-select. Toggling a type
               adds or removes it from the accepted-types list. Selecting
               none means "no preference" (server accepts any type);
-              selecting two or more implements the feature requested by
-              @MikeSpreitzer in kubestellar/console#8144 so a developer
-              can reserve "any sufficiently powerful GPU". */}
+              selecting two or more lets a developer reserve "any
+              sufficiently powerful GPU". */}
           {clusterGPUTypes.length > 1 && (
             <div>
               <label className="block text-sm font-medium text-muted-foreground mb-2">{t('gpuReservations.form.fields.gpuTypeLabel')}</label>
@@ -587,11 +586,10 @@ export function ReservationFormModal({
                 })}
               </div>
               <div className="mt-1 text-xs text-muted-foreground">
-                {/* #8144: helper copy for the multi-type selector.
+                {/* Helper copy for the multi-type selector.
                     Kept as plain English for now — a follow-up PR
                     will add i18n keys to all locale bundles once the
-                    base feature lands and @MikeSpreitzer approves
-                    the UX. */}
+                    base feature lands and the UX is approved. */}
                 {gpuPreferences.length === 0
                   ? 'No type selected — any GPU will be accepted.'
                   : gpuPreferences.length === 1

--- a/web/src/components/gpu/ReservationFormModal.tsx
+++ b/web/src/components/gpu/ReservationFormModal.tsx
@@ -14,6 +14,7 @@ import {
   COMMON_RESOURCE_TYPES } from '../../hooks/useMCP'
 import type { GPUNode } from '../../hooks/useMCP'
 import type { GPUReservation, CreateGPUReservationInput, UpdateGPUReservationInput } from '../../hooks/useGPUReservations'
+import { normalizeGpuTypes } from '../../hooks/useGPUReservations'
 import { cn } from '../../lib/cn'
 
 // GPU resource keys used to identify GPU quotas
@@ -136,7 +137,15 @@ export function ReservationFormModal({
   const [title, setTitle] = useState(editingReservation?.title || '')
   const [description, setDescription] = useState(editingReservation?.description || '')
   const [gpuCount, setGpuCount] = useState(editingReservation ? String(editingReservation.gpu_count) : '')
-  const [gpuPreference, setGpuPreference] = useState(editingReservation?.gpu_type || '')
+  // #8144: multi-type preference. `gpuPreferences` holds the list of
+  // acceptable GPU types for this reservation — an empty array is
+  // "no preference" (any type is acceptable), a one-element array is
+  // the legacy single-type behaviour, and two or more entries implement
+  // the feature requested in kubestellar/console#8144 by
+  // @MikeSpreitzer. Seeded from both the legacy `gpu_type` string and
+  // the new `gpu_types` array via `normalizeGpuTypes` so edits of
+  // existing pre-migration reservations keep their type.
+  const [gpuPreferences, setGpuPreferences] = useState<string[]>(() => normalizeGpuTypes(editingReservation))
   const [startDate, setStartDate] = useState(
     toDateInputValue(editingReservation?.start_date) || prefillDate || new Date().toISOString().split('T')[0],
   )
@@ -159,7 +168,10 @@ export function ReservationFormModal({
       title: editingReservation?.title || '',
       description: editingReservation?.description || '',
       gpuCount: editingReservation ? String(editingReservation.gpu_count) : '',
-      gpuPreference: editingReservation?.gpu_type || '',
+      // #8144: snapshot the multi-type preference list so dirty
+      // detection can see a type-only edit. Sorted so order churn
+      // does not trip a false positive.
+      gpuPreferences: [...normalizeGpuTypes(editingReservation)].sort(),
       startDate: toDateInputValue(editingReservation?.start_date) || prefillDate || new Date().toISOString().split('T')[0],
       durationHours: editingReservation ? String(editingReservation.duration_hours) : '',
       notes: editingReservation?.notes || '' }),
@@ -184,7 +196,14 @@ export function ReservationFormModal({
     if (title !== initialSnapshot.title) return true
     if (description !== initialSnapshot.description) return true
     if (gpuCount !== initialSnapshot.gpuCount) return true
-    if (gpuPreference !== initialSnapshot.gpuPreference) return true
+    // #8144: compare the sorted multi-type list. Order is intentionally
+    // ignored because the form renders the same set regardless of
+    // toggle order — only membership matters for dirty detection.
+    const currentGpuPrefSorted = [...gpuPreferences].sort()
+    if (currentGpuPrefSorted.length !== initialSnapshot.gpuPreferences.length) return true
+    for (let i = 0; i < currentGpuPrefSorted.length; i++) {
+      if (currentGpuPrefSorted[i] !== initialSnapshot.gpuPreferences[i]) return true
+    }
     if (startDate !== initialSnapshot.startDate) return true
     if (durationHours !== initialSnapshot.durationHours) return true
     if (notes !== initialSnapshot.notes) return true
@@ -286,6 +305,20 @@ export function ReservationFormModal({
       // Backend requires RFC 3339; <input type="date"> only emits YYYY-MM-DD,
       // so normalize to midnight UTC before sending.
       const rfc3339StartDate = toRFC3339StartDate(startDate)
+      // #8144: canonical list of accepted GPU types. An empty list is
+      // "no preference" (server-side: any GPU acceptable). If the user
+      // left every type toggled off but the cluster only has one type,
+      // fall back to that single type so the back-compat path with
+      // older clusters stays unchanged.
+      const gpuTypesList =
+        gpuPreferences.length > 0
+          ? gpuPreferences
+          : clusterGPUTypes.length === 1 && clusterGPUTypes[0]?.type
+          ? [clusterGPUTypes[0].type]
+          : []
+      // Legacy singular mirror — kept for pre-#8144 clients still
+      // reading `gpu_type`. See CLAUDE.md back-compat rule.
+      const primaryGpuType = gpuTypesList[0] || ''
       if (editingReservation) {
         // Partial update
         const input: UpdateGPUReservationInput = {
@@ -294,7 +327,8 @@ export function ReservationFormModal({
           cluster,
           namespace,
           gpu_count: count,
-          gpu_type: gpuPreference || clusterGPUTypes[0]?.type || '',
+          gpu_type: primaryGpuType,
+          gpu_types: gpuTypesList,
           start_date: rfc3339StartDate,
           duration_hours: parseInt(durationHours) || DEFAULT_RESERVATION_DURATION_HOURS,
           notes,
@@ -310,7 +344,8 @@ export function ReservationFormModal({
           cluster,
           namespace,
           gpu_count: count,
-          gpu_type: gpuPreference || clusterGPUTypes[0]?.type || '',
+          gpu_type: primaryGpuType,
+          gpu_types: gpuTypesList,
           start_date: rfc3339StartDate,
           duration_hours: parseInt(durationHours) || DEFAULT_RESERVATION_DURATION_HOURS,
           notes,
@@ -432,7 +467,7 @@ export function ReservationFormModal({
           {/* Cluster (GPU-only, with counts) */}
           <div>
             <label className="block text-sm font-medium text-muted-foreground mb-1">{t('gpuReservations.form.fields.clusterLabel')}</label>
-            <select value={cluster} onChange={e => { setCluster(e.target.value); setNamespace(''); setIsNewNamespace(false); setGpuPreference('') }}
+            <select value={cluster} onChange={e => { setCluster(e.target.value); setNamespace(''); setIsNewNamespace(false); setGpuPreferences([]) }}
               disabled={!!editingReservation}
               className="w-full px-3 py-2 rounded-lg bg-secondary border border-border text-foreground disabled:opacity-50">
               <option value="">{t('gpuReservations.form.fields.selectCluster')}</option>
@@ -513,25 +548,55 @@ export function ReservationFormModal({
               className="w-full px-3 py-2 rounded-lg bg-secondary border border-border text-foreground placeholder:text-muted-foreground" />
           </div>
 
-          {/* GPU Type Selection (only when cluster has multiple types) */}
+          {/* GPU Type Selection — #8144: multi-select. Toggling a type
+              adds or removes it from the accepted-types list. Selecting
+              none means "no preference" (server accepts any type);
+              selecting two or more implements the feature requested by
+              @MikeSpreitzer in kubestellar/console#8144 so a developer
+              can reserve "any sufficiently powerful GPU". */}
           {clusterGPUTypes.length > 1 && (
             <div>
               <label className="block text-sm font-medium text-muted-foreground mb-2">{t('gpuReservations.form.fields.gpuTypeLabel')}</label>
               <div className="flex flex-wrap gap-2">
-                {clusterGPUTypes.map(gt => (
-                  <button key={gt.type} type="button"
-                    onClick={() => setGpuPreference(gt.type)}
-                    className={cn(
-                      'flex items-center gap-2 px-3 py-1.5 rounded-lg border text-sm transition-colors',
-                      gpuPreference === gt.type
-                        ? 'border-purple-500 bg-purple-500/10 text-purple-400'
-                        : 'border-border bg-secondary text-muted-foreground hover:text-foreground'
-                    )}>
-                    <Zap className="w-3.5 h-3.5" />
-                    {gt.type}
-                    <span className="text-xs opacity-70">{t('gpuReservations.form.fields.gpuTypeAvailability', { available: gt.available, total: gt.total })}</span>
-                  </button>
-                ))}
+                {clusterGPUTypes.map(gt => {
+                  const isSelected = gpuPreferences.includes(gt.type)
+                  return (
+                    <button
+                      key={gt.type}
+                      type="button"
+                      aria-pressed={isSelected}
+                      onClick={() => {
+                        setGpuPreferences(prev =>
+                          prev.includes(gt.type)
+                            ? prev.filter(t => t !== gt.type)
+                            : [...prev, gt.type],
+                        )
+                      }}
+                      className={cn(
+                        'flex items-center gap-2 px-3 py-1.5 rounded-lg border text-sm transition-colors',
+                        isSelected
+                          ? 'border-purple-500 bg-purple-500/10 text-purple-400'
+                          : 'border-border bg-secondary text-muted-foreground hover:text-foreground',
+                      )}
+                    >
+                      <Zap className="w-3.5 h-3.5" />
+                      {gt.type}
+                      <span className="text-xs opacity-70">{t('gpuReservations.form.fields.gpuTypeAvailability', { available: gt.available, total: gt.total })}</span>
+                    </button>
+                  )
+                })}
+              </div>
+              <div className="mt-1 text-xs text-muted-foreground">
+                {/* #8144: helper copy for the multi-type selector.
+                    Kept as plain English for now — a follow-up PR
+                    will add i18n keys to all locale bundles once the
+                    base feature lands and @MikeSpreitzer approves
+                    the UX. */}
+                {gpuPreferences.length === 0
+                  ? 'No type selected — any GPU will be accepted.'
+                  : gpuPreferences.length === 1
+                  ? '1 type accepted'
+                  : `${gpuPreferences.length} types accepted`}
               </div>
             </div>
           )}

--- a/web/src/hooks/__tests__/useGPUReservations.test.ts
+++ b/web/src/hooks/__tests__/useGPUReservations.test.ts
@@ -331,10 +331,10 @@ describe('useGPUReservations', () => {
   })
 })
 
-// #8144: multi-type GPU reservations. These tests pin the front-end
+// Multi-type GPU reservations. These tests pin the front-end
 // reconciliation helper used everywhere the UI needs to know the
 // canonical list of accepted GPU types for a reservation.
-describe('normalizeGpuTypes (#8144)', () => {
+describe('normalizeGpuTypes (gpu-multitype)', () => {
   it('returns the multi-type list when gpu_types is populated', () => {
     const r = { gpu_type: 'NVIDIA A100', gpu_types: ['NVIDIA A100', 'NVIDIA H100'] }
     expect(normalizeGpuTypes(r)).toEqual(['NVIDIA A100', 'NVIDIA H100'])

--- a/web/src/hooks/__tests__/useGPUReservations.test.ts
+++ b/web/src/hooks/__tests__/useGPUReservations.test.ts
@@ -29,7 +29,7 @@ vi.mock('../useBackendHealth', () => ({
   isInClusterMode: vi.fn(() => false),
 }))
 
-import { useGPUReservations } from '../useGPUReservations'
+import { useGPUReservations, normalizeGpuTypes } from '../useGPUReservations'
 import type { GPUReservation, CreateGPUReservationInput } from '../useGPUReservations'
 
 // ============================================================================
@@ -328,5 +328,31 @@ describe('useGPUReservations', () => {
     mockGet.mockResolvedValue({ data: [] })
     await act(async () => { result.current.refetch() })
     await waitFor(() => expect(result.current.error).toBeNull())
+  })
+})
+
+// #8144: multi-type GPU reservations. These tests pin the front-end
+// reconciliation helper used everywhere the UI needs to know the
+// canonical list of accepted GPU types for a reservation.
+describe('normalizeGpuTypes (#8144)', () => {
+  it('returns the multi-type list when gpu_types is populated', () => {
+    const r = { gpu_type: 'NVIDIA A100', gpu_types: ['NVIDIA A100', 'NVIDIA H100'] }
+    expect(normalizeGpuTypes(r)).toEqual(['NVIDIA A100', 'NVIDIA H100'])
+  })
+
+  it('promotes legacy gpu_type to a one-element list when gpu_types is missing', () => {
+    const r = { gpu_type: 'NVIDIA A100', gpu_types: undefined }
+    expect(normalizeGpuTypes(r)).toEqual(['NVIDIA A100'])
+  })
+
+  it('returns an empty array when neither field is set', () => {
+    expect(normalizeGpuTypes({ gpu_type: '', gpu_types: undefined })).toEqual([])
+    expect(normalizeGpuTypes(null)).toEqual([])
+    expect(normalizeGpuTypes(undefined)).toEqual([])
+  })
+
+  it('deduplicates entries while preserving first-seen order', () => {
+    const r = { gpu_type: '', gpu_types: ['A100', '', 'A100', 'H100', 'A100'] }
+    expect(normalizeGpuTypes(r)).toEqual(['A100', 'H100'])
   })
 })

--- a/web/src/hooks/useGPUReservations.ts
+++ b/web/src/hooks/useGPUReservations.ts
@@ -16,7 +16,26 @@ export interface GPUReservation {
   cluster: string
   namespace: string
   gpu_count: number
+  /**
+   * Legacy single-type field kept for backwards compatibility with
+   * pre-#8144 reservations and external readers. New UI code should
+   * prefer `gpu_types`; the backend guarantees `gpu_type` always
+   * mirrors `gpu_types[0]` (or is empty when any type is acceptable).
+   */
   gpu_type: string
+  /**
+   * #8144: list of acceptable GPU types for this reservation. An empty
+   * list means "any GPU is acceptable"; a one-element list behaves
+   * like the legacy single-type reservation; two or more entries
+   * implement the multi-type-preference feature requested by
+   * @MikeSpreitzer in issue #8144.
+   *
+   * Optional on the wire for back-compat with any cached client that
+   * was populated before the column existed. Helpers in this module
+   * use `normalizeGpuTypes()` to reconcile the two fields into a
+   * single canonical array.
+   */
+  gpu_types?: string[]
   start_date: string
   duration_hours: number
   notes: string
@@ -27,13 +46,41 @@ export interface GPUReservation {
   updated_at?: string
 }
 
+/**
+ * Reconcile the legacy `gpu_type` and new `gpu_types` fields on a
+ * `GPUReservation` fetched from the API (#8144). Returns the canonical
+ * acceptable-types list: the `gpu_types` array when present and
+ * non-empty, otherwise a one-element list wrapping `gpu_type`, or an
+ * empty array when neither is set. Safe to call on partial objects.
+ */
+export function normalizeGpuTypes(r: Pick<GPUReservation, 'gpu_type' | 'gpu_types'> | null | undefined): string[] {
+  if (!r) return []
+  if (r.gpu_types && r.gpu_types.length > 0) {
+    // De-duplicate while preserving first-seen order so the "primary"
+    // type (index 0) stays stable across re-renders.
+    const seen = new Set<string>()
+    const out: string[] = []
+    for (const t of r.gpu_types) {
+      if (!t || seen.has(t)) continue
+      seen.add(t)
+      out.push(t)
+    }
+    return out
+  }
+  if (r.gpu_type) return [r.gpu_type]
+  return []
+}
+
 export interface CreateGPUReservationInput {
   title: string
   description?: string
   cluster: string
   namespace: string
   gpu_count: number
+  /** Legacy single-type; prefer `gpu_types` for new reservations. */
   gpu_type?: string
+  /** #8144: acceptable GPU types; empty/omitted means any type. */
+  gpu_types?: string[]
   start_date: string
   duration_hours?: number
   notes?: string
@@ -48,7 +95,10 @@ export interface UpdateGPUReservationInput {
   cluster?: string
   namespace?: string
   gpu_count?: number
+  /** Legacy single-type; prefer `gpu_types` for new reservations. */
   gpu_type?: string
+  /** #8144: acceptable GPU types; empty array explicitly clears. */
+  gpu_types?: string[]
   start_date?: string
   duration_hours?: number
   notes?: string
@@ -70,6 +120,7 @@ const DEMO_RESERVATIONS: GPUReservation[] = [
     namespace: 'ml-training',
     gpu_count: 8,
     gpu_type: 'NVIDIA A100',
+    gpu_types: ['NVIDIA A100'],
     start_date: new Date().toISOString().split('T')[0],
     duration_hours: 48,
     notes: 'Priority training run for Q1 release',
@@ -87,6 +138,9 @@ const DEMO_RESERVATIONS: GPUReservation[] = [
     namespace: 'benchmarks',
     gpu_count: 4,
     gpu_type: 'NVIDIA H100',
+    // #8144: demo data showing multi-type preference — this
+    // reservation accepts either H100 or A100 nodes.
+    gpu_types: ['NVIDIA H100', 'NVIDIA A100'],
     start_date: new Date(Date.now() + 86400000).toISOString().split('T')[0],
     duration_hours: 24,
     notes: '',
@@ -104,6 +158,7 @@ const DEMO_RESERVATIONS: GPUReservation[] = [
     namespace: 'ml-training',
     gpu_count: 16,
     gpu_type: 'NVIDIA A100',
+    gpu_types: ['NVIDIA A100'],
     start_date: new Date(Date.now() - 172800000).toISOString().split('T')[0],
     duration_hours: 72,
     notes: 'Completed successfully',

--- a/web/src/hooks/useGPUReservations.ts
+++ b/web/src/hooks/useGPUReservations.ts
@@ -18,17 +18,17 @@ export interface GPUReservation {
   gpu_count: number
   /**
    * Legacy single-type field kept for backwards compatibility with
-   * pre-#8144 reservations and external readers. New UI code should
+   * pre-multitype reservations and external readers. New UI code should
    * prefer `gpu_types`; the backend guarantees `gpu_type` always
    * mirrors `gpu_types[0]` (or is empty when any type is acceptable).
    */
   gpu_type: string
   /**
-   * #8144: list of acceptable GPU types for this reservation. An empty
+   * Multi-type: list of acceptable GPU types for this reservation. An empty
    * list means "any GPU is acceptable"; a one-element list behaves
    * like the legacy single-type reservation; two or more entries
    * implement the multi-type-preference feature requested by
-   * @MikeSpreitzer in issue #8144.
+   * @MikeSpreitzer.
    *
    * Optional on the wire for back-compat with any cached client that
    * was populated before the column existed. Helpers in this module
@@ -48,7 +48,7 @@ export interface GPUReservation {
 
 /**
  * Reconcile the legacy `gpu_type` and new `gpu_types` fields on a
- * `GPUReservation` fetched from the API (#8144). Returns the canonical
+ * `GPUReservation` fetched from the API (gpu-multitype). Returns the canonical
  * acceptable-types list: the `gpu_types` array when present and
  * non-empty, otherwise a one-element list wrapping `gpu_type`, or an
  * empty array when neither is set. Safe to call on partial objects.
@@ -79,7 +79,7 @@ export interface CreateGPUReservationInput {
   gpu_count: number
   /** Legacy single-type; prefer `gpu_types` for new reservations. */
   gpu_type?: string
-  /** #8144: acceptable GPU types; empty/omitted means any type. */
+  /** Multi-type: acceptable GPU types; empty/omitted means any type. */
   gpu_types?: string[]
   start_date: string
   duration_hours?: number
@@ -97,7 +97,7 @@ export interface UpdateGPUReservationInput {
   gpu_count?: number
   /** Legacy single-type; prefer `gpu_types` for new reservations. */
   gpu_type?: string
-  /** #8144: acceptable GPU types; empty array explicitly clears. */
+  /** Multi-type: acceptable GPU types; empty array explicitly clears. */
   gpu_types?: string[]
   start_date?: string
   duration_hours?: number
@@ -138,7 +138,7 @@ const DEMO_RESERVATIONS: GPUReservation[] = [
     namespace: 'benchmarks',
     gpu_count: 4,
     gpu_type: 'NVIDIA H100',
-    // #8144: demo data showing multi-type preference — this
+    // Multi-type demo data showing multi-type preference — this
     // reservation accepts either H100 or A100 nodes.
     gpu_types: ['NVIDIA H100', 'NVIDIA A100'],
     start_date: new Date(Date.now() + 86400000).toISOString().split('T')[0],


### PR DESCRIPTION
Fixes #8144

## Summary

@MikeSpreitzer filed #8144:

> As a developer of an inferencing platform, I need the ability to use real GPUs but can use any sufficiently powerful GPU. I do dev/test in a shared cluster with just a few GPU-bearing nodes of a few different types. The form for making a GPU reservation allows me to select one type of GPU, but I want to be able to select multiple types of GPU.

This PR adds multi-type GPU reservations end-to-end (model, SQLite schema, handler, form, list display, search) while keeping every pre-#8144 single-type reservation working unchanged.

## Schema change

`GPUReservation` gains a `GPUTypes []string` field alongside the existing `GPUType string`. The `gpu_reservations` table gets a new `gpu_types TEXT` column (JSON-encoded array) via an idempotent `ALTER TABLE` migration — the legacy `gpu_type` column is kept and now mirrors `gpu_types[0]` so pre-#8144 readers continue to see a meaningful value. An empty `gpu_types` means **"no preference"** (any GPU is acceptable), which is what the new `MatchesNodeGPUType` helper enforces: an empty list matches every node; a populated list requires a case-insensitive match against at least one entry.

`NormalizeGPUTypes` on the model is idempotent and handles every combination (legacy-only, multi-only, both, neither) — called on create, update, read, and in the handler before validation so the two fields can never drift out of sync.

## Frontend

- `ReservationFormModal.tsx`: the single-select button row for GPU types becomes a multi-select toggle list. Selecting zero means "any type"; selecting one behaves exactly like the legacy form; two or more implements the feature Mike asked for. `aria-pressed` is wired up for accessibility.
- `useGPUReservations.ts`: new `normalizeGpuTypes()` helper is the canonical reader used by the form, the list display (`GPUReservationsTab.tsx`), and search (`GPUReservations.tsx`). Demo data now includes one two-type reservation so the new badge is visible without a live cluster.
- Reservation list row shows a comma-joined list when multiple types are accepted.

The helper copy for the multi-select (e.g. "No type selected — any GPU will be accepted") is intentionally inline English in this PR; a follow-up will add i18n keys to all 10 locale bundles once the base feature ships and Mike signs off on the UX.

## Tests

- **pkg/models/models_test.go** — 5 new unit tests: legacy promotion, multi-type mirroring, dedup, empty-list any-type matching, two-type node matching, full JSON round-trip.
- **pkg/store/wave3_fixes_test.go** — 2 new SQLite round-trip tests: a `{A100, H100}` reservation must come back with both types, accept either, reject V100, and the legacy singular field must mirror the primary type. A second test pins the back-compat path for pre-migration rows.
- **web/src/hooks/__tests__/useGPUReservations.test.ts** — 4 new unit tests pinning `normalizeGpuTypes` (multi, legacy promotion, empty, dedup).

All 12 GPU/reservation tests pass locally; `go build ./... && go vet ./...` clean; `npm run build` clean; lint has no new warnings from touched files.

## Test plan

- [ ] `go test ./pkg/models/... ./pkg/store/... -run 'GPU|Reservation' -count=1` passes
- [ ] `npm run build` passes
- [ ] Create a new reservation selecting zero GPU types — gets stored as "any type acceptable"
- [ ] Create a reservation selecting two types (A100 + H100) — list row shows `NVIDIA A100, NVIDIA H100`
- [ ] Edit an existing pre-migration reservation — the single selected type is preserved
- [ ] Search for "H100" surfaces a multi-type reservation that lists H100 as one of several accepted types
- [ ] @MikeSpreitzer approves the UX before merge

Filed by: @MikeSpreitzer (KubeStellar project lead)

---

**Please do not merge without Mike's review** — he filed the issue and should see the form flow before we ship.