### PR TITLE
✨ feat: Kubara Mission Control integration (#8481, #8482, #8485)

### DIFF
--- a/web/src/components/cards/multi-tenancy/missionLoader.ts
+++ b/web/src/components/cards/multi-tenancy/missionLoader.ts
@@ -8,6 +8,7 @@
  */
 
 import type { MissionExport } from '../../../lib/missions/types'
+import { fetchKubaraValues } from '../../../lib/kubara'
 
 /** Timeout for fetching a mission file from console-kb (ms) */
 const MISSION_FETCH_TIMEOUT_MS = 10_000
@@ -36,6 +37,7 @@ export async function loadMissionPrompt(
   componentKey: string,
   fallbackPrompt: string,
   kbPaths?: string[],
+  options?: LoadMissionPromptOptions,
 ): Promise<string> {
   // Try kbPaths first, then legacy MISSION_PATHS lookup
   const path = kbPaths?.[0] ?? MISSION_PATHS[componentKey]
@@ -77,6 +79,29 @@ export async function loadMissionPrompt(
       prompt += `### Step ${i + 1}: ${step.title}\n${step.description}\n\n`
     }
 
+    // #8482 — Embed Kubara values.yaml into the install prompt when a
+    // kubaraValuesUrl (or chart name) is provided. This gives the AI agent
+    // production-tested Helm values to use during installation, avoiding
+    // default values that may not be production-ready.
+    const kubaraValuesUrl = options?.kubaraValuesUrl
+    const kubaraChartName = options?.kubaraChartName
+    if (kubaraValuesUrl || kubaraChartName) {
+      try {
+        const valuesYaml = await fetchKubaraValues(
+          kubaraChartName ?? componentKey,
+          kubaraValuesUrl,
+        )
+        if (valuesYaml) {
+          prompt += `## Kubara Production Values\n\n`
+          prompt += `The following values.yaml contains production-tested Helm values from the Kubara platform. `
+          prompt += `Use these values as the baseline for the installation — they have been validated in production environments.\n\n`
+          prompt += `\`\`\`yaml\n${valuesYaml}\n\`\`\`\n\n`
+        }
+      } catch {
+        // Non-critical — Kubara values are optional enrichment
+      }
+    }
+
     // Add troubleshooting if available (v2+ schema field — absent in older exports)
     const rawTroubleshooting: unknown = mission?.troubleshooting
     const troubleshooting = Array.isArray(rawTroubleshooting)
@@ -99,6 +124,17 @@ export async function loadMissionPrompt(
     // Network error, timeout, parse error — fall back to raw prompt
     return fallbackPrompt
   }
+}
+
+/**
+ * Options for loadMissionPrompt (#8482).
+ * When provided, Kubara Helm values are fetched and embedded into the prompt.
+ */
+export interface LoadMissionPromptOptions {
+  /** Full URL to a Kubara values.yaml (takes precedence over kubaraChartName) */
+  kubaraValuesUrl?: string
+  /** Kubara chart name — used to construct the default values.yaml URL */
+  kubaraChartName?: string
 }
 
 /**

--- a/web/src/components/mission-control/ClusterAssignmentPanel.tsx
+++ b/web/src/components/mission-control/ClusterAssignmentPanel.tsx
@@ -25,7 +25,7 @@ type ViewMode = 'cards' | 'matrix'
 interface ClusterAssignmentPanelProps {
   state: MissionControlState
   onAskAI: (projects: PayloadProject[], clustersJson: string) => void
-  onAutoAssign: (clusters: Array<{ name: string; context?: string; distribution?: string; cpuCores?: number; memoryGB?: number; storageGB?: number; cpuUsageCores?: number; cpuRequestsCores?: number; memoryUsageGB?: number; memoryRequestsGB?: number }>) => void
+  onAutoAssign: (clusters: Array<{ name: string; context?: string; distribution?: string; cpuCores?: number; memoryGB?: number; storageGB?: number; cpuUsageCores?: number; cpuRequestsCores?: number; memoryUsageGB?: number; memoryRequestsGB?: number }>) => void | Promise<void>
   onSetAssignment: (clusterName: string, projectName: string, assigned: boolean) => void
   aiStreaming: boolean
   planningMission?: Mission | null

--- a/web/src/components/mission-control/FixerDefinitionPanel.tsx
+++ b/web/src/components/mission-control/FixerDefinitionPanel.tsx
@@ -33,7 +33,7 @@ interface FixerDefinitionPanelProps {
   onDescriptionChange: (desc: string) => void
   onTitleChange: (title: string) => void
   onTargetClustersChange: (clusters: string[]) => void
-  onAskAI: (description: string, existing?: PayloadProject[]) => void
+  onAskAI: (description: string, existing?: PayloadProject[]) => void | Promise<void>
   onAddProject: (project: PayloadProject) => void
   onRemoveProject: (name: string) => void
   onUpdatePriority: (name: string, priority: PayloadProject['priority']) => void

--- a/web/src/components/mission-control/LaunchSequence.tsx
+++ b/web/src/components/mission-control/LaunchSequence.tsx
@@ -197,10 +197,13 @@ export function LaunchSequence({
           project.name,
           project.displayName,
         )
+        // #8482 — Pass Kubara chart name so loadMissionPrompt can embed
+        // production-tested Helm values into the install prompt.
         const prompt = await loadMissionPrompt(
           project.name,
           fallbackPrompt,
           project.kbPath ? [project.kbPath] : undefined,
+          project.kubaraChartName ? { kubaraChartName: project.kubaraChartName } : undefined,
         )
 
         // Derive a safe display name for UI strings too — the title is

--- a/web/src/components/mission-control/types.ts
+++ b/web/src/components/mission-control/types.ts
@@ -26,6 +26,8 @@ export interface PayloadProject {
   dependencies: string[]
   /** Path in console-kb to the install mission JSON */
   kbPath?: string
+  /** Kubara chart name when a matching chart exists in the Kubara platform catalog */
+  kubaraChartName?: string
   /** GitHub org for avatar URL */
   githubOrg?: string
   /** CNCF maturity level */

--- a/web/src/components/mission-control/useMissionControl.ts
+++ b/web/src/components/mission-control/useMissionControl.ts
@@ -11,6 +11,8 @@ import { useDebouncedValue } from '../../hooks/useDebouncedValue'
 import { useHelmReleases } from '../../hooks/mcp/helm'
 import { useClusters } from '../../hooks/mcp/clusters'
 import { isDemoMode } from '../../lib/demoMode'
+import { fetchKubaraCatalog, fetchKubaraValues, parseResourceRequests } from '../../lib/kubara'
+import type { KubaraResourceRequests } from '../../lib/kubara'
 import { getDemoMissionControlState } from './demoState'
 import type {
   MissionControlState,
@@ -723,10 +725,14 @@ export function useMissionControl() {
             `[MissionControl] filtered ${projectsArr.length - validProjects.length} invalid project(s) from AI payload`
           )
         }
-        // Ensure dependencies defaults to []
+        // Ensure dependencies defaults to [] and tag Kubara-matched charts (#8481)
+        const kubaraNames = kubaraChartNamesRef.current
         const normalized = validProjects.map((p) => ({
           ...p,
-          dependencies: p.dependencies ?? [] }))
+          dependencies: p.dependencies ?? [],
+          // #8481 — Tag projects that have a matching Kubara chart so
+          // LaunchSequence can embed production Helm values in the prompt.
+          kubaraChartName: kubaraNames.has(p.name) ? p.name : undefined }))
         lastParsedContentRef.current = latest.content
         setState((prev) => ({
           ...prev,
@@ -915,6 +921,9 @@ export function useMissionControl() {
   // synchronously at the top of askAIForSuggestions and cleared when streaming ends.
   const aiRequestInFlightRef = useRef(false)
   const helmReleasesRef = useRef(helmReleases)
+  // #8481 — Kubara catalog chart names (populated by askAIForSuggestions,
+  // read by the AI response parser to tag projects with kubaraChartName).
+  const kubaraChartNamesRef = useRef<Set<string>>(new Set())
   // #6834 — Dedicated ref for planningMissionId so askAIForSuggestions always
   // reads the latest value, even when a prior setState hasn't been committed yet.
   const planningMissionIdRef = useRef(state.planningMissionId)
@@ -927,7 +936,7 @@ export function useMissionControl() {
   useLayoutEffect(() => { planningMissionIdRef.current = state.planningMissionId }, [state.planningMissionId])
   useLayoutEffect(() => { helmReleasesRef.current = helmReleases }, [helmReleases])
 
-  const askAIForSuggestions = (description: string, existingProjects: PayloadProject[] = []) => {
+  const askAIForSuggestions = async (description: string, existingProjects: PayloadProject[] = []) => {
       // #6827 — Synchronous ref guard: two rapid Enter keystrokes in a single
       // frame can both pass the stateRef.current.aiStreaming check below because
       // that ref is updated via useEffect (runs after render). This ref is set
@@ -973,9 +982,26 @@ export function useMissionControl() {
         ? `\n\nIMPORTANT — Cluster inspection results (helm releases already installed across clusters):\n${JSON.stringify(scopedReleases.map(r => ({ name: r.name, chart: r.chart, namespace: r.namespace, status: r.status, cluster: r.cluster })), null, 2)}\n\nFor each suggested project, check if it is already installed on the clusters. Include a "Cluster Inspection Summary" table in your analysis showing which components are Running vs Not installed on each cluster.`
         : ''
 
+      // #8481 — Pre-fetch Kubara catalog index so the AI knows which
+      // production-tested Helm charts are available in the Kubara platform.
+      // The fetch is non-blocking: if it fails the prompt simply omits the
+      // catalog context (graceful degradation, no user-visible error).
+      let kubaraCatalogContext = ''
+      try {
+        const catalog = await fetchKubaraCatalog()
+        if ((catalog || []).length > 0) {
+          const chartNames = (catalog || []).map(c => c.name)
+          // Populate ref so the AI response parser can tag matched projects
+          kubaraChartNamesRef.current = new Set(chartNames)
+          kubaraCatalogContext = `\n\nKubara Platform Catalog — The following production-tested Helm charts are available via the Kubara platform (kubara-io/kubara). When a Kubara chart matches a suggested project, prefer it and note "(Kubara chart available)" in the reason:\n${JSON.stringify(chartNames)}`
+        }
+      } catch {
+        // Non-critical — catalog context is optional enrichment
+      }
+
       const prompt = `You are helping plan a Kubernetes fix deployment.
 User's goal: "${description}"
-${clusterScope}${existingContext}${helmContext}
+${clusterScope}${existingContext}${helmContext}${kubaraCatalogContext}
 
 First, provide a brief executive analysis of the user's requirements and your recommended architecture approach. Explain what layers of the stack need to be covered (security, networking, observability, etc.) and why.
 
@@ -1493,7 +1519,7 @@ Order phases by dependency — prerequisites first. Each phase completes before 
   // Auto-assign: deterministic local algorithm (no AI)
   // ---------------------------------------------------------------------------
 
-  const autoAssignProjects = (availableClusters: Array<{ name: string; context?: string; server?: string; distribution?: string; cpuCores?: number; memoryGB?: number; storageGB?: number; cpuUsageCores?: number; cpuRequestsCores?: number; memoryUsageGB?: number; memoryRequestsGB?: number }>) => {
+  const autoAssignProjects = async (availableClusters: Array<{ name: string; context?: string; server?: string; distribution?: string; cpuCores?: number; memoryGB?: number; storageGB?: number; cpuUsageCores?: number; cpuRequestsCores?: number; memoryUsageGB?: number; memoryRequestsGB?: number }>) => {
       if (availableClusters.length === 0 || state.projects.length === 0) return
 
       // Category groups — projects in the same group have affinity
@@ -1512,8 +1538,50 @@ Order phases by dependency — prerequisites first. Each phase completes before 
         Storage: 'storage',
         'Backup & Recovery': 'storage' }
 
+      // #8485 — Pre-fetch Kubara catalog to look up resource requests for
+      // projects that have a matching chart. The catalog fetch is cached
+      // in-memory so repeated calls within the TTL are free.
+      let kubaraChartNames = new Set<string>()
+      try {
+        const catalog = await fetchKubaraCatalog()
+        kubaraChartNames = new Set((catalog || []).map(c => c.name))
+      } catch {
+        // Non-critical — sizing falls back to generic headroom scoring
+      }
+
+      // #8485 — Fetch resource requests for matched projects in parallel.
+      // Map: projectName → KubaraResourceRequests (only for projects with a
+      // matching Kubara chart that has parseable resource requests).
+      const projectResources = new Map<string, KubaraResourceRequests>()
+      const resourceFetchPromises: Array<Promise<void>> = []
+      for (const project of state.projects) {
+        if (kubaraChartNames.has(project.name)) {
+          resourceFetchPromises.push(
+            fetchKubaraValues(project.name)
+              .then((yaml) => {
+                if (yaml) {
+                  const resources = parseResourceRequests(yaml)
+                  if (resources) {
+                    projectResources.set(project.name, resources)
+                  }
+                }
+              })
+              .catch(() => { /* Non-critical — skip this project's sizing */ }),
+          )
+        }
+      }
+      await Promise.all(resourceFetchPromises)
+
       // Score each cluster for resource headroom (0-100)
       const clusterScores = new Map<string, number>()
+      // #8485 — Track remaining capacity per cluster (in real units) so
+      // Kubara resource requests can be subtracted as projects are assigned.
+      /** Millicores per core for unit conversion */
+      const MILLICORES_PER_CORE = 1000
+      /** MiB per GiB for unit conversion */
+      const MIB_PER_GIB = 1024
+      const clusterCpuFreeMillicores = new Map<string, number>()
+      const clusterMemFreeMiB = new Map<string, number>()
       for (const c of availableClusters) {
         const cpuTotal = c.cpuCores ?? 0
         const cpuUsed = c.cpuUsageCores ?? c.cpuRequestsCores ?? 0
@@ -1522,6 +1590,9 @@ Order phases by dependency — prerequisites first. Each phase completes before 
         const cpuFree = cpuTotal > 0 ? ((cpuTotal - cpuUsed) / cpuTotal) * 100 : 50
         const memFree = memTotal > 0 ? ((memTotal - memUsed) / memTotal) * 100 : 50
         clusterScores.set(c.name, (cpuFree + memFree) / 2)
+        // Store remaining capacity in absolute units for Kubara sizing
+        clusterCpuFreeMillicores.set(c.name, (cpuTotal - cpuUsed) * MILLICORES_PER_CORE)
+        clusterMemFreeMiB.set(c.name, (memTotal - memUsed) * MIB_PER_GIB)
       }
 
       // Track how many projects each cluster gets (for load balancing)
@@ -1561,6 +1632,9 @@ Order phases by dependency — prerequisites first. Each phase completes before 
         (a, b) => rankPriority(a.priority) - rankPriority(b.priority)
       )
 
+      /** #8485 — Penalty applied when a cluster lacks capacity for the chart's resource requests */
+      const INSUFFICIENT_CAPACITY_PENALTY = 40
+
       for (const project of sortedProjects) {
         const pName = project.name
         const group = CATEGORY_GROUPS[project.category] ?? project.category.toLowerCase()
@@ -1571,6 +1645,9 @@ Order phases by dependency — prerequisites first. Each phase completes before 
           // Don't add to newAssignments — it's already installed
           continue
         }
+
+        // #8485 — Look up Kubara resource requests for this project
+        const chartResources = projectResources.get(pName)
 
         // Score each cluster for this project
         let bestCluster = availableClusters[0].name
@@ -1596,6 +1673,18 @@ Order phases by dependency — prerequisites first. Each phase completes before 
           const load = clusterLoad.get(c.name) ?? 0
           score -= load * 8
 
+          // #8485 — Kubara resource-aware capacity check: penalize clusters
+          // that don't have enough free CPU/memory for this chart's requests.
+          if (chartResources) {
+            const freeCpu = clusterCpuFreeMillicores.get(c.name) ?? 0
+            const freeMem = clusterMemFreeMiB.get(c.name) ?? 0
+            const cpuFits = chartResources.cpuMillicores <= 0 || freeCpu >= chartResources.cpuMillicores
+            const memFits = chartResources.memoryMiB <= 0 || freeMem >= chartResources.memoryMiB
+            if (!cpuFits || !memFits) {
+              score -= INSUFFICIENT_CAPACITY_PENALTY
+            }
+          }
+
           if (score > bestScore) {
             bestScore = score
             bestCluster = c.name
@@ -1605,6 +1694,17 @@ Order phases by dependency — prerequisites first. Each phase completes before 
         // Assign
         newAssignments.get(bestCluster)!.push(pName)
         clusterLoad.set(bestCluster, (clusterLoad.get(bestCluster) ?? 0) + 1)
+
+        // #8485 — Subtract assigned chart's resource requests from the
+        // cluster's remaining capacity so subsequent projects see accurate
+        // headroom. This prevents packing too many resource-heavy charts
+        // onto a single cluster.
+        if (chartResources) {
+          const prevCpu = clusterCpuFreeMillicores.get(bestCluster) ?? 0
+          const prevMem = clusterMemFreeMiB.get(bestCluster) ?? 0
+          clusterCpuFreeMillicores.set(bestCluster, prevCpu - chartResources.cpuMillicores)
+          clusterMemFreeMiB.set(bestCluster, prevMem - chartResources.memoryMiB)
+        }
 
         // Record category affinity
         if (!categoryCluster.has(group)) {

--- a/web/src/lib/kubara.ts
+++ b/web/src/lib/kubara.ts
@@ -1,0 +1,216 @@
+/**
+ * Kubara catalog utilities for Mission Control integration.
+ *
+ * Provides helpers to fetch the Kubara chart catalog index, retrieve
+ * per-chart values.yaml contents, and parse resource requests from
+ * Helm values so that Mission Control can:
+ *   1. Include available chart names in AI suggestion context (#8481)
+ *   2. Embed values.yaml into install prompts (#8482)
+ *   3. Factor chart resource requests into cluster sizing (#8485)
+ */
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/** Timeout (ms) for fetching the Kubara catalog index */
+const KUBARA_CATALOG_FETCH_TIMEOUT_MS = 8_000
+
+/** Timeout (ms) for fetching a single chart's values.yaml */
+const KUBARA_VALUES_FETCH_TIMEOUT_MS = 10_000
+
+/** Base path inside the kubara-io/kubara repo for Helm charts */
+const KUBARA_HELM_BASE_PATH = 'go-binary/templates/embedded/managed-service-catalog/helm'
+
+/** In-memory TTL for the catalog index cache (ms) — avoids redundant fetches */
+const CATALOG_CACHE_TTL_MS = 5 * 60 * 1000
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/** A single entry in the Kubara chart catalog */
+export interface KubaraChartEntry {
+  /** Chart name (e.g. "kube-prometheus-stack") */
+  name: string
+  /** Relative path inside the repo (e.g. "go-binary/.../helm/kube-prometheus-stack") */
+  path: string
+  /** Optional description from the catalog */
+  description?: string
+}
+
+/** Parsed resource requests from a chart's values.yaml */
+export interface KubaraResourceRequests {
+  /** CPU request (in millicores, e.g. 100 for "100m", 1000 for "1") */
+  cpuMillicores: number
+  /** Memory request (in MiB, e.g. 128 for "128Mi", 1024 for "1Gi") */
+  memoryMiB: number
+}
+
+// ---------------------------------------------------------------------------
+// In-memory catalog cache
+// ---------------------------------------------------------------------------
+
+let cachedCatalog: KubaraChartEntry[] | null = null
+let cachedCatalogTimestamp = 0
+
+// ---------------------------------------------------------------------------
+// Static fallback catalog (used in demo mode and when fetch fails)
+// ---------------------------------------------------------------------------
+
+const STATIC_KUBARA_CHARTS: KubaraChartEntry[] = [
+  { name: 'kube-prometheus-stack', path: `${KUBARA_HELM_BASE_PATH}/kube-prometheus-stack`, description: 'Production Prometheus + Grafana + Alertmanager' },
+  { name: 'cert-manager', path: `${KUBARA_HELM_BASE_PATH}/cert-manager`, description: 'Automated TLS certificate management' },
+  { name: 'kyverno', path: `${KUBARA_HELM_BASE_PATH}/kyverno`, description: 'Kubernetes policy engine for security' },
+  { name: 'kyverno-policies', path: `${KUBARA_HELM_BASE_PATH}/kyverno-policies`, description: 'Curated Kyverno policy library' },
+  { name: 'argo-cd', path: `${KUBARA_HELM_BASE_PATH}/argo-cd`, description: 'Declarative GitOps continuous delivery' },
+  { name: 'external-secrets', path: `${KUBARA_HELM_BASE_PATH}/external-secrets`, description: 'Sync secrets from external providers' },
+  { name: 'loki', path: `${KUBARA_HELM_BASE_PATH}/loki`, description: 'Log aggregation system' },
+  { name: 'longhorn', path: `${KUBARA_HELM_BASE_PATH}/longhorn`, description: 'Cloud-native distributed storage' },
+  { name: 'metallb', path: `${KUBARA_HELM_BASE_PATH}/metallb`, description: 'Bare metal load balancer for Kubernetes' },
+  { name: 'traefik', path: `${KUBARA_HELM_BASE_PATH}/traefik`, description: 'Cloud-native ingress controller' },
+]
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Fetch the Kubara catalog index (list of available chart names).
+ * Returns the static fallback in demo mode or on network error.
+ * Results are cached in-memory for `CATALOG_CACHE_TTL_MS`.
+ */
+export async function fetchKubaraCatalog(): Promise<KubaraChartEntry[]> {
+  // Return cached if still fresh
+  const now = Date.now()
+  if (cachedCatalog && now - cachedCatalogTimestamp < CATALOG_CACHE_TTL_MS) {
+    return cachedCatalog
+  }
+
+  try {
+    const url = `/api/github/repos/kubara-io/kubara/contents/${encodeURIComponent(KUBARA_HELM_BASE_PATH)}`
+    const response = await fetch(url, {
+      signal: AbortSignal.timeout(KUBARA_CATALOG_FETCH_TIMEOUT_MS),
+    })
+
+    if (!response.ok) {
+      cachedCatalog = STATIC_KUBARA_CHARTS
+      cachedCatalogTimestamp = now
+      return STATIC_KUBARA_CHARTS
+    }
+
+    const data: unknown = await response.json()
+    if (!Array.isArray(data) || data.length === 0) {
+      cachedCatalog = STATIC_KUBARA_CHARTS
+      cachedCatalogTimestamp = now
+      return STATIC_KUBARA_CHARTS
+    }
+
+    const entries: KubaraChartEntry[] = (data as Array<Record<string, unknown>>)
+      .filter((item) => item.type === 'directory' || item.type === 'dir')
+      .map((item) => ({
+        name: String(item.name ?? ''),
+        path: String(item.path ?? ''),
+        description: typeof item.description === 'string' ? item.description : undefined,
+      }))
+      .filter((e) => e.name.length > 0)
+
+    cachedCatalog = entries.length > 0 ? entries : STATIC_KUBARA_CHARTS
+    cachedCatalogTimestamp = now
+    return cachedCatalog
+  } catch {
+    // Network error, timeout, parse error — fall back to static catalog
+    cachedCatalog = STATIC_KUBARA_CHARTS
+    cachedCatalogTimestamp = now
+    return STATIC_KUBARA_CHARTS
+  }
+}
+
+/**
+ * Fetch the raw values.yaml content for a specific Kubara chart.
+ * Returns `null` on any failure (network error, 404, timeout).
+ *
+ * @param chartName  The chart directory name (e.g. "cert-manager")
+ * @param valuesUrl  Optional override URL — if provided, fetches from
+ *                   that URL directly instead of the default Kubara path.
+ */
+export async function fetchKubaraValues(
+  chartName: string,
+  valuesUrl?: string,
+): Promise<string | null> {
+  try {
+    const url = valuesUrl
+      ?? `/api/github/repos/kubara-io/kubara/contents/${encodeURIComponent(`${KUBARA_HELM_BASE_PATH}/${chartName}/values.yaml`)}`
+    const response = await fetch(url, {
+      signal: AbortSignal.timeout(KUBARA_VALUES_FETCH_TIMEOUT_MS),
+    })
+
+    if (!response.ok) return null
+
+    const text = await response.text()
+    return text || null
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Parse resource requests (CPU + memory) from a values.yaml string.
+ * Looks for the `resources.requests` block and extracts `cpu` and `memory`.
+ *
+ * Returns `null` if the values don't contain parseable resource requests.
+ */
+export function parseResourceRequests(valuesYaml: string): KubaraResourceRequests | null {
+  // Simple YAML regex parsing — avoids pulling in a full YAML library.
+  // Matches patterns like:
+  //   resources:
+  //     requests:
+  //       cpu: 100m
+  //       memory: 128Mi
+  const resourcesBlock = valuesYaml.match(
+    /resources:\s*\n\s+requests:\s*\n((?:\s+\w+:.*\n?)*)/,
+  )
+  if (!resourcesBlock) return null
+
+  const block = resourcesBlock[1]
+  const cpuMatch = block.match(/cpu:\s*["']?(\d+m?|\d+\.?\d*)["']?/)
+  const memMatch = block.match(/memory:\s*["']?(\d+(?:Mi|Gi|Ki|M|G)?)["']?/)
+
+  if (!cpuMatch && !memMatch) return null
+
+  return {
+    cpuMillicores: cpuMatch ? parseCpuToMillicores(cpuMatch[1]) : 0,
+    memoryMiB: memMatch ? parseMemoryToMiB(memMatch[1]) : 0,
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+/** Convert a Kubernetes CPU string (e.g. "100m", "0.5", "1") to millicores */
+function parseCpuToMillicores(cpu: string): number {
+  if (cpu.endsWith('m')) {
+    return parseInt(cpu.slice(0, -1), 10) || 0
+  }
+  // Whole or decimal cores → millicores
+  const MILLICORES_PER_CORE = 1000
+  return Math.round((parseFloat(cpu) || 0) * MILLICORES_PER_CORE)
+}
+
+/** Convert a Kubernetes memory string (e.g. "128Mi", "1Gi", "512M") to MiB */
+function parseMemoryToMiB(mem: string): number {
+  const GI_TO_MIB = 1024
+  const KI_TO_MIB = 1 / 1024
+  const G_TO_MIB = 1000 * 1000 / (1024 * 1024) // ~953.67
+  const M_TO_MIB = 1000 * 1000 / (1024 * 1024)  // ~0.954 per MB
+
+  if (mem.endsWith('Gi')) return Math.round((parseFloat(mem) || 0) * GI_TO_MIB)
+  if (mem.endsWith('Mi')) return Math.round(parseFloat(mem) || 0)
+  if (mem.endsWith('Ki')) return Math.round((parseFloat(mem) || 0) * KI_TO_MIB)
+  if (mem.endsWith('G')) return Math.round((parseFloat(mem) || 0) * G_TO_MIB)
+  if (mem.endsWith('M')) return Math.round((parseFloat(mem) || 0) * M_TO_MIB)
+  // Raw number — assume bytes → MiB
+  const BYTES_PER_MIB = 1024 * 1024
+  return Math.round((parseFloat(mem) || 0) / BYTES_PER_MIB)
+}


### PR DESCRIPTION
## Summary

Fixes #8481, Fixes #8482, Fixes #8485

Integrates the Kubara platform catalog into Mission Control's three key phases:

- **Phase 1 — AI Suggestions (#8481):** `askAIForSuggestions()` pre-fetches the Kubara catalog index and includes available chart names in the AI prompt context. The AI can now recommend production-tested Kubara charts and matched projects are tagged with `kubaraChartName` for downstream use.
- **Phase 2 — Cluster Sizing (#8485):** `autoAssignProjects()` fetches resource requests (CPU/memory) from matched Kubara charts' `values.yaml` and factors them into cluster capacity calculation. Clusters lacking capacity receive a scoring penalty and assigned resources are subtracted from remaining headroom for subsequent projects.
- **Phase 3 — Install Prompt (#8482):** `loadMissionPrompt()` accepts an optional `kubaraValuesUrl`/`kubaraChartName` parameter. When provided, it fetches and embeds production-tested Helm values into the install prompt.

New `lib/kubara.ts` utility provides `fetchKubaraCatalog()`, `fetchKubaraValues()`, and `parseResourceRequests()` with in-memory caching and static fallback.

## Test plan

- [ ] Verify `askAIForSuggestions` includes Kubara catalog context in the prompt (check console logs or AI response mentioning "Kubara chart available")
- [ ] Verify `loadMissionPrompt` embeds values.yaml when `kubaraChartName` is provided
- [ ] Verify `autoAssignProjects` factors resource requests into cluster scoring (projects should prefer clusters with more headroom)
- [ ] Verify graceful degradation: all three features fall back cleanly when Kubara catalog fetch fails
- [ ] Build passes: `cd web && npm run build && npm run lint`