### PR TITLE
feat(drasi): real integration — REST adapters + SSE stream + gear CRUD

### DIFF
--- a/pkg/api/handlers/drasi_proxy.go
+++ b/pkg/api/handlers/drasi_proxy.go
@@ -1,0 +1,321 @@
+// Package handlers implements the HTTP API for the KubeStellar Console.
+//
+// drasi_proxy.go: a generic reverse proxy for the Drasi REST API.
+//
+// Drasi ships in three deployment modes (drasi-lib embedded library, drasi-server
+// standalone REST process, drasi-platform Kubernetes operator). The console's
+// `/drasi` dashboard talks to all three through this single proxy:
+//
+//   - drasi-server (mode 1+2): requested via ?target=server&url=<full-URL>.
+//     The proxy forwards the request to the URL the user configured (typically
+//     localhost:8090 or a Docker host). drasi-server already sends permissive
+//     CORS, so the frontend could call it directly — but routing it through this
+//     proxy keeps the client code path identical for both modes and lets us add
+//     auth/audit later without touching the frontend.
+//
+//   - drasi-platform (mode 3): requested via ?target=platform&cluster=<ctx>.
+//     drasi-platform exposes its REST API on the in-cluster `drasi-api` Service
+//     in `drasi-system`. The proxy uses the Kubernetes API server's built-in
+//     Service proxy to reach it without requiring the user to set up Ingress or
+//     a manual port-forward.
+//
+// The handler streams the upstream response directly so SSE and chunked
+// responses work — drasi-server's `/api/v1/instances/.../events/stream`
+// endpoints are SSE.
+package handlers
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/gofiber/fiber/v2"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+)
+
+// Constants used by the Drasi proxy.
+const (
+	// drasiPlatformNamespace is the namespace where drasi-platform installs
+	// its `drasi-api` Service. Hardcoded to match `drasi init` defaults.
+	drasiPlatformNamespace = "drasi-system"
+	// drasiPlatformServiceName is the Service name exposed by drasi-platform.
+	drasiPlatformServiceName = "drasi-api"
+	// drasiPlatformServicePort is the named port on the drasi-api Service.
+	drasiPlatformServicePort = "8080"
+	// drasiProxyMaxBodyBytes caps request body size to prevent unbounded
+	// uploads when creating Drasi resources via the gear modals.
+	drasiProxyMaxBodyBytes = 1 << 20 // 1 MiB
+	// drasiProxyDefaultTimeout caps non-streaming proxy calls.
+	drasiProxyDefaultTimeout = 30 * time.Second
+)
+
+// drasiHopByHopHeaders are removed from both directions per RFC 7230 §6.1.
+var drasiHopByHopHeaders = map[string]bool{
+	"connection":          true,
+	"keep-alive":          true,
+	"proxy-authenticate":  true,
+	"proxy-authorization": true,
+	"te":                  true,
+	"trailers":            true,
+	"transfer-encoding":   true,
+	"upgrade":             true,
+}
+
+// ProxyDrasi is the handler registered at `/api/drasi/proxy/*`.
+// It accepts ANY method (GET/POST/PUT/DELETE/PATCH) and forwards to the
+// upstream Drasi REST API, streaming the response.
+//
+// Query parameters:
+//
+//	target  — "server" (drasi-server REST) or "platform" (drasi-platform via K8s Service proxy)
+//	url     — (target=server) full upstream URL, e.g. "http://localhost:8090"
+//	cluster — (target=platform) kubeconfig context name
+//
+// The wildcard segment after `/api/drasi/proxy/` is the upstream path:
+//
+//	/api/drasi/proxy/api/v1/sources?target=server&url=http://localhost:8090
+//	→ GET http://localhost:8090/api/v1/sources
+//
+//	/api/drasi/proxy/v1/continuousQueries?target=platform&cluster=prow
+//	→ K8s Service proxy on `prow` cluster: drasi-system/drasi-api:8080/v1/continuousQueries
+func (h *MCPHandlers) ProxyDrasi(c *fiber.Ctx) error {
+	if err := requireViewerOrAbove(c, h.store); err != nil {
+		return err
+	}
+
+	target := c.Query("target")
+	if target != "server" && target != "platform" {
+		return fiber.NewError(fiber.StatusBadRequest, "target must be 'server' or 'platform'")
+	}
+
+	// The fiber wildcard captures everything after `/api/drasi/proxy/`.
+	upstreamPath := c.Params("*")
+	if upstreamPath == "" {
+		upstreamPath = "/"
+	} else if !strings.HasPrefix(upstreamPath, "/") {
+		upstreamPath = "/" + upstreamPath
+	}
+
+	// Drop the proxy-control query params before forwarding the rest to the upstream.
+	upstreamQuery := stripDrasiControlQuery(c.Request().URI().QueryString())
+
+	switch target {
+	case "server":
+		return h.proxyDrasiServer(c, upstreamPath, upstreamQuery)
+	case "platform":
+		return h.proxyDrasiPlatform(c, upstreamPath, upstreamQuery)
+	}
+	return fiber.NewError(fiber.StatusBadRequest, "unreachable")
+}
+
+// proxyDrasiServer forwards to a drasi-server REST URL configured via ?url=…
+func (h *MCPHandlers) proxyDrasiServer(c *fiber.Ctx, upstreamPath string, upstreamQuery []byte) error {
+	rawURL := c.Query("url")
+	if rawURL == "" {
+		return fiber.NewError(fiber.StatusBadRequest, "target=server requires url query param")
+	}
+	base, err := url.Parse(rawURL)
+	if err != nil || base.Scheme == "" || base.Host == "" {
+		return fiber.NewError(fiber.StatusBadRequest, "invalid url query param")
+	}
+	// Reject URL schemes other than http/https to prevent SSRF surprises.
+	if base.Scheme != "http" && base.Scheme != "https" {
+		return fiber.NewError(fiber.StatusBadRequest, "url must be http or https")
+	}
+	full := *base
+	full.Path = strings.TrimRight(base.Path, "/") + upstreamPath
+	if len(upstreamQuery) > 0 {
+		full.RawQuery = string(upstreamQuery)
+	}
+
+	req, err := buildUpstreamRequest(c, full.String())
+	if err != nil {
+		return fiber.NewError(fiber.StatusBadRequest, err.Error())
+	}
+	return streamUpstream(c, http.DefaultClient, req)
+}
+
+// proxyDrasiPlatform forwards to drasi-platform's `drasi-api` Service via
+// the Kubernetes API server's built-in Service proxy. Requires a kubeconfig
+// context name in ?cluster=…
+func (h *MCPHandlers) proxyDrasiPlatform(c *fiber.Ctx, upstreamPath string, upstreamQuery []byte) error {
+	cluster := c.Query("cluster")
+	if cluster == "" {
+		return fiber.NewError(fiber.StatusBadRequest, "target=platform requires cluster query param")
+	}
+	if h.k8sClient == nil {
+		return fiber.NewError(fiber.StatusServiceUnavailable, "no kubernetes client available")
+	}
+
+	cfg, err := h.k8sClient.GetRestConfig(cluster)
+	if err != nil {
+		return fiber.NewError(fiber.StatusBadRequest, fmt.Sprintf("unknown cluster %q: %v", cluster, err))
+	}
+
+	// Build the Kubernetes Service proxy URL and use the cluster's
+	// authenticated REST client to call it. The Service proxy URL pattern is:
+	//   /api/v1/namespaces/{ns}/services/{name}:{port}/proxy/{path}
+	clientset, err := kubernetes.NewForConfig(cfg)
+	if err != nil {
+		return fiber.NewError(fiber.StatusInternalServerError, fmt.Sprintf("kubeclient init failed: %v", err))
+	}
+
+	rawQuery := ""
+	if len(upstreamQuery) > 0 {
+		rawQuery = string(upstreamQuery)
+	}
+
+	// Use the typed Services client's proxy verb. This honors RBAC + auth
+	// configured on the kubeconfig, and the API server tunnels the request
+	// to the Pod backing the Service.
+	httpReq := clientset.CoreV1().
+		Services(drasiPlatformNamespace).
+		ProxyGet(
+			"http",
+			drasiPlatformServiceName,
+			drasiPlatformServicePort,
+			strings.TrimPrefix(upstreamPath, "/"),
+			parseQueryParams(rawQuery),
+		)
+
+	// drasi-platform only exposes synchronous JSON for sources/queries/reactions.
+	// SSE streaming is via a separate reaction component (out of scope for the
+	// platform proxy in this PR — Phase 3 will add an SSE reaction install path).
+	ctx, cancel := context.WithTimeout(c.UserContext(), drasiProxyDefaultTimeout)
+	defer cancel()
+
+	body, err := httpReq.DoRaw(ctx)
+	if err != nil {
+		// Surface API server errors with their original status when possible.
+		var status int
+		if statusErr := upstreamStatus(err); statusErr != 0 {
+			status = statusErr
+		} else {
+			status = fiber.StatusBadGateway
+		}
+		return fiber.NewError(status, fmt.Sprintf("drasi-platform proxy: %v", err))
+	}
+	c.Set("content-type", "application/json")
+	return c.Send(body)
+}
+
+// buildUpstreamRequest constructs a *http.Request from the incoming Fiber
+// request, forwarding method + body + headers minus hop-by-hop and host.
+func buildUpstreamRequest(c *fiber.Ctx, fullURL string) (*http.Request, error) {
+	method := c.Method()
+	bodyBytes := c.Body()
+	if len(bodyBytes) > drasiProxyMaxBodyBytes {
+		return nil, errors.New("request body exceeds 1 MiB limit")
+	}
+	var body io.Reader
+	if len(bodyBytes) > 0 {
+		body = strings.NewReader(string(bodyBytes))
+	}
+	req, err := http.NewRequestWithContext(c.UserContext(), method, fullURL, body)
+	if err != nil {
+		return nil, err
+	}
+	c.Request().Header.VisitAll(func(k, v []byte) {
+		key := strings.ToLower(string(k))
+		if drasiHopByHopHeaders[key] {
+			return
+		}
+		if key == "host" || key == "cookie" || key == "authorization" {
+			return // never forward console auth to upstream
+		}
+		req.Header.Add(string(k), string(v))
+	})
+	if req.Header.Get("Accept") == "" {
+		req.Header.Set("Accept", "application/json,text/event-stream")
+	}
+	return req, nil
+}
+
+// streamUpstream issues the upstream request and streams the response body
+// back to the Fiber client without buffering — required for SSE.
+func streamUpstream(c *fiber.Ctx, client *http.Client, req *http.Request) error {
+	// SSE responses can be very long-lived. Don't impose a request-level
+	// deadline; rely on the client closing the connection.
+	resp, err := client.Do(req)
+	if err != nil {
+		return fiber.NewError(fiber.StatusBadGateway, fmt.Sprintf("upstream request failed: %v", err))
+	}
+	defer resp.Body.Close()
+
+	for k, vs := range resp.Header {
+		key := strings.ToLower(k)
+		if drasiHopByHopHeaders[key] {
+			continue
+		}
+		for _, v := range vs {
+			c.Append(k, v)
+		}
+	}
+	c.Status(resp.StatusCode)
+
+	// Use SendStream to forward the body without loading it into memory.
+	// Fiber will set Transfer-Encoding: chunked automatically when the body
+	// has no known length, which is correct for SSE.
+	return c.SendStream(resp.Body)
+}
+
+// stripDrasiControlQuery removes the proxy's own control params (target, url,
+// cluster) from the query string before forwarding. Other params pass through.
+func stripDrasiControlQuery(raw []byte) []byte {
+	if len(raw) == 0 {
+		return raw
+	}
+	values, err := url.ParseQuery(string(raw))
+	if err != nil {
+		return raw
+	}
+	values.Del("target")
+	values.Del("url")
+	values.Del("cluster")
+	encoded := values.Encode()
+	return []byte(encoded)
+}
+
+// parseQueryParams turns a raw query string into the map the typed Services
+// client's ProxyGet expects.
+func parseQueryParams(raw string) map[string]string {
+	out := map[string]string{}
+	if raw == "" {
+		return out
+	}
+	values, err := url.ParseQuery(raw)
+	if err != nil {
+		return out
+	}
+	for k, vs := range values {
+		if len(vs) > 0 {
+			out[k] = vs[0]
+		}
+	}
+	return out
+}
+
+// upstreamStatus extracts the HTTP status code from a Kubernetes API error
+// (k8s.io/apimachinery/pkg/api/errors). Returns 0 if the error is not a
+// recognized API status error.
+func upstreamStatus(err error) int {
+	type statusGetter interface {
+		Status() int
+	}
+	if sg, ok := err.(statusGetter); ok {
+		return sg.Status()
+	}
+	return 0
+}
+
+// Compile-time check that ProxyDrasi has the right signature for the route
+// table. (kubernetes.NewForConfig+rest are imported here to ensure the
+// k8s client compiles even when not using dynamic clients elsewhere.)
+var _ = func() *rest.Config { return nil }
+var _ = func() (kubernetes.Interface, error) { return nil, nil }

--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -958,6 +958,10 @@ func (s *Server) setupRoutes() {
 	api.Get("/mcp/wasmcloud/hosts", mcpHandlers.GetWasmCloudHosts)
 	api.Get("/mcp/wasmcloud/actors", mcpHandlers.GetWasmCloudActors)
 	api.Get("/mcp/custom-resources", mcpHandlers.GetCustomResources)
+	// Drasi reverse proxy — forwards to drasi-server (mode 1+2) or drasi-platform
+	// (mode 3) so the `/drasi` dashboard speaks the same client code to either.
+	// See pkg/api/handlers/drasi_proxy.go for the protocol detection contract.
+	api.All("/drasi/proxy/*", mcpHandlers.ProxyDrasi)
 	api.Get("/mcp/replicasets", mcpHandlers.GetReplicaSets)
 	api.Get("/mcp/statefulsets", mcpHandlers.GetStatefulSets)
 	api.Get("/mcp/daemonsets", mcpHandlers.GetDaemonSets)

--- a/web/src/components/cards/drasi/DrasiReactiveGraph.tsx
+++ b/web/src/components/cards/drasi/DrasiReactiveGraph.tsx
@@ -18,6 +18,11 @@ import {
 } from 'lucide-react'
 import { useCardDemoState, useReportCardDataState } from '../CardDataContext'
 import { useDrasiResources } from '../../../hooks/useDrasiResources'
+import { useDrasiQueryStream } from '../../../hooks/useDrasiQueryStream'
+
+/** drasi-server URL configured for the live integration. Empty when running
+ *  against drasi-platform or in demo mode. */
+const DRASI_SERVER_URL = import.meta.env.VITE_DRASI_SERVER_URL as string | undefined
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -74,13 +79,11 @@ interface DrasiReaction {
   queryIds: string[]
 }
 
-interface LiveResultRow {
-  changePercent: number
-  name: string
-  previousClose: number
-  price: number
-  symbol: string
-}
+// Drasi continuous-query result rows are arbitrary key/value maps — each
+// query returns its own schema. The card's results table renders columns
+// dynamically from the first row's keys instead of hardcoding the stock
+// schema we use for demo mode.
+type LiveResultRow = Record<string, string | number | boolean | null>
 
 interface DrasiPipelineData {
   sources: DrasiSource[]
@@ -133,7 +136,10 @@ function rectsEqual(a: MeasuredRects, b: MeasuredRects): boolean {
 // Demo data
 // ---------------------------------------------------------------------------
 
-const DEMO_STOCKS: Omit<LiveResultRow, 'changePercent' | 'price'>[] = [
+// Stock-ticker shape used by the demo result rows. Real Drasi queries return
+// arbitrary schemas — the table renders columns dynamically from each row's
+// keys. This array is just the seed values for the demo schema.
+const DEMO_STOCKS: Array<{ name: string; previousClose: number; symbol: string }> = [
   { name: 'UnitedHealth Group', previousClose: 536.88, symbol: 'UNH' },
   { name: 'Visa Inc.', previousClose: 272.19, symbol: 'V' },
   { name: 'Chevron', previousClose: 144.75, symbol: 'CVX' },
@@ -170,7 +176,7 @@ function generateDemoData(): DrasiPipelineData {
     const price = parseFloat((stock.previousClose * (1 + changePercent / 100)).toFixed(2))
     return { ...stock, changePercent, price }
   })
-  liveResults.sort((a, b) => a.changePercent - b.changePercent)
+  liveResults.sort((a, b) => Number(a.changePercent ?? 0) - Number(b.changePercent ?? 0))
   return { sources, queries, reactions, liveResults }
 }
 
@@ -410,10 +416,35 @@ function FlowLine({ d, dashed, active = true, delay = 0, lineKey = '' }: FlowLin
 // Results table
 // ---------------------------------------------------------------------------
 
+/** Format a single cell value for the dynamic results table. */
+function formatCell(value: LiveResultRow[string]): React.ReactNode {
+  if (value === null || value === undefined) return ''
+  if (typeof value === 'number') {
+    // Render numbers with up to 2 decimals; ints render plain.
+    return Number.isInteger(value) ? String(value) : value.toFixed(2)
+  }
+  if (typeof value === 'boolean') return value ? 'true' : 'false'
+  return String(value)
+}
+
+/** Pick a percentage-like column for the leading ▲/▼ trend indicator, if any. */
+function findTrendColumn(columns: string[]): string | null {
+  return (
+    columns.find(c => c === 'changePercent' || c === 'change_percent' || c === 'change') ||
+    null
+  )
+}
+
 function ResultsTable({ results, isDemo }: { results: LiveResultRow[]; isDemo: boolean }) {
   const displayResults = results.slice(0, MAX_RESULT_ROWS)
   const totalRows = results.length
   const label = isDemo ? 'Demo Results' : 'Live Results'
+
+  // Derive columns from the first row's keys so the table works for any
+  // continuous-query schema, not just the stock-ticker shape we use in demo.
+  const columns: string[] = displayResults[0] ? Object.keys(displayResults[0]) : []
+  const trendCol = findTrendColumn(columns)
+
   return (
     <div className="mt-2 bg-slate-950/80 border border-slate-700/40 rounded overflow-hidden">
       <div className="px-2 py-1 border-b border-slate-700/50 flex items-center justify-between">
@@ -431,26 +462,56 @@ function ResultsTable({ results, isDemo }: { results: LiveResultRow[]; isDemo: b
         <table className="w-full text-[10px]">
           <thead>
             <tr className="border-b border-slate-800/50">
-              <th className="text-left px-2 py-1 text-muted-foreground font-medium">changePercent</th>
-              <th className="text-left px-2 py-1 text-muted-foreground font-medium">name</th>
-              <th className="text-right px-2 py-1 text-muted-foreground font-medium">previousClose</th>
-              <th className="text-right px-2 py-1 text-muted-foreground font-medium">price</th>
-              <th className="text-right px-2 py-1 text-muted-foreground font-medium">symbol</th>
+              {columns.map(col => (
+                <th
+                  key={col}
+                  className={`px-2 py-1 text-muted-foreground font-medium ${
+                    typeof displayResults[0]?.[col] === 'number' ? 'text-right' : 'text-left'
+                  }`}
+                >
+                  {col}
+                </th>
+              ))}
             </tr>
           </thead>
           <tbody>
-            {displayResults.map(row => (
-              <tr key={row.symbol} className="border-b border-slate-800/30 hover:bg-slate-800/30">
-                <td className="px-2 py-1">
-                  <span className={`font-mono flex items-center gap-1 ${row.changePercent < 0 ? 'text-red-400' : 'text-green-400'}`}>
-                    {row.changePercent < 0 ? <TrendingDown className="w-2.5 h-2.5" /> : <TrendingUp className="w-2.5 h-2.5" />}
-                    {row.changePercent.toFixed(2)}
-                  </span>
-                </td>
-                <td className="px-2 py-1 text-white truncate max-w-[120px]">{row.name}</td>
-                <td className="px-2 py-1 text-muted-foreground font-mono text-right">{row.previousClose.toFixed(2)}</td>
-                <td className="px-2 py-1 text-white font-mono text-right">{row.price.toFixed(2)}</td>
-                <td className="px-2 py-1 text-cyan-400 font-mono text-right">{row.symbol}</td>
+            {displayResults.map((row, idx) => (
+              <tr key={idx} className="border-b border-slate-800/30 hover:bg-slate-800/30">
+                {columns.map(col => {
+                  const value = row[col]
+                  const isTrend = col === trendCol
+                  const isNumeric = typeof value === 'number'
+                  if (isTrend && isNumeric) {
+                    return (
+                      <td key={col} className="px-2 py-1">
+                        <span
+                          className={`font-mono flex items-center gap-1 ${
+                            value < 0 ? 'text-red-400' : 'text-green-400'
+                          }`}
+                        >
+                          {value < 0 ? (
+                            <TrendingDown className="w-2.5 h-2.5" />
+                          ) : (
+                            <TrendingUp className="w-2.5 h-2.5" />
+                          )}
+                          {value.toFixed(2)}
+                        </span>
+                      </td>
+                    )
+                  }
+                  return (
+                    <td
+                      key={col}
+                      className={`px-2 py-1 ${
+                        isNumeric
+                          ? 'text-white font-mono text-right'
+                          : 'text-white truncate max-w-[160px]'
+                      }`}
+                    >
+                      {formatCell(value)}
+                    </td>
+                  )
+                })}
               </tr>
             ))}
           </tbody>
@@ -738,9 +799,31 @@ export function DrasiReactiveGraph() {
   }, [isDemoMode, liveData])
 
   const isLive = !!liveData && !isDemoMode
+
+  // Subscribe to the selected query's SSE event stream when running against
+  // a real drasi-server. Falls through to the demo regen / static results
+  // path when in demo mode or running against drasi-platform.
+  const streamSubscription = useDrasiQueryStream({
+    mode: isLive ? (liveData?.mode ?? null) : null,
+    drasiServerUrl: DRASI_SERVER_URL,
+    instanceId: liveData?.instanceId ?? null,
+    queryId: isLive ? selectedQueryId : null,
+    paused: stoppedNodeIds.has(selectedQueryId),
+  })
+
   const pipelineData = useMemo<DrasiPipelineData>(
-    () => (isLive && liveData ? liveData : demoData),
-    [isLive, liveData, demoData],
+    () => {
+      if (isLive && liveData) {
+        // Prefer the rolling streamed results when the SSE subscription is
+        // live; otherwise use the snapshot the REST adapter returned.
+        const liveResults = streamSubscription.results.length > 0
+          ? streamSubscription.results
+          : liveData.liveResults
+        return { ...liveData, liveResults }
+      }
+      return demoData
+    },
+    [isLive, liveData, demoData, streamSubscription.results],
   )
   const { sources, queries, reactions, liveResults } = pipelineData
 
@@ -769,19 +852,71 @@ export function DrasiReactiveGraph() {
     setSelectedQueryId(queryId)
   }, [])
 
-  const saveSourceConfig = useCallback((sourceId: string, config: SourceConfig) => {
+  const { refetch: refetchDrasi } = useDrasiResources()
+
+  const saveSourceConfig = useCallback(async (sourceId: string, config: SourceConfig) => {
+    if (isLive && liveData) {
+      // Real Drasi mutation. drasi-server uses POST /api/v1/sources, drasi-platform
+      // uses PUT /v1/sources/{id} — both routed through the backend proxy.
+      const proxyBase = '/api/drasi/proxy'
+      const targetParams =
+        liveData.mode === 'server' && DRASI_SERVER_URL
+          ? `target=server&url=${encodeURIComponent(DRASI_SERVER_URL)}`
+          : `target=platform&cluster=${encodeURIComponent(import.meta.env.VITE_DRASI_PLATFORM_CLUSTER || '')}`
+      const path =
+        liveData.mode === 'server'
+          ? `/api/v1/sources/${encodeURIComponent(sourceId)}`
+          : `/v1/sources/${encodeURIComponent(sourceId)}`
+      try {
+        await fetch(`${proxyBase}${path}?${targetParams}`, {
+          method: 'PUT',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify({ id: config.name, spec: { kind: config.kind } }),
+        })
+        refetchDrasi()
+      } catch {
+        // Surface via the existing error path on the next poll.
+      }
+      return
+    }
+    // Demo mode — local-state only.
     setDemoData(prev => ({
       ...prev,
       sources: prev.sources.map(s => s.id === sourceId ? { ...s, name: config.name, kind: config.kind } : s),
     }))
-  }, [])
+  }, [isLive, liveData, refetchDrasi])
 
-  const saveQueryConfig = useCallback((queryId: string, config: QueryConfig) => {
+  const saveQueryConfig = useCallback(async (queryId: string, config: QueryConfig) => {
+    if (isLive && liveData) {
+      const proxyBase = '/api/drasi/proxy'
+      const targetParams =
+        liveData.mode === 'server' && DRASI_SERVER_URL
+          ? `target=server&url=${encodeURIComponent(DRASI_SERVER_URL)}`
+          : `target=platform&cluster=${encodeURIComponent(import.meta.env.VITE_DRASI_PLATFORM_CLUSTER || '')}`
+      const path =
+        liveData.mode === 'server'
+          ? `/api/v1/queries/${encodeURIComponent(queryId)}`
+          : `/v1/continuousQueries/${encodeURIComponent(queryId)}`
+      try {
+        await fetch(`${proxyBase}${path}?${targetParams}`, {
+          method: 'PUT',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify({
+            id: config.name,
+            spec: { mode: config.language.replace(/ QUERY$/, ''), query: config.queryText },
+          }),
+        })
+        refetchDrasi()
+      } catch {
+        // Surface via the existing error path on the next poll.
+      }
+      return
+    }
     setDemoData(prev => ({
       ...prev,
       queries: prev.queries.map(q => q.id === queryId ? { ...q, name: config.name, language: config.language, queryText: config.queryText } : q),
     }))
-  }, [])
+  }, [isLive, liveData, refetchDrasi])
 
   // --- Dynamic line positioning --------------------------------------------
 

--- a/web/src/hooks/useDrasiQueryStream.ts
+++ b/web/src/hooks/useDrasiQueryStream.ts
@@ -1,0 +1,179 @@
+/**
+ * Hook for subscribing to a Drasi continuous-query event stream over SSE.
+ *
+ * drasi-server exposes a built-in SSE endpoint per query at:
+ *   GET /api/v1/instances/{instanceId}/queries/{queryId}/events/stream
+ *
+ * The events arrive as `data: <json>` lines. There are two event flavors:
+ *
+ *   1. Lifecycle events (status changes):
+ *      { componentId, componentType, status, timestamp, message }
+ *
+ *   2. Result-delta events (the interesting ones for the results table):
+ *      { added: [...], updated: [...], deleted: [...], timestamp }
+ *
+ * This hook maintains a rolling result set, applying deltas as they arrive,
+ * and exposes it as a flat array of rows for the card's results table.
+ *
+ * For drasi-platform mode (mode 3) the built-in stream is not exposed —
+ * platform deployments require a Result reaction. That path will be added
+ * in a follow-up; for now `mode === 'platform'` skips the subscription and
+ * returns an empty result set.
+ */
+import { useState, useEffect, useRef } from 'react'
+
+/** A single row in a result set — Drasi rows are arbitrary key/value maps. */
+type LiveResultRow = Record<string, string | number | boolean | null>
+
+/** Identifying key for a row inside a result set. Drasi delta events do not
+ *  guarantee a stable key, so we hash the row to a string. */
+function rowKey(row: LiveResultRow): string {
+  return JSON.stringify(row)
+}
+
+/** Update-event element from drasi-server's events/stream. Either a
+ *  `{before, after}` envelope or a bare row. */
+interface UpdateEnvelope {
+  before?: LiveResultRow
+  after: LiveResultRow
+}
+
+/** A delta event payload from drasi-server's events/stream. */
+interface QueryDeltaEvent {
+  added?: LiveResultRow[]
+  updated?: Array<UpdateEnvelope | LiveResultRow>
+  deleted?: LiveResultRow[]
+  timestamp?: string
+  /** Lifecycle events have these instead. */
+  componentId?: string
+  componentType?: string
+  status?: string
+  message?: string
+}
+
+/** Type guard: distinguish a `{before, after}` envelope from a bare row. */
+function isUpdateEnvelope(v: UpdateEnvelope | LiveResultRow): v is UpdateEnvelope {
+  if (!v || typeof v !== 'object') return false
+  const after = (v as UpdateEnvelope).after
+  return after !== undefined && after !== null && typeof after === 'object'
+}
+
+/** Maximum rows held in the rolling result set; oldest dropped if exceeded. */
+const MAX_STREAMED_ROWS = 200
+
+export interface UseDrasiQueryStreamResult {
+  results: LiveResultRow[]
+  connected: boolean
+  error: string | null
+}
+
+interface Args {
+  /** Connection mode — 'server' enables streaming, 'platform' is a no-op. */
+  mode: 'server' | 'platform' | null
+  /** drasi-server URL (mode 1+2). Required when mode === 'server'. */
+  drasiServerUrl?: string
+  /** drasi-server instance UUID (mode 1+2). Required when mode === 'server'. */
+  instanceId?: string | null
+  /** Continuous query ID. Streaming pauses when this is null. */
+  queryId: string | null
+  /** When true, do not subscribe — used to honor the per-node Stop control. */
+  paused?: boolean
+}
+
+/**
+ * Subscribe to a continuous query's event stream and return a rolling
+ * materialized result set. The connection is reopened whenever queryId,
+ * mode, or instanceId changes; it is closed on unmount.
+ */
+export function useDrasiQueryStream(args: Args): UseDrasiQueryStreamResult {
+  const { mode, drasiServerUrl, instanceId, queryId, paused = false } = args
+  const [results, setResults] = useState<LiveResultRow[]>([])
+  const [connected, setConnected] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const sourceRef = useRef<EventSource | null>(null)
+
+  useEffect(() => {
+    // Reset whenever we switch queries.
+    setResults([])
+    setConnected(false)
+    setError(null)
+
+    if (paused || mode !== 'server' || !drasiServerUrl || !instanceId || !queryId) {
+      return
+    }
+
+    // Subscribe via the backend reverse proxy so the browser doesn't need
+    // direct access to the drasi-server URL. The proxy streams the SSE body
+    // through unchanged.
+    const upstreamPath =
+      `/api/v1/instances/${encodeURIComponent(instanceId)}` +
+      `/queries/${encodeURIComponent(queryId)}/events/stream`
+    const proxyUrl =
+      `/api/drasi/proxy${upstreamPath}` +
+      `?target=server&url=${encodeURIComponent(drasiServerUrl)}`
+
+    const es = new EventSource(proxyUrl)
+    sourceRef.current = es
+
+    es.onopen = () => {
+      setConnected(true)
+      setError(null)
+    }
+
+    es.onmessage = (ev) => {
+      let payload: QueryDeltaEvent
+      try {
+        payload = JSON.parse(ev.data)
+      } catch {
+        return // Non-JSON heartbeats etc.
+      }
+
+      // Lifecycle events update connection state but don't touch the table.
+      if (payload.componentType === 'Query' && payload.status) {
+        if (payload.status === 'Stopped' || payload.status === 'Failed') {
+          setConnected(false)
+        }
+        return
+      }
+
+      // Apply the delta to the rolling result set.
+      setResults(prev => {
+        const next = new Map<string, LiveResultRow>(
+          prev.map(r => [rowKey(r), r]),
+        )
+        for (const r of payload.added || []) {
+          next.set(rowKey(r), r)
+        }
+        for (const u of payload.updated || []) {
+          const after: LiveResultRow = isUpdateEnvelope(u) ? u.after : u
+          // For updates, drasi sends the new state — we just upsert by the
+          // hashed key. Without a stable identifier it's not possible to
+          // remove the old row, so updates accumulate as inserts.
+          next.set(rowKey(after), after)
+        }
+        for (const r of payload.deleted || []) {
+          next.delete(rowKey(r))
+        }
+        const arr = Array.from(next.values())
+        if (arr.length > MAX_STREAMED_ROWS) {
+          return arr.slice(arr.length - MAX_STREAMED_ROWS)
+        }
+        return arr
+      })
+    }
+
+    es.onerror = () => {
+      setConnected(false)
+      setError('SSE connection error')
+      // EventSource auto-reconnects, so no manual retry loop needed.
+    }
+
+    return () => {
+      es.close()
+      sourceRef.current = null
+      setConnected(false)
+    }
+  }, [mode, drasiServerUrl, instanceId, queryId, paused])
+
+  return { results, connected, error }
+}

--- a/web/src/hooks/useDrasiResources.ts
+++ b/web/src/hooks/useDrasiResources.ts
@@ -1,15 +1,34 @@
 /**
  * Hook for fetching Drasi resources (Sources, Continuous Queries, Reactions)
- * from the Drasi API.
+ * from a real Drasi installation. Falls back to null so the card uses demo
+ * data when nothing is reachable.
  *
- * Drasi exposes a REST API on its management endpoint:
- *   GET /v1/sources
- *   GET /v1/continuousQueries
- *   GET /v1/reactions
- *   GET /v1/continuousQueries/{id}/results  (for live result rows)
+ * Drasi ships in three deployment modes and the dashboard supports all three
+ * with the same code path:
  *
- * When the Drasi API is unavailable, returns null so the card falls back
- * to demo data.
+ *   1. drasi-lib  — Rust library embedded in another program. No wire protocol
+ *                   on its own; embedders expose it via the drasi-server REST
+ *                   API, so it is covered transitively by mode 2.
+ *   2. drasi-server — standalone REST server. Default port 8080. Routes are
+ *                     under `/api/v1/*` and responses use the
+ *                     `{success, data, error}` wrapper.
+ *   3. drasi-platform — Kubernetes operator. The `drasi-api` Service in
+ *                       `drasi-system` exposes a REST API at `/v1/*` (NOT
+ *                       `/api/v1/*` — different from drasi-server). Responses
+ *                       are raw arrays/objects, no wrapper. Has NO Kubernetes
+ *                       CRDs — the listing path is HTTP, not kubectl.
+ *
+ * Detection order:
+ *
+ *   a. `VITE_DRASI_SERVER_URL` env var → drasi-server adapter via the
+ *      backend proxy (`/api/drasi/proxy/...?target=server&url=...`).
+ *   b. Probe the configured cluster contexts for `drasi-api` in `drasi-system`
+ *      → drasi-platform adapter via
+ *      `/api/drasi/proxy/...?target=platform&cluster=<ctx>`.
+ *   c. Neither configured → return null, card uses demo data.
+ *
+ * Both adapters return the same normalized `DrasiResourceData` shape so
+ * `DrasiReactiveGraph.tsx` is oblivious to which mode is active.
  */
 import { useState, useEffect, useCallback, useRef } from 'react'
 
@@ -19,48 +38,60 @@ import { useState, useEffect, useCallback, useRef } from 'react'
 
 /** Polling interval for Drasi resource refresh */
 const DRASI_POLL_INTERVAL_MS = 10_000
-/** Default Drasi API base URL — override via VITE_DRASI_API_URL env var */
-const DRASI_API_BASE = import.meta.env.VITE_DRASI_API_URL as string | undefined
+/** Configured drasi-server URL (mode 1+2). Frontend env var. */
+const DRASI_SERVER_URL = import.meta.env.VITE_DRASI_SERVER_URL as string | undefined
+/** Configured drasi-platform cluster context (mode 3). Frontend env var. */
+const DRASI_PLATFORM_CLUSTER = import.meta.env.VITE_DRASI_PLATFORM_CLUSTER as string | undefined
+/** Maximum result rows pulled into the live results table per query. */
+const MAX_LIVE_RESULTS_PER_QUERY = 50
 
 // ---------------------------------------------------------------------------
-// Types (matching the card's expected shape)
+// Public types — matches the shapes the card already renders
 // ---------------------------------------------------------------------------
 
 type SourceKind = 'HTTP' | 'POSTGRES' | 'COSMOSDB' | 'GREMLIN' | 'SQL'
 type ReactionKind = 'SSE' | 'SIGNALR' | 'WEBHOOK' | 'KAFKA'
+// Status enum kept aligned with the card's internal type. Drasi `Stopped`
+// maps to `pending` since the card has no separate stopped-vs-paused visual
+// (the Stop button uses local UI state, not the backend status).
+type DrasiStatus = 'ready' | 'error' | 'pending'
 
 interface DrasiSource {
   id: string
   name: string
   kind: SourceKind
-  status: 'ready' | 'error' | 'pending'
+  status: DrasiStatus
 }
 
 interface DrasiQuery {
   id: string
   name: string
   language: string
-  status: 'ready' | 'error' | 'pending'
+  status: DrasiStatus
   sourceIds: string[]
+  /** Body of the query if available — used by the gear/configure modal. */
+  queryText?: string
 }
 
 interface DrasiReaction {
   id: string
   name: string
   kind: ReactionKind
-  status: 'ready' | 'error' | 'pending'
+  status: DrasiStatus
   queryIds: string[]
 }
 
-interface LiveResultRow {
-  changePercent: number
-  name: string
-  previousClose: number
-  price: number
-  symbol: string
-}
+/** A single row in a continuous-query result set. Drasi result rows are
+ *  arbitrary key/value maps, so we keep them dynamic. */
+type LiveResultRow = Record<string, string | number | boolean | null>
 
 export interface DrasiResourceData {
+  /** "server" | "platform" — set by the active adapter; informs the card's
+   *  mode indicator and which mutation endpoint the gear modals call. */
+  mode: 'server' | 'platform'
+  /** drasi-server's instance UUID (mode 2) — used to scope SSE stream URLs.
+   *  null in platform mode. */
+  instanceId: string | null
   sources: DrasiSource[]
   queries: DrasiQuery[]
   reactions: DrasiReaction[]
@@ -68,150 +99,285 @@ export interface DrasiResourceData {
 }
 
 // ---------------------------------------------------------------------------
-// API response types (raw Drasi API shapes)
+// Status normalization (shared by both adapters)
 // ---------------------------------------------------------------------------
 
-interface DrasiApiSource {
-  id?: string
-  metadata?: { name?: string }
-  spec?: { kind?: string; properties?: Record<string, unknown> }
-  status?: { available?: boolean; message?: string }
-}
-
-interface DrasiApiQuery {
-  id?: string
-  metadata?: { name?: string }
-  spec?: { mode?: string; query?: string; sources?: Array<{ name?: string; id?: string }> }
-  status?: { available?: boolean }
-}
-
-interface DrasiApiReaction {
-  id?: string
-  metadata?: { name?: string }
-  spec?: { kind?: string; queries?: Array<{ name?: string; id?: string }> }
-  status?: { available?: boolean }
-}
-
-// ---------------------------------------------------------------------------
-// Mappers
-// ---------------------------------------------------------------------------
-
-function mapStatus(available?: boolean): 'ready' | 'error' | 'pending' {
-  if (available === true) return 'ready'
-  if (available === false) return 'error'
+/** Map any backend status string into the card's 3-state enum. */
+function normalizeStatus(raw: unknown): DrasiStatus {
+  const s = String(raw || '').toLowerCase()
+  if (s === 'running' || s === 'available' || s === 'ready' || s === 'true') return 'ready'
+  if (s === 'starting' || s === 'pending' || s === 'creating' || s === 'updating') return 'pending'
+  if (s === 'stopped' || s === 'paused' || s === 'disabled') return 'pending'
+  if (s === 'error' || s === 'failed' || s === 'unhealthy' || s === 'false') return 'error'
   return 'pending'
 }
 
-function mapSourceKind(kind?: string): SourceKind {
-  const normalized = (kind || '').toUpperCase()
-  if (normalized.includes('HTTP')) return 'HTTP'
-  if (normalized.includes('POSTGRES') || normalized.includes('PG')) return 'POSTGRES'
-  if (normalized.includes('COSMOS')) return 'COSMOSDB'
-  if (normalized.includes('GREMLIN')) return 'GREMLIN'
-  if (normalized.includes('SQL')) return 'SQL'
+function mapSourceKind(raw: unknown): SourceKind {
+  const k = String(raw || '').toUpperCase()
+  if (k.includes('HTTP') || k.includes('REST')) return 'HTTP'
+  if (k.includes('POSTGRES') || k.includes('PG') || k.includes('MYSQL') || k.includes('DEBEZIUM')) return 'POSTGRES'
+  if (k.includes('COSMOS')) return 'COSMOSDB'
+  if (k.includes('GREMLIN')) return 'GREMLIN'
+  if (k.includes('SQL')) return 'SQL'
   return 'POSTGRES'
 }
 
-function mapReactionKind(kind?: string): ReactionKind {
-  const normalized = (kind || '').toUpperCase()
-  if (normalized.includes('SSE')) return 'SSE'
-  if (normalized.includes('SIGNAL')) return 'SIGNALR'
-  if (normalized.includes('WEBHOOK') || normalized.includes('HTTP')) return 'WEBHOOK'
-  if (normalized.includes('KAFKA')) return 'KAFKA'
+function mapReactionKind(raw: unknown): ReactionKind {
+  const k = String(raw || '').toUpperCase()
+  if (k.includes('SSE') || k === 'LOG' || k === 'DEBUG') return 'SSE'
+  if (k.includes('SIGNAL')) return 'SIGNALR'
+  if (k.includes('WEBHOOK') || k.includes('HTTP')) return 'WEBHOOK'
+  if (k.includes('KAFKA')) return 'KAFKA'
   return 'SSE'
+}
+
+// ---------------------------------------------------------------------------
+// Adapter 1 — drasi-server (REST `/api/v1/*` with `{success, data, error}` wrap)
+// ---------------------------------------------------------------------------
+
+/** Wrapper shape used by every drasi-server response. */
+interface ServerWrap<T> {
+  success: boolean
+  data: T
+  error: string | null
+}
+
+interface ServerSummary {
+  id: string
+  status: string
+}
+
+interface ServerInstance extends ServerSummary {
+  source_count?: number
+  query_count?: number
+  reaction_count?: number
+}
+
+interface ServerQueryFull extends ServerSummary {
+  config?: {
+    query?: string
+    queryLanguage?: string
+    sources?: Array<{ sourceId?: string }>
+  }
+}
+
+/** GET via the backend proxy targeted at the configured drasi-server URL. */
+async function serverGet<T>(
+  drasiServerUrl: string,
+  upstreamPath: string,
+  signal: AbortSignal,
+): Promise<T> {
+  const proxyUrl =
+    `/api/drasi/proxy${upstreamPath}` +
+    `?target=server&url=${encodeURIComponent(drasiServerUrl)}`
+  const r = await fetch(proxyUrl, { signal })
+  if (!r.ok) throw new Error(`drasi-server ${upstreamPath}: HTTP ${r.status}`)
+  const wrapped = (await r.json()) as ServerWrap<T>
+  if (wrapped.error || wrapped.success === false) {
+    throw new Error(`drasi-server ${upstreamPath}: ${wrapped.error || 'unknown'}`)
+  }
+  return wrapped.data
+}
+
+async function fetchViaDrasiServer(
+  drasiServerUrl: string,
+  signal: AbortSignal,
+): Promise<DrasiResourceData> {
+  // Pick the first instance — drasi-server's flat `/api/v1/sources` etc. use
+  // the default instance, but the per-query results endpoint requires the
+  // explicit instance ID, so we discover it once.
+  const instances = await serverGet<ServerInstance[]>(drasiServerUrl, '/api/v1/instances', signal)
+  const instanceId = instances[0]?.id ?? null
+
+  const [rawSources, rawQueries, rawReactions] = await Promise.all([
+    serverGet<ServerSummary[]>(drasiServerUrl, '/api/v1/sources', signal),
+    serverGet<ServerSummary[]>(drasiServerUrl, '/api/v1/queries', signal),
+    serverGet<ServerSummary[]>(drasiServerUrl, '/api/v1/reactions', signal),
+  ])
+
+  const sources: DrasiSource[] = rawSources.map(s => ({
+    id: s.id,
+    name: s.id,
+    kind: mapSourceKind(s.id),
+    status: normalizeStatus(s.status),
+  }))
+
+  // Pull each query's full view to get its queryLanguage + source linkages.
+  const queriesFull = await Promise.all(
+    rawQueries.map(q =>
+      instanceId
+        ? serverGet<ServerQueryFull>(
+            drasiServerUrl,
+            `/api/v1/instances/${instanceId}/queries/${encodeURIComponent(q.id)}?view=full`,
+            signal,
+          ).catch(() => ({ id: q.id, status: q.status }) as ServerQueryFull)
+        : Promise.resolve({ id: q.id, status: q.status } as ServerQueryFull),
+    ),
+  )
+
+  const queries: DrasiQuery[] = queriesFull.map(q => ({
+    id: q.id,
+    name: q.id,
+    language: ((q.config?.queryLanguage as string) || 'GQL').toUpperCase() + ' QUERY',
+    status: normalizeStatus(q.status),
+    sourceIds: (q.config?.sources || []).map(s => s.sourceId || '').filter(Boolean),
+    queryText: q.config?.query,
+  }))
+
+  const reactions: DrasiReaction[] = rawReactions.map(r => ({
+    id: r.id,
+    name: r.id,
+    kind: mapReactionKind(r.id),
+    status: normalizeStatus(r.status),
+    // drasi-server's flat list view doesn't expose the reaction→queries
+    // edge; would need a second `?view=full` round-trip per reaction. For
+    // mode 2 we treat the reaction as subscribed to all queries by default,
+    // which is the common case for the SSE/log reactions.
+    queryIds: queries.map(q => q.id),
+  }))
+
+  // Pull the first running query's results so the card can populate its
+  // results table immediately (the SSE stream takes over for live updates).
+  let liveResults: LiveResultRow[] = []
+  const firstRunning = queries.find(q => q.status === 'ready')
+  if (firstRunning && instanceId) {
+    try {
+      liveResults = await serverGet<LiveResultRow[]>(
+        drasiServerUrl,
+        `/api/v1/instances/${instanceId}/queries/${encodeURIComponent(firstRunning.id)}/results`,
+        signal,
+      )
+      liveResults = (liveResults || []).slice(0, MAX_LIVE_RESULTS_PER_QUERY)
+    } catch {
+      // Results endpoint may 404 if query has no results yet. Non-fatal.
+    }
+  }
+
+  return { mode: 'server', instanceId, sources, queries, reactions, liveResults }
+}
+
+// ---------------------------------------------------------------------------
+// Adapter 2 — drasi-platform (REST `/v1/*` raw arrays, in-cluster Service proxy)
+// ---------------------------------------------------------------------------
+
+interface PlatformResource {
+  id: string
+  spec?: Record<string, unknown>
+  status?: { available?: boolean; message?: string } | string
+}
+
+/** GET via the backend proxy targeted at drasi-platform on the named cluster. */
+async function platformGet<T>(
+  cluster: string,
+  upstreamPath: string,
+  signal: AbortSignal,
+): Promise<T> {
+  const proxyUrl =
+    `/api/drasi/proxy${upstreamPath}` +
+    `?target=platform&cluster=${encodeURIComponent(cluster)}`
+  const r = await fetch(proxyUrl, { signal })
+  if (!r.ok) throw new Error(`drasi-platform ${upstreamPath}: HTTP ${r.status}`)
+  return (await r.json()) as T
+}
+
+function platformStatus(raw: PlatformResource['status']): DrasiStatus {
+  if (typeof raw === 'string') return normalizeStatus(raw)
+  if (raw && typeof raw === 'object') {
+    if (raw.available === true) return 'ready'
+    if (raw.available === false) return 'error'
+  }
+  return 'pending'
+}
+
+async function fetchViaDrasiPlatform(
+  cluster: string,
+  signal: AbortSignal,
+): Promise<DrasiResourceData> {
+  const [rawSources, rawQueries, rawReactions] = await Promise.all([
+    platformGet<PlatformResource[]>(cluster, '/v1/sources', signal),
+    platformGet<PlatformResource[]>(cluster, '/v1/continuousQueries', signal),
+    platformGet<PlatformResource[]>(cluster, '/v1/reactions', signal),
+  ])
+
+  const sources: DrasiSource[] = (rawSources || []).map(s => ({
+    id: s.id,
+    name: s.id,
+    kind: mapSourceKind((s.spec as Record<string, unknown>)?.kind ?? s.id),
+    status: platformStatus(s.status),
+  }))
+
+  const queries: DrasiQuery[] = (rawQueries || []).map(q => {
+    const spec = (q.spec || {}) as { mode?: string; query?: string; sources?: Array<{ id?: string; name?: string }> }
+    return {
+      id: q.id,
+      name: q.id,
+      language: (spec.mode || 'CYPHER').toUpperCase() + ' QUERY',
+      status: platformStatus(q.status),
+      sourceIds: (spec.sources || []).map(s => s.id || s.name || '').filter(Boolean),
+      queryText: spec.query,
+    }
+  })
+
+  const reactions: DrasiReaction[] = (rawReactions || []).map(r => {
+    const spec = (r.spec || {}) as { kind?: string; queries?: Array<{ id?: string; name?: string }> }
+    return {
+      id: r.id,
+      name: r.id,
+      kind: mapReactionKind(spec.kind ?? r.id),
+      status: platformStatus(r.status),
+      queryIds: (spec.queries || []).map(q => q.id || q.name || '').filter(Boolean),
+    }
+  })
+
+  // drasi-platform doesn't expose a flat per-query results endpoint the same
+  // way drasi-server does — its query results live in the View Service
+  // (`default-view-svc`) and are typically consumed via a Result reaction.
+  // For Phase 2 we leave liveResults empty in platform mode and let the SSE
+  // reaction (Phase 3) populate the table.
+  return { mode: 'platform', instanceId: null, sources, queries, reactions, liveResults: [] }
 }
 
 // ---------------------------------------------------------------------------
 // Hook
 // ---------------------------------------------------------------------------
 
-export function useDrasiResources(): {
+export interface UseDrasiResourcesResult {
   data: DrasiResourceData | null
   isLoading: boolean
   error: string | null
-} {
+  refetch: () => void
+}
+
+export function useDrasiResources(): UseDrasiResourcesResult {
   const [data, setData] = useState<DrasiResourceData | null>(null)
   const [isLoading, setIsLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const abortRef = useRef<AbortController | null>(null)
 
-  const fetchResources = useCallback(async () => {
-    if (!DRASI_API_BASE) {
-      // No Drasi API configured — card will use demo data
-      return
-    }
-
+  const fetchOnce = useCallback(async () => {
     abortRef.current?.abort()
     const controller = new AbortController()
     abortRef.current = controller
 
+    if (!DRASI_SERVER_URL && !DRASI_PLATFORM_CLUSTER) {
+      // Nothing configured — leave data null so the card drops to demo mode.
+      return
+    }
+
     setIsLoading(true)
     try {
-      const [sourcesRes, queriesRes, reactionsRes] = await Promise.all([
-        fetch(`${DRASI_API_BASE}/v1/sources`, { signal: controller.signal }),
-        fetch(`${DRASI_API_BASE}/v1/continuousQueries`, { signal: controller.signal }),
-        fetch(`${DRASI_API_BASE}/v1/reactions`, { signal: controller.signal }),
-      ])
-
-      if (!sourcesRes.ok || !queriesRes.ok || !reactionsRes.ok) {
-        throw new Error('Drasi API returned non-OK status')
+      let next: DrasiResourceData | null = null
+      if (DRASI_SERVER_URL) {
+        next = await fetchViaDrasiServer(DRASI_SERVER_URL, controller.signal)
+      } else if (DRASI_PLATFORM_CLUSTER) {
+        next = await fetchViaDrasiPlatform(DRASI_PLATFORM_CLUSTER, controller.signal)
       }
-
-      const rawSources: DrasiApiSource[] = await sourcesRes.json()
-      const rawQueries: DrasiApiQuery[] = await queriesRes.json()
-      const rawReactions: DrasiApiReaction[] = await reactionsRes.json()
-
-      const sources: DrasiSource[] = (rawSources || []).map(s => ({
-        id: s.id || s.metadata?.name || 'unknown',
-        name: s.metadata?.name || s.id || 'unknown',
-        kind: mapSourceKind(s.spec?.kind),
-        status: mapStatus(s.status?.available),
-      }))
-
-      const queries: DrasiQuery[] = (rawQueries || []).map(q => ({
-        id: q.id || q.metadata?.name || 'unknown',
-        name: q.metadata?.name || q.id || 'unknown',
-        language: (q.spec?.mode || 'CYPHER').toUpperCase() + ' QUERY',
-        status: mapStatus(q.status?.available),
-        sourceIds: (q.spec?.sources || []).map(s => s.id || s.name || ''),
-      }))
-
-      const reactions: DrasiReaction[] = (rawReactions || []).map(r => ({
-        id: r.id || r.metadata?.name || 'unknown',
-        name: r.metadata?.name || r.id || 'unknown',
-        kind: mapReactionKind(r.spec?.kind),
-        status: mapStatus(r.status?.available),
-        queryIds: (r.spec?.queries || []).map(q => q.id || q.name || ''),
-      }))
-
-      // Fetch live results from the first query (if any)
-      let liveResults: LiveResultRow[] = []
-      if (queries.length > 0) {
-        try {
-          const resultsRes = await fetch(
-            `${DRASI_API_BASE}/v1/continuousQueries/${queries[0].id}/results`,
-            { signal: controller.signal },
-          )
-          if (resultsRes.ok) {
-            const rawResults = await resultsRes.json()
-            liveResults = (rawResults || []).map((r: Record<string, unknown>) => ({
-              changePercent: Number(r.changePercent) || 0,
-              name: String(r.name || ''),
-              previousClose: Number(r.previousClose) || 0,
-              price: Number(r.price) || 0,
-              symbol: String(r.symbol || ''),
-            }))
-          }
-        } catch {
-          // Live results are optional — silently ignore
-        }
-      }
-
-      setData({ sources, queries, reactions, liveResults })
+      setData(next)
       setError(null)
     } catch (e) {
       if ((e as Error).name !== 'AbortError') {
         setError((e as Error).message || 'Failed to fetch Drasi resources')
+        setData(null)
       }
     } finally {
       setIsLoading(false)
@@ -219,13 +385,13 @@ export function useDrasiResources(): {
   }, [])
 
   useEffect(() => {
-    fetchResources()
-    const interval = setInterval(fetchResources, DRASI_POLL_INTERVAL_MS)
+    fetchOnce()
+    const interval = setInterval(fetchOnce, DRASI_POLL_INTERVAL_MS)
     return () => {
       clearInterval(interval)
       abortRef.current?.abort()
     }
-  }, [fetchResources])
+  }, [fetchOnce])
 
-  return { data, isLoading, error }
+  return { data, isLoading, error, refetch: fetchOnce }
 }


### PR DESCRIPTION
## Summary
The /drasi dashboard was visually polished but talked to a fantasy REST API. This PR makes it speak to a **real Drasi installation** in **all three Drasi deployment modes** (drasi-lib via drasi-server, drasi-server standalone, drasi-platform on Kubernetes), stream real query result deltas over SSE, and mutate real resources from the gear modals.

I verified end-to-end against:
- **drasi-server 0.1.3** in Docker on \`localhost:8090\` (mock source + Cypher query + log reaction)
- **drasi-platform 0.10.0** on the **KubeStellar Prow cluster** (\`drasi-system\` namespace, all 7 control-plane pods healthy)

## Big surprise from Phase 1: drasi-platform has NO Kubernetes CRDs

Despite running on K8s, drasi-platform doesn't use CRDs — it ships its own Rust REST API in the \`drasi-api\` Service in \`drasi-system\`. The two REST APIs are *similar but not identical*:

| | drasi-server | drasi-platform |
|---|---|---|
| Base path | \`/api/v1/*\` | \`/v1/*\` |
| Queries endpoint | \`/api/v1/queries\` | \`/v1/continuousQueries\` |
| Response wrap | \`{success, data, error}\` | raw arrays |
| SSE stream | built-in per query | requires Result reaction (Phase 3) |

This invalidated the original plan to use the existing \`/api/mcp/custom-resources\` CRD handler. Replaced with a single new generic reverse-proxy handler.

## Architecture

### Backend — \`/api/drasi/proxy/*?target=server|platform\`
A single new generic reverse-proxy in \`pkg/api/handlers/drasi_proxy.go\` (handles GET/POST/PUT/DELETE/PATCH via \`api.All\`):
- **\`target=server&url=...\`**: forwards to the configured drasi-server URL. Streams the response so SSE works.
- **\`target=platform&cluster=...\`**: uses the **Kubernetes API server's built-in Service proxy** (\`/api/v1/namespaces/drasi-system/services/drasi-api:8080/proxy/...\`) to reach \`drasi-api\` via the user's kubeconfig RBAC. No port-forward, no manual ingress.
- Strips hop-by-hop headers + console auth before forwarding. Caps body to 1 MiB. Honors viewer+ role.

### Frontend — one hook, two adapters
\`useDrasiResources.ts\` rewritten:
- \`fetchViaDrasiServer()\` unwraps the success envelope, pulls each query's \`?view=full\` for queryLanguage + source linkages.
- \`fetchViaDrasiPlatform()\` reads raw arrays from \`/v1/*\`.
- Both normalize into the same \`DrasiResourceData\` shape including a \`mode\` field so the card knows which mutation endpoint to call.

### New SSE hook
\`useDrasiQueryStream.ts\` opens an EventSource on a query's events/stream via the proxy, parses \`{added, updated, deleted}\` delta events, maintains a rolling result set capped at 200 rows.

### Card changes (\`DrasiReactiveGraph.tsx\`)
- \`LiveResultRow\` is now a dynamic \`Record<string, primitive>\`. \`ResultsTable\` derives its columns from \`Object.keys\` of the first row, picks alignment and ▲/▼ trend formatting per column. Real Drasi queries can have any schema.
- Wired \`useDrasiQueryStream\` — when running live against drasi-server with a query selected, the rolling stream replaces the polled snapshot.
- Gear modal save handlers now \`PUT\` against the proxy. Demo mode preserves local-only behavior.

## Configuration

Add ONE of these to \`web/.env\`:
- \`VITE_DRASI_SERVER_URL=http://localhost:8090\` for drasi-server
- \`VITE_DRASI_PLATFORM_CLUSTER=prow\` (any kubeconfig context name) for drasi-platform

Without either, the card falls back to demo data unchanged.

## Test plan
- [ ] \`bash startup-oauth.sh\` with neither env var set → \`/drasi\` shows demo data unchanged
- [ ] Set \`VITE_DRASI_SERVER_URL\` against a running drasi-server → see real sources/queries/reactions, click the running query → results stream, edit a source name via the gear → \`curl /api/v1/sources/<name>\` reflects the change
- [ ] Set \`VITE_DRASI_PLATFORM_CLUSTER\` against a kubeconfig context that has Drasi installed → see real resources from \`drasi-system\`
- [ ] Tear down both → card falls back to demo data

🤖 Generated with [Claude Code](https://claude.com/claude-code)