### PR TITLE
fix: update tests for useCachedData and useTopology after Zod validation

### DIFF
--- a/web/src/hooks/__tests__/useCachedData.test.ts
+++ b/web/src/hooks/__tests__/useCachedData.test.ts
@@ -2572,7 +2572,7 @@ describe('useCachedData', () => {
 
       mockAuthFetch.mockResolvedValue({
         ok: true,
-        json: vi.fn().mockResolvedValue({ issues: [{ name: 'rest-sec', issue: 'Priv', severity: 'high' }] }),
+        json: vi.fn().mockResolvedValue({ issues: [{ name: 'rest-sec', namespace: 'default', issue: 'Priv', severity: 'high' }] }),
       })
 
       const { useCachedSecurityIssues } = await loadModule()
@@ -3154,7 +3154,7 @@ describe('useCachedData', () => {
 
       mockAuthFetch.mockResolvedValue({
         ok: true,
-        json: vi.fn().mockResolvedValue({ issues: [{ name: 'sec1', issue: 'Priv', severity: 'high' }] }),
+        json: vi.fn().mockResolvedValue({ issues: [{ name: 'sec1', namespace: 'default', issue: 'Priv', severity: 'high' }] }),
       })
 
       const { coreFetchers } = await loadModule()
@@ -6114,7 +6114,7 @@ describe('useCachedData', () => {
       mockIsBackendUnavailable.mockReturnValue(false)
       mockAuthFetch.mockResolvedValue({
         ok: true,
-        json: vi.fn().mockResolvedValue({ issues: [{ name: 'rest-issue', severity: 'high' }] }),
+        json: vi.fn().mockResolvedValue({ issues: [{ name: 'rest-issue', namespace: 'default', severity: 'high', issue: 'Privilege escalation' }] }),
       })
       mockUseCache.mockReturnValue(makeCacheResult([]))
 

--- a/web/src/hooks/__tests__/useTopology.test.ts
+++ b/web/src/hooks/__tests__/useTopology.test.ts
@@ -145,10 +145,10 @@ describe('useTopology', () => {
     const { result } = renderHook(() => useTopology())
 
     await waitFor(() => {
-      expect(result.current.isDemoData).toBe(true)
+      expect(result.current.graph).not.toBeNull()
     })
 
-    expect(result.current.graph).not.toBeNull()
+    expect(result.current.isDemoData).toBe(true)
     expect(result.current.consecutiveFailures).toBe(1)
   })
 


### PR DESCRIPTION
## Summary
- Add missing `namespace` field to 3 security issue test mocks in `useCachedData.test.ts` — required by the `SecurityIssuesResponseSchema` Zod validation added in PR #8743
- Fix race condition in `useTopology.test.ts` network-error test — `isDemoData` initializes to `true` (no cache), so `waitFor(isDemoData === true)` resolved immediately before the fetch completed; changed to `waitFor(graph !== null)` which correctly waits for demo fallback data

## Test plan
- [x] All 3 security issue tests pass: `coreFetchers.securityIssues tries kubectl then REST`, `useCachedSecurityIssues fetcher: falls back to REST authFetch`, `falls through to REST when kubectl returns no issues`
- [x] Topology test passes: `falls back to demo data on network error when no prior data exists`
- [x] Full test suites pass for both files (334 tests in useCachedData, 12 in useTopology)
- [x] `npm run build` passes
- [x] `npm run lint` passes

Fixes #8749