### PR TITLE
📖 docs: add AGENTS.md for ACMM acmm:agents-md criterion

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,34 @@
+# AGENTS.md — KubeStellar Console
+
+Tool-neutral entry point for AI coding agents (Claude Code, GitHub Copilot, Cursor, Codex, Aider, Continue, etc.) working on this repo.
+
+## Source of truth
+
+All project conventions, architecture notes, critical rules, and testing requirements live in **[`CLAUDE.md`](./CLAUDE.md)**. That file is the canonical guide — read it first, and follow it regardless of which AI tool you are using.
+
+Tool-specific overrides (if any):
+
+- GitHub Copilot: [`.github/copilot-instructions.md`](./.github/copilot-instructions.md)
+
+If a tool-specific file conflicts with `CLAUDE.md`, `CLAUDE.md` wins.
+
+## Quick orientation
+
+- **Start the console:** `./startup-oauth.sh` (requires `.env` with GitHub OAuth) or `./start-dev.sh` (mock user, no OAuth).
+- **Ports:** backend `8080`, frontend `5174`, kc-agent WebSocket `8585`.
+- **Pre-PR gate:** `cd web && npm run build && npm run lint`.
+- **Testing is mandatory** for UI and API work — see the "MANDATORY Testing Requirements" section in `CLAUDE.md`.
+
+## Non-negotiable rules (excerpt — full list in `CLAUDE.md`)
+
+- No magic numbers — use named constants.
+- No hardcoded secrets — use env vars only.
+- Array safety — guard with `(data || [])` before `.map`/`.filter`/`.join`/`for...of`.
+- Use `DeduplicatedClusters()` when iterating clusters.
+- All card data fetching goes through `useCache` / `useCached*` hooks.
+- User-facing strings use `t()` from `react-i18next` — never raw strings.
+- Netlify Functions (`web/netlify/functions/*.mts`) must be updated alongside Go API handlers, since production (console.kubestellar.io) runs on Netlify, not the Go backend.
+
+## Reporting back
+
+When you finish a task, summarize what changed and confirm the pre-PR gate (`npm run build && npm run lint`) passed. Do not push or open PRs unless explicitly asked.


### PR DESCRIPTION
## Summary
- Adds `AGENTS.md` at repo root as a tool-neutral entry point for any AI coding agent (Copilot, Cursor, Codex, Aider, Continue, etc.).
- Points all agents at `CLAUDE.md` as the canonical guide, plus `.github/copilot-instructions.md` for Copilot-specific guidance.
- Satisfies the ACMM `acmm:agents-md` criterion (path match on `AGENTS.md`) — an L2 durability signal for cross-tool agent instructions.

## Why this shape
`CLAUDE.md` is ~18KB and is the single source of truth for project conventions. Duplicating it into `AGENTS.md` would create drift. Instead, `AGENTS.md` is a thin pointer with a short excerpt of non-negotiable rules so any tool that reads `AGENTS.md` first still gets the critical guidance.

## Test plan
- [ ] ACMM dashboard scan detects `acmm:agents-md` as satisfied
- [ ] `AGENTS.md` renders correctly on GitHub
- [ ] Links to `CLAUDE.md` and `.github/copilot-instructions.md` resolve