### PR TITLE
🐛 fix: useGitHubRewards localStorage safety + cookie-only test (#8497)

### DIFF
--- a/web/src/hooks/__tests__/useGitHubRewards.test.ts
+++ b/web/src/hooks/__tests__/useGitHubRewards.test.ts
@@ -19,6 +19,7 @@ vi.mock('../../lib/auth', () => ({ useAuth: () => mockUseAuth() }))
 
 // Constants are simple values -- we mirror them here for localStorage setup.
 const STORAGE_KEY_TOKEN = 'token'
+const STORAGE_KEY_HAS_SESSION = 'kc-has-session'
 /** Per-user cache key format matching the hook's userCacheKey() */
 function userCacheKey(login: string): string {
   return `github-rewards-cache:${login}`
@@ -280,5 +281,58 @@ describe('useGitHubRewards', () => {
 
     const fetchUrl = vi.mocked(global.fetch).mock.calls[0][0] as string
     expect(fetchUrl).toContain('login=octocat')
+  })
+
+  // 9. Cookie-only session: no token but STORAGE_KEY_HAS_SESSION is set
+  it('fetches when token is absent but cookie session hint is set', async () => {
+    localStorage.removeItem(STORAGE_KEY_TOKEN)
+    localStorage.setItem(STORAGE_KEY_HAS_SESSION, 'true')
+
+    const apiResponse = makeSampleResponse({ total_points: 2000 })
+    vi.mocked(global.fetch).mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve(apiResponse),
+    } as Response)
+
+    const { useGitHubRewards } = await import('../useGitHubRewards')
+    const { result } = renderHook(() => useGitHubRewards())
+
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalled()
+      expect(result.current.githubRewards).not.toBeNull()
+      expect(result.current.githubRewards!.total_points).toBe(2000)
+    })
+
+    // Verify no Authorization header was sent (cookie-only path)
+    const fetchInit = vi.mocked(global.fetch).mock.calls[0][1] as RequestInit
+    expect(fetchInit.headers).toBeDefined()
+    const headers = fetchInit.headers as Record<string, string>
+    expect(headers['Authorization']).toBeUndefined()
+    // credentials: 'include' must be set for cookie transport
+    expect(fetchInit.credentials).toBe('include')
+  })
+
+  // 10. localStorage.getItem throwing does not crash the hook
+  it('handles localStorage throwing without crashing', async () => {
+    // Remove the token set in beforeEach so we start clean
+    localStorage.removeItem(STORAGE_KEY_TOKEN)
+
+    // Simulate restricted browser mode where localStorage throws on read.
+    // Use vi.spyOn so jsdom's internal binding is properly intercepted.
+    const getItemSpy = vi.spyOn(Storage.prototype, 'getItem').mockImplementation(() => {
+      throw new DOMException('Access denied')
+    })
+
+    const { useGitHubRewards } = await import('../useGitHubRewards')
+    const { result } = renderHook(() => useGitHubRewards())
+
+    await act(async () => { /* flush effects */ })
+
+    // Should not crash — just skip fetching since both token and session are unavailable
+    expect(result.current.githubRewards).toBeNull()
+    expect(result.current.isLoading).toBe(false)
+    expect(global.fetch).not.toHaveBeenCalled()
+
+    getItemSpy.mockRestore()
   })
 })

--- a/web/src/hooks/useGitHubRewards.ts
+++ b/web/src/hooks/useGitHubRewards.ts
@@ -109,9 +109,12 @@ export function useGitHubRewards() {
     // exclusively in the HttpOnly kc_auth cookie with no token in
     // localStorage. Check both the token AND the session hint so we
     // don't bail out for cookie-only authenticated users.
-    const token = localStorage.getItem(STORAGE_KEY_TOKEN)
+    // Both reads are wrapped because localStorage can throw in
+    // restricted browser modes (private browsing, disabled storage).
+    let token: string | null = null
     let hasCookieSession = false
     try {
+      token = localStorage.getItem(STORAGE_KEY_TOKEN)
       hasCookieSession = localStorage.getItem(STORAGE_KEY_HAS_SESSION) === 'true'
     } catch {
       // localStorage unavailable — fall through


### PR DESCRIPTION
Fixes #8497

## Summary
- Wraps `localStorage.getItem(STORAGE_KEY_TOKEN)` inside the existing try/catch block so it cannot throw in restricted browser modes (private browsing, disabled storage)
- Adds test case for the cookie-only session fallback path (no token, `STORAGE_KEY_HAS_SESSION` set)
- Adds test case verifying `localStorage` throwing does not crash the hook

## Test plan
- [x] All 13 `useGitHubRewards` tests pass (including 2 new ones)
- [x] `npm run build` passes
- [x] `npm run lint` clean on changed files