### PR TITLE
fix(acmm): L5 Semi-Automated, L6 Fully Autonomous + intro modal + recommendations for 6 levels

### DIFF
--- a/web/src/components/acmm/ACMMIntroModal.tsx
+++ b/web/src/components/acmm/ACMMIntroModal.tsx
@@ -66,7 +66,7 @@ export function ACMMIntroModal({ isOpen, onClose }: ACMMIntroModalProps) {
     >
       <BaseModal.Header
         title="Welcome to the AI Codebase Maturity Model"
-        description="Score any GitHub repo on a 5-level framework for AI-assisted engineering"
+        description="Score any GitHub repo on a 6-level framework for AI-assisted engineering"
         icon={BarChart3}
         onClose={handleClose}
       />
@@ -80,14 +80,16 @@ export function ACMMIntroModal({ isOpen, onClose }: ACMMIntroModalProps) {
               <h3 className="font-semibold text-foreground">What is ACMM?</h3>
             </div>
             <p className="text-muted-foreground leading-relaxed">
-              The AI Codebase Maturity Model is a 5-level framework that scores how
+              The AI Codebase Maturity Model is a 6-level framework that scores how
               ready your repository is for AI-assisted engineering. It looks for
               concrete, detectable signals — instruction files, measurement
               workflows, feedback loops, gating policies — and scores from{' '}
-              <span className="font-mono text-foreground">L1 Assisted</span> (an AI
+              <span className="font-mono text-foreground">L1 Assisted / Ad Hoc</span> (an AI
               suggests completions) up to{' '}
-              <span className="font-mono text-foreground">L5 Self-Sustaining</span>{' '}
-              (the codebase proposes, triages, and gates its own work).
+              <span className="font-mono text-foreground">L6 Fully Autonomous</span>{' '}
+              (the codebase generates work, executes it, reviews it, and merges it
+              with minimal human intervention). A prerequisites tier tracks
+              foundational engineering hygiene without gating level progression.
             </p>
             <p className="text-muted-foreground leading-relaxed mt-2">
               The dashboard scans the repo&apos;s file structure, workflows, and
@@ -96,39 +98,48 @@ export function ACMMIntroModal({ isOpen, onClose }: ACMMIntroModalProps) {
             </p>
           </section>
 
-          {/* The 5 levels */}
+          {/* The 6 levels */}
           <section>
             <div className="flex items-center gap-2 mb-2">
               <Layers className="w-4 h-4 text-primary" />
-              <h3 className="font-semibold text-foreground">The 5 levels</h3>
+              <h3 className="font-semibold text-foreground">The 6 levels</h3>
             </div>
             <div className="space-y-1.5">
               <div className="flex gap-3">
                 <span className="font-mono text-xs text-muted-foreground w-8 shrink-0">L1</span>
-                <span className="font-medium text-foreground w-28 shrink-0">Assisted</span>
+                <span className="font-medium text-foreground w-36 shrink-0">Assisted / Ad Hoc</span>
                 <span className="text-xs text-muted-foreground">AI suggests completions, no persistent rules</span>
               </div>
               <div className="flex gap-3">
                 <span className="font-mono text-xs text-muted-foreground w-8 shrink-0">L2</span>
-                <span className="font-medium text-foreground w-28 shrink-0">Instructed</span>
+                <span className="font-medium text-foreground w-36 shrink-0">Instructed</span>
                 <span className="text-xs text-muted-foreground">Judgment encoded in CLAUDE.md / AGENTS.md / Copilot instructions</span>
               </div>
               <div className="flex gap-3">
                 <span className="font-mono text-xs text-muted-foreground w-8 shrink-0">L3</span>
-                <span className="font-medium text-foreground w-28 shrink-0">Measured</span>
-                <span className="text-xs text-muted-foreground">Metrics instrument the AI loop itself</span>
+                <span className="font-medium text-foreground w-36 shrink-0">Measured / Enforced</span>
+                <span className="text-xs text-muted-foreground">Rules mechanically enforced; metrics instrument the loop</span>
               </div>
               <div className="flex gap-3">
                 <span className="font-mono text-xs text-muted-foreground w-8 shrink-0">L4</span>
-                <span className="font-medium text-foreground w-28 shrink-0">Adaptive</span>
-                <span className="text-xs text-muted-foreground">Metrics feed back into instructions and gating thresholds</span>
+                <span className="font-medium text-foreground w-36 shrink-0">Adaptive / Structured</span>
+                <span className="text-xs text-muted-foreground">Metrics feed back into instructions; workflows are structured</span>
               </div>
               <div className="flex gap-3">
                 <span className="font-mono text-xs text-muted-foreground w-8 shrink-0">L5</span>
-                <span className="font-medium text-foreground w-28 shrink-0">Self-Sustaining</span>
-                <span className="text-xs text-muted-foreground">Codebase proposes, triages, and gates its own work</span>
+                <span className="font-medium text-foreground w-36 shrink-0">Semi-Automated</span>
+                <span className="text-xs text-muted-foreground">System detects + proposes — humans still approve</span>
+              </div>
+              <div className="flex gap-3">
+                <span className="font-mono text-xs text-muted-foreground w-8 shrink-0">L6</span>
+                <span className="font-medium text-foreground w-36 shrink-0">Fully Autonomous</span>
+                <span className="text-xs text-muted-foreground">System acts — generates issues, merges PRs, rolls back; humans set policy</span>
               </div>
             </div>
+            <p className="text-xs text-muted-foreground mt-2 italic">
+              L5 vs L6: at L5 the system proposes and humans approve.
+              At L6 the system acts and humans audit after the fact.
+            </p>
           </section>
 
           {/* Source frameworks */}
@@ -145,7 +156,7 @@ export function ACMMIntroModal({ isOpen, onClose }: ACMMIntroModalProps) {
             <ul className="space-y-1 text-xs">
               <li>
                 <span className="font-mono px-1.5 py-0.5 rounded bg-primary/20 text-primary">ACMM</span>{' '}
-                <span className="text-muted-foreground">— the 5-level model itself</span>
+                <span className="text-muted-foreground">— the 6-level model (L1–L6 + prerequisites)</span>
               </li>
               <li>
                 <span className="font-mono px-1.5 py-0.5 rounded bg-orange-500/20 text-orange-400">Fullsend</span>{' '}

--- a/web/src/components/cards/ACMMRecommendations.tsx
+++ b/web/src/components/cards/ACMMRecommendations.tsx
@@ -36,9 +36,10 @@ const ROLE_BY_LEVEL: Record<number, string> = {
   2: 'Rule-writer',
   3: 'Analyst',
   4: 'Governor',
-  5: 'Strategist',
+  5: 'Operator',
+  6: 'Strategist',
 }
-const LEVEL_TICKS = [1, 2, 3, 4, 5] as const
+const LEVEL_TICKS = [1, 2, 3, 4, 5, 6] as const
 
 export function ACMMRecommendations() {
   const { scan, repo, targetLevel, setTargetLevel } = useACMM()
@@ -111,7 +112,7 @@ export function ACMMRecommendations() {
         <input
           type="range"
           min={1}
-          max={5}
+          max={6}
           step={1}
           value={targetLevel}
           onChange={(e) => setTargetLevel(Number(e.target.value))}

--- a/web/src/lib/acmm/sources/acmm.ts
+++ b/web/src/lib/acmm/sources/acmm.ts
@@ -43,7 +43,7 @@ const LEVELS: LevelDef[] = [
   },
   {
     n: 5,
-    name: 'Automated / Self-Sustaining',
+    name: 'Semi-Automated',
     role: 'Operator',
     characteristic: 'Detection and proposed resolution happen without human initiation. Scheduled workflows find problems, create issues, and route them to AI for proposed resolution. Humans approve; the system proposes.',
     transitionTrigger: '"I want the system to act on what it finds, not just propose."',
@@ -51,7 +51,7 @@ const LEVELS: LevelDef[] = [
   },
   {
     n: 6,
-    name: 'Autonomous',
+    name: 'Fully Autonomous',
     role: 'Strategist',
     characteristic: 'The codebase operates with minimal human intervention. AI agents generate work, execute it, review it, merge it, and learn from outcomes. Humans hold 15-20% of contributions — the share that requires strategic judgment, not execution.',
     transitionTrigger: 'None — L6 is the terminal state. The human role becomes direction-setting, not code writing.',
@@ -659,7 +659,7 @@ const CRITERIA: Criterion[] = [
     crossCutting: 'traceability',
   },
 
-  // ── L5 — Automated / Self-Sustaining ────────────────────────────
+  // ── L5 — Semi-Automated ────────────────────────────
   {
     id: 'acmm:github-actions-ai',
     source: 'acmm',


### PR DESCRIPTION
## Summary
Follow-up to #8662:
- **L5**: "Automated / Self-Sustaining" → **Semi-Automated** (system proposes, human approves)
- **L6**: "Autonomous" → **Fully Autonomous** (system acts, human audits)
- **Intro modal**: updated from 5 → 6 levels with descriptions, L5/L6 distinction explained
- **Recommendations card**: `ROLE_BY_LEVEL` extended to L6 (Strategist), `LEVEL_TICKS` to [1-6], slider `max=6`

## Test plan
- [x] Build + 55 tests pass
- [ ] `/acmm` level ladder shows "Semi-Automated" at L5 and "Fully Autonomous" at L6
- [ ] "Your Role + Next Steps" slider goes to L6, shows "Strategist" role
- [ ] Intro modal (clear `kc-acmm-intro-dismissed` from localStorage) shows 6 levels with L5/L6 distinction

🤖 Generated with [Claude Code](https://claude.com/claude-code)