### PR TITLE
feat: add Zod runtime validation for critical API responses

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -42,7 +42,8 @@
         "remark-gfm": "^4.0.1",
         "sucrase": "^3.35.1",
         "tailwind-merge": "^3.5.0",
-        "three": "^0.183.2"
+        "three": "^0.183.2",
+        "zod": "^4.3.6"
       },
       "devDependencies": {
         "@axe-core/playwright": "^4.10.0",
@@ -11358,7 +11359,6 @@
       "version": "4.3.6",
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"

--- a/web/package.json
+++ b/web/package.json
@@ -80,7 +80,8 @@
     "remark-gfm": "^4.0.1",
     "sucrase": "^3.35.1",
     "tailwind-merge": "^3.5.0",
-    "three": "^0.183.2"
+    "three": "^0.183.2",
+    "zod": "^4.3.6"
   },
   "devDependencies": {
     "@axe-core/playwright": "^4.10.0",

--- a/web/src/components/cards/workload-monitor/GitHubCIMonitor.tsx
+++ b/web/src/components/cards/workload-monitor/GitHubCIMonitor.tsx
@@ -13,6 +13,8 @@ import { useCardLoadingState } from '../CardDataContext'
 import { useCache } from '../../../lib/cache'
 import type { SortDirection } from '../../../lib/cards/cardHooks'
 import { useMissions } from '../../../hooks/useMissions'
+import { GitHubWorkflowRunsResponseSchema } from '../../../lib/schemas'
+import { validateResponse } from '../../../lib/schemas/validate'
 import { cn } from '../../../lib/cn'
 import { WorkloadMonitorAlerts } from './WorkloadMonitorAlerts'
 import type { MonitorIssue } from '../../../types/workloadMonitor'
@@ -131,7 +133,8 @@ export function GitHubCIMonitor({ config, ref }: GitHubCIMonitorProps & { ref?: 
           if (!response.ok) continue // Skip this repo on other errors
           // Use .catch() directly to prevent Firefox from firing unhandledrejection
           // before the outer try/catch processes the rejection (Firefox-specific timing issue).
-          const data = await response.json().catch(() => null) as { workflow_runs?: Record<string, unknown>[] } | null
+          const rawGH = await response.json().catch(() => null)
+          const data = validateResponse(GitHubWorkflowRunsResponseSchema, rawGH, `/api/github/repos/${repo}/actions/runs`)
           if (!data) continue
           const prFromCommit = /\(#(\d+)\)\s*$/
           const runs = (data.workflow_runs || []).map((run: Record<string, unknown>) => {

--- a/web/src/hooks/useCachedData.ts
+++ b/web/src/hooks/useCachedData.ts
@@ -61,6 +61,8 @@ import type {
 import type { Workload } from './useWorkloads'
 import { fetchProwJobs } from './useCachedProw'
 import { fetchLLMdServers, fetchLLMdModels } from './useCachedLLMd'
+import { SecurityIssuesResponseSchema } from '../lib/schemas'
+import { validateResponse } from '../lib/schemas/validate'
 
 // ============================================================================
 // API Fetchers
@@ -1265,7 +1267,8 @@ export function useCachedSecurityIssues(
               Authorization: `Bearer ${token}` },
             signal: AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS) })
           if (response.ok) {
-            const data = await response.json().catch(() => null) as { issues: SecurityIssue[] } | null
+            const rawSecurity = await response.json().catch(() => null)
+            const data = validateResponse(SecurityIssuesResponseSchema, rawSecurity, '/security-issues')
             if (data?.issues && data.issues.length > 0) return data.issues
           }
         } catch (err) {
@@ -1674,7 +1677,8 @@ export const coreFetchers = {
           Authorization: `Bearer ${token}` },
         signal: AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS) })
       if (response.ok) {
-        const data = await response.json().catch(() => null) as { issues: SecurityIssue[] } | null
+        const rawSecurity = await response.json().catch(() => null)
+        const data = validateResponse(SecurityIssuesResponseSchema, rawSecurity, '/security-issues (fallback)')
         if (data && data.issues && data.issues.length > 0) return data.issues
       }
     }

--- a/web/src/lib/auth.tsx
+++ b/web/src/lib/auth.tsx
@@ -8,6 +8,8 @@ import { clearClusterCacheOnLogout } from '../hooks/mcp/shared'
 import { STORAGE_KEY_TOKEN, DEMO_TOKEN_VALUE, STORAGE_KEY_DEMO_MODE, STORAGE_KEY_ONBOARDED, STORAGE_KEY_USER_CACHE, STORAGE_KEY_HAS_SESSION, FETCH_DEFAULT_TIMEOUT_MS } from './constants'
 import { emitLogin, emitLogout, setAnalyticsUserId, setAnalyticsUserProperties, emitConversionStep, emitDeveloperSession } from './analytics'
 import { setDemoMode as setGlobalDemoMode } from './demoMode'
+import { AuthRefreshResponseSchema, UserSchema } from './schemas'
+import { validateResponse } from './schemas/validate'
 
 interface User {
   id: string
@@ -302,7 +304,8 @@ export function AuthProvider({ children }: { children: ReactNode }) {
             // we cannot read the token from JS — but the JWTAuth middleware
             // accepts the cookie on subsequent requests, so we can call
             // /api/me directly via cookie credentials to populate the user.
-            const data = await refreshResponse.json().catch(() => null) as { refreshed?: boolean } | null
+            const rawRefresh = await refreshResponse.json().catch(() => null)
+            const data = validateResponse(AuthRefreshResponseSchema, rawRefresh, '/auth/refresh')
             if (data?.refreshed) {
               try {
                 localStorage.setItem(STORAGE_KEY_HAS_SESSION, 'true')
@@ -314,7 +317,8 @@ export function AuthProvider({ children }: { children: ReactNode }) {
                 signal: AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS),
               })
               if (meResponse.ok) {
-                const userData = await meResponse.json().catch(() => null) as User | null
+                const rawUser = await meResponse.json().catch(() => null)
+                const userData = validateResponse(UserSchema, rawUser, '/api/me') as User | null
                 if (userData) {
                   setUser(userData)
                   cacheUser(userData)
@@ -400,7 +404,8 @@ export function AuthProvider({ children }: { children: ReactNode }) {
         headers: { Authorization: `Bearer ${effectiveToken}` },
         signal: AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS) })
       if (!meResponse.ok) throw new Error(`/api/me returned ${meResponse.status}`)
-      const userData = await meResponse.json().catch(() => null) as User | null
+      const rawMe = await meResponse.json().catch(() => null)
+      const userData = validateResponse(UserSchema, rawMe, '/api/me') as User | null
       if (!userData) throw new Error('Invalid JSON from /api/me')
       // #6149 — Avoid triggering an AuthProvider re-render cascade when the
       // background /api/me poll returns an identical user. Shallow-compare

--- a/web/src/lib/schemas/auth.ts
+++ b/web/src/lib/schemas/auth.ts
@@ -1,0 +1,27 @@
+/**
+ * Zod schemas for auth-related API responses.
+ *
+ * These provide runtime validation for endpoints where the frontend
+ * previously used unsafe `as { ... } | null` type assertions.
+ */
+import { z } from 'zod'
+
+/** POST /auth/refresh — body carries { refreshed, onboarded }. */
+export const AuthRefreshResponseSchema = z.object({
+  refreshed: z.boolean().optional(),
+  onboarded: z.boolean().optional(),
+})
+export type AuthRefreshResponse = z.infer<typeof AuthRefreshResponseSchema>
+
+/** GET /api/me — current authenticated user. */
+export const UserSchema = z.object({
+  id: z.string(),
+  github_id: z.string(),
+  github_login: z.string(),
+  email: z.string().optional(),
+  slack_id: z.string().optional(),
+  avatar_url: z.string().optional(),
+  role: z.enum(['admin', 'editor', 'viewer']).optional(),
+  onboarded: z.boolean(),
+})
+export type User = z.infer<typeof UserSchema>

--- a/web/src/lib/schemas/github.ts
+++ b/web/src/lib/schemas/github.ts
@@ -1,0 +1,33 @@
+/**
+ * Zod schemas for GitHub Actions API responses.
+ *
+ * Covers the workflow-runs endpoint consumed by GitHubCIMonitor.tsx.
+ * We intentionally use `.passthrough()` on the run object because the
+ * GitHub API returns many fields we don't need to enumerate — we only
+ * validate the structural shape the component relies on.
+ */
+import { z } from 'zod'
+
+/** A single workflow run from the GitHub Actions API. */
+export const GitHubWorkflowRunSchema = z.object({
+  id: z.number().optional(),
+  name: z.string().optional(),
+  status: z.string().optional(),
+  conclusion: z.string().nullable().optional(),
+  html_url: z.string().optional(),
+  head_branch: z.string().optional(),
+  event: z.string().optional(),
+  pull_requests: z.array(z.object({
+    number: z.number(),
+    url: z.string(),
+  })).optional(),
+  head_commit: z.object({
+    message: z.string().optional(),
+  }).nullable().optional(),
+}).passthrough()
+
+/** Response from /actions/runs endpoint. */
+export const GitHubWorkflowRunsResponseSchema = z.object({
+  workflow_runs: z.array(GitHubWorkflowRunSchema).optional(),
+})
+export type GitHubWorkflowRunsResponse = z.infer<typeof GitHubWorkflowRunsResponseSchema>

--- a/web/src/lib/schemas/index.ts
+++ b/web/src/lib/schemas/index.ts
@@ -1,0 +1,12 @@
+/**
+ * Centralized Zod schema exports for runtime API response validation.
+ *
+ * Only high-risk endpoints are covered — auth, security, and external APIs
+ * where type assertions previously bypassed safety.
+ */
+export { AuthRefreshResponseSchema, UserSchema } from './auth'
+export type { AuthRefreshResponse, User } from './auth'
+export { SecurityIssueSchema, SecurityIssuesResponseSchema } from './security'
+export type { SecurityIssuesResponse } from './security'
+export { GitHubWorkflowRunSchema, GitHubWorkflowRunsResponseSchema } from './github'
+export type { GitHubWorkflowRunsResponse } from './github'

--- a/web/src/lib/schemas/security.ts
+++ b/web/src/lib/schemas/security.ts
@@ -1,0 +1,20 @@
+/**
+ * Zod schemas for security-related API responses.
+ *
+ * Covers the /security-issues endpoint consumed by useCachedData.ts.
+ */
+import { z } from 'zod'
+
+export const SecurityIssueSchema = z.object({
+  name: z.string(),
+  namespace: z.string(),
+  cluster: z.string().optional(),
+  issue: z.string(),
+  severity: z.enum(['high', 'medium', 'low']),
+  details: z.string().optional(),
+})
+
+export const SecurityIssuesResponseSchema = z.object({
+  issues: z.array(SecurityIssueSchema),
+})
+export type SecurityIssuesResponse = z.infer<typeof SecurityIssuesResponseSchema>

--- a/web/src/lib/schemas/validate.ts
+++ b/web/src/lib/schemas/validate.ts
@@ -1,0 +1,51 @@
+/**
+ * Runtime validation utilities for API responses using Zod.
+ *
+ * These helpers wrap `.safeParse()` so that validation failures log a
+ * warning instead of crashing. This is intentional: we want to know
+ * when the backend contract drifts, but we don't want a schema mismatch
+ * to hard-crash the UI for users.
+ */
+import type { ZodType, ZodError } from 'zod'
+
+/** Maximum number of Zod issues to log per validation failure. */
+const MAX_LOGGED_ISSUES = 5
+
+/**
+ * Validate `data` against a Zod schema. On success, returns the parsed
+ * (and potentially coerced) value. On failure, logs a warning with the
+ * endpoint label and returns `null`.
+ *
+ * @param schema  Zod schema to validate against
+ * @param data    Raw data from `response.json()`
+ * @param label   Human-readable label for log messages (e.g. "/auth/refresh")
+ */
+export function validateResponse<T>(
+  schema: ZodType<T>,
+  data: unknown,
+  label: string,
+): T | null {
+  const result = schema.safeParse(data)
+  if (result.success) {
+    return result.data
+  }
+  logValidationWarning(label, result.error)
+  return null
+}
+
+/**
+ * Log a structured warning for a validation failure.
+ * Limits the number of issues logged to avoid flooding the console.
+ */
+function logValidationWarning(label: string, error: ZodError): void {
+  const issues = error.issues.slice(0, MAX_LOGGED_ISSUES)
+  const summary = issues.map(
+    (i) => `  path: ${i.path.join('.')}, code: ${i.code}, message: ${i.message}`,
+  ).join('\n')
+  const truncated = error.issues.length > MAX_LOGGED_ISSUES
+    ? `\n  ... and ${error.issues.length - MAX_LOGGED_ISSUES} more issues`
+    : ''
+  console.warn(
+    `[Zod] API response validation failed for "${label}":\n${summary}${truncated}`,
+  )
+}


### PR DESCRIPTION
## Summary
- Add `zod` dependency for runtime type validation
- Create `web/src/lib/schemas/` with Zod schemas for auth, security, and GitHub API responses
- Replace 4 unsafe `as { ... } | null` type assertions with `safeParse()` validation
- Add reusable `validateResponse()` wrapper that logs warnings on contract drift instead of crashing

**Validated endpoints:**
- `/auth/refresh` — auth refresh response shape
- `/api/me` — user profile response (2 call sites)
- `/security-issues` — security issues response (2 call sites in useCachedData.ts)
- GitHub Actions `/actions/runs` — workflow runs response (GitHubCIMonitor.tsx)

Fixes #8705

## Test plan
- [ ] Auth refresh still works (validated response)
- [ ] Login/logout flow unaffected
- [ ] GitHub CI monitor renders correctly
- [ ] Invalid API responses are caught and logged gracefully (check console for `[Zod]` warnings)
- [ ] Build passes (`npm run build`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)