### PR TITLE
fix: show connection-lost diagnostic text and improve copy feedback

### DIFF
--- a/web/src/components/layout/Layout.tsx
+++ b/web/src/components/layout/Layout.tsx
@@ -560,35 +560,42 @@ export function Layout({ children: _children }: LayoutProps) {
               : "bg-green-900/80 border-green-700/50 text-green-200"
           )}>
             {backendDown ? (
-              <>
-                <div className="w-2 h-2 rounded-full bg-red-400 animate-pulse" />
-                <span>{t('layout.connectionLost')}</span>
-                {restartState === 'restarting' ? (
-                  <button disabled className="ml-1 flex items-center gap-1.5 px-2.5 py-1 bg-muted text-muted-foreground rounded text-xs cursor-wait">
-                    <Loader2 className="w-3 h-3 animate-spin" />
-                    {t('layout.restarting')}
-                  </button>
-                ) : restartState === 'waiting' ? (
-                  <span className="ml-1 flex items-center gap-1.5 px-2.5 py-1 bg-muted text-muted-foreground rounded text-xs">
-                    <Loader2 className="w-3 h-3 animate-spin" />
-                    {t('layout.restartedWaiting')}
-                  </span>
-                ) : restartState === 'copied' ? (
-                  <span className="ml-1 flex items-center gap-1.5 px-2.5 py-1 bg-green-800/50 text-green-300 rounded text-xs">
-                    <Check className="w-3 h-3" />
-                    {t('actions.copied')}
-                  </span>
+              <div className="flex flex-col items-center gap-1">
+                <div className="flex items-center gap-2">
+                  <div className="w-2 h-2 rounded-full bg-red-400 animate-pulse" />
+                  <span>{t('layout.connectionLost')}</span>
+                  {restartState === 'restarting' ? (
+                    <button disabled className="ml-1 flex items-center gap-1.5 px-2.5 py-1 bg-muted text-muted-foreground rounded text-xs cursor-wait">
+                      <Loader2 className="w-3 h-3 animate-spin" />
+                      {t('layout.restarting')}
+                    </button>
+                  ) : restartState === 'waiting' ? (
+                    <span className="ml-1 flex items-center gap-1.5 px-2.5 py-1 bg-muted text-muted-foreground rounded text-xs">
+                      <Loader2 className="w-3 h-3 animate-spin" />
+                      {t('layout.restartedWaiting')}
+                    </span>
+                  ) : restartState === 'copied' ? (
+                    <span className="ml-1 flex items-center gap-1.5 px-2.5 py-1 bg-green-800/50 text-green-300 rounded text-xs">
+                      <Check className="w-3 h-3" />
+                      {t('layout.copiedRestartCommand')}
+                    </span>
+                  ) : (
+                    <button
+                      onClick={handleRestartBackend}
+                      className="ml-1 flex items-center gap-1.5 px-2.5 py-1 bg-muted hover:bg-muted/80 text-foreground rounded text-xs transition-colors"
+                      title={t('layout.restartBackendServer')}
+                    >
+                      <RotateCcw className="w-3 h-3" />
+                      {t('layout.restart')}
+                    </button>
+                  )}
+                </div>
+                {restartError ? (
+                  <span className="text-xs text-muted-foreground">{restartError}</span>
                 ) : (
-                  <button
-                    onClick={handleRestartBackend}
-                    className="ml-1 flex items-center gap-1.5 px-2.5 py-1 bg-muted hover:bg-muted/80 text-foreground rounded text-xs transition-colors"
-                    title={restartError ?? t('layout.restartBackendServer')}
-                  >
-                    <RotateCcw className="w-3 h-3" />
-                    {t('layout.restart')}
-                  </button>
+                  <span className="text-xs text-muted-foreground">{t('layout.connectionLostHint')}</span>
                 )}
-              </>
+              </div>
             ) : (
               <>
                 <div className="w-2 h-2 rounded-full bg-green-400" />

--- a/web/src/locales/en/common.json
+++ b/web/src/locales/en/common.json
@@ -3352,6 +3352,8 @@
     "switchTo": "Switch to",
     "demo": "Demo",
     "connectionLost": "Connection lost",
+    "connectionLostHint": "Could not reach the backend — restart the server to reconnect",
+    "copiedRestartCommand": "Copied — run this in your project root terminal",
     "restarting": "Restarting\u2026",
     "restartedWaiting": "Restarted, waiting for connection\u2026",
     "restartBackendServer": "Restart the backend server",


### PR DESCRIPTION
## Summary
- Made the "Could not reach agent" diagnostic text visible as secondary text below the "Connection lost" banner, instead of hiding it in a tooltip-only `title` attribute (invisible on touch devices)
- When the restart attempt fails with a specific error, that error is now shown inline in the banner
- Changed post-copy feedback from generic "Copied!" to "Copied — run this in your project root terminal" so users know where to execute the command
- Added i18n keys `layout.connectionLostHint` and `layout.copiedRestartCommand`

## Test plan
- [ ] Start the console, then stop the backend — verify the banner shows "Connection lost" with visible hint text below
- [ ] Click Restart when kc-agent is not running — verify the error message appears inline (not just in tooltip)
- [ ] After copy fallback, verify the feedback says "Copied — run this in your project root terminal"
- [ ] Verify the reconnected state still shows correctly when the backend comes back

Fixes #8633