### PR TITLE
🐛 fix(missions): stop sidebar from auto-opening on refresh for terminal missions

### DIFF
--- a/web/src/hooks/useMissions.tsx
+++ b/web/src/hooks/useMissions.tsx
@@ -544,8 +544,24 @@ export function MissionProvider({ children }: { children: ReactNode }) {
     } catch { return null }
   })
   const [isSidebarOpen, setIsSidebarOpen] = useState(() => {
-    // #7313 — If there's a persisted active mission, open the sidebar on load
-    try { return !!localStorage.getItem(ACTIVE_MISSION_STORAGE_KEY) } catch { return false }
+    // #7313 — If there's a persisted active mission that is still
+    // in-progress, open the sidebar on load. Completed / failed /
+    // cancelled missions keep their ID in localStorage (so the
+    // transcript can be reviewed on reload) but should NOT force the
+    // sidebar open — that was annoying on every refresh.
+    try {
+      const persistedId = localStorage.getItem(ACTIVE_MISSION_STORAGE_KEY)
+      if (!persistedId) return false
+      // Cross-check against the persisted missions list.
+      const stored = localStorage.getItem(MISSIONS_STORAGE_KEY)
+      if (!stored) return false
+      const parsed = JSON.parse(stored) as Array<{ id: string; status: string }>
+      const match = (parsed || []).find(m => m.id === persistedId)
+      if (!match) return false
+      // Only auto-open for non-terminal statuses.
+      const terminalStatuses: Set<string> = new Set(['completed', 'failed', 'cancelled', 'saved'])
+      return !terminalStatuses.has(match.status)
+    } catch { return false }
   })
   const [isSidebarMinimized, setIsSidebarMinimized] = useState(false)
   const [isFullScreen, setIsFullScreen] = useState(false)


### PR DESCRIPTION
## Summary

**Problem:** The AI Missions sidebar re-opens on every page refresh, even when there's nothing in-progress.

**Root cause:** \`useMissions.tsx:546\` checks \`!!localStorage.getItem('kc_active_mission_id')\` — if ANY mission ID is persisted, the sidebar opens. The ID persists after mission completion because only \`dismissMission()\` clears it (via \`setActiveMissionId(null)\`); normal completion transitions don't.

**Fix:** Cross-check the persisted ID against the persisted missions list (\`kc_missions\`). Only auto-open if the mission's status is **non-terminal** — i.e., not \`completed\` / \`failed\` / \`cancelled\` / \`saved\`.

Terminal missions keep their ID in localStorage so their transcript is still available if the user manually re-opens the sidebar — they just no longer force it open on every refresh.

This preserves the original \`#7313\` intent (reload restores sidebar for in-progress missions) while eliminating the annoyance.

## Test plan

- [x] \`npm run build\` passes
- [ ] Start a mission → refresh → sidebar opens (mission is \`running\`)
- [ ] Complete a mission → refresh → sidebar stays closed
- [ ] Manually open sidebar after completion → transcript still there
- [ ] With no missions at all → sidebar stays closed
- [ ] Cancel a mission → refresh → sidebar stays closed

🤖 Generated with [Claude Code](https://claude.com/claude-code)