### PR TITLE
🐛 fix: broaden card prune filter to include component-only cards (#8438)

### DIFF
--- a/web/src/lib/dashboards/__tests__/dashboardHooks.test.ts
+++ b/web/src/lib/dashboards/__tests__/dashboardHooks.test.ts
@@ -24,6 +24,15 @@ vi.mock('../../cache', () => ({
   setAutoRefreshPaused: (...args: unknown[]) => mockSetAutoRefreshPaused(...args),
 }))
 
+// Allow all card types through the prune filter so synthetic test types
+// (card_a, saved_card, x, etc.) are not filtered out during localStorage restore.
+vi.mock('../../../config/cards', () => ({
+  hasUnifiedConfig: () => true,
+}))
+vi.mock('../../../components/cards/cardRegistry', () => ({
+  isCardTypeRegistered: () => true,
+}))
+
 // Mock requestAnimationFrame for undo/redo
 vi.stubGlobal('requestAnimationFrame', (cb: () => void) => { cb(); return 0 })
 

--- a/web/src/lib/dashboards/dashboardHooks.ts
+++ b/web/src/lib/dashboards/dashboardHooks.ts
@@ -9,6 +9,7 @@ import {
 import { arrayMove, sortableKeyboardCoordinates } from '@dnd-kit/sortable'
 import { dashboardSync } from './dashboardSync'
 import { hasUnifiedConfig } from '../../config/cards'
+import { isCardTypeRegistered } from '../../components/cards/cardRegistry'
 import { DashboardCard, DashboardCardPlacement, NewCardInput } from './types'
 import { useDashboardUndoRedo } from '../../hooks/useUndoRedo'
 import { setAutoRefreshPaused } from '../cache'
@@ -145,7 +146,11 @@ export function useDashboardCards(
         // Filter out card types that were removed from the registry (e.g.
         // acmm_balance after #8426). Without this, users who visited
         // before the removal keep a ghost card in their saved layout.
-        const valid = parsed.filter(c => hasUnifiedConfig(c.card_type))
+        // Check both UnifiedCardConfig AND the component registry so
+        // component-only cards (e.g. benchmark_hero) are not pruned.
+        const valid = parsed.filter(c =>
+          hasUnifiedConfig(c.card_type) || isCardTypeRegistered(c.card_type)
+        )
         // Ensure every card has a position object (guards against old/corrupt data)
         return valid.map(c => ({
           ...c,


### PR DESCRIPTION
## Summary

- Broadens the localStorage card prune filter in `dashboardHooks.ts` to check both `hasUnifiedConfig()` AND `isCardTypeRegistered()` from cardRegistry
- Component-only cards (tracked via `CARD_COMPONENTS` / `CARD_PROJECT_TAGS` like `benchmark_hero`) are no longer incorrectly pruned on page load
- Mocks both registry functions in the dashboardHooks unit tests so synthetic `card_type` values pass the filter

Fixes #8438, Fixes #8437

## Test plan

- [x] All 51 existing `dashboardHooks.test.ts` tests pass
- [x] `npm run build` passes
- [x] `npm run lint` clean on changed files
- [ ] CI build/lint passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)