### PR TITLE
fix: sort releases by published_at to avoid stale nightly tag

### DIFF
--- a/pkg/api/handlers/github_pipelines.go
+++ b/pkg/api/handlers/github_pipelines.go
@@ -50,6 +50,7 @@ const (
 	ghpMaxErrorBodyBytes     = 10_000
 	ghpMaxLogBytes           = 10 * 1024 * 1024 // 10 MB cap on job log downloads
 	ghpMatrixSparseMinCells  = 1
+	ghpReleaseOverfetch      = 10 // fetch recent releases so we can sort by published_at
 )
 
 // ghpDefaultRepos is the default when PIPELINE_REPOS env var is not set.
@@ -89,6 +90,9 @@ var ghpRepos = ghpGetRepos()
 // ghpValidRepoPattern enforces strict owner/repo format to prevent path
 // traversal — the repo value is interpolated into GitHub API paths.
 var ghpValidRepoPattern = regexp.MustCompile(`^[a-zA-Z0-9._-]+/[a-zA-Z0-9._-]+$`)
+
+// ghpNightlyTagRe matches nightly release tags like "v0.3.21-nightly.20260417".
+var ghpNightlyTagRe = regexp.MustCompile(`(?i)nightly`)
 
 func ghpIsAllowedRepo(repo string) bool {
 	// Accept any valid owner/repo slug — the GitHub token's permissions
@@ -634,18 +638,52 @@ func (h *GitHubPipelinesHandler) buildPulse(c *fiber.Ctx) (any, error) {
 	}
 	h.history.merge(releaseRuns)
 
-	// Latest release tag (best-effort)
+	// Latest release tag (best-effort).
+	// Fetch several recent releases and pick the one with the newest
+	// published_at timestamp. GitHub's /releases endpoint sorts by the
+	// release-object created_at, which can differ from published_at when
+	// a draft is edited or a release is re-published — causing a stale
+	// tag to appear at position 0. Sorting by published_at ourselves
+	// eliminates that false staleness. (#8666)
 	var releaseTag *string
-	relRes, relErr := h.ghGet(ctx, "/repos/"+pulseRepo+"/releases?per_page=1")
+	relRes, relErr := h.ghGet(ctx, "/repos/"+pulseRepo+"/releases?per_page="+strconv.Itoa(ghpReleaseOverfetch))
 	if relErr == nil {
 		defer relRes.Body.Close()
 		if relRes.StatusCode == http.StatusOK {
 			var arr []struct {
-				TagName string `json:"tag_name"`
+				TagName     string  `json:"tag_name"`
+				PublishedAt *string `json:"published_at"`
+				Draft       bool    `json:"draft"`
 			}
 			if dec := json.NewDecoder(relRes.Body).Decode(&arr); dec == nil && len(arr) > 0 {
-				tag := arr[0].TagName
-				releaseTag = &tag
+				// Filter to non-draft nightly releases and sort by published_at descending.
+				type candidate struct {
+					tag         string
+					publishedAt time.Time
+				}
+				candidates := make([]candidate, 0, len(arr))
+				for _, r := range arr {
+					if r.Draft {
+						continue
+					}
+					if !ghpNightlyTagRe.MatchString(r.TagName) {
+						continue
+					}
+					var pub time.Time
+					if r.PublishedAt != nil {
+						if parsed, pErr := time.Parse(time.RFC3339, *r.PublishedAt); pErr == nil {
+							pub = parsed
+						}
+					}
+					candidates = append(candidates, candidate{tag: r.TagName, publishedAt: pub})
+				}
+				sort.Slice(candidates, func(i, j int) bool {
+					return candidates[i].publishedAt.After(candidates[j].publishedAt)
+				})
+				if len(candidates) > 0 {
+					tag := candidates[0].tag
+					releaseTag = &tag
+				}
 			}
 		}
 	}

--- a/web/netlify/functions/github-pipelines.mts
+++ b/web/netlify/functions/github-pipelines.mts
@@ -89,6 +89,12 @@ const REPOS = getRepos();
 const NIGHTLY_RELEASE_REPO = "kubestellar/console";
 const NIGHTLY_RELEASE_WORKFLOW = "release.yml";
 
+/** How many releases to fetch so we can sort by published_at ourselves */
+const RELEASE_OVERFETCH = 10;
+
+/** Matches nightly release tags like "v0.3.21-nightly.20260417" */
+const NIGHTLY_TAG_RE = /nightly/i;
+
 /** ms per day — used in matrix date math */
 const MS_PER_DAY = 86_400_000;
 
@@ -362,13 +368,28 @@ async function buildPulse(
   const runs = (data.workflow_runs ?? []).map((r) => normalizeRun(r, targetRepo));
   mergeIntoHistory(await readHistory(store), runs); // side-effect updates below
 
-  // Latest release tag (best-effort — release might be on the same day as the run)
+  // Latest release tag (best-effort).
+  // Fetch several recent releases and pick the one with the newest
+  // published_at. GitHub's /releases endpoint sorts by created_at of the
+  // release API object, not published_at — causing stale tags when a
+  // release is re-published or a draft is later promoted. (#8666)
   let releaseTag: string | null = null;
   try {
-    const rel = await gh(`/repos/${targetRepo}/releases?per_page=1`, token);
+    const rel = await gh(`/repos/${targetRepo}/releases?per_page=${RELEASE_OVERFETCH}`, token);
     if (rel.ok) {
-      const releases = (await rel.json()) as Array<{ tag_name?: string }>;
-      releaseTag = releases[0]?.tag_name ?? null;
+      const releases = (await rel.json()) as Array<{
+        tag_name?: string;
+        published_at?: string;
+        draft?: boolean;
+      }>;
+      const candidates = (releases || [])
+        .filter((r) => !r.draft && r.tag_name && NIGHTLY_TAG_RE.test(r.tag_name))
+        .sort((a, b) => {
+          const pa = a.published_at ? new Date(a.published_at).getTime() : 0;
+          const pb = b.published_at ? new Date(b.published_at).getTime() : 0;
+          return pb - pa; // newest first
+        });
+      releaseTag = candidates[0]?.tag_name ?? null;
     }
   } catch {
     // Non-fatal


### PR DESCRIPTION
## Summary
- Fetch 10 recent releases instead of 1 from GitHub's `/releases` endpoint
- Filter to non-draft nightly tags (matching `nightly` pattern)
- Sort by `published_at` descending to pick the truly latest release
- Fix applied to both Go backend (`pkg/api/handlers/github_pipelines.go`) and Netlify Function (`web/netlify/functions/github-pipelines.mts`)

## Problem
GitHub's `/releases?per_page=1` returns releases sorted by `created_at` of the release API object, not by `published_at`. When a release is re-published or a draft is later promoted, the stale tag appears at position 0, causing the Nightly Release Pulse card to show an outdated release tag.

## Test plan
- [ ] Verify Nightly Release Pulse card shows the correct latest nightly tag
- [ ] Confirm non-nightly and draft releases are filtered out
- [ ] Check that the Go backend and Netlify Function produce consistent results

Fixes #8666