### PR TITLE
feat: AI Diagnose button on failing CI/CD workflow items

### DIFF
--- a/web/src/components/cards/pipelines/NightlyReleasePulse.tsx
+++ b/web/src/components/cards/pipelines/NightlyReleasePulse.tsx
@@ -14,7 +14,7 @@ import { useState, useRef, useMemo } from 'react'
 import { createPortal } from 'react-dom'
 import {
   CheckCircle, XCircle, AlertTriangle, Clock, ExternalLink,
-  TrendingUp, TrendingDown, Minus, Loader2, Search,
+  TrendingUp, TrendingDown, Minus, Loader2, Search, Stethoscope,
 } from 'lucide-react'
 import { useDemoMode } from '../../../hooks/useDemoMode'
 import { useCardLoadingState } from '../CardDataContext'
@@ -28,6 +28,7 @@ import { usePipelineFilter } from './PipelineFilterContext'
 import { usePipelineData } from './PipelineDataContext'
 import { RepoSubtitle } from './RepoSubtitle'
 import { EmbedButton } from './EmbedButton'
+import { useMissions } from '../../../hooks/useMissions'
 import { cn } from '../../../lib/cn'
 
 /** Max dots per row */
@@ -40,6 +41,7 @@ const TREND_THRESHOLD = 0.1
 const MATRIX_DAYS = 14
 
 const WORKFLOW_URL_BASE = 'https://github.com'
+const TITLE_DIAGNOSE = 'Diagnose with AI'
 
 /** Extracted strings for ui-ux ratchet */
 const PLACEHOLDER_REPO = 'owner/repo'
@@ -189,6 +191,7 @@ function TrendIndicator({ passRate, trend }: { passRate: number; trend: 'up' | '
 // ---------------------------------------------------------------------------
 
 function WorkflowRow({ wf }: { wf: MatrixWorkflow }) {
+  const { startMission } = useMissions()
   const dots: DotInfo[] = useMemo(() =>
     [...wf.cells].reverse().slice(0, MAX_DOTS).map((c) => ({
       conclusion: c.conclusion as Conclusion, htmlUrl: c.htmlUrl, date: c.date,
@@ -196,6 +199,7 @@ function WorkflowRow({ wf }: { wf: MatrixWorkflow }) {
 
   const { passRate, trend } = useMemo(() => computeTrend(dots), [dots])
   const latest = dots[0]?.conclusion
+  const latestFailed = latest === 'failure' || latest === 'timed_out'
   const StatusIcon = !latest ? AlertTriangle
     : latest === 'success' ? CheckCircle
     : latest === 'failure' || latest === 'timed_out' ? XCircle
@@ -220,6 +224,21 @@ function WorkflowRow({ wf }: { wf: MatrixWorkflow }) {
         ))}
       </div>
       <TrendIndicator passRate={passRate} trend={trend} />
+      {latestFailed && (
+        <button
+          type="button"
+          onClick={() => startMission({
+            title: `Diagnose: ${wf.name}`,
+            description: `Diagnose failing workflow ${wf.name} on ${wf.repo}`,
+            type: 'troubleshoot',
+            initialPrompt: `Diagnose why the "${wf.name}" workflow failed on ${wf.repo}.\n\nRun URL: ${dots[0]?.htmlUrl ?? `${WORKFLOW_URL_BASE}/${wf.repo}/actions`}\n\nPlease:\n1. Check the workflow logs and identify the root cause.\n2. Tell me what went wrong, then ask:\n   - "Should I create a fix?"\n   - "Show me more details"\n3. If I say fix it, create a branch with the fix and open a PR.`,
+          })}
+          className="text-muted-foreground hover:text-blue-400 p-1 rounded hover:bg-blue-500/10"
+          title={TITLE_DIAGNOSE}
+        >
+          <Stethoscope className="w-3 h-3" />
+        </button>
+      )}
       <a href={`${WORKFLOW_URL_BASE}/${wf.repo}/actions`} target="_blank" rel="noopener noreferrer"
         className="ml-auto opacity-0 group-hover:opacity-100 transition-opacity p-0.5 rounded hover:bg-secondary"
         onClick={(e) => e.stopPropagation()}>

--- a/web/src/components/cards/pipelines/PipelineFlow.tsx
+++ b/web/src/components/cards/pipelines/PipelineFlow.tsx
@@ -13,7 +13,7 @@
  * cadence) so the flow looks live without hammering the function.
  */
 import { useState, useMemo, useRef, useLayoutEffect, useEffect, type CSSProperties } from 'react'
-import { RefreshCw, XCircle, ExternalLink } from 'lucide-react'
+import { RefreshCw, XCircle, ExternalLink, Stethoscope } from 'lucide-react'
 import { useReducedMotion } from 'framer-motion'
 import { useDemoMode } from '../../../hooks/useDemoMode'
 import { useCardLoadingState } from '../CardDataContext'
@@ -29,6 +29,7 @@ import { usePipelineFilter } from './PipelineFilterContext'
 import { usePipelineData } from './PipelineDataContext'
 import { RepoSubtitle } from './RepoSubtitle'
 import { EmbedButton } from './EmbedButton'
+import { useMissions } from '../../../hooks/useMissions'
 import { cn } from '../../../lib/cn'
 
 /** Flow-dot radius for active segments */
@@ -47,6 +48,7 @@ const MUTATION_TOAST_MS = 4000
 const LABEL_FILTER_REPO = 'Filter by repo'
 const LABEL_REFRESH = 'Refresh'
 const TITLE_OPEN_RUN = 'Open run on GitHub'
+const TITLE_DIAGNOSE = 'Diagnose with AI'
 
 function statusColor(status: Status, conclusion: Conclusion): string {
   if (status === 'in_progress') return 'text-blue-400'
@@ -124,6 +126,7 @@ interface RunRowProps {
 }
 
 function RunRow({ run, onCancel, canMutate, mutating }: RunRowProps) {
+  const { startMission } = useMissions()
   const containerRef = useRef<HTMLDivElement>(null)
   const triggerRef = useRef<HTMLDivElement>(null)
   const workflowRef = useRef<HTMLDivElement>(null)
@@ -226,12 +229,27 @@ function RunRow({ run, onCancel, canMutate, mutating }: RunRowProps) {
             key={job.id}
             ref={(el) => { jobRefs.current[job.id] = el }}
             className={cn(
-              'px-2 py-1 rounded border text-[11px] truncate',
+              'px-2 py-1 rounded border text-[11px] truncate flex items-center gap-1',
               statusBg(job.status, job.conclusion),
             )}
             title={`${job.name} — ${job.status}${job.conclusion ? ` (${job.conclusion})` : ''}`}
           >
-            <span className={statusColor(job.status, job.conclusion)}>{job.name}</span>
+            <span className={cn('truncate', statusColor(job.status, job.conclusion))}>{job.name}</span>
+            {(job.conclusion === 'failure' || job.conclusion === 'timed_out') && (
+              <button
+                type="button"
+                onClick={() => startMission({
+                  title: `Diagnose: ${job.name}`,
+                  description: `Diagnose failing job ${job.name} in workflow ${run.run.name} on ${run.run.repo}`,
+                  type: 'troubleshoot',
+                  initialPrompt: `Diagnose why the "${job.name}" job failed in workflow "${run.run.name}" on ${run.run.repo} (branch: ${run.run.headBranch}).\n\nRun URL: ${run.run.htmlUrl}\n\nPlease:\n1. Check the workflow logs and identify the root cause.\n2. Tell me what went wrong, then ask:\n   - "Should I create a fix?"\n   - "Show me more details"\n3. If I say fix it, create a branch with the fix and open a PR.`,
+                })}
+                className="text-muted-foreground hover:text-blue-400 p-1 rounded hover:bg-blue-500/10 shrink-0"
+                title={TITLE_DIAGNOSE}
+              >
+                <Stethoscope className="w-3 h-3" />
+              </button>
+            )}
           </div>
         ))}
         {hiddenJobCount > 0 && (

--- a/web/src/components/cards/pipelines/RecentFailures.tsx
+++ b/web/src/components/cards/pipelines/RecentFailures.tsx
@@ -3,7 +3,7 @@
  * tracked repos, with the first failing step and drill-down to the log.
  */
 import { useState, useMemo } from 'react'
-import { ExternalLink, RefreshCw, FileText } from 'lucide-react'
+import { ExternalLink, RefreshCw, FileText, Stethoscope } from 'lucide-react'
 import { useDemoMode } from '../../../hooks/useDemoMode'
 import { useCardLoadingState } from '../CardDataContext'
 import {
@@ -16,6 +16,7 @@ import { usePipelineData } from './PipelineDataContext'
 import { RepoSubtitle } from './RepoSubtitle'
 import { EmbedButton } from './EmbedButton'
 import { LogsModal } from './LogsModal'
+import { useMissions } from '../../../hooks/useMissions'
 import { cn } from '../../../lib/cn'
 
 /** Maximum ms duration we format compactly (1 hr). Over this, show "1h+" */
@@ -27,6 +28,7 @@ const LABEL_FILTER_REPO = 'Filter by repo'
 const LABEL_REFRESH = 'Refresh'
 const TITLE_VIEW_LOG = 'View log tail'
 const TITLE_OPEN_RUN = 'Open run on GitHub'
+const TITLE_DIAGNOSE = 'Diagnose with AI'
 
 function formatDuration(ms: number): string {
   if (ms < 1000) return `${ms}ms`
@@ -65,6 +67,7 @@ export function RecentFailures() {
   const refetch = hasUnified ? unifiedData.refetch : individual.refetch
   const { run: runMutation } = usePipelineMutations()
   const { isDemoMode } = useDemoMode()
+  const { startMission } = useMissions()
 
   const hasData = (data?.runs?.length ?? 0) > 0
   useCardLoadingState({ isLoading: isLoading && !hasData, hasAnyData: hasData, isDemoData: isDemoMode })
@@ -171,6 +174,19 @@ export function RecentFailures() {
                     {formatDuration(r.durationMs)}
                   </td>
                   <td className="py-1.5 pr-2 text-right whitespace-nowrap">
+                    <button
+                      type="button"
+                      onClick={() => startMission({
+                        title: `Diagnose: ${r.workflow}`,
+                        description: `Diagnose failing workflow ${r.workflow} on ${r.repo}`,
+                        type: 'troubleshoot',
+                        initialPrompt: `Diagnose why the "${r.workflow}" workflow failed on ${r.repo} (branch: ${r.branch}).\n\nRun URL: ${r.htmlUrl}\n\n${r.failedStep ? `Failed step: ${r.failedStep.stepName}` : ''}\n\nPlease:\n1. Check the workflow logs and identify the root cause.\n2. Tell me what went wrong, then ask:\n   - "Should I create a fix?"\n   - "Show me more details"\n3. If I say fix it, create a branch with the fix and open a PR.`,
+                      })}
+                      className="text-muted-foreground hover:text-blue-400 p-1 rounded hover:bg-blue-500/10"
+                      title={TITLE_DIAGNOSE}
+                    >
+                      <Stethoscope className="w-3 h-3" />
+                    </button>
                     {r.failedStep && (
                       <button
                         type="button"

--- a/web/src/components/cards/workload-monitor/GitHubCIMonitor.tsx
+++ b/web/src/components/cards/workload-monitor/GitHubCIMonitor.tsx
@@ -80,6 +80,8 @@ const SORT_OPTIONS = [
   { value: 'branch', label: 'Branch' },
 ]
 
+const TITLE_DIAGNOSE = 'Diagnose with AI'
+
 // Demo data for when GitHub API is not available
 const DEMO_WORKFLOWS: WorkflowRun[] = [
   { id: '1', name: 'CI / Build & Test', repo: 'kubestellar/kubestellar', status: 'completed', conclusion: 'success', branch: 'main', event: 'push', runNumber: 1234, createdAt: new Date(Date.now() - 300000).toISOString(), updatedAt: new Date(Date.now() - 60000).toISOString(), url: '#' },
@@ -494,7 +496,7 @@ export function GitHubCIMonitor({ config, ref }: GitHubCIMonitorProps & { ref?: 
                       initialPrompt: `Diagnose why the "${w.name}" workflow failed on ${w.repo} (branch: ${w.branch}).\n\nRun URL: ${w.url}\n\nPlease:\n1. Check the workflow logs and identify the root cause.\n2. Tell me what went wrong, then ask:\n   - "Should I create a fix?"\n   - "Show me more details"\n3. If I say fix it, create a branch with the fix and open a PR.`,
                     })}
                     className="text-muted-foreground hover:text-blue-400 p-1 rounded hover:bg-blue-500/10 shrink-0"
-                    title="Diagnose with AI"
+                    title={TITLE_DIAGNOSE}
                   >
                     <Stethoscope className="w-3 h-3" />
                   </button>

--- a/web/src/components/cards/workload-monitor/GitHubCIMonitor.tsx
+++ b/web/src/components/cards/workload-monitor/GitHubCIMonitor.tsx
@@ -1,7 +1,7 @@
 import { useState, useMemo, useImperativeHandle, type Ref } from 'react'
 import {
   GitBranch, AlertTriangle, CheckCircle, XCircle,
-  Clock, Loader2, ExternalLink, Key, Settings, Plus, X, Check } from 'lucide-react'
+  Clock, Loader2, ExternalLink, Key, Settings, Plus, X, Check, Stethoscope } from 'lucide-react'
 import { FETCH_EXTERNAL_TIMEOUT_MS } from '../../../lib/constants'
 import { Button } from '../../ui/Button'
 import { Skeleton } from '../../ui/Skeleton'
@@ -12,6 +12,7 @@ import { CardSearchInput, CardAIActions } from '../../../lib/cards/CardComponent
 import { useCardLoadingState } from '../CardDataContext'
 import { useCache } from '../../../lib/cache'
 import type { SortDirection } from '../../../lib/cards/cardHooks'
+import { useMissions } from '../../../hooks/useMissions'
 import { cn } from '../../../lib/cn'
 import { WorkloadMonitorAlerts } from './WorkloadMonitorAlerts'
 import type { MonitorIssue } from '../../../types/workloadMonitor'
@@ -94,6 +95,7 @@ const DEMO_WORKFLOWS: WorkflowRun[] = [
 
 export function GitHubCIMonitor({ config, ref }: GitHubCIMonitorProps & { ref?: Ref<GitHubCIMonitorRef> }) {
   const { t } = useTranslation()
+  const { startMission } = useMissions()
   const ghConfig = config as GitHubCIConfig | undefined
   const shared = usePipelineFilter()
 
@@ -482,11 +484,26 @@ export function GitHubCIMonitor({ config, ref }: GitHubCIMonitorProps & { ref?: 
                 {formatTimeAgo(w.updatedAt)}
               </span>
               {(w.conclusion === 'failure' || w.conclusion === 'timed_out') && (
-                <CardAIActions
-                  resource={{ kind: 'GitHubWorkflow', name: w.name, status: w.conclusion }}
-                  issues={[{ name: `${w.conclusion} on ${w.repo}/${w.branch}`, message: `Run #${w.runNumber}, event: ${w.event}` }]}
-                  showRepair={false}
-                />
+                <>
+                  <button
+                    type="button"
+                    onClick={() => startMission({
+                      title: `Diagnose: ${w.name}`,
+                      description: `Diagnose failing workflow ${w.name} on ${w.repo}`,
+                      type: 'troubleshoot',
+                      initialPrompt: `Diagnose why the "${w.name}" workflow failed on ${w.repo} (branch: ${w.branch}).\n\nRun URL: ${w.url}\n\nPlease:\n1. Check the workflow logs and identify the root cause.\n2. Tell me what went wrong, then ask:\n   - "Should I create a fix?"\n   - "Show me more details"\n3. If I say fix it, create a branch with the fix and open a PR.`,
+                    })}
+                    className="text-muted-foreground hover:text-blue-400 p-1 rounded hover:bg-blue-500/10 shrink-0"
+                    title="Diagnose with AI"
+                  >
+                    <Stethoscope className="w-3 h-3" />
+                  </button>
+                  <CardAIActions
+                    resource={{ kind: 'GitHubWorkflow', name: w.name, status: w.conclusion }}
+                    issues={[{ name: `${w.conclusion} on ${w.repo}/${w.branch}`, message: `Run #${w.runNumber}, event: ${w.event}` }]}
+                    showRepair={false}
+                  />
+                </>
               )}
               {w.url !== '#' && (
                 <a


### PR DESCRIPTION
## Summary
Fixes #8728

Adds a Stethoscope (🩺) button on every failed/timed_out workflow item across 4 CI/CD cards. Clicking launches an AI mission with full context (workflow name, repo, branch, run URL, failed step).

**Cards updated:**
| Card | Where button appears |
|------|---------------------|
| Recent Failures | Actions column on each failure row |
| Nightly Release Pulse | End of workflow row (only when latest run failed) |
| GitHub CI Monitor | Next to status badge on failed items |
| Live Runs (Pipeline Flow) | Inside failed job pills |

Mission prompt includes guided decision points: diagnose → "Should I create a fix?" → push + open PR.

## Test plan
- [ ] Recent Failures — Stethoscope visible on each row, launches mission
- [ ] Nightly Pulse — Stethoscope on workflows with red latest dot
- [ ] CI Monitor — Stethoscope on failed items only
- [ ] Pipeline Flow — Stethoscope inside red job pills

🤖 Generated with [Claude Code](https://claude.com/claude-code)