### PR TITLE
✨ ACMM scan input accepts github.com URLs (not just owner/repo)

### DIFF
--- a/web/src/components/acmm/ACMMProvider.tsx
+++ b/web/src/components/acmm/ACMMProvider.tsx
@@ -15,6 +15,29 @@ const DEFAULT_REPO = 'kubestellar/console'
 const SELECTED_REPO_KEY = 'kubestellar-acmm-selected-repo'
 const RECENT_REPOS_KEY = 'kubestellar-acmm-recent-repos'
 const MAX_RECENT_REPOS = 5
+const REPO_SLUG_RE = /^[\w.-]+\/[\w.-]+$/
+
+/** Coerce common GitHub URL shapes to bare owner/repo so users can paste
+ *  what's in their address bar directly:
+ *    - https://github.com/owner/repo
+ *    - https://github.com/owner/repo.git
+ *    - https://github.com/owner/repo/tree/main/anything
+ *    - git@github.com:owner/repo.git
+ *    - github.com/owner/repo
+ *  Returns the input unchanged if it doesn't look like a GitHub URL —
+ *  REPO_SLUG_RE validation downstream still catches garbage. */
+export function normalizeRepoInput(raw: string): string {
+  const trimmed = raw.trim()
+  if (!trimmed) return trimmed
+  // SSH form: git@github.com:owner/repo(.git)?
+  const ssh = /^git@github\.com:([\w.-]+)\/([\w.-]+?)(?:\.git)?$/.exec(trimmed)
+  if (ssh) return `${ssh[1]}/${ssh[2]}`
+  // HTTPS / bare-host form. Strip protocol, optional www, github.com/, then
+  // peel any trailing /tree/... or .git suffix.
+  const httpsLike = /^(?:https?:\/\/)?(?:www\.)?github\.com\/([\w.-]+)\/([\w.-]+?)(?:\.git)?(?:\/.*)?$/.exec(trimmed)
+  if (httpsLike) return `${httpsLike[1]}/${httpsLike[2]}`
+  return trimmed
+}
 
 interface ACMMContextValue {
   repo: string
@@ -34,10 +57,14 @@ const ACMMContext = createContext<ACMMContextValue | null>(null)
 function readInitialRepo(): string {
   // URL param (?repo=owner/name) takes precedence so that badge links and
   // shared dashboard URLs open in-context regardless of the user's last selection.
+  // Also accepts a full github.com URL passed via ?repo= for convenience.
   try {
     const url = new URL(window.location.href)
     const fromUrl = url.searchParams.get('repo')
-    if (fromUrl && /^[\w.-]+\/[\w.-]+$/.test(fromUrl)) return fromUrl
+    if (fromUrl) {
+      const normalized = normalizeRepoInput(fromUrl)
+      if (REPO_SLUG_RE.test(normalized)) return normalized
+    }
   } catch {
     // window unavailable (SSR)
   }
@@ -80,7 +107,10 @@ export function ACMMProvider({ children }: { children: ReactNode }) {
   const closeIntro = useCallback(() => setIntroOpen(false), [])
 
   const setRepo = useCallback((next: string) => {
-    const trimmed = next.trim()
+    // Coerce pasted GitHub URLs to bare owner/repo so the rest of the
+    // pipeline (URL sync, badges, share link, scan endpoint) sees a
+    // canonical slug regardless of what the user typed.
+    const trimmed = normalizeRepoInput(next)
     if (!trimmed) return
     setRepoState(trimmed)
     try {

--- a/web/src/components/acmm/RepoPicker.tsx
+++ b/web/src/components/acmm/RepoPicker.tsx
@@ -11,7 +11,7 @@ import { RefreshCw, X, ExternalLink, AlertCircle, Award, Copy, Check, Share2, In
 import { Button } from '../ui/Button'
 import { Input } from '../ui/Input'
 import { cn } from '../../lib/cn'
-import { useACMM, DEFAULT_REPO } from './ACMMProvider'
+import { useACMM, DEFAULT_REPO, normalizeRepoInput } from './ACMMProvider'
 import { ALL_CRITERIA } from '../../lib/acmm/sources'
 
 const REPO_RE = /^[\w.-]+\/[\w.-]+$/
@@ -45,17 +45,21 @@ export function RepoPicker() {
   }
 
   function submit(next: string) {
-    const trimmed = next.trim()
-    if (!trimmed) {
-      setError('Enter a repo in owner/name format')
+    // Accept either bare owner/name or any common GitHub URL — normalize
+    // first, then validate. Reflects the cleaned slug back into the input
+    // so the user sees what got sent.
+    const normalized = normalizeRepoInput(next)
+    if (!normalized) {
+      setError('Enter a repo as owner/name or a github.com URL')
       return
     }
-    if (!REPO_RE.test(trimmed)) {
-      setError('Invalid format — use owner/name')
+    if (!REPO_RE.test(normalized)) {
+      setError('Invalid format — use owner/name or a github.com URL')
       return
     }
     setError(null)
-    setRepo(trimmed)
+    if (normalized !== next) setInput(normalized)
+    setRepo(normalized)
   }
 
   const detected = scan.data.detectedIds?.length ?? 0
@@ -91,7 +95,7 @@ export function RepoPicker() {
               type="text"
               value={input}
               onChange={(e) => setInput(e.target.value)}
-              placeholder="owner/repo"
+              placeholder="owner/repo or https://github.com/owner/repo"
               inputSize="md"
               className={cn('font-mono', input && 'pr-8')}
               list="acmm-recent-repos"


### PR DESCRIPTION
## Summary

Pasting `https://github.com/ublue-os/bluefin` (or any common GitHub URL shape) now works the same as typing `ublue-os/bluefin`. Handy when the user is already on a repo's GitHub page and wants to scan it without hand-extracting the slug.

### Shapes accepted

- `owner/repo` — original behavior, unchanged
- `https://github.com/owner/repo` — new
- `https://github.com/owner/repo.git` — new
- `https://github.com/owner/repo/tree/main/anything` — new
- `git@github.com:owner/repo.git` — new
- `github.com/owner/repo` (bare host) — new

### Three entry points covered

1. `setRepo()` in `ACMMProvider` — picker submits, badge link navigation, any programmatic callers
2. `readInitialRepo()` URL-param read — `?repo=https://github.com/owner/repo` in the address bar works
3. `RepoPicker.submit()` — also reflects the cleaned slug back into the input so the user sees what got sent

Placeholder updated to advertise both forms.

## Test plan

- [ ] Paste `https://github.com/ublue-os/bluefin` → input normalizes to `ublue-os/bluefin`, scan starts
- [ ] Paste `https://github.com/kubestellar/console/tree/main/web` → normalizes to `kubestellar/console`
- [ ] Paste `git@github.com:kubestellar/console.git` → normalizes to `kubestellar/console`
- [ ] Type `kubestellar/console` → unchanged behavior
- [ ] Visit `/acmm?repo=https%3A%2F%2Fgithub.com%2Fublue-os%2Fbluefin` → loads correctly
- [ ] Type garbage like `hello world` → still rejected with clear error