### PR TITLE
fix: Export Widget opens Console Studio on all dashboards

### DIFF
--- a/web/src/lib/dashboards/DashboardPage.tsx
+++ b/web/src/lib/dashboards/DashboardPage.tsx
@@ -28,6 +28,7 @@ import { DashboardHealthIndicator } from '../../components/dashboard/DashboardHe
 import { useUniversalStats, createMergedStatValueGetter } from '../../hooks/useUniversalStats'
 import { useRefreshIndicator } from '../../hooks/useRefreshIndicator'
 import { prefetchCardChunks } from '../../components/cards/cardRegistry'
+import { useDashboardContextOptional } from '../../hooks/useDashboardContext'
 
 // ============================================================================
 // Types
@@ -197,6 +198,25 @@ export function DashboardPage({
   // Combined refreshing state
   const isRefreshing = externalRefreshing || showIndicator
   const isFetching = isLoading || isRefreshing
+
+  // Bridge: when CardWrapper's "Export Widget" calls studioContext.openAddCardModal(),
+  // it sets isAddCardModalOpen in the DashboardContext. Sync that into our local
+  // showAddCard state so the DashboardCustomizer opens.
+  const dashCtx = useDashboardContextOptional()
+  const [widgetCardType, setWidgetCardType] = useState<string | undefined>(undefined)
+  useEffect(() => {
+    if (dashCtx?.isAddCardModalOpen) {
+      setShowAddCard(true)
+      if (dashCtx.studioInitialSection) {
+        setCustomizerInitialSection(dashCtx.studioInitialSection as 'cards' | 'dashboards' | undefined)
+      }
+      if (dashCtx.studioWidgetCardType) {
+        setWidgetCardType(dashCtx.studioWidgetCardType)
+      }
+      // Reset context state so it doesn't re-trigger
+      dashCtx.closeAddCardModal()
+    }
+  }, [dashCtx?.isAddCardModalOpen, dashCtx?.studioInitialSection, dashCtx?.studioWidgetCardType])
 
   // Handle addCard and customizeSidebar URL params via the DashboardCustomizer.
   // Guard with mounted route: KeepAlive keeps hidden dashboards mounted,
@@ -433,12 +453,13 @@ export function DashboardPage({
     {/* Dashboard Studio — unified customization panel */}
     <DashboardCustomizer
       isOpen={showAddCard}
-      onClose={() => { setShowAddCard(false); setAddCardSearch(''); setInsertAtIndex(null); setCustomizerInitialSection(undefined) }}
+      onClose={() => { setShowAddCard(false); setAddCardSearch(''); setInsertAtIndex(null); setCustomizerInitialSection(undefined); setWidgetCardType(undefined) }}
       dashboardName={title}
       onAddCards={handleAddCards}
       existingCardTypes={cards.map(c => c.card_type)}
       initialSection={customizerInitialSection}
       initialSearch={addCardSearch}
+      initialWidgetCardType={widgetCardType}
       onApplyTemplate={applyTemplate}
       /* onExport not available on generic DashboardPage — only on Dashboard.tsx */
       onReset={reset}


### PR DESCRIPTION
## Summary

- **Bug**: Clicking "Export Widget" on any card menu did nothing on CI/CD, Deploy, Security, and other non-main dashboards. The menu closed but no modal appeared.
- **Root cause**: `CardWrapper` calls `studioContext.openAddCardModal('widgets', cardType)` which sets `isAddCardModalOpen=true` in `DashboardContext`. But `DashboardPage` (used by all specialty dashboards) never read that context state — it only used its own local `showAddCard` state. The two were disconnected.
- **Fix**: Added a bridge `useEffect` in `DashboardPage` that syncs the context's `isAddCardModalOpen` into the local `showAddCard` state, including the `studioInitialSection` and `studioWidgetCardType` props. Now clicking Export Widget on any dashboard opens Console Studio with the Widgets section and the card type pre-selected.

## Test plan

- [ ] Go to CI/CD dashboard → click any card's menu → Export Widget → Console Studio opens at Widgets section
- [ ] Go to Deploy dashboard → same test
- [ ] Go to main Dashboard → same test (was already working)
- [ ] Verify the widget card type is pre-selected in the Studio panel
- [ ] Verify closing Studio resets all state cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)