### PR TITLE
📖 docs(acmm): split 405 from GET validation errors (#8339)

### DIFF
--- a/web/netlify/functions/acmm-scan.mts
+++ b/web/netlify/functions/acmm-scan.mts
@@ -21,14 +21,15 @@
  *   - demoFallback: present (true) only when the live fetch failed and the
  *     function returned the demo catalog as a soft degradation; omitted
  *     otherwise.
- *   - error: present on non-200 JSON responses for rejected `GET` requests
- *     (400 invalid repo, 404 repo not found, 405 method not allowed),
- *     carrying a short description of why the request was rejected. The
- *     204 `OPTIONS` CORS preflight response has no JSON body and
- *     therefore no `error` field. Also present on the 200 demo-fallback
- *     response (alongside `demoFallback: true`), carrying the upstream
- *     GitHub error message so the UI can surface it (rate-limited,
- *     network error, etc.) while still rendering the demo catalog.
+ *   - error: present on non-200 JSON responses, carrying a short
+ *     description of why the request was rejected: for rejected `GET`
+ *     requests, 400 invalid repo or 404 repo not found; for non-`GET`
+ *     methods, 405 method not allowed. The 204 `OPTIONS` CORS preflight
+ *     response has no JSON body and therefore no `error` field. Also
+ *     present on the 200 demo-fallback response (alongside
+ *     `demoFallback: true`), carrying the upstream GitHub error message
+ *     so the UI can surface it (rate-limited, network error, etc.)
+ *     while still rendering the demo catalog.
  *
  * Optional env var:
  *   GITHUB_TOKEN — enables higher rate limits (5000 req/hr vs 60)


### PR DESCRIPTION
## Summary

Address Copilot review on merged PR #8338:

The updated contract grouped 400/404/405 together as "rejected GET requests", but **405** fires when \`req.method !== "GET"\` — it's a non-GET method rejection, not a rejected GET. Split the description:

- **400/404** — GET validation errors (invalid repo slug, repo not found)
- **405** — non-GET methods (anything other than GET/OPTIONS)
- **204** — OPTIONS CORS preflight (no body, no error field)
- **200 demo-fallback** — carries upstream GitHub error message

Doc-only; no runtime change.

Fixes #8339

## Test plan
- [x] Diff is comment-only in `acmm-scan.mts` header