### PR TITLE
fix: unify notification UX patterns and dedup rules

### DIFF
--- a/web/src/components/alerts/AlertDetail.tsx
+++ b/web/src/components/alerts/AlertDetail.tsx
@@ -162,6 +162,19 @@ export function AlertDetail({ alert, onClose }: AlertDetailProps) {
               >
                 {alert.status === 'firing' ? 'FIRING' : 'RESOLVED'}
               </span>
+              {/* Signal type classification badge (#8750) */}
+              {alert.signalType && alert.signalType !== 'state' && (
+                <span
+                  className={`px-2 py-0.5 text-xs rounded ${
+                    alert.signalType === 'acknowledged'
+                      ? 'bg-cyan-500/20 text-cyan-400 border border-cyan-500/30'
+                      : 'bg-purple-500/20 text-purple-400 border border-purple-500/30'
+                  }`}
+                  title={t(`settings.notifications.signalTypes.${alert.signalType}Description`)}
+                >
+                  {t(`settings.notifications.signalTypes.${alert.signalType}`)}
+                </span>
+              )}
             </div>
           </div>
         </div>

--- a/web/src/components/ui/Toast.tsx
+++ b/web/src/components/ui/Toast.tsx
@@ -32,17 +32,29 @@ export function ToastProvider({ children }: { children: ReactNode }) {
   const toastCounter = useRef(0)
   // Auto-dismiss duration for transient toast notifications
   const TOAST_AUTO_DISMISS_MS = 3_000
+  /** Cooldown (ms) after a toast is dismissed before the same message+type can appear again.
+   *  Prevents rapid-fire re-creation of identical toasts (#8751). */
+  const TOAST_DEDUP_COOLDOWN_MS = 2_000
+  /** Tracks recently dismissed toast keys (message+type) with their dismissal timestamp
+   *  to enforce the dedup cooldown window (#8751). */
+  const recentlyDismissedRef = useRef<Map<string, number>>(new Map())
+
   const showToast = useCallback((message: string, type: ToastType = 'success') => {
+    const dedupKey = `${type}::${message}`
     const id = `toast-${Date.now()}-${++toastCounter.current}`
     setToasts((prev) => {
       // Deduplicate: skip if an identical message+type is already visible
       if (prev.some(t => t.message === message && t.type === type)) return prev
+      // Also skip if the same toast was recently dismissed (cooldown dedup)
+      const lastDismissed = recentlyDismissedRef.current.get(dedupKey)
+      if (lastDismissed && (Date.now() - lastDismissed) < TOAST_DEDUP_COOLDOWN_MS) return prev
       return [...prev, { id, message, type }]
     })
 
     // Auto-remove after TOAST_AUTO_DISMISS_MS (timeout is harmless if toast was deduplicated)
     const timeoutId = window.setTimeout(() => {
       setToasts((prev) => prev.filter((t) => t.id !== id))
+      recentlyDismissedRef.current.set(dedupKey, Date.now())
       if (timeoutsRef.current.has(id)) {
         timeoutsRef.current.delete(id)
       }
@@ -51,7 +63,14 @@ export function ToastProvider({ children }: { children: ReactNode }) {
   }, [])
 
   const removeToast = useCallback((id: string) => {
-    setToasts((prev) => prev.filter((t) => t.id !== id))
+    setToasts((prev) => {
+      // Track the dismissed toast's dedup key so it respects cooldown (#8751)
+      const toast = prev.find(t => t.id === id)
+      if (toast) {
+        recentlyDismissedRef.current.set(`${toast.type}::${toast.message}`, Date.now())
+      }
+      return prev.filter((t) => t.id !== id)
+    })
     // Clear timeout if manually removed
     const timeoutId = timeoutsRef.current.get(id)
     if (timeoutId) {

--- a/web/src/contexts/AlertsContext.tsx
+++ b/web/src/contexts/AlertsContext.tsx
@@ -14,7 +14,7 @@ import { STORAGE_KEY_AUTH_TOKEN, FETCH_DEFAULT_TIMEOUT_MS, STORAGE_KEY_NOTIFIED_
 import { safeGet, safeSet, safeRemove, safeGetJSON } from '../lib/safeLocalStorage'
 import { INITIAL_FETCH_DELAY_MS, POLL_INTERVAL_SLOW_MS, SECONDARY_FETCH_DELAY_MS, NIGHTLY_E2E_POLL_INTERVAL_MS } from '../lib/constants/network'
 import { PRESET_ALERT_RULES } from '../types/alerts'
-import { sendNotificationWithDeepLink } from '../hooks/useDeepLink'
+import { sendNotificationWithDeepLink, type DeepLinkParams } from '../hooks/useDeepLink'
 import { findRunbookForCondition } from '../lib/runbooks/builtins'
 import { executeRunbook } from '../lib/runbooks/executor'
 
@@ -260,6 +260,69 @@ function getNotificationCooldown(severity: string): number {
  *  These fire only once and suppress until the cluster recovers —
  *  no 5-minute cooldown repeat for ongoing connectivity failures. */
 const PERSISTENT_CLUSTER_CONDITIONS = new Set(['certificate_error', 'cluster_unreachable'])
+
+// ── Centralized Browser Notification Dispatcher (#8750, #8751, #8752) ───
+//
+// All evaluators previously had inline dedup-check + sendNotificationWithDeepLink
+// logic with subtle inconsistencies:
+//   - Some used cooldown-based repeat, others used one-shot "fire once"
+//   - Persistent condition detection was duplicated in each evaluator
+//   - The dedup key format varied per evaluator
+//
+// This centralized helper unifies the rules:
+//   1. Check if the rule has a `browser` channel enabled
+//   2. Compute the dedup key using the standard `alertDedupKey`
+//   3. For persistent conditions: notify once, suppress until recovery
+//   4. For transient conditions: notify once per cooldown window (severity-tiered)
+//   5. Record the dedup key + timestamp for future checks
+
+/** Parameters for the centralized browser notification dispatcher */
+interface BrowserNotificationParams {
+  /** The alert rule that triggered this notification */
+  rule: AlertRule
+  /** The notification dedup key (from alertDedupKey or custom) */
+  dedupKey: string
+  /** The notification title */
+  title: string
+  /** The notification body text */
+  body: string
+  /** Deep link parameters for click-through navigation */
+  deepLinkParams: DeepLinkParams
+}
+
+/**
+ * Dispatch a browser notification with centralized dedup rules.
+ *
+ * This replaces the 6 inline dedup-check patterns that were scattered
+ * across individual evaluators, each with slightly different logic.
+ *
+ * @returns true if the notification was sent, false if suppressed by dedup
+ */
+function shouldDispatchBrowserNotification(
+  rule: AlertRule,
+  dedupKey: string,
+  notifiedKeys: Map<string, number>
+): boolean {
+  // Gate: rule must have an enabled browser channel
+  const hasBrowserChannel = (rule.channels || []).some(
+    ch => ch.type === 'browser' && ch.enabled
+  )
+  if (!hasBrowserChannel) return false
+
+  const isPersistent = PERSISTENT_CLUSTER_CONDITIONS.has(rule.condition.type)
+  const alreadyNotified = notifiedKeys.has(dedupKey)
+
+  if (isPersistent) {
+    // Persistent conditions: notify exactly once, suppress until recovery
+    // clears the dedup key (see evaluateCertificateError/evaluateClusterUnreachable)
+    return !alreadyNotified
+  }
+
+  // Transient conditions: use severity-tiered cooldown
+  if (!alreadyNotified) return true
+  const lastNotified = notifiedKeys.get(dedupKey) ?? 0
+  return (Date.now() - lastNotified) > getNotificationCooldown(rule.severity)
+}
 
 /**
  * When a cluster is unreachable we cannot observe its node / disk / memory
@@ -685,24 +748,24 @@ export function AlertsProvider({ children }: { children: ReactNode }) {
     return deduplicateAlerts(acked, rules)
   }, [alerts, rules])
 
-  // Acknowledge an alert
+  // Acknowledge an alert — transitions signalType from 'state' to 'acknowledged' (#8750)
   const acknowledgeAlert = (alertId: string, acknowledgedBy?: string) => {
     setAlerts(prev =>
       prev.map(alert =>
         alert.id === alertId
-          ? { ...alert, acknowledgedAt: new Date().toISOString(), acknowledgedBy }
+          ? { ...alert, acknowledgedAt: new Date().toISOString(), acknowledgedBy, signalType: 'acknowledged' as const }
           : alert
       )
     )
   }
 
-  // Acknowledge multiple alerts at once
+  // Acknowledge multiple alerts at once — transitions signalType to 'acknowledged' (#8750)
   const acknowledgeAlerts = (alertIds: string[], acknowledgedBy?: string) => {
     const now = new Date().toISOString()
     setAlerts(prev =>
       prev.map(alert =>
         alertIds.includes(alert.id)
-          ? { ...alert, acknowledgedAt: now, acknowledgedBy }
+          ? { ...alert, acknowledgedAt: now, acknowledgedBy, signalType: 'acknowledged' as const }
           : alert
       )
     )
@@ -805,7 +868,8 @@ export function AlertsProvider({ children }: { children: ReactNode }) {
             resource,
             resourceKind,
             firedAt: new Date().toISOString(),
-            isDemo: isDemoMode }
+            isDemo: isDemoMode,
+            signalType: 'state' }
           acc.mutations.push({ type: 'create', rule, alert })
 
           // Queue notification for after the flush
@@ -847,7 +911,8 @@ export function AlertsProvider({ children }: { children: ReactNode }) {
         resource,
         resourceKind,
         firedAt,
-        isDemo: isDemoMode }
+        isDemo: isDemoMode,
+        signalType: 'state' }
 
       setAlerts(prev => {
         const existingAlert = prev.find(
@@ -1001,6 +1066,21 @@ export function AlertsProvider({ children }: { children: ReactNode }) {
       // Silent failure - notifications are best-effort
     }
   }
+
+  // ── Centralized browser notification dispatch (#8750, #8751, #8752) ──
+  // Replaces 6 inline dedup-check + sendNotificationWithDeepLink patterns
+  // that had inconsistent logic across evaluators.
+  const dispatchBrowserNotification = useCallback(
+    (params: BrowserNotificationParams) => {
+      const { rule, dedupKey, title, body, deepLinkParams } = params
+      if (!shouldDispatchBrowserNotification(rule, dedupKey, notifiedAlertKeysRef.current)) {
+        return
+      }
+      setNotifiedKey(dedupKey, Date.now())
+      sendNotificationWithDeepLink(title, body, deepLinkParams)
+    },
+    [setNotifiedKey]
+  )
 
   // #7341 — Track in-flight diagnosis requests to prevent duplicate missions
   const diagnosisInFlightRef = useRef<Set<string>>(new Set())
@@ -1352,23 +1432,18 @@ Please provide:
             'Node'
           )
 
-          // Send browser notification only once per alert (not on every evaluation cycle)
-          const notifKey = alertDedupKey(rule.id, rule.condition.type, cluster.name)
-          if (
-            rule.channels?.some(ch => ch.type === 'browser' && ch.enabled) &&
-            (!notifiedAlertKeysRef.current.has(notifKey) || (Date.now() - (notifiedAlertKeysRef.current.get(notifKey) ?? 0)) > getNotificationCooldown(rule.severity))
-          ) {
-            setNotifiedKey(notifKey, Date.now())
-            const firstNode = failedNodes[0]
-            sendNotificationWithDeepLink(
-              `GPU Health Alert: ${cluster.name}`,
-              `${totalIssues} issue(s) on ${failedNodes.length} GPU node(s)`,
-              {
-                drilldown: 'node',
-                cluster: cluster.name,
-                node: firstNode.nodeName }
-            )
-          }
+          // Browser notification via centralized dispatcher (#8751)
+          const firstNode = failedNodes[0]
+          dispatchBrowserNotification({
+            rule,
+            dedupKey: alertDedupKey(rule.id, rule.condition.type, cluster.name),
+            title: `GPU Health Alert: ${cluster.name}`,
+            body: `${totalIssues} issue(s) on ${failedNodes.length} GPU node(s)`,
+            deepLinkParams: {
+              drilldown: 'node',
+              cluster: cluster.name,
+              node: firstNode.nodeName },
+          })
         } else {
           // Auto-resolve if all nodes are healthy
           queueAutoResolve(rule.id, cluster.name)
@@ -1413,23 +1488,16 @@ Please provide:
             'Cluster'
           )
 
-          // Send browser notification only once per alert (not on every evaluation cycle).
-          // notifiedAlertKeysRef tracks which (ruleId, cluster) combos already sent a notification.
-          const notifKey = alertDedupKey(rule.id, rule.condition.type, cluster.name)
-          if (
-            rule.channels?.some(ch => ch.type === 'browser' && ch.enabled) &&
-            (!notifiedAlertKeysRef.current.has(notifKey) || (Date.now() - (notifiedAlertKeysRef.current.get(notifKey) ?? 0)) > getNotificationCooldown(rule.severity))
-          ) {
-            setNotifiedKey(notifKey, Date.now())
-            sendNotificationWithDeepLink(
-              `Disk Pressure: ${cluster.name}`,
-              diskPressureIssue,
-              // Deep link to the affected node drilldown (not cluster_health card)
-              affectedNode
-                ? { drilldown: 'node', cluster: cluster.name, node: affectedNode, issue: 'DiskPressure' }
-                : { drilldown: 'cluster', cluster: cluster.name, issue: 'DiskPressure' }
-            )
-          }
+          // Browser notification via centralized dispatcher (#8751)
+          dispatchBrowserNotification({
+            rule,
+            dedupKey: alertDedupKey(rule.id, rule.condition.type, cluster.name),
+            title: `Disk Pressure: ${cluster.name}`,
+            body: diskPressureIssue,
+            deepLinkParams: affectedNode
+              ? { drilldown: 'node', cluster: cluster.name, node: affectedNode, issue: 'DiskPressure' }
+              : { drilldown: 'cluster', cluster: cluster.name, issue: 'DiskPressure' },
+          })
         } else {
           // Auto-resolve if DiskPressure clears — also clear the notification dedup key
           queueAutoResolve(rule.id, cluster.name)
@@ -1510,18 +1578,14 @@ Please provide:
           'Pod'
         )
 
-        const notifKey = alertDedupKey(rule.id, rule.condition.type, cluster)
-        if (
-          rule.channels?.some(ch => ch.type === 'browser' && ch.enabled) &&
-          (!notifiedAlertKeysRef.current.has(notifKey) || (Date.now() - (notifiedAlertKeysRef.current.get(notifKey) ?? 0)) > getNotificationCooldown(rule.severity))
-        ) {
-          setNotifiedKey(notifKey, Date.now())
-          sendNotificationWithDeepLink(
-            `DNS Failure: ${cluster}`,
-            `${pods.length} CoreDNS pod(s) unhealthy — ${issues || 'check pod status'}`,
-            { drilldown: 'pod', cluster, namespace: pods[0].namespace, pod: pods[0].name }
-          )
-        }
+        // Browser notification via centralized dispatcher (#8751)
+        dispatchBrowserNotification({
+          rule,
+          dedupKey: alertDedupKey(rule.id, rule.condition.type, cluster),
+          title: `DNS Failure: ${cluster}`,
+          body: `${pods.length} CoreDNS pod(s) unhealthy — ${issues || 'check pod status'}`,
+          deepLinkParams: { drilldown: 'pod', cluster, namespace: pods[0].namespace, pod: pods[0].name },
+        })
       }
 
       // Auto-resolve clusters that no longer have DNS issues
@@ -1557,27 +1621,18 @@ Please provide:
             'Cluster'
           )
 
-          const notifKey = alertDedupKey(rule.id, rule.condition.type, cluster.name)
-          const isPersistent = PERSISTENT_CLUSTER_CONDITIONS.has(rule.condition.type)
-          const alreadyNotified = notifiedAlertKeysRef.current.has(notifKey)
-          const cooldownExpired = !alreadyNotified || (Date.now() - (notifiedAlertKeysRef.current.get(notifKey) ?? 0)) > getNotificationCooldown(rule.severity)
-          // Persistent cluster errors: notify once, suppress until recovery.
-          // Transient alerts: use the standard 5-minute cooldown.
-          const shouldNotify = isPersistent ? !alreadyNotified : cooldownExpired
-          if (
-            rule.channels?.some(ch => ch.type === 'browser' && ch.enabled) && shouldNotify
-          ) {
-            setNotifiedKey(notifKey, Date.now())
-            sendNotificationWithDeepLink(
-              `Certificate Error: ${cluster.name}`,
-              cluster.errorMessage || 'TLS certificate validation failed',
-              { drilldown: 'cluster', cluster: cluster.name, issue: 'certificate' }
-            )
-          }
+          // Browser notification via centralized dispatcher (#8751)
+          // Persistent conditions are handled uniformly by shouldDispatchBrowserNotification
+          dispatchBrowserNotification({
+            rule,
+            dedupKey: alertDedupKey(rule.id, rule.condition.type, cluster.name),
+            title: `Certificate Error: ${cluster.name}`,
+            body: cluster.errorMessage || 'TLS certificate validation failed',
+            deepLinkParams: { drilldown: 'cluster', cluster: cluster.name, issue: 'certificate' },
+          })
         } else {
           // Auto-resolve if cert error clears — also clear dedup so next failure re-notifies
-          const notifKey = alertDedupKey(rule.id, rule.condition.type, cluster.name)
-          deleteNotifiedKey(notifKey)
+          deleteNotifiedKey(alertDedupKey(rule.id, rule.condition.type, cluster.name))
           queueAutoResolve(rule.id, cluster.name)
         }
       }
@@ -1612,25 +1667,17 @@ Please provide:
             'Cluster'
           )
 
-          const notifKey = alertDedupKey(rule.id, rule.condition.type, cluster.name)
-          const isPersistent = PERSISTENT_CLUSTER_CONDITIONS.has(rule.condition.type)
-          const alreadyNotified = notifiedAlertKeysRef.current.has(notifKey)
-          const cooldownExpired = !alreadyNotified || (Date.now() - (notifiedAlertKeysRef.current.get(notifKey) ?? 0)) > getNotificationCooldown(rule.severity)
-          const shouldNotify = isPersistent ? !alreadyNotified : cooldownExpired
-          if (
-            rule.channels?.some(ch => ch.type === 'browser' && ch.enabled) && shouldNotify
-          ) {
-            setNotifiedKey(notifKey, Date.now())
-            sendNotificationWithDeepLink(
-              `Cluster Unreachable: ${cluster.name}`,
-              `${errorLabel}${cluster.lastSeen ? ` — last seen ${cluster.lastSeen}` : ''}`,
-              { drilldown: 'cluster', cluster: cluster.name, issue: 'unreachable' }
-            )
-          }
+          // Browser notification via centralized dispatcher (#8751)
+          dispatchBrowserNotification({
+            rule,
+            dedupKey: alertDedupKey(rule.id, rule.condition.type, cluster.name),
+            title: `Cluster Unreachable: ${cluster.name}`,
+            body: `${errorLabel}${cluster.lastSeen ? ` — last seen ${cluster.lastSeen}` : ''}`,
+            deepLinkParams: { drilldown: 'cluster', cluster: cluster.name, issue: 'unreachable' },
+          })
         } else if (cluster.reachable !== false) {
           // Auto-resolve when cluster becomes reachable — clear dedup so next failure re-notifies
-          const notifKey = alertDedupKey(rule.id, rule.condition.type, cluster.name)
-          deleteNotifiedKey(notifKey)
+          deleteNotifiedKey(alertDedupKey(rule.id, rule.condition.type, cluster.name))
           queueAutoResolve(rule.id, cluster.name)
         }
       }
@@ -1682,19 +1729,14 @@ Please provide:
             'WorkflowRun'
           )
 
-          // Send browser notification only once per failed run (not on every evaluation cycle)
-          const notifKey = `${rule.id}::${guide.acronym}::${run.runNumber}`
-          if (
-            rule.channels?.some(ch => ch.type === 'browser' && ch.enabled) &&
-            (!notifiedAlertKeysRef.current.has(notifKey) || (Date.now() - (notifiedAlertKeysRef.current.get(notifKey) ?? 0)) > getNotificationCooldown(rule.severity))
-          ) {
-            setNotifiedKey(notifKey, Date.now())
-            sendNotificationWithDeepLink(
-              `Nightly E2E Failed: ${guide.acronym} (${guide.platform})`,
-              `Run #${run.runNumber} failed — ${guide.guide}`,
-              { card: 'nightly_e2e_status' }
-            )
-          }
+          // Browser notification via centralized dispatcher (#8751)
+          dispatchBrowserNotification({
+            rule,
+            dedupKey: `${rule.id}::${guide.acronym}::${run.runNumber}`,
+            title: `Nightly E2E Failed: ${guide.acronym} (${guide.platform})`,
+            body: `Run #${run.runNumber} failed — ${guide.guide}`,
+            deepLinkParams: { card: 'nightly_e2e_status' },
+          })
         }
       }
 

--- a/web/src/hooks/useDeepLink.ts
+++ b/web/src/hooks/useDeepLink.ts
@@ -31,7 +31,7 @@ export type DeepLinkDrilldown =
   | 'deployment'
   | 'namespace'
 
-interface DeepLinkParams {
+export interface DeepLinkParams {
   drilldown?: DeepLinkDrilldown
   action?: DeepLinkAction
   card?: string

--- a/web/src/locales/en/common.json
+++ b/web/src/locales/en/common.json
@@ -351,6 +351,15 @@
       "title": "Alert Notifications",
       "subtitle": "Configure notification channels",
       "description": "Configure notification channels for alert delivery. Alerts will be sent to all enabled channels.",
+      "signalTypes": {
+        "state": "Persistent State",
+        "stateDescription": "Ongoing system condition — stays until resolved",
+        "notification": "Transient Notification",
+        "notificationDescription": "One-time user-facing event (toast or browser push)",
+        "acknowledged": "Acknowledged",
+        "acknowledgedDescription": "User has seen and dismissed this signal"
+      },
+      "dedupSuppressed": "Notification suppressed (duplicate within cooldown window)",
       "slack": {
         "title": "Slack Integration",
         "webhookUrl": "Webhook URL *",

--- a/web/src/types/alerts.ts
+++ b/web/src/types/alerts.ts
@@ -20,6 +20,18 @@ export type AlertSeverity = 'critical' | 'warning' | 'info'
 // Alert status
 export type AlertStatus = 'firing' | 'resolved'
 
+/**
+ * Signal classification for alerts (#8750).
+ *
+ * - `state`        Persistent system condition (e.g. "6 alerts firing").
+ *                  Displayed in the alerts card/page. Stays until resolved.
+ * - `notification` Transient user-facing event (toast, browser push).
+ *                  Fires once per dedup window; not persisted in alert list.
+ * - `acknowledged` User has explicitly seen/dismissed the signal.
+ *                  Removes from active count but keeps in history.
+ */
+export type AlertSignalType = 'state' | 'notification' | 'acknowledged'
+
 // Alert channel types
 export type AlertChannelType = 'browser' | 'slack' | 'webhook' | 'pagerduty' | 'opsgenie'
 
@@ -93,6 +105,8 @@ export interface Alert {
   acknowledgedBy?: string
   aiDiagnosis?: AlertAIDiagnosis
   isDemo?: boolean // True if alert was generated during demo mode
+  /** Signal classification — see AlertSignalType. Defaults to 'state'. */
+  signalType?: AlertSignalType
 }
 
 // Slack webhook configuration


### PR DESCRIPTION
## Summary

- **Centralized browser notification dispatch** — Extracted the 6 inline dedup-check + `sendNotificationWithDeepLink` patterns from individual alert evaluators into a single `dispatchBrowserNotification` helper with unified rules: persistent conditions notify once until recovery; transient conditions use severity-tiered cooldowns
- **Added `AlertSignalType` classification** — New `signalType` field on `Alert` (`'state' | 'notification' | 'acknowledged'`) enables clear separation between persistent system conditions, transient user-facing events, and acknowledged signals. Displayed as a badge in AlertDetail view
- **Enhanced Toast dedup** — Added a cooldown window (`TOAST_DEDUP_COOLDOWN_MS`) that prevents rapid-fire re-creation of identical toasts after auto-dismiss or manual removal
- **Added i18n keys** for signal type labels and descriptions

Fixes #8750, Fixes #8751, Fixes #8752

## Test plan

- [ ] Verify alerts still fire correctly for all condition types (GPU, node, pod crash, disk/memory pressure, DNS, cert, cluster unreachable, nightly E2E)
- [ ] Verify browser notifications respect dedup: same alert does not trigger multiple notifications within cooldown
- [ ] Verify persistent conditions (cert error, cluster unreachable) notify once and suppress until recovery
- [ ] Verify acknowledging an alert transitions `signalType` to `'acknowledged'` and shows badge in AlertDetail
- [ ] Verify toasts with identical message+type don't re-appear within 2s cooldown window
- [ ] Verify build and lint pass with no new errors

Generated with [Claude Code](https://claude.com/claude-code)