### PR TITLE
🐛 fix: start.sh falsely reports failure when OAuth is configured (#8228)

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -393,21 +393,29 @@ echo ""
 echo "Waiting for console to start..."
 MAX_WAIT=60
 WAITED=0
+CONSOLE_READY=0
 while [ $WAITED -lt $MAX_WAIT ]; do
-    # Poll the root path — returns 200 only when Fiber is fully started and
-    # serving the SPA frontend (web/dist/index.html). The warmup phase may
-    # start a temporary listener that returns 404 for / before Fiber is ready.
+    # Any response that proves Fiber is up and routing is sufficient:
+    # - 200 from dev mode SPA (web/dist/index.html)
+    # - 301/302 → /login when OAuth is enabled
+    # - 401/403 if middleware rejects without redirect
+    # Note: 404 is NOT accepted — the warmup phase may start a temporary
+    # listener that returns 404 for / before Fiber is fully ready.
+    # 000 (connection refused/error) or 5xx also mean not ready.
     HTTP_CODE=$(curl -s -o /dev/null -w '%{http_code}' "http://localhost:${PORT}/" 2>/dev/null || echo "000")
-    if [ "$HTTP_CODE" = "200" ]; then
-        break
-    fi
+    case "$HTTP_CODE" in
+        200|301|302|401|403)
+            CONSOLE_READY=1
+            break
+            ;;
+    esac
     sleep 2
     WAITED=$((WAITED + 2))
     printf "  %ds..." "$WAITED"
 done
 echo ""
 
-if [ "$HTTP_CODE" = "200" ]; then
+if [ "$CONSOLE_READY" = "1" ]; then
     echo ""
     echo "=== KubeStellar Console is running ==="
     echo ""


### PR DESCRIPTION
## Summary

Fixes #8228
Refs #8202

`start.sh` strictly checked for `HTTP 200` from `http://localhost:${PORT}/` as its "console ready" signal. When OAuth is configured, the Fiber server returns `302 → /login` for the root path, so the readiness loop never matches and the script prints:

> Warning: Console did not respond within 60s

…even though the console is actually running correctly. This is the likely root cause of #8202 (rishi-jat).

## Fix

Accept any response that proves Fiber is up and routing as "ready":

- `200` — dev mode SPA
- `301` / `302` — OAuth redirect to `/login`
- `401` / `403` — middleware rejects without redirect

`404` is intentionally **not** accepted — the warmup phase may start a temporary listener that returns 404 for `/` before Fiber is fully ready, and that existing behavior is preserved (see the original comment at the poll site).

Introduced an explicit `CONSOLE_READY` flag and switched the post-loop success check from `HTTP_CODE = 200` to `CONSOLE_READY = 1` so the success/warning branches reflect the new semantics.

Scope intentionally kept tight — other start.sh issues (chmod exit-code swallow, grep pattern) are left for follow-up PRs.

## Test plan

- [x] `bash -n start.sh` passes
- [ ] Manual: run `./start.sh` with OAuth configured → console ready banner instead of 60s warning
- [ ] Manual: run `./start.sh` without OAuth → still shows ready banner (200 path)