### PR TITLE
🛡️ Add pre-merge Go test gate + consolidate release-failure issues

### DIFF
--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -1,0 +1,54 @@
+name: Go Tests
+
+# Pre-merge gate that runs the FULL Go test suite on PRs. Without this,
+# Go test breakages would only surface in the nightly Release workflow —
+# historically every test failure in the nightly had to be traced back
+# to an already-merged commit. See release.yml for the other invocation.
+
+on:
+  pull_request:
+    paths:
+      - '**.go'
+      - 'go.mod'
+      - 'go.sum'
+      - '.github/workflows/go-test.yml'
+  push:
+    branches: [main]
+    paths:
+      - '**.go'
+      - 'go.mod'
+      - 'go.sum'
+      - '.github/workflows/go-test.yml'
+  workflow_dispatch:
+
+# Cancel superseded runs on the same PR/branch so we don't queue stale work.
+concurrency:
+  group: go-test-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    name: go test ./...
+    runs-on: ubuntu-latest
+    # Matches the release workflow's timeout budget; full suite runs in
+    # ~1-2 minutes today, cushion is for slower runners and test growth.
+    timeout-minutes: 15
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Set up Go
+        uses: actions/setup-go@3041bf56c941b39c61721a86cd11f3bb1338122a # v5.2.0
+        with:
+          go-version: '1.25'
+          cache: true
+
+      # Full suite — must match what release.yml runs or main can still
+      # break the nightly. -race catches concurrency bugs that only show
+      # up under load, which is cheap relative to the cost of a broken
+      # release pipeline.
+      - name: Run full Go test suite
+        run: go test -race -timeout 10m ./...

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -436,11 +436,16 @@ jobs:
             if (releaseResult === 'failure') failedJobs.push('release');
             if (helmResult === 'failure') failedJobs.push('helm-release');
 
-            const title = `🚨 ${releaseType} release failed: ${version}`;
-            const body = [
-              `## Release Failure`,
+            // Hours after closure that still counts as the "same incident" —
+            // if the last release-failure issue closed within this window and
+            // tonight still failed, the fix didn't stick. Reopen it instead
+            // of cutting a fresh issue every night.
+            const SAME_INCIDENT_HOURS = 48;
+
+            const failureSummary = [
+              `## Release Failure — \`${version}\``,
               ``,
-              `The **${releaseType}** release for \`${version}\` failed.`,
+              `The **${releaseType}** release failed.`,
               ``,
               `**Failed jobs:** ${failedJobs.join(', ')}`,
               `- test: ${testResult}`,
@@ -448,14 +453,54 @@ jobs:
               `- helm-release: ${helmResult}`,
               ``,
               `**Workflow run:** ${runUrl}`,
-              ``,
-              `This issue was auto-created by the release workflow.`,
             ].join('\n');
 
-            await github.rest.issues.create({
+            // Look for the most recent release-failure issue (any state).
+            // Rolling incident model: open issue → comment; recently-closed
+            // issue → reopen + comment; otherwise → new issue.
+            const { data: recent } = await github.rest.issues.listForRepo({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              title,
-              body,
-              labels: ['bug', 'release-failure'],
+              labels: 'release-failure',
+              state: 'all',
+              sort: 'created',
+              direction: 'desc',
+              per_page: 1,
             });
+            const existing = recent[0];
+
+            const now = Date.now();
+            const closedAt = existing?.closed_at ? new Date(existing.closed_at).getTime() : 0;
+            const hoursSinceClose = closedAt ? (now - closedAt) / 36e5 : Infinity;
+            const isOpen = existing && existing.state === 'open';
+            const recentlyClosed = existing && existing.state === 'closed' && hoursSinceClose <= SAME_INCIDENT_HOURS;
+
+            if (isOpen || recentlyClosed) {
+              if (recentlyClosed) {
+                await github.rest.issues.update({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: existing.number,
+                  state: 'open',
+                });
+              }
+              const note = recentlyClosed
+                ? `🔁 **Reopened:** previous fix did not stick — tonight's release also failed.`
+                : `🔁 **Still failing:** another release failure recorded.`;
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: existing.number,
+                body: `${note}\n\n${failureSummary}`,
+              });
+              core.info(`Updated existing issue #${existing.number} (${recentlyClosed ? 'reopened' : 'commented'}).`);
+            } else {
+              const { data: created } = await github.rest.issues.create({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                title: `🚨 ${releaseType} release failing`,
+                body: `${failureSummary}\n\n_Auto-created by the release workflow. Subsequent nightly failures within ${SAME_INCIDENT_HOURS}h will append to this issue instead of opening a duplicate._`,
+                labels: ['bug', 'release-failure'],
+              });
+              core.info(`Created new issue #${created.number}.`);
+            }


### PR DESCRIPTION
## Summary

Two changes to break the nightly-release-breakage cycle we've been in since 4/13 (issues #7256, #7898, #8091, #8310, #8313, #8314 — one auto-opened per night, one AI fix per day, next night still broken).

### 1. Pre-merge Go test gate — new `go-test.yml`
**Root cause of the cycle:** PR CI never ran `go test ./...`. The only invocation of the full Go suite lived in `release.yml`, which runs overnight. Go breakages landed on main silently during the day and only surfaced as a release failure the next morning.

New workflow runs `go test -race -timeout 10m ./...` on every PR that touches Go code (plus push-to-main as safety net). Uses a concurrency group to cancel stale runs. Locally the full suite with `-race` completes in ~2.5 min; 15 min timeout for headroom.

### 2. Rolling-incident issue consolidation — `release.yml` notify job
Previously the notify job called `issues.create()` unconditionally, so each failed night cut a fresh bug with no thread linking it to yesterday's "fixed" one. Made the "this keeps breaking" signal invisible.

New logic:
- Look up the most recent `release-failure` issue (any state)
- **Open** → append a "still failing" comment
- **Closed within 48h** → reopen it with a "🔁 previous fix did not stick" note + append comment
- **Otherwise** → create a new issue

One rolling thread per incident instead of a fresh daily issue.

## Test plan

- [x] Local: `go test -race -timeout 10m ./...` — all packages pass in ~2.5 min
- [x] YAML: both workflows parse cleanly with PyYAML
- [ ] After merge: PR CI will include `Go Tests` as a required check
- [ ] Next release failure (if any): verify the notify job reopens the prior issue instead of opening a fresh one