### PR TITLE
🐛 fix: disable Space/Backspace close on sticky ACMM intro modal (#8369)

### DIFF
--- a/web/src/components/acmm/ACMMIntroModal.tsx
+++ b/web/src/components/acmm/ACMMIntroModal.tsx
@@ -57,6 +57,7 @@ export function ACMMIntroModal({ isOpen, onClose }: ACMMIntroModalProps) {
       size="lg"
       closeOnBackdrop={false}
       closeOnEscape={false}
+      enableBackspace={false}
     >
       <BaseModal.Header
         title="Welcome to the AI Codebase Maturity Model"


### PR DESCRIPTION
## Summary

Follow-up to PR #8368 addressing the **third** Copilot review comment on PR #8360 ([flagged in issue #8369](https://github.com/kubestellar/console/issues/8369)).

#8368 hid the misleading \`Esc close · Space close\` hints from the footer, but \`BaseModal\`'s \`enableBackspace\` defaults to \`true\` — so Space/Backspace would actually still close the modal, undermining its sticky-on-first-visit intent.

Adds \`enableBackspace={false}\` alongside the existing \`closeOnEscape={false}\` / \`closeOnBackdrop={false}\`, so the intro modal can only be dismissed via its explicit close icon or the primary CTA.

## Test plan

- [x] \`npm run build\` — passes
- [ ] Open /acmm in a fresh browser → modal opens
- [ ] Press Space — modal stays open
- [ ] Press Backspace — modal stays open
- [ ] Click X in header — modal closes
- [ ] Click 'Got it — let's go' — modal closes

Fixes #8369