### PR TITLE
✨ feat: add Groq as AI provider

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -70,8 +70,19 @@ OPENROUTER_MODEL=
 # Optional base URL override for self-hosted OpenRouter proxies.
 OPENROUTER_BASE_URL=
 
+# Groq API (https://console.groq.com/keys)
+# OpenAI-compatible chat completions backed by Groq's LPU inference hardware,
+# yielding very low latency for Llama, Mixtral, Gemma and other open-weights
+# models. See https://console.groq.com/docs/openai for wire-format details.
+GROQ_API_KEY=
+# Model selection (optional - default: llama-3.3-70b-versatile). See
+# https://console.groq.com/docs/models for the full catalog.
+GROQ_MODEL=
+# Optional base URL override for self-hosted Groq proxies.
+GROQ_BASE_URL=
+
 # Default AI agent (optional - auto-detected based on available keys)
-# Options: claude, openai, gemini, openrouter
+# Options: claude, openai, gemini, openrouter, groq
 DEFAULT_AGENT=
 
 # ===========================================

--- a/pkg/agent/config.go
+++ b/pkg/agent/config.go
@@ -304,6 +304,8 @@ func getEnvKeyForProvider(provider string) string {
 		return "OPEN_WEBUI_API_KEY"
 	case "openrouter":
 		return "OPENROUTER_API_KEY"
+	case "groq":
+		return "GROQ_API_KEY"
 	case "goose":
 		return "GOOSE_PROVIDER"
 	default:
@@ -327,6 +329,8 @@ func getModelEnvKeyForProvider(provider string) string {
 		return "OPEN_WEBUI_MODEL"
 	case "openrouter":
 		return "OPENROUTER_MODEL"
+	case "groq":
+		return "GROQ_MODEL"
 	case "goose":
 		return "GOOSE_MODEL"
 	default:

--- a/pkg/agent/provider_groq.go
+++ b/pkg/agent/provider_groq.go
@@ -1,0 +1,94 @@
+package agent
+
+import (
+	"context"
+	"os"
+)
+
+// Groq (https://groq.com) offers an OpenAI-compatible chat completions API
+// backed by their custom LPU inference hardware, yielding very low latency
+// for Llama, Mixtral, Gemma, and other open-weights models. See
+// https://console.groq.com/docs/openai for wire-format details.
+//
+// Because the wire format is OpenAI-compatible, this provider reuses the
+// shared chatViaOpenAICompatible* helpers. The only Groq-specific bits are
+// (a) the default base URL and (b) a curated default model.
+
+const (
+	// groqProviderKey is the config-manager key used for the API key and
+	// model preference on disk and in the env-var lookup tables.
+	groqProviderKey = "groq"
+
+	// groqDefaultBaseURL is the public Groq OpenAI-compatible v1 base URL.
+	// It can be overridden with the GROQ_BASE_URL environment variable for
+	// self-hosted / enterprise Groq proxies.
+	groqDefaultBaseURL = "https://api.groq.com/openai/v1"
+
+	// groqChatCompletionsPath is appended to the base URL to form the
+	// OpenAI-compatible chat completions endpoint.
+	groqChatCompletionsPath = "/chat/completions"
+
+	// groqDefaultModel is a sensible, generally-available default. Users
+	// can pick any model listed at https://console.groq.com/docs/models
+	// via the GROQ_MODEL env var or the settings UI.
+	groqDefaultModel = "llama-3.3-70b-versatile"
+
+	// groqValidationURL is the Groq models listing endpoint. It returns
+	// 200 for any valid API key and 401 otherwise, so it's a cheap way to
+	// check credentials without spending tokens on a chat completion.
+	groqValidationURL = "https://api.groq.com/openai/v1/models"
+)
+
+// GroqProvider implements AIProvider for Groq (https://groq.com).
+type GroqProvider struct {
+	baseURL string
+}
+
+// NewGroqProvider constructs a provider using the default base URL,
+// overridable via GROQ_BASE_URL.
+func NewGroqProvider() *GroqProvider {
+	baseURL := groqDefaultBaseURL
+	if v := os.Getenv("GROQ_BASE_URL"); v != "" {
+		baseURL = v
+	}
+	return &GroqProvider{baseURL: baseURL}
+}
+
+func (g *GroqProvider) Name() string        { return "groq" }
+func (g *GroqProvider) DisplayName() string { return "Groq" }
+func (g *GroqProvider) Provider() string    { return "groq" }
+func (g *GroqProvider) Description() string {
+	return "Groq - ultra-low-latency inference on LPU hardware for Llama, Mixtral, Gemma and other open-weights models"
+}
+
+func (g *GroqProvider) IsAvailable() bool {
+	// Dynamic check so keys added via settings take effect without a restart.
+	return GetConfigManager().IsKeyAvailable(groqProviderKey)
+}
+
+func (g *GroqProvider) Capabilities() ProviderCapability {
+	return CapabilityChat
+}
+
+// endpoint returns the fully qualified chat completions URL.
+func (g *GroqProvider) endpoint() string {
+	base := g.baseURL
+	if base == "" {
+		base = groqDefaultBaseURL
+	}
+	return base + groqChatCompletionsPath
+}
+
+// Chat sends a message and returns the complete response.
+func (g *GroqProvider) Chat(ctx context.Context, req *ChatRequest) (*ChatResponse, error) {
+	return chatViaOpenAICompatibleWithHeaders(
+		ctx, req, groqProviderKey, g.endpoint(), g.Name(), groqDefaultModel, nil,
+	)
+}
+
+// StreamChat sends a message and streams the response.
+func (g *GroqProvider) StreamChat(ctx context.Context, req *ChatRequest, onChunk func(chunk string)) (*ChatResponse, error) {
+	return streamViaOpenAICompatibleWithHeaders(
+		ctx, req, groqProviderKey, g.endpoint(), g.Name(), groqDefaultModel, onChunk, nil,
+	)
+}

--- a/pkg/agent/provider_groq_test.go
+++ b/pkg/agent/provider_groq_test.go
@@ -1,0 +1,75 @@
+package agent
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestGroqProvider_Basics(t *testing.T) {
+	p := NewGroqProvider()
+
+	if p.Name() != "groq" {
+		t.Errorf("Expected 'groq', got %q", p.Name())
+	}
+	if p.DisplayName() != "Groq" {
+		t.Errorf("Expected 'Groq', got %q", p.DisplayName())
+	}
+	if p.Provider() != "groq" {
+		t.Errorf("Expected 'groq', got %q", p.Provider())
+	}
+	if p.Description() == "" {
+		t.Error("Description should not be empty")
+	}
+}
+
+func TestGroqProvider_Capabilities(t *testing.T) {
+	p := &GroqProvider{}
+
+	if p.Capabilities()&CapabilityChat == 0 {
+		t.Error("Expected CapabilityChat to be set")
+	}
+}
+
+func TestGroqProvider_Interface(t *testing.T) {
+	var _ AIProvider = &GroqProvider{}
+}
+
+// TestGroqProvider_DefaultBaseURL ensures NewGroqProvider uses the public
+// Groq endpoint when GROQ_BASE_URL is not set.
+func TestGroqProvider_DefaultBaseURL(t *testing.T) {
+	t.Setenv("GROQ_BASE_URL", "")
+	p := NewGroqProvider()
+
+	got := p.endpoint()
+	want := groqDefaultBaseURL + groqChatCompletionsPath
+	if got != want {
+		t.Errorf("endpoint() = %q, want %q", got, want)
+	}
+}
+
+// TestGroqProvider_BaseURLOverride ensures GROQ_BASE_URL overrides the
+// default (useful for self-hosted proxies).
+func TestGroqProvider_BaseURLOverride(t *testing.T) {
+	override := "https://proxy.example.com/v1"
+	t.Setenv("GROQ_BASE_URL", override)
+	p := NewGroqProvider()
+
+	got := p.endpoint()
+	if !strings.HasPrefix(got, override) {
+		t.Errorf("endpoint() = %q, expected prefix %q", got, override)
+	}
+	if !strings.HasSuffix(got, groqChatCompletionsPath) {
+		t.Errorf("endpoint() = %q, expected suffix %q", got, groqChatCompletionsPath)
+	}
+}
+
+// TestGetEnvKeyForProvider_Groq guards the env-var mapping used by
+// ConfigManager.GetAPIKey so GROQ_API_KEY continues to be honored.
+func TestGetEnvKeyForProvider_Groq(t *testing.T) {
+	if got := getEnvKeyForProvider("groq"); got != "GROQ_API_KEY" {
+		t.Errorf("getEnvKeyForProvider(groq) = %q, want %q", got, "GROQ_API_KEY")
+	}
+	if got := getModelEnvKeyForProvider("groq"); got != "GROQ_MODEL" {
+		t.Errorf("getModelEnvKeyForProvider(groq) = %q, want %q", got, "GROQ_MODEL")
+	}
+}

--- a/pkg/agent/server_operations.go
+++ b/pkg/agent/server_operations.go
@@ -412,6 +412,8 @@ func (s *Server) validateAPIKeyValue(provider, apiKey string) (bool, error) {
 		return validateGeminiKey(ctx, apiKey)
 	case "openrouter":
 		return validateOpenRouterKey(ctx, apiKey)
+	case "groq":
+		return validateGroqKey(ctx, apiKey)
 	default:
 		// For IDE/app providers (cursor, windsurf, cline, etc.)
 		// we accept the key without validation since we don't have
@@ -435,7 +437,7 @@ func (s *Server) refreshProviderAvailability() {
 // This should be called on server startup to detect invalid keys early
 func (s *Server) ValidateAllKeys() {
 	cm := GetConfigManager()
-	providers := []string{"claude", "openai", "gemini", "openrouter", "cursor", "vscode", "windsurf", "cline", "jetbrains", "zed", "continue", "raycast", "open-webui"}
+	providers := []string{"claude", "openai", "gemini", "openrouter", "groq", "cursor", "vscode", "windsurf", "cline", "jetbrains", "zed", "continue", "raycast", "open-webui"}
 
 	for _, provider := range providers {
 		if cm.HasAPIKey(provider) {
@@ -534,6 +536,36 @@ const openRouterValidationURL = "https://openrouter.ai/api/v1/models"
 // startup — see #7923).
 func validateOpenRouterKey(ctx context.Context, apiKey string) (bool, error) {
 	req, err := http.NewRequestWithContext(ctx, "GET", openRouterValidationURL, nil)
+	if err != nil {
+		return false, err
+	}
+	req.Header.Set("Authorization", "Bearer "+apiKey)
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return false, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusOK {
+		return true, nil
+	}
+	if resp.StatusCode == http.StatusUnauthorized {
+		return false, nil
+	}
+	body, readErr := io.ReadAll(resp.Body)
+	if readErr != nil {
+		body = []byte("(failed to read response body)")
+	}
+	return false, fmt.Errorf("API error: %s", string(body))
+}
+
+// validateGroqKey tests a Groq API key by hitting the OpenAI-compatible
+// models listing endpoint. Mirrors validateOpenAIKey semantics: a 200 means
+// valid, 401 means invalid (cached as (false, nil) so we don't re-fire on
+// every startup — see #7923).
+func validateGroqKey(ctx context.Context, apiKey string) (bool, error) {
+	req, err := http.NewRequestWithContext(ctx, "GET", groqValidationURL, nil)
 	if err != nil {
 		return false, err
 	}

--- a/web/src/components/agent/APIKeySettings.tsx
+++ b/web/src/components/agent/APIKeySettings.tsx
@@ -86,6 +86,10 @@ const PROVIDER_INFO: Record<string, { docsUrl: string; placeholder: string }> = 
     docsUrl: AI_PROVIDER_DOCS.openrouter,
     placeholder: 'sk-or-...',
   },
+  groq: {
+    docsUrl: AI_PROVIDER_DOCS.groq,
+    placeholder: 'gsk_...',
+  },
 }
 
 // Map backend provider key names to AgentIcon provider values
@@ -104,6 +108,7 @@ function providerToIconMap(provider: string): string {
     raycast: 'raycast',
     'open-webui': 'open-webui',
     openrouter: 'openrouter',
+    groq: 'groq',
   }
   return map[provider] || provider
 }

--- a/web/src/components/agent/AgentIcon.tsx
+++ b/web/src/components/agent/AgentIcon.tsx
@@ -153,6 +153,13 @@ export function AgentIcon({ provider, className = 'w-5 h-5' }: AgentIconProps) {
           <path d="M6 12 L18 19" className="stroke-sky-500" />
         </svg>
       )
+    case 'groq':
+      return (
+        <svg className={className} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+          {/* Groq icon - lightning bolt (ultra-low-latency LPU inference) */}
+          <path d="M13 2 L4 14 L11 14 L10 22 L20 9 L13 9 Z" className="fill-orange-500 stroke-orange-500" />
+        </svg>
+      )
     case 'bob':
       return (
         <svg className={className} viewBox="0 0 100 100" fill="none">

--- a/web/src/config/externalApis.ts
+++ b/web/src/config/externalApis.ts
@@ -47,6 +47,7 @@ export const AI_PROVIDER_DOCS = {
   raycast: 'https://raycast.com',
   'open-webui': 'https://github.com/open-webui/open-webui',
   openrouter: 'https://openrouter.ai/keys',
+  groq: 'https://console.groq.com/keys',
 } as const
 
 /**

--- a/web/src/locales/en/common.json
+++ b/web/src/locales/en/common.json
@@ -220,7 +220,7 @@
     },
     "apiKeys": {
       "title": "AI Provider Keys",
-      "subtitle": "Configure API keys for Claude, OpenAI, Gemini, and OpenRouter",
+      "subtitle": "Configure API keys for Claude, OpenAI, Gemini, OpenRouter, and Groq",
       "securityNote": "API keys are stored securely on your local machine in ~/.kc/config.yaml and are never sent to our servers.",
       "manageKeys": "Manage API Keys"
     },

--- a/web/src/types/agent.ts
+++ b/web/src/types/agent.ts
@@ -19,6 +19,7 @@ export type AgentProvider =
   | 'raycast'         // Raycast
   | 'open-webui'      // Open WebUI
   | 'openrouter'      // OpenRouter (https://openrouter.ai) — unified OpenAI-compatible gateway
+  | 'groq'            // Groq (https://groq.com) — ultra-low-latency LPU inference, OpenAI-compatible
   | 'bob'             // Bob (discovery-only)
   | 'block'           // Goose (Block Inc)
   | 'github-cli'      // GitHub Copilot CLI


### PR DESCRIPTION
## Summary

Adds **Groq** (https://groq.com) as a new AI provider using its OpenAI-compatible chat completions API. Groq's LPU hardware delivers very low latency inference for Llama, Mixtral, Gemma and other open-weights models — useful for fast chat and quick analysis in the console.

Because the wire format is OpenAI-compatible, the new `GroqProvider` is a thin wrapper around the existing `chatViaOpenAICompatible*` helpers (same pattern as `provider_openrouter.go`).

Fixes #8153

## Changes

**Backend (`pkg/agent`)**
- `provider_groq.go` — new `GroqProvider` with constants for base URL, chat completions path, default model (`llama-3.3-70b-versatile`), and validation URL. Base URL overridable via `GROQ_BASE_URL`.
- `config.go` — wire `groq` into `getEnvKeyForProvider` / `getModelEnvKeyForProvider` so `GROQ_API_KEY` / `GROQ_MODEL` are honored.
- `server_operations.go` — add `validateGroqKey` (hits `/openai/v1/models`, 200/401 semantics mirror `validateOpenRouterKey` / `validateOpenAIKey`) and include `groq` in `ValidateAllKeys`.
- `provider_groq_test.go` — basic interface, capabilities, base-URL, override, and env-var mapping tests.

**Frontend**
- `web/src/types/agent.ts` — add `'groq'` to `AgentProvider` union.
- `web/src/config/externalApis.ts` — add `groq: https://console.groq.com/keys`.
- `web/src/components/agent/APIKeySettings.tsx` — Groq entry in `PROVIDER_INFO` with `gsk_...` placeholder plus provider→icon mapping.
- `web/src/components/agent/AgentIcon.tsx` — lightning-bolt icon case for `'groq'`.
- `web/src/locales/en/common.json` — include Groq in the API keys settings subtitle.

**Config**
- `.env.example` — document `GROQ_API_KEY`, `GROQ_MODEL`, `GROQ_BASE_URL`, and list `groq` as a `DEFAULT_AGENT` option.

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./pkg/agent/ -run 'TestGroq|TestGetEnvKeyForProvider_Groq'` passes
- [x] `npm run build` passes (web)
- [x] `npm run lint` — no new errors introduced (baseline `363 errors / 753 warnings` unchanged)
- [ ] Manual: set `GROQ_API_KEY` and confirm the provider appears in the API Key Settings UI with the lightning-bolt icon and is validated against Groq's `/v1/models` endpoint