### PR TITLE
fix: validate dashboard name to prevent empty/blank creation

### DIFF
--- a/web/src/components/dashboard/CreateDashboardModal.test.tsx
+++ b/web/src/components/dashboard/CreateDashboardModal.test.tsx
@@ -96,6 +96,36 @@ describe('CreateDashboardModal Component', () => {
     expect(screen.queryByRole('alert')).not.toBeInTheDocument()
   })
 
+  it('disables Create button when name is empty', () => {
+    vi.mocked(useDashboardHealth).mockReturnValue(mockHealthHealthy)
+    render(<CreateDashboardModal isOpen={true} onClose={vi.fn()} onCreate={vi.fn()} />)
+
+    const createBtn = screen.getByRole('button', { name: /title/i })
+    expect(createBtn).toBeDisabled()
+  })
+
+  it('enables Create button when name is non-empty', () => {
+    vi.mocked(useDashboardHealth).mockReturnValue(mockHealthHealthy)
+    render(<CreateDashboardModal isOpen={true} onClose={vi.fn()} onCreate={vi.fn()} />)
+
+    const input = screen.getByLabelText(/nameLabel/i)
+    fireEvent.change(input, { target: { value: 'My Dashboard' } })
+
+    const createBtn = screen.getByRole('button', { name: /title/i })
+    expect(createBtn).not.toBeDisabled()
+  })
+
+  it('disables Create button when name is only whitespace', () => {
+    vi.mocked(useDashboardHealth).mockReturnValue(mockHealthHealthy)
+    render(<CreateDashboardModal isOpen={true} onClose={vi.fn()} onCreate={vi.fn()} />)
+
+    const input = screen.getByLabelText(/nameLabel/i)
+    fireEvent.change(input, { target: { value: '   ' } })
+
+    const createBtn = screen.getByRole('button', { name: /title/i })
+    expect(createBtn).toBeDisabled()
+  })
+
   it('disables Create button while async onCreate is in progress', async () => {
     let resolveCreate!: () => void
     const asyncOnCreate = vi.fn(
@@ -104,6 +134,10 @@ describe('CreateDashboardModal Component', () => {
     const onClose = vi.fn()
     vi.mocked(useDashboardHealth).mockReturnValue(mockHealthHealthy)
     render(<CreateDashboardModal isOpen={true} onClose={onClose} onCreate={asyncOnCreate} />)
+
+    // Type a name first — Create button requires a non-empty name
+    const input = screen.getByLabelText(/nameLabel/i)
+    fireEvent.change(input, { target: { value: 'Test Dashboard' } })
 
     // Capture button by initial text before click
     const createBtn = screen.getByRole('button', { name: /title/i })
@@ -131,6 +165,10 @@ describe('CreateDashboardModal Component', () => {
     vi.mocked(useDashboardHealth).mockReturnValue(mockHealthHealthy)
     render(<CreateDashboardModal isOpen={true} onClose={onClose} onCreate={asyncOnCreate} />)
 
+    // Type a name first — Create button requires a non-empty name
+    const input = screen.getByLabelText(/nameLabel/i)
+    fireEvent.change(input, { target: { value: 'Test Dashboard' } })
+
     const createBtn = screen.getByRole('button', { name: /title/i })
     const cancelBtn = screen.getByRole('button', { name: /cancel/i })
     fireEvent.click(createBtn)
@@ -155,6 +193,10 @@ describe('CreateDashboardModal Component', () => {
     )
     vi.mocked(useDashboardHealth).mockReturnValue(mockHealthHealthy)
     render(<CreateDashboardModal isOpen={true} onClose={vi.fn()} onCreate={asyncOnCreate} />)
+
+    // Type a name first — Create button requires a non-empty name
+    const input = screen.getByLabelText(/nameLabel/i)
+    fireEvent.change(input, { target: { value: 'Test Dashboard' } })
 
     const createBtn = screen.getByRole('button', { name: /title/i })
     fireEvent.click(createBtn)

--- a/web/src/components/dashboard/CreateDashboardModal.tsx
+++ b/web/src/components/dashboard/CreateDashboardModal.tsx
@@ -80,12 +80,15 @@ function CreateDashboardModalInner({
     return defaultName
   }
 
+  const trimmedName = name.trim()
+  const isNameEmpty = trimmedName.length === 0
+  const isCreateDisabled = isCreating || isNameEmpty
+
   const handleCreate = async () => {
-    if (isCreating) return
+    if (isCreateDisabled) return
     setIsCreating(true)
     try {
-      const dashboardName = name.trim() || generateDefaultName()
-      await onCreate(dashboardName, selectedTemplate || undefined, description.trim() || undefined)
+      await onCreate(trimmedName, selectedTemplate || undefined, description.trim() || undefined)
       onClose()
     } finally {
       setIsCreating(false)
@@ -116,8 +119,13 @@ function CreateDashboardModalInner({
             onChange={(e) => setName(e.target.value)}
             onKeyDown={handleKeyDown}
             placeholder={generateDefaultName()}
-            className="w-full px-4 py-3 bg-secondary/30 border border-border rounded-lg text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-purple-500/50 focus:border-transparent"
+            className={`w-full px-4 py-3 bg-secondary/30 border rounded-lg text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-purple-500/50 focus:border-transparent ${
+              name.length > 0 && isNameEmpty ? 'border-destructive' : 'border-border'
+            }`}
           />
+          {name.length > 0 && isNameEmpty && (
+            <p className="mt-1 text-xs text-destructive">{t('dashboard.create.nameRequired')}</p>
+          )}
         </div>
 
         {/* Description input (optional) */}
@@ -260,7 +268,7 @@ function CreateDashboardModalInner({
       iconRight={isCreating ? undefined : <ChevronRight className="w-4 h-4" />}
       onClick={handleCreate}
       loading={isCreating}
-      disabled={isCreating}
+      disabled={isCreateDisabled}
     >
       {isCreating ? t('dashboard.create.creating') : t('dashboard.create.title', 'Create Dashboard')}
     </Button>

--- a/web/src/components/dashboard/__tests__/CreateDashboardModal.test.tsx
+++ b/web/src/components/dashboard/__tests__/CreateDashboardModal.test.tsx
@@ -160,8 +160,22 @@ describe('CreateDashboardModal', () => {
 
   // ── Name generation ─────────────────────────────────────────────────
 
-  it('generates a unique default name avoiding existing names', async () => {
+  it('disables Create button when name is empty', () => {
+    render(<CreateDashboardModal {...defaultProps} />)
+    const createBtn = screen.getByText('Create Dashboard', { selector: 'button' })
+    expect(createBtn).toBeDisabled()
+  })
+
+  it('disables Create button when name is only whitespace', async () => {
     const user = userEvent.setup()
+    render(<CreateDashboardModal {...defaultProps} />)
+    const nameInput = screen.getByPlaceholderText('Dashboard 1')
+    await user.type(nameInput, '   ')
+    const createBtn = screen.getByText('Create Dashboard', { selector: 'button' })
+    expect(createBtn).toBeDisabled()
+  })
+
+  it('uses placeholder as default name in input', () => {
     const onCreate = vi.fn().mockResolvedValue(undefined)
     render(
       <CreateDashboardModal
@@ -170,12 +184,9 @@ describe('CreateDashboardModal', () => {
         onCreate={onCreate}
       />
     )
-    // Click create without entering a name
-    const createBtn = screen.getByText('Create Dashboard', { selector: 'button' })
-    await user.click(createBtn)
-    await waitFor(() => {
-      expect(onCreate).toHaveBeenCalledWith('Dashboard 3', undefined, undefined)
-    })
+    // Placeholder should show the next available name
+    const nameInput = screen.getByPlaceholderText('Dashboard 3')
+    expect(nameInput).toBeInTheDocument()
   })
 
   // ── Template selection ──────────────────────────────────────────────
@@ -276,6 +287,10 @@ describe('CreateDashboardModal', () => {
     let resolveCreate: () => void = () => {}
     const onCreate = vi.fn().mockImplementation(() => new Promise<void>((r) => { resolveCreate = r }))
     render(<CreateDashboardModal {...defaultProps} onCreate={onCreate} />)
+
+    // Type a name first — Create button requires a non-empty name
+    const nameInput = screen.getByPlaceholderText('Dashboard 1')
+    await user.type(nameInput, 'Test Dashboard')
 
     const createBtn = screen.getByText('Create Dashboard', { selector: 'button' })
     await user.click(createBtn)

--- a/web/src/locales/en/common.json
+++ b/web/src/locales/en/common.json
@@ -887,7 +887,9 @@
       "preConfiguredCards_other": "{{count}} pre-configured cards",
       "selectByCategory": "Select a template by category:",
       "cards": "cards",
-      "creating": "Creating..."
+      "creating": "Creating...",
+      "nameRequired": "Dashboard name is required",
+      "descriptionCollection": "Name your dashboard and optionally start with a card collection."
     },
     "templates": {
       "title": "Dashboard Templates",


### PR DESCRIPTION
## Summary
- Adds input validation to the Create Dashboard modal requiring a non-empty, non-whitespace name
- Disables the Create button when the name field is empty or contains only whitespace
- Shows a validation error message when the user types only whitespace
- Blocks Enter key submission when name is invalid

Fixes #8757

## Test plan
- [ ] Open Create Dashboard modal with empty name field -- Create button should be disabled
- [ ] Type only spaces in the name field -- Create button stays disabled, error message appears
- [ ] Type a valid name -- Create button becomes enabled
- [ ] Pressing Enter with empty name does not create a dashboard
- [ ] Creating with a valid name works as before

Generated with [Claude Code](https://claude.com/claude-code)