### PR TITLE
🐛 fix: persist JWT secret to ~/.kubestellar/ across curl reinstalls (#8202)

### DIFF
--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -1620,38 +1620,68 @@ const devSecretBytes = 32
 // and should be gitignored.
 const devSecretFile = ".jwt-secret"
 
-// loadOrCreateDevSecret reads a previously persisted dev secret from .jwt-secret,
-// or generates a new one and writes it to that file. This ensures tokens issued
-// before a dev-mode restart remain valid (#6850).
-func loadOrCreateDevSecret() string {
-	secretPath := filepath.Join(".", devSecretFile)
+// sharedSecretDir is the user-level config directory where the JWT secret is
+// also persisted so it survives across fresh curl-install runs (#8202).
+const sharedSecretDir = ".kubestellar"
 
-	// Try to read an existing secret file.
-	data, err := os.ReadFile(secretPath)
-	if err == nil {
+// loadOrCreateDevSecret checks two locations for an existing JWT secret:
+// first the local working directory (explicit override), then the shared
+// ~/.kubestellar/ dir (survives reinstalls). If neither exists, it generates
+// a new secret and writes to both locations.
+func loadOrCreateDevSecret() string {
+	localPath := filepath.Join(".", devSecretFile)
+	sharedPath := sharedSecretPath()
+
+	for _, p := range []string{localPath, sharedPath} {
+		if p == "" {
+			continue
+		}
+		data, err := os.ReadFile(p)
+		if err != nil {
+			continue
+		}
 		secret := strings.TrimSpace(string(data))
 		if len(secret) >= devSecretBytes {
-			slog.Info("Loaded persisted dev JWT secret from " + devSecretFile)
+			slog.Info("Loaded persisted dev JWT secret", "path", p)
+			if p == sharedPath {
+				persistSecret(localPath, secret)
+			}
 			return secret
 		}
-		// File exists but content is too short / corrupt — regenerate.
-		slog.Warn("Existing " + devSecretFile + " is too short, regenerating")
+		slog.Warn("Existing secret file is too short, skipping", "path", p)
 	}
 
-	// Generate a new random secret.
 	secret := generateRandomSecret()
 
-	// Persist to file so it survives restarts.
-	// File permissions 0600: owner read/write only.
-	const secretFilePerms = 0o600
-	if wErr := os.WriteFile(secretPath, []byte(secret+"\n"), secretFilePerms); wErr != nil {
-		slog.Warn("Could not persist dev JWT secret to "+devSecretFile+"; tokens will not survive restart",
-			"error", wErr)
-	} else {
-		slog.Info("Generated and persisted dev JWT secret to " + devSecretFile)
+	persistSecret(localPath, secret)
+	if sharedPath != "" {
+		persistSecret(sharedPath, secret)
 	}
 
 	return secret
+}
+
+func sharedSecretPath() string {
+	home, err := os.UserHomeDir()
+	if err != nil || home == "" {
+		return ""
+	}
+	return filepath.Join(home, sharedSecretDir, devSecretFile)
+}
+
+func persistSecret(path, secret string) {
+	const secretFilePerms = 0o600
+	const secretDirPerms = 0o700
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, secretDirPerms); err != nil {
+		slog.Warn("Could not create directory for JWT secret", "dir", dir, "error", err)
+		return
+	}
+	if err := os.WriteFile(path, []byte(secret+"\n"), secretFilePerms); err != nil {
+		slog.Warn("Could not persist dev JWT secret", "path", path, "error", err)
+	} else {
+		slog.Info("Persisted dev JWT secret", "path", path)
+	}
 }
 
 // generateRandomSecret produces a cryptographically random hex string for use


### PR DESCRIPTION
## Summary

- When users reinstall via `curl | bash`, the new binary generates a fresh JWT secret. Existing browser sessions fail with `token_exchange_failed` because tokens were signed with the old secret.
- Fix: `loadOrCreateDevSecret()` now checks `~/.kubestellar/.jwt-secret` as a shared fallback before generating a new secret. Reinstalls reuse the same key, so browser sessions survive.
- Local `.jwt-secret` still takes priority (explicit override for dev workflows)
- New secrets are written to both locations (local + shared)
- No impact on production (production requires `JWT_SECRET` env var explicitly)

## How it works

| Scenario | Before | After |
|----------|--------|-------|
| First install | Secret in `./kubestellar-console/.jwt-secret` | Secret in both `./` and `~/.kubestellar/.jwt-secret` |
| Reinstall (curl \| bash) | New secret generated, old sessions break | Reads from `~/.kubestellar/.jwt-secret`, sessions survive |
| `startup-oauth.sh` (dev) | Local `.jwt-secret` used | Same — local takes priority |
| Production (`JWT_SECRET` env) | Not affected | Not affected — `loadOrCreateDevSecret()` only runs in dev mode |

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./pkg/api/...` — all tests pass
- [ ] Fresh install via `start.sh` → `~/.kubestellar/.jwt-secret` created
- [ ] Second install in new directory → reuses secret from `~/.kubestellar/`
- [ ] Existing browser session survives reinstall
- [ ] `rm ~/.kubestellar/.jwt-secret` → new secret generated (clean reset)

Fixes #8202

🤖 Generated with [Claude Code](https://claude.com/claude-code)