### PR TITLE
🐛 fix(modals): ESC closes only the front-most stacked modal + taller prompt editor

### DIFF
--- a/web/src/components/missions/ConfirmMissionPromptDialog.tsx
+++ b/web/src/components/missions/ConfirmMissionPromptDialog.tsx
@@ -25,8 +25,10 @@ import { BaseModal } from '../../lib/modals/BaseModal'
 import { Button } from '../ui/Button'
 import { TextArea } from '../ui/TextArea'
 
-/** Minimum visible rows for the prompt textarea. */
-const PROMPT_TEXTAREA_ROWS = 12
+/** Minimum visible rows for the prompt textarea. Bumped from 12 to 20
+ *  so ACMM-length prompts (~25 lines of detection rules + context)
+ *  don't require immediate scrolling to see the full content. */
+const PROMPT_TEXTAREA_ROWS = 20
 
 interface ConfirmMissionPromptDialogProps {
   /** Whether the dialog is open. */

--- a/web/src/lib/modals/useModalNavigation.ts
+++ b/web/src/lib/modals/useModalNavigation.ts
@@ -1,5 +1,14 @@
-import { useState, useEffect, useCallback } from 'react'
+import { useState, useEffect, useCallback, useRef } from 'react'
 import { UseModalNavigationOptions, UseModalNavigationResult } from './types'
+
+// ---------------------------------------------------------------------------
+// Modal stack — ensures only the front-most open modal handles ESC.
+// Each open modal registers itself (push) and deregisters on close (splice).
+// The ESC handler checks whether this modal's ID is at the top of the stack
+// before processing the key — background modals pass through silently.
+// ---------------------------------------------------------------------------
+const modalStack: number[] = []
+let modalStackCounter = 0
 
 /**
  * #6749-B (Copilot on PR #6746) — Module-level stable no-op ref object
@@ -102,13 +111,41 @@ export function useModalNavigation({
     [onClose, onBack, enableEscape, enableBackspace]
   )
 
-  // Set up keyboard listener
+  // Register this modal in the global stack so only the top-most open
+  // modal handles ESC. Without this, stacked modals (e.g. ACMM intro
+  // behind + mission-prompt-review on top) both fire their ESC handlers
+  // and the wrong one closes.
+  const modalIdRef = useRef(++modalStackCounter)
   useEffect(() => {
     if (!isOpen) return
+    const id = modalIdRef.current
+    modalStack.push(id)
+    return () => {
+      const idx = modalStack.indexOf(id)
+      if (idx >= 0) modalStack.splice(idx, 1)
+    }
+  }, [isOpen])
 
-    window.addEventListener('keydown', handleKeyDown)
-    return () => window.removeEventListener('keydown', handleKeyDown)
-  }, [isOpen, handleKeyDown])
+  // Set up keyboard listener — only process ESC when this modal is the
+  // top of the stack. Other keys (Backspace/Space) pass through
+  // unconditionally because they only affect focused elements inside
+  // the modal anyway.
+  const guardedHandleKeyDown = useCallback(
+    (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        const topId = modalStack[modalStack.length - 1]
+        if (topId !== modalIdRef.current) return // not the top modal
+      }
+      handleKeyDown(e)
+    },
+    [handleKeyDown],
+  )
+
+  useEffect(() => {
+    if (!isOpen) return
+    window.addEventListener('keydown', guardedHandleKeyDown)
+    return () => window.removeEventListener('keydown', guardedHandleKeyDown)
+  }, [isOpen, guardedHandleKeyDown])
 
   // Disable body scroll when modal is open
   useEffect(() => {


### PR DESCRIPTION
## Summary

Two user-reported issues:

### 1. ESC closes the wrong modal when two are stacked

**Symptom:** With the ACMM intro modal open, clicking "Ask agent for help" opens the "Review AI mission prompt" modal on top. Pressing ESC closes the ACMM intro (behind) instead of the prompt review (in front).

**Root cause:** Both \`BaseModal\` instances register a \`window.addEventListener('keydown', ...)\` via \`useModalNavigation\`. Event listeners on the same target fire in registration order (oldest first). The ACMM intro was mounted first, so its ESC handler fires before the prompt review's.

**Fix:** Module-level modal stack (\`number[] + counter\`) in \`useModalNavigation.ts\`. Each open modal pushes its ID on mount and splices on unmount. The ESC handler checks whether this modal's ID is at the top of the stack before processing — background modals pass through silently. Generic fix that works for any number of stacked \`BaseModal\` instances.

### 2. Mission prompt textarea too short

**Symptom:** ACMM mission prompts (~25 lines of detection rules + context) require immediate scrolling because the textarea is only 12 rows.

**Fix:** Bump \`PROMPT_TEXTAREA_ROWS\` from 12 → 20 in \`ConfirmMissionPromptDialog.tsx\`.

## Test plan

- [x] \`npm run build\` passes
- [ ] Open ACMM intro → click "Ask agent for help" → "Review AI mission prompt" appears on top → press ESC → front modal closes, ACMM intro stays
- [ ] Same flow → press ESC again → now ACMM intro closes
- [ ] Open a mission prompt review directly (no ACMM intro behind) → ESC closes it normally
- [ ] Mission prompt textarea shows ~20 visible rows, no immediate scroll needed for ACMM prompts

🤖 Generated with [Claude Code](https://claude.com/claude-code)