### PR TITLE
🐛 Fix: What's New button does nothing on click (kill-switch removal)

### DIFF
--- a/web/src/components/layout/navbar/UpdateIndicator.tsx
+++ b/web/src/components/layout/navbar/UpdateIndicator.tsx
@@ -4,7 +4,7 @@ import { Download } from 'lucide-react'
 import { useVersionCheck } from '../../../hooks/useVersionCheck'
 import { useFeatureHints } from '../../../hooks/useFeatureHints'
 import { FeatureHintTooltip } from '../../ui/FeatureHintTooltip'
-import { WhatsNewModal, isUpdateSnoozed, isKillSwitchEnabled } from '../../updates/WhatsNewModal'
+import { WhatsNewModal, isUpdateSnoozed } from '../../updates/WhatsNewModal'
 import { isDemoMode } from '../../../lib/demoMode'
 import { useToast } from '../../ui/Toast'
 import { emitWhatsNewModalOpened } from '../../../lib/analytics'
@@ -44,21 +44,6 @@ export function UpdateIndicator() {
 
   if (!isDeveloperUpdate && !latestRelease) {
     return null
-  }
-
-  if (isKillSwitchEnabled()) {
-    return (
-      <button
-        onClick={updateHint.action}
-        className="flex items-center gap-2 px-2 py-1.5 h-9 rounded-lg bg-green-500/10 text-green-400 hover:bg-green-500/20 transition-colors"
-        title={isDeveloperUpdate
-          ? `New commit: ${devSHA?.slice(0, 7) ?? 'unknown'}`
-          : t('update.availableTag', { tag: latestRelease?.tag ?? '' })}
-      >
-        <Download className="w-4 h-4" />
-        <span className="w-2 h-2 bg-green-400 rounded-full animate-pulse" />
-      </button>
-    )
   }
 
   return (

--- a/web/src/components/updates/WhatsNewModal.tsx
+++ b/web/src/components/updates/WhatsNewModal.tsx
@@ -14,7 +14,6 @@ import { FETCH_DEFAULT_TIMEOUT_MS } from '../../lib/constants'
 import { emitWhatsNewUpdateClicked, emitWhatsNewRemindLater } from '../../lib/analytics'
 
 const SNOOZE_STORAGE_KEY = 'kc-update-snoozed'
-const KILL_SWITCH_KEY = 'kc-whats-new-modal-disabled'
 
 const SNOOZE_DURATION_1H_MS = 60 * 60 * 1000
 const SNOOZE_DURATION_1D_MS = 24 * 60 * 60 * 1000
@@ -31,13 +30,6 @@ export function isUpdateSnoozed(): boolean {
   }
 }
 
-export function isKillSwitchEnabled(): boolean {
-  try {
-    return localStorage.getItem(KILL_SWITCH_KEY) === '1'
-  } catch {
-    return false
-  }
-}
 
 function snoozeUpdate(durationMs: number) {
   try {

--- a/web/src/components/updates/WhatsNewModal.tsx
+++ b/web/src/components/updates/WhatsNewModal.tsx
@@ -15,6 +15,10 @@ import { emitWhatsNewUpdateClicked, emitWhatsNewRemindLater } from '../../lib/an
 
 const SNOOZE_STORAGE_KEY = 'kc-update-snoozed'
 
+// Clean up the removed kill-switch key so users who had it set during
+// development don't get a dead button. Runs once on module load.
+try { localStorage.removeItem('kc-whats-new-modal-disabled') } catch { /* ignore */ }
+
 const SNOOZE_DURATION_1H_MS = 60 * 60 * 1000
 const SNOOZE_DURATION_1D_MS = 24 * 60 * 60 * 1000
 const SNOOZE_DURATION_1W_MS = 7 * 24 * 60 * 60 * 1000


### PR DESCRIPTION
## Summary

The green update button in the navbar rendered a dead click when the kill-switch localStorage key was set. The kill-switch code path called `updateHint.action()` (tooltip dismiss) but never opened the `WhatsNewModal`.

Removed the kill-switch entirely — it was a rollout safety net from the initial What's New modal PR, the modal has been live with no regressions.

## Test plan

- [ ] Click green update button → What's New modal opens
- [ ] No `kc-whats-new-modal-disabled` localStorage check needed
- [ ] Snooze still works (separate mechanism, untouched)