### PR TITLE
🐛 fix: recognize cookie-only sessions in feature-request demo check (#8291)

### DIFF
--- a/web/src/hooks/useFeatureRequests.ts
+++ b/web/src/hooks/useFeatureRequests.ts
@@ -1,15 +1,21 @@
 import { useState, useEffect, useCallback, useRef } from 'react'
 import { api } from '../lib/api'
-import { STORAGE_KEY_TOKEN } from '../lib/constants'
+import { STORAGE_KEY_TOKEN, STORAGE_KEY_HAS_SESSION, DEMO_TOKEN_VALUE } from '../lib/constants'
 import { MIN_PERCEIVED_DELAY_MS } from '../lib/constants/network'
 
 /** Cache TTL: 30 seconds — polling interval for status updates */
 const CACHE_TTL_MS = 30_000
 
-// Check if user is in demo mode — no token or explicit demo-token
+// #8291 — Post-#6590, a legitimate OAuth session can live ENTIRELY in the
+// HttpOnly kc_auth cookie with nothing in localStorage['token']. The previous
+// token-only check mislabeled those users as demo and served them the
+// hardcoded sample queue. The `kc-has-session` flag is set by /auth/refresh
+// once the backend confirms a cookie-backed session, so it's the authoritative
+// signal that a real user is logged in even with an empty localStorage token.
 function isDemoUser(): boolean {
+  if (localStorage.getItem(STORAGE_KEY_HAS_SESSION) === 'true') return false
   const token = localStorage.getItem(STORAGE_KEY_TOKEN)
-  return !token || token === 'demo-token'
+  return !token || token === DEMO_TOKEN_VALUE
 }
 
 // Types


### PR DESCRIPTION
## Summary

Follow-up to #8366. The banner fix surfaced the demo-mode state to the user, but the underlying misclassification remained.

@xonas1101 diagnosed the exact pathology in #8291: POST \`/api/feedback/requests\` returns 201, but **no GET \`/api/feedback/queue\` follows**, and the Updates tab shows the three hardcoded sample items.

Why: \`isDemoUser()\` in \`useFeatureRequests.ts\` read only \`localStorage['token']\`. Post-#6590 / #8108, a legitimate OAuth session lives entirely in the HttpOnly \`kc_auth\` cookie, so that check returned true for real users — which skips the GET (serving demo data) and clobbers the just-prepended submission on refresh. The POST still worked because the cookie carries the JWT to the backend regardless of what JS can see.

Reconcile with \`auth.tsx:702\`, which already uses \`kc-has-session === 'true'\` as authoritative for authentication on cookie-only sessions. Applying the same signal here routes real sessions through the API path.

## Test plan

- [ ] Self-hosted console, complete GitHub OAuth → Updates tab fetches \`/api/feedback/queue\` (verify GET in Network tab); no yellow demo banner
- [ ] Demo deployment (console.kubestellar.io) or logged-out session → Updates tab still shows demo items + yellow banner (unchanged)
- [ ] Submit a new feature request while OAuth'd → item appears and persists after the 5s auto-refresh
- [ ] \`npm run build\` passes

Fixes #8291