### PR TITLE
fix: mission prompt test + Copilot review feedback from #8630

### DIFF
--- a/web/src/lib/acmm/__tests__/missionPrompts.test.ts
+++ b/web/src/lib/acmm/__tests__/missionPrompts.test.ts
@@ -87,7 +87,7 @@ describe('allRecommendationsPrompt', () => {
     expect(prompt).toContain('1. Test suite')
     expect(prompt).toContain('2. Coverage gate')
     expect(prompt).toContain('org/repo')
-    expect(prompt).toContain('Do not push or open a PR automatically')
+    expect(prompt).toContain('Should I push and open a PR with all changes?')
   })
 })
 

--- a/web/src/lib/acmm/missionPrompts.ts
+++ b/web/src/lib/acmm/missionPrompts.ts
@@ -41,10 +41,11 @@ Please:
 1. Audit the repo for any existing artifact that satisfies this detection (don't duplicate).
 2. If found, tell me what you found and ask if I want to modify it or skip.
 3. If missing, create a feature branch, add the minimum file(s) that match the detection pattern.
-4. Show me a summary of what you created, then ask:
-   - "Should I push this branch and open a PR?"
-   - "Should I make changes first?"
-5. If I say yes, push the branch and open a PR. Return the PR URL.`
+4. Run build and lint to verify no regressions before committing or pushing.
+5. Show me a summary of what you created, then ask:
+   1. "Should I push this branch and open a PR?"
+   2. "Should I make changes first?"
+6. If I say yes, push the branch and open a PR. Return the PR URL.`
 }
 
 /**
@@ -73,13 +74,13 @@ export function allRecommendationsPrompt(recs: Recommendation[], repo: string): 
 ${list}
 
 For each item:
-- Check whether an equivalent artifact already exists (don't duplicate).
-- If truly missing, add the minimum change that matches the detection pattern.
-- After each item, briefly confirm what was added.
+1. Check whether an equivalent artifact already exists (don't duplicate).
+2. If truly missing, add the minimum change that matches the detection pattern.
+3. After each item, briefly confirm what was added.
 
-When all items are done, ask:
-  - "Should I push and open a PR with all changes?"
-  - "Should I make adjustments first?"`
+When all items are done, run build and lint to verify no regressions, then ask:
+  1. "Should I push and open a PR with all changes?"
+  2. "Should I make adjustments first?"`
 }
 
 /** Mission prompt for finishing all missing criteria at a given ACMM
@@ -96,11 +97,11 @@ ${list}
 Why this matters: completing L${earnedLevel} unlocks L${earnedLevel + 1} on the ACMM dashboard and bumps the README badge.
 
 For each item:
-- Check whether an equivalent artifact already exists (don't duplicate).
-- If truly missing, add the minimum change that matches the detection pattern.
-- After each item, briefly confirm what was added.
+1. Check whether an equivalent artifact already exists (don't duplicate).
+2. If truly missing, add the minimum change that matches the detection pattern.
+3. After each item, briefly confirm what was added.
 
-When all items are done, ask:
-  - "Should I push and open a PR with all changes?"
-  - "Should I make adjustments first?"`
+When all items are done, run build and lint to verify no regressions, then ask:
+  1. "Should I push and open a PR with all changes?"
+  2. "Should I make adjustments first?"`
 }


### PR DESCRIPTION
## Summary
- Fix failing `allRecommendationsPrompt` test that expected old prompt format (`Do not push or open a PR automatically`) instead of the new guided decision-point format from PR #8630
- Add build/lint reminder to all three ACMM mission prompt builders (`buildPromptForCriterion`, `allRecommendationsPrompt`, `levelCompletionPrompt`) per CLAUDE.md requirement
- Convert hyphen-bullet decision points to numbered lists for consistency with the provider system prompt's interaction style directive

Fixes #8638, Fixes #8636

## Test plan
- [x] `npx vitest run src/lib/acmm/__tests__/missionPrompts.test.ts` — all 7 tests pass
- [x] `npm run build` — clean build with no errors