### PR TITLE
✨ feat(ux): shared Tooltip primitive + apply to top-level nav (#8192)

### DIFF
--- a/web/src/components/layout/Sidebar.tsx
+++ b/web/src/components/layout/Sidebar.tsx
@@ -4,6 +4,7 @@ import { NavLink, useNavigate, useLocation } from 'react-router-dom'
 import { Plus, ChevronLeft, ChevronRight, CheckCircle2, AlertTriangle, WifiOff, GripVertical, X, User, Pin, PinOff, Satellite } from 'lucide-react'
 import { iconRegistry } from '../../lib/icons'
 import { cn } from '../../lib/cn'
+import { Tooltip } from '../ui/Tooltip'
 import { SnoozedCards } from './SnoozedCards'
 import { useSidebarConfig, SidebarItem, PROTECTED_SIDEBAR_IDS, SIDEBAR_COLLAPSED_WIDTH_PX, SIDEBAR_DEFAULT_WIDTH_PX } from '../../hooks/useSidebarConfig'
 import { useMobile } from '../../hooks/useMobile'
@@ -322,10 +323,22 @@ export function Sidebar() {
 
   const renderNavItem = (item: SidebarItem, section: 'primary' | 'secondary') => {
     const isEditing = editingItemId === item.id
+    // Only show the shared Tooltip in collapsed mode — when expanded, the
+    // full item label is already visible, so the tooltip would be redundant.
+    const showTooltip = isCollapsed && !isEditing
+    const tooltipContent = showTooltip
+      ? `${item.name} — ${t('help.sidebarNavItem')}`
+      : ''
 
     return (
-      <div
+      <Tooltip
         key={item.id}
+        content={tooltipContent}
+        side="right"
+        disabled={!showTooltip}
+        wrapperClassName="block w-full"
+      >
+      <div
         draggable={!isCollapsed && !isEditing}
         onDragStart={(e) => handleDragStart(e, item.id, section)}
         onDragEnd={handleDragEnd}
@@ -334,7 +347,7 @@ export function Sidebar() {
         onDragOver={handleDragOver}
         onDrop={(e) => handleDrop(e, item.id, section)}
         className={cn(
-          'group relative transition-all duration-150',
+          'group relative transition-all duration-150 w-full',
           dragOverItem === item.id && dragSection === section && 'before:absolute before:inset-x-0 before:-top-0.5 before:h-0.5 before:bg-purple-500 before:rounded-full',
           draggedItem === item.id && 'opacity-50'
         )}
@@ -425,6 +438,7 @@ export function Sidebar() {
           </NavLink>
         )}
       </div>
+      </Tooltip>
     )
   }
 

--- a/web/src/components/layout/navbar/ClusterFilterPanel.tsx
+++ b/web/src/components/layout/navbar/ClusterFilterPanel.tsx
@@ -5,6 +5,7 @@ import { AlertCircle, CheckCircle2 } from 'lucide-react'
 import { useGlobalFilters, SEVERITY_LEVELS, SEVERITY_CONFIG, STATUS_LEVELS, STATUS_CONFIG } from '../../../hooks/useGlobalFilters'
 import { useModalState } from '../../../lib/modals'
 import { cn } from '../../../lib/cn'
+import { Tooltip } from '../../ui/Tooltip'
 
 /** Color palette for saved filter sets */
 const FILTER_SET_COLORS = ['#8B5CF6', '#3B82F6', '#10B981', '#F59E0B', '#EF4444', '#EC4899']
@@ -165,25 +166,27 @@ export function ClusterFilterPanel() {
       {/* Filter icon button — isolate creates a stacking context to prevent
            the glow shadow from bleeding into adjacent header controls (#4380) */}
       <div className="relative isolate" ref={dropdownRef}>
-        <button
-          onClick={() => toggleDropdown()}
-          className={cn(
-            'relative flex items-center justify-center w-9 h-9 rounded-lg transition-colors',
-            isFiltered
-              ? 'bg-purple-500/20 text-purple-400 shadow-[0_0_6px_rgba(139,92,246,0.2)]'
-              : 'bg-secondary/50 text-muted-foreground hover:text-foreground'
-          )}
-          title={isFiltered ? t('layout.navbar.filtersActive') : t('layout.navbar.noFilters')}
-        >
-          <Filter className="w-4 h-4" />
-          {/* Color dot from active filter set, or generic purple dot */}
-          {isFiltered && (
-            <span
-              className="absolute -top-0.5 -right-0.5 w-2.5 h-2.5 rounded-full border border-card"
-              style={{ backgroundColor: activeSet?.color || '#a78bfa' }}
-            />
-          )}
-        </button>
+        <Tooltip content={t('help.globalClusterFilter')} side="bottom">
+          <button
+            onClick={() => toggleDropdown()}
+            className={cn(
+              'relative flex items-center justify-center w-9 h-9 rounded-lg transition-colors',
+              isFiltered
+                ? 'bg-purple-500/20 text-purple-400 shadow-[0_0_6px_rgba(139,92,246,0.2)]'
+                : 'bg-secondary/50 text-muted-foreground hover:text-foreground'
+            )}
+            aria-label={isFiltered ? t('layout.navbar.filtersActive') : t('layout.navbar.noFilters')}
+          >
+            <Filter className="w-4 h-4" />
+            {/* Color dot from active filter set, or generic purple dot */}
+            {isFiltered && (
+              <span
+                className="absolute -top-0.5 -right-0.5 w-2.5 h-2.5 rounded-full border border-card"
+                style={{ backgroundColor: activeSet?.color || '#a78bfa' }}
+              />
+            )}
+          </button>
+        </Tooltip>
 
         {/* Filter dropdown */}
         {showDropdown && (

--- a/web/src/components/layout/navbar/Navbar.tsx
+++ b/web/src/components/layout/navbar/Navbar.tsx
@@ -9,6 +9,7 @@ import { useMobile } from '../../../hooks/useMobile'
 import { useBranding } from '../../../hooks/useBranding'
 import { LearnDropdown } from './LearnDropdown'
 import { LogoWithStar } from '../../ui/LogoWithStar'
+import { Tooltip } from '../../ui/Tooltip'
 import { UserProfileDropdown } from '../UserProfileDropdown'
 import { AlertBadge } from '../../ui/AlertBadge'
 import { FeatureRequestButton } from '../../feedback'
@@ -97,16 +98,17 @@ export function Navbar({ topOffset = 0 }: NavbarProps) {
             DEV
           </span>
         )}
-        <a
-          href={branding.docsUrl}
-          target="_blank"
-          rel="noopener noreferrer"
-          className="hidden lg:flex items-center p-1.5 hover:bg-secondary rounded-md transition-colors"
-          aria-label={t('navbar.viewDocs')}
-          title={t('navbar.viewDocs')}
-        >
-          <ExternalLink className="w-3.5 h-3.5 text-muted-foreground" />
-        </a>
+        <Tooltip content={t('help.viewDocs')} side="bottom">
+          <a
+            href={branding.docsUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="hidden lg:flex items-center p-1.5 hover:bg-secondary rounded-md transition-colors"
+            aria-label={t('navbar.viewDocs')}
+          >
+            <ExternalLink className="w-3.5 h-3.5 text-muted-foreground" />
+          </a>
+        </Tooltip>
       </div>
 
       {/* Search - hidden on small mobile; min-w-0 prevents layout overflow
@@ -137,20 +139,21 @@ export function Navbar({ topOffset = 0 }: NavbarProps) {
 
           {/* AI Missions — opens the mission sidebar */}
           {!isSidebarOpen && (
-            <button
-              onClick={openSidebar}
-              className="relative flex items-center gap-1.5 px-3 py-1.5 h-9 text-sm font-medium rounded-lg transition-colors bg-purple-500/10 hover:bg-purple-500/20 text-purple-400 border border-purple-500/20"
-              aria-label={t('missionSidebar.openAIMissions')}
-              title={t('missionSidebar.openAIMissions')}
-            >
-              <Sparkles className="w-4 h-4" />
-              <span>{t('missionSidebar.aiMissions')}</span>
-              {missionsNeedingAttention > 0 && (
-                <span className="absolute -top-1.5 -right-1.5 flex items-center justify-center w-5 h-5 text-[10px] font-bold bg-purple-500 text-white rounded-full animate-pulse">
-                  {missionsNeedingAttention}
-                </span>
-              )}
-            </button>
+            <Tooltip content={t('help.aiMissions')} side="bottom">
+              <button
+                onClick={openSidebar}
+                className="relative flex items-center gap-1.5 px-3 py-1.5 h-9 text-sm font-medium rounded-lg transition-colors bg-purple-500/10 hover:bg-purple-500/20 text-purple-400 border border-purple-500/20"
+                aria-label={t('missionSidebar.openAIMissions')}
+              >
+                <Sparkles className="w-4 h-4" />
+                <span>{t('missionSidebar.aiMissions')}</span>
+                {missionsNeedingAttention > 0 && (
+                  <span className="absolute -top-1.5 -right-1.5 flex items-center justify-center w-5 h-5 text-[10px] font-bold bg-purple-500 text-white rounded-full animate-pulse">
+                    {missionsNeedingAttention}
+                  </span>
+                )}
+              </button>
+            </Tooltip>
           )}
 
           {/* Visit Streak */}
@@ -170,19 +173,21 @@ export function Navbar({ topOffset = 0 }: NavbarProps) {
           <LearnDropdown />
 
           {/* Theme toggle */}
-          <button
-            onClick={toggleTheme}
-            className="p-2 w-9 h-9 flex items-center justify-center shrink-0 hover:bg-secondary rounded-lg transition-colors"
-            title={t('navbar.themeToggle', { theme })}
-          >
-            {theme === 'dark' ? (
-              <Moon className="w-5 h-5 text-muted-foreground" />
-            ) : theme === 'light' ? (
-              <Sun className="w-5 h-5 text-amber-600 dark:text-yellow-400" />
-            ) : (
-              <Monitor className="w-5 h-5 text-muted-foreground" />
-            )}
-          </button>
+          <Tooltip content={t('help.themeToggle')} side="bottom">
+            <button
+              onClick={toggleTheme}
+              className="p-2 w-9 h-9 flex items-center justify-center shrink-0 hover:bg-secondary rounded-lg transition-colors"
+              aria-label={t('navbar.themeToggle', { theme })}
+            >
+              {theme === 'dark' ? (
+                <Moon className="w-5 h-5 text-muted-foreground" />
+              ) : theme === 'light' ? (
+                <Sun className="w-5 h-5 text-amber-600 dark:text-yellow-400" />
+              ) : (
+                <Monitor className="w-5 h-5 text-muted-foreground" />
+              )}
+            </button>
+          </Tooltip>
 
           {/* Alerts */}
           <AlertBadge />

--- a/web/src/components/ui/Tooltip.tsx
+++ b/web/src/components/ui/Tooltip.tsx
@@ -1,0 +1,112 @@
+/**
+ * Tooltip — shared hover tooltip primitive.
+ *
+ * CSS-only hover/focus implementation using Tailwind group utilities so
+ * tooltips work without JS state or portal wiring. The child element
+ * receives an `aria-describedby` pointing at the floating bubble so screen
+ * readers announce the help text.
+ *
+ * Motion is handled via a Tailwind `transition-opacity` that respects the
+ * global `.reduce-motion` class defined in `index.css` (which zeroes all
+ * transition durations for users who prefer reduced motion).
+ *
+ * Usage:
+ *   <Tooltip content={t('help.sidebarMissions')}>
+ *     <SomeIconButton />
+ *   </Tooltip>
+ */
+
+import { type ReactNode, useId } from 'react'
+import { cn } from '../../lib/cn'
+
+// ── Named constants ─────────────────────────────────────────────────────────
+
+/**
+ * Tailwind class for the opacity fade duration on hover. Exported as a named
+ * constant so the magic "150ms" is documented and reused consistently. The
+ * global `.reduce-motion` rule in `index.css` zeroes out transitions, so this
+ * automatically respects `prefers-reduced-motion`.
+ */
+const TOOLTIP_FADE_DURATION_CLASS = 'duration-150'
+
+/**
+ * Side positioning classes. Keyed by the `side` prop — each entry places
+ * the tooltip bubble relative to the wrapping `<span>` trigger.
+ */
+const SIDE_POSITION_MAP = {
+  top: 'bottom-full left-1/2 -translate-x-1/2 mb-1',
+  bottom: 'top-full left-1/2 -translate-x-1/2 mt-1',
+  left: 'right-full top-1/2 -translate-y-1/2 mr-1',
+  right: 'left-full top-1/2 -translate-y-1/2 ml-1',
+} as const
+
+type TooltipSide = keyof typeof SIDE_POSITION_MAP
+
+interface TooltipProps {
+  /** Content to show inside the tooltip bubble (usually a translated string). */
+  content: ReactNode
+  /** Trigger element the user hovers/focuses. */
+  children: ReactNode
+  /** Which side of the trigger to render the bubble on. Defaults to `top`. */
+  side?: TooltipSide
+  /** Extra classes to merge onto the bubble. */
+  className?: string
+  /**
+   * Extra classes to merge onto the outer wrapper `<span>`. Useful for
+   * callers that need the trigger span to stretch to its parent (e.g.
+   * full-width sidebar rows — pass `block w-full`).
+   */
+  wrapperClassName?: string
+  /** If true, renders children unchanged with no wrapper or bubble. */
+  disabled?: boolean
+}
+
+/**
+ * Render a shared Tooltip with accessible wiring.
+ *
+ * When `disabled` is true or `content` is empty we short-circuit and return
+ * `children` directly — this keeps the DOM flat and avoids unnecessary
+ * wrappers when a caller conditionally opts out (e.g. on small screens).
+ */
+export function Tooltip({
+  content,
+  children,
+  side = 'top',
+  className,
+  wrapperClassName,
+  disabled,
+}: TooltipProps) {
+  const tooltipId = useId()
+
+  if (disabled || content == null || content === '') {
+    return <>{children}</>
+  }
+
+  return (
+    <span
+      className={cn('group relative inline-flex', wrapperClassName)}
+      aria-describedby={tooltipId}
+    >
+      {children}
+      <span
+        id={tooltipId}
+        role="tooltip"
+        className={cn(
+          'absolute z-dropdown',
+          SIDE_POSITION_MAP[side],
+          'pointer-events-none opacity-0 group-hover:opacity-100 group-focus-within:opacity-100',
+          'transition-opacity',
+          TOOLTIP_FADE_DURATION_CLASS,
+          'bg-card text-card-foreground border border-border shadow-lg',
+          'rounded-md px-2 py-1 text-xs whitespace-nowrap',
+          className,
+        )}
+      >
+        {content}
+      </span>
+    </span>
+  )
+}
+
+export default Tooltip
+export type { TooltipProps, TooltipSide }

--- a/web/src/components/ui/__tests__/Tooltip.test.tsx
+++ b/web/src/components/ui/__tests__/Tooltip.test.tsx
@@ -1,0 +1,76 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { Tooltip } from '../Tooltip'
+
+describe('Tooltip', () => {
+  it('renders children', () => {
+    render(
+      <Tooltip content="Helpful text">
+        <button>Trigger</button>
+      </Tooltip>,
+    )
+    expect(screen.getByRole('button', { name: 'Trigger' })).toBeTruthy()
+  })
+
+  it('applies aria-describedby on the wrapper and matches the tooltip id', () => {
+    render(
+      <Tooltip content="Helpful text">
+        <button>Trigger</button>
+      </Tooltip>,
+    )
+    // The wrapper <span> carries aria-describedby pointing at the tooltip bubble.
+    const trigger = screen.getByRole('button', { name: 'Trigger' })
+    const wrapper = trigger.parentElement as HTMLElement
+    const describedBy = wrapper.getAttribute('aria-describedby')
+    expect(describedBy).toBeTruthy()
+
+    const tooltipBubble = screen.getByRole('tooltip')
+    expect(tooltipBubble.id).toBe(describedBy)
+    expect(tooltipBubble.textContent).toBe('Helpful text')
+  })
+
+  it('skips the wrapper when disabled=true', () => {
+    render(
+      <Tooltip content="Helpful text" disabled>
+        <button>Trigger</button>
+      </Tooltip>,
+    )
+    // No tooltip bubble should be rendered.
+    expect(screen.queryByRole('tooltip')).toBeNull()
+    // The button should be present without an aria-describedby wrapper.
+    const trigger = screen.getByRole('button', { name: 'Trigger' })
+    const parent = trigger.parentElement as HTMLElement
+    // Either no wrapper, or the wrapper lacks aria-describedby (not added by Tooltip).
+    expect(parent?.getAttribute('aria-describedby')).toBeNull()
+  })
+
+  it('skips the wrapper when content is empty', () => {
+    render(
+      <Tooltip content="">
+        <button>Trigger</button>
+      </Tooltip>,
+    )
+    expect(screen.queryByRole('tooltip')).toBeNull()
+  })
+
+  it('renders on all four sides with the correct position classes', () => {
+    const sides = ['top', 'bottom', 'left', 'right'] as const
+    const expected: Record<(typeof sides)[number], string> = {
+      top: 'bottom-full',
+      bottom: 'top-full',
+      left: 'right-full',
+      right: 'left-full',
+    }
+
+    for (const side of sides) {
+      const { unmount } = render(
+        <Tooltip content={`on ${side}`} side={side}>
+          <button>{`btn-${side}`}</button>
+        </Tooltip>,
+      )
+      const bubble = screen.getByRole('tooltip')
+      expect(bubble.className).toContain(expected[side])
+      unmount()
+    }
+  })
+})

--- a/web/src/locales/en/common.json
+++ b/web/src/locales/en/common.json
@@ -1,4 +1,11 @@
 {
+  "help": {
+    "sidebarNavItem": "Click to navigate. Hover a collapsed icon to see its name and what it opens.",
+    "themeToggle": "Switch between dark, light, and system themes. Your choice is saved across sessions.",
+    "aiMissions": "AI Missions are assistant-driven tasks that monitor your clusters and propose fixes.",
+    "viewDocs": "Open the KubeStellar docs site in a new tab for guides, tutorials, and reference.",
+    "globalClusterFilter": "Filter every card on this dashboard to a subset of your clusters, severities, or statuses."
+  },
   "navigation": {
     "dashboard": "Dashboard",
     "clusters": "My Clusters",


### PR DESCRIPTION
Fixes #8192

## Summary

New users landing on the console hit terminology (clusters, workloads, cards, missions) and icon-only controls with no inline explanation. This PR introduces a reusable `Tooltip` primitive and wires it into five high-traffic, icon/terminology-heavy spots that are visible on first load.

## What's in this PR

### 1. New `Tooltip` primitive — `web/src/components/ui/Tooltip.tsx`
- CSS-only hover/focus trigger using Tailwind `group` + `group-hover` (no JS state, no portal).
- Accessible: `role="tooltip"`, `aria-describedby` wired via `useId()`.
- `side` prop with `top | bottom | left | right` positioning.
- `disabled` / empty-content short-circuit renders children unchanged.
- Respects `prefers-reduced-motion` via the existing global `.reduce-motion` rule in `index.css`.
- No magic numbers — fade duration is a named constant; z-index uses the `z-dropdown` semantic token.
- Styled with existing design tokens (`bg-card`, `text-card-foreground`, `border-border`) — no raw hex values.

### 2. Unit tests — `web/src/components/ui/__tests__/Tooltip.test.tsx`
Five test cases:
1. Renders children
2. Applies `aria-describedby` matching the tooltip bubble `id`
3. Skips the wrapper when `disabled=true`
4. Skips the wrapper when content is empty
5. Renders on all four sides with the correct position classes

### 3. Five applied locations (high-impact, visible on first load)
| # | Location | File |
|---|----------|------|
| 1 | Sidebar nav items (collapsed mode) | `components/layout/Sidebar.tsx` |
| 2 | Navbar docs external-link button | `components/layout/navbar/Navbar.tsx` |
| 3 | Navbar AI Missions button | `components/layout/navbar/Navbar.tsx` |
| 4 | Navbar theme toggle | `components/layout/navbar/Navbar.tsx` |
| 5 | Global cluster filter icon | `components/layout/navbar/ClusterFilterPanel.tsx` |

### 4. New i18n keys — `web/src/locales/en/common.json`
Added a new top-level `help` namespace with five keys:
- `help.sidebarNavItem`
- `help.themeToggle`
- `help.aiMissions`
- `help.viewDocs`
- `help.globalClusterFilter`

All new user-facing text goes through `t()` — no raw strings.

## Scope notes
- This is a **landing PR**. The 329 existing `title="..."` attributes across the codebase are intentionally **not** replaced — that's follow-up work.
- Card internals are untouched.
- Form inputs and modal content are untouched.

## Test plan
- [x] `npm run build` passes
- [x] `npm run lint` — no new errors on touched files (pre-existing error in `Navbar.tsx:57` is unrelated)
- [x] `npx vitest run src/components/ui/__tests__/Tooltip.test.tsx` — 5/5 pass
- [x] `npx vitest run src/test/ui-ux-standards.test.ts` — passes (no new design-token violations)
- [x] `npx vitest run src/test/no-magic-numbers.test.ts` — passes
- [x] `npx vitest run src/test/card-loading-standard.test.ts` — passes