### PR TITLE
🐛 fix(ci): nightly-test-suite timeout — benchmark per-test + workflow budget

### DIFF
--- a/.github/workflows/nightly-test-suite.yml
+++ b/.github/workflows/nightly-test-suite.yml
@@ -24,7 +24,16 @@ jobs:
       issues: write
     if: github.repository == 'kubestellar/console'
     runs-on: ubuntu-latest
-    timeout-minutes: 90
+    # The suite bundles 13 Playwright specs after the Go and security tests.
+    # One of them (benchmark-dashboard, which hits live Google Drive + GitHub
+    # Actions + Netlify functions) had been burning 20+ minutes on retry
+    # storms and pushing the total over 90m, cancelling three nights in a row
+    # (runs 24439970651, 24420...). 120m covers the worst case with headroom;
+    # the per-test timeout in benchmarks.config.ts is also being cut from 5m
+    # to 2m in the same PR, which should actually bring total runtime back
+    # under 90m — the 120m bump is belt-and-suspenders in case one of the
+    # other Playwright specs inherits a similar pattern.
+    timeout-minutes: 120
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/web/e2e/benchmarks/benchmarks.config.ts
+++ b/web/e2e/benchmarks/benchmarks.config.ts
@@ -22,9 +22,20 @@ function getWebServer() {
   }
 }
 
+// Per-test timeout. The in-test waitForFunction assertions use 15-30s
+// timeouts (STREAM_DATA_TIMEOUT_MS, NETLIFY_FETCH_TIMEOUT_MS in the spec),
+// so the outer Playwright timeout only matters as a backstop when a page
+// hangs. 5 minutes was vastly over-budget — a single retry storm against
+// live Google Drive / GitHub Actions / Netlify could eat 20+ minutes and
+// cancel the whole nightly-test-suite workflow at 90m (seen on 2026-04-13
+// through 04-15). 2 minutes is enough backstop for the slowest real case
+// (SSE streaming + chart render on a cold preview server) without letting
+// a hang compound across all 12 tests.
+const PER_TEST_TIMEOUT_MS = 120_000
+
 export default defineConfig({
   testDir: '.',
-  timeout: 300_000,
+  timeout: PER_TEST_TIMEOUT_MS,
   expect: { timeout: 20_000 },
   retries: 1,
   workers: 1,


### PR DESCRIPTION
## Summary

Three consecutive **nightly-test-suite** runs cancelled at the 90-minute job budget (2026-04-13, 04-14, 04-15). Investigation of run [24439970651](https://github.com/kubestellar/console/actions/runs/24439970651) shows the kill fired while \`scripts/benchmark-test.sh\` had been running for 23+ minutes on a single Playwright spec — the rest of the suite took only a few minutes each.

Root cause: \`web/e2e/benchmarks/benchmarks.config.ts\` used \`timeout: 300_000\` (5 min per test) with \`retries: 1\`. With 12 tests in the spec, worst case is **120 minutes** — more than the entire job budget for the whole test suite. In-test \`waitForFunction\` assertions already use 15-30s timeouts, so the 300s outer budget was only a hang backstop — overkill.

## Fix

Surgical two-line change:

1. **\`web/e2e/benchmarks/benchmarks.config.ts\`** — cut per-test \`timeout\` from 300_000 to 120_000 (2 min), extracted to a named constant with a comment pointing at the cancelled runs. Worst case drops from 120 min to ~48 min (12 tests × 2 min × 2 attempts), well within the 90m job budget.

2. **\`.github/workflows/nightly-test-suite.yml\`** — bump job \`timeout-minutes\` from 90 to 120 as safety margin in case another Playwright spec inherits a similar retry-storm pattern.

No test logic changes, no retry changes, no new flakiness surface.

## Why tonight will be green

This PR plus [1980b477](https://github.com/kubestellar/console/commit/1980b477) (the auth-refresh contract fix that landed 04-15 at 03:14 EDT — too late for that night's 01:45 EDT release/06:30 EDT test-suite runs) together close the two regressions:

- **nightly-dashboard-health** — was failing on the \`/auth/refresh\` contract test. 1980b477 restored the cookie-only contract; main is already green locally (\`go test ./pkg/api/handlers/...\` passes on 095c0b97).
- **nightly-test-suite** — this PR prevents benchmark retry storms from pushing total runtime over budget.

Tonight's 06:00 UTC run should succeed.

## Test plan

- [x] Benchmark config reads cleanly in isolation
- [x] Go tests still pass on current main (\`go test ./pkg/api/handlers/... -run 'TestRefreshToken|TestAuthRefreshContract' -count=1\`)
- [ ] Tonight: monitor https://github.com/kubestellar/console/actions/workflows/nightly-test-suite.yml
- [ ] Tomorrow: verify no \"Job was cancelled\" annotation on the 2026-04-16 run

🤖 Generated with [Claude Code](https://claude.com/claude-code)