### PR TITLE
🔒 fix: validate pulseRepo query param in pipeline handler (#8575)

### DIFF
--- a/pkg/api/handlers/github_pipelines.go
+++ b/pkg/api/handlers/github_pipelines.go
@@ -614,6 +614,8 @@ func (h *GitHubPipelinesHandler) buildPulse(c *fiber.Ctx) (any, error) {
 	pulseRepo := c.Query("repo")
 	if pulseRepo == "" {
 		pulseRepo = ghpNightlyReleaseRepo
+	} else if !ghpIsAllowedRepo(pulseRepo) {
+		return nil, fiber.NewError(fiber.StatusBadRequest, "invalid repo slug")
 	}
 	// Fetch Release workflow runs via the workflow-specific endpoint so we
 	// don't have to filter from /actions/runs (which returns ALL workflows).


### PR DESCRIPTION
Fixes #8575

## Summary

The `buildPulse` handler accepted `c.Query("repo")` without calling `ghpIsAllowedRepo()`, unlike all other pipeline views. This allowed unsanitized input to be interpolated into GitHub API paths (`/repos/{repo}/releases`).

Added the same `ghpIsAllowedRepo` gate that every other view already uses.

## Test plan

- [ ] `go build ./...` passes
- [ ] `curl 'localhost:8080/api/github/pipelines?view=pulse&repo=owner/../etc' → 400`
- [ ] `curl 'localhost:8080/api/github/pipelines?view=pulse&repo=kubestellar/console' → 200`