### PR TITLE
fix: widen widget preview panel from 50% to 65%

### DIFF
--- a/web/src/components/widgets/WidgetExportModal.tsx
+++ b/web/src/components/widgets/WidgetExportModal.tsx
@@ -182,8 +182,8 @@ export function WidgetExportModal({ isOpen, onClose, cardType, mode: _mode = 'pi
         </div>
 
         <div className="flex-1 flex gap-4 overflow-hidden">
-          {/* Left: Selection */}
-          <div className="w-1/2 flex flex-col overflow-hidden">
+          {/* Left: Selection (narrower to give preview more room) */}
+          <div className="w-[35%] flex flex-col overflow-hidden">
             <div ref={cardListRef} className="flex-1 overflow-y-auto pr-2">
               {activeTab === 'templates' && (
                 <div className="space-y-2">
@@ -297,7 +297,7 @@ export function WidgetExportModal({ isOpen, onClose, cardType, mode: _mode = 'pi
 
           {/* Right: Preview & Code — overflow-hidden + min-h-0 keeps the preview
               pinned in view while the left card list scrolls independently */}
-          <div className="w-1/2 flex flex-col overflow-hidden min-h-0">
+          <div className="w-[65%] flex flex-col overflow-hidden min-h-0">
             <div className="flex items-center justify-between mb-2">
               <span className="text-sm font-medium">{t('common.preview')}</span>
               <button


### PR DESCRIPTION
## Summary
- Card list: `w-1/2` → `w-[35%]`
- Preview panel: `w-1/2` → `w-[65%]`
- Widget preview renders ~50% larger

## Test plan
- [ ] Console Studio → Export Widgets → preview card is visibly larger
- [ ] Card list still scrolls and items are readable at 35% width

🤖 Generated with [Claude Code](https://claude.com/claude-code)