### PR TITLE
🐛 fix: useExecSession wss URL test

### DIFF
--- a/web/src/hooks/__tests__/useExecSession-expand.test.ts
+++ b/web/src/hooks/__tests__/useExecSession-expand.test.ts
@@ -161,14 +161,22 @@ describe('useExecSession — expanded edge cases', () => {
     expect(result.current.reconnectAttempt).toBe(0)
   })
 
-  // 7. WebSocket URL uses wss: for https: protocol
-  it('builds wss: URL when page uses https', () => {
+  // 7. WebSocket URL routes through the local kc-agent regardless of page protocol.
+  //
+  // Pre-#8168 (phase3d) this hook built the URL from `window.location`
+  // (e.g. `wss://<page-host>/ws/exec`). After the exec migration to kc-agent
+  // (#7993 / #8168), the SPDY exec stream runs under the user's own kubeconfig
+  // via a local WebSocket to `LOCAL_AGENT_WS_URL` — always ws://127.0.0.1:8585
+  // in the non-Netlify build. The page protocol no longer affects the URL,
+  // so this test asserts the new, stable target (see useExecSession.ts:235).
+  it('builds kc-agent /ws/exec URL regardless of page protocol', () => {
     // Save original
-    const originalProtocol = window.location.protocol
-    // Mock protocol
+    const originalLocation = window.location
+    // Mock protocol — the URL builder must ignore this post-#8168.
     Object.defineProperty(window, 'location', {
       value: { protocol: 'https:', host: 'example.com' },
       writable: true,
+      configurable: true,
     })
 
     const constructorSpy = vi.fn().mockReturnValue(mockWs)
@@ -178,12 +186,13 @@ describe('useExecSession — expanded edge cases', () => {
 
     const { result } = renderHook(() => useExecSession())
     act(() => { result.current.connect(DEFAULT_CONFIG) })
-    expect(constructorSpy).toHaveBeenCalledWith('wss://example.com/ws/exec')
+    expect(constructorSpy).toHaveBeenCalledWith('ws://127.0.0.1:8585/ws/exec')
 
     // Restore
     Object.defineProperty(window, 'location', {
-      value: { protocol: originalProtocol, host: window.location.host },
+      value: originalLocation,
       writable: true,
+      configurable: true,
     })
   })
 


### PR DESCRIPTION
Fixes #8175

## Root cause

The `builds wss: URL when page uses https` test in `useExecSession-expand.test.ts` was asserting the pre-phase3d URL shape — `wss://<page-host>/ws/exec` — built from `window.location.protocol`.

After #8168 migrated pod exec to kc-agent (#7993 Phase 3d), the hook uses the `LOCAL_AGENT_WS_URL` constant (`ws://127.0.0.1:8585/ws`) unconditionally, because the SPDY exec stream now runs under the user's own kubeconfig on the local loopback rather than through the page origin. The page protocol no longer influences the URL, so the old assertion has been stale since #8168 merged.

**This is a pre-existing flake** that Coverage Suite run #760 happened to surface on top of b828c874 (#8169). #8169 only touched `useDashboardHealth`, MSW handlers, and `useDashboardHealth.test.ts` — none of which are related to exec session URL construction.

## Verification

- Reproduced the failure on unmodified main: test fails with `expected wss://example.com/ws/exec, received ws://127.0.0.1:8585/ws/exec` — confirms the source pointer to `useExecSession.ts:235`.
- Test passes in isolation after the fix (14/14).
- Test passes alongside `useDashboardHealth.test.ts` (23/23) — no cross-test state leak.
- `npm run build` clean.
- `npm run lint` clean for the changed file.

## Fix

Renamed the test to `builds kc-agent /ws/exec URL regardless of page protocol` and asserted the new, stable target (`ws://127.0.0.1:8585/ws/exec`). Inline comment documents the rationale with a source pointer to `useExecSession.ts:235` so future readers don't reintroduce the old assertion.