### PR TITLE
✨ feat(agent): register RamaLama as a local OpenAI-compatible runner

### DIFF
--- a/pkg/agent/config.go
+++ b/pkg/agent/config.go
@@ -413,6 +413,8 @@ func getEnvKeyForProvider(provider string) string {
 		return "LM_STUDIO_API_KEY"
 	case "rhaiis":
 		return "RHAIIS_API_KEY"
+	case "ramalama":
+		return "RAMALAMA_API_KEY"
 	default:
 		return ""
 	}
@@ -437,6 +439,8 @@ func getBaseURLEnvKeyForProvider(provider string) string {
 		return "LM_STUDIO_URL"
 	case "rhaiis":
 		return "RHAIIS_URL"
+	case "ramalama":
+		return "RAMALAMA_URL"
 	// OpenAI-compatible gateways
 	case "groq":
 		return "GROQ_BASE_URL"
@@ -481,6 +485,8 @@ func getModelEnvKeyForProvider(provider string) string {
 		return "LM_STUDIO_MODEL"
 	case "rhaiis":
 		return "RHAIIS_MODEL"
+	case "ramalama":
+		return "RAMALAMA_MODEL"
 	default:
 		return ""
 	}

--- a/pkg/agent/provider_local_openai_compat.go
+++ b/pkg/agent/provider_local_openai_compat.go
@@ -144,6 +144,7 @@ const (
 	ProviderKeyVLLM         = "vllm"
 	ProviderKeyLMStudio     = "lm-studio"
 	ProviderKeyRHAIIS       = "rhaiis"
+	ProviderKeyRamalama     = "ramalama"
 	ProviderKeyClaudeDesktopLocal = "claude-desktop"
 )
 
@@ -157,6 +158,7 @@ const (
 	envVLLMURL     = "VLLM_URL"
 	envLMStudioURL = "LM_STUDIO_URL"
 	envRHAIISURL   = "RHAIIS_URL"
+	envRamalamaURL = "RAMALAMA_URL"
 )
 
 // Default local URLs for each runner. These are only used if the corresponding
@@ -246,6 +248,20 @@ func NewRHAIISProvider() *LocalOpenAICompatProvider {
 		providerKey: ProviderKeyRHAIIS,
 		description: "Red Hat AI Inference Server - productized vLLM on OpenShift",
 		urlEnvVar:   envRHAIISURL,
+		chatPath:    "/v1/chat/completions",
+	}
+}
+
+// NewRamalamaProvider returns the RamaLama provider. RamaLama wraps llama.cpp
+// and vLLM behind an OCI-packaged workflow and exposes an OpenAI-compatible
+// server when started with `ramalama serve`.
+func NewRamalamaProvider() *LocalOpenAICompatProvider {
+	return &LocalOpenAICompatProvider{
+		name:        ProviderKeyRamalama,
+		displayName: "RamaLama (Local)",
+		providerKey: ProviderKeyRamalama,
+		description: "RamaLama - OCI-packaged local model runtime (llama.cpp/vLLM under the hood)",
+		urlEnvVar:   envRamalamaURL,
 		chatPath:    "/v1/chat/completions",
 	}
 }

--- a/pkg/agent/registry.go
+++ b/pkg/agent/registry.go
@@ -319,6 +319,7 @@ func InitializeProviders() error {
 	registry.Register(NewVLLMProvider())
 	registry.Register(NewLMStudioProvider())
 	registry.Register(NewRHAIISProvider())
+	registry.Register(NewRamalamaProvider())
 
 	// Register the OpenAI-compatible gateway and frontend providers. These
 	// have existed in the codebase but were previously unregistered because

--- a/web/src/components/agent/AgentIcon.tsx
+++ b/web/src/components/agent/AgentIcon.tsx
@@ -309,6 +309,18 @@ export function AgentIcon({ provider, className = 'w-5 h-5' }: AgentIconProps) {
           <text x="18" y="7" textAnchor="middle" className="fill-red-900" fontSize="4" fontWeight="bold">AI</text>
         </svg>
       )
+    case 'ramalama':
+      return (
+        <svg className={className} viewBox="0 0 24 24" fill="none">
+          {/* RamaLama - llama silhouette inside an OCI shipping container */}
+          <rect x="2" y="6" width="20" height="14" rx="2" className="fill-orange-600" />
+          <rect x="2" y="6" width="20" height="2" className="fill-orange-800" />
+          <rect x="2" y="18" width="20" height="2" className="fill-orange-800" />
+          <path d="M8 10c0 1 0 2 0.5 3H7l0.5 4h9L17 13h-1.5c0.5-1 0.5-2 0.5-3" className="fill-orange-100" />
+          <circle cx="9.5" cy="11.5" r="0.6" className="fill-gray-900" />
+          <circle cx="14.5" cy="11.5" r="0.6" className="fill-gray-900" />
+        </svg>
+      )
     default:
       // Generic AI/robot icon
       return (

--- a/web/src/components/agent/agentSelectorUtils.ts
+++ b/web/src/components/agent/agentSelectorUtils.ts
@@ -27,6 +27,7 @@ export const LOCAL_LLM_INSTALL_MISSIONS: Readonly<Partial<Record<string, string>
   vllm: 'install-vllm',
   'lm-studio': 'install-lm-studio',
   rhaiis: 'install-rhaiis',
+  ramalama: 'install-ramalama',
   // Registered by their own provider files, listed here for the dropdown
   'open-webui': 'install-open-webui',
   'claude-desktop': 'install-claude-desktop',

--- a/web/src/types/agent.ts
+++ b/web/src/types/agent.ts
@@ -31,6 +31,7 @@ export type AgentProvider =
   | 'vllm'            // vLLM - high-throughput GPU inference
   | 'lm-studio'       // LM Studio - workstation GUI runner
   | 'rhaiis'          // Red Hat AI Inference Server
+  | 'ramalama'        // RamaLama - OCI-packaged local model runtime
 
 // Capability flags matching backend ProviderCapability
 export const AgentCapabilityChat = 1


### PR DESCRIPTION
## Summary

Adds [RamaLama](https://ramalama.ai) to the chat-only local LLM runner registry alongside Ollama, llama.cpp, LocalAI, vLLM, LM Studio, and RHAIIS.

RamaLama packages models as OCI images and exposes an OpenAI-compatible server at `/v1/chat/completions` when started with `ramalama serve`, so it plugs into the shared `LocalOpenAICompatProvider` with zero new plumbing. Same pattern, same env-var-gated availability story as the other local runners.

## Changes

**Backend (`pkg/agent/`):**
- `provider_local_openai_compat.go`: `ProviderKeyRamalama`, `envRamalamaURL`, `NewRamalamaProvider()`
- `config.go`: API key / base URL / model env var mappings (`RAMALAMA_API_KEY`, `RAMALAMA_URL`, `RAMALAMA_MODEL`)
- `registry.go`: registration in `InitializeProviders()`

**Frontend (`web/src/`):**
- `types/agent.ts`: `'ramalama'` added to the `AgentProvider` union
- `components/agent/agentSelectorUtils.ts`: `install-ramalama` mission link for the dropdown
- `components/agent/AgentIcon.tsx`: inline SVG icon (llama silhouette inside an OCI shipping container, matching the OCI-packaging theme)

## How it works

RamaLama is off unless the operator points the console at one:

\`\`\`bash
export RAMALAMA_URL=http://localhost:8080
# optional:
export RAMALAMA_API_KEY=...
export RAMALAMA_MODEL=granite3-dense
\`\`\`

With none of those set, the provider reports \`Available: false\` and the agent selector offers the \`install-ramalama\` mission link (to be defined in \`kubestellar/console-kb\`).

## Test plan

- [x] \`go build ./...\`
- [x] \`go test ./pkg/agent/...\`
- [x] \`npm run build\`
- [x] ESLint clean on all touched files
- [ ] CI: build / lint / preview (Playwright may be ignored)
- [ ] Verify RamaLama appears in the agent selector dropdown with \`RAMALAMA_URL\` set
- [ ] Verify install link appears when \`RAMALAMA_URL\` is unset