### PR TITLE
feat: add container query infra + convert 5 pilot cards (Phase 2 of #8695)

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -17,6 +17,7 @@
         "@react-three/drei": "^10.7.7",
         "@react-three/fiber": "^9.5.0",
         "@sqlite.org/sqlite-wasm": "^3.51.2-build8",
+        "@tailwindcss/container-queries": "^0.1.1",
         "@tanstack/react-virtual": "^3.13.23",
         "@uiw/react-codemirror": "^4.25.9",
         "@xterm/addon-fit": "^0.11.0",
@@ -2774,6 +2775,15 @@
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
         "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
         "storybook": "^10.3.4"
+      }
+    },
+    "node_modules/@tailwindcss/container-queries": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/container-queries/-/container-queries-0.1.1.tgz",
+      "integrity": "sha512-p18dswChx6WnTSaJCSGx6lTmrGzNNvm2FtXmiO6AuA1V4U5REyoqwmT6kgAsIMdjo07QdAfYXHJ4hnMtfHzWgA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "tailwindcss": ">=3.2.0"
       }
     },
     "node_modules/@tanstack/react-virtual": {

--- a/web/package.json
+++ b/web/package.json
@@ -55,6 +55,7 @@
     "@react-three/drei": "^10.7.7",
     "@react-three/fiber": "^9.5.0",
     "@sqlite.org/sqlite-wasm": "^3.51.2-build8",
+    "@tailwindcss/container-queries": "^0.1.1",
     "@tanstack/react-virtual": "^3.13.23",
     "@uiw/react-codemirror": "^4.25.9",
     "@xterm/addon-fit": "^0.11.0",

--- a/web/src/components/cards/ActiveAlerts.tsx
+++ b/web/src/components/cards/ActiveAlerts.tsx
@@ -228,9 +228,10 @@ export function ActiveAlerts() {
 
   return (
     <div className="h-full flex flex-col">
-      {/* Header with controls */}
-      <div className="flex flex-wrap items-center justify-between gap-y-2 mb-2 flex-shrink-0">
-        <div className="flex items-center gap-2">
+      {/* Header with controls — uses @container queries so layout
+           responds to card width, not viewport width */}
+      <div className="flex flex-wrap @lg:flex-nowrap items-center justify-between gap-y-2 mb-2 flex-shrink-0">
+        <div className="flex items-center gap-2 @xs:flex-wrap">
           {stats.firing > 0 && (
             <StatusBadge color="red" variant="outline" rounded="full">
               {t('activeAlerts.firingCount', { count: stats.firing })}
@@ -289,7 +290,7 @@ export function ActiveAlerts() {
           </div>
         </div>
 
-        <div className="flex items-center gap-2">
+        <div className="flex items-center gap-2 @xs:flex-wrap">
           {/* 1. Ack'd toggle */}
           <button
             onClick={() => setShowAcknowledged(!showAcknowledged)}

--- a/web/src/components/cards/CardWrapper.tsx
+++ b/web/src/components/cards/CardWrapper.tsx
@@ -1336,6 +1336,12 @@ export function CardWrapper({
             {/* Content - hidden when collapsed, lazy loaded when visible or expanded */}
             {!isCollapsed && (
               <div className="flex-1 p-4 overflow-auto scroll-enhanced min-h-0 flex flex-col">
+                {/* Container query boundary — cards use @container breakpoints
+                    instead of viewport breakpoints so layouts respond to actual
+                    card width (which shrinks when side panels expand).
+                    Must be INSIDE overflow-auto (CSS spec: container-type and
+                    overflow conflict on the same element). */}
+                <div className="@container flex-1 flex flex-col min-h-0" style={{ containerType: 'inline-size' }}>
                 {(isVisible || isExpanded) ? (
                   <>
                     {/* Show skeleton overlay when loading with no cached data */}
@@ -1449,6 +1455,7 @@ export function CardWrapper({
                   // This provides visual continuity instead of a tiny pulse loader
                   <CardSkeleton type={effectiveSkeletonType} rows={skeletonRows || 3} showHeader={false} />
                 )}
+                </div>{/* Close @container query boundary */}
               </div>
             )}
 

--- a/web/src/components/cards/ClusterMetrics.tsx
+++ b/web/src/components/cards/ClusterMetrics.tsx
@@ -330,8 +330,8 @@ export function ClusterMetrics() {
 
   return (
     <div className="h-full flex flex-col">
-      {/* Header with metric value and selector */}
-      <div className="flex flex-wrap items-center justify-between gap-y-2 mb-2">
+      {/* Header with metric value and selector — @container responsive */}
+      <div className="flex flex-wrap @lg:flex-nowrap items-center justify-between gap-y-2 mb-2">
         <div>
           <h4 className="text-sm font-medium text-foreground">{config.label}</h4>
           <p className="text-2xl font-bold text-foreground">
@@ -355,8 +355,9 @@ export function ClusterMetrics() {
         </div>
       </div>
 
-      {/* Controls - single row: Cluster count → Time Range → Cluster Filter → Chart Mode → Refresh */}
-      <div className="flex items-center gap-2 mb-3">
+      {/* Controls - single row at wide widths, wraps at narrow.
+           Uses @container queries to respond to card width */}
+      <div className="flex flex-wrap @lg:flex-nowrap items-center gap-2 mb-3">
         {/* Cluster count indicator */}
         {localClusterFilter.length > 0 && (
           <span className="flex items-center gap-1 text-xs text-muted-foreground bg-secondary/50 px-1.5 py-0.5 rounded">

--- a/web/src/components/cards/GPUWorkloads.tsx
+++ b/web/src/components/cards/GPUWorkloads.tsx
@@ -225,14 +225,14 @@ export function GPUWorkloads({ config: _config }: GPUWorkloadsProps) {
 
   return (
     <div className="h-full flex flex-col content-loaded">
-      {/* Controls */}
-      <div className="flex flex-wrap items-center justify-between gap-y-2 mb-3">
+      {/* Controls — @container responsive */}
+      <div className="flex flex-wrap @lg:flex-nowrap items-center justify-between gap-y-2 mb-3">
         {summary.failed > 0 ? (
           <StatusBadge color="red">
             {t('gpuWorkloads.failedCount', { count: summary.failed })}
           </StatusBadge>
         ) : <div />}
-        <div className="flex items-center gap-2">
+        <div className="flex items-center gap-2 @xs:flex-wrap">
           {/* Cluster count indicator */}
           {filters.localClusterFilter.length > 0 && (
             <span className="flex items-center gap-1 text-xs text-muted-foreground bg-secondary/50 px-1.5 py-0.5 rounded">
@@ -272,8 +272,8 @@ export function GPUWorkloads({ config: _config }: GPUWorkloadsProps) {
         placeholder={t('gpuWorkloads.searchPlaceholder')}
       />
 
-      {/* Summary stats */}
-      <div className="grid grid-cols-2 sm:grid-cols-4 gap-2 mb-3">
+      {/* Summary stats — @container responsive grid */}
+      <div className="grid grid-cols-2 @md:grid-cols-4 gap-2 mb-3">
         <div className="p-2 rounded-lg bg-secondary/30 text-center" title={t('gpuWorkloads.totalGPUWorkloads', { count: summary.total })}>
           <p className="text-lg font-bold text-foreground">{summary.total}</p>
           <p className="text-xs text-muted-foreground">{t('common:common.total')}</p>

--- a/web/src/components/cards/IssueActivityChart.tsx
+++ b/web/src/components/cards/IssueActivityChart.tsx
@@ -551,8 +551,8 @@ export function IssueActivityChart(props: { config?: IssueActivityConfig }) {
 
   return (
     <div className="p-4 space-y-3">
-      {/* Header */}
-      <div className="flex flex-wrap items-center justify-between gap-2">
+      {/* Header — @container responsive */}
+      <div className="flex flex-wrap @lg:flex-nowrap items-center justify-between gap-2">
         <div className="flex items-center gap-2">
           <Calendar className="h-4 w-4 text-muted-foreground" />
           <RepoSubtitle repo={repo} />
@@ -590,7 +590,7 @@ export function IssueActivityChart(props: { config?: IssueActivityConfig }) {
         </div>
       </div>
 
-      {/* Summary stats */}
+      {/* Summary stats — @container responsive grid */}
       {visibleStats.isCustomRange && visibleStats.startDate && visibleStats.endDate && (
         <div className="text-[10px] text-muted-foreground text-center">
           {t('issueActivityChart.showingRange', 'Showing {{start}} to {{end}}', {
@@ -599,7 +599,7 @@ export function IssueActivityChart(props: { config?: IssueActivityConfig }) {
           })}
         </div>
       )}
-      <div className="grid grid-cols-2 sm:grid-cols-3 gap-3">
+      <div className="grid grid-cols-2 @md:grid-cols-3 gap-3">
         <div className="rounded-md bg-blue-500/10 border border-blue-500/20 px-3 py-2 text-center">
           <div className="text-lg font-semibold text-blue-400">{visibleStats.totalOpened}</div>
           <div className="text-[10px] text-muted-foreground uppercase tracking-wide">

--- a/web/src/components/cards/workload-detection/LLMInference.tsx
+++ b/web/src/components/cards/workload-detection/LLMInference.tsx
@@ -162,9 +162,9 @@ export function LLMInference({ config: _config }: LLMInferenceProps) {
 
   return (
     <div className="h-full flex flex-col min-h-card">
-      {/* Header controls */}
-      <div className="flex flex-wrap items-center justify-between gap-y-2 mb-4">
-        <div className="flex items-center gap-2">
+      {/* Header controls — @container responsive */}
+      <div className="flex flex-wrap @lg:flex-nowrap items-center justify-between gap-y-2 mb-4">
+        <div className="flex items-center gap-2 @xs:flex-wrap">
           <RefreshIndicator
             isRefreshing={isRefreshing}
             lastUpdated={lastRefresh ? new Date(lastRefresh) : null}
@@ -188,7 +188,7 @@ export function LLMInference({ config: _config }: LLMInferenceProps) {
             {items.filter(s => s.status === 'running').length} running
           </StatusBadge>
         </div>
-        <div className="flex items-center gap-2">
+        <div className="flex items-center gap-2 @xs:flex-wrap">
           {/* Component type filter */}
           <div ref={componentFilterRef} className="relative">
             <button

--- a/web/tailwind.config.js
+++ b/web/tailwind.config.js
@@ -1,3 +1,5 @@
+import containerQueries from '@tailwindcss/container-queries'
+
 /** @type {import('tailwindcss').Config} */
 export default {
   content: [
@@ -18,6 +20,22 @@ export default {
   ],
   theme: {
     extend: {
+      /**
+       * Container query breakpoint tokens for card-width-responsive layouts.
+       * Cards use @container queries instead of viewport breakpoints so they
+       * respond to their own width (which shrinks when panels expand).
+       *
+       * @xs  (<300px)  — stack vertically, hide non-essential controls
+       * @sm  (300px+)  — two-row wrapped layout
+       * @md  (450px+)  — relaxed wrapping
+       * @lg  (600px+)  — single-row layout (full width)
+       */
+      containers: {
+        xs: '300px',
+        sm: '300px',
+        md: '450px',
+        lg: '600px',
+      },
       fontSize: {
         '2xs': ['10px', { lineHeight: '14px' }],
       },
@@ -145,5 +163,5 @@ export default {
       },
     },
   },
-  plugins: [],
+  plugins: [containerQueries],
 }


### PR DESCRIPTION
## Summary

- Install `@tailwindcss/container-queries` plugin and define standard card-width breakpoint tokens (`@xs` <300px, `@sm` 300px, `@md` 450px, `@lg` 600px) in `tailwind.config.js`
- Add a `container-type: inline-size` wrapper div inside `CardWrapper.tsx` so every card can use `@container` queries to respond to its own width rather than the viewport width
- Convert the 5 worst-offending cards to use `@container` breakpoints instead of viewport breakpoints:
  - **ActiveAlerts** — control bar wraps at narrow card widths
  - **ClusterMetrics** — metric header and controls row wrap responsively
  - **LLMInference** — header controls and filter groups adapt to card width
  - **GPUWorkloads** — controls and summary stats grid use container queries
  - **IssueActivityChart** — header and summary stats grid use container queries

This is Phase 2 of the card overlap fix. Phase 1 (flex-wrap safety net, PR #8735) is already merged. Phase 3 (converting remaining cards) will follow separately.

Fixes #8695

## Test plan

- [ ] Verify cards render correctly at full dashboard width
- [ ] Resize browser with side panel open to confirm control bars wrap at card-width breakpoints (not viewport)
- [ ] Confirm no layout regression on the 5 converted cards
- [ ] Verify build and lint pass