### PR TITLE
🐛 fix: dashboard card vertical resize + add-button overflow (#8335 #8336 #8337)

### DIFF
--- a/web/src/components/dashboard/SharedSortableCard.tsx
+++ b/web/src/components/dashboard/SharedSortableCard.tsx
@@ -148,7 +148,7 @@ export const SortableCard = memo(function SortableCard({ card, onConfigure, onRe
       {onInsertAfter && (
         <button
           onClick={(e) => { e.stopPropagation(); onInsertAfter() }}
-          className="absolute -top-2 -right-2 z-20 opacity-0 group-hover/card:opacity-100 transition-all w-6 h-6 rounded-full bg-primary text-primary-foreground flex items-center justify-center text-sm font-bold shadow-lg hover:scale-110 ring-2 ring-background"
+          className="absolute top-2 right-2 z-20 opacity-0 group-hover/card:opacity-100 transition-all w-6 h-6 rounded-full bg-primary text-primary-foreground flex items-center justify-center text-sm font-bold shadow-lg hover:scale-110 ring-2 ring-background"
           aria-label="Add card"
           title="Add card here"
         >

--- a/web/src/lib/unified/dashboard/DashboardGrid.tsx
+++ b/web/src/lib/unified/dashboard/DashboardGrid.tsx
@@ -34,6 +34,16 @@ import { useDashboardHealth } from '../../../hooks/useDashboardHealth'
 /** Viewport width breakpoint below which small cards are clamped to wider minimum */
 const NARROW_VIEWPORT_BREAKPOINT_PX = 1024
 
+/**
+ * Minimum pixel height contributed by ONE row of card span. Mirrors the
+ * constant in SharedSortableCard.tsx so both dashboard renderers respond
+ * identically to the "Resize height" menu (#8335, #8336). Without scaling
+ * by the row span, `gridRow: span N` reserves grid rows but `auto-rows-min`
+ * collapses them to content height, so height changes have no visible
+ * effect (same bug class as #8289/#8298 for the legacy grid).
+ */
+const EXPANDED_CARD_ROW_MIN_HEIGHT_PX = 180
+
 export interface DashboardGridProps {
   /** Card placements */
   cards: DashboardCardPlacement[]
@@ -210,9 +220,11 @@ function DashboardCardWrapper({
   const rawW = Math.min(12, Math.max(3, placement.position?.w || 4))
   const effectiveW = isNarrow && rawW < 6 ? 6 : rawW
 
-  // Calculate height (each row unit = 100px) — use inline style because
-  // Tailwind JIT can't detect dynamically constructed arbitrary classes.
-  const minHeightPx = (placement.position?.h || 2) * 100
+  // Scale min-height by row span so the "Resize height" menu actually
+  // grows/shrinks the card (#8335, #8336). Uses the same constant as
+  // SharedSortableCard so both renderers behave identically.
+  const posH = placement.position?.h || 2
+  const minHeightPx = posH * EXPANDED_CARD_ROW_MIN_HEIGHT_PX
 
   // Get card config - support both cardType (new) and card_type (legacy localStorage)
   const cardTypeKey = placement.cardType || (placement as { card_type?: string }).card_type
@@ -224,6 +236,7 @@ function DashboardCardWrapper({
   const style: React.CSSProperties = {
     minHeight: `${minHeightPx}px`,
     gridColumn: `span ${effectiveW} / span ${effectiveW}`,
+    gridRow: `span ${posH} / span ${posH}`,
     ...(isDraggable
       ? {
           transform: CSS.Transform.toString(transform),


### PR DESCRIPTION
## Summary
- Fix vertical resize on the **unified dashboard grid** (Security Issues, AI Health Check, etc.) — PR #8311 fixed the legacy grid but left `DashboardGrid.tsx` using a flat 100px/row scale with no `gridRow` span, so the Resize height menu had no visible effect.
- Mirror `SharedSortableCard`'s `EXPANDED_CARD_ROW_MIN_HEIGHT_PX = 180` constant and add `gridRow: span N` so both renderers behave identically.
- Move the hover "+" add-card button inside the card (`top-2 right-2`) so it no longer overflows the viewport on rightmost grid columns (#8337).

## Test plan
- [x] `npm run build` — passes (post-build vendor safety checks pass)
- [x] `npm run lint` — passes
- [ ] Manual: resize Security Issues / AI Health Check vertically on `/dashboard` → card height grows/shrinks with the menu
- [ ] Manual: hover the rightmost card on a 12-col grid → "+" button stays inside the card

Fixes #8335
Fixes #8336
Fixes #8337