### PR TITLE
🐛 fix: cluster info cards overflow on hover (#8559)

### DIFF
--- a/web/src/components/clusters/components/ClusterGrid.tsx
+++ b/web/src/components/clusters/components/ClusterGrid.tsx
@@ -931,7 +931,7 @@ export const ClusterGrid = memo(function ClusterGrid({
   return (
     <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={handleDragEnd}>
       <SortableContext items={clusterIds} strategy={sortingStrategy}>
-        <div className={`${gridClasses[layoutMode]} mb-6`}>
+        <div className={`${gridClasses[layoutMode]} mb-6 overflow-hidden px-2 -mx-2 py-1 -my-1`}>
           {clusters.map((cluster) => {
             const clusterKey = cluster.name.split('/')[0]
             const gpuInfo = gpuByCluster[clusterKey] || gpuByCluster[cluster.name]


### PR DESCRIPTION
## Summary
- Add `overflow-hidden` with compensating padding (`px-2 -mx-2 py-1 -my-1`) to the cluster grid container
- The `hover:scale-[1.02]` animation on edge cards caused them to extend beyond the container boundary, creating horizontal overflow
- The padding gives cards room to scale visually while `overflow-hidden` clips any remaining overflow

Fixes #8559

## Test plan
- [ ] Hover over the leftmost cluster info card — should not overflow left
- [ ] Hover over the rightmost cluster info card — should not overflow right
- [ ] Verify hover scale animation still looks smooth
- [ ] Test all layout modes (grid, list, compact, wide)