### PR TITLE
🎨 Add ACMM to default sidebar navigation

### DIFF
--- a/web/src/hooks/useSidebarConfig.ts
+++ b/web/src/hooks/useSidebarConfig.ts
@@ -57,6 +57,7 @@ export const DEFAULT_PRIMARY_NAV: SidebarItem[] = [
   { id: 'insights', name: 'Insights', icon: 'Lightbulb', href: '/insights', type: 'link', order: 3.5 },
   { id: 'ai-ml', name: 'AI/ML', icon: 'Sparkles', href: '/ai-ml', type: 'link', order: 4 },
   { id: 'ai-agents', name: 'AI Agents', icon: 'Bot', href: '/ai-agents', type: 'link', order: 5 },
+  { id: 'acmm', name: 'ACMM', icon: 'BarChart3', href: '/acmm', type: 'link', order: 5.5 },
   { id: 'ci-cd', name: 'CI/CD', icon: 'GitMerge', href: '/ci-cd', type: 'link', order: 6 },
   { id: 'multi-tenancy', name: 'Multi-Tenancy', icon: 'Users', href: '/multi-tenancy', type: 'link', order: 6.5 },
   { id: 'alerts', name: 'Alerts', icon: 'Bell', href: '/alerts', type: 'link', order: 7 },
@@ -89,7 +90,6 @@ export const DISCOVERABLE_DASHBOARDS: SidebarItem[] = [
   { id: 'services', name: 'Services', icon: 'Network', href: '/services', type: 'link', order: 17 },
   { id: 'storage', name: 'Storage', icon: 'HardDrive', href: '/storage', type: 'link', order: 18 },
   { id: 'workloads', name: 'Workloads', icon: 'Box', href: '/workloads', type: 'link', order: 19 },
-  { id: 'acmm', name: 'AI Codebase Maturity', icon: 'BarChart3', href: '/acmm', type: 'link', order: 20 },
 ]
 
 const DEFAULT_SECONDARY_NAV: SidebarItem[] = [


### PR DESCRIPTION
## Summary

Moves ACMM from the discoverable dashboards list to the default sidebar nav. Placed after **AI Agents** (order 5.5) to keep AI-related items grouped together.

- Icon: `BarChart3` (matches the page header)
- Label: `ACMM` (short, recognizable)
- Removed from `DISCOVERABLE_DASHBOARDS` (no longer needed since it's default)

## Test plan

- [ ] Fresh visit (or cleared sidebar localStorage) → ACMM appears in sidebar between AI Agents and CI/CD
- [ ] Click ACMM → navigates to /acmm
- [ ] Sidebar customizer no longer lists ACMM in "Recommended Dashboards"
- [ ] Existing users who customized their sidebar keep their layout (ACMM only appears on fresh/reset sidebars)