### PR TITLE
🐛 fix(ui): Tooltip a11y + wrapping + HTML nesting follow-up (#8237)

### DIFF
--- a/web/src/components/ui/Tooltip.tsx
+++ b/web/src/components/ui/Tooltip.tsx
@@ -2,21 +2,26 @@
  * Tooltip — shared hover tooltip primitive.
  *
  * CSS-only hover/focus implementation using Tailwind group utilities so
- * tooltips work without JS state or portal wiring. The child element
- * receives an `aria-describedby` pointing at the floating bubble so screen
- * readers announce the help text.
+ * tooltips work without JS state or portal wiring. When `children` is a
+ * valid React element, the child is cloned and receives an
+ * `aria-describedby` attribute pointing at the floating bubble so screen
+ * readers announce the help text when the focusable trigger is focused.
+ * If the child is not a valid element (string, fragment, array), we fall
+ * back to rendering the bubble without wiring `aria-describedby` — in that
+ * case screen-reader description is not guaranteed, but visual hover still
+ * works. Callers should prefer a single focusable child element.
  *
  * Motion is handled via a Tailwind `transition-opacity` that respects the
  * global `.reduce-motion` class defined in `index.css` (which zeroes all
  * transition durations for users who prefer reduced motion).
  *
  * Usage:
- *   <Tooltip content={t('help.sidebarMissions')}>
+ *   <Tooltip content={t('help.aiMissions')}>
  *     <SomeIconButton />
  *   </Tooltip>
  */
 
-import { type ReactNode, useId } from 'react'
+import React, { type ReactNode, useId } from 'react'
 import { cn } from '../../lib/cn'
 
 // ── Named constants ─────────────────────────────────────────────────────────
@@ -30,8 +35,16 @@ import { cn } from '../../lib/cn'
 const TOOLTIP_FADE_DURATION_CLASS = 'duration-150'
 
 /**
+ * Tailwind class for the maximum width of the tooltip bubble. Using
+ * `max-w-xs` (20rem) as a semantic design token keeps long help strings
+ * from overflowing the viewport while allowing the bubble to wrap onto
+ * multiple lines via `whitespace-normal`.
+ */
+const TOOLTIP_MAX_WIDTH_CLASS = 'max-w-xs'
+
+/**
  * Side positioning classes. Keyed by the `side` prop — each entry places
- * the tooltip bubble relative to the wrapping `<span>` trigger.
+ * the tooltip bubble relative to the wrapping trigger container.
  */
 const SIDE_POSITION_MAP = {
   top: 'bottom-full left-1/2 -translate-x-1/2 mb-1',
@@ -52,9 +65,11 @@ interface TooltipProps {
   /** Extra classes to merge onto the bubble. */
   className?: string
   /**
-   * Extra classes to merge onto the outer wrapper `<span>`. Useful for
-   * callers that need the trigger span to stretch to its parent (e.g.
-   * full-width sidebar rows — pass `block w-full`).
+   * Extra classes to merge onto the outer wrapper `<div>`. The wrapper is a
+   * `<div>` styled `inline-flex` so it can legally contain block-level
+   * children (e.g. full-width sidebar rows that use `<div>` internally).
+   * Useful for callers that need the trigger container to stretch to its
+   * parent — pass `block w-full`.
    */
   wrapperClassName?: string
   /** If true, renders children unchanged with no wrapper or bubble. */
@@ -82,12 +97,28 @@ export function Tooltip({
     return <>{children}</>
   }
 
+  // Clone the child so `aria-describedby` lands on the actual focusable
+  // trigger instead of the wrapper — screen readers only announce the
+  // description when the focused element carries the attribute. If the
+  // child already has an `aria-describedby`, preserve it by space-joining.
+  const childWithAria = React.isValidElement(children)
+    ? React.cloneElement(
+        children as React.ReactElement<{ 'aria-describedby'?: string }>,
+        {
+          'aria-describedby': [
+            (children as React.ReactElement<{ 'aria-describedby'?: string }>)
+              .props['aria-describedby'],
+            tooltipId,
+          ]
+            .filter(Boolean)
+            .join(' '),
+        },
+      )
+    : children
+
   return (
-    <span
-      className={cn('group relative inline-flex', wrapperClassName)}
-      aria-describedby={tooltipId}
-    >
-      {children}
+    <div className={cn('group relative inline-flex', wrapperClassName)}>
+      {childWithAria}
       <span
         id={tooltipId}
         role="tooltip"
@@ -98,13 +129,15 @@ export function Tooltip({
           'transition-opacity',
           TOOLTIP_FADE_DURATION_CLASS,
           'bg-card text-card-foreground border border-border shadow-lg',
-          'rounded-md px-2 py-1 text-xs whitespace-nowrap',
+          'rounded-md px-2 py-1 text-xs text-center',
+          'whitespace-normal',
+          TOOLTIP_MAX_WIDTH_CLASS,
           className,
         )}
       >
         {content}
       </span>
-    </span>
+    </div>
   )
 }
 

--- a/web/src/components/ui/__tests__/Tooltip.test.tsx
+++ b/web/src/components/ui/__tests__/Tooltip.test.tsx
@@ -12,21 +12,48 @@ describe('Tooltip', () => {
     expect(screen.getByRole('button', { name: 'Trigger' })).toBeTruthy()
   })
 
-  it('applies aria-describedby on the wrapper and matches the tooltip id', () => {
+  it('applies aria-describedby to the trigger child, not the wrapper', () => {
     render(
       <Tooltip content="Helpful text">
-        <button>Trigger</button>
+        <button data-testid="trigger">Trigger</button>
       </Tooltip>,
     )
-    // The wrapper <span> carries aria-describedby pointing at the tooltip bubble.
-    const trigger = screen.getByRole('button', { name: 'Trigger' })
-    const wrapper = trigger.parentElement as HTMLElement
-    const describedBy = wrapper.getAttribute('aria-describedby')
-    expect(describedBy).toBeTruthy()
+    // The aria-describedby now lives on the actual focusable child so
+    // screen readers announce the description when the trigger is focused.
+    const trigger = screen.getByTestId('trigger')
+    const bubble = screen.getByRole('tooltip')
+    expect(trigger.getAttribute('aria-describedby')).toBe(bubble.id)
+    expect(bubble.textContent).toBe('Helpful text')
 
-    const tooltipBubble = screen.getByRole('tooltip')
-    expect(tooltipBubble.id).toBe(describedBy)
-    expect(tooltipBubble.textContent).toBe('Helpful text')
+    // Wrapper should NOT carry aria-describedby any more.
+    const wrapper = trigger.parentElement as HTMLElement
+    expect(wrapper.getAttribute('aria-describedby')).toBeNull()
+  })
+
+  it('preserves existing aria-describedby on child by space-joining', () => {
+    render(
+      <Tooltip content="Help">
+        <button data-testid="trigger" aria-describedby="existing-id">
+          Trigger
+        </button>
+      </Tooltip>,
+    )
+    const trigger = screen.getByTestId('trigger')
+    const bubble = screen.getByRole('tooltip')
+    const describedBy = trigger.getAttribute('aria-describedby') ?? ''
+    expect(describedBy).toContain('existing-id')
+    expect(describedBy).toContain(bubble.id)
+  })
+
+  it('allows wrapping for long content', () => {
+    render(
+      <Tooltip content="A long sentence that should wrap across multiple lines and not overflow the viewport">
+        <button>T</button>
+      </Tooltip>,
+    )
+    const bubble = screen.getByRole('tooltip')
+    expect(bubble.className).toMatch(/whitespace-normal/)
+    expect(bubble.className).toMatch(/max-w-/)
   })
 
   it('skips the wrapper when disabled=true', () => {


### PR DESCRIPTION
Fixes #8237

Follow-up on #8235 addressing 6 Copilot review comments on the shared Tooltip primitive (4 distinct bugs).

## Fixes

- **aria-describedby now lands on the focusable trigger, not the wrapper.** Screen readers only announce the description when the focused element carries the attribute, so the previous wrapper-only wiring silently did nothing for keyboard users. We now clone the child with `React.cloneElement` and inject `aria-describedby`, preserving any existing value by space-joining. Non-element children (strings, fragments) pass through without the attribute — documented in JSDoc as a limitation, callers should prefer a single focusable child.
- **Wrapper is now a `<div>` (styled `inline-flex`) instead of `<span>`.** The previous `<span>` wrapper was invalid HTML when wrapping block-level children (e.g. the `<div>` used in `Sidebar.tsx:343`). A `<div>` with `inline-flex` is valid around anything and still behaves inline.
- **Bubble now wraps long content.** `whitespace-nowrap` is replaced with `whitespace-normal` + `max-w-xs` (new named constant `TOOLTIP_MAX_WIDTH_CLASS`) so multi-sentence help strings wrap instead of overflowing the viewport. Text is centered via `text-center`.
- **JSDoc usage example** updated from the nonexistent `help.sidebarMissions` key to the real `help.aiMissions` key added in #8235.

## Tests

Updated `web/src/components/ui/__tests__/Tooltip.test.tsx`:
- Existing "aria-describedby on wrapper" test rewritten to assert the attribute lands on the trigger child and NOT on the wrapper.
- New test: `preserves existing aria-describedby on child by space-joining`.
- New test: `allows wrapping for long content` (asserts `whitespace-normal` + `max-w-` on the bubble).

All 7 Tooltip tests pass. `npm run build` passes. `npm run lint` clean on touched files.

## Notes

No call-site changes required — the 5 call-sites from #8235 all wrap real focusable elements (buttons, links) or block containers, both handled correctly by the new design.