### PR TITLE
🐛 fix: preserve GPU inventory across partial fetch failures (#8080, #8081)

### DIFF
--- a/web/src/components/cards/GPUUsageTrend.tsx
+++ b/web/src/components/cards/GPUUsageTrend.tsx
@@ -6,6 +6,8 @@ import { useClusters } from '../../hooks/useMCP'
 import { useCachedGPUNodes } from '../../hooks/useCachedData'
 import { useGlobalFilters } from '../../hooks/useGlobalFilters'
 import { useMetricsHistoryReadOnly } from '../../hooks/useMetricsHistory'
+import { gpuNodeCache as mcpGPUNodeCache } from '../../hooks/mcp/compute'
+import type { GPUNode } from '../../hooks/mcp/types'
 import { Skeleton, SkeletonStats } from '../ui/Skeleton'
 import { useCardLoadingState } from './CardDataContext'
 import { useTranslation } from 'react-i18next'
@@ -110,6 +112,21 @@ export function GPUUsageTrend() {
     return () => clearInterval(intervalId)
   }, [])
 
+  // Fall back to the most recent snapshot's GPU nodes if the live list is
+  // empty. Snapshots use `gpuTotal`; we remap to `gpuCount` so downstream
+  // aggregation (currentTotals, filteredNodes) stays unchanged.
+  //
+  // Three-tier fallback (see issues 8080 and 8081):
+  //   1. Live cached GPU nodes from useCachedGPUNodes (SWR)
+  //   2. Most recent non-empty snapshot from useMetricsHistoryReadOnly
+  //   3. The MCP compute.ts localStorage cache (`kubestellar-gpu-cache`)
+  //      which persists across page reloads and is populated by the
+  //      useGPUNodes/mcp hook path
+  //
+  // Tier 3 specifically handles the fresh-page-load + flapping-cluster
+  // case: metrics history hasn't captured a snapshot yet and the live
+  // fetch returned empty, but a previous session's GPU cache is still
+  // sitting in localStorage.
   const effectiveGPUNodes: EffectiveGPUNode[] = useMemo(() => {
     if (gpuNodes.length > 0) {
       return gpuNodes.map(n => ({
@@ -154,6 +171,19 @@ export function GPUUsageTrend() {
         gpuType: g.gpuType,
         gpuCount: g.gpuTotal,
         gpuAllocated: g.gpuAllocated }))
+    }
+    // Tier 3: MCP module-level GPU cache (persisted to localStorage by
+    // web/src/hooks/mcp/compute.ts). This is last-resort when both the
+    // live fetch and metrics history are empty — typically on a fresh
+    // page load against a cluster whose GPU fetch is currently flapping.
+    const mcpCachedNodes: GPUNode[] = mcpGPUNodeCache?.nodes || []
+    if (mcpCachedNodes.length > 0) {
+      return mcpCachedNodes.map(n => ({
+        name: n.name,
+        cluster: n.cluster,
+        gpuType: n.gpuType,
+        gpuCount: n.gpuCount,
+        gpuAllocated: n.gpuAllocated }))
     }
     return []
   }, [gpuNodes, metricsHistory, hookLoading, isFailed, consecutiveFailures, stalenessTick])

--- a/web/src/components/cards/__tests__/GPUUsageTrend.test.tsx
+++ b/web/src/components/cards/__tests__/GPUUsageTrend.test.tsx
@@ -64,6 +64,13 @@ vi.mock('../../../hooks/useMetricsHistory', () => ({
   useMetricsHistoryReadOnly: () => ({ history: mockUseMetricsHistory().history }),
 }))
 
+// Mock the MCP compute module so GPUUsageTrend's tertiary fallback
+// (issues #8080, #8081) sees an empty persisted GPU cache in tests
+// and does not rely on real localStorage side effects.
+vi.mock('../../../hooks/mcp/compute', () => ({
+  gpuNodeCache: { nodes: [], lastUpdated: null, isLoading: false, isRefreshing: false, error: null, consecutiveFailures: 0, lastRefresh: null },
+}))
+
 import { GPUUsageTrend } from '../GPUUsageTrend'
 
 describe('GPUUsageTrend', () => {

--- a/web/src/hooks/__tests__/useMetricsHistory.test.ts
+++ b/web/src/hooks/__tests__/useMetricsHistory.test.ts
@@ -817,7 +817,11 @@ describe('useMetricsHistory', () => {
     })
 
     it('eventually accepts empty GPU state after the carry-forward window expires', async () => {
-      // MAX_GPU_CARRY_FORWARD = 2 — after two empty captures, the third must reflect the empty state.
+      // MAX_GPU_CARRY_FORWARD = 6 (widened in #8080/#8081 to absorb longer
+      // slow-rolling flaps on GPU-bearing clusters). After six consecutive
+      // empty captures the seventh must reflect the empty state so truly
+      // removed GPUs eventually propagate into history.
+      const CARRY_FORWARD_WINDOW = 6
       mockClusters.push({ name: 'c1', cpuCores: 4, cpuUsageCores: 2, memoryGB: 8, memoryUsageGB: 4, nodeCount: 1, healthy: true })
       mockGPUNodes.push({ name: 'gpu-node-1', cluster: 'c1', gpuType: 'NVIDIA H100', gpuAllocated: 3, gpuCount: 8 })
 
@@ -830,13 +834,14 @@ describe('useMetricsHistory', () => {
       // Now transition to empty GPU state
       mockGPUNodes.length = 0
 
-      // Two empty captures — both should be carried-forward
-      act(() => { result.current.captureNow() })
-      act(() => { result.current.captureNow() })
+      // CARRY_FORWARD_WINDOW empty captures — all should be carried-forward
+      for (let i = 0; i < CARRY_FORWARD_WINDOW; i += 1) {
+        act(() => { result.current.captureNow() })
+      }
       const afterCarryForward = result.current.history[result.current.history.length - 1]
       expect(afterCarryForward.gpuNodes).toHaveLength(1)
 
-      // Third consecutive empty capture — must accept the empty state
+      // One more consecutive empty capture — must accept the empty state
       act(() => { result.current.captureNow() })
       const afterWindow = result.current.history[result.current.history.length - 1]
       expect(afterWindow.gpuNodes).toHaveLength(0)

--- a/web/src/hooks/useCachedData.ts
+++ b/web/src/hooks/useCachedData.ts
@@ -155,6 +155,20 @@ async function fetchClusters(): Promise<string[]> {
     .map(c => c.name)
 }
 
+/**
+ * Options for fetchFromAllClusters that alter empty-result semantics.
+ */
+interface FetchFromAllClustersOptions {
+  /**
+   * When true, throw if any cluster fetch failed AND the accumulated result
+   * is empty. Intended for endpoints where an empty result from a partially
+   * failed fan-out is ambiguous (we cannot tell "truly zero" from "the one
+   * cluster with data errored"). Forces callers into the error path so
+   * existing cached data is preserved. See issues #8080, #8081 (GPU flap).
+   */
+  throwIfPartialFailureEmpty?: boolean
+}
+
 // Fetch data from all clusters in parallel and merge results
 // Throws if ALL cluster fetches fail (so callers can fall back to agent)
 async function fetchFromAllClusters<T>(
@@ -162,7 +176,8 @@ async function fetchFromAllClusters<T>(
   resultKey: string,
   params?: Record<string, string | number | undefined>,
   addClusterField = true,
-  onProgress?: (partial: T[]) => void
+  onProgress?: (partial: T[]) => void,
+  options?: FetchFromAllClustersOptions
 ): Promise<T[]> {
   const clusters = await fetchClusters()
   if (clusters.length === 0) {
@@ -202,6 +217,23 @@ async function fetchFromAllClusters<T>(
     throw new Error('All cluster fetches failed')
   }
 
+  // Opt-in partial-failure protection: if any cluster failed and the
+  // accumulated result is empty, the empty result is ambiguous — we cannot
+  // distinguish "no data anywhere" from "the one cluster with data errored".
+  // Callers that set throwIfPartialFailureEmpty=true prefer preserving stale
+  // cache via the error path over silently overwriting it with []. See
+  // issues #8080, #8081 where a transient fetch failure for the vllm-d
+  // cluster caused GPU Usage Trend to flap to "No GPU Nodes".
+  if (
+    options?.throwIfPartialFailureEmpty &&
+    accumulated.length === 0 &&
+    failedCount > 0
+  ) {
+    throw new Error(
+      `Partial cluster failure yielded empty result (${failedCount}/${clusters.length} clusters errored) — preserving existing cache`,
+    )
+  }
+
   return accumulated
 }
 
@@ -214,27 +246,46 @@ async function fetchViaSSE<T>(
   endpoint: string,
   resultKey: string,
   params?: Record<string, string | number | undefined>,
-  onProgress?: (partial: T[]) => void
+  onProgress?: (partial: T[]) => void,
+  options?: FetchFromAllClustersOptions
 ): Promise<T[]> {
   const token = getToken()
   // SSE only available with real backend token
   if (!token || token === 'demo-token' || isBackendUnavailable()) {
-    return fetchFromAllClusters<T>(endpoint, resultKey, params, true, onProgress)
+    return fetchFromAllClusters<T>(endpoint, resultKey, params, true, onProgress, options)
   }
 
   try {
     const accumulated: T[] = []
-    return await fetchSSE<T>({
+    // Track backend-emitted cluster_error events so we can detect the
+    // "partial failure yielding empty result" case below (issues #8080,
+    // #8081). Without this, a cluster_error on the only GPU-bearing
+    // cluster would silently resolve to [] and flap the UI.
+    let clusterErrorCount = 0
+    const result = await fetchSSE<T>({
       url: `/api/mcp/${endpoint}/stream`,
       params,
       itemsKey: resultKey,
       onClusterData: (_cluster, items) => {
         accumulated.push(...items)
         onProgress?.([...accumulated])
+      },
+      onClusterError: () => {
+        clusterErrorCount += 1
       } })
+    if (
+      options?.throwIfPartialFailureEmpty &&
+      result.length === 0 &&
+      clusterErrorCount > 0
+    ) {
+      throw new Error(
+        `Partial SSE failure yielded empty result (${clusterErrorCount} cluster_error events) — preserving existing cache`,
+      )
+    }
+    return result
   } catch {
     // SSE failed — fall back to per-cluster REST
-    return fetchFromAllClusters<T>(endpoint, resultKey, params, true, onProgress)
+    return fetchFromAllClusters<T>(endpoint, resultKey, params, true, onProgress, options)
   }
 }
 
@@ -2111,6 +2162,15 @@ export function useCachedGPUNodes(
   const { category = 'gpu' } = options || {}
   const key = `gpuNodes:${cluster || 'all'}`
 
+  // Partial-failure protection (#8080, #8081): on the multi-cluster fan-out
+  // path, a transient error for the ONE cluster that actually has GPUs
+  // combined with empty results from the others is indistinguishable from
+  // "no GPUs anywhere". Rather than silently overwrite the cache with [],
+  // throw so useCache takes the error path and preserves the previous
+  // inventory. This is opt-in and GPU-specific — other endpoints (pods,
+  // deployments, etc.) still return partial data on partial failure.
+  const gpuFetchOptions: FetchFromAllClustersOptions = { throwIfPartialFailureEmpty: true }
+
   const result = useCache({
     key,
     category,
@@ -2121,10 +2181,17 @@ export function useCachedGPUNodes(
         const data = await fetchAPI<{ nodes: GPUNode[] }>('gpu-nodes', { cluster })
         return (data.nodes || []).map(n => ({ ...n, cluster }))
       }
-      return await fetchFromAllClusters<GPUNode>('gpu-nodes', 'nodes')
+      return await fetchFromAllClusters<GPUNode>(
+        'gpu-nodes',
+        'nodes',
+        undefined,
+        true,
+        undefined,
+        gpuFetchOptions,
+      )
     },
     progressiveFetcher: cluster ? undefined : async (onProgress) => {
-      return await fetchViaSSE<GPUNode>('gpu-nodes', 'nodes', {}, onProgress)
+      return await fetchViaSSE<GPUNode>('gpu-nodes', 'nodes', {}, onProgress, gpuFetchOptions)
     } })
 
   return {

--- a/web/src/hooks/useMetricsHistory.ts
+++ b/web/src/hooks/useMetricsHistory.ts
@@ -15,9 +15,16 @@ const MAX_INCREASING_RESTART_PODS = 10
  * from the last known non-empty gpuNodes list. Prevents a transient GPU fetch
  * glitch (SSE race, partial cluster reachability) from being persisted as a
  * zero-total snapshot in GPU Inventory History while still allowing truly
- * removed GPUs to reflect after ~2 intervals.
+ * removed GPUs to reflect after roughly this-many capture intervals.
+ *
+ * At the default 10-minute capture interval, 6 consecutive carries covers
+ * ~1 hour of flapping — long enough to absorb a slow-rolling cluster outage
+ * on the GPU-bearing cluster (see issues #8080, #8081 from Mike Spreitzer's
+ * vllm-d cluster where partial fetch failures flapped inventory for multiple
+ * polling windows). Previously this was 2, which only covered ~20 minutes
+ * and still let zero bars leak into the persisted history.
  */
-const MAX_GPU_CARRY_FORWARD = 2
+const MAX_GPU_CARRY_FORWARD = 6
 
 // Singleton state - shared across all hook instances
 let snapshots: MetricsSnapshot[] = []

--- a/web/src/lib/sseClient.ts
+++ b/web/src/lib/sseClient.ts
@@ -22,6 +22,12 @@ export interface SSEFetchOptions<T> {
   params?: Record<string, string | number | undefined>
   /** Called when each cluster's data arrives */
   onClusterData: (clusterName: string, items: T[]) => void
+  /**
+   * Called when the backend emits a `cluster_error` event for a cluster that
+   * failed mid-stream. Used so callers can distinguish "no data for this
+   * cluster" from "the cluster fetch errored" (see issues #8080, #8081).
+   */
+  onClusterError?: (clusterName: string, error: string) => void
   /** Called when stream completes */
   onDone?: (summary: Record<string, unknown>) => void
   /** Key in each event's JSON that holds the items array */
@@ -48,6 +54,7 @@ const inflightRequests = new Map<string, Promise<unknown[]>>()
 /** Subscribers waiting for callbacks on an in-flight SSE stream */
 interface SSESubscriber<T = unknown> {
   onClusterData: (clusterName: string, items: T[]) => void
+  onClusterError?: (clusterName: string, error: string) => void
   onDone?: (summary: Record<string, unknown>) => void
 }
 const inflightSubscribers = new Map<string, SSESubscriber[]>()
@@ -109,7 +116,7 @@ function parseSSEChunk(
  * (up to SSE_MAX_RECONNECT_ATTEMPTS attempts) before rejecting.
  */
 export function fetchSSE<T>(options: SSEFetchOptions<T>): Promise<T[]> {
-  const { url, params, onClusterData, onDone, itemsKey, signal } = options
+  const { url, params, onClusterData, onClusterError, onDone, itemsKey, signal } = options
 
   const searchParams = new URLSearchParams()
   if (params) {
@@ -152,7 +159,10 @@ export function fetchSSE<T>(options: SSEFetchOptions<T>): Promise<T[]> {
   const inflight = inflightRequests.get(cacheKey)
   if (inflight) {
     const subscribers = inflightSubscribers.get(cacheKey) || []
-    subscribers.push({ onClusterData: onClusterData as SSESubscriber['onClusterData'], onDone })
+    subscribers.push({
+      onClusterData: onClusterData as SSESubscriber['onClusterData'],
+      onClusterError: onClusterError as SSESubscriber['onClusterError'],
+      onDone })
     inflightSubscribers.set(cacheKey, subscribers)
     return inflight as Promise<T[]>
   }
@@ -282,6 +292,25 @@ export function fetchSSE<T>(options: SSEFetchOptions<T>): Promise<T[]> {
                 }
               } catch (e) {
                 console.error('[SSE] Failed to parse cluster_data:', e)
+              }
+            } else if (eventType === 'cluster_error') {
+              // Backend emits cluster_error when a single cluster fetch
+              // failed mid-stream (see pkg/api/handlers/sse.go). Surface this
+              // to callers so they can distinguish "zero results" from
+              // "some clusters errored". Without this, a transient failure
+              // on the only GPU-bearing cluster looks like "no GPUs" to the
+              // client and flaps the inventory (issues #8080, #8081).
+              try {
+                const parsed = JSON.parse(data) as Record<string, unknown>
+                const clusterName = (parsed.cluster as string) || 'unknown'
+                const errorMessage = (parsed.error as string) || 'unknown error'
+                onClusterError?.(clusterName, errorMessage)
+                const subs = inflightSubscribers.get(cacheKey) || []
+                for (const sub of subs) {
+                  try { sub.onClusterError?.(clusterName, errorMessage) } catch { /* subscriber error */ }
+                }
+              } catch (e) {
+                console.error('[SSE] Failed to parse cluster_error:', e)
               }
             } else if (eventType === 'done') {
               receivedDone = true


### PR DESCRIPTION
## Summary

Mike Spreitzer reported two bugs on his vllm-d cluster:
- #8081 — GPU Usage Trend card shows "No GPU Nodes" and "refresh failed" even though `kubectl get node -l nvidia.com/gpu.present=true` returns 7 H100/L40/IL nodes.
- #8080 — GPU Inventory History flaps between the real inventory and zero.

Root cause: the multi-cluster GPU fan-out treats a partial failure (the one GPU-bearing cluster errored while the others returned empty successfully) as a legitimate "no GPUs anywhere" result and overwrites the cache with `[]`.

Fixes #8080, Fixes #8081

## What changed

- **sseClient**: track backend-emitted `cluster_error` events and expose them via a new `onClusterError` callback. Previously these events were silently swallowed.
- **useCachedData**: add opt-in `throwIfPartialFailureEmpty` to `fetchFromAllClusters` and `fetchViaSSE`. When any cluster fetch errored AND the accumulated result is empty, throw so `useCache` takes the error path and preserves the existing cached data.
- **useCachedGPUNodes**: opt in to the new partial-failure protection. Other endpoints (pods, deployments, etc.) still return partial data on partial failure — only GPU data is ambiguous enough to need this.
- **useMetricsHistory**: widen `MAX_GPU_CARRY_FORWARD` from 2 to 6. At the default 10-minute capture interval this covers ~1 hour of slow-rolling flap on the GPU-bearing cluster before zero bars can be persisted to the history.
- **GPUUsageTrend**: add a third-tier fallback to the MCP `gpuNodeCache` localStorage. This handles the fresh-load-plus-flap case where neither the live fetch nor the metrics history has data yet but a previous session's GPU inventory is still sitting in localStorage.
- Tests updated for the widened carry-forward window and new dependency.

All named constants, no magic numbers. Existing contract for other fan-out endpoints is unchanged.

## Test plan

- [x] `npm run build` passes
- [x] `npm run lint` introduces zero new errors in touched files
- [x] `npx vitest run` — 151 tests pass in touched files, 391 tests pass in useCachedData/sseClient suites
- [ ] Mike Spreitzer re-verifies on his vllm-d cluster

🤖 Generated with [Claude Code](https://claude.com/claude-code)