### PR TITLE
fix(ui): increase FAB right clearance to 64px

### DIFF
--- a/web/src/components/dashboard/FloatingDashboardActions.tsx
+++ b/web/src/components/dashboard/FloatingDashboardActions.tsx
@@ -125,12 +125,12 @@ export function FloatingDashboardActions({
 
   const getPositionClasses = () => {
     if (isMobile) return 'left-4 bottom-4'
-    // right-10 (40px) instead of right-6 (24px) — the scrollbar on
-    // the main content area eats ~15px of viewport width, so right-6
-    // left the 40px button clipped to a half-circle (#8464 follow-up).
-    if (!isSidebarOpen) return 'right-10 bottom-20'
-    if (isSidebarMinimized) return 'right-[88px] bottom-20'
-    return 'right-[552px] bottom-20'
+    // right-16 (64px) keeps the 40px FAB fully visible regardless of
+    // macOS "always-show scrollbars" preference, browser zoom, or any
+    // future scrollbar-gutter changes (#8551 follow-up).
+    if (!isSidebarOpen) return 'right-16 bottom-20'
+    if (isSidebarMinimized) return 'right-[104px] bottom-20'
+    return 'right-[568px] bottom-20'
   }
   const positionClasses = getPositionClasses()
 


### PR DESCRIPTION
## Summary
- Bumps FAB (Console Studio / + button) right offset from `right-10` (40px) to `right-16` (64px)
- Proportionally adjusts sidebar-open variants: `right-[88px]` → `right-[104px]`, `right-[552px]` → `right-[568px]`
- Prevents clipping on viewports with always-visible scrollbars, browser zoom, or scrollbar-gutter changes

Follow-up to #8551 which bumped `right-6` → `right-10` but was still reported as truncated.

## Test plan
- [ ] Verify FAB fully visible on main dashboard (no sidebar)
- [ ] Verify FAB fully visible with mission sidebar minimized
- [ ] Verify FAB fully visible with mission sidebar fully open
- [ ] Verify FAB visible with macOS "Always show scrollbars" enabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)