### PR TITLE
🐛 fix(drasi): depend on array lengths, not references, in layout effect

### DIFF
--- a/web/src/components/cards/drasi/DrasiReactiveGraph.tsx
+++ b/web/src/components/cards/drasi/DrasiReactiveGraph.tsx
@@ -1423,7 +1423,16 @@ export function DrasiReactiveGraph() {
       observer.disconnect()
       window.removeEventListener('resize', measure)
     }
-  }, [sources, queries, reactions, selectedQueryId, liveResults.length])
+    // Depend on lengths, not array references. `sources/queries/reactions`
+    // are recreated every render by useMemo consumers in pipelineData, so
+    // including the arrays themselves triggered this effect every render
+    // and drove React's update-depth limit — see GA4 error
+    // "Maximum update depth exceeded" on / from 2026-04-14. The effect
+    // only needs to re-run when the *set* of nodes changes (so new
+    // children mount and their refs become observable); a length change
+    // is a safe proxy for that, and `selectedQueryId` catches active-path
+    // changes that share the same node count.
+  }, [sources.length, queries.length, reactions.length, selectedQueryId, liveResults.length])
 
   // --- Compute paths from measured rects ------------------------------------
 


### PR DESCRIPTION
## Summary
- GA4 flagged a \`Maximum update depth exceeded\` crash on \`/\` today.
- Traced to \`DrasiReactiveGraph.tsx:1426\` — the \`useLayoutEffect\` depended on the \`sources\`, \`queries\`, \`reactions\` array references, which are recreated on every render by the \`pipelineData\` consumer. The effect ran every render → reobserved all nodes → occasionally produced a non-equal measurement → committed a new \`setRects\` → re-rendered → repeated until React's update-depth guard fired.
- Fix: depend on array **lengths** instead. New children still trigger re-observation when the count changes (and their refs get attached), and \`selectedQueryId\` already catches active-path changes that share the same node count.

## Test plan
- [ ] Open \`/drasi\` (or any dashboard hosting \`drasi_reactive_graph\`) — flow lines render correctly
- [ ] Resize the window — lines reflow smoothly, no flicker
- [ ] Add/remove a source or query and confirm the new node gets measured (check DevTools — the layout effect runs once, not in a loop)
- [ ] Monitor GA4 \`ksc_error\` / \`uncaught_render\` on \`/\` over the next 24h — should drop to zero

🤖 Generated with [Claude Code](https://claude.com/claude-code)