### PR TITLE
fix: card retry buttons refetch data instead of reloading page

### DIFF
--- a/web/src/components/cards/HardwareHealthCard.tsx
+++ b/web/src/components/cards/HardwareHealthCard.tsx
@@ -642,7 +642,7 @@ export function HardwareHealthCard() {
               <span>{fetchError}</span>
             </div>
             <button
-              onClick={() => window.location.reload()}
+              onClick={() => refetch()}
               className="flex items-center gap-1.5 px-3 py-1.5 rounded bg-red-500/20 hover:bg-red-500/30 transition-colors whitespace-nowrap"
             >
               <RefreshCw className="w-3 h-3" />

--- a/web/src/components/cards/ServiceImports.tsx
+++ b/web/src/components/cards/ServiceImports.tsx
@@ -52,7 +52,7 @@ function ServiceImportsInternal({ config: _config }: ServiceImportsProps) {
   const SORT_OPTIONS = SORT_OPTIONS_KEYS.map(opt => ({ value: opt.value, label: String(t(opt.labelKey)) }))
 
   // Fetch real ServiceImport data with demo fallback
-  const { imports: allImports, isLoading, isDemoData, isFailed, consecutiveFailures } = useServiceImportsCard()
+  const { imports: allImports, isLoading, isDemoData, isFailed, consecutiveFailures, refetch } = useServiceImportsCard()
   const hasError = isFailed
 
   // Compute stats from real data
@@ -122,7 +122,7 @@ function ServiceImportsInternal({ config: _config }: ServiceImportsProps) {
         <AlertCircle className="w-12 h-12 text-red-400 mb-4" />
         <p className="text-sm text-muted-foreground mb-4">{t('serviceImports.loadFailed')}</p>
         <button
-          onClick={() => window.location.reload()}
+          onClick={() => refetch()}
           className="px-4 py-2 rounded-lg bg-purple-500 hover:bg-purple-600 text-white text-sm"
         >
           {t('common:common.retry')}

--- a/web/src/components/cards/VClusterStatus.tsx
+++ b/web/src/components/cards/VClusterStatus.tsx
@@ -98,7 +98,7 @@ export function VClusterStatus({ config: _config }: VClusterStatusProps) {
   const SORT_OPTIONS = SORT_OPTIONS_KEYS.map(opt => ({ value: opt.value, label: String(t(opt.labelKey)) }))
   const { isConnected } = useLocalAgent()
   const { isDemoMode } = useDemoMode()
-  const { vclusterInstances, isVClustersLoading, vclustersError } = useLocalClusterTools()
+  const { vclusterInstances, isVClustersLoading, vclustersError, refresh } = useLocalClusterTools()
 
   // Use live agent data when connected and not in demo mode. When the agent
   // is connected but returns zero vclusters, we still treat that as live
@@ -142,7 +142,7 @@ export function VClusterStatus({ config: _config }: VClusterStatusProps) {
     return (<div className="h-full flex flex-col min-h-card"><div className="flex items-center justify-between mb-3"><Skeleton variant="text" width={120} height={20} /><Skeleton variant="rounded" width={80} height={28} /></div><div className="space-y-2"><Skeleton variant="rounded" height={60} /><Skeleton variant="rounded" height={60} /><Skeleton variant="rounded" height={60} /></div></div>)
   }
   if (hasError) {
-    return (<div className="h-full flex flex-col items-center justify-center min-h-card p-6"><AlertCircle className="w-12 h-12 text-red-400 mb-4" /><p className="text-sm text-muted-foreground mb-4">{t('vclusterStatus.loadFailed')}</p><button onClick={() => window.location.reload()} className="px-4 py-2 rounded-lg bg-purple-500 hover:bg-purple-600 text-white text-sm">{t('common:common.retry')}</button></div>)
+    return (<div className="h-full flex flex-col items-center justify-center min-h-card p-6"><AlertCircle className="w-12 h-12 text-red-400 mb-4" /><p className="text-sm text-muted-foreground mb-4">{t('vclusterStatus.loadFailed')}</p><button onClick={() => refresh()} className="px-4 py-2 rounded-lg bg-purple-500 hover:bg-purple-600 text-white text-sm">{t('common:common.retry')}</button></div>)
   }
   return (
     <div className="h-full flex flex-col min-h-card">


### PR DESCRIPTION
## Summary
- Fix Hardware Health, VCluster Status, and Service Imports card Retry buttons to call their hook's `refetch()`/`refresh()` function instead of `window.location.reload()`
- Clicking Retry now only refreshes that card's data without disrupting other cards or losing page state

## Test plan
- [ ] Click Retry on Hardware Health card error state — only that card refreshes
- [ ] Click Retry on VCluster Status card error state — only that card refreshes
- [ ] Click Retry on Service Imports card error state — only that card refreshes
- [ ] Other cards retain their state during retry
- [ ] No console errors

Fixes #8691, Fixes #8689, Fixes #8687