### PR TITLE
🐛 fix: browser-specific notification enable instructions (#8305)

### DIFF
--- a/web/src/components/settings/sections/BrowserNotificationSettings.tsx
+++ b/web/src/components/settings/sections/BrowserNotificationSettings.tsx
@@ -7,11 +7,31 @@ import { isBrowserNotifVerified, setBrowserNotifVerified } from '../../../lib/no
 type BrowserNotifState = 'idle' | 'asked' | 'verified' | 'failed'
 
 /**
+ * Pick browser-specific instruction key. The OS-level notification center
+ * labels the browser differently depending on which one is installed, so
+ * showing "Google Chrome → Allow Notifications" to a Firefox user is wrong
+ * (#8305). Edge must match before Chrome because its UA contains "Chrome".
+ */
+export function detectInstructionKey(ua: string): string {
+  const u = ua.toLowerCase()
+  if (u.includes('edg/') || u.includes('edge/')) return 'settings.notifications.browser.enableInstructionsEdge'
+  if (u.includes('firefox/')) return 'settings.notifications.browser.enableInstructionsFirefox'
+  if (u.includes('safari/') && !u.includes('chrome/') && !u.includes('chromium/') && !u.includes('android')) {
+    return 'settings.notifications.browser.enableInstructionsSafari'
+  }
+  if (u.includes('chrome/') || u.includes('chromium/')) return 'settings.notifications.browser.enableInstructionsChrome'
+  return 'settings.notifications.browser.enableInstructionsGeneric'
+}
+
+/**
  * Browser notification settings sub-section.
  * Handles permission requests, test notifications, and verification flow.
  */
 export function BrowserNotificationSettings() {
   const { t } = useTranslation()
+  const instructionKey = detectInstructionKey(
+    typeof navigator !== 'undefined' ? navigator.userAgent : '',
+  )
   const [browserNotifState, setBrowserNotifState] = useState<BrowserNotifState>(
     () => (isBrowserNotifVerified() ? 'verified' : 'idle'),
   )
@@ -122,7 +142,10 @@ export function BrowserNotificationSettings() {
               <div className="flex items-start gap-2 p-3 rounded-lg bg-amber-500/10 border border-amber-500/20">
                 <X className="w-4 h-4 text-amber-400 flex-shrink-0 mt-0.5" />
                 <p className="text-sm text-amber-400">
-                  {t('settings.notifications.browser.enableInstructions')}
+                  {t(instructionKey as never)}
+                </p>
+                <p className="text-xs text-amber-400/80">
+                  {t('settings.notifications.browser.dndHint')}
                 </p>
               </div>
               <button

--- a/web/src/components/settings/sections/__tests__/BrowserNotificationSettings.test.tsx
+++ b/web/src/components/settings/sections/__tests__/BrowserNotificationSettings.test.tsx
@@ -1,0 +1,31 @@
+import { describe, it, expect } from 'vitest'
+import { detectInstructionKey } from '../BrowserNotificationSettings'
+
+const FIREFOX_UA = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:120.0) Gecko/20100101 Firefox/120.0'
+const CHROME_UA = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/122.0.0.0 Safari/537.36'
+const EDGE_UA = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/122.0.0.0 Safari/537.36 Edg/122.0.0.0'
+const SAFARI_UA = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.3 Safari/605.1.15'
+
+describe('detectInstructionKey', () => {
+  it('returns Firefox key for a Firefox UA (reporter is on Firefox — #8305)', () => {
+    expect(detectInstructionKey(FIREFOX_UA)).toBe('settings.notifications.browser.enableInstructionsFirefox')
+  })
+
+  it('returns Chrome key for Chrome', () => {
+    expect(detectInstructionKey(CHROME_UA)).toBe('settings.notifications.browser.enableInstructionsChrome')
+  })
+
+  it('returns Edge key for Edge (must match before Chrome — its UA contains "Chrome")', () => {
+    expect(detectInstructionKey(EDGE_UA)).toBe('settings.notifications.browser.enableInstructionsEdge')
+  })
+
+  it('returns Safari key only for real Safari, not Chrome-on-Mac', () => {
+    expect(detectInstructionKey(SAFARI_UA)).toBe('settings.notifications.browser.enableInstructionsSafari')
+    expect(detectInstructionKey(CHROME_UA)).not.toBe('settings.notifications.browser.enableInstructionsSafari')
+  })
+
+  it('falls back to generic for empty/unknown UA', () => {
+    expect(detectInstructionKey('')).toBe('settings.notifications.browser.enableInstructionsGeneric')
+    expect(detectInstructionKey('SomeWeirdBrowser/1.0')).toBe('settings.notifications.browser.enableInstructionsGeneric')
+  })
+})

--- a/web/src/locales/en/common.json
+++ b/web/src/locales/en/common.json
@@ -388,6 +388,12 @@
         "no": "No",
         "verified": "Browser notifications verified and working.",
         "enableInstructions": "Make sure notifications are enabled: System Settings → Notifications → Google Chrome → Allow Notifications",
+        "enableInstructionsChrome": "Make sure notifications are enabled: System Settings → Notifications → Google Chrome → Allow Notifications.",
+        "enableInstructionsFirefox": "Make sure notifications are enabled: System Settings → Notifications → Firefox → Allow Notifications, and check Firefox's site permissions for this page.",
+        "enableInstructionsSafari": "Make sure notifications are enabled: System Settings → Notifications → Safari → Allow Notifications, and Safari → Settings → Websites → Notifications.",
+        "enableInstructionsEdge": "Make sure notifications are enabled: System Settings → Notifications → Microsoft Edge → Allow Notifications.",
+        "enableInstructionsGeneric": "Make sure notifications are enabled in your operating system's notification settings for this browser, and in the browser's site permissions for this page.",
+        "dndHint": "Also check that Do Not Disturb / Focus mode is off — the OS suppresses notifications while it's on.",
         "tryAgain": "Try Again",
         "blocked": "Browser notifications are blocked. Enable them in your browser's site settings for this page, then reload.",
         "requestPermission": "Request Permission"


### PR DESCRIPTION
Fixes #8305

## Summary
- Detect the user's browser from `navigator.userAgent` and pick a matching instruction string instead of always saying "Google Chrome → Allow Notifications"
- Added 5 browser-specific keys (Chrome/Chromium, Firefox, Edge, Safari, Generic) plus a DND/Focus-mode hint
- Edge is matched before Chrome (its UA contains `Chrome/`); Safari excludes Chrome/Chromium/Android to avoid matching Chrome-on-Mac
- Unit tests cover all 5 branches

## Why
Reporter was on Firefox, triggered the "Didn't see it?" path, and got told to change Chrome's settings — confusing and unactionable. The OS notification center labels the browser by its name, so the hint is only useful when it matches the browser the user is actually running.

## Test plan
- [x] Unit tests for `detectInstructionKey()` — Firefox / Chrome / Edge / Safari / empty
- [x] `npm run build` passes
- [x] `npm run lint` — no new violations on touched files

🤖 Generated with [Claude Code](https://claude.com/claude-code)