### PR TITLE
✨ feat(security): add Security surfaces to install modal and mission detail

### DIFF
--- a/web/src/components/missions/MissionDetailView.tsx
+++ b/web/src/components/missions/MissionDetailView.tsx
@@ -32,7 +32,10 @@ import type { MissionExport, MissionStep } from '../../lib/missions/types'
 import { UI_FEEDBACK_TIMEOUT_MS } from '../../lib/constants/network'
 import { copyToClipboard } from '../../lib/clipboard'
 
-type TabId = 'install' | 'uninstall' | 'upgrade' | 'troubleshooting'
+type TabId = 'install' | 'uninstall' | 'upgrade' | 'troubleshooting' | 'security'
+
+/** GitHub URL for the overall Console security model doc. Linked from the Security tab fallback / footer. */
+const SECURITY_MODEL_DOC_URL = 'https://github.com/kubestellar/console/blob/main/docs/security/SECURITY-MODEL.md'
 
 interface TabDef {
   id: TabId
@@ -249,6 +252,13 @@ export function MissionDetailView({
       steps: mission.troubleshooting || [],
       emptyMessage: t('missions.detail.tabs.troubleshootingEmpty'),
       color: 'bg-yellow-500/20 text-yellow-400' },
+    {
+      id: 'security',
+      label: t('missions.detail.tabs.security'),
+      icon: Shield,
+      steps: mission.security || [],
+      emptyMessage: t('missions.detail.tabs.securityEmpty'),
+      color: 'bg-purple-500/20 text-purple-400' },
   ]
 
   const [activeTab, setActiveTab] = useState<TabId>('install')
@@ -581,14 +591,66 @@ export function MissionDetailView({
                 </div>
               ))
             ) : activeTabDef.steps.length > 0 ? (
-              activeTabDef.steps.map((step, i) => (
-                <StepCard
-                  key={`${activeTab}-${i}`}
-                  step={step}
-                  index={i}
-                  accentColor={activeTabDef.color}
-                />
-              ))
+              <>
+                {activeTabDef.steps.map((step, i) => (
+                  <StepCard
+                    key={`${activeTab}-${i}`}
+                    step={step}
+                    index={i}
+                    accentColor={activeTabDef.color}
+                  />
+                ))}
+                {activeTab === 'security' && (
+                  <div className="mt-4 p-4 rounded-lg border border-purple-500/20 bg-purple-500/5 text-xs text-muted-foreground">
+                    The bullets above are specific to this mission. For the Console's overall security model — how kc-agent binds,
+                    where AI keys live, what leaves your machine, and how to run air-gapped — read the
+                    {' '}
+                    <a
+                      href={SECURITY_MODEL_DOC_URL}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="inline-flex items-center gap-1 text-purple-400 hover:text-purple-300"
+                    >
+                      KubeStellar Console Security Model
+                      <ExternalLink className="w-3 h-3" />
+                    </a>.
+                  </div>
+                )}
+              </>
+            ) : activeTab === 'security' ? (
+              <div className="py-6 px-4 rounded-lg border border-purple-500/20 bg-purple-500/5 text-sm text-muted-foreground space-y-3">
+                <div className="flex items-start gap-3">
+                  <Shield className="w-5 h-5 text-purple-400 flex-shrink-0 mt-0.5" />
+                  <div className="space-y-2">
+                    <p className="font-medium text-foreground">No mission-specific security notes yet</p>
+                    <p>
+                      This mission does not yet include a <code className="font-mono text-foreground/70">security</code> section
+                      in its definition. The Console's overall security posture — kc-agent loopback bind, user-kubeconfig RBAC,
+                      AI-key storage, air-gapped and local-LLM options — applies regardless:
+                    </p>
+                    <p>
+                      <a
+                        href={SECURITY_MODEL_DOC_URL}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="inline-flex items-center gap-1 text-purple-400 hover:text-purple-300"
+                      >
+                        Read the KubeStellar Console Security Model
+                        <ExternalLink className="w-3 h-3" />
+                      </a>
+                    </p>
+                    {onImprove && (
+                      <button
+                        onClick={onImprove}
+                        className="mt-2 inline-flex items-center gap-1.5 px-3 py-1.5 text-xs rounded-lg border border-purple-500/30 text-purple-400 hover:bg-purple-500/10 transition-colors"
+                      >
+                        <MessageSquarePlus className="w-3.5 h-3.5" />
+                        Suggest security notes for this mission
+                      </button>
+                    )}
+                  </div>
+                </div>
+              </div>
             ) : (
               <div className="py-8 text-center">
                 <AlertTriangle className="w-8 h-8 text-muted-foreground/40 mx-auto mb-3" />

--- a/web/src/components/setup/SetupInstructionsDialog.tsx
+++ b/web/src/components/setup/SetupInstructionsDialog.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useState, useEffect, useRef } from 'react'
-import { Rocket, Copy, Check, Terminal, ExternalLink, ChevronDown, ChevronRight, KeyRound, Server } from 'lucide-react'
+import { Rocket, Copy, Check, Terminal, ExternalLink, ChevronDown, ChevronRight, KeyRound, Server, Shield } from 'lucide-react'
 import { BaseModal } from '../../lib/modals'
 import { useTranslation } from 'react-i18next'
 import { UI_FEEDBACK_TIMEOUT_MS } from '../../lib/constants/network'
@@ -15,6 +15,7 @@ interface SetupInstructionsDialogProps {
 
 const REPO_URL = 'https://github.com/kubestellar/console'
 const DOCS_URL = 'https://console-docs.kubestellar.io'
+const SECURITY_DOC_URL = 'https://github.com/kubestellar/console/blob/main/docs/security/SECURITY-MODEL.md'
 const CURL_BASE = 'https://raw.githubusercontent.com/kubestellar/console/main'
 
 const QUICKSTART_CMD = `curl -sSL ${CURL_BASE}/start.sh | bash`
@@ -39,6 +40,7 @@ export function SetupInstructionsDialog({ isOpen, onClose }: SetupInstructionsDi
   const [showOAuthGuide, setShowOAuthGuide] = useState(false)
   const [showDevGuide, setShowDevGuide] = useState(false)
   const [showK8sGuide, setShowK8sGuide] = useState(false)
+  const [showSecurity, setShowSecurity] = useState(false)
   const copiedTimerRef = useRef<ReturnType<typeof setTimeout>>(undefined)
 
   useEffect(() => {
@@ -200,6 +202,77 @@ export function SetupInstructionsDialog({ isOpen, onClose }: SetupInstructionsDi
                       <p className="text-xs text-muted-foreground">
                         Supports <code className="font-mono text-foreground/70">--context</code>, <code className="font-mono text-foreground/70">--openshift</code>, <code className="font-mono text-foreground/70">--ingress &lt;host&gt;</code>, and <code className="font-mono text-foreground/70">--github-oauth</code> flags.
                       </p>
+                    </div>
+                  )}
+                </div>
+
+                {/* Security guide */}
+                <div className="mt-2">
+                  <button
+                    onClick={() => setShowSecurity(!showSecurity)}
+                    className="flex items-center gap-1.5 text-xs text-purple-400 hover:text-purple-300 transition-colors"
+                  >
+                    {showSecurity ? (
+                      <ChevronDown className="w-3.5 h-3.5" />
+                    ) : (
+                      <ChevronRight className="w-3.5 h-3.5" />
+                    )}
+                    <Shield className="w-3.5 h-3.5" />
+                    Security posture — what runs where, what leaves your machine
+                  </button>
+                  {showSecurity && (
+                    <div className="mt-2 rounded-lg border border-blue-500/20 bg-blue-500/5 p-3 space-y-3 text-xs text-muted-foreground">
+                      <div>
+                        <p className="font-medium text-foreground mb-1">kc-agent runs on your machine, not ours</p>
+                        <p>
+                          kc-agent binds <code className="font-mono text-foreground/70">127.0.0.1:8585</code> only
+                          (hardcoded loopback, not configurable). It reads{' '}
+                          <code className="font-mono text-foreground/70">~/.kube/config</code> and executes every
+                          cluster operation as <em>you</em> — the apiserver enforces your real RBAC on every call.
+                          Set <code className="font-mono text-foreground/70">KC_AGENT_TOKEN</code> for an additional
+                          shared-secret gate against other local processes.
+                        </p>
+                      </div>
+                      <div>
+                        <p className="font-medium text-foreground mb-1">AI keys never leave your machine</p>
+                        <p>
+                          API keys are stored at{' '}
+                          <code className="font-mono text-foreground/70">~/.kc/config.yaml</code> with mode{' '}
+                          <code className="font-mono text-foreground/70">0600</code>. The browser never holds the
+                          keys; kc-agent calls the provider directly. No API key reaches the console's servers or
+                          the hosted demo at console.kubestellar.io.
+                        </p>
+                      </div>
+                      <div>
+                        <p className="font-medium text-foreground mb-1">What does leave your machine</p>
+                        <p>
+                          Your AI chat history and prompts are sent to whichever LLM provider you configured —
+                          cloud (Anthropic, OpenAI, Gemini) or self-hosted. Your kubeconfig, cluster tokens, and
+                          secrets are <em>not</em> auto-attached; only what you paste into the chat. Analytics
+                          (page views, feature-use events) can be opted out in Settings.
+                        </p>
+                      </div>
+                      <div>
+                        <p className="font-medium text-foreground mb-1">Air-gapped / high-security environments</p>
+                        <p>
+                          Point kc-agent at a local LLM (Ollama, vLLM, LM Studio, corporate gateway) by overriding{' '}
+                          <code className="font-mono text-foreground/70">GROQ_BASE_URL</code>,{' '}
+                          <code className="font-mono text-foreground/70">OPENROUTER_BASE_URL</code>, or{' '}
+                          <code className="font-mono text-foreground/70">OPEN_WEBUI_URL</code>. AI traffic then
+                          never leaves your perimeter. The core cluster-management UX works with no AI at all.
+                        </p>
+                      </div>
+                      <div className="pt-1">
+                        <a
+                          href={SECURITY_DOC_URL}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="inline-flex items-center gap-1 text-purple-400 hover:text-purple-300"
+                        >
+                          Read the full security model
+                          <ExternalLink className="w-3 h-3" />
+                        </a>
+                      </div>
                     </div>
                   )}
                 </div>

--- a/web/src/lib/missions/types.ts
+++ b/web/src/lib/missions/types.ts
@@ -70,6 +70,8 @@ export interface MissionExport {
   uninstall?: MissionStep[]
   upgrade?: MissionStep[]
   troubleshooting?: MissionStep[]
+  /** Security considerations for the install: cluster-scoped changes, privileged access, outbound calls, upstream policy links, hardening options. */
+  security?: MissionStep[]
   /** Orbit (recurring maintenance) configuration — present when missionClass is 'orbit' */
   orbitConfig?: OrbitConfig
   resolution?: {

--- a/web/src/locales/en/common.json
+++ b/web/src/locales/en/common.json
@@ -3406,7 +3406,9 @@
         "upgrade": "Update / Upgrade",
         "upgradeEmpty": "Upgrade steps not yet available for this mission.",
         "troubleshooting": "Troubleshooting",
-        "troubleshootingEmpty": "Troubleshooting steps not yet available for this mission."
+        "troubleshootingEmpty": "Troubleshooting steps not yet available for this mission.",
+        "security": "Security",
+        "securityEmpty": "Security notes not yet available for this mission."
       }
     }
   },


### PR DESCRIPTION
## Summary

Makes the security picture visible in-context at the two moments users care about — installing the Console itself and installing a CNCF project via a guided mission. Both surfaces link to \`docs/security/SECURITY-MODEL.md\` (merged in #8203) as the canonical reference.

This is the UI half of task 3 from the session todo — the docs half landed in #8203, the mermaid enhancement is in #8206, the schema side is in kubestellar/console-kb#2027.

## What changes

### Setup install modal — \`SetupInstructionsDialog.tsx\`

New expandable **Security posture** section alongside the existing Dev Guide / K8s Deploy / OAuth sections. Four subsections:

1. **kc-agent runs on your machine, not ours** — loopback bind, user kubeconfig RBAC, \`KC_AGENT_TOKEN\` optional shared secret
2. **AI keys never leave your machine** — \`~/.kc/config.yaml\` mode 0600, browser never holds the keys
3. **What does leave your machine** — AI chat history only, cluster secrets not auto-attached, analytics opt-outable
4. **Air-gapped / high-security environments** — \`GROQ_BASE_URL\` / \`OPENROUTER_BASE_URL\` / \`OPEN_WEBUI_URL\` overrides for local LLMs

Framed deliberately to **not** conflate with broader local-LLM support work (tracked separately as Manuela's feedback).

### Mission Detail view — \`MissionDetailView.tsx\`

Adds a 5th tab: \`install | uninstall | upgrade | troubleshooting | **security**\`. The tab:

- Renders \`mission.security\` steps via the existing \`StepCard\` component
- When populated, adds a footer link to the overall \`SECURITY-MODEL.md\`
- When empty (most missions today), shows a helpful fallback with the global doc link + a \"Suggest security notes\" button that reuses the existing \`onImprove\` flow

### Schema — \`types.ts\`

Adds optional \`security?: MissionStep[]\` to the \`MissionExport\` interface. Backwards-compatible.

### Locale — \`locales/en/common.json\`

Adds \`missions.detail.tabs.security\` and \`missions.detail.tabs.securityEmpty\` strings.

## Paired PRs

- [#8203](https://github.com/kubestellar/console/pull/8203) (merged) — \`docs/security/SECURITY-MODEL.md\`
- [#8206](https://github.com/kubestellar/console/pull/8206) — mermaid diagrams for SECURITY-MODEL.md
- [kubestellar/console-kb#2027](https://github.com/kubestellar/console-kb/pull/2027) — schema + populate \`install-kubevirt.json\` with 6 security bullets
- [kubestellar/docs (branch docs/console-security-model)](https://github.com/kubestellar/docs/tree/docs/console-security-model) — public-docs mirror page

## Test plan

- [x] \`npm run build\` passes locally
- [x] No TypeScript errors
- [ ] Render check: open SetupInstructionsDialog and verify the new Security section expands/collapses and links resolve
- [ ] Render check: open any mission detail and verify the new Security tab renders; populated missions (install-kubevirt after console-kb#2027 merges) show the 6 bullets, others show the fallback