### PR TITLE
🐛 fix(test): assert on DOM output not render() return (#8286)

### DIFF
--- a/web/src/components/layout/navbar/__tests__/UpdateIndicator.test.tsx
+++ b/web/src/components/layout/navbar/__tests__/UpdateIndicator.test.tsx
@@ -45,7 +45,10 @@ import { UpdateIndicator } from '../UpdateIndicator'
 import { ToastProvider } from '../../../ui/Toast'
 
 describe('UpdateIndicator', () => {
-  it('renders without crashing', () => {
+  it('renders nothing when there is no update available', () => {
+    // useVersionCheck is mocked to return hasUpdate=null + no release, so the
+    // component should early-return null. Assert on the DOM, not on whether
+    // render() succeeded — `container` is always truthy if render didn't throw.
     const { container } = render(
       <MemoryRouter>
         <ToastProvider>
@@ -53,6 +56,6 @@ describe('UpdateIndicator', () => {
         </ToastProvider>
       </MemoryRouter>
     )
-    expect(container).toBeTruthy()
+    expect(container.firstChild).toBeNull()
   })
 })


### PR DESCRIPTION
## Summary

- UpdateIndicator test asserted `expect(container).toBeTruthy()` which trivially passes whenever `render()` doesn't throw — it never verified the component's early-return on no-update state
- Replaced with `expect(container.firstChild).toBeNull()` so the assertion catches regressions where the component mistakenly renders on a no-update response
- Renamed the test from "renders without crashing" to "renders nothing when there is no update available" to reflect what it actually validates

## Test plan

- [x] `npx vitest run src/components/layout/navbar/__tests__/UpdateIndicator.test.tsx` — passes
- [x] `npm run build` — passes
- [ ] CI green

Addresses #8286 (Copilot review on merged #8283).