### PR TITLE
feat: add SQLite audit table + admin query API (Phase 3 of #8670)

### DIFF
--- a/pkg/api/audit/audit.go
+++ b/pkg/api/audit/audit.go
@@ -1,15 +1,22 @@
 // Package audit provides structured logging helpers for security-sensitive
 // operations such as role changes, user deletions, and unauthorized access
 // attempts. Phase 1 of #8670.
+//
+// Phase 3 adds opt-in SQLite persistence: call SetStore once at startup to
+// enable writing audit entries to the audit_log table in addition to slog.
 package audit
 
 import (
+	"context"
+	"encoding/json"
 	"log/slog"
 	"strings"
+	"sync"
 
 	"github.com/gofiber/fiber/v2"
 
 	"github.com/kubestellar/console/pkg/api/middleware"
+	"github.com/kubestellar/console/pkg/store"
 )
 
 // Action constants identify the kind of auditable event.
@@ -19,20 +26,45 @@ const (
 	ActionUnauthorizedAttempt = "unauthorized_attempt"
 
 	// Phase 2: settings, cluster groups, notifications, tokens, quotas.
-	ActionSaveSettings         = "save_settings"
-	ActionImportSettings       = "import_settings"
-	ActionExportSettings       = "export_settings"
-	ActionCreateClusterGroup   = "create_cluster_group"
-	ActionUpdateClusterGroup   = "update_cluster_group"
-	ActionDeleteClusterGroup   = "delete_cluster_group"
+	ActionSaveSettings           = "save_settings"
+	ActionImportSettings         = "import_settings"
+	ActionExportSettings         = "export_settings"
+	ActionCreateClusterGroup     = "create_cluster_group"
+	ActionUpdateClusterGroup     = "update_cluster_group"
+	ActionDeleteClusterGroup     = "delete_cluster_group"
 	ActionSaveNotificationConfig = "save_notification_config"
-	ActionDeleteToken          = "delete_token"
-	ActionCreateResourceQuota  = "create_resource_quota"
-	ActionDeleteResourceQuota  = "delete_resource_quota"
+	ActionDeleteToken            = "delete_token"
+	ActionCreateResourceQuota    = "create_resource_quota"
+	ActionDeleteResourceQuota    = "delete_resource_quota"
 )
+
+// storeMu guards the package-level store reference.
+var (
+	storeMu   sync.RWMutex
+	auditStore store.Store
+)
+
+// SetStore enables SQLite persistence for audit entries. Pass nil to disable.
+// Safe to call concurrently but typically called once at startup.
+func SetStore(s store.Store) {
+	storeMu.Lock()
+	defer storeMu.Unlock()
+	auditStore = s
+}
+
+// getStore returns the current store (or nil if not set).
+func getStore() store.Store {
+	storeMu.RLock()
+	defer storeMu.RUnlock()
+	return auditStore
+}
 
 // Log emits a structured audit log entry for a security-sensitive operation.
 // Optional detail strings are joined with a space and included in the entry.
+//
+// If a store has been set via SetStore, the entry is also persisted to SQLite.
+// Store write failures are logged but never propagated to the caller — audit
+// persistence is best-effort so it cannot break request handling.
 func Log(c *fiber.Ctx, action, targetType, targetID string, details ...string) {
 	userID := middleware.GetUserID(c)
 	ip := c.IP()
@@ -47,9 +79,26 @@ func Log(c *fiber.Ctx, action, targetType, targetID string, details ...string) {
 		"method", c.Method(),
 	}
 
+	detailText := ""
 	if len(details) > 0 {
-		attrs = append(attrs, "details", strings.Join(details, " "))
+		detailText = strings.Join(details, " ")
+		attrs = append(attrs, "details", detailText)
 	}
 
 	slog.Info("audit", attrs...)
+
+	// Persist to SQLite if a store is available.
+	if s := getStore(); s != nil {
+		detail, _ := json.Marshal(map[string]string{
+			"target_type": targetType,
+			"target_id":   targetID,
+			"ip":          ip,
+			"path":        c.Path(),
+			"method":      c.Method(),
+			"details":     detailText,
+		})
+		if err := s.InsertAuditLog(context.Background(), userID.String(), action, string(detail)); err != nil {
+			slog.Error("audit: failed to persist audit entry", "error", err, "action", action)
+		}
+	}
 }

--- a/pkg/api/handlers/audit.go
+++ b/pkg/api/handlers/audit.go
@@ -1,0 +1,59 @@
+package handlers
+
+import (
+	"strconv"
+
+	"github.com/gofiber/fiber/v2"
+
+	"github.com/kubestellar/console/pkg/store"
+)
+
+// defaultAuditLimit is used when the "limit" query param is absent or zero.
+const defaultAuditLimit = 50
+
+// maxAuditLimit caps the "limit" query param to prevent unbounded reads.
+const maxAuditLimit = 200
+
+// AuditHandler serves the admin audit-log query endpoint (#8670 Phase 3).
+type AuditHandler struct {
+	store store.Store
+}
+
+// NewAuditHandler creates an AuditHandler backed by the given store.
+func NewAuditHandler(s store.Store) *AuditHandler {
+	return &AuditHandler{store: s}
+}
+
+// GetAuditLog returns recent audit entries, newest first.
+//
+// Query params:
+//   - limit  — max entries to return (default 50, capped at 200)
+//   - user_id — optional filter by actor
+//   - action  — optional filter by action constant
+//
+// In demo mode, returns an empty JSON array.
+func (h *AuditHandler) GetAuditLog(c *fiber.Ctx) error {
+	if isDemoMode(c) {
+		return c.JSON(make([]store.AuditEntry, 0))
+	}
+
+	limit := defaultAuditLimit
+	if q := c.Query("limit"); q != "" {
+		if v, err := strconv.Atoi(q); err == nil && v > 0 {
+			limit = v
+		}
+	}
+	if limit > maxAuditLimit {
+		limit = maxAuditLimit
+	}
+
+	userID := c.Query("user_id")
+	action := c.Query("action")
+
+	entries, err := h.store.QueryAuditLogs(c.Context(), limit, userID, action)
+	if err != nil {
+		return fiber.NewError(fiber.StatusInternalServerError, "failed to query audit log")
+	}
+
+	return c.JSON(entries)
+}

--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -28,6 +28,7 @@ import (
 	"github.com/gofiber/fiber/v2/middleware/recover"
 
 	"github.com/kubestellar/console/pkg/agent"
+	"github.com/kubestellar/console/pkg/api/audit"
 	"github.com/kubestellar/console/pkg/api/handlers"
 	"github.com/kubestellar/console/pkg/api/middleware"
 	"github.com/kubestellar/console/pkg/k8s"
@@ -334,6 +335,9 @@ func NewServer(cfg Config) (*Server, error) {
 		loadingSrv:          loadingSrv,
 		done:                make(chan struct{}),
 	}
+
+	// Enable SQLite persistence for audit entries (#8670 Phase 3).
+	audit.SetStore(db)
 
 	server.setupMiddleware()
 	server.setupRoutes()
@@ -919,6 +923,10 @@ func (s *Server) setupRoutes() {
 	// ${LOCAL_AGENT_HTTP_URL}/rbac/can-i so SelfSubjectAccessReviews run
 	// under the user's kubeconfig instead of the backend pod ServiceAccount
 	// when console is deployed in-cluster.
+
+	// Admin audit-log endpoint (#8670 Phase 3) — returns recent audit entries.
+	auditHandler := handlers.NewAuditHandler(s.store)
+	api.Get("/admin/audit-log", auditHandler.GetAuditLog)
 
 	// Namespace read routes. GET /namespaces is viewer-or-above (see
 	// ListNamespaces's requireViewerOrAbove check) and

--- a/pkg/store/sqlite.go
+++ b/pkg/store/sqlite.go
@@ -468,6 +468,18 @@ func (s *SQLiteStore) migrate() error {
 		data BLOB NOT NULL,
 		updated_at DATETIME DEFAULT CURRENT_TIMESTAMP
 	);
+
+	-- Audit log for security-sensitive operations (#8670 Phase 3).
+	-- Entries are append-only; the detail column holds a JSON blob with
+	-- action-specific context (target type, target ID, IP, path, etc.).
+	CREATE TABLE IF NOT EXISTS audit_log (
+		id INTEGER PRIMARY KEY AUTOINCREMENT,
+		timestamp TEXT NOT NULL,
+		user_id TEXT NOT NULL,
+		action TEXT NOT NULL,
+		detail TEXT
+	);
+	CREATE INDEX IF NOT EXISTS idx_audit_log_user_time ON audit_log(user_id, timestamp);
 	`
 	_, err := s.db.Exec(schema)
 	if err != nil {
@@ -2985,4 +2997,70 @@ func (s *SQLiteStore) ListClusterGroups() (map[string][]byte, error) {
 		groups[name] = data
 	}
 	return groups, rows.Err()
+}
+
+// ---------------------------------------------------------------------------
+// Audit Log (#8670 Phase 3)
+// ---------------------------------------------------------------------------
+
+// maxAuditQueryLimit is the upper bound on rows returned by QueryAuditLogs
+// to prevent unbounded reads from large audit tables.
+const maxAuditQueryLimit = 200
+
+// defaultAuditQueryLimit is used when the caller passes 0 for limit.
+const defaultAuditQueryLimit = 50
+
+// InsertAuditLog appends an audit entry to the audit_log table.
+func (s *SQLiteStore) InsertAuditLog(ctx context.Context, userID, action, detail string) error {
+	_, err := s.db.ExecContext(ctx,
+		`INSERT INTO audit_log (timestamp, user_id, action, detail) VALUES (?, ?, ?, ?)`,
+		time.Now().UTC().Format(time.RFC3339), userID, action, detail,
+	)
+	return err
+}
+
+// QueryAuditLogs returns recent audit entries, newest first. Empty userID or
+// action strings disable the corresponding filter. Limit is clamped to
+// maxAuditQueryLimit.
+func (s *SQLiteStore) QueryAuditLogs(ctx context.Context, limit int, userID, action string) ([]AuditEntry, error) {
+	if limit <= 0 {
+		limit = defaultAuditQueryLimit
+	}
+	if limit > maxAuditQueryLimit {
+		limit = maxAuditQueryLimit
+	}
+
+	query := `SELECT id, timestamp, user_id, action, COALESCE(detail, '') FROM audit_log`
+	args := make([]interface{}, 0)
+	clauses := make([]string, 0)
+
+	if userID != "" {
+		clauses = append(clauses, "user_id = ?")
+		args = append(args, userID)
+	}
+	if action != "" {
+		clauses = append(clauses, "action = ?")
+		args = append(args, action)
+	}
+	if len(clauses) > 0 {
+		query += " WHERE " + strings.Join(clauses, " AND ")
+	}
+	query += " ORDER BY id DESC LIMIT ?"
+	args = append(args, limit)
+
+	rows, err := s.db.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	entries := make([]AuditEntry, 0)
+	for rows.Next() {
+		var e AuditEntry
+		if err := rows.Scan(&e.ID, &e.Timestamp, &e.UserID, &e.Action, &e.Detail); err != nil {
+			return nil, err
+		}
+		entries = append(entries, e)
+	}
+	return entries, rows.Err()
 }

--- a/pkg/store/store.go
+++ b/pkg/store/store.go
@@ -45,6 +45,15 @@ type UserTokenUsage struct {
 	UpdatedAt          time.Time
 }
 
+// AuditEntry represents a single row in the audit_log table (#8670 Phase 3).
+type AuditEntry struct {
+	ID        int64  `json:"id"`
+	Timestamp string `json:"timestamp"`
+	UserID    string `json:"user_id"`
+	Action    string `json:"action"`
+	Detail    string `json:"detail,omitempty"`
+}
+
 // Store defines the interface for data persistence
 type Store interface {
 	// Users
@@ -238,6 +247,15 @@ type Store interface {
 	// the BEGIN IMMEDIATE transaction if the browser disconnects.
 	ConsumeOAuthState(ctx context.Context, state string) (bool, error)
 	CleanupExpiredOAuthStates() (int64, error)
+
+	// Audit Log — persistent audit trail for security-sensitive operations
+	// (#8670 Phase 3). Entries survive restarts so admins can review who did
+	// what. The detail field is a JSON blob for action-specific context.
+	InsertAuditLog(ctx context.Context, userID, action, detail string) error
+	// QueryAuditLogs returns recent audit entries, newest first. All filter
+	// parameters are optional (empty string = no filter). Limit is clamped
+	// to maxAuditQueryLimit internally.
+	QueryAuditLogs(ctx context.Context, limit int, userID, action string) ([]AuditEntry, error)
 
 	// Cluster Groups — persistent storage for cluster group definitions so they
 	// survive server restarts (#7013). The in-memory map is the runtime cache;

--- a/pkg/test/mock_store.go
+++ b/pkg/test/mock_store.go
@@ -369,4 +369,16 @@ func (m *MockStore) ListClusterGroups() (map[string][]byte, error) {
 	return args.Get(0).(map[string][]byte), args.Error(1)
 }
 
+func (m *MockStore) InsertAuditLog(_ context.Context, _, _, _ string) error {
+	return nil
+}
+
+func (m *MockStore) QueryAuditLogs(_ context.Context, limit int, userID, action string) ([]store.AuditEntry, error) {
+	args := m.Called(limit, userID, action)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).([]store.AuditEntry), args.Error(1)
+}
+
 func (m *MockStore) Close() error { return nil }


### PR DESCRIPTION
## Summary
- Adds `audit_log` SQLite table with `id`, `timestamp`, `user_id`, `action`, `detail` columns and a composite index on `(user_id, timestamp)`
- Adds `InsertAuditLog` and `QueryAuditLogs` to the store interface + SQLite implementation
- Updates `audit.Log` to persist entries to SQLite via opt-in `audit.SetStore()` — nil-safe, best-effort (failures logged, never propagated)
- Adds `GET /api/admin/audit-log` endpoint with `limit`, `user_id`, `action` query params; returns `[]` in demo mode
- Updates `MockStore` to satisfy the new interface methods

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./pkg/store/... ./pkg/api/...` passes
- [x] `cd web && npm run build` passes
- [ ] CI build/lint pass

Fixes #8670