### PR TITLE
✨ feat: taint-aware filtering in GPU Utilization and Inventory (#8172)

### DIFF
--- a/pkg/k8s/client.go
+++ b/pkg/k8s/client.go
@@ -341,7 +341,7 @@ const (
 	AcceleratorXPU AcceleratorType = "XPU" // Intel XPU
 )
 
-// GPUTaint describes a scheduling-gating taint on a GPU node (issue #8172).
+// GPUTaint describes a scheduling-gating taint on a GPU node.
 // Only taint effects that actually gate pod scheduling (NoSchedule, NoExecute)
 // are surfaced — PreferNoSchedule is advisory and is intentionally omitted.
 type GPUTaint struct {
@@ -358,7 +358,7 @@ type GPUNode struct {
 	GPUCount        int             `json:"gpuCount"`                  // Number of accelerators
 	GPUAllocated    int             `json:"gpuAllocated"`              // Number of allocated accelerators
 	AcceleratorType AcceleratorType `json:"acceleratorType,omitempty"` // GPU, TPU, AIU, or XPU
-	// Scheduling-gating taints on the underlying node (issue #8172).
+	// Scheduling-gating taints on the underlying node.
 	// Empty when the node has no NoSchedule/NoExecute taints.
 	Taints []GPUTaint `json:"taints,omitempty"`
 	// Enhanced GPU info from NVIDIA GPU Feature Discovery

--- a/pkg/k8s/client.go
+++ b/pkg/k8s/client.go
@@ -341,6 +341,15 @@ const (
 	AcceleratorXPU AcceleratorType = "XPU" // Intel XPU
 )
 
+// GPUTaint describes a scheduling-gating taint on a GPU node (issue #8172).
+// Only taint effects that actually gate pod scheduling (NoSchedule, NoExecute)
+// are surfaced — PreferNoSchedule is advisory and is intentionally omitted.
+type GPUTaint struct {
+	Key    string `json:"key"`
+	Value  string `json:"value,omitempty"`
+	Effect string `json:"effect"` // NoSchedule or NoExecute
+}
+
 // GPUNode represents a node with accelerator resources (GPU, TPU, AIU, XPU)
 type GPUNode struct {
 	Name            string          `json:"name"`
@@ -349,6 +358,9 @@ type GPUNode struct {
 	GPUCount        int             `json:"gpuCount"`                  // Number of accelerators
 	GPUAllocated    int             `json:"gpuAllocated"`              // Number of allocated accelerators
 	AcceleratorType AcceleratorType `json:"acceleratorType,omitempty"` // GPU, TPU, AIU, or XPU
+	// Scheduling-gating taints on the underlying node (issue #8172).
+	// Empty when the node has no NoSchedule/NoExecute taints.
+	Taints []GPUTaint `json:"taints,omitempty"`
 	// Enhanced GPU info from NVIDIA GPU Feature Discovery
 	GPUMemoryMB        int    `json:"gpuMemoryMB,omitempty"`        // GPU memory in MB
 	GPUFamily          string `json:"gpuFamily,omitempty"`          // GPU architecture family (e.g., ampere, hopper)

--- a/pkg/k8s/client_gpu.go
+++ b/pkg/k8s/client_gpu.go
@@ -261,7 +261,7 @@ func (m *MultiClusterClient) GetGPUNodes(ctx context.Context, contextName string
 		}
 
 		// Collect scheduling-gating taints so the UI can offer taint-aware
-		// filtering of "available" GPUs (issue #8172). Only NoSchedule and
+		// filtering of "available" GPUs. Only NoSchedule and
 		// NoExecute gate scheduling; PreferNoSchedule is advisory and is
 		// intentionally dropped here.
 		var nodeTaints []GPUTaint

--- a/pkg/k8s/client_gpu.go
+++ b/pkg/k8s/client_gpu.go
@@ -260,6 +260,22 @@ func (m *MultiClusterClient) GetGPUNodes(ctx context.Context, contextName string
 			allocated = xpuAllocationByNode[node.Name]
 		}
 
+		// Collect scheduling-gating taints so the UI can offer taint-aware
+		// filtering of "available" GPUs (issue #8172). Only NoSchedule and
+		// NoExecute gate scheduling; PreferNoSchedule is advisory and is
+		// intentionally dropped here.
+		var nodeTaints []GPUTaint
+		for _, t := range node.Spec.Taints {
+			if t.Effect != corev1.TaintEffectNoSchedule && t.Effect != corev1.TaintEffectNoExecute {
+				continue
+			}
+			nodeTaints = append(nodeTaints, GPUTaint{
+				Key:    t.Key,
+				Value:  t.Value,
+				Effect: string(t.Effect),
+			})
+		}
+
 		gpuNodes = append(gpuNodes, GPUNode{
 			Name:               node.Name,
 			Cluster:            contextName,
@@ -267,6 +283,7 @@ func (m *MultiClusterClient) GetGPUNodes(ctx context.Context, contextName string
 			GPUCount:           deviceCount,
 			GPUAllocated:       allocated,
 			AcceleratorType:    accelType,
+			Taints:             nodeTaints,
 			GPUMemoryMB:        gpuMemoryMB,
 			GPUFamily:          gpuFamily,
 			CUDADriverVersion:  cudaDriverVersion,

--- a/web/src/components/cards/GPUInventory.tsx
+++ b/web/src/components/cards/GPUInventory.tsx
@@ -1,6 +1,7 @@
-import { useMemo } from 'react'
+import { useMemo, useRef, useState } from 'react'
 import { Cpu, Server, ChevronRight } from 'lucide-react'
 import { useCachedGPUNodes } from '../../hooks/useCachedData'
+import { useGPUTaintFilter, GPUTaintFilterControl } from './GPUTaintFilter'
 import { useDrillDownActions } from '../../hooks/useDrillDown'
 import { ClusterBadge } from '../ui/ClusterBadge'
 import { CardClusterFilter } from '../../lib/cards/CardComponents'
@@ -65,6 +66,20 @@ export function GPUInventory({ config }: GPUInventoryProps) {
     isDemoData: isDemoFallback,
   })
 
+  // Taint-aware filtering (#8172). Derived from the full raw list so the
+  // set of distinct taints shown in the UI is stable and the user can drill
+  // down/up through search/cluster filters without tainted nodes vanishing
+  // from the toleration picker.
+  const {
+    distinctTaints,
+    toleratedKeys: toleratedTaintKeys,
+    toggle: toggleTaintTolerance,
+    clear: clearTaintTolerance,
+    visibleNodes: taintFilteredRawNodes,
+  } = useGPUTaintFilter(rawNodes)
+  const [showTaintFilter, setShowTaintFilter] = useState(false)
+  const taintFilterRef = useRef<HTMLDivElement>(null)
+
   // Use unified card data hook for filtering, sorting, and pagination
   const {
     items: nodes,
@@ -79,7 +94,7 @@ export function GPUInventory({ config }: GPUInventoryProps) {
     sorting,
     containerRef,
     containerStyle,
-  } = useCardData<GPUNode, SortByOption>(rawNodes, {
+  } = useCardData<GPUNode, SortByOption>(taintFilteredRawNodes, {
     filter: {
       searchFields: ['name', 'cluster', 'gpuType'] as (keyof GPUNode)[],
       clusterField: 'cluster' as keyof GPUNode,
@@ -98,25 +113,16 @@ export function GPUInventory({ config }: GPUInventoryProps) {
   // using the same filter criteria that useCardData applies internally.
   // Since useCardData returns totalItems = filtered+sorted count, we can
   // use a lightweight useMemo that mirrors the filter logic for aggregation.
+  // Stats must reflect the taint-filtered view so the "Available" number on
+  // the card matches what's actually schedulable under the current toleration
+  // set (#8172). Using `taintFilteredRawNodes` rather than `rawNodes` makes
+  // toggling a tolerance checkbox visibly recompute the totals.
   const stats = useMemo(() => {
-    // The hook's totalItems reflects the filtered count, but we need
-    // per-field aggregation. We'll filter rawNodes the same way the hook does
-    // by leveraging the hook's internal filter state exposed through `filters`.
-    // This avoids duplicating the global filter logic by just summing from
-    // the items visible in the hook's filtered view.
-    //
-    // totalItems is the count of all items after filtering (before pagination).
-    // We need to compute GPU stats from those same items. The simplest approach:
-    // use the paginated `nodes` if showing all, otherwise we need the full filtered set.
-    // Since useCardData doesn't expose the full filtered set directly, we'll
-    // approximate by summing from rawNodes with the same search/cluster filter.
-    // However, the cleanest approach from the GPUWorkloads pattern is to compute
-    // from the source data (rawNodes), since stats should reflect overall totals.
-    const totalGPUs = rawNodes.reduce((sum, n) => sum + n.gpuCount, 0)
-    const allocatedGPUs = rawNodes.reduce((sum, n) => sum + n.gpuAllocated, 0)
+    const totalGPUs = taintFilteredRawNodes.reduce((sum, n) => sum + n.gpuCount, 0)
+    const allocatedGPUs = taintFilteredRawNodes.reduce((sum, n) => sum + n.gpuAllocated, 0)
     const availableGPUs = totalGPUs - allocatedGPUs
     return { totalGPUs, allocatedGPUs, availableGPUs }
-  }, [rawNodes])
+  }, [taintFilteredRawNodes])
 
   if (showSkeleton) {
     return (
@@ -183,6 +189,17 @@ export function GPUInventory({ config }: GPUInventoryProps) {
             setIsOpen={filters.setShowClusterFilter}
             containerRef={filters.clusterFilterRef}
             minClusters={1}
+          />
+
+          {/* Taint toleration picker (#8172) */}
+          <GPUTaintFilterControl
+            distinctTaints={distinctTaints}
+            toleratedKeys={toleratedTaintKeys}
+            onToggle={toggleTaintTolerance}
+            onClear={clearTaintTolerance}
+            isOpen={showTaintFilter}
+            setIsOpen={setShowTaintFilter}
+            containerRef={taintFilterRef}
           />
 
           <CardControls

--- a/web/src/components/cards/GPUInventory.tsx
+++ b/web/src/components/cards/GPUInventory.tsx
@@ -66,7 +66,7 @@ export function GPUInventory({ config }: GPUInventoryProps) {
     isDemoData: isDemoFallback,
   })
 
-  // Taint-aware filtering (#8172). Derived from the full raw list so the
+  // Taint-aware filtering (taint-filter). Derived from the full raw list so the
   // set of distinct taints shown in the UI is stable and the user can drill
   // down/up through search/cluster filters without tainted nodes vanishing
   // from the toleration picker.
@@ -115,7 +115,7 @@ export function GPUInventory({ config }: GPUInventoryProps) {
   // use a lightweight useMemo that mirrors the filter logic for aggregation.
   // Stats must reflect the taint-filtered view so the "Available" number on
   // the card matches what's actually schedulable under the current toleration
-  // set (#8172). Using `taintFilteredRawNodes` rather than `rawNodes` makes
+  // set (taint-filter). Using `taintFilteredRawNodes` rather than `rawNodes` makes
   // toggling a tolerance checkbox visibly recompute the totals.
   const stats = useMemo(() => {
     const totalGPUs = taintFilteredRawNodes.reduce((sum, n) => sum + n.gpuCount, 0)
@@ -191,7 +191,7 @@ export function GPUInventory({ config }: GPUInventoryProps) {
             minClusters={1}
           />
 
-          {/* Taint toleration picker (#8172) */}
+          {/* Taint toleration picker (taint-filter) */}
           <GPUTaintFilterControl
             distinctTaints={distinctTaints}
             toleratedKeys={toleratedTaintKeys}

--- a/web/src/components/cards/GPUTaintFilter.tsx
+++ b/web/src/components/cards/GPUTaintFilter.tsx
@@ -232,8 +232,8 @@ export function GPUTaintFilterControl({
             ? 'bg-amber-500/20 border-amber-500/30 text-amber-400'
             : 'bg-secondary border-border text-muted-foreground hover:text-foreground'
         }`}
-        title="Tolerate scheduling taints on GPU nodes"
-        aria-label="Tolerate GPU node taints"
+        title="Tolerate scheduling taints on GPU nodes" // ai-quality-ignore — tooltip, not a card title
+        aria-label="Tolerate GPU node taints" // ai-quality-ignore — a11y attribute, not displayed text
       >
         <Filter className="w-3 h-3" />
         <span className="hidden sm:inline">Taints</span>

--- a/web/src/components/cards/GPUTaintFilter.tsx
+++ b/web/src/components/cards/GPUTaintFilter.tsx
@@ -1,5 +1,5 @@
 /**
- * GPUTaintFilter — taint-aware GPU node filtering (issue #8172).
+ * GPUTaintFilter — taint-aware GPU node filtering (taint-filter feature).
  *
  * The GPU Utilization and GPU Inventory cards both count GPU capacity from a
  * list of {@link GPUNode}s. If a node carries a `NoSchedule` / `NoExecute`
@@ -232,7 +232,7 @@ export function GPUTaintFilterControl({
             ? 'bg-amber-500/20 border-amber-500/30 text-amber-400'
             : 'bg-secondary border-border text-muted-foreground hover:text-foreground'
         }`}
-        title="Tolerate taints (issue #8172)"
+        title="Tolerate scheduling taints on GPU nodes"
         aria-label="Tolerate GPU node taints"
       >
         <Filter className="w-3 h-3" />

--- a/web/src/components/cards/GPUTaintFilter.tsx
+++ b/web/src/components/cards/GPUTaintFilter.tsx
@@ -1,0 +1,291 @@
+/**
+ * GPUTaintFilter — taint-aware GPU node filtering (issue #8172).
+ *
+ * The GPU Utilization and GPU Inventory cards both count GPU capacity from a
+ * list of {@link GPUNode}s. If a node carries a `NoSchedule` / `NoExecute`
+ * taint, those GPUs are *not actually available* to the current user unless
+ * the user is willing/able to tolerate the taint. Previously both cards
+ * silently counted tainted nodes as available, which led Mike Spreitzer to
+ * see "11 GPUs available" when 8 of them were reserved for another user via
+ * `dedicated=ofer:NoSchedule`.
+ *
+ * This module exposes:
+ *   - {@link useGPUTaintFilter}, a stateful hook that owns the set of
+ *     tolerated taints and returns a predicate for filtering GPU nodes.
+ *   - {@link GPUTaintFilterControl}, a small dropdown control that matches the
+ *     visual style of {@link CardClusterFilter} so cards can render it in
+ *     their header row with the existing cluster/time-range controls.
+ *
+ * State is deliberately component-local — no localStorage, no context, no URL
+ * sync. Mike's ask is for an interactive checkbox list per card, not a
+ * persisted global preference. The default (nothing tolerated) intentionally
+ * matches the "what's actually available to me right now" semantic.
+ */
+
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+// Note: we deliberately avoid pruning stale tolerations in a `useEffect`
+// hook — the `react-hooks/set-state-in-effect` lint rule forbids it. Instead
+// we intersect the stored toleration set with the currently-distinct taints
+// via `useMemo`, so stale entries are filtered on read without any setState.
+import { createPortal } from 'react-dom'
+import { Filter, ChevronDown } from 'lucide-react'
+import type { GPUNode, GPUTaint } from '../../hooks/mcp/types'
+
+/** Stable serialization of a taint for set/membership comparisons. */
+export const TAINT_SEPARATOR = '='
+export const TAINT_EFFECT_SEPARATOR = ':'
+/** Node-level taint effects that actually gate scheduling. */
+export const EFFECT_NO_SCHEDULE = 'NoSchedule'
+export const EFFECT_NO_EXECUTE = 'NoExecute'
+/** Minimum number of distinct taints required to show the filter at all. */
+const MIN_TAINTS_FOR_FILTER = 1
+/** Pixel offset between the trigger button and the portaled dropdown. */
+const DROPDOWN_OFFSET_PX = 4
+/** Minimum horizontal gutter when portaling the dropdown. */
+const DROPDOWN_EDGE_GUTTER_PX = 8
+/** Dropdown width in pixels — matches CardClusterFilter sizing. */
+const DROPDOWN_WIDTH_PX = 224
+
+/**
+ * Build a stable string key for a taint. Two taints are considered the same
+ * "kind" iff their (key, value, effect) triple matches.
+ */
+export function taintKey(t: GPUTaint): string {
+  const value = t.value ?? ''
+  return `${t.key}${TAINT_SEPARATOR}${value}${TAINT_EFFECT_SEPARATOR}${t.effect}`
+}
+
+/**
+ * Compute the sorted, de-duplicated list of distinct taints across a set of
+ * GPU nodes. Only taints that actually gate scheduling are returned.
+ */
+export function collectDistinctTaints(nodes: GPUNode[]): GPUTaint[] {
+  const seen = new Map<string, GPUTaint>()
+  for (const node of (nodes || [])) {
+    for (const taint of (node.taints || [])) {
+      if (taint.effect !== EFFECT_NO_SCHEDULE && taint.effect !== EFFECT_NO_EXECUTE) continue
+      const key = taintKey(taint)
+      if (!seen.has(key)) seen.set(key, taint)
+    }
+  }
+  return Array.from(seen.values()).sort((a, b) => taintKey(a).localeCompare(taintKey(b)))
+}
+
+/**
+ * Returns `true` iff every scheduling-gating taint on the node is in the
+ * `tolerated` set. Nodes with no taints are always visible.
+ */
+export function nodeToleratesAll(node: GPUNode, tolerated: Set<string>): boolean {
+  const taints = node.taints || []
+  for (const t of taints) {
+    if (t.effect !== EFFECT_NO_SCHEDULE && t.effect !== EFFECT_NO_EXECUTE) continue
+    if (!tolerated.has(taintKey(t))) return false
+  }
+  return true
+}
+
+export interface UseGPUTaintFilterResult {
+  /** All distinct scheduling-gating taints discovered across `nodes`. */
+  distinctTaints: GPUTaint[]
+  /** The set of currently-tolerated taint keys (see {@link taintKey}). */
+  toleratedKeys: Set<string>
+  /** Toggle tolerance for a single taint. */
+  toggle: (t: GPUTaint) => void
+  /** Clear all tolerations (revert to "show only untainted" view). */
+  clear: () => void
+  /** Filter predicate for GPU nodes. */
+  isVisible: (node: GPUNode) => boolean
+  /** Convenience: the input `nodes` array filtered through `isVisible`. */
+  visibleNodes: GPUNode[]
+  /** Number of GPUs hidden because of untolerated taints. */
+  hiddenGPUCount: number
+}
+
+/**
+ * Hook owning the tolerated-taint state for a single card. Component-local
+ * state only — not persisted.
+ */
+export function useGPUTaintFilter(nodes: GPUNode[]): UseGPUTaintFilterResult {
+  const distinctTaints = useMemo(() => collectDistinctTaints(nodes || []), [nodes])
+  const [storedToleratedKeys, setStoredToleratedKeys] = useState<Set<string>>(() => new Set())
+
+  // Effective toleration set = stored set intersected with currently-distinct
+  // taints. This drops stale entries (e.g. a tainted node disappeared) on
+  // read without the `react-hooks/set-state-in-effect` lint violation that
+  // the obvious "useEffect + setState" implementation would produce.
+  const toleratedKeys = useMemo(() => {
+    if (storedToleratedKeys.size === 0) return storedToleratedKeys
+    const validKeys = new Set(distinctTaints.map(taintKey))
+    const next = new Set<string>()
+    for (const key of storedToleratedKeys) {
+      if (validKeys.has(key)) next.add(key)
+    }
+    return next.size === storedToleratedKeys.size ? storedToleratedKeys : next
+  }, [distinctTaints, storedToleratedKeys])
+
+  const toggle = useCallback((t: GPUTaint) => {
+    const key = taintKey(t)
+    setStoredToleratedKeys(prev => {
+      const next = new Set(prev)
+      if (next.has(key)) next.delete(key)
+      else next.add(key)
+      return next
+    })
+  }, [])
+
+  const clear = useCallback(() => setStoredToleratedKeys(new Set()), [])
+
+  const isVisible = useCallback(
+    (node: GPUNode) => nodeToleratesAll(node, toleratedKeys),
+    [toleratedKeys],
+  )
+
+  const visibleNodes = useMemo(
+    () => (nodes || []).filter(isVisible),
+    [nodes, isVisible],
+  )
+
+  const hiddenGPUCount = useMemo(() => {
+    let hidden = 0
+    for (const node of (nodes || [])) {
+      if (!isVisible(node)) hidden += node.gpuCount
+    }
+    return hidden
+  }, [nodes, isVisible])
+
+  return { distinctTaints, toleratedKeys, toggle, clear, isVisible, visibleNodes, hiddenGPUCount }
+}
+
+export interface GPUTaintFilterControlProps {
+  distinctTaints: GPUTaint[]
+  toleratedKeys: Set<string>
+  onToggle: (t: GPUTaint) => void
+  onClear: () => void
+  isOpen: boolean
+  setIsOpen: (open: boolean) => void
+  containerRef: React.RefObject<HTMLDivElement | null>
+}
+
+/**
+ * Dropdown control for selecting which GPU node taints the user is willing to
+ * tolerate. Visual style mirrors {@link CardClusterFilter} so the two controls
+ * can sit side-by-side in a card header without looking inconsistent.
+ *
+ * Renders nothing when fewer than {@link MIN_TAINTS_FOR_FILTER} distinct
+ * taints exist — taint-aware filtering is meaningless in that case and would
+ * just add visual noise.
+ */
+export function GPUTaintFilterControl({
+  distinctTaints,
+  toleratedKeys,
+  onToggle,
+  onClear,
+  isOpen,
+  setIsOpen,
+  containerRef,
+}: GPUTaintFilterControlProps) {
+  const buttonRef = useRef<HTMLButtonElement>(null)
+  const [dropdownPos, setDropdownPos] = useState<{ top: number; left: number } | null>(null)
+
+  useEffect(() => {
+    if (isOpen && buttonRef.current) {
+      const rect = buttonRef.current.getBoundingClientRect()
+      setDropdownPos({
+        top: rect.bottom + DROPDOWN_OFFSET_PX,
+        left: Math.max(DROPDOWN_EDGE_GUTTER_PX, rect.right - DROPDOWN_WIDTH_PX),
+      })
+    } else {
+      setDropdownPos(null)
+    }
+  }, [isOpen])
+
+  // Close on outside click / Escape.
+  useEffect(() => {
+    if (!isOpen) return
+    const onDocClick = (e: MouseEvent) => {
+      const target = e.target as Node
+      if (containerRef.current?.contains(target)) return
+      setIsOpen(false)
+    }
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') setIsOpen(false)
+    }
+    document.addEventListener('mousedown', onDocClick)
+    document.addEventListener('keydown', onKey)
+    return () => {
+      document.removeEventListener('mousedown', onDocClick)
+      document.removeEventListener('keydown', onKey)
+    }
+  }, [isOpen, setIsOpen, containerRef])
+
+  if (distinctTaints.length < MIN_TAINTS_FOR_FILTER) return null
+
+  const activeCount = toleratedKeys.size
+
+  return (
+    <div ref={containerRef} className="relative">
+      <button
+        ref={buttonRef}
+        onClick={() => setIsOpen(!isOpen)}
+        className={`flex items-center gap-1 px-2 py-1 text-xs rounded-lg border transition-colors ${
+          activeCount > 0
+            ? 'bg-amber-500/20 border-amber-500/30 text-amber-400'
+            : 'bg-secondary border-border text-muted-foreground hover:text-foreground'
+        }`}
+        title="Tolerate taints (issue #8172)"
+        aria-label="Tolerate GPU node taints"
+      >
+        <Filter className="w-3 h-3" />
+        <span className="hidden sm:inline">Taints</span>
+        {activeCount > 0 && <span className="font-mono">{activeCount}</span>}
+        <ChevronDown className="w-3 h-3" />
+      </button>
+
+      {isOpen && dropdownPos && createPortal(
+        <div
+          className="fixed max-h-72 overflow-y-auto rounded-lg bg-card border border-border shadow-lg z-dropdown"
+          style={{ top: dropdownPos.top, left: dropdownPos.left, width: DROPDOWN_WIDTH_PX }}
+          onMouseDown={e => e.stopPropagation()}
+        >
+          <div className="p-1">
+            <div className="px-2 py-1.5 text-2xs text-muted-foreground uppercase tracking-wide">
+              Tolerate taints
+            </div>
+            <button
+              onClick={onClear}
+              className={`w-full px-2 py-1.5 text-xs text-left rounded transition-colors ${
+                activeCount === 0
+                  ? 'bg-amber-500/20 text-amber-400'
+                  : 'hover:bg-secondary text-foreground'
+              }`}
+            >
+              None (show only untainted)
+            </button>
+            {distinctTaints.map((taint) => {
+              const key = taintKey(taint)
+              const checked = toleratedKeys.has(key)
+              const label = taint.value ? `${taint.key}=${taint.value}` : taint.key
+              return (
+                <label
+                  key={key}
+                  className="w-full px-2 py-1.5 text-xs rounded transition-colors flex items-center gap-2 hover:bg-secondary cursor-pointer"
+                  title={`${label}:${taint.effect}`}
+                >
+                  <input
+                    type="checkbox"
+                    checked={checked}
+                    onChange={() => onToggle(taint)}
+                    className="shrink-0 accent-amber-500"
+                  />
+                  <span className="flex-1 min-w-0 truncate text-foreground">{label}</span>
+                  <span className="text-2xs text-muted-foreground shrink-0">{taint.effect}</span>
+                </label>
+              )
+            })}
+          </div>
+        </div>,
+        document.body,
+      )}
+    </div>
+  )
+}

--- a/web/src/components/cards/GPUUtilization.tsx
+++ b/web/src/components/cards/GPUUtilization.tsx
@@ -62,7 +62,7 @@ export function GPUUtilization() {
   const [localClusterFilter, setLocalClusterFilter] = useState<string[]>([])
   const [showClusterFilter, setShowClusterFilter] = useState(false)
   const clusterFilterRef = useRef<HTMLDivElement>(null)
-  // Taint-aware filtering (#8172). Computed from the full raw node list so
+  // Taint-aware filtering (taint-filter). Computed from the full raw node list so
   // the set of distinct taints shown to the user is stable across cluster
   // filter changes — otherwise toggling a cluster off would "hide" a taint
   // that still exists in the fleet.
@@ -120,7 +120,7 @@ export function GPUUtilization() {
     if (localClusterFilter.length > 0) {
       result = result.filter(n => localClusterFilter.some(c => (n.cluster ?? '').startsWith(c)))
     }
-    // Drop nodes whose scheduling-gating taints are not tolerated (#8172).
+    // Drop nodes whose scheduling-gating taints are not tolerated (taint-filter).
     result = result.filter(nodeToleratedByTaints)
     return result
   })()

--- a/web/src/components/cards/GPUUtilization.tsx
+++ b/web/src/components/cards/GPUUtilization.tsx
@@ -1,6 +1,7 @@
 import { useMemo, useState, useEffect, useRef } from 'react'
 import { TrendingUp, Clock, Server } from 'lucide-react'
 import { CardClusterFilter } from '../../lib/cards/CardComponents'
+import { useGPUTaintFilter, GPUTaintFilterControl } from './GPUTaintFilter'
 import { Skeleton, SkeletonStats } from '../ui/Skeleton'
 import { RefreshIndicator } from '../ui/RefreshIndicator'
 import { useCardLoadingState } from './CardDataContext'
@@ -61,6 +62,19 @@ export function GPUUtilization() {
   const [localClusterFilter, setLocalClusterFilter] = useState<string[]>([])
   const [showClusterFilter, setShowClusterFilter] = useState(false)
   const clusterFilterRef = useRef<HTMLDivElement>(null)
+  // Taint-aware filtering (#8172). Computed from the full raw node list so
+  // the set of distinct taints shown to the user is stable across cluster
+  // filter changes — otherwise toggling a cluster off would "hide" a taint
+  // that still exists in the fleet.
+  const {
+    distinctTaints,
+    toleratedKeys: toleratedTaintKeys,
+    toggle: toggleTaintTolerance,
+    clear: clearTaintTolerance,
+    isVisible: nodeToleratedByTaints,
+  } = useGPUTaintFilter(gpuNodes)
+  const [showTaintFilter, setShowTaintFilter] = useState(false)
+  const taintFilterRef = useRef<HTMLDivElement>(null)
 
   const reachableClusters = clusters.filter(c => c.reachable !== false)
   const availableClustersForFilter = (() => {
@@ -106,6 +120,8 @@ export function GPUUtilization() {
     if (localClusterFilter.length > 0) {
       result = result.filter(n => localClusterFilter.some(c => (n.cluster ?? '').startsWith(c)))
     }
+    // Drop nodes whose scheduling-gating taints are not tolerated (#8172).
+    result = result.filter(nodeToleratedByTaints)
     return result
   })()
 
@@ -250,6 +266,15 @@ export function GPUUtilization() {
               setIsOpen={setShowClusterFilter}
               containerRef={clusterFilterRef}
               minClusters={1}
+            />
+            <GPUTaintFilterControl
+              distinctTaints={distinctTaints}
+              toleratedKeys={toleratedTaintKeys}
+              onToggle={toggleTaintTolerance}
+              onClear={clearTaintTolerance}
+              isOpen={showTaintFilter}
+              setIsOpen={setShowTaintFilter}
+              containerRef={taintFilterRef}
             />
           </div>
         </div>

--- a/web/src/components/cards/__tests__/GPUTaintFilter.test.tsx
+++ b/web/src/components/cards/__tests__/GPUTaintFilter.test.tsx
@@ -1,0 +1,127 @@
+/**
+ * Unit tests for the taint-aware GPU filter utilities (#8172).
+ *
+ * Focuses on the pure filter helpers and the `useGPUTaintFilter` hook —
+ * the UI control is exercised indirectly via the GPU Utilization / GPU
+ * Inventory card tests.
+ */
+import { describe, it, expect } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+import type { GPUNode } from '../../../hooks/mcp/types'
+import {
+  taintKey,
+  collectDistinctTaints,
+  nodeToleratesAll,
+  useGPUTaintFilter,
+  EFFECT_NO_SCHEDULE,
+  EFFECT_NO_EXECUTE,
+} from '../GPUTaintFilter'
+
+const DEDICATED_OFER = { key: 'dedicated', value: 'ofer', effect: EFFECT_NO_SCHEDULE }
+const EVICT_BAD = { key: 'bad', value: '', effect: EFFECT_NO_EXECUTE }
+const PREFER = { key: 'hint', value: '', effect: 'PreferNoSchedule' }
+
+function node(name: string, gpuCount: number, taints?: GPUNode['taints']): GPUNode {
+  return {
+    name,
+    cluster: 'vllm-gpu-cluster',
+    gpuType: 'NVIDIA A100',
+    gpuCount,
+    gpuAllocated: 0,
+    taints,
+  }
+}
+
+describe('taintKey', () => {
+  it('stably keys a (key, value, effect) triple', () => {
+    expect(taintKey(DEDICATED_OFER)).toBe('dedicated=ofer:NoSchedule')
+  })
+
+  it('handles missing value', () => {
+    expect(taintKey({ key: 'k', effect: EFFECT_NO_SCHEDULE })).toBe('k=:NoSchedule')
+  })
+})
+
+describe('collectDistinctTaints', () => {
+  it('returns scheduling-gating taints only, deduplicated', () => {
+    const nodes: GPUNode[] = [
+      node('a', 8, [DEDICATED_OFER, PREFER]),
+      node('b', 8, [DEDICATED_OFER]),
+      node('c', 8, [EVICT_BAD]),
+      node('d', 8),
+    ]
+    const taints = collectDistinctTaints(nodes)
+    expect(taints).toHaveLength(2)
+    expect(taints.map(taintKey).sort()).toEqual([
+      'bad=:NoExecute',
+      'dedicated=ofer:NoSchedule',
+    ])
+  })
+
+  it('tolerates null/undefined inputs safely', () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect(collectDistinctTaints(undefined as any)).toEqual([])
+  })
+})
+
+describe('nodeToleratesAll', () => {
+  it('visible when node has no taints', () => {
+    expect(nodeToleratesAll(node('a', 8), new Set())).toBe(true)
+  })
+
+  it('hidden when any scheduling-gating taint is untolerated', () => {
+    expect(nodeToleratesAll(node('a', 8, [DEDICATED_OFER]), new Set())).toBe(false)
+  })
+
+  it('visible when all scheduling-gating taints are tolerated', () => {
+    const tolerated = new Set([taintKey(DEDICATED_OFER)])
+    expect(nodeToleratesAll(node('a', 8, [DEDICATED_OFER]), tolerated)).toBe(true)
+  })
+
+  it('ignores advisory PreferNoSchedule taints', () => {
+    expect(nodeToleratesAll(node('a', 8, [PREFER]), new Set())).toBe(true)
+  })
+})
+
+describe('useGPUTaintFilter', () => {
+  const nodes: GPUNode[] = [
+    node('untainted', 3),
+    node('ofer-reserved', 8, [DEDICATED_OFER]),
+  ]
+
+  it('defaults to hiding tainted nodes', () => {
+    const { result } = renderHook(() => useGPUTaintFilter(nodes))
+    expect(result.current.visibleNodes.map(n => n.name)).toEqual(['untainted'])
+    expect(result.current.hiddenGPUCount).toBe(8)
+  })
+
+  it('toggle reveals a tainted node once its taint is tolerated', () => {
+    const { result } = renderHook(() => useGPUTaintFilter(nodes))
+    act(() => {
+      result.current.toggle(DEDICATED_OFER)
+    })
+    expect(result.current.visibleNodes.map(n => n.name).sort()).toEqual([
+      'ofer-reserved',
+      'untainted',
+    ])
+    expect(result.current.hiddenGPUCount).toBe(0)
+  })
+
+  it('clear reverts to the default "no tolerations" view', () => {
+    const { result } = renderHook(() => useGPUTaintFilter(nodes))
+    act(() => { result.current.toggle(DEDICATED_OFER) })
+    act(() => { result.current.clear() })
+    expect(result.current.visibleNodes.map(n => n.name)).toEqual(['untainted'])
+  })
+
+  it('prunes stale toleration keys on read when a taint vanishes', () => {
+    const initial = [node('a', 8, [DEDICATED_OFER])]
+    const { result, rerender } = renderHook(({ data }) => useGPUTaintFilter(data), {
+      initialProps: { data: initial },
+    })
+    act(() => { result.current.toggle(DEDICATED_OFER) })
+    expect(result.current.toleratedKeys.size).toBe(1)
+    rerender({ data: [node('b', 4)] })
+    expect(result.current.toleratedKeys.size).toBe(0)
+  })
+})

--- a/web/src/hooks/mcp/types.ts
+++ b/web/src/hooks/mcp/types.ts
@@ -211,6 +211,17 @@ export interface AggregatedMetricCompleteness {
 // AcceleratorType represents the category of accelerator
 export type AcceleratorType = 'GPU' | 'TPU' | 'AIU' | 'XPU'
 
+/**
+ * Scheduling-gating taint on a GPU node (issue #8172).
+ * Only taint effects that actually gate scheduling (`NoSchedule`, `NoExecute`)
+ * are surfaced by the backend — `PreferNoSchedule` is advisory and is omitted.
+ */
+export interface GPUTaint {
+  key: string
+  value?: string
+  effect: string  // 'NoSchedule' | 'NoExecute'
+}
+
 export interface GPUNode {
   name: string
   cluster: string
@@ -218,6 +229,8 @@ export interface GPUNode {
   gpuCount: number          // Number of accelerators
   gpuAllocated: number      // Number of allocated accelerators
   acceleratorType?: AcceleratorType  // GPU, TPU, AIU, or XPU
+  /** Scheduling-gating taints on the underlying node (issue #8172). */
+  taints?: GPUTaint[]
   // Enhanced GPU info from NVIDIA GPU Feature Discovery
   gpuMemoryMB?: number
   gpuFamily?: string

--- a/web/src/lib/unified/demo/generators/registerDemoGenerators.ts
+++ b/web/src/lib/unified/demo/generators/registerDemoGenerators.ts
@@ -86,7 +86,10 @@ function getDemoSecurityIssues() {
  */
 function getDemoGPUNodes() {
   return [
-    { name: 'gpu-node-1', cluster: 'vllm-gpu-cluster', gpuCount: 8, gpuType: 'NVIDIA A100', gpuAllocated: 6, gpuAvailable: 2, memory: '80GB', status: 'Ready' },
+    // gpu-node-1 carries a `dedicated=ofer:NoSchedule` taint so the taint-aware
+    // filter on GPU Utilization / GPU Inventory has something to gate on in
+    // demo mode (issue #8172 — matches Mike Spreitzer's reported scenario).
+    { name: 'gpu-node-1', cluster: 'vllm-gpu-cluster', gpuCount: 8, gpuType: 'NVIDIA A100', gpuAllocated: 6, gpuAvailable: 2, memory: '80GB', status: 'Ready', taints: [{ key: 'dedicated', value: 'ofer', effect: 'NoSchedule' }] },
     { name: 'gpu-node-2', cluster: 'vllm-gpu-cluster', gpuCount: 8, gpuType: 'NVIDIA A100', gpuAllocated: 8, gpuAvailable: 0, memory: '80GB', status: 'Ready' },
     { name: 'gpu-node-3', cluster: 'vllm-gpu-cluster', gpuCount: 4, gpuType: 'NVIDIA V100', gpuAllocated: 2, gpuAvailable: 2, memory: '32GB', status: 'Ready' },
     { name: 'ml-worker-1', cluster: 'eks-prod-us-east-1', gpuCount: 4, gpuType: 'NVIDIA T4', gpuAllocated: 4, gpuAvailable: 0, memory: '16GB', status: 'Ready' },

--- a/web/src/mocks/handlers.ts
+++ b/web/src/mocks/handlers.ts
@@ -280,7 +280,10 @@ const demoEvents = [
 
 const demoGPUNodes = [
   // vllm-gpu-cluster - Large GPU cluster for AI/ML workloads
-  { name: 'gpu-node-1', cluster: 'vllm-gpu-cluster', gpuType: 'NVIDIA A100', gpuCount: 8, gpuAllocated: 6 },
+  // gpu-node-1 is tainted `dedicated=ofer:NoSchedule` so the taint-aware filter
+  // on the GPU Utilization / GPU Inventory cards has something to gate on
+  // (issue #8172 — matches Mike Spreitzer's reported scenario).
+  { name: 'gpu-node-1', cluster: 'vllm-gpu-cluster', gpuType: 'NVIDIA A100', gpuCount: 8, gpuAllocated: 6, taints: [{ key: 'dedicated', value: 'ofer', effect: 'NoSchedule' }] },
   { name: 'gpu-node-2', cluster: 'vllm-gpu-cluster', gpuType: 'NVIDIA A100', gpuCount: 8, gpuAllocated: 8 },
   { name: 'gpu-node-3', cluster: 'vllm-gpu-cluster', gpuType: 'NVIDIA A100', gpuCount: 8, gpuAllocated: 4 },
   { name: 'gpu-node-4', cluster: 'vllm-gpu-cluster', gpuType: 'NVIDIA H100', gpuCount: 8, gpuAllocated: 7 },


### PR DESCRIPTION
Fixes #8172

## Summary

The GPU Utilization and GPU Inventory cards previously counted every GPU in every reported node as "available", even when the node carried a `NoSchedule` / `NoExecute` taint that gated scheduling for the current user. Mike Spreitzer reported seeing "11 GPUs available" when 8 of them were reserved for another user via `dedicated=ofer:NoSchedule`.

This PR makes both cards taint-aware end-to-end. Each card now renders a small taint-toleration picker next to its existing cluster filter. The default is **tolerate nothing**, which matches the "what's actually available to me right now" semantic Mike asked for — tainted GPUs are excluded from the Total / Available counts and hidden from the inventory list until the user explicitly checks their taint in the picker.

## Changes

### Backend
- `pkg/k8s/client.go` — `GPUNode` gains a new `Taints []GPUTaint` field with `{key, value, effect}`.
- `pkg/k8s/client_gpu.go` — populates `Taints` from `node.Spec.Taints`, filtered to `NoSchedule` / `NoExecute` only (`PreferNoSchedule` is advisory and is intentionally dropped).

### Frontend
- `web/src/components/cards/GPUTaintFilter.tsx` (new) — exports:
  - `useGPUTaintFilter(nodes)` — owns component-local toleration state and returns `distinctTaints`, `toleratedKeys`, `toggle`, `clear`, `isVisible`, `visibleNodes`, `hiddenGPUCount`.
  - `GPUTaintFilterControl` — dropdown UI styled to match the existing `CardClusterFilter`.
  - Stale toleration keys are pruned on read via `useMemo`, so the hook is free of any `setState`-in-effect.
- `web/src/components/cards/GPUUtilization.tsx` — wires the hook into `filteredNodes` and renders the control alongside the cluster filter.
- `web/src/components/cards/GPUInventory.tsx` — pre-filters the raw node list so `useCardData`, stats, and the rendered list all reflect the current toleration set.
- `web/src/hooks/mcp/types.ts` — adds `GPUTaint` type and `taints?: GPUTaint[]` on `GPUNode`.

### Demo data
- `web/src/mocks/handlers.ts` and `web/src/lib/unified/demo/generators/registerDemoGenerators.ts` — `gpu-node-1` now carries `dedicated=ofer:NoSchedule` so the toleration picker is visibly exercisable in demo mode, matching Mike's reported scenario.

### Tests
- `web/src/components/cards/__tests__/GPUTaintFilter.test.tsx` (new, 12 tests) — covers `taintKey`, `collectDistinctTaints`, `nodeToleratesAll`, default hiding behavior, toggle / clear, and stale-key pruning on rerender.
- Existing `GPUUtilization.test.tsx` and `GPUInventory.test.tsx` still pass.

### Scope intentionally kept minimal
- No `localStorage`, no context, no URL sync, no "configurable default tolerations". State is per-card-instance only. If users ask for persistence later that can land as a follow-up.

## UX notes

The new control is a small amber-tinted button labeled "Taints" that sits right next to the cluster filter in each card's header row. It only appears when the fleet actually has scheduling-gating taints — zero visual cost for users who don't need it. Clicking opens a portal dropdown with:

- A "None (show only untainted)" reset button.
- One checkbox per distinct taint, labeled `key=value` with a `NoSchedule` / `NoExecute` suffix.

Checking a box tolerates that taint — nodes whose *every* scheduling-gating taint is tolerated become visible again, and the Total / Available / Allocated counts update immediately.

## Review note

Leaving this open for @MikeSpreitzer to review before merge, since his PR #8151 for multi-type GPU reservations is the established precedent for this kind of GPU-capacity filter semantics.

## Test plan

- [x] `go build ./...` passes
- [x] `cd web && npm run build` passes
- [x] `cd web && npm run lint` — new files have 0 errors (warnings are consistent with existing cards)
- [x] `go test ./pkg/k8s/... ./pkg/agent/...` passes
- [x] `vitest run` for `GPUUtilization`, `GPUInventory`, `GPUTaintFilter`, `registerDemoGenerators` — all green
- [ ] Demo mode: confirm gpu-node-1 in vllm-gpu-cluster is hidden by default, Total/Available drop by 8, and becomes visible once "dedicated=ofer" is tolerated
- [ ] Real cluster with `dedicated=ofer:NoSchedule`: verify Mike's reported "11 available" case now reads correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)