### PR TITLE
🐛 fix: card removal error handling + duplicate toast close buttons (#8564, #8565)

### DIFF
--- a/web/src/components/dashboard/CustomDashboard.tsx
+++ b/web/src/components/dashboard/CustomDashboard.tsx
@@ -460,8 +460,9 @@ export function CustomDashboard() {
       try {
         await api.delete(`/api/dashboards/${id}/cards/${cardId}`)
       } catch (error) {
-        console.error('Failed to delete card:', error)
-        showToast('Failed to delete card from backend', 'error')
+        // Card is already removed from UI state above — backend failure is
+        // non-critical. Log for debugging but don't alarm the user. (#8564)
+        console.debug('Backend card deletion failed (card already removed from UI):', error)
       }
     }
   }

--- a/web/src/components/dashboard/Dashboard.tsx
+++ b/web/src/components/dashboard/Dashboard.tsx
@@ -774,12 +774,9 @@ export function Dashboard() {
       try {
         await api.delete(`/api/cards/${cardId}`)
       } catch (error) {
-        // Ignore 404 — card may have been local-only (e.g. demo-, new-, rec-, template- prefixed IDs)
-        const status = (error as { response?: { status?: number } })?.response?.status
-        if (status !== 404) {
-          console.error('Failed to delete card from backend:', error)
-          showToast('Failed to delete card from backend', 'error')
-        }
+        // Card is already removed from UI state above — backend failure is
+        // non-critical. Log for debugging but don't alarm the user. (#8564)
+        console.debug('Backend card deletion failed (card already removed from UI):', error)
       }
     }
   }

--- a/web/src/components/ui/Toast.tsx
+++ b/web/src/components/ui/Toast.tsx
@@ -1,5 +1,5 @@
 import { createContext, useContext, useState, useEffect, useRef, useCallback, useMemo, ReactNode } from 'react'
-import { X, Check, AlertTriangle, Info } from 'lucide-react'
+import { X, XCircle, Check, AlertTriangle, Info } from 'lucide-react'
 import { cn } from '../../lib/cn'
 import { Button } from './Button'
 
@@ -111,7 +111,7 @@ interface ToastItemProps {
 function ToastItem({ toast, onRemove }: ToastItemProps) {
   const icons: Record<ToastType, ReactNode> = {
     success: <Check className="w-4 h-4" />,
-    error: <X className="w-4 h-4" />,
+    error: <XCircle className="w-4 h-4" />,
     warning: <AlertTriangle className="w-4 h-4" />,
     info: <Info className="w-4 h-4" /> }
 


### PR DESCRIPTION
## Summary
- **#8564**: Suppress the "Failed to remove card from backend" error toast when removing dashboard cards. The card is already removed from UI state before the backend call, so backend failures are non-critical — now logged to `console.debug` instead of showing an error toast.
- **#8565**: Fix duplicate close buttons on error toasts by changing the error type icon from `X` to `XCircle` (a circle with an X), making it visually distinct from the dismiss button's `X` icon.

## Changes
- `web/src/components/ui/Toast.tsx` — Import `XCircle` from lucide-react; use it as the error toast type icon instead of plain `X`
- `web/src/components/dashboard/Dashboard.tsx` — Replace error toast + console.error with console.debug for backend card deletion failures
- `web/src/components/dashboard/CustomDashboard.tsx` — Same change as above

## Test plan
- [ ] Remove a card from the dashboard — no error toast should appear
- [ ] Trigger an error toast (e.g., via a failed API call) — verify single close button (XCircle icon on left, X dismiss on right)
- [ ] Verify card removal still works correctly in the UI

Fixes #8564, Fixes #8565

🤖 Generated with [Claude Code](https://claude.com/claude-code)