### PR TITLE
🐛 fix(alerts): stop notification spam — opt-in defaults, DND, severity cooldowns

### DIFF
--- a/web/src/contexts/AlertsContext.tsx
+++ b/web/src/contexts/AlertsContext.tsx
@@ -240,8 +240,21 @@ const MAX_ALERTS = 500
 /** Maximum number of resolved alerts to keep after a quota-exceeded prune. */
 const MAX_RESOLVED_ALERTS_AFTER_PRUNE = 50
 
-/** Minimum time (ms) between repeat notifications for the same alert */
-const NOTIFICATION_COOLDOWN_MS = 300_000 // 5 minutes
+/** Minimum time (ms) between repeat notifications for the same alert,
+ *  tiered by severity so critical alerts re-notify quickly while
+ *  lower-severity alerts don't spam the desktop. */
+const NOTIFICATION_COOLDOWN_BY_SEVERITY: Record<string, number> = {
+  critical: 5 * 60 * 1000,    // 5 min — urgent, re-notify quickly
+  warning: 30 * 60 * 1000,    // 30 min — important but not urgent
+  info: 4 * 60 * 60 * 1000,   // 4 hours — informational, minimal interruption
+}
+/** Fallback cooldown when severity is unknown */
+const DEFAULT_NOTIFICATION_COOLDOWN_MS = 30 * 60 * 1000 // 30 min
+
+/** Get the notification cooldown for a given severity level */
+function getNotificationCooldown(severity: string): number {
+  return NOTIFICATION_COOLDOWN_BY_SEVERITY[severity] ?? DEFAULT_NOTIFICATION_COOLDOWN_MS
+}
 
 /** Condition types that represent persistent cluster-level errors.
  *  These fire only once and suppress until the cluster recovers —
@@ -1343,7 +1356,7 @@ Please provide:
           const notifKey = alertDedupKey(rule.id, rule.condition.type, cluster.name)
           if (
             rule.channels?.some(ch => ch.type === 'browser' && ch.enabled) &&
-            (!notifiedAlertKeysRef.current.has(notifKey) || (Date.now() - (notifiedAlertKeysRef.current.get(notifKey) ?? 0)) > NOTIFICATION_COOLDOWN_MS)
+            (!notifiedAlertKeysRef.current.has(notifKey) || (Date.now() - (notifiedAlertKeysRef.current.get(notifKey) ?? 0)) > getNotificationCooldown(rule.severity))
           ) {
             setNotifiedKey(notifKey, Date.now())
             const firstNode = failedNodes[0]
@@ -1405,7 +1418,7 @@ Please provide:
           const notifKey = alertDedupKey(rule.id, rule.condition.type, cluster.name)
           if (
             rule.channels?.some(ch => ch.type === 'browser' && ch.enabled) &&
-            (!notifiedAlertKeysRef.current.has(notifKey) || (Date.now() - (notifiedAlertKeysRef.current.get(notifKey) ?? 0)) > NOTIFICATION_COOLDOWN_MS)
+            (!notifiedAlertKeysRef.current.has(notifKey) || (Date.now() - (notifiedAlertKeysRef.current.get(notifKey) ?? 0)) > getNotificationCooldown(rule.severity))
           ) {
             setNotifiedKey(notifKey, Date.now())
             sendNotificationWithDeepLink(
@@ -1500,7 +1513,7 @@ Please provide:
         const notifKey = alertDedupKey(rule.id, rule.condition.type, cluster)
         if (
           rule.channels?.some(ch => ch.type === 'browser' && ch.enabled) &&
-          (!notifiedAlertKeysRef.current.has(notifKey) || (Date.now() - (notifiedAlertKeysRef.current.get(notifKey) ?? 0)) > NOTIFICATION_COOLDOWN_MS)
+          (!notifiedAlertKeysRef.current.has(notifKey) || (Date.now() - (notifiedAlertKeysRef.current.get(notifKey) ?? 0)) > getNotificationCooldown(rule.severity))
         ) {
           setNotifiedKey(notifKey, Date.now())
           sendNotificationWithDeepLink(
@@ -1547,7 +1560,7 @@ Please provide:
           const notifKey = alertDedupKey(rule.id, rule.condition.type, cluster.name)
           const isPersistent = PERSISTENT_CLUSTER_CONDITIONS.has(rule.condition.type)
           const alreadyNotified = notifiedAlertKeysRef.current.has(notifKey)
-          const cooldownExpired = !alreadyNotified || (Date.now() - (notifiedAlertKeysRef.current.get(notifKey) ?? 0)) > NOTIFICATION_COOLDOWN_MS
+          const cooldownExpired = !alreadyNotified || (Date.now() - (notifiedAlertKeysRef.current.get(notifKey) ?? 0)) > getNotificationCooldown(rule.severity)
           // Persistent cluster errors: notify once, suppress until recovery.
           // Transient alerts: use the standard 5-minute cooldown.
           const shouldNotify = isPersistent ? !alreadyNotified : cooldownExpired
@@ -1602,7 +1615,7 @@ Please provide:
           const notifKey = alertDedupKey(rule.id, rule.condition.type, cluster.name)
           const isPersistent = PERSISTENT_CLUSTER_CONDITIONS.has(rule.condition.type)
           const alreadyNotified = notifiedAlertKeysRef.current.has(notifKey)
-          const cooldownExpired = !alreadyNotified || (Date.now() - (notifiedAlertKeysRef.current.get(notifKey) ?? 0)) > NOTIFICATION_COOLDOWN_MS
+          const cooldownExpired = !alreadyNotified || (Date.now() - (notifiedAlertKeysRef.current.get(notifKey) ?? 0)) > getNotificationCooldown(rule.severity)
           const shouldNotify = isPersistent ? !alreadyNotified : cooldownExpired
           if (
             rule.channels?.some(ch => ch.type === 'browser' && ch.enabled) && shouldNotify
@@ -1673,7 +1686,7 @@ Please provide:
           const notifKey = `${rule.id}::${guide.acronym}::${run.runNumber}`
           if (
             rule.channels?.some(ch => ch.type === 'browser' && ch.enabled) &&
-            (!notifiedAlertKeysRef.current.has(notifKey) || (Date.now() - (notifiedAlertKeysRef.current.get(notifKey) ?? 0)) > NOTIFICATION_COOLDOWN_MS)
+            (!notifiedAlertKeysRef.current.has(notifKey) || (Date.now() - (notifiedAlertKeysRef.current.get(notifKey) ?? 0)) > getNotificationCooldown(rule.severity))
           ) {
             setNotifiedKey(notifKey, Date.now())
             sendNotificationWithDeepLink(

--- a/web/src/hooks/useDeepLink.ts
+++ b/web/src/hooks/useDeepLink.ts
@@ -3,6 +3,7 @@ import { useSearchParams, useNavigate } from 'react-router-dom'
 import { useDrillDownActions } from './useDrillDown'
 import { scrollToCard } from '../lib/scrollToCard'
 import { ROUTES } from '../config/routes'
+import { isDNDActive } from './useDoNotDisturb'
 
 /**
  * Deep linking support for notifications and external links.
@@ -106,6 +107,11 @@ export function sendNotificationWithDeepLink(
   if (!('Notification' in window) || Notification.permission !== 'granted') {
     return
   }
+
+  // Respect Do Not Disturb / quiet hours — skip silently.
+  // isDNDActive reads from localStorage directly so it works in
+  // non-React contexts (evaluator callbacks in AlertsContext).
+  if (isDNDActive()) return
 
   const url = buildDeepLinkURL(params)
 

--- a/web/src/hooks/useDoNotDisturb.ts
+++ b/web/src/hooks/useDoNotDisturb.ts
@@ -1,0 +1,205 @@
+/**
+ * Do Not Disturb (DND) + Quiet Hours for desktop notifications.
+ *
+ * Three suppression modes, checked in order:
+ *   1. Explicit DND toggle (manual "pause all notifications")
+ *   2. Timed DND (pause for 1h / 4h / until tomorrow morning)
+ *   3. Quiet hours (recurring daily window, e.g. 22:00–08:00)
+ *
+ * State persisted in localStorage so it survives tab refreshes.
+ * The module-level `isDNDActive()` function can be called from
+ * non-React contexts (e.g. the notification dispatch in useDeepLink).
+ */
+
+import { useState, useEffect, useCallback } from 'react'
+
+const STORAGE_KEY = 'kc_dnd'
+
+/** How often to re-check timed DND expiry (ms) */
+const CHECK_INTERVAL_MS = 30_000
+
+export type TimedDuration = '1h' | '4h' | 'tomorrow'
+
+/** Stored DND state */
+interface DNDState {
+  /** Manual toggle — indefinite until turned off */
+  manualDND: boolean
+  /** Timed DND — epoch timestamp when it expires (0 = not active) */
+  timedDNDUntil: number
+  /** Quiet hours enabled */
+  quietHoursEnabled: boolean
+  /** Quiet hours start (24h format, e.g. "22:00") */
+  quietHoursStart: string
+  /** Quiet hours end (24h format, e.g. "08:00") */
+  quietHoursEnd: string
+}
+
+const DEFAULT_STATE: DNDState = {
+  manualDND: false,
+  timedDNDUntil: 0,
+  quietHoursEnabled: false,
+  quietHoursStart: '22:00',
+  quietHoursEnd: '08:00',
+}
+
+function loadState(): DNDState {
+  try {
+    const stored = localStorage.getItem(STORAGE_KEY)
+    if (stored) {
+      const parsed = JSON.parse(stored) as Partial<DNDState>
+      return { ...DEFAULT_STATE, ...parsed }
+    }
+  } catch {
+    // corrupt data
+  }
+  return { ...DEFAULT_STATE }
+}
+
+function saveState(state: DNDState): void {
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(state))
+  } catch {
+    // localStorage unavailable
+  }
+}
+
+/** Parse "HH:MM" to minutes since midnight */
+function parseTime(time: string): number {
+  const [h, m] = time.split(':').map(Number)
+  return (h || 0) * 60 + (m || 0)
+}
+
+/** Check if the current time falls within the quiet hours window.
+ *  Handles overnight windows (e.g. 22:00–08:00) correctly. */
+function isInQuietHours(start: string, end: string): boolean {
+  const now = new Date()
+  const currentMinutes = now.getHours() * 60 + now.getMinutes()
+  const startMinutes = parseTime(start)
+  const endMinutes = parseTime(end)
+
+  if (startMinutes <= endMinutes) {
+    // Same-day window (e.g. 09:00–17:00)
+    return currentMinutes >= startMinutes && currentMinutes < endMinutes
+  }
+  // Overnight window (e.g. 22:00–08:00)
+  return currentMinutes >= startMinutes || currentMinutes < endMinutes
+}
+
+/**
+ * Module-level check — callable from non-React contexts.
+ * Returns true if ANY suppression mode is active.
+ */
+export function isDNDActive(): boolean {
+  const state = loadState()
+  if (state.manualDND) return true
+  if (state.timedDNDUntil > 0 && Date.now() < state.timedDNDUntil) return true
+  if (state.quietHoursEnabled && isInQuietHours(state.quietHoursStart, state.quietHoursEnd)) return true
+  return false
+}
+
+/** Milliseconds remaining on timed DND (0 if not active) */
+export function getDNDRemaining(): number {
+  const state = loadState()
+  if (state.timedDNDUntil > 0) {
+    const remaining = state.timedDNDUntil - Date.now()
+    return remaining > 0 ? remaining : 0
+  }
+  return 0
+}
+
+/**
+ * React hook for DND state + controls.
+ */
+export function useDoNotDisturb() {
+  const [state, setState] = useState<DNDState>(loadState)
+  // Re-render periodically to update timed DND expiry display
+  const [, setTick] = useState(0)
+
+  useEffect(() => {
+    const interval = setInterval(() => {
+      const fresh = loadState()
+      // Auto-clear expired timed DND
+      if (fresh.timedDNDUntil > 0 && Date.now() >= fresh.timedDNDUntil) {
+        fresh.timedDNDUntil = 0
+        saveState(fresh)
+      }
+      setState(fresh)
+      setTick(t => t + 1)
+    }, CHECK_INTERVAL_MS)
+    return () => clearInterval(interval)
+  }, [])
+
+  const setManualDND = useCallback((on: boolean) => {
+    setState(prev => {
+      const next = { ...prev, manualDND: on, timedDNDUntil: 0 }
+      saveState(next)
+      return next
+    })
+  }, [])
+
+  const setTimedDND = useCallback((duration: TimedDuration) => {
+    const now = Date.now()
+    /** Milliseconds per hour */
+    const MS_PER_HOUR = 60 * 60 * 1000
+    let until: number
+    switch (duration) {
+      case '1h': until = now + MS_PER_HOUR; break
+      case '4h': until = now + 4 * MS_PER_HOUR; break
+      case 'tomorrow': {
+        const tomorrow = new Date()
+        tomorrow.setDate(tomorrow.getDate() + 1)
+        tomorrow.setHours(8, 0, 0, 0)
+        until = tomorrow.getTime()
+        break
+      }
+    }
+    setState(prev => {
+      const next = { ...prev, manualDND: false, timedDNDUntil: until }
+      saveState(next)
+      return next
+    })
+  }, [])
+
+  const clearDND = useCallback(() => {
+    setState(prev => {
+      const next = { ...prev, manualDND: false, timedDNDUntil: 0 }
+      saveState(next)
+      return next
+    })
+  }, [])
+
+  const setQuietHours = useCallback((enabled: boolean, start?: string, end?: string) => {
+    setState(prev => {
+      const next = {
+        ...prev,
+        quietHoursEnabled: enabled,
+        ...(start !== undefined && { quietHoursStart: start }),
+        ...(end !== undefined && { quietHoursEnd: end }),
+      }
+      saveState(next)
+      return next
+    })
+  }, [])
+
+  const isActive = state.manualDND ||
+    (state.timedDNDUntil > 0 && Date.now() < state.timedDNDUntil) ||
+    (state.quietHoursEnabled && isInQuietHours(state.quietHoursStart, state.quietHoursEnd))
+
+  const remaining = state.timedDNDUntil > 0
+    ? Math.max(0, state.timedDNDUntil - Date.now())
+    : 0
+
+  return {
+    isActive,
+    isManualDND: state.manualDND,
+    timedDNDUntil: state.timedDNDUntil,
+    remaining,
+    quietHoursEnabled: state.quietHoursEnabled,
+    quietHoursStart: state.quietHoursStart,
+    quietHoursEnd: state.quietHoursEnd,
+    setManualDND,
+    setTimedDND,
+    clearDND,
+    setQuietHours,
+  }
+}

--- a/web/src/types/alerts.ts
+++ b/web/src/types/alerts.ts
@@ -142,7 +142,7 @@ export const PRESET_ALERT_RULES: Omit<AlertRule, 'id' | 'createdAt' | 'updatedAt
       duration: 300, // 5 minutes
     },
     severity: 'critical',
-    channels: [{ type: 'browser', enabled: true, config: {} }],
+    channels: [{ type: 'browser', enabled: false, config: {} }],
     aiDiagnose: true,
   },
   {
@@ -154,7 +154,7 @@ export const PRESET_ALERT_RULES: Omit<AlertRule, 'id' | 'createdAt' | 'updatedAt
       duration: 60, // 1 minute
     },
     severity: 'warning',
-    channels: [{ type: 'browser', enabled: true, config: {} }],
+    channels: [{ type: 'browser', enabled: false, config: {} }],
     aiDiagnose: true,
   },
   {
@@ -167,7 +167,7 @@ export const PRESET_ALERT_RULES: Omit<AlertRule, 'id' | 'createdAt' | 'updatedAt
       duration: 600, // 10 minutes
     },
     severity: 'warning',
-    channels: [{ type: 'browser', enabled: true, config: {} }],
+    channels: [{ type: 'browser', enabled: false, config: {} }],
     aiDiagnose: true,
   },
   {
@@ -180,7 +180,7 @@ export const PRESET_ALERT_RULES: Omit<AlertRule, 'id' | 'createdAt' | 'updatedAt
       duration: 300, // 5 minutes
     },
     severity: 'info',
-    channels: [{ type: 'browser', enabled: true, config: {} }],
+    channels: [{ type: 'browser', enabled: false, config: {} }],
     aiDiagnose: false,
   },
   {
@@ -204,7 +204,7 @@ export const PRESET_ALERT_RULES: Omit<AlertRule, 'id' | 'createdAt' | 'updatedAt
       duration: 0, // Immediate — CronJob already ran checks
     },
     severity: 'warning',
-    channels: [{ type: 'browser', enabled: true, config: {} }],
+    channels: [{ type: 'browser', enabled: false, config: {} }],
     aiDiagnose: true,
   },
   {
@@ -217,7 +217,7 @@ export const PRESET_ALERT_RULES: Omit<AlertRule, 'id' | 'createdAt' | 'updatedAt
       duration: 300,
     },
     severity: 'warning',
-    channels: [{ type: 'browser', enabled: true, config: {} }],
+    channels: [{ type: 'browser', enabled: false, config: {} }],
     aiDiagnose: false,
   },
   {
@@ -229,7 +229,7 @@ export const PRESET_ALERT_RULES: Omit<AlertRule, 'id' | 'createdAt' | 'updatedAt
       duration: 0,
     },
     severity: 'warning',
-    channels: [{ type: 'browser', enabled: true, config: {} }],
+    channels: [{ type: 'browser', enabled: false, config: {} }],
     aiDiagnose: true,
   },
   {


### PR DESCRIPTION
## Summary
The alert notification system is broken — every new user gets spammed with desktop notifications for all 11 alert types the moment they grant permission. No global mute. 5-minute flat cooldown means non-critical conditions re-notify forever.

### What changed

**1. Opt-in defaults** (was: all 11 rules had browser notifications ON)
- Only 4 critical rules now default to browser notifications enabled: Disk Pressure, DNS Failure, Certificate Error, Cluster Unreachable
- 7 non-critical rules default to notifications OFF — users opt in to what they want

**2. Do Not Disturb + Quiet Hours** (new: `web/src/hooks/useDoNotDisturb.ts`)
- Manual DND toggle ("Until I turn it off")
- Timed DND ("For 1h / 4h / Until tomorrow morning")  
- Quiet hours (recurring daily window, e.g. 22:00–08:00, default disabled)
- All persisted in localStorage
- Module-level `isDNDActive()` callable from non-React contexts — wired into `sendNotificationWithDeepLink()` so ALL desktop notifications respect DND

**3. Severity-tiered cooldowns** (was: flat 5 min for everything)
- Critical: 5 min (re-notify quickly)
- Warning: 30 min
- Info: 4 hours
- Persistent conditions (certificate/cluster-unreachable) keep existing "fire once until resolved"

### What's NOT in this PR (follow-up)
- DND toggle UI in the alerts card header (hook is ready, UI wiring is next)
- Quiet hours config in Settings → Notifications (hook ready)
- Severity threshold picker in Settings ("Only notify for Critical")
- Auto-save of channel toggles in AlertRuleEditor (preference reset bug)

## Test plan
- [ ] Fresh localStorage: only 4 rules have browser channel enabled
- [ ] When DND active via `localStorage.setItem('kc_dnd', '{"manualDND":true}')`: no desktop notifications fire
- [ ] Warning-severity alert: 30-minute cooldown between repeats (not 5 min)
- [ ] Existing snooze per-alert still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)