### PR TITLE
🐛 fix(test): DashboardGrid min-height test tracks EXPANDED_CARD_ROW_MIN_HEIGHT_PX

### DIFF
--- a/web/src/lib/unified/dashboard/__tests__/DashboardGrid.test.tsx
+++ b/web/src/lib/unified/dashboard/__tests__/DashboardGrid.test.tsx
@@ -258,9 +258,30 @@ describe('DashboardGrid', () => {
     const cards = [makePlacement('c1', 'test-card', 6, 3)]
     const { container } = render(<DashboardGrid cards={cards} />)
 
-    // h=3, each row = 100px, so min-height = 300px
-    const cardEl = container.querySelector('[style*="min-height: 300px"]')
+    // h=3, EXPANDED_CARD_ROW_MIN_HEIGHT_PX = 180 (raised from 100 in
+    // #8349 so the Resize-height menu actually grows the card visibly
+    // — #8335 #8336 #8337). 3 * 180 = 540px.
+    const cardEl = container.querySelector('[style*="min-height: 540px"]')
     expect(cardEl).not.toBeNull()
+  })
+
+  it('min-height scales linearly with position.h (constant-independent)', () => {
+    // Regression guard: if the per-row constant changes again, the
+    // previous literal-pixel test breaks silently. Assert the ratio so
+    // the only way this fails is a genuine scaling bug, not a constant
+    // retune.
+    mockGetCardConfig = (type: string) => ({ type, title: type })
+    const extract = (h: number) => {
+      const { container } = render(
+        <DashboardGrid cards={[makePlacement(`h${h}`, 'test-card', 6, h)]} />,
+      )
+      const el = container.querySelector('[style*="min-height"]') as HTMLElement | null
+      return Number((el?.style.minHeight || '').replace('px', ''))
+    }
+    const h2 = extract(2)
+    const h4 = extract(4)
+    expect(h2).toBeGreaterThan(0)
+    expect(h4).toBe(h2 * 2)
   })
 
   it('renders empty grid when no cards provided', () => {


### PR DESCRIPTION
## Summary

Closes **#8351** (Coverage Suite run #823 failing test).

PR #8349 raised \`EXPANDED_CARD_ROW_MIN_HEIGHT_PX\` from 100 → 180 to make the Resize-height menu actually grow the card visibly (#8335, #8336, #8337). The existing test still expected 300px for \`h=3\` and broke.

## Changes

- **Update the literal-pixel assertion** to 540px (3 * 180) with a comment explaining the constant, so the next retune is obvious.
- **Add a constant-independent regression guard** that asserts h=4 yields exactly 2× the min-height of h=2. If the constant changes again, the literal-pixel test still needs updating — but the ratio test continues passing, catching real scaling regressions separately from constant retunes.

## Test plan

- [x] `npx vitest run DashboardGrid.test.tsx` — 16/16 pass (was 15/16 failing)
- [ ] Coverage Suite re-runs green
- [ ] Issue #8351 auto-closes via `Closes #8351`

Closes #8351

🤖 Generated with [Claude Code](https://claude.com/claude-code)