### PR TITLE
feat: add re-scan button to ACMM Feedback Loop Inventory card

### DIFF
--- a/web/src/components/cards/ACMMFeedbackLoops.tsx
+++ b/web/src/components/cards/ACMMFeedbackLoops.tsx
@@ -7,7 +7,7 @@
  */
 
 import { useMemo, useState } from 'react'
-import { Check, X, Filter, ChevronDown, ChevronRight, Flag, Sparkles, Lock, Unlock, Eye } from 'lucide-react'
+import { Check, X, Filter, ChevronDown, ChevronRight, Flag, Sparkles, Lock, Unlock, Eye, RefreshCw } from 'lucide-react'
 import { useCardLoadingState } from './CardDataContext'
 import { CardSkeleton } from '../../lib/cards/CardComponents'
 import { useACMM } from '../acmm/ACMMProvider'
@@ -252,6 +252,18 @@ export function ACMMFeedbackLoops() {
           </button>
         ))}
         <div className="ml-auto flex items-center gap-1">
+          {/* Re-scan: force a fresh ACMM scan bypassing the server cache */}
+          <button
+            type="button"
+            onClick={() => scan.forceRefetch()}
+            disabled={scan.isLoading || scan.isRefreshing}
+            className="p-1 rounded hover:bg-muted/50 text-muted-foreground transition-colors disabled:opacity-50"
+            title="Re-scan current repo (bypasses server cache)"
+          >
+            <RefreshCw
+              className={`w-3.5 h-3.5 ${scan.isRefreshing ? 'animate-spin' : ''}`}
+            />
+          </button>
           {/* Lock-status chip — gamification: rows above earnedLevel are
               locked until the user finishes their current level. Click to
               toggle the session-scoped override. */}


### PR DESCRIPTION
## Summary
- Adds a RefreshCw re-scan button to the ACMM Feedback Loops card control bar
- Wires to `scan.forceRefetch()` to bypass server cache and trigger a fresh ACMM scan
- Button shows spin animation while refreshing, disabled during loading
- ~13 lines added, follows existing pattern from RepoPicker.tsx

## Test plan
- [ ] Open a dashboard with the ACMM Feedback Loop Inventory card
- [ ] Verify the refresh icon appears in the card control bar (between source filters and lock chip)
- [ ] Click the button — verify it spins during refresh and data updates
- [ ] Verify button is disabled while scan is in progress