### PR TITLE
fix: responsive card control bars — flex-wrap + truncation (#8695 Phase 1)

### DIFF
--- a/web/src/components/cards/ACMMFeedbackLoops.tsx
+++ b/web/src/components/cards/ACMMFeedbackLoops.tsx
@@ -371,7 +371,7 @@ export function ACMMFeedbackLoops() {
                 </span>
               </button>
               {isLocked && isLockPromptOpen && (
-                <div className="px-8 pb-2 pt-1 text-[10px] border-t border-border/30 flex items-center justify-between gap-2 flex-wrap">
+                <div className="px-8 pb-2 pt-1 text-[10px] border-t border-border/30 flex flex-wrap items-center justify-between gap-y-2 gap-2 ">
                   <span className="text-muted-foreground">
                     Locked — reach <span className="font-mono text-foreground">L{nextLevel}</span> first
                     {missingForNext > 0 && (

--- a/web/src/components/cards/ACMMLevel.tsx
+++ b/web/src/components/cards/ACMMLevel.tsx
@@ -70,7 +70,7 @@ export function ACMMLevel() {
 
   return (
     <div className="h-full flex flex-col p-4 gap-4 overflow-y-auto">
-      <div className="flex items-center justify-between">
+      <div className="flex flex-wrap items-center justify-between gap-y-2">
         <div className="text-xs text-muted-foreground font-mono truncate">{repo}</div>
         <a
           href={PAPER_URL}
@@ -178,7 +178,7 @@ export function ACMMLevel() {
 
       {nextLevel && (
         <div className="mt-auto pt-2 border-t border-border/50">
-          <div className="flex items-center justify-between text-xs mb-1">
+          <div className="flex flex-wrap items-center justify-between gap-y-2 text-xs mb-1">
             <span className="text-muted-foreground">Progress to L{nextLevel}</span>
             <span className="font-mono">
               {nextDetected}/{nextRequired}

--- a/web/src/components/cards/ACMMRecommendations.tsx
+++ b/web/src/components/cards/ACMMRecommendations.tsx
@@ -105,7 +105,7 @@ export function ACMMRecommendations() {
       {/* Level slider — drag to explore other levels. Filters the
           Feedback Loops Inventory card via shared context. */}
       <div>
-        <div className="flex items-center justify-between text-[10px] text-muted-foreground mb-1">
+        <div className="flex flex-wrap items-center justify-between gap-y-2 text-[10px] text-muted-foreground mb-1">
           <span>Explore level <span className="italic text-muted-foreground/60">— drag to preview AI vs human balance</span></span>
           <span className="font-mono text-foreground">L{targetLevel}</span>
         </div>
@@ -119,7 +119,7 @@ export function ACMMRecommendations() {
           className="w-full accent-primary"
           aria-label="Target ACMM level"
         />
-        <div className="flex items-center justify-between text-[9px] text-muted-foreground mt-0.5">
+        <div className="flex flex-wrap items-center justify-between gap-y-2 text-[9px] text-muted-foreground mt-0.5">
           {LEVEL_TICKS.map((n) => (
             <span
               key={n}
@@ -154,7 +154,7 @@ export function ACMMRecommendations() {
       )}
 
       <div>
-        <div className="flex items-center justify-between mb-1.5">
+        <div className="flex flex-wrap items-center justify-between gap-y-2 mb-1.5">
           <div className="text-[10px] text-muted-foreground uppercase tracking-wide">
             Top recommendations
           </div>
@@ -205,7 +205,7 @@ export function ACMMRecommendations() {
               <div className="text-[10px] text-muted-foreground/80 mt-1 italic leading-snug">
                 {rec.reason}
               </div>
-              <div className="mt-1.5 flex items-center justify-between gap-2">
+              <div className="mt-1.5 flex flex-wrap items-center justify-between gap-y-2 gap-2">
                 <code className="text-[9px] font-mono text-muted-foreground/70 truncate flex-1" title={`Detection (${rec.criterion.detection.type})`}>
                   {detectionLabel(rec.criterion.detection)}
                 </code>

--- a/web/src/components/cards/ActiveAlerts.tsx
+++ b/web/src/components/cards/ActiveAlerts.tsx
@@ -25,7 +25,7 @@ import { AlertListItem } from './AlertListItem'
 function AlertStatsRow({ critical, warning, acknowledged }: { critical: number; warning: number; acknowledged: number }) {
   const { t } = useTranslation('cards')
   return (
-    <div className="grid grid-cols-3 gap-2 mb-3">
+    <div className="grid grid-cols-2 sm:grid-cols-3 gap-2 mb-3">
       <div className="p-2 rounded-lg bg-red-500/10 border border-red-500/20">
         <div className="flex items-center gap-1.5 mb-1">
           <AlertTriangle className="w-3 h-3 text-red-400" />
@@ -215,7 +215,7 @@ export function ActiveAlerts() {
   return (
     <div className="h-full flex flex-col">
       {/* Header with controls */}
-      <div className="flex items-center justify-between mb-2 flex-shrink-0">
+      <div className="flex flex-wrap items-center justify-between gap-y-2 mb-2 flex-shrink-0">
         <div className="flex items-center gap-2">
           {stats.firing > 0 && (
             <StatusBadge color="red" variant="outline" rounded="full">

--- a/web/src/components/cards/AdmissionWebhooks.tsx
+++ b/web/src/components/cards/AdmissionWebhooks.tsx
@@ -66,7 +66,7 @@ export function AdmissionWebhooks() {
 
       <div className="space-y-1 max-h-[300px] overflow-y-auto">
         {filtered.map((wh, i) => (
-          <div key={`${wh.cluster}-${wh.name}-${i}`} className="flex items-center justify-between px-2 py-1.5 rounded-lg bg-muted/30 hover:bg-muted/50 transition-colors">
+          <div key={`${wh.cluster}-${wh.name}-${i}`} className="flex flex-wrap items-center justify-between gap-y-2 px-2 py-1.5 rounded-lg bg-muted/30 hover:bg-muted/50 transition-colors">
             <div className="min-w-0 flex-1">
               <div className="flex items-center gap-1.5">
                 <span className={`text-xs px-1.5 py-0.5 rounded ${

--- a/web/src/components/cards/AlertRules.tsx
+++ b/web/src/components/cards/AlertRules.tsx
@@ -166,7 +166,7 @@ export function AlertRulesCard() {
   return (
     <div className="h-full flex flex-col">
       {/* Header with controls */}
-      <div className="flex items-center justify-between mb-2 flex-shrink-0">
+      <div className="flex flex-wrap items-center justify-between gap-y-2 mb-2 flex-shrink-0">
         <div className="flex items-center gap-2">
           <span className="px-1.5 py-0.5 text-xs rounded bg-secondary text-muted-foreground">
             {t('alertRules.activeCount', { count: enabledCount })}

--- a/web/src/components/cards/AppStatus.tsx
+++ b/web/src/components/cards/AppStatus.tsx
@@ -231,7 +231,7 @@ export function AppStatus(_props: AppStatusProps) {
             className={`p-3 rounded-lg hover:bg-secondary/50 transition-colors cursor-pointer group ${idx % 2 === 0 ? 'bg-secondary/20' : 'bg-secondary/40'}`}
             title={`Click to view details for ${app.name}`}
           >
-            <div className="flex items-center justify-between mb-2 gap-2">
+            <div className="flex flex-wrap items-center justify-between gap-y-2 mb-2 gap-2">
               <div className="flex items-center gap-2 min-w-0 flex-1">
                 <span title="Workload"><Box className="w-4 h-4 text-purple-400 shrink-0" /></span>
                 <span className="text-sm font-medium text-foreground truncate" title={app.name}>{app.name}</span>

--- a/web/src/components/cards/ArgoCDApplicationSets.tsx
+++ b/web/src/components/cards/ArgoCDApplicationSets.tsx
@@ -115,7 +115,7 @@ function ArgoCDApplicationSetsInternal({ config }: ArgoCDApplicationSetsProps) {
   if (showSkeleton) {
     return (
       <div className="h-full flex flex-col min-h-card">
-        <div className="flex items-center justify-between mb-4">
+        <div className="flex flex-wrap items-center justify-between gap-y-2 mb-4">
           <Skeleton variant="text" width={150} height={20} />
           <Skeleton variant="rounded" width={80} height={28} />
         </div>
@@ -141,7 +141,7 @@ function ArgoCDApplicationSetsInternal({ config }: ArgoCDApplicationSetsProps) {
   return (
     <div className="h-full flex flex-col min-h-card content-loaded">
       {/* Header with controls */}
-      <div className="flex items-center justify-between mb-3 flex-shrink-0">
+      <div className="flex flex-wrap items-center justify-between gap-y-2 mb-3 flex-shrink-0">
         <div className="flex items-center gap-2">
           <StatusBadge color="purple">
             {totalItems} AppSet{totalItems !== 1 ? 's' : ''}
@@ -213,7 +213,7 @@ function ArgoCDApplicationSetsInternal({ config }: ArgoCDApplicationSetsProps) {
       />
 
       {/* Stats */}
-      <div className="grid grid-cols-3 gap-2 mb-3">
+      <div className="grid grid-cols-2 sm:grid-cols-3 gap-2 mb-3">
         <div className="text-center p-2 rounded-lg bg-green-500/10">
           <p className="text-lg font-bold text-green-400">{stats.healthy}</p>
           <p className="text-xs text-muted-foreground">Healthy</p>
@@ -244,7 +244,7 @@ function ArgoCDApplicationSetsInternal({ config }: ArgoCDApplicationSetsProps) {
                 key={`${appSet.cluster}-${appSet.namespace}-${appSet.name}-${idx}`}
                 className="p-3 rounded-lg bg-secondary/30 hover:bg-secondary/50 transition-colors group"
               >
-                <div className="flex items-center justify-between mb-2">
+                <div className="flex flex-wrap items-center justify-between gap-y-2 mb-2">
                   <div className="flex items-center gap-2">
                     <Layers className="w-4 h-4 text-purple-400" />
                     <span className="text-sm font-medium text-foreground">{appSet.name}</span>
@@ -266,7 +266,7 @@ function ArgoCDApplicationSetsInternal({ config }: ArgoCDApplicationSetsProps) {
                     </span>
                   </div>
                 </div>
-                <div className="flex items-center justify-between text-xs text-muted-foreground">
+                <div className="flex flex-wrap items-center justify-between gap-y-2 text-xs text-muted-foreground">
                   <div className="flex items-center gap-2">
                     <ClusterBadge cluster={appSet.cluster} size="sm" />
                     <span>/{appSet.namespace}</span>

--- a/web/src/components/cards/ArgoCDApplications.tsx
+++ b/web/src/components/cards/ArgoCDApplications.tsx
@@ -142,7 +142,7 @@ function ArgoCDApplicationsInternal({ config }: ArgoCDApplicationsProps) {
   if (showSkeleton) {
     return (
       <div className="h-full flex flex-col min-h-card">
-        <div className="flex items-center justify-between mb-4">
+        <div className="flex flex-wrap items-center justify-between gap-y-2 mb-4">
           <Skeleton variant="text" width={150} height={20} />
           <Skeleton variant="rounded" width={80} height={28} />
         </div>
@@ -168,7 +168,7 @@ function ArgoCDApplicationsInternal({ config }: ArgoCDApplicationsProps) {
   return (
     <div className="h-full flex flex-col min-h-card content-loaded">
       {/* Header with controls */}
-      <div className="flex items-center justify-between mb-3 flex-shrink-0">
+      <div className="flex flex-wrap items-center justify-between gap-y-2 mb-3 flex-shrink-0">
         <div className="flex items-center gap-2">
           <StatusBadge color="orange">
             {t('argoCDApplications.appsCount', { count: totalItems })}
@@ -313,7 +313,7 @@ function ArgoCDApplicationsInternal({ config }: ArgoCDApplicationsProps) {
                 className="p-3 rounded-lg bg-secondary/30 hover:bg-secondary/50 cursor-pointer transition-colors group"
                 title={t('argoCDApplications.clickToView', { name: app.name })}
               >
-                <div className="flex items-center justify-between mb-2">
+                <div className="flex flex-wrap items-center justify-between gap-y-2 mb-2">
                   <div className="flex items-center gap-2">
                     <span className="text-sm font-medium text-foreground">{app.name}</span>
                     <span className={`text-xs px-1.5 py-0.5 rounded ${syncConfig.bg} ${syncConfig.color}`}>
@@ -345,7 +345,7 @@ function ArgoCDApplicationsInternal({ config }: ArgoCDApplicationsProps) {
                     <ChevronRight className="w-4 h-4 text-muted-foreground opacity-0 group-hover:opacity-100 transition-opacity" />
                   </div>
                 </div>
-                <div className="flex items-center justify-between text-xs text-muted-foreground">
+                <div className="flex flex-wrap items-center justify-between gap-y-2 text-xs text-muted-foreground">
                   <div className="flex items-center gap-2">
                     <ClusterBadge cluster={app.cluster} size="sm" />
                     <span>/{app.namespace}</span>

--- a/web/src/components/cards/ArgoCDHealth.tsx
+++ b/web/src/components/cards/ArgoCDHealth.tsx
@@ -54,7 +54,7 @@ export function ArgoCDHealth({ config: _config }: ArgoCDHealthProps) {
   if (showSkeleton) {
     return (
       <div className="h-full flex flex-col min-h-card">
-        <div className="flex items-center justify-between mb-4">
+        <div className="flex flex-wrap items-center justify-between gap-y-2 mb-4">
           <Skeleton variant="text" width={130} height={20} />
           <Skeleton variant="rounded" width={80} height={28} />
         </div>
@@ -79,7 +79,7 @@ export function ArgoCDHealth({ config: _config }: ArgoCDHealthProps) {
   return (
     <div className="h-full flex flex-col min-h-card content-loaded">
       {/* Header */}
-      <div className="flex items-center justify-between mb-3">
+      <div className="flex flex-wrap items-center justify-between gap-y-2 mb-3">
         <h3 className="text-sm font-medium text-foreground truncate">{t('argoCDHealth.title')}</h3>
         <div className="flex items-center gap-1">
           <a
@@ -130,7 +130,7 @@ export function ArgoCDHealth({ config: _config }: ArgoCDHealthProps) {
           const Icon = config.icon
 
           return (
-            <div key={key} className={`flex items-center justify-between p-2 rounded-lg ${config.bg}`}>
+            <div key={key} className={`flex flex-wrap items-center justify-between gap-y-2 p-2 rounded-lg ${config.bg}`}>
               <div className="flex items-center gap-2">
                 <Icon className={`w-4 h-4 ${config.color}`} />
                 <span className="text-sm text-foreground">{t(config.labelKey)}</span>

--- a/web/src/components/cards/ArgoCDSyncStatus.tsx
+++ b/web/src/components/cards/ArgoCDSyncStatus.tsx
@@ -53,7 +53,7 @@ export function ArgoCDSyncStatus({ config: _config }: ArgoCDSyncStatusProps) {
   if (showSkeleton) {
     return (
       <div className="h-full flex flex-col min-h-card">
-        <div className="flex items-center justify-between mb-4">
+        <div className="flex flex-wrap items-center justify-between gap-y-2 mb-4">
           <Skeleton variant="text" width={130} height={20} />
           <Skeleton variant="rounded" width={80} height={28} />
         </div>
@@ -177,21 +177,21 @@ export function ArgoCDSyncStatus({ config: _config }: ArgoCDSyncStatusProps) {
 
       {/* Legend */}
       <div className="space-y-2">
-        <div className="flex items-center justify-between p-2 rounded-lg bg-green-500/10">
+        <div className="flex flex-wrap items-center justify-between gap-y-2 p-2 rounded-lg bg-green-500/10">
           <div className="flex items-center gap-2">
             <CheckCircle className="w-4 h-4 text-green-400" />
             <span className="text-sm text-foreground">{t('argoCDSyncStatus.synced')}</span>
           </div>
           <span className="text-sm font-bold text-green-400">{stats.synced}</span>
         </div>
-        <div className="flex items-center justify-between p-2 rounded-lg bg-yellow-500/10">
+        <div className="flex flex-wrap items-center justify-between gap-y-2 p-2 rounded-lg bg-yellow-500/10">
           <div className="flex items-center gap-2">
             <RefreshCw className="w-4 h-4 text-yellow-400" />
             <span className="text-sm text-foreground">{t('argoCDSyncStatus.outOfSync')}</span>
           </div>
           <span className="text-sm font-bold text-yellow-400">{stats.outOfSync}</span>
         </div>
-        <div className="flex items-center justify-between p-2 rounded-lg bg-secondary/30">
+        <div className="flex flex-wrap items-center justify-between gap-y-2 p-2 rounded-lg bg-secondary/30">
           <div className="flex items-center gap-2">
             <AlertTriangle className="w-4 h-4 text-muted-foreground" />
             <span className="text-sm text-foreground">{t('argoCDSyncStatus.unknown')}</span>

--- a/web/src/components/cards/CRDHealth.tsx
+++ b/web/src/components/cards/CRDHealth.tsx
@@ -140,7 +140,7 @@ export function CRDHealth({ config: _config }: CRDHealthProps) {
   if (showSkeleton) {
     return (
       <div className="h-full flex flex-col min-h-card">
-        <div className="flex items-center justify-between mb-4">
+        <div className="flex flex-wrap items-center justify-between gap-y-2 mb-4">
           <Skeleton variant="text" width={110} height={20} />
           <Skeleton variant="rounded" width={120} height={32} />
         </div>
@@ -165,7 +165,7 @@ export function CRDHealth({ config: _config }: CRDHealthProps) {
   return (
     <div className="h-full flex flex-col min-h-card content-loaded">
       {/* Controls - single row */}
-      <div className="flex items-center justify-between gap-2 mb-4">
+      <div className="flex flex-wrap items-center justify-between gap-y-2 gap-2 mb-4">
         <div className="flex items-center gap-2" />
         <CardControlsRow
           clusterIndicator={{
@@ -227,7 +227,7 @@ export function CRDHealth({ config: _config }: CRDHealthProps) {
           </div>
 
           {/* Summary */}
-          <div className="grid grid-cols-4 gap-2 mb-4">
+          <div className="grid grid-cols-2 sm:grid-cols-4 gap-2 mb-4">
             <div className="p-2 rounded-lg bg-cyan-500/10 text-center">
               <span className="text-lg font-bold text-cyan-400">{statsSource.length}</span>
               <p className="text-xs text-muted-foreground">{t('crdHealth.crds')}</p>
@@ -257,7 +257,7 @@ export function CRDHealth({ config: _config }: CRDHealthProps) {
                   key={`${crd.cluster}-${crd.group}-${crd.name}`}
                   className="p-2 rounded-lg bg-secondary/30 hover:bg-secondary/50 transition-colors"
                 >
-                  <div className="flex items-center justify-between">
+                  <div className="flex flex-wrap items-center justify-between gap-y-2">
                     <div className="flex items-center gap-2">
                       <StatusIcon className={`w-4 h-4 text-${color}-400`} />
                       <ClusterBadge cluster={crd.cluster} size="sm" />

--- a/web/src/components/cards/CardChat.tsx
+++ b/web/src/components/cards/CardChat.tsx
@@ -199,7 +199,7 @@ export function CardChat({
                     </button>
                   </div>
                 )}
-                <div className="flex items-center justify-between mt-1">
+                <div className="flex flex-wrap items-center justify-between gap-y-2 mt-1">
                   <span className="text-xs opacity-50">
                     {new Date(message.timestamp).toLocaleTimeString()}
                   </span>

--- a/web/src/components/cards/CardWrapper.tsx
+++ b/web/src/components/cards/CardWrapper.tsx
@@ -982,7 +982,7 @@ export function CardWrapper({
             onMouseLeave={() => setShowSummary(false)}
           >
             {/* Header */}
-            <div data-tour="card-header" className="flex items-center justify-between px-4 py-3 border-b border-border/50">
+            <div data-tour="card-header" className="flex flex-wrap items-center justify-between gap-y-2 px-4 py-3 border-b border-border/50">
               <div className="flex items-center gap-2 min-w-0">
                 {dragHandle}
                 {ResolvedIcon && <ResolvedIcon className={cn('w-4 h-4 flex-shrink-0', resolvedIconColor)} />}
@@ -1183,7 +1183,7 @@ export function CardWrapper({
                               setShowResizeMenu(!showResizeMenu)
                               setShowHeightMenu(false)
                             }}
-                            className="w-full px-4 py-2 text-left text-sm text-muted-foreground hover:text-foreground hover:bg-secondary/50 flex items-center justify-between"
+                            className="w-full px-4 py-2 text-left text-sm text-muted-foreground hover:text-foreground hover:bg-secondary/50 flex flex-wrap items-center justify-between gap-y-2"
                             role="menuitem"
                             aria-haspopup="menu"
                             aria-expanded={showResizeMenu}
@@ -1220,7 +1220,7 @@ export function CardWrapper({
                                     setShowMenu(false)
                                   }}
                                   className={cn(
-                                    'w-full px-3 py-2 text-left text-sm flex items-center justify-between',
+                                    'w-full px-3 py-2 text-left text-sm flex flex-wrap items-center justify-between gap-y-2',
                                     cardWidth === option.value
                                       ? 'text-purple-400 bg-purple-500/10'
                                       : 'text-muted-foreground hover:text-foreground hover:bg-secondary/50'
@@ -1243,7 +1243,7 @@ export function CardWrapper({
                               setShowHeightMenu(!showHeightMenu)
                               setShowResizeMenu(false)
                             }}
-                            className="w-full px-4 py-2 text-left text-sm text-muted-foreground hover:text-foreground hover:bg-secondary/50 flex items-center justify-between"
+                            className="w-full px-4 py-2 text-left text-sm text-muted-foreground hover:text-foreground hover:bg-secondary/50 flex flex-wrap items-center justify-between gap-y-2"
                             role="menuitem"
                             aria-haspopup="menu"
                             aria-expanded={showHeightMenu}
@@ -1280,7 +1280,7 @@ export function CardWrapper({
                                     setShowMenu(false)
                                   }}
                                   className={cn(
-                                    'w-full px-3 py-2 text-left text-sm flex items-center justify-between',
+                                    'w-full px-3 py-2 text-left text-sm flex flex-wrap items-center justify-between gap-y-2',
                                     cardHeight === option.value
                                       ? 'text-purple-400 bg-purple-500/10'
                                       : 'text-muted-foreground hover:text-foreground hover:bg-secondary/50'
@@ -1598,7 +1598,7 @@ export function CardWrapper({
           {showInstallGuide && (
             <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm" role="presentation" onClick={() => setShowInstallGuide(null)}>
               <div className="bg-card border border-border rounded-xl shadow-2xl max-w-lg w-full mx-4 max-h-[80vh] overflow-y-auto p-6" role="dialog" aria-modal="true" aria-labelledby="install-guide-title" onClick={e => e.stopPropagation()}>
-                <div className="flex items-center justify-between mb-4">
+                <div className="flex flex-wrap items-center justify-between gap-y-2 mb-4">
                   <h3 id="install-guide-title" className="text-lg font-semibold">{showInstallGuide.mission.mission?.title ?? `Install ${installInfo?.project ?? 'Component'}`}</h3>
                   <button onClick={() => setShowInstallGuide(null)} className="p-2 min-h-11 min-w-11 flex items-center justify-center hover:bg-secondary rounded" aria-label="Close dialog"><X className="w-4 h-4" /></button>
                 </div>

--- a/web/src/components/cards/ChartVersions.tsx
+++ b/web/src/components/cards/ChartVersions.tsx
@@ -128,7 +128,7 @@ export function ChartVersions({ config: _config }: ChartVersionsProps) {
   return (
     <div className="h-full flex flex-col min-h-card content-loaded">
       {/* Header */}
-      <div className="flex items-center justify-between mb-4">
+      <div className="flex flex-wrap items-center justify-between gap-y-2 mb-4">
         <RefreshIndicator
           isRefreshing={isRefreshing}
           lastUpdated={lastRefresh ? new Date(lastRefresh) : null}
@@ -197,7 +197,7 @@ export function ChartVersions({ config: _config }: ChartVersionsProps) {
                   key={`${chart.cluster}-${chart.namespace}-${chart.name}-${idx}`}
                   className="p-3 rounded-lg bg-secondary/30 hover:bg-secondary/50 transition-colors"
                 >
-                  <div className="flex items-center justify-between mb-1 gap-2 min-w-0">
+                  <div className="flex flex-wrap items-center justify-between gap-y-2 mb-1 gap-2 min-w-0">
                     <div className="flex items-center gap-2 min-w-0 flex-1">
                       <Package className="w-4 h-4 text-green-400 shrink-0" />
                       <span className="text-sm text-foreground font-medium truncate">{chart.name}</span>

--- a/web/src/components/cards/Checkers.tsx
+++ b/web/src/components/cards/Checkers.tsx
@@ -692,7 +692,7 @@ export function Checkers(_props: CardComponentProps) {
   return (
     <div className="h-full flex flex-col p-2 select-none">
       {/* Header */}
-      <div className="flex items-center justify-between gap-2 mb-2 flex-wrap">
+      <div className="flex flex-wrap items-center justify-between gap-y-2 gap-2 mb-2 ">
         <div className="flex items-center gap-2 text-xs text-muted-foreground">
           <span className="flex items-center gap-1">
             <Box className="w-3 h-3 text-blue-400" />

--- a/web/src/components/cards/ClusterChangelog.tsx
+++ b/web/src/components/cards/ClusterChangelog.tsx
@@ -79,7 +79,7 @@ export function ClusterChangelog() {
 
   return (
     <div className="space-y-2 p-1">
-      <div className="flex items-center justify-between gap-2">
+      <div className="flex flex-wrap items-center justify-between gap-y-2 gap-2">
         <div className="flex gap-1">
           {(['1h', '6h', '24h', '7d'] as TimeRange[]).map(r => (
             <button

--- a/web/src/components/cards/ClusterComparison.tsx
+++ b/web/src/components/cards/ClusterComparison.tsx
@@ -108,11 +108,11 @@ function ClusterComparisonInternal({ config }: ClusterComparisonProps) {
   if (showSkeleton) {
     return (
       <div className="h-full flex flex-col min-h-card">
-        <div className="flex items-center justify-between mb-4">
+        <div className="flex flex-wrap items-center justify-between gap-y-2 mb-4">
           <Skeleton variant="text" width={150} height={20} />
           <Skeleton variant="rounded" width={80} height={28} />
         </div>
-        <div className="grid grid-cols-3 gap-2">
+        <div className="grid grid-cols-2 sm:grid-cols-3 gap-2">
           <Skeleton variant="rounded" height={150} />
           <Skeleton variant="rounded" height={150} />
           <Skeleton variant="rounded" height={150} />
@@ -232,7 +232,7 @@ function ClusterComparisonInternal({ config }: ClusterComparisonProps) {
       <div className="mt-4 pt-3 border-t border-border/50 space-y-2">
         {metrics.slice(0, 2).map(m => (
           <div key={m.key}>
-            <div className="flex items-center justify-between text-xs text-muted-foreground mb-1">
+            <div className="flex flex-wrap items-center justify-between gap-y-2 text-xs text-muted-foreground mb-1">
               <span>{m.label}</span>
             </div>
             <div className="flex gap-1">

--- a/web/src/components/cards/ClusterCosts.tsx
+++ b/web/src/components/cards/ClusterCosts.tsx
@@ -354,7 +354,7 @@ export function ClusterCosts({ config }: ClusterCostsProps) {
   if (isLoading && allClusters.length === 0) {
     return (
       <div className="h-full flex flex-col min-h-card">
-        <div className="flex items-center justify-between mb-4">
+        <div className="flex flex-wrap items-center justify-between gap-y-2 mb-4">
           <Skeleton variant="text" width={120} height={20} />
           <Skeleton variant="rounded" width={80} height={28} />
         </div>
@@ -371,7 +371,7 @@ export function ClusterCosts({ config }: ClusterCostsProps) {
   return (
     <div className="h-full flex flex-col min-h-card content-loaded">
       {/* Header */}
-      <div className="flex items-center justify-between mb-3">
+      <div className="flex flex-wrap items-center justify-between gap-y-2 mb-3">
         <div className="flex items-center gap-2">
           <span className="text-sm font-medium text-muted-foreground">
             {t('cards:clusterCosts.clusterCount', { count: totalItems })}
@@ -415,7 +415,7 @@ export function ClusterCosts({ config }: ClusterCostsProps) {
       </div>
 
       {/* Pricing Mode and Provider Selector */}
-      <div className="flex items-center justify-between gap-2 mb-3">
+      <div className="flex flex-wrap items-center justify-between gap-y-2 gap-2 mb-3">
         <div className="flex items-center gap-2">
           {/* Pricing Mode Toggle */}
           <div className="relative">
@@ -441,7 +441,7 @@ export function ClusterCosts({ config }: ClusterCostsProps) {
                     setPricingMode('per-cluster')
                     setShowSettingsMenu(false)
                   }}
-                  className={`w-full px-3 py-2 text-xs text-left hover:bg-secondary transition-colors flex items-center justify-between ${
+                  className={`w-full px-3 py-2 text-xs text-left hover:bg-secondary transition-colors flex flex-wrap items-center justify-between gap-y-2 ${
                     pricingMode === 'per-cluster' ? 'text-purple-400 bg-purple-500/10' : 'text-foreground'
                   }`}
                 >
@@ -456,7 +456,7 @@ export function ClusterCosts({ config }: ClusterCostsProps) {
                     setPricingMode('uniform')
                     setShowSettingsMenu(false)
                   }}
-                  className={`w-full px-3 py-2 text-xs text-left hover:bg-secondary transition-colors flex items-center justify-between ${
+                  className={`w-full px-3 py-2 text-xs text-left hover:bg-secondary transition-colors flex flex-wrap items-center justify-between gap-y-2 ${
                     pricingMode === 'uniform' ? 'text-purple-400 bg-purple-500/10' : 'text-foreground'
                   }`}
                 >
@@ -546,7 +546,7 @@ export function ClusterCosts({ config }: ClusterCostsProps) {
           {pricingMode === 'uniform' ? (
             // Uniform mode - show single provider rates
             <>
-              <div className="flex items-center justify-between mb-2">
+              <div className="flex flex-wrap items-center justify-between gap-y-2 mb-2">
                 <span className="font-medium text-foreground">{t('cards:clusterCosts.pricingRates', { provider: pricing.name })}</span>
                 {pricing.pricingUrl && (
                   <a
@@ -560,7 +560,7 @@ export function ClusterCosts({ config }: ClusterCostsProps) {
                   </a>
                 )}
               </div>
-              <div className="grid grid-cols-3 gap-2 mb-2">
+              <div className="grid grid-cols-2 sm:grid-cols-3 gap-2 mb-2">
                 <div className="p-2 rounded bg-secondary/50">
                   <p className="text-muted-foreground mb-0.5">{t('common:common.cpu')}</p>
                   <p className="text-foreground font-medium">${cpuCost.toFixed(3)}/hr</p>
@@ -582,7 +582,7 @@ export function ClusterCosts({ config }: ClusterCostsProps) {
           ) : (
             // Per-cluster mode - show all providers' rates
             <>
-              <div className="flex items-center justify-between mb-2">
+              <div className="flex flex-wrap items-center justify-between gap-y-2 mb-2">
                 <span className="font-medium text-foreground">{t('cards:clusterCosts.perClusterPricingRates')}</span>
                 <span className="text-muted-foreground">{t('cards:clusterCosts.clickBadgesToChange')}</span>
               </div>
@@ -635,7 +635,7 @@ export function ClusterCosts({ config }: ClusterCostsProps) {
 
       {/* Total costs */}
       <div className="p-4 rounded-lg bg-gradient-to-r from-green-500/20 to-green-500/20 border border-green-500/30 mb-4">
-        <div className="flex items-center justify-between">
+        <div className="flex flex-wrap items-center justify-between gap-y-2">
           <div>
             <p className="text-xs text-green-400 mb-1">{t('cards:clusterCosts.estimatedMonthly')}</p>
             <p className="text-2xl font-bold text-foreground">${totalMonthly.toLocaleString(undefined, { maximumFractionDigits: 0 })}</p>
@@ -667,7 +667,7 @@ export function ClusterCosts({ config }: ClusterCostsProps) {
                 provider: cluster.provider })}
               className="p-3 rounded-lg bg-secondary/30 hover:bg-secondary/50 transition-colors group cursor-pointer"
             >
-              <div className="flex items-center justify-between mb-2 gap-2">
+              <div className="flex flex-wrap items-center justify-between gap-y-2 mb-2 gap-2">
                 <div className="flex items-center gap-2 min-w-0 flex-1">
                   {/* 1. Server icon */}
                   <Server className="w-4 h-4 text-muted-foreground flex-shrink-0" />
@@ -765,7 +765,7 @@ export function ClusterCosts({ config }: ClusterCostsProps) {
 
       {/* Footer */}
       <div className="mt-4 pt-3 border-t border-border/50 space-y-2 text-xs text-muted-foreground">
-        <div className="flex items-center justify-between">
+        <div className="flex flex-wrap items-center justify-between gap-y-2">
           <div className="flex items-center gap-1.5 flex-wrap">
             {pricingMode === 'uniform' ? (
               <>

--- a/web/src/components/cards/ClusterFocus.tsx
+++ b/web/src/components/cards/ClusterFocus.tsx
@@ -83,7 +83,7 @@ export function ClusterFocus({ config }: ClusterFocusProps) {
   if (showSkeleton) {
     return (
       <div className="h-full flex flex-col min-h-card">
-        <div className="flex items-center justify-between mb-4">
+        <div className="flex flex-wrap items-center justify-between gap-y-2 mb-4">
           <Skeleton variant="text" width={150} height={20} />
           <Skeleton variant="rounded" width={120} height={32} />
         </div>
@@ -131,7 +131,7 @@ export function ClusterFocus({ config }: ClusterFocusProps) {
   return (
     <div className="h-full flex flex-col min-h-card content-loaded overflow-hidden">
       {/* Header */}
-      <div className="flex items-center justify-between mb-4">
+      <div className="flex flex-wrap items-center justify-between gap-y-2 mb-4">
         <div className="flex items-center gap-2 min-w-0 flex-1">
           <span className="text-sm font-medium text-foreground truncate">{clusterName}</span>
           <div className={`w-2 h-2 rounded-full shrink-0 ${cluster?.healthy ? 'bg-green-500' : 'bg-red-500'}`} />
@@ -216,7 +216,7 @@ export function ClusterFocus({ config }: ClusterFocusProps) {
       {/* Issues Summary */}
       <div className="space-y-2">
         <div
-          className="flex items-center justify-between p-2 rounded-lg bg-red-500/10 border border-red-500/20 cursor-pointer hover:bg-red-500/20 transition-colors"
+          className="flex flex-wrap items-center justify-between gap-y-2 p-2 rounded-lg bg-red-500/10 border border-red-500/20 cursor-pointer hover:bg-red-500/20 transition-colors"
           onClick={() => {
             if (podIssues.length > 0) {
               const issue = podIssues[0]
@@ -237,7 +237,7 @@ export function ClusterFocus({ config }: ClusterFocusProps) {
         </div>
 
         <div
-          className="flex items-center justify-between p-2 rounded-lg bg-red-500/10 border border-red-500/20 cursor-pointer hover:bg-red-500/20 transition-colors"
+          className="flex flex-wrap items-center justify-between gap-y-2 p-2 rounded-lg bg-red-500/10 border border-red-500/20 cursor-pointer hover:bg-red-500/20 transition-colors"
           onClick={() => {
             if (deploymentIssues.length > 0) {
               const issue = deploymentIssues[0]

--- a/web/src/components/cards/ClusterGroups.tsx
+++ b/web/src/components/cards/ClusterGroups.tsx
@@ -155,7 +155,7 @@ export function ClusterGroups(_props: ClusterGroupsProps) {
   return (
     <div className="space-y-3">
       {/* Header */}
-      <div className="flex items-center justify-between">
+      <div className="flex flex-wrap items-center justify-between gap-y-2">
         <div className="flex items-center gap-2">
           <Layers className="w-4 h-4 text-blue-400" />
           <span className="text-sm font-medium text-foreground">
@@ -551,7 +551,7 @@ function CreateGroupForm({ availableClusters, clusterHealthMap, onSave, onCancel
 
   return (
     <div className="rounded-lg border border-blue-500/40 bg-blue-500/5 p-3 space-y-3">
-      <div className="flex items-center justify-between">
+      <div className="flex flex-wrap items-center justify-between gap-y-2">
         <span className="text-xs font-medium text-blue-400">{t('cards:clusterGroups.newClusterGroup')}</span>
         <button onClick={onCancel} aria-label={t('common:common.cancel')} className="p-2 hover:bg-gray-900/10 dark:hover:bg-white/10 rounded min-h-11 min-w-11 flex items-center justify-center">
           <X className="w-3.5 h-3.5 text-muted-foreground" />
@@ -823,7 +823,7 @@ function QueryBuilder({
 
       {/* Resource filters */}
       <div>
-        <div className="flex items-center justify-between mb-1">
+        <div className="flex flex-wrap items-center justify-between gap-y-2 mb-1">
           <label className="flex items-center gap-1 text-2xs text-muted-foreground">
             <Filter className="w-2.5 h-2.5" />
             {t('cards:clusterGroups.resourceFilters')}
@@ -1054,7 +1054,7 @@ function EditGroupForm({ group, availableClusters, clusterHealthMap, onSave, onC
 
   return (
     <div className="rounded-lg border border-yellow-500/40 bg-yellow-500/5 p-3 space-y-3">
-      <div className="flex items-center justify-between">
+      <div className="flex flex-wrap items-center justify-between gap-y-2">
         <span className="text-xs font-medium text-yellow-400">{t('common:common.edit')}: {group.name}</span>
         <button onClick={onCancel} aria-label={t('common:common.cancel')} className="p-2 hover:bg-gray-900/10 dark:hover:bg-white/10 rounded min-h-11 min-w-11 flex items-center justify-center">
           <X className="w-3.5 h-3.5 text-muted-foreground" />

--- a/web/src/components/cards/ClusterHealth.tsx
+++ b/web/src/components/cards/ClusterHealth.tsx
@@ -184,7 +184,7 @@ export function ClusterHealth() {
     return (
       <div className="h-full flex flex-col min-h-card">
         {/* Header skeleton */}
-        <div className="flex items-center justify-between mb-4">
+        <div className="flex flex-wrap items-center justify-between gap-y-2 mb-4">
           <div className="flex items-center gap-2">
             <Skeleton variant="circular" width={16} height={16} />
             <Skeleton variant="text" width={80} height={16} />
@@ -216,7 +216,7 @@ export function ClusterHealth() {
   return (
     <div className="h-full flex flex-col min-h-card content-loaded">
       {/* Header with controls */}
-      <div className="flex items-center justify-between mb-4">
+      <div className="flex flex-wrap items-center justify-between gap-y-2 mb-4">
         <div className="flex items-center gap-2">
           <StatusBadge color="purple" title={t('clusterHealth.totalClustersTitle', { count: rawClusters.length })}>
             {rawClusters.length} {t('clusterHealth.clustersLabel')}
@@ -321,7 +321,7 @@ export function ClusterHealth() {
             <div
               key={cluster.name}
               data-tour={idx === 0 ? 'drilldown' : undefined}
-              className={`group ${isMobile ? 'flex flex-col gap-1.5' : 'flex items-center justify-between'} p-2 rounded-lg border border-border/30 bg-secondary/30 transition-all cursor-pointer hover:bg-secondary/50 hover:border-border/50 min-w-0 overflow-hidden`}
+              className={`group ${isMobile ? 'flex flex-col gap-1.5' : 'flex flex-wrap items-center justify-between gap-y-2'} p-2 rounded-lg border border-border/30 bg-secondary/30 transition-all cursor-pointer hover:bg-secondary/50 hover:border-border/50 min-w-0 overflow-hidden`}
               onClick={() => setSelectedCluster(cluster.name)}
               title={t('clusterHealth.clickViewDetails', { name: cluster.name })}
             >

--- a/web/src/components/cards/ClusterLocations.tsx
+++ b/web/src/components/cards/ClusterLocations.tsx
@@ -398,7 +398,7 @@ export function ClusterLocations({ config: _config }: ClusterLocationsProps) {
   if (showSkeleton) {
     return (
       <div className="h-full flex flex-col min-h-card">
-        <div className="flex items-center justify-between mb-4">
+        <div className="flex flex-wrap items-center justify-between gap-y-2 mb-4">
           <Skeleton variant="text" width={140} height={20} />
           <Skeleton variant="rounded" width={80} height={28} />
         </div>

--- a/web/src/components/cards/ClusterMetrics.tsx
+++ b/web/src/components/cards/ClusterMetrics.tsx
@@ -331,7 +331,7 @@ export function ClusterMetrics() {
   return (
     <div className="h-full flex flex-col">
       {/* Header with metric value and selector */}
-      <div className="flex items-center justify-between mb-2">
+      <div className="flex flex-wrap items-center justify-between gap-y-2 mb-2">
         <div>
           <h4 className="text-sm font-medium text-foreground">{config.label}</h4>
           <p className="text-2xl font-bold text-foreground">
@@ -456,7 +456,7 @@ export function ClusterMetrics() {
 
       {/* Stats - show when we have time series data */}
       {data.length > 0 && (
-        <div className="mt-3 pt-3 border-t border-border/50 grid grid-cols-3 gap-4">
+        <div className="mt-3 pt-3 border-t border-border/50 grid grid-cols-2 sm:grid-cols-3 gap-4">
           <div>
             <p className="text-xs text-muted-foreground">{t('cards:clusterMetrics.min')}</p>
             <p className="text-sm font-medium text-foreground">

--- a/web/src/components/cards/ClusterNetwork.tsx
+++ b/web/src/components/cards/ClusterNetwork.tsx
@@ -68,7 +68,7 @@ export function ClusterNetwork({ config }: ClusterNetworkProps) {
   if (showSkeleton) {
     return (
       <div className="h-full flex flex-col min-h-card">
-        <div className="flex items-center justify-between mb-4">
+        <div className="flex flex-wrap items-center justify-between gap-y-2 mb-4">
           <Skeleton variant="text" width={130} height={20} />
           <Skeleton variant="rounded" width={120} height={32} />
         </div>
@@ -112,7 +112,7 @@ export function ClusterNetwork({ config }: ClusterNetworkProps) {
   return (
     <div className="h-full flex flex-col min-h-card content-loaded overflow-hidden">
       {/* Controls */}
-      <div className="flex items-center justify-between mb-4 gap-2 min-w-0">
+      <div className="flex flex-wrap items-center justify-between gap-y-2 mb-4 gap-2 min-w-0">
         <div className="flex items-center gap-2 min-w-0 flex-1">
           <span className="text-sm font-medium text-foreground truncate">{selectedCluster}</span>
           <div className={`w-2 h-2 rounded-full ${cluster?.healthy ? 'bg-green-500' : 'bg-red-500'}`} />
@@ -140,15 +140,15 @@ export function ClusterNetwork({ config }: ClusterNetworkProps) {
             <span className="text-sm font-medium text-cyan-300">{t('cards:clusterNetwork.apiServer')}</span>
           </div>
           <div className="space-y-2">
-            <div className="flex items-center justify-between gap-2 min-w-0">
+            <div className="flex flex-wrap items-center justify-between gap-y-2 gap-2 min-w-0">
               <span className="text-xs text-muted-foreground shrink-0">{t('cards:clusterNetwork.host')}</span>
               <span className="text-sm text-foreground font-mono truncate">{serverInfo.host}</span>
             </div>
-            <div className="flex items-center justify-between">
+            <div className="flex flex-wrap items-center justify-between gap-y-2">
               <span className="text-xs text-muted-foreground">{t('common:common.port')}</span>
               <span className="text-sm text-foreground font-mono">{serverInfo.port}</span>
             </div>
-            <div className="flex items-center justify-between">
+            <div className="flex flex-wrap items-center justify-between gap-y-2">
               <span className="text-xs text-muted-foreground">{t('common:common.protocol')}</span>
               <span className="text-sm text-foreground font-mono uppercase">{serverInfo.protocol}</span>
             </div>
@@ -159,7 +159,7 @@ export function ClusterNetwork({ config }: ClusterNetworkProps) {
       {/* Connection Status */}
       <div className="space-y-3">
         <div className="p-3 rounded-lg bg-secondary/30">
-          <div className="flex items-center justify-between">
+          <div className="flex flex-wrap items-center justify-between gap-y-2">
             <div className="flex items-center gap-2">
               <div className={`w-2 h-2 rounded-full ${cluster?.healthy ? 'bg-green-500 animate-pulse' : 'bg-red-500'}`} />
               <span className="text-sm text-muted-foreground">{t('cards:clusterNetwork.connectionStatus')}</span>
@@ -171,7 +171,7 @@ export function ClusterNetwork({ config }: ClusterNetworkProps) {
         </div>
 
         <div className="p-3 rounded-lg bg-secondary/30">
-          <div className="flex items-center justify-between">
+          <div className="flex flex-wrap items-center justify-between gap-y-2">
             <div className="flex items-center gap-2">
               <Shield className="w-4 h-4 text-purple-400" />
               <span className="text-sm text-muted-foreground">TLS</span>
@@ -181,7 +181,7 @@ export function ClusterNetwork({ config }: ClusterNetworkProps) {
         </div>
 
         <div className="p-3 rounded-lg bg-secondary/30">
-          <div className="flex items-center justify-between">
+          <div className="flex flex-wrap items-center justify-between gap-y-2">
             <div className="flex items-center gap-2">
               <Server className="w-4 h-4 text-blue-400" />
               <span className="text-sm text-muted-foreground">{t('common:common.nodes')}</span>

--- a/web/src/components/cards/ComplianceCards.tsx
+++ b/web/src/components/cards/ComplianceCards.tsx
@@ -606,7 +606,7 @@ Please proceed step by step.`,
             const info = getFrameworkInfo(fw.name)
             return (
               <div key={i} className="rounded-md px-2 py-1.5 hover:bg-secondary/30 transition-colors">
-                <div className="flex items-center justify-between">
+                <div className="flex flex-wrap items-center justify-between gap-y-2">
                   <div className="flex items-center gap-1.5 min-w-0">
                     <span className="text-xs font-medium text-foreground truncate">
                       {info?.label || fw.name}
@@ -833,7 +833,7 @@ export function PolicyViolations({ config: _config }: CardConfig) {
         {(violations || []).map((v, i) => (
           <div
             key={i}
-            className="group flex items-center justify-between p-2 rounded-lg bg-secondary/30 hover:bg-secondary/50 transition-colors cursor-pointer"
+            className="group flex flex-wrap items-center justify-between gap-y-2 p-2 rounded-lg bg-secondary/30 hover:bg-secondary/50 transition-colors cursor-pointer"
             onClick={() => setSelectedViolation(v)}
             role="button"
             aria-label={t('cards:policyViolations.viewViolationAria', { policy: v.policy })}

--- a/web/src/components/cards/ComplianceDrift.tsx
+++ b/web/src/components/cards/ComplianceDrift.tsx
@@ -221,7 +221,7 @@ export function ComplianceDrift({ config: _config }: CardConfig) {
       </div>
 
       {/* Refresh indicator + inline progress */}
-      <div className="flex items-center justify-between">
+      <div className="flex flex-wrap items-center justify-between gap-y-2">
         {(isLoading || isRefreshing) && totalChecking > 0 && (
           <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
             <ProgressRing progress={minChecked / totalChecking} size={14} strokeWidth={1.5} />

--- a/web/src/components/cards/ComputeOverview.tsx
+++ b/web/src/components/cards/ComputeOverview.tsx
@@ -255,7 +255,7 @@ export function ComputeOverview() {
         onClick={() => stats.totalGPUs > 0 && drillToResources()}
         title={stats.totalGPUs > 0 ? t('computeOverview.gpuAllocatedTitle', { allocated: stats.allocatedGPUs, total: stats.totalGPUs, percent: stats.gpuUtilization }) : t('computeOverview.noGPUsInClusters')}
       >
-        <div className="flex items-center justify-between mb-2">
+        <div className="flex flex-wrap items-center justify-between gap-y-2 mb-2">
           <div className="flex items-center gap-2">
             <Zap className="w-4 h-4 text-purple-400" />
             <span className="text-xs text-purple-400">{t('computeOverview.gpus')}</span>
@@ -286,7 +286,7 @@ export function ComputeOverview() {
             {stats.gpuTypes.length > 0 && (
               <div className="space-y-1">
                 {stats.gpuTypes.slice(0, 3).map(([type, count]) => (
-                  <div key={type} className="flex items-center justify-between text-xs cursor-default" title={t('computeOverview.gpuTypeCountTitle', { count, type })}>
+                  <div key={type} className="flex flex-wrap items-center justify-between gap-y-2 text-xs cursor-default" title={t('computeOverview.gpuTypeCountTitle', { count, type })}>
                     <span className="text-muted-foreground truncate" title={type}>{type}</span>
                     <span className="text-foreground">{count}</span>
                   </div>

--- a/web/src/components/cards/ContainerTetris.tsx
+++ b/web/src/components/cards/ContainerTetris.tsx
@@ -349,7 +349,7 @@ function ContainerTetrisInternal(_props: CardComponentProps) {
   return (
     <div ref={gameContainerRef} className="h-full flex flex-col p-2 select-none">
       {/* Header */}
-      <div className="flex items-center justify-between gap-2 mb-2 flex-wrap">
+      <div className="flex flex-wrap items-center justify-between gap-y-2 gap-2 mb-2 ">
         <div className="flex items-center gap-3 text-xs">
           <div className="text-center">
             <div className="text-muted-foreground">Score</div>

--- a/web/src/components/cards/ControlPlaneHealth.tsx
+++ b/web/src/components/cards/ControlPlaneHealth.tsx
@@ -127,7 +127,7 @@ export function ControlPlaneHealth() {
         </div>
       )}
       {componentStatus.map(comp => (
-        <div key={comp.name} className="flex items-center justify-between px-2 py-1.5 rounded-lg bg-muted/30 hover:bg-muted/50 transition-colors">
+        <div key={comp.name} className="flex flex-wrap items-center justify-between gap-y-2 px-2 py-1.5 rounded-lg bg-muted/30 hover:bg-muted/50 transition-colors">
           <div className="flex items-center gap-2">
             <div className={`w-2 h-2 rounded-full ${
               comp.total === 0 ? 'bg-muted-foreground/30' :

--- a/web/src/components/cards/CrossClusterPolicyComparison.tsx
+++ b/web/src/components/cards/CrossClusterPolicyComparison.tsx
@@ -204,7 +204,7 @@ function CrossClusterPolicyComparisonInternal({ config: _config }: CardConfig) {
       </div>
 
       {/* Refresh indicator + inline progress */}
-      <div className="flex items-center justify-between">
+      <div className="flex flex-wrap items-center justify-between gap-y-2">
         {(isLoading || isRefreshing) && totalClusters > 0 && (
           <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
             <ProgressRing progress={clustersChecked / totalClusters} size={14} strokeWidth={1.5} />

--- a/web/src/components/cards/DNSHealth.tsx
+++ b/web/src/components/cards/DNSHealth.tsx
@@ -61,7 +61,7 @@ export function DNSHealth() {
 
   return (
     <div className="space-y-2 p-1">
-      <div className="flex items-center justify-between gap-2 mb-1">
+      <div className="flex flex-wrap items-center justify-between gap-y-2 gap-2 mb-1">
         <div className="flex items-center gap-2 text-xs text-muted-foreground">
           <span>{t('dnsHealth.podsSummary', { pods: dnsPods.length, clusters: byCluster.length })}</span>
         </div>
@@ -81,7 +81,7 @@ export function DNSHealth() {
 
         return (
           <div key={cluster} className="px-2 py-1.5 rounded-lg bg-muted/30 hover:bg-muted/50 transition-colors">
-            <div className="flex items-center justify-between">
+            <div className="flex flex-wrap items-center justify-between gap-y-2">
               <div className="flex items-center gap-2">
                 <div className={`w-2 h-2 rounded-full ${allHealthy ? 'bg-green-500' : 'bg-yellow-500'}`} />
                 <span className="text-sm font-medium">{cluster}</span>

--- a/web/src/components/cards/DataComplianceCards.tsx
+++ b/web/src/components/cards/DataComplianceCards.tsx
@@ -344,7 +344,7 @@ export function ExternalSecrets({ config: _config }: CardConfig) {
         </div>
       </div>
 
-      <div className="grid grid-cols-3 gap-2 text-center text-xs">
+      <div className="grid grid-cols-2 sm:grid-cols-3 gap-2 text-center text-xs">
         <div className="p-2 rounded-lg bg-green-500/10">
           <CheckCircle2 className="w-4 h-4 text-green-400 mx-auto mb-1" />
           <p className="font-medium text-foreground">{esoStatus.synced}</p>
@@ -362,7 +362,7 @@ export function ExternalSecrets({ config: _config }: CardConfig) {
         </div>
       </div>
 
-      <div className="flex items-center justify-between text-xs">
+      <div className="flex flex-wrap items-center justify-between gap-y-2 text-xs">
         <span className="text-muted-foreground">Secret Stores</span>
         <span className="font-medium text-foreground">{esoStatus.totalStores}</span>
       </div>
@@ -416,7 +416,7 @@ export function CertManager({ config: _config }: CardConfig) {
   if (isLoading && issuers.length === 0) {
     return (
       <div className="space-y-3">
-        <div className="animate-pulse grid grid-cols-4 gap-1.5">
+        <div className="animate-pulse grid grid-cols-2 sm:grid-cols-4 gap-1.5">
           {[...Array(4)].map((_, i) => (
             <div key={i} className="p-2 rounded-lg bg-secondary/30 h-16" />
           ))}
@@ -443,7 +443,7 @@ export function CertManager({ config: _config }: CardConfig) {
         </span>
       </div>
 
-      <div className="grid grid-cols-4 gap-1.5 text-center text-xs">
+      <div className="grid grid-cols-2 sm:grid-cols-4 gap-1.5 text-center text-xs">
         <div className="p-2 rounded-lg bg-green-500/10">
           <p className="text-lg font-bold text-green-400">{status.validCertificates}</p>
           <p className="text-muted-foreground">Valid</p>
@@ -484,7 +484,7 @@ export function CertManager({ config: _config }: CardConfig) {
         </p>
         {topIssuers.length > 0 ? (
           topIssuers.map((issuer) => (
-            <div key={issuer.id} className="flex items-center justify-between p-2 rounded-lg bg-secondary/30">
+            <div key={issuer.id} className="flex flex-wrap items-center justify-between gap-y-2 p-2 rounded-lg bg-secondary/30">
               <div className="flex items-center gap-2">
                 <Shield className={`w-3 h-3 ${
                   issuer.status === 'ready' ? 'text-green-400' :

--- a/web/src/components/cards/DeploymentIssues.tsx
+++ b/web/src/components/cards/DeploymentIssues.tsx
@@ -180,7 +180,7 @@ function DeploymentIssuesInternal({ config }: DeploymentIssuesProps) {
   return (
     <div className="h-full flex flex-col min-h-card content-loaded">
       {/* Header */}
-      <div className="flex items-center justify-between mb-3">
+      <div className="flex flex-wrap items-center justify-between gap-y-2 mb-3">
         <div className="flex items-center gap-2">
           <StatusBadge color="red" title={t('deploymentIssues.issuesTitle', { count: rawIssues.length })}>
             {t('deploymentIssues.nIssues', { count: rawIssues.length })}

--- a/web/src/components/cards/DeploymentProgress.tsx
+++ b/web/src/components/cards/DeploymentProgress.tsx
@@ -219,7 +219,7 @@ export function DeploymentProgress({ config }: DeploymentProgressProps) {
   return (
     <div className="h-full flex flex-col min-h-0">
       {/* Header with controls */}
-      <div className="flex items-center justify-between mb-2 flex-shrink-0">
+      <div className="flex flex-wrap items-center justify-between gap-y-2 mb-2 flex-shrink-0">
         <div className="flex items-center gap-2">
           <span className="text-sm font-medium text-muted-foreground">
             {statusCounts.all} progressing

--- a/web/src/components/cards/DeploymentStatus.tsx
+++ b/web/src/components/cards/DeploymentStatus.tsx
@@ -188,7 +188,7 @@ export function DeploymentStatus() {
   if (isLoading) {
     return (
       <div className="h-full flex flex-col min-h-card">
-        <div className="flex items-center justify-between mb-2">
+        <div className="flex flex-wrap items-center justify-between gap-y-2 mb-2">
           <Skeleton variant="text" width={100} height={16} />
           <Skeleton variant="rounded" width={80} height={28} />
         </div>
@@ -215,7 +215,7 @@ export function DeploymentStatus() {
   return (
     <div className="h-full flex flex-col min-h-0 content-loaded">
       {/* Header with controls */}
-      <div className="flex items-center justify-between mb-2 flex-shrink-0">
+      <div className="flex flex-wrap items-center justify-between gap-y-2 mb-2 flex-shrink-0">
         <div className="flex items-center gap-2">
           <span className="text-sm font-medium text-muted-foreground">
             {statusCounts.all} deployments

--- a/web/src/components/cards/EtcdStatus.tsx
+++ b/web/src/components/cards/EtcdStatus.tsx
@@ -145,7 +145,7 @@ export function EtcdStatus() {
 
         return (
           <div key={cluster} className="px-2 py-1.5 rounded-lg bg-muted/30 hover:bg-muted/50 transition-colors">
-            <div className="flex items-center justify-between">
+            <div className="flex flex-wrap items-center justify-between gap-y-2">
               <div className="flex items-center gap-2">
                 <div className={`w-2 h-2 rounded-full ${allHealthy ? 'bg-green-500' : 'bg-red-500'}`} />
                 <span className="text-sm font-medium">{cluster}</span>

--- a/web/src/components/cards/EventStream.tsx
+++ b/web/src/components/cards/EventStream.tsx
@@ -209,7 +209,7 @@ function EventStreamInternal({ config }: { config?: EventStreamConfig }) {
   return (
     <div className="h-full flex flex-col content-loaded">
       {/* Header */}
-      <div className="flex items-center justify-between mb-3">
+      <div className="flex flex-wrap items-center justify-between gap-y-2 mb-3">
         <div className="flex items-center gap-2">
           <RefreshIndicator
             isRefreshing={isRefreshing}

--- a/web/src/components/cards/EventSummary.tsx
+++ b/web/src/components/cards/EventSummary.tsx
@@ -93,7 +93,7 @@ export function EventSummary() {
   return (
     <div className="space-y-4">
       {/* Header controls */}
-      <div className="flex items-center justify-between">
+      <div className="flex flex-wrap items-center justify-between gap-y-2">
         <span className="text-xs text-muted-foreground">
           {t('eventSummary.nEvents', { count: total })}
         </span>
@@ -172,7 +172,7 @@ export function EventSummary() {
           <div className="text-xs font-medium text-muted-foreground mb-2">{t('eventSummary.topReasons')}</div>
           <div className="space-y-1">
             {summary.topReasons.map(([reason, count]) => (
-              <div key={reason} className="flex items-center justify-between text-xs">
+              <div key={reason} className="flex flex-wrap items-center justify-between gap-y-2 text-xs">
                 <span className="text-foreground truncate mr-2">{reason}</span>
                 <div className="flex items-center gap-2 flex-shrink-0">
                   <div className="w-16 h-1.5 rounded-full bg-secondary overflow-hidden">
@@ -195,7 +195,7 @@ export function EventSummary() {
           <div className="text-xs font-medium text-muted-foreground mb-2">{t('eventSummary.byCluster')}</div>
           <div className="space-y-1">
             {summary.topClusters.map(([cluster, count]) => (
-              <div key={cluster} className="flex items-center justify-between text-xs">
+              <div key={cluster} className="flex flex-wrap items-center justify-between gap-y-2 text-xs">
                 <span className="text-foreground truncate mr-2">{cluster}</span>
                 <div className="flex items-center gap-2 flex-shrink-0">
                   <div className="w-16 h-1.5 rounded-full bg-secondary overflow-hidden">

--- a/web/src/components/cards/EventsTimeline.tsx
+++ b/web/src/components/cards/EventsTimeline.tsx
@@ -243,7 +243,7 @@ function EventsTimelineInternal() {
   if (showSkeleton) {
     return (
       <div className="h-full flex flex-col min-h-card">
-        <div className="flex items-center justify-between mb-2">
+        <div className="flex flex-wrap items-center justify-between gap-y-2 mb-2">
           <Skeleton variant="text" width={120} height={16} />
           <Skeleton variant="rounded" width={28} height={28} />
         </div>
@@ -265,7 +265,7 @@ function EventsTimelineInternal() {
   return (
     <div className="h-full flex flex-col content-loaded">
       {/* Controls - single row: Time Range -> Cluster Filter -> Refresh */}
-      <div className="flex items-center justify-between mb-3">
+      <div className="flex flex-wrap items-center justify-between gap-y-2 mb-3">
         <div className="flex items-center gap-2">
           <RefreshIndicator
             isRefreshing={isRefreshing}
@@ -313,7 +313,7 @@ function EventsTimelineInternal() {
       </div>
 
       {/* Stats row */}
-      <div className="grid grid-cols-3 gap-2 mb-4">
+      <div className="grid grid-cols-2 sm:grid-cols-3 gap-2 mb-4">
         <div className="p-2 rounded-lg bg-orange-500/10 border border-orange-500/20">
           <div className="flex items-center gap-1.5 mb-1">
             <AlertTriangle className="w-3 h-3 text-orange-400" aria-hidden="true" />

--- a/web/src/components/cards/FlappyPod.tsx
+++ b/web/src/components/cards/FlappyPod.tsx
@@ -234,7 +234,7 @@ export function FlappyPod(_props: CardComponentProps) {
   return (
     <div ref={gameContainerRef} className="h-full flex flex-col p-2 select-none">
       {/* Header */}
-      <div className="flex items-center justify-between gap-2 mb-2 flex-wrap">
+      <div className="flex flex-wrap items-center justify-between gap-y-2 gap-2 mb-2 ">
         <div className="flex items-center gap-3 text-xs">
           <div className="text-center">
             <div className="text-muted-foreground">Score</div>

--- a/web/src/components/cards/FleetComplianceHeatmap.tsx
+++ b/web/src/components/cards/FleetComplianceHeatmap.tsx
@@ -356,7 +356,7 @@ export function FleetComplianceHeatmap({ config: _config }: CardConfig) {
       </div>
 
       {/* Refresh indicator + inline progress */}
-      <div className="flex items-center justify-between">
+      <div className="flex flex-wrap items-center justify-between gap-y-2">
         {(isLoading || isRefreshing) && totalChecking > 0 && (
           <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
             <ProgressRing progress={minChecked / totalChecking} size={14} strokeWidth={1.5} />

--- a/web/src/components/cards/GPUInventory.tsx
+++ b/web/src/components/cards/GPUInventory.tsx
@@ -127,11 +127,11 @@ export function GPUInventory({ config }: GPUInventoryProps) {
   if (showSkeleton) {
     return (
       <div className="h-full flex flex-col min-h-card">
-        <div className="flex items-center justify-between mb-3">
+        <div className="flex flex-wrap items-center justify-between gap-y-2 mb-3">
           <Skeleton variant="text" width={100} height={16} />
           <Skeleton variant="rounded" width={80} height={28} />
         </div>
-        <div className="grid grid-cols-3 gap-2 mb-4">
+        <div className="grid grid-cols-2 sm:grid-cols-3 gap-2 mb-4">
           {[1, 2, 3].map(i => (
             <Skeleton key={i} variant="rounded" height={50} />
           ))}
@@ -164,7 +164,7 @@ export function GPUInventory({ config }: GPUInventoryProps) {
   return (
     <div className="h-full flex flex-col content-loaded overflow-hidden">
       {/* Header */}
-      <div className="flex items-center justify-between mb-3">
+      <div className="flex flex-wrap items-center justify-between gap-y-2 mb-3">
         <div className="flex items-center gap-2">
           <StatusBadge color="green">
             {t('gpuInventory.gpuCount', { count: stats.totalGPUs })}
@@ -223,7 +223,7 @@ export function GPUInventory({ config }: GPUInventoryProps) {
       />
 
       {/* Summary */}
-      <div className="grid grid-cols-3 gap-2 mb-4">
+      <div className="grid grid-cols-2 sm:grid-cols-3 gap-2 mb-4">
         <div className="p-2 rounded-lg bg-secondary/30 text-center">
           <p className="text-lg font-bold text-foreground">{stats.totalGPUs}</p>
           <p className="text-xs text-muted-foreground">{t('common:common.total')}</p>
@@ -256,7 +256,7 @@ export function GPUInventory({ config }: GPUInventoryProps) {
               <span className="text-sm font-medium text-foreground truncate min-w-0 flex-1 group-hover:text-purple-400">{node.name}</span>
               <ChevronRight className="w-4 h-4 text-muted-foreground shrink-0 opacity-0 group-hover:opacity-100 transition-opacity" />
             </div>
-            <div className="flex items-center justify-between text-xs gap-2 min-w-0">
+            <div className="flex flex-wrap items-center justify-between gap-y-2 text-xs gap-2 min-w-0">
               <div className="min-w-0 flex-1">
                 <ClusterBadge cluster={node.cluster} size="sm" />
               </div>

--- a/web/src/components/cards/GPUInventoryHistory.tsx
+++ b/web/src/components/cards/GPUInventoryHistory.tsx
@@ -1017,7 +1017,7 @@ export function GPUInventoryHistory() {
               </tbody>
             </table>
             {totalTablePages > 1 && (
-              <div className="flex items-center justify-between mt-2 text-xs text-muted-foreground">
+              <div className="flex flex-wrap items-center justify-between gap-y-2 mt-2 text-xs text-muted-foreground">
                 <span>{t('cards:gpuInventoryHistory.showing', 'Showing')} {tablePage * TABLE_PAGE_SIZE + 1}-{Math.min((tablePage + 1) * TABLE_PAGE_SIZE, (tableRows || []).length)} {t('cards:gpuInventoryHistory.of', 'of')} {(tableRows || []).length}</span>
                 <div className="flex gap-1">
                   <button

--- a/web/src/components/cards/GPUNamespaceAllocations.tsx
+++ b/web/src/components/cards/GPUNamespaceAllocations.tsx
@@ -141,7 +141,7 @@ function GPUNamespaceAllocationsInternal({ config: _config }: GPUNamespaceAlloca
   if (isLoading) {
     return (
       <div className="h-full flex flex-col min-h-card">
-        <div className="flex items-center justify-between mb-3">
+        <div className="flex flex-wrap items-center justify-between gap-y-2 mb-3">
           <Skeleton variant="text" width={120} height={16} />
           <Skeleton variant="rounded" width={80} height={28} />
         </div>
@@ -171,7 +171,7 @@ function GPUNamespaceAllocationsInternal({ config: _config }: GPUNamespaceAlloca
   return (
     <div className="h-full flex flex-col content-loaded overflow-hidden">
       {/* Header */}
-      <div className="flex items-center justify-between mb-3">
+      <div className="flex flex-wrap items-center justify-between gap-y-2 mb-3">
         <div className="flex items-center gap-2">
           <StatusBadge color="purple">
             {t('gpuNamespaceAllocations.gpusAcrossNamespaces', { gpus: totalGPUs, count: namespaceAllocations.length })}
@@ -254,7 +254,7 @@ function GPUNamespaceAllocationsInternal({ config: _config }: GPUNamespaceAlloca
               </span>
               <ChevronRight className="w-4 h-4 text-muted-foreground shrink-0 opacity-0 group-hover:opacity-100 transition-opacity" />
             </div>
-            <div className="flex items-center justify-between text-xs gap-2">
+            <div className="flex flex-wrap items-center justify-between gap-y-2 text-xs gap-2">
               <div className="flex items-center gap-2">
                 {ns.clusters.slice(0, 2).map(c => (
                   <ClusterBadge key={c} cluster={c} size="sm" />

--- a/web/src/components/cards/GPUOverview.tsx
+++ b/web/src/components/cards/GPUOverview.tsx
@@ -105,14 +105,14 @@ export function GPUOverview({ config: _config }: GPUOverviewProps) {
   if (isLoading && hasReachableClusters) {
     return (
       <div className="h-full flex flex-col min-h-card">
-        <div className="flex items-center justify-between mb-4">
+        <div className="flex flex-wrap items-center justify-between gap-y-2 mb-4">
           <Skeleton variant="text" width={100} height={16} />
           <Skeleton variant="rounded" width={80} height={28} />
         </div>
         <div className="flex justify-center mb-4">
           <Skeleton variant="circular" width={128} height={128} />
         </div>
-        <div className="grid grid-cols-3 gap-2 mb-4">
+        <div className="grid grid-cols-2 sm:grid-cols-3 gap-2 mb-4">
           {[1, 2, 3].map(i => (
             <Skeleton key={i} variant="rounded" height={50} />
           ))}
@@ -296,7 +296,7 @@ export function GPUOverview({ config: _config }: GPUOverviewProps) {
       </div>
 
       {/* Stats */}
-      <div className="grid grid-cols-3 gap-2 mb-4">
+      <div className="grid grid-cols-2 sm:grid-cols-3 gap-2 mb-4">
         <div
           className={`text-center ${totalGPUs > 0 ? 'cursor-pointer hover:bg-secondary/50 rounded-lg' : 'cursor-default'} transition-colors p-1`}
           onClick={() => totalGPUs > 0 && drillToResources()}
@@ -331,7 +331,7 @@ export function GPUOverview({ config: _config }: GPUOverviewProps) {
             {sortedGpuTypes.map(([type, count]) => (
               <div
                 key={type}
-                className="flex items-center justify-between text-sm cursor-pointer hover:bg-secondary/50 rounded px-1 transition-colors"
+                className="flex flex-wrap items-center justify-between gap-y-2 text-sm cursor-pointer hover:bg-secondary/50 rounded px-1 transition-colors"
                 onClick={() => drillToResources()}
                 title={t('gpuOverview.gpuTypeRowTitle', { count, type })}
               >

--- a/web/src/components/cards/GPUStatus.tsx
+++ b/web/src/components/cards/GPUStatus.tsx
@@ -136,7 +136,7 @@ export function GPUStatus({ config }: GPUStatusProps) {
   if (showSkeleton) {
     return (
       <div className="h-full flex flex-col min-h-card">
-        <div className="flex items-center justify-between mb-3">
+        <div className="flex flex-wrap items-center justify-between gap-y-2 mb-3">
           <Skeleton variant="text" width={100} height={16} />
           <Skeleton variant="rounded" width={80} height={28} />
         </div>
@@ -169,7 +169,7 @@ export function GPUStatus({ config }: GPUStatusProps) {
   return (
     <div className="h-full flex flex-col content-loaded overflow-hidden">
       {/* Header */}
-      <div className="flex items-center justify-between mb-3">
+      <div className="flex flex-wrap items-center justify-between gap-y-2 mb-3">
         <div className="flex items-center gap-2">
           <StatusBadge color="purple">
             {t('gpuStatus.clusterCount', { count: totalItems })}
@@ -239,7 +239,7 @@ export function GPUStatus({ config }: GPUStatusProps) {
               gpuUtilization: stats.utilization })}
             className="p-3 rounded-lg bg-secondary/30 hover:bg-secondary/50 transition-colors cursor-pointer group"
           >
-            <div className="flex items-center justify-between mb-2 gap-2 min-w-0">
+            <div className="flex flex-wrap items-center justify-between gap-y-2 mb-2 gap-2 min-w-0">
               <div className="min-w-0 flex-1">
                 <ClusterBadge cluster={stats.clusterName} size="sm" />
               </div>
@@ -254,7 +254,7 @@ export function GPUStatus({ config }: GPUStatusProps) {
                 <ChevronRight className="w-4 h-4 text-muted-foreground opacity-0 group-hover:opacity-100 transition-opacity" />
               </div>
             </div>
-            <div className="flex items-center justify-between text-xs text-muted-foreground mb-2 gap-2 min-w-0">
+            <div className="flex flex-wrap items-center justify-between gap-y-2 text-xs text-muted-foreground mb-2 gap-2 min-w-0">
               <span className="truncate min-w-0 flex-1">{(stats.types || []).join(', ')}</span>
               <span className="shrink-0">{stats.used}/{stats.total} {t('gpuStatus.gpus')}</span>
             </div>

--- a/web/src/components/cards/GPUUsageTrend.tsx
+++ b/web/src/components/cards/GPUUsageTrend.tsx
@@ -398,7 +398,7 @@ export function GPUUsageTrend() {
   if (isLoading && history.length === 0) {
     return (
       <div className="h-full flex flex-col min-h-card">
-        <div className="flex items-center justify-between mb-2">
+        <div className="flex flex-wrap items-center justify-between gap-y-2 mb-2">
           <Skeleton variant="text" width={120} height={16} />
           <Skeleton variant="rounded" width={28} height={28} />
         </div>
@@ -425,7 +425,7 @@ export function GPUUsageTrend() {
 
   return (
     <div className="h-full flex flex-col content-loaded">
-      <div className="flex items-center justify-between mb-2">
+      <div className="flex flex-wrap items-center justify-between gap-y-2 mb-2">
         <div className="flex items-center gap-2">
           {localClusterFilter.length > 0 && (
             <span className="flex items-center gap-1 text-xs text-muted-foreground bg-secondary/50 px-1.5 py-0.5 rounded">

--- a/web/src/components/cards/GPUUtilization.tsx
+++ b/web/src/components/cards/GPUUtilization.tsx
@@ -221,7 +221,7 @@ export function GPUUtilization() {
   if (isLoading && history.length === 0 && hasReachableClusters) {
     return (
       <div className="h-full flex flex-col min-h-card">
-        <div className="flex items-center justify-between mb-2">
+        <div className="flex flex-wrap items-center justify-between gap-y-2 mb-2">
           <Skeleton variant="text" width={120} height={16} />
           <Skeleton variant="rounded" width={28} height={28} />
         </div>
@@ -234,7 +234,7 @@ export function GPUUtilization() {
   if (!hasReachableClusters || (!hookLoading && currentStats.total === 0)) {
     return (
       <div className="h-full flex flex-col content-loaded">
-        <div className="flex items-center justify-between mb-3">
+        <div className="flex flex-wrap items-center justify-between gap-y-2 mb-3">
           <div className="flex items-center gap-2">
             {localClusterFilter.length > 0 && (
               <span className="flex items-center gap-1 text-xs text-muted-foreground bg-secondary/50 px-1.5 py-0.5 rounded">
@@ -287,7 +287,7 @@ export function GPUUtilization() {
 
   return (
     <div className="h-full flex flex-col content-loaded">
-      <div className="flex items-center justify-between mb-3">
+      <div className="flex flex-wrap items-center justify-between gap-y-2 mb-3">
         <div className="flex items-center gap-2">
           {localClusterFilter.length > 0 && (
             <span className="flex items-center gap-1 text-xs text-muted-foreground bg-secondary/50 px-1.5 py-0.5 rounded">
@@ -344,7 +344,7 @@ export function GPUUtilization() {
             <span className="text-sm font-bold text-foreground">{currentStats.utilization}%</span>
           </div>
         </div>
-        <div className="flex-1 grid grid-cols-3 gap-2">
+        <div className="flex-1 grid grid-cols-2 sm:grid-cols-3 gap-2">
           <div className="p-2 rounded-lg bg-purple-500/10 border border-purple-500/20">
             <div className="text-xs text-purple-400 mb-1">{t('common.allocated')}</div>
             <span className="text-lg font-bold text-foreground">{currentStats.allocated}</span>

--- a/web/src/components/cards/GPUWorkloads.tsx
+++ b/web/src/components/cards/GPUWorkloads.tsx
@@ -189,11 +189,11 @@ export function GPUWorkloads({ config: _config }: GPUWorkloadsProps) {
   if (isLoading && gpuWorkloadSource.length === 0) {
     return (
       <div className="h-full flex flex-col min-h-card">
-        <div className="flex items-center justify-between mb-3">
+        <div className="flex flex-wrap items-center justify-between gap-y-2 mb-3">
           <Skeleton variant="text" width={100} height={16} />
           <Skeleton variant="rounded" width={80} height={28} />
         </div>
-        <div className="grid grid-cols-4 gap-2 mb-3">
+        <div className="grid grid-cols-2 sm:grid-cols-4 gap-2 mb-3">
           {[1, 2, 3, 4].map(i => (
             <Skeleton key={i} variant="rounded" height={50} />
           ))}
@@ -226,7 +226,7 @@ export function GPUWorkloads({ config: _config }: GPUWorkloadsProps) {
   return (
     <div className="h-full flex flex-col content-loaded">
       {/* Controls */}
-      <div className="flex items-center justify-between mb-3">
+      <div className="flex flex-wrap items-center justify-between gap-y-2 mb-3">
         {summary.failed > 0 ? (
           <StatusBadge color="red">
             {t('gpuWorkloads.failedCount', { count: summary.failed })}
@@ -273,7 +273,7 @@ export function GPUWorkloads({ config: _config }: GPUWorkloadsProps) {
       />
 
       {/* Summary stats */}
-      <div className="grid grid-cols-4 gap-2 mb-3">
+      <div className="grid grid-cols-2 sm:grid-cols-4 gap-2 mb-3">
         <div className="p-2 rounded-lg bg-secondary/30 text-center" title={t('gpuWorkloads.totalGPUWorkloads', { count: summary.total })}>
           <p className="text-lg font-bold text-foreground">{summary.total}</p>
           <p className="text-xs text-muted-foreground">{t('common:common.total')}</p>

--- a/web/src/components/cards/Game2048.tsx
+++ b/web/src/components/cards/Game2048.tsx
@@ -301,7 +301,7 @@ export function Game2048(_props: CardComponentProps) {
   return (
     <div ref={gameContainerRef} className="h-full flex flex-col p-2 select-none">
       {/* Header */}
-      <div className="flex items-center justify-between gap-2 mb-2 flex-wrap">
+      <div className="flex flex-wrap items-center justify-between gap-y-2 gap-2 mb-2 ">
         <div className="flex items-center gap-3 text-xs">
           <div className="text-center">
             <div className="text-muted-foreground">Score</div>

--- a/web/src/components/cards/GatewayStatus.tsx
+++ b/web/src/components/cards/GatewayStatus.tsx
@@ -131,7 +131,7 @@ export function GatewayStatus({ config: _config }: GatewayStatusProps) {
   if (isLoading) {
     return (
       <div className="h-full flex flex-col min-h-card">
-        <div className="flex items-center justify-between mb-3">
+        <div className="flex flex-wrap items-center justify-between gap-y-2 mb-3">
           <Skeleton variant="text" width={120} height={20} />
           <Skeleton variant="rounded" width={80} height={28} />
         </div>
@@ -163,7 +163,7 @@ export function GatewayStatus({ config: _config }: GatewayStatusProps) {
   return (
     <div className="h-full flex flex-col min-h-card">
       {/* Header with controls */}
-      <div className="flex items-center justify-between mb-2 flex-shrink-0">
+      <div className="flex flex-wrap items-center justify-between gap-y-2 mb-2 flex-shrink-0">
         <div className="flex items-center gap-2">
           <span className="text-sm font-medium text-muted-foreground">
             {t('gatewayStatus.nGateways', { count: totalItems })}
@@ -233,7 +233,7 @@ export function GatewayStatus({ config: _config }: GatewayStatusProps) {
       </div>
 
       {/* Stats */}
-      <div className="grid grid-cols-3 gap-2 mb-3">
+      <div className="grid grid-cols-2 sm:grid-cols-3 gap-2 mb-3">
         <div className="p-2 rounded-lg bg-purple-500/10 border border-purple-500/20 text-center">
           <p className="text-2xs text-purple-400">{t('gatewayStatus.gateways')}</p>
           <p className="text-lg font-bold text-foreground">{stats.totalGateways}</p>
@@ -258,7 +258,7 @@ export function GatewayStatus({ config: _config }: GatewayStatusProps) {
               key={`${gw.cluster}-${gw.namespace}-${gw.name}-${idx}`}
               className="p-2.5 rounded-lg bg-secondary/30 hover:bg-secondary/50 transition-colors"
             >
-              <div className="flex items-center justify-between mb-1">
+              <div className="flex flex-wrap items-center justify-between gap-y-2 mb-1">
                 <div className="flex items-center gap-2">
                   <Icon className={`w-4 h-4 ${colors.text}`} />
                   <span className="text-sm font-medium text-foreground truncate">{gw.name}</span>
@@ -270,7 +270,7 @@ export function GatewayStatus({ config: _config }: GatewayStatusProps) {
                   {t('gatewayStatus.nRoutes', { count: gw.attachedRoutes })}
                 </span>
               </div>
-              <div className="flex items-center justify-between text-xs">
+              <div className="flex flex-wrap items-center justify-between gap-y-2 text-xs">
                 <div className="flex items-center gap-2">
                   <ClusterBadge cluster={gw.cluster} />
                   <span className="text-muted-foreground">{gw.namespace}</span>

--- a/web/src/components/cards/GitHubActivity.tsx
+++ b/web/src/components/cards/GitHubActivity.tsx
@@ -723,7 +723,7 @@ export function GitHubActivity({ config, ref }: { config?: GitHubActivityConfig;
   if (isLoading && !repoInfo) {
     return (
       <div className="h-full flex flex-col min-h-card">
-        <div className="flex items-center justify-between mb-3">
+        <div className="flex flex-wrap items-center justify-between gap-y-2 mb-3">
           <Skeleton variant="text" width={150} height={16} />
           <Skeleton variant="rounded" width={100} height={28} />
         </div>
@@ -746,7 +746,7 @@ export function GitHubActivity({ config, ref }: { config?: GitHubActivityConfig;
     return (
       <div className="h-full flex flex-col content-loaded">
         {/* Header with inline repo editor */}
-        <div className="flex items-center justify-between mb-3">
+        <div className="flex flex-wrap items-center justify-between gap-y-2 mb-3">
           <StatusBadge color="red" variant="outline" rounded="full">
             {t('common:common.error')}
           </StatusBadge>
@@ -878,7 +878,7 @@ export function GitHubActivity({ config, ref }: { config?: GitHubActivityConfig;
   return (
     <div className="h-full flex flex-col content-loaded">
       {/* Row 1: Header with repo selector and controls - inline CRUD style */}
-      <div className="flex items-center justify-between mb-2 flex-shrink-0">
+      <div className="flex flex-wrap items-center justify-between gap-y-2 mb-2 flex-shrink-0">
         <div className="flex items-center gap-2">
           <span className="text-sm font-medium text-muted-foreground">
             {t('common:common.itemCount', { count: totalItems, item: viewMode })}

--- a/web/src/components/cards/GitOpsDrift.tsx
+++ b/web/src/components/cards/GitOpsDrift.tsx
@@ -195,7 +195,7 @@ export function GitOpsDrift({ config }: GitOpsDriftProps) {
   return (
     <div className="h-full flex flex-col">
       {/* Header */}
-      <div className="flex items-center justify-between mb-4">
+      <div className="flex flex-wrap items-center justify-between gap-y-2 mb-4">
         <div className="flex items-center gap-2">
           {localClusterFilter.length > 0 && (
             <span className="flex items-center gap-1 text-xs text-muted-foreground bg-secondary/50 px-1.5 py-0.5 rounded">

--- a/web/src/components/cards/HardwareHealthCard.tsx
+++ b/web/src/components/cards/HardwareHealthCard.tsx
@@ -454,7 +454,7 @@ export function HardwareHealthCard() {
         </div>
       )}
       {/* Status Summary */}
-      <div className="grid grid-cols-3 gap-1.5 sm:gap-2 mb-4">
+      <div className="grid grid-cols-2 sm:grid-cols-3 gap-1.5 sm:gap-2 mb-4">
         <div className={cn(
           'p-2 rounded-lg border',
           criticalCount > 0
@@ -636,7 +636,7 @@ export function HardwareHealthCard() {
       {/* Error display with retry */}
       {fetchError && (
         <div className="mb-3 p-3 rounded-lg bg-red-500/10 border border-red-500/20 text-red-400 text-xs">
-          <div className="flex items-center justify-between gap-2">
+          <div className="flex flex-wrap items-center justify-between gap-y-2 gap-2">
             <div className="flex items-center gap-2">
               <AlertTriangle className="w-4 h-4 flex-shrink-0" />
               <span>{fetchError}</span>

--- a/web/src/components/cards/HelmHistory.tsx
+++ b/web/src/components/cards/HelmHistory.tsx
@@ -232,7 +232,7 @@ export function HelmHistory({ config }: HelmHistoryProps) {
   if (showSkeleton) {
     return (
       <div className="h-full flex flex-col min-h-card">
-        <div className="flex items-center justify-between mb-4">
+        <div className="flex flex-wrap items-center justify-between gap-y-2 mb-4">
           <Skeleton variant="text" width={120} height={20} />
           <Skeleton variant="rounded" width={80} height={28} />
         </div>
@@ -258,7 +258,7 @@ export function HelmHistory({ config }: HelmHistoryProps) {
   return (
     <div className="h-full flex flex-col min-h-card content-loaded overflow-hidden">
       {/* Header */}
-      <div className="flex items-center justify-between mb-4">
+      <div className="flex flex-wrap items-center justify-between gap-y-2 mb-4">
         <div className="flex items-center gap-2">
           {totalItems > 0 && (
             <StatusBadge color="purple">
@@ -379,7 +379,7 @@ export function HelmHistory({ config }: HelmHistoryProps) {
                         </div>
 
                         <div className={`p-2 rounded-lg transition-colors ${isCurrent ? 'bg-green-500/10 border border-green-500/20 group-hover:bg-green-500/20' : 'bg-secondary/30 group-hover:bg-secondary/50'}`}>
-                          <div className="flex items-center justify-between mb-1">
+                          <div className="flex flex-wrap items-center justify-between gap-y-2 mb-1">
                             <div className="flex items-center gap-2">
                               <span className="text-sm font-medium text-foreground">{t('helmHistory.rev', { revision: entry.revision })}</span>
                               {isCurrent && (

--- a/web/src/components/cards/HelmReleaseStatus.tsx
+++ b/web/src/components/cards/HelmReleaseStatus.tsx
@@ -190,7 +190,7 @@ export function HelmReleaseStatus({ config }: HelmReleaseStatusProps) {
   if (showSkeleton) {
     return (
       <div className="h-full flex flex-col min-h-card">
-        <div className="flex items-center justify-between mb-4">
+        <div className="flex flex-wrap items-center justify-between gap-y-2 mb-4">
           <Skeleton variant="text" width={140} height={20} />
           <Skeleton variant="rounded" width={80} height={28} />
         </div>
@@ -217,7 +217,7 @@ export function HelmReleaseStatus({ config }: HelmReleaseStatusProps) {
   return (
     <div className="h-full flex flex-col min-h-card content-loaded overflow-hidden">
       {/* Controls - single row */}
-      <div className="flex items-center justify-between gap-2 mb-4">
+      <div className="flex flex-wrap items-center justify-between gap-y-2 gap-2 mb-4">
         <div className="flex items-center gap-2">
           {localClusterFilter.length > 0 && (
             <span className="flex items-center gap-1 text-xs text-muted-foreground bg-secondary/50 px-1.5 py-0.5 rounded">
@@ -331,7 +331,7 @@ export function HelmReleaseStatus({ config }: HelmReleaseStatusProps) {
                   className={`p-3 rounded-lg ${release.status === 'failed' ? 'bg-red-500/10 border border-red-500/20' : idx % 2 === 0 ? 'bg-secondary/20' : 'bg-secondary/40'} hover:bg-secondary/50 transition-colors cursor-pointer group`}
                   title={`${release.name} - ${release.chart}@${release.version} (Revision ${release.revision})`}
                 >
-                  <div className="flex items-center justify-between mb-1">
+                  <div className="flex flex-wrap items-center justify-between gap-y-2 mb-1">
                     <div className="flex items-center gap-2">
                       <span title={`Status: ${release.status}`}><StatusIcon className={`w-4 h-4 ${STATUS_TEXT_CLASSES[color]}`} /></span>
                       <span className="text-sm text-foreground font-medium group-hover:text-purple-400" title={release.name}>{release.name}</span>

--- a/web/src/components/cards/HelmValuesDiff.tsx
+++ b/web/src/components/cards/HelmValuesDiff.tsx
@@ -275,7 +275,7 @@ export function HelmValuesDiff({ config }: HelmValuesDiffProps) {
   if (isLoading) {
     return (
       <div className="h-full flex flex-col min-h-card">
-        <div className="flex items-center justify-between mb-4">
+        <div className="flex flex-wrap items-center justify-between gap-y-2 mb-4">
           <Skeleton variant="text" width={130} height={20} />
           <Skeleton variant="rounded" width={80} height={28} />
         </div>
@@ -292,7 +292,7 @@ export function HelmValuesDiff({ config }: HelmValuesDiffProps) {
   return (
     <div className="h-full flex flex-col min-h-card content-loaded overflow-hidden">
       {/* Header with controls */}
-      <div className="flex items-center justify-between mb-2 flex-shrink-0">
+      <div className="flex flex-wrap items-center justify-between gap-y-2 mb-2 flex-shrink-0">
         <div className="flex items-center gap-2">
           <span className="text-sm font-medium text-muted-foreground">
             {totalItems} values

--- a/web/src/components/cards/ISO27001Audit.tsx
+++ b/web/src/components/cards/ISO27001Audit.tsx
@@ -222,7 +222,7 @@ export function ISO27001Audit({ config }: ISO27001AuditProps) {
   return (
     <div className="h-full flex flex-col min-h-card content-loaded">
       {/* Header: stats + controls */}
-      <div className="flex items-center justify-between mb-2">
+      <div className="flex flex-wrap items-center justify-between gap-y-2 mb-2">
         <div className="flex items-center gap-2">
           <div className="flex items-center gap-1">
             <Shield className="w-4 h-4 text-blue-400" />

--- a/web/src/components/cards/IframeEmbed.tsx
+++ b/web/src/components/cards/IframeEmbed.tsx
@@ -177,7 +177,7 @@ export function IframeEmbed({ config }: { config?: IframeEmbedConfig }) {
     <div className="h-full flex flex-col">
       <div className="h-full flex flex-col">
         {/* Header controls */}
-        <div className="flex items-center justify-between mb-2">
+        <div className="flex flex-wrap items-center justify-between gap-y-2 mb-2">
           <div className="flex items-center gap-2 min-w-0">
             <Globe className="w-4 h-4 text-muted-foreground flex-shrink-0" />
             {url && !showSettings ? (
@@ -217,7 +217,7 @@ export function IframeEmbed({ config }: { config?: IframeEmbedConfig }) {
         {/* Settings panel */}
         {showSettings && (
           <div className="mb-3 p-3 rounded-lg bg-secondary/30 border border-border/50">
-            <div className="flex items-center justify-between mb-3">
+            <div className="flex flex-wrap items-center justify-between gap-y-2 mb-3">
               <span className="text-sm font-medium">{t('cards:iframeEmbed.embedConfiguration')}</span>
               {url && (
                 <button

--- a/web/src/components/cards/IssueActivityChart.tsx
+++ b/web/src/components/cards/IssueActivityChart.tsx
@@ -469,7 +469,7 @@ export function IssueActivityChart(props: { config?: IssueActivityConfig }) {
   return (
     <div className="p-4 space-y-3">
       {/* Header */}
-      <div className="flex items-center justify-between flex-wrap gap-2">
+      <div className="flex flex-wrap items-center justify-between gap-y-2  gap-2">
         <div className="flex items-center gap-2">
           <Calendar className="h-4 w-4 text-muted-foreground" />
           <RepoSubtitle repo={repo} />
@@ -503,7 +503,7 @@ export function IssueActivityChart(props: { config?: IssueActivityConfig }) {
       </div>
 
       {/* Summary stats */}
-      <div className="grid grid-cols-3 gap-3">
+      <div className="grid grid-cols-2 sm:grid-cols-3 gap-3">
         <div className="rounded-md bg-blue-500/10 border border-blue-500/20 px-3 py-2 text-center">
           <div className="text-lg font-semibold text-blue-400">{summary.totalOpened}</div>
           <div className="text-[10px] text-muted-foreground uppercase tracking-wide">

--- a/web/src/components/cards/KagentStatusCard.tsx
+++ b/web/src/components/cards/KagentStatusCard.tsx
@@ -100,7 +100,7 @@ export function KagentStatusCard({ config }: KagentStatusCardProps) {
   if (showSkeleton) {
     return (
       <div className="space-y-3 p-1">
-        <div className="grid grid-cols-3 gap-2">
+        <div className="grid grid-cols-2 sm:grid-cols-3 gap-2">
           {[1, 2, 3].map(i => <Skeleton key={i} className="h-16 rounded-lg" />)}
         </div>
         <Skeleton className="h-24 rounded-lg" />
@@ -126,7 +126,7 @@ export function KagentStatusCard({ config }: KagentStatusCardProps) {
   return (
     <div className="space-y-3 p-1">
       {/* Metric tiles */}
-      <div className="grid grid-cols-3 gap-2">
+      <div className="grid grid-cols-2 sm:grid-cols-3 gap-2">
         <MetricTile
           icon={Bot}
           label="Agents"

--- a/web/src/components/cards/KagentiStatusCard.tsx
+++ b/web/src/components/cards/KagentiStatusCard.tsx
@@ -106,7 +106,7 @@ export function KagentiStatusCard({ config }: KagentiStatusCardProps) {
   if (showSkeleton) {
     return (
       <div className="space-y-3 p-1">
-        <div className="grid grid-cols-3 gap-2">
+        <div className="grid grid-cols-2 sm:grid-cols-3 gap-2">
           {[1, 2, 3].map(i => <Skeleton key={i} className="h-16 rounded-lg" />)}
         </div>
         <Skeleton className="h-24 rounded-lg" />
@@ -132,7 +132,7 @@ export function KagentiStatusCard({ config }: KagentiStatusCardProps) {
   return (
     <div className="space-y-3 p-1">
       {/* Metric tiles */}
-      <div className="grid grid-cols-3 gap-2">
+      <div className="grid grid-cols-2 sm:grid-cols-3 gap-2">
         <MetricTile
           icon={Bot}
           label="Agents"

--- a/web/src/components/cards/KubeBert.tsx
+++ b/web/src/components/cards/KubeBert.tsx
@@ -649,7 +649,7 @@ export function KubeBert() {
   return (
     <div ref={containerRef} className="h-full flex flex-col">
       {/* Stats bar */}
-      <div className="flex items-center justify-between px-3 py-1.5 bg-black/30 rounded-t-lg text-xs">
+      <div className="flex flex-wrap items-center justify-between gap-y-2 px-3 py-1.5 bg-black/30 rounded-t-lg text-xs">
         <div className="flex items-center gap-3">
           <span className="flex items-center gap-1 text-yellow-400">
             <Trophy className="w-3.5 h-3.5" />

--- a/web/src/components/cards/KubeChess.tsx
+++ b/web/src/components/cards/KubeChess.tsx
@@ -935,7 +935,7 @@ function KubeChessInternal() {
     <div className="h-full flex flex-col">
       <div className="flex flex-col items-center gap-3">
         {/* Status */}
-        <div className="flex items-center justify-between w-full max-w-xs">
+        <div className="flex flex-wrap items-center justify-between gap-y-2 w-full max-w-xs">
           <div className="flex items-center gap-2">
             <div className={`w-3 h-3 rounded-full ${gameState.turn === 'white' ? 'bg-white border border-gray-300 dark:border-gray-600' : 'bg-gray-800 dark:bg-gray-900'}`} />
             <span className="text-sm font-medium">

--- a/web/src/components/cards/KubeDoom.tsx
+++ b/web/src/components/cards/KubeDoom.tsx
@@ -555,7 +555,7 @@ export function KubeDoom() {
     <div ref={gameContainerRef} className="h-full flex flex-col">
       <div className={`flex flex-col items-center gap-3 ${isExpanded ? 'flex-1 min-h-0' : ''}`}>
         {/* Stats bar */}
-        <div className="flex items-center justify-between w-full max-w-[480px] text-sm">
+        <div className="flex flex-wrap items-center justify-between gap-y-2 w-full max-w-[480px] text-sm">
           <div className="flex items-center gap-4">
             <div className="flex items-center gap-1">
               <Target className="w-4 h-4 text-cyan-400" />

--- a/web/src/components/cards/KubeGalaga.tsx
+++ b/web/src/components/cards/KubeGalaga.tsx
@@ -485,7 +485,7 @@ export function KubeGalaga() {
     <div ref={gameContainerRef} className="h-full flex flex-col">
       <div className={`flex flex-col items-center gap-3 ${isExpanded ? 'flex-1 min-h-0' : ''}`}>
         {/* Stats bar */}
-        <div className="flex items-center justify-between w-full max-w-[400px] text-sm">
+        <div className="flex flex-wrap items-center justify-between gap-y-2 w-full max-w-[400px] text-sm">
           <div className="flex items-center gap-4">
             <div className="flex items-center gap-1">
               <Target className="w-4 h-4 text-cyan-400" />

--- a/web/src/components/cards/KubeKart.tsx
+++ b/web/src/components/cards/KubeKart.tsx
@@ -529,7 +529,7 @@ export function KubeKart() {
     <div ref={gameContainerRef} className="h-full flex flex-col">
       <div className={`flex flex-col items-center gap-3 ${isExpanded ? 'flex-1 min-h-0' : ''}`}>
         {/* Stats bar */}
-        <div className="flex items-center justify-between w-full max-w-[400px] text-sm">
+        <div className="flex flex-wrap items-center justify-between gap-y-2 w-full max-w-[400px] text-sm">
           <div className="flex items-center gap-4">
             <div className="flex items-center gap-1">
               <Flag className="w-4 h-4 text-green-400" />

--- a/web/src/components/cards/KubeKong.tsx
+++ b/web/src/components/cards/KubeKong.tsx
@@ -672,7 +672,7 @@ export function KubeKong(_props: CardComponentProps) {
 
   return (
     <div ref={gameContainerRef} className="h-full flex flex-col p-2 select-none">
-      <div className="flex items-center justify-between gap-2 mb-2 flex-wrap">
+      <div className="flex flex-wrap items-center justify-between gap-y-2 gap-2 mb-2 ">
         <div className="flex items-center gap-3 text-xs">
           <div className="text-center">
             <div className="text-muted-foreground">Score</div>

--- a/web/src/components/cards/KubeMan.tsx
+++ b/web/src/components/cards/KubeMan.tsx
@@ -601,7 +601,7 @@ export function KubeMan(_props: CardComponentProps) {
   return (
     <div ref={gameContainerRef} className="h-full flex flex-col p-2 select-none">
       {/* Header */}
-      <div className="flex items-center justify-between gap-2 mb-2 flex-wrap">
+      <div className="flex flex-wrap items-center justify-between gap-y-2 gap-2 mb-2 ">
         <div className="flex items-center gap-3 text-xs">
           <div className="text-center">
             <div className="text-muted-foreground">Score</div>

--- a/web/src/components/cards/KubePong.tsx
+++ b/web/src/components/cards/KubePong.tsx
@@ -305,7 +305,7 @@ export function KubePong() {
     <div ref={gameContainerRef} className="h-full flex flex-col">
       <div className={`flex flex-col items-center gap-3 ${isExpanded ? 'flex-1 min-h-0' : ''}`}>
         {/* Stats bar */}
-        <div className="flex items-center justify-between w-full max-w-[400px] text-sm">
+        <div className="flex flex-wrap items-center justify-between gap-y-2 w-full max-w-[400px] text-sm">
           <div className="flex items-center gap-2">
             <User className="w-4 h-4 text-blue-400" />
             <span className="font-bold text-lg">{playerScore}</span>

--- a/web/src/components/cards/KubeSnake.tsx
+++ b/web/src/components/cards/KubeSnake.tsx
@@ -331,7 +331,7 @@ export function KubeSnake() {
     <div ref={gameContainerRef} className="h-full flex flex-col">
       <div className={`flex flex-col items-center gap-3 ${isExpanded ? 'flex-1 min-h-0' : ''}`}>
         {/* Stats bar */}
-        <div className="flex items-center justify-between w-full text-sm" style={{ maxWidth: isExpanded ? CANVAS_WIDTH * canvasScale : DEFAULT_CANVAS_SIZE }}>
+        <div className="flex flex-wrap items-center justify-between gap-y-2 w-full text-sm" style={{ maxWidth: isExpanded ? CANVAS_WIDTH * canvasScale : DEFAULT_CANVAS_SIZE }}>
           <div className="flex items-center gap-2">
             <Apple className="w-4 h-4 text-red-400" />
             <span className="font-bold text-lg">{score}</span>

--- a/web/src/components/cards/KubecostOverview.tsx
+++ b/web/src/components/cards/KubecostOverview.tsx
@@ -109,7 +109,7 @@ export function KubecostOverview({ config: _config }: KubecostOverviewProps) {
 
       {/* Savings recommendations */}
       <div className="flex-1 overflow-y-auto">
-        <div className="flex items-center justify-between mb-2">
+        <div className="flex flex-wrap items-center justify-between gap-y-2 mb-2">
           <p className="text-xs text-muted-foreground font-medium">{t('kubecostOverview.savingsRecommendations')}</p>
           <span className="flex items-center gap-1 text-xs text-green-400">
             <TrendingDown className="w-3 h-3" aria-hidden="true" />
@@ -128,7 +128,7 @@ export function KubecostOverview({ config: _config }: KubecostOverviewProps) {
               })}
               className="p-2 rounded-lg bg-secondary/30 hover:bg-secondary/50 transition-colors cursor-pointer group"
             >
-              <div className="flex items-center justify-between">
+              <div className="flex flex-wrap items-center justify-between gap-y-2">
                 <div className="flex items-center gap-2">
                   <AlertTriangle className="w-3.5 h-3.5 text-yellow-400" />
                   <span className="text-xs text-foreground group-hover:text-green-400">{rec.description}</span>
@@ -144,7 +144,7 @@ export function KubecostOverview({ config: _config }: KubecostOverviewProps) {
       </div>
 
       {/* Footer */}
-      <div className="mt-3 pt-2 border-t border-border/50 flex items-center justify-between text-xs text-muted-foreground">
+      <div className="mt-3 pt-2 border-t border-border/50 flex flex-wrap items-center justify-between gap-y-2 text-xs text-muted-foreground">
         <span>{t('kubecostOverview.poweredBy')}</span>
         <a
           href="https://docs.kubecost.com/"

--- a/web/src/components/cards/Kubectl.tsx
+++ b/web/src/components/cards/Kubectl.tsx
@@ -482,7 +482,7 @@ data:
   return (
     <div className="h-full flex flex-col min-h-card overflow-hidden">
       {/* Header with controls */}
-      <div className="flex items-center justify-between mb-4 gap-2 min-w-0">
+      <div className="flex flex-wrap items-center justify-between gap-y-2 mb-4 gap-2 min-w-0">
         <div className="flex items-center gap-2 min-w-0 flex-1">
           {clusters.length > 0 && (
             <select
@@ -580,7 +580,7 @@ data:
       {/* YAML Editor Panel */}
       {showYAMLEditor && (
         <div className="mb-4 p-3 bg-blue-500/10 border border-blue-500/20 rounded-lg">
-          <div className="flex items-center justify-between mb-2">
+          <div className="flex flex-wrap items-center justify-between gap-y-2 mb-2">
             <div className="flex items-center gap-2">
               <FileCode className="w-4 h-4 text-blue-400" />
               <span className="text-sm font-medium text-blue-300">{t('cards:kubectl.yamlEditor')}</span>
@@ -681,7 +681,7 @@ data:
                       selectedManifest === manifest.id ? 'bg-secondary/50 text-foreground' : 'text-muted-foreground'
                     )}
                   >
-                    <div className="flex items-center justify-between">
+                    <div className="flex flex-wrap items-center justify-between gap-y-2">
                       <span>{manifest.name}</span>
                       <span className="text-2xs">{manifest.timestamp.toLocaleTimeString()}</span>
                     </div>
@@ -722,7 +722,7 @@ data:
                 }}
                 className="w-full px-2 py-1.5 text-xs rounded text-left hover:bg-secondary/50 group"
               >
-                <div className="flex items-center justify-between">
+                <div className="flex flex-wrap items-center justify-between gap-y-2">
                   <div className="flex items-center gap-2 flex-1 min-w-0">
                     {item.success ? (
                       <CheckCircle className="w-3 h-3 text-green-400 flex-shrink-0" />

--- a/web/src/components/cards/Kubedle.tsx
+++ b/web/src/components/cards/Kubedle.tsx
@@ -278,7 +278,7 @@ export function Kubedle(_props: CardComponentProps) {
   return (
     <div ref={gameContainerRef} className="h-full flex flex-col p-2 select-none">
       {/* Header */}
-      <div className="flex items-center justify-between gap-2 mb-2">
+      <div className="flex flex-wrap items-center justify-between gap-y-2 gap-2 mb-2">
         {practiceMode && (
           <span className="text-xs text-muted-foreground">(Practice)</span>
         )}
@@ -390,7 +390,7 @@ export function Kubedle(_props: CardComponentProps) {
       {showHelp && (
         <div className="absolute inset-0 bg-background/90 flex items-center justify-center rounded-lg z-10 p-4">
           <div className="bg-card border border-border rounded-lg p-4 max-w-sm">
-            <div className="flex items-center justify-between mb-3">
+            <div className="flex flex-wrap items-center justify-between gap-y-2 mb-3">
               <h3 className="font-bold text-foreground">How to Play</h3>
               <button onClick={() => setShowHelp(false)} aria-label="Close help">
                 <X className="w-4 h-4" />
@@ -422,14 +422,14 @@ export function Kubedle(_props: CardComponentProps) {
       {showStats && (
         <div className="absolute inset-0 bg-background/90 flex items-center justify-center rounded-lg z-10 p-4">
           <div className="bg-card border border-border rounded-lg p-4 max-w-sm w-full">
-            <div className="flex items-center justify-between mb-3">
+            <div className="flex flex-wrap items-center justify-between gap-y-2 mb-3">
               <h3 className="font-bold text-foreground">Statistics</h3>
               <button onClick={() => setShowStats(false)} aria-label="Close statistics">
                 <X className="w-4 h-4" />
               </button>
             </div>
 
-            <div className="grid grid-cols-4 gap-2 text-center mb-4">
+            <div className="grid grid-cols-2 sm:grid-cols-4 gap-2 text-center mb-4">
               <div>
                 <div className="text-2xl font-bold text-foreground">{stats.played}</div>
                 <div className="text-xs text-muted-foreground">Played</div>

--- a/web/src/components/cards/KustomizationStatus.tsx
+++ b/web/src/components/cards/KustomizationStatus.tsx
@@ -221,7 +221,7 @@ export function KustomizationStatus({ config }: KustomizationStatusProps) {
   if (showSkeleton) {
     return (
       <div className="h-full flex flex-col min-h-card">
-        <div className="flex items-center justify-between mb-4">
+        <div className="flex flex-wrap items-center justify-between gap-y-2 mb-4">
           <Skeleton variant="text" width={160} height={20} />
           <Skeleton variant="rounded" width={80} height={28} />
         </div>
@@ -247,7 +247,7 @@ export function KustomizationStatus({ config }: KustomizationStatusProps) {
   return (
     <div className="h-full flex flex-col min-h-card content-loaded">
       {/* Header */}
-      <div className="flex items-center justify-between mb-4">
+      <div className="flex flex-wrap items-center justify-between gap-y-2 mb-4">
         <div className="flex items-center gap-2">
           <span className="text-sm font-medium text-muted-foreground">
             {totalItems} kustomizations
@@ -361,7 +361,7 @@ export function KustomizationStatus({ config }: KustomizationStatusProps) {
                   className={`p-3 rounded-lg cursor-pointer group ${ks.status === 'NotReady' ? 'bg-red-500/10 border border-red-500/20' : 'bg-secondary/30'} hover:bg-secondary/50 transition-colors`}
                   title={`Click to view ${ks.name} details`}
                 >
-                  <div className="flex items-center justify-between mb-1">
+                  <div className="flex flex-wrap items-center justify-between gap-y-2 mb-1">
                     <div className="flex items-center gap-2">
                       <StatusIcon className={`w-4 h-4 text-${color}-400 ${ks.status === 'Progressing' ? 'animate-spin' : ''}`} />
                       <span className="text-sm text-foreground font-medium">{ks.name}</span>
@@ -378,7 +378,7 @@ export function KustomizationStatus({ config }: KustomizationStatusProps) {
                       <GitBranch className="w-3 h-3" />
                       <span className="truncate">{ks.path}</span>
                     </div>
-                    <div className="flex items-center justify-between">
+                    <div className="flex flex-wrap items-center justify-between gap-y-2">
                       <span className="truncate">{ks.revision.split('@')[1]?.slice(0, 12)}</span>
                       <span>{formatTime(ks.lastApplied)}</span>
                     </div>

--- a/web/src/components/cards/KyvernoPolicies.tsx
+++ b/web/src/components/cards/KyvernoPolicies.tsx
@@ -257,7 +257,7 @@ Please proceed step by step.`,
       )}
 
       {/* Stats */}
-      <div className="grid grid-cols-3 gap-2 mb-3">
+      <div className="grid grid-cols-2 sm:grid-cols-3 gap-2 mb-3">
         <div className="p-2 rounded-lg bg-cyan-500/10 border border-cyan-500/20 text-center">
           <p className="text-2xs text-cyan-400">Policies</p>
           <p className="text-lg font-bold text-foreground">{stats.totalPolicies}</p>
@@ -295,7 +295,7 @@ Please proceed step by step.`,
             tabIndex={0}
             onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); handlePolicyClick(policy) } }}
           >
-            <div className="flex items-center justify-between mb-1">
+            <div className="flex flex-wrap items-center justify-between gap-y-2 mb-1">
               <div className="flex items-center gap-2">
                 <span className="text-sm font-medium text-foreground truncate">{policy.name}</span>
                 <span className={`px-1.5 py-0.5 rounded text-2xs ${getStatusColor(policy.status)}`}>
@@ -309,7 +309,7 @@ Please proceed step by step.`,
                 </span>
               )}
             </div>
-            <div className="flex items-center justify-between text-xs">
+            <div className="flex flex-wrap items-center justify-between gap-y-2 text-xs">
               <span className={getCategoryColor(policy.category)}>{policy.category}</span>
               <div className="flex items-center gap-2 text-muted-foreground">
                 <span>{policy.kind}</span>

--- a/web/src/components/cards/MaintenanceWindows.tsx
+++ b/web/src/components/cards/MaintenanceWindows.tsx
@@ -150,7 +150,7 @@ export function MaintenanceWindows() {
 
   return (
     <div className="space-y-2 p-1">
-      <div className="flex items-center justify-between">
+      <div className="flex flex-wrap items-center justify-between gap-y-2">
         <span className="text-xs text-muted-foreground">{displayWindows.filter(w => w.status !== 'completed').length} upcoming</span>
         <button
           onClick={() => { setShowForm(!showForm); setTimeError('') }}
@@ -206,7 +206,7 @@ export function MaintenanceWindows() {
           {timeError && (
             <p className="text-xs text-red-400">{timeError}</p>
           )}
-          <div className="flex items-center justify-between">
+          <div className="flex flex-wrap items-center justify-between gap-y-2">
             <select
               value={formData.type}
               onChange={e => setFormData(f => ({ ...f, type: e.target.value as MaintenanceWindow['type'] }))}
@@ -231,7 +231,7 @@ export function MaintenanceWindows() {
           </div>
         ) : (
           displayWindows.map(w => (
-            <div key={w.id} className="flex items-center justify-between px-2 py-1.5 rounded-lg bg-muted/30 hover:bg-muted/50 transition-colors group">
+            <div key={w.id} className="flex flex-wrap items-center justify-between gap-y-2 px-2 py-1.5 rounded-lg bg-muted/30 hover:bg-muted/50 transition-colors group">
               <div className="min-w-0 flex-1">
                 <div className="flex items-center gap-1.5">
                   <span className={`text-xs px-1.5 py-0.5 rounded ${statusColors[w.status]}`}>{w.status}</span>

--- a/web/src/components/cards/MatchGame.tsx
+++ b/web/src/components/cards/MatchGame.tsx
@@ -291,7 +291,7 @@ export function MatchGame(_props: CardComponentProps) {
       />
 
       {/* Header with controls */}
-      <div className="flex items-center justify-between gap-2 flex-wrap">
+      <div className="flex flex-wrap items-center justify-between gap-y-2 gap-2 ">
         {/* Difficulty selector */}
         <div className="flex gap-1">
           {(['easy', 'medium', 'hard'] as Difficulty[]).map(d => (
@@ -312,7 +312,7 @@ export function MatchGame(_props: CardComponentProps) {
 
       {/* Game stats */}
       {isPlaying && (
-        <div className="flex items-center justify-between gap-2 text-xs">
+        <div className="flex flex-wrap items-center justify-between gap-y-2 gap-2 text-xs">
           <div className="flex items-center gap-1.5">
             <Hash className="w-3.5 h-3.5 text-blue-400" />
             <span>Moves: <span className="font-bold">{moves}</span></span>

--- a/web/src/components/cards/MissileCommand.tsx
+++ b/web/src/components/cards/MissileCommand.tsx
@@ -505,7 +505,7 @@ export function MissileCommand(_props: CardComponentProps) {
   return (
     <div className="h-full flex flex-col p-2 select-none">
       {/* Header */}
-      <div className="flex items-center justify-between gap-2 mb-2 flex-wrap">
+      <div className="flex flex-wrap items-center justify-between gap-y-2 gap-2 mb-2 ">
         <div className="flex items-center gap-1.5">
           <Crosshair className="w-4 h-4 text-red-400" />
           <span className="text-sm font-semibold">Missile Command</span>

--- a/web/src/components/cards/Missions.tsx
+++ b/web/src/components/cards/Missions.tsx
@@ -350,7 +350,7 @@ Please:
   return (
     <div className="h-full flex flex-col">
       {/* Controls row: cluster filter + sort + limit */}
-      <div className="flex items-center justify-between mb-2 shrink-0">
+      <div className="flex flex-wrap items-center justify-between gap-y-2 mb-2 shrink-0">
         <div className="flex items-center gap-2">
           {activeMissions.length > 0 ? (
             <StatusBadge color="blue" size="xs">

--- a/web/src/components/cards/MobileBrowser.tsx
+++ b/web/src/components/cards/MobileBrowser.tsx
@@ -317,7 +317,7 @@ export function MobileBrowser() {
                   {bookmarks.length > 0 && (
                     <div className="mb-4">
                       <h3 className="text-xs font-semibold text-muted-foreground mb-2">Favorites</h3>
-                      <div className="grid grid-cols-4 gap-2">
+                      <div className="grid grid-cols-2 sm:grid-cols-4 gap-2">
                         {bookmarks.slice(0, 8).map((bookmark, i) => (
                           <button
                             key={i}
@@ -339,7 +339,7 @@ export function MobileBrowser() {
                   {/* Quick Links */}
                   <div>
                     <h3 className="text-xs font-semibold text-muted-foreground mb-2">Quick Links</h3>
-                    <div className="grid grid-cols-4 gap-2">
+                    <div className="grid grid-cols-2 sm:grid-cols-4 gap-2">
                       {QUICK_LINKS.map((link) => (
                         <button
                           key={link.url}
@@ -389,7 +389,7 @@ export function MobileBrowser() {
                       }`}
                     >
                       <div className="bg-white dark:bg-secondary p-3">
-                        <div className="flex items-center justify-between">
+                        <div className="flex flex-wrap items-center justify-between gap-y-2">
                           <span className="text-xs font-medium text-gray-700 dark:text-foreground truncate">
                             {tab.title || 'New Tab'}
                           </span>

--- a/web/src/components/cards/NamespaceEvents.tsx
+++ b/web/src/components/cards/NamespaceEvents.tsx
@@ -183,7 +183,7 @@ export function NamespaceEvents({ config }: NamespaceEventsProps) {
   return (
     <div className="h-full flex flex-col min-h-card content-loaded overflow-hidden">
       {/* Header */}
-      <div className="flex items-center justify-between mb-4">
+      <div className="flex flex-wrap items-center justify-between gap-y-2 mb-4">
         <div className="flex items-center gap-2">
           {totalItems > 0 && (
             <StatusBadge color="orange">

--- a/web/src/components/cards/NamespaceMonitor.tsx
+++ b/web/src/components/cards/NamespaceMonitor.tsx
@@ -560,7 +560,7 @@ export function NamespaceMonitor({ config: _config }: CardComponentProps) {
     <div className={`absolute right-0 top-12 w-80 bg-card border border-border rounded-lg shadow-xl z-40 transition-all ${
       showChangesPanel ? 'opacity-100 translate-y-0' : 'opacity-0 -translate-y-2 pointer-events-none'
     }`}>
-      <div className="flex items-center justify-between p-3 border-b border-border">
+      <div className="flex flex-wrap items-center justify-between gap-y-2 p-3 border-b border-border">
         <span className="text-sm font-medium text-foreground">Recent Changes</span>
         <button onClick={() => setShowChangesPanel(false)} aria-label="Close recent changes panel" className="p-2 hover:bg-secondary rounded min-h-11 min-w-11 flex items-center justify-center">
           <X className="w-4 h-4 text-muted-foreground" />

--- a/web/src/components/cards/NamespaceOverview.tsx
+++ b/web/src/components/cards/NamespaceOverview.tsx
@@ -130,7 +130,7 @@ export function NamespaceOverview({ config }: NamespaceOverviewProps) {
   if (showSkeleton) {
     return (
       <div className="h-full flex flex-col min-h-card">
-        <div className="flex items-center justify-between mb-4">
+        <div className="flex flex-wrap items-center justify-between gap-y-2 mb-4">
           <Skeleton variant="text" width={150} height={20} />
           <Skeleton variant="rounded" width={200} height={32} />
         </div>
@@ -156,7 +156,7 @@ export function NamespaceOverview({ config }: NamespaceOverviewProps) {
   return (
     <div className="h-full flex flex-col min-h-card content-loaded overflow-hidden">
       {/* Header */}
-      <div className="flex items-center justify-between mb-4">
+      <div className="flex flex-wrap items-center justify-between gap-y-2 mb-4">
         <RefreshIndicator
           isRefreshing={isRefreshing}
           lastUpdated={lastRefresh ? new Date(lastRefresh) : null}

--- a/web/src/components/cards/NamespaceQuotas.tsx
+++ b/web/src/components/cards/NamespaceQuotas.tsx
@@ -226,7 +226,7 @@ function QuotaModal({
 
           {/* Resources */}
           <div>
-            <div className="flex items-center justify-between mb-2">
+            <div className="flex flex-wrap items-center justify-between gap-y-2 mb-2">
               <label className="text-sm font-medium text-muted-foreground">{t('namespaceQuotas.resourceLimits')}</label>
               <div className="flex items-center gap-2">
                 <div className="relative">
@@ -553,7 +553,7 @@ export function NamespaceQuotas({ config }: NamespaceQuotasProps) {
   if (isInitialLoading) {
     return (
       <div className="h-full flex flex-col min-h-card">
-        <div className="flex items-center justify-between mb-4">
+        <div className="flex flex-wrap items-center justify-between gap-y-2 mb-4">
           <Skeleton variant="text" width={140} height={20} />
           <Skeleton variant="rounded" width={80} height={28} />
         </div>
@@ -570,7 +570,7 @@ export function NamespaceQuotas({ config }: NamespaceQuotasProps) {
   return (
     <div className="h-full flex flex-col min-h-card content-loaded overflow-hidden">
       {/* Header */}
-      <div className="flex items-center justify-between mb-4">
+      <div className="flex flex-wrap items-center justify-between gap-y-2 mb-4">
         <div className="flex items-center gap-2">
           <StatusBadge color="yellow">
             {activeTab === 'quotas' ? `${totalQuotas} quotas` : `${totalLimits} limits`}
@@ -724,7 +724,7 @@ export function NamespaceQuotas({ config }: NamespaceQuotasProps) {
                 return (
                   <div key={`${quota.cluster}-${quota.namespace}-${quota.resource}-${idx}`} className={`p-3 rounded-lg bg-secondary/30 ${isFetchingData ? 'opacity-50' : ''}`}>
                     {showScope && (
-                      <div className="flex items-center justify-between mb-2 gap-2">
+                      <div className="flex flex-wrap items-center justify-between gap-y-2 mb-2 gap-2">
                         <div className="flex items-center gap-1 text-xs text-muted-foreground min-w-0 overflow-hidden">
                           {quota.cluster && <span className="flex-shrink-0"><ClusterBadge cluster={quota.cluster} size="sm" /></span>}
                           {quota.namespace && (
@@ -760,7 +760,7 @@ export function NamespaceQuotas({ config }: NamespaceQuotasProps) {
                         )}
                       </div>
                     )}
-                    <div className="flex items-center justify-between mb-2">
+                    <div className="flex flex-wrap items-center justify-between gap-y-2 mb-2">
                       <div className="flex items-center gap-2">
                         <Icon className={`w-4 h-4 ${USAGE_TEXT_CLASSES[color]}`} />
                         <span className="text-sm text-foreground">{quota.resource}</span>
@@ -803,7 +803,7 @@ export function NamespaceQuotas({ config }: NamespaceQuotasProps) {
                         )}
                       </div>
                     )}
-                    <div className="flex items-center justify-between">
+                    <div className="flex flex-wrap items-center justify-between gap-y-2">
                       <div className="flex items-center gap-2">
                         <Gauge className="w-4 h-4 text-blue-400" />
                         <span className="text-sm text-foreground">{item.name}</span>

--- a/web/src/components/cards/NamespaceRBAC.tsx
+++ b/web/src/components/cards/NamespaceRBAC.tsx
@@ -176,7 +176,7 @@ function NamespaceRBACInternal({ config }: NamespaceRBACProps) {
   if (showSkeleton) {
     return (
       <div className="h-full flex flex-col min-h-card">
-        <div className="flex items-center justify-between mb-4">
+        <div className="flex flex-wrap items-center justify-between gap-y-2 mb-4">
           <Skeleton variant="text" width={130} height={20} />
           <Skeleton variant="rounded" width={80} height={28} />
         </div>
@@ -202,7 +202,7 @@ function NamespaceRBACInternal({ config }: NamespaceRBACProps) {
   return (
     <div className="h-full flex flex-col min-h-card content-loaded">
       {/* Header */}
-      <div className="flex items-center justify-between mb-4">
+      <div className="flex flex-wrap items-center justify-between gap-y-2 mb-4">
         <div className="flex items-center gap-2">
           <StatusBadge color="purple">
             {activeTab === 'roles' ? t('namespaceRBAC.nRoles', { count: rbacRoles.length }) : activeTab === 'bindings' ? t('namespaceRBAC.nBindings', { count: rbacBindings.length }) : t('namespaceRBAC.nServiceAccounts', { count: rbacServiceAccounts.length })}
@@ -340,7 +340,7 @@ function NamespaceRBACInternal({ config }: NamespaceRBACProps) {
                     subjects: item.subjects })}
                   className={`p-3 rounded-lg bg-secondary/30 hover:bg-secondary/50 cursor-pointer transition-colors group ${isFetchingRBAC ? 'opacity-50' : ''}`}
                 >
-                  <div className="flex items-center justify-between">
+                  <div className="flex flex-wrap items-center justify-between gap-y-2">
                     <div className="flex items-center gap-2">
                       {activeTab === 'roles' && <Key className="w-4 h-4 text-yellow-400" />}
                       {activeTab === 'bindings' && <Lock className="w-4 h-4 text-green-400" />}
@@ -375,7 +375,7 @@ function NamespaceRBACInternal({ config }: NamespaceRBACProps) {
           />
 
           {/* Summary */}
-          <div className="mt-4 pt-3 border-t border-border/50 flex items-center justify-between text-xs text-muted-foreground">
+          <div className="mt-4 pt-3 border-t border-border/50 flex flex-wrap items-center justify-between gap-y-2 text-xs text-muted-foreground">
             <span>{t('namespaceRBAC.nRoles', { count: rbacRoles.length })}</span>
             <span>{t('namespaceRBAC.nBindings', { count: rbacBindings.length })}</span>
             <span>{t('namespaceRBAC.nServiceAccounts', { count: rbacServiceAccounts.length })}</span>

--- a/web/src/components/cards/NetworkOverview.tsx
+++ b/web/src/components/cards/NetworkOverview.tsx
@@ -109,7 +109,7 @@ export function NetworkOverview() {
     return (
       <div className="h-full flex flex-col min-h-card">
         {/* Header skeleton */}
-        <div className="flex items-center justify-between mb-3">
+        <div className="flex flex-wrap items-center justify-between gap-y-2 mb-3">
           <div className="flex items-center gap-2">
             <Skeleton variant="circular" width={16} height={16} />
             <Skeleton variant="text" width={100} height={16} />
@@ -162,7 +162,7 @@ export function NetworkOverview() {
       )}
 
       {/* Controls */}
-      <div className="flex items-center justify-between mb-4">
+      <div className="flex flex-wrap items-center justify-between gap-y-2 mb-4">
         {/* part 5: freshness indicator.
             #6265: this card uses BOTH useClusters() and useCachedServices(),
             so the indicator must reflect the OLDER of the two timestamps
@@ -314,7 +314,7 @@ export function NetworkOverview() {
               return (
                 <div
                   key={name}
-                  className={`flex items-center justify-between gap-2 p-2 rounded bg-secondary/30 ${svc ? 'cursor-pointer hover:bg-secondary/50' : 'cursor-default'} transition-colors`}
+                  className={`flex flex-wrap items-center justify-between gap-y-2 gap-2 p-2 rounded bg-secondary/30 ${svc ? 'cursor-pointer hover:bg-secondary/50' : 'cursor-default'} transition-colors`}
                   onClick={() => svc?.cluster && svc?.namespace && drillToService(svc.cluster, svc.namespace, svc.name)}
                   title={`${count} service${count !== 1 ? 's' : ''} in namespace ${name}${svc ? ' - Click to view' : ''}`}
                 >

--- a/web/src/components/cards/NetworkPolicyCoverage.tsx
+++ b/web/src/components/cards/NetworkPolicyCoverage.tsx
@@ -154,7 +154,7 @@ export function NetworkPolicyCoverage() {
       {/* Namespace list */}
       <div className="space-y-1 max-h-[250px] overflow-y-auto">
         {displayed.slice(0, 30).map(ns => (
-          <div key={`${ns.cluster}/${ns.namespace}`} className="flex items-center justify-between px-2 py-1 rounded-lg bg-muted/30 hover:bg-muted/50 transition-colors">
+          <div key={`${ns.cluster}/${ns.namespace}`} className="flex flex-wrap items-center justify-between gap-y-2 px-2 py-1 rounded-lg bg-muted/30 hover:bg-muted/50 transition-colors">
             <div className="flex items-center gap-2 min-w-0">
               <div className={`w-2 h-2 rounded-full ${ns.hasPolicies ? 'bg-green-500' : 'bg-red-500'}`} />
               <div className="min-w-0">

--- a/web/src/components/cards/NetworkUtils.tsx
+++ b/web/src/components/cards/NetworkUtils.tsx
@@ -318,7 +318,7 @@ export function NetworkUtils() {
   return (
     <div className="h-full flex flex-col">
         {/* Network status bar */}
-        <div className="flex items-center justify-between mb-3 p-2 rounded-lg bg-secondary/30">
+        <div className="flex flex-wrap items-center justify-between gap-y-2 mb-3 p-2 rounded-lg bg-secondary/30">
           <div className="flex items-center gap-2">
             {networkInfo.online ? (
               <Wifi className="w-4 h-4 text-green-400" />
@@ -440,7 +440,7 @@ export function NetworkUtils() {
                     key={host}
                     className="p-3 rounded-lg bg-secondary/20 border border-border/50"
                   >
-                    <div className="flex items-center justify-between mb-2">
+                    <div className="flex flex-wrap items-center justify-between gap-y-2 mb-2">
                       <span className="text-sm font-medium truncate flex-1 mr-2">{host}</span>
                       <button
                         onClick={() => removeHost(host, 'ping')}
@@ -548,7 +548,7 @@ export function NetworkUtils() {
                   <div className="mt-4 space-y-2">
                     <p className="text-xs text-muted-foreground">{t('networkUtils.savedPortChecks')}</p>
                     {portHosts.map(({ host, port }) => (
-                      <div key={`${host}:${port}`} className="flex items-center justify-between px-3 py-2 bg-secondary/30 rounded">
+                      <div key={`${host}:${port}`} className="flex flex-wrap items-center justify-between gap-y-2 px-3 py-2 bg-secondary/30 rounded">
                         <span className="text-sm">{host}:{port}</span>
                         <button
                           onClick={() => removeHost(host, 'port', port)}

--- a/web/src/components/cards/NodeConditions.tsx
+++ b/web/src/components/cards/NodeConditions.tsx
@@ -141,7 +141,7 @@ export function NodeConditions() {
 
       {/* Error toast for failed actions */}
       {actionError && (
-        <div className="p-2 rounded-lg bg-red-500/10 border border-red-500/30 text-xs text-red-400 flex items-center justify-between">
+        <div className="p-2 rounded-lg bg-red-500/10 border border-red-500/30 text-xs text-red-400 flex flex-wrap items-center justify-between gap-y-2">
           <span>{actionError}</span>
           <button onClick={() => setActionError(null)} className="ml-2 text-red-300 hover:text-red-200">
             ✕
@@ -193,7 +193,7 @@ export function NodeConditions() {
           const pressures = conditions.filter(c => c.type !== 'Ready' && c.status === 'True')
 
           return (
-            <div key={`${node.cluster}-${node.name}`} className="flex items-center justify-between px-2 py-1.5 rounded-lg bg-muted/30 hover:bg-muted/50 transition-colors">
+            <div key={`${node.cluster}-${node.name}`} className="flex flex-wrap items-center justify-between gap-y-2 px-2 py-1.5 rounded-lg bg-muted/30 hover:bg-muted/50 transition-colors">
               <div className="flex items-center gap-2 min-w-0 flex-1">
                 <div className={`w-2 h-2 rounded-full shrink-0 ${
                   node.unschedulable ? 'bg-yellow-500' :

--- a/web/src/components/cards/NodeInvaders.tsx
+++ b/web/src/components/cards/NodeInvaders.tsx
@@ -393,7 +393,7 @@ export function NodeInvaders(_props: CardComponentProps) {
 
   return (
     <div ref={gameContainerRef} className="h-full flex flex-col p-2 select-none">
-      <div className="flex items-center justify-between gap-2 mb-2 flex-wrap">
+      <div className="flex flex-wrap items-center justify-between gap-y-2 gap-2 mb-2 ">
         <div className="flex items-center gap-1.5">
           <Rocket className="w-4 h-4 text-cyan-400" />
           <span className="text-sm font-semibold">Node Invaders</span>

--- a/web/src/components/cards/OPAPolicies.tsx
+++ b/web/src/components/cards/OPAPolicies.tsx
@@ -634,7 +634,7 @@ Please:
   return (
     <div className="h-full flex flex-col min-h-card">
       {/* Controls */}
-      <div className="flex items-center justify-between mb-3">
+      <div className="flex flex-wrap items-center justify-between gap-y-2 mb-3">
         <div className="flex items-center gap-2">
           {installedCount > 0 && (
             <StatusBadge color="green" size="xs">
@@ -740,7 +740,7 @@ Please:
                     : ''
                 } ${isOffline ? 'opacity-50' : ''}`}
               >
-                <div className="flex items-center justify-between mb-1">
+                <div className="flex flex-wrap items-center justify-between gap-y-2 mb-1">
                   <span className={`text-sm font-medium text-foreground ${!isOffline && status?.installed ? 'group-hover:text-purple-400' : ''}`}>
                     {cluster.name}
                   </span>
@@ -805,7 +805,7 @@ Please:
                     <span>{status.error}</span>
                   </div>
                 ) : (
-                  <div className="flex items-center justify-between">
+                  <div className="flex flex-wrap items-center justify-between gap-y-2">
                     <span className="text-xs text-muted-foreground">Not installed</span>
                     <span
                       onClick={(e) => {
@@ -854,7 +854,7 @@ Please:
                     setSelectedPolicy(policy)
                     openPolicyModal()
                   }}
-                  className="w-full flex items-center justify-between text-xs p-1.5 -mx-1.5 rounded hover:bg-secondary/50 transition-colors group"
+                  className="w-full flex flex-wrap items-center justify-between gap-y-2 text-xs p-1.5 -mx-1.5 rounded hover:bg-secondary/50 transition-colors group"
                 >
                   <span className="text-foreground truncate group-hover:text-purple-400">{policy.name}</span>
                   <div className="flex items-center gap-2">

--- a/web/src/components/cards/OpenCostOverview.tsx
+++ b/web/src/components/cards/OpenCostOverview.tsx
@@ -95,7 +95,7 @@ function OpenCostOverviewInternal({ config: _config }: OpenCostOverviewProps) {
   return (
     <div className="h-full flex flex-col min-h-card content-loaded">
       {/* Header with controls */}
-      <div className="flex items-center justify-between mb-2 flex-shrink-0">
+      <div className="flex flex-wrap items-center justify-between gap-y-2 mb-2 flex-shrink-0">
         <div className="flex items-center gap-2">
           <span className="text-sm font-medium text-muted-foreground">
             {totalItems} namespaces
@@ -184,7 +184,7 @@ function OpenCostOverviewInternal({ config: _config }: OpenCostOverviewProps) {
             })}
             className="p-2 rounded-lg bg-secondary/30 hover:bg-secondary/50 transition-colors cursor-pointer group"
           >
-            <div className="flex items-center justify-between mb-1.5">
+            <div className="flex flex-wrap items-center justify-between gap-y-2 mb-1.5">
               <div className="flex items-center gap-2">
                 <Box className="w-3.5 h-3.5 text-muted-foreground" />
                 <span className="text-sm font-medium text-foreground group-hover:text-blue-400">{ns.namespace}</span>
@@ -226,7 +226,7 @@ function OpenCostOverviewInternal({ config: _config }: OpenCostOverviewProps) {
       />
 
       {/* Footer */}
-      <div className="mt-3 pt-2 border-t border-border/50 flex items-center justify-between text-xs text-muted-foreground">
+      <div className="mt-3 pt-2 border-t border-border/50 flex flex-wrap items-center justify-between gap-y-2 text-xs text-muted-foreground">
         <span>{t('costs.poweredByOpenCost')}</span>
         <a
           href="https://www.opencost.io/docs"

--- a/web/src/components/cards/OperatorStatus.tsx
+++ b/web/src/components/cards/OperatorStatus.tsx
@@ -149,7 +149,7 @@ function OperatorStatusInternal({ config: _config }: OperatorStatusProps) {
   if (showSkeleton) {
     return (
       <div className="h-full flex flex-col min-h-card">
-        <div className="flex items-center justify-between mb-4">
+        <div className="flex flex-wrap items-center justify-between gap-y-2 mb-4">
           <Skeleton variant="text" width={130} height={20} />
           <Skeleton variant="rounded" width={120} height={32} />
         </div>
@@ -192,7 +192,7 @@ function OperatorStatusInternal({ config: _config }: OperatorStatusProps) {
   return (
     <div className="h-full flex flex-col min-h-card content-loaded">
       {/* Controls row */}
-      <div className="flex items-center justify-between mb-4">
+      <div className="flex flex-wrap items-center justify-between gap-y-2 mb-4">
         <div className="flex items-center gap-2">
           {totalItems > 0 && (
             <StatusBadge color="purple">
@@ -280,7 +280,7 @@ function OperatorStatusInternal({ config: _config }: OperatorStatusProps) {
                     upgradeAvailable: op.upgradeAvailable })}
                   className="p-3 rounded-lg bg-secondary/30 hover:bg-secondary/50 transition-colors cursor-pointer group"
                 >
-                  <div className="flex items-center justify-between">
+                  <div className="flex flex-wrap items-center justify-between gap-y-2">
                     <div className="flex items-center gap-2">
                       <StatusIcon className={`w-4 h-4 ${STATUS_ICON_CLASS[color]} ${op.status === 'Installing' ? 'animate-spin' : ''}`} />
                       {op.cluster && (

--- a/web/src/components/cards/OperatorSubscriptions.tsx
+++ b/web/src/components/cards/OperatorSubscriptions.tsx
@@ -109,7 +109,7 @@ export function OperatorSubscriptions({ config: _config }: OperatorSubscriptions
   if (showSkeleton) {
     return (
       <div className="h-full flex flex-col min-h-card">
-        <div className="flex items-center justify-between mb-4">
+        <div className="flex flex-wrap items-center justify-between gap-y-2 mb-4">
           <Skeleton variant="text" width={150} height={20} />
           <Skeleton variant="rounded" width={120} height={32} />
         </div>
@@ -151,7 +151,7 @@ export function OperatorSubscriptions({ config: _config }: OperatorSubscriptions
   return (
     <div className="h-full flex flex-col min-h-card content-loaded">
       {/* Controls - single row */}
-      <div className="flex items-center justify-between mb-4">
+      <div className="flex flex-wrap items-center justify-between gap-y-2 mb-4">
         <div className="flex items-center gap-2">
           {pendingCount > 0 && (
             <StatusBadge color="orange">
@@ -239,7 +239,7 @@ export function OperatorSubscriptions({ config: _config }: OperatorSubscriptions
                 className={`p-3 rounded-lg cursor-pointer hover:bg-secondary/50 transition-colors group ${sub.pendingUpgrade ? 'bg-orange-500/10 border border-orange-500/20' : 'bg-secondary/30'}`}
                 title={`Click to view operator ${sub.name} details`}
               >
-                <div className="flex items-center justify-between mb-1">
+                <div className="flex flex-wrap items-center justify-between gap-y-2 mb-1">
                   <div className="flex items-center gap-2">
                     {sub.cluster && (
                       <ClusterBadge cluster={sub.cluster} size="sm" />
@@ -258,11 +258,11 @@ export function OperatorSubscriptions({ config: _config }: OperatorSubscriptions
                   </div>
                 </div>
                 <div className="text-xs text-muted-foreground space-y-0.5">
-                  <div className="flex items-center justify-between">
+                  <div className="flex flex-wrap items-center justify-between gap-y-2">
                     <span>{t('operatorSubscriptions.channelLabel')}: {sub.channel}</span>
                     <span>{sub.namespace}</span>
                   </div>
-                  <div className="flex items-center justify-between">
+                  <div className="flex flex-wrap items-center justify-between gap-y-2">
                     <span className="truncate">{sub.currentCSV}</span>
                   </div>
                   {sub.pendingUpgrade && (

--- a/web/src/components/cards/OverlayComparison.tsx
+++ b/web/src/components/cards/OverlayComparison.tsx
@@ -115,7 +115,7 @@ export function OverlayComparison({ config }: OverlayComparisonProps) {
   if (isLoading && allClusters.length === 0) {
     return (
       <div className="h-full flex flex-col min-h-card">
-        <div className="flex items-center justify-between mb-4">
+        <div className="flex flex-wrap items-center justify-between gap-y-2 mb-4">
           <Skeleton variant="text" width={150} height={20} />
           <Skeleton variant="rounded" width={80} height={28} />
         </div>
@@ -132,7 +132,7 @@ export function OverlayComparison({ config }: OverlayComparisonProps) {
   return (
     <div className="h-full flex flex-col min-h-card content-loaded">
       {/* Header */}
-      <div className="flex items-center justify-between mb-4">
+      <div className="flex flex-wrap items-center justify-between gap-y-2 mb-4">
         <div className="flex items-center gap-2">
           {diffs.length > 0 && (
             <StatusBadge color="purple">
@@ -239,7 +239,7 @@ export function OverlayComparison({ config }: OverlayComparisonProps) {
                       })}
                       className={`p-2 rounded-lg bg-${color}-500/10 border-l-2 border-${color}-500 hover:bg-${color}-500/20 transition-colors cursor-pointer group`}
                     >
-                      <div className="flex items-center justify-between mb-1">
+                      <div className="flex flex-wrap items-center justify-between gap-y-2 mb-1">
                         <div className="flex items-center gap-2">
                           <DiffIcon className={`w-4 h-4 text-${color}-400 flex-shrink-0`} />
                           <span className="text-sm text-foreground group-hover:text-purple-400 truncate">{diff.resource}</span>

--- a/web/src/components/cards/PVCStatus.tsx
+++ b/web/src/components/cards/PVCStatus.tsx
@@ -192,7 +192,7 @@ function PVCStatusInternal() {
   return (
     <div className="h-full flex flex-col">
       {/* Controls */}
-      <div className="flex items-center justify-between mb-4">
+      <div className="flex flex-wrap items-center justify-between gap-y-2 mb-4">
         <div className="flex items-center gap-2">
           <span className="text-sm font-medium text-muted-foreground">{totalItems} PVCs</span>
           <RefreshIndicator
@@ -238,7 +238,7 @@ function PVCStatusInternal() {
       />
 
       {/* Stats row */}
-      <div className="grid grid-cols-4 gap-2 mb-4">
+      <div className="grid grid-cols-2 sm:grid-cols-4 gap-2 mb-4">
         <div className="p-2 rounded-lg bg-secondary/50 text-center">
           <div className="text-lg font-bold text-foreground">{stats.total}</div>
           <div className="text-xs text-muted-foreground">{t('common.total')}</div>
@@ -267,7 +267,7 @@ function PVCStatusInternal() {
           displayPVCs.map(pvc => (
             <div
               key={`${pvc.cluster}-${pvc.namespace}-${pvc.name}`}
-              className="flex items-center justify-between p-2 rounded-lg bg-secondary/30 transition-colors"
+              className="flex flex-wrap items-center justify-between gap-y-2 p-2 rounded-lg bg-secondary/30 transition-colors"
               title="PVC drilldown not available"
             >
               <div className="flex items-center gap-2 min-w-0">

--- a/web/src/components/cards/PodBrothers.tsx
+++ b/web/src/components/cards/PodBrothers.tsx
@@ -501,7 +501,7 @@ export function PodBrothers() {
     <div ref={gameContainerRef} className="h-full flex flex-col">
       <div className={`flex flex-col items-center gap-3 ${isExpanded ? 'flex-1 min-h-0' : ''}`}>
         {/* Stats bar */}
-        <div className="flex items-center justify-between w-full max-w-[480px] text-sm">
+        <div className="flex flex-wrap items-center justify-between gap-y-2 w-full max-w-[480px] text-sm">
           <div className="flex items-center gap-4">
             <div className="flex items-center gap-1">
               <Star className="w-4 h-4 text-yellow-400" />

--- a/web/src/components/cards/PodCrosser.tsx
+++ b/web/src/components/cards/PodCrosser.tsx
@@ -561,7 +561,7 @@ export function PodCrosser(_props: CardComponentProps) {
 
   return (
     <div ref={gameContainerRef} className="h-full flex flex-col p-2 select-none">
-      <div className="flex items-center justify-between gap-2 mb-2 flex-wrap">
+      <div className="flex flex-wrap items-center justify-between gap-y-2 gap-2 mb-2 ">
         <div className="flex items-center gap-3 text-xs">
           <div className="text-center">
             <div className="text-muted-foreground">Score</div>

--- a/web/src/components/cards/PodHealthTrend.tsx
+++ b/web/src/components/cards/PodHealthTrend.tsx
@@ -349,7 +349,7 @@ export function PodHealthTrend() {
   return (
     <div className="h-full flex flex-col">
       {/* Controls - single row: Time Range -> Cluster Filter -> Refresh */}
-      <div className="flex items-center justify-between mb-3">
+      <div className="flex flex-wrap items-center justify-between gap-y-2 mb-3">
         <div className="flex items-center gap-2">
           {/* Cluster count indicator */}
           {localClusterFilter.length > 0 && (
@@ -391,7 +391,7 @@ export function PodHealthTrend() {
       </div>
 
       {/* Stats row */}
-      <div className="grid grid-cols-3 gap-2 mb-4">
+      <div className="grid grid-cols-2 sm:grid-cols-3 gap-2 mb-4">
         <div className="p-2 rounded-lg bg-green-500/10 border border-green-500/20" title={hasReachableClusters ? `${currentStats.healthy} healthy pods` : 'No reachable clusters'}>
           <div className="flex items-center gap-1.5 mb-1">
             <CheckCircle className="w-3 h-3 text-green-400" />

--- a/web/src/components/cards/PodIssues.tsx
+++ b/web/src/components/cards/PodIssues.tsx
@@ -144,7 +144,7 @@ export function PodIssues() {
   return (
     <div className="h-full flex flex-col content-loaded">
       {/* Header */}
-      <div className="flex items-center justify-between mb-3">
+      <div className="flex flex-wrap items-center justify-between gap-y-2 mb-3">
         <div className="flex items-center gap-2">
           <StatusBadge color="red" title={`${rawIssues.length} pods with issues`}>
             {rawIssues.length} issues

--- a/web/src/components/cards/PodPitfall.tsx
+++ b/web/src/components/cards/PodPitfall.tsx
@@ -540,7 +540,7 @@ export function PodPitfall(_props: CardComponentProps) {
 
   return (
     <div ref={gameContainerRef} className="h-full flex flex-col p-2 select-none">
-      <div className="flex items-center justify-between gap-2 mb-2 flex-wrap">
+      <div className="flex flex-wrap items-center justify-between gap-y-2 gap-2 mb-2 ">
         <div className="flex items-center gap-3 text-xs">
           <div className="text-center">
             <div className="text-muted-foreground">Score</div>

--- a/web/src/components/cards/PodSweeper.tsx
+++ b/web/src/components/cards/PodSweeper.tsx
@@ -252,7 +252,7 @@ function PodSweeperInternal(_props: CardComponentProps) {
   return (
     <div className="h-full flex flex-col p-2 select-none">
       {/* Header */}
-      <div className="flex items-center justify-between gap-2 mb-2 flex-wrap">
+      <div className="flex flex-wrap items-center justify-between gap-y-2 gap-2 mb-2 ">
         <div className="flex items-center gap-3 text-xs">
           <div className="flex items-center gap-1 text-red-400">
             <Flag className="w-3 h-3" />

--- a/web/src/components/cards/ProactiveGPUNodeHealthMonitor.tsx
+++ b/web/src/components/cards/ProactiveGPUNodeHealthMonitor.tsx
@@ -64,7 +64,7 @@ function StatusBadge({ status }: { status: string }) {
 function CheckRow({ check }: { check: GPUNodeHealthCheck }) {
   const label = CHECK_LABELS[check.name] || check.name
   return (
-    <div className="flex items-center justify-between py-1 text-xs">
+    <div className="flex flex-wrap items-center justify-between gap-y-2 py-1 text-xs">
       <span className="text-white/60">{label}</span>
       <div className="flex items-center gap-1.5">
         {check.passed ? (

--- a/web/src/components/cards/QuotaHeatmap.tsx
+++ b/web/src/components/cards/QuotaHeatmap.tsx
@@ -77,7 +77,7 @@ export function QuotaHeatmap() {
 
   return (
     <div className="space-y-2 p-1">
-      <div className="flex items-center justify-between gap-2">
+      <div className="flex flex-wrap items-center justify-between gap-y-2 gap-2">
         <div className="text-xs text-muted-foreground">
           {t('quotaHeatmap.summary', { namespaces: namespaceData.length, clusters: new Set(namespaceData.map(d => d.cluster)).size })}
         </div>
@@ -90,7 +90,7 @@ export function QuotaHeatmap() {
           staleThresholdMinutes={5}
         />
       </div>
-      <div className="grid grid-cols-4 sm:grid-cols-6 gap-1 max-h-[350px] overflow-y-auto">
+      <div className="grid grid-cols-2 sm:grid-cols-4 md:grid-cols-6 gap-1 max-h-[350px] overflow-y-auto">
         {namespaceData.slice(0, 60).map(ns => {
           const ratio = ns.podCount / maxPods
           const isSelected = selectedNs === `${ns.cluster}/${ns.namespace}`

--- a/web/src/components/cards/RBACExplorer.tsx
+++ b/web/src/components/cards/RBACExplorer.tsx
@@ -242,7 +242,7 @@ export function RBACExplorer() {
                     transform: `translateY(${virtualRow.start}px)` }}
                 >
                   <div className={`px-2 py-1.5 mb-1 rounded-lg ${style.bg} border border-transparent hover:border-current/20 transition-colors`}>
-                    <div className="flex items-center justify-between gap-2">
+                    <div className="flex flex-wrap items-center justify-between gap-y-2 gap-2">
                       <div className="flex items-center gap-2 min-w-0">
                         <span className={`text-xs px-1.5 py-0.5 rounded ${style.bg} ${style.text} font-medium shrink-0`}>
                           {finding.risk.toUpperCase()}

--- a/web/src/components/cards/RecentEvents.tsx
+++ b/web/src/components/cards/RecentEvents.tsx
@@ -98,7 +98,7 @@ export function RecentEvents() {
   return (
     <div className="space-y-3">
       {/* Header controls */}
-      <div className="flex items-center justify-between">
+      <div className="flex flex-wrap items-center justify-between gap-y-2">
         <div className="flex items-center gap-2">
           <Clock className="w-3.5 h-3.5 text-blue-400" />
           <span className="text-xs text-muted-foreground">

--- a/web/src/components/cards/RecommendedPolicies.tsx
+++ b/web/src/components/cards/RecommendedPolicies.tsx
@@ -469,7 +469,7 @@ Deploy each policy to every cluster where it's missing. Proceed cluster by clust
               {/* Category header */}
               <button
                 onClick={() => setExpandedCategory(isExpanded ? null : category)}
-                className={`w-full flex items-center justify-between p-2 rounded-lg border transition-colors ${
+                className={`w-full flex flex-wrap items-center justify-between gap-y-2 p-2 rounded-lg border transition-colors ${
                   isExpanded ? CATEGORY_BG[category] : 'bg-secondary/20 border-transparent hover:bg-secondary/40'
                 }`}
               >

--- a/web/src/components/cards/ResourceCapacity.tsx
+++ b/web/src/components/cards/ResourceCapacity.tsx
@@ -202,7 +202,7 @@ export function ResourceCapacity({ config: _config }: ResourceCapacityProps) {
   if (showSkeleton) {
     return (
       <div className="h-full flex flex-col min-h-card">
-        <div className="flex items-center justify-between mb-4">
+        <div className="flex flex-wrap items-center justify-between gap-y-2 mb-4">
           <Skeleton variant="text" width={140} height={20} />
           <Skeleton variant="rounded" width={28} height={28} />
         </div>
@@ -235,7 +235,7 @@ export function ResourceCapacity({ config: _config }: ResourceCapacityProps) {
   return (
     <div className="h-full flex flex-col min-h-card content-loaded">
       {/* Header */}
-      <div className="flex items-center justify-between mb-4">
+      <div className="flex flex-wrap items-center justify-between gap-y-2 mb-4">
         <div className="flex items-center gap-2">
           <RefreshIndicator
             isRefreshing={isRefreshing}
@@ -293,7 +293,7 @@ export function ResourceCapacity({ config: _config }: ResourceCapacityProps) {
 
             return (
               <div key={item.id} className="p-3 rounded-lg bg-secondary/30">
-                <div className="flex items-center justify-between mb-1.5">
+                <div className="flex flex-wrap items-center justify-between gap-y-2 mb-1.5">
                   <div className="flex items-center gap-2">
                     <span className={textClasses[item.color]}>{getIcon(item.icon)}</span>
                     <span className="text-sm font-medium text-foreground">{item.label}</span>
@@ -346,7 +346,7 @@ export function ResourceCapacity({ config: _config }: ResourceCapacityProps) {
       {/* Summary */}
       {/* Summary footer */}
       <div
-        className={`mt-3 pt-3 border-t border-border/50 grid ${totals.totalGPUs > 0 ? 'grid-cols-4' : 'grid-cols-3'} gap-2 text-center cursor-pointer hover:bg-secondary/30 rounded-lg transition-colors`}
+        className={`mt-3 pt-3 border-t border-border/50 grid ${totals.totalGPUs > 0 ? 'grid-cols-2 sm:grid-cols-4' : 'grid-cols-2 sm:grid-cols-3'} gap-2 text-center cursor-pointer hover:bg-secondary/30 rounded-lg transition-colors`}
         onClick={() => drillToResources()}
       >
         <div>

--- a/web/src/components/cards/ResourceTrend.tsx
+++ b/web/src/components/cards/ResourceTrend.tsx
@@ -259,7 +259,7 @@ export function ResourceTrend() {
   return (
     <div className="h-full flex flex-col">
       {/* Controls */}
-      <div className="flex items-center justify-between mb-3">
+      <div className="flex flex-wrap items-center justify-between gap-y-2 mb-3">
         <div className="flex items-center gap-2">
           {localClusterFilter.length > 0 && (
             <span className="flex items-center gap-1 text-xs text-muted-foreground bg-secondary/50 px-1.5 py-0.5 rounded">
@@ -313,7 +313,7 @@ export function ResourceTrend() {
       </div>
 
       {/* Stats row */}
-      <div className="grid grid-cols-4 gap-2 mb-4">
+      <div className="grid grid-cols-2 sm:grid-cols-4 gap-2 mb-4">
         <div className="p-2 rounded-lg bg-blue-500/10 border border-blue-500/20" title={hasReachableClusters ? `${currentTotals.cpuCores} CPU cores total` : 'No reachable clusters'}>
           <div className="flex items-center gap-1 mb-1">
             <Cpu className="w-3 h-3 text-blue-400" />

--- a/web/src/components/cards/ResourceUsage.tsx
+++ b/web/src/components/cards/ResourceUsage.tsx
@@ -103,7 +103,7 @@ function ResourceUsageInternal() {
   if (showSkeleton) {
     return (
       <div className="h-full flex flex-col min-h-[200px]">
-        <div className="flex items-center justify-between mb-4">
+        <div className="flex flex-wrap items-center justify-between gap-y-2 mb-4">
           <Skeleton variant="text" width={80} height={16} />
           <Skeleton variant="rounded" width={60} height={24} />
         </div>
@@ -155,7 +155,7 @@ function ResourceUsageInternal() {
   return (
     <div className="h-full flex flex-col">
       {/* Controls - single row: Cluster count → Cluster Filter → Refresh */}
-      <div className="flex items-center justify-between mb-4">
+      <div className="flex flex-wrap items-center justify-between gap-y-2 mb-4">
         <div className="flex items-center gap-2">
           {localClusterFilter.length > 0 && (
             <span className="flex items-center gap-1 text-xs text-muted-foreground bg-secondary/50 px-1.5 py-0.5 rounded">

--- a/web/src/components/cards/SecurityIssues.tsx
+++ b/web/src/components/cards/SecurityIssues.tsx
@@ -179,7 +179,7 @@ function SecurityIssuesInternal({ config }: SecurityIssuesProps) {
   if (showSkeleton) {
     return (
       <div className="h-full flex flex-col">
-        <div className="flex items-center justify-between mb-3">
+        <div className="flex flex-wrap items-center justify-between gap-y-2 mb-3">
           <div className="flex items-center gap-2">
             <div className="h-4 w-24 bg-secondary rounded animate-pulse" />
             <div className="h-4 w-12 bg-secondary rounded animate-pulse" />
@@ -243,7 +243,7 @@ function SecurityIssuesInternal({ config }: SecurityIssuesProps) {
   return (
     <div className="h-full flex flex-col min-h-card content-loaded">
       {/* Header */}
-      <div className="flex items-center justify-between mb-3">
+      <div className="flex flex-wrap items-center justify-between gap-y-2 mb-3">
         <div className="flex items-center gap-2">
           {highCount > 0 && (
             <StatusBadge color="red" title={t('securityIssues.highSeverityTitle', { count: highCount })}>

--- a/web/src/components/cards/ServiceExports.tsx
+++ b/web/src/components/cards/ServiceExports.tsx
@@ -111,7 +111,7 @@ function ServiceExportsInternal({ config: _config }: ServiceExportsProps) {
   if (showSkeleton) {
     return (
       <div className="h-full flex flex-col min-h-card">
-        <div className="flex items-center justify-between mb-3">
+        <div className="flex flex-wrap items-center justify-between gap-y-2 mb-3">
           <Skeleton variant="text" width={120} height={20} />
           <Skeleton variant="rounded" width={80} height={28} />
         </div>
@@ -127,7 +127,7 @@ function ServiceExportsInternal({ config: _config }: ServiceExportsProps) {
   return (
     <div className="h-full flex flex-col min-h-card">
       {/* Header with controls */}
-      <div className="flex items-center justify-between mb-2 flex-shrink-0">
+      <div className="flex flex-wrap items-center justify-between gap-y-2 mb-2 flex-shrink-0">
         <div className="flex items-center gap-2">
           <a
             href={K8S_DOCS.mcsApi}
@@ -189,7 +189,7 @@ function ServiceExportsInternal({ config: _config }: ServiceExportsProps) {
       </div>
 
       {/* Stats */}
-      <div className="grid grid-cols-3 gap-2 mb-3">
+      <div className="grid grid-cols-2 sm:grid-cols-3 gap-2 mb-3">
         <div className="p-2 rounded-lg bg-blue-500/10 border border-blue-500/20 text-center">
           <p className="text-2xs text-blue-400">{t('serviceExports.exports')}</p>
           <p className="text-lg font-bold text-foreground">{totalItems}</p>
@@ -222,7 +222,7 @@ function ServiceExportsInternal({ config: _config }: ServiceExportsProps) {
               key={`${exp.cluster}-${exp.namespace}-${exp.name}-${idx}`}
               className={`p-2.5 rounded-lg bg-secondary/30 hover:bg-secondary/50 transition-colors`}
             >
-              <div className="flex items-center justify-between mb-1">
+              <div className="flex flex-wrap items-center justify-between gap-y-2 mb-1">
                 <div className="flex items-center gap-2">
                   <Icon className={`w-4 h-4 ${colors.text}`} />
                   <span className="text-sm font-medium text-foreground truncate">{exp.name}</span>
@@ -236,7 +236,7 @@ function ServiceExportsInternal({ config: _config }: ServiceExportsProps) {
                   </span>
                 )}
               </div>
-              <div className="flex items-center justify-between text-xs">
+              <div className="flex flex-wrap items-center justify-between gap-y-2 text-xs">
                 <div className="flex items-center gap-2">
                   <ClusterBadge cluster={exp.cluster} />
                   <span className="text-muted-foreground">{exp.namespace}</span>

--- a/web/src/components/cards/ServiceImports.tsx
+++ b/web/src/components/cards/ServiceImports.tsx
@@ -102,7 +102,7 @@ function ServiceImportsInternal({ config: _config }: ServiceImportsProps) {
   if (isLoading) {
     return (
       <div className="h-full flex flex-col min-h-card">
-        <div className="flex items-center justify-between mb-3">
+        <div className="flex flex-wrap items-center justify-between gap-y-2 mb-3">
           <Skeleton variant="text" width={120} height={20} />
           <Skeleton variant="rounded" width={80} height={28} />
         </div>
@@ -134,7 +134,7 @@ function ServiceImportsInternal({ config: _config }: ServiceImportsProps) {
   return (
     <div className="h-full flex flex-col min-h-card">
       {/* Header with controls */}
-      <div className="flex items-center justify-between mb-2 flex-shrink-0">
+      <div className="flex flex-wrap items-center justify-between gap-y-2 mb-2 flex-shrink-0">
         <div className="flex items-center gap-2">
           <a
             href={K8S_DOCS.mcsApi}
@@ -193,7 +193,7 @@ function ServiceImportsInternal({ config: _config }: ServiceImportsProps) {
       </div>
 
       {/* Stats */}
-      <div className="grid grid-cols-3 gap-2 mb-3">
+      <div className="grid grid-cols-2 sm:grid-cols-3 gap-2 mb-3">
         <div className="p-2 rounded-lg bg-cyan-500/10 border border-cyan-500/20 text-center">
           <p className="text-2xs text-cyan-400">{t('serviceImports.imports')}</p>
           <p className="text-lg font-bold text-foreground">{stats.totalImports}</p>
@@ -226,7 +226,7 @@ function ServiceImportsInternal({ config: _config }: ServiceImportsProps) {
               key={`${imp.cluster}-${imp.namespace}-${imp.name}-${idx}`}
               className="p-2.5 rounded-lg bg-secondary/30 hover:bg-secondary/50 transition-colors"
             >
-              <div className="flex items-center justify-between mb-1">
+              <div className="flex flex-wrap items-center justify-between gap-y-2 mb-1">
                 <div className="flex items-center gap-2">
                   <EndpointIcon className={`w-4 h-4 ${endpointStatus.color}`} />
                   <span className="text-sm font-medium text-foreground truncate">{imp.name}</span>

--- a/web/src/components/cards/ServiceStatus.tsx
+++ b/web/src/components/cards/ServiceStatus.tsx
@@ -229,7 +229,7 @@ export function ServiceStatus() {
   if (showSkeleton) {
     return (
       <div className="h-full flex flex-col min-h-card">
-        <div className="flex items-center justify-between mb-4">
+        <div className="flex flex-wrap items-center justify-between gap-y-2 mb-4">
           <Skeleton variant="text" width={100} height={16} />
           <Skeleton variant="rounded" width={80} height={28} />
         </div>
@@ -251,7 +251,7 @@ export function ServiceStatus() {
   return (
     <div className="h-full flex flex-col content-loaded">
       {/* Controls */}
-      <div className="flex items-center justify-between mb-4">
+      <div className="flex flex-wrap items-center justify-between gap-y-2 mb-4">
         <div className="flex items-center gap-2">
           {/* Cache freshness badge (#6162) */}
           {isStale && cacheAgeMs !== null && (
@@ -302,7 +302,7 @@ export function ServiceStatus() {
       />
 
       {/* Stats row */}
-      <div className="grid grid-cols-4 gap-2 mb-3">
+      <div className="grid grid-cols-2 sm:grid-cols-4 gap-2 mb-3">
         <div className="p-1.5 rounded-lg bg-secondary/50 text-center">
           <div className="text-sm font-bold text-foreground">{stats.total}</div>
           <div className="text-2xs text-muted-foreground">{t('common.total')}</div>
@@ -350,7 +350,7 @@ export function ServiceStatus() {
                 lbStatus: service.lbStatus,
                 selector: service.selector,
               })}
-              className="flex items-center justify-between p-2 rounded-lg bg-secondary/30 hover:bg-secondary/50 transition-colors cursor-pointer group gap-2"
+              className="flex flex-wrap items-center justify-between gap-y-2 p-2 rounded-lg bg-secondary/30 hover:bg-secondary/50 transition-colors cursor-pointer group gap-2"
             >
               <div className="flex items-center gap-2 min-w-0 flex-1">
                 {/* Connectivity dot — single source of truth via deriveServiceHealth (#6167) */}

--- a/web/src/components/cards/ServiceTopology.tsx
+++ b/web/src/components/cards/ServiceTopology.tsx
@@ -361,7 +361,7 @@ export function ServiceTopology({ config: _config }: ServiceTopologyProps) {
       {/* Selected node details */}
       {selectedNodeData && (
         <div className="mt-2 p-2 bg-secondary/50 rounded-lg text-xs">
-          <div className="flex items-center justify-between mb-1">
+          <div className="flex flex-wrap items-center justify-between gap-y-2 mb-1">
             <div className="flex items-center gap-2">
               <div className={`w-2 h-2 rounded-full ${getNodeColor(selectedNodeData.type, selectedNodeData.health)}`} />
               <span className="font-medium text-foreground">{selectedNodeData.label}</span>

--- a/web/src/components/cards/Solitaire.tsx
+++ b/web/src/components/cards/Solitaire.tsx
@@ -550,7 +550,7 @@ export function Solitaire(_props: CardComponentProps) {
   return (
     <div className="h-full flex flex-col p-2 select-none">
       {/* Header */}
-      <div className="flex items-center justify-between gap-2 mb-2 flex-wrap">
+      <div className="flex flex-wrap items-center justify-between gap-y-2 gap-2 mb-2 ">
         <div className="flex items-center gap-2 text-xs text-muted-foreground">
           <span>Moves: {moves}</span>
           <span>Time: {formatTime(time)}</span>

--- a/web/src/components/cards/StockMarketTicker.tsx
+++ b/web/src/components/cards/StockMarketTicker.tsx
@@ -710,7 +710,7 @@ export function StockMarketTicker({ config }: StockMarketTickerProps) {
   return (
     <div className="h-full flex flex-col">
       {/* Header with market status and controls */}
-      <div className="flex items-center justify-between mb-3">
+      <div className="flex flex-wrap items-center justify-between gap-y-2 mb-3">
         <div className="flex items-center gap-2">
           <BarChart3 className="w-4 h-4 text-muted-foreground" />
           <div className="text-xs">
@@ -781,7 +781,7 @@ export function StockMarketTicker({ config }: StockMarketTickerProps) {
                 <button
                   key={result.symbol}
                   onClick={() => addStock(result)}
-                  className="w-full p-2 text-left hover:bg-accent transition-colors flex items-center justify-between"
+                  className="w-full p-2 text-left hover:bg-accent transition-colors flex flex-wrap items-center justify-between gap-y-2"
                   disabled={activeSymbols.includes(result.symbol)}
                 >
                   <div>
@@ -801,7 +801,7 @@ export function StockMarketTicker({ config }: StockMarketTickerProps) {
       </div>
 
       {/* Portfolio summary */}
-      <div className="grid grid-cols-3 gap-2 mb-3 p-2 bg-accent/30 rounded-lg text-xs">
+      <div className="grid grid-cols-2 sm:grid-cols-3 gap-2 mb-3 p-2 bg-accent/30 rounded-lg text-xs">
         <div className="text-center">
           <div className="text-muted-foreground">{t('stockMarket.avgChange')}</div>
           <div className={`font-semibold ${portfolioSummary.avgChange >= 0 ? 'text-green-500' : 'text-red-500'}`}>
@@ -841,7 +841,7 @@ export function StockMarketTicker({ config }: StockMarketTickerProps) {
       )}
 
       {/* Footer with pagination and data source */}
-      <div className="flex items-center justify-between mt-2 pt-2 border-t border-border/30">
+      <div className="flex flex-wrap items-center justify-between gap-y-2 mt-2 pt-2 border-t border-border/30">
         <div className="text-xs text-muted-foreground flex items-center gap-1">
           <span>{t('stockMarket.dataFrom', { source: dataSource })}</span>
           {useLiveData && <span className="text-green-500">{t('stockMarket.liveLabel')}</span>}

--- a/web/src/components/cards/StorageOverview.tsx
+++ b/web/src/components/cards/StorageOverview.tsx
@@ -108,7 +108,7 @@ export function StorageOverview() {
         {/* Loading label for accessibility / test hook */}
         <p className="sr-only">{t('storageOverview.loading')}</p>
         {/* Header skeleton */}
-        <div className="flex items-center justify-between mb-4">
+        <div className="flex flex-wrap items-center justify-between gap-y-2 mb-4">
           <Skeleton variant="text" width={120} height={16} />
           <Skeleton variant="rounded" width={80} height={24} />
         </div>
@@ -132,7 +132,7 @@ export function StorageOverview() {
   return (
     <div className="h-full flex flex-col">
       {/* Controls */}
-      <div className="flex items-center justify-between mb-4">
+      <div className="flex flex-wrap items-center justify-between gap-y-2 mb-4">
         <div />
         <div className="flex items-center gap-2">
           {/* Cluster count indicator */}
@@ -200,7 +200,7 @@ export function StorageOverview() {
       </div>
 
       {/* PVC Status breakdown */}
-      <div className="grid grid-cols-3 gap-2 mb-4">
+      <div className="grid grid-cols-2 sm:grid-cols-3 gap-2 mb-4">
         <div
           className="p-2 rounded-lg bg-green-500/10 border border-green-500/20 cursor-default transition-colors"
           title={stats.boundPVCs > 0 ? `${stats.boundPVCs} PVC${stats.boundPVCs !== 1 ? 's' : ''} successfully bound` : 'No bound PVCs'}
@@ -239,7 +239,7 @@ export function StorageOverview() {
           <div className="text-xs text-muted-foreground mb-2">{t('storageOverview.storageClasses')}</div>
           <div className="space-y-1.5">
             {stats.storageClasses.slice(0, 5).map(([name, count]) => (
-              <div key={name} className="flex items-center justify-between p-2 rounded bg-secondary/30 cursor-default" title={`Storage class "${name}" has ${count} PVC${count !== 1 ? 's' : ''}`}>
+              <div key={name} className="flex flex-wrap items-center justify-between gap-y-2 p-2 rounded bg-secondary/30 cursor-default" title={`Storage class "${name}" has ${count} PVC${count !== 1 ? 's' : ''}`}>
                 <span className="text-sm text-foreground truncate" title={name}>{name}</span>
                 <span className="text-xs text-muted-foreground">{t('storageOverview.nPVCs', { count })}</span>
               </div>

--- a/web/src/components/cards/SudokuGame.tsx
+++ b/web/src/components/cards/SudokuGame.tsx
@@ -446,7 +446,7 @@ function SudokuGameInternal({ config: _config }: SudokuGameProps) {
   return (
     <div className="h-full flex-1 flex flex-col min-h-card content-loaded">
       {/* Header */}
-      <div className={`flex items-center justify-between ${isMaximized ? 'mb-4' : 'mb-1.5'}`}>
+      <div className={`flex flex-wrap items-center justify-between gap-y-2 ${isMaximized ? 'mb-4' : 'mb-1.5'}`}>
         <div className={`flex items-center ${isMaximized ? 'gap-3' : 'gap-1.5'}`}>
           <Sparkles className={isMaximized ? 'w-5 h-5 text-purple-400' : 'w-3.5 h-3.5 text-purple-400'} />
           <span className={`font-medium text-muted-foreground ${isMaximized ? 'text-base' : 'text-xs'}`}>Sudoku</span>
@@ -463,7 +463,7 @@ function SudokuGameInternal({ config: _config }: SudokuGameProps) {
       </div>
 
       {/* Game info */}
-      <div className={`flex items-center justify-between ${isMaximized ? 'mb-4 text-sm' : 'mb-1.5 text-2xs'}`}>
+      <div className={`flex flex-wrap items-center justify-between gap-y-2 ${isMaximized ? 'mb-4 text-sm' : 'mb-1.5 text-2xs'}`}>
         <div className={`flex items-center ${isMaximized ? 'gap-4' : 'gap-2'}`}>
           <span className={`${isMaximized ? 'px-3 py-1' : 'px-1.5 py-0.5'} rounded bg-purple-500/20 text-purple-400 font-medium`}>
             {DIFFICULTIES[gameState.difficulty].label}
@@ -611,7 +611,7 @@ function SudokuGameInternal({ config: _config }: SudokuGameProps) {
       {showSettings && (
         <div className="absolute inset-0 bg-black/50 flex items-center justify-center z-50 rounded-lg">
           <div className="bg-background border border-border rounded-lg p-4 max-w-xs w-full mx-4">
-            <div className="flex items-center justify-between mb-3">
+            <div className="flex flex-wrap items-center justify-between gap-y-2 mb-3">
               <h3 className="text-sm font-medium">New Game</h3>
               <button
                 onClick={() => setShowSettings(false)}
@@ -627,7 +627,7 @@ function SudokuGameInternal({ config: _config }: SudokuGameProps) {
                   onClick={() => startNewGame(difficulty)}
                   className="w-full text-left px-3 py-2 rounded bg-secondary/50 hover:bg-purple-500/20 transition-colors"
                 >
-                  <div className="flex items-center justify-between">
+                  <div className="flex flex-wrap items-center justify-between gap-y-2">
                     <span className="font-medium">{DIFFICULTIES[difficulty].label}</span>
                     {bestTimes[difficulty] && (
                       <span className="text-xs text-muted-foreground flex items-center gap-1">

--- a/web/src/components/cards/TopPods.tsx
+++ b/web/src/components/cards/TopPods.tsx
@@ -174,7 +174,7 @@ function TopPodsInternal({ config }: TopPodsProps) {
   return (
     <div className="h-full flex flex-col min-h-card content-loaded">
       {/* Header */}
-      <div className="flex items-center justify-between mb-3">
+      <div className="flex flex-wrap items-center justify-between gap-y-2 mb-3">
         <div className="flex items-center gap-2">
           <RefreshIndicator
             isRefreshing={isRefreshing}
@@ -242,7 +242,7 @@ function TopPodsInternal({ config }: TopPodsProps) {
               })}
               title={`Click to view details for ${pod.name}`}
             >
-              <div className="flex items-center justify-between mb-1">
+              <div className="flex flex-wrap items-center justify-between gap-y-2 mb-1">
                 <div className="flex items-center gap-2 min-w-0 flex-1">
                   <span className="text-xs text-muted-foreground w-5">{displayIndex}.</span>
                   <span className="text-sm font-medium text-foreground truncate" title={pod.name}>
@@ -392,7 +392,7 @@ function TopPodsInternal({ config }: TopPodsProps) {
               ) : null}
 
               {/* Details row */}
-              <div className="flex items-center justify-between text-xs text-muted-foreground">
+              <div className="flex flex-wrap items-center justify-between gap-y-2 text-xs text-muted-foreground">
                 <div className="flex items-center gap-3">
                   <span className="flex-shrink-0">{pod.status}</span>
                   <span className="flex-shrink-0">{pod.ready}</span>

--- a/web/src/components/cards/TrestleScan.tsx
+++ b/web/src/components/cards/TrestleScan.tsx
@@ -241,7 +241,7 @@ Please proceed step by step. Start with verifying prerequisites (Python 3.9+, ku
       )}
 
       {/* Overall Score */}
-      <div className="flex items-center justify-between">
+      <div className="flex flex-wrap items-center justify-between gap-y-2">
         <div className="flex items-center gap-3">
           <button
             onClick={() => drillToCompliance('', {})}
@@ -315,12 +315,12 @@ Please proceed step by step. Start with verifying prerequisites (Python 3.9+, ku
               className="w-full text-left p-2.5 rounded-lg border border-border/50 hover:border-border transition-colors bg-secondary/20 cursor-pointer"
               onClick={() => setExpandedProfile(isExpanded ? null : profile.name)}
             >
-              <div className="flex items-center justify-between gap-2">
+              <div className="flex flex-wrap items-center justify-between gap-y-2 gap-2">
                 <div
                   className="flex-1 text-left"
                   title={t('cards:trestleScan.toggleProfileDetails', { name: profile.name })}
                 >
-                  <div className="flex items-center justify-between">
+                  <div className="flex flex-wrap items-center justify-between gap-y-2">
                     <div className="flex items-center gap-2">
                       <Shield className="w-3.5 h-3.5 text-teal-400" />
                       <span className="text-xs font-medium text-foreground">{profile.name}</span>
@@ -364,7 +364,7 @@ Please proceed step by step. Start with verifying prerequisites (Python 3.9+, ku
 
               {/* Expanded details */}
               {isExpanded && (
-                <div className="mt-2 grid grid-cols-3 gap-2 text-xs">
+                <div className="mt-2 grid grid-cols-2 sm:grid-cols-3 gap-2 text-xs">
                   <button
                     onClick={(e) => { e.stopPropagation(); drillToCompliance('pass', { profile: profile.name }) }}
                     className="flex items-center gap-1 text-green-400 hover:opacity-80 transition-opacity cursor-pointer"
@@ -417,7 +417,7 @@ Please proceed step by step. Start with verifying prerequisites (Python 3.9+, ku
       )}
 
       {/* CNCF badge */}
-      <div className="flex items-center justify-between text-2xs text-muted-foreground pt-1 border-t border-border/30">
+      <div className="flex flex-wrap items-center justify-between gap-y-2 text-2xs text-muted-foreground pt-1 border-t border-border/30">
         <a
           href="https://oscal-compass.github.io/compliance-trestle/"
           target="_blank"

--- a/web/src/components/cards/UpgradeStatus.tsx
+++ b/web/src/components/cards/UpgradeStatus.tsx
@@ -697,7 +697,7 @@ Please proceed step by step and ask for confirmation before making any changes.`
   return (
     <div className="h-full flex flex-col">
       {/* Header */}
-      <div className="flex items-center justify-between mb-3">
+      <div className="flex flex-wrap items-center justify-between gap-y-2 mb-3">
         <div className="flex items-center gap-2">
           {pendingUpgrades > 0 && (
             <StatusBadge color="yellow">
@@ -751,7 +751,7 @@ Please proceed step by step and ask for confirmation before making any changes.`
               className="cursor-pointer"
               onClick={() => drillToCluster(cluster.name, { tab: 'upgrade', version: cluster.currentVersion, targetVersion: cluster.targetVersion })}
             >
-              <div className="flex items-center justify-between mb-2 gap-2">
+              <div className="flex flex-wrap items-center justify-between gap-y-2 mb-2 gap-2">
                 <span className="text-sm font-medium text-foreground truncate min-w-0 flex-1">{cluster.name}</span>
                 <span className="shrink-0">{getStatusIcon(cluster.status)}</span>
               </div>

--- a/web/src/components/cards/UserManagement.tsx
+++ b/web/src/components/cards/UserManagement.tsx
@@ -310,7 +310,7 @@ export function UserManagement({ config: _config }: UserManagementProps) {
     return (
       <div className="h-full flex flex-col min-h-card">
         {/* Header skeleton */}
-        <div className="flex items-center justify-between mb-3">
+        <div className="flex flex-wrap items-center justify-between gap-y-2 mb-3">
           <div className="flex gap-2">
             <Skeleton variant="rounded" width={100} height={28} />
             <Skeleton variant="rounded" width={120} height={28} />
@@ -341,7 +341,7 @@ export function UserManagement({ config: _config }: UserManagementProps) {
   return (
     <div className="h-full flex flex-col min-h-card content-loaded">
       {/* Row 1: Header with count badge and controls */}
-      <div className="flex items-center justify-between mb-2 flex-shrink-0">
+      <div className="flex flex-wrap items-center justify-between gap-y-2 mb-2 flex-shrink-0">
         <div className="flex items-center gap-2">
           <span className="text-sm font-medium text-muted-foreground">
             {currentTabCount} {currentTabLabel}
@@ -577,7 +577,7 @@ function ConsoleUsersTab({
             )}
           >
             <div className={cn(
-              'flex items-center justify-between',
+              'flex flex-wrap items-center justify-between gap-y-2',
               isBlurred && 'blur-sm select-none pointer-events-none'
             )}>
               <div className="flex items-center gap-3">
@@ -634,7 +634,7 @@ function ConsoleUsersTab({
             {/* Expanded actions */}
             {isAdmin && expandedUser === user.id && !isCurrentUser && (
               <div className="mt-3 pt-3 border-t border-border/50">
-                <div className="flex items-center justify-between">
+                <div className="flex flex-wrap items-center justify-between gap-y-2">
                   <div className="flex gap-2">
                     {(['admin', 'editor', 'viewer'] as UserRole[]).map((role) => (
                       <button
@@ -741,7 +741,7 @@ function ClusterUsersTab({
               onClick={() => onDrillToUser(user.cluster, user.name)}
               className="p-2 rounded bg-secondary/30 text-sm hover:bg-secondary/50 transition-colors cursor-pointer group"
             >
-              <div className="flex items-center justify-between">
+              <div className="flex flex-wrap items-center justify-between gap-y-2">
                 <div className="flex items-center gap-2">
                   <span className="text-foreground font-medium group-hover:text-purple-400">{user.name}</span>
                   {user.fullName && (
@@ -871,7 +871,7 @@ function ServiceAccountsTab({
               onClick={() => onDrillToServiceAccount(sa.cluster, sa.namespace, sa.name, sa.roles)}
               className="p-2 rounded bg-secondary/30 text-sm hover:bg-secondary/50 transition-colors cursor-pointer group"
             >
-              <div className="flex items-center justify-between">
+              <div className="flex flex-wrap items-center justify-between gap-y-2">
                 <div className="flex items-center gap-2">
                   <span className="text-foreground font-medium group-hover:text-purple-400">{sa.name}</span>
                   {showClusterBadge && (

--- a/web/src/components/cards/VClusterStatus.tsx
+++ b/web/src/components/cards/VClusterStatus.tsx
@@ -139,14 +139,14 @@ export function VClusterStatus({ config: _config }: VClusterStatusProps) {
     defaultLimit: DEFAULT_PAGE_SIZE,
   })
   if (isLoading) {
-    return (<div className="h-full flex flex-col min-h-card"><div className="flex items-center justify-between mb-3"><Skeleton variant="text" width={120} height={20} /><Skeleton variant="rounded" width={80} height={28} /></div><div className="space-y-2"><Skeleton variant="rounded" height={60} /><Skeleton variant="rounded" height={60} /><Skeleton variant="rounded" height={60} /></div></div>)
+    return (<div className="h-full flex flex-col min-h-card"><div className="flex flex-wrap items-center justify-between gap-y-2 mb-3"><Skeleton variant="text" width={120} height={20} /><Skeleton variant="rounded" width={80} height={28} /></div><div className="space-y-2"><Skeleton variant="rounded" height={60} /><Skeleton variant="rounded" height={60} /><Skeleton variant="rounded" height={60} /></div></div>)
   }
   if (hasError) {
     return (<div className="h-full flex flex-col items-center justify-center min-h-card p-6"><AlertCircle className="w-12 h-12 text-red-400 mb-4" /><p className="text-sm text-muted-foreground mb-4">{t('vclusterStatus.loadFailed')}</p><button onClick={() => refresh()} className="px-4 py-2 rounded-lg bg-purple-500 hover:bg-purple-600 text-white text-sm">{t('common:common.retry')}</button></div>)
   }
   return (
     <div className="h-full flex flex-col min-h-card">
-      <div className="flex items-center justify-between mb-2 flex-shrink-0">
+      <div className="flex flex-wrap items-center justify-between gap-y-2 mb-2 flex-shrink-0">
         <div className="flex items-center gap-2">
           <span className="text-sm font-medium text-muted-foreground">{t('vclusterStatus.nVClusters', { count: totalItems })}</span>
           {localClusterFilter.length > 0 && (<span className="flex items-center gap-1 text-xs text-muted-foreground bg-secondary/50 px-1.5 py-0.5 rounded"><Server className="w-3 h-3" />{localClusterFilter.length}/{availableClusters.length}</span>)}
@@ -157,7 +157,7 @@ export function VClusterStatus({ config: _config }: VClusterStatusProps) {
         />
       </div>
       <CardSearchInput value={localSearch} onChange={setLocalSearch} placeholder={t('vclusterStatus.searchPlaceholder')} className="mb-3" />
-      <div className="grid grid-cols-3 gap-2 mb-3">
+      <div className="grid grid-cols-2 sm:grid-cols-3 gap-2 mb-3">
         <div className="p-2 rounded-lg bg-purple-500/10 border border-purple-500/20 text-center"><p className="text-2xs text-purple-400">{t('vclusterStatus.total')}</p><p className="text-lg font-bold text-foreground">{stats.totalVClusters}</p></div>
         <div className="p-2 rounded-lg bg-green-500/10 border border-green-500/20 text-center"><p className="text-2xs text-green-400">{t('vclusterStatus.running')}</p><p className="text-lg font-bold text-foreground">{stats.runningCount}</p></div>
         <div className="p-2 rounded-lg bg-yellow-500/10 border border-yellow-500/20 text-center"><p className="text-2xs text-yellow-400">{t('vclusterStatus.paused')}</p><p className="text-lg font-bold text-foreground">{stats.pausedCount}</p></div>
@@ -174,7 +174,7 @@ export function VClusterStatus({ config: _config }: VClusterStatusProps) {
           const colors = getStatusColors(vc.status)
           return (
             <div key={`${vc.hostCluster}-${vc.namespace}-${vc.name}-${idx}`} className="p-2.5 rounded-lg bg-secondary/30 hover:bg-secondary/50 transition-colors">
-              <div className="flex items-center justify-between mb-1">
+              <div className="flex flex-wrap items-center justify-between gap-y-2 mb-1">
                 <div className="flex items-center gap-2">
                   <Icon className={`w-4 h-4 ${colors.text}`} />
                   <span className="text-sm font-medium text-foreground truncate">{vc.name}</span>
@@ -182,7 +182,7 @@ export function VClusterStatus({ config: _config }: VClusterStatusProps) {
                 </div>
                 <span className="text-xs text-muted-foreground font-mono">{vc.k8sVersion}</span>
               </div>
-              <div className="flex items-center justify-between text-xs">
+              <div className="flex flex-wrap items-center justify-between gap-y-2 text-xs">
                 <div className="flex items-center gap-2"><ClusterBadge cluster={vc.hostCluster} /><span className="text-muted-foreground">{vc.namespace}</span></div>
               </div>
             </div>

--- a/web/src/components/cards/WarningEvents.tsx
+++ b/web/src/components/cards/WarningEvents.tsx
@@ -125,7 +125,7 @@ export function WarningEvents() {
   return (
     <div className="space-y-3">
       {/* Header controls */}
-      <div className="flex items-center justify-between">
+      <div className="flex flex-wrap items-center justify-between gap-y-2">
         <span className="text-xs text-muted-foreground">
           {totalItems} warning{totalItems !== 1 ? 's' : ''}
         </span>

--- a/web/src/components/cards/WorkloadDeployment.tsx
+++ b/web/src/components/cards/WorkloadDeployment.tsx
@@ -414,7 +414,7 @@ function DraggableWorkloadItem({ workload, isSelected, onSelect, onScaled }: Dra
       {/* Expanded details */}
       {isSelected && !isDragging && (
         <div className="mt-3 pt-3 ml-10 border-t border-gray-200 dark:border-border space-y-2">
-          <div className="flex items-center justify-between">
+          <div className="flex flex-wrap items-center justify-between gap-y-2">
             <span className="text-xs text-muted-foreground">Target Clusters</span>
             <div className="flex gap-1">
               {workload.targetClusters.map((c) => (
@@ -422,7 +422,7 @@ function DraggableWorkloadItem({ workload, isSelected, onSelect, onScaled }: Dra
               ))}
             </div>
           </div>
-          <div className="flex items-center justify-between">
+          <div className="flex flex-wrap items-center justify-between gap-y-2">
             <span className="text-xs text-muted-foreground">{t('common.labels')}</span>
             <div className="flex gap-1 flex-wrap justify-end">
               {Object.entries(workload.labels).map(([k, v]) => (
@@ -731,7 +731,7 @@ export function WorkloadDeployment(_props: WorkloadDeploymentProps) {
   if (showSkeleton) {
     return (
       <div className="h-full flex flex-col min-h-card p-3">
-        <div className="flex items-center justify-between mb-2">
+        <div className="flex flex-wrap items-center justify-between gap-y-2 mb-2">
           <Skeleton variant="text" width={120} height={16} />
           <Skeleton variant="rounded" width={80} height={28} />
         </div>
@@ -749,7 +749,7 @@ export function WorkloadDeployment(_props: WorkloadDeploymentProps) {
   return (
     <div className="h-full flex flex-col">
       {/* Header with controls */}
-      <div className="flex items-center justify-between mb-2 flex-shrink-0 px-3 pt-3">
+      <div className="flex flex-wrap items-center justify-between gap-y-2 mb-2 flex-shrink-0 px-3 pt-3">
         <div className="flex items-center gap-2">
           <span className="text-sm font-medium text-muted-foreground">
             {stats.totalWorkloads} total &middot; {stats.uniqueWorkloads} unique

--- a/web/src/components/cards/WorkloadImportDialog.tsx
+++ b/web/src/components/cards/WorkloadImportDialog.tsx
@@ -415,7 +415,7 @@ export function WorkloadImportDialog({ isOpen, onClose, onImport }: WorkloadImpo
 
   const renderYamlTab = () => (
     <div className="space-y-3">
-      <div className="flex items-center justify-between">
+      <div className="flex flex-wrap items-center justify-between gap-y-2">
         <p className="text-xs text-muted-foreground">
           {t('workloadImport.yamlDescription')}
         </p>

--- a/web/src/components/cards/buildpacks-status/BuildpacksStatus.tsx
+++ b/web/src/components/cards/buildpacks-status/BuildpacksStatus.tsx
@@ -190,7 +190,7 @@ export function BuildpacksStatus({ config }: BuildpacksStatusProps) {
   return (
     <div className="h-full flex flex-col min-h-card content-loaded overflow-hidden">
       {/* Controls */}
-      <div className="flex items-center justify-between gap-2 mb-4">
+      <div className="flex flex-wrap items-center justify-between gap-y-2 gap-2 mb-4">
         <div className="flex items-center gap-2">
           {localClusterFilter.length > 0 && (
             <span className="flex items-center gap-1 text-xs text-muted-foreground bg-secondary/50 px-1.5 py-0.5 rounded">
@@ -306,7 +306,7 @@ export function BuildpacksStatus({ config }: BuildpacksStatusProps) {
                   : 'bg-secondary/30'
               } hover:bg-secondary/50`}
             >
-              <div className="flex items-center justify-between mb-1">
+              <div className="flex flex-wrap items-center justify-between gap-y-2 mb-1">
                 <div className="flex items-center gap-2">
                   <Icon className={`w-4 h-4 ${styles.icon}`} />
                   <span className="text-sm font-medium group-hover:text-purple-400">

--- a/web/src/components/cards/cloudevents_status/CloudEventsStatus.tsx
+++ b/web/src/components/cards/cloudevents_status/CloudEventsStatus.tsx
@@ -63,7 +63,7 @@ export function CloudEventsStatus() {
   if (showSkeleton) {
     return (
       <div className="h-full flex flex-col min-h-card gap-4">
-        <div className="flex items-center justify-between">
+        <div className="flex flex-wrap items-center justify-between gap-y-2">
           <Skeleton variant="rounded" width={140} height={28} />
           <Skeleton variant="rounded" width={90} height={20} />
         </div>
@@ -95,7 +95,7 @@ export function CloudEventsStatus() {
 
   return (
     <div className="h-full flex flex-col min-h-card content-loaded gap-4 overflow-hidden">
-      <div className="flex items-center justify-between">
+      <div className="flex flex-wrap items-center justify-between gap-y-2">
         <div
           className={`flex items-center gap-2 px-3 py-1.5 rounded-full text-sm font-medium ${
             isHealthy ? 'bg-green-500/15 text-green-400' : 'bg-yellow-500/15 text-yellow-400'
@@ -156,7 +156,7 @@ export function CloudEventsStatus() {
               const style = STATUS_STYLE[resource.state]
               return (
                 <div key={`${resource.cluster}/${resource.namespace}/${resource.kind}/${resource.name}`} className="rounded-md bg-secondary/30 px-3 py-2.5 space-y-1.5">
-                  <div className="flex items-center justify-between gap-2">
+                  <div className="flex flex-wrap items-center justify-between gap-y-2 gap-2">
                     <div className="min-w-0 flex items-center gap-1.5">
                       {style.icon}
                       <span className="text-xs font-medium truncate">{resource.name}</span>
@@ -165,7 +165,7 @@ export function CloudEventsStatus() {
                       {t(STATUS_LABEL_KEY[resource.state])}
                     </span>
                   </div>
-                  <div className="text-xs text-muted-foreground flex items-center justify-between gap-2">
+                  <div className="text-xs text-muted-foreground flex flex-wrap items-center justify-between gap-y-2 gap-2">
                     <span className="truncate">{resource.kind} · {resource.namespace} · {resource.cluster}</span>
                     <span className="shrink-0">{t('cloudevents.sink')}: {resource.sink || t('security.notApplicable')}</span>
                   </div>

--- a/web/src/components/cards/cluster-resource-tree/ClusterResourceTree.tsx
+++ b/web/src/components/cards/cluster-resource-tree/ClusterResourceTree.tsx
@@ -327,7 +327,7 @@ export function ClusterResourceTree({ config: _config }: ClusterResourceTreeProp
   return (
     <div className="h-full flex flex-col min-h-0">
       {/* Header */}
-      <div className="flex items-center justify-between mb-3 flex-shrink-0">
+      <div className="flex flex-wrap items-center justify-between gap-y-2 mb-3 flex-shrink-0">
         <div className="flex items-center gap-2">
           <span className="text-sm font-medium text-muted-foreground">
             {t('resourceTree.clustersCount', { count: filteredClusters.length })}

--- a/web/src/components/cards/compliance/ComplianceScoreBreakdownModal.tsx
+++ b/web/src/components/cards/compliance/ComplianceScoreBreakdownModal.tsx
@@ -191,7 +191,7 @@ function OverviewTab({ score, breakdown, scoreCtx, kubescapeData, kyvernoData }:
 
       {/* Aggregate stats — makes the Overview tab informative even when a single tool is connected. */}
       {totalChecks > 0 && (
-        <div className="grid grid-cols-3 gap-3">
+        <div className="grid grid-cols-2 sm:grid-cols-3 gap-3">
           <StatBox label="Total Checks" value={totalChecks} />
           <StatBox label="Passing" value={totalPassed} color="text-green-400" />
           <StatBox label="Failing" value={totalFailed} color="text-red-400" />
@@ -204,7 +204,7 @@ function OverviewTab({ score, breakdown, scoreCtx, kubescapeData, kyvernoData }:
           <h4 className="text-xs font-medium text-muted-foreground">By tool</h4>
           {breakdown.map(item => (
             <div key={item.name} className="space-y-1">
-              <div className="flex items-center justify-between">
+              <div className="flex flex-wrap items-center justify-between gap-y-2">
                 <span className="text-sm font-medium text-foreground">{item.name}</span>
                 <span className={`text-sm font-bold ${item.value >= SCORE_GOOD_THRESHOLD ? 'text-green-400' : item.value >= SCORE_WARN_THRESHOLD ? 'text-yellow-400' : 'text-red-400'}`}>
                   {item.value}%
@@ -236,7 +236,7 @@ function KubescapeTab({ data }: { data: NonNullable<ComplianceScoreBreakdownModa
   return (
     <div className="space-y-4">
       {/* Stats grid */}
-      <div className="grid grid-cols-3 gap-3">
+      <div className="grid grid-cols-2 sm:grid-cols-3 gap-3">
         <StatBox label="Total Controls" value={data.totalControls} />
         <StatBox label="Passed" value={data.passedControls} color="text-green-400" />
         <StatBox label="Failed" value={data.failedControls} color="text-red-400" />

--- a/web/src/components/cards/console-missions/ConsoleHealthCheckCard.tsx
+++ b/web/src/components/cards/console-missions/ConsoleHealthCheckCard.tsx
@@ -154,7 +154,7 @@ Please provide:
       </div>
 
       {/* Quick Stats */}
-      <div className="grid grid-cols-3 gap-2 mb-2 text-center">
+      <div className="grid grid-cols-2 sm:grid-cols-3 gap-2 mb-2 text-center">
         <div
           className={cn(
             "p-2 rounded bg-green-500/10",

--- a/web/src/components/cards/console-missions/ConsoleIssuesCard.tsx
+++ b/web/src/components/cards/console-missions/ConsoleIssuesCard.tsx
@@ -121,7 +121,7 @@ Please:
         onGoToSettings={goToSettings}
       />
 
-      <div className="flex items-center justify-between mb-4">
+      <div className="flex flex-wrap items-center justify-between gap-y-2 mb-4">
         <div className="flex items-center gap-2">
           {runningRepairMission && (
             <span className="flex items-center gap-1 text-xs text-purple-400">
@@ -165,7 +165,7 @@ Please:
         {podIssues.slice(0, 3).map((issue, i) => (
           <div
             key={`pod-${i}`}
-            className="p-2 rounded bg-orange-500/10 text-xs cursor-pointer hover:bg-orange-500/20 transition-colors group flex items-center justify-between"
+            className="p-2 rounded bg-orange-500/10 text-xs cursor-pointer hover:bg-orange-500/20 transition-colors group flex flex-wrap items-center justify-between gap-y-2"
             onClick={() => issue.cluster && drillToPod(issue.cluster, issue.namespace, issue.name, { status: issue.status, restarts: issue.restarts, issues: issue.issues })}
             title={`Click to view details for pod ${issue.name}`}
           >

--- a/web/src/components/cards/console-missions/ConsoleKubeconfigAuditCard.tsx
+++ b/web/src/components/cards/console-missions/ConsoleKubeconfigAuditCard.tsx
@@ -122,7 +122,7 @@ Please:
         {unreachableClusters.slice(0, 3).map((cluster, i) => (
           <div
             key={i}
-            className="p-2 rounded bg-yellow-500/10 text-xs cursor-pointer hover:bg-yellow-500/20 transition-colors group flex items-center justify-between"
+            className="p-2 rounded bg-yellow-500/10 text-xs cursor-pointer hover:bg-yellow-500/20 transition-colors group flex flex-wrap items-center justify-between gap-y-2"
             onClick={() => drillToCluster(cluster.name)}
             title={`Click to view details for ${cluster.name}`}
           >

--- a/web/src/components/cards/console-missions/ConsoleOfflineDetectionCard.tsx
+++ b/web/src/components/cards/console-missions/ConsoleOfflineDetectionCard.tsx
@@ -874,7 +874,7 @@ Please:
       </div>
 
       {/* Status Summary */}
-      <div className="grid grid-cols-3 gap-2 mb-4">
+      <div className="grid grid-cols-2 sm:grid-cols-3 gap-2 mb-4">
         <div
           className={cn(
             'p-2 rounded-lg border',
@@ -1042,7 +1042,7 @@ ${aiEnabled ? '\nClick to run AI analysis now' : ''}`}
                   {/* Group Header */}
                   <div
                     className={cn(
-                      'p-2 rounded text-xs cursor-pointer transition-colors flex items-center justify-between',
+                      'p-2 rounded text-xs cursor-pointer transition-colors flex flex-wrap items-center justify-between gap-y-2',
                       `bg-${severityColor}-500/10 hover:bg-${severityColor}-500/20 border border-${severityColor}-500/20`
                     )}
                     style={{
@@ -1119,7 +1119,7 @@ TASK:
                       {group.items.map((item) => (
                         <div
                           key={item.id}
-                          className="p-1.5 rounded bg-secondary/30 text-xs cursor-pointer hover:bg-secondary/50 transition-colors flex items-center justify-between"
+                          className="p-1.5 rounded bg-secondary/30 text-xs cursor-pointer hover:bg-secondary/50 transition-colors flex flex-wrap items-center justify-between gap-y-2"
                           onClick={() => {
                             if (item.category === 'offline' && item.nodeData?.cluster) {
                               drillToNode(item.nodeData.cluster, item.name, {})
@@ -1162,7 +1162,7 @@ TASK:
             return (
               <div
                 key={item.id}
-                className="p-2 rounded bg-red-500/10 text-xs cursor-pointer hover:bg-red-500/20 transition-colors group flex items-center justify-between"
+                className="p-2 rounded bg-red-500/10 text-xs cursor-pointer hover:bg-red-500/20 transition-colors group flex flex-wrap items-center justify-between gap-y-2"
                 onClick={() => node.cluster && drillToNode(node.cluster, node.name, {
                   status: node.unschedulable ? 'Cordoned' : node.status,
                   unschedulable: node.unschedulable,
@@ -1203,7 +1203,7 @@ TASK:
             return (
               <div
                 key={item.id}
-                className="p-2 rounded bg-yellow-500/10 text-xs cursor-pointer hover:bg-yellow-500/20 transition-colors group flex items-center justify-between"
+                className="p-2 rounded bg-yellow-500/10 text-xs cursor-pointer hover:bg-yellow-500/20 transition-colors group flex flex-wrap items-center justify-between gap-y-2"
                 onClick={() => drillToCluster(issue.cluster)}
                 title={`Click to view cluster ${issue.cluster}`}
               >
@@ -1243,7 +1243,7 @@ TASK:
                 )}
                 title={risk.reasonDetailed || risk.reason}
               >
-                <div className="flex items-center justify-between">
+                <div className="flex flex-wrap items-center justify-between gap-y-2">
                   <div
                     className="min-w-0 flex items-center gap-2 flex-1 cursor-pointer"
                     onClick={() => risk.cluster && drillToCluster(risk.cluster)}

--- a/web/src/components/cards/coredns_status/CoreDNSStatus.tsx
+++ b/web/src/components/cards/coredns_status/CoreDNSStatus.tsx
@@ -47,7 +47,7 @@ export function CoreDNSStatus({ config }: CoreDNSStatusProps) {
   if (showSkeleton) {
     return (
       <div className="h-full flex flex-col min-h-card gap-3">
-        <div className="grid grid-cols-3 gap-2">
+        <div className="grid grid-cols-2 sm:grid-cols-3 gap-2">
           {[1, 2, 3].map(i => <Skeleton key={i} variant="rounded" height={52} />)}
         </div>
         <Skeleton variant="rounded" height={64} />
@@ -70,7 +70,7 @@ export function CoreDNSStatus({ config }: CoreDNSStatusProps) {
     <div className="h-full flex flex-col min-h-card content-loaded overflow-hidden gap-3">
       {/* top stats — only pod-derivable metrics */}
       {totals && (
-        <div className="grid grid-cols-3 gap-2">
+        <div className="grid grid-cols-2 sm:grid-cols-3 gap-2">
           <StatTile
             value={totals.totalPods.toString()}
             sub={t('coreDNSStatus.pods')}
@@ -97,7 +97,7 @@ export function CoreDNSStatus({ config }: CoreDNSStatusProps) {
       </div>
 
       {/* footer */}
-      <div className="pt-2 border-t border-border/50 text-xs text-muted-foreground flex items-center justify-between">
+      <div className="pt-2 border-t border-border/50 text-xs text-muted-foreground flex flex-wrap items-center justify-between gap-y-2">
         <span>
           {t('coreDNSStatus.summary', {
             pods: clusters.reduce((s, c) => s + c.pods.length, 0),
@@ -122,7 +122,7 @@ function ClusterRow({ cluster, t }: { cluster: CoreDNSClusterStatus; t: ReturnTy
         }`}
     >
       {/* name + badge */}
-      <div className="flex items-center justify-between mb-2">
+      <div className="flex flex-wrap items-center justify-between gap-y-2 mb-2">
         <div className="flex items-center gap-2">
           <StatusIcon
             className={`w-4 h-4 flex-shrink-0 ${cluster.healthy ? 'text-green-400' : 'text-red-400'}`}

--- a/web/src/components/cards/crio_status/CrioStatus.tsx
+++ b/web/src/components/cards/crio_status/CrioStatus.tsx
@@ -84,7 +84,7 @@ export function CrioStatus() {
   return (
     <div className="h-full flex flex-col min-h-card content-loaded gap-4">
       {/* Health badge + last check */}
-      <div className="flex items-center justify-between">
+      <div className="flex flex-wrap items-center justify-between gap-y-2">
         <div
           className={`flex items-center gap-2 px-3 py-1.5 rounded-full text-sm font-medium ${
             isHealthy
@@ -184,7 +184,7 @@ export function CrioStatus() {
           <p className="text-xs font-medium text-muted-foreground">{t('crio.recentImagePulls')}</p>
           <div className="space-y-1.5 max-h-32 overflow-y-auto scrollbar-thin">
             {(data.recentImagePulls || []).slice(0, 5).map((pull, idx) => (
-              <div key={idx} className="flex items-center justify-between text-xs gap-2">
+              <div key={idx} className="flex flex-wrap items-center justify-between gap-y-2 text-xs gap-2">
                 <span className="text-muted-foreground truncate flex-1" title={pull.image}>
                   {pull.image.split('/').pop()?.split(':')[0] || pull.image}
                 </span>

--- a/web/src/components/cards/crossplane-status/CrossplaneManagedResources.tsx
+++ b/web/src/components/cards/crossplane-status/CrossplaneManagedResources.tsx
@@ -144,7 +144,7 @@ export function CrossplaneManagedResources() {
   return (
     <div className="h-full flex flex-col min-h-card content-loaded">
       {/* Header */}
-      <div className="flex items-center justify-between mb-4">
+      <div className="flex flex-wrap items-center justify-between gap-y-2 mb-4">
         <StatusBadge color="purple">
           {t('crossplaneManagedResources.resourceCount', { count: rawResources.length })}
         </StatusBadge>
@@ -170,7 +170,7 @@ export function CrossplaneManagedResources() {
         className="mb-4"
       />
       {/* Stats */}
-      <div className="grid grid-cols-4 gap-2 mb-4">
+      <div className="grid grid-cols-2 sm:grid-cols-4 gap-2 mb-4">
         <StatBox label={t('crossplaneManagedResources.ready')} value={readyCount} color="green" />
         <StatBox label={t('crossplaneManagedResources.notReady')} value={notReadyCount} color="orange" />
         <StatBox label={t('crossplaneManagedResources.error')} value={errorCount} color="red" />
@@ -193,7 +193,7 @@ export function CrossplaneManagedResources() {
           return (
             <div
               key={`${resource.namespace}/${resource.name}`}
-              className="group flex items-center justify-between p-2 rounded-lg border border-border/30 bg-secondary/30 transition-all hover:bg-secondary/50 hover:border-border/50"
+              className="group flex flex-wrap items-center justify-between gap-y-2 p-2 rounded-lg border border-border/30 bg-secondary/30 transition-all hover:bg-secondary/50 hover:border-border/50"
             >
               <div className="flex items-center gap-2 min-w-0 flex-1">
                 {statusIcon}

--- a/web/src/components/cards/drasi/DrasiReactiveGraph.tsx
+++ b/web/src/components/cards/drasi/DrasiReactiveGraph.tsx
@@ -870,7 +870,7 @@ function findTrendColumn(columns: string[]): string | null {
 function KPIBox({ label, value, accent }: { label: string; value: number; accent: 'emerald' | 'cyan' }) {
   const accentClass = accent === 'cyan' ? 'text-cyan-400' : 'text-emerald-400'
   return (
-    <div className="bg-slate-900/80 border border-slate-700/40 rounded px-3 py-1.5 flex items-center justify-between">
+    <div className="bg-slate-900/80 border border-slate-700/40 rounded px-3 py-1.5 flex flex-wrap items-center justify-between gap-y-2">
       <span className="text-[10px] font-semibold text-muted-foreground uppercase tracking-wider">{label}</span>
       <span className={`text-sm font-mono font-semibold ${accentClass}`}>{value}</span>
     </div>
@@ -936,7 +936,7 @@ function ResultsTable({ results, isDemo, onRowClick, headerAction }: ResultsTabl
 
   return (
     <div className="mt-2 bg-slate-950/80 border border-slate-700/40 rounded overflow-hidden">
-      <div className="px-2 py-1 border-b border-slate-700/50 flex items-center justify-between">
+      <div className="px-2 py-1 border-b border-slate-700/50 flex flex-wrap items-center justify-between gap-y-2">
         <div className="flex items-center gap-1.5">
           <span className="text-[10px] font-medium text-cyan-400 uppercase tracking-wider">{label}</span>
           <motion.div
@@ -1058,7 +1058,7 @@ function RowDetailDrawer({ row, onClose }: { row: LiveResultRow | null; onClose:
       exit={{ x: '100%' }}
       transition={{ type: 'tween', duration: 0.2 }}
     >
-      <div className="flex items-center justify-between px-3 py-2 border-b border-slate-700/60">
+      <div className="flex flex-wrap items-center justify-between gap-y-2 px-3 py-2 border-b border-slate-700/60">
         <span className="text-xs font-semibold text-cyan-300 uppercase tracking-wider">{t('drasi.rowDetailTitle')}</span>
         <button type="button" onClick={onClose} className="min-w-11 min-h-11 flex items-center justify-center rounded hover:bg-slate-800 text-slate-400" aria-label={t('actions.close')}>
           <X className="w-3.5 h-3.5" />
@@ -1775,7 +1775,7 @@ function StreamSampleDrawer({ endpoint, isDemo, onClose }: StreamSampleDrawerPro
       exit={{ x: '100%' }}
       transition={{ type: 'tween', duration: 0.2 }}
     >
-      <div className="flex items-center justify-between px-3 py-2 border-b border-slate-700/60">
+      <div className="flex flex-wrap items-center justify-between gap-y-2 px-3 py-2 border-b border-slate-700/60">
         <div className="flex items-center gap-1.5">
           <Code2 className="w-3.5 h-3.5 text-cyan-400" />
           <span className="text-xs font-semibold text-cyan-300 uppercase tracking-wider">{t('drasi.consumeStreamTitle')}</span>
@@ -1808,7 +1808,7 @@ function StreamSampleDrawer({ endpoint, isDemo, onClose }: StreamSampleDrawerPro
         ))}
       </div>
 
-      <div className="px-3 py-1.5 flex items-center justify-between border-b border-slate-800/60">
+      <div className="px-3 py-1.5 flex flex-wrap items-center justify-between gap-y-2 border-b border-slate-800/60">
         <code className="text-[10px] text-muted-foreground font-mono truncate flex-1 mr-2">{endpoint}</code>
         <button
           type="button"
@@ -2583,7 +2583,7 @@ export function DrasiReactiveGraph() {
       {/* Install Drasi CTA — shown only when no live connection is active.
           Deep-links to the existing console-kb install mission. */}
       {!isLive && (
-        <div className="flex-shrink-0 mb-2 p-2 rounded border border-cyan-500/30 bg-cyan-500/5 flex items-center justify-between gap-3">
+        <div className="flex-shrink-0 mb-2 p-2 rounded border border-cyan-500/30 bg-cyan-500/5 flex flex-wrap items-center justify-between gap-y-2 gap-3">
           <div className="min-w-0">
             <div className="text-xs font-semibold text-cyan-300 truncate">{t('drasi.installDrasiTitle')}</div>
             <div className="text-[10px] text-muted-foreground truncate">{t('drasi.installDrasiDescription')}</div>
@@ -2599,7 +2599,7 @@ export function DrasiReactiveGraph() {
         </div>
       )}
       {/* Pipeline KPIs strip */}
-      <div className="flex-shrink-0 grid grid-cols-4 gap-2 mb-2">
+      <div className="flex-shrink-0 grid grid-cols-2 sm:grid-cols-4 gap-2 mb-2">
         <KPIBox label={KPI_LABEL_EVENTS_PER_SEC} value={kpis.eventsPerSec} accent="emerald" />
         <KPIBox label={KPI_LABEL_RESULT_ROWS} value={kpis.matchRate} accent="cyan" />
         <KPIBox label={KPI_LABEL_SOURCES} value={kpis.activeSources} accent="emerald" />

--- a/web/src/components/cards/failover_timeline/FailoverTimeline.tsx
+++ b/web/src/components/cards/failover_timeline/FailoverTimeline.tsx
@@ -126,7 +126,7 @@ function TimelineEvent({ event }: { event: FailoverEvent }) {
       {/* Content */}
       <div className="flex-1 min-w-0 space-y-1">
         {/* Row 1: type badge + timestamp */}
-        <div className="flex items-center justify-between gap-2">
+        <div className="flex flex-wrap items-center justify-between gap-y-2 gap-2">
           <div className={`inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium ${typeCfg.badgeClass}`}>
             {typeCfg.icon}
             {typeCfg.label}
@@ -182,7 +182,7 @@ export function FailoverTimeline() {
   if (showSkeleton) {
     return (
       <div className="h-full flex flex-col min-h-card gap-4">
-        <div className="flex items-center justify-between">
+        <div className="flex flex-wrap items-center justify-between gap-y-2">
           <Skeleton variant="rounded" width={160} height={28} />
           <Skeleton variant="rounded" width={80} height={20} />
         </div>
@@ -230,7 +230,7 @@ export function FailoverTimeline() {
   return (
     <div className="h-full flex flex-col min-h-card content-loaded gap-4 overflow-hidden">
       {/* ── Header ── */}
-      <div className="flex items-center justify-between">
+      <div className="flex flex-wrap items-center justify-between gap-y-2">
         <div className="flex items-center gap-2">
           <div className={`flex items-center gap-2 px-3 py-1.5 rounded-full text-sm font-medium ${healthColorClass}`}>
             <Server className="w-4 h-4" />
@@ -249,7 +249,7 @@ export function FailoverTimeline() {
       </div>
 
       {/* ── Summary stats ── */}
-      <div className="grid grid-cols-3 gap-2">
+      <div className="grid grid-cols-2 sm:grid-cols-3 gap-2">
         <div className="p-2 rounded-lg bg-secondary/30 border border-red-500/20">
           <span className="text-xs text-red-400 block">
             {t('failoverTimeline.clusterDown', 'Down Events')}

--- a/web/src/components/cards/flatcar_status/index.tsx
+++ b/web/src/components/cards/flatcar_status/index.tsx
@@ -63,7 +63,7 @@ export function FlatcarStatus() {
   return (
     <div className="h-full flex flex-col min-h-card content-loaded gap-4">
       {/* Health badge + last check */}
-      <div className="flex items-center justify-between">
+      <div className="flex flex-wrap items-center justify-between gap-y-2">
         <div
           className={`flex items-center gap-2 px-3 py-1.5 rounded-full text-sm font-medium ${
             isHealthy

--- a/web/src/components/cards/fluentd_status/FluentdStatus.tsx
+++ b/web/src/components/cards/fluentd_status/FluentdStatus.tsx
@@ -116,7 +116,7 @@ function FluentdStatusInternal() {
   return (
     <div className="h-full flex flex-col min-h-card content-loaded gap-4 overflow-hidden">
       {/* Health badge + last check */}
-      <div className="flex items-center justify-between">
+      <div className="flex flex-wrap items-center justify-between gap-y-2">
         <div className={`flex items-center gap-2 px-3 py-1.5 rounded-full text-sm font-medium ${healthColorClass}`}>
           {isHealthy ? (
             <CheckCircle className="w-4 h-4" />
@@ -160,7 +160,7 @@ function FluentdStatusInternal() {
       {/* Buffer utilization */}
       {data.bufferUtilization > 0 && (
         <div>
-          <div className="flex items-center justify-between mb-1">
+          <div className="flex flex-wrap items-center justify-between gap-y-2 mb-1">
             <span className="text-xs text-muted-foreground">
               {t('fluentd.bufferUtilization', 'Buffer utilization')}
             </span>
@@ -179,7 +179,7 @@ function FluentdStatusInternal() {
             {outputPlugins.map((plugin) => (
               <div
                 key={plugin.name}
-                className="flex items-center justify-between rounded-md bg-muted/30 px-3 py-2"
+                className="flex flex-wrap items-center justify-between gap-y-2 rounded-md bg-muted/30 px-3 py-2"
               >
                 <div className="flex items-center gap-2 min-w-0">
                   {pluginStatusIcon(plugin.status)}

--- a/web/src/components/cards/insights/ClusterDeltaDetector.tsx
+++ b/web/src/components/cards/insights/ClusterDeltaDetector.tsx
@@ -192,7 +192,7 @@ export function ClusterDeltaDetector() {
                   key={`${delta.dimension}-${i}`}
                   className={`rounded-lg border p-2 ${SIGNIFICANCE_COLORS[delta.significance] || SIGNIFICANCE_COLORS.low}`}
                 >
-                  <div className="flex items-center justify-between">
+                  <div className="flex flex-wrap items-center justify-between gap-y-2">
                     <span className="text-xs font-medium">{delta.dimension}</span>
                     <StatusBadge
                       color={delta.significance === 'high' ? 'red' : delta.significance === 'medium' ? 'yellow' : 'gray'}

--- a/web/src/components/cards/insights/InsightDetailModal.tsx
+++ b/web/src/components/cards/insights/InsightDetailModal.tsx
@@ -139,7 +139,7 @@ Help me investigate and resolve this.`,
         )}
       </BaseModal.Content>
       <BaseModal.Footer>
-        <div className="flex items-center justify-between w-full">
+        <div className="flex flex-wrap items-center justify-between gap-y-2 w-full">
           <div className="flex items-center gap-2">
             {!acknowledged && (
               <button

--- a/web/src/components/cards/intoto_supply_chain/IntotoSupplyChain.tsx
+++ b/web/src/components/cards/intoto_supply_chain/IntotoSupplyChain.tsx
@@ -210,7 +210,7 @@ Please proceed step by step.`,
   return (
     <div className="h-full flex flex-col min-h-card">
       {/* Controls */}
-      <div className="flex items-center justify-between mb-3">
+      <div className="flex flex-wrap items-center justify-between gap-y-2 mb-3">
         <div className="flex items-center gap-1">
           <RefreshIndicator isRefreshing={isRefreshing} lastUpdated={lastRefresh} size="xs" />
           {isDemoData && (
@@ -242,7 +242,7 @@ Please proceed step by step.`,
       {isLoading && !hasData && (
         <div className="space-y-3 animate-pulse">
           <div className="h-10 bg-secondary/50 rounded-lg" />
-          <div className="grid grid-cols-3 gap-2">
+          <div className="grid grid-cols-2 sm:grid-cols-3 gap-2">
             <div className="h-12 bg-secondary/50 rounded-lg" />
             <div className="h-12 bg-secondary/50 rounded-lg" />
             <div className="h-12 bg-secondary/50 rounded-lg" />
@@ -340,7 +340,7 @@ Please proceed step by step.`,
       )}
 
       {/* Stats */}
-      <div className="grid grid-cols-3 gap-2 mb-3">
+      <div className="grid grid-cols-2 sm:grid-cols-3 gap-2 mb-3">
         <div className="p-2 rounded-lg bg-cyan-500/10 border border-cyan-500/20 text-center">
           <p className="text-2xs text-cyan-400">{t('intoto_supply_chain.statsLayouts')}</p>
           <p className="text-lg font-bold text-foreground">{stats.totalLayouts}</p>
@@ -389,7 +389,7 @@ Please proceed step by step.`,
                 aria-expanded={isExpanded}
                 aria-label={`${isExpanded ? 'Collapse' : 'Expand'} layout: ${layout.name} on ${layout.cluster}`}
               >
-                <div className="flex items-center justify-between mb-1">
+                <div className="flex flex-wrap items-center justify-between gap-y-2 mb-1">
                   <span className="text-sm font-medium text-foreground truncate">
                     {layout.name}
                   </span>
@@ -405,7 +405,7 @@ Please proceed step by step.`,
                     </StatusBadge>
                   </div>
                 </div>
-                <div className="flex items-center justify-between text-xs text-muted-foreground">
+                <div className="flex flex-wrap items-center justify-between gap-y-2 text-xs text-muted-foreground">
                   <span>{t('intoto_supply_chain.stepsCount', { count: layout.steps.length })}</span>
                   <span className="text-2xs">{layout.cluster}</span>
                 </div>
@@ -420,7 +420,7 @@ Please proceed step by step.`,
                     return (
                       <div
                         key={`${step.name}-${si}`}
-                        className="flex items-center justify-between text-xs"
+                        className="flex flex-wrap items-center justify-between gap-y-2 text-xs"
                       >
                         <div className="flex items-center gap-1.5">
                           <StatusIcon className={`w-3 h-3 ${cfg.color} flex-shrink-0`} />

--- a/web/src/components/cards/kagent/KagentSecurity.tsx
+++ b/web/src/components/cards/kagent/KagentSecurity.tsx
@@ -145,7 +145,7 @@ export function KagentSecurity({ config }: { config?: Record<string, unknown> })
           </div>
           <div className="space-y-1">
             {byoAgents.map(agent => (
-              <div key={`${agent.cluster}-${agent.name}`} className="flex items-center justify-between text-xs py-1 px-2 rounded bg-yellow-400/5 border border-yellow-400/10">
+              <div key={`${agent.cluster}-${agent.name}`} className="flex flex-wrap items-center justify-between gap-y-2 text-xs py-1 px-2 rounded bg-yellow-400/5 border border-yellow-400/10">
                 <div className="flex items-center gap-1.5">
                   <ShieldAlert className="w-3 h-3 text-yellow-400" />
                   <span className="text-foreground">{agent.name}</span>

--- a/web/src/components/cards/kagenti/KagentiSecurity.tsx
+++ b/web/src/components/cards/kagenti/KagentiSecurity.tsx
@@ -50,7 +50,7 @@ export function KagentiSecurity({ config }: { config?: Record<string, unknown> }
           </div>
           <span className="text-lg font-bold text-white">{stats.pct}%</span>
         </div>
-        <div className="grid grid-cols-3 gap-2 text-center">
+        <div className="grid grid-cols-2 sm:grid-cols-3 gap-2 text-center">
           <div className="rounded bg-green-400/10 py-1.5">
             <div className="text-sm font-bold text-green-400">{stats.strict}</div>
             <div className="text-xs text-muted-foreground">Strict</div>
@@ -78,7 +78,7 @@ export function KagentiSecurity({ config }: { config?: Record<string, unknown> }
               // issue 6449 — include namespace in the React key to avoid
               // collisions when two cards share the same name across
               // namespaces on the same cluster.
-              <div key={`${agent.cluster}:${agent.namespace}:${agent.name}`} className="flex items-center justify-between text-xs py-1 px-2 rounded bg-red-400/5 border border-red-400/10">
+              <div key={`${agent.cluster}:${agent.namespace}:${agent.name}`} className="flex flex-wrap items-center justify-between gap-y-2 text-xs py-1 px-2 rounded bg-red-400/5 border border-red-400/10">
                 <div className="flex items-center gap-1.5">
                   <ShieldAlert className="w-3 h-3 text-red-400" />
                   <span className="text-foreground">{agent.agentName}</span>

--- a/web/src/components/cards/karmada_status/KarmadaStatus.tsx
+++ b/web/src/components/cards/karmada_status/KarmadaStatus.tsx
@@ -76,7 +76,7 @@ function MemberClusterRow({ cluster }: { cluster: KarmadaMemberCluster }) {
   return (
     <div className="rounded-md bg-muted/30 px-3 py-2 space-y-1">
       {/* Row 1: name + status */}
-      <div className="flex items-center justify-between gap-2">
+      <div className="flex flex-wrap items-center justify-between gap-y-2 gap-2">
         <div className="flex items-center gap-1.5 min-w-0">
           {statusCfg.icon}
           <span className="text-xs font-medium truncate">{cluster.name}</span>
@@ -84,7 +84,7 @@ function MemberClusterRow({ cluster }: { cluster: KarmadaMemberCluster }) {
         <span className={`text-xs shrink-0 ${statusCfg.color}`}>{cluster.status}</span>
       </div>
       {/* Row 2: k8s version + node count */}
-      <div className="flex items-center justify-between text-xs text-muted-foreground">
+      <div className="flex flex-wrap items-center justify-between gap-y-2 text-xs text-muted-foreground">
         <span className="truncate">{cluster.kubernetesVersion}</span>
         <span className="shrink-0 ml-2">
           {cluster.nodeCount} nodes · {cluster.syncedResources} synced
@@ -99,11 +99,11 @@ function ResourceBindingRow({ binding }: { binding: KarmadaResourceBinding }) {
   const clusters = (binding.boundClusters || []).join(', ') || '—'
   return (
     <div className="rounded-md bg-muted/30 px-3 py-2 space-y-1">
-      <div className="flex items-center justify-between gap-2">
+      <div className="flex flex-wrap items-center justify-between gap-y-2 gap-2">
         <span className="text-xs font-medium truncate">{binding.name}</span>
         <span className={`text-xs shrink-0 ${color}`}>{binding.status}</span>
       </div>
-      <div className="flex items-center justify-between text-xs text-muted-foreground">
+      <div className="flex flex-wrap items-center justify-between gap-y-2 text-xs text-muted-foreground">
         <span className="shrink-0">{binding.resourceKind}</span>
         <span className="truncate ml-2 text-right">{clusters}</span>
       </div>
@@ -158,7 +158,7 @@ export function KarmadaStatus() {
   if (showSkeleton) {
     return (
       <div className="h-full flex flex-col min-h-card gap-4">
-        <div className="flex items-center justify-between">
+        <div className="flex flex-wrap items-center justify-between gap-y-2">
           <Skeleton variant="rounded" width={140} height={28} />
           <Skeleton variant="rounded" width={80} height={20} />
         </div>
@@ -207,7 +207,7 @@ export function KarmadaStatus() {
   return (
     <div className="h-full flex flex-col min-h-card content-loaded gap-4 overflow-hidden">
       {/* ── Header ── */}
-      <div className="flex items-center justify-between">
+      <div className="flex flex-wrap items-center justify-between gap-y-2">
         <div className="flex items-center gap-2">
           <div
             className={`flex items-center gap-2 px-3 py-1.5 rounded-full text-sm font-medium ${healthColorClass}`}
@@ -233,7 +233,7 @@ export function KarmadaStatus() {
       </div>
 
       {/* ── Stats grid ── */}
-      <div className="grid grid-cols-4 gap-2">
+      <div className="grid grid-cols-2 sm:grid-cols-4 gap-2">
         <StatTile
           icon={<Globe className="w-4 h-4 text-blue-400" />}
           label={t('karmada.clusters', 'Clusters')}

--- a/web/src/components/cards/keda_status/KedaStatus.tsx
+++ b/web/src/components/cards/keda_status/KedaStatus.tsx
@@ -143,7 +143,7 @@ function ScaledObjectRow({ obj }: { obj: KedaScaledObject }) {
   return (
     <div className="rounded-md bg-muted/30 px-3 py-2 space-y-1.5">
       {/* Row 1: name + status + replicas */}
-      <div className="flex items-center justify-between gap-2">
+      <div className="flex flex-wrap items-center justify-between gap-y-2 gap-2">
         <div className="flex items-center gap-1.5 min-w-0">
           {cfg.icon}
           <span className="text-xs font-medium truncate">{obj.name}</span>
@@ -157,7 +157,7 @@ function ScaledObjectRow({ obj }: { obj: KedaScaledObject }) {
       </div>
 
       {/* Row 2: namespace + trigger */}
-      <div className="flex items-center justify-between text-xs text-muted-foreground">
+      <div className="flex flex-wrap items-center justify-between gap-y-2 text-xs text-muted-foreground">
         <span className="truncate">{obj.namespace} › {obj.target}</span>
         <span className="shrink-0 ml-2">
           {triggerLabel}
@@ -227,7 +227,7 @@ export function KedaStatus() {
   if (showSkeleton) {
     return (
       <div className="h-full flex flex-col min-h-card gap-4">
-        <div className="flex items-center justify-between">
+        <div className="flex flex-wrap items-center justify-between gap-y-2">
           <Skeleton variant="rounded" width={120} height={28} />
           <Skeleton variant="rounded" width={80} height={20} />
         </div>
@@ -276,7 +276,7 @@ export function KedaStatus() {
   return (
     <div className="h-full flex flex-col min-h-card content-loaded gap-4 overflow-hidden">
       {/* ── Header: health badge + operator pods + last check ── */}
-      <div className="flex items-center justify-between">
+      <div className="flex flex-wrap items-center justify-between gap-y-2">
         <div className="flex items-center gap-2">
           <div
             className={`flex items-center gap-2 px-3 py-1.5 rounded-full text-sm font-medium ${healthColorClass}`}
@@ -304,7 +304,7 @@ export function KedaStatus() {
 
       {/* ── Stats grid ── */}
       {scaledObjects.length > 0 && (
-        <div className="grid grid-cols-4 gap-2">
+        <div className="grid grid-cols-2 sm:grid-cols-4 gap-2">
           <StatTile
             icon={<TrendingUp className="w-4 h-4 text-blue-400" />}
             label={t('keda.total', 'Total')}

--- a/web/src/components/cards/keycloak_status/KeycloakStatus.tsx
+++ b/web/src/components/cards/keycloak_status/KeycloakStatus.tsx
@@ -113,7 +113,7 @@ function RealmRow({ realm }: { realm: KeycloakRealm }) {
   return (
     <div className="rounded-md bg-muted/30 px-3 py-2 space-y-1.5">
       {/* Row 1: name + status */}
-      <div className="flex items-center justify-between gap-2">
+      <div className="flex flex-wrap items-center justify-between gap-y-2 gap-2">
         <div className="flex items-center gap-1.5 min-w-0">
           {cfg.icon}
           <span className="text-xs font-medium truncate">{realm.name}</span>
@@ -127,7 +127,7 @@ function RealmRow({ realm }: { realm: KeycloakRealm }) {
       </div>
 
       {/* Row 2: namespace + metrics */}
-      <div className="flex items-center justify-between text-xs text-muted-foreground">
+      <div className="flex flex-wrap items-center justify-between gap-y-2 text-xs text-muted-foreground">
         <span className="truncate">{realm.namespace}</span>
         <div className="flex items-center gap-3 shrink-0 ml-2">
           <span className="flex items-center gap-1">
@@ -224,7 +224,7 @@ export function KeycloakStatus() {
   if (showSkeleton) {
     return (
       <div className="h-full flex flex-col min-h-card gap-4">
-        <div className="flex items-center justify-between">
+        <div className="flex flex-wrap items-center justify-between gap-y-2">
           <Skeleton variant="rounded" width={120} height={28} />
           <Skeleton variant="rounded" width={80} height={20} />
         </div>
@@ -270,7 +270,7 @@ export function KeycloakStatus() {
   return (
     <div className="h-full flex flex-col min-h-card content-loaded gap-4 overflow-hidden">
       {/* ── Header: health badge + operator pods + last check ── */}
-      <div className="flex items-center justify-between">
+      <div className="flex flex-wrap items-center justify-between gap-y-2">
         <div className="flex items-center gap-2">
           <div
             className={`flex items-center gap-2 px-3 py-1.5 rounded-full text-sm font-medium ${healthColorClass}`}
@@ -298,7 +298,7 @@ export function KeycloakStatus() {
 
       {/* ── Stats grid ── */}
       {realms.length > 0 && (
-        <div className="grid grid-cols-4 gap-2">
+        <div className="grid grid-cols-2 sm:grid-cols-4 gap-2">
           <StatTile
             icon={<Globe className="w-4 h-4 text-blue-400" />}
             label={t('keycloak.realms')}

--- a/web/src/components/cards/kuberay_fleet/KubeRayFleet.tsx
+++ b/web/src/components/cards/kuberay_fleet/KubeRayFleet.tsx
@@ -50,7 +50,7 @@ export function KubeRayFleet() {
   if (showSkeleton) {
     return (
       <div className="h-full flex flex-col min-h-card gap-3 p-1">
-        <div className="grid grid-cols-4 gap-2">
+        <div className="grid grid-cols-2 sm:grid-cols-4 gap-2">
           {Array.from({ length: 4 }).map((_, i) => (
             <Skeleton key={i} variant="rounded" height={48} />
           ))}
@@ -82,7 +82,7 @@ export function KubeRayFleet() {
   return (
     <div className="h-full flex flex-col min-h-card gap-3 p-1 overflow-hidden">
       {/* Fleet summary tiles */}
-      <div className="grid grid-cols-4 gap-2">
+      <div className="grid grid-cols-2 sm:grid-cols-4 gap-2">
         <StatTile icon={Server} label="Clusters" value={`${readyClusters}/${rayClusters.length}`} color="text-blue-400" />
         <StatTile icon={Cpu} label="Workers" value={String(totalWorkers)} color="text-purple-400" />
         <StatTile icon={Layers} label="GPUs" value={String(data.totalGPUs)} color="text-green-400" />
@@ -94,7 +94,7 @@ export function KubeRayFleet() {
         {rayClusters.length > 0 && (
           <Section title={`Ray Clusters (${rayClusters.length})`}>
             {rayClusters.map(c => (
-              <div key={`${c.cluster}/${c.namespace}/${c.name}`} className="flex items-center justify-between px-2 py-1.5 rounded bg-secondary/30 text-xs">
+              <div key={`${c.cluster}/${c.namespace}/${c.name}`} className="flex flex-wrap items-center justify-between gap-y-2 px-2 py-1.5 rounded bg-secondary/30 text-xs">
                 <div className="flex items-center gap-2 min-w-0">
                   <div className={`w-1.5 h-1.5 rounded-full ${c.state === 'ready' ? 'bg-green-500' : c.state === 'unhealthy' ? 'bg-red-500' : 'bg-yellow-500'}`} />
                   <span className="truncate font-mono">{c.name}</span>
@@ -114,7 +114,7 @@ export function KubeRayFleet() {
         {rayServices.length > 0 && (
           <Section title={`Serving Endpoints (${servingEndpoints}/${rayServices.length})`}>
             {rayServices.map(s => (
-              <div key={`${s.cluster}/${s.namespace}/${s.name}`} className="flex items-center justify-between px-2 py-1.5 rounded bg-secondary/30 text-xs">
+              <div key={`${s.cluster}/${s.namespace}/${s.name}`} className="flex flex-wrap items-center justify-between gap-y-2 px-2 py-1.5 rounded bg-secondary/30 text-xs">
                 <div className="flex items-center gap-2 min-w-0">
                   <ArrowUpCircle className={`w-3 h-3 flex-shrink-0 ${SERVICE_STATUS_COLORS[s.status]}`} />
                   <span className="truncate font-mono">{s.name}</span>
@@ -139,7 +139,7 @@ export function KubeRayFleet() {
             {rayJobs.map(j => {
               const { Icon, color } = JOB_STATUS_ICONS[j.jobStatus] || JOB_STATUS_ICONS.PENDING
               return (
-                <div key={`${j.cluster}/${j.namespace}/${j.name}`} className="flex items-center justify-between px-2 py-1.5 rounded bg-secondary/30 text-xs">
+                <div key={`${j.cluster}/${j.namespace}/${j.name}`} className="flex flex-wrap items-center justify-between gap-y-2 px-2 py-1.5 rounded bg-secondary/30 text-xs">
                   <div className="flex items-center gap-2 min-w-0">
                     <Icon className={`w-3 h-3 flex-shrink-0 ${color}`} />
                     <span className="truncate font-mono">{j.name}</span>

--- a/web/src/components/cards/kubescape/KubescapeDetailModal.tsx
+++ b/web/src/components/cards/kubescape/KubescapeDetailModal.tsx
@@ -109,7 +109,7 @@ export function KubescapeDetailModal({
               <h3 className="text-sm font-medium text-muted-foreground">Framework Scores</h3>
               {(status.frameworks || []).map((fw, i) => (
                 <div key={i} className="space-y-1">
-                  <div className="flex items-center justify-between text-sm">
+                  <div className="flex flex-wrap items-center justify-between gap-y-2 text-sm">
                     <span className="text-foreground">{fw.name}</span>
                     <span className={`font-medium ${
                       fw.score >= SCORE_GOOD_THRESHOLD ? 'text-green-400' :
@@ -137,7 +137,7 @@ export function KubescapeDetailModal({
           </div>
 
           {/* Summary stats */}
-          <div className="grid grid-cols-3 gap-3">
+          <div className="grid grid-cols-2 sm:grid-cols-3 gap-3">
             <div className="p-3 rounded-lg bg-secondary/30 text-center">
               <p className="text-xl font-bold text-foreground">{status.totalControls}</p>
               <p className="text-xs text-muted-foreground">Total Controls</p>

--- a/web/src/components/cards/kubevela_status/KubeVelaStatus.tsx
+++ b/web/src/components/cards/kubevela_status/KubeVelaStatus.tsx
@@ -126,7 +126,7 @@ export function KubeVelaStatus() {
   return (
     <div className="h-full flex flex-col min-h-card content-loaded gap-4 overflow-hidden">
       {/* Health badge + last check */}
-      <div className="flex items-center justify-between">
+      <div className="flex flex-wrap items-center justify-between gap-y-2">
         <div className={`flex items-center gap-2 px-3 py-1.5 rounded-full text-sm font-medium ${healthColorClass}`}>
           {isHealthy ? (
             <CheckCircle className="w-4 h-4" />

--- a/web/src/components/cards/kyverno/KyvernoDetailModal.tsx
+++ b/web/src/components/cards/kyverno/KyvernoDetailModal.tsx
@@ -176,7 +176,7 @@ Please proceed step by step.`,
             </div>
 
             {/* Stats row */}
-            <div className="grid grid-cols-4 gap-3">
+            <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
               <StatBox label="Total" value={status.totalPolicies} color="text-foreground" />
               <StatBox label="Enforcing" value={status.enforcingCount} color="text-green-400" />
               <StatBox label="Audit" value={status.auditCount} color="text-yellow-400" />
@@ -274,7 +274,7 @@ function PolicyRow({
       tabIndex={0}
       onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); onClick(policy) } }}
     >
-      <div className="flex items-center justify-between mb-1">
+      <div className="flex flex-wrap items-center justify-between gap-y-2 mb-1">
         <div className="flex items-center gap-2 min-w-0">
           <span className="text-sm font-medium text-foreground truncate">{policy.name}</span>
           <StatusBadge color={getStatusColor(policy.status)} size="xs">
@@ -319,7 +319,7 @@ function ReportBar({ report }: { report: KyvernoPolicyReport }) {
 
   return (
     <div className="space-y-1">
-      <div className="flex items-center justify-between text-xs">
+      <div className="flex flex-wrap items-center justify-between gap-y-2 text-xs">
         <span className="font-mono text-foreground">{report.namespace}</span>
         <span className="text-muted-foreground">
           {report.fail > REPORT_HIGHLIGHT_THRESHOLD && (

--- a/web/src/components/cards/lima_status/LimaStatus.tsx
+++ b/web/src/components/cards/lima_status/LimaStatus.tsx
@@ -75,7 +75,7 @@ export function LimaStatus() {
   return (
     <div className="h-full flex flex-col min-h-card content-loaded gap-4">
       {/* Health badge + last check */}
-      <div className="flex items-center justify-between">
+      <div className="flex flex-wrap items-center justify-between gap-y-2">
         <div
           className={`flex items-center gap-2 px-3 py-1.5 rounded-full text-sm font-medium ${
             isHealthy
@@ -128,7 +128,7 @@ export function LimaStatus() {
           {data.instances.map((instance) => (
             <div
               key={instance.name}
-              className="flex items-center justify-between gap-2 rounded-md px-2 py-1.5 bg-secondary/30"
+              className="flex flex-wrap items-center justify-between gap-y-2 gap-2 rounded-md px-2 py-1.5 bg-secondary/30"
             >
               <div className="flex items-center gap-2 min-w-0">
                 <Monitor className={`w-3.5 h-3.5 shrink-0 ${STATUS_COLORS[instance.status] ?? 'text-muted-foreground'}`} />

--- a/web/src/components/cards/llmd/BenchmarkHero.tsx
+++ b/web/src/components/cards/llmd/BenchmarkHero.tsx
@@ -176,7 +176,7 @@ export function BenchmarkHero() {
   return (
     <div className="p-5 h-full flex flex-col gap-4">
       {/* Top row: Run info + time range filter */}
-      <div className="flex items-center justify-between">
+      <div className="flex flex-wrap items-center justify-between gap-y-2">
         <div className="flex items-center gap-3">
           <motion.div
             initial={{ scale: 0 }}
@@ -241,7 +241,7 @@ export function BenchmarkHero() {
       </div>
 
       {/* Hero metrics row */}
-      <div className="grid grid-cols-4 gap-3 flex-1">
+      <div className="grid grid-cols-2 sm:grid-cols-4 gap-3 flex-1">
         <HeroMetric
           label="Output Throughput"
           value={fmtNum(throughput)}

--- a/web/src/components/cards/llmd/EPPRouting.tsx
+++ b/web/src/components/cards/llmd/EPPRouting.tsx
@@ -887,7 +887,7 @@ function EPPRoutingInternal() {
         </div>
       )}
       {/* Header */}
-      <div className="flex items-center justify-between mb-3">
+      <div className="flex flex-wrap items-center justify-between gap-y-2 mb-3">
         <div className="flex items-center gap-2">
           <div className="p-1.5 rounded-lg bg-yellow-500/20">
             <Zap size={14} className="text-yellow-400" />
@@ -1075,7 +1075,7 @@ function EPPRoutingInternal() {
 
                 return (
                   <>
-                    <div className="flex items-center justify-between mb-2">
+                    <div className="flex flex-wrap items-center justify-between gap-y-2 mb-2">
                       <span className="text-white font-medium text-sm">{node.label}</span>
                       <button
                         onClick={(e) => { e.stopPropagation(); setSelectedNode(null) }}
@@ -1183,7 +1183,7 @@ function EPPRoutingInternal() {
             if (!link) return null
 
             return (
-              <div className="flex items-center justify-between">
+              <div className="flex flex-wrap items-center justify-between gap-y-2">
                 <div className="flex items-center gap-2">
                   <span className="text-white capitalize font-medium">{link.source.replace('-', ' ')}</span>
                   <ArrowRight size={12} className="text-muted-foreground" />

--- a/web/src/components/cards/llmd/HardwareLeaderboard.tsx
+++ b/web/src/components/cards/llmd/HardwareLeaderboard.tsx
@@ -104,7 +104,7 @@ export function HardwareLeaderboard() {
   return (
     <div className="p-4 h-full flex flex-col">
       {/* Header */}
-      <div className="flex items-center justify-between mb-3">
+      <div className="flex flex-wrap items-center justify-between gap-y-2 mb-3">
         <div className="flex items-center gap-2">
           <Trophy size={16} className="text-yellow-400" />
           <span className="text-sm font-medium text-white">Hardware Leaderboard</span>

--- a/web/src/components/cards/llmd/KVCacheMonitor.tsx
+++ b/web/src/components/cards/llmd/KVCacheMonitor.tsx
@@ -548,7 +548,7 @@ export function KVCacheMonitor() {
         </div>
       )}
       {/* Header */}
-      <div className="flex items-center justify-between mb-4">
+      <div className="flex flex-wrap items-center justify-between gap-y-2 mb-4">
         <div className="flex items-center gap-2">
           <div className="p-1.5 rounded-lg bg-cyan-500/20">
             <Database size={16} className="text-cyan-400" />
@@ -631,7 +631,7 @@ export function KVCacheMonitor() {
       </div>
 
       {/* Summary stats with glow */}
-      <div className={`grid grid-cols-4 mb-4 ${isExpanded ? 'gap-4' : 'gap-2'}`}>
+      <div className={`grid grid-cols-2 sm:grid-cols-4 mb-4 ${isExpanded ? 'gap-4' : 'gap-2'}`}>
         <div className="bg-secondary/60 backdrop-blur-sm rounded-lg p-2 text-center border border-border/50">
           <div className="text-lg font-bold text-white flex items-center justify-center gap-1">
             {aggregateMetrics.avgUtil}%
@@ -682,7 +682,7 @@ export function KVCacheMonitor() {
 
                   return (
                     <>
-                      <div className="flex items-center justify-between mb-2">
+                      <div className="flex flex-wrap items-center justify-between gap-y-2 mb-2">
                         <span className="text-white font-medium text-sm">{stat.podName.replace('vllm-', '').slice(0, 14)}</span>
                         <button
                           onClick={() => { setSelectedPod(null); setPanelPosition(null) }}
@@ -774,14 +774,14 @@ export function KVCacheMonitor() {
               className={`h-full overflow-auto ${
                 isExpanded
                   ? (stats.length <= 2 ? 'flex items-center justify-evenly gap-16' :
-                     stats.length <= 4 ? 'grid grid-cols-4 gap-8 place-items-center' :
-                     stats.length <= 6 ? 'grid grid-cols-3 gap-6 place-items-center' :
-                     'grid grid-cols-4 gap-4 place-items-center')
+                     stats.length <= 4 ? 'grid grid-cols-2 sm:grid-cols-4 gap-8 place-items-center' :
+                     stats.length <= 6 ? 'grid grid-cols-2 sm:grid-cols-3 gap-6 place-items-center' :
+                     'grid grid-cols-2 sm:grid-cols-4 gap-4 place-items-center')
                   : (stats.length <= 2 ? 'flex items-center justify-evenly gap-12' :
-                     stats.length <= 3 ? 'grid grid-cols-3 gap-6 place-items-center' :
-                     stats.length <= 6 ? 'grid grid-cols-3 gap-3 place-items-center' :
-                     stats.length <= 9 ? 'grid grid-cols-3 gap-2 place-items-center' :
-                     'grid grid-cols-4 gap-2 place-items-center')
+                     stats.length <= 3 ? 'grid grid-cols-2 sm:grid-cols-3 gap-6 place-items-center' :
+                     stats.length <= 6 ? 'grid grid-cols-2 sm:grid-cols-3 gap-3 place-items-center' :
+                     stats.length <= 9 ? 'grid grid-cols-2 sm:grid-cols-3 gap-2 place-items-center' :
+                     'grid grid-cols-2 sm:grid-cols-4 gap-2 place-items-center')
               }`}
               initial={{ opacity: 0, y: 10 }}
               animate={{ opacity: 1, y: 0 }}
@@ -815,13 +815,13 @@ export function KVCacheMonitor() {
               className={`grid h-full place-items-center overflow-auto ${
                 isExpanded
                   ? (stats.length <= 2 ? 'grid-cols-2 gap-6' :
-                     stats.length <= 4 ? 'grid-cols-4 gap-4' :
-                     stats.length <= 6 ? 'grid-cols-3 gap-4' :
-                     'grid-cols-4 gap-3')
+                     stats.length <= 4 ? 'grid-cols-2 sm:grid-cols-4 gap-4' :
+                     stats.length <= 6 ? 'grid-cols-2 sm:grid-cols-3 gap-4' :
+                     'grid-cols-2 sm:grid-cols-4 gap-3')
                   : (stats.length <= 2 ? 'grid-cols-2 gap-2' :
-                     stats.length <= 3 ? 'grid-cols-3 gap-1' :
-                     stats.length <= 6 ? 'grid-cols-3 gap-1' :
-                     'grid-cols-4 gap-1')
+                     stats.length <= 3 ? 'grid-cols-2 sm:grid-cols-3 gap-1' :
+                     stats.length <= 6 ? 'grid-cols-2 sm:grid-cols-3 gap-1' :
+                     'grid-cols-2 sm:grid-cols-4 gap-1')
               }`}
               initial={{ opacity: 0, y: 10 }}
               animate={{ opacity: 1, y: 0 }}

--- a/web/src/components/cards/llmd/LLMdAIInsights.tsx
+++ b/web/src/components/cards/llmd/LLMdAIInsights.tsx
@@ -53,7 +53,7 @@ function InsightCard({ insight, isExpanded, onToggle }: InsightCardProps) {
           </div>
 
           <div className="flex-1 min-w-0">
-            <div className="flex items-center justify-between">
+            <div className="flex flex-wrap items-center justify-between gap-y-2">
               <h4 className={`font-medium text-sm ${colors.text}`}>{insight.title}</h4>
               <motion.div
                 animate={{ rotate: isExpanded ? 90 : 0 }}
@@ -86,7 +86,7 @@ function InsightCard({ insight, isExpanded, onToggle }: InsightCardProps) {
 
               {/* Metrics */}
               {insight.metrics && (
-                <div className="grid grid-cols-3 gap-2">
+                <div className="grid grid-cols-2 sm:grid-cols-3 gap-2">
                   {Object.entries(insight.metrics).map(([key, value]) => (
                     <div key={key} className="bg-secondary rounded p-2 text-center">
                       <div className="text-xs text-muted-foreground truncate">{key}</div>
@@ -391,7 +391,7 @@ export function LLMdAIInsights() {
   return (
     <div className="p-4 h-full flex-1 flex flex-col">
       {/* Header */}
-      <div className="flex items-center justify-between mb-4">
+      <div className="flex flex-wrap items-center justify-between gap-y-2 mb-4">
         <div className="flex items-center gap-2">
           <Brain size={18} className="text-purple-400" />
           <span className="font-medium text-white">{t('llmdAIInsights.aiInsights')}</span>

--- a/web/src/components/cards/llmd/LLMdConfigurator.tsx
+++ b/web/src/components/cards/llmd/LLMdConfigurator.tsx
@@ -91,7 +91,7 @@ interface ParameterSliderProps {
 function ParameterSlider({ param, onChange }: ParameterSliderProps) {
   if (typeof param.value === 'boolean') {
     return (
-      <div className="flex items-center justify-between py-2 border-b border-border/50">
+      <div className="flex flex-wrap items-center justify-between gap-y-2 py-2 border-b border-border/50">
         <div>
           <div className="text-sm text-white">{param.name}</div>
           <div className="text-xs text-muted-foreground">{param.description}</div>
@@ -114,7 +114,7 @@ function ParameterSlider({ param, onChange }: ParameterSliderProps) {
   if (typeof param.value === 'string') {
     return (
       <div className="py-2 border-b border-border/50">
-        <div className="flex items-center justify-between mb-1">
+        <div className="flex flex-wrap items-center justify-between gap-y-2 mb-1">
           <div className="text-sm text-white">{param.name}</div>
           <div className="text-sm font-mono text-purple-400">{param.value}</div>
         </div>
@@ -126,7 +126,7 @@ function ParameterSlider({ param, onChange }: ParameterSliderProps) {
   // Numeric slider
   return (
     <div className="py-2 border-b border-border/50">
-      <div className="flex items-center justify-between mb-1">
+      <div className="flex flex-wrap items-center justify-between gap-y-2 mb-1">
         <div className="text-sm text-white">{param.name}</div>
         <div className="text-sm font-mono text-purple-400">
           {param.value}{param.unit || ''}
@@ -199,7 +199,7 @@ ${Object.entries(params).map(([k, v]) => `    ${k}: ${v}`).join('\n')}`
   return (
     <div className="p-4 h-full flex flex-col">
       {/* Header */}
-      <div className="flex items-center justify-between mb-4">
+      <div className="flex flex-wrap items-center justify-between gap-y-2 mb-4">
         <div className="flex items-center gap-2">
           <Settings size={18} className="text-purple-400" />
           <span className="font-medium text-white">Configurator</span>
@@ -258,7 +258,7 @@ ${Object.entries(params).map(([k, v]) => `    ${k}: ${v}`).join('\n')}`
             </div>
 
             {/* Expected impact */}
-            <div className="grid grid-cols-3 gap-2 mb-4">
+            <div className="grid grid-cols-2 sm:grid-cols-3 gap-2 mb-4">
               <div className="bg-green-500/10 border border-green-500/20 rounded-lg p-2 text-center">
                 <div className="text-xs text-muted-foreground"><Acronym term="TTFT" /> Improvement</div>
                 <div className="text-lg font-bold text-green-400">
@@ -288,7 +288,7 @@ ${Object.entries(params).map(([k, v]) => `    ${k}: ${v}`).join('\n')}`
 
             {/* Config export */}
             <div className="bg-background rounded-lg p-3 border border-border">
-              <div className="flex items-center justify-between mb-2">
+              <div className="flex flex-wrap items-center justify-between gap-y-2 mb-2">
                 <span className="text-xs text-muted-foreground">Generated Config</span>
                 <button
                   onClick={copyConfig}

--- a/web/src/components/cards/llmd/LLMdFlow.tsx
+++ b/web/src/components/cards/llmd/LLMdFlow.tsx
@@ -961,7 +961,7 @@ export function LLMdFlow() {
         </div>
       )}
       {/* Header */}
-      <div className="absolute top-3 left-3 right-3 flex items-center justify-between z-10">
+      <div className="absolute top-3 left-3 right-3 flex flex-wrap items-center justify-between gap-y-2 z-10">
         <div className="flex items-center gap-4">
           {/* Stack info */}
           {selectedStack && (
@@ -1109,7 +1109,7 @@ export function LLMdFlow() {
             exit={{ opacity: 0, x: -20 }}
             className="absolute top-10 left-3 w-56 bg-background/95 backdrop-blur-sm rounded-xl p-4 border border-border shadow-xl"
           >
-            <div className="flex items-center justify-between mb-3">
+            <div className="flex flex-wrap items-center justify-between gap-y-2 mb-3">
               <h4 className="text-white font-semibold text-sm">
                 {selectedMetrics.name}
               </h4>

--- a/web/src/components/cards/llmd/LatencyBreakdown.tsx
+++ b/web/src/components/cards/llmd/LatencyBreakdown.tsx
@@ -192,7 +192,7 @@ function LatencyBreakdownInternal() {
   return (
     <div className="p-4 h-full flex flex-col">
       {/* Header */}
-      <div className="flex items-center justify-between mb-3">
+      <div className="flex flex-wrap items-center justify-between gap-y-2 mb-3">
         <div className="flex items-center gap-2">
           <Clock size={14} className="text-yellow-400" />
           <span className="text-sm font-medium text-white">Latency Under Load</span>

--- a/web/src/components/cards/llmd/NightlyE2EStatus.tsx
+++ b/web/src/components/cards/llmd/NightlyE2EStatus.tsx
@@ -754,45 +754,45 @@ function GuideDetailPanel({ guide, hoveredRun, onRunHover }: {
             </span>
           </div>
         )}
-        <div className="flex items-center justify-between text-[11px]">
+        <div className="flex flex-wrap items-center justify-between gap-y-2 text-[11px]">
           <span className="text-muted-foreground">{t('cards:llmd.model')}</span>
           <span className={`font-mono text-2xs truncate max-w-[140px] ${hoveredRun ? 'text-foreground' : 'text-foreground'}`} title={displayModel}>{displayModel}</span>
         </div>
-        <div className="flex items-center justify-between text-[11px]">
+        <div className="flex flex-wrap items-center justify-between gap-y-2 text-[11px]">
           <span className="text-muted-foreground">{t('cards:llmd.gpu')}</span>
           <span className={`font-mono text-2xs ${hoveredRun ? 'text-foreground' : 'text-foreground'}`}>
             {displayGpuCount > 0 ? `${displayGpuCount}× ${displayGpuType}` : displayGpuType}
           </span>
         </div>
         {hoveredRun && runDur !== null ? (
-          <div className="flex items-center justify-between text-[11px]">
+          <div className="flex flex-wrap items-center justify-between gap-y-2 text-[11px]">
             <span className="text-muted-foreground">{t('cards:llmd.duration')}</span>
             <span className="text-foreground font-mono">{formatDuration(runDur)}</span>
           </div>
         ) : avgDur !== null ? (
-          <div className="flex items-center justify-between text-[11px]">
+          <div className="flex flex-wrap items-center justify-between gap-y-2 text-[11px]">
             <span className="text-muted-foreground">{t('cards:llmd.avgDuration')}</span>
             <span className="text-foreground font-mono">{formatDuration(avgDur)}</span>
           </div>
         ) : null}
         <div className="h-px bg-border/30 my-0.5" />
         {lastSuccess && (
-          <div className="flex items-center justify-between text-[11px]">
+          <div className="flex flex-wrap items-center justify-between gap-y-2 text-[11px]">
             <span className="text-muted-foreground">{t('cards:llmd.lastPass')}</span>
             <span className="text-green-400 font-mono">{formatTimeAgo(lastSuccess.updatedAt)}</span>
           </div>
         )}
         {lastFailure && (
-          <div className="flex items-center justify-between text-[11px]">
+          <div className="flex flex-wrap items-center justify-between gap-y-2 text-[11px]">
             <span className="text-muted-foreground">{t('cards:llmd.lastFail')}</span>
             <span className="text-red-400 font-mono">{formatTimeAgo(lastFailure.updatedAt)}</span>
           </div>
         )}
-        <div className="flex items-center justify-between text-[11px]">
+        <div className="flex flex-wrap items-center justify-between gap-y-2 text-[11px]">
           <span className="text-muted-foreground">{t('cards:llmd.totalRuns')}</span>
           <span className="text-foreground font-mono">{guide.runs.length}</span>
         </div>
-        <div className="flex items-center justify-between text-[11px]">
+        <div className="flex flex-wrap items-center justify-between gap-y-2 text-[11px]">
           <span className="text-muted-foreground">{t('cards:llmd.trend')}</span>
           <TrendIndicator trend={guide.trend} passRate={guide.passRate} />
         </div>
@@ -895,7 +895,7 @@ export function NightlyE2EStatus() {
   if (showSkeleton) {
     return (
       <div className="p-4 h-full flex flex-col gap-3 overflow-hidden">
-        <div className="grid grid-cols-4 gap-3">
+        <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
           {Array.from({ length: 4 }).map((_, i) => (
             <Skeleton key={i} variant="rounded" height={64} />
           ))}
@@ -917,7 +917,7 @@ export function NightlyE2EStatus() {
   return (
     <div className="p-4 h-full flex flex-col gap-3 overflow-hidden">
       {/* Stats row */}
-      <div className="grid grid-cols-4 gap-3">
+      <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
         <motion.div
           initial={{ opacity: 0, y: 8 }}
           animate={{ opacity: 1, y: 0 }}

--- a/web/src/components/cards/llmd/PDDisaggregation.tsx
+++ b/web/src/components/cards/llmd/PDDisaggregation.tsx
@@ -113,7 +113,7 @@ function ServerCard({ server, isHighlighted }: ServerCardProps) {
       animate={{ opacity: 1, y: 0 }}
       whileHover={{ scale: 1.02 }}
     >
-      <div className="flex items-center justify-between mb-2">
+      <div className="flex flex-wrap items-center justify-between gap-y-2 mb-2">
         <span className="font-medium text-white text-sm">{server.name}</span>
         <div
           className="w-2 h-2 rounded-full"
@@ -332,7 +332,7 @@ export function PDDisaggregation() {
   return (
     <div className={`p-4 h-full flex-1 flex flex-col ${isExpanded ? 'min-h-[500px]' : ''}`}>
       {/* Header */}
-      <div className="flex items-center justify-between mb-4">
+      <div className="flex flex-wrap items-center justify-between gap-y-2 mb-4">
         <div className="flex items-center gap-2">
           <Split size={18} className="text-cyan-400" />
           <span className="font-medium text-white">{t('llmd.pdDisaggregation')}</span>

--- a/web/src/components/cards/llmd/ParetoFrontier.tsx
+++ b/web/src/components/cards/llmd/ParetoFrontier.tsx
@@ -650,7 +650,7 @@ function FilterDropdown({
 
 function Toggle({ label, active, onChange }: { label: string; active: boolean; onChange: (v: boolean) => void }) {
   return (
-    <button onClick={() => onChange(!active)} className="flex items-center justify-between w-full group">
+    <button onClick={() => onChange(!active)} className="flex flex-wrap items-center justify-between gap-y-2 w-full group">
       <span className="text-2xs text-muted-foreground group-hover:text-foreground transition-colors">{label}</span>
       <span
         className={`relative inline-flex rounded-full transition-colors ${

--- a/web/src/components/cards/llmd/PerformanceTimeline.tsx
+++ b/web/src/components/cards/llmd/PerformanceTimeline.tsx
@@ -129,7 +129,7 @@ export function PerformanceTimeline() {
   return (
     <div className="p-4 h-full flex flex-col">
       {/* Header */}
-      <div className="flex items-center justify-between mb-3">
+      <div className="flex flex-wrap items-center justify-between gap-y-2 mb-3">
         <div className="flex items-center gap-2">
           <LayoutGrid size={14} className="text-purple-400" />
           <span className="text-sm font-medium text-white">Sequence Length Impact</span>

--- a/web/src/components/cards/llmd/ResourceUtilization.tsx
+++ b/web/src/components/cards/llmd/ResourceUtilization.tsx
@@ -168,7 +168,7 @@ export function ResourceUtilization() {
   return (
     <div className="p-4 h-full flex flex-col">
       {/* Header */}
-      <div className="flex items-center justify-between mb-3">
+      <div className="flex flex-wrap items-center justify-between gap-y-2 mb-3">
         <div className="flex items-center gap-2">
           <BarChart3 size={14} className="text-green-400" />
           <span className="text-sm font-medium text-white">Experiment Comparison</span>

--- a/web/src/components/cards/llmd/StackSelector.tsx
+++ b/web/src/components/cards/llmd/StackSelector.tsx
@@ -108,7 +108,7 @@ const StackOption = memo(function StackOption({ stack, isSelected, onSelect }: S
       }`}
     >
       {/* Row 1: Name and replica counts */}
-      <div className="flex items-center justify-between mb-1">
+      <div className="flex flex-wrap items-center justify-between gap-y-2 mb-1">
         <div className="flex items-center gap-2">
           {/* Status indicator */}
           <div className={`w-2 h-2 rounded-full shrink-0 ${STATUS_COLORS[stack.status]}`} />
@@ -422,7 +422,7 @@ export function StackSelector() {
                 </p>
               </div>
 
-              <div className="flex items-center justify-between px-3 py-2">
+              <div className="flex flex-wrap items-center justify-between gap-y-2 px-3 py-2">
                 <span className="text-xs font-medium text-muted-foreground">
                   {filteredAndSortedStacks.length} stack{filteredAndSortedStacks.length !== 1 ? 's' : ''}{searchQuery ? ` of ${stacks.length}` : ''}
                 </span>
@@ -441,7 +441,7 @@ export function StackSelector() {
               {/* Error message */}
               {fetchError && (
                 <div className="px-3 py-2 bg-red-500/10 border-b border-red-500/20 text-red-400 text-xs">
-                  <div className="flex items-center justify-between gap-2">
+                  <div className="flex flex-wrap items-center justify-between gap-y-2 gap-2">
                     <span className="flex-1">{fetchError}</span>
                     <button
                       onClick={handleRefetch}
@@ -525,7 +525,7 @@ export function StackSelector() {
                 <div className="px-3 py-4 space-y-3">
                   {Array.from({ length: 3 }).map((_, i) => (
                     <div key={i} className="px-3 py-2.5 border-b border-border/50 last:border-0">
-                      <div className="flex items-center justify-between mb-1">
+                      <div className="flex flex-wrap items-center justify-between gap-y-2 mb-1">
                         <div className="flex items-center gap-2">
                           <Skeleton variant="circular" width={8} height={8} />
                           <Skeleton variant="text" width={120} height={14} />
@@ -547,7 +547,7 @@ export function StackSelector() {
             </div>
 
             {/* Footer stats */}
-            <div className="px-3 py-2 border-t border-border bg-background/50 flex items-center justify-between text-2xs">
+            <div className="px-3 py-2 border-t border-border bg-background/50 flex flex-wrap items-center justify-between gap-y-2 text-2xs">
               <div className="flex items-center gap-3">
                 <span className="flex items-center gap-1">
                   <div className="w-1.5 h-1.5 rounded-full bg-green-500" />

--- a/web/src/components/cards/llmd/ThroughputComparison.tsx
+++ b/web/src/components/cards/llmd/ThroughputComparison.tsx
@@ -157,7 +157,7 @@ export function ThroughputComparison() {
   return (
     <div className="p-4 h-full flex flex-col">
       {/* Header */}
-      <div className="flex items-center justify-between mb-3">
+      <div className="flex flex-wrap items-center justify-between gap-y-2 mb-3">
         <div className="flex items-center gap-2">
           <Zap size={14} className="text-blue-400" />
           <span className="text-sm font-medium text-white">Throughput Scaling</span>

--- a/web/src/components/cards/multi-tenancy/k3s-status/K3sDetailModal.tsx
+++ b/web/src/components/cards/multi-tenancy/k3s-status/K3sDetailModal.tsx
@@ -47,7 +47,7 @@ function ServerPodRow({ pod }: { pod: K3sServerPodInfo }) {
   const statusColor = POD_STATUS_COLORS[pod.status] || POD_STATUS_COLORS.failed
 
   return (
-    <div className="flex items-center justify-between text-sm gap-3 px-3 py-2.5 rounded-lg bg-secondary/30 hover:bg-secondary/50 transition-colors">
+    <div className="flex flex-wrap items-center justify-between gap-y-2 text-sm gap-3 px-3 py-2.5 rounded-lg bg-secondary/30 hover:bg-secondary/50 transition-colors">
       <div className="flex items-center gap-2 min-w-0 flex-1">
         <Server className="w-4 h-4 text-purple-400 shrink-0" />
         <div className="min-w-0 flex-1">

--- a/web/src/components/cards/multi-tenancy/k3s-status/K3sStatus.tsx
+++ b/web/src/components/cards/multi-tenancy/k3s-status/K3sStatus.tsx
@@ -145,7 +145,7 @@ export function K3sStatus() {
   return (
     <div className="h-full flex flex-col min-h-card content-loaded gap-4">
       {/* Health badge + last check */}
-      <div className="flex items-center justify-between">
+      <div className="flex flex-wrap items-center justify-between gap-y-2">
         <div
           role="button"
           tabIndex={0}
@@ -200,7 +200,7 @@ export function K3sStatus() {
           <p className="text-xs font-medium text-muted-foreground">{t('k3sStatus.serverPodList')}</p>
           <div className="space-y-1.5 max-h-40 overflow-y-auto scrollbar-thin">
             {serverPods.map((pod) => (
-              <div key={pod.name} className="flex items-center justify-between text-xs gap-2 px-2 py-1.5 rounded bg-secondary/30 cursor-pointer hover:bg-secondary/50 transition-colors" role="button" tabIndex={0} aria-label={t('k3sStatus.viewServerPod', { name: pod.name })} onClick={openDetailModal} onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); openDetailModal() } }}>
+              <div key={pod.name} className="flex flex-wrap items-center justify-between gap-y-2 text-xs gap-2 px-2 py-1.5 rounded bg-secondary/30 cursor-pointer hover:bg-secondary/50 transition-colors" role="button" tabIndex={0} aria-label={t('k3sStatus.viewServerPod', { name: pod.name })} onClick={openDetailModal} onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); openDetailModal() } }}>
                 <span className="text-foreground truncate flex-1" title={pod.name}>
                   {pod.name}
                 </span>

--- a/web/src/components/cards/multi-tenancy/kubeflex-status/KubeFlexDetailModal.tsx
+++ b/web/src/components/cards/multi-tenancy/kubeflex-status/KubeFlexDetailModal.tsx
@@ -39,7 +39,7 @@ interface KubeFlexDetailModalProps {
 
 function ControlPlaneRow({ cp }: { cp: ControlPlaneInfo }) {
   return (
-    <div className="flex items-center justify-between text-sm gap-3 px-3 py-2.5 rounded-lg bg-secondary/30 hover:bg-secondary/50 transition-colors">
+    <div className="flex flex-wrap items-center justify-between gap-y-2 text-sm gap-3 px-3 py-2.5 rounded-lg bg-secondary/30 hover:bg-secondary/50 transition-colors">
       <div className="flex items-center gap-2 min-w-0 flex-1">
         <Layers className="w-4 h-4 text-purple-400 shrink-0" />
         <span className="text-foreground truncate font-medium" title={cp.name}>

--- a/web/src/components/cards/multi-tenancy/kubeflex-status/KubeFlexStatus.tsx
+++ b/web/src/components/cards/multi-tenancy/kubeflex-status/KubeFlexStatus.tsx
@@ -150,7 +150,7 @@ export function KubeFlexStatus() {
   return (
     <div className="h-full flex flex-col min-h-card content-loaded gap-4">
       {/* Health badge + last check */}
-      <div className="flex items-center justify-between">
+      <div className="flex flex-wrap items-center justify-between gap-y-2">
         <div
           role="button"
           tabIndex={0}
@@ -218,7 +218,7 @@ export function KubeFlexStatus() {
                 onClick={openDetailModal}
                 onKeyDown={handleDetailKeyDown}
                 aria-label={`${cp.name}: ${cp.healthy ? t('kubeFlexStatus.cpHealthy') : t('kubeFlexStatus.cpUnhealthy')}`}
-                className="flex items-center justify-between text-xs gap-2 px-2 py-1.5 rounded bg-secondary/30 cursor-pointer hover:bg-secondary/50 transition-colors"
+                className="flex flex-wrap items-center justify-between gap-y-2 text-xs gap-2 px-2 py-1.5 rounded bg-secondary/30 cursor-pointer hover:bg-secondary/50 transition-colors"
               >
                 <span className="text-foreground truncate flex-1" title={cp.name}>
                   {cp.name}

--- a/web/src/components/cards/multi-tenancy/kubevirt-status/KubevirtDetailModal.tsx
+++ b/web/src/components/cards/multi-tenancy/kubevirt-status/KubevirtDetailModal.tsx
@@ -86,7 +86,7 @@ function VmRow({ vm }: { vm: VmInfo }) {
   const age = formatVmAge(vm.creationTime)
 
   return (
-    <div className="flex items-center justify-between text-sm gap-3 px-3 py-2.5 rounded-lg bg-secondary/30 hover:bg-secondary/50 transition-colors">
+    <div className="flex flex-wrap items-center justify-between gap-y-2 text-sm gap-3 px-3 py-2.5 rounded-lg bg-secondary/30 hover:bg-secondary/50 transition-colors">
       <div className="flex items-center gap-2 min-w-0 flex-1">
         <Monitor className="w-4 h-4 text-purple-400 shrink-0" />
         <div className="min-w-0 flex-1">
@@ -299,7 +299,7 @@ export function KubevirtDetailModal({ isOpen, onClose, data, isDemoData }: Kubev
               <p className="text-xs font-medium text-muted-foreground mb-2">
                 {t('kubevirtStatus.tenantDistribution', 'Tenant Distribution')}
               </p>
-              <div className="grid grid-cols-3 gap-2">
+              <div className="grid grid-cols-2 sm:grid-cols-3 gap-2">
                 {(tenantDistribution || []).map((td) => (
                   <div key={td.namespace} className="p-2 rounded bg-secondary/30 text-center">
                     <p className="text-sm font-bold text-foreground">{td.vmCount}</p>
@@ -320,7 +320,7 @@ export function KubevirtDetailModal({ isOpen, onClose, data, isDemoData }: Kubev
               </p>
               <div className="space-y-1.5">
                 {clusters.map((ci) => (
-                  <div key={ci.cluster} className="flex items-center justify-between text-sm gap-3 px-3 py-2 rounded-lg bg-secondary/30">
+                  <div key={ci.cluster} className="flex flex-wrap items-center justify-between gap-y-2 text-sm gap-3 px-3 py-2 rounded-lg bg-secondary/30">
                     <div className="flex items-center gap-2 min-w-0 flex-1">
                       <Server className="w-4 h-4 text-cyan-400 shrink-0" />
                       <span className="text-foreground font-medium truncate" title={ci.cluster}>{ci.cluster}</span>

--- a/web/src/components/cards/multi-tenancy/kubevirt-status/KubevirtStatus.tsx
+++ b/web/src/components/cards/multi-tenancy/kubevirt-status/KubevirtStatus.tsx
@@ -172,7 +172,7 @@ export function KubevirtStatus() {
   return (
     <div className="h-full flex flex-col min-h-card content-loaded gap-4">
       {/* Health badge + last check */}
-      <div className="flex items-center justify-between">
+      <div className="flex flex-wrap items-center justify-between gap-y-2">
         <div
           role="button"
           tabIndex={0}
@@ -267,7 +267,7 @@ export function KubevirtStatus() {
           <p className="text-xs font-medium text-muted-foreground">{t('kubevirtStatus.clusterBreakdown')}</p>
           <div className="space-y-1.5">
             {clusters.map((ci) => (
-              <div key={ci.cluster} className="flex items-center justify-between text-xs gap-2 px-2 py-1.5 rounded bg-secondary/30 cursor-pointer hover:bg-secondary/50 transition-colors" role="button" tabIndex={0} aria-label={t('kubevirtStatus.viewCluster', { cluster: ci.cluster })} onClick={openDetailModal} onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); openDetailModal() } }}>
+              <div key={ci.cluster} className="flex flex-wrap items-center justify-between gap-y-2 text-xs gap-2 px-2 py-1.5 rounded bg-secondary/30 cursor-pointer hover:bg-secondary/50 transition-colors" role="button" tabIndex={0} aria-label={t('kubevirtStatus.viewCluster', { cluster: ci.cluster })} onClick={openDetailModal} onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); openDetailModal() } }}>
                 <div className="flex items-center gap-2 min-w-0 flex-1">
                   <Server className="w-3 h-3 text-cyan-400 shrink-0" />
                   <span className="text-foreground truncate" title={ci.cluster}>{ci.cluster}</span>
@@ -288,7 +288,7 @@ export function KubevirtStatus() {
           <p className="text-xs font-medium text-muted-foreground">{t('kubevirtStatus.vmList')}</p>
           <div className="space-y-1.5 max-h-40 overflow-y-auto scrollbar-thin">
             {vms.map((vm) => (
-              <div key={`${vm.cluster}/${vm.namespace}/${vm.name}`} className="flex items-center justify-between text-xs gap-2 px-2 py-1.5 rounded bg-secondary/30 cursor-pointer hover:bg-secondary/50 transition-colors" role="button" tabIndex={0} aria-label={t('kubevirtStatus.viewVm', { name: vm.name, namespace: vm.namespace })} onClick={openDetailModal} onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); openDetailModal() } }}>
+              <div key={`${vm.cluster}/${vm.namespace}/${vm.name}`} className="flex flex-wrap items-center justify-between gap-y-2 text-xs gap-2 px-2 py-1.5 rounded bg-secondary/30 cursor-pointer hover:bg-secondary/50 transition-colors" role="button" tabIndex={0} aria-label={t('kubevirtStatus.viewVm', { name: vm.name, namespace: vm.namespace })} onClick={openDetailModal} onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); openDetailModal() } }}>
                 <div className="flex flex-col min-w-0 flex-1">
                   <span className="text-foreground truncate" title={vm.name}>
                     {vm.name}

--- a/web/src/components/cards/multi-tenancy/multi-tenancy-overview/MultiTenancyDetailModal.tsx
+++ b/web/src/components/cards/multi-tenancy/multi-tenancy-overview/MultiTenancyDetailModal.tsx
@@ -100,7 +100,7 @@ function ComponentDetailCard({ component }: { component: ComponentStatus }) {
     <div className={`p-4 rounded-lg border ${healthBg} flex items-start gap-3`}>
       <IconComponent className={`w-5 h-5 ${healthColor} shrink-0 mt-0.5`} />
       <div className="flex-1 min-w-0">
-        <div className="flex items-center justify-between gap-2">
+        <div className="flex flex-wrap items-center justify-between gap-y-2 gap-2">
           <span className="text-sm font-medium text-foreground">{component.name}</span>
           <div className={`w-2.5 h-2.5 rounded-full ${component.detected ? 'bg-green-400' : 'bg-zinc-500'}`} />
         </div>
@@ -122,7 +122,7 @@ function IsolationLevelCard({ level }: { level: IsolationLevel }) {
   const statusBg = ISOLATION_STATUS_BG[level.status]
 
   return (
-    <div className={`p-4 rounded-lg border ${statusBg} flex items-center justify-between`}>
+    <div className={`p-4 rounded-lg border ${statusBg} flex flex-wrap items-center justify-between gap-y-2`}>
       <div className="flex items-center gap-3">
         <IsolationStatusIcon status={level.status} />
         <div>
@@ -171,7 +171,7 @@ export function MultiTenancyDetailModal({ isOpen, onClose, data, isDemoData }: M
       <BaseModal.Content>
         <div className="space-y-6">
           {/* Score and tenant summary */}
-          <div className="grid grid-cols-3 gap-3">
+          <div className="grid grid-cols-2 sm:grid-cols-3 gap-3">
             <div className="p-4 rounded-lg bg-cyan-500/10 border border-cyan-500/20 text-center">
               <div className="flex items-center justify-center gap-1.5 mb-1">
                 <Shield className="w-5 h-5 text-cyan-400" />
@@ -201,7 +201,7 @@ export function MultiTenancyDetailModal({ isOpen, onClose, data, isDemoData }: M
 
           {/* Component health section */}
           <div>
-            <div className="flex items-center justify-between mb-3">
+            <div className="flex flex-wrap items-center justify-between gap-y-2 mb-3">
               <p className="text-sm font-medium text-muted-foreground">
                 {t('multiTenancy.componentHealth', 'Component Health')}
               </p>
@@ -218,7 +218,7 @@ export function MultiTenancyDetailModal({ isOpen, onClose, data, isDemoData }: M
 
           {/* Isolation levels section */}
           <div>
-            <div className="flex items-center justify-between mb-3">
+            <div className="flex flex-wrap items-center justify-between gap-y-2 mb-3">
               <p className="text-sm font-medium text-muted-foreground">
                 {t('multiTenancy.isolationLevels', 'Isolation Levels')}
               </p>

--- a/web/src/components/cards/multi-tenancy/multi-tenancy-overview/MultiTenancyOverview.tsx
+++ b/web/src/components/cards/multi-tenancy/multi-tenancy-overview/MultiTenancyOverview.tsx
@@ -81,7 +81,7 @@ function ComponentBadge({ component, onClick }: { component: ComponentStatus; on
 /** Single isolation level row */
 function IsolationRow({ level, onClick }: { level: IsolationLevel; onClick?: () => void }) {
   return (
-    <div className="flex items-center justify-between py-1.5 cursor-pointer hover:bg-secondary/50 transition-colors rounded px-1 -mx-1" role="button" tabIndex={0} aria-label={`${level.type} isolation: ${level.status}`} onClick={onClick} onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); onClick?.() } }}>
+    <div className="flex flex-wrap items-center justify-between gap-y-2 py-1.5 cursor-pointer hover:bg-secondary/50 transition-colors rounded px-1 -mx-1" role="button" tabIndex={0} aria-label={`${level.type} isolation: ${level.status}`} onClick={onClick} onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); onClick?.() } }}>
       <div className="flex items-center gap-2">
         <IsolationStatusIcon status={level.status} />
         <span className="text-xs font-medium text-foreground">{level.type}</span>
@@ -151,7 +151,7 @@ export function MultiTenancyOverview() {
   return (
     <div className="h-full flex flex-col gap-3">
       {/* Overall score header */}
-      <div className="flex items-center justify-between px-2 py-1.5 bg-secondary/30 rounded-lg cursor-pointer hover:bg-secondary/50 transition-colors" role="button" tabIndex={0} aria-labelledby="multi-tenancy-isolation-score-header" onClick={openDetailModal} onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); openDetailModal() } }}>
+      <div className="flex flex-wrap items-center justify-between gap-y-2 px-2 py-1.5 bg-secondary/30 rounded-lg cursor-pointer hover:bg-secondary/50 transition-colors" role="button" tabIndex={0} aria-labelledby="multi-tenancy-isolation-score-header" onClick={openDetailModal} onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); openDetailModal() } }}>
         <div className="flex items-center gap-2">
           <Shield className="w-4 h-4 text-cyan-400" />
           <span className="text-xs font-medium text-foreground" id="multi-tenancy-isolation-score-header">

--- a/web/src/components/cards/multi-tenancy/ovn-status/OvnDetailModal.tsx
+++ b/web/src/components/cards/multi-tenancy/ovn-status/OvnDetailModal.tsx
@@ -60,7 +60,7 @@ function UdnRow({ udn }: { udn: UdnInfo }) {
   const roleColor = ROLE_COLORS[udn.role] || ROLE_COLORS.unknown
 
   return (
-    <div className="flex items-center justify-between text-sm gap-3 px-3 py-2.5 rounded-lg bg-secondary/30 hover:bg-secondary/50 transition-colors">
+    <div className="flex flex-wrap items-center justify-between gap-y-2 text-sm gap-3 px-3 py-2.5 rounded-lg bg-secondary/30 hover:bg-secondary/50 transition-colors">
       <div className="flex items-center gap-2 min-w-0 flex-1">
         <Network className="w-4 h-4 text-purple-400 shrink-0" />
         <span className="text-foreground truncate font-medium" title={udn.name}>
@@ -172,7 +172,7 @@ export function OvnDetailModal({ isOpen, onClose, data, isDemoData }: OvnDetailM
           {activeTab === TAB_UDNS && (
             <div className="space-y-3">
               {/* Network type breakdown */}
-              <div className="grid grid-cols-4 gap-2">
+              <div className="grid grid-cols-2 sm:grid-cols-4 gap-2">
                 <div className="p-2 rounded bg-secondary/30 text-center">
                   <p className="text-sm font-bold text-foreground">{udns.length}</p>
                   <p className="text-[10px] text-muted-foreground">{t('ovnStatus.totalUdns', 'Total')}</p>

--- a/web/src/components/cards/multi-tenancy/ovn-status/OvnStatus.tsx
+++ b/web/src/components/cards/multi-tenancy/ovn-status/OvnStatus.tsx
@@ -146,7 +146,7 @@ export function OvnStatus() {
   return (
     <div className="h-full flex flex-col min-h-card content-loaded gap-4">
       {/* Health badge + last check */}
-      <div className="flex items-center justify-between">
+      <div className="flex flex-wrap items-center justify-between gap-y-2">
         <div
           role="button"
           tabIndex={0}
@@ -223,7 +223,7 @@ export function OvnStatus() {
           <p className="text-xs font-medium text-muted-foreground">{t('ovnStatus.udnList')}</p>
           <div className="space-y-1.5 max-h-32 overflow-y-auto scrollbar-thin">
             {(data.udns || []).map((udn) => (
-              <div key={udn.name} className="flex items-center justify-between text-xs gap-2 cursor-pointer hover:bg-secondary/50 transition-colors rounded px-1 -mx-1" role="button" tabIndex={0} aria-label={t('ovnStatus.viewUdn', { name: udn.name })} onClick={openDetailModal} onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); openDetailModal() } }}>
+              <div key={udn.name} className="flex flex-wrap items-center justify-between gap-y-2 text-xs gap-2 cursor-pointer hover:bg-secondary/50 transition-colors rounded px-1 -mx-1" role="button" tabIndex={0} aria-label={t('ovnStatus.viewUdn', { name: udn.name })} onClick={openDetailModal} onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); openDetailModal() } }}>
                 <span className="text-muted-foreground truncate flex-1" title={udn.name}>
                   {udn.name}
                 </span>

--- a/web/src/components/cards/multi-tenancy/tenant-isolation-setup/TenantIsolationSetup.tsx
+++ b/web/src/components/cards/multi-tenancy/tenant-isolation-setup/TenantIsolationSetup.tsx
@@ -87,7 +87,7 @@ function ReadinessBadge({ component, onInstall }: {
 /** Isolation level row */
 function IsolationLevelRow({ level }: { level: IsolationLevel }) {
   return (
-    <div className="flex items-center justify-between py-1">
+    <div className="flex flex-wrap items-center justify-between gap-y-2 py-1">
       <div className="flex items-center gap-1.5">
         <IsolationStatusIcon status={level.status} />
         <span className="text-xs text-foreground">{level.type}</span>

--- a/web/src/components/cards/opa/ClusterOPAModal.tsx
+++ b/web/src/components/cards/opa/ClusterOPAModal.tsx
@@ -235,7 +235,7 @@ Please proceed with applying this policy.`,
 
         <BaseModal.Content className="max-h-[60vh]">
           {/* Tabs */}
-          <div className="flex items-center justify-between mb-4 pb-3 border-b border-border">
+          <div className="flex flex-wrap items-center justify-between gap-y-2 mb-4 pb-3 border-b border-border">
             <div className="flex gap-1">
               <button
                 onClick={() => setActiveTab('policies')}
@@ -322,7 +322,7 @@ Please proceed with applying this policy.`,
                     onClick={() => handleEditYaml(policy)}
                     className="p-3 rounded-lg bg-secondary/30 hover:bg-secondary/50 transition-colors cursor-pointer group"
                   >
-                    <div className="flex items-center justify-between mb-2">
+                    <div className="flex flex-wrap items-center justify-between gap-y-2 mb-2">
                       <div className="flex items-center gap-2">
                         <span className="text-sm font-medium text-foreground group-hover:text-purple-400 transition-colors">{policy.name}</span>
                         <span className="text-xs text-muted-foreground">({policy.kind})</span>
@@ -337,7 +337,7 @@ Please proceed with applying this policy.`,
                         </button>
                       </div>
                     </div>
-                    <div className="flex items-center justify-between">
+                    <div className="flex flex-wrap items-center justify-between gap-y-2">
                       <div className="flex items-center gap-3 text-xs">
                         {policy.violations > 0 ? (
                           <span className="flex items-center gap-1 text-yellow-400">
@@ -385,7 +385,7 @@ Please proceed with applying this policy.`,
           {activeTab === 'violations' && (
             <>
               {/* Summary */}
-              <div className="grid grid-cols-3 gap-3 mb-4 pb-4 border-b border-border">
+              <div className="grid grid-cols-2 sm:grid-cols-3 gap-3 mb-4 pb-4 border-b border-border">
                 <div className="p-3 rounded-lg bg-red-500/10 border border-red-500/20 text-center">
                   <p className="text-2xl font-bold text-red-400">{severityCounts.critical}</p>
                   <p className="text-xs text-muted-foreground">{t('common:common.critical')}</p>
@@ -479,7 +479,7 @@ Please proceed with applying this policy.`,
                 onClick={() => handleUseTemplate(template)}
                 className="w-full p-3 rounded-lg bg-secondary/30 hover:bg-secondary/50 transition-colors text-left"
               >
-                <div className="flex items-center justify-between mb-1">
+                <div className="flex flex-wrap items-center justify-between gap-y-2 mb-1">
                   <span className="text-sm font-medium text-foreground">{template.name}</span>
                   <span className="text-xs text-muted-foreground">{template.kind}</span>
                 </div>
@@ -501,7 +501,7 @@ Please proceed with applying this policy.`,
         />
         <BaseModal.Content className="!overflow-visible">
           <div className="space-y-3">
-            <div className="flex items-center justify-between text-xs">
+            <div className="flex flex-wrap items-center justify-between gap-y-2 text-xs">
               <span className="text-muted-foreground">YAML will be applied to: <span className="text-foreground">{clusterName}</span></span>
               <button
                 onClick={() => copyToClipboard(yamlContent)}

--- a/web/src/components/cards/opa/CreatePolicyModal.tsx
+++ b/web/src/components/cards/opa/CreatePolicyModal.tsx
@@ -407,7 +407,7 @@ Please proceed with applying this policy.`,
                     onClick={() => handleUseTemplate(template)}
                     className="w-full p-3 rounded-lg bg-secondary/30 hover:bg-secondary/50 transition-colors text-left"
                   >
-                    <div className="flex items-center justify-between mb-1">
+                    <div className="flex flex-wrap items-center justify-between gap-y-2 mb-1">
                       <span className="text-sm font-medium text-foreground">{template.name}</span>
                       <span className="text-xs text-muted-foreground">{template.kind}</span>
                     </div>
@@ -420,7 +420,7 @@ Please proceed with applying this policy.`,
             {/* Flow: Custom YAML / Template editor */}
             {flow === 'yaml' && (
               <div className="space-y-3">
-                <div className="flex items-center justify-between text-xs">
+                <div className="flex flex-wrap items-center justify-between gap-y-2 text-xs">
                   <span className="text-muted-foreground">
                     YAML will be applied to: <span className="text-foreground">{selectedCluster}</span>
                   </span>

--- a/web/src/components/cards/openfeature_status/OpenFeatureStatus.tsx
+++ b/web/src/components/cards/openfeature_status/OpenFeatureStatus.tsx
@@ -77,7 +77,7 @@ export function OpenFeatureStatus() {
   return (
     <div className="h-full flex flex-col min-h-card content-loaded gap-4">
       {/* Health badge + last check */}
-      <div className="flex items-center justify-between">
+      <div className="flex flex-wrap items-center justify-between gap-y-2">
         <div className={`flex items-center gap-2 px-3 py-1.5 rounded-full text-sm font-medium ${healthColorClass}`}>
           {isHealthy ? (
             <CheckCircle className="w-4 h-4" />
@@ -144,7 +144,7 @@ export function OpenFeatureStatus() {
               return (
                 <div
                   key={provider.name}
-                  className="flex items-center justify-between rounded-lg bg-secondary/40 px-3 py-2"
+                  className="flex flex-wrap items-center justify-between gap-y-2 rounded-lg bg-secondary/40 px-3 py-2"
                 >
                   <div className="flex items-center gap-2">
                     <div className={`w-2 h-2 rounded-full ${statusColor.replace('text-', 'bg-')}`} />

--- a/web/src/components/cards/openkruise_status/index.tsx
+++ b/web/src/components/cards/openkruise_status/index.tsx
@@ -445,7 +445,7 @@ export function OpenKruiseStatus({ config: _config }: OpenKruiseStatusProps) {
   if (showSkeleton) {
     return (
       <div className="h-full flex flex-col min-h-card">
-        <div className="flex items-center justify-between mb-4">
+        <div className="flex flex-wrap items-center justify-between gap-y-2 mb-4">
           <Skeleton variant="text" width={140} height={20} />
           <Skeleton variant="rounded" width={80} height={28} />
         </div>
@@ -488,7 +488,7 @@ export function OpenKruiseStatus({ config: _config }: OpenKruiseStatusProps) {
   return (
     <div className="h-full flex flex-col min-h-card content-loaded overflow-hidden">
       {/* Controls row */}
-      <div className="flex items-center justify-between gap-2 mb-4">
+      <div className="flex flex-wrap items-center justify-between gap-y-2 gap-2 mb-4">
         <div className="flex items-center gap-2">
           {localClusterFilter.length > 0 && (
             <span className="flex items-center gap-1 text-xs text-muted-foreground bg-secondary/50 px-1.5 py-0.5 rounded">
@@ -648,7 +648,7 @@ export function OpenKruiseStatus({ config: _config }: OpenKruiseStatusProps) {
                   } hover:bg-secondary/50 transition-colors cursor-pointer group`}
                   title={`${item.name} \u2014 ${getCategoryLabel(item.category)}`}
                 >
-                  <div className="flex items-center justify-between mb-1">
+                  <div className="flex flex-wrap items-center justify-between gap-y-2 mb-1">
                     <div className="flex items-center gap-2">
                       <span title={`${t('common:common.status')}: ${item.status}`}>
                         <StatusIcon

--- a/web/src/components/cards/pipelines/EmbedCodeDialog.tsx
+++ b/web/src/components/cards/pipelines/EmbedCodeDialog.tsx
@@ -96,7 +96,7 @@ export function EmbedCodeDialog({ open, cardType, cardTitle, currentRepo, onClos
         onClick={(e) => e.stopPropagation()}
       >
         {/* Header */}
-        <div className="flex items-center justify-between px-5 py-4 border-b border-border">
+        <div className="flex flex-wrap items-center justify-between gap-y-2 px-5 py-4 border-b border-border">
           <div className="flex items-center gap-2">
             <Code2 size={18} className="text-primary" />
             <h2 className="text-base font-semibold text-foreground">

--- a/web/src/components/cards/pipelines/LogsModal.tsx
+++ b/web/src/components/cards/pipelines/LogsModal.tsx
@@ -92,7 +92,7 @@ export function LogsModal({ repo, jobId, title, onClose }: LogsModalProps) {
         className="relative w-full max-w-4xl max-h-[85vh] bg-card border border-border rounded-xl shadow-2xl flex flex-col overflow-hidden"
         onClick={(e) => e.stopPropagation()}
       >
-        <div className="flex items-center justify-between gap-2 px-4 py-3 border-b border-border shrink-0">
+        <div className="flex flex-wrap items-center justify-between gap-y-2 gap-2 px-4 py-3 border-b border-border shrink-0">
           <div className="min-w-0">
             <div className="text-sm font-medium text-foreground truncate">{title}</div>
             <div className="text-[11px] text-muted-foreground truncate">{repo} • job #{jobId}</div>

--- a/web/src/components/cards/pipelines/NightlyReleasePulse.tsx
+++ b/web/src/components/cards/pipelines/NightlyReleasePulse.tsx
@@ -346,7 +346,7 @@ export function NightlyReleasePulse() {
           )}
         </div>
 
-        <div className="grid grid-cols-3 gap-2">
+        <div className="grid grid-cols-2 sm:grid-cols-3 gap-2">
           <div className="rounded-lg bg-secondary/30 px-3 py-2">
             <div className="text-[11px] text-muted-foreground">Streak</div>
             <div className={cn('text-sm font-medium mt-0.5',

--- a/web/src/components/cards/pipelines/PipelineFlow.tsx
+++ b/web/src/components/cards/pipelines/PipelineFlow.tsx
@@ -372,7 +372,7 @@ export function PipelineFlow() {
 
   return (
     <div className="p-3 h-full flex flex-col gap-2 min-h-0">
-      <div className="flex items-center justify-between gap-2">
+      <div className="flex flex-wrap items-center justify-between gap-y-2 gap-2">
         <select
           value={repoFilter ?? ''}
           onChange={(e) => setRepoFilter(e.target.value || null)}

--- a/web/src/components/cards/pipelines/RecentFailures.tsx
+++ b/web/src/components/cards/pipelines/RecentFailures.tsx
@@ -90,7 +90,7 @@ export function RecentFailures() {
 
   return (
     <div className="p-3 h-full flex flex-col gap-2 min-h-0">
-      <div className="flex items-center justify-between gap-2">
+      <div className="flex flex-wrap items-center justify-between gap-y-2 gap-2">
         <select
           value={repoFilter ?? ''}
           onChange={(e) => setRepoFilter(e.target.value || null)}

--- a/web/src/components/cards/pipelines/WorkflowMatrix.tsx
+++ b/web/src/components/cards/pipelines/WorkflowMatrix.tsx
@@ -87,7 +87,7 @@ export function WorkflowMatrix() {
 
   return (
     <div className="p-3 h-full flex flex-col gap-2 min-h-0">
-      <div className="flex items-center justify-between gap-2">
+      <div className="flex flex-wrap items-center justify-between gap-y-2 gap-2">
         <div className="flex items-center gap-2">
           <select
             value={repoFilter ?? ''}
@@ -174,7 +174,7 @@ export function WorkflowMatrix() {
         )}
       </div>
 
-      <div className="flex items-center justify-between gap-3 text-[10px] text-muted-foreground">
+      <div className="flex flex-wrap items-center justify-between gap-y-2 gap-3 text-[10px] text-muted-foreground">
         <div className="flex items-center gap-2">
           <Legend className="bg-green-500/70" label="success" />
           <Legend className="bg-red-500/80" label="failure" />

--- a/web/src/components/cards/rss/RSSFeed.tsx
+++ b/web/src/components/cards/rss/RSSFeed.tsx
@@ -650,7 +650,7 @@ function RSSFeedInternal({ config }: RSSFeedProps) {
   if (showFullSkeleton) {
     return (
       <div className="h-full flex flex-col animate-pulse">
-        <div className="flex items-center justify-between mb-3">
+        <div className="flex flex-wrap items-center justify-between gap-y-2 mb-3">
           <div className="h-5 w-32 bg-secondary/50 rounded" />
           <div className="h-6 w-6 bg-secondary/50 rounded" />
         </div>
@@ -669,7 +669,7 @@ function RSSFeedInternal({ config }: RSSFeedProps) {
   return (
     <div className="h-full flex flex-col min-h-0 overflow-hidden relative">
       {/* Row 1: Header */}
-      <div className="flex items-center justify-between mb-2 flex-shrink-0">
+      <div className="flex flex-wrap items-center justify-between gap-y-2 mb-2 flex-shrink-0">
         <div className="flex items-center gap-2 min-w-0">
           {/* Feed Selector */}
           <div className="relative">
@@ -793,7 +793,7 @@ function RSSFeedInternal({ config }: RSSFeedProps) {
       )}
 
       {/* Sort & Filter Controls */}
-      <div className="flex items-center justify-between mb-2 flex-shrink-0">
+      <div className="flex flex-wrap items-center justify-between gap-y-2 mb-2 flex-shrink-0">
         <div className="flex items-center gap-2">
           {/* CardControlsRow for sort & limit */}
           <CardControlsRow
@@ -885,7 +885,7 @@ function RSSFeedInternal({ config }: RSSFeedProps) {
       {/* Filter Editor Modal */}
       {showFilterEditor && (
         <div className="mb-2 p-2 bg-purple-500/10 border border-purple-500/20 rounded-lg flex-shrink-0 max-h-36 overflow-y-auto">
-          <div className="flex items-center justify-between mb-2">
+          <div className="flex flex-wrap items-center justify-between gap-y-2 mb-2">
             <span className="text-xs font-medium text-purple-300">Filter: {activeFeed?.name}</span>
             <button
               onClick={() => setShowFilterEditor(false)}
@@ -943,7 +943,7 @@ function RSSFeedInternal({ config }: RSSFeedProps) {
       {/* Settings Panel - absolute positioned to not affect card height */}
       {showSettings && (
         <div className="absolute inset-x-3 top-16 bottom-3 p-3 bg-card border border-border rounded-lg shadow-lg z-40 flex flex-col overflow-hidden">
-          <div className="flex items-center justify-between mb-3">
+          <div className="flex flex-wrap items-center justify-between gap-y-2 mb-3">
             <span className="text-sm font-medium">{t('cards:rssFeed.manageFeeds')}</span>
             <button
               onClick={() => setShowSettings(false)}
@@ -1015,7 +1015,7 @@ function RSSFeedInternal({ config }: RSSFeedProps) {
                 <div
                   key={feed.url}
                   className={cn(
-                    "flex items-center justify-between px-2 py-1.5 rounded transition-colors",
+                    "flex flex-wrap items-center justify-between gap-y-2 px-2 py-1.5 rounded transition-colors",
                     idx === activeFeedIndex
                       ? "bg-primary/20 border border-primary/30"
                       : "bg-secondary/30 hover:bg-secondary/50"
@@ -1153,7 +1153,7 @@ function RSSFeedInternal({ config }: RSSFeedProps) {
 
                 {/* Source feed selector */}
                 <div className="mb-2">
-                  <div className="flex items-center justify-between">
+                  <div className="flex flex-wrap items-center justify-between gap-y-2">
                     <label className="text-2xs text-muted-foreground">{t('cards:rssFeed.selectSourceFeeds')}:</label>
                     <button
                       type="button"
@@ -1262,7 +1262,7 @@ function RSSFeedInternal({ config }: RSSFeedProps) {
             Loading {activeFeed?.name || 'feed'}...
           </span>
         ) : error ? (
-          <div className="flex items-center justify-between gap-2 w-full px-2 py-0.5 bg-yellow-500/10 border border-yellow-500/20 rounded text-2xs text-yellow-400">
+          <div className="flex flex-wrap items-center justify-between gap-y-2 gap-2 w-full px-2 py-0.5 bg-yellow-500/10 border border-yellow-500/20 rounded text-2xs text-yellow-400">
             <span className="truncate">
               ⚠ {error === 'Failed to fetch' || error.includes('failed')
                 ? `Could not load ${activeFeed?.name || 'feed'}`

--- a/web/src/components/cards/slo_compliance/SLOCompliance.tsx
+++ b/web/src/components/cards/slo_compliance/SLOCompliance.tsx
@@ -155,7 +155,7 @@ export function SLOCompliance() {
           return (
             <div
               key={target.metric}
-              className="flex items-center justify-between px-2 py-1.5 rounded bg-secondary/30 text-xs"
+              className="flex flex-wrap items-center justify-between gap-y-2 px-2 py-1.5 rounded bg-secondary/30 text-xs"
             >
               <div className="flex items-center gap-2 min-w-0">
                 <Target className={`w-3 h-3 flex-shrink-0 ${getBudgetColor(target.currentCompliance)}`} />

--- a/web/src/components/cards/strimzi_status/StrimziStatus.tsx
+++ b/web/src/components/cards/strimzi_status/StrimziStatus.tsx
@@ -24,7 +24,7 @@ function TopicRow({ topic }: { topic: StrimziTopic }) {
     t('strimziStatus.topicStatus_error', 'Error')
 
   return (
-    <div className="flex items-center justify-between rounded-md bg-muted/30 px-3 py-2">
+    <div className="flex flex-wrap items-center justify-between gap-y-2 rounded-md bg-muted/30 px-3 py-2">
       <div className="min-w-0 flex-1">
         <p className="text-xs font-medium truncate">{topic.name}</p>
         <p className="text-xs text-muted-foreground">
@@ -55,7 +55,7 @@ function ConsumerGroupRow({ group }: { group: StrimziConsumerGroup }) {
     t('strimziStatus.groupStatus_error', 'Error')
 
   return (
-    <div className="flex items-center justify-between rounded-md bg-muted/30 px-3 py-2">
+    <div className="flex flex-wrap items-center justify-between gap-y-2 rounded-md bg-muted/30 px-3 py-2">
       <div className="min-w-0 flex-1">
         <p className="text-xs font-medium truncate">{group.groupId}</p>
         <p className={`text-xs tabular-nums ${lagColor}`}>
@@ -126,7 +126,7 @@ export function StrimziStatus() {
   return (
     <div className="h-full flex flex-col min-h-card content-loaded gap-4 overflow-hidden">
       {/* Health badge + cluster name + last check */}
-      <div className="flex items-center justify-between">
+      <div className="flex flex-wrap items-center justify-between gap-y-2">
         <div className={`flex items-center gap-2 px-3 py-1.5 rounded-full text-sm font-medium ${healthColorClass}`}>
           {isHealthy ? (
             <CheckCircle className="w-4 h-4" />

--- a/web/src/components/cards/thanos_status/index.tsx
+++ b/web/src/components/cards/thanos_status/index.tsx
@@ -75,7 +75,7 @@ export function ThanosStatus() {
     return (
         <div className="h-full flex flex-col min-h-card content-loaded gap-4">
             {/* Health badge + last check */}
-            <div className="flex items-center justify-between">
+            <div className="flex flex-wrap items-center justify-between gap-y-2">
                 <div
                     className={`flex items-center gap-2 px-3 py-1.5 rounded-full text-sm font-medium ${isHealthy
                             ? 'bg-green-500/20 text-green-400'

--- a/web/src/components/cards/trino_gateway/TrinoGateway.tsx
+++ b/web/src/components/cards/trino_gateway/TrinoGateway.tsx
@@ -41,7 +41,7 @@ export function TrinoGateway() {
   if (showSkeleton) {
     return (
       <div className="h-full flex flex-col min-h-card gap-3 p-1">
-        <div className="grid grid-cols-4 gap-2">
+        <div className="grid grid-cols-2 sm:grid-cols-4 gap-2">
           {Array.from({ length: SUMMARY_TILE_COUNT }).map((_, i) => (
             <Skeleton key={i} variant="rounded" height={48} />
           ))}
@@ -76,7 +76,7 @@ export function TrinoGateway() {
   return (
     <div className="h-full flex flex-col min-h-card gap-3 p-1 overflow-hidden">
       {/* Summary tiles */}
-      <div className="grid grid-cols-4 gap-2">
+      <div className="grid grid-cols-2 sm:grid-cols-4 gap-2">
         <StatTile icon={Database} label="Clusters" value={`${healthyClusters}/${trinoClusters.length}`} color="text-blue-400" />
         <StatTile icon={Server} label="Workers" value={String(data.totalWorkers)} color="text-purple-400" />
         <StatTile icon={Activity} label="Queries" value={String(data.totalActiveQueries)} color="text-green-400" />
@@ -88,7 +88,7 @@ export function TrinoGateway() {
         {trinoClusters.length > 0 && (
           <Section title={`Trino Clusters (${trinoClusters.length})`}>
             {trinoClusters.map(c => (
-              <div key={`${c.cluster}/${c.namespace}/${c.name}`} className="flex items-center justify-between px-2 py-1.5 rounded bg-secondary/30 text-xs">
+              <div key={`${c.cluster}/${c.namespace}/${c.name}`} className="flex flex-wrap items-center justify-between gap-y-2 px-2 py-1.5 rounded bg-secondary/30 text-xs">
                 <div className="flex items-center gap-2 min-w-0">
                   <div className={`w-1.5 h-1.5 rounded-full ${c.coordinatorReady ? 'bg-green-500' : 'bg-red-500'}`} />
                   <span className="truncate font-mono">{c.name}</span>
@@ -112,7 +112,7 @@ export function TrinoGateway() {
           <Section title={`Gateways (${gateways.length})`}>
             {gateways.map(g => (
               <div key={`${g.cluster}/${g.namespace}/${g.name}`} className="space-y-1">
-                <div className="flex items-center justify-between px-2 py-1.5 rounded bg-secondary/30 text-xs">
+                <div className="flex flex-wrap items-center justify-between gap-y-2 px-2 py-1.5 rounded bg-secondary/30 text-xs">
                   <div className="flex items-center gap-2 min-w-0">
                     <div className={`w-1.5 h-1.5 rounded-full ${GATEWAY_STATUS_DOT[g.status]}`} />
                     <span className="truncate font-mono">{g.name}</span>

--- a/web/src/components/cards/trivy/TrivyDetailModal.tsx
+++ b/web/src/components/cards/trivy/TrivyDetailModal.tsx
@@ -158,7 +158,7 @@ Please proceed step by step.`,
       <BaseModal.Content>
         <div className="space-y-4">
           {/* Severity summary */}
-          <div className="grid grid-cols-4 gap-3">
+          <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
             <SeverityBox label="Critical" count={critical} color="text-red-400" bg="bg-red-500/10" />
             <SeverityBox label="High" count={high} color="text-orange-400" bg="bg-orange-500/10" />
             <SeverityBox label="Medium" count={medium} color="text-yellow-400" bg="bg-yellow-500/10" />

--- a/web/src/components/cards/weather/Weather.tsx
+++ b/web/src/components/cards/weather/Weather.tsx
@@ -330,7 +330,7 @@ export function Weather({ config }: { config?: WeatherConfig }) {
   return (
     <div className="h-full flex flex-col min-h-card content-loaded">
       {/* Compact Header */}
-      <div className="flex items-center justify-between mb-3">
+      <div className="flex flex-wrap items-center justify-between gap-y-2 mb-3">
         <button
           onClick={() => setShowSettings(!showSettings)}
           className={`flex items-center gap-1.5 px-2.5 py-1.5 rounded-lg transition-colors ${showSettings ? 'bg-primary/20 text-primary' : 'hover:bg-secondary/50 text-muted-foreground'}`}
@@ -381,7 +381,7 @@ export function Weather({ config }: { config?: WeatherConfig }) {
           </div>
 
           {/* Current Location + Save Button */}
-          <div className="flex items-center justify-between p-2.5 rounded-lg bg-secondary/50 border border-border/30">
+          <div className="flex flex-wrap items-center justify-between gap-y-2 p-2.5 rounded-lg bg-secondary/50 border border-border/30">
             <div className="flex items-center gap-2">
               <MapPin className="w-4 h-4 text-primary" />
               <div>
@@ -631,11 +631,11 @@ export function Weather({ config }: { config?: WeatherConfig }) {
 
                     {isExpanded && (
                       <div className="px-4 py-3 ml-6 space-y-2 text-sm">
-                        <div className="flex items-center justify-between">
+                        <div className="flex flex-wrap items-center justify-between gap-y-2">
                           <span className="text-muted-foreground">Condition</span>
                           <span className="font-medium">{condition.label}</span>
                         </div>
-                        <div className="flex items-center justify-between">
+                        <div className="flex flex-wrap items-center justify-between gap-y-2">
                           <span className="text-muted-foreground">Precipitation</span>
                           <span className="font-medium">{day.precipitation}%</span>
                         </div>
@@ -715,7 +715,7 @@ export function Weather({ config }: { config?: WeatherConfig }) {
       </div>
 
       {/* Footer */}
-      <div className="mt-3 pt-2 border-t border-border/30 text-xs text-muted-foreground flex items-center justify-between">
+      <div className="mt-3 pt-2 border-t border-border/30 text-xs text-muted-foreground flex flex-wrap items-center justify-between gap-y-2">
         <a
           href="https://open-meteo.com"
           target="_blank"

--- a/web/src/components/cards/workload-detection/LLMInference.tsx
+++ b/web/src/components/cards/workload-detection/LLMInference.tsx
@@ -163,7 +163,7 @@ export function LLMInference({ config: _config }: LLMInferenceProps) {
   return (
     <div className="h-full flex flex-col min-h-card">
       {/* Header controls */}
-      <div className="flex items-center justify-between mb-4">
+      <div className="flex flex-wrap items-center justify-between gap-y-2 mb-4">
         <div className="flex items-center gap-2">
           <RefreshIndicator
             isRefreshing={isRefreshing}
@@ -298,7 +298,7 @@ export function LLMInference({ config: _config }: LLMInferenceProps) {
           const compBadge = getComponentBadge(server.componentType)
           return (
             <div key={server.id} className="p-3 rounded-lg bg-secondary/30 hover:bg-secondary/50 transition-colors">
-              <div className="flex items-center justify-between mb-1">
+              <div className="flex flex-wrap items-center justify-between gap-y-2 mb-1">
                 <div className="flex items-center gap-2 min-w-0">
                   <span className="text-sm font-medium text-foreground truncate" title={server.name}>{server.name}</span>
                   {/* Component type badge */}
@@ -352,7 +352,7 @@ export function LLMInference({ config: _config }: LLMInferenceProps) {
                   </span>
                 )}
               </div>
-              <div className="flex items-center justify-between text-xs text-muted-foreground">
+              <div className="flex flex-wrap items-center justify-between gap-y-2 text-xs text-muted-foreground">
                 <div className="flex items-center gap-3">
                   {server.componentType === 'model' && (
                     <span className="flex items-center gap-1"><Layers className="w-3 h-3" /> {server.model}</span>

--- a/web/src/components/cards/workload-detection/LLMModels.tsx
+++ b/web/src/components/cards/workload-detection/LLMModels.tsx
@@ -99,7 +99,7 @@ export function LLMModels({ config: _config }: LLMModelsProps) {
   return (
     <div className="h-full flex flex-col min-h-card">
       {/* Header controls */}
-      <div className="flex items-center justify-between mb-3">
+      <div className="flex flex-wrap items-center justify-between gap-y-2 mb-3">
         <div className="flex items-center gap-2">
           <RefreshIndicator
             isRefreshing={isRefreshing}

--- a/web/src/components/cards/workload-detection/MLJobs.tsx
+++ b/web/src/components/cards/workload-detection/MLJobs.tsx
@@ -96,7 +96,7 @@ export function MLJobs({ config: _config }: MLJobsProps) {
   return (
     <div className="h-full flex flex-col min-h-card">
       {/* Header controls */}
-      <div className="flex items-center justify-between mb-4">
+      <div className="flex flex-wrap items-center justify-between gap-y-2 mb-4">
         <div className="flex items-center gap-2">
           {filters.localClusterFilter.length > 0 && (
             <span className="flex items-center gap-1 text-xs text-muted-foreground bg-secondary/50 px-1.5 py-0.5 rounded">
@@ -157,7 +157,7 @@ export function MLJobs({ config: _config }: MLJobsProps) {
       <div ref={containerRef} className="flex-1 overflow-y-auto space-y-2" style={containerStyle}>
         {items.map((job, idx) => (
           <div key={idx} className="p-3 rounded-lg bg-secondary/30 hover:bg-secondary/50 transition-colors">
-            <div className="flex items-center justify-between mb-2">
+            <div className="flex flex-wrap items-center justify-between gap-y-2 mb-2">
               <div className="flex items-center gap-2">
                 <span className="text-sm font-medium text-foreground">{job.name}</span>
                 <span className="text-xs px-1.5 py-0.5 rounded bg-secondary text-muted-foreground">

--- a/web/src/components/cards/workload-detection/MLNotebooks.tsx
+++ b/web/src/components/cards/workload-detection/MLNotebooks.tsx
@@ -80,7 +80,7 @@ export function MLNotebooks({ config: _config }: MLNotebooksProps) {
   return (
     <div className="h-full flex flex-col min-h-card">
       {/* Header controls */}
-      <div className="flex items-center justify-between mb-3">
+      <div className="flex flex-wrap items-center justify-between gap-y-2 mb-3">
         <StatusBadge color="blue">
           {notebooks.filter(n => n.status === 'running').length} active
         </StatusBadge>

--- a/web/src/components/cards/workload-detection/ProwHistory.tsx
+++ b/web/src/components/cards/workload-detection/ProwHistory.tsx
@@ -79,7 +79,7 @@ export function ProwHistory({ config: _config }: ProwHistoryProps) {
   return (
     <div className="h-full flex flex-col min-h-card">
       {/* Controls */}
-      <div className="flex items-center justify-between mb-4">
+      <div className="flex flex-wrap items-center justify-between gap-y-2 mb-4">
         <StatusBadge color="orange">
           {totalItems} revisions
         </StatusBadge>
@@ -122,7 +122,7 @@ export function ProwHistory({ config: _config }: ProwHistoryProps) {
                 )}
               </div>
               <div className="p-2 rounded-lg bg-secondary/30 hover:bg-secondary/50 transition-colors">
-                <div className="flex items-center justify-between">
+                <div className="flex flex-wrap items-center justify-between gap-y-2">
                   <span className="text-sm font-medium text-foreground truncate">{job.name}</span>
                   <span className="text-xs text-muted-foreground">{formatTimeAgo(job.startTime)}</span>
                 </div>

--- a/web/src/components/cards/workload-detection/ProwJobs.tsx
+++ b/web/src/components/cards/workload-detection/ProwJobs.tsx
@@ -123,7 +123,7 @@ export function ProwJobs({ config: _config }: ProwJobsProps) {
   return (
     <div className="h-full flex flex-col min-h-card">
       {/* Header controls */}
-      <div className="flex items-center justify-between mb-4">
+      <div className="flex flex-wrap items-center justify-between gap-y-2 mb-4">
         <div className="flex items-center gap-2">
           <RefreshIndicator
             isRefreshing={isRefreshing}
@@ -193,7 +193,7 @@ export function ProwJobs({ config: _config }: ProwJobsProps) {
       <div ref={containerRef} className="flex-1 overflow-y-auto space-y-2" style={containerStyle}>
         {items.map((job) => (
           <div key={job.id} className="p-2 rounded-lg bg-secondary/30 hover:bg-secondary/50 transition-colors">
-            <div className="flex items-center justify-between">
+            <div className="flex flex-wrap items-center justify-between gap-y-2">
               <div className="flex items-center gap-2">
                 {getStateIcon(job.state)}
                 <span className="text-sm font-medium text-foreground truncate max-w-[200px]">{job.name}</span>

--- a/web/src/components/cards/workload-detection/ProwStatus.tsx
+++ b/web/src/components/cards/workload-detection/ProwStatus.tsx
@@ -37,7 +37,7 @@ export function ProwStatus({ config: _config }: ProwStatusProps) {
   return (
     <div className="h-full flex flex-col min-h-card">
       {/* Status badge */}
-      <div className="flex items-center justify-between mb-4">
+      <div className="flex flex-wrap items-center justify-between gap-y-2 mb-4">
         <span className={`text-xs px-1.5 py-0.5 rounded ${status.healthy ? 'bg-green-500/20 text-green-400' : 'bg-red-500/20 text-red-400'}`}>
           {status.healthy ? 'Healthy' : 'Unhealthy'}
         </span>

--- a/web/src/components/cards/workload-monitor/ClusterHealthMonitor.tsx
+++ b/web/src/components/cards/workload-monitor/ClusterHealthMonitor.tsx
@@ -202,7 +202,7 @@ export function ClusterHealthMonitor({ config: _config }: ClusterHealthMonitorPr
     return (
       <div className="space-y-3">
         <Skeleton variant="text" width={160} height={20} />
-        <div className="grid grid-cols-3 gap-2">
+        <div className="grid grid-cols-2 sm:grid-cols-3 gap-2">
           {Array.from({ length: 3 }).map((_, i) => (
             <Skeleton key={i} variant="rounded" height={48} />
           ))}
@@ -236,7 +236,7 @@ export function ClusterHealthMonitor({ config: _config }: ClusterHealthMonitorPr
       </div>
 
       {/* Stats grid */}
-      <div className="grid grid-cols-3 gap-2 mb-3">
+      <div className="grid grid-cols-2 sm:grid-cols-3 gap-2 mb-3">
         <div className="rounded-md bg-card/50 border border-border p-2 text-center">
           <p className="text-lg font-semibold text-foreground">{stats.totalNodes}</p>
           <p className="text-2xs text-muted-foreground">{t('common.nodes')}</p>

--- a/web/src/components/cards/workload-monitor/GitHubCIMonitor.tsx
+++ b/web/src/components/cards/workload-monitor/GitHubCIMonitor.tsx
@@ -288,7 +288,7 @@ export function GitHubCIMonitor({ config, ref }: GitHubCIMonitorProps & { ref?: 
     return (
       <div className="space-y-3">
         <Skeleton variant="text" width={160} height={20} />
-        <div className="grid grid-cols-4 gap-2">
+        <div className="grid grid-cols-2 sm:grid-cols-4 gap-2">
           {Array.from({ length: 4 }).map((_, i) => (
             <Skeleton key={i} variant="rounded" height={48} />
           ))}
@@ -403,7 +403,7 @@ export function GitHubCIMonitor({ config, ref }: GitHubCIMonitorProps & { ref?: 
       )}
 
       {/* Stats grid */}
-      <div className="grid grid-cols-4 gap-2 mb-3">
+      <div className="grid grid-cols-2 sm:grid-cols-4 gap-2 mb-3">
         <div className="rounded-md bg-card/50 border border-border p-2 text-center">
           <p className="text-lg font-semibold text-green-400">{stats.successRate}%</p>
           <p className="text-2xs text-muted-foreground">Pass Rate</p>

--- a/web/src/components/cards/workload-monitor/ProwCIMonitor.tsx
+++ b/web/src/components/cards/workload-monitor/ProwCIMonitor.tsx
@@ -211,7 +211,7 @@ export function ProwCIMonitor({ config: _config }: ProwCIMonitorProps) {
       </div>
 
       {/* Stats grid */}
-      <div className="grid grid-cols-4 gap-2 mb-3">
+      <div className="grid grid-cols-2 sm:grid-cols-4 gap-2 mb-3">
         <div className="rounded-md bg-card/50 border border-border p-2 text-center">
           <p className="text-lg font-semibold text-green-400">{stats.successRate}%</p>
           <p className="text-2xs text-muted-foreground">Success Rate</p>

--- a/web/src/components/cards/workload-monitor/WorkloadMonitorDiagnose.tsx
+++ b/web/src/components/cards/workload-monitor/WorkloadMonitorDiagnose.tsx
@@ -91,7 +91,7 @@ export function WorkloadMonitorDiagnose({
   return (
     <div className="mt-3 border-t border-border/50 pt-3">
       {/* Header */}
-      <div className="flex items-center justify-between">
+      <div className="flex flex-wrap items-center justify-between gap-y-2">
         <button
           onClick={() => setExpanded(!expanded)}
           className="flex items-center gap-2 text-xs font-medium text-muted-foreground hover:text-foreground transition-colors"
@@ -182,7 +182,7 @@ export function WorkloadMonitorDiagnose({
           {/* Proposed repairs */}
           {(state.phase === 'proposing-repair' || state.phase === 'awaiting-approval') && state.proposedRepairs.length > 0 && (
             <div className="space-y-2">
-              <div className="flex items-center justify-between">
+              <div className="flex flex-wrap items-center justify-between gap-y-2">
                 <span className="text-xs font-medium text-foreground">Proposed Repairs</span>
                 {!allApproved && (
                   <button

--- a/web/src/components/cards/workload-monitor/WorkloadMonitorToolbar.tsx
+++ b/web/src/components/cards/workload-monitor/WorkloadMonitorToolbar.tsx
@@ -53,7 +53,7 @@ export function WorkloadMonitorToolbar({
   return (
     <div className="space-y-2 mb-3">
       {/* Top row: summary + controls */}
-      <div className="flex items-center justify-between">
+      <div className="flex flex-wrap items-center justify-between gap-y-2">
         <div className="flex items-center gap-2">
           <StatusBadge color="purple">
             {totalItems} resources


### PR DESCRIPTION
## Summary
Phase 1 of the responsive card layout fix (RFC in #8695).

- Add `flex-wrap gap-y-2` to all ~444 card control bars using `flex items-center justify-between` so they wrap instead of overlapping when sidebars compress available width
- Make dense stat grids responsive: `grid-cols-4` → `grid-cols-2 sm:grid-cols-4` and `grid-cols-3` → `grid-cols-2 sm:grid-cols-3`
- Skip structural grids (FleetComplianceHeatmap, SudokuGame) where columns must stay aligned

**Result:** No more visual overlap when sidebars expand. Not beautiful at narrow widths, but functional. Phase 2 (container queries) will add graceful adaptation.

Fixes #8695

## Test plan
- [ ] Expand left sidebar — card control bars wrap instead of overlapping
- [ ] Expand right mission panel — same behavior
- [ ] Expand both — cards still usable
- [ ] Narrow viewport to mobile width — stat grids reflow to 2 columns
- [ ] FleetComplianceHeatmap still has aligned header/data columns

🤖 Generated with [Claude Code](https://claude.com/claude-code)