### PR TITLE
📖 docs(acmm): full AI-vs-human heuristic + error field on all non-200 (#8332)

### DIFF
--- a/web/netlify/functions/acmm-scan.mts
+++ b/web/netlify/functions/acmm-scan.mts
@@ -13,16 +13,21 @@
  *     registry includes non-loop criteria from non-ACMM sources.
  *   - weeklyActivity: 16 weeks of WeeklyActivity entries —
  *     `{ week, aiPrs, humanPrs, aiIssues, humanIssues }`. `week` is an
- *     ISO `YYYY-Www` bucket; PR and issue counts split AI vs human by the
- *     `ai-generated` label.
+ *     ISO `YYYY-Www` bucket. Counts are split AI vs human by `isAIContribution`:
+ *     item is AI if the author login is in `AI_AUTHORS`, OR ends in `[bot]`,
+ *     OR any attached label is `ai-generated` — human otherwise.
  *   - fromCache: present (true) only on cache-hit responses; omitted on
  *     live scans and demo fallback.
  *   - demoFallback: present (true) only when the live fetch failed and the
  *     function returned the demo catalog as a soft degradation; omitted
  *     otherwise.
- *   - error: present only alongside `demoFallback: true` — carries the
- *     upstream GitHub error message so the UI can surface it
- *     (rate-limited, 404, etc.) while still rendering the demo catalog.
+ *   - error: always present on non-200 responses (400 invalid repo,
+ *     404 repo not found, 405 method not allowed), carrying a short
+ *     description of why the request was rejected. Also present on the
+ *     200 demo-fallback response (alongside `demoFallback: true`),
+ *     carrying the upstream GitHub error message so the UI can surface
+ *     it (rate-limited, network error, etc.) while still rendering
+ *     the demo catalog.
  *
  * Optional env var:
  *   GITHUB_TOKEN — enables higher rate limits (5000 req/hr vs 60)


### PR DESCRIPTION
## Summary

Address Copilot review on merged PR #8329 — two doc inaccuracies in `web/netlify/functions/acmm-scan.mts`:

1. **Line 17**: weeklyActivity comment said the AI vs human split was determined by the `ai-generated` label, but `isAIContribution()` also flags known AI authors (`AI_AUTHORS` set: `clubanderson`, `Copilot`, `copilot-swe-agent[bot]`) and any login ending in `[bot]`. Doc now lists all three disjuncts.

2. **Line 25**: comment said `error` is present only with `demoFallback: true`, but the handler also returns `{ error: ... }` on **400** (invalid repo), **404** (repo not found), and **405** (method not allowed) without `demoFallback`. Doc now clarifies `error` is always present on non-200 responses, and additionally on the 200 demo-fallback path.

Doc-only; no runtime change.

Fixes #8332

## Test plan
- [x] `npm run build` passes locally
- [x] Diff is comments only in `acmm-scan.mts`