### PR TITLE
♻️ refactor(phase2.5): migrate ConsoleResource CR writes to kc-agent (#7993)

### DIFF
--- a/pkg/agent/server.go
+++ b/pkg/agent/server.go
@@ -418,6 +418,18 @@ func (s *Server) Start() error {
 	mux.HandleFunc("/helm/uninstall", s.handleHelmUninstall)
 	mux.HandleFunc("/helm/upgrade", s.handleHelmUpgrade)
 
+	// ConsoleResource CR writes moved to kc-agent (#7993 Phase 2.5).
+	// ManagedWorkload / ClusterGroup / WorkloadDeployment creates, updates,
+	// and deletes now run under the user's kubeconfig. The backend still
+	// hosts the reconciler (console_persistence.go StartWatcher /
+	// reconcileDeployment) because that's system-internal — it reacts to
+	// CR state changes without a human in the loop and legitimately runs
+	// as the pod SA.
+	mux.HandleFunc("/console-cr/workloads", s.handleConsoleCRManagedWorkloads)
+	mux.HandleFunc("/console-cr/groups", s.handleConsoleCRClusterGroups)
+	mux.HandleFunc("/console-cr/deployments", s.handleConsoleCRWorkloadDeployments)
+	mux.HandleFunc("/console-cr/deployments/status", s.handleConsoleCRWorkloadDeploymentStatus)
+
 	// GitOps drift detection + kubectl sync moved to kc-agent (#7993 Phase 3b).
 	// These shell `kubectl diff` / `kubectl apply` under the user's kubeconfig.
 	// Backend handlers are still present until Phase 4 deletes them — routes

--- a/pkg/agent/server_console_cr.go
+++ b/pkg/agent/server_console_cr.go
@@ -1,0 +1,350 @@
+package agent
+
+// Console Resource (CR) write handlers for kc-agent.
+//
+// These endpoints are the kc-agent side of Phase 2.5 of #7993: user-initiated
+// writes to the console's own CRDs (ManagedWorkload / ClusterGroup /
+// WorkloadDeployment) must run under the user's kubeconfig, not the backend
+// pod ServiceAccount. The backend continues to host the *reconcilers*
+// (console_persistence.go StartWatcher / reconcileDeployment) because those
+// are system-internal — they react to CR state changes without a human in
+// the loop and legitimately run as the pod SA.
+//
+// The frontend passes the persistence cluster context name and the
+// persistence namespace as query parameters (both already exposed by
+// usePersistence()'s `activeCluster` + `config.namespace`). kc-agent then
+// resolves the dynamic client for that context from the user's kubeconfig
+// and delegates to the shared pkg/k8s.ConsolePersistence methods so there is
+// zero duplication of the CR CRUD logic.
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/kubestellar/console/pkg/api/v1alpha1"
+	"github.com/kubestellar/console/pkg/k8s"
+)
+
+// consoleCRRequestTimeout is the per-request deadline applied to CR writes.
+// It matches the existing agentExtendedTimeout used by other mutation
+// handlers (service accounts, role bindings, workload deploy) so that a slow
+// apiserver does not block the kc-agent request loop indefinitely.
+const consoleCRRequestTimeout = 30 * time.Second
+
+// resolveConsoleCRTarget reads the `cluster` and `namespace` query parameters
+// that the frontend passes on every console-cr request and returns a
+// dynamic.Interface authenticated against the user's kubeconfig for that
+// cluster context, along with the validated namespace. Returns a rendered
+// 400 response and `false` when either parameter is missing; returns a
+// rendered error and `false` when the k8s client cannot be resolved.
+func (s *Server) resolveConsoleCRTarget(w http.ResponseWriter, r *http.Request) (k8s.ConsolePersistence, string, bool) {
+	cluster := r.URL.Query().Get("cluster")
+	namespace := r.URL.Query().Get("namespace")
+	if cluster == "" || namespace == "" {
+		w.WriteHeader(http.StatusBadRequest)
+		writeJSON(w, map[string]interface{}{
+			"success": false,
+			"error":   "cluster and namespace query parameters are required",
+		})
+		return nil, "", false
+	}
+	if s.k8sClient == nil {
+		writeJSONError(w, http.StatusServiceUnavailable, "k8s client not initialized")
+		return nil, "", false
+	}
+	dyn, err := s.k8sClient.GetDynamicClient(cluster)
+	if err != nil {
+		writeJSONError(w, http.StatusServiceUnavailable, err.Error())
+		return nil, "", false
+	}
+	return k8s.NewConsolePersistence(dyn), namespace, true
+}
+
+// handleConsoleCRManagedWorkloads serves POST/PUT/DELETE for ManagedWorkload
+// CRs. POST creates with a body-supplied spec. PUT updates by name (name
+// also in query). DELETE removes by name.
+func (s *Server) handleConsoleCRManagedWorkloads(w http.ResponseWriter, r *http.Request) {
+	s.setCORSHeaders(w, r)
+	w.Header().Set("Content-Type", "application/json")
+	if r.Method == http.MethodOptions {
+		w.WriteHeader(http.StatusOK)
+		return
+	}
+	if !s.validateToken(r) {
+		http.Error(w, "Unauthorized", http.StatusUnauthorized)
+		return
+	}
+
+	persistence, namespace, ok := s.resolveConsoleCRTarget(w, r)
+	if !ok {
+		return
+	}
+	ctx, cancel := context.WithTimeout(r.Context(), consoleCRRequestTimeout)
+	defer cancel()
+
+	switch r.Method {
+	case http.MethodPost:
+		var mw v1alpha1.ManagedWorkload
+		if err := json.NewDecoder(r.Body).Decode(&mw); err != nil {
+			writeJSONError(w, http.StatusBadRequest, "invalid request body")
+			return
+		}
+		mw.Namespace = namespace
+		if mw.APIVersion == "" {
+			mw.APIVersion = v1alpha1.GroupVersion.String()
+		}
+		if mw.Kind == "" {
+			mw.Kind = "ManagedWorkload"
+		}
+		if mw.CreationTimestamp.IsZero() {
+			mw.CreationTimestamp = metav1.Now()
+		}
+		created, err := persistence.CreateManagedWorkload(ctx, &mw)
+		if err != nil {
+			writeJSONError(w, http.StatusInternalServerError, err.Error())
+			return
+		}
+		w.WriteHeader(http.StatusCreated)
+		writeJSON(w, created)
+
+	case http.MethodPut:
+		name := r.URL.Query().Get("name")
+		if name == "" {
+			writeJSONError(w, http.StatusBadRequest, "name query parameter is required")
+			return
+		}
+		var mw v1alpha1.ManagedWorkload
+		if err := json.NewDecoder(r.Body).Decode(&mw); err != nil {
+			writeJSONError(w, http.StatusBadRequest, "invalid request body")
+			return
+		}
+		mw.Name = name
+		mw.Namespace = namespace
+		updated, err := persistence.UpdateManagedWorkload(ctx, &mw)
+		if err != nil {
+			writeJSONError(w, http.StatusInternalServerError, err.Error())
+			return
+		}
+		writeJSON(w, updated)
+
+	case http.MethodDelete:
+		name := r.URL.Query().Get("name")
+		if name == "" {
+			writeJSONError(w, http.StatusBadRequest, "name query parameter is required")
+			return
+		}
+		if err := persistence.DeleteManagedWorkload(ctx, namespace, name); err != nil {
+			writeJSONError(w, http.StatusInternalServerError, err.Error())
+			return
+		}
+		writeJSON(w, map[string]interface{}{"success": true, "name": name})
+
+	default:
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+	}
+}
+
+// handleConsoleCRClusterGroups serves POST/PUT/DELETE for ClusterGroup CRs.
+func (s *Server) handleConsoleCRClusterGroups(w http.ResponseWriter, r *http.Request) {
+	s.setCORSHeaders(w, r)
+	w.Header().Set("Content-Type", "application/json")
+	if r.Method == http.MethodOptions {
+		w.WriteHeader(http.StatusOK)
+		return
+	}
+	if !s.validateToken(r) {
+		http.Error(w, "Unauthorized", http.StatusUnauthorized)
+		return
+	}
+
+	persistence, namespace, ok := s.resolveConsoleCRTarget(w, r)
+	if !ok {
+		return
+	}
+	ctx, cancel := context.WithTimeout(r.Context(), consoleCRRequestTimeout)
+	defer cancel()
+
+	switch r.Method {
+	case http.MethodPost:
+		var cg v1alpha1.ClusterGroup
+		if err := json.NewDecoder(r.Body).Decode(&cg); err != nil {
+			writeJSONError(w, http.StatusBadRequest, "invalid request body")
+			return
+		}
+		cg.Namespace = namespace
+		if cg.APIVersion == "" {
+			cg.APIVersion = v1alpha1.GroupVersion.String()
+		}
+		if cg.Kind == "" {
+			cg.Kind = "ClusterGroup"
+		}
+		if cg.CreationTimestamp.IsZero() {
+			cg.CreationTimestamp = metav1.Now()
+		}
+		created, err := persistence.CreateClusterGroup(ctx, &cg)
+		if err != nil {
+			writeJSONError(w, http.StatusInternalServerError, err.Error())
+			return
+		}
+		w.WriteHeader(http.StatusCreated)
+		writeJSON(w, created)
+
+	case http.MethodPut:
+		name := r.URL.Query().Get("name")
+		if name == "" {
+			writeJSONError(w, http.StatusBadRequest, "name query parameter is required")
+			return
+		}
+		var cg v1alpha1.ClusterGroup
+		if err := json.NewDecoder(r.Body).Decode(&cg); err != nil {
+			writeJSONError(w, http.StatusBadRequest, "invalid request body")
+			return
+		}
+		cg.Name = name
+		cg.Namespace = namespace
+		updated, err := persistence.UpdateClusterGroup(ctx, &cg)
+		if err != nil {
+			writeJSONError(w, http.StatusInternalServerError, err.Error())
+			return
+		}
+		writeJSON(w, updated)
+
+	case http.MethodDelete:
+		name := r.URL.Query().Get("name")
+		if name == "" {
+			writeJSONError(w, http.StatusBadRequest, "name query parameter is required")
+			return
+		}
+		if err := persistence.DeleteClusterGroup(ctx, namespace, name); err != nil {
+			writeJSONError(w, http.StatusInternalServerError, err.Error())
+			return
+		}
+		writeJSON(w, map[string]interface{}{"success": true, "name": name})
+
+	default:
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+	}
+}
+
+// handleConsoleCRWorkloadDeployments serves POST/DELETE for WorkloadDeployment
+// CRs. The general PUT path is intentionally absent — the backend only ever
+// exposed status updates (see handleConsoleCRWorkloadDeploymentStatus), and
+// spec updates are reserved for the system-internal reconciler.
+func (s *Server) handleConsoleCRWorkloadDeployments(w http.ResponseWriter, r *http.Request) {
+	s.setCORSHeaders(w, r)
+	w.Header().Set("Content-Type", "application/json")
+	if r.Method == http.MethodOptions {
+		w.WriteHeader(http.StatusOK)
+		return
+	}
+	if !s.validateToken(r) {
+		http.Error(w, "Unauthorized", http.StatusUnauthorized)
+		return
+	}
+
+	persistence, namespace, ok := s.resolveConsoleCRTarget(w, r)
+	if !ok {
+		return
+	}
+	ctx, cancel := context.WithTimeout(r.Context(), consoleCRRequestTimeout)
+	defer cancel()
+
+	switch r.Method {
+	case http.MethodPost:
+		var wd v1alpha1.WorkloadDeployment
+		if err := json.NewDecoder(r.Body).Decode(&wd); err != nil {
+			writeJSONError(w, http.StatusBadRequest, "invalid request body")
+			return
+		}
+		wd.Namespace = namespace
+		if wd.APIVersion == "" {
+			wd.APIVersion = v1alpha1.GroupVersion.String()
+		}
+		if wd.Kind == "" {
+			wd.Kind = "WorkloadDeployment"
+		}
+		if wd.CreationTimestamp.IsZero() {
+			wd.CreationTimestamp = metav1.Now()
+		}
+		created, err := persistence.CreateWorkloadDeployment(ctx, &wd)
+		if err != nil {
+			writeJSONError(w, http.StatusInternalServerError, err.Error())
+			return
+		}
+		w.WriteHeader(http.StatusCreated)
+		writeJSON(w, created)
+
+	case http.MethodDelete:
+		name := r.URL.Query().Get("name")
+		if name == "" {
+			writeJSONError(w, http.StatusBadRequest, "name query parameter is required")
+			return
+		}
+		if err := persistence.DeleteWorkloadDeployment(ctx, namespace, name); err != nil {
+			writeJSONError(w, http.StatusInternalServerError, err.Error())
+			return
+		}
+		writeJSON(w, map[string]interface{}{"success": true, "name": name})
+
+	default:
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+	}
+}
+
+// handleConsoleCRWorkloadDeploymentStatus handles PUT for the status subresource
+// of WorkloadDeployment CRs. The frontend sends a partial spec containing only
+// the status field, merged with the current resource on the apiserver side.
+func (s *Server) handleConsoleCRWorkloadDeploymentStatus(w http.ResponseWriter, r *http.Request) {
+	s.setCORSHeaders(w, r)
+	w.Header().Set("Content-Type", "application/json")
+	if r.Method == http.MethodOptions {
+		w.WriteHeader(http.StatusOK)
+		return
+	}
+	if !s.validateToken(r) {
+		http.Error(w, "Unauthorized", http.StatusUnauthorized)
+		return
+	}
+	if r.Method != http.MethodPut {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	persistence, namespace, ok := s.resolveConsoleCRTarget(w, r)
+	if !ok {
+		return
+	}
+	ctx, cancel := context.WithTimeout(r.Context(), consoleCRRequestTimeout)
+	defer cancel()
+
+	name := r.URL.Query().Get("name")
+	if name == "" {
+		writeJSONError(w, http.StatusBadRequest, "name query parameter is required")
+		return
+	}
+
+	// Fetch the current WD, apply the status from the request body, and
+	// update. The backend handler does the same shape: the frontend sends
+	// just a WorkloadDeploymentStatus, not the whole WD.
+	current, err := persistence.GetWorkloadDeployment(ctx, namespace, name)
+	if err != nil {
+		writeJSONError(w, http.StatusNotFound, err.Error())
+		return
+	}
+	var status v1alpha1.WorkloadDeploymentStatus
+	if err := json.NewDecoder(r.Body).Decode(&status); err != nil {
+		writeJSONError(w, http.StatusBadRequest, "invalid request body")
+		return
+	}
+	current.Status = status
+	updated, err := persistence.UpdateWorkloadDeploymentStatus(ctx, current)
+	if err != nil {
+		writeJSONError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	writeJSON(w, updated)
+}

--- a/pkg/api/handlers/console_persistence.go
+++ b/pkg/api/handlers/console_persistence.go
@@ -159,17 +159,46 @@ func (h *ConsolePersistenceHandlers) StopWatcher() {
 	}
 }
 
-// handleResourceEvent broadcasts resource changes to connected clients
+// handleResourceEvent broadcasts resource changes to connected clients and,
+// for newly created WorkloadDeployment resources, kicks off reconciliation.
+//
+// The reconcile-on-ADDED path is the Phase 2.5 replacement for the inline
+// reconcileDeployment goroutine that CreateWorkloadDeployment used to fire
+// directly (#7993). The CR write itself is now handled by kc-agent under the
+// user's kubeconfig; the backend sees the new resource via the watcher and
+// reconciles it as a proper controller. The reconciler still uses the pod SA
+// because it's system-internal (not user-initiated).
 func (h *ConsolePersistenceHandlers) handleResourceEvent(event k8s.ConsoleResourceEvent) {
-	if h.hub == nil {
-		return
+	if h.hub != nil {
+		msg := Message{
+			Type: "console_resource_changed",
+			Data: event,
+		}
+		h.hub.BroadcastAll(msg)
 	}
 
-	msg := Message{
-		Type: "console_resource_changed",
-		Data: event,
+	// Trigger reconciliation on newly observed WorkloadDeployment CRs.
+	// Only act on ADDED events — MODIFIED covers status updates from the
+	// reconciler itself and would cause reconcile loops, DELETED is a no-op.
+	if event.Type != "ADDED" || event.ResourceType != "WorkloadDeployment" {
+		return
 	}
-	h.hub.BroadcastAll(msg)
+	wd, ok := event.Resource.(*v1alpha1.WorkloadDeployment)
+	if !ok {
+		slog.Warn("[ConsolePersistence] watcher returned non-WorkloadDeployment resource",
+			"type", event.ResourceType, "name", event.Name)
+		return
+	}
+	// Use a detached context with a wall-clock bound so reconciliation
+	// survives independently of the watcher's event dispatch goroutine and
+	// cannot run forever. 5 minutes matches the prior CreateWorkloadDeployment
+	// detached timeout.
+	const reconcileTimeout = 5 * time.Minute
+	reconcileCtx, reconcileCancel := context.WithTimeout(context.Background(), reconcileTimeout)
+	go func() {
+		defer reconcileCancel()
+		h.reconcileDeployment(reconcileCtx, wd)
+	}()
 }
 
 // =============================================================================
@@ -280,107 +309,12 @@ func (h *ConsolePersistenceHandlers) GetManagedWorkload(c *fiber.Ctx) error {
 	return c.JSON(workload)
 }
 
-// CreateManagedWorkload creates a new managed workload
-// POST /api/persistence/workloads
-func (h *ConsolePersistenceHandlers) CreateManagedWorkload(c *fiber.Ctx) error {
-	if err := h.requireAdmin(c); err != nil {
-		return err
-	}
-
-	var workload v1alpha1.ManagedWorkload
-	if err := c.BodyParser(&workload); err != nil {
-		return c.Status(400).JSON(fiber.Map{"error": "Invalid request body"})
-	}
-
-	client, _, err := h.persistenceStore.GetActiveClient(c.Context())
-	if err != nil {
-		slog.Warn("[ConsolePersistence] service unavailable", "error", err)
-		return c.Status(503).JSON(fiber.Map{"error": "service unavailable"})
-	}
-
-	namespace := h.persistenceStore.GetNamespace()
-	persistence := k8s.NewConsolePersistence(client)
-
-	// Set namespace and metadata
-	workload.Namespace = namespace
-	if workload.APIVersion == "" {
-		workload.APIVersion = v1alpha1.GroupVersion.String()
-	}
-	if workload.Kind == "" {
-		workload.Kind = "ManagedWorkload"
-	}
-	workload.CreationTimestamp = metav1.Now()
-
-	created, err := persistence.CreateManagedWorkload(c.Context(), &workload)
-	if err != nil {
-		slog.Warn("[ConsolePersistence] internal error", "error", err)
-		return c.Status(500).JSON(fiber.Map{"error": "internal server error"})
-	}
-
-	return c.Status(201).JSON(created)
-}
-
-// UpdateManagedWorkload updates an existing managed workload
-// PUT /api/persistence/workloads/:name
-func (h *ConsolePersistenceHandlers) UpdateManagedWorkload(c *fiber.Ctx) error {
-	if err := h.requireAdmin(c); err != nil {
-		return err
-	}
-
-	name := c.Params("name")
-
-	var workload v1alpha1.ManagedWorkload
-	if err := c.BodyParser(&workload); err != nil {
-		return c.Status(400).JSON(fiber.Map{"error": "Invalid request body"})
-	}
-
-	client, _, err := h.persistenceStore.GetActiveClient(c.Context())
-	if err != nil {
-		slog.Warn("[ConsolePersistence] service unavailable", "error", err)
-		return c.Status(503).JSON(fiber.Map{"error": "service unavailable"})
-	}
-
-	namespace := h.persistenceStore.GetNamespace()
-	persistence := k8s.NewConsolePersistence(client)
-
-	// Ensure name matches
-	workload.Name = name
-	workload.Namespace = namespace
-
-	updated, err := persistence.UpdateManagedWorkload(c.Context(), &workload)
-	if err != nil {
-		slog.Warn("[ConsolePersistence] internal error", "error", err)
-		return c.Status(500).JSON(fiber.Map{"error": "internal server error"})
-	}
-
-	return c.JSON(updated)
-}
-
-// DeleteManagedWorkload deletes a managed workload
-// DELETE /api/persistence/workloads/:name
-func (h *ConsolePersistenceHandlers) DeleteManagedWorkload(c *fiber.Ctx) error {
-	if err := h.requireAdmin(c); err != nil {
-		return err
-	}
-
-	name := c.Params("name")
-
-	client, _, err := h.persistenceStore.GetActiveClient(c.Context())
-	if err != nil {
-		slog.Warn("[ConsolePersistence] service unavailable", "error", err)
-		return c.Status(503).JSON(fiber.Map{"error": "service unavailable"})
-	}
-
-	namespace := h.persistenceStore.GetNamespace()
-	persistence := k8s.NewConsolePersistence(client)
-
-	if err := persistence.DeleteManagedWorkload(c.Context(), namespace, name); err != nil {
-		slog.Warn("[ConsolePersistence] internal error", "error", err)
-		return c.Status(500).JSON(fiber.Map{"error": "internal server error"})
-	}
-
-	return c.SendStatus(204)
-}
+// CreateManagedWorkload / UpdateManagedWorkload / DeleteManagedWorkload were
+// removed in #7993 Phase 2.5. These user-initiated CR writes now go through
+// kc-agent's /console-cr/workloads route so they run under the caller's own
+// kubeconfig rather than the backend pod ServiceAccount. The reconciler
+// (reconcileDeployment below) still runs here because it's system-internal
+// and legitimately uses the pod SA.
 
 // =============================================================================
 // ClusterGroup endpoints
@@ -434,119 +368,13 @@ func (h *ConsolePersistenceHandlers) GetClusterGroup(c *fiber.Ctx) error {
 	return c.JSON(group)
 }
 
-// CreateClusterGroup creates a new cluster group
-// POST /api/persistence/groups
-func (h *ConsolePersistenceHandlers) CreateClusterGroup(c *fiber.Ctx) error {
-	if err := h.requireAdmin(c); err != nil {
-		return err
-	}
-
-	var group v1alpha1.ClusterGroup
-	if err := c.BodyParser(&group); err != nil {
-		return c.Status(400).JSON(fiber.Map{"error": "Invalid request body"})
-	}
-
-	client, _, err := h.persistenceStore.GetActiveClient(c.Context())
-	if err != nil {
-		slog.Warn("[ConsolePersistence] service unavailable", "error", err)
-		return c.Status(503).JSON(fiber.Map{"error": "service unavailable"})
-	}
-
-	namespace := h.persistenceStore.GetNamespace()
-	persistence := k8s.NewConsolePersistence(client)
-
-	// Set namespace and metadata
-	group.Namespace = namespace
-	if group.APIVersion == "" {
-		group.APIVersion = v1alpha1.GroupVersion.String()
-	}
-	if group.Kind == "" {
-		group.Kind = "ClusterGroup"
-	}
-	group.CreationTimestamp = metav1.Now()
-
-	// Evaluate matched clusters
-	group.Status.MatchedClusters = h.evaluateClusterGroup(c.Context(), &group)
-	group.Status.MatchedClusterCount = len(group.Status.MatchedClusters)
-	now := metav1.Now()
-	group.Status.LastEvaluated = &now
-
-	created, err := persistence.CreateClusterGroup(c.Context(), &group)
-	if err != nil {
-		slog.Warn("[ConsolePersistence] internal error", "error", err)
-		return c.Status(500).JSON(fiber.Map{"error": "internal server error"})
-	}
-
-	return c.Status(201).JSON(created)
-}
-
-// UpdateClusterGroup updates an existing cluster group
-// PUT /api/persistence/groups/:name
-func (h *ConsolePersistenceHandlers) UpdateClusterGroup(c *fiber.Ctx) error {
-	if err := h.requireAdmin(c); err != nil {
-		return err
-	}
-
-	name := c.Params("name")
-
-	var group v1alpha1.ClusterGroup
-	if err := c.BodyParser(&group); err != nil {
-		return c.Status(400).JSON(fiber.Map{"error": "Invalid request body"})
-	}
-
-	client, _, err := h.persistenceStore.GetActiveClient(c.Context())
-	if err != nil {
-		slog.Warn("[ConsolePersistence] service unavailable", "error", err)
-		return c.Status(503).JSON(fiber.Map{"error": "service unavailable"})
-	}
-
-	namespace := h.persistenceStore.GetNamespace()
-	persistence := k8s.NewConsolePersistence(client)
-
-	// Ensure name matches
-	group.Name = name
-	group.Namespace = namespace
-
-	// Re-evaluate matched clusters
-	group.Status.MatchedClusters = h.evaluateClusterGroup(c.Context(), &group)
-	group.Status.MatchedClusterCount = len(group.Status.MatchedClusters)
-	now := metav1.Now()
-	group.Status.LastEvaluated = &now
-
-	updated, err := persistence.UpdateClusterGroup(c.Context(), &group)
-	if err != nil {
-		slog.Warn("[ConsolePersistence] internal error", "error", err)
-		return c.Status(500).JSON(fiber.Map{"error": "internal server error"})
-	}
-
-	return c.JSON(updated)
-}
-
-// DeleteClusterGroup deletes a cluster group
-// DELETE /api/persistence/groups/:name
-func (h *ConsolePersistenceHandlers) DeleteClusterGroup(c *fiber.Ctx) error {
-	if err := h.requireAdmin(c); err != nil {
-		return err
-	}
-
-	name := c.Params("name")
-
-	client, _, err := h.persistenceStore.GetActiveClient(c.Context())
-	if err != nil {
-		slog.Warn("[ConsolePersistence] service unavailable", "error", err)
-		return c.Status(503).JSON(fiber.Map{"error": "service unavailable"})
-	}
-
-	namespace := h.persistenceStore.GetNamespace()
-	persistence := k8s.NewConsolePersistence(client)
-
-	if err := persistence.DeleteClusterGroup(c.Context(), namespace, name); err != nil {
-		slog.Warn("[ConsolePersistence] internal error", "error", err)
-		return c.Status(500).JSON(fiber.Map{"error": "internal server error"})
-	}
-
-	return c.SendStatus(204)
-}
+// CreateClusterGroup / UpdateClusterGroup / DeleteClusterGroup were removed
+// in #7993 Phase 2.5 and now live in kc-agent at /console-cr/groups. The
+// evaluateClusterGroup pre-population of Status.MatchedClusters that those
+// handlers used to do is now handled by the reconciler below on its next
+// reconcile pass — kc-agent creates the CR with just the spec, and the
+// reconciler (which is system-internal and legitimately uses the pod SA)
+// fills in the evaluated status on the next cycle.
 
 // evaluateClusterGroup evaluates which clusters match a group's criteria.
 // The context should be the inbound request context so that k8s calls are
@@ -738,127 +566,13 @@ func (h *ConsolePersistenceHandlers) GetWorkloadDeployment(c *fiber.Ctx) error {
 // asynchronous reconciliation to deploy the referenced workload manifests
 // to the resolved target clusters.
 //
-// POST /api/persistence/deployments
-func (h *ConsolePersistenceHandlers) CreateWorkloadDeployment(c *fiber.Ctx) error {
-	if err := h.requireAdmin(c); err != nil {
-		return err
-	}
-
-	var deployment v1alpha1.WorkloadDeployment
-	if err := c.BodyParser(&deployment); err != nil {
-		return c.Status(400).JSON(fiber.Map{"error": "Invalid request body"})
-	}
-
-	client, _, err := h.persistenceStore.GetActiveClient(c.Context())
-	if err != nil {
-		slog.Warn("[ConsolePersistence] service unavailable", "error", err)
-		return c.Status(503).JSON(fiber.Map{"error": "service unavailable"})
-	}
-
-	namespace := h.persistenceStore.GetNamespace()
-	persistence := k8s.NewConsolePersistence(client)
-
-	// Set namespace and metadata
-	deployment.Namespace = namespace
-	if deployment.APIVersion == "" {
-		deployment.APIVersion = v1alpha1.GroupVersion.String()
-	}
-	if deployment.Kind == "" {
-		deployment.Kind = "WorkloadDeployment"
-	}
-	deployment.CreationTimestamp = metav1.Now()
-
-	// Initialize status
-	now := metav1.Now()
-	deployment.Status.Phase = "Pending"
-	deployment.Status.StartedAt = &now
-
-	created, err := persistence.CreateWorkloadDeployment(c.Context(), &deployment)
-	if err != nil {
-		slog.Warn("[ConsolePersistence] internal error", "error", err)
-		return c.Status(500).JSON(fiber.Map{"error": "internal server error"})
-	}
-
-	// Kick off reconciliation in a background goroutine. Use a detached
-	// context with a timeout so reconciliation survives after the HTTP
-	// response is sent but cannot block indefinitely.
-	const reconcileTimeout = 5 * time.Minute // max wall-clock for full reconciliation
-	reconcileCtx, reconcileCancel := context.WithTimeout(context.Background(), reconcileTimeout)
-	go func() {
-		defer reconcileCancel()
-		h.reconcileDeployment(reconcileCtx, created)
-	}()
-
-	return c.Status(201).JSON(created)
-}
-
-// UpdateWorkloadDeploymentStatus updates the status of a workload deployment
-// PUT /api/persistence/deployments/:name/status
-func (h *ConsolePersistenceHandlers) UpdateWorkloadDeploymentStatus(c *fiber.Ctx) error {
-	if err := h.requireAdmin(c); err != nil {
-		return err
-	}
-
-	name := c.Params("name")
-
-	var status v1alpha1.WorkloadDeploymentStatus
-	if err := c.BodyParser(&status); err != nil {
-		return c.Status(400).JSON(fiber.Map{"error": "Invalid request body"})
-	}
-
-	client, _, err := h.persistenceStore.GetActiveClient(c.Context())
-	if err != nil {
-		slog.Warn("[ConsolePersistence] service unavailable", "error", err)
-		return c.Status(503).JSON(fiber.Map{"error": "service unavailable"})
-	}
-
-	namespace := h.persistenceStore.GetNamespace()
-	persistence := k8s.NewConsolePersistence(client)
-
-	// Get existing deployment
-	deployment, err := persistence.GetWorkloadDeployment(c.Context(), namespace, name)
-	if err != nil {
-		slog.Warn("[ConsolePersistence] internal error", "error", err)
-		return c.Status(500).JSON(fiber.Map{"error": "internal server error"})
-	}
-
-	// Update status
-	deployment.Status = status
-
-	updated, err := persistence.UpdateWorkloadDeploymentStatus(c.Context(), deployment)
-	if err != nil {
-		slog.Warn("[ConsolePersistence] internal error", "error", err)
-		return c.Status(500).JSON(fiber.Map{"error": "internal server error"})
-	}
-
-	return c.JSON(updated)
-}
-
-// DeleteWorkloadDeployment deletes a workload deployment
-// DELETE /api/persistence/deployments/:name
-func (h *ConsolePersistenceHandlers) DeleteWorkloadDeployment(c *fiber.Ctx) error {
-	if err := h.requireAdmin(c); err != nil {
-		return err
-	}
-
-	name := c.Params("name")
-
-	client, _, err := h.persistenceStore.GetActiveClient(c.Context())
-	if err != nil {
-		slog.Warn("[ConsolePersistence] service unavailable", "error", err)
-		return c.Status(503).JSON(fiber.Map{"error": "service unavailable"})
-	}
-
-	namespace := h.persistenceStore.GetNamespace()
-	persistence := k8s.NewConsolePersistence(client)
-
-	if err := persistence.DeleteWorkloadDeployment(c.Context(), namespace, name); err != nil {
-		slog.Warn("[ConsolePersistence] internal error", "error", err)
-		return c.Status(500).JSON(fiber.Map{"error": "internal server error"})
-	}
-
-	return c.SendStatus(204)
-}
+// CreateWorkloadDeployment / UpdateWorkloadDeploymentStatus /
+// DeleteWorkloadDeployment were removed in #7993 Phase 2.5. User-initiated CR
+// writes now go through kc-agent at /console-cr/deployments and
+// /console-cr/deployments/status. The reconciler that used to be kicked off
+// inline from the old CreateWorkloadDeployment handler now fires from
+// handleResourceEvent above when the watcher observes an ADDED event for a
+// WorkloadDeployment — the proper controller pattern.
 
 // reconcileDeployment handles the full lifecycle of deploying a workload to
 // target clusters. It:

--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -1201,24 +1201,19 @@ func (s *Server) setupRoutes() {
 	api.Get("/persistence/status", persistenceHandler.GetStatus)
 	api.Post("/persistence/sync", persistenceHandler.SyncNow)
 	api.Post("/persistence/test", persistenceHandler.TestConnection)
-	// ManagedWorkload endpoints
+	// ManagedWorkload endpoints — writes moved to kc-agent /console-cr/workloads
+	// (#7993 Phase 2.5). They run under the user's kubeconfig instead of the
+	// backend pod SA. List/Get remain until Phase 4.5.
 	api.Get("/persistence/workloads", persistenceHandler.ListManagedWorkloads)
 	api.Get("/persistence/workloads/:name", persistenceHandler.GetManagedWorkload)
-	api.Post("/persistence/workloads", persistenceHandler.CreateManagedWorkload)
-	api.Put("/persistence/workloads/:name", persistenceHandler.UpdateManagedWorkload)
-	api.Delete("/persistence/workloads/:name", persistenceHandler.DeleteManagedWorkload)
-	// ClusterGroup endpoints
+	// ClusterGroup endpoints — writes moved to kc-agent /console-cr/groups (#7993 Phase 2.5).
 	api.Get("/persistence/groups", persistenceHandler.ListClusterGroups)
 	api.Get("/persistence/groups/:name", persistenceHandler.GetClusterGroup)
-	api.Post("/persistence/groups", persistenceHandler.CreateClusterGroup)
-	api.Put("/persistence/groups/:name", persistenceHandler.UpdateClusterGroup)
-	api.Delete("/persistence/groups/:name", persistenceHandler.DeleteClusterGroup)
-	// WorkloadDeployment endpoints
+	// WorkloadDeployment endpoints — writes (including the status subresource)
+	// moved to kc-agent /console-cr/deployments and
+	// /console-cr/deployments/status (#7993 Phase 2.5).
 	api.Get("/persistence/deployments", persistenceHandler.ListWorkloadDeployments)
 	api.Get("/persistence/deployments/:name", persistenceHandler.GetWorkloadDeployment)
-	api.Post("/persistence/deployments", persistenceHandler.CreateWorkloadDeployment)
-	api.Put("/persistence/deployments/:name/status", persistenceHandler.UpdateWorkloadDeploymentStatus)
-	api.Delete("/persistence/deployments/:name", persistenceHandler.DeleteWorkloadDeployment)
 
 	// GitHub webhook (public endpoint, uses signature verification)
 	s.app.Post("/webhooks/github", feedback.HandleGitHubWebhook)

--- a/web/src/hooks/__tests__/useConsoleCRs.test.ts
+++ b/web/src/hooks/__tests__/useConsoleCRs.test.ts
@@ -13,7 +13,16 @@ import { renderHook, act, waitFor } from '@testing-library/react'
 // Mocks
 // ---------------------------------------------------------------------------
 
-const mockUsePersistence = vi.fn(() => ({ isEnabled: true, isActive: true }))
+// #7993 Phase 2.5: useConsoleCR now destructures activeCluster and
+// config.namespace from usePersistence() so it can target the kc-agent
+// /console-cr routes with the correct persistence cluster + namespace query
+// parameters. Tests pass both fields so the mutation helpers actually fire.
+const mockUsePersistence = vi.fn(() => ({
+  isEnabled: true,
+  isActive: true,
+  activeCluster: 'wds1',
+  config: { namespace: 'kubestellar-console' },
+}))
 vi.mock('../usePersistence', () => ({
   usePersistence: () => mockUsePersistence(),
 }))
@@ -79,7 +88,12 @@ describe('useConsoleCRs', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     mockFetch.mockReset()
-    mockUsePersistence.mockReturnValue({ isEnabled: true, isActive: true })
+    mockUsePersistence.mockReturnValue({
+      isEnabled: true,
+      isActive: true,
+      activeCluster: 'wds1',
+      config: { namespace: 'kubestellar-console' },
+    })
   })
 
   afterEach(() => {
@@ -103,7 +117,7 @@ describe('useConsoleCRs', () => {
     })
 
     it('skips fetch and sets loading=false when persistence is disabled', async () => {
-      mockUsePersistence.mockReturnValue({ isEnabled: false, isActive: false })
+      mockUsePersistence.mockReturnValue({ isEnabled: false, isActive: false, activeCluster: "", config: { namespace: "" } })
 
       const { result } = renderHook(() => useManagedWorkloads())
 
@@ -163,7 +177,7 @@ describe('useConsoleCRs', () => {
     })
 
     it('getItem returns null when persistence is disabled', async () => {
-      mockUsePersistence.mockReturnValue({ isEnabled: false, isActive: false })
+      mockUsePersistence.mockReturnValue({ isEnabled: false, isActive: false, activeCluster: "", config: { namespace: "" } })
 
       const { result } = renderHook(() => useManagedWorkloads())
       await waitFor(() => expect(result.current.loading).toBe(false))
@@ -214,7 +228,7 @@ describe('useConsoleCRs', () => {
     })
 
     it('createItem returns null when persistence is disabled', async () => {
-      mockUsePersistence.mockReturnValue({ isEnabled: false, isActive: false })
+      mockUsePersistence.mockReturnValue({ isEnabled: false, isActive: false, activeCluster: "", config: { namespace: "" } })
 
       const { result } = renderHook(() => useManagedWorkloads())
       await waitFor(() => expect(result.current.loading).toBe(false))
@@ -263,7 +277,7 @@ describe('useConsoleCRs', () => {
     })
 
     it('updateItem returns null when persistence is disabled', async () => {
-      mockUsePersistence.mockReturnValue({ isEnabled: false, isActive: false })
+      mockUsePersistence.mockReturnValue({ isEnabled: false, isActive: false, activeCluster: "", config: { namespace: "" } })
 
       const { result } = renderHook(() => useManagedWorkloads())
       await waitFor(() => expect(result.current.loading).toBe(false))
@@ -300,7 +314,7 @@ describe('useConsoleCRs', () => {
     })
 
     it('deleteItem returns false when persistence is disabled', async () => {
-      mockUsePersistence.mockReturnValue({ isEnabled: false, isActive: false })
+      mockUsePersistence.mockReturnValue({ isEnabled: false, isActive: false, activeCluster: "", config: { namespace: "" } })
 
       const { result } = renderHook(() => useManagedWorkloads())
       await waitFor(() => expect(result.current.loading).toBe(false))
@@ -380,12 +394,17 @@ describe('useConsoleCRs', () => {
         (c) => typeof c[0] === 'string' && c[0].includes('/status')
       )
       expect(statusCall).toBeDefined()
-      expect(statusCall![0]).toBe('/api/persistence/deployments/dep1/status')
+      // #7993 Phase 2.5: status updates go through kc-agent with the
+      // persistence cluster + namespace + name as query parameters.
+      expect(statusCall![0] as string).toMatch(/\/console-cr\/deployments\/status\?/)
+      expect(statusCall![0] as string).toContain('cluster=wds1')
+      expect(statusCall![0] as string).toContain('namespace=kubestellar-console')
+      expect(statusCall![0] as string).toContain('name=dep1')
       expect(statusCall![1].method).toBe('PUT')
     })
 
     it('updateStatus returns null when persistence is disabled', async () => {
-      mockUsePersistence.mockReturnValue({ isEnabled: false, isActive: false })
+      mockUsePersistence.mockReturnValue({ isEnabled: false, isActive: false, activeCluster: "", config: { namespace: "" } })
 
       const { result } = renderHook(() => useWorkloadDeployments())
       await waitFor(() => expect(result.current.loading).toBe(false))

--- a/web/src/hooks/useConsoleCRs.ts
+++ b/web/src/hooks/useConsoleCRs.ts
@@ -1,6 +1,6 @@
 import { useState, useEffect, useCallback, useRef } from 'react'
 import { usePersistence } from './usePersistence'
-import { FETCH_DEFAULT_TIMEOUT_MS } from '../lib/constants/network'
+import { FETCH_DEFAULT_TIMEOUT_MS, LOCAL_AGENT_HTTP_URL } from '../lib/constants/network'
 
 // =============================================================================
 // Types
@@ -177,17 +177,43 @@ interface Condition {
 // Generic CRUD hook factory
 // =============================================================================
 
+// consoleCRAgentEndpoint maps the legacy backend endpoint segment ("workloads",
+// "groups", "deployments") to the corresponding kc-agent route segment added
+// in #7993 Phase 2.5. Reads still go to the backend until Phase 4.5 migrates
+// the list/get handlers; writes go through the agent so they run under the
+// user's kubeconfig instead of the backend pod SA.
+const consoleCRAgentEndpoint: Record<string, string> = {
+  workloads: 'workloads',
+  groups: 'groups',
+  deployments: 'deployments' }
+
 function useConsoleCR<T extends { metadata: { name: string } }>(
   resourceType: string,
   endpoint: string
 ) {
-  const { isEnabled, isActive } = usePersistence()
+  const { isEnabled, isActive, activeCluster, config } = usePersistence()
   const [items, setItems] = useState<T[]>([])
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
   const isMounted = useRef(true)
 
   const shouldUseCRs = isEnabled && isActive
+  const persistenceNamespace = config.namespace
+
+  // agentWriteURL composes the kc-agent URL for a CR write. Cluster and
+  // namespace are query parameters so kc-agent can resolve the user's
+  // kubeconfig context for the persistence cluster. #7993 Phase 2.5.
+  const agentWriteURL = useCallback(
+    (extraPath = '', extraParams: Record<string, string> = {}) => {
+      const base = `${LOCAL_AGENT_HTTP_URL}/console-cr/${consoleCRAgentEndpoint[endpoint] ?? endpoint}${extraPath}`
+      const params = new URLSearchParams({
+        cluster: activeCluster,
+        namespace: persistenceNamespace,
+        ...extraParams })
+      return `${base}?${params.toString()}`
+    },
+    [endpoint, activeCluster, persistenceNamespace]
+  )
 
   // Fetch all items
   const fetchItems = useCallback(async () => {
@@ -236,12 +262,16 @@ function useConsoleCR<T extends { metadata: { name: string } }>(
     return null
   }
 
-  // Create item
+  // Create item — routed through kc-agent (#7993 Phase 2.5).
   const createItem = async (item: Omit<T, 'metadata'> & { metadata: { name: string } }): Promise<T | null> => {
     if (!shouldUseCRs) return null
+    if (!activeCluster || !persistenceNamespace) {
+      console.error(`[useConsoleCR] cannot create ${resourceType}: persistence cluster or namespace not set`)
+      return null
+    }
 
     try {
-      const response = await fetch(`/api/persistence/${endpoint}`, {
+      const response = await fetch(agentWriteURL(), {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(item),
@@ -258,12 +288,16 @@ function useConsoleCR<T extends { metadata: { name: string } }>(
     return null
   }
 
-  // Update item
+  // Update item — routed through kc-agent (#7993 Phase 2.5).
   const updateItem = async (name: string, item: Partial<T>): Promise<T | null> => {
     if (!shouldUseCRs) return null
+    if (!activeCluster || !persistenceNamespace) {
+      console.error(`[useConsoleCR] cannot update ${resourceType}: persistence cluster or namespace not set`)
+      return null
+    }
 
     try {
-      const response = await fetch(`/api/persistence/${endpoint}/${name}`, {
+      const response = await fetch(agentWriteURL('', { name }), {
         method: 'PUT',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(item),
@@ -280,12 +314,16 @@ function useConsoleCR<T extends { metadata: { name: string } }>(
     return null
   }
 
-  // Delete item
+  // Delete item — routed through kc-agent (#7993 Phase 2.5).
   const deleteItem = async (name: string): Promise<boolean> => {
     if (!shouldUseCRs) return false
+    if (!activeCluster || !persistenceNamespace) {
+      console.error(`[useConsoleCR] cannot delete ${resourceType}: persistence cluster or namespace not set`)
+      return false
+    }
 
     try {
-      const response = await fetch(`/api/persistence/${endpoint}/${name}`, {
+      const response = await fetch(agentWriteURL('', { name }), {
         method: 'DELETE',
         signal: AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS) })
       if (response.ok || response.status === 204) {
@@ -336,18 +374,25 @@ export function useClusterGroups() {
 
 export function useWorkloadDeployments() {
   const base = useConsoleCR<WorkloadDeployment>('WorkloadDeployment', 'deployments')
-  const { isEnabled, isActive } = usePersistence()
+  const { isEnabled, isActive, activeCluster, config } = usePersistence()
   const shouldUseCRs = isEnabled && isActive
+  const persistenceNamespace = config.namespace
 
-  // Additional status update method
+  // Additional status update method — routed through kc-agent (#7993 Phase 2.5).
   const updateStatus = async (
     name: string,
     status: WorkloadDeploymentStatus
   ): Promise<WorkloadDeployment | null> => {
     if (!shouldUseCRs) return null
+    if (!activeCluster || !persistenceNamespace) {
+      console.error('[useWorkloadDeployments] cannot update status: persistence cluster or namespace not set')
+      return null
+    }
 
     try {
-      const response = await fetch(`/api/persistence/deployments/${name}/status`, {
+      const params = new URLSearchParams({ cluster: activeCluster, namespace: persistenceNamespace, name })
+      const url = `${LOCAL_AGENT_HTTP_URL}/console-cr/deployments/status?${params.toString()}`
+      const response = await fetch(url, {
         method: 'PUT',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(status),


### PR DESCRIPTION
## Summary

Phase 2.5 of the pod-SA → kc-agent refactor (#7993). User-initiated writes to the console's own CRDs (ManagedWorkload / ClusterGroup / WorkloadDeployment) now run under the user's kubeconfig via kc-agent instead of the backend pod ServiceAccount. The reconciler stays in the backend as a new legitimate pod-SA exception: **system-internal reconcilers** react to CR state changes without a human in the loop.

Refs #7993.

## What moved

**9 backend CUD handlers deleted** from \`pkg/api/handlers/console_persistence.go\`:
- \`CreateManagedWorkload\` / \`UpdateManagedWorkload\` / \`DeleteManagedWorkload\`
- \`CreateClusterGroup\` / \`UpdateClusterGroup\` / \`DeleteClusterGroup\`
- \`CreateWorkloadDeployment\` / \`UpdateWorkloadDeploymentStatus\` / \`DeleteWorkloadDeployment\`

**New kc-agent routes** in \`pkg/agent/server_console_cr.go\`:
- \`POST/PUT/DELETE /console-cr/workloads\`
- \`POST/PUT/DELETE /console-cr/groups\`
- \`POST/DELETE /console-cr/deployments\`
- \`PUT /console-cr/deployments/status\`

Each handler is a thin wrapper that resolves \`?cluster=X&namespace=Y\` (already exposed by the frontend's \`usePersistence()\` as \`activeCluster\` + \`config.namespace\`), gets the dynamic client for the user's kubeconfig context, and delegates to the shared \`pkg/k8s.ConsolePersistence\` methods — zero duplication of the CR CRUD logic.

## Reconciler stays

The reconciler (\`reconcileDeployment\`, \`evaluateClusterGroup\`, \`clusterMatchesFilters\`, \`resolveManagedWorkload\`, \`resolveTargetClusters\`, \`setTerminalStatus\`, \`SyncNow\`, the watcher, and all the read handlers) all stay in the backend. They're system-internal — they react to CR state changes without a user in the loop — and legitimately use the pod SA.

**Reconcile trigger rewire**: \`CreateWorkloadDeployment\` used to fire reconciliation inline from the request goroutine. With the backend handler gone, \`handleResourceEvent\` now triggers \`reconcileDeployment\` when the watcher observes an \`ADDED\` event on a \`WorkloadDeployment\` — the proper controller pattern. Same 5-minute detached context, same function call.

\`ClusterGroup\` writes used to pre-populate \`Status.MatchedClusters\` via \`evaluateClusterGroup\` before persisting; with the backend handler gone, the reconciler fills that in on its next pass.

## Frontend

\`web/src/hooks/useConsoleCRs.ts\`:
- \`useConsoleCR\` destructures \`activeCluster\` + \`config.namespace\` from \`usePersistence()\` and routes \`createItem\`/\`updateItem\`/\`deleteItem\` through \`\${LOCAL_AGENT_HTTP_URL}/console-cr/<kind>\` with both as query parameters.
- \`useWorkloadDeployments.updateStatus\` routes through \`/console-cr/deployments/status\`.
- \`consoleCRAgentEndpoint\` maps the legacy path segment (\`workloads\`/\`groups\`/\`deployments\`) to the corresponding kc-agent segment so the migration is a pure URL swap.
- Reads still hit \`/api/persistence/\`\* — Phase 4.5 migrates those.

Tests updated: mock includes \`activeCluster\` + \`config\`; \`updateStatus\` assertion verifies the kc-agent URL with \`cluster\`/\`namespace\`/\`name\` query parameters. All 28 vitest cases pass.

## Test plan
- [x] \`go build ./...\` green
- [x] \`go vet ./pkg/api/... ./pkg/agent/...\` clean
- [x] \`go test ./pkg/api/handlers/ -run TestClusterMatches|TestResolveTargetClusters|TestResolveManagedWorkload|TestReconcileDeployment|TestSetTerminalStatus\` — all pass (reconciler logic unchanged)
- [x] \`npx vitest run src/hooks/__tests__/useConsoleCRs.test.ts\` — 28/28 pass
- [x] \`npm run build\` — green, all post-build safety checks pass
- [ ] Manual: on an in-cluster install with kc-agent running locally, create a ManagedWorkload, confirm it lands on the persistence cluster as the user's identity
- [ ] Manual: create a WorkloadDeployment, confirm the reconciler fires via the watcher and reconciles to the target clusters as before