### PR TITLE
✨ ACMM: add Launch AI mission star to Feedback Loops Inventory items

### DIFF
--- a/web/node_modules
+++ b/web/node_modules
@@ -1,1 +1,0 @@
-/tmp/kubestellar-console-local-llm/web/node_modules

--- a/web/node_modules
+++ b/web/node_modules
@@ -1,0 +1,1 @@
+/tmp/kubestellar-console-local-llm/web/node_modules

--- a/web/src/components/cards/ACMMFeedbackLoops.tsx
+++ b/web/src/components/cards/ACMMFeedbackLoops.tsx
@@ -12,7 +12,7 @@ import { useCardLoadingState } from './CardDataContext'
 import { CardSkeleton } from '../../lib/cards/CardComponents'
 import { useACMM } from '../acmm/ACMMProvider'
 import { useMissions } from '../../hooks/useMissions'
-import { ALL_CRITERIA } from '../../lib/acmm/sources'
+import { ALL_CRITERIA, SOURCES_BY_ID } from '../../lib/acmm/sources'
 import type { Criterion, SourceId } from '../../lib/acmm/sources/types'
 import { detectionLabel, singleCriterionPrompt } from '../../lib/acmm/missionPrompts'
 
@@ -66,7 +66,7 @@ export function ACMMFeedbackLoops() {
 
   function launchOne(c: Criterion) {
     startMission({
-      title: `Add ACMM loop: ${c.name}`,
+      title: `Add ACMM criterion: ${c.name}`,
       description: `Add "${c.name}" to ${repo}`,
       type: 'custom',
       initialPrompt: singleCriterionPrompt(c, repo),
@@ -168,12 +168,34 @@ export function ACMMFeedbackLoops() {
                 {c.level && (
                   <span className="text-[10px] font-mono text-muted-foreground">L{c.level}</span>
                 )}
-                <span className={`text-[9px] px-1.5 py-0.5 rounded-full ${SOURCE_COLORS[c.source]}`}>
+                <span
+                  className={`text-[9px] px-1.5 py-0.5 rounded-full ${SOURCE_COLORS[c.source]}`}
+                  title={SOURCES_BY_ID[c.source]?.citation}
+                >
                   {SOURCE_LABELS[c.source]}
                 </span>
               </button>
               {isExpanded && (
                 <div className="px-8 pb-2 pt-0 text-[10px] space-y-1.5 border-t border-border/30">
+                  {SOURCES_BY_ID[c.source]?.url && (
+                    <div>
+                      <span className="text-muted-foreground">Cited from:</span>{' '}
+                      <a
+                        href={SOURCES_BY_ID[c.source].url}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="text-primary hover:underline"
+                        title={SOURCES_BY_ID[c.source]?.citation}
+                      >
+                        {SOURCES_BY_ID[c.source].name}
+                      </a>
+                      {SOURCES_BY_ID[c.source]?.citation && (
+                        <span className="ml-1 text-muted-foreground/70 italic">
+                          — {SOURCES_BY_ID[c.source].citation}
+                        </span>
+                      )}
+                    </div>
+                  )}
                   <div>
                     <span className="text-muted-foreground">Detection ({c.detection.type}):</span>{' '}
                     <code className="font-mono bg-background/60 px-1 py-0.5 rounded">
@@ -224,7 +246,7 @@ export function ACMMFeedbackLoops() {
                           launchOne(c)
                         }}
                         className="inline-flex items-center gap-1 text-primary hover:text-primary/80"
-                        title={`Ask the selected agent to add the "${c.name}" loop to ${repo}`}
+                        title={`Ask the selected agent to add the "${c.name}" criterion to ${repo}`}
                       >
                         <Sparkles className="w-2.5 h-2.5" />
                         Ask agent for help

--- a/web/src/components/cards/ACMMFeedbackLoops.tsx
+++ b/web/src/components/cards/ACMMFeedbackLoops.tsx
@@ -7,12 +7,14 @@
  */
 
 import { useMemo, useState } from 'react'
-import { Check, X, Filter, ChevronDown, ChevronRight, Flag } from 'lucide-react'
+import { Check, X, Filter, ChevronDown, ChevronRight, Flag, Sparkles } from 'lucide-react'
 import { useCardLoadingState } from './CardDataContext'
 import { CardSkeleton } from '../../lib/cards/CardComponents'
 import { useACMM } from '../acmm/ACMMProvider'
+import { useMissions } from '../../hooks/useMissions'
 import { ALL_CRITERIA } from '../../lib/acmm/sources'
-import type { Criterion, DetectionHint, SourceId } from '../../lib/acmm/sources/types'
+import type { Criterion, SourceId } from '../../lib/acmm/sources/types'
+import { detectionLabel, singleCriterionPrompt } from '../../lib/acmm/missionPrompts'
 
 type StatusFilter = 'all' | 'detected' | 'missing'
 
@@ -40,11 +42,6 @@ const SOURCE_FILES: Record<SourceId, string> = {
 
 const CONSOLE_REPO = 'kubestellar/console'
 
-function detectionLabel(hint: DetectionHint): string {
-  const patterns = Array.isArray(hint.pattern) ? hint.pattern : [hint.pattern]
-  return patterns.join(' · ')
-}
-
 function proposeChangeUrl(c: Criterion): string {
   const title = encodeURIComponent(`ACMM criterion fix: ${c.id}`)
   const body = encodeURIComponent(
@@ -59,12 +56,23 @@ function proposeChangeUrl(c: Criterion): string {
 }
 
 export function ACMMFeedbackLoops() {
-  const { scan } = useACMM()
+  const { scan, repo } = useACMM()
   const { detectedIds, isLoading, isRefreshing, isDemoData, isFailed, consecutiveFailures, lastRefresh } = scan
+  const { startMission } = useMissions()
 
   const [sourceFilter, setSourceFilter] = useState<SourceId | 'all'>('all')
   const [statusFilter, setStatusFilter] = useState<StatusFilter>('all')
   const [expandedId, setExpandedId] = useState<string | null>(null)
+
+  function launchOne(c: Criterion) {
+    startMission({
+      title: `Add ACMM loop: ${c.name}`,
+      description: `Add "${c.name}" to ${repo}`,
+      type: 'custom',
+      initialPrompt: singleCriterionPrompt(c, repo),
+      context: { repo, criterionId: c.id },
+    })
+  }
 
   const hasData = detectedIds.size > 0
   const { showSkeleton } = useCardLoadingState({
@@ -185,7 +193,7 @@ export function ACMMFeedbackLoops() {
                       </a>
                     </div>
                   )}
-                  <div className="flex items-center gap-3">
+                  <div className="flex items-center gap-3 flex-wrap">
                     <a
                       href={`https://github.com/${CONSOLE_REPO}/blob/main/${SOURCE_FILES[c.source]}`}
                       target="_blank"
@@ -203,6 +211,25 @@ export function ACMMFeedbackLoops() {
                       <Flag className="w-2.5 h-2.5" />
                       Propose a change
                     </a>
+                    {/* AI mission star — only offered for missing loops; an
+                        already-detected loop has nothing to add. Mirrors the
+                        per-recommendation "Launch" button on the Your Role
+                        card so users get the same affordance from either
+                        entry point. */}
+                    {!detected && (
+                      <button
+                        type="button"
+                        onClick={(e) => {
+                          e.stopPropagation()
+                          launchOne(c)
+                        }}
+                        className="inline-flex items-center gap-1 text-primary hover:text-primary/80"
+                        title={'Launch an AI mission to add this loop'}
+                      >
+                        <Sparkles className="w-2.5 h-2.5" />
+                        Launch AI mission
+                      </button>
+                    )}
                   </div>
                 </div>
               )}

--- a/web/src/components/cards/ACMMFeedbackLoops.tsx
+++ b/web/src/components/cards/ACMMFeedbackLoops.tsx
@@ -224,10 +224,10 @@ export function ACMMFeedbackLoops() {
                           launchOne(c)
                         }}
                         className="inline-flex items-center gap-1 text-primary hover:text-primary/80"
-                        title={'Launch an AI mission to add this loop'}
+                        title={`Ask the selected agent to add the "${c.name}" loop to ${repo}`}
                       >
                         <Sparkles className="w-2.5 h-2.5" />
-                        Launch AI mission
+                        Ask agent for help
                       </button>
                     )}
                   </div>

--- a/web/src/components/cards/ACMMRecommendations.tsx
+++ b/web/src/components/cards/ACMMRecommendations.tsx
@@ -12,54 +12,18 @@ import { CardSkeleton } from '../../lib/cards/CardComponents'
 import { useACMM } from '../acmm/ACMMProvider'
 import { useMissions } from '../../hooks/useMissions'
 import type { Recommendation } from '../../lib/acmm/computeRecommendations'
-import type { DetectionHint, SourceId } from '../../lib/acmm/sources/types'
+import type { SourceId } from '../../lib/acmm/sources/types'
+import {
+  detectionLabel,
+  singleRecommendationPrompt,
+  allRecommendationsPrompt,
+} from '../../lib/acmm/missionPrompts'
 
 const SOURCE_LABELS: Record<SourceId, string> = {
   acmm: 'ACMM',
   fullsend: 'Fullsend',
   'agentic-engineering-framework': 'AEF',
   'claude-reflect': 'Reflect',
-}
-
-function detectionLabel(hint: DetectionHint): string {
-  const patterns = Array.isArray(hint.pattern) ? hint.pattern : [hint.pattern]
-  return patterns.join(' · ')
-}
-
-function singleRecommendationPrompt(rec: Recommendation, repo: string): string {
-  const c = rec.criterion
-  const ref = c.referencePath ? `\n- Reference implementation: ${c.referencePath} in kubestellar/console` : ''
-  return `Add the "${c.name}" feedback loop to ${repo} so the ACMM dashboard detects it.
-
-Source: ${SOURCE_LABELS[c.source]}
-Criterion ID: ${c.id}
-What this loop does: ${c.description}
-Why it matters: ${rec.reason}
-
-Detection rule (must match at least one after your change):
-- Type: ${c.detection.type}
-- Pattern: ${detectionLabel(c.detection)}${ref}
-
-Please:
-1. Audit the existing repo for any similar artifact that could already satisfy this detection (don't duplicate).
-2. If missing, create/commit the minimum file(s) that match the detection pattern and follow our project conventions.
-3. Return a short summary of what was added and why.
-Do not push or open a PR automatically — stop after the commit so I can review.`
-}
-
-function allRecommendationsPrompt(recs: Recommendation[], repo: string): string {
-  const list = recs
-    .map((r, i) => `${i + 1}. ${r.criterion.name} (${SOURCE_LABELS[r.criterion.source]}) — detection: ${detectionLabel(r.criterion.detection)}`)
-    .join('\n')
-  return `Implement the missing ACMM feedback loops for ${repo}:
-
-${list}
-
-For each item:
-- Check whether an equivalent artifact already exists under a non-standard path (don't duplicate).
-- If truly missing, add the minimum change that matches the detection pattern and follows the repo's conventions.
-- Return a brief summary of what changed for each loop.
-Do not push or open a PR automatically — stop after commits so I can review.`
 }
 
 export function ACMMRecommendations() {

--- a/web/src/components/cards/ACMMRecommendations.tsx
+++ b/web/src/components/cards/ACMMRecommendations.tsx
@@ -2,7 +2,7 @@
  * ACMM Recommendations Card
  *
  * Shows the user's current role, the next transition trigger, and the
- * top prioritized recommendations (missing feedback loops) merged from
+ * top prioritized recommendations (missing criteria) merged from
  * all registered sources.
  */
 
@@ -11,6 +11,7 @@ import { useCardLoadingState } from './CardDataContext'
 import { CardSkeleton } from '../../lib/cards/CardComponents'
 import { useACMM } from '../acmm/ACMMProvider'
 import { useMissions } from '../../hooks/useMissions'
+import { SOURCES_BY_ID } from '../../lib/acmm/sources'
 import type { Recommendation } from '../../lib/acmm/computeRecommendations'
 import type { SourceId } from '../../lib/acmm/sources/types'
 import {
@@ -33,7 +34,7 @@ export function ACMMRecommendations() {
 
   function launchOne(rec: Recommendation) {
     startMission({
-      title: `Add ACMM loop: ${rec.criterion.name}`,
+      title: `Add ACMM criterion: ${rec.criterion.name}`,
       description: `Add "${rec.criterion.name}" to ${repo}`,
       type: 'custom',
       initialPrompt: singleRecommendationPrompt(rec, repo),
@@ -44,7 +45,7 @@ export function ACMMRecommendations() {
   function launchAll() {
     if (recommendations.length === 0) return
     startMission({
-      title: `Add ${recommendations.length} missing ACMM loops`,
+      title: `Add ${recommendations.length} missing ACMM criteria`,
       description: `Implement all top ACMM recommendations for ${repo}`,
       type: 'custom',
       initialPrompt: allRecommendationsPrompt(recommendations, repo),
@@ -99,7 +100,7 @@ export function ACMMRecommendations() {
               type="button"
               onClick={launchAll}
               className="inline-flex items-center gap-1 text-[10px] px-2 py-0.5 rounded-full bg-primary/20 text-primary hover:bg-primary/30 transition-colors"
-              title={`Ask the selected agent to add all ${recommendations.length} missing loops to ${repo}`}
+              title={`Ask the selected agent to add all ${recommendations.length} missing criteria to ${repo}`}
             >
               <Sparkles className="w-2.5 h-2.5" />
               Ask agent for help with all ({recommendations.length})
@@ -115,14 +116,24 @@ export function ACMMRecommendations() {
               <div className="flex items-start justify-between gap-2">
                 <div className="text-xs font-medium flex-1">{rec.criterion.name}</div>
                 <div className="flex gap-1 flex-shrink-0">
-                  {rec.sources.map((s) => (
-                    <span
-                      key={s}
-                      className="text-[9px] px-1.5 py-0.5 rounded-full bg-primary/20 text-primary"
-                    >
-                      {SOURCE_LABELS[s]}
-                    </span>
-                  ))}
+                  {rec.sources.map((s) => {
+                    const src = SOURCES_BY_ID[s]
+                    const badge = (
+                      <span
+                        className="text-[9px] px-1.5 py-0.5 rounded-full bg-primary/20 text-primary hover:bg-primary/30"
+                        title={src?.citation}
+                      >
+                        {SOURCE_LABELS[s]}
+                      </span>
+                    )
+                    return src?.url ? (
+                      <a key={s} href={src.url} target="_blank" rel="noopener noreferrer" className="no-underline">
+                        {badge}
+                      </a>
+                    ) : (
+                      <span key={s}>{badge}</span>
+                    )
+                  })}
                 </div>
               </div>
               <div className="text-[10px] text-muted-foreground mt-0.5 leading-snug">
@@ -139,7 +150,7 @@ export function ACMMRecommendations() {
                   type="button"
                   onClick={() => launchOne(rec)}
                   className="inline-flex items-center gap-1 text-[10px] px-1.5 py-0.5 rounded-md bg-primary/10 text-primary hover:bg-primary/20 transition-colors flex-shrink-0"
-                  title={`Ask the selected agent to add the "${rec.criterion.name}" loop to ${repo}`}
+                  title={`Ask the selected agent to add the "${rec.criterion.name}" criterion to ${repo}`}
                 >
                   <Zap className="w-2.5 h-2.5" />
                   Ask agent for help

--- a/web/src/components/cards/ACMMRecommendations.tsx
+++ b/web/src/components/cards/ACMMRecommendations.tsx
@@ -99,10 +99,10 @@ export function ACMMRecommendations() {
               type="button"
               onClick={launchAll}
               className="inline-flex items-center gap-1 text-[10px] px-2 py-0.5 rounded-full bg-primary/20 text-primary hover:bg-primary/30 transition-colors"
-              title={`Launch an AI mission to implement all ${recommendations.length} recommendations`}
+              title={`Ask the selected agent to add all ${recommendations.length} missing loops to ${repo}`}
             >
               <Sparkles className="w-2.5 h-2.5" />
-              Launch mission (all)
+              Ask agent for help with all ({recommendations.length})
             </button>
           )}
         </div>
@@ -139,10 +139,10 @@ export function ACMMRecommendations() {
                   type="button"
                   onClick={() => launchOne(rec)}
                   className="inline-flex items-center gap-1 text-[10px] px-1.5 py-0.5 rounded-md bg-primary/10 text-primary hover:bg-primary/20 transition-colors flex-shrink-0"
-                  title={'Launch an AI mission to add this loop'}
+                  title={`Ask the selected agent to add the "${rec.criterion.name}" loop to ${repo}`}
                 >
                   <Zap className="w-2.5 h-2.5" />
-                  Launch
+                  Ask agent for help
                 </button>
               </div>
             </div>

--- a/web/src/lib/acmm/missionPrompts.ts
+++ b/web/src/lib/acmm/missionPrompts.ts
@@ -25,11 +25,11 @@ export function detectionLabel(hint: DetectionHint): string {
 
 function buildPromptForCriterion(c: Criterion, repo: string, reason: string): string {
   const ref = c.referencePath ? `\n- Reference implementation: ${c.referencePath} in kubestellar/console` : ''
-  return `Add the "${c.name}" feedback loop to ${repo} so the ACMM dashboard detects it.
+  return `Add the "${c.name}" ACMM criterion to ${repo} so the ACMM dashboard detects it.
 
 Source: ${SOURCE_LABELS[c.source]}
 Criterion ID: ${c.id}
-What this loop does: ${c.description}
+What this criterion does: ${c.description}
 Why it matters: ${reason}
 
 Detection rule (must match at least one after your change):
@@ -64,13 +64,13 @@ export function allRecommendationsPrompt(recs: Recommendation[], repo: string): 
   const list = recs
     .map((r, i) => `${i + 1}. ${r.criterion.name} (${SOURCE_LABELS[r.criterion.source]}) — detection: ${detectionLabel(r.criterion.detection)}`)
     .join('\n')
-  return `Implement the missing ACMM feedback loops for ${repo}:
+  return `Implement the missing ACMM criteria for ${repo}:
 
 ${list}
 
 For each item:
 - Check whether an equivalent artifact already exists under a non-standard path (don't duplicate).
 - If truly missing, add the minimum change that matches the detection pattern and follows the repo's conventions.
-- Return a brief summary of what changed for each loop.
+- Return a brief summary of what changed for each criterion.
 Do not push or open a PR automatically — stop after commits so I can review.`
 }

--- a/web/src/lib/acmm/missionPrompts.ts
+++ b/web/src/lib/acmm/missionPrompts.ts
@@ -1,0 +1,76 @@
+/**
+ * Shared AI mission prompt builders for the ACMM dashboard cards.
+ *
+ * Both ACMMRecommendations (top-N missing loops) and ACMMFeedbackLoops
+ * (full inventory) launch the same kind of mission for a missing
+ * criterion: "audit the repo, then add the minimum thing that satisfies
+ * this detection rule." Keeping the prompts in one place ensures the
+ * two cards produce identical agent behavior.
+ */
+
+import type { Criterion, DetectionHint, SourceId } from './sources/types'
+import type { Recommendation } from './computeRecommendations'
+
+const SOURCE_LABELS: Record<SourceId, string> = {
+  acmm: 'ACMM',
+  fullsend: 'Fullsend',
+  'agentic-engineering-framework': 'AEF',
+  'claude-reflect': 'Reflect',
+}
+
+export function detectionLabel(hint: DetectionHint): string {
+  const patterns = Array.isArray(hint.pattern) ? hint.pattern : [hint.pattern]
+  return patterns.join(' · ')
+}
+
+function buildPromptForCriterion(c: Criterion, repo: string, reason: string): string {
+  const ref = c.referencePath ? `\n- Reference implementation: ${c.referencePath} in kubestellar/console` : ''
+  return `Add the "${c.name}" feedback loop to ${repo} so the ACMM dashboard detects it.
+
+Source: ${SOURCE_LABELS[c.source]}
+Criterion ID: ${c.id}
+What this loop does: ${c.description}
+Why it matters: ${reason}
+
+Detection rule (must match at least one after your change):
+- Type: ${c.detection.type}
+- Pattern: ${detectionLabel(c.detection)}${ref}
+
+Please:
+1. Audit the existing repo for any similar artifact that could already satisfy this detection (don't duplicate).
+2. If missing, create/commit the minimum file(s) that match the detection pattern and follow our project conventions.
+3. Return a short summary of what was added and why.
+Do not push or open a PR automatically — stop after the commit so I can review.`
+}
+
+/**
+ * Build a mission prompt from a Recommendation (used by ACMMRecommendations).
+ * Recommendations carry a synthesized `reason` from computeRecommendations.
+ */
+export function singleRecommendationPrompt(rec: Recommendation, repo: string): string {
+  return buildPromptForCriterion(rec.criterion, repo, rec.reason)
+}
+
+/**
+ * Build a mission prompt from a bare Criterion (used by ACMMFeedbackLoops
+ * where the user picks any missing criterion, not just the prioritized
+ * top-N). Falls back to the criterion's own rationale as the "why".
+ */
+export function singleCriterionPrompt(c: Criterion, repo: string): string {
+  return buildPromptForCriterion(c, repo, c.rationale)
+}
+
+export function allRecommendationsPrompt(recs: Recommendation[], repo: string): string {
+  const list = recs
+    .map((r, i) => `${i + 1}. ${r.criterion.name} (${SOURCE_LABELS[r.criterion.source]}) — detection: ${detectionLabel(r.criterion.detection)}`)
+    .join('\n')
+  return `Implement the missing ACMM feedback loops for ${repo}:
+
+${list}
+
+For each item:
+- Check whether an equivalent artifact already exists under a non-standard path (don't duplicate).
+- If truly missing, add the minimum change that matches the detection pattern and follows the repo's conventions.
+- Return a brief summary of what changed for each loop.
+Do not push or open a PR automatically — stop after commits so I can review.`
+}


### PR DESCRIPTION
## Summary

The **Feedback Loops Inventory** card was missing the "Launch AI mission" affordance that already exists on the **Recommendations** (Your Role) card. Users could see the same missing criterion in both places but only had the option to launch a fix mission from one of them.

## What changed

1. **Extracted shared prompt builders** to `web/src/lib/acmm/missionPrompts.ts` so both cards use identical agent prompts:
   - \`singleRecommendationPrompt(rec, repo)\` — for Recommendations (uses synthesized \`reason\`)
   - \`singleCriterionPrompt(c, repo)\` — for Feedback Loops (uses \`c.rationale\` as fallback)
   - \`allRecommendationsPrompt(recs, repo)\` — for the batch "Launch mission (all)" button
   - \`detectionLabel(hint)\` — shared

2. **Refactored \`ACMMRecommendations.tsx\`** to import from the shared module — no behavior change.

3. **Added Sparkles "Launch AI mission" button** to each expanded item in \`ACMMFeedbackLoops.tsx\`, **only when \`!detected\`** — there is no reason to launch a mission for a loop that is already in place.

## User-facing change

When you expand a missing criterion in the Feedback Loops Inventory, you now see three actions instead of two:
- View source
- Propose a change (file an issue against the criterion definition)
- **✨ Launch AI mission** (new — kicks off an agent to add the loop)

For already-detected items, only "View source" + "Propose a change" appear.

## Test plan

- [x] \`npx tsc --noEmit\` clean
- [x] \`npm run build\` passes all post-build safety checks
- [ ] Manual: expand a missing item in Feedback Loops → verify Sparkles button shows + clicking it opens the AI mission sidebar with the prompt pre-filled
- [ ] Manual: expand a detected item → verify Sparkles button is absent

🤖 Generated with [Claude Code](https://claude.com/claude-code)