### PR TITLE
feat: wire audit logging into all sensitive handlers (Phase 2 of #8670)

### DIFF
--- a/pkg/api/audit/audit.go
+++ b/pkg/api/audit/audit.go
@@ -17,6 +17,18 @@ const (
 	ActionUpdateRole          = "update_role"
 	ActionDeleteUser          = "delete_user"
 	ActionUnauthorizedAttempt = "unauthorized_attempt"
+
+	// Phase 2: settings, cluster groups, notifications, tokens, quotas.
+	ActionSaveSettings         = "save_settings"
+	ActionImportSettings       = "import_settings"
+	ActionExportSettings       = "export_settings"
+	ActionCreateClusterGroup   = "create_cluster_group"
+	ActionUpdateClusterGroup   = "update_cluster_group"
+	ActionDeleteClusterGroup   = "delete_cluster_group"
+	ActionSaveNotificationConfig = "save_notification_config"
+	ActionDeleteToken          = "delete_token"
+	ActionCreateResourceQuota  = "create_resource_quota"
+	ActionDeleteResourceQuota  = "delete_resource_quota"
 )
 
 // Log emits a structured audit log entry for a security-sensitive operation.

--- a/pkg/api/handlers/github_proxy.go
+++ b/pkg/api/handlers/github_proxy.go
@@ -12,6 +12,7 @@ import (
 	"github.com/gofiber/fiber/v2"
 	"golang.org/x/time/rate"
 
+	"github.com/kubestellar/console/pkg/api/audit"
 	"github.com/kubestellar/console/pkg/api/middleware"
 	"github.com/kubestellar/console/pkg/settings"
 	"github.com/kubestellar/console/pkg/store"
@@ -340,6 +341,8 @@ func (h *GitHubProxyHandler) DeleteToken(c *fiber.Ctx) error {
 			"error": "Failed to clear token",
 		})
 	}
+
+	audit.Log(c, audit.ActionDeleteToken, "token", "github")
 
 	return c.JSON(fiber.Map{"success": true})
 }

--- a/pkg/api/handlers/mcp_resources.go
+++ b/pkg/api/handlers/mcp_resources.go
@@ -9,6 +9,9 @@ import (
 	"time"
 
 	"github.com/gofiber/fiber/v2"
+
+	"github.com/kubestellar/console/pkg/api/audit"
+
 	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
@@ -813,6 +816,9 @@ func (h *MCPHandlers) CreateOrUpdateResourceQuota(c *fiber.Ctx) error {
 			return handleK8sError(c, err)
 		}
 
+		audit.Log(c, audit.ActionCreateResourceQuota, "resource_quota", req.Name,
+			"cluster="+req.Cluster, "namespace="+req.Namespace)
+
 		return c.JSON(fiber.Map{"resourceQuota": quota, "source": "k8s"})
 	}
 
@@ -848,6 +854,9 @@ func (h *MCPHandlers) DeleteResourceQuota(c *fiber.Ctx) error {
 		if err != nil {
 			return handleK8sError(c, err)
 		}
+
+		audit.Log(c, audit.ActionDeleteResourceQuota, "resource_quota", name,
+			"cluster="+cluster, "namespace="+namespace)
 
 		return c.JSON(fiber.Map{"deleted": true, "name": name, "namespace": namespace, "cluster": cluster})
 	}

--- a/pkg/api/handlers/notifications.go
+++ b/pkg/api/handlers/notifications.go
@@ -4,6 +4,7 @@ import (
 	"log/slog"
 
 	"github.com/gofiber/fiber/v2"
+	"github.com/kubestellar/console/pkg/api/audit"
 	"github.com/kubestellar/console/pkg/api/middleware"
 	"github.com/kubestellar/console/pkg/models"
 	"github.com/kubestellar/console/pkg/notifications"
@@ -141,6 +142,8 @@ func (h *NotificationHandler) SaveNotificationConfig(c *fiber.Ctx) error {
 			"error": "Invalid request body",
 		})
 	}
+
+	audit.Log(c, audit.ActionSaveNotificationConfig, "notification_config", userID.String())
 
 	// Config validation only - actual storage is client-side
 	// This endpoint exists for future server-side config storage

--- a/pkg/api/handlers/settings.go
+++ b/pkg/api/handlers/settings.go
@@ -4,6 +4,7 @@ import (
 	"log/slog"
 
 	"github.com/gofiber/fiber/v2"
+	"github.com/kubestellar/console/pkg/api/audit"
 	"github.com/kubestellar/console/pkg/api/middleware"
 	"github.com/kubestellar/console/pkg/models"
 	"github.com/kubestellar/console/pkg/settings"
@@ -84,6 +85,8 @@ func (h *SettingsHandler) SaveSettings(c *fiber.Ctx) error {
 		})
 	}
 
+	audit.Log(c, audit.ActionSaveSettings, "settings", "all")
+
 	return c.JSON(fiber.Map{
 		"success": true,
 		"message": "Settings saved",
@@ -107,6 +110,8 @@ func (h *SettingsHandler) ExportSettings(c *fiber.Ctx) error {
 			"error": "Failed to export settings",
 		})
 	}
+
+	audit.Log(c, audit.ActionExportSettings, "settings", "backup")
 
 	c.Set("Content-Type", "application/json")
 	c.Set("Content-Disposition", "attachment; filename=kc-settings-backup.json")
@@ -137,6 +142,8 @@ func (h *SettingsHandler) ImportSettings(c *fiber.Ctx) error {
 			"message": "invalid settings data",
 		})
 	}
+
+	audit.Log(c, audit.ActionImportSettings, "settings", "backup")
 
 	return c.JSON(fiber.Map{
 		"success": true,

--- a/pkg/api/handlers/workloads.go
+++ b/pkg/api/handlers/workloads.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/gofiber/fiber/v2"
 	"github.com/kubestellar/console/pkg/agent"
+	"github.com/kubestellar/console/pkg/api/audit"
 	"github.com/kubestellar/console/pkg/api/middleware"
 	"github.com/kubestellar/console/pkg/k8s"
 	"github.com/kubestellar/console/pkg/models"
@@ -439,6 +440,8 @@ func (h *WorkloadHandlers) CreateClusterGroup(c *fiber.Ctx) error {
 		}
 	}
 
+	audit.Log(c, audit.ActionCreateClusterGroup, "cluster_group", group.Name)
+
 	return c.Status(201).JSON(group)
 }
 
@@ -512,6 +515,8 @@ func (h *WorkloadHandlers) UpdateClusterGroup(c *fiber.Ctx) error {
 		}
 	}
 
+	audit.Log(c, audit.ActionUpdateClusterGroup, "cluster_group", name)
+
 	return c.JSON(group)
 }
 
@@ -558,6 +563,8 @@ func (h *WorkloadHandlers) DeleteClusterGroup(c *fiber.Ctx) error {
 			})
 		}
 	}
+
+	audit.Log(c, audit.ActionDeleteClusterGroup, "cluster_group", name)
 
 	return c.JSON(fiber.Map{"message": "Cluster group deleted", "name": name})
 }


### PR DESCRIPTION
## Summary
- Adds 10 new action constants to `pkg/api/audit/audit.go` for Phase 2 coverage
- Wires `audit.Log` into all remaining state-modifying admin handlers:
  - **settings.go**: `SaveSettings`, `ExportSettings`, `ImportSettings`
  - **workloads.go**: `CreateClusterGroup`, `UpdateClusterGroup`, `DeleteClusterGroup`
  - **notifications.go**: `SaveNotificationConfig`
  - **github_proxy.go**: `DeleteToken`
  - **mcp_resources.go**: `CreateOrUpdateResourceQuota`, `DeleteResourceQuota`
- Each audit call fires only after the operation succeeds (not before, not on failure)
- 41 lines added across 6 files (well within 100 LOC budget)

Phase 2 of #8670 — Phase 3 will add SQLite storage and admin query API.

Fixes #8670

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./pkg/api/...` passes (all 4 packages)
- [x] `npm run build` passes
- [x] No new dependencies added