### PR TITLE
feat: per-user/IP composite rate limit keys + failure tracker (#8676 Phase 1)

### DIFF
--- a/pkg/api/middleware/ratelimit.go
+++ b/pkg/api/middleware/ratelimit.go
@@ -1,0 +1,128 @@
+package middleware
+
+import (
+	"context"
+	"log/slog"
+	"sync"
+	"time"
+
+	"github.com/gofiber/fiber/v2"
+)
+
+const (
+	// failureRecordMaxAge is the maximum age of a failure record before it is
+	// purged by the cleanup goroutine. Matches the token revocation cleanup
+	// cadence in auth.go:23.
+	failureRecordMaxAge = 1 * time.Hour
+
+	// failureCleanupInterval is how often stale failure records are purged.
+	failureCleanupInterval = 5 * time.Minute
+)
+
+// failureRecord tracks consecutive auth failures for a single composite key.
+type failureRecord struct {
+	Count   int
+	FirstAt time.Time
+	LastAt  time.Time
+}
+
+// FailureTracker provides thread-safe per-key failure counting with automatic
+// cleanup of stale entries. Phase 1 of #8676 — Phase 2 adds progressive delays.
+type FailureTracker struct {
+	mu       sync.Mutex
+	failures map[string]*failureRecord
+	cancel   context.CancelFunc
+}
+
+// NewFailureTracker creates a FailureTracker and starts its background cleanup
+// goroutine. Call Stop() to release the goroutine.
+func NewFailureTracker() *FailureTracker {
+	ctx, cancel := context.WithCancel(context.Background())
+	ft := &FailureTracker{
+		failures: make(map[string]*failureRecord),
+		cancel:   cancel,
+	}
+	go ft.cleanupLoop(ctx)
+	return ft
+}
+
+// RecordFailure increments the failure count for key and updates timestamps.
+func (ft *FailureTracker) RecordFailure(key string) {
+	ft.mu.Lock()
+	defer ft.mu.Unlock()
+	now := time.Now()
+	rec, ok := ft.failures[key]
+	if !ok {
+		ft.failures[key] = &failureRecord{Count: 1, FirstAt: now, LastAt: now}
+		return
+	}
+	rec.Count++
+	rec.LastAt = now
+}
+
+// GetFailureCount returns the current failure count for key (0 if absent).
+func (ft *FailureTracker) GetFailureCount(key string) int {
+	ft.mu.Lock()
+	defer ft.mu.Unlock()
+	rec, ok := ft.failures[key]
+	if !ok {
+		return 0
+	}
+	return rec.Count
+}
+
+// Reset clears the failure record for key (e.g. after a successful login).
+func (ft *FailureTracker) Reset(key string) {
+	ft.mu.Lock()
+	defer ft.mu.Unlock()
+	delete(ft.failures, key)
+}
+
+// Stop cancels the background cleanup goroutine.
+func (ft *FailureTracker) Stop() {
+	if ft.cancel != nil {
+		ft.cancel()
+	}
+}
+
+// cleanupLoop purges records older than failureRecordMaxAge every
+// failureCleanupInterval until ctx is cancelled.
+func (ft *FailureTracker) cleanupLoop(ctx context.Context) {
+	ticker := time.NewTicker(failureCleanupInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			ft.purgeStale()
+		}
+	}
+}
+
+func (ft *FailureTracker) purgeStale() {
+	ft.mu.Lock()
+	defer ft.mu.Unlock()
+	cutoff := time.Now().Add(-failureRecordMaxAge)
+	purged := 0
+	for key, rec := range ft.failures {
+		if rec.LastAt.Before(cutoff) {
+			delete(ft.failures, key)
+			purged++
+		}
+	}
+	if purged > 0 {
+		slog.Debug("[RateLimit] purged stale failure records", "count", purged)
+	}
+}
+
+// CompositeKey returns a rate-limit key: "userID:IP" when a JWT-authenticated
+// user is present, or plain IP for pre-auth requests. This prevents a single
+// IP behind NAT from exhausting the limit for all users sharing that IP.
+func CompositeKey(c *fiber.Ctx) string {
+	userID := GetUserID(c)
+	if userID.String() != "00000000-0000-0000-0000-000000000000" {
+		return userID.String() + ":" + c.IP()
+	}
+	return c.IP()
+}

--- a/pkg/api/middleware/ratelimit_test.go
+++ b/pkg/api/middleware/ratelimit_test.go
@@ -1,0 +1,90 @@
+package middleware
+
+import (
+	"testing"
+	"time"
+)
+
+func TestFailureTracker_RecordAndGet(t *testing.T) {
+	ft := NewFailureTracker()
+	defer ft.Stop()
+
+	if got := ft.GetFailureCount("user1"); got != 0 {
+		t.Fatalf("expected 0 failures for new key, got %d", got)
+	}
+
+	ft.RecordFailure("user1")
+	ft.RecordFailure("user1")
+	ft.RecordFailure("user2")
+
+	if got := ft.GetFailureCount("user1"); got != 2 {
+		t.Fatalf("expected 2 failures for user1, got %d", got)
+	}
+	if got := ft.GetFailureCount("user2"); got != 1 {
+		t.Fatalf("expected 1 failure for user2, got %d", got)
+	}
+}
+
+func TestFailureTracker_Reset(t *testing.T) {
+	ft := NewFailureTracker()
+	defer ft.Stop()
+
+	ft.RecordFailure("key1")
+	ft.RecordFailure("key1")
+	ft.Reset("key1")
+
+	if got := ft.GetFailureCount("key1"); got != 0 {
+		t.Fatalf("expected 0 after reset, got %d", got)
+	}
+
+	// Reset on non-existent key should not panic.
+	ft.Reset("nonexistent")
+}
+
+func TestFailureTracker_PurgeStale(t *testing.T) {
+	ft := NewFailureTracker()
+	defer ft.Stop()
+
+	// Inject a record with LastAt well in the past.
+	ft.mu.Lock()
+	staleTime := time.Now().Add(-2 * failureRecordMaxAge)
+	ft.failures["stale"] = &failureRecord{Count: 5, FirstAt: staleTime, LastAt: staleTime}
+	ft.failures["fresh"] = &failureRecord{Count: 1, FirstAt: time.Now(), LastAt: time.Now()}
+	ft.mu.Unlock()
+
+	ft.purgeStale()
+
+	if got := ft.GetFailureCount("stale"); got != 0 {
+		t.Fatalf("expected stale record purged, got count %d", got)
+	}
+	if got := ft.GetFailureCount("fresh"); got != 1 {
+		t.Fatalf("expected fresh record retained, got count %d", got)
+	}
+}
+
+func TestFailureTracker_Timestamps(t *testing.T) {
+	ft := NewFailureTracker()
+	defer ft.Stop()
+
+	before := time.Now()
+	ft.RecordFailure("ts")
+	after := time.Now()
+
+	ft.mu.Lock()
+	rec := ft.failures["ts"]
+	ft.mu.Unlock()
+
+	if rec.FirstAt.Before(before) || rec.FirstAt.After(after) {
+		t.Fatalf("FirstAt %v not in expected range [%v, %v]", rec.FirstAt, before, after)
+	}
+
+	ft.RecordFailure("ts")
+
+	ft.mu.Lock()
+	rec = ft.failures["ts"]
+	ft.mu.Unlock()
+
+	if rec.LastAt.Before(rec.FirstAt) {
+		t.Fatalf("LastAt %v should be >= FirstAt %v", rec.LastAt, rec.FirstAt)
+	}
+}

--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -643,24 +643,34 @@ func (s *Server) setupRoutes() {
 		DevMode:        s.config.DevMode,
 		SkipOnboarding: s.config.SkipOnboarding,
 	})
-	// Rate limit auth endpoints — stricter to prevent brute-force
+	// FailureTracker for per-user/IP auth failure counting (#8676 Phase 1).
+	// Exposed via c.Locals for use in auth handlers in future phases.
+	failureTracker := middleware.NewFailureTracker()
+
+	// Rate limit auth endpoints — stricter to prevent brute-force.
+	// Uses composite key (userID:IP when authenticated, IP alone pre-auth)
+	// so users behind shared NAT don't exhaust each other's budgets (#8676).
 	authLimiterMaxRequests := 10         // max requests per window
 	authLimiterWindow := 1 * time.Minute // sliding window duration
 	authLimiter := limiter.New(limiter.Config{
 		Max:        authLimiterMaxRequests,
 		Expiration: authLimiterWindow,
-		KeyGenerator: func(c *fiber.Ctx) string {
-			return c.IP()
-		},
+		KeyGenerator: middleware.CompositeKey,
 		LimitReached: func(c *fiber.Ctx) error {
 			c.Set("Retry-After", strconv.Itoa(int(authLimiterWindow.Seconds()))) // #7040
 			return c.Status(429).JSON(fiber.Map{"error": "too many requests, try again later"})
 		},
 	})
+	// Inject FailureTracker into request context for auth handlers (#8676).
+	injectTracker := func(c *fiber.Ctx) error {
+		c.Locals("failureTracker", failureTracker)
+		return c.Next()
+	}
+
 	// Wire WebSocket hub into auth handler so logout disconnects WS sessions (#4906)
 	auth.SetHub(s.hub)
-	s.app.Get("/auth/github", authLimiter, auth.GitHubLogin)
-	s.app.Get("/auth/github/callback", authLimiter, auth.GitHubCallback)
+	s.app.Get("/auth/github", authLimiter, injectTracker, auth.GitHubLogin)
+	s.app.Get("/auth/github/callback", authLimiter, injectTracker, auth.GitHubCallback)
 	// #6587 — /auth/logout now requires JWTAuth. Previously anyone could
 	// POST /auth/logout with any JWT (even a stolen one) because the route
 	// was registered without the auth middleware. Requiring JWTAuth proves
@@ -672,8 +682,8 @@ func (s *Server) setupRoutes() {
 	// token is rejected by the middleware before the handler even runs.
 	jwtAuth := middleware.JWTAuth(s.config.JWTSecret)
 	csrfGuard := middleware.RequireCSRF()
-	s.app.Post("/auth/refresh", authLimiter, csrfGuard, jwtAuth, auth.RefreshToken)
-	s.app.Post("/auth/logout", authLimiter, csrfGuard, jwtAuth, auth.Logout)
+	s.app.Post("/auth/refresh", authLimiter, injectTracker, csrfGuard, jwtAuth, auth.RefreshToken)
+	s.app.Post("/auth/logout", authLimiter, injectTracker, csrfGuard, jwtAuth, auth.Logout)
 
 	// Public endpoint rate limiter — loose limit to prevent DoS on unauthenticated
 	// routes (active-users, ping, nightly-e2e, youtube, medium, analytics) (#7029).


### PR DESCRIPTION
## Summary
- Adds `FailureTracker` struct in `pkg/api/middleware/ratelimit.go` with thread-safe record/get/reset and automatic stale-entry cleanup (every 5 min, purges records older than 1 hour)
- Switches `authLimiter` KeyGenerator from plain `c.IP()` to `CompositeKey` (`userID:IP` when JWT is present, `IP` alone pre-auth) so users behind shared NAT don't exhaust each other's budgets
- Injects `FailureTracker` into auth route context via `c.Locals("failureTracker", ...)` for use by Phase 2 progressive delays
- All numeric literals use named constants; structured logging via `log/slog`

Phase 1 of 3 per the approved RFC in #8676. Does NOT change thresholds or add progressive delays (Phase 2).

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./pkg/api/middleware/...` — 4 new tests (record+get, reset, purge stale, timestamps) + all existing tests pass
- [x] `npm run build` passes (no frontend changes)

Fixes #8676