### PR TITLE
fix: derive widget test categories from source types

### DIFF
--- a/web/src/lib/widgets/__tests__/widgetRegistry.test.ts
+++ b/web/src/lib/widgets/__tests__/widgetRegistry.test.ts
@@ -7,6 +7,10 @@ import {
   isCardExportable,
   getExportableCardsByCategory,
   getTemplatesByCategory,
+  VALID_CARD_CATEGORIES,
+  VALID_TEMPLATE_CATEGORIES,
+  VALID_TEMPLATE_LAYOUTS,
+  VALID_STAT_FORMATS,
 } from '../widgetRegistry'
 
 describe('WIDGET_CARDS', () => {
@@ -26,7 +30,7 @@ describe('WIDGET_CARDS', () => {
       expect(card.minRefreshInterval).toBeGreaterThan(0)
       expect(card.defaultSize.width).toBeGreaterThan(0)
       expect(card.defaultSize.height).toBeGreaterThan(0)
-      expect(['cluster', 'workload', 'gpu', 'security', 'monitoring', 'ci-cd']).toContain(card.category)
+      expect(VALID_CARD_CATEGORIES).toContain(card.category)
     }
   })
 
@@ -55,7 +59,7 @@ describe('WIDGET_STATS', () => {
       expect(stat.displayName).toBeTruthy()
       expect(stat.apiEndpoint).toBeTruthy()
       expect(stat.dataPath).toBeTruthy()
-      expect(['number', 'percentage', 'bytes', 'duration']).toContain(stat.format)
+      expect(VALID_STAT_FORMATS).toContain(stat.format)
       expect(stat.color).toMatch(/^#/)
       expect(stat.size.width).toBeGreaterThan(0)
       expect(stat.size.height).toBeGreaterThan(0)
@@ -78,10 +82,10 @@ describe('WIDGET_TEMPLATES', () => {
       expect(template.displayName).toBeTruthy()
       expect(template.description).toBeTruthy()
       expect(Array.isArray(template.cards)).toBe(true)
-      expect(['grid', 'row', 'column', 'dashboard']).toContain(template.layout)
+      expect(VALID_TEMPLATE_LAYOUTS).toContain(template.layout)
       expect(template.size.width).toBeGreaterThan(0)
       expect(template.size.height).toBeGreaterThan(0)
-      expect(['overview', 'gpu', 'pods', 'security', 'custom', 'ci-cd']).toContain(template.category)
+      expect(VALID_TEMPLATE_CATEGORIES).toContain(template.category)
     }
   })
 

--- a/web/src/lib/widgets/widgetRegistry.ts
+++ b/web/src/lib/widgets/widgetRegistry.ts
@@ -40,6 +40,54 @@ export interface WidgetTemplateDefinition {
   category: 'overview' | 'gpu' | 'pods' | 'security' | 'custom' | 'ci-cd'
 }
 
+/**
+ * Valid category values for card widgets.
+ * Derived from the WidgetCardDefinition['category'] union type.
+ */
+export const VALID_CARD_CATEGORIES: WidgetCardDefinition['category'][] = [
+  'cluster',
+  'workload',
+  'gpu',
+  'security',
+  'monitoring',
+  'ci-cd',
+]
+
+/**
+ * Valid category values for template widgets.
+ * Derived from the WidgetTemplateDefinition['category'] union type.
+ */
+export const VALID_TEMPLATE_CATEGORIES: WidgetTemplateDefinition['category'][] = [
+  'overview',
+  'gpu',
+  'pods',
+  'security',
+  'custom',
+  'ci-cd',
+]
+
+/**
+ * Valid layout values for template widgets.
+ * Derived from the WidgetTemplateDefinition['layout'] union type.
+ */
+export const VALID_TEMPLATE_LAYOUTS: WidgetTemplateDefinition['layout'][] = [
+  'grid',
+  'row',
+  'column',
+  'dashboard',
+]
+
+/**
+ * Valid format values for stat widgets.
+ * Derived from the WidgetStatDefinition['format'] union type.
+ */
+export const VALID_STAT_FORMATS: WidgetStatDefinition['format'][] = [
+  'number',
+  'percentage',
+  'bytes',
+  'duration',
+]
+
 // Cards that support widget export
 export const WIDGET_CARDS: Record<string, WidgetCardDefinition> = {
   cluster_health: {


### PR DESCRIPTION
## Summary
- Export `VALID_CARD_CATEGORIES`, `VALID_TEMPLATE_CATEGORIES`, `VALID_TEMPLATE_LAYOUTS`, and `VALID_STAT_FORMATS` constants from `widgetRegistry.ts`, typed against the actual union types
- Update `widgetRegistry.test.ts` to use these shared constants instead of hardcoded arrays
- Fixes #8627

## Test plan
- [x] `widgetRegistry.test.ts` passes (20/20)
- [x] `npm run build` passes
- [x] `npm run lint` passes