### PR TITLE
🐛 fix: wait for state flush in staleness drop test (#8285)

### DIFF
--- a/web/src/lib/__tests__/auth-coverage.test.tsx
+++ b/web/src/lib/__tests__/auth-coverage.test.tsx
@@ -693,11 +693,13 @@ describe('cached user staleness bound (#6067)', () => {
     vi.stubGlobal('fetch', mockFetch)
 
     const { result } = await renderWithAuthProvider()
-    await waitFor(() => expect(result.current.isLoading).toBe(false))
-
-    // Stale cache → session dropped
-    expect(result.current.token).toBeNull()
-    expect(result.current.user).toBeNull()
+    // Stale cache + failed refetch fires setTokenState(null)/setUser(null) —
+    // wait for both flushes, not just the isLoading flip.
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false)
+      expect(result.current.token).toBeNull()
+      expect(result.current.user).toBeNull()
+    })
   })
 
   it('writes validated timestamp after successful /api/me fetch', async () => {


### PR DESCRIPTION
## Summary

- The cache-staleness test in `auth-coverage.test.tsx` asserted `token`/`user` were null right after `isLoading` flipped false
- In the drop-to-login path (stale cache + failed /api/me refetch), the provider flips `isLoading=false` first, then fires `setTokenState(null)` / `setUser(null)` — React batches those into a second render
- Moved the token/user expectations into the existing `waitFor` block so vitest waits for the full state flush

## Test plan

- [x] `npx vitest run src/lib/__tests__/auth-coverage.test.tsx` — 23/23 pass locally
- [ ] CI (build/lint/preview) green

Fixes #8285