### PR TITLE
🐛 fix: CTA button text truncation on smaller screens

### DIFF
--- a/web/src/components/layout/Layout.tsx
+++ b/web/src/components/layout/Layout.tsx
@@ -379,19 +379,19 @@ export function Layout({ children: _children }: LayoutProps) {
                 variant="accent"
                 size="sm"
                 onClick={() => setShowSetupDialog(true)}
-                className="hidden sm:flex ml-2 rounded-full"
+                className="hidden sm:flex ml-2 rounded-full whitespace-nowrap"
               >
                 {isAuthenticatedNoAgent ? (
                   <>
                     <Plug className="w-3.5 h-3.5" aria-hidden="true" />
-                    <span className="hidden lg:inline">{t('layout.howToConnectAgent')}</span>
-                    <span className="lg:hidden">{t('layout.connect')}</span>
+                    <span className="hidden xl:inline">{t('layout.howToConnectAgent')}</span>
+                    <span className="xl:hidden">{t('layout.connect')}</span>
                   </>
                 ) : (
                   <>
                     <Rocket className="w-3.5 h-3.5" aria-hidden="true" />
-                    <span className="hidden lg:inline">{t('layout.wantYourOwnConsole')}</span>
-                    <span className="lg:hidden">{t('layout.getConsole')}</span>
+                    <span className="hidden xl:inline">{t('layout.wantYourOwnConsole')}</span>
+                    <span className="xl:hidden">{t('layout.getConsole')}</span>
                   </>
                 )}
               </Button>


### PR DESCRIPTION
## Summary
- Bumps the demo-mode CTA button full-text breakpoint from `lg` (1024px) to `xl` (1280px) so the long label only renders when there is enough room
- Adds `whitespace-nowrap` to the button to prevent mid-word line breaks
- Below `xl`, the compact labels ("Get Console" / "Connect") are shown instead

Fixes #8409

## Test plan
- [ ] Resize browser from 640px to 1280px+ and verify the CTA button in the demo-mode banner shows the short label below `xl` and full label at `xl`+
- [ ] Confirm no text truncation at any viewport width
- [ ] Verify the banner wraps gracefully with the sidebar open/closed