### PR TITLE
🐛 fix: Resource Tree Issues filter

### DIFF
--- a/web/src/components/cards/cluster-resource-tree/ClusterResourceTree.tsx
+++ b/web/src/components/cards/cluster-resource-tree/ClusterResourceTree.tsx
@@ -458,8 +458,22 @@ export function ClusterResourceTree({ config: _config }: ClusterResourceTreeProp
                     </div>
                   )}
 
-                  {/* Nodes section - use cached data */}
-                  {(activeLens === 'all' || activeLens === 'nodes' || activeLens === 'issues') && clusterExpanded && hasData && clusterData.nodes.length > 0 && (
+                  {/* Empty-state hint when the Issues lens has no matching
+                      resources in this cluster. Without this, the tree
+                      collapses to a silent blank after switching from the
+                      All lens (see issue: Resource tree disappears when
+                      filtering by Issues after notification navigation). */}
+                  {clusterExpanded && hasData && activeLens === 'issues' && visibleNs.length === 0 && issueCounts.nodes === 0 && (
+                    <div className="flex items-center gap-2 px-2 py-1.5 ml-8 text-xs text-muted-foreground">
+                      {t('resourceTree.noIssuesFound')}
+                    </div>
+                  )}
+
+                  {/* Nodes section - use cached data. In the Issues lens
+                      we only render this section when there is at least
+                      one unhealthy node, otherwise switching to Issues
+                      would still surface a full Ready-node list. */}
+                  {(activeLens === 'all' || activeLens === 'nodes' || (activeLens === 'issues' && issueCounts.nodes > 0)) && clusterExpanded && hasData && clusterData.nodes.length > 0 && (
                     <TreeNode
                       id={`${clusterId}:nodes`}
                       label={t('resourceTree.nodes')}

--- a/web/src/components/cards/cluster-resource-tree/TreeBuilder.ts
+++ b/web/src/components/cards/cluster-resource-tree/TreeBuilder.ts
@@ -1,39 +1,72 @@
 import type { ClusterDataCache, NamespaceResources, TreeLens, IssueCounts } from './types'
 
 /**
+ * Default restart count used when seeding a pod row from the podIssues
+ * endpoint, which does not report restart counts. Keeping this as a named
+ * constant avoids a magic number in the merge logic below.
+ */
+const POD_ISSUE_DEFAULT_RESTARTS = 0
+
+/** Factory that returns an empty NamespaceResources record. */
+function createEmptyNamespaceResources(): NamespaceResources {
+  return {
+    deployments: [],
+    services: [],
+    pvcs: [],
+    pods: [],
+    configmaps: [],
+    secrets: [],
+    serviceaccounts: [],
+    jobs: [],
+    hpas: [],
+    replicasets: [],
+    statefulsets: [],
+    daemonsets: [],
+    cronjobs: [],
+    ingresses: [],
+    networkpolicies: [],
+  }
+}
+
+/**
+ * Returns true when a pod row represents an issue (not Running/Succeeded).
+ * Centralizing this keeps the "what counts as a pod issue" definition in
+ * sync between the namespace filter and the namespace badge.
+ */
+function isPodIssueStatus(status: string): boolean {
+  return status !== 'Running' && status !== 'Succeeded'
+}
+
+/**
  * Build a map of namespace -> resources from cached cluster data.
  * Optionally filters namespaces by a search query.
+ *
+ * Pods from clusterData.podIssues (a separate API endpoint than the bulk
+ * pods list) are merged into each namespace's pods so the Issues lens and
+ * the top-of-card issues badge stay in sync. Without this merge, the badge
+ * could report "1 issue" while the tree collapsed to an empty state when
+ * the issue-bearing pod was not present in the limited bulk pods response.
  */
 export function buildNamespaceResources(clusterData: ClusterDataCache, searchFilter: string): Map<string, NamespaceResources> {
   const map = new Map<string, NamespaceResources>()
 
-  // Filter namespaces based on search
-  let namespaces = clusterData.namespaces || []
-  if (searchFilter) {
-    const query = searchFilter.toLowerCase()
-    namespaces = namespaces.filter((ns: string) => ns.toLowerCase().includes(query))
-  }
+  const query = searchFilter ? searchFilter.toLowerCase() : ''
+  const matchesSearch = (ns: string): boolean => !query || ns.toLowerCase().includes(query)
 
-  // Initialize all namespaces
+  // Filter namespaces based on search, then initialize records
+  const namespaces = (clusterData.namespaces || []).filter(matchesSearch)
   namespaces.forEach((ns: string) => {
-    map.set(ns, {
-      deployments: [],
-      services: [],
-      pvcs: [],
-      pods: [],
-      configmaps: [],
-      secrets: [],
-      serviceaccounts: [],
-      jobs: [],
-      hpas: [],
-      replicasets: [],
-      statefulsets: [],
-      daemonsets: [],
-      cronjobs: [],
-      ingresses: [],
-      networkpolicies: [],
-    })
+    map.set(ns, createEmptyNamespaceResources())
   })
+
+  // Ensure namespaces that appear only in podIssues are still represented.
+  // Otherwise a pod issue in a namespace missing from the bulk namespace
+  // listing would silently disappear from the Issues lens.
+  for (const p of clusterData.podIssues || []) {
+    if (!map.has(p.namespace) && matchesSearch(p.namespace)) {
+      map.set(p.namespace, createEmptyNamespaceResources())
+    }
+  }
 
   // Group deployments
   for (const d of clusterData.deployments) {
@@ -70,6 +103,25 @@ export function buildNamespaceResources(clusterData: ClusterDataCache, searchFil
         restarts: p.restarts,
       })
     }
+  }
+
+  // Merge podIssues into namespace pods. The bulk pods list is capped per
+  // request and may omit pods that are included in the dedicated podIssues
+  // endpoint. Dedupe by (namespace, name) so we do not double-count pods
+  // that exist in both lists.
+  for (const issue of clusterData.podIssues || []) {
+    const nsData = map.get(issue.namespace)
+    if (!nsData) continue
+    const alreadyPresent = nsData.pods.some(
+      existing => existing.name === issue.name,
+    )
+    if (alreadyPresent) continue
+    nsData.pods.push({
+      name: issue.name,
+      namespace: issue.namespace,
+      status: issue.status,
+      restarts: POD_ISSUE_DEFAULT_RESTARTS,
+    })
   }
 
   // Group ConfigMaps
@@ -207,7 +259,7 @@ export function getVisibleNamespaces(
   if (activeLens === 'issues') {
     filtered = filtered.filter(ns => {
       const resources = namespaceResources.get(ns)!
-      return resources.pods.some(p => p.status !== 'Running' && p.status !== 'Succeeded') ||
+      return resources.pods.some(p => isPodIssueStatus(p.status)) ||
              resources.deployments.some(d => d.readyReplicas < d.replicas) ||
              resources.pvcs.some(p => p.status !== 'Bound')
     })

--- a/web/src/locales/en/common.json
+++ b/web/src/locales/en/common.json
@@ -1291,6 +1291,7 @@
     "loadingResources": "Loading resources...",
     "viewClusterDetails": "View cluster details →",
     "noClustersMatch": "No clusters match the current filter",
+    "noIssuesFound": "No resources with issues in this cluster",
     "nodesCount": "{{count}} nodes",
     "nodesCount_one": "{{count}} node",
     "nodesCount_other": "{{count}} nodes",


### PR DESCRIPTION
Fixes #8155

## Problem

In the Resource Tree card, switching the lens from **All** to **Issues** made the tree disappear even though the cluster's issue badge showed `1`. Under **All**, the tree rendered namespaces and resources normally.

Root cause: `getIssueCounts()` counts pods from `clusterData.podIssues` (a dedicated endpoint), but `getVisibleNamespaces()` filtered namespaces by scanning each namespace's own `pods` array — which comes from the capped bulk pods response. When the issue-bearing pod was not present in the bulk pods response, every namespace was filtered out, the tree collapsed to empty, and the Nodes section still rendered a full Ready-node list (misleading for an "Issues" lens).

## Fix

- `TreeBuilder.buildNamespaceResources` now merges `clusterData.podIssues` into each namespace's pods (deduped by `(namespace, name)`) and seeds an empty `NamespaceResources` record for namespaces that appear only in `podIssues`. This keeps the Issues-lens namespace filter in sync with the issue badge.
- `ClusterResourceTree` renders an explicit empty-state hint (`No resources with issues in this cluster`) in the Issues lens when no resources match, so users see a message instead of a silent blank.
- The Nodes section is only rendered under the Issues lens when `issueCounts.nodes > 0`, so the Issues lens no longer shows a full list of healthy nodes.
- Extracted `createEmptyNamespaceResources()` and `isPodIssueStatus()` helpers to keep the "what counts as a pod issue" definition consistent across the merge and filter paths.

## Test plan

- [x] `npm run build` passes
- [x] `npm run lint` — no new errors (baseline 361 errors on `main`, unchanged after this change)
- [x] `vitest run cluster-resource-tree` passes
- [ ] Manual: navigate via a cluster notification, open Resource Tree, switch to Issues lens, verify the tree still renders (or shows the empty-state hint when there really are no issues)