### PR TITLE
⚡ ACMM badge: 1 h cache to scale to 200+ badged repos

### DIFF
--- a/web/netlify/functions/acmm-badge.mts
+++ b/web/netlify/functions/acmm-badge.mts
@@ -16,6 +16,16 @@ const GITHUB_API = "https://api.github.com";
 const REPO_RE = /^[\w.-]+\/[\w.-]+$/;
 const API_TIMEOUT_MS = 15_000;
 const LEVEL_COMPLETION_THRESHOLD = 0.7;
+/**
+ * Badge cache window. ACMM level changes slowly (file-tree shape, not commit
+ * activity), so a 1 h cache is plenty. This is shared across three layers:
+ *   1. shields.io respects this in its `cacheSeconds` JSON field below
+ *   2. our CDN respects this in the `Cache-Control` header below
+ *   3. GitHub's camo image proxy fetches the badge SVG and caches it itself
+ * Bumping from the prior 5 min to 1 h cuts function invocations ~12× without
+ * any user-visible staleness for a maturity-level signal.
+ */
+const BADGE_CACHE_SECONDS = 3600;
 
 /** ACMM criteria grouped by level. Mirrors acmm-scan.mts CRITERIA entries. */
 const ACMM_IDS_BY_LEVEL: Record<number, string[]> = {
@@ -81,7 +91,7 @@ const ALLOWED_ORIGIN_RE = /^https?:\/\/(.*\.kubestellar\.io|localhost(:\d+)?)$/;
 
 function corsHeaders(origin: string | null): Record<string, string> {
   const headers: Record<string, string> = {
-    "Cache-Control": "public, max-age=300",
+    "Cache-Control": `public, max-age=${BADGE_CACHE_SECONDS}`,
   };
   if (origin && ALLOWED_ORIGIN_RE.test(origin)) {
     headers["Access-Control-Allow-Origin"] = origin;
@@ -156,6 +166,7 @@ export default async (req: Request) => {
         label: "ACMM",
         message: "invalid repo",
         color: "red",
+        cacheSeconds: BADGE_CACHE_SECONDS,
       }),
       {
         status: 200,
@@ -178,6 +189,7 @@ export default async (req: Request) => {
           label: "ACMM",
           message: "unavailable",
           color: "lightgrey",
+          cacheSeconds: BADGE_CACHE_SECONDS,
         }),
         {
           status: 200,
@@ -198,6 +210,7 @@ export default async (req: Request) => {
       message: `L${level} · ${name} · ${totalDetected}/${totalAcmm}`,
       color,
       namedLogo: "github",
+      cacheSeconds: BADGE_CACHE_SECONDS,
     }),
     {
       status: 200,

--- a/web/netlify/functions/acmm-scan.mts
+++ b/web/netlify/functions/acmm-scan.mts
@@ -58,8 +58,13 @@ import { getStore } from "@netlify/blobs";
 
 const GITHUB_API = "https://api.github.com";
 const CACHE_STORE = "acmm-scan";
-/** Per-repo cache TTL: 15 minutes. Scans are expensive and state changes slowly. */
-const CACHE_TTL_MS = 15 * 60 * 1000;
+/**
+ * Per-repo cache TTL: 1 hour. Scans are expensive (full repo tree fetch) and
+ * the maturity signal changes on the order of days, not minutes. Aligned with
+ * the badge function's `cacheSeconds: 3600` so badge re-fetches almost always
+ * land on a warm blob and never re-hit GitHub.
+ */
+const CACHE_TTL_MS = 60 * 60 * 1000;
 /** Request timeout for GitHub API calls */
 const API_TIMEOUT_MS = 15_000;
 /** How many weeks of contribution history to return */


### PR DESCRIPTION
## Summary

The ACMM badge is starting to land in third-party READMEs (outreach to fullsend-ai/fullsend, AEF, Reflect). Each rendered badge URL gets re-evaluated by shields.io → our `/api/acmm/badge` → `/api/acmm/scan` → GitHub tree API. Prior cache windows (badge 5 min, scan 15 min) meant ~4 GitHub calls per badged repo per hour. Fine at 50 repos, tight at 1000+.

This PR aligns three caches at **1 hour** so the chain serves from cache uniformly:

| Layer | Setting | Before | After |
|---|---|---|---|
| `acmm-badge` `Cache-Control` | CDN window | `max-age=300` | `max-age=3600` |
| `acmm-badge` JSON | shields.io re-eval window | *(absent → defaults ~5 min)* | `cacheSeconds: 3600` |
| `acmm-scan` blob | per-repo cache | 15 min | 60 min |

### Rate-limit math (verified `GITHUB_TOKEN` is set in Netlify production context)

- 1 GitHub call per badged repo per hour (worst case)
- 200 repos → 200/hr → **4 % of our 5000/hr authenticated limit**
- 1000 repos → 1000/hr → 20 %
- Ceiling before throttle: ~5000 active badged repos

If we ever push past that, `KUBESTELLAR_CONSOLE_APP_ID` + `KUBESTELLAR_CONSOLE_APP_INSTALLATION_ID` are already set in Netlify env — switching the badge function to GitHub App auth lifts the limit. Easy follow-up, not needed today.

### Why a 1 h cache is safe

ACMM level reflects file-tree shape (CLAUDE.md present? coverage workflow? merge queue?) which changes on the order of days, not minutes. Users will never notice a 1 h delay between merging an instruction file and the badge ticking up.

## Test plan

- [ ] After merge, `curl https://console.kubestellar.io/api/acmm/badge?repo=kubestellar/console -i` shows `Cache-Control: public, max-age=3600` and the JSON includes `"cacheSeconds": 3600`
- [ ] Visit https://img.shields.io/endpoint?url=… → renders correctly with the new cache window
- [ ] Existing badges in `kubestellar/console` README continue to render (no shape change)
- [ ] Manual `?force=true` parameter on `/api/acmm/scan` still bypasses the (now 1 h) blob cache