### PR TITLE
🐛 fix: GPU fallback respects authoritative empty + footer cursor scoping

### DIFF
--- a/web/src/components/clusters/ClusterDetailModal.tsx
+++ b/web/src/components/clusters/ClusterDetailModal.tsx
@@ -103,7 +103,7 @@ export function ClusterDetailModal({ clusterName, clusterUser, onClose, onRename
   const { deduplicatedClusters, clusters: rawClusters } = useClusters()
   const { issues: podIssues } = usePodIssues(clusterName)
   const { issues: deploymentIssues } = useDeploymentIssues(clusterName)
-  const { nodes: gpuNodes } = useGPUNodes(clusterName)
+  const { nodes: gpuNodes, isLoading: gpuLoading, isRefreshing: gpuRefreshing } = useGPUNodes(clusterName)
   const { nodes: clusterNodes, isLoading: nodesLoading } = useNodes(clusterName)
   const { stats: namespaceStats, isLoading: nsLoading } = useNamespaceStats(clusterName)
   const { deployments: clusterDeployments } = useDeployments(clusterName)
@@ -261,11 +261,16 @@ After I approve, help me execute the repairs step by step.`,
   })()
 
   // Retain last non-empty GPU data so the section doesn't vanish during refetch (#8597).
-  // When the hook briefly returns an empty array mid-poll, we keep showing the previous
-  // data to prevent the "GPUs by Type" section from flickering in and out.
+  // Only fall back to cached data while a refresh/load is in progress (transient empty).
+  // When a settled (non-loading, non-refreshing) fetch returns empty, respect it as
+  // authoritative — GPUs may have been removed from the cluster (#8601).
+  const isGpuTransient = gpuLoading || gpuRefreshing
   const lastGpuDataRef = useRef<{ clusterGPUs: typeof clusterGPUs; gpuByType: typeof gpuByType }>({ clusterGPUs: [], gpuByType: {} })
   if (clusterGPUs.length > 0) {
     lastGpuDataRef.current = { clusterGPUs, gpuByType }
+  } else if (!isGpuTransient) {
+    // Settled fetch returned empty — clear cached data so UI shows no GPUs
+    lastGpuDataRef.current = { clusterGPUs: [], gpuByType: {} }
   }
   const stableClusterGPUs = clusterGPUs.length > 0 ? clusterGPUs : lastGpuDataRef.current.clusterGPUs
   const stableGpuByType = clusterGPUs.length > 0 ? gpuByType : lastGpuDataRef.current.gpuByType

--- a/web/src/components/clusters/components/ClusterGrid.tsx
+++ b/web/src/components/clusters/components/ClusterGrid.tsx
@@ -522,7 +522,7 @@ const FullClusterCard = memo(function FullClusterCard({
                 target="_blank"
                 rel="noopener noreferrer"
                 onClick={(e) => e.stopPropagation()}
-                className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg bg-secondary/70 hover:bg-secondary text-sm text-muted-foreground hover:text-foreground transition-colors"
+                className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg bg-secondary/70 hover:bg-secondary text-sm text-muted-foreground hover:text-foreground transition-colors cursor-pointer"
                 title={`Open ${providerLabel} console`}
               >
                 <span>console</span>


### PR DESCRIPTION
## Summary
- GPU "stable" fallback now only uses cached ref data while `isRefreshing` or `isLoading` is true (transient empty array). When a settled fetch returns empty, `lastGpuDataRef.current` is cleared so the UI correctly shows no GPUs — fixing the case where GPUs physically removed from a cluster would never clear from the UI.
- Added explicit `cursor-pointer` to the console `<a>` link in `ClusterGrid` footer so the parent `cursor-default` container does not suppress the interactive affordance.

Fixes #8601

## Test plan
- [ ] Open Cluster Detail modal for a cluster with GPUs — verify GPU section renders
- [ ] Simulate GPU removal (empty API response while not refreshing) — verify GPU section clears
- [ ] During a refresh cycle, verify GPU data stays visible (no flicker)
- [ ] Hover over the console link in cluster grid footer — verify pointer cursor appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)