### PR TITLE
📖 docs(acmm): document `error` output field in acmm-scan header (#8324)

### DIFF
--- a/web/netlify/functions/acmm-scan.mts
+++ b/web/netlify/functions/acmm-scan.mts
@@ -6,13 +6,16 @@
  * /acmm dashboard's four cards.
  *
  * Input:  ?repo=owner/repo
- * Output: { repo, scannedAt, detectedIds, weeklyActivity, fromCache, demoFallback }
+ * Output: { repo, scannedAt, detectedIds, weeklyActivity, fromCache, demoFallback, error? }
  *   - detectedIds: array of criterion IDs (source-prefixed) matched against the
  *     repo tree. Frontend computes ACMM level + role + recommendations from
  *     this. Field is named `detectedIds`, not `detectedLoops`, because the
  *     registry includes non-loop criteria from non-ACMM sources.
  *   - weeklyActivity: 16 weeks of {weekStart, ai, human} merged-PR splits.
  *   - fromCache / demoFallback: provenance flags so the UI can show badges.
+ *   - error: present only when `demoFallback: true` — carries the upstream
+ *     GitHub error message so the UI can surface it (rate-limited, 404, etc.)
+ *     while still rendering the demo catalog.
  *
  * Optional env var:
  *   GITHUB_TOKEN — enables higher rate limits (5000 req/hr vs 60)


### PR DESCRIPTION
## Summary

Addresses 1 of 2 Copilot review comments on merged PR #8322.

**Fix:** header comment in `web/netlify/functions/acmm-scan.mts` didn't enumerate the `error` field that the catch block returns alongside `demoFallback: true`. Added the field to the `Output:` line plus a one-liner noting it's present only on the fallback path and carries the upstream GitHub error so the UI can surface "rate limited", "404", etc.

**Deferred (false positive):** the second comment on `RepoPicker.tsx:82` claims `ref={inputRef}` won't wire to the underlying `<input>` unless `<Input>` uses `React.forwardRef`. That's correct for React <19, but this repo is on React 19.2.4 (`web/package.json`), where **ref-as-prop is native**. `Input.tsx` destructures `ref` from props and forwards it to `<input ref={ref} ...>`, so `inputRef.current?.focus()` in RepoPicker's clear button works as-is. No code change warranted.

## Test plan

- [x] Change is documentation-only (JSDoc header comment). No runtime behavior change.
- [x] React 19 ref-as-prop confirmed: `web/package.json` → `"react": "^19.2.4"`.
- [ ] CI: dco, pr-check, build, ui-ux-standard, route-smoke, netlify deploy-preview

Fixes #8324