### PR TITLE
🌐 i18n: broader sweep of CanIChecker/Compute/DrasiReactiveGraph

### DIFF
--- a/web/src/components/cards/drasi/DrasiReactiveGraph.tsx
+++ b/web/src/components/cards/drasi/DrasiReactiveGraph.tsx
@@ -587,6 +587,7 @@ interface ExpandedNodeDetails {
 }
 
 function ExpandModal({ node, onClose }: { node: ExpandedNodeDetails | null; onClose: () => void }) {
+  const { t } = useTranslation()
   if (!node) return null
   const titleId = `drasi-expand-title-${node.id}`
   return (
@@ -602,13 +603,13 @@ function ExpandModal({ node, onClose }: { node: ExpandedNodeDetails | null; onCl
             {node.type} · {node.kind}
           </div>
         </div>
-        <button type="button" onClick={onClose} className="w-6 h-6 flex items-center justify-center rounded hover:bg-slate-800 text-slate-400" aria-label="Close">
+        <button type="button" onClick={onClose} className="w-6 h-6 flex items-center justify-center rounded hover:bg-slate-800 text-slate-400" aria-label={t('actions.close')}>
           <X className="w-4 h-4" />
         </button>
       </div>
       <div className="space-y-1.5 text-xs">
         <div className="flex justify-between text-slate-300">
-          <span className="text-muted-foreground">ID:</span>
+          <span className="text-muted-foreground">{t('drasi.idLabel')}</span>
           <span className="font-mono">{node.id}</span>
         </div>
         {node.extra && Object.entries(node.extra).map(([k, v]) => (
@@ -659,16 +660,16 @@ function SourceConfigModal({
     >
       <div className="flex items-start justify-between mb-3">
         <div>
-          <div id={titleId} className="text-white font-semibold text-sm">Configure Source</div>
-          <div className="text-muted-foreground text-xs uppercase tracking-wider mt-0.5">Source · {source.kind}</div>
+          <div id={titleId} className="text-white font-semibold text-sm">{t('drasi.configureSource')}</div>
+          <div className="text-muted-foreground text-xs uppercase tracking-wider mt-0.5">{t('drasi.sourceKindLabel', { kind: source.kind })}</div>
         </div>
-        <button type="button" onClick={onClose} className="w-6 h-6 flex items-center justify-center rounded hover:bg-slate-800 text-slate-400" aria-label="Close">
+        <button type="button" onClick={onClose} className="w-6 h-6 flex items-center justify-center rounded hover:bg-slate-800 text-slate-400" aria-label={t('actions.close')}>
           <X className="w-4 h-4" />
         </button>
       </div>
       <div className="space-y-3">
         <div>
-          <label className="block text-[10px] uppercase tracking-wider text-muted-foreground mb-1">Name</label>
+          <label className="block text-[10px] uppercase tracking-wider text-muted-foreground mb-1">{t('drasi.nameLabel')}</label>
           <input
             type="text"
             value={name}
@@ -677,7 +678,7 @@ function SourceConfigModal({
           />
         </div>
         <div>
-          <label className="block text-[10px] uppercase tracking-wider text-muted-foreground mb-1">Source Type</label>
+          <label className="block text-[10px] uppercase tracking-wider text-muted-foreground mb-1">{t('drasi.sourceTypeLabel')}</label>
           <select
             value={kind}
             onChange={e => setKind(e.target.value as SourceKind)}
@@ -718,16 +719,16 @@ function QueryConfigModal({
     >
       <div className="flex items-start justify-between mb-3">
         <div>
-          <div id={titleId} className="text-white font-semibold text-sm">Configure Continuous Query</div>
-          <div className="text-muted-foreground text-xs uppercase tracking-wider mt-0.5">Query · {query.language}</div>
+          <div id={titleId} className="text-white font-semibold text-sm">{t('drasi.configureContinuousQuery')}</div>
+          <div className="text-muted-foreground text-xs uppercase tracking-wider mt-0.5">{t('drasi.queryLanguageLabel', { language: query.language })}</div>
         </div>
-        <button type="button" onClick={onClose} className="w-6 h-6 flex items-center justify-center rounded hover:bg-slate-800 text-slate-400" aria-label="Close">
+        <button type="button" onClick={onClose} className="w-6 h-6 flex items-center justify-center rounded hover:bg-slate-800 text-slate-400" aria-label={t('actions.close')}>
           <X className="w-4 h-4" />
         </button>
       </div>
       <div className="space-y-3">
         <div>
-          <label className="block text-[10px] uppercase tracking-wider text-muted-foreground mb-1">Name</label>
+          <label className="block text-[10px] uppercase tracking-wider text-muted-foreground mb-1">{t('drasi.nameLabel')}</label>
           <input
             type="text"
             value={name}
@@ -736,7 +737,7 @@ function QueryConfigModal({
           />
         </div>
         <div>
-          <label className="block text-[10px] uppercase tracking-wider text-muted-foreground mb-1">Query Type</label>
+          <label className="block text-[10px] uppercase tracking-wider text-muted-foreground mb-1">{t('drasi.queryTypeLabel')}</label>
           <select
             value={language}
             onChange={e => setLanguage(e.target.value)}
@@ -746,13 +747,13 @@ function QueryConfigModal({
           </select>
         </div>
         <div>
-          <label className="block text-[10px] uppercase tracking-wider text-muted-foreground mb-1">Query</label>
+          <label className="block text-[10px] uppercase tracking-wider text-muted-foreground mb-1">{t('drasi.queryLabel')}</label>
           <textarea
             value={queryText}
             onChange={e => setQueryText(e.target.value)}
             rows={5}
             className="w-full px-2 py-1.5 text-xs font-mono bg-slate-950 border border-slate-700 rounded text-white focus:border-cyan-500 focus:outline-none resize-none"
-            placeholder="MATCH (n) RETURN n"
+            placeholder={t('drasi.queryPlaceholder')}
           />
         </div>
       </div>

--- a/web/src/components/compute/Compute.tsx
+++ b/web/src/components/compute/Compute.tsx
@@ -210,13 +210,13 @@ export function Compute() {
         {selectedForComparison.length > 0 && (
           <div className="flex items-center gap-2">
             <span className="text-xs text-muted-foreground">
-              {selectedForComparison.length} selected
+              {t('compute.countSelected', { count: selectedForComparison.length })}
             </span>
             <button
               onClick={clearSelection}
               className="text-xs text-muted-foreground hover:text-foreground transition-colors"
             >
-              Clear
+              {t('actions.clear')}
             </button>
             {selectedForComparison.length >= 2 && (
               <Button
@@ -225,7 +225,7 @@ export function Compute() {
                 onClick={handleCompare}
                 icon={<GitCompare className="w-4 h-4" />}
               >
-                Compare ({selectedForComparison.length})
+                {t('compute.compareWithCount', { count: selectedForComparison.length })}
               </Button>
             )}
           </div>
@@ -250,7 +250,9 @@ export function Compute() {
                       ? 'opacity-50 cursor-not-allowed'
                       : 'hover:bg-secondary/50'
                 }`}
-                aria-label={`${isSelected ? 'Deselect' : 'Select'} ${cluster.context || cluster.name} for comparison`}
+                aria-label={isSelected
+                  ? t('compute.deselectForComparison', { name: cluster.context || cluster.name })
+                  : t('compute.selectForComparison', { name: cluster.context || cluster.name })}
                 aria-pressed={isSelected}
               >
                 <div className="flex items-start gap-3">
@@ -292,7 +294,7 @@ export function Compute() {
 
       {showClusterList && filteredClusters.length === 0 && (
         <div className="glass p-8 rounded-lg text-center">
-          <p className="text-muted-foreground">No clusters available</p>
+          <p className="text-muted-foreground">{t('compute.noClustersAvailable')}</p>
         </div>
       )}
     </div>

--- a/web/src/components/rbac/CanIChecker.tsx
+++ b/web/src/components/rbac/CanIChecker.tsx
@@ -347,7 +347,7 @@ export function CanIChecker() {
                   <button
                     onClick={() => toggleUserGroup(group)}
                     className="hover:text-blue-200"
-                    aria-label={`Remove group ${group}`}
+                    aria-label={t('rbac.removeGroup', { group })}
                   >
                     <X className="w-3 h-3" />
                   </button>
@@ -388,7 +388,7 @@ export function CanIChecker() {
                   addCustomUserGroup()
                 }
               }}
-              placeholder="Add custom group..."
+              placeholder={t('rbac.addCustomGroupPlaceholder')}
               className="flex-1 p-2 rounded-lg bg-secondary border border-border text-foreground text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
             />
             <Button
@@ -417,13 +417,13 @@ export function CanIChecker() {
 
         {showAdvanced && (
           <div className="text-xs text-muted-foreground p-3 bg-secondary/30 rounded-lg">
-            <p className="font-medium mb-2">Common API Groups:</p>
+            <p className="font-medium mb-2">{t('rbac.commonApiGroupsTitle')}</p>
             <ul className="space-y-1">
-              <li><code className="text-blue-400">""</code> - Core API (pods, services, secrets, configmaps, namespaces)</li>
-              <li><code className="text-blue-400">apps</code> - Deployments, StatefulSets, DaemonSets, ReplicaSets</li>
-              <li><code className="text-blue-400">rbac.authorization.k8s.io</code> - Roles, ClusterRoles, Bindings</li>
-              <li><code className="text-blue-400">batch</code> - Jobs, CronJobs</li>
-              <li><code className="text-blue-400">networking.k8s.io</code> - Ingresses, NetworkPolicies</li>
+              <li><code className="text-blue-400">""</code> - {t('rbac.apiGroupCoreDesc')}</li>
+              <li><code className="text-blue-400">apps</code> - {t('rbac.apiGroupAppsDesc')}</li>
+              <li><code className="text-blue-400">rbac.authorization.k8s.io</code> - {t('rbac.apiGroupRbacDesc')}</li>
+              <li><code className="text-blue-400">batch</code> - {t('rbac.apiGroupBatchDesc')}</li>
+              <li><code className="text-blue-400">networking.k8s.io</code> - {t('rbac.apiGroupNetworkingDesc')}</li>
             </ul>
           </div>
         )}

--- a/web/src/locales/en/common.json
+++ b/web/src/locales/en/common.json
@@ -16,6 +16,7 @@
     "save": "Save",
     "cancel": "Cancel",
     "close": "Close",
+    "clear": "Clear",
     "refresh": "Refresh",
     "configure": "Configure",
     "replace": "Replace",
@@ -1479,10 +1480,35 @@
     "clusterRole": "Cluster Role",
     "roleBinding": "Role Binding",
     "clusterRoleBinding": "Cluster Role Binding",
-    "selectCommonGroups": "Select common groups..."
+    "selectCommonGroups": "Select common groups...",
+    "addCustomGroupPlaceholder": "Add custom group...",
+    "removeGroup": "Remove group {{group}}",
+    "commonApiGroupsTitle": "Common API Groups:",
+    "apiGroupCoreDesc": "Core API (pods, services, secrets, configmaps, namespaces)",
+    "apiGroupAppsDesc": "Deployments, StatefulSets, DaemonSets, ReplicaSets",
+    "apiGroupRbacDesc": "Roles, ClusterRoles, Bindings",
+    "apiGroupBatchDesc": "Jobs, CronJobs",
+    "apiGroupNetworkingDesc": "Ingresses, NetworkPolicies"
   },
   "compute": {
-    "clusterComparison": "Cluster Comparison"
+    "clusterComparison": "Cluster Comparison",
+    "countSelected": "{{count}} selected",
+    "compareWithCount": "Compare ({{count}})",
+    "selectForComparison": "Select {{name}} for comparison",
+    "deselectForComparison": "Deselect {{name}} for comparison",
+    "noClustersAvailable": "No clusters available"
+  },
+  "drasi": {
+    "configureSource": "Configure Source",
+    "configureContinuousQuery": "Configure Continuous Query",
+    "nameLabel": "Name",
+    "sourceTypeLabel": "Source Type",
+    "queryTypeLabel": "Query Type",
+    "queryLabel": "Query",
+    "queryPlaceholder": "MATCH (n) RETURN n",
+    "idLabel": "ID:",
+    "sourceKindLabel": "Source · {{kind}}",
+    "queryLanguageLabel": "Query · {{language}}"
   },
   "missionChat": {
     "saveTranscript": "Save transcript",


### PR DESCRIPTION
Fixes #8160

Addresses Copilot review comments from merged PR #8154 that flagged remaining hardcoded user-facing strings in three files where only a single string had been extracted previously.

## Changes

### web/src/components/rbac/CanIChecker.tsx
- `"Add custom group..."` placeholder → `rbac.addCustomGroupPlaceholder`
- `` `Remove group ${group}` `` aria-label → `rbac.removeGroup` (interpolated)
- `"Common API Groups:"` advanced help block (title + 5 description lines) → `rbac.commonApiGroupsTitle`, `rbac.apiGroupCoreDesc`, `rbac.apiGroupAppsDesc`, `rbac.apiGroupRbacDesc`, `rbac.apiGroupBatchDesc`, `rbac.apiGroupNetworkingDesc`

### web/src/components/compute/Compute.tsx
- `"{n} selected"` → `compute.countSelected` (interpolated count)
- `"Clear"` → reuses existing `actions.clear` (added to common `actions` block)
- `"Compare ({n})"` → `compute.compareWithCount` (interpolated count)
- Select/Deselect aria-labels → `compute.selectForComparison` / `compute.deselectForComparison`
- `"No clusters available"` empty state → `compute.noClustersAvailable`

### web/src/components/cards/drasi/DrasiReactiveGraph.tsx
Modal content for `ExpandModal`, `SourceConfigModal`, and `QueryConfigModal`:
- `"Configure Source"` → `drasi.configureSource`
- `"Configure Continuous Query"` → `drasi.configureContinuousQuery`
- `"Name"` label → `drasi.nameLabel`
- `"Source Type"` → `drasi.sourceTypeLabel`
- `"Query Type"` → `drasi.queryTypeLabel`
- `"Query"` label → `drasi.queryLabel`
- `"MATCH (n) RETURN n"` placeholder → `drasi.queryPlaceholder`
- `"ID:"` label → `drasi.idLabel`
- `"Source · {kind}"` / `"Query · {language}"` subtitles → `drasi.sourceKindLabel` / `drasi.queryLanguageLabel`
- All `aria-label="Close"` → reuses `actions.close`
- `ExpandModal` now wires in `useTranslation`

Reuses existing `actions.save` / `actions.cancel` / `actions.close` keys. Added `actions.clear` to the common actions block. New namespaced keys live under `rbac.*` / `compute.*` / `drasi.*` in `web/src/locales/en/common.json`.

## Test plan
- [x] `npm run build` passes locally
- [x] `npm run lint` — no new issues in the edited files
- [ ] CI build/lint/preview green