### PR TITLE
🐛 fix(test): Tooltip Fragment warning check tolerates React's variadic console.error (#8246)

### DIFF
--- a/web/src/components/ui/__tests__/Tooltip.test.tsx
+++ b/web/src/components/ui/__tests__/Tooltip.test.tsx
@@ -93,11 +93,14 @@ describe('Tooltip', () => {
       )
       // Bubble still renders
       expect(getByRole('tooltip')).toBeInTheDocument()
-      // No React warning about invalid prop on Fragment
-      expect(errorSpy).not.toHaveBeenCalledWith(
-        expect.stringContaining('Invalid prop'),
-        expect.anything(),
-      )
+      // React logs Fragment warnings via console.error with variable arg shape
+      // (format string + substitutions). Flatten every call's args into a single
+      // string and assert the warning text isn't present anywhere.
+      const warningsText = errorSpy.mock.calls
+        .map(args => args.map(a => (typeof a === 'string' ? a : '')).join(' '))
+        .join('\n')
+      expect(warningsText).not.toMatch(/Invalid prop.*Fragment/i)
+      expect(warningsText).not.toMatch(/React\.Fragment can only have/i)
     } finally {
       errorSpy.mockRestore()
     }


### PR DESCRIPTION
Fixes #8246

Follow-up on #8243.

The previous assertion used `expect(errorSpy).not.toHaveBeenCalledWith(expect.stringContaining('Invalid prop'), expect.anything())`, which requires an exact arg-arity match. React logs `console.error` with a format string plus a variable number of substitution args, so the two-arg matcher would pass even if a real Fragment warning fired with 3+ args — masking a regression.

Switched to a flatten-all-calls + `toMatch` approach: join every call's args into a single string and assert the warning text (`/Invalid prop.*Fragment/i` and `/React\.Fragment can only have/i`) is not present anywhere. Either regex catches the real React warning; keeping both is robust against future React wording changes in one.