### PR TITLE
fix: widget preview 50/50 split with 1.5x scaled content

### DIFF
--- a/web/src/components/widgets/WidgetExportModal.tsx
+++ b/web/src/components/widgets/WidgetExportModal.tsx
@@ -182,8 +182,8 @@ export function WidgetExportModal({ isOpen, onClose, cardType, mode: _mode = 'pi
         </div>
 
         <div className="flex-1 flex gap-4 overflow-hidden">
-          {/* Left: Selection (narrower to give preview more room) */}
-          <div className="w-[35%] flex flex-col overflow-hidden">
+          {/* Left: Selection */}
+          <div className="w-1/2 flex flex-col overflow-hidden">
             <div ref={cardListRef} className="flex-1 overflow-y-auto pr-2">
               {activeTab === 'templates' && (
                 <div className="space-y-2">
@@ -297,7 +297,7 @@ export function WidgetExportModal({ isOpen, onClose, cardType, mode: _mode = 'pi
 
           {/* Right: Preview & Code — overflow-hidden + min-h-0 keeps the preview
               pinned in view while the left card list scrolls independently */}
-          <div className="w-[65%] flex flex-col overflow-hidden min-h-0">
+          <div className="w-1/2 flex flex-col overflow-hidden min-h-0">
             <div className="flex items-center justify-between mb-2">
               <span className="text-sm font-medium">{t('common.preview')}</span>
               <button
@@ -315,8 +315,10 @@ export function WidgetExportModal({ isOpen, onClose, cardType, mode: _mode = 'pi
                 </pre>
               </div>
             ) : (
-              <div className="flex-1 bg-secondary/50 rounded-lg p-4 flex items-center justify-center">
-                <WidgetPreview config={exportConfig} />
+              <div className="flex-1 bg-secondary/50 rounded-lg p-4 flex items-center justify-center overflow-hidden">
+                <div style={{ transform: 'scale(1.5)', transformOrigin: 'center center' }}>
+                  <WidgetPreview config={exportConfig} />
+                </div>
               </div>
             )}
 


### PR DESCRIPTION
## Summary
- Reverts panel split from 35/65 back to 50/50
- Adds `transform: scale(1.5)` to widget preview content so the card renders 50% larger
- Adds `overflow-hidden` to prevent scaled content from bleeding out

## Test plan
- [ ] Console Studio → Export Widgets → panels are 50/50
- [ ] Preview card renders ~50% larger than before

🤖 Generated with [Claude Code](https://claude.com/claude-code)