### PR TITLE
fix: Daily Issues & PRs shows demo data on Netlify instead of zeros

### DIFF
--- a/web/src/components/cards/IssueActivityChart.tsx
+++ b/web/src/components/cards/IssueActivityChart.tsx
@@ -184,6 +184,13 @@ async function fetchAllPages(
       { signal }
     )
     if (!response.ok) break
+    // On Netlify (no Go backend), /api/github/* returns the SPA's index.html
+    // (text/html, status 200). Throw so the caller falls back to demo data
+    // instead of silently showing zeros from an empty JSON parse.
+    const ct = response.headers.get('content-type') || ''
+    if (!ct.includes('application/json')) {
+      throw new Error('GitHub proxy not available — showing demo data')
+    }
     const data = await response.json().catch(() => null)
     if (!data || !Array.isArray(data) || data.length === 0) break
     allItems.push(...data)


### PR DESCRIPTION
## Summary
- On Netlify, `/api/github/*` returns HTML (SPA catch-all) with status 200
- `fetchAllPages` parsed this as empty JSON and returned `[]` — card showed 0/0/0
- Now checks `Content-Type` header and throws if not JSON, triggering demo fallback with realistic data

## Test plan
- [ ] Open console.kubestellar.io → Daily Issues & PRs card shows demo data with non-zero values
- [ ] Open localhost with Go backend → card shows live GitHub data
- [ ] Verify Demo badge appears on Netlify

🤖 Generated with [Claude Code](https://claude.com/claude-code)