### PR TITLE
🐛 fix(analytics): include accumulated in peekSessionEngagementMs + tests (#8318)

### DIFF
--- a/web/src/lib/__tests__/analytics-deep.test.ts
+++ b/web/src/lib/__tests__/analytics-deep.test.ts
@@ -595,6 +595,88 @@ describe('engagement tracking logic', () => {
     expect(total).toBe(10000)
     expect(accumulatedEngagementMs).toBe(0)
   })
+
+  it('peekSessionEngagementMs includes accumulated + session + active', () => {
+    const sessionEngagementMs = 4000
+    const accumulatedEngagementMs = 3000
+    const isUserActive = true
+    const engagementStartMs = Date.now() - 2000
+
+    function peekSessionEngagementMs(): number {
+      let total = sessionEngagementMs + accumulatedEngagementMs
+      if (isUserActive) {
+        total += Date.now() - engagementStartMs
+      }
+      return total
+    }
+
+    expect(peekSessionEngagementMs()).toBeGreaterThanOrEqual(9000)
+  })
+
+  it('cumulative engagement across route changes triggers engaged-session', () => {
+    const ENGAGED_SESSION_THRESHOLD_MS = 10000
+    let sessionEngagementMs = 0
+    let accumulatedEngagementMs = 0
+    let sessionPageViewCount = 0
+    let sessionEngaged = false
+
+    function peekSessionEngagementMs(): number {
+      return sessionEngagementMs + accumulatedEngagementMs
+    }
+
+    function onSend(eventName: string) {
+      if (eventName === 'page_view') sessionPageViewCount += 1
+      if (!sessionEngaged && (
+        peekSessionEngagementMs() >= ENGAGED_SESSION_THRESHOLD_MS ||
+        sessionPageViewCount >= 2
+      )) {
+        sessionEngaged = true
+      }
+      if (eventName === 'user_engagement') {
+        sessionEngagementMs += accumulatedEngagementMs
+        accumulatedEngagementMs = 0
+      }
+    }
+
+    // Route 1: 4s dwell → flushed by user_engagement
+    accumulatedEngagementMs = 4000
+    onSend('user_engagement')
+    expect(sessionEngaged).toBe(false)
+
+    // Route 2: 4s dwell → cumulative now 8s, still not engaged by time
+    accumulatedEngagementMs = 4000
+    onSend('user_engagement')
+    expect(sessionEngaged).toBe(false)
+
+    // Route 3: 3s dwell → cumulative 11s ≥ 10s threshold
+    accumulatedEngagementMs = 3000
+    onSend('custom_event')
+    expect(sessionEngaged).toBe(true)
+  })
+
+  it('two page_views trigger engaged-session without time threshold', () => {
+    const ENGAGED_SESSION_THRESHOLD_MS = 10000
+    let sessionEngaged = false
+    let sessionPageViewCount = 0
+    const sessionEngagementMs = 0
+
+    function onSend(eventName: string) {
+      if (eventName === 'page_view') sessionPageViewCount += 1
+      if (!sessionEngaged && (
+        sessionEngagementMs >= ENGAGED_SESSION_THRESHOLD_MS ||
+        sessionPageViewCount >= 2
+      )) {
+        sessionEngaged = true
+      }
+    }
+
+    onSend('page_view')
+    expect(sessionEngaged).toBe(false)
+
+    // Second page_view flips engaged on this very event (bump-before-check)
+    onSend('page_view')
+    expect(sessionEngaged).toBe(true)
+  })
 })
 
 // ============================================================================

--- a/web/src/lib/analytics.ts
+++ b/web/src/lib/analytics.ts
@@ -234,9 +234,17 @@ function peekEngagementMs(): number {
   return total
 }
 
-/** Session-wide engagement total including any currently-active time. */
+/** Session-wide engagement total including any currently-active time.
+ *
+ *  Includes `accumulatedEngagementMs` because the visibilitychange handler
+ *  folds active time into `accumulatedEngagementMs` without updating
+ *  `sessionEngagementMs`. Without this, peek reads after a tab-hidden flush
+ *  are stale until the next user_engagement send() folds accumulated back
+ *  into the session counter. No double-count risk: when
+ *  `getAndResetEngagementMs` later drains `accumulatedEngagementMs` into
+ *  `sessionEngagementMs`, accumulated is zeroed — so the sum stays stable. */
 function peekSessionEngagementMs(): number {
-  let total = sessionEngagementMs
+  let total = sessionEngagementMs + accumulatedEngagementMs
   if (isUserActive) {
     total += Date.now() - engagementStartMs
   }
@@ -465,7 +473,9 @@ function sendViaProxy(
   // GA4 considers a session engaged when ANY of:
   //   - cumulative session engagement ≥ 10s
   //   - ≥ 2 page_views in the session
-  //   - a conversion event
+  // (Conversion-event triggering is handled server-side by GA4 based on
+  // events marked as conversions in the GA4 admin UI — the client doesn't
+  // need to flip seg=1 for that case.)
   // Previously we only checked per-page engagement via peekEngagementMs(),
   // so a user who clicked through 5 short-dwell routes (8s each → 40s
   // total) never flipped engaged — each page's accumulator reset on flush


### PR DESCRIPTION
## Summary

Follow-up to merged PR #8221 addressing 3 Copilot review comments on `web/src/lib/analytics.ts`.

- **peekSessionEngagementMs()** now includes `accumulatedEngagementMs`. The `visibilitychange` handler folds active-user delta into `accumulatedEngagementMs` without updating `sessionEngagementMs`, so reads between that flush and the next `user_engagement` send were stale. No double-count risk because `getAndResetEngagementMs` zeros accumulated before any subsequent peek.
- Remove stale **"conversion event"** bullet from the engaged-session comment. Conversion-event triggering is GA4-side (configured in the admin UI) — the client doesn't need to flip `seg=1` for that path.
- Add unit tests covering:
  - peek includes session + accumulated + active time
  - cumulative engagement across multiple route flushes crosses 10s → `sessionEngaged = true`
  - 2+ `page_view`s trigger `sessionEngaged` on the second pageview (bump-before-check)

Fixes #8318

## Test plan

- [x] \`cd web && npx vitest run src/lib/__tests__/analytics-deep.test.ts\` — 82/82 pass
- [x] \`cd web && npm run build\` — post-build safety checks pass
- [x] \`cd web && npm run lint\` — exit 0 (no new lint issues)