### PR TITLE
📖 docs(acmm): correct weeklyActivity shape + mark cache/demo flags optional (#8328)

### DIFF
--- a/web/netlify/functions/acmm-scan.mts
+++ b/web/netlify/functions/acmm-scan.mts
@@ -6,16 +6,23 @@
  * /acmm dashboard's four cards.
  *
  * Input:  ?repo=owner/repo
- * Output: { repo, scannedAt, detectedIds, weeklyActivity, fromCache, demoFallback, error? }
+ * Output: { repo, scannedAt, detectedIds, weeklyActivity, fromCache?, demoFallback?, error? }
  *   - detectedIds: array of criterion IDs (source-prefixed) matched against the
  *     repo tree. Frontend computes ACMM level + role + recommendations from
  *     this. Field is named `detectedIds`, not `detectedLoops`, because the
  *     registry includes non-loop criteria from non-ACMM sources.
- *   - weeklyActivity: 16 weeks of {weekStart, ai, human} merged-PR splits.
- *   - fromCache / demoFallback: provenance flags so the UI can show badges.
- *   - error: present only when `demoFallback: true` — carries the upstream
- *     GitHub error message so the UI can surface it (rate-limited, 404, etc.)
- *     while still rendering the demo catalog.
+ *   - weeklyActivity: 16 weeks of WeeklyActivity entries —
+ *     `{ week, aiPrs, humanPrs, aiIssues, humanIssues }`. `week` is an
+ *     ISO `YYYY-Www` bucket; PR and issue counts split AI vs human by the
+ *     `ai-generated` label.
+ *   - fromCache: present (true) only on cache-hit responses; omitted on
+ *     live scans and demo fallback.
+ *   - demoFallback: present (true) only when the live fetch failed and the
+ *     function returned the demo catalog as a soft degradation; omitted
+ *     otherwise.
+ *   - error: present only alongside `demoFallback: true` — carries the
+ *     upstream GitHub error message so the UI can surface it
+ *     (rate-limited, 404, etc.) while still rendering the demo catalog.
  *
  * Optional env var:
  *   GITHUB_TOKEN — enables higher rate limits (5000 req/hr vs 60)


### PR DESCRIPTION
## Summary

Addresses both Copilot review comments on merged PR #8326 (the doc-only follow-up itself).

### Fix 1 — `weeklyActivity` shape mismatch
Header comment said `{weekStart, ai, human}` but the actual \`WeeklyActivity\` interface uses \`{ week, aiPrs, humanPrs, aiIssues, humanIssues }\`. Corrected, and added the \`week\` ISO-bucket format + the AI/human split heuristic (\`ai-generated\` label).

### Fix 2 — `fromCache` / `demoFallback` aren't always present
Live scan 200 response returns neither flag. `fromCache` appears only on cache-hit (line 455); `demoFallback` only on demo fallback (line 510). Marked both as \`?\` in the \`Output:\` signature and split the bullet so each flag's presence condition is explicit.

Doc-only, no runtime change.

## Test plan

- [x] Verified shape against the `WeeklyActivity` interface (line 142) and all return paths in `acmm-scan.mts`
- [x] \`fromCache\` / \`demoFallback\` flag presence confirmed by reading the three response paths
- [ ] CI: dco, pr-check, build, netlify deploy-preview

Fixes #8328