### PR TITLE
🐛 fix(intoto): use cross-namespace translation for search placeholder (#8271)

### DIFF
--- a/web/src/components/cards/intoto_supply_chain/IntotoSupplyChain.tsx
+++ b/web/src/components/cards/intoto_supply_chain/IntotoSupplyChain.tsx
@@ -59,7 +59,7 @@ const STEP_STATUS_CONFIG: Record<
 }
 
 function IntotoSupplyChainInternal({ config: _config }: IntotoSupplyChainProps) {
-  const { t } = useTranslation('cards')
+  const { t } = useTranslation(['cards', 'common'])
   const {
     statuses,
     isLoading,
@@ -359,7 +359,7 @@ Please proceed step by step.`,
       <CardSearchInput
         value={localSearch}
         onChange={setLocalSearch}
-        placeholder={t('common:searchLayouts' as any)}
+        placeholder={t('common:common.searchLayouts')}
       />
 
       {/* Layouts list */}


### PR DESCRIPTION
## Summary

- The `IntotoSupplyChain` card called `useTranslation('cards')` with a single namespace, then referenced `t('common:searchLayouts' as any)` via the `common:` prefix
- The `as any` cast hid a real bug: the `searchLayouts` key isn't at the top level of `common.json` — it lives at `common.searchLayouts`
- Aligned with the same pattern as `KyvernoPolicies.tsx:30`: use `useTranslation(['cards', 'common'])` and the full path `common:common.searchLayouts`
- Placeholder now renders "Search layouts..." instead of the raw key

## Remaining Copilot comments on #8271

Verified each and resolved the others without a patch:

- **useSearchIndex.ts ALL_STATS_DASHBOARD_TYPES** — already contains `'acmm'` (line 119)
- **RepoPicker total 33** — already uses `ALL_CRITERIA.length` (line 60), not hardcoded
- **useCachedACMMScan refresh rate** — already uses `'costs'` (10-min), not `'default'` (2-min)
- **acmm-scan.mts `trees/HEAD`** — empirically works (tested 200 on kubestellar/console); GitHub's Git Trees API accepts HEAD as a ref
- **acmm-scan.mts pagination** — already uses `searchAllPages` (up to 10 × 100 pages)
- **acmm-scan.mts header comment** — already accurate (mentions `detectedIds`, `weeklyActivity`, `fromCache`, `demoFallback`)
- **RepoPicker raw `<input>`** — not flagged by eslint `no-restricted-syntax` (rule only covers consecutive setState calls, not `<input>`); deferred as cosmetic

## Test plan

- [x] `npm run build` — passes
- [x] `npm run lint` — exit 0
- [ ] CI green

Addresses #8271 (Copilot review on merged #8260).