### PR TITLE
🐛 fix: Pod Health time range selector + Cluster Health layout (#8512, #8518)

### DIFF
--- a/web/src/components/cards/ClusterHealth.tsx
+++ b/web/src/components/cards/ClusterHealth.tsx
@@ -264,7 +264,7 @@ export function ClusterHealth() {
       />
 
       {/* Stats */}
-      <div className="grid grid-cols-4 gap-2 mb-4">
+      <div className="grid grid-cols-2 sm:grid-cols-4 gap-2 mb-4">
         <div className="p-3 rounded-lg bg-green-500/10 border border-green-500/20 min-w-0 overflow-hidden" title={t('clusterHealth.healthyTooltip', { count: healthyClusters })}>
           <div className="flex items-center gap-1.5 mb-1 min-w-0">
             <CheckCircle className="w-4 h-4 text-green-400 shrink-0" />

--- a/web/src/components/cards/PodHealthTrend.tsx
+++ b/web/src/components/cards/PodHealthTrend.tsx
@@ -26,11 +26,19 @@ interface HealthPoint {
 
 type TimeRange = '15m' | '1h' | '6h' | '24h'
 
+/** Maximum data points to display per time range selection */
+const TIME_RANGE_MAX_POINTS: Record<TimeRange, number> = {
+  '15m': 15,
+  '1h': 20,
+  '6h': 24,
+  '24h': 24,
+}
+
 const TIME_RANGE_OPTIONS: { value: TimeRange; label: string; points: number }[] = [
-  { value: '15m', label: '15 min', points: 15 },
-  { value: '1h', label: '1 hour', points: 20 },
-  { value: '6h', label: '6 hours', points: 24 },
-  { value: '24h', label: '24 hours', points: 24 },
+  { value: '15m', label: '15 min', points: TIME_RANGE_MAX_POINTS['15m'] },
+  { value: '1h', label: '1 hour', points: TIME_RANGE_MAX_POINTS['1h'] },
+  { value: '6h', label: '6 hours', points: TIME_RANGE_MAX_POINTS['6h'] },
+  { value: '24h', label: '24 hours', points: TIME_RANGE_MAX_POINTS['24h'] },
 ]
 
 export function PodHealthTrend() {
@@ -235,12 +243,18 @@ export function PodHealthTrend() {
     }
   }, [currentStats, history.length])
 
+  // Slice history to the number of points allowed by the selected time range
+  const visibleHistory = useMemo(() => {
+    const maxPoints = TIME_RANGE_MAX_POINTS[timeRange]
+    return history.slice(-maxPoints)
+  }, [history, timeRange])
+
   const chartOption = useMemo(() => ({
     backgroundColor: 'transparent',
     grid: { left: 40, right: 5, top: 5, bottom: 25 },
     xAxis: {
       type: 'category' as const,
-      data: history.map(d => d.time),
+      data: visibleHistory.map(d => d.time),
       axisLabel: { color: CHART_TICK_COLOR, fontSize: 10 },
       axisLine: { lineStyle: { color: CHART_AXIS_STROKE } },
       axisTick: { show: false },
@@ -265,7 +279,7 @@ export function PodHealthTrend() {
         type: 'line',
         stack: 'total',
         smooth: true,
-        data: history.map(d => d.issues),
+        data: visibleHistory.map(d => d.issues),
         lineStyle: { color: '#f97316', width: 2 },
         itemStyle: { color: '#f97316' },
         areaStyle: {
@@ -279,7 +293,7 @@ export function PodHealthTrend() {
         type: 'line',
         stack: 'total',
         smooth: true,
-        data: history.map(d => d.pending),
+        data: visibleHistory.map(d => d.pending),
         lineStyle: { color: '#eab308', width: 2 },
         itemStyle: { color: '#eab308' },
         areaStyle: {
@@ -293,7 +307,7 @@ export function PodHealthTrend() {
         type: 'line',
         stack: 'total',
         smooth: true,
-        data: history.map(d => d.healthy),
+        data: visibleHistory.map(d => d.healthy),
         lineStyle: { color: '#22c55e', width: 2 },
         itemStyle: { color: '#22c55e' },
         areaStyle: {
@@ -305,7 +319,7 @@ export function PodHealthTrend() {
       {
         name: 'Issues (trend)',
         type: 'line',
-        data: history.map(d => d.issues),
+        data: visibleHistory.map(d => d.issues),
         smooth: true,
         lineStyle: { color: '#f97316', width: 2, type: 'dashed' as const },
         itemStyle: { color: '#f97316' },
@@ -313,7 +327,7 @@ export function PodHealthTrend() {
         silent: true,
       },
     ],
-  }), [history])
+  }), [visibleHistory])
 
   if (showSkeleton && history.length === 0) {
     return (


### PR DESCRIPTION
## Summary
- **Pod Health Trend (#8512):** Time range dropdown updated state but chart always rendered all history points. Added `visibleHistory` derived from `history.slice(-maxPoints)` keyed to the selected time range, so changing the dropdown now updates the chart data.
- **Cluster Health (#8518):** Stats grid used fixed `grid-cols-4` that compressed/clipped text on narrow viewports. Changed to `grid-cols-2 sm:grid-cols-4` so stats wrap to 2 columns on small screens.

Fixes #8512, Fixes #8518

## Test plan
- [ ] Open Pod Health Trend card, change time range dropdown — chart should update to show fewer/more data points
- [ ] Resize browser to narrow width — Cluster Health stat boxes should wrap to 2 columns without text clipping
- [ ] Verify demo mode still shows correct data with Demo badge