### PR TITLE
🐛 fix(acmm): broaden CI/CD detection + Copilot review from #8260

### DIFF
--- a/web/netlify/functions/acmm-scan.mts
+++ b/web/netlify/functions/acmm-scan.mts
@@ -6,7 +6,7 @@
  * /acmm dashboard's four cards.
  *
  * Input:  ?repo=owner/repo
- * Output: { repo, scannedAt, detectedLoops, weeklyActivity, level, ... }
+ * Output: { repo, scannedAt, detectedIds, weeklyActivity }
  *
  * Optional env var:
  *   GITHUB_TOKEN — enables higher rate limits (5000 req/hr vs 60)
@@ -101,7 +101,7 @@ const CRITERIA: Criterion[] = [
 
   // Fullsend
   { id: "fullsend:test-coverage", source: "fullsend", category: "readiness", name: "Test coverage threshold", detection: { type: "any-of", pattern: ["codecov.yml", ".codecov.yml", "coverage.yml", ".github/workflows/coverage-gate.yml"] } },
-  { id: "fullsend:ci-cd-maturity", source: "fullsend", category: "readiness", name: "CI/CD pipeline", detection: { type: "any-of", pattern: [".github/workflows/ci.yml", ".github/workflows/build.yml", ".github/workflows/test.yml", ".github/workflows/pr-check.yml"] } },
+  { id: "fullsend:ci-cd-maturity", source: "fullsend", category: "readiness", name: "CI/CD pipeline", detection: { type: "any-of", pattern: [".github/workflows/"] } },
   { id: "fullsend:auto-merge-policy", source: "fullsend", category: "autonomy", name: "Auto-merge policy", detection: { type: "any-of", pattern: [".github/auto-merge.yml", ".prow.yaml", "tide.yaml", ".github/workflows/auto-merge.yml"] } },
   { id: "fullsend:branch-protection-doc", source: "fullsend", category: "governance", name: "Branch protection doc", detection: { type: "any-of", pattern: ["docs/branch-protection.md", "docs/governance.md", ".github/branch-protection.yml"] } },
   { id: "fullsend:production-feedback", source: "fullsend", category: "observability", name: "Production feedback", detection: { type: "any-of", pattern: ["monitoring/", "grafana/", ".github/workflows/post-deploy-check.yml", "scripts/production-feedback.mjs"] } },

--- a/web/src/components/acmm/RepoPicker.tsx
+++ b/web/src/components/acmm/RepoPicker.tsx
@@ -6,10 +6,11 @@
  * a "Load Console example" button.
  */
 
-import { useRef, useState } from 'react'
+import { useMemo, useRef, useState } from 'react'
 import { RefreshCw, X, ExternalLink, AlertCircle } from 'lucide-react'
 import { Button } from '../ui/Button'
 import { useACMM, DEFAULT_REPO } from './ACMMProvider'
+import { ALL_CRITERIA } from '../../lib/acmm/sources'
 
 const REPO_RE = /^[\w.-]+\/[\w.-]+$/
 
@@ -34,7 +35,7 @@ export function RepoPicker() {
   }
 
   const detected = scan.data.detectedIds?.length ?? 0
-  const totalLoops = 33
+  const totalCriteria = useMemo(() => ALL_CRITERIA.length, [])
   const scannedLabel = scan.data.scannedAt
     ? new Date(scan.data.scannedAt).toLocaleTimeString()
     : '—'
@@ -127,7 +128,7 @@ export function RepoPicker() {
           </div>
         ) : (
           <div>
-            Scanned {scannedLabel} · {detected}/{totalLoops} loops detected · L{scan.level.level} ({scan.level.levelName})
+            Scanned {scannedLabel} · {detected}/{totalCriteria} criteria detected · L{scan.level.level} ({scan.level.levelName})
           </div>
         )}
       </div>

--- a/web/src/hooks/useCachedACMMScan.ts
+++ b/web/src/hooks/useCachedACMMScan.ts
@@ -11,8 +11,8 @@ import { computeLevel, type LevelComputation } from '../lib/acmm/computeLevel'
 import { computeRecommendations, type Recommendation } from '../lib/acmm/computeRecommendations'
 
 const API_PATH = '/api/acmm/scan'
-/** How long a cached scan is considered fresh (must match Netlify function TTL). */
-const REFRESH_CATEGORY: RefreshCategory = 'default'
+/** Scan results change slowly; 10-min refresh avoids GitHub rate limits. */
+const REFRESH_CATEGORY: RefreshCategory = 'costs'
 
 export interface WeeklyActivity {
   week: string

--- a/web/src/hooks/useSearchIndex.ts
+++ b/web/src/hooks/useSearchIndex.ts
@@ -116,7 +116,7 @@ const ALL_STATS_DASHBOARD_TYPES: DashboardStatsType[] = [
   'dashboard', 'clusters', 'workloads', 'pods', 'gitops', 'storage',
   'network', 'security', 'compliance', 'data-compliance', 'compute',
   'events', 'cost', 'alerts', 'operators', 'deploy', 'ai-agents',
-  'cluster-admin', 'insights', 'ci-cd', 'drasi',
+  'cluster-admin', 'insights', 'ci-cd', 'drasi', 'acmm',
 ]
 
 // --- Dashboard storage keys → routes (for scanning placed cards) ---

--- a/web/src/lib/acmm/sources/fullsend.ts
+++ b/web/src/lib/acmm/sources/fullsend.ts
@@ -17,7 +17,7 @@ const CRITERIA: Criterion[] = [
     name: 'CI/CD pipeline',
     description: 'A working CI/CD pipeline that runs on every PR.',
     rationale: 'The second fullsend readiness prerequisite — a repo without CI cannot gate agent work.',
-    detection: { type: 'any-of', pattern: ['.github/workflows/ci.yml', '.github/workflows/build.yml', '.github/workflows/test.yml', '.github/workflows/pr-check.yml'] },
+    detection: { type: 'any-of', pattern: ['.github/workflows/'] },
   },
   {
     id: 'fullsend:auto-merge-policy',


### PR DESCRIPTION
## Summary
- `fullsend:ci-cd-maturity` now detects any `.github/workflows/` tree presence instead of four hardcoded filenames. kubestellar/console has `build-deploy.yml`, `fullstack-e2e.yml`, `coverage-gate.yml` etc. — none matched the old pattern, so the console was wrongly flagged "missing CI".
- Mirror the change in the Netlify function's embedded criteria table.
- Outdated comment in Netlify function: `detectedLoops` → `detectedIds`.
- `RepoPicker`: compute `totalCriteria` from `ALL_CRITERIA.length` (was hardcoded 33 — stale since we added 3 more sources).
- `useCachedACMMScan`: refresh category `costs` (10 min) instead of `default` (2 min) to stay under GitHub's rate limit.
- `useSearchIndex`: add `acmm` to `ALL_STATS_DASHBOARD_TYPES`.

## Why
User reported kubestellar/console showing a "CI/CD pipeline" recommendation even though the repo has many CI workflows. Root cause was the detection patterns were too narrow.

Addresses Copilot review comments from #8271 (PR #8260).

## Test plan
- [x] `cd web && npm run build` passes
- [ ] Scan `kubestellar/console` after merge → CI/CD criterion detected
- [ ] Other repos unaffected