### PR TITLE
✨ feat(navbar): rotating tagline with AI-generated subtitle slot

### DIFF
--- a/web/src/components/layout/navbar/Navbar.tsx
+++ b/web/src/components/layout/navbar/Navbar.tsx
@@ -28,6 +28,7 @@ import { useMissions } from '../../../hooks/useMissions'
 import { TokenUsageWidget } from './TokenUsageWidget'
 import { ClusterFilterPanel } from './ClusterFilterPanel'
 import { AgentStatusIndicator } from './AgentStatusIndicator'
+import { RotatingTagline } from './RotatingTagline'
 import { UpdateIndicator } from './UpdateIndicator'
 import { StreakBadge } from './StreakBadge'
 import { ROUTES } from '../../../config/routes'
@@ -91,7 +92,7 @@ export function Navbar({ topOffset = 0 }: NavbarProps) {
           aria-label={t('navbar.goHome')}
         >
           <span className="text-base md:text-lg font-semibold text-foreground">{branding.appName}</span>
-          <span className="text-[10px] text-muted-foreground tracking-wide">{branding.tagline}</span>
+          <RotatingTagline />
         </button>
         {__DEV_MODE__ && (
           <span className="hidden sm:inline-flex items-center justify-center px-1.5 py-0.5 text-[9px] font-bold uppercase tracking-wider bg-green-500/20 text-green-400 border border-green-500/30 rounded-full" title={t('layout.navbar.devModeTitle')}>

--- a/web/src/components/layout/navbar/RotatingTagline.tsx
+++ b/web/src/components/layout/navbar/RotatingTagline.tsx
@@ -1,0 +1,63 @@
+import { useState, useEffect, useCallback } from 'react'
+
+/** Interval between tagline rotations (ms). Long enough that users absorb it
+ *  subconsciously — the tagline is ambient branding, not a ticker. */
+const ROTATION_INTERVAL_MS = 180_000
+/** Duration of the fade transition (ms). */
+const FADE_DURATION_MS = 600
+
+/**
+ * Static taglines that rotate on every page load. The first entry is also
+ * the branding default so it appears immediately while the component mounts.
+ */
+const TAGLINES: readonly string[] = [
+  'multi-cluster first, saving time and tokens',
+  'not a dashboard, THIS is AI Ops',
+  'make this thing do anything!',
+  'deploys and manages the magical stuff — in your cluster, with what you already have',
+] as const
+
+/**
+ * RotatingTagline cycles through a set of static taglines with a smooth
+ * fade transition. When a live AI agent is connected, an AI-generated
+ * tagline (contextual to user behavior) can be injected into the rotation.
+ */
+export function RotatingTagline({ aiTagline }: { aiTagline?: string }) {
+  const [index, setIndex] = useState(0)
+  const [visible, setVisible] = useState(true)
+
+  // Build the full list: static taglines + optional AI-generated one
+  const allTaglines = aiTagline
+    ? [...TAGLINES, aiTagline]
+    : TAGLINES
+
+  const advance = useCallback(() => {
+    // Fade out, swap text, fade in
+    setVisible(false)
+    const tid = setTimeout(() => {
+      setIndex(prev => (prev + 1) % allTaglines.length)
+      setVisible(true)
+    }, FADE_DURATION_MS)
+    return () => clearTimeout(tid)
+  }, [allTaglines.length])
+
+  useEffect(() => {
+    const id = setInterval(advance, ROTATION_INTERVAL_MS)
+    return () => clearInterval(id)
+  }, [advance])
+
+  // Clamp index if tagline list shrinks (AI tagline removed)
+  const safeIndex = index < allTaglines.length ? index : 0
+
+  return (
+    <span
+      className="text-[10px] text-muted-foreground tracking-wide transition-opacity"
+      style={{
+        opacity: visible ? 1 : 0,
+        transitionDuration: `${FADE_DURATION_MS}ms`,
+      }}
+    >
+      {allTaglines[safeIndex]}
+    </span>
+  )
+}


### PR DESCRIPTION
## Summary

- Replaces the static branding tagline with a **rotating set of 4 taglines** that fade-transition every 3 minutes
- Accepts an optional \`aiTagline\` prop for injecting context-aware subtitles generated by the AI agent (when live agent is connected)

## Taglines

1. *multi-cluster first, saving time and tokens* (original)
2. *not a dashboard, THIS is AI Ops*
3. *make this thing do anything!*
4. *deploys and manages the magical stuff — in your cluster, with what you already have*

## How it works

- \`RotatingTagline\` component cycles through taglines with a 600ms fade transition
- 3-minute dwell time per tagline — ambient branding, not a ticker
- Optional \`aiTagline\` prop adds a 5th AI-generated tagline to the rotation (for localhost/console with live agent)
- Safe index clamping if the AI tagline is removed mid-rotation

## Test plan

- [x] \`npm run build\`
- [x] ESLint clean on touched files
- [x] \`go build ./...\`
- [ ] CI: build / lint / preview
- [ ] Verify tagline rotates in browser (can temporarily lower interval to test)
- [ ] Verify fade transition is smooth