### PR TITLE
fix: grant Write/Edit/Glob/Grep tools to mission agent

### DIFF
--- a/pkg/agent/provider_claudecode.go
+++ b/pkg/agent/provider_claudecode.go
@@ -254,13 +254,15 @@ func (c *ClaudeCodeProvider) StreamChatWithProgress(ctx context.Context, req *Ch
 	// Build command with streaming JSON output
 	// -p (print mode) is required for stream-json
 	// --verbose is required for stream-json in print mode
-	// --allowedTools restricts tool access to Bash and Read only (no Write/Edit)
+	// --allowedTools grants the tools missions need: file I/O for creating
+	// feedback loops (AGENTS.md, workflows) and search for code exploration.
+	// Bash covers git, gh CLI, and shell commands for PR creation.
 	// --max-turns limits agentic loops (workaround for CLI bug with duplicate tool_use IDs)
 	args := []string{
 		"-p",
 		"--output-format", "stream-json",
 		"--verbose",
-		"--allowedTools", "Bash,Read",
+		"--allowedTools", "Bash,Read,Write,Edit,Glob,Grep",
 		"--max-turns", "25",
 		fullPrompt,
 	}


### PR DESCRIPTION
## Summary
- Changes `--allowedTools "Bash,Read"` to `"Bash,Read,Write,Edit,Glob,Grep"` in the Claude Code provider
- Enables missions to create files (AGENTS.md, CLAUDE.md, workflows) and search codebases
- Without this, ACMM missions like "Add AGENTS.md shared directives" fail with "Write permission blocked"

## Test plan
- [ ] Run an ACMM mission to add a feedback loop → mission creates the file and opens a PR
- [ ] Verify existing missions (chat, analysis) still work with the expanded tool set
- [ ] Verify no security regression — Write/Edit are standard Claude Code tools

🤖 Generated with [Claude Code](https://claude.com/claude-code)