### PR TITLE
🎨 ACMM intro modal: hide misleading Esc/Space hints

### DIFF
--- a/web/src/components/acmm/ACMMIntroModal.tsx
+++ b/web/src/components/acmm/ACMMIntroModal.tsx
@@ -186,7 +186,7 @@ export function ACMMIntroModal({ isOpen, onClose }: ACMMIntroModalProps) {
         </div>
       </BaseModal.Content>
 
-      <BaseModal.Footer>
+      <BaseModal.Footer showKeyboardHints={false}>
         <div className="flex items-center justify-between w-full">
           <label className="flex items-center gap-2 text-xs text-muted-foreground cursor-pointer select-none">
             <input


### PR DESCRIPTION
## Summary

The intro modal (#8360) is intentionally sticky — `closeOnEscape={false}` and `closeOnBackdrop={false}` so users have time to read it. But `BaseModal.Footer` defaults to showing 'Esc close · Space close' hints in the bottom right, which were lying to the user: pressing either key did nothing.

One-line fix: pass `showKeyboardHints={false}` to the Footer.

The 'Got it — let's go' button keeps its right-edge position via the existing `justify-between w-full` wrapper.

## Test plan

- [ ] Open /acmm in a fresh browser → modal opens
- [ ] No 'Esc close / Space close' hints in bottom right
- [ ] Press Esc — modal stays open (intended sticky behavior)
- [ ] 'Got it — let's go' is at the far right of the footer, checkbox at the far left