### PR TITLE
🎨 fix: clarify 'Live' card-badge tooltip (#8363)

### DIFF
--- a/web/src/locales/en/cards.json
+++ b/web/src/locales/en/cards.json
@@ -552,7 +552,7 @@
     "demoBadgeTitle": "This card displays demo data",
     "demoModeTitle": "Demo mode enabled - showing sample data",
     "live": "Live",
-    "liveBadgeTitle": "Showing live data",
+    "liveBadgeTitle": "Streaming live events — this card subscribes to a real-time feed. Cards without the badge refresh on a polling interval.",
     "refreshFailed": "Refresh failed",
     "refreshFailedCount": "{{count}} consecutive refresh failures",
     "refreshFailedCount_one": "{{count}} consecutive refresh failure",


### PR DESCRIPTION
## Summary

Issue #8363 — @xonas1101 noticed that some cards show a green \"Live\" badge while others don't, and wasn't sure whether this meant the latter aren't live or whether the badge is redundant with the global nav indicator.

Neither — the badge is specifically for cards that subscribe to a real-time event stream (today: \`VClusterStatus\`, \`DrasiReactiveGraph\`). Cards without the badge aren't \"not live\"; they're polling at their cache interval.

This PR rewrites the tooltip so the distinction is readable without opening the code:

- **before:** \"Showing live data\"
- **after:** \"Streaming live events — this card subscribes to a real-time feed. Cards without the badge refresh on a polling interval.\"

Minor copy-only change — no behavior impact.

## Test plan

- [ ] Hover the green \"Live\" badge on a vCluster card → new tooltip renders
- [ ] \`npm run build\` passes

Fixes #8363