### PR TITLE
🐛 fix(acmm): trees API branch, RepoPicker Input, header doc (#8271)

### DIFF
--- a/web/netlify/functions/acmm-scan.mts
+++ b/web/netlify/functions/acmm-scan.mts
@@ -7,6 +7,12 @@
  *
  * Input:  ?repo=owner/repo
  * Output: { repo, scannedAt, detectedIds, weeklyActivity, fromCache, demoFallback }
+ *   - detectedIds: array of criterion IDs (source-prefixed) matched against the
+ *     repo tree. Frontend computes ACMM level + role + recommendations from
+ *     this. Field is named `detectedIds`, not `detectedLoops`, because the
+ *     registry includes non-loop criteria from non-ACMM sources.
+ *   - weeklyActivity: 16 weeks of {weekStart, ai, human} merged-PR splits.
+ *   - fromCache / demoFallback: provenance flags so the UI can show badges.
  *
  * Optional env var:
  *   GITHUB_TOKEN — enables higher rate limits (5000 req/hr vs 60)
@@ -237,7 +243,21 @@ async function fetchTreePaths(repo: string, token: string): Promise<Set<string>>
   };
   if (token) headers["Authorization"] = `Bearer ${token}`;
 
-  const url = `${GITHUB_API}/repos/${repo}/git/trees/HEAD?recursive=1`;
+  // Resolve the default branch first — the trees endpoint accepts a branch
+  // name or commit SHA, NOT "HEAD" (HEAD is git-CLI shorthand, not REST).
+  // #8271.
+  const repoRes = await fetch(`${GITHUB_API}/repos/${repo}`, {
+    headers,
+    signal: AbortSignal.timeout(API_TIMEOUT_MS),
+  });
+  if (!repoRes.ok) {
+    if (repoRes.status === 404) throw new Error("Repo not found");
+    throw new Error(`GitHub repo API ${repoRes.status}`);
+  }
+  const repoInfo = (await repoRes.json()) as { default_branch?: string };
+  const branch = repoInfo.default_branch || "main";
+
+  const url = `${GITHUB_API}/repos/${repo}/git/trees/${branch}?recursive=1`;
   const res = await fetch(url, {
     headers,
     signal: AbortSignal.timeout(API_TIMEOUT_MS),

--- a/web/src/components/acmm/RepoPicker.tsx
+++ b/web/src/components/acmm/RepoPicker.tsx
@@ -9,6 +9,8 @@
 import { useMemo, useRef, useState } from 'react'
 import { RefreshCw, X, ExternalLink, AlertCircle, Award, Copy, Check } from 'lucide-react'
 import { Button } from '../ui/Button'
+import { Input } from '../ui/Input'
+import { cn } from '../../lib/cn'
 import { useACMM, DEFAULT_REPO } from './ACMMProvider'
 import { ALL_CRITERIA } from '../../lib/acmm/sources'
 
@@ -73,13 +75,14 @@ export function RepoPicker() {
           className="flex items-center gap-2 flex-1 min-w-[300px]"
         >
           <div className="relative flex-1">
-            <input
+            <Input
               ref={inputRef}
               type="text"
               value={input}
               onChange={(e) => setInput(e.target.value)}
               placeholder="owner/repo"
-              className="w-full px-3 py-2 pr-8 rounded-md bg-secondary/50 border border-border text-sm font-mono focus:outline-none focus:ring-2 focus:ring-primary/40"
+              inputSize="md"
+              className={cn('font-mono', input && 'pr-8')}
               list="acmm-recent-repos"
               aria-label="GitHub repository"
             />


### PR DESCRIPTION
## Summary

Follow-up to merged PR #8260 addressing the actionable Copilot review comments. 3 fixed, 5 verified already-fixed in main, 2 intentionally deferred.

### Fixed

- **Netlify function** (`acmm-scan.mts`) — `git/trees/HEAD?recursive=1` is not a valid REST call (HEAD is git-CLI shorthand, not a tree SHA). Now resolves `default_branch` via `/repos/{owner}/{repo}` first, falling back to \`main\` when the field is absent.
- **Netlify function header** — comment now enumerates all return fields (\`detectedIds\`/\`weeklyActivity\`/\`fromCache\`/\`demoFallback\`) and documents why the field is \`detectedIds\` rather than \`detectedLoops\` (registry includes non-loop criteria from Fullsend/AEF/claude-reflect).
- **RepoPicker** — replaced raw \`<input>\` with shared \`<Input>\` component to satisfy the \`no-restricted-syntax\` lint rule. The datalist, clear-X overlay, and aria attributes are preserved.

### Verified already-fixed (no change)

- \`acmm\` is in \`ALL_STATS_DASHBOARD_TYPES\`
- Weekly activity search paginates (\`SEARCH_MAX_PAGES=10\`, \`SEARCH_PAGE_SIZE=100\`)
- \`useCachedACMMScan\` uses \`'costs'\` refresh (10 min, matches Netlify TTL)
- \`IntotoSupplyChain\` uses the explicit namespace prefix \`common:common.searchLayouts\`
- \`totalCriteria\` uses \`ALL_CRITERIA.length\` (source-aware), not the hardcoded 33

### Not addressed (out of scope)

- **intoto_supply_chain bundled in ACMM PR** — can't unbundle post-merge.
- **Criterion catalog duplication between Netlify function and frontend** — intentional because Netlify Functions are self-contained and bundling the frontend TS sources requires additional build plumbing.

Fixes #8271

## Test plan

- [x] \`cd web && npm run build\` — post-build safety checks pass
- [ ] Manual: test on \`facebook/react\` to confirm default_branch resolution works for master-default repos