### PR TITLE
🐛 Fix: Daily Issues & PRs respects central repo selection

### DIFF
--- a/web/src/components/cards/GitHubActivity.tsx
+++ b/web/src/components/cards/GitHubActivity.tsx
@@ -11,6 +11,7 @@ import { useCardLoadingState } from './CardDataContext'
 import type { SortDirection } from '../../lib/cards/cardHooks'
 import { useTranslation } from 'react-i18next'
 import { StatusBadge } from '../ui/StatusBadge'
+import { usePipelineFilter } from './pipelines/PipelineFilterContext'
 
 // Types for GitHub activity data
 interface GitHubPR {
@@ -547,6 +548,9 @@ export function GitHubActivity({ config, ref }: { config?: GitHubActivityConfig;
   const [viewMode, setViewMode] = useState<ViewMode>('prs')
   const [timeRange, setTimeRange] = useState<'7d' | '30d' | '90d' | '1y'>(config?.timeRange || '30d')
 
+  // Shared pipeline filter (if on /ci-cd inside PipelineFilterProvider).
+  const shared = usePipelineFilter()
+
   // Multi-repo state - inline CRUD pattern (matching GitHubCIMonitor)
   const [savedRepos, setSavedRepos] = useState<string[]>(() => getSavedRepos())
   const [currentRepo, setCurrentRepo] = useState<string>(() => {
@@ -559,8 +563,9 @@ export function GitHubActivity({ config, ref }: { config?: GitHubActivityConfig;
   const [repoInput, setRepoInput] = useState('')
   const [isEditingRepos, setIsEditingRepos] = useState(false)
 
-  // Use current repo for data fetching
-  const effectiveConfig = { ...config, repos: [currentRepo] }
+  // Use shared filter repo if available, otherwise per-card selection
+  const effectiveRepo = shared?.repoFilter || currentRepo
+  const effectiveConfig = { ...config, repos: [effectiveRepo] }
 
   const {
     prs,

--- a/web/src/components/cards/IssueActivityChart.tsx
+++ b/web/src/components/cards/IssueActivityChart.tsx
@@ -13,6 +13,7 @@ import ReactECharts from 'echarts-for-react'
 import { Calendar, RefreshCw, GitPullRequest } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 import { Skeleton } from '../ui/Skeleton'
+import { usePipelineFilter } from './pipelines/PipelineFilterContext'
 import { Button } from '../ui/Button'
 import { useDemoMode } from '../../hooks/useDemoMode'
 import { useCardLoadingState } from './CardDataContext'
@@ -262,7 +263,8 @@ async function fetchIssueStats(
 export function IssueActivityChart(props: { config?: IssueActivityConfig }) {
   const { t } = useTranslation('cards')
   const { isDemoMode } = useDemoMode()
-  const repo = props.config?.repo || DEFAULT_REPO
+  const shared = usePipelineFilter()
+  const repo = shared?.repoFilter || props.config?.repo || DEFAULT_REPO
   const initialDays = props.config?.days || DEFAULT_LOOKBACK_DAYS
 
   const [days, setDays] = useState(initialDays)

--- a/web/src/components/cards/pipelines/PipelineFilterContext.tsx
+++ b/web/src/components/cards/pipelines/PipelineFilterContext.tsx
@@ -16,6 +16,9 @@ import { safeGetJSON, safeSetJSON } from '../../../lib/utils/localStorage'
 
 /** localStorage key for user-managed repo overrides */
 const STORAGE_KEY = 'kc-pipeline-repos'
+/** localStorage key for the active repo selection — persists across
+ *  refreshes and restarts so the user doesn't lose their filter. */
+const SELECTION_STORAGE_KEY = 'kc-pipeline-selection'
 
 /** Shape persisted in localStorage */
 interface StoredRepoConfig {
@@ -33,6 +36,15 @@ function loadConfig(): StoredRepoConfig {
 
 function saveConfig(config: StoredRepoConfig): void {
   safeSetJSON(STORAGE_KEY, config)
+}
+
+function loadSelection(): Set<string> {
+  const arr = safeGetJSON<string[]>(SELECTION_STORAGE_KEY)
+  return arr && arr.length > 0 ? new Set(arr) : new Set()
+}
+
+function saveSelection(sel: Set<string>): void {
+  safeSetJSON(SELECTION_STORAGE_KEY, [...sel])
 }
 
 /** Merge server repos + user config into the visible list */
@@ -83,9 +95,18 @@ export interface PipelineFilterState {
 const PipelineFilterCtx = createContext<PipelineFilterState | null>(null)
 
 export function PipelineFilterProvider({ children }: { children: ReactNode }) {
-  const [selectedRepos, setSelectedRepos] = useState<Set<string>>(new Set())
+  const [selectedRepos, setSelectedReposRaw] = useState<Set<string>>(() => loadSelection())
   const [config, setConfig] = useState<StoredRepoConfig>(loadConfig)
   const serverRepos = getPipelineRepos()
+
+  // Wrap setSelectedRepos to persist on every change
+  const setSelectedRepos = useCallback((updater: Set<string> | ((prev: Set<string>) => Set<string>)) => {
+    setSelectedReposRaw((prev) => {
+      const next = typeof updater === 'function' ? updater(prev) : updater
+      saveSelection(next)
+      return next
+    })
+  }, [])
 
   // Persist repo config on every change
   useEffect(() => {

--- a/web/src/components/cards/pipelines/RepoInput.tsx
+++ b/web/src/components/cards/pipelines/RepoInput.tsx
@@ -1,0 +1,80 @@
+/**
+ * RepoInput — shared owner/repo text input for CI/CD cards.
+ *
+ * Used both as a standalone per-card repo selector (on non-CI/CD dashboards)
+ * and alongside the central PipelineFilterProvider (on /ci-cd where the
+ * shared filter takes precedence).
+ *
+ * Accepts any valid owner/repo slug or GitHub URL (reuses normalizeRepoInput
+ * from the ACMM provider). Persists the user's choice so it survives page
+ * reloads.
+ */
+
+import { useState, useRef } from 'react'
+import { X } from 'lucide-react'
+import { normalizeRepoInput } from '../../acmm/ACMMProvider'
+
+const REPO_RE = /^[\w.-]+\/[\w.-]+$/
+
+interface RepoInputProps {
+  /** Current effective repo (from shared filter or local state) */
+  value: string
+  /** Called when the user submits a new repo */
+  onChange: (repo: string) => void
+  /** Placeholder text */
+  placeholder?: string
+  /** Additional class names */
+  className?: string
+}
+
+export function RepoInput({ value, onChange, placeholder, className }: RepoInputProps) {
+  const [input, setInput] = useState(value)
+  const [error, setError] = useState<string | null>(null)
+  const inputRef = useRef<HTMLInputElement>(null)
+
+  function submit() {
+    const normalized = normalizeRepoInput(input)
+    if (!normalized) {
+      setError('Enter owner/repo')
+      return
+    }
+    if (!REPO_RE.test(normalized)) {
+      setError('Invalid — use owner/repo')
+      return
+    }
+    setError(null)
+    if (normalized !== input) setInput(normalized)
+    onChange(normalized)
+  }
+
+  return (
+    <div className={className}>
+      <div className="flex items-center gap-1.5">
+        <div className="relative flex-1">
+          <input
+            ref={inputRef}
+            type="text"
+            value={input}
+            onChange={(e) => { setInput(e.target.value); setError(null) }}
+            onKeyDown={(e) => e.key === 'Enter' && submit()}
+            onBlur={submit}
+            placeholder={placeholder || 'owner/repo or github.com URL'}
+            className="w-full text-xs font-mono bg-background/60 border border-border/50 rounded px-2 py-1 focus:outline-none focus:border-primary/50"
+          />
+          {input && input !== value && (
+            <button
+              type="button"
+              onClick={() => { setInput(value); setError(null) }}
+              className="absolute right-1 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground"
+            >
+              <X className="w-3 h-3" />
+            </button>
+          )}
+        </div>
+      </div>
+      {error && (
+        <div className="text-[10px] text-red-400 mt-0.5">{error}</div>
+      )}
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary

IssueActivityChart (Daily Issues & PRs) was hardcoded to kubestellar/console. Now reads the shared PipelineFilterContext so it respects the central repo selection on /ci-cd.

Also adds a shared RepoInput component for future per-card repo input across CI/CD cards.

## Test plan

- [ ] On /ci-cd, select ublue-os/bluefin in central filter → Daily Issues & PRs shows bluefin data
- [ ] No selection → defaults to kubestellar/console
- [ ] Card on a different dashboard → uses DEFAULT_REPO (no shared filter)