### PR TITLE
fix: Export Widgets panel scrolls within modal instead of overflowing

### DIFF
--- a/web/src/components/widgets/WidgetExportModal.tsx
+++ b/web/src/components/widgets/WidgetExportModal.tsx
@@ -146,7 +146,7 @@ export function WidgetExportModal({ isOpen, onClose, cardType, mode: _mode = 'pi
   }
 
   const widgetContent = (
-      <div className="flex flex-col">
+      <div className="flex flex-col h-full min-h-0 overflow-hidden">
         {/* Tabs */}
         <div className="flex border-b border-border mb-4">
           <button


### PR DESCRIPTION
## Summary
- Adds `h-full min-h-0 overflow-hidden` to the widget export content container
- Card list now scrolls within the Console Studio modal instead of overflowing

## Test plan
- [ ] Open Console Studio → Export Widgets → card list scrolls within the panel
- [ ] Preview panel stays visible while scrolling the card list

🤖 Generated with [Claude Code](https://claude.com/claude-code)