### PR TITLE
🐛 fix: address Copilot review on cardHooks + keyboard focus (#8404 #8403)

### DIFF
--- a/web/src/components/dashboard/SharedSortableCard.tsx
+++ b/web/src/components/dashboard/SharedSortableCard.tsx
@@ -155,7 +155,7 @@ export const SortableCard = memo(function SortableCard({ card, onConfigure, onRe
           // this button in the same coordinate space as the kebab menu
           // (which sits at roughly right:16px inside the header) causing
           // a direct overlap at rest and on hover.
-          className="absolute top-1/2 -translate-y-1/2 right-2 z-20 opacity-0 group-hover/card:opacity-100 transition-all w-6 h-6 rounded-full bg-primary text-primary-foreground flex items-center justify-center text-sm font-bold shadow-lg hover:scale-110 ring-2 ring-background"
+          className="absolute top-1/2 -translate-y-1/2 right-2 z-20 opacity-0 group-hover/card:opacity-100 focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary transition-all w-6 h-6 rounded-full bg-primary text-primary-foreground flex items-center justify-center text-sm font-bold shadow-lg hover:scale-110 ring-2 ring-background"
           aria-label="Add card"
           title="Add card here"
         >

--- a/web/src/lib/cards/cardHooks.ts
+++ b/web/src/lib/cards/cardHooks.ts
@@ -471,17 +471,14 @@ export function useCardData<T, S extends string = string>(
 
   // Ensure current page is valid when total pages shrinks (e.g., data errors).
   // Uses functional setState to read the latest `currentPage` without including
-  // it in the dep array (adding it to deps causes an infinite loop when
-  // totalPages=0 because Math.max(1,0)=1 and 1>0 is always true — #5762).
+  // it in the dep array — including it caused a feedback loop (#5762).
   // Previously the stale closure also meant a Next-click mid-refresh could
   // read a pre-click `currentPage` and clamp an in-flight page update back
-  // down to `totalPages`, which looked like the page snapped back to 1
-  // (#8381). Functional setState + a totalPages ref (below) eliminate both
-  // stale reads.
+  // down to `totalPages`, which looked like the page snapped back to 1 (#8381).
+  // Functional setState + a totalPages ref (below) eliminate both stale reads.
+  // `totalPages` is `Math.ceil(...) || 1`, so it is always >= 1 — no zero guard.
   useEffect(() => {
-    if (totalPages > 0) {
-      setCurrentPage((prev) => (prev > totalPages ? totalPages : prev))
-    }
+    setCurrentPage((prev) => (prev > totalPages ? totalPages : prev))
   }, [totalPages])
 
   // Paginate
@@ -496,8 +493,8 @@ export function useCardData<T, S extends string = string>(
   // `totalPages` could clamp against the *pre-render* value (e.g. 1) and
   // silently snap the user back to page 1. Reading from a ref guarantees
   // `goToPage` always clamps against the most recent totalPages. The ref is
-  // synced in an effect (not during render) to satisfy React's no-mutation
-  // -during-render rule.
+  // synced in an effect (not during render) to satisfy React's
+  // no-mutation-during-render rule.
   const totalPagesRef = useRef(totalPages)
   useEffect(() => {
     totalPagesRef.current = totalPages


### PR DESCRIPTION
## Summary
- Remove redundant `if (totalPages > 0)` guard in `cardHooks.ts` — `totalPages` is `Math.ceil(...) || 1` so it is always >= 1. This restores the magic-numbers ratchet (37 → 36 comparisons, 55 → 54 total) that regressed in PR #8401
- Add `focus-visible` styles to the "+" insert-card button in `SharedSortableCard.tsx` so keyboard users can discover and activate it (was `opacity-0` with no focus state)
- Rewrap a split-word comment (`no-mutation-\n-during-render`) into a single token for grep-ability

Fixes #8404
Fixes #8403

## Test plan
- [ ] `npm run build` passes
- [ ] `npm run lint` passes
- [ ] `npx vitest run src/lib/cards` — 415 tests pass
- [ ] ui-ux-standard ratchet restored (magic-numbers comparisons back to 36, total back to 54)
- [ ] Tab to the "+" insert button on a card — focus ring visible