### PR TITLE
🧪 fix: address Copilot review on UnifiedStatBlock tests (#8528)

### DIFF
--- a/web/src/lib/unified/stats/__tests__/UnifiedStatBlock.test.tsx
+++ b/web/src/lib/unified/stats/__tests__/UnifiedStatBlock.test.tsx
@@ -4,14 +4,11 @@
 import { describe, it, expect, vi } from 'vitest'
 import { render, screen, fireEvent } from '@testing-library/react'
 
-vi.mock('../../../../lib/modeTransition', () => ({
+vi.mock('../demo', () => ({
   useIsModeSwitching: () => false,
 }))
 vi.mock('../valueResolvers', () => ({
   resolveStatValue: () => ({ value: 42, sublabel: 'pods', isDemo: false }),
-}))
-vi.mock('../../../../lib/cn', () => ({
-  cn: (...args: unknown[]) => args.filter(Boolean).join(' '),
 }))
 
 import UnifiedStatBlock from '../UnifiedStatBlock'
@@ -21,24 +18,24 @@ const BASE_CONFIG = {
   name: 'Healthy Nodes',
   icon: 'Server',
   color: 'green',
-  valueSource: { type: 'field' as const, field: 'healthy' },
+  valueSource: { type: 'field' as const, path: 'summary.healthy' },
 }
 
 describe('UnifiedStatBlock', () => {
   it('renders config name and resolved value', () => {
     render(<UnifiedStatBlock config={BASE_CONFIG} data={{}} />)
-    expect(screen.getByText('Healthy Nodes')).toBeDefined()
-    expect(screen.getByText('42')).toBeDefined()
+    expect(screen.getByText('Healthy Nodes')).toBeInTheDocument()
+    expect(screen.getByText('42')).toBeInTheDocument()
   })
 
   it('renders sublabel when present', () => {
     render(<UnifiedStatBlock config={{ ...BASE_CONFIG, sublabelField: 'sublabel' }} data={{}} />)
-    expect(screen.getByText('pods')).toBeDefined()
+    expect(screen.getByText('pods')).toBeInTheDocument()
   })
 
   it('shows placeholder "-" when isLoading', () => {
     render(<UnifiedStatBlock config={BASE_CONFIG} data={{}} isLoading />)
-    expect(screen.getByText('-')).toBeDefined()
+    expect(screen.getByText('-')).toBeInTheDocument()
   })
 
   it('uses getValue override when provided', () => {
@@ -49,7 +46,7 @@ describe('UnifiedStatBlock', () => {
         getValue={() => ({ value: 99, isClickable: false })}
       />,
     )
-    expect(screen.getByText('99')).toBeDefined()
+    expect(screen.getByText('99')).toBeInTheDocument()
   })
 
   it('renders tooltip from config', () => {
@@ -68,7 +65,7 @@ describe('UnifiedStatBlock', () => {
   })
 
   it('applies value color based on config.id', () => {
-    const { container } = render(
+    render(
       <UnifiedStatBlock config={{ ...BASE_CONFIG, id: 'critical' }} data={{}} />,
     )
     // "critical" maps to text-red-400
@@ -77,16 +74,15 @@ describe('UnifiedStatBlock', () => {
   })
 
   it('is clickable when config.onClick is set', () => {
-    const onClick = vi.fn()
-    // handleStatClick dispatches events — we just verify the click handler fires
     const { container } = render(
       <UnifiedStatBlock
-        config={{ ...BASE_CONFIG, onClick: { type: 'navigate', path: '/test' } }}
+        config={{ ...BASE_CONFIG, onClick: { type: 'navigate', target: '/test' } }}
         data={{}}
       />,
     )
-    fireEvent.click(container.firstElementChild!)
     // The internal handleStatClick uses window.location — hard to assert
     // in jsdom, but the click should not throw.
+    fireEvent.click(container.firstElementChild!)
+    expect(container.firstElementChild).toBeInTheDocument()
   })
 })


### PR DESCRIPTION
## Summary
- Fix `valueSource` to use `{ type: 'field', path }` matching the `StatValueSourceField` type instead of `{ type: 'field', field }`
- Mock `useIsModeSwitching` from `../demo` (where the component actually imports it) instead of unused `modeTransition` and `cn` mocks
- Fix `onClick` shape to use `{ target }` matching `StatBlockAction` type instead of `{ path }`
- Add assertion to click test, remove unused `container` and `onClick` locals
- Replace redundant `.toBeDefined()` with `.toBeInTheDocument()` from jest-dom (`getByText` already throws if not found)

Fixes #8528

## Test plan
- [x] All 8 tests in `UnifiedStatBlock.test.tsx` pass
- [x] `npm run build` passes
- [x] `npm run lint` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)