### PR TITLE
🧪 fix: update useIntoto-deep tests for current API (#8560)

### DIFF
--- a/web/src/hooks/__tests__/useIntoto-deep.test.tsx
+++ b/web/src/hooks/__tests__/useIntoto-deep.test.tsx
@@ -37,7 +37,17 @@ vi.mock('../useDemoMode', () => ({
 
 vi.mock('../../lib/demoMode', () => ({
   isDemoMode: () => true,
+  getDemoMode: () => true,
+  setDemoMode: vi.fn(),
+  toggleDemoMode: vi.fn(),
+  subscribeDemoMode: vi.fn(() => vi.fn()),
+  isDemoModeForced: false,
   isNetlifyDeployment: false,
+  canToggleDemoMode: () => true,
+  isDemoToken: () => true,
+  hasRealToken: () => false,
+  setDemoToken: vi.fn(),
+  setGlobalDemoMode: vi.fn(),
 }))
 
 vi.mock('../../lib/modeTransition', () => ({


### PR DESCRIPTION
## Summary
- The `../../lib/demoMode` mock in `useIntoto-deep.test.tsx` was missing the `subscribeDemoMode` export that `shared.ts` now imports at module init time (added transitively via `useMCP`)
- Added `subscribeDemoMode` and other missing exports to the mock to match the current `demoMode.ts` module shape
- All 4 previously failing tests now pass

## Test plan
- [x] `npx vitest run src/hooks/__tests__/useIntoto-deep.test.tsx` — 4/4 pass
- [x] `npm run build` — clean
- [x] `npm run lint` — no new issues

Fixes #8560