### PR TITLE
🐛 fix: useCachedACMMScan forceRefetch test (#8590)

### DIFF
--- a/web/src/hooks/__tests__/useCachedACMMScan.test.tsx
+++ b/web/src/hooks/__tests__/useCachedACMMScan.test.tsx
@@ -124,6 +124,7 @@ describe('useCachedACMMScan', () => {
       return {
         ok: true,
         status: 200,
+        headers: new Headers({ 'content-type': 'application/json' }),
         json: async () => ({ repo: 'x/y', scannedAt: '', detectedIds: [], weeklyActivity: [], _url: url }),
       } as Response
     }) as typeof globalThis.fetch


### PR DESCRIPTION
## Summary
- Add missing `headers` property to the mock fetch response in the forceRefetch test
- The hook's `fetchACMMScan` checks `res.headers.get('content-type')` to detect non-JSON SPA catch-all responses, but the test mock lacked headers, causing `TypeError: Cannot read properties of undefined (reading 'get')`

Fixes #8590

## Test plan
- [x] `npx vitest run src/hooks/__tests__/useCachedACMMScan.test.tsx` — all 9 tests pass
- [x] `npm run build` passes
- [x] `npm run lint` passes