### PR TITLE
🧪 test: cluster dedup, card persistence, demo mode toggle (#8502, #8504, #8505)

### DIFF
--- a/web/src/hooks/mcp/__tests__/clusterDedup-regression.test.ts
+++ b/web/src/hooks/mcp/__tests__/clusterDedup-regression.test.ts
@@ -1,0 +1,266 @@
+/**
+ * Regression test: Cluster deduplication (#8502)
+ *
+ * Verifies that when two kubeconfig contexts point to the same physical cluster
+ * (same server URL), deduplication produces exactly one entry with the alias
+ * tracked. This is the end-to-end dedup pipeline: shareMetrics → deduplicate.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import type { ClusterInfo } from '../types'
+
+// ---------------------------------------------------------------------------
+// Hoisted mocks (same set as shared.test.ts)
+// ---------------------------------------------------------------------------
+const mockIsDemoMode = vi.hoisted(() => vi.fn(() => false))
+const mockIsDemoToken = vi.hoisted(() => vi.fn(() => false))
+const mockIsNetlifyDeployment = vi.hoisted(() => ({ value: false }))
+const mockSubscribeDemoMode = vi.hoisted(() => vi.fn())
+const mockIsBackendUnavailable = vi.hoisted(() => vi.fn(() => false))
+const mockReportAgentDataError = vi.hoisted(() => vi.fn())
+const mockReportAgentDataSuccess = vi.hoisted(() => vi.fn())
+const mockIsAgentUnavailable = vi.hoisted(() => vi.fn(() => true))
+const mockRegisterCacheReset = vi.hoisted(() => vi.fn())
+const mockTriggerAllRefetches = vi.hoisted(() => vi.fn())
+const mockResetFailuresForCluster = vi.hoisted(() => vi.fn())
+const mockResetAllCacheFailures = vi.hoisted(() => vi.fn())
+const mockKubectlProxyExec = vi.hoisted(() => vi.fn())
+const mockApiGet = vi.hoisted(() => vi.fn())
+
+vi.mock('../../../lib/api', () => ({
+  api: { get: mockApiGet },
+  isBackendUnavailable: mockIsBackendUnavailable,
+}))
+
+vi.mock('../../../lib/demoMode', () => ({
+  isDemoMode: mockIsDemoMode,
+  isDemoToken: mockIsDemoToken,
+  get isNetlifyDeployment() { return mockIsNetlifyDeployment.value },
+  subscribeDemoMode: mockSubscribeDemoMode,
+}))
+
+vi.mock('../../useLocalAgent', () => ({
+  reportAgentDataError: mockReportAgentDataError,
+  reportAgentDataSuccess: mockReportAgentDataSuccess,
+  isAgentUnavailable: mockIsAgentUnavailable,
+}))
+
+vi.mock('../../../lib/modeTransition', () => ({
+  registerCacheReset: mockRegisterCacheReset,
+  triggerAllRefetches: mockTriggerAllRefetches,
+}))
+
+vi.mock('../../../lib/cache', () => ({
+  resetFailuresForCluster: mockResetFailuresForCluster,
+  resetAllCacheFailures: mockResetAllCacheFailures,
+}))
+
+vi.mock('../../../lib/kubectlProxy', () => ({
+  kubectlProxy: { exec: mockKubectlProxyExec },
+}))
+
+vi.mock('../../../lib/constants', async () => {
+  const actual = await vi.importActual<typeof import('../../../lib/constants')>('../../../lib/constants')
+  return { ...actual }
+})
+
+vi.mock('../../../lib/constants/network', async () => {
+  const actual = await vi.importActual<typeof import('../../../lib/constants/network')>('../../../lib/constants/network')
+  return { ...actual }
+})
+
+// ---------------------------------------------------------------------------
+// Imports (after mocks)
+// ---------------------------------------------------------------------------
+import {
+  deduplicateClustersByServer,
+  shareMetricsBetweenSameServerClusters,
+} from '../shared'
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Build a minimal ClusterInfo with sensible defaults. */
+function makeCluster(overrides: Partial<ClusterInfo> = {}): ClusterInfo {
+  return {
+    name: 'test-cluster',
+    context: 'test-context',
+    server: 'https://test.example.com:6443',
+    healthy: true,
+    source: 'kubeconfig',
+    nodeCount: 3,
+    podCount: 20,
+    cpuCores: 8,
+    memoryGB: 32,
+    storageGB: 100,
+    ...overrides,
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Regression: two kubeconfig contexts → same physical cluster (#8502)
+// ---------------------------------------------------------------------------
+
+describe('Cluster deduplication regression (#8502)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('two contexts with identical server URL produce exactly one deduplicated entry', () => {
+    const SHARED_SERVER = 'https://api.prod.example.com:6443'
+
+    const contextA = makeCluster({
+      name: 'prod-admin',
+      context: 'prod-admin',
+      server: SHARED_SERVER,
+      cpuCores: 16,
+      memoryGB: 64,
+      nodeCount: 5,
+      podCount: 80,
+    })
+
+    const contextB = makeCluster({
+      name: 'prod-developer',
+      context: 'prod-developer',
+      server: SHARED_SERVER,
+      cpuCores: undefined,
+      memoryGB: undefined,
+      nodeCount: undefined,
+      podCount: undefined,
+    })
+
+    // Run the full pipeline: share metrics, then deduplicate
+    const withSharedMetrics = shareMetricsBetweenSameServerClusters([contextA, contextB])
+    const deduplicated = deduplicateClustersByServer(withSharedMetrics)
+
+    // Only one entry should remain
+    expect(deduplicated).toHaveLength(1)
+
+    const result = deduplicated[0]
+
+    // The shorter/friendlier name should be primary
+    expect(result.name).toBe('prod-admin')
+
+    // The other context should appear as an alias
+    expect(result.aliases).toContain('prod-developer')
+
+    // Metrics should come from the context that had them
+    expect(result.cpuCores).toBe(16)
+    expect(result.memoryGB).toBe(64)
+    expect(result.nodeCount).toBe(5)
+    expect(result.podCount).toBe(80)
+  })
+
+  it('three contexts pointing to the same server produce one entry with two aliases', () => {
+    const SHARED_SERVER = 'https://api.staging.example.com:6443'
+
+    const clusters = [
+      makeCluster({ name: 'staging', context: 'staging', server: SHARED_SERVER, cpuCores: 8 }),
+      makeCluster({ name: 'staging-readonly', context: 'staging-readonly', server: SHARED_SERVER, cpuCores: undefined }),
+      makeCluster({ name: 'staging-ci', context: 'staging-ci', server: SHARED_SERVER, cpuCores: undefined }),
+    ]
+
+    const deduplicated = deduplicateClustersByServer(
+      shareMetricsBetweenSameServerClusters(clusters)
+    )
+
+    expect(deduplicated).toHaveLength(1)
+    const EXPECTED_ALIAS_COUNT = 2
+    expect(deduplicated[0].aliases).toHaveLength(EXPECTED_ALIAS_COUNT)
+    expect(deduplicated[0].name).toBe('staging')
+  })
+
+  it('contexts pointing to different servers remain separate', () => {
+    const clusterA = makeCluster({ name: 'prod', server: 'https://api.prod.example.com:6443' })
+    const clusterB = makeCluster({ name: 'staging', server: 'https://api.staging.example.com:6443' })
+
+    const deduplicated = deduplicateClustersByServer(
+      shareMetricsBetweenSameServerClusters([clusterA, clusterB])
+    )
+
+    expect(deduplicated).toHaveLength(2)
+    expect(deduplicated[0].aliases).toEqual([])
+    expect(deduplicated[1].aliases).toEqual([])
+  })
+
+  it('mixed scenario: two pairs of duplicates plus one unique cluster', () => {
+    const SERVER_A = 'https://api.prod.example.com:6443'
+    const SERVER_B = 'https://api.dev.example.com:6443'
+    const SERVER_C = 'https://api.test.example.com:6443'
+
+    const clusters = [
+      makeCluster({ name: 'prod', server: SERVER_A }),
+      makeCluster({ name: 'prod-alt', server: SERVER_A }),
+      makeCluster({ name: 'dev', server: SERVER_B }),
+      makeCluster({ name: 'dev-alt', server: SERVER_B }),
+      makeCluster({ name: 'test', server: SERVER_C }),
+    ]
+
+    const deduplicated = deduplicateClustersByServer(
+      shareMetricsBetweenSameServerClusters(clusters)
+    )
+
+    const EXPECTED_UNIQUE_CLUSTERS = 3
+    expect(deduplicated).toHaveLength(EXPECTED_UNIQUE_CLUSTERS)
+
+    const names = deduplicated.map(c => c.name).sort()
+    expect(names).toEqual(['dev', 'prod', 'test'])
+  })
+
+  it('prefers user-friendly name over OpenShift auto-generated context', () => {
+    const SHARED_SERVER = 'https://api.pok-prod.openshiftapps.com:6443'
+
+    const friendlyCtx = makeCluster({
+      name: 'pok-prod',
+      context: 'pok-prod',
+      server: SHARED_SERVER,
+      cpuCores: undefined,
+      memoryGB: undefined,
+      storageGB: undefined,
+      nodeCount: undefined,
+      podCount: undefined,
+    })
+
+    const autoCtx = makeCluster({
+      name: 'default/api-pokprod001.openshiftapps.com:6443/kube:admin',
+      context: 'default/api-pokprod001.openshiftapps.com:6443/kube:admin',
+      server: SHARED_SERVER,
+      cpuCores: 96,
+      memoryGB: 384,
+    })
+
+    const deduplicated = deduplicateClustersByServer(
+      shareMetricsBetweenSameServerClusters([friendlyCtx, autoCtx])
+    )
+
+    expect(deduplicated).toHaveLength(1)
+    // Friendly name wins even though auto-generated has metrics
+    expect(deduplicated[0].name).toBe('pok-prod')
+    // Metrics are merged from the auto-generated context
+    expect(deduplicated[0].cpuCores).toBe(96)
+    expect(deduplicated[0].memoryGB).toBe(384)
+  })
+
+  it('health is true if ANY duplicate context reports healthy', () => {
+    const SHARED_SERVER = 'https://api.cluster.example.com:6443'
+
+    const unhealthy = makeCluster({
+      name: 'ctx-a',
+      server: SHARED_SERVER,
+      healthy: false,
+      reachable: false,
+    })
+    const healthy = makeCluster({
+      name: 'ctx-b',
+      server: SHARED_SERVER,
+      healthy: true,
+      reachable: true,
+    })
+
+    const deduplicated = deduplicateClustersByServer([unhealthy, healthy])
+
+    expect(deduplicated).toHaveLength(1)
+    expect(deduplicated[0].healthy).toBe(true)
+    expect(deduplicated[0].reachable).toBe(true)
+  })
+})

--- a/web/src/lib/__tests__/demoModeToggle-regression.test.ts
+++ b/web/src/lib/__tests__/demoModeToggle-regression.test.ts
@@ -1,0 +1,223 @@
+/**
+ * Regression test: Demo mode toggle badge behavior (#8505)
+ *
+ * Verifies that toggling demo mode on/off correctly:
+ * 1. Updates the global state (isDemoMode)
+ * 2. Persists to localStorage (drives badge on reload)
+ * 3. Dispatches the 'kc-demo-mode-change' CustomEvent (drives badge reactivity)
+ * 4. Notifies all subscribers (drives useDemoMode hook → CardWrapper badge)
+ * 5. Clears caches before toggling (shows loading skeletons during transition)
+ *
+ * The Demo badge and yellow outline in CardWrapper are driven by:
+ *   showDemoIndicator = !effectiveIsLoading && (effectiveIsDemoData || (isDemoMode && !childExplicitlyNotDemo))
+ * This test verifies the inputs to that expression change correctly.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+
+// ---------------------------------------------------------------------------
+// Constants (mirror source values)
+// ---------------------------------------------------------------------------
+const DEMO_MODE_STORAGE_KEY = 'kc-demo-mode'
+const DEMO_MODE_EVENT_NAME = 'kc-demo-mode-change'
+
+// ---------------------------------------------------------------------------
+// Mock clearAllRegisteredCaches so toggleDemoMode can call it
+// ---------------------------------------------------------------------------
+const mockClearAllRegisteredCaches = vi.hoisted(() => vi.fn())
+
+vi.mock('../modeTransition', () => ({
+  clearAllRegisteredCaches: mockClearAllRegisteredCaches,
+}))
+
+// ---------------------------------------------------------------------------
+// Imports (after mocks)
+// ---------------------------------------------------------------------------
+import {
+  isDemoMode,
+  setDemoMode,
+  toggleDemoMode,
+  subscribeDemoMode,
+  canToggleDemoMode,
+} from '../demoMode'
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('Demo mode toggle badge behavior (#8505)', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    vi.clearAllMocks()
+    // Ensure we start from a known state — demo mode off
+    setDemoMode(false, true)
+  })
+
+  afterEach(() => {
+    // Clean up — restore demo mode to off
+    setDemoMode(false, true)
+  })
+
+  it('toggleDemoMode flips isDemoMode from false to true', () => {
+    expect(isDemoMode()).toBe(false)
+    toggleDemoMode()
+    expect(isDemoMode()).toBe(true)
+  })
+
+  it('toggleDemoMode flips isDemoMode from true to false', () => {
+    setDemoMode(true, true)
+    expect(isDemoMode()).toBe(true)
+    toggleDemoMode()
+    expect(isDemoMode()).toBe(false)
+  })
+
+  it('toggle persists "true" to localStorage (badge appears on reload)', () => {
+    toggleDemoMode()
+    expect(localStorage.getItem(DEMO_MODE_STORAGE_KEY)).toBe('true')
+  })
+
+  it('toggle back persists "false" to localStorage (badge disappears on reload)', () => {
+    // Toggle on
+    toggleDemoMode()
+    expect(localStorage.getItem(DEMO_MODE_STORAGE_KEY)).toBe('true')
+
+    // Toggle off
+    toggleDemoMode()
+    expect(localStorage.getItem(DEMO_MODE_STORAGE_KEY)).toBe('false')
+  })
+
+  it('toggle dispatches kc-demo-mode-change CustomEvent with correct detail', () => {
+    const eventHandler = vi.fn()
+    window.addEventListener(DEMO_MODE_EVENT_NAME, eventHandler)
+
+    try {
+      toggleDemoMode() // false → true
+
+      expect(eventHandler).toHaveBeenCalledTimes(1)
+      const event = eventHandler.mock.calls[0][0] as CustomEvent
+      expect(event.detail).toBe(true)
+
+      eventHandler.mockClear()
+
+      toggleDemoMode() // true → false
+
+      expect(eventHandler).toHaveBeenCalledTimes(1)
+      const event2 = eventHandler.mock.calls[0][0] as CustomEvent
+      expect(event2.detail).toBe(false)
+    } finally {
+      window.removeEventListener(DEMO_MODE_EVENT_NAME, eventHandler)
+    }
+  })
+
+  it('toggle notifies all subscribers (drives useDemoMode → CardWrapper)', () => {
+    const subscriber1 = vi.fn()
+    const subscriber2 = vi.fn()
+
+    const unsub1 = subscribeDemoMode(subscriber1)
+    const unsub2 = subscribeDemoMode(subscriber2)
+
+    try {
+      toggleDemoMode() // false → true
+
+      expect(subscriber1).toHaveBeenCalledWith(true)
+      expect(subscriber2).toHaveBeenCalledWith(true)
+
+      subscriber1.mockClear()
+      subscriber2.mockClear()
+
+      toggleDemoMode() // true → false
+
+      expect(subscriber1).toHaveBeenCalledWith(false)
+      expect(subscriber2).toHaveBeenCalledWith(false)
+    } finally {
+      unsub1()
+      unsub2()
+    }
+  })
+
+  it('toggleDemoMode clears all caches before flipping (skeleton transition)', () => {
+    toggleDemoMode()
+
+    // clearAllRegisteredCaches should be called BEFORE the mode change
+    // (it sets isLoading: true on all caches so skeletons appear)
+    expect(mockClearAllRegisteredCaches).toHaveBeenCalledTimes(1)
+  })
+
+  it('canToggleDemoMode returns true in non-Netlify environment', () => {
+    // In the test environment (jsdom), we are not on Netlify
+    expect(canToggleDemoMode()).toBe(true)
+  })
+
+  it('setDemoMode with userInitiated=false does not override explicit user choice', () => {
+    // User explicitly enables demo mode
+    setDemoMode(true, true)
+    expect(isDemoMode()).toBe(true)
+
+    // Automatic attempt to disable should be ignored
+    setDemoMode(false, false)
+    expect(isDemoMode()).toBe(true)
+
+    // User can still disable manually
+    setDemoMode(false, true)
+    expect(isDemoMode()).toBe(false)
+  })
+
+  it('setDemoMode with userInitiated=false does not auto-enable when user disabled', () => {
+    // User explicitly disables demo mode
+    setDemoMode(true, true)
+    setDemoMode(false, true)
+    expect(isDemoMode()).toBe(false)
+    expect(localStorage.getItem(DEMO_MODE_STORAGE_KEY)).toBe('false')
+
+    // Automatic attempt to enable should be ignored
+    setDemoMode(true, false)
+    expect(isDemoMode()).toBe(false)
+  })
+
+  it('subscriber is not called after unsubscribe', () => {
+    const subscriber = vi.fn()
+    const unsub = subscribeDemoMode(subscriber)
+    unsub()
+
+    toggleDemoMode()
+
+    expect(subscriber).not.toHaveBeenCalled()
+  })
+
+  it('full on/off cycle: state, storage, events, and subscribers all consistent', () => {
+    const subscriber = vi.fn()
+    const eventHandler = vi.fn()
+    const unsub = subscribeDemoMode(subscriber)
+    window.addEventListener(DEMO_MODE_EVENT_NAME, eventHandler)
+
+    try {
+      // Verify initial state
+      expect(isDemoMode()).toBe(false)
+      // localStorage may be null (cleared) or 'false' — both mean demo is off
+      const initialStored = localStorage.getItem(DEMO_MODE_STORAGE_KEY)
+      expect(initialStored === null || initialStored === 'false').toBe(true)
+
+      // Toggle ON
+      toggleDemoMode()
+      expect(isDemoMode()).toBe(true)
+      expect(localStorage.getItem(DEMO_MODE_STORAGE_KEY)).toBe('true')
+      expect(subscriber).toHaveBeenLastCalledWith(true)
+      expect((eventHandler.mock.calls[0][0] as CustomEvent).detail).toBe(true)
+
+      // Toggle OFF
+      toggleDemoMode()
+      expect(isDemoMode()).toBe(false)
+      expect(localStorage.getItem(DEMO_MODE_STORAGE_KEY)).toBe('false')
+      expect(subscriber).toHaveBeenLastCalledWith(false)
+      expect((eventHandler.mock.calls[1][0] as CustomEvent).detail).toBe(false)
+
+      // Verify call counts
+      const EXPECTED_TOGGLE_COUNT = 2
+      expect(subscriber).toHaveBeenCalledTimes(EXPECTED_TOGGLE_COUNT)
+      expect(eventHandler).toHaveBeenCalledTimes(EXPECTED_TOGGLE_COUNT)
+      expect(mockClearAllRegisteredCaches).toHaveBeenCalledTimes(EXPECTED_TOGGLE_COUNT)
+    } finally {
+      unsub()
+      window.removeEventListener(DEMO_MODE_EVENT_NAME, eventHandler)
+    }
+  })
+})

--- a/web/src/lib/dashboards/__tests__/cardPersistence-regression.test.ts
+++ b/web/src/lib/dashboards/__tests__/cardPersistence-regression.test.ts
@@ -1,0 +1,222 @@
+/**
+ * Regression test: Card add/remove persistence (#8504)
+ *
+ * Verifies that adding and removing cards persists to localStorage so the
+ * layout survives a page reload (simulated by unmounting + re-mounting the hook).
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+const mockFullSync = vi.fn<(key: string) => Promise<import('../types').DashboardCard[] | null>>()
+const mockSaveCards = vi.fn()
+const mockIsAuthenticated = vi.fn(() => false)
+const mockClearCache = vi.fn()
+
+vi.mock('../dashboardSync', () => ({
+  dashboardSync: {
+    fullSync: (...args: unknown[]) => mockFullSync(args[0] as string),
+    saveCards: (...args: unknown[]) => mockSaveCards(...args),
+    isAuthenticated: () => mockIsAuthenticated(),
+    clearCache: () => mockClearCache(),
+  },
+}))
+
+const mockSetAutoRefreshPaused = vi.fn()
+vi.mock('../../cache', () => ({
+  setAutoRefreshPaused: (...args: unknown[]) => mockSetAutoRefreshPaused(...args),
+}))
+
+// Allow all card types through the prune filter so synthetic test types
+// are not filtered out during localStorage restore.
+vi.mock('../../../config/cards', () => ({
+  hasUnifiedConfig: () => true,
+}))
+vi.mock('../../../components/cards/cardRegistry', () => ({
+  isCardTypeRegistered: () => true,
+}))
+
+// Mock requestAnimationFrame for undo/redo
+vi.stubGlobal('requestAnimationFrame', (cb: () => void) => { cb(); return 0 })
+
+// ---------------------------------------------------------------------------
+// Imports (AFTER mocks)
+// ---------------------------------------------------------------------------
+
+import type { DashboardCardPlacement } from '../types'
+import { useDashboardCards } from '../dashboardHooks'
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const STORAGE_KEY = 'test-card-persistence'
+
+const DEFAULT_PLACEMENTS: DashboardCardPlacement[] = [
+  { type: 'cluster_health', position: { w: 4, h: 2 } },
+  { type: 'pod_status', position: { w: 4, h: 2 } },
+  { type: 'node_overview', position: { w: 6, h: 3 } },
+]
+
+const INITIAL_CARD_COUNT = 3
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('Card add/remove persistence (#8504)', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    localStorage.clear()
+    vi.clearAllMocks()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('added card survives simulated page reload', () => {
+    // --- First mount: add a card ---
+    const { result, unmount } = renderHook(() =>
+      useDashboardCards(STORAGE_KEY, DEFAULT_PLACEMENTS)
+    )
+
+    expect(result.current.cards).toHaveLength(INITIAL_CARD_COUNT)
+
+    act(() => {
+      result.current.addCards([{ type: 'new_card', config: { foo: 'bar' } }])
+    })
+
+    const AFTER_ADD_COUNT = 4
+    expect(result.current.cards).toHaveLength(AFTER_ADD_COUNT)
+
+    // Let the persistence effect run
+    act(() => { vi.runAllTimers() })
+
+    // Verify localStorage was written
+    const stored = localStorage.getItem(STORAGE_KEY)
+    expect(stored).not.toBeNull()
+    const parsed = JSON.parse(stored!)
+    expect(parsed).toHaveLength(AFTER_ADD_COUNT)
+
+    // Remember the added card's ID so we can verify identity after reload
+    const addedCard = result.current.cards.find(c => c.card_type === 'new_card')
+    expect(addedCard).toBeDefined()
+    const addedCardId = addedCard!.id
+
+    // --- Simulate page reload by unmounting and re-mounting ---
+    unmount()
+
+    const { result: reloaded } = renderHook(() =>
+      useDashboardCards(STORAGE_KEY, DEFAULT_PLACEMENTS)
+    )
+
+    expect(reloaded.current.cards).toHaveLength(AFTER_ADD_COUNT)
+    const restoredCard = reloaded.current.cards.find(c => c.card_type === 'new_card')
+    expect(restoredCard).toBeDefined()
+    expect(restoredCard!.id).toBe(addedCardId)
+    expect(restoredCard!.config).toEqual({ foo: 'bar' })
+  })
+
+  it('removed card stays removed after simulated page reload', () => {
+    // --- First mount: remove a card ---
+    const { result, unmount } = renderHook(() =>
+      useDashboardCards(STORAGE_KEY, DEFAULT_PLACEMENTS)
+    )
+
+    expect(result.current.cards).toHaveLength(INITIAL_CARD_COUNT)
+
+    const removedId = result.current.cards[0].id
+    const removedType = result.current.cards[0].card_type
+
+    act(() => {
+      result.current.removeCard(removedId)
+    })
+
+    const AFTER_REMOVE_COUNT = 2
+    expect(result.current.cards).toHaveLength(AFTER_REMOVE_COUNT)
+
+    // Let the persistence effect run
+    act(() => { vi.runAllTimers() })
+
+    // --- Simulate reload ---
+    unmount()
+
+    const { result: reloaded } = renderHook(() =>
+      useDashboardCards(STORAGE_KEY, DEFAULT_PLACEMENTS)
+    )
+
+    expect(reloaded.current.cards).toHaveLength(AFTER_REMOVE_COUNT)
+    expect(reloaded.current.cards.find(c => c.id === removedId)).toBeUndefined()
+    // Verify the correct type was removed, not some other card
+    const remainingTypes = reloaded.current.cards.map(c => c.card_type)
+    expect(remainingTypes).not.toContain(removedType)
+  })
+
+  it('add then remove then reload preserves final state', () => {
+    // --- First mount: add then remove ---
+    const { result, unmount } = renderHook(() =>
+      useDashboardCards(STORAGE_KEY, DEFAULT_PLACEMENTS)
+    )
+
+    // Add a card
+    act(() => {
+      result.current.addCards([{ type: 'temp_card' }])
+    })
+    const AFTER_ADD = 4
+    expect(result.current.cards).toHaveLength(AFTER_ADD)
+
+    // Remove the original first card
+    const firstCardId = result.current.cards.find(c => c.card_type === 'cluster_health')!.id
+    act(() => {
+      result.current.removeCard(firstCardId)
+    })
+
+    // Now we should have: temp_card, pod_status, node_overview
+    expect(result.current.cards).toHaveLength(INITIAL_CARD_COUNT)
+
+    // Let persistence run
+    act(() => { vi.runAllTimers() })
+
+    // --- Simulate reload ---
+    unmount()
+
+    const { result: reloaded } = renderHook(() =>
+      useDashboardCards(STORAGE_KEY, DEFAULT_PLACEMENTS)
+    )
+
+    expect(reloaded.current.cards).toHaveLength(INITIAL_CARD_COUNT)
+    const types = reloaded.current.cards.map(c => c.card_type)
+    expect(types).toContain('temp_card')
+    expect(types).toContain('pod_status')
+    expect(types).toContain('node_overview')
+    expect(types).not.toContain('cluster_health')
+  })
+
+  it('isCustomized reflects changes after reload', () => {
+    const { result, unmount } = renderHook(() =>
+      useDashboardCards(STORAGE_KEY, DEFAULT_PLACEMENTS)
+    )
+
+    // Initially not customized
+    expect(result.current.isCustomized).toBe(false)
+
+    // Remove a card to customize
+    act(() => {
+      result.current.removeCard(result.current.cards[0].id)
+    })
+    expect(result.current.isCustomized).toBe(true)
+
+    act(() => { vi.runAllTimers() })
+    unmount()
+
+    // After reload, should still be customized
+    const { result: reloaded } = renderHook(() =>
+      useDashboardCards(STORAGE_KEY, DEFAULT_PLACEMENTS)
+    )
+    expect(reloaded.current.isCustomized).toBe(true)
+  })
+})


### PR DESCRIPTION
Fixes #8502, Fixes #8504, Fixes #8505

## Summary
- **Cluster deduplication regression** (#8502): Tests the full `shareMetrics → deduplicateClustersByServer` pipeline with two kubeconfig contexts pointing to the same server, verifying exactly one entry with aliases
- **Card add/remove persistence** (#8504): Tests that adding/removing cards persists to localStorage and survives a simulated page reload (unmount + remount)
- **Demo mode toggle badge** (#8505): Tests that toggling demo mode correctly updates state, persists to localStorage, dispatches `kc-demo-mode-change` CustomEvent, notifies subscribers, and clears caches (the inputs that drive the Demo badge and yellow outline in CardWrapper)

## Test plan
- [x] All 22 new tests pass (`npx vitest run`)
- [x] `npm run build` passes
- [x] `npm run lint` passes
- [ ] CI build/lint pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)