### PR TITLE
feat: add audit logging helper + wire RBAC handlers

### DIFF
--- a/pkg/api/audit/audit.go
+++ b/pkg/api/audit/audit.go
@@ -1,0 +1,43 @@
+// Package audit provides structured logging helpers for security-sensitive
+// operations such as role changes, user deletions, and unauthorized access
+// attempts. Phase 1 of #8670.
+package audit
+
+import (
+	"log/slog"
+	"strings"
+
+	"github.com/gofiber/fiber/v2"
+
+	"github.com/kubestellar/console/pkg/api/middleware"
+)
+
+// Action constants identify the kind of auditable event.
+const (
+	ActionUpdateRole          = "update_role"
+	ActionDeleteUser          = "delete_user"
+	ActionUnauthorizedAttempt = "unauthorized_attempt"
+)
+
+// Log emits a structured audit log entry for a security-sensitive operation.
+// Optional detail strings are joined with a space and included in the entry.
+func Log(c *fiber.Ctx, action, targetType, targetID string, details ...string) {
+	userID := middleware.GetUserID(c)
+	ip := c.IP()
+
+	attrs := []any{
+		"action", action,
+		"actor_id", userID,
+		"target_type", targetType,
+		"target_id", targetID,
+		"ip", ip,
+		"path", c.Path(),
+		"method", c.Method(),
+	}
+
+	if len(details) > 0 {
+		attrs = append(attrs, "details", strings.Join(details, " "))
+	}
+
+	slog.Info("audit", attrs...)
+}

--- a/pkg/api/audit/audit_test.go
+++ b/pkg/api/audit/audit_test.go
@@ -1,0 +1,113 @@
+package audit
+
+import (
+	"bytes"
+	"encoding/json"
+	"log/slog"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gofiber/fiber/v2"
+)
+
+// captureLog replaces the default slog logger with a JSON logger that writes
+// to buf, calls fn, then restores the original logger.
+func captureLog(buf *bytes.Buffer, fn func()) {
+	original := slog.Default()
+	slog.SetDefault(slog.New(slog.NewJSONHandler(buf, nil)))
+	defer slog.SetDefault(original)
+	fn()
+}
+
+func TestLogEmitsRequiredFields(t *testing.T) {
+	app := fiber.New()
+	app.Post("/api/users/:id/role", func(c *fiber.Ctx) error {
+		Log(c, ActionUpdateRole, "user", "target-123", "viewer->admin")
+		return c.SendStatus(fiber.StatusOK)
+	})
+
+	var buf bytes.Buffer
+	captureLog(&buf, func() {
+		req := httptest.NewRequest("POST", "/api/users/target-123/role", nil)
+		req.Header.Set("X-Forwarded-For", "10.0.0.1")
+		//nolint:errcheck // test-only; response body is irrelevant
+		app.Test(req)
+	})
+
+	var entry map[string]any
+	if err := json.Unmarshal(buf.Bytes(), &entry); err != nil {
+		t.Fatalf("failed to parse log JSON: %v\nbuf: %s", err, buf.String())
+	}
+
+	requiredKeys := []string{"action", "actor_id", "target_type", "target_id", "ip", "path", "method", "details"}
+	for _, k := range requiredKeys {
+		if _, ok := entry[k]; !ok {
+			t.Errorf("missing required audit field %q in log entry", k)
+		}
+	}
+
+	if entry["action"] != ActionUpdateRole {
+		t.Errorf("action = %v, want %v", entry["action"], ActionUpdateRole)
+	}
+	if entry["target_type"] != "user" {
+		t.Errorf("target_type = %v, want %q", entry["target_type"], "user")
+	}
+	if entry["target_id"] != "target-123" {
+		t.Errorf("target_id = %v, want %q", entry["target_id"], "target-123")
+	}
+	if entry["details"] != "viewer->admin" {
+		t.Errorf("details = %v, want %q", entry["details"], "viewer->admin")
+	}
+}
+
+func TestLogOmitsDetailsWhenEmpty(t *testing.T) {
+	app := fiber.New()
+	app.Delete("/api/users/:id", func(c *fiber.Ctx) error {
+		Log(c, ActionDeleteUser, "user", "target-456")
+		return c.SendStatus(fiber.StatusOK)
+	})
+
+	var buf bytes.Buffer
+	captureLog(&buf, func() {
+		req := httptest.NewRequest("DELETE", "/api/users/target-456", nil)
+		//nolint:errcheck // test-only
+		app.Test(req)
+	})
+
+	var entry map[string]any
+	if err := json.Unmarshal(buf.Bytes(), &entry); err != nil {
+		t.Fatalf("failed to parse log JSON: %v", err)
+	}
+
+	if _, ok := entry["details"]; ok {
+		t.Error("details field should be omitted when no details are provided")
+	}
+
+	if entry["action"] != ActionDeleteUser {
+		t.Errorf("action = %v, want %v", entry["action"], ActionDeleteUser)
+	}
+}
+
+func TestLogUnauthorizedAttempt(t *testing.T) {
+	app := fiber.New()
+	app.Get("/api/users", func(c *fiber.Ctx) error {
+		Log(c, ActionUnauthorizedAttempt, "endpoint", "/api/users", "non-admin list attempt")
+		return c.SendStatus(fiber.StatusForbidden)
+	})
+
+	var buf bytes.Buffer
+	captureLog(&buf, func() {
+		req := httptest.NewRequest("GET", "/api/users", nil)
+		//nolint:errcheck // test-only
+		app.Test(req)
+	})
+
+	var entry map[string]any
+	if err := json.Unmarshal(buf.Bytes(), &entry); err != nil {
+		t.Fatalf("failed to parse log JSON: %v", err)
+	}
+
+	if entry["action"] != ActionUnauthorizedAttempt {
+		t.Errorf("action = %v, want %v", entry["action"], ActionUnauthorizedAttempt)
+	}
+}

--- a/pkg/api/handlers/rbac.go
+++ b/pkg/api/handlers/rbac.go
@@ -2,6 +2,7 @@ package handlers
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
 	"sync"
 	"time"
@@ -10,6 +11,7 @@ import (
 	"github.com/google/uuid"
 	"golang.org/x/sync/errgroup"
 
+	"github.com/kubestellar/console/pkg/api/audit"
 	"github.com/kubestellar/console/pkg/api/middleware"
 	"github.com/kubestellar/console/pkg/k8s"
 	"github.com/kubestellar/console/pkg/models"
@@ -52,9 +54,7 @@ func (h *RBACHandler) ListConsoleUsers(c *fiber.Ctx) error {
 	}
 
 	if currentUser.Role != models.UserRoleAdmin {
-		slog.Warn("[rbac] SECURITY: non-admin attempted to list all users",
-			"user_id", currentUser.ID,
-			"github_login", currentUser.GitHubLogin)
+		audit.Log(c, audit.ActionUnauthorizedAttempt, "endpoint", "/api/users", "non-admin list attempt")
 		return fiber.NewError(fiber.StatusForbidden, "Admin access required")
 	}
 
@@ -108,9 +108,18 @@ func (h *RBACHandler) UpdateUserRole(c *fiber.Ctx) error {
 		return fiber.NewError(fiber.StatusBadRequest, "Cannot remove your own admin role")
 	}
 
+	// Fetch old role for audit trail before mutating.
+	oldRole := "unknown"
+	if target, err := h.store.GetUser(targetID); err == nil && target != nil {
+		oldRole = string(target.Role)
+	}
+
 	if err := h.store.UpdateUserRole(targetID, string(req.Role)); err != nil {
 		return fiber.NewError(fiber.StatusInternalServerError, "Failed to update user role")
 	}
+
+	audit.Log(c, audit.ActionUpdateRole, "user", targetUserID,
+		fmt.Sprintf("%s->%s", oldRole, string(req.Role)))
 
 	return c.JSON(fiber.Map{"success": true})
 }
@@ -143,6 +152,8 @@ func (h *RBACHandler) DeleteConsoleUser(c *fiber.Ctx) error {
 		return fiber.NewError(fiber.StatusInternalServerError, "Failed to delete user")
 	}
 
+	audit.Log(c, audit.ActionDeleteUser, "user", targetUserID)
+
 	return c.JSON(fiber.Map{"success": true})
 }
 
@@ -157,9 +168,7 @@ func (h *RBACHandler) GetUserManagementSummary(c *fiber.Ctx) error {
 	}
 
 	if currentUser.Role != models.UserRoleAdmin {
-		slog.Warn("[rbac] SECURITY: non-admin attempted to read user-management summary",
-			"user_id", currentUser.ID,
-			"github_login", currentUser.GitHubLogin)
+		audit.Log(c, audit.ActionUnauthorizedAttempt, "endpoint", "/api/users/summary", "non-admin summary attempt")
 		return fiber.NewError(fiber.StatusForbidden, "Admin access required")
 	}
 
@@ -290,9 +299,7 @@ func (h *RBACHandler) ListK8sRoles(c *fiber.Ctx) error {
 	}
 
 	if currentUser.Role != models.UserRoleAdmin {
-		slog.Warn("[rbac] SECURITY: non-admin attempted to list Kubernetes roles",
-			"user_id", currentUser.ID,
-			"github_login", currentUser.GitHubLogin)
+		audit.Log(c, audit.ActionUnauthorizedAttempt, "endpoint", "/api/k8s/roles", "non-admin role list attempt")
 		return fiber.NewError(fiber.StatusForbidden, "Admin access required")
 	}
 
@@ -340,9 +347,7 @@ func (h *RBACHandler) ListK8sRoleBindings(c *fiber.Ctx) error {
 	}
 
 	if currentUser.Role != models.UserRoleAdmin {
-		slog.Warn("[rbac] SECURITY: non-admin attempted to list role bindings",
-			"user_id", currentUser.ID,
-			"github_login", currentUser.GitHubLogin)
+		audit.Log(c, audit.ActionUnauthorizedAttempt, "endpoint", "/api/k8s/rolebindings", "non-admin role-binding list attempt")
 		return fiber.NewError(fiber.StatusForbidden, "Admin access required")
 	}
 
@@ -405,9 +410,7 @@ func (h *RBACHandler) ListK8sUsers(c *fiber.Ctx) error {
 	}
 
 	if currentUser.Role != models.UserRoleAdmin {
-		slog.Warn("[rbac] SECURITY: non-admin attempted to list Kubernetes subjects",
-			"user_id", currentUser.ID,
-			"github_login", currentUser.GitHubLogin)
+		audit.Log(c, audit.ActionUnauthorizedAttempt, "endpoint", "/api/k8s/users", "non-admin subject list attempt")
 		return fiber.NewError(fiber.StatusForbidden, "Admin access required")
 	}
 
@@ -442,9 +445,7 @@ func (h *RBACHandler) ListOpenShiftUsers(c *fiber.Ctx) error {
 	}
 
 	if currentUser.Role != models.UserRoleAdmin {
-		slog.Warn("[rbac] SECURITY: non-admin attempted to list OpenShift users",
-			"user_id", currentUser.ID,
-			"github_login", currentUser.GitHubLogin)
+		audit.Log(c, audit.ActionUnauthorizedAttempt, "endpoint", "/api/k8s/openshift-users", "non-admin OpenShift user list attempt")
 		return fiber.NewError(fiber.StatusForbidden, "Admin access required")
 	}
 


### PR DESCRIPTION
## Summary
- Introduces `pkg/api/audit` package with a structured `Log()` helper that emits actor ID, target, IP, path, and method for security-sensitive operations
- Wires audit logging into `UpdateUserRole` (logs old->new role transition) and `DeleteConsoleUser` (logs deleted user ID)
- Migrates 6 existing `slog.Warn` unauthorized-attempt calls in RBAC handlers to use the consistent `audit.Log` format with `ActionUnauthorizedAttempt`
- Phase 1 of #8670 (audit helper + RBAC handlers only; settings/workloads/notifications are Phase 2)

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./pkg/api/audit/...` — 3 tests verify correct structured fields, details omission, and action constants
- [x] `go test ./pkg/api/handlers/...` — all existing handler tests pass
- [x] `npm run build` passes (no frontend changes)

Fixes #8670