### PR TITLE
🐛 fix: show demo-mode banner in feedback Updates tab (#8291)

### DIFF
--- a/web/src/components/feedback/FeatureRequestModal.tsx
+++ b/web/src/components/feedback/FeatureRequestModal.tsx
@@ -95,7 +95,7 @@ export function FeatureRequestModal({ isOpen, onClose, initialTab, initialReques
   const { user, isAuthenticated, token } = useAuth()
   const { showToast } = useToast()
   const currentGitHubLogin = user?.github_login || ''
-  const { createRequest, isSubmitting, requests, isLoading: requestsLoading, isRefreshing: requestsRefreshing, refresh: refreshRequests, requestUpdate, closeRequest } = useFeatureRequests(currentGitHubLogin)
+  const { createRequest, isSubmitting, requests, isLoading: requestsLoading, isRefreshing: requestsRefreshing, refresh: refreshRequests, requestUpdate, closeRequest, isDemoMode: isInDemoMode } = useFeatureRequests(currentGitHubLogin)
   const { notifications, isRefreshing: notificationsRefreshing, refresh: refreshNotifications, getUnreadCountForRequest, markRequestNotificationsAsRead } = useNotifications()
   const { githubRewards, githubPoints, refreshGitHubRewards } = useRewards()
   const { drafts, draftCount, saveDraft, deleteDraft, clearAllDrafts } = useFeedbackDrafts()
@@ -885,6 +885,17 @@ export function FeatureRequestModal({ isOpen, onClose, initialTab, initialReques
         ) : activeTab === 'updates' ? (
           /* Updates Tab — unified scrollable view */
           <div className="flex-1 flex flex-col min-h-0 overflow-hidden">
+              {isInDemoMode && (
+                <div
+                  role="status"
+                  className="flex items-start gap-2 border-b border-yellow-500/30 bg-yellow-500/10 px-3 py-2 text-xs text-yellow-400"
+                >
+                  <AlertTriangle className="w-3.5 h-3.5 mt-0.5 shrink-0" />
+                  <span>
+                    {t('feedback.demoDataBanner')}
+                  </span>
+                </div>
+              )}
               {/* Contributor banner — coins + level + progress */}
               <ContributorBanner />
 

--- a/web/src/locales/en/common.json
+++ b/web/src/locales/en/common.json
@@ -1775,6 +1775,7 @@
     "loginWithGitHub": "Login with GitHub",
     "loginExplanation": "Please login with GitHub to submit feedback, request updates, or close requests.",
     "loginDemoExplanation": "This is a public demo — GitHub login requires your own KubeStellar Console instance. Install locally to submit feedback and unlock all features.",
+    "demoDataBanner": "Demo mode: the items below are sample data, not your submissions. Install your own console or log in via GitHub OAuth to see real feature requests.",
     "getYourOwn": "Get Your Own Console",
     "oauthRequired": "GitHub Login Required",
     "oauthExplanation": "To submit feedback and earn coins through the console, you need a GitHub OAuth app configured for your installation.",


### PR DESCRIPTION
## Summary

Issue #8291 — @xonas1101 submitted a feature request from console.kubestellar.io, switched to the Updates tab, and saw the three hardcoded demo items (dark-mode toggle, dashboard-not-loading, export-as-PDF). Nothing on screen explained this was demo data, so it looked like the submission was lost.

On Netlify, `isDemoUser()` in `useFeatureRequests.ts` returns true (no real backend, no persisted JWT), so the hook serves `DEMO_FEATURE_REQUESTS` instead of calling `/api/feedback/queue`. That's the correct behavior — what was missing was the visible cue.

This PR adds a yellow banner at the top of the Updates tab when the hook reports demo mode:

> Demo mode: the items below are sample data, not your submissions. Install your own console or log in via GitHub OAuth to see real feature requests.

The hook already exposes `isDemoMode` on its return — no hook changes needed. The modal destructures it and renders a single `<div role=\"status\">` above `<ContributorBanner />`.

## Test plan

- [ ] Open modal on demo deployment (console.kubestellar.io) → switch to Updates tab → banner visible, sample items below it
- [ ] Open modal in OAuth-authenticated self-hosted console → banner hidden, real requests render
- [ ] Verify i18n key `feedback.demoDataBanner` resolves in English
- [ ] `npm run build` + `npm run lint` (no new errors in touched files)

Fixes #8291