### PR TITLE
🐛 fix(missions): auto-seed sidebar key + stop setup dialog re-popping on refresh

### DIFF
--- a/web/src/components/layout/mission-sidebar/MissionChat.tsx
+++ b/web/src/components/layout/mission-sidebar/MissionChat.tsx
@@ -210,8 +210,15 @@ export function MissionChat({ mission, isFullScreen = false, fontSize = 'base' a
     }
   }, [mission.status])
 
-  // Auto-open setup dialog when agent connection error occurs
+  // Auto-open setup dialog when agent connection error occurs — but only
+  // for NEW messages, not messages restored from localStorage on refresh.
+  // Without this guard the dialog re-pops on every refresh because the
+  // stale "Local Agent Not Connected" system message persists across
+  // page loads.
+  const initialMessageCountRef = useRef(mission.messages.length)
   useEffect(() => {
+    // Skip messages that existed at mount time (restored from persistence).
+    if (mission.messages.length <= initialMessageCountRef.current) return
     const lastMsg = mission.messages[mission.messages.length - 1]
     if (lastMsg?.role === 'system' && lastMsg.content.includes('Local Agent Not Connected')) {
       setShowSetupDialog(true)

--- a/web/src/hooks/useMissions.tsx
+++ b/web/src/hooks/useMissions.tsx
@@ -550,8 +550,22 @@ export function MissionProvider({ children }: { children: ReactNode }) {
     // If the user had it open before refresh, it reopens. If closed,
     // it stays closed. Simple and predictable — no heuristics about
     // mission status or demo mode.
+    //
+    // One-time migration for users who visited before #8436: if the
+    // new key doesn't exist yet but the old kc_active_mission_id does,
+    // default to closed and write the new key so the old heuristic
+    // never runs again. This prevents the sidebar from force-opening
+    // on every refresh for existing users who had a stale active ID.
     try {
-      return localStorage.getItem(SIDEBAR_OPEN_STORAGE_KEY) === 'true'
+      const persisted = localStorage.getItem(SIDEBAR_OPEN_STORAGE_KEY)
+      if (persisted !== null) {
+        // New key exists — use it directly.
+        return persisted === 'true'
+      }
+      // New key missing (first visit after #8436). Default to closed
+      // and seed the key so subsequent refreshes use the new path.
+      localStorage.setItem(SIDEBAR_OPEN_STORAGE_KEY, 'false')
+      return false
     } catch { return false }
   })
   const [isSidebarMinimized, setIsSidebarMinimized] = useState(false)


### PR DESCRIPTION
## Summary

Two bundled fixes for modals/sidebar misbehaving on refresh:

### 1. Auto-seed sidebar key for pre-#8436 users

Users who visited before #8436 don't have \`kc_mission_sidebar_open\` in localStorage. On first visit after the fix, the key is \`null\` — the sidebar correctly defaults to closed, but the key never gets written. This seeds it explicitly so it exists for all subsequent loads.

### 2. Setup dialog stops re-popping on refresh

The "Run KubeStellar Console Locally" setup dialog re-appears on every refresh because the auto-open \`useEffect\` in \`MissionChat.tsx\` checks \`mission.messages\` for a "Local Agent Not Connected" system message — and that message persists in localStorage across reloads.

**Fix:** Capture the initial message count at mount time via \`useRef\`. The \`useEffect\` only opens the dialog for messages that arrive AFTER mount (new real-time messages), not messages restored from a previous session.

This does NOT prevent the dialog from showing the first time the error occurs — only from re-showing on refresh after the user already dismissed it.

## Test plan

- [x] \`npm run build\` passes
- [ ] Run a mission in demo mode → "Local Agent Not Connected" → setup dialog appears → close it → refresh → dialog does NOT re-appear
- [ ] Clear all localStorage → refresh → sidebar closed, \`kc_mission_sidebar_open\` = \`'false'\`
- [ ] Trigger a real "Local Agent Not Connected" (no kc-agent running) → dialog still shows the first time

🤖 Generated with [Claude Code](https://claude.com/claude-code)