### PR TITLE
♻️ refactor(phase4.5b): migrate /api/mcp hook reads to kc-agent (#7993)

### DIFF
--- a/web/src/components/logs/Logs.tsx
+++ b/web/src/components/logs/Logs.tsx
@@ -14,7 +14,7 @@ const LOGS_CARDS_KEY = 'kubestellar-logs-cards'
 //
 // Fixes #6045: the Logs dashboard historically only surfaced Kubernetes
 // Events (via `useCachedEvents()`).  The new `pod_logs` card wires the
-// existing `/api/mcp/pods/logs` backend endpoint to the dashboard so users
+// existing `${LOCAL_AGENT_HTTP_URL}/pods/logs` backend endpoint to the dashboard so users
 // can actually tail container logs — not just events — from this page.
 const DEFAULT_LOGS_CARDS = [
   { type: 'pod_logs', title: 'Pod Logs', position: { w: 12, h: 4 } },

--- a/web/src/components/namespaces/NamespaceManager.tsx
+++ b/web/src/components/namespaces/NamespaceManager.tsx
@@ -163,7 +163,7 @@ export function NamespaceManager() {
         if (clusterNamespaces.length === 0) {
           try {
             const response = await api.get<{ pods: Array<{ namespace: string; status: string }> }>(
-              `/api/mcp/pods?cluster=${encodeURIComponent(cluster)}&limit=1000`
+              `${LOCAL_AGENT_HTTP_URL}/pods?cluster=${encodeURIComponent(cluster)}&limit=1000`
             )
 
             // Extract unique namespaces from pods

--- a/web/src/config/cards/pod-logs.ts
+++ b/web/src/config/cards/pod-logs.ts
@@ -2,7 +2,7 @@
  * Pod Logs Card Configuration
  *
  * Renders container logs via a custom component (PodLogs.tsx) that wires
- * cluster/namespace/pod/container selectors to the `/api/mcp/pods/logs`
+ * cluster/namespace/pod/container selectors to the `${LOCAL_AGENT_HTTP_URL}/pods/logs`
  * endpoint through the `usePodLogs` hook.
  */
 

--- a/web/src/hooks/mcp/clusters.ts
+++ b/web/src/hooks/mcp/clusters.ts
@@ -26,6 +26,7 @@ import {
   setHealthCheckFailures } from './shared'
 import type { ClusterInfo } from './types'
 import { subscribePolling } from './pollingManager'
+import { LOCAL_AGENT_HTTP_URL } from '../../lib/constants/network'
 
 /** Data slice returned by useClusters — heavy, arrives via startTransition. */
 interface ClusterDataSlice {
@@ -52,7 +53,7 @@ export function useMCPStatus() {
   useEffect(() => {
     const fetchStatus = async () => {
       try {
-        const { data } = await api.get<MCPStatus>('/api/mcp/status')
+        const { data } = await api.get<MCPStatus>(`${LOCAL_AGENT_HTTP_URL}/status`)
         setStatus(data)
         setError(null)
       } catch {

--- a/web/src/hooks/mcp/compute.ts
+++ b/web/src/hooks/mcp/compute.ts
@@ -8,7 +8,7 @@ import { registerCacheReset, registerRefetch } from '../../lib/modeTransition'
 import { STORAGE_KEY_TOKEN } from '../../lib/constants'
 import { GPU_POLL_INTERVAL_MS, getEffectiveInterval, LOCAL_AGENT_URL, agentFetch } from './shared'
 import { subscribePolling } from './pollingManager'
-import { MCP_EXTENDED_TIMEOUT_MS, MCP_HOOK_TIMEOUT_MS } from '../../lib/constants/network'
+import { MCP_EXTENDED_TIMEOUT_MS, MCP_HOOK_TIMEOUT_MS, LOCAL_AGENT_HTTP_URL } from '../../lib/constants/network'
 import type { GPUNode, NodeInfo, NVIDIAOperatorStatus } from './types'
 
 // Module-level cache for GPU nodes (persists across navigation)
@@ -178,7 +178,7 @@ async function fetchGPUNodes(cluster?: string, _source?: string) {
       try {
         // Try SSE streaming first for progressive rendering
         const sseResult = await fetchSSE<GPUNode>({
-          url: '/api/mcp/gpu-nodes/stream',
+          url: `${LOCAL_AGENT_HTTP_URL}/gpu-nodes/stream`,
           params: Object.fromEntries(params.entries()),
           itemsKey: 'nodes',
           onClusterData: (_cluster, items) => {
@@ -197,7 +197,7 @@ async function fetchGPUNodes(cluster?: string, _source?: string) {
       } catch {
         // SSE failed, try REST fallback
         try {
-          const { data } = await api.get<{ nodes: GPUNode[] }>(`/api/mcp/gpu-nodes?${params}`)
+          const { data } = await api.get<{ nodes: GPUNode[] }>(`${LOCAL_AGENT_HTTP_URL}/gpu-nodes?${params}`)
           newNodes = data.nodes || []
           fetchSucceeded = true
         } catch {
@@ -502,7 +502,7 @@ export function useNodes(cluster?: string) {
       if (cluster) sseParams.cluster = cluster
 
       const allNodes = await fetchSSE<NodeInfo>({
-        url: '/api/mcp/nodes/stream',
+        url: `${LOCAL_AGENT_HTTP_URL}/nodes/stream`,
         params: sseParams,
         itemsKey: 'nodes',
         onClusterData: (_clusterName, items) => {
@@ -566,7 +566,7 @@ export function useNVIDIAOperators(cluster?: string) {
         try {
           const accumulated: NVIDIAOperatorStatus[] = []
           const result = await fetchSSE<NVIDIAOperatorStatus>({
-            url: '/api/mcp/nvidia-operators/stream',
+            url: `${LOCAL_AGENT_HTTP_URL}/nvidia-operators/stream`,
             params,
             itemsKey: 'operators',
             onClusterData: (_clusterName, items) => {
@@ -587,7 +587,7 @@ export function useNVIDIAOperators(cluster?: string) {
       // REST fallback
       const urlParams = new URLSearchParams()
       if (cluster) urlParams.append('cluster', cluster)
-      const { data } = await api.get<{ operators?: NVIDIAOperatorStatus[], operator?: NVIDIAOperatorStatus }>(`/api/mcp/nvidia-operators?${urlParams}`)
+      const { data } = await api.get<{ operators?: NVIDIAOperatorStatus[], operator?: NVIDIAOperatorStatus }>(`${LOCAL_AGENT_HTTP_URL}/nvidia-operators?${urlParams}`)
       if (data.operators) {
         setOperators(data.operators)
       } else if (data.operator) {

--- a/web/src/hooks/mcp/config.ts
+++ b/web/src/hooks/mcp/config.ts
@@ -7,7 +7,7 @@ import { useDemoMode } from '../useDemoMode'
 import { registerRefetch } from '../../lib/modeTransition'
 import { STORAGE_KEY_TOKEN } from '../../lib/constants'
 import { LOCAL_AGENT_URL, agentFetch } from './shared'
-import { MCP_HOOK_TIMEOUT_MS } from '../../lib/constants/network'
+import { MCP_HOOK_TIMEOUT_MS, LOCAL_AGENT_HTTP_URL } from '../../lib/constants/network'
 import type { ConfigMap, Secret, ServiceAccount } from './types'
 
 export function useConfigMaps(cluster?: string, namespace?: string) {
@@ -59,7 +59,7 @@ export function useConfigMaps(cluster?: string, namespace?: string) {
         if (namespace) sseParams.namespace = namespace
         const accumulated: ConfigMap[] = []
         const result = await fetchSSE<ConfigMap>({
-          url: '/api/mcp/configmaps/stream',
+          url: `${LOCAL_AGENT_HTTP_URL}/configmaps/stream`,
           params: sseParams,
           itemsKey: 'configmaps',
           onClusterData: (_clusterName, items) => {
@@ -80,7 +80,7 @@ export function useConfigMaps(cluster?: string, namespace?: string) {
       const params = new URLSearchParams()
       if (cluster) params.append('cluster', cluster)
       if (namespace) params.append('namespace', namespace)
-      const { data } = await api.get<{ configmaps: ConfigMap[] }>(`/api/mcp/configmaps?${params}`)
+      const { data } = await api.get<{ configmaps: ConfigMap[] }>(`${LOCAL_AGENT_HTTP_URL}/configmaps?${params}`)
       setConfigMaps(data.configmaps || [])
       setError(null)
     } catch {
@@ -162,7 +162,7 @@ export function useSecrets(cluster?: string, namespace?: string) {
         if (namespace) sseParams.namespace = namespace
         const accumulated: Secret[] = []
         const result = await fetchSSE<Secret>({
-          url: '/api/mcp/secrets/stream',
+          url: `${LOCAL_AGENT_HTTP_URL}/secrets/stream`,
           params: sseParams,
           itemsKey: 'secrets',
           onClusterData: (_clusterName, items) => {
@@ -183,7 +183,7 @@ export function useSecrets(cluster?: string, namespace?: string) {
       const params = new URLSearchParams()
       if (cluster) params.append('cluster', cluster)
       if (namespace) params.append('namespace', namespace)
-      const { data } = await api.get<{ secrets: Secret[] }>(`/api/mcp/secrets?${params}`)
+      const { data } = await api.get<{ secrets: Secret[] }>(`${LOCAL_AGENT_HTTP_URL}/secrets?${params}`)
       setSecrets(data.secrets || [])
       setError(null)
     } catch {
@@ -260,7 +260,7 @@ export function useServiceAccounts(cluster?: string, namespace?: string) {
       const params = new URLSearchParams()
       if (cluster) params.append('cluster', cluster)
       if (namespace) params.append('namespace', namespace)
-      const { data } = await api.get<{ serviceAccounts: ServiceAccount[] }>(`/api/mcp/serviceaccounts?${params}`)
+      const { data } = await api.get<{ serviceAccounts: ServiceAccount[] }>(`${LOCAL_AGENT_HTTP_URL}/serviceaccounts?${params}`)
       setServiceAccounts(data.serviceAccounts || [])
       setError(null)
     } catch {

--- a/web/src/hooks/mcp/events.ts
+++ b/web/src/hooks/mcp/events.ts
@@ -7,7 +7,7 @@ import { registerRefetch } from '../../lib/modeTransition'
 import { registerCacheReset } from '../../lib/modeTransition'
 import { REFRESH_INTERVAL_MS, MIN_REFRESH_INDICATOR_MS, getEffectiveInterval, LOCAL_AGENT_URL, agentFetch } from './shared'
 import { subscribePolling } from './pollingManager'
-import { MCP_HOOK_TIMEOUT_MS } from '../../lib/constants/network'
+import { MCP_HOOK_TIMEOUT_MS, LOCAL_AGENT_HTTP_URL } from '../../lib/constants/network'
 import type { ClusterEvent } from './types'
 
 // ---------------------------------------------------------------------------
@@ -154,7 +154,7 @@ export function useEvents(cluster?: string, namespace?: string, limit = 20) {
       sseParams.limit = limit.toString()
 
       const allEvents = await fetchSSE<ClusterEvent>({
-        url: '/api/mcp/events/stream',
+        url: `${LOCAL_AGENT_HTTP_URL}/events/stream`,
         params: sseParams,
         itemsKey: 'events',
         signal,
@@ -335,7 +335,7 @@ export function useWarningEvents(cluster?: string, namespace?: string, limit = 2
       sseParams.limit = limit.toString()
 
       const allEvents = await fetchSSE<ClusterEvent>({
-        url: '/api/mcp/events/warnings/stream',
+        url: `${LOCAL_AGENT_HTTP_URL}/events/warnings/stream`,
         params: sseParams,
         itemsKey: 'events',
         signal,

--- a/web/src/hooks/mcp/namespaces.ts
+++ b/web/src/hooks/mcp/namespaces.ts
@@ -5,6 +5,7 @@ import { kubectlProxy } from '../../lib/kubectlProxy'
 import { isDemoMode } from '../../lib/demoMode'
 import { LOCAL_AGENT_URL, agentFetch, clusterCacheRef } from './shared'
 import type { PodInfo, NamespaceStats } from './types'
+import { LOCAL_AGENT_HTTP_URL } from '../../lib/constants/network'
 
 // Large clusters (100+ namespaces) can take 30s+ to list all namespaces.
 // Use a generous timeout to avoid aborting valid but slow requests.
@@ -142,7 +143,7 @@ export function useNamespaces(cluster?: string, forceLive = false) {
     try {
       const podNs: string[] = []
       try {
-        const { data } = await api.get<{ pods: PodInfo[] }>(`/api/mcp/pods?cluster=${encodeURIComponent(cluster)}`)
+        const { data } = await api.get<{ pods: PodInfo[] }>(`${LOCAL_AGENT_HTTP_URL}/pods?cluster=${encodeURIComponent(cluster)}`)
         for (const pod of (data.pods || [])) {
           if (pod.namespace) podNs.push(pod.namespace)
         }
@@ -193,7 +194,7 @@ export function useNamespaceStats(cluster?: string) {
     setIsLoading(true)
     try {
       // Fetch all pods for the cluster (no limit)
-      const { data } = await api.get<{ pods: PodInfo[] }>(`/api/mcp/pods?cluster=${encodeURIComponent(cluster)}&limit=1000`)
+      const { data } = await api.get<{ pods: PodInfo[] }>(`${LOCAL_AGENT_HTTP_URL}/pods?cluster=${encodeURIComponent(cluster)}&limit=1000`)
 
       // Group pods by namespace and calculate stats
       const nsMap: Record<string, NamespaceStats> = {}

--- a/web/src/hooks/mcp/networking.ts
+++ b/web/src/hooks/mcp/networking.ts
@@ -8,7 +8,7 @@ import { kubectlProxy } from '../../lib/kubectlProxy'
 import { STORAGE_KEY_TOKEN } from '../../lib/constants'
 import { REFRESH_INTERVAL_MS, MIN_REFRESH_INDICATOR_MS, getEffectiveInterval, LOCAL_AGENT_URL, agentFetch, clusterCacheRef } from './shared'
 import { subscribePolling } from './pollingManager'
-import { MCP_HOOK_TIMEOUT_MS, DEPLOY_ABORT_TIMEOUT_MS, SERVICES_CACHE_TTL_MS } from '../../lib/constants/network'
+import { MCP_HOOK_TIMEOUT_MS, DEPLOY_ABORT_TIMEOUT_MS, SERVICES_CACHE_TTL_MS, LOCAL_AGENT_HTTP_URL } from '../../lib/constants/network'
 import type { Service, Ingress, NetworkPolicy } from './types'
 
 // ---------------------------------------------------------------------------
@@ -247,7 +247,7 @@ export function useServices(cluster?: string, namespace?: string) {
       const params = new URLSearchParams()
       if (cluster) params.append('cluster', cluster)
       if (namespace) params.append('namespace', namespace)
-      const url = `/api/mcp/services?${params}`
+      const url = `${LOCAL_AGENT_HTTP_URL}/services?${params}`
 
       // Use direct fetch with timeout to prevent hanging
       const token = localStorage.getItem(STORAGE_KEY_TOKEN)
@@ -395,7 +395,7 @@ export function useIngresses(cluster?: string, namespace?: string) {
       const params = new URLSearchParams()
       if (cluster) params.append('cluster', cluster)
       if (namespace) params.append('namespace', namespace)
-      const { data } = await api.get<{ ingresses: Ingress[] }>(`/api/mcp/ingresses?${params}`)
+      const { data } = await api.get<{ ingresses: Ingress[] }>(`${LOCAL_AGENT_HTTP_URL}/ingresses?${params}`)
       setIngresses(data.ingresses || [])
       setError(null)
       setConsecutiveFailures(0)
@@ -476,7 +476,7 @@ export function useNetworkPolicies(cluster?: string, namespace?: string) {
       const params = new URLSearchParams()
       if (cluster) params.append('cluster', cluster)
       if (namespace) params.append('namespace', namespace)
-      const { data } = await api.get<{ networkpolicies: NetworkPolicy[] }>(`/api/mcp/networkpolicies?${params}`)
+      const { data } = await api.get<{ networkpolicies: NetworkPolicy[] }>(`${LOCAL_AGENT_HTTP_URL}/networkpolicies?${params}`)
       setNetworkPolicies(data.networkpolicies || [])
       setError(null)
       setConsecutiveFailures(0)

--- a/web/src/hooks/mcp/security.ts
+++ b/web/src/hooks/mcp/security.ts
@@ -6,7 +6,7 @@ import { registerRefetch, registerCacheReset } from '../../lib/modeTransition'
 import { STORAGE_KEY_TOKEN } from '../../lib/constants'
 import { MIN_REFRESH_INDICATOR_MS, REFRESH_INTERVAL_MS, getEffectiveInterval } from './shared'
 import { subscribePolling } from './pollingManager'
-import { MCP_HOOK_TIMEOUT_MS } from '../../lib/constants/network'
+import { MCP_HOOK_TIMEOUT_MS, LOCAL_AGENT_HTTP_URL } from '../../lib/constants/network'
 import type { SecurityIssue, GitOpsDrift } from './types'
 
 // LocalStorage cache keys
@@ -98,7 +98,7 @@ export function useSecurityIssues(cluster?: string, namespace?: string) {
       if (namespace) sseParams.namespace = namespace
 
       const allIssues = await fetchSSE<SecurityIssue>({
-        url: '/api/mcp/security-issues/stream',
+        url: `${LOCAL_AGENT_HTTP_URL}/security-issues/stream`,
         params: sseParams,
         itemsKey: 'issues',
         onClusterData: (_clusterName, items) => {

--- a/web/src/hooks/mcp/shared.ts
+++ b/web/src/hooks/mcp/shared.ts
@@ -1074,7 +1074,7 @@ export async function fetchSingleClusterHealth(clusterName: string, kubectlConte
   const token = localStorage.getItem(STORAGE_KEY_TOKEN)
   try {
     const response = await fetch(
-      `/api/mcp/clusters/${encodeURIComponent(clusterName)}/health`,
+      `${LOCAL_AGENT_HTTP_URL}/clusters/${encodeURIComponent(clusterName)}/health`,
       {
         signal: AbortSignal.timeout(MCP_HOOK_TIMEOUT_MS),
         headers: token ? { 'Authorization': `Bearer ${token}` } : {},
@@ -1202,7 +1202,7 @@ async function detectClusterDistribution(clusterName: string, kubectlContext?: s
   // Try pods endpoint first
   try {
     const response = await fetch(
-      `/api/mcp/pods?cluster=${encodeURIComponent(clusterName)}&limit=500`,
+      `${LOCAL_AGENT_HTTP_URL}/pods?cluster=${encodeURIComponent(clusterName)}&limit=500`,
       { signal: AbortSignal.timeout(METRICS_SERVER_TIMEOUT_MS), headers }
     )
     if (response.ok) {
@@ -1224,7 +1224,7 @@ async function detectClusterDistribution(clusterName: string, kubectlContext?: s
   // Fallback: try events endpoint
   try {
     const response = await fetch(
-      `/api/mcp/events?cluster=${encodeURIComponent(clusterName)}&limit=200`,
+      `${LOCAL_AGENT_HTTP_URL}/events?cluster=${encodeURIComponent(clusterName)}&limit=200`,
       { signal: AbortSignal.timeout(METRICS_SERVER_TIMEOUT_MS), headers }
     )
     if (response.ok) {
@@ -1246,7 +1246,7 @@ async function detectClusterDistribution(clusterName: string, kubectlContext?: s
   // Fallback: try deployments endpoint
   try {
     const response = await fetch(
-      `/api/mcp/deployments?cluster=${encodeURIComponent(clusterName)}`,
+      `${LOCAL_AGENT_HTTP_URL}/deployments?cluster=${encodeURIComponent(clusterName)}`,
       { signal: AbortSignal.timeout(METRICS_SERVER_TIMEOUT_MS), headers }
     )
     if (response.ok) {
@@ -1594,7 +1594,7 @@ export async function fullFetchClusters() {
     }
 
     // Fall back to backend API
-    const { data } = await api.get<{ clusters: ClusterInfo[] }>('/api/mcp/clusters')
+    const { data } = await api.get<{ clusters: ClusterInfo[] }>(`${LOCAL_AGENT_HTTP_URL}/clusters`)
     // Merge new cluster list with existing cached data (preserve distribution, health, etc.)
     const existingClusters = clusterCache.clusters
     const mergedClusters = (data.clusters || []).map(newCluster => {

--- a/web/src/hooks/mcp/storage.ts
+++ b/web/src/hooks/mcp/storage.ts
@@ -7,7 +7,7 @@ import { kubectlProxy } from '../../lib/kubectlProxy'
 import { REFRESH_INTERVAL_MS, getEffectiveInterval, LOCAL_AGENT_URL, agentFetch, clusterCacheRef } from './shared'
 import { subscribePolling } from './pollingManager'
 import { settledWithConcurrency } from '../../lib/utils/concurrency'
-import { MCP_HOOK_TIMEOUT_MS } from '../../lib/constants/network'
+import { MCP_HOOK_TIMEOUT_MS, LOCAL_AGENT_HTTP_URL } from '../../lib/constants/network'
 import type { PVC, PV, ResourceQuota, LimitRange, ResourceQuotaSpec } from './types'
 
 // ---------------------------------------------------------------------------
@@ -266,7 +266,7 @@ export function usePVCs(cluster?: string, namespace?: string) {
       const params = new URLSearchParams()
       if (cluster) params.append('cluster', cluster)
       if (namespace) params.append('namespace', namespace)
-      const { data } = await api.get<{ pvcs: PVC[] }>(`/api/mcp/pvcs?${params}`)
+      const { data } = await api.get<{ pvcs: PVC[] }>(`${LOCAL_AGENT_HTTP_URL}/pvcs?${params}`)
       const newData = data.pvcs || []
       const now = new Date()
 
@@ -377,7 +377,7 @@ export function usePVs(cluster?: string) {
     try {
       const params = new URLSearchParams()
       if (cluster) params.append('cluster', cluster)
-      const { data } = await api.get<{ pvs: PV[] }>(`/api/mcp/pvs?${params}`)
+      const { data } = await api.get<{ pvs: PV[] }>(`${LOCAL_AGENT_HTTP_URL}/pvs?${params}`)
       if (!isMountedRef.current) return
       setPVs(data.pvs || [])
       setError(null)
@@ -443,7 +443,7 @@ export function useResourceQuotas(cluster?: string, namespace?: string, forceLiv
       const params = new URLSearchParams()
       if (cluster) params.append('cluster', cluster)
       if (namespace) params.append('namespace', namespace)
-      const { data } = await api.get<{ resourceQuotas: ResourceQuota[] }>(`/api/mcp/resourcequotas?${params}`)
+      const { data } = await api.get<{ resourceQuotas: ResourceQuota[] }>(`${LOCAL_AGENT_HTTP_URL}/resourcequotas?${params}`)
       setResourceQuotas(data.resourceQuotas || [])
       setError(null)
     } catch {
@@ -501,7 +501,7 @@ export function useLimitRanges(cluster?: string, namespace?: string) {
       const params = new URLSearchParams()
       if (cluster) params.append('cluster', cluster)
       if (namespace) params.append('namespace', namespace)
-      const { data } = await api.get<{ limitRanges: LimitRange[] }>(`/api/mcp/limitranges?${params}`)
+      const { data } = await api.get<{ limitRanges: LimitRange[] }>(`${LOCAL_AGENT_HTTP_URL}/limitranges?${params}`)
       setLimitRanges(data.limitRanges || [])
       setError(null)
     } catch {
@@ -539,13 +539,13 @@ export function useLimitRanges(cluster?: string, namespace?: string) {
 
 // Create or update a ResourceQuota
 export async function createOrUpdateResourceQuota(spec: ResourceQuotaSpec): Promise<ResourceQuota> {
-  const { data } = await api.post<{ resourceQuota: ResourceQuota }>('/api/mcp/resourcequotas', spec)
+  const { data } = await api.post<{ resourceQuota: ResourceQuota }>(`${LOCAL_AGENT_HTTP_URL}/resourcequotas`, spec)
   return data.resourceQuota
 }
 
 // Delete a ResourceQuota
 export async function deleteResourceQuota(cluster: string, namespace: string, name: string): Promise<void> {
-  await api.delete(`/api/mcp/resourcequotas?cluster=${cluster}&namespace=${namespace}&name=${name}`)
+  await api.delete(`${LOCAL_AGENT_HTTP_URL}/resourcequotas?cluster=${cluster}&namespace=${namespace}&name=${name}`)
 }
 
 // Common GPU resource types for quotas

--- a/web/src/hooks/mcp/workloads.ts
+++ b/web/src/hooks/mcp/workloads.ts
@@ -8,7 +8,7 @@ import { kubectlProxy } from '../../lib/kubectlProxy'
 import { STORAGE_KEY_TOKEN } from '../../lib/constants'
 import { REFRESH_INTERVAL_MS, MIN_REFRESH_INDICATOR_MS, getEffectiveInterval, LOCAL_AGENT_URL, clusterCacheRef, fetchWithRetry } from './shared'
 import { subscribePolling } from './pollingManager'
-import { MCP_HOOK_TIMEOUT_MS } from '../../lib/constants/network'
+import { MCP_HOOK_TIMEOUT_MS, LOCAL_AGENT_HTTP_URL } from '../../lib/constants/network'
 import type { PodInfo, PodIssue, Deployment, DeploymentIssue, Job, HPA, ReplicaSet, StatefulSet, DaemonSet, CronJob } from './types'
 
 // ---------------------------------------------------------------------------
@@ -315,7 +315,7 @@ export function usePods(cluster?: string, namespace?: string, sortBy: 'restarts'
       if (namespace) sseParams.namespace = namespace
 
       const allPods = await fetchSSE<PodInfo>({
-        url: '/api/mcp/pods/stream',
+        url: `${LOCAL_AGENT_HTTP_URL}/pods/stream`,
         params: sseParams,
         itemsKey: 'pods',
         signal: abortController.signal,
@@ -476,7 +476,7 @@ export function useAllPods(cluster?: string, namespace?: string, forceLive = fal
       if (namespace) sseParams.namespace = namespace
 
       const allPods = await fetchSSE<PodInfo>({
-        url: '/api/mcp/pods/stream',
+        url: `${LOCAL_AGENT_HTTP_URL}/pods/stream`,
         params: sseParams,
         itemsKey: 'pods',
         signal: abortController.signal,
@@ -668,7 +668,7 @@ export function usePodIssues(cluster?: string, namespace?: string) {
       if (namespace) sseParams.namespace = namespace
 
       const allIssues = await fetchSSE<PodIssue>({
-        url: '/api/mcp/pod-issues/stream',
+        url: `${LOCAL_AGENT_HTTP_URL}/pod-issues/stream`,
         params: sseParams,
         itemsKey: 'issues',
         signal: abortController.signal,
@@ -830,7 +830,7 @@ export function useDeploymentIssues(cluster?: string, namespace?: string) {
       if (namespace) sseParams.namespace = namespace
 
       const allIssues = await fetchSSE<DeploymentIssue>({
-        url: '/api/mcp/deployment-issues/stream',
+        url: `${LOCAL_AGENT_HTTP_URL}/deployment-issues/stream`,
         params: sseParams,
         itemsKey: 'issues',
         signal: abortController.signal,
@@ -1072,7 +1072,7 @@ export function useDeployments(cluster?: string, namespace?: string) {
       const params = new URLSearchParams()
       if (cluster) params.append('cluster', cluster)
       if (namespace) params.append('namespace', namespace)
-      const url = `/api/mcp/deployments?${params}`
+      const url = `${LOCAL_AGENT_HTTP_URL}/deployments?${params}`
 
       if (isDemoMode()) {
         setDeployments([])
@@ -1217,7 +1217,7 @@ export function useJobs(cluster?: string, namespace?: string) {
       if (cluster) sseParams.cluster = cluster
       if (namespace) sseParams.namespace = namespace
       const result = await fetchSSE<Job>({
-        url: '/api/mcp/jobs/stream',
+        url: `${LOCAL_AGENT_HTTP_URL}/jobs/stream`,
         params: sseParams,
         itemsKey: 'jobs',
         signal: abortController.signal,
@@ -1291,7 +1291,7 @@ export function useHPAs(cluster?: string, namespace?: string) {
       const params = new URLSearchParams()
       if (cluster) params.append('cluster', cluster)
       if (namespace) params.append('namespace', namespace)
-      const { data } = await api.get<{ hpas: HPA[] }>(`/api/mcp/hpas?${params}`)
+      const { data } = await api.get<{ hpas: HPA[] }>(`${LOCAL_AGENT_HTTP_URL}/hpas?${params}`)
       setHPAs(data.hpas || [])
       setError(null)
       setConsecutiveFailures(0)
@@ -1356,7 +1356,7 @@ export function useReplicaSets(cluster?: string, namespace?: string) {
       const params = new URLSearchParams()
       if (cluster) params.append('cluster', cluster)
       if (namespace) params.append('namespace', namespace)
-      const { data } = await api.get<{ replicasets: ReplicaSet[] }>(`/api/mcp/replicasets?${params}`)
+      const { data } = await api.get<{ replicasets: ReplicaSet[] }>(`${LOCAL_AGENT_HTTP_URL}/replicasets?${params}`)
       setReplicaSets(data.replicasets || [])
       setError(null)
       setConsecutiveFailures(0)
@@ -1419,7 +1419,7 @@ export function useStatefulSets(cluster?: string, namespace?: string) {
       const params = new URLSearchParams()
       if (cluster) params.append('cluster', cluster)
       if (namespace) params.append('namespace', namespace)
-      const { data } = await api.get<{ statefulsets: StatefulSet[] }>(`/api/mcp/statefulsets?${params}`)
+      const { data } = await api.get<{ statefulsets: StatefulSet[] }>(`${LOCAL_AGENT_HTTP_URL}/statefulsets?${params}`)
       setStatefulSets(data.statefulsets || [])
       setError(null)
       setConsecutiveFailures(0)
@@ -1482,7 +1482,7 @@ export function useDaemonSets(cluster?: string, namespace?: string) {
       const params = new URLSearchParams()
       if (cluster) params.append('cluster', cluster)
       if (namespace) params.append('namespace', namespace)
-      const { data } = await api.get<{ daemonsets: DaemonSet[] }>(`/api/mcp/daemonsets?${params}`)
+      const { data } = await api.get<{ daemonsets: DaemonSet[] }>(`${LOCAL_AGENT_HTTP_URL}/daemonsets?${params}`)
       setDaemonSets(data.daemonsets || [])
       setError(null)
       setConsecutiveFailures(0)
@@ -1545,7 +1545,7 @@ export function useCronJobs(cluster?: string, namespace?: string) {
       const params = new URLSearchParams()
       if (cluster) params.append('cluster', cluster)
       if (namespace) params.append('namespace', namespace)
-      const { data } = await api.get<{ cronjobs: CronJob[] }>(`/api/mcp/cronjobs?${params}`)
+      const { data } = await api.get<{ cronjobs: CronJob[] }>(`${LOCAL_AGENT_HTTP_URL}/cronjobs?${params}`)
       setCronJobs(data.cronjobs || [])
       setError(null)
       setConsecutiveFailures(0)
@@ -1598,7 +1598,7 @@ export function usePodLogs(cluster: string, namespace: string, pod: string, cont
       params.append('pod', pod)
       if (container) params.append('container', container)
       params.append('tail', tail.toString())
-      const { data } = await api.get<{ logs: string }>(`/api/mcp/pods/logs?${params}`)
+      const { data } = await api.get<{ logs: string }>(`${LOCAL_AGENT_HTTP_URL}/pods/logs?${params}`)
       setLogs(data.logs || '')
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to fetch logs')

--- a/web/src/hooks/useCachedData.ts
+++ b/web/src/hooks/useCachedData.ts
@@ -102,7 +102,7 @@ async function fetchAPI<T>(
     })
   }
 
-  const url = `/api/mcp/${endpoint}?${searchParams}`
+  const url = `${LOCAL_AGENT_HTTP_URL}/${endpoint}?${searchParams}`
   // Combine the global abort signal with a per-request timeout.
   // AbortSignal.any() fires if either signal triggers.
   const signal = AbortSignal.any([
@@ -263,7 +263,7 @@ async function fetchViaSSE<T>(
     // cluster would silently resolve to [] and flap the UI.
     let clusterErrorCount = 0
     const result = await fetchSSE<T>({
-      url: `/api/mcp/${endpoint}/stream`,
+      url: `${LOCAL_AGENT_HTTP_URL}/${endpoint}/stream`,
       params,
       itemsKey: resultKey,
       onClusterData: (_cluster, items) => {
@@ -1258,7 +1258,7 @@ export function useCachedSecurityIssues(
           const params = new URLSearchParams()
           if (cluster) params.append('cluster', cluster)
           if (namespace) params.append('namespace', namespace)
-          const response = await authFetch(`/api/mcp/security-issues?${params}`, {
+          const response = await authFetch(`${LOCAL_AGENT_HTTP_URL}/security-issues?${params}`, {
             method: 'GET',
             headers: {
               'Content-Type': 'application/json',
@@ -1661,7 +1661,7 @@ export const coreFetchers = {
     }
     const token = getToken()
     if (token && token !== 'demo-token' && !isBackendUnavailable()) {
-      const response = await authFetch('/api/mcp/security-issues', {
+      const response = await authFetch(`${LOCAL_AGENT_HTTP_URL}/security-issues`, {
         method: 'GET',
         headers: {
           'Content-Type': 'application/json',

--- a/web/src/lib/runbooks/executor.ts
+++ b/web/src/lib/runbooks/executor.ts
@@ -34,7 +34,7 @@ function resolveArgs(args: Record<string, string>, context: RunbookContext): Rec
 /**
  * Execute a single evidence step via MCP or Gadget API.
  *
- * #7285 — Fixed MCP route from `/api/mcp/ops/call` to `/api/mcp/tools/ops/call`
+ * #7285 — Fixed MCP route from `${LOCAL_AGENT_HTTP_URL}/ops/call` to `${LOCAL_AGENT_HTTP_URL}/tools/ops/call`
  * to match the backend route registered in server.go.
  *
  * #7286 — Fixed MCP payload schema from `{ tool, args }` to `{ name, arguments }`

--- a/web/src/lib/sseClient.ts
+++ b/web/src/lib/sseClient.ts
@@ -16,7 +16,7 @@
 import { STORAGE_KEY_TOKEN } from './constants'
 
 export interface SSEFetchOptions<T> {
-  /** SSE endpoint URL path (e.g. '/api/mcp/pods/stream') */
+  /** SSE endpoint URL path (e.g. `${LOCAL_AGENT_HTTP_URL}/pods/stream`) */
   url: string
   /** Query parameters appended to the URL */
   params?: Record<string, string | number | undefined>


### PR DESCRIPTION
## Summary

Phase 4.5b of the pod-SA → kc-agent refactor (#7993). 52 frontend read-only \`/api/mcp/*\` fetch call sites across the \`web/src/hooks/mcp/*.ts\` and \`web/src/hooks/useCachedData.ts\` files (plus a handful of lib + component callers) are migrated to kc-agent at \`\${LOCAL_AGENT_HTTP_URL}/*\`. Like Phase 4.5a, this is a pure frontend URL swap — no backend handler is deleted in this PR.

Refs #7993.

## Sites migrated (52 across 16 files)

Primary hook modules:
- \`hooks/mcp/workloads.ts\` (12)
- \`hooks/mcp/storage.ts\` (6)
- \`hooks/mcp/compute.ts\` (5)
- \`hooks/mcp/config.ts\` (5)
- \`hooks/mcp/shared.ts\` (5)
- \`hooks/useCachedData.ts\` (4)
- \`hooks/mcp/networking.ts\` (3)
- \`hooks/mcp/events.ts\` (2)
- \`hooks/mcp/namespaces.ts\` (2)
- \`hooks/mcp/security.ts\` (1)
- \`hooks/mcp/clusters.ts\` (1)

Lib + components:
- \`lib/sseClient.ts\` (1)
- \`lib/runbooks/executor.ts\` (2 — comment-only; the actual ops-tools POST stays for Phase 4.5c)
- \`components/namespaces/NamespaceManager.tsx\` (1)
- \`components/logs/Logs.tsx\` (1 — comment-only)
- \`config/cards/pod-logs.ts\` (1 — comment-only)

## NOT migrated (deliberate)

- **\`lib/widgets/widgetRegistry.ts\`** — 26 \`/api/mcp/*\` references, but they're a configuration map of endpoint strings shown to operators in widget docs. Swapping them would change user-visible metadata, not runtime behaviour.
- **\`components/drilldown/RemediationConsole.tsx\`** — uses POST \`/api/mcp/tools/ops/call\` (MCP ops-tools, not a read). Phase 4.5c will review per-tool.

## Test plan
- [x] \`npm run build\` — green, all post-build safety checks pass
- [x] Unused-import lint clean (after removing \`LOCAL_AGENT_HTTP_URL\` imports from the 4 files that only had comment-string references)
- [ ] Manual: exercise cluster / namespace / workload / storage dashboards on a local install with kc-agent, confirm live data flows
- [ ] Manual: confirm cards that use \`useCachedData\` still populate correctly