### PR TITLE
🐛 fix: Copilot follow-up on proxy 429 handling (#8307)

### DIFF
--- a/pkg/api/handlers/github_proxy.go
+++ b/pkg/api/handlers/github_proxy.go
@@ -4,6 +4,7 @@ import (
 	"io"
 	"log/slog"
 	"net/http"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -33,6 +34,10 @@ const (
 	// as "Too many requests" even when the user's PAT had plenty of quota
 	// left (#8299). 20 comfortably absorbs one card's load.
 	githubProxyBurstSize = 20
+	// githubProxyRetryAfterSeconds is the value advertised in the Retry-After
+	// header when we reject a request with 429 (#8307). 60 matches the bucket
+	// refill window so clients back off for a full cycle.
+	githubProxyRetryAfterSeconds = 60
 	// maxGitHubResponseBytes caps the size of GitHub API response bodies that
 	// the proxy will buffer, preventing memory exhaustion from large list
 	// endpoints or crafted query parameters (#7035).
@@ -143,7 +148,8 @@ func (h *GitHubProxyHandler) resolveToken() string {
 // Only GET requests are allowed (read-only proxy).
 func (h *GitHubProxyHandler) Proxy(c *fiber.Ctx) error {
 	// Rate-limit outbound GitHub API calls per user to protect the shared PAT
-	// quota. Each user gets their own 30 req/min bucket (#7034).
+	// quota (#7034). See githubProxyMaxRequestsPerMinute / githubProxyBurstSize
+	// for the current bucket size.
 	uid := middleware.GetUserID(c)
 	limiterKey := uid.String()
 	if limiterKey == "00000000-0000-0000-0000-000000000000" {
@@ -151,6 +157,7 @@ func (h *GitHubProxyHandler) Proxy(c *fiber.Ctx) error {
 	}
 	if !getGitHubProxyLimiter(limiterKey).Allow() {
 		slog.Warn("[GitHubProxy] rate limit exceeded, rejecting request", "user", limiterKey)
+		c.Set("Retry-After", strconv.Itoa(githubProxyRetryAfterSeconds))
 		return c.Status(fiber.StatusTooManyRequests).JSON(fiber.Map{
 			"error": "Console proxy rate limit exceeded (not GitHub). Please wait a moment and retry.",
 		})

--- a/web/src/components/cards/GitHubActivity.tsx
+++ b/web/src/components/cards/GitHubActivity.tsx
@@ -199,6 +199,24 @@ function saveRepos(repos: string[]) {
 }
 
 // Demo data for GitHub Activity card
+/**
+ * Build an Error for a failed /api/github/* fetch that prefers the proxy's
+ * JSON body `error` field over response.statusText (#8307). The console proxy
+ * returns context-rich 429 messages like "Console proxy rate limit exceeded
+ * (not GitHub)." that never reached users when we only read statusText.
+ */
+async function githubFetchError(response: Response, label: string): Promise<Error> {
+  try {
+    const body = await response.clone().json()
+    if (body && typeof body.error === 'string' && body.error) {
+      return new Error(`${label}: ${body.error}`)
+    }
+  } catch {
+    // Fall through to statusText
+  }
+  return new Error(`${label}: ${response.statusText || response.status}`)
+}
+
 function getDemoGitHubData(repoName: string) {
   const now = new Date()
   const daysAgo = (d: number) => new Date(now.getTime() - d * 86400000).toISOString()
@@ -325,7 +343,7 @@ function useGitHubActivity(config?: GitHubActivityConfig) {
 
       // Fetch repository info
       const repoResponse = await fetch(`/api/github/repos/${targetRepo}`, fetchOptions)
-      if (!repoResponse.ok) throw new Error(`Failed to fetch repo: ${repoResponse.statusText}`)
+      if (!repoResponse.ok) throw await githubFetchError(repoResponse, 'Failed to fetch repo')
       // Use .catch() directly on .json() to prevent Firefox from firing unhandledrejection
       // before the outer try/catch processes the rejection (Firefox-specific microtask timing).
       const repoData = await repoResponse.json().catch(() => null)
@@ -340,8 +358,8 @@ function useGitHubActivity(config?: GitHubActivityConfig) {
         fetch(`/api/github/repos/${targetRepo}/pulls?state=closed&per_page=50&sort=updated`, fetchOptions)
       ])
 
-      if (!openPRsResponse.ok) throw new Error(`Failed to fetch open PRs: ${openPRsResponse.statusText}`)
-      if (!closedPRsResponse.ok) throw new Error(`Failed to fetch closed PRs: ${closedPRsResponse.statusText}`)
+      if (!openPRsResponse.ok) throw await githubFetchError(openPRsResponse, 'Failed to fetch open PRs')
+      if (!closedPRsResponse.ok) throw await githubFetchError(closedPRsResponse, 'Failed to fetch closed PRs')
 
       const openPRsData = await openPRsResponse.json().catch(() => null)
       const closedPRsData = await closedPRsResponse.json().catch(() => null)
@@ -377,7 +395,7 @@ function useGitHubActivity(config?: GitHubActivityConfig) {
         setOpenIssueCount(calculatedOpenIssueCount)
       }
 
-      if (!recentIssuesResponse.ok) throw new Error(`Failed to fetch issues: ${recentIssuesResponse.statusText}`)
+      if (!recentIssuesResponse.ok) throw await githubFetchError(recentIssuesResponse, 'Failed to fetch issues')
       const issuesData: GitHubIssue[] = await recentIssuesResponse.json().catch(() => null) ?? []
       // Filter out pull requests (they come with issues endpoint but have pull_request field)
       const filteredIssues = issuesData.filter((issue: GitHubIssue & { pull_request?: unknown }) => !issue.pull_request)
@@ -386,7 +404,7 @@ function useGitHubActivity(config?: GitHubActivityConfig) {
 
       // Fetch Releases
       const releasesResponse = await fetch(`/api/github/repos/${targetRepo}/releases?per_page=10`, fetchOptions)
-      if (!releasesResponse.ok) throw new Error(`Failed to fetch releases: ${releasesResponse.statusText}`)
+      if (!releasesResponse.ok) throw await githubFetchError(releasesResponse, 'Failed to fetch releases')
       const releasesData = await releasesResponse.json().catch(() => null)
       if (!releasesData) throw new Error('Failed to parse GitHub releases response: invalid JSON')
       if (signal?.aborted) return
@@ -394,7 +412,7 @@ function useGitHubActivity(config?: GitHubActivityConfig) {
 
       // Fetch Contributors
       const contributorsResponse = await fetch(`/api/github/repos/${targetRepo}/contributors?per_page=20`, fetchOptions)
-      if (!contributorsResponse.ok) throw new Error(`Failed to fetch contributors: ${contributorsResponse.statusText}`)
+      if (!contributorsResponse.ok) throw await githubFetchError(contributorsResponse, 'Failed to fetch contributors')
       const contributorsData = await contributorsResponse.json().catch(() => null)
       if (!contributorsData) throw new Error('Failed to parse GitHub contributors response: invalid JSON')
       if (signal?.aborted) return


### PR DESCRIPTION
Fixes #8307

## Summary
Addresses the three Copilot review comments left on merged PR #8304:

1. **Stale comment** — the inline `"each user gets a 30 req/min bucket"` note in `Proxy()` was never updated when the constant was bumped to 60. Reworded so it points at the constants (self-documenting).
2. **Retry-After header** — 429 responses now set `Retry-After: 60` (matches the bucket refill window), consistent with the auth/public/api limiters already in `server.go`.
3. **Error body surfaced** — added `githubFetchError()` helper in `GitHubActivity.tsx` that prefers the proxy's JSON `error` field over `response.statusText`. Applied to all six fetch sites, so a 429 from our proxy now shows the helpful `"Console proxy rate limit exceeded (not GitHub)..."` instead of plain `"Too Many Requests"`.

## Test plan
- [x] `go build ./...` + `go vet ./pkg/api/handlers/...` clean
- [x] `npm run build` clean
- [x] Backend change is additive (new constant + header); no behavior change for successful requests

🤖 Generated with [Claude Code](https://claude.com/claude-code)