### PR TITLE
fix: address Copilot review on nightly release tag logic

### DIFF
--- a/pkg/api/handlers/github_pipelines.go
+++ b/pkg/api/handlers/github_pipelines.go
@@ -746,32 +746,38 @@ func (h *GitHubPipelinesHandler) buildPulse(c *fiber.Ctx) (any, error) {
 			var arr []struct {
 				TagName     string  `json:"tag_name"`
 				PublishedAt *string `json:"published_at"`
+				CreatedAt   *string `json:"created_at"`
 				Draft       bool    `json:"draft"`
 			}
 			if dec := json.NewDecoder(relRes.Body).Decode(&arr); dec == nil && len(arr) > 0 {
-				// Filter to non-draft nightly releases and sort by published_at descending.
-				type candidate struct {
-					tag         string
-					publishedAt time.Time
-				}
 				// Include drafts — nightly releases on this repo are created as
 				// drafts and never promoted, so filtering them out leaves zero
-				// candidates. (#8666 follow-up)
+				// candidates. Sort by published_at (preferred) or created_at
+				// (fallback for drafts where published_at is unset). (#8666 follow-up)
+				type candidate struct {
+					tag       string
+					sortTime  time.Time
+				}
 				candidates := make([]candidate, 0, len(arr))
 				for _, r := range arr {
 					if !ghpNightlyTagRe.MatchString(r.TagName) {
 						continue
 					}
-					var pub time.Time
+					var sortTime time.Time
 					if r.PublishedAt != nil {
 						if parsed, pErr := time.Parse(time.RFC3339, *r.PublishedAt); pErr == nil {
-							pub = parsed
+							sortTime = parsed
 						}
 					}
-					candidates = append(candidates, candidate{tag: r.TagName, publishedAt: pub})
+					if sortTime.IsZero() && r.CreatedAt != nil {
+						if parsed, pErr := time.Parse(time.RFC3339, *r.CreatedAt); pErr == nil {
+							sortTime = parsed
+						}
+					}
+					candidates = append(candidates, candidate{tag: r.TagName, sortTime: sortTime})
 				}
 				sort.Slice(candidates, func(i, j int) bool {
-					return candidates[i].publishedAt.After(candidates[j].publishedAt)
+					return candidates[i].sortTime.After(candidates[j].sortTime)
 				})
 				if len(candidates) > 0 {
 					tag := candidates[0].tag

--- a/web/netlify/functions/github-pipelines.mts
+++ b/web/netlify/functions/github-pipelines.mts
@@ -415,17 +415,21 @@ async function buildPulse(
       const releases = (await rel.json()) as Array<{
         tag_name?: string;
         published_at?: string;
+        created_at?: string;
         draft?: boolean;
       }>;
       // Include drafts — nightly releases on this repo are created as drafts
       // and never promoted, so filtering them out leaves zero candidates.
+      // Sort by published_at when available, falling back to created_at for
+      // drafts where published_at is unset.
+      const sortTime = (r: { published_at?: string; created_at?: string }): number => {
+        if (r.published_at) return new Date(r.published_at).getTime();
+        if (r.created_at) return new Date(r.created_at).getTime();
+        return 0;
+      };
       const candidates = (releases || [])
         .filter((r) => r.tag_name && NIGHTLY_TAG_RE.test(r.tag_name))
-        .sort((a, b) => {
-          const pa = a.published_at ? new Date(a.published_at).getTime() : 0;
-          const pb = b.published_at ? new Date(b.published_at).getTime() : 0;
-          return pb - pa; // newest first
-        });
+        .sort((a, b) => sortTime(b) - sortTime(a)); // newest first
       releaseTag = candidates[0]?.tag_name ?? null;
     }
   } catch {


### PR DESCRIPTION
## Summary

Addresses all 4 Copilot review comments from PR #8711:

- **Go + Netlify**: Use `created_at` as fallback timestamp when `published_at` is unset on draft nightly releases, preventing zero-time values from corrupting sort order
- **Go**: Fixed stale comment that said "Filter to non-draft nightly releases" when code now intentionally includes drafts
- **Go + Netlify**: Added `created_at` field to the release struct/type so it is available for the fallback

Fixes #8714

## Test plan

- [ ] Verify nightly release tag is correctly identified when releases are drafts (published_at unset)
- [ ] Verify tags-API fallback still works when release timestamps are unusable
- [ ] Build passes (`npm run build` + `go build ./...`)