### PR TITLE
🐛 fix(analytics): filter browser-extension noise from ksc_error

### DIFF
--- a/web/src/lib/analytics.ts
+++ b/web/src/lib/analytics.ts
@@ -1054,6 +1054,37 @@ function wasAlreadyReported(msg: string): boolean {
   return true
 }
 
+/**
+ * Detect promise rejections injected by browser extensions (wallet
+ * providers, adblockers, password managers) that throw against our
+ * window but have nothing to do with our code. GA4 was counting these
+ * as product errors and polluting ksc_error metrics — 5 of 9 errors on
+ * 2026-04-14 were "Failed to connect to MetaMask" from users who
+ * happened to have the extension installed.
+ *
+ * Match on:
+ *  - Message substrings for known extension errors
+ *  - Stack frames that reference chrome-extension:// or moz-extension://
+ *    URLs, which is a strong signal the code throwing isn't ours
+ */
+function isBrowserExtensionNoise(msg: string, reason: unknown): boolean {
+  if (
+    msg.includes('MetaMask') ||
+    msg.includes('ethereum') ||
+    msg.includes('web3') ||
+    msg.includes('evmAsk') ||
+    msg.includes('solana') ||
+    msg.includes('Could not establish connection. Receiving end does not exist')
+  ) return true
+  const stack = (reason as { stack?: string } | null)?.stack
+  if (typeof stack === 'string' && (
+    stack.includes('chrome-extension://') ||
+    stack.includes('moz-extension://') ||
+    stack.includes('safari-extension://')
+  )) return true
+  return false
+}
+
 export function emitError(category: string, detail: string, cardId?: string) {
   send('ksc_error', {
     error_code: category,
@@ -1149,6 +1180,10 @@ export function startGlobalErrorTracking() {
       if (wasAlreadyReported(msg)) return
       // Skip clipboard API errors — expected on non-HTTPS and in restricted contexts
       if (msg.includes('writeText') || msg.includes('clipboard') || msg.includes('copy')) return
+      // Skip browser-extension promise rejections (wallet providers, etc.)
+      // that throw against our window but aren't our code. See
+      // isBrowserExtensionNoise() for rationale.
+      if (isBrowserExtensionNoise(msg, event.reason)) return
       // Stale chunks can surface as unhandled rejections from dynamic import()
       if (tryChunkReloadRecovery(msg)) return
       // Skip AbortError / TimeoutError — expected when fetches are cancelled on unmount
@@ -1212,6 +1247,16 @@ export function startGlobalErrorTracking() {
       if (wasAlreadyReported(event.message)) return
       // Skip clipboard API errors — expected on non-HTTPS and in restricted contexts
       if (event.message.includes('writeText') || event.message.includes('clipboard') || event.message.includes('copy')) return
+      // Skip browser-extension runtime errors — wallet/adblocker content
+      // scripts occasionally throw against our window.
+      if (isBrowserExtensionNoise(event.message, event.error)) return
+      // Also skip when the source filename itself points at an extension URL,
+      // regardless of whether stack parsing catches it.
+      if (typeof event.filename === 'string' && (
+        event.filename.startsWith('chrome-extension://') ||
+        event.filename.startsWith('moz-extension://') ||
+        event.filename.startsWith('safari-extension://')
+      )) return
       // Stale chunks can surface as runtime errors (Safari: "Importing a module script failed")
       if (tryChunkReloadRecovery(event.message)) return
       emitError('runtime', event.message)


### PR DESCRIPTION
## Summary
- GA4 today: 5 of 9 \`ksc_error\` events were \"Failed to connect to MetaMask\" — extension-injected promise rejections against our window that have nothing to do with our code.
- Our global \`unhandledrejection\` / \`error\` handlers counted them as product errors, polluting the \`ksc_error\` metric used to track real regressions.
- Fix adds \`isBrowserExtensionNoise()\` matching on:
  - Known wallet-provider messages (MetaMask, ethereum, web3, evmAsk, solana, \"Could not establish connection\")
  - Stack frames pointing at \`chrome-extension://\` / \`moz-extension://\` / \`safari-extension://\`
  - (sync errors only) \`event.filename\` starting with an extension URL
- Applied in both handlers so content-script sync throws are also filtered.

## Test plan
- [ ] Install MetaMask in a Chrome profile, load localhost console, confirm \`ksc_error\` for \"Failed to connect to MetaMask\" no longer fires (check Network tab / ga_send_event)
- [ ] Verify real product errors (e.g. a thrown React error) still fire \`ksc_error\` as before
- [ ] Check GA4 \`ksc_error\` volume over next 24h — expect ~50% drop from the extension noise floor

🤖 Generated with [Claude Code](https://claude.com/claude-code)