### PR TITLE
🐛 fix: verify /api/me before treating 401 as session expiry (#8372)

### DIFF
--- a/web/src/lib/__tests__/api.test.ts
+++ b/web/src/lib/__tests__/api.test.ts
@@ -356,11 +356,16 @@ describe('api.ts', () => {
       vi.mocked(fetch)
         .mockResolvedValueOnce(makeResponse({ status: 'ok' })) // health
         .mockResolvedValueOnce(makeResponse({}, { status: 401 })) // 401
+        .mockResolvedValueOnce(makeResponse({}, { status: 401 })) // /api/me verify probe (#8372)
 
       const { api, UnauthorizedError } = await importFresh()
       await expect(api.get('/api/data')).rejects.toThrow(UnauthorizedError)
 
-      expect(localStorage.getItem(STORAGE_KEY_TOKEN)).toBeNull()
+      // The 401 handler verifies the session via /api/me before clearing —
+      // wait for that microtask chain to resolve before asserting cleanup.
+      await vi.waitFor(() => {
+        expect(localStorage.getItem(STORAGE_KEY_TOKEN)).toBeNull()
+      })
       expect(localStorage.getItem(STORAGE_KEY_USER_CACHE)).toBeNull()
     })
 
@@ -463,6 +468,7 @@ describe('api.ts', () => {
       vi.mocked(fetch)
         .mockResolvedValueOnce(makeResponse({ status: 'ok' })) // health
         .mockResolvedValueOnce(makeResponse({}, { status: 401 }))
+        .mockResolvedValueOnce(makeResponse({}, { status: 401 })) // /api/me verify probe (#8372)
 
       const { api, UnauthorizedError } = await importFresh()
       await expect(api.post('/api/items', {})).rejects.toThrow(UnauthorizedError)
@@ -508,6 +514,7 @@ describe('api.ts', () => {
       vi.mocked(fetch)
         .mockResolvedValueOnce(makeResponse({ status: 'ok' })) // health
         .mockResolvedValueOnce(makeResponse({}, { status: 401 }))
+        .mockResolvedValueOnce(makeResponse({}, { status: 401 })) // /api/me verify probe (#8372)
 
       const { api, UnauthorizedError } = await importFresh()
       await expect(api.delete('/api/items/1')).rejects.toThrow(UnauthorizedError)
@@ -576,6 +583,7 @@ describe('api.ts', () => {
       vi.mocked(fetch)
         .mockResolvedValueOnce(makeResponse({ status: 'ok' })) // health for req 1
         .mockResolvedValueOnce(makeResponse({}, { status: 401 })) // 401 for req 1
+        .mockResolvedValueOnce(makeResponse({}, { status: 401 })) // /api/me verify probe (#8372)
         .mockResolvedValueOnce(makeResponse({ status: 'ok' })) // health for req 2
         .mockResolvedValueOnce(makeResponse({}, { status: 401 })) // 401 for req 2
 
@@ -584,8 +592,33 @@ describe('api.ts', () => {
       // Both should throw but only one handle401 should fire
       await expect(api.get('/api/a')).rejects.toThrow()
 
-      // Token already cleared by first 401
-      expect(localStorage.getItem(STORAGE_KEY_TOKEN)).toBeNull()
+      // Token clearing is async (waits for /api/me verify probe) — poll.
+      await vi.waitFor(() => {
+        expect(localStorage.getItem(STORAGE_KEY_TOKEN)).toBeNull()
+      })
+    })
+
+    // #8372 — a 401 from one endpoint must NOT nuke the session if /api/me
+    // still returns 200. Otherwise the user gets bounced to /login with a
+    // stale ?reason=session_expired param on refresh, even though their
+    // cookie is still valid.
+    it('does NOT clear auth state when /api/me still returns 200', async () => {
+      localStorage.setItem(STORAGE_KEY_TOKEN, 'still-valid-token')
+      localStorage.setItem(STORAGE_KEY_USER_CACHE, '{"id":1}')
+
+      vi.mocked(fetch)
+        .mockResolvedValueOnce(makeResponse({ status: 'ok' })) // health
+        .mockResolvedValueOnce(makeResponse({}, { status: 401 })) // endpoint 401
+        .mockResolvedValueOnce(makeResponse({ id: 1 }, { status: 200 })) // /api/me OK
+
+      const { api, UnauthorizedError } = await importFresh()
+      await expect(api.get('/api/some-scoped-route')).rejects.toThrow(UnauthorizedError)
+
+      // Drain microtasks so the verify-probe promise chain settles under
+      // fake timers. Token should remain because /api/me returned 200.
+      await vi.advanceTimersByTimeAsync(100)
+      expect(localStorage.getItem(STORAGE_KEY_TOKEN)).toBe('still-valid-token')
+      expect(localStorage.getItem(STORAGE_KEY_USER_CACHE)).toBe('{"id":1}')
     })
   })
 })

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -44,12 +44,26 @@ let handling401 = false
 /** Safety cap: reset the 401 debounce flag after this many ms so future
  *  auth failures aren't permanently silenced if the redirect doesn't fire (#3899). */
 const HANDLING_401_RESET_MS = 10_000
+/** Short timeout on the session-verify probe so a hung backend doesn't block
+ *  the session-expired UI indefinitely (#8372). */
+const SESSION_VERIFY_TIMEOUT_MS = 3_000
+/** Endpoint used to verify the HttpOnly cookie is still valid. A 200 here
+ *  means the cookie still authenticates, so a 401 from another endpoint was
+ *  endpoint-specific (not a session expiry). */
+const AUTH_VERIFY_ENDPOINT = '/api/me'
 
 /**
  * Handle 401 Unauthorized responses by clearing auth state and redirecting to login.
  * This is debounced to avoid multiple simultaneous logouts from parallel API calls.
  * The flag auto-resets after HANDLING_401_RESET_MS so a failed redirect doesn't
  * permanently block all API calls.
+ *
+ * Before nuking the session we re-verify via /api/me. If the cookie-based
+ * session is still valid, the 401 was specific to the originating endpoint
+ * (e.g. a route that requires elevated scope, or a backend race) and we must
+ * NOT show "Session expired" nor redirect — doing so would bounce the user
+ * through /login?reason=session_expired and leave a stale `?reason=…` query
+ * param on the landing page (#8372).
  */
 function handle401(): void {
   if (handling401) return
@@ -61,6 +75,28 @@ function handle401(): void {
     handling401 = false
   }, HANDLING_401_RESET_MS)
 
+  // Verify the cookie-based session before treating this as an expiry. If
+  // /api/me comes back 200, the session is still valid — abort the
+  // session-expired flow entirely (#8372).
+  fetch(`${API_BASE}${AUTH_VERIFY_ENDPOINT}`, {
+    credentials: 'include',
+    signal: AbortSignal.timeout(SESSION_VERIFY_TIMEOUT_MS),
+  }).then(verifyResponse => {
+    if (verifyResponse.ok) {
+      console.warn('[API] 401 received but /api/me still 200 — endpoint-specific failure, keeping session')
+      handling401 = false
+      return
+    }
+    performSessionExpiry()
+  }).catch(() => {
+    // Verify probe failed (network error / timeout / no backend). Treat the
+    // 401 as authoritative and run the normal expiry flow.
+    performSessionExpiry()
+  })
+}
+
+/** Second half of handle401: banner + cookie invalidation + redirect. */
+function performSessionExpiry(): void {
   console.warn('[API] Received 401 Unauthorized - token invalid or expired, logging out')
 
   // Show an in-page notification before redirecting (DOM-injected, no React dependency)
@@ -93,6 +129,7 @@ function handle401(): void {
   // Clear auth state
   localStorage.removeItem(STORAGE_KEY_TOKEN)
   localStorage.removeItem(STORAGE_KEY_USER_CACHE)
+  localStorage.removeItem(STORAGE_KEY_HAS_SESSION)
 
   // Redirect to login after a delay so the user sees the banner
   setTimeout(() => {


### PR DESCRIPTION
## Summary

Fixes #8372 — @xonas1101 reported that refreshing the dashboard
sometimes leaves the URL at `http://localhost:5174/?reason=session_expired`
even though the session is still valid and the view is unchanged.

**Root cause**: After #6590 / #8108 moved OAuth sessions into an HttpOnly
`kc_auth` cookie, a 401 from a single endpoint doesn't necessarily mean
the whole session is expired — other endpoints may still authenticate
fine. But `handle401` in `api.ts` treated every 401 as a hard expiry,
running the banner + localStorage wipe + `window.location.href = '/login?reason=session_expired'`
redirect. Login.tsx then saw `isAuthenticated=true` (cookie still valid)
and bounced to `ROUTES.HOME`, leaving `?reason=session_expired` glued
onto the landing page.

**Fix**: Before running the expiry flow, probe `/api/me` with a 3s
timeout. If it returns 200, the cookie-based session is still valid —
abort the expiry (keep localStorage, skip banner, skip redirect). If it
rejects or the probe times out, fall through to the existing banner +
cookie-invalidation + redirect path. Also clear `STORAGE_KEY_HAS_SESSION`
on real expiry so the cookie-only session flag from #6590 doesn't
resurrect a dead session on next page load.

## Test plan

- [x] `npm run lint` — passes
- [x] `npm run build` — passes
- [x] `npx vitest run src/lib/__tests__/api.test.ts` — 46/46 pass
  (4 existing 401-handling tests updated to mock the new `/api/me`
  verify probe; new test `does NOT clear auth state when /api/me still
  returns 200` covers the specific #8372 path)
- [ ] Manual: trigger a synthetic 401 on the dashboard and confirm the
  banner does NOT appear and the URL stays clean when /api/me is
  healthy.

Fixes #8372