### PR TITLE
fix: address 6 Copilot review comments on CI/CD stat blocks

### DIFF
--- a/web/src/components/cards/pipelines/PipelineDataContext.tsx
+++ b/web/src/components/cards/pipelines/PipelineDataContext.tsx
@@ -51,6 +51,7 @@ export function PipelineDataProvider({
     isRefreshing,
     error,
     isFailed,
+    isDemoFallback,
     lastRefresh,
     refetch,
   } = useUnifiedPipelineData(repo, days)
@@ -65,10 +66,11 @@ export function PipelineDataProvider({
       isRefreshing,
       error,
       isFailed,
+      isDemoFallback: isDemoFallback && !isLoading,
       lastRefresh,
       refetch,
     }),
-    [data, isLoading, isRefreshing, error, isFailed, lastRefresh, refetch],
+    [data, isLoading, isRefreshing, error, isFailed, isDemoFallback, lastRefresh, refetch],
   )
 
   return (

--- a/web/src/components/cicd/CICD.tsx
+++ b/web/src/components/cicd/CICD.tsx
@@ -2,6 +2,7 @@ import { DashboardPage } from '../../lib/dashboards/DashboardPage'
 import { getDefaultCards } from '../../config/dashboards'
 import { RotatingTip } from '../ui/RotatingTip'
 import { PipelineFilterProvider, PipelineDataProvider, PipelineFilterBar } from '../cards/pipelines'
+import { usePipelineFilter } from '../cards/pipelines/PipelineFilterContext'
 import { useCICDStats } from './useCICDStats'
 
 const CICD_CARDS_KEY = 'kubestellar-cicd-cards'
@@ -14,7 +15,15 @@ const DEFAULT_CICD_CARDS = getDefaultCards('ci-cd')
  * consume the unified pipeline data for stat calculations.
  */
 function CICDDashboard() {
-  const { getStatValue, isLoading } = useCICDStats()
+  const {
+    getStatValue,
+    isLoading,
+    isRefreshing,
+    isDemoData,
+    error,
+    lastRefresh,
+    refetch,
+  } = useCICDStats()
 
   return (
     <DashboardPage
@@ -28,6 +37,11 @@ function CICDDashboard() {
       statsType="ci-cd"
       getStatValue={getStatValue}
       isLoading={isLoading}
+      isRefreshing={isRefreshing}
+      isDemoData={isDemoData}
+      error={error}
+      lastUpdated={lastRefresh != null ? new Date(lastRefresh) : null}
+      onRefresh={refetch ?? undefined}
       emptyState={{
         title: 'CI/CD Dashboard',
         description: 'Add cards to monitor pipelines, builds, and deployment status across your clusters.' }}
@@ -35,12 +49,27 @@ function CICDDashboard() {
   )
 }
 
+/**
+ * Bridges PipelineFilterContext → PipelineDataProvider so the unified
+ * fetch respects the dashboard-level repo filter.
+ */
+function CICDDataBridge({ children }: { children: React.ReactNode }) {
+  const filterState = usePipelineFilter()
+  const repoFilter = filterState?.repoFilter ?? null
+
+  return (
+    <PipelineDataProvider repo={repoFilter}>
+      {children}
+    </PipelineDataProvider>
+  )
+}
+
 export function CICD() {
   return (
     <PipelineFilterProvider>
-    <PipelineDataProvider>
-      <CICDDashboard />
-    </PipelineDataProvider>
+      <CICDDataBridge>
+        <CICDDashboard />
+      </CICDDataBridge>
     </PipelineFilterProvider>
   )
 }

--- a/web/src/components/cicd/useCICDStats.ts
+++ b/web/src/components/cicd/useCICDStats.ts
@@ -11,9 +11,6 @@ import type { StatBlockValue } from '../ui/StatsOverview'
 import { usePipelineData } from '../cards/pipelines/PipelineDataContext'
 import type { Conclusion, FlowRun } from '../../hooks/useGitHubPipelines'
 
-/** Number of days used for the pass-rate calculation window */
-const PASS_RATE_WINDOW_DAYS = 14
-
 /** Milliseconds in 24 hours — used to filter recent failures */
 const MS_PER_24H = 24 * 60 * 60 * 1000
 
@@ -27,6 +24,9 @@ const PASS_RATE_MAX = 100
 /** Milliseconds per minute — used for duration formatting */
 const MS_PER_MINUTE = 60_000
 
+/** Minutes per hour — used for duration formatting */
+const MINUTES_PER_HOUR = 60
+
 /** Whether a conclusion counts as a "pass" */
 function isPassing(c: Conclusion): boolean {
   return c === 'success' || c === 'skipped' || c === 'neutral'
@@ -36,13 +36,24 @@ function isPassing(c: Conclusion): boolean {
 function formatDuration(ms: number): string {
   const minutes = Math.round(ms / MS_PER_MINUTE)
   if (minutes < 1) return '<1m'
-  if (minutes < 60) return `${minutes}m` // eslint-disable-line @typescript-eslint/no-magic-numbers
-  const hours = Math.floor(minutes / 60) // eslint-disable-line @typescript-eslint/no-magic-numbers
-  const remainder = minutes % 60 // eslint-disable-line @typescript-eslint/no-magic-numbers
+  if (minutes < MINUTES_PER_HOUR) return `${minutes}m`
+  const hours = Math.floor(minutes / MINUTES_PER_HOUR)
+  const remainder = minutes % MINUTES_PER_HOUR
   return remainder > 0 ? `${hours}h ${remainder}m` : `${hours}h`
 }
 
-export function useCICDStats() {
+/** Return shape for useCICDStats — callers use these to drive DashboardPage lifecycle */
+export interface CICDStatsResult {
+  getStatValue: (blockId: string) => StatBlockValue
+  isLoading: boolean
+  isRefreshing: boolean
+  isDemoData: boolean
+  error: string | null
+  lastRefresh: number | null
+  refetch: (() => Promise<void>) | null
+}
+
+export function useCICDStats(): CICDStatsResult {
   const pipelineData = usePipelineData()
 
   // Memoize computed values from pipeline data
@@ -59,12 +70,13 @@ export function useCICDStats() {
         totalWorkflows: 0,
         openPRs: 0,
         isDemo: true,
+        matrixDays: 0,
       }
     }
 
     const { matrix, pulse, failures, flow } = pipelineData
 
-    // --- Pass Rate (14-day window from matrix) ---
+    // --- Pass Rate (window from matrix.days) ---
     let totalCells = 0
     let passingCells = 0
     for (const wf of (matrix?.workflows || [])) {
@@ -120,10 +132,9 @@ export function useCICDStats() {
     }
     const openPRs = prNumbers.size
 
-    // Check if data is demo (all from demo fixtures)
-    const isDemo = pipelineData.isFailed || (
-      totalCells === 0 && completedRuns.length === 0 && streak === 0
-    )
+    // Use the context's isDemoFallback for accurate demo detection —
+    // a real repo with no recent activity should NOT be flagged as demo.
+    const isDemo = pipelineData.isDemoFallback
 
     return {
       passRate,
@@ -136,6 +147,7 @@ export function useCICDStats() {
       totalWorkflows,
       openPRs,
       isDemo,
+      matrixDays: matrix?.days ?? 0,
     }
   }, [pipelineData])
 
@@ -149,7 +161,9 @@ export function useCICDStats() {
             : 'Critical'
         return {
           value: computed.passRate,
-          sublabel: `${sublabel} (${PASS_RATE_WINDOW_DAYS}d)`,
+          sublabel: computed.matrixDays > 0
+            ? `${sublabel} (${computed.matrixDays}d)`
+            : sublabel,
           max: PASS_RATE_MAX,
           isDemo: computed.isDemo,
           modeHints: ['ring', 'gauge', 'horseshoe', 'numeric'],
@@ -183,7 +197,6 @@ export function useCICDStats() {
       }
 
       case 'cicd_streak': {
-        const prefix = computed.streakKind === 'success' ? '' : ''
         const label = computed.streakKind === 'success'
           ? `${computed.streak} passing`
           : computed.streakKind === 'failure'
@@ -191,7 +204,7 @@ export function useCICDStats() {
             : 'mixed'
         return {
           value: computed.streak,
-          sublabel: `${prefix}${label}`,
+          sublabel: label,
           isDemo: computed.isDemo,
         }
       }
@@ -208,5 +221,13 @@ export function useCICDStats() {
     }
   }, [computed])
 
-  return { getStatValue, isLoading: pipelineData?.isLoading ?? false }
+  return {
+    getStatValue,
+    isLoading: pipelineData?.isLoading ?? false,
+    isRefreshing: pipelineData?.isRefreshing ?? false,
+    isDemoData: computed.isDemo,
+    error: pipelineData?.error ?? null,
+    lastRefresh: pipelineData?.lastRefresh ?? null,
+    refetch: pipelineData?.refetch ?? null,
+  }
 }

--- a/web/src/hooks/useGitHubPipelines.ts
+++ b/web/src/hooks/useGitHubPipelines.ts
@@ -352,6 +352,7 @@ export interface UnifiedPipelineData {
   isRefreshing: boolean
   error: string | null
   isFailed: boolean
+  isDemoFallback: boolean
   lastRefresh: number | null
   refetch: () => Promise<void>
 }


### PR DESCRIPTION
## Summary

Fixes #8736

Addresses all 6 Copilot review comments from PR #8733 (CI/CD stat blocks):

1. **isDemo detection** (`useCICDStats.ts:126`): Replaced fragile heuristic (`no cells + no completed runs + streak=0`) with `isDemoFallback` from the cache layer. A real repo with no recent activity is no longer misidentified as demo data.

2. **Pass-rate sublabel** (`useCICDStats.ts:153`): Now uses `matrix.days` (the actual window from the API response) instead of the hardcoded `PASS_RATE_WINDOW_DAYS` constant.

3. **Streak prefix dead code** (`useCICDStats.ts:194`): Removed the always-empty `prefix` variable (`'' : ''` ternary). The sublabel is now built directly without the dead code path.

4. **Missing lifecycle fields** (`useCICDStats.ts:211`): `useCICDStats()` now returns `isRefreshing`, `isDemoData`, `error`, `lastRefresh`, and `refetch` so callers can properly drive `DashboardPage` lifecycle.

5. **Repo filter not threaded** (`CICD.tsx:44`): Added `CICDDataBridge` component that reads `repoFilter` from `PipelineFilterContext` and passes it as the `repo` prop to `PipelineDataProvider`. The unified `view=all` fetch now respects the selected repo filter.

6. **Missing DashboardPage lifecycle props** (`CICD.tsx:34`): `CICDDashboard` now wires `onRefresh`, `isRefreshing`, `lastUpdated`, `error`, and `isDemoData` from `useCICDStats` into `DashboardPage`.

Additionally threaded `isDemoFallback` through `UnifiedPipelineData` and `PipelineDataContext` so the demo signal flows from the cache layer to consumers.

## Test plan

- [ ] CI/CD dashboard loads with correct stats (pass rate, streak, etc.)
- [ ] Repo filter pills change the data shown in stat blocks
- [ ] Demo badge and yellow outline appear when in demo/fallback mode
- [ ] Refresh icon animates during background refresh
- [ ] Last-updated timestamp updates after each fetch cycle
- [ ] `npm run build` passes