### PR TITLE
🐛 fix(test): avoid regex metachar ambiguity in AlertRuleEditor label test (#8244)

### DIFF
--- a/web/src/components/alerts/AlertRuleEditor.test.tsx
+++ b/web/src/components/alerts/AlertRuleEditor.test.tsx
@@ -90,8 +90,10 @@ describe('AlertRuleEditor Component', () => {
           />,
         )
         // The i18n mock returns the key verbatim, so the label's visible text
-        // is the key itself. getByLabelText should succeed via htmlFor -> id.
-        const field = screen.getByLabelText(new RegExp(`^${labelKey}`))
+        // is the key itself (optionally followed by a required marker like ' *').
+        // Use a plain substring match so i18n keys containing '.' aren't
+        // interpreted as regex wildcards.
+        const field = screen.getByLabelText(labelKey, { exact: false })
         expect(field).toHaveAttribute('id', expectedId)
       },
     )


### PR DESCRIPTION
Fixes #8244

Follow-up on #8242. The table-driven label-association test built regexes from i18n keys via `new RegExp(\`^${labelKey}\`)`, but those keys contain `.` (e.g. `alerts.ruleName`) which the regex engine treats as "match any character" — works today but brittle. Switched to a plain-string `getByLabelText(labelKey, { exact: false })` so the match is a literal substring; no metacharacter interpretation.

Verified: `npx vitest run src/components/alerts/AlertRuleEditor.test.tsx` — all 13 tests pass, `npm run build` passes.