### PR TITLE
feat(alerts): per-alert snooze buttons + duration preset chips

### DIFF
--- a/web/src/components/alerts/AlertRuleEditor.tsx
+++ b/web/src/components/alerts/AlertRuleEditor.tsx
@@ -27,6 +27,20 @@ const DEFAULT_DURATION_SECS = 60 // Default condition duration in seconds
 const DEFAULT_TEMPERATURE_F = 100 // Default temperature threshold in Fahrenheit
 const DEFAULT_WIND_SPEED_MPH = 40 // Default wind speed threshold in mph
 
+/** Seconds per minute */
+const SECS_PER_MINUTE = 60
+/** Seconds per hour */
+const SECS_PER_HOUR = 3600
+
+/** Preset duration options shown as clickable chips in the rule editor */
+const DURATION_PRESETS = [
+  { label: 'Immediate', value: 0 },
+  { label: '1 min', value: SECS_PER_MINUTE },
+  { label: '5 min', value: 5 * SECS_PER_MINUTE },
+  { label: '15 min', value: 15 * SECS_PER_MINUTE },
+  { label: '1 hour', value: SECS_PER_HOUR },
+] as const
+
 interface AlertRuleEditorProps {
   isOpen?: boolean
   rule?: AlertRule // If editing existing rule
@@ -469,13 +483,7 @@ export function AlertRuleEditor({ isOpen = true, rule, onSave, onCancel }: Alert
                 Duration (seconds before alerting)
               </label>
               <div className="flex items-center gap-2 flex-wrap">
-                {[
-                  { label: 'Immediate', value: 0 },
-                  { label: '1 min', value: 60 },
-                  { label: '5 min', value: 300 },
-                  { label: '15 min', value: 900 },
-                  { label: '1 hour', value: 3600 },
-                ].map(preset => (
+                {DURATION_PRESETS.map(preset => (
                   <button
                     key={preset.value}
                     type="button"

--- a/web/src/components/alerts/AlertRuleEditor.tsx
+++ b/web/src/components/alerts/AlertRuleEditor.tsx
@@ -466,9 +466,29 @@ export function AlertRuleEditor({ isOpen = true, rule, onSave, onCancel }: Alert
             {/* Duration */}
             <div>
               <label htmlFor="alertRuleDuration" className="block text-xs text-muted-foreground mb-1">
-                {t('alerts.durationSeconds')}
+                Duration (seconds before alerting)
               </label>
-              <div className="flex items-center gap-2">
+              <div className="flex items-center gap-2 flex-wrap">
+                {[
+                  { label: 'Immediate', value: 0 },
+                  { label: '1 min', value: 60 },
+                  { label: '5 min', value: 300 },
+                  { label: '15 min', value: 900 },
+                  { label: '1 hour', value: 3600 },
+                ].map(preset => (
+                  <button
+                    key={preset.value}
+                    type="button"
+                    onClick={() => setDuration(preset.value)}
+                    className={`px-2.5 py-1.5 text-xs rounded-lg border transition-colors ${
+                      duration === preset.value
+                        ? 'bg-purple-500/20 border-purple-500/30 text-purple-400'
+                        : 'bg-secondary border-border text-muted-foreground hover:text-foreground'
+                    }`}
+                  >
+                    {preset.label}
+                  </button>
+                ))}
                 <input
                   id="alertRuleDuration"
                   name="alertRuleDuration"
@@ -477,9 +497,9 @@ export function AlertRuleEditor({ isOpen = true, rule, onSave, onCancel }: Alert
                   max={3600}
                   value={duration}
                   onChange={e => setDuration(Number(e.target.value))}
-                  className="w-24 px-3 py-2 rounded-lg bg-secondary border border-border text-foreground focus:outline-none focus:ring-2 focus:ring-purple-500"
+                  className="w-20 px-2 py-1.5 text-xs rounded-lg bg-secondary border border-border text-foreground focus:outline-none focus:ring-2 focus:ring-purple-500"
                 />
-                <span className="text-sm text-muted-foreground">{t('alerts.durationHint')}</span>
+                <span className="text-xs text-muted-foreground">{t('alerts.durationHint')}</span>
               </div>
             </div>
 

--- a/web/src/components/cards/AlertListItem.tsx
+++ b/web/src/components/cards/AlertListItem.tsx
@@ -1,9 +1,11 @@
+import { useState, useRef, useEffect } from 'react'
 import {
   Clock,
   ChevronRight,
   Bot,
   Server,
   ExternalLink,
+  BellOff,
 } from 'lucide-react'
 import { getSeverityIcon } from '../../types/alerts'
 import type { Alert, AlertSeverity } from '../../types/alerts'
@@ -12,6 +14,7 @@ import { CardAIActions } from '../../lib/cards/CardComponents'
 import { useTranslation } from 'react-i18next'
 import type { TFunction } from 'i18next'
 import type { Mission } from '../../hooks/useMissions'
+import { useSnoozedAlerts, SNOOZE_DURATIONS, formatSnoozeRemaining, type SnoozeDuration } from '../../hooks/useSnoozedAlerts'
 
 // Severity color map — defined at module level to avoid re-creation on each render
 const SEVERITY_COLORS: Record<AlertSeverity, string> = {
@@ -73,6 +76,23 @@ export function AlertListItem({
   onOpenMission,
 }: AlertListItemProps) {
   const { t } = useTranslation('cards')
+  const { snoozeAlert, unsnoozeAlert, isSnoozed, getSnoozeRemaining } = useSnoozedAlerts()
+  const [snoozeMenuOpen, setSnoozeMenuOpen] = useState(false)
+  const snoozeRef = useRef<HTMLDivElement>(null)
+  const alertSnoozed = isSnoozed(alert.id)
+  const snoozeRemaining = alertSnoozed ? getSnoozeRemaining(alert.id) : 0
+
+  // Close snooze menu on outside click
+  useEffect(() => {
+    if (!snoozeMenuOpen) return
+    const handler = (e: MouseEvent) => {
+      if (snoozeRef.current && !snoozeRef.current.contains(e.target as Node)) {
+        setSnoozeMenuOpen(false)
+      }
+    }
+    document.addEventListener('mousedown', handler)
+    return () => document.removeEventListener('mousedown', handler)
+  }, [snoozeMenuOpen])
 
   return (
     <div
@@ -119,6 +139,40 @@ export function AlertListItem({
 
       {/* Quick Actions */}
       <div className="flex items-center gap-2 mt-2 pt-2 border-t border-border/30">
+        {/* Snooze button */}
+        <div className="relative" ref={snoozeRef}>
+          {alertSnoozed ? (
+            <button
+              onClick={(e) => { e.stopPropagation(); unsnoozeAlert(alert.id) }}
+              className="flex items-center gap-1 px-2 py-1 text-xs rounded bg-yellow-500/20 text-yellow-400 border border-yellow-500/30 hover:bg-yellow-500/30 transition-colors"
+              title="Snoozed — click to unsnooze"
+            >
+              <BellOff className="w-3 h-3" />
+              {formatSnoozeRemaining(snoozeRemaining ?? 0)}
+            </button>
+          ) : (
+            <button
+              onClick={(e) => { e.stopPropagation(); setSnoozeMenuOpen(!snoozeMenuOpen) }}
+              className="p-1.5 rounded text-muted-foreground hover:text-foreground hover:bg-muted/50 transition-colors"
+              title="Snooze this alert"
+            >
+              <BellOff className="w-3.5 h-3.5" />
+            </button>
+          )}
+          {snoozeMenuOpen && (
+            <div className="absolute left-0 bottom-full mb-1 z-50 bg-[#1a1a2e] border border-border rounded-lg shadow-xl py-1 min-w-[100px]">
+              {(Object.keys(SNOOZE_DURATIONS) as SnoozeDuration[]).map(duration => (
+                <button
+                  key={duration}
+                  onClick={(e) => { e.stopPropagation(); snoozeAlert(alert.id, duration); setSnoozeMenuOpen(false) }}
+                  className="w-full px-3 py-1.5 text-xs text-left text-foreground hover:bg-muted/50 transition-colors"
+                >
+                  {duration}
+                </button>
+              ))}
+            </div>
+          )}
+        </div>
         {!alert.acknowledgedAt && (
           <Button
             variant="secondary"


### PR DESCRIPTION
## Summary
Two missing alert UX controls that made the system hard to use:

### Per-alert snooze (AlertListItem)
The `useSnoozedAlerts` hook existed but was only wired into `HardwareHealthCard` — the main Active Alerts card had no snooze capability. Now each alert row has a BellOff button that opens a dropdown (5m/15m/1h/4h/24h). When snoozed, shows a yellow badge with remaining time; click to unsnooze.

### Duration preset chips (AlertRuleEditor)
The "Duration (seconds before alerting)" field was a raw number input — users had to know "300 = 5 minutes". Replaced with clickable preset chips: Immediate / 1 min / 5 min / 15 min / 1 hour, plus a manual input for custom values.

## Test plan
- [ ] Open /alerts → each alert row shows a BellOff icon in quick actions
- [ ] Click BellOff → dropdown with 5m/15m/1h/4h/24h appears (solid background)
- [ ] Select "15m" → alert shows yellow "14m" badge, click to unsnooze
- [ ] Edit Alert Rule → duration section shows preset chips, clicking "5 min" sets value to 300

🤖 Generated with [Claude Code](https://claude.com/claude-code)