### PR TITLE
🐛 Fix: pipeline cards can query any GitHub repo (not just preconfigured)

### DIFF
--- a/pkg/api/handlers/github_pipelines.go
+++ b/pkg/api/handlers/github_pipelines.go
@@ -86,6 +86,13 @@ func ghpGetRepos() []string {
 var ghpRepos = ghpGetRepos()
 
 func ghpIsAllowedRepo(repo string) bool {
+	// Accept any valid owner/repo slug — the GitHub token's permissions
+	// are the real access control. The preconfigured list only controls
+	// which repos are fetched by default (no filter), not which repos
+	// a user is allowed to query.
+	if strings.Contains(repo, "/") && len(repo) > 2 {
+		return true
+	}
 	for _, r := range ghpRepos {
 		if r == repo {
 			return true


### PR DESCRIPTION
## Summary

Pipeline cards rejected repos not in the PIPELINE_REPOS allowlist. When users selected ublue-os/bluefin in the dropdown, the backend returned 'unknown repo' and the card fell back to kubestellar/console data.

**Fix:** ghpIsAllowedRepo() now accepts any valid owner/repo slug. The GitHub token's permissions are the real access control — the preconfigured list only controls the default repos when no filter is specified.

**Verified via Chrome CDP:** API returns real bluefin workflow data (AI Moderator, etc.) after the fix.

## Test plan

- [ ] Select ublue-os/bluefin in Workflow Matrix dropdown → shows bluefin workflows
- [ ] Default (no selection) → still shows preconfigured kubestellar repos
- [ ] Invalid repo → GitHub API returns 404, card shows appropriate error