### PR TITLE
✨ feat(ci): tier-based change classification workflow (labels only)

### DIFF
--- a/.github/tier-classifier-rules.yml
+++ b/.github/tier-classifier-rules.yml
@@ -1,0 +1,78 @@
+# Tier classifier rules — path globs per tier.
+#
+# Used by .github/workflows/tier-classifier.yml. Patterns are glob-style
+# with `*` (non-slash wildcard) and `**` (any path depth). Matched
+# against `paths` from the GitHub `pulls.listFiles` API — which are
+# repo-relative POSIX paths.
+#
+# Classification logic:
+#  - If ANY file matches a tier/3-restricted pattern → the PR is tier 3.
+#    (Tier 3 wins over everything — a PR that accidentally edits
+#    CODEOWNERS in addition to harmless files still requires multi-
+#    maintainer approval.)
+#  - Otherwise, if EVERY file matches a tier/0-automatic pattern → tier 0.
+#  - Otherwise, if EVERY file matches a tier/0 or tier/1-lightweight
+#    pattern → tier 1.
+#  - Otherwise → tier/2-standard (the default, no special handling).
+#
+# Tweak these patterns to tune what counts as "safe" or "sensitive." Keep
+# tier/0 narrow — mistakes here let unsafe changes skip review once
+# auto-merge is wired up in a follow-up PR.
+
+tier/0-automatic:
+  # Dependency manifests maintained by tooling
+  - "package-lock.json"
+  - "web/package-lock.json"
+  - "go.sum"
+  - "go.mod"
+  - "deploy/helm/console/Chart.lock"
+  # Docs-only changes
+  - "docs/**"
+  - "README.md"
+  - "CHANGELOG.md"
+  - "**/*.md"
+  # Generated artifacts
+  - "web/src/locales/**/*.json"
+  - "**/__snapshots__/**"
+  - "**/*.snap"
+
+tier/1-lightweight:
+  # Tests only
+  - "**/__tests__/**"
+  - "**/*.test.ts"
+  - "**/*.test.tsx"
+  - "**/*.spec.ts"
+  - "**/*.spec.tsx"
+  - "**/*_test.go"
+  - "web/e2e/**"
+  # Small surface-area config files
+  - ".editorconfig"
+  - ".gitignore"
+  - ".prettierrc*"
+  - ".eslintrc*"
+
+# tier/2-standard is the default and has no patterns — any PR that
+# doesn't fit tier/0, tier/1, or tier/3 lands here.
+
+tier/3-restricted:
+  # Governance
+  - "CODEOWNERS"
+  - ".github/CODEOWNERS"
+  # CI / automation (workflows can exfiltrate secrets)
+  - ".github/workflows/**"
+  - ".github/actions/**"
+  # Authentication and authorization
+  - "pkg/auth/**"
+  - "pkg/api/middleware/**"
+  - "pkg/api/handlers/auth*.go"
+  - "pkg/api/handlers/oauth*.go"
+  # RBAC and cluster-facing Helm values
+  - "deploy/helm/console/templates/rbac*.yaml"
+  - "deploy/helm/console/templates/clusterrole*.yaml"
+  - "deploy/helm/console/templates/role*.yaml"
+  - "deploy/helm/console/values.yaml"
+  # Security documentation — changes here need security-reviewer approval
+  - "docs/security/**"
+  # Release pipeline + signing keys
+  - ".goreleaser*.yaml"
+  - ".goreleaser*.yml"

--- a/.github/workflows/tier-classifier.yml
+++ b/.github/workflows/tier-classifier.yml
@@ -1,0 +1,207 @@
+name: Tier Classifier
+
+# Labels PRs with exactly one tier/* label based on the set of file paths
+# touched. The tier system is a graduated-autonomy model adapted from the
+# fullsend-ai/fullsend research framework — safe changes (dep bumps, docs,
+# generated files) can move fast; risky changes (workflows, auth, RBAC)
+# need multi-maintainer sign-off.
+#
+# This workflow only LABELS — it does not enforce approval rules yet. A
+# follow-up PR will wire up auto-merge for tier/0-automatic once we've
+# validated the classifier against real PRs for a week.
+#
+# Rules live in .github/tier-classifier-rules.yml so they can be tweaked
+# without editing the workflow itself.
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  classify:
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.head.repo.full_name != ''
+    steps:
+      - name: Checkout rules file
+        uses: actions/checkout@v4
+        with:
+          sparse-checkout: |
+            .github/tier-classifier-rules.yml
+          sparse-checkout-cone-mode: false
+
+      - name: Classify and apply tier label
+        uses: actions/github-script@v8
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const fs = require('fs');
+            const path = require('path');
+
+            // -----------------------------------------------------------------
+            // Load the rules file
+            // -----------------------------------------------------------------
+            const rulesPath = '.github/tier-classifier-rules.yml';
+            if (!fs.existsSync(rulesPath)) {
+              core.setFailed(`Rules file missing: ${rulesPath}`);
+              return;
+            }
+            const rulesText = fs.readFileSync(rulesPath, 'utf8');
+
+            // Tiny YAML subset parser — we only need top-level tier keys
+            // each followed by a list of glob patterns (one per line, indented).
+            // Using a hand-parser avoids pulling in a yaml dep for ~30 lines.
+            const rules = {};
+            let currentTier = null;
+            for (const rawLine of rulesText.split('\n')) {
+              const line = rawLine.replace(/#.*$/, '').trimEnd();
+              if (!line.trim()) continue;
+              const tierMatch = line.match(/^(tier\/[0-9a-z-]+):\s*$/);
+              if (tierMatch) {
+                currentTier = tierMatch[1];
+                rules[currentTier] = [];
+                continue;
+              }
+              const itemMatch = line.match(/^\s*-\s*(?:"([^"]+)"|'([^']+)'|(.+))\s*$/);
+              if (itemMatch && currentTier) {
+                const pattern = (itemMatch[1] || itemMatch[2] || itemMatch[3] || '').trim();
+                if (pattern) rules[currentTier].push(pattern);
+              }
+            }
+
+            core.info(`Loaded tiers: ${Object.keys(rules).join(', ')}`);
+
+            // -----------------------------------------------------------------
+            // Fetch changed files for this PR
+            // -----------------------------------------------------------------
+            const pr = context.payload.pull_request;
+            const files = await github.paginate(
+              github.rest.pulls.listFiles,
+              { owner: context.repo.owner, repo: context.repo.repo, pull_number: pr.number, per_page: 100 }
+            );
+            const paths = files.map(f => f.filename);
+            core.info(`PR #${pr.number} touches ${paths.length} files`);
+
+            // -----------------------------------------------------------------
+            // Match-glob helper — supports *, **, ? and leading/trailing /
+            // -----------------------------------------------------------------
+            function globToRegex(glob) {
+              // Escape regex specials, then translate glob syntax.
+              let re = '';
+              let i = 0;
+              while (i < glob.length) {
+                const c = glob[i];
+                if (c === '*' && glob[i + 1] === '*') {
+                  re += '.*';
+                  i += 2;
+                  if (glob[i] === '/') i++;
+                } else if (c === '*') {
+                  re += '[^/]*';
+                  i++;
+                } else if (c === '?') {
+                  re += '[^/]';
+                  i++;
+                } else if ('.+^$()|[]{}\\'.includes(c)) {
+                  re += '\\' + c;
+                  i++;
+                } else {
+                  re += c;
+                  i++;
+                }
+              }
+              return new RegExp('^' + re + '$');
+            }
+            function matchAny(filePath, patterns) {
+              return patterns.some(p => globToRegex(p).test(filePath));
+            }
+
+            // -----------------------------------------------------------------
+            // Classify — evaluate tiers from most-restrictive to least.
+            // A PR is classified to the HIGHEST tier any of its files matches.
+            // Default (no match anywhere) = tier/2-standard.
+            // -----------------------------------------------------------------
+            const tierOrder = [
+              'tier/3-restricted',
+              'tier/2-standard',
+              'tier/1-lightweight',
+              'tier/0-automatic',
+            ];
+
+            // For tier/3: ANY matching file pulls the whole PR up to tier 3.
+            const tier3Patterns = rules['tier/3-restricted'] || [];
+            const hasTier3 = paths.some(p => matchAny(p, tier3Patterns));
+
+            // For tier/0 and tier/1: EVERY file must match (and no tier/3 hits).
+            const tier0Patterns = rules['tier/0-automatic'] || [];
+            const tier1Patterns = rules['tier/1-lightweight'] || [];
+            const allTier0 = paths.length > 0 && paths.every(p => matchAny(p, tier0Patterns));
+            const allTier1 = paths.length > 0 && paths.every(p => matchAny(p, [...tier0Patterns, ...tier1Patterns]));
+
+            let classified;
+            if (hasTier3) classified = 'tier/3-restricted';
+            else if (allTier0) classified = 'tier/0-automatic';
+            else if (allTier1) classified = 'tier/1-lightweight';
+            else classified = 'tier/2-standard';
+
+            core.info(`Classified PR #${pr.number} as ${classified}`);
+
+            // -----------------------------------------------------------------
+            // Apply: remove any other tier/* labels, add the classified one
+            // -----------------------------------------------------------------
+            const currentLabels = pr.labels.map(l => l.name);
+            const toRemove = currentLabels.filter(l => l.startsWith('tier/') && l !== classified);
+            for (const name of toRemove) {
+              try {
+                await github.rest.issues.removeLabel({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: pr.number,
+                  name,
+                });
+              } catch (e) {
+                core.warning(`Could not remove label ${name}: ${e.message}`);
+              }
+            }
+            if (!currentLabels.includes(classified)) {
+              try {
+                await github.rest.issues.addLabels({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: pr.number,
+                  labels: [classified],
+                });
+              } catch (e) {
+                // Label may not exist yet — create it and retry.
+                core.warning(`addLabels failed: ${e.message}. Creating label and retrying.`);
+                const colors = {
+                  'tier/0-automatic': '0e8a16', // green
+                  'tier/1-lightweight': 'a2eeef', // light blue
+                  'tier/2-standard': 'fbca04', // yellow
+                  'tier/3-restricted': 'd93f0b', // red
+                };
+                const descriptions = {
+                  'tier/0-automatic': 'Safe changes (deps, docs, generated) — future auto-merge candidate',
+                  'tier/1-lightweight': 'Single-concern changes, lightweight review',
+                  'tier/2-standard': 'Default classification — standard review required',
+                  'tier/3-restricted': 'Touches security-sensitive paths — needs multi-maintainer sign-off',
+                };
+                await github.rest.issues.createLabel({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  name: classified,
+                  color: colors[classified] || 'ededed',
+                  description: descriptions[classified] || '',
+                }).catch(() => {}); // Ignore if it was created by another run in parallel.
+                await github.rest.issues.addLabels({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: pr.number,
+                  labels: [classified],
+                });
+              }
+            }
+
+            core.info(`PR #${pr.number} now labeled ${classified}`);

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -55,6 +55,25 @@ Starts backend on `:8080` and frontend on `:5174` with a mock `dev-user` account
 
 - Sign all commits with DCO: `git commit -s`
 
+## Change Tiers
+
+Every PR gets automatically labeled with exactly one `tier/*` label when it opens. The tier classifies how much review scrutiny the change needs based on which files it touches. Rules live in [`.github/tier-classifier-rules.yml`](.github/tier-classifier-rules.yml); logic runs in [`.github/workflows/tier-classifier.yml`](.github/workflows/tier-classifier.yml).
+
+| Label | Meaning | What it covers |
+|---|---|---|
+| `tier/0-automatic` | Safe — safe to fast-track | Lockfiles, `go.sum`, docs-only, `*.md`, i18n files, snapshots, generated artifacts |
+| `tier/1-lightweight` | Single-concern, low risk | Test-only changes, editor config (`.editorconfig`, `.prettierrc`, etc.) |
+| `tier/2-standard` | Default — standard review | Everything not matched by another tier |
+| `tier/3-restricted` | Touches security-sensitive paths | `CODEOWNERS`, `.github/workflows/**`, `pkg/auth/**`, `pkg/api/middleware/**`, `docs/security/**`, Helm RBAC templates, GoReleaser config |
+
+**Classification rules.** A PR is tier 3 if *any* of its files match a tier-3 path. Otherwise it's tier 0 only if *every* file is a tier-0 match; tier 1 only if every file is a tier-0 or tier-1 match; otherwise tier 2.
+
+**Today:** labels are informational. Reviewers can use them to prioritize their queue.
+
+**Future (separate PR):** `tier/0-automatic` PRs with CI green will auto-merge via admin squash. Rolling out after a week of label-only observation to confirm the rules don't produce false positives.
+
+This system is adapted from fullsend-ai/fullsend's tier-based change classification — see [`SECURITY-AI.md`](docs/security/SECURITY-AI.md) for the broader context.
+
 ## Getting Help
 
 - [Documentation](https://console-docs.kubestellar.io)


### PR DESCRIPTION
## Summary

Second of **four PRs** from the fullsend-ai/fullsend automation evaluation. Adds a `tier-classifier` workflow that labels every PR with exactly one `tier/*` label based on the file paths touched, so reviewers can prioritize and (in a follow-up PR) tier/0 PRs can auto-merge.

Adapted from [fullsend-ai/fullsend](https://github.com/fullsend-ai/fullsend)'s tier-based change classification pattern — graduated autonomy where safe changes (dep bumps, docs, generated files) can fast-track and risky changes (workflows, auth, RBAC) require multi-maintainer sign-off.

### What lands here

- **`.github/workflows/tier-classifier.yml`** — `pull_request_target` trigger, reads the rules file, calls `pulls.listFiles`, classifies, applies the label. Uses `actions/github-script@v8` — no new dependencies. Hand-parses the rules YAML (tiny subset — three top-level keys with lists) to avoid pulling in a yaml dep.
- **`.github/tier-classifier-rules.yml`** — path globs per tier as a data file, so rules can be tweaked without editing the workflow.
- **`CONTRIBUTING.md`** — new `## Change Tiers` section explaining what each label means and where the rules live.

### The four tiers

| Label | Covers |
|---|---|
| `tier/0-automatic` | `package-lock.json`, `go.sum`, `go.mod`, `docs/**`, `README.md`, `**/*.md`, `web/src/locales/**/*.json`, snapshots |
| `tier/1-lightweight` | `**/__tests__/**`, `**/*.test.ts[x]`, `**/*.spec.ts[x]`, `**/*_test.go`, `web/e2e/**`, editor config |
| `tier/2-standard` | Default — everything not matched by another tier |
| `tier/3-restricted` | `CODEOWNERS`, `.github/workflows/**`, `.github/actions/**`, `pkg/auth/**`, `pkg/api/middleware/**`, `pkg/api/handlers/auth*`, Helm RBAC/ClusterRole/values, `docs/security/**`, `.goreleaser*` |

### Classification logic

- **Tier 3 wins** if ANY file matches a tier-3 pattern. A single workflow edit pulls the whole PR up to restricted, even if the other 50 files are harmless.
- **Tier 0 and Tier 1** require EVERY file to match. Conservative — any unclassified file bumps the PR to tier 2.
- **Tier 2** is the implicit default.

### Label auto-creation

The labels are created on first use by the workflow itself (green for tier/0, light blue for tier/1, yellow for tier/2, red for tier/3) so maintainers don't need to pre-seed them.

### Scope: labels only, no enforcement yet

This PR **only labels**. A follow-up PR will wire auto-merge for `tier/0-automatic` once the rules have proven accurate on real PRs for a week. Rolling it out blind is risky — wait for empirical validation of the allowlist.

## Test plan

- [x] `npm run build` — passes
- [x] `python3 -c "import yaml; yaml.safe_load(...)"` — both YAML files parse
- [ ] Open a docs-only PR → `tier/0-automatic` label applied
- [ ] Open a test-only PR → `tier/1-lightweight` label applied
- [ ] Open a PR touching `web/src/components/cards/...` → `tier/2-standard` label applied
- [ ] Open a PR touching `.github/workflows/*.yml` → `tier/3-restricted` label applied
- [ ] Open a PR touching docs + a workflow → `tier/3-restricted` wins

🤖 Generated with [Claude Code](https://claude.com/claude-code)