### PR TITLE
🐛 fix: sorting/filtering data mismatch in events + Helm cards (#8520, #8521, #8522)

### DIFF
--- a/web/src/components/cards/HelmHistory.tsx
+++ b/web/src/components/cards/HelmHistory.tsx
@@ -368,14 +368,14 @@ export function HelmHistory({ config }: HelmHistoryProps) {
 
                 {/* History entries */}
                 <div className="space-y-3">
-                  {history.map((entry, idx) => {
+                  {history.map((entry) => {
                     const StatusIcon = getStatusIcon(entry.status)
                     const color = getStatusColor(entry.status)
                     const isCurrent = entry.status === 'deployed'
 
                     return (
                       <div
-                        key={idx}
+                        key={`${entry.revision}-${entry.chart}-${entry.updated}`}
                         className="relative pl-6 group cursor-pointer"
                         onClick={() => setModalEntry(entry)}
                         title={`Click to view details for revision ${entry.revision}`}

--- a/web/src/components/cards/RecentEvents.tsx
+++ b/web/src/components/cards/RecentEvents.tsx
@@ -163,9 +163,9 @@ export function RecentEvents() {
         </div>
       ) : (
         <div ref={containerRef} className="space-y-2" style={containerStyle}>
-          {paginatedItems.map((event, i) => (
+          {paginatedItems.map((event) => (
             <div
-              key={`${event.object}-${event.reason}-${i}`}
+              key={`${event.cluster}-${event.namespace}-${event.object}-${event.reason}-${event.lastSeen}`}
               className={`p-2 rounded-lg border ${
                 event.type === 'Warning'
                   ? 'bg-yellow-500/5 border-yellow-500/20'

--- a/web/src/components/cards/WarningEvents.tsx
+++ b/web/src/components/cards/WarningEvents.tsx
@@ -171,9 +171,9 @@ export function WarningEvents() {
         </div>
       ) : (
         <div ref={containerRef} className="space-y-2" style={containerStyle}>
-          {displayedEvents.map((event, i) => (
+          {displayedEvents.map((event) => (
             <div
-              key={`${event.object}-${event.reason}-${i}`}
+              key={`${event.cluster}-${event.namespace}-${event.object}-${event.reason}-${event.lastSeen}`}
               className="p-2 rounded-lg bg-yellow-500/5 border border-yellow-500/20"
             >
               <div className="flex items-start gap-2">

--- a/web/src/lib/cards/cardHooks.ts
+++ b/web/src/lib/cards/cardHooks.ts
@@ -342,17 +342,15 @@ export function useCardSort<T, S extends string>(
     setSortDirection(prev => (prev === 'asc' ? 'desc' : 'asc'))
   }
 
-  const sorted = (() => {
+  const sorted = useMemo(() => {
     const comparator = comparators?.[sortBy]
-    if (!comparator) return items
+    if (!comparator) return [...(items || [])]
 
-    const sortedItems = [...items].sort((a, b) => {
+    return [...(items || [])].sort((a, b) => {
       const result = comparator(a, b)
       return sortDirection === 'asc' ? result : -result
     })
-
-    return sortedItems
-  })()
+  }, [items, comparators, sortBy, sortDirection])
 
   return {
     sorted,


### PR DESCRIPTION
## Summary
- Replace index-based React keys with stable identity keys in RecentEvents, WarningEvents, and HelmHistory cards so DOM nodes track correct items after re-sort/filter
- Wrap `useCardSort` sort computation in `useMemo` for stable references — only recomputes when inputs change
- Guard sort input arrays against `undefined`

## Root cause
All three cards used array index (`i` / `idx`) in their React `key` prop. After sorting or filtering changed the order, React reused DOM nodes for the wrong items, causing visual mismatches between displayed content and actual list position.

## What changed
| File | Change |
|------|--------|
| `RecentEvents.tsx` | Key: `cluster-namespace-object-reason-lastSeen` instead of `object-reason-i` |
| `WarningEvents.tsx` | Key: `cluster-namespace-object-reason-lastSeen` instead of `object-reason-i` |
| `HelmHistory.tsx` | Key: `revision-chart-updated` instead of `idx` |
| `cardHooks.ts` | `useCardSort` sort wrapped in `useMemo`; undefined guard on items |

Fixes #8520, Fixes #8521, Fixes #8522