### PR TITLE
fix: resolve 7 arcade game bugs — key trap, chess AI, restart, styling

### DIFF
--- a/web/src/components/cards/KubeChess.tsx
+++ b/web/src/components/cards/KubeChess.tsx
@@ -149,6 +149,8 @@ const KNIGHT_TABLE = [
 const STORAGE_KEY = 'kube_chess_state'
 const STORAGE_KEY_STATS = 'kube_chess_stats'
 const AI_THINK_DELAY_MS = 300 // delay before AI computation to allow UI to update
+/** Maximum wall-clock time (ms) the AI is allowed to spend computing a move. */
+const AI_TIMEOUT_MS = 5000
 
 // Initialize the starting position
 function createInitialBoard(): Board {
@@ -561,11 +563,11 @@ function evaluateBoard(board: Board, state: GameState): number {
 const MAX_POSITIONS_EVALUATED = 50_000
 
 // Minimax with alpha-beta pruning and position count limit
-function minimax(state: GameState, depth: number, alpha: number, beta: number, maximizing: boolean, counter: { count: number }): number {
+function minimax(state: GameState, depth: number, alpha: number, beta: number, maximizing: boolean, counter: { count: number; deadline: number }): number {
   counter.count++
 
-  // Bail out if we've evaluated too many positions to prevent UI freeze
-  if (counter.count >= MAX_POSITIONS_EVALUATED) {
+  // Bail out if we've evaluated too many positions or exceeded time budget
+  if (counter.count >= MAX_POSITIONS_EVALUATED || performance.now() > counter.deadline) {
     return evaluateBoard(state.board, state)
   }
 
@@ -636,13 +638,13 @@ function findBestMove(state: GameState, depth: number): { from: { row: number; c
     return valueB - valueA
   })
 
-  const counter = { count: 0 }
+  const counter = { count: 0, deadline: performance.now() + AI_TIMEOUT_MS }
   let bestMove = moves[0]
   let bestScore = state.turn === 'white' ? -Infinity : Infinity
 
   for (const move of moves) {
-    // If we've hit the position limit, stop searching and use best so far
-    if (counter.count > MAX_POSITIONS_EVALUATED) break
+    // If we've hit the position limit or exceeded time budget, stop and use best so far
+    if (counter.count > MAX_POSITIONS_EVALUATED || performance.now() > counter.deadline) break
 
     const newState = makeMove(state, move.from, move.to)
     const score = minimax(newState, depth - 1, -Infinity, Infinity, state.turn === 'black', counter)
@@ -691,6 +693,8 @@ function KubeChessInternal() {
   const [difficulty, setDifficulty] = useState<1 | 2 | 3>(2) // 1=easy, 2=medium, 3=hard
   const [isThinking, setIsThinking] = useState(false)
   const isThinkingRef = useRef(false)
+  /** Incremented on reset/flip to signal in-flight AI setTimeout to bail out. */
+  const aiGenerationRef = useRef(0)
   const [showSettings, setShowSettings] = useState(false)
   const [promotionPending, setPromotionPending] = useState<{ from: { row: number; col: number }; to: { row: number; col: number } } | null>(null)
   const [stats, setStats] = useState(() => {
@@ -724,11 +728,20 @@ function KubeChessInternal() {
       isThinkingRef.current = true
       setIsThinking(true)
 
+      // Capture the current generation so we can detect reset/flip during compute
+      const generation = aiGenerationRef.current
+
       // Use setTimeout to allow UI to update before heavy computation
       const id = setTimeout(() => {
         try {
+          // Bail out if the game was reset/flipped while waiting
+          if (aiGenerationRef.current !== generation) return
+
           const depth = difficulty + 1 // 2, 3, or 4
           const bestMove = findBestMove(gameState, depth)
+
+          // Bail out if reset/flipped during computation
+          if (aiGenerationRef.current !== generation) return
 
           if (bestMove) {
             // UI commit: track repetition history.
@@ -828,8 +841,11 @@ function KubeChessInternal() {
     }
   }
 
-  // Reset game
+  // Reset game — bump generation to abort any in-flight AI computation
   const resetGame = () => {
+    aiGenerationRef.current++
+    isThinkingRef.current = false
+    setIsThinking(false)
     setGameState(createInitialState())
     setSelectedSquare(null)
     setValidMoves([])
@@ -837,8 +853,11 @@ function KubeChessInternal() {
     emitGameStarted('chess')
   }
 
-  // Flip board
+  // Flip board — bump generation to abort any in-flight AI computation
   const flipBoard = () => {
+    aiGenerationRef.current++
+    isThinkingRef.current = false
+    setIsThinking(false)
     setPlayerColor(prev => prev === 'white' ? 'black' : 'white')
   }
 

--- a/web/src/components/cards/KubeKart.tsx
+++ b/web/src/components/cards/KubeKart.tsx
@@ -150,22 +150,22 @@ export function KubeKart() {
     activeShieldRef.current = 0
   }, [])
 
-  // Get track curve at position
-  const getTrackCurve = (y: number): number => {
+  // Get track curve at position — stable ref for render/update deps
+  const getTrackCurve = useCallback((y: number): number => {
     const period = 400
     const phase = (y + trackScrollRef.current) / period
     return Math.sin(phase) * 0.3
-  }
+  }, [])
 
-  // Check if position is on track
-  const isOnTrack = (x: number): boolean => {
+  // Check if position is on track — stable ref for update deps
+  const isOnTrack = useCallback((x: number): boolean => {
     const trackLeft = (CANVAS_WIDTH - TRACK_WIDTH) / 2
     const trackRight = trackLeft + TRACK_WIDTH
     return x >= trackLeft + 20 && x <= trackRight - 20
-  }
+  }, [])
 
   // Update AI karts - drive straight at moderate speed in fixed lanes
-  const updateAI = (kart: Kart, index: number) => {
+  const updateAI = useCallback((kart: Kart, index: number) => {
     const maxAiSpeed = MAX_SPEED * (0.65 + index * 0.05)
     if (kart.speed < maxAiSpeed) {
       kart.speed += ACCELERATION * 0.6
@@ -186,7 +186,7 @@ export function KubeKart() {
 
     // Face forward
     kart.angle = FORWARD_ANGLE
-  }
+  }, [])
 
   // Game update
   const update = useCallback(() => {
@@ -502,6 +502,8 @@ export function KubeKart() {
   }, [gameState, initTrack, render])
 
   const startGame = () => {
+    cancelAnimationFrame(animationRef.current)
+    keysRef.current.clear()
     initTrack()
     raceTimeRef.current = 0
     setRaceTime(0)

--- a/web/src/components/cards/KubePong.tsx
+++ b/web/src/components/cards/KubePong.tsx
@@ -47,6 +47,8 @@ export function KubePong() {
   const [gameState, setGameState] = useState<'idle' | 'playing' | 'paused' | 'finished'>('idle')
   const [playerScore, setPlayerScore] = useState(0)
   const [aiScore, setAiScore] = useState(0)
+  const playerScoreRef = useRef(0)
+  const aiScoreRef = useRef(0)
   const [winner, setWinner] = useState<'player' | 'ai' | null>(null)
   const [difficulty, setDifficulty] = useState<'easy' | 'medium' | 'hard'>('medium')
   const [wins, setWins] = useState(() => {
@@ -79,14 +81,14 @@ export function KubePong() {
     hard: { speed: 5.5, reactionDelay: 0.1, errorMargin: 5 } }
 
   // Reset ball to center
-  const resetBall = (direction: number = 1) => {
+  const resetBall = useCallback((direction: number = 1) => {
     ballRef.current = {
       x: CANVAS_WIDTH / 2,
       y: CANVAS_HEIGHT / 2,
       vx: INITIAL_BALL_SPEED * direction,
       vy: (Math.random() - 0.5) * 4,
       speed: INITIAL_BALL_SPEED }
-  }
+  }, [])
 
   // Initialize game
   const initGame = useCallback(() => {
@@ -97,6 +99,8 @@ export function KubePong() {
       y: CANVAS_HEIGHT / 2 - PADDLE_HEIGHT / 2,
       score: 0 }
     resetBall(Math.random() > 0.5 ? 1 : -1)
+    playerScoreRef.current = 0
+    aiScoreRef.current = 0
     setPlayerScore(0)
     setAiScore(0)
     setWinner(null)
@@ -177,31 +181,35 @@ export function KubePong() {
     // Score
     if (ball.x < 0) {
       // AI scores
-      const newAiScore = aiScore + 1
+      aiScoreRef.current++
+      const newAiScore = aiScoreRef.current
       setAiScore(newAiScore)
       if (newAiScore >= WINNING_SCORE) {
         setWinner('ai')
         setGameState('finished')
-        emitGameEnded('pong', 'loss', playerScore)
+        emitGameEnded('pong', 'loss', playerScoreRef.current)
         return
       }
       resetBall(-1)
     } else if (ball.x > CANVAS_WIDTH) {
       // Player scores
-      const newPlayerScore = playerScore + 1
+      playerScoreRef.current++
+      const newPlayerScore = playerScoreRef.current
       setPlayerScore(newPlayerScore)
       if (newPlayerScore >= WINNING_SCORE) {
         setWinner('player')
-        const newWins = wins + 1
-        setWins(newWins)
-        localStorage.setItem('kubePongWins', newWins.toString())
+        setWins(prev => {
+          const newWins = prev + 1
+          localStorage.setItem('kubePongWins', newWins.toString())
+          return newWins
+        })
         setGameState('finished')
         emitGameEnded('pong', 'win', newPlayerScore)
         return
       }
       resetBall(1)
     }
-  }, [difficulty, aiScore, playerScore, resetBall, wins])
+  }, [difficulty, resetBall])
 
   // Render
   const render = useCallback(() => {
@@ -282,6 +290,8 @@ export function KubePong() {
   }, [gameState, initGame, render])
 
   const startGame = () => {
+    cancelAnimationFrame(animationRef.current)
+    keysRef.current.clear()
     initGame()
     setGameState('playing')
     emitGameStarted('pong')

--- a/web/src/components/cards/PodBrothers.tsx
+++ b/web/src/components/cards/PodBrothers.tsx
@@ -146,19 +146,19 @@ export function PodBrothers() {
     invincibilityRef.current = INVINCIBILITY_FRAMES
   }, [])
 
-  // Collision detection
-  const getTileAt = (x: number, y: number): number => {
+  // Collision detection — wrapped in useCallback for stable update() deps
+  const getTileAt = useCallback((x: number, y: number): number => {
     const col = Math.floor(x / TILE_SIZE)
     const row = Math.floor(y / TILE_SIZE)
     if (row < 0 || row >= levelRef.current.length || col < 0 || col >= levelRef.current[0].length) {
       return EMPTY
     }
     return levelRef.current[row][col]
-  }
+  }, [])
 
-  const isSolid = (tile: number): boolean => {
+  const isSolid = useCallback((tile: number): boolean => {
     return tile === BRICK || tile === GROUND || tile === PIPE || tile === QUESTION
-  }
+  }, [])
 
   // Game loop
   const update = useCallback(() => {
@@ -483,6 +483,8 @@ export function PodBrothers() {
   const startGame = () => {
     // Cancel any in-flight animation frame to prevent stale updates
     cancelAnimationFrame(animationRef.current)
+    // Clear held keys so stale presses don't carry into the new game
+    keysRef.current.clear()
     initLevel()
     setScore(0)
     livesRef.current = 3

--- a/web/src/components/cards/SudokuGame.tsx
+++ b/web/src/components/cards/SudokuGame.tsx
@@ -488,7 +488,7 @@ function SudokuGameInternal({ config: _config }: SudokuGameProps) {
 
       {/* Sudoku Grid */}
       <div className={`flex-1 flex items-center justify-center ${isMaximized ? 'mb-8' : 'mb-1.5'}`}>
-        <div className={`inline-grid grid-cols-9 gap-0 ${isMaximized ? 'border-4 rounded-lg' : 'border rounded'} border-purple-500/30 overflow-hidden bg-secondary/20`}>
+        <div className={`inline-grid grid-cols-9 gap-0 ${isMaximized ? 'border-4 rounded-lg' : 'border-2 rounded'} border-purple-400 overflow-hidden bg-secondary/20`}>
           {gameState.board.map((row, i) =>
             row.map((cell, j) => {
               const isSelected = selectedCell?.[0] === i && selectedCell?.[1] === j
@@ -508,8 +508,8 @@ function SudokuGameInternal({ config: _config }: SudokuGameProps) {
                   disabled={gameState.isComplete}
                   className={`
                     ${cellSize} font-medium transition-all
-                    ${rightBorder ? (isMaximized ? 'border-r-4' : 'border-r-2') + ' border-purple-500/50' : 'border-r border-border/30'}
-                    ${bottomBorder ? (isMaximized ? 'border-b-4' : 'border-b-2') + ' border-purple-500/50' : 'border-b border-border/30'}
+                    ${rightBorder ? (isMaximized ? 'border-r-4' : 'border-r-2') + ' border-purple-400' : 'border-r border-border/60'}
+                    ${bottomBorder ? (isMaximized ? 'border-b-4' : 'border-b-2') + ' border-purple-400' : 'border-b border-border/60'}
                     ${isSelected ? 'bg-purple-500/30 ring-2 ring-purple-500' : ''}
                     ${!isSelected && (isInSameRow || isInSameCol || isInSameBox) ? 'bg-purple-500/10' : ''}
                     ${cell.isOriginal ? 'text-foreground font-bold' : 'text-purple-400'}

--- a/web/src/hooks/useGameKeys.ts
+++ b/web/src/hooks/useGameKeys.ts
@@ -115,13 +115,28 @@ export function useGameKeyTracking(
       keysRef.current.delete(lowercase ? e.key.toLowerCase() : e.key)
     }
 
+    /** Release all held keys when the tab/window loses focus or becomes hidden. */
+    const handleBlur = () => {
+      keysRef.current.clear()
+    }
+
+    const handleVisibilityChange = () => {
+      if (document.hidden) {
+        keysRef.current.clear()
+      }
+    }
+
     window.addEventListener('keydown', handleKeyDown)
     window.addEventListener('keyup', handleKeyUp)
+    window.addEventListener('blur', handleBlur)
+    document.addEventListener('visibilitychange', handleVisibilityChange)
 
     const keys = keysRef.current
     return () => {
       window.removeEventListener('keydown', handleKeyDown)
       window.removeEventListener('keyup', handleKeyUp)
+      window.removeEventListener('blur', handleBlur)
+      document.removeEventListener('visibilitychange', handleVisibilityChange)
       keys.clear()
     }
   }, [containerRef, keysRef])


### PR DESCRIPTION
## Summary
- Release keyboard listeners on blur/visibilitychange to prevent WASD+Space key trap after leaving arcade games (#8702)
- Add 5-second timeout and generation-based abort for chess AI computation (#8703, #8704)
- Fix game restart from game-over state by clearing held keys and canceling stale animation frames (#8707, #8709, #8710)
- Fix stale closure over score state in Kube Pong using refs
- Increase sudoku grid line contrast for better visibility (#8706)
- Stabilize useCallback dependencies for game helper functions

## Test plan
- [ ] Play any arcade game, navigate away — WASD/Space/Arrow keys work normally in other pages
- [ ] Chess AI responds within 5 seconds even on hard difficulty
- [ ] Switch chess sides mid-game — no hang, AI starts thinking for new side
- [ ] Sudoku grid 3x3 box lines clearly visible in both themes
- [ ] Pod Brothers can restart after game over
- [ ] Kube Pong can restart after game finishes
- [ ] Kube Kart can restart after race finishes

Fixes #8702, Fixes #8703, Fixes #8704, Fixes #8706, Fixes #8707, Fixes #8709, Fixes #8710