### PR TITLE
✨ ACMM: 'What is ACMM?' link to re-open the intro modal

### DIFF
--- a/web/src/components/acmm/ACMM.tsx
+++ b/web/src/components/acmm/ACMM.tsx
@@ -8,15 +8,21 @@
 
 import { DashboardPage } from '../../lib/dashboards/DashboardPage'
 import { getDefaultCards } from '../../config/dashboards'
-import { ACMMProvider } from './ACMMProvider'
+import { ACMMProvider, useACMM } from './ACMMProvider'
 import { RepoPicker } from './RepoPicker'
-import { ACMMIntroModal, useACMMIntroModal } from './ACMMIntroModal'
+import { ACMMIntroModal } from './ACMMIntroModal'
 
 const ACMM_CARDS_KEY = 'kubestellar-acmm-cards'
 const DEFAULT_ACMM_CARDS = getDefaultCards('acmm')
 
+/** Small consumer that wires the context-managed intro state into the
+ *  props-driven modal. Lives inside the provider so useACMM() works. */
+function ACMMIntroModalConnector() {
+  const { introOpen, closeIntro } = useACMM()
+  return <ACMMIntroModal isOpen={introOpen} onClose={closeIntro} />
+}
+
 export function ACMM() {
-  const intro = useACMMIntroModal()
   return (
     <ACMMProvider>
       <DashboardPage
@@ -33,7 +39,7 @@ export function ACMM() {
             'Enter a GitHub repo above to assess it against the AI Codebase Maturity Model.',
         }}
       />
-      <ACMMIntroModal isOpen={intro.isOpen} onClose={intro.onClose} />
+      <ACMMIntroModalConnector />
     </ACMMProvider>
   )
 }

--- a/web/src/components/acmm/ACMMIntroModal.tsx
+++ b/web/src/components/acmm/ACMMIntroModal.tsx
@@ -12,7 +12,7 @@
  * reset by clearing the localStorage key.
  */
 
-import { useState, useEffect } from 'react'
+import { useState } from 'react'
 import { BarChart3, ExternalLink, BookOpen, Layers, Wrench, GitBranch } from 'lucide-react'
 import { BaseModal } from '../../lib/modals'
 
@@ -210,21 +210,3 @@ export function ACMMIntroModal({ isOpen, onClose }: ACMMIntroModalProps) {
   )
 }
 
-/**
- * Hook that controls intro modal visibility for the /acmm page.
- * Opens on mount unless the user previously dismissed with "don't show again".
- */
-export function useACMMIntroModal() {
-  const [isOpen, setIsOpen] = useState(false)
-
-  useEffect(() => {
-    if (!isACMMIntroDismissed()) {
-      setIsOpen(true)
-    }
-  }, [])
-
-  return {
-    isOpen,
-    onClose: () => setIsOpen(false),
-  }
-}

--- a/web/src/components/acmm/ACMMProvider.tsx
+++ b/web/src/components/acmm/ACMMProvider.tsx
@@ -9,6 +9,7 @@
 import { createContext, useCallback, useContext, useEffect, useMemo, useState } from 'react'
 import type { ReactNode } from 'react'
 import { useCachedACMMScan, type UseACMMScanResult } from '../../hooks/useCachedACMMScan'
+import { isACMMIntroDismissed } from './ACMMIntroModal'
 
 const DEFAULT_REPO = 'kubestellar/console'
 const SELECTED_REPO_KEY = 'kubestellar-acmm-selected-repo'
@@ -21,6 +22,11 @@ interface ACMMContextValue {
   recentRepos: string[]
   clearRepo: () => void
   scan: UseACMMScanResult
+  /** Intro-modal visibility — lifted into context so the picker can
+   *  re-trigger the modal via "What is ACMM?" after dismissal. */
+  introOpen: boolean
+  openIntro: () => void
+  closeIntro: () => void
 }
 
 const ACMMContext = createContext<ACMMContextValue | null>(null)
@@ -57,8 +63,21 @@ function readRecentRepos(): string[] {
 export function ACMMProvider({ children }: { children: ReactNode }) {
   const [repo, setRepoState] = useState<string>(() => readInitialRepo())
   const [recentRepos, setRecentRepos] = useState<string[]>(() => readRecentRepos())
+  const [introOpen, setIntroOpen] = useState(false)
 
   const scan = useCachedACMMScan(repo)
+
+  // Auto-open the intro on first visit unless previously dismissed. The
+  // "What is ACMM?" link in RepoPicker can re-trigger via openIntro()
+  // regardless of dismissal state — manual recall always wins.
+  useEffect(() => {
+    if (!isACMMIntroDismissed()) {
+      setIntroOpen(true)
+    }
+  }, [])
+
+  const openIntro = useCallback(() => setIntroOpen(true), [])
+  const closeIntro = useCallback(() => setIntroOpen(false), [])
 
   const setRepo = useCallback((next: string) => {
     const trimmed = next.trim()
@@ -113,8 +132,8 @@ export function ACMMProvider({ children }: { children: ReactNode }) {
   }, [repo, recentRepos])
 
   const value = useMemo<ACMMContextValue>(
-    () => ({ repo, setRepo, recentRepos, clearRepo, scan }),
-    [repo, setRepo, recentRepos, clearRepo, scan],
+    () => ({ repo, setRepo, recentRepos, clearRepo, scan, introOpen, openIntro, closeIntro }),
+    [repo, setRepo, recentRepos, clearRepo, scan, introOpen, openIntro, closeIntro],
   )
 
   return <ACMMContext.Provider value={value}>{children}</ACMMContext.Provider>

--- a/web/src/components/acmm/RepoPicker.tsx
+++ b/web/src/components/acmm/RepoPicker.tsx
@@ -7,7 +7,7 @@
  */
 
 import { useMemo, useRef, useState } from 'react'
-import { RefreshCw, X, ExternalLink, AlertCircle, Award, Copy, Check, Share2 } from 'lucide-react'
+import { RefreshCw, X, ExternalLink, AlertCircle, Award, Copy, Check, Share2, Info } from 'lucide-react'
 import { Button } from '../ui/Button'
 import { Input } from '../ui/Input'
 import { cn } from '../../lib/cn'
@@ -19,7 +19,7 @@ const BADGE_SITE = 'https://console.kubestellar.io'
 const COPIED_FEEDBACK_MS = 1500
 
 export function RepoPicker() {
-  const { repo, setRepo, recentRepos, scan } = useACMM()
+  const { repo, setRepo, recentRepos, scan, openIntro } = useACMM()
   const [input, setInput] = useState(repo)
   const [error, setError] = useState<string | null>(null)
   const [showBadge, setShowBadge] = useState(false)
@@ -66,6 +66,17 @@ export function RepoPicker() {
 
   return (
     <div className="sticky top-0 z-20 bg-background/95 backdrop-blur-sm border-b border-border">
+      <div className="max-w-screen-2xl mx-auto px-6 pt-2 pb-0">
+        <button
+          type="button"
+          onClick={openIntro}
+          className="inline-flex items-center gap-1 text-xs text-muted-foreground hover:text-primary transition-colors"
+          title="Re-open the ACMM intro"
+        >
+          <Info className="w-3 h-3" />
+          What is ACMM?
+        </button>
+      </div>
       <div className="max-w-screen-2xl mx-auto px-6 py-3 flex flex-wrap items-center gap-3">
         <form
           onSubmit={(e) => {


### PR DESCRIPTION
## Summary

Users who dismissed the intro modal (#8360) had no way back to it. This PR adds a small info-icon link in the sticky picker bar — *ⓘ What is ACMM?* — that re-opens the modal.

Placed **above the input row** inside the picker (same column the user is already looking at), not next to the page title (which scrolls away when the user starts browsing).

## Implementation

- Lifted the modal's open-state out of `useACMMIntroModal()` and into `ACMMProvider` so the picker can re-trigger via `openIntro()` without remounting the modal.
- `ACMM.tsx` renders an inline `ACMMIntroModalConnector` that reads context and passes props to the still-pure modal component.
- `isACMMIntroDismissed()` localStorage check still controls **auto-open** behavior on first visit; `openIntro()` always opens regardless of dismissal — manual recall always wins.
- Removed the now-redundant `useACMMIntroModal` hook export.

## Test plan

- [ ] Fresh visit to /acmm with cleared localStorage → modal auto-opens
- [ ] Tick *Don't show this again*, close the modal
- [ ] Reload → modal does not auto-open (dismissal still respected)
- [ ] Click *ⓘ What is ACMM?* in the picker → modal re-opens regardless of dismissal
- [ ] Close the re-opened modal → stays closed until the link is clicked again or localStorage is cleared