### PR TITLE
🧪 test: coverage push round 2 — useDrasiResources + ACMM scan + sources (+56 tests)

### DIFF
--- a/web/src/hooks/__tests__/useCachedACMMScan.test.tsx
+++ b/web/src/hooks/__tests__/useCachedACMMScan.test.tsx
@@ -1,0 +1,135 @@
+/**
+ * Branch-coverage tests for useCachedACMMScan.
+ *
+ * Exercises the demoScan generator, fetchACMMScan happy/error paths,
+ * forceRefetch flag-flip semantics, and the derived level+recommendations.
+ * useCache is mocked to short-circuit the caching layer so the hook's own
+ * logic is what's under test.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { renderHook, act, waitFor } from '@testing-library/react'
+
+// ---------------------------------------------------------------------------
+// Mock useCache — the hook delegates all fetching/caching to it. We mock it
+// to surface the passed-in `demoData` / `initialData` / `fetcher` so tests
+// can verify they were constructed correctly.
+// ---------------------------------------------------------------------------
+
+const lastArgs: { current: Record<string, unknown> | null } = { current: null }
+
+vi.mock('../../lib/cache', () => ({
+  useCache: (args: Record<string, unknown>) => {
+    lastArgs.current = args
+    return {
+      data: args.demoData,
+      isLoading: false,
+      isRefreshing: false,
+      isDemoFallback: false,
+      error: null,
+      isFailed: false,
+      consecutiveFailures: 0,
+      lastRefresh: Date.now(),
+      refetch: vi.fn(),
+    }
+  },
+  REFRESH_RATES: { costs: 600_000, default: 120_000 },
+}))
+
+import { useCachedACMMScan } from '../useCachedACMMScan'
+
+describe('useCachedACMMScan', () => {
+  beforeEach(() => {
+    lastArgs.current = null
+    globalThis.fetch = vi.fn() as typeof globalThis.fetch
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('uses the default repo when none is provided', () => {
+    renderHook(() => useCachedACMMScan())
+    expect(lastArgs.current?.key).toBe('acmm:scan:kubestellar/console')
+  })
+
+  it('accepts a custom repo and uses it in the cache key + initial data', () => {
+    renderHook(() => useCachedACMMScan('microsoft/drasi'))
+    expect(lastArgs.current?.key).toBe('acmm:scan:microsoft/drasi')
+    const demo = lastArgs.current?.demoData as { repo: string; weeklyActivity: Array<unknown> }
+    expect(demo.repo).toBe('microsoft/drasi')
+  })
+
+  it('demoScan generates 16 weekly activity buckets with non-negative counts', () => {
+    renderHook(() => useCachedACMMScan('x/y'))
+    const demo = lastArgs.current?.demoData as {
+      weeklyActivity: Array<{ week: string; aiPrs: number; humanPrs: number; aiIssues: number; humanIssues: number }>
+    }
+    expect(demo.weeklyActivity.length).toBe(16)
+    for (const wk of demo.weeklyActivity) {
+      expect(wk.week).toMatch(/^\d{4}-W\d{2}$/)
+      expect(wk.aiPrs).toBeGreaterThanOrEqual(0)
+      expect(wk.humanPrs).toBeGreaterThanOrEqual(0)
+      expect(wk.aiIssues).toBeGreaterThanOrEqual(0)
+      expect(wk.humanIssues).toBeGreaterThanOrEqual(0)
+    }
+  })
+
+  it('demoScan seeds a realistic detectedIds list that covers multiple sources', () => {
+    renderHook(() => useCachedACMMScan('x/y'))
+    const demo = lastArgs.current?.demoData as { detectedIds: string[] }
+    expect(demo.detectedIds.length).toBeGreaterThan(10)
+    // Should span ACMM + supplementary source prefixes.
+    expect(demo.detectedIds.some(id => id.startsWith('acmm:'))).toBe(true)
+    expect(demo.detectedIds.some(id => id.startsWith('fullsend:'))).toBe(true)
+  })
+
+  it('computes level + recommendations from detected IDs', () => {
+    const { result } = renderHook(() => useCachedACMMScan('x/y'))
+    expect(result.current.level).toBeDefined()
+    expect(result.current.level.level).toBeGreaterThan(0)
+    expect(Array.isArray(result.current.recommendations)).toBe(true)
+  })
+
+  it('detectedIds is a Set, not an array', () => {
+    const { result } = renderHook(() => useCachedACMMScan('x/y'))
+    expect(result.current.detectedIds).toBeInstanceOf(Set)
+  })
+
+  it('isDemoData is false when useCache reports no demo fallback', () => {
+    const { result } = renderHook(() => useCachedACMMScan('x/y'))
+    expect(result.current.isDemoData).toBe(false)
+  })
+
+  it('forceRefetch flips the force flag and calls refetch', async () => {
+    const { result } = renderHook(() => useCachedACMMScan('x/y'))
+    // Call the fetcher directly to verify the force flag makes it to the URL.
+    const fetcher = lastArgs.current?.fetcher as () => Promise<unknown>
+    globalThis.fetch = vi.fn(async (input: RequestInfo | URL) => {
+      const url = typeof input === 'string' ? input : (input as URL).toString()
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({ repo: 'x/y', scannedAt: '', detectedIds: [], weeklyActivity: [], _url: url }),
+      } as Response
+    }) as typeof globalThis.fetch
+
+    await act(async () => { await result.current.forceRefetch() })
+    // Directly invoke the fetcher after forceRefetch — forceNextRef was set
+    // to true in forceRefetch, so this first call should include &force=true.
+    await act(async () => { await fetcher() })
+    const urls = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls.map(
+      c => (typeof c[0] === 'string' ? c[0] : String(c[0])),
+    )
+    expect(urls.some(u => u.includes('force=true'))).toBe(true)
+  })
+
+  it('fetcher bubbles a non-2xx response as an Error', async () => {
+    renderHook(() => useCachedACMMScan('x/y'))
+    const fetcher = lastArgs.current?.fetcher as () => Promise<unknown>
+    globalThis.fetch = vi.fn(async () => ({
+      ok: false, status: 503, statusText: 'Service Unavailable',
+      json: async () => ({}),
+    }) as Response) as typeof globalThis.fetch
+    await expect(fetcher()).rejects.toThrow(/503/)
+  })
+})

--- a/web/src/hooks/__tests__/useDrasiResources.test.tsx
+++ b/web/src/hooks/__tests__/useDrasiResources.test.tsx
@@ -1,0 +1,360 @@
+/**
+ * Branch-coverage tests for useDrasiResources.ts.
+ *
+ * Exercises both adapters (drasi-server REST and drasi-platform REST),
+ * the status/kind normalizers, the isDemoSeed short-circuit, and the
+ * abort-on-refetch behavior. fetch is mocked at the global level.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { renderHook, waitFor, act } from '@testing-library/react'
+
+// ---------------------------------------------------------------------------
+// Mocks — useDrasiResources pulls the active connection from
+// useDrasiConnections. We stub that module so each test picks the mode
+// it wants without also exercising the connections hook.
+// ---------------------------------------------------------------------------
+
+const mockActive: { current: {
+  id: string
+  name: string
+  mode: 'server' | 'platform'
+  url?: string
+  cluster?: string
+  isDemoSeed?: boolean
+  createdAt: number
+} | null } = { current: null }
+
+vi.mock('../useDrasiConnections', () => ({
+  useDrasiConnections: () => ({
+    connections: mockActive.current ? [mockActive.current] : [],
+    activeId: mockActive.current?.id ?? '',
+    activeConnection: mockActive.current,
+    addConnection: vi.fn(),
+    updateConnection: vi.fn(),
+    removeConnection: vi.fn(),
+    setActive: vi.fn(),
+  }),
+  getActiveDrasiConnection: () => mockActive.current,
+}))
+
+import { useDrasiResources } from '../useDrasiResources'
+
+// Minimal fetch mock — responses is keyed by URL *substring* so tests
+// declare the match pattern near the assertion.
+const fetchMap = new Map<string, unknown>()
+function wireFetch(entries: Record<string, unknown>) {
+  fetchMap.clear()
+  for (const [k, v] of Object.entries(entries)) fetchMap.set(k, v)
+}
+function serverWrap(data: unknown) {
+  return { success: true, data, error: null }
+}
+
+describe('useDrasiResources', () => {
+  beforeEach(() => {
+    mockActive.current = null
+    fetchMap.clear()
+    globalThis.fetch = vi.fn(async (input: RequestInfo | URL) => {
+      const url = typeof input === 'string' ? input : (input as URL).toString()
+      for (const [pattern, payload] of fetchMap.entries()) {
+        if (url.includes(pattern)) {
+          return {
+            ok: true,
+            status: 200,
+            json: async () => payload,
+          } as Response
+        }
+      }
+      return { ok: false, status: 404, json: async () => ({}) } as Response
+    }) as typeof globalThis.fetch
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  describe('no-fetch short-circuits', () => {
+    it('returns null data when no active connection', async () => {
+      mockActive.current = null
+      const { result } = renderHook(() => useDrasiResources())
+      // Give the effect a tick to run.
+      await act(async () => { await new Promise(r => setTimeout(r, 10)) })
+      expect(result.current.data).toBeNull()
+      expect(globalThis.fetch).not.toHaveBeenCalled()
+    })
+
+    it('skips fetch when active connection is a demo seed', async () => {
+      mockActive.current = {
+        id: 'demo-seed-retail',
+        name: 'retail (demo)',
+        mode: 'server',
+        url: 'http://fake',
+        isDemoSeed: true,
+        createdAt: 1,
+      }
+      const { result } = renderHook(() => useDrasiResources())
+      await act(async () => { await new Promise(r => setTimeout(r, 10)) })
+      expect(result.current.data).toBeNull()
+      expect(globalThis.fetch).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('drasi-server adapter', () => {
+    beforeEach(() => {
+      mockActive.current = {
+        id: 'srv', name: 'srv', mode: 'server',
+        url: 'http://drasi-server:8080', createdAt: 1,
+      }
+    })
+
+    it('normalizes sources / queries / reactions from drasi-server REST', async () => {
+      // Ordering matters — the fetch mock does substring match in insertion
+      // order, so more-specific paths (…/results) must be registered BEFORE
+      // their prefix (…/queries/my-query).
+      wireFetch({
+        '/api/v1/instances/inst-1/queries/my-query/results?': serverWrap([
+          { symbol: 'AAPL', price: 180.5 },
+        ]),
+        '/api/v1/instances/inst-1/queries/my-query?view=full': serverWrap({
+          id: 'my-query', status: 'Running',
+          config: {
+            query: 'MATCH (n) RETURN n',
+            queryLanguage: 'Cypher',
+            sources: [{ sourceId: 'src-postgres' }],
+          },
+        }),
+        '/api/v1/instances?': serverWrap([{ id: 'inst-1', status: 'Running' }]),
+        '/api/v1/sources?': serverWrap([
+          { id: 'src-postgres', status: 'Running' },
+          { id: 'src-http', status: 'Stopped' },
+        ]),
+        '/api/v1/queries?': serverWrap([{ id: 'my-query', status: 'Running' }]),
+        '/api/v1/reactions?': serverWrap([{ id: 'sse-stream', status: 'Running' }]),
+      })
+
+      const { result } = renderHook(() => useDrasiResources())
+      await waitFor(() => expect(result.current.data).not.toBeNull())
+
+      expect(result.current.data?.mode).toBe('server')
+      expect(result.current.data?.instanceId).toBe('inst-1')
+      expect(result.current.data?.sources.length).toBe(2)
+      expect(result.current.data?.sources[0].kind).toBe('POSTGRES')
+      expect(result.current.data?.sources[0].status).toBe('ready')
+      expect(result.current.data?.sources[1].status).toBe('pending') // Stopped → pending
+      expect(result.current.data?.queries.length).toBe(1)
+      expect(result.current.data?.queries[0].language).toBe('CYPHER QUERY')
+      expect(result.current.data?.queries[0].sourceIds).toEqual(['src-postgres'])
+      expect(result.current.data?.queries[0].queryText).toBe('MATCH (n) RETURN n')
+      expect(result.current.data?.reactions.length).toBe(1)
+      expect(result.current.data?.liveResults.length).toBe(1)
+    })
+
+    it('falls back to GQL QUERY when queryLanguage missing', async () => {
+      wireFetch({
+        '/api/v1/instances?': serverWrap([{ id: 'inst-1', status: 'Running' }]),
+        '/api/v1/sources?': serverWrap([]),
+        '/api/v1/queries?': serverWrap([{ id: 'q-no-config', status: 'Running' }]),
+        '/api/v1/reactions?': serverWrap([]),
+        '/api/v1/instances/inst-1/queries/q-no-config': serverWrap({
+          id: 'q-no-config', status: 'Running',
+        }),
+      })
+      const { result } = renderHook(() => useDrasiResources())
+      await waitFor(() => expect(result.current.data?.queries.length).toBe(1))
+      expect(result.current.data?.queries[0].language).toBe('GQL QUERY')
+      expect(result.current.data?.queries[0].sourceIds).toEqual([])
+    })
+
+    it('swallows the per-query full-view 404 and uses the summary', async () => {
+      wireFetch({
+        '/api/v1/instances?': serverWrap([{ id: 'inst-1', status: 'Running' }]),
+        '/api/v1/sources?': serverWrap([]),
+        '/api/v1/queries?': serverWrap([{ id: 'q-missing', status: 'Running' }]),
+        '/api/v1/reactions?': serverWrap([]),
+        // NO /api/v1/instances/inst-1/queries/q-missing mock — 404
+      })
+      const { result } = renderHook(() => useDrasiResources())
+      await waitFor(() => expect(result.current.data?.queries.length).toBe(1))
+      // Falls back to summary-shape → GQL default, empty source list.
+      expect(result.current.data?.queries[0].id).toBe('q-missing')
+    })
+
+    it('surfaces error when the first call fails (non-200)', async () => {
+      // No wire → first fetch returns 404 → throw → setError path
+      const { result } = renderHook(() => useDrasiResources())
+      await waitFor(() => expect(result.current.error).not.toBeNull())
+      expect(result.current.data).toBeNull()
+    })
+
+    it('surfaces error when drasi-server wrapper signals error', async () => {
+      wireFetch({
+        '/api/v1/instances?': { success: false, data: null, error: 'oh no' },
+      })
+      const { result } = renderHook(() => useDrasiResources())
+      await waitFor(() => expect(result.current.error).not.toBeNull())
+      expect(result.current.error).toMatch(/oh no/)
+    })
+
+    it('handles empty results (no instances, no running query)', async () => {
+      wireFetch({
+        '/api/v1/instances?': serverWrap([]),
+        '/api/v1/sources?': serverWrap([]),
+        '/api/v1/queries?': serverWrap([]),
+        '/api/v1/reactions?': serverWrap([]),
+      })
+      const { result } = renderHook(() => useDrasiResources())
+      await waitFor(() => expect(result.current.data).not.toBeNull())
+      expect(result.current.data?.instanceId).toBeNull()
+      expect(result.current.data?.liveResults).toEqual([])
+    })
+
+    it('refetch() triggers an additional call and aborts the previous', async () => {
+      wireFetch({
+        '/api/v1/instances?': serverWrap([]),
+        '/api/v1/sources?': serverWrap([]),
+        '/api/v1/queries?': serverWrap([]),
+        '/api/v1/reactions?': serverWrap([]),
+      })
+      const { result } = renderHook(() => useDrasiResources())
+      await waitFor(() => expect(result.current.data).not.toBeNull())
+      const callsBefore = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls.length
+
+      await act(async () => { result.current.refetch() })
+      await waitFor(() => {
+        const callsAfter = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls.length
+        expect(callsAfter).toBeGreaterThan(callsBefore)
+      })
+    })
+  })
+
+  describe('drasi-platform adapter', () => {
+    beforeEach(() => {
+      mockActive.current = {
+        id: 'plat', name: 'plat', mode: 'platform',
+        cluster: 'prow', createdAt: 1,
+      }
+    })
+
+    it('normalizes platform sources / continuousQueries / reactions (raw arrays, no wrapper)', async () => {
+      wireFetch({
+        '/v1/sources?': [{
+          id: 'src-pg',
+          spec: { kind: 'PostgreSQL' },
+          status: { available: true },
+        }],
+        '/v1/continuousQueries?': [{
+          id: 'q-cypher',
+          spec: {
+            mode: 'cypher',
+            query: 'MATCH (n) RETURN n',
+            sources: [{ id: 'src-pg' }],
+          },
+          status: { available: true },
+        }],
+        '/v1/reactions?': [{
+          id: 'rx-sse',
+          spec: {
+            kind: 'SignalR',
+            queries: [{ id: 'q-cypher' }],
+          },
+          status: { available: false },
+        }],
+      })
+
+      const { result } = renderHook(() => useDrasiResources())
+      await waitFor(() => expect(result.current.data).not.toBeNull())
+      expect(result.current.data?.mode).toBe('platform')
+      expect(result.current.data?.instanceId).toBeNull()
+      expect(result.current.data?.sources[0].kind).toBe('POSTGRES')
+      expect(result.current.data?.sources[0].status).toBe('ready')
+      expect(result.current.data?.queries[0].language).toBe('CYPHER QUERY')
+      expect(result.current.data?.queries[0].sourceIds).toEqual(['src-pg'])
+      expect(result.current.data?.reactions[0].kind).toBe('SIGNALR')
+      expect(result.current.data?.reactions[0].status).toBe('error') // available: false
+      expect(result.current.data?.liveResults).toEqual([]) // platform never eagerly fetches
+    })
+
+    it('defaults language to CYPHER QUERY when spec.mode is missing', async () => {
+      wireFetch({
+        '/v1/sources?': [],
+        '/v1/continuousQueries?': [{
+          id: 'q-no-mode',
+          spec: { query: 'MATCH (n) RETURN n' },
+          status: { available: true },
+        }],
+        '/v1/reactions?': [],
+      })
+      const { result } = renderHook(() => useDrasiResources())
+      await waitFor(() => expect(result.current.data?.queries.length).toBe(1))
+      expect(result.current.data?.queries[0].language).toBe('CYPHER QUERY')
+    })
+
+    it('handles empty arrays gracefully', async () => {
+      wireFetch({
+        '/v1/sources?': null, // null arrays should coerce to []
+        '/v1/continuousQueries?': null,
+        '/v1/reactions?': null,
+      })
+      const { result } = renderHook(() => useDrasiResources())
+      await waitFor(() => expect(result.current.data).not.toBeNull())
+      expect(result.current.data?.sources).toEqual([])
+      expect(result.current.data?.queries).toEqual([])
+      expect(result.current.data?.reactions).toEqual([])
+    })
+
+    it('status pending when status object is ambiguous', async () => {
+      wireFetch({
+        '/v1/sources?': [{ id: 's1', spec: {}, status: { available: undefined } }],
+        '/v1/continuousQueries?': [],
+        '/v1/reactions?': [],
+      })
+      const { result } = renderHook(() => useDrasiResources())
+      await waitFor(() => expect(result.current.data?.sources.length).toBe(1))
+      expect(result.current.data?.sources[0].status).toBe('pending')
+    })
+
+    it('accepts string status (legacy platform shape)', async () => {
+      wireFetch({
+        '/v1/sources?': [{ id: 's1', spec: {}, status: 'Running' }],
+        '/v1/continuousQueries?': [],
+        '/v1/reactions?': [],
+      })
+      const { result } = renderHook(() => useDrasiResources())
+      await waitFor(() => expect(result.current.data?.sources.length).toBe(1))
+      expect(result.current.data?.sources[0].status).toBe('ready')
+    })
+  })
+
+  describe('kind mappers (via sources adapter output)', () => {
+    beforeEach(() => {
+      mockActive.current = {
+        id: 'srv', name: 'srv', mode: 'server',
+        url: 'http://drasi-server:8080', createdAt: 1,
+      }
+    })
+
+    it('maps various source identifiers to the expected kind', async () => {
+      wireFetch({
+        '/api/v1/instances?': serverWrap([{ id: 'i', status: 'Running' }]),
+        '/api/v1/sources?': serverWrap([
+          { id: 'cosmos-x', status: 'Running' },
+          { id: 'gremlin-y', status: 'Running' },
+          { id: 'http-z', status: 'Running' },
+          { id: 'sqlserver-a', status: 'Running' },
+          { id: 'unknown-b', status: 'Running' },
+        ]),
+        '/api/v1/queries?': serverWrap([]),
+        '/api/v1/reactions?': serverWrap([]),
+      })
+      const { result } = renderHook(() => useDrasiResources())
+      await waitFor(() => expect(result.current.data?.sources.length).toBe(5))
+      const kinds = result.current.data!.sources.map(s => s.kind)
+      expect(kinds).toContain('COSMOSDB')
+      expect(kinds).toContain('GREMLIN')
+      expect(kinds).toContain('HTTP')
+      expect(kinds).toContain('SQL')
+      // The fallback is POSTGRES for unrecognized ids.
+      expect(kinds).toContain('POSTGRES')
+    })
+  })
+})

--- a/web/src/lib/acmm/sources/__tests__/sources.test.ts
+++ b/web/src/lib/acmm/sources/__tests__/sources.test.ts
@@ -1,0 +1,133 @@
+/**
+ * Structural + data-integrity tests for the ACMM sources index.
+ *
+ * These files are pure data modules — the "test" is that every source
+ * is well-formed, every criterion has the required fields, and the
+ * composite arrays (ALL_CRITERIA, SOURCES_BY_ID) stay in sync with
+ * the individual source exports. Cheap to write, high coverage gain.
+ */
+import { describe, it, expect } from 'vitest'
+import {
+  SOURCES,
+  SOURCES_BY_ID,
+  ALL_CRITERIA,
+  ACMM_LEVELS,
+} from '../index'
+import { acmmSource } from '../acmm'
+import { fullsendSource } from '../fullsend'
+import { agenticEngineeringFrameworkSource } from '../agentic-engineering-framework'
+import { claudeReflectSource } from '../claude-reflect'
+
+const VALID_CATEGORIES = [
+  'feedback-loop',
+  'readiness',
+  'autonomy',
+  'observability',
+  'governance',
+  'self-tuning',
+]
+const VALID_SOURCES = ['acmm', 'fullsend', 'agentic-engineering-framework', 'claude-reflect']
+
+describe('ACMM sources index', () => {
+  it('SOURCES contains exactly four sources', () => {
+    expect(SOURCES.length).toBe(4)
+  })
+
+  it('SOURCES_BY_ID keys match each source.id', () => {
+    for (const src of SOURCES) {
+      expect(SOURCES_BY_ID[src.id]).toBe(src)
+    }
+  })
+
+  it('ALL_CRITERIA equals the union of every source.criteria list', () => {
+    const expected = SOURCES.flatMap(s => s.criteria).length
+    expect(ALL_CRITERIA.length).toBe(expected)
+  })
+
+  it('ACMM_LEVELS is populated only from the acmm source', () => {
+    expect(ACMM_LEVELS.length).toBe(acmmSource.levels?.length ?? 0)
+    expect(ACMM_LEVELS.length).toBeGreaterThan(0)
+  })
+})
+
+describe('Each source is well-formed', () => {
+  for (const source of [
+    acmmSource,
+    fullsendSource,
+    agenticEngineeringFrameworkSource,
+    claudeReflectSource,
+  ]) {
+    describe(`source "${source.id}"`, () => {
+      it('has id, name, and a non-empty criteria list', () => {
+        expect(source.id).toBeTruthy()
+        expect(source.name).toBeTruthy()
+        expect(source.criteria.length).toBeGreaterThan(0)
+      })
+
+      it('uses a known source id on every criterion', () => {
+        for (const c of source.criteria) {
+          expect(VALID_SOURCES).toContain(c.source)
+        }
+      })
+
+      it('criterion.source matches the containing source.id', () => {
+        for (const c of source.criteria) {
+          expect(c.source).toBe(source.id)
+        }
+      })
+
+      it('every criterion has an id, name, description, rationale, and detection hint', () => {
+        for (const c of source.criteria) {
+          expect(c.id).toBeTruthy()
+          expect(c.name).toBeTruthy()
+          expect(c.description).toBeTruthy()
+          expect(c.rationale).toBeTruthy()
+          expect(c.detection).toBeDefined()
+          expect(['path', 'glob', 'any-of']).toContain(c.detection.type)
+        }
+      })
+
+      it('every criterion category is one of the known categories', () => {
+        for (const c of source.criteria) {
+          expect(VALID_CATEGORIES).toContain(c.category)
+        }
+      })
+
+      it('no duplicate criterion ids within the source', () => {
+        const ids = source.criteria.map(c => c.id)
+        expect(new Set(ids).size).toBe(ids.length)
+      })
+    })
+  }
+})
+
+describe('ACMM-specific invariants', () => {
+  it('every ACMM criterion has a level in 1..5', () => {
+    for (const c of acmmSource.criteria) {
+      if (c.source === 'acmm') {
+        expect(c.level).toBeGreaterThanOrEqual(1)
+        expect(c.level).toBeLessThanOrEqual(5)
+      }
+    }
+  })
+
+  it('acmm.levels defines 5 entries with n=1..5', () => {
+    expect(acmmSource.levels?.map(l => l.n)).toEqual([1, 2, 3, 4, 5])
+  })
+
+  it('every level has a name, role, characteristic, and anti-pattern', () => {
+    for (const lvl of acmmSource.levels ?? []) {
+      expect(lvl.name).toBeTruthy()
+      expect(lvl.role).toBeTruthy()
+      expect(lvl.characteristic).toBeTruthy()
+      expect(lvl.antiPattern).toBeTruthy()
+    }
+  })
+})
+
+describe('Cross-source de-dup sanity', () => {
+  it('no criterion id collisions across sources', () => {
+    const allIds = ALL_CRITERIA.map(c => c.id)
+    expect(new Set(allIds).size).toBe(allIds.length)
+  })
+})


### PR DESCRIPTION
## Summary

Second round of the 88.53% → 91%+ coverage push. Post-round-1 coverage is **89.03%**; this PR targets three more high-value under-tested files.

| File | Before | Tests added | Est. coverage |
|---|---|---|---|
| `hooks/useDrasiResources.ts` | 2% (2/98) | 15 | ~80% |
| `hooks/useCachedACMMScan.ts` | 0% (0/34) | 9 | ~90% |
| `lib/acmm/sources/*.ts` + `index.ts` | 0% (0/13+) | 32 | 100% |

**Total:** 56 new passing tests, 628 lines of test code. Expected gain ≈ **+0.8 pp** → coverage ~89.8%.

### Test detail

**`useDrasiResources.ts`** — demo-seed short-circuit, full drasi-server REST adapter (happy path + language default + 404 full-view fallback + wrap-error surfacing + empty results), full drasi-platform adapter (raw arrays, legacy string status, ambiguous-object status, empty arrays), all 5 source-kind mappings (COSMOSDB/GREMLIN/HTTP/SQL/POSTGRES fallback), and `refetch()` invocation. Mocks `useDrasiConnections` and global `fetch`.

**`useCachedACMMScan.ts`** — default vs custom repo, 16-week activity buckets with ISO week labels, cross-source `detectedIds` coverage, level + recommendations derivation, `Set`-not-array contract, `forceRefetch` flag-flip reaches the URL as `?force=true`, non-2xx error surfacing. Mocks `useCache` so the hook's own logic is what's under test.

**ACMM sources index + 4 source files** — 32 structural/integrity tests: `SOURCES` length, `SOURCES_BY_ID` keying, `ALL_CRITERIA` union, `ACMM_LEVELS` derived from acmm source, per-source well-formedness, criterion id/source consistency, category whitelist, no duplicate ids within or across sources, ACMM L1-L5 level invariants.

### Round 3 targets

The remaining top-uncovered files that will push past 91%:
- `hooks/useIntoto.ts` (161 lines, 6%) — **largest remaining target**
- `hooks/mcp/crossplane.ts` (130 lines, 8%)
- `lib/unified/card/UnifiedCardAdapter.tsx` (36 lines, 5%)
- `lib/llmd/mockData.ts` (12 lines, 0%)
- `lib/dashboards/DashboardComponents.tsx` (18 lines, 5%)

Those combined hold ~340 more uncovered lines.

## Test plan

- [x] `npx vitest run src/hooks/__tests__/useDrasiResources.test.tsx` — 15/15
- [x] `npx vitest run src/hooks/__tests__/useCachedACMMScan.test.tsx` — 9/9
- [x] `npx vitest run src/lib/acmm/sources/__tests__/` — 32/32
- [ ] Coverage Suite workflow reports > 89.03%

🤖 Generated with [Claude Code](https://claude.com/claude-code)