### PR TITLE
feat: GA4 events for ACMM mission launches

### DIFF
--- a/web/src/components/cards/ACMMFeedbackLoops.tsx
+++ b/web/src/components/cards/ACMMFeedbackLoops.tsx
@@ -15,6 +15,7 @@ import { useMissions } from '../../hooks/useMissions'
 import { ALL_CRITERIA, SOURCES_BY_ID } from '../../lib/acmm/sources'
 import type { Criterion, SourceId } from '../../lib/acmm/sources/types'
 import { detectionLabel, singleCriterionPrompt, levelCompletionPrompt } from '../../lib/acmm/missionPrompts'
+import { emitACMMMissionLaunched, emitACMMLevelMissionLaunched } from '../../lib/analytics'
 
 type StatusFilter = 'all' | 'detected' | 'missing'
 
@@ -123,6 +124,7 @@ export function ACMMFeedbackLoops() {
   }
 
   function launchOne(c: Criterion) {
+    emitACMMMissionLaunched(repo, c.id, c.source, c.level ?? 0)
     startMission({
       title: `Add ACMM criterion: ${c.name}`,
       description: `Add "${c.name}" to ${repo}`,
@@ -172,6 +174,7 @@ export function ACMMFeedbackLoops() {
 
   function launchLevelCompletion() {
     if (missingForNextList.length === 0) return
+    emitACMMLevelMissionLaunched(repo, nextLevel, missingForNextList.length)
     startMission({
       title: `Reach ACMM L${nextLevel} for ${repo}`,
       description: `Add the ${missingForNextList.length} missing L${nextLevel} criteria to ${repo}`,

--- a/web/src/components/cards/ACMMRecommendations.tsx
+++ b/web/src/components/cards/ACMMRecommendations.tsx
@@ -20,6 +20,7 @@ import {
   singleRecommendationPrompt,
   allRecommendationsPrompt,
 } from '../../lib/acmm/missionPrompts'
+import { emitACMMMissionLaunched } from '../../lib/analytics'
 
 const SOURCE_LABELS: Record<SourceId, string> = {
   acmm: 'ACMM',
@@ -49,6 +50,7 @@ export function ACMMRecommendations() {
   const displayedRole = targetLevel === level.level ? level.role : (ROLE_BY_LEVEL[targetLevel] ?? level.role)
 
   function launchOne(rec: Recommendation) {
+    emitACMMMissionLaunched(repo, rec.criterion.id, rec.criterion.source, rec.criterion.level ?? 0)
     startMission({
       title: `Add ACMM criterion: ${rec.criterion.name}`,
       description: `Add "${rec.criterion.name}" to ${repo}`,
@@ -60,6 +62,9 @@ export function ACMMRecommendations() {
 
   function launchAll() {
     if (recommendations.length === 0) return
+    for (const rec of recommendations) {
+      emitACMMMissionLaunched(repo, rec.criterion.id, rec.criterion.source, rec.criterion.level ?? 0)
+    }
     startMission({
       title: `Add ${recommendations.length} missing ACMM criteria`,
       description: `Implement all top ACMM recommendations for ${repo}`,

--- a/web/src/lib/analytics.ts
+++ b/web/src/lib/analytics.ts
@@ -2243,3 +2243,33 @@ export function emitWhatsNewRemindLater(tag: string, duration: string) {
 export function emitACMMScanned(repo: string, level: number, detected: number, total: number) {
   send('ksc_acmm_scanned', { repo, acmm_level: level, detected, total })
 }
+
+/** Fired when a user launches an AI mission from the ACMM dashboard to
+ *  add a missing criterion. Connects the scan → mission → level-up funnel. */
+export function emitACMMMissionLaunched(
+  repo: string,
+  criterionId: string,
+  criterionSource: string,
+  targetLevel: number,
+) {
+  send('ksc_acmm_mission_launched', {
+    repo,
+    criterion_id: criterionId,
+    criterion_source: criterionSource,
+    target_level: targetLevel,
+  })
+}
+
+/** Fired when a user launches a "complete this level" mission from the
+ *  ACMM Feedback Loop Inventory sticky footer. */
+export function emitACMMLevelMissionLaunched(
+  repo: string,
+  targetLevel: number,
+  criteriaCount: number,
+) {
+  send('ksc_acmm_level_mission_launched', {
+    repo,
+    target_level: targetLevel,
+    criteria_count: criteriaCount,
+  })
+}


### PR DESCRIPTION
## Summary

Adds two new GA4 events that close the scan → mission → level-up funnel:

- **`ksc_acmm_mission_launched`** — fired when a user clicks "Ask agent for help" on any criterion (from both the Feedback Loop Inventory and Recommendations cards). Params: `repo`, `criterion_id`, `criterion_source`, `target_level`.
- **`ksc_acmm_level_mission_launched`** — fired when a user clicks "Help me reach L{n}" from the sticky footer. Params: `repo`, `target_level`, `criteria_count`.

**Why**: We already track `ksc_acmm_scanned` (who scanned) but had no way to tell if visitors are actually launching missions to level up. Now we can answer: "pytorch/pytorch was scanned → someone launched a mission for EditorConfig → did they complete it?"

## Test plan

- [ ] Open ACMM dashboard → scan a repo → click "Ask agent for help" on any criterion → verify `ksc_acmm_mission_launched` fires in GA4 DebugView
- [ ] Click "Help me reach L2" footer button → verify `ksc_acmm_level_mission_launched` fires
- [ ] Open Recommendations card → click Launch on a single rec → verify event fires
- [ ] Click "Launch all" → verify one event fires per criterion

🤖 Generated with [Claude Code](https://claude.com/claude-code)