### PR TITLE
fix: cmd/ctrl+enter submit, sidebar pin toggle, negative bar height

### DIFF
--- a/web/src/components/feedback/FeedbackModal.tsx
+++ b/web/src/components/feedback/FeedbackModal.tsx
@@ -249,7 +249,11 @@ export function FeedbackModal({ isOpen, onClose, initialType = 'feature' }: Feed
     forceClose()
   }, [forceClose])
 
-  // Keyboard navigation - ESC to close, Space to close when not typing
+  // Submit form programmatically via ref (used by Cmd/Ctrl+Enter shortcut)
+  const formRef = useRef<HTMLFormElement>(null)
+
+  // Keyboard navigation - ESC to close, Space to close when not typing,
+  // Cmd/Ctrl+Enter to submit (#8651)
   useEffect(() => {
     if (!isOpen) return
 
@@ -258,6 +262,13 @@ export function FeedbackModal({ isOpen, onClose, initialType = 'feature' }: Feed
       if (e.key === 'Escape') {
         e.preventDefault()
         handleClose()
+        return
+      }
+
+      // Cmd+Enter (Mac) or Ctrl+Enter (Win/Linux) submits the form
+      if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) {
+        e.preventDefault()
+        formRef.current?.requestSubmit()
         return
       }
 
@@ -418,7 +429,7 @@ export function FeedbackModal({ isOpen, onClose, initialType = 'feature' }: Feed
                 </button>
               </div>
 
-              <form onSubmit={handleSubmit}>
+              <form ref={formRef} onSubmit={handleSubmit}>
                 <div className="space-y-4">
                   <div>
                     <label className="block text-sm font-medium text-foreground mb-1.5">
@@ -554,6 +565,9 @@ export function FeedbackModal({ isOpen, onClose, initialType = 'feature' }: Feed
         <div className="flex items-center justify-end gap-3 px-4 py-2 border-t border-border/50 text-2xs text-muted-foreground/50">
           <span><kbd className="px-1 py-0.5 rounded bg-secondary/50 text-[9px]">Esc</kbd> close</span>
           <span><kbd className="px-1 py-0.5 rounded bg-secondary/50 text-[9px]">Space</kbd> close</span>
+          {!success && (
+            <span><kbd className="px-1 py-0.5 rounded bg-secondary/50 text-[9px]">{navigator.platform?.includes('Mac') ? '⌘' : 'Ctrl'}+↵</kbd> submit</span>
+          )}
         </div>
       </div>
     </div>,

--- a/web/src/components/layout/Sidebar.tsx
+++ b/web/src/components/layout/Sidebar.tsx
@@ -111,8 +111,13 @@ export function Sidebar() {
     setIsPinned(prev => {
       const next = !prev
       try { localStorage.setItem('sidebar-left-pinned', String(next)) } catch { /* ignore */ }
-      if (next) clearAutoHideTimer()
-      else if (!config.collapsed) {
+      if (next) {
+        clearAutoHideTimer()
+        // Pinning while collapsed should expand the sidebar (#8647)
+        if (config.collapsed) {
+          setCollapsed(false)
+        }
+      } else if (!config.collapsed) {
         // Start auto-hide when unpinning
         autoHideTimerRef.current = setTimeout(() => setCollapsed(true), SIDEBAR_AUTO_HIDE_MS)
       }

--- a/web/src/components/widgets/WidgetExportModal.tsx
+++ b/web/src/components/widgets/WidgetExportModal.tsx
@@ -523,6 +523,11 @@ const PREV_FS_BODY = '12px'     // body text, count badges
 const PREV_FS_CAPTION = '10px'  // caption text, row items
 const PREV_FS_MICRO = '9px'     // micro text, timestamps, secondary labels
 
+// Issue activity chart bar-height multipliers — keeps preview bars proportional
+const PREV_BAR_OPENED_SCALE = 6   // px per unit for the "opened" bar segment
+const PREV_BAR_CLOSED_SCALE = 4   // px per unit for the "closed" bar segment
+const PREV_BAR_CLOSED_BASE = 8    // baseline value subtracted before scaling closed segment
+
 // Preview color constants — declared before `ps` so they can be used in its definition
 const PREV_CLR_TEXT = '#f9fafb'      // primary text color in widget previews
 const PREV_CLR_MUTED = '#9ca3af'     // muted/secondary text color
@@ -1021,8 +1026,8 @@ function CardPreview({ cardType }: { cardType: string }) {
           <div style={{ display: 'flex', alignItems: 'flex-end', gap: '3px', height: '60px', marginBottom: PREV_SM }}>
             {[4, 7, 3, 8, 5, 6, 9, 2, 5, 7, 4, 6, 3].map((v, i) => (
               <div key={i} style={{ flex: 1, display: 'flex', flexDirection: 'column', gap: '1px', justifyContent: 'flex-end', height: '100%' }}>
-                <div style={{ height: `${v * 6}px`, backgroundColor: ps.colors.info, borderRadius: '1px', opacity: 0.7 }} />
-                <div style={{ height: `${(8 - v) * 4}px`, backgroundColor: ps.colors.healthy, borderRadius: '1px', opacity: 0.5 }} />
+                <div style={{ height: `${v * PREV_BAR_OPENED_SCALE}px`, backgroundColor: ps.colors.info, borderRadius: '1px', opacity: 0.7 }} />
+                <div style={{ height: `${Math.max(0, (PREV_BAR_CLOSED_BASE - v) * PREV_BAR_CLOSED_SCALE)}px`, backgroundColor: ps.colors.healthy, borderRadius: '1px', opacity: 0.5 }} />
               </div>
             ))}
           </div>


### PR DESCRIPTION
## Summary
- **#8651**: Add Cmd+Enter (Mac) / Ctrl+Enter (Win/Linux) keyboard shortcut to submit the feedback modal, with a visible hint in the footer
- **#8647**: Fix sidebar pin button so pinning while collapsed also expands the sidebar, making pin toggle functional in all states
- **#8646**: Clamp `issue_activity_chart` preview bar height to `Math.max(0, ...)` so sample values exceeding the baseline (e.g. `v=9` vs base `8`) no longer produce negative CSS heights; extract magic numbers into named constants

## Test plan
- [ ] Open feedback modal, type title+description, press Cmd+Enter (Mac) or Ctrl+Enter — form submits
- [ ] Keyboard hint shows platform-appropriate shortcut (⌘+↵ on Mac, Ctrl+↵ elsewhere)
- [ ] Collapse sidebar, click pin button — sidebar expands and stays pinned
- [ ] Unpin while expanded — sidebar auto-hides after timeout
- [ ] Open widget export modal, select `issue_activity_chart` preview — no negative-height bars visible

Fixes #8651, Fixes #8647, Fixes #8646

🤖 Generated with [Claude Code](https://claude.com/claude-code)