### PR TITLE
🐛 fix: make "Terms of Service" text on login screen a link (#8376)

### DIFF
--- a/web/src/components/auth/Login.tsx
+++ b/web/src/components/auth/Login.tsx
@@ -13,6 +13,9 @@ import { useBranding } from '../../hooks/useBranding'
 // Lazy load the heavy Three.js globe animation
 const GlobeAnimation = lazy(() => import('../animations/globe').then(m => ({ default: m.GlobeAnimation })))
 
+// Apache 2.0 license is the project's effective terms; link opens in a new tab (#8376).
+const TERMS_OF_SERVICE_URL = 'https://github.com/kubestellar/console/blob/main/LICENSE'
+
 /** Structured info displayed for each OAuth error code returned by the backend. */
 interface OAuthErrorEntry {
   title: string
@@ -343,7 +346,15 @@ export function Login() {
 
           {/* Footer */}
           <div className="text-center text-sm text-muted-foreground mt-8">
-            {t('login.termsOfService')}
+            {t('login.termsOfServicePrefix')}{' '}
+            <a
+              href={TERMS_OF_SERVICE_URL}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="underline hover:text-foreground transition-colors"
+            >
+              {t('login.termsOfServiceLink')}
+            </a>
           </div>
         </div>
       </div>

--- a/web/src/locales/de/common.json
+++ b/web/src/locales/de/common.json
@@ -2831,7 +2831,8 @@
     "welcomeBack": "Welcome back",
     "signInDescription": "Sign in to manage your multi-cluster deployments",
     "continueWithGitHub": "Continue with GitHub",
-    "termsOfService": "By signing in, you agree to our Terms of Service"
+    "termsOfServicePrefix": "By signing in, you agree to our",
+    "termsOfServiceLink": "Terms of Service"
   },
   "authCallback": {
     "signingIn": "Signing you in...",

--- a/web/src/locales/en/common.json
+++ b/web/src/locales/en/common.json
@@ -3212,7 +3212,8 @@
     "welcomeBack": "Welcome back",
     "signInDescription": "Sign in to manage your multi-cluster deployments",
     "continueWithGitHub": "Continue with GitHub",
-    "termsOfService": "By signing in, you agree to our Terms of Service"
+    "termsOfServicePrefix": "By signing in, you agree to our",
+    "termsOfServiceLink": "Terms of Service"
   },
   "authCallback": {
     "signingIn": "Signing you in...",

--- a/web/src/locales/es/common.json
+++ b/web/src/locales/es/common.json
@@ -2831,7 +2831,8 @@
     "welcomeBack": "Welcome back",
     "signInDescription": "Sign in to manage your multi-cluster deployments",
     "continueWithGitHub": "Continue with GitHub",
-    "termsOfService": "By signing in, you agree to our Terms of Service"
+    "termsOfServicePrefix": "By signing in, you agree to our",
+    "termsOfServiceLink": "Terms of Service"
   },
   "authCallback": {
     "signingIn": "Signing you in...",

--- a/web/src/locales/fr/common.json
+++ b/web/src/locales/fr/common.json
@@ -2831,7 +2831,8 @@
     "welcomeBack": "Welcome back",
     "signInDescription": "Sign in to manage your multi-cluster deployments",
     "continueWithGitHub": "Continue with GitHub",
-    "termsOfService": "By signing in, you agree to our Terms of Service"
+    "termsOfServicePrefix": "By signing in, you agree to our",
+    "termsOfServiceLink": "Terms of Service"
   },
   "authCallback": {
     "signingIn": "Signing you in...",

--- a/web/src/locales/hi/common.json
+++ b/web/src/locales/hi/common.json
@@ -2831,7 +2831,8 @@
     "welcomeBack": "Welcome back",
     "signInDescription": "Sign in to manage your multi-cluster deployments",
     "continueWithGitHub": "Continue with GitHub",
-    "termsOfService": "By signing in, you agree to our Terms of Service"
+    "termsOfServicePrefix": "By signing in, you agree to our",
+    "termsOfServiceLink": "Terms of Service"
   },
   "authCallback": {
     "signingIn": "Signing you in...",

--- a/web/src/locales/it/common.json
+++ b/web/src/locales/it/common.json
@@ -2831,7 +2831,8 @@
     "welcomeBack": "Welcome back",
     "signInDescription": "Sign in to manage your multi-cluster deployments",
     "continueWithGitHub": "Continue with GitHub",
-    "termsOfService": "By signing in, you agree to our Terms of Service"
+    "termsOfServicePrefix": "By signing in, you agree to our",
+    "termsOfServiceLink": "Terms of Service"
   },
   "authCallback": {
     "signingIn": "Signing you in...",

--- a/web/src/locales/ja/common.json
+++ b/web/src/locales/ja/common.json
@@ -2831,7 +2831,8 @@
     "welcomeBack": "Welcome back",
     "signInDescription": "Sign in to manage your multi-cluster deployments",
     "continueWithGitHub": "Continue with GitHub",
-    "termsOfService": "By signing in, you agree to our Terms of Service"
+    "termsOfServicePrefix": "By signing in, you agree to our",
+    "termsOfServiceLink": "Terms of Service"
   },
   "authCallback": {
     "signingIn": "Signing you in...",

--- a/web/src/locales/pt/common.json
+++ b/web/src/locales/pt/common.json
@@ -2831,7 +2831,8 @@
     "welcomeBack": "Welcome back",
     "signInDescription": "Sign in to manage your multi-cluster deployments",
     "continueWithGitHub": "Continue with GitHub",
-    "termsOfService": "By signing in, you agree to our Terms of Service"
+    "termsOfServicePrefix": "By signing in, you agree to our",
+    "termsOfServiceLink": "Terms of Service"
   },
   "authCallback": {
     "signingIn": "Signing you in...",

--- a/web/src/locales/zh/common.json
+++ b/web/src/locales/zh/common.json
@@ -2831,7 +2831,8 @@
     "welcomeBack": "Welcome back",
     "signInDescription": "Sign in to manage your multi-cluster deployments",
     "continueWithGitHub": "Continue with GitHub",
-    "termsOfService": "By signing in, you agree to our Terms of Service"
+    "termsOfServicePrefix": "By signing in, you agree to our",
+    "termsOfServiceLink": "Terms of Service"
   },
   "authCallback": {
     "signingIn": "Signing you in...",


### PR DESCRIPTION
## Summary

The login footer rendered "By signing in, you agree to our Terms of Service" as plain text. The phrasing implies users can click through to read the terms, but nothing was clickable.

## Changes

- Split i18n key `login.termsOfService` into `login.termsOfServicePrefix` + `login.termsOfServiceLink` across all 10 locales
- Wrap "Terms of Service" in an `<a>` that opens in a new tab
- Link target is the Apache 2.0 `LICENSE` in the repo (the project's effective terms)

## Test plan

- [x] `npm run build` — clean
- [x] `npm run lint` — no new errors
- [ ] Visual: `/login` footer shows "Terms of Service" underlined; hover transitions; click opens LICENSE in new tab

Fixes #8376