### PR TITLE
fix: nightly release tag + Daily Issues demo data on Netlify

### DIFF
--- a/pkg/api/handlers/github_pipelines.go
+++ b/pkg/api/handlers/github_pipelines.go
@@ -753,11 +753,11 @@ func (h *GitHubPipelinesHandler) buildPulse(c *fiber.Ctx) (any, error) {
 					tag         string
 					publishedAt time.Time
 				}
+				// Include drafts — nightly releases on this repo are created as
+				// drafts and never promoted, so filtering them out leaves zero
+				// candidates. (#8666 follow-up)
 				candidates := make([]candidate, 0, len(arr))
 				for _, r := range arr {
-					if r.Draft {
-						continue
-					}
 					if !ghpNightlyTagRe.MatchString(r.TagName) {
 						continue
 					}
@@ -775,6 +775,29 @@ func (h *GitHubPipelinesHandler) buildPulse(c *fiber.Ctx) (any, error) {
 				if len(candidates) > 0 {
 					tag := candidates[0].tag
 					releaseTag = &tag
+				}
+			}
+		}
+	}
+
+	// Fallback: if no nightly release was found (releases may only exist as
+	// tags, not GitHub Release objects), try the tags API.
+	if releaseTag == nil {
+		tagRes, tagErr := h.ghGet(ctx, "/repos/"+pulseRepo+"/tags?per_page=10")
+		if tagErr == nil {
+			defer tagRes.Body.Close()
+			if tagRes.StatusCode == http.StatusOK {
+				var tags []struct {
+					Name string `json:"name"`
+				}
+				if err := json.NewDecoder(tagRes.Body).Decode(&tags); err == nil {
+					for _, t := range tags {
+						if ghpNightlyTagRe.MatchString(t.Name) {
+							tag := t.Name
+							releaseTag = &tag
+							break
+						}
+					}
 				}
 			}
 		}

--- a/web/netlify/functions/github-pipelines.mts
+++ b/web/netlify/functions/github-pipelines.mts
@@ -416,8 +416,10 @@ async function buildPulse(
         published_at?: string;
         draft?: boolean;
       }>;
+      // Include drafts — nightly releases on this repo are created as drafts
+      // and never promoted, so filtering them out leaves zero candidates.
       const candidates = (releases || [])
-        .filter((r) => !r.draft && r.tag_name && NIGHTLY_TAG_RE.test(r.tag_name))
+        .filter((r) => r.tag_name && NIGHTLY_TAG_RE.test(r.tag_name))
         .sort((a, b) => {
           const pa = a.published_at ? new Date(a.published_at).getTime() : 0;
           const pb = b.published_at ? new Date(b.published_at).getTime() : 0;
@@ -427,6 +429,21 @@ async function buildPulse(
     }
   } catch {
     // Non-fatal
+  }
+
+  // Fallback: if no nightly release found (they may only exist as tags,
+  // not GitHub Release objects), try the tags API.
+  if (!releaseTag) {
+    try {
+      const tagRes = await gh(`/repos/${targetRepo}/tags?per_page=10`, token);
+      if (tagRes.ok) {
+        const tags = (await tagRes.json()) as Array<{ name: string }>;
+        const match = (tags || []).find((t) => NIGHTLY_TAG_RE.test(t.name));
+        if (match) releaseTag = match.name;
+      }
+    } catch {
+      // Non-fatal
+    }
   }
 
   const last = runs[0];

--- a/web/src/components/cards/IssueActivityChart.tsx
+++ b/web/src/components/cards/IssueActivityChart.tsx
@@ -184,10 +184,12 @@ async function fetchAllPages(
       `${url}${separator}per_page=${GITHUB_PER_PAGE}&page=${page}`,
       { signal }
     )
-    if (!response.ok) break
-    // On Netlify (no Go backend), /api/github/* returns the SPA's index.html
-    // (text/html, status 200). Throw so the caller falls back to demo data
-    // instead of silently showing zeros from an empty JSON parse.
+    // Throw on non-2xx (MSW catch-all returns 503 in demo mode) AND on
+    // non-JSON (SPA catch-all returns HTML on Netlify). Both should trigger
+    // the demo data fallback instead of silently returning empty arrays.
+    if (!response.ok) {
+      throw new Error(`GitHub proxy returned ${response.status}`)
+    }
     const ct = response.headers.get('content-type') || ''
     if (!ct.includes('application/json')) {
       throw new Error('GitHub proxy not available — showing demo data')


### PR DESCRIPTION
## Summary
Fixes #8666

**Release tag:** Nightly releases are created as drafts — the `!r.draft` filter excluded ALL of them. Removed draft filter and added tags API fallback for releases that only exist as git tags.

**Daily Issues & PRs:** MSW catch-all returns JSON 503 for `/api/github/*`. The old code silently broke out of the pagination loop and returned empty data (zeros). Now throws on non-2xx so `generateDemoData()` runs.

## Test plan
- [ ] console.kubestellar.io: Nightly Release Pulse shows `v0.3.21-nightly.20260417`
- [ ] console.kubestellar.io: Daily Issues & PRs shows non-zero demo data
- [ ] localhost: both cards show live data

🤖 Generated with [Claude Code](https://claude.com/claude-code)