### PR TITLE
🐛 fix: ACMM GA4 event dedup + dead code cleanup (#8498)

### DIFF
--- a/web/src/components/acmm/ACMMProvider.tsx
+++ b/web/src/components/acmm/ACMMProvider.tsx
@@ -130,16 +130,23 @@ export function ACMMProvider({ children }: { children: ReactNode }) {
     }
   }, [scan.level.level])
 
-  // GA4: fire ksc_acmm_scanned when a scan completes with data.
-  const lastEmittedRepo = useRef('')
+  // GA4: fire ksc_acmm_scanned once per repo per session (including
+  // zero-criteria scans so we can see which repos people scan).
+  const GA4_EMITTED_KEY = 'kubestellar-acmm-ga4-emitted'
   useEffect(() => {
-    const detectedCount = scan.data.detectedIds instanceof Set
-      ? scan.data.detectedIds.size
-      : (scan.data.detectedIds || []).length // ai-quality-ignore
-    if (detectedCount > 0 && repo !== lastEmittedRepo.current) {
-      lastEmittedRepo.current = repo
-      emitACMMScanned(repo, scan.level.level, detectedCount, ALL_CRITERIA.length)
+    // Wait until the scan has resolved (level is populated).
+    if (!scan.level.level) return
+    const detectedCount = (scan.data.detectedIds || []).length
+    // Dedupe within the browser session via sessionStorage so remounts
+    // and page refreshes don't re-fire for the same repo.
+    try {
+      const emitted = JSON.parse(sessionStorage.getItem(GA4_EMITTED_KEY) || '[]') as string[]
+      if (emitted.includes(repo)) return
+      sessionStorage.setItem(GA4_EMITTED_KEY, JSON.stringify([...emitted, repo]))
+    } catch {
+      // sessionStorage unavailable — emit anyway, accept possible dupe
     }
+    emitACMMScanned(repo, scan.level.level, detectedCount, ALL_CRITERIA.length)
   }, [repo, scan.level.level, scan.data.detectedIds])
 
   const setTargetLevel = useCallback((next: number) => {


### PR DESCRIPTION
Fixes #8498

## Summary
- **Zero-criteria tracking**: Removed `detectedCount > 0` gate so scans that detect zero criteria still emit `ksc_acmm_scanned` — enables "which repos are people scanning?" analytics
- **Session-persistent dedup**: Replaced `useRef` with `sessionStorage` for `lastEmittedRepo` so GA4 events don't re-fire on page refresh or component remount within the same session
- **Dead code removal**: Removed `instanceof Set` branch on `scan.data.detectedIds` — the data always arrives as an array from the API, never a Set

## Test plan
- [ ] Scan a repo with detected criteria — GA4 event fires once
- [ ] Refresh page, same repo — event does NOT re-fire (check sessionStorage key `kubestellar-acmm-ga4-emitted`)
- [ ] Scan a repo with zero detected criteria — event still fires
- [ ] Switch to a new repo — event fires for the new repo
- [ ] Open new tab (new session) — event fires again for same repo (sessionStorage is per-tab)