### PR TITLE
fix: prevent stale closure from resetting drill-down navigation stack

### DIFF
--- a/web/src/components/ui/AlertBadge.tsx
+++ b/web/src/components/ui/AlertBadge.tsx
@@ -3,7 +3,7 @@ import { useTranslation } from 'react-i18next'
 import { useNavigate } from 'react-router-dom'
 import { Bell, AlertTriangle, CheckCircle, Clock, ChevronRight, X, Server, Search, ExternalLink, CheckSquare, Square, MinusSquare } from 'lucide-react'
 import { useAlerts } from '../../hooks/useAlerts'
-import { useDrillDown } from '../../hooks/useDrillDown'
+import { useDrillDownActions } from '../../hooks/useDrillDown'
 import { useMissions } from '../../hooks/useMissions'
 import { useMobile } from '../../hooks/useMobile'
 import { getSeverityIcon } from '../../types/alerts'
@@ -94,7 +94,7 @@ export function AlertBadge() {
   const { t } = useTranslation()
   const navigate = useNavigate()
   const { activeAlerts, stats, acknowledgeAlert, acknowledgeAlerts, runAIDiagnosis } = useAlerts()
-  const { open: openDrillDown } = useDrillDown()
+  const { drillToCluster } = useDrillDownActions()
   const { missions, setActiveMission, openSidebar } = useMissions()
   const { isMobile } = useMobile()
   const { isOpen, close, toggle } = useModalState()
@@ -179,10 +179,7 @@ export function AlertBadge() {
   const handleAlertClick = (alert: Alert) => {
     close()
     if (alert.cluster) {
-      openDrillDown({
-        type: 'cluster',
-        title: alert.cluster,
-        data: { cluster: alert.cluster, alert } })
+      drillToCluster(alert.cluster, { alert })
     }
   }
 

--- a/web/src/hooks/__tests__/useDrillDown.test.tsx
+++ b/web/src/hooks/__tests__/useDrillDown.test.tsx
@@ -224,6 +224,10 @@ describe('useDrillDownActions', () => {
     expect(typeof result.current.drillToAllClusters).toBe('function')
     expect(typeof result.current.drillToAllPods).toBe('function')
     expect(typeof result.current.drillToAllGPU).toBe('function')
+    // Navigation helpers
+    expect(typeof result.current.goBack).toBe('function')
+    expect(typeof result.current.closeDrillDown).toBe('function')
+    expect(result.current.canGoBack).toBe(false) // nothing open yet
   })
 
   it('does not throw when used outside provider', () => {
@@ -306,6 +310,64 @@ describe('useDrillDownActions', () => {
     })
 
     expect(result.current.drill.state.currentView?.title).toBe('All Clusters')
+  })
+
+  it('goBack pops the stack and canGoBack reflects depth', () => {
+    const { result } = renderHook(
+      () => ({ actions: useDrillDownActions(), drill: useDrillDown() }),
+      { wrapper }
+    )
+
+    // Initially canGoBack is false
+    expect(result.current.actions.canGoBack).toBe(false)
+
+    act(() => {
+      result.current.actions.drillToCluster('cluster-1')
+    })
+
+    // Single view: canGoBack is still false (nothing behind the root)
+    expect(result.current.actions.canGoBack).toBe(false)
+
+    act(() => {
+      result.current.actions.drillToNamespace('cluster-1', 'default')
+    })
+
+    // Two views: canGoBack is true
+    expect(result.current.actions.canGoBack).toBe(true)
+    expect(result.current.drill.state.stack).toHaveLength(2)
+
+    // goBack should pop to the first view
+    act(() => {
+      result.current.actions.goBack()
+    })
+
+    expect(result.current.drill.state.stack).toHaveLength(1)
+    expect(result.current.drill.state.currentView?.type).toBe('cluster')
+    expect(result.current.drill.state.isOpen).toBe(true)
+  })
+
+  it('closeDrillDown closes the modal entirely', () => {
+    const { result } = renderHook(
+      () => ({ actions: useDrillDownActions(), drill: useDrillDown() }),
+      { wrapper }
+    )
+
+    act(() => {
+      result.current.actions.drillToCluster('cluster-1')
+    })
+
+    act(() => {
+      result.current.actions.drillToNamespace('cluster-1', 'default')
+    })
+
+    expect(result.current.drill.state.stack).toHaveLength(2)
+
+    act(() => {
+      result.current.actions.closeDrillDown()
+    })
+
+    expect(result.current.drill.state.isOpen).toBe(false)
+    expect(result.current.drill.state.stack).toHaveLength(0)
   })
 
   it('navigates to existing view instead of duplicating', () => {

--- a/web/src/hooks/useDrillDown.tsx
+++ b/web/src/hooks/useDrillDown.tsx
@@ -86,6 +86,10 @@ interface DrillDownContextType {
   close: () => void
   // Replace current view
   replace: (view: DrillDownView) => void
+  // Open or push: opens if closed, pushes if open, navigates to existing
+  // if the view is already in the stack. Uses functional setState to
+  // guarantee the latest state is read, avoiding stale-closure bugs.
+  openOrPush: (view: DrillDownView) => void
 }
 
 const DrillDownContext = createContext<DrillDownContextType | null>(null)
@@ -154,11 +158,46 @@ export function DrillDownProvider({ children }: { children: ReactNode }) {
     })
   }, [])
 
+  // Open-or-push that reads state via functional setState to guarantee
+  // freshness even when the calling component hasn't re-rendered yet.
+  // This prevents the stale-closure bug where state.isOpen reads as false
+  // when the modal is actually open, which would reset the entire stack.
+  const openOrPushFn = useCallback((view: DrillDownView) => {
+    setState(prev => {
+      if (!prev.isOpen) {
+        emitDrillDownOpened(view.type)
+        return {
+          isOpen: true,
+          stack: [view],
+          currentView: view }
+      }
+
+      // Check if this view already exists in the stack
+      const viewKey = getViewKey(view)
+      const existingIndex = prev.stack.findIndex(v => getViewKey(v) === viewKey)
+
+      if (existingIndex >= 0) {
+        // Navigate to existing view instead of pushing duplicate
+        const newStack = prev.stack.slice(0, existingIndex + 1)
+        return {
+          ...prev,
+          stack: newStack,
+          currentView: newStack[newStack.length - 1] }
+      }
+
+      // Push new view onto the stack
+      return {
+        ...prev,
+        stack: [...prev.stack, view],
+        currentView: view }
+    })
+  }, [])
+
   // #6149 — Memoize the provider value so consumers don't re-render every
   // time DrillDownProvider itself re-renders for an unrelated reason.
   const contextValue = useMemo(
-    () => ({ state, open, push, pop, goTo, close, replace }),
-    [state, open, push, pop, goTo, close, replace]
+    () => ({ state, open, push, pop, goTo, close, replace, openOrPush: openOrPushFn }),
+    [state, open, push, pop, goTo, close, replace, openOrPushFn]
   )
 
   return (
@@ -279,38 +318,37 @@ function getViewKey(view: DrillDownView): string {
 }
 
 // Stable no-op functions used when DrillDownProvider is absent
-const _noopOpen = () => {}
-const _noopPush = () => {}
-const _noopGoTo = () => {}
+const _noop = () => {}
 const _noopState: DrillDownState = { isOpen: false, stack: [], currentView: null }
 
 // Helper hook to create drill-down actions
 export function useDrillDownActions() {
   const context = useContext(DrillDownContext)
   const state = context?.state ?? _noopState
-  const open = context?.open ?? _noopOpen
-  const push = context?.push ?? _noopPush
-  const goTo = context?.goTo ?? _noopGoTo
+  const pop = context?.pop ?? _noop
+  const close = context?.close ?? _noop
 
-  // Helper to navigate - checks if view already exists in stack
-  const openOrPush = (view: DrillDownView) => {
-    if (!context) return
-    if (!state.isOpen) {
-      open(view)
-      return
-    }
+  // Use the provider-level openOrPush which reads state via functional
+  // setState — immune to stale closures since it always sees the latest
+  // state, even when the calling component hasn't re-rendered yet.
+  const providerOpenOrPush = context?.openOrPush ?? _noop
 
-    // Check if this view already exists in the stack
-    const viewKey = getViewKey(view)
-    const existingIndex = state.stack.findIndex(v => getViewKey(v) === viewKey)
+  /** Whether the drill-down stack has a previous view to navigate back to */
+  const canGoBack = state.stack.length > 1
 
-    if (existingIndex >= 0) {
-      // Navigate to existing view instead of pushing duplicate
-      goTo(existingIndex)
-    } else {
-      push(view)
-    }
-  }
+  /** Navigate back one level in the drill-down stack. If at the root view,
+   *  closes the drill-down entirely. */
+  const goBack = useCallback(() => {
+    pop()
+  }, [pop])
+
+  /** Close the drill-down modal entirely, clearing the full stack. */
+  const closeDrillDown = useCallback(() => {
+    close()
+  }, [close])
+
+  // Delegate to provider-level openOrPush (stale-closure-safe)
+  const openOrPush = providerOpenOrPush
 
   const drillToCluster = (cluster: string, clusterData?: Record<string, unknown>) => {
     openOrPush({
@@ -751,5 +789,9 @@ export function useDrillDownActions() {
     drillToAllSecurity,
     drillToAllGPU,
     drillToAllStorage,
-    drillToAllJobs }
+    drillToAllJobs,
+    // Navigation helpers
+    goBack,
+    canGoBack,
+    closeDrillDown }
 }


### PR DESCRIPTION
## Summary
- Moves `openOrPush` logic from `useDrillDownActions` into `DrillDownProvider` where it uses functional `setState` to always read the latest state, preventing stale closures from resetting the navigation stack
- Adds `goBack`, `canGoBack`, and `closeDrillDown` helpers to `useDrillDownActions` so drill-down views can offer explicit back navigation
- Fixes `AlertBadge` to use `drillToCluster` (goes through `openOrPush`) instead of calling `open()` directly, which would reset the stack if the modal was already open
- Adds tests for `goBack` and `closeDrillDown` navigation helpers

## Root cause
`useDrillDownActions` captured `state` at render time in a closure. When a component triggered `drillTo*()` before React re-rendered it with the updated context, `openOrPush` saw stale `state.isOpen = false` and called `open()` — which resets the entire stack to a single view — instead of `push()`. The new provider-level `openOrPush` uses `setState(prev => ...)` to guarantee it always reads the current state.

## Test plan
- [x] `npm run build` passes
- [x] All 26 drill-down tests pass (21 useDrillDown + 5 DrillDownModal)
- [x] 2 new tests for `goBack`/`closeDrillDown` pass
- [x] AlertBadge tests pass
- [ ] Manual: Open drill-down via card click, navigate deeper (Cluster → Namespace → Deployment), verify back button pops stack instead of closing
- [ ] Manual: Open drill-down from AlertBadge while another drill-down is already open, verify stack is preserved

Fixes #8641