### PR TITLE
🐛 fix: Nightly Release Pulse crash on undefined nextCron

### DIFF
--- a/web/netlify/functions/github-pipelines.mts
+++ b/web/netlify/functions/github-pipelines.mts
@@ -830,7 +830,11 @@ export default async (req: Request): Promise<Response> => {
     });
   } catch (err) {
     return jsonResponse(
-      { error: (err as Error).message ?? "Internal error" },
+      {
+        error: (err as Error).message ?? "Internal error",
+        repos: REPOS,
+        nextCron: "0 5 * * *",
+      },
       { status: 500, headers: baseHeaders }
     );
   }

--- a/web/src/components/cards/pipelines/NightlyReleasePulse.tsx
+++ b/web/src/components/cards/pipelines/NightlyReleasePulse.tsx
@@ -44,7 +44,8 @@ const PLACEHOLDER_REPO = 'owner/repo'
 const LABEL_SET_REPO = 'Set repo to monitor'
 const STANDARD_CRON_FIELD_COUNT = 5
 
-function formatCron(cron: string): string {
+function formatCron(cron: string | undefined | null): string {
+  if (!cron || typeof cron !== 'string') return '—'
   const parts = cron.trim().split(/\s+/)
   if (parts.length === STANDARD_CRON_FIELD_COUNT && parts[2] === '*' && parts[3] === '*' && parts[4] === '*') {
     const minute = parseInt(parts[0], 10)


### PR DESCRIPTION
## Problem

On `console.kubestellar.io` (demo mode, Netlify Functions), the **Nightly Release Pulse** card on the CI/CD page renders:

> Card Render Error — Cannot read properties of undefined (reading 'trim')

Works fine on localhost (Go backend).

## Root cause

Regression from cc20fc0f (Apr 16, "fix: CI/CD cards respect repo dropdown selection"), which added repo-filter support to `buildPulse` in `web/netlify/functions/github-pipelines.mts`. Non-default repos are more likely to hit GitHub rate limits or scoping issues — when that happens `buildPulse` throws, the outer catch returns `{ error: "..." }` with **no `nextCron`**, and `NightlyReleasePulse.tsx:48` calls `cron.trim()` on undefined.

The Go backend returns HTTP 5xx on error (handled differently by the hook), so localhost avoided this.

## Fix

Two defensive guards, either alone would stop the crash:

1. **Frontend** — `formatCron` in `NightlyReleasePulse.tsx` widens its parameter to `string | undefined | null` and returns `—` when absent.
2. **Backend** — Netlify error path now includes `nextCron: "0 5 * * *"` (same hardcoded fallback used on success) plus `repos: REPOS`, so cards that destructure before checking the error flag no longer crash.

## Test plan

- [x] `npm run build` clean
- [x] `eslint` on the changed tsx — 0 new errors
- [ ] CI build + lint pass
- [ ] Netlify preview: `/ci-cd` on demo mode, Nightly Release Pulse renders
- [ ] Switch repo dropdown to one that triggered the error — card shows `—` instead of crashing