### PR TITLE
🐛 fix: add ACMM dashboard to sidebar navigation (#8260)

### DIFF
--- a/web/src/hooks/useSidebarConfig.ts
+++ b/web/src/hooks/useSidebarConfig.ts
@@ -89,6 +89,7 @@ export const DISCOVERABLE_DASHBOARDS: SidebarItem[] = [
   { id: 'services', name: 'Services', icon: 'Network', href: '/services', type: 'link', order: 17 },
   { id: 'storage', name: 'Storage', icon: 'HardDrive', href: '/storage', type: 'link', order: 18 },
   { id: 'workloads', name: 'Workloads', icon: 'Box', href: '/workloads', type: 'link', order: 19 },
+  { id: 'acmm', name: 'AI Codebase Maturity', icon: 'BarChart3', href: '/acmm', type: 'link', order: 20 },
 ]
 
 const DEFAULT_SECONDARY_NAV: SidebarItem[] = [


### PR DESCRIPTION
## Summary

- Add ACMM to `DISCOVERABLE_DASHBOARDS` in `useSidebarConfig.ts` so it appears in the sidebar customizer and can be navigated to
- The `/acmm` route, dashboard config, and all 4 cards were deployed in #8260 but the sidebar entry was missed

## Test plan

- [ ] Open console.kubestellar.io, customize sidebar → "AI Codebase Maturity" appears in discoverable dashboards
- [ ] Add it to sidebar → navigates to `/acmm` with all 4 cards

🤖 Generated with [Claude Code](https://claude.com/claude-code)