### PR TITLE
feat: ACMM scan auto-refreshes after mission completion

### DIFF
--- a/web/src/components/acmm/ACMMProvider.tsx
+++ b/web/src/components/acmm/ACMMProvider.tsx
@@ -112,6 +112,15 @@ export function ACMMProvider({ children }: { children: ReactNode }) {
 
   const scan = useCachedACMMScan(repo)
 
+  // Force-refresh the scan when a mission completes — the mission may
+  // have added a feedback loop (e.g. created CLAUDE.md, added a workflow)
+  // that changes the repo's maturity score.
+  useEffect(() => {
+    const handler = () => { scan.forceRefetch() }
+    window.addEventListener('kc-mission-completed', handler)
+    return () => window.removeEventListener('kc-mission-completed', handler)
+  }, [scan.forceRefetch])
+
   // Auto-open the intro on first visit unless previously dismissed.
   useEffect(() => {
     if (!isACMMIntroDismissed()) {

--- a/web/src/hooks/useMissions.tsx
+++ b/web/src/hooks/useMissions.tsx
@@ -2051,6 +2051,11 @@ The WebSocket connection to the agent at \`${LOCAL_AGENT_WS_URL}\` was lost and 
           const rawDuration = Math.round((Date.now() - m.createdAt.getTime()) / 1000)
           const clampedDuration = Math.min(Math.max(rawDuration, 0), MAX_MISSION_DURATION_SEC)
           emitMissionCompleted(m.type, clampedDuration)
+          // Notify data-dependent components (e.g. ACMM scan) so they
+          // re-fetch after a mission may have changed the repo's state.
+          window.dispatchEvent(new CustomEvent('kc-mission-completed', {
+            detail: { missionId, missionType: m.type },
+          }))
         }
 
         const resultContent = chatPayload.content || (payload as { output?: string }).output || 'Task completed.'


### PR DESCRIPTION
## Summary
- Dispatches `kc-mission-completed` CustomEvent when a mission result arrives
- ACMMProvider listens for this event and calls `forceRefetch()` on the scan
- After running a mission that adds a feedback loop (e.g. "Add CLAUDE.md to my repo"), the ACMM score updates immediately

## Test plan
- [ ] Run an ACMM mission (e.g. "add a contributing guide") → scan refreshes on completion
- [ ] Verify no re-scan when navigating away from `/acmm` (event listener cleaned up)
- [ ] Verify console.kubestellar.io unchanged (Netlify Function still handles scan)

🤖 Generated with [Claude Code](https://claude.com/claude-code)