### PR TITLE
🐛 fix(cards): Keycloak card unified controls + hook contract (#8219 #8220)

### DIFF
--- a/web/src/components/cards/keycloak_status/KeycloakStatus.tsx
+++ b/web/src/components/cards/keycloak_status/KeycloakStatus.tsx
@@ -1,3 +1,4 @@
+import { useMemo } from 'react'
 import {
   CheckCircle,
   AlertTriangle,
@@ -11,10 +12,18 @@ import {
 } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 import { Skeleton, SkeletonStats, SkeletonList } from '../../ui/Skeleton'
-import { CardSearchInput } from '../../../lib/cards/CardComponents'
+import {
+  CardSearchInput,
+  CardControlsRow,
+  CardPaginationFooter,
+} from '../../../lib/cards/CardComponents'
 import { useCardData } from '../../../lib/cards/cardHooks'
 import { useKeycloakStatus } from './useKeycloakStatus'
 import type { KeycloakRealm, KeycloakRealmStatus } from './demoData'
+
+// Default page size for the paginated realm list. Named constant per
+// CLAUDE.md "No magic numbers" rule.
+const REALMS_PER_PAGE = 10
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -148,7 +157,8 @@ function RealmRow({ realm }: { realm: KeycloakRealm }) {
 export function KeycloakStatus() {
   const { t } = useTranslation('cards')
   const formatRelativeTime = useFormatRelativeTime()
-  const { data, isRefreshing, error, showSkeleton, showEmptyState } = useKeycloakStatus()
+  const { data, isRefreshing, isFailed, showSkeleton, showEmptyState } =
+    useKeycloakStatus()
 
   const realms = data.realms || []
   const operatorPods = data.operatorPods || { ready: 0, total: 0 }
@@ -159,12 +169,43 @@ export function KeycloakStatus() {
     issues: realms.filter(r => r.status === 'degraded' || r.status === 'error').length,
   }
 
+  // Sort options for CardControls — labels resolved through i18n. Memoized so
+  // the reference stays stable across renders.
+  const SORT_OPTIONS = useMemo(
+    () => [
+      { value: 'status' as const, label: String(t('keycloak.sortByStatus')) },
+      { value: 'name' as const, label: String(t('keycloak.sortByName')) },
+    ],
+    [t],
+  )
+
   const {
-    items: filteredRealms,
-    filters: { search, setSearch },
+    items: displayRealms,
+    totalItems,
+    currentPage,
+    totalPages,
+    itemsPerPage,
+    goToPage,
+    needsPagination,
+    setItemsPerPage,
+    filters: {
+      search,
+      setSearch,
+      localClusterFilter,
+      toggleClusterFilter,
+      clearClusterFilter,
+      availableClusters,
+      showClusterFilter,
+      setShowClusterFilter,
+      clusterFilterRef,
+    },
+    sorting: { sortBy, setSortBy, sortDirection, setSortDirection },
+    containerRef,
+    containerStyle,
   } = useCardData<KeycloakRealm, RealmSortKey>(realms, {
     filter: {
       searchFields: ['name', 'namespace'],
+      clusterField: 'cluster' as keyof KeycloakRealm,
       storageKey: 'keycloak-status',
     },
     sort: {
@@ -176,7 +217,7 @@ export function KeycloakStatus() {
         name: (a, b) => a.name.localeCompare(b.name),
       },
     },
-    defaultLimit: 'unlimited',
+    defaultLimit: REALMS_PER_PAGE,
   })
 
   // ── Loading ───────────────────────────────────────────────────────────────
@@ -195,7 +236,7 @@ export function KeycloakStatus() {
   }
 
   // ── Error ─────────────────────────────────────────────────────────────────
-  if (error && showEmptyState) {
+  if (isFailed && showEmptyState) {
     return (
       <div className="h-full flex flex-col items-center justify-center min-h-card text-muted-foreground gap-2">
         <AlertTriangle className="w-6 h-6 text-red-400" />
@@ -289,20 +330,50 @@ export function KeycloakStatus() {
         </div>
       )}
 
-      {/* ── Search ── */}
+      {/* ── Search + unified controls (sort, limit, cluster filter) ── */}
       {realms.length > 0 && (
-        <CardSearchInput
-          value={search}
-          onChange={setSearch}
-          placeholder={t('keycloak.searchPlaceholder')}
-        />
+        <>
+          <CardSearchInput
+            value={search}
+            onChange={setSearch}
+            placeholder={t('keycloak.searchPlaceholder')}
+          />
+          <CardControlsRow
+            clusterFilter={{
+              availableClusters,
+              selectedClusters: localClusterFilter,
+              onToggle: toggleClusterFilter,
+              onClear: clearClusterFilter,
+              isOpen: showClusterFilter,
+              setIsOpen: setShowClusterFilter,
+              containerRef: clusterFilterRef,
+              minClusters: 1,
+            }}
+            cardControls={{
+              limit: itemsPerPage,
+              onLimitChange: setItemsPerPage,
+              sortBy,
+              sortOptions: SORT_OPTIONS,
+              onSortChange: v => setSortBy(v as RealmSortKey),
+              sortDirection,
+              onSortDirectionChange: setSortDirection,
+            }}
+          />
+        </>
       )}
 
       {/* ── Realm list ── */}
-      <div className="flex-1 space-y-2 overflow-y-auto">
-        {filteredRealms.length > 0 ? (
-          filteredRealms.map(realm => (
-            <RealmRow key={`${realm.namespace}/${realm.name}`} realm={realm} />
+      <div
+        ref={containerRef}
+        className="flex-1 space-y-2 overflow-y-auto"
+        style={containerStyle}
+      >
+        {displayRealms.length > 0 ? (
+          displayRealms.map(realm => (
+            <RealmRow
+              key={`${realm.cluster}/${realm.namespace}/${realm.name}`}
+              realm={realm}
+            />
           ))
         ) : realms.length === 0 ? (
           <div className="flex flex-col items-center justify-center h-full text-muted-foreground gap-1 py-6">
@@ -318,6 +389,16 @@ export function KeycloakStatus() {
           </div>
         )}
       </div>
+
+      {/* ── Pagination ── */}
+      <CardPaginationFooter
+        currentPage={currentPage}
+        totalPages={totalPages}
+        totalItems={totalItems}
+        itemsPerPage={typeof itemsPerPage === 'number' ? itemsPerPage : REALMS_PER_PAGE}
+        onPageChange={goToPage}
+        needsPagination={needsPagination && itemsPerPage !== 'unlimited'}
+      />
 
       {/* ── Footer: totals ── */}
       {realms.length > 0 && (

--- a/web/src/components/cards/keycloak_status/__tests__/KeycloakStatus.test.tsx
+++ b/web/src/components/cards/keycloak_status/__tests__/KeycloakStatus.test.tsx
@@ -91,60 +91,56 @@ const INITIAL_DATA = {
 // Tests
 // ---------------------------------------------------------------------------
 
+// Factory for the canonical hook return shape, per CLAUDE.md Caching Contract.
+// Individual tests override only the fields they care about.
+function makeHookResult(overrides: Partial<ReturnType<typeof useKeycloakStatus>>) {
+  return {
+    data: INITIAL_DATA,
+    isLoading: false,
+    isRefreshing: false,
+    isDemoData: false,
+    isFailed: false,
+    consecutiveFailures: 0,
+    lastRefresh: null,
+    refetch: vi.fn(async () => {}),
+    showSkeleton: false,
+    showEmptyState: false,
+    ...overrides,
+  } as ReturnType<typeof useKeycloakStatus>
+}
+
 describe('KeycloakStatus', () => {
   it('renders skeleton while loading', () => {
-    vi.mocked(useKeycloakStatus).mockReturnValue({
-      data: INITIAL_DATA,
-      loading: true,
-      isRefreshing: false,
-      error: false,
-      consecutiveFailures: 0,
-      showSkeleton: true,
-      showEmptyState: false,
-    })
+    vi.mocked(useKeycloakStatus).mockReturnValue(
+      makeHookResult({ isLoading: true, showSkeleton: true }),
+    )
     const { container } = render(<KeycloakStatus />)
     // Skeleton renders pulsing divs, not realm rows
     expect(container.querySelector('.animate-pulse')).toBeTruthy()
   })
 
   it('renders not-installed state when Keycloak is absent', () => {
-    vi.mocked(useKeycloakStatus).mockReturnValue({
-      data: INITIAL_DATA,
-      loading: false,
-      isRefreshing: false,
-      error: false,
-      consecutiveFailures: 0,
-      showSkeleton: false,
-      showEmptyState: false,
-    })
+    vi.mocked(useKeycloakStatus).mockReturnValue(makeHookResult({}))
     render(<KeycloakStatus />)
     expect(screen.getByText('keycloak.notInstalled')).toBeTruthy()
   })
 
   it('renders error state when fetch fails and there is no data', () => {
-    vi.mocked(useKeycloakStatus).mockReturnValue({
-      data: INITIAL_DATA,
-      loading: false,
-      isRefreshing: false,
-      error: true,
-      consecutiveFailures: 3,
-      showSkeleton: false,
-      showEmptyState: true,
-    })
+    vi.mocked(useKeycloakStatus).mockReturnValue(
+      makeHookResult({
+        isFailed: true,
+        consecutiveFailures: 3,
+        showEmptyState: true,
+      }),
+    )
     render(<KeycloakStatus />)
     expect(screen.getByText('keycloak.fetchError')).toBeTruthy()
   })
 
   it('renders live data with health badge and realm list', () => {
-    vi.mocked(useKeycloakStatus).mockReturnValue({
-      data: KEYCLOAK_DEMO_DATA,
-      loading: false,
-      isRefreshing: false,
-      error: false,
-      consecutiveFailures: 0,
-      showSkeleton: false,
-      showEmptyState: false,
-    })
+    vi.mocked(useKeycloakStatus).mockReturnValue(
+      makeHookResult({ data: KEYCLOAK_DEMO_DATA }),
+    )
     render(<KeycloakStatus />)
     // Health badge — "degraded" also appears on the staging realm row, so use getAllByText
     expect(screen.getAllByText('keycloak.degraded').length).toBeGreaterThanOrEqual(1)
@@ -157,15 +153,9 @@ describe('KeycloakStatus', () => {
   })
 
   it('renders without crashing', () => {
-    vi.mocked(useKeycloakStatus).mockReturnValue({
-      data: KEYCLOAK_DEMO_DATA,
-      loading: false,
-      isRefreshing: false,
-      error: false,
-      consecutiveFailures: 0,
-      showSkeleton: false,
-      showEmptyState: false,
-    })
+    vi.mocked(useKeycloakStatus).mockReturnValue(
+      makeHookResult({ data: KEYCLOAK_DEMO_DATA }),
+    )
     const { container } = render(<KeycloakStatus />)
     expect(container).toBeTruthy()
   })

--- a/web/src/components/cards/keycloak_status/demoData.ts
+++ b/web/src/components/cards/keycloak_status/demoData.ts
@@ -21,6 +21,8 @@ export type KeycloakRealmStatus = 'ready' | 'provisioning' | 'degraded' | 'error
 export interface KeycloakRealm {
   name: string
   namespace: string
+  /** Cluster the Keycloak instance runs on. Empty string when unknown. */
+  cluster: string
   status: KeycloakRealmStatus
   /** Whether the realm is enabled for login */
   enabled: boolean
@@ -54,6 +56,7 @@ export const KEYCLOAK_DEMO_DATA: KeycloakDemoData = {
       // The built-in admin realm — always present in every Keycloak installation
       name: 'master',
       namespace: 'keycloak',
+      cluster: 'prod-cluster',
       status: 'ready',
       enabled: true,
       clients: 12,
@@ -64,6 +67,7 @@ export const KEYCLOAK_DEMO_DATA: KeycloakDemoData = {
       // Primary production SSO realm serving the platform's end users
       name: 'platform',
       namespace: 'keycloak',
+      cluster: 'prod-cluster',
       status: 'ready',
       enabled: true,
       clients: 24,
@@ -74,6 +78,7 @@ export const KEYCLOAK_DEMO_DATA: KeycloakDemoData = {
       // Staging realm — degraded due to misconfigured identity provider
       name: 'staging',
       namespace: 'keycloak-staging',
+      cluster: 'staging-cluster',
       status: 'degraded',
       enabled: true,
       clients: 8,
@@ -84,6 +89,7 @@ export const KEYCLOAK_DEMO_DATA: KeycloakDemoData = {
       // New dev realm currently being provisioned; login disabled until ready
       name: 'dev-sandbox',
       namespace: 'keycloak-dev',
+      cluster: 'dev-cluster',
       status: 'provisioning',
       enabled: false,
       clients: 3,
@@ -94,6 +100,7 @@ export const KEYCLOAK_DEMO_DATA: KeycloakDemoData = {
       // Legacy SSO realm in error state — database backend unreachable
       name: 'legacy-sso',
       namespace: 'keycloak',
+      cluster: 'prod-cluster',
       status: 'error',
       enabled: true,
       clients: 5,

--- a/web/src/components/cards/keycloak_status/useKeycloakStatus.ts
+++ b/web/src/components/cards/keycloak_status/useKeycloakStatus.ts
@@ -28,6 +28,7 @@ interface BackendPodInfo {
   status?: string
   ready?: string
   labels?: Record<string, string>
+  cluster?: string
 }
 
 interface CRItem {
@@ -120,6 +121,7 @@ export function parseKeycloakInstance(item: CRItem): KeycloakRealm {
   return {
     name: item.name,
     namespace: item.namespace ?? '',
+    cluster: item.cluster ?? '',
     status: realmStatus,
     enabled: true,
     clients: 0,
@@ -133,7 +135,7 @@ export function parseKeycloakInstance(item: CRItem): KeycloakRealm {
 // ---------------------------------------------------------------------------
 
 async function fetchPods(url: string): Promise<BackendPodInfo[]> {
-  const resp = await fetch(url, {
+  const resp = await authFetch(url, {
     headers: { Accept: 'application/json' },
     signal: AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS),
   })
@@ -197,12 +199,28 @@ async function fetchKeycloakStatus(): Promise<KeycloakStatus> {
 // Hook
 // ---------------------------------------------------------------------------
 
+/**
+ * Hook return contract for the Keycloak status card.
+ *
+ * Follows the canonical "Caching Contract" shape documented in CLAUDE.md:
+ * `{ data, isLoading, isRefreshing, isDemoData, isFailed,
+ *    consecutiveFailures, lastRefresh, refetch }`.
+ *
+ * `showSkeleton` and `showEmptyState` are card-local helpers derived from
+ * `useCardLoadingState` — retained so the component doesn't have to
+ * re-compute them — but they are additive to, not replacements for, the
+ * canonical contract above.
+ */
 export interface UseKeycloakStatusResult {
   data: KeycloakStatus
-  loading: boolean
+  isLoading: boolean
   isRefreshing: boolean
-  error: boolean
+  isDemoData: boolean
+  isFailed: boolean
   consecutiveFailures: number
+  lastRefresh: number | null
+  refetch: () => Promise<void>
+  // card-local helpers (derived from useCardLoadingState)
   showSkeleton: boolean
   showEmptyState: boolean
 }
@@ -215,6 +233,8 @@ export function useKeycloakStatus(): UseKeycloakStatusResult {
     isFailed,
     consecutiveFailures,
     isDemoFallback,
+    lastRefresh,
+    refetch,
   } = useCache<KeycloakStatus>({
     key: CACHE_KEY,
     category: 'default',
@@ -241,14 +261,18 @@ export function useKeycloakStatus(): UseKeycloakStatusResult {
     isFailed,
     consecutiveFailures,
     isDemoData: effectiveIsDemoData,
+    lastRefresh,
   })
 
   return {
     data,
-    loading: isLoading,
+    isLoading,
     isRefreshing,
-    error: isFailed && !hasAnyData,
+    isDemoData: effectiveIsDemoData,
+    isFailed: isFailed && !hasAnyData,
     consecutiveFailures,
+    lastRefresh,
+    refetch,
     showSkeleton,
     showEmptyState,
   }

--- a/web/src/locales/en/cards.json
+++ b/web/src/locales/en/cards.json
@@ -3542,6 +3542,8 @@
     "syncedHoursAgo": "{{count}}h ago",
     "syncedDaysAgo": "{{count}}d ago",
     "provisioning": "Provisioning",
-    "error": "Error"
+    "error": "Error",
+    "sortByStatus": "Status",
+    "sortByName": "Name"
   }
 }


### PR DESCRIPTION
## Summary
Post-merge audit of #6893 found two tech-debt gaps in the Keycloak card. Fixes both in one PR since they touch the same two files.

**Fixes #8219** — Adds `Pagination`, `CardControls`, and cluster filter wiring:
- Replaces the ad-hoc single-search UI with the canonical `CardControlsRow` + `CardPaginationFooter` pair used by ~41 other cards.
- Changes `defaultLimit: 'unlimited'` to `REALMS_PER_PAGE = 10` (named constant).
- Renders `<CardControls>` next to `<CardSearchInput>` so users can reach the existing `status`/`name` sort comparators.
- Wires `CardClusterFilter` through `useCardData` so realms can be filtered per cluster.
- `KeycloakRealm` now carries a `cluster` field sourced from the Keycloak CR, and the demo dataset spreads realms across three demo clusters so the filter has something to show.

**Fixes #8220** — Aligns `useKeycloakStatus` return shape with the CLAUDE.md Caching Contract:
- Renames `loading` → `isLoading`, `error` → `isFailed`.
- Exposes `isDemoData`, `refetch`, `lastRefresh` from the underlying `useCache`.
- Keeps `showSkeleton` / `showEmptyState` as additive card-local helpers.
- Tests updated to use a factory for the canonical return shape so future contract additions only require touching one helper.

Also switches the pods fetcher to `authFetch` for consistency with the CR fetcher (both paths now authenticate the same way).

## Test plan
- [x] `npm run build` passes
- [x] `npm run lint` clean on changed files (pre-existing lint debt elsewhere unchanged)
- [x] `vitest run src/components/cards/keycloak_status/` — 26 tests pass
- [ ] Visual check: Keycloak card renders with pagination + sort controls; cluster filter hides other-cluster realms