### PR TITLE
feat: ACMM scan works on localhost/cluster via Go handler

### DIFF
--- a/pkg/api/handlers/acmm_scan.go
+++ b/pkg/api/handlers/acmm_scan.go
@@ -1,0 +1,458 @@
+// Package handlers provides HTTP handlers for the console API.
+package handlers
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"math"
+	"net/http"
+	"os"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/gofiber/fiber/v2"
+)
+
+// ACMM scan constants
+const (
+	acmmGitHubAPI    = "https://api.github.com"
+	acmmAPITimeoutMS = 15000
+	weeksOfHistory   = 16
+	// GitHub search API max pages/size
+	searchPageSize = 100
+	searchMaxPages = 10
+	// AI contribution detection
+	aiLabel = "ai-generated"
+)
+
+var (
+	repoSlugRE = regexp.MustCompile(`^[\w.\-]+/[\w.\-]+$`)
+	aiAuthors  = map[string]bool{
+		"clubanderson":          true,
+		"Copilot":               true,
+		"copilot-swe-agent[bot]": true,
+	}
+)
+
+// acmmCriterion describes a single maturity detection rule.
+type acmmCriterion struct {
+	ID       string   `json:"id"`
+	Patterns []string `json:"patterns"` // file paths or directory prefixes
+}
+
+// acmmScanResult is the JSON response from /api/acmm/scan.
+type acmmScanResult struct {
+	Repo           string               `json:"repo"`
+	ScannedAt      string               `json:"scannedAt"`
+	DetectedIDs    []string             `json:"detectedIds"`
+	WeeklyActivity []acmmWeeklyActivity `json:"weeklyActivity"`
+}
+
+type acmmWeeklyActivity struct {
+	Week        string `json:"week"`
+	AIPrs       int    `json:"aiPrs"`
+	HumanPrs    int    `json:"humanPrs"`
+	AIIssues    int    `json:"aiIssues"`
+	HumanIssues int    `json:"humanIssues"`
+}
+
+// criteria catalog — mirrors the Netlify Function and frontend sources.
+// Each entry has an ID and a list of path patterns to check against the repo tree.
+//
+//nolint:lll // catalog entries are intentionally wide for readability
+var acmmCriteria = []acmmCriterion{
+	// ACMM L2 — Instructed
+	{ID: "acmm:claude-md", Patterns: []string{"CLAUDE.md", ".claude/CLAUDE.md"}},
+	{ID: "acmm:copilot-instructions", Patterns: []string{".github/copilot-instructions.md"}},
+	{ID: "acmm:agents-md", Patterns: []string{"AGENTS.md"}},
+	{ID: "acmm:cursor-rules", Patterns: []string{".cursorrules", ".cursor/rules"}},
+	{ID: "acmm:prompts-catalog", Patterns: []string{"prompts/", ".prompts/", "docs/prompts/", ".github/prompts/", ".github/agents/"}},
+	{ID: "acmm:pr-template", Patterns: []string{".github/pull_request_template.md", ".github/PULL_REQUEST_TEMPLATE.md"}},
+	{ID: "acmm:issue-template", Patterns: []string{".github/ISSUE_TEMPLATE/", ".github/issue_template.md"}},
+	{ID: "acmm:contrib-guide", Patterns: []string{"CONTRIBUTING.md", "docs/contributing.md"}},
+	{ID: "acmm:style-config", Patterns: []string{".eslintrc", ".eslintrc.json", ".eslintrc.js", "eslint.config.js", "eslint.config.mjs", ".prettierrc", ".prettierrc.json", "prettier.config.js", "ruff.toml", ".golangci.yml", "biome.json"}},
+	{ID: "acmm:editor-config", Patterns: []string{".editorconfig"}},
+	// ACMM L3 — Measured
+	{ID: "acmm:coverage-gate", Patterns: []string{"codecov.yml", ".codecov.yml", ".github/workflows/coverage-gate.yml", "coverage.yml"}},
+	{ID: "acmm:pr-acceptance-metric", Patterns: []string{"scripts/build-accm-history.mjs", ".github/workflows/accm-history-update.yml", "scripts/pr-metrics.mjs", ".github/workflows/pr-metrics.yml", "docs/metrics.md"}},
+	{ID: "acmm:test-suite", Patterns: []string{"vitest.config.ts", "vitest.config.js", "jest.config.js", "jest.config.ts", "go.mod", "pytest.ini", "pyproject.toml", "test/", "tests/", "__tests__/", "spec/"}},
+	{ID: "acmm:e2e-tests", Patterns: []string{"playwright.config.ts", "playwright.config.js", "cypress.config.ts", "e2e/"}},
+	{ID: "acmm:pr-review-rubric", Patterns: []string{".github/workflows/review.yml", "docs/review-rubric.md", ".github/review-checklist.md", ".github/prompts/review.md", "docs/qa/"}},
+	{ID: "acmm:quality-dashboard", Patterns: []string{"public/analytics.js", "web/public/analytics.js", "web/src/components/analytics/", "docs/quality.md", ".github/workflows/quality-report.yml", "docs/AI-QUALITY-ASSURANCE.md"}},
+	{ID: "acmm:ci-matrix", Patterns: []string{".github/workflows/ci.yml", ".github/workflows/test.yml", ".github/workflows/build.yml"}},
+	// ACMM L4 — Adaptive
+	{ID: "acmm:auto-qa-tuning", Patterns: []string{".github/auto-qa-tuning.json", ".github/workflows/auto-qa.yml", "scripts/auto-qa-tuner.mjs"}},
+	{ID: "acmm:nightly-compliance", Patterns: []string{".github/workflows/nightly-compliance.yml", ".github/workflows/nightly.yml", ".github/workflows/nightly-test.yml", ".github/workflows/nightly-test-suite.yml"}},
+	{ID: "acmm:copilot-review-apply", Patterns: []string{".github/workflows/copilot-review-apply.yml", ".github/workflows/apply-copilot.yml"}},
+	{ID: "acmm:auto-label", Patterns: []string{".github/labeler.yml", ".github/workflows/labeler.yml"}},
+	{ID: "acmm:ai-fix-workflow", Patterns: []string{".github/workflows/ai-fix.yml", ".github/workflows/ai-fix-requested.yml"}},
+	{ID: "acmm:tier-classifier", Patterns: []string{".github/workflows/tier-classifier.yml", "docs/risk-tiers.md", ".github/risk-tiers.yml"}},
+	{ID: "acmm:security-ai-md", Patterns: []string{"docs/security/SECURITY-AI.md", "SECURITY-AI.md", "docs/SECURITY-AI.md"}},
+	// ACMM L5 — Self-Sustaining
+	{ID: "acmm:auto-issue-gen", Patterns: []string{".github/workflows/auto-issues.yml", "scripts/generate-issues.mjs"}},
+	{ID: "acmm:multi-agent-orchestration", Patterns: []string{".github/workflows/dispatcher.yml", "docs/multi-agent.md", ".claude/dispatcher/"}},
+	{ID: "acmm:strategic-dashboard", Patterns: []string{"web/src/components/acmm/", "docs/strategy.md", ".github/workflows/strategy-report.yml", "docs/autonomous-work-log.md"}},
+	{ID: "acmm:merge-queue", Patterns: []string{".github/workflows/merge-queue.yml", ".github/merge-queue.yml"}},
+	{ID: "acmm:policy-as-code", Patterns: []string{"policies/", ".github/policies/", "kyverno/"}},
+	{ID: "acmm:public-metrics", Patterns: []string{"public/analytics.js", "docs/metrics/", ".github/workflows/public-metrics.yml"}},
+	{ID: "acmm:reflection-log", Patterns: []string{".claude/reflections/", "memory/", "docs/reflections/"}},
+	// Fullsend
+	{ID: "fullsend:test-coverage", Patterns: []string{"codecov.yml", ".codecov.yml", "coverage.yml", ".github/workflows/coverage-gate.yml"}},
+	{ID: "fullsend:ci-cd-maturity", Patterns: []string{".github/workflows/"}},
+	{ID: "fullsend:auto-merge-policy", Patterns: []string{".github/auto-merge.yml", ".prow.yaml", "tide.yaml", ".github/workflows/auto-merge.yml"}},
+	{ID: "fullsend:branch-protection-doc", Patterns: []string{"docs/branch-protection.md", "docs/governance.md", ".github/branch-protection.yml"}},
+	{ID: "fullsend:production-feedback", Patterns: []string{"monitoring/", "grafana/", ".github/workflows/post-deploy-check.yml", "scripts/production-feedback.mjs"}},
+	{ID: "fullsend:observability-runbook", Patterns: []string{"docs/runbook.md", "docs/runbooks/", "RUNBOOK.md", "docs/operations/"}},
+	{ID: "fullsend:risk-assessment", Patterns: []string{".github/risk-assessment.yml", "docs/risk-tiers.md", ".github/workflows/tier-classifier.yml"}},
+	{ID: "fullsend:rollback-drill", Patterns: []string{"docs/rollback.md", ".github/workflows/rollback.yml", "scripts/rollback.sh"}},
+	// Agentic Engineering Framework
+	{ID: "aef:task-traceability", Patterns: []string{".agent/tasks/", "docs/agent-tasks/", ".github/agent-log/", "agent-tasks.md"}},
+	{ID: "aef:structural-gates", Patterns: []string{"CODEOWNERS", ".github/CODEOWNERS", ".agent/boundaries.yml", "docs/agent-boundaries.md"}},
+	{ID: "aef:session-continuity", Patterns: []string{"CLAUDE.md", "AGENTS.md", ".cursorrules", ".github/copilot-instructions.md", "docs/agent-context.md"}},
+	{ID: "aef:audit-trail", Patterns: []string{".github/workflows/ai-audit.yml", ".github/workflows/agent-audit.yml", "scripts/ai-audit-report.mjs"}},
+	{ID: "aef:cross-tool-config", Patterns: []string{"AGENTS.md", "docs/ai-contributors.md", ".github/ai-config.yml"}},
+	{ID: "aef:change-classification", Patterns: []string{"docs/change-classification.md", ".github/change-tiers.yml", "docs/risk-tiers.md"}},
+	// Claude Reflect
+	{ID: "claude-reflect:correction-capture", Patterns: []string{".claude/reflections/", "memory/feedback_", ".github/ai-corrections.yml", "scripts/capture-corrections.mjs"}},
+	{ID: "claude-reflect:positive-reinforcement", Patterns: []string{".claude/reflections/", "memory/feedback_", "docs/ai-reinforcement.md"}},
+	{ID: "claude-reflect:claude-md-sync", Patterns: []string{".github/workflows/claude-md-sync.yml", "scripts/sync-claude-md.mjs", "scripts/update-claude-md.mjs"}},
+	{ID: "claude-reflect:preference-index", Patterns: []string{".claude/preferences.json", "memory/MEMORY.md", ".github/agent-preferences.yml"}},
+	{ID: "claude-reflect:reflection-review", Patterns: []string{".github/workflows/reflection-review.yml", "scripts/review-reflections.mjs", "docs/reflection-review.md"}},
+	{ID: "claude-reflect:session-summary", Patterns: []string{".claude/sessions/", "docs/session-summaries/", "memory/session_"}},
+}
+
+// ACMMScanHandler handles GET /api/acmm/scan?repo=owner/name.
+// It calls the GitHub API to scan the repo tree and weekly activity.
+func ACMMScanHandler(c *fiber.Ctx) error {
+	repo := c.Query("repo")
+	if repo == "" {
+		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"error": "Missing repo query parameter"})
+	}
+	if !repoSlugRE.MatchString(repo) {
+		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"error": "Invalid repo — must be owner/name"})
+	}
+
+	token := os.Getenv("GITHUB_TOKEN")
+
+	ctx, cancel := context.WithTimeout(c.Context(), time.Duration(acmmAPITimeoutMS)*time.Millisecond)
+	defer cancel()
+
+	// Fetch repo tree
+	treePaths, err := fetchACMMTreePaths(ctx, repo, token)
+	if err != nil {
+		if strings.Contains(err.Error(), "not found") {
+			return c.Status(fiber.StatusNotFound).JSON(fiber.Map{"error": "Repo not found", "detail": repo})
+		}
+		return c.Status(fiber.StatusOK).JSON(fiber.Map{
+			"error":        err.Error(),
+			"demoFallback": true,
+			"repo":         repo,
+			"scannedAt":    time.Now().UTC().Format(time.RFC3339),
+			"detectedIds":  []string{},
+			"weeklyActivity": []acmmWeeklyActivity{},
+		})
+	}
+
+	// Detect criteria
+	var detected []string
+	for _, crit := range acmmCriteria {
+		if matchesPatterns(treePaths, crit.Patterns) {
+			detected = append(detected, crit.ID)
+		}
+	}
+	if detected == nil {
+		detected = []string{}
+	}
+
+	// Fetch weekly activity (best-effort — don't fail if rate-limited)
+	weekly := fetchACMMWeeklyActivity(ctx, repo, token)
+
+	result := acmmScanResult{
+		Repo:           repo,
+		ScannedAt:      time.Now().UTC().Format(time.RFC3339),
+		DetectedIDs:    detected,
+		WeeklyActivity: weekly,
+	}
+
+	return c.JSON(result)
+}
+
+// fetchACMMTreePaths gets all file paths in a GitHub repo via the trees API.
+func fetchACMMTreePaths(ctx context.Context, repo, token string) (map[string]bool, error) {
+	// Get default branch
+	repoURL := fmt.Sprintf("%s/repos/%s", acmmGitHubAPI, repo)
+	repoBody, err := githubGet(ctx, repoURL, token)
+	if err != nil {
+		return nil, err
+	}
+
+	var repoInfo struct {
+		DefaultBranch string `json:"default_branch"`
+	}
+	if err := json.Unmarshal(repoBody, &repoInfo); err != nil {
+		return nil, fmt.Errorf("parse repo info: %w", err)
+	}
+	branch := repoInfo.DefaultBranch
+	if branch == "" {
+		branch = "main"
+	}
+
+	// Get recursive tree
+	treeURL := fmt.Sprintf("%s/repos/%s/git/trees/%s?recursive=1", acmmGitHubAPI, repo, branch)
+	treeBody, err := githubGet(ctx, treeURL, token)
+	if err != nil {
+		return nil, err
+	}
+
+	var treeResp struct {
+		Tree []struct {
+			Path string `json:"path"`
+		} `json:"tree"`
+	}
+	if err := json.Unmarshal(treeBody, &treeResp); err != nil {
+		return nil, fmt.Errorf("parse tree: %w", err)
+	}
+
+	paths := make(map[string]bool, len(treeResp.Tree))
+	for _, entry := range treeResp.Tree {
+		paths[entry.Path] = true
+	}
+	return paths, nil
+}
+
+// matchesPatterns checks if any pattern matches any path in the tree.
+func matchesPatterns(treePaths map[string]bool, patterns []string) bool {
+	for _, pattern := range patterns {
+		if strings.HasSuffix(pattern, "/") {
+			// Directory pattern
+			for path := range treePaths {
+				if strings.HasPrefix(path, pattern) ||
+					path == strings.TrimSuffix(pattern, "/") ||
+					strings.Contains(path, "/"+pattern) {
+					return true
+				}
+			}
+		} else {
+			// File pattern
+			for path := range treePaths {
+				if path == pattern ||
+					strings.HasSuffix(path, "/"+pattern) ||
+					strings.HasPrefix(path, pattern+"/") {
+					return true
+				}
+			}
+		}
+	}
+	return false
+}
+
+// isoWeek returns the ISO 8601 week string for a date.
+func isoWeek(t time.Time) string {
+	year, week := t.ISOWeek()
+	return fmt.Sprintf("%d-W%02d", year, week)
+}
+
+// fetchACMMWeeklyActivity gets PR and issue counts per week from GitHub Search API.
+func fetchACMMWeeklyActivity(ctx context.Context, repo, token string) []acmmWeeklyActivity {
+	weeks := lastNWeeks(weeksOfHistory)
+	buckets := make(map[string]*acmmWeeklyActivity, len(weeks))
+	for _, w := range weeks {
+		buckets[w] = &acmmWeeklyActivity{Week: w}
+	}
+
+	since := time.Now().AddDate(0, 0, -weeksOfHistory*7).Format("2006-01-02")
+
+	// PRs
+	prURL := fmt.Sprintf("%s/search/issues?q=repo:%s+type:pr+created:>=%s", acmmGitHubAPI, repo, since)
+	prItems := searchAllACMMPages(ctx, prURL, token)
+	for _, item := range prItems {
+		t, err := time.Parse(time.RFC3339, item.CreatedAt)
+		if err != nil {
+			continue
+		}
+		w := isoWeek(t)
+		b, ok := buckets[w]
+		if !ok {
+			continue
+		}
+		if isACMMAIContribution(item.Labels, item.User.Login) {
+			b.AIPrs++
+		} else {
+			b.HumanPrs++
+		}
+	}
+
+	// Issues
+	issueURL := fmt.Sprintf("%s/search/issues?q=repo:%s+type:issue+created:>=%s", acmmGitHubAPI, repo, since)
+	issueItems := searchAllACMMPages(ctx, issueURL, token)
+	for _, item := range issueItems {
+		if item.PullRequest != nil {
+			continue
+		}
+		t, err := time.Parse(time.RFC3339, item.CreatedAt)
+		if err != nil {
+			continue
+		}
+		w := isoWeek(t)
+		b, ok := buckets[w]
+		if !ok {
+			continue
+		}
+		if isACMMAIContribution(item.Labels, item.User.Login) {
+			b.AIIssues++
+		} else {
+			b.HumanIssues++
+		}
+	}
+
+	result := make([]acmmWeeklyActivity, 0, len(weeks))
+	for _, w := range weeks {
+		result = append(result, *buckets[w])
+	}
+	return result
+}
+
+func lastNWeeks(n int) []string {
+	seen := make(map[string]bool)
+	var weeks []string
+	now := time.Now()
+	for i := n - 1; i >= 0; i-- {
+		d := now.AddDate(0, 0, -i*7)
+		w := isoWeek(d)
+		if !seen[w] {
+			seen[w] = true
+			weeks = append(weeks, w)
+		}
+	}
+	return weeks
+}
+
+type acmmSearchItem struct {
+	CreatedAt   string `json:"created_at"`
+	PullRequest *struct {
+		MergedAt *string `json:"merged_at"`
+	} `json:"pull_request"`
+	User struct {
+		Login string `json:"login"`
+	} `json:"user"`
+	Labels []acmmLabel `json:"labels"`
+}
+
+func searchAllACMMPages(ctx context.Context, baseURL, token string) []acmmSearchItem {
+	var items []acmmSearchItem
+	for page := 1; page <= searchMaxPages; page++ {
+		url := fmt.Sprintf("%s&per_page=%d&page=%d", baseURL, searchPageSize, page)
+		body, err := githubGet(ctx, url, token)
+		if err != nil {
+			break
+		}
+		var resp struct {
+			Items []acmmSearchItem `json:"items"`
+		}
+		if err := json.Unmarshal(body, &resp); err != nil {
+			break
+		}
+		items = append(items, resp.Items...)
+		if len(resp.Items) < searchPageSize {
+			break
+		}
+	}
+	return items
+}
+
+type acmmLabel struct {
+	Name string `json:"name"`
+}
+
+func isACMMAIContribution(labels []acmmLabel, author string) bool {
+	if aiAuthors[author] {
+		return true
+	}
+	if strings.HasSuffix(author, "[bot]") {
+		return true
+	}
+	for _, l := range labels {
+		if l.Name == aiLabel {
+			return true
+		}
+	}
+	return false
+}
+
+// githubGet performs an authenticated GET request to the GitHub API.
+func githubGet(ctx context.Context, url, token string) ([]byte, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Accept", "application/vnd.github.v3+json")
+	if token != "" {
+		req.Header.Set("Authorization", "Bearer "+token)
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("GitHub API request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusNotFound {
+		return nil, fmt.Errorf("not found")
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("GitHub API %d", resp.StatusCode)
+	}
+
+	// Read body with a size limit to avoid unbounded memory
+	const maxBodySize = 10 * 1024 * 1024 // 10 MB
+	body := make([]byte, 0, 1024)
+	buf := make([]byte, 4096)
+	total := 0
+	for {
+		n, readErr := resp.Body.Read(buf)
+		if n > 0 {
+			total += n
+			if total > maxBodySize {
+				return nil, fmt.Errorf("response too large (>%d bytes)", maxBodySize)
+			}
+			body = append(body, buf[:n]...)
+		}
+		if readErr != nil {
+			break
+		}
+	}
+
+	return body, nil
+}
+
+// demoACMMScan returns demo data for when the GitHub API is unavailable.
+func demoACMMScan(repo string) acmmScanResult {
+	weeks := lastNWeeks(weeksOfHistory)
+	activity := make([]acmmWeeklyActivity, len(weeks))
+	for i, w := range weeks {
+		activity[i] = acmmWeeklyActivity{
+			Week:        w,
+			AIPrs:       25 + int(math.Floor(math.Sin(float64(i))*5+10)),
+			HumanPrs:    4 + int(math.Floor(math.Cos(float64(i))*2+1)),
+			AIIssues:    12 + int(math.Floor(math.Sin(float64(i)*2)*3)),
+			HumanIssues: 3,
+		}
+	}
+	return acmmScanResult{
+		Repo:      repo,
+		ScannedAt: time.Now().UTC().Format(time.RFC3339),
+		DetectedIDs: []string{
+			"acmm:claude-md", "acmm:copilot-instructions", "acmm:pr-template",
+			"acmm:contrib-guide", "acmm:style-config", "acmm:editor-config",
+			"acmm:coverage-gate", "acmm:test-suite", "acmm:e2e-tests",
+			"acmm:ci-matrix", "acmm:nightly-compliance", "acmm:auto-label",
+			"acmm:ai-fix-workflow", "acmm:security-ai-md", "acmm:public-metrics",
+			"acmm:reflection-log", "fullsend:test-coverage", "fullsend:ci-cd-maturity",
+			"aef:structural-gates", "aef:session-continuity",
+			"claude-reflect:preference-index", "claude-reflect:session-summary",
+		},
+		WeeklyActivity: activity,
+	}
+}

--- a/pkg/api/handlers/acmm_scan.go
+++ b/pkg/api/handlers/acmm_scan.go
@@ -309,7 +309,9 @@ func fetchACMMWeeklyActivity(ctx context.Context, repo, token string) []acmmWeek
 
 	result := make([]acmmWeeklyActivity, 0, len(weeks))
 	for _, w := range weeks {
-		result = append(result, *buckets[w])
+		if b := buckets[w]; b != nil {
+			result = append(result, *b)
+		}
 	}
 	return result
 }

--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -773,6 +773,8 @@ func (s *Server) setupRoutes() {
 	// Medium blog (public — proxies to Medium RSS feed, cached 1h)
 	s.app.Get("/api/medium/blog", publicLimiter, handlers.MediumBlogHandler)
 
+	// ACMM scan — registered below on the authenticated api group
+
 	// Mission knowledge base browse/file (public — proxies to public GitHub repo)
 	missions := handlers.NewMissionsHandler()
 	missions.RegisterPublicRoutes(s.app.Group("/api/missions"))
@@ -827,6 +829,9 @@ func (s *Server) setupRoutes() {
 	api.Post("/github-pipelines", githubPipelines.Serve)
 
 	api.Get("/github/*", githubProxy.Proxy)
+
+	// ACMM scan — uses server's GitHub token like other GitHub-powered cards
+	api.Get("/acmm/scan", handlers.ACMMScanHandler)
 
 	// Persistent settings routes
 	settingsHandler := handlers.NewSettingsHandler(settings.GetSettingsManager(), s.store)

--- a/web/src/hooks/useCachedACMMScan.ts
+++ b/web/src/hooks/useCachedACMMScan.ts
@@ -114,9 +114,9 @@ async function fetchACMMScan(repo: string, force: boolean): Promise<ACMMScanData
   if (!res.ok) {
     throw new Error(`ACMM scan failed: ${res.status} ${res.statusText}`)
   }
-  // The Go backend and cluster deployments don't implement /api/acmm/scan —
-  // the SPA catch-all returns index.html (text/html) instead of JSON.
-  // Detect this and throw a clean error so the card falls back to demo data.
+  // Safety net: if the response isn't JSON (e.g. older builds without the Go
+  // handler, or an SPA catch-all returning index.html), throw a clean error
+  // so the card falls back to demo data instead of a JSON parse crash.
   const ct = res.headers.get('content-type') || ''
   if (!ct.includes('application/json')) {
     throw new Error('ACMM scan is not available on this deployment — showing demo data')

--- a/web/src/hooks/useCachedACMMScan.ts
+++ b/web/src/hooks/useCachedACMMScan.ts
@@ -149,9 +149,14 @@ export function useCachedACMMScan(repo: string = DEFAULT_REPO): UseACMMScanResul
   }, [refetch])
 
   // When the Netlify Function isn't available (localhost / cluster deploy),
-  // the fetcher fails. Fall back to demo data so the cards render something
-  // useful instead of showing an empty state with a raw error.
-  const apiUnavailable = cacheResult.isFailed && cacheResult.data.detectedIds.length === 0
+  // the fetcher throws "ACMM scan is not available on this deployment".
+  // Detect this from the error string (available on the FIRST failure) rather
+  // than isFailed (which requires 3 consecutive failures to flip). Once
+  // detected, substitute demo data and suppress all error/failure indicators
+  // so the cards render with the standard Demo badge instead of "Refresh failed".
+  const apiUnavailable =
+    (cacheResult.error?.includes('not available') ?? false) ||
+    (cacheResult.isFailed && cacheResult.data.detectedIds.length === 0)
   const effectiveData = apiUnavailable ? demoScan(repo) : cacheResult.data
 
   const detectedIds = new Set(effectiveData.detectedIds ?? [])
@@ -166,8 +171,8 @@ export function useCachedACMMScan(repo: string = DEFAULT_REPO): UseACMMScanResul
     detectedIds,
     level,
     recommendations,
-    isLoading: cacheResult.isLoading,
-    isRefreshing: cacheResult.isRefreshing,
+    isLoading: apiUnavailable ? false : cacheResult.isLoading,
+    isRefreshing: apiUnavailable ? false : cacheResult.isRefreshing,
     isDemoData,
     error: apiUnavailable ? null : cacheResult.error,
     isFailed: apiUnavailable ? false : cacheResult.isFailed,


### PR DESCRIPTION
## Summary
- Adds Go backend handler for `/api/acmm/scan` that mirrors the Netlify Function
- Calls GitHub tree API + search API to detect maturity criteria and weekly activity
- Uses `GITHUB_TOKEN` from env for authenticated requests (5000 req/hr)
- Frontend hook detects API unavailability on first error (not after 3 failures) and shows demo badges
- Suppresses `isLoading`/`isRefreshing` when API unavailable to prevent "Refresh failed" badge

Fixes the `<!doctype` JSON parse error on localhost and makes ACMM fully functional on all deployment modes.

## Test plan
- [ ] Open `/acmm` on localhost — scan `kubestellar/console`, verify 25+ criteria detected
- [ ] Scan a different repo (e.g. `ublue-os/bluefin`) — verify different criteria
- [ ] Open `/acmm` on console.kubestellar.io — verify unchanged behavior (Netlify Function)
- [ ] Without `GITHUB_TOKEN` set — verify graceful demo fallback with Demo badge

🤖 Generated with [Claude Code](https://claude.com/claude-code)