### PR TITLE
🐛 fix(local-llm): add unit tests for buildBaseURLPayload (#8323)

### DIFF
--- a/web/src/components/agent/APIKeySettings.test.tsx
+++ b/web/src/components/agent/APIKeySettings.test.tsx
@@ -1,9 +1,24 @@
 import { describe, it, expect } from 'vitest'
 import * as APIKeySettingsModule from './APIKeySettings'
+import { buildBaseURLPayload } from './APIKeySettings'
 
 describe('APIKeySettings Component', () => {
   it('exports APIKeySettings component', () => {
     expect(APIKeySettingsModule.APIKeySettings).toBeDefined()
     expect(typeof APIKeySettingsModule.APIKeySettings).toBe('function')
+  })
+})
+
+describe('buildBaseURLPayload', () => {
+  it('sends clearBaseURL:true and omits baseURL when draft is empty (#8277)', () => {
+    const body = buildBaseURLPayload('ollama', '')
+    expect(body).toEqual({ provider: 'ollama', clearBaseURL: true })
+    expect('baseURL' in body).toBe(false)
+  })
+
+  it('sends baseURL and omits clearBaseURL when draft is non-empty', () => {
+    const body = buildBaseURLPayload('ollama', 'http://localhost:11434')
+    expect(body).toEqual({ provider: 'ollama', baseURL: 'http://localhost:11434' })
+    expect('clearBaseURL' in body).toBe(false)
   })
 })

--- a/web/src/components/agent/APIKeySettings.tsx
+++ b/web/src/components/agent/APIKeySettings.tsx
@@ -14,6 +14,20 @@ const INSTALL_COMMAND = KC_AGENT.installCommand
 
 const KC_AGENT_URL = KC_AGENT.url
 
+/** Body shape for POST /settings/keys when saving a Base URL override.
+ *
+ *  Empty draft = "Leave blank to use the compiled-in default" — send
+ *  clearBaseURL:true so the backend removes the persisted override (and
+ *  bypasses the missing_field guard that rejects all-empty requests).
+ *  Non-empty draft sends the override value. See #8277. */
+export function buildBaseURLPayload(provider: string, draft: string):
+  | { provider: string; clearBaseURL: true }
+  | { provider: string; baseURL: string } {
+  return draft === ''
+    ? { provider, clearBaseURL: true }
+    : { provider, baseURL: draft }
+}
+
 interface KeyStatus {
   provider: string
   displayName: string
@@ -221,13 +235,7 @@ export function APIKeySettings({ isOpen, onClose }: APIKeySettingsProps) {
     setBaseURLError(e => ({ ...e, [provider]: '' }))
     try {
       setSaving(true)
-      // Empty draft = "Leave blank to use the compiled-in default" — send
-      // clearBaseURL:true so the backend removes the persisted override
-      // (and bypasses the missing_field guard that rejects all-empty
-      // requests). #8277.
-      const body = draft === ''
-        ? { provider, clearBaseURL: true }
-        : { provider, baseURL: draft }
+      const body = buildBaseURLPayload(provider, draft)
       const response = await fetch(`${KC_AGENT_URL}/settings/keys`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },


### PR DESCRIPTION
## Summary

Addresses the sole Copilot follow-up comment on merged PR #8320: *"Consider adding/expanding a Vitest test to cover this branch: when the Base URL input is blank/whitespace, the POST body should include `clearBaseURL: true` (and omit `baseURL`), and when non-blank it should include `baseURL`."*

## What

Extracts the body-building branch from the `handleSaveBaseURL` `useCallback` closure into `buildBaseURLPayload(provider, draft)` — a pure, exported function — and adds two Vitest cases:

- `sends clearBaseURL:true and omits baseURL when draft is empty (#8277)`
- `sends baseURL and omits clearBaseURL when draft is non-empty`

The `#8277` rationale (empty draft ⇒ clear override to bypass the missing_field guard) is preserved on the function JSDoc so the why stays colocated with the branch. No runtime behavior change.

## Test plan

- [x] `npx vitest run src/components/agent/APIKeySettings.test.tsx` — 3/3 passed locally
- [x] `npm run build` — passed locally
- [x] `npm run lint` — no new errors in modified files
- [ ] CI: build (amd64, arm64), fullstack-smoke, coverage-gate, ts-null-safety, dco, pr-check, netlify deploy-preview, ui-ux-standard, route-smoke

Fixes #8323