### PR TITLE
fix: reduce GitHub API load to prevent secondary rate limiting

### DIFF
--- a/pkg/api/handlers/github_pipelines.go
+++ b/pkg/api/handlers/github_pipelines.go
@@ -38,7 +38,7 @@ const (
 	ghpFailuresLimit         = 10
 	ghpFailuresOverfetch     = 30
 	ghpLogTailLines          = 500
-	ghpMatrixRunsPerRepo     = 500
+	ghpMatrixRunsPerRepo     = 200
 	ghpFlowMaxRunsPerRepo    = 8
 	ghpPulseWindowDays       = 14
 	ghpGitHubAPIBase         = "https://api.github.com"

--- a/web/netlify/functions/github-pipelines.mts
+++ b/web/netlify/functions/github-pipelines.mts
@@ -54,7 +54,7 @@ const FAILURES_OVERFETCH = 30;
 const LOG_TAIL_LINES = 500;
 
 /** How many workflow runs to pull per repo for the matrix view */
-const MATRIX_RUNS_PER_REPO = 500;
+const MATRIX_RUNS_PER_REPO = 200;
 
 /** How many in-progress/queued runs to pull per repo for the flow view */
 const FLOW_MAX_RUNS_PER_REPO = 8;

--- a/web/src/hooks/useGitHubPipelines.ts
+++ b/web/src/hooks/useGitHubPipelines.ts
@@ -11,8 +11,9 @@ import { useCache } from '../lib/cache'
 
 /** Client-side poll interval for the live flow card — matches Drasi's cadence */
 const FLOW_POLL_MS = 10_000
-/** Poll interval for the other cards */
-const DEFAULT_POLL_MS = 60_000
+/** Poll interval for GitHub pipeline data. Hourly to stay within
+ *  GitHub's rate limits. Manual refresh button still works instantly. */
+const DEFAULT_POLL_MS = 3_600_000
 /** Timeout for any /api/github-pipelines fetch */
 const FETCH_TIMEOUT_MS = 10_000
 


### PR DESCRIPTION
## Summary
- Matrix runs per repo: 500 → 200 (Go handler + Netlify Function)
- Auto-poll interval: 60s → 1 hour (manual refresh button still instant)
- Prevents GitHub secondary rate limit (abuse detection) which was blocking ALL API calls

Root cause: 500 runs × 6 repos × 5 pages × every 60s = ~1800 API calls/hour, triggering GitHub's abuse detection even though primary rate limit (5000/hr) wasn't exceeded.

## Test plan
- [ ] CI/CD cards load data on first visit
- [ ] Refresh button works immediately
- [ ] No rate limiting after 10+ minutes of usage

🤖 Generated with [Claude Code](https://claude.com/claude-code)