### PR TITLE
🐛 fix: System Updates checker rapid-fire errors (#8584)

### DIFF
--- a/web/src/components/settings/UpdateSettings.tsx
+++ b/web/src/components/settings/UpdateSettings.tsx
@@ -177,10 +177,16 @@ export function UpdateSettings() {
     }
   }, [isChecking])
 
-  // Check for updates on mount
+  // Check for updates once on mount — use a ref to avoid re-firing when
+  // forceCheck's identity changes (its useCallback deps include state that
+  // changes after each check, which would cause a rapid-fire loop).
+  const mountCheckDoneRef = useRef(false)
   useEffect(() => {
+    if (mountCheckDoneRef.current) return
+    mountCheckDoneRef.current = true
     forceCheck()
-  }, [forceCheck])
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
 
   // Clear triggered state once WebSocket progress starts or update fails.
   // Emit GA4 lifecycle events for update completion/failure.

--- a/web/src/hooks/useVersionCheck.tsx
+++ b/web/src/hooks/useVersionCheck.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback, useMemo, createContext, use, type ReactNode } from 'react'
+import { useState, useEffect, useCallback, useMemo, useRef, createContext, use, type ReactNode } from 'react'
 import type {
   UpdateChannel,
   ReleaseType,
@@ -25,6 +25,9 @@ const MIN_CHECK_INTERVAL_MS = 30 * 60 * 1000 // 30 minutes minimum between check
 const AUTO_UPDATE_POLL_MS = 60 * 1000 // Poll kc-agent for update status every 60s
 const DEV_SHA_CACHE_KEY = 'kc-dev-latest-sha'
 
+/** Timeout for the /health fetch during install-method detection (ms) */
+/** Number of consecutive fetch failures before surfacing an error to the UI */
+const ERROR_DISPLAY_THRESHOLD = 2
 /** Timeout for the /health fetch during install-method detection (ms) */
 const HEALTH_FETCH_TIMEOUT_MS = 3000
 /** Max retries for /health when the backend is still warming up */
@@ -278,6 +281,10 @@ function useVersionCheckCore() {
   })
   const [skippedVersions, setSkippedVersions] = useState<string[]>(loadSkippedVersions)
 
+  // Consecutive failure counter — errors are only surfaced to the UI after
+  // ERROR_DISPLAY_THRESHOLD consecutive failures to avoid flicker on transient errors.
+  const consecutiveFailuresRef = useRef(0)
+
   // Auto-update state
   const [autoUpdateEnabled, setAutoUpdateEnabledState] = useState(loadAutoUpdateEnabled)
   // Initialize install method: localhost always means dev mode (running from source)
@@ -330,6 +337,7 @@ function useVersionCheckCore() {
         console.debug('[version-check] Auto-update status:', data)
         setAutoUpdateStatus(data)
         // Clear any stale error from a previous failed check
+        consecutiveFailuresRef.current = 0
         setError(null)
         // Update latestMainSHA and lastChecked from agent response
         if (data.latestSHA) {
@@ -340,11 +348,17 @@ function useVersionCheckCore() {
         localStorage.setItem(UPDATE_STORAGE_KEYS.LAST_CHECK, String(now))
       } else {
         console.debug('[version-check] Auto-update status failed:', resp.status)
-        setError(`kc-agent returned ${resp.status}`)
+        consecutiveFailuresRef.current += 1
+        if (consecutiveFailuresRef.current >= ERROR_DISPLAY_THRESHOLD) {
+          setError(`kc-agent returned ${resp.status}`)
+        }
       }
     } catch (err) {
       console.debug('[version-check] Auto-update status error:', err)
-      setError('Could not reach kc-agent')
+      consecutiveFailuresRef.current += 1
+      if (consecutiveFailuresRef.current >= ERROR_DISPLAY_THRESHOLD) {
+        setError('Could not reach kc-agent')
+      }
     }
   }, [agentSupportsAutoUpdate])
 
@@ -552,7 +566,6 @@ function useVersionCheckCore() {
    */
   const fetchReleases = async (force = false): Promise<void> => {
     setIsChecking(true)
-    setError(null)
 
     try {
       // Check cache first
@@ -608,11 +621,16 @@ function useVersionCheckCore() {
 
       // Parse and set releases
       setReleases(validReleases.map(parseRelease))
+      consecutiveFailuresRef.current = 0
+      setError(null)
       setLastChecked(Date.now())
       localStorage.setItem(UPDATE_STORAGE_KEYS.LAST_CHECK, Date.now().toString())
     } catch (err) {
       const message = err instanceof Error ? err.message : 'Failed to check for updates'
-      setError(message)
+      consecutiveFailuresRef.current += 1
+      if (consecutiveFailuresRef.current >= ERROR_DISPLAY_THRESHOLD) {
+        setError(message)
+      }
 
       // Fall back to cache if available
       const cache = loadCache()
@@ -665,6 +683,9 @@ function useVersionCheckCore() {
   const forceCheck = async (): Promise<void> => {
     console.debug('[version-check] Force check — channel:', channel, 'agentSupportsAutoUpdate:', agentSupportsAutoUpdate)
     setIsChecking(true)
+    // Reset consecutive failure counter on user-initiated check so a single
+    // success clears the error, and a single failure doesn't flash red.
+    consecutiveFailuresRef.current = 0
     setError(null)
     // Trigger an immediate agent health check via the shared singleton
     refreshAgent()


### PR DESCRIPTION
## Summary

Fixes #8584

The "System Updates" section in Settings rapidly flickered between "Up to date" (white) and "Error checking updates" (red) because:

1. **Mount effect re-fired on every `forceCheck` identity change** — `useEffect(() => { forceCheck() }, [forceCheck])` re-triggered whenever `forceCheck`'s `useCallback` dependencies changed (which happened after each check due to state updates), creating a rapid-fire loop
2. **Error cleared then immediately re-set** — `forceCheck` eagerly called `setError(null)` at the start of every cycle, then the fetch failed and called `setError(message)`, causing the visible flicker

### Changes

- **Guard mount check with a ref** so it fires exactly once instead of re-triggering on every `forceCheck` identity change (`UpdateSettings.tsx`)
- **Add consecutive failure tracking** with `ERROR_DISPLAY_THRESHOLD = 2` so transient errors don't flash red — only persistent failures surface to the UI (`useVersionCheck.tsx`)
- **Move `setError(null)` to success path** in `fetchReleases` instead of eagerly clearing at the start of every fetch — prevents the clear/set flicker cycle

## Test plan

- [ ] Open Settings, scroll to System Updates — status should not flicker
- [ ] With kc-agent not running: status should show "Error checking updates" only after 2 consecutive failures (not instantly)
- [ ] Click "Check Now" — should work normally, spinning icon, then result
- [ ] With kc-agent running: status should show "Up to date" or update info without any flicker

🤖 Generated with [Claude Code](https://claude.com/claude-code)