### PR TITLE
🐛 fix(ci): drop truncated run ID from nightly-test-suite comment (#8264)

### DIFF
--- a/.github/workflows/nightly-test-suite.yml
+++ b/.github/workflows/nightly-test-suite.yml
@@ -28,7 +28,8 @@ jobs:
     # One of them (benchmark-dashboard, which hits live Google Drive + GitHub
     # Actions + Netlify functions) had been burning 20+ minutes on retry
     # storms and pushing the total over 90m, cancelling three nights in a row
-    # (runs 24439970651, 24420...). 120m covers the worst case with headroom;
+    # (run 24439970651, plus two earlier runs on 2026-04-13 and 04-14).
+    # 120m covers the worst case with headroom;
     # the per-test timeout in benchmarks.config.ts is also being cut from 5m
     # to 2m in the same PR, which should actually bring total runtime back
     # under 90m — the 120m bump is belt-and-suspenders in case one of the


### PR DESCRIPTION
## Summary
Replace \`24420...\` truncation in the nightly-test-suite.yml comment with the one complete run ID (\`24439970651\`) plus a date-range reference for the other two cancelled nights.

Addresses Copilot review on merged PR #8261 (#8264).

The other #8264 comment about \`PER_TEST_TIMEOUT_MS\` is already explained in-code (the 2-minute budget is intentional and documented at benchmarks.config.ts:25-34).

Fixes #8264