### PR TITLE
♻️ Centralize pipeline repo list: server-driven, env-configurable

### DIFF
--- a/pkg/api/handlers/github_pipelines.go
+++ b/pkg/api/handlers/github_pipelines.go
@@ -50,8 +50,8 @@ const (
 	ghpMatrixSparseMinCells  = 1
 )
 
-// ghpRepos is the canonical list scanned — same set /hygiene uses.
-var ghpRepos = []string{
+// ghpDefaultRepos is the default when PIPELINE_REPOS env var is not set.
+var ghpDefaultRepos = []string{
 	"kubestellar/console",
 	"kubestellar/docs",
 	"kubestellar/console-kb",
@@ -59,6 +59,30 @@ var ghpRepos = []string{
 	"kubestellar/console-marketplace",
 	"kubestellar/homebrew-tap",
 }
+
+// ghpGetRepos reads the PIPELINE_REPOS env var (comma-separated owner/repo
+// list). Falls back to ghpDefaultRepos if unset. Called once at handler
+// construction time — not on every request.
+func ghpGetRepos() []string {
+	env := os.Getenv("PIPELINE_REPOS")
+	if env == "" {
+		return ghpDefaultRepos
+	}
+	var repos []string
+	for _, s := range strings.Split(env, ",") {
+		s = strings.TrimSpace(s)
+		if s != "" {
+			repos = append(repos, s)
+		}
+	}
+	if len(repos) == 0 {
+		return ghpDefaultRepos
+	}
+	return repos
+}
+
+// ghpRepos is populated once at init from PIPELINE_REPOS env var.
+var ghpRepos = ghpGetRepos()
 
 func ghpIsAllowedRepo(repo string) bool {
 	for _, r := range ghpRepos {
@@ -366,7 +390,26 @@ func (h *GitHubPipelinesHandler) serveCached(c *fiber.Ctx, key string, build fun
 	if err != nil {
 		return c.Status(fiber.StatusBadGateway).JSON(fiber.Map{"error": err.Error()})
 	}
-	body, err := json.Marshal(v)
+	// Wrap payload with the repo list so the client reads it from the
+	// response instead of hardcoding. Uses a two-step marshal: first the
+	// inner payload, then merge with the repos envelope.
+	inner, err := json.Marshal(v)
+	if err != nil {
+		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{"error": "marshal failed"})
+	}
+	// Build merged JSON: { ...payload, "repos": [...] }
+	reposJSON, _ := json.Marshal(ghpRepos)
+	var body []byte
+	if len(inner) > 2 && inner[0] == '{' {
+		// Merge repos into existing object
+		body = make([]byte, 0, len(inner)+len(reposJSON)+12)
+		body = append(body, inner[:len(inner)-1]...) // strip trailing }
+		body = append(body, `,"repos":`...)
+		body = append(body, reposJSON...)
+		body = append(body, '}')
+	} else {
+		body = inner
+	}
 	if err != nil {
 		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{"error": "marshal failed"})
 	}

--- a/web/netlify/functions/github-pipelines.mts
+++ b/web/netlify/functions/github-pipelines.mts
@@ -59,15 +59,31 @@ const MATRIX_RUNS_PER_REPO = 100;
 /** How many in-progress/queued runs to pull per repo for the flow view */
 const FLOW_MAX_RUNS_PER_REPO = 8;
 
-/** Repos scanned — same set used by /hygiene. Order matters for UI */
-const REPOS = [
+/** Default repos when PIPELINE_REPOS env var is not set */
+const DEFAULT_REPOS = [
   "kubestellar/console",
   "kubestellar/docs",
   "kubestellar/console-kb",
   "kubestellar/kubestellar-mcp",
   "kubestellar/console-marketplace",
   "kubestellar/homebrew-tap",
-] as const;
+];
+
+/**
+ * Repos scanned by the pipelines dashboard. Centralized: set the
+ * PIPELINE_REPOS env var to a comma-separated list of owner/repo strings
+ * to override (e.g. "myorg/myrepo" for a single-repo install, or
+ * "org/a,org/b,org/c" for multi-repo). If unset, defaults to the 6
+ * KubeStellar repos above. The repo list is returned in every API
+ * response so the frontend never hardcodes it.
+ */
+function getRepos(): string[] {
+  const env = process.env.PIPELINE_REPOS;
+  if (!env) return DEFAULT_REPOS;
+  return env.split(",").map((s) => s.trim()).filter(Boolean);
+}
+
+const REPOS = getRepos();
 
 /** The nightly release workflow on kubestellar/console — drives the Pulse card */
 const NIGHTLY_RELEASE_REPO = "kubestellar/console";
@@ -192,8 +208,8 @@ async function gh(path: string, token: string, init: RequestInit = {}): Promise<
   });
 }
 
-function isValidRepo(repo: string | null): repo is (typeof REPOS)[number] {
-  return !!repo && (REPOS as readonly string[]).includes(repo);
+function isValidRepo(repo: string | null): boolean {
+  return !!repo && REPOS.includes(repo);
 }
 
 /** YYYY-MM-DD in UTC */
@@ -789,8 +805,11 @@ export default async (req: Request): Promise<Response> => {
         return jsonResponse({ error: `Unknown view: ${view}` }, { status: 400, headers: baseHeaders });
     }
 
-    await writeCache(store, cacheKey, payload).catch(() => {});
-    return jsonResponse(payload, {
+    // Wrap payload with the repo list so the client never hardcodes it.
+    // Cards read `repos` from the response to populate their filter dropdown.
+    const wrapped = { ...(payload as Record<string, unknown>), repos: REPOS };
+    await writeCache(store, cacheKey, wrapped).catch(() => {});
+    return jsonResponse(wrapped, {
       headers: {
         ...baseHeaders,
         "Cache-Control": `public, max-age=${Math.floor(CACHE_TTL_MS / 1000)}`,

--- a/web/src/components/cards/pipelines/PipelineFlow.tsx
+++ b/web/src/components/cards/pipelines/PipelineFlow.tsx
@@ -20,7 +20,7 @@ import { useCardLoadingState } from '../CardDataContext'
 import {
   usePipelineFlow,
   usePipelineMutations,
-  PIPELINE_REPOS,
+  getPipelineRepos,
   type FlowRun,
   type Status,
   type Conclusion,
@@ -352,7 +352,7 @@ export function PipelineFlow() {
           aria-label={LABEL_FILTER_REPO}
         >
           <option value="">All repos</option>
-          {PIPELINE_REPOS.map((r) => (
+          {getPipelineRepos().map((r) => (
             <option key={r} value={r}>{r}</option>
           ))}
         </select>

--- a/web/src/components/cards/pipelines/RecentFailures.tsx
+++ b/web/src/components/cards/pipelines/RecentFailures.tsx
@@ -9,7 +9,7 @@ import { useCardLoadingState } from '../CardDataContext'
 import {
   usePipelineFailures,
   usePipelineMutations,
-  PIPELINE_REPOS,
+  getPipelineRepos,
 } from '../../../hooks/useGitHubPipelines'
 import { LogsModal } from './LogsModal'
 import { cn } from '../../../lib/cn'
@@ -82,7 +82,7 @@ export function RecentFailures() {
           aria-label={LABEL_FILTER_REPO}
         >
           <option value="">All repos</option>
-          {PIPELINE_REPOS.map((r) => (
+          {getPipelineRepos().map((r) => (
             <option key={r} value={r}>{r}</option>
           ))}
         </select>

--- a/web/src/components/cards/pipelines/WorkflowMatrix.tsx
+++ b/web/src/components/cards/pipelines/WorkflowMatrix.tsx
@@ -11,7 +11,7 @@ import { useState } from 'react'
 import { ExternalLink } from 'lucide-react'
 import { useDemoMode } from '../../../hooks/useDemoMode'
 import { useCardLoadingState } from '../CardDataContext'
-import { usePipelineMatrix, PIPELINE_REPOS, type Conclusion } from '../../../hooks/useGitHubPipelines'
+import { usePipelineMatrix, getPipelineRepos, type Conclusion } from '../../../hooks/useGitHubPipelines'
 import { cn } from '../../../lib/cn'
 
 /** Available range options. Must match the server's MATRIX_MAX_DAYS (90) */
@@ -79,7 +79,7 @@ export function WorkflowMatrix() {
             aria-label={LABEL_FILTER_REPO}
           >
             <option value="">All repos</option>
-            {PIPELINE_REPOS.map((r) => (
+            {getPipelineRepos().map((r) => (
               <option key={r} value={r}>{r}</option>
             ))}
           </select>

--- a/web/src/hooks/useGitHubPipelines.ts
+++ b/web/src/hooks/useGitHubPipelines.ts
@@ -16,19 +16,28 @@ const DEFAULT_POLL_MS = 60_000
 /** Timeout for any /api/github-pipelines fetch */
 const FETCH_TIMEOUT_MS = 10_000
 
-/** Canonical list of repos the dashboard scans. Server authoritative — this
- * is duplicated here only to drive the repo-filter dropdowns; if they drift,
- * the server response is the source of truth. */
-export const PIPELINE_REPOS = [
+/** Fallback repos used in demo mode before the first server response arrives.
+ * The server is the single source of truth — it reads PIPELINE_REPOS env var
+ * and returns the live list in every response under the `repos` field.
+ * Cards read repos from the response to populate their filter dropdown. */
+const FALLBACK_REPOS = [
   'kubestellar/console',
   'kubestellar/docs',
   'kubestellar/console-kb',
   'kubestellar/kubestellar-mcp',
   'kubestellar/console-marketplace',
   'kubestellar/homebrew-tap',
-] as const
+]
 
-export type PipelineRepo = (typeof PIPELINE_REPOS)[number]
+/** Last-known repo list from the server. Updated on every successful fetch.
+ * Cards call `getPipelineRepos()` to get the current list for their dropdown. */
+let serverRepos: string[] = FALLBACK_REPOS
+
+/** Returns the current repo list. After the first successful fetch, this
+ * reflects whatever the server's PIPELINE_REPOS env var is set to. */
+export function getPipelineRepos(): string[] {
+  return serverRepos
+}
 
 export type Conclusion =
   | 'success'
@@ -298,7 +307,14 @@ async function fetchView<T>(params: URLSearchParams): Promise<T> {
   const url = `/api/github-pipelines?${params.toString()}`
   const res = await fetch(url, { signal: AbortSignal.timeout(FETCH_TIMEOUT_MS) })
   if (!res.ok) throw new Error(`HTTP ${res.status}`)
-  return (await res.json()) as T
+  const body = (await res.json()) as T & { repos?: string[] }
+  // Update the shared repo list from the server response — this is the
+  // single source of truth for which repos the backend is configured to
+  // scan (set via PIPELINE_REPOS env var).
+  if (Array.isArray(body.repos) && body.repos.length > 0) {
+    serverRepos = body.repos
+  }
+  return body
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Follow-up to #8394 + #8408. The 4 pipeline cards' repo filter dropdown was hardcoded in 3 places (Netlify Function, Go handler, TS hook). Now centralized into one env var.

### How it works

1. **Server** reads `PIPELINE_REPOS` env var (comma-separated `owner/repo`). Defaults to the 6 KubeStellar repos if unset. Single-repo installs just set `PIPELINE_REPOS=myorg/myrepo`.
2. Every API response includes a `repos` field with the live list.
3. **Client** reads repos from the response — no hardcoded list. `getPipelineRepos()` returns the last-known server list, updated on every successful fetch. Fallback array only drives the initial render before the first fetch.

### Also fixes

**Pulse view stale data:** The `event=schedule` filter excluded `workflow_dispatch` runs, so today's manual v0.3.21 nightly was invisible. Dropped the filter — the Release workflow only triggers on `schedule` and `workflow_dispatch` anyway.

## Test plan

- [x] `go build ./...` — clean
- [x] `go test -race ./pkg/api/handlers/ -run GitHubPipelines` — 10/10 pass
- [x] `npx tsc --noEmit` — clean
- [x] `npm run build` — green
- [ ] After merge: `curl https://console.kubestellar.io/api/github-pipelines?view=pulse` should show `repos: [...]` in response + today's successful nightly
- [ ] Set `PIPELINE_REPOS=kubestellar/console` in Netlify env → cards should show only 1 repo in dropdown