### PR TITLE
🔒 fix: strict repo slug validation in pipeline handler (#8568)

### DIFF
--- a/pkg/api/handlers/github_pipelines.go
+++ b/pkg/api/handlers/github_pipelines.go
@@ -15,6 +15,7 @@ import (
 	"io"
 	"net/http"
 	"os"
+	"regexp"
 	"sort"
 	"strconv"
 	"strings"
@@ -85,12 +86,16 @@ func ghpGetRepos() []string {
 // ghpRepos is populated once at init from PIPELINE_REPOS env var.
 var ghpRepos = ghpGetRepos()
 
+// ghpValidRepoPattern enforces strict owner/repo format to prevent path
+// traversal — the repo value is interpolated into GitHub API paths.
+var ghpValidRepoPattern = regexp.MustCompile(`^[a-zA-Z0-9._-]+/[a-zA-Z0-9._-]+$`)
+
 func ghpIsAllowedRepo(repo string) bool {
 	// Accept any valid owner/repo slug — the GitHub token's permissions
 	// are the real access control. The preconfigured list only controls
 	// which repos are fetched by default (no filter), not which repos
 	// a user is allowed to query.
-	if strings.Contains(repo, "/") && len(repo) > 2 {
+	if ghpValidRepoPattern.MatchString(repo) {
 		return true
 	}
 	for _, r := range ghpRepos {

--- a/pkg/api/handlers/github_pipelines_test.go
+++ b/pkg/api/handlers/github_pipelines_test.go
@@ -58,7 +58,8 @@ func TestGitHubPipelines_MutateDisabledWhenNoMutationToken(t *testing.T) {
 
 func TestGitHubPipelines_MutateRejectsUnknownRepo(t *testing.T) {
 	app := newGHPTestApp(t, "fake-token", "fake-mutation-token")
-	req := httptest.NewRequest("POST", "/api/github-pipelines?view=mutate&op=rerun&repo=evil/repo&run=1", nil)
+	// Use a path-traversal slug that the regex must reject.
+	req := httptest.NewRequest("POST", "/api/github-pipelines?view=mutate&op=rerun&repo=evil/../passwd&run=1", nil)
 	res, err := app.Test(req, -1)
 	if err != nil {
 		t.Fatalf("app.Test: %v", err)
@@ -133,11 +134,28 @@ func TestGHPHistory_MergeAndTrim(t *testing.T) {
 }
 
 func TestGHPIsAllowedRepo(t *testing.T) {
+	// Preconfigured repo must always be allowed.
 	if !ghpIsAllowedRepo("kubestellar/console") {
 		t.Fatal("console should be allowed")
 	}
-	if ghpIsAllowedRepo("evil/repo") {
-		t.Fatal("non-allowlist repo must be rejected")
+	// Any valid owner/repo slug is allowed (GitHub token is the real ACL).
+	if !ghpIsAllowedRepo("some-org/some-repo") {
+		t.Fatal("valid owner/repo slug should be allowed")
+	}
+	// Path-traversal and malformed slugs must be rejected.
+	for _, bad := range []string{
+		"",
+		"noslash",
+		"owner/repo/extra",
+		"../etc/passwd",
+		"owner/../repo",
+		"owner/repo%00evil",
+		"/leading-slash",
+		"trailing-slash/",
+	} {
+		if ghpIsAllowedRepo(bad) {
+			t.Errorf("expected %q to be rejected", bad)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary

- Replace loose `strings.Contains(repo, "/") && len(repo) > 2` check in `ghpIsAllowedRepo` with a compiled regex: `^[a-zA-Z0-9._-]+/[a-zA-Z0-9._-]+$`
- Prevents path traversal via malicious repo values interpolated into GitHub API paths
- Aligns the Go backend validation with the Netlify function, which already uses the strict pattern

Fixes #8568