### PR TITLE
🐛 fix: reflect 503 backend failures in dashboard health (#8162)

### DIFF
--- a/web/src/hooks/__tests__/useDashboardHealth.test.ts
+++ b/web/src/hooks/__tests__/useDashboardHealth.test.ts
@@ -1,9 +1,10 @@
-import { describe, it, expect, vi } from 'vitest'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { renderHook } from '@testing-library/react'
 
 const mockUseAlerts = vi.fn()
 const mockUseClusters = vi.fn()
 const mockUsePodIssues = vi.fn()
+const mockUseBackendHealth = vi.fn()
 
 vi.mock('../useAlerts', () => ({
   useAlerts: () => mockUseAlerts(),
@@ -13,6 +14,16 @@ vi.mock('../useMCP', () => ({
   useClusters: () => mockUseClusters(),
   usePodIssues: () => mockUsePodIssues(),
 }))
+
+vi.mock('../useBackendHealth', () => ({
+  useBackendHealth: () => mockUseBackendHealth(),
+}))
+
+// Default all tests to a "connected" backend so pre-existing cases stay
+// healthy. Individual tests override this for disconnected scenarios.
+beforeEach(() => {
+  mockUseBackendHealth.mockReturnValue({ status: 'connected' })
+})
 
 import { useDashboardHealth } from '../useDashboardHealth'
 
@@ -103,6 +114,30 @@ describe('useDashboardHealth', () => {
     const { result } = renderHook(() => useDashboardHealth())
     expect(result.current.warningCount).toBe(2)
     expect(result.current.details).toContain('2 pods failing')
+  })
+
+  it('flags disconnected backend as critical (issue #8162)', () => {
+    mockUseBackendHealth.mockReturnValue({ status: 'disconnected' })
+    mockUseAlerts.mockReturnValue({ activeAlerts: [] })
+    mockUseClusters.mockReturnValue({ deduplicatedClusters: [], isLoading: false })
+    mockUsePodIssues.mockReturnValue({ issues: [], isLoading: false })
+
+    const { result } = renderHook(() => useDashboardHealth())
+    expect(result.current.status).toBe('critical')
+    expect(result.current.criticalCount).toBe(1)
+    expect(result.current.details).toContain('Backend API unreachable')
+    expect(result.current.navigateTo).toBe('/alerts')
+  })
+
+  it('ignores connecting backend status (not yet confirmed down)', () => {
+    mockUseBackendHealth.mockReturnValue({ status: 'connecting' })
+    mockUseAlerts.mockReturnValue({ activeAlerts: [] })
+    mockUseClusters.mockReturnValue({ deduplicatedClusters: [{ healthy: true, reachable: true }], isLoading: false })
+    mockUsePodIssues.mockReturnValue({ issues: [], isLoading: false })
+
+    const { result } = renderHook(() => useDashboardHealth())
+    expect(result.current.status).toBe('healthy')
+    expect(result.current.criticalCount).toBe(0)
   })
 
   it('skips cluster/pod checks while loading', () => {

--- a/web/src/hooks/useDashboardHealth.ts
+++ b/web/src/hooks/useDashboardHealth.ts
@@ -1,5 +1,6 @@
 import { useMemo } from 'react'
 import { useAlerts } from './useAlerts'
+import { useBackendHealth } from './useBackendHealth'
 import { useClusters, usePodIssues } from './useMCP'
 
 export type DashboardHealthStatus = 'healthy' | 'warning' | 'critical'
@@ -15,17 +16,36 @@ export interface DashboardHealthInfo {
 
 /**
  * Hook to aggregate health status across the dashboard
- * Checks alerts, cluster health, and pod issues
+ * Checks alerts, cluster health, pod issues, and backend connectivity.
+ *
+ * Backend connectivity (issue #8162): persistent failures of the root
+ * `/health` endpoint — which also indicate that downstream API calls
+ * such as `/api/kagent/status`, `/api/kagenti-provider/status`, and
+ * various `/api/.../runs` and `/api/.../stream` endpoints are likely
+ * returning 503 — are surfaced as a critical dashboard health state so
+ * the UI does not appear "healthy" while backend services are down.
  */
 export function useDashboardHealth(): DashboardHealthInfo {
   const { activeAlerts } = useAlerts()
   const { deduplicatedClusters, isLoading: clustersLoading } = useClusters()
   const { issues: podIssues, isLoading: podsLoading } = usePodIssues()
+  const { status: backendStatus } = useBackendHealth()
 
   return useMemo(() => {
     const details: string[] = []
     let criticalCount = 0
     let warningCount = 0
+
+    // Backend connectivity check (issue #8162).
+    // `useBackendHealth` only flips to 'disconnected' after a debounced
+    // number of consecutive failures on /health (see FAILURE_THRESHOLD in
+    // useBackendHealth.ts), so this is a persistent-failure signal, not a
+    // transient one. When demo mode is active on Netlify, /health is
+    // mocked (web/src/mocks/handlers.ts) and this branch stays inactive.
+    if (backendStatus === 'disconnected') {
+      criticalCount += 1
+      details.push('Backend API unreachable')
+    }
 
     // Count critical and warning alerts
     const criticalAlerts = activeAlerts.filter(a => a.severity === 'critical').length
@@ -98,5 +118,5 @@ export function useDashboardHealth(): DashboardHealthInfo {
       warningCount,
       navigateTo,
     }
-  }, [activeAlerts, deduplicatedClusters, clustersLoading, podIssues, podsLoading])
+  }, [activeAlerts, deduplicatedClusters, clustersLoading, podIssues, podsLoading, backendStatus])
 }

--- a/web/src/mocks/handlers.ts
+++ b/web/src/mocks/handlers.ts
@@ -717,6 +717,39 @@ export const handlers = [
     ])
   }),
 
+  // ── Optional feature status endpoints (issue #8162) ──────────────
+  // These endpoints probe for optional in-cluster integrations. In demo
+  // mode the integrations are not installed, so we return a success (200)
+  // response with `available: false`. Returning 200 here (instead of
+  // letting the catch-all return 503) keeps the DevTools network tab
+  // clean for demo visitors and avoids the MSW "unhandled request"
+  // warning. Source callers already branch on `available` so semantics
+  // are unchanged. See web/src/lib/kagentBackend.ts and related files.
+  http.get('/api/kagent/status', () => {
+    return HttpResponse.json({ available: false, reason: 'not configured in demo mode' })
+  }),
+  http.get('/api/kagent/agents', () => {
+    return HttpResponse.json({ agents: [] })
+  }),
+  http.get('/api/kagenti-provider/status', () => {
+    return HttpResponse.json({ available: false, reason: 'not configured in demo mode' })
+  }),
+  http.get('/api/kagenti-provider/agents', () => {
+    return HttpResponse.json({ agents: [] })
+  }),
+  http.get('/api/gadget/status', () => {
+    return HttpResponse.json({ available: false, reason: 'not configured in demo mode' })
+  }),
+  http.get('/api/mcs/status', () => {
+    return HttpResponse.json({ available: false, reason: 'not configured in demo mode' })
+  }),
+  http.get('/api/persistence/status', () => {
+    return HttpResponse.json({ available: false, reason: 'not configured in demo mode' })
+  }),
+  http.get('/api/self-upgrade/status', () => {
+    return HttpResponse.json({ available: false, reason: 'not configured in demo mode' })
+  }),
+
   // ── Catch-all for unmocked API routes ────────────────────────────
   // On Netlify, unhandled /api/* and /health requests fall through to the SPA
   // catch-all which returns index.html (200 OK, text/html). Code calling


### PR DESCRIPTION
Fixes #8162

## Summary

Two related problems on console.kubestellar.io, both reported in issue #8162:

1. **MSW 503 noise** — Optional feature probes (`/api/kagent/status`, `/api/kagenti-provider/status`, and friends) fell through the MSW `/api/*` catch-all and returned `503` plus an `[MSW] Warning: intercepted a request without a matching request handler` warning. Add explicit MSW handlers that return `200` with `{ available: false, reason: 'not configured in demo mode' }`. Callers (`kagentBackend.ts`, `kagentiProviderBackend.ts`, `useKagentBackend`) already branch on `available` so semantics are unchanged — the DevTools network tab is just no longer littered with scary 503s in the hosted demo.

2. **Dashboard health gap** — `useDashboardHealth` didn't consult `useBackendHealth`, so the dashboard health indicator stayed **healthy** even when the backend `/health` endpoint was persistently failing (which is the same signal that drives all those downstream 503s). Wire `backendStatus` in as a critical input so the indicator correctly shows `Backend API unreachable` once `useBackendHealth`'s failure debounce trips (`FAILURE_THRESHOLD = 4` consecutive failures, so this is a persistent-failure signal, not a transient one).

In demo mode on Netlify, the `/health` MSW handler returns `{ status: 'ok' }` so the new branch stays inactive and the hosted demo continues to show "healthy" — which is now truthful because the 503 probes were replaced with proper 200 responses.

## Changes

- `web/src/mocks/handlers.ts` — 6 new explicit handlers before the `/api/*` catch-all
- `web/src/hooks/useDashboardHealth.ts` — consume `useBackendHealth()`, flag disconnected as critical
- `web/src/hooks/__tests__/useDashboardHealth.test.ts` — mock `useBackendHealth`, two new test cases

## Test plan

- [x] `npm run build` green
- [x] `npm run lint` clean on touched files (1117 pre-existing lint problems on main, none from this PR)
- [x] `useDashboardHealth.test.ts` — 9/9 pass (2 new tests for #8162)
- [x] `kagentBackend.test.ts`, `useKagentBackend.test.ts`, `useBackendHealth.test.ts` — 69/69 pass
- [ ] Verify on preview deploy that DevTools network tab shows `200` for `/api/kagent/status` etc.
- [ ] Verify health indicator flips to critical when backend is disconnected (manual, non-demo)

🤖 Generated with [Claude Code](https://claude.com/claude-code)