### PR TITLE
🐛 fix: Cluster Info Card click targets and GPU flicker

### DIFF
--- a/web/src/components/clusters/ClusterDetailModal.tsx
+++ b/web/src/components/clusters/ClusterDetailModal.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useState, useRef } from 'react'
 import { X, CheckCircle, AlertTriangle, WifiOff, Pencil, Trash2, ChevronRight, ChevronDown, Layers, Server, Network, HardDrive, Box, FolderOpen, Loader2, Cpu, MemoryStick, Database, Wand2, Stethoscope, Wrench, Bot, ExternalLink } from 'lucide-react'
 import { BaseModal } from '../../lib/modals'
 import { useClusterHealth, usePodIssues, useDeploymentIssues, useGPUNodes, useNodes, useNamespaceStats, useDeployments, useClusters } from '../../hooks/useMCP'
@@ -259,6 +259,16 @@ After I approve, help me execute the repairs step by step.`,
     })
     return map
   })()
+
+  // Retain last non-empty GPU data so the section doesn't vanish during refetch (#8597).
+  // When the hook briefly returns an empty array mid-poll, we keep showing the previous
+  // data to prevent the "GPUs by Type" section from flickering in and out.
+  const lastGpuDataRef = useRef<{ clusterGPUs: typeof clusterGPUs; gpuByType: typeof gpuByType }>({ clusterGPUs: [], gpuByType: {} })
+  if (clusterGPUs.length > 0) {
+    lastGpuDataRef.current = { clusterGPUs, gpuByType }
+  }
+  const stableClusterGPUs = clusterGPUs.length > 0 ? clusterGPUs : lastGpuDataRef.current.clusterGPUs
+  const stableGpuByType = clusterGPUs.length > 0 ? gpuByType : lastGpuDataRef.current.gpuByType
 
   // Show modal immediately with loading state for data - don't block on isLoading
   return (
@@ -523,12 +533,12 @@ After I approve, help me execute the repairs step by step.`,
             )}
           </button>
           <button
-            onClick={() => !isUnreachable && !isLoading && clusterGPUs.length > 0 && setShowGPUDetail(true)}
-            disabled={isUnreachable || isLoading || clusterGPUs.length === 0}
+            onClick={() => !isUnreachable && !isLoading && stableClusterGPUs.length > 0 && setShowGPUDetail(true)}
+            disabled={isUnreachable || isLoading || stableClusterGPUs.length === 0}
             className={`group p-4 rounded-lg bg-card/50 border text-left transition-all duration-200 ${
-              !isUnreachable && !isLoading && clusterGPUs.length > 0 ? 'border-border hover:border-yellow-500/50 hover:bg-yellow-500/5 hover:shadow-lg hover:shadow-yellow-500/10 cursor-pointer' : 'border-border cursor-default'
+              !isUnreachable && !isLoading && stableClusterGPUs.length > 0 ? 'border-border hover:border-yellow-500/50 hover:bg-yellow-500/5 hover:shadow-lg hover:shadow-yellow-500/10 cursor-pointer' : 'border-border cursor-default'
             }`}
-            title={!isUnreachable && !isLoading && clusterGPUs.length > 0 ? t('clusterDetail.clickToViewGPU') : undefined}
+            title={!isUnreachable && !isLoading && stableClusterGPUs.length > 0 ? t('clusterDetail.clickToViewGPU') : undefined}
           >
             {isLoading ? (
               <>
@@ -538,10 +548,10 @@ After I approve, help me execute the repairs step by step.`,
               </>
             ) : (
               <>
-                <div className="text-2xl font-bold text-foreground">{!isUnreachable ? clusterGPUs.reduce((sum, n) => sum + n.gpuCount, 0) : '-'}</div>
+                <div className="text-2xl font-bold text-foreground">{!isUnreachable ? stableClusterGPUs.reduce((sum, n) => sum + n.gpuCount, 0) : '-'}</div>
                 <div className="text-sm text-muted-foreground">{t('common.gpus')}</div>
-                <div className="text-xs text-yellow-400">{!isUnreachable ? `${clusterGPUs.reduce((sum, n) => sum + n.gpuAllocated, 0)} ${t('clusterDetail.allocated')}` : ''}</div>
-                {!isUnreachable && clusterGPUs.length > 0 && (
+                <div className="text-xs text-yellow-400">{!isUnreachable ? `${stableClusterGPUs.reduce((sum, n) => sum + n.gpuAllocated, 0)} ${t('clusterDetail.allocated')}` : ''}</div>
+                {!isUnreachable && stableClusterGPUs.length > 0 && (
                   <div className="text-2xs text-muted-foreground/50 mt-2 group-hover:text-yellow-400/70 transition-colors">{t('clusterDetail.clickForDetails')}</div>
                 )}
               </>
@@ -778,14 +788,14 @@ After I approve, help me execute the repairs step by step.`,
         )}
 
         {/* GPU Section */}
-        {clusterGPUs.length > 0 && (
+        {stableClusterGPUs.length > 0 && (
           <div className="mb-6">
             <h3 className="text-sm font-medium text-muted-foreground mb-3 flex items-center gap-2">
               <HardDrive className="w-4 h-4 text-purple-400" />
               {t('clusterDetail.gpusByType')}
             </h3>
             <div className="space-y-4">
-              {Object.entries(gpuByType).map(([type, info]) => (
+              {Object.entries(stableGpuByType).map(([type, info]) => (
                 <div key={type} className="rounded-lg bg-card/50 border border-border overflow-hidden">
                   <div className="p-3 border-b border-border/50 bg-purple-500/5">
                     <div className="flex items-center justify-between">
@@ -944,7 +954,7 @@ After I approve, help me execute the repairs step by step.`,
       {showGPUDetail && (
         <GPUDetailModal
           clusterName={clusterName}
-          gpuNodes={clusterGPUs.map(n => ({
+          gpuNodes={stableClusterGPUs.map(n => ({
             name: n.name,
             gpuType: n.gpuType || 'Unknown',
             gpuCount: n.gpuCount,

--- a/web/src/components/clusters/components/ClusterGrid.tsx
+++ b/web/src/components/clusters/components/ClusterGrid.tsx
@@ -441,7 +441,7 @@ const FullClusterCard = memo(function FullClusterCard({
               <div className="flex flex-col gap-1 mt-1">
                 {cluster.server && (
                   <span
-                    className="flex items-center gap-1.5 text-xs text-muted-foreground hover:text-foreground transition-colors cursor-default truncate max-w-[220px]"
+                    className="flex items-center gap-1.5 text-xs text-muted-foreground cursor-default truncate max-w-[220px]"
                     title={`Server: ${cluster.server}`}
                   >
                     <Globe className="w-3 h-3 flex-shrink-0" />
@@ -450,7 +450,7 @@ const FullClusterCard = memo(function FullClusterCard({
                 )}
                 {cluster.user && (
                   <span
-                    className="flex items-center gap-1.5 text-xs text-muted-foreground hover:text-foreground transition-colors cursor-default truncate max-w-[220px]"
+                    className="flex items-center gap-1.5 text-xs text-muted-foreground cursor-default truncate max-w-[220px]"
                     title={`User: ${cluster.user}`}
                   >
                     <User className="w-3 h-3 flex-shrink-0" />
@@ -487,7 +487,7 @@ const FullClusterCard = memo(function FullClusterCard({
           </div>
         </div>
 
-        <div className="grid grid-cols-4 gap-4 text-center relative z-10">
+        <div className="grid grid-cols-4 gap-4 text-center relative z-10 cursor-default">
           <div title={unreachable ? 'Nodes: Cluster offline' : hasCachedData && cluster.nodeCount !== undefined ? `Nodes: ${cluster.nodeCount} worker nodes in cluster` : 'Nodes: Loading...'}>
             <div className={`text-lg font-bold ${refreshing ? 'text-muted-foreground' : 'text-foreground'}`}>
               <FlashingValue value={hasCachedData && cluster.nodeCount !== undefined ? cluster.nodeCount : '-'} />
@@ -514,7 +514,7 @@ const FullClusterCard = memo(function FullClusterCard({
           </div>
         </div>
 
-        <div className="mt-4 pt-4 border-t border-border relative z-10">
+        <div className="mt-4 pt-4 border-t border-border relative z-10 cursor-default">
           {consoleUrl && (
             <div className="flex justify-center mb-3">
               <a


### PR DESCRIPTION
## Summary
- **Misleading hover highlights**: Server URL and User lines in the Cluster Info Card no longer highlight on hover or appear as separate clickable links — they are display-only informational fields
- **Pointer cursor bleed**: Stats grid and footer areas now show a default cursor instead of a pointer hand, making it clear the whole card is one click target
- **GPU section flicker**: The "GPUs by Type" section in the cluster detail drill-down no longer vanishes and reappears during background refetch — a `useRef` retains the last non-empty GPU data so the section stays stable

Fixes #8597

## Test plan
- [ ] Open My Clusters dashboard, hover over server URL and user lines — they should NOT highlight or show pointer cursor
- [ ] Hover over stats grid (Nodes, CPU, Pods, GPUs) — cursor should be default, not pointer
- [ ] Open a cluster with GPUs, observe "GPUs by Type" section — it should remain visible during refetch cycles without flickering

🤖 Generated with [Claude Code](https://claude.com/claude-code)