### PR TITLE
fix: wire real data hooks into GatewayStatus and ServiceImports cards

### DIFF
--- a/web/src/components/cards/GatewayStatus.tsx
+++ b/web/src/components/cards/GatewayStatus.tsx
@@ -1,3 +1,4 @@
+import { useMemo } from 'react'
 import { CheckCircle2, Clock, XCircle, AlertCircle, ExternalLink, Globe, ArrowRight, Server } from 'lucide-react'
 import { ClusterBadge } from '../ui/ClusterBadge'
 import { Skeleton } from '../ui/Skeleton'
@@ -6,100 +7,11 @@ import { useCardData, commonComparators } from '../../lib/cards/cardHooks'
 import { K8S_DOCS } from '../../config/externalApis'
 import { useCardLoadingState } from './CardDataContext'
 import { useTranslation } from 'react-i18next'
+import { useGatewayStatus as useGatewayStatusHook } from '../../hooks/useGatewayStatus'
+import type { Gateway } from '../../hooks/useGatewayStatus'
 
 // Gateway status types
 type GatewayStatusType = 'Programmed' | 'Accepted' | 'Pending' | 'NotAccepted' | 'Unknown'
-
-interface Listener {
-  name: string
-  protocol: string
-  port: number
-  hostname?: string
-  attachedRoutes: number
-}
-
-interface Gateway {
-  name: string
-  namespace: string
-  cluster: string
-  gatewayClass: string
-  status: GatewayStatusType
-  addresses: string[]
-  listeners: Listener[]
-  attachedRoutes: number
-  createdAt: string
-}
-
-// Demo data for Gateway API resources
-const DEMO_GATEWAYS: Gateway[] = [
-  {
-    name: 'prod-gateway',
-    namespace: 'gateway-system',
-    cluster: 'us-east-1',
-    gatewayClass: 'istio',
-    status: 'Programmed',
-    addresses: ['34.102.136.180'],
-    listeners: [
-      { name: 'http', protocol: 'HTTP', port: 80, attachedRoutes: 5 },
-      { name: 'https', protocol: 'HTTPS', port: 443, hostname: '*.example.com', attachedRoutes: 8 },
-    ],
-    attachedRoutes: 13,
-    createdAt: new Date(Date.now() - 30 * 24 * 60 * 60 * 1000).toISOString() },
-  {
-    name: 'api-gateway',
-    namespace: 'api',
-    cluster: 'us-west-2',
-    gatewayClass: 'envoy-gateway',
-    status: 'Programmed',
-    addresses: ['10.0.0.50'],
-    listeners: [
-      { name: 'api', protocol: 'HTTP', port: 8080, attachedRoutes: 12 },
-    ],
-    attachedRoutes: 12,
-    createdAt: new Date(Date.now() - 14 * 24 * 60 * 60 * 1000).toISOString() },
-  {
-    name: 'internal-gateway',
-    namespace: 'internal',
-    cluster: 'eu-central-1',
-    gatewayClass: 'contour',
-    status: 'Accepted',
-    addresses: [],
-    listeners: [
-      { name: 'grpc', protocol: 'HTTPS', port: 443, attachedRoutes: 3 },
-    ],
-    attachedRoutes: 3,
-    createdAt: new Date(Date.now() - 7 * 24 * 60 * 60 * 1000).toISOString() },
-  {
-    name: 'staging-gateway',
-    namespace: 'staging',
-    cluster: 'us-east-1',
-    gatewayClass: 'nginx',
-    status: 'Pending',
-    addresses: [],
-    listeners: [
-      { name: 'http', protocol: 'HTTP', port: 80, attachedRoutes: 0 },
-    ],
-    attachedRoutes: 0,
-    createdAt: new Date(Date.now() - 1 * 60 * 60 * 1000).toISOString() },
-  {
-    name: 'legacy-gateway',
-    namespace: 'legacy',
-    cluster: 'on-prem-dc1',
-    gatewayClass: 'traefik',
-    status: 'NotAccepted',
-    addresses: [],
-    listeners: [],
-    attachedRoutes: 0,
-    createdAt: new Date(Date.now() - 2 * 24 * 60 * 60 * 1000).toISOString() },
-]
-
-const DEMO_STATS = {
-  totalGateways: 8,
-  programmedCount: 5,
-  pendingCount: 2,
-  failedCount: 1,
-  totalRoutes: 42,
-  clustersWithGatewayAPI: 4 }
 
 const getStatusIcon = (status: GatewayStatusType) => {
   switch (status) {
@@ -152,15 +64,32 @@ interface GatewayStatusProps {
 export function GatewayStatus({ config: _config }: GatewayStatusProps) {
   const { t } = useTranslation(['cards', 'common'])
   const SORT_OPTIONS = SORT_OPTIONS_KEYS.map(opt => ({ value: opt.value, label: String(t(opt.labelKey)) }))
-  // Demo data - always available, never loading/erroring
-  const isLoading = false
-  const hasError = false
+
+  // Fetch real gateway data with demo fallback
+  const { gateways: allGateways, isLoading, isDemoData, isFailed, consecutiveFailures } = useGatewayStatusHook()
+  const hasError = isFailed
+
+  // Compute stats from real data
+  const stats = useMemo(() => {
+    const items = allGateways || []
+    const programmedCount = items.filter(g => g.status === 'Programmed').length
+    const pendingCount = items.filter(g => g.status === 'Pending').length
+    const totalRoutes = items.reduce((sum, g) => sum + (g.attachedRoutes || 0), 0)
+    return {
+      totalGateways: items.length,
+      programmedCount,
+      pendingCount,
+      totalRoutes,
+    }
+  }, [allGateways])
 
   // Report loading state to CardWrapper for skeleton/refresh behavior
   useCardLoadingState({
     isLoading,
-    hasAnyData: DEMO_GATEWAYS.length > 0,
-    isDemoData: true })
+    hasAnyData: (allGateways || []).length > 0,
+    isDemoData,
+    isFailed,
+    consecutiveFailures })
 
   const {
     items: paginatedGateways,
@@ -187,7 +116,7 @@ export function GatewayStatus({ config: _config }: GatewayStatusProps) {
       sortDirection,
       setSortDirection },
     containerRef,
-    containerStyle } = useCardData<Gateway, SortByOption>(DEMO_GATEWAYS, {
+    containerStyle } = useCardData<Gateway, SortByOption>(allGateways || [], {
     filter: {
       searchFields: ['name', 'namespace', 'cluster', 'gatewayClass', 'status'],
       clusterField: 'cluster',
@@ -307,15 +236,15 @@ export function GatewayStatus({ config: _config }: GatewayStatusProps) {
       <div className="grid grid-cols-3 gap-2 mb-3">
         <div className="p-2 rounded-lg bg-purple-500/10 border border-purple-500/20 text-center">
           <p className="text-2xs text-purple-400">{t('gatewayStatus.gateways')}</p>
-          <p className="text-lg font-bold text-foreground">{DEMO_STATS.totalGateways}</p>
+          <p className="text-lg font-bold text-foreground">{stats.totalGateways}</p>
         </div>
         <div className="p-2 rounded-lg bg-green-500/10 border border-green-500/20 text-center">
           <p className="text-2xs text-green-400">{t('gatewayStatus.programmed')}</p>
-          <p className="text-lg font-bold text-foreground">{DEMO_STATS.programmedCount}</p>
+          <p className="text-lg font-bold text-foreground">{stats.programmedCount}</p>
         </div>
         <div className="p-2 rounded-lg bg-blue-500/10 border border-blue-500/20 text-center">
           <p className="text-2xs text-blue-400">{t('gatewayStatus.routes')}</p>
-          <p className="text-lg font-bold text-foreground">{DEMO_STATS.totalRoutes}</p>
+          <p className="text-lg font-bold text-foreground">{stats.totalRoutes}</p>
         </div>
       </div>
 

--- a/web/src/components/cards/ServiceImports.tsx
+++ b/web/src/components/cards/ServiceImports.tsx
@@ -1,3 +1,4 @@
+import { useMemo } from 'react'
 import { CheckCircle2, XCircle, AlertCircle, ExternalLink, Globe } from 'lucide-react'
 import { ClusterBadge } from '../ui/ClusterBadge'
 import { useCardData, commonComparators } from '../../lib/cards/cardHooks'
@@ -8,67 +9,7 @@ import type { ServiceImport, ServiceImportType } from '../../types/mcs'
 import { useCardLoadingState } from './CardDataContext'
 import { DynamicCardErrorBoundary } from './DynamicCardErrorBoundary'
 import { useTranslation } from 'react-i18next'
-
-// Demo data for MCS ServiceImports
-const DEMO_IMPORTS: ServiceImport[] = [
-  {
-    name: 'api-gateway',
-    namespace: 'production',
-    cluster: 'us-west-2',
-    sourceCluster: 'us-east-1',
-    type: 'ClusterSetIP',
-    dnsName: 'api-gateway.production.svc.clusterset.local',
-    ports: [{ name: 'http', protocol: 'TCP', port: 8080 }],
-    endpoints: 3,
-    createdAt: new Date(Date.now() - 7 * 24 * 60 * 60 * 1000).toISOString() },
-  {
-    name: 'auth-service',
-    namespace: 'production',
-    cluster: 'eu-central-1',
-    sourceCluster: 'us-east-1',
-    type: 'ClusterSetIP',
-    dnsName: 'auth-service.production.svc.clusterset.local',
-    ports: [{ name: 'grpc', protocol: 'TCP', port: 9090 }],
-    endpoints: 2,
-    createdAt: new Date(Date.now() - 14 * 24 * 60 * 60 * 1000).toISOString() },
-  {
-    name: 'cache-redis',
-    namespace: 'infrastructure',
-    cluster: 'us-east-1',
-    sourceCluster: 'us-west-2',
-    type: 'Headless',
-    dnsName: 'cache-redis.infrastructure.svc.clusterset.local',
-    ports: [{ name: 'redis', protocol: 'TCP', port: 6379 }],
-    endpoints: 1,
-    createdAt: new Date(Date.now() - 3 * 24 * 60 * 60 * 1000).toISOString() },
-  {
-    name: 'metrics-collector',
-    namespace: 'monitoring',
-    cluster: 'ap-southeast-1',
-    sourceCluster: 'us-east-1',
-    type: 'ClusterSetIP',
-    dnsName: 'metrics-collector.monitoring.svc.clusterset.local',
-    ports: [{ name: 'metrics', protocol: 'TCP', port: 9100 }],
-    endpoints: 4,
-    createdAt: new Date(Date.now() - 5 * 24 * 60 * 60 * 1000).toISOString() },
-  {
-    name: 'database-proxy',
-    namespace: 'data',
-    cluster: 'eu-central-1',
-    sourceCluster: 'us-west-2',
-    type: 'ClusterSetIP',
-    dnsName: 'database-proxy.data.svc.clusterset.local',
-    ports: [{ name: 'postgres', protocol: 'TCP', port: 5432 }],
-    endpoints: 0,
-    createdAt: new Date(Date.now() - 1 * 60 * 60 * 1000).toISOString() },
-]
-
-const DEMO_STATS = {
-  totalImports: 15,
-  withEndpoints: 12,
-  noEndpoints: 3,
-  clusterSetIP: 13,
-  headless: 2 }
+import { useServiceImportsCard } from '../../hooks/useServiceImportsCard'
 
 const getEndpointStatus = (endpoints: number) => {
   if (endpoints > 0) {
@@ -109,15 +50,30 @@ interface ServiceImportsProps {
 function ServiceImportsInternal({ config: _config }: ServiceImportsProps) {
   const { t } = useTranslation(['cards', 'common'])
   const SORT_OPTIONS = SORT_OPTIONS_KEYS.map(opt => ({ value: opt.value, label: String(t(opt.labelKey)) }))
-  // Demo data - always available, never loading/erroring
-  const isLoading = false
-  const hasError = false
+
+  // Fetch real ServiceImport data with demo fallback
+  const { imports: allImports, isLoading, isDemoData, isFailed, consecutiveFailures } = useServiceImportsCard()
+  const hasError = isFailed
+
+  // Compute stats from real data
+  const stats = useMemo(() => {
+    const items = allImports || []
+    const withEndpoints = items.filter(i => i.endpoints > 0).length
+    const noEndpoints = items.filter(i => i.endpoints === 0).length
+    return {
+      totalImports: items.length,
+      withEndpoints,
+      noEndpoints,
+    }
+  }, [allImports])
 
   // Report loading state to CardWrapper for skeleton/refresh behavior
   useCardLoadingState({
     isLoading,
-    hasAnyData: DEMO_IMPORTS.length > 0,
-    isDemoData: true })
+    hasAnyData: (allImports || []).length > 0,
+    isDemoData,
+    isFailed,
+    consecutiveFailures })
 
   const {
     items: filteredImports,
@@ -131,7 +87,7 @@ function ServiceImportsInternal({ config: _config }: ServiceImportsProps) {
     filters,
     sorting,
     containerRef,
-    containerStyle } = useCardData<ServiceImport, SortByOption>(DEMO_IMPORTS, {
+    containerStyle } = useCardData<ServiceImport, SortByOption>(allImports || [], {
     filter: {
       searchFields: ['name', 'namespace', 'cluster', 'sourceCluster', 'dnsName', 'type'],
       clusterField: 'cluster',
@@ -190,7 +146,7 @@ function ServiceImportsInternal({ config: _config }: ServiceImportsProps) {
             <ExternalLink className="w-4 h-4" />
           </a>
           <span className="text-sm font-medium text-muted-foreground">
-            {t('serviceImports.nImports', { count: DEMO_STATS.totalImports })}
+            {t('serviceImports.nImports', { count: stats.totalImports })}
           </span>
         </div>
         <CardControlsRow
@@ -240,15 +196,15 @@ function ServiceImportsInternal({ config: _config }: ServiceImportsProps) {
       <div className="grid grid-cols-3 gap-2 mb-3">
         <div className="p-2 rounded-lg bg-cyan-500/10 border border-cyan-500/20 text-center">
           <p className="text-2xs text-cyan-400">{t('serviceImports.imports')}</p>
-          <p className="text-lg font-bold text-foreground">{DEMO_STATS.totalImports}</p>
+          <p className="text-lg font-bold text-foreground">{stats.totalImports}</p>
         </div>
         <div className="p-2 rounded-lg bg-green-500/10 border border-green-500/20 text-center">
           <p className="text-2xs text-green-400">{t('common:common.healthy')}</p>
-          <p className="text-lg font-bold text-foreground">{DEMO_STATS.withEndpoints}</p>
+          <p className="text-lg font-bold text-foreground">{stats.withEndpoints}</p>
         </div>
         <div className="p-2 rounded-lg bg-red-500/10 border border-red-500/20 text-center">
           <p className="text-2xs text-red-400">{t('serviceImports.noEndpoints')}</p>
-          <p className="text-lg font-bold text-foreground">{DEMO_STATS.noEndpoints}</p>
+          <p className="text-lg font-bold text-foreground">{stats.noEndpoints}</p>
         </div>
       </div>
 

--- a/web/src/hooks/useGatewayStatus.ts
+++ b/web/src/hooks/useGatewayStatus.ts
@@ -1,0 +1,312 @@
+/**
+ * Gateway Status Data Hook with real backend API and demo data fallback
+ *
+ * Fetches live Gateway API data from GET /api/gateway/gateways.
+ * Falls back to demo data when the API returns 503 (no k8s client)
+ * or on network error.
+ *
+ * Provides:
+ * - localStorage cache load/save with 5 minute expiry
+ * - isDemoData flag for CardWrapper demo badge
+ * - Auto-refresh every 2 minutes
+ */
+
+import { useState, useEffect, useCallback, useRef } from 'react'
+import { useClusters } from './useMCP'
+import { STORAGE_KEY_TOKEN } from '../lib/constants'
+import { FETCH_DEFAULT_TIMEOUT_MS } from '../lib/constants/network'
+
+// ============================================================================
+// Constants
+// ============================================================================
+
+/** Cache expiry time — 5 minutes */
+const CACHE_EXPIRY_MS = 300_000
+
+/** Auto-refresh interval — 2 minutes */
+const REFRESH_INTERVAL_MS = 120_000
+
+/** Number of consecutive failures before marking as failed */
+const FAILURE_THRESHOLD = 3
+
+/** localStorage key for Gateway status cache */
+const CACHE_KEY = 'kc-gateway-status-cache'
+
+/** HTTP status code returned when the backend has no k8s client */
+const STATUS_SERVICE_UNAVAILABLE = 503
+
+// ============================================================================
+// Types
+// ============================================================================
+
+type GatewayStatusType = 'Programmed' | 'Accepted' | 'Pending' | 'NotAccepted' | 'Unknown'
+
+interface Listener {
+  name: string
+  protocol: string
+  port: number
+  hostname?: string
+  attachedRoutes: number
+}
+
+export interface Gateway {
+  name: string
+  namespace: string
+  cluster: string
+  gatewayClass: string
+  status: GatewayStatusType
+  addresses: string[]
+  listeners: Listener[]
+  attachedRoutes: number
+  createdAt: string
+}
+
+interface GatewayListResponse {
+  items: Gateway[]
+  totalCount: number
+}
+
+interface CachedData {
+  data: Gateway[]
+  timestamp: number
+  isDemoData: boolean
+}
+
+// ============================================================================
+// Auth Helper
+// ============================================================================
+
+function authHeaders(): Record<string, string> {
+  const token = localStorage.getItem(STORAGE_KEY_TOKEN)
+  const headers: Record<string, string> = { 'Accept': 'application/json' }
+  if (token) headers['Authorization'] = `Bearer ${token}`
+  return headers
+}
+
+// ============================================================================
+// Cache Helpers
+// ============================================================================
+
+function loadFromCache(): CachedData | null {
+  try {
+    const stored = localStorage.getItem(CACHE_KEY)
+    if (stored) {
+      const parsed = JSON.parse(stored) as CachedData
+      if (Date.now() - parsed.timestamp < CACHE_EXPIRY_MS) {
+        return parsed
+      }
+    }
+  } catch {
+    // Ignore parse errors
+  }
+  return null
+}
+
+function saveToCache(data: Gateway[], isDemoData: boolean): void {
+  try {
+    localStorage.setItem(CACHE_KEY, JSON.stringify({
+      data,
+      timestamp: Date.now(),
+      isDemoData,
+    }))
+  } catch {
+    // Ignore storage errors (quota, etc.)
+  }
+}
+
+// ============================================================================
+// Demo Data Generator
+// ============================================================================
+
+/** Days in milliseconds */
+const MS_PER_DAY = 86_400_000
+/** Hours in milliseconds */
+const MS_PER_HOUR = 3_600_000
+
+function getDemoGateways(clusterNames: string[]): Gateway[] {
+  const gateways: Gateway[] = []
+  const names = clusterNames.length > 0 ? clusterNames : ['us-east-1', 'us-west-2', 'eu-central-1']
+
+  const templates: Array<{
+    name: string
+    namespace: string
+    gatewayClass: string
+    status: GatewayStatusType
+    listeners: Listener[]
+  }> = [
+    {
+      name: 'prod-gateway',
+      namespace: 'gateway-system',
+      gatewayClass: 'istio',
+      status: 'Programmed',
+      listeners: [
+        { name: 'http', protocol: 'HTTP', port: 80, attachedRoutes: 5 },
+        { name: 'https', protocol: 'HTTPS', port: 443, hostname: '*.example.com', attachedRoutes: 8 },
+      ],
+    },
+    {
+      name: 'api-gateway',
+      namespace: 'api',
+      gatewayClass: 'envoy-gateway',
+      status: 'Programmed',
+      listeners: [
+        { name: 'api', protocol: 'HTTP', port: 8080, attachedRoutes: 12 },
+      ],
+    },
+    {
+      name: 'internal-gateway',
+      namespace: 'internal',
+      gatewayClass: 'contour',
+      status: 'Accepted',
+      listeners: [
+        { name: 'grpc', protocol: 'HTTPS', port: 443, attachedRoutes: 3 },
+      ],
+    },
+    {
+      name: 'staging-gateway',
+      namespace: 'staging',
+      gatewayClass: 'nginx',
+      status: 'Pending',
+      listeners: [
+        { name: 'http', protocol: 'HTTP', port: 80, attachedRoutes: 0 },
+      ],
+    },
+    {
+      name: 'legacy-gateway',
+      namespace: 'legacy',
+      gatewayClass: 'traefik',
+      status: 'NotAccepted',
+      listeners: [],
+    },
+  ]
+
+  for (const cluster of (names || [])) {
+    const hash = cluster.split('').reduce((acc, char) => acc + char.charCodeAt(0), 0)
+    const count = 1 + (hash % 3) // 1-3 gateways per cluster
+
+    for (let i = 0; i < count && i < templates.length; i++) {
+      const tmpl = templates[i]
+      const totalRoutes = (tmpl.listeners || []).reduce((sum, l) => sum + l.attachedRoutes, 0)
+      gateways.push({
+        name: tmpl.name,
+        namespace: tmpl.namespace,
+        cluster,
+        gatewayClass: tmpl.gatewayClass,
+        status: tmpl.status,
+        addresses: tmpl.status === 'Programmed' ? [`10.${hash % 256}.0.${i + 1}`] : [],
+        listeners: tmpl.listeners,
+        attachedRoutes: totalRoutes,
+        createdAt: new Date(Date.now() - (i + 1) * MS_PER_DAY - hash * MS_PER_HOUR).toISOString(),
+      })
+    }
+  }
+
+  return gateways
+}
+
+// ============================================================================
+// Hook: useGatewayStatus
+// ============================================================================
+
+export interface UseGatewayStatusResult {
+  gateways: Gateway[]
+  isDemoData: boolean
+  isLoading: boolean
+  isFailed: boolean
+  consecutiveFailures: number
+  lastRefresh: number | null
+  refetch: () => Promise<void>
+}
+
+export function useGatewayStatus(): UseGatewayStatusResult {
+  const { deduplicatedClusters: clusters, isLoading: clustersLoading } = useClusters()
+
+  // Initialize from cache — snapshot ref value to avoid reading ref during render
+  const cachedData = useRef(loadFromCache())
+  const cachedSnapshot = cachedData.current
+  const [gateways, setGateways] = useState<Gateway[]>(cachedSnapshot?.data || [])
+  const [isDemoData, setIsDemoData] = useState(cachedSnapshot?.isDemoData ?? true)
+  const [isLoading, setIsLoading] = useState(!cachedSnapshot)
+  const [consecutiveFailures, setConsecutiveFailures] = useState(0)
+  const [lastRefresh, setLastRefresh] = useState<number | null>(
+    cachedSnapshot?.timestamp || null
+  )
+  const initialLoadDone = useRef(!!cachedSnapshot)
+
+  const refetch = useCallback(async (silent = false) => {
+    if (!silent && !initialLoadDone.current) {
+      setIsLoading(true)
+    }
+
+    try {
+      const res = await fetch('/api/gateway/gateways', {
+        headers: authHeaders(),
+        signal: AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS),
+      })
+
+      if (res.status === STATUS_SERVICE_UNAVAILABLE) {
+        throw new Error('Service unavailable')
+      }
+
+      if (!res.ok) {
+        throw new Error(`HTTP ${res.status}: ${res.statusText}`)
+      }
+
+      const data = (await res.json()) as GatewayListResponse
+
+      // An empty array is a legitimate result (no Gateways configured)
+      const items = (data.items || []).map(gw => ({
+        ...gw,
+        // Normalize createdAt to ISO string (backend sends time.Time)
+        createdAt: typeof gw.createdAt === 'string' ? gw.createdAt : new Date(gw.createdAt).toISOString(),
+      }))
+
+      setGateways(items)
+      setIsDemoData(false)
+      setConsecutiveFailures(0)
+      setLastRefresh(Date.now())
+      initialLoadDone.current = true
+      saveToCache(items, false)
+    } catch {
+      // API failed — fall back to demo data
+      const clusterNames = (clusters || []).filter(c => c.reachable !== false).map(c => c.name)
+      const demoGateways = getDemoGateways(clusterNames)
+      setGateways(demoGateways)
+      setIsDemoData(true)
+      setConsecutiveFailures(prev => prev + 1)
+      setLastRefresh(Date.now())
+      initialLoadDone.current = true
+      saveToCache(demoGateways, true)
+    } finally {
+      setIsLoading(false)
+    }
+  }, [clusters])
+
+  // Initial load
+  useEffect(() => {
+    if (!clustersLoading) {
+      refetch()
+    }
+  }, [clustersLoading]) // eslint-disable-line react-hooks/exhaustive-deps
+
+  // Auto-refresh
+  useEffect(() => {
+    if (!initialLoadDone.current) return
+
+    const interval = setInterval(() => {
+      refetch(true)
+    }, REFRESH_INTERVAL_MS)
+
+    return () => clearInterval(interval)
+  }, [refetch])
+
+  return {
+    gateways,
+    isDemoData,
+    isLoading: isLoading || clustersLoading,
+    isFailed: consecutiveFailures >= FAILURE_THRESHOLD,
+    consecutiveFailures,
+    lastRefresh,
+    refetch: () => refetch(false),
+  }
+}

--- a/web/src/hooks/useServiceImportsCard.ts
+++ b/web/src/hooks/useServiceImportsCard.ts
@@ -1,0 +1,243 @@
+/**
+ * ServiceImports Card Data Hook with real backend API and demo data fallback
+ *
+ * Fetches live MCS ServiceImport data from GET /api/mcs/imports.
+ * Falls back to demo data when the API returns 503 (no k8s client)
+ * or on network error.
+ *
+ * Provides:
+ * - localStorage cache load/save with 5 minute expiry
+ * - isDemoData flag for CardWrapper demo badge
+ * - Auto-refresh every 2 minutes
+ */
+
+import { useState, useEffect, useCallback, useRef } from 'react'
+import { useClusters } from './useMCP'
+import { STORAGE_KEY_TOKEN } from '../lib/constants'
+import { FETCH_DEFAULT_TIMEOUT_MS } from '../lib/constants/network'
+import type { ServiceImport, ServiceImportList } from '../types/mcs'
+
+// ============================================================================
+// Constants
+// ============================================================================
+
+/** Cache expiry time — 5 minutes */
+const CACHE_EXPIRY_MS = 300_000
+
+/** Auto-refresh interval — 2 minutes */
+const REFRESH_INTERVAL_MS = 120_000
+
+/** Number of consecutive failures before marking as failed */
+const FAILURE_THRESHOLD = 3
+
+/** localStorage key for ServiceImports cache */
+const CACHE_KEY = 'kc-service-imports-cache'
+
+/** HTTP status code returned when the backend has no k8s client */
+const STATUS_SERVICE_UNAVAILABLE = 503
+
+// ============================================================================
+// Types
+// ============================================================================
+
+interface CachedData {
+  data: ServiceImport[]
+  timestamp: number
+  isDemoData: boolean
+}
+
+// ============================================================================
+// Auth Helper
+// ============================================================================
+
+function authHeaders(): Record<string, string> {
+  const token = localStorage.getItem(STORAGE_KEY_TOKEN)
+  const headers: Record<string, string> = { 'Accept': 'application/json' }
+  if (token) headers['Authorization'] = `Bearer ${token}`
+  return headers
+}
+
+// ============================================================================
+// Cache Helpers
+// ============================================================================
+
+function loadFromCache(): CachedData | null {
+  try {
+    const stored = localStorage.getItem(CACHE_KEY)
+    if (stored) {
+      const parsed = JSON.parse(stored) as CachedData
+      if (Date.now() - parsed.timestamp < CACHE_EXPIRY_MS) {
+        return parsed
+      }
+    }
+  } catch {
+    // Ignore parse errors
+  }
+  return null
+}
+
+function saveToCache(data: ServiceImport[], isDemoData: boolean): void {
+  try {
+    localStorage.setItem(CACHE_KEY, JSON.stringify({
+      data,
+      timestamp: Date.now(),
+      isDemoData,
+    }))
+  } catch {
+    // Ignore storage errors (quota, etc.)
+  }
+}
+
+// ============================================================================
+// Demo Data Generator
+// ============================================================================
+
+/** Days in milliseconds */
+const MS_PER_DAY = 86_400_000
+/** Hours in milliseconds */
+const MS_PER_HOUR = 3_600_000
+
+function getDemoServiceImports(clusterNames: string[]): ServiceImport[] {
+  const imports: ServiceImport[] = []
+  const names = clusterNames.length > 0 ? clusterNames : ['us-east-1', 'us-west-2', 'eu-central-1']
+
+  const templates: Array<{
+    name: string
+    namespace: string
+    type: 'ClusterSetIP' | 'Headless'
+    endpoints: number
+  }> = [
+    { name: 'api-gateway', namespace: 'production', type: 'ClusterSetIP', endpoints: 3 },
+    { name: 'auth-service', namespace: 'production', type: 'ClusterSetIP', endpoints: 2 },
+    { name: 'cache-redis', namespace: 'infrastructure', type: 'Headless', endpoints: 1 },
+    { name: 'metrics-collector', namespace: 'monitoring', type: 'ClusterSetIP', endpoints: 4 },
+    { name: 'database-proxy', namespace: 'data', type: 'ClusterSetIP', endpoints: 0 },
+  ]
+
+  for (const cluster of (names || [])) {
+    const hash = cluster.split('').reduce((acc, char) => acc + char.charCodeAt(0), 0)
+    const count = 1 + (hash % 3) // 1-3 imports per cluster
+    const others = names.filter(n => n !== cluster)
+
+    for (let i = 0; i < count && i < templates.length; i++) {
+      const tmpl = templates[i]
+      const sourceCluster = others.length > 0 ? others[hash % others.length] : 'unknown'
+      imports.push({
+        name: tmpl.name,
+        namespace: tmpl.namespace,
+        cluster,
+        sourceCluster,
+        type: tmpl.type,
+        dnsName: `${tmpl.name}.${tmpl.namespace}.svc.clusterset.local`,
+        ports: [{ name: tmpl.name, protocol: 'TCP', port: 8080 + i }],
+        endpoints: tmpl.endpoints,
+        createdAt: new Date(Date.now() - (i + 1) * MS_PER_DAY - hash * MS_PER_HOUR).toISOString(),
+      })
+    }
+  }
+
+  return imports
+}
+
+// ============================================================================
+// Hook: useServiceImportsCard
+// ============================================================================
+
+export interface UseServiceImportsCardResult {
+  imports: ServiceImport[]
+  isDemoData: boolean
+  isLoading: boolean
+  isFailed: boolean
+  consecutiveFailures: number
+  lastRefresh: number | null
+  refetch: () => Promise<void>
+}
+
+export function useServiceImportsCard(): UseServiceImportsCardResult {
+  const { deduplicatedClusters: clusters, isLoading: clustersLoading } = useClusters()
+
+  // Initialize from cache — snapshot ref value to avoid reading ref during render
+  const cachedData = useRef(loadFromCache())
+  const cachedSnapshot = cachedData.current
+  const [imports, setImports] = useState<ServiceImport[]>(cachedSnapshot?.data || [])
+  const [isDemoData, setIsDemoData] = useState(cachedSnapshot?.isDemoData ?? true)
+  const [isLoading, setIsLoading] = useState(!cachedSnapshot)
+  const [consecutiveFailures, setConsecutiveFailures] = useState(0)
+  const [lastRefresh, setLastRefresh] = useState<number | null>(
+    cachedSnapshot?.timestamp || null
+  )
+  const initialLoadDone = useRef(!!cachedSnapshot)
+
+  const refetch = useCallback(async (silent = false) => {
+    if (!silent && !initialLoadDone.current) {
+      setIsLoading(true)
+    }
+
+    try {
+      const res = await fetch('/api/mcs/imports', {
+        headers: authHeaders(),
+        signal: AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS),
+      })
+
+      if (res.status === STATUS_SERVICE_UNAVAILABLE) {
+        throw new Error('Service unavailable')
+      }
+
+      if (!res.ok) {
+        throw new Error(`HTTP ${res.status}: ${res.statusText}`)
+      }
+
+      const data = (await res.json()) as ServiceImportList
+
+      // An empty array is a legitimate result (no ServiceImports configured)
+      const items = data.items || []
+
+      setImports(items)
+      setIsDemoData(false)
+      setConsecutiveFailures(0)
+      setLastRefresh(Date.now())
+      initialLoadDone.current = true
+      saveToCache(items, false)
+    } catch {
+      // API failed — fall back to demo data
+      const clusterNames = (clusters || []).filter(c => c.reachable !== false).map(c => c.name)
+      const demoImports = getDemoServiceImports(clusterNames)
+      setImports(demoImports)
+      setIsDemoData(true)
+      setConsecutiveFailures(prev => prev + 1)
+      setLastRefresh(Date.now())
+      initialLoadDone.current = true
+      saveToCache(demoImports, true)
+    } finally {
+      setIsLoading(false)
+    }
+  }, [clusters])
+
+  // Initial load
+  useEffect(() => {
+    if (!clustersLoading) {
+      refetch()
+    }
+  }, [clustersLoading]) // eslint-disable-line react-hooks/exhaustive-deps
+
+  // Auto-refresh
+  useEffect(() => {
+    if (!initialLoadDone.current) return
+
+    const interval = setInterval(() => {
+      refetch(true)
+    }, REFRESH_INTERVAL_MS)
+
+    return () => clearInterval(interval)
+  }, [refetch])
+
+  return {
+    imports,
+    isDemoData,
+    isLoading: isLoading || clustersLoading,
+    isFailed: consecutiveFailures >= FAILURE_THRESHOLD,
+    consecutiveFailures,
+    lastRefresh,
+    refetch: () => refetch(false),
+  }
+}


### PR DESCRIPTION
## Summary
- **GatewayStatus card** was hardcoded to always use demo data (`isDemoData: true`), showing a permanent Demo badge even with real Gateway API resources
- **ServiceImports card** had the same problem — always showing Demo badge with fake data regardless of real ServiceImport resources
- Created `useGatewayStatus` hook (fetches `/api/gateway/gateways`) and `useServiceImportsCard` hook (fetches `/api/mcs/imports`) with localStorage caching, 2-minute auto-refresh, and demo data fallback
- Wired `isDemoData` from these hooks through to `useCardLoadingState()` so the Demo badge only appears when actual demo data is being shown
- Computed stats (totals, programmed count, routes, endpoints) dynamically from fetched data instead of hardcoded constants

Fixes #8658, Fixes #8660

## Test plan
- [ ] With real Gateway API resources configured, verify the GatewayStatus card shows real data without the Demo badge
- [ ] With real ServiceImport resources configured, verify the ServiceImports card shows real data without the Demo badge
- [ ] Without cluster connection (demo mode), verify both cards still show demo data WITH the Demo badge and yellow outline
- [ ] Verify loading skeleton appears on first visit before data loads
- [ ] Verify stats section reflects actual data counts, not hardcoded numbers
- [ ] `npm run build` passes
- [ ] `npm run lint` passes