### PR TITLE
🐛 fix(missions): persist sidebar open/closed state instead of guessing from mission status

### DIFF
--- a/web/src/hooks/useMissions.tsx
+++ b/web/src/hooks/useMissions.tsx
@@ -538,29 +538,20 @@ export function MissionProvider({ children }: { children: ReactNode }) {
   // #7313 — Restore the active mission ID from localStorage so a reload
   // while a mission is running keeps the sidebar view open.
   const ACTIVE_MISSION_STORAGE_KEY = 'kc_active_mission_id'
+  /** Persists the sidebar open/closed state so it survives page refresh. */
+  const SIDEBAR_OPEN_STORAGE_KEY = 'kc_mission_sidebar_open'
   const [activeMissionId, setActiveMissionId] = useState<string | null>(() => {
     try {
       return localStorage.getItem(ACTIVE_MISSION_STORAGE_KEY) || null
     } catch { return null }
   })
   const [isSidebarOpen, setIsSidebarOpen] = useState(() => {
-    // #7313 — If there's a persisted active mission that is still
-    // in-progress, open the sidebar on load. Completed / failed /
-    // cancelled missions keep their ID in localStorage (so the
-    // transcript can be reviewed on reload) but should NOT force the
-    // sidebar open — that was annoying on every refresh.
+    // Restore the sidebar's open/closed state from localStorage.
+    // If the user had it open before refresh, it reopens. If closed,
+    // it stays closed. Simple and predictable — no heuristics about
+    // mission status or demo mode.
     try {
-      const persistedId = localStorage.getItem(ACTIVE_MISSION_STORAGE_KEY)
-      if (!persistedId) return false
-      // Cross-check against the persisted missions list.
-      const stored = localStorage.getItem(MISSIONS_STORAGE_KEY)
-      if (!stored) return false
-      const parsed = JSON.parse(stored) as Array<{ id: string; status: string }>
-      const match = (parsed || []).find(m => m.id === persistedId)
-      if (!match) return false
-      // Only auto-open for non-terminal statuses.
-      const terminalStatuses: Set<string> = new Set(['completed', 'failed', 'cancelled', 'saved'])
-      return !terminalStatuses.has(match.status)
+      return localStorage.getItem(SIDEBAR_OPEN_STORAGE_KEY) === 'true'
     } catch { return false }
   })
   const [isSidebarMinimized, setIsSidebarMinimized] = useState(false)
@@ -637,7 +628,11 @@ export function MissionProvider({ children }: { children: ReactNode }) {
       }
     } catch { /* localStorage unavailable */ }
   }, [activeMissionId])
-  useEffect(() => { isSidebarOpenRef.current = isSidebarOpen }, [isSidebarOpen])
+  useEffect(() => {
+    isSidebarOpenRef.current = isSidebarOpen
+    // Persist so the next page load restores the same state.
+    try { localStorage.setItem(SIDEBAR_OPEN_STORAGE_KEY, String(isSidebarOpen)) } catch { /* ok */ }
+  }, [isSidebarOpen])
   useEffect(() => { selectedAgentRef.current = selectedAgent }, [selectedAgent])
   useEffect(() => { defaultAgentRef.current = defaultAgent }, [defaultAgent])
   // Ref to always hold the latest handleAgentMessage — avoids reconnecting WebSocket when the handler changes


### PR DESCRIPTION
## Summary

**Problem:** The AI Missions sidebar re-opens on every refresh on \`console.kubestellar.io\` (and localhost). This persisted even after #8428 because the terminal-status heuristic races with demo-mode mission seeding — the \`useState\` initializer reads stale localStorage data that has \`running\` status from a previous interaction, then \`loadMissions()\` replaces it with fresh demo data milliseconds later, but the sidebar is already open.

**User's rule:** "If it was open before refresh, open it. If closed, keep it closed."

**Fix:** Replace the mission-status heuristic with a **direct boolean persistence**:

- New \`kc_mission_sidebar_open\` localStorage key
- Persisted on every \`isSidebarOpen\` state change via \`useEffect\`
- Read back on init — \`true\` = open, anything else = closed
- Works identically in demo mode and live mode — no heuristics, no race conditions

The \`ACTIVE_MISSION_STORAGE_KEY\` is still used for restoring which mission is selected (transcript view), just no longer for inferring sidebar visibility.

## Test plan

- [x] \`npm run build\` passes
- [ ] \`console.kubestellar.io\`: open sidebar → refresh → sidebar is open
- [ ] \`console.kubestellar.io\`: close sidebar → refresh → sidebar stays closed
- [ ] Same behavior on localhost with \`startup-oauth.sh\`
- [ ] Open sidebar → interact with a mission → close sidebar → refresh → stays closed

🤖 Generated with [Claude Code](https://claude.com/claude-code)