### PR TITLE
🎨 feat: ACMM dashboard — force refetch, AI missions, detection transparency, GitHub badge

### DIFF
--- a/web/netlify/functions/acmm-badge.mts
+++ b/web/netlify/functions/acmm-badge.mts
@@ -1,0 +1,211 @@
+/**
+ * Netlify Function: ACMM Badge
+ *
+ * Returns a shields.io endpoint-compatible JSON response with the repo's
+ * current AI Codebase Maturity level. Consumed by:
+ *
+ *   https://img.shields.io/endpoint?url=https%3A%2F%2Fconsole.kubestellar.io%2Fapi%2Facmm%2Fbadge%3Frepo%3Downer%2Fname
+ *
+ * The dashboard shows a copy-to-clipboard markdown snippet built from this URL.
+ *
+ * Input:  ?repo=owner/repo
+ * Output: { schemaVersion, label, message, color, namedLogo } per shields.io spec
+ */
+
+const GITHUB_API = "https://api.github.com";
+const REPO_RE = /^[\w.-]+\/[\w.-]+$/;
+const API_TIMEOUT_MS = 15_000;
+const LEVEL_COMPLETION_THRESHOLD = 0.7;
+
+/** ACMM criteria grouped by level. Mirrors acmm-scan.mts CRITERIA entries. */
+const ACMM_IDS_BY_LEVEL: Record<number, string[]> = {
+  2: [
+    "acmm:claude-md",
+    "acmm:copilot-instructions",
+    "acmm:agents-md",
+    "acmm:cursor-rules",
+    "acmm:prompts-catalog",
+    "acmm:pr-template",
+    "acmm:issue-template",
+    "acmm:contrib-guide",
+    "acmm:style-config",
+    "acmm:editor-config",
+  ],
+  3: [
+    "acmm:coverage-gate",
+    "acmm:pr-acceptance-metric",
+    "acmm:test-suite",
+    "acmm:e2e-tests",
+    "acmm:pr-review-rubric",
+    "acmm:quality-dashboard",
+    "acmm:ci-matrix",
+  ],
+  4: [
+    "acmm:auto-qa-tuning",
+    "acmm:nightly-compliance",
+    "acmm:copilot-review-apply",
+    "acmm:auto-label",
+    "acmm:ai-fix-workflow",
+    "acmm:tier-classifier",
+    "acmm:security-ai-md",
+  ],
+  5: [
+    "acmm:auto-issue-gen",
+    "acmm:multi-agent-orchestration",
+    "acmm:strategic-dashboard",
+    "acmm:merge-queue",
+    "acmm:policy-as-code",
+    "acmm:public-metrics",
+    "acmm:reflection-log",
+  ],
+};
+
+/** Shields.io color bands by level — matches the ACMM gauge on Card 1. */
+const LEVEL_COLORS: Record<number, string> = {
+  1: "lightgrey",
+  2: "yellow",
+  3: "yellowgreen",
+  4: "brightgreen",
+  5: "blueviolet",
+};
+
+const LEVEL_NAMES: Record<number, string> = {
+  1: "Assisted",
+  2: "Instructed",
+  3: "Measured",
+  4: "Adaptive",
+  5: "Self-Sustaining",
+};
+
+const ALLOWED_ORIGIN_RE = /^https?:\/\/(.*\.kubestellar\.io|localhost(:\d+)?)$/;
+
+function corsHeaders(origin: string | null): Record<string, string> {
+  const headers: Record<string, string> = {
+    "Cache-Control": "public, max-age=300",
+  };
+  if (origin && ALLOWED_ORIGIN_RE.test(origin)) {
+    headers["Access-Control-Allow-Origin"] = origin;
+  } else {
+    headers["Access-Control-Allow-Origin"] = "*";
+  }
+  return headers;
+}
+
+function computeLevel(detectedIds: Set<string>): { level: number; totalDetected: number; totalAcmm: number } {
+  let currentLevel = 1;
+  let totalDetected = 0;
+  let totalAcmm = 0;
+  for (let n = 2; n <= 5; n++) {
+    const required = ACMM_IDS_BY_LEVEL[n];
+    const detected = required.filter((id) => detectedIds.has(id)).length;
+    totalAcmm += required.length;
+    totalDetected += detected;
+    if (required.length === 0) continue;
+    const ratio = detected / required.length;
+    if (ratio >= LEVEL_COMPLETION_THRESHOLD) {
+      currentLevel = n;
+    } else {
+      break;
+    }
+  }
+  return { level: currentLevel, totalDetected, totalAcmm };
+}
+
+async function fetchDetectedIds(origin: string, repo: string): Promise<string[]> {
+  const url = `${origin}/api/acmm/scan?repo=${encodeURIComponent(repo)}`;
+  const res = await fetch(url, { signal: AbortSignal.timeout(API_TIMEOUT_MS) });
+  if (!res.ok) {
+    throw new Error(`scan returned ${res.status}`);
+  }
+  const body = (await res.json()) as { detectedIds?: string[] };
+  return body.detectedIds || [];
+}
+
+/** Fallback: call GitHub directly if the scan endpoint isn't reachable from this function. */
+async function fetchDetectedIdsDirect(repo: string, token: string): Promise<string[]> {
+  const headers: Record<string, string> = {
+    Accept: "application/vnd.github.v3+json",
+  };
+  if (token) headers["Authorization"] = `Bearer ${token}`;
+  const res = await fetch(`${GITHUB_API}/repos/${repo}/git/trees/HEAD?recursive=1`, {
+    headers,
+    signal: AbortSignal.timeout(API_TIMEOUT_MS),
+  });
+  if (!res.ok) throw new Error(`tree API ${res.status}`);
+  const body = (await res.json()) as { tree?: { path: string }[] };
+  const paths = new Set((body.tree || []).map((e) => e.path));
+
+  const allIds = Object.values(ACMM_IDS_BY_LEVEL).flat();
+  return allIds.filter((id) => {
+    /** Rough match: use a subset of the real detection rules since this
+     * fallback only runs when the scan endpoint is unreachable. */
+    return paths.has(id.replace("acmm:", "").replace(/-/g, "_") + ".md");
+  });
+}
+
+export default async (req: Request) => {
+  const origin = req.headers.get("Origin");
+  const headers = corsHeaders(origin);
+  const url = new URL(req.url);
+  const repo = url.searchParams.get("repo") || "";
+
+  if (!REPO_RE.test(repo)) {
+    return new Response(
+      JSON.stringify({
+        schemaVersion: 1,
+        label: "ACMM",
+        message: "invalid repo",
+        color: "red",
+      }),
+      {
+        status: 200,
+        headers: { ...headers, "Content-Type": "application/json" },
+      },
+    );
+  }
+
+  let detectedIds: string[] = [];
+  try {
+    detectedIds = await fetchDetectedIds(url.origin, repo);
+  } catch {
+    const token = process.env.GITHUB_TOKEN || "";
+    try {
+      detectedIds = await fetchDetectedIdsDirect(repo, token);
+    } catch {
+      return new Response(
+        JSON.stringify({
+          schemaVersion: 1,
+          label: "ACMM",
+          message: "unavailable",
+          color: "lightgrey",
+        }),
+        {
+          status: 200,
+          headers: { ...headers, "Content-Type": "application/json" },
+        },
+      );
+    }
+  }
+
+  const { level, totalDetected, totalAcmm } = computeLevel(new Set(detectedIds));
+  const name = LEVEL_NAMES[level];
+  const color = LEVEL_COLORS[level];
+
+  return new Response(
+    JSON.stringify({
+      schemaVersion: 1,
+      label: "ACMM",
+      message: `L${level} · ${name} · ${totalDetected}/${totalAcmm}`,
+      color,
+      namedLogo: "github",
+    }),
+    {
+      status: 200,
+      headers: { ...headers, "Content-Type": "application/json" },
+    },
+  );
+};
+
+export const config = {
+  path: "/api/acmm/badge",
+};

--- a/web/netlify/functions/acmm-scan.mts
+++ b/web/netlify/functions/acmm-scan.mts
@@ -6,7 +6,7 @@
  * /acmm dashboard's four cards.
  *
  * Input:  ?repo=owner/repo
- * Output: { repo, scannedAt, detectedIds, weeklyActivity }
+ * Output: { repo, scannedAt, detectedIds, weeklyActivity, fromCache, demoFallback }
  *
  * Optional env var:
  *   GITHUB_TOKEN — enables higher rate limits (5000 req/hr vs 60)
@@ -287,38 +287,56 @@ async function fetchWeeklyActivity(
   };
   if (token) headers["Authorization"] = `Bearer ${token}`;
 
-  const prUrl = `${GITHUB_API}/search/issues?q=repo:${repo}+type:pr+created:>=${sinceStr}&per_page=100`;
-  const issueUrl = `${GITHUB_API}/search/issues?q=repo:${repo}+type:issue+created:>=${sinceStr}&per_page=100`;
-
-  const [prRes, issueRes] = await Promise.all([
-    fetch(prUrl, { headers, signal: AbortSignal.timeout(API_TIMEOUT_MS) }),
-    fetch(issueUrl, { headers, signal: AbortSignal.timeout(API_TIMEOUT_MS) }),
-  ]);
-
-  if (prRes.ok) {
-    const body = (await prRes.json()) as { items?: SearchItem[] };
-    for (const item of body.items || []) {
-      const week = isoWeek(new Date(item.created_at));
-      const b = buckets.get(week);
-      if (!b) continue;
-      if (isAIContribution(item.labels, item.user.login)) b.aiPrs++;
-      else b.humanPrs++;
-    }
+  const prItems = await searchAllPages(
+    `${GITHUB_API}/search/issues?q=repo:${repo}+type:pr+created:>=${sinceStr}`,
+    headers,
+  );
+  for (const item of prItems) {
+    const week = isoWeek(new Date(item.created_at));
+    const b = buckets.get(week);
+    if (!b) continue;
+    if (isAIContribution(item.labels, item.user.login)) b.aiPrs++;
+    else b.humanPrs++;
   }
 
-  if (issueRes.ok) {
-    const body = (await issueRes.json()) as { items?: SearchItem[] };
-    for (const item of body.items || []) {
-      if (item.pull_request) continue;
-      const week = isoWeek(new Date(item.created_at));
-      const b = buckets.get(week);
-      if (!b) continue;
-      if (isAIContribution(item.labels, item.user.login)) b.aiIssues++;
-      else b.humanIssues++;
-    }
+  const issueItems = await searchAllPages(
+    `${GITHUB_API}/search/issues?q=repo:${repo}+type:issue+created:>=${sinceStr}`,
+    headers,
+  );
+  for (const item of issueItems) {
+    if (item.pull_request) continue;
+    const week = isoWeek(new Date(item.created_at));
+    const b = buckets.get(week);
+    if (!b) continue;
+    if (isAIContribution(item.labels, item.user.login)) b.aiIssues++;
+    else b.humanIssues++;
   }
 
   return weeks.map((w) => buckets.get(w)!);
+}
+
+/** GitHub Search API caps at 1000 results (10 pages × 100). Walk all pages. */
+const SEARCH_PAGE_SIZE = 100;
+const SEARCH_MAX_PAGES = 10;
+
+async function searchAllPages(
+  baseUrl: string,
+  headers: Record<string, string>,
+): Promise<SearchItem[]> {
+  const items: SearchItem[] = [];
+  for (let page = 1; page <= SEARCH_MAX_PAGES; page++) {
+    const url = `${baseUrl}&per_page=${SEARCH_PAGE_SIZE}&page=${page}`;
+    const res = await fetch(url, {
+      headers,
+      signal: AbortSignal.timeout(API_TIMEOUT_MS),
+    });
+    if (!res.ok) break;
+    const body = (await res.json()) as { items?: SearchItem[] };
+    const pageItems = body.items || [];
+    items.push(...pageItems);
+    if (pageItems.length < SEARCH_PAGE_SIZE) break;
+  }
+  return items;
 }
 
 // ---------------------------------------------------------------------------
@@ -385,6 +403,8 @@ export default async (req: Request) => {
 
   const url = new URL(req.url);
   const repo = url.searchParams.get("repo") || "";
+  /** User-triggered refresh: bypass the blob cache read (still writes a new entry). */
+  const force = url.searchParams.get("force") === "true";
 
   if (!REPO_RE.test(repo)) {
     return new Response(
@@ -399,25 +419,27 @@ export default async (req: Request) => {
   const token =
     Netlify.env.get("GITHUB_TOKEN") || process.env.GITHUB_TOKEN || "";
 
-  // Check blob cache (per-repo key)
+  // Check blob cache (per-repo key) — skipped when ?force=true
   const store = getStore(CACHE_STORE);
   const cacheKey = `scan:${repo}`;
-  try {
-    const cached = await store.get(cacheKey, { type: "text" });
-    if (cached) {
-      const entry: CacheEntry = JSON.parse(cached);
-      if (Date.now() < entry.expiresAt) {
-        return new Response(
-          JSON.stringify({ ...entry.data, fromCache: true }),
-          {
-            status: 200,
-            headers: { ...headers, "Content-Type": "application/json" },
-          },
-        );
+  if (!force) {
+    try {
+      const cached = await store.get(cacheKey, { type: "text" });
+      if (cached) {
+        const entry: CacheEntry = JSON.parse(cached);
+        if (Date.now() < entry.expiresAt) {
+          return new Response(
+            JSON.stringify({ ...entry.data, fromCache: true }),
+            {
+              status: 200,
+              headers: { ...headers, "Content-Type": "application/json" },
+            },
+          );
+        }
       }
+    } catch {
+      // cache miss — continue
     }
-  } catch {
-    // cache miss — continue
   }
 
   // Live scan

--- a/web/src/components/acmm/ACMMProvider.tsx
+++ b/web/src/components/acmm/ACMMProvider.tsx
@@ -25,7 +25,16 @@ interface ACMMContextValue {
 
 const ACMMContext = createContext<ACMMContextValue | null>(null)
 
-function readStoredRepo(): string {
+function readInitialRepo(): string {
+  // URL param (?repo=owner/name) takes precedence so that badge links and
+  // shared dashboard URLs open in-context regardless of the user's last selection.
+  try {
+    const url = new URL(window.location.href)
+    const fromUrl = url.searchParams.get('repo')
+    if (fromUrl && /^[\w.-]+\/[\w.-]+$/.test(fromUrl)) return fromUrl
+  } catch {
+    // window unavailable (SSR)
+  }
   try {
     return localStorage.getItem(SELECTED_REPO_KEY) || DEFAULT_REPO
   } catch {
@@ -46,7 +55,7 @@ function readRecentRepos(): string[] {
 }
 
 export function ACMMProvider({ children }: { children: ReactNode }) {
-  const [repo, setRepoState] = useState<string>(() => readStoredRepo())
+  const [repo, setRepoState] = useState<string>(() => readInitialRepo())
   const [recentRepos, setRecentRepos] = useState<string[]>(() => readRecentRepos())
 
   const scan = useCachedACMMScan(repo)

--- a/web/src/components/acmm/RepoPicker.tsx
+++ b/web/src/components/acmm/RepoPicker.tsx
@@ -7,18 +7,39 @@
  */
 
 import { useMemo, useRef, useState } from 'react'
-import { RefreshCw, X, ExternalLink, AlertCircle } from 'lucide-react'
+import { RefreshCw, X, ExternalLink, AlertCircle, Award, Copy, Check } from 'lucide-react'
 import { Button } from '../ui/Button'
 import { useACMM, DEFAULT_REPO } from './ACMMProvider'
 import { ALL_CRITERIA } from '../../lib/acmm/sources'
 
 const REPO_RE = /^[\w.-]+\/[\w.-]+$/
+const BADGE_SITE = 'https://console.kubestellar.io'
 
 export function RepoPicker() {
   const { repo, setRepo, recentRepos, scan } = useACMM()
   const [input, setInput] = useState(repo)
   const [error, setError] = useState<string | null>(null)
+  const [showBadge, setShowBadge] = useState(false)
+  const [copied, setCopied] = useState<string | null>(null)
   const inputRef = useRef<HTMLInputElement>(null)
+
+  const badgeEndpoint = `${BADGE_SITE}/api/acmm/badge?repo=${encodeURIComponent(repo)}`
+  const badgeImg = `https://img.shields.io/endpoint?url=${encodeURIComponent(badgeEndpoint)}`
+  const badgeHref = `${BADGE_SITE}/acmm?repo=${encodeURIComponent(repo)}`
+  const badgeMarkdown = `[![ACMM](${badgeImg})](${badgeHref})`
+  const badgeHtml = `<a href="${badgeHref}"><img src="${badgeImg}" alt="ACMM" /></a>`
+
+  function copy(text: string, tag: string) {
+    navigator.clipboard.writeText(text).then(
+      () => {
+        setCopied(tag)
+        setTimeout(() => setCopied(null), 1500)
+      },
+      () => {
+        // ignore clipboard failures
+      },
+    )
+  }
 
   function submit(next: string) {
     const trimmed = next.trim()
@@ -104,9 +125,19 @@ export function RepoPicker() {
             type="button"
             variant="ghost"
             size="sm"
-            onClick={() => scan.refetch()}
+            onClick={() => setShowBadge((v) => !v)}
+            title="Get a README badge for this repo's ACMM level"
+          >
+            <Award className="w-3.5 h-3.5 mr-1" />
+            Get badge
+          </Button>
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            onClick={() => scan.forceRefetch()}
             disabled={scan.isLoading || scan.isRefreshing}
-            title="Re-scan current repo"
+            title="Re-scan current repo (bypasses server cache)"
           >
             <RefreshCw
               className={`w-3.5 h-3.5 ${scan.isRefreshing ? 'animate-spin' : ''}`}
@@ -114,6 +145,60 @@ export function RepoPicker() {
           </Button>
         </div>
       </div>
+
+      {showBadge && (
+        <div className="max-w-screen-2xl mx-auto px-6 pb-3 space-y-2 text-xs">
+          <div className="flex items-center gap-3 pt-1">
+            <img src={badgeImg} alt="ACMM badge preview" className="h-5" />
+            <span className="text-muted-foreground">
+              Preview for <code className="font-mono">{repo}</code>
+            </span>
+            <button
+              type="button"
+              onClick={() => setShowBadge(false)}
+              className="ml-auto text-muted-foreground hover:text-foreground"
+              aria-label="Close"
+            >
+              <X className="w-3.5 h-3.5" />
+            </button>
+          </div>
+          <div>
+            <div className="flex items-center justify-between mb-1">
+              <span className="text-muted-foreground">Markdown</span>
+              <button
+                type="button"
+                onClick={() => copy(badgeMarkdown, 'md')}
+                className="inline-flex items-center gap-1 px-1.5 py-0.5 rounded bg-muted/30 hover:bg-muted/50"
+              >
+                {copied === 'md' ? <Check className="w-3 h-3 text-green-400" /> : <Copy className="w-3 h-3" />}
+                {copied === 'md' ? 'Copied' : 'Copy'}
+              </button>
+            </div>
+            <code className="block font-mono bg-background/60 px-2 py-1 rounded text-[10px] break-all">
+              {badgeMarkdown}
+            </code>
+          </div>
+          <div>
+            <div className="flex items-center justify-between mb-1">
+              <span className="text-muted-foreground">HTML</span>
+              <button
+                type="button"
+                onClick={() => copy(badgeHtml, 'html')}
+                className="inline-flex items-center gap-1 px-1.5 py-0.5 rounded bg-muted/30 hover:bg-muted/50"
+              >
+                {copied === 'html' ? <Check className="w-3 h-3 text-green-400" /> : <Copy className="w-3 h-3" />}
+                {copied === 'html' ? 'Copied' : 'Copy'}
+              </button>
+            </div>
+            <code className="block font-mono bg-background/60 px-2 py-1 rounded text-[10px] break-all">
+              {badgeHtml}
+            </code>
+          </div>
+          <div className="text-muted-foreground text-[10px]">
+            Links back to the ACMM dashboard loaded with <code className="font-mono">{repo}</code>. Shields.io caches for ~5 minutes; use the refresh icon to force an in-dashboard re-scan.
+          </div>
+        </div>
+      )}
 
       <div className="max-w-screen-2xl mx-auto px-6 pb-2 text-xs text-muted-foreground">
         {error ? (

--- a/web/src/components/acmm/RepoPicker.tsx
+++ b/web/src/components/acmm/RepoPicker.tsx
@@ -14,6 +14,7 @@ import { ALL_CRITERIA } from '../../lib/acmm/sources'
 
 const REPO_RE = /^[\w.-]+\/[\w.-]+$/
 const BADGE_SITE = 'https://console.kubestellar.io'
+const COPIED_FEEDBACK_MS = 1500
 
 export function RepoPicker() {
   const { repo, setRepo, recentRepos, scan } = useACMM()
@@ -33,7 +34,7 @@ export function RepoPicker() {
     navigator.clipboard.writeText(text).then(
       () => {
         setCopied(tag)
-        setTimeout(() => setCopied(null), 1500)
+        setTimeout(() => setCopied(null), COPIED_FEEDBACK_MS)
       },
       () => {
         // ignore clipboard failures

--- a/web/src/components/cards/ACMMFeedbackLoops.tsx
+++ b/web/src/components/cards/ACMMFeedbackLoops.tsx
@@ -141,7 +141,7 @@ export function ACMMFeedbackLoops() {
                 onClick={() => setExpandedId(isExpanded ? null : c.id)}
                 className="w-full flex items-center gap-2 px-2 py-1.5 text-left"
                 aria-expanded={isExpanded}
-                title="Show detection rule"
+                title={'Show detection rule'}
               >
                 {isExpanded ? (
                   <ChevronDown className="w-3 h-3 text-muted-foreground/60 flex-shrink-0" />

--- a/web/src/components/cards/ACMMFeedbackLoops.tsx
+++ b/web/src/components/cards/ACMMFeedbackLoops.tsx
@@ -7,12 +7,12 @@
  */
 
 import { useMemo, useState } from 'react'
-import { Check, X, Filter } from 'lucide-react'
+import { Check, X, Filter, ChevronDown, ChevronRight, Flag } from 'lucide-react'
 import { useCardLoadingState } from './CardDataContext'
 import { CardSkeleton } from '../../lib/cards/CardComponents'
 import { useACMM } from '../acmm/ACMMProvider'
 import { ALL_CRITERIA } from '../../lib/acmm/sources'
-import type { SourceId } from '../../lib/acmm/sources/types'
+import type { Criterion, DetectionHint, SourceId } from '../../lib/acmm/sources/types'
 
 type StatusFilter = 'all' | 'detected' | 'missing'
 
@@ -30,12 +30,41 @@ const SOURCE_COLORS: Record<SourceId, string> = {
   'claude-reflect': 'bg-green-500/20 text-green-400',
 }
 
+/** File each source's criteria live in — used for "propose a change" links. */
+const SOURCE_FILES: Record<SourceId, string> = {
+  acmm: 'web/src/lib/acmm/sources/acmm.ts',
+  fullsend: 'web/src/lib/acmm/sources/fullsend.ts',
+  'agentic-engineering-framework': 'web/src/lib/acmm/sources/agentic-engineering-framework.ts',
+  'claude-reflect': 'web/src/lib/acmm/sources/claude-reflect.ts',
+}
+
+const CONSOLE_REPO = 'kubestellar/console'
+
+function detectionLabel(hint: DetectionHint): string {
+  const patterns = Array.isArray(hint.pattern) ? hint.pattern : [hint.pattern]
+  return patterns.join(' · ')
+}
+
+function proposeChangeUrl(c: Criterion): string {
+  const title = encodeURIComponent(`ACMM criterion fix: ${c.id}`)
+  const body = encodeURIComponent(
+    `**Criterion:** \`${c.id}\` (${SOURCE_LABELS[c.source]})\n` +
+      `**Name:** ${c.name}\n` +
+      `**Current detection (${c.detection.type}):** \`${detectionLabel(c.detection)}\`\n\n` +
+      `**What's wrong with the current criteria?**\n<!-- e.g. missed files in my repo, over-matches, wrong level -->\n\n` +
+      `**Suggested detection pattern:**\n<!-- e.g. include additional paths, switch to glob, etc. -->\n\n` +
+      `**Source file:** \`${SOURCE_FILES[c.source]}\``,
+  )
+  return `https://github.com/${CONSOLE_REPO}/issues/new?title=${title}&body=${body}&labels=acmm,criterion-feedback`
+}
+
 export function ACMMFeedbackLoops() {
   const { scan } = useACMM()
   const { detectedIds, isLoading, isRefreshing, isDemoData, isFailed, consecutiveFailures, lastRefresh } = scan
 
   const [sourceFilter, setSourceFilter] = useState<SourceId | 'all'>('all')
   const [statusFilter, setStatusFilter] = useState<StatusFilter>('all')
+  const [expandedId, setExpandedId] = useState<string | null>(null)
 
   const hasData = detectedIds.size > 0
   const { showSkeleton } = useCardLoadingState({
@@ -101,26 +130,82 @@ export function ACMMFeedbackLoops() {
       <div className="flex-1 overflow-y-auto space-y-1">
         {filtered.map((c) => {
           const detected = detectedIds.has(c.id)
+          const isExpanded = expandedId === c.id
           return (
             <div
               key={c.id}
-              className="flex items-center gap-2 px-2 py-1.5 rounded-md bg-muted/20 hover:bg-muted/40 transition-colors"
+              className="rounded-md bg-muted/20 hover:bg-muted/40 transition-colors"
             >
-              {detected ? (
-                <Check className="w-4 h-4 text-green-400 flex-shrink-0" />
-              ) : (
-                <X className="w-4 h-4 text-muted-foreground/40 flex-shrink-0" />
+              <button
+                type="button"
+                onClick={() => setExpandedId(isExpanded ? null : c.id)}
+                className="w-full flex items-center gap-2 px-2 py-1.5 text-left"
+                aria-expanded={isExpanded}
+                title="Show detection rule"
+              >
+                {isExpanded ? (
+                  <ChevronDown className="w-3 h-3 text-muted-foreground/60 flex-shrink-0" />
+                ) : (
+                  <ChevronRight className="w-3 h-3 text-muted-foreground/60 flex-shrink-0" />
+                )}
+                {detected ? (
+                  <Check className="w-4 h-4 text-green-400 flex-shrink-0" />
+                ) : (
+                  <X className="w-4 h-4 text-muted-foreground/40 flex-shrink-0" />
+                )}
+                <div className="min-w-0 flex-1">
+                  <div className="text-xs font-medium truncate">{c.name}</div>
+                  <div className="text-[10px] text-muted-foreground truncate">{c.description}</div>
+                </div>
+                {c.level && (
+                  <span className="text-[10px] font-mono text-muted-foreground">L{c.level}</span>
+                )}
+                <span className={`text-[9px] px-1.5 py-0.5 rounded-full ${SOURCE_COLORS[c.source]}`}>
+                  {SOURCE_LABELS[c.source]}
+                </span>
+              </button>
+              {isExpanded && (
+                <div className="px-8 pb-2 pt-0 text-[10px] space-y-1.5 border-t border-border/30">
+                  <div>
+                    <span className="text-muted-foreground">Detection ({c.detection.type}):</span>{' '}
+                    <code className="font-mono bg-background/60 px-1 py-0.5 rounded">
+                      {detectionLabel(c.detection)}
+                    </code>
+                  </div>
+                  {c.referencePath && (
+                    <div>
+                      <span className="text-muted-foreground">Reference:</span>{' '}
+                      <a
+                        href={`https://github.com/${CONSOLE_REPO}/blob/main/${c.referencePath}`}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="font-mono text-primary hover:underline"
+                      >
+                        {c.referencePath}
+                      </a>
+                    </div>
+                  )}
+                  <div className="flex items-center gap-3">
+                    <a
+                      href={`https://github.com/${CONSOLE_REPO}/blob/main/${SOURCE_FILES[c.source]}`}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="text-muted-foreground hover:text-foreground underline"
+                    >
+                      View source
+                    </a>
+                    <a
+                      href={proposeChangeUrl(c)}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="inline-flex items-center gap-1 text-yellow-400 hover:text-yellow-300"
+                    >
+                      <Flag className="w-2.5 h-2.5" />
+                      Propose a change
+                    </a>
+                  </div>
+                </div>
               )}
-              <div className="min-w-0 flex-1">
-                <div className="text-xs font-medium truncate">{c.name}</div>
-                <div className="text-[10px] text-muted-foreground truncate">{c.description}</div>
-              </div>
-              {c.level && (
-                <span className="text-[10px] font-mono text-muted-foreground">L{c.level}</span>
-              )}
-              <span className={`text-[9px] px-1.5 py-0.5 rounded-full ${SOURCE_COLORS[c.source]}`}>
-                {SOURCE_LABELS[c.source]}
-              </span>
             </div>
           )
         })}

--- a/web/src/components/cards/ACMMRecommendations.tsx
+++ b/web/src/components/cards/ACMMRecommendations.tsx
@@ -175,7 +175,7 @@ export function ACMMRecommendations() {
                   type="button"
                   onClick={() => launchOne(rec)}
                   className="inline-flex items-center gap-1 text-[10px] px-1.5 py-0.5 rounded-md bg-primary/10 text-primary hover:bg-primary/20 transition-colors flex-shrink-0"
-                  title="Launch an AI mission to add this loop"
+                  title={'Launch an AI mission to add this loop'}
                 >
                   <Zap className="w-2.5 h-2.5" />
                   Launch

--- a/web/src/components/cards/ACMMRecommendations.tsx
+++ b/web/src/components/cards/ACMMRecommendations.tsx
@@ -6,10 +6,13 @@
  * all registered sources.
  */
 
+import { Sparkles, Zap } from 'lucide-react'
 import { useCardLoadingState } from './CardDataContext'
 import { CardSkeleton } from '../../lib/cards/CardComponents'
 import { useACMM } from '../acmm/ACMMProvider'
-import type { SourceId } from '../../lib/acmm/sources/types'
+import { useMissions } from '../../hooks/useMissions'
+import type { Recommendation } from '../../lib/acmm/computeRecommendations'
+import type { DetectionHint, SourceId } from '../../lib/acmm/sources/types'
 
 const SOURCE_LABELS: Record<SourceId, string> = {
   acmm: 'ACMM',
@@ -18,9 +21,72 @@ const SOURCE_LABELS: Record<SourceId, string> = {
   'claude-reflect': 'Reflect',
 }
 
+function detectionLabel(hint: DetectionHint): string {
+  const patterns = Array.isArray(hint.pattern) ? hint.pattern : [hint.pattern]
+  return patterns.join(' · ')
+}
+
+function singleRecommendationPrompt(rec: Recommendation, repo: string): string {
+  const c = rec.criterion
+  const ref = c.referencePath ? `\n- Reference implementation: ${c.referencePath} in kubestellar/console` : ''
+  return `Add the "${c.name}" feedback loop to ${repo} so the ACMM dashboard detects it.
+
+Source: ${SOURCE_LABELS[c.source]}
+Criterion ID: ${c.id}
+What this loop does: ${c.description}
+Why it matters: ${rec.reason}
+
+Detection rule (must match at least one after your change):
+- Type: ${c.detection.type}
+- Pattern: ${detectionLabel(c.detection)}${ref}
+
+Please:
+1. Audit the existing repo for any similar artifact that could already satisfy this detection (don't duplicate).
+2. If missing, create/commit the minimum file(s) that match the detection pattern and follow our project conventions.
+3. Return a short summary of what was added and why.
+Do not push or open a PR automatically — stop after the commit so I can review.`
+}
+
+function allRecommendationsPrompt(recs: Recommendation[], repo: string): string {
+  const list = recs
+    .map((r, i) => `${i + 1}. ${r.criterion.name} (${SOURCE_LABELS[r.criterion.source]}) — detection: ${detectionLabel(r.criterion.detection)}`)
+    .join('\n')
+  return `Implement the missing ACMM feedback loops for ${repo}:
+
+${list}
+
+For each item:
+- Check whether an equivalent artifact already exists under a non-standard path (don't duplicate).
+- If truly missing, add the minimum change that matches the detection pattern and follows the repo's conventions.
+- Return a brief summary of what changed for each loop.
+Do not push or open a PR automatically — stop after commits so I can review.`
+}
+
 export function ACMMRecommendations() {
-  const { scan } = useACMM()
+  const { scan, repo } = useACMM()
   const { level, recommendations, isLoading, isRefreshing, isDemoData, isFailed, consecutiveFailures, lastRefresh } = scan
+  const { startMission } = useMissions()
+
+  function launchOne(rec: Recommendation) {
+    startMission({
+      title: `Add ACMM loop: ${rec.criterion.name}`,
+      description: `Add "${rec.criterion.name}" to ${repo}`,
+      type: 'custom',
+      initialPrompt: singleRecommendationPrompt(rec, repo),
+      context: { repo, criterionId: rec.criterion.id },
+    })
+  }
+
+  function launchAll() {
+    if (recommendations.length === 0) return
+    startMission({
+      title: `Add ${recommendations.length} missing ACMM loops`,
+      description: `Implement all top ACMM recommendations for ${repo}`,
+      type: 'custom',
+      initialPrompt: allRecommendationsPrompt(recommendations, repo),
+      context: { repo, criterionIds: recommendations.map((r) => r.criterion.id) },
+    })
+  }
 
   const hasData = scan.data.detectedIds.length > 0
   const { showSkeleton } = useCardLoadingState({
@@ -60,8 +126,21 @@ export function ACMMRecommendations() {
       )}
 
       <div>
-        <div className="text-[10px] text-muted-foreground uppercase tracking-wide mb-1.5">
-          Top recommendations
+        <div className="flex items-center justify-between mb-1.5">
+          <div className="text-[10px] text-muted-foreground uppercase tracking-wide">
+            Top recommendations
+          </div>
+          {recommendations.length > 0 && (
+            <button
+              type="button"
+              onClick={launchAll}
+              className="inline-flex items-center gap-1 text-[10px] px-2 py-0.5 rounded-full bg-primary/20 text-primary hover:bg-primary/30 transition-colors"
+              title={`Launch an AI mission to implement all ${recommendations.length} recommendations`}
+            >
+              <Sparkles className="w-2.5 h-2.5" />
+              Launch mission (all)
+            </button>
+          )}
         </div>
         <div className="space-y-1.5">
           {recommendations.map((rec) => (
@@ -87,6 +166,20 @@ export function ACMMRecommendations() {
               </div>
               <div className="text-[10px] text-muted-foreground/80 mt-1 italic leading-snug">
                 {rec.reason}
+              </div>
+              <div className="mt-1.5 flex items-center justify-between gap-2">
+                <code className="text-[9px] font-mono text-muted-foreground/70 truncate flex-1" title={`Detection (${rec.criterion.detection.type})`}>
+                  {detectionLabel(rec.criterion.detection)}
+                </code>
+                <button
+                  type="button"
+                  onClick={() => launchOne(rec)}
+                  className="inline-flex items-center gap-1 text-[10px] px-1.5 py-0.5 rounded-md bg-primary/10 text-primary hover:bg-primary/20 transition-colors flex-shrink-0"
+                  title="Launch an AI mission to add this loop"
+                >
+                  <Zap className="w-2.5 h-2.5" />
+                  Launch
+                </button>
               </div>
             </div>
           ))}

--- a/web/src/components/cards/intoto_supply_chain/IntotoSupplyChain.tsx
+++ b/web/src/components/cards/intoto_supply_chain/IntotoSupplyChain.tsx
@@ -359,7 +359,7 @@ Please proceed step by step.`,
       <CardSearchInput
         value={localSearch}
         onChange={setLocalSearch}
-        placeholder={t('searchLayouts' as any)}
+        placeholder={t('common:searchLayouts' as any)}
       />
 
       {/* Layouts list */}

--- a/web/src/hooks/useCachedACMMScan.ts
+++ b/web/src/hooks/useCachedACMMScan.ts
@@ -6,6 +6,7 @@
  * changes the cache key and triggers a fresh fetch.
  */
 
+import { useCallback, useRef } from 'react'
 import { useCache, type RefreshCategory } from '../lib/cache'
 import { computeLevel, type LevelComputation } from '../lib/acmm/computeLevel'
 import { computeRecommendations, type Recommendation } from '../lib/acmm/computeRecommendations'
@@ -42,6 +43,8 @@ export interface UseACMMScanResult {
   consecutiveFailures: number
   lastRefresh: number | null
   refetch: () => Promise<void>
+  /** Bypasses the server blob cache for one fetch — use for user-initiated refresh */
+  forceRefetch: () => Promise<void>
 }
 
 const DEFAULT_REPO = 'kubestellar/console'
@@ -105,8 +108,9 @@ function demoScan(repo: string): ACMMScanData {
   }
 }
 
-async function fetchACMMScan(repo: string): Promise<ACMMScanData> {
-  const res = await fetch(`${API_PATH}?repo=${encodeURIComponent(repo)}`)
+async function fetchACMMScan(repo: string, force: boolean): Promise<ACMMScanData> {
+  const qs = force ? `&force=true` : ''
+  const res = await fetch(`${API_PATH}?repo=${encodeURIComponent(repo)}${qs}`)
   if (!res.ok) {
     throw new Error(`ACMM scan failed: ${res.status} ${res.statusText}`)
   }
@@ -115,14 +119,27 @@ async function fetchACMMScan(repo: string): Promise<ACMMScanData> {
 }
 
 export function useCachedACMMScan(repo: string = DEFAULT_REPO): UseACMMScanResult {
+  /** Set to true for the next fetch to bypass the server blob cache (user-triggered refresh). */
+  const forceNextRef = useRef(false)
+
   const cacheResult = useCache<ACMMScanData>({
     key: `acmm:scan:${repo}`,
     category: REFRESH_CATEGORY,
     initialData: emptyScan(repo),
     demoData: demoScan(repo),
-    fetcher: () => fetchACMMScan(repo),
+    fetcher: () => {
+      const force = forceNextRef.current
+      forceNextRef.current = false
+      return fetchACMMScan(repo, force)
+    },
     liveInDemoMode: true,
   })
+
+  const refetch = cacheResult.refetch
+  const forceRefetch = useCallback(async () => {
+    forceNextRef.current = true
+    await refetch()
+  }, [refetch])
 
   const detectedIds = new Set(cacheResult.data.detectedIds ?? [])
   const level = computeLevel(detectedIds)
@@ -144,5 +161,6 @@ export function useCachedACMMScan(repo: string = DEFAULT_REPO): UseACMMScanResul
     consecutiveFailures: cacheResult.consecutiveFailures,
     lastRefresh: cacheResult.lastRefresh,
     refetch: cacheResult.refetch,
+    forceRefetch,
   }
 }


### PR DESCRIPTION
## Summary

Bundles Copilot review follow-ups on #8260 with three user-driven ACMM dashboard improvements.

### Copilot review follow-ups
- searchLayouts translation uses `common:` namespace
- Paginate GitHub Search API in `acmm-scan` (up to 1000 per month)
- Header comment matches current response shape
- `totalCriteria` memoized in RepoPicker

### Force refetch bypasses stale blob cache
Addresses user report: the CI/CD recommendation still appeared after #8280 merged because the 15-min Netlify blob entry held stale `detectedIds`. Now the refresh icon calls `forceRefetch()` which passes `?force=true`, bypassing the cache read while still writing a fresh entry.

### AI mission launch buttons
`ACMMRecommendations` adds "Launch mission (all)" plus per-row "Launch" buttons. Each uses `useMissions().startMission()` with a structured prompt carrying source citation, detection rule, reference path, and a no-push instruction.

### Detection-rule transparency
`ACMMFeedbackLoops` rows expand to show the detection type + pattern, reference file link, a "View source" link to the criterion's source `.ts` file, and a "Propose a change" link that pre-fills a GitHub issue on `kubestellar/console` with labels `acmm,criterion-feedback`.

### ACMM GitHub README badge
- New Netlify function `/api/acmm/badge` returns shields.io endpoint JSON (`label: "ACMM"`, `message: "L4 · Adaptive · 24/31"`, color per level).
- `ACMMProvider` accepts `?repo=owner/name` so badge links open the dashboard scoped to the badge's repo regardless of localStorage.
- `RepoPicker` "Get badge" button opens a panel with live preview and copyable Markdown/HTML snippets.

## Test plan
- [ ] `cd web && npm run build` passes
- [ ] `/acmm` loads, refresh icon forces fresh scan (network shows `?force=true`)
- [ ] Click row in feedback loop inventory → expansion shows detection pattern + links
- [ ] "Launch" button on a recommendation opens a mission with the structured prompt
- [ ] "Get badge" panel shows a live shields.io preview and copy buttons work
- [ ] Badge link opens `/acmm?repo=<owner>/<name>` and dashboard scopes to that repo