### PR TITLE
feat: progressive rate-limit thresholds + Retry-After escalation (Phase 2 of #8676)

### DIFF
--- a/pkg/api/handlers/auth.go
+++ b/pkg/api/handlers/auth.go
@@ -466,6 +466,10 @@ func sanitizeOAuthErrorDescription(raw string) string {
 // Any attacker-influenceable detail MUST be passed through
 // sanitizeOAuthErrorDescription before reaching this function (#6583).
 func (h *AuthHandler) oauthErrorRedirect(c *fiber.Ctx, errorCode, detail string) error {
+	// Record auth failure for progressive rate-limit escalation (#8676 Phase 2).
+	if tracker, ok := c.Locals("failureTracker").(*middleware.FailureTracker); ok {
+		tracker.RecordFailure(c.IP())
+	}
 	q := url.Values{"error": {errorCode}}
 	if detail != "" {
 		q.Set("error_detail", detail)

--- a/pkg/api/middleware/ratelimit.go
+++ b/pkg/api/middleware/ratelimit.go
@@ -17,6 +17,17 @@ const (
 
 	// failureCleanupInterval is how often stale failure records are purged.
 	failureCleanupInterval = 5 * time.Minute
+
+	// Progressive threshold tiers for Retry-After escalation (#8676 Phase 2).
+	FailureThresholdEscalate = 6  // 5min Retry-After
+	FailureThresholdSoftLock = 11 // 15min Retry-After + log warning
+	FailureThresholdHardLock = 21 // 1hr Retry-After + GA4 event (Phase 3)
+
+	// Retry-After values (seconds) for each tier.
+	RetryAfterNormalSec    = 60   // default for rate-limited requests
+	RetryAfterEscalateSec  = 300  // 5 minutes
+	RetryAfterSoftLockSec  = 900  // 15 minutes
+	RetryAfterHardLockSec  = 3600 // 1 hour
 )
 
 // failureRecord tracks consecutive auth failures for a single composite key.
@@ -76,6 +87,22 @@ func (ft *FailureTracker) Reset(key string) {
 	ft.mu.Lock()
 	defer ft.mu.Unlock()
 	delete(ft.failures, key)
+}
+
+// GetRetryAfter returns the Retry-After value (seconds) for the given key
+// based on which failure-count tier it falls into (#8676 Phase 2).
+func (ft *FailureTracker) GetRetryAfter(key string) int {
+	count := ft.GetFailureCount(key)
+	switch {
+	case count >= FailureThresholdHardLock:
+		return RetryAfterHardLockSec
+	case count >= FailureThresholdSoftLock:
+		return RetryAfterSoftLockSec
+	case count >= FailureThresholdEscalate:
+		return RetryAfterEscalateSec
+	default:
+		return RetryAfterNormalSec
+	}
 }
 
 // Stop cancels the background cleanup goroutine.

--- a/pkg/api/middleware/ratelimit_test.go
+++ b/pkg/api/middleware/ratelimit_test.go
@@ -62,6 +62,52 @@ func TestFailureTracker_PurgeStale(t *testing.T) {
 	}
 }
 
+func TestFailureTracker_GetRetryAfter(t *testing.T) {
+	ft := NewFailureTracker()
+	defer ft.Stop()
+
+	// No failures → normal tier.
+	if got := ft.GetRetryAfter("k"); got != RetryAfterNormalSec {
+		t.Fatalf("0 failures: want %d, got %d", RetryAfterNormalSec, got)
+	}
+
+	// Record failures up to just below escalate threshold.
+	for i := 0; i < FailureThresholdEscalate-1; i++ {
+		ft.RecordFailure("k")
+	}
+	if got := ft.GetRetryAfter("k"); got != RetryAfterNormalSec {
+		t.Fatalf("below escalate: want %d, got %d", RetryAfterNormalSec, got)
+	}
+
+	// Hit escalate threshold.
+	ft.RecordFailure("k")
+	if got := ft.GetRetryAfter("k"); got != RetryAfterEscalateSec {
+		t.Fatalf("at escalate: want %d, got %d", RetryAfterEscalateSec, got)
+	}
+
+	// Advance to soft-lock threshold.
+	for ft.GetFailureCount("k") < FailureThresholdSoftLock {
+		ft.RecordFailure("k")
+	}
+	if got := ft.GetRetryAfter("k"); got != RetryAfterSoftLockSec {
+		t.Fatalf("at soft-lock: want %d, got %d", RetryAfterSoftLockSec, got)
+	}
+
+	// Advance to hard-lock threshold.
+	for ft.GetFailureCount("k") < FailureThresholdHardLock {
+		ft.RecordFailure("k")
+	}
+	if got := ft.GetRetryAfter("k"); got != RetryAfterHardLockSec {
+		t.Fatalf("at hard-lock: want %d, got %d", RetryAfterHardLockSec, got)
+	}
+
+	// Reset clears the tier.
+	ft.Reset("k")
+	if got := ft.GetRetryAfter("k"); got != RetryAfterNormalSec {
+		t.Fatalf("after reset: want %d, got %d", RetryAfterNormalSec, got)
+	}
+}
+
 func TestFailureTracker_Timestamps(t *testing.T) {
 	ft := NewFailureTracker()
 	defer ft.Stop()

--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -657,7 +657,13 @@ func (s *Server) setupRoutes() {
 		Expiration: authLimiterWindow,
 		KeyGenerator: middleware.CompositeKey,
 		LimitReached: func(c *fiber.Ctx) error {
-			c.Set("Retry-After", strconv.Itoa(int(authLimiterWindow.Seconds()))) // #7040
+			ip := c.IP()
+			retryAfter := failureTracker.GetRetryAfter(ip)
+			count := failureTracker.GetFailureCount(ip)
+			if count >= middleware.FailureThresholdSoftLock {
+				slog.Warn("[RateLimit] auth soft-lock", "ip", ip, "failures", count)
+			}
+			c.Set("Retry-After", strconv.Itoa(retryAfter)) // #7040 + #8676 Phase 2
 			return c.Status(429).JSON(fiber.Map{"error": "too many requests, try again later"})
 		},
 	})


### PR DESCRIPTION
## Summary
- Adds tiered threshold constants (`FailureThresholdEscalate`/`SoftLock`/`HardLock`) and corresponding `RetryAfter*Sec` constants to `pkg/api/middleware/ratelimit.go`
- Adds `GetRetryAfter(key)` method that maps failure count to the appropriate Retry-After tier
- Wires `RecordFailure(ip)` into `oauthErrorRedirect` in `auth.go` so every OAuth failure path feeds the tracker
- Updates `authLimiter.LimitReached` in `server.go` to use progressive Retry-After headers and emit `slog.Warn` at soft-lock level
- Adds comprehensive tests covering all tiers and reset behavior (84 LOC total)

## Threshold tiers
| Failures | Retry-After | Action |
|----------|-------------|--------|
| < 6      | 60s         | Normal |
| 6–10     | 300s (5min) | Escalate |
| 11–20    | 900s (15min)| Soft-lock + `slog.Warn` |
| 21+      | 3600s (1hr) | Hard-lock (GA4 event in Phase 3) |

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./pkg/api/middleware/...` passes (new `TestFailureTracker_GetRetryAfter`)
- [x] `go test ./pkg/api/handlers/...` passes
- [x] `npm run build` passes

Fixes #8676