### PR TITLE
📝 docs: rationale belongs in PR body, not allowlist file

### DIFF
--- a/pkg/k8s/client.go
+++ b/pkg/k8s/client.go
@@ -71,8 +71,10 @@ import (
 //  1. If the handler legitimately needs to mutate a managed cluster via the
 //     pod SA, declare the field as *PrivilegedClient to flag intent for
 //     reviewers, AND add the handler's file basename to
-//     .github/allowlist-privileged-client-callers.txt in the same PR with a
-//     short justification.
+//     .github/allowlist-privileged-client-callers.txt in the same PR. The
+//     allowlist file itself takes only plain basenames (no inline
+//     justifications); explain the rationale for the new exception in the
+//     PR description, as the lint workflow's failure message instructs.
 //  2. If the handler is user-initiated work, it must go through kc-agent
 //     with the caller's kubeconfig instead — neither the type alias nor an
 //     allowlist entry is appropriate.


### PR DESCRIPTION
Fixes #8180

## Summary

Recursive Copilot review follow-up on #8178 (which was itself a follow-up on #8174).

The `PrivilegedClient` doc comment in `pkg/k8s/client.go` told authors:

> add the handler's file basename to `.github/allowlist-privileged-client-callers.txt` in the same PR with a short justification.

But the allowlist file only takes plain basenames — it has no inline-justification format. Both the allowlist file header and the lint workflow's failure message instruct authors to explain the rationale in the PR description instead:

- `.github/allowlist-privileged-client-callers.txt` header: *"Adding a new file to this allowlist is a security decision. Do it in the same PR as the new exception and explain the rationale in the PR body."*
- `.github/workflows/privileged-client-lint.yml` failure message: *"update \$ALLOWLIST_FILE in the same PR and explain the reason in the PR description."*

This PR corrects the doc comment to match that policy.

## Test plan

- [x] `go build ./...` passes (no code changes, comment only)
- [x] No behavior change; comment-only edit to `pkg/k8s/client.go`