### PR TITLE
fix: What's New modal shows merged PRs when no release notes

### DIFF
--- a/web/src/components/updates/WhatsNewModal.tsx
+++ b/web/src/components/updates/WhatsNewModal.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo, useCallback } from 'react'
+import { useState, useMemo, useCallback, useEffect } from 'react'
 import { Download, Clock, SkipForward, ChevronDown, Copy, Check } from 'lucide-react'
 import ReactMarkdown from 'react-markdown'
 import remarkGfm from 'remark-gfm'
@@ -79,8 +79,40 @@ export function WhatsNewModal({ isOpen, onClose }: WhatsNewModalProps) {
   const [showManualUpdate, setShowManualUpdate] = useState(false)
   const [showSnoozeMenu, setShowSnoozeMenu] = useState(false)
   const [copiedCommand, setCopiedCommand] = useState<string | null>(null)
+  const [recentPRs, setRecentPRs] = useState<Array<{ number: number; title: string; merged_at: string }>>([])
 
   const markdownComponents = useMemo(() => buildReleaseNotesComponents('sm'), [])
+
+  // When release notes are empty, fetch recent merged PRs as fallback content
+  const MAX_RECENT_PRS = 20
+  const hasReleaseNotes = !!latestRelease?.releaseNotes?.trim()
+  useEffect(() => {
+    if (hasReleaseNotes || !isOpen) return
+    let cancelled = false
+    const fetchPRs = async () => {
+      try {
+        const resp = await fetch(
+          `/api/github/repos/kubestellar/console/pulls?state=closed&sort=updated&direction=desc&per_page=${MAX_RECENT_PRS}`,
+          { credentials: 'include' },
+        )
+        if (!resp.ok || cancelled) return
+        const data = await resp.json()
+        if (cancelled) return
+        const merged = (data || [])
+          .filter((pr: { merged_at: string | null }) => pr.merged_at)
+          .map((pr: { number: number; title: string; merged_at: string }) => ({
+            number: pr.number,
+            title: pr.title,
+            merged_at: pr.merged_at,
+          }))
+        setRecentPRs(merged)
+      } catch {
+        // Silently fail — the modal still shows "no release notes"
+      }
+    }
+    fetchPRs()
+    return () => { cancelled = true }
+  }, [hasReleaseNotes, isOpen])
 
   const previousReleases = useMemo(() => {
     if (!releases || !currentVersion || !latestRelease) return []
@@ -173,15 +205,44 @@ export function WhatsNewModal({ isOpen, onClose }: WhatsNewModalProps) {
 
       <BaseModal.Content>
         <div className="space-y-4">
-          {/* Primary release notes */}
-          <div className="prose dark:prose-invert max-w-none text-sm overflow-x-auto break-words [word-break:break-word] prose-pre:my-5 prose-pre:bg-transparent prose-pre:p-0 prose-code:text-purple-700 dark:prose-code:text-purple-300 prose-code:bg-black/5 dark:prose-code:bg-black/20 prose-code:px-1 prose-code:rounded">
-            <ReactMarkdown
-              remarkPlugins={[remarkGfm, remarkBreaks]}
-              components={markdownComponents}
-            >
-              {latestRelease?.releaseNotes || '*No release notes available. Pull the latest commits to update.*'}
-            </ReactMarkdown>
-          </div>
+          {/* Primary release notes — or recent merged PRs as fallback */}
+          {hasReleaseNotes ? (
+            <div className="prose dark:prose-invert max-w-none text-sm overflow-x-auto break-words [word-break:break-word] prose-pre:my-5 prose-pre:bg-transparent prose-pre:p-0 prose-code:text-purple-700 dark:prose-code:text-purple-300 prose-code:bg-black/5 dark:prose-code:bg-black/20 prose-code:px-1 prose-code:rounded">
+              <ReactMarkdown
+                remarkPlugins={[remarkGfm, remarkBreaks]}
+                components={markdownComponents}
+              >
+                {latestRelease?.releaseNotes ?? ''}
+              </ReactMarkdown>
+            </div>
+          ) : recentPRs.length > 0 ? (
+            <div className="space-y-1">
+              <p className="text-xs text-muted-foreground mb-2">
+                Recently merged pull requests:
+              </p>
+              {recentPRs.map((pr) => (
+                <a
+                  key={pr.number}
+                  href={`https://github.com/kubestellar/console/pull/${pr.number}`}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="flex items-start gap-2 px-2 py-1.5 rounded hover:bg-secondary/50 transition-colors group"
+                >
+                  <span className="text-xs text-muted-foreground font-mono shrink-0">#{pr.number}</span>
+                  <span className="text-sm text-foreground group-hover:text-primary transition-colors">{pr.title}</span>
+                  <span className="text-xs text-muted-foreground ml-auto shrink-0">
+                    {formatRelativeTime(new Date(pr.merged_at))}
+                  </span>
+                </a>
+              ))}
+            </div>
+          ) : (
+            <div className="prose dark:prose-invert max-w-none text-sm">
+              <ReactMarkdown remarkPlugins={[remarkGfm, remarkBreaks]} components={markdownComponents}>
+                {'*No release notes available. Pull the latest commits to update.*'}
+              </ReactMarkdown>
+            </div>
+          )}
 
           {/* Previous releases (collapsible) */}
           {previousReleases.length > 0 && (

--- a/web/src/hooks/useVersionCheck.tsx
+++ b/web/src/hooks/useVersionCheck.tsx
@@ -583,7 +583,7 @@ function useVersionCheckCore() {
         headers['If-None-Match'] = cache.etag
       }
 
-      const response = await fetch(GITHUB_API_URL, { headers, signal: AbortSignal.timeout(FETCH_EXTERNAL_TIMEOUT_MS) })
+      const response = await fetch(GITHUB_API_URL, { headers, credentials: 'include', signal: AbortSignal.timeout(FETCH_EXTERNAL_TIMEOUT_MS) })
 
       // Handle rate limiting
       if (response.status === 403) {


### PR DESCRIPTION
## Summary

The What's New modal was always empty on localhost and on developer channel because:
1. The releases fetch didn't include `credentials: 'include'`, so the session cookie wasn't sent and the backend returned "Missing authorization"
2. On developer channel there are no GitHub releases, so even with auth fixed there was nothing to show

**Fix:**
- Added `credentials: 'include'` to the releases fetch
- When release notes are empty, fetches the 20 most recently merged PRs via `/api/github/repos/kubestellar/console/pulls` and displays them as a clickable list with `#number`, title, and relative merge time
- Each PR links to GitHub for full details
- Falls back to the original "no release notes" message only if both releases AND PRs fail

## Test plan

- [ ] Open What's New modal on localhost (developer channel) → shows list of recent merged PRs
- [ ] Click a PR → opens GitHub PR page in new tab
- [ ] Switch to stable channel with a release → shows release notes (not PR list)
- [ ] On console.kubestellar.io → shows release notes as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)