### PR TITLE
🐛 fix(drasi): widen Consume stream drawer so code snippets have room

### DIFF
--- a/web/src/components/cards/drasi/DrasiReactiveGraph.tsx
+++ b/web/src/components/cards/drasi/DrasiReactiveGraph.tsx
@@ -1766,7 +1766,10 @@ function StreamSampleDrawer({ endpoint, isDemo, onClose }: StreamSampleDrawerPro
 
   return (
     <motion.div
-      className="absolute top-0 right-0 bottom-0 z-40 w-[480px] bg-slate-950 border-l border-slate-700 shadow-2xl flex flex-col"
+      // Drawer capped at min(75% of card, 720px) so code snippets get
+      // breathing room without wall-to-walling the whole card on wide
+      // viewports. Was a flat 480px — too cramped for Go / C# samples.
+      className="absolute top-0 right-0 bottom-0 z-40 w-[min(75%,720px)] min-w-[520px] bg-slate-950 border-l border-slate-700 shadow-2xl flex flex-col"
       initial={{ x: '100%' }}
       animate={{ x: 0 }}
       exit={{ x: '100%' }}


### PR DESCRIPTION
## Summary

"Consume stream" drawer was a flat \`w-[480px]\` (a leftover from Wave B's row-detail drawer) which made the Go and C#/.NET snippets wrap awkwardly and squeezed the language tab strip. Bump to \`w-[min(75%,720px)] min-w-[520px]\` so it:

- scales with the viewport up to 720px on wide cards
- never drops below 520px (comfortable floor for the narrowest snippet)
- caps at 75% of the card width so the graph behind it stays partially visible

Single className change on the \`StreamSampleDrawer\` motion div.

**Live dashboard:** https://console.kubestellar.io/drasi

Reported by Nandita Valsan (nvalsan@microsoft.com).

## Test plan

- [x] \`npm run build\` — passes
- [ ] Open /drasi → click "Consume stream" → drawer is wider, code snippets don't wrap mid-line
- [ ] On a narrow card, drawer still at 520px min
- [ ] On a wide card, capped at 720px

🤖 Generated with [Claude Code](https://claude.com/claude-code)