### PR TITLE
fix: wire isRefreshing in Service Exports card

### DIFF
--- a/web/src/components/cards/ServiceExports.tsx
+++ b/web/src/components/cards/ServiceExports.tsx
@@ -57,12 +57,13 @@ interface ServiceExportsProps {
 
 function ServiceExportsInternal({ config: _config }: ServiceExportsProps) {
   const { t } = useTranslation(['cards', 'common'])
-  const { exports: allExports, isLoading, isDemoData } = useServiceExports()
+  const { exports: allExports, isLoading, isRefreshing, isDemoData } = useServiceExports()
   const SORT_OPTIONS = SORT_OPTIONS_KEYS.map(opt => ({ value: opt.value, label: String(t(opt.labelKey)) }))
 
   // Report loading state to CardWrapper for skeleton/refresh behavior
   const { showSkeleton } = useCardLoadingState({
     isLoading,
+    isRefreshing,
     hasAnyData: allExports.length > 0,
     isDemoData })
 

--- a/web/src/components/cards/__tests__/ServiceExports.test.tsx
+++ b/web/src/components/cards/__tests__/ServiceExports.test.tsx
@@ -61,7 +61,7 @@ describe('ServiceExports', () => {
     vi.clearAllMocks()
     mockUseDemoMode.mockReturnValue({ isDemoMode: true, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() })
     mockUseCardLoadingState.mockReturnValue({ showSkeleton: false, showEmptyState: false, hasData: true, isRefreshing: false })
-    mockServiceExports.mockReturnValue({ exports: [], isLoading: false, error: null })
+    mockServiceExports.mockReturnValue({ exports: [], isLoading: false, isRefreshing: false, isDemoData: false, error: null })
   })
 
   it('renders without crashing', () => {
@@ -91,6 +91,14 @@ describe('ServiceExports', () => {
     mockUseDemoMode.mockReturnValue({ isDemoMode: false, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() })
     const { container } = render(<ServiceExports />)
     expect(container).toBeTruthy()
+  })
+
+  it('passes isRefreshing to useCardLoadingState', () => {
+    mockServiceExports.mockReturnValue({ exports: [], isLoading: false, isRefreshing: true, isDemoData: false, error: null })
+    render(<ServiceExports />)
+    expect(mockUseCardLoadingState).toHaveBeenCalledWith(
+      expect.objectContaining({ isRefreshing: true }),
+    )
   })
 
 })

--- a/web/src/hooks/useServiceExports.ts
+++ b/web/src/hooks/useServiceExports.ts
@@ -146,6 +146,7 @@ export interface UseServiceExportsResult {
   exports: ServiceExport[]
   isDemoData: boolean
   isLoading: boolean
+  isRefreshing: boolean
   isFailed: boolean
   consecutiveFailures: number
   lastRefresh: number | null
@@ -161,6 +162,7 @@ export function useServiceExports(): UseServiceExportsResult {
   const [exports, setExports] = useState<ServiceExport[]>(cachedSnapshot?.data || [])
   const [isDemoData, setIsDemoData] = useState(cachedSnapshot?.isDemoData ?? true)
   const [isLoading, setIsLoading] = useState(!cachedSnapshot)
+  const [isRefreshing, setIsRefreshing] = useState(false)
   const [consecutiveFailures, setConsecutiveFailures] = useState(0)
   const [lastRefresh, setLastRefresh] = useState<number | null>(
     cachedSnapshot?.timestamp || null
@@ -170,6 +172,9 @@ export function useServiceExports(): UseServiceExportsResult {
   const refetch = useCallback(async (silent = false) => {
     if (!silent && !initialLoadDone.current) {
       setIsLoading(true)
+    }
+    if (silent && initialLoadDone.current) {
+      setIsRefreshing(true)
     }
 
     try {
@@ -213,6 +218,7 @@ export function useServiceExports(): UseServiceExportsResult {
       saveToCache(demoExports, true)
     } finally {
       setIsLoading(false)
+      setIsRefreshing(false)
     }
   }, [clusters])
 
@@ -238,6 +244,7 @@ export function useServiceExports(): UseServiceExportsResult {
     exports,
     isDemoData,
     isLoading: isLoading || clustersLoading,
+    isRefreshing,
     isFailed: consecutiveFailures >= FAILURE_THRESHOLD,
     consecutiveFailures,
     lastRefresh,


### PR DESCRIPTION
## Summary
- Service Exports card never passed `isRefreshing` to `useCardLoadingState()`, so the refresh icon stayed static during background data fetches
- Added `isRefreshing` state tracking to the `useServiceExports` hook (set during silent background refetches, cleared on completion)
- Wired `isRefreshing` from hook through card component to `useCardLoadingState()`
- Added test verifying `isRefreshing` is passed through to `useCardLoadingState`

Fixes #8672

## Test plan
- [ ] Service Exports card refresh icon animates during background data refresh cycles
- [ ] Card still renders correctly in demo mode with Demo badge visible
- [ ] Build and lint pass
- [ ] All ServiceExports tests pass (6/6)

🤖 Generated with [Claude Code](https://claude.com/claude-code)