### PR TITLE
🐛 fix(unified): memoize mergedConfig to stop dep-array loops

### DIFF
--- a/web/src/lib/unified/card/UnifiedCard.tsx
+++ b/web/src/lib/unified/card/UnifiedCard.tsx
@@ -10,10 +10,10 @@
  *   <UnifiedCard config={clusterHealthConfig} title="Custom Title" />
  */
 
-import { ReactNode } from 'react'
-import { 
-  AlertTriangle, 
-  Info, 
+import { ReactNode, useMemo } from 'react'
+import {
+  AlertTriangle,
+  Info,
   RefreshCw,
   CheckCircle,
   AlertCircle,
@@ -47,14 +47,18 @@ export function UnifiedCard({
   // Check if mode is switching (show skeleton during transition)
   const isModeSwitching = useIsModeSwitching()
 
-  // Merge instance config with base config
-  const mergedConfig = (() => {
+  // Merge instance config with base config.
+  // MUST be memoized: the merged object is passed to useDataSource,
+  // useCardFiltering, and InlineStats — if those (or any downstream
+  // hook) read `mergedConfig.dataSource`/`.filters`/`.stats` in a
+  // useEffect dep, a fresh object every render becomes a setState loop
+  // that trips React error #185. Seen today in GA4 on pv_status /
+  // /storage. Memoizing against `config` and `instanceConfig` identity
+  // is safe: both come from static modules or stable parent state.
+  const mergedConfig = useMemo<UnifiedCardConfig>(() => {
     if (!instanceConfig) return config
-    return {
-      ...config,
-      // Instance config can override certain fields
-      ...instanceConfig } as UnifiedCardConfig
-  })()
+    return { ...config, ...instanceConfig } as UnifiedCardConfig
+  }, [config, instanceConfig])
 
   // Fetch data using the configured data source (skipped if overrideData provided)
   const { data: fetchedData, isLoading: isDataLoading, error, refetch } = useDataSource(


### PR DESCRIPTION
## Summary
- GA4 flagged React error #185 (\`Maximum update depth exceeded\`) today on \`/storage\` for \`default-pv_status-2\`.
- \`UnifiedCard\` was recomputing \`mergedConfig\` as a fresh object on every render when \`instanceConfig\` was provided. That gives \`mergedConfig.dataSource\`, \`.filters\`, \`.stats\`, etc. brand-new identities every render, and any downstream \`useEffect\` that depends on one of those fires on every render → setState → render → effect → repeat.
- Fix: memoize against \`(config, instanceConfig)\` identity. Both come from static modules or stable parent state, so cache hits are the common case.
- Same pattern as the DrasiReactiveGraph fix (#8213) pushed earlier today.

## Test plan
- [ ] Storage dashboard at \`/storage\` renders without crash
- [ ] Add a second \`pv_status\` instance to a custom dashboard and confirm both render cleanly
- [ ] GA4 \`ksc_error\` / \`card_render\` for \`pv_status\` trends to zero over the next 24h

🤖 Generated with [Claude Code](https://claude.com/claude-code)