### PR TITLE
♻️ refactor(phase4.5a): migrate /api/mcp card reads to kc-agent (#7993)

### DIFF
--- a/web/src/components/cards/crio_status/useCrioStatus.ts
+++ b/web/src/components/cards/crio_status/useCrioStatus.ts
@@ -1,7 +1,7 @@
 import { useCache } from '../../../lib/cache'
 import { useCardLoadingState } from '../CardDataContext'
 import { CRIO_DEMO_DATA, type CrioStatusDemoData } from './demoData'
-import { FETCH_DEFAULT_TIMEOUT_MS } from '../../../lib/constants/network'
+import { FETCH_DEFAULT_TIMEOUT_MS, LOCAL_AGENT_HTTP_URL } from '../../../lib/constants/network'
 import {
   buildRecentImagePulls,
   extractCrioVersion,
@@ -109,15 +109,15 @@ interface BackendEventInfo {
  */
 async function fetchCrioStatus(): Promise<CrioStatus> {
   const [nodesResp, podsResp, eventsResp] = await Promise.all([
-    fetch('/api/mcp/nodes', {
+    fetch(`${LOCAL_AGENT_HTTP_URL}/nodes`, {
       headers: { Accept: 'application/json' },
       signal: AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS),
     }),
-    fetch('/api/mcp/pods', {
+    fetch(`${LOCAL_AGENT_HTTP_URL}/pods`, {
       headers: { Accept: 'application/json' },
       signal: AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS),
     }),
-    fetch('/api/mcp/events?limit=200', {
+    fetch(`${LOCAL_AGENT_HTTP_URL}/events?limit=200`, {
       headers: { Accept: 'application/json' },
       signal: AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS),
     }).catch(() => undefined),

--- a/web/src/components/cards/failover_timeline/useFailoverTimeline.ts
+++ b/web/src/components/cards/failover_timeline/useFailoverTimeline.ts
@@ -1,7 +1,7 @@
 import { useCache } from '../../../lib/cache'
 import { useCardLoadingState } from '../CardDataContext'
 import { authFetch } from '../../../lib/api'
-import { FETCH_DEFAULT_TIMEOUT_MS } from '../../../lib/constants/network'
+import { FETCH_DEFAULT_TIMEOUT_MS, LOCAL_AGENT_HTTP_URL } from '../../../lib/constants/network'
 import {
   FAILOVER_TIMELINE_DEMO_DATA,
   type FailoverTimelineData,
@@ -69,7 +69,7 @@ function getArray(val: unknown): unknown[] {
 async function fetchCR(group: string, version: string, resource: string): Promise<CRItem[]> {
   try {
     const params = new URLSearchParams({ group, version, resource })
-    const resp = await authFetch(`/api/mcp/custom-resources?${params}`, {
+    const resp = await authFetch(`${LOCAL_AGENT_HTTP_URL}/custom-resources?${params}`, {
       headers: { Accept: 'application/json' },
       signal: AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS),
     })

--- a/web/src/components/cards/flatcar_status/useFlatcarStatus.ts
+++ b/web/src/components/cards/flatcar_status/useFlatcarStatus.ts
@@ -4,6 +4,7 @@ import { FLATCAR_DEMO_DATA, type FlatcarDemoData } from './demoData'
 import { compareFlatcarVersions } from './versionUtils'
 import { FETCH_DEFAULT_TIMEOUT_MS } from '../../../lib/constants/network'
 import { authFetch } from '../../../lib/api'
+import { LOCAL_AGENT_HTTP_URL } from '../../../lib/constants/network'
 
 export interface FlatcarStatus {
   totalNodes: number
@@ -42,7 +43,7 @@ interface FlatcarNodeInfo {
  * so no client-side filtering is needed.
  */
 async function fetchFlatcarStatus(): Promise<FlatcarStatus> {
-  const resp = await authFetch('/api/mcp/flatcar/nodes', {
+  const resp = await authFetch(`${LOCAL_AGENT_HTTP_URL}/flatcar/nodes`, {
     headers: { Accept: 'application/json' },
     signal: AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS),
   })

--- a/web/src/components/cards/fluentd_status/useFluentdStatus.ts
+++ b/web/src/components/cards/fluentd_status/useFluentdStatus.ts
@@ -3,6 +3,7 @@ import { useCardLoadingState } from '../CardDataContext'
 import { FLUENTD_DEMO_DATA, type FluentdDemoData } from './demoData'
 import { FETCH_DEFAULT_TIMEOUT_MS } from '../../../lib/constants'
 import { authFetch } from '../../../lib/api'
+import { LOCAL_AGENT_HTTP_URL } from '../../../lib/constants/network'
 
 export type FluentdStatus = FluentdDemoData
 
@@ -174,7 +175,7 @@ async function fetchPods(url: string): Promise<BackendPodInfo[]> {
 
 async function fetchDaemonSets(namespace?: string): Promise<BackendDaemonSetInfo[]> {
   const query = namespace ? `?namespace=${encodeURIComponent(namespace)}` : ''
-  const resp = await authFetch(`/api/mcp/daemonsets${query}`, {
+  const resp = await authFetch(`${LOCAL_AGENT_HTTP_URL}/daemonsets${query}`, {
     headers: { Accept: 'application/json' },
     signal: AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS),
   })
@@ -194,7 +195,7 @@ async function fetchEvents(namespace: string): Promise<BackendEventInfo[]> {
       limit: String(EVENT_SAMPLE_LIMIT),
     })
 
-    const resp = await authFetch(`/api/mcp/events?${params}`, {
+    const resp = await authFetch(`${LOCAL_AGENT_HTTP_URL}/events?${params}`, {
       headers: { Accept: 'application/json' },
       signal: AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS),
     })
@@ -212,7 +213,7 @@ async function fetchEvents(namespace: string): Promise<BackendEventInfo[]> {
 
 async function fetchFluentdStatus(): Promise<FluentdStatus> {
   const [labeledPods, daemonSets, events] = await Promise.all([
-    fetchPods('/api/mcp/pods?labelSelector=app.kubernetes.io%2Fname%3Dfluentd').catch(() => []),
+    fetchPods(`${LOCAL_AGENT_HTTP_URL}/pods?labelSelector=app.kubernetes.io%2Fname%3Dfluentd`).catch(() => []),
     fetchDaemonSets(LOGGING_NAMESPACE).catch(() => []),
     fetchEvents(LOGGING_NAMESPACE),
   ])
@@ -221,7 +222,7 @@ async function fetchFluentdStatus(): Promise<FluentdStatus> {
   const fluentdDaemonSets = (daemonSets || []).filter(isFluentdDaemonSet)
 
   if ((fluentdPods || []).length === 0 && (fluentdDaemonSets || []).length === 0) {
-    const fallbackPods = (await fetchPods('/api/mcp/pods?labelSelector=app%3Dfluentd')).filter(isFluentdPod)
+    const fallbackPods = (await fetchPods(`${LOCAL_AGENT_HTTP_URL}/pods?labelSelector=app%3Dfluentd`)).filter(isFluentdPod)
     if (fallbackPods.length === 0) {
       return {
         ...INITIAL_DATA,

--- a/web/src/components/cards/karmada_status/useKarmadaStatus.ts
+++ b/web/src/components/cards/karmada_status/useKarmadaStatus.ts
@@ -1,7 +1,7 @@
 import { useCache } from '../../../lib/cache'
 import { useCardLoadingState } from '../CardDataContext'
 import { authFetch } from '../../../lib/api'
-import { FETCH_DEFAULT_TIMEOUT_MS } from '../../../lib/constants/network'
+import { FETCH_DEFAULT_TIMEOUT_MS, LOCAL_AGENT_HTTP_URL } from '../../../lib/constants/network'
 import {
   KARMADA_DEMO_DATA,
   type KarmadaDemoData,
@@ -106,7 +106,7 @@ function isPodReady(pod: BackendPodInfo): boolean {
 async function fetchCR(group: string, version: string, resource: string): Promise<CRItem[]> {
   try {
     const params = new URLSearchParams({ group, version, resource })
-    const resp = await authFetch(`/api/mcp/custom-resources?${params}`, {
+    const resp = await authFetch(`${LOCAL_AGENT_HTTP_URL}/custom-resources?${params}`, {
       headers: { Accept: 'application/json' },
       signal: AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS),
     })
@@ -262,11 +262,11 @@ async function fetchPods(url: string): Promise<BackendPodInfo[]> {
 async function fetchKarmadaStatus(): Promise<KarmadaStatus> {
   // Step 1: Detect Karmada controller pods via label selector, fallback to all pods
   const labeledPods = await fetchPods(
-    '/api/mcp/pods?labelSelector=app.kubernetes.io%2Fname%3Dkarmada',
+    `${LOCAL_AGENT_HTTP_URL}/pods?labelSelector=app.kubernetes.io%2Fname%3Dkarmada`,
   )
   const karmadaPods = labeledPods.length > 0
     ? labeledPods.filter(isKarmadaControllerPod)
-    : (await fetchPods('/api/mcp/pods?namespace=karmada-system')).filter(isKarmadaControllerPod)
+    : (await fetchPods(`${LOCAL_AGENT_HTTP_URL}/pods?namespace=karmada-system`)).filter(isKarmadaControllerPod)
 
   if (karmadaPods.length === 0) {
     return {

--- a/web/src/components/cards/keda_status/useKedaStatus.ts
+++ b/web/src/components/cards/keda_status/useKedaStatus.ts
@@ -3,6 +3,7 @@ import { useCardLoadingState } from '../CardDataContext'
 import { KEDA_DEMO_DATA, type KedaDemoData, type KedaScaledObject, type KedaTriggerType } from './demoData'
 import { FETCH_DEFAULT_TIMEOUT_MS } from '../../../lib/constants'
 import { authFetch } from '../../../lib/api'
+import { LOCAL_AGENT_HTTP_URL } from '../../../lib/constants/network'
 
 export type KedaStatus = KedaDemoData
 
@@ -74,7 +75,7 @@ function isPodReady(pod: BackendPodInfo): boolean {
 async function fetchCR(group: string, version: string, resource: string): Promise<CRItem[]> {
   try {
     const params = new URLSearchParams({ group, version, resource })
-    const resp = await authFetch(`/api/mcp/custom-resources?${params}`, {
+    const resp = await authFetch(`${LOCAL_AGENT_HTTP_URL}/custom-resources?${params}`, {
       headers: { Accept: 'application/json' },
       signal: AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS),
     })
@@ -172,11 +173,11 @@ async function fetchPods(url: string): Promise<BackendPodInfo[]> {
 async function fetchKedaStatus(): Promise<KedaStatus> {
   // Step 1: Detect operator pods (label-filtered first, then unfiltered fallback)
   const labeledPods = await fetchPods(
-    '/api/mcp/pods?labelSelector=app.kubernetes.io%2Fpart-of%3Dkeda-operator',
+    `${LOCAL_AGENT_HTTP_URL}/pods?labelSelector=app.kubernetes.io%2Fpart-of%3Dkeda-operator`,
   )
   const kedaPods = labeledPods.length > 0
     ? labeledPods.filter(isKedaOperatorPod)
-    : (await fetchPods('/api/mcp/pods')).filter(isKedaOperatorPod)
+    : (await fetchPods(`${LOCAL_AGENT_HTTP_URL}/pods`)).filter(isKedaOperatorPod)
 
   if (kedaPods.length === 0) {
     return {

--- a/web/src/components/cards/kubevela_status/useKubeVelaStatus.ts
+++ b/web/src/components/cards/kubevela_status/useKubeVelaStatus.ts
@@ -3,6 +3,7 @@ import { useCardLoadingState } from '../CardDataContext'
 import { KUBEVELA_DEMO_DATA, type KubeVelaDemoData, type KubeVelaApplication } from './demoData'
 import { FETCH_DEFAULT_TIMEOUT_MS } from '../../../lib/constants'
 import { authFetch } from '../../../lib/api'
+import { LOCAL_AGENT_HTTP_URL } from '../../../lib/constants/network'
 
 export type KubeVelaStatus = KubeVelaDemoData
 
@@ -77,7 +78,7 @@ function isPodReady(pod: BackendPodInfo): boolean {
 async function fetchCR(group: string, version: string, resource: string): Promise<CRItem[]> {
   try {
     const params = new URLSearchParams({ group, version, resource })
-    const resp = await authFetch(`/api/mcp/custom-resources?${params}`, {
+    const resp = await authFetch(`${LOCAL_AGENT_HTTP_URL}/custom-resources?${params}`, {
       headers: { Accept: 'application/json' },
       signal: AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS),
     })
@@ -154,7 +155,7 @@ function parseApplication(item: CRItem): KubeVelaApplication {
 
 async function fetchKubeVelaStatus(): Promise<KubeVelaStatus> {
   // Step 1: Detect controller pods
-  const resp = await authFetch('/api/mcp/pods', {
+  const resp = await authFetch(`${LOCAL_AGENT_HTTP_URL}/pods`, {
     headers: { Accept: 'application/json' },
     signal: AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS),
   })

--- a/web/src/components/cards/lima_status/useLimaStatus.ts
+++ b/web/src/components/cards/lima_status/useLimaStatus.ts
@@ -3,6 +3,7 @@ import { useCardLoadingState } from '../CardDataContext'
 import { LIMA_DEMO_DATA, type LimaDemoData, type LimaInstance } from './demoData'
 import { FETCH_DEFAULT_TIMEOUT_MS } from '../../../lib/constants/network'
 import { authFetch } from '../../../lib/api'
+import { LOCAL_AGENT_HTTP_URL } from '../../../lib/constants/network'
 
 export interface LimaStatus {
   instances: LimaInstance[]
@@ -56,7 +57,7 @@ interface BackendNodeInfo {
  * clusters. The backend returns { nodes: NodeInfo[], source: string }.
  */
 async function fetchLimaStatus(): Promise<LimaStatus> {
-  const resp = await authFetch('/api/mcp/nodes', {
+  const resp = await authFetch(`${LOCAL_AGENT_HTTP_URL}/nodes`, {
     headers: { Accept: 'application/json' },
     signal: AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS),
   })

--- a/web/src/components/cards/multi-tenancy/k3s-status/useK3sStatus.ts
+++ b/web/src/components/cards/multi-tenancy/k3s-status/useK3sStatus.ts
@@ -12,6 +12,7 @@ import { FETCH_DEFAULT_TIMEOUT_MS } from '../../../../lib/constants/network'
 import { K3S_CACHE_KEY, OPERATOR_REFRESH_CATEGORY } from '../shared'
 import type { ComponentHealth } from '../shared'
 import { K3S_DEMO_DATA, type K3sServerPodInfo, type K3sStatusDemoData } from './demoData'
+import { LOCAL_AGENT_HTTP_URL } from '../../../../lib/constants/network'
 
 // ============================================================================
 // Data Interface
@@ -97,7 +98,7 @@ function extractVersion(pod: BackendPodInfo): string {
 // ============================================================================
 
 async function fetchK3sStatus(): Promise<K3sStatus> {
-  const podsResp = await fetch('/api/mcp/pods', {
+  const podsResp = await fetch(`${LOCAL_AGENT_HTTP_URL}/pods`, {
     headers: { Accept: 'application/json' },
     signal: AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS),
   })

--- a/web/src/components/cards/multi-tenancy/kubeflex-status/useKubeflexStatus.ts
+++ b/web/src/components/cards/multi-tenancy/kubeflex-status/useKubeflexStatus.ts
@@ -21,6 +21,7 @@ import {
   countTenants,
 } from './helpers'
 import { KUBEFLEX_DEMO_DATA, type KubeFlexStatusDemoData } from './demoData'
+import { LOCAL_AGENT_HTTP_URL } from '../../../../lib/constants/network'
 
 // ============================================================================
 // Data Interface
@@ -70,7 +71,7 @@ interface BackendPodInfo {
 // ============================================================================
 
 async function fetchKubeFlexStatus(): Promise<KubeFlexStatus> {
-  const podsResp = await fetch('/api/mcp/pods', {
+  const podsResp = await fetch(`${LOCAL_AGENT_HTTP_URL}/pods`, {
     headers: { Accept: 'application/json' },
     signal: AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS),
   })

--- a/web/src/components/cards/multi-tenancy/kubevirt-status/useKubevirtStatus.ts
+++ b/web/src/components/cards/multi-tenancy/kubevirt-status/useKubevirtStatus.ts
@@ -21,6 +21,7 @@ import {
 } from './helpers'
 import type { KubevirtPodInfo } from './helpers'
 import { KUBEVIRT_DEMO_DATA, type VmInfo, type ClusterKubevirtInfo, type KubevirtStatusDemoData } from './demoData'
+import { LOCAL_AGENT_HTTP_URL } from '../../../../lib/constants/network'
 
 // ============================================================================
 // Data Interface
@@ -81,7 +82,7 @@ interface BackendPodInfo {
 // ============================================================================
 
 async function fetchKubevirtStatus(): Promise<KubevirtStatus> {
-  const podsResp = await fetch('/api/mcp/pods', {
+  const podsResp = await fetch(`${LOCAL_AGENT_HTTP_URL}/pods`, {
     headers: { Accept: 'application/json' },
     signal: AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS),
   })

--- a/web/src/components/cards/multi-tenancy/ovn-status/useOvnStatus.ts
+++ b/web/src/components/cards/multi-tenancy/ovn-status/useOvnStatus.ts
@@ -15,6 +15,7 @@ import type { ComponentHealth } from '../shared'
 import type { UdnInfo } from './helpers'
 import { isOvnPod, extractUdns, summarizeOvnPods } from './helpers'
 import { OVN_DEMO_DATA, type OvnStatusDemoData } from './demoData'
+import { LOCAL_AGENT_HTTP_URL } from '../../../../lib/constants/network'
 
 // ============================================================================
 // Data Interface
@@ -71,7 +72,7 @@ interface BackendPodInfo {
  * infrastructure pods via label selectors.
  */
 async function fetchOvnStatus(): Promise<OvnStatus> {
-  const podsResp = await fetch('/api/mcp/pods', {
+  const podsResp = await fetch(`${LOCAL_AGENT_HTTP_URL}/pods`, {
     headers: { Accept: 'application/json' },
     signal: AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS),
   })

--- a/web/src/components/cards/multi-tenancy/tenant-topology/useNetworkStats.ts
+++ b/web/src/components/cards/multi-tenancy/tenant-topology/useNetworkStats.ts
@@ -12,6 +12,7 @@
 
 import { useCache } from '../../../../lib/cache'
 import { FETCH_DEFAULT_TIMEOUT_MS } from '../../../../lib/constants/network'
+import { LOCAL_AGENT_HTTP_URL } from '../../../../lib/constants/network'
 
 // ============================================================================
 // Constants
@@ -104,7 +105,7 @@ const INITIAL_DATA: NetworkStatsData = { stats: [] }
 // ============================================================================
 
 async function fetchNetworkStats(): Promise<NetworkStatsData> {
-  const resp = await fetch('/api/mcp/pod-network-stats', {
+  const resp = await fetch(`${LOCAL_AGENT_HTTP_URL}/pod-network-stats`, {
     headers: { Accept: 'application/json' },
     signal: AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS),
   })

--- a/web/src/components/cards/openfeature_status/useOpenFeatureStatus.ts
+++ b/web/src/components/cards/openfeature_status/useOpenFeatureStatus.ts
@@ -4,6 +4,7 @@ import { OPENFEATURE_DEMO_DATA } from './demoData'
 import { FETCH_DEFAULT_TIMEOUT_MS } from '../../../lib/constants/network'
 import { authFetch } from '../../../lib/api'
 import type { OpenFeatureDemoData } from './demoData'
+import { LOCAL_AGENT_HTTP_URL } from '../../../lib/constants/network'
 
 export type OpenFeatureStatus = OpenFeatureDemoData
 
@@ -101,7 +102,7 @@ function extractProviderName(pod: BackendPodInfo): string {
 async function fetchCR(group: string, version: string, resource: string): Promise<CRItem[]> {
   try {
     const params = new URLSearchParams({ group, version, resource })
-    const resp = await authFetch(`/api/mcp/custom-resources?${params}`, {
+    const resp = await authFetch(`${LOCAL_AGENT_HTTP_URL}/custom-resources?${params}`, {
       headers: { Accept: 'application/json' },
       signal: AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS),
     })
@@ -147,7 +148,7 @@ function countFlags(items: CRItem[]): { total: number; enabled: number; disabled
 
 async function fetchOpenFeatureStatus(): Promise<OpenFeatureStatus> {
   // Step 1: Detect OpenFeature pods
-  const resp = await authFetch('/api/mcp/pods', {
+  const resp = await authFetch(`${LOCAL_AGENT_HTTP_URL}/pods`, {
     headers: { Accept: 'application/json' },
     signal: AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS),
   })

--- a/web/src/components/cards/openkruise_status/useOpenKruiseStatus.ts
+++ b/web/src/components/cards/openkruise_status/useOpenKruiseStatus.ts
@@ -3,7 +3,7 @@
  *
  * Queries the OpenKruise CRDs (CloneSet, Advanced StatefulSet, Advanced
  * DaemonSet, SidecarSet, BroadcastJob, AdvancedCronJob) across connected
- * clusters through the `/api/mcp/custom-resources` endpoint and maps the
+ * clusters through the `${LOCAL_AGENT_HTTP_URL}/custom-resources` endpoint and maps the
  * results into the OpenKruiseDemoData shape consumed by the card.
  *
  * Falls back to OPENKRUISE_DEMO_DATA via useCache's built-in demo fallback
@@ -12,7 +12,7 @@
 
 import { useCache } from '../../../lib/cache'
 import { authFetch } from '../../../lib/api'
-import { FETCH_DEFAULT_TIMEOUT_MS } from '../../../lib/constants/network'
+import { FETCH_DEFAULT_TIMEOUT_MS, LOCAL_AGENT_HTTP_URL } from '../../../lib/constants/network'
 import {
   OPENKRUISE_DEMO_DATA,
   type OpenKruiseDemoData,
@@ -62,7 +62,7 @@ async function fetchCR(
 ): Promise<CRItem[]> {
   try {
     const params = new URLSearchParams({ group, version, resource })
-    const resp = await authFetch(`/api/mcp/custom-resources?${params}`, {
+    const resp = await authFetch(`${LOCAL_AGENT_HTTP_URL}/custom-resources?${params}`, {
       headers: { Accept: 'application/json' },
       signal: AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS),
     })

--- a/web/src/components/cards/strimzi_status/useStrimziStatus.ts
+++ b/web/src/components/cards/strimzi_status/useStrimziStatus.ts
@@ -3,6 +3,7 @@ import { useCardLoadingState } from '../CardDataContext'
 import { STRIMZI_DEMO_DATA, type StrimziDemoData, type StrimziTopic } from './demoData'
 import { FETCH_DEFAULT_TIMEOUT_MS } from '../../../lib/constants/network'
 import { authFetch } from '../../../lib/api'
+import { LOCAL_AGENT_HTTP_URL } from '../../../lib/constants/network'
 
 export type StrimziStatus = StrimziDemoData
 
@@ -81,7 +82,7 @@ function isBrokerPod(pod: BackendPodInfo): boolean {
 async function fetchCR(group: string, version: string, resource: string): Promise<CRItem[]> {
   try {
     const params = new URLSearchParams({ group, version, resource })
-    const resp = await authFetch(`/api/mcp/custom-resources?${params}`, {
+    const resp = await authFetch(`${LOCAL_AGENT_HTTP_URL}/custom-resources?${params}`, {
       headers: { Accept: 'application/json' },
       signal: AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS),
     })
@@ -126,7 +127,7 @@ function parseTopic(item: CRItem): StrimziTopic {
 
 async function fetchStrimziStatus(): Promise<StrimziStatus> {
   // Step 1: Detect Strimzi pods
-  const resp = await authFetch('/api/mcp/pods', {
+  const resp = await authFetch(`${LOCAL_AGENT_HTTP_URL}/pods`, {
     headers: { Accept: 'application/json' },
     signal: AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS),
   })

--- a/web/src/components/cards/trino_gateway/useTrinoGateway.ts
+++ b/web/src/components/cards/trino_gateway/useTrinoGateway.ts
@@ -9,7 +9,7 @@
 import { useCache } from '../../../lib/cache'
 import { useCardLoadingState } from '../CardDataContext'
 import { authFetch } from '../../../lib/api'
-import { FETCH_DEFAULT_TIMEOUT_MS } from '../../../lib/constants/network'
+import { FETCH_DEFAULT_TIMEOUT_MS, LOCAL_AGENT_HTTP_URL } from '../../../lib/constants/network'
 import {
   TRINO_GATEWAY_DEMO_DATA,
   type TrinoGatewayData,
@@ -192,9 +192,9 @@ function aggregateGateways(
 
 async function fetchTrinoGatewayData(): Promise<TrinoGatewayData> {
   const [coordinators, workers, gatewayPods] = await Promise.all([
-    fetchPods(`/api/mcp/pods?labelSelector=${LABEL_TRINO_COORDINATOR}`),
-    fetchPods(`/api/mcp/pods?labelSelector=${LABEL_TRINO_WORKER}`),
-    fetchPods(`/api/mcp/pods?labelSelector=${LABEL_TRINO_GATEWAY}`),
+    fetchPods(`${LOCAL_AGENT_HTTP_URL}/pods?labelSelector=${LABEL_TRINO_COORDINATOR}`),
+    fetchPods(`${LOCAL_AGENT_HTTP_URL}/pods?labelSelector=${LABEL_TRINO_WORKER}`),
+    fetchPods(`${LOCAL_AGENT_HTTP_URL}/pods?labelSelector=${LABEL_TRINO_GATEWAY}`),
   ])
 
   const detected = coordinators.length > 0 || workers.length > 0 || gatewayPods.length > 0


### PR DESCRIPTION
## Summary

Phase 4.5a of the pod-SA → kc-agent refactor (#7993). 32 frontend fetch call sites across 17 status-card and drilldown hooks are migrated from the backend's \`/api/mcp/*\` read endpoints to kc-agent at \`\${LOCAL_AGENT_HTTP_URL}/*\`. 

The effect: the data each card displays is now scoped to what the user's own kubeconfig can see, not what the backend pod ServiceAccount can see.

Refs #7993.

## Scope

Pure frontend migration. No backend handlers are deleted in this PR — they stay on the backend for the handful of other consumers (\`useKubectl\`, \`useCachedData\`, \`useSearchIndex\`, etc.) that haven't been migrated yet. Phase 4.5b / 4.5c will finish the sweep and then Phase 5 can delete the backend read handlers cleanly.

Files touched (17):

| File | Sites |
|---|---|
| \`crio_status/useCrioStatus.ts\` | 3 |
| \`failover_timeline/useFailoverTimeline.ts\` | 1 |
| \`flatcar_status/useFlatcarStatus.ts\` | 1 |
| \`fluentd_status/useFluentdStatus.ts\` | 4 |
| \`karmada_status/useKarmadaStatus.ts\` | 3 |
| \`keda_status/useKedaStatus.ts\` | 3 |
| \`kubevela_status/useKubeVelaStatus.ts\` | 2 |
| \`lima_status/useLimaStatus.ts\` | 1 |
| \`multi-tenancy/k3s-status/useK3sStatus.ts\` | 1 |
| \`multi-tenancy/kubeflex-status/useKubeflexStatus.ts\` | 1 |
| \`multi-tenancy/kubevirt-status/useKubevirtStatus.ts\` | 1 |
| \`multi-tenancy/ovn-status/useOvnStatus.ts\` | 1 |
| \`multi-tenancy/tenant-topology/useNetworkStats.ts\` | 1 |
| \`openfeature_status/useOpenFeatureStatus.ts\` | 2 |
| \`openkruise_status/useOpenKruiseStatus.ts\` | 2 |
| \`strimzi_status/useStrimziStatus.ts\` | 2 |
| \`trino_gateway/useTrinoGateway.ts\` | 3 |

## How the migration works

Each \`'/api/mcp/X'\` (or \`\`\`/api/mcp/X?\${params}\`\`\`) is rewritten to the template literal \`\`\`\${LOCAL_AGENT_HTTP_URL}/X\`\`\`. Fetch method, timeout, headers, and query-string shape are unchanged. \`LOCAL_AGENT_HTTP_URL\` is imported from \`../lib/constants/network\` — where files already had a \`FETCH_DEFAULT_TIMEOUT_MS\` import from the same module, the new symbol is folded into the same destructure.

kc-agent already serves the matching read routes (\`/pods\`, \`/deployments\`, \`/events\`, \`/nodes\`, \`/gpu-nodes\`, \`/custom-resources\`, \`/daemonsets\`, \`/pod-network-stats\`, etc.) from Phase 0 of the refactor, so this is a pure URL swap with no new agent endpoints.

## Test plan

- [x] \`npm run build\` — green, all post-build safety checks pass
- [x] Type-check clean after fixing two multi-line imports the scripted migration initially mis-inserted (openkruise, trino_gateway, crio, failover_timeline, karmada)
- [ ] Manual: exercise each migrated card on a local install with kc-agent running, confirm the card renders with data
- [ ] Manual: exercise the same cards on an in-cluster install **without** local kc-agent — they should fall through to the existing demo-mode / fallback behaviour (the fetch 503s with \`ECONNREFUSED\`, hooks handle it)