### PR TITLE
🐛 fix(nightly-gh-aw-version-check): exclude pre-releases

### DIFF
--- a/.github/workflows/nightly-gh-aw-version-check.yml
+++ b/.github/workflows/nightly-gh-aw-version-check.yml
@@ -28,8 +28,8 @@ jobs:
           fi
           echo "Current version: v${CURRENT_VERSION}"
 
-          # Get latest release
-          LATEST_VERSION=$(gh release list --repo github/gh-aw --limit 1 --json tagName --jq '.[0].tagName' | sed 's/^v//')
+          # Get latest stable release (exclude pre-releases — upstream tags -rc / pre-release cuts we shouldn't auto-bump to)
+          LATEST_VERSION=$(gh release list --repo github/gh-aw --exclude-pre-releases --limit 1 --json tagName --jq '.[0].tagName' | sed 's/^v//')
           echo "Latest version: v${LATEST_VERSION}"
 
           if [ "$CURRENT_VERSION" = "$LATEST_VERSION" ]; then
@@ -46,7 +46,7 @@ jobs:
 
           # Get changelog highlights for breaking changes
           BREAKING_CHANGES=""
-          for tag in $(gh release list --repo github/gh-aw --limit 10 --json tagName --jq '.[].tagName'); do
+          for tag in $(gh release list --repo github/gh-aw --exclude-pre-releases --limit 10 --json tagName --jq '.[].tagName'); do
             tag_minor=$(echo "$tag" | sed 's/^v//' | cut -d. -f2)
             if [ "$tag_minor" -gt "$CURRENT_MINOR" ]; then
               NOTES=$(gh release view "$tag" --repo github/gh-aw --json body --jq '.body' 2>/dev/null | grep -A1 "Breaking" | head -5)


### PR DESCRIPTION
## Summary

Addresses #8321 as a false-positive from the nightly check.

- The issue flagged v0.68.3 → v0.68.4, but v0.68.4 is a **pre-release** on `github/gh-aw`. We're already on the latest stable (v0.68.3), so there's nothing to bump.
- Root cause: the nightly `Nightly gh-aw Version Check` workflow used `gh release list --limit 1`, which returns the most recent tag regardless of pre-release flag. Between stable cuts, that tag is usually a pre-release, which is why we kept getting bump issues we couldn't act on.
- Fix: add `--exclude-pre-releases` to both `gh release list` calls (the latest-version lookup and the breaking-change walk) so the check only fires on stable releases.

Once this merges, #8321 will be closed as not-planned with an explanatory comment.

Fixes #8321

## Test plan

- [x] Verified via `gh api repos/githubnext/gh-aw/releases` that v0.68.4 is `prerelease: true`.
- [x] Verified `gh release view --repo githubnext/gh-aw` (which respects stable/latest) returns v0.68.3.
- [x] Workflow still compiles — only two string args added.