### PR TITLE
🐛 fix(intoto): drop concurrent mutation of allStatuses (#8270)

### DIFF
--- a/web/src/hooks/useIntoto.ts
+++ b/web/src/hooks/useIntoto.ts
@@ -406,11 +406,10 @@ export function useIntoto() {
       setClustersChecked(0)
 
       // Check all clusters with bounded concurrency, stream results progressively
-      const allStatuses: Record<string, IntotoClusterStatus> = {}
+      const clusterList = clusters || []
 
-      const tasks = (clusters || []).map(cluster => async () => {
+      const tasks = clusterList.map(cluster => async () => {
         const status = await fetchSingleCluster(cluster)
-        allStatuses[cluster] = status
         // Stream each result immediately — card re-renders progressively
         setStatuses(prev => ({ ...prev, [cluster]: status }))
         setClustersChecked(prev => prev + 1)
@@ -419,9 +418,19 @@ export function useIntoto() {
           initialLoadDone.current = true
           setIsLoading(false)
         }
+        return { cluster, status }
       })
 
-      await settledWithConcurrency(tasks)
+      const settled = await settledWithConcurrency(tasks)
+
+      // Collect results from settled promises — no shared mutable state
+      const allStatuses: Record<string, IntotoClusterStatus> = {}
+      for (const result of settled) {
+        if (result.status === 'fulfilled' && result.value) {
+          const { cluster, status } = result.value as { cluster: string; status: IntotoClusterStatus }
+          allStatuses[cluster] = status
+        }
+      }
 
       // A cycle "fails" only when every cluster returned a connection error —
       // "not installed" is a clean result and should reset the counter.


### PR DESCRIPTION
## Summary
- Remove shared mutable `allStatuses` map from concurrent scan callbacks
- Each task returns its `{cluster, status}` result; aggregate is built from the settled promises after all tasks resolve
- Per-cluster streaming via `setStatuses(prev => ...)` is unchanged

## Why
In `useIntoto`, `settledWithConcurrency` runs task callbacks in parallel. The callback was mutating the outer-scope `allStatuses` object from inside the async body, which interleaves with other tasks in Node's test scheduler and occasionally dropped entries. The fix moves the aggregate build into the post-settle step, so concurrent code touches nothing shared.

Fixes #8270

## Test plan
- [x] `cd web && npm run build` passes
- [x] `cd web && npm run lint` passes
- [ ] Coverage Suite run succeeds (CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)