### PR TITLE
fix: email validation + stats bar overflow

### DIFF
--- a/pkg/api/handlers/user.go
+++ b/pkg/api/handlers/user.go
@@ -1,13 +1,19 @@
 package handlers
 
 import (
-	"strings"
+	"net/mail"
+	"regexp"
 
 	"github.com/gofiber/fiber/v2"
 
 	"github.com/kubestellar/console/pkg/api/middleware"
 	"github.com/kubestellar/console/pkg/store"
 )
+
+// emailDomainRegexp requires a domain with at least one dot and a TLD of 2+ chars.
+// This complements net/mail.ParseAddress which handles RFC 5322 structure but
+// accepts bare domains like "user@localhost".
+var emailDomainRegexp = regexp.MustCompile(`^[^@]+@[^@]+\.[a-zA-Z]{2,}$`)
 
 // UserHandler handles user operations
 type UserHandler struct {
@@ -53,7 +59,12 @@ func (h *UserHandler) UpdateCurrentUser(c *fiber.Ctx) error {
 	}
 
 	if updates.Email != "" {
-		if !strings.Contains(updates.Email, "@") {
+		// RFC 5322 structural validation
+		if _, err := mail.ParseAddress(updates.Email); err != nil {
+			return fiber.NewError(fiber.StatusBadRequest, "invalid email format")
+		}
+		// Require a real domain with a TLD (e.g. "user@example.com", not "user@localhost")
+		if !emailDomainRegexp.MatchString(updates.Email) {
 			return fiber.NewError(fiber.StatusBadRequest, "invalid email format")
 		}
 		user.Email = updates.Email

--- a/web/src/components/widgets/WidgetExportModal.tsx
+++ b/web/src/components/widgets/WidgetExportModal.tsx
@@ -315,8 +315,8 @@ export function WidgetExportModal({ isOpen, onClose, cardType, mode: _mode = 'pi
                 </pre>
               </div>
             ) : (
-              <div className="flex-1 bg-secondary/50 rounded-lg p-4 flex items-center justify-center overflow-hidden">
-                <div style={{ transform: 'scale(1.5)', transformOrigin: 'center center' }}>
+              <div className="flex-1 bg-secondary/50 rounded-lg p-4 flex items-center justify-center overflow-hidden min-w-0 min-h-0">
+                <div className="max-w-full max-h-full overflow-hidden" style={{ transform: 'scale(1.5)', transformOrigin: 'center center' }}>
                   <WidgetPreview config={exportConfig} />
                 </div>
               </div>
@@ -1248,7 +1248,7 @@ function GenericCardPreview({ card }: { card: WidgetCardDefinition }) {
 // --- Stat previews ---
 function StatPreview({ statIds }: { statIds: string[] }) {
   return (
-    <div style={{ ...ps.card, display: 'flex', gap: '8px', padding: '8px 12px' }}>
+    <div style={{ ...ps.card, display: 'flex', flexWrap: 'wrap', gap: '8px', padding: '8px 12px', overflow: 'hidden' }}>
       {statIds.map((id) => {
         const stat = WIDGET_STATS[id]
         const value = SAMPLE_STATS[id] ?? '—'
@@ -1269,7 +1269,7 @@ function TemplatePreview({ templateId }: { templateId: string }) {
   if (!template) return null
 
   const statsRow = template.stats && template.stats.length > 0 ? (
-    <div style={{ display: 'flex', gap: PREV_XS, marginBottom: PREV_SM }}>
+    <div style={{ display: 'flex', flexWrap: 'wrap', gap: PREV_XS, marginBottom: PREV_SM, overflow: 'hidden' }}>
       {template.stats.map((id) => {
         const stat = WIDGET_STATS[id]
         const value = SAMPLE_STATS[id] ?? '—'


### PR DESCRIPTION
## Summary
- **Email validation (#8688)**: Replace weak `strings.Contains(email, "@")` check with `net/mail.ParseAddress` (RFC 5322) plus a domain regex requiring at least one dot and a 2+ char TLD. Rejects malformed emails like `a@`, `@@`, `user@localhost`.
- **Stats bar overflow (#8686)**: Add `flexWrap: 'wrap'`, `overflow: 'hidden'`, and `min-w-0`/`min-h-0` constraints to the widget export preview container and stat blocks so they wrap instead of overflowing when multiple stats are selected or the preview is scaled.

Fixes #8688, Fixes #8686

## Test plan
- [ ] Send PUT `/api/user` with invalid emails (`a@`, `@@`, `test@localhost`, `@example.com`) and verify 400 response
- [ ] Send PUT `/api/user` with valid email (`user@example.com`) and verify 200 response
- [ ] Open widget export modal, select Stats tab, select 5+ stat blocks -- verify no overflow in preview
- [ ] Open widget export modal, select Templates tab, verify stats row wraps properly