### PR TITLE
fix: address Copilot review comments on FeatureRequestModal refactor

### DIFF
--- a/web/src/components/feedback/FeatureRequestModal.tsx
+++ b/web/src/components/feedback/FeatureRequestModal.tsx
@@ -157,13 +157,26 @@ export function FeatureRequestModal({ isOpen, onClose, initialTab, initialReques
     showToast('Draft deleted', 'success')
   }
 
+  /** Ref to track the success display timeout so it can be cleared on unmount */
+  const successTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  // Clear the success display timeout when the component unmounts
+  useEffect(() => {
+    return () => {
+      if (successTimeoutRef.current) {
+        clearTimeout(successTimeoutRef.current)
+      }
+    }
+  }, [])
+
   const handleSubmitSuccess = (result: SuccessState) => {
     setSuccess(result)
     if (editingDraftId) {
       deleteDraft(editingDraftId)
       setEditingDraftId(null)
     }
-    setTimeout(() => {
+    successTimeoutRef.current = setTimeout(() => {
+      successTimeoutRef.current = null
       setDescription('')
       setRequestType('bug')
       setTargetRepo('console')
@@ -343,6 +356,7 @@ export function FeatureRequestModal({ isOpen, onClose, initialTab, initialReques
             githubRewards={githubRewards}
             githubPoints={githubPoints}
             token={token}
+            showToast={showToast}
             onRefreshRequests={refreshRequests}
             onRefreshNotifications={refreshNotifications}
             onRefreshGitHub={handleRefreshGitHub}

--- a/web/src/components/feedback/FeedbackDialogs.tsx
+++ b/web/src/components/feedback/FeedbackDialogs.tsx
@@ -7,7 +7,7 @@ import { useTranslation } from 'react-i18next'
 import ReactMarkdown from 'react-markdown'
 import remarkGfm from 'remark-gfm'
 import remarkBreaks from 'remark-breaks'
-import { useRef } from 'react'
+import { useRef, useEffect } from 'react'
 
 // ── Discard / Save Draft confirmation dialog ──
 
@@ -265,10 +265,17 @@ interface ScreenshotPreviewOverlayProps {
 
 export function ScreenshotPreviewOverlay({ src, onClose }: ScreenshotPreviewOverlayProps) {
   const overlayRef = useRef<HTMLDivElement>(null)
+
+  // Auto-focus the overlay so it can receive keyboard events (e.g. Escape)
+  useEffect(() => {
+    overlayRef.current?.focus()
+  }, [])
+
   return (
     <div
       ref={overlayRef}
-      className="fixed inset-0 z-overlay flex items-center justify-center bg-black/60 backdrop-blur-sm"
+      tabIndex={-1}
+      className="fixed inset-0 z-overlay flex items-center justify-center bg-black/60 backdrop-blur-sm outline-none"
       onClick={(e) => {
         if (e.target === overlayRef.current) {
           onClose()

--- a/web/src/components/feedback/UpdatesTab.tsx
+++ b/web/src/components/feedback/UpdatesTab.tsx
@@ -44,6 +44,7 @@ interface UpdatesTabProps {
   } | null
   githubPoints: number
   token: string | null
+  showToast: (message: string, type: 'success' | 'error' | 'info') => void
   onRefreshRequests: () => void
   onRefreshNotifications: () => void
   onRefreshGitHub: () => void
@@ -68,6 +69,7 @@ export function UpdatesTab({
   githubRewards,
   githubPoints,
   token,
+  showToast,
   onRefreshRequests,
   onRefreshNotifications,
   onRefreshGitHub,
@@ -91,7 +93,9 @@ export function UpdatesTab({
       setActionError(null)
       await onRequestUpdate(requestId)
     } catch {
-      setActionError('Failed to request update')
+      const errorMsg = 'Failed to request update'
+      setActionError(errorMsg)
+      showToast(errorMsg, 'error')
     } finally {
       setActionLoading(null)
     }
@@ -104,7 +108,9 @@ export function UpdatesTab({
       await onCloseRequest(requestId)
       setConfirmClose(null)
     } catch {
-      setActionError('Failed to close request')
+      const errorMsg = 'Failed to close request'
+      setActionError(errorMsg)
+      showToast(errorMsg, 'error')
     } finally {
       setActionLoading(null)
     }
@@ -113,8 +119,12 @@ export function UpdatesTab({
   const handleCheckPreview = async (prNumber: number) => {
     setPreviewChecking(prNumber)
     try {
+      const headers: Record<string, string> = {}
+      if (token) {
+        headers.Authorization = `Bearer ${token}`
+      }
       const res = await fetch(`${BACKEND_DEFAULT_URL}/api/feedback/preview/${prNumber}`, {
-        headers: { Authorization: `Bearer ${token}` },
+        headers,
         signal: AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS),
       })
       if (res.ok) {


### PR DESCRIPTION
## Summary

Addresses all 5 Copilot review comments from PR #8754:

- **Toast notifications for errors**: `handleRequestUpdate` and `handleCloseRequest` in `UpdatesTab.tsx` now show toast notifications on failure (previously only set `actionError` state without user-visible feedback)
- **Null token guard**: `handleCheckPreview` no longer sends `Authorization: Bearer null` when token is null — the header is omitted entirely if no token is available
- **Timeout cleanup on unmount**: `handleSubmitSuccess` in `FeatureRequestModal.tsx` stores the setTimeout ref and clears it via `useEffect` cleanup to prevent state updates on unmounted components
- **Focusable overlay for Escape key**: `ScreenshotPreviewOverlay` in `FeedbackDialogs.tsx` now has `tabIndex={-1}` and auto-focuses on mount so the `onKeyDown` handler can receive Escape key events

## Test plan

- [ ] Submit a feature request with a failing backend — verify error toast appears
- [ ] Close a request with a failing backend — verify error toast appears
- [ ] Check preview with null token — verify no `Bearer null` in network request
- [ ] Open screenshot preview overlay — verify Escape key closes it
- [ ] Submit successfully and unmount modal quickly — verify no React warnings about state updates on unmounted component

Fixes #8756