### PR TITLE
fix: change default Helm pullPolicy to IfNotPresent

### DIFF
--- a/deploy/helm/kubestellar-console/values.yaml
+++ b/deploy/helm/kubestellar-console/values.yaml
@@ -2,7 +2,7 @@ replicaCount: 1
 
 image:
   repository: ghcr.io/kubestellar/console
-  pullPolicy: Always
+  pullPolicy: IfNotPresent
   tag: ""  # Defaults to chart appVersion ("latest"); overridden at release time
 
 imagePullSecrets: []


### PR DESCRIPTION
## Summary
- Changes the default image pull policy in `deploy/helm/kubestellar-console/values.yaml` from `Always` to `IfNotPresent`
- `IfNotPresent` is the Kubernetes-recommended default — it avoids unnecessary image pulls when the tag is already cached on the node, reducing startup latency and registry load

Fixes #8716