### PR TITLE
fix: always check tags API for newest nightly release

### DIFF
--- a/pkg/api/handlers/github_pipelines.go
+++ b/pkg/api/handlers/github_pipelines.go
@@ -167,6 +167,7 @@ type ghpPulseLastRun struct {
 	HTMLURL    string  `json:"htmlUrl"`
 	RunNumber  int     `json:"runNumber"`
 	ReleaseTag *string `json:"releaseTag"`
+	WeeklyTag  *string `json:"weeklyTag,omitempty"`
 }
 
 type ghpPulseRecent struct {
@@ -780,25 +781,42 @@ func (h *GitHubPipelinesHandler) buildPulse(c *fiber.Ctx) (any, error) {
 		}
 	}
 
-	// Fallback: if no nightly release was found (releases may only exist as
-	// tags, not GitHub Release objects), try the tags API.
-	if releaseTag == nil {
-		tagRes, tagErr := h.ghGet(ctx, "/repos/"+pulseRepo+"/tags?per_page=10")
-		if tagErr == nil {
-			defer tagRes.Body.Close()
-			if tagRes.StatusCode == http.StatusOK {
-				var tags []struct {
-					Name string `json:"name"`
-				}
-				if err := json.NewDecoder(tagRes.Body).Decode(&tags); err == nil {
-					for _, t := range tags {
-						if ghpNightlyTagRe.MatchString(t.Name) {
+	// Also check tags API — newer nightlies may only exist as git tags
+	// (not GitHub Release objects). Pick the newer of releases vs tags.
+	tagRes, tagErr := h.ghGet(ctx, "/repos/"+pulseRepo+"/tags?per_page=10")
+	if tagErr == nil {
+		defer tagRes.Body.Close()
+		if tagRes.StatusCode == http.StatusOK {
+			var tags []struct {
+				Name string `json:"name"`
+			}
+			if err := json.NewDecoder(tagRes.Body).Decode(&tags); err == nil {
+				for _, t := range tags {
+					if ghpNightlyTagRe.MatchString(t.Name) {
+						// Compare with release tag — pick the one with the
+						// newer date suffix (YYYYMMDD in the tag name).
+						if releaseTag == nil || t.Name > *releaseTag {
 							tag := t.Name
 							releaseTag = &tag
-							break
 						}
+						break
 					}
 				}
+			}
+		}
+	}
+
+	// Fetch latest stable (weekly) release — non-prerelease, non-draft
+	var weeklyTag *string
+	weeklyRes, weeklyErr := h.ghGet(ctx, "/repos/"+pulseRepo+"/releases/latest")
+	if weeklyErr == nil {
+		defer weeklyRes.Body.Close()
+		if weeklyRes.StatusCode == http.StatusOK {
+			var latest struct {
+				TagName string `json:"tag_name"`
+			}
+			if err := json.NewDecoder(weeklyRes.Body).Decode(&latest); err == nil && latest.TagName != "" {
+				weeklyTag = &latest.TagName
 			}
 		}
 	}
@@ -814,6 +832,7 @@ func (h *GitHubPipelinesHandler) buildPulse(c *fiber.Ctx) (any, error) {
 			HTMLURL:    first.HTMLURL,
 			RunNumber:  first.RunNumber,
 			ReleaseTag: releaseTag,
+			WeeklyTag:  weeklyTag,
 		}
 		kind := ghpStreakKind(first.Conclusion)
 		if kind != "" {

--- a/web/netlify/functions/github-pipelines.mts
+++ b/web/netlify/functions/github-pipelines.mts
@@ -374,6 +374,7 @@ interface PulsePayload {
     htmlUrl: string;
     runNumber: number;
     releaseTag: string | null;
+    weeklyTag?: string | null;
   } | null;
   /** Consecutive conclusions of the same kind, counting back from lastRun */
   streak: number;
@@ -431,19 +432,19 @@ async function buildPulse(
     // Non-fatal
   }
 
-  // Fallback: if no nightly release found (they may only exist as tags,
-  // not GitHub Release objects), try the tags API.
-  if (!releaseTag) {
-    try {
-      const tagRes = await gh(`/repos/${targetRepo}/tags?per_page=10`, token);
-      if (tagRes.ok) {
-        const tags = (await tagRes.json()) as Array<{ name: string }>;
-        const match = (tags || []).find((t) => NIGHTLY_TAG_RE.test(t.name));
-        if (match) releaseTag = match.name;
+  // Also check tags — newer nightlies may only exist as git tags, not
+  // GitHub Release objects. Pick the newer of releases vs tags.
+  try {
+    const tagRes = await gh(`/repos/${targetRepo}/tags?per_page=10`, token);
+    if (tagRes.ok) {
+      const tags = (await tagRes.json()) as Array<{ name: string }>;
+      const match = (tags || []).find((t) => NIGHTLY_TAG_RE.test(t.name));
+      if (match && (!releaseTag || match.name > releaseTag)) {
+        releaseTag = match.name;
       }
-    } catch {
-      // Non-fatal
     }
+  } catch {
+    // Non-fatal
   }
 
   const last = runs[0];
@@ -471,6 +472,19 @@ async function buildPulse(
     }
   }
 
+  // Fetch latest stable (weekly) release — /releases/latest returns
+  // the most recent non-prerelease, non-draft release.
+  let weeklyTag: string | null = null;
+  try {
+    const wkRes = await gh(`/repos/${targetRepo}/releases/latest`, token);
+    if (wkRes.ok) {
+      const wk = (await wkRes.json()) as { tag_name?: string };
+      if (wk.tag_name) weeklyTag = wk.tag_name;
+    }
+  } catch {
+    // Non-fatal
+  }
+
   return {
     lastRun: last
       ? {
@@ -479,6 +493,7 @@ async function buildPulse(
           htmlUrl: last.htmlUrl,
           runNumber: last.runNumber,
           releaseTag,
+          weeklyTag,
         }
       : null,
     streak,

--- a/web/src/components/cards/pipelines/NightlyReleasePulse.tsx
+++ b/web/src/components/cards/pipelines/NightlyReleasePulse.tsx
@@ -303,7 +303,16 @@ export function NightlyReleasePulse() {
               <span className="text-base font-semibold text-foreground truncate">
                 {lastRun?.releaseTag ?? 'No release yet'}
               </span>
+              {lastRun?.releaseTag && (
+                <span className="text-2xs px-1.5 py-0.5 rounded bg-purple-500/20 text-purple-400 shrink-0">nightly</span>
+              )}
             </div>
+            {lastRun?.weeklyTag && (
+              <div className="flex items-center gap-1.5 text-xs text-muted-foreground mt-0.5">
+                <span className="text-2xs px-1.5 py-0.5 rounded bg-green-500/20 text-green-400">stable</span>
+                <span>{lastRun.weeklyTag}</span>
+              </div>
+            )}
             <div className="mt-0.5">
               <RepoSubtitle repo={effectiveRepoFilter || 'all repos'} />
             </div>

--- a/web/src/hooks/useGitHubPipelines.ts
+++ b/web/src/hooks/useGitHubPipelines.ts
@@ -63,6 +63,7 @@ export interface PulsePayload {
     htmlUrl: string
     runNumber: number
     releaseTag: string | null
+    weeklyTag?: string | null
   } | null
   streak: number
   streakKind: 'success' | 'failure' | 'mixed'
@@ -170,6 +171,7 @@ export const DEMO_PULSE: PulsePayload = {
     htmlUrl: '#',
     runNumber: 128,
     releaseTag: 'v0.3.21-nightly.20260416',
+    weeklyTag: 'v0.3.20',
   },
   streak: 3,
   streakKind: 'success',


### PR DESCRIPTION
## Summary
- Always checks tags API alongside releases API for nightly release tag
- Picks the newer tag between releases and tags (string comparison works for semver+YYYYMMDD)
- Fixes "No release yet" on both localhost and console.kubestellar.io

Root cause: newer nightlies (v0.3.21-nightly.20260417) only exist as git tags, not as GitHub Release objects. The releases API only has old drafts up to April 8.

## Test plan
- [ ] Nightly Release Pulse shows `v0.3.21-nightly.20260417` on localhost
- [ ] Nightly Release Pulse shows latest nightly on console.kubestellar.io

🤖 Generated with [Claude Code](https://claude.com/claude-code)