### PR TITLE
fix: address Copilot review comments from nodes drill-down PR

### DIFF
--- a/web/src/components/cards/cluster-resource-tree/__tests__/ClusterResourceTree.test.tsx
+++ b/web/src/components/cards/cluster-resource-tree/__tests__/ClusterResourceTree.test.tsx
@@ -38,7 +38,7 @@ vi.mock('../../../../hooks/useMCP', () => ({
 
 vi.mock('../../../../hooks/useCachedData', () => ({
   useCachedPodIssues: () => ({ issues: [] }),
-  useCachedNodes: () => ({ nodes: [], isLoading: false, isDemoFallback: null }),
+  useCachedNodes: () => ({ nodes: [], isLoading: false, isDemoFallback: false, isFailed: false, isRefreshing: false, consecutiveFailures: 0, lastRefresh: null, refetch: vi.fn() }),
   useCachedNamespaces: () => ({ namespaces: [], isLoading: false, isDemoFallback: null }),
   useCachedDeployments: () => ({ deployments: [], isDemoFallback: null }),
   useCachedServices: () => ({ services: [], isDemoFallback: null }),

--- a/web/src/components/drilldown/views/ClusterDrillDown.tsx
+++ b/web/src/components/drilldown/views/ClusterDrillDown.tsx
@@ -14,6 +14,9 @@ import { LOADING_TIMEOUT_MS } from '../../../lib/constants/network'
 type TreeLens = 'all' | 'issues' | 'nodes' | 'workloads' | 'storage' | 'network'
 type ClusterTab = 'events' | 'resources'
 
+/** Scroll delay (ms) to let the DOM update after switching tabs */
+const SCROLL_AFTER_TAB_SWITCH_MS = 100
+
 interface Props {
   data: Record<string, unknown>
 }
@@ -29,9 +32,6 @@ export function ClusterDrillDown({ data }: Props) {
   const [activeLens, setActiveLens] = useState<TreeLens>('all')
   const [activeTab, setActiveTab] = useState<ClusterTab>('events')
   const nodesSectionRef = useRef<HTMLDivElement>(null)
-
-  /** Scroll delay to let the DOM update after switching tabs */
-  const SCROLL_AFTER_TAB_SWITCH_MS = 100
 
   /** Navigate to the nodes section in the resource tree */
   const scrollToNodesSection = useCallback(() => {
@@ -622,11 +622,12 @@ export function ClusterDrillDown({ data }: Props) {
 
                         {expandedSections.has('nodes') && (
                           <div ref={nodesSectionRef} className="ml-6 border-l-2 border-blue-500/30 pl-4 mt-1 space-y-1">
-                            {filteredNodes.slice(0, 20).map((node, i) => (
-                              <div
-                                key={i}
+                            {filteredNodes.slice(0, 20).map((node) => (
+                              <button
+                                key={node.name}
                                 onClick={() => drillToNode(clusterName, node.name, { status: node.status, roles: node.roles, unschedulable: node.unschedulable })}
-                                className="flex items-center gap-2 p-2 rounded-lg hover:bg-secondary/50 cursor-pointer group"
+                                type="button"
+                                className="flex items-center gap-2 p-2 rounded-lg hover:bg-secondary/50 cursor-pointer group w-full text-left bg-transparent border-none"
                               >
                                 <div className={`w-2 h-2 rounded-full ${node.status === 'Ready' ? 'bg-green-400' : 'bg-red-400'}`} />
                                 <span className="text-sm text-foreground group-hover:text-primary transition-colors">{node.name}</span>
@@ -639,7 +640,7 @@ export function ClusterDrillDown({ data }: Props) {
                                   </span>
                                 )}
                                 <ChevronRight className="w-3 h-3 text-muted-foreground opacity-0 group-hover:opacity-100 ml-auto" />
-                              </div>
+                              </button>
                             ))}
                             {filteredNodes.length > 20 && (
                               <div className="text-xs text-muted-foreground p-2">

--- a/web/src/components/drilldown/views/MultiClusterSummaryDrillDown.tsx
+++ b/web/src/components/drilldown/views/MultiClusterSummaryDrillDown.tsx
@@ -444,7 +444,7 @@ export function MultiClusterSummaryDrillDown({ data, viewType }: MultiClusterSum
       {/* Freshness indicator for cached data */}
       {viewType === 'all-nodes' && (nodesDataAge || nodesIsDemoFallback) && (
         <div className="flex items-center justify-end gap-2">
-          {nodesIsDemoFallback && (
+          {nodesIsDemoFallback && !nodesIsLoading && (
             <span className="text-2xs px-1.5 py-0.5 rounded bg-yellow-500/20 text-yellow-400 border border-yellow-500/30">
               Demo
             </span>

--- a/web/src/components/drilldown/views/__tests__/MultiClusterSummaryDrillDown.test.tsx
+++ b/web/src/components/drilldown/views/__tests__/MultiClusterSummaryDrillDown.test.tsx
@@ -41,8 +41,8 @@ vi.mock('../../../../hooks/useDrillDown', () => ({
 }))
 
 vi.mock('../../../../hooks/useCachedData', () => ({
-  useCachedNodes: () => ({ nodes: [], lastRefresh: Date.now() }),
-  useCachedPVCs: () => ({ pvcs: [], lastRefresh: Date.now() }),
+  useCachedNodes: () => ({ nodes: [], lastRefresh: Date.now(), isLoading: false, isFailed: false, isDemoFallback: false, isRefreshing: false, consecutiveFailures: 0, refetch: vi.fn() }),
+  useCachedPVCs: () => ({ pvcs: [], lastRefresh: Date.now(), isLoading: false, isFailed: false, isDemoFallback: false, isRefreshing: false, consecutiveFailures: 0, refetch: vi.fn() }),
 }))
 
 import { MultiClusterSummaryDrillDown } from '../MultiClusterSummaryDrillDown'

--- a/web/src/components/drilldown/views/__tests__/NodeDrillDown.test.tsx
+++ b/web/src/components/drilldown/views/__tests__/NodeDrillDown.test.tsx
@@ -46,7 +46,7 @@ vi.mock('../../../../lib/clipboard', () => ({
 }))
 
 vi.mock('../../../../hooks/useCachedData', () => ({
-  useCachedNodes: () => ({ nodes: [], isLoading: false, isFailed: false, lastRefresh: Date.now() }),
+  useCachedNodes: () => ({ nodes: [], isLoading: false, isFailed: false, isDemoFallback: false, isRefreshing: false, consecutiveFailures: 0, lastRefresh: Date.now(), refetch: vi.fn() }),
 }))
 
 import { NodeDrillDown } from '../NodeDrillDown'

--- a/web/src/hooks/useCachedData.ts
+++ b/web/src/hooks/useCachedData.ts
@@ -1342,12 +1342,17 @@ export function useCachedNodes(
       return fetchViaSSE<NodeInfo>('nodes', 'nodes', {}, onProgress)
     } })
 
+  // Only report demo fallback when NOT loading — prevents Demo badge
+  // from flashing during the optimistic demo phase while a real fetch
+  // is still in-flight (CLAUDE.md: effectiveIsDemoFallback pattern).
+  const effectiveIsDemoFallback = result.isDemoFallback && !result.isLoading
+
   return {
     nodes: result.data,
     data: result.data,
     isLoading: result.isLoading,
     isRefreshing: result.isRefreshing,
-    isDemoFallback: result.isDemoFallback,
+    isDemoFallback: effectiveIsDemoFallback,
     error: result.error,
     isFailed: result.isFailed,
     consecutiveFailures: result.consecutiveFailures,


### PR DESCRIPTION
## Summary
- Guard Demo badge with `!nodesIsLoading` to prevent flashing during optimistic demo phase
- Move `SCROLL_AFTER_TAB_SWITCH_MS` to module scope so it is not a `useCallback` dependency concern
- Use `node.name` as React key instead of array index for stable identity
- Replace clickable `<div>` with semantic `<button>` for keyboard accessibility
- Apply `effectiveIsDemoFallback` pattern in `useCachedNodes` hook per CLAUDE.md contract
- Complete test mock shapes for `useCachedNodes` with all `CachedHookResult` fields

Fixes #8655

## Test plan
- [ ] Build passes (`npm run build`)
- [ ] Lint passes (`npm run lint`)
- [ ] Existing tests pass with updated mocks
- [ ] Demo badge no longer flashes during loading in all-nodes drill-down
- [ ] Node rows in cluster drill-down are keyboard-focusable

🤖 Generated with [Claude Code](https://claude.com/claude-code)