### PR TITLE
fix: add ci-cd category to widget registry test assertions

### DIFF
--- a/web/src/lib/widgets/__tests__/widgetRegistry.test.ts
+++ b/web/src/lib/widgets/__tests__/widgetRegistry.test.ts
@@ -26,7 +26,7 @@ describe('WIDGET_CARDS', () => {
       expect(card.minRefreshInterval).toBeGreaterThan(0)
       expect(card.defaultSize.width).toBeGreaterThan(0)
       expect(card.defaultSize.height).toBeGreaterThan(0)
-      expect(['cluster', 'workload', 'gpu', 'security', 'monitoring']).toContain(card.category)
+      expect(['cluster', 'workload', 'gpu', 'security', 'monitoring', 'ci-cd']).toContain(card.category)
     }
   })
 
@@ -81,7 +81,7 @@ describe('WIDGET_TEMPLATES', () => {
       expect(['grid', 'row', 'column', 'dashboard']).toContain(template.layout)
       expect(template.size.width).toBeGreaterThan(0)
       expect(template.size.height).toBeGreaterThan(0)
-      expect(['overview', 'gpu', 'pods', 'security', 'custom']).toContain(template.category)
+      expect(['overview', 'gpu', 'pods', 'security', 'custom', 'ci-cd']).toContain(template.category)
     }
   })
 


### PR DESCRIPTION
## Summary
- PR #8611 added 7 CI/CD cards with `category: 'ci-cd'` to the widget registry
- The test's allowed-category assertions only listed `['cluster', 'workload', 'gpu', 'security', 'monitoring']`
- Added `'ci-cd'` to both the card and template category assertion lists

Fixes #8620

## Test plan
- [x] `vitest run widgetRegistry.test.ts` — all 20 tests pass (was 1 failure)

🤖 Generated with [Claude Code](https://claude.com/claude-code)