### PR TITLE
🐛 fix: update DashboardGrid min-height test for 180px/row scale (#8351)

### DIFF
--- a/web/src/lib/unified/dashboard/__tests__/DashboardGrid.test.tsx
+++ b/web/src/lib/unified/dashboard/__tests__/DashboardGrid.test.tsx
@@ -258,8 +258,8 @@ describe('DashboardGrid', () => {
     const cards = [makePlacement('c1', 'test-card', 6, 3)]
     const { container } = render(<DashboardGrid cards={cards} />)
 
-    // h=3, each row = 100px, so min-height = 300px
-    const cardEl = container.querySelector('[style*="min-height: 300px"]')
+    // h=3, each row = EXPANDED_CARD_ROW_MIN_HEIGHT_PX (180px), so min-height = 540px
+    const cardEl = container.querySelector('[style*="min-height: 540px"]')
     expect(cardEl).not.toBeNull()
   })
 


### PR DESCRIPTION
## Summary
- PR #8349 bumped the unified grid's per-row min-height from 100px to `EXPANDED_CARD_ROW_MIN_HEIGHT_PX` (180px) so the unified grid behaves identically to `SharedSortableCard` (#8335/#8336).
- The `DashboardGrid.test.tsx` "calculates min-height from position.h" expectation still encoded the old 100px scale (`min-height: 300px` for h=3) and started failing in Coverage Suite run #823.
- Bump the expected value to 540px (3 × 180).

## Test plan
- [x] `npx vitest run src/lib/unified/dashboard/__tests__/DashboardGrid.test.tsx` — 15/15 passing

Fixes #8351