### PR TITLE
🐛 fix: restore card loading skeletons + update WhatsNew tests (#8534)

### DIFF
--- a/web/src/components/cards/NetworkOverview.tsx
+++ b/web/src/components/cards/NetworkOverview.tsx
@@ -9,6 +9,7 @@ import { CardClusterFilter } from '../../lib/cards/CardComponents'
 import { useChartFilters } from '../../lib/cards/cardHooks'
 import { ClusterStatusDot } from '../ui/ClusterStatusBadge'
 import { RefreshIndicator } from '../ui/RefreshIndicator'
+import { Skeleton, SkeletonStats, SkeletonList } from '../ui/Skeleton'
 
 export function NetworkOverview() {
   const { deduplicatedClusters: clusters, isLoading, isRefreshing: clustersRefreshing, lastRefresh: clustersLastRefreshDate } = useClusters()
@@ -105,7 +106,22 @@ export function NetworkOverview() {
   }, [filteredServices, filteredClusters])
 
   if (showSkeleton) {
-    return null
+    return (
+      <div className="h-full flex flex-col min-h-card">
+        {/* Header skeleton */}
+        <div className="flex items-center justify-between mb-3">
+          <div className="flex items-center gap-2">
+            <Skeleton variant="circular" width={16} height={16} />
+            <Skeleton variant="text" width={100} height={16} />
+          </div>
+          <Skeleton variant="rounded" width={80} height={24} />
+        </div>
+        {/* Stats skeleton */}
+        <SkeletonStats className="mb-4" />
+        {/* List skeleton */}
+        <SkeletonList items={3} className="flex-1" />
+      </div>
+    )
   }
 
   if (showEmptyState) {

--- a/web/src/components/cards/StorageOverview.tsx
+++ b/web/src/components/cards/StorageOverview.tsx
@@ -9,6 +9,7 @@ import { CardClusterFilter } from '../../lib/cards/CardComponents'
 import { useChartFilters } from '../../lib/cards/cardHooks'
 import { useTranslation } from 'react-i18next'
 import { useDemoMode } from '../../hooks/useDemoMode'
+import { Skeleton, SkeletonStats, SkeletonList } from '../ui/Skeleton'
 
 export function StorageOverview() {
   const { t } = useTranslation(['cards', 'common'])
@@ -102,7 +103,21 @@ export function StorageOverview() {
     filteredClusters.some(c => c.reachable !== false && c.storageGB !== undefined)
 
   if (showSkeleton) {
-    return null
+    return (
+      <div className="h-full flex flex-col min-h-card">
+        {/* Loading label for accessibility / test hook */}
+        <p className="sr-only">{t('storageOverview.loading')}</p>
+        {/* Header skeleton */}
+        <div className="flex items-center justify-between mb-4">
+          <Skeleton variant="text" width={120} height={16} />
+          <Skeleton variant="rounded" width={80} height={24} />
+        </div>
+        {/* Stats skeleton */}
+        <SkeletonStats className="mb-4" />
+        {/* List skeleton */}
+        <SkeletonList items={3} className="flex-1" />
+      </div>
+    )
   }
 
   if (showEmptyState) {

--- a/web/src/components/updates/WhatsNewModal.test.tsx
+++ b/web/src/components/updates/WhatsNewModal.test.tsx
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render, screen, fireEvent } from '@testing-library/react'
-import { WhatsNewModal, isUpdateSnoozed, isKillSwitchEnabled } from './WhatsNewModal'
+import { WhatsNewModal, isUpdateSnoozed } from './WhatsNewModal'
 
 // Mock dependencies
 vi.mock('../../hooks/useVersionCheck', () => ({
@@ -165,15 +165,4 @@ describe('isUpdateSnoozed', () => {
   })
 })
 
-describe('isKillSwitchEnabled', () => {
-  beforeEach(() => localStorage.clear())
-
-  it('returns false by default', () => {
-    expect(isKillSwitchEnabled()).toBe(false)
-  })
-
-  it('returns true when set', () => {
-    localStorage.setItem('kc-whats-new-modal-disabled', '1')
-    expect(isKillSwitchEnabled()).toBe(true)
-  })
-})
+// isKillSwitchEnabled was removed in PR #8527 — kill-switch is no longer needed


### PR DESCRIPTION
## Summary
- **NetworkOverview / StorageOverview**: PR #8532 changed `showSkeleton` to `return null`, assuming CardWrapper renders a data-loading skeleton. It does not — cards showed blank during initial load. Restored proper `Skeleton`/`SkeletonStats`/`SkeletonList` UI matching the pattern used by ClusterHealth and other working cards.
- **WhatsNewModal tests**: PR #8527 removed the `isKillSwitchEnabled` export but left two test assertions importing it. Removed those dead tests.

Fixes #8534

## Test plan
- [x] `npx vitest run NetworkOverview StorageOverview WhatsNewModal` — all 37 tests pass
- [x] `npm run build` — clean
- [x] `npm run lint` — no new warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)