### PR TITLE
fix: remove redundant gap-y-2 and trailing spaces in card control bars

### DIFF
--- a/web/src/components/cards/ACMMFeedbackLoops.tsx
+++ b/web/src/components/cards/ACMMFeedbackLoops.tsx
@@ -371,7 +371,7 @@ export function ACMMFeedbackLoops() {
                 </span>
               </button>
               {isLocked && isLockPromptOpen && (
-                <div className="px-8 pb-2 pt-1 text-[10px] border-t border-border/30 flex flex-wrap items-center justify-between gap-y-2 gap-2 ">
+                <div className="px-8 pb-2 pt-1 text-[10px] border-t border-border/30 flex flex-wrap items-center justify-between gap-2">
                   <span className="text-muted-foreground">
                     Locked — reach <span className="font-mono text-foreground">L{nextLevel}</span> first
                     {missingForNext > 0 && (

--- a/web/src/components/cards/Checkers.tsx
+++ b/web/src/components/cards/Checkers.tsx
@@ -692,7 +692,7 @@ export function Checkers(_props: CardComponentProps) {
   return (
     <div className="h-full flex flex-col p-2 select-none">
       {/* Header */}
-      <div className="flex flex-wrap items-center justify-between gap-y-2 gap-2 mb-2 ">
+      <div className="flex flex-wrap items-center justify-between gap-2 mb-2">
         <div className="flex items-center gap-2 text-xs text-muted-foreground">
           <span className="flex items-center gap-1">
             <Box className="w-3 h-3 text-blue-400" />

--- a/web/src/components/cards/ContainerTetris.tsx
+++ b/web/src/components/cards/ContainerTetris.tsx
@@ -349,7 +349,7 @@ function ContainerTetrisInternal(_props: CardComponentProps) {
   return (
     <div ref={gameContainerRef} className="h-full flex flex-col p-2 select-none">
       {/* Header */}
-      <div className="flex flex-wrap items-center justify-between gap-y-2 gap-2 mb-2 ">
+      <div className="flex flex-wrap items-center justify-between gap-2 mb-2">
         <div className="flex items-center gap-3 text-xs">
           <div className="text-center">
             <div className="text-muted-foreground">Score</div>

--- a/web/src/components/cards/FlappyPod.tsx
+++ b/web/src/components/cards/FlappyPod.tsx
@@ -234,7 +234,7 @@ export function FlappyPod(_props: CardComponentProps) {
   return (
     <div ref={gameContainerRef} className="h-full flex flex-col p-2 select-none">
       {/* Header */}
-      <div className="flex flex-wrap items-center justify-between gap-y-2 gap-2 mb-2 ">
+      <div className="flex flex-wrap items-center justify-between gap-2 mb-2">
         <div className="flex items-center gap-3 text-xs">
           <div className="text-center">
             <div className="text-muted-foreground">Score</div>

--- a/web/src/components/cards/Game2048.tsx
+++ b/web/src/components/cards/Game2048.tsx
@@ -301,7 +301,7 @@ export function Game2048(_props: CardComponentProps) {
   return (
     <div ref={gameContainerRef} className="h-full flex flex-col p-2 select-none">
       {/* Header */}
-      <div className="flex flex-wrap items-center justify-between gap-y-2 gap-2 mb-2 ">
+      <div className="flex flex-wrap items-center justify-between gap-2 mb-2">
         <div className="flex items-center gap-3 text-xs">
           <div className="text-center">
             <div className="text-muted-foreground">Score</div>

--- a/web/src/components/cards/IssueActivityChart.tsx
+++ b/web/src/components/cards/IssueActivityChart.tsx
@@ -469,7 +469,7 @@ export function IssueActivityChart(props: { config?: IssueActivityConfig }) {
   return (
     <div className="p-4 space-y-3">
       {/* Header */}
-      <div className="flex flex-wrap items-center justify-between gap-y-2  gap-2">
+      <div className="flex flex-wrap items-center justify-between gap-2">
         <div className="flex items-center gap-2">
           <Calendar className="h-4 w-4 text-muted-foreground" />
           <RepoSubtitle repo={repo} />

--- a/web/src/components/cards/KubeKong.tsx
+++ b/web/src/components/cards/KubeKong.tsx
@@ -672,7 +672,7 @@ export function KubeKong(_props: CardComponentProps) {
 
   return (
     <div ref={gameContainerRef} className="h-full flex flex-col p-2 select-none">
-      <div className="flex flex-wrap items-center justify-between gap-y-2 gap-2 mb-2 ">
+      <div className="flex flex-wrap items-center justify-between gap-2 mb-2">
         <div className="flex items-center gap-3 text-xs">
           <div className="text-center">
             <div className="text-muted-foreground">Score</div>

--- a/web/src/components/cards/KubeMan.tsx
+++ b/web/src/components/cards/KubeMan.tsx
@@ -601,7 +601,7 @@ export function KubeMan(_props: CardComponentProps) {
   return (
     <div ref={gameContainerRef} className="h-full flex flex-col p-2 select-none">
       {/* Header */}
-      <div className="flex flex-wrap items-center justify-between gap-y-2 gap-2 mb-2 ">
+      <div className="flex flex-wrap items-center justify-between gap-2 mb-2">
         <div className="flex items-center gap-3 text-xs">
           <div className="text-center">
             <div className="text-muted-foreground">Score</div>

--- a/web/src/components/cards/MatchGame.tsx
+++ b/web/src/components/cards/MatchGame.tsx
@@ -291,7 +291,7 @@ export function MatchGame(_props: CardComponentProps) {
       />
 
       {/* Header with controls */}
-      <div className="flex flex-wrap items-center justify-between gap-y-2 gap-2 ">
+      <div className="flex flex-wrap items-center justify-between gap-2">
         {/* Difficulty selector */}
         <div className="flex gap-1">
           {(['easy', 'medium', 'hard'] as Difficulty[]).map(d => (
@@ -312,7 +312,7 @@ export function MatchGame(_props: CardComponentProps) {
 
       {/* Game stats */}
       {isPlaying && (
-        <div className="flex flex-wrap items-center justify-between gap-y-2 gap-2 text-xs">
+        <div className="flex flex-wrap items-center justify-between gap-2 text-xs">
           <div className="flex items-center gap-1.5">
             <Hash className="w-3.5 h-3.5 text-blue-400" />
             <span>Moves: <span className="font-bold">{moves}</span></span>

--- a/web/src/components/cards/MissileCommand.tsx
+++ b/web/src/components/cards/MissileCommand.tsx
@@ -505,7 +505,7 @@ export function MissileCommand(_props: CardComponentProps) {
   return (
     <div className="h-full flex flex-col p-2 select-none">
       {/* Header */}
-      <div className="flex flex-wrap items-center justify-between gap-y-2 gap-2 mb-2 ">
+      <div className="flex flex-wrap items-center justify-between gap-2 mb-2">
         <div className="flex items-center gap-1.5">
           <Crosshair className="w-4 h-4 text-red-400" />
           <span className="text-sm font-semibold">Missile Command</span>

--- a/web/src/components/cards/NodeInvaders.tsx
+++ b/web/src/components/cards/NodeInvaders.tsx
@@ -393,7 +393,7 @@ export function NodeInvaders(_props: CardComponentProps) {
 
   return (
     <div ref={gameContainerRef} className="h-full flex flex-col p-2 select-none">
-      <div className="flex flex-wrap items-center justify-between gap-y-2 gap-2 mb-2 ">
+      <div className="flex flex-wrap items-center justify-between gap-2 mb-2">
         <div className="flex items-center gap-1.5">
           <Rocket className="w-4 h-4 text-cyan-400" />
           <span className="text-sm font-semibold">Node Invaders</span>

--- a/web/src/components/cards/PodCrosser.tsx
+++ b/web/src/components/cards/PodCrosser.tsx
@@ -561,7 +561,7 @@ export function PodCrosser(_props: CardComponentProps) {
 
   return (
     <div ref={gameContainerRef} className="h-full flex flex-col p-2 select-none">
-      <div className="flex flex-wrap items-center justify-between gap-y-2 gap-2 mb-2 ">
+      <div className="flex flex-wrap items-center justify-between gap-2 mb-2">
         <div className="flex items-center gap-3 text-xs">
           <div className="text-center">
             <div className="text-muted-foreground">Score</div>

--- a/web/src/components/cards/PodPitfall.tsx
+++ b/web/src/components/cards/PodPitfall.tsx
@@ -540,7 +540,7 @@ export function PodPitfall(_props: CardComponentProps) {
 
   return (
     <div ref={gameContainerRef} className="h-full flex flex-col p-2 select-none">
-      <div className="flex flex-wrap items-center justify-between gap-y-2 gap-2 mb-2 ">
+      <div className="flex flex-wrap items-center justify-between gap-2 mb-2">
         <div className="flex items-center gap-3 text-xs">
           <div className="text-center">
             <div className="text-muted-foreground">Score</div>

--- a/web/src/components/cards/PodSweeper.tsx
+++ b/web/src/components/cards/PodSweeper.tsx
@@ -252,7 +252,7 @@ function PodSweeperInternal(_props: CardComponentProps) {
   return (
     <div className="h-full flex flex-col p-2 select-none">
       {/* Header */}
-      <div className="flex flex-wrap items-center justify-between gap-y-2 gap-2 mb-2 ">
+      <div className="flex flex-wrap items-center justify-between gap-2 mb-2">
         <div className="flex items-center gap-3 text-xs">
           <div className="flex items-center gap-1 text-red-400">
             <Flag className="w-3 h-3" />

--- a/web/src/components/cards/Solitaire.tsx
+++ b/web/src/components/cards/Solitaire.tsx
@@ -550,7 +550,7 @@ export function Solitaire(_props: CardComponentProps) {
   return (
     <div className="h-full flex flex-col p-2 select-none">
       {/* Header */}
-      <div className="flex flex-wrap items-center justify-between gap-y-2 gap-2 mb-2 ">
+      <div className="flex flex-wrap items-center justify-between gap-2 mb-2">
         <div className="flex items-center gap-2 text-xs text-muted-foreground">
           <span>Moves: {moves}</span>
           <span>Time: {formatTime(time)}</span>


### PR DESCRIPTION
## Summary
- Removed redundant `gap-y-2` from 15 card files where `gap-2` already sets both axes
- Removed trailing spaces before closing quotes in className strings
- Collapsed double-spaces between class names in className attributes

Fixes #8741

## Test plan
- [x] `npm run build` passes
- [ ] Visual inspection: card control bars render identically (no layout change expected since `gap-2` already covered both axes)