### PR TITLE
🐛 fix(ui): Tooltip skips cloneElement for React.Fragment children (#8241)

### DIFF
--- a/web/src/components/ui/Tooltip.tsx
+++ b/web/src/components/ui/Tooltip.tsx
@@ -3,13 +3,14 @@
  *
  * CSS-only hover/focus implementation using Tailwind group utilities so
  * tooltips work without JS state or portal wiring. When `children` is a
- * valid React element, the child is cloned and receives an
- * `aria-describedby` attribute pointing at the floating bubble so screen
- * readers announce the help text when the focusable trigger is focused.
- * If the child is not a valid element (string, fragment, array), we fall
- * back to rendering the bubble without wiring `aria-describedby` — in that
- * case screen-reader description is not guaranteed, but visual hover still
- * works. Callers should prefer a single focusable child element.
+ * valid React element (and not a `React.Fragment`), the child is cloned
+ * and receives an `aria-describedby` attribute pointing at the floating
+ * bubble so screen readers announce the help text when the focusable
+ * trigger is focused. Non-element and fragment children (strings, numbers,
+ * fragments, arrays) pass through without `aria-describedby` wiring — the
+ * tooltip bubble is still visible on hover but screen readers won't
+ * announce the description to the focused trigger. Callers should prefer
+ * a single focusable child element.
  *
  * Motion is handled via a Tailwind `transition-opacity` that respects the
  * global `.reduce-motion` class defined in `index.css` (which zeroes all
@@ -101,7 +102,14 @@ export function Tooltip({
   // trigger instead of the wrapper — screen readers only announce the
   // description when the focused element carries the attribute. If the
   // child already has an `aria-describedby`, preserve it by space-joining.
-  const childWithAria = React.isValidElement(children)
+  // `React.Fragment` is a valid element but cloning it with an
+  // `aria-describedby` prop triggers a React warning ("Invalid prop
+  // `aria-describedby` supplied to `React.Fragment`"), so we skip the
+  // clone for fragments and pass them through unchanged.
+  const isCloneable =
+    React.isValidElement(children) &&
+    (children as React.ReactElement).type !== React.Fragment
+  const childWithAria = isCloneable
     ? React.cloneElement(
         children as React.ReactElement<{ 'aria-describedby'?: string }>,
         {

--- a/web/src/components/ui/__tests__/Tooltip.test.tsx
+++ b/web/src/components/ui/__tests__/Tooltip.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, vi } from 'vitest'
 import { render, screen } from '@testing-library/react'
 import { Tooltip } from '../Tooltip'
 
@@ -78,6 +78,29 @@ describe('Tooltip', () => {
       </Tooltip>,
     )
     expect(screen.queryByRole('tooltip')).toBeNull()
+  })
+
+  it('passes through React.Fragment children without cloning (no React warning)', () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    try {
+      const { getByRole } = render(
+        <Tooltip content="Help">
+          <>
+            <button>A</button>
+            <button>B</button>
+          </>
+        </Tooltip>,
+      )
+      // Bubble still renders
+      expect(getByRole('tooltip')).toBeInTheDocument()
+      // No React warning about invalid prop on Fragment
+      expect(errorSpy).not.toHaveBeenCalledWith(
+        expect.stringContaining('Invalid prop'),
+        expect.anything(),
+      )
+    } finally {
+      errorSpy.mockRestore()
+    }
   })
 
   it('renders on all four sides with the correct position classes', () => {


### PR DESCRIPTION
Fixes #8241

Follow-up to #8239. The `cloneElement` pattern in `Tooltip` treated any `React.isValidElement(children)` as cloneable, but `React.Fragment` is a valid element that can only accept `key` and `children` props — cloning it with `aria-describedby` produced a React warning ("Invalid prop `aria-describedby` supplied to `React.Fragment`"). This PR narrows the guard so fragments pass through unchanged alongside strings, numbers, and arrays, and adds a regression test that asserts no `Invalid prop` warning is emitted when a `<Tooltip>` wraps a fragment.