### PR TITLE
feat: extract CSRF middleware for consistent protection

### DIFF
--- a/pkg/api/handlers/auth.go
+++ b/pkg/api/handlers/auth.go
@@ -255,13 +255,6 @@ func (h *AuthHandler) SetHub(hub SessionDisconnecter) {
 const (
 	// jwtCookieName is the HttpOnly cookie that carries the JWT.
 	jwtCookieName = "kc_auth"
-	// csrfHeaderName is the custom header required on mutating auth endpoints
-	// (#6588). Browsers will not send this header on cross-origin form POSTs,
-	// so requiring it blocks a malicious site from triggering logout/refresh
-	// via a forged form submission even if the victim's cookie is SameSite=Lax.
-	csrfHeaderName = "X-Requested-With"
-	// csrfHeaderValue is the expected value for csrfHeaderName.
-	csrfHeaderValue = "XMLHttpRequest"
 	// maxOAuthErrorDescriptionLen bounds the length of an OAuth
 	// error_description value reflected into a redirect URL (#6583).
 	maxOAuthErrorDescriptionLen = 200
@@ -654,14 +647,7 @@ func (h *AuthHandler) GitHubCallback(c *fiber.Ctx) error {
 //   - The /auth/logout route is registered with h.JWTAuth middleware in
 //     server.go (#6587), which additionally enforces the revocation check.
 func (h *AuthHandler) Logout(c *fiber.Ctx) error {
-	// #6588 — require the XHR header as a CSRF gate. This rejects cross-origin
-	// form POSTs that would otherwise succeed because session cookies are
-	// sent on top-level POSTs when SameSite=Lax.
-	if c.Get(csrfHeaderName) != csrfHeaderValue {
-		slog.Warn("[Auth] logout rejected: missing CSRF header",
-			"ip", c.IP(), "path", c.Path())
-		return fiber.NewError(fiber.StatusForbidden, "CSRF header required")
-	}
+	// CSRF protection is enforced by the RequireCSRF middleware in server.go.
 
 	// Accept token from Authorization header or HttpOnly cookie
 	var tokenString string
@@ -750,12 +736,7 @@ func (h *AuthHandler) Logout(c *fiber.Ctx) error {
 //     no longer contains the token (#6590) so JavaScript cannot read it,
 //     preserving the intent of HttpOnly.
 func (h *AuthHandler) RefreshToken(c *fiber.Ctx) error {
-	// #6588 — CSRF gate (see Logout for rationale).
-	if c.Get(csrfHeaderName) != csrfHeaderValue {
-		slog.Warn("[Auth] refresh rejected: missing CSRF header",
-			"ip", c.IP(), "path", c.Path())
-		return fiber.NewError(fiber.StatusForbidden, "CSRF header required")
-	}
+	// CSRF protection is enforced by the RequireCSRF middleware in server.go.
 
 	var tokenString string
 

--- a/pkg/api/handlers/auth_contract_test.go
+++ b/pkg/api/handlers/auth_contract_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/google/uuid"
+	"github.com/kubestellar/console/pkg/api/middleware"
 	"github.com/kubestellar/console/pkg/models"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -30,7 +31,7 @@ import (
 // DO NOT re-introduce a "token" field in the /auth/refresh JSON body.
 func TestAuthRefreshContract_TokenNotInResponseBody(t *testing.T) {
 	app, mockStore, handler := setupAuthTest()
-	app.Post("/auth/refresh", handler.RefreshToken)
+	app.Post("/auth/refresh", middleware.RequireCSRF(), handler.RefreshToken)
 
 	// 1. Create a mock user and generate a valid JWT.
 	uid := uuid.New()
@@ -89,7 +90,7 @@ func TestAuthRefreshContract_TokenNotInResponseBody(t *testing.T) {
 // still be cookie-only, never returned in the JSON body.
 func TestAuthRefreshContract_OnboardedFalse(t *testing.T) {
 	app, mockStore, handler := setupAuthTest()
-	app.Post("/auth/refresh", handler.RefreshToken)
+	app.Post("/auth/refresh", middleware.RequireCSRF(), handler.RefreshToken)
 
 	uid := uuid.New()
 	user := &models.User{ID: uid, GitHubLogin: "new-user", Onboarded: false}

--- a/pkg/api/handlers/auth_test.go
+++ b/pkg/api/handlers/auth_test.go
@@ -89,8 +89,8 @@ func TestDevModeLogin(t *testing.T) {
 }
 
 // refreshReq builds a POST /auth/refresh request with the CSRF header
-// set so the handler does not reject it at the CSRF gate (#6588). Tests
-// that want to exercise the CSRF gate should build requests directly.
+// set so the RequireCSRF middleware allows it through (#6588). Tests that
+// want to exercise the CSRF gate should build requests directly.
 func refreshReq(authHeader string) *http.Request {
 	req, err := http.NewRequest("POST", "/auth/refresh", nil)
 	if err != nil {
@@ -105,7 +105,7 @@ func refreshReq(authHeader string) *http.Request {
 
 func TestRefreshToken(t *testing.T) {
 	app, mockStore, handler := setupAuthTest()
-	app.Post("/auth/refresh", handler.RefreshToken)
+	app.Post("/auth/refresh", middleware.RequireCSRF(), handler.RefreshToken)
 
 	t.Run("Valid token refresh", func(t *testing.T) {
 		// 1. Generate a valid token manually
@@ -618,7 +618,7 @@ func TestGitHubCallback_SanitizesErrorDescription(t *testing.T) {
 // when a valid JWT is presented.
 func TestLogout_RequiresCSRFHeader(t *testing.T) {
 	app, _, handler := setupAuthTest()
-	app.Post("/auth/logout", handler.Logout)
+	app.Post("/auth/logout", middleware.RequireCSRF(), handler.Logout)
 
 	uid := uuid.New()
 	user := &models.User{ID: uid, GitHubLogin: "test"}
@@ -648,7 +648,7 @@ func TestLogout_RequiresCSRFHeader(t *testing.T) {
 // JTIs only bloats the persistent table for no security benefit.
 func TestLogout_ExpiredTokenIdempotent(t *testing.T) {
 	app, _, handler := setupAuthTest()
-	app.Post("/auth/logout", handler.Logout)
+	app.Post("/auth/logout", middleware.RequireCSRF(), handler.Logout)
 
 	expClaims := middleware.UserClaims{
 		UserID: uuid.New(),

--- a/pkg/api/middleware/csrf.go
+++ b/pkg/api/middleware/csrf.go
@@ -1,0 +1,55 @@
+package middleware
+
+import (
+	"log/slog"
+
+	"github.com/gofiber/fiber/v2"
+)
+
+const (
+	// CSRFHeaderName is the custom header required on state-changing requests.
+	// Browsers will not send this header on cross-origin form POSTs, so
+	// requiring it blocks a malicious site from triggering mutations via a
+	// forged form submission even if the victim's cookie is SameSite=Lax.
+	CSRFHeaderName = "X-Requested-With"
+
+	// CSRFHeaderValue is the expected value for CSRFHeaderName.
+	CSRFHeaderValue = "XMLHttpRequest"
+
+	// csrfForbiddenMsg is the error message returned when the CSRF header
+	// is missing or has an incorrect value.
+	csrfForbiddenMsg = "CSRF header required"
+)
+
+// safeHTTPMethods are HTTP methods that do not change server state and are
+// therefore exempt from the CSRF check. RFC 7231 §4.2.1.
+var safeHTTPMethods = map[string]bool{
+	fiber.MethodGet:     true,
+	fiber.MethodHead:    true,
+	fiber.MethodOptions: true,
+}
+
+// RequireCSRF returns a Fiber middleware that rejects state-changing requests
+// (POST, PUT, DELETE, PATCH) that lack the X-Requested-With: XMLHttpRequest
+// header. GET, HEAD, and OPTIONS requests pass through unconditionally because
+// they must not cause side effects per HTTP semantics.
+//
+// This is a defence-in-depth measure against cross-site request forgery:
+// browsers never attach custom headers to requests initiated by <form> or
+// navigation, so a cross-origin attacker cannot forge a request with this
+// header. See #6588 and #8680 for background.
+func RequireCSRF() fiber.Handler {
+	return func(c *fiber.Ctx) error {
+		if safeHTTPMethods[c.Method()] {
+			return c.Next()
+		}
+
+		if c.Get(CSRFHeaderName) != CSRFHeaderValue {
+			slog.Warn("[CSRF] request rejected: missing or invalid CSRF header",
+				"ip", c.IP(), "method", c.Method(), "path", c.Path())
+			return fiber.NewError(fiber.StatusForbidden, csrfForbiddenMsg)
+		}
+
+		return c.Next()
+	}
+}

--- a/pkg/api/middleware/csrf_test.go
+++ b/pkg/api/middleware/csrf_test.go
@@ -1,0 +1,121 @@
+package middleware_test
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gofiber/fiber/v2"
+
+	"github.com/kubestellar/console/pkg/api/middleware"
+)
+
+// testOKBody is the response body returned by the downstream handler in tests.
+const testOKBody = "ok"
+
+// newTestApp creates a Fiber app with the CSRF middleware and a catch-all
+// handler that returns 200 "ok" for any route.
+func newTestApp() *fiber.App {
+	app := fiber.New()
+	app.Use(middleware.RequireCSRF())
+	app.Use(func(c *fiber.Ctx) error {
+		return c.SendString(testOKBody)
+	})
+	return app
+}
+
+func TestCSRF_SafeMethodsPassThrough(t *testing.T) {
+	t.Parallel()
+	app := newTestApp()
+
+	safeMethods := []string{
+		http.MethodGet,
+		http.MethodHead,
+		http.MethodOptions,
+	}
+
+	for _, method := range safeMethods {
+		t.Run(method, func(t *testing.T) {
+			req := httptest.NewRequest(method, "/any-path", nil)
+			// No CSRF header — should still pass for safe methods
+			resp, err := app.Test(req)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if resp.StatusCode != http.StatusOK {
+				t.Errorf("expected 200, got %d", resp.StatusCode)
+			}
+		})
+	}
+}
+
+func TestCSRF_UnsafeMethodsRejectedWithoutHeader(t *testing.T) {
+	t.Parallel()
+	app := newTestApp()
+
+	unsafeMethods := []string{
+		http.MethodPost,
+		http.MethodPut,
+		http.MethodDelete,
+		http.MethodPatch,
+	}
+
+	for _, method := range unsafeMethods {
+		t.Run(method, func(t *testing.T) {
+			req := httptest.NewRequest(method, "/any-path", nil)
+			resp, err := app.Test(req)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if resp.StatusCode != http.StatusForbidden {
+				t.Errorf("expected 403, got %d", resp.StatusCode)
+			}
+		})
+	}
+}
+
+func TestCSRF_UnsafeMethodsRejectedWithWrongValue(t *testing.T) {
+	t.Parallel()
+	app := newTestApp()
+
+	req := httptest.NewRequest(http.MethodPost, "/any-path", nil)
+	req.Header.Set(middleware.CSRFHeaderName, "BadValue")
+	resp, err := app.Test(req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.StatusCode != http.StatusForbidden {
+		t.Errorf("expected 403, got %d", resp.StatusCode)
+	}
+}
+
+func TestCSRF_UnsafeMethodsPassWithCorrectHeader(t *testing.T) {
+	t.Parallel()
+	app := newTestApp()
+
+	unsafeMethods := []string{
+		http.MethodPost,
+		http.MethodPut,
+		http.MethodDelete,
+		http.MethodPatch,
+	}
+
+	for _, method := range unsafeMethods {
+		t.Run(method, func(t *testing.T) {
+			req := httptest.NewRequest(method, "/any-path", nil)
+			req.Header.Set(middleware.CSRFHeaderName, middleware.CSRFHeaderValue)
+			resp, err := app.Test(req)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if resp.StatusCode != http.StatusOK {
+				t.Errorf("expected 200, got %d", resp.StatusCode)
+			}
+			body, _ := io.ReadAll(resp.Body)
+			if string(body) != testOKBody {
+				t.Errorf("expected body %q, got %q", testOKBody, string(body))
+			}
+		})
+	}
+}

--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -671,8 +671,9 @@ func (s *Server) setupRoutes() {
 	// #6579 — /auth/refresh similarly requires JWTAuth so that a revoked
 	// token is rejected by the middleware before the handler even runs.
 	jwtAuth := middleware.JWTAuth(s.config.JWTSecret)
-	s.app.Post("/auth/refresh", authLimiter, jwtAuth, auth.RefreshToken)
-	s.app.Post("/auth/logout", authLimiter, jwtAuth, auth.Logout)
+	csrfGuard := middleware.RequireCSRF()
+	s.app.Post("/auth/refresh", authLimiter, csrfGuard, jwtAuth, auth.RefreshToken)
+	s.app.Post("/auth/logout", authLimiter, csrfGuard, jwtAuth, auth.Logout)
 
 	// Public endpoint rate limiter — loose limit to prevent DoS on unauthenticated
 	// routes (active-users, ping, nightly-e2e, youtube, medium, analytics) (#7029).
@@ -810,7 +811,7 @@ func (s *Server) setupRoutes() {
 		}
 		return c.Next()
 	}
-	api := s.app.Group("/api", apiLimiter, bodyGuard, middleware.JWTAuth(s.config.JWTSecret))
+	api := s.app.Group("/api", apiLimiter, bodyGuard, csrfGuard, middleware.JWTAuth(s.config.JWTSecret))
 
 	// User routes
 	user := handlers.NewUserHandler(s.store)
@@ -1240,7 +1241,10 @@ func (s *Server) setupRoutes() {
 	api.Get("/persistence/deployments", persistenceHandler.ListWorkloadDeployments)
 	api.Get("/persistence/deployments/:name", persistenceHandler.GetWorkloadDeployment)
 
-	// GitHub webhook (public endpoint, uses signature verification)
+	// GitHub webhook (public endpoint, uses signature verification).
+	// Not behind the /api group, so the CSRF middleware does not apply — the
+	// handler's own HMAC signature check (X-Hub-Signature-256) authenticates
+	// the request instead.
 	s.app.Post("/webhooks/github", feedback.HandleGitHubWebhook)
 
 	// WebSocket for real-time updates


### PR DESCRIPTION
## Summary
- Extract inline CSRF checks from `auth.go` into reusable `pkg/api/middleware/csrf.go`
- Apply CSRF protection consistently to all state-changing endpoints via the `/api` group
- Previously only 2 of ~40+ POST endpoints had CSRF protection; now all authenticated state-changing routes are protected
- GET/HEAD/OPTIONS requests pass through unconditionally
- GitHub webhook endpoint remains unaffected (uses HMAC signature verification instead)
- Add comprehensive tests for the middleware

Fixes #8680

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./pkg/api/middleware/...` passes (all CSRF + existing JWT tests)
- [x] `npm run build` passes (frontend unaffected)
- [ ] Login/logout still works
- [ ] POST endpoints reject requests without X-Requested-With header
- [ ] GET endpoints work without the header

🤖 Generated with [Claude Code](https://claude.com/claude-code)