### PR TITLE
🐛 Fix NPS submit in demo mode: MSW OPTIONS preflight was 503'd

### DIFF
--- a/web/src/mocks/handlers.ts
+++ b/web/src/mocks/handlers.ts
@@ -706,11 +706,11 @@ export const handlers = [
   http.get('/api/missions/file', () => passthrough()),
   http.get('/api/missions/browse', () => passthrough()),
   http.get('/api/rewards/github', () => passthrough()),
-  // NPS (voluntary feedback) — widget is gated off in demo mode at the
-  // hook level, but if a dev enables it the POST/GET must reach the real
-  // Netlify Function instead of the 503 catch-all below.
-  http.get('/api/nps', () => passthrough()),
-  http.post('/api/nps', () => passthrough()),
+  // NPS (voluntary feedback) — use http.all so the CORS preflight
+  // OPTIONS request also passes through. Without this, the catch-all
+  // http.all('/api/*') below returns 503 on the preflight and the
+  // browser blocks the actual POST.
+  http.all('/api/nps', () => passthrough()),
   http.get('/api/acmm/scan', () => passthrough()),
 
   // ── Kubara Platform Catalog (demo) ──────────────────────────────


### PR DESCRIPTION
## Summary

Follow-up to #8257 and #8258. The NPS widget now shows for demo visitors, but submitting fails because MSW blocks the CORS preflight.

### Root cause
When the browser sends `POST /api/nps` with `Content-Type: application/json`, it first sends an `OPTIONS` preflight request. PR #8257 added `http.get` and `http.post` passthrough handlers — but `OPTIONS` didn't match either, so it fell through to the catch-all `http.all('/api/*')` which returned `{ error: "not available in demo mode" }` with status 503. The browser saw 503 on the preflight and blocked the actual POST entirely.

### Fix
Replace the separate `http.get` + `http.post` handlers with a single `http.all('/api/nps', () => passthrough())` so GET, POST, and OPTIONS all pass through to the real Netlify Function.

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npm run build` — green
- [ ] After merge: submit NPS feedback on console.kubestellar.io in demo mode — should succeed instead of showing error toast