### PR TITLE
✨ feat(drasi): Wave B — CodeMirror editor, sortable results, row drawer, platform SSE

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "license": "Apache-2.0",
       "dependencies": {
+        "@codemirror/legacy-modes": "^6.5.2",
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",
         "@dnd-kit/utilities": "^3.2.2",
@@ -17,6 +18,7 @@
         "@react-three/fiber": "^9.5.0",
         "@sqlite.org/sqlite-wasm": "^3.51.2-build8",
         "@tanstack/react-virtual": "^3.13.23",
+        "@uiw/react-codemirror": "^4.25.9",
         "@xterm/addon-fit": "^0.11.0",
         "@xterm/xterm": "^6.0.0",
         "clsx": "^2.1.1",
@@ -471,6 +473,108 @@
       },
       "bin": {
         "specificity": "bin/cli.js"
+      }
+    },
+    "node_modules/@codemirror/autocomplete": {
+      "version": "6.20.1",
+      "resolved": "https://registry.npmjs.org/@codemirror/autocomplete/-/autocomplete-6.20.1.tgz",
+      "integrity": "sha512-1cvg3Vz1dSSToCNlJfRA2WSI4ht3K+WplO0UMOgmUYPivCyy2oueZY6Lx7M9wThm7SDUBViRmuT+OG/i8+ON9A==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.17.0",
+        "@lezer/common": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/commands": {
+      "version": "6.10.3",
+      "resolved": "https://registry.npmjs.org/@codemirror/commands/-/commands-6.10.3.tgz",
+      "integrity": "sha512-JFRiqhKu+bvSkDLI+rUhJwSxQxYb759W5GBezE8Uc8mHLqC9aV/9aTC7yJSqCtB3F00pylrLCwnyS91Ap5ej4Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.6.0",
+        "@codemirror/view": "^6.27.0",
+        "@lezer/common": "^1.1.0"
+      }
+    },
+    "node_modules/@codemirror/language": {
+      "version": "6.12.3",
+      "resolved": "https://registry.npmjs.org/@codemirror/language/-/language-6.12.3.tgz",
+      "integrity": "sha512-QwCZW6Tt1siP37Jet9Tb02Zs81TQt6qQrZR2H+eGMcFsL1zMrk2/b9CLC7/9ieP1fjIUMgviLWMmgiHoJrj+ZA==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.23.0",
+        "@lezer/common": "^1.5.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.0.0",
+        "style-mod": "^4.0.0"
+      }
+    },
+    "node_modules/@codemirror/legacy-modes": {
+      "version": "6.5.2",
+      "resolved": "https://registry.npmjs.org/@codemirror/legacy-modes/-/legacy-modes-6.5.2.tgz",
+      "integrity": "sha512-/jJbwSTazlQEDOQw2FJ8LEEKVS72pU0lx6oM54kGpL8t/NJ2Jda3CZ4pcltiKTdqYSRk3ug1B3pil1gsjA6+8Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/language": "^6.0.0"
+      }
+    },
+    "node_modules/@codemirror/lint": {
+      "version": "6.9.5",
+      "resolved": "https://registry.npmjs.org/@codemirror/lint/-/lint-6.9.5.tgz",
+      "integrity": "sha512-GElsbU9G7QT9xXhpUg1zWGmftA/7jamh+7+ydKRuT0ORpWS3wOSP0yT1FOlIZa7mIJjpVPipErsyvVqB9cfTFA==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.35.0",
+        "crelt": "^1.0.5"
+      }
+    },
+    "node_modules/@codemirror/search": {
+      "version": "6.6.0",
+      "resolved": "https://registry.npmjs.org/@codemirror/search/-/search-6.6.0.tgz",
+      "integrity": "sha512-koFuNXcDvyyotWcgOnZGmY7LZqEOXZaaxD/j6n18TCLx2/9HieZJ5H6hs1g8FiRxBD0DNfs0nXn17g872RmYdw==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.37.0",
+        "crelt": "^1.0.5"
+      }
+    },
+    "node_modules/@codemirror/state": {
+      "version": "6.6.0",
+      "resolved": "https://registry.npmjs.org/@codemirror/state/-/state-6.6.0.tgz",
+      "integrity": "sha512-4nbvra5R5EtiCzr9BTHiTLc+MLXK2QGiAVYMyi8PkQd3SR+6ixar/Q/01Fa21TBIDOZXgeWV4WppsQolSreAPQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@marijn/find-cluster-break": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/theme-one-dark": {
+      "version": "6.1.3",
+      "resolved": "https://registry.npmjs.org/@codemirror/theme-one-dark/-/theme-one-dark-6.1.3.tgz",
+      "integrity": "sha512-NzBdIvEJmx6fjeremiGp3t/okrLPYT0d9orIc7AFun8oZcRk58aejkqhv6spnz4MLAevrKNPMQYXEWMg4s+sKA==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.0.0",
+        "@lezer/highlight": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/view": {
+      "version": "6.41.0",
+      "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.41.0.tgz",
+      "integrity": "sha512-6H/qadXsVuDY219Yljhohglve8xf4B8xJkVOEWfA5uiYKiTFppjqsvsfR5iPA0RbvRBoOyTZpbLIxe9+0UR8xA==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/state": "^6.6.0",
+        "crelt": "^1.0.6",
+        "style-mod": "^4.1.0",
+        "w3c-keyname": "^2.2.4"
       }
     },
     "node_modules/@csstools/color-helpers": {
@@ -1655,6 +1759,36 @@
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
+    },
+    "node_modules/@lezer/common": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@lezer/common/-/common-1.5.2.tgz",
+      "integrity": "sha512-sxQE460fPZyU3sdc8lafxiPwJHBzZRy/udNFynGQky1SePYBdhkBl1kOagA9uT3pxR8K09bOrmTUqA9wb/PjSQ==",
+      "license": "MIT"
+    },
+    "node_modules/@lezer/highlight": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@lezer/highlight/-/highlight-1.2.3.tgz",
+      "integrity": "sha512-qXdH7UqTvGfdVBINrgKhDsVTJTxactNNxLk7+UMwZhU13lMHaOBlJe9Vqp907ya56Y3+ed2tlqzys7jDkTmW0g==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.3.0"
+      }
+    },
+    "node_modules/@lezer/lr": {
+      "version": "1.4.8",
+      "resolved": "https://registry.npmjs.org/@lezer/lr/-/lr-1.4.8.tgz",
+      "integrity": "sha512-bPWa0Pgx69ylNlMlPvBPryqeLYQjyJjqPx+Aupm5zydLIF3NE+6MMLT8Yi23Bd9cif9VS00aUebn+6fDIGBcDA==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.0.0"
+      }
+    },
+    "node_modules/@marijn/find-cluster-break": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@marijn/find-cluster-break/-/find-cluster-break-1.0.2.tgz",
+      "integrity": "sha512-l0h88YhZFyKdXIFNfSWpyjStDjGHwZ/U7iobcK1cQQD8sejsONdQtTVU+1wVN1PBw40PiiHB1vA5S7VTfQiP9g==",
+      "license": "MIT"
     },
     "node_modules/@mediapipe/tasks-vision": {
       "version": "0.10.17",
@@ -3265,6 +3399,59 @@
         "url": "https://opencollective.com/typescript-eslint"
       }
     },
+    "node_modules/@uiw/codemirror-extensions-basic-setup": {
+      "version": "4.25.9",
+      "resolved": "https://registry.npmjs.org/@uiw/codemirror-extensions-basic-setup/-/codemirror-extensions-basic-setup-4.25.9.tgz",
+      "integrity": "sha512-QFAqr+pu6lDmNpAlecODcF49TlsrZ0bj15zPzfhiqSDl+Um3EsDLFLppixC7kFLn+rdDM2LTvVjn5CPvefpRgw==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/autocomplete": "^6.0.0",
+        "@codemirror/commands": "^6.0.0",
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/lint": "^6.0.0",
+        "@codemirror/search": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://jaywcjlove.github.io/#/sponsor"
+      },
+      "peerDependencies": {
+        "@codemirror/autocomplete": ">=6.0.0",
+        "@codemirror/commands": ">=6.0.0",
+        "@codemirror/language": ">=6.0.0",
+        "@codemirror/lint": ">=6.0.0",
+        "@codemirror/search": ">=6.0.0",
+        "@codemirror/state": ">=6.0.0",
+        "@codemirror/view": ">=6.0.0"
+      }
+    },
+    "node_modules/@uiw/react-codemirror": {
+      "version": "4.25.9",
+      "resolved": "https://registry.npmjs.org/@uiw/react-codemirror/-/react-codemirror-4.25.9.tgz",
+      "integrity": "sha512-HftqCBUYShAOH0pGi1CHP8vfm5L8fQ3+0j0VI6lQD6QpK+UBu3J7nxfEN5O/BXMilMNf9ZyFJRvRcuMMOLHMng==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.18.6",
+        "@codemirror/commands": "^6.1.0",
+        "@codemirror/state": "^6.1.1",
+        "@codemirror/theme-one-dark": "^6.0.0",
+        "@uiw/codemirror-extensions-basic-setup": "4.25.9",
+        "codemirror": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://jaywcjlove.github.io/#/sponsor"
+      },
+      "peerDependencies": {
+        "@babel/runtime": ">=7.11.0",
+        "@codemirror/state": ">=6.0.0",
+        "@codemirror/theme-one-dark": ">=6.0.0",
+        "@codemirror/view": ">=6.0.0",
+        "codemirror": ">=6.0.0",
+        "react": ">=17.0.0",
+        "react-dom": ">=17.0.0"
+      }
+    },
     "node_modules/@ungap/structured-clone": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.0.tgz",
@@ -4354,6 +4541,21 @@
         "node": ">=6"
       }
     },
+    "node_modules/codemirror": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-6.0.2.tgz",
+      "integrity": "sha512-VhydHotNW5w1UGK0Qj96BwSk/Zqbp9WbnyK2W/eVMv4QyF41INRGpjUhFJY7/uDNuudSc33a/PKr4iDqRduvHw==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/autocomplete": "^6.0.0",
+        "@codemirror/commands": "^6.0.0",
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/lint": "^6.0.0",
+        "@codemirror/search": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.0.0"
+      }
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -4425,6 +4627,12 @@
         "type": "opencollective",
         "url": "https://opencollective.com/express"
       }
+    },
+    "node_modules/crelt": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/crelt/-/crelt-1.0.6.tgz",
+      "integrity": "sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g==",
+      "license": "MIT"
     },
     "node_modules/cross-env": {
       "version": "7.0.3",
@@ -9691,6 +9899,12 @@
         "node": ">=8"
       }
     },
+    "node_modules/style-mod": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/style-mod/-/style-mod-4.1.3.tgz",
+      "integrity": "sha512-i/n8VsZydrugj3Iuzll8+x/00GH2vnYsk1eomD8QiRrSAeW6ItbCQDtfXCeJHd0iwiNagqjQkvpvREEPtW3IoQ==",
+      "license": "MIT"
+    },
     "node_modules/style-to-js": {
       "version": "1.1.21",
       "resolved": "https://registry.npmjs.org/style-to-js/-/style-to-js-1.1.21.tgz",
@@ -10850,6 +11064,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/w3c-keyname": {
+      "version": "2.2.8",
+      "resolved": "https://registry.npmjs.org/w3c-keyname/-/w3c-keyname-2.2.8.tgz",
+      "integrity": "sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==",
+      "license": "MIT"
     },
     "node_modules/w3c-xmlserializer": {
       "version": "5.0.0",

--- a/web/package.json
+++ b/web/package.json
@@ -47,6 +47,7 @@
     "test:e2e:visual": "playwright test --config e2e/visual/visual.config.ts"
   },
   "dependencies": {
+    "@codemirror/legacy-modes": "^6.5.2",
     "@dnd-kit/core": "^6.3.1",
     "@dnd-kit/sortable": "^10.0.0",
     "@dnd-kit/utilities": "^3.2.2",
@@ -55,6 +56,7 @@
     "@react-three/fiber": "^9.5.0",
     "@sqlite.org/sqlite-wasm": "^3.51.2-build8",
     "@tanstack/react-virtual": "^3.13.23",
+    "@uiw/react-codemirror": "^4.25.9",
     "@xterm/addon-fit": "^0.11.0",
     "@xterm/xterm": "^6.0.0",
     "clsx": "^2.1.1",

--- a/web/src/components/cards/drasi/DrasiReactiveGraph.tsx
+++ b/web/src/components/cards/drasi/DrasiReactiveGraph.tsx
@@ -15,11 +15,15 @@ import { motion, AnimatePresence, useReducedMotion } from 'framer-motion'
 import {
   Database, Globe, Search, Radio,
   TrendingDown, TrendingUp, Maximize2, Pin, Square, X, Settings,
-  Plus, Trash2, Download, Rocket,
+  Plus, Trash2, Download, Rocket, ArrowUp, ArrowDown, ArrowUpDown, Zap,
 } from 'lucide-react'
 import { useNavigate } from 'react-router-dom'
 import { useTranslation } from 'react-i18next'
 import yaml from 'js-yaml'
+import CodeMirror from '@uiw/react-codemirror'
+import { StreamLanguage } from '@codemirror/language'
+import { cypher } from '@codemirror/legacy-modes/mode/cypher'
+import { oneDark } from '@codemirror/theme-one-dark'
 import { downloadText } from '../../../lib/download'
 import { useCardDemoState, useReportCardDataState } from '../CardDataContext'
 import { useDrasiResources } from '../../../hooks/useDrasiResources'
@@ -59,6 +63,9 @@ const KPI_LABEL_EVENTS_PER_SEC = 'Events/s'
 const KPI_LABEL_RESULT_ROWS = 'Result Rows'
 const KPI_LABEL_SOURCES = 'Sources'
 const KPI_LABEL_REACTIONS = 'Reactions'
+
+/** CodeMirror editor height inside the Query Configure modal. */
+const CODEMIRROR_EDITOR_HEIGHT_PX = '140px'
 
 // ---------------------------------------------------------------------------
 // Flow-line palette (named constants so the UI/UX ratchet scanner skips them)
@@ -543,15 +550,62 @@ function KPIBox({ label, value, accent }: { label: string; value: number; accent
   )
 }
 
-function ResultsTable({ results, isDemo }: { results: LiveResultRow[]; isDemo: boolean }) {
-  const displayResults = results.slice(0, MAX_RESULT_ROWS)
-  const totalRows = results.length
-  const label = isDemo ? 'Demo Results' : 'Live Results'
+/** Compare two result cells for sort ordering. Handles numbers, strings, and
+ *  mixed-type columns gracefully. Nullish values sort last. */
+function compareCells(a: LiveResultRow[string], b: LiveResultRow[string]): number {
+  const aNull = a === null || a === undefined
+  const bNull = b === null || b === undefined
+  if (aNull && bNull) return 0
+  if (aNull) return 1
+  if (bNull) return -1
+  if (typeof a === 'number' && typeof b === 'number') return a - b
+  return String(a).localeCompare(String(b))
+}
+
+interface ResultsTableProps {
+  results: LiveResultRow[]
+  isDemo: boolean
+  /** Row click opens the detail drawer in the parent. */
+  onRowClick?: (row: LiveResultRow) => void
+  /** Optional CTA rendered in the header bar (right-aligned). Used by the
+   *  drasi-platform "Enable live results" button. */
+  headerAction?: React.ReactNode
+}
+
+function ResultsTable({ results, isDemo, onRowClick, headerAction }: ResultsTableProps) {
+  const { t } = useTranslation()
+  const [sortCol, setSortCol] = useState<string | null>(null)
+  const [sortDir, setSortDir] = useState<'asc' | 'desc'>('asc')
 
   // Derive columns from the first row's keys so the table works for any
   // continuous-query schema, not just the stock-ticker shape we use in demo.
-  const columns: string[] = displayResults[0] ? Object.keys(displayResults[0]) : []
+  const columns: string[] = results[0] ? Object.keys(results[0]) : []
   const trendCol = findTrendColumn(columns)
+
+  // Sort the full result set (not the truncated slice) so sorting remains
+  // consistent when MAX_RESULT_ROWS cuts off. Only slice AFTER sorting.
+  const sortedResults = useMemo(() => {
+    if (!sortCol) return results
+    const sorted = [...results].sort((a, b) => compareCells(a[sortCol], b[sortCol]))
+    return sortDir === 'desc' ? sorted.reverse() : sorted
+  }, [results, sortCol, sortDir])
+  const displayResults = sortedResults.slice(0, MAX_RESULT_ROWS)
+  const totalRows = results.length
+  const label = isDemo ? t('drasi.demoResultsLabel') : t('drasi.liveResultsLabel')
+
+  const handleHeaderClick = (col: string) => {
+    if (sortCol !== col) {
+      setSortCol(col)
+      setSortDir('asc')
+      return
+    }
+    // Toggle direction on repeat click; third click clears the sort.
+    if (sortDir === 'asc') {
+      setSortDir('desc')
+    } else {
+      setSortCol(null)
+    }
+  }
 
   return (
     <div className="mt-2 bg-slate-950/80 border border-slate-700/40 rounded overflow-hidden">
@@ -564,27 +618,46 @@ function ResultsTable({ results, isDemo }: { results: LiveResultRow[]; isDemo: b
             transition={{ repeat: Infinity, duration: 1.5 }}
           />
         </div>
-        <span className="text-[10px] text-muted-foreground">{totalRows} rows</span>
+        <div className="flex items-center gap-2">
+          {headerAction}
+          <span className="text-[10px] text-muted-foreground">{totalRows} rows</span>
+        </div>
       </div>
       <div className="overflow-x-auto">
         <table className="w-full text-[10px]">
           <thead>
             <tr className="border-b border-slate-800/50">
-              {columns.map(col => (
-                <th
-                  key={col}
-                  className={`px-2 py-1 text-muted-foreground font-medium ${
-                    typeof displayResults[0]?.[col] === 'number' ? 'text-right' : 'text-left'
-                  }`}
-                >
-                  {col}
-                </th>
-              ))}
+              {columns.map(col => {
+                const isNumCol = typeof displayResults[0]?.[col] === 'number'
+                const isSorted = sortCol === col
+                return (
+                  <th
+                    key={col}
+                    onClick={e => { e.stopPropagation(); handleHeaderClick(col) }}
+                    className={`px-2 py-1 text-muted-foreground font-medium cursor-pointer select-none hover:text-cyan-300 ${
+                      isNumCol ? 'text-right' : 'text-left'
+                    }`}
+                  >
+                    <span className={`inline-flex items-center gap-0.5 ${isNumCol ? 'justify-end w-full' : ''}`}>
+                      {col}
+                      {isSorted ? (
+                        sortDir === 'asc' ? <ArrowUp className="w-2 h-2" /> : <ArrowDown className="w-2 h-2" />
+                      ) : (
+                        <ArrowUpDown className="w-2 h-2 opacity-30" />
+                      )}
+                    </span>
+                  </th>
+                )
+              })}
             </tr>
           </thead>
           <tbody>
             {displayResults.map((row, idx) => (
-              <tr key={idx} className="border-b border-slate-800/30 hover:bg-slate-800/30">
+              <tr
+                key={idx}
+                onClick={e => { e.stopPropagation(); onRowClick?.(row) }}
+                className={`border-b border-slate-800/30 hover:bg-slate-800/30 ${onRowClick ? 'cursor-pointer' : ''}`}
+              >
                 {columns.map(col => {
                   const value = row[col]
                   const isTrend = col === trendCol
@@ -626,6 +699,59 @@ function ResultsTable({ results, isDemo }: { results: LiveResultRow[]; isDemo: b
         </table>
       </div>
     </div>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Row detail drawer — click any results-table row to open a slide-in panel
+// with the row's full JSON. Uses CodeMirror in read-only mode for syntax
+// highlighting (reuses the editor already on the page for the query modal).
+// ---------------------------------------------------------------------------
+
+function RowDetailDrawer({ row, onClose }: { row: LiveResultRow | null; onClose: () => void }) {
+  const { t } = useTranslation()
+  useEffect(() => {
+    function onKey(e: KeyboardEvent) {
+      if (e.key === 'Escape' && row) {
+        e.stopPropagation()
+        onClose()
+      }
+    }
+    document.addEventListener('keydown', onKey)
+    return () => document.removeEventListener('keydown', onKey)
+  }, [row, onClose])
+
+  if (!row) return null
+  const json = JSON.stringify(row, null, 2)
+  return (
+    <motion.div
+      className="absolute top-0 right-0 bottom-0 z-40 w-80 bg-slate-950 border-l border-slate-700 shadow-2xl flex flex-col"
+      initial={{ x: '100%' }}
+      animate={{ x: 0 }}
+      exit={{ x: '100%' }}
+      transition={{ type: 'tween', duration: 0.2 }}
+    >
+      <div className="flex items-center justify-between px-3 py-2 border-b border-slate-700/60">
+        <span className="text-xs font-semibold text-cyan-300 uppercase tracking-wider">{t('drasi.rowDetailTitle')}</span>
+        <button type="button" onClick={onClose} className="w-5 h-5 flex items-center justify-center rounded hover:bg-slate-800 text-slate-400" aria-label={t('actions.close')}>
+          <X className="w-3.5 h-3.5" />
+        </button>
+      </div>
+      <div className="flex-1 overflow-hidden text-xs">
+        <CodeMirror
+          value={json}
+          theme={oneDark}
+          extensions={[]}
+          editable={false}
+          basicSetup={{
+            lineNumbers: false,
+            highlightActiveLine: false,
+            foldGutter: false,
+            autocompletion: false,
+          }}
+        />
+      </div>
+    </motion.div>
   )
 }
 
@@ -903,13 +1029,22 @@ function QueryConfigModal({
         </div>
         <div>
           <label className="block text-[10px] uppercase tracking-wider text-muted-foreground mb-1">{t('drasi.queryLabel')}</label>
-          <textarea
-            value={queryText}
-            onChange={e => setQueryText(e.target.value)}
-            rows={5}
-            className="w-full px-2 py-1.5 text-xs font-mono bg-slate-950 border border-slate-700 rounded text-white focus:border-cyan-500 focus:outline-none resize-none"
-            placeholder={t('drasi.queryPlaceholder')}
-          />
+          <div className="rounded border border-slate-700 overflow-hidden text-xs">
+            <CodeMirror
+              value={queryText}
+              onChange={setQueryText}
+              theme={oneDark}
+              extensions={[StreamLanguage.define(cypher)]}
+              height={CODEMIRROR_EDITOR_HEIGHT_PX}
+              basicSetup={{
+                lineNumbers: true,
+                highlightActiveLine: true,
+                foldGutter: false,
+                autocompletion: false,
+              }}
+              placeholder={t('drasi.queryPlaceholder')}
+            />
+          </div>
         </div>
       </div>
       <div className="flex justify-between items-center gap-2 mt-4">
@@ -966,6 +1101,8 @@ export function DrasiReactiveGraph() {
   // null = modal closed. Single state avoids an extra boolean flag.
   const [configuringSource, setConfiguringSource] = useState<DrasiSource | 'new' | null>(null)
   const [configuringQuery, setConfiguringQuery] = useState<DrasiQuery | 'new' | null>(null)
+  // Clicked results-table row — opens the right-side detail drawer.
+  const [selectedRow, setSelectedRow] = useState<LiveResultRow | null>(null)
   const navigate = useNavigate()
   const [demoData, setDemoData] = useState<DrasiPipelineData>(generateDemoData)
 
@@ -1161,6 +1298,28 @@ export function DrasiReactiveGraph() {
       }],
     }))
   }, [isLive, liveData, queries, refetchDrasi, drasiProxyTarget, drasiResourcePath])
+
+  // Creates a Result reaction scoped to a single continuous query. Used by
+  // the drasi-platform "Enable live results" button. Platform mode does not
+  // expose drasi-server's built-in per-query SSE stream, so a Result reaction
+  // is the canonical way to subscribe to query deltas.
+  const createResultReactionForQuery = useCallback(async (queryId: string) => {
+    if (!isLive || !liveData) return
+    const reactionName = `result-${queryId}`.toLowerCase().replace(/[^a-z0-9-]/g, '-')
+    try {
+      await fetch(`/api/drasi/proxy${drasiResourcePath('reaction')}?${drasiProxyTarget()}`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          id: reactionName,
+          spec: { kind: 'Result', queries: [{ id: queryId }] },
+        }),
+      })
+      refetchDrasi()
+    } catch {
+      // Non-fatal; next poll surfaces the error.
+    }
+  }, [isLive, liveData, refetchDrasi, drasiProxyTarget, drasiResourcePath])
 
   const deleteResource = useCallback(async (
     kind: 'source' | 'query' | 'reaction',
@@ -1692,7 +1851,29 @@ export function DrasiReactiveGraph() {
                   onHoverEnter={() => setHoveredNodeId(query.id)}
                   onHoverLeave={() => setHoveredNodeId(null)}
                 >
-                  {hasResults && <ResultsTable results={liveResults} isDemo={!isLive} />}
+                  {hasResults && (
+                    <ResultsTable
+                      results={liveResults}
+                      isDemo={!isLive}
+                      onRowClick={setSelectedRow}
+                      headerAction={
+                        // drasi-platform has no built-in per-query SSE stream;
+                        // offer a one-click Result reaction create so the
+                        // results table starts receiving deltas.
+                        isLive && liveData?.mode === 'platform' && !reactions.some(r => r.queryIds.includes(query.id) && r.kind === 'SSE') ? (
+                          <button
+                            type="button"
+                            onClick={e => { e.stopPropagation(); createResultReactionForQuery(query.id) }}
+                            className="text-[10px] px-1.5 py-0.5 rounded bg-cyan-600/20 hover:bg-cyan-600/40 border border-cyan-500/40 text-cyan-300 flex items-center gap-1"
+                            title={t('drasi.enableLiveResultsHint')}
+                          >
+                            <Zap className="w-2.5 h-2.5" />
+                            {t('drasi.enableLiveResults')}
+                          </button>
+                        ) : null
+                      }
+                    />
+                  )}
                 </NodeCard>
               </div>
             )
@@ -1722,6 +1903,7 @@ export function DrasiReactiveGraph() {
         </div>
 
         <AnimatePresence>
+          {selectedRow && <RowDetailDrawer row={selectedRow} onClose={() => setSelectedRow(null)} />}
           {expandedNode && <ExpandModal node={expandedNode} onClose={() => setExpandedNode(null)} />}
           {configuringSource && (
             <SourceConfigModal

--- a/web/src/locales/en/common.json
+++ b/web/src/locales/en/common.json
@@ -1521,7 +1521,12 @@
     "deleteConfirm": "Delete \"{{name}}\"? This cannot be undone.",
     "installDrasiTitle": "No live Drasi install detected",
     "installDrasiDescription": "Showing demo data. Install Drasi to visualize your reactive pipelines live.",
-    "installDrasiButton": "Install Drasi"
+    "installDrasiButton": "Install Drasi",
+    "rowDetailTitle": "Row Detail",
+    "enableLiveResults": "Enable live results",
+    "enableLiveResultsHint": "Create a Result reaction to stream query deltas",
+    "demoResultsLabel": "Demo Results",
+    "liveResultsLabel": "Live Results"
   },
   "missionChat": {
     "saveTranscript": "Save transcript",


### PR DESCRIPTION
## Summary

Wave B of the Drasi dashboard follow-up. Picks up where #8186 (Wave A CRUD) left off — makes the \`/drasi\` card feel like a real product instead of a read/write demo.

### What's new

- **CodeMirror Cypher editor** in the Configure Query modal.
  - Replaces the plain textarea with \`@uiw/react-codemirror\` + \`@codemirror/legacy-modes/mode/cypher\` (first-party \`@codemirror/lang-cypher\` does not exist on npm).
  - Dark theme (\`@codemirror/theme-one-dark\`) to match the rest of the card.
  - Line numbers + active-line highlight; autocompletion off for now.
- **Sortable results table.**
  - Click any column header → sort asc → desc → clear.
  - Works on both numeric and string cells; nullish values sort last.
  - Sort runs on the full result set before the \`MAX_RESULT_ROWS\` slice, so the displayed rows are the true top-N by sort order.
- **Row detail drawer.**
  - Click any row → slide-in right panel with the row's full JSON.
  - Renders through CodeMirror read-only so the styling matches the query editor.
  - ESC / click-X closes; overlay is scoped to the card container (no portal).
- **drasi-platform "Enable live results" button.**
  - drasi-platform does not expose drasi-server's built-in per-query SSE stream, so the results-table header now shows a one-click CTA in platform mode when no SSE reaction is wired to the selected query.
  - Clicking it POSTs a Result reaction scoped to that query through the existing \`/api/drasi/proxy\` route. The reaction shows up on the next poll; the full subscription path hooks into \`useDrasiQueryStream\` in a future iteration once the reaction endpoint is validated.

### Deps added

- \`@uiw/react-codemirror\`
- \`@codemirror/legacy-modes\` (for the Cypher StreamLanguage)
- \`@codemirror/theme-one-dark\` comes transitively

### Zero backend changes

Every Wave B action reuses the \`/api/drasi/proxy/*\` reverse proxy shipped in #8158.

## Test plan

- [x] \`npm run build\` — passes locally
- [x] No new \`ts-null-safety\` ratchet regressions (checked P1/P3/P5 locally)
- [ ] Edit a query → Cypher keywords highlight, line numbers visible, edit saves through live mode
- [ ] Click any column header in a results table → rows sort by that column; click again → reverse; click again → cleared
- [ ] Click any row → right drawer opens with pretty-printed JSON; ESC closes
- [ ] drasi-platform mode: create a query without an SSE reaction → "Enable live results" button appears → click → new Result reaction in next poll

🤖 Generated with [Claude Code](https://claude.com/claude-code)