### PR TITLE
🐛 fix: address Copilot review on local LLM providers (#8255, #8259)

### DIFF
--- a/pkg/agent/config.go
+++ b/pkg/agent/config.go
@@ -42,6 +42,11 @@ type ConfigManager struct {
 	config      *AgentConfig
 	keyValidity map[string]bool // Cache of key validity (true=valid, false=invalid)
 	validityMu  sync.RWMutex    // Separate mutex for validity cache
+	// inMemoryKeys holds provider API keys that should NOT be persisted to
+	// ~/.kc/config.yaml — for example the sentinel placeholder used by local
+	// LLM runners that do not enforce auth. Using an in-memory map avoids
+	// disk side-effects and works on read-only filesystems (#8255).
+	inMemoryKeys sync.Map // map[string]string
 }
 
 var (
@@ -132,7 +137,12 @@ func (cm *ConfigManager) saveLocked() error {
 	return nil
 }
 
-// GetAPIKey returns the API key for a provider (env var takes precedence)
+// GetAPIKey returns the API key for a provider. Precedence:
+//  1. Environment variable
+//  2. Persistent config file (~/.kc/config.yaml)
+//  3. In-memory override set via SetAPIKeyInMemory (e.g. local LLM sentinel)
+//
+// Real operator keys always win over in-memory placeholders.
 func (cm *ConfigManager) GetAPIKey(provider string) string {
 	// Environment variable takes precedence
 	envKey := getEnvKeyForProvider(provider)
@@ -145,11 +155,25 @@ func (cm *ConfigManager) GetAPIKey(provider string) string {
 	defer cm.mu.RUnlock()
 
 	if cm.config != nil {
-		if agentConfig, ok := cm.config.Agents[provider]; ok {
+		if agentConfig, ok := cm.config.Agents[provider]; ok && agentConfig.APIKey != "" {
 			return agentConfig.APIKey
 		}
 	}
+	// Finally, fall back to in-memory override (never persisted).
+	if v, ok := cm.inMemoryKeys.Load(provider); ok {
+		if s, ok := v.(string); ok {
+			return s
+		}
+	}
 	return ""
+}
+
+// SetAPIKeyInMemory stores a key for a provider WITHOUT writing to disk.
+// Used for sentinel placeholders (e.g. local LLM runners that do not
+// enforce auth) so read-only filesystems and ephemeral containers do not
+// see spurious writes to ~/.kc/config.yaml (#8255).
+func (cm *ConfigManager) SetAPIKeyInMemory(provider, apiKey string) {
+	cm.inMemoryKeys.Store(provider, apiKey)
 }
 
 // GetModel returns the model for a provider (env var takes precedence)
@@ -246,9 +270,23 @@ func (cm *ConfigManager) RemoveAPIKey(provider string) error {
 	return cm.saveLocked()
 }
 
-// HasAPIKey checks if a provider has an API key configured (env or config)
+// HasAPIKey checks if a provider has a REAL API key configured in the
+// environment or on disk. In-memory placeholders (see SetAPIKeyInMemory)
+// are deliberately ignored so local LLM runners are not reported as
+// "configured" just because the sentinel was seeded at chat time (#8255).
 func (cm *ConfigManager) HasAPIKey(provider string) bool {
-	return cm.GetAPIKey(provider) != ""
+	envKey := getEnvKeyForProvider(provider)
+	if envVal := os.Getenv(envKey); envVal != "" {
+		return true
+	}
+	cm.mu.RLock()
+	defer cm.mu.RUnlock()
+	if cm.config != nil {
+		if agentConfig, ok := cm.config.Agents[provider]; ok && agentConfig.APIKey != "" {
+			return true
+		}
+	}
+	return false
 }
 
 // IsFromEnv checks if the API key is from environment variable

--- a/pkg/agent/provider_local_openai_compat.go
+++ b/pkg/agent/provider_local_openai_compat.go
@@ -65,12 +65,22 @@ func (p *LocalOpenAICompatProvider) DisplayName() string { return p.displayName 
 func (p *LocalOpenAICompatProvider) Provider() string    { return p.providerKey }
 func (p *LocalOpenAICompatProvider) Description() string { return p.description }
 
-// IsAvailable returns true when either the env var is set or the provider has
-// a non-empty default URL. Local runners typically have no API key — the OpenAI
-// helper accepts a sentinel value when CapabilityChat is the only capability,
-// so availability is driven by URL reachability rather than credential state.
+// IsAvailable reports whether an operator has EXPLICITLY configured this
+// runner via its URL env var or via Settings → API Keys (persisted as a
+// base-URL override in ~/.kc/config.yaml). Compiled-in loopback defaults
+// (Ollama, LM Studio) are deliberately NOT treated as "available" here —
+// otherwise the agent selector would flag those two runners as reachable on
+// any machine, even when the runner is not installed (#8255). Operators who
+// really do want the loopback path can set OLLAMA_URL / LM_STUDIO_URL
+// explicitly and the dropdown will light up immediately.
 func (p *LocalOpenAICompatProvider) IsAvailable() bool {
-	return p.localOpenAICompatBaseURL() != ""
+	if v := strings.TrimRight(os.Getenv(p.urlEnvVar), "/"); v != "" {
+		return true
+	}
+	if v := strings.TrimRight(GetConfigManager().GetBaseURL(p.providerKey), "/"); v != "" {
+		return true
+	}
+	return false
 }
 
 // Capabilities: chat only. These providers cannot execute cluster commands,
@@ -110,13 +120,17 @@ func (p *LocalOpenAICompatProvider) StreamChat(ctx context.Context, req *ChatReq
 // error.
 const localLLMPlaceholderKey = "local-llm-no-auth" //nolint:gosec // sentinel, not a credential
 
-// ensureLocalLLMPlaceholderKey seeds the config manager with the placeholder
-// key only when the operator has NOT explicitly set a real key via env var or
-// ~/.kc/config.yaml. Real keys always win.
+// ensureLocalLLMPlaceholderKey seeds an in-memory sentinel API key for the
+// runner ONLY when the operator has not explicitly set a real key via env
+// var or ~/.kc/config.yaml. The sentinel is stored in ConfigManager's
+// in-memory override (NOT persisted to disk) so read-only filesystems and
+// ephemeral containers do not see spurious writes to ~/.kc/config.yaml
+// (#8255). Real keys always win because GetAPIKey checks env → config →
+// in-memory in that order.
 func ensureLocalLLMPlaceholderKey(providerKey string) {
 	cm := GetConfigManager()
 	if cm.GetAPIKey(providerKey) == "" {
-		_ = cm.SetAPIKey(providerKey, localLLMPlaceholderKey)
+		cm.SetAPIKeyInMemory(providerKey, localLLMPlaceholderKey)
 	}
 }
 

--- a/pkg/agent/server_ai.go
+++ b/pkg/agent/server_ai.go
@@ -1633,11 +1633,16 @@ type KeysStatusResponse struct {
 // Setting APIKey requires a valid key; setting BaseURL is independent
 // (operators can configure a base URL without an API key, which is the
 // common path for unauthenticated local LLM runners).
+//
+// To clear a previously-set base URL (reverting to the compiled-in default),
+// set ClearBaseURL=true with an empty BaseURL. This avoids the "missing
+// field" guard that rejects requests where all three fields are empty (#8259).
 type SetKeyRequest struct {
-	Provider string `json:"provider"`
-	APIKey   string `json:"apiKey,omitempty"`
-	Model    string `json:"model,omitempty"`
-	BaseURL  string `json:"baseURL,omitempty"`
+	Provider     string `json:"provider"`
+	APIKey       string `json:"apiKey,omitempty"`
+	Model        string `json:"model,omitempty"`
+	BaseURL      string `json:"baseURL,omitempty"`
+	ClearBaseURL bool   `json:"clearBaseURL,omitempty"`
 }
 
 // handleSettingsKeys handles GET and POST for /settings/keys

--- a/pkg/agent/server_operations.go
+++ b/pkg/agent/server_operations.go
@@ -297,6 +297,15 @@ func (s *Server) handleGetKeysStatus(w http.ResponseWriter, r *http.Request) {
 		// their placeholder sentinel key against a real endpoint is
 		// pointless — we report Configured=true whenever a URL is set.
 		validationRequired bool
+		// isLocalLLM marks URL-driven providers (Ollama, llama.cpp, etc.)
+		// whose "configured" status is derived from URL presence rather
+		// than API key presence. This also drives the BaseURL resolution
+		// to include compiled-in defaults so the UI shows the current
+		// effective endpoint (#8259).
+		isLocalLLM bool
+		// defaultURL is the compiled-in loopback URL (e.g. Ollama on
+		// 127.0.0.1:11434). Empty for providers with no default.
+		defaultURL string
 	}
 
 	providers := []providerDef{
@@ -304,13 +313,14 @@ func (s *Server) handleGetKeysStatus(w http.ResponseWriter, r *http.Request) {
 		{name: "groq", displayName: "Groq", validationRequired: true},
 		{name: "openrouter", displayName: "OpenRouter", validationRequired: true},
 		{name: "open-webui", displayName: "Open WebUI", validationRequired: false},
-		// Local LLM runners — URL-driven, no API key by default
-		{name: "ollama", displayName: "Ollama (Local)"},
-		{name: "llamacpp", displayName: "llama.cpp (Local)"},
-		{name: "localai", displayName: "LocalAI (Local)"},
-		{name: "vllm", displayName: "vLLM (Local)"},
-		{name: "lm-studio", displayName: "LM Studio (Local)"},
-		{name: "rhaiis", displayName: "Red Hat AI Inference Server"},
+		// Local LLM runners — URL-driven, no API key by default.
+		// isLocalLLM=true changes Configured semantics: URL-present counts.
+		{name: ProviderKeyOllama, displayName: "Ollama (Local)", isLocalLLM: true, defaultURL: defaultOllamaURL},
+		{name: ProviderKeyLlamaCpp, displayName: "llama.cpp (Local)", isLocalLLM: true},
+		{name: ProviderKeyLocalAI, displayName: "LocalAI (Local)", isLocalLLM: true},
+		{name: ProviderKeyVLLM, displayName: "vLLM (Local)", isLocalLLM: true},
+		{name: ProviderKeyLMStudio, displayName: "LM Studio (Local)", isLocalLLM: true, defaultURL: defaultLMStudioURL},
+		{name: ProviderKeyRHAIIS, displayName: "Red Hat AI Inference Server", isLocalLLM: true},
 	}
 
 	keys := make([]KeyStatus, 0, len(providers))
@@ -321,14 +331,27 @@ func (s *Server) handleGetKeysStatus(w http.ResponseWriter, r *http.Request) {
 			Configured:  cm.HasAPIKey(p.name),
 		}
 
-		// Base URL metadata — surfaces the current resolved value and
-		// the env var name so the UI can render an Advanced expandable.
+		// Base URL metadata — surfaces the fully-resolved value (env →
+		// config → compiled default) and the env var name so the UI can
+		// render an Advanced expandable section.
 		status.BaseURL = cm.GetBaseURL(p.name)
 		status.BaseURLEnvVar = getBaseURLEnvKeyForProvider(p.name)
 		if status.BaseURLEnvVar != "" && os.Getenv(status.BaseURLEnvVar) != "" {
 			status.BaseURLSource = "env"
 		} else if status.BaseURL != "" {
 			status.BaseURLSource = "config"
+		}
+		// For local LLM runners, fall through to the compiled-in default
+		// so the UI always shows the effective endpoint (#8259).
+		if p.isLocalLLM && status.BaseURL == "" && p.defaultURL != "" {
+			status.BaseURL = p.defaultURL
+			status.BaseURLSource = "default"
+		}
+		// Local LLM runners are "configured" when a URL is reachable —
+		// either via env/config override or compiled-in default. Having
+		// only a sentinel placeholder API key is not enough (#8259).
+		if p.isLocalLLM {
+			status.Configured = status.BaseURL != ""
 		}
 
 		if status.Configured {
@@ -381,12 +404,13 @@ func (s *Server) handleSetKey(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// At least one of APIKey, BaseURL, or Model must be present — a request
-	// with none is a programming bug we should reject rather than silently
-	// store nothing.
-	if req.APIKey == "" && req.BaseURL == "" && req.Model == "" {
+	// At least one actionable field must be present — a request with none
+	// is a programming bug we should reject rather than silently store
+	// nothing. ClearBaseURL counts as actionable (it reverts the URL to
+	// the compiled-in default).
+	if req.APIKey == "" && req.BaseURL == "" && req.Model == "" && !req.ClearBaseURL {
 		w.WriteHeader(http.StatusBadRequest)
-		json.NewEncoder(w).Encode(protocol.ErrorPayload{Code: "missing_field", Message: "At least one of apiKey, baseURL, or model is required"})
+		json.NewEncoder(w).Encode(protocol.ErrorPayload{Code: "missing_field", Message: "At least one of apiKey, baseURL, model, or clearBaseURL is required"})
 		return
 	}
 
@@ -411,6 +435,16 @@ func (s *Server) handleSetKey(w http.ResponseWriter, r *http.Request) {
 		}
 		// Invalidate cached validity for this provider — the endpoint
 		// changed, so any previously-cached "key valid" result is stale.
+		cm.InvalidateKeyValidity(req.Provider)
+	} else if req.ClearBaseURL {
+		// Explicit clear: remove the persisted base URL override so the
+		// provider reverts to its compiled-in default URL (#8259).
+		if err := cm.RemoveBaseURL(req.Provider); err != nil {
+			slog.Error("clear base URL error", "error", err)
+			w.WriteHeader(http.StatusInternalServerError)
+			json.NewEncoder(w).Encode(protocol.ErrorPayload{Code: "save_failed", Message: "failed to clear base URL"})
+			return
+		}
 		cm.InvalidateKeyValidity(req.Provider)
 	}
 

--- a/web/src/components/agent/APIKeySettings.tsx
+++ b/web/src/components/agent/APIKeySettings.tsx
@@ -190,6 +190,32 @@ export function APIKeySettings({ isOpen, onClose }: APIKeySettingsProps) {
     })
   }, [])
 
+  const fetchKeysStatus = useCallback(async () => {
+    try {
+      setLoading(true)
+      setError(null)
+      const response = await fetch(`${KC_AGENT_URL}/settings/keys`, {
+        signal: AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS),
+      })
+      if (!response.ok) {
+        throw new Error(t('agent.failedToFetchKeyStatus'))
+      }
+      const data: KeysStatusResponse = await response.json()
+      setKeysStatus(data.keys)
+      setConfigPath(data.configPath)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : t('agent.failedToConnect'))
+    } finally {
+      setLoading(false)
+    }
+  }, [t])
+
+  useEffect(() => {
+    if (isOpen) {
+      fetchKeysStatus()
+    }
+  }, [isOpen, fetchKeysStatus])
+
   const handleSaveBaseURL = useCallback(async (provider: string) => {
     const draft = (baseURLDraft[provider] ?? '').trim()
     setBaseURLError(e => ({ ...e, [provider]: '' }))
@@ -219,7 +245,7 @@ export function APIKeySettings({ isOpen, onClose }: APIKeySettingsProps) {
     } finally {
       setSaving(false)
     }
-  }, [baseURLDraft, t])
+  }, [baseURLDraft, t, fetchKeysStatus])
 
   const copyInstallCommand = async () => {
     await copyToClipboard(INSTALL_COMMAND)
@@ -235,32 +261,6 @@ export function APIKeySettings({ isOpen, onClose }: APIKeySettingsProps) {
       }
     }
   }, [])
-
-  const fetchKeysStatus = useCallback(async () => {
-    try {
-      setLoading(true)
-      setError(null)
-      const response = await fetch(`${KC_AGENT_URL}/settings/keys`, {
-        signal: AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS),
-      })
-      if (!response.ok) {
-        throw new Error(t('agent.failedToFetchKeyStatus'))
-      }
-      const data: KeysStatusResponse = await response.json()
-      setKeysStatus(data.keys)
-      setConfigPath(data.configPath)
-    } catch (err) {
-      setError(err instanceof Error ? err.message : t('agent.failedToConnect'))
-    } finally {
-      setLoading(false)
-    }
-  }, [t])
-
-  useEffect(() => {
-    if (isOpen) {
-      fetchKeysStatus()
-    }
-  }, [isOpen, fetchKeysStatus])
 
   const handleSaveKey = async (provider: string) => {
     if (!newKeyValue.trim()) return

--- a/web/src/components/agent/agentSelectorUtils.ts
+++ b/web/src/components/agent/agentSelectorUtils.ts
@@ -3,20 +3,31 @@ import type { AgentInfo, AgentProvider } from '../../types/agent'
 // Providers that are cluster-based (rendered in bottom section)
 export const CLUSTER_PROVIDER_KEYS: AgentProvider[] = ['kagent', 'kagenti']
 
-// Local LLM runners. Each is registered in the backend agent registry but only
-// reports Available=true when its URL env var is set (or a loopback default
-// applies for Ollama / LM Studio). When they are NOT available, we still want
-// the dropdown to surface them with a link to their install mission so the
-// operator can get from "not set up" to "chatting with a local LLM" without
-// leaving the Console. Keep this map in sync with the provider keys in
-// pkg/agent/provider_local_openai_compat.go.
-export const LOCAL_LLM_INSTALL_MISSIONS: Readonly<Record<string, string>> = Object.freeze({
+// Install mission IDs for local/desktop LLM runners that the agent selector
+// should surface a "Install …" link for when they are not yet reachable.
+//
+// The first block tracks runners registered in
+// pkg/agent/provider_local_openai_compat.go — keep those entries in sync
+// with the ProviderKey* constants in that file.
+//
+// The second block covers runners that are NOT implemented by the local
+// OpenAI-compat provider (open-webui and claude-desktop are each registered
+// by their own provider files) but still need install-mission links in the
+// dropdown. They are listed here so agentSelectorUtils has one source of
+// truth for the dropdown UX.
+//
+// Typed as `Partial<Record<…>>` so indexing with an arbitrary agent name
+// narrows to `string | undefined` and callers are forced to handle the
+// "no mission registered" case (#8255).
+export const LOCAL_LLM_INSTALL_MISSIONS: Readonly<Partial<Record<string, string>>> = Object.freeze({
+  // Registered in pkg/agent/provider_local_openai_compat.go
   ollama: 'install-ollama',
   llamacpp: 'install-llama-cpp',
   localai: 'install-localai',
   vllm: 'install-vllm',
   'lm-studio': 'install-lm-studio',
   rhaiis: 'install-rhaiis',
+  // Registered by their own provider files, listed here for the dropdown
   'open-webui': 'install-open-webui',
   'claude-desktop': 'install-claude-desktop',
 })


### PR DESCRIPTION
Fixes #8255, Fixes #8259

## Summary

Addresses all 9 Copilot review comments across PRs #8248 and #8256 for the local LLM provider feature:

**Backend (Go)**
- `ensureLocalLLMPlaceholderKey` now stores the sentinel in ConfigManager's in-memory map (`SetAPIKeyInMemory`) instead of persisting to `~/.kc/config.yaml`, eliminating disk side-effects on read-only filesystems
- `IsAvailable()` only returns true when operator explicitly set env var or config override — compiled-in loopback defaults (Ollama, LM Studio) no longer auto-report as available
- `handleGetKeysStatus`: `Configured` is now URL-driven for local LLM runners; `BaseURL` resolves through compiled-in defaults so the UI always shows the effective endpoint
- `handleSetKey`: new `ClearBaseURL` field allows reverting a base URL override to compiled-in default without hitting the "missing field" guard
- `HasAPIKey` deliberately excludes in-memory sentinels so local runners are not falsely reported as "configured"

**Frontend (TypeScript)**
- `LOCAL_LLM_INSTALL_MISSIONS` typed as `Partial<Record<string, string>>` so indexing returns `string | undefined` — callers forced to handle missing case
- Comment clarifies which entries track `provider_local_openai_compat.go` vs other provider files
- `fetchKeysStatus` moved before `handleSaveBaseURL` and added to its `useCallback` dependency array to prevent stale closure capture

## Test plan

- [x] `go build ./...` passes
- [x] `npm run build` passes
- [x] `npm run lint` passes
- [ ] Manual: Settings → API Keys shows "default" source for Ollama/LM Studio BaseURL
- [ ] Manual: Save a custom BaseURL, then clear it — reverts to compiled-in default