### PR TITLE
🐛 fix(test): wrap UpdateIndicator test in ToastProvider (#8282)

### DIFF
--- a/web/src/components/layout/navbar/__tests__/UpdateIndicator.test.tsx
+++ b/web/src/components/layout/navbar/__tests__/UpdateIndicator.test.tsx
@@ -42,10 +42,17 @@ vi.mock('../../../../hooks/useFeatureHints', () => ({
 }))
 
 import { UpdateIndicator } from '../UpdateIndicator'
+import { ToastProvider } from '../../../ui/Toast'
 
 describe('UpdateIndicator', () => {
   it('renders without crashing', () => {
-    const { container } = render(<MemoryRouter><UpdateIndicator /></MemoryRouter>)
+    const { container } = render(
+      <MemoryRouter>
+        <ToastProvider>
+          <UpdateIndicator />
+        </ToastProvider>
+      </MemoryRouter>
+    )
     expect(container).toBeTruthy()
   })
 })


### PR DESCRIPTION
## Summary

UpdateIndicator.tsx now calls `useToast()`, which throws `'useToast must be used within a ToastProvider'` when the test renders the component bare. The coverage suite has been failing because of this.

Wrap the test render in `ToastProvider` so the hook has a valid context.

## Test plan

- [x] `npx vitest run src/components/layout/navbar/__tests__/UpdateIndicator.test.tsx` passes locally
- [ ] CI coverage suite turns green on this PR

Fixes #8282