### PR TITLE
📝 fix(security-links): address Copilot review on #8348

### DIFF
--- a/web/src/components/missions/MissionDetailView.tsx
+++ b/web/src/components/missions/MissionDetailView.tsx
@@ -34,7 +34,7 @@ import { copyToClipboard } from '../../lib/clipboard'
 
 type TabId = 'install' | 'uninstall' | 'upgrade' | 'troubleshooting' | 'security'
 
-/** Primary (docs.kubestellar.io) URL for the Console security model. Linked
+/** Primary (kubestellar.io) URL for the Console security model. Linked
  *  from the Security tab fallback / footer. Prefer the rendered docs site
  *  for users; the repo version is the source-grounded reference. */
 const SECURITY_MODEL_DOC_URL = 'https://kubestellar.io/docs/console/main/console/security-model/'
@@ -665,7 +665,7 @@ export function MissionDetailView({
                         rel="noopener noreferrer"
                         className="inline-flex items-center gap-1 text-purple-400 hover:text-purple-300"
                       >
-                        AI threat model
+                        AI automation threat model
                         <ExternalLink className="w-3 h-3" />
                       </a>
                     </p>

--- a/web/src/components/setup/SetupInstructionsDialog.tsx
+++ b/web/src/components/setup/SetupInstructionsDialog.tsx
@@ -15,9 +15,8 @@ interface SetupInstructionsDialogProps {
 
 const REPO_URL = 'https://github.com/kubestellar/console'
 const DOCS_URL = 'https://console-docs.kubestellar.io'
-// Primary (user-friendly) security doc link — rendered docs site. Falls
-// back to the source-grounded repo version + AI-specific threat model
-// for readers who want the ground truth.
+// Rendered docs site for the Console security model (shown alongside
+// the source-grounded repo version and the AI-specific threat model).
 const SECURITY_DOC_URL = 'https://kubestellar.io/docs/console/main/console/security-model/'
 const SECURITY_DOC_REPO_URL = 'https://github.com/kubestellar/console/blob/main/docs/security/SECURITY-MODEL.md'
 const SECURITY_AI_DOC_URL = 'https://github.com/kubestellar/console/blob/main/docs/security/SECURITY-AI.md'
@@ -274,7 +273,7 @@ export function SetupInstructionsDialog({ isOpen, onClose }: SetupInstructionsDi
                           rel="noopener noreferrer"
                           className="inline-flex items-center gap-1 text-purple-400 hover:text-purple-300"
                         >
-                          Read the full security model (docs.kubestellar.io)
+                          Read the full security model (kubestellar.io)
                           <ExternalLink className="w-3 h-3" />
                         </a>
                         <a


### PR DESCRIPTION
## Summary

Addresses the four Copilot-generated review nits from #8352 on the merged #8348.

- Rewrote the misleading "Falls back to" comment on `SECURITY_DOC_URL` in `SetupInstructionsDialog.tsx` — both links are shown side-by-side, not in a fallback chain.
- Fixed inconsistent label `(docs.kubestellar.io)` → `(kubestellar.io)` in `SetupInstructionsDialog.tsx` to match the actual host of `SECURITY_DOC_URL`.
- Corrected `MissionDetailView.tsx` docstring from `docs.kubestellar.io` → `kubestellar.io` for the same constant.
- Aligned link text `AI threat model` → `AI automation threat model` in `MissionDetailView.tsx` so both entry points read the same.

Fixes #8352

## Test plan

- [x] `npm run build` passes
- [x] No functional changes — comments + label copy only