### PR TITLE
🐛 fix: AI Missions sidebar must show terminal missions (#8143)

### DIFF
--- a/web/src/components/layout/mission-sidebar/MissionSidebar.tsx
+++ b/web/src/components/layout/mission-sidebar/MissionSidebar.tsx
@@ -376,12 +376,19 @@ export function MissionSidebar() {
     return m.title.toLowerCase().includes(q) || m.description.toLowerCase().includes(q)
   }
   const savedMissions = missions.filter(m => m.status === 'saved' && matchesSearch(m))
-  // #5946 — "Active" missions must exclude completed, failed, and cancelled
-  // missions. Previously this filter only excluded 'saved', which caused
-  // terminal missions to still appear under the active list and inflate the
-  // count.
+  // issue 8143 — The sidebar list MUST show terminal (completed / failed /
+  // cancelled) missions so users can find their mission history. Issue 5946
+  // tightened this filter to isActiveMission, which correctly excludes
+  // terminal entries from the MissionSidebarToggle count badge but was
+  // mistakenly applied to the list too — and with no "History" section to
+  // catch the excluded entries, every finished mission simply vanished
+  // from the sidebar. The list filter only excludes 'saved' (which has its
+  // own section above); the toggle-badge count below still uses
+  // isActiveMission so the badge stays accurate. Named `activeMissions`
+  // for historical continuity with the many references below, but the
+  // contents are now "all non-library missions".
   const activeMissions = missions
-    .filter(m => isActiveMission(m) && matchesSearch(m))
+    .filter(m => m.status !== 'saved' && matchesSearch(m))
     .sort((a, b) => new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime())
 
   /** Paginated slice of active missions for rendering (#4778) */
@@ -389,12 +396,13 @@ export function MissionSidebar() {
   const hasMoreMissions = activeMissions.length > visibleMissionCount
 
   /**
-   * Total missions actually rendered in the list view (saved + active).
-   * Used so the list header count and the chat view's "Back to missions"
-   * label agree on the same source of truth (#6134, #6135, #6136, #6137).
-   * Previously the chat button used `missions.length` (which included
-   * terminal completed/failed/cancelled missions that the list filters
-   * out via isActiveMission), producing a mismatch like "21 vs 24".
+   * Total missions actually rendered in the list view (saved + the
+   * non-library bucket). Used so the list header count and the chat
+   * view's "Back to missions" label agree on the same source of truth
+   * (issues 6134, 6135, 6136, 6137). After issue 8143 the non-library
+   * bucket includes terminal missions again so the sidebar shows
+   * history, so this total now equals `missions.length` unless a search
+   * filter is active.
    */
   const listTotalMissions = savedMissions.length + activeMissions.length
 


### PR DESCRIPTION
## Summary

Real fix for #8143 — the original fix (PR #8146 + follow-up #8157) only added an empty-state CTA. The reporter [@ghanshyam2005singh](https://github.com/ghanshyam2005singh) **reopened the issue a few hours after merge** because his missions still weren't showing. This PR addresses the underlying regression.

## Root cause — PR #5946 (merged 2026-04-10, 5 days ago)

#5946 tightened the sidebar's `activeMissions` filter:

```diff
- .filter(m => m.status !== 'saved' && matchesSearch(m))
+ .filter(m => isActiveMission(m) && matchesSearch(m))
```

Where `isActiveMission` excludes `saved | completed | failed | cancelled`.

The intent of #5946 was correct **for the `MissionSidebarToggle` count badge** — a finished mission shouldn't count as currently active. But the same filter was applied to the **list rendering**, and the sidebar only renders two sections: `savedMissions` and `activeMissions`. There is no "History" or "Completed" section.

Net effect: the moment a mission transitions to `completed`, `failed`, or `cancelled`, it **vanishes from the sidebar entirely**. A user whose mission history contains only terminal entries — which is the steady-state for any real user — sees a blank panel. The reporter's wording matches exactly:

> *"Existing missions are not displayed, and even newly created missions do not show up in the list."*

("Newly created" missions appeared while running, then disappeared when they completed.)

## Why #8146 didn't fix it

PR #8146 added a "start a new mission" CTA when `listTotalMissions === 0`. The author explicitly noted *"I could not reproduce the exact user flow from the issue report on console.kubestellar.io"* — demo mode seeds 6 saved + 1 completed mission, so `listTotalMissions >= 6` on the hosted site and the bug path was unreachable there. The fix made the empty state prettier but didn't restore the missing entries. The reporter rightly reopened the issue.

## Fix

Revert **only the list filter** to `m.status !== 'saved'` so terminal missions render again. The toggle-badge count below still uses `isActiveMission` so the badge stays accurate (#5947 intent preserved). Two filters, one file.

```diff
   const activeMissions = missions
-    .filter(m => isActiveMission(m) && matchesSearch(m))
+    .filter(m => m.status !== 'saved' && matchesSearch(m))
     .sort((a, b) => new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime())
```

```ts
// MissionSidebarToggle (unchanged, still in this file ~line 1385)
const activeCount = missions.filter(isActiveMission).length
```

The variable is still named `activeMissions` to avoid churn against the many downstream references — its contents are now *"all non-library missions"* and the comment above it spells that out.

`listTotalMissions` (used by the empty-state gate from #8146) automatically follows since it's `savedMissions.length + activeMissions.length`; the CTA now only fires when the user genuinely has zero missions, which is the correct semantics.

## Why option 1 and not a new History section

I considered adding a collapsible "History" section below the active list, but:

- it's a ~100-line UX change that needs its own design review
- it doesn't match what users remember working — pre-#5946 the list just showed everything non-library
- @ghanshyam2005singh's bug report is explicit: he wants to *see his missions in the list*, not in a hidden sub-panel

The 2-line filter revert is the minimum change that restores the pre-regression UX.

## Test plan

- [x] `npm run build` — clean (post-build safety checks all pass)
- [x] `isActiveMission` import still used (toggle-badge count at line 1385 — grep confirms)
- [x] No sidebar test regressions (MissionSidebar.test.tsx does not exercise this filter)
- [ ] Manual repro in-browser: populate localStorage with 3 `completed` missions, reload — list should render them instead of showing the "start a new mission" CTA
- [ ] Manual check: toggle-button badge count still shows `0` when all missions are terminal (issue 5947 not re-regressed)

## Closes

Fixes #8143