### PR TITLE
feat: CI/CD stat blocks with repo-contextual metrics

### DIFF
--- a/web/src/components/cicd/CICD.tsx
+++ b/web/src/components/cicd/CICD.tsx
@@ -1,116 +1,45 @@
-import { useClusters, useDeployments } from '../../hooks/useMCP'
-import { useCachedProwJobs } from '../../hooks/useCachedData'
-import { useUniversalStats, createMergedStatValueGetter } from '../../hooks/useUniversalStats'
-import { StatBlockValue } from '../ui/StatsOverview'
 import { DashboardPage } from '../../lib/dashboards/DashboardPage'
 import { getDefaultCards } from '../../config/dashboards'
 import { RotatingTip } from '../ui/RotatingTip'
 import { PipelineFilterProvider, PipelineDataProvider, PipelineFilterBar } from '../cards/pipelines'
+import { useCICDStats } from './useCICDStats'
 
 const CICD_CARDS_KEY = 'kubestellar-cicd-cards'
 
 // Default cards for CI/CD dashboard
 const DEFAULT_CICD_CARDS = getDefaultCards('ci-cd')
 
+/**
+ * Inner dashboard that lives inside PipelineDataProvider so it can
+ * consume the unified pipeline data for stat calculations.
+ */
+function CICDDashboard() {
+  const { getStatValue, isLoading } = useCICDStats()
+
+  return (
+    <DashboardPage
+      title="CI/CD"
+      subtitle="Monitor continuous integration and deployment pipelines"
+      icon="GitPullRequest"
+      rightExtra={<RotatingTip page="ci-cd" />}
+      headerExtra={<PipelineFilterBar />}
+      storageKey={CICD_CARDS_KEY}
+      defaultCards={DEFAULT_CICD_CARDS}
+      statsType="ci-cd"
+      getStatValue={getStatValue}
+      isLoading={isLoading}
+      emptyState={{
+        title: 'CI/CD Dashboard',
+        description: 'Add cards to monitor pipelines, builds, and deployment status across your clusters.' }}
+    />
+  )
+}
+
 export function CICD() {
-  const { clusters, isLoading, isRefreshing: dataRefreshing, lastUpdated, refetch, error } = useClusters()
-  const { jobs: prowJobs, isLoading: prowLoading, status: prowStatus } = useCachedProwJobs()
-  const { deployments, isLoading: deploymentsLoading } = useDeployments()
-  const { getStatValue: getUniversalStatValue } = useUniversalStats()
-
-  // Filter reachable clusters
-  const reachableClusters = clusters.filter(c => c.reachable !== false)
-
-  // Calculate pipeline/job stats
-  const runningJobs = prowJobs.filter(j => j.state === 'pending' || j.state === 'running').length
-  const failedJobs = prowJobs.filter(j => j.state === 'failure' || j.state === 'error').length
-
-  // Count active deployments (currently deploying or recently deployed)
-  const deploymentsToday = deployments.filter(d => d.status === 'deploying' || d.status === 'running').length
-
-  // Determine if we have real data
-  const hasRealData = prowJobs.length > 0 || deployments.length > 0
-  const isDemoData = !hasRealData && !prowLoading && !deploymentsLoading
-
-  // Stats value getter for the configurable StatsOverview component
-  const getDashboardStatValue = (blockId: string): StatBlockValue => {
-    switch (blockId) {
-      case 'clusters':
-        return { value: reachableClusters.length, sublabel: 'clusters', isClickable: false }
-      case 'pipelines':
-        return {
-          value: prowJobs.length,
-          sublabel: `${runningJobs} running`,
-          isClickable: false,
-          isDemo: prowJobs.length === 0 && !prowLoading
-        }
-      case 'running_jobs':
-        return {
-          value: runningJobs,
-          sublabel: 'running jobs',
-          isClickable: false,
-          isDemo: prowJobs.length === 0 && !prowLoading
-        }
-      case 'failed_jobs':
-        return {
-          value: failedJobs,
-          sublabel: 'failed jobs',
-          isClickable: false,
-          isDemo: prowJobs.length === 0 && !prowLoading
-        }
-      case 'success_rate': {
-        const successRate = prowStatus?.successRate || 0
-        return {
-          value: `${Math.round(successRate)}%`,
-          sublabel: 'success rate',
-          isClickable: false,
-          isDemo: prowJobs.length === 0 && !prowLoading
-        }
-      }
-      case 'deployments':
-        return {
-          value: deploymentsToday,
-          sublabel: 'deployments today',
-          isClickable: false,
-          isDemo: deployments.length === 0 && !deploymentsLoading
-        }
-      default:
-        return { value: '-' }
-    }
-  }
-
-  const getStatValue = (blockId: string) => createMergedStatValueGetter(getDashboardStatValue, getUniversalStatValue)(blockId)
-
   return (
     <PipelineFilterProvider>
     <PipelineDataProvider>
-      <DashboardPage
-        title="CI/CD"
-        subtitle="Monitor continuous integration and deployment pipelines"
-        icon="GitPullRequest"
-        rightExtra={<RotatingTip page="ci-cd" />}
-        headerExtra={<PipelineFilterBar />}
-        storageKey={CICD_CARDS_KEY}
-        defaultCards={DEFAULT_CICD_CARDS}
-        statsType="ci-cd"
-        getStatValue={getStatValue}
-        onRefresh={refetch}
-        isLoading={isLoading || prowLoading || deploymentsLoading}
-        isRefreshing={dataRefreshing}
-        lastUpdated={lastUpdated}
-        hasData={reachableClusters.length > 0 || hasRealData}
-        isDemoData={isDemoData}
-        emptyState={{
-          title: 'CI/CD Dashboard',
-          description: 'Add cards to monitor pipelines, builds, and deployment status across your clusters.' }}
-      >
-        {error && (
-          <div className="mb-4 p-4 rounded-lg bg-red-500/10 border border-red-500/20 text-red-400">
-            <div className="font-medium">Error loading cluster data</div>
-            <div className="text-sm text-muted-foreground">{error}</div>
-          </div>
-        )}
-      </DashboardPage>
+      <CICDDashboard />
     </PipelineDataProvider>
     </PipelineFilterProvider>
   )

--- a/web/src/components/cicd/useCICDStats.ts
+++ b/web/src/components/cicd/useCICDStats.ts
@@ -1,0 +1,212 @@
+/**
+ * useCICDStats
+ *
+ * Provides stat block values for the CI/CD dashboard Stats Overview bar.
+ * Reads from PipelineDataContext (unified fetch) so values update
+ * instantly when the user changes the repo filter.
+ */
+
+import { useCallback, useMemo } from 'react'
+import type { StatBlockValue } from '../ui/StatsOverview'
+import { usePipelineData } from '../cards/pipelines/PipelineDataContext'
+import type { Conclusion, FlowRun } from '../../hooks/useGitHubPipelines'
+
+/** Number of days used for the pass-rate calculation window */
+const PASS_RATE_WINDOW_DAYS = 14
+
+/** Milliseconds in 24 hours — used to filter recent failures */
+const MS_PER_24H = 24 * 60 * 60 * 1000
+
+/** Percentage thresholds for pass-rate coloring */
+const PASS_RATE_GOOD_PCT = 90
+const PASS_RATE_WARN_PCT = 70
+
+/** Maximum value for pass-rate (100%) — used as gauge max */
+const PASS_RATE_MAX = 100
+
+/** Milliseconds per minute — used for duration formatting */
+const MS_PER_MINUTE = 60_000
+
+/** Whether a conclusion counts as a "pass" */
+function isPassing(c: Conclusion): boolean {
+  return c === 'success' || c === 'skipped' || c === 'neutral'
+}
+
+/** Format milliseconds as a human-readable duration string */
+function formatDuration(ms: number): string {
+  const minutes = Math.round(ms / MS_PER_MINUTE)
+  if (minutes < 1) return '<1m'
+  if (minutes < 60) return `${minutes}m` // eslint-disable-line @typescript-eslint/no-magic-numbers
+  const hours = Math.floor(minutes / 60) // eslint-disable-line @typescript-eslint/no-magic-numbers
+  const remainder = minutes % 60 // eslint-disable-line @typescript-eslint/no-magic-numbers
+  return remainder > 0 ? `${hours}h ${remainder}m` : `${hours}h`
+}
+
+export function useCICDStats() {
+  const pipelineData = usePipelineData()
+
+  // Memoize computed values from pipeline data
+  const computed = useMemo(() => {
+    if (!pipelineData) {
+      return {
+        passRate: 0,
+        totalRuns: 0,
+        passCount: 0,
+        failed24h: 0,
+        avgDurationMs: 0,
+        streak: 0,
+        streakKind: 'mixed' as const,
+        totalWorkflows: 0,
+        openPRs: 0,
+        isDemo: true,
+      }
+    }
+
+    const { matrix, pulse, failures, flow } = pipelineData
+
+    // --- Pass Rate (14-day window from matrix) ---
+    let totalCells = 0
+    let passingCells = 0
+    for (const wf of (matrix?.workflows || [])) {
+      for (const cell of (wf.cells || [])) {
+        if (cell.conclusion !== null) {
+          totalCells++
+          if (isPassing(cell.conclusion)) passingCells++
+        }
+      }
+    }
+    const passRate = totalCells > 0 ? Math.round((passingCells / totalCells) * PASS_RATE_MAX) : 0
+
+    // --- Failed (24h) ---
+    const now = Date.now()
+    const cutoff24h = now - MS_PER_24H
+    const failed24h = (failures?.runs || []).filter(
+      (r) => new Date(r.createdAt).getTime() >= cutoff24h
+    ).length
+
+    // --- Avg Duration (from flow runs that have completed) ---
+    const completedRuns = (flow?.runs || []).filter(
+      (r: FlowRun) => r.run.status === 'completed' && r.run.createdAt && r.run.updatedAt
+    )
+    let avgDurationMs = 0
+    if (completedRuns.length > 0) {
+      const totalMs = completedRuns.reduce((sum: number, r: FlowRun) => {
+        const start = new Date(r.run.createdAt).getTime()
+        const end = new Date(r.run.updatedAt).getTime()
+        return sum + (end - start)
+      }, 0)
+      avgDurationMs = totalMs / completedRuns.length
+    }
+
+    // --- Nightly Streak (from pulse data) ---
+    const streak = pulse?.streak ?? 0
+    const streakKind = pulse?.streakKind ?? 'mixed'
+
+    // --- Total Workflows (unique workflow names across all repos in matrix) ---
+    const workflowNames = new Set<string>()
+    for (const wf of (matrix?.workflows || [])) {
+      workflowNames.add(wf.name)
+    }
+    const totalWorkflows = workflowNames.size
+
+    // --- Open PRs (count from flow runs triggered by pull_request) ---
+    const prNumbers = new Set<string>()
+    for (const r of (flow?.runs || [])) {
+      if (r.run.event === 'pull_request' && r.run.pullRequests) {
+        for (const pr of r.run.pullRequests) {
+          prNumbers.add(`${r.run.repo}#${pr.number}`)
+        }
+      }
+    }
+    const openPRs = prNumbers.size
+
+    // Check if data is demo (all from demo fixtures)
+    const isDemo = pipelineData.isFailed || (
+      totalCells === 0 && completedRuns.length === 0 && streak === 0
+    )
+
+    return {
+      passRate,
+      totalRuns: totalCells,
+      passCount: passingCells,
+      failed24h,
+      avgDurationMs,
+      streak,
+      streakKind,
+      totalWorkflows,
+      openPRs,
+      isDemo,
+    }
+  }, [pipelineData])
+
+  const getStatValue = useCallback((blockId: string): StatBlockValue => {
+    switch (blockId) {
+      case 'cicd_pass_rate': {
+        const sublabel = computed.passRate >= PASS_RATE_GOOD_PCT
+          ? 'Healthy'
+          : computed.passRate >= PASS_RATE_WARN_PCT
+            ? 'Needs attention'
+            : 'Critical'
+        return {
+          value: computed.passRate,
+          sublabel: `${sublabel} (${PASS_RATE_WINDOW_DAYS}d)`,
+          max: PASS_RATE_MAX,
+          isDemo: computed.isDemo,
+          modeHints: ['ring', 'gauge', 'horseshoe', 'numeric'],
+        }
+      }
+
+      case 'cicd_open_prs':
+        return {
+          value: computed.openPRs,
+          sublabel: 'with active runs',
+          isDemo: computed.isDemo,
+        }
+
+      case 'cicd_failed_24h':
+        return {
+          value: computed.failed24h,
+          sublabel: computed.failed24h > 0 ? 'needs attention' : 'all clear',
+          isDemo: computed.isDemo,
+          modeHints: ['numeric', 'heatmap', 'trend'],
+        }
+
+      case 'cicd_avg_duration': {
+        const formatted = computed.avgDurationMs > 0
+          ? formatDuration(computed.avgDurationMs)
+          : '-'
+        return {
+          value: formatted,
+          sublabel: 'avg run time',
+          isDemo: computed.isDemo,
+        }
+      }
+
+      case 'cicd_streak': {
+        const prefix = computed.streakKind === 'success' ? '' : ''
+        const label = computed.streakKind === 'success'
+          ? `${computed.streak} passing`
+          : computed.streakKind === 'failure'
+            ? `${computed.streak} failing`
+            : 'mixed'
+        return {
+          value: computed.streak,
+          sublabel: `${prefix}${label}`,
+          isDemo: computed.isDemo,
+        }
+      }
+
+      case 'cicd_total_workflows':
+        return {
+          value: computed.totalWorkflows,
+          sublabel: 'unique workflows',
+          isDemo: computed.isDemo,
+        }
+
+      default:
+        return { value: '-' }
+    }
+  }, [computed])
+
+  return { getStatValue, isLoading: pipelineData?.isLoading ?? false }
+}

--- a/web/src/components/ui/StatsBlockDefinitions.ts
+++ b/web/src/components/ui/StatsBlockDefinitions.ts
@@ -424,6 +424,18 @@ export const ACMM_STAT_BLOCKS: StatBlockConfig[] = [
 ]
 
 /**
+ * Default stat blocks for the CI/CD dashboard
+ */
+export const CICD_STAT_BLOCKS: StatBlockConfig[] = [
+  { id: 'cicd_pass_rate', name: 'Pass Rate', icon: 'Percent', visible: true, color: 'green', displayMode: 'ring' },
+  { id: 'cicd_open_prs', name: 'Open PRs', icon: 'ClipboardList', visible: true, color: 'blue' },
+  { id: 'cicd_failed_24h', name: 'Failed (24h)', icon: 'XCircle', visible: true, color: 'red' },
+  { id: 'cicd_avg_duration', name: 'Avg Duration', icon: 'Clock', visible: true, color: 'cyan' },
+  { id: 'cicd_streak', name: 'Nightly Streak', icon: 'Activity', visible: true, color: 'purple', displayMode: 'sparkline' },
+  { id: 'cicd_total_workflows', name: 'Total Workflows', icon: 'Workflow', visible: true, color: 'yellow' },
+]
+
+/**
  * Default stat blocks for the Drasi dashboard
  */
 export const DRASI_STAT_BLOCKS: StatBlockConfig[] = [
@@ -477,6 +489,7 @@ export const ALL_STAT_BLOCKS: StatBlockConfig[] = (() => {
     ...KAGENTI_STAT_BLOCKS,
     ...CLUSTER_ADMIN_STAT_BLOCKS,
     ...MULTI_TENANCY_STAT_BLOCKS,
+    ...CICD_STAT_BLOCKS,
     ...DRASI_STAT_BLOCKS,
     ...ACMM_STAT_BLOCKS,
     ...AI_AGENTS_STAT_BLOCKS,
@@ -540,7 +553,7 @@ export function getDefaultStatBlocks(dashboardType: DashboardStatsType): StatBlo
     case 'multi-tenancy':
       return MULTI_TENANCY_STAT_BLOCKS
     case 'ci-cd':
-      return GITOPS_STAT_BLOCKS
+      return CICD_STAT_BLOCKS
     case 'drasi':
       return DRASI_STAT_BLOCKS
     case 'acmm':
@@ -594,6 +607,11 @@ export const STAT_DISPLAY_MODE_DEFAULTS: Record<string, StatDisplayMode> = {
 
   // Pods — trend over time
   'pods:total_pods': 'sparkline',
+
+  // CI/CD — pass rate as ring, streak as sparkline, failed as heatmap
+  'ci-cd:cicd_pass_rate': 'ring',
+  'ci-cd:cicd_streak': 'sparkline',
+  'ci-cd:cicd_failed_24h': 'heatmap',
 
   // Multi-tenancy — isolation score as gauge, components as ring, tenants as sparkline
   'multi-tenancy:isolation_score': 'gauge',


### PR DESCRIPTION
## Summary
Fixes #8727

Replaces generic cluster stat blocks on the CI/CD dashboard with 6 repo-contextual CI metrics:

| Stat | Source | Display |
|------|--------|---------|
| Pass Rate | Matrix (14d conclusions) | Ring/percentage |
| Open PRs | Flow (deduplicated PR refs) | Count |
| Failed (24h) | Failures (24h cutoff) | Red count |
| Avg Duration | Flow (created→updated delta) | Minutes |
| Nightly Streak | Pulse (streak/streakKind) | Count + kind |
| Total Workflows | Matrix (unique names) | Count |

All stats powered by the unified `view=all` fetch — **zero extra API calls**.

Follows the `useACMMStats` pattern: `useCICDStats()` hook + inner `CICDDashboard` component inside `PipelineDataProvider`.

## Test plan
- [ ] CI/CD dashboard shows CI-relevant stats (pass rate, PRs, failures)
- [ ] Stats update when repo filter changes
- [ ] Other dashboards unaffected (still show their own stats)

🤖 Generated with [Claude Code](https://claude.com/claude-code)