### PR TITLE
🐛 fix: nightly auth uses correct CSRF header X-Requested-With

### DIFF
--- a/.github/workflows/nightly-dashboard-health.yml
+++ b/.github/workflows/nightly-dashboard-health.yml
@@ -96,13 +96,13 @@ jobs:
           echo "Dev-mode login OK — got kc_auth cookie (HTTP ${LAST_STATUS})"
 
           # Test /auth/refresh contract (#6590):
-          # - Token is sent via cookie (primary) AND Bearer header (fallback)
+          # - Token is sent via Authorization header (primary) AND cookie (fallback)
           # - Response body must contain "refreshed" and "onboarded" (NOT "token")
           # - New JWT is delivered exclusively via the HttpOnly kc_auth cookie
           REFRESH_RESP=$(curl -sS --max-time 5 -X POST \
             -H "Cookie: kc_auth=$TOKEN" \
             -H "Authorization: Bearer $TOKEN" \
-            -H "X-CSRF-Token: nightly" \
+            -H "X-Requested-With: XMLHttpRequest" \
             http://localhost:8081/auth/refresh)
           HAS_REFRESHED=$(echo "$REFRESH_RESP" | jq -r '.refreshed // empty')
           if [ "$HAS_REFRESHED" != "true" ]; then


### PR DESCRIPTION
Fixes #8605

## Summary
- Changed CSRF header from `X-CSRF-Token: nightly` to `X-Requested-With: XMLHttpRequest` in the nightly auth-contract smoke test, matching what `pkg/api/handlers/auth.go` actually enforces (`csrfHeaderName`/`csrfHeaderValue` constants)
- Fixed inline comment: token resolution order is Authorization header (primary), cookie (fallback) — not the other way around

## Context
PR #8604 added the auth-contract smoke test but used the wrong CSRF header. The `/auth/refresh` endpoint would reject the request with 403 because it checks for `X-Requested-With: XMLHttpRequest`, not `X-CSRF-Token`.

## Test plan
- [ ] `auth-contract` job in nightly workflow passes (no 403 on `/auth/refresh`)
- [ ] Comment matches actual `RefreshToken` implementation in `auth.go` line 762