### PR TITLE
🐛 fix: CI/CD cards respect repo dropdown selection (#8556)

### DIFF
--- a/web/netlify/functions/github-pipelines.mts
+++ b/web/netlify/functions/github-pipelines.mts
@@ -208,8 +208,12 @@ async function gh(path: string, token: string, init: RequestInit = {}): Promise<
   });
 }
 
+/** Matches `owner/repo` format — allows any valid GitHub repo, not just
+ * preconfigured PIPELINE_REPOS. The token's access controls what's fetchable. */
+const VALID_REPO_PATTERN = /^[a-zA-Z0-9._-]+\/[a-zA-Z0-9._-]+$/;
+
 function isValidRepo(repo: string | null): boolean {
-  return !!repo && REPOS.includes(repo);
+  return !!repo && VALID_REPO_PATTERN.test(repo);
 }
 
 /** YYYY-MM-DD in UTC */
@@ -342,21 +346,26 @@ interface PulsePayload {
 
 async function buildPulse(
   store: ReturnType<typeof getStore>,
-  token: string
+  token: string,
+  repoFilter: string | null
 ): Promise<PulsePayload> {
-  const res = await gh(
-    `/repos/${NIGHTLY_RELEASE_REPO}/actions/workflows/${NIGHTLY_RELEASE_WORKFLOW}/runs?per_page=${MATRIX_DEFAULT_DAYS}`,
-    token
-  );
+  // When a specific repo is selected, fetch its most recent workflow runs
+  // across all workflows. When null, use the default nightly release workflow.
+  const targetRepo = repoFilter && isValidRepo(repoFilter) ? repoFilter : NIGHTLY_RELEASE_REPO;
+  const isDefault = targetRepo === NIGHTLY_RELEASE_REPO;
+  const apiPath = isDefault
+    ? `/repos/${targetRepo}/actions/workflows/${NIGHTLY_RELEASE_WORKFLOW}/runs?per_page=${MATRIX_DEFAULT_DAYS}`
+    : `/repos/${targetRepo}/actions/runs?per_page=${MATRIX_DEFAULT_DAYS}`;
+  const res = await gh(apiPath, token);
   if (!res.ok) throw new Error(`pulse: GitHub ${res.status}`);
   const data = (await res.json()) as { workflow_runs: Array<Record<string, unknown>> };
-  const runs = (data.workflow_runs ?? []).map((r) => normalizeRun(r, NIGHTLY_RELEASE_REPO));
+  const runs = (data.workflow_runs ?? []).map((r) => normalizeRun(r, targetRepo));
   mergeIntoHistory(await readHistory(store), runs); // side-effect updates below
 
   // Latest release tag (best-effort — release might be on the same day as the run)
   let releaseTag: string | null = null;
   try {
-    const rel = await gh(`/repos/${NIGHTLY_RELEASE_REPO}/releases?per_page=1`, token);
+    const rel = await gh(`/repos/${targetRepo}/releases?per_page=1`, token);
     if (rel.ok) {
       const releases = (await rel.json()) as Array<{ tag_name?: string }>;
       releaseTag = releases[0]?.tag_name ?? null;
@@ -777,7 +786,7 @@ export default async (req: Request): Promise<Response> => {
     let payload: unknown;
     switch (view) {
       case "pulse":
-        payload = await buildPulse(store, token);
+        payload = await buildPulse(store, token, url.searchParams.get("repo"));
         break;
       case "matrix": {
         const daysRaw = parseInt(url.searchParams.get("days") ?? String(MATRIX_DEFAULT_DAYS), 10);

--- a/web/src/components/cards/pipelines/NightlyReleasePulse.tsx
+++ b/web/src/components/cards/pipelines/NightlyReleasePulse.tsx
@@ -252,7 +252,7 @@ export function NightlyReleasePulse() {
     ? shared.repoFilter
     : standaloneRepo.includes('/') ? standaloneRepo.trim() : null
 
-  const { data: pulseData, isLoading: pulseLoading, error: pulseError, refetch } = usePipelinePulse()
+  const { data: pulseData, isLoading: pulseLoading, error: pulseError, refetch } = usePipelinePulse(effectiveRepoFilter)
   const { data: matrixData, isLoading: matrixLoading } = usePipelineMatrix(effectiveRepoFilter, MATRIX_DAYS)
   const { isDemoMode } = useDemoMode()
 

--- a/web/src/hooks/__tests__/useGitHubPipelines.test.ts
+++ b/web/src/hooks/__tests__/useGitHubPipelines.test.ts
@@ -133,9 +133,14 @@ describe('DEMO_FAILURES', () => {
 describe('hooks pass correct useCache config', () => {
   beforeEach(() => { lastCacheArgs.calls = [] })
 
-  it('usePipelinePulse uses key gh-pipelines-pulse', () => {
-    renderHook(() => usePipelinePulse())
-    expect(lastCacheArgs.calls.some(a => a.key === 'gh-pipelines-pulse')).toBe(true)
+  it('usePipelinePulse with null repo uses key gh-pipelines-pulse:all', () => {
+    renderHook(() => usePipelinePulse(null))
+    expect(lastCacheArgs.calls.some(a => a.key === 'gh-pipelines-pulse:all')).toBe(true)
+  })
+
+  it('usePipelinePulse with specific repo includes repo in key', () => {
+    renderHook(() => usePipelinePulse('kubestellar/docs'))
+    expect(lastCacheArgs.calls.some(a => (a.key as string).includes('kubestellar/docs'))).toBe(true)
   })
 
   it('usePipelineMatrix uses key containing the repo', () => {

--- a/web/src/hooks/useGitHubPipelines.ts
+++ b/web/src/hooks/useGitHubPipelines.ts
@@ -321,15 +321,19 @@ async function fetchView<T>(params: URLSearchParams): Promise<T> {
 // Hooks — one per view
 // ---------------------------------------------------------------------------
 
-export function usePipelinePulse() {
+export function usePipelinePulse(repo: string | null) {
   return useCache<PulsePayload>({
-    key: 'gh-pipelines-pulse',
+    key: `gh-pipelines-pulse:${repo ?? 'all'}`,
     category: 'default',
     refreshInterval: DEFAULT_POLL_MS,
     initialData: DEMO_PULSE,
     demoData: DEMO_PULSE,
     liveInDemoMode: true,
-    fetcher: () => fetchView<PulsePayload>(new URLSearchParams({ view: 'pulse' })),
+    fetcher: () => {
+      const p = new URLSearchParams({ view: 'pulse' })
+      if (repo) p.set('repo', repo)
+      return fetchView<PulsePayload>(p)
+    },
   })
 }
 


### PR DESCRIPTION
## Summary
- **`usePipelinePulse`** now accepts a `repo` parameter (like `usePipelineMatrix`, `usePipelineFlow`, `usePipelineFailures` already do) and passes it to the API
- **`NightlyReleasePulse`** card passes its `effectiveRepoFilter` to `usePipelinePulse` so the pulse view fetches data for the selected repo
- **Netlify Function `buildPulse`** accepts a `repo` query param — when specified, fetches that repo's workflow runs instead of always using the hardcoded `kubestellar/console` nightly release workflow
- **`isValidRepo`** now accepts any valid `owner/repo` format string (regex-validated) instead of restricting to preconfigured `PIPELINE_REPOS`, so user-added repos work

## Root cause
`usePipelinePulse()` took no parameters and always fetched without a `repo` query param. The backend's `buildPulse` was hardcoded to `NIGHTLY_RELEASE_REPO` (`kubestellar/console`) and `NIGHTLY_RELEASE_WORKFLOW` (`release.yml`). When a user selected a different repo in the card dropdown, the pulse data never changed.

## Test plan
- [ ] Select a non-default repo in the CI/CD dashboard dropdown — NightlyReleasePulse card should show that repo's data
- [ ] Select "All repos" — card should show the default nightly release pulse
- [ ] Verify WorkflowMatrix, PipelineFlow, RecentFailures continue to respect repo selection (unchanged)
- [ ] Existing tests pass (`npm run build && npm run lint`)

Fixes #8556