### PR TITLE
🐛 fix: Go test alignment unblocking nightly release (#8310 #8313 #8314)

### DIFF
--- a/pkg/agent/server_test.go
+++ b/pkg/agent/server_test.go
@@ -460,10 +460,19 @@ func TestServer_SettingsHandlers(t *testing.T) {
 		t.Fatalf("Failed to decode keys status: %v", err)
 	}
 
-	// API-key providers are intentionally hidden (only CLI-based agents shown),
-	// so the keys endpoint returns an empty list even when keys are configured.
-	if len(resp.Keys) != 0 {
-		t.Errorf("Expected empty keys list (API-key providers hidden), got %d entries", len(resp.Keys))
+	// handleGetKeysStatus now reports the nine chat-only HTTP providers registered
+	// in InitializeProviders (3 OpenAI-compatible gateways + 6 local LLM runners)
+	// so the Settings modal can render a per-provider base URL override field
+	// (#8248, #8254, #8256). CLI-based tool-capable agents remain hidden — they
+	// manage their own credentials. The list must be non-empty and all entries
+	// must carry a Provider name.
+	if len(resp.Keys) == 0 {
+		t.Error("Expected keys list to include chat-only HTTP providers, got 0 entries")
+	}
+	for _, k := range resp.Keys {
+		if k.Provider == "" {
+			t.Errorf("Key status entry missing Provider: %+v", k)
+		}
 	}
 }
 

--- a/pkg/api/handlers/cards_test.go
+++ b/pkg/api/handlers/cards_test.go
@@ -199,8 +199,17 @@ func TestRecordFocus_BadBody_Returns400(t *testing.T) {
 	dashID := uuid.New()
 	cardID := uuid.New()
 
+	mockStore := new(test.MockStore)
+	// RecordFocus now runs requireEditorOrAdmin before parsing the body (#7011),
+	// which calls store.GetUser. Register an admin user so the role check passes
+	// and the handler proceeds to BodyParser, which is what this test exercises.
+	mockStore.On("GetUser", userID).Return(&models.User{
+		ID:   userID,
+		Role: models.UserRoleAdmin,
+	}, nil).Maybe()
+
 	rfs := &recordFocusStore{
-		MockStore: new(test.MockStore),
+		MockStore: mockStore,
 		card: &models.Card{
 			ID:          cardID,
 			DashboardID: dashID,

--- a/pkg/api/handlers/dashboard_test.go
+++ b/pkg/api/handlers/dashboard_test.go
@@ -23,6 +23,14 @@ const fiberTestTimeout = 5000
 func setupDashboardTest(userID uuid.UUID) (*fiber.App, *test.MockStore, *DashboardHandler) {
 	app := fiber.New()
 	mockStore := new(test.MockStore)
+
+	// CreateDashboard now enforces a per-user dashboard limit (#7010) by
+	// calling store.CountUserDashboards before creating. Register a default
+	// expectation so tests that don't override it return 0 (under limit) and
+	// proceed to creation. Tests exercising the limit can override with a
+	// higher return value before calling the handler.
+	mockStore.On("CountUserDashboards", userID).Return(0, nil).Maybe()
+
 	handler := NewDashboardHandler(mockStore)
 
 	// Inject userID into context (simulates auth middleware)

--- a/pkg/api/handlers/setup_test.go
+++ b/pkg/api/handlers/setup_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/kubestellar/console/pkg/settings"
 	"github.com/kubestellar/console/pkg/store"
 	"github.com/kubestellar/console/pkg/test"
+	"github.com/stretchr/testify/mock"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/dynamic/fake"
@@ -80,6 +81,14 @@ func setupTestEnv(t *testing.T) *testEnv {
 		ID:   testAdminUserID,
 		Role: "admin",
 	}, nil)
+
+	// Cluster-group CRUD handlers persist definitions to the store (#7013).
+	// Register permissive mocks so TestClusterGroupsCRUD doesn't panic when
+	// the handler calls Save/Delete/List. Individual tests can override with
+	// an explicit expectation to assert specific persistence behavior.
+	mockStore.On("SaveClusterGroup", mock.Anything, mock.Anything).Return(nil).Maybe()
+	mockStore.On("DeleteClusterGroup", mock.Anything).Return(nil).Maybe()
+	mockStore.On("ListClusterGroups").Return(map[string][]byte{}, nil).Maybe()
 
 	app := fiber.New()
 


### PR DESCRIPTION
## Summary

Nightly `Release` workflow has been failing every night since 2026-04-13 (runs: 24328017228, 24383107176, 24438572049, 24494366158). Root cause is four Go tests that fell out of sync with handler changes shipped in the last two weeks.

- **`TestServer_SettingsHandlers`** expected the agent `/settings/keys` response to be empty, but #8248/#8254/#8256 now register nine chat-only HTTP providers (3 OpenAI-compatible gateways + 6 local LLM runners) so the Settings modal can render a per-provider base URL override field. Asserts non-empty list and `Provider` presence instead.
- **`TestRecordFocus_BadBody_Returns400`** panicked because `RecordFocus` now runs `requireEditorOrAdmin` (#7011), which calls `store.GetUser` — the test's custom `recordFocusStore` wrapper never registered the expectation. Adds the admin-user mock so the role check passes and the test reaches its intended BodyParser check.
- **`setupDashboardTest`** — `CreateDashboard` now enforces a per-user dashboard limit (#7010) via `store.CountUserDashboards`. Default helper registers `Return(0, nil).Maybe()` so the three existing CreateDashboard tests stay under the limit; tests exercising the limit can override.
- **`setupTestEnv`** — `TestClusterGroupsCRUD` panicked because cluster-group handlers persist to the store (#7013) via `SaveClusterGroup` / `DeleteClusterGroup` / `ListClusterGroups`. Registers permissive `.Maybe()` mocks on the shared MockStore.

## Test plan

- [x] `go test ./...` — all packages pass locally
- [x] Each originally-failing test runs green in isolation
- [ ] CI build + lint pass on PR

Fixes #8310, Fixes #8313, Fixes #8314