### PR TITLE
📖 docs(acmm): force bypasses reads only + clarify 200-shape split (#8344)

### DIFF
--- a/web/netlify/functions/acmm-scan.mts
+++ b/web/netlify/functions/acmm-scan.mts
@@ -5,12 +5,17 @@
  * ACMM registry plus weekly AI-vs-human contribution activity. Powers the
  * /acmm dashboard's four cards.
  *
- * Input:  ?repo=owner/repo&force=true (force bypasses cache)
+ * Input:  ?repo=owner/repo&force=true
+ *         (`force` bypasses cache *reads* and refreshes the cached entry —
+ *         the response body is always written back to the blob store)
  *
- * Response body (JSON) — discriminated by HTTP status:
+ * Response body (JSON) — discriminated by HTTP status, and for 200 also
+ * by the `demoFallback` / `fromCache` flags (both 200 shapes share the
+ * same status code):
  *
  *   200 live/cache-hit:
  *     { repo, scannedAt, detectedIds, weeklyActivity, fromCache? }
+ *     (`fromCache: true` iff served from blob cache; omitted on a live scan)
  *
  *   200 demo fallback (live fetch failed — soft degradation):
  *     { repo, scannedAt, detectedIds, weeklyActivity, demoFallback: true, error }


### PR DESCRIPTION
Fixes #8344

## Summary

Address Copilot review on merged PR #8343:

1. **Input line** said \`force\` "bypasses cache" — ambiguous. The handler only skips the cache *read* (\`if (!force) { store.get() }\`) and still calls \`store.set()\` on the fresh scan, so it refreshes the cache rather than disabling it. Clients shouldn't read \`force=true\` as "don't cache this response."

2. **"discriminated by HTTP status"** oversold it: the two 200 shapes (live/cache-hit vs demo-fallback) **share a status code** and are distinguished at runtime by \`demoFallback\` / \`fromCache\`. Note that status alone doesn't determine the body for 200.

Doc-only; no runtime change.

## Test plan
- [x] Diff is comment-only in \`acmm-scan.mts\` header