### PR TITLE
🐛 ACMM: unlock next level's criteria (lock only L3+ for L1 repos)

### DIFF
--- a/web/src/components/cards/ACMMFeedbackLoops.tsx
+++ b/web/src/components/cards/ACMMFeedbackLoops.tsx
@@ -216,10 +216,10 @@ export function ACMMFeedbackLoops() {
                 ? 'bg-yellow-500/20 text-yellow-400 hover:bg-yellow-500/30'
                 : 'bg-muted/30 text-muted-foreground hover:bg-muted/50'
             }`}
-            title={locksOverridden ? 'Locks overridden for this session — click to re-lock' : `Locked above L${earnedLevel} — click to override`}
+            title={locksOverridden ? 'Locks overridden for this session — click to re-lock' : `Locked above L${earnedLevel + 1} — click to override`}
           >
             {locksOverridden ? <Unlock className="w-2.5 h-2.5" /> : <Lock className="w-2.5 h-2.5" />}
-            {locksOverridden ? 'Unlocked' : `L${earnedLevel}`}
+            {locksOverridden ? 'Unlocked' : `≤ L${earnedLevel + 1}`}
           </button>
           {(['all', 'detected', 'missing'] as const).map((s) => (
             <button
@@ -244,7 +244,9 @@ export function ACMMFeedbackLoops() {
           // Lock criteria above earnedLevel until the user finishes their
           // current level (or chooses to override). Criteria without a
           // level (structural ones) are never locked.
-          const isLocked = !locksOverridden && !!c.level && c.level > earnedLevel
+          // Lock criteria TWO+ levels above earned. The next level (earnedLevel+1)
+          // stays unlocked — that's what the user is actively working toward.
+          const isLocked = !locksOverridden && !!c.level && c.level > earnedLevel + 1
           const isLockPromptOpen = lockPromptId === c.id
           return (
             <div


### PR DESCRIPTION
## Summary

For an L1 repo, L2 criteria were locked — but L2 is exactly what the user needs to work on. The lock was one level too aggressive.

**Before:** `c.level > earnedLevel` → L1 repo locks L2+
**After:** `c.level > earnedLevel + 1` → L1 repo locks L3+ (L2 stays open)

Also updated the lock chip label from `L1` to `≤ L2` to show the unlocked boundary.

## Test plan

- [ ] L1 repo (ublue-os/bluefin) → L2 criteria unlocked, L3-L5 locked
- [ ] L4 repo (kubestellar/console) → L2-L5 unlocked, nothing locked (L5 = earnedLevel+1)
- [ ] Click locked L3 item → override prompt still works
- [ ] Lock chip shows `≤ L2` for L1 repos