### PR TITLE
📊 ACMM: GA4 event tracking which repos get scanned

### DIFF
--- a/web/src/components/acmm/ACMMProvider.tsx
+++ b/web/src/components/acmm/ACMMProvider.tsx
@@ -10,6 +10,8 @@ import { createContext, useCallback, useContext, useEffect, useMemo, useRef, use
 import type { ReactNode } from 'react'
 import { useCachedACMMScan, type UseACMMScanResult } from '../../hooks/useCachedACMMScan'
 import { isACMMIntroDismissed } from './ACMMIntroModal'
+import { emitACMMScanned } from '../../lib/analytics'
+import { ALL_CRITERIA } from '../../lib/acmm/sources'
 
 const DEFAULT_REPO = 'kubestellar/console'
 const SELECTED_REPO_KEY = 'kubestellar-acmm-selected-repo'
@@ -127,6 +129,18 @@ export function ACMMProvider({ children }: { children: ReactNode }) {
       setTargetLevelState(Math.min(MAX_LEVEL, scan.level.level + 1))
     }
   }, [scan.level.level])
+
+  // GA4: fire ksc_acmm_scanned when a scan completes with data.
+  const lastEmittedRepo = useRef('')
+  useEffect(() => {
+    const detectedCount = scan.data.detectedIds instanceof Set
+      ? scan.data.detectedIds.size
+      : (scan.data.detectedIds || []).length // ai-quality-ignore
+    if (detectedCount > 0 && repo !== lastEmittedRepo.current) {
+      lastEmittedRepo.current = repo
+      emitACMMScanned(repo, scan.level.level, detectedCount, ALL_CRITERIA.length)
+    }
+  }, [repo, scan.level.level, scan.data.detectedIds])
 
   const setTargetLevel = useCallback((next: number) => {
     userOverrodeLevel.current = true

--- a/web/src/lib/analytics.ts
+++ b/web/src/lib/analytics.ts
@@ -2235,3 +2235,11 @@ export function emitWhatsNewUpdateClicked(tag: string, installMethod: string) {
 export function emitWhatsNewRemindLater(tag: string, duration: string) {
   send('ksc_whats_new_remind_later', { release_tag: tag, snooze_duration: duration })
 }
+
+// ── ACMM Dashboard ──────────────────────────────────────────────────
+
+/** Fired when a user scans a repo on the ACMM dashboard. Tracks which
+ *  repos people are scanning and what level they land at. */
+export function emitACMMScanned(repo: string, level: number, detected: number, total: number) {
+  send('ksc_acmm_scanned', { repo, acmm_level: level, detected, total })
+}


### PR DESCRIPTION
## Summary

Fires `ksc_acmm_scanned` GA4 event when a user scans a repo on the ACMM dashboard. Answers "which repos are people scanning?" without needing to manually check Netlify blob cache.

**Event:** `ksc_acmm_scanned`
**Params:** `repo`, `acmm_level`, `detected`, `total`

Deduped per repo change (ref tracks last emitted repo — won't re-fire on page revisits or data refreshes for the same repo).

## Test plan

- [ ] Open /acmm → `ksc_acmm_scanned` fires in GA4 with kubestellar/console (default repo)
- [ ] Switch to ublue-os/bluefin → fires again with new repo
- [ ] Refresh page (same repo) → does NOT re-fire
- [ ] Check GA4 Events → ksc_acmm_scanned shows repo parameter