### PR TITLE
🐛 fix(ui): Tooltip bubble crushed to one-word-per-line when trigger is narrow

### DIFF
--- a/web/src/components/ui/Tooltip.tsx
+++ b/web/src/components/ui/Tooltip.tsx
@@ -44,6 +44,17 @@ const TOOLTIP_FADE_DURATION_CLASS = 'duration-150'
 const TOOLTIP_MAX_WIDTH_CLASS = 'max-w-xs'
 
 /**
+ * Tailwind class forcing the bubble to size to its content's natural
+ * width (`width: max-content`). Without this the `absolute` bubble
+ * inherits a layout-time width of 0 from its `relative` wrapper — so
+ * `whitespace-normal` wraps aggressively and a short trigger (like the
+ * "AI Missions" navbar button) ends up showing one word per line.
+ * Combined with `max-w-xs` this gives "as wide as the content needs,
+ * up to 20rem" which is the expected tooltip behavior.
+ */
+const TOOLTIP_INTRINSIC_WIDTH_CLASS = 'w-max'
+
+/**
  * Side positioning classes. Keyed by the `side` prop — each entry places
  * the tooltip bubble relative to the wrapping trigger container.
  */
@@ -139,6 +150,7 @@ export function Tooltip({
           'bg-card text-card-foreground border border-border shadow-lg',
           'rounded-md px-2 py-1 text-xs text-center',
           'whitespace-normal',
+          TOOLTIP_INTRINSIC_WIDTH_CLASS,
           TOOLTIP_MAX_WIDTH_CLASS,
           className,
         )}

--- a/web/src/components/ui/__tests__/Tooltip.test.tsx
+++ b/web/src/components/ui/__tests__/Tooltip.test.tsx
@@ -54,6 +54,11 @@ describe('Tooltip', () => {
     const bubble = screen.getByRole('tooltip')
     expect(bubble.className).toMatch(/whitespace-normal/)
     expect(bubble.className).toMatch(/max-w-/)
+    // `w-max` is required alongside `max-w-xs` — without it the bubble
+    // inherits width from its relative wrapper and the AI Missions case
+    // ends up with one word per line. Regression guard for the fix
+    // addressing that screenshot report.
+    expect(bubble.className).toMatch(/w-max/)
   })
 
   it('skips the wrapper when disabled=true', () => {


### PR DESCRIPTION
## Summary

User reported that the "AI Missions" navbar tooltip renders tall and narrow (one word per line) instead of wide:

![one-word-per-line tooltip]

The Tooltip primitive from #8235 uses `max-w-xs` + `whitespace-normal` which handles long strings correctly — but it was missing an intrinsic width hint (`w-max`). Without it, the absolute-positioned bubble's layout-time width gets clamped to its relative wrapper's width, so on a narrow trigger the bubble squeezes down to ~100px and text wraps aggressively.

**Fix:** add `w-max` (CSS `width: max-content`) to the bubble. Content sizes to its natural width, still capped by `max-w-xs` (20rem) for long help strings.

## Before / After

**Before** (AI Missions tooltip):
```
┌──────────┐
│   AI     │
│ Missions │
│   are    │
│assistant-│
│ driven   │
│ tasks    │
│ that     │
│ monitor  │
│ your     │
│ clusters │
│ and      │
│ propose  │
│ fixes.   │
└──────────┘
```

**After:**
```
┌───────────────────────────────────┐
│ AI Missions are assistant-driven  │
│ tasks that monitor your clusters  │
│ and propose fixes.                │
└───────────────────────────────────┘
```

## Regression guard

`Tooltip.test.tsx` now asserts `w-max` is present on the bubble className. Existing 7 tests still pass (8 total).

## Test plan

- [x] `npm run build` — passes
- [x] `npx vitest run Tooltip.test.tsx` — 8/8 pass
- [ ] On prod: hover the AI Missions button → tooltip is wide, wraps at a reasonable width, not one-word-per-line
- [ ] Verify long tooltips still wrap at `max-w-xs` (20rem), not infinitely wide
- [ ] Verify short tooltips (1-3 words) render on a single line

🤖 Generated with [Claude Code](https://claude.com/claude-code)