### PR TITLE
✨ Multi-repo pulse card + matrix newest-first

### DIFF
--- a/web/src/components/cards/pipelines/NightlyReleasePulse.tsx
+++ b/web/src/components/cards/pipelines/NightlyReleasePulse.tsx
@@ -1,30 +1,46 @@
 /**
- * NightlyReleasePulse — mirrors the NightlyE2EStatus card UX:
- * colored run dots with hover popups, trend indicator, clickable
- * GitHub links, newest run leftmost. Drop-in for CI/CD dashboard.
+ * NightlyReleasePulse — NightlyE2E-style card showing per-workflow
+ * run dots with hover popups, trend indicators, and clickable links.
  *
- * Data: /api/github-pipelines?view=pulse
+ * Multi-repo aware:
+ * - On /ci-cd (inside PipelineFilterProvider): reads shared selection,
+ *   shows one row per workflow per selected repo.
+ * - On other dashboards (no provider): shows an input to type owner/repo.
+ *
+ * Uses the matrix view for per-workflow dot rows (already has per-repo
+ * per-workflow history) and the pulse view for the hero header.
  */
 import { useState, useRef, useMemo } from 'react'
 import { createPortal } from 'react-dom'
 import {
   CheckCircle, XCircle, AlertTriangle, Clock, ExternalLink,
-  TrendingUp, TrendingDown, Minus, Loader2,
+  TrendingUp, TrendingDown, Minus, Loader2, Search,
 } from 'lucide-react'
 import { useDemoMode } from '../../../hooks/useDemoMode'
 import { useCardLoadingState } from '../CardDataContext'
-import { usePipelinePulse } from '../../../hooks/useGitHubPipelines'
+import {
+  usePipelinePulse,
+  usePipelineMatrix,
+  type MatrixWorkflow,
+  type Conclusion,
+} from '../../../hooks/useGitHubPipelines'
+import { usePipelineFilter } from './PipelineFilterContext'
 import { cn } from '../../../lib/cn'
 
-/** Max dots to render per row (matches NightlyE2EStatus's 7, but we have room for 14) */
+/** Max dots per row */
 const MAX_DOTS = 14
-/** ms before hiding the hover popup after mouse leaves */
+/** ms before hiding hover popup */
 const POPUP_HIDE_DELAY_MS = 200
-/** Minimum pass-rate delta between halves to flag a trend (avoids noise on flat data) */
+/** Minimum pass-rate delta to flag a trend */
 const TREND_THRESHOLD = 0.1
+/** Matrix days for dot rows */
+const MATRIX_DAYS = 14
 
-// Nightly release workflow link — used when the user hasn't selected a specific run
-const WORKFLOW_URL = 'https://github.com/kubestellar/console/actions/workflows/release.yml'
+const WORKFLOW_URL_BASE = 'https://github.com'
+
+/** Extracted strings for ui-ux ratchet */
+const PLACEHOLDER_REPO = 'owner/repo'
+const LABEL_SET_REPO = 'Set repo to monitor'
 
 function formatCron(cron: string): string {
   const parts = cron.trim().split(/\s+/)
@@ -47,50 +63,44 @@ function formatTimeAgo(iso: string): string {
   if (minutes < 60) return `${minutes}m ago`
   const hours = Math.floor(minutes / 60)
   if (hours < 24) return `${hours}h ago`
-  const days = Math.floor(hours / 24)
-  return `${days}d ago`
+  return `${Math.floor(hours / 24)}d ago`
 }
 
 // ---------------------------------------------------------------------------
-// RunDot — colored dot with hover popup (mirrors NightlyE2EStatus.RunDot)
+// RunDot — colored dot with hover popup
 // ---------------------------------------------------------------------------
 
-interface RunInfo {
-  conclusion: string | null
-  createdAt: string
+interface DotInfo {
+  conclusion: Conclusion
   htmlUrl: string
+  date: string
 }
 
-function conclusionColor(c: string | null): string {
-  if (!c || c === 'in_progress') return 'bg-blue-400'
+function dotColor(c: Conclusion): string {
+  if (!c) return 'bg-border/50'
   if (c === 'success') return 'bg-green-400'
   if (c === 'failure' || c === 'timed_out') return 'bg-red-400'
   if (c === 'cancelled') return 'bg-gray-500 dark:bg-gray-400'
+  if (c === 'action_required') return 'bg-yellow-400'
   return 'bg-yellow-400'
 }
 
-function conclusionTextColor(c: string | null): string {
-  if (!c || c === 'in_progress') return 'text-blue-400'
+function dotTextColor(c: Conclusion): string {
+  if (!c) return 'text-muted-foreground'
   if (c === 'success') return 'text-green-400'
   if (c === 'failure' || c === 'timed_out') return 'text-red-400'
   return 'text-muted-foreground'
 }
 
-function conclusionLabel(c: string | null): string {
-  if (!c || c === 'in_progress') return 'running'
-  if (c === 'success') return 'passed'
-  return c
-}
-
-function RunDot({ run }: { run: RunInfo }) {
+function RunDot({ dot }: { dot: DotInfo }) {
   const [showPopup, setShowPopup] = useState(false)
   const dotRef = useRef<HTMLDivElement>(null)
   const hideTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
   const [popupPos, setPopupPos] = useState<{ top: number; left: number } | null>(null)
-
-  const isRunning = !run.conclusion || run.conclusion === 'in_progress'
+  const isEmpty = dot.conclusion === null
 
   function handleEnter() {
+    if (isEmpty) return
     if (hideTimer.current) clearTimeout(hideTimer.current)
     if (dotRef.current) {
       const rect = dotRef.current.getBoundingClientRect()
@@ -104,45 +114,29 @@ function RunDot({ run }: { run: RunInfo }) {
   }
 
   return (
-    <div
-      ref={dotRef}
-      className="group relative"
-      onMouseEnter={handleEnter}
-      onMouseLeave={handleLeave}
-    >
-      <a
-        href={run.htmlUrl !== '#' ? run.htmlUrl : undefined}
-        target="_blank"
-        rel="noopener noreferrer"
-      >
-        <div className={cn(
-          'w-3 h-3 rounded-full transition-all',
-          conclusionColor(run.conclusion),
-          isRunning && 'animate-pulse',
-          'group-hover:ring-2 group-hover:ring-white/30',
-        )} />
-      </a>
+    <>
+      <div ref={dotRef} className="group relative" onMouseEnter={handleEnter} onMouseLeave={handleLeave}>
+        {dot.htmlUrl && dot.htmlUrl !== '#' && !isEmpty ? (
+          <a href={dot.htmlUrl} target="_blank" rel="noopener noreferrer">
+            <div className={cn('w-3 h-3 rounded-full transition-all', dotColor(dot.conclusion),
+              'group-hover:ring-2 group-hover:ring-white/30')} />
+          </a>
+        ) : (
+          <div className={cn('w-3 h-3 rounded-full', dotColor(dot.conclusion))} />
+        )}
+      </div>
       {showPopup && popupPos && createPortal(
-        <div
-          className="fixed z-dropdown"
-          style={{ top: popupPos.top, left: popupPos.left, transform: 'translate(-50%, -100%)' }}
-          onMouseEnter={() => { if (hideTimer.current) clearTimeout(hideTimer.current) }}
-          onMouseLeave={handleLeave}
-        >
+        <div className="fixed z-dropdown" style={{ top: popupPos.top, left: popupPos.left, transform: 'translate(-50%, -100%)' }}
+          onMouseEnter={() => { if (hideTimer.current) clearTimeout(hideTimer.current) }} onMouseLeave={handleLeave}>
           <div className="mb-1.5 bg-secondary border border-border rounded-lg shadow-xl px-2.5 py-1.5 text-2xs whitespace-nowrap">
             <div className="text-foreground">
-              <span className={conclusionTextColor(run.conclusion)}>{conclusionLabel(run.conclusion)}</span>
-              {' '}&middot; {formatTimeAgo(run.createdAt)}
-              {' '}&middot; {run.createdAt.slice(0, 10)}
+              <span className={dotTextColor(dot.conclusion)}>{dot.conclusion ?? 'no run'}</span>
+              {' '}&middot; {dot.date}
             </div>
-            {run.htmlUrl !== '#' && (
-              <a
-                href={run.htmlUrl}
-                target="_blank"
-                rel="noopener noreferrer"
+            {dot.htmlUrl && dot.htmlUrl !== '#' && (
+              <a href={dot.htmlUrl} target="_blank" rel="noopener noreferrer"
                 className="text-blue-400 hover:text-blue-300 flex items-center gap-0.5 mt-0.5"
-                onClick={(e) => e.stopPropagation()}
-              >
+                onClick={(e) => e.stopPropagation()}>
                 View on GitHub <ExternalLink size={8} />
               </a>
             )}
@@ -151,21 +145,32 @@ function RunDot({ run }: { run: RunInfo }) {
         </div>,
         document.body
       )}
-    </div>
+    </>
   )
 }
 
 // ---------------------------------------------------------------------------
-// TrendIndicator (same as NightlyE2EStatus)
+// TrendIndicator + compute
 // ---------------------------------------------------------------------------
+
+function computeTrend(cells: DotInfo[]): { passRate: number; trend: 'up' | 'down' | 'steady' } {
+  const with_ = cells.filter((c) => c.conclusion !== null)
+  if (with_.length === 0) return { passRate: 0, trend: 'steady' }
+  const successes = with_.filter((c) => c.conclusion === 'success').length
+  const rate = Math.round((successes / with_.length) * 100)
+  const mid = Math.floor(with_.length / 2)
+  const first = with_.slice(0, mid)
+  const second = with_.slice(mid)
+  const fr = first.length ? first.filter((c) => c.conclusion === 'success').length / first.length : 0
+  const sr = second.length ? second.filter((c) => c.conclusion === 'success').length / second.length : 0
+  const t: 'up' | 'down' | 'steady' =
+    fr > sr + TREND_THRESHOLD ? 'up' : fr < sr - TREND_THRESHOLD ? 'down' : 'steady'
+  return { passRate: rate, trend: t }
+}
 
 function TrendIndicator({ passRate, trend }: { passRate: number; trend: 'up' | 'down' | 'steady' }) {
   const Icon = trend === 'up' ? TrendingUp : trend === 'down' ? TrendingDown : Minus
-  const color = passRate === 100
-    ? 'text-green-400'
-    : passRate >= 70
-      ? 'text-yellow-400'
-      : 'text-red-400'
+  const color = passRate === 100 ? 'text-green-400' : passRate >= 70 ? 'text-yellow-400' : 'text-red-400'
   return (
     <div className={cn('flex items-center gap-1', color)}>
       <Icon size={12} />
@@ -175,143 +180,181 @@ function TrendIndicator({ passRate, trend }: { passRate: number; trend: 'up' | '
 }
 
 // ---------------------------------------------------------------------------
+// WorkflowRow — one per workflow, newest-first dots
+// ---------------------------------------------------------------------------
+
+function WorkflowRow({ wf }: { wf: MatrixWorkflow }) {
+  const dots: DotInfo[] = useMemo(() =>
+    [...wf.cells].reverse().slice(0, MAX_DOTS).map((c) => ({
+      conclusion: c.conclusion as Conclusion, htmlUrl: c.htmlUrl, date: c.date,
+    })), [wf.cells])
+
+  const { passRate, trend } = useMemo(() => computeTrend(dots), [dots])
+  const latest = dots[0]?.conclusion
+  const StatusIcon = !latest ? AlertTriangle
+    : latest === 'success' ? CheckCircle
+    : latest === 'failure' || latest === 'timed_out' ? XCircle
+    : AlertTriangle
+  const iconColor = !latest ? 'text-muted-foreground'
+    : latest === 'success' ? 'text-green-400'
+    : latest === 'failure' || latest === 'timed_out' ? 'text-red-400'
+    : 'text-yellow-400'
+  const shortRepo = wf.repo.split('/')[1] ?? wf.repo
+
+  return (
+    <div className="flex items-center gap-3 py-1.5 px-2 rounded-lg hover:bg-secondary/30 transition-colors group">
+      <StatusIcon size={14} className={cn('shrink-0', iconColor)} />
+      <div className="w-36 shrink-0 min-w-0">
+        <div className="text-xs text-foreground font-medium truncate" title={wf.name}>{wf.name}</div>
+        <div className="text-[10px] text-muted-foreground truncate">{shortRepo}</div>
+      </div>
+      <div className="flex items-center gap-1.5 shrink-0">
+        {dots.map((d, i) => <RunDot key={`${d.date}-${i}`} dot={d} />)}
+        {Array.from({ length: Math.max(0, MAX_DOTS - dots.length) }).map((_, i) => (
+          <div key={`empty-${i}`} className="w-3 h-3 rounded-full bg-border/50" />
+        ))}
+      </div>
+      <TrendIndicator passRate={passRate} trend={trend} />
+      <a href={`${WORKFLOW_URL_BASE}/${wf.repo}/actions`} target="_blank" rel="noopener noreferrer"
+        className="ml-auto opacity-0 group-hover:opacity-100 transition-opacity p-0.5 rounded hover:bg-secondary"
+        onClick={(e) => e.stopPropagation()}>
+        <ExternalLink size={12} className="text-muted-foreground" />
+      </a>
+    </div>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Standalone repo input (when outside /ci-cd dashboard)
+// ---------------------------------------------------------------------------
+
+function StandaloneRepoInput({ value, onChange }: { value: string; onChange: (v: string) => void }) {
+  return (
+    <div className="flex items-center gap-2 px-4 py-3 border-b border-border/50">
+      <Search size={12} className="text-muted-foreground" />
+      <input type="text" value={value} onChange={(e) => onChange(e.target.value)}
+        placeholder={PLACEHOLDER_REPO}
+        className="flex-1 text-xs bg-transparent text-foreground placeholder:text-muted-foreground/50 focus:outline-none"
+        aria-label={LABEL_SET_REPO} />
+    </div>
+  )
+}
+
+// ---------------------------------------------------------------------------
 // Main card
 // ---------------------------------------------------------------------------
 
 export function NightlyReleasePulse() {
-  const { data, isLoading, error, refetch } = usePipelinePulse()
+  const shared = usePipelineFilter()
+  const [standaloneRepo, setStandaloneRepo] = useState('')
+  const effectiveRepoFilter = shared
+    ? shared.repoFilter
+    : standaloneRepo.includes('/') ? standaloneRepo.trim() : null
+
+  const { data: pulseData, isLoading: pulseLoading, error: pulseError, refetch } = usePipelinePulse()
+  const { data: matrixData, isLoading: matrixLoading } = usePipelineMatrix(effectiveRepoFilter, MATRIX_DAYS)
   const { isDemoMode } = useDemoMode()
-  const hasData = !!data?.lastRun
-  useCardLoadingState({ isLoading: isLoading && !hasData, hasAnyData: hasData, isDemoData: isDemoMode })
 
-  const { passRate, trend } = useMemo(() => {
-    if (!data?.recent?.length) return { passRate: 0, trend: 'steady' as const }
-    const total = data.recent.length
-    const successes = data.recent.filter((r) => r.conclusion === 'success').length
-    const rate = Math.round((successes / total) * 100)
-    const mid = Math.floor(total / 2)
-    const first = data.recent.slice(0, mid)
-    const second = data.recent.slice(mid)
-    const firstRate = first.length ? first.filter((r) => r.conclusion === 'success').length / first.length : 0
-    const secondRate = second.length ? second.filter((r) => r.conclusion === 'success').length / second.length : 0
-    const t: 'up' | 'down' | 'steady' =
-      secondRate > firstRate + TREND_THRESHOLD ? 'down' // second half is older = trend worsening
-        : secondRate < firstRate - TREND_THRESHOLD ? 'up' // first half (newest) is better
-        : 'steady'
-    return { passRate: rate, trend: t }
-  }, [data])
+  const hasData = !!pulseData?.lastRun || (matrixData?.workflows?.length ?? 0) > 0
+  useCardLoadingState({ isLoading: (pulseLoading || matrixLoading) && !hasData, hasAnyData: hasData, isDemoData: isDemoMode })
 
-  if (error && !hasData) {
-    return (
-      <div className="p-4 h-full flex items-center justify-center text-sm text-red-400">
-        Failed to load release pulse. {error}
-      </div>
-    )
+  const workflows = useMemo(() => {
+    const wfs = matrixData?.workflows ?? []
+    if (!shared || shared.selectedRepos.size === 0) return wfs
+    return wfs.filter((wf) => shared.selectedRepos.has(wf.repo))
+  }, [matrixData, shared])
+
+  const allDots: DotInfo[] = useMemo(() =>
+    workflows.flatMap((wf) =>
+      [...wf.cells].reverse().slice(0, MAX_DOTS).map((c) => ({
+        conclusion: c.conclusion as Conclusion, htmlUrl: c.htmlUrl, date: c.date,
+      }))), [workflows])
+  const { passRate: overallPassRate, trend: overallTrend } = useMemo(() => computeTrend(allDots), [allDots])
+
+  if (pulseError && !hasData) {
+    return <div className="p-4 h-full flex items-center justify-center text-sm text-red-400">
+      Failed to load release pulse. {pulseError}
+    </div>
   }
 
-  const { lastRun, recent, nextCron, streak, streakKind } = data
-
+  const { lastRun, nextCron, streak, streakKind } = pulseData
   const StatusIcon = !lastRun ? AlertTriangle
     : lastRun.conclusion === 'success' ? CheckCircle
     : lastRun.conclusion === 'failure' || lastRun.conclusion === 'timed_out' ? XCircle
-    : lastRun.conclusion === null ? Loader2
-    : AlertTriangle
+    : lastRun.conclusion === null ? Loader2 : AlertTriangle
   const iconColor = !lastRun ? 'text-muted-foreground'
     : lastRun.conclusion === 'success' ? 'text-green-400'
     : lastRun.conclusion === 'failure' || lastRun.conclusion === 'timed_out' ? 'text-red-400'
-    : lastRun.conclusion === null ? 'text-blue-400 animate-spin'
-    : 'text-yellow-400'
+    : lastRun.conclusion === null ? 'text-blue-400 animate-spin' : 'text-yellow-400'
 
   return (
-    <div className="p-4 h-full flex flex-col gap-3">
-      {/* Header: release tag + link */}
-      <div className="flex items-start justify-between gap-3">
-        <div className="min-w-0">
-          <div className="flex items-center gap-2">
-            <StatusIcon size={18} className={cn('shrink-0', iconColor)} />
-            <span className="text-base font-semibold text-foreground truncate">
-              {lastRun?.releaseTag ?? 'No release yet'}
-            </span>
-          </div>
-          <div className="text-xs text-muted-foreground mt-0.5 flex items-center gap-2">
-            {lastRun && (
-              <>
+    <div className="h-full flex flex-col">
+      {!shared && <StandaloneRepoInput value={standaloneRepo} onChange={setStandaloneRepo} />}
+
+      <div className="p-4 flex-1 flex flex-col gap-3 min-h-0">
+        <div className="flex items-start justify-between gap-3">
+          <div className="min-w-0">
+            <div className="flex items-center gap-2">
+              <StatusIcon size={18} className={cn('shrink-0', iconColor)} />
+              <span className="text-base font-semibold text-foreground truncate">
+                {lastRun?.releaseTag ?? 'No release yet'}
+              </span>
+            </div>
+            <div className="text-xs text-muted-foreground mt-0.5 flex items-center gap-2">
+              {lastRun && <>
                 <span>{formatTimeAgo(lastRun.createdAt)}</span>
                 <span>&middot;</span>
                 <span className="capitalize">{lastRun.conclusion ?? 'running'}</span>
                 <span>&middot;</span>
                 <span>run #{lastRun.runNumber}</span>
-              </>
-            )}
+              </>}
+            </div>
           </div>
+          {lastRun?.htmlUrl && lastRun.htmlUrl !== '#' && (
+            <a href={lastRun.htmlUrl} target="_blank" rel="noreferrer noopener"
+              className="text-xs text-muted-foreground hover:text-foreground shrink-0">
+              <ExternalLink size={12} />
+            </a>
+          )}
         </div>
-        <a
-          href={WORKFLOW_URL}
-          target="_blank"
-          rel="noreferrer noopener"
-          className="text-xs text-muted-foreground hover:text-foreground flex items-center gap-1 shrink-0"
-        >
-          <ExternalLink size={12} />
-        </a>
-      </div>
 
-      {/* Stats row: streak, next, pass rate */}
-      <div className="grid grid-cols-3 gap-2">
-        <div className="rounded-lg bg-secondary/30 px-3 py-2">
-          <div className="text-[11px] text-muted-foreground">Streak</div>
-          <div className={cn(
-            'text-sm font-medium mt-0.5',
-            streakKind === 'success' && 'text-green-400',
-            streakKind === 'failure' && 'text-red-400',
-          )}>
-            {streak === 0 ? '—' : `${streak}${streakKind === 'success' ? ' pass' : ' fail'}`}
+        <div className="grid grid-cols-3 gap-2">
+          <div className="rounded-lg bg-secondary/30 px-3 py-2">
+            <div className="text-[11px] text-muted-foreground">Streak</div>
+            <div className={cn('text-sm font-medium mt-0.5',
+              streakKind === 'success' && 'text-green-400', streakKind === 'failure' && 'text-red-400')}>
+              {streak === 0 ? '—' : `${streak}${streakKind === 'success' ? ' pass' : ' fail'}`}
+            </div>
+          </div>
+          <div className="rounded-lg bg-secondary/30 px-3 py-2">
+            <div className="text-[11px] text-muted-foreground flex items-center gap-1"><Clock size={10} /> Next</div>
+            <div className="text-sm font-medium mt-0.5 text-foreground">{formatCron(nextCron)}</div>
+          </div>
+          <div className="rounded-lg bg-secondary/30 px-3 py-2">
+            <div className="text-[11px] text-muted-foreground">Overall</div>
+            <div className="mt-0.5"><TrendIndicator passRate={overallPassRate} trend={overallTrend} /></div>
           </div>
         </div>
-        <div className="rounded-lg bg-secondary/30 px-3 py-2">
-          <div className="text-[11px] text-muted-foreground flex items-center gap-1">
-            <Clock size={10} /> Next
-          </div>
-          <div className="text-sm font-medium mt-0.5 text-foreground">{formatCron(nextCron)}</div>
-        </div>
-        <div className="rounded-lg bg-secondary/30 px-3 py-2">
-          <div className="text-[11px] text-muted-foreground">Pass rate</div>
-          <div className="mt-0.5">
-            <TrendIndicator passRate={passRate} trend={trend} />
-          </div>
-        </div>
-      </div>
 
-      {/* Run dots row — mirrors NightlyE2EStatus GuideRow layout */}
-      <div className="flex items-center gap-3 py-1.5 px-2 rounded-lg hover:bg-secondary/30 transition-colors group">
-        <StatusIcon size={14} className={cn('shrink-0', iconColor)} />
-        <span className="text-xs text-foreground w-14 shrink-0 font-medium">Release</span>
-        <div className="flex items-center gap-1.5 shrink-0">
-          {(recent || []).slice(0, MAX_DOTS).map((r, i) => (
-            <RunDot key={`${r.createdAt}-${i}`} run={r} />
-          ))}
-          {Array.from({ length: Math.max(0, MAX_DOTS - (recent || []).length) }).map((_, i) => (
-            <div key={`empty-${i}`} className="w-3 h-3 rounded-full bg-border/50" />
-          ))}
+        <div className="flex-1 min-h-0 overflow-auto">
+          {workflows.length === 0 ? (
+            <div className="h-full flex items-center justify-center text-xs text-muted-foreground">
+              {!shared && !standaloneRepo.includes('/')
+                ? 'Enter an owner/repo above to see workflow runs'
+                : 'No workflow activity in this range'}
+            </div>
+          ) : (
+            <div className="flex flex-col">
+              {workflows.map((wf) => <WorkflowRow key={`${wf.repo}:${wf.name}`} wf={wf} />)}
+            </div>
+          )}
         </div>
-        <TrendIndicator passRate={passRate} trend={trend} />
-        <a
-          href={WORKFLOW_URL}
-          target="_blank"
-          rel="noopener noreferrer"
-          className="ml-auto opacity-0 group-hover:opacity-100 transition-opacity p-0.5 rounded hover:bg-secondary"
-          onClick={(e) => e.stopPropagation()}
-        >
-          <ExternalLink size={12} className="text-muted-foreground" />
-        </a>
-      </div>
 
-      <button
-        type="button"
-        onClick={() => refetch()}
-        className="mt-auto self-end text-[11px] text-muted-foreground hover:text-foreground"
-      >
-        Refresh
-      </button>
+        <button type="button" onClick={() => refetch()}
+          className="self-end text-[11px] text-muted-foreground hover:text-foreground">
+          Refresh
+        </button>
+      </div>
     </div>
   )
 }

--- a/web/src/components/cards/pipelines/WorkflowMatrix.tsx
+++ b/web/src/components/cards/pipelines/WorkflowMatrix.tsx
@@ -128,7 +128,8 @@ export function WorkflowMatrix() {
                   className="flex-1 grid gap-0.5"
                   style={{ gridTemplateColumns: `repeat(${wf.cells.length}, minmax(${MIN_CELL_PX}px, 1fr))` }}
                 >
-                  {wf.cells.map((cell) => {
+                  {/* Newest-first: server sends oldest→newest, reverse for display */}
+                  {[...wf.cells].reverse().map((cell) => {
                     const label = `${cell.date}: ${cell.conclusion ?? 'no run'}`
                     const common = 'h-5 rounded-[2px] transition-colors'
                     return cell.htmlUrl && cell.htmlUrl !== '#' ? (
@@ -167,7 +168,7 @@ export function WorkflowMatrix() {
         </div>
         {data?.range?.[0] && data?.range?.[data.range.length - 1] && (
           <span className="flex items-center gap-1">
-            {data.range[0]} → {data.range[data.range.length - 1]}
+            {data.range[data.range.length - 1]} → {data.range[0]}
             <ExternalLink className="w-3 h-3 opacity-60" />
           </span>
         )}


### PR DESCRIPTION
## Summary

Closes the last 3 items from today's pipeline dashboard session.

### 1. Pulse card respects shared repo multi-select

On `/ci-cd` (inside `PipelineFilterProvider`): reads the shared selection, shows one row per workflow per selected repo using matrix data. Selecting specific repos from the filter bar filters the rows; "All" shows everything.

### 2. Per-repo dot rows when multiple repos selected

Each workflow gets its own row with NightlyE2E-style dots (newest-first, hover popups, trend indicator, GitHub link). Multiple repos = multiple sections of workflow rows.

### 3. Standalone card prompts for repo input

When dragged to a different dashboard (no `PipelineFilterProvider`), the card shows an `owner/repo` text input at the top. User types a repo → card fetches matrix data for that single repo and renders workflow rows.

### Also fixes: Matrix heatmap newest-first

The matrix grid cells were oldest-left. Now `[...wf.cells].reverse()` so newest is leftmost, matching the nightly E2E card convention.

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npm run build` — green
- [ ] `/ci-cd` → select "console" pill → pulse card shows only console workflows
- [ ] Select "console" + "docs" → pulse shows workflows from both
- [ ] "All" → all repos' workflows visible
- [ ] Matrix heatmap → newest date on the left
- [ ] Drag pulse card to another dashboard → repo input appears, type `kubestellar/console` → workflows load