### PR TITLE
🐛 fix: Node Conditions pills always sum to total (#8297)

### DIFF
--- a/web/src/components/cards/NodeConditions.tsx
+++ b/web/src/components/cards/NodeConditions.tsx
@@ -35,42 +35,35 @@ export function NodeConditions() {
   const [confirmAction, setConfirmAction] = useState<PendingAction | null>(null)
   const [actionError, setActionError] = useState<string | null>(null)
 
+  // Mutually-exclusive classification so the pill counts always sum to the
+  // total: a node with Ready!=True and no other True conditions (network
+  // partition, NotReady) otherwise lands in no bucket, and a cordoned node
+  // with pressure was being double-counted (#8297). Priority: cordoned >
+  // pressure > healthy.
+  const classify = (n: { unschedulable?: boolean; conditions?: Array<{ type: string; status: string }> }): Exclude<ConditionFilter, 'all'> => {
+    if (n.unschedulable) return 'cordoned'
+    const conditions = n.conditions || []
+    const ready = conditions.find(c => c.type === 'Ready')
+    const isReady = ready?.status === 'True'
+    const hasOtherPressure = conditions.some(c => c.type !== 'Ready' && c.status === 'True')
+    if (!isReady || hasOtherPressure) return 'pressure'
+    return 'healthy'
+  }
+
   const summary = (() => {
-    const cordoned = nodes.filter(n => n.unschedulable)
-    const pressure = nodes.filter(n => {
-      const conditions = n.conditions || []
-      return conditions.some((c: { type: string; status: string }) =>
-        c.type !== 'Ready' && c.status === 'True'
-      )
-    })
-    const healthy = nodes.filter(n => {
-      const conditions = n.conditions || []
-      const ready = conditions.find((c: { type: string }) => c.type === 'Ready')
-      return ready && (ready as { status: string }).status === 'True' && !n.unschedulable
-    })
-    return { total: nodes.length, healthy: healthy.length, cordoned: cordoned.length, pressure: pressure.length }
+    let healthy = 0, cordoned = 0, pressure = 0
+    for (const n of nodes) {
+      const bucket = classify(n)
+      if (bucket === 'healthy') healthy++
+      else if (bucket === 'cordoned') cordoned++
+      else pressure++
+    }
+    return { total: nodes.length, healthy, cordoned, pressure }
   })()
 
   const filtered = useMemo(() => {
-    switch (filter) {
-      case 'healthy':
-        return nodes.filter(n => {
-          const conditions = n.conditions || []
-          const ready = conditions.find((c: { type: string }) => c.type === 'Ready')
-          return ready && (ready as { status: string }).status === 'True' && !n.unschedulable
-        })
-      case 'cordoned':
-        return nodes.filter(n => n.unschedulable)
-      case 'pressure':
-        return nodes.filter(n => {
-          const conditions = n.conditions || []
-          return conditions.some((c: { type: string; status: string }) =>
-            c.type !== 'Ready' && c.status === 'True'
-          )
-        })
-      default:
-        return nodes
-    }
+    if (filter === 'all') return nodes
+    return nodes.filter(n => classify(n) === filter)
   }, [nodes, filter])
 
   /** Show confirmation dialog before executing cordon/uncordon */

--- a/web/src/components/cards/__tests__/NodeConditions.test.tsx
+++ b/web/src/components/cards/__tests__/NodeConditions.test.tsx
@@ -98,6 +98,40 @@ describe('NodeConditions', () => {
       expect(screen.getByText(/nodeConditions.filterAll: 2/)).toBeTruthy()
     })
 
+    it('classifies NotReady nodes as pressure so pills always sum to total (#8297)', async () => {
+      const { useCachedNodes } = await import('../../../hooks/useCachedData')
+      vi.mocked(useCachedNodes).mockReturnValue({
+        nodes: [
+          makeNode({ name: 'a' }),
+          makeNode({ name: 'b' }),
+          makeNode({ name: 'c' }),
+          makeNode({ name: 'notready', conditions: [{ type: 'Ready', status: 'Unknown' }] }),
+        ],
+        isLoading: false, isRefreshing: false, isDemoFallback: false, isFailed: false, consecutiveFailures: 0,
+      } as never)
+      render(<NodeConditions />)
+      expect(screen.getByText(/nodeConditions.filterAll: 4/)).toBeTruthy()
+      expect(screen.getByText(/nodeConditions.filterHealthy: 3/)).toBeTruthy()
+      expect(screen.getByText(/nodeConditions.filterCordoned: 0/)).toBeTruthy()
+      expect(screen.getByText(/nodeConditions.filterPressure: 1/)).toBeTruthy()
+    })
+
+    it('does not double-count a cordoned node that also has pressure (#8297)', async () => {
+      const { useCachedNodes } = await import('../../../hooks/useCachedData')
+      vi.mocked(useCachedNodes).mockReturnValue({
+        nodes: [makeNode({
+          name: 'both',
+          unschedulable: true,
+          conditions: [{ type: 'Ready', status: 'True' }, { type: 'MemoryPressure', status: 'True' }],
+        })],
+        isLoading: false, isRefreshing: false, isDemoFallback: false, isFailed: false, consecutiveFailures: 0,
+      } as never)
+      render(<NodeConditions />)
+      expect(screen.getByText(/nodeConditions.filterAll: 1/)).toBeTruthy()
+      expect(screen.getByText(/nodeConditions.filterCordoned: 1/)).toBeTruthy()
+      expect(screen.getByText(/nodeConditions.filterPressure: 0/)).toBeTruthy()
+    })
+
     it('filters to cordoned nodes on cordoned pill click', async () => {
       const { useCachedNodes } = await import('../../../hooks/useCachedData')
       vi.mocked(useCachedNodes).mockReturnValue({


### PR DESCRIPTION
## Summary

Fixes #8297 — reporter saw \`All:4 Healthy:3 Cordoned:0 Pressure:0\` on the Node Conditions card. One node was unclassified because the three filter predicates weren't mutually exclusive: a node with \`Ready!=True\` and no other \`status:True\` conditions landed in no bucket, and a cordoned-with-pressure node landed in two.

## Fix

Single \`classify()\` pass with priority \`cordoned > pressure > healthy\`. NotReady/Unknown nodes now classify as pressure. Filtered view reuses the same predicate.

## Test plan

- [x] \`npx vitest run NodeConditions\` — 17 tests pass (2 new: NotReady classification, cordoned+pressure no double-count)
- [x] \`npm run build\`
- [x] \`npm run lint\`

Fixes #8297