### PR TITLE
🐛 fix: mcp hook tests to use LOCAL_AGENT_*_URL constants

### DIFF
--- a/web/src/hooks/mcp/__tests__/config.test.ts
+++ b/web/src/hooks/mcp/__tests__/config.test.ts
@@ -73,6 +73,9 @@ vi.mock('../../../lib/constants', async (importOriginal) => {
 // ---------------------------------------------------------------------------
 
 import { useConfigMaps, useSecrets, useServiceAccounts } from '../config'
+// Import the same constant the source hooks use so URL assertions track
+// kc-agent migration automatically (phase 4.5b, #7993 / #8173).
+import { LOCAL_AGENT_HTTP_URL } from '../../../lib/constants/network'
 
 // ---------------------------------------------------------------------------
 // Setup / teardown
@@ -577,7 +580,7 @@ describe('useConfigMaps — SSE streaming', () => {
       itemsKey: string
       params: Record<string, string>
     }
-    expect(sseArg.url).toBe('/api/mcp/configmaps/stream')
+    expect(sseArg.url).toBe(`${LOCAL_AGENT_HTTP_URL}/configmaps/stream`)
     expect(sseArg.itemsKey).toBe('configmaps')
   })
 
@@ -648,7 +651,7 @@ describe('useSecrets — SSE streaming', () => {
       url: string
       itemsKey: string
     }
-    expect(sseArg.url).toBe('/api/mcp/secrets/stream')
+    expect(sseArg.url).toBe(`${LOCAL_AGENT_HTTP_URL}/secrets/stream`)
     expect(sseArg.itemsKey).toBe('secrets')
   })
 
@@ -735,7 +738,7 @@ describe('useConfigMaps — REST fallback', () => {
 
     await waitFor(() => expect(mockApiGet).toHaveBeenCalled())
     const url: string = mockApiGet.mock.calls[0][0]
-    expect(url).toContain('/api/mcp/configmaps')
+    expect(url).toContain(`${LOCAL_AGENT_HTTP_URL}/configmaps`)
     expect(url).toContain('cluster=prod-east')
     expect(url).toContain('namespace=monitoring')
   })
@@ -776,7 +779,7 @@ describe('useSecrets — REST fallback', () => {
 
     await waitFor(() => expect(mockApiGet).toHaveBeenCalled())
     const url: string = mockApiGet.mock.calls[0][0]
-    expect(url).toContain('/api/mcp/secrets')
+    expect(url).toContain(`${LOCAL_AGENT_HTTP_URL}/secrets`)
     expect(url).toContain('cluster=prod-east')
     expect(url).toContain('namespace=monitoring')
   })
@@ -813,7 +816,7 @@ describe('useServiceAccounts — REST fallback', () => {
 
     await waitFor(() => expect(mockApiGet).toHaveBeenCalled())
     const url: string = mockApiGet.mock.calls[0][0]
-    expect(url).toContain('/api/mcp/serviceaccounts')
+    expect(url).toContain(`${LOCAL_AGENT_HTTP_URL}/serviceaccounts`)
     expect(url).toContain('cluster=prod-east')
     expect(url).toContain('namespace=monitoring')
   })

--- a/web/src/hooks/mcp/__tests__/events.test.ts
+++ b/web/src/hooks/mcp/__tests__/events.test.ts
@@ -75,6 +75,9 @@ import {
   useEvents,
   useWarningEvents,
 } from '../events'
+// Import the same constant the source hooks use so URL assertions track
+// kc-agent migration automatically (phase 4.5b, #7993 / #8173).
+import { LOCAL_AGENT_HTTP_URL } from '../../../lib/constants/network'
 
 // ---------------------------------------------------------------------------
 // Setup / teardown
@@ -262,7 +265,7 @@ describe('useEvents', () => {
     renderHook(() => useEvents())
     await waitFor(() => expect(mockFetchSSE).toHaveBeenCalled())
     const callArgs = mockFetchSSE.mock.calls[0][0] as { url: string }
-    expect(callArgs.url).toBe('/api/mcp/events/stream')
+    expect(callArgs.url).toBe(`${LOCAL_AGENT_HTTP_URL}/events/stream`)
   })
 
   it('applies default limit of 20 when none is provided', async () => {
@@ -591,7 +594,7 @@ describe('useWarningEvents', () => {
 
     await waitFor(() => expect(mockFetchSSE).toHaveBeenCalled())
     const callArgs = mockFetchSSE.mock.calls[0][0] as { url: string }
-    expect(callArgs.url).toBe('/api/mcp/events/warnings/stream')
+    expect(callArgs.url).toBe(`${LOCAL_AGENT_HTTP_URL}/events/warnings/stream`)
   })
 
   it('forwards cluster, namespace, and limit when provided', async () => {

--- a/web/src/hooks/mcp/__tests__/security.test.ts
+++ b/web/src/hooks/mcp/__tests__/security.test.ts
@@ -64,6 +64,9 @@ vi.mock('../../../lib/constants', async (importOriginal) => {
 // ---------------------------------------------------------------------------
 
 import { useSecurityIssues, useGitOpsDrifts } from '../security'
+// Import the same constant the source hooks use so URL assertions track
+// kc-agent migration automatically (phase 4.5b, #7993 / #8173).
+import { LOCAL_AGENT_HTTP_URL } from '../../../lib/constants/network'
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -250,7 +253,7 @@ describe('useSecurityIssues', () => {
 
     await waitFor(() => expect(mockFetchSSE).toHaveBeenCalled())
     const callArgs = mockFetchSSE.mock.calls[0][0] as { url: string; itemsKey: string }
-    expect(callArgs.url).toBe('/api/mcp/security-issues/stream')
+    expect(callArgs.url).toBe(`${LOCAL_AGENT_HTTP_URL}/security-issues/stream`)
     expect(callArgs.itemsKey).toBe('issues')
   })
 

--- a/web/src/hooks/mcp/__tests__/shared.test.ts
+++ b/web/src/hooks/mcp/__tests__/shared.test.ts
@@ -1285,7 +1285,10 @@ describe('fullFetchClusters', () => {
 
     await fullFetchClusters()
 
-    expect(mockApiGet).toHaveBeenCalledWith('/api/mcp/clusters')
+    // LOCAL_AGENT_URL is re-exported from shared.ts as LOCAL_AGENT_HTTP_URL —
+    // using it here keeps the assertion tracking the kc-agent migration
+    // (phase 4.5b, #7993 / #8173) instead of re-hardcoding the REST path.
+    expect(mockApiGet).toHaveBeenCalledWith(`${LOCAL_AGENT_URL}/clusters`)
     expect(clusterCache.isLoading).toBe(false)
     expect(clusterCache.clusters.some(c => c.name === 'backend-cluster')).toBe(true)
   })

--- a/web/src/hooks/mcp/__tests__/storage.test.ts
+++ b/web/src/hooks/mcp/__tests__/storage.test.ts
@@ -106,6 +106,9 @@ import {
   GPU_RESOURCE_TYPES,
   COMMON_RESOURCE_TYPES,
 } from '../storage'
+// Import the same constant the source hooks use so URL assertions track
+// kc-agent migration automatically (phase 4.5b, #7993 / #8173).
+import { LOCAL_AGENT_HTTP_URL } from '../../../lib/constants/network'
 
 // ---------------------------------------------------------------------------
 // Setup / teardown
@@ -882,7 +885,7 @@ describe('createOrUpdateResourceQuota', () => {
 
     const result = await createOrUpdateResourceQuota(spec)
 
-    expect(mockApiPost).toHaveBeenCalledWith('/api/mcp/resourcequotas', spec)
+    expect(mockApiPost).toHaveBeenCalledWith(`${LOCAL_AGENT_HTTP_URL}/resourcequotas`, spec)
     expect(result).toEqual(createdQuota)
   })
 
@@ -909,7 +912,7 @@ describe('deleteResourceQuota', () => {
     await deleteResourceQuota('prod-east', 'default', 'compute-quota')
 
     expect(mockApiDelete).toHaveBeenCalledWith(
-      '/api/mcp/resourcequotas?cluster=prod-east&namespace=default&name=compute-quota'
+      `${LOCAL_AGENT_HTTP_URL}/resourcequotas?cluster=prod-east&namespace=default&name=compute-quota`
     )
   })
 
@@ -1239,7 +1242,7 @@ describe('deleteResourceQuota', () => {
   it('calls DELETE with correct params', async () => {
     await deleteResourceQuota('cluster-x', 'namespace-y', 'quota-z')
     expect(mockApiDelete).toHaveBeenCalledWith(
-      '/api/mcp/resourcequotas?cluster=cluster-x&namespace=namespace-y&name=quota-z'
+      `${LOCAL_AGENT_HTTP_URL}/resourcequotas?cluster=cluster-x&namespace=namespace-y&name=quota-z`
     )
   })
 

--- a/web/src/hooks/useCachedData.test.ts
+++ b/web/src/hooks/useCachedData.test.ts
@@ -96,6 +96,11 @@ import {
   useCachedSecurityIssues,
   useCachedNodes,
 } from './useCachedData'
+// Import the same (mocked) constant the hook uses so URL assertions track
+// kc-agent migration automatically (phase 4.5b, #7993 / #8173). The vi.mock
+// of '../lib/constants' above overrides LOCAL_AGENT_HTTP_URL to the test
+// value, and this import resolves through that mock.
+import { LOCAL_AGENT_HTTP_URL } from '../lib/constants'
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -192,7 +197,7 @@ describe('fetchAPI internals (via useCachedPods)', () => {
     await capturedFetcher()
 
     expect(globalThis.fetch).toHaveBeenCalledWith(
-      expect.stringContaining('/api/mcp/pods?'),
+      expect.stringContaining(`${LOCAL_AGENT_HTTP_URL}/pods?`),
       expect.any(Object),
     )
     const url = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0][0] as string
@@ -575,7 +580,7 @@ describe('useCachedServices', () => {
     await capturedFetcher()
 
     const url = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0][0] as string
-    expect(url).toContain('/api/mcp/services')
+    expect(url).toContain(`${LOCAL_AGENT_HTTP_URL}/services`)
     expect(url).toContain('cluster=my-cluster')
     expect(url).toContain('namespace=default')
   })
@@ -906,7 +911,7 @@ describe('useCachedWarningEvents', () => {
     await capturedFetcher()
 
     const url = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0][0] as string
-    expect(url).toContain('/api/mcp/events/warnings')
+    expect(url).toContain(`${LOCAL_AGENT_HTTP_URL}/events/warnings`)
     expect(url).toContain('cluster=prod-east')
   })
 })


### PR DESCRIPTION
Fixes #8182

## Root cause

PR #8173 (phase 4.5b of the pod-SA → kc-agent refactor) migrated `/api/mcp/*` hook reads to kc-agent at `LOCAL_AGENT_HTTP_URL` / `LOCAL_AGENT_WS_URL`, but 15 tests across 6 files still asserted the old backend REST URL shape (`/api/mcp/...`) and started failing against the new `http://127.0.0.1:8585/...` URLs produced by the source hooks.

Same pattern as #8175.

## Fix

Each test now imports the same URL constant the source hooks use and builds expected URLs from it, so future migrations of the constant value don't require another test sweep:

- `web/src/hooks/mcp/__tests__/config.test.ts` — imports `LOCAL_AGENT_HTTP_URL` from `../../../lib/constants/network` (5 assertions: configmaps/secrets SSE + configmaps/secrets/serviceaccounts REST)
- `web/src/hooks/mcp/__tests__/events.test.ts` — same import (2 assertions: events/stream + events/warnings/stream)
- `web/src/hooks/mcp/__tests__/security.test.ts` — same import (1 assertion: security-issues/stream)
- `web/src/hooks/mcp/__tests__/shared.test.ts` — reuses the already-imported `LOCAL_AGENT_URL` alias (1 assertion: fullFetchClusters backend fallback)
- `web/src/hooks/mcp/__tests__/storage.test.ts` — imports `LOCAL_AGENT_HTTP_URL` (3 assertions: createOrUpdateResourceQuota POST + deleteResourceQuota DELETE ×2)
- `web/src/hooks/useCachedData.test.ts` — imports `LOCAL_AGENT_HTTP_URL` from `../lib/constants` so it resolves through the existing `vi.mock('../lib/constants', …)` that sets it to `http://localhost:8585` (3 assertions: useCachedPods, useCachedServices, useCachedWarningEvents)

No source code changes — this is test-only.

## Test plan

- [x] `npx vitest run src/hooks/mcp/__tests__/{config,events,security,shared,storage}.test.ts src/hooks/useCachedData.test.ts` — 490/490 pass (previously 15 failing)
- [x] `npm run build` — clean
- [x] `npm run lint` on changed files — clean