### PR TITLE
fix: add a11y attrs and test coverage for dashboard name validation

### DIFF
--- a/web/src/components/dashboard/CreateDashboardModal.test.tsx
+++ b/web/src/components/dashboard/CreateDashboardModal.test.tsx
@@ -115,7 +115,7 @@ describe('CreateDashboardModal Component', () => {
     expect(createBtn).not.toBeDisabled()
   })
 
-  it('disables Create button when name is only whitespace', () => {
+  it('disables Create button when name is only whitespace and shows error', () => {
     vi.mocked(useDashboardHealth).mockReturnValue(mockHealthHealthy)
     render(<CreateDashboardModal isOpen={true} onClose={vi.fn()} onCreate={vi.fn()} />)
 
@@ -124,6 +124,14 @@ describe('CreateDashboardModal Component', () => {
 
     const createBtn = screen.getByRole('button', { name: /title/i })
     expect(createBtn).toBeDisabled()
+
+    // Error message should be rendered with role="alert"
+    const errorMsg = screen.getByRole('alert')
+    expect(errorMsg).toHaveTextContent('nameRequired')
+
+    // Input should have accessible error attributes
+    expect(input).toHaveAttribute('aria-invalid', 'true')
+    expect(input).toHaveAttribute('aria-describedby', 'create-dashboard-name-error')
   })
 
   it('disables Create button while async onCreate is in progress', async () => {

--- a/web/src/components/dashboard/CreateDashboardModal.tsx
+++ b/web/src/components/dashboard/CreateDashboardModal.tsx
@@ -83,6 +83,8 @@ function CreateDashboardModalInner({
   const trimmedName = name.trim()
   const isNameEmpty = trimmedName.length === 0
   const isCreateDisabled = isCreating || isNameEmpty
+  const showNameError = name.length > 0 && isNameEmpty
+  const NAME_ERROR_ID = 'create-dashboard-name-error'
 
   const handleCreate = async () => {
     if (isCreateDisabled) return
@@ -119,12 +121,14 @@ function CreateDashboardModalInner({
             onChange={(e) => setName(e.target.value)}
             onKeyDown={handleKeyDown}
             placeholder={generateDefaultName()}
+            aria-invalid={showNameError}
+            aria-describedby={showNameError ? NAME_ERROR_ID : undefined}
             className={`w-full px-4 py-3 bg-secondary/30 border rounded-lg text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-purple-500/50 focus:border-transparent ${
-              name.length > 0 && isNameEmpty ? 'border-destructive' : 'border-border'
+              showNameError ? 'border-destructive' : 'border-border'
             }`}
           />
-          {name.length > 0 && isNameEmpty && (
-            <p className="mt-1 text-xs text-destructive">{t('dashboard.create.nameRequired')}</p>
+          {showNameError && (
+            <p id={NAME_ERROR_ID} role="alert" className="mt-1 text-xs text-destructive">{t('dashboard.create.nameRequired')}</p>
           )}
         </div>
 

--- a/web/src/components/dashboard/__tests__/CreateDashboardModal.test.tsx
+++ b/web/src/components/dashboard/__tests__/CreateDashboardModal.test.tsx
@@ -28,6 +28,7 @@ vi.mock('react-i18next', () => ({
         'dashboard.create.cards': 'cards',
         'dashboard.create.creating': 'Creating...',
         'actions.cancel': 'Cancel',
+        'dashboard.create.nameRequired': 'Dashboard name is required',
       }
       if (key === 'dashboard.create.preConfiguredCards' && opts?.count) {
         return `${opts.count} pre-configured cards`
@@ -173,6 +174,14 @@ describe('CreateDashboardModal', () => {
     await user.type(nameInput, '   ')
     const createBtn = screen.getByText('Create Dashboard', { selector: 'button' })
     expect(createBtn).toBeDisabled()
+
+    // Error message should be rendered
+    const errorMsg = screen.getByRole('alert')
+    expect(errorMsg).toHaveTextContent('Dashboard name is required')
+
+    // Input should have accessible error attributes
+    expect(nameInput).toHaveAttribute('aria-invalid', 'true')
+    expect(nameInput).toHaveAttribute('aria-describedby', 'create-dashboard-name-error')
   })
 
   it('uses placeholder as default name in input', () => {


### PR DESCRIPTION
## Summary
- Add `aria-invalid`, `aria-describedby`, and `role="alert"` to the dashboard name validation error in `CreateDashboardModal.tsx` for screen reader accessibility
- Add error message text assertions to whitespace-name validation tests in both test files
- Add `aria-invalid` and `aria-describedby` attribute assertions to verify accessible error binding

Fixes #8760

## Test plan
- [x] `npm run build` passes
- [x] `npm run lint` — no new errors
- [x] All 436 dashboard tests pass (`npx vitest run src/components/dashboard`)
- [x] Whitespace-name tests now assert error message rendering and a11y attributes