### PR TITLE
🔒 fix: RBAC follow-ups — CORS POST, reuse agentAuthHeaders, accurate header comment

### DIFF
--- a/pkg/agent/server_http.go
+++ b/pkg/agent/server_http.go
@@ -1952,14 +1952,28 @@ func (s *Server) handleClusterHealthHTTP(w http.ResponseWriter, r *http.Request)
 	writeJSON(w,health)
 }
 
-// setCORSHeaders sets common CORS headers for HTTP endpoints
-func (s *Server) setCORSHeaders(w http.ResponseWriter, r *http.Request) {
+// defaultCORSAllowedMethods is the Access-Control-Allow-Methods value used
+// when a caller of setCORSHeaders does not supply an explicit method list.
+// Historically this helper hard-coded "GET, OPTIONS", so this preserves
+// back-compat for every GET-only handler that still passes no methods.
+const defaultCORSAllowedMethods = "GET, OPTIONS"
+
+// setCORSHeaders sets common CORS headers for HTTP endpoints. An optional
+// list of HTTP methods may be supplied to override the default
+// Access-Control-Allow-Methods value — this is required for POST/PUT/DELETE
+// endpoints so browser preflight requests succeed. When no methods are
+// supplied the header defaults to defaultCORSAllowedMethods.
+func (s *Server) setCORSHeaders(w http.ResponseWriter, r *http.Request, methods ...string) {
 	origin := r.Header.Get("Origin")
 	if s.isAllowedOrigin(origin) {
 		w.Header().Set("Access-Control-Allow-Origin", origin)
 	}
 	w.Header().Set("Access-Control-Allow-Private-Network", "true")
-	w.Header().Set("Access-Control-Allow-Methods", "GET, OPTIONS")
+	allowed := defaultCORSAllowedMethods
+	if len(methods) > 0 {
+		allowed = strings.Join(methods, ", ")
+	}
+	w.Header().Set("Access-Control-Allow-Methods", allowed)
 	w.Header().Set("Access-Control-Allow-Headers", "Authorization, Content-Type")
 }
 

--- a/pkg/agent/server_rbac.go
+++ b/pkg/agent/server_rbac.go
@@ -5,8 +5,15 @@ package agent
 // These endpoints are the kc-agent side of Phase 6 of #7993: user-facing
 // permission checks (SelfSubjectAccessReview + permission summaries) must
 // run under the user's kubeconfig, not the backend pod ServiceAccount.
-// Otherwise the pod SA's permissions answer the question, not the caller's,
-// which is both wrong and a privilege-escalation vector.
+//
+// Before #8185 the backend's CheckCanI / GetClusterPermissions /
+// GetAllPermissionsSummaries paths executed against the pod ServiceAccount,
+// so the UI displayed the pod SA's permissions instead of the caller's —
+// a misleading RBAC display, not a real privilege-escalation vector
+// (mutations already flowed through kc-agent under the user's identity).
+// The practical impact was cosmetic/UX: users saw permission summaries
+// that didn't match what they could actually do. Routing these reads
+// through kc-agent makes the displayed permissions reflect the caller.
 //
 // kc-agent loads `s.k8sClient` from the user's kubeconfig at startup, so
 // calling the existing pkg/k8s.MultiClusterClient methods here is already
@@ -36,7 +43,10 @@ const rbacAnalysisTimeout = 60 * time.Second
 // the user whose kubeconfig kc-agent was started with — which is what the
 // UI actually wants to show.
 func (s *Server) handleCanIHTTP(w http.ResponseWriter, r *http.Request) {
-	s.setCORSHeaders(w, r)
+	// This is a POST endpoint, so we must advertise POST in
+	// Access-Control-Allow-Methods or browser preflight requests will fail.
+	// setCORSHeaders defaults to "GET, OPTIONS" when no methods are supplied.
+	s.setCORSHeaders(w, r, http.MethodPost, http.MethodOptions)
 	w.Header().Set("Content-Type", "application/json")
 	if r.Method == http.MethodOptions {
 		w.WriteHeader(http.StatusOK)

--- a/pkg/agent/server_rbac_test.go
+++ b/pkg/agent/server_rbac_test.go
@@ -1,0 +1,64 @@
+package agent
+
+import (
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// TestHandleCanIHTTP_CORSMethodsHeader verifies the POST-specific
+// Access-Control-Allow-Methods override runs, so the browser preflight
+// advertises POST and not the default "GET, OPTIONS" (#8188).
+func TestHandleCanIHTTP_CORSMethodsHeader(t *testing.T) {
+	s := &Server{
+		allowedOrigins: []string{"http://localhost:3000"},
+	}
+
+	req := httptest.NewRequest("OPTIONS", "/rbac/can-i", nil)
+	req.Header.Set("Origin", "http://localhost:3000")
+	w := httptest.NewRecorder()
+	s.handleCanIHTTP(w, req)
+
+	methods := w.Header().Get("Access-Control-Allow-Methods")
+	if !strings.Contains(methods, "POST") {
+		t.Errorf("expected Access-Control-Allow-Methods to include POST, got %q", methods)
+	}
+}
+
+// TestSetCORSHeaders_DefaultsToGET verifies that back-compat callers that
+// pass no explicit methods still get the historical "GET, OPTIONS" value.
+func TestSetCORSHeaders_DefaultsToGET(t *testing.T) {
+	s := &Server{
+		allowedOrigins: []string{"http://localhost:3000"},
+	}
+
+	req := httptest.NewRequest("OPTIONS", "/anything", nil)
+	req.Header.Set("Origin", "http://localhost:3000")
+	w := httptest.NewRecorder()
+
+	s.setCORSHeaders(w, req)
+
+	methods := w.Header().Get("Access-Control-Allow-Methods")
+	if methods != defaultCORSAllowedMethods {
+		t.Errorf("expected %q, got %q", defaultCORSAllowedMethods, methods)
+	}
+}
+
+// TestSetCORSHeaders_ExplicitMethodsJoined verifies that passing an explicit
+// method list produces a comma-separated Access-Control-Allow-Methods header.
+func TestSetCORSHeaders_ExplicitMethodsJoined(t *testing.T) {
+	s := &Server{
+		allowedOrigins: []string{"http://localhost:3000"},
+	}
+
+	req := httptest.NewRequest("OPTIONS", "/anything", nil)
+	req.Header.Set("Origin", "http://localhost:3000")
+	w := httptest.NewRecorder()
+
+	s.setCORSHeaders(w, req, "POST", "OPTIONS")
+
+	methods := w.Header().Get("Access-Control-Allow-Methods")
+	if methods != "POST, OPTIONS" {
+		t.Errorf("expected %q, got %q", "POST, OPTIONS", methods)
+	}
+}

--- a/web/src/hooks/useUsers.ts
+++ b/web/src/hooks/useUsers.ts
@@ -698,12 +698,13 @@ export function useClusterPermissions(cluster?: string) {
     try {
       // #7993 Phase 6: route through kc-agent so SelfSubjectAccessReviews run
       // under the user's kubeconfig instead of the backend pod ServiceAccount.
+      // Reuse agentAuthHeaders() so the Authorization header is omitted when
+      // no token is configured (agent accepts unauthenticated requests from
+      // allowed origins when KC_AGENT_TOKEN is unset). Sending an empty
+      // Authorization header would fail token validation on the agent side.
       const params = cluster ? `?cluster=${cluster}` : ''
-      const token = localStorage.getItem(STORAGE_KEY_TOKEN)
       const response = await fetch(`${LOCAL_AGENT_HTTP_URL}/rbac/permissions${params}`, {
-        headers: {
-          'Authorization': token ? `Bearer ${token}` : '',
-          'Content-Type': 'application/json' },
+        headers: agentAuthHeaders(),
         signal: AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS) })
       if (!response.ok) {
         setIsLoading(false)


### PR DESCRIPTION
Fixes #8188

Addresses three Copilot review comments on merged #8185 (route RBAC introspection through kc-agent, #7993 Phase 6).

## Finding 1 — POST preflight CORS
`handleCanIHTTP` is a POST endpoint but `setCORSHeaders` defaulted `Access-Control-Allow-Methods` to `"GET, OPTIONS"`, so browser preflight for POST would fail.

Generalized `setCORSHeaders` with a variadic `methods ...string` parameter:
- Callers that pass nothing still get `defaultCORSAllowedMethods` (`"GET, OPTIONS"`) — fully back-compat, all 70+ existing call sites untouched.
- `handleCanIHTTP` now passes `http.MethodPost, http.MethodOptions`.

## Finding 2 — reuse agentAuthHeaders()
`useClusterPermissions` re-implemented the agent auth-header logic and sent `Authorization: ''` when no token was stored (the agent rejects empty Bearer tokens). Refactored to reuse the existing `agentAuthHeaders()` helper, which correctly omits the header when no token is configured. The old fetch was a plain GET with no body, so no `Content-Type` is needed.

## Finding 3 — accurate header comment
The `server_rbac.go` header comment called the pre-#8185 behavior a "privilege-escalation vector". That's wrong — the PR description of #8185 explicitly noted the impact was cosmetic/UX only (no real escalation because mutations already flowed through kc-agent under the user's identity).

Rewrote the comment to describe the real problem: misleading RBAC display — `CheckCanI` ran under the pod SA, so the UI showed system permissions instead of the caller's.

## Tests
Added `pkg/agent/server_rbac_test.go`:
- `TestHandleCanIHTTP_CORSMethodsHeader` — POST preflight advertises POST.
- `TestSetCORSHeaders_DefaultsToGET` — back-compat: no methods → `"GET, OPTIONS"`.
- `TestSetCORSHeaders_ExplicitMethodsJoined` — explicit methods are comma-joined.

## Validation
- `go build ./...` passes
- `go test ./pkg/agent/... -run 'RBAC|CanI|CORS' -v` passes (9 tests)
- `cd web && npm run build` passes (post-build safety checks green)
- `cd web && npm run lint` on `useUsers.ts` only flags 2 pre-existing errors on lines 378/587 (unrelated)