### PR TITLE
fix: batch UI fixes — sidebar border, configurator overflow, mission icons, profile dropdown

### DIFF
--- a/web/src/components/cards/llmd/LLMdConfigurator.tsx
+++ b/web/src/components/cards/llmd/LLMdConfigurator.tsx
@@ -38,7 +38,7 @@ function PresetCard({ preset, isSelected, onSelect }: PresetCardProps) {
 
   return (
     <motion.div
-      className={`${colors.bg} ${colors.border} border rounded-lg p-3 cursor-pointer transition-all ${
+      className={`${colors.bg} ${colors.border} border rounded-lg p-3 cursor-pointer transition-all min-w-0 overflow-hidden ${
         isSelected ? 'ring-2 ring-white/30' : 'hover:border-white/20'
       }`}
       onClick={onSelect}

--- a/web/src/components/layout/Sidebar.tsx
+++ b/web/src/components/layout/Sidebar.tsx
@@ -601,7 +601,7 @@ export function Sidebar() {
       {/* Collapse + Pin controls — top-right of sidebar, above resize handle */}
       {!isMobile && !isMissionFullScreen && (
         <div
-          className="fixed top-[4.5rem] z-sticky flex flex-col gap-1.5 items-center transition-[left] duration-300"
+          className="fixed top-[4.5rem] z-sticky flex flex-col gap-1.5 items-center transition-[left] duration-300 bg-background rounded-full p-1"
           style={{ left: sidebarWidth + 4 }}
         >
           <button

--- a/web/src/components/layout/UserProfileDropdown.tsx
+++ b/web/src/components/layout/UserProfileDropdown.tsx
@@ -151,7 +151,7 @@ export function UserProfileDropdown({ user, onLogout, onPreferences }: UserProfi
 
       {/* Dropdown menu */}
       {isOpen && (
-        <div id="profile-dropdown-menu" role="menu" className="absolute right-0 top-full mt-2 w-72 max-w-[calc(100vw-1rem)] bg-card border border-border rounded-xl shadow-2xl overflow-hidden z-toast">
+        <div id="profile-dropdown-menu" role="menu" className="absolute right-0 top-full mt-2 w-72 max-w-[calc(100vw-1rem)] max-h-[calc(100vh-5rem)] bg-card border border-border rounded-xl shadow-2xl overflow-hidden overflow-y-auto z-toast">
           {/* Header with avatar and name */}
           <div className="p-4 bg-secondary border-b border-border">
             <div className="flex items-center gap-3">

--- a/web/src/components/layout/mission-sidebar/MissionSidebar.tsx
+++ b/web/src/components/layout/mission-sidebar/MissionSidebar.tsx
@@ -931,7 +931,7 @@ export function MissionSidebar() {
                 }}
                 className="flex flex-col items-center justify-center gap-1.5 px-3 py-3 text-sm font-medium bg-primary text-primary-foreground rounded-lg hover:bg-primary/90 transition-colors h-[72px]"
               >
-                <Sparkles className="w-5 h-5 flex-shrink-0" />
+                <Sparkles className="w-6 h-6 flex-shrink-0" />
                 <span className="text-center leading-tight text-xs truncate max-w-full">{t('missionSidebar.startCustomMission')}</span>
               </button>
             )}
@@ -939,14 +939,14 @@ export function MissionSidebar() {
               onClick={() => setShowBrowser(true)}
               className="flex flex-col items-center justify-center gap-1.5 px-3 py-3 text-sm font-medium bg-secondary text-foreground rounded-lg hover:bg-secondary/80 transition-colors h-[72px]"
             >
-              <Globe className="w-5 h-5 flex-shrink-0" />
+              <Globe className="w-6 h-6 flex-shrink-0" />
               <span className="text-center leading-tight text-xs truncate max-w-full">{t('layout.missionSidebar.browseCommunityMissions')}</span>
             </button>
             <button
               onClick={() => setShowMissionControl(true)}
               className="flex flex-col items-center justify-center gap-1.5 px-3 py-3 text-sm font-medium bg-gradient-to-r from-violet-600 to-indigo-600 text-white rounded-lg hover:from-violet-500 hover:to-indigo-500 transition-colors shadow-lg shadow-violet-500/25 h-[72px]"
             >
-              <Rocket className="w-5 h-5 flex-shrink-0" />
+              <Rocket className="w-6 h-6 flex-shrink-0" />
               <span className="text-center leading-tight text-xs truncate max-w-full">{t('layout.missionSidebar.missionControl')}</span>
             </button>
           </div>


### PR DESCRIPTION
## Summary
Fixes 4 UI bugs from the TODO list:

1. **Sidebar pin border bleed** — added `bg-background rounded-full p-1` to icon container
2. **Configurator text overflow** — added `min-w-0 overflow-hidden` to PresetCard
3. **Mission empty state icons** — increased from `w-5 h-5` to `w-6 h-6`
4. **Profile dropdown overflow** — added `max-h-[calc(100vh-5rem)] overflow-y-auto`

2 TODOs were already resolved (dynamic card crash, GitHub Activity magic number).

## Test plan
- [ ] Sidebar pin icons have solid background, no border bleed
- [ ] Configurator TTFT/Throughput truncates with mission panel open
- [ ] Mission empty state icons properly sized
- [ ] Profile dropdown scrolls on small viewports

🤖 Generated with [Claude Code](https://claude.com/claude-code)