### PR TITLE
🔒 fix: audit setCORSHeaders callers to pass explicit methods (#8201)

### DIFF
--- a/pkg/agent/server_argocd.go
+++ b/pkg/agent/server_argocd.go
@@ -51,11 +51,8 @@ type agentArgoSyncRequest struct {
 // ServiceAccount on the backend; on kc-agent it runs under the user's
 // kubeconfig (#7993 Phase 3c).
 func (s *Server) handleArgoCDSync(w http.ResponseWriter, r *http.Request) {
-	s.setCORSHeaders(w, r)
-	// #8040: setCORSHeaders defaults Access-Control-Allow-Methods to
-	// "GET, OPTIONS" (pkg/agent/server_http.go). This endpoint is POST-only,
-	// so browsers would reject the CORS preflight without this override.
-	w.Header().Set("Access-Control-Allow-Methods", "POST, OPTIONS")
+	// POST-only ArgoCD sync — preflight must advertise POST (#8040, #8201).
+	s.setCORSHeaders(w, r, http.MethodPost, http.MethodOptions)
 	w.Header().Set("Content-Type", "application/json")
 	if r.Method == "OPTIONS" {
 		w.WriteHeader(http.StatusOK)

--- a/pkg/agent/server_console_cr.go
+++ b/pkg/agent/server_console_cr.go
@@ -68,7 +68,8 @@ func (s *Server) resolveConsoleCRTarget(w http.ResponseWriter, r *http.Request) 
 // CRs. POST creates with a body-supplied spec. PUT updates by name (name
 // also in query). DELETE removes by name.
 func (s *Server) handleConsoleCRManagedWorkloads(w http.ResponseWriter, r *http.Request) {
-	s.setCORSHeaders(w, r)
+	// #8201: POST create, PUT update, DELETE remove — preflight must advertise all.
+	s.setCORSHeaders(w, r, http.MethodPost, http.MethodPut, http.MethodDelete, http.MethodOptions)
 	w.Header().Set("Content-Type", "application/json")
 	if r.Method == http.MethodOptions {
 		w.WriteHeader(http.StatusOK)
@@ -150,7 +151,8 @@ func (s *Server) handleConsoleCRManagedWorkloads(w http.ResponseWriter, r *http.
 
 // handleConsoleCRClusterGroups serves POST/PUT/DELETE for ClusterGroup CRs.
 func (s *Server) handleConsoleCRClusterGroups(w http.ResponseWriter, r *http.Request) {
-	s.setCORSHeaders(w, r)
+	// #8201: POST create, PUT update, DELETE remove — preflight must advertise all.
+	s.setCORSHeaders(w, r, http.MethodPost, http.MethodPut, http.MethodDelete, http.MethodOptions)
 	w.Header().Set("Content-Type", "application/json")
 	if r.Method == http.MethodOptions {
 		w.WriteHeader(http.StatusOK)
@@ -235,7 +237,8 @@ func (s *Server) handleConsoleCRClusterGroups(w http.ResponseWriter, r *http.Req
 // exposed status updates (see handleConsoleCRWorkloadDeploymentStatus), and
 // spec updates are reserved for the system-internal reconciler.
 func (s *Server) handleConsoleCRWorkloadDeployments(w http.ResponseWriter, r *http.Request) {
-	s.setCORSHeaders(w, r)
+	// #8201: POST create, DELETE remove — preflight must advertise both.
+	s.setCORSHeaders(w, r, http.MethodPost, http.MethodDelete, http.MethodOptions)
 	w.Header().Set("Content-Type", "application/json")
 	if r.Method == http.MethodOptions {
 		w.WriteHeader(http.StatusOK)
@@ -299,7 +302,8 @@ func (s *Server) handleConsoleCRWorkloadDeployments(w http.ResponseWriter, r *ht
 // of WorkloadDeployment CRs. The frontend sends a partial spec containing only
 // the status field, merged with the current resource on the apiserver side.
 func (s *Server) handleConsoleCRWorkloadDeploymentStatus(w http.ResponseWriter, r *http.Request) {
-	s.setCORSHeaders(w, r)
+	// PUT-only status update — preflight must advertise PUT (#8201).
+	s.setCORSHeaders(w, r, http.MethodPut, http.MethodOptions)
 	w.Header().Set("Content-Type", "application/json")
 	if r.Method == http.MethodOptions {
 		w.WriteHeader(http.StatusOK)

--- a/pkg/agent/server_gitops.go
+++ b/pkg/agent/server_gitops.go
@@ -280,7 +280,8 @@ func gitopsParseApplyOutput(output string) []string {
 // portable to kc-agent — this handler always uses the kubectl path, matching
 // the backend's fallback behavior when `h.bridge` is nil (#7993 Phase 3b).
 func (s *Server) handleDetectDrift(w http.ResponseWriter, r *http.Request) {
-	s.setCORSHeaders(w, r)
+	// POST-only drift detection — preflight must advertise POST (#8201).
+	s.setCORSHeaders(w, r, http.MethodPost, http.MethodOptions)
 	w.Header().Set("Content-Type", "application/json")
 	if r.Method == "OPTIONS" {
 		w.WriteHeader(http.StatusOK)
@@ -391,7 +392,8 @@ func (s *Server) handleDetectDrift(w http.ResponseWriter, r *http.Request) {
 // user's kubeconfig. Backend had an MCP-first path; kc-agent always uses
 // kubectl (#7993 Phase 3b).
 func (s *Server) handleGitopsSync(w http.ResponseWriter, r *http.Request) {
-	s.setCORSHeaders(w, r)
+	// POST-only gitops sync — preflight must advertise POST (#8201).
+	s.setCORSHeaders(w, r, http.MethodPost, http.MethodOptions)
 	w.Header().Set("Content-Type", "application/json")
 	if r.Method == "OPTIONS" {
 		w.WriteHeader(http.StatusOK)

--- a/pkg/agent/server_gpu_health.go
+++ b/pkg/agent/server_gpu_health.go
@@ -58,7 +58,8 @@ func isValidCronScheduleAgent(schedule string) bool {
 // s.k8sClient (MultiClusterClient) which, in kc-agent, uses the user's
 // kubeconfig.
 func (s *Server) handleGPUHealthCronJob(w http.ResponseWriter, r *http.Request) {
-	s.setCORSHeaders(w, r)
+	// #8201: POST install, DELETE uninstall — preflight must advertise both.
+	s.setCORSHeaders(w, r, http.MethodPost, http.MethodDelete, http.MethodOptions)
 	w.Header().Set("Content-Type", "application/json")
 
 	if r.Method == "OPTIONS" {

--- a/pkg/agent/server_helm.go
+++ b/pkg/agent/server_helm.go
@@ -141,7 +141,8 @@ type helmUpgradeRequest struct {
 // Part of #7993 Phase 3a — the backend handler is still present until
 // Phase 4 deletes it.
 func (s *Server) handleHelmRollback(w http.ResponseWriter, r *http.Request) {
-	s.setCORSHeaders(w, r)
+	// POST-only Helm rollback — preflight must advertise POST (#8201).
+	s.setCORSHeaders(w, r, http.MethodPost, http.MethodOptions)
 	w.Header().Set("Content-Type", "application/json")
 	if r.Method == "OPTIONS" {
 		w.WriteHeader(http.StatusOK)
@@ -218,7 +219,8 @@ func (s *Server) handleHelmRollback(w http.ResponseWriter, r *http.Request) {
 // handleHelmUninstall is the kc-agent version of the legacy backend
 // /api/gitops/helm-uninstall endpoint.
 func (s *Server) handleHelmUninstall(w http.ResponseWriter, r *http.Request) {
-	s.setCORSHeaders(w, r)
+	// POST-only Helm uninstall — preflight must advertise POST (#8201).
+	s.setCORSHeaders(w, r, http.MethodPost, http.MethodOptions)
 	w.Header().Set("Content-Type", "application/json")
 	if r.Method == "OPTIONS" {
 		w.WriteHeader(http.StatusOK)
@@ -290,7 +292,8 @@ func (s *Server) handleHelmUninstall(w http.ResponseWriter, r *http.Request) {
 // handleHelmUpgrade is the kc-agent version of the legacy backend
 // /api/gitops/helm-upgrade endpoint.
 func (s *Server) handleHelmUpgrade(w http.ResponseWriter, r *http.Request) {
-	s.setCORSHeaders(w, r)
+	// POST-only Helm upgrade — preflight must advertise POST (#8201).
+	s.setCORSHeaders(w, r, http.MethodPost, http.MethodOptions)
 	w.Header().Set("Content-Type", "application/json")
 	if r.Method == "OPTIONS" {
 		w.WriteHeader(http.StatusOK)

--- a/pkg/agent/server_http.go
+++ b/pkg/agent/server_http.go
@@ -318,7 +318,9 @@ func (s *Server) handleEventsHTTP(w http.ResponseWriter, r *http.Request) {
 // pkg/api/handlers/mcp_resources.go#CreateOrUpdateResourceQuota) because the
 // reservation operator owns quota semantics and needs pod-SA access.
 func (s *Server) handleNamespacesHTTP(w http.ResponseWriter, r *http.Request) {
-	s.setCORSHeaders(w, r)
+	// #8201: GET list, POST create, DELETE remove — preflight must advertise all
+	// three so browsers don't reject cross-origin POST/DELETE.
+	s.setCORSHeaders(w, r, http.MethodGet, http.MethodPost, http.MethodDelete, http.MethodOptions)
 	w.Header().Set("Content-Type", "application/json")
 
 	if r.Method == "OPTIONS" {
@@ -793,7 +795,9 @@ func (s *Server) handleSecretsHTTP(w http.ResponseWriter, r *http.Request) {
 // mutations that run under the user's kubeconfig via kc-agent rather than the
 // backend's pod ServiceAccount (#7993 Phase 1.5 PR A).
 func (s *Server) handleServiceAccountsHTTP(w http.ResponseWriter, r *http.Request) {
-	s.setCORSHeaders(w, r)
+	// #8201: GET list, POST create, DELETE remove — preflight must advertise all
+	// three so browsers don't reject cross-origin POST/DELETE.
+	s.setCORSHeaders(w, r, http.MethodGet, http.MethodPost, http.MethodDelete, http.MethodOptions)
 	w.Header().Set("Content-Type", "application/json")
 	if r.Method == "OPTIONS" {
 		w.WriteHeader(http.StatusOK)
@@ -904,7 +908,8 @@ func (s *Server) deleteServiceAccountHTTP(w http.ResponseWriter, r *http.Request
 // frontend consumer and have been removed — any future UI that adds MCS
 // export management should call this route.
 func (s *Server) handleServiceExportsHTTP(w http.ResponseWriter, r *http.Request) {
-	s.setCORSHeaders(w, r)
+	// #8201: POST create, DELETE remove — preflight must advertise both.
+	s.setCORSHeaders(w, r, http.MethodPost, http.MethodDelete, http.MethodOptions)
 	w.Header().Set("Content-Type", "application/json")
 	if r.Method == "OPTIONS" {
 		w.WriteHeader(http.StatusOK)
@@ -1140,7 +1145,9 @@ func (s *Server) handleRolesHTTP(w http.ResponseWriter, r *http.Request) {
 // user-initiated mutations that run under the user's kubeconfig via kc-agent
 // rather than the backend's pod ServiceAccount (#7993 Phase 1.5 PR A).
 func (s *Server) handleRoleBindingsHTTP(w http.ResponseWriter, r *http.Request) {
-	s.setCORSHeaders(w, r)
+	// #8201: GET list, POST create, DELETE remove — preflight must advertise all
+	// three so browsers don't reject cross-origin POST/DELETE.
+	s.setCORSHeaders(w, r, http.MethodGet, http.MethodPost, http.MethodDelete, http.MethodOptions)
 	w.Header().Set("Content-Type", "application/json")
 	if r.Method == "OPTIONS" {
 		w.WriteHeader(http.StatusOK)
@@ -1461,11 +1468,9 @@ func (s *Server) handleResolveDepsHTTP(w http.ResponseWriter, r *http.Request) {
 // replica count via the Kubernetes API. Only POST with a JSON body is accepted;
 // GET-based mutations are rejected to prevent CSRF-style attacks (#4150).
 func (s *Server) handleScaleHTTP(w http.ResponseWriter, r *http.Request) {
-	s.setCORSHeaders(w, r)
-	// setCORSHeaders defaults Access-Control-Allow-Methods to "GET, OPTIONS".
-	// This is a mutating POST endpoint — browsers would otherwise reject the
-	// cross-origin POST preflight (#8019, #8021).
-	w.Header().Set("Access-Control-Allow-Methods", "POST, OPTIONS")
+	// POST-only mutating endpoint — preflight must advertise POST so browsers
+	// don't reject the cross-origin request (#8019, #8021, #8201).
+	s.setCORSHeaders(w, r, http.MethodPost, http.MethodOptions)
 	w.Header().Set("Content-Type", "application/json")
 	if r.Method == "OPTIONS" {
 		w.WriteHeader(http.StatusOK)
@@ -1621,9 +1626,8 @@ func (s *Server) handleScaleHTTP(w http.ResponseWriter, r *http.Request) {
 // Only POST with a JSON body is accepted; GET-based mutations are rejected to
 // prevent CSRF-style attacks (#4150 pattern, same as handleScaleHTTP).
 func (s *Server) handleDeployWorkloadHTTP(w http.ResponseWriter, r *http.Request) {
-	s.setCORSHeaders(w, r)
-	// setCORSHeaders defaults Methods to "GET, OPTIONS"; override for POST (#8021).
-	w.Header().Set("Access-Control-Allow-Methods", "POST, OPTIONS")
+	// POST-only deploy endpoint — preflight must advertise POST (#8021, #8201).
+	s.setCORSHeaders(w, r, http.MethodPost, http.MethodOptions)
 	w.Header().Set("Content-Type", "application/json")
 	if r.Method == "OPTIONS" {
 		w.WriteHeader(http.StatusOK)
@@ -1771,9 +1775,8 @@ func (s *Server) handleDeployWorkloadHTTP(w http.ResponseWriter, r *http.Request
 // is POST-with-body for all mutations (same as /scale), so the frontend sends
 // a POST with {cluster, namespace, name} in the body.
 func (s *Server) handleDeleteWorkloadHTTP(w http.ResponseWriter, r *http.Request) {
-	s.setCORSHeaders(w, r)
-	// setCORSHeaders defaults Methods to "GET, OPTIONS"; override for POST (#8021).
-	w.Header().Set("Access-Control-Allow-Methods", "POST, OPTIONS")
+	// POST-only delete endpoint — preflight must advertise POST (#8021, #8201).
+	s.setCORSHeaders(w, r, http.MethodPost, http.MethodOptions)
 	w.Header().Set("Content-Type", "application/json")
 	if r.Method == "OPTIONS" {
 		w.WriteHeader(http.StatusOK)
@@ -1963,6 +1966,12 @@ const defaultCORSAllowedMethods = "GET, OPTIONS"
 // Access-Control-Allow-Methods value — this is required for POST/PUT/DELETE
 // endpoints so browser preflight requests succeed. When no methods are
 // supplied the header defaults to defaultCORSAllowedMethods.
+//
+// Audit rule (#8201): every handler that serves any method other than GET
+// MUST pass an explicit method list including OPTIONS, e.g.
+// setCORSHeaders(w, r, http.MethodPost, http.MethodOptions). Handlers that
+// rely on the default and silently advertise "GET, OPTIONS" will fail
+// browser preflight for cross-origin POST/DELETE requests.
 func (s *Server) setCORSHeaders(w http.ResponseWriter, r *http.Request, methods ...string) {
 	origin := r.Header.Get("Origin")
 	if s.isAllowedOrigin(origin) {
@@ -2254,11 +2263,11 @@ func (s *Server) checkBackendHealth() bool {
 
 // handleAutoUpdateConfig handles GET/POST for auto-update configuration.
 func (s *Server) handleAutoUpdateConfig(w http.ResponseWriter, r *http.Request) {
-	s.setCORSHeaders(w, r)
+	// #8201: GET reads config, POST writes config — preflight must advertise both.
+	s.setCORSHeaders(w, r, http.MethodGet, http.MethodPost, http.MethodOptions)
 	w.Header().Set("Content-Type", "application/json")
 
 	if r.Method == "OPTIONS" {
-		w.Header().Set("Access-Control-Allow-Methods", "GET, POST, OPTIONS")
 		w.WriteHeader(http.StatusOK)
 		return
 	}
@@ -2352,11 +2361,11 @@ func (s *Server) handleAutoUpdateStatus(w http.ResponseWriter, r *http.Request) 
 
 // handleAutoUpdateTrigger triggers an immediate update check.
 func (s *Server) handleAutoUpdateTrigger(w http.ResponseWriter, r *http.Request) {
-	s.setCORSHeaders(w, r)
+	// POST-only trigger endpoint — preflight must advertise POST (#8201).
+	s.setCORSHeaders(w, r, http.MethodPost, http.MethodOptions)
 	w.Header().Set("Content-Type", "application/json")
 
 	if r.Method == "OPTIONS" {
-		w.Header().Set("Access-Control-Allow-Methods", "POST, OPTIONS")
 		w.WriteHeader(http.StatusOK)
 		return
 	}
@@ -2403,11 +2412,11 @@ func (s *Server) handleAutoUpdateTrigger(w http.ResponseWriter, r *http.Request)
 // honored, and the update cannot be cancelled once the restart step has begun
 // (startup-oauth.sh is spawned as a detached process).
 func (s *Server) handleAutoUpdateCancel(w http.ResponseWriter, r *http.Request) {
-	s.setCORSHeaders(w, r)
+	// POST-only cancel endpoint — preflight must advertise POST (#8201).
+	s.setCORSHeaders(w, r, http.MethodPost, http.MethodOptions)
 	w.Header().Set("Content-Type", "application/json")
 
 	if r.Method == "OPTIONS" {
-		w.Header().Set("Access-Control-Allow-Methods", "POST, OPTIONS")
 		w.WriteHeader(http.StatusOK)
 		return
 	}
@@ -2618,8 +2627,8 @@ type kubeconfigAddResponse struct {
 
 // handleKubeconfigRemoveHTTP removes a cluster context from the kubeconfig (#5658).
 func (s *Server) handleKubeconfigRemoveHTTP(w http.ResponseWriter, r *http.Request) {
-	s.setCORSHeaders(w, r)
-	w.Header().Set("Access-Control-Allow-Methods", "POST, OPTIONS") // Copilot: setCORSHeaders defaults to GET
+	// POST-only kubeconfig removal — preflight must advertise POST (#8201).
+	s.setCORSHeaders(w, r, http.MethodPost, http.MethodOptions)
 	w.Header().Set("Content-Type", "application/json")
 
 	if r.Method == "OPTIONS" {

--- a/pkg/agent/server_operations.go
+++ b/pkg/agent/server_operations.go
@@ -1285,7 +1285,8 @@ func (s *Server) handleLocalClusterTools(w http.ResponseWriter, r *http.Request)
 
 // handleLocalClusters handles local cluster operations (list, create, delete)
 func (s *Server) handleLocalClusters(w http.ResponseWriter, r *http.Request) {
-	s.setCORSHeaders(w, r)
+	// #8201: GET list, POST create, DELETE remove — preflight must advertise all.
+	s.setCORSHeaders(w, r, http.MethodGet, http.MethodPost, http.MethodDelete, http.MethodOptions)
 	w.Header().Set("Content-Type", "application/json")
 
 	if r.Method == "OPTIONS" {
@@ -1446,7 +1447,8 @@ func (s *Server) handleLocalClusters(w http.ResponseWriter, r *http.Request) {
 
 // handleLocalClusterLifecycle handles start/stop/restart for local clusters
 func (s *Server) handleLocalClusterLifecycle(w http.ResponseWriter, r *http.Request) {
-	s.setCORSHeaders(w, r)
+	// POST-only lifecycle action — preflight must advertise POST (#8201).
+	s.setCORSHeaders(w, r, http.MethodPost, http.MethodOptions)
 	w.Header().Set("Content-Type", "application/json")
 
 	if r.Method == "OPTIONS" {
@@ -1566,7 +1568,8 @@ func (s *Server) handleVClusterList(w http.ResponseWriter, r *http.Request) {
 
 // handleVClusterCreate creates a new vCluster
 func (s *Server) handleVClusterCreate(w http.ResponseWriter, r *http.Request) {
-	s.setCORSHeaders(w, r)
+	// POST-only vCluster create — preflight must advertise POST (#8201).
+	s.setCORSHeaders(w, r, http.MethodPost, http.MethodOptions)
 	w.Header().Set("Content-Type", "application/json")
 
 	if r.Method == "OPTIONS" {
@@ -1645,7 +1648,8 @@ func (s *Server) handleVClusterCreate(w http.ResponseWriter, r *http.Request) {
 
 // handleVClusterConnect connects to an existing vCluster
 func (s *Server) handleVClusterConnect(w http.ResponseWriter, r *http.Request) {
-	s.setCORSHeaders(w, r)
+	// POST-only vCluster connect — preflight must advertise POST (#8201).
+	s.setCORSHeaders(w, r, http.MethodPost, http.MethodOptions)
 	w.Header().Set("Content-Type", "application/json")
 
 	if r.Method == "OPTIONS" {
@@ -1702,7 +1706,8 @@ func (s *Server) handleVClusterConnect(w http.ResponseWriter, r *http.Request) {
 
 // handleVClusterDisconnect disconnects from a vCluster
 func (s *Server) handleVClusterDisconnect(w http.ResponseWriter, r *http.Request) {
-	s.setCORSHeaders(w, r)
+	// POST-only vCluster disconnect — preflight must advertise POST (#8201).
+	s.setCORSHeaders(w, r, http.MethodPost, http.MethodOptions)
 	w.Header().Set("Content-Type", "application/json")
 
 	if r.Method == "OPTIONS" {
@@ -1759,7 +1764,8 @@ func (s *Server) handleVClusterDisconnect(w http.ResponseWriter, r *http.Request
 
 // handleVClusterDelete deletes a vCluster
 func (s *Server) handleVClusterDelete(w http.ResponseWriter, r *http.Request) {
-	s.setCORSHeaders(w, r)
+	// POST-only vCluster delete — preflight must advertise POST (#8201).
+	s.setCORSHeaders(w, r, http.MethodPost, http.MethodOptions)
 	w.Header().Set("Content-Type", "application/json")
 
 	if r.Method == "OPTIONS" {

--- a/pkg/agent/server_rbac_test.go
+++ b/pkg/agent/server_rbac_test.go
@@ -62,3 +62,28 @@ func TestSetCORSHeaders_ExplicitMethodsJoined(t *testing.T) {
 		t.Errorf("expected %q, got %q", "POST, OPTIONS", methods)
 	}
 }
+
+// TestHandleServiceAccounts_CORSMethodsHeader verifies the audit fix for
+// #8201 — the /serviceaccounts handler now advertises GET/POST/DELETE on the
+// preflight response, so cross-origin POST/DELETE requests aren't rejected by
+// the browser. Before the audit, every handler that fell through to the
+// default "GET, OPTIONS" had this bug; this test pins the fix for one of the
+// handlers Copilot specifically called out.
+func TestHandleServiceAccounts_CORSMethodsHeader(t *testing.T) {
+	s := &Server{
+		allowedOrigins: []string{"http://localhost:3000"},
+	}
+
+	req := httptest.NewRequest("OPTIONS", "/serviceaccounts", nil)
+	req.Header.Set("Origin", "http://localhost:3000")
+	w := httptest.NewRecorder()
+
+	s.handleServiceAccountsHTTP(w, req)
+
+	methods := w.Header().Get("Access-Control-Allow-Methods")
+	for _, want := range []string{"GET", "POST", "DELETE", "OPTIONS"} {
+		if !strings.Contains(methods, want) {
+			t.Errorf("expected Access-Control-Allow-Methods to include %q, got %q", want, methods)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Copilot review on merged PR #8198 flagged:

> `pkg/agent/server_http.go:1976` — `setCORSHeaders` still defaults `Access-Control-Allow-Methods` to `"GET, OPTIONS"` unless callers pass an explicit method list. There are existing kc-agent handlers that serve POST/DELETE (e.g., `/serviceaccounts`, and others) which call `setCORSHeaders(w)` without passing methods, so their preflight responses still advertise only GET/OPTIONS.

This PR audits every `setCORSHeaders` caller in `pkg/agent` and updates each non-GET handler to pass an explicit method list. The default of `"GET, OPTIONS"` is preserved for back-compat and remains correct for read-only handlers.

## Handlers Updated

**`server_http.go`**
- `handleNamespacesHTTP` → GET, POST, DELETE, OPTIONS
- `handleServiceAccountsHTTP` → GET, POST, DELETE, OPTIONS (Copilot-flagged)
- `handleServiceExportsHTTP` → POST, DELETE, OPTIONS
- `handleRoleBindingsHTTP` → GET, POST, DELETE, OPTIONS
- `handleScaleHTTP` → POST, OPTIONS (consolidated from inline override)
- `handleDeployWorkloadHTTP` → POST, OPTIONS (consolidated from inline override)
- `handleDeleteWorkloadHTTP` → POST, OPTIONS (consolidated from inline override)
- `handleAutoUpdateConfig` → GET, POST, OPTIONS (was set only inside the OPTIONS branch)
- `handleAutoUpdateTrigger` → POST, OPTIONS (was set only inside the OPTIONS branch)
- `handleAutoUpdateCancel` → POST, OPTIONS (was set only inside the OPTIONS branch)
- `handleKubeconfigRemoveHTTP` → POST, OPTIONS (consolidated from inline override)

**`server_helm.go`**
- `handleHelmRollback` → POST, OPTIONS
- `handleHelmUninstall` → POST, OPTIONS
- `handleHelmUpgrade` → POST, OPTIONS

**`server_gitops.go`**
- `handleDetectDrift` → POST, OPTIONS
- `handleGitopsSync` → POST, OPTIONS

**`server_console_cr.go`**
- `handleConsoleCRManagedWorkloads` → POST, PUT, DELETE, OPTIONS
- `handleConsoleCRClusterGroups` → POST, PUT, DELETE, OPTIONS
- `handleConsoleCRWorkloadDeployments` → POST, DELETE, OPTIONS
- `handleConsoleCRWorkloadDeploymentStatus` → PUT, OPTIONS

**`server_argocd.go`**
- `handleArgoCDSync` → POST, OPTIONS (consolidated from inline override added in #8040)

**`server_gpu_health.go`**
- `handleGPUHealthCronJob` → POST, DELETE, OPTIONS

**`server_operations.go`**
- `handleLocalClusters` → GET, POST, DELETE, OPTIONS
- `handleLocalClusterLifecycle` → POST, OPTIONS
- `handleVClusterCreate` → POST, OPTIONS
- `handleVClusterConnect` → POST, OPTIONS
- `handleVClusterDisconnect` → POST, OPTIONS
- `handleVClusterDelete` → POST, OPTIONS

GET-only handlers (gpu-nodes, nodes, pods, events, deployments, replicasets, statefulsets, daemonsets, cronjobs, ingresses, networkpolicies, services, configmaps, secrets, jobs, hpas, pvcs, roles, resourcequotas, limitranges, resolve-deps, cluster-health, autoUpdateStatus, kagenti/*, kagent-crds/*, prometheus query, vCluster list/check, cloudCLIStatus, localClusterTools, rbac/permissions, permissions/summary) keep the default and remain correct.

The `setCORSHeaders` doc comment now carries an explicit audit rule so future handlers serving non-GET methods don't silently regress.

A new regression test `TestHandleServiceAccounts_CORSMethodsHeader` pins the fix for the specific handler Copilot called out.

## Test plan

- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] `go test ./pkg/agent/ -run "TestSetCORSHeaders|TestHandleCanIHTTP_CORSMethodsHeader|TestHandleServiceAccounts_CORSMethodsHeader"` passes
- [x] `cd web && npm run build` passes
- [ ] CI build/lint green

Fixes #8201