### PR TITLE
🔒 fix(pipelines): gate repo CRUD behind install dialog in demo mode

### DIFF
--- a/web/src/components/cards/pipelines/PipelineFilterBar.tsx
+++ b/web/src/components/cards/pipelines/PipelineFilterBar.tsx
@@ -7,10 +7,11 @@
  * - "x" on each pill hides/removes it
  * - Manage icon shows hidden repos + "Reset to defaults"
  */
-import { useState, useRef, useEffect } from 'react'
+import { useState, useRef, useEffect, useCallback } from 'react'
 import { Plus, X, RotateCcw, Eye } from 'lucide-react'
 import { usePipelineFilter } from './PipelineFilterContext'
 import { cn } from '../../../lib/cn'
+import { isDemoMode } from '../../../lib/demoMode'
 
 /** Extracted user-visible strings */
 const LABEL_ADD_REPO = 'Add repo'
@@ -25,6 +26,15 @@ export function PipelineFilterBar() {
   const ctx = usePipelineFilter()
   const [showAdd, setShowAdd] = useState(false)
   const [showManage, setShowManage] = useState(false)
+
+  // In demo mode (console.kubestellar.io), repo CRUD is gated behind
+  // the install dialog — we don't give away the full feature for free.
+  // The custom event 'open-setup-dialog' is listened to by Layout.tsx
+  // which renders the SetupInstructionsDialog.
+  const isDemo = isDemoMode()
+  const showInstallGate = useCallback(() => {
+    window.dispatchEvent(new CustomEvent('open-setup-dialog'))
+  }, [])
   const [addValue, setAddValue] = useState('')
   const [addError, setAddError] = useState<string | null>(null)
   const inputRef = useRef<HTMLInputElement>(null)
@@ -112,7 +122,7 @@ export function PipelineFilterBar() {
               </button>
               <button
                 type="button"
-                onClick={(e) => { e.stopPropagation(); removeRepo(repo) }}
+                onClick={(e) => { e.stopPropagation(); isDemo ? showInstallGate() : removeRepo(repo) }}
                 className="absolute right-1 top-1/2 -translate-y-1/2 opacity-0 group-hover:opacity-100 transition-opacity p-0.5 rounded-full hover:bg-red-500/20 text-muted-foreground hover:text-red-400"
                 title={LABEL_REMOVE_REPO}
                 aria-label={`${LABEL_REMOVE_REPO}: ${repo}`}
@@ -157,7 +167,7 @@ export function PipelineFilterBar() {
         ) : (
           <button
             type="button"
-            onClick={() => setShowAdd(true)}
+            onClick={() => isDemo ? showInstallGate() : setShowAdd(true)}
             className="px-2 py-1 rounded-full text-xs border border-dashed border-border text-muted-foreground hover:text-foreground hover:border-primary/40 transition-colors"
             title={LABEL_ADD_REPO}
           >
@@ -170,7 +180,7 @@ export function PipelineFilterBar() {
           <div className="relative" ref={manageRef}>
             <button
               type="button"
-              onClick={() => setShowManage(!showManage)}
+              onClick={() => isDemo ? showInstallGate() : setShowManage(!showManage)}
               className={cn(
                 'px-2 py-1 rounded-full text-xs border transition-colors',
                 showManage ? 'bg-primary/20 text-primary border-primary/40' : 'border-border text-muted-foreground hover:text-foreground',


### PR DESCRIPTION
## Summary

On \`console.kubestellar.io\` (demo mode), users can add and remove repos in the CI/CD dashboard pipeline filter bar — a feature that shouldn't be available for free on the hosted demo.

**Fix:** Check \`isDemoMode()\` in \`PipelineFilterBar.tsx\` and intercept the three CRUD actions:

| Action | Demo mode behavior | Self-hosted behavior |
|---|---|---|
| **+ (add repo)** | Shows install dialog | Opens inline add form (unchanged) |
| **x (remove repo)** | Shows install dialog | Hides/removes the repo (unchanged) |
| **Manage (restore/reset)** | Shows install dialog | Opens manage dropdown (unchanged) |

Repo **selection** (toggling pills to filter the dashboard view) still works in demo mode — that's read-only and appropriate for the demo. Only add/remove/manage are gated.

Uses the existing \`'open-setup-dialog'\` custom event that \`Layout.tsx\` already listens for. No new components or dependencies.

## Test plan

- [x] \`npm run build\` passes
- [ ] \`console.kubestellar.io\`: click + → install dialog appears, no add form
- [ ] \`console.kubestellar.io\`: hover a repo pill → click x → install dialog, repo stays
- [ ] \`console.kubestellar.io\`: click manage icon → install dialog, no dropdown
- [ ] \`console.kubestellar.io\`: click a repo pill → still toggles filter (read-only OK)
- [ ] Localhost (non-demo): all three CRUD actions work normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)