### PR TITLE
🐛 Fix: Daily Issues & PRs shows live data on console.kubestellar.io

### DIFF
--- a/web/src/components/cards/IssueActivityChart.tsx
+++ b/web/src/components/cards/IssueActivityChart.tsx
@@ -276,12 +276,8 @@ export function IssueActivityChart(props: { config?: IssueActivityConfig }) {
   useCardLoadingState({ isLoading: isLoading && !hasData, hasAnyData: hasData, isDemoData: isDemoMode })
 
   const loadData = useCallback(async (lookbackDays: number, signal?: AbortSignal) => {
-    if (isDemoMode) {
-      setStats(generateDemoData(lookbackDays))
-      setIsLoading(false)
-      setError(null)
-      return
-    }
+    // No early demo guard — try live data first (liveInDemoMode pattern).
+    // Falls back to demo fixtures on fetch error (line ~300).
 
     // Check cache
     const cached = getCachedStats(repo, lookbackDays)


### PR DESCRIPTION
## Summary

IssueActivityChart had an early `if (isDemoMode) return demoData` guard that prevented live fetches on console.kubestellar.io. Other pipeline cards use `liveInDemoMode: true` — this card had its own fetch logic.

Fix: remove early demo guard. Card tries live data first, falls back to demo on error.

Does NOT affect repo selection — shared filter still works for localhost.

## Test plan

- [ ] console.kubestellar.io → Daily Issues & PRs shows real kubestellar/console data
- [ ] Localhost /ci-cd → select bluefin → shows bluefin issue data
- [ ] Fetch failure → falls back to demo data gracefully