### PR TITLE
🐛 fix(watchdog): return JSON 503 for XHR/fetch calls, not HTML

### DIFF
--- a/cmd/console/watchdog.go
+++ b/cmd/console/watchdog.go
@@ -505,11 +505,35 @@ func pollBackendHealth(ctx context.Context, backendBase string, healthy *int32, 
 	}
 }
 
+// isAPIRequest returns true when the inbound request is an XHR/fetch call
+// rather than a top-level HTML navigation. The watchdog must hand those calls
+// a 503 JSON body, not the HTML fallback page — otherwise a cached page whose
+// `fetch('/api/…')` lands on the watchdog gets HTML back, the client JS tries
+// to parse it as JSON, and the UI control (e.g. the login button) silently
+// fails. `*/*` is the default `Accept` for browser `fetch()`, so Accept alone
+// can't disambiguate navigation from XHR.
+func isAPIRequest(r *http.Request) bool {
+	if strings.HasPrefix(r.URL.Path, "/api/") ||
+		strings.HasPrefix(r.URL.Path, "/ws/") ||
+		strings.HasPrefix(r.URL.Path, "/sse/") {
+		return true
+	}
+	if r.Method != http.MethodGet && r.Method != http.MethodHead {
+		return true
+	}
+	if strings.Contains(r.Header.Get("Accept"), "application/json") {
+		return true
+	}
+	return false
+}
+
 // serveFallback serves the appropriate response when the backend is down.
-// HTML requests get the branded reconnecting page; API requests get a 503 JSON response.
+// HTML navigations get the branded reconnecting page; API/XHR requests get a
+// 503 JSON response so client-side fetch handlers can react cleanly.
 func serveFallback(w http.ResponseWriter, r *http.Request) {
 	accept := r.Header.Get("Accept")
-	if strings.Contains(accept, "text/html") || accept == "" || accept == "*/*" {
+	wantsHTML := strings.Contains(accept, "text/html") || accept == "" || accept == "*/*"
+	if wantsHTML && !isAPIRequest(r) {
 		w.Header().Set("Content-Type", "text/html; charset=utf-8")
 		w.WriteHeader(http.StatusServiceUnavailable)
 		// Inject version info into the HTML template. Prefer the hash resolved

--- a/cmd/console/watchdog_test.go
+++ b/cmd/console/watchdog_test.go
@@ -152,3 +152,87 @@ func TestWatchdogProxiesDegradedBackend(t *testing.T) {
 		t.Errorf("expected version=test via proxy, got %q", body["version"])
 	}
 }
+
+func TestServeFallback_APIRequestGetsJSON(t *testing.T) {
+	// Regression: a fetch() call to /api/auth while the backend is booting
+	// must return a 503 JSON body, not the HTML fallback. Otherwise the
+	// caller's `response.json()` call blows up on the HTML and the login
+	// button silently fails. `*/*` is the default fetch() Accept header, so
+	// Accept-based content negotiation alone is insufficient.
+	cases := []struct {
+		name   string
+		method string
+		path   string
+		accept string
+	}{
+		{"default fetch POST to /api/auth", "POST", "/api/auth/login", "*/*"},
+		{"default fetch GET to /api/version", "GET", "/api/version", "*/*"},
+		{"empty Accept POST", "POST", "/api/anything", ""},
+		{"text/html Accept on /api still JSON", "GET", "/api/version", "text/html"},
+		{"explicit application/json", "GET", "/something", "application/json"},
+		{"WebSocket upgrade path", "GET", "/ws/events", "*/*"},
+		{"SSE path", "GET", "/sse/stream", "*/*"},
+		{"non-GET method on root", "POST", "/", "*/*"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			req := httptest.NewRequest(tc.method, tc.path, nil)
+			if tc.accept != "" {
+				req.Header.Set("Accept", tc.accept)
+			}
+			rec := httptest.NewRecorder()
+			serveFallback(rec, req)
+
+			if rec.Code != http.StatusServiceUnavailable {
+				t.Errorf("status = %d, want %d", rec.Code, http.StatusServiceUnavailable)
+			}
+			if got := rec.Header().Get("Content-Type"); got != "application/json" {
+				t.Errorf("Content-Type = %q, want application/json", got)
+			}
+			var body map[string]string
+			if err := json.NewDecoder(rec.Body).Decode(&body); err != nil {
+				t.Fatalf("response body is not JSON: %v", err)
+			}
+			if body["error"] != "backend_unavailable" {
+				t.Errorf("body error = %q, want backend_unavailable", body["error"])
+			}
+		})
+	}
+}
+
+func TestServeFallback_NavigationGetsHTML(t *testing.T) {
+	// Top-level HTML navigations (browser hitting / or /login directly) must
+	// still render the branded reconnecting page so the user sees something
+	// better than a raw 503.
+	cases := []struct {
+		name   string
+		method string
+		path   string
+		accept string
+	}{
+		{"GET / with HTML accept", "GET", "/", "text/html,application/xhtml+xml"},
+		{"GET / with */*", "GET", "/", "*/*"},
+		{"GET /login with HTML accept", "GET", "/login", "text/html"},
+		{"GET /login with empty accept", "GET", "/login", ""},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			req := httptest.NewRequest(tc.method, tc.path, nil)
+			if tc.accept != "" {
+				req.Header.Set("Accept", tc.accept)
+			}
+			rec := httptest.NewRecorder()
+			serveFallback(rec, req)
+
+			if rec.Code != http.StatusServiceUnavailable {
+				t.Errorf("status = %d, want %d", rec.Code, http.StatusServiceUnavailable)
+			}
+			ct := rec.Header().Get("Content-Type")
+			if ct != "text/html; charset=utf-8" {
+				t.Errorf("Content-Type = %q, want text/html; charset=utf-8", ct)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Watchdog's \`serveFallback\` treated \`Accept: */*\` as an HTML request. That's the default for browser \`fetch()\`, so XHR calls to \`/api/...\` landing on the watchdog got HTML back, the client's \`response.json()\` threw, and the UI control (login button) silently did nothing. Reload was required to actually land on the watchdog page.
- Introduce \`isAPIRequest()\`: \`/api/\`, \`/ws/\`, \`/sse/\` prefixes, any non-GET/HEAD method, or explicit \`Accept: application/json\` always return the 503 JSON body regardless of the \`Accept\` header. Top-level HTML navigations still render the branded reconnecting page.
- Table-driven tests cover the specific cases that reproduced the original bug (POST \`/api/auth/login\` with \`*/*\`), WebSocket/SSE paths, and navigation paths that must keep getting HTML.

## Reproducer (before this PR)

1. Have the console open with a valid login page loaded in the browser
2. Restart the backend (e.g. \`startup-oauth.sh\`) so the watchdog is serving while the backend boots
3. Click the login button → \`fetch('/api/auth/...')\` returns HTML → button does nothing
4. Reload → watchdog page finally appears

After this PR: the \`fetch\` call receives a 503 JSON response and the client JS can handle it cleanly (e.g. show a toast or reload).

## Test plan

- [x] \`go build ./...\`
- [x] \`go test ./cmd/console/...\` — new tests pass, existing tests unchanged
- [ ] CI: build / lint / preview (Playwright may be ignored)