### PR TITLE
fix: address Copilot review feedback on DashboardPage

### DIFF
--- a/web/src/lib/dashboards/DashboardPage.tsx
+++ b/web/src/lib/dashboards/DashboardPage.tsx
@@ -20,6 +20,7 @@ import { SortableDashboardCard, DragPreviewCard } from './DashboardComponents'
 import { ConfigureCardModal } from '../../components/dashboard/ConfigureCardModal'
 import { FloatingDashboardActions } from '../../components/dashboard/FloatingDashboardActions'
 import { DashboardCustomizer } from '../../components/dashboard/customizer/DashboardCustomizer'
+import type { CustomizerSection } from '../../components/dashboard/customizer/customizerNav'
 import { DashboardTemplate } from '../../components/dashboard/templates'
 import { StatsOverview, StatBlockValue } from '../../components/ui/StatsOverview'
 import { DashboardStatsType } from '../../components/ui/StatsBlockDefinitions'
@@ -205,10 +206,14 @@ export function DashboardPage({
   const dashCtx = useDashboardContextOptional()
   const [widgetCardType, setWidgetCardType] = useState<string | undefined>(undefined)
   useEffect(() => {
+    // Guard: only process on the active dashboard — KeepAlive keeps inactive
+    // dashboards mounted, so without this check we'd open the customizer on
+    // a hidden dashboard when the context fires.
+    if (location.pathname !== mountedRouteRef.current) return
     if (dashCtx?.isAddCardModalOpen) {
       setShowAddCard(true)
       if (dashCtx.studioInitialSection) {
-        setCustomizerInitialSection(dashCtx.studioInitialSection as 'cards' | 'dashboards' | undefined)
+        setCustomizerInitialSection(dashCtx.studioInitialSection)
       }
       if (dashCtx.studioWidgetCardType) {
         setWidgetCardType(dashCtx.studioWidgetCardType)
@@ -216,14 +221,14 @@ export function DashboardPage({
       // Reset context state so it doesn't re-trigger
       dashCtx.closeAddCardModal()
     }
-  }, [dashCtx?.isAddCardModalOpen, dashCtx?.studioInitialSection, dashCtx?.studioWidgetCardType])
+  }, [dashCtx?.isAddCardModalOpen, dashCtx?.studioInitialSection, dashCtx?.studioWidgetCardType, location.pathname])
 
   // Handle addCard and customizeSidebar URL params via the DashboardCustomizer.
   // Guard with mounted route: KeepAlive keeps hidden dashboards mounted,
   // so all of them see the same searchParams. Only process when active.
   const [addCardSearch, setAddCardSearch] = useState('')
   // Determine initial section for DashboardCustomizer based on URL params
-  const [customizerInitialSection, setCustomizerInitialSection] = useState<'cards' | 'dashboards' | undefined>(undefined)
+  const [customizerInitialSection, setCustomizerInitialSection] = useState<CustomizerSection | undefined>(undefined)
   useEffect(() => {
     if (location.pathname !== mountedRouteRef.current) return
     if (searchParams.get('addCard') === 'true') {
@@ -259,6 +264,8 @@ export function DashboardPage({
     }
     expandCards()
     setShowAddCard(false)
+    setWidgetCardType(undefined)
+    setCustomizerInitialSection(undefined)
   }
 
   const handleRemoveCard = (cardId: string) => {
@@ -292,6 +299,8 @@ export function DashboardPage({
     expandCards()
     // Close DashboardCustomizer after applying template
     setShowAddCard(false)
+    setWidgetCardType(undefined)
+    setCustomizerInitialSection(undefined)
   }
 
   // Merged stat value getter: dashboard-specific first, then universal fallback


### PR DESCRIPTION
## Summary

Addresses the 4 Copilot review comments from merged PR #8631.

- **KeepAlive guard on bridge effect**: Added `location.pathname !== mountedRouteRef.current` check so the bridge effect that syncs `DashboardContext.isAddCardModalOpen` into local state only fires on the active dashboard, preventing the customizer from opening on hidden/inactive dashboards kept alive by KeepAlive.
- **Widened type assertion**: Replaced the narrowing `as 'cards' | 'dashboards' | undefined` cast with the actual `CustomizerSection` type from `customizerNav.ts`, which includes all valid sections (`cards`, `collections`, `dashboards`, `widgets`, `create-dashboard`, `card-factory`, `stat-factory`).
- **Clear stale widgetCardType**: Added `setWidgetCardType(undefined)` and `setCustomizerInitialSection(undefined)` to `handleAddCards()` and `applyTemplate()`, which close the customizer via `setShowAddCard(false)` without going through the `onClose` handler. This prevents stale `widgetCardType` from persisting across customizer open/close cycles.
- **Test coverage**: Deferred — DashboardPage has no existing test file and the component requires extensive mocking (react-router, DnD, contexts). Not straightforward to add incrementally.

Fixes #8634

## Test plan
- [ ] Verify build passes (`npm run build`)
- [ ] Open a dashboard, use "Export Widget" from a card — customizer should open on the correct section
- [ ] Navigate to a different dashboard — the customizer should NOT open on the previous dashboard
- [ ] Add cards via customizer — `widgetCardType` should be cleared after adding
- [ ] Apply a template — `widgetCardType` should be cleared after applying