### PR TITLE
🐛 fix(local-llm): align BaseURLSource enum + send clearBaseURL on blank (#8277)

### DIFF
--- a/pkg/agent/server_operations.go
+++ b/pkg/agent/server_operations.go
@@ -342,10 +342,12 @@ func (s *Server) handleGetKeysStatus(w http.ResponseWriter, r *http.Request) {
 			status.BaseURLSource = "config"
 		}
 		// For local LLM runners, fall through to the compiled-in default
-		// so the UI always shows the effective endpoint (#8259).
+		// so the UI always shows the effective endpoint (#8259). Leave
+		// BaseURLSource empty here — per KeyStatus docs, empty signals
+		// "the resolved value is the compiled-in default" (the UI treats
+		// empty as "default" without needing a separate enum value).
 		if p.isLocalLLM && status.BaseURL == "" && p.defaultURL != "" {
 			status.BaseURL = p.defaultURL
-			status.BaseURLSource = "default"
 		}
 		// Local LLM runners are "configured" when a URL is reachable —
 		// either via env/config override or compiled-in default. Having

--- a/web/src/components/agent/APIKeySettings.tsx
+++ b/web/src/components/agent/APIKeySettings.tsx
@@ -221,10 +221,17 @@ export function APIKeySettings({ isOpen, onClose }: APIKeySettingsProps) {
     setBaseURLError(e => ({ ...e, [provider]: '' }))
     try {
       setSaving(true)
+      // Empty draft = "Leave blank to use the compiled-in default" — send
+      // clearBaseURL:true so the backend removes the persisted override
+      // (and bypasses the missing_field guard that rejects all-empty
+      // requests). #8277.
+      const body = draft === ''
+        ? { provider, clearBaseURL: true }
+        : { provider, baseURL: draft }
       const response = await fetch(`${KC_AGENT_URL}/settings/keys`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ provider, baseURL: draft }),
+        body: JSON.stringify(body),
         signal: AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS),
       })
       if (!response.ok) {


### PR DESCRIPTION
## Summary

Follow-up to merged PR #8267 addressing 2 of the 5 Copilot review comments on local LLM provider plumbing.

- **Backend** (`pkg/agent/server_operations.go:348`) — stop setting `BaseURLSource="default"` for local LLM runners. `KeyStatus.BaseURLSource` is documented as `"env"`/`"config"`/empty, and the frontend type (\`'env' | 'config'\`) treats empty as the canonical signal for "value is the compiled-in default". The "default" string was unhandled by the UI and violated the documented contract.
- **Frontend** (`web/src/components/agent/APIKeySettings.tsx:248`) — `handleSaveBaseURL` with an empty trimmed input now sends \`{ clearBaseURL: true }\` instead of \`{ baseURL: "" }\`, so the backend removes the persisted override and reverts to the compiled-in default. Without this the request hit the \`missing_field\` guard.

### Not addressed (with reasoning)

- **Configured = URL-present semantics for local LLMs** — the existing inline comment marks this as intentional (#8259); changing it would be a behavior change, not a bug fix. Leaving for product/UX review.
- **Populating BaseURL via per-provider resolvers for non-local providers** (Groq/OpenRouter so they show the effective compiled endpoint) — separate scope; requires resolver-side changes.
- **\`TestServer_SettingsHandlers\` test mismatch** — already fixed in PR #8317.

Fixes #8277

## Test plan

- [x] \`go build ./...\` passes
- [x] \`go test ./pkg/agent/...\` — 61.9s, all pass
- [x] \`cd web && npm run build\` — post-build safety checks pass