### PR TITLE
🧪 test: address Copilot review on #8374 (#8379)

### DIFF
--- a/web/src/hooks/__tests__/useCachedACMMScan.test.tsx
+++ b/web/src/hooks/__tests__/useCachedACMMScan.test.tsx
@@ -7,7 +7,7 @@
  * logic is what's under test.
  */
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
-import { renderHook, act, waitFor } from '@testing-library/react'
+import { renderHook, act } from '@testing-library/react'
 
 // ---------------------------------------------------------------------------
 // Mock useCache — the hook delegates all fetching/caching to it. We mock it
@@ -16,10 +16,15 @@ import { renderHook, act, waitFor } from '@testing-library/react'
 // ---------------------------------------------------------------------------
 
 const lastArgs: { current: Record<string, unknown> | null } = { current: null }
+// Capture the last `refetch` mock handed to the hook so tests can assert
+// `forceRefetch()` actually calls through to it.
+const lastRefetch: { current: ReturnType<typeof vi.fn> | null } = { current: null }
 
 vi.mock('../../lib/cache', () => ({
   useCache: (args: Record<string, unknown>) => {
     lastArgs.current = args
+    const refetch = vi.fn()
+    lastRefetch.current = refetch
     return {
       data: args.demoData,
       isLoading: false,
@@ -29,7 +34,7 @@ vi.mock('../../lib/cache', () => ({
       isFailed: false,
       consecutiveFailures: 0,
       lastRefresh: Date.now(),
-      refetch: vi.fn(),
+      refetch,
     }
   },
   REFRESH_RATES: { costs: 600_000, default: 120_000 },
@@ -38,13 +43,19 @@ vi.mock('../../lib/cache', () => ({
 import { useCachedACMMScan } from '../useCachedACMMScan'
 
 describe('useCachedACMMScan', () => {
+  // Capture the real fetch once so `afterEach` can restore it — otherwise a
+  // reassigned `globalThis.fetch` from one test would leak into later files.
+  const ORIGINAL_FETCH = globalThis.fetch
+
   beforeEach(() => {
     lastArgs.current = null
+    lastRefetch.current = null
     globalThis.fetch = vi.fn() as typeof globalThis.fetch
   })
 
   afterEach(() => {
     vi.restoreAllMocks()
+    globalThis.fetch = ORIGINAL_FETCH
   })
 
   it('uses the default repo when none is provided', () => {
@@ -102,6 +113,10 @@ describe('useCachedACMMScan', () => {
 
   it('forceRefetch flips the force flag and calls refetch', async () => {
     const { result } = renderHook(() => useCachedACMMScan('x/y'))
+    // Capture the mocked refetch that the hook received from useCache — we
+    // assert it gets invoked by forceRefetch() below.
+    const refetchMock = lastRefetch.current
+    expect(refetchMock).not.toBeNull()
     // Call the fetcher directly to verify the force flag makes it to the URL.
     const fetcher = lastArgs.current?.fetcher as () => Promise<unknown>
     globalThis.fetch = vi.fn(async (input: RequestInfo | URL) => {
@@ -114,6 +129,9 @@ describe('useCachedACMMScan', () => {
     }) as typeof globalThis.fetch
 
     await act(async () => { await result.current.forceRefetch() })
+    // forceRefetch must delegate to the underlying cache.refetch — that's
+    // the "calls refetch" half of this test's contract.
+    expect(refetchMock).toHaveBeenCalledTimes(1)
     // Directly invoke the fetcher after forceRefetch — forceNextRef was set
     // to true in forceRefetch, so this first call should include &force=true.
     await act(async () => { await fetcher() })

--- a/web/src/hooks/__tests__/useDrasiResources.test.tsx
+++ b/web/src/hooks/__tests__/useDrasiResources.test.tsx
@@ -51,6 +51,10 @@ function serverWrap(data: unknown) {
 }
 
 describe('useDrasiResources', () => {
+  // Capture the real fetch once so `afterEach` can restore it — otherwise a
+  // reassigned `globalThis.fetch` from one test would leak into later files.
+  const ORIGINAL_FETCH = globalThis.fetch
+
   beforeEach(() => {
     mockActive.current = null
     fetchMap.clear()
@@ -71,6 +75,7 @@ describe('useDrasiResources', () => {
 
   afterEach(() => {
     vi.restoreAllMocks()
+    globalThis.fetch = ORIGINAL_FETCH
   })
 
   describe('no-fetch short-circuits', () => {
@@ -219,7 +224,7 @@ describe('useDrasiResources', () => {
       await waitFor(() => expect(result.current.data).not.toBeNull())
       const callsBefore = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls.length
 
-      await act(async () => { result.current.refetch() })
+      await act(async () => { await result.current.refetch() })
       await waitFor(() => {
         const callsAfter = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls.length
         expect(callsAfter).toBeGreaterThan(callsBefore)

--- a/web/src/lib/acmm/sources/__tests__/sources.test.ts
+++ b/web/src/lib/acmm/sources/__tests__/sources.test.ts
@@ -13,11 +13,16 @@ import {
   ALL_CRITERIA,
   ACMM_LEVELS,
 } from '../index'
+import type { CriterionCategory } from '../types'
 import { acmmSource } from '../acmm'
 import { fullsendSource } from '../fullsend'
 import { agenticEngineeringFrameworkSource } from '../agentic-engineering-framework'
 import { claudeReflectSource } from '../claude-reflect'
 
+// Pin the runtime whitelist to the `CriterionCategory` union via `satisfies` —
+// TypeScript will fail compilation if the union drifts, so we don't need to
+// also duplicate the literal list in a separate module. (`CriterionCategory`
+// is a type-only export, so it can't be reflected at runtime directly.)
 const VALID_CATEGORIES = [
   'feedback-loop',
   'readiness',
@@ -25,8 +30,10 @@ const VALID_CATEGORIES = [
   'observability',
   'governance',
   'self-tuning',
-]
-const VALID_SOURCES = ['acmm', 'fullsend', 'agentic-engineering-framework', 'claude-reflect']
+] as const satisfies readonly CriterionCategory[]
+// VALID_SOURCES is derived from SOURCES so adding a new source doesn't
+// require updating a second literal list.
+const VALID_SOURCES = SOURCES.map(s => s.id)
 
 describe('ACMM sources index', () => {
   it('SOURCES contains exactly four sources', () => {
@@ -40,8 +47,15 @@ describe('ACMM sources index', () => {
   })
 
   it('ALL_CRITERIA equals the union of every source.criteria list', () => {
-    const expected = SOURCES.flatMap(s => s.criteria).length
-    expect(ALL_CRITERIA.length).toBe(expected)
+    // Use deep-equality against the concatenated criteria so a swap (right
+    // count, wrong items) fails. Order mirrors the SOURCES declaration.
+    const expected = SOURCES.flatMap(s => s.criteria)
+    expect(ALL_CRITERIA).toEqual(expected)
+    // Also assert the ID set matches — redundant but makes the intent clear
+    // and surfaces any accidental dedup in ALL_CRITERIA.
+    expect(new Set(ALL_CRITERIA.map(c => c.id))).toEqual(
+      new Set(SOURCES.flatMap(s => s.criteria.map(c => c.id))),
+    )
   })
 
   it('ACMM_LEVELS is populated only from the acmm source', () => {


### PR DESCRIPTION
## Summary

Follow-up to merged PR #8374. Addresses all 7 Copilot review comments — concrete test-hygiene fixes, no source changes.

## Items fixed

| # | File | Fix |
|---|------|-----|
| 1 | `web/src/hooks/__tests__/useCachedACMMScan.test.tsx:10` | Drop unused `waitFor` import |
| 2 | `web/src/hooks/__tests__/useCachedACMMScan.test.tsx:48` | Capture original `globalThis.fetch`, restore in `afterEach` — `vi.restoreAllMocks()` doesn't restore reassigned globals |
| 3 | `web/src/hooks/__tests__/useCachedACMMScan.test.tsx:124` | Assert `forceRefetch()` actually invokes the `useCache().refetch` mock (test name promised it; previously only the query-string side-effect was checked) |
| 4 | `web/src/hooks/__tests__/useDrasiResources.test.tsx:74` | Same `globalThis.fetch` restoration fix |
| 5 | `web/src/hooks/__tests__/useDrasiResources.test.tsx:222` | `await result.current.refetch()` inside `act(async …)` so the Promise flushes before `act` closes |
| 6 | `web/src/lib/acmm/sources/__tests__/sources.test.ts:30` | Derive `VALID_SOURCES` from `SOURCES.map(s => s.id)`; pin `VALID_CATEGORIES` to `CriterionCategory` via `satisfies` so drift is caught structurally rather than via duplicated literals |
| 7 | `web/src/lib/acmm/sources/__tests__/sources.test.ts:44` | Replace length-only check with a deep-equality assertion against `SOURCES.flatMap(s => s.criteria)` plus an ID-set cross-check |

### Note on item 6 (`VALID_CATEGORIES`)

`CriterionCategory` is a type-only export in `../types`, so it can't be reflected at runtime directly. The cleanest equivalent is `as const satisfies readonly CriterionCategory[]` — TypeScript will fail compilation if the union grows and the literal list isn't updated, giving the same drift protection the Copilot suggestion aimed for.

## Test plan

- [x] `npx vitest run <3 affected files>` — 56/56 pass
- [x] `npm run build` — clean
- [x] `npm run lint` — no new errors in touched files (pre-existing baseline errors elsewhere unchanged)

Fixes #8379