### PR TITLE
feat: add Zod runtime validation for critical API responses

### DIFF
--- a/web/src/hooks/useCachedData.ts
+++ b/web/src/hooks/useCachedData.ts
@@ -61,8 +61,17 @@ import type {
 import type { Workload } from './useWorkloads'
 import { fetchProwJobs } from './useCachedProw'
 import { fetchLLMdServers, fetchLLMdModels } from './useCachedLLMd'
-import { SecurityIssuesResponseSchema } from '../lib/schemas'
-import { validateResponse } from '../lib/schemas/validate'
+import {
+  SecurityIssuesResponseSchema,
+  PodsResponseSchema,
+  EventsResponseSchema,
+  DeploymentsResponseSchema,
+  NodesResponseSchema,
+  GPUNodesResponseSchema,
+  GPUNodeHealthResponseSchema,
+  ClustersResponseSchema,
+} from '../lib/schemas'
+import { validateResponse, validateArrayResponse } from '../lib/schemas/validate'
 
 // ============================================================================
 // API Fetchers
@@ -151,7 +160,8 @@ async function fetchClusters(): Promise<string[]> {
   }
 
   // Fall back to backend API
-  const data = await fetchAPI<{ clusters: Array<{ name: string; reachable?: boolean }> }>('clusters')
+  const raw = await fetchAPI<unknown>('clusters')
+  const data = validateArrayResponse<{ clusters: Array<{ name: string; reachable?: boolean }> }>(ClustersResponseSchema, raw, '/api/mcp/clusters', 'clusters')
   return (data.clusters || [])
     .filter(c => c.reachable !== false && !c.name.includes('/'))
     .map(c => c.name)
@@ -562,7 +572,8 @@ export function useCachedPods(
     fetcher: async () => {
       let pods: PodInfo[]
       if (cluster) {
-        const data = await fetchAPI<{ pods: PodInfo[] }>('pods', { cluster, namespace })
+        const raw = await fetchAPI<unknown>('pods', { cluster, namespace })
+        const data = validateArrayResponse<{ pods: PodInfo[] }>(PodsResponseSchema, raw, '/api/mcp/pods', 'pods')
         pods = (data.pods || []).map(p => ({ ...p, cluster }))
       } else {
         pods = await fetchFromAllClusters<PodInfo>('pods', 'pods', { namespace })
@@ -642,7 +653,8 @@ export function useCachedEvents(
 
       // Fall back to REST API (requires backend auth)
       if (cluster) {
-        const data = await fetchAPI<{ events: ClusterEvent[] }>('events', { cluster, namespace, limit })
+        const raw = await fetchAPI<unknown>('events', { cluster, namespace, limit })
+        const data = validateArrayResponse<{ events: ClusterEvent[] }>(EventsResponseSchema, raw, '/api/mcp/events', 'events')
         return data.events || []
       }
       return await fetchFromAllClusters<ClusterEvent>('events', 'events', { namespace, limit })
@@ -888,9 +900,10 @@ export function useCachedDeployments(
           clearTimeout(timeoutId)
 
           if (response.ok) {
-            const data = await response.json().catch(() => null)
-            if (!data) return []
-            return ((data.deployments || []) as Deployment[]).map(d => ({
+            const rawData = await response.json().catch(() => null)
+            if (!rawData) return []
+            const data = validateArrayResponse<{ deployments: Deployment[] }>(DeploymentsResponseSchema, rawData, '/agent/deployments', 'deployments')
+            return (data.deployments || []).map(d => ({
               ...d,
               cluster: cluster }))
           }
@@ -903,7 +916,8 @@ export function useCachedDeployments(
       const hasRealToken = token && token !== 'demo-token'
       if (hasRealToken && !isBackendUnavailable()) {
         if (cluster) {
-          const data = await fetchAPI<{ deployments: Deployment[] }>('deployments', { cluster, namespace })
+          const raw = await fetchAPI<unknown>('deployments', { cluster, namespace })
+          const data = validateArrayResponse<{ deployments: Deployment[] }>(DeploymentsResponseSchema, raw, '/api/mcp/deployments', 'deployments')
           const deployments = data.deployments || []
           return deployments.map(d => ({ ...d, cluster: d.cluster || cluster }))
         }
@@ -1336,7 +1350,8 @@ export function useCachedNodes(
     persist: true,
     fetcher: async () => {
       if (cluster) {
-        const data = await fetchAPI<{ nodes: NodeInfo[] }>('nodes', { cluster })
+        const raw = await fetchAPI<unknown>('nodes', { cluster })
+        const data = validateArrayResponse<{ nodes: NodeInfo[] }>(NodesResponseSchema, raw, '/api/mcp/nodes', 'nodes')
         return (data.nodes || []).map(n => ({ ...n, cluster }))
       }
       return fetchFromAllClusters<NodeInfo>('nodes', 'nodes', {})
@@ -1426,7 +1441,8 @@ export function useCachedGPUNodeHealth(
     persist: true,
     fetcher: async () => {
       if (cluster) {
-        const data = await fetchAPI<{ nodes: GPUNodeHealthStatus[] }>('gpu-nodes/health', { cluster })
+        const raw = await fetchAPI<unknown>('gpu-nodes/health', { cluster })
+        const data = validateArrayResponse<{ nodes: GPUNodeHealthStatus[] }>(GPUNodeHealthResponseSchema, raw, '/api/mcp/gpu-nodes/health', 'nodes')
         return (data.nodes || []).map(n => ({ ...n, cluster }))
       }
       return fetchFromAllClusters<GPUNodeHealthStatus>('gpu-nodes/health', 'nodes', {})
@@ -2188,7 +2204,8 @@ export function useCachedGPUNodes(
     demoData: getDemoGPUNodes(),
     fetcher: async () => {
       if (cluster) {
-        const data = await fetchAPI<{ nodes: GPUNode[] }>('gpu-nodes', { cluster })
+        const raw = await fetchAPI<unknown>('gpu-nodes', { cluster })
+        const data = validateArrayResponse<{ nodes: GPUNode[] }>(GPUNodesResponseSchema, raw, '/api/mcp/gpu-nodes', 'nodes')
         return (data.nodes || []).map(n => ({ ...n, cluster }))
       }
       return await fetchFromAllClusters<GPUNode>(
@@ -2235,7 +2252,8 @@ export function useCachedAllPods(
     demoData: getDemoPods(),
     fetcher: async () => {
       if (cluster) {
-        const data = await fetchAPI<{ pods: PodInfo[] }>('pods', { cluster })
+        const raw = await fetchAPI<unknown>('pods', { cluster })
+        const data = validateArrayResponse<{ pods: PodInfo[] }>(PodsResponseSchema, raw, '/api/mcp/pods (allPods)', 'pods')
         return (data.pods || []).map(p => ({ ...p, cluster }))
       }
       return await fetchFromAllClusters<PodInfo>('pods', 'pods')

--- a/web/src/lib/schemas/__tests__/kubernetes.test.ts
+++ b/web/src/lib/schemas/__tests__/kubernetes.test.ts
@@ -1,0 +1,316 @@
+/**
+ * Tests for Kubernetes Zod schemas and the validateArrayResponse utility.
+ *
+ * These tests verify that:
+ * 1. Valid API responses pass schema validation
+ * 2. Malformed responses produce warnings (not crashes)
+ * 3. The fallback path returns safe empty arrays
+ * 4. Extra backend fields are tolerated (forward compatibility)
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import {
+  PodsResponseSchema,
+  EventsResponseSchema,
+  DeploymentsResponseSchema,
+  NodesResponseSchema,
+  GPUNodesResponseSchema,
+  GPUNodeHealthResponseSchema,
+  ClustersResponseSchema,
+} from '../kubernetes'
+import { validateArrayResponse, validateResponse } from '../validate'
+import { SecurityIssuesResponseSchema } from '../security'
+
+beforeEach(() => {
+  vi.restoreAllMocks()
+})
+
+// ============================================================================
+// PodsResponseSchema
+// ============================================================================
+
+describe('PodsResponseSchema', () => {
+  it('validates a well-formed pods response', () => {
+    const data = {
+      pods: [
+        {
+          name: 'nginx-abc123',
+          namespace: 'default',
+          status: 'Running',
+          ready: '1/1',
+          restarts: 0,
+          age: '2d',
+        },
+      ],
+    }
+    const result = PodsResponseSchema.safeParse(data)
+    expect(result.success).toBe(true)
+  })
+
+  it('defaults missing pods key to empty array', () => {
+    const data = {}
+    const result = PodsResponseSchema.safeParse(data)
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect(result.data.pods).toEqual([])
+    }
+  })
+
+  it('fails on non-object input', () => {
+    const result = PodsResponseSchema.safeParse('not-an-object')
+    expect(result.success).toBe(false)
+  })
+
+  it('tolerates extra fields on pod objects', () => {
+    const data = {
+      pods: [
+        {
+          name: 'pod-1',
+          namespace: 'ns',
+          status: 'Running',
+          ready: '1/1',
+          restarts: 0,
+          age: '1h',
+          futureField: 'should not fail',
+        },
+      ],
+    }
+    const result = PodsResponseSchema.safeParse(data)
+    expect(result.success).toBe(true)
+  })
+})
+
+// ============================================================================
+// EventsResponseSchema
+// ============================================================================
+
+describe('EventsResponseSchema', () => {
+  it('validates a well-formed events response', () => {
+    const data = {
+      events: [
+        {
+          type: 'Warning',
+          reason: 'BackOff',
+          message: 'Back-off restarting failed container',
+          object: 'pod/nginx-abc123',
+          namespace: 'default',
+          count: 5,
+        },
+      ],
+    }
+    const result = EventsResponseSchema.safeParse(data)
+    expect(result.success).toBe(true)
+  })
+})
+
+// ============================================================================
+// DeploymentsResponseSchema
+// ============================================================================
+
+describe('DeploymentsResponseSchema', () => {
+  it('validates a well-formed deployments response', () => {
+    const data = {
+      deployments: [
+        {
+          name: 'nginx',
+          namespace: 'default',
+          status: 'running',
+          replicas: 3,
+          readyReplicas: 3,
+          updatedReplicas: 3,
+          availableReplicas: 3,
+          progress: 100,
+        },
+      ],
+    }
+    const result = DeploymentsResponseSchema.safeParse(data)
+    expect(result.success).toBe(true)
+  })
+
+  it('rejects invalid deployment status', () => {
+    const data = {
+      deployments: [
+        {
+          name: 'nginx',
+          namespace: 'default',
+          status: 'banana',
+          replicas: 3,
+          readyReplicas: 3,
+          updatedReplicas: 3,
+          availableReplicas: 3,
+          progress: 100,
+        },
+      ],
+    }
+    const result = DeploymentsResponseSchema.safeParse(data)
+    expect(result.success).toBe(false)
+  })
+})
+
+// ============================================================================
+// NodesResponseSchema
+// ============================================================================
+
+describe('NodesResponseSchema', () => {
+  it('validates a well-formed nodes response', () => {
+    const data = {
+      nodes: [
+        {
+          name: 'node-1',
+          status: 'Ready',
+          roles: ['control-plane'],
+          kubeletVersion: 'v1.28.4',
+          cpuCapacity: '8',
+          memoryCapacity: '32Gi',
+          podCapacity: '110',
+          conditions: [{ type: 'Ready', status: 'True' }],
+          unschedulable: false,
+        },
+      ],
+    }
+    const result = NodesResponseSchema.safeParse(data)
+    expect(result.success).toBe(true)
+  })
+})
+
+// ============================================================================
+// GPUNodesResponseSchema
+// ============================================================================
+
+describe('GPUNodesResponseSchema', () => {
+  it('validates a well-formed GPU nodes response', () => {
+    const data = {
+      nodes: [
+        {
+          name: 'gpu-node-1',
+          cluster: 'vllm-d',
+          gpuType: 'NVIDIA A100',
+          gpuCount: 8,
+          gpuAllocated: 4,
+        },
+      ],
+    }
+    const result = GPUNodesResponseSchema.safeParse(data)
+    expect(result.success).toBe(true)
+  })
+})
+
+// ============================================================================
+// GPUNodeHealthResponseSchema
+// ============================================================================
+
+describe('GPUNodeHealthResponseSchema', () => {
+  it('validates a well-formed GPU health response', () => {
+    const data = {
+      nodes: [
+        {
+          nodeName: 'gpu-node-1',
+          cluster: 'vllm-d',
+          status: 'healthy',
+          gpuCount: 8,
+          gpuType: 'NVIDIA A100',
+          checks: [{ name: 'node_ready', passed: true }],
+          issues: [],
+          stuckPods: 0,
+          checkedAt: '2025-01-01T00:00:00Z',
+        },
+      ],
+    }
+    const result = GPUNodeHealthResponseSchema.safeParse(data)
+    expect(result.success).toBe(true)
+  })
+
+  it('rejects invalid health status', () => {
+    const data = {
+      nodes: [
+        {
+          nodeName: 'gpu-node-1',
+          cluster: 'vllm-d',
+          status: 'on-fire',
+          gpuCount: 8,
+          gpuType: 'NVIDIA A100',
+          checks: [],
+          issues: [],
+          stuckPods: 0,
+          checkedAt: '2025-01-01T00:00:00Z',
+        },
+      ],
+    }
+    const result = GPUNodeHealthResponseSchema.safeParse(data)
+    expect(result.success).toBe(false)
+  })
+})
+
+// ============================================================================
+// ClustersResponseSchema
+// ============================================================================
+
+describe('ClustersResponseSchema', () => {
+  it('validates a well-formed clusters response', () => {
+    const data = {
+      clusters: [
+        { name: 'prod-east', reachable: true },
+        { name: 'staging', reachable: false },
+      ],
+    }
+    const result = ClustersResponseSchema.safeParse(data)
+    expect(result.success).toBe(true)
+  })
+
+  it('allows clusters without reachable field', () => {
+    const data = {
+      clusters: [{ name: 'unknown-cluster' }],
+    }
+    const result = ClustersResponseSchema.safeParse(data)
+    expect(result.success).toBe(true)
+  })
+})
+
+// ============================================================================
+// validateArrayResponse utility
+// ============================================================================
+
+describe('validateArrayResponse', () => {
+  it('returns original data on successful validation', () => {
+    const data = { pods: [{ name: 'p', namespace: 'ns', status: 'Running', ready: '1/1', restarts: 0, age: '1h' }] }
+    const result = validateArrayResponse<{ pods: unknown[] }>(PodsResponseSchema, data, 'test', 'pods')
+    expect(result.pods).toHaveLength(1)
+    expect(result.pods[0]).toEqual(data.pods[0])
+  })
+
+  it('returns empty-array fallback on validation failure and warns', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const result = validateArrayResponse<{ pods: unknown[] }>(PodsResponseSchema, 'invalid', 'test-pods', 'pods')
+    expect(result.pods).toEqual([])
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('[Zod]'))
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('test-pods'))
+  })
+
+  it('returns empty-array fallback when data has wrong field type', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    // pods should be an array, not a string
+    const data = { pods: 'not-an-array' }
+    const result = validateArrayResponse<{ pods: unknown[] }>(PodsResponseSchema, data, 'test', 'pods')
+    expect(result.pods).toEqual([])
+    expect(warnSpy).toHaveBeenCalled()
+  })
+})
+
+// ============================================================================
+// validateResponse (existing utility, regression test)
+// ============================================================================
+
+describe('validateResponse', () => {
+  it('returns parsed data on success', () => {
+    const data = { issues: [{ name: 'x', namespace: 'ns', issue: 'test', severity: 'high' }] }
+    const result = validateResponse(SecurityIssuesResponseSchema, data, 'test')
+    expect(result).not.toBeNull()
+    expect(result?.issues).toHaveLength(1)
+  })
+
+  it('returns null on failure and warns', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const result = validateResponse(SecurityIssuesResponseSchema, 42, 'test-sec')
+    expect(result).toBeNull()
+    expect(warnSpy).toHaveBeenCalled()
+  })
+})

--- a/web/src/lib/schemas/index.ts
+++ b/web/src/lib/schemas/index.ts
@@ -1,8 +1,8 @@
 /**
  * Centralized Zod schema exports for runtime API response validation.
  *
- * Only high-risk endpoints are covered — auth, security, and external APIs
- * where type assertions previously bypassed safety.
+ * High-risk endpoints are covered — auth, security, external APIs, and
+ * core Kubernetes data where type assertions previously bypassed safety.
  */
 export { AuthRefreshResponseSchema, UserSchema } from './auth'
 export type { AuthRefreshResponse, User } from './auth'
@@ -10,3 +10,28 @@ export { SecurityIssueSchema, SecurityIssuesResponseSchema } from './security'
 export type { SecurityIssuesResponse } from './security'
 export { GitHubWorkflowRunSchema, GitHubWorkflowRunsResponseSchema } from './github'
 export type { GitHubWorkflowRunsResponse } from './github'
+export {
+  PodInfoSchema,
+  PodsResponseSchema,
+  ClusterEventSchema,
+  EventsResponseSchema,
+  DeploymentSchema,
+  DeploymentsResponseSchema,
+  NodeInfoSchema,
+  NodesResponseSchema,
+  GPUNodeSchema,
+  GPUNodesResponseSchema,
+  GPUNodeHealthStatusSchema,
+  GPUNodeHealthResponseSchema,
+  ClusterInfoSchema,
+  ClustersResponseSchema,
+} from './kubernetes'
+export type {
+  PodsResponse,
+  EventsResponse,
+  DeploymentsResponse,
+  NodesResponse,
+  GPUNodesResponse,
+  GPUNodeHealthResponse,
+  ClustersResponse,
+} from './kubernetes'

--- a/web/src/lib/schemas/kubernetes.ts
+++ b/web/src/lib/schemas/kubernetes.ts
@@ -1,0 +1,232 @@
+/**
+ * Zod schemas for Kubernetes API responses consumed by useCachedData hooks.
+ *
+ * These provide runtime validation for the most crash-prone response types:
+ * pods, deployments, nodes, GPU nodes, events, and clusters. When the backend
+ * contract drifts (field renamed, type changed, field missing), the safeParse
+ * path emits a structured console.warn instead of letting the card crash with
+ * "Cannot read properties of undefined".
+ *
+ * Design:
+ * - Item schemas use `.passthrough()` so new backend fields are preserved and
+ *   do not cause validation failures. We cast the parsed result back to the
+ *   existing TypeScript interface at the call site via `validateArrayResponse`,
+ *   which returns the fallback type.
+ * - All optional fields are explicitly marked `.optional()`.
+ * - Wrapper schemas (e.g. `PodsResponseSchema`) validate the envelope the
+ *   backend wraps around the array, so `data.pods` is guaranteed to be an array.
+ */
+import { z } from 'zod'
+
+/**
+ * Label/annotation maps — Zod v4 requires two arguments for z.record().
+ * We use z.unknown() for values because Kubernetes labels are always strings
+ * in practice, but passthrough schemas need compatible index signatures.
+ */
+const labelsSchema = z.record(z.string(), z.string()).optional()
+
+// ============================================================================
+// Container / Pod schemas
+// ============================================================================
+
+export const ContainerInfoSchema = z.object({
+  name: z.string(),
+  image: z.string().optional(),
+  ready: z.boolean().optional(),
+  restartCount: z.number().optional(),
+  state: z.enum(['running', 'waiting', 'terminated']),
+  reason: z.string().optional(),
+  message: z.string().optional(),
+  gpuRequested: z.number().optional(),
+})
+
+export const PodInfoSchema = z.object({
+  name: z.string(),
+  namespace: z.string(),
+  cluster: z.string().optional(),
+  status: z.string(),
+  ready: z.string(),
+  restarts: z.number(),
+  age: z.string(),
+  node: z.string().optional(),
+  labels: labelsSchema,
+  annotations: labelsSchema,
+  containers: z.array(ContainerInfoSchema).optional(),
+  cpuRequestMillis: z.number().optional(),
+  cpuLimitMillis: z.number().optional(),
+  memoryRequestBytes: z.number().optional(),
+  memoryLimitBytes: z.number().optional(),
+  gpuRequest: z.number().optional(),
+  cpuUsageMillis: z.number().optional(),
+  memoryUsageBytes: z.number().optional(),
+  metricsAvailable: z.boolean().optional(),
+})
+
+/** Envelope: `{ pods: PodInfo[] }` returned by the `/pods` endpoint. */
+export const PodsResponseSchema = z.object({
+  pods: z.array(PodInfoSchema).optional().default([]),
+})
+export type PodsResponse = z.infer<typeof PodsResponseSchema>
+
+// ============================================================================
+// Cluster event schemas
+// ============================================================================
+
+export const ClusterEventSchema = z.object({
+  type: z.string(),
+  reason: z.string(),
+  message: z.string(),
+  object: z.string(),
+  namespace: z.string(),
+  cluster: z.string().optional(),
+  count: z.number(),
+  firstSeen: z.string().optional(),
+  lastSeen: z.string().optional(),
+})
+
+/** Envelope: `{ events: ClusterEvent[] }` */
+export const EventsResponseSchema = z.object({
+  events: z.array(ClusterEventSchema).optional().default([]),
+})
+export type EventsResponse = z.infer<typeof EventsResponseSchema>
+
+// ============================================================================
+// Deployment schemas
+// ============================================================================
+
+export const DeploymentSchema = z.object({
+  name: z.string(),
+  namespace: z.string(),
+  cluster: z.string().optional(),
+  status: z.enum(['running', 'deploying', 'failed']),
+  replicas: z.number(),
+  readyReplicas: z.number(),
+  updatedReplicas: z.number(),
+  availableReplicas: z.number(),
+  progress: z.number(),
+  image: z.string().optional(),
+  age: z.string().optional(),
+  labels: labelsSchema,
+  annotations: labelsSchema,
+})
+
+/** Envelope: `{ deployments: Deployment[] }` */
+export const DeploymentsResponseSchema = z.object({
+  deployments: z.array(DeploymentSchema).optional().default([]),
+})
+export type DeploymentsResponse = z.infer<typeof DeploymentsResponseSchema>
+
+// ============================================================================
+// Node schemas
+// ============================================================================
+
+export const NodeConditionSchema = z.object({
+  type: z.string(),
+  status: z.string(),
+  reason: z.string().optional(),
+  message: z.string().optional(),
+})
+
+export const NodeInfoSchema = z.object({
+  name: z.string(),
+  cluster: z.string().optional(),
+  status: z.string(),
+  roles: z.array(z.string()),
+  internalIP: z.string().optional(),
+  externalIP: z.string().optional(),
+  kubeletVersion: z.string(),
+  containerRuntime: z.string().optional(),
+  os: z.string().optional(),
+  architecture: z.string().optional(),
+  cpuCapacity: z.string(),
+  memoryCapacity: z.string(),
+  storageCapacity: z.string().optional(),
+  podCapacity: z.string(),
+  conditions: z.array(NodeConditionSchema),
+  labels: labelsSchema,
+  taints: z.array(z.string()).optional(),
+  age: z.string().optional(),
+  unschedulable: z.boolean(),
+})
+
+/** Envelope: `{ nodes: NodeInfo[] }` */
+export const NodesResponseSchema = z.object({
+  nodes: z.array(NodeInfoSchema).optional().default([]),
+})
+export type NodesResponse = z.infer<typeof NodesResponseSchema>
+
+// ============================================================================
+// GPU Node schemas
+// ============================================================================
+
+export const GPUTaintSchema = z.object({
+  key: z.string(),
+  value: z.string().optional(),
+  effect: z.string(),
+})
+
+export const GPUNodeSchema = z.object({
+  name: z.string(),
+  cluster: z.string(),
+  gpuType: z.string(),
+  gpuCount: z.number(),
+  gpuAllocated: z.number(),
+  acceleratorType: z.enum(['GPU', 'TPU', 'AIU', 'XPU']).optional(),
+  taints: z.array(GPUTaintSchema).optional(),
+  gpuMemoryMB: z.number().optional(),
+  gpuFamily: z.string().optional(),
+  cudaDriverVersion: z.string().optional(),
+  cudaRuntimeVersion: z.string().optional(),
+  migCapable: z.boolean().optional(),
+  migStrategy: z.string().optional(),
+  manufacturer: z.string().optional(),
+})
+
+/** Envelope: `{ nodes: GPUNode[] }` */
+export const GPUNodesResponseSchema = z.object({
+  nodes: z.array(GPUNodeSchema).optional().default([]),
+})
+export type GPUNodesResponse = z.infer<typeof GPUNodesResponseSchema>
+
+// ============================================================================
+// GPU Node Health schemas
+// ============================================================================
+
+export const GPUNodeHealthCheckSchema = z.object({
+  name: z.string(),
+  passed: z.boolean(),
+  message: z.string().optional(),
+})
+
+export const GPUNodeHealthStatusSchema = z.object({
+  nodeName: z.string(),
+  cluster: z.string(),
+  status: z.enum(['healthy', 'degraded', 'unhealthy']),
+  gpuCount: z.number(),
+  gpuType: z.string(),
+  checks: z.array(GPUNodeHealthCheckSchema),
+  issues: z.array(z.string()),
+  stuckPods: z.number(),
+  checkedAt: z.string(),
+})
+
+/** Envelope: `{ nodes: GPUNodeHealthStatus[] }` */
+export const GPUNodeHealthResponseSchema = z.object({
+  nodes: z.array(GPUNodeHealthStatusSchema).optional().default([]),
+})
+export type GPUNodeHealthResponse = z.infer<typeof GPUNodeHealthResponseSchema>
+
+// ============================================================================
+// Cluster list schema (used by fetchClusters)
+// ============================================================================
+
+export const ClusterInfoSchema = z.object({
+  name: z.string(),
+  reachable: z.boolean().optional(),
+})
+
+/** Envelope: `{ clusters: ClusterInfo[] }` */
+export const ClustersResponseSchema = z.object({
+  clusters: z.array(ClusterInfoSchema).optional().default([]),
+})
+export type ClustersResponse = z.infer<typeof ClustersResponseSchema>

--- a/web/src/lib/schemas/validate.ts
+++ b/web/src/lib/schemas/validate.ts
@@ -34,6 +34,39 @@ export function validateResponse<T>(
 }
 
 /**
+ * Validate an API response that wraps an array in an envelope object
+ * (e.g. `{ pods: [...] }`). The schema is used only for validation — the
+ * original data is returned on success (preserving the caller's expected
+ * TypeScript type). On failure, logs a warning and returns a safe fallback
+ * with an empty array for the result key so callers never crash on undefined.
+ *
+ * The `TResult` type parameter is the caller's expected shape (e.g.
+ * `{ pods: PodInfo[] }`). It is separate from the Zod schema's inferred
+ * type to avoid structural mismatches between Zod output and existing
+ * TypeScript interfaces.
+ *
+ * @param schema    Zod schema for the envelope object
+ * @param data      Raw data from `response.json()`
+ * @param label     Human-readable label for log messages
+ * @param resultKey The key holding the array (e.g. "pods", "nodes")
+ */
+export function validateArrayResponse<TResult>(
+  schema: ZodType,
+  data: unknown,
+  label: string,
+  resultKey: string,
+): TResult {
+  const result = schema.safeParse(data)
+  if (result.success) {
+    // Return original data (not result.data) to preserve the caller's TS type
+    return data as TResult
+  }
+  logValidationWarning(label, result.error)
+  // Return a safe fallback with an empty array so callers never crash
+  return { [resultKey]: [] } as unknown as TResult
+}
+
+/**
  * Log a structured warning for a validation failure.
  * Limits the number of issues logged to avoid flooding the console.
  */


### PR DESCRIPTION
## Summary

- Adds Zod schemas for the 7 most crash-prone Kubernetes API response envelopes: pods, events, deployments, nodes, GPU nodes, GPU node health, and clusters
- Introduces `validateArrayResponse` utility that returns safe empty-array fallbacks on schema drift instead of crashing
- Wires validation into 9 fetch call sites in `useCachedData.ts` (single-cluster `fetchAPI` calls and agent HTTP calls)
- When validation fails, emits structured `console.warn` with schema path details rather than crashing cards with "Cannot read properties of undefined"
- Includes 18 unit tests covering valid data, malformed data, missing fields, and fallback behavior

Fixes #8705

## Test plan

- [x] `npm run build` passes
- [x] `npm run lint` passes (no new errors)
- [x] 18 new unit tests pass via `vitest run`
- [ ] Verify cards render correctly with live cluster data
- [ ] Verify demo mode still works (schemas tolerate demo data shapes)