### PR TITLE
✨ feat: Kubara foundation — types, server cache, demo fixtures (#8480, #8486, #8487)

### DIFF
--- a/pkg/api/handlers/kubara_catalog.go
+++ b/pkg/api/handlers/kubara_catalog.go
@@ -1,0 +1,248 @@
+// Package handlers provides HTTP handlers for the console API.
+package handlers
+
+import (
+	"encoding/json"
+	"io"
+	"log/slog"
+	"net/http"
+	"sync"
+	"time"
+
+	"github.com/gofiber/fiber/v2"
+)
+
+const (
+	// kubaraCatalogCacheTTL is how long a successful catalog fetch is cached
+	// before re-fetching from GitHub. All users share a single cached copy
+	// so only one upstream request is made per TTL window (#8487).
+	kubaraCatalogCacheTTL = 10 * time.Minute
+
+	// kubaraCatalogTimeout is the HTTP timeout for the upstream GitHub
+	// Contents API call when refreshing the catalog.
+	kubaraCatalogTimeout = 15 * time.Second
+
+	// kubaraCatalogMaxResponseBytes caps the response body from the upstream
+	// GitHub Contents API to prevent unbounded memory consumption.
+	kubaraCatalogMaxResponseBytes = 5 * 1024 * 1024 // 5 MB
+
+	// kubaraCatalogUpstreamURL is the GitHub Contents API endpoint for the
+	// kubara-io/kubara repository's helm directory.
+	kubaraCatalogUpstreamURL = "https://api.github.com/repos/kubara-io/kubara/contents/helm"
+)
+
+// KubaraCatalogEntry represents a single chart directory in the Kubara repo.
+type KubaraCatalogEntry struct {
+	Name        string `json:"name"`
+	Path        string `json:"path"`
+	Type        string `json:"type"`
+	Description string `json:"description,omitempty"`
+}
+
+// KubaraCatalogHandler serves the Kubara platform catalog with an in-process
+// cache so that multiple users share a single upstream fetch (#8487).
+type KubaraCatalogHandler struct {
+	githubToken string
+	httpClient  *http.Client
+
+	mu       sync.RWMutex
+	cache    []KubaraCatalogEntry
+	cacheExp time.Time
+}
+
+// NewKubaraCatalogHandler creates a new handler for the Kubara catalog endpoint.
+func NewKubaraCatalogHandler(githubToken string) *KubaraCatalogHandler {
+	return &KubaraCatalogHandler{
+		githubToken: githubToken,
+		httpClient:  &http.Client{Timeout: kubaraCatalogTimeout},
+	}
+}
+
+// GetCatalog handles GET /api/kubara/catalog — returns the cached Kubara
+// chart index, refreshing from upstream if the cache has expired.
+func (h *KubaraCatalogHandler) GetCatalog(c *fiber.Ctx) error {
+	// Demo mode: return static demo catalog immediately
+	if isDemoMode(c) {
+		return c.JSON(fiber.Map{
+			"entries": getDemoKubaraCatalog(),
+			"source":  "demo",
+		})
+	}
+
+	// Check cache (read lock)
+	h.mu.RLock()
+	if h.cache != nil && time.Now().Before(h.cacheExp) {
+		entries := h.cache
+		h.mu.RUnlock()
+		return c.JSON(fiber.Map{
+			"entries": entries,
+			"source":  "cache",
+		})
+	}
+	h.mu.RUnlock()
+
+	// Cache miss — fetch from upstream (write lock)
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	// Double-check: another goroutine may have refreshed while we waited
+	if h.cache != nil && time.Now().Before(h.cacheExp) {
+		return c.JSON(fiber.Map{
+			"entries": h.cache,
+			"source":  "cache",
+		})
+	}
+
+	entries, err := h.fetchUpstream()
+	if err != nil {
+		slog.Error("[KubaraCatalog] upstream fetch failed", "error", err)
+		// If we have a stale cache, serve it rather than failing
+		if h.cache != nil {
+			return c.JSON(fiber.Map{
+				"entries": h.cache,
+				"source":  "stale-cache",
+			})
+		}
+		return c.Status(fiber.StatusBadGateway).JSON(fiber.Map{
+			"error": "Failed to fetch Kubara catalog",
+		})
+	}
+
+	h.cache = entries
+	h.cacheExp = time.Now().Add(kubaraCatalogCacheTTL)
+
+	return c.JSON(fiber.Map{
+		"entries": entries,
+		"source":  "upstream",
+	})
+}
+
+// fetchUpstream calls the GitHub Contents API for the kubara-io/kubara repo.
+func (h *KubaraCatalogHandler) fetchUpstream() ([]KubaraCatalogEntry, error) {
+	req, err := http.NewRequest(http.MethodGet, kubaraCatalogUpstreamURL, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Set("Accept", "application/vnd.github.v3+json")
+	req.Header.Set("User-Agent", "KubeStellar-Console-KubaraCatalog")
+	if h.githubToken != "" {
+		req.Header.Set("Authorization", "Bearer "+h.githubToken)
+	}
+
+	resp, err := h.httpClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fiber.NewError(resp.StatusCode, "GitHub API returned non-200 status")
+	}
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, kubaraCatalogMaxResponseBytes))
+	if err != nil {
+		return nil, err
+	}
+
+	// GitHub Contents API returns an array of objects for directory listings
+	var raw []struct {
+		Name string `json:"name"`
+		Path string `json:"path"`
+		Type string `json:"type"`
+	}
+	if err := json.Unmarshal(body, &raw); err != nil {
+		return nil, err
+	}
+
+	entries := make([]KubaraCatalogEntry, 0, len(raw))
+	for _, item := range raw {
+		if item.Type == "dir" {
+			entries = append(entries, KubaraCatalogEntry{
+				Name: item.Name,
+				Path: item.Path,
+				Type: item.Type,
+			})
+		}
+	}
+
+	return entries, nil
+}
+
+// getDemoKubaraCatalog returns realistic fixture data for demo mode (#8486).
+func getDemoKubaraCatalog() []KubaraCatalogEntry {
+	return []KubaraCatalogEntry{
+		{
+			Name:        "prometheus-stack",
+			Path:        "helm/prometheus-stack",
+			Type:        "dir",
+			Description: "Production Prometheus + Grafana + Alertmanager monitoring stack",
+		},
+		{
+			Name:        "cert-manager",
+			Path:        "helm/cert-manager",
+			Type:        "dir",
+			Description: "Automated TLS certificate management with Let's Encrypt and custom CAs",
+		},
+		{
+			Name:        "falco-runtime-security",
+			Path:        "helm/falco-runtime-security",
+			Type:        "dir",
+			Description: "Runtime threat detection and incident response for containers",
+		},
+		{
+			Name:        "kyverno-policies",
+			Path:        "helm/kyverno-policies",
+			Type:        "dir",
+			Description: "Kubernetes-native policy engine for admission control and governance",
+		},
+		{
+			Name:        "argocd-gitops",
+			Path:        "helm/argocd-gitops",
+			Type:        "dir",
+			Description: "Declarative GitOps continuous delivery with Argo CD",
+		},
+		{
+			Name:        "istio-service-mesh",
+			Path:        "helm/istio-service-mesh",
+			Type:        "dir",
+			Description: "Service mesh for traffic management, mTLS, and observability",
+		},
+		{
+			Name:        "velero-backups",
+			Path:        "helm/velero-backups",
+			Type:        "dir",
+			Description: "Cluster backup, disaster recovery, and migration tooling",
+		},
+		{
+			Name:        "external-secrets",
+			Path:        "helm/external-secrets",
+			Type:        "dir",
+			Description: "Sync secrets from AWS Secrets Manager, Vault, GCP, and Azure Key Vault",
+		},
+		{
+			Name:        "trivy-vulnerability-scanner",
+			Path:        "helm/trivy-vulnerability-scanner",
+			Type:        "dir",
+			Description: "Container image and filesystem vulnerability scanning",
+		},
+		{
+			Name:        "fluent-bit-logging",
+			Path:        "helm/fluent-bit-logging",
+			Type:        "dir",
+			Description: "Lightweight log processor and forwarder for Kubernetes",
+		},
+		{
+			Name:        "harbor-registry",
+			Path:        "helm/harbor-registry",
+			Type:        "dir",
+			Description: "Enterprise container registry with vulnerability scanning and RBAC",
+		},
+		{
+			Name:        "crossplane-infra",
+			Path:        "helm/crossplane-infra",
+			Type:        "dir",
+			Description: "Infrastructure-as-code with Kubernetes-native resource provisioning",
+		},
+	}
+}

--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -1149,6 +1149,11 @@ func (s *Server) setupRoutes() {
 	api.Get("/nightly-e2e/runs", nightlyE2E.GetRuns)
 	api.Get("/nightly-e2e/run-logs", nightlyE2E.GetRunLogs)
 
+	// Kubara platform catalog — server-side cache so all users share one
+	// upstream fetch from kubara-io/kubara (#8487)
+	kubaraCatalog := handlers.NewKubaraCatalogHandler(s.config.GitHubToken)
+	api.Get("/kubara/catalog", kubaraCatalog.GetCatalog)
+
 	// GitHub Pipelines dashboard (powers /ci-cd cards). Same endpoint shape
 	// as the Netlify Function at web/netlify/functions/github-pipelines.mts
 	// so the TS hook works against either backend without branching.

--- a/web/src/components/mission-control/types.ts
+++ b/web/src/components/mission-control/types.ts
@@ -46,6 +46,19 @@ export interface PayloadProject {
    * loses user-selected CNCF projects on refinement.
    */
   userAdded?: boolean
+  /**
+   * Kubara platform chart reference. When present, the project can be
+   * installed via the Kubara catalog instead of (or in addition to) the
+   * console-kb install mission. `repoPath` is the directory path inside
+   * the kubara-io/kubara repo (e.g. "helm/prometheus-stack"). `valuesUrl`
+   * optionally points to a pre-built values file for the chart (#8480).
+   */
+  kubaraChart?: {
+    /** Path inside the kubara-io/kubara repo (e.g. "helm/prometheus-stack") */
+    repoPath: string
+    /** Optional URL to a default or recommended values file */
+    valuesUrl?: string
+  }
 }
 
 // ---------------------------------------------------------------------------

--- a/web/src/mocks/handlers.ts
+++ b/web/src/mocks/handlers.ts
@@ -11,6 +11,159 @@ import { http, HttpResponse, delay, passthrough } from 'msw'
  * Provides mock API responses without requiring backend connectivity.
  */
 
+// ---------------------------------------------------------------------------
+// Kubara catalog fixture — realistic snapshot of the GitHub Contents API
+// response for kubara-io/kubara/contents/helm. Each entry includes the full
+// set of fields returned by the API (sha, size, URLs) so that components
+// exercising those fields work correctly in demo mode (#8486).
+// ---------------------------------------------------------------------------
+const kubaraCatalogFixture = [
+  {
+    name: 'prometheus-stack',
+    path: 'helm/prometheus-stack',
+    sha: 'a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2',
+    size: 0,
+    url: 'https://api.github.com/repos/kubara-io/kubara/contents/helm/prometheus-stack?ref=main',
+    html_url: 'https://github.com/kubara-io/kubara/tree/main/helm/prometheus-stack',
+    git_url: 'https://api.github.com/repos/kubara-io/kubara/git/trees/a1b2c3d',
+    download_url: null,
+    type: 'dir',
+    description: 'Production Prometheus + Grafana + Alertmanager monitoring stack',
+  },
+  {
+    name: 'cert-manager',
+    path: 'helm/cert-manager',
+    sha: 'b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3',
+    size: 0,
+    url: 'https://api.github.com/repos/kubara-io/kubara/contents/helm/cert-manager?ref=main',
+    html_url: 'https://github.com/kubara-io/kubara/tree/main/helm/cert-manager',
+    git_url: 'https://api.github.com/repos/kubara-io/kubara/git/trees/b2c3d4e',
+    download_url: null,
+    type: 'dir',
+    description: 'Automated TLS certificate management with Let\'s Encrypt and custom CAs',
+  },
+  {
+    name: 'falco-runtime-security',
+    path: 'helm/falco-runtime-security',
+    sha: 'c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4',
+    size: 0,
+    url: 'https://api.github.com/repos/kubara-io/kubara/contents/helm/falco-runtime-security?ref=main',
+    html_url: 'https://github.com/kubara-io/kubara/tree/main/helm/falco-runtime-security',
+    git_url: 'https://api.github.com/repos/kubara-io/kubara/git/trees/c3d4e5f',
+    download_url: null,
+    type: 'dir',
+    description: 'Runtime threat detection and incident response for containers',
+  },
+  {
+    name: 'kyverno-policies',
+    path: 'helm/kyverno-policies',
+    sha: 'd4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5',
+    size: 0,
+    url: 'https://api.github.com/repos/kubara-io/kubara/contents/helm/kyverno-policies?ref=main',
+    html_url: 'https://github.com/kubara-io/kubara/tree/main/helm/kyverno-policies',
+    git_url: 'https://api.github.com/repos/kubara-io/kubara/git/trees/d4e5f6a',
+    download_url: null,
+    type: 'dir',
+    description: 'Kubernetes-native policy engine for admission control and governance',
+  },
+  {
+    name: 'argocd-gitops',
+    path: 'helm/argocd-gitops',
+    sha: 'e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6',
+    size: 0,
+    url: 'https://api.github.com/repos/kubara-io/kubara/contents/helm/argocd-gitops?ref=main',
+    html_url: 'https://github.com/kubara-io/kubara/tree/main/helm/argocd-gitops',
+    git_url: 'https://api.github.com/repos/kubara-io/kubara/git/trees/e5f6a1b',
+    download_url: null,
+    type: 'dir',
+    description: 'Declarative GitOps continuous delivery with Argo CD',
+  },
+  {
+    name: 'istio-service-mesh',
+    path: 'helm/istio-service-mesh',
+    sha: 'f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1',
+    size: 0,
+    url: 'https://api.github.com/repos/kubara-io/kubara/contents/helm/istio-service-mesh?ref=main',
+    html_url: 'https://github.com/kubara-io/kubara/tree/main/helm/istio-service-mesh',
+    git_url: 'https://api.github.com/repos/kubara-io/kubara/git/trees/f6a1b2c',
+    download_url: null,
+    type: 'dir',
+    description: 'Service mesh for traffic management, mTLS, and observability',
+  },
+  {
+    name: 'velero-backups',
+    path: 'helm/velero-backups',
+    sha: 'a7b8c9d0e1f2a7b8c9d0e1f2a7b8c9d0e1f2a7b8',
+    size: 0,
+    url: 'https://api.github.com/repos/kubara-io/kubara/contents/helm/velero-backups?ref=main',
+    html_url: 'https://github.com/kubara-io/kubara/tree/main/helm/velero-backups',
+    git_url: 'https://api.github.com/repos/kubara-io/kubara/git/trees/a7b8c9d',
+    download_url: null,
+    type: 'dir',
+    description: 'Cluster backup, disaster recovery, and migration tooling',
+  },
+  {
+    name: 'external-secrets',
+    path: 'helm/external-secrets',
+    sha: 'b8c9d0e1f2a7b8c9d0e1f2a7b8c9d0e1f2a7b8c9',
+    size: 0,
+    url: 'https://api.github.com/repos/kubara-io/kubara/contents/helm/external-secrets?ref=main',
+    html_url: 'https://github.com/kubara-io/kubara/tree/main/helm/external-secrets',
+    git_url: 'https://api.github.com/repos/kubara-io/kubara/git/trees/b8c9d0e',
+    download_url: null,
+    type: 'dir',
+    description: 'Sync secrets from AWS Secrets Manager, Vault, GCP, and Azure Key Vault',
+  },
+  {
+    name: 'trivy-vulnerability-scanner',
+    path: 'helm/trivy-vulnerability-scanner',
+    sha: 'c9d0e1f2a7b8c9d0e1f2a7b8c9d0e1f2a7b8c9d0',
+    size: 0,
+    url: 'https://api.github.com/repos/kubara-io/kubara/contents/helm/trivy-vulnerability-scanner?ref=main',
+    html_url: 'https://github.com/kubara-io/kubara/tree/main/helm/trivy-vulnerability-scanner',
+    git_url: 'https://api.github.com/repos/kubara-io/kubara/git/trees/c9d0e1f',
+    download_url: null,
+    type: 'dir',
+    description: 'Container image and filesystem vulnerability scanning',
+  },
+  {
+    name: 'fluent-bit-logging',
+    path: 'helm/fluent-bit-logging',
+    sha: 'd0e1f2a7b8c9d0e1f2a7b8c9d0e1f2a7b8c9d0e1',
+    size: 0,
+    url: 'https://api.github.com/repos/kubara-io/kubara/contents/helm/fluent-bit-logging?ref=main',
+    html_url: 'https://github.com/kubara-io/kubara/tree/main/helm/fluent-bit-logging',
+    git_url: 'https://api.github.com/repos/kubara-io/kubara/git/trees/d0e1f2a',
+    download_url: null,
+    type: 'dir',
+    description: 'Lightweight log processor and forwarder for Kubernetes',
+  },
+  {
+    name: 'harbor-registry',
+    path: 'helm/harbor-registry',
+    sha: 'e1f2a7b8c9d0e1f2a7b8c9d0e1f2a7b8c9d0e1f2',
+    size: 0,
+    url: 'https://api.github.com/repos/kubara-io/kubara/contents/helm/harbor-registry?ref=main',
+    html_url: 'https://github.com/kubara-io/kubara/tree/main/helm/harbor-registry',
+    git_url: 'https://api.github.com/repos/kubara-io/kubara/git/trees/e1f2a7b',
+    download_url: null,
+    type: 'dir',
+    description: 'Enterprise container registry with vulnerability scanning and RBAC',
+  },
+  {
+    name: 'crossplane-infra',
+    path: 'helm/crossplane-infra',
+    sha: 'f2a7b8c9d0e1f2a7b8c9d0e1f2a7b8c9d0e1f2a7',
+    size: 0,
+    url: 'https://api.github.com/repos/kubara-io/kubara/contents/helm/crossplane-infra?ref=main',
+    html_url: 'https://github.com/kubara-io/kubara/tree/main/helm/crossplane-infra',
+    git_url: 'https://api.github.com/repos/kubara-io/kubara/git/trees/f2a7b8c',
+    download_url: null,
+    type: 'dir',
+    description: 'Infrastructure-as-code with Kubernetes-native resource provisioning',
+  },
+]
+
 // Demo data - one cluster for each provider type to showcase all icons
 const demoClusters = [
   { name: 'kind-local', context: 'kind-local', healthy: true, source: 'kubeconfig', nodeCount: 1, podCount: 15, cpuCores: 4, memoryGB: 8, storageGB: 50, distribution: 'kind' },
@@ -733,18 +886,23 @@ export const handlers = [
   // http.get) to cover mutation POSTs + CORS preflight.
   http.all('/api/github-pipelines', () => passthrough()),
 
-  // ── Kubara Platform Catalog (demo) ──────────────────────────────
+  // ── Kubara Platform Catalog (demo fixtures — #8486) ─────────────
+  // Realistic fixture snapshots matching the GitHub Contents API shape
+  // returned by the kubara-io/kubara repo. Each entry mirrors a real
+  // chart directory with sha, size, git URLs, and download links so that
+  // downstream components exercising those fields work correctly in demo.
   http.get('/api/github/repos/kubara-io/kubara/contents/*', () => {
-    return HttpResponse.json([
-      { name: 'prometheus-stack', path: 'helm/prometheus-stack', type: 'directory', description: 'Production Prometheus + Grafana + Alertmanager' },
-      { name: 'cert-manager', path: 'helm/cert-manager', type: 'directory', description: 'Automated TLS certificate management' },
-      { name: 'falco-runtime-security', path: 'helm/falco-runtime-security', type: 'directory', description: 'Runtime threat detection and response' },
-      { name: 'kyverno-policies', path: 'helm/kyverno-policies', type: 'directory', description: 'Kubernetes policy engine for security' },
-      { name: 'argocd-gitops', path: 'helm/argocd-gitops', type: 'directory', description: 'Declarative GitOps continuous delivery' },
-      { name: 'istio-service-mesh', path: 'helm/istio-service-mesh', type: 'directory', description: 'Service mesh for traffic management and security' },
-      { name: 'velero-backups', path: 'helm/velero-backups', type: 'directory', description: 'Cluster backup and disaster recovery' },
-      { name: 'external-secrets', path: 'helm/external-secrets', type: 'directory', description: 'Sync secrets from external providers' },
-    ])
+    return HttpResponse.json(kubaraCatalogFixture)
+  }),
+
+  // Server-side Kubara catalog endpoint (Go handler with cache — #8487).
+  // In demo mode this is intercepted by MSW; the Go handler also returns
+  // demo data when it sees X-Demo-Mode, but belt-and-suspenders is safer.
+  http.get('/api/kubara/catalog', () => {
+    return HttpResponse.json({
+      entries: kubaraCatalogFixture,
+      source: 'demo',
+    })
   }),
 
   // ── Optional feature status endpoints (issue #8162) ──────────────


### PR DESCRIPTION
## Summary

- **#8480** — Add `kubaraChart?: { repoPath: string; valuesUrl?: string }` optional field to `PayloadProject` type so projects can reference Kubara catalog charts for installation
- **#8487** — Add `KubaraCatalogHandler` Go handler at `GET /api/kubara/catalog` with in-process cache (10-minute TTL), stale-cache fallback on upstream failure, and demo mode support
- **#8486** — Replace hardcoded Kubara mock data in MSW handlers with realistic fixture snapshots matching the GitHub Contents API shape (sha, URLs, git_url, download_url) and expand from 8 to 12 chart entries

Fixes #8480, Fixes #8486, Fixes #8487

## Changed files

| File | Change |
|------|--------|
| `web/src/components/mission-control/types.ts` | Add `kubaraChart` field to `PayloadProject` |
| `pkg/api/handlers/kubara_catalog.go` | New Go handler with cache + demo mode |
| `pkg/api/server.go` | Register `/api/kubara/catalog` route |
| `web/src/mocks/handlers.ts` | Realistic Kubara fixtures + new MSW handler |

## Test plan

- [ ] `go build ./...` passes
- [ ] `npm run build` passes
- [ ] `npm run lint` passes
- [ ] Demo mode shows Kubara catalog data (12 entries with full GitHub API fields)
- [ ] Server-side cache returns `source: "cache"` on subsequent requests within TTL
- [ ] PayloadProject type accepts `kubaraChart` field without breaking existing consumers