### PR TITLE
✨ Widen NPS reach: show for demo/unauth visitors, lower thresholds

### DIFF
--- a/web/src/hooks/__tests__/useNPSSurvey.test.ts
+++ b/web/src/hooks/__tests__/useNPSSurvey.test.ts
@@ -2,8 +2,6 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { renderHook, act } from '@testing-library/react'
 
 const {
-  mockIsAuthenticated,
-  mockIsDemoMode,
   mockAwardCoins,
   mockApiPost,
   mockEmitShown,
@@ -11,22 +9,12 @@ const {
   mockEmitDismissed,
   store,
 } = vi.hoisted(() => ({
-  mockIsAuthenticated: vi.fn(() => true),
-  mockIsDemoMode: vi.fn(() => false),
   mockAwardCoins: vi.fn(),
   mockApiPost: vi.fn().mockResolvedValue({ data: {} }),
   mockEmitShown: vi.fn(),
   mockEmitResponse: vi.fn(),
   mockEmitDismissed: vi.fn(),
   store: new Map<string, string>(),
-}))
-
-vi.mock('../../lib/auth', () => ({
-  useAuth: () => ({ isAuthenticated: mockIsAuthenticated() }),
-}))
-
-vi.mock('../../lib/demoMode', () => ({
-  isDemoMode: () => mockIsDemoMode(),
 }))
 
 vi.mock('../useRewards', () => ({
@@ -63,8 +51,6 @@ describe('useNPSSurvey', () => {
   beforeEach(() => {
     vi.useFakeTimers()
     store.clear()
-    mockIsAuthenticated.mockReturnValue(true)
-    mockIsDemoMode.mockReturnValue(false)
     mockAwardCoins.mockClear()
     mockApiPost.mockClear()
     mockEmitShown.mockClear()
@@ -83,31 +69,25 @@ describe('useNPSSurvey', () => {
     fetchMock.mockReset()
   })
 
-  it('does not show for unauthenticated users', () => {
-    mockIsAuthenticated.mockReturnValue(false)
+  it('shows for demo/unauthenticated visitors (voluntary feedback has no auth gate)', () => {
     const { result } = renderHook(() => useNPSSurvey())
-    act(() => { vi.advanceTimersByTime(35_000) })
-    expect(result.current.isVisible).toBe(false)
-  })
-
-  it('does not show for demo-mode users', () => {
-    mockIsDemoMode.mockReturnValue(true)
-    const { result } = renderHook(() => useNPSSurvey())
-    act(() => { vi.advanceTimersByTime(35_000) })
-    expect(result.current.isVisible).toBe(false)
+    act(() => { vi.advanceTimersByTime(15_000) })
+    expect(result.current.isVisible).toBe(true)
+    expect(mockEmitShown).toHaveBeenCalledOnce()
   })
 
   it('does not show before MIN_SESSIONS_BEFORE_NPS sessions', () => {
-    store.set('kc-session-count', '3')
+    // MIN_SESSIONS_BEFORE_NPS is 2; 1 session is below threshold
+    store.set('kc-session-count', '1')
     const { result } = renderHook(() => useNPSSurvey())
-    act(() => { vi.advanceTimersByTime(35_000) })
+    act(() => { vi.advanceTimersByTime(15_000) })
     expect(result.current.isVisible).toBe(false)
   })
 
   it('shows after idle delay when eligible', () => {
     const { result } = renderHook(() => useNPSSurvey())
     expect(result.current.isVisible).toBe(false)
-    act(() => { vi.advanceTimersByTime(30_000) })
+    act(() => { vi.advanceTimersByTime(10_000) })
     expect(result.current.isVisible).toBe(true)
     expect(mockEmitShown).toHaveBeenCalledOnce()
   })

--- a/web/src/hooks/useNPSSurvey.ts
+++ b/web/src/hooks/useNPSSurvey.ts
@@ -1,6 +1,4 @@
 import { useState, useEffect, useCallback } from 'react'
-import { useAuth } from '../lib/auth'
-import { isDemoMode } from '../lib/demoMode'
 import { safeGetJSON, safeSetJSON, safeGetItem } from '../lib/utils/localStorage'
 import { STORAGE_KEY_NPS_STATE, STORAGE_KEY_SESSION_COUNT } from '../lib/constants/storage'
 import { emitNPSSurveyShown, emitNPSResponse, emitNPSDismissed } from '../lib/analytics'
@@ -8,9 +6,9 @@ import { api } from '../lib/api'
 import { useRewards } from './useRewards'
 
 /** Minimum sessions before showing NPS for the first time */
-const MIN_SESSIONS_BEFORE_NPS = 5
+const MIN_SESSIONS_BEFORE_NPS = 2
 /** Idle delay in ms before the widget slides up */
-const NPS_IDLE_DELAY_MS = 30_000
+const NPS_IDLE_DELAY_MS = 10_000
 /** Days to wait after submission before re-prompting */
 const NPS_REPROMPT_DAYS = 30
 /** Days to wait after a dismissal before retrying */
@@ -72,15 +70,16 @@ function isEligible(state: NPSPersistentState): boolean {
 }
 
 export function useNPSSurvey(): NPSSurveyState {
-  const { isAuthenticated } = useAuth()
   const { awardCoins } = useRewards()
   const [isVisible, setIsVisible] = useState(false)
 
-  // Check eligibility and start idle timer
+  // Check eligibility and start idle timer.
+  // Demo-mode and unauthenticated visitors are both eligible: NPS is
+  // voluntary feedback, and since the vast majority of console.kubestellar.io
+  // traffic is demo visitors, gating it behind authenticated non-demo
+  // sessions left us with almost no data. Feedback still has to be
+  // explicitly submitted by the user.
   useEffect(() => {
-    // Auth + demo guard
-    if (!isAuthenticated || isDemoMode()) return
-
     // Session threshold guard
     const sessionCount = parseInt(safeGetItem(STORAGE_KEY_SESSION_COUNT) || '0', 10)
     if (sessionCount < MIN_SESSIONS_BEFORE_NPS) return
@@ -96,7 +95,7 @@ export function useNPSSurvey(): NPSSurveyState {
     }, NPS_IDLE_DELAY_MS)
 
     return () => clearTimeout(timer)
-  }, [isAuthenticated])
+  }, [])
 
   const submitResponse = useCallback(async (score: number, feedback?: string) => {
     if (!Number.isInteger(score) || score < 1 || score > 4) return


### PR DESCRIPTION
## Summary

Follow-up to #8257. The NPS backend is now wired correctly, but we still only have 2 responses because the widget never shows — it was gated behind authenticated + non-demo-mode users, and console.kubestellar.io is ~99% demo visitors. Plus the session/timing gates added more attrition on top.

Relax the eligibility so voluntary feedback actually has an audience:

### 1. Drop the auth/demo guard
`useNPSSurvey.ts:80` used to return early if `!isAuthenticated || isDemoMode()`. NPS is voluntary, user-initiated feedback with an explicit click-to-submit step — gating it behind auth state made no sense. Passive tracking opt-out still applies to every other analytics event (and the NPS backend POST has always been opt-out-independent anyway).

### 2. Lower session threshold
`MIN_SESSIONS_BEFORE_NPS`: 5 → 2. Users now see the prompt on their second visit instead of the fifth.

### 3. Shorten idle delay
`NPS_IDLE_DELAY_MS`: 30_000 → 10_000. Widget slides up after 10s of page time instead of 30s.

### What's **not** changing
- `NPS_REPROMPT_DAYS = 30` — still a 30-day gap after a submission before re-prompting
- `NPS_DISMISS_RETRY_DAYS = 7` — still a 7-day gap after a dismissal
- `NPS_MAX_DISMISSALS = 3` — still stops after 3 dismissals within the reprompt window
- Failure-path UX (PR #8257): POST errors still surface a toast and keep the widget open

## Tests

- Dropped `does not show for unauthenticated users` / `does not show for demo-mode users` — no longer applicable.
- Added `shows for demo/unauthenticated visitors` as a positive case.
- Rebased the session-threshold test to use `'1'` against the new `MIN_SESSIONS_BEFORE_NPS = 2`.
- Rebased the idle-delay test to 10_000 ms.

## Test plan

- [x] `npx vitest run src/hooks/__tests__/useNPSSurvey.test.ts` — 11/11 pass
- [x] `npx tsc --noEmit` — clean
- [x] `npm run lint` — no new issues on edited files
- [x] `npm run build` — green, all post-build safety checks pass
- [ ] After merge: real demo visitors on console.kubestellar.io should start seeing the widget after ~10s on their 2nd session
- [ ] Monitor `/analytics` for NPS response growth over the next few days