### PR TITLE
🌐 i18n: extract hardcoded user-facing strings (#8149)

### DIFF
--- a/web/src/components/cards/drasi/DrasiReactiveGraph.tsx
+++ b/web/src/components/cards/drasi/DrasiReactiveGraph.tsx
@@ -16,6 +16,7 @@ import {
   Database, Globe, Search, Radio,
   TrendingDown, TrendingUp, Maximize2, Pin, Square, X, Settings,
 } from 'lucide-react'
+import { useTranslation } from 'react-i18next'
 import { useCardDemoState, useReportCardDataState } from '../CardDataContext'
 import { useDrasiResources } from '../../../hooks/useDrasiResources'
 
@@ -584,6 +585,7 @@ function SourceConfigModal({
   onSave: (config: SourceConfig) => void
   onClose: () => void
 }) {
+  const { t } = useTranslation()
   const [name, setName] = useState(source.name)
   const [kind, setKind] = useState<SourceKind>(source.kind)
   const titleId = `drasi-source-config-title-${source.id}`
@@ -625,8 +627,8 @@ function SourceConfigModal({
         </div>
       </div>
       <div className="flex justify-end gap-2 mt-4">
-        <button type="button" onClick={onClose} className="px-3 py-1.5 text-xs rounded bg-slate-800 hover:bg-slate-700 text-slate-300 border border-slate-700">Cancel</button>
-        <button type="button" onClick={() => { onSave({ name, kind }); onClose() }} className="px-3 py-1.5 text-xs rounded bg-cyan-600 hover:bg-cyan-500 text-white">Save</button>
+        <button type="button" onClick={onClose} className="px-3 py-1.5 text-xs rounded bg-slate-800 hover:bg-slate-700 text-slate-300 border border-slate-700">{t('actions.cancel')}</button>
+        <button type="button" onClick={() => { onSave({ name, kind }); onClose() }} className="px-3 py-1.5 text-xs rounded bg-cyan-600 hover:bg-cyan-500 text-white">{t('actions.save')}</button>
       </div>
     </ModalShell>
   )
@@ -641,6 +643,7 @@ function QueryConfigModal({
   onSave: (config: QueryConfig) => void
   onClose: () => void
 }) {
+  const { t } = useTranslation()
   const [name, setName] = useState(query.name)
   const [language, setLanguage] = useState(query.language)
   const [queryText, setQueryText] = useState(query.queryText || '')
@@ -693,8 +696,8 @@ function QueryConfigModal({
         </div>
       </div>
       <div className="flex justify-end gap-2 mt-4">
-        <button type="button" onClick={onClose} className="px-3 py-1.5 text-xs rounded bg-slate-800 hover:bg-slate-700 text-slate-300 border border-slate-700">Cancel</button>
-        <button type="button" onClick={() => { onSave({ name, language, queryText }); onClose() }} className="px-3 py-1.5 text-xs rounded bg-cyan-600 hover:bg-cyan-500 text-white">Save</button>
+        <button type="button" onClick={onClose} className="px-3 py-1.5 text-xs rounded bg-slate-800 hover:bg-slate-700 text-slate-300 border border-slate-700">{t('actions.cancel')}</button>
+        <button type="button" onClick={() => { onSave({ name, language, queryText }); onClose() }} className="px-3 py-1.5 text-xs rounded bg-cyan-600 hover:bg-cyan-500 text-white">{t('actions.save')}</button>
       </div>
     </ModalShell>
   )

--- a/web/src/components/compute/Compute.tsx
+++ b/web/src/components/compute/Compute.tsx
@@ -204,7 +204,7 @@ export function Compute() {
           aria-controls="cluster-comparison-list"
         >
           <GitCompare className="w-4 h-4" />
-          <span>Cluster Comparison</span>
+          <span>{t('compute.clusterComparison')}</span>
           {showClusterList ? <ChevronDown className="w-4 h-4" /> : <ChevronRight className="w-4 h-4" />}
         </button>
         {selectedForComparison.length > 0 && (

--- a/web/src/components/rbac/CanIChecker.tsx
+++ b/web/src/components/rbac/CanIChecker.tsx
@@ -368,7 +368,7 @@ export function CanIChecker() {
               className="w-full p-2 rounded-lg bg-secondary border border-border text-foreground focus:outline-none focus:ring-2 focus:ring-blue-500 appearance-none pr-8"
               data-testid="can-i-user-groups"
             >
-              <option value="">Select common groups...</option>
+              <option value="">{t('rbac.selectCommonGroups')}</option>
               {COMMON_USER_GROUPS.filter(g => !selectedUserGroups.includes(g.value)).map((group) => (
                 <option key={group.value} value={group.value}>{group.label}</option>
               ))}

--- a/web/src/locales/en/common.json
+++ b/web/src/locales/en/common.json
@@ -1478,7 +1478,11 @@
     "binding": "Binding",
     "clusterRole": "Cluster Role",
     "roleBinding": "Role Binding",
-    "clusterRoleBinding": "Cluster Role Binding"
+    "clusterRoleBinding": "Cluster Role Binding",
+    "selectCommonGroups": "Select common groups..."
+  },
+  "compute": {
+    "clusterComparison": "Cluster Comparison"
   },
   "missionChat": {
     "saveTranscript": "Save transcript",


### PR DESCRIPTION
## Summary

Extracts 5 hardcoded user-facing strings flagged by Auto-QA into i18n translations.

- `CanIChecker.tsx`: "Select common groups..." dropdown placeholder → `rbac.selectCommonGroups`
- `Compute.tsx`: "Cluster Comparison" section header → `compute.clusterComparison`
- `DrasiReactiveGraph.tsx`: Cancel/Save buttons in Source and Query config modals → existing `actions.cancel` / `actions.save`

Reuses existing common-namespace keys for the Drasi buttons. Adds two new keys (rbac + compute) in `common.json`.

## Excluded (Auto-QA false positives)

- `*.stories.tsx` / `*.test.tsx` — Storybook and tests don't need i18n
- `StatusBadge` `color=` props and variant demos
- `HardwareHealthCard.tsx` "Mellanox" — vendor brand name, not translatable

Fixes #8149

## Test plan

- [x] `npm run build` passes
- [x] `npm run lint` passes (no new issues in modified files)
- [ ] Manual: open RBAC checker, compute page, and Drasi reactive graph modals — verify strings render correctly