### PR TITLE
fix: move Create Cluster with AI button next to Add Cluster

### DIFF
--- a/web/src/components/clusters/Clusters.tsx
+++ b/web/src/components/clusters/Clusters.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect } from 'react'
 import { useSearchParams, useLocation, useNavigate } from 'react-router-dom'
-import { AlertTriangle, ChevronRight, ChevronDown, Server, Scissors, Sparkles } from 'lucide-react'
+import { AlertTriangle, ChevronRight, ChevronDown, Server, Scissors } from 'lucide-react'
 import { useClusters, useGPUNodes, useNVIDIAOperators, refreshSingleCluster } from '../../hooks/useMCP'
 import { agentFetch } from '../../hooks/mcp/shared'
 import { ClusterDetailModal } from './ClusterDetailModal'
@@ -343,30 +343,6 @@ export function Clusters() {
         </div>
       )}
 
-      {/* Create Cluster with AI Mission button (#6454) */}
-      <div className="mb-4 flex items-center gap-3">
-        <button
-          onClick={() => {
-            createCheckKeyAndRun(async () => {
-              const prompt = await loadMissionPrompt(
-                'create-cluster',
-                'Help me create a new Kubernetes cluster. Ask me about the provider (kind, k3d, EKS, GKE, AKS, OpenShift), cluster name, node count, and Kubernetes version. Then generate and execute the appropriate commands to create the cluster and add it to my kubeconfig.',
-              )
-              startMission({
-                title: 'Create Cluster with AI',
-                description: 'AI-guided cluster creation across any provider',
-                type: 'deploy',
-                initialPrompt: prompt })
-              openSidebar()
-            })
-          }}
-          className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg bg-purple-500/20 text-purple-300 text-xs font-medium hover:bg-purple-500/30 transition-colors whitespace-nowrap border border-purple-500/30"
-        >
-          <Sparkles className="w-3.5 h-3.5" />
-          Create Cluster with AI
-        </button>
-      </div>
-
       {/* Cluster Info Cards - collapsible */}
       <div className="mb-6">
         <button
@@ -409,6 +385,20 @@ export function Clusters() {
                   safeSetItem(STORAGE_KEY_CLUSTER_LAYOUT, mode)
                 }}
                 onAddCluster={() => setShowAddCluster(true)}
+                onCreateClusterWithAI={() => {
+                  createCheckKeyAndRun(async () => {
+                    const prompt = await loadMissionPrompt(
+                      'create-cluster',
+                      'Help me create a new Kubernetes cluster. Ask me about the provider (kind, k3d, EKS, GKE, AKS, OpenShift), cluster name, node count, and Kubernetes version. Then generate and execute the appropriate commands to create the cluster and add it to my kubeconfig.',
+                    )
+                    startMission({
+                      title: t('cluster.createClusterWithAI'),
+                      description: 'AI-guided cluster creation across any provider',
+                      type: 'deploy',
+                      initialPrompt: prompt })
+                    openSidebar()
+                  })
+                }}
               />
               {filteredClusters.length === 0 && !isLoading && !showSkeletonContent ? (
                 <EmptyClusterState onAddCluster={() => setShowAddCluster(true)} />

--- a/web/src/components/clusters/components/FilterTabs.test.tsx
+++ b/web/src/components/clusters/components/FilterTabs.test.tsx
@@ -80,7 +80,7 @@ describe('FilterTabs', () => {
     const onAddCluster = vi.fn()
     renderFilterTabs({ onAddCluster })
 
-    const addBtn = screen.getByText('Add Cluster')
+    const addBtn = screen.getByText('cluster.addCluster')
     expect(addBtn).toBeTruthy()
     fireEvent.click(addBtn)
     expect(onAddCluster).toHaveBeenCalled()
@@ -88,6 +88,35 @@ describe('FilterTabs', () => {
 
   it('does not show Add Cluster button when onAddCluster is not provided', () => {
     renderFilterTabs()
-    expect(screen.queryByText('Add Cluster')).toBeNull()
+    expect(screen.queryByText('cluster.addCluster')).toBeNull()
+  })
+
+  it('shows Create Cluster with AI button when onCreateClusterWithAI is provided', () => {
+    const onCreateClusterWithAI = vi.fn()
+    renderFilterTabs({ onCreateClusterWithAI })
+
+    const createBtn = screen.getByText('cluster.createClusterWithAI')
+    expect(createBtn).toBeTruthy()
+    fireEvent.click(createBtn)
+    expect(onCreateClusterWithAI).toHaveBeenCalled()
+  })
+
+  it('does not show Create Cluster with AI button when onCreateClusterWithAI is not provided', () => {
+    renderFilterTabs()
+    expect(screen.queryByText('cluster.createClusterWithAI')).toBeNull()
+  })
+
+  it('renders both buttons adjacent when both handlers are provided', () => {
+    const onAddCluster = vi.fn()
+    const onCreateClusterWithAI = vi.fn()
+    renderFilterTabs({ onAddCluster, onCreateClusterWithAI })
+
+    const addBtn = screen.getByText('cluster.addCluster')
+    const createBtn = screen.getByText('cluster.createClusterWithAI')
+    expect(addBtn).toBeTruthy()
+    expect(createBtn).toBeTruthy()
+
+    // Both buttons should share a common parent container
+    expect(addBtn.closest('div')).toBe(createBtn.closest('div'))
   })
 })

--- a/web/src/components/clusters/components/FilterTabs.tsx
+++ b/web/src/components/clusters/components/FilterTabs.tsx
@@ -1,4 +1,4 @@
-import { WifiOff, SortAsc, SortDesc, LayoutGrid, List, Grid3X3, Columns, Plus } from 'lucide-react'
+import { WifiOff, SortAsc, SortDesc, LayoutGrid, List, Grid3X3, Columns, Plus, Sparkles } from 'lucide-react'
 import { ClusterStats } from './StatsOverview'
 import { ClusterLayoutMode } from './ClusterGrid'
 import { useTranslation } from 'react-i18next'
@@ -17,6 +17,7 @@ interface FilterTabsProps {
   layoutMode?: ClusterLayoutMode
   onLayoutModeChange?: (mode: ClusterLayoutMode) => void
   onAddCluster?: () => void
+  onCreateClusterWithAI?: () => void
 }
 
 const LAYOUT_OPTIONS: { mode: ClusterLayoutMode; icon: typeof LayoutGrid; label: string }[] = [
@@ -37,6 +38,7 @@ export function FilterTabs({
   layoutMode = 'grid',
   onLayoutModeChange,
   onAddCluster,
+  onCreateClusterWithAI,
 }: FilterTabsProps) {
   const { t } = useTranslation()
   return (
@@ -84,17 +86,30 @@ export function FilterTabs({
         Offline ({stats.unreachable})
       </button>
 
-      {/* Add Cluster, Layout, and Sort */}
+      {/* Add Cluster, Create with AI, Layout, and Sort */}
       <div className="ml-auto flex items-center gap-3">
-        {/* Add Cluster */}
-        {onAddCluster && (
-          <button
-            onClick={onAddCluster}
-            className="flex items-center gap-1.5 px-3 py-1.5 text-sm font-medium rounded-lg bg-purple-600 hover:bg-purple-500 text-white transition-colors"
-          >
-            <Plus className="w-4 h-4" />
-            Add Cluster
-          </button>
+        {/* Add Cluster + Create Cluster with AI */}
+        {(onAddCluster || onCreateClusterWithAI) && (
+          <div className="flex items-center gap-2">
+            {onAddCluster && (
+              <button
+                onClick={onAddCluster}
+                className="flex items-center gap-1.5 px-3 py-1.5 text-sm font-medium rounded-lg bg-purple-600 hover:bg-purple-500 text-white transition-colors"
+              >
+                <Plus className="w-4 h-4" />
+                {t('cluster.addCluster')}
+              </button>
+            )}
+            {onCreateClusterWithAI && (
+              <button
+                onClick={onCreateClusterWithAI}
+                className="flex items-center gap-1.5 px-3 py-1.5 text-sm font-medium rounded-lg bg-purple-600/80 hover:bg-purple-500 text-white transition-colors border border-purple-500/30"
+              >
+                <Sparkles className="w-4 h-4" />
+                {t('cluster.createClusterWithAI')}
+              </button>
+            )}
+          </div>
         )}
         {/* Layout mode selector */}
         {onLayoutModeChange && (

--- a/web/src/locales/en/common.json
+++ b/web/src/locales/en/common.json
@@ -2909,6 +2909,7 @@
     "clickToViewWorkloads": "Click to view workloads by namespace",
     "deleteGroup": "Delete group",
     "addCluster": "Add Cluster",
+    "createClusterWithAI": "Create Cluster with AI",
     "addClusterTitle": "Add a Cluster",
     "addClusterCommandLine": "Command Line",
     "addClusterImport": "Import Kubeconfig",


### PR DESCRIPTION
## Summary
- Moves the "Create Cluster with AI" button from a standalone section above cluster info cards into the FilterTabs toolbar, directly adjacent to the "Add Cluster" button
- Both buttons now share consistent purple styling (same size, font, border-radius)
- Adds `onCreateClusterWithAI` prop to `FilterTabs` component
- Adds i18n key `cluster.createClusterWithAI` for the button label
- Updates FilterTabs tests to cover the new prop and adjacency

Fixes #8642

## Test plan
- [ ] Verify both buttons appear side-by-side in the cluster filter toolbar
- [ ] Verify "Add Cluster" opens the add cluster dialog
- [ ] Verify "Create Cluster with AI" triggers the AI mission flow
- [ ] Verify buttons have consistent styling (size, color, spacing)
- [ ] Verify buttons do not render when handlers are not provided
- [ ] Run `npm run build` — passes
- [ ] Run FilterTabs unit tests — all 9 pass