### PR TITLE
🐛 fix: NPS NaN guard + stale fetchKeysStatus closure (#8263, #8259)

### DIFF
--- a/web/src/hooks/useNPSSurvey.ts
+++ b/web/src/hooks/useNPSSurvey.ts
@@ -81,7 +81,8 @@ export function useNPSSurvey(): NPSSurveyState {
   // explicitly submitted by the user.
   useEffect(() => {
     // Session threshold guard
-    const sessionCount = parseInt(safeGetItem(STORAGE_KEY_SESSION_COUNT) || '0', 10)
+    const rawCount = parseInt(safeGetItem(STORAGE_KEY_SESSION_COUNT) || '0', 10)
+    const sessionCount = Number.isFinite(rawCount) ? rawCount : 0
     if (sessionCount < MIN_SESSIONS_BEFORE_NPS) return
 
     // Timing guard


### PR DESCRIPTION
## Summary
- **NPS NaN guard** (#8263): `parseInt` on a corrupted localStorage value yields `NaN`, which passes the `< MIN_SESSIONS_BEFORE_NPS` check (since `NaN < 2` is `false`), incorrectly showing the NPS survey to first-time visitors. Now guarded with `Number.isFinite`.
- **Stale closure** (#8259): `handleSaveBaseURL` in `APIKeySettings.tsx` called `fetchKeysStatus()` but omitted it from `useCallback` deps, risking a stale closure after `t` (translation) changes. Added to dependency array.

Fixes #8263, Fixes #8259