### PR TITLE
🎨 ACMM Feedback Loops: right-align 'Ask agent for help'

### DIFF
--- a/web/src/components/cards/ACMMFeedbackLoops.tsx
+++ b/web/src/components/cards/ACMMFeedbackLoops.tsx
@@ -245,7 +245,7 @@ export function ACMMFeedbackLoops() {
                           e.stopPropagation()
                           launchOne(c)
                         }}
-                        className="inline-flex items-center gap-1 text-primary hover:text-primary/80"
+                        className="ml-auto inline-flex items-center gap-1 text-primary hover:text-primary/80"
                         title={`Ask the selected agent to add the "${c.name}" criterion to ${repo}`}
                       >
                         <Sparkles className="w-2.5 h-2.5" />


### PR DESCRIPTION
## Summary

Mirrors the **Top Recommendations** card layout where 'Ask agent for help' sits at the right edge of each row. Now consistent across both cards — users find the same affordance in the same visual position.

One-line change: `ml-auto` on the launch button in the expanded row of `ACMMFeedbackLoops.tsx`.

## Test plan

- [ ] Open /acmm, expand any missing criterion in the Feedback Loops Inventory
- [ ] 'Ask agent for help' button now sits at the right edge of the action row, with View source / Propose a change on the left