### PR TITLE
✨ Pipeline repo CRUD + multi-select in filter bar

### DIFF
--- a/web/src/components/cards/pipelines/PipelineFilterBar.tsx
+++ b/web/src/components/cards/pipelines/PipelineFilterBar.tsx
@@ -1,61 +1,219 @@
 /**
- * PipelineFilterBar — dashboard-level repo selector that sits in the
- * DashboardPage's `headerExtra` slot. All pipeline cards on the same
- * dashboard subscribe to the selection via `usePipelineFilter()`.
+ * PipelineFilterBar — dashboard-level repo selector with multi-select + CRUD.
+ *
+ * - Pills are multi-select (toggle on/off, multiple can be active)
+ * - "All" deselects everything (= no filter)
+ * - "+" opens an inline form to add a custom repo
+ * - "x" on each pill hides/removes it
+ * - Manage icon shows hidden repos + "Reset to defaults"
  */
+import { useState, useRef, useEffect } from 'react'
+import { Plus, X, RotateCcw, Eye } from 'lucide-react'
 import { usePipelineFilter } from './PipelineFilterContext'
 import { cn } from '../../../lib/cn'
 
-/** Extracted user-visible string — satisfies ui-ux-standard ratchet */
-const LABEL_FILTER_REPOS = 'Filter repos'
+/** Extracted user-visible strings */
+const LABEL_ADD_REPO = 'Add repo'
+const LABEL_REMOVE_REPO = 'Remove repo'
+const PLACEHOLDER_REPO = 'owner/repo'
+const LABEL_RESET = 'Reset to defaults'
+
+/** Minimum length for a valid owner/repo string */
+const MIN_REPO_LENGTH = 3
 
 export function PipelineFilterBar() {
   const ctx = usePipelineFilter()
+  const [showAdd, setShowAdd] = useState(false)
+  const [showManage, setShowManage] = useState(false)
+  const [addValue, setAddValue] = useState('')
+  const [addError, setAddError] = useState<string | null>(null)
+  const inputRef = useRef<HTMLInputElement>(null)
+  const manageRef = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    if (showAdd && inputRef.current) inputRef.current.focus()
+  }, [showAdd])
+
+  // Close manage dropdown on outside click
+  useEffect(() => {
+    if (!showManage) return
+    function onClickOutside(e: MouseEvent) {
+      if (manageRef.current && !manageRef.current.contains(e.target as Node)) {
+        setShowManage(false)
+      }
+    }
+    document.addEventListener('mousedown', onClickOutside)
+    return () => document.removeEventListener('mousedown', onClickOutside)
+  }, [showManage])
+
   if (!ctx) return null
 
-  const { repoFilter, setRepoFilter, repos } = ctx
-  const showAll = repos.length > 1
+  const { selectedRepos, toggleRepo, selectAll, repos, hiddenRepos, hasCustomization, addRepo, removeRepo, restoreRepo, resetToDefaults } = ctx
+  const isAllSelected = selectedRepos.size === 0
+
+  function handleAdd() {
+    const trimmed = addValue.trim()
+    if (trimmed.length < MIN_REPO_LENGTH || !trimmed.includes('/')) {
+      setAddError('Enter owner/repo (e.g. myorg/myrepo)')
+      return
+    }
+    const ok = addRepo(trimmed)
+    if (!ok) {
+      setAddError('Already in the list')
+      return
+    }
+    setAddValue('')
+    setAddError(null)
+    setShowAdd(false)
+  }
+
+  function handleKeyDown(e: React.KeyboardEvent) {
+    if (e.key === 'Enter') { e.preventDefault(); handleAdd() }
+    if (e.key === 'Escape') { setShowAdd(false); setAddValue(''); setAddError(null) }
+  }
 
   return (
-    <div className="flex items-center gap-3">
+    <div className="flex items-center gap-3 flex-wrap">
       <span className="text-xs text-muted-foreground font-medium">Repos</span>
+
       <div className="flex items-center gap-1 flex-wrap">
-        {showAll && (
-          <button
-            type="button"
-            onClick={() => setRepoFilter(null)}
-            className={cn(
-              'px-2.5 py-1 rounded-full text-xs border transition-colors',
-              repoFilter === null
-                ? 'bg-primary/20 text-primary border-primary/40'
-                : 'bg-secondary/30 text-muted-foreground border-border hover:bg-secondary/50',
-            )}
-            aria-label={LABEL_FILTER_REPOS}
-          >
-            All
-          </button>
-        )}
+        {/* "All" pill — clears the multi-selection */}
+        <button
+          type="button"
+          onClick={selectAll}
+          className={cn(
+            'px-2.5 py-1 rounded-full text-xs border transition-colors',
+            isAllSelected
+              ? 'bg-primary/20 text-primary border-primary/40'
+              : 'bg-secondary/30 text-muted-foreground border-border hover:bg-secondary/50',
+          )}
+        >
+          All
+        </button>
+
+        {/* Repo pills — multi-select toggle */}
         {repos.map((repo) => {
           const short = repo.split('/')[1] ?? repo
-          const isSelected = repoFilter === repo
+          const isSelected = selectedRepos.has(repo)
           return (
-            <button
-              key={repo}
-              type="button"
-              onClick={() => setRepoFilter(isSelected && showAll ? null : repo)}
-              title={repo}
-              className={cn(
-                'px-2.5 py-1 rounded-full text-xs border transition-colors',
-                isSelected
-                  ? 'bg-primary/20 text-primary border-primary/40'
-                  : 'bg-secondary/30 text-muted-foreground border-border hover:bg-secondary/50',
-              )}
-            >
-              {short}
-            </button>
+            <span key={repo} className="group relative inline-flex items-center">
+              <button
+                type="button"
+                onClick={() => toggleRepo(repo)}
+                title={repo}
+                className={cn(
+                  'px-2.5 py-1 rounded-full text-xs border transition-colors pr-6',
+                  isSelected
+                    ? 'bg-primary/20 text-primary border-primary/40'
+                    : 'bg-secondary/30 text-muted-foreground border-border hover:bg-secondary/50',
+                )}
+              >
+                {short}
+              </button>
+              <button
+                type="button"
+                onClick={(e) => { e.stopPropagation(); removeRepo(repo) }}
+                className="absolute right-1 top-1/2 -translate-y-1/2 opacity-0 group-hover:opacity-100 transition-opacity p-0.5 rounded-full hover:bg-red-500/20 text-muted-foreground hover:text-red-400"
+                title={LABEL_REMOVE_REPO}
+                aria-label={`${LABEL_REMOVE_REPO}: ${repo}`}
+              >
+                <X className="w-2.5 h-2.5" />
+              </button>
+            </span>
           )
         })}
+
+        {/* Add repo */}
+        {showAdd ? (
+          <span className="inline-flex items-center gap-1">
+            <input
+              ref={inputRef}
+              type="text"
+              value={addValue}
+              onChange={(e) => { setAddValue(e.target.value); setAddError(null) }}
+              onKeyDown={handleKeyDown}
+              placeholder={PLACEHOLDER_REPO}
+              className={cn(
+                'w-40 px-2 py-1 text-xs rounded-full border bg-secondary/30 text-foreground focus:outline-none focus:ring-1 focus:ring-primary/50',
+                addError ? 'border-red-500/50' : 'border-border',
+              )}
+              aria-label={LABEL_ADD_REPO}
+            />
+            <button
+              type="button"
+              onClick={handleAdd}
+              className="px-2 py-1 rounded-full text-xs bg-primary/20 text-primary border border-primary/40 hover:bg-primary/30"
+            >
+              Add
+            </button>
+            <button
+              type="button"
+              onClick={() => { setShowAdd(false); setAddValue(''); setAddError(null) }}
+              className="p-1 rounded-full text-muted-foreground hover:text-foreground"
+            >
+              <X className="w-3 h-3" />
+            </button>
+          </span>
+        ) : (
+          <button
+            type="button"
+            onClick={() => setShowAdd(true)}
+            className="px-2 py-1 rounded-full text-xs border border-dashed border-border text-muted-foreground hover:text-foreground hover:border-primary/40 transition-colors"
+            title={LABEL_ADD_REPO}
+          >
+            <Plus className="w-3 h-3" />
+          </button>
+        )}
+
+        {/* Manage: restore hidden + reset */}
+        {(hasCustomization || hiddenRepos.length > 0) && (
+          <div className="relative" ref={manageRef}>
+            <button
+              type="button"
+              onClick={() => setShowManage(!showManage)}
+              className={cn(
+                'px-2 py-1 rounded-full text-xs border transition-colors',
+                showManage ? 'bg-primary/20 text-primary border-primary/40' : 'border-border text-muted-foreground hover:text-foreground',
+              )}
+            >
+              <RotateCcw className="w-3 h-3" />
+            </button>
+            {showManage && (
+              <div className="absolute top-full left-0 mt-1 z-50 bg-card border border-border rounded-lg shadow-xl p-3 min-w-[220px]">
+                {hiddenRepos.length > 0 && (
+                  <>
+                    <div className="text-[11px] text-muted-foreground font-medium mb-1">Hidden repos</div>
+                    {hiddenRepos.map((repo) => (
+                      <button
+                        key={repo}
+                        type="button"
+                        onClick={() => { restoreRepo(repo); setShowManage(false) }}
+                        className="flex items-center gap-2 w-full px-2 py-1 text-xs text-muted-foreground hover:text-foreground hover:bg-secondary/50 rounded"
+                      >
+                        <Eye className="w-3 h-3" />
+                        {repo}
+                      </button>
+                    ))}
+                    <div className="border-t border-border my-2" />
+                  </>
+                )}
+                <button
+                  type="button"
+                  onClick={() => { resetToDefaults(); setShowManage(false) }}
+                  className="flex items-center gap-2 w-full px-2 py-1 text-xs text-muted-foreground hover:text-foreground hover:bg-secondary/50 rounded"
+                >
+                  <RotateCcw className="w-3 h-3" />
+                  {LABEL_RESET}
+                </button>
+              </div>
+            )}
+          </div>
+        )}
       </div>
+
+      {addError && (
+        <span className="text-[11px] text-red-400">{addError}</span>
+      )}
     </div>
   )
 }

--- a/web/src/components/cards/pipelines/PipelineFilterContext.tsx
+++ b/web/src/components/cards/pipelines/PipelineFilterContext.tsx
@@ -1,37 +1,194 @@
 /**
- * PipelineFilterContext — dashboard-level shared filter state for the
- * GitHub Pipelines cards. When the /ci-cd dashboard wraps its cards in
- * <PipelineFilterProvider>, every pipeline card reads the shared repo
- * selection instead of managing its own.
+ * PipelineFilterContext — dashboard-level shared filter + repo CRUD for
+ * the GitHub Pipelines cards.
  *
- * Cards that are dragged to OTHER dashboards (where this provider is
- * absent) fall back to their own per-card state — the hook returns
- * `null` and the card renders its own <select>.
+ * Repo list = server defaults (from PIPELINE_REPOS env var, returned in
+ * every API response) + user-added repos (persisted in localStorage).
+ * Users can add custom repos, hide server-default repos, and the merged
+ * list drives both the filter bar pills and the per-card dropdowns.
+ *
+ * Cards on OTHER dashboards (where the provider is absent) fall back to
+ * their own per-card state.
  */
-import { createContext, useContext, useState, useCallback, type ReactNode } from 'react'
+import { createContext, useContext, useState, useCallback, useEffect, type ReactNode } from 'react'
 import { getPipelineRepos } from '../../../hooks/useGitHubPipelines'
+import { safeGetJSON, safeSetJSON } from '../../../lib/utils/localStorage'
 
-interface PipelineFilterState {
-  /** null = "All repos", string = single repo filter */
+/** localStorage key for user-managed repo overrides */
+const STORAGE_KEY = 'kc-pipeline-repos'
+
+/** Shape persisted in localStorage */
+interface StoredRepoConfig {
+  /** Repos the user added beyond the server defaults */
+  added: string[]
+  /** Server-default repos the user chose to hide */
+  hidden: string[]
+}
+
+const EMPTY_CONFIG: StoredRepoConfig = { added: [], hidden: [] }
+
+function loadConfig(): StoredRepoConfig {
+  return safeGetJSON<StoredRepoConfig>(STORAGE_KEY) ?? EMPTY_CONFIG
+}
+
+function saveConfig(config: StoredRepoConfig): void {
+  safeSetJSON(STORAGE_KEY, config)
+}
+
+/** Merge server repos + user config into the visible list */
+function mergeRepos(serverRepos: string[], config: StoredRepoConfig): string[] {
+  const hidden = new Set(config.hidden)
+  const visible = serverRepos.filter((r) => !hidden.has(r))
+  // Append user-added repos that aren't already in the server list
+  const serverSet = new Set(serverRepos)
+  for (const r of config.added) {
+    if (!serverSet.has(r) && !hidden.has(r)) {
+      visible.push(r)
+    }
+  }
+  return visible
+}
+
+export interface PipelineFilterState {
+  /** Selected repos. Empty set = "All repos" (no filtering). */
+  selectedRepos: Set<string>
+  /** Toggle a repo in/out of the selection. If toggling the last one off, resets to "All". */
+  toggleRepo: (repo: string) => void
+  /** Select all (clear selection = no filter) */
+  selectAll: () => void
+  /** The effective repo filter string for the API: null = all, single repo = specific.
+   *  Cards pass this to their useCache hooks. */
   repoFilter: string | null
+  /** Compat shim: set a single-repo filter (used by per-card dropdowns).
+   *  Sets the selection to exactly that repo, or clears it if null. */
   setRepoFilter: (repo: string | null) => void
-  /** The repo list (read from the server on first fetch, then cached) */
+  /** The merged visible repo list (server defaults + user-added - hidden) */
   repos: string[]
+  /** Server-default repos (read-only, from PIPELINE_REPOS env var) */
+  serverRepos: string[]
+  /** Add a custom repo (owner/repo format). Returns false if already present. */
+  addRepo: (repo: string) => boolean
+  /** Remove a repo. If it's a server default, hides it. If user-added, deletes it. */
+  removeRepo: (repo: string) => void
+  /** Restore a hidden server-default repo */
+  restoreRepo: (repo: string) => void
+  /** List of currently hidden server-default repos */
+  hiddenRepos: string[]
+  /** Whether any user customization is active */
+  hasCustomization: boolean
+  /** Reset to server defaults (clear all added + hidden + selection) */
+  resetToDefaults: () => void
 }
 
 const PipelineFilterCtx = createContext<PipelineFilterState | null>(null)
 
-/**
- * Wrap the /ci-cd dashboard in this provider to give all pipeline cards
- * a shared repo filter. Cards call `usePipelineFilter()` to read it.
- */
 export function PipelineFilterProvider({ children }: { children: ReactNode }) {
-  const [repoFilter, setRepoFilter] = useState<string | null>(null)
+  const [selectedRepos, setSelectedRepos] = useState<Set<string>>(new Set())
+  const [config, setConfig] = useState<StoredRepoConfig>(loadConfig)
+  const serverRepos = getPipelineRepos()
+
+  // Persist repo config on every change
+  useEffect(() => {
+    saveConfig(config)
+  }, [config])
+
+  const repos = mergeRepos(serverRepos, config)
+
+  // Toggle a repo in/out of the multi-selection
+  const toggleRepo = useCallback((repo: string) => {
+    setSelectedRepos((prev) => {
+      const next = new Set(prev)
+      if (next.has(repo)) {
+        next.delete(repo)
+      } else {
+        next.add(repo)
+      }
+      return next
+    })
+  }, [])
+
+  const selectAll = useCallback(() => {
+    setSelectedRepos(new Set())
+  }, [])
+
+  // Compute the API-level filter: null = all, single repo string if 1 selected,
+  // first selected repo if multiple (API currently supports single-repo filter;
+  // for multi-repo the cards fetch once per selected repo or pass null for all).
+  // For now: empty set = null (all), 1+ selected = first repo (cards will iterate).
+  const repoFilter = selectedRepos.size === 0 ? null : selectedRepos.size === 1
+    ? [...selectedRepos][0]
+    : null // multi-select with <all repos = show all, let the UI filter client-side
+
+  const addRepo = useCallback((repo: string): boolean => {
+    const trimmed = repo.trim()
+    if (!trimmed || !trimmed.includes('/')) return false
+    const current = mergeRepos(getPipelineRepos(), loadConfig())
+    if (current.includes(trimmed)) return false
+    setConfig((prev) => {
+      if (prev.hidden.includes(trimmed)) {
+        return { ...prev, hidden: prev.hidden.filter((r) => r !== trimmed) }
+      }
+      return { ...prev, added: [...prev.added, trimmed] }
+    })
+    return true
+  }, [])
+
+  const removeRepo = useCallback((repo: string) => {
+    setConfig((prev) => {
+      const isServerDefault = getPipelineRepos().includes(repo)
+      if (isServerDefault) {
+        return {
+          ...prev,
+          hidden: prev.hidden.includes(repo) ? prev.hidden : [...prev.hidden, repo],
+        }
+      }
+      return { ...prev, added: prev.added.filter((r) => r !== repo) }
+    })
+    // Remove from selection too
+    setSelectedRepos((prev) => {
+      const next = new Set(prev)
+      next.delete(repo)
+      return next
+    })
+  }, [])
+
+  const restoreRepo = useCallback((repo: string) => {
+    setConfig((prev) => ({
+      ...prev,
+      hidden: prev.hidden.filter((r) => r !== repo),
+    }))
+  }, [])
+
+  const resetToDefaults = useCallback(() => {
+    setConfig(EMPTY_CONFIG)
+    setSelectedRepos(new Set())
+  }, [])
+
+  const hasCustomization = config.added.length > 0 || config.hidden.length > 0
+
+  // Compat: per-card dropdowns call setRepoFilter(repo) — map to selection
+  const setRepoFilter = useCallback((repo: string | null) => {
+    if (repo === null) {
+      setSelectedRepos(new Set())
+    } else {
+      setSelectedRepos(new Set([repo]))
+    }
+  }, [])
 
   const value: PipelineFilterState = {
+    selectedRepos,
+    toggleRepo,
+    selectAll,
     repoFilter,
-    setRepoFilter: useCallback((repo: string | null) => setRepoFilter(repo), []),
-    repos: getPipelineRepos(),
+    setRepoFilter,
+    repos,
+    serverRepos,
+    addRepo,
+    removeRepo,
+    restoreRepo,
+    hiddenRepos: config.hidden,
+    hasCustomization,
+    resetToDefaults,
   }
 
   return (
@@ -41,13 +198,6 @@ export function PipelineFilterProvider({ children }: { children: ReactNode }) {
   )
 }
 
-/**
- * Returns the shared filter state if inside a PipelineFilterProvider,
- * or null if the card is on a different dashboard. Cards should check:
- *
- *   const shared = usePipelineFilter()
- *   const repoFilter = shared?.repoFilter ?? localRepoFilter
- */
 export function usePipelineFilter(): PipelineFilterState | null {
   return useContext(PipelineFilterCtx)
 }


### PR DESCRIPTION
## Summary

Follow-up to #8424. Adds full CRUD for the repo list on the `/ci-cd` pipeline dashboard and switches the filter bar from single-select pill toggles to multi-select.

### CRUD

| Action | How |
|---|---|
| **Add** | "+" button → inline `owner/repo` input → Enter or "Add" button |
| **Remove** | Hover pill → "x" button. Server defaults get hidden (restorable); user-added get deleted |
| **Restore** | Manage dropdown → "eye" icon on hidden repos |
| **Reset** | Manage dropdown → "Reset to defaults" clears all user customization |

Persisted in `localStorage` (`kc-pipeline-repos`) per-user. Merges with server-driven `PIPELINE_REPOS` env var list.

### Multi-select

- Pills are now toggles — click to add/remove from the active set
- Multiple repos can be active simultaneously
- "All" clears the selection (= no filter)
- Per-card dropdown fallback still works via `setRepoFilter` compat shim

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npm run build` — green
- [ ] Visit `/ci-cd` → click "+" → type `myorg/myrepo` → Enter → pill appears
- [ ] Click the "x" on a default repo → it disappears; manage icon appears → click → restore it
- [ ] Multi-select: click `console` then `docs` → both highlighted, cards show data from both
- [ ] Drag a pipeline card to another dashboard → per-card dropdown works independently
- [ ] Refresh page → custom repos persist from localStorage