### PR TITLE
fix: make nodes clickable and visible in drill-down views

### DIFF
--- a/web/src/components/drilldown/views/ClusterDrillDown.tsx
+++ b/web/src/components/drilldown/views/ClusterDrillDown.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useState, useRef, useCallback } from 'react'
 import { ChevronRight, ChevronDown, Server, Box, Layers, Database, Network, HardDrive, Search, AlertTriangle, XCircle } from 'lucide-react'
 import { StatusBadge } from '../../ui/StatusBadge'
 import { useClusterHealth, usePodIssues, useDeploymentIssues, useGPUNodes, useNodes, useNamespaces, useDeployments, useServices, useEvents } from '../../../hooks/useMCP'
@@ -21,13 +21,33 @@ interface Props {
 export function ClusterDrillDown({ data }: Props) {
   const { t } = useTranslation()
   const clusterName = (data.cluster as string) || ''
-  const { drillToNamespace, drillToPod, drillToGPUNode, drillToEvents } = useDrillDownActions()
+  const { drillToNamespace, drillToPod, drillToGPUNode, drillToEvents, drillToNode } = useDrillDownActions()
 
   // Tree view state
   const [expandedSections, setExpandedSections] = useState<Set<string>>(new Set(['cluster', 'nodes', 'namespaces']))
   const [searchFilter, setSearchFilter] = useState('')
   const [activeLens, setActiveLens] = useState<TreeLens>('all')
   const [activeTab, setActiveTab] = useState<ClusterTab>('events')
+  const nodesSectionRef = useRef<HTMLDivElement>(null)
+
+  /** Scroll delay to let the DOM update after switching tabs */
+  const SCROLL_AFTER_TAB_SWITCH_MS = 100
+
+  /** Navigate to the nodes section in the resource tree */
+  const scrollToNodesSection = useCallback(() => {
+    setActiveTab('resources')
+    setActiveLens('nodes')
+    setExpandedSections(prev => {
+      const next = new Set(prev)
+      next.add('cluster')
+      next.add('nodes')
+      return next
+    })
+    // Allow DOM to update before scrolling
+    setTimeout(() => {
+      nodesSectionRef.current?.scrollIntoView({ behavior: 'smooth', block: 'nearest' })
+    }, SCROLL_AFTER_TAB_SWITCH_MS)
+  }, [])
 
   // Safeguard timeout to prevent infinite loading - show content after 5 seconds max
   const [loadingTimedOut, setLoadingTimedOut] = useState(false)
@@ -248,11 +268,14 @@ export function ClusterDrillDown({ data }: Props) {
           </div>
         </div>
 
-        <div className="p-4 rounded-lg bg-card/50 border border-border">
+        <button
+          onClick={scrollToNodesSection}
+          className="p-4 rounded-lg bg-card/50 border border-border text-left hover:bg-card hover:border-primary/50 transition-colors cursor-pointer w-full"
+        >
           <div className="text-sm text-muted-foreground mb-2">{t('common.nodes')}</div>
           <div className="text-2xl font-bold text-foreground">{health?.nodeCount || 0}</div>
           <div className="text-xs text-green-400">{health?.readyNodes || 0} ready</div>
-        </div>
+        </button>
 
         <div className="p-4 rounded-lg bg-card/50 border border-border">
           <div className="text-sm text-muted-foreground mb-2">{t('common.pods')}</div>
@@ -598,14 +621,15 @@ export function ClusterDrillDown({ data }: Props) {
                         </div>
 
                         {expandedSections.has('nodes') && (
-                          <div className="ml-6 border-l-2 border-blue-500/30 pl-4 mt-1 space-y-1">
+                          <div ref={nodesSectionRef} className="ml-6 border-l-2 border-blue-500/30 pl-4 mt-1 space-y-1">
                             {filteredNodes.slice(0, 20).map((node, i) => (
                               <div
                                 key={i}
+                                onClick={() => drillToNode(clusterName, node.name, { status: node.status, roles: node.roles, unschedulable: node.unschedulable })}
                                 className="flex items-center gap-2 p-2 rounded-lg hover:bg-secondary/50 cursor-pointer group"
                               >
                                 <div className={`w-2 h-2 rounded-full ${node.status === 'Ready' ? 'bg-green-400' : 'bg-red-400'}`} />
-                                <span className="text-sm text-foreground">{node.name}</span>
+                                <span className="text-sm text-foreground group-hover:text-primary transition-colors">{node.name}</span>
                                 <span className={`text-xs ${node.status === 'Ready' ? 'text-green-400' : 'text-red-400'}`}>
                                   {node.status}
                                 </span>

--- a/web/src/components/drilldown/views/MultiClusterSummaryDrillDown.tsx
+++ b/web/src/components/drilldown/views/MultiClusterSummaryDrillDown.tsx
@@ -163,6 +163,7 @@ export function MultiClusterSummaryDrillDown({ data, viewType }: MultiClusterSum
     lastRefresh: nodesLastRefresh,
     isLoading: nodesIsLoading,
     isFailed: nodesIsFailed,
+    isDemoFallback: nodesIsDemoFallback,
   } = useCachedNodes()
   const { pvcs: cachedPVCs } = useCachedPVCs()
   // Guard against undefined to prevent crashes when APIs return 404/500/empty
@@ -441,11 +442,18 @@ export function MultiClusterSummaryDrillDown({ data, viewType }: MultiClusterSum
   return (
     <div className="space-y-6">
       {/* Freshness indicator for cached data */}
-      {nodesDataAge && (
-        <div className="flex justify-end">
-          <span className="text-2xs text-muted-foreground" title={new Date(nodesLastRefresh!).toLocaleString()}>
-            Updated {formatRelativeTime(nodesDataAge)}
-          </span>
+      {viewType === 'all-nodes' && (nodesDataAge || nodesIsDemoFallback) && (
+        <div className="flex items-center justify-end gap-2">
+          {nodesIsDemoFallback && (
+            <span className="text-2xs px-1.5 py-0.5 rounded bg-yellow-500/20 text-yellow-400 border border-yellow-500/30">
+              Demo
+            </span>
+          )}
+          {nodesDataAge && (
+            <span className="text-2xs text-muted-foreground" title={new Date(nodesLastRefresh!).toLocaleString()}>
+              Updated {formatRelativeTime(nodesDataAge)}
+            </span>
+          )}
         </div>
       )}
 

--- a/web/src/hooks/useCachedData.ts
+++ b/web/src/hooks/useCachedData.ts
@@ -1329,6 +1329,7 @@ export function useCachedNodes(
     category: 'pods' as RefreshCategory,
     initialData: [] as NodeInfo[],
     demoData: getDemoCachedNodes(),
+    demoWhenEmpty: !cluster,
     persist: true,
     fetcher: async () => {
       if (cluster) {


### PR DESCRIPTION
## Summary
- **ClusterDrillDown**: Node names in the resource tree are now clickable and navigate to the NodeDrillDown detail view (#8644)
- **ClusterDrillDown**: The Nodes stat block at the top of the cluster drill-down is now clickable — it switches to the Resources tab with the Nodes lens active and scrolls to the nodes section, so users don't miss the expanded content (#8645)
- **MultiClusterSummaryDrillDown**: The all-nodes drill-down now falls back to demo data when live node data is unavailable (via `demoWhenEmpty`), so the view is never empty (#8650)
- Shows a "Demo" badge in the all-nodes drill-down when using demo fallback data

Fixes #8644, Fixes #8645, Fixes #8650

## Test plan
- [ ] Open cluster drill-down, go to Resources tab, expand Nodes — click a node name and verify it opens the NodeDrillDown detail view
- [ ] In cluster drill-down, click the Nodes stat block at the top — verify it switches to Resources tab with Nodes lens and scrolls to the nodes section
- [ ] Open the all-nodes drill-down (click nodes count on the Nodes dashboard) — verify nodes are displayed (demo data if no live clusters)
- [ ] Verify Demo badge appears when showing demo fallback data in the all-nodes view

🤖 Generated with [Claude Code](https://claude.com/claude-code)