### PR TITLE
🔧 ACMM: auto-prune stale cards, level assignments, layout + UX fixes

### DIFF
--- a/web/src/components/cards/ACMMFeedbackLoops.tsx
+++ b/web/src/components/cards/ACMMFeedbackLoops.tsx
@@ -184,7 +184,7 @@ export function ACMMFeedbackLoops() {
   const sources: (SourceId | 'all')[] = ['all', 'acmm', 'fullsend', 'agentic-engineering-framework', 'claude-reflect']
 
   return (
-    <div className="h-full flex flex-col p-2 gap-2">
+    <div className="h-full flex flex-col p-2 gap-2 max-w-4xl">
       <div className="flex items-center gap-1.5 flex-wrap">
         <Filter className="w-3.5 h-3.5 text-muted-foreground" />
         {sources.map((s) => (

--- a/web/src/components/cards/ACMMRecommendations.tsx
+++ b/web/src/components/cards/ACMMRecommendations.tsx
@@ -100,7 +100,7 @@ export function ACMMRecommendations() {
           Feedback Loops Inventory card via shared context. */}
       <div>
         <div className="flex items-center justify-between text-[10px] text-muted-foreground mb-1">
-          <span>Explore level</span>
+          <span>Explore level <span className="italic text-muted-foreground/60">— drag to preview AI vs human balance</span></span>
           <span className="font-mono text-foreground">L{targetLevel}</span>
         </div>
         <input

--- a/web/src/lib/acmm/sources/agentic-engineering-framework.ts
+++ b/web/src/lib/acmm/sources/agentic-engineering-framework.ts
@@ -4,6 +4,7 @@ const CRITERIA: Criterion[] = [
   {
     id: 'aef:task-traceability',
     source: 'agentic-engineering-framework',
+    level: 3,
     category: 'governance',
     name: 'Task traceability ledger',
     description: 'Every agent task is logged with intent, inputs, and outputs.',
@@ -13,6 +14,7 @@ const CRITERIA: Criterion[] = [
   {
     id: 'aef:structural-gates',
     source: 'agentic-engineering-framework',
+    level: 2,
     category: 'governance',
     name: 'Structural gates',
     description: 'Config-enforced gates that block agents from touching protected areas without review.',
@@ -22,6 +24,7 @@ const CRITERIA: Criterion[] = [
   {
     id: 'aef:session-continuity',
     source: 'agentic-engineering-framework',
+    level: 2,
     category: 'governance',
     name: 'Session continuity doc',
     description: 'A persistent record the agent reads at session start to recover prior context.',
@@ -31,6 +34,7 @@ const CRITERIA: Criterion[] = [
   {
     id: 'aef:audit-trail',
     source: 'agentic-engineering-framework',
+    level: 4,
     category: 'governance',
     name: 'Audit trail workflow',
     description: 'A workflow that records agent-generated PRs and attributes them for later review.',
@@ -40,6 +44,7 @@ const CRITERIA: Criterion[] = [
   {
     id: 'aef:cross-tool-config',
     source: 'agentic-engineering-framework',
+    level: 4,
     category: 'governance',
     name: 'Cross-tool agent config',
     description: 'Agent instructions that apply across Claude, Copilot, Cursor, and other tools rather than being tool-specific.',
@@ -49,6 +54,7 @@ const CRITERIA: Criterion[] = [
   {
     id: 'aef:change-classification',
     source: 'agentic-engineering-framework',
+    level: 3,
     category: 'governance',
     name: 'Change classification policy',
     description: 'A documented policy that classifies changes by risk tier and routes them to appropriate review.',

--- a/web/src/lib/acmm/sources/claude-reflect.ts
+++ b/web/src/lib/acmm/sources/claude-reflect.ts
@@ -4,6 +4,7 @@ const CRITERIA: Criterion[] = [
   {
     id: 'claude-reflect:correction-capture',
     source: 'claude-reflect',
+    level: 3,
     category: 'self-tuning',
     name: 'Correction capture',
     description: 'A mechanism that captures user corrections during agent sessions and persists them.',
@@ -13,6 +14,7 @@ const CRITERIA: Criterion[] = [
   {
     id: 'claude-reflect:positive-reinforcement',
     source: 'claude-reflect',
+    level: 3,
     category: 'self-tuning',
     name: 'Positive reinforcement capture',
     description: 'A mechanism that captures confirmations of non-obvious correct behavior, not just corrections.',
@@ -22,6 +24,7 @@ const CRITERIA: Criterion[] = [
   {
     id: 'claude-reflect:claude-md-sync',
     source: 'claude-reflect',
+    level: 4,
     category: 'self-tuning',
     name: 'CLAUDE.md auto-sync',
     description: 'A workflow that syncs captured corrections/preferences into CLAUDE.md or AGENTS.md.',
@@ -31,6 +34,7 @@ const CRITERIA: Criterion[] = [
   {
     id: 'claude-reflect:preference-index',
     source: 'claude-reflect',
+    level: 3,
     category: 'self-tuning',
     name: 'Preference index',
     description: 'A structured index of captured preferences keyed by topic or file area.',
@@ -40,6 +44,7 @@ const CRITERIA: Criterion[] = [
   {
     id: 'claude-reflect:reflection-review',
     source: 'claude-reflect',
+    level: 4,
     category: 'self-tuning',
     name: 'Periodic reflection review',
     description: 'A scheduled job that surfaces captured reflections for human review and pruning.',
@@ -49,6 +54,7 @@ const CRITERIA: Criterion[] = [
   {
     id: 'claude-reflect:session-summary',
     source: 'claude-reflect',
+    level: 3,
     category: 'self-tuning',
     name: 'Session summary artifact',
     description: 'An end-of-session artifact that records what changed, what was tried, and what was learned.',

--- a/web/src/lib/acmm/sources/fullsend.ts
+++ b/web/src/lib/acmm/sources/fullsend.ts
@@ -4,6 +4,7 @@ const CRITERIA: Criterion[] = [
   {
     id: 'fullsend:test-coverage',
     source: 'fullsend',
+    level: 2,
     category: 'readiness',
     name: 'Test coverage threshold',
     description: 'Documented or enforced test coverage floor.',
@@ -13,6 +14,7 @@ const CRITERIA: Criterion[] = [
   {
     id: 'fullsend:ci-cd-maturity',
     source: 'fullsend',
+    level: 2,
     category: 'readiness',
     name: 'CI/CD pipeline',
     description: 'A working CI/CD pipeline that runs on every PR.',
@@ -22,6 +24,7 @@ const CRITERIA: Criterion[] = [
   {
     id: 'fullsend:auto-merge-policy',
     source: 'fullsend',
+    level: 3,
     category: 'autonomy',
     name: 'Auto-merge policy',
     description: 'Explicit policy for when PRs auto-merge vs. escalate to humans.',
@@ -31,6 +34,7 @@ const CRITERIA: Criterion[] = [
   {
     id: 'fullsend:branch-protection-doc',
     source: 'fullsend',
+    level: 3,
     category: 'governance',
     name: 'Branch protection documentation',
     description: 'Documented branch protection rules (required reviews, status checks).',
@@ -40,6 +44,7 @@ const CRITERIA: Criterion[] = [
   {
     id: 'fullsend:production-feedback',
     source: 'fullsend',
+    level: 4,
     category: 'observability',
     name: 'Production feedback signal',
     description: 'A mechanism that feeds production observations back into the development loop.',
@@ -49,6 +54,7 @@ const CRITERIA: Criterion[] = [
   {
     id: 'fullsend:observability-runbook',
     source: 'fullsend',
+    level: 4,
     category: 'observability',
     name: 'Observability runbook',
     description: 'A runbook or guide describing how humans debug autonomous behavior.',
@@ -58,6 +64,7 @@ const CRITERIA: Criterion[] = [
   {
     id: 'fullsend:risk-assessment',
     source: 'fullsend',
+    level: 4,
     category: 'autonomy',
     name: 'Risk assessment config',
     description: 'A config that lets the agent assess blast radius before acting.',
@@ -67,6 +74,7 @@ const CRITERIA: Criterion[] = [
   {
     id: 'fullsend:rollback-drill',
     source: 'fullsend',
+    level: 3,
     category: 'readiness',
     name: 'Rollback drill',
     description: 'A documented or automated rollback procedure.',

--- a/web/src/lib/dashboards/dashboardHooks.ts
+++ b/web/src/lib/dashboards/dashboardHooks.ts
@@ -8,6 +8,7 @@ import {
   DragStartEvent } from '@dnd-kit/core'
 import { arrayMove, sortableKeyboardCoordinates } from '@dnd-kit/sortable'
 import { dashboardSync } from './dashboardSync'
+import { hasUnifiedConfig } from '../../config/cards'
 import { DashboardCard, DashboardCardPlacement, NewCardInput } from './types'
 import { useDashboardUndoRedo } from '../../hooks/useUndoRedo'
 import { setAutoRefreshPaused } from '../cache'
@@ -141,8 +142,12 @@ export function useDashboardCards(
       const stored = localStorage.getItem(storageKey)
       if (stored) {
         const parsed = JSON.parse(stored) as DashboardCard[]
+        // Filter out card types that were removed from the registry (e.g.
+        // acmm_balance after #8426). Without this, users who visited
+        // before the removal keep a ghost card in their saved layout.
+        const valid = parsed.filter(c => hasUnifiedConfig(c.card_type))
         // Ensure every card has a position object (guards against old/corrupt data)
-        return parsed.map(c => ({
+        return valid.map(c => ({
           ...c,
           position: c.position || { w: 4, h: 2 } }))
       }


### PR DESCRIPTION
## Summary

Bundle of ACMM dashboard fixes:

1. **Auto-prune stale card types** — when loading from localStorage, filter out cards whose `card_type` is no longer in the registry. Fixes ghost cards (like the removed `acmm_balance`) persisting in users' browsers without manual clearing.

2. **Level assignments** — all 20 criteria from fullsend (8), AEF (6), and claude-reflect (6) now have ACMM levels (L2-L4) so they participate in the lock/unlock gamification and show level badges in the inventory.

3. **Layout fix** — `max-w-4xl` on the Feedback Loop Inventory content prevents L2/ACMM badges and "Ask agent for help" from being pushed to the far right edge on the full-width (12w) card.

4. **Slider hint** — "drag to preview AI vs human balance" text prompts users to interact with the explore-level slider.

5. **Level-up button fix** — targets `earnedLevel + 1` (the level you're working toward) instead of `earnedLevel` (which has no criteria at L1).

## Test plan

- [ ] Clear localStorage → 3-card ACMM layout loads (no ghost balance card)
- [ ] Returning user with old layout → balance card auto-removed on load
- [ ] Fullsend/AEF/Reflect criteria now show L2-L4 badges in the inventory
- [ ] Lock system applies to fullsend/AEF/reflect criteria (not just ACMM ones)
- [ ] Inventory content is readable on full-width card (not stretched to edges)
- [ ] Slider shows "drag to preview" hint
- [ ] L1 repo (ublue-os/bluefin) → "Help me reach L2" button visible at bottom of inventory