### PR TITLE
🐛 fix: harden notifier dedup keys, deadlines, and transport (#8389 #8390 #8391 #8392)

### DIFF
--- a/pkg/notifications/email.go
+++ b/pkg/notifications/email.go
@@ -12,6 +12,24 @@ import (
 	"time"
 )
 
+const (
+	// SMTPDialTimeout bounds the initial TCP connect to the SMTP server.
+	SMTPDialTimeout = 10 * time.Second
+	// SMTPOpTimeout bounds each individual SMTP phase (TLS handshake,
+	// STARTTLS, AUTH, MAIL/RCPT, DATA, QUIT). Without per-phase deadlines a
+	// stalled server could hang the notifier indefinitely after the TCP
+	// connection succeeds (#8391).
+	SMTPOpTimeout = 30 * time.Second
+)
+
+// setSMTPDeadline arms a fresh per-operation deadline on conn. Called before
+// each SMTP phase so a stalled phase doesn't consume the entire budget of the
+// next one. Returns any error from SetDeadline so callers can surface it.
+// (#8391)
+func setSMTPDeadline(conn net.Conn) error {
+	return conn.SetDeadline(time.Now().Add(SMTPOpTimeout))
+}
+
 // EmailNotifier handles email notifications via SMTP
 type EmailNotifier struct {
 	SMTPHost string
@@ -83,12 +101,20 @@ func (e *EmailNotifier) Send(alert Alert) error {
 
 // sendWithTLS sends an email using STARTTLS to encrypt the connection before
 // transmitting SMTP credentials. This prevents plaintext credential exposure
-// on non-localhost connections (#4730).
+// on non-localhost connections (#4730). Every SMTP phase gets a fresh
+// per-operation deadline (SMTPOpTimeout) so a stalled phase cannot hang the
+// notifier indefinitely (#8391).
 func (e *EmailNotifier) sendWithTLS(addr string, auth smtp.Auth, msg string) error {
-	// Connect to SMTP server
-	conn, err := net.DialTimeout("tcp", addr, 10*time.Second)
+	// Connect to SMTP server with an initial dial timeout.
+	conn, err := net.DialTimeout("tcp", addr, SMTPDialTimeout)
 	if err != nil {
 		return fmt.Errorf("failed to connect to SMTP server: %w", err)
+	}
+
+	// Arm a deadline for the SMTP banner / NewClient handshake.
+	if err := setSMTPDeadline(conn); err != nil {
+		conn.Close()
+		return fmt.Errorf("failed to set SMTP deadline: %w", err)
 	}
 
 	client, err := smtp.NewClient(conn, e.SMTPHost)
@@ -103,28 +129,44 @@ func (e *EmailNotifier) sendWithTLS(addr string, auth smtp.Auth, msg string) err
 		ServerName: e.SMTPHost,
 		MinVersion: tls.VersionTLS12,
 	}
+	// Reset the deadline before STARTTLS so the handshake has its full budget.
+	if err := setSMTPDeadline(conn); err != nil {
+		return fmt.Errorf("failed to set STARTTLS deadline: %w", err)
+	}
 	if err := client.StartTLS(tlsConfig); err != nil {
 		return fmt.Errorf("STARTTLS failed (SMTP server may not support TLS): %w", err)
 	}
 
 	// Authenticate after TLS is established
 	if auth != nil {
+		if err := setSMTPDeadline(conn); err != nil {
+			return fmt.Errorf("failed to set AUTH deadline: %w", err)
+		}
 		if err := client.Auth(auth); err != nil {
 			return fmt.Errorf("SMTP auth failed: %w", err)
 		}
 	}
 
 	// Set sender and recipients
+	if err := setSMTPDeadline(conn); err != nil {
+		return fmt.Errorf("failed to set MAIL deadline: %w", err)
+	}
 	if err := client.Mail(e.From); err != nil {
 		return fmt.Errorf("SMTP MAIL FROM failed: %w", err)
 	}
 	for _, recipient := range e.To {
+		if err := setSMTPDeadline(conn); err != nil {
+			return fmt.Errorf("failed to set RCPT deadline: %w", err)
+		}
 		if err := client.Rcpt(recipient); err != nil {
 			return fmt.Errorf("SMTP RCPT TO failed for %s: %w", recipient, err)
 		}
 	}
 
 	// Write message body
+	if err := setSMTPDeadline(conn); err != nil {
+		return fmt.Errorf("failed to set DATA deadline: %w", err)
+	}
 	w, err := client.Data()
 	if err != nil {
 		return fmt.Errorf("SMTP DATA failed: %w", err)
@@ -136,6 +178,10 @@ func (e *EmailNotifier) sendWithTLS(addr string, auth smtp.Auth, msg string) err
 		return fmt.Errorf("failed to close email body: %w", err)
 	}
 
+	// Final deadline for QUIT so a stalled close doesn't hang the notifier.
+	if err := setSMTPDeadline(conn); err != nil {
+		return fmt.Errorf("failed to set QUIT deadline: %w", err)
+	}
 	return client.Quit()
 }
 

--- a/pkg/notifications/fixes_test.go
+++ b/pkg/notifications/fixes_test.go
@@ -3,6 +3,7 @@ package notifications
 import (
 	"encoding/json"
 	"io"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -266,3 +267,172 @@ func TestOpsGenie_CloseAlert_NoEscapeNeeded(t *testing.T) {
 type roundTripFunc func(*http.Request) (*http.Response, error)
 
 func (f roundTripFunc) RoundTrip(r *http.Request) (*http.Response, error) { return f(r) }
+
+// ---------------------------------------------------------------------------
+// #8389 — PagerDuty dedup key collision when ID/RuleID/Cluster all empty
+// ---------------------------------------------------------------------------
+
+// TestPagerDuty_FallbackDedupKey_DistinctMessages verifies that when all three
+// identity fields are empty, distinct alert messages produce distinct dedup
+// keys (previously the key degenerated to the constant "::::" so unrelated
+// alerts collapsed into one incident).
+func TestPagerDuty_FallbackDedupKey_DistinctMessages(t *testing.T) {
+	firedAt := time.Date(2026, 4, 16, 12, 0, 0, 0, time.UTC)
+	a := Alert{Message: "disk full", FiredAt: firedAt}
+	b := Alert{Message: "oom killed", FiredAt: firedAt}
+
+	keyA := fallbackDedupKey(a)
+	keyB := fallbackDedupKey(b)
+
+	require.NotEqual(t, keyA, keyB, "distinct messages must produce distinct dedup keys")
+	require.NotEqual(t, "::::", keyA, "fallback key must not degenerate to constant")
+	require.NotEqual(t, "::::", keyB)
+	// Sanity: prefix + hex truncation length.
+	require.True(t, strings.HasPrefix(keyA, "fallback-"))
+	require.Equal(t, len("fallback-")+dedupHashHexLen, len(keyA))
+}
+
+// TestPagerDuty_FallbackDedupKey_Stable verifies identical (Message, FiredAt)
+// pairs produce the same dedup key so PagerDuty still dedupes repeats.
+func TestPagerDuty_FallbackDedupKey_Stable(t *testing.T) {
+	firedAt := time.Date(2026, 4, 16, 12, 0, 0, 0, time.UTC)
+	a := Alert{Message: "disk full", FiredAt: firedAt}
+	b := Alert{Message: "disk full", FiredAt: firedAt}
+
+	require.Equal(t, fallbackDedupKey(a), fallbackDedupKey(b))
+}
+
+// TestPagerDuty_Send_UsesFallbackWhenAllEmpty wires the notifier through a
+// round-tripper and confirms the outgoing dedup_key is NOT the degenerate
+// "::::" when every identity field is empty.
+func TestPagerDuty_Send_UsesFallbackWhenAllEmpty(t *testing.T) {
+	var captured pagerdutyEvent
+	rt := roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		body, _ := io.ReadAll(req.Body)
+		_ = json.Unmarshal(body, &captured)
+		return &http.Response{
+			StatusCode: http.StatusAccepted,
+			Body:       io.NopCloser(strings.NewReader("")),
+			Header:     make(http.Header),
+		}, nil
+	})
+	p := &PagerDutyNotifier{RoutingKey: "test-key", HTTPClient: &http.Client{Transport: rt}}
+
+	err := p.Send(Alert{Message: "disk full", Severity: SeverityCritical, Status: "firing", FiredAt: time.Now()})
+	require.NoError(t, err)
+	require.NotEqual(t, "::::", captured.DedupKey)
+	require.NotEmpty(t, captured.DedupKey)
+	require.True(t, strings.HasPrefix(captured.DedupKey, "fallback-"))
+}
+
+// ---------------------------------------------------------------------------
+// #8390 — OpsGenie alias collision (same class of bug as #8389)
+// ---------------------------------------------------------------------------
+
+// TestOpsGenie_Send_UsesFallbackAliasWhenAllEmpty confirms the OpsGenie
+// createAlert path does not send "::::" as the alias when every identity
+// field is empty.
+func TestOpsGenie_Send_UsesFallbackAliasWhenAllEmpty(t *testing.T) {
+	var captured opsgenieAlert
+	rt := roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		body, _ := io.ReadAll(req.Body)
+		_ = json.Unmarshal(body, &captured)
+		return &http.Response{
+			StatusCode: http.StatusAccepted,
+			Body:       io.NopCloser(strings.NewReader("")),
+			Header:     make(http.Header),
+		}, nil
+	})
+	o := &OpsGenieNotifier{APIKey: "test-key", HTTPClient: &http.Client{Transport: rt}}
+
+	err := o.Send(Alert{RuleName: "no-id rule", Message: "oom", Severity: SeverityCritical, Status: "firing", FiredAt: time.Now()})
+	require.NoError(t, err)
+	require.NotEqual(t, "::::", captured.Alias)
+	require.NotEmpty(t, captured.Alias)
+	require.True(t, strings.HasPrefix(captured.Alias, "fallback-"))
+}
+
+// ---------------------------------------------------------------------------
+// #8391 — SMTP missing per-op deadlines
+// ---------------------------------------------------------------------------
+
+// TestSetSMTPDeadline_ArmsDeadline confirms the helper pushes the deadline
+// forward by roughly SMTPOpTimeout. We use a net.Pipe() conn because it
+// honors SetDeadline without needing a real TCP socket.
+func TestSetSMTPDeadline_ArmsDeadline(t *testing.T) {
+	// Use a net.Pipe to get a net.Conn that supports SetDeadline. We don't
+	// actually do I/O on it — we just verify SetDeadline returns nil and the
+	// helper doesn't panic. Read/write deadline enforcement is covered by the
+	// stdlib tests; we're verifying our call site plumbs correctly.
+	a, b := net.Pipe()
+	defer a.Close()
+	defer b.Close()
+
+	before := time.Now()
+	err := setSMTPDeadline(a)
+	require.NoError(t, err)
+	// The deadline must be at least SMTPOpTimeout-epsilon into the future.
+	// We can't directly read the deadline back, but we can assert the helper
+	// didn't error and the constant is plausibly non-zero.
+	require.True(t, SMTPOpTimeout > 0)
+	require.True(t, time.Since(before) < SMTPOpTimeout)
+}
+
+// ---------------------------------------------------------------------------
+// #8392 — Webhook accepts plaintext HTTP
+// ---------------------------------------------------------------------------
+
+// TestWebhookNotifier_RejectsPlaintextHTTPForRemoteHost verifies plaintext
+// http:// URLs to non-loopback hosts are rejected at construction time.
+func TestWebhookNotifier_RejectsPlaintextHTTPForRemoteHost(t *testing.T) {
+	_, err := NewWebhookNotifier("http://evil.com/hook")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "https")
+	require.Contains(t, err.Error(), "loopback")
+}
+
+// TestWebhookNotifier_AllowsPlaintextHTTPForLoopback verifies loopback hosts
+// may still be reached over plaintext http for local development and sidecar
+// receivers.
+func TestWebhookNotifier_AllowsPlaintextHTTPForLoopback(t *testing.T) {
+	for _, u := range []string{
+		"http://localhost:9000/hook",
+		"http://127.0.0.1:9000/hook",
+		"http://[::1]:9000/hook",
+	} {
+		_, err := NewWebhookNotifier(u)
+		require.NoErrorf(t, err, "loopback URL must be accepted: %s", u)
+	}
+}
+
+// TestWebhookNotifier_AllowsHTTPSForAnyHost verifies https:// is always
+// accepted regardless of host.
+func TestWebhookNotifier_AllowsHTTPSForAnyHost(t *testing.T) {
+	for _, u := range []string{
+		"https://alerts.example.com/hook",
+		"https://localhost:9000/hook",
+	} {
+		_, err := NewWebhookNotifier(u)
+		require.NoErrorf(t, err, "https URL must be accepted: %s", u)
+	}
+}
+
+// TestIsLoopbackHost covers the helper's recognized values and rejects
+// anything else, including a host name that merely *contains* "localhost".
+func TestIsLoopbackHost(t *testing.T) {
+	cases := []struct {
+		host string
+		want bool
+	}{
+		{"localhost", true},
+		{"127.0.0.1", true},
+		{"::1", true},
+		{"evil.com", false},
+		{"localhost.evil.com", false},
+		{"127.0.0.2", false},
+		{"", false},
+	}
+	for _, c := range cases {
+		require.Equalf(t, c.want, isLoopbackHost(c.host), "isLoopbackHost(%q)", c.host)
+	}
+}

--- a/pkg/notifications/opsgenie.go
+++ b/pkg/notifications/opsgenie.go
@@ -55,6 +55,13 @@ func (o *OpsGenieNotifier) Send(alert Alert) error {
 	if alert.RuleID == "" || alert.Cluster == "" {
 		alias = alert.ID + "::" + alert.RuleID + "::" + alert.Cluster
 	}
+	// #8390: if ID, RuleID, and Cluster are ALL empty the alias degenerates to
+	// "::::" — a constant that would cause every such alert to share the same
+	// OpsGenie alias and resolve/overwrite each other. Fall back to a stable
+	// hash of the alert message + fired timestamp (see fallbackDedupKey).
+	if alert.ID == "" && alert.RuleID == "" && alert.Cluster == "" {
+		alias = fallbackDedupKey(alert)
+	}
 
 	if alert.Status == "resolved" {
 		return o.closeAlert(alias)

--- a/pkg/notifications/pagerduty.go
+++ b/pkg/notifications/pagerduty.go
@@ -2,6 +2,8 @@ package notifications
 
 import (
 	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -12,6 +14,11 @@ import (
 const (
 	pagerdutyEventsURL  = "https://events.pagerduty.com/v2/enqueue"
 	pagerdutyHTTPTimeout = 10 * time.Second
+	// dedupHashHexLen truncates the SHA-256 hex digest used as a fallback
+	// dedup key when ID, RuleID, and Cluster are all empty. 16 hex chars = 64
+	// bits of entropy, plenty to avoid accidental collisions between distinct
+	// alerts while keeping the key short in PagerDuty / OpsGenie UIs (#8389, #8390).
+	dedupHashHexLen = 16
 )
 
 // PagerDutyNotifier handles PagerDuty Events API v2 notifications
@@ -58,6 +65,14 @@ func (p *PagerDutyNotifier) Send(alert Alert) error {
 	dedupKey := alert.RuleID + "::" + alert.Cluster
 	if alert.RuleID == "" || alert.Cluster == "" {
 		dedupKey = alert.ID + "::" + alert.RuleID + "::" + alert.Cluster
+	}
+	// #8389: if ID, RuleID, and Cluster are ALL empty the key degenerates to
+	// "::::", a constant that would collapse every such alert into a single
+	// PagerDuty incident. Fall back to a stable hash of the alert message +
+	// fired timestamp so identical alerts fired very close together still
+	// dedupe, but distinct alerts get distinct keys.
+	if alert.ID == "" && alert.RuleID == "" && alert.Cluster == "" {
+		dedupKey = fallbackDedupKey(alert)
 	}
 
 	event := pagerdutyEvent{
@@ -142,6 +157,19 @@ func (p *PagerDutyNotifier) sendEvent(event pagerdutyEvent) error {
 	}
 
 	return nil
+}
+
+// fallbackDedupKey returns a stable short hash used as the dedup key when all
+// three identity fields on the alert (ID, RuleID, Cluster) are empty. Without
+// this, PagerDuty (#8389) and OpsGenie (#8390) would collapse unrelated alerts
+// into a single incident because the composed key degenerates to a constant
+// ("::::"). The hash covers Message + FiredAt timestamp so identical alerts
+// fired at the same instant still dedupe, but distinct alerts get distinct
+// keys. Truncated to dedupHashHexLen hex chars (64 bits) — collision-safe for
+// this use case.
+func fallbackDedupKey(alert Alert) string {
+	h := sha256.Sum256([]byte(alert.Message + "::" + alert.FiredAt.String()))
+	return "fallback-" + hex.EncodeToString(h[:])[:dedupHashHexLen]
 }
 
 // mapSeverity maps console severity to PagerDuty severity

--- a/pkg/notifications/webhook.go
+++ b/pkg/notifications/webhook.go
@@ -65,6 +65,12 @@ func NewWebhookNotifier(webhookURL string) (*WebhookNotifier, error) {
 	if u.Host == "" {
 		return nil, fmt.Errorf("webhook URL must have a host")
 	}
+	// #8392: reject plaintext http by default. Allow it only when the host
+	// is a loopback address so local development and in-cluster testing
+	// against sidecar receivers still work without TLS.
+	if u.Scheme == "http" && !isLoopbackHost(u.Hostname()) {
+		return nil, fmt.Errorf("webhook URL must use https (plaintext http allowed only for loopback hosts)")
+	}
 	if err := checkWebhookHostAllowed(u.Hostname()); err != nil {
 		return nil, err
 	}
@@ -80,6 +86,18 @@ func NewWebhookNotifier(webhookURL string) (*WebhookNotifier, error) {
 			},
 		},
 	}, nil
+}
+
+// isLoopbackHost returns true if host is a recognized loopback hostname or
+// address. Used to carve out an exception to the HTTPS-only webhook rule for
+// local development and in-cluster sidecar receivers (#8392).
+func isLoopbackHost(host string) bool {
+	switch host {
+	case "localhost", "127.0.0.1", "::1":
+		return true
+	default:
+		return false
+	}
 }
 
 // checkWebhookHostAllowed enforces the optional KC_WEBHOOK_ALLOWED_HOSTS


### PR DESCRIPTION
Consolidated fix for four notifier bugs (#8389 #8390 #8391 #8392) reported by @xonas1101. All four touch `pkg/notifications/` and follow prior consolidation precedent for this reporter.

## #8389 — PagerDuty dedup key collision

`pkg/notifications/pagerduty.go` — when `Alert.ID`, `Alert.RuleID`, and `Alert.Cluster` were all empty, `dedupKey` degenerated to the constant `"::::"`. Every such alert collapsed into a single PagerDuty incident.

Fix: added a final fallback that hashes `Message + FiredAt` with SHA-256 and truncates to `dedupHashHexLen` (16) hex chars. Identical repeats still dedupe; distinct alerts get distinct keys. New helper `fallbackDedupKey(Alert) string`.

Fixes #8389

## #8390 — OpsGenie alias collision

`pkg/notifications/opsgenie.go` — identical bug class, same constant `"::::"` degeneracy for the OpsGenie alias. Unrelated alerts shared an alias and resolved/overwrote each other.

Fix: same `fallbackDedupKey()` helper applied in `OpsGenieNotifier.Send`.

Fixes #8390

## #8391 — SMTP missing per-op deadlines

`pkg/notifications/email.go` — `sendWithTLS` called `net.DialTimeout` but never armed per-operation deadlines afterwards. STARTTLS / AUTH / MAIL / RCPT / DATA / QUIT could all hang indefinitely on a stalled server.

Fix: added `SMTPOpTimeout = 30 * time.Second` constant and a `setSMTPDeadline(conn)` helper. Deadline is reset before each SMTP phase so a stalled phase cannot consume the budget of the next. `SMTPDialTimeout` (10s) also named for the initial connect.

Fixes #8391

## #8392 — Webhook accepts plaintext HTTP

`pkg/notifications/webhook.go` — `NewWebhookNotifier` accepted any `http://` URL, including plaintext to remote hosts. Webhook secrets and alert payloads were exposed in transit.

Fix: reject `http://` unless the host is a recognized loopback (`localhost`, `127.0.0.1`, `::1`) via new `isLoopbackHost(host string) bool` helper. Error message: `"webhook URL must use https (plaintext http allowed only for loopback hosts)"`.

Fixes #8392

## Tests

Added to `pkg/notifications/fixes_test.go`:

- `TestPagerDuty_FallbackDedupKey_DistinctMessages` / `_Stable`
- `TestPagerDuty_Send_UsesFallbackWhenAllEmpty` (round-tripper captures outgoing `dedup_key`)
- `TestOpsGenie_Send_UsesFallbackAliasWhenAllEmpty`
- `TestSetSMTPDeadline_ArmsDeadline` (uses `net.Pipe()` conn)
- `TestWebhookNotifier_RejectsPlaintextHTTPForRemoteHost`
- `TestWebhookNotifier_AllowsPlaintextHTTPForLoopback`
- `TestWebhookNotifier_AllowsHTTPSForAnyHost`
- `TestIsLoopbackHost` — including `localhost.evil.com` negative case

## Verification

- `go test ./pkg/notifications/...` — ok
- `go build ./...` — ok
- `npm run build` — ok (post-build safety checks pass)