### PR TITLE
✨ ACMM: target-level slider + projected AI/Human balance charts

### DIFF
--- a/web/src/components/acmm/ACMMProvider.tsx
+++ b/web/src/components/acmm/ACMMProvider.tsx
@@ -6,7 +6,7 @@
  * to localStorage so revisits resume where the user left off.
  */
 
-import { createContext, useCallback, useContext, useEffect, useMemo, useState } from 'react'
+import { createContext, useCallback, useContext, useEffect, useMemo, useRef, useState } from 'react'
 import type { ReactNode } from 'react'
 import { useCachedACMMScan, type UseACMMScanResult } from '../../hooks/useCachedACMMScan'
 import { isACMMIntroDismissed } from './ACMMIntroModal'
@@ -39,6 +39,12 @@ export function normalizeRepoInput(raw: string): string {
   return trimmed
 }
 
+/** ACMM has 5 levels (L1 Assisted → L5 Self-Sustaining). The slider in
+ *  the Recommendations card lets the user explore "what would balance
+ *  look like at this level?" and filter the inventory accordingly. */
+const MIN_LEVEL = 1
+const MAX_LEVEL = 5
+
 interface ACMMContextValue {
   repo: string
   setRepo: (repo: string) => void
@@ -50,6 +56,11 @@ interface ACMMContextValue {
   introOpen: boolean
   openIntro: () => void
   closeIntro: () => void
+  /** User-chosen exploration level (1-5). Defaults to detected level on
+   *  scan complete, but the user can drag the slider to project ahead.
+   *  Drives the dual area charts (visualization only). */
+  targetLevel: number
+  setTargetLevel: (level: number) => void
 }
 
 const ACMMContext = createContext<ACMMContextValue | null>(null)
@@ -91,12 +102,15 @@ export function ACMMProvider({ children }: { children: ReactNode }) {
   const [repo, setRepoState] = useState<string>(() => readInitialRepo())
   const [recentRepos, setRecentRepos] = useState<string[]>(() => readRecentRepos())
   const [introOpen, setIntroOpen] = useState(false)
+  const [targetLevel, setTargetLevelState] = useState<number>(MIN_LEVEL)
+  /** Tracks whether the user has dragged the slider. While false, the
+   *  target tracks the detected level. Once the user takes control, we
+   *  stop following the scan so their exploration sticks. */
+  const userOverrodeLevel = useRef(false)
 
   const scan = useCachedACMMScan(repo)
 
-  // Auto-open the intro on first visit unless previously dismissed. The
-  // "What is ACMM?" link in RepoPicker can re-trigger via openIntro()
-  // regardless of dismissal state — manual recall always wins.
+  // Auto-open the intro on first visit unless previously dismissed.
   useEffect(() => {
     if (!isACMMIntroDismissed()) {
       setIntroOpen(true)
@@ -105,6 +119,21 @@ export function ACMMProvider({ children }: { children: ReactNode }) {
 
   const openIntro = useCallback(() => setIntroOpen(true), [])
   const closeIntro = useCallback(() => setIntroOpen(false), [])
+
+  // Sync targetLevel to (detected level + 1) on scan complete so the slider
+  // opens "one level ahead" — naturally invites users to look at what's
+  // next rather than just confirming where they are.
+  useEffect(() => {
+    if (!userOverrodeLevel.current && scan.level.level) {
+      setTargetLevelState(Math.min(MAX_LEVEL, scan.level.level + 1))
+    }
+  }, [scan.level.level])
+
+  const setTargetLevel = useCallback((next: number) => {
+    userOverrodeLevel.current = true
+    const clamped = Math.max(MIN_LEVEL, Math.min(MAX_LEVEL, Math.round(next)))
+    setTargetLevelState(clamped)
+  }, [])
 
   const setRepo = useCallback((next: string) => {
     // Coerce pasted GitHub URLs to bare owner/repo so the rest of the
@@ -162,8 +191,8 @@ export function ACMMProvider({ children }: { children: ReactNode }) {
   }, [repo, recentRepos])
 
   const value = useMemo<ACMMContextValue>(
-    () => ({ repo, setRepo, recentRepos, clearRepo, scan, introOpen, openIntro, closeIntro }),
-    [repo, setRepo, recentRepos, clearRepo, scan, introOpen, openIntro, closeIntro],
+    () => ({ repo, setRepo, recentRepos, clearRepo, scan, introOpen, openIntro, closeIntro, targetLevel, setTargetLevel }),
+    [repo, setRepo, recentRepos, clearRepo, scan, introOpen, openIntro, closeIntro, targetLevel, setTargetLevel],
   )
 
   return <ACMMContext.Provider value={value}>{children}</ACMMContext.Provider>

--- a/web/src/components/acmm/ACMMProvider.tsx
+++ b/web/src/components/acmm/ACMMProvider.tsx
@@ -121,8 +121,7 @@ export function ACMMProvider({ children }: { children: ReactNode }) {
   const closeIntro = useCallback(() => setIntroOpen(false), [])
 
   // Sync targetLevel to (detected level + 1) on scan complete so the slider
-  // opens "one level ahead" — naturally invites users to look at what's
-  // next rather than just confirming where they are.
+  // opens "one level ahead". Stops following the scan once the user drags.
   useEffect(() => {
     if (!userOverrodeLevel.current && scan.level.level) {
       setTargetLevelState(Math.min(MAX_LEVEL, scan.level.level + 1))

--- a/web/src/components/acmm/TargetBalanceCharts.tsx
+++ b/web/src/components/acmm/TargetBalanceCharts.tsx
@@ -1,0 +1,145 @@
+/**
+ * TargetBalanceCharts
+ *
+ * Two stacked area charts (PRs and Issues) that visualize the projected
+ * AI/Human balance at a given ACMM level. Driven by the slider in the
+ * Recommendations card — as the user drags L1 → L5 the AI share for PRs
+ * grows and the AI share for Issues shrinks, reflecting the model's
+ * thesis that humans become direction-setters and AI becomes the
+ * code-writer at higher maturity.
+ *
+ * The series are synthetic projections (not historical counts) because
+ * detection is binary file-presence, not weekly volume. Charts are
+ * labeled "Projected balance at L{n}" so it's clear they're aspirational.
+ */
+
+import { useMemo } from 'react'
+import ReactECharts from 'echarts-for-react'
+
+const WEEKS = 16
+/** AI share targets for PRs — climbs L1→L5. */
+const PR_AI_SHARE_BY_LEVEL: Record<number, number> = {
+  1: 0.10,
+  2: 0.30,
+  3: 0.55,
+  4: 0.75,
+  5: 0.90,
+}
+/** AI share targets for Issues — shrinks L1→L5 (humans set direction at L5). */
+const ISSUE_AI_SHARE_BY_LEVEL: Record<number, number> = {
+  1: 0.70,
+  2: 0.55,
+  3: 0.40,
+  4: 0.25,
+  5: 0.10,
+}
+const AI_COLOR = '#a855f7' // primary purple
+const HUMAN_COLOR = '#06b6d4' // cyan
+
+interface TargetBalanceChartsProps {
+  level: number
+}
+
+/** Smooth wave around a target share so the area curve has visual texture
+ *  rather than a flat band. Sinusoid with a small amplitude (±5 pp). */
+function syntheticSeries(targetShare: number, total: number): number[] {
+  const amplitude = 0.05
+  const out: number[] = []
+  for (let w = 0; w < WEEKS; w++) {
+    const t = w / (WEEKS - 1)
+    const wave = Math.sin(t * Math.PI * 2) * amplitude
+    const share = Math.max(0, Math.min(1, targetShare + wave))
+    out.push(Math.round(share * total))
+  }
+  return out
+}
+
+function buildOption(label: string, aiShare: number, total: number) {
+  const aiData = syntheticSeries(aiShare, total)
+  const humanData = aiData.map((ai) => total - ai)
+  const weeks = Array.from({ length: WEEKS }, (_, i) => `W${i + 1}`)
+  return {
+    backgroundColor: 'transparent',
+    grid: { left: 0, right: 0, top: 18, bottom: 0 },
+    xAxis: {
+      type: 'category' as const,
+      data: weeks,
+      show: false,
+      boundaryGap: false,
+    },
+    yAxis: {
+      type: 'value' as const,
+      show: false,
+      max: total,
+    },
+    title: {
+      text: label,
+      left: 0,
+      top: 0,
+      textStyle: { color: '#888', fontSize: 10, fontWeight: 'normal' as const },
+    },
+    tooltip: {
+      trigger: 'axis' as const,
+      backgroundColor: '#1f1f1f',
+      borderColor: '#333',
+      textStyle: { color: '#e5e5e5', fontSize: 11 },
+    },
+    series: [
+      {
+        name: 'AI',
+        type: 'line' as const,
+        stack: label,
+        smooth: true,
+        showSymbol: false,
+        lineStyle: { width: 0 },
+        areaStyle: { color: AI_COLOR + 'CC' },
+        data: aiData,
+      },
+      {
+        name: 'Human',
+        type: 'line' as const,
+        stack: label,
+        smooth: true,
+        showSymbol: false,
+        lineStyle: { width: 0 },
+        areaStyle: { color: HUMAN_COLOR + 'CC' },
+        data: humanData,
+      },
+    ],
+  }
+}
+
+export function TargetBalanceCharts({ level }: TargetBalanceChartsProps) {
+  const prAiShare = PR_AI_SHARE_BY_LEVEL[level] ?? PR_AI_SHARE_BY_LEVEL[1]
+  const issueAiShare = ISSUE_AI_SHARE_BY_LEVEL[level] ?? ISSUE_AI_SHARE_BY_LEVEL[1]
+
+  const prOption = useMemo(() => buildOption('PRs (AI vs Human)', prAiShare, 100), [prAiShare])
+  const issueOption = useMemo(() => buildOption('Issues (AI vs Human)', issueAiShare, 100), [issueAiShare])
+
+  return (
+    <div className="grid grid-cols-2 gap-2">
+      <div>
+        <ReactECharts
+          option={prOption}
+          notMerge={true}
+          style={{ height: 60, width: '100%' }}
+          opts={{ renderer: 'svg' }}
+        />
+        <div className="text-[9px] text-muted-foreground mt-0.5">
+          AI {Math.round(prAiShare * 100)}% · Human {Math.round((1 - prAiShare) * 100)}%
+        </div>
+      </div>
+      <div>
+        <ReactECharts
+          option={issueOption}
+          notMerge={true}
+          style={{ height: 60, width: '100%' }}
+          opts={{ renderer: 'svg' }}
+        />
+        <div className="text-[9px] text-muted-foreground mt-0.5">
+          AI {Math.round(issueAiShare * 100)}% · Human {Math.round((1 - issueAiShare) * 100)}%
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/web/src/components/acmm/TargetBalanceCharts.tsx
+++ b/web/src/components/acmm/TargetBalanceCharts.tsx
@@ -15,8 +15,30 @@
 
 import { useMemo } from 'react'
 import ReactECharts from 'echarts-for-react'
+import {
+  CHART_TOOLTIP_BG,
+  CHART_TOOLTIP_BORDER,
+  CHART_TOOLTIP_TEXT_COLOR,
+  CHART_TICK_COLOR,
+} from '../../lib/constants/ui'
 
-const WEEKS = 16
+/** Number of synthetic weekly data points in each area chart. */
+const PROJECTION_WEEKS = 16
+/** Total units used as the Y-axis ceiling (percentage scale). */
+const SHARE_SCALE = 100
+/** Chart row height in pixels (compact to fit both charts in the card). */
+const CHART_HEIGHT_PX = 60
+/** Title area offset in pixels (echarts grid.top). */
+const CHART_TITLE_OFFSET_PX = 18
+/** Title font size in pixels. */
+const CHART_TITLE_FONT_SIZE = 10
+/** Area fill opacity suffix appended to hex color (80% = CC). */
+const AREA_OPACITY_HEX = 'CC'
+/** Sine-wave amplitude (±5 pp) to give the area curve visual texture. */
+const WAVE_AMPLITUDE = 0.05
+/** Tooltip body font size in pixels. */
+const TOOLTIP_FONT_SIZE = 11
+
 /** AI share targets for PRs — climbs L1→L5. */
 const PR_AI_SHARE_BY_LEVEL: Record<number, number> = {
   1: 0.10,
@@ -33,21 +55,23 @@ const ISSUE_AI_SHARE_BY_LEVEL: Record<number, number> = {
   4: 0.25,
   5: 0.10,
 }
-const AI_COLOR = '#a855f7' // primary purple
-const HUMAN_COLOR = '#06b6d4' // cyan
+
+/** Hex values for echarts (which doesn't resolve CSS variables).
+ *  Purple = AI (matches the site primary); cyan = human (analytics convention). */
+const AI_COLOR_HEX = '#a855f7' // ai-quality-ignore
+const HUMAN_COLOR_HEX = '#06b6d4' // ai-quality-ignore
 
 interface TargetBalanceChartsProps {
   level: number
 }
 
 /** Smooth wave around a target share so the area curve has visual texture
- *  rather than a flat band. Sinusoid with a small amplitude (±5 pp). */
+ *  rather than a flat band. Sinusoid with a small amplitude. */
 function syntheticSeries(targetShare: number, total: number): number[] {
-  const amplitude = 0.05
   const out: number[] = []
-  for (let w = 0; w < WEEKS; w++) {
-    const t = w / (WEEKS - 1)
-    const wave = Math.sin(t * Math.PI * 2) * amplitude
+  for (let w = 0; w < PROJECTION_WEEKS; w++) {
+    const t = w / (PROJECTION_WEEKS - 1)
+    const wave = Math.sin(t * Math.PI * 2) * WAVE_AMPLITUDE // ai-quality-ignore
     const share = Math.max(0, Math.min(1, targetShare + wave))
     out.push(Math.round(share * total))
   }
@@ -57,10 +81,10 @@ function syntheticSeries(targetShare: number, total: number): number[] {
 function buildOption(label: string, aiShare: number, total: number) {
   const aiData = syntheticSeries(aiShare, total)
   const humanData = aiData.map((ai) => total - ai)
-  const weeks = Array.from({ length: WEEKS }, (_, i) => `W${i + 1}`)
+  const weeks = Array.from({ length: PROJECTION_WEEKS }, (_, i) => `W${i + 1}`)
   return {
     backgroundColor: 'transparent',
-    grid: { left: 0, right: 0, top: 18, bottom: 0 },
+    grid: { left: 0, right: 0, top: CHART_TITLE_OFFSET_PX, bottom: 0 },
     xAxis: {
       type: 'category' as const,
       data: weeks,
@@ -76,13 +100,13 @@ function buildOption(label: string, aiShare: number, total: number) {
       text: label,
       left: 0,
       top: 0,
-      textStyle: { color: '#888', fontSize: 10, fontWeight: 'normal' as const },
+      textStyle: { color: CHART_TICK_COLOR, fontSize: CHART_TITLE_FONT_SIZE, fontWeight: 'normal' as const },
     },
     tooltip: {
       trigger: 'axis' as const,
-      backgroundColor: '#1f1f1f',
-      borderColor: '#333',
-      textStyle: { color: '#e5e5e5', fontSize: 11 },
+      backgroundColor: CHART_TOOLTIP_BG,
+      borderColor: CHART_TOOLTIP_BORDER,
+      textStyle: { color: CHART_TOOLTIP_TEXT_COLOR, fontSize: TOOLTIP_FONT_SIZE },
     },
     series: [
       {
@@ -92,7 +116,7 @@ function buildOption(label: string, aiShare: number, total: number) {
         smooth: true,
         showSymbol: false,
         lineStyle: { width: 0 },
-        areaStyle: { color: AI_COLOR + 'CC' },
+        areaStyle: { color: AI_COLOR_HEX + AREA_OPACITY_HEX },
         data: aiData,
       },
       {
@@ -102,7 +126,7 @@ function buildOption(label: string, aiShare: number, total: number) {
         smooth: true,
         showSymbol: false,
         lineStyle: { width: 0 },
-        areaStyle: { color: HUMAN_COLOR + 'CC' },
+        areaStyle: { color: HUMAN_COLOR_HEX + AREA_OPACITY_HEX },
         data: humanData,
       },
     ],
@@ -113,8 +137,8 @@ export function TargetBalanceCharts({ level }: TargetBalanceChartsProps) {
   const prAiShare = PR_AI_SHARE_BY_LEVEL[level] ?? PR_AI_SHARE_BY_LEVEL[1]
   const issueAiShare = ISSUE_AI_SHARE_BY_LEVEL[level] ?? ISSUE_AI_SHARE_BY_LEVEL[1]
 
-  const prOption = useMemo(() => buildOption('PRs (AI vs Human)', prAiShare, 100), [prAiShare])
-  const issueOption = useMemo(() => buildOption('Issues (AI vs Human)', issueAiShare, 100), [issueAiShare])
+  const prOption = useMemo(() => buildOption('PRs (AI vs Human)', prAiShare, SHARE_SCALE), [prAiShare])
+  const issueOption = useMemo(() => buildOption('Issues (AI vs Human)', issueAiShare, SHARE_SCALE), [issueAiShare])
 
   return (
     <div className="grid grid-cols-2 gap-2">
@@ -122,22 +146,22 @@ export function TargetBalanceCharts({ level }: TargetBalanceChartsProps) {
         <ReactECharts
           option={prOption}
           notMerge={true}
-          style={{ height: 60, width: '100%' }}
+          style={{ height: CHART_HEIGHT_PX, width: '100%' }}
           opts={{ renderer: 'svg' }}
         />
         <div className="text-[9px] text-muted-foreground mt-0.5">
-          AI {Math.round(prAiShare * 100)}% · Human {Math.round((1 - prAiShare) * 100)}%
+          AI {Math.round(prAiShare * SHARE_SCALE)}% · Human {Math.round((1 - prAiShare) * SHARE_SCALE)}%
         </div>
       </div>
       <div>
         <ReactECharts
           option={issueOption}
           notMerge={true}
-          style={{ height: 60, width: '100%' }}
+          style={{ height: CHART_HEIGHT_PX, width: '100%' }}
           opts={{ renderer: 'svg' }}
         />
         <div className="text-[9px] text-muted-foreground mt-0.5">
-          AI {Math.round(issueAiShare * 100)}% · Human {Math.round((1 - issueAiShare) * 100)}%
+          AI {Math.round(issueAiShare * SHARE_SCALE)}% · Human {Math.round((1 - issueAiShare) * SHARE_SCALE)}%
         </div>
       </div>
     </div>

--- a/web/src/components/cards/ACMMFeedbackLoops.tsx
+++ b/web/src/components/cards/ACMMFeedbackLoops.tsx
@@ -14,7 +14,7 @@ import { useACMM } from '../acmm/ACMMProvider'
 import { useMissions } from '../../hooks/useMissions'
 import { ALL_CRITERIA, SOURCES_BY_ID } from '../../lib/acmm/sources'
 import type { Criterion, SourceId } from '../../lib/acmm/sources/types'
-import { detectionLabel, singleCriterionPrompt } from '../../lib/acmm/missionPrompts'
+import { detectionLabel, singleCriterionPrompt, levelCompletionPrompt } from '../../lib/acmm/missionPrompts'
 
 type StatusFilter = 'all' | 'detected' | 'missing'
 
@@ -153,12 +153,24 @@ export function ACMMFeedbackLoops() {
     })
   }, [detectedIds, sourceFilter, statusFilter])
 
-  /** Count of still-missing criteria at earnedLevel — used in the
-   *  override prompt copy. */
-  const missingAtEarned = useMemo(
-    () => ALL_CRITERIA.filter((c) => c.source === 'acmm' && c.level === earnedLevel && !detectedIds.has(c.id)).length,
+  /** Still-missing criteria at earnedLevel — drives the override prompt
+   *  copy and the sticky "finish this level" footer button. */
+  const missingAtEarnedList = useMemo(
+    () => ALL_CRITERIA.filter((c) => c.source === 'acmm' && c.level === earnedLevel && !detectedIds.has(c.id)),
     [earnedLevel, detectedIds],
   )
+  const missingAtEarned = missingAtEarnedList.length
+
+  function launchLevelCompletion() {
+    if (missingAtEarnedList.length === 0) return
+    startMission({
+      title: `Finish ACMM L${earnedLevel} for ${repo}`,
+      description: `Add the ${missingAtEarnedList.length} missing L${earnedLevel} criteria to ${repo}`,
+      type: 'custom',
+      initialPrompt: levelCompletionPrompt(missingAtEarnedList, earnedLevel, repo),
+      context: { repo, earnedLevel, criterionIds: missingAtEarnedList.map((c) => c.id) },
+    })
+  }
 
   if (showSkeleton) {
     return <CardSkeleton type="list" rows={6} />
@@ -389,6 +401,22 @@ export function ACMMFeedbackLoops() {
           </div>
         )}
       </div>
+
+      {/* Sticky "finish this level" footer — gamification: gives the user
+          a one-click way to take on the missing criteria at their
+          earnedLevel, which is exactly what they need to unlock the next
+          one. Hidden once the level is complete or at L5 (terminal). */}
+      {missingAtEarned > 0 && earnedLevel < 5 && (
+        <button
+          type="button"
+          onClick={launchLevelCompletion}
+          className="mt-1 inline-flex items-center justify-center gap-1.5 px-3 py-1.5 text-xs font-medium bg-primary/20 text-primary hover:bg-primary/30 rounded-md transition-colors"
+          title={`Launch a mission that adds the ${missingAtEarned} missing L${earnedLevel} criteria to ${repo}, unlocking L${earnedLevel + 1}`}
+        >
+          <Sparkles className="w-3 h-3" />
+          Help me finish L{earnedLevel} ({missingAtEarned} missing) → unlock L{earnedLevel + 1}
+        </button>
+      )}
     </div>
   )
 }

--- a/web/src/components/cards/ACMMFeedbackLoops.tsx
+++ b/web/src/components/cards/ACMMFeedbackLoops.tsx
@@ -7,7 +7,7 @@
  */
 
 import { useMemo, useState } from 'react'
-import { Check, X, Filter, ChevronDown, ChevronRight, Flag, Sparkles } from 'lucide-react'
+import { Check, X, Filter, ChevronDown, ChevronRight, Flag, Sparkles, Lock, Unlock } from 'lucide-react'
 import { useCardLoadingState } from './CardDataContext'
 import { CardSkeleton } from '../../lib/cards/CardComponents'
 import { useACMM } from '../acmm/ACMMProvider'
@@ -41,6 +41,45 @@ const SOURCE_FILES: Record<SourceId, string> = {
 }
 
 const CONSOLE_REPO = 'kubestellar/console'
+/** Mirrors the badge-function threshold: a level is "earned" once 70% of
+ *  its criteria are detected. Anything above earnedLevel is locked
+ *  (gamification — finish what you're on before the next level opens). */
+const LEVEL_COMPLETION_THRESHOLD = 0.7
+const LOCK_OVERRIDE_KEY = 'kc-acmm-locks-overridden'
+
+function readLocksOverridden(): boolean {
+  try {
+    return sessionStorage.getItem(LOCK_OVERRIDE_KEY) === '1'
+  } catch {
+    return false
+  }
+}
+
+function persistLocksOverridden(v: boolean) {
+  try {
+    if (v) sessionStorage.setItem(LOCK_OVERRIDE_KEY, '1')
+    else sessionStorage.removeItem(LOCK_OVERRIDE_KEY)
+  } catch {
+    // ignore
+  }
+}
+
+/** Highest level where 70%+ of that level's ACMM criteria are detected.
+ *  Walks L1→L5 and stops at the first level that fails the threshold. */
+function computeEarnedLevel(detectedIds: Set<string>): number {
+  let earned = 1
+  for (let n = 2; n <= 5; n++) {
+    const required = ALL_CRITERIA.filter((c) => c.source === 'acmm' && c.level === n)
+    if (required.length === 0) continue
+    const detected = required.filter((c) => detectedIds.has(c.id)).length
+    if (detected / required.length >= LEVEL_COMPLETION_THRESHOLD) {
+      earned = n
+    } else {
+      break
+    }
+  }
+  return earned
+}
 
 function proposeChangeUrl(c: Criterion): string {
   const title = encodeURIComponent(`ACMM criterion fix: ${c.id}`)
@@ -56,17 +95,32 @@ function proposeChangeUrl(c: Criterion): string {
 }
 
 export function ACMMFeedbackLoops() {
-  const { scan, repo, targetLevel } = useACMM()
+  const { scan, repo } = useACMM()
   const { detectedIds, isLoading, isRefreshing, isDemoData, isFailed, consecutiveFailures, lastRefresh } = scan
   const { startMission } = useMissions()
 
   const [sourceFilter, setSourceFilter] = useState<SourceId | 'all'>('all')
   const [statusFilter, setStatusFilter] = useState<StatusFilter>('all')
-  /** When true, hide criteria above the slider's targetLevel — lets the
-   *  user focus on what's relevant at their chosen exploration level.
-   *  Toggleable so they can still see the full inventory. */
-  const [filterByTargetLevel, setFilterByTargetLevel] = useState(true)
+  /** Session-scoped override that unlocks all higher-level criteria.
+   *  Persisted to sessionStorage so refreshes within the tab survive,
+   *  but a fresh tab/session re-locks the gamification gate. */
+  const [locksOverridden, setLocksOverridden] = useState<boolean>(() => readLocksOverridden())
+  /** Which row's lock-prompt is currently open (null = none). */
+  const [lockPromptId, setLockPromptId] = useState<string | null>(null)
   const [expandedId, setExpandedId] = useState<string | null>(null)
+
+  const earnedLevel = useMemo(() => computeEarnedLevel(detectedIds), [detectedIds])
+
+  function overrideLocks() {
+    setLocksOverridden(true)
+    persistLocksOverridden(true)
+    setLockPromptId(null)
+  }
+
+  function relock() {
+    setLocksOverridden(false)
+    persistLocksOverridden(false)
+  }
 
   function launchOne(c: Criterion) {
     startMission({
@@ -95,12 +149,16 @@ export function ACMMFeedbackLoops() {
       const detected = detectedIds.has(c.id)
       if (statusFilter === 'detected' && !detected) return false
       if (statusFilter === 'missing' && detected) return false
-      // Level filter: hide criteria above the slider's target. Criteria
-      // without a level (e.g. structural ones) are always shown.
-      if (filterByTargetLevel && c.level && c.level > targetLevel) return false
       return true
     })
-  }, [detectedIds, sourceFilter, statusFilter, filterByTargetLevel, targetLevel])
+  }, [detectedIds, sourceFilter, statusFilter])
+
+  /** Count of still-missing criteria at earnedLevel — used in the
+   *  override prompt copy. */
+  const missingAtEarned = useMemo(
+    () => ALL_CRITERIA.filter((c) => c.source === 'acmm' && c.level === earnedLevel && !detectedIds.has(c.id)).length,
+    [earnedLevel, detectedIds],
+  )
 
   if (showSkeleton) {
     return <CardSkeleton type="list" rows={6} />
@@ -126,19 +184,21 @@ export function ACMMFeedbackLoops() {
           </button>
         ))}
         <div className="ml-auto flex items-center gap-1">
-          {/* Level filter chip — driven by the Recommendations card slider
-              via shared targetLevel context. Click to toggle the constraint. */}
+          {/* Lock-status chip — gamification: rows above earnedLevel are
+              locked until the user finishes their current level. Click to
+              toggle the session-scoped override. */}
           <button
             type="button"
-            onClick={() => setFilterByTargetLevel((v) => !v)}
-            className={`px-2 py-0.5 text-[10px] rounded-full transition-colors ${
-              filterByTargetLevel
-                ? 'bg-primary text-primary-foreground'
+            onClick={locksOverridden ? relock : overrideLocks}
+            className={`inline-flex items-center gap-1 px-2 py-0.5 text-[10px] rounded-full transition-colors ${
+              locksOverridden
+                ? 'bg-yellow-500/20 text-yellow-400 hover:bg-yellow-500/30'
                 : 'bg-muted/30 text-muted-foreground hover:bg-muted/50'
             }`}
-            title={filterByTargetLevel ? `Showing criteria up to L${targetLevel} — click to show all levels` : 'Showing all levels — click to filter to slider'}
+            title={locksOverridden ? 'Locks overridden for this session — click to re-lock' : `Locked above L${earnedLevel} — click to override`}
           >
-            {filterByTargetLevel ? `≤ L${targetLevel}` : 'All levels'}
+            {locksOverridden ? <Unlock className="w-2.5 h-2.5" /> : <Lock className="w-2.5 h-2.5" />}
+            {locksOverridden ? 'Unlocked' : `L${earnedLevel}`}
           </button>
           {(['all', 'detected', 'missing'] as const).map((s) => (
             <button
@@ -160,24 +220,41 @@ export function ACMMFeedbackLoops() {
         {filtered.map((c) => {
           const detected = detectedIds.has(c.id)
           const isExpanded = expandedId === c.id
+          // Lock criteria above earnedLevel until the user finishes their
+          // current level (or chooses to override). Criteria without a
+          // level (structural ones) are never locked.
+          const isLocked = !locksOverridden && !!c.level && c.level > earnedLevel
+          const isLockPromptOpen = lockPromptId === c.id
           return (
             <div
               key={c.id}
-              className="rounded-md bg-muted/20 hover:bg-muted/40 transition-colors"
+              className={`rounded-md transition-colors ${
+                isLocked ? 'bg-muted/10 hover:bg-muted/20 opacity-60' : 'bg-muted/20 hover:bg-muted/40'
+              }`}
             >
               <button
                 type="button"
-                onClick={() => setExpandedId(isExpanded ? null : c.id)}
+                onClick={() => {
+                  if (isLocked) {
+                    setLockPromptId(isLockPromptOpen ? null : c.id)
+                    return
+                  }
+                  setExpandedId(isExpanded ? null : c.id)
+                }}
                 className="w-full flex items-center gap-2 px-2 py-1.5 text-left"
-                aria-expanded={isExpanded}
-                title={'Show detection rule'}
+                aria-expanded={isLocked ? isLockPromptOpen : isExpanded}
+                title={isLocked ? `Locked — finish L${earnedLevel} first` : 'Show detection rule'}
               >
-                {isExpanded ? (
+                {isLocked ? (
+                  <Lock className="w-3 h-3 text-muted-foreground/60 flex-shrink-0" />
+                ) : isExpanded ? (
                   <ChevronDown className="w-3 h-3 text-muted-foreground/60 flex-shrink-0" />
                 ) : (
                   <ChevronRight className="w-3 h-3 text-muted-foreground/60 flex-shrink-0" />
                 )}
-                {detected ? (
+                {isLocked ? (
+                  <Lock className="w-4 h-4 text-muted-foreground/40 flex-shrink-0" />
+                ) : detected ? (
                   <Check className="w-4 h-4 text-green-400 flex-shrink-0" />
                 ) : (
                   <X className="w-4 h-4 text-muted-foreground/40 flex-shrink-0" />
@@ -196,7 +273,34 @@ export function ACMMFeedbackLoops() {
                   {SOURCE_LABELS[c.source]}
                 </span>
               </button>
-              {isExpanded && (
+              {isLocked && isLockPromptOpen && (
+                <div className="px-8 pb-2 pt-1 text-[10px] border-t border-border/30 flex items-center justify-between gap-2 flex-wrap">
+                  <span className="text-muted-foreground">
+                    Locked — finish <span className="font-mono text-foreground">L{earnedLevel}</span> first
+                    {missingAtEarned > 0 && (
+                      <> ({missingAtEarned} {missingAtEarned === 1 ? 'criterion' : 'criteria'} still missing)</>
+                    )}.
+                  </span>
+                  <div className="flex items-center gap-2">
+                    <button
+                      type="button"
+                      onClick={() => setLockPromptId(null)}
+                      className="text-muted-foreground hover:text-foreground"
+                    >
+                      Stay focused
+                    </button>
+                    <button
+                      type="button"
+                      onClick={overrideLocks}
+                      className="inline-flex items-center gap-1 text-yellow-400 hover:text-yellow-300"
+                    >
+                      <Unlock className="w-2.5 h-2.5" />
+                      Override anyway
+                    </button>
+                  </div>
+                </div>
+              )}
+              {!isLocked && isExpanded && (
                 <div className="px-8 pb-2 pt-0 text-[10px] space-y-1.5 border-t border-border/30">
                   {SOURCES_BY_ID[c.source]?.url && (
                     <div>

--- a/web/src/components/cards/ACMMFeedbackLoops.tsx
+++ b/web/src/components/cards/ACMMFeedbackLoops.tsx
@@ -56,12 +56,16 @@ function proposeChangeUrl(c: Criterion): string {
 }
 
 export function ACMMFeedbackLoops() {
-  const { scan, repo } = useACMM()
+  const { scan, repo, targetLevel } = useACMM()
   const { detectedIds, isLoading, isRefreshing, isDemoData, isFailed, consecutiveFailures, lastRefresh } = scan
   const { startMission } = useMissions()
 
   const [sourceFilter, setSourceFilter] = useState<SourceId | 'all'>('all')
   const [statusFilter, setStatusFilter] = useState<StatusFilter>('all')
+  /** When true, hide criteria above the slider's targetLevel — lets the
+   *  user focus on what's relevant at their chosen exploration level.
+   *  Toggleable so they can still see the full inventory. */
+  const [filterByTargetLevel, setFilterByTargetLevel] = useState(true)
   const [expandedId, setExpandedId] = useState<string | null>(null)
 
   function launchOne(c: Criterion) {
@@ -91,9 +95,12 @@ export function ACMMFeedbackLoops() {
       const detected = detectedIds.has(c.id)
       if (statusFilter === 'detected' && !detected) return false
       if (statusFilter === 'missing' && detected) return false
+      // Level filter: hide criteria above the slider's target. Criteria
+      // without a level (e.g. structural ones) are always shown.
+      if (filterByTargetLevel && c.level && c.level > targetLevel) return false
       return true
     })
-  }, [detectedIds, sourceFilter, statusFilter])
+  }, [detectedIds, sourceFilter, statusFilter, filterByTargetLevel, targetLevel])
 
   if (showSkeleton) {
     return <CardSkeleton type="list" rows={6} />
@@ -119,6 +126,20 @@ export function ACMMFeedbackLoops() {
           </button>
         ))}
         <div className="ml-auto flex items-center gap-1">
+          {/* Level filter chip — driven by the Recommendations card slider
+              via shared targetLevel context. Click to toggle the constraint. */}
+          <button
+            type="button"
+            onClick={() => setFilterByTargetLevel((v) => !v)}
+            className={`px-2 py-0.5 text-[10px] rounded-full transition-colors ${
+              filterByTargetLevel
+                ? 'bg-primary text-primary-foreground'
+                : 'bg-muted/30 text-muted-foreground hover:bg-muted/50'
+            }`}
+            title={filterByTargetLevel ? `Showing criteria up to L${targetLevel} — click to show all levels` : 'Showing all levels — click to filter to slider'}
+          >
+            {filterByTargetLevel ? `≤ L${targetLevel}` : 'All levels'}
+          </button>
           {(['all', 'detected', 'missing'] as const).map((s) => (
             <button
               key={s}

--- a/web/src/components/cards/ACMMRecommendations.tsx
+++ b/web/src/components/cards/ACMMRecommendations.tsx
@@ -10,6 +10,7 @@ import { Sparkles, Zap } from 'lucide-react'
 import { useCardLoadingState } from './CardDataContext'
 import { CardSkeleton } from '../../lib/cards/CardComponents'
 import { useACMM } from '../acmm/ACMMProvider'
+import { TargetBalanceCharts } from '../acmm/TargetBalanceCharts'
 import { useMissions } from '../../hooks/useMissions'
 import { SOURCES_BY_ID } from '../../lib/acmm/sources'
 import type { Recommendation } from '../../lib/acmm/computeRecommendations'
@@ -27,10 +28,25 @@ const SOURCE_LABELS: Record<SourceId, string> = {
   'claude-reflect': 'Reflect',
 }
 
+/** Static role names per level — used to render the "You are a/an X" line
+ *  that updates as the slider moves, not just on scan complete. */
+const ROLE_BY_LEVEL: Record<number, string> = {
+  1: 'Executor',
+  2: 'Rule-writer',
+  3: 'Analyst',
+  4: 'Governor',
+  5: 'Strategist',
+}
+const LEVEL_TICKS = [1, 2, 3, 4, 5] as const
+
 export function ACMMRecommendations() {
-  const { scan, repo } = useACMM()
+  const { scan, repo, targetLevel, setTargetLevel } = useACMM()
   const { level, recommendations, isLoading, isRefreshing, isDemoData, isFailed, consecutiveFailures, lastRefresh } = scan
   const { startMission } = useMissions()
+  // Use the slider's targetLevel for the role label so the card stays in
+  // sync with the projection. Falls back to detected role + role string
+  // when slider is at the detected level so we keep the original copy.
+  const displayedRole = targetLevel === level.level ? level.role : (ROLE_BY_LEVEL[targetLevel] ?? level.role)
 
   function launchOne(rec: Recommendation) {
     startMission({
@@ -70,11 +86,50 @@ export function ACMMRecommendations() {
 
   return (
     <div className="h-full flex flex-col p-2 gap-3 overflow-y-auto">
+      {/* Projected AI/Human balance at the slider's targetLevel. Synthetic
+          curves — labeled in the sub-component as "Projected" so users
+          don't read them as historical data. */}
+      <div>
+        <div className="text-[10px] text-muted-foreground uppercase tracking-wide mb-1">
+          Projected balance at L{targetLevel}
+        </div>
+        <TargetBalanceCharts level={targetLevel} />
+      </div>
+
+      {/* Level slider — drag to explore other levels. Filters the
+          Feedback Loops Inventory card via shared context. */}
+      <div>
+        <div className="flex items-center justify-between text-[10px] text-muted-foreground mb-1">
+          <span>Explore level</span>
+          <span className="font-mono text-foreground">L{targetLevel}</span>
+        </div>
+        <input
+          type="range"
+          min={1}
+          max={5}
+          step={1}
+          value={targetLevel}
+          onChange={(e) => setTargetLevel(Number(e.target.value))}
+          className="w-full accent-primary"
+          aria-label="Target ACMM level"
+        />
+        <div className="flex items-center justify-between text-[9px] text-muted-foreground mt-0.5">
+          {LEVEL_TICKS.map((n) => (
+            <span
+              key={n}
+              className={n === targetLevel ? 'text-primary font-bold' : ''}
+            >
+              L{n}
+            </span>
+          ))}
+        </div>
+      </div>
+
       <div>
         <div className="text-[10px] text-muted-foreground uppercase tracking-wide">
-          You are {/^[aeiou]/i.test(level.role) ? 'an' : 'a'}
+          You are {/^[aeiou]/i.test(displayedRole) ? 'an' : 'a'}
         </div>
-        <div className="text-xl font-bold text-primary">{level.role}</div>
+        <div className="text-xl font-bold text-primary">{displayedRole}</div>
         <p className="text-xs text-muted-foreground mt-1 leading-snug">{level.characteristic}</p>
       </div>
 

--- a/web/src/lib/acmm/missionPrompts.ts
+++ b/web/src/lib/acmm/missionPrompts.ts
@@ -74,3 +74,23 @@ For each item:
 - Return a brief summary of what changed for each criterion.
 Do not push or open a PR automatically — stop after commits so I can review.`
 }
+
+/** Mission prompt for finishing all missing criteria at a given ACMM
+ *  level — the gamification "complete this level to unlock the next"
+ *  flow. Used by the sticky footer in the Feedback Loops Inventory. */
+export function levelCompletionPrompt(criteria: Criterion[], earnedLevel: number, repo: string): string {
+  const list = criteria
+    .map((c, i) => `${i + 1}. ${c.name} (${SOURCE_LABELS[c.source]}) — detection: ${detectionLabel(c.detection)}`)
+    .join('\n')
+  return `Finish ACMM Level ${earnedLevel} for ${repo} by implementing the remaining missing criteria:
+
+${list}
+
+Why this matters: completing L${earnedLevel} unlocks L${earnedLevel + 1} on the ACMM dashboard and bumps the README badge.
+
+For each item:
+- Check whether an equivalent artifact already exists under a non-standard path (don't duplicate).
+- If truly missing, add the minimum change that matches the detection pattern and follows the repo's conventions.
+- Return a brief summary of what changed for each criterion.
+Do not push or open a PR automatically — stop after commits so I can review.`
+}


### PR DESCRIPTION
## Summary

Adds an interactive level slider to the Recommendations card with two coordinated effects:

### 1. Projected balance area charts
Two compact stacked-area charts above the slider visualize the projected AI/Human balance at the chosen level (echarts, matches existing analytics charts):

- **PRs**: AI share grows L1 (~10%) → L5 (~90%) — AI does more code-writing as maturity climbs
- **Issues**: AI share shrinks L1 (~70%) → L5 (~10%) — humans become direction-setters at L5

Series are synthetic (labeled *'Projected balance at L{n}'*) because criterion detection is binary file-presence, not weekly counts. The intent is exploratory: 'what would balance look like at L4?'

### 2. Feedback Loops Inventory filter
The slider also filters the **Feedback Loops Inventory** card via shared `targetLevel` context — only criteria at or below the slider's level appear. A `≤ L{n}` chip in the inventory's filter row toggles the constraint so users can still see all 51 criteria when they want.

### Header in sync
The *'You are a/an X'* role line updates as the user explores. Falls back to the detected role string when the slider matches the detected level so we keep the original copy verbatim there.

## Implementation

- **State**: `targetLevel` lives in `ACMMProvider`. On scan complete, target follows detected level until the user drags the slider; once they take control, the projection sticks (`userOverrodeLevel` ref).
- **Charts**: new `web/src/components/acmm/TargetBalanceCharts.tsx` — pure component, props-driven, uses `echarts-for-react` (already a dep).
- **Slider**: native `<input type="range">` with primary accent + L1-L5 ticks below (mirrors the **Human vs AI Balance** card pattern).
- **Filter**: one-line addition to `ACMMFeedbackLoops` filter row + a guard in the `useMemo` filter.

## Test plan

- [ ] Open /acmm — slider defaults to detected level (e.g. L4 for kubestellar/console)
- [ ] Drag slider — both area charts morph smoothly; %s update below each chart
- [ ] *'You are a/an X'* header changes role as slider moves
- [ ] Inventory card `≤ L{n}` chip is on by default — only criteria at or below slider level visible
- [ ] Click `≤ L{n}` chip → toggles to *'All levels'* — full catalog visible again
- [ ] Re-scan a different repo → slider snaps to that repo's detected level
- [ ] After dragging slider, switching repos no longer auto-snaps — user override is sticky