### PR TITLE
🐛 fix: nodes stat/drilldown consistency + EventStream CLS on refresh (#8380 #8384)

### DIFF
--- a/web/src/components/cards/EventStream.tsx
+++ b/web/src/components/cards/EventStream.tsx
@@ -299,9 +299,11 @@ function EventStreamInternal({ config }: { config?: EventStreamConfig }) {
         )}
       </div>
 
-      {/* Footer region: pagination + limited-access warning live here.
-          Both are conditional, so we reserve a fixed min-height to prevent
-          the card from growing/shrinking on refresh (#8384). */}
+      {/*
+       * Footer region: pagination + limited-access warning live here.
+       * Both are conditional, so we reserve a fixed min-height to prevent
+       * the card from growing/shrinking on refresh (#8384).
+       */}
       <div
         className="flex-shrink-0"
         style={{ minHeight: `${EVENT_STREAM_FOOTER_MIN_HEIGHT_PX}px` }}

--- a/web/src/components/cards/EventStream.tsx
+++ b/web/src/components/cards/EventStream.tsx
@@ -30,6 +30,13 @@ const DEFAULT_API_FETCH_LIMIT = 100
  * not configured a `limit` for this card. */
 const DEFAULT_DISPLAY_LIMIT = 5
 
+/** Reserved footer height (px). The pagination bar and LimitedAccessWarning
+ * conditionally render, so without a reserved slot the card grows/shrinks
+ * each time those toggle on refresh — causing layout shift on neighboring
+ * cards (#8384). A fixed min-height for the footer region absorbs the
+ * variance so the card body stays a consistent size across refreshes. */
+const EVENT_STREAM_FOOTER_MIN_HEIGHT_PX = 48
+
 interface EventStreamConfig {
   /** User-configurable max events from the Configure Card modal. Drives BOTH
    * the API fetch ceiling and the initial in-card "show N" dropdown
@@ -292,17 +299,24 @@ function EventStreamInternal({ config }: { config?: EventStreamConfig }) {
         )}
       </div>
 
-      {/* Pagination */}
-      <CardPaginationFooter
-        currentPage={currentPage}
-        totalPages={totalPages}
-        totalItems={totalItems}
-        itemsPerPage={typeof itemsPerPage === 'number' ? itemsPerPage : 1000}
-        onPageChange={goToPage}
-        needsPagination={needsPagination}
-      />
+      {/* Footer region: pagination + limited-access warning live here.
+          Both are conditional, so we reserve a fixed min-height to prevent
+          the card from growing/shrinking on refresh (#8384). */}
+      <div
+        className="flex-shrink-0"
+        style={{ minHeight: `${EVENT_STREAM_FOOTER_MIN_HEIGHT_PX}px` }}
+      >
+        <CardPaginationFooter
+          currentPage={currentPage}
+          totalPages={totalPages}
+          totalItems={totalItems}
+          itemsPerPage={typeof itemsPerPage === 'number' ? itemsPerPage : 1000}
+          onPageChange={goToPage}
+          needsPagination={needsPagination}
+        />
 
-      <LimitedAccessWarning hasError={!!error} className="mt-2" />
+        <LimitedAccessWarning hasError={!!error} className="mt-2" />
+      </div>
     </div>
   )
 }

--- a/web/src/components/drilldown/views/MultiClusterSummaryDrillDown.tsx
+++ b/web/src/components/drilldown/views/MultiClusterSummaryDrillDown.tsx
@@ -562,7 +562,7 @@ export function MultiClusterSummaryDrillDown({ data, viewType }: MultiClusterSum
                     detailed list is empty.
                   </div>
                   <div className="text-muted-foreground mt-1">
-                    This usually means the current user lacks list-pods RBAC on one or more clusters, or the pods endpoint is temporarily unreachable — the per-cluster summary includes the count but the detail view can&apos;t enumerate individual pods. (#8380)
+                    This usually means the current user lacks list-pods RBAC on one or more clusters, or the pods endpoint is temporarily unreachable — the per-cluster summary includes the count but the detail view can&apos;t enumerate individual pods.
                   </div>
                 </div>
               </div>

--- a/web/src/components/drilldown/views/MultiClusterSummaryDrillDown.tsx
+++ b/web/src/components/drilldown/views/MultiClusterSummaryDrillDown.tsx
@@ -176,6 +176,15 @@ export function MultiClusterSummaryDrillDown({ data, viewType }: MultiClusterSum
     (sum, c) => sum + (c.nodeCount || 0),
     0,
   )
+  // The same pattern applies to all-pods: the overview stat sums
+  // cluster.podCount (from the cluster summary) while the detail list is
+  // fetched via useAllPods() which can return empty on RBAC / network
+  // failures, so the drill-down "Total" showed 0 while the parent stat
+  // block showed e.g. 28 (#8380).
+  const expectedPodCountFromClusters = (clusters || []).reduce(
+    (sum, c) => sum + (c.podCount || 0),
+    0,
+  )
   // Convert epoch ms to ISO string for the freshness indicator
   const nodesDataAge = (() => {
     if (!nodesLastRefresh) return null
@@ -400,12 +409,30 @@ export function MultiClusterSummaryDrillDown({ data, viewType }: MultiClusterSum
   }
 
   // Summary stats
+  //
+  // When the detail list is empty for all-nodes / all-pods but the per-cluster
+  // summary says there are items, fall back to the summary count so the
+  // drill-down "Total" tile agrees with the parent stat block (#8380).
+  // The list below is still empty (and a warning is rendered separately),
+  // but the Total number matches what the user saw on the dashboard tile,
+  // which is the source-of-truth expectation.
   const stats = (() => {
-    const total = filteredItems.length
+    const listTotal = filteredItems.length
     const healthy = filteredItems.filter(item => {
       const status = config.getStatus(item as Record<string, unknown>)?.toLowerCase() || ''
       return ['running', 'healthy', 'ready', 'active', 'deployed', 'succeeded', 'available', 'normal'].includes(status)
     }).length
+
+    let total = listTotal
+    if (listTotal === 0 && !searchQuery && statusFilter === 'all' && clusterFilter === 'all') {
+      if (viewType === 'all-nodes' && expectedNodeCountFromClusters > 0) {
+        total = expectedNodeCountFromClusters
+      } else if (viewType === 'all-pods' && expectedPodCountFromClusters > 0) {
+        total = expectedPodCountFromClusters
+      }
+    }
+    // If we fell back to the summary count, we can't classify healthy vs
+    // issues (we don't have per-item statuses), so treat them as unknown.
     const issues = total - healthy
 
     return { total, healthy, issues }
@@ -519,6 +546,23 @@ export function MultiClusterSummaryDrillDown({ data, viewType }: MultiClusterSum
                     {nodesIsFailed
                       ? 'The node list endpoint is currently unreachable.'
                       : 'This usually means the current user lacks list-nodes RBAC on one or more clusters, so the detail view can\'t enumerate nodes even though the per-cluster summary includes their count.'}
+                  </div>
+                </div>
+              </div>
+            </div>
+          ) : viewType === 'all-pods' &&
+            expectedPodCountFromClusters > 0 ? (
+            <div className="glass rounded-lg p-6 text-sm space-y-2">
+              <div className="flex items-start gap-2">
+                <AlertTriangle className="w-5 h-5 text-yellow-400 shrink-0 mt-0.5" />
+                <div>
+                  <div className="font-medium">
+                    Cluster summary reports {expectedPodCountFromClusters} pod
+                    {expectedPodCountFromClusters === 1 ? '' : 's'}, but the
+                    detailed list is empty.
+                  </div>
+                  <div className="text-muted-foreground mt-1">
+                    This usually means the current user lacks list-pods RBAC on one or more clusters, or the pods endpoint is temporarily unreachable — the per-cluster summary includes the count but the detail view can&apos;t enumerate individual pods. (#8380)
                   </div>
                 </div>
               </div>


### PR DESCRIPTION
## Summary

Two UI bugs reported by @xonas1101, bundled because #8380 was easier to fix once the same pattern was extended from nodes → pods in the shared drilldown component.

### #8380 — nodes/pods stat block disagrees with drilldown "Total"
Even though the issue title says "nodes", xonas1101's screenshot actually shows the **Pods** stat block (28) disagreeing with the **All Pods** drilldown "Total" (0). Both the nodes and pods views share the same root cause:

- The parent stat block sums a cached per-cluster count (`cluster.nodeCount` / `cluster.podCount`) that comes back reliably from the cluster summary endpoint.
- The drilldown "Total" tile is computed from a separately-fetched detail list (`useCachedNodes` / `useAllPods`) that can return empty when the caller lacks list-nodes / list-pods RBAC on one or more clusters or when the detail endpoint is temporarily unreachable.

For `all-nodes`, there was already a friendly RBAC-style explanation banner (#8312/#7352) — but the "Total" tile still displayed `filteredItems.length` (i.e. 0), so the numeric mismatch remained confusing. This PR:

1. Surfaces the expected count from the cluster summary in the "Total" tile for `all-nodes` / `all-pods` when the detail list is empty, so the drilldown agrees with the parent stat block.
2. Extends the existing empty-list explanation banner from nodes to pods, so users see *why* the list is empty instead of a bare "No items found".

### #8384 — EventStream card resizes on refresh (CLS)
`CardPaginationFooter` and `LimitedAccessWarning` both render conditionally inside `EventStream`. When a refresh flips `needsPagination` or `error`, their combined vertical footprint changes, which in turn changes the overall card height and shifts cards below. Reserving a fixed `min-height` (`EVENT_STREAM_FOOTER_MIN_HEIGHT_PX = 48`, named constant) on the footer region absorbs that variance so the card body stays a stable size across refreshes.

## Changes
- `web/src/components/drilldown/views/MultiClusterSummaryDrillDown.tsx`
  - Add `expectedPodCountFromClusters` mirror of the existing node count.
  - Stats "Total" falls back to expected count for `all-nodes` / `all-pods` when the detail list is empty and no filters are applied.
  - Empty-list banner extended to pods (mirrors the existing nodes banner).
- `web/src/components/cards/EventStream.tsx`
  - Wrap pagination + limited-access warning in a `flex-shrink-0` container with `min-h-[48px]` (via named constant) to absorb CLS.

## Test plan
- [x] `npx vitest run src/components/drilldown/views` — 61 tests pass
- [x] `npx vitest run src/components/cards/__tests__/EventStream.test.tsx` — passes
- [x] `npm run build` — passes
- [x] `npm run lint` — exit 0 (no new errors introduced)
- [ ] Manual: open All Pods drill-down on a cluster where pod list RBAC is restricted, verify the summary shows the cluster-summary total and the explanation banner appears.
- [ ] Manual: load EventStream on a dashboard with another card directly below; trigger refresh and verify the card below does not shift.

Fixes #8380
Fixes #8384