### PR TITLE
🐛 fix: Login wizard — Copilot review + hex ratchet (#8546, #8547)

### DIFF
--- a/web/src/components/auth/Login.test.tsx
+++ b/web/src/components/auth/Login.test.tsx
@@ -1,21 +1,25 @@
 /// <reference types='@testing-library/jest-dom/vitest' />
 import { describe, it, expect, vi } from 'vitest'
-import { render, screen } from '@testing-library/react'
+import { render, screen, waitFor } from '@testing-library/react'
 import { MemoryRouter } from 'react-router-dom'
 
 import '../../test/utils/setupMocks'
 
+const mockLogin = vi.fn()
+
 vi.mock('../../lib/auth', () => ({
   useAuth: () => ({
-    login: vi.fn(),
+    login: mockLogin,
     isAuthenticated: false,
     isLoading: false,
   }),
 }))
 
+/** Resolved value for the OAuth probe — overridden per-test when needed. */
+let oauthProbeResult = { backendUp: false, oauthConfigured: false }
+
 vi.mock('../../lib/api', () => ({
-  checkOAuthConfigured: () =>
-    Promise.resolve({ backendUp: false, oauthConfigured: false }),
+  checkOAuthConfiguredWithRetry: () => Promise.resolve(oauthProbeResult),
 }))
 
 vi.mock('react-i18next', () => ({
@@ -31,6 +35,11 @@ describe('Login Component', () => {
         <Login />
       </MemoryRouter>,
     )
+
+  beforeEach(() => {
+    oauthProbeResult = { backendUp: false, oauthConfigured: false }
+    mockLogin.mockClear()
+  })
 
   it('renders without crashing', () => {
     expect(() => renderLogin()).not.toThrow()
@@ -56,5 +65,34 @@ describe('Login Component', () => {
   it('renders the KubeStellar branding', () => {
     renderLogin()
     expect(screen.getByText('KubeStellar')).toBeInTheDocument()
+  })
+
+  describe('OAuth setup wizard (backendUp && !oauthConfigured)', () => {
+    beforeEach(() => {
+      oauthProbeResult = { backendUp: true, oauthConfigured: false }
+    })
+
+    it('shows the setup notice when backend is up but OAuth is not configured', async () => {
+      renderLogin()
+      await waitFor(() => {
+        expect(screen.getByTestId('oauth-setup-notice')).toBeInTheDocument()
+      })
+    })
+
+    it('renders a distinct setup button (not github-login-button)', async () => {
+      renderLogin()
+      await waitFor(() => {
+        expect(screen.getByTestId('github-setup-button')).toBeInTheDocument()
+      })
+      // The standard login button should not be present when setup wizard is shown
+      expect(screen.queryByTestId('github-login-button')).not.toBeInTheDocument()
+    })
+
+    it('renders a demo mode button', async () => {
+      renderLogin()
+      await waitFor(() => {
+        expect(screen.getByTestId('demo-mode-button')).toBeInTheDocument()
+      })
+    })
   })
 })

--- a/web/src/components/auth/Login.tsx
+++ b/web/src/components/auth/Login.tsx
@@ -3,7 +3,7 @@ import { AlertTriangle, ExternalLink, Settings, Copy, Check, ChevronDown, Chevro
 import { Github } from '@/lib/icons'
 import { Navigate, useSearchParams } from 'react-router-dom'
 import { useAuth } from '../../lib/auth'
-import { checkOAuthConfigured } from '../../lib/api'
+import { checkOAuthConfiguredWithRetry } from '../../lib/api'
 import { ROUTES } from '../../config/routes'
 import { useTranslation } from 'react-i18next'
 import { emitLogin } from '../../lib/analytics'
@@ -197,7 +197,8 @@ export function Login() {
   }, [])
 
   const handleCopyStep = async (text: string, stepKey: number) => {
-    await copyToClipboard(text)
+    const ok = await copyToClipboard(text)
+    if (!ok) return
     setCopiedStep(stepKey)
     clearTimeout(copiedTimerRef.current)
     copiedTimerRef.current = setTimeout(() => setCopiedStep(null), UI_FEEDBACK_TIMEOUT_MS)
@@ -239,17 +240,17 @@ export function Login() {
     // When the backend is up but OAuth is not configured, show the login page
     // with setup instructions rather than silently auto-logging in as a demo
     // user. Users can still choose "Continue in Demo Mode" from the page.
-    checkOAuthConfigured().then(({ backendUp, oauthConfigured }) => {
+    checkOAuthConfiguredWithRetry().then(({ backendUp, oauthConfigured }) => {
       if (backendUp && !oauthConfigured) {
         setShowOAuthSetup(true)
       }
-    }).catch(() => { /* checkOAuthConfigured always resolves — defensive catch */ })
+    }).catch(() => { /* checkOAuthConfiguredWithRetry always resolves — defensive catch */ })
   }, [isLoading, isAuthenticated, login, oauthError, branding.hostedDomain])
 
   // Show loading while checking auth status
   if (isLoading) {
     return (
-      <div className="min-h-screen flex items-center justify-center bg-[#0a0a0a]">
+      <div className="min-h-screen flex items-center justify-center bg-background">
         <div className="animate-spin rounded-full h-8 w-8 border-2 border-transparent border-t-primary" />
       </div>
     )
@@ -261,7 +262,7 @@ export function Login() {
   }
 
   return (
-    <div data-testid="login-page" className="h-screen flex bg-[#0a0a0a] relative overflow-hidden">
+    <div data-testid="login-page" className="h-screen flex bg-background relative overflow-hidden">
       {/* Left side - Login form */}
       <div className="flex-1 h-full flex items-center justify-center relative z-10">
         {/* Star field background (left side only) */}
@@ -359,8 +360,8 @@ export function Login() {
           </div>
 
           {/* Hosted demo notice — shown when on the hosted demo domain so users
-              understand that GitHub OAuth is intentionally unavailable and that
-              they'll be auto-logged-in as a demo user. Ref: #6338. */}
+            * understand that GitHub OAuth is intentionally unavailable and that
+            * they'll be auto-logged-in as a demo user. Ref: #6338. */}
           {isHostedDemoLogin && (
             <div className="mb-4 px-4 py-3 rounded-lg border border-purple-500/30 bg-purple-500/10 text-purple-200 text-xs">
               <div className="font-medium text-purple-300 mb-1">Hosted demo</div>
@@ -382,9 +383,9 @@ export function Login() {
           )}
 
           {/* OAuth not configured notice — shown when the backend is running
-              but no GITHUB_CLIENT_ID / GITHUB_CLIENT_SECRET are set. Gives
-              self-hosted users a clear path to enable GitHub sign-in instead
-              of silently falling into demo mode (#3761). */}
+            * but no GITHUB_CLIENT_ID / GITHUB_CLIENT_SECRET are set. Gives
+            * self-hosted users a clear path to enable GitHub sign-in instead
+            * of silently falling into demo mode (#3761). */}
           {showOAuthSetup && !oauthError && (
             <div data-testid="oauth-setup-notice" className="mb-4 rounded-lg border border-blue-500/30 bg-blue-500/5 overflow-hidden">
               <div className="px-4 py-3">
@@ -508,7 +509,7 @@ export function Login() {
           {showOAuthSetup && (
             <div className="space-y-3">
               <button
-                data-testid="github-login-button"
+                data-testid="github-setup-button"
                 onClick={() => setOauthSetupExpanded(true)}
                 className="w-full flex items-center justify-center gap-3 bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 font-medium py-3 px-4 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-700 transition-all duration-200 hover:shadow-lg"
               >
@@ -544,7 +545,7 @@ export function Login() {
       {/* Right side - Globe animation */}
       <div className="hidden lg:block flex-1 h-full relative overflow-hidden">
         {/* Subtle gradient background for the globe side */}
-        <div className="absolute inset-0 bg-gradient-to-l from-[#0a0f1c] to-transparent" />
+        <div className="absolute inset-0 bg-gradient-to-l from-background to-transparent" />
         {/* Wrapper div ensures the globe is absolutely positioned (GlobeAnimation
             internally prepends "relative" to className which overrides "absolute"
             in Tailwind's CSS ordering, causing layout breakage). */}

--- a/web/src/test/ui-ux-standards.test.ts
+++ b/web/src/test/ui-ux-standards.test.ts
@@ -82,9 +82,13 @@ const COMPONENTS_DIR = path.resolve(
 //              that incremented the ratchet over many previous bumps. The
 //              new baseline is the count of real `#RRGGBB` literals only.
 //   270 → 271: PR #8550 ratchet drift — pre-existing hex literal not introduced by this PR
-const EXPECTED_RAW_HEX_COUNT = 271
+//   271 → 269: PR #8546 — fixed comment continuation lines in Login.tsx
+//              that tripped false-positive hex detection (#6338, #3761 refs)
+const EXPECTED_RAW_HEX_COUNT = 269
 const EXPECTED_RAW_RGBA_COUNT = 104
-const EXPECTED_ARBITRARY_TW_COLOR_COUNT = 22
+//   22 → 19: PR #8547 — replaced 3 arbitrary Tailwind hex colors in Login.tsx
+//            (bg-[#0a0a0a], from-[#0a0f1c]) with semantic bg-background/from-background
+const EXPECTED_ARBITRARY_TW_COLOR_COUNT = 19
 // Inline style color ratchet — bump history:
 //   213 → 215: Drasi reactive graph (PRs #7832, #7857) — two new
 //              echarts/flow-node inline colors not covered by theming utils.


### PR DESCRIPTION
## Summary

- **handleCopyStep**: Only show success feedback when `copyToClipboard()` actually succeeds (was showing checkmark even on failure)
- **OAuth probe**: Use `checkOAuthConfiguredWithRetry()` to retry/poll when the backend is slow to start, instead of a single-shot `checkOAuthConfigured()`
- **Distinct testids**: Setup button now uses `data-testid="github-setup-button"` instead of reusing `"github-login-button"`
- **Test coverage**: Added 3 test cases covering the OAuth setup wizard path (`backendUp && !oauthConfigured`)
- **Hex ratchet**: Replaced 3 raw hex colors (`bg-[#0a0a0a]`, `from-[#0a0f1c]`) with semantic `bg-background`/`from-background`; fixed multi-line comment continuation lines that caused false-positive hex detection; lowered ratchet baselines accordingly

Fixes #8546, Fixes #8547

## Test plan

- [x] `npm run build` passes
- [x] `npm run lint` passes (no new warnings)
- [x] `npx vitest run src/test/ui-ux-standards.test.ts` — hex ratchet passes with lowered baselines
- [x] `npx vitest run src/components/auth/Login.test.tsx` — all 8 tests pass (5 existing + 3 new)