### PR TITLE
📝 fix(security-links): point at docs.kubestellar.io + add AI threat model links

### DIFF
--- a/web/src/components/missions/MissionDetailView.tsx
+++ b/web/src/components/missions/MissionDetailView.tsx
@@ -34,8 +34,13 @@ import { copyToClipboard } from '../../lib/clipboard'
 
 type TabId = 'install' | 'uninstall' | 'upgrade' | 'troubleshooting' | 'security'
 
-/** GitHub URL for the overall Console security model doc. Linked from the Security tab fallback / footer. */
-const SECURITY_MODEL_DOC_URL = 'https://github.com/kubestellar/console/blob/main/docs/security/SECURITY-MODEL.md'
+/** Primary (docs.kubestellar.io) URL for the Console security model. Linked
+ *  from the Security tab fallback / footer. Prefer the rendered docs site
+ *  for users; the repo version is the source-grounded reference. */
+const SECURITY_MODEL_DOC_URL = 'https://kubestellar.io/docs/console/main/console/security-model/'
+/** AI-specific threat model for LLM-backed automation (prompt injection,
+ *  supply chain, agent drift). Only lives in the repo. */
+const SECURITY_AI_DOC_URL = 'https://github.com/kubestellar/console/blob/main/docs/security/SECURITY-AI.md'
 
 interface TabDef {
   id: TabId
@@ -601,19 +606,34 @@ export function MissionDetailView({
                   />
                 ))}
                 {activeTab === 'security' && (
-                  <div className="mt-4 p-4 rounded-lg border border-purple-500/20 bg-purple-500/5 text-xs text-muted-foreground">
-                    The bullets above are specific to this mission. For the Console's overall security model — how kc-agent binds,
-                    where AI keys live, what leaves your machine, and how to run air-gapped — read the
-                    {' '}
-                    <a
-                      href={SECURITY_MODEL_DOC_URL}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      className="inline-flex items-center gap-1 text-purple-400 hover:text-purple-300"
-                    >
-                      KubeStellar Console Security Model
-                      <ExternalLink className="w-3 h-3" />
-                    </a>.
+                  <div className="mt-4 p-4 rounded-lg border border-purple-500/20 bg-purple-500/5 text-xs text-muted-foreground space-y-1">
+                    <p>
+                      The bullets above are specific to this mission. For the Console's overall security model — how kc-agent binds,
+                      where AI keys live, what leaves your machine, and how to run air-gapped — read the
+                      {' '}
+                      <a
+                        href={SECURITY_MODEL_DOC_URL}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="inline-flex items-center gap-1 text-purple-400 hover:text-purple-300"
+                      >
+                        KubeStellar Console Security Model
+                        <ExternalLink className="w-3 h-3" />
+                      </a>.
+                    </p>
+                    <p>
+                      For the LLM-specific threat model (prompt injection, supply chain, agent drift), see the
+                      {' '}
+                      <a
+                        href={SECURITY_AI_DOC_URL}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="inline-flex items-center gap-1 text-purple-400 hover:text-purple-300"
+                      >
+                        AI automation threat model
+                        <ExternalLink className="w-3 h-3" />
+                      </a>.
+                    </p>
                   </div>
                 )}
               </>
@@ -636,6 +656,16 @@ export function MissionDetailView({
                         className="inline-flex items-center gap-1 text-purple-400 hover:text-purple-300"
                       >
                         Read the KubeStellar Console Security Model
+                        <ExternalLink className="w-3 h-3" />
+                      </a>
+                      {' · '}
+                      <a
+                        href={SECURITY_AI_DOC_URL}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="inline-flex items-center gap-1 text-purple-400 hover:text-purple-300"
+                      >
+                        AI threat model
                         <ExternalLink className="w-3 h-3" />
                       </a>
                     </p>

--- a/web/src/components/setup/SetupInstructionsDialog.tsx
+++ b/web/src/components/setup/SetupInstructionsDialog.tsx
@@ -15,7 +15,12 @@ interface SetupInstructionsDialogProps {
 
 const REPO_URL = 'https://github.com/kubestellar/console'
 const DOCS_URL = 'https://console-docs.kubestellar.io'
-const SECURITY_DOC_URL = 'https://github.com/kubestellar/console/blob/main/docs/security/SECURITY-MODEL.md'
+// Primary (user-friendly) security doc link — rendered docs site. Falls
+// back to the source-grounded repo version + AI-specific threat model
+// for readers who want the ground truth.
+const SECURITY_DOC_URL = 'https://kubestellar.io/docs/console/main/console/security-model/'
+const SECURITY_DOC_REPO_URL = 'https://github.com/kubestellar/console/blob/main/docs/security/SECURITY-MODEL.md'
+const SECURITY_AI_DOC_URL = 'https://github.com/kubestellar/console/blob/main/docs/security/SECURITY-AI.md'
 const CURL_BASE = 'https://raw.githubusercontent.com/kubestellar/console/main'
 
 const QUICKSTART_CMD = `curl -sSL ${CURL_BASE}/start.sh | bash`
@@ -262,14 +267,32 @@ export function SetupInstructionsDialog({ isOpen, onClose }: SetupInstructionsDi
                           never leaves your perimeter. The core cluster-management UX works with no AI at all.
                         </p>
                       </div>
-                      <div className="pt-1">
+                      <div className="pt-1 flex flex-col gap-1">
                         <a
                           href={SECURITY_DOC_URL}
                           target="_blank"
                           rel="noopener noreferrer"
                           className="inline-flex items-center gap-1 text-purple-400 hover:text-purple-300"
                         >
-                          Read the full security model
+                          Read the full security model (docs.kubestellar.io)
+                          <ExternalLink className="w-3 h-3" />
+                        </a>
+                        <a
+                          href={SECURITY_AI_DOC_URL}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="inline-flex items-center gap-1 text-purple-400 hover:text-purple-300"
+                        >
+                          AI automation threat model (SECURITY-AI.md)
+                          <ExternalLink className="w-3 h-3" />
+                        </a>
+                        <a
+                          href={SECURITY_DOC_REPO_URL}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="inline-flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground"
+                        >
+                          Source-grounded version on GitHub
                           <ExternalLink className="w-3 h-3" />
                         </a>
                       </div>


### PR DESCRIPTION
## Summary

Follow-up to **#8210** (just merged) which added the Security posture section to the install modal and a Security tab to mission detail views. The original PR linked to the source-grounded repo version of \`SECURITY-MODEL.md\` — functional but less user-friendly than the rendered docs site, and missed the AI threat model entirely.

### Changes

**\`SetupInstructionsDialog.tsx\` — "Run KubeStellar Console Locally" modal:**
- Primary link now points at \`https://kubestellar.io/docs/console/main/console/security-model/\` (rendered docs site)
- Added AI automation threat model link (\`SECURITY-AI.md\` from #8249)
- Kept the repo version as a secondary "source-grounded" link with smaller muted styling

**\`MissionDetailView.tsx\` — mission security tab:**
- Same docs.kubestellar.io primary URL swap
- Added AI threat model link to both the populated-tab footer and the empty-state fallback

### Three URL constants replace the single hardcoded GH link

| Constant | URL |
|---|---|
| \`SECURITY_DOC_URL\` | docs.kubestellar.io (primary, user-friendly) |
| \`SECURITY_DOC_REPO_URL\` | github.com/.../SECURITY-MODEL.md (secondary, source-grounded) |
| \`SECURITY_AI_DOC_URL\` | github.com/.../SECURITY-AI.md |

## Test plan

- [x] \`npm run build\` — passes
- [ ] Open the Run KubeStellar Console Locally modal → expand Security posture → see 3 links (docs.kubestellar.io primary, AI threat model, muted repo link)
- [ ] Open any mission → Security tab → see docs link + AI threat link in footer and empty state
- [ ] Verify all 3 URLs resolve

🤖 Generated with [Claude Code](https://claude.com/claude-code)