### PR TITLE
🔗 ACMM: sync URL on repo change + add Share button

### DIFF
--- a/web/src/components/acmm/ACMMProvider.tsx
+++ b/web/src/components/acmm/ACMMProvider.tsx
@@ -69,6 +69,16 @@ export function ACMMProvider({ children }: { children: ReactNode }) {
     } catch {
       // ignore localStorage failures
     }
+    // Sync the URL so the current scan is always shareable. replaceState
+    // (not pushState) keeps the back button useful — picking a new repo
+    // is dashboard interaction, not navigation.
+    try {
+      const url = new URL(window.location.href)
+      url.searchParams.set('repo', trimmed)
+      window.history.replaceState(null, '', url.toString())
+    } catch {
+      // window/history unavailable (SSR)
+    }
     setRecentRepos((prev) => {
       const dedup = [trimmed, ...prev.filter((r) => r !== trimmed)].slice(0, MAX_RECENT_REPOS)
       try {
@@ -86,6 +96,13 @@ export function ACMMProvider({ children }: { children: ReactNode }) {
       localStorage.setItem(SELECTED_REPO_KEY, DEFAULT_REPO)
     } catch {
       // ignore
+    }
+    try {
+      const url = new URL(window.location.href)
+      url.searchParams.set('repo', DEFAULT_REPO)
+      window.history.replaceState(null, '', url.toString())
+    } catch {
+      // window/history unavailable
     }
   }, [])
 

--- a/web/src/components/acmm/RepoPicker.tsx
+++ b/web/src/components/acmm/RepoPicker.tsx
@@ -7,7 +7,7 @@
  */
 
 import { useMemo, useRef, useState } from 'react'
-import { RefreshCw, X, ExternalLink, AlertCircle, Award, Copy, Check } from 'lucide-react'
+import { RefreshCw, X, ExternalLink, AlertCircle, Award, Copy, Check, Share2 } from 'lucide-react'
 import { Button } from '../ui/Button'
 import { Input } from '../ui/Input'
 import { cn } from '../../lib/cn'
@@ -134,6 +134,25 @@ export function RepoPicker() {
           >
             <Award className="w-3.5 h-3.5 mr-1" />
             Get badge
+          </Button>
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            onClick={() => copy(`${BADGE_SITE}/acmm?repo=${encodeURIComponent(repo)}`, 'share')}
+            title={`Copy a shareable link to this scan: ${BADGE_SITE}/acmm?repo=${repo}`}
+          >
+            {copied === 'share' ? (
+              <>
+                <Check className="w-3.5 h-3.5 mr-1 text-green-400" />
+                Copied
+              </>
+            ) : (
+              <>
+                <Share2 className="w-3.5 h-3.5 mr-1" />
+                Share
+              </>
+            )}
           </Button>
           <Button
             type="button"


### PR DESCRIPTION
## Summary

Two related UX fixes spotted while iterating on the picker:

### 1. URL sync on repo change
The address-bar `?repo=` was frozen on whatever loaded at page open, so copy-pasting the URL shared a *different* repo than the one on screen. `setRepo` and `clearRepo` in `ACMMProvider` now write to the URL via `history.replaceState` — the address bar is always shareable.

`replaceState` (not `pushState`) intentional: picking a new repo is dashboard interaction, not navigation, so it shouldn't pollute the back-button stack.

### 2. Share button
A `Share2` icon button between *Get badge* and the refresh icon copies the canonical `https://console.kubestellar.io/acmm?repo=…` URL to clipboard with a brief 'Copied' confirmation. Same copy-feedback pattern already used by the badge markdown/HTML buttons.

Conventional placement (right side of toolbar, after action buttons).

## Test plan

- [ ] Open /acmm with no `?repo=` param → defaults work
- [ ] Pick a different repo in the input → address bar `?repo=` updates immediately
- [ ] Browser back button does *not* pop through every repo selection (replaceState, not pushState)
- [ ] Click Share → 'Copied' shown for ~1.5 s, clipboard contains the in-context URL
- [ ] Paste the copied URL in a new tab → loads the same scan
- [ ] Refresh the page → URL still reflects the current repo (not whatever was first loaded)