### PR TITLE
fix: make critical issue badge consistent across pages

### DIFF
--- a/web/src/components/dashboard/DashboardHealthIndicator.tsx
+++ b/web/src/components/dashboard/DashboardHealthIndicator.tsx
@@ -1,6 +1,8 @@
 import { CheckCircle, AlertTriangle, AlertCircle } from 'lucide-react'
-import { useNavigate } from 'react-router-dom'
+import { useNavigate, useLocation } from 'react-router-dom'
 import { useDashboardHealth, type DashboardHealthStatus } from '../../hooks/useDashboardHealth'
+import { useGlobalFilters } from '../../hooks/useGlobalFilters'
+import { ROUTES } from '../../config/routes'
 import { cn } from '../../lib/cn'
 
 interface StatusConfig {
@@ -48,14 +50,33 @@ export function DashboardHealthIndicator({
 }: DashboardHealthIndicatorProps) {
   const health = useDashboardHealth()
   const navigate = useNavigate()
+  const location = useLocation()
+  const { setSelectedSeverities } = useGlobalFilters()
   const config = STATUS_CONFIGS[health.status]
   const Icon = config.icon
 
+  const isOnAlertsPage = location.pathname === ROUTES.ALERTS
+
   const handleClick = () => {
-    if (health.navigateTo) {
+    if (health.status === 'critical') {
+      // Apply critical severity filter
+      setSelectedSeverities(['critical'])
+      if (!isOnAlertsPage) {
+        navigate(ROUTES.ALERTS)
+      }
+    } else if (health.status === 'warning') {
+      // Apply warning severity filter
+      setSelectedSeverities(['warning'])
+      if (!isOnAlertsPage) {
+        navigate(ROUTES.ALERTS)
+      }
+    } else if (health.navigateTo && !isOnAlertsPage) {
       navigate(health.navigateTo)
     }
   }
+
+  /** Whether clicking the badge has an action (navigate or filter) */
+  const isClickable = health.status !== 'healthy'
 
   const iconSize = size === 'sm' ? 'w-3 h-3' : 'w-4 h-4'
   const textSize = size === 'sm' ? 'text-2xs' : 'text-xs'
@@ -67,7 +88,7 @@ export function DashboardHealthIndicator({
   return (
     <button
       onClick={handleClick}
-      disabled={!health.navigateTo}
+      disabled={!isClickable}
       className={cn(
         'inline-flex items-center gap-1 rounded border font-medium transition-all',
         config.bgColor,
@@ -75,7 +96,7 @@ export function DashboardHealthIndicator({
         config.borderColor,
         padding,
         textSize,
-        health.navigateTo
+        isClickable
           ? 'cursor-pointer hover:scale-105 hover:shadow-md'
           : 'cursor-default',
         className


### PR DESCRIPTION
## Summary
- When on the Alerts page, clicking the health status badge (e.g. "1 critical issue") now applies the corresponding severity filter instead of being non-responsive
- When on other pages, the badge navigates to /alerts with the severity filter pre-applied
- Badge is always clickable when status is critical or warning, regardless of current page

Fixes #8725

## Test plan
- [ ] Navigate to My Clusters or Dashboard with active critical alerts — click the badge and verify it navigates to /alerts with critical filter applied
- [ ] On the Alerts page with active critical alerts — click the badge and verify the severity filter updates to show only critical alerts
- [ ] Verify the badge shows hover/pointer styles on all pages when status is critical or warning
- [ ] Verify the healthy badge remains non-clickable (disabled)

🤖 Generated with [Claude Code](https://claude.com/claude-code)