### PR TITLE
fix: replace hardcoded English strings with i18n translations

### DIFF
--- a/web/src/components/cards/ArgoCDHealth.tsx
+++ b/web/src/components/cards/ArgoCDHealth.tsx
@@ -79,7 +79,8 @@ export function ArgoCDHealth({ config: _config }: ArgoCDHealthProps) {
   return (
     <div className="h-full flex flex-col min-h-card content-loaded">
       {/* Header */}
-      <div className="flex items-center justify-end mb-3">
+      <div className="flex items-center justify-between mb-3">
+        <h3 className="text-sm font-medium text-foreground truncate">{t('argoCDHealth.title')}</h3>
         <div className="flex items-center gap-1">
           <a
             href="https://argo-cd.readthedocs.io/"

--- a/web/src/components/cards/workload-detection/MLJobs.tsx
+++ b/web/src/components/cards/workload-detection/MLJobs.tsx
@@ -16,20 +16,25 @@ import { useTranslation } from 'react-i18next'
 type MLJob = typeof DEMO_ML_JOBS[number]
 type SortByOption = 'name' | 'status' | 'framework' | 'gpus'
 
-const SORT_OPTIONS = [
-  { value: 'name' as const, label: 'Name' },
-  { value: 'status' as const, label: 'Status' },
-  { value: 'framework' as const, label: 'Framework' },
-  { value: 'gpus' as const, label: 'GPUs' },
-]
+const SORT_OPTION_KEYS = [
+  { value: 'name' as const, labelKey: 'mlJobs.sortName' },
+  { value: 'status' as const, labelKey: 'mlJobs.sortStatus' },
+  { value: 'framework' as const, labelKey: 'mlJobs.sortFramework' },
+  { value: 'gpus' as const, labelKey: 'mlJobs.sortGpus' },
+] as const
 
 interface MLJobsProps {
   config?: Record<string, unknown>
 }
 
 export function MLJobs({ config: _config }: MLJobsProps) {
-  const { t } = useTranslation()
+  const { t } = useTranslation(['cards', 'common'])
   const { data: jobs, isLoading, isRefreshing, isDemoData } = useDemoData(DEMO_ML_JOBS)
+
+  const sortOptions = SORT_OPTION_KEYS.map(opt => ({
+    value: opt.value,
+    label: t(opt.labelKey),
+  }))
 
   const hasData = jobs.length > 0
   useCardLoadingState({
@@ -118,7 +123,7 @@ export function MLJobs({ config: _config }: MLJobsProps) {
             limit={itemsPerPage}
             onLimitChange={setItemsPerPage}
             sortBy={sorting.sortBy}
-            sortOptions={SORT_OPTIONS}
+            sortOptions={sortOptions}
             onSortChange={(v) => sorting.setSortBy(v as SortByOption)}
             sortDirection={sorting.sortDirection}
             onSortDirectionChange={sorting.setSortDirection}
@@ -130,7 +135,7 @@ export function MLJobs({ config: _config }: MLJobsProps) {
       <CardSearchInput
         value={filters.search}
         onChange={filters.setSearch}
-        placeholder={t('common.searchJobs')}
+        placeholder={t('mlJobs.searchJobs', 'Search jobs...')}
         className="mb-2"
       />
 

--- a/web/src/components/charts/DataTable.tsx
+++ b/web/src/components/charts/DataTable.tsx
@@ -1,3 +1,5 @@
+import { useTranslation } from 'react-i18next'
+
 interface Column<T> {
   key: keyof T
   header: string
@@ -20,6 +22,7 @@ export function DataTable<T extends Record<string, unknown>>({
   maxHeight = 300,
   onRowClick,
 }: DataTableProps<T>) {
+  const { t } = useTranslation()
   return (
     <div className="w-full">
       {title && (
@@ -68,7 +71,7 @@ export function DataTable<T extends Record<string, unknown>>({
         </table>
         {data.length === 0 && (
           <div className="px-3 py-8 text-center text-muted-foreground">
-            No data available
+            {t('common.noData')}
           </div>
         )}
       </div>

--- a/web/src/locales/en/cards.json
+++ b/web/src/locales/en/cards.json
@@ -2173,6 +2173,7 @@
     "syncNow": "Sync Now"
   },
   "argoCDHealth": {
+    "title": "ArgoCD Health",
     "healthy": "Healthy",
     "degraded": "Degraded",
     "progressing": "Progressing",
@@ -3583,5 +3584,12 @@
     "error": "Error",
     "sortByStatus": "Status",
     "sortByName": "Name"
+  },
+  "mlJobs": {
+    "sortName": "Name",
+    "sortStatus": "Status",
+    "sortFramework": "Framework",
+    "sortGpus": "GPUs",
+    "searchJobs": "Search jobs..."
   }
 }


### PR DESCRIPTION
## Summary
- ML Jobs sort dropdown: replace hardcoded English labels (Name, Status, Framework, GPUs) with `t()` calls using `cards:mlJobs.*` keys
- Data table empty state: replace hardcoded "No data available" with `t('common.noData')` 
- ArgoCD Health card: add visible title via `t('argoCDHealth.title')` in the card header

## Test plan
- [ ] ML Jobs sort dropdown shows translated labels
- [ ] Data table empty state uses translated string
- [ ] ArgoCD Health card shows a visible title
- [ ] No console errors
- [ ] Build passes

Fixes #8696, Fixes #8694, Fixes #8693