### PR TITLE
🐛 fix: GPU bars, warning filters, PVC status, cluster selection UX (#8511, #8515, #8516, #8519)

### DIFF
--- a/web/src/components/cards/GPUInventory.tsx
+++ b/web/src/components/cards/GPUInventory.tsx
@@ -28,8 +28,12 @@ const SORT_OPTIONS = [
 
 type GPUNode = ReturnType<typeof useCachedGPUNodes>['nodes'][number]
 
+/** Safe GPU utilization ratio — returns 0 when gpuCount is zero to avoid NaN. */
+const safeGpuUtilization = (node: GPUNode): number =>
+  node.gpuCount > 0 ? (node.gpuAllocated / node.gpuCount) * 100 : 0
+
 const GPU_SORT_COMPARATORS: Record<SortByOption, (a: GPUNode, b: GPUNode) => number> = {
-  utilization: (a, b) => (a.gpuAllocated / a.gpuCount) - (b.gpuAllocated / b.gpuCount),
+  utilization: (a, b) => safeGpuUtilization(a) - safeGpuUtilization(b),
   name: commonComparators.string<GPUNode>('name'),
   cluster: commonComparators.string<GPUNode>('cluster'),
   gpuType: commonComparators.string<GPUNode>('gpuType'),
@@ -226,7 +230,7 @@ export function GPUInventory({ config }: GPUInventoryProps) {
               gpuType: node.gpuType,
               gpuCount: node.gpuCount,
               gpuAllocated: node.gpuAllocated,
-              utilization: (node.gpuAllocated / node.gpuCount) * 100,
+              utilization: safeGpuUtilization(node),
             })}
             className="p-3 rounded-lg bg-secondary/30 hover:bg-secondary/50 transition-colors cursor-pointer group"
           >
@@ -246,12 +250,18 @@ export function GPUInventory({ config }: GPUInventoryProps) {
                 </span>
               </div>
             </div>
-            <div className="mt-2 h-1.5 bg-secondary rounded-full overflow-hidden">
-              <div
-                className="h-full bg-purple-500 transition-all"
-                style={{ width: `${(node.gpuAllocated / node.gpuCount) * 100}%` }}
-              />
-            </div>
+            {node.gpuCount > 0 ? (
+              <div className="mt-2 h-1.5 bg-secondary rounded-full overflow-hidden">
+                <div
+                  className="h-full bg-purple-500 transition-all"
+                  style={{ width: `${safeGpuUtilization(node)}%` }}
+                />
+              </div>
+            ) : (
+              <p className="mt-2 text-xs text-muted-foreground italic">
+                {t('gpuInventory.noGPUsAvailable')}
+              </p>
+            )}
           </div>
         ))}
       </div>

--- a/web/src/components/cards/StorageOverview.tsx
+++ b/web/src/components/cards/StorageOverview.tsx
@@ -74,7 +74,10 @@ export function StorageOverview() {
     const totalPVCs = filteredPVCs.length
     const boundPVCs = filteredPVCs.filter(p => p.status === 'Bound').length
     const pendingPVCs = filteredPVCs.filter(p => p.status === 'Pending').length
-    const failedPVCs = totalPVCs - boundPVCs - pendingPVCs
+    // Only count PVCs with explicitly failed statuses — Released, Terminating,
+    // and Available are valid lifecycle states, not failures (#8516).
+    const PVC_FAILED_STATUSES = ['Failed', 'Lost']
+    const failedPVCs = filteredPVCs.filter(p => PVC_FAILED_STATUSES.includes(p.status || '')).length
 
     // Group by storage class
     const storageClasses = new Map<string, number>()

--- a/web/src/components/cards/WarningEvents.tsx
+++ b/web/src/components/cards/WarningEvents.tsx
@@ -109,6 +109,19 @@ export function WarningEvents() {
     )
   }
 
+  /* If there are no warning events at all, show a clean empty state without filters */
+  if (warningOnly.length === 0) {
+    return (
+      <div className="h-full flex flex-col content-loaded">
+        <div className="flex-1 flex flex-col items-center justify-center text-center py-6">
+          <CheckCircle2 className="w-8 h-8 mx-auto mb-2 text-green-400 opacity-50" />
+          <p className="text-sm text-foreground font-medium">{t('warningEvents.noWarnings')}</p>
+          <p className="text-xs text-muted-foreground mt-1">{t('warningEvents.noWarningsHint')}</p>
+        </div>
+      </div>
+    )
+  }
+
   return (
     <div className="space-y-3">
       {/* Header controls */}
@@ -163,11 +176,11 @@ export function WarningEvents() {
         placeholder={t('common.searchWarnings')}
       />
 
-      {/* Warning events list */}
+      {/* Warning events list — filtered by search/cluster may yield 0 even when warningOnly > 0 */}
       {totalItems === 0 ? (
         <div className="text-center py-6">
           <CheckCircle2 className="w-8 h-8 mx-auto mb-2 text-green-400 opacity-50" />
-          <p className="text-sm text-muted-foreground">No warnings</p>
+          <p className="text-sm text-muted-foreground">{t('warningEvents.noMatchingWarnings')}</p>
         </div>
       ) : (
         <div ref={containerRef} className="space-y-2" style={containerStyle}>

--- a/web/src/components/compute/Compute.tsx
+++ b/web/src/components/compute/Compute.tsx
@@ -171,14 +171,16 @@ export function Compute() {
 
   const getStatValue = (blockId: string) => createMergedStatValueGetter(getDashboardStatValue, getUniversalStatValue)(blockId)
 
+  /** Maximum number of clusters that can be selected for side-by-side comparison. */
+  const MAX_COMPARISON_CLUSTERS = 4
+
   // Cluster comparison handlers
   const toggleClusterSelection = (clusterName: string) => {
     setSelectedForComparison(prev => {
       if (prev.includes(clusterName)) {
         return prev.filter(name => name !== clusterName)
       }
-      // Max 4 clusters
-      if (prev.length >= 4) return prev
+      if (prev.length >= MAX_COMPARISON_CLUSTERS) return prev
       return [...prev, clusterName]
     })
   }
@@ -212,6 +214,12 @@ export function Compute() {
             <span className="text-xs text-muted-foreground">
               {t('compute.countSelected', { count: selectedForComparison.length })}
             </span>
+            {selectedForComparison.length >= MAX_COMPARISON_CLUSTERS && (
+              <span className="flex items-center gap-1 text-xs text-yellow-400">
+                <AlertCircle className="w-3 h-3" />
+                {t('compute.maxClustersReached', { max: MAX_COMPARISON_CLUSTERS })}
+              </span>
+            )}
             <button
               onClick={clearSelection}
               className="text-xs text-muted-foreground hover:text-foreground transition-colors"
@@ -236,7 +244,7 @@ export function Compute() {
         <div id="cluster-comparison-list" className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-3">
           {filteredClusters.map((cluster) => {
             const isSelected = selectedForComparison.includes(cluster.name)
-            const isDisabled = !isSelected && selectedForComparison.length >= 4
+            const isDisabled = !isSelected && selectedForComparison.length >= MAX_COMPARISON_CLUSTERS
 
             return (
               <button

--- a/web/src/locales/en/cards.json
+++ b/web/src/locales/en/cards.json
@@ -2250,7 +2250,8 @@
     "gpuCount_other": "{{count}} GPUs",
     "searchPlaceholder": "Search GPU nodes...",
     "inUse": "In Use",
-    "usingSimulatedData": "Using simulated data"
+    "usingSimulatedData": "Using simulated data",
+    "noGPUsAvailable": "No GPUs available"
   },
   "gpuInventoryHistory": {
     "noData": "No GPU History",

--- a/web/src/locales/en/common.json
+++ b/web/src/locales/en/common.json
@@ -1518,7 +1518,13 @@
     "compareWithCount": "Compare ({{count}})",
     "selectForComparison": "Select {{name}} for comparison",
     "deselectForComparison": "Deselect {{name}} for comparison",
-    "noClustersAvailable": "No clusters available"
+    "noClustersAvailable": "No clusters available",
+    "maxClustersReached": "Maximum {{max}} clusters can be compared at once"
+  },
+  "warningEvents": {
+    "noWarnings": "No Warnings",
+    "noWarningsHint": "Warning events will appear here when detected",
+    "noMatchingWarnings": "No warnings match the current filters"
   },
   "drasi": {
     "configureSource": "Configure Source",


### PR DESCRIPTION
## Summary

- **#8511 GPU zero-state**: Nodes with `gpuCount=0` caused division-by-zero rendering broken/empty utilization bars. Now shows "No GPUs available" message and uses a safe utility function for all GPU utilization math.
- **#8515 Warning Events empty state**: Filters, search, and controls were shown even when there were zero warning events. Now shows a clean empty state without controls when `warningOnly` is empty.
- **#8516 PVC status classification**: `failedPVCs` was calculated as `total - bound - pending`, incorrectly counting Released/Terminating/Available PVCs as failed. Now only counts PVCs with explicit `Failed` or `Lost` status.
- **#8519 Cluster selection max feedback**: Selecting 4+ clusters for comparison silently blocked further selection. Now shows a yellow warning message when the max is reached and extracts the magic number `4` to a named constant `MAX_COMPARISON_CLUSTERS`.

Fixes #8511, Fixes #8515, Fixes #8516, Fixes #8519

## Test plan

- [ ] GPUInventory card: verify nodes with 0 GPUs show "No GPUs available" text instead of broken bar
- [ ] GPUInventory card: verify nodes with >0 GPUs still show correct utilization bar
- [ ] WarningEvents card: verify empty state (no warnings) shows clean message without filters
- [ ] WarningEvents card: verify when warnings exist, filters and list render normally
- [ ] StorageOverview card: verify Released/Terminating PVCs are not counted as failed
- [ ] StorageOverview card: verify actual Failed/Lost PVCs are still counted correctly
- [ ] Compute page: verify selecting 4 clusters shows max-reached warning message
- [ ] Compute page: verify deselecting a cluster removes the warning