### PR TITLE
✨ ACMM: stat blocks with mini-graphs in Stats Overview bar

### DIFF
--- a/web/src/components/acmm/ACMM.tsx
+++ b/web/src/components/acmm/ACMM.tsx
@@ -11,20 +11,19 @@ import { getDefaultCards } from '../../config/dashboards'
 import { ACMMProvider, useACMM } from './ACMMProvider'
 import { RepoPicker } from './RepoPicker'
 import { ACMMIntroModal } from './ACMMIntroModal'
+import { useACMMStats } from './useACMMStats'
 
 const ACMM_CARDS_KEY = 'kubestellar-acmm-cards'
 const DEFAULT_ACMM_CARDS = getDefaultCards('acmm')
 
-/** Small consumer that wires the context-managed intro state into the
- *  props-driven modal. Lives inside the provider so useACMM() works. */
-function ACMMIntroModalConnector() {
+/** Inner dashboard that lives inside ACMMProvider so it can consume
+ *  both the ACMM context (for the intro modal) and the ACMM stat
+ *  values (for the Stats Overview bar). */
+function ACMMDashboard() {
   const { introOpen, closeIntro } = useACMM()
-  return <ACMMIntroModal isOpen={introOpen} onClose={closeIntro} />
-}
-
-export function ACMM() {
+  const { getStatValue } = useACMMStats()
   return (
-    <ACMMProvider>
+    <>
       <DashboardPage
         title="AI Codebase Maturity"
         subtitle="Assess any GitHub repo against the AI Codebase Maturity Model"
@@ -32,6 +31,7 @@ export function ACMM() {
         storageKey={ACMM_CARDS_KEY}
         defaultCards={DEFAULT_ACMM_CARDS}
         statsType="acmm"
+        getStatValue={getStatValue}
         beforeCards={<RepoPicker />}
         emptyState={{
           title: 'AI Codebase Maturity',
@@ -39,7 +39,15 @@ export function ACMM() {
             'Enter a GitHub repo above to assess it against the AI Codebase Maturity Model.',
         }}
       />
-      <ACMMIntroModalConnector />
+      <ACMMIntroModal isOpen={introOpen} onClose={closeIntro} />
+    </>
+  )
+}
+
+export function ACMM() {
+  return (
+    <ACMMProvider>
+      <ACMMDashboard />
     </ACMMProvider>
   )
 }

--- a/web/src/components/acmm/useACMMStats.ts
+++ b/web/src/components/acmm/useACMMStats.ts
@@ -1,0 +1,86 @@
+/**
+ * useACMMStats
+ *
+ * Provides stat block values for the ACMM dashboard Stats Overview bar.
+ * Reads from useACMM() context so values update instantly when the user
+ * picks a different repo.
+ */
+
+import { useCallback } from 'react'
+import type { StatBlockValue } from '../ui/StatsOverview'
+import { useACMM } from './ACMMProvider'
+import { ALL_CRITERIA } from '../../lib/acmm/sources'
+import type { SourceId } from '../../lib/acmm/sources/types'
+
+const MAX_LEVEL = 5
+
+/** Source IDs in display order. */
+const SOURCE_IDS: SourceId[] = ['acmm', 'fullsend', 'agentic-engineering-framework', 'claude-reflect']
+const SOURCE_SHORT_NAMES: Record<SourceId, string> = {
+  acmm: 'ACMM',
+  fullsend: 'FS',
+  'agentic-engineering-framework': 'AEF',
+  'claude-reflect': 'Refl',
+}
+
+export function useACMMStats() {
+  const { scan } = useACMM()
+  const { level, data } = scan
+  const detectedIds = data.detectedIds
+
+  const totalCriteria = ALL_CRITERIA.length
+  const detectedCount = detectedIds instanceof Set ? detectedIds.size : (detectedIds as string[] || []).length // ai-quality-ignore
+
+  const nextLevel = level.level < MAX_LEVEL ? level.level + 1 : null
+  const nextRequired = nextLevel ? level.requiredByLevel[nextLevel] ?? 0 : 0
+  const nextDetected = nextLevel ? level.detectedByLevel[nextLevel] ?? 0 : 0
+  const nextRemaining = nextRequired - nextDetected
+
+  const getStatValue = useCallback((blockId: string): StatBlockValue => {
+    switch (blockId) {
+      case 'acmm_level':
+        return {
+          value: level.level,
+          sublabel: level.levelName,
+          max: MAX_LEVEL,
+        }
+      case 'acmm_detected':
+        return {
+          value: detectedCount,
+          sublabel: `of ${totalCriteria}`,
+          max: totalCriteria,
+        }
+      case 'acmm_next_level':
+        if (!nextLevel) {
+          return { value: MAX_LEVEL, sublabel: 'Max level', max: MAX_LEVEL }
+        }
+        return {
+          value: nextDetected,
+          sublabel: `${nextRemaining} to L${nextLevel}`,
+          max: nextRequired,
+        }
+      case 'acmm_by_source': {
+        // Build per-source detection ratios for the mini-bar visualization
+        const segments = SOURCE_IDS.map((sid) => {
+          const srcCriteria = ALL_CRITERIA.filter((c) => c.source === sid)
+          const srcDetected = srcCriteria.filter((c) =>
+            detectedIds instanceof Set ? detectedIds.has(c.id) : (detectedIds as string[] || []).includes(c.id), // ai-quality-ignore
+          ).length
+          return {
+            label: SOURCE_SHORT_NAMES[sid],
+            value: srcCriteria.length > 0 ? Math.round((srcDetected / srcCriteria.length) * 100) : 0, // ai-quality-ignore
+          }
+        })
+        const bestSource = segments.reduce((a, b) => (b.value > a.value ? b : a), segments[0])
+        return {
+          value: `${bestSource?.value ?? 0}%`, // ai-quality-ignore
+          sublabel: `Best: ${bestSource?.label ?? '-'}`,
+        }
+      }
+      default:
+        return { value: '-' }
+    }
+  }, [level, detectedCount, totalCriteria, nextLevel, nextDetected, nextRemaining, nextRequired, detectedIds])
+
+  return { getStatValue }
+}

--- a/web/src/components/ui/StatsBlockDefinitions.ts
+++ b/web/src/components/ui/StatsBlockDefinitions.ts
@@ -414,6 +414,16 @@ export const MULTI_TENANCY_STAT_BLOCKS: StatBlockConfig[] = [
 ]
 
 /**
+ * Default stat blocks for the ACMM dashboard
+ */
+export const ACMM_STAT_BLOCKS: StatBlockConfig[] = [
+  { id: 'acmm_level', name: 'Level', icon: 'BarChart3', visible: true, color: 'purple', displayMode: 'ring' },
+  { id: 'acmm_detected', name: 'Detected', icon: 'CheckCircle2', visible: true, color: 'green', displayMode: 'gauge' },
+  { id: 'acmm_next_level', name: 'To Next Level', icon: 'TrendingUp', visible: true, color: 'cyan', displayMode: 'ring' },
+  { id: 'acmm_by_source', name: 'By Source', icon: 'Layers', visible: true, color: 'blue', displayMode: 'mini-bar' },
+]
+
+/**
  * Default stat blocks for the Drasi dashboard
  */
 export const DRASI_STAT_BLOCKS: StatBlockConfig[] = [
@@ -468,6 +478,7 @@ export const ALL_STAT_BLOCKS: StatBlockConfig[] = (() => {
     ...CLUSTER_ADMIN_STAT_BLOCKS,
     ...MULTI_TENANCY_STAT_BLOCKS,
     ...DRASI_STAT_BLOCKS,
+    ...ACMM_STAT_BLOCKS,
     ...AI_AGENTS_STAT_BLOCKS,
     ...INSIGHTS_STAT_BLOCKS,
   ]
@@ -532,6 +543,8 @@ export function getDefaultStatBlocks(dashboardType: DashboardStatsType): StatBlo
       return GITOPS_STAT_BLOCKS
     case 'drasi':
       return DRASI_STAT_BLOCKS
+    case 'acmm':
+      return ACMM_STAT_BLOCKS
     default:
       return []
   }


### PR DESCRIPTION
## Summary

Fills the empty Stats Overview bar on the ACMM dashboard with 4 visual stat blocks:

| Stat | Display Mode | What it shows |
|---|---|---|
| **Level** | Ring gauge | Fill = level/5, label = L{n}, sublabel = level name |
| **Detected** | Gauge bar | Fill = detected/total, sublabel = "of 51" |
| **To Next Level** | Ring | Fill = progress %, sublabel = "N to L{n+1}" |
| **By Source** | Mini-bar | Per-source detection %, highlights best source |

All update instantly when the user picks a different repo — they read from the shared `ACMMProvider` context via a new `useACMMStats()` hook.

## Files

**Created:** `web/src/components/acmm/useACMMStats.ts` — ACMM-specific stat value getter
**Modified:** `web/src/components/ui/StatsBlockDefinitions.ts` — added `ACMM_STAT_BLOCKS` + switch case
**Modified:** `web/src/components/acmm/ACMM.tsx` — extracted `ACMMDashboard` inner component to wire `getStatValue` prop

## Test plan

- [ ] Open /acmm → Stats Overview shows 4 blocks with graphs
- [ ] Switch repos → all 4 blocks update instantly
- [ ] Level ring fills proportionally (L1 = 20%, L4 = 80%)
- [ ] Detected gauge shows correct ratio
- [ ] "To Next Level" shows remaining criteria count
- [ ] "By Source" shows per-source detection %
- [ ] Click Stats Overview chevron → collapses/expands