### PR TITLE
🐛 fix(pipelines): correct event name for install dialog gate

### DIFF
--- a/web/src/components/cards/pipelines/PipelineFilterBar.tsx
+++ b/web/src/components/cards/pipelines/PipelineFilterBar.tsx
@@ -29,11 +29,11 @@ export function PipelineFilterBar() {
 
   // In demo mode (console.kubestellar.io), repo CRUD is gated behind
   // the install dialog — we don't give away the full feature for free.
-  // The custom event 'open-setup-dialog' is listened to by Layout.tsx
+  // The custom event 'open-install' is listened to by Layout.tsx:114
   // which renders the SetupInstructionsDialog.
   const isDemo = isDemoMode()
   const showInstallGate = useCallback(() => {
-    window.dispatchEvent(new CustomEvent('open-setup-dialog'))
+    window.dispatchEvent(new CustomEvent('open-install'))
   }, [])
   const [addValue, setAddValue] = useState('')
   const [addError, setAddError] = useState<string | null>(null)


### PR DESCRIPTION
## Summary

One-line fix for #8469: the event name was \`'open-setup-dialog'\` but Layout.tsx:114 listens for \`'open-install'\`. Clicking +/x/manage in demo mode did nothing because no listener caught the event.

Fix: \`'open-setup-dialog'\` → \`'open-install'\`.

## Test plan

- [x] \`npm run build\` passes
- [ ] console.kubestellar.io: click + on CI/CD repo filter → install dialog appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)