### PR TITLE
fix: address Copilot review comments on RepoSubtitle

### DIFF
--- a/web/src/components/cards/pipelines/RepoSubtitle.tsx
+++ b/web/src/components/cards/pipelines/RepoSubtitle.tsx
@@ -7,9 +7,9 @@ import { GitFork } from 'lucide-react'
 export function RepoSubtitle({ repo }: { repo: string | null }) {
   if (!repo) return null
   return (
-    <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
+    <div className="flex items-center gap-1.5 text-xs text-muted-foreground min-w-0">
       <GitFork size={10} className="shrink-0" />
-      <span className="truncate">{repo}</span>
+      <span className="truncate min-w-0">{repo}</span>
     </div>
   )
 }

--- a/web/src/components/cards/pipelines/WorkflowMatrix.tsx
+++ b/web/src/components/cards/pipelines/WorkflowMatrix.tsx
@@ -108,7 +108,7 @@ export function WorkflowMatrix() {
             ))}
           </div>
         </div>
-        <div className="flex items-center gap-2 text-[11px] text-muted-foreground">
+        <div className="flex items-center gap-2 text-xs text-muted-foreground">
           {repoFilter && <RepoSubtitle repo={repoFilter} />}
           <span>{workflows.length} workflows</span>
           <EmbedButton

--- a/web/src/components/cards/workload-monitor/GitHubCIMonitor.tsx
+++ b/web/src/components/cards/workload-monitor/GitHubCIMonitor.tsx
@@ -282,7 +282,7 @@ export function GitHubCIMonitor({ config, ref }: GitHubCIMonitorProps & { ref?: 
       <div className="rounded-lg bg-card/50 border border-border p-2.5 mb-3 flex items-center gap-2">
         <GitBranch className="w-4 h-4 text-purple-400 shrink-0" />
         <span className="text-sm font-medium text-foreground">GitHub CI</span>
-        {shared?.repoFilter && <RepoSubtitle repo={shared.repoFilter} />}
+        {shared && shared.repoFilter && <RepoSubtitle repo={shared.repoFilter} />}
         <button
           onClick={() => setIsEditingRepos(!isEditingRepos)}
           className={cn(


### PR DESCRIPTION
## Summary
- Fix TypeScript narrowing for `shared?.repoFilter` in GitHubCIMonitor — use `shared && shared.repoFilter` for proper narrowing
- Align font size between RepoSubtitle (`text-xs`) and WorkflowMatrix header (was `text-[11px]`, now `text-xs`)
- Add `min-w-0` on RepoSubtitle flex container and span for proper truncation of long repo names

## Test plan
- [ ] Long repo names truncate with ellipsis
- [ ] Font sizes consistent in workflow matrix header
- [ ] No TypeScript errors

Fixes #8697