### PR TITLE
fix: update useCachedData tests after Zod validation (#8765)

### DIFF
--- a/web/src/hooks/__tests__/useCachedData.test.ts
+++ b/web/src/hooks/__tests__/useCachedData.test.ts
@@ -101,6 +101,11 @@ vi.mock('../useCachedISO27001', () => ({}))
 // Stub the re-exports so the module loads cleanly
 vi.mock('../useWorkloads', () => ({}))
 
+vi.mock('../../lib/schemas/validate', () => ({
+  validateResponse: (_schema: unknown, data: unknown) => data,
+  validateArrayResponse: (_schema: unknown, data: unknown) => data,
+}))
+
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------

--- a/web/src/hooks/useCachedData.test.ts
+++ b/web/src/hooks/useCachedData.test.ts
@@ -60,6 +60,11 @@ vi.mock('../lib/sseClient', () => ({
   fetchSSE: vi.fn().mockResolvedValue([]),
 }))
 
+vi.mock('../lib/schemas/validate', () => ({
+  validateResponse: (_schema: unknown, data: unknown) => data,
+  validateArrayResponse: (_schema: unknown, data: unknown) => data,
+}))
+
 vi.mock('./mcp/shared', () => ({
   clusterCacheRef: mockClusterCacheRef,
 }))


### PR DESCRIPTION
## Summary
- Mock `validateArrayResponse` and `validateResponse` in both useCachedData test files to pass data through without Zod schema validation
- The tests verify hook logic (sorting, routing, caching), not schema validation — schema validation has its own dedicated tests in `lib/schemas/__tests__/kubernetes.test.ts`
- Root cause: PR #8765 added Zod runtime validation to fetchers, but test mock data uses minimal objects that don't conform to the full schemas, causing `validateArrayResponse` to return empty fallback arrays

Fixes #8774

## Test plan
- [x] All 405 useCachedData tests pass (previously 11 failing)
- [x] `npm run build` passes
- [x] Lint clean on changed files