### PR TITLE
🐛 Fix: GitHub CI Monitor respects central repo selection

### DIFF
--- a/web/src/components/cards/workload-monitor/GitHubCIMonitor.tsx
+++ b/web/src/components/cards/workload-monitor/GitHubCIMonitor.tsx
@@ -17,6 +17,7 @@ import { WorkloadMonitorAlerts } from './WorkloadMonitorAlerts'
 import type { MonitorIssue } from '../../../types/workloadMonitor'
 import { useTranslation } from 'react-i18next'
 import { formatTimeAgo, loadRepos, saveRepos } from './gitHubCIUtils'
+import { usePipelineFilter } from '../pipelines/PipelineFilterContext'
 
 interface GitHubCIMonitorProps {
   config?: Record<string, unknown>
@@ -91,9 +92,12 @@ const DEMO_WORKFLOWS: WorkflowRun[] = [
 export function GitHubCIMonitor({ config, ref }: GitHubCIMonitorProps & { ref?: Ref<GitHubCIMonitorRef> }) {
   const { t } = useTranslation()
   const ghConfig = config as GitHubCIConfig | undefined
+  const shared = usePipelineFilter()
 
-  // Repo configuration
-  const [repos, setRepos] = useState<string[]>(() => ghConfig?.repos || loadRepos())
+  // Repo configuration — shared filter overrides when on /ci-cd
+  const [localRepos, setLocalRepos] = useState<string[]>(() => ghConfig?.repos || loadRepos())
+  const repos = shared?.repoFilter ? [shared.repoFilter] : localRepos
+  const setRepos = shared?.repoFilter ? () => {} : setLocalRepos
   const [isEditingRepos, setIsEditingRepos] = useState(false)
   const [newRepoInput, setNewRepoInput] = useState('')
 


### PR DESCRIPTION
## Summary

Last CI/CD card to be wired to the shared PipelineFilterContext. When on /ci-cd with a repo selected, the CI Monitor shows that repo's workflows. Falls back to its own per-card repo list on other dashboards.

All CI/CD cards now respect the central selection:
- [x] Workflow Matrix
- [x] Live Runs
- [x] Recent Failures
- [x] Nightly Release Pulse (#8566)
- [x] Daily Issues & PRs (#8573)
- [x] GitHub Activity (#8573)
- [x] GitHub CI Monitor (this PR)

## Test plan
- [ ] Select ublue-os/bluefin in central filter → CI Monitor shows bluefin workflows
- [ ] No selection → shows default repos from per-card config