### PR TITLE
🐛 fix: restore STANDARD_CRON_FIELD_COUNT in NightlyReleasePulse (#8466)

### DIFF
--- a/web/src/components/cards/pipelines/NightlyReleasePulse.tsx
+++ b/web/src/components/cards/pipelines/NightlyReleasePulse.tsx
@@ -41,10 +41,11 @@ const WORKFLOW_URL_BASE = 'https://github.com'
 /** Extracted strings for ui-ux ratchet */
 const PLACEHOLDER_REPO = 'owner/repo'
 const LABEL_SET_REPO = 'Set repo to monitor'
+const STANDARD_CRON_FIELD_COUNT = 5
 
 function formatCron(cron: string): string {
   const parts = cron.trim().split(/\s+/)
-  if (parts.length === 5 && parts[2] === '*' && parts[3] === '*' && parts[4] === '*') {
+  if (parts.length === STANDARD_CRON_FIELD_COUNT && parts[2] === '*' && parts[3] === '*' && parts[4] === '*') {
     const minute = parseInt(parts[0], 10)
     const hourUtc = parseInt(parts[1], 10)
     if (!isNaN(minute) && !isNaN(hourUtc)) {


### PR DESCRIPTION
## Summary
- PR #8463 (multi-repo pulse card) re-introduced `parts.length === 5` in `NightlyReleasePulse.tsx` that was previously extracted to `STANDARD_CRON_FIELD_COUNT` in PR #8427
- Restores the named constant to pass the magic-numbers ratchet test (comparison count back to ≤36, total back to ≤54)

Fixes #8466