### PR TITLE
♿ fix: replace low-contrast gray text with semantic classes (#8553)

### DIFF
--- a/web/src/components/cards/PodLogs.tsx
+++ b/web/src/components/cards/PodLogs.tsx
@@ -283,7 +283,7 @@ export function PodLogs({ config }: PodLogsProps) {
             No log output.
           </div>
         ) : (
-          <pre className="h-full w-full overflow-auto p-3 text-xs leading-snug font-mono text-slate-200 whitespace-pre">
+          <pre className="h-full w-full overflow-auto p-3 text-xs leading-snug font-mono text-foreground whitespace-pre">
             {logs}
           </pre>
         )}

--- a/web/src/components/cards/drasi/DrasiReactiveGraph.tsx
+++ b/web/src/components/cards/drasi/DrasiReactiveGraph.tsx
@@ -580,7 +580,7 @@ function NodeControls({ isStopped, isPinned = false, showPin = false, showGear =
         onClick={handle(onStop)}
         className={`w-5 h-5 flex items-center justify-center rounded border transition-colors ${
           isStopped
-            ? 'bg-slate-700/60 border-slate-500/50 text-slate-300'
+            ? 'bg-slate-700/60 border-slate-500/50 text-muted-foreground'
             : 'bg-red-500/20 hover:bg-red-500/40 border-red-500/40 text-red-400'
         }`}
         aria-label={isStopped ? 'Start' : 'Stop'}
@@ -1168,12 +1168,12 @@ function ExpandModal({ node, onClose }: { node: ExpandedNodeDetails | null; onCl
         </button>
       </div>
       <div className="space-y-1.5 text-xs">
-        <div className="flex justify-between text-slate-300">
+        <div className="flex justify-between text-foreground">
           <span className="text-muted-foreground">{t('drasi.idLabel')}</span>
           <span className="font-mono">{node.id}</span>
         </div>
         {node.extra && Object.entries(node.extra).map(([k, v]) => (
-          <div key={k} className="flex justify-between text-slate-300 gap-3">
+          <div key={k} className="flex justify-between text-foreground gap-3">
             <span className="text-muted-foreground whitespace-nowrap">{k}:</span>
             <span className="font-mono truncate text-right">{v}</span>
           </div>
@@ -1263,14 +1263,14 @@ function SourceConfigModal({
           <button
             type="button"
             onClick={handleDownloadYaml}
-            className="px-3 py-1.5 text-xs rounded bg-slate-800 hover:bg-slate-700 text-slate-300 border border-slate-700 flex items-center gap-1.5"
+            className="px-3 py-1.5 text-xs rounded bg-slate-800 hover:bg-slate-700 text-muted-foreground border border-slate-700 flex items-center gap-1.5"
           >
             <Download className="w-3 h-3" />
             {t('drasi.downloadYaml')}
           </button>
         ) : <div />}
         <div className="flex gap-2">
-          <button type="button" onClick={onClose} className="px-3 py-1.5 text-xs rounded bg-slate-800 hover:bg-slate-700 text-slate-300 border border-slate-700">{t('actions.cancel')}</button>
+          <button type="button" onClick={onClose} className="px-3 py-1.5 text-xs rounded bg-slate-800 hover:bg-slate-700 text-muted-foreground border border-slate-700">{t('actions.cancel')}</button>
           <button
             type="button"
             disabled={!name.trim()}
@@ -1379,14 +1379,14 @@ function QueryConfigModal({
           <button
             type="button"
             onClick={handleDownloadYaml}
-            className="px-3 py-1.5 text-xs rounded bg-slate-800 hover:bg-slate-700 text-slate-300 border border-slate-700 flex items-center gap-1.5"
+            className="px-3 py-1.5 text-xs rounded bg-slate-800 hover:bg-slate-700 text-muted-foreground border border-slate-700 flex items-center gap-1.5"
           >
             <Download className="w-3 h-3" />
             {t('drasi.downloadYaml')}
           </button>
         ) : <div />}
         <div className="flex gap-2">
-          <button type="button" onClick={onClose} className="px-3 py-1.5 text-xs rounded bg-slate-800 hover:bg-slate-700 text-slate-300 border border-slate-700">{t('actions.cancel')}</button>
+          <button type="button" onClick={onClose} className="px-3 py-1.5 text-xs rounded bg-slate-800 hover:bg-slate-700 text-muted-foreground border border-slate-700">{t('actions.cancel')}</button>
           <button
             type="button"
             disabled={!name.trim()}
@@ -1580,7 +1580,7 @@ function ConnectionsModal({
             </div>
           )}
           <div className="flex justify-end gap-2">
-            <button type="button" onClick={() => setEditing(null)} className="px-3 py-1.5 text-xs rounded bg-slate-800 hover:bg-slate-700 text-slate-300 border border-slate-700">{t('actions.cancel')}</button>
+            <button type="button" onClick={() => setEditing(null)} className="px-3 py-1.5 text-xs rounded bg-slate-800 hover:bg-slate-700 text-muted-foreground border border-slate-700">{t('actions.cancel')}</button>
             <button
               type="button"
               onClick={saveEdit}
@@ -1813,7 +1813,7 @@ function StreamSampleDrawer({ endpoint, isDemo, onClose }: StreamSampleDrawerPro
         <button
           type="button"
           onClick={handleCopy}
-          className="shrink-0 px-2 py-0.5 text-[10px] rounded bg-slate-800 hover:bg-slate-700 text-slate-300 border border-slate-700 flex items-center gap-1"
+          className="shrink-0 px-2 py-0.5 text-[10px] rounded bg-slate-800 hover:bg-slate-700 text-muted-foreground border border-slate-700 flex items-center gap-1"
           aria-label={t('drasi.copySnippet')}
         >
           {copied ? <Check className="w-2.5 h-2.5 text-emerald-400" /> : <Copy className="w-2.5 h-2.5" />}
@@ -2541,7 +2541,7 @@ export function DrasiReactiveGraph() {
         <button
           type="button"
           onClick={() => setShowConnectionsModal(true)}
-          className="shrink-0 w-6 h-6 flex items-center justify-center rounded bg-slate-800 hover:bg-slate-700 border border-slate-700 text-slate-300 hover:text-cyan-300"
+          className="shrink-0 w-6 h-6 flex items-center justify-center rounded bg-slate-800 hover:bg-slate-700 border border-slate-700 text-muted-foreground hover:text-cyan-300"
           aria-label={t('drasi.manageConnections')}
           title={t('drasi.manageConnections')}
         >
@@ -2572,7 +2572,7 @@ export function DrasiReactiveGraph() {
         <button
           type="button"
           onClick={() => setShowStreamSamples(true)}
-          className="shrink-0 ml-auto px-2 py-1 text-[10px] rounded bg-slate-800 hover:bg-slate-700 border border-slate-700 text-slate-300 hover:text-cyan-300 flex items-center gap-1.5"
+          className="shrink-0 ml-auto px-2 py-1 text-[10px] rounded bg-slate-800 hover:bg-slate-700 border border-slate-700 text-muted-foreground hover:text-cyan-300 flex items-center gap-1.5"
           aria-label={t('drasi.consumeStreamTitle')}
           title={t('drasi.consumeStreamTitle')}
         >
@@ -2787,7 +2787,7 @@ export function DrasiReactiveGraph() {
                           <button
                             type="button"
                             onClick={e => { e.stopPropagation(); setShowStreamSamples(true) }}
-                            className="text-[10px] px-1.5 py-0.5 rounded bg-slate-800 hover:bg-slate-700 border border-slate-700 text-slate-300 hover:text-cyan-300 flex items-center gap-1"
+                            className="text-[10px] px-1.5 py-0.5 rounded bg-slate-800 hover:bg-slate-700 border border-slate-700 text-muted-foreground hover:text-cyan-300 flex items-center gap-1"
                             title={t('drasi.consumeStreamTitle')}
                           >
                             <Code2 className="w-2.5 h-2.5" />

--- a/web/src/components/mission-control/FlightPlanBlueprint.tsx
+++ b/web/src/components/mission-control/FlightPlanBlueprint.tsx
@@ -306,7 +306,7 @@ function GaugeRow({ label, value, max, unit }: {
     <div className="space-y-1">
       <div className="flex items-center justify-between text-xs">
         <span className="text-slate-400 font-medium">{label}</span>
-        <span className="text-slate-300 tabular-nums">{display}{pctVal != null ? ` (${pctVal}%)` : ''}</span>
+        <span className="text-foreground tabular-nums">{display}{pctVal != null ? ` (${pctVal}%)` : ''}</span>
       </div>
       <div className="h-1.5 rounded-full bg-slate-800 overflow-hidden">
         {pctVal != null && (

--- a/web/src/components/missions/PreflightFailure.tsx
+++ b/web/src/components/missions/PreflightFailure.tsx
@@ -115,7 +115,7 @@ function ActionButton({
 
   if (action.actionType === 'info') {
     return (
-      <div className="flex items-start gap-2 text-xs text-gray-300">
+      <div className="flex items-start gap-2 text-xs text-muted-foreground">
         <Icon size={14} className="mt-0.5 shrink-0 text-gray-400" />
         <span>{action.description}</span>
       </div>
@@ -152,11 +152,11 @@ function ActionButton({
   return (
     <div className="space-y-1">
       <div className="flex items-center justify-between">
-        <span className="text-xs font-medium text-gray-300">{action.label}</span>
+        <span className="text-xs font-medium text-muted-foreground">{action.label}</span>
         {action.codeSnippet && (
           <button
             onClick={handleCopy}
-            className="flex items-center gap-1 rounded px-2 py-0.5 text-xs text-gray-400 transition-colors hover:bg-gray-700 hover:text-gray-200"
+            className="flex items-center gap-1 rounded px-2 py-0.5 text-xs text-gray-400 transition-colors hover:bg-gray-700 hover:text-foreground"
           >
             <Icon size={12} />
             {copied ? 'Copied' : 'Copy'}
@@ -165,7 +165,7 @@ function ActionButton({
       </div>
       <p className="text-xs text-gray-400">{action.description}</p>
       {action.codeSnippet && (
-        <pre className="mt-1 overflow-x-auto rounded-md bg-gray-900/70 p-2 text-xs text-gray-300">
+        <pre className="mt-1 overflow-x-auto rounded-md bg-gray-900/70 p-2 text-xs text-muted-foreground">
           <code>{action.codeSnippet}</code>
         </pre>
       )}
@@ -209,7 +209,7 @@ export function PreflightFailure({ error, context, onRetry }: PreflightFailurePr
       </div>
 
       {/* Error message */}
-      <p className="mb-3 text-xs leading-relaxed text-gray-300">
+      <p className="mb-3 text-xs leading-relaxed text-muted-foreground">
         {error.message}
       </p>
 

--- a/web/src/pages/FeatureKagent.tsx
+++ b/web/src/pages/FeatureKagent.tsx
@@ -125,7 +125,7 @@ export function FeatureKagent() {
               href="https://kagent.dev"
               target="_blank"
               rel="noopener noreferrer"
-              className="inline-flex items-center gap-2 px-6 py-3 rounded-lg border border-slate-700 text-slate-300 font-medium hover:bg-slate-800 transition-colors"
+              className="inline-flex items-center gap-2 px-6 py-3 rounded-lg border border-border text-muted-foreground font-medium hover:bg-secondary transition-colors"
             >
               kagent.dev
               <ExternalLink className="w-4 h-4" />


### PR DESCRIPTION
## Summary
- Replace 20 instances of `text-slate-200`, `text-slate-300`, `text-gray-200`, `text-gray-300` with semantic Tailwind classes (`text-foreground`, `text-muted-foreground`) that maintain WCAG AA contrast ratios in both dark and light themes
- Affected files: `PodLogs.tsx`, `DrasiReactiveGraph.tsx`, `PreflightFailure.tsx`, `FlightPlanBlueprint.tsx`, `FeatureKagent.tsx`
- Also replaced `border-slate-700` and `hover:bg-slate-800` with semantic equivalents (`border-border`, `hover:bg-secondary`) in FeatureKagent.tsx

## Test plan
- [ ] Verify card text is readable in dark theme
- [ ] Verify card text is readable in light theme
- [ ] Check PodLogs log output text contrast
- [ ] Check Drasi reactive graph buttons and labels
- [ ] Check PreflightFailure remediation actions
- [ ] Check FlightPlanBlueprint metric values
- [ ] Check kagent.dev link button on FeatureKagent page

Fixes #8553