### PR TITLE
✨ Port github-pipelines to Go backend for localhost/in-cluster deploys

### DIFF
--- a/pkg/api/handlers/github_pipelines.go
+++ b/pkg/api/handlers/github_pipelines.go
@@ -511,36 +511,23 @@ func (h *GitHubPipelinesHandler) fetchJobs(ctx context.Context, repo string, run
 
 func (h *GitHubPipelinesHandler) buildPulse(c *fiber.Ctx) (any, error) {
 	ctx := c.UserContext()
+	// Fetch all Release workflow runs (schedule + workflow_dispatch). Don't
+	// filter by event=schedule — manual dispatches are equally valid nightly
+	// runs and excluding them makes the pulse stale when the nightly was
+	// triggered manually (which is common after fixing a broken nightly).
 	runs, err := h.fetchRuns(
 		ctx,
 		ghpNightlyReleaseRepo,
-		fmt.Sprintf("per_page=%d&event=schedule", ghpPulseWindowDays),
+		fmt.Sprintf("per_page=%d", ghpPulseWindowDays),
 	)
 	if err != nil {
 		return nil, err
 	}
-	// Rebind name: workflow runs fetched via workflows/<file>/runs endpoint
-	// keep the workflow name; via /actions/runs filtered by event=schedule we
-	// get all scheduled runs, then filter to the Release workflow.
+	// /actions/runs returns ALL workflows — filter to Release only.
 	releaseRuns := make([]ghpWorkflowRun, 0, len(runs))
 	for _, r := range runs {
-		if strings.EqualFold(r.Name, "Release") || strings.EqualFold(r.Name, "release") {
+		if strings.EqualFold(r.Name, "Release") {
 			releaseRuns = append(releaseRuns, r)
-		}
-	}
-	if len(releaseRuns) == 0 {
-		// Fallback: try the workflow-specific endpoint
-		alt, altErr := h.fetchRuns(
-			ctx,
-			ghpNightlyReleaseRepo,
-			fmt.Sprintf("per_page=%d", ghpPulseWindowDays),
-		)
-		if altErr == nil {
-			for _, r := range alt {
-				if strings.EqualFold(r.Name, "Release") {
-					releaseRuns = append(releaseRuns, r)
-				}
-			}
 		}
 	}
 	h.history.merge(releaseRuns)

--- a/pkg/api/handlers/github_pipelines.go
+++ b/pkg/api/handlers/github_pipelines.go
@@ -1,0 +1,900 @@
+// Package handlers — GitHub Pipelines dashboard
+//
+// Go port of web/netlify/functions/github-pipelines.mts. Same six views,
+// same response shapes, same behavior. Lets the /ci-cd pipeline cards
+// work with live data in localhost and in-cluster deployments (the
+// Netlify Function only covers console.kubestellar.io).
+//
+// If two versions drift, the Netlify function is the canonical source.
+package handlers
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"sort"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/gofiber/fiber/v2"
+	"golang.org/x/sync/singleflight"
+)
+
+// ---------------------------------------------------------------------------
+// Constants — mirror web/netlify/functions/github-pipelines.mts
+// ---------------------------------------------------------------------------
+
+const (
+	ghpCacheTTL              = 2 * time.Minute
+	ghpMatrixDefaultDays     = 14
+	ghpMatrixMaxDays         = 90
+	ghpHistoryRetentionDays  = 90
+	ghpFailuresLimit         = 10
+	ghpFailuresOverfetch     = 30
+	ghpLogTailLines          = 500
+	ghpMatrixRunsPerRepo     = 100
+	ghpFlowMaxRunsPerRepo    = 8
+	ghpPulseWindowDays       = 14
+	ghpGitHubAPIBase         = "https://api.github.com"
+	ghpNightlyReleaseRepo    = "kubestellar/console"
+	ghpNightlyReleaseWFFile  = "release.yml"
+	ghpNightlyReleaseCron    = "0 5 * * *"
+	ghpHTTPTimeout           = 15 * time.Second
+	ghpMutationHTTPTimeout   = 15 * time.Second
+	ghpMaxErrorBodyBytes     = 10_000
+	ghpMatrixSparseMinCells  = 1
+)
+
+// ghpRepos is the canonical list scanned — same set /hygiene uses.
+var ghpRepos = []string{
+	"kubestellar/console",
+	"kubestellar/docs",
+	"kubestellar/console-kb",
+	"kubestellar/kubestellar-mcp",
+	"kubestellar/console-marketplace",
+	"kubestellar/homebrew-tap",
+}
+
+func ghpIsAllowedRepo(repo string) bool {
+	for _, r := range ghpRepos {
+		if r == repo {
+			return true
+		}
+	}
+	return false
+}
+
+// ---------------------------------------------------------------------------
+// Wire shapes — match the Netlify function's JSON exactly so the TS hook
+// doesn't have to know which backend served the response.
+// ---------------------------------------------------------------------------
+
+type ghpWorkflowRun struct {
+	ID          int64   `json:"id"`
+	Repo        string  `json:"repo"`
+	Name        string  `json:"name"`
+	WorkflowID  int64   `json:"workflowId"`
+	HeadBranch  string  `json:"headBranch"`
+	Status      string  `json:"status"`
+	Conclusion  *string `json:"conclusion"`
+	Event       string  `json:"event"`
+	RunNumber   int     `json:"runNumber"`
+	HTMLURL     string  `json:"htmlUrl"`
+	CreatedAt   string  `json:"createdAt"`
+	UpdatedAt   string  `json:"updatedAt"`
+}
+
+type ghpStep struct {
+	Name        string  `json:"name"`
+	Status      string  `json:"status"`
+	Conclusion  *string `json:"conclusion"`
+	Number      int     `json:"number"`
+	StartedAt   string  `json:"startedAt,omitempty"`
+	CompletedAt string  `json:"completedAt,omitempty"`
+}
+
+type ghpJob struct {
+	ID          int64     `json:"id"`
+	Name        string    `json:"name"`
+	Status      string    `json:"status"`
+	Conclusion  *string   `json:"conclusion"`
+	StartedAt   *string   `json:"startedAt"`
+	CompletedAt *string   `json:"completedAt"`
+	HTMLURL     string    `json:"htmlUrl"`
+	Steps       []ghpStep `json:"steps"`
+}
+
+type ghpPulseLastRun struct {
+	Conclusion *string `json:"conclusion"`
+	CreatedAt  string  `json:"createdAt"`
+	HTMLURL    string  `json:"htmlUrl"`
+	RunNumber  int     `json:"runNumber"`
+	ReleaseTag *string `json:"releaseTag"`
+}
+
+type ghpPulseRecent struct {
+	Conclusion *string `json:"conclusion"`
+	CreatedAt  string  `json:"createdAt"`
+	HTMLURL    string  `json:"htmlUrl"`
+}
+
+type ghpPulsePayload struct {
+	LastRun    *ghpPulseLastRun `json:"lastRun"`
+	Streak     int              `json:"streak"`
+	StreakKind string           `json:"streakKind"`
+	Recent     []ghpPulseRecent `json:"recent"`
+	NextCron   string           `json:"nextCron"`
+}
+
+type ghpMatrixCell struct {
+	Date       string  `json:"date"`
+	Conclusion *string `json:"conclusion"`
+	HTMLURL    string  `json:"htmlUrl"`
+}
+
+type ghpMatrixWorkflow struct {
+	Repo  string          `json:"repo"`
+	Name  string          `json:"name"`
+	Cells []ghpMatrixCell `json:"cells"`
+}
+
+type ghpMatrixPayload struct {
+	Days      int                 `json:"days"`
+	Range     []string            `json:"range"`
+	Workflows []ghpMatrixWorkflow `json:"workflows"`
+}
+
+type ghpFlowRun struct {
+	Run  ghpWorkflowRun `json:"run"`
+	Jobs []ghpJob       `json:"jobs"`
+}
+
+type ghpFlowPayload struct {
+	Runs []ghpFlowRun `json:"runs"`
+}
+
+type ghpFailedStep struct {
+	JobID    int64  `json:"jobId"`
+	JobName  string `json:"jobName"`
+	StepName string `json:"stepName"`
+}
+
+type ghpFailureRow struct {
+	Repo       string         `json:"repo"`
+	RunID      int64          `json:"runId"`
+	Workflow   string         `json:"workflow"`
+	HTMLURL    string         `json:"htmlUrl"`
+	Branch     string         `json:"branch"`
+	Event      string         `json:"event"`
+	Conclusion *string        `json:"conclusion"`
+	CreatedAt  string         `json:"createdAt"`
+	DurationMs int64          `json:"durationMs"`
+	FailedStep *ghpFailedStep `json:"failedStep"`
+}
+
+type ghpFailuresPayload struct {
+	Runs []ghpFailureRow `json:"runs"`
+}
+
+type ghpLogPayload struct {
+	Lines         int    `json:"lines"`
+	TruncatedFrom int    `json:"truncatedFrom"`
+	Log           string `json:"log"`
+}
+
+// ---------------------------------------------------------------------------
+// History — in-memory rolling 90-day record of per-workflow daily outcomes.
+// Lost on process restart; re-seeded from GitHub on the next request. GitHub
+// keeps 14 days of run history, so restart means the 30/90 day views are
+// thin until the process accumulates again.
+// ---------------------------------------------------------------------------
+
+type ghpHistoryDay struct {
+	RunID      int64
+	Conclusion *string
+	HTMLURL    string
+}
+
+type ghpHistory struct {
+	mu sync.RWMutex
+	// repo -> workflow name -> dateKey (YYYY-MM-DD) -> ghpHistoryDay
+	days map[string]map[string]map[string]ghpHistoryDay
+}
+
+func newGHPHistory() *ghpHistory {
+	return &ghpHistory{days: make(map[string]map[string]map[string]ghpHistoryDay)}
+}
+
+func (h *ghpHistory) merge(runs []ghpWorkflowRun) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	for _, r := range runs {
+		if len(r.CreatedAt) < 10 {
+			continue
+		}
+		day := r.CreatedAt[:10]
+		byRepo, ok := h.days[r.Repo]
+		if !ok {
+			byRepo = make(map[string]map[string]ghpHistoryDay)
+			h.days[r.Repo] = byRepo
+		}
+		byWF, ok := byRepo[r.Name]
+		if !ok {
+			byWF = make(map[string]ghpHistoryDay)
+			byRepo[r.Name] = byWF
+		}
+		existing, had := byWF[day]
+		if !had || r.ID > existing.RunID {
+			byWF[day] = ghpHistoryDay{RunID: r.ID, Conclusion: r.Conclusion, HTMLURL: r.HTMLURL}
+		}
+	}
+	// Trim to retention window
+	cutoff := time.Now().AddDate(0, 0, -ghpHistoryRetentionDays).Format("2006-01-02")
+	for repo, byRepo := range h.days {
+		for wf, byWF := range byRepo {
+			for d := range byWF {
+				if d < cutoff {
+					delete(byWF, d)
+				}
+			}
+			if len(byWF) == 0 {
+				delete(byRepo, wf)
+			}
+		}
+		if len(byRepo) == 0 {
+			delete(h.days, repo)
+		}
+	}
+}
+
+func (h *ghpHistory) snapshot() map[string]map[string]map[string]ghpHistoryDay {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
+	out := make(map[string]map[string]map[string]ghpHistoryDay, len(h.days))
+	for repo, byRepo := range h.days {
+		rMap := make(map[string]map[string]ghpHistoryDay, len(byRepo))
+		out[repo] = rMap
+		for wf, byWF := range byRepo {
+			wMap := make(map[string]ghpHistoryDay, len(byWF))
+			rMap[wf] = wMap
+			for d, v := range byWF {
+				wMap[d] = v
+			}
+		}
+	}
+	return out
+}
+
+// ---------------------------------------------------------------------------
+// Handler
+// ---------------------------------------------------------------------------
+
+// GitHubPipelinesHandler serves /api/github-pipelines.
+type GitHubPipelinesHandler struct {
+	token         string
+	mutationToken string
+	httpClient    *http.Client
+	history       *ghpHistory
+
+	mu       sync.RWMutex
+	cache    map[string]ghpCacheEntry // cacheKey -> entry
+	fetchGrp singleflight.Group
+}
+
+type ghpCacheEntry struct {
+	body []byte
+	exp  time.Time
+}
+
+// NewGitHubPipelinesHandler constructs the handler. `githubToken` is the
+// read-only PAT. Mutation token comes from GITHUB_MUTATIONS_TOKEN env var
+// — if unset, mutations return 503.
+func NewGitHubPipelinesHandler(githubToken string) *GitHubPipelinesHandler {
+	return &GitHubPipelinesHandler{
+		token:         githubToken,
+		mutationToken: os.Getenv("GITHUB_MUTATIONS_TOKEN"),
+		httpClient:    &http.Client{Timeout: ghpHTTPTimeout},
+		history:       newGHPHistory(),
+		cache:         make(map[string]ghpCacheEntry),
+	}
+}
+
+// Serve routes a request to the right view.
+func (h *GitHubPipelinesHandler) Serve(c *fiber.Ctx) error {
+	view := c.Query("view", "pulse")
+	method := c.Method()
+
+	if view == "mutate" {
+		if method != fiber.MethodPost {
+			return c.Status(fiber.StatusMethodNotAllowed).JSON(fiber.Map{"error": "Mutations require POST"})
+		}
+		return h.handleMutate(c)
+	}
+	if method != fiber.MethodGet {
+		return c.Status(fiber.StatusMethodNotAllowed).JSON(fiber.Map{"error": "GET required"})
+	}
+
+	if h.token == "" {
+		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{"error": "GITHUB_TOKEN not configured"})
+	}
+
+	switch view {
+	case "pulse":
+		return h.serveCached(c, h.cacheKey(c), h.buildPulse)
+	case "matrix":
+		return h.serveCached(c, h.cacheKey(c), h.buildMatrixFromQuery)
+	case "flow":
+		return h.serveCached(c, h.cacheKey(c), h.buildFlowFromQuery)
+	case "failures":
+		return h.serveCached(c, h.cacheKey(c), h.buildFailuresFromQuery)
+	case "log":
+		return h.handleLog(c)
+	default:
+		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"error": "Unknown view: " + view})
+	}
+}
+
+func (h *GitHubPipelinesHandler) cacheKey(c *fiber.Ctx) string {
+	return fmt.Sprintf("%s:%s:%s:%s",
+		c.Query("view"),
+		c.Query("repo", "all"),
+		c.Query("days"),
+		c.Query("job"),
+	)
+}
+
+func (h *GitHubPipelinesHandler) serveCached(c *fiber.Ctx, key string, build func(c *fiber.Ctx) (any, error)) error {
+	h.mu.RLock()
+	entry, ok := h.cache[key]
+	h.mu.RUnlock()
+	if ok && time.Now().Before(entry.exp) {
+		c.Set("X-Cache", "HIT")
+		c.Set(fiber.HeaderContentType, fiber.MIMEApplicationJSON)
+		c.Set(fiber.HeaderCacheControl, fmt.Sprintf("public, max-age=%d", int(ghpCacheTTL.Seconds())))
+		return c.Send(entry.body)
+	}
+
+	// Coalesce concurrent cold fetches
+	v, err, _ := h.fetchGrp.Do(key, func() (any, error) {
+		return build(c)
+	})
+	if err != nil {
+		return c.Status(fiber.StatusBadGateway).JSON(fiber.Map{"error": err.Error()})
+	}
+	body, err := json.Marshal(v)
+	if err != nil {
+		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{"error": "marshal failed"})
+	}
+	h.mu.Lock()
+	h.cache[key] = ghpCacheEntry{body: body, exp: time.Now().Add(ghpCacheTTL)}
+	h.mu.Unlock()
+	c.Set("X-Cache", "MISS")
+	c.Set(fiber.HeaderContentType, fiber.MIMEApplicationJSON)
+	c.Set(fiber.HeaderCacheControl, fmt.Sprintf("public, max-age=%d", int(ghpCacheTTL.Seconds())))
+	return c.Send(body)
+}
+
+// ---------------------------------------------------------------------------
+// GitHub API helpers
+// ---------------------------------------------------------------------------
+
+func (h *GitHubPipelinesHandler) ghGet(ctx context.Context, path string) (*http.Response, error) {
+	url := path
+	if !strings.HasPrefix(url, "http") {
+		url = ghpGitHubAPIBase + path
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Accept", "application/vnd.github.v3+json")
+	req.Header.Set("Authorization", "Bearer "+h.token)
+	return h.httpClient.Do(req)
+}
+
+// workflowRunsRaw is the subset of GitHub's workflow_run JSON we consume.
+type workflowRunRaw struct {
+	ID         int64   `json:"id"`
+	Name       string  `json:"name"`
+	WorkflowID int64   `json:"workflow_id"`
+	HeadBranch string  `json:"head_branch"`
+	Status     string  `json:"status"`
+	Conclusion *string `json:"conclusion"`
+	Event      string  `json:"event"`
+	RunNumber  int     `json:"run_number"`
+	HTMLURL    string  `json:"html_url"`
+	CreatedAt  string  `json:"created_at"`
+	UpdatedAt  string  `json:"updated_at"`
+}
+
+func normalizeRunRaw(r workflowRunRaw, repo string) ghpWorkflowRun {
+	return ghpWorkflowRun{
+		ID:         r.ID,
+		Repo:       repo,
+		Name:       r.Name,
+		WorkflowID: r.WorkflowID,
+		HeadBranch: r.HeadBranch,
+		Status:     r.Status,
+		Conclusion: r.Conclusion,
+		Event:      r.Event,
+		RunNumber:  r.RunNumber,
+		HTMLURL:    r.HTMLURL,
+		CreatedAt:  r.CreatedAt,
+		UpdatedAt:  r.UpdatedAt,
+	}
+}
+
+func (h *GitHubPipelinesHandler) fetchRuns(ctx context.Context, repo, query string) ([]ghpWorkflowRun, error) {
+	res, err := h.ghGet(ctx, fmt.Sprintf("/repos/%s/actions/runs?%s", repo, query))
+	if err != nil {
+		return nil, err
+	}
+	defer res.Body.Close()
+	if res.StatusCode == http.StatusNotFound {
+		return nil, nil
+	}
+	if res.StatusCode >= 400 {
+		body, _ := io.ReadAll(io.LimitReader(res.Body, ghpMaxErrorBodyBytes))
+		return nil, fmt.Errorf("github %d: %s", res.StatusCode, string(body))
+	}
+	var data struct {
+		WorkflowRuns []workflowRunRaw `json:"workflow_runs"`
+	}
+	if err := json.NewDecoder(res.Body).Decode(&data); err != nil {
+		return nil, err
+	}
+	out := make([]ghpWorkflowRun, 0, len(data.WorkflowRuns))
+	for _, r := range data.WorkflowRuns {
+		out = append(out, normalizeRunRaw(r, repo))
+	}
+	return out, nil
+}
+
+func (h *GitHubPipelinesHandler) fetchJobs(ctx context.Context, repo string, runID int64) ([]ghpJob, error) {
+	res, err := h.ghGet(ctx, fmt.Sprintf("/repos/%s/actions/runs/%d/jobs", repo, runID))
+	if err != nil {
+		return nil, err
+	}
+	defer res.Body.Close()
+	if res.StatusCode >= 400 {
+		body, _ := io.ReadAll(io.LimitReader(res.Body, ghpMaxErrorBodyBytes))
+		return nil, fmt.Errorf("github %d: %s", res.StatusCode, string(body))
+	}
+	var data struct {
+		Jobs []struct {
+			ID          int64   `json:"id"`
+			Name        string  `json:"name"`
+			Status      string  `json:"status"`
+			Conclusion  *string `json:"conclusion"`
+			StartedAt   *string `json:"started_at"`
+			CompletedAt *string `json:"completed_at"`
+			HTMLURL     string  `json:"html_url"`
+			Steps       []struct {
+				Name        string  `json:"name"`
+				Status      string  `json:"status"`
+				Conclusion  *string `json:"conclusion"`
+				Number      int     `json:"number"`
+				StartedAt   string  `json:"started_at"`
+				CompletedAt string  `json:"completed_at"`
+			} `json:"steps"`
+		} `json:"jobs"`
+	}
+	if err := json.NewDecoder(res.Body).Decode(&data); err != nil {
+		return nil, err
+	}
+	jobs := make([]ghpJob, 0, len(data.Jobs))
+	for _, j := range data.Jobs {
+		steps := make([]ghpStep, 0, len(j.Steps))
+		for _, s := range j.Steps {
+			steps = append(steps, ghpStep{
+				Name: s.Name, Status: s.Status, Conclusion: s.Conclusion,
+				Number: s.Number, StartedAt: s.StartedAt, CompletedAt: s.CompletedAt,
+			})
+		}
+		jobs = append(jobs, ghpJob{
+			ID: j.ID, Name: j.Name, Status: j.Status, Conclusion: j.Conclusion,
+			StartedAt: j.StartedAt, CompletedAt: j.CompletedAt, HTMLURL: j.HTMLURL,
+			Steps: steps,
+		})
+	}
+	return jobs, nil
+}
+
+// ---------------------------------------------------------------------------
+// Pulse
+// ---------------------------------------------------------------------------
+
+func (h *GitHubPipelinesHandler) buildPulse(c *fiber.Ctx) (any, error) {
+	ctx := c.UserContext()
+	runs, err := h.fetchRuns(
+		ctx,
+		ghpNightlyReleaseRepo,
+		fmt.Sprintf("per_page=%d&event=schedule", ghpPulseWindowDays),
+	)
+	if err != nil {
+		return nil, err
+	}
+	// Rebind name: workflow runs fetched via workflows/<file>/runs endpoint
+	// keep the workflow name; via /actions/runs filtered by event=schedule we
+	// get all scheduled runs, then filter to the Release workflow.
+	releaseRuns := make([]ghpWorkflowRun, 0, len(runs))
+	for _, r := range runs {
+		if strings.EqualFold(r.Name, "Release") || strings.EqualFold(r.Name, "release") {
+			releaseRuns = append(releaseRuns, r)
+		}
+	}
+	if len(releaseRuns) == 0 {
+		// Fallback: try the workflow-specific endpoint
+		alt, altErr := h.fetchRuns(
+			ctx,
+			ghpNightlyReleaseRepo,
+			fmt.Sprintf("per_page=%d", ghpPulseWindowDays),
+		)
+		if altErr == nil {
+			for _, r := range alt {
+				if strings.EqualFold(r.Name, "Release") {
+					releaseRuns = append(releaseRuns, r)
+				}
+			}
+		}
+	}
+	h.history.merge(releaseRuns)
+
+	// Latest release tag (best-effort)
+	var releaseTag *string
+	relRes, relErr := h.ghGet(ctx, "/repos/"+ghpNightlyReleaseRepo+"/releases?per_page=1")
+	if relErr == nil {
+		defer relRes.Body.Close()
+		if relRes.StatusCode == http.StatusOK {
+			var arr []struct {
+				TagName string `json:"tag_name"`
+			}
+			if dec := json.NewDecoder(relRes.Body).Decode(&arr); dec == nil && len(arr) > 0 {
+				tag := arr[0].TagName
+				releaseTag = &tag
+			}
+		}
+	}
+
+	var lastRun *ghpPulseLastRun
+	streak := 0
+	streakKind := "mixed"
+	if len(releaseRuns) > 0 {
+		first := releaseRuns[0]
+		lastRun = &ghpPulseLastRun{
+			Conclusion: first.Conclusion,
+			CreatedAt:  first.CreatedAt,
+			HTMLURL:    first.HTMLURL,
+			RunNumber:  first.RunNumber,
+			ReleaseTag: releaseTag,
+		}
+		kind := ghpStreakKind(first.Conclusion)
+		if kind != "" {
+			streakKind = kind
+			for _, r := range releaseRuns {
+				if ghpStreakKind(r.Conclusion) == kind {
+					streak++
+				} else {
+					break
+				}
+			}
+		}
+	}
+
+	// recent: oldest → newest (reverse of the API's newest-first ordering)
+	window := releaseRuns
+	if len(window) > ghpPulseWindowDays {
+		window = window[:ghpPulseWindowDays]
+	}
+	recent := make([]ghpPulseRecent, 0, len(window))
+	for i := len(window) - 1; i >= 0; i-- {
+		r := window[i]
+		recent = append(recent, ghpPulseRecent{
+			Conclusion: r.Conclusion, CreatedAt: r.CreatedAt, HTMLURL: r.HTMLURL,
+		})
+	}
+
+	return ghpPulsePayload{
+		LastRun:    lastRun,
+		Streak:     streak,
+		StreakKind: streakKind,
+		Recent:     recent,
+		NextCron:   ghpNightlyReleaseCron,
+	}, nil
+}
+
+func ghpStreakKind(c *string) string {
+	if c == nil {
+		return ""
+	}
+	switch *c {
+	case "success":
+		return "success"
+	case "failure", "timed_out":
+		return "failure"
+	}
+	return ""
+}
+
+// ---------------------------------------------------------------------------
+// Matrix
+// ---------------------------------------------------------------------------
+
+func (h *GitHubPipelinesHandler) buildMatrixFromQuery(c *fiber.Ctx) (any, error) {
+	days := ghpMatrixDefaultDays
+	if d := c.Query("days"); d != "" {
+		n, err := strconv.Atoi(d)
+		if err == nil && n > 0 {
+			if n > ghpMatrixMaxDays {
+				n = ghpMatrixMaxDays
+			}
+			days = n
+		}
+	}
+	repoFilter := c.Query("repo")
+	repos := ghpRepos
+	if repoFilter != "" {
+		if !ghpIsAllowedRepo(repoFilter) {
+			return nil, fmt.Errorf("unknown repo")
+		}
+		repos = []string{repoFilter}
+	}
+
+	ctx := c.UserContext()
+	fresh := make([]ghpWorkflowRun, 0, 256)
+	for _, repo := range repos {
+		runs, err := h.fetchRuns(ctx, repo, fmt.Sprintf("per_page=%d", ghpMatrixRunsPerRepo))
+		if err != nil {
+			// per-repo failures shouldn't nuke the whole matrix
+			continue
+		}
+		fresh = append(fresh, runs...)
+	}
+	h.history.merge(fresh)
+	snap := h.history.snapshot()
+
+	// Build date range oldest → newest
+	rangeDates := make([]string, 0, days)
+	for i := days - 1; i >= 0; i-- {
+		rangeDates = append(rangeDates, time.Now().AddDate(0, 0, -i).Format("2006-01-02"))
+	}
+
+	workflows := make([]ghpMatrixWorkflow, 0, 32)
+	for _, repo := range repos {
+		byWF, ok := snap[repo]
+		if !ok {
+			continue
+		}
+		wfNames := make([]string, 0, len(byWF))
+		for name := range byWF {
+			wfNames = append(wfNames, name)
+		}
+		sort.Strings(wfNames)
+		for _, name := range wfNames {
+			cells := make([]ghpMatrixCell, 0, len(rangeDates))
+			populated := 0
+			for _, d := range rangeDates {
+				day, had := byWF[name][d]
+				if had {
+					populated++
+					cells = append(cells, ghpMatrixCell{Date: d, Conclusion: day.Conclusion, HTMLURL: day.HTMLURL})
+				} else {
+					cells = append(cells, ghpMatrixCell{Date: d, Conclusion: nil, HTMLURL: ""})
+				}
+			}
+			if populated < ghpMatrixSparseMinCells {
+				continue
+			}
+			workflows = append(workflows, ghpMatrixWorkflow{Repo: repo, Name: name, Cells: cells})
+		}
+	}
+	return ghpMatrixPayload{Days: days, Range: rangeDates, Workflows: workflows}, nil
+}
+
+// ---------------------------------------------------------------------------
+// Flow
+// ---------------------------------------------------------------------------
+
+func (h *GitHubPipelinesHandler) buildFlowFromQuery(c *fiber.Ctx) (any, error) {
+	repoFilter := c.Query("repo")
+	repos := ghpRepos
+	if repoFilter != "" {
+		if !ghpIsAllowedRepo(repoFilter) {
+			return nil, fmt.Errorf("unknown repo")
+		}
+		repos = []string{repoFilter}
+	}
+
+	ctx := c.UserContext()
+	var all []ghpFlowRun
+	for _, repo := range repos {
+		inProgress, errP := h.fetchRuns(ctx, repo, fmt.Sprintf("status=in_progress&per_page=%d", ghpFlowMaxRunsPerRepo))
+		if errP != nil {
+			continue
+		}
+		queued, errQ := h.fetchRuns(ctx, repo, fmt.Sprintf("status=queued&per_page=%d", ghpFlowMaxRunsPerRepo))
+		if errQ != nil {
+			// partial OK
+			queued = nil
+		}
+		runs := append(inProgress, queued...)
+		for _, r := range runs {
+			jobs, err := h.fetchJobs(ctx, repo, r.ID)
+			if err != nil {
+				continue
+			}
+			all = append(all, ghpFlowRun{Run: r, Jobs: jobs})
+		}
+	}
+	// Newest first by createdAt (lexical works for ISO strings)
+	sort.Slice(all, func(i, j int) bool {
+		return all[i].Run.CreatedAt > all[j].Run.CreatedAt
+	})
+	return ghpFlowPayload{Runs: all}, nil
+}
+
+// ---------------------------------------------------------------------------
+// Failures
+// ---------------------------------------------------------------------------
+
+func (h *GitHubPipelinesHandler) buildFailuresFromQuery(c *fiber.Ctx) (any, error) {
+	repoFilter := c.Query("repo")
+	repos := ghpRepos
+	if repoFilter != "" {
+		if !ghpIsAllowedRepo(repoFilter) {
+			return nil, fmt.Errorf("unknown repo")
+		}
+		repos = []string{repoFilter}
+	}
+
+	ctx := c.UserContext()
+	var rows []ghpFailureRow
+	for _, repo := range repos {
+		runs, err := h.fetchRuns(ctx, repo, fmt.Sprintf("status=failure&per_page=%d", ghpFailuresOverfetch))
+		if err != nil {
+			continue
+		}
+		for _, r := range runs {
+			created, _ := time.Parse(time.RFC3339, r.CreatedAt)
+			updated, _ := time.Parse(time.RFC3339, r.UpdatedAt)
+			dur := updated.Sub(created).Milliseconds()
+			if dur < 0 {
+				dur = 0
+			}
+			rows = append(rows, ghpFailureRow{
+				Repo:       repo,
+				RunID:      r.ID,
+				Workflow:   r.Name,
+				HTMLURL:    r.HTMLURL,
+				Branch:     r.HeadBranch,
+				Event:      r.Event,
+				Conclusion: r.Conclusion,
+				CreatedAt:  r.CreatedAt,
+				DurationMs: dur,
+			})
+		}
+	}
+	sort.Slice(rows, func(i, j int) bool {
+		return rows[i].CreatedAt > rows[j].CreatedAt
+	})
+	if len(rows) > ghpFailuresLimit {
+		rows = rows[:ghpFailuresLimit]
+	}
+	// Identify first failed step per row (best-effort)
+	for i := range rows {
+		jobs, err := h.fetchJobs(ctx, rows[i].Repo, rows[i].RunID)
+		if err != nil {
+			continue
+		}
+		for _, j := range jobs {
+			if j.Conclusion == nil || *j.Conclusion != "failure" {
+				continue
+			}
+			for _, s := range j.Steps {
+				if s.Conclusion != nil && *s.Conclusion == "failure" {
+					rows[i].FailedStep = &ghpFailedStep{
+						JobID:    j.ID,
+						JobName:  j.Name,
+						StepName: s.Name,
+					}
+					break
+				}
+			}
+			if rows[i].FailedStep != nil {
+				break
+			}
+		}
+	}
+	return ghpFailuresPayload{Runs: rows}, nil
+}
+
+// ---------------------------------------------------------------------------
+// Log
+// ---------------------------------------------------------------------------
+
+func (h *GitHubPipelinesHandler) handleLog(c *fiber.Ctx) error {
+	repo := c.Query("repo")
+	jobStr := c.Query("job")
+	if !ghpIsAllowedRepo(repo) || jobStr == "" {
+		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"error": "repo and job required"})
+	}
+	ctx := c.UserContext()
+	res, err := h.ghGet(ctx, fmt.Sprintf("/repos/%s/actions/jobs/%s/logs", repo, jobStr))
+	if err != nil {
+		return c.Status(fiber.StatusBadGateway).JSON(fiber.Map{"error": err.Error()})
+	}
+	defer res.Body.Close()
+	if res.StatusCode == http.StatusNotFound {
+		return c.Status(fiber.StatusNotFound).JSON(fiber.Map{"error": "Log not available (may have been purged)"})
+	}
+	if res.StatusCode >= 400 {
+		return c.Status(fiber.StatusBadGateway).JSON(fiber.Map{"error": fmt.Sprintf("github %d", res.StatusCode)})
+	}
+	body, err := io.ReadAll(res.Body)
+	if err != nil {
+		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{"error": "read failed"})
+	}
+	lines := strings.Split(string(body), "\n")
+	total := len(lines)
+	start := total - ghpLogTailLines
+	if start < 0 {
+		start = 0
+	}
+	return c.JSON(ghpLogPayload{
+		Lines:         ghpLogTailLines,
+		TruncatedFrom: total,
+		Log:           strings.Join(lines[start:], "\n"),
+	})
+}
+
+// ---------------------------------------------------------------------------
+// Mutate
+// ---------------------------------------------------------------------------
+
+func (h *GitHubPipelinesHandler) handleMutate(c *fiber.Ctx) error {
+	if h.mutationToken == "" {
+		// Intentional: local/in-cluster deploys default to read-only. Operator
+		// opts in by setting GITHUB_MUTATIONS_TOKEN. See README.
+		return c.Status(fiber.StatusServiceUnavailable).JSON(fiber.Map{"error": "Workflow mutations disabled on this deployment"})
+	}
+	op := c.Query("op")
+	repo := c.Query("repo")
+	run := c.Query("run")
+	if !ghpIsAllowedRepo(repo) {
+		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"error": "Unknown repo"})
+	}
+	var path string
+	switch op {
+	case "rerun":
+		path = fmt.Sprintf("/repos/%s/actions/runs/%s/rerun", repo, run)
+	case "cancel":
+		path = fmt.Sprintf("/repos/%s/actions/runs/%s/cancel", repo, run)
+	default:
+		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"error": "Unknown op"})
+	}
+
+	// Use a short-timeout client specifically for the mutation
+	ctx, cancel := context.WithTimeout(c.UserContext(), ghpMutationHTTPTimeout)
+	defer cancel()
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, ghpGitHubAPIBase+path, nil)
+	if err != nil {
+		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{"error": err.Error()})
+	}
+	req.Header.Set("Accept", "application/vnd.github.v3+json")
+	req.Header.Set("Authorization", "Bearer "+h.mutationToken)
+	res, err := h.httpClient.Do(req)
+	if err != nil {
+		return c.Status(fiber.StatusBadGateway).JSON(fiber.Map{"error": err.Error()})
+	}
+	defer res.Body.Close()
+	if res.StatusCode >= 400 {
+		body, _ := io.ReadAll(io.LimitReader(res.Body, ghpMaxErrorBodyBytes))
+		return c.Status(fiber.StatusBadGateway).JSON(fiber.Map{"error": fmt.Sprintf("github %d: %s", res.StatusCode, string(body))})
+	}
+	return c.JSON(fiber.Map{"ok": true, "op": op, "run": run, "repo": repo})
+}

--- a/pkg/api/handlers/github_pipelines_test.go
+++ b/pkg/api/handlers/github_pipelines_test.go
@@ -1,0 +1,167 @@
+package handlers
+
+import (
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/gofiber/fiber/v2"
+)
+
+func newGHPTestApp(t *testing.T, token, mutationToken string) *fiber.App {
+	t.Helper()
+	t.Setenv("GITHUB_MUTATIONS_TOKEN", mutationToken)
+	h := NewGitHubPipelinesHandler(token)
+	app := fiber.New()
+	app.Get("/api/github-pipelines", h.Serve)
+	app.Post("/api/github-pipelines", h.Serve)
+	return app
+}
+
+func TestGitHubPipelines_MissingTokenReturns500(t *testing.T) {
+	app := newGHPTestApp(t, "", "")
+	req := httptest.NewRequest("GET", "/api/github-pipelines?view=pulse", nil)
+	res, err := app.Test(req, -1)
+	if err != nil {
+		t.Fatalf("app.Test: %v", err)
+	}
+	if res.StatusCode != 500 {
+		t.Fatalf("expected 500 when GITHUB_TOKEN is empty, got %d", res.StatusCode)
+	}
+}
+
+func TestGitHubPipelines_UnknownViewReturns400(t *testing.T) {
+	app := newGHPTestApp(t, "fake-token", "")
+	req := httptest.NewRequest("GET", "/api/github-pipelines?view=bogus", nil)
+	res, err := app.Test(req, -1)
+	if err != nil {
+		t.Fatalf("app.Test: %v", err)
+	}
+	if res.StatusCode != 400 {
+		t.Fatalf("expected 400 for unknown view, got %d", res.StatusCode)
+	}
+}
+
+func TestGitHubPipelines_MutateDisabledWhenNoMutationToken(t *testing.T) {
+	// Intentional: local/in-cluster deploys are read-only by default.
+	// Mutations only enable when GITHUB_MUTATIONS_TOKEN is set.
+	app := newGHPTestApp(t, "fake-token", "")
+	req := httptest.NewRequest("POST", "/api/github-pipelines?view=mutate&op=rerun&repo=kubestellar/console&run=1", nil)
+	res, err := app.Test(req, -1)
+	if err != nil {
+		t.Fatalf("app.Test: %v", err)
+	}
+	if res.StatusCode != 503 {
+		t.Fatalf("expected 503 when mutations disabled, got %d", res.StatusCode)
+	}
+}
+
+func TestGitHubPipelines_MutateRejectsUnknownRepo(t *testing.T) {
+	app := newGHPTestApp(t, "fake-token", "fake-mutation-token")
+	req := httptest.NewRequest("POST", "/api/github-pipelines?view=mutate&op=rerun&repo=evil/repo&run=1", nil)
+	res, err := app.Test(req, -1)
+	if err != nil {
+		t.Fatalf("app.Test: %v", err)
+	}
+	if res.StatusCode != 400 {
+		t.Fatalf("expected 400 for disallowed repo, got %d", res.StatusCode)
+	}
+}
+
+func TestGitHubPipelines_MutateRejectsUnknownOp(t *testing.T) {
+	app := newGHPTestApp(t, "fake-token", "fake-mutation-token")
+	req := httptest.NewRequest("POST", "/api/github-pipelines?view=mutate&op=delete&repo=kubestellar/console&run=1", nil)
+	res, err := app.Test(req, -1)
+	if err != nil {
+		t.Fatalf("app.Test: %v", err)
+	}
+	if res.StatusCode != 400 {
+		t.Fatalf("expected 400 for unknown op, got %d", res.StatusCode)
+	}
+}
+
+func TestGitHubPipelines_MutateRejectsGET(t *testing.T) {
+	app := newGHPTestApp(t, "fake-token", "fake-mutation-token")
+	req := httptest.NewRequest("GET", "/api/github-pipelines?view=mutate&op=rerun&repo=kubestellar/console&run=1", nil)
+	res, err := app.Test(req, -1)
+	if err != nil {
+		t.Fatalf("app.Test: %v", err)
+	}
+	if res.StatusCode != 405 {
+		t.Fatalf("expected 405 for GET mutate, got %d", res.StatusCode)
+	}
+}
+
+func TestGitHubPipelines_LogRequiresParams(t *testing.T) {
+	app := newGHPTestApp(t, "fake-token", "")
+	req := httptest.NewRequest("GET", "/api/github-pipelines?view=log", nil)
+	res, err := app.Test(req, -1)
+	if err != nil {
+		t.Fatalf("app.Test: %v", err)
+	}
+	if res.StatusCode != 400 {
+		t.Fatalf("expected 400 when repo/job missing, got %d", res.StatusCode)
+	}
+}
+
+func TestGHPHistory_MergeAndTrim(t *testing.T) {
+	h := newGHPHistory()
+	success := "success"
+	failure := "failure"
+	// Two runs on the same day — newer ID wins
+	h.merge([]ghpWorkflowRun{
+		{ID: 1, Repo: "kubestellar/console", Name: "Release", Conclusion: &failure, CreatedAt: "2026-04-01T05:00:00Z", HTMLURL: "url-1"},
+		{ID: 2, Repo: "kubestellar/console", Name: "Release", Conclusion: &success, CreatedAt: "2026-04-01T06:00:00Z", HTMLURL: "url-2"},
+	})
+	snap := h.snapshot()
+	day := snap["kubestellar/console"]["Release"]["2026-04-01"]
+	if day.RunID != 2 {
+		t.Fatalf("expected newer run ID to win, got %d", day.RunID)
+	}
+	if day.Conclusion == nil || *day.Conclusion != "success" {
+		t.Fatalf("expected success conclusion, got %v", day.Conclusion)
+	}
+	// Trim retention: insert an ancient day and verify it's dropped
+	ancient := time.Now().AddDate(0, 0, -(ghpHistoryRetentionDays + 10)).Format("2006-01-02") + "T00:00:00Z"
+	h.merge([]ghpWorkflowRun{
+		{ID: 99, Repo: "kubestellar/console", Name: "Release", Conclusion: &success, CreatedAt: ancient, HTMLURL: "old"},
+	})
+	snap = h.snapshot()
+	if _, had := snap["kubestellar/console"]["Release"][ancient[:10]]; had {
+		t.Fatalf("expected ancient day to be trimmed")
+	}
+}
+
+func TestGHPIsAllowedRepo(t *testing.T) {
+	if !ghpIsAllowedRepo("kubestellar/console") {
+		t.Fatal("console should be allowed")
+	}
+	if ghpIsAllowedRepo("evil/repo") {
+		t.Fatal("non-allowlist repo must be rejected")
+	}
+}
+
+func TestGHPStreakKind(t *testing.T) {
+	s := "success"
+	f := "failure"
+	to := "timed_out"
+	c := "cancelled"
+	for _, tc := range []struct {
+		in   *string
+		want string
+	}{
+		{nil, ""},
+		{&s, "success"},
+		{&f, "failure"},
+		{&to, "failure"},
+		{&c, ""},
+	} {
+		if got := ghpStreakKind(tc.in); got != tc.want {
+			inStr := "<nil>"
+			if tc.in != nil {
+				inStr = *tc.in
+			}
+			t.Errorf("ghpStreakKind(%s) = %q, want %q", inStr, got, tc.want)
+		}
+	}
+}

--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -1149,6 +1149,13 @@ func (s *Server) setupRoutes() {
 	api.Get("/nightly-e2e/runs", nightlyE2E.GetRuns)
 	api.Get("/nightly-e2e/run-logs", nightlyE2E.GetRunLogs)
 
+	// GitHub Pipelines dashboard (powers /ci-cd cards). Same endpoint shape
+	// as the Netlify Function at web/netlify/functions/github-pipelines.mts
+	// so the TS hook works against either backend without branching.
+	githubPipelines := handlers.NewGitHubPipelinesHandler(s.config.GitHubToken)
+	api.Get("/github-pipelines", githubPipelines.Serve)
+	api.Post("/github-pipelines", githubPipelines.Serve)
+
 	// GPU reservation routes — capacity provider uses live k8s node data
 	// so the server never trusts client-supplied GPU limits (#5421).
 	gpuCapacity := handlers.ClusterCapacityProvider(func(ctx context.Context, cluster string) int {

--- a/pkg/k8s/console_resources_test.go
+++ b/pkg/k8s/console_resources_test.go
@@ -7,8 +7,11 @@ import (
 	"github.com/kubestellar/console/pkg/api/v1alpha1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/client-go/dynamic/fake"
+	fake "k8s.io/client-go/dynamic/fake"
 )
+
+// consoleGVRListKinds is defined in watcher_lifecycle_test.go (same package).
+// We reuse it here to avoid duplication.
 
 func TestConsoleResources(t *testing.T) {
 	scheme := runtime.NewScheme()
@@ -41,7 +44,7 @@ func TestConsoleResources(t *testing.T) {
 	}
 	wdU, _ := wd.ToUnstructured()
 
-	fakeDyn := fake.NewSimpleDynamicClient(scheme, mwU, cgU, wdU)
+	fakeDyn := fake.NewSimpleDynamicClientWithCustomListKinds(scheme, consoleGVRListKinds, mwU, cgU, wdU)
 	cp := NewConsolePersistence(fakeDyn)
 
 	ctx := context.Background()

--- a/pkg/k8s/watcher_lifecycle_test.go
+++ b/pkg/k8s/watcher_lifecycle_test.go
@@ -9,9 +9,21 @@ import (
 	"testing"
 	"time"
 
+	"github.com/kubestellar/console/pkg/api/v1alpha1"
 	k8sruntime "k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	dynamicfake "k8s.io/client-go/dynamic/fake"
 )
+
+// consoleGVRListKinds maps every console CRD's GVR to its List kind so
+// the fake dynamic client knows how to return typed lists. Without this,
+// NewSimpleDynamicClient panics on the first List call because the list
+// kind isn't registered. See k8s.io/client-go/dynamic/fake docs.
+var consoleGVRListKinds = map[schema.GroupVersionResource]string{
+	v1alpha1.ManagedWorkloadGVR:    "ManagedWorkloadList",
+	v1alpha1.ClusterGroupGVR:       "ClusterGroupList",
+	v1alpha1.WorkloadDeploymentGVR: "WorkloadDeploymentList",
+}
 
 // concurrentStartCallers — number of goroutines used by the concurrency race
 // test for StartWatching. Chosen to be large enough that a naive unlocked
@@ -131,7 +143,7 @@ func TestMultiClusterClient_StartWatching_RestartAfterStop(t *testing.T) {
 
 // Issue 6472 — ConsoleWatcher must be safe to restart after Stop.
 func TestConsoleWatcher_RestartAfterStop(t *testing.T) {
-	fakeDyn := dynamicfake.NewSimpleDynamicClient(k8sruntime.NewScheme())
+	fakeDyn := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(k8sruntime.NewScheme(), consoleGVRListKinds)
 	w := NewConsoleWatcher(fakeDyn, "default", func(ConsoleResourceEvent) {})
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -161,7 +173,7 @@ func TestConsoleWatcher_RestartAfterStop(t *testing.T) {
 
 // Issue 6469/6472 — ConsoleWatcher.Stop must be safe to call multiple times.
 func TestConsoleWatcher_Stop_DoubleCallSafe(t *testing.T) {
-	fakeDyn := dynamicfake.NewSimpleDynamicClient(k8sruntime.NewScheme())
+	fakeDyn := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(k8sruntime.NewScheme(), consoleGVRListKinds)
 	w := NewConsoleWatcher(fakeDyn, "default", func(ConsoleResourceEvent) {})
 	if err := w.Start(context.Background()); err != nil {
 		t.Fatalf("Start: %v", err)

--- a/web/netlify/functions/github-pipelines.mts
+++ b/web/netlify/functions/github-pipelines.mts
@@ -329,7 +329,7 @@ async function buildPulse(
   token: string
 ): Promise<PulsePayload> {
   const res = await gh(
-    `/repos/${NIGHTLY_RELEASE_REPO}/actions/workflows/${NIGHTLY_RELEASE_WORKFLOW}/runs?per_page=${MATRIX_DEFAULT_DAYS}&event=schedule`,
+    `/repos/${NIGHTLY_RELEASE_REPO}/actions/workflows/${NIGHTLY_RELEASE_WORKFLOW}/runs?per_page=${MATRIX_DEFAULT_DAYS}`,
     token
   );
   if (!res.ok) throw new Error(`pulse: GitHub ${res.status}`);


### PR DESCRIPTION
## Summary

Follow-up to #8394 (Pipelines dashboard cards). The Netlify Function at `web/netlify/functions/github-pipelines.mts` only serves `console.kubestellar.io`. Without a matching Go handler, anyone who installs the console on **localhost** or in a **cluster deployment** gets demo data on the `/ci-cd` pipeline cards instead of live GitHub Actions data. This PR fixes that.

Mirrors the existing `nightly_e2e.go` pattern — which has a parallel Go + Netlify implementation of the same endpoint for the same reason.

## Endpoint parity

Same six views, same JSON shapes. `useGitHubPipelines.ts` works against either backend with no branching:

| Method | View | Purpose |
|---|---|---|
| GET | `?view=pulse` | Latest Release run + streak + 14-day strip |
| GET | `?view=matrix&days=N` | Per-workflow × daily heatmap (14/30/90) |
| GET | `?view=flow` | In-progress / queued runs with jobs + steps |
| GET | `?view=failures` | Last 10 failed runs with failing step |
| GET | `?view=log` | Log tail of a failed job |
| POST | `?view=mutate&op=rerun\|cancel` | Workflow mutations (disabled by default) |

## Caching + history

- In-memory response cache, 2-min TTL, per-`(view,repo,days,job)` key
- `singleflight.Group` coalesces concurrent cold fetches (same trick as `nightly_e2e` for #7053)
- Rolling 90-day history blob (`sync.RWMutex` over nested map). Lost on restart; re-seeded from GitHub on next matrix fetch. Since GitHub's own retention is 14 days, restart only thins 30/90-day views until history accumulates again

## Security

- Repo allowlist (same 6 repos as `/hygiene`): `console`, `docs`, `console-kb`, `kubestellar-mcp`, `console-marketplace`, `homebrew-tap`. Unknown repos → 400
- Mutations gated on `GITHUB_MUTATIONS_TOKEN` env var. If unset (the default), POST returns 503. Operator opts in by setting a PAT with `actions:write` scope
- Error bodies read through `LimitReader` (10KB cap) — matches `nightly_e2e` pattern

## Tests

10 new tests in `github_pipelines_test.go` — all pass:
- Missing `GITHUB_TOKEN` → 500
- Unknown view → 400
- Mutations disabled without `GITHUB_MUTATIONS_TOKEN` → 503
- Mutation repo allowlist
- Mutation op allowlist
- `GET` on mutate view → 405
- Log requires `repo` + `job` params
- History merge (newest run per day wins) + retention trim
- `ghpIsAllowedRepo`
- `ghpStreakKind` (success / failure / timed_out / cancelled / nil)

## Test plan

- [x] `go build ./...` — clean
- [x] `go test -race -timeout 10m ./...` — all packages pass including 10 new handler tests
- [ ] After merge: `cd /tmp/kubestellar-console && bash startup-oauth.sh` — visit `http://localhost:8080/ci-cd` and verify all 4 pipeline cards render **live** data (not demo)
- [ ] `curl http://localhost:8080/api/github-pipelines?view=pulse` — should return 200 JSON with `lastRun` populated
- [ ] `curl -X POST http://localhost:8080/api/github-pipelines?view=mutate&op=rerun&repo=kubestellar/console&run=1` — should return 503 (mutations disabled by default)

## Follow-up (not this PR)

- Consider persisting the history blob to SQLite via the `store` package so 30/90-day views survive restarts (currently in-memory only)