### PR TITLE
🧪 test: coverage push round 7 — releaseNotesComponents + useNightlyE2EData (+15 tests)

### DIFF
--- a/web/src/hooks/__tests__/useNightlyE2EData.test.tsx
+++ b/web/src/hooks/__tests__/useNightlyE2EData.test.tsx
@@ -1,0 +1,98 @@
+/**
+ * Tests for useNightlyE2EData — verifies the hook passes correct
+ * config to useCache (key, demoData shape, initialData from localStorage).
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook } from '@testing-library/react'
+
+const lastCacheArgs: { current: Record<string, unknown> | null } = { current: null }
+
+vi.mock('../../lib/cache', () => ({
+  useCache: (args: Record<string, unknown>) => {
+    lastCacheArgs.current = args
+    return {
+      data: args.demoData,
+      isLoading: false,
+      isRefreshing: false,
+      isDemoFallback: true,
+      error: null,
+      isFailed: false,
+      consecutiveFailures: 0,
+      lastRefresh: null,
+      refetch: vi.fn(),
+    }
+  },
+}))
+vi.mock('../../lib/llmd/nightlyE2EDemoData', () => ({
+  generateDemoNightlyData: () => [{ guide: 'demo', acronym: 'DM', platform: 'test', runs: [] }],
+}))
+vi.mock('../../lib/demoMode', () => ({
+  isNetlifyDeployment: false,
+}))
+vi.mock('../../lib/constants', () => ({
+  STORAGE_KEY_TOKEN: 'token',
+}))
+vi.mock('../../lib/constants/network', () => ({
+  FETCH_DEFAULT_TIMEOUT_MS: 30000,
+}))
+
+describe('useNightlyE2EData', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    lastCacheArgs.current = null
+  })
+
+  it('passes correct cache key and demo data shape', async () => {
+    vi.resetModules()
+    const { useNightlyE2EData } = await import('../useNightlyE2EData')
+    renderHook(() => useNightlyE2EData())
+
+    expect(lastCacheArgs.current).not.toBeNull()
+    expect(lastCacheArgs.current?.key).toBe('nightly-e2e-status')
+    const demo = lastCacheArgs.current?.demoData as { isDemo: boolean; guides: unknown[] }
+    expect(demo.isDemo).toBe(true)
+    expect(demo.guides.length).toBeGreaterThan(0)
+  })
+
+  it('reads initialData from localStorage when valid data cached', async () => {
+    const cached = {
+      guides: [{ guide: 'cached', acronym: 'C', platform: 'ocp', runs: [] }],
+      isDemo: false,
+    }
+    localStorage.setItem('nightly-e2e-cache', JSON.stringify(cached))
+
+    vi.resetModules()
+    const { useNightlyE2EData } = await import('../useNightlyE2EData')
+    renderHook(() => useNightlyE2EData())
+
+    const init = lastCacheArgs.current?.initialData as { guides: unknown[]; isDemo: boolean }
+    expect(init.guides.length).toBe(1)
+    expect(init.isDemo).toBe(false)
+  })
+
+  it('returns empty guides when localStorage is malformed', async () => {
+    localStorage.setItem('nightly-e2e-cache', 'not json')
+
+    vi.resetModules()
+    const { useNightlyE2EData } = await import('../useNightlyE2EData')
+    renderHook(() => useNightlyE2EData())
+
+    const init = lastCacheArgs.current?.initialData as { guides: unknown[] }
+    expect(init.guides).toEqual([])
+  })
+
+  it('returns empty guides when cached data has isDemo=true', async () => {
+    // Demo-flagged cache should be ignored on next load
+    localStorage.setItem('nightly-e2e-cache', JSON.stringify({
+      guides: [{ guide: 'demo' }],
+      isDemo: true,
+    }))
+
+    vi.resetModules()
+    const { useNightlyE2EData } = await import('../useNightlyE2EData')
+    renderHook(() => useNightlyE2EData())
+
+    const init = lastCacheArgs.current?.initialData as { guides: unknown[] }
+    expect(init.guides).toEqual([])
+  })
+})

--- a/web/src/lib/markdown/__tests__/releaseNotesComponents.test.tsx
+++ b/web/src/lib/markdown/__tests__/releaseNotesComponents.test.tsx
@@ -1,0 +1,132 @@
+/**
+ * Tests for releaseNotesComponents.tsx — the custom markdown component map.
+ * Renders each component to verify it produces valid JSX without crashing.
+ */
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { buildReleaseNotesComponents } from '../releaseNotesComponents'
+
+// Mock CodeBlock — releaseNotesComponents just passes props through
+vi.mock('../../../components/ui/CodeBlock', () => ({
+  CodeBlock: ({ children, language }: { children: string; language: string }) => (
+    <pre data-lang={language}>{children}</pre>
+  ),
+}))
+
+const components = buildReleaseNotesComponents('sm')
+
+describe('buildReleaseNotesComponents', () => {
+  it('returns an object with all expected element keys', () => {
+    const keys = Object.keys(components)
+    for (const expected of ['code', 'a', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'p', 'ul', 'ol', 'li', 'blockquote', 'strong', 'hr', 'table', 'thead', 'th', 'td']) {
+      expect(keys).toContain(expected)
+    }
+  })
+
+  it('accepts sm/base/lg font sizes without error', () => {
+    for (const size of ['sm', 'base', 'lg'] as const) {
+      const c = buildReleaseNotesComponents(size)
+      expect(c).toBeDefined()
+    }
+  })
+})
+
+describe('code component', () => {
+  it('renders inline code when no language class', () => {
+    const Code = components.code
+    render(<Code>hello</Code>)
+    expect(screen.getByText('hello').tagName).toBe('CODE')
+  })
+
+  it('renders CodeBlock for fenced code with language class', () => {
+    const Code = components.code
+    render(<Code className="language-bash">echo hi</Code>)
+    const pre = screen.getByText('echo hi')
+    expect(pre.tagName).toBe('PRE')
+    expect(pre.getAttribute('data-lang')).toBe('bash')
+  })
+})
+
+describe('link component', () => {
+  const Link = components.a
+
+  it('renders a safe link for https URLs', () => {
+    render(<Link href="https://example.com">click</Link>)
+    const el = screen.getByText('click')
+    expect(el.tagName).toBe('A')
+    expect(el.getAttribute('href')).toBe('https://example.com')
+    expect(el.getAttribute('target')).toBe('_blank')
+  })
+
+  it('renders a span for unsafe/missing hrefs', () => {
+    render(<Link href="javascript:alert(1)">bad</Link>)
+    expect(screen.getByText('bad').tagName).toBe('SPAN')
+  })
+
+  it('renders a span when href is undefined', () => {
+    render(<Link>no link</Link>)
+    expect(screen.getByText('no link').tagName).toBe('SPAN')
+  })
+})
+
+describe('heading components', () => {
+  it('renders h1-h6 with children', () => {
+    for (const [tag, Comp] of [
+      ['H1', components.h1],
+      ['H2', components.h2],
+      ['H3', components.h3],
+      ['H4', components.h4],
+      ['H5', components.h5],
+      ['H6', components.h6],
+    ] as const) {
+      render(<Comp>{`heading-${tag}`}</Comp>)
+      expect(screen.getByText(`heading-${tag}`).tagName).toBe(tag)
+    }
+  })
+})
+
+describe('block elements', () => {
+  it('renders p, ul, ol, li, blockquote, strong', () => {
+    const P = components.p
+    const Ul = components.ul
+    const Li = components.li
+    const Strong = components.strong
+
+    render(<P>paragraph</P>)
+    expect(screen.getByText('paragraph').tagName).toBe('P')
+
+    render(<Ul><Li>item</Li></Ul>)
+    expect(screen.getByText('item').tagName).toBe('LI')
+
+    render(<Strong>bold</Strong>)
+    expect(screen.getByText('bold').tagName).toBe('STRONG')
+  })
+
+  it('renders hr without crashing', () => {
+    const Hr = components.hr
+    const { container } = render(<Hr />)
+    expect(container.querySelector('hr')).toBeTruthy()
+  })
+})
+
+describe('table components', () => {
+  it('renders a complete table structure', () => {
+    const Table = components.table
+    const Thead = components.thead
+    const Th = components.th
+    const Td = components.td
+
+    render(
+      <Table>
+        <Thead>
+          <tr><Th>Header</Th></tr>
+        </Thead>
+        <tbody>
+          <tr><Td>Cell</Td></tr>
+        </tbody>
+      </Table>,
+    )
+    expect(screen.getByText('Header').tagName).toBe('TH')
+    expect(screen.getByText('Cell').tagName).toBe('TD')
+  })
+})


### PR DESCRIPTION
## Summary

Seventh round of coverage push toward 95%.

| File | Before | Tests added |
|---|---|---|
| \`lib/markdown/releaseNotesComponents.tsx\` | 4% (1/24) | 11 |
| \`hooks/useNightlyE2EData.ts\` | 45% (18/40) | 4 |

**Total:** 15 new tests, 230 lines.

## Test plan

- [x] All 15 pass locally
- [ ] Coverage Suite reports improvement

🤖 Generated with [Claude Code](https://claude.com/claude-code)