### PR TITLE
✨ feat(kagenti): add in-cluster integration for Kagenti agents

### DIFF
--- a/deploy/helm/kubestellar-console/templates/deployment.yaml
+++ b/deploy/helm/kubestellar-console/templates/deployment.yaml
@@ -291,6 +291,36 @@ spec:
             - name: SELF_UPGRADE_ENABLED
               value: "true"
             {{- end }}
+            {{- if .Values.kagenti.enabled }}
+            {{- if .Values.kagenti.forceDefaultAgent }}
+            - name: DEFAULT_AGENT
+              value: "kagenti"
+            {{- end }}
+            {{- if .Values.kagenti.controllerUrl }}
+            - name: KAGENTI_CONTROLLER_URL
+              value: {{ .Values.kagenti.controllerUrl | quote }}
+            {{- end }}
+            - name: KAGENTI_NAMESPACE
+              value: {{ .Values.kagenti.namespace | quote }}
+            - name: KAGENTI_SERVICE_NAME
+              value: {{ .Values.kagenti.serviceName | quote }}
+            - name: KAGENTI_SERVICE_PORT
+              value: {{ .Values.kagenti.servicePort | quote }}
+            - name: KAGENTI_SERVICE_PROTOCOL
+              value: {{ .Values.kagenti.serviceProtocol | quote }}
+            {{- if .Values.kagenti.directAgentUrl }}
+            - name: KAGENTI_AGENT_URL
+              value: {{ .Values.kagenti.directAgentUrl | quote }}
+            {{- end }}
+            {{- if .Values.kagenti.directAgentName }}
+            - name: KAGENTI_AGENT_NAME
+              value: {{ .Values.kagenti.directAgentName | quote }}
+            {{- end }}
+            {{- if .Values.kagenti.directAgentNamespace }}
+            - name: KAGENTI_AGENT_NAMESPACE
+              value: {{ .Values.kagenti.directAgentNamespace | quote }}
+            {{- end }}
+            {{- end }}
             {{- with .Values.extraEnv }}
             {{- toYaml . | nindent 12 }}
             {{- end }}

--- a/deploy/helm/kubestellar-console/templates/networkpolicy.yaml
+++ b/deploy/helm/kubestellar-console/templates/networkpolicy.yaml
@@ -33,6 +33,12 @@ spec:
           protocol: TCP
         - port: 6443
           protocol: TCP
+    {{- if and .Values.kagenti.enabled .Values.kagenti.allowNetworkPolicyEgress }}
+    # Allow connection to in-cluster Kagenti controller service
+    - ports:
+        - port: {{ .Values.kagenti.servicePort }}
+          protocol: TCP
+    {{- end }}
     {{- with .Values.networkPolicy.extraEgress }}
     {{- toYaml . | nindent 4 }}
     {{- end }}

--- a/deploy/helm/kubestellar-console/values-kagenti-incluster.example.yaml
+++ b/deploy/helm/kubestellar-console/values-kagenti-incluster.example.yaml
@@ -1,0 +1,35 @@
+# Example overrides for in-cluster Kagenti integration
+# Usage:
+#   helm upgrade --install <release> ./deploy/helm/kubestellar-console \
+#     -n <namespace> \
+#     -f deploy/helm/kubestellar-console/values-kagenti-incluster.example.yaml \
+#     --set image.repository=<your-registry>/kubestellar-console \
+#     --set image.tag=<your-new-tag>
+
+kagenti:
+  enabled: true
+
+  # Keep Kagenti selected by default in Missions UI
+  forceDefaultAgent: true
+
+  # Adds NetworkPolicy egress on kagenti.servicePort when networkPolicy.enabled=true
+  allowNetworkPolicyEgress: true
+
+  # Controller mode (recommended)
+  controllerUrl: ""
+  namespace: kagenti-system
+  serviceName: kagenti-backend
+  servicePort: "8000"
+  serviceProtocol: http
+
+  # Direct-agent mode (optional)
+  # directAgentUrl: "http://my-agent.my-namespace.svc:8080"
+  # directAgentName: "my-agent"
+  # directAgentNamespace: "my-namespace"
+
+# If you enforce NetworkPolicy in your cluster, enable this.
+networkPolicy:
+  enabled: true
+
+# Optional extra env values
+extraEnv: []

--- a/deploy/helm/kubestellar-console/values.yaml
+++ b/deploy/helm/kubestellar-console/values.yaml
@@ -265,3 +265,38 @@ selfUpgrade:
 
 # Additional environment variables
 extraEnv: []
+
+# Kagenti integration (optional)
+# Enable this section when the console should connect to an in-cluster Kagenti
+# controller and/or a direct Kagenti agent service.
+#
+# Controller mode (recommended):
+#   - enable: true
+#   - set controllerUrl/service values
+#
+# Direct agent mode (optional, overrides controller discovery):
+#   - set directAgentUrl to a service URL
+#   - optionally set directAgentName/directAgentNamespace for UI metadata
+kagenti:
+  enabled: false
+
+  # Force Kagenti as the default AI agent when enabled.
+  # This sets DEFAULT_AGENT=kagenti in the backend container.
+  forceDefaultAgent: true
+
+  # If NetworkPolicy is enabled, also add a default egress rule to the
+  # Kagenti controller port. Disable if you prefer managing egress via
+  # networkPolicy.extraEgress explicitly.
+  allowNetworkPolicyEgress: true
+
+  # Controller mode settings
+  controllerUrl: ""
+  namespace: "kagenti-system"
+  serviceName: "kagenti-backend"
+  servicePort: "8000"
+  serviceProtocol: "http"
+
+  # Direct agent mode settings (optional)
+  directAgentUrl: ""
+  directAgentName: ""
+  directAgentNamespace: ""

--- a/pkg/agent/provider_kagenti.go
+++ b/pkg/agent/provider_kagenti.go
@@ -1,0 +1,510 @@
+package agent
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+)
+
+// KagentiProvider implements AIProvider and StreamingProvider for Kagenti agents REST API
+type KagentiProvider struct {
+	baseURL      string
+	directAgent  string
+	agentName    string
+	namespace    string
+	chatBasePath string
+	client       *http.Client
+}
+
+var _ AIProvider = (*KagentiProvider)(nil)
+var _ StreamingProvider = (*KagentiProvider)(nil)
+var _ HandshakeProvider = (*KagentiProvider)(nil)
+
+// NewKagentiProvider creates a new KagentiProvider connected to the Kagenti HTTP backend.
+// It auto-detects the backend URL or falls back to an environment variable.
+func NewKagentiProvider() *KagentiProvider {
+	client := &http.Client{Timeout: 0}
+
+	if agentURL := strings.TrimRight(os.Getenv("KAGENTI_AGENT_URL"), "/"); agentURL != "" {
+		return &KagentiProvider{
+			directAgent:  agentURL,
+			agentName:    os.Getenv("KAGENTI_AGENT_NAME"),
+			namespace:    os.Getenv("KAGENTI_AGENT_NAMESPACE"),
+			chatBasePath: "/",
+			client:       client,
+		}
+	}
+
+	baseURL := os.Getenv("KAGENTI_CONTROLLER_URL")
+	if baseURL == "" {
+		baseURL = detectKagentiControllerURL(client)
+	}
+	if baseURL == "" {
+		baseURL = "http://kagenti-controller.kagenti-system.svc:8083"
+	}
+
+	p := &KagentiProvider{
+		baseURL:      strings.TrimRight(baseURL, "/"),
+		chatBasePath: "/api",
+		client:       client,
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	p.findDefaultAgent(ctx)
+
+	return p
+}
+
+func detectKagentiControllerURL(client *http.Client) string {
+	namespace := os.Getenv("KAGENTI_NAMESPACE")
+	if namespace == "" {
+		namespace = "kagenti-system"
+	}
+	serviceName := os.Getenv("KAGENTI_SERVICE_NAME")
+	if serviceName == "" {
+		serviceName = "kagenti-controller"
+	}
+	port := os.Getenv("KAGENTI_SERVICE_PORT")
+	if port == "" {
+		port = "8083"
+	}
+	protocol := os.Getenv("KAGENTI_SERVICE_PROTOCOL")
+	if protocol == "" {
+		protocol = "http"
+	}
+
+	candidates := []string{
+		fmt.Sprintf("%s://%s.%s.svc:%s", protocol, serviceName, namespace, port),
+		fmt.Sprintf("%s://%s.%s.svc.cluster.local:%s", protocol, serviceName, namespace, port),
+		"http://kagenti-backend.kagenti-system.svc:8000",
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+
+	healthPaths := []string{"/health", "/healthz", "/api/health"}
+	for _, candidate := range candidates {
+		base := strings.TrimRight(candidate, "/")
+		for _, hp := range healthPaths {
+			req, err := http.NewRequestWithContext(ctx, http.MethodGet, base+hp, nil)
+			if err != nil {
+				continue
+			}
+			resp, err := client.Do(req)
+			if err != nil {
+				continue
+			}
+			resp.Body.Close()
+			if resp.StatusCode < 400 {
+				return base
+			}
+		}
+	}
+
+	return ""
+}
+
+type kagentiAgentInfo struct {
+	Name      string `json:"name"`
+	Namespace string `json:"namespace"`
+}
+
+func parseAgentList(body []byte) []kagentiAgentInfo {
+	agents := make([]kagentiAgentInfo, 0)
+
+	var list []map[string]any
+	if err := json.Unmarshal(body, &list); err == nil {
+		for _, item := range list {
+			name, _ := item["name"].(string)
+			namespace, _ := item["namespace"].(string)
+			if name != "" {
+				agents = append(agents, kagentiAgentInfo{Name: name, Namespace: namespace})
+			}
+		}
+		return agents
+	}
+
+	var wrapper struct {
+		Items []map[string]any `json:"items"`
+	}
+	if err := json.Unmarshal(body, &wrapper); err == nil {
+		for _, item := range wrapper.Items {
+			name, _ := item["name"].(string)
+			namespace, _ := item["namespace"].(string)
+			if name != "" {
+				agents = append(agents, kagentiAgentInfo{Name: name, Namespace: namespace})
+			}
+		}
+	}
+
+	return agents
+}
+
+func (p *KagentiProvider) tryFindDefaultAgent(ctx context.Context, endpoint string) bool {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, p.baseURL+endpoint, nil)
+	if err != nil {
+		return false
+	}
+
+	resp, err := p.client.Do(req)
+	if err != nil {
+		return false
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return false
+	}
+
+	body, _ := io.ReadAll(resp.Body)
+	agents := parseAgentList(body)
+	if len(agents) == 0 {
+		return false
+	}
+
+	p.agentName = agents[0].Name
+	p.namespace = agents[0].Namespace
+	if p.namespace == "" {
+		p.namespace = "default"
+	}
+	p.chatBasePath = strings.TrimSuffix(endpoint, "/agents")
+	return true
+}
+
+func (p *KagentiProvider) findDefaultAgent(ctx context.Context) {
+	if p.baseURL == "" {
+		return
+	}
+
+	for _, endpoint := range []string{"/api/agents", "/api/v1/agents"} {
+		if p.tryFindDefaultAgent(ctx, endpoint) {
+			return
+		}
+	}
+}
+
+func (p *KagentiProvider) Name() string {
+	return "kagenti"
+}
+
+func (p *KagentiProvider) DisplayName() string {
+	return "Kagenti (In-Cluster)"
+}
+
+func (p *KagentiProvider) Description() string {
+	if p.directAgent != "" {
+		if p.agentName != "" {
+			return fmt.Sprintf("Cluster-native AI Agent (%s/%s @ %s)", p.namespace, p.agentName, p.directAgent)
+		}
+		return fmt.Sprintf("Cluster-native AI Agent (%s)", p.directAgent)
+	}
+	if p.agentName != "" {
+		return fmt.Sprintf("Cluster-native AI Agent (%s/%s)", p.namespace, p.agentName)
+	}
+	return "Cluster-native AI Agent"
+}
+
+func (p *KagentiProvider) Provider() string {
+	return "kagenti"
+}
+
+func (p *KagentiProvider) IsAvailable() bool {
+	if p.directAgent != "" {
+		return true
+	}
+	if p.baseURL == "" {
+		return false
+	}
+
+	if p.agentName != "" || p.namespace != "" {
+		return true
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 1200*time.Millisecond)
+	defer cancel()
+	return p.controllerReachable(ctx)
+}
+
+func (p *KagentiProvider) Capabilities() ProviderCapability {
+	return CapabilityChat | CapabilityToolExec
+}
+
+func (p *KagentiProvider) Handshake(ctx context.Context) *HandshakeResult {
+	if p.directAgent != "" {
+		for _, cardPath := range []string{"/.well-known/agent-card.json", "/.well-known/agent.json"} {
+			req, err := http.NewRequestWithContext(ctx, http.MethodGet, p.directAgent+cardPath, nil)
+			if err != nil {
+				continue
+			}
+			resp, err := p.client.Do(req)
+			if err != nil {
+				continue
+			}
+			if resp.StatusCode != http.StatusOK {
+				resp.Body.Close()
+				continue
+			}
+
+			var card struct {
+				Name string `json:"name"`
+			}
+			_ = json.NewDecoder(resp.Body).Decode(&card)
+			resp.Body.Close()
+			if card.Name != "" {
+				p.agentName = card.Name
+			}
+
+			return &HandshakeResult{
+				Ready:   true,
+				State:   "connected",
+				Message: fmt.Sprintf("Connected to Kagenti agent at %s", p.directAgent),
+			}
+		}
+
+		return &HandshakeResult{
+			Ready:   false,
+			State:   "failed",
+			Message: fmt.Sprintf("Cannot fetch agent card from %s", p.directAgent),
+		}
+	}
+
+	if p.baseURL == "" {
+		return &HandshakeResult{
+			Ready:   false,
+			State:   "failed",
+			Message: "Kagenti controller URL is not configured. Set KAGENTI_CONTROLLER_URL or KAGENTI_AGENT_URL.",
+		}
+	}
+
+	if !p.controllerReachable(ctx) {
+		return &HandshakeResult{
+			Ready:   false,
+			State:   "failed",
+			Message: fmt.Sprintf("Cannot reach Kagenti controller at %s", p.baseURL),
+		}
+	}
+
+	if p.agentName == "" {
+		p.findDefaultAgent(ctx)
+		if p.agentName == "" {
+			return &HandshakeResult{
+				Ready:   false,
+				State:   "connected",
+				Message: "Kagenti controller is reachable but no agents were found in the cluster.",
+			}
+		}
+	}
+
+	return &HandshakeResult{
+		Ready:   true,
+		State:   "connected",
+		Message: fmt.Sprintf("Connected to Kagenti controller. Selected agent: %s/%s", p.namespace, p.agentName),
+	}
+}
+
+// ChatRequestPayload defines what /api/chat/{ns}/{name}/stream expects
+type ChatRequestPayload struct {
+	Message   string `json:"message"`
+	SessionID string `json:"session_id,omitempty"`
+}
+
+func (p *KagentiProvider) StreamChat(ctx context.Context, req *ChatRequest, onChunk func(chunk string)) (*ChatResponse, error) {
+	return p.StreamChatWithProgress(ctx, req, onChunk, nil)
+}
+
+func (p *KagentiProvider) StreamChatWithProgress(ctx context.Context, req *ChatRequest, onChunk func(chunk string), onProgress func(event StreamEvent)) (*ChatResponse, error) {
+	if p.agentName == "" {
+		p.findDefaultAgent(ctx)
+		if p.agentName == "" {
+			return nil, fmt.Errorf("no kagenti agent is available")
+		}
+	}
+	if p.namespace == "" {
+		p.namespace = "default"
+	}
+
+	payload := ChatRequestPayload{
+		Message:   req.Prompt,
+		SessionID: req.SessionID,
+	}
+
+	bodyBytes, err := json.Marshal(payload)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal kagenti request: %w", err)
+	}
+
+	urls := p.streamCandidateURLs()
+	if len(urls) == 0 {
+		return nil, fmt.Errorf("no kagenti endpoint is configured")
+	}
+
+	var resp *http.Response
+	var invokeErr error
+	for _, url := range urls {
+		httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(bodyBytes))
+		if err != nil {
+			invokeErr = fmt.Errorf("failed to create request: %w", err)
+			continue
+		}
+		httpReq.Header.Set("Content-Type", "application/json")
+		httpReq.Header.Set("Accept", "text/event-stream")
+
+		resp, err = p.client.Do(httpReq)
+		if err != nil {
+			invokeErr = fmt.Errorf("failed to invoke kagenti backend at %s: %w", url, err)
+			continue
+		}
+
+		if resp.StatusCode == http.StatusOK {
+			invokeErr = nil
+			break
+		}
+
+		b, _ := io.ReadAll(resp.Body)
+		resp.Body.Close()
+		invokeErr = fmt.Errorf("kagenti endpoint %s responded with status %d: %s", url, resp.StatusCode, string(b))
+		resp = nil
+	}
+
+	if invokeErr != nil {
+		return nil, invokeErr
+	}
+	if resp == nil {
+		return nil, fmt.Errorf("kagenti backend did not return a valid stream response")
+	}
+	defer resp.Body.Close()
+
+	reader := bufio.NewReader(resp.Body)
+	var fullContent strings.Builder
+
+	for {
+		line, err := reader.ReadString('\n')
+		if err != nil {
+			if err == io.EOF {
+				break
+			}
+			return nil, fmt.Errorf("error reading kagenti stream: %w", err)
+		}
+
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+
+		if strings.HasPrefix(line, "data: ") {
+			data := strings.TrimPrefix(line, "data: ")
+			if data == "[DONE]" {
+				break
+			}
+
+			var eventObj map[string]any
+			if jsonErr := json.Unmarshal([]byte(data), &eventObj); jsonErr == nil {
+				if t, ok := eventObj["type"].(string); ok && t != "" {
+					if t == "text" || t == "message_delta" {
+						if content, ok := eventObj["text"].(string); ok {
+							fullContent.WriteString(content)
+							if onChunk != nil {
+								onChunk(content)
+							}
+						}
+					} else if onProgress != nil {
+						ev := StreamEvent{
+							Type: t,
+						}
+						onProgress(ev)
+					}
+				} else {
+					if content, ok := eventObj["content"].(string); ok {
+						fullContent.WriteString(content)
+						if onChunk != nil {
+							onChunk(content)
+						}
+					}
+				}
+			} else {
+				content := data
+				fullContent.WriteString(content)
+				if onChunk != nil {
+					onChunk(content)
+				}
+			}
+		}
+	}
+
+	return &ChatResponse{
+		Content: fullContent.String(),
+		Agent:   p.agentName,
+		Done:    true,
+	}, nil
+}
+
+func (p *KagentiProvider) Chat(ctx context.Context, req *ChatRequest) (*ChatResponse, error) {
+	return p.StreamChat(ctx, req, nil)
+}
+
+func (p *KagentiProvider) controllerReachable(ctx context.Context) bool {
+	if p.baseURL == "" {
+		return false
+	}
+
+	for _, path := range []string{"/health", "/healthz", "/api/health"} {
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, p.baseURL+path, nil)
+		if err != nil {
+			continue
+		}
+		resp, err := p.client.Do(req)
+		if err != nil {
+			continue
+		}
+		resp.Body.Close()
+		if resp.StatusCode >= 200 && resp.StatusCode < 400 {
+			return true
+		}
+	}
+
+	return false
+}
+
+func (p *KagentiProvider) streamCandidateURLs() []string {
+	if p.directAgent != "" {
+		base := strings.TrimRight(p.directAgent, "/")
+		urls := make([]string, 0, 5)
+
+		if p.namespace != "" && p.agentName != "" {
+			urls = append(urls,
+				fmt.Sprintf("%s/api/chat/%s/%s/stream", base, p.namespace, p.agentName),
+				fmt.Sprintf("%s/chat/%s/%s/stream", base, p.namespace, p.agentName),
+			)
+		}
+
+		urls = append(urls,
+			base+"/api/chat/stream",
+			base+"/chat/stream",
+			base+"/stream",
+		)
+
+		return urls
+	}
+
+	if p.baseURL == "" {
+		return nil
+	}
+
+	chatBasePath := p.chatBasePath
+	if chatBasePath == "" {
+		chatBasePath = "/api"
+	}
+
+	return []string{
+		fmt.Sprintf("%s%s/chat/%s/%s/stream", p.baseURL, chatBasePath, p.namespace, p.agentName),
+	}
+}

--- a/pkg/agent/provider_kagenti.go
+++ b/pkg/agent/provider_kagenti.go
@@ -2,193 +2,73 @@ package agent
 
 import (
 	"bufio"
-	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
 	"io"
-	"net/http"
-	"os"
 	"strings"
 	"time"
+
+	"github.com/kubestellar/console/pkg/kagenti_provider"
 )
 
-// KagentiProvider implements AIProvider and StreamingProvider for Kagenti agents REST API
+const (
+	kagentiProviderHandshakeTimeout    = 2 * time.Second
+	kagentiProviderAvailabilityTimeout = 1200 * time.Millisecond
+	kagentiDefaultAgentNamespace       = "default"
+)
+
+// KagentiProvider implements AIProvider and StreamingProvider for Kagenti agents REST API.
 type KagentiProvider struct {
-	baseURL      string
-	directAgent  string
-	agentName    string
-	namespace    string
-	chatBasePath string
-	client       *http.Client
+	baseURL     string
+	directAgent string
+	agentName   string
+	namespace   string
+	client      *kagenti_provider.KagentiClient
 }
 
 var _ AIProvider = (*KagentiProvider)(nil)
 var _ StreamingProvider = (*KagentiProvider)(nil)
 var _ HandshakeProvider = (*KagentiProvider)(nil)
 
-// NewKagentiProvider creates a new KagentiProvider connected to the Kagenti HTTP backend.
-// It auto-detects the backend URL or falls back to an environment variable.
+// NewKagentiProvider creates a new KagentiProvider and reuses kagenti_provider
+// as the single source of truth for endpoint discovery and invocation.
 func NewKagentiProvider() *KagentiProvider {
-	client := &http.Client{Timeout: 0}
-
-	if agentURL := strings.TrimRight(os.Getenv("KAGENTI_AGENT_URL"), "/"); agentURL != "" {
-		return &KagentiProvider{
-			directAgent:  agentURL,
-			agentName:    os.Getenv("KAGENTI_AGENT_NAME"),
-			namespace:    os.Getenv("KAGENTI_AGENT_NAMESPACE"),
-			chatBasePath: "/",
-			client:       client,
-		}
+	client := kagenti_provider.NewKagentiClientFromEnv()
+	p := &KagentiProvider{client: client}
+	if client == nil {
+		return p
 	}
 
-	baseURL := os.Getenv("KAGENTI_CONTROLLER_URL")
-	if baseURL == "" {
-		baseURL = detectKagentiControllerURL(client)
-	}
-	if baseURL == "" {
-		baseURL = "http://kagenti-controller.kagenti-system.svc:8083"
-	}
-
-	p := &KagentiProvider{
-		baseURL:      strings.TrimRight(baseURL, "/"),
-		chatBasePath: "/api",
-		client:       client,
+	p.baseURL = client.BaseURL()
+	p.directAgent = client.DirectAgentURL()
+	p.agentName = client.DirectAgentName()
+	p.namespace = client.DirectAgentNamespace()
+	if p.namespace == "" && p.directAgent != "" {
+		p.namespace = kagentiDefaultAgentNamespace
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), kagentiProviderHandshakeTimeout)
 	defer cancel()
-
 	p.findDefaultAgent(ctx)
 
 	return p
 }
 
-func detectKagentiControllerURL(client *http.Client) string {
-	namespace := os.Getenv("KAGENTI_NAMESPACE")
-	if namespace == "" {
-		namespace = "kagenti-system"
-	}
-	serviceName := os.Getenv("KAGENTI_SERVICE_NAME")
-	if serviceName == "" {
-		serviceName = "kagenti-controller"
-	}
-	port := os.Getenv("KAGENTI_SERVICE_PORT")
-	if port == "" {
-		port = "8083"
-	}
-	protocol := os.Getenv("KAGENTI_SERVICE_PROTOCOL")
-	if protocol == "" {
-		protocol = "http"
+func (p *KagentiProvider) findDefaultAgent(ctx context.Context) {
+	if p.client == nil {
+		return
 	}
 
-	candidates := []string{
-		fmt.Sprintf("%s://%s.%s.svc:%s", protocol, serviceName, namespace, port),
-		fmt.Sprintf("%s://%s.%s.svc.cluster.local:%s", protocol, serviceName, namespace, port),
-		"http://kagenti-backend.kagenti-system.svc:8000",
-	}
-
-	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
-	defer cancel()
-
-	healthPaths := []string{"/health", "/healthz", "/api/health"}
-	for _, candidate := range candidates {
-		base := strings.TrimRight(candidate, "/")
-		for _, hp := range healthPaths {
-			req, err := http.NewRequestWithContext(ctx, http.MethodGet, base+hp, nil)
-			if err != nil {
-				continue
-			}
-			resp, err := client.Do(req)
-			if err != nil {
-				continue
-			}
-			resp.Body.Close()
-			if resp.StatusCode < 400 {
-				return base
-			}
-		}
-	}
-
-	return ""
-}
-
-type kagentiAgentInfo struct {
-	Name      string `json:"name"`
-	Namespace string `json:"namespace"`
-}
-
-func parseAgentList(body []byte) []kagentiAgentInfo {
-	agents := make([]kagentiAgentInfo, 0)
-
-	var list []map[string]any
-	if err := json.Unmarshal(body, &list); err == nil {
-		for _, item := range list {
-			name, _ := item["name"].(string)
-			namespace, _ := item["namespace"].(string)
-			if name != "" {
-				agents = append(agents, kagentiAgentInfo{Name: name, Namespace: namespace})
-			}
-		}
-		return agents
-	}
-
-	var wrapper struct {
-		Items []map[string]any `json:"items"`
-	}
-	if err := json.Unmarshal(body, &wrapper); err == nil {
-		for _, item := range wrapper.Items {
-			name, _ := item["name"].(string)
-			namespace, _ := item["namespace"].(string)
-			if name != "" {
-				agents = append(agents, kagentiAgentInfo{Name: name, Namespace: namespace})
-			}
-		}
-	}
-
-	return agents
-}
-
-func (p *KagentiProvider) tryFindDefaultAgent(ctx context.Context, endpoint string) bool {
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, p.baseURL+endpoint, nil)
-	if err != nil {
-		return false
-	}
-
-	resp, err := p.client.Do(req)
-	if err != nil {
-		return false
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		return false
-	}
-
-	body, _ := io.ReadAll(resp.Body)
-	agents := parseAgentList(body)
-	if len(agents) == 0 {
-		return false
+	agents, err := p.client.ListAgentsWithContext(ctx)
+	if err != nil || len(agents) == 0 {
+		return
 	}
 
 	p.agentName = agents[0].Name
 	p.namespace = agents[0].Namespace
 	if p.namespace == "" {
-		p.namespace = "default"
-	}
-	p.chatBasePath = strings.TrimSuffix(endpoint, "/agents")
-	return true
-}
-
-func (p *KagentiProvider) findDefaultAgent(ctx context.Context) {
-	if p.baseURL == "" {
-		return
-	}
-
-	for _, endpoint := range []string{"/api/agents", "/api/v1/agents"} {
-		if p.tryFindDefaultAgent(ctx, endpoint) {
-			return
-		}
+		p.namespace = kagentiDefaultAgentNamespace
 	}
 }
 
@@ -218,10 +98,7 @@ func (p *KagentiProvider) Provider() string {
 }
 
 func (p *KagentiProvider) IsAvailable() bool {
-	if p.directAgent != "" {
-		return true
-	}
-	if p.baseURL == "" {
+	if p.client == nil {
 		return false
 	}
 
@@ -229,7 +106,7 @@ func (p *KagentiProvider) IsAvailable() bool {
 		return true
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), 1200*time.Millisecond)
+	ctx, cancel := context.WithTimeout(context.Background(), kagentiProviderAvailabilityTimeout)
 	defer cancel()
 	return p.controllerReachable(ctx)
 }
@@ -239,45 +116,7 @@ func (p *KagentiProvider) Capabilities() ProviderCapability {
 }
 
 func (p *KagentiProvider) Handshake(ctx context.Context) *HandshakeResult {
-	if p.directAgent != "" {
-		for _, cardPath := range []string{"/.well-known/agent-card.json", "/.well-known/agent.json"} {
-			req, err := http.NewRequestWithContext(ctx, http.MethodGet, p.directAgent+cardPath, nil)
-			if err != nil {
-				continue
-			}
-			resp, err := p.client.Do(req)
-			if err != nil {
-				continue
-			}
-			if resp.StatusCode != http.StatusOK {
-				resp.Body.Close()
-				continue
-			}
-
-			var card struct {
-				Name string `json:"name"`
-			}
-			_ = json.NewDecoder(resp.Body).Decode(&card)
-			resp.Body.Close()
-			if card.Name != "" {
-				p.agentName = card.Name
-			}
-
-			return &HandshakeResult{
-				Ready:   true,
-				State:   "connected",
-				Message: fmt.Sprintf("Connected to Kagenti agent at %s", p.directAgent),
-			}
-		}
-
-		return &HandshakeResult{
-			Ready:   false,
-			State:   "failed",
-			Message: fmt.Sprintf("Cannot fetch agent card from %s", p.directAgent),
-		}
-	}
-
-	if p.baseURL == "" {
+	if p.client == nil {
 		return &HandshakeResult{
 			Ready:   false,
 			State:   "failed",
@@ -286,10 +125,14 @@ func (p *KagentiProvider) Handshake(ctx context.Context) *HandshakeResult {
 	}
 
 	if !p.controllerReachable(ctx) {
+		target := p.baseURL
+		if p.directAgent != "" {
+			target = p.directAgent
+		}
 		return &HandshakeResult{
 			Ready:   false,
 			State:   "failed",
-			Message: fmt.Sprintf("Cannot reach Kagenti controller at %s", p.baseURL),
+			Message: fmt.Sprintf("Cannot reach Kagenti at %s", target),
 		}
 	}
 
@@ -303,6 +146,17 @@ func (p *KagentiProvider) Handshake(ctx context.Context) *HandshakeResult {
 			}
 		}
 	}
+	if p.namespace == "" {
+		p.namespace = kagentiDefaultAgentNamespace
+	}
+
+	if p.directAgent != "" {
+		return &HandshakeResult{
+			Ready:   true,
+			State:   "connected",
+			Message: fmt.Sprintf("Connected to Kagenti agent at %s", p.directAgent),
+		}
+	}
 
 	return &HandshakeResult{
 		Ready:   true,
@@ -311,17 +165,15 @@ func (p *KagentiProvider) Handshake(ctx context.Context) *HandshakeResult {
 	}
 }
 
-// ChatRequestPayload defines what /api/chat/{ns}/{name}/stream expects
-type ChatRequestPayload struct {
-	Message   string `json:"message"`
-	SessionID string `json:"session_id,omitempty"`
-}
-
 func (p *KagentiProvider) StreamChat(ctx context.Context, req *ChatRequest, onChunk func(chunk string)) (*ChatResponse, error) {
 	return p.StreamChatWithProgress(ctx, req, onChunk, nil)
 }
 
 func (p *KagentiProvider) StreamChatWithProgress(ctx context.Context, req *ChatRequest, onChunk func(chunk string), onProgress func(event StreamEvent)) (*ChatResponse, error) {
+	if p.client == nil {
+		return nil, fmt.Errorf("no kagenti endpoint is configured")
+	}
+
 	if p.agentName == "" {
 		p.findDefaultAgent(ctx)
 		if p.agentName == "" {
@@ -329,61 +181,16 @@ func (p *KagentiProvider) StreamChatWithProgress(ctx context.Context, req *ChatR
 		}
 	}
 	if p.namespace == "" {
-		p.namespace = "default"
+		p.namespace = kagentiDefaultAgentNamespace
 	}
 
-	payload := ChatRequestPayload{
-		Message:   req.Prompt,
-		SessionID: req.SessionID,
-	}
-
-	bodyBytes, err := json.Marshal(payload)
+	stream, err := p.client.Invoke(ctx, p.namespace, p.agentName, req.Prompt, req.SessionID)
 	if err != nil {
-		return nil, fmt.Errorf("failed to marshal kagenti request: %w", err)
+		return nil, err
 	}
+	defer stream.Close()
 
-	urls := p.streamCandidateURLs()
-	if len(urls) == 0 {
-		return nil, fmt.Errorf("no kagenti endpoint is configured")
-	}
-
-	var resp *http.Response
-	var invokeErr error
-	for _, url := range urls {
-		httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(bodyBytes))
-		if err != nil {
-			invokeErr = fmt.Errorf("failed to create request: %w", err)
-			continue
-		}
-		httpReq.Header.Set("Content-Type", "application/json")
-		httpReq.Header.Set("Accept", "text/event-stream")
-
-		resp, err = p.client.Do(httpReq)
-		if err != nil {
-			invokeErr = fmt.Errorf("failed to invoke kagenti backend at %s: %w", url, err)
-			continue
-		}
-
-		if resp.StatusCode == http.StatusOK {
-			invokeErr = nil
-			break
-		}
-
-		b, _ := io.ReadAll(resp.Body)
-		resp.Body.Close()
-		invokeErr = fmt.Errorf("kagenti endpoint %s responded with status %d: %s", url, resp.StatusCode, string(b))
-		resp = nil
-	}
-
-	if invokeErr != nil {
-		return nil, invokeErr
-	}
-	if resp == nil {
-		return nil, fmt.Errorf("kagenti backend did not return a valid stream response")
-	}
-	defer resp.Body.Close()
-
-	reader := bufio.NewReader(resp.Body)
+	reader := bufio.NewReader(stream)
 	var fullContent strings.Builder
 
 	for {
@@ -417,10 +224,7 @@ func (p *KagentiProvider) StreamChatWithProgress(ctx context.Context, req *ChatR
 							}
 						}
 					} else if onProgress != nil {
-						ev := StreamEvent{
-							Type: t,
-						}
-						onProgress(ev)
+						onProgress(StreamEvent{Type: t})
 					}
 				} else {
 					if content, ok := eventObj["content"].(string); ok {
@@ -431,10 +235,9 @@ func (p *KagentiProvider) StreamChatWithProgress(ctx context.Context, req *ChatR
 					}
 				}
 			} else {
-				content := data
-				fullContent.WriteString(content)
+				fullContent.WriteString(data)
 				if onChunk != nil {
-					onChunk(content)
+					onChunk(data)
 				}
 			}
 		}
@@ -452,59 +255,10 @@ func (p *KagentiProvider) Chat(ctx context.Context, req *ChatRequest) (*ChatResp
 }
 
 func (p *KagentiProvider) controllerReachable(ctx context.Context) bool {
-	if p.baseURL == "" {
+	if p.client == nil {
 		return false
 	}
 
-	for _, path := range []string{"/health", "/healthz", "/api/health"} {
-		req, err := http.NewRequestWithContext(ctx, http.MethodGet, p.baseURL+path, nil)
-		if err != nil {
-			continue
-		}
-		resp, err := p.client.Do(req)
-		if err != nil {
-			continue
-		}
-		resp.Body.Close()
-		if resp.StatusCode >= 200 && resp.StatusCode < 400 {
-			return true
-		}
-	}
-
-	return false
-}
-
-func (p *KagentiProvider) streamCandidateURLs() []string {
-	if p.directAgent != "" {
-		base := strings.TrimRight(p.directAgent, "/")
-		urls := make([]string, 0, 5)
-
-		if p.namespace != "" && p.agentName != "" {
-			urls = append(urls,
-				fmt.Sprintf("%s/api/chat/%s/%s/stream", base, p.namespace, p.agentName),
-				fmt.Sprintf("%s/chat/%s/%s/stream", base, p.namespace, p.agentName),
-			)
-		}
-
-		urls = append(urls,
-			base+"/api/chat/stream",
-			base+"/chat/stream",
-			base+"/stream",
-		)
-
-		return urls
-	}
-
-	if p.baseURL == "" {
-		return nil
-	}
-
-	chatBasePath := p.chatBasePath
-	if chatBasePath == "" {
-		chatBasePath = "/api"
-	}
-
-	return []string{
-		fmt.Sprintf("%s%s/chat/%s/%s/stream", p.baseURL, chatBasePath, p.namespace, p.agentName),
-	}
+	available, err := p.client.StatusWithContext(ctx)
+	return err == nil && available
 }

--- a/pkg/agent/provider_kagenti_test.go
+++ b/pkg/agent/provider_kagenti_test.go
@@ -1,0 +1,151 @@
+package agent
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestKagentiProvider_Interfaces(t *testing.T) {
+	var _ AIProvider = &KagentiProvider{}
+	var _ StreamingProvider = &KagentiProvider{}
+	var _ HandshakeProvider = &KagentiProvider{}
+}
+
+func TestKagentiProvider_Handshake_ConnectionRefused(t *testing.T) {
+	t.Setenv("KAGENTI_CONTROLLER_URL", "http://localhost:59999")
+
+	p := NewKagentiProvider()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	result := p.Handshake(ctx)
+
+	if result.Ready {
+		t.Error("Expected Ready=false when connection is refused")
+	}
+	if result.State != "failed" {
+		t.Errorf("Expected state='failed', got '%s'", result.State)
+	}
+}
+
+func TestKagentiProvider_IsAvailable_NoAgent(t *testing.T) {
+	t.Setenv("KAGENTI_CONTROLLER_URL", "http://localhost:59999")
+	p := NewKagentiProvider()
+
+	if p.IsAvailable() {
+		t.Error("Expected IsAvailable=false when no endpoint is reachable and no agent found")
+	}
+	if p.Name() != "kagenti" {
+		t.Errorf("Expected name 'kagenti', got '%s'", p.Name())
+	}
+	if p.Capabilities() != CapabilityChat|CapabilityToolExec {
+		t.Error("Missing expected capabilities")
+	}
+}
+
+func TestKagentiProvider_Handshake_ControllerAPI(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/health":
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"status":"ok"}`))
+		case "/api/agents":
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`[{"name":"weather","namespace":"team1"}]`))
+		case "/api/chat/team1/weather/stream":
+			w.Header().Set("Content-Type", "text/event-stream")
+			_, _ = w.Write([]byte("data: [DONE]\n\n"))
+		default:
+			http.Error(w, fmt.Sprintf("unexpected path: %s", r.URL.Path), http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+
+	t.Setenv("KAGENTI_CONTROLLER_URL", server.URL)
+	p := NewKagentiProvider()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	result := p.Handshake(ctx)
+	if !result.Ready {
+		t.Fatalf("Expected handshake ready=true, got ready=false (%s)", result.Message)
+	}
+	if result.State != "connected" {
+		t.Fatalf("Expected state='connected', got '%s'", result.State)
+	}
+}
+
+func TestKagentiProvider_DirectAgent_StreamChat(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/.well-known/agent-card.json":
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"name":"ops-agent"}`))
+		case "/chat/stream":
+			w.Header().Set("Content-Type", "text/event-stream")
+			_, _ = w.Write([]byte("data: {\"type\":\"text\",\"text\":\"hello\"}\n\n"))
+			_, _ = w.Write([]byte("data: [DONE]\n\n"))
+		default:
+			http.Error(w, fmt.Sprintf("unexpected path: %s", r.URL.Path), http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+
+	t.Setenv("KAGENTI_AGENT_URL", server.URL)
+	t.Setenv("KAGENTI_AGENT_NAME", "")
+	t.Setenv("KAGENTI_AGENT_NAMESPACE", "")
+	p := NewKagentiProvider()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	h := p.Handshake(ctx)
+	if !h.Ready {
+		t.Fatalf("expected direct agent handshake to be ready, got: %+v", h)
+	}
+
+	res, err := p.Chat(ctx, &ChatRequest{Prompt: "hi", SessionID: "s1"})
+	if err != nil {
+		t.Fatalf("expected direct agent stream chat to succeed, got: %v", err)
+	}
+	if !strings.Contains(res.Content, "hello") {
+		t.Fatalf("expected streamed content to contain 'hello', got: %q", res.Content)
+	}
+}
+
+func TestKagentiProvider_Handshake_HealthzFallback(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/health":
+			http.Error(w, "missing", http.StatusNotFound)
+		case "/healthz":
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`ok`))
+		case "/api/agents":
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`[{"name":"planner","namespace":"ops"}]`))
+		default:
+			_, _ = io.WriteString(w, "")
+		}
+	}))
+	defer server.Close()
+
+	t.Setenv("KAGENTI_CONTROLLER_URL", server.URL)
+	p := NewKagentiProvider()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	result := p.Handshake(ctx)
+	if !result.Ready {
+		t.Fatalf("expected handshake ready=true with /healthz fallback, got: %+v", result)
+	}
+}

--- a/pkg/agent/provider_kagenti_test.go
+++ b/pkg/agent/provider_kagenti_test.go
@@ -11,6 +11,8 @@ import (
 	"time"
 )
 
+const kagentiProviderTestTimeout = 2 * time.Second
+
 func TestKagentiProvider_Interfaces(t *testing.T) {
 	var _ AIProvider = &KagentiProvider{}
 	var _ StreamingProvider = &KagentiProvider{}
@@ -22,7 +24,7 @@ func TestKagentiProvider_Handshake_ConnectionRefused(t *testing.T) {
 
 	p := NewKagentiProvider()
 
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), kagentiProviderTestTimeout)
 	defer cancel()
 
 	result := p.Handshake(ctx)
@@ -71,7 +73,7 @@ func TestKagentiProvider_Handshake_ControllerAPI(t *testing.T) {
 	t.Setenv("KAGENTI_CONTROLLER_URL", server.URL)
 	p := NewKagentiProvider()
 
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), kagentiProviderTestTimeout)
 	defer cancel()
 
 	result := p.Handshake(ctx)
@@ -104,7 +106,7 @@ func TestKagentiProvider_DirectAgent_StreamChat(t *testing.T) {
 	t.Setenv("KAGENTI_AGENT_NAMESPACE", "")
 	p := NewKagentiProvider()
 
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), kagentiProviderTestTimeout)
 	defer cancel()
 
 	h := p.Handshake(ctx)
@@ -141,7 +143,7 @@ func TestKagentiProvider_Handshake_HealthzFallback(t *testing.T) {
 	t.Setenv("KAGENTI_CONTROLLER_URL", server.URL)
 	p := NewKagentiProvider()
 
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), kagentiProviderTestTimeout)
 	defer cancel()
 
 	result := p.Handshake(ctx)

--- a/pkg/agent/registry.go
+++ b/pkg/agent/registry.go
@@ -289,6 +289,11 @@ func InitializeProviders() error {
 	registry.Register(NewClaudeCodeProvider())
 	registry.Register(NewBobProvider())
 
+	// Register in-cluster Kagenti agent (preferred when in-cluster)
+	if p := NewKagentiProvider(); p != nil {
+		registry.Register(p)
+	}
+
 	// Register CLI-based tool-capable agents
 	registry.Register(NewCodexProvider())
 	registry.Register(NewGeminiCLIProvider())

--- a/pkg/api/handlers/kagenti_provider_proxy.go
+++ b/pkg/api/handlers/kagenti_provider_proxy.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"strings"
 
 	"github.com/gofiber/fiber/v2"
 
@@ -72,7 +73,7 @@ func (h *KagentiProviderProxyHandler) Chat(c *fiber.Ctx) error {
 	if err != nil {
 		return c.Status(fiber.StatusBadGateway).JSON(fiber.Map{"error": err.Error()})
 	}
-	defer stream.Close()
+	// stream is closed inside the stream writer callback.
 
 	// Set SSE headers
 	c.Set("Content-Type", "text/event-stream")
@@ -80,29 +81,87 @@ func (h *KagentiProviderProxyHandler) Chat(c *fiber.Ctx) error {
 	c.Set("Connection", "keep-alive")
 
 	c.Context().SetBodyStreamWriter(func(w *bufio.Writer) {
-		scanner := bufio.NewScanner(stream)
-		// Use a 64KB buffer for potentially large chunks
-		buf := make([]byte, 64*1024)
-		scanner.Buffer(buf, len(buf))
+		defer stream.Close()
 
-		for scanner.Scan() {
-			line := scanner.Text()
-			fmt.Fprintf(w, "data: %s\n\n", line)
-			w.Flush()
+		reader := bufio.NewReaderSize(stream, 256*1024) // 256KB buffer per line
+		doneSent := false
+
+		for {
+			line, err := reader.ReadString('\n')
+			line = strings.TrimRight(line, "\r\n")
+
+			if line != "" {
+				payload := line
+				if strings.HasPrefix(line, "data: ") {
+					payload = line[6:]
+				}
+
+				if payload == "[DONE]" {
+					fmt.Fprintf(w, "data: [DONE]\n\n")
+					w.Flush()
+					doneSent = true
+					break
+				}
+
+				text := extractTextFromChunk(payload)
+				fmt.Fprintf(w, "data: %s\n\n", text)
+				w.Flush()
+			}
+
+			if err != nil {
+				if err != io.EOF {
+					fmt.Fprintf(w, "data: {\"error\": \"stream interrupted: %s\"}\n\n", err.Error())
+					w.Flush()
+				}
+				break
+			}
 		}
 
-		if err := scanner.Err(); err != nil {
-			// Stream was interrupted — send error event instead of [DONE]
-			fmt.Fprintf(w, "data: {\"error\": \"stream interrupted\"}\n\n")
+		if !doneSent {
+			fmt.Fprintf(w, "data: [DONE]\n\n")
 			w.Flush()
-			return
 		}
-
-		fmt.Fprintf(w, "data: [DONE]\n\n")
-		w.Flush()
 	})
 
 	return nil
+}
+
+// extractTextFromChunk extracts text fields from known JSON chunk shapes.
+func extractTextFromChunk(s string) string {
+	if len(s) == 0 || s[0] != '{' {
+		return s // not JSON, pass through as-is
+	}
+	var m map[string]json.RawMessage
+	if err := json.Unmarshal([]byte(s), &m); err != nil {
+		return s
+	}
+	// {"type": "text", "text": "..."}
+	if raw, ok := m["text"]; ok {
+		var t string
+		if json.Unmarshal(raw, &t) == nil {
+			return t
+		}
+	}
+	// {"content": "..."}
+	if raw, ok := m["content"]; ok {
+		var t string
+		if json.Unmarshal(raw, &t) == nil {
+			return t
+		}
+	}
+	// {"delta": {"text": "..."}}
+	if raw, ok := m["delta"]; ok {
+		var delta map[string]json.RawMessage
+		if json.Unmarshal(raw, &delta) == nil {
+			if tRaw, ok := delta["text"]; ok {
+				var t string
+				if json.Unmarshal(tRaw, &t) == nil {
+					return t
+				}
+			}
+		}
+	}
+	return s // unknown schema, pass through raw
 }
 
 // kagentiCallToolRequest is the request body for the CallTool endpoint.

--- a/pkg/api/handlers/kagenti_provider_proxy.go
+++ b/pkg/api/handlers/kagenti_provider_proxy.go
@@ -12,6 +12,10 @@ import (
 	"github.com/kubestellar/console/pkg/kagenti_provider"
 )
 
+// kagentiSSELineBufferBytes is the per-line read buffer for SSE streaming responses.
+// 256 KB handles large JSON payloads in a single SSE event.
+const kagentiSSELineBufferBytes = 256 * 1024
+
 // KagentiProviderProxyHandler proxies requests to the kagenti A2A endpoint.
 type KagentiProviderProxyHandler struct {
 	client *kagenti_provider.KagentiClient // can be nil if kagenti not detected
@@ -83,7 +87,7 @@ func (h *KagentiProviderProxyHandler) Chat(c *fiber.Ctx) error {
 	c.Context().SetBodyStreamWriter(func(w *bufio.Writer) {
 		defer stream.Close()
 
-		reader := bufio.NewReaderSize(stream, 256*1024) // 256KB buffer per line
+		reader := bufio.NewReaderSize(stream, kagentiSSELineBufferBytes)
 		doneSent := false
 
 		for {

--- a/pkg/kagenti_provider/client.go
+++ b/pkg/kagenti_provider/client.go
@@ -252,7 +252,17 @@ func (c *KagentiClient) Invoke(ctx context.Context, namespace, agentName, messag
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Accept", "text/event-stream")
 
-	httpClient := &http.Client{} // no timeout — let caller cancel via ctx
+	// Reuse configured client settings (transport/TLS/proxy) and disable timeout
+	// so long-running streams are controlled by ctx cancellation.
+	httpClient := c.httpClient
+	if httpClient == nil {
+		httpClient = &http.Client{}
+	} else {
+		clone := *httpClient
+		clone.Timeout = 0
+		httpClient = &clone
+	}
+
 	resp, err := httpClient.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("kagenti invoke failed: %w", err)

--- a/pkg/kagenti_provider/client.go
+++ b/pkg/kagenti_provider/client.go
@@ -12,6 +12,36 @@ import (
 	"time"
 )
 
+const (
+	defaultClientTimeout        = 30 * time.Second
+	defaultDetectTimeout        = 3 * time.Second
+	defaultKagentiNamespace     = "kagenti-system"
+	defaultKagentiServiceName   = "kagenti-backend"
+	defaultKagentiServicePort   = "8000"
+	legacyKagentiServiceName    = "kagenti-controller"
+	legacyKagentiServicePort    = "8083"
+	defaultKagentiServiceScheme = "http"
+	defaultDirectAgentName      = "kagenti-agent"
+	defaultDirectAgentNamespace = "default"
+)
+
+var (
+	kagentiHealthPaths = []string{"/health", "/healthz", "/api/health"}
+
+	// Keep both legacy and newer list paths for cross-version compatibility.
+	kagentiListAgentPaths = []string{"/api/v1/agents", "/api/agents"}
+
+	kagentiDirectCardPaths = []string{"/.well-known/agent-card.json", "/.well-known/agent.json"}
+
+	kagentiDirectStreamPaths = []string{"/api/chat/stream", "/chat/stream", "/stream"}
+
+	// Keep both legacy and newer controller chat paths.
+	kagentiControllerStreamPathPatterns = []string{
+		"/api/v1/chat/%s/%s/stream",
+		"/api/chat/%s/%s/stream",
+	}
+)
+
 // AgentInfo describes a kagenti agent discovered via the platform.
 type AgentInfo struct {
 	Name        string   `json:"name"`
@@ -43,7 +73,7 @@ func NewKagentiClient(baseURL string) *KagentiClient {
 	return &KagentiClient{
 		baseURL: strings.TrimRight(baseURL, "/"),
 		httpClient: &http.Client{
-			Timeout: 30 * time.Second,
+			Timeout: defaultClientTimeout,
 		},
 	}
 }
@@ -58,7 +88,7 @@ func NewKagentiClientFromEnv() *KagentiClient {
 			directAgentName:      os.Getenv("KAGENTI_AGENT_NAME"),
 			directAgentNamespace: os.Getenv("KAGENTI_AGENT_NAMESPACE"),
 			httpClient: &http.Client{
-				Timeout: 30 * time.Second,
+				Timeout: defaultClientTimeout,
 			},
 		}
 	}
@@ -66,7 +96,7 @@ func NewKagentiClientFromEnv() *KagentiClient {
 	url := os.Getenv("KAGENTI_CONTROLLER_URL")
 	if url == "" {
 		// Try auto-detection with a short timeout client
-		c := &KagentiClient{httpClient: &http.Client{Timeout: 3 * time.Second}}
+		c := &KagentiClient{httpClient: &http.Client{Timeout: defaultDetectTimeout}}
 		url = c.Detect()
 	}
 	if url == "" {
@@ -75,11 +105,40 @@ func NewKagentiClientFromEnv() *KagentiClient {
 	return NewKagentiClient(url)
 }
 
+// BaseURL returns the configured controller base URL.
+func (c *KagentiClient) BaseURL() string {
+	return c.baseURL
+}
+
+// DirectAgentURL returns the configured direct agent URL.
+func (c *KagentiClient) DirectAgentURL() string {
+	return c.directAgentURL
+}
+
+// DirectAgentName returns the configured direct agent name (if any).
+func (c *KagentiClient) DirectAgentName() string {
+	return c.directAgentName
+}
+
+// DirectAgentNamespace returns the configured direct agent namespace (if any).
+func (c *KagentiClient) DirectAgentNamespace() string {
+	return c.directAgentNamespace
+}
+
 // Status checks whether the kagenti controller is reachable.
 func (c *KagentiClient) Status() (bool, error) {
+	return c.StatusWithContext(context.Background())
+}
+
+// StatusWithContext checks whether the kagenti controller/agent is reachable.
+func (c *KagentiClient) StatusWithContext(ctx context.Context) (bool, error) {
 	if c.directAgentURL != "" {
-		for _, p := range []string{"/.well-known/agent-card.json", "/.well-known/agent.json", "/health", "/healthz"} {
-			resp, err := c.httpClient.Get(c.directAgentURL + p)
+		for _, p := range append(append([]string{}, kagentiDirectCardPaths...), kagentiHealthPaths...) {
+			req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.directAgentURL+p, nil)
+			if err != nil {
+				continue
+			}
+			resp, err := c.httpClient.Do(req)
 			if err != nil {
 				continue
 			}
@@ -91,25 +150,44 @@ func (c *KagentiClient) Status() (bool, error) {
 		return false, fmt.Errorf("kagenti direct agent health check failed at %s", c.directAgentURL)
 	}
 
-	resp, err := c.httpClient.Get(c.baseURL + "/health")
-	if err != nil {
-		return false, fmt.Errorf("kagenti health check failed: %w", err)
+	for _, healthPath := range kagentiHealthPaths {
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.baseURL+healthPath, nil)
+		if err != nil {
+			continue
+		}
+		resp, err := c.httpClient.Do(req)
+		if err != nil {
+			continue
+		}
+		resp.Body.Close()
+		if resp.StatusCode >= 200 && resp.StatusCode < 300 {
+			return true, nil
+		}
 	}
-	defer resp.Body.Close()
-	return resp.StatusCode >= 200 && resp.StatusCode < 300, nil
+
+	return false, fmt.Errorf("kagenti health check failed for all known endpoints at %s", c.baseURL)
 }
 
 // ListAgents queries the kagenti controller for registered agents.
 func (c *KagentiClient) ListAgents() ([]AgentInfo, error) {
+	return c.ListAgentsWithContext(context.Background())
+}
+
+// ListAgentsWithContext queries the kagenti controller for registered agents.
+func (c *KagentiClient) ListAgentsWithContext(ctx context.Context) ([]AgentInfo, error) {
 	if c.directAgentURL != "" {
 		name := c.directAgentName
 		namespace := c.directAgentNamespace
 		if namespace == "" {
-			namespace = "default"
+			namespace = defaultDirectAgentNamespace
 		}
 
-		for _, p := range []string{"/.well-known/agent-card.json", "/.well-known/agent.json"} {
-			resp, err := c.httpClient.Get(c.directAgentURL + p)
+		for _, p := range kagentiDirectCardPaths {
+			req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.directAgentURL+p, nil)
+			if err != nil {
+				continue
+			}
+			resp, err := c.httpClient.Do(req)
 			if err != nil {
 				continue
 			}
@@ -126,7 +204,7 @@ func (c *KagentiClient) ListAgents() ([]AgentInfo, error) {
 		}
 
 		if name == "" {
-			name = "kagenti-agent"
+			name = defaultDirectAgentName
 		}
 
 		return []AgentInfo{{
@@ -137,26 +215,63 @@ func (c *KagentiClient) ListAgents() ([]AgentInfo, error) {
 		}}, nil
 	}
 
-	// Kagenti backend exposes agents under /api/v1/agents
-	resp, err := c.httpClient.Get(c.baseURL + "/api/v1/agents")
+	var lastErr error
+	for _, path := range kagentiListAgentPaths {
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.baseURL+path, nil)
+		if err != nil {
+			lastErr = err
+			continue
+		}
+
+		resp, err := c.httpClient.Do(req)
+		if err != nil {
+			lastErr = err
+			continue
+		}
+
+		if resp.StatusCode != http.StatusOK {
+			body, _ := io.ReadAll(resp.Body)
+			resp.Body.Close()
+			lastErr = fmt.Errorf("list agents at %s returned %d: %s", path, resp.StatusCode, string(body))
+			continue
+		}
+
+		agents, err := decodeAgentList(resp.Body)
+		resp.Body.Close()
+		if err != nil {
+			lastErr = fmt.Errorf("failed to decode agent list at %s: %w", path, err)
+			continue
+		}
+
+		return agents, nil
+	}
+
+	if lastErr == nil {
+		lastErr = fmt.Errorf("failed to list kagenti agents: no reachable list endpoint")
+	}
+
+	return nil, lastErr
+}
+
+func decodeAgentList(body io.Reader) ([]AgentInfo, error) {
+	raw, err := io.ReadAll(body)
 	if err != nil {
-		return nil, fmt.Errorf("failed to list kagenti agents: %w", err)
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		body, _ := io.ReadAll(resp.Body)
-		return nil, fmt.Errorf("list agents returned %d: %s", resp.StatusCode, string(body))
+		return nil, err
 	}
 
-	// The Kagenti API returns a list envelope: `{"items": [...]}`
-	var result struct {
+	var wrapped struct {
 		Items []AgentInfo `json:"items"`
 	}
-	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
-		return nil, fmt.Errorf("failed to decode agent list: %w", err)
+	if err := json.Unmarshal(raw, &wrapped); err == nil && wrapped.Items != nil {
+		return wrapped.Items, nil
 	}
-	return result.Items, nil
+
+	var direct []AgentInfo
+	if err := json.Unmarshal(raw, &direct); err == nil {
+		return direct, nil
+	}
+
+	return nil, fmt.Errorf("unsupported list response shape")
 }
 
 // Discover fetches the A2A agent card for the given agent.
@@ -195,11 +310,7 @@ func (c *KagentiClient) Invoke(ctx context.Context, namespace, agentName, messag
 			return nil, fmt.Errorf("failed to marshal direct invoke payload: %w", err)
 		}
 
-		urls := []string{
-			c.directAgentURL + "/api/chat/stream",
-			c.directAgentURL + "/chat/stream",
-			c.directAgentURL + "/stream",
-		}
+		urls := c.directStreamURLs()
 
 		var lastErr error
 		for _, u := range urls {
@@ -232,7 +343,7 @@ func (c *KagentiClient) Invoke(ctx context.Context, namespace, agentName, messag
 		return nil, lastErr
 	}
 
-	// Kagenti backend uses REST+SSE via FastAPI: POST /api/v1/chat/{namespace}/{name}/stream
+	// Kagenti backend uses REST+SSE; keep both known controller paths.
 	type restPayload struct {
 		Message   string `json:"message"`
 		SessionID string `json:"session_id,omitempty"`
@@ -243,64 +354,95 @@ func (c *KagentiClient) Invoke(ctx context.Context, namespace, agentName, messag
 		return nil, fmt.Errorf("failed to marshal kagenti request: %w", err)
 	}
 
-	url := fmt.Sprintf("%s/api/v1/chat/%s/%s/stream",
-		c.baseURL, neturl.PathEscape(namespace), neturl.PathEscape(agentName))
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, strings.NewReader(string(payload)))
-	if err != nil {
-		return nil, fmt.Errorf("failed to create request: %w", err)
-	}
-	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("Accept", "text/event-stream")
+	urls := c.controllerStreamURLs(namespace, agentName)
 
-	// Reuse configured client settings (transport/TLS/proxy) and disable timeout
-	// so long-running streams are controlled by ctx cancellation.
-	httpClient := c.httpClient
-	if httpClient == nil {
-		httpClient = &http.Client{}
-	} else {
-		clone := *httpClient
-		clone.Timeout = 0
-		httpClient = &clone
-	}
+	var lastErr error
+	for _, url := range urls {
+		req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, strings.NewReader(string(payload)))
+		if err != nil {
+			lastErr = err
+			continue
+		}
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("Accept", "text/event-stream")
 
-	resp, err := httpClient.Do(req)
-	if err != nil {
-		return nil, fmt.Errorf("kagenti invoke failed: %w", err)
-	}
+		// Reuse configured client settings (transport/TLS/proxy) and disable timeout
+		// so long-running streams are controlled by ctx cancellation.
+		httpClient := c.httpClient
+		if httpClient == nil {
+			httpClient = &http.Client{}
+		} else {
+			clone := *httpClient
+			clone.Timeout = 0
+			httpClient = &clone
+		}
 
-	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		resp, err := httpClient.Do(req)
+		if err != nil {
+			lastErr = fmt.Errorf("kagenti invoke failed at %s: %w", url, err)
+			continue
+		}
+
+		if resp.StatusCode >= 200 && resp.StatusCode < 300 {
+			return resp.Body, nil
+		}
+
 		errBody, _ := io.ReadAll(resp.Body)
 		resp.Body.Close()
-		return nil, fmt.Errorf("kagenti invoke returned %d: %s", resp.StatusCode, string(errBody))
+		lastErr = fmt.Errorf("kagenti invoke at %s returned %d: %s", url, resp.StatusCode, string(errBody))
 	}
 
-	return resp.Body, nil
+	if lastErr == nil {
+		lastErr = fmt.Errorf("kagenti invoke failed: no reachable stream endpoint")
+	}
+
+	return nil, lastErr
 }
 
-// buildDetectCandidates constructs the list of candidate URLs for kagenti auto-detection.
+// BuildDetectCandidatesFromEnv constructs the list of candidate URLs for kagenti auto-detection.
 // The namespace, service name, port, and protocol are configurable via environment
 // variables so non-standard deployments can be discovered automatically.
-func buildDetectCandidates() []string {
+func BuildDetectCandidatesFromEnv() []string {
 	namespace := os.Getenv("KAGENTI_NAMESPACE")
 	if namespace == "" {
-		namespace = "kagenti-system"
+		namespace = defaultKagentiNamespace
 	}
 	serviceName := os.Getenv("KAGENTI_SERVICE_NAME")
 	if serviceName == "" {
-		serviceName = "kagenti-backend"
+		serviceName = defaultKagentiServiceName
 	}
 	port := os.Getenv("KAGENTI_SERVICE_PORT")
 	if port == "" {
-		port = "8000"
+		port = defaultKagentiServicePort
 	}
 	protocol := os.Getenv("KAGENTI_SERVICE_PROTOCOL")
 	if protocol == "" {
-		protocol = "http"
+		protocol = defaultKagentiServiceScheme
 	}
-	return []string{
+
+	configured := []string{
 		fmt.Sprintf("%s://%s.%s.svc:%s", protocol, serviceName, namespace, port),
 		fmt.Sprintf("%s://%s.%s.svc.cluster.local:%s", protocol, serviceName, namespace, port),
 	}
+
+	legacy := []string{
+		fmt.Sprintf("%s://%s.%s.svc:%s", defaultKagentiServiceScheme, legacyKagentiServiceName, defaultKagentiNamespace, legacyKagentiServicePort),
+		fmt.Sprintf("%s://%s.%s.svc.cluster.local:%s", defaultKagentiServiceScheme, legacyKagentiServiceName, defaultKagentiNamespace, legacyKagentiServicePort),
+		fmt.Sprintf("%s://%s.%s.svc:%s", defaultKagentiServiceScheme, defaultKagentiServiceName, defaultKagentiNamespace, defaultKagentiServicePort),
+		fmt.Sprintf("%s://%s.%s.svc.cluster.local:%s", defaultKagentiServiceScheme, defaultKagentiServiceName, defaultKagentiNamespace, defaultKagentiServicePort),
+	}
+
+	seen := make(map[string]struct{}, len(configured)+len(legacy))
+	all := make([]string, 0, len(configured)+len(legacy))
+	for _, c := range append(configured, legacy...) {
+		if _, ok := seen[c]; ok {
+			continue
+		}
+		seen[c] = struct{}{}
+		all = append(all, c)
+	}
+
+	return all
 }
 
 // Detect tries common in-cluster kagenti service URLs and returns the first reachable one.
@@ -310,17 +452,42 @@ func (c *KagentiClient) Detect() string {
 
 // DetectWithContext tries common in-cluster kagenti service URLs with context support (#5566).
 func (c *KagentiClient) DetectWithContext(ctx context.Context) string {
-	candidates := buildDetectCandidates()
+	candidates := BuildDetectCandidatesFromEnv()
 	for _, url := range candidates {
-		req, err := http.NewRequestWithContext(ctx, http.MethodGet, url+"/health", nil)
-		if err != nil {
-			continue
-		}
-		resp, err := c.httpClient.Do(req)
-		if err == nil {
+		base := strings.TrimRight(url, "/")
+		for _, path := range kagentiHealthPaths {
+			req, err := http.NewRequestWithContext(ctx, http.MethodGet, base+path, nil)
+			if err != nil {
+				continue
+			}
+			resp, err := c.httpClient.Do(req)
+			if err != nil {
+				continue
+			}
 			resp.Body.Close()
-			return url
+			if resp.StatusCode >= 200 && resp.StatusCode < 400 {
+				return base
+			}
 		}
 	}
 	return ""
+}
+
+func (c *KagentiClient) directStreamURLs() []string {
+	base := strings.TrimRight(c.directAgentURL, "/")
+	urls := make([]string, 0, len(kagentiDirectStreamPaths))
+	for _, path := range kagentiDirectStreamPaths {
+		urls = append(urls, base+path)
+	}
+	return urls
+}
+
+func (c *KagentiClient) controllerStreamURLs(namespace, agentName string) []string {
+	escapedNamespace := neturl.PathEscape(namespace)
+	escapedAgentName := neturl.PathEscape(agentName)
+	urls := make([]string, 0, len(kagentiControllerStreamPathPatterns))
+	for _, pattern := range kagentiControllerStreamPathPatterns {
+		urls = append(urls, fmt.Sprintf("%s"+pattern, c.baseURL, escapedNamespace, escapedAgentName))
+	}
+	return urls
 }

--- a/pkg/kagenti_provider/client.go
+++ b/pkg/kagenti_provider/client.go
@@ -31,8 +31,11 @@ type AgentCard struct {
 
 // KagentiClient proxies requests to the kagenti A2A protocol endpoint.
 type KagentiClient struct {
-	baseURL    string
-	httpClient *http.Client
+	baseURL              string
+	directAgentURL       string
+	directAgentName      string
+	directAgentNamespace string
+	httpClient           *http.Client
 }
 
 // NewKagentiClient creates a new KagentiClient with the given base URL.
@@ -49,6 +52,17 @@ func NewKagentiClient(baseURL string) *KagentiClient {
 // environment variable, falling back to in-cluster auto-detection. Returns nil
 // if kagenti is not available.
 func NewKagentiClientFromEnv() *KagentiClient {
+	if direct := strings.TrimRight(os.Getenv("KAGENTI_AGENT_URL"), "/"); direct != "" {
+		return &KagentiClient{
+			directAgentURL:       direct,
+			directAgentName:      os.Getenv("KAGENTI_AGENT_NAME"),
+			directAgentNamespace: os.Getenv("KAGENTI_AGENT_NAMESPACE"),
+			httpClient: &http.Client{
+				Timeout: 30 * time.Second,
+			},
+		}
+	}
+
 	url := os.Getenv("KAGENTI_CONTROLLER_URL")
 	if url == "" {
 		// Try auto-detection with a short timeout client
@@ -63,6 +77,20 @@ func NewKagentiClientFromEnv() *KagentiClient {
 
 // Status checks whether the kagenti controller is reachable.
 func (c *KagentiClient) Status() (bool, error) {
+	if c.directAgentURL != "" {
+		for _, p := range []string{"/.well-known/agent-card.json", "/.well-known/agent.json", "/health", "/healthz"} {
+			resp, err := c.httpClient.Get(c.directAgentURL + p)
+			if err != nil {
+				continue
+			}
+			resp.Body.Close()
+			if resp.StatusCode >= 200 && resp.StatusCode < 300 {
+				return true, nil
+			}
+		}
+		return false, fmt.Errorf("kagenti direct agent health check failed at %s", c.directAgentURL)
+	}
+
 	resp, err := c.httpClient.Get(c.baseURL + "/health")
 	if err != nil {
 		return false, fmt.Errorf("kagenti health check failed: %w", err)
@@ -73,7 +101,44 @@ func (c *KagentiClient) Status() (bool, error) {
 
 // ListAgents queries the kagenti controller for registered agents.
 func (c *KagentiClient) ListAgents() ([]AgentInfo, error) {
-	resp, err := c.httpClient.Get(c.baseURL + "/api/agents")
+	if c.directAgentURL != "" {
+		name := c.directAgentName
+		namespace := c.directAgentNamespace
+		if namespace == "" {
+			namespace = "default"
+		}
+
+		for _, p := range []string{"/.well-known/agent-card.json", "/.well-known/agent.json"} {
+			resp, err := c.httpClient.Get(c.directAgentURL + p)
+			if err != nil {
+				continue
+			}
+			if resp.StatusCode >= 200 && resp.StatusCode < 300 {
+				var card AgentCard
+				if err := json.NewDecoder(resp.Body).Decode(&card); err == nil && card.Name != "" {
+					name = card.Name
+				}
+			}
+			resp.Body.Close()
+			if name != "" {
+				break
+			}
+		}
+
+		if name == "" {
+			name = "kagenti-agent"
+		}
+
+		return []AgentInfo{{
+			Name:        name,
+			Namespace:   namespace,
+			Description: fmt.Sprintf("Direct Kagenti agent (%s)", c.directAgentURL),
+			Framework:   "kagenti",
+		}}, nil
+	}
+
+	// Kagenti backend exposes agents under /api/v1/agents
+	resp, err := c.httpClient.Get(c.baseURL + "/api/v1/agents")
 	if err != nil {
 		return nil, fmt.Errorf("failed to list kagenti agents: %w", err)
 	}
@@ -84,11 +149,14 @@ func (c *KagentiClient) ListAgents() ([]AgentInfo, error) {
 		return nil, fmt.Errorf("list agents returned %d: %s", resp.StatusCode, string(body))
 	}
 
-	var agents []AgentInfo
-	if err := json.NewDecoder(resp.Body).Decode(&agents); err != nil {
+	// The Kagenti API returns a list envelope: `{"items": [...]}`
+	var result struct {
+		Items []AgentInfo `json:"items"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
 		return nil, fmt.Errorf("failed to decode agent list: %w", err)
 	}
-	return agents, nil
+	return result.Items, nil
 }
 
 // Discover fetches the A2A agent card for the given agent.
@@ -113,59 +181,87 @@ func (c *KagentiClient) Discover(namespace, agentName string) (*AgentCard, error
 	return &card, nil
 }
 
-// a2aRequest is the JSON-RPC 2.0 envelope sent to the A2A endpoint.
-type a2aRequest struct {
-	JSONRPC string         `json:"jsonrpc"`
-	Method  string         `json:"method"`
-	Params  map[string]any `json:"params"`
-}
-
 // Invoke sends a message to an agent via the A2A protocol and returns the raw
 // response body for streaming consumption.
 func (c *KagentiClient) Invoke(ctx context.Context, namespace, agentName, message string, contextID string) (io.ReadCloser, error) {
-	params := map[string]any{
-		"message": map[string]any{
-			"role": "user",
-			"parts": []map[string]any{
-				{"kind": "text", "text": message},
-			},
-		},
-		"configuration": map[string]any{
-			"acceptedOutputModes": []string{"text"},
-		},
-	}
-	if contextID != "" {
-		params["contextId"] = contextID
+	if c.directAgentURL != "" {
+		payload := map[string]any{"message": message}
+		if contextID != "" {
+			payload["session_id"] = contextID
+		}
+
+		body, err := json.Marshal(payload)
+		if err != nil {
+			return nil, fmt.Errorf("failed to marshal direct invoke payload: %w", err)
+		}
+
+		urls := []string{
+			c.directAgentURL + "/api/chat/stream",
+			c.directAgentURL + "/chat/stream",
+			c.directAgentURL + "/stream",
+		}
+
+		var lastErr error
+		for _, u := range urls {
+			req, err := http.NewRequestWithContext(ctx, http.MethodPost, u, strings.NewReader(string(body)))
+			if err != nil {
+				lastErr = err
+				continue
+			}
+			req.Header.Set("Content-Type", "application/json")
+			req.Header.Set("Accept", "text/event-stream")
+
+			resp, err := c.httpClient.Do(req)
+			if err != nil {
+				lastErr = err
+				continue
+			}
+
+			if resp.StatusCode >= 200 && resp.StatusCode < 300 {
+				return resp.Body, nil
+			}
+
+			errBody, _ := io.ReadAll(resp.Body)
+			resp.Body.Close()
+			lastErr = fmt.Errorf("direct invoke returned %d: %s", resp.StatusCode, string(errBody))
+		}
+
+		if lastErr == nil {
+			lastErr = fmt.Errorf("direct invoke failed: no reachable streaming endpoint")
+		}
+		return nil, lastErr
 	}
 
-	body := a2aRequest{
-		JSONRPC: "2.0",
-		Method:  "message/send",
-		Params:  params,
+	// Kagenti backend uses REST+SSE via FastAPI: POST /api/v1/chat/{namespace}/{name}/stream
+	type restPayload struct {
+		Message   string `json:"message"`
+		SessionID string `json:"session_id,omitempty"`
 	}
-
-	payload, err := json.Marshal(body)
+	rp := restPayload{Message: message, SessionID: contextID}
+	payload, err := json.Marshal(rp)
 	if err != nil {
-		return nil, fmt.Errorf("failed to marshal A2A request: %w", err)
+		return nil, fmt.Errorf("failed to marshal kagenti request: %w", err)
 	}
 
-	url := fmt.Sprintf("%s/api/a2a/%s/%s",
+	url := fmt.Sprintf("%s/api/v1/chat/%s/%s/stream",
 		c.baseURL, neturl.PathEscape(namespace), neturl.PathEscape(agentName))
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, strings.NewReader(string(payload)))
 	if err != nil {
 		return nil, fmt.Errorf("failed to create request: %w", err)
 	}
 	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "text/event-stream")
 
-	resp, err := c.httpClient.Do(req)
+	httpClient := &http.Client{} // no timeout — let caller cancel via ctx
+	resp, err := httpClient.Do(req)
 	if err != nil {
-		return nil, fmt.Errorf("A2A invoke failed: %w", err)
+		return nil, fmt.Errorf("kagenti invoke failed: %w", err)
 	}
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		errBody, _ := io.ReadAll(resp.Body)
 		resp.Body.Close()
-		return nil, fmt.Errorf("A2A invoke returned %d: %s", resp.StatusCode, string(errBody))
+		return nil, fmt.Errorf("kagenti invoke returned %d: %s", resp.StatusCode, string(errBody))
 	}
 
 	return resp.Body, nil
@@ -181,11 +277,11 @@ func buildDetectCandidates() []string {
 	}
 	serviceName := os.Getenv("KAGENTI_SERVICE_NAME")
 	if serviceName == "" {
-		serviceName = "kagenti-controller"
+		serviceName = "kagenti-backend"
 	}
 	port := os.Getenv("KAGENTI_SERVICE_PORT")
 	if port == "" {
-		port = "8083"
+		port = "8000"
 	}
 	protocol := os.Getenv("KAGENTI_SERVICE_PROTOCOL")
 	if protocol == "" {
@@ -197,8 +293,6 @@ func buildDetectCandidates() []string {
 	}
 }
 
-// Detect tries common in-cluster kagenti service URLs and returns the first
-// reachable one. Returns an empty string if none are reachable.
 // Detect tries common in-cluster kagenti service URLs and returns the first reachable one.
 func (c *KagentiClient) Detect() string {
 	return c.DetectWithContext(context.Background())

--- a/web/src/components/agent/AgentSelector.tsx
+++ b/web/src/components/agent/AgentSelector.tsx
@@ -21,17 +21,21 @@ import { AgentIcon } from "./AgentIcon";
 import type { AgentInfo, AgentProvider } from "../../types/agent";
 
 /** Timeout (ms) for fetching mission install guide files from the API */
-const MISSION_FILE_FETCH_TIMEOUT_MS = 5_000
-import { PROVIDER_PREREQUISITES } from '../../types/agent'
-import type { MissionExport } from '../../lib/missions/types'
-import { cn } from '../../lib/cn'
-import { useModalState } from '../../lib/modals'
-import { safeGetItem, safeSetItem } from '../../lib/utils/localStorage'
+const MISSION_FILE_FETCH_TIMEOUT_MS = 5_000;
+import { PROVIDER_PREREQUISITES} from "../../types/agent";
+import type { MissionExport } from "../../lib/missions/types";
+import { cn } from "../../lib/cn";
+import { useModalState } from "../../lib/modals";
+import { safeGetItem, safeSetItem } from "../../lib/utils/localStorage";
 import { sanitizeUrl } from '../../lib/utils/sanitizeUrl'
-import { AgentApprovalDialog, hasApprovedAgents } from './AgentApprovalDialog'
-import { MissionDetailView } from '../missions/MissionDetailView'
-import { ClusterSelectionDialog } from '../missions/ClusterSelectionDialog'
-import { CLUSTER_PROVIDER_KEYS, buildVisibleAgents, sectionAgents } from './agentSelectorUtils'
+import { AgentApprovalDialog, hasApprovedAgents } from "./AgentApprovalDialog";
+import { MissionDetailView } from "../missions/MissionDetailView";
+import { ClusterSelectionDialog } from "../missions/ClusterSelectionDialog";
+import {
+  CLUSTER_PROVIDER_KEYS,
+  buildVisibleAgents,
+  sectionAgents,
+} from "./agentSelectorUtils";
 
 /** Map agent names to their backend provider key for prerequisite lookup */
 const AGENT_TO_PROVIDER_KEY: Record<string, string> = {

--- a/web/src/components/agent/AgentSelector.tsx
+++ b/web/src/components/agent/AgentSelector.tsx
@@ -1,13 +1,24 @@
-import { useRef, useEffect, useMemo, useState } from 'react'
-import { useTranslation } from 'react-i18next'
-import { createPortal } from 'react-dom'
-import { ChevronDown, Check, Loader2, Sparkles, Play, BookOpen, X, RefreshCw, AlertTriangle, ExternalLink } from 'lucide-react'
-import { useMissions } from '../../hooks/useMissions'
-import { useDemoMode, getDemoMode } from '../../hooks/useDemoMode'
-import { useKagentBackend } from '../../hooks/useKagentBackend'
-import { useProviderConnection } from '../../hooks/useProviderConnection'
-import { AgentIcon } from './AgentIcon'
-import type { AgentInfo, AgentProvider } from '../../types/agent'
+import { useRef, useEffect, useMemo, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { createPortal } from "react-dom";
+import {
+  ChevronDown,
+  Check,
+  Loader2,
+  Sparkles,
+  Play,
+  BookOpen,
+  X,
+  RefreshCw,
+  AlertTriangle,
+  ExternalLink,
+} from "lucide-react";
+import { useMissions } from "../../hooks/useMissions";
+import { useDemoMode, getDemoMode } from "../../hooks/useDemoMode";
+import { useKagentBackend } from "../../hooks/useKagentBackend";
+import { useProviderConnection } from "../../hooks/useProviderConnection";
+import { AgentIcon } from "./AgentIcon";
+import type { AgentInfo, AgentProvider } from "../../types/agent";
 
 /** Timeout (ms) for fetching mission install guide files from the API */
 const MISSION_FILE_FETCH_TIMEOUT_MS = 5_000
@@ -24,278 +35,436 @@ import { CLUSTER_PROVIDER_KEYS, buildVisibleAgents, sectionAgents } from './agen
 
 /** Map agent names to their backend provider key for prerequisite lookup */
 const AGENT_TO_PROVIDER_KEY: Record<string, string> = {
-  vscode: 'vscode',
-  antigravity: 'antigravity' }
+  vscode: "vscode",
+  antigravity: "antigravity",
+};
 
 interface AgentSelectorProps {
-  compact?: boolean
-  className?: string
+  compact?: boolean;
+  className?: string;
 }
 
-export function AgentSelector({ compact = false, className = '' }: AgentSelectorProps) {
-  const { t } = useTranslation()
-  const { agents, selectedAgent, agentsLoading, selectAgent, connectToAgent, startMission, openSidebar } = useMissions()
-  const { isDemoMode: isDemoModeHook } = useDemoMode()
-  const { kagentAvailable, kagentiAvailable, selectedKagentAgent, selectedKagentiAgent } = useKagentBackend()
+export function AgentSelector({
+  compact = false,
+  className = "",
+}: AgentSelectorProps) {
+  const { t } = useTranslation();
+  const {
+    agents,
+    selectedAgent,
+    agentsLoading,
+    selectAgent,
+    connectToAgent,
+    startMission,
+    openSidebar,
+  } = useMissions();
+  const { isDemoMode: isDemoModeHook } = useDemoMode();
+  const {
+    kagentAvailable,
+    kagentiAvailable,
+    selectedKagentAgent,
+    selectedKagentiAgent,
+    activeBackend,
+    hasPolled,
+  } = useKagentBackend();
   // Synchronous fallback prevents flash during React transitions
-  const isDemoMode = isDemoModeHook || getDemoMode()
-  const { isOpen, close: closeDropdown, toggle: toggleDropdown } = useModalState()
-  const PREV_AGENT_KEY = 'kc_previous_agent'
+  const isDemoMode = isDemoModeHook || getDemoMode();
+  const {
+    isOpen,
+    close: closeDropdown,
+    toggle: toggleDropdown,
+  } = useModalState();
+  const PREV_AGENT_KEY = "kc_previous_agent";
   const previousAgentRef = useRef<string | null>(
-    typeof window !== 'undefined' ? safeGetItem(PREV_AGENT_KEY) : null
-  )
-  const dropdownRef = useRef<HTMLDivElement>(null)
-  const buttonRef = useRef<HTMLButtonElement>(null)
-  const panelRef = useRef<HTMLDivElement>(null)
-  const [dropdownPos, setDropdownPos] = useState<{ top: number; right: number } | null>(null)
-  const [showApproval, setShowApproval] = useState(false)
+    typeof window !== "undefined" ? safeGetItem(PREV_AGENT_KEY) : null,
+  );
+  const dropdownRef = useRef<HTMLDivElement>(null);
+  const buttonRef = useRef<HTMLButtonElement>(null);
+  const panelRef = useRef<HTMLDivElement>(null);
+  const [dropdownPos, setDropdownPos] = useState<{
+    top: number;
+    right: number;
+  } | null>(null);
+  const [showApproval, setShowApproval] = useState(false);
   // Provider connection lifecycle tracking
-  const { connectionState, startConnection, retry, reset: resetConnection, dismiss: dismissConnection } = useProviderConnection()
+  const {
+    connectionState,
+    startConnection,
+    retry,
+    reset: resetConnection,
+    dismiss: dismissConnection,
+  } = useProviderConnection();
   // Stash the agent name the user intended to select when approval was triggered
-  const pendingAgentRef = useRef<string | null>(null)
+  const pendingAgentRef = useRef<string | null>(null);
   // Install guide modal state
-  const [installGuide, setInstallGuide] = useState<{ mission: MissionExport; raw: string } | null>(null)
-  const [installGuideLoading, setInstallGuideLoading] = useState(false)
-  const [installGuideError, setInstallGuideError] = useState(false)
-  const [installGuideShowRaw, setInstallGuideShowRaw] = useState(false)
+  const [installGuide, setInstallGuide] = useState<{
+    mission: MissionExport;
+    raw: string;
+  } | null>(null);
+  const [installGuideLoading, setInstallGuideLoading] = useState(false);
+  const [installGuideError, setInstallGuideError] = useState(false);
+  const [installGuideShowRaw, setInstallGuideShowRaw] = useState(false);
   // Cluster selection for AI install
-  const [pendingInstall, setPendingInstall] = useState<{ missionId: string; displayName: string; mission: MissionExport } | null>(null)
+  const [pendingInstall, setPendingInstall] = useState<{
+    missionId: string;
+    displayName: string;
+    mission: MissionExport;
+  } | null>(null);
 
   // Providers that are cluster-based (rendered in bottom section)
-  const CLUSTER_PROVIDERS: Set<AgentProvider> = new Set(CLUSTER_PROVIDER_KEYS)
+  const CLUSTER_PROVIDERS: Set<AgentProvider> = new Set(CLUSTER_PROVIDER_KEYS);
 
   // Always-show CLI agents (appear grayed out when not detected)
   const ALWAYS_SHOW_CLI: AgentInfo[] = [
     {
-      name: 'goose',
-      displayName: 'Goose',
-      description: 'Open-source AI agent by Block with MCP support',
-      provider: 'block',
+      name: "goose",
+      displayName: "Goose",
+      description: "Open-source AI agent by Block with MCP support",
+      provider: "block",
       available: false,
-      installUrl: 'https://github.com/block/goose' },
+      installUrl: "https://github.com/block/goose",
+    },
     {
-      name: 'copilot-cli',
-      displayName: 'Copilot CLI',
-      description: 'GitHub Copilot in the terminal',
-      provider: 'github-cli',
+      name: "copilot-cli",
+      displayName: "Copilot CLI",
+      description: "GitHub Copilot in the terminal",
+      provider: "github-cli",
       available: false,
-      installUrl: 'https://docs.github.com/en/copilot/github-copilot-in-the-cli' },
-  ]
+      installUrl:
+        "https://docs.github.com/en/copilot/github-copilot-in-the-cli",
+    },
+  ];
 
   // Merge local agents with always-show CLI agents and in-cluster backends
-  const visibleAgents = buildVisibleAgents(agents, ALWAYS_SHOW_CLI, { kagentAvailable, kagentiAvailable, selectedKagentAgent, selectedKagentiAgent })
+  const visibleAgents = buildVisibleAgents(agents, ALWAYS_SHOW_CLI, {
+    kagentAvailable,
+    kagentiAvailable,
+    selectedKagentAgent,
+    selectedKagentiAgent,
+  });
 
   // Check if any CLI agent is available (can run install missions)
-  const hasCliAgent = agents.some(a => a.available)
+  const hasCliAgent = agents.some((a) => a.available);
 
   // Known KB paths for install missions (stable reference to avoid recreating callbacks)
-  const INSTALL_MISSION_PATHS = useMemo<Record<string, string[]>>(() => ({
-    'install-kagent': ['fixes/cncf-install/install-kagent.json'],
-    'install-kagenti': ['fixes/platform-install/install-kagenti.json'] }), [])
+  const INSTALL_MISSION_PATHS = useMemo<Record<string, string[]>>(
+    () => ({
+      "install-kagent": ["fixes/cncf-install/install-kagent.json"],
+      "install-kagenti": ["fixes/platform-install/install-kagenti.json"],
+    }),
+    [],
+  );
 
   const openInstallGuide = async (missionId: string) => {
-    closeDropdown()
-    setInstallGuideLoading(true)
-    setInstallGuideError(false)
-    const paths = INSTALL_MISSION_PATHS[missionId] || [`fixes/cncf-install/${missionId}.json`, `fixes/platform-install/${missionId}.json`]
+    closeDropdown();
+    setInstallGuideLoading(true);
+    setInstallGuideError(false);
+    const paths = INSTALL_MISSION_PATHS[missionId] || [
+      `fixes/cncf-install/${missionId}.json`,
+      `fixes/platform-install/${missionId}.json`,
+    ];
     for (const path of paths) {
       try {
-        const res = await fetch(`/api/missions/file?path=${encodeURIComponent(path)}`, { signal: AbortSignal.timeout(MISSION_FILE_FETCH_TIMEOUT_MS) })
-        if (!res.ok) continue
-        const raw = await res.text()
-        const parsed = JSON.parse(raw)
-        const nested = parsed.mission || {}
+        const res = await fetch(
+          `/api/missions/file?path=${encodeURIComponent(path)}`,
+          { signal: AbortSignal.timeout(MISSION_FILE_FETCH_TIMEOUT_MS) },
+        );
+        if (!res.ok) continue;
+        const raw = await res.text();
+        const parsed = JSON.parse(raw);
+        const nested = parsed.mission || {};
         const mission: MissionExport = {
-          version: parsed.version || '1.0',
+          version: parsed.version || "1.0",
           title: nested.title || parsed.title || missionId,
-          description: nested.description || parsed.description || '',
-          type: nested.type || parsed.type || 'deploy',
+          description: nested.description || parsed.description || "",
+          type: nested.type || parsed.type || "deploy",
           steps: nested.steps || parsed.steps || [],
           uninstall: nested.uninstall || parsed.uninstall,
           upgrade: nested.upgrade || parsed.upgrade,
           troubleshooting: nested.troubleshooting || parsed.troubleshooting,
           tags: nested.tags || parsed.tags,
-          missionClass: 'install' }
-        setInstallGuide({ mission, raw })
-        setInstallGuideLoading(false)
-        return
-      } catch { continue }
+          missionClass: "install",
+        };
+        setInstallGuide({ mission, raw });
+        setInstallGuideLoading(false);
+        return;
+      } catch {
+        continue;
+      }
     }
-    setInstallGuideError(true)
-    setInstallGuideLoading(false)
-  }
+    setInstallGuideError(true);
+    setInstallGuideLoading(false);
+  };
 
-  const handleInstallMission = async (missionId: string, displayName: string) => {
-    closeDropdown()
+  const handleInstallMission = async (
+    missionId: string,
+    displayName: string,
+  ) => {
+    closeDropdown();
     // Fetch the actual mission content
-    const paths = INSTALL_MISSION_PATHS[missionId] || [`fixes/cncf-install/${missionId}.json`, `fixes/platform-install/${missionId}.json`]
-    let missionData: MissionExport | null = null
+    const paths = INSTALL_MISSION_PATHS[missionId] || [
+      `fixes/cncf-install/${missionId}.json`,
+      `fixes/platform-install/${missionId}.json`,
+    ];
+    let missionData: MissionExport | null = null;
     for (const path of paths) {
       try {
-        const res = await fetch(`/api/missions/file?path=${encodeURIComponent(path)}`, { signal: AbortSignal.timeout(MISSION_FILE_FETCH_TIMEOUT_MS) })
-        if (!res.ok) continue
-        const raw = await res.text()
-        const parsed = JSON.parse(raw)
-        const nested = parsed.mission || {}
+        const res = await fetch(
+          `/api/missions/file?path=${encodeURIComponent(path)}`,
+          { signal: AbortSignal.timeout(MISSION_FILE_FETCH_TIMEOUT_MS) },
+        );
+        if (!res.ok) continue;
+        const raw = await res.text();
+        const parsed = JSON.parse(raw);
+        const nested = parsed.mission || {};
         missionData = {
-          version: parsed.version || '1.0',
+          version: parsed.version || "1.0",
           title: nested.title || parsed.title || displayName,
-          description: nested.description || parsed.description || `Install ${displayName}`,
-          type: 'deploy',
+          description:
+            nested.description ||
+            parsed.description ||
+            `Install ${displayName}`,
+          type: "deploy",
           tags: nested.tags || parsed.tags || [],
-          steps: nested.steps || parsed.steps || [] }
-        break
-      } catch { continue }
+          steps: nested.steps || parsed.steps || [],
+        };
+        break;
+      } catch {
+        continue;
+      }
     }
     if (!missionData) {
       // Fallback: start with simple prompt
-      startMission({ title: `Install ${displayName}`, description: `Install ${displayName} in the cluster`, type: 'deploy', initialPrompt: `Install ${displayName} in the cluster` })
-      return
+      startMission({
+        title: `Install ${displayName}`,
+        description: `Install ${displayName} in the cluster`,
+        type: "deploy",
+        initialPrompt: `Install ${displayName} in the cluster`,
+      });
+      return;
     }
     // Show cluster selection dialog before running
-    setPendingInstall({ missionId, displayName, mission: missionData })
-  }
+    setPendingInstall({ missionId, displayName, mission: missionData });
+  };
 
   // Split agents into sections: selected at top, then CLI, then Cluster
-  const { selectedAgentInfo, cliAgents, clusterAgents } = sectionAgents(visibleAgents, selectedAgent, CLUSTER_PROVIDERS)
+  const { selectedAgentInfo, cliAgents, clusterAgents } = sectionAgents(
+    visibleAgents,
+    selectedAgent,
+    CLUSTER_PROVIDERS,
+  );
 
   // Flat list for keyboard navigation and length checks
   const sortedAgents = (() => {
-    const list: AgentInfo[] = []
-    if (selectedAgentInfo) list.push(selectedAgentInfo)
-    list.push(...cliAgents, ...clusterAgents)
-    return list
-  })()
+    const list: AgentInfo[] = [];
+    if (selectedAgentInfo) list.push(selectedAgentInfo);
+    list.push(...cliAgents, ...clusterAgents);
+    return list;
+  })();
 
-  const currentAgent = visibleAgents.find(a => a.name === selectedAgent) || visibleAgents[0]
-  const hasAvailableAgents = visibleAgents.some(a => a.available)
+  const currentAgent =
+    visibleAgents.find((a) => a.name === selectedAgent) || visibleAgents[0];
+  const hasAvailableAgents = visibleAgents.some((a) => a.available);
 
   // Connect to agent WebSocket on mount and when leaving demo mode
   useEffect(() => {
-    if (!isDemoMode) {
-      connectToAgent()
+    if (!isDemoMode && activeBackend === "kc-agent") {
+      connectToAgent();
     }
-  }, [connectToAgent, isDemoMode])
+  }, [connectToAgent, isDemoMode, activeBackend]);
+
+  // Auto-select kagenti/kagent when running in-cluster with no kc-agent.
+  // Without this, the user lands in-cluster with no selected agent and the
+  // missions chat is disconnected until they manually open the dropdown.
+  //
+  // #7xxx — The previous guard `if (selectedAgent && selectedAgent !== "none") return`
+  // was too weak: when the WS opens it fires an `agent_selected` message (e.g.
+  // "claude-code") which set selectedAgent before this effect ran, causing it to
+  // bail and never switch to kagenti. In-cluster with no real kc-agent (agents=[]),
+  // a WS-based selectedAgent is always stale — override it unless we are already
+  // on a cluster backend.
+  useEffect(() => {
+    if (isDemoMode) return;
+    if (agents.length > 0) return; // kc-agent WS has real agents — respect selection
+    // If already on a cluster backend, nothing to do
+    const isClusterBackendSelected =
+      selectedAgent === "kagenti" || selectedAgent === "kagent";
+    if (isClusterBackendSelected) return;
+    // Force-select cluster backend, overriding any stale WS agent in state/localStorage
+    if (kagentiAvailable) {
+      selectAgent("kagenti");
+    } else if (kagentAvailable) {
+      selectAgent("kagent");
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [
+    isDemoMode,
+    kagentiAvailable,
+    kagentAvailable,
+    agents.length,
+    selectedAgent,
+  ]);
 
   // Retry connection when dropdown is opened and agents are empty
   useEffect(() => {
-    if (isOpen && agents.length === 0 && !agentsLoading && !isDemoMode) {
-      connectToAgent()
+    if (
+      isOpen &&
+      agents.length === 0 &&
+      !agentsLoading &&
+      !isDemoMode &&
+      activeBackend === "kc-agent"
+    ) {
+      connectToAgent();
     }
-  }, [isOpen, agents.length, agentsLoading, isDemoMode, connectToAgent])
+  }, [
+    isOpen,
+    agents.length,
+    agentsLoading,
+    isDemoMode,
+    connectToAgent,
+    activeBackend,
+  ]);
 
   // Close dropdown when clicking outside (check both trigger and portal panel)
   useEffect(() => {
     function handleClickOutside(event: MouseEvent) {
-      const target = event.target as Node
+      const target = event.target as Node;
       if (
-        dropdownRef.current && !dropdownRef.current.contains(target) &&
+        dropdownRef.current &&
+        !dropdownRef.current.contains(target) &&
         (!panelRef.current || !panelRef.current.contains(target))
       ) {
-        closeDropdown()
+        closeDropdown();
       }
     }
-    document.addEventListener('mousedown', handleClickOutside)
-    return () => document.removeEventListener('mousedown', handleClickOutside)
-  }, [closeDropdown])
+    document.addEventListener("mousedown", handleClickOutside);
+    return () => document.removeEventListener("mousedown", handleClickOutside);
+  }, [closeDropdown]);
 
   // Compute dropdown position when opened (portal needs absolute screen coords)
   // Recompute on resize/scroll so the menu stays attached to its trigger
   useEffect(() => {
-    if (!isOpen) return
+    if (!isOpen) return;
 
     const updatePosition = () => {
-      if (!buttonRef.current) return
-      const rect = buttonRef.current.getBoundingClientRect()
-      const DROPDOWN_GAP_PX = 4
+      if (!buttonRef.current) return;
+      const rect = buttonRef.current.getBoundingClientRect();
+      const DROPDOWN_GAP_PX = 4;
       setDropdownPos({
         top: rect.bottom + DROPDOWN_GAP_PX,
-        right: window.innerWidth - rect.right })
-    }
+        right: window.innerWidth - rect.right,
+      });
+    };
 
-    updatePosition()
-    window.addEventListener('resize', updatePosition)
-    window.addEventListener('scroll', updatePosition, true)
+    updatePosition();
+    window.addEventListener("resize", updatePosition);
+    window.addEventListener("scroll", updatePosition, true);
     return () => {
-      window.removeEventListener('resize', updatePosition)
-      window.removeEventListener('scroll', updatePosition, true)
-    }
-  }, [isOpen])
+      window.removeEventListener("resize", updatePosition);
+      window.removeEventListener("scroll", updatePosition, true);
+    };
+  }, [isOpen]);
 
   // Close on escape
   useEffect(() => {
     function handleEscape(event: KeyboardEvent) {
-      if (event.key === 'Escape') {
-        closeDropdown()
+      if (event.key === "Escape") {
+        closeDropdown();
       }
     }
     if (isOpen) {
-      document.addEventListener('keydown', handleEscape)
-      return () => document.removeEventListener('keydown', handleEscape)
+      document.addEventListener("keydown", handleEscape);
+      return () => document.removeEventListener("keydown", handleEscape);
     }
-  }, [isOpen, closeDropdown])
+  }, [isOpen, closeDropdown]);
 
   // Close dropdown when entering demo mode
   useEffect(() => {
     if (isDemoMode) {
-      closeDropdown()
+      closeDropdown();
     }
-  }, [isDemoMode, closeDropdown])
+  }, [isDemoMode, closeDropdown]);
 
   // Reset connection lifecycle state when dropdown closes
   useEffect(() => {
-    if (!isOpen && connectionState.phase !== 'idle') {
-      resetConnection()
+    if (!isOpen && connectionState.phase !== "idle") {
+      resetConnection();
     }
-  }, [isOpen]) // eslint-disable-line react-hooks/exhaustive-deps
+  }, [isOpen]); // eslint-disable-line react-hooks/exhaustive-deps
 
-  // Loading state — only show spinner if we already had agents (reconnecting).
-  // When no agents have loaded yet (e.g. cluster mode with no kc-agent), render nothing
-  // to avoid a perpetual spinner from the reconnect loop.
-  if (agentsLoading && !isDemoMode) {
-    if (agents.length === 0) return null
+  // In-cluster deployments can have no kc-agent (agents=[]), so compute this
+  // before loading/null guards.
+  const hasClusterAgents = kagentAvailable || kagentiAvailable;
+
+  // Hold rendering until the first kagenti/kagent poll completes, otherwise
+  // we'd hit the return-null guard below while kagentiAvailable is still false
+  // (the poll hasn't fired yet) — causing the selector to blink and disappear.
+  if (!hasPolled && !isDemoMode && agents.length === 0) {
     return (
-      <div className={cn('flex items-center gap-2 text-sm text-muted-foreground', className)}>
+      <div
+        className={cn(
+          "flex items-center gap-2 text-sm text-muted-foreground",
+          className,
+        )}
+      >
         <Loader2 className="w-4 h-4 animate-spin" />
-        {!compact && <span>{t('common.loading')}</span>}
+        {!compact && <span>{t("common.loading")}</span>}
       </div>
-    )
+    );
   }
 
-  // No agents available and not in demo mode — hide selector entirely (cluster mode)
-  if (agents.length === 0 && !agentsLoading && !isDemoMode) return null
+  // Loading state — keep a stable visual instead of returning null to avoid
+  // trigger blink/disappear during transient reconnect/poll windows.
+  if (agentsLoading && !isDemoMode && !hasClusterAgents) {
+    return (
+      <div
+        className={cn(
+          "flex items-center gap-2 text-sm text-muted-foreground",
+          className,
+        )}
+      >
+        <Loader2 className="w-4 h-4 animate-spin" />
+        {!compact && <span>{t("common.loading")}</span>}
+      </div>
+    );
+  }
+
+  // No agents available and not in demo mode — hide selector unless cluster agents are available.
+  // In-cluster deployments have no kc-agent (agents=[]) but may have kagenti/kagent.
+  if (agents.length === 0 && !agentsLoading && !isDemoMode && !hasClusterAgents)
+    return null;
 
   // Only gray out in demo mode - allow interaction during loading/reconnection
-  const isGreyedOut = isDemoMode
+  const isGreyedOut = isDemoMode;
 
-  const isNoneSelected = selectedAgent === 'none'
+  const isNoneSelected = selectedAgent === "none";
 
   // Always show dropdown (even with 1 agent) so user can access "None" option
 
   const handleSelect = (agentName: string) => {
     // Gate agent activation behind approval for all non-none selections
-    if (agentName !== 'none' && !hasApprovedAgents()) {
-      pendingAgentRef.current = agentName
-      setShowApproval(true)
-      return
+    if (agentName !== "none" && !hasApprovedAgents()) {
+      pendingAgentRef.current = agentName;
+      setShowApproval(true);
+      return;
     }
 
     // For providers with prerequisites (e.g. VS Code), run a readiness check
     // with clear lifecycle feedback instead of silently timing out
-    const providerKey = AGENT_TO_PROVIDER_KEY[agentName]
+    const providerKey = AGENT_TO_PROVIDER_KEY[agentName];
     if (providerKey && PROVIDER_PREREQUISITES[providerKey]) {
       // Persist the selection immediately so it is not lost on timeout
-      selectAgent(agentName)
+      selectAgent(agentName);
       startConnection(agentName, () => {
         // Connection confirmed - dropdown can close
-        closeDropdown()
-      })
-      return
+        closeDropdown();
+      });
+      return;
     }
 
-    selectAgent(agentName)
-    closeDropdown()
-  }
+    selectAgent(agentName);
+    closeDropdown();
+  };
 
   const renderAgentRow = (agent: AgentInfo) => (
     <div
@@ -305,42 +474,71 @@ export function AgentSelector({ compact = false, className = '' }: AgentSelector
       aria-disabled={!agent.available}
       tabIndex={agent.available ? 0 : -1}
       className={cn(
-        'w-full flex items-start gap-3 px-3 py-2 text-left transition-colors',
+        "w-full flex items-start gap-3 px-3 py-2 text-left transition-colors",
         agent.available
-          ? 'hover:bg-secondary cursor-pointer'
-          : 'cursor-default',
-        agent.name === selectedAgent && 'bg-primary/10'
+          ? "hover:bg-secondary cursor-pointer"
+          : "cursor-default",
+        agent.name === selectedAgent && "bg-primary/10",
       )}
       onClick={() => agent.available && handleSelect(agent.name)}
-      onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); if (agent.available) handleSelect(agent.name) } }}
+      onKeyDown={(e) => {
+        if (e.key === "Enter" || e.key === " ") {
+          e.preventDefault();
+          if (agent.available) handleSelect(agent.name);
+        }
+      }}
     >
-      <AgentIcon provider={agent.provider} className={cn('w-5 h-5 mt-0.5 flex-shrink-0', !agent.available && 'opacity-40')} />
+      <AgentIcon
+        provider={agent.provider}
+        className={cn(
+          "w-5 h-5 mt-0.5 flex-shrink-0",
+          !agent.available && "opacity-40",
+        )}
+      />
       <div className="flex-1 min-w-0">
         <div className="flex items-center gap-2">
-          <span className={cn(
-            'text-sm font-medium',
-            agent.name === selectedAgent ? 'text-primary' : agent.available ? 'text-foreground' : 'text-muted-foreground'
-          )}>
+          <span
+            className={cn(
+              "text-sm font-medium",
+              agent.name === selectedAgent
+                ? "text-primary"
+                : agent.available
+                  ? "text-foreground"
+                  : "text-muted-foreground",
+            )}
+          >
             {agent.displayName}
           </span>
           {agent.name === selectedAgent && (
             <Check className="w-4 h-4 text-primary flex-shrink-0" />
           )}
         </div>
-        <p className={cn('text-xs', agent.available ? 'text-muted-foreground' : 'text-muted-foreground/60')}>
+        <p
+          className={cn(
+            "text-xs",
+            agent.available
+              ? "text-muted-foreground"
+              : "text-muted-foreground/60",
+          )}
+        >
           {agent.description}
         </p>
         {agent.model ? (
           <span className="text-2xs text-muted-foreground bg-secondary/50 px-1.5 py-0.5 rounded">
             {agent.model}
           </span>
-        ) : agent.provider === 'github-cli' ? (
-          <span className="text-2xs text-muted-foreground italic">Default model</span>
+        ) : agent.provider === "github-cli" ? (
+          <span className="text-2xs text-muted-foreground italic">
+            Default model
+          </span>
         ) : null}
         {!agent.available && agent.installMissionId && (
           <div className="flex items-center gap-2 mt-1">
             <button
-              onClick={(e) => { e.stopPropagation(); openInstallGuide(agent.installMissionId!) }}
+              onClick={(e) => {
+                e.stopPropagation();
+                openInstallGuide(agent.installMissionId!);
+              }}
               className="flex items-center gap-1 text-xs text-primary hover:text-primary/80 transition-colors"
             >
               <BookOpen className="w-3 h-3" />
@@ -350,7 +548,13 @@ export function AgentSelector({ compact = false, className = '' }: AgentSelector
               <>
                 <span className="text-xs text-muted-foreground/40">|</span>
                 <button
-                  onClick={(e) => { e.stopPropagation(); handleInstallMission(agent.installMissionId!, agent.displayName) }}
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    handleInstallMission(
+                      agent.installMissionId!,
+                      agent.displayName,
+                    );
+                  }}
                   className="flex items-center gap-1 text-xs text-purple-400 hover:text-purple-300 transition-colors"
                 >
                   <Play className="w-3 h-3" />
@@ -374,341 +578,468 @@ export function AgentSelector({ compact = false, className = '' }: AgentSelector
         )}
       </div>
     </div>
-  )
+  );
 
   // Always show the dropdown trigger — never a standalone gear.
   // When no agents are available, show a generic agent icon; settings gear
   // lives only inside the dropdown as a footer item.
   return (
     <>
-    <div ref={dropdownRef} className={cn('relative flex items-center gap-1', className, isGreyedOut && 'opacity-40 pointer-events-none')}>
-      <button
-        ref={buttonRef}
-        onClick={() => !isDemoMode && toggleDropdown()}
-        aria-haspopup="listbox"
-        aria-expanded={isOpen}
+      <div
+        ref={dropdownRef}
         className={cn(
-          'flex items-center gap-2 px-3 py-1.5 h-9 rounded-lg border transition-colors',
-          'bg-secondary/50 border-border hover:bg-secondary',
-          isOpen && 'ring-1 ring-primary'
+          "relative flex items-center gap-1",
+          className,
+          isGreyedOut && "opacity-40 pointer-events-none",
         )}
       >
-        {isNoneSelected ? (
-          <Sparkles className="w-4 h-4 text-muted-foreground" />
-        ) : hasAvailableAgents && currentAgent ? (
-          <AgentIcon provider={currentAgent.provider} className="w-4 h-4" />
-        ) : (
-          <AgentIcon provider="default" className="w-4 h-4" />
-        )}
-        {!compact && (
-          <span className="text-sm font-medium text-foreground truncate max-w-[120px]">
-            {isNoneSelected ? t('agent.noneAgent') : hasAvailableAgents && currentAgent ? currentAgent.displayName : 'AI Agent'}
-          </span>
-        )}
-        <ChevronDown className={cn(
-          'w-4 h-4 text-muted-foreground transition-transform',
-          isOpen && 'rotate-180'
-        )} />
-      </button>
-
-      {isOpen && dropdownPos && createPortal(
-        <div
-          ref={panelRef}
-          role="listbox"
-          aria-label={t('agent.selectAgent')}
-          className="fixed z-modal w-96 max-h-[calc(100vh-8rem)] rounded-lg bg-card border border-border shadow-lg overflow-hidden flex flex-col"
-          style={{ top: dropdownPos.top, right: dropdownPos.right }}
-          onKeyDown={(e) => {
-            if (e.key !== 'ArrowDown' && e.key !== 'ArrowUp') return
-            e.preventDefault()
-            const items = e.currentTarget.querySelectorAll<HTMLElement>('[role="option"]:not([aria-disabled="true"])')
-            const idx = Array.from(items).indexOf(document.activeElement as HTMLElement)
-            if (e.key === 'ArrowDown') items[Math.min(idx + 1, items.length - 1)]?.focus()
-            else items[Math.max(idx - 1, 0)]?.focus()
-          }}
+        <button
+          ref={buttonRef}
+          onClick={() => !isDemoMode && toggleDropdown()}
+          aria-haspopup="listbox"
+          aria-expanded={isOpen}
+          className={cn(
+            "flex items-center gap-2 px-3 py-1.5 h-9 rounded-lg border transition-colors",
+            "bg-secondary/50 border-border hover:bg-secondary",
+            isOpen && "ring-1 ring-primary",
+          )}
         >
-          {/* AI Agent toggle — ON by default, OFF disables AI processing */}
-          <div className="px-3 py-3 border-b border-border flex-shrink-0">
-            <div className="flex items-center justify-between">
-              <div className="flex items-center gap-2">
-                <Sparkles className={cn('w-4 h-4', isNoneSelected ? 'text-muted-foreground' : 'text-primary')} />
-                <div>
-                  <span className="text-sm font-medium text-foreground">{t('agent.aiAgentToggle')}</span>
-                  <p className="text-xs text-muted-foreground">
-                    {isNoneSelected ? t('agent.noneAgentDesc') : t('agent.aiAgentOnDesc')}
-                  </p>
-                </div>
-              </div>
-              <button
-                role="switch"
-                aria-checked={!isNoneSelected}
-                onClick={() => {
-                  if (isNoneSelected) {
-                    // Turn AI on — require approval on first use
-                    const prev = previousAgentRef.current
-                    const restored = prev ? sortedAgents.find(a => a.name === prev && a.available) : undefined
-                    const targetAgent = restored?.name || sortedAgents.find(a => a.available)?.name || ''
-
-                    // Guard: don't select an empty agent ID (#5673)
-                    if (!targetAgent) return
-
-                    if (!hasApprovedAgents()) {
-                      // Show approval dialog before enabling
-                      pendingAgentRef.current = targetAgent
-                      setShowApproval(true)
-                      return
-                    }
-                    handleSelect(targetAgent)
-                  } else {
-                    // Save current agent before turning AI off
-                    previousAgentRef.current = selectedAgent || null
-                    if (selectedAgent) safeSetItem(PREV_AGENT_KEY, selectedAgent)
-                    handleSelect('none')
-                  }
-                }}
-                className={cn(
-                  'relative inline-flex h-6 w-11 items-center rounded-full transition-colors flex-shrink-0',
-                  !isNoneSelected ? 'bg-primary' : 'bg-secondary'
-                )}
-              >
-                <span className={cn(
-                  'inline-block h-4 w-4 transform rounded-full bg-white dark:bg-gray-200 transition-transform',
-                  !isNoneSelected ? 'translate-x-6' : 'translate-x-1'
-                )} />
-              </button>
-            </div>
-          </div>
-          {sortedAgents.length > 0 && (
-            <div className="py-1 overflow-y-auto min-h-0">
-              {/* Selected agent at the very top */}
-              {selectedAgentInfo && renderAgentRow(selectedAgentInfo)}
-
-              {/* CLI Agents section */}
-              {cliAgents.length > 0 && (
-                <>
-                  <div className="px-3 pt-2 pb-1">
-                    <span className="text-[10px] font-semibold uppercase tracking-wider text-muted-foreground/60">CLI Agents</span>
-                  </div>
-                  {cliAgents.map(renderAgentRow)}
-                </>
-              )}
-
-              {/* Cluster Agents section */}
-              {clusterAgents.length > 0 && (
-                <>
-                  <div className="px-3 pt-2 pb-1 border-t border-border/50 mt-1">
-                    <span className="text-[10px] font-semibold uppercase tracking-wider text-muted-foreground/60">Cluster Agents</span>
-                  </div>
-                  {clusterAgents.map(renderAgentRow)}
-                </>
-              )}
-            </div>
+          {isNoneSelected ? (
+            <Sparkles className="w-4 h-4 text-muted-foreground" />
+          ) : hasAvailableAgents && currentAgent ? (
+            <AgentIcon provider={currentAgent.provider} className="w-4 h-4" />
+          ) : (
+            <AgentIcon provider="default" className="w-4 h-4" />
           )}
-          {/* Provider connection lifecycle feedback */}
-          {connectionState.phase !== 'idle' && (
-            <div className="px-3 py-3 border-t border-border bg-secondary/20">
-              {(connectionState.phase === 'starting' || connectionState.phase === 'handshake') && (
-                <div className="space-y-2">
+          {!compact && (
+            <span className="text-sm font-medium text-foreground truncate max-w-[120px]">
+              {isNoneSelected
+                ? t("agent.noneAgent")
+                : hasAvailableAgents && currentAgent
+                  ? currentAgent.displayName
+                  : "AI Agent"}
+            </span>
+          )}
+          <ChevronDown
+            className={cn(
+              "w-4 h-4 text-muted-foreground transition-transform",
+              isOpen && "rotate-180",
+            )}
+          />
+        </button>
+
+        {isOpen &&
+          dropdownPos &&
+          createPortal(
+            <div
+              ref={panelRef}
+              role="listbox"
+              aria-label={t("agent.selectAgent")}
+              className="fixed z-modal w-96 max-h-[calc(100vh-8rem)] rounded-lg bg-card border border-border shadow-lg overflow-hidden flex flex-col"
+              style={{ top: dropdownPos.top, right: dropdownPos.right }}
+              onKeyDown={(e) => {
+                if (e.key !== "ArrowDown" && e.key !== "ArrowUp") return;
+                e.preventDefault();
+                const items = e.currentTarget.querySelectorAll<HTMLElement>(
+                  '[role="option"]:not([aria-disabled="true"])',
+                );
+                const idx = Array.from(items).indexOf(
+                  document.activeElement as HTMLElement,
+                );
+                if (e.key === "ArrowDown")
+                  items[Math.min(idx + 1, items.length - 1)]?.focus();
+                else items[Math.max(idx - 1, 0)]?.focus();
+              }}
+            >
+              {/* AI Agent toggle — ON by default, OFF disables AI processing */}
+              <div className="px-3 py-3 border-b border-border flex-shrink-0">
+                <div className="flex items-center justify-between">
                   <div className="flex items-center gap-2">
-                    <Loader2 className="w-4 h-4 animate-spin text-yellow-400 flex-shrink-0" />
-                    <span className="text-sm font-medium text-foreground">
-                      {connectionState.phase === 'starting'
-                        ? t('agent.providerStarting', { provider: connectionState.provider })
-                        : t('agent.providerHandshake', { provider: connectionState.provider })}
-                    </span>
-                  </div>
-                  {connectionState.prerequisite && (
-                    <p className="text-xs text-muted-foreground ml-6">
-                      {connectionState.prerequisite}
-                    </p>
-                  )}
-                  {connectionState.error && (
-                    <p className="text-xs text-yellow-400 ml-6">{connectionState.error}</p>
-                  )}
-                </div>
-              )}
-              {connectionState.phase === 'connected' && (
-                <div className="flex items-center gap-2">
-                  <Check className="w-4 h-4 text-green-400 flex-shrink-0" />
-                  <span className="text-sm font-medium text-green-400">
-                    {t('agent.providerConnected', { provider: connectionState.provider })}
-                  </span>
-                </div>
-              )}
-              {connectionState.phase === 'failed' && (
-                <div className="space-y-2">
-                  <div className="flex items-center gap-2">
-                    <AlertTriangle className="w-4 h-4 text-red-400 flex-shrink-0" />
-                    <span className="text-sm font-medium text-red-400">
-                      {t('agent.providerFailed', { provider: connectionState.provider })}
-                    </span>
-                  </div>
-                  {connectionState.error && (
-                    <p className="text-xs text-muted-foreground ml-6">{connectionState.error}</p>
-                  )}
-                  {/* Backend handshake prerequisites (from /provider/check) */}
-                  {connectionState.prerequisites.length > 0 && (
-                    <ul className="ml-6 space-y-1">
-                      {connectionState.prerequisites.map((prereq, i) => (
-                        <li key={i} className="flex items-start gap-1.5 text-xs text-muted-foreground">
-                          <span className="text-muted-foreground/60 mt-0.5">-</span>
-                          <span>{prereq}</span>
-                        </li>
-                      ))}
-                    </ul>
-                  )}
-                  {/* Static prerequisite from PROVIDER_PREREQUISITES config */}
-                  {connectionState.prerequisites.length === 0 && connectionState.provider && PROVIDER_PREREQUISITES[AGENT_TO_PROVIDER_KEY[connectionState.provider] ?? ''] && (
-                    <div className="ml-6 space-y-1">
+                    <Sparkles
+                      className={cn(
+                        "w-4 h-4",
+                        isNoneSelected
+                          ? "text-muted-foreground"
+                          : "text-primary",
+                      )}
+                    />
+                    <div>
+                      <span className="text-sm font-medium text-foreground">
+                        {t("agent.aiAgentToggle")}
+                      </span>
                       <p className="text-xs text-muted-foreground">
-                        {t('agent.providerPrerequisite')}:
+                        {isNoneSelected
+                          ? t("agent.noneAgentDesc")
+                          : t("agent.aiAgentOnDesc")}
                       </p>
-                      <a
-                        href={PROVIDER_PREREQUISITES[AGENT_TO_PROVIDER_KEY[connectionState.provider] ?? '']?.installUrl}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        className="inline-flex items-center gap-1 text-xs text-primary hover:text-primary/80"
-                      >
-                        <ExternalLink className="w-3 h-3" />
-                        {PROVIDER_PREREQUISITES[AGENT_TO_PROVIDER_KEY[connectionState.provider] ?? '']?.label}
-                      </a>
                     </div>
-                  )}
-                  <div className="flex items-center gap-2 ml-6">
-                    <button
-                      onClick={() => retry(() => closeDropdown())}
-                      className="flex items-center gap-1 text-xs text-primary hover:text-primary/80"
-                    >
-                      <RefreshCw className="w-3 h-3" />
-                      {t('agent.providerRetry')}
-                    </button>
-                    <span className="text-xs text-muted-foreground/40">|</span>
-                    <button
-                      onClick={dismissConnection}
-                      className="text-xs text-muted-foreground hover:text-foreground"
-                    >
-                      {t('actions.dismiss')}
-                    </button>
                   </div>
-                </div>
-              )}
-            </div>
-          )}
-          {sortedAgents.length === 0 && (
-            <div className="py-4 text-center">
-              {agentsLoading ? (
-                <div className="flex items-center justify-center gap-2 text-sm text-muted-foreground">
-                  <Loader2 className="w-4 h-4 animate-spin" />
-                  <span>{t('agent.connectingToAgent')}</span>
-                </div>
-              ) : (
-                <div className="space-y-2">
-                  <p className="text-sm text-muted-foreground">{t('agent.noAgentsAvailable')}</p>
                   <button
-                    onClick={() => connectToAgent()}
-                    className="text-xs text-primary hover:underline"
+                    role="switch"
+                    aria-checked={!isNoneSelected}
+                    onClick={() => {
+                      if (isNoneSelected) {
+                        // Turn AI on — require approval on first use
+                        const prev = previousAgentRef.current;
+                        const restored = prev
+                          ? sortedAgents.find(
+                              (a) => a.name === prev && a.available,
+                            )
+                          : undefined;
+                        const targetAgent =
+                          restored?.name ||
+                          sortedAgents.find((a) => a.available)?.name ||
+                          "";
+
+                        // Guard: don't select an empty agent ID (#5673)
+                        if (!targetAgent) return;
+
+                        if (!hasApprovedAgents()) {
+                          // Show approval dialog before enabling
+                          pendingAgentRef.current = targetAgent;
+                          setShowApproval(true);
+                          return;
+                        }
+                        handleSelect(targetAgent);
+                      } else {
+                        // Save current agent before turning AI off
+                        previousAgentRef.current = selectedAgent || null;
+                        if (selectedAgent)
+                          safeSetItem(PREV_AGENT_KEY, selectedAgent);
+                        handleSelect("none");
+                      }
+                    }}
+                    className={cn(
+                      "relative inline-flex h-6 w-11 items-center rounded-full transition-colors flex-shrink-0",
+                      !isNoneSelected ? "bg-primary" : "bg-secondary",
+                    )}
                   >
-                    Retry connection
+                    <span
+                      className={cn(
+                        "inline-block h-4 w-4 transform rounded-full bg-white dark:bg-gray-200 transition-transform",
+                        !isNoneSelected ? "translate-x-6" : "translate-x-1",
+                      )}
+                    />
                   </button>
                 </div>
+              </div>
+              {sortedAgents.length > 0 && (
+                <div className="py-1 overflow-y-auto min-h-0">
+                  {/* Selected agent at the very top */}
+                  {selectedAgentInfo && renderAgentRow(selectedAgentInfo)}
+
+                  {/* CLI Agents section */}
+                  {cliAgents.length > 0 && (
+                    <>
+                      <div className="px-3 pt-2 pb-1">
+                        <span className="text-[10px] font-semibold uppercase tracking-wider text-muted-foreground/60">
+                          CLI Agents
+                        </span>
+                      </div>
+                      {cliAgents.map(renderAgentRow)}
+                    </>
+                  )}
+
+                  {/* Cluster Agents section */}
+                  {clusterAgents.length > 0 && (
+                    <>
+                      <div className="px-3 pt-2 pb-1 border-t border-border/50 mt-1">
+                        <span className="text-[10px] font-semibold uppercase tracking-wider text-muted-foreground/60">
+                          Cluster Agents
+                        </span>
+                      </div>
+                      {clusterAgents.map(renderAgentRow)}
+                    </>
+                  )}
+                </div>
               )}
-            </div>
+              {/* Provider connection lifecycle feedback */}
+              {connectionState.phase !== "idle" && (
+                <div className="px-3 py-3 border-t border-border bg-secondary/20">
+                  {(connectionState.phase === "starting" ||
+                    connectionState.phase === "handshake") && (
+                    <div className="space-y-2">
+                      <div className="flex items-center gap-2">
+                        <Loader2 className="w-4 h-4 animate-spin text-yellow-400 flex-shrink-0" />
+                        <span className="text-sm font-medium text-foreground">
+                          {connectionState.phase === "starting"
+                            ? t("agent.providerStarting", {
+                                provider: connectionState.provider,
+                              })
+                            : t("agent.providerHandshake", {
+                                provider: connectionState.provider,
+                              })}
+                        </span>
+                      </div>
+                      {connectionState.prerequisite && (
+                        <p className="text-xs text-muted-foreground ml-6">
+                          {connectionState.prerequisite}
+                        </p>
+                      )}
+                      {connectionState.error && (
+                        <p className="text-xs text-yellow-400 ml-6">
+                          {connectionState.error}
+                        </p>
+                      )}
+                    </div>
+                  )}
+                  {connectionState.phase === "connected" && (
+                    <div className="flex items-center gap-2">
+                      <Check className="w-4 h-4 text-green-400 flex-shrink-0" />
+                      <span className="text-sm font-medium text-green-400">
+                        {t("agent.providerConnected", {
+                          provider: connectionState.provider,
+                        })}
+                      </span>
+                    </div>
+                  )}
+                  {connectionState.phase === "failed" && (
+                    <div className="space-y-2">
+                      <div className="flex items-center gap-2">
+                        <AlertTriangle className="w-4 h-4 text-red-400 flex-shrink-0" />
+                        <span className="text-sm font-medium text-red-400">
+                          {t("agent.providerFailed", {
+                            provider: connectionState.provider,
+                          })}
+                        </span>
+                      </div>
+                      {connectionState.error && (
+                        <p className="text-xs text-muted-foreground ml-6">
+                          {connectionState.error}
+                        </p>
+                      )}
+                      {/* Backend handshake prerequisites (from /provider/check) */}
+                      {connectionState.prerequisites.length > 0 && (
+                        <ul className="ml-6 space-y-1">
+                          {connectionState.prerequisites.map((prereq, i) => (
+                            <li
+                              key={i}
+                              className="flex items-start gap-1.5 text-xs text-muted-foreground"
+                            >
+                              <span className="text-muted-foreground/60 mt-0.5">
+                                -
+                              </span>
+                              <span>{prereq}</span>
+                            </li>
+                          ))}
+                        </ul>
+                      )}
+                      {/* Static prerequisite from PROVIDER_PREREQUISITES config */}
+                      {connectionState.prerequisites.length === 0 &&
+                        connectionState.provider &&
+                        PROVIDER_PREREQUISITES[
+                          AGENT_TO_PROVIDER_KEY[connectionState.provider] ?? ""
+                        ] && (
+                          <div className="ml-6 space-y-1">
+                            <p className="text-xs text-muted-foreground">
+                              {t("agent.providerPrerequisite")}:
+                            </p>
+                            <a
+                              href={
+                                PROVIDER_PREREQUISITES[
+                                  AGENT_TO_PROVIDER_KEY[
+                                    connectionState.provider
+                                  ] ?? ""
+                                ]?.installUrl
+                              }
+                              target="_blank"
+                              rel="noopener noreferrer"
+                              className="inline-flex items-center gap-1 text-xs text-primary hover:text-primary/80"
+                            >
+                              <ExternalLink className="w-3 h-3" />
+                              {
+                                PROVIDER_PREREQUISITES[
+                                  AGENT_TO_PROVIDER_KEY[
+                                    connectionState.provider
+                                  ] ?? ""
+                                ]?.label
+                              }
+                            </a>
+                          </div>
+                        )}
+                      <div className="flex items-center gap-2 ml-6">
+                        <button
+                          onClick={() => retry(() => closeDropdown())}
+                          className="flex items-center gap-1 text-xs text-primary hover:text-primary/80"
+                        >
+                          <RefreshCw className="w-3 h-3" />
+                          {t("agent.providerRetry")}
+                        </button>
+                        <span className="text-xs text-muted-foreground/40">
+                          |
+                        </span>
+                        <button
+                          onClick={dismissConnection}
+                          className="text-xs text-muted-foreground hover:text-foreground"
+                        >
+                          {t("actions.dismiss")}
+                        </button>
+                      </div>
+                    </div>
+                  )}
+                </div>
+              )}
+              {sortedAgents.length === 0 && (
+                <div className="py-4 text-center">
+                  {agentsLoading ? (
+                    <div className="flex items-center justify-center gap-2 text-sm text-muted-foreground">
+                      <Loader2 className="w-4 h-4 animate-spin" />
+                      <span>{t("agent.connectingToAgent")}</span>
+                    </div>
+                  ) : (
+                    <div className="space-y-2">
+                      <p className="text-sm text-muted-foreground">
+                        {t("agent.noAgentsAvailable")}
+                      </p>
+                      <button
+                        onClick={() => connectToAgent()}
+                        className="text-xs text-primary hover:underline"
+                      >
+                        Retry connection
+                      </button>
+                    </div>
+                  )}
+                </div>
+              )}
+            </div>,
+            document.body,
           )}
-        </div>,
-        document.body
-      )}
-    </div>
-    <AgentApprovalDialog
-      isOpen={showApproval}
-      agents={agents}
-      onApprove={() => {
-        setShowApproval(false)
-        const target = pendingAgentRef.current
-        pendingAgentRef.current = null
-        if (target) {
-          // Run the same readiness lifecycle as handleSelect (#5677)
-          const providerKey = AGENT_TO_PROVIDER_KEY[target]
-          if (providerKey && PROVIDER_PREREQUISITES[providerKey]) {
-            selectAgent(target)
-            startConnection(target, () => closeDropdown())
-          } else {
-            selectAgent(target)
-            closeDropdown()
+      </div>
+      <AgentApprovalDialog
+        isOpen={showApproval}
+        agents={agents}
+        onApprove={() => {
+          setShowApproval(false);
+          const target = pendingAgentRef.current;
+          pendingAgentRef.current = null;
+          if (target) {
+            // Run the same readiness lifecycle as handleSelect (#5677)
+            const providerKey = AGENT_TO_PROVIDER_KEY[target];
+            if (providerKey && PROVIDER_PREREQUISITES[providerKey]) {
+              selectAgent(target);
+              startConnection(target, () => closeDropdown());
+            } else {
+              selectAgent(target);
+              closeDropdown();
+            }
           }
-        }
-      }}
-      onCancel={() => {
-        setShowApproval(false)
-        pendingAgentRef.current = null
-      }}
-    />
-    {/* Install guide modal */}
-    {(installGuide || installGuideLoading || installGuideError) && createPortal(
-      <div
-        className="fixed inset-0 z-modal flex items-center justify-center bg-black/60 backdrop-blur-sm"
-        onClick={(e) => { if (e.target === e.currentTarget) { setInstallGuide(null); setInstallGuideLoading(false); setInstallGuideError(false) } }}
-        onKeyDown={(e) => { if (e.key === 'Escape') { setInstallGuide(null); setInstallGuideLoading(false); setInstallGuideError(false) } }}
-        tabIndex={-1}
-        ref={(el) => el?.focus()}
-      >
-        <div className="relative bg-card border border-border rounded-xl shadow-2xl overflow-hidden flex flex-col w-[900px] max-h-[85vh]">
-          <button
-            onClick={() => { setInstallGuide(null); setInstallGuideLoading(false); setInstallGuideError(false) }}
-            className="absolute top-3 right-3 z-10 p-1.5 rounded-lg hover:bg-secondary text-muted-foreground hover:text-foreground transition-colors"
-          >
-            <X className="w-4 h-4" />
-          </button>
-          <div className="flex-1 overflow-y-auto scroll-enhanced p-6">
-            {installGuideLoading ? (
-              <div className="flex items-center justify-center py-12">
-                <Loader2 className="w-6 h-6 animate-spin text-muted-foreground" />
-              </div>
-            ) : installGuideError ? (
-              <div role="alert" className="flex flex-col items-center justify-center py-12 gap-3 text-center">
-                <p className="text-sm text-red-400">{t('agent.installGuideLoadError', 'Failed to load install guide')}</p>
-                <p className="text-xs text-muted-foreground">{t('agent.installGuideLoadErrorHint', 'Check your connection or try again later')}</p>
-              </div>
-            ) : installGuide ? (
-              <MissionDetailView
-                mission={installGuide.mission}
-                rawContent={installGuide.raw}
-                showRaw={installGuideShowRaw}
-                onToggleRaw={() => setInstallGuideShowRaw(prev => !prev)}
-                onImport={() => {
-                  const missionId = installGuide.mission.title.toLowerCase().includes('kagenti') ? 'install-kagenti' : 'install-kagent'
-                  handleInstallMission(missionId, installGuide.mission.title)
-                  setInstallGuide(null)
-                }}
-                onBack={() => setInstallGuide(null)}
-                importLabel="Run"
-                hideBackButton
-              />
-            ) : null}
-          </div>
-        </div>
-      </div>,
-      document.body
-    )}
-    {/* Cluster selection for AI install */}
-    {pendingInstall && (
-      <ClusterSelectionDialog
-        open
-        missionTitle={`Install ${pendingInstall.displayName}`}
-        onSelect={(clusters) => {
-          const m = pendingInstall.mission
-          const stepsText = (m.steps ?? []).map((s, i) => `${i + 1}. ${s.title}${s.description ? ': ' + s.description : ''}`).join('\n') || m.description
-          startMission({
-            title: `Install ${pendingInstall.displayName}`,
-            description: m.description,
-            type: 'deploy',
-            cluster: clusters.length > 0 ? clusters.join(',') : undefined,
-            initialPrompt: stepsText })
-          openSidebar()
-          setPendingInstall(null)
         }}
-        onCancel={() => setPendingInstall(null)}
+        onCancel={() => {
+          setShowApproval(false);
+          pendingAgentRef.current = null;
+        }}
       />
-    )}
+      {/* Install guide modal */}
+      {(installGuide || installGuideLoading || installGuideError) &&
+        createPortal(
+          <div
+            className="fixed inset-0 z-modal flex items-center justify-center bg-black/60 backdrop-blur-sm"
+            onClick={(e) => {
+              if (e.target === e.currentTarget) {
+                setInstallGuide(null);
+                setInstallGuideLoading(false);
+                setInstallGuideError(false);
+              }
+            }}
+            onKeyDown={(e) => {
+              if (e.key === "Escape") {
+                setInstallGuide(null);
+                setInstallGuideLoading(false);
+                setInstallGuideError(false);
+              }
+            }}
+            tabIndex={-1}
+            ref={(el) => el?.focus()}
+          >
+            <div className="relative bg-card border border-border rounded-xl shadow-2xl overflow-hidden flex flex-col w-[900px] max-h-[85vh]">
+              <button
+                onClick={() => {
+                  setInstallGuide(null);
+                  setInstallGuideLoading(false);
+                  setInstallGuideError(false);
+                }}
+                className="absolute top-3 right-3 z-10 p-1.5 rounded-lg hover:bg-secondary text-muted-foreground hover:text-foreground transition-colors"
+              >
+                <X className="w-4 h-4" />
+              </button>
+              <div className="flex-1 overflow-y-auto scroll-enhanced p-6">
+                {installGuideLoading ? (
+                  <div className="flex items-center justify-center py-12">
+                    <Loader2 className="w-6 h-6 animate-spin text-muted-foreground" />
+                  </div>
+                ) : installGuideError ? (
+                  <div
+                    role="alert"
+                    className="flex flex-col items-center justify-center py-12 gap-3 text-center"
+                  >
+                    <p className="text-sm text-red-400">
+                      {t(
+                        "agent.installGuideLoadError",
+                        "Failed to load install guide",
+                      )}
+                    </p>
+                    <p className="text-xs text-muted-foreground">
+                      {t(
+                        "agent.installGuideLoadErrorHint",
+                        "Check your connection or try again later",
+                      )}
+                    </p>
+                  </div>
+                ) : installGuide ? (
+                  <MissionDetailView
+                    mission={installGuide.mission}
+                    rawContent={installGuide.raw}
+                    showRaw={installGuideShowRaw}
+                    onToggleRaw={() => setInstallGuideShowRaw((prev) => !prev)}
+                    onImport={() => {
+                      const missionId = installGuide.mission.title
+                        .toLowerCase()
+                        .includes("kagenti")
+                        ? "install-kagenti"
+                        : "install-kagent";
+                      handleInstallMission(
+                        missionId,
+                        installGuide.mission.title,
+                      );
+                      setInstallGuide(null);
+                    }}
+                    onBack={() => setInstallGuide(null)}
+                    importLabel="Run"
+                    hideBackButton
+                  />
+                ) : null}
+              </div>
+            </div>
+          </div>,
+          document.body,
+        )}
+      {/* Cluster selection for AI install */}
+      {pendingInstall && (
+        <ClusterSelectionDialog
+          open
+          missionTitle={`Install ${pendingInstall.displayName}`}
+          onSelect={(clusters) => {
+            const m = pendingInstall.mission;
+            const stepsText =
+              (m.steps ?? [])
+                .map(
+                  (s, i) =>
+                    `${i + 1}. ${s.title}${s.description ? ": " + s.description : ""}`,
+                )
+                .join("\n") || m.description;
+            startMission({
+              title: `Install ${pendingInstall.displayName}`,
+              description: m.description,
+              type: "deploy",
+              cluster: clusters.length > 0 ? clusters.join(",") : undefined,
+              initialPrompt: stepsText,
+            });
+            openSidebar();
+            setPendingInstall(null);
+          }}
+          onCancel={() => setPendingInstall(null)}
+        />
+      )}
     </>
-  )
+  );
 }

--- a/web/src/components/agent/__tests__/agentSelectorUtils.kagenti.test.ts
+++ b/web/src/components/agent/__tests__/agentSelectorUtils.kagenti.test.ts
@@ -1,0 +1,175 @@
+import { describe, it, expect } from 'vitest'
+import { buildVisibleAgents, sectionAgents, CLUSTER_PROVIDER_KEYS } from '../agentSelectorUtils'
+import type { AgentInfo } from '../../../types/agent'
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeAgent(name: string, provider: AgentInfo['provider'], available = true): AgentInfo {
+  return { name, displayName: name, description: '', provider, available }
+}
+
+const CLUSTER_PROVIDERS = new Set(CLUSTER_PROVIDER_KEYS)
+
+const GEMINI_AGENT = { name: 'gemini-kagenti-agent' }
+const MOCK_AGENT = { name: 'mock-kagenti-agent' }
+
+// ---------------------------------------------------------------------------
+// buildVisibleAgents — kagenti mode
+// ---------------------------------------------------------------------------
+
+describe('buildVisibleAgents — kagenti mode', () => {
+  it('adds kagenti to visible agents when available', () => {
+    const result = buildVisibleAgents([], [], {
+      kagentAvailable: false,
+      kagentiAvailable: true,
+      selectedKagentAgent: null,
+      selectedKagentiAgent: GEMINI_AGENT,
+    })
+    const kagenti = result.find(a => a.provider === 'kagenti')
+    expect(kagenti).toBeDefined()
+    expect(kagenti?.available).toBe(true)
+  })
+
+  it('shows kagenti display name with selected agent name when an agent is selected', () => {
+    const result = buildVisibleAgents([], [], {
+      kagentAvailable: false,
+      kagentiAvailable: true,
+      selectedKagentAgent: null,
+      selectedKagentiAgent: GEMINI_AGENT,
+    })
+    const kagenti = result.find(a => a.provider === 'kagenti')
+    expect(kagenti?.displayName).toContain('gemini-kagenti-agent')
+  })
+
+  it('does not add kagenti when already in the agents list from the backend', () => {
+    const agents: AgentInfo[] = [makeAgent('kagenti', 'kagenti')]
+    const result = buildVisibleAgents(agents, [], {
+      kagentAvailable: false,
+      kagentiAvailable: true,
+      selectedKagentAgent: null,
+      selectedKagentiAgent: GEMINI_AGENT,
+    })
+    // Should not duplicate
+    expect(result.filter(a => a.provider === 'kagenti')).toHaveLength(1)
+  })
+
+  it('marks kagenti as unavailable and includes installMissionId when not available', () => {
+    const result = buildVisibleAgents([], [], {
+      kagentAvailable: false,
+      kagentiAvailable: false,
+      selectedKagentAgent: null,
+      selectedKagentiAgent: null,
+    })
+    const kagenti = result.find(a => a.provider === 'kagenti')
+    expect(kagenti?.available).toBe(false)
+    expect(kagenti?.installMissionId).toBe('install-kagenti')
+  })
+
+  it('includes no installMissionId for kagenti when available', () => {
+    const result = buildVisibleAgents([], [], {
+      kagentAvailable: false,
+      kagentiAvailable: true,
+      selectedKagentAgent: null,
+      selectedKagentiAgent: MOCK_AGENT,
+    })
+    const kagenti = result.find(a => a.provider === 'kagenti')
+    expect(kagenti?.installMissionId).toBeUndefined()
+  })
+
+  it('shows plain "Kagenti" displayName when no agent is selected', () => {
+    const result = buildVisibleAgents([], [], {
+      kagentAvailable: false,
+      kagentiAvailable: true,
+      selectedKagentAgent: null,
+      selectedKagentiAgent: null,
+    })
+    const kagenti = result.find(a => a.provider === 'kagenti')
+    expect(kagenti?.displayName).toBe('Kagenti')
+  })
+
+  it('includes both kagent and kagenti when both are available', () => {
+    const result = buildVisibleAgents([], [], {
+      kagentAvailable: true,
+      kagentiAvailable: true,
+      selectedKagentAgent: { name: 'my-kagent', namespace: 'ns' },
+      selectedKagentiAgent: GEMINI_AGENT,
+    })
+    expect(result.some(a => a.provider === 'kagenti')).toBe(true)
+    expect(result.some(a => a.provider === 'kagent')).toBe(true)
+  })
+
+  it('merges CLI agents with kagenti without duplication', () => {
+    const cli: AgentInfo[] = [makeAgent('goose', 'block', false)]
+    const result = buildVisibleAgents([], cli, {
+      kagentAvailable: false,
+      kagentiAvailable: true,
+      selectedKagentAgent: null,
+      selectedKagentiAgent: GEMINI_AGENT,
+    })
+    expect(result.some(a => a.name === 'goose')).toBe(true)
+    expect(result.some(a => a.provider === 'kagenti')).toBe(true)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// sectionAgents — kagenti mode
+// ---------------------------------------------------------------------------
+
+describe('sectionAgents — kagenti mode', () => {
+  it('puts kagenti in the clusterAgents section', () => {
+    const agents: AgentInfo[] = [
+      makeAgent('claude-code', 'anthropic'),
+      makeAgent('kagenti', 'kagenti'),
+    ]
+    // Pass null as selectedAgent so clusterAgents retains kagenti (not pinned to top)
+    const { cliAgents, clusterAgents } = sectionAgents(agents, null, CLUSTER_PROVIDERS)
+    expect(clusterAgents.some(a => a.provider === 'kagenti')).toBe(true)
+    expect(cliAgents.some(a => a.provider === 'kagenti')).toBe(false)
+  })
+
+  it('pins the selected kagenti agent at the top as selectedAgentInfo', () => {
+    const agents: AgentInfo[] = [
+      makeAgent('claude-code', 'anthropic'),
+      makeAgent('kagenti', 'kagenti'),
+    ]
+    const { selectedAgentInfo } = sectionAgents(agents, 'kagenti', CLUSTER_PROVIDERS)
+    expect(selectedAgentInfo?.provider).toBe('kagenti')
+  })
+
+  it('sorts kagenti before kagent in clusterAgents section', () => {
+    const agents: AgentInfo[] = [
+      makeAgent('kagent', 'kagent'),
+      makeAgent('kagenti', 'kagenti'),
+    ]
+    const { clusterAgents } = sectionAgents(agents, null, CLUSTER_PROVIDERS)
+    const providers = clusterAgents.map(a => a.provider)
+    expect(providers.indexOf('kagenti')).toBeLessThan(providers.indexOf('kagent'))
+  })
+
+  it('returns empty cliAgents when only cluster agents are present', () => {
+    const agents: AgentInfo[] = [
+      makeAgent('kagenti', 'kagenti'),
+      makeAgent('kagent', 'kagent'),
+    ]
+    const { cliAgents } = sectionAgents(agents, null, CLUSTER_PROVIDERS)
+    expect(cliAgents).toHaveLength(0)
+  })
+
+  it('handles null selectedAgent without error', () => {
+    const agents: AgentInfo[] = [makeAgent('kagenti', 'kagenti')]
+    const { selectedAgentInfo, clusterAgents } = sectionAgents(agents, null, CLUSTER_PROVIDERS)
+    expect(selectedAgentInfo).toBeNull()
+    expect(clusterAgents).toHaveLength(1)
+  })
+
+  it('sorts available kagenti before unavailable kagenti in cluster section', () => {
+    const agents: AgentInfo[] = [
+      makeAgent('kagent', 'kagent', false),
+      makeAgent('kagenti', 'kagenti', true),
+    ]
+    const { clusterAgents } = sectionAgents(agents, null, CLUSTER_PROVIDERS)
+    expect(clusterAgents[0].available).toBe(true)
+  })
+})

--- a/web/src/components/layout/Layout.tsx
+++ b/web/src/components/layout/Layout.tsx
@@ -1,15 +1,35 @@
 import { ReactNode, Suspense, lazy, useState, useEffect, useRef } from 'react'
 import { useTranslation } from 'react-i18next'
 import { Link, useLocation } from 'react-router-dom'
-import { Box, Wifi, WifiOff, X, Settings, Rocket, RotateCcw, Check, Loader2, RefreshCw, Plug } from 'lucide-react'
+import {
+  Box,
+  Wifi,
+  WifiOff,
+  X,
+  Settings,
+  Rocket,
+  RotateCcw,
+  Check,
+  Loader2,
+  RefreshCw,
+  Plug,
+} from 'lucide-react'
 import { Button } from '../ui/Button'
 import { Navbar } from './navbar/index'
 import { Sidebar } from './Sidebar'
-import { useSidebarConfig, SIDEBAR_COLLAPSED_WIDTH_PX, SIDEBAR_DEFAULT_WIDTH_PX } from '../../hooks/useSidebarConfig'
+import {
+  useSidebarConfig,
+  SIDEBAR_COLLAPSED_WIDTH_PX,
+  SIDEBAR_DEFAULT_WIDTH_PX,
+} from '../../hooks/useSidebarConfig'
 import { useMobile } from '../../hooks/useMobile'
 import { useNavigationHistory } from '../../hooks/useNavigationHistory'
 import { useLastRoute } from '../../hooks/useLastRoute'
-import { useDemoMode, isDemoModeForced, hasRealToken } from '../../hooks/useDemoMode'
+import {
+  useDemoMode,
+  isDemoModeForced,
+  hasRealToken,
+} from '../../hooks/useDemoMode'
 import { setDemoMode } from '../../lib/demoMode'
 import { hasApprovedAgents } from '../agent/AgentApprovalDialog'
 import { useLocalAgent } from '../../hooks/useLocalAgent'
@@ -17,6 +37,7 @@ import { useClusters } from '../../hooks/mcp/clusters'
 import { emitClusterInventory } from '../../lib/analytics'
 import { useNetworkStatus } from '../../hooks/useNetworkStatus'
 import { useBackendHealth } from '../../hooks/useBackendHealth'
+import { useKagentBackend } from '../../hooks/useKagentBackend'
 import { useDeepLink } from '../../hooks/useDeepLink'
 import { cn } from '../../lib/cn'
 import { LOCAL_AGENT_HTTP_URL, FETCH_DEFAULT_TIMEOUT_MS } from '../../lib/constants'
@@ -37,12 +58,13 @@ import { copyToClipboard } from '../../lib/clipboard'
 // Lazy-load the AI mission sidebar so react-markdown and remark plugins are
 // not part of the initial bundle — they only load when the sidebar is first rendered.
 const MissionSidebar = lazy(() =>
-  import('./mission-sidebar').then(m => ({ default: m.MissionSidebar }))
+  import('./mission-sidebar').then((m) => ({ default: m.MissionSidebar })),
 )
 const MissionSidebarToggle = lazy(() =>
-  import('./mission-sidebar').then(m => ({ default: m.MissionSidebarToggle }))
+  import('./mission-sidebar').then((m) => ({
+    default: m.MissionSidebarToggle,
+  })),
 )
-
 
 // Module-level constant — computed once, never changes on re-render.
 // Prevents star field from flickering when Layout re-renders due to hooks.
@@ -51,7 +73,8 @@ const STAR_POSITIONS = Array.from({ length: 30 }, () => ({
   height: Math.random() * 2 + 1 + 'px',
   left: Math.random() * 100 + '%',
   top: Math.random() * 100 + '%',
-  animationDelay: Math.random() * 3 + 's' }))
+  animationDelay: Math.random() * 3 + 's',
+}))
 
 // Thin progress bar shown during route transitions so the user
 // gets immediate visual feedback that navigation is happening.
@@ -80,7 +103,9 @@ export function ContentLoadingSkeleton() {
     <div className="flex items-center justify-center h-64">
       <div className="flex flex-col items-center gap-3">
         <div className="h-6 w-6 border-2 border-muted border-t-foreground rounded-full animate-spin" />
-        <span className="text-sm text-muted-foreground">{t('labels.loading')}</span>
+        <span className="text-sm text-muted-foreground">
+          {t('labels.loading')}
+        </span>
       </div>
     </div>
   )
@@ -94,19 +119,30 @@ export function Layout({ children: _children }: LayoutProps) {
   const { t } = useTranslation()
   const { config } = useSidebarConfig()
   const { isMobile } = useMobile()
-  const sidebarWidthPx = isMobile ? 0 : (config.collapsed ? SIDEBAR_COLLAPSED_WIDTH_PX : (config.width ?? SIDEBAR_DEFAULT_WIDTH_PX))
+  const sidebarWidthPx = isMobile
+    ? 0
+    : config.collapsed
+      ? SIDEBAR_COLLAPSED_WIDTH_PX
+      : (config.width ?? SIDEBAR_DEFAULT_WIDTH_PX)
   // Mission sidebar width is communicated via CSS custom property --mission-sidebar-width
   // set by MissionSidebar.tsx — no need to read sidebar state from the hook here.
   const { isDemoMode, toggleDemoMode } = useDemoMode()
   const { status: agentStatus } = useLocalAgent()
   const { deduplicatedClusters } = useClusters()
-  const { progress: updateProgress, dismiss: dismissUpdateProgress } = useUpdateProgress()
+  const { progress: updateProgress, dismiss: dismissUpdateProgress } =
+    useUpdateProgress()
   const { isOnline, wasOffline } = useNetworkStatus()
-  const { status: backendStatus, versionChanged, isInClusterMode } = useBackendHealth()
+  const {
+    status: backendStatus,
+    versionChanged,
+    isInClusterMode,
+  } = useBackendHealth()
+  const { kagentAvailable, kagentiAvailable } = useKagentBackend()
   const [offlineBannerDismissed, setOfflineBannerDismissed] = useState(false)
   const [demoBannerDismissed, setDemoBannerDismissed] = useState(false)
   const [showSetupDialog, setShowSetupDialog] = useState(false)
-  const [showInClusterAgentDialog, setShowInClusterAgentDialog] = useState(false)
+  const [showInClusterAgentDialog, setShowInClusterAgentDialog] =
+    useState(false)
   const [wasBackendDown, setWasBackendDown] = useState(false)
 
   // Allow any component to open the install dialog via a custom event
@@ -116,7 +152,9 @@ export function Layout({ children: _children }: LayoutProps) {
     return () => window.removeEventListener('open-install', handler)
   }, [])
 
-  const [restartState, setRestartState] = useState<'idle' | 'restarting' | 'waiting' | 'copied'>('idle')
+  const [restartState, setRestartState] = useState<
+    'idle' | 'restarting' | 'waiting' | 'copied'
+  >('idle')
   const [restartError, setRestartError] = useState<string | null>(null)
 
   const handleCopyFallback = async () => {
@@ -135,7 +173,8 @@ export function Layout({ children: _children }: LayoutProps) {
       const resp = await fetch(`${LOCAL_AGENT_HTTP_URL}/restart-backend`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        signal: AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS) })
+        signal: AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS),
+      })
       if (resp.ok) {
         const data = await resp.json()
         if (data.success) {
@@ -160,7 +199,7 @@ export function Layout({ children: _children }: LayoutProps) {
       const key = localStorage.key(i)
       if (key && key.startsWith('kc_meta:')) keysToRemove.push(key)
     }
-    keysToRemove.forEach(k => localStorage.removeItem(k))
+    keysToRemove.forEach((k) => localStorage.removeItem(k))
   }, [])
 
   // Auto-enable demo mode when agent is confirmed disconnected and not in cluster mode.
@@ -183,7 +222,12 @@ export function Layout({ children: _children }: LayoutProps) {
   }, [isDemoMode, agentStatus])
 
   useEffect(() => {
-    if (agentStatus === 'disconnected' && !isInClusterMode && !isDemoMode && !isDemoModeForced) {
+    if (
+      agentStatus === 'disconnected' &&
+      !isInClusterMode &&
+      !isDemoMode &&
+      !isDemoModeForced
+    ) {
       if (userToggledOffRef.current) {
         // User manually toggled off — give agent time to connect before re-enabling
         demoReEnableTimerRef.current = setTimeout(() => {
@@ -196,17 +240,27 @@ export function Layout({ children: _children }: LayoutProps) {
         demoAutoEnabledRef.current = true
         setDemoMode(true)
       }
-    } else if (agentStatus === 'connected' && isDemoMode && demoAutoEnabledRef.current && hasApprovedAgents()) {
+    } else if (
+      agentStatus === 'connected' &&
+      isDemoMode &&
+      demoAutoEnabledRef.current &&
+      hasApprovedAgents()
+    ) {
       // Only auto-switch from demo → agent if user has previously approved agents
       demoAutoEnabledRef.current = false
       userToggledOffRef.current = false
-      if (demoReEnableTimerRef.current) clearTimeout(demoReEnableTimerRef.current)
+      if (demoReEnableTimerRef.current)
+        clearTimeout(demoReEnableTimerRef.current)
       setDemoMode(false, true)
     } else {
       // Agent connected or demo manually re-enabled — cancel pending timer
-      if (demoReEnableTimerRef.current) clearTimeout(demoReEnableTimerRef.current)
+      if (demoReEnableTimerRef.current)
+        clearTimeout(demoReEnableTimerRef.current)
     }
-    return () => { if (demoReEnableTimerRef.current) clearTimeout(demoReEnableTimerRef.current) }
+    return () => {
+      if (demoReEnableTimerRef.current)
+        clearTimeout(demoReEnableTimerRef.current)
+    }
   }, [agentStatus, isInClusterMode, isDemoMode])
 
   // Emit cluster inventory when cluster count changes (counts only, never names).
@@ -234,20 +288,36 @@ export function Layout({ children: _children }: LayoutProps) {
       distributions[dist] = (distributions[dist] || 0) + 1
     }
 
-    emitClusterInventory({ total, healthy, unhealthy, unreachable, distributions })
+    emitClusterInventory({
+      total,
+      healthy,
+      unhealthy,
+      unreachable,
+      distributions,
+    })
   }, [deduplicatedClusters])
 
   // Startup snackbar — shows while backend health is in initial 'connecting' state
-  const showStartupSnackbar = !isDemoModeForced && backendStatus === 'connecting'
+  const showStartupSnackbar =
+    !isDemoModeForced && backendStatus === 'connecting'
 
   // Show network banner when browser detects no network, or briefly after reconnecting
   const showNetworkBanner = !isOnline || wasOffline
   // Show offline banner only when agent is confirmed disconnected (not during 'connecting' state)
   // This prevents flickering during initial connection attempts
-  const showOfflineBanner = !isDemoMode && agentStatus === 'disconnected' && backendStatus !== 'connected' && !offlineBannerDismissed
+  const showOfflineBanner =
+    !isDemoMode &&
+    agentStatus === 'disconnected' &&
+    backendStatus !== 'connected' &&
+    !offlineBannerDismissed
   // Show in-cluster agent banner when running in a cluster (Helm) and no agent connection detected.
   // This is distinct from the offline banner (which requires backend to be down too).
-  const showInClusterBanner = isInClusterMode && agentStatus === 'disconnected' && !isDemoMode
+  const hasInClusterAIBackend = kagentAvailable || kagentiAvailable
+  const showInClusterBanner =
+    isInClusterMode &&
+    agentStatus === 'disconnected' &&
+    !isDemoMode &&
+    !hasInClusterAIBackend
 
   // Banner stacking: each banner's top offset depends on how many banners above it are visible.
   // Dev bar (20px) → Navbar (64px) → Banners (36px each).
@@ -265,8 +335,11 @@ export function Layout({ children: _children }: LayoutProps) {
   // Show bottom snackbar when backend is down, or briefly after reconnecting.
   // Suppress during active updates — the backend is expected to be down while restarting.
   const backendDown = backendStatus === 'disconnected'
-  const isUpdateInProgress = updateProgress != null && !['idle', 'done', 'failed'].includes(updateProgress.status)
-  const showBackendBanner = (backendDown || wasBackendDown) && !isUpdateInProgress
+  const isUpdateInProgress =
+    updateProgress != null &&
+    !['idle', 'done', 'failed'].includes(updateProgress.status)
+  const showBackendBanner =
+    (backendDown || wasBackendDown) && !isUpdateInProgress
   const prevBackendDown = useRef(backendDown)
   useEffect(() => {
     const wasDown = prevBackendDown.current
@@ -291,68 +364,78 @@ export function Layout({ children: _children }: LayoutProps) {
 
   return (
     <VersionCheckProvider>
-    <TourProvider>
-    <div className="h-screen bg-background overflow-hidden flex flex-col">
-      {/* Dev mode indicator removed — now shown as a badge in the Navbar */}
+      <TourProvider>
+        <div className="h-screen bg-background overflow-hidden flex flex-col">
+          {/* Dev mode indicator removed — now shown as a badge in the Navbar */}
 
-      {/* Skip to content link for keyboard users and screen readers */}
-      <a
-        href="#main-content"
-        className="sr-only focus:not-sr-only focus:absolute focus:z-50 focus:top-4 focus:left-4 focus:px-4 focus:py-2 focus:bg-purple-500 focus:text-white focus:rounded-lg"
-      >
-        {t('actions.skipToContent')}
-      </a>
+          {/* Skip to content link for keyboard users and screen readers */}
+          <a
+            href="#main-content"
+            className="sr-only focus:not-sr-only focus:absolute focus:z-50 focus:top-4 focus:left-4 focus:px-4 focus:py-2 focus:bg-purple-500 focus:text-white focus:rounded-lg"
+          >
+            {t('actions.skipToContent')}
+          </a>
 
-      {/* Tour overlay and prompt */}
-      <TourOverlay />
-      <TourPrompt />
+          {/* Tour overlay and prompt */}
+          <TourOverlay />
+          <TourPrompt />
 
-      {/* Star field background — positions are stable (module-level constant) */}
-      <div className="star-field">
-        {STAR_POSITIONS.map((style, i) => (
-          <div key={i} className="star" style={style} />
-        ))}
-      </div>
-
-      <Navbar />
-
-      {/* Auto-Update Progress Banner */}
-      <UpdateProgressBanner progress={updateProgress} onDismiss={dismissUpdateProgress} />
-
-      {/* Network Disconnected Banner */}
-      {showNetworkBanner && (
-        <div
-          style={{ top: networkBannerTop, left: sidebarWidthPx }}
-          className={cn(
-            "fixed right-0 z-40 border-b transition-[left] duration-300",
-            isOnline
-              ? "bg-green-500/10 border-green-500/20"
-              : "bg-red-500/10 border-red-500/20",
-          )}>
-          <div className="flex items-center justify-center gap-3 py-1.5 px-4">
-            {isOnline ? (
-              <>
-                <Wifi className="w-4 h-4 text-green-400" aria-hidden="true" />
-                <span className="text-sm text-green-400 font-medium">
-                  {t('layout.networkReconnected')}
-                </span>
-              </>
-            ) : (
-              <>
-                <WifiOff className="w-4 h-4 text-red-400" aria-hidden="true" />
-                <span className="text-sm text-red-400 font-medium">
-                  {t('layout.networkDisconnected')}
-                </span>
-                <span className="text-xs text-red-400/70">
-                  {t('layout.checkInternetConnection')}
-                </span>
-              </>
-            )}
+          {/* Star field background — positions are stable (module-level constant) */}
+          <div className="star-field">
+            {STAR_POSITIONS.map((style, i) => (
+              <div key={i} className="star" style={style} />
+            ))}
           </div>
-        </div>
-      )}
 
-      {/* Demo Mode Banner — context-aware messaging:
+          <Navbar />
+
+          {/* Auto-Update Progress Banner */}
+          <UpdateProgressBanner
+            progress={updateProgress}
+            onDismiss={dismissUpdateProgress}
+          />
+
+          {/* Network Disconnected Banner */}
+          {showNetworkBanner && (
+            <div
+              style={{ top: networkBannerTop, left: sidebarWidthPx }}
+              className={cn(
+                'fixed right-0 z-40 border-b transition-[left] duration-300',
+                isOnline
+                  ? 'bg-green-500/10 border-green-500/20'
+                  : 'bg-red-500/10 border-red-500/20',
+              )}
+            >
+              <div className="flex items-center justify-center gap-3 py-1.5 px-4">
+                {isOnline ? (
+                  <>
+                    <Wifi
+                      className="w-4 h-4 text-green-400"
+                      aria-hidden="true"
+                    />
+                    <span className="text-sm text-green-400 font-medium">
+                      {t('layout.networkReconnected')}
+                    </span>
+                  </>
+                ) : (
+                  <>
+                    <WifiOff
+                      className="w-4 h-4 text-red-400"
+                      aria-hidden="true"
+                    />
+                    <span className="text-sm text-red-400 font-medium">
+                      {t('layout.networkDisconnected')}
+                    </span>
+                    <span className="text-xs text-red-400/70">
+                      {t('layout.checkInternetConnection')}
+                    </span>
+                  </>
+                )}
+              </div>
+            </div>
+          )}
+
+          {/* Demo Mode Banner — context-aware messaging:
           - Authenticated (real JWT) but no agent: "Connect your agent"
           - No auth / Netlify preview: "Install locally" */}
       {showDemoBanner && (() => {
@@ -410,85 +493,112 @@ export function Layout({ children: _children }: LayoutProps) {
         )
       })()}
 
-      {/* In-Cluster Agent Banner — shown when running in a Kubernetes cluster (Helm) with no agent connection */}
-      {showInClusterBanner && (
-        <div
-          style={{ top: inClusterBannerTop, left: sidebarWidthPx }}
-          className={cn(
-            "fixed right-0 z-20 bg-background border-b border-blue-500/20 transition-[left] duration-300",
-          )}>
-          <div className="flex flex-wrap items-center justify-center gap-2 md:gap-3 py-1.5 px-3 md:px-4">
-            <Plug className="w-4 h-4 text-blue-400" aria-hidden="true" />
-            <span className="text-sm text-blue-400 font-medium">
-              {t('layout.agentNotDetected')}
-            </span>
-            <span className="hidden md:inline text-xs text-blue-400/70">
-              {t('layout.installAgentOrCORS')}
-            </span>
-            <Button
-              variant="accent"
-              size="sm"
-              onClick={() => setShowInClusterAgentDialog(true)}
-              className="hidden sm:flex ml-2 rounded-full"
+          {/* In-Cluster Agent Banner — shown when running in a Kubernetes cluster (Helm) with no agent connection */}
+          {showInClusterBanner && (
+            <div
+              style={{ top: inClusterBannerTop, left: sidebarWidthPx }}
+              className={cn(
+                'fixed right-0 z-20 bg-background border-b border-blue-500/20 transition-[left] duration-300',
+              )}
             >
-              <Plug className="w-3.5 h-3.5" aria-hidden="true" />
-              <span className="hidden lg:inline">{t('layout.setupGuide')}</span>
-              <span className="lg:hidden">{t('layout.setup')}</span>
-            </Button>
-            <button
-              onClick={() => setShowInClusterAgentDialog(true)}
-              className="sm:hidden ml-1 p-2 min-h-11 min-w-11 flex items-center justify-center hover:bg-blue-500/20 rounded-full transition-colors"
-              aria-label={t('layout.openAgentSetupGuide')}
-              title={t('layout.openAgentSetupGuide')}
+              <div className="flex flex-wrap items-center justify-center gap-2 md:gap-3 py-1.5 px-3 md:px-4">
+                <Plug className="w-4 h-4 text-blue-400" aria-hidden="true" />
+                <span className="text-sm text-blue-400 font-medium">
+                  {t('layout.agentNotDetected')}
+                </span>
+                <span className="hidden md:inline text-xs text-blue-400/70">
+                  {t('layout.installAgentOrCORS')}
+                </span>
+                <Button
+                  variant="accent"
+                  size="sm"
+                  onClick={() => setShowInClusterAgentDialog(true)}
+                  className="hidden sm:flex ml-2 rounded-full"
+                >
+                  <Plug className="w-3.5 h-3.5" aria-hidden="true" />
+                  <span className="hidden lg:inline">
+                    {t('layout.setupGuide')}
+                  </span>
+                  <span className="lg:hidden">{t('layout.setup')}</span>
+                </Button>
+                <button
+                  onClick={() => setShowInClusterAgentDialog(true)}
+                  className="sm:hidden ml-1 p-2 min-h-11 min-w-11 flex items-center justify-center hover:bg-blue-500/20 rounded-full transition-colors"
+                  aria-label={t('layout.openAgentSetupGuide')}
+                  title={t('layout.openAgentSetupGuide')}
+                >
+                  <Plug
+                    className="w-3.5 h-3.5 text-blue-400"
+                    aria-hidden="true"
+                  />
+                </button>
+              </div>
+            </div>
+          )}
+
+          {/* Offline Mode Banner - positioned in main content area only */}
+          {showOfflineBanner && (
+            <div
+              style={{
+                top: offlineBannerTop,
+                left: sidebarWidthPx,
+                right: 'var(--mission-sidebar-width, 0px)',
+              }}
+              className="fixed z-20 bg-background border-b border-orange-500/20 transition-[right] duration-300"
             >
-              <Plug className="w-3.5 h-3.5 text-blue-400" aria-hidden="true" />
-            </button>
-          </div>
-        </div>
-      )}
-
-      {/* Offline Mode Banner - positioned in main content area only */}
-      {showOfflineBanner && (
-        <div
-          style={{ top: offlineBannerTop, left: sidebarWidthPx, right: 'var(--mission-sidebar-width, 0px)' }}
-          className="fixed z-20 bg-background border-b border-orange-500/20 transition-[right] duration-300"
-        >
-          <div className="flex flex-wrap items-center justify-between gap-2 py-1.5 px-3 md:px-4">
-            <div className="flex items-center gap-2 min-w-0">
-              <WifiOff className="w-4 h-4 text-orange-400 shrink-0" />
-              <span className="text-sm text-orange-400 font-medium shrink-0">{t('common.offline')}</span>
-              <span className="hidden lg:inline text-xs text-orange-400/70 truncate">
-                — Install: <code className="bg-orange-500/20 px-1 rounded">brew install kubestellar/tap/kc-agent</code> → run <code className="bg-orange-500/20 px-1 rounded">kc-agent</code>
-              </span>
+              <div className="flex flex-wrap items-center justify-between gap-2 py-1.5 px-3 md:px-4">
+                <div className="flex items-center gap-2 min-w-0">
+                  <WifiOff className="w-4 h-4 text-orange-400 shrink-0" />
+                  <span className="text-sm text-orange-400 font-medium shrink-0">
+                    {t('common.offline')}
+                  </span>
+                  <span className="hidden lg:inline text-xs text-orange-400/70 truncate">
+                    — Install:{' '}
+                    <code className="bg-orange-500/20 px-1 rounded">
+                      brew install kubestellar/tap/kc-agent
+                    </code>{' '}
+                    → run{' '}
+                    <code className="bg-orange-500/20 px-1 rounded">
+                      kc-agent
+                    </code>
+                  </span>
+                </div>
+                <div className="flex items-center gap-2 shrink-0">
+                  <Link
+                    to="/settings"
+                    className="flex items-center gap-1 text-xs px-2 py-2 bg-orange-500/20 hover:bg-orange-500/30 text-orange-400 rounded transition-colors whitespace-nowrap"
+                  >
+                    <Settings className="w-3 h-3" />
+                    <span className="hidden sm:inline">
+                      {t('navigation.settings')}
+                    </span>
+                  </Link>
+                  <button
+                    onClick={toggleDemoMode}
+                    className="text-xs px-2 py-2 bg-orange-500/20 hover:bg-orange-500/30 text-orange-400 rounded transition-colors whitespace-nowrap"
+                  >
+                    <span className="hidden sm:inline">
+                      {t('layout.switchTo')}{' '}
+                    </span>
+                    {t('layout.demo')}
+                  </button>
+                  <button
+                    onClick={() => setOfflineBannerDismissed(true)}
+                    className="p-2 min-h-11 min-w-11 flex items-center justify-center hover:bg-orange-500/20 rounded-full transition-colors"
+                    title={t('actions.dismiss')}
+                  >
+                    <X className="w-3.5 h-3.5 text-orange-400" />
+                  </button>
+                </div>
+              </div>
             </div>
-            <div className="flex items-center gap-2 shrink-0">
-              <Link
-                to="/settings"
-                className="flex items-center gap-1 text-xs px-2 py-2 bg-orange-500/20 hover:bg-orange-500/30 text-orange-400 rounded transition-colors whitespace-nowrap"
-              >
-                <Settings className="w-3 h-3" />
-                <span className="hidden sm:inline">{t('navigation.settings')}</span>
-              </Link>
-              <button
-                onClick={toggleDemoMode}
-                className="text-xs px-2 py-2 bg-orange-500/20 hover:bg-orange-500/30 text-orange-400 rounded transition-colors whitespace-nowrap"
-              >
-                <span className="hidden sm:inline">{t('layout.switchTo')} </span>{t('layout.demo')}
-              </button>
-              <button
-                onClick={() => setOfflineBannerDismissed(true)}
-                className="p-2 min-h-11 min-w-11 flex items-center justify-center hover:bg-orange-500/20 rounded-full transition-colors"
-                title={t('actions.dismiss')}
-              >
-                <X className="w-3.5 h-3.5 text-orange-400" />
-              </button>
-            </div>
-          </div>
-        </div>
-      )}
+          )}
 
-      <div className="flex flex-1 overflow-hidden transition-[padding-top] duration-300" style={{ paddingTop: NAVBAR_HEIGHT_PX + totalBannerHeight }}>
-        {/* Wrap Sidebar in PageErrorBoundary so stale-chunk errors
+          <div
+            className="flex flex-1 overflow-hidden transition-[padding-top] duration-300"
+            style={{ paddingTop: NAVBAR_HEIGHT_PX + totalBannerHeight }}
+          >
+            {/* Wrap Sidebar in PageErrorBoundary so stale-chunk errors
             (e.g. "Can't find variable: handleSidebarMouseEnter" from cached
             old bundles) are caught at page level instead of propagating to
             AppErrorBoundary and crashing the entire application. */}
@@ -529,26 +639,26 @@ export function Layout({ children: _children }: LayoutProps) {
         </main>
       </div>
 
-      {/* AI Mission sidebar — lazy loaded to keep react-markdown out of initial bundle */}
-      <Suspense fallback={null}>
-        <MissionSidebar />
-        <MissionSidebarToggle />
-      </Suspense>
+          {/* AI Mission sidebar — lazy loaded to keep react-markdown out of initial bundle */}
+          <Suspense fallback={null}>
+            <MissionSidebar />
+            <MissionSidebarToggle />
+          </Suspense>
 
-      {/* Setup Instructions Dialog — also shown when user tries to exit forced demo mode */}
-      <SetupInstructionsDialog
-        isOpen={showSetupDialog}
-        onClose={() => setShowSetupDialog(false)}
-      />
+          {/* Setup Instructions Dialog — also shown when user tries to exit forced demo mode */}
+          <SetupInstructionsDialog
+            isOpen={showSetupDialog}
+            onClose={() => setShowSetupDialog(false)}
+          />
 
-      {/* In-Cluster Agent Dialog — install agent or configure CORS */}
-      <InClusterAgentDialog
-        isOpen={showInClusterAgentDialog}
-        onClose={() => setShowInClusterAgentDialog(false)}
-      />
+          {/* In-Cluster Agent Dialog — install agent or configure CORS */}
+          <InClusterAgentDialog
+            isOpen={showInClusterAgentDialog}
+            onClose={() => setShowInClusterAgentDialog(false)}
+          />
 
-      {/* Agent Setup Dialog — shown when agent not connected; also triggered by open-agent-setup event */}
-      <AgentSetupDialog />
+          {/* Agent Setup Dialog — shown when agent not connected; also triggered by open-agent-setup event */}
+          <AgentSetupDialog />
 
       {/* Backend connection lost snackbar — fixed bottom center */}
       {showBackendBanner && (
@@ -615,25 +725,25 @@ export function Layout({ children: _children }: LayoutProps) {
         </div>
       )}
 
-      {/* Version changed snackbar — persistent until user reloads */}
-      {versionChanged && !showStartupSnackbar && !showBackendBanner && (
-        <div className="fixed bottom-6 left-1/2 -translate-x-1/2 z-toast animate-in fade-in slide-in-from-bottom-2 duration-300">
-          <div className="flex items-center gap-3 px-4 py-3 rounded-lg border shadow-lg text-sm bg-blue-950/90 border-blue-800/50 text-blue-200">
-            <RefreshCw className="w-4 h-4 text-blue-400" />
-            <span>{t('layout.newVersionAvailable')}</span>
-            <Button
-              variant="primary"
-              size="sm"
-              onClick={() => window.location.reload()}
-              className="ml-1 rounded"
-            >
-              {t('layout.reload')}
-            </Button>
-          </div>
+          {/* Version changed snackbar — persistent until user reloads */}
+          {versionChanged && !showStartupSnackbar && !showBackendBanner && (
+            <div className="fixed bottom-6 left-1/2 -translate-x-1/2 z-toast animate-in fade-in slide-in-from-bottom-2 duration-300">
+              <div className="flex items-center gap-3 px-4 py-3 rounded-lg border shadow-lg text-sm bg-blue-950/90 border-blue-800/50 text-blue-200">
+                <RefreshCw className="w-4 h-4 text-blue-400" />
+                <span>{t('layout.newVersionAvailable')}</span>
+                <Button
+                  variant="primary"
+                  size="sm"
+                  onClick={() => window.location.reload()}
+                  className="ml-1 rounded"
+                >
+                  {t('layout.reload')}
+                </Button>
+              </div>
+            </div>
+          )}
         </div>
-      )}
-    </div>
-    </TourProvider>
+      </TourProvider>
     </VersionCheckProvider>
   )
 }

--- a/web/src/components/layout/navbar/AgentStatusIndicator.tsx
+++ b/web/src/components/layout/navbar/AgentStatusIndicator.tsx
@@ -3,19 +3,42 @@ import { Server, Box, Wifi, WifiOff, Loader2 } from 'lucide-react'
 import { useLocalAgent } from '../../../hooks/useLocalAgent'
 import { useMissions } from '../../../hooks/useMissions'
 import { useBackendHealth } from '../../../hooks/useBackendHealth'
-import { useDemoMode, isDemoModeForced, getDemoMode } from '../../../hooks/useDemoMode'
+import {
+  useDemoMode,
+  isDemoModeForced,
+  getDemoMode,
+} from '../../../hooks/useDemoMode'
 import { SetupInstructionsDialog } from '../../setup/SetupInstructionsDialog'
-import { AgentApprovalDialog, hasApprovedAgents } from '../../agent/AgentApprovalDialog'
+import {
+  AgentApprovalDialog,
+  hasApprovedAgents,
+} from '../../agent/AgentApprovalDialog'
 import { cn } from '../../../lib/cn'
 import { useTranslation } from 'react-i18next'
-import { TOAST_DISMISS_MS, LOCAL_AGENT_HTTP_URL, BACKEND_HEALTH_CHECK_TIMEOUT_MS } from '../../../lib/constants/network'
+import {
+  TOAST_DISMISS_MS,
+  LOCAL_AGENT_HTTP_URL,
+  BACKEND_HEALTH_CHECK_TIMEOUT_MS,
+} from '../../../lib/constants/network'
 import type { AgentInfo } from '../../../types/agent'
 
 export function AgentStatusIndicator() {
   const { t } = useTranslation(['common'])
-  const { status: agentStatus, health: agentHealth, connectionEvents, isConnected, isDegraded, dataErrorCount, lastDataError } = useLocalAgent()
+  const {
+    status: agentStatus,
+    health: agentHealth,
+    connectionEvents,
+    isConnected,
+    isDegraded,
+    dataErrorCount,
+    lastDataError,
+  } = useLocalAgent()
   const { selectedAgent, agents } = useMissions()
-  const { status: backendStatus, isConnected: isBackendConnected, isInClusterMode } = useBackendHealth()
+  const {
+    status: backendStatus,
+    isConnected: isBackendConnected,
+    isInClusterMode,
+  } = useBackendHealth()
   const { isDemoMode: isDemoModeHook, toggleDemoMode } = useDemoMode()
   // Synchronous fallback prevents flash of WifiOff icon during React transitions
   const isDemoMode = isDemoModeHook || getDemoMode()
@@ -32,14 +55,15 @@ export function AgentStatusIndicator() {
     setIsDiscoveringAgents(true)
     try {
       const res = await fetch(`${LOCAL_AGENT_HTTP_URL}/health`, {
-        signal: AbortSignal.timeout(BACKEND_HEALTH_CHECK_TIMEOUT_MS) })
+        signal: AbortSignal.timeout(BACKEND_HEALTH_CHECK_TIMEOUT_MS),
+      })
       if (!res.ok) return
       const data = await res.json()
       if (data.availableProviders) {
         // Map agent name to provider type for icon rendering
         const nameToProvider: Record<string, string> = {
           'claude-code': 'anthropic-local',
-          'codex': 'openai-cli',
+          codex: 'openai-cli',
           'copilot-cli': 'github',
           'gemini-cli': 'google-cli',
           'antigravity': 'google-ag',
@@ -87,10 +111,13 @@ export function AgentStatusIndicator() {
       if (connectingTimerRef.current) clearTimeout(connectingTimerRef.current)
       setStableStatus(agentStatus)
     }
-    return () => { if (connectingTimerRef.current) clearTimeout(connectingTimerRef.current) }
+    return () => {
+      if (connectingTimerRef.current) clearTimeout(connectingTimerRef.current)
+    }
   }, [agentStatus])
 
-  const stableConnected = stableStatus === 'connected' || stableStatus === 'degraded'
+  const stableConnected =
+    stableStatus === 'connected' || stableStatus === 'degraded'
   const stableDegraded = stableStatus === 'degraded'
 
   // --- Sticky demo styling (fixes demo toggle flash) ---
@@ -114,8 +141,13 @@ export function AgentStatusIndicator() {
   // Safety timeout: clear sticky flag after 3s even if agent never connects
   useEffect(() => {
     if (!isDemoMode && showDemoStyle) {
-      demoExitTimerRef.current = setTimeout(() => setShowDemoStyle(false), TOAST_DISMISS_MS)
-      return () => { if (demoExitTimerRef.current) clearTimeout(demoExitTimerRef.current) }
+      demoExitTimerRef.current = setTimeout(
+        () => setShowDemoStyle(false),
+        TOAST_DISMISS_MS,
+      )
+      return () => {
+        if (demoExitTimerRef.current) clearTimeout(demoExitTimerRef.current)
+      }
     }
   }, [isDemoMode, showDemoStyle])
 
@@ -127,7 +159,10 @@ export function AgentStatusIndicator() {
     const CLOSE_DISTANCE = 20
 
     const handleClickOutside = (event: MouseEvent) => {
-      if (agentRef.current && !agentRef.current.contains(event.target as Node)) {
+      if (
+        agentRef.current &&
+        !agentRef.current.contains(event.target as Node)
+      ) {
         setShowAgentStatus(false)
       }
     }
@@ -138,12 +173,23 @@ export function AgentStatusIndicator() {
       if (!trigger) return
 
       // Combined bounding box of trigger button + dropdown panel
-      const top = Math.min(trigger.top, dropdown?.top ?? trigger.top) - CLOSE_DISTANCE
-      const bottom = Math.max(trigger.bottom, dropdown?.bottom ?? trigger.bottom) + CLOSE_DISTANCE
-      const left = Math.min(trigger.left, dropdown?.left ?? trigger.left) - CLOSE_DISTANCE
-      const right = Math.max(trigger.right, dropdown?.right ?? trigger.right) + CLOSE_DISTANCE
+      const top =
+        Math.min(trigger.top, dropdown?.top ?? trigger.top) - CLOSE_DISTANCE
+      const bottom =
+        Math.max(trigger.bottom, dropdown?.bottom ?? trigger.bottom) +
+        CLOSE_DISTANCE
+      const left =
+        Math.min(trigger.left, dropdown?.left ?? trigger.left) - CLOSE_DISTANCE
+      const right =
+        Math.max(trigger.right, dropdown?.right ?? trigger.right) +
+        CLOSE_DISTANCE
 
-      if (event.clientX < left || event.clientX > right || event.clientY < top || event.clientY > bottom) {
+      if (
+        event.clientX < left ||
+        event.clientX > right ||
+        event.clientY < top ||
+        event.clientY > bottom
+      ) {
         setShowAgentStatus(false)
       }
     }
@@ -160,32 +206,98 @@ export function AgentStatusIndicator() {
   // Uses stabilized status values to prevent color flashes during navigation.
   // showDemoStyle is sticky: stays true after demo toggle until agent connects.
   const showAsDemoMode = isDemoMode || showDemoStyle
+  const isClusterBacked = isInClusterMode && !showAsDemoMode
 
   // Backend health affects the indicator when agent is connected (but not in demo mode)
-  const backendIssue = !showAsDemoMode && !isBackendConnected && backendStatus !== 'connecting'
+  const backendIssue =
+    !showAsDemoMode && !isBackendConnected && backendStatus !== 'connecting'
   const isLiveMode = selectedAgent === 'none'
+  const showInClusterConnectionLog =
+    isInClusterMode && !isConnected && !isDemoMode
+  const visibleConnectionEvents = showInClusterConnectionLog
+    ? [
+        {
+          timestamp: new Date(),
+          type: 'connected' as const,
+          message: t('agent.usingInClusterService'),
+        },
+      ]
+    : connectionEvents
 
   const pillStyle = showAsDemoMode
-    ? { bg: 'bg-purple-500/10 text-purple-400 hover:bg-purple-500/20', dot: 'bg-purple-400', label: t('agent.demoMode'), Icon: Box, title: t('agent.demoModeTitle') }
+    ? {
+        bg: 'bg-purple-500/10 text-purple-400 hover:bg-purple-500/20',
+        dot: 'bg-purple-400',
+        label: t('agent.demoMode'),
+        Icon: Box,
+        title: t('agent.demoModeTitle'),
+      }
     : stableDegraded
-    ? { bg: 'bg-yellow-500/10 text-yellow-400 hover:bg-yellow-500/20', dot: 'bg-yellow-400 animate-pulse', label: t('agent.degraded'), Icon: Wifi, title: t('agent.degradedTitle', { count: dataErrorCount }) }
-    : stableConnected && backendIssue
-    ? { bg: 'bg-yellow-500/10 text-yellow-400 hover:bg-yellow-500/20', dot: 'bg-yellow-400 animate-pulse', label: t('agent.aiLabel'), Icon: Wifi, title: t('agent.backendUnavailable') }
-    : stableConnected && isLiveMode
-    ? { bg: 'bg-cyan-500/10 text-cyan-400 hover:bg-cyan-500/20', dot: 'bg-cyan-400', label: t('agent.liveLabel'), Icon: Wifi, title: t('agent.liveMode') }
-    : stableConnected
-    ? { bg: 'bg-green-500/10 text-green-400 hover:bg-green-500/20', dot: 'bg-green-400', label: t('agent.aiLabel'), Icon: Wifi, title: t('agent.localAgentConnected') }
-    : stableStatus === 'connecting'
-    ? { bg: 'bg-yellow-500/10 text-yellow-400 hover:bg-yellow-500/20', dot: 'bg-yellow-400 animate-pulse', label: t('agent.aiLabel'), Icon: Wifi, title: t('agent.connecting') }
-    : isInClusterMode
-    ? { bg: 'bg-blue-500/10 text-blue-400 hover:bg-blue-500/20', dot: 'bg-blue-400', label: t('agent.cluster'), Icon: Server, title: t('agent.inClusterModeTitle') }
-    : { bg: 'bg-red-500/10 text-red-400 hover:bg-red-500/20', dot: 'bg-red-400', label: t('agent.offline'), Icon: WifiOff, title: t('agent.localAgentDisconnected') }
+      ? {
+          bg: 'bg-yellow-500/10 text-yellow-400 hover:bg-yellow-500/20',
+          dot: 'bg-yellow-400 animate-pulse',
+          label: t('agent.degraded'),
+          Icon: Wifi,
+          title: t('agent.degradedTitle', { count: dataErrorCount }),
+        }
+      : stableConnected && backendIssue
+        ? {
+            bg: 'bg-yellow-500/10 text-yellow-400 hover:bg-yellow-500/20',
+            dot: 'bg-yellow-400 animate-pulse',
+            label: t('agent.aiLabel'),
+            Icon: Wifi,
+            title: t('agent.backendUnavailable'),
+          }
+        : stableConnected && isLiveMode
+          ? {
+              bg: 'bg-cyan-500/10 text-cyan-400 hover:bg-cyan-500/20',
+              dot: 'bg-cyan-400',
+              label: t('agent.liveLabel'),
+              Icon: Wifi,
+              title: t('agent.liveMode'),
+            }
+          : stableConnected
+            ? {
+                bg: 'bg-green-500/10 text-green-400 hover:bg-green-500/20',
+                dot: 'bg-green-400',
+                label: t('agent.aiLabel'),
+                Icon: Wifi,
+                title: t('agent.localAgentConnected'),
+              }
+            : stableStatus === 'connecting'
+              ? {
+                  bg: 'bg-yellow-500/10 text-yellow-400 hover:bg-yellow-500/20',
+                  dot: 'bg-yellow-400 animate-pulse',
+                  label: t('agent.aiLabel'),
+                  Icon: Wifi,
+                  title: t('agent.connecting'),
+                }
+              : isInClusterMode
+                ? {
+                    bg: 'bg-blue-500/10 text-blue-400 hover:bg-blue-500/20',
+                    dot: 'bg-blue-400',
+                    label: t('agent.cluster'),
+                    Icon: Server,
+                    title: t('agent.inClusterModeTitle'),
+                  }
+                : {
+                    bg: 'bg-red-500/10 text-red-400 hover:bg-red-500/20',
+                    dot: 'bg-red-400',
+                    label: t('agent.offline'),
+                    Icon: WifiOff,
+                    title: t('agent.localAgentDisconnected'),
+                  }
 
   // Loading state: show spinner while initial agent status is resolving (#6772)
   if (stableStatus === 'connecting' && !showAsDemoMode && !isInClusterMode) {
     return (
       <div className="relative" ref={agentRef}>
-        <div className={cn('flex items-center justify-center gap-2 px-3 py-1.5 rounded-lg whitespace-nowrap', 'bg-yellow-500/10 text-yellow-400')}>
+        <div
+          className={cn(
+            'flex items-center justify-center gap-2 px-3 py-1.5 rounded-lg whitespace-nowrap',
+            'bg-yellow-500/10 text-yellow-400',
+          )}
+        >
           <Loader2 className="w-4 h-4 animate-spin" />
           <span className="text-xs font-medium hidden sm:inline whitespace-nowrap">
             {t('agent.connecting')}
@@ -199,25 +311,35 @@ export function AgentStatusIndicator() {
     <div className="relative" ref={agentRef}>
       <button
         onClick={() => setShowAgentStatus(!showAgentStatus)}
-        className={cn('flex items-center justify-center gap-2 px-3 py-1.5 h-9 rounded-lg whitespace-nowrap', pillStyle.bg)}
+        className={cn(
+          'flex items-center justify-center gap-2 px-3 py-1.5 h-9 rounded-lg whitespace-nowrap',
+          pillStyle.bg,
+        )}
         title={pillStyle.title}
       >
         <pillStyle.Icon className="w-4 h-4" />
         <span className="text-xs font-medium hidden sm:inline whitespace-nowrap">
           {pillStyle.label}
         </span>
-        <span className={cn('w-2 h-2 rounded-full flex-shrink-0', pillStyle.dot)} />
+        <span
+          className={cn('w-2 h-2 rounded-full flex-shrink-0', pillStyle.dot)}
+        />
       </button>
 
       {/* Agent status dropdown */}
       {showAgentStatus && (
-        <div ref={dropdownRef} className="absolute top-full right-0 mt-2 w-96 bg-card border border-border rounded-lg shadow-xl z-50">
+        <div
+          ref={dropdownRef}
+          className="absolute top-full right-0 mt-2 w-96 bg-card border border-border rounded-lg shadow-xl z-50"
+        >
           {/* Demo Mode Toggle */}
           <div className="p-3 border-b border-border">
             <div className="flex items-center justify-between">
               <div className="flex items-center gap-2">
                 <Box className="w-4 h-4 text-purple-400" />
-                <span className="text-sm font-medium text-foreground">{t('agent.demoMode')}</span>
+                <span className="text-sm font-medium text-foreground">
+                  {t('agent.demoMode')}
+                </span>
               </div>
               <button
                 disabled={isDiscoveringAgents}
@@ -239,7 +361,7 @@ export function AgentStatusIndicator() {
                 className={cn(
                   'relative w-11 h-6 rounded-full transition-colors',
                   isDemoMode ? 'bg-purple-500' : 'bg-secondary',
-                  isDiscoveringAgents && 'opacity-50 cursor-wait'
+                  isDiscoveringAgents && 'opacity-50 cursor-wait',
                 )}
               >
                 {isDiscoveringAgents ? (
@@ -248,7 +370,7 @@ export function AgentStatusIndicator() {
                   <span
                     className={cn(
                       'absolute top-1 left-1 w-4 h-4 bg-white rounded-full transition-transform shadow-sm',
-                      isDemoMode ? 'translate-x-5' : 'translate-x-0'
+                      isDemoMode ? 'translate-x-5' : 'translate-x-0',
                     )}
                   />
                 )}
@@ -257,58 +379,92 @@ export function AgentStatusIndicator() {
             <p className="text-xs text-muted-foreground mt-1.5">
               {isDemoMode
                 ? t('agent.demoModeShowingSample')
-                : t('agent.enableToViewDemo')
-              }
+                : t('agent.enableToViewDemo')}
             </p>
           </div>
 
           {/* Agent Status */}
           <div className="p-3 border-b border-border">
             <div className="flex items-center gap-2">
-              <div className={cn(
-                'w-3 h-3 rounded-full',
-                isDemoMode ? 'bg-gray-400' : isDegraded ? 'bg-yellow-400' : isConnected ? 'bg-green-400' : agentStatus === 'connecting' ? 'bg-yellow-400' : isInClusterMode ? 'bg-blue-400' : 'bg-red-400'
-              )} />
-              <span className={cn('text-sm font-medium', isDemoMode ? 'text-muted-foreground' : 'text-foreground')}>
-                {isDemoMode ? t('agent.localAgentBypassed') : isDegraded ? t('agent.localAgentDegraded') : isConnected ? t('agent.localAgentConnectedLabel') : agentStatus === 'connecting' ? t('agent.localAgentConnecting') : isInClusterMode ? t('agent.clusterMode') : t('agent.localAgentDisconnectedLabel')}
+              <div
+                className={cn(
+                  'w-3 h-3 rounded-full',
+                  isDemoMode
+                    ? 'bg-gray-400'
+                    : isClusterBacked
+                      ? 'bg-blue-400'
+                      : isDegraded
+                        ? 'bg-yellow-400'
+                        : isConnected
+                          ? 'bg-green-400'
+                          : agentStatus === 'connecting'
+                            ? 'bg-yellow-400'
+                            : 'bg-red-400',
+                )}
+              />
+              <span
+                className={cn(
+                  'text-sm font-medium',
+                  isDemoMode ? 'text-muted-foreground' : 'text-foreground',
+                )}
+              >
+                {isDemoMode
+                  ? t('agent.localAgentBypassed')
+                  : isClusterBacked
+                    ? t('agent.clusterMode')
+                    : isDegraded
+                      ? t('agent.localAgentDegraded')
+                      : isConnected
+                        ? t('agent.localAgentConnectedLabel')
+                        : agentStatus === 'connecting'
+                          ? t('agent.localAgentConnecting')
+                          : t('agent.localAgentDisconnectedLabel')}
               </span>
-              {isConnected && agentHealth?.version && agentHealth.version !== 'demo' && (
-                <span className="text-xs text-muted-foreground bg-secondary/50 px-1.5 py-0.5 rounded">
-                  v{agentHealth.version}
-                </span>
-              )}
+              {isConnected &&
+                agentHealth?.version &&
+                agentHealth.version !== 'demo' && (
+                  <span className="text-xs text-muted-foreground bg-secondary/50 px-1.5 py-0.5 rounded">
+                    v{agentHealth.version}
+                  </span>
+                )}
             </div>
             {/* Show selected agent name and model when connected */}
-            {isConnected && selectedAgent && selectedAgent !== 'none' && (() => {
-              const activeAgent = agents.find(a => a.name === selectedAgent)
-              return activeAgent ? (
-                <div className="flex items-center gap-2 mt-1.5">
-                  <span className="text-xs text-foreground font-medium">{activeAgent.displayName}</span>
-                  {activeAgent.model ? (
-                    <span className="text-2xs text-muted-foreground bg-secondary/50 px-1.5 py-0.5 rounded">
-                      {activeAgent.model}
+            {isConnected &&
+              selectedAgent &&
+              selectedAgent !== 'none' &&
+              (() => {
+                const activeAgent = agents.find((a) => a.name === selectedAgent)
+                return activeAgent ? (
+                  <div className="flex items-center gap-2 mt-1.5">
+                    <span className="text-xs text-foreground font-medium">
+                      {activeAgent.displayName}
                     </span>
-                  ) : activeAgent.provider === 'github-cli' ? (
-                    <span className="text-2xs text-muted-foreground italic">Default model</span>
-                  ) : null}
-                </div>
-              ) : null
-            })()}
+                    {activeAgent.model ? (
+                      <span className="text-2xs text-muted-foreground bg-secondary/50 px-1.5 py-0.5 rounded">
+                        {activeAgent.model}
+                      </span>
+                    ) : activeAgent.provider === 'github-cli' ? (
+                      <span className="text-2xs text-muted-foreground italic">
+                        Default model
+                      </span>
+                    ) : null}
+                  </div>
+                ) : null
+              })()}
             <p className="text-xs text-muted-foreground mt-1">
               {isDemoMode
                 ? isDemoModeForced
-                  // Hosted demo (e.g. console.kubestellar.io): agent can never connect
-                  // from this origin, so point the user at the self-host path.
-                  ? t('agent.hostedDemoBypassed')
+                  ? // Hosted demo (e.g. console.kubestellar.io): agent can never connect
+                    // from this origin, so point the user at the self-host path.
+                    t('agent.hostedDemoBypassed')
                   : t('agent.agentBypassedInDemo')
-                : isDegraded
-                ? t('agent.connectedButErrors', { count: dataErrorCount })
-                : isConnected
-                ? t('agent.connectedToLocalAgent')
-                : isInClusterMode
-                ? t('agent.usingInClusterService')
-                : t('agent.unableToConnect')
-              }
+                : isClusterBacked
+                  ? t('agent.usingInClusterService')
+                  : isDegraded
+                    ? t('agent.connectedButErrors', { count: dataErrorCount })
+                    : isConnected
+                      ? t('agent.connectedToLocalAgent')
+                      : t('agent.unableToConnect')}
             </p>
             {/* When running on the hosted demo, surface a self-host link so
                 users who want real cluster data know where to go next. */}
@@ -335,43 +491,61 @@ export function AgentStatusIndicator() {
           {!isDemoMode && (
             <div className="p-3 border-b border-border">
               <div className="flex items-center gap-2">
-                <div className={cn(
-                  'w-3 h-3 rounded-full',
-                  isBackendConnected ? 'bg-green-400' : backendStatus === 'connecting' ? 'bg-yellow-400' : 'bg-red-400'
-                )} />
+                <div
+                  className={cn(
+                    'w-3 h-3 rounded-full',
+                    isBackendConnected
+                      ? 'bg-green-400'
+                      : backendStatus === 'connecting'
+                        ? 'bg-yellow-400'
+                        : 'bg-red-400',
+                  )}
+                />
                 <span className="text-sm font-medium text-foreground">
-                  {isBackendConnected ? t('agent.backendApiConnected') : backendStatus === 'connecting' ? t('agent.backendApiConnecting') : t('agent.backendApiDisconnected')}
+                  {isBackendConnected
+                    ? t('agent.backendApiConnected')
+                    : backendStatus === 'connecting'
+                      ? t('agent.backendApiConnecting')
+                      : t('agent.backendApiDisconnected')}
                 </span>
               </div>
               <p className="text-xs text-muted-foreground mt-1">
                 {isBackendConnected
                   ? t('agent.connectedToBackend')
                   : backendStatus === 'connecting'
-                  ? t('agent.checkingBackend')
-                  : t('agent.unableToConnectBackend')
-                }
+                    ? t('agent.checkingBackend')
+                    : t('agent.unableToConnectBackend')}
               </p>
             </div>
           )}
 
           <div className="p-2 max-h-48 overflow-y-auto">
-            <div className="text-xs text-muted-foreground px-2 py-1 font-medium">{t('agent.connectionLog')}</div>
-            {connectionEvents.length === 0 ? (
-              <div className="text-xs text-muted-foreground text-center py-4">{t('agent.noEventsYet')}</div>
+            <div className="text-xs text-muted-foreground px-2 py-1 font-medium">
+              {t('agent.connectionLog')}
+            </div>
+            {visibleConnectionEvents.length === 0 ? (
+              <div className="text-xs text-muted-foreground text-center py-4">
+                {t('agent.noEventsYet')}
+              </div>
             ) : (
               <div className="space-y-1">
-                {connectionEvents.slice(0, 20).map((event, i) => (
+                {visibleConnectionEvents.slice(0, 20).map((event, i) => (
                   <div
                     key={i}
                     className="flex items-start gap-2 px-2 py-1.5 rounded hover:bg-secondary/30"
                   >
-                    <div className={cn(
-                      'w-2 h-2 rounded-full mt-1 flex-shrink-0',
-                      event.type === 'connected' ? 'bg-green-400' :
-                      event.type === 'disconnected' ? 'bg-red-400' :
-                      event.type === 'error' ? 'bg-red-400' :
-                      'bg-yellow-400'
-                    )} />
+                    <div
+                      className={cn(
+                        'w-2 h-2 rounded-full mt-1 flex-shrink-0',
+                        event.type === 'connected'
+                          ? 'bg-green-400'
+                          : event.type === 'disconnected'
+                            ? 'bg-red-400'
+                            : event.type === 'error'
+                              ? 'bg-red-400'
+                              : 'bg-yellow-400',
+                      )}
+                    />
                     <div className="flex-1 min-w-0">
                       <p className="text-xs text-foreground">{event.message}</p>
                       <p className="text-2xs text-muted-foreground">
@@ -384,42 +558,55 @@ export function AgentStatusIndicator() {
             )}
           </div>
 
-          {/* Install instructions - always visible at bottom */}
-          <div className="p-3 border-t border-border bg-secondary/20">
-            <h4 className="text-xs font-medium text-foreground mb-2 flex items-center gap-2">
-              <Server className="w-3 h-3 text-purple-400" />
-              {t('agent.installLocalAgent')}
-            </h4>
-            <p className="text-xs text-muted-foreground mb-2">
-              {t('agent.localAgentDesc')}
-            </p>
-            <div className="bg-black/50 rounded p-2 font-mono text-[11px] text-green-400 mb-2 space-y-1">
-              <div className="text-muted-foreground">{t('agent.installViaHomebrewMacOS')}</div>
-              <code className="block">{t('agent.tapKubestellar')}</code>
-              <code className="block">{t('agent.installKcAgent')}</code>
+          {/* Install instructions are only relevant for local-agent mode */}
+          {!isClusterBacked && (
+            <div className="p-3 border-t border-border bg-secondary/20">
+              <h4 className="text-xs font-medium text-foreground mb-2 flex items-center gap-2">
+                <Server className="w-3 h-3 text-purple-400" />
+                {t('agent.installLocalAgent')}
+              </h4>
+              <p className="text-xs text-muted-foreground mb-2">
+                {t('agent.localAgentDesc')}
+              </p>
+              <div className="bg-black/50 rounded p-2 font-mono text-[11px] text-green-400 mb-2 space-y-1">
+                <div className="text-muted-foreground">
+                  {t('agent.installViaHomebrewMacOS')}
+                </div>
+                <code className="block">{t('agent.tapKubestellar')}</code>
+                <code className="block">{t('agent.installKcAgent')}</code>
+              </div>
+              <div className="bg-black/50 rounded p-2 font-mono text-[11px] text-green-400 mb-2 space-y-1">
+                <div className="text-muted-foreground">
+                  {t('agent.installLinuxBuildFromSource')}
+                </div>
+                <code className="block">
+                  git clone https://github.com/kubestellar/console.git
+                </code>
+                <code className="block">
+                  cd console &amp;&amp; go build -o bin/kc-agent ./cmd/kc-agent
+                </code>
+                <code className="block">./bin/kc-agent</code>
+              </div>
+              <p className="text-2xs text-muted-foreground">
+                {t('agent.visitGithub')}{' '}
+                <a
+                  href="https://github.com/kubestellar/homebrew-tap"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-purple-400 hover:text-purple-300 underline"
+                >
+                  github.com/kubestellar/homebrew-tap
+                </a>{' '}
+                {t('agent.forMoreInfo')}
+              </p>
             </div>
-            <div className="bg-black/50 rounded p-2 font-mono text-[11px] text-green-400 mb-2 space-y-1">
-              <div className="text-muted-foreground">{t('agent.installLinuxBuildFromSource')}</div>
-              <code className="block">git clone https://github.com/kubestellar/console.git</code>
-              <code className="block">cd console &amp;&amp; go build -o bin/kc-agent ./cmd/kc-agent</code>
-              <code className="block">./bin/kc-agent</code>
-            </div>
-            <p className="text-2xs text-muted-foreground">
-              {t('agent.visitGithub')}{' '}
-              <a
-                href="https://github.com/kubestellar/homebrew-tap"
-                target="_blank"
-                rel="noopener noreferrer"
-                className="text-purple-400 hover:text-purple-300 underline"
-              >
-                github.com/kubestellar/homebrew-tap
-              </a>
-              {' '}{t('agent.forMoreInfo')}
-            </p>
-          </div>
+          )}
         </div>
       )}
-      <SetupInstructionsDialog isOpen={showSetupDialog} onClose={() => setShowSetupDialog(false)} />
+      <SetupInstructionsDialog
+        isOpen={showSetupDialog}
+        onClose={() => setShowSetupDialog(false)}
+      />
       <AgentApprovalDialog
         isOpen={showApprovalDialog}
         agents={agents.length > 0 ? agents : discoveredAgents}

--- a/web/src/components/settings/Settings.tsx
+++ b/web/src/components/settings/Settings.tsx
@@ -2,20 +2,46 @@ import { useEffect, useState, useRef, useCallback } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useLocation, useNavigate } from 'react-router-dom'
 import {
-  Cpu, TrendingUp, Coins, User, Bell, Shield,
-  Palette, Eye, Plug, LayoutGrid, Download, Database, Container, HardDrive,
-  CheckCircle, Loader2, AlertCircle, WifiOff, BarChart3, X } from 'lucide-react'
+  Cpu,
+  TrendingUp,
+  Coins,
+  User,
+  Bell,
+  Shield,
+  Palette,
+  Eye,
+  Plug,
+  LayoutGrid,
+  Download,
+  Database,
+  Container,
+  HardDrive,
+  CheckCircle,
+  Loader2,
+  AlertCircle,
+  WifiOff,
+  BarChart3,
+  X,
+} from 'lucide-react'
 import { Github } from '@/lib/icons'
 import { useAuth } from '../../lib/auth'
 import { useTheme } from '../../hooks/useTheme'
 import { useTokenUsage } from '../../hooks/useTokenUsage'
 import { useAIMode } from '../../hooks/useAIMode'
 import { useLocalAgent } from '../../hooks/useLocalAgent'
+import { useBackendHealth } from '../../hooks/useBackendHealth'
 import { useAccessibility } from '../../hooks/useAccessibility'
 import { useVersionCheck } from '../../hooks/useVersionCheck'
 import { usePredictionSettings } from '../../hooks/usePredictionSettings'
-import { usePersistedSettings, type SyncStatus } from '../../hooks/usePersistedSettings'
-import { BANNER_DISMISS_MS, UI_FEEDBACK_TIMEOUT_MS, TOOLTIP_HIDE_DELAY_MS } from '../../lib/constants/network'
+import {
+  usePersistedSettings,
+  type SyncStatus,
+} from '../../hooks/usePersistedSettings'
+import {
+  BANNER_DISMISS_MS,
+  UI_FEEDBACK_TIMEOUT_MS,
+  TOOLTIP_HIDE_DELAY_MS,
+} from '../../lib/constants/network'
 import { ROUTES } from '../../config/routes'
 import { UpdateSettings } from './UpdateSettings'
 import {
@@ -33,16 +59,21 @@ import {
   PersistenceSection,
   LocalClustersSection,
   SettingsBackupSection,
-  AnalyticsSection } from './sections'
+  AnalyticsSection,
+} from './sections'
 import { cn } from '../../lib/cn'
 
 // Labels are filled at render time via t()
-const SYNC_ICONS: Record<SyncStatus, { icon: typeof CheckCircle; className: string }> = {
-  idle:    { icon: CheckCircle, className: 'text-muted-foreground' },
-  saving:  { icon: Loader2,     className: 'text-yellow-400' },
-  saved:   { icon: CheckCircle, className: 'text-green-400' },
-  error:   { icon: AlertCircle, className: 'text-red-400' },
-  offline: { icon: WifiOff,     className: 'text-muted-foreground' } }
+const SYNC_ICONS: Record<
+  SyncStatus,
+  { icon: typeof CheckCircle; className: string }
+> = {
+  idle: { icon: CheckCircle, className: 'text-muted-foreground' },
+  saving: { icon: Loader2, className: 'text-yellow-400' },
+  saved: { icon: CheckCircle, className: 'text-green-400' },
+  error: { icon: AlertCircle, className: 'text-red-400' },
+  offline: { icon: WifiOff, className: 'text-muted-foreground' },
+}
 
 // Define settings navigation structure with groups
 // Labels use i18n keys resolved at render time
@@ -50,39 +81,108 @@ const SETTINGS_NAV = [
   {
     groupKey: 'settings.groups.aiIntelligence' as const,
     items: [
-      { id: 'ai-mode-settings', labelKey: 'settings.nav.aiMode' as const, icon: Cpu },
-      { id: 'prediction-settings', labelKey: 'settings.nav.predictions' as const, icon: TrendingUp },
-      { id: 'agent-settings', labelKey: 'settings.nav.localAgent' as const, icon: Plug },
-      { id: 'token-usage-settings', labelKey: 'settings.nav.tokenUsage' as const, icon: Coins },
-    ] },
+      {
+        id: 'ai-mode-settings',
+        labelKey: 'settings.nav.aiMode' as const,
+        icon: Cpu,
+      },
+      {
+        id: 'prediction-settings',
+        labelKey: 'settings.nav.predictions' as const,
+        icon: TrendingUp,
+      },
+      {
+        id: 'agent-settings',
+        labelKey: 'settings.nav.localAgent' as const,
+        icon: Plug,
+      },
+      {
+        id: 'token-usage-settings',
+        labelKey: 'settings.nav.tokenUsage' as const,
+        icon: Coins,
+      },
+    ],
+  },
   {
     groupKey: 'settings.groups.integrations' as const,
     items: [
-      { id: 'github-token-settings', labelKey: 'settings.nav.github' as const, icon: Github },
-      { id: 'widget-settings', labelKey: 'settings.nav.desktopWidget' as const, icon: LayoutGrid },
-      { id: 'persistence-settings', labelKey: 'settings.nav.deployPersistence' as const, icon: Database },
-    ] },
+      {
+        id: 'github-token-settings',
+        labelKey: 'settings.nav.github' as const,
+        icon: Github,
+      },
+      {
+        id: 'widget-settings',
+        labelKey: 'settings.nav.desktopWidget' as const,
+        icon: LayoutGrid,
+      },
+      {
+        id: 'persistence-settings',
+        labelKey: 'settings.nav.deployPersistence' as const,
+        icon: Database,
+      },
+    ],
+  },
   {
     groupKey: 'settings.groups.userAlerts' as const,
     items: [
-      { id: 'profile-settings', labelKey: 'settings.nav.profile' as const, icon: User },
-      { id: 'notifications-settings', labelKey: 'settings.nav.notifications' as const, icon: Bell },
-    ] },
+      {
+        id: 'profile-settings',
+        labelKey: 'settings.nav.profile' as const,
+        icon: User,
+      },
+      {
+        id: 'notifications-settings',
+        labelKey: 'settings.nav.notifications' as const,
+        icon: Bell,
+      },
+    ],
+  },
   {
     groupKey: 'settings.groups.appearance' as const,
     items: [
-      { id: 'theme-settings', labelKey: 'settings.nav.theme' as const, icon: Palette },
-      { id: 'accessibility-settings', labelKey: 'settings.nav.accessibility' as const, icon: Eye },
-    ] },
+      {
+        id: 'theme-settings',
+        labelKey: 'settings.nav.theme' as const,
+        icon: Palette,
+      },
+      {
+        id: 'accessibility-settings',
+        labelKey: 'settings.nav.accessibility' as const,
+        icon: Eye,
+      },
+    ],
+  },
   {
     groupKey: 'settings.groups.utilities' as const,
     items: [
-      { id: 'settings-backup', labelKey: 'settings.nav.backupSync' as const, icon: HardDrive },
-      { id: 'local-clusters-settings', labelKey: 'settings.nav.localClusters' as const, icon: Container },
-      { id: 'permissions-settings', labelKey: 'settings.nav.permissions' as const, icon: Shield },
-      { id: 'analytics-settings', labelKey: 'settings.nav.analytics' as const, icon: BarChart3 },
-      { id: 'system-updates-settings', labelKey: 'settings.nav.updates' as const, icon: Download },
-    ] },
+      {
+        id: 'settings-backup',
+        labelKey: 'settings.nav.backupSync' as const,
+        icon: HardDrive,
+      },
+      {
+        id: 'local-clusters-settings',
+        labelKey: 'settings.nav.localClusters' as const,
+        icon: Container,
+      },
+      {
+        id: 'permissions-settings',
+        labelKey: 'settings.nav.permissions' as const,
+        icon: Shield,
+      },
+      {
+        id: 'analytics-settings',
+        labelKey: 'settings.nav.analytics' as const,
+        icon: BarChart3,
+      },
+      {
+        id: 'system-updates-settings',
+        labelKey: 'settings.nav.updates' as const,
+        icon: Download,
+      },
+    ],
+  },
 ]
 
 export function Settings() {
@@ -94,10 +194,29 @@ export function Settings() {
   const { usage, updateSettings, resetUsage, isDemoData } = useTokenUsage()
   const { mode, setMode, description } = useAIMode()
   const { health, isConnected, refresh } = useLocalAgent()
-  const { colorBlindMode, setColorBlindMode, reduceMotion, setReduceMotion, highContrast, setHighContrast } = useAccessibility()
+  const { isInClusterMode } = useBackendHealth()
+  const {
+    colorBlindMode,
+    setColorBlindMode,
+    reduceMotion,
+    setReduceMotion,
+    highContrast,
+    setHighContrast,
+  } = useAccessibility()
   const { forceCheck: forceVersionCheck } = useVersionCheck()
-  const { settings: predictionSettings, updateSettings: updatePredictionSettings, resetSettings: resetPredictionSettings } = usePredictionSettings()
-  const { restoredFromFile, syncStatus, lastSaved, filePath, exportSettings, importSettings } = usePersistedSettings()
+  const {
+    settings: predictionSettings,
+    updateSettings: updatePredictionSettings,
+    resetSettings: resetPredictionSettings,
+  } = usePredictionSettings()
+  const {
+    restoredFromFile,
+    syncStatus,
+    lastSaved,
+    filePath,
+    exportSettings,
+    importSettings,
+  } = usePersistedSettings()
 
   const [activeSection, setActiveSection] = useState<string>('ai-mode-settings')
   const [showRestoredToast, setShowRestoredToast] = useState(false)
@@ -130,7 +249,10 @@ export function Settings() {
   useEffect(() => {
     if (restoredFromFile) {
       setShowRestoredToast(true)
-      const timer = setTimeout(() => setShowRestoredToast(false), BANNER_DISMISS_MS)
+      const timer = setTimeout(
+        () => setShowRestoredToast(false),
+        BANNER_DISMISS_MS,
+      )
       return () => clearTimeout(timer)
     }
   }, [restoredFromFile])
@@ -147,7 +269,8 @@ export function Settings() {
     if (!element || !container) return
     const containerRect = container.getBoundingClientRect()
     const elementRect = element.getBoundingClientRect()
-    const y = elementRect.top - containerRect.top + container.scrollTop - SCROLL_OFFSET
+    const y =
+      elementRect.top - containerRect.top + container.scrollTop - SCROLL_OFFSET
     container.scrollTo({ top: y, behavior: smooth ? 'smooth' : 'auto' })
   }, [])
 
@@ -173,12 +296,17 @@ export function Settings() {
         // Suppress observer while deep-link scroll settles
         isNavScrollingRef.current = true
         if (navScrollTimerRef.current) clearTimeout(navScrollTimerRef.current)
-        navScrollTimerRef.current = setTimeout(() => { isNavScrollingRef.current = false }, NAV_SCROLL_SUPPRESS_MS)
+        navScrollTimerRef.current = setTimeout(() => {
+          isNavScrollingRef.current = false
+        }, NAV_SCROLL_SUPPRESS_MS)
 
         scrollToSection(hash, false)
         setActiveSection(hash)
         element.classList.add('ring-2', 'ring-purple-500/50')
-        setTimeout(() => element.classList.remove('ring-2', 'ring-purple-500/50'), UI_FEEDBACK_TIMEOUT_MS)
+        setTimeout(
+          () => element.classList.remove('ring-2', 'ring-purple-500/50'),
+          UI_FEEDBACK_TIMEOUT_MS,
+        )
       } else if (++attempts < maxAttempts) {
         requestAnimationFrame(tryScroll)
       }
@@ -199,7 +327,7 @@ export function Settings() {
     const container = getScrollContainer()
     if (!container) return
 
-    const allSectionIds = SETTINGS_NAV.flatMap(g => g.items.map(i => i.id))
+    const allSectionIds = SETTINGS_NAV.flatMap((g) => g.items.map((i) => i.id))
     const visibleSections = new Map<string, number>()
     let debounceTimer: ReturnType<typeof setTimeout> | null = null
 
@@ -257,7 +385,9 @@ export function Settings() {
     // Suppress IntersectionObserver while the smooth scroll animates
     isNavScrollingRef.current = true
     if (navScrollTimerRef.current) clearTimeout(navScrollTimerRef.current)
-    navScrollTimerRef.current = setTimeout(() => { isNavScrollingRef.current = false }, NAV_SCROLL_SUPPRESS_MS)
+    navScrollTimerRef.current = setTimeout(() => {
+      isNavScrollingRef.current = false
+    }, NAV_SCROLL_SUPPRESS_MS)
 
     scrollToSection(sectionId)
     setActiveSection(sectionId)
@@ -270,14 +400,23 @@ export function Settings() {
     // scrollToSection above. Instead, manually scroll only the sidebar's
     // own overflow container so #main-content is unaffected.
     requestAnimationFrame(() => {
-      const btn = document.querySelector<HTMLElement>(`[data-settings-nav="${sectionId}"]`)
+      const btn = document.querySelector<HTMLElement>(
+        `[data-settings-nav="${sectionId}"]`,
+      )
       if (!btn) return
       const sidebar = btn.closest<HTMLElement>('.overflow-y-auto')
       if (!sidebar || sidebar.id === 'main-content') return
       const btnRect = btn.getBoundingClientRect()
       const sidebarRect = sidebar.getBoundingClientRect()
-      if (btnRect.top < sidebarRect.top || btnRect.bottom > sidebarRect.bottom) {
-        const scrollDelta = btnRect.top - sidebarRect.top - sidebarRect.height / 2 + btnRect.height / 2
+      if (
+        btnRect.top < sidebarRect.top ||
+        btnRect.bottom > sidebarRect.bottom
+      ) {
+        const scrollDelta =
+          btnRect.top -
+          sidebarRect.top -
+          sidebarRect.height / 2 +
+          btnRect.height / 2
         sidebar.scrollBy({ top: scrollDelta, behavior: 'smooth' })
       }
     })
@@ -288,13 +427,17 @@ export function Settings() {
     saving: t('settings.syncStatus.saving'),
     saved: t('settings.syncStatus.savedToFile'),
     error: t('settings.syncStatus.saveFailed'),
-    offline: t('settings.syncStatus.localOnly') }
+    offline: t('settings.syncStatus.localOnly'),
+  }
   const sync = SYNC_ICONS[syncStatus]
   const SyncIcon = sync.icon
   const syncLabel = SYNC_LABELS[syncStatus]
 
   return (
-    <div data-testid="settings-page" className="pt-16 max-w-6xl mx-auto flex gap-6">
+    <div
+      data-testid="settings-page"
+      className="pt-16 max-w-6xl mx-auto flex gap-6"
+    >
       {/* Settings restored toast */}
       {showRestoredToast && (
         <div className="fixed top-20 right-4 z-toast bg-green-500/20 border border-green-500/30 text-green-400 px-4 py-2 rounded-lg text-sm shadow-lg backdrop-blur-sm animate-in slide-in-from-right">
@@ -306,7 +449,12 @@ export function Settings() {
         <div className="sticky top-20 max-h-[calc(100vh-6rem)] overflow-y-auto scroll-enhanced space-y-4">
           <div className="mb-4">
             <div className="flex items-center justify-between">
-              <h1 data-testid="settings-title" className="text-xl font-bold text-foreground">{t('settings.title')}</h1>
+              <h1
+                data-testid="settings-title"
+                className="text-xl font-bold text-foreground"
+              >
+                {t('settings.title')}
+              </h1>
               <button
                 data-testid="settings-close-desktop"
                 onClick={handleClose}
@@ -316,9 +464,21 @@ export function Settings() {
                 <X className="w-5 h-5" />
               </button>
             </div>
-            <p className="text-sm text-muted-foreground">{t('settings.subtitle')}</p>
-            <div className={cn('flex items-center gap-1.5 mt-2 text-xs', sync.className)}>
-              <SyncIcon className={cn('w-3.5 h-3.5', syncStatus === 'saving' && 'animate-spin')} />
+            <p className="text-sm text-muted-foreground">
+              {t('settings.subtitle')}
+            </p>
+            <div
+              className={cn(
+                'flex items-center gap-1.5 mt-2 text-xs',
+                sync.className,
+              )}
+            >
+              <SyncIcon
+                className={cn(
+                  'w-3.5 h-3.5',
+                  syncStatus === 'saving' && 'animate-spin',
+                )}
+              />
               <span>{syncLabel}</span>
             </div>
           </div>
@@ -340,10 +500,17 @@ export function Settings() {
                         'w-full flex items-center gap-2 px-2 py-1.5 rounded-md text-sm transition-colors text-left',
                         isActive
                           ? 'bg-purple-500/20 text-purple-400'
-                          : 'text-muted-foreground hover:text-foreground hover:bg-secondary/50'
+                          : 'text-muted-foreground hover:text-foreground hover:bg-secondary/50',
                       )}
                     >
-                      <Icon className={cn('w-4 h-4 shrink-0', isActive ? 'text-purple-400' : 'text-muted-foreground')} />
+                      <Icon
+                        className={cn(
+                          'w-4 h-4 shrink-0',
+                          isActive
+                            ? 'text-purple-400'
+                            : 'text-muted-foreground',
+                        )}
+                      />
                       <span className="truncate">{t(item.labelKey)}</span>
                     </button>
                   )
@@ -359,7 +526,12 @@ export function Settings() {
         {/* Mobile Header */}
         <div className="lg:hidden mb-6">
           <div className="flex items-center justify-between">
-            <h1 data-testid="settings-title-mobile" className="text-2xl font-bold text-foreground">{t('settings.title')}</h1>
+            <h1
+              data-testid="settings-title-mobile"
+              className="text-2xl font-bold text-foreground"
+            >
+              {t('settings.title')}
+            </h1>
             <button
               data-testid="settings-close-mobile"
               onClick={handleClose}
@@ -370,8 +542,18 @@ export function Settings() {
             </button>
           </div>
           <p className="text-muted-foreground">{t('settings.subtitle')}</p>
-          <div className={cn('flex items-center gap-1.5 mt-2 text-xs', sync.className)}>
-            <SyncIcon className={cn('w-3.5 h-3.5', syncStatus === 'saving' && 'animate-spin')} />
+          <div
+            className={cn(
+              'flex items-center gap-1.5 mt-2 text-xs',
+              sync.className,
+            )}
+          >
+            <SyncIcon
+              className={cn(
+                'w-3.5 h-3.5',
+                syncStatus === 'saving' && 'animate-spin',
+              )}
+            />
             <span>{syncLabel}</span>
           </div>
         </div>
@@ -382,14 +564,28 @@ export function Settings() {
             {t('settings.groups.aiIntelligence')}
           </h2>
           <div className="space-y-6">
-            <AISettingsSection mode={mode} setMode={setMode} description={description} />
+            <AISettingsSection
+              mode={mode}
+              setMode={setMode}
+              description={description}
+            />
             <PredictionSettingsSection
               settings={predictionSettings}
               updateSettings={updatePredictionSettings}
               resetSettings={resetPredictionSettings}
             />
-            <AgentSection isConnected={isConnected} health={health} refresh={refresh} />
-            <TokenUsageSection usage={usage} updateSettings={updateSettings} resetUsage={resetUsage} isDemoData={isDemoData} />
+            <AgentSection
+              isConnected={isConnected}
+              isInClusterMode={isInClusterMode}
+              health={health}
+              refresh={refresh}
+            />
+            <TokenUsageSection
+              usage={usage}
+              updateSettings={updateSettings}
+              resetUsage={resetUsage}
+              isDemoData={isDemoData}
+            />
           </div>
         </div>
 

--- a/web/src/components/settings/sections/AgentSection.tsx
+++ b/web/src/components/settings/sections/AgentSection.tsx
@@ -1,103 +1,154 @@
-import { useState, useEffect, useRef } from 'react'
-import { useTranslation } from 'react-i18next'
-import { Plug, RefreshCw, Check, X, Copy, Cpu } from 'lucide-react'
-import { Button } from '../../ui/Button'
-import type { AgentHealth } from '../../../hooks/useLocalAgent'
-import { UI_FEEDBACK_TIMEOUT_MS, RETRY_DELAY_MS } from '../../../lib/constants/network'
-import { copyToClipboard } from '../../../lib/clipboard'
+import { useState, useEffect, useRef } from "react";
+import { useTranslation } from "react-i18next";
+import { Plug, RefreshCw, Check, X, Copy, Cpu } from "lucide-react";
+import { Button } from "../../ui/Button";
+import type { AgentHealth } from "../../../hooks/useLocalAgent";
+import {
+  UI_FEEDBACK_TIMEOUT_MS,
+  RETRY_DELAY_MS,
+} from "../../../lib/constants/network";
+import { copyToClipboard } from "../../../lib/clipboard";
 
 interface AgentSectionProps {
-  isConnected: boolean
-  health: AgentHealth | null
-  refresh: () => void
+  isConnected: boolean;
+  isInClusterMode?: boolean;
+  health: AgentHealth | null;
+  refresh: () => void;
 }
 
-const INSTALL_COMMAND = 'curl -sSL https://raw.githubusercontent.com/kubestellar/console/main/start.sh | bash'
+const INSTALL_COMMAND =
+  "curl -sSL https://raw.githubusercontent.com/kubestellar/console/main/start.sh | bash";
 
-export function AgentSection({ isConnected, health, refresh }: AgentSectionProps) {
-  const { t } = useTranslation()
-  const [copied, setCopied] = useState(false)
-  const [isRefreshing, setIsRefreshing] = useState(false)
-  const timeoutRef = useRef<number>(undefined)
-  const refreshTimerRef = useRef<number>(undefined)
+export function AgentSection({
+  isConnected,
+  isInClusterMode = false,
+  health,
+  refresh,
+}: AgentSectionProps) {
+  const { t } = useTranslation();
+  const [copied, setCopied] = useState(false);
+  const [isRefreshing, setIsRefreshing] = useState(false);
+  const timeoutRef = useRef<number>(undefined);
+  const refreshTimerRef = useRef<number>(undefined);
 
   const copyInstallCommand = async () => {
-    await copyToClipboard(INSTALL_COMMAND)
-    setCopied(true)
-    timeoutRef.current = window.setTimeout(() => setCopied(false), UI_FEEDBACK_TIMEOUT_MS)
-  }
+    await copyToClipboard(INSTALL_COMMAND);
+    setCopied(true);
+    timeoutRef.current = window.setTimeout(
+      () => setCopied(false),
+      UI_FEEDBACK_TIMEOUT_MS,
+    );
+  };
 
   const handleRefresh = () => {
-    setIsRefreshing(true)
-    refresh()
-    refreshTimerRef.current = window.setTimeout(() => setIsRefreshing(false), RETRY_DELAY_MS)
-  }
+    setIsRefreshing(true);
+    refresh();
+    refreshTimerRef.current = window.setTimeout(
+      () => setIsRefreshing(false),
+      RETRY_DELAY_MS,
+    );
+  };
 
   // Cleanup timeouts on unmount
   useEffect(() => {
     return () => {
       if (timeoutRef.current) {
-        clearTimeout(timeoutRef.current)
+        clearTimeout(timeoutRef.current);
       }
       if (refreshTimerRef.current) {
-        clearTimeout(refreshTimerRef.current)
+        clearTimeout(refreshTimerRef.current);
       }
-    }
-  }, [])
+    };
+  }, []);
+
+  const isAgentReady = isConnected || isInClusterMode;
 
   return (
     <div id="agent-settings" className="glass rounded-xl p-6">
       <div className="flex items-center justify-between mb-4">
         <div className="flex items-center gap-3">
-          <div className={`p-2 rounded-lg ${isConnected ? 'bg-green-500/20' : 'bg-orange-500/20'}`}>
-            <Plug className={`w-5 h-5 ${isConnected ? 'text-green-400' : 'text-orange-400'}`} />
+          <div
+            className={`p-2 rounded-lg ${isAgentReady ? "bg-green-500/20" : "bg-orange-500/20"}`}
+          >
+            <Plug
+              className={`w-5 h-5 ${isAgentReady ? "text-green-400" : "text-orange-400"}`}
+            />
           </div>
           <div>
-            <h2 className="text-lg font-medium text-foreground">{t('settings.agent.title')}</h2>
-            <p className="text-sm text-muted-foreground">{t('settings.agent.subtitle')}</p>
+            <h2 className="text-lg font-medium text-foreground">
+              {t("settings.agent.title")}
+            </h2>
+            <p className="text-sm text-muted-foreground">
+              {t("settings.agent.subtitle")}
+            </p>
           </div>
         </div>
         <Button
           variant="ghost"
           size="md"
-          icon={<RefreshCw className={`w-4 h-4 ${isRefreshing ? 'animate-spin' : ''}`} />}
+          icon={
+            <RefreshCw
+              className={`w-4 h-4 ${isRefreshing ? "animate-spin" : ""}`}
+            />
+          }
           onClick={handleRefresh}
           disabled={isRefreshing}
         >
-          {t('settings.agent.refresh')}
+          {t("settings.agent.refresh")}
         </Button>
       </div>
 
       {/* Connection Status */}
-      <div className={`p-4 rounded-lg mb-4 ${isConnected ? 'bg-green-500/10 border border-green-500/20' : 'bg-orange-500/10 border border-orange-500/20'}`}>
+      <div
+        className={`p-4 rounded-lg mb-4 ${isAgentReady ? "bg-green-500/10 border border-green-500/20" : "bg-orange-500/10 border border-orange-500/20"}`}
+      >
         <div className="flex items-center gap-2">
-          {isConnected ? (
+          {isAgentReady ? (
             <>
               <Check className="w-5 h-5 text-green-400" />
-              <span className="font-medium text-green-400">{t('settings.agent.connected')}</span>
-              <span className="text-muted-foreground">- {t('settings.agent.agentVersion', { version: health?.version })}</span>
+              <span className="font-medium text-green-400">
+                {isInClusterMode && !isConnected
+                  ? t("agent.clusterMode")
+                  : t("settings.agent.connected")}
+              </span>
+              <span className="text-muted-foreground">
+                -{" "}
+                {isInClusterMode && !isConnected
+                  ? t("agent.usingInClusterService")
+                  : t("settings.agent.agentVersion", {
+                      version: health?.version,
+                    })}
+              </span>
             </>
           ) : (
             <>
               <X className="w-5 h-5 text-orange-400" />
-              <span className="font-medium text-orange-400">{t('settings.agent.notConnected')}</span>
-              <span className="text-muted-foreground">- {t('settings.agent.usingDemoData')}</span>
+              <span className="font-medium text-orange-400">
+                {t("settings.agent.notConnected")}
+              </span>
+              <span className="text-muted-foreground">
+                - {t("settings.agent.usingDemoData")}
+              </span>
             </>
           )}
         </div>
         {isConnected && health && (
           <div className="mt-2 flex gap-4 text-sm text-muted-foreground">
-            <span>{t('settings.agent.clustersCount', { count: health.clusters })}</span>
-            {health.hasClaude && <span>{t('settings.agent.claudeAvailable')}</span>}
+            <span>
+              {t("settings.agent.clustersCount", { count: health.clusters })}
+            </span>
+            {health.hasClaude && (
+              <span>{t("settings.agent.claudeAvailable")}</span>
+            )}
           </div>
         )}
       </div>
 
       {/* Install Instructions (when not connected) */}
-      {!isConnected && (
+      {!isAgentReady && (
         <div className="space-y-3">
           <p className="text-sm text-muted-foreground">
-            {t('settings.agent.installInstructions')}
+            {t("settings.agent.installInstructions")}
           </p>
           <div className="flex items-center gap-2">
             <code className="flex-1 min-w-0 px-4 py-3 rounded-lg bg-secondary font-mono text-sm select-all overflow-x-auto">
@@ -108,13 +159,13 @@ export function AgentSection({ isConnected, health, refresh }: AgentSectionProps
               className="shrink-0 flex items-center gap-2 px-4 py-3 rounded-lg bg-purple-500 text-white hover:bg-purple-600"
             >
               <Copy className="w-4 h-4" />
-              {copied ? t('settings.agent.copied') : t('settings.agent.copy')}
+              {copied ? t("settings.agent.copied") : t("settings.agent.copy")}
             </button>
           </div>
           <div className="flex gap-4 text-xs text-muted-foreground">
-            <span>✓ {t('settings.agent.featureClusters')}</span>
-            <span>✓ {t('settings.agent.featureTokens')}</span>
-            <span>✓ {t('settings.agent.featureLocal')}</span>
+            <span>✓ {t("settings.agent.featureClusters")}</span>
+            <span>✓ {t("settings.agent.featureTokens")}</span>
+            <span>✓ {t("settings.agent.featureLocal")}</span>
           </div>
         </div>
       )}
@@ -124,34 +175,65 @@ export function AgentSection({ isConnected, health, refresh }: AgentSectionProps
         <div className="mt-4 p-4 rounded-lg bg-purple-500/10 border border-purple-500/20">
           <div className="flex items-center gap-2 mb-3">
             <Cpu className="w-5 h-5 text-purple-400" />
-            <span className="font-medium text-purple-400">{t('settings.agent.claudeCode')}</span>
-            <span className="text-muted-foreground text-sm">v{health.claude.version}</span>
+            <span className="font-medium text-purple-400">
+              {t("settings.agent.claudeCode")}
+            </span>
+            <span className="text-muted-foreground text-sm">
+              v{health.claude.version}
+            </span>
           </div>
           <div className="grid grid-cols-3 gap-4">
             <div className="text-center p-3 rounded-lg bg-secondary/30">
-              <p className="text-xs text-muted-foreground mb-1">{t('settings.agent.thisSession')}</p>
-              <p className="text-sm font-mono text-foreground">
-                {((health.claude.tokenUsage.session.input + health.claude.tokenUsage.session.output) / 1000).toFixed(1)}k
+              <p className="text-xs text-muted-foreground mb-1">
+                {t("settings.agent.thisSession")}
               </p>
-              <p className="text-xs text-muted-foreground">{t('settings.agent.tokens')}</p>
+              <p className="text-sm font-mono text-foreground">
+                {(
+                  (health.claude.tokenUsage.session.input +
+                    health.claude.tokenUsage.session.output) /
+                  1000
+                ).toFixed(1)}
+                k
+              </p>
+              <p className="text-xs text-muted-foreground">
+                {t("settings.agent.tokens")}
+              </p>
             </div>
             <div className="text-center p-3 rounded-lg bg-secondary/30">
-              <p className="text-xs text-muted-foreground mb-1">{t('settings.agent.today')}</p>
-              <p className="text-sm font-mono text-foreground">
-                {((health.claude.tokenUsage.today.input + health.claude.tokenUsage.today.output) / 1000).toFixed(1)}k
+              <p className="text-xs text-muted-foreground mb-1">
+                {t("settings.agent.today")}
               </p>
-              <p className="text-xs text-muted-foreground">{t('settings.agent.tokens')}</p>
+              <p className="text-sm font-mono text-foreground">
+                {(
+                  (health.claude.tokenUsage.today.input +
+                    health.claude.tokenUsage.today.output) /
+                  1000
+                ).toFixed(1)}
+                k
+              </p>
+              <p className="text-xs text-muted-foreground">
+                {t("settings.agent.tokens")}
+              </p>
             </div>
             <div className="text-center p-3 rounded-lg bg-secondary/30">
-              <p className="text-xs text-muted-foreground mb-1">{t('settings.agent.thisMonth')}</p>
-              <p className="text-sm font-mono text-foreground">
-                {((health.claude.tokenUsage.thisMonth.input + health.claude.tokenUsage.thisMonth.output) / 1000000).toFixed(2)}M
+              <p className="text-xs text-muted-foreground mb-1">
+                {t("settings.agent.thisMonth")}
               </p>
-              <p className="text-xs text-muted-foreground">{t('settings.agent.tokens')}</p>
+              <p className="text-sm font-mono text-foreground">
+                {(
+                  (health.claude.tokenUsage.thisMonth.input +
+                    health.claude.tokenUsage.thisMonth.output) /
+                  1000000
+                ).toFixed(2)}
+                M
+              </p>
+              <p className="text-xs text-muted-foreground">
+                {t("settings.agent.tokens")}
+              </p>
             </div>
           </div>
         </div>
       )}
     </div>
-  )
+  );
 }

--- a/web/src/hooks/__tests__/useKagentBackend.test.ts
+++ b/web/src/hooks/__tests__/useKagentBackend.test.ts
@@ -517,7 +517,8 @@ describe('useKagentBackend', () => {
     localStorage.setItem('kc_agent_backend_preference', 'kagent')
     setupBothUnavailable()
     const { result, unmount } = renderHook(() => useKagentBackend())
-    await waitFor(() => expect(mockFetchKagentStatus).toHaveBeenCalled())
+    // Wait for the first poll to settle so hasPolled=true and activeBackend reflects live state
+    await waitFor(() => expect(result.current.hasPolled).toBe(true))
     expect(result.current.activeBackend).toBe('kc-agent')
     setupKagentAvailable()
     await act(async () => {
@@ -575,6 +576,80 @@ describe('useKagentBackend', () => {
     await waitFor(() => expect(result.current.kagentiAgents).toHaveLength(2))
     expect(result.current.kagentiAgents[0].name).toBe('ki-1')
     expect(result.current.kagentiAgents[1].name).toBe('ki-2')
+    unmount()
+  })
+
+  // ---------------------------------------------------------------------------
+  // hasPolled flag — guards AgentSelector blink-and-disappear race
+  // ---------------------------------------------------------------------------
+
+  it('exposes hasPolled property', () => {
+    const { result, unmount } = renderHook(() => useKagentBackend())
+    expect(result.current).toHaveProperty('hasPolled')
+    unmount()
+  })
+
+  it('hasPolled starts false before the first poll resolves', () => {
+    // Use a never-resolving mock so we can inspect the pre-poll state
+    mockFetchKagentStatus.mockReturnValue(new Promise(() => {}))
+    mockFetchKagentiProviderStatus.mockReturnValue(new Promise(() => {}))
+    const { result, unmount } = renderHook(() => useKagentBackend())
+    expect(result.current.hasPolled).toBe(false)
+    unmount()
+  })
+
+  it('hasPolled becomes true after the first poll completes', async () => {
+    setupBothUnavailable()
+    const { result, unmount } = renderHook(() => useKagentBackend())
+    expect(result.current.hasPolled).toBe(false)
+    await waitFor(() => expect(result.current.hasPolled).toBe(true))
+    unmount()
+  })
+
+  it('hasPolled becomes true even when kagenti is available', async () => {
+    setupKagentiAvailable()
+    const { result, unmount } = renderHook(() => useKagentBackend())
+    await waitFor(() => expect(result.current.hasPolled).toBe(true))
+    expect(result.current.kagentiAvailable).toBe(true)
+    unmount()
+  })
+
+  it('activeBackend uses stored preference before first poll (pre-poll stability)', () => {
+    // Pre-poll: stored pref is kagenti. Poll hasn't returned yet so kagentiAvailable=false.
+    // activeBackend should still return 'kagenti' (not snap to kc-agent before the poll).
+    localStorage.setItem('kc_agent_backend_preference', 'kagenti')
+    mockFetchKagentiProviderStatus.mockReturnValue(new Promise(() => {})) // never resolves
+    mockFetchKagentStatus.mockReturnValue(new Promise(() => {}))
+    const { result, unmount } = renderHook(() => useKagentBackend())
+    expect(result.current.hasPolled).toBe(false)
+    expect(result.current.activeBackend).toBe('kagenti') // trust stored pref, not live state
+    unmount()
+  })
+
+  it('activeBackend reflects live kagentiAvailable after first poll', async () => {
+    localStorage.setItem('kc_agent_backend_preference', 'kagenti')
+    setupKagentiAvailable()
+    const { result, unmount } = renderHook(() => useKagentBackend())
+    await waitFor(() => expect(result.current.hasPolled).toBe(true))
+    expect(result.current.activeBackend).toBe('kagenti')
+    unmount()
+  })
+
+  it('activeBackend falls back to kc-agent after poll when preferred kagenti is unavailable', async () => {
+    localStorage.setItem('kc_agent_backend_preference', 'kagenti')
+    setupBothUnavailable()
+    const { result, unmount } = renderHook(() => useKagentBackend())
+    await waitFor(() => expect(result.current.hasPolled).toBe(true))
+    expect(result.current.activeBackend).toBe('kc-agent')
+    unmount()
+  })
+
+  it('hasPolled remains true across subsequent refreshes', async () => {
+    setupBothUnavailable()
+    const { result, unmount } = renderHook(() => useKagentBackend())
+    await waitFor(() => expect(result.current.hasPolled).toBe(true))
+    await act(async () => { await result.current.refresh() })
+    expect(result.current.hasPolled).toBe(true)
     unmount()
   })
 })

--- a/web/src/hooks/useKagentBackend.ts
+++ b/web/src/hooks/useKagentBackend.ts
@@ -38,6 +38,8 @@ export interface UseKagentBackendResult {
   setPreferredBackend: (backend: AgentBackendType) => void
   /** The active backend (based on preference + availability) */
   activeBackend: AgentBackendType
+  /** True once the first status poll has completed */
+  hasPolled: boolean
   /** Refresh all statuses */
   refresh: () => void
 }
@@ -52,6 +54,9 @@ export function useKagentBackend(): UseKagentBackendResult {
   const [kagentiStatus, setKagentiStatus] = useState<KagentiProviderStatus | null>(null)
   const [kagentiAgents, setKagentiAgents] = useState<KagentiProviderAgent[]>([])
   const [selectedKagentiAgent, setSelectedKagentiAgent] = useState<KagentiProviderAgent | null>(null)
+
+  // Track whether the first status poll has finished (to avoid blinking activeBackend)
+  const [hasPolled, setHasPolled] = useState(false)
 
   const [preferredBackend, setPreferredBackendState] = useState<AgentBackendType>(() => {
     const saved = localStorage.getItem(BACKEND_PREF_KEY)
@@ -73,8 +78,6 @@ export function useKagentBackend(): UseKagentBackendResult {
     if (refreshInFlightRef.current) return
     refreshInFlightRef.current = true
     try {
-      // Poll kagent and kagenti concurrently — independent fetch chains
-      // should not block each other
       const [kStatus, kiStatus] = await Promise.all([
         fetchKagentStatus(),
         fetchKagentiProviderStatus(),
@@ -110,6 +113,7 @@ export function useKagentBackend(): UseKagentBackendResult {
       }
     } finally {
       refreshInFlightRef.current = false
+      setHasPolled(true)
     }
   }, [])
 
@@ -137,7 +141,10 @@ export function useKagentBackend(): UseKagentBackendResult {
   const kagentAvailable = kagentStatus?.available ?? false
   const kagentiAvailable = kagentiStatus?.available ?? false
 
+  // Use stored preference before the first poll completes to avoid activeBackend
+  // snapping to kc-agent while kagentiAvailable is still false.
   const activeBackend: AgentBackendType =
+    !hasPolled ? preferredBackend :
     preferredBackend === 'kagenti' && kagentiAvailable ? 'kagenti' :
     preferredBackend === 'kagent' && kagentAvailable ? 'kagent' :
     'kc-agent'
@@ -156,5 +163,6 @@ export function useKagentBackend(): UseKagentBackendResult {
     preferredBackend,
     setPreferredBackend,
     activeBackend,
+    hasPolled,
     refresh }
 }

--- a/web/src/hooks/useMissions.tsx
+++ b/web/src/hooks/useMissions.tsx
@@ -10,6 +10,7 @@ import { emitMissionStarted, emitMissionCompleted, emitMissionError, emitMission
 import { scanForMaliciousContent } from '../lib/missions/scanner/malicious'
 import { runPreflightCheck, type PreflightError, type PreflightResult } from '../lib/missions/preflightCheck'
 import { kubectlProxy } from '../lib/kubectlProxy'
+import { kagentiProviderChat, fetchKagentiProviderAgents } from '../lib/kagentiProviderBackend'
 import { ConfirmMissionPromptDialog } from '../components/missions/ConfirmMissionPromptDialog'
 
 export type MissionStatus = 'pending' | 'running' | 'waiting_input' | 'completed' | 'failed' | 'saved' | 'blocked' | 'cancelling' | 'cancelled'
@@ -222,6 +223,7 @@ const MISSIONS_STORAGE_KEY = 'kc_missions'
 const CROSS_TAB_ECHO_IGNORE_MS = 5
 const UNREAD_MISSIONS_KEY = 'kc_unread_missions'
 const SELECTED_AGENT_KEY = 'kc_selected_agent'
+const KAGENTI_SELECTED_AGENT_KEY = 'kc_kagenti_selected_agent'
 
 /**
  * #7089 — Monotonic counter for generating unique request IDs. The previous
@@ -246,6 +248,18 @@ let messageIdCounter = 0
 function generateMessageId(suffix = ''): string {
   messageIdCounter += 1
   return `msg-${Date.now()}-${messageIdCounter}${suffix ? `-${suffix}` : ''}`
+}
+
+function getSelectedKagentiAgentFromStorage(): { name: string; namespace: string } | null {
+  try {
+    const value = localStorage.getItem(KAGENTI_SELECTED_AGENT_KEY)
+    if (!value) return null
+    const [namespace, name] = value.split('/')
+    if (!namespace || !name) return null
+    return { namespace, name }
+  } catch {
+    return null
+  }
 }
 
 /** Delay before auto-reconnecting interrupted missions after WS opens */
@@ -2487,6 +2501,7 @@ The WebSocket connection to the agent at \`${LOCAL_AGENT_WS_URL}\` was lost and 
     enhancedPrompt: string,
     params: { context?: Record<string, unknown>; type?: string; dryRun?: boolean },
   ) => {
+    const missionType = params.type || 'custom'
     // #6384 item 1 (dup of #6381) — if a cancel intent is already set for
     // this missionId we must not clear it and proceed to send. This
     // scenario happens when the user clicks Cancel after preflightAndExecute
@@ -2510,6 +2525,151 @@ The WebSocket connection to the agent at \`${LOCAL_AGENT_WS_URL}\` was lost and 
     // `preflightAndExecute`, which checks above; `startMission` reaches
     // this point with a fresh mission ID and an empty cancelIntents entry.
     cancelIntents.current.delete(missionId)
+
+    // Route Kagenti-selected missions through backend SSE proxy instead of
+    // local-agent WebSocket, so in-cluster deployments work without kc-agent.
+    if (selectedAgentRef.current === 'kagenti') {
+      const startedAt = Date.now()
+      const assistantMessageId = generateMessageId('kagenti-stream')
+
+      setMissions(prev => prev.map(m =>
+        m.id === missionId
+          ? { ...m, status: 'running', currentStep: 'Connecting to kagenti...' }
+          : m
+      ))
+
+      void (async () => {
+        let target = getSelectedKagentiAgentFromStorage()
+        if (!target) {
+          const discovered = await fetchKagentiProviderAgents()
+          if ((discovered || []).length > 0) {
+            target = {
+              namespace: discovered[0].namespace,
+              name: discovered[0].name,
+            }
+          }
+        }
+
+        if (!target) {
+          executingMissions.current.delete(missionId)
+          const errorContent = `**Kagenti Agent Not Selected**\n\nSelect a Kagenti agent in Settings → Agent Backend, then retry this mission.`
+          setMissions(prev => prev.map(m =>
+            m.id === missionId
+              ? {
+                  ...m,
+                  status: 'failed',
+                  currentStep: undefined,
+                  messages: [
+                    ...m.messages,
+                    {
+                      id: generateMessageId('kagenti-missing-agent'),
+                      role: 'system',
+                      content: errorContent,
+                      timestamp: new Date(),
+                    },
+                  ],
+                }
+              : m
+          ))
+          emitMissionError(missionType, 'kagenti_agent_missing', 'no_selected_kagenti_agent')
+          return
+        }
+
+        await kagentiProviderChat(target.name, target.namespace, enhancedPrompt, {
+          contextId: missionId,
+          onChunk: (text: string) => {
+            setMissions(prev => prev.map(m => {
+              if (m.id !== missionId) return m
+
+              const idx = m.messages.findIndex(msg => msg.id === assistantMessageId)
+              if (idx === -1) {
+                return {
+                  ...m,
+                  currentStep: `Processing with ${selectedAgentRef.current || 'kagenti'}...`,
+                  messages: [
+                    ...m.messages,
+                    {
+                      id: assistantMessageId,
+                      role: 'assistant',
+                      content: text,
+                      timestamp: new Date(),
+                      agent: selectedAgentRef.current || 'kagenti',
+                    },
+                  ],
+                }
+              }
+
+              const nextMessages = [...m.messages]
+              nextMessages[idx] = {
+                ...nextMessages[idx],
+                content: `${nextMessages[idx].content}${text}`,
+                timestamp: new Date(),
+              }
+              return {
+                ...m,
+                currentStep: `Processing with ${selectedAgentRef.current || 'kagenti'}...`,
+                messages: nextMessages,
+              }
+            }))
+          },
+          onDone: () => {
+            executingMissions.current.delete(missionId)
+            const durationMs = Math.max(0, Date.now() - startedAt)
+            emitMissionCompleted(missionType, durationMs)
+
+            setMissions(prev => prev.map(m => {
+              if (m.id !== missionId) return m
+
+              const hasAssistant = m.messages.some(msg => msg.id === assistantMessageId && msg.content.trim().length > 0)
+              return {
+                ...m,
+                status: 'completed',
+                currentStep: undefined,
+                updatedAt: new Date(),
+                messages: hasAssistant
+                  ? m.messages
+                  : [
+                      ...m.messages,
+                      {
+                        id: assistantMessageId,
+                        role: 'assistant',
+                        content: 'Task completed.',
+                        timestamp: new Date(),
+                        agent: selectedAgentRef.current || 'kagenti',
+                      },
+                    ],
+              }
+            }))
+          },
+          onError: (error: string) => {
+            executingMissions.current.delete(missionId)
+            emitMissionError(missionType, 'kagenti_chat_error', error)
+
+            setMissions(prev => prev.map(m =>
+              m.id === missionId
+                ? {
+                    ...m,
+                    status: 'failed',
+                    currentStep: undefined,
+                    updatedAt: new Date(),
+                    messages: [
+                      ...m.messages,
+                      {
+                        id: generateMessageId('kagenti-error'),
+                        role: 'system',
+                        content: `**Kagenti Request Failed**\n\n${error}`,
+                        timestamp: new Date(),
+                      },
+                    ],
+                  }
+                : m
+            ))
+          },
+        })
+      })()
+
+      return
+    }
 
     // Send to agent
     ensureConnection().then(() => {

--- a/web/src/lib/kagentiProviderBackend.ts
+++ b/web/src/lib/kagentiProviderBackend.ts
@@ -2,6 +2,11 @@ import { authFetch } from './api'
 
 const API_BASE = import.meta.env.VITE_API_BASE_URL || ''
 
+// Timeout for kagenti provider status and agent list queries
+const KAGENTI_STATUS_TIMEOUT_MS = 5_000
+// Timeout for tool invocation through kagenti provider
+const KAGENTI_TOOL_CALL_TIMEOUT_MS = 30_000
+
 export interface KagentiProviderAgent {
   name: string
   namespace: string
@@ -19,7 +24,7 @@ export interface KagentiProviderStatus {
 export async function fetchKagentiProviderStatus(): Promise<KagentiProviderStatus> {
   try {
     const resp = await authFetch(`${API_BASE}/api/kagenti-provider/status`, {
-      signal: AbortSignal.timeout(5000),
+      signal: AbortSignal.timeout(KAGENTI_STATUS_TIMEOUT_MS),
     })
     if (!resp.ok) return { available: false, reason: `HTTP ${resp.status}` }
     return resp.json()
@@ -31,7 +36,7 @@ export async function fetchKagentiProviderStatus(): Promise<KagentiProviderStatu
 export async function fetchKagentiProviderAgents(): Promise<KagentiProviderAgent[]> {
   try {
     const resp = await authFetch(`${API_BASE}/api/kagenti-provider/agents`, {
-      signal: AbortSignal.timeout(5000),
+      signal: AbortSignal.timeout(KAGENTI_STATUS_TIMEOUT_MS),
     })
     if (!resp.ok) return []
     const data = await resp.json()
@@ -125,7 +130,7 @@ export async function kagentiProviderCallTool(
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ agent, namespace, tool, args }),
-    signal: AbortSignal.timeout(30000),
+    signal: AbortSignal.timeout(KAGENTI_TOOL_CALL_TIMEOUT_MS),
   })
   if (!resp.ok) throw new Error(`Tool call failed: HTTP ${resp.status}`)
   return resp.json()

--- a/web/src/lib/kubectlProxy.ts
+++ b/web/src/lib/kubectlProxy.ts
@@ -6,6 +6,7 @@
  */
 
 import { isNetlifyDeployment } from './demoMode'
+import { isInClusterMode } from '../hooks/useBackendHealth'
 import {
   LOCAL_AGENT_WS_URL,
   WS_CONNECT_TIMEOUT_MS,
@@ -68,6 +69,47 @@ class KubectlProxy {
   private activeRequests = 0
   private readonly maxConcurrentRequests = MAX_CONCURRENT_KUBECTL_REQUESTS // Limit concurrent requests to local agent
   private lastConnectionFailureAt = 0
+  private wsMode: 'unknown' | 'local' | 'backend' = 'unknown'
+
+  private getBackendWSURL(): string {
+    if (typeof window === 'undefined') return LOCAL_AGENT_WS_URL
+    const wsProtocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:'
+    return `${wsProtocol}//${window.location.host}/ws`
+  }
+
+  private async resolveWebSocketURL(): Promise<string> {
+    if (this.wsMode === 'backend') return this.getBackendWSURL()
+    if (this.wsMode === 'local') return LOCAL_AGENT_WS_URL
+
+    // Fast path from shared backend health state
+    if (isInClusterMode()) {
+      this.wsMode = 'backend'
+      return this.getBackendWSURL()
+    }
+
+    // Fallback probe for early startup before health subscribers settle.
+    try {
+      const res = await fetch('/health', {
+        method: 'GET',
+        headers: { Accept: 'application/json' },
+        signal: AbortSignal.timeout(1200),
+      })
+      if (res.ok) {
+        const data = (await res.json().catch(() => null)) as {
+          in_cluster?: boolean
+        } | null
+        if (data?.in_cluster === true) {
+          this.wsMode = 'backend'
+          return this.getBackendWSURL()
+        }
+      }
+    } catch {
+      // ignore probe failure and fall back to local endpoint
+    }
+
+    this.wsMode = 'local'
+    return LOCAL_AGENT_WS_URL
+  }
 
   /**
    * Ensure WebSocket is connected
@@ -82,94 +124,137 @@ class KubectlProxy {
       return
     }
 
-    // Fail fast during cooldown windows to avoid repeated expensive retries
-    if (Date.now() - this.lastConnectionFailureAt < WS_CONNECTION_COOLDOWN_MS) {
-      throw new Error('Local agent unavailable (cooldown)')
-    }
-
     if (this.connectPromise) {
       return this.connectPromise
     }
 
     if (this.isConnecting) {
       // Wait for existing connection attempt
-      await new Promise(resolve => setTimeout(resolve, FOCUS_DELAY_MS))
+      await new Promise((resolve) => setTimeout(resolve, FOCUS_DELAY_MS))
       return this.ensureConnected()
     }
 
     this.isConnecting = true
-    this.connectPromise = new Promise((resolve, reject) => {
-      let settled = false
-      let connectTimeout: ReturnType<typeof setTimeout> | null = null
-      const finalize = (cb: () => void) => {
-        if (settled) return
-        settled = true
-        if (connectTimeout) clearTimeout(connectTimeout)
-        cb()
+    this.connectPromise = (async () => {
+      const wsURL = await this.resolveWebSocketURL()
+      const isLocalTarget = wsURL === LOCAL_AGENT_WS_URL
+
+      // Fail fast during cooldown windows only for local-agent targets.
+      // For backend /ws targets we should always retry, because the backend
+      // may become reachable while a previous local attempt is still cooling down.
+      if (
+        isLocalTarget &&
+        Date.now() - this.lastConnectionFailureAt < WS_CONNECTION_COOLDOWN_MS
+      ) {
+        throw new Error('Local agent unavailable (cooldown)')
       }
-      try {
-        this.ws = new WebSocket(LOCAL_AGENT_WS_URL)
-        connectTimeout = setTimeout(() => {
-          try { this.ws?.close() } catch { /* ignore */ }
-          this.lastConnectionFailureAt = Date.now()
-          this.isConnecting = false
-          this.connectPromise = null
-          finalize(() => reject(new Error(`Connection timeout after ${WS_CONNECT_TIMEOUT_MS}ms`)))
-        }, WS_CONNECT_TIMEOUT_MS)
 
-        this.ws.onopen = () => {
-          this.isConnecting = false
-          this.lastConnectionFailureAt = 0
-          finalize(() => resolve())
+      return new Promise<void>((resolve, reject) => {
+        let settled = false
+        let connectTimeout: ReturnType<typeof setTimeout> | null = null
+        const finalize = (cb: () => void) => {
+          if (settled) return
+          settled = true
+          if (connectTimeout) clearTimeout(connectTimeout)
+          cb()
         }
-
-        this.ws.onmessage = (event) => {
-          try {
-            const message: Message = JSON.parse(event.data)
-            const pending = this.pendingRequests.get(message.id)
-            if (pending) {
-              clearTimeout(pending.timeout)
-              this.pendingRequests.delete(message.id)
-
-              if (message.type === 'error') {
-                const errorPayload = message.payload as { code: string; message: string }
-                pending.reject(new Error(errorPayload.message || 'Unknown error'))
-              } else {
-                pending.resolve(message.payload as KubectlResponse)
-              }
+        try {
+          this.ws = new WebSocket(wsURL)
+          connectTimeout = setTimeout(() => {
+            try {
+              this.ws?.close()
+            } catch {
+              /* ignore */
             }
-          } catch (e) {
-            console.error('[KubectlProxy] Failed to parse message:', e)
+            this.lastConnectionFailureAt = Date.now()
+            this.isConnecting = false
+            this.connectPromise = null
+            finalize(() =>
+              reject(
+                new Error(
+                  `Connection timeout after ${WS_CONNECT_TIMEOUT_MS}ms`,
+                ),
+              ),
+            )
+          }, WS_CONNECT_TIMEOUT_MS)
+
+          this.ws.onopen = () => {
+            this.isConnecting = false
+            this.lastConnectionFailureAt = 0
+            this.wsMode = wsURL === LOCAL_AGENT_WS_URL ? 'local' : 'backend'
+            finalize(() => resolve())
           }
-        }
 
-        this.ws.onclose = () => {
-          this.ws = null
-          this.connectPromise = null
+          this.ws.onmessage = (event) => {
+            try {
+              const message: Message = JSON.parse(event.data)
+              const pending = this.pendingRequests.get(message.id)
+              if (pending) {
+                clearTimeout(pending.timeout)
+                this.pendingRequests.delete(message.id)
+
+                if (message.type === 'error') {
+                  const errorPayload = message.payload as {
+                    code: string
+                    message: string
+                  }
+                  pending.reject(
+                    new Error(errorPayload.message || 'Unknown error'),
+                  )
+                } else {
+                  pending.resolve(message.payload as KubectlResponse)
+                }
+              }
+            } catch (e) {
+              console.error('[KubectlProxy] Failed to parse message:', e)
+            }
+          }
+
+          this.ws.onclose = () => {
+            this.ws = null
+            this.connectPromise = null
+            this.isConnecting = false
+            this.lastConnectionFailureAt = Date.now()
+            this.wsMode = 'unknown'
+
+            // Reject all pending requests
+            this.pendingRequests.forEach((pending, id) => {
+              clearTimeout(pending.timeout)
+              pending.reject(new Error('Connection closed'))
+              this.pendingRequests.delete(id)
+            })
+          }
+
+          this.ws.onerror = (err) => {
+            console.error('[KubectlProxy] WebSocket error:', err)
+            this.isConnecting = false
+            this.connectPromise = null
+            this.lastConnectionFailureAt = Date.now()
+            this.wsMode = 'unknown'
+            finalize(() =>
+              reject(
+                new Error(
+                  isLocalTarget
+                    ? 'Failed to connect to local agent'
+                    : 'Failed to connect to backend WebSocket',
+                ),
+              ),
+            )
+          }
+        } catch (err) {
           this.isConnecting = false
-          this.lastConnectionFailureAt = Date.now()
-
-          // Reject all pending requests
-          this.pendingRequests.forEach((pending, id) => {
-            clearTimeout(pending.timeout)
-            pending.reject(new Error('Connection closed'))
-            this.pendingRequests.delete(id)
-          })
-        }
-
-        this.ws.onerror = (err) => {
-          console.error('[KubectlProxy] WebSocket error:', err)
-          this.isConnecting = false
           this.connectPromise = null
           this.lastConnectionFailureAt = Date.now()
-          finalize(() => reject(new Error('Failed to connect to local agent')))
+          this.wsMode = 'unknown'
+          finalize(() => reject(err))
         }
-      } catch (err) {
-        this.isConnecting = false
-        this.connectPromise = null
-        this.lastConnectionFailureAt = Date.now()
-        finalize(() => reject(err))
-      }
+      })
+    })().catch((err) => {
+      this.isConnecting = false
+      this.connectPromise = null
+      this.lastConnectionFailureAt = Date.now()
+      this.wsMode = 'unknown'
+      throw err
     })
 
     return this.connectPromise
@@ -188,7 +273,12 @@ class KubectlProxy {
    */
   async exec(
     args: string[],
-    options: { context?: string; namespace?: string; timeout?: number; priority?: boolean } = {}
+    options: {
+      context?: string
+      namespace?: string
+      timeout?: number
+      priority?: boolean
+    } = {},
   ): Promise<KubectlResponse> {
     // Priority requests bypass the queue for immediate execution (interactive user actions)
     if (options.priority) {
@@ -237,7 +327,7 @@ class KubectlProxy {
    */
   private async execImmediate(
     args: string[],
-    options: { context?: string; namespace?: string; timeout?: number } = {}
+    options: { context?: string; namespace?: string; timeout?: number } = {},
   ): Promise<KubectlResponse> {
     await this.ensureConnected()
 
@@ -284,7 +374,10 @@ class KubectlProxy {
    * Get nodes for a cluster (used for health checks)
    */
   async getNodes(context: string): Promise<NodeInfo[]> {
-    const response = await this.exec(['get', 'nodes', '-o', 'json'], { context, timeout: KUBECTL_MAX_TIMEOUT_MS })
+    const response = await this.exec(['get', 'nodes', '-o', 'json'], {
+      context,
+      timeout: KUBECTL_MAX_TIMEOUT_MS,
+    })
     if (response.exitCode !== 0) {
       throw new Error(response.error || 'Failed to get nodes')
     }
@@ -303,15 +396,17 @@ class KubectlProxy {
       const cpuCores = parseResourceQuantity(cpuStr)
 
       // Check Ready condition - Kubernetes uses 'True' (capitalized string)
-      const readyCondition = node.status?.conditions?.find((c: NodeCondition) => c.type === 'Ready')
+      const readyCondition = node.status?.conditions?.find(
+        (c: NodeCondition) => c.type === 'Ready',
+      )
       const isReady = readyCondition?.status === 'True'
 
       return {
         name: node.metadata.name,
         ready: isReady,
         roles: Object.keys(node.metadata.labels || {})
-          .filter(k => k.startsWith('node-role.kubernetes.io/'))
-          .map(k => k.replace('node-role.kubernetes.io/', '')),
+          .filter((k) => k.startsWith('node-role.kubernetes.io/'))
+          .map((k) => k.replace('node-role.kubernetes.io/', '')),
         cpuCores: cpuCores,
         memoryBytes: parseResourceQuantity(alloc.memory),
         storageBytes: parseResourceQuantity(alloc['ephemeral-storage']),
@@ -323,12 +418,29 @@ class KubectlProxy {
   /**
    * Get pod count and resource requests for a cluster
    */
-  async getPodMetrics(context: string): Promise<{ count: number; cpuRequestsMillicores: number; memoryRequestsBytes: number }> {
-    const response = await this.exec(['get', 'pods', '-A', '-o', 'json'], { context, timeout: KUBECTL_MAX_TIMEOUT_MS })
+  async getPodMetrics(
+    context: string,
+  ): Promise<{
+    count: number
+    cpuRequestsMillicores: number
+    memoryRequestsBytes: number
+  }> {
+    const response = await this.exec(['get', 'pods', '-A', '-o', 'json'], {
+      context,
+      timeout: KUBECTL_MAX_TIMEOUT_MS,
+    })
     if (response.exitCode !== 0) {
       throw new Error(response.error || 'Failed to get pods')
     }
-    let data: { items?: Array<{ spec?: { containers?: Array<{ resources?: { requests?: { cpu?: string; memory?: string } } }> } }> }
+    let data: {
+      items?: Array<{
+        spec?: {
+          containers?: Array<{
+            resources?: { requests?: { cpu?: string; memory?: string } }
+          }>
+        }
+      }>
+    }
     try {
       data = JSON.parse(response.output)
     } catch {
@@ -375,7 +487,7 @@ class KubectlProxy {
   async getNamespaces(context: string): Promise<string[]> {
     const response = await this.exec(
       ['get', 'namespaces', '-o', 'jsonpath={.items[*].metadata.name}'],
-      { context, timeout: KUBECTL_MAX_TIMEOUT_MS }
+      { context, timeout: KUBECTL_MAX_TIMEOUT_MS },
     )
     if (response.exitCode !== 0) {
       throw new Error(response.error || 'Failed to get namespaces')
@@ -386,9 +498,15 @@ class KubectlProxy {
   /**
    * Get services from a cluster
    */
-  async getServices(context: string, namespace?: string): Promise<KubectlServiceResult[]> {
+  async getServices(
+    context: string,
+    namespace?: string,
+  ): Promise<KubectlServiceResult[]> {
     const nsArg = namespace ? ['-n', namespace] : ['-A']
-    const response = await this.exec(['get', 'services', ...nsArg, '-o', 'json'], { context, timeout: KUBECTL_EXTENDED_TIMEOUT_MS })
+    const response = await this.exec(
+      ['get', 'services', ...nsArg, '-o', 'json'],
+      { context, timeout: KUBECTL_EXTENDED_TIMEOUT_MS },
+    )
     if (response.exitCode !== 0) {
       throw new Error(response.error || 'Failed to get services')
     }
@@ -421,7 +539,9 @@ class KubectlProxy {
         namespace: svc.metadata.namespace,
         type: svc.spec.type,
         clusterIP: svc.spec.clusterIP || '',
-        ports: (svc.spec.ports || []).map(p => `${p.port}/${p.protocol}`).join(', '),
+        ports: (svc.spec.ports || [])
+          .map((p) => `${p.port}/${p.protocol}`)
+          .join(', '),
         externalIP: allExternalIPs.join(', '),
         externalIPs: allExternalIPs,
         lbStatus,
@@ -433,42 +553,84 @@ class KubectlProxy {
   /**
    * Get PVCs from a cluster
    */
-  async getPVCs(context: string, namespace?: string): Promise<{ name: string; namespace: string; status: string; capacity: string; storageClass: string }[]> {
+  async getPVCs(
+    context: string,
+    namespace?: string,
+  ): Promise<
+    {
+      name: string
+      namespace: string
+      status: string
+      capacity: string
+      storageClass: string
+    }[]
+  > {
     const nsArg = namespace ? ['-n', namespace] : ['-A']
-    const response = await this.exec(['get', 'pvc', ...nsArg, '-o', 'json'], { context, timeout: KUBECTL_EXTENDED_TIMEOUT_MS })
+    const response = await this.exec(['get', 'pvc', ...nsArg, '-o', 'json'], {
+      context,
+      timeout: KUBECTL_EXTENDED_TIMEOUT_MS,
+    })
     if (response.exitCode !== 0) {
       throw new Error(response.error || 'Failed to get PVCs')
     }
-    let data: { items?: Array<{ metadata: { name: string; namespace: string }; status: { phase: string; capacity?: { storage: string } }; spec: { storageClassName?: string } }> }
+    let data: {
+      items?: Array<{
+        metadata: { name: string; namespace: string }
+        status: { phase: string; capacity?: { storage: string } }
+        spec: { storageClassName?: string }
+      }>
+    }
     try {
       data = JSON.parse(response.output)
     } catch {
       throw new Error('Failed to parse kubectl output as JSON')
     }
-    return (data.items || []).map((pvc: { metadata: { name: string; namespace: string }; status: { phase: string; capacity?: { storage: string } }; spec: { storageClassName?: string } }) => ({
-      name: pvc.metadata.name,
-      namespace: pvc.metadata.namespace,
-      status: pvc.status.phase,
-      capacity: pvc.status.capacity?.storage || '',
-      storageClass: pvc.spec.storageClassName || '',
-    }))
+    return (data.items || []).map(
+      (pvc: {
+        metadata: { name: string; namespace: string }
+        status: { phase: string; capacity?: { storage: string } }
+        spec: { storageClassName?: string }
+      }) => ({
+        name: pvc.metadata.name,
+        namespace: pvc.metadata.namespace,
+        status: pvc.status.phase,
+        capacity: pvc.status.capacity?.storage || '',
+        storageClass: pvc.spec.storageClassName || '',
+      }),
+    )
   }
 
   /**
    * Get actual resource usage from metrics-server via kubectl top nodes
    * Returns actual CPU and memory consumption (not requests/allocations)
    */
-  async getClusterUsage(context: string): Promise<{ cpuUsageMillicores: number; memoryUsageBytes: number; metricsAvailable: boolean }> {
+  async getClusterUsage(
+    context: string,
+  ): Promise<{
+    cpuUsageMillicores: number
+    memoryUsageBytes: number
+    metricsAvailable: boolean
+  }> {
     try {
-      const response = await this.exec(['top', 'nodes', '--no-headers'], { context, timeout: METRICS_SERVER_TIMEOUT_MS })
+      const response = await this.exec(['top', 'nodes', '--no-headers'], {
+        context,
+        timeout: METRICS_SERVER_TIMEOUT_MS,
+      })
       if (response.exitCode !== 0) {
         // Metrics server not available
-        return { cpuUsageMillicores: 0, memoryUsageBytes: 0, metricsAvailable: false }
+        return {
+          cpuUsageMillicores: 0,
+          memoryUsageBytes: 0,
+          metricsAvailable: false,
+        }
       }
 
       // Parse kubectl top nodes output
       // Format: NAME   CPU(cores)   CPU%   MEMORY(bytes)   MEMORY%
-      const lines = response.output.trim().split('\n').filter(l => l.trim())
+      const lines = response.output
+        .trim()
+        .split('\n')
+        .filter((l) => l.trim())
       let totalCpuMillicores = 0
       let totalMemoryBytes = 0
 
@@ -489,10 +651,18 @@ class KubectlProxy {
         }
       }
 
-      return { cpuUsageMillicores: totalCpuMillicores, memoryUsageBytes: totalMemoryBytes, metricsAvailable: true }
+      return {
+        cpuUsageMillicores: totalCpuMillicores,
+        memoryUsageBytes: totalMemoryBytes,
+        metricsAvailable: true,
+      }
     } catch (err) {
       console.error(`[ClusterUsage] ${context}: error getting usage -`, err)
-      return { cpuUsageMillicores: 0, memoryUsageBytes: 0, metricsAvailable: false }
+      return {
+        cpuUsageMillicores: 0,
+        memoryUsageBytes: 0,
+        metricsAvailable: false,
+      }
     }
   }
 
@@ -509,24 +679,40 @@ class KubectlProxy {
       ])
 
       // Try to get usage metrics with a short timeout, but don't block health check
-      let usageMetrics = { cpuUsageMillicores: 0, memoryUsageBytes: 0, metricsAvailable: false }
+      let usageMetrics = {
+        cpuUsageMillicores: 0,
+        memoryUsageBytes: 0,
+        metricsAvailable: false,
+      }
       try {
         const usagePromise = this.getClusterUsage(context)
         const timeoutPromise = new Promise<typeof usageMetrics>((_, reject) =>
-          setTimeout(() => reject(new Error('Usage metrics timeout')), METRICS_SERVER_TIMEOUT_MS)
+          setTimeout(
+            () => reject(new Error('Usage metrics timeout')),
+            METRICS_SERVER_TIMEOUT_MS,
+          ),
         )
         usageMetrics = await Promise.race([usagePromise, timeoutPromise])
       } catch (err) {
         // Usage metrics failed or timed out - continue without them
-        console.error(`[ClusterHealth] ${context}: Usage metrics unavailable, using requests only`, err)
+        console.error(
+          `[ClusterHealth] ${context}: Usage metrics unavailable, using requests only`,
+          err,
+        )
       }
 
-      const readyNodes = nodes.filter(n => n.ready).length
+      const readyNodes = nodes.filter((n) => n.ready).length
 
       // Aggregate resource metrics from all nodes (capacity)
       const totalCpuCores = nodes.reduce((sum, n) => sum + (n.cpuCores || 0), 0)
-      const totalMemoryBytes = nodes.reduce((sum, n) => sum + (n.memoryBytes || 0), 0)
-      const totalStorageBytes = nodes.reduce((sum, n) => sum + (n.storageBytes || 0), 0)
+      const totalMemoryBytes = nodes.reduce(
+        (sum, n) => sum + (n.memoryBytes || 0),
+        0,
+      )
+      const totalStorageBytes = nodes.reduce(
+        (sum, n) => sum + (n.storageBytes || 0),
+        0,
+      )
 
       // Consider healthy if at least 50% of nodes are ready (lenient threshold)
       // A cluster with working nodes should show as healthy, not warning
@@ -580,7 +766,10 @@ class KubectlProxy {
    */
   async getPodIssues(context: string, namespace?: string): Promise<PodIssue[]> {
     const nsArg = namespace ? ['-n', namespace] : ['-A']
-    const response = await this.exec(['get', 'pods', ...nsArg, '-o', 'json'], { context, timeout: KUBECTL_EXTENDED_TIMEOUT_MS })
+    const response = await this.exec(['get', 'pods', ...nsArg, '-o', 'json'], {
+      context,
+      timeout: KUBECTL_EXTENDED_TIMEOUT_MS,
+    })
 
     if (response.exitCode !== 0) {
       throw new Error(response.error || 'Failed to get pods')
@@ -622,7 +811,14 @@ class KubectlProxy {
 
         if (cs.state?.waiting) {
           const waitReason = cs.state.waiting.reason ?? ''
-          if (['CrashLoopBackOff', 'ImagePullBackOff', 'ErrImagePull', 'CreateContainerError'].includes(waitReason)) {
+          if (
+            [
+              'CrashLoopBackOff',
+              'ImagePullBackOff',
+              'ErrImagePull',
+              'CreateContainerError',
+            ].includes(waitReason)
+          ) {
             problems.push(waitReason)
             reason = waitReason
           }
@@ -634,8 +830,9 @@ class KubectlProxy {
       }
 
       if (phase === 'Pending' && status.conditions) {
-        const unschedulable = status.conditions.find((c: { type: string; status: string; reason?: string }) =>
-          c.type === 'PodScheduled' && c.status === 'False'
+        const unschedulable = status.conditions.find(
+          (c: { type: string; status: string; reason?: string }) =>
+            c.type === 'PodScheduled' && c.status === 'False',
         )
         if (unschedulable) {
           problems.push('Unschedulable')
@@ -667,11 +864,15 @@ class KubectlProxy {
   /**
    * Get events from a cluster
    */
-  async getEvents(context: string, namespace?: string, limit = 50): Promise<ClusterEvent[]> {
+  async getEvents(
+    context: string,
+    namespace?: string,
+    limit = 50,
+  ): Promise<ClusterEvent[]> {
     const nsArg = namespace ? ['-n', namespace] : ['-A']
     const response = await this.exec(
       ['get', 'events', ...nsArg, '--sort-by=.lastTimestamp', '-o', 'json'],
-      { context, timeout: KUBECTL_EXTENDED_TIMEOUT_MS }
+      { context, timeout: KUBECTL_EXTENDED_TIMEOUT_MS },
     )
 
     if (response.exitCode !== 0) {
@@ -684,17 +885,20 @@ class KubectlProxy {
     } catch {
       throw new Error('Failed to parse kubectl output as JSON')
     }
-    const events: ClusterEvent[] = (data.items || []).slice(-limit).reverse().map((e: KubeEvent) => ({
-      type: e.type,
-      reason: e.reason,
-      message: e.message,
-      object: `${e.involvedObject.kind}/${e.involvedObject.name}`,
-      namespace: e.metadata.namespace,
-      cluster: context,
-      count: e.count || 1,
-      firstSeen: e.firstTimestamp,
-      lastSeen: e.lastTimestamp,
-    }))
+    const events: ClusterEvent[] = (data.items || [])
+      .slice(-limit)
+      .reverse()
+      .map((e: KubeEvent) => ({
+        type: e.type,
+        reason: e.reason,
+        message: e.message,
+        object: `${e.involvedObject.kind}/${e.involvedObject.name}`,
+        namespace: e.metadata.namespace,
+        cluster: context,
+        count: e.count || 1,
+        firstSeen: e.firstTimestamp,
+        lastSeen: e.lastTimestamp,
+      }))
 
     return events
   }
@@ -702,9 +906,15 @@ class KubectlProxy {
   /**
    * Get deployments from a cluster
    */
-  async getDeployments(context: string, namespace?: string): Promise<Deployment[]> {
+  async getDeployments(
+    context: string,
+    namespace?: string,
+  ): Promise<Deployment[]> {
     const nsArg = namespace ? ['-n', namespace] : ['-A']
-    const response = await this.exec(['get', 'deployments', ...nsArg, '-o', 'json'], { context, timeout: KUBECTL_EXTENDED_TIMEOUT_MS })
+    const response = await this.exec(
+      ['get', 'deployments', ...nsArg, '-o', 'json'],
+      { context, timeout: KUBECTL_EXTENDED_TIMEOUT_MS },
+    )
 
     if (response.exitCode !== 0) {
       throw new Error(response.error || 'Failed to get deployments')
@@ -757,7 +967,7 @@ class KubectlProxy {
   async getBulkClusterHealth(
     contexts: string[],
     onProgress?: (health: ClusterHealth) => void,
-    concurrency = 5
+    concurrency = 5,
   ): Promise<ClusterHealth[]> {
     const results: ClusterHealth[] = []
     const queue = [...contexts]
@@ -770,11 +980,11 @@ class KubectlProxy {
 
         // Don't await here - let multiple run in parallel
         this.getClusterHealth(context)
-          .then(health => {
+          .then((health) => {
             results.push(health)
             onProgress?.(health)
           })
-          .catch(err => {
+          .catch((err) => {
             const errorHealth: ClusterHealth = {
               cluster: context,
               healthy: false,
@@ -782,7 +992,8 @@ class KubectlProxy {
               nodeCount: 0,
               readyNodes: 0,
               podCount: 0,
-              errorMessage: err instanceof Error ? err.message : 'Unknown error',
+              errorMessage:
+                err instanceof Error ? err.message : 'Unknown error',
             }
             results.push(errorHealth)
             onProgress?.(errorHealth)
@@ -805,7 +1016,7 @@ class KubectlProxy {
 
     // Wait for all to complete
     while (results.length < contexts.length) {
-      await new Promise(resolve => setTimeout(resolve, FOCUS_DELAY_MS))
+      await new Promise((resolve) => setTimeout(resolve, FOCUS_DELAY_MS))
     }
 
     return results
@@ -887,12 +1098,21 @@ interface KubeEvent {
 
 /** Shape of a Kubernetes Service object from `kubectl get services -o json` */
 interface KubeService {
-  metadata: { name: string; namespace: string; labels?: Record<string, string> }
+  metadata: {
+    name: string
+    namespace: string
+    labels?: Record<string, string>
+  }
   spec: {
     type: string
     clusterIP: string
     externalIPs?: string[]
-    ports?: Array<{ port: number; protocol: string; nodePort?: number; name?: string }>
+    ports?: Array<{
+      port: number
+      protocol: string
+      nodePort?: number
+      name?: string
+    }>
     selector?: Record<string, string>
   }
   status?: {
@@ -920,7 +1140,12 @@ export interface KubectlServiceResult {
 }
 
 interface KubeDeployment {
-  metadata: { name: string; namespace: string; labels?: Record<string, string>; annotations?: Record<string, string> }
+  metadata: {
+    name: string
+    namespace: string
+    labels?: Record<string, string>
+    annotations?: Record<string, string>
+  }
   spec: {
     replicas?: number
     template?: { spec?: { containers?: Array<{ image?: string }> } }
@@ -945,16 +1170,26 @@ function parseResourceQuantity(value: string | undefined): number {
   const num = parseFloat(match[1])
   const suffix = match[2]
   switch (suffix) {
-    case 'Ki': return num * 1024
-    case 'Mi': return num * 1024 * 1024
-    case 'Gi': return num * 1024 * 1024 * 1024
-    case 'Ti': return num * 1024 * 1024 * 1024 * 1024
-    case 'K': return num * 1000
-    case 'M': return num * 1000 * 1000
-    case 'G': return num * 1000 * 1000 * 1000
-    case 'T': return num * 1000 * 1000 * 1000 * 1000
-    case 'm': return num / 1000 // millicores
-    default: return num
+    case 'Ki':
+      return num * 1024
+    case 'Mi':
+      return num * 1024 * 1024
+    case 'Gi':
+      return num * 1024 * 1024 * 1024
+    case 'Ti':
+      return num * 1024 * 1024 * 1024 * 1024
+    case 'K':
+      return num * 1000
+    case 'M':
+      return num * 1000 * 1000
+    case 'G':
+      return num * 1000 * 1000 * 1000
+    case 'T':
+      return num * 1000 * 1000 * 1000 * 1000
+    case 'm':
+      return num / 1000 // millicores
+    default:
+      return num
   }
 }
 

--- a/web/src/lib/kubectlProxy.ts
+++ b/web/src/lib/kubectlProxy.ts
@@ -11,6 +11,7 @@ import {
   LOCAL_AGENT_WS_URL,
   WS_CONNECT_TIMEOUT_MS,
   WS_CONNECTION_COOLDOWN_MS,
+  BACKEND_HEALTH_CHECK_TIMEOUT_MS,
   KUBECTL_DEFAULT_TIMEOUT_MS,
   KUBECTL_EXTENDED_TIMEOUT_MS,
   KUBECTL_MAX_TIMEOUT_MS,
@@ -92,7 +93,7 @@ class KubectlProxy {
       const res = await fetch('/health', {
         method: 'GET',
         headers: { Accept: 'application/json' },
-        signal: AbortSignal.timeout(1200),
+        signal: AbortSignal.timeout(BACKEND_HEALTH_CHECK_TIMEOUT_MS),
       })
       if (res.ok) {
         const data = (await res.json().catch(() => null)) as {


### PR DESCRIPTION
This PR adds  Kagenti in-cluster support and stabilises backend/agent UX behaviour across controller and direct-agent modes.

### 📌 Fixes

Fixes #8492 

---

### 📝 Summary of Changes

### Changes Made
### Backend / API

- Added Kagenti provider registration in the agent registry.
- Added controller and direct-agent support paths for Kagenti client/provider.
- Improved Kagenti SSE chat streaming/proxy behavior and completion handling.
- Added/updated provider tests for handshake, availability, and stream behavior.

### Helm / Deployment

- Added Kagenti environment wiring in Deployment values/template.
- Added optional NetworkPolicy egress support for Kagenti service communication.
- Added an example values file for in-cluster Kagenti installs.

### Frontend

- Improved backend preference/selection stability during initial polling.
- Updated agent selection/status/settings behavior for in-cluster backends.
- Added test coverage for backend-selection and kagenti agent-list utilities.

---

### Checklist

Please ensure the following before submitting your PR:

- [ ] I used a coding agent (Claude Code, Copilot, Gemini, or Codex) to generate/review this code
- [ ] I have reviewed the project's contribution guidelines
- [ ] New cards target [console-marketplace](https://github.com/kubestellar/console-marketplace), not this repo
- [ ] isDemoData is wired correctly (cards show Demo badge when using demo data)
- [ ] I have written unit tests for the changes (if applicable)
- [ ] I have tested the changes locally and ensured they work as expected
- [ ] All commits are signed with DCO (`git commit -s`)

---

### Screenshots or Logs (if applicable)

<img width="1920" height="919" alt="image" src="https://github.com/user-attachments/assets/94237885-2d21-4135-8400-67e6c14fa933" />
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/b6ee6af1-52ed-4311-ba71-ba3c769ffe74" />

---

### 👀 Reviewer Notes

_Add any special notes for the reviewer here_
