### PR TITLE
🐛 fix(test): align useGlobalFilters outside-provider test with PR #8211 (#8218)

### DIFF
--- a/web/src/hooks/__tests__/useGlobalFilters.test.tsx
+++ b/web/src/hooks/__tests__/useGlobalFilters.test.tsx
@@ -110,14 +110,40 @@ describe('exported constants', () => {
 })
 
 // ===========================================================================
-// Provider requirement
+// Provider requirement — see PR #8211: useGlobalFilters now returns no-op
+// defaults when used outside a provider instead of throwing, so that cards
+// rendered outside the dashboard shell (e.g. in isolated previews) degrade
+// gracefully. The behaviour test below locks in that contract.
 // ===========================================================================
 describe('useGlobalFilters without provider', () => {
-  it('throws when used outside GlobalFiltersProvider', () => {
+  it('returns safe no-op defaults when used outside GlobalFiltersProvider', () => {
     const spy = vi.spyOn(console, 'error').mockImplementation(() => {})
-    expect(() => renderHook(() => useGlobalFilters())).toThrow(
-      'useGlobalFilters must be used within a GlobalFiltersProvider',
-    )
+    const { result } = renderHook(() => useGlobalFilters())
+
+    // All-selected / unfiltered state
+    expect(result.current.selectedClusters).toEqual([])
+    expect(result.current.isAllClustersSelected).toBe(true)
+    expect(result.current.isClustersFiltered).toBe(false)
+    expect(result.current.isAllSeveritiesSelected).toBe(true)
+    expect(result.current.isSeveritiesFiltered).toBe(false)
+    expect(result.current.isAllStatusesSelected).toBe(true)
+    expect(result.current.isStatusesFiltered).toBe(false)
+    expect(result.current.hasCustomFilter).toBe(false)
+    expect(result.current.isFiltered).toBe(false)
+
+    // Setter/action methods are no-ops (do not throw)
+    expect(() => result.current.toggleCluster('cluster-a')).not.toThrow()
+    expect(() => result.current.selectAllClusters()).not.toThrow()
+    expect(() => result.current.clearAllFilters()).not.toThrow()
+
+    // Filter helpers pass items through unchanged
+    const sampleItems = [{ id: 1 }, { id: 2 }]
+    expect(result.current.filterByCluster(sampleItems)).toBe(sampleItems)
+    expect(result.current.filterBySeverity(sampleItems)).toBe(sampleItems)
+    expect(result.current.filterByStatus(sampleItems)).toBe(sampleItems)
+    expect(result.current.filterByCustomText(sampleItems)).toBe(sampleItems)
+    expect(result.current.filterItems(sampleItems)).toBe(sampleItems)
+
     spy.mockRestore()
   })
 })


### PR DESCRIPTION
## Summary

The Coverage Suite has been failing on `src/hooks/__tests__/useGlobalFilters.test.tsx > useGlobalFilters without provider > throws when used outside GlobalFiltersProvider` since PR #8211 was merged.

**Root cause:** PR #8211 (commit `cf8f322a`) intentionally changed `useGlobalFilters` to return safe no-op `DEFAULT_GLOBAL_FILTERS` when used outside a provider (instead of throwing), so cards rendered in isolated previews degrade gracefully. The companion test still asserted the old throw behaviour and was never updated.

Issue #8218 (triggered by PR #8209) was a misattribution — #8209 only touched locale JSON files and has no path to affect this test. The failure was pre-existing from #8211.

## Changes

- Replace the throw assertion with a behaviour contract that locks in the new defaults:
  - Returns `DEFAULT_GLOBAL_FILTERS` shape
  - All "is filtered" flags are `false`, "all selected" flags are `true`
  - Setter/action methods are no-ops (do not throw)
  - Filter helpers (`filterByCluster`, `filterBySeverity`, etc.) pass items through unchanged
- Add a comment pointing at PR #8211 so the intent is discoverable

## Test plan

- [x] `npx vitest run src/hooks/__tests__/useGlobalFilters.test.tsx` — 181/181 pass locally
- [x] `npm run lint` — exit 0 (pre-existing warnings/errors unchanged)
- [x] `npm run build` — exit 0

Fixes #8218