### PR TITLE
🐛 fix: standardize add-card button placement across dashboards (#8561)

### DIFF
--- a/web/src/components/dashboard/CustomDashboard.tsx
+++ b/web/src/components/dashboard/CustomDashboard.tsx
@@ -140,7 +140,7 @@ function SortableCard({ card, onConfigure, onRemove, onWidthChange, onHeightChan
         {onInsertAfter && (
           <button
             onClick={(e) => { e.stopPropagation(); onInsertAfter() }}
-            className="absolute -top-2 -right-2 z-20 opacity-0 group-hover/card:opacity-100 transition-all w-6 h-6 rounded-full bg-primary text-primary-foreground flex items-center justify-center text-sm font-bold shadow-lg hover:scale-110 ring-2 ring-background"
+            className="absolute top-1/2 -translate-y-1/2 right-2 z-20 opacity-0 group-hover/card:opacity-100 focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary transition-all w-6 h-6 rounded-full bg-primary text-primary-foreground flex items-center justify-center text-sm font-bold shadow-lg hover:scale-110 ring-2 ring-background"
             aria-label="Add card"
             title="Add card here"
           >
@@ -174,7 +174,7 @@ function SortableCard({ card, onConfigure, onRemove, onWidthChange, onHeightChan
       {onInsertAfter && (
         <button
           onClick={(e) => { e.stopPropagation(); onInsertAfter() }}
-          className="absolute -top-2 -right-2 z-20 opacity-0 group-hover/card:opacity-100 transition-all w-6 h-6 rounded-full bg-primary text-primary-foreground flex items-center justify-center text-sm font-bold shadow-lg hover:scale-110 ring-2 ring-background"
+          className="absolute top-1/2 -translate-y-1/2 right-2 z-20 opacity-0 group-hover/card:opacity-100 focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary transition-all w-6 h-6 rounded-full bg-primary text-primary-foreground flex items-center justify-center text-sm font-bold shadow-lg hover:scale-110 ring-2 ring-background"
           aria-label="Add card"
           title="Add card here"
         >

--- a/web/src/lib/dashboards/DashboardComponents.tsx
+++ b/web/src/lib/dashboards/DashboardComponents.tsx
@@ -74,7 +74,10 @@ export const SortableDashboardCard = memo(function SortableDashboardCard({
       {onInsertAfter && (
         <button
           onClick={(e) => { e.stopPropagation(); onInsertAfter() }}
-          className="absolute -top-2 -right-2 z-20 opacity-0 group-hover/card:opacity-100 transition-all w-6 h-6 rounded-full bg-primary text-primary-foreground flex items-center justify-center text-sm font-bold shadow-lg hover:scale-110 ring-2 ring-background"
+          // Anchor to the right edge centered vertically so the "+"
+          // sits between this card and the next column, consistent with
+          // SharedSortableCard.tsx (#8383, #8561).
+          className="absolute top-1/2 -translate-y-1/2 right-2 z-20 opacity-0 group-hover/card:opacity-100 focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary transition-all w-6 h-6 rounded-full bg-primary text-primary-foreground flex items-center justify-center text-sm font-bold shadow-lg hover:scale-110 ring-2 ring-background"
           aria-label="Add card"
           title="Add card here"
         >


### PR DESCRIPTION
## Summary
- Standardizes the per-card "+" (add card here) button to **middle-right** positioning (`top-1/2 -translate-y-1/2 right-2`) across all dashboard card components
- Previously, `DashboardComponents.tsx` and `CustomDashboard.tsx` used top-right (`-top-2 -right-2`) while `SharedSortableCard.tsx` already used middle-right — causing inconsistent placement on dashboards like Security Compliance
- Also adds `focus-visible` accessibility styles to match the SharedSortableCard pattern

## Files changed
- `web/src/lib/dashboards/DashboardComponents.tsx` — update SortableDashboardCard add button position
- `web/src/components/dashboard/CustomDashboard.tsx` — update both card variants (unknown + known card types)

## Test plan
- [ ] Hover over cards on the main dashboard — "+" button appears at middle-right
- [ ] Hover over cards on Security Compliance dashboard — "+" button appears at middle-right (was top-right)
- [ ] Hover over cards on custom dashboards — "+" button appears at middle-right
- [ ] Verify no overflow/clipping of the "+" button on any dashboard

Fixes #8561