### PR TITLE
🐛 fix(useGlobalFilters): return no-op defaults instead of throwing

### DIFF
--- a/web/src/hooks/useGlobalFilters.tsx
+++ b/web/src/hooks/useGlobalFilters.tsx
@@ -668,10 +668,68 @@ export function GlobalFiltersProvider({ children }: { children: ReactNode }) {
   )
 }
 
+// Default returned when a consumer renders outside the provider — e.g. cards
+// pulled into a LightweightShell route, or a brief mid-transition frame where
+// `useLivePathname` flips the root <Routes> between FullDashboardApp and
+// LightweightShell. Throwing would bubble up to AppErrorBoundary and show a
+// crash screen on lightweight pages that don't need filtering at all. A
+// no-op fallback lets those pages render while still behaving correctly
+// (no clusters selected means "all", setters are no-ops, filter functions
+// return items untouched).
+const DEFAULT_GLOBAL_FILTERS: GlobalFiltersContextType = {
+  selectedClusters: [],
+  setSelectedClusters: () => {},
+  toggleCluster: () => {},
+  selectAllClusters: () => {},
+  deselectAllClusters: () => {},
+  isAllClustersSelected: true,
+  isClustersFiltered: false,
+  availableClusters: [],
+  clusterInfoMap: {},
+
+  clusterGroups: [],
+  addClusterGroup: () => {},
+  updateClusterGroup: () => {},
+  deleteClusterGroup: () => {},
+  selectClusterGroup: () => {},
+
+  selectedSeverities: [],
+  setSelectedSeverities: () => {},
+  toggleSeverity: () => {},
+  selectAllSeverities: () => {},
+  deselectAllSeverities: () => {},
+  isAllSeveritiesSelected: true,
+  isSeveritiesFiltered: false,
+
+  selectedStatuses: [],
+  setSelectedStatuses: () => {},
+  toggleStatus: () => {},
+  selectAllStatuses: () => {},
+  deselectAllStatuses: () => {},
+  isAllStatusesSelected: true,
+  isStatusesFiltered: false,
+
+  customFilter: '',
+  setCustomFilter: () => {},
+  clearCustomFilter: () => {},
+  hasCustomFilter: false,
+
+  isFiltered: false,
+  clearAllFilters: () => {},
+
+  savedFilterSets: [],
+  saveCurrentFilters: () => {},
+  applySavedFilterSet: () => {},
+  deleteSavedFilterSet: () => {},
+  activeFilterSetId: null,
+
+  filterByCluster: items => items,
+  filterBySeverity: items => items,
+  filterByStatus: items => items,
+  filterByCustomText: items => items,
+  filterItems: items => items,
+}
+
 export function useGlobalFilters() {
-  const context = useContext(GlobalFiltersContext)
-  if (!context) {
-    throw new Error('useGlobalFilters must be used within a GlobalFiltersProvider')
-  }
-  return context
+  return useContext(GlobalFiltersContext) ?? DEFAULT_GLOBAL_FILTERS
 }


### PR DESCRIPTION
## Summary
- Fixes the `useGlobalFilters must be used within a GlobalFiltersProvider` uncaught-render error seen today in GA4 on `/clusters`.
- Root cause is **not** /clusters itself — it's the shell boundary between `FullDashboardApp` (wraps children in `GlobalFiltersProvider`) and `LightweightShell` (no providers: `/welcome`, `/missions/:id`, `/from-*`, `/feature-*`, `/white-label`). `useLivePathname` polls `window.location` every 60ms to bypass React Router's `startTransition`, so during client-side navigation between a full-dashboard route and a lightweight route the root `<Routes>` re-evaluates mid-transition and a card that calls `useGlobalFilters` can render under the wrong shell for a frame. GA4's `error_page` is captured at throw-time, which is why it shows up on the route the user happened to be on.
- Throwing bubbled to `AppErrorBoundary` and painted a crash screen for what was almost always a transient transition.
- Fix: return no-op defaults (empty cluster selection = "all", no-op setters, pass-through filter functions) when the provider is missing. Full-dashboard consumers are unaffected — they still see the real provider value.

## Test plan
- [ ] Verify `/welcome`, `/missions/some-id`, `/from-lens` still render (they don't import `useGlobalFilters` directly today, but this removes a future footgun).
- [ ] Verify `/clusters`, `/`, `/gpu-reservations`, etc. still filter correctly when clicking cluster chips — real provider value must still be returned there.
- [ ] Check GA4 `ksc_error` count for `uncaught_render` with `useGlobalFilters` over the next 24h — should drop to zero.

🤖 Generated with [Claude Code](https://claude.com/claude-code)