### PR TITLE
🐛 fix: add acmm to enabled dashboards + address Copilot review (#8468)

### DIFF
--- a/pkg/api/projects.go
+++ b/pkg/api/projects.go
@@ -8,7 +8,8 @@ package api
 var projectDashboardPresets = map[string][]string{
 	"kubestellar": {
 		"dashboard", "clusters", "cluster-admin", "compliance", "deploy",
-		"insights", "ai-ml", "ai-agents", "ci-cd", "alerts", "arcade",
+		"insights", "ai-ml", "ai-agents", "acmm", "ci-cd",
+		"multi-tenancy", "alerts", "arcade",
 		"llm-d-benchmarks", "gpu-reservations",
 		"compute", "security", "storage", "network", "events",
 		"workloads", "operators", "nodes", "deployments", "pods",

--- a/web/src/hooks/useSidebarConfig.ts
+++ b/web/src/hooks/useSidebarConfig.ts
@@ -179,7 +179,10 @@ export async function fetchEnabledDashboards(): Promise<void> {
   }
 }
 
-// Migrate config to ensure all default routes exist
+// Migrate config to ensure all default routes exist.
+// By design, new routes added to DEFAULT_PRIMARY_NAV (e.g. /acmm) are
+// automatically appended to any stored sidebar config that lacks them,
+// so existing users pick up new dashboards without resetting their layout.
 function migrateConfig(stored: SidebarConfig): SidebarConfig {
   // First, remove deprecated routes
   const primaryNav = stored.primaryNav.filter(item => !DEPRECATED_ROUTES.includes(item.href))


### PR DESCRIPTION
## Summary
- Add `acmm` and `multi-tenancy` to the `kubestellar` project dashboard preset in `pkg/api/projects.go` so the ACMM sidebar route is not filtered out when `CONSOLE_PROJECT=kubestellar`
- Document the intentional migration behavior in `useSidebarConfig.ts` where new `DEFAULT_PRIMARY_NAV` entries are automatically appended to existing stored sidebar configs

## Context
Addresses two Copilot review comments from PR #8465:
1. `migrateConfig()` appending new defaults into stored configs is **by design** — added a clarifying comment
2. The `kubestellar` project preset was missing `acmm` (and `multi-tenancy`), which would cause `fetchEnabledDashboards` to filter them out

Fixes #8468