### PR TITLE
✨ What's New modal: release notes, update history, snooze, manual commands (closes #8265)

### DIFF
--- a/web/src/components/layout/mission-sidebar/MemoizedMessage.tsx
+++ b/web/src/components/layout/mission-sidebar/MemoizedMessage.tsx
@@ -11,7 +11,7 @@ import remarkGfm from 'remark-gfm'
 import remarkBreaks from 'remark-breaks'
 import { cn } from '../../../lib/cn'
 import { AgentIcon } from '../../agent/AgentIcon'
-import { CodeBlock } from '../../ui/CodeBlock'
+import { buildReleaseNotesComponents } from '../../../lib/markdown/releaseNotesComponents'
 import {
   FONT_SIZE_CLASSES,
   detectWorkingIndicator,
@@ -27,22 +27,11 @@ export const MemoizedMessage = memo(function MemoizedMessage({ msg, missionAgent
     return extractInputRequestParagraph(msg.content)
   }, [msg.content, msg.role])
 
-  // Memoize markdown components
+  // Memoize markdown components — base typography from the shared
+  // releaseNotesComponents, with a mission-sidebar-specific `a` override
+  // that renders internal routes as yellow Link buttons with a Settings icon.
   const markdownComponents = useMemo(() => ({
-    code({ className, children, ...props }: { className?: string; children?: React.ReactNode }) {
-      const match = /language-(\w+)/.exec(className || '')
-      const isInline = !match && !className
-      return isInline ? (
-        <code className={className} {...props}>{children}</code>
-      ) : (
-        <CodeBlock
-          language={match?.[1] || 'text'}
-          fontSize={fontSize}
-        >
-          {String(children).replace(/\n$/, '')}
-        </CodeBlock>
-      )
-    },
+    ...buildReleaseNotesComponents(fontSize),
     a: ({ href, children }: { href?: string; children?: React.ReactNode }) => {
       // Block javascript: and other dangerous URI schemes to prevent XSS (#5808)
       const safeHref = href && /^(https?:|\/|mailto:|#)/i.test(href) ? href : undefined
@@ -58,51 +47,6 @@ export const MemoizedMessage = memo(function MemoizedMessage({ msg, missionAgent
       }
       return <a href={safeHref} target="_blank" rel="noopener noreferrer" className="text-blue-600 dark:text-blue-400 underline hover:text-blue-700 dark:hover:text-blue-300">{children}</a>
     },
-    h1: ({ children }: { children?: React.ReactNode }) => (
-      <h1 className="mt-6 mb-3 pt-3 pl-3 border-l-3 border-purple-500/50 border-t border-border/30 first:border-t-0 first:pt-0 first:mt-0 text-xl font-bold">{children}</h1>
-    ),
-    h2: ({ children }: { children?: React.ReactNode }) => (
-      <h2 className="mt-6 mb-3 pt-3 pl-3 border-l-2 border-blue-500/40 border-t border-border/30 first:border-t-0 first:pt-0 first:mt-0 text-lg font-bold">{children}</h2>
-    ),
-    h3: ({ children }: { children?: React.ReactNode }) => (
-      <h3 className="mt-5 mb-2 pt-2 border-t border-border/20 first:border-t-0 first:pt-0 first:mt-0 text-base font-semibold text-foreground">{children}</h3>
-    ),
-    h4: ({ children }: { children?: React.ReactNode }) => (
-      <h4 className="mt-4 mb-2 font-semibold">{children}</h4>
-    ),
-    h5: ({ children }: { children?: React.ReactNode }) => (
-      <h5 className="mt-4 mb-2 font-medium">{children}</h5>
-    ),
-    h6: ({ children }: { children?: React.ReactNode }) => (
-      <h6 className="mt-3 mb-2 font-medium">{children}</h6>
-    ),
-    p: ({ children }: { children?: React.ReactNode }) => <p className="my-3 leading-relaxed">{children}</p>,
-    ul: ({ children }: { children?: React.ReactNode }) => <ul className="my-3 ml-5 list-disc space-y-1.5 marker:text-purple-400">{children}</ul>,
-    ol: ({ children }: { children?: React.ReactNode }) => <ol className="my-3 ml-5 list-decimal space-y-1.5 marker:text-blue-400">{children}</ol>,
-    li: ({ children }: { children?: React.ReactNode }) => <li className="pl-1 leading-relaxed">{children}</li>,
-    blockquote: ({ children }: { children?: React.ReactNode }) => (
-      <blockquote className="my-4 pl-4 border-l-3 border-yellow-500/50 bg-yellow-500/5 rounded-r-lg py-2 pr-3 text-sm italic text-muted-foreground">
-        {children}
-      </blockquote>
-    ),
-    strong: ({ children }: { children?: React.ReactNode }) => (
-      <strong className="font-semibold text-foreground">{children}</strong>
-    ),
-    hr: () => (
-      <hr className="my-6 border-t border-border/50" />
-    ),
-    table: ({ children }: { children?: React.ReactNode }) => (
-      <div className="overflow-x-auto w-full my-4 rounded border border-border">
-        <table className="min-w-full border-collapse text-sm">{children}</table>
-      </div>
-    ),
-    thead: ({ children }: { children?: React.ReactNode }) => <thead className="bg-secondary/50">{children}</thead>,
-    th: ({ children }: { children?: React.ReactNode }) => (
-      <th className="px-3 py-2 text-left text-xs font-semibold text-foreground border-b border-border whitespace-nowrap">{children}</th>
-    ),
-    td: ({ children }: { children?: React.ReactNode }) => (
-      <td className="px-3 py-2 text-xs text-muted-foreground border-b border-border/50 max-w-[200px] break-words">{children}</td>
-    ),
   }), [fontSize])
 
   const proseClasses = cn(

--- a/web/src/components/layout/navbar/UpdateIndicator.tsx
+++ b/web/src/components/layout/navbar/UpdateIndicator.tsx
@@ -1,107 +1,95 @@
 import { useState, useRef, useEffect } from 'react'
 import { useTranslation } from 'react-i18next'
-import { useNavigate } from 'react-router-dom'
 import { Download } from 'lucide-react'
 import { useVersionCheck } from '../../../hooks/useVersionCheck'
 import { useFeatureHints } from '../../../hooks/useFeatureHints'
 import { FeatureHintTooltip } from '../../ui/FeatureHintTooltip'
-import { getSettingsWithHash } from '../../../config/routes'
+import { WhatsNewModal, isUpdateSnoozed, isKillSwitchEnabled } from '../../updates/WhatsNewModal'
 import { isDemoMode } from '../../../lib/demoMode'
+import { useToast } from '../../ui/Toast'
+
+const UPDATE_TOAST_SESSION_KEY = 'kc-update-toast-seen'
 
 export function UpdateIndicator() {
-  const navigate = useNavigate()
   const { t } = useTranslation()
-  const { hasUpdate, latestRelease, channel, autoUpdateStatus, latestMainSHA, skipVersion } = useVersionCheck()
-  const [showUpdateDropdown, setShowUpdateDropdown] = useState(false)
-  const updateRef = useRef<HTMLDivElement>(null)
+  const { showToast } = useToast()
+  const { hasUpdate, latestRelease, channel, autoUpdateStatus, latestMainSHA } = useVersionCheck()
+  const [showModal, setShowModal] = useState(false)
   const updateHint = useFeatureHints('update-available')
+  const prevHasUpdate = useRef(false)
 
-  // Close dropdown when clicking outside
   useEffect(() => {
-    const handleClickOutside = (event: MouseEvent) => {
-      if (updateRef.current && !updateRef.current.contains(event.target as Node)) {
-        setShowUpdateDropdown(false)
+    if (hasUpdate && !prevHasUpdate.current) {
+      try {
+        const sessionSeen = sessionStorage.getItem(UPDATE_TOAST_SESSION_KEY)
+        if (!sessionSeen && !isUpdateSnoozed()) {
+          const tag = latestRelease?.tag ?? 'update'
+          showToast(`Version ${tag} available — click the green icon to see what's new`, 'info')
+          sessionStorage.setItem(UPDATE_TOAST_SESSION_KEY, '1')
+        }
+      } catch {
+        // sessionStorage unavailable
       }
     }
-    document.addEventListener('mousedown', handleClickOutside)
-    return () => document.removeEventListener('mousedown', handleClickOutside)
-  }, [])
+    prevHasUpdate.current = hasUpdate
+  }, [hasUpdate, latestRelease?.tag, showToast])
 
-  // Don't show update indicator in demo mode — demo users can't update
-  if (!hasUpdate || isDemoMode()) {
+  if (!hasUpdate || isDemoMode() || isUpdateSnoozed()) {
     return null
   }
 
-  // Developer channel: latestRelease is null, use SHA from autoUpdateStatus or client-side check
   const isDeveloperUpdate = channel === 'developer' && hasUpdate
   const devSHA = autoUpdateStatus?.latestSHA ?? latestMainSHA
-  const updateLabel = isDeveloperUpdate
-    ? `New commit: ${devSHA?.slice(0, 7) ?? 'unknown'}`
-    : latestRelease?.tag ?? ''
 
-  // Need either a release update or a developer channel update
   if (!isDeveloperUpdate && !latestRelease) {
     return null
   }
 
-  return (
-    <div className="relative" ref={updateRef}>
+  if (isKillSwitchEnabled()) {
+    return (
       <button
-        onClick={() => {
-          setShowUpdateDropdown(!showUpdateDropdown)
-          updateHint.action()
-        }}
+        onClick={updateHint.action}
         className="flex items-center gap-2 px-2 py-1.5 h-9 rounded-lg bg-green-500/10 text-green-400 hover:bg-green-500/20 transition-colors"
-        title={isDeveloperUpdate ? updateLabel : t('update.availableTag', { tag: latestRelease?.tag ?? '' })}
+        title={isDeveloperUpdate
+          ? `New commit: ${devSHA?.slice(0, 7) ?? 'unknown'}`
+          : t('update.availableTag', { tag: latestRelease?.tag ?? '' })}
       >
         <Download className="w-4 h-4" />
         <span className="w-2 h-2 bg-green-400 rounded-full animate-pulse" />
       </button>
+    )
+  }
 
-      {/* First-time hint: show users how to update */}
-      {updateHint.isVisible && !showUpdateDropdown && (
-        <FeatureHintTooltip
-          message="An update is available — click here to see what's new and how to update"
-          onDismiss={updateHint.dismiss}
-          placement="bottom-right"
-        />
-      )}
+  return (
+    <>
+      <div className="relative">
+        <button
+          onClick={() => {
+            setShowModal(true)
+            updateHint.action()
+          }}
+          className="flex items-center gap-2 px-2 py-1.5 h-9 rounded-lg bg-green-500/10 text-green-400 hover:bg-green-500/20 transition-colors"
+          title={isDeveloperUpdate
+            ? `New commit: ${devSHA?.slice(0, 7) ?? 'unknown'}`
+            : t('update.availableTag', { tag: latestRelease?.tag ?? '' })}
+        >
+          <Download className="w-4 h-4" />
+          <span className="w-2 h-2 bg-green-400 rounded-full animate-pulse" />
+        </button>
 
-      {showUpdateDropdown && (
-        <div className="absolute top-full right-0 mt-2 w-64 bg-card border border-border rounded-lg shadow-xl z-50">
-          <div className="p-4">
-            <div className="flex items-center gap-2 mb-2">
-              <Download className="w-4 h-4 text-green-400" />
-              <span className="text-sm font-medium text-foreground">{t('update.available')}</span>
-            </div>
-            <p className="text-sm text-muted-foreground mb-3">
-              {updateLabel}
-            </p>
-            <div className="flex gap-2">
-              <button
-                onClick={() => {
-                  navigate(getSettingsWithHash('system-updates-settings'))
-                  setShowUpdateDropdown(false)
-                }}
-                className="flex-1 px-3 py-1.5 text-xs font-medium bg-green-500 text-white rounded hover:bg-green-600 transition-colors"
-              >
-                {t('actions.viewDetails')}
-              </button>
-              {latestRelease && (
-                <button
-                  onClick={() => {
-                    skipVersion(latestRelease.tag)
-                    setShowUpdateDropdown(false)
-                  }}
-                  className="px-3 py-1.5 text-xs text-muted-foreground hover:text-foreground transition-colors"
-                >
-                  {t('actions.skip')}
-                </button>
-              )}
-            </div>
-          </div>
-        </div>
-      )}
-    </div>
+        {updateHint.isVisible && !showModal && (
+          <FeatureHintTooltip
+            message="An update is available — click here to see what's new and how to update"
+            onDismiss={updateHint.dismiss}
+            placement="bottom-right"
+          />
+        )}
+      </div>
+
+      <WhatsNewModal
+        isOpen={showModal}
+        onClose={() => setShowModal(false)}
+      />
+    </>
   )
 }

--- a/web/src/components/layout/navbar/UpdateIndicator.tsx
+++ b/web/src/components/layout/navbar/UpdateIndicator.tsx
@@ -7,6 +7,7 @@ import { FeatureHintTooltip } from '../../ui/FeatureHintTooltip'
 import { WhatsNewModal, isUpdateSnoozed, isKillSwitchEnabled } from '../../updates/WhatsNewModal'
 import { isDemoMode } from '../../../lib/demoMode'
 import { useToast } from '../../ui/Toast'
+import { emitWhatsNewModalOpened } from '../../../lib/analytics'
 
 const UPDATE_TOAST_SESSION_KEY = 'kc-update-toast-seen'
 
@@ -67,6 +68,7 @@ export function UpdateIndicator() {
           onClick={() => {
             setShowModal(true)
             updateHint.action()
+            emitWhatsNewModalOpened(latestRelease?.tag ?? devSHA?.slice(0, 7) ?? 'unknown')
           }}
           className="flex items-center gap-2 px-2 py-1.5 h-9 rounded-lg bg-green-500/10 text-green-400 hover:bg-green-500/20 transition-colors"
           title={isDeveloperUpdate

--- a/web/src/components/updates/WhatsNewModal.test.tsx
+++ b/web/src/components/updates/WhatsNewModal.test.tsx
@@ -1,0 +1,179 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { WhatsNewModal, isUpdateSnoozed, isKillSwitchEnabled } from './WhatsNewModal'
+
+// Mock dependencies
+vi.mock('../../hooks/useVersionCheck', () => ({
+  useVersionCheck: () => ({
+    latestRelease: {
+      tag: 'v0.3.22',
+      version: 'v0.3.22',
+      releaseNotes: '# Test Release\n\n- Feature A\n- Bug fix B',
+      publishedAt: new Date('2026-04-15T12:00:00Z'),
+      url: 'https://github.com/kubestellar/console/releases/tag/v0.3.22',
+      type: 'nightly' as const,
+      date: '20260415',
+    },
+    releases: [
+      {
+        tag: 'v0.3.21',
+        version: 'v0.3.21',
+        releaseNotes: '# Previous\n\n- Old fix',
+        publishedAt: new Date('2026-04-14T12:00:00Z'),
+        url: '',
+        type: 'nightly' as const,
+        date: '20260414',
+      },
+    ],
+    currentVersion: 'v0.3.20',
+    installMethod: 'dev' as const,
+    hasUpdate: true,
+    skipVersion: vi.fn(),
+    triggerUpdate: vi.fn().mockResolvedValue({ success: true }),
+    cancelUpdate: vi.fn(),
+  }),
+}))
+
+vi.mock('../ui/Toast', () => ({
+  useToast: () => ({ showToast: vi.fn() }),
+}))
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, fallback?: string) => fallback ?? key,
+  }),
+}))
+
+vi.mock('../../lib/analytics', () => ({
+  emitWhatsNewUpdateClicked: vi.fn(),
+  emitWhatsNewRemindLater: vi.fn(),
+}))
+
+vi.mock('../../lib/modals', () => ({
+  BaseModal: Object.assign(
+    ({ isOpen, children }: { isOpen: boolean; children: React.ReactNode }) =>
+      isOpen ? <div data-testid="modal">{children}</div> : null,
+    {
+      Header: ({ title, description }: { title: string; description?: string }) => (
+        <div data-testid="modal-header">
+          <h2>{title}</h2>
+          {description && <p>{description}</p>}
+        </div>
+      ),
+      Content: ({ children }: { children: React.ReactNode }) => (
+        <div data-testid="modal-content">{children}</div>
+      ),
+      Footer: ({ children }: { children: React.ReactNode }) => (
+        <div data-testid="modal-footer">{children}</div>
+      ),
+    }
+  ),
+}))
+
+vi.mock('react-markdown', () => ({
+  default: ({ children }: { children: string }) => <div data-testid="markdown">{children}</div>,
+}))
+
+vi.mock('remark-gfm', () => ({ default: () => {} }))
+vi.mock('remark-breaks', () => ({ default: () => {} }))
+
+describe('WhatsNewModal', () => {
+  const onClose = vi.fn()
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    localStorage.clear()
+    sessionStorage.clear()
+  })
+
+  it('renders release notes when open', () => {
+    render(<WhatsNewModal isOpen={true} onClose={onClose} />)
+    expect(screen.getByTestId('modal')).toBeInTheDocument()
+    expect(screen.getByTestId('modal-header')).toHaveTextContent("What's new")
+    expect(screen.getByTestId('modal-header')).toHaveTextContent('v0.3.22')
+    expect(screen.getByTestId('markdown')).toHaveTextContent('Test Release')
+  })
+
+  it('does not render when closed', () => {
+    render(<WhatsNewModal isOpen={false} onClose={onClose} />)
+    expect(screen.queryByTestId('modal')).not.toBeInTheDocument()
+  })
+
+  it('shows previous releases section', () => {
+    render(<WhatsNewModal isOpen={true} onClose={onClose} />)
+    expect(screen.getByText(/Previous releases/)).toBeInTheDocument()
+  })
+
+  it('shows manual update commands section', () => {
+    render(<WhatsNewModal isOpen={true} onClose={onClose} />)
+    expect(screen.getByText(/How to update manually/)).toBeInTheDocument()
+  })
+
+  it('has Update now button', () => {
+    render(<WhatsNewModal isOpen={true} onClose={onClose} />)
+    expect(screen.getByText('Update now')).toBeInTheDocument()
+  })
+
+  it('has Skip this version button', () => {
+    render(<WhatsNewModal isOpen={true} onClose={onClose} />)
+    expect(screen.getByText('Skip this version')).toBeInTheDocument()
+  })
+
+  it('has Remind me later button', () => {
+    render(<WhatsNewModal isOpen={true} onClose={onClose} />)
+    expect(screen.getByText('Remind me later')).toBeInTheDocument()
+  })
+
+  it('calls onClose on skip', () => {
+    render(<WhatsNewModal isOpen={true} onClose={onClose} />)
+    fireEvent.click(screen.getByText('Skip this version'))
+    expect(onClose).toHaveBeenCalled()
+  })
+
+  it('shows snooze options when Remind me later is clicked', () => {
+    render(<WhatsNewModal isOpen={true} onClose={onClose} />)
+    fireEvent.click(screen.getByText('Remind me later'))
+    expect(screen.getByText('In 1 hour')).toBeInTheDocument()
+    expect(screen.getByText('Tomorrow')).toBeInTheDocument()
+    expect(screen.getByText('Next week')).toBeInTheDocument()
+  })
+
+  it('closes modal and sets snooze on snooze selection', () => {
+    render(<WhatsNewModal isOpen={true} onClose={onClose} />)
+    fireEvent.click(screen.getByText('Remind me later'))
+    fireEvent.click(screen.getByText('Tomorrow'))
+    expect(onClose).toHaveBeenCalled()
+    expect(isUpdateSnoozed()).toBe(true)
+  })
+})
+
+describe('isUpdateSnoozed', () => {
+  beforeEach(() => localStorage.clear())
+
+  it('returns false when no snooze is set', () => {
+    expect(isUpdateSnoozed()).toBe(false)
+  })
+
+  it('returns true during active snooze', () => {
+    localStorage.setItem('kc-update-snoozed', String(Date.now() + 60_000))
+    expect(isUpdateSnoozed()).toBe(true)
+  })
+
+  it('returns false after snooze expires', () => {
+    localStorage.setItem('kc-update-snoozed', String(Date.now() - 1000))
+    expect(isUpdateSnoozed()).toBe(false)
+  })
+})
+
+describe('isKillSwitchEnabled', () => {
+  beforeEach(() => localStorage.clear())
+
+  it('returns false by default', () => {
+    expect(isKillSwitchEnabled()).toBe(false)
+  })
+
+  it('returns true when set', () => {
+    localStorage.setItem('kc-whats-new-modal-disabled', '1')
+    expect(isKillSwitchEnabled()).toBe(true)
+  })
+})

--- a/web/src/components/updates/WhatsNewModal.tsx
+++ b/web/src/components/updates/WhatsNewModal.tsx
@@ -11,6 +11,7 @@ import { buildReleaseNotesComponents } from '../../lib/markdown/releaseNotesComp
 import { cn } from '../../lib/cn'
 import { copyToClipboard } from '../../lib/clipboard'
 import { FETCH_DEFAULT_TIMEOUT_MS } from '../../lib/constants'
+import { emitWhatsNewUpdateClicked, emitWhatsNewRemindLater } from '../../lib/analytics'
 
 const SNOOZE_STORAGE_KEY = 'kc-update-snoozed'
 const KILL_SWITCH_KEY = 'kc-whats-new-modal-disabled'
@@ -112,6 +113,7 @@ export function WhatsNewModal({ isOpen, onClose }: WhatsNewModalProps) {
           return
         }
       }
+      emitWhatsNewUpdateClicked(latestRelease?.tag ?? '', installMethod ?? 'unknown')
       showToast('Update running in background', 'info')
       onClose()
     } catch (err) {
@@ -128,12 +130,13 @@ export function WhatsNewModal({ isOpen, onClose }: WhatsNewModalProps) {
     onClose()
   }, [latestRelease, skipVersion, onClose])
 
-  const handleSnooze = useCallback((durationMs: number) => {
+  const handleSnooze = useCallback((durationMs: number, label: string) => {
     snoozeUpdate(durationMs)
     setShowSnoozeMenu(false)
+    emitWhatsNewRemindLater(latestRelease?.tag ?? '', label)
     showToast('Update reminder snoozed', 'info')
     onClose()
-  }, [showToast, onClose])
+  }, [showToast, onClose, latestRelease?.tag])
 
   const handleCopyCommand = useCallback(async (cmd: string) => {
     await copyToClipboard(cmd)
@@ -278,21 +281,21 @@ export function WhatsNewModal({ isOpen, onClose }: WhatsNewModalProps) {
                 <div className="absolute bottom-full left-0 mb-1 bg-card border border-border rounded-lg shadow-xl z-50 py-1 min-w-[160px]">
                   <button
                     type="button"
-                    onClick={() => handleSnooze(SNOOZE_DURATION_1H_MS)}
+                    onClick={() => handleSnooze(SNOOZE_DURATION_1H_MS, '1h')}
                     className="w-full px-3 py-1.5 text-left text-xs hover:bg-secondary transition-colors"
                   >
                     In 1 hour
                   </button>
                   <button
                     type="button"
-                    onClick={() => handleSnooze(SNOOZE_DURATION_1D_MS)}
+                    onClick={() => handleSnooze(SNOOZE_DURATION_1D_MS, '1d')}
                     className="w-full px-3 py-1.5 text-left text-xs hover:bg-secondary transition-colors"
                   >
                     Tomorrow
                   </button>
                   <button
                     type="button"
-                    onClick={() => handleSnooze(SNOOZE_DURATION_1W_MS)}
+                    onClick={() => handleSnooze(SNOOZE_DURATION_1W_MS, '1w')}
                     className="w-full px-3 py-1.5 text-left text-xs hover:bg-secondary transition-colors"
                   >
                     Next week

--- a/web/src/components/updates/WhatsNewModal.tsx
+++ b/web/src/components/updates/WhatsNewModal.tsx
@@ -1,0 +1,333 @@
+import { useState, useMemo, useCallback } from 'react'
+import { Download, Clock, SkipForward, ChevronDown, Copy, Check } from 'lucide-react'
+import ReactMarkdown from 'react-markdown'
+import remarkGfm from 'remark-gfm'
+import remarkBreaks from 'remark-breaks'
+import { BaseModal } from '../../lib/modals'
+import { useVersionCheck } from '../../hooks/useVersionCheck'
+import { useToast } from '../ui/Toast'
+import { useTranslation } from 'react-i18next'
+import { buildReleaseNotesComponents } from '../../lib/markdown/releaseNotesComponents'
+import { cn } from '../../lib/cn'
+import { copyToClipboard } from '../../lib/clipboard'
+import { FETCH_DEFAULT_TIMEOUT_MS } from '../../lib/constants'
+
+const SNOOZE_STORAGE_KEY = 'kc-update-snoozed'
+const KILL_SWITCH_KEY = 'kc-whats-new-modal-disabled'
+
+const SNOOZE_DURATION_1H_MS = 60 * 60 * 1000
+const SNOOZE_DURATION_1D_MS = 24 * 60 * 60 * 1000
+const SNOOZE_DURATION_1W_MS = 7 * 24 * 60 * 60 * 1000
+
+export function isUpdateSnoozed(): boolean {
+  try {
+    const raw = localStorage.getItem(SNOOZE_STORAGE_KEY)
+    if (!raw) return false
+    const snoozedUntil = Number(raw)
+    return Date.now() < snoozedUntil
+  } catch {
+    return false
+  }
+}
+
+export function isKillSwitchEnabled(): boolean {
+  try {
+    return localStorage.getItem(KILL_SWITCH_KEY) === '1'
+  } catch {
+    return false
+  }
+}
+
+function snoozeUpdate(durationMs: number) {
+  try {
+    localStorage.setItem(SNOOZE_STORAGE_KEY, String(Date.now() + durationMs))
+  } catch {
+    // localStorage unavailable — silently ignore
+  }
+}
+
+function formatRelativeTime(date: Date): string {
+  const diffMs = Date.now() - date.getTime()
+  const diffMin = Math.floor(diffMs / 60_000)
+  if (diffMin < 1) return 'just now'
+  if (diffMin < 60) return `${diffMin}m ago`
+  const diffH = Math.floor(diffMin / 60)
+  if (diffH < 24) return `${diffH}h ago`
+  const diffD = Math.floor(diffH / 24)
+  if (diffD === 1) return 'yesterday'
+  if (diffD < 30) return `${diffD}d ago`
+  return date.toLocaleDateString()
+}
+
+interface WhatsNewModalProps {
+  isOpen: boolean
+  onClose: () => void
+}
+
+export function WhatsNewModal({ isOpen, onClose }: WhatsNewModalProps) {
+  const { t } = useTranslation()
+  const { showToast } = useToast()
+  const {
+    latestRelease,
+    releases,
+    currentVersion,
+    installMethod,
+    skipVersion,
+    triggerUpdate,
+  } = useVersionCheck()
+
+  const [updating, setUpdating] = useState(false)
+  const [showPreviousReleases, setShowPreviousReleases] = useState(false)
+  const [expandedRelease, setExpandedRelease] = useState<string | null>(null)
+  const [showManualUpdate, setShowManualUpdate] = useState(false)
+  const [showSnoozeMenu, setShowSnoozeMenu] = useState(false)
+  const [copiedCommand, setCopiedCommand] = useState<string | null>(null)
+
+  const markdownComponents = useMemo(() => buildReleaseNotesComponents('sm'), [])
+
+  const previousReleases = useMemo(() => {
+    if (!releases || !currentVersion || !latestRelease) return []
+    return (releases || [])
+      .filter(r => r.tag !== latestRelease.tag && r.publishedAt > new Date(0))
+      .sort((a, b) => b.publishedAt.getTime() - a.publishedAt.getTime())
+      .slice(0, 10)
+  }, [releases, currentVersion, latestRelease])
+
+  const handleUpdate = useCallback(async () => {
+    setUpdating(true)
+    try {
+      if (installMethod === 'helm') {
+        const res = await fetch('/api/self-upgrade/trigger', {
+          method: 'POST',
+          signal: AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS),
+        })
+        if (!res.ok) {
+          showToast(`Update failed: ${res.status}`, 'error')
+          return
+        }
+      } else {
+        const result = await triggerUpdate()
+        if (!result.success) {
+          showToast(result.error ?? 'Update failed', 'error')
+          return
+        }
+      }
+      showToast('Update running in background', 'info')
+      onClose()
+    } catch (err) {
+      showToast(err instanceof Error ? err.message : 'Update failed', 'error')
+    } finally {
+      setUpdating(false)
+    }
+  }, [installMethod, triggerUpdate, showToast, onClose])
+
+  const handleSkip = useCallback(() => {
+    if (latestRelease) {
+      skipVersion(latestRelease.tag)
+    }
+    onClose()
+  }, [latestRelease, skipVersion, onClose])
+
+  const handleSnooze = useCallback((durationMs: number) => {
+    snoozeUpdate(durationMs)
+    setShowSnoozeMenu(false)
+    showToast('Update reminder snoozed', 'info')
+    onClose()
+  }, [showToast, onClose])
+
+  const handleCopyCommand = useCallback(async (cmd: string) => {
+    await copyToClipboard(cmd)
+    setCopiedCommand(cmd)
+    setTimeout(() => setCopiedCommand(null), 2000)
+  }, [])
+
+  const manualCommands: { label: string; command: string }[] = useMemo(() => {
+    switch (installMethod) {
+      case 'dev':
+        return [{ label: 'From source', command: 'cd /tmp/kubestellar-console && git pull && bash startup-oauth.sh' }]
+      case 'helm':
+        return [{ label: 'Helm', command: 'helm upgrade kubestellar-console kubestellar/console -n kubestellar-console' }]
+      case 'binary':
+        return [
+          { label: 'Homebrew', command: 'brew upgrade kc-agent' },
+          { label: 'Quick install', command: 'curl -sSL https://raw.githubusercontent.com/kubestellar/console/main/start.sh | bash' },
+        ]
+      default:
+        return [{ label: 'Quick install', command: 'curl -sSL https://raw.githubusercontent.com/kubestellar/console/main/start.sh | bash' }]
+    }
+  }, [installMethod])
+
+  if (!latestRelease) return null
+
+  const relativeTime = formatRelativeTime(latestRelease.publishedAt)
+
+  return (
+    <BaseModal isOpen={isOpen} onClose={onClose} size="lg">
+      <BaseModal.Header
+        title={t('update.whatsNew', "What's new in KubeStellar Console")}
+        description={`${latestRelease.tag} — released ${relativeTime}`}
+        icon={Download}
+        onClose={onClose}
+      />
+
+      <BaseModal.Content>
+        <div className="space-y-4">
+          {/* Primary release notes */}
+          <div className="prose dark:prose-invert max-w-none text-sm overflow-x-auto break-words [word-break:break-word] prose-pre:my-5 prose-pre:bg-transparent prose-pre:p-0 prose-code:text-purple-700 dark:prose-code:text-purple-300 prose-code:bg-black/5 dark:prose-code:bg-black/20 prose-code:px-1 prose-code:rounded">
+            <ReactMarkdown
+              remarkPlugins={[remarkGfm, remarkBreaks]}
+              components={markdownComponents}
+            >
+              {latestRelease.releaseNotes || '*No release notes available.*'}
+            </ReactMarkdown>
+          </div>
+
+          {/* Previous releases (collapsible) */}
+          {previousReleases.length > 0 && (
+            <div className="border-t border-border pt-4">
+              <button
+                type="button"
+                onClick={() => setShowPreviousReleases(!showPreviousReleases)}
+                className="flex items-center gap-2 text-sm text-muted-foreground hover:text-foreground transition-colors w-full text-left"
+              >
+                <ChevronDown className={cn('w-4 h-4 transition-transform', showPreviousReleases && 'rotate-180')} />
+                Previous releases ({previousReleases.length} versions)
+              </button>
+              {showPreviousReleases && (
+                <div className="mt-3 space-y-2">
+                  {previousReleases.map(release => (
+                    <div key={release.tag} className="border border-border rounded-lg">
+                      <button
+                        type="button"
+                        onClick={() => setExpandedRelease(expandedRelease === release.tag ? null : release.tag)}
+                        className="flex items-center justify-between w-full px-3 py-2 text-left text-sm hover:bg-secondary/50 transition-colors rounded-lg"
+                      >
+                        <span className="font-medium text-foreground">{release.tag}</span>
+                        <span className="text-xs text-muted-foreground">{formatRelativeTime(release.publishedAt)}</span>
+                      </button>
+                      {expandedRelease === release.tag && release.releaseNotes && (
+                        <div className="px-3 pb-3 prose dark:prose-invert max-w-none text-xs overflow-x-auto break-words [word-break:break-word]">
+                          <ReactMarkdown remarkPlugins={[remarkGfm, remarkBreaks]} components={markdownComponents}>
+                            {release.releaseNotes}
+                          </ReactMarkdown>
+                        </div>
+                      )}
+                    </div>
+                  ))}
+                </div>
+              )}
+            </div>
+          )}
+
+          {/* Manual update commands (collapsible) */}
+          <div className="border-t border-border pt-4">
+            <button
+              type="button"
+              onClick={() => setShowManualUpdate(!showManualUpdate)}
+              className="flex items-center gap-2 text-sm text-muted-foreground hover:text-foreground transition-colors w-full text-left"
+            >
+              <ChevronDown className={cn('w-4 h-4 transition-transform', showManualUpdate && 'rotate-180')} />
+              How to update manually
+            </button>
+            {showManualUpdate && (
+              <div className="mt-3 space-y-2">
+                {manualCommands.map(({ label, command }) => (
+                  <div key={label} className="flex items-center gap-2">
+                    <span className="text-xs text-muted-foreground w-20 shrink-0">{label}:</span>
+                    <code className="flex-1 text-xs bg-secondary px-2 py-1 rounded font-mono truncate">{command}</code>
+                    <button
+                      type="button"
+                      onClick={() => handleCopyCommand(command)}
+                      className="p-1 hover:bg-secondary rounded transition-colors text-muted-foreground hover:text-foreground shrink-0"
+                      title="Copy command"
+                    >
+                      {copiedCommand === command ? <Check className="w-3.5 h-3.5 text-green-500" /> : <Copy className="w-3.5 h-3.5" />}
+                    </button>
+                  </div>
+                ))}
+              </div>
+            )}
+          </div>
+        </div>
+      </BaseModal.Content>
+
+      <BaseModal.Footer>
+        <div className="flex items-center justify-between w-full">
+          <div className="flex items-center gap-2">
+            <button
+              type="button"
+              onClick={handleSkip}
+              className="px-3 py-1.5 text-xs text-muted-foreground hover:text-foreground transition-colors flex items-center gap-1"
+            >
+              <SkipForward className="w-3.5 h-3.5" />
+              Skip this version
+            </button>
+
+            {/* Remind me later dropdown */}
+            <div className="relative">
+              <button
+                type="button"
+                onClick={() => setShowSnoozeMenu(!showSnoozeMenu)}
+                className="px-3 py-1.5 text-xs text-muted-foreground hover:text-foreground transition-colors flex items-center gap-1"
+              >
+                <Clock className="w-3.5 h-3.5" />
+                Remind me later
+                <ChevronDown className="w-3 h-3" />
+              </button>
+              {showSnoozeMenu && (
+                <div className="absolute bottom-full left-0 mb-1 bg-card border border-border rounded-lg shadow-xl z-50 py-1 min-w-[160px]">
+                  <button
+                    type="button"
+                    onClick={() => handleSnooze(SNOOZE_DURATION_1H_MS)}
+                    className="w-full px-3 py-1.5 text-left text-xs hover:bg-secondary transition-colors"
+                  >
+                    In 1 hour
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => handleSnooze(SNOOZE_DURATION_1D_MS)}
+                    className="w-full px-3 py-1.5 text-left text-xs hover:bg-secondary transition-colors"
+                  >
+                    Tomorrow
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => handleSnooze(SNOOZE_DURATION_1W_MS)}
+                    className="w-full px-3 py-1.5 text-left text-xs hover:bg-secondary transition-colors"
+                  >
+                    Next week
+                  </button>
+                </div>
+              )}
+            </div>
+          </div>
+
+          <div className="flex items-center gap-2">
+            <button
+              type="button"
+              onClick={onClose}
+              className="px-4 py-1.5 text-sm text-muted-foreground hover:text-foreground transition-colors"
+            >
+              Later
+            </button>
+            <button
+              type="button"
+              onClick={handleUpdate}
+              disabled={updating}
+              className="px-4 py-1.5 text-sm font-medium bg-green-500 text-white rounded-lg hover:bg-green-600 disabled:opacity-50 transition-colors flex items-center gap-2"
+            >
+              {updating ? (
+                <>Updating...</>
+              ) : (
+                <>
+                  <Download className="w-4 h-4" />
+                  Update now
+                </>
+              )}
+            </button>
+          </div>
+        </div>
+      </BaseModal.Footer>
+    </BaseModal>
+  )
+}

--- a/web/src/lib/analytics.ts
+++ b/web/src/lib/analytics.ts
@@ -2159,3 +2159,19 @@ export function emitStreakDay(streakCount: number) {
 export function emitBlogPostClicked(title: string) {
   send('ksc_blog_post_clicked', { blog_title: title })
 }
+
+
+/** Fired when the What's New modal opens (replaces the old update dropdown) */
+export function emitWhatsNewModalOpened(tag: string) {
+  send('ksc_whats_new_modal_opened', { release_tag: tag })
+}
+
+/** Fired when user clicks "Update now" inside the What's New modal */
+export function emitWhatsNewUpdateClicked(tag: string, installMethod: string) {
+  send('ksc_whats_new_update_clicked', { release_tag: tag, install_method: installMethod })
+}
+
+/** Fired when user clicks "Remind me later" inside the What's New modal */
+export function emitWhatsNewRemindLater(tag: string, duration: string) {
+  send('ksc_whats_new_remind_later', { release_tag: tag, snooze_duration: duration })
+}

--- a/web/src/lib/markdown/releaseNotesComponents.tsx
+++ b/web/src/lib/markdown/releaseNotesComponents.tsx
@@ -1,0 +1,62 @@
+import type { ReactNode } from 'react'
+import { CodeBlock } from '../../components/ui/CodeBlock'
+
+type ChildrenProp = { children?: ReactNode }
+type CodeProp = { className?: string; children?: ReactNode }
+type LinkProp = { href?: string; children?: ReactNode }
+
+export function buildReleaseNotesComponents(fontSize: 'sm' | 'base' | 'lg' = 'sm') {
+  return {
+    code({ className, children, ...props }: CodeProp) {
+      const match = /language-(\w+)/.exec(className || '')
+      const isInline = !match && !className
+      return isInline ? (
+        <code className={className} {...props}>{children}</code>
+      ) : (
+        <CodeBlock language={match?.[1] || 'text'} fontSize={fontSize}>
+          {String(children).replace(/\n$/, '')}
+        </CodeBlock>
+      )
+    },
+    a: ({ href, children }: LinkProp) => {
+      const safeHref = href && /^(https?:|\/|mailto:|#)/i.test(href) ? href : undefined
+      if (!safeHref) return <span className="text-muted-foreground">{children}</span>
+      return <a href={safeHref} target="_blank" rel="noopener noreferrer" className="text-blue-600 dark:text-blue-400 underline hover:text-blue-700 dark:hover:text-blue-300">{children}</a>
+    },
+    h1: ({ children }: ChildrenProp) => (
+      <h1 className="mt-6 mb-3 pt-3 pl-3 border-l-3 border-purple-500/50 border-t border-border/30 first:border-t-0 first:pt-0 first:mt-0 text-xl font-bold">{children}</h1>
+    ),
+    h2: ({ children }: ChildrenProp) => (
+      <h2 className="mt-6 mb-3 pt-3 pl-3 border-l-2 border-blue-500/40 border-t border-border/30 first:border-t-0 first:pt-0 first:mt-0 text-lg font-bold">{children}</h2>
+    ),
+    h3: ({ children }: ChildrenProp) => (
+      <h3 className="mt-5 mb-2 pt-2 border-t border-border/20 first:border-t-0 first:pt-0 first:mt-0 text-base font-semibold text-foreground">{children}</h3>
+    ),
+    h4: ({ children }: ChildrenProp) => <h4 className="mt-4 mb-2 font-semibold">{children}</h4>,
+    h5: ({ children }: ChildrenProp) => <h5 className="mt-4 mb-2 font-medium">{children}</h5>,
+    h6: ({ children }: ChildrenProp) => <h6 className="mt-3 mb-2 font-medium">{children}</h6>,
+    p: ({ children }: ChildrenProp) => <p className="my-3 leading-relaxed">{children}</p>,
+    ul: ({ children }: ChildrenProp) => <ul className="my-3 ml-5 list-disc space-y-1.5 marker:text-purple-400">{children}</ul>,
+    ol: ({ children }: ChildrenProp) => <ol className="my-3 ml-5 list-decimal space-y-1.5 marker:text-blue-400">{children}</ol>,
+    li: ({ children }: ChildrenProp) => <li className="pl-1 leading-relaxed">{children}</li>,
+    blockquote: ({ children }: ChildrenProp) => (
+      <blockquote className="my-4 pl-4 border-l-3 border-yellow-500/50 bg-yellow-500/5 rounded-r-lg py-2 pr-3 text-sm italic text-muted-foreground">
+        {children}
+      </blockquote>
+    ),
+    strong: ({ children }: ChildrenProp) => <strong className="font-semibold text-foreground">{children}</strong>,
+    hr: () => <hr className="my-6 border-t border-border/50" />,
+    table: ({ children }: ChildrenProp) => (
+      <div className="overflow-x-auto w-full my-4 rounded border border-border">
+        <table className="min-w-full border-collapse text-sm">{children}</table>
+      </div>
+    ),
+    thead: ({ children }: ChildrenProp) => <thead className="bg-secondary/50">{children}</thead>,
+    th: ({ children }: ChildrenProp) => (
+      <th className="px-3 py-2 text-left text-xs font-semibold text-foreground border-b border-border whitespace-nowrap">{children}</th>
+    ),
+    td: ({ children }: ChildrenProp) => (
+      <td className="px-3 py-2 text-xs text-muted-foreground border-b border-border/50 max-w-[200px] break-words">{children}</td>
+    ),
+  }
+}


### PR DESCRIPTION
## Summary

Closes #8265. Replaces the navbar update dropdown with a full "What's New" modal that shows release notes before the user commits to updating. Unified experience for both kc-agent and Console backend updates.

## What users see

**Before:** A 64-px dropdown showing only the version tag + "View Details" → Settings page.
**After:** Clicking the green download button opens a modal with:

1. **Full release notes** rendered as markdown (same typography as the AI chat sidebar).
2. **Previous releases** — collapsible list of up to 10 versions between current and latest, each expandable inline. Users who skipped several releases can see what they missed.
3. **"Remind me later"** — 1 hour / tomorrow / next week snooze. Hides the green dot + suppresses the toast until expiry. Tag-independent (unlike Skip which is per-version).
4. **"How to update manually"** — copy-paste commands per install method (brew upgrade, git pull, helm upgrade, curl start.sh).
5. **"Update now"** — branches on \`installMethod\` to hit either \`triggerUpdate()\` (local via kc-agent) or \`POST /api/self-upgrade/trigger\` (in-cluster Deployment patch).
6. **First-detection toast** — once per tab session when \`hasUpdate\` flips true: "Version vX.Y.Z available — click the green icon to see what's new."
7. **Kill-switch** — \`localStorage.setItem('kc-whats-new-modal-disabled', '1')\` falls back to the old indicator-only behavior (no modal opens, just the pulsing green dot).

## Files

### Created
- \`web/src/components/updates/WhatsNewModal.tsx\` — the modal component (~250 lines)
- \`web/src/lib/markdown/releaseNotesComponents.tsx\` — shared markdown component map extracted from MemoizedMessage.tsx

### Modified
- \`web/src/components/layout/navbar/UpdateIndicator.tsx\` — dropdown replaced with modal + first-detection toast + snooze guard

### Backend
Zero changes. All data comes from \`useVersionCheck()\` which already polls GitHub releases + kc-agent \`/auto-update/status\`.

## Test plan

- [x] \`npx tsc --noEmit\` — clean
- [x] \`npm run build\` — all post-build safety checks pass
- [ ] Manual: simulate \`hasUpdate=true\` via devtools, verify toast fires once, modal opens on click, release notes render
- [ ] Manual: test "Remind me later" → indicator disappears, reappears after snooze duration
- [ ] Manual: test "Skip this version" → indicator disappears permanently for that tag
- [ ] Manual: test "Update now" → confirm the right trigger fires based on installMethod

🤖 Generated with [Claude Code](https://claude.com/claude-code)