### PR TITLE
🐛 fix(mission-control): modal top clears navbar instead of hiding behind it

### DIFF
--- a/web/src/components/mission-control/MissionControlDialog.tsx
+++ b/web/src/components/mission-control/MissionControlDialog.tsx
@@ -228,8 +228,12 @@ export function MissionControlDialog({ open, onClose, initialKubaraChart }: Miss
     setHighestReached(0)
   }
 
-  /** Inset (in px) from viewport edges so the backdrop peeks through */
-  const MODAL_INSET_PX = 16
+  /** Inset from left/right/bottom so the backdrop peeks through. */
+  const MODAL_SIDE_INSET_PX = 16
+  /** Top inset must clear the fixed navbar (64px) + a small gap so the
+   *  modal header doesn't hide behind it. Previous value was 16px which
+   *  left the top ~48px of the modal obscured. */
+  const MODAL_TOP_INSET_PX = 80 // NAVBAR_HEIGHT_PX (64) + 16px breathing room
 
   return (
     <AnimatePresence>
@@ -255,7 +259,10 @@ export function MissionControlDialog({ open, onClose, initialKubaraChart }: Miss
             data-testid="mission-control-dialog"
             className="fixed z-modal flex flex-col bg-background rounded-xl border border-border shadow-2xl shadow-black/30 overflow-hidden"
             style={{
-              inset: `${MODAL_INSET_PX}px`,
+              top: `${MODAL_TOP_INSET_PX}px`,
+              left: `${MODAL_SIDE_INSET_PX}px`,
+              right: `${MODAL_SIDE_INSET_PX}px`,
+              bottom: `${MODAL_SIDE_INSET_PX}px`,
             }}
             initial={{ opacity: 0, scale: 0.97, y: 12 }}
             animate={{ opacity: 1, scale: 1, y: 0 }}


### PR DESCRIPTION
## Summary

The Mission Control dialog ("Define Your Mission") hides behind the fixed navbar because it uses \`inset: 16px\` for all four edges — but the navbar is 64px tall, so the top 48px of the modal is obscured.

**Fix:** Split the single \`inset\` into explicit \`top/left/right/bottom\`. Top is now **80px** (64px navbar + 16px gap). Left/right/bottom stay at 16px.

## Test plan

- [x] \`npm run build\` passes
- [ ] Open Mission Control → modal header is fully visible below the navbar
- [ ] Resize window → modal still fits with backdrop visible on all sides

🤖 Generated with [Claude Code](https://claude.com/claude-code)