### PR TITLE
🐛 fix: mission-sidebar empty-state gate normalizes whitespace

### DIFF
--- a/web/src/components/layout/mission-sidebar/MissionSidebar.tsx
+++ b/web/src/components/layout/mission-sidebar/MissionSidebar.tsx
@@ -897,7 +897,7 @@ export function MissionSidebar() {
        * `missionSearchQuery` is excluded so a failed search still surfaces the
        * "no search results" branch below instead of this full-panel empty state.
        */}
-      {listTotalMissions === 0 && !missionSearchQuery && !activeMission ? (
+      {listTotalMissions === 0 && !missionSearchQuery.trim() && !activeMission ? (
         <div className="flex-1 flex flex-col items-center justify-center p-8 text-center">
           <Sparkles className="w-10 h-10 text-purple-400/60 mb-4" />
           <p className="text-muted-foreground">{t('missionSidebar.noActiveMissions')}</p>


### PR DESCRIPTION
## Summary

Copilot review follow-up for #8146. The new empty-state gate uses `!missionSearchQuery`, but `matchesSearch` normalizes the query with `.trim()`. A whitespace-only query (e.g. `'   '`) is truthy, so the full-panel empty state is suppressed — but `matchesSearch` treats the query as empty, and the list falls through with nothing rendered. That reproduces the exact blank panel that #8146 was meant to fix.

## Fix

One-line change: `!missionSearchQuery` → `!missionSearchQuery.trim()` so the gate agrees with `matchesSearch` on what counts as an empty search.

Fixes #8152

## Test plan

- [x] `npm run build` passes locally
- [x] Lint errors unchanged vs main (pre-existing, unrelated)
- [ ] Type a single space into the mission search box with no missions present — full-panel empty-state CTA still renders