### PR TITLE
fix: refresh/retry button wiring for 4 cards

### DIFF
--- a/web/src/components/cards/ClusterNetwork.tsx
+++ b/web/src/components/cards/ClusterNetwork.tsx
@@ -15,13 +15,14 @@ interface ClusterNetworkProps {
 
 export function ClusterNetwork({ config }: ClusterNetworkProps) {
   const { t } = useTranslation(['cards', 'common'])
-  const { deduplicatedClusters: allClusters, isLoading } = useClusters()
+  const { deduplicatedClusters: allClusters, isLoading, isRefreshing } = useClusters()
   const [selectedCluster, setSelectedCluster] = useState<string>(config?.cluster || '')
   const { isDemoMode } = useDemoMode()
 
   // Report state to CardWrapper for refresh animation
   const { showSkeleton, showEmptyState } = useCardLoadingState({
     isLoading,
+    isRefreshing,
     hasAnyData: allClusters.length > 0,
     isDemoData: isDemoMode })
 

--- a/web/src/components/cards/GatewayStatus.tsx
+++ b/web/src/components/cards/GatewayStatus.tsx
@@ -66,7 +66,7 @@ export function GatewayStatus({ config: _config }: GatewayStatusProps) {
   const SORT_OPTIONS = SORT_OPTIONS_KEYS.map(opt => ({ value: opt.value, label: String(t(opt.labelKey)) }))
 
   // Fetch real gateway data with demo fallback
-  const { gateways: allGateways, isLoading, isDemoData, isFailed, consecutiveFailures } = useGatewayStatusHook()
+  const { gateways: allGateways, isLoading, isRefreshing, isDemoData, isFailed, consecutiveFailures, refetch } = useGatewayStatusHook()
   const hasError = isFailed
 
   // Compute stats from real data
@@ -86,6 +86,7 @@ export function GatewayStatus({ config: _config }: GatewayStatusProps) {
   // Report loading state to CardWrapper for skeleton/refresh behavior
   useCardLoadingState({
     isLoading,
+    isRefreshing,
     hasAnyData: (allGateways || []).length > 0,
     isDemoData,
     isFailed,
@@ -151,7 +152,7 @@ export function GatewayStatus({ config: _config }: GatewayStatusProps) {
         <AlertCircle className="w-12 h-12 text-red-400 mb-4" />
         <p className="text-sm text-muted-foreground mb-4">{t('gatewayStatus.loadFailed')}</p>
         <button
-          onClick={() => window.location.reload()}
+          onClick={() => refetch()}
           className="px-4 py-2 rounded-lg bg-purple-500 hover:bg-purple-600 text-white text-sm"
         >
           {t('common:common.retry')}

--- a/web/src/components/cards/WorkloadDeployment.tsx
+++ b/web/src/components/cards/WorkloadDeployment.tsx
@@ -548,16 +548,17 @@ export function WorkloadDeployment(_props: WorkloadDeploymentProps) {
   const isDemo = demoMode
 
   // Fetch real workloads from cache (handles demo mode internally via useCache)
-  const { data: realWorkloads, isLoading: workloadsLoading, isFailed, consecutiveFailures, isDemoFallback, refetch: refetchWorkloads } = useCachedWorkloads()
+  const { data: realWorkloads, isLoading: workloadsLoading, isRefreshing: workloadsRefreshing, isFailed, consecutiveFailures, isDemoFallback, refetch: refetchWorkloads } = useCachedWorkloads()
 
   // Report state to CardWrapper for refresh animation
   const { showSkeleton } = useCardLoadingState({
     isLoading: clustersLoading || workloadsLoading,
+    isRefreshing: workloadsRefreshing,
     hasAnyData: isDemo ? DEMO_WORKLOADS.length > 0 : (realWorkloads?.length ?? 0) > 0,
     isFailed,
     consecutiveFailures,
     isDemoData: isDemoFallback || isDemo,
-    errorMessage: isFailed ? 'Failed to load workloads' : undefined })
+    errorMessage: isFailed ? t('common.failedToLoadWorkloads') : undefined })
   const [localClusterFilter, setLocalClusterFilterState] = useState<string[]>(() => {
     try {
       const stored = localStorage.getItem(CLUSTER_FILTER_STORAGE_KEY)

--- a/web/src/hooks/useGatewayStatus.ts
+++ b/web/src/hooks/useGatewayStatus.ts
@@ -15,6 +15,7 @@ import { useState, useEffect, useCallback, useRef } from 'react'
 import { useClusters } from './useMCP'
 import { STORAGE_KEY_TOKEN } from '../lib/constants'
 import { FETCH_DEFAULT_TIMEOUT_MS } from '../lib/constants/network'
+import { registerRefetch } from '../lib/modeTransition'
 
 // ============================================================================
 // Constants
@@ -212,6 +213,7 @@ export interface UseGatewayStatusResult {
   gateways: Gateway[]
   isDemoData: boolean
   isLoading: boolean
+  isRefreshing: boolean
   isFailed: boolean
   consecutiveFailures: number
   lastRefresh: number | null
@@ -227,6 +229,7 @@ export function useGatewayStatus(): UseGatewayStatusResult {
   const [gateways, setGateways] = useState<Gateway[]>(cachedSnapshot?.data || [])
   const [isDemoData, setIsDemoData] = useState(cachedSnapshot?.isDemoData ?? true)
   const [isLoading, setIsLoading] = useState(!cachedSnapshot)
+  const [isRefreshing, setIsRefreshing] = useState(false)
   const [consecutiveFailures, setConsecutiveFailures] = useState(0)
   const [lastRefresh, setLastRefresh] = useState<number | null>(
     cachedSnapshot?.timestamp || null
@@ -236,6 +239,9 @@ export function useGatewayStatus(): UseGatewayStatusResult {
   const refetch = useCallback(async (silent = false) => {
     if (!silent && !initialLoadDone.current) {
       setIsLoading(true)
+    }
+    if (initialLoadDone.current) {
+      setIsRefreshing(true)
     }
 
     try {
@@ -279,6 +285,7 @@ export function useGatewayStatus(): UseGatewayStatusResult {
       saveToCache(demoGateways, true)
     } finally {
       setIsLoading(false)
+      setIsRefreshing(false)
     }
   }, [clusters])
 
@@ -288,6 +295,12 @@ export function useGatewayStatus(): UseGatewayStatusResult {
       refetch()
     }
   }, [clustersLoading]) // eslint-disable-line react-hooks/exhaustive-deps
+
+  // Register with the global refetch registry so the dashboard refresh button
+  // and mode transitions can trigger a data reload (#8679).
+  useEffect(() => {
+    return registerRefetch('gateway-status', () => refetch(false))
+  }, [refetch])
 
   // Auto-refresh
   useEffect(() => {
@@ -304,6 +317,7 @@ export function useGatewayStatus(): UseGatewayStatusResult {
     gateways,
     isDemoData,
     isLoading: isLoading || clustersLoading,
+    isRefreshing,
     isFailed: consecutiveFailures >= FAILURE_THRESHOLD,
     consecutiveFailures,
     lastRefresh,

--- a/web/src/locales/en/common.json
+++ b/web/src/locales/en/common.json
@@ -2507,6 +2507,7 @@
     "itemCount_other": "{{count}} {{item}}",
     "errorLoading": "Error loading data",
     "failedToFetch": "Failed to fetch {{resource}}",
+    "failedToLoadWorkloads": "Failed to load workloads",
     "connectToCluster": "Connect to a cluster to view data",
     "demoData": "Demo data",
     "liveData": "Live data",


### PR DESCRIPTION
## Summary

- **Gateway Status retry reloads page (#8685)**: Replaced `window.location.reload()` with `refetch()` from the `useGatewayStatus` hook. Also wired `isRefreshing` to `useCardLoadingState`.
- **Cluster Network refresh icon not animating (#8678)**: Destructured `isRefreshing` from `useClusters` and passed it to `useCardLoadingState` so the refresh spinner animates during background data updates.
- **Workload Deployment refresh icon + untranslated error (#8683)**: Destructured `isRefreshing` from `useCachedWorkloads` and passed it to `useCardLoadingState`. Replaced hardcoded error string with `t('common.failedToLoadWorkloads')`.
- **Dashboard refresh button broken for Gateway Status (#8679)**: Registered `useGatewayStatus` with the global `registerRefetch` registry so `triggerAllRefetches()` (called by the dashboard toolbar refresh button) reaches the gateway data hook.

Fixes #8685, Fixes #8678, Fixes #8683, Fixes #8679

## Test plan

- [ ] Click retry button on Gateway Status card in error state — should refetch data, not reload page
- [ ] Verify Cluster Network card shows refresh spinner when data updates in background
- [ ] Verify Workload Deployment card shows refresh spinner when data updates in background
- [ ] Click dashboard toolbar refresh button — all cards including Gateway Status should refetch
- [ ] Toggle demo mode on/off — Gateway Status card should transition correctly