### PR TITLE
🐛 fix(ci): auto-issue on cancellation + benchmark retries:0 (closes #8262)

### DIFF
--- a/.github/workflows/nightly-test-suite.yml
+++ b/.github/workflows/nightly-test-suite.yml
@@ -162,7 +162,7 @@ jobs:
           git push origin main || echo "::warning::Failed to push results — will retry next run"
 
       - name: Find or create tracking issue
-        if: always() && steps.tests.outputs.result_file != ''
+        if: always() && (steps.tests.outputs.result_file != '' || job.status == 'cancelled')
         id: issue
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/web/e2e/benchmarks/benchmarks.config.ts
+++ b/web/e2e/benchmarks/benchmarks.config.ts
@@ -37,7 +37,11 @@ export default defineConfig({
   testDir: '.',
   timeout: PER_TEST_TIMEOUT_MS,
   expect: { timeout: 20_000 },
-  retries: 1,
+  // retries:0 — benchmark tests hit live external services (Google Drive,
+  // GitHub Actions, Netlify functions) so retries double wall time on every
+  // flake without improving signal. Accept the occasional red rather than
+  // routinely burning 20+ extra minutes in the nightly suite (#8262).
+  retries: 0,
   workers: 1,
   reporter: [
     ['json', { outputFile: '../test-results/benchmark-results.json' }],


### PR DESCRIPTION
## Summary

Closes #8262 (nightly CI health tracking). Two surgical fixes:

1. **nightly-test-suite auto-issue guard** — changed from \`steps.tests.outputs.result_file != ''\` to also fire on \`job.status == 'cancelled'\`. When the job was cancelled at the 90m timeout (three nights in a row), the test step never wrote \`result_file\` so the issue-creation step was silently skipped.

2. **benchmark retries:0** — \`web/e2e/benchmarks/benchmarks.config.ts\` retries cut from 1 to 0. These tests hit live external services (Google Drive, GitHub Actions, Netlify) so retries double wall time on every flake. Per-test timeout was already reduced from 5m to 2m in #8261. Worst case drops from ~48m to ~24m.

## What turned out to already work

Investigation showed these items from #8262 were already implemented:
- **release.yml auto-issue**: fires on failure, label \`release-failure\` — issues #8091, #7898, #7256 were auto-created
- **release.yml manual retry**: \`workflow_dispatch\` already supported
- **nightly-dashboard-health auto-issue**: fires on \`failure()\`
- **In-UI agent notification**: shipped in #8269

## Test plan

- [x] YAML syntax valid
- [x] Benchmark config parses correctly
- [ ] Tonight: verify nightly-test-suite run creates a tracking issue comment (even if cancelled)

🤖 Generated with [Claude Code](https://claude.com/claude-code)