### PR TITLE
📖 docs(acmm): force write is live-path only + best-effort (#8346)

### DIFF
--- a/web/netlify/functions/acmm-scan.mts
+++ b/web/netlify/functions/acmm-scan.mts
@@ -6,8 +6,10 @@
  * /acmm dashboard's four cards.
  *
  * Input:  ?repo=owner/repo&force=true
- *         (`force` bypasses cache *reads* and refreshes the cached entry —
- *         the response body is always written back to the blob store)
+ *         (`force` bypasses cache *reads*; on a successful live scan the
+ *         cached entry is refreshed. Demo-fallback responses are not
+ *         cached, and all writes are best-effort — `store.set()` errors
+ *         are swallowed so a blob-store outage never fails the request.)
  *
  * Response body (JSON) — discriminated by HTTP status, and for 200 also
  * by the `demoFallback` / `fromCache` flags (both 200 shapes share the


### PR DESCRIPTION
Fixes #8346

## Summary

Address Copilot review on merged PR #8345:

The Input line said the response body is "always written back to the blob store", but:
- \`store.set()\` only runs inside the successful **live-scan** \`try\` block
- **Demo fallback** (catch branch, line 517) never writes
- The live path wraps the set in \`.catch(() => {})\` — writes are **best-effort** by design so a blob-store outage never fails the request

Correct the doc so clients don't assume every request updates the cache.

Doc-only; no runtime change.

## Test plan
- [x] Diff is comment-only in \`acmm-scan.mts\` header