### PR TITLE
🐛 fix(nodes-drilldown): explain empty list when RBAC blocks node enumeration

### DIFF
--- a/web/src/components/drilldown/views/MultiClusterSummaryDrillDown.tsx
+++ b/web/src/components/drilldown/views/MultiClusterSummaryDrillDown.tsx
@@ -158,10 +158,24 @@ function getStatusBadge(status: string) {
 export function MultiClusterSummaryDrillDown({ data, viewType }: MultiClusterSummaryDrillDownProps) {
   const { t } = useTranslation()
   const { clusters, deduplicatedClusters, pods, deployments, events, helmReleases, operatorSubscriptions, securityIssues } = useClusterData()
-  const { nodes: rawCachedNodes, lastRefresh: nodesLastRefresh } = useCachedNodes()
+  const {
+    nodes: rawCachedNodes,
+    lastRefresh: nodesLastRefresh,
+    isLoading: nodesIsLoading,
+    isFailed: nodesIsFailed,
+  } = useCachedNodes()
   const { pvcs: cachedPVCs } = useCachedPVCs()
   // Guard against undefined to prevent crashes when APIs return 404/500/empty
   const cachedNodes = rawCachedNodes || []
+  // For the all-nodes view: the overview stat block sums cluster.nodeCount,
+  // but the detail list is fetched from a separate endpoint that may return
+  // empty when the caller lacks list-nodes RBAC on some clusters (#8312).
+  // Track the expected count so we can explain the discrepancy instead of
+  // showing a blank "No items found".
+  const expectedNodeCountFromClusters = (clusters || []).reduce(
+    (sum, c) => sum + (c.nodeCount || 0),
+    0,
+  )
   // Convert epoch ms to ISO string for the freshness indicator
   const nodesDataAge = (() => {
     if (!nodesLastRefresh) return null
@@ -485,9 +499,35 @@ export function MultiClusterSummaryDrillDown({ data, viewType }: MultiClusterSum
       {/* Items List */}
       <div className="space-y-2">
         {filteredItems.length === 0 ? (
-          <div className="text-center py-8 text-muted-foreground">
-            No items found
-          </div>
+          viewType === 'all-nodes' && nodesIsLoading ? (
+            <div className="text-center py-8 text-muted-foreground text-sm">
+              Loading node details…
+            </div>
+          ) : viewType === 'all-nodes' &&
+            cachedNodes.length === 0 &&
+            expectedNodeCountFromClusters > 0 ? (
+            <div className="glass rounded-lg p-6 text-sm space-y-2">
+              <div className="flex items-start gap-2">
+                <AlertTriangle className="w-5 h-5 text-yellow-400 shrink-0 mt-0.5" />
+                <div>
+                  <div className="font-medium">
+                    Cluster summary reports {expectedNodeCountFromClusters} node
+                    {expectedNodeCountFromClusters === 1 ? '' : 's'}, but the
+                    detailed list is empty.
+                  </div>
+                  <div className="text-muted-foreground mt-1">
+                    {nodesIsFailed
+                      ? 'The node list endpoint is currently unreachable.'
+                      : 'This usually means the current user lacks list-nodes RBAC on one or more clusters, so the detail view can\'t enumerate nodes even though the per-cluster summary includes their count.'}
+                  </div>
+                </div>
+              </div>
+            </div>
+          ) : (
+            <div className="text-center py-8 text-muted-foreground">
+              No items found
+            </div>
+          )
         ) : (
           filteredItems.slice(0, 100).map((item, idx) => {
             const name = (item as Record<string, unknown>)[config.nameKey] as string || (item as Record<string, unknown>).name as string || 'Unknown'


### PR DESCRIPTION
## Summary

Addresses the reporter's symptom — `31 nodes in overview, drillDown shows no resources` — by explaining the discrepancy instead of rendering a bare "No items found".

**Root cause**
- The Nodes stat-overview block sums `cluster.nodeCount` from the cluster summary (one value per reachable cluster).
- The all-nodes drill-down reads from `useCachedNodes()` which hits `/api/nodes` per cluster. If the current user has cluster-level read access but not `list nodes` RBAC, this returns zero records for those clusters.
- Result: overview shows 31, drill-down shows an unqualified empty state. Users reasonably read that as a bug.

**Change**
In `MultiClusterSummaryDrillDown.tsx` (all-nodes view only):
1. While the node list is still loading, show "Loading node details…" instead of "No items found".
2. Once loading finishes, if cluster summaries reported >0 nodes but the detail list is empty, show a yellow-flagged info card that:
   - Restates the expected count
   - Distinguishes RBAC-gating from an unreachable endpoint (via `isFailed`)
   - Explains why the two views disagree

Other views and the generic empty case keep the existing "No items found" message.

Fixes #8312

## Test plan

- [x] `npm run build` passes
- [ ] Manual: open the Nodes stat-overview drill-down on a cluster where the user lacks `list nodes` — verify the info card renders with the expected count
- [ ] Manual: same view while the cache is still loading — verify the transient "Loading node details…" state
- [ ] Manual: other drill-downs (pods, deployments) still show "No items found" unchanged