### PR TITLE
🐛 fix: explicit type for setRepos union (#8588)

### DIFF
--- a/web/src/components/cards/workload-monitor/GitHubCIMonitor.tsx
+++ b/web/src/components/cards/workload-monitor/GitHubCIMonitor.tsx
@@ -97,7 +97,7 @@ export function GitHubCIMonitor({ config, ref }: GitHubCIMonitorProps & { ref?: 
   // Repo configuration — shared filter overrides when on /ci-cd
   const [localRepos, setLocalRepos] = useState<string[]>(() => ghConfig?.repos || loadRepos())
   const repos = shared?.repoFilter ? [shared.repoFilter] : localRepos
-  const setRepos = shared?.repoFilter ? () => {} : setLocalRepos
+  const setRepos: React.Dispatch<React.SetStateAction<string[]>> = shared?.repoFilter ? () => {} : setLocalRepos
   const [isEditingRepos, setIsEditingRepos] = useState(false)
   const [newRepoInput, setNewRepoInput] = useState('')
 


### PR DESCRIPTION
Fixes #8588

## Summary

`setRepos` was conditionally assigned to either a no-op `() => {}` or `setLocalRepos`, producing a union type that TypeScript couldn't safely call with arguments. Added explicit `React.Dispatch<React.SetStateAction<string[]>>` annotation.

## Test plan

- [ ] `npm run build` passes (TypeScript compilation)