### PR TITLE
🐛 fix: card Resize Height menu had no visual effect (#8289 #8298)

### DIFF
--- a/web/src/components/dashboard/CustomDashboard.tsx
+++ b/web/src/components/dashboard/CustomDashboard.tsx
@@ -67,13 +67,15 @@ const NARROW_MAX = 1023
 const MIN_NARROW_COLS = 6
 
 /**
- * Minimum pixel height a non-collapsed sortable card cell should occupy.
- * Mirrors the legacy `auto-rows-[minmax(180px,auto)]` baseline so expanded
- * cards keep their previous look now that the grid container uses
- * `auto-rows-min` (which is required so collapsed cards can shrink and let
- * neighbours pack upward — see issue #6072).
+ * Minimum pixel height contributed by ONE row of card span. Effective
+ * min-height = posH × this constant, so the "Resize height" menu has a
+ * visible effect on `auto-rows-min` grids (#8289, #8298). Mirrors the
+ * legacy `auto-rows-[minmax(180px,auto)]` baseline (180px per row).
  */
-const EXPANDED_CARD_MIN_HEIGHT_PX = 180
+const EXPANDED_CARD_ROW_MIN_HEIGHT_PX = 180
+
+/** Default row span when a card has no persisted position.h */
+const DEFAULT_CARD_ROW_SPAN = 2
 
 // Sortable card component
 interface SortableCardProps {
@@ -111,18 +113,23 @@ function SortableCard({ card, onConfigure, onRemove, onWidthChange, onHeightChan
   }, []) // eslint-disable-line react-hooks/exhaustive-deps
 
   const effectiveW = isNarrowRange && (card.position?.w || 4) < MIN_NARROW_COLS ? MIN_NARROW_COLS : (card.position?.w || 4)
+  const posH = card.position?.h || DEFAULT_CARD_ROW_SPAN
 
   // Read collapse state so the cell can drop its minimum height when the
   // card is collapsed (#6072). Without this, the grid leaves dead space
   // under collapsed cards because every cell is forced to the expanded
   // baseline height.
   const { isCollapsed } = useCardCollapse(card.id)
+  const effectiveRowSpan = isCollapsed ? 1 : posH
 
   const style = {
     transform: CSS.Transform.toString(transform),
     transition,
     gridColumn: `span ${effectiveW}`,
-    minHeight: isCollapsed ? undefined : `${EXPANDED_CARD_MIN_HEIGHT_PX}px`,
+    gridRow: `span ${effectiveRowSpan}`,
+    // Scale min-height by posH so the "Resize height" menu actually changes
+    // the card's visual height on an auto-rows-min grid (#8289, #8298).
+    minHeight: isCollapsed ? undefined : `${posH * EXPANDED_CARD_ROW_MIN_HEIGHT_PX}px`,
     opacity: isDragging ? 0.5 : 1 }
 
   const CardComponent = CARD_COMPONENTS[card.card_type]

--- a/web/src/components/dashboard/SharedSortableCard.tsx
+++ b/web/src/components/dashboard/SharedSortableCard.tsx
@@ -17,12 +17,17 @@ import type { Card } from './dashboardUtils'
 const COLLAPSED_CARD_ROW_SPAN = 1
 
 /**
- * Minimum pixel height a non-collapsed sortable card cell should occupy.
- * Mirrors the legacy `auto-rows-[minmax(180px,auto)]` baseline so expanded
- * cards keep their previous look when the grid container itself uses
- * `auto-rows-min` (which is required so collapsed cards can shrink).
+ * Minimum pixel height contributed by ONE row of card span, used to mirror
+ * the legacy `auto-rows-[minmax(180px,auto)]` baseline while the grid itself
+ * uses `auto-rows-min` (required so collapsed cards can shrink).
+ *
+ * Effective card min-height = row count × this constant. Scaling with the
+ * row span is what makes the "Resize height" menu actually change card
+ * height (#8289, #8298). With a flat constant, `gridRow: span N` only
+ * reserves N grid rows but `auto-rows-min` collapses those rows to the
+ * card's content, so taller row counts had no visible effect.
  */
-const EXPANDED_CARD_MIN_HEIGHT_PX = 180
+const EXPANDED_CARD_ROW_MIN_HEIGHT_PX = 180
 
 interface SortableCardProps {
   card: Card
@@ -109,8 +114,9 @@ export const SortableCard = memo(function SortableCard({ card, onConfigure, onRe
     gridRow: `span ${effectiveRowSpan}`,
     // Only enforce the legacy minimum height when expanded; collapsed cards
     // must be free to shrink to their header height so neighbouring rows can
-    // pack upward instead of leaving dead space.
-    minHeight: isCollapsed ? undefined : `${EXPANDED_CARD_MIN_HEIGHT_PX}px`,
+    // pack upward instead of leaving dead space. Scale with posH so the
+    // "Resize height" menu actually grows/shrinks the card (#8289, #8298).
+    minHeight: isCollapsed ? undefined : `${posH * EXPANDED_CARD_ROW_MIN_HEIGHT_PX}px`,
     opacity: isDragging ? 0.5 : 1,
   }
 


### PR DESCRIPTION
Fixes #8289, Fixes #8298

## Summary
The per-card **Resize height** menu (Small/Medium/Large/Wide/Full) persisted the pick but didn't actually change card height — and neighbouring cards would shift for no obvious reason. Reporters flagged it on Cluster Health (#8289) and AI Health Check (#8298), but the bug affects every card on both `Dashboard.tsx` and `CustomDashboard.tsx`.

## Root cause
The dashboard grid uses `auto-rows-min grid-flow-dense` (required so collapsed cards can shrink and neighbours can pack upward — #6072). Cards set `gridRow: span N` from `position.h`, but `auto-rows-min` sizes rows to min-content, so a taller row count only reserves more rows without enforcing a taller cell. The only thing driving actual card height was a flat `minHeight: 180px`, which is the same value for every row span. That's why the menu looked broken — it updated storage and re-rendered, but the card stayed 180px tall while the dense packer redistributed neighbours around the unchanged cell.

## Fix
- Rename `EXPANDED_CARD_MIN_HEIGHT_PX` → `EXPANDED_CARD_ROW_MIN_HEIGHT_PX` and multiply by `posH`, so a height-4 card gets `4 × 180 = 720px` min-height
- Apply the same fix in both `SharedSortableCard.tsx` and `CustomDashboard.tsx`
- `CustomDashboard` was also missing `gridRow: span N` entirely — the Height menu was a no-op there — so that was added
- Collapsed cards keep their existing `undefined` minHeight + single-row span

## Test plan
- [x] `npm run build` clean
- [ ] Manual: open a custom dashboard, pick Small → Medium → Large → Wide → Full from the Height menu on several cards; card height should visibly grow each time
- [ ] Manual: collapse a card — it should still shrink to header height regardless of persisted height pick

🤖 Generated with [Claude Code](https://claude.com/claude-code)