### PR TITLE
fix: complete PR context across all CI/CD cards

### DIFF
--- a/pkg/api/handlers/github_pipelines.go
+++ b/pkg/api/handlers/github_pipelines.go
@@ -38,7 +38,7 @@ const (
 	ghpFailuresLimit         = 10
 	ghpFailuresOverfetch     = 30
 	ghpLogTailLines          = 500
-	ghpMatrixRunsPerRepo     = 100
+	ghpMatrixRunsPerRepo     = 500
 	ghpFlowMaxRunsPerRepo    = 8
 	ghpPulseWindowDays       = 14
 	ghpGitHubAPIBase         = "https://api.github.com"
@@ -93,6 +93,10 @@ var ghpValidRepoPattern = regexp.MustCompile(`^[a-zA-Z0-9._-]+/[a-zA-Z0-9._-]+$`
 
 // ghpNightlyTagRe matches nightly release tags like "v0.3.21-nightly.20260417".
 var ghpNightlyTagRe = regexp.MustCompile(`(?i)nightly`)
+
+// ghpPRFromCommitRe extracts a PR number from merge-commit messages like
+// "feat: something (#8673)".
+var ghpPRFromCommitRe = regexp.MustCompile(`\(#(\d+)\)\s*$`)
 
 func ghpIsAllowedRepo(repo string) bool {
 	// Accept any valid owner/repo slug — the GitHub token's permissions
@@ -505,12 +509,28 @@ type workflowRunRaw struct {
 		Number int    `json:"number"`
 		URL    string `json:"url"`
 	} `json:"pull_requests"`
+	HeadCommit struct {
+		Message string `json:"message"`
+	} `json:"head_commit"`
 }
 
 func normalizeRunRaw(r workflowRunRaw, repo string) ghpWorkflowRun {
 	var prs []ghpPullRequestRef
 	for _, pr := range r.PullRequests {
 		prs = append(prs, ghpPullRequestRef{Number: pr.Number, URL: pr.URL})
+	}
+	// For push events (merge commits), the pull_requests array is empty.
+	// Extract the PR number from the commit message pattern "feat: … (#1234)".
+	if len(prs) == 0 && r.Event == "push" && r.HeadCommit.Message != "" {
+		if m := ghpPRFromCommitRe.FindStringSubmatch(r.HeadCommit.Message); len(m) > 1 {
+			n, _ := strconv.Atoi(m[1])
+			if n > 0 {
+				prs = append(prs, ghpPullRequestRef{
+					Number: n,
+					URL:    fmt.Sprintf("https://github.com/%s/pull/%d", repo, n),
+				})
+			}
+		}
 	}
 	return ghpWorkflowRun{
 		ID:           r.ID,
@@ -529,28 +549,75 @@ func normalizeRunRaw(r workflowRunRaw, repo string) ghpWorkflowRun {
 	}
 }
 
+// ghpMaxPerPage is the GitHub API maximum for per_page.
+const ghpMaxPerPage = 100
+
+// ghpMaxPages caps pagination depth to avoid runaway API calls.
+const ghpMaxPages = 5
+
 func (h *GitHubPipelinesHandler) fetchRuns(ctx context.Context, repo, query string) ([]ghpWorkflowRun, error) {
-	res, err := h.ghGet(ctx, fmt.Sprintf("/repos/%s/actions/runs?%s", repo, query))
-	if err != nil {
-		return nil, err
+	// Parse per_page from the query string to determine the desired total.
+	// GitHub caps per_page at 100, so we paginate if the caller asks for more.
+	desired := ghpMaxPerPage
+	parts := strings.Split(query, "&")
+	baseParams := make([]string, 0, len(parts))
+	for _, p := range parts {
+		if strings.HasPrefix(p, "per_page=") {
+			n, err := strconv.Atoi(strings.TrimPrefix(p, "per_page="))
+			if err == nil && n > 0 {
+				desired = n
+			}
+		} else {
+			baseParams = append(baseParams, p)
+		}
 	}
-	defer res.Body.Close()
-	if res.StatusCode == http.StatusNotFound {
-		return nil, nil
+	pageSize := desired
+	if pageSize > ghpMaxPerPage {
+		pageSize = ghpMaxPerPage
 	}
-	if res.StatusCode >= 400 {
-		body, _ := io.ReadAll(io.LimitReader(res.Body, ghpMaxErrorBodyBytes))
-		return nil, fmt.Errorf("github %d: %s", res.StatusCode, string(body))
+	maxPages := (desired + pageSize - 1) / pageSize
+	if maxPages > ghpMaxPages {
+		maxPages = ghpMaxPages
 	}
-	var data struct {
-		WorkflowRuns []workflowRunRaw `json:"workflow_runs"`
+	baseQuery := strings.Join(baseParams, "&")
+	if baseQuery != "" {
+		baseQuery += "&"
 	}
-	if err := json.NewDecoder(res.Body).Decode(&data); err != nil {
-		return nil, err
-	}
-	out := make([]ghpWorkflowRun, 0, len(data.WorkflowRuns))
-	for _, r := range data.WorkflowRuns {
-		out = append(out, normalizeRunRaw(r, repo))
+
+	var out []ghpWorkflowRun
+	for page := 1; page <= maxPages; page++ {
+		pageQuery := fmt.Sprintf("%sper_page=%d&page=%d", baseQuery, pageSize, page)
+		res, err := h.ghGet(ctx, fmt.Sprintf("/repos/%s/actions/runs?%s", repo, pageQuery))
+		if err != nil {
+			return out, err
+		}
+		if res.StatusCode == http.StatusNotFound {
+			res.Body.Close()
+			return out, nil
+		}
+		if res.StatusCode >= 400 {
+			body, _ := io.ReadAll(io.LimitReader(res.Body, ghpMaxErrorBodyBytes))
+			res.Body.Close()
+			return out, fmt.Errorf("github %d: %s", res.StatusCode, string(body))
+		}
+		var data struct {
+			WorkflowRuns []workflowRunRaw `json:"workflow_runs"`
+		}
+		if err := json.NewDecoder(res.Body).Decode(&data); err != nil {
+			res.Body.Close()
+			return out, err
+		}
+		res.Body.Close()
+		for _, r := range data.WorkflowRuns {
+			out = append(out, normalizeRunRaw(r, repo))
+		}
+		// Stop early if this page returned fewer than pageSize (no more pages)
+		if len(data.WorkflowRuns) < pageSize {
+			break
+		}
+		if len(out) >= desired {
+			break
+		}
 	}
 	return out, nil
 }

--- a/web/netlify/functions/github-pipelines.mts
+++ b/web/netlify/functions/github-pipelines.mts
@@ -54,7 +54,7 @@ const FAILURES_OVERFETCH = 30;
 const LOG_TAIL_LINES = 500;
 
 /** How many workflow runs to pull per repo for the matrix view */
-const MATRIX_RUNS_PER_REPO = 100;
+const MATRIX_RUNS_PER_REPO = 500;
 
 /** How many in-progress/queued runs to pull per repo for the flow view */
 const FLOW_MAX_RUNS_PER_REPO = 8;
@@ -94,6 +94,9 @@ const RELEASE_OVERFETCH = 10;
 
 /** Matches nightly release tags like "v0.3.21-nightly.20260417" */
 const NIGHTLY_TAG_RE = /nightly/i;
+
+/** Extracts PR number from merge-commit messages like "feat: something (#8673)" */
+const PR_FROM_COMMIT_RE = /\(#(\d+)\)\s*$/;
 
 /** ms per day — used in matrix date math */
 const MS_PER_DAY = 86_400_000;
@@ -235,11 +238,24 @@ function dayKey(iso: string): string {
 
 /** Map GitHub's workflow_run shape to our WorkflowRun type */
 function normalizeRun(r: Record<string, unknown>, repo: string): WorkflowRun {
-  const rawPRs = Array.isArray(r.pull_requests)
+  let rawPRs = Array.isArray(r.pull_requests)
     ? (r.pull_requests as Array<{ number?: number; url?: string }>)
       .filter((pr) => typeof pr.number === "number")
       .map((pr) => ({ number: pr.number!, url: String(pr.url ?? "") }))
     : undefined;
+  // For push events (merge commits), the pull_requests array is empty.
+  // Extract the PR number from the commit message pattern "feat: … (#1234)".
+  if ((!rawPRs || rawPRs.length === 0) && r.event === "push") {
+    const headCommit = r.head_commit as { message?: string } | undefined;
+    const msg = headCommit?.message ?? "";
+    const m = PR_FROM_COMMIT_RE.exec(msg);
+    if (m) {
+      const num = Number(m[1]);
+      if (num > 0) {
+        rawPRs = [{ number: num, url: `https://github.com/${repo}/pull/${num}` }];
+      }
+    }
+  }
   return {
     id: Number(r.id),
     repo,
@@ -488,18 +504,29 @@ async function buildMatrix(
 ): Promise<MatrixPayload> {
   const targetRepos = repoFilter && isValidRepo(repoFilter) ? [repoFilter] : (REPOS as readonly string[]);
 
-  // Fetch fresh runs per repo
+  // Fetch fresh runs per repo with pagination (GitHub caps per_page at 100)
+  const MAX_PER_PAGE = 100;
+  const MAX_PAGES = 5;
   const freshRuns: WorkflowRun[] = [];
   for (const repo of targetRepos) {
     try {
-      const res = await gh(
-        `/repos/${repo}/actions/runs?per_page=${MATRIX_RUNS_PER_REPO}`,
-        token
-      );
-      if (!res.ok) continue;
-      const data = (await res.json()) as { workflow_runs: Array<Record<string, unknown>> };
-      for (const r of data.workflow_runs ?? []) {
-        freshRuns.push(normalizeRun(r, repo));
+      let fetched = 0;
+      const pages = Math.min(Math.ceil(MATRIX_RUNS_PER_REPO / MAX_PER_PAGE), MAX_PAGES);
+      for (let page = 1; page <= pages; page++) {
+        const res = await gh(
+          `/repos/${repo}/actions/runs?per_page=${MAX_PER_PAGE}&page=${page}`,
+          token
+        );
+        if (!res.ok) break;
+        const data = (await res.json()) as { workflow_runs: Array<Record<string, unknown>> };
+        const runs = data.workflow_runs ?? [];
+        for (const r of runs) {
+          freshRuns.push(normalizeRun(r, repo));
+        }
+        fetched += runs.length;
+        // Stop early if fewer results than page size (no more pages)
+        if (runs.length < MAX_PER_PAGE) break;
+        if (fetched >= MATRIX_RUNS_PER_REPO) break;
       }
     } catch {
       // Per-repo fetch failures shouldn't nuke the whole matrix

--- a/web/src/components/cards/pipelines/PipelineFlow.tsx
+++ b/web/src/components/cards/pipelines/PipelineFlow.tsx
@@ -199,9 +199,9 @@ function RunRow({ run, onCancel, canMutate, mutating }: RunRowProps) {
       )}>
         {run.run.event}
         {(run.run.pullRequests?.length ?? 0) > 0 && (
-          <div className="text-[10px] text-muted-foreground mt-0.5">
+          <a href={run.run.pullRequests![0].url || `https://github.com/${run.run.repo}/pull/${run.run.pullRequests![0].number}`} target="_blank" rel="noopener noreferrer" className="text-[10px] text-blue-400 hover:underline mt-0.5 block">
             #{run.run.pullRequests![0].number}
-          </div>
+          </a>
         )}
       </div>
 
@@ -214,7 +214,7 @@ function RunRow({ run, onCancel, canMutate, mutating }: RunRowProps) {
         <div className="text-[10px] text-muted-foreground truncate">
           {run.run.headBranch}
           {(run.run.pullRequests?.length ?? 0) > 0 && (
-            <span className="ml-1 text-blue-400">#{run.run.pullRequests![0].number}</span>
+            <a href={run.run.pullRequests![0].url || `https://github.com/${run.run.repo}/pull/${run.run.pullRequests![0].number}`} target="_blank" rel="noopener noreferrer" className="ml-1 text-blue-400 hover:underline">#{run.run.pullRequests![0].number}</a>
           )}
         </div>
       </div>
@@ -266,7 +266,9 @@ function RunRow({ run, onCancel, canMutate, mutating }: RunRowProps) {
         })}
       </div>
 
-      <div className="absolute top-2 right-2 z-20 flex items-center gap-1">
+      {/* Actions — inline at the end of the steps column so they don't
+           get clipped by the card's overflow-auto scroll container. */}
+      <div className="relative z-20 flex items-center gap-1 justify-end pt-1">
         <a
           href={run.run.htmlUrl}
           target="_blank"

--- a/web/src/components/cards/pipelines/RecentFailures.tsx
+++ b/web/src/components/cards/pipelines/RecentFailures.tsx
@@ -152,7 +152,7 @@ export function RecentFailures() {
                   <td className="py-1.5 pr-2 text-muted-foreground truncate max-w-[120px]" title={r.branch}>
                     {r.branch}
                     {(r.pullRequests?.length ?? 0) > 0 && (
-                      <span className="ml-1 text-blue-400">#{r.pullRequests![0].number}</span>
+                      <a href={r.pullRequests![0].url || `https://github.com/${r.repo}/pull/${r.pullRequests![0].number}`} target="_blank" rel="noopener noreferrer" className="ml-1 text-blue-400 hover:underline">#{r.pullRequests![0].number}</a>
                     )}
                   </td>
                   <td className="py-1.5 pr-2 text-muted-foreground whitespace-nowrap">

--- a/web/src/components/cards/workload-monitor/GitHubCIMonitor.tsx
+++ b/web/src/components/cards/workload-monitor/GitHubCIMonitor.tsx
@@ -44,6 +44,8 @@ interface WorkflowRun {
   createdAt: string
   updatedAt: string
   url: string
+  prNumber?: number
+  prUrl?: string
 }
 
 type SortField = 'name' | 'status' | 'repo' | 'branch'
@@ -127,18 +129,38 @@ export function GitHubCIMonitor({ config, ref }: GitHubCIMonitorProps & { ref?: 
           // before the outer try/catch processes the rejection (Firefox-specific timing issue).
           const data = await response.json().catch(() => null) as { workflow_runs?: Record<string, unknown>[] } | null
           if (!data) continue
-          const runs = (data.workflow_runs || []).map((run: Record<string, unknown>) => ({
-            id: String(run.id),
-            name: run.name as string,
-            repo,
-            status: run.status as WorkflowRun['status'],
-            conclusion: run.conclusion as WorkflowRun['conclusion'],
-            branch: (run.head_branch || 'unknown') as string,
-            event: (run.event || 'unknown') as string,
-            runNumber: run.run_number as number,
-            createdAt: run.created_at as string,
-            updatedAt: run.updated_at as string,
-            url: (run.html_url || '#') as string }))
+          const prFromCommit = /\(#(\d+)\)\s*$/
+          const runs = (data.workflow_runs || []).map((run: Record<string, unknown>) => {
+            const prs = run.pull_requests as { number: number; url: string }[] | undefined
+            let prNumber: number | undefined
+            let prUrl: string | undefined
+            if (prs && prs.length > 0) {
+              prNumber = prs[0].number
+              prUrl = `https://github.com/${repo}/pull/${prs[0].number}`
+            } else if (run.event === 'push') {
+              const msg = (run.head_commit as { message?: string } | undefined)?.message ?? ''
+              const m = prFromCommit.exec(msg)
+              if (m) {
+                prNumber = parseInt(m[1], 10)
+                prUrl = `https://github.com/${repo}/pull/${m[1]}`
+              }
+            }
+            return {
+              id: String(run.id),
+              name: run.name as string,
+              repo,
+              status: run.status as WorkflowRun['status'],
+              conclusion: run.conclusion as WorkflowRun['conclusion'],
+              branch: (run.head_branch || 'unknown') as string,
+              event: (run.event || 'unknown') as string,
+              runNumber: run.run_number as number,
+              createdAt: run.created_at as string,
+              updatedAt: run.updated_at as string,
+              url: (run.html_url || '#') as string,
+              prNumber,
+              prUrl,
+            }
+          })
           allRuns.push(...runs)
         } catch {
           // Network error for this repo — skip it
@@ -448,6 +470,9 @@ export function GitHubCIMonitor({ config, ref }: GitHubCIMonitorProps & { ref?: 
                 <span className="text-xs text-foreground truncate block">{w.name}</span>
                 <span className="text-2xs text-muted-foreground truncate block">
                   {w.repo.split('/')[1]} · {w.branch}
+                  {w.prNumber && (
+                    <a href={w.prUrl || `https://github.com/${w.repo}/pull/${w.prNumber}`} target="_blank" rel="noopener noreferrer" className="ml-1 text-blue-400 hover:underline">#{w.prNumber}</a>
+                  )}
                 </span>
               </div>
               <span className={cn('text-2xs px-1 py-0.5 rounded shrink-0', badgeClass)}>

--- a/web/src/hooks/useGitHubPipelines.ts
+++ b/web/src/hooks/useGitHubPipelines.ts
@@ -245,6 +245,7 @@ export const DEMO_FLOW: FlowPayload = {
         htmlUrl: '#',
         createdAt: new Date(Date.now() - 120_000).toISOString(),
         updatedAt: new Date().toISOString(),
+        pullRequests: [{ number: 8630, url: '#' }],
       },
       jobs: [
         {
@@ -291,6 +292,7 @@ export const DEMO_FAILURES: FailuresPayload = {
       createdAt: new Date(Date.now() - 3 * 86_400_000).toISOString(),
       durationMs: 612_000,
       failedStep: { jobId: 2, jobName: 'e2e', stepName: 'Run Playwright tests' },
+      pullRequests: [{ number: 8625, url: '#' }],
     },
     {
       repo: 'kubestellar/docs',
@@ -303,6 +305,7 @@ export const DEMO_FAILURES: FailuresPayload = {
       createdAt: new Date(Date.now() - 2 * 86_400_000).toISOString(),
       durationMs: 95_000,
       failedStep: { jobId: 3, jobName: 'build', stepName: 'Build MkDocs' },
+      pullRequests: [{ number: 1205, url: '#' }],
     },
   ],
 }


### PR DESCRIPTION
## Summary
Fixes #8666, Fixes #8668

**Clickable PR links** — all PR numbers (`#8692`) are now `<a>` tags linking to the PR on GitHub (new tab).

**PR extraction from commit messages** — push events (merged PRs) extract the PR number from the commit message pattern `(#1234)`. Works in Go handler, Netlify Function, and GitHubCIMonitor.

**GitHubCIMonitor** — now shows PR numbers next to branch names, extracted from GitHub Actions API `pull_requests` field + commit message fallback.

**Cancel/launch buttons** — moved from `absolute` positioning to inline flow so they're no longer clipped by the card's `overflow-auto` container.

**Matrix history depth** — increased from 100 to 500 runs per repo (5 paginated pages) to fill the 14-day matrix for repos with many workflows.

**Demo fixtures** — flow and failure demo data includes PR references.

## Test plan
- [ ] Live Runs — PR numbers clickable, Cancel/launch buttons visible
- [ ] Recent Failures — PR numbers clickable next to branch
- [ ] GitHub CI Monitor — PR numbers next to branch names
- [ ] Workflow Matrix — fewer grey dots with deeper history
- [ ] Demo mode — PR numbers in demo data

🤖 Generated with [Claude Code](https://claude.com/claude-code)