### PR TITLE
feat(alerts): DND toggle in alerts card + quiet hours in settings

### DIFF
--- a/web/src/components/cards/ActiveAlerts.tsx
+++ b/web/src/components/cards/ActiveAlerts.tsx
@@ -4,7 +4,9 @@ import {
   CheckCircle,
   Eye,
   EyeOff,
-  Server } from 'lucide-react'
+  Server,
+  Bell,
+  BellOff } from 'lucide-react'
 import { useAlerts } from '../../hooks/useAlerts'
 import { StatusBadge } from '../ui/StatusBadge'
 import { useGlobalFilters, type SeverityLevel } from '../../hooks/useGlobalFilters'
@@ -20,6 +22,16 @@ import { useTranslation } from 'react-i18next'
 import { useDemoMode } from '../../hooks/useDemoMode'
 import { NotificationVerifyIndicator } from './NotificationVerifyIndicator'
 import { AlertListItem } from './AlertListItem'
+import { useDoNotDisturb, type TimedDuration } from '../../hooks/useDoNotDisturb'
+
+/** Format remaining DND time as "Xh Ym" or "Ym" */
+function formatRemaining(ms: number): string {
+  const totalMinutes = Math.ceil(ms / 60_000)
+  const hours = Math.floor(totalMinutes / 60)
+  const minutes = totalMinutes % 60
+  if (hours > 0) return `${hours}h ${minutes}m`
+  return `${minutes}m`
+}
 
 // Stats summary row shown at the top of the alerts card
 function AlertStatsRow({ critical, warning, acknowledged }: { critical: number; warning: number; acknowledged: number }) {
@@ -86,6 +98,8 @@ export function ActiveAlerts() {
   const { missions, setActiveMission, openSidebar } = useMissions()
 
   const [showAcknowledged, setShowAcknowledged] = useState(false)
+  const [showDNDMenu, setShowDNDMenu] = useState(false)
+  const dnd = useDoNotDisturb()
 
   // Combine active and acknowledged alerts when toggle is on
   const allAlertsToShow = (() => {
@@ -230,6 +244,49 @@ export function ActiveAlerts() {
           )}
           {/* Browser notification verification indicator */}
           <NotificationVerifyIndicator />
+          {/* Do Not Disturb toggle */}
+          <div className="relative">
+            <button
+              onClick={() => dnd.isActive ? dnd.clearDND() : setShowDNDMenu(!showDNDMenu)}
+              className={`flex items-center gap-1 px-1.5 py-1 text-xs rounded-lg border transition-colors ${
+                dnd.isActive
+                  ? 'bg-yellow-500/20 border-yellow-500/30 text-yellow-400'
+                  : 'bg-secondary border-border text-muted-foreground hover:text-foreground'
+              }`}
+              title={dnd.isActive
+                ? `Notifications paused${dnd.remaining > 0 ? ` (${formatRemaining(dnd.remaining)})` : ''} — click to resume`
+                : 'Pause notifications'}
+            >
+              {dnd.isActive ? <BellOff className="w-3 h-3" /> : <Bell className="w-3 h-3" />}
+              {dnd.isActive && dnd.remaining > 0 && (
+                <span className="text-[10px]">{formatRemaining(dnd.remaining)}</span>
+              )}
+            </button>
+            {showDNDMenu && !dnd.isActive && (
+              <div className="absolute top-full left-0 mt-1 z-50 bg-popover border border-border rounded-lg shadow-lg py-1 min-w-[160px]">
+                {([
+                  ['1h', 'For 1 hour'],
+                  ['4h', 'For 4 hours'],
+                  ['tomorrow', 'Until tomorrow 8am'],
+                ] as [TimedDuration, string][]).map(([duration, label]) => (
+                  <button
+                    key={duration}
+                    onClick={() => { dnd.setTimedDND(duration); setShowDNDMenu(false) }}
+                    className="w-full text-left px-3 py-1.5 text-xs text-foreground hover:bg-muted/50 transition-colors"
+                  >
+                    {label}
+                  </button>
+                ))}
+                <div className="border-t border-border my-1" />
+                <button
+                  onClick={() => { dnd.setManualDND(true); setShowDNDMenu(false) }}
+                  className="w-full text-left px-3 py-1.5 text-xs text-foreground hover:bg-muted/50 transition-colors"
+                >
+                  Until I turn it off
+                </button>
+              </div>
+            )}
+          </div>
         </div>
 
         <div className="flex items-center gap-2">

--- a/web/src/components/settings/sections/BrowserNotificationSettings.tsx
+++ b/web/src/components/settings/sections/BrowserNotificationSettings.tsx
@@ -1,7 +1,8 @@
 import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import { Globe, Check, X } from 'lucide-react'
+import { Globe, Check, X, Moon } from 'lucide-react'
 import { isBrowserNotifVerified, setBrowserNotifVerified } from '../../../lib/notificationStatus'
+import { useDoNotDisturb } from '../../../hooks/useDoNotDisturb'
 
 /** Browser notification verification flow state */
 type BrowserNotifState = 'idle' | 'asked' | 'verified' | 'failed'
@@ -174,6 +175,56 @@ export function BrowserNotificationSettings() {
               {t('settings.notifications.browser.requestPermission')}
             </button>
           )}
+        </div>
+      )}
+
+      {/* Quiet Hours */}
+      <QuietHoursConfig />
+    </div>
+  )
+}
+
+/** Quiet hours configuration — recurring daily window where notifications are suppressed */
+function QuietHoursConfig() {
+  const dnd = useDoNotDisturb()
+
+  return (
+    <div className="space-y-3 pt-4 border-t border-border">
+      <div className="flex items-center gap-2">
+        <Moon className="w-4 h-4 text-muted-foreground" />
+        <h4 className="text-sm font-medium text-foreground">Quiet Hours</h4>
+      </div>
+      <p className="text-xs text-muted-foreground">
+        Suppress desktop notifications during a recurring daily window.
+      </p>
+
+      <label className="flex items-center gap-2 cursor-pointer">
+        <input
+          type="checkbox"
+          checked={dnd.quietHoursEnabled}
+          onChange={(e) => dnd.setQuietHours(e.target.checked)}
+          className="rounded border-border accent-primary"
+        />
+        <span className="text-sm text-foreground">
+          Don&apos;t notify between
+        </span>
+      </label>
+
+      {dnd.quietHoursEnabled && (
+        <div className="flex items-center gap-2 pl-6">
+          <input
+            type="time"
+            value={dnd.quietHoursStart}
+            onChange={(e) => dnd.setQuietHours(true, e.target.value)}
+            className="px-2 py-1 text-sm bg-secondary border border-border rounded text-foreground"
+          />
+          <span className="text-xs text-muted-foreground">and</span>
+          <input
+            type="time"
+            value={dnd.quietHoursEnd}
+            onChange={(e) => dnd.setQuietHours(true, undefined, e.target.value)}
+            className="px-2 py-1 text-sm bg-secondary border border-border rounded text-foreground"
+          />
         </div>
       )}
     </div>


### PR DESCRIPTION
## Summary
Follow-up to #8723 — wires the `useDoNotDisturb` hook into the UI.

### Alerts card header
- **Bell/BellOff toggle** with dropdown: "For 1h", "For 4h", "Until tomorrow 8am", "Until I turn it off"
- When DND active: yellow BellOff icon with remaining time (e.g. "2h 15m"), click to resume

### Settings → Notifications
- **Quiet Hours** section: enable toggle + start/end time pickers
- Default: disabled. Suggested: 22:00–08:00
- Persisted in localStorage

## Test plan
- [ ] Click bell icon in alerts card → dropdown shows 4 options
- [ ] Select "For 1 hour" → icon turns yellow with "59m" countdown, no notifications fire
- [ ] Click yellow icon → DND clears, notifications resume
- [ ] Settings → Notifications → enable quiet hours 22:00–08:00 → verify notifications suppressed during that window

🤖 Generated with [Claude Code](https://claude.com/claude-code)