### PR TITLE
🐛 fix(missions): sidebar ESC yields to open modals instead of closing both

### DIFF
--- a/web/src/components/layout/mission-sidebar/MissionSidebar.tsx
+++ b/web/src/components/layout/mission-sidebar/MissionSidebar.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useRef, lazy, Suspense } from 'react'
+import { isAnyModalOpen } from '../../../lib/modals'
 import {
   X,
   ChevronRight,
@@ -495,12 +496,19 @@ export function MissionSidebar() {
   const pendingMission = pendingRunMissionId ? missions.find(m => m.id === pendingRunMissionId) : null
 
   // Escape key: exit fullscreen first, then close sidebar.
-  // Skip when an overlay (MissionBrowser or MissionControlDialog) is open —
-  // those handle their own Escape and closing the sidebar behind them is wrong.
+  // Skip when an overlay (MissionBrowser, MissionControlDialog, or ANY
+  // BaseModal) is open — those handle their own Escape via the modal
+  // stack, and closing the sidebar behind them is wrong (#8428 follow-up).
   useEffect(() => {
     const handleEscape = (e: KeyboardEvent) => {
       if (e.key !== 'Escape') return
       if (showBrowser || showMissionControl) return
+      // Yield to any open BaseModal (ACMM intro, confirm dialog, etc.)
+      // — isAnyModalOpen() checks the global modal stack maintained by
+      // useModalNavigation. Without this guard, dismissing a modal also
+      // closes the sidebar behind it because both listeners fire on the
+      // same keypress.
+      if (isAnyModalOpen()) return
       if (isFullScreen) {
         setFullScreen(false)
       } else if (isSidebarOpen) {

--- a/web/src/lib/modals/index.ts
+++ b/web/src/lib/modals/index.ts
@@ -21,6 +21,7 @@ export {
   useModalFocusTrap,
   useModal,
   useModalState,
+  isAnyModalOpen,
   type UseModalOptions,
   type UseModalStateResult,
 } from './useModalNavigation'

--- a/web/src/lib/modals/useModalNavigation.ts
+++ b/web/src/lib/modals/useModalNavigation.ts
@@ -10,6 +10,13 @@ import { UseModalNavigationOptions, UseModalNavigationResult } from './types'
 const modalStack: number[] = []
 let modalStackCounter = 0
 
+/** Returns true when at least one BaseModal is currently open. Used by
+ *  non-modal ESC handlers (e.g. the mission sidebar) to yield to the
+ *  front-most modal instead of closing the sidebar behind it. */
+export function isAnyModalOpen(): boolean {
+  return modalStack.length > 0
+}
+
 /**
  * #6749-B (Copilot on PR #6746) — Module-level stable no-op ref object
  * used as a fallback when a `useModal` caller omits `modalRef`/`backdropRef`.


### PR DESCRIPTION
## Summary

When a BaseModal is open on top of the mission sidebar (ACMM intro, confirm dialog, mission prompt review), pressing ESC closes **both** the modal and the sidebar — the user sees two things disappear at once.

**Root cause:** The sidebar ESC handler (\`document.addEventListener('keydown', ...)\`) and the modal stack handlers (\`window.addEventListener('keydown', ...)\`) fire on the same keypress. \`stopImmediatePropagation()\` only blocks other listeners on the same target (\`window\`), not a different target (\`document\`).

**Fix:** Export \`isAnyModalOpen()\` from the modal stack (\`useModalNavigation.ts\`). The sidebar's ESC handler checks it before processing — when any \`BaseModal\` is open, the handler returns early so only the front-most modal closes.

Complement of #8414 (modal-on-modal ESC stacking). That fixed modal-to-modal; this fixes modal-to-sidebar.

## Test plan

- [x] \`npm run build\` passes
- [ ] Open ACMM intro modal with sidebar visible → press ESC → modal closes, sidebar stays
- [ ] Press ESC again → sidebar closes
- [ ] Open confirm dialog (trash a resource) with sidebar visible → press ESC → dialog closes, sidebar stays
- [ ] No modal open + sidebar visible → press ESC → sidebar closes (existing behavior preserved)

🤖 Generated with [Claude Code](https://claude.com/claude-code)