### PR TITLE
🔐 ci: add Privileged Client Lint to enforce #7993 architectural rule

### DIFF
--- a/.github/allowlist-privileged-client-callers.txt
+++ b/.github/allowlist-privileged-client-callers.txt
@@ -1,0 +1,30 @@
+# Allowlist for the "Privileged Client Lint" CI check
+# (.github/workflows/privileged-client-lint.yml).
+#
+# Each non-comment line is a file **basename** in pkg/api/handlers/ that is
+# permitted to call `h.k8sClient.(Create|Update|Delete|Patch)…`,
+# `s.k8sClient.(Create|Update|Delete|Patch)…`, or
+# `persistence.(Create|Update|Delete)…` against a managed cluster using the
+# backend pod ServiceAccount.
+#
+# The architectural rule (#7993): all user-initiated k8s mutations must run
+# under the caller's own kubeconfig via kc-agent. The only legitimate
+# pod-SA exceptions are:
+#
+# 1. GPU reservation — creating a namespace + setting a ResourceQuota on it.
+#    Users cannot create namespaces or set quotas themselves; the console is
+#    the authorized policy layer.
+#
+# 2. Self-upgrade — the console pod patching its own Deployment. No other
+#    identity could perform a self-upgrade.
+#
+# 3. System-internal reconcilers — CR watchers that react to state changes
+#    without a human in the loop. User-initiated CR writes go through
+#    kc-agent at /console-cr/* (#7993 Phase 2.5).
+#
+# Adding a new file to this allowlist is a security decision. Do it in the
+# same PR as the new exception and explain the rationale in the PR body.
+
+mcp_resources.go
+self_upgrade.go
+console_persistence.go

--- a/.github/workflows/privileged-client-lint.yml
+++ b/.github/workflows/privileged-client-lint.yml
@@ -1,0 +1,122 @@
+name: Privileged Client Lint
+
+# Prevents new code from using the backend pod ServiceAccount to perform
+# user-initiated k8s mutations against managed clusters. All such operations
+# must go through kc-agent at LOCAL_AGENT_HTTP_URL / LOCAL_AGENT_WS_URL with
+# the user's own kubeconfig — see issue #7993 and the phase sequence it
+# tracks.
+#
+# The rule: a Fiber handler in pkg/api/handlers/ may not call
+#   h.k8sClient.(Create|Update|Delete|Patch)...
+#   s.k8sClient.(Create|Update|Delete|Patch)...
+#   persistence.(Create|Update|Delete)...
+# outside an explicit allowlist of files that legitimately use the pod SA.
+#
+# Legitimate exceptions (allowlist):
+#   mcp_resources.go     — GPU reservation (ResourceQuota + GPU-specific
+#                          namespace path). Users cannot create namespaces or
+#                          set quotas themselves; the console is the
+#                          authorized policy layer.
+#   self_upgrade.go      — The console pod patches its own Deployment. No
+#                          other identity could perform a self-upgrade.
+#   console_persistence.go — The reconciler (StartWatcher, reconcileDeployment,
+#                          evaluateClusterGroup, resolveManagedWorkload,
+#                          resolveTargetClusters, setTerminalStatus,
+#                          SyncNow, UpdateConfig) is system-internal: it
+#                          reacts to CR state changes without a human in the
+#                          loop and legitimately uses the pod SA. User-
+#                          initiated CR writes go through kc-agent at
+#                          /console-cr/* (#7993 Phase 2.5).
+#
+# This workflow runs on every PR that touches pkg/api/handlers/ or the
+# workflow itself so that an architectural regression is caught at review
+# time, not after it has shipped.
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'pkg/api/handlers/**.go'
+      - '.github/workflows/privileged-client-lint.yml'
+      - '.github/allowlist-privileged-client-callers.txt'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  verify:
+    name: Verify no new pod-SA mutations in handlers
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Scan for disallowed privileged client calls
+        run: |
+          set -euo pipefail
+
+          ALLOWLIST_FILE=".github/allowlist-privileged-client-callers.txt"
+          HANDLER_DIR="pkg/api/handlers"
+
+          if [ ! -f "$ALLOWLIST_FILE" ]; then
+            echo "::error::Allowlist file $ALLOWLIST_FILE is missing"
+            exit 1
+          fi
+
+          # Load allowlist (one basename per line, # comments ignored).
+          ALLOWED_BASENAMES=$(grep -vE '^\s*(#|$)' "$ALLOWLIST_FILE" | sort -u)
+          echo "Allowed basenames:"
+          echo "$ALLOWED_BASENAMES" | sed 's/^/  /'
+          echo
+
+          # The three patterns to guard:
+          #   h.k8sClient.(Create|Update|Delete|Patch)<Name>
+          #   s.k8sClient.(Create|Update|Delete|Patch)<Name>
+          #   persistence.(Create|Update|Delete)<Name>
+          # where <Name> starts with an uppercase letter so we only catch
+          # exported mutation methods on the MultiClusterClient /
+          # ConsolePersistence facades (not arbitrary local vars or
+          # lower-case helpers).
+          PATTERN='(h\.k8sClient|s\.k8sClient)\.(Create|Update|Delete|Patch)[A-Z][A-Za-z0-9_]*\(|persistence\.(Create|Update|Delete)[A-Z][A-Za-z0-9_]*\('
+
+          # List candidate matches across the handler dir, excluding tests.
+          CANDIDATES=$(grep -rEn "$PATTERN" "$HANDLER_DIR" --include='*.go' | grep -v '_test\.go' || true)
+
+          if [ -z "$CANDIDATES" ]; then
+            echo "PASS: no privileged-client mutations found in $HANDLER_DIR"
+            exit 0
+          fi
+
+          # Filter out allowlisted files.
+          DISALLOWED=""
+          while IFS= read -r line; do
+            file_path=$(printf '%s' "$line" | cut -d: -f1)
+            base=$(basename "$file_path")
+            if ! printf '%s\n' "$ALLOWED_BASENAMES" | grep -qx "$base"; then
+              DISALLOWED="$DISALLOWED$line"$'\n'
+            fi
+          done <<< "$CANDIDATES"
+
+          if [ -z "$DISALLOWED" ]; then
+            echo "PASS: all privileged-client mutations in $HANDLER_DIR are in allowlisted files"
+            echo "$CANDIDATES"
+            exit 0
+          fi
+
+          echo "::error::Found privileged-client mutation(s) in non-allowlisted file(s)."
+          echo
+          echo "The backend pod ServiceAccount may only be used for the GPU"
+          echo "reservation exception (mcp_resources.go ResourceQuota handlers),"
+          echo "the console self-upgrade (self_upgrade.go), and the system-"
+          echo "internal persistence reconciler (console_persistence.go)."
+          echo "Every other k8s mutation must go through kc-agent at"
+          echo "LOCAL_AGENT_HTTP_URL with the user's kubeconfig — see #7993."
+          echo
+          echo "Disallowed call sites:"
+          printf '%s' "$DISALLOWED"
+          echo
+          echo "If you believe this is a legitimate new exception, update"
+          echo "$ALLOWLIST_FILE in the same PR and explain the reason in the"
+          echo "PR description."
+          exit 1


### PR DESCRIPTION
## Summary

Lands the Phase 5 CI guard early so #7993's architectural rule is enforced on every PR to \`pkg/api/handlers/\`, even while the remaining refactor phases (3d-A exec WebSocket port, 4.5 read-leak sweep, the rest of Phase 5) are still in flight.

**The rule**: backend handlers may not call

\`\`\`
h.k8sClient.(Create|Update|Delete|Patch)...
s.k8sClient.(Create|Update|Delete|Patch)...
persistence.(Create|Update|Delete)...
\`\`\`

against a managed cluster using the pod ServiceAccount unless the file is on an explicit allowlist. All user-initiated mutations must go through kc-agent at \`LOCAL_AGENT_HTTP_URL\` / \`LOCAL_AGENT_WS_URL\` with the caller's own kubeconfig.

Refs #7993.

## Allowlist (the legitimate pod-SA exceptions)

| File | Reason |
|---|---|
| \`mcp_resources.go\` | GPU reservation — \`CreateOrUpdateResourceQuota\` + \`DeleteResourceQuota\`. Users cannot create namespaces or set quotas themselves; the console is the authorized policy layer. |
| \`self_upgrade.go\` | The console pod patches its own Deployment. No other identity could perform a self-upgrade. |
| \`console_persistence.go\` | The reconciler (StartWatcher, reconcileDeployment, evaluateClusterGroup, setTerminalStatus) is system-internal — it reacts to CR state changes without a human in the loop and legitimately uses the pod SA. User-initiated CR writes go through kc-agent at \`/console-cr/*\` per Phase 2.5 (merged as #8159). |

Adding a new file to the allowlist is a security decision and requires explaining the rationale in the PR body.

## What it catches

Verified locally on current main (post Phase 2.5):

\`\`\`
pkg/api/handlers/mcp_resources.go:811:      quota, err := h.k8sClient.CreateOrUpdateResourceQuota(...)
pkg/api/handlers/mcp_resources.go:847:      err := h.k8sClient.DeleteResourceQuota(...)
pkg/api/handlers/console_persistence.go:601: updated, err := persistence.UpdateWorkloadDeploymentStatus(...)
\`\`\`

All 3 hits are in allowlisted files → lint passes. If anyone adds a new privileged call in a non-allowlisted file, the CI check fails with an actionable message naming the file + line and pointing at #7993 for context.

## How it works

- Path-filtered workflow: runs on every PR that touches \`pkg/api/handlers/\` or the workflow itself.
- One bash step that greps for the three patterns, filters out allowlisted basenames, and fails if anything remains.
- Error output includes the specific line(s), the rationale, and instructions for updating the allowlist if the exception is legitimate.

No Go code changes in this PR. Pure additive CI guard.

## Test plan
- [x] Dry-run locally on post-Phase-2.5 main — 3 hits, all allowlisted, PASS
- [x] YAML syntax validated
- [ ] CI runs the workflow on this PR itself — should PASS (no handler file changes)
- [ ] Next PR that touches \`pkg/api/handlers/\` will exercise the check against a real diff