### PR TITLE
fix: update stale sidebar comment + add persistence test

### DIFF
--- a/web/src/hooks/useMissions.test.tsx
+++ b/web/src/hooks/useMissions.test.tsx
@@ -5821,3 +5821,48 @@ describe('runSavedMission wsSend failure', () => {
     }
   })
 })
+
+// ── Sidebar open/closed persistence via kc_mission_sidebar_open ──────────────
+
+describe('sidebar open/closed persistence', () => {
+  const SIDEBAR_OPEN_KEY = 'kc_mission_sidebar_open'
+
+  it('persists sidebar open state to localStorage when opened', () => {
+    const { result } = renderHook(() => useMissions(), { wrapper })
+
+    // Sidebar starts closed (localStorage is cleared in beforeEach)
+    expect(result.current.isSidebarOpen).toBe(false)
+    expect(localStorage.getItem(SIDEBAR_OPEN_KEY)).toBe('false')
+
+    act(() => { result.current.openSidebar() })
+
+    expect(result.current.isSidebarOpen).toBe(true)
+    expect(localStorage.getItem(SIDEBAR_OPEN_KEY)).toBe('true')
+  })
+
+  it('persists sidebar closed state to localStorage when closed', () => {
+    // Pre-seed open state
+    localStorage.setItem(SIDEBAR_OPEN_KEY, 'true')
+
+    const { result } = renderHook(() => useMissions(), { wrapper })
+    expect(result.current.isSidebarOpen).toBe(true)
+
+    act(() => { result.current.closeSidebar() })
+
+    expect(result.current.isSidebarOpen).toBe(false)
+    expect(localStorage.getItem(SIDEBAR_OPEN_KEY)).toBe('false')
+  })
+
+  it('restores sidebar open state from localStorage on mount', () => {
+    localStorage.setItem(SIDEBAR_OPEN_KEY, 'true')
+
+    const { result } = renderHook(() => useMissions(), { wrapper })
+    expect(result.current.isSidebarOpen).toBe(true)
+  })
+
+  it('defaults to closed when localStorage has no sidebar key', () => {
+    // localStorage is cleared in beforeEach — no key present
+    const { result } = renderHook(() => useMissions(), { wrapper })
+    expect(result.current.isSidebarOpen).toBe(false)
+  })
+})

--- a/web/src/hooks/useMissions.tsx
+++ b/web/src/hooks/useMissions.tsx
@@ -536,7 +536,8 @@ function saveUnreadMissionIds(ids: Set<string>) {
 export function MissionProvider({ children }: { children: ReactNode }) {
   const [missions, setMissions] = useState<Mission[]>(() => loadMissions())
   // #7313 — Restore the active mission ID from localStorage so a reload
-  // while a mission is running keeps the sidebar view open.
+  // remembers which mission was selected. Sidebar visibility is restored
+  // separately via SIDEBAR_OPEN_STORAGE_KEY (kc_mission_sidebar_open).
   const ACTIVE_MISSION_STORAGE_KEY = 'kc_active_mission_id'
   /** Persists the sidebar open/closed state so it survives page refresh. */
   const SIDEBAR_OPEN_STORAGE_KEY = 'kc_mission_sidebar_open'


### PR DESCRIPTION
## Summary
- Updated stale comment at `useMissions.tsx:539` that incorrectly claimed restoring `kc_active_mission_id` keeps the sidebar view open on reload. Sidebar visibility is actually restored via `kc_mission_sidebar_open`.
- Added 4 unit tests for sidebar open/closed state persistence via localStorage: open, close, restore on mount, default when absent.

Fixes #8443

## Test plan
- [x] All 288 useMissions tests pass (`npx vitest run src/hooks/useMissions.test.tsx`)
- [x] `npm run build` passes
- [x] `npm run lint` shows no new issues