### PR TITLE
🐛 fix: enable ERE in privileged-client-lint grep

### DIFF
--- a/.github/workflows/privileged-client-lint.yml
+++ b/.github/workflows/privileged-client-lint.yml
@@ -81,7 +81,11 @@ jobs:
           PATTERN='(h\.k8sClient|s\.k8sClient)\.(Create|Update|Delete|Patch)[A-Z][A-Za-z0-9_]*\(|persistence\.(Create|Update|Delete)[A-Z][A-Za-z0-9_]*\('
 
           # List candidate matches across the handler dir, excluding tests.
-          CANDIDATES=$(grep -rEn "$PATTERN" "$HANDLER_DIR" --include='*.go' | grep -v '_test\.go' || true)
+          # Use -E (ERE) explicitly, pass --include as an option before the
+          # path, and use -e to pass the pattern so ERE metacharacters like
+          # (...) and | are interpreted correctly and the include filter is
+          # always honored regardless of grep flavor.
+          CANDIDATES=$(grep -REn --include='*.go' -e "$PATTERN" "$HANDLER_DIR" | grep -v '_test\.go' || true)
 
           if [ -z "$CANDIDATES" ]; then
             echo "PASS: no privileged-client mutations found in $HANDLER_DIR"


### PR DESCRIPTION
Fixes #8165

Copilot review on merged #8161 flagged that the grep populating `CANDIDATES` in `.github/workflows/privileged-client-lint.yml` had two potential issues:

1. The PATTERN uses ERE operators `(...)` and `|`. The original call used `grep -rEn` which does include `-E`, but the form was fragile.
2. `--include='*.go'` was placed after the search path, which some grep flavors treat as an extra filename rather than an option.

## Fix

Use the explicit, portable form:

```sh
CANDIDATES=\$(grep -REn --include='*.go' -e "\$PATTERN" "\$HANDLER_DIR" | grep -v '_test\.go' || true)
```

- `-E` ERE mode is explicit
- `--include` is passed as an option before the path
- `-e` passes the pattern unambiguously

## Verification

Ran the new grep locally against `pkg/api/handlers/` — still matches the three allowlisted call sites reported in the original PR body:

- `pkg/api/handlers/console_persistence.go:601` `UpdateWorkloadDeploymentStatus`
- `pkg/api/handlers/mcp_resources.go:811` `CreateOrUpdateResourceQuota`
- `pkg/api/handlers/mcp_resources.go:847` `DeleteResourceQuota`

All three are in allowlisted files, so the lint job passes.

Because this PR touches `.github/workflows/privileged-client-lint.yml`, the workflow runs against itself on this PR.