### PR TITLE
feat: add rate-limit admin visibility + metrics endpoint (Phase 3 of #8676)

### DIFF
--- a/pkg/api/handlers/admin.go
+++ b/pkg/api/handlers/admin.go
@@ -1,0 +1,28 @@
+package handlers
+
+import (
+	"github.com/gofiber/fiber/v2"
+	"github.com/kubestellar/console/pkg/api/middleware"
+)
+
+// AdminHandler exposes internal operational state for administrator visibility.
+type AdminHandler struct {
+	tracker *middleware.FailureTracker
+}
+
+// NewAdminHandler creates a handler wired to the given FailureTracker.
+func NewAdminHandler(ft *middleware.FailureTracker) *AdminHandler {
+	return &AdminHandler{tracker: ft}
+}
+
+// GetRateLimitStatus returns a snapshot of every tracked key, its failure count,
+// tier, and Retry-After value. In demo mode it returns an empty set.
+func (h *AdminHandler) GetRateLimitStatus(c *fiber.Ctx) error {
+	if isDemoMode(c) {
+		return c.JSON(middleware.StatusResponse{
+			Keys:  make([]middleware.KeyStatus, 0),
+			Total: 0,
+		})
+	}
+	return c.JSON(h.tracker.Status())
+}

--- a/pkg/api/middleware/ratelimit.go
+++ b/pkg/api/middleware/ratelimit.go
@@ -58,6 +58,8 @@ func NewFailureTracker() *FailureTracker {
 }
 
 // RecordFailure increments the failure count for key and updates timestamps.
+// When the count crosses the hard-lock threshold, a structured log event is
+// emitted so that external monitors (e.g. GA4 error workflow) can alert on it.
 func (ft *FailureTracker) RecordFailure(key string) {
 	ft.mu.Lock()
 	defer ft.mu.Unlock()
@@ -69,6 +71,15 @@ func (ft *FailureTracker) RecordFailure(key string) {
 	}
 	rec.Count++
 	rec.LastAt = now
+
+	// Emit structured log when crossing the hard-lock threshold (#8676 Phase 3).
+	if rec.Count == FailureThresholdHardLock {
+		slog.Error("[RateLimit] hard-lock threshold reached",
+			"event", "rate_limit_hard_lock",
+			"key", key,
+			"failures", rec.Count,
+		)
+	}
 }
 
 // GetFailureCount returns the current failure count for key (0 if absent).
@@ -92,7 +103,58 @@ func (ft *FailureTracker) Reset(key string) {
 // GetRetryAfter returns the Retry-After value (seconds) for the given key
 // based on which failure-count tier it falls into (#8676 Phase 2).
 func (ft *FailureTracker) GetRetryAfter(key string) int {
-	count := ft.GetFailureCount(key)
+	return retryAfterForCount(ft.GetFailureCount(key))
+}
+
+// KeyStatus describes the rate-limit state for a single tracked key.
+type KeyStatus struct {
+	Key           string `json:"key"`
+	Failures      int    `json:"failures"`
+	Tier          string `json:"tier"`
+	LastFailure   string `json:"lastFailure"`
+	RetryAfterSec int    `json:"retryAfterSec"`
+}
+
+// TierName returns the human-readable tier for the given failure count.
+func TierName(count int) string {
+	switch {
+	case count >= FailureThresholdHardLock:
+		return "hard-lock"
+	case count >= FailureThresholdSoftLock:
+		return "soft-lock"
+	case count >= FailureThresholdEscalate:
+		return "escalate"
+	default:
+		return "normal"
+	}
+}
+
+// StatusResponse is the JSON shape returned by the admin metrics endpoint.
+type StatusResponse struct {
+	Keys  []KeyStatus `json:"keys"`
+	Total int         `json:"total"`
+}
+
+// Status returns a snapshot of all tracked keys and their current tier.
+func (ft *FailureTracker) Status() StatusResponse {
+	ft.mu.Lock()
+	defer ft.mu.Unlock()
+	keys := make([]KeyStatus, 0, len(ft.failures))
+	for k, rec := range ft.failures {
+		keys = append(keys, KeyStatus{
+			Key:           k,
+			Failures:      rec.Count,
+			Tier:          TierName(rec.Count),
+			LastFailure:   rec.LastAt.UTC().Format(time.RFC3339),
+			RetryAfterSec: retryAfterForCount(rec.Count),
+		})
+	}
+	return StatusResponse{Keys: keys, Total: len(keys)}
+}
+
+// retryAfterForCount returns the Retry-After seconds for a given count without
+// acquiring the lock (used internally by Status which already holds it).
+func retryAfterForCount(count int) int {
 	switch {
 	case count >= FailureThresholdHardLock:
 		return RetryAfterHardLockSec

--- a/pkg/api/middleware/ratelimit_test.go
+++ b/pkg/api/middleware/ratelimit_test.go
@@ -108,6 +108,74 @@ func TestFailureTracker_GetRetryAfter(t *testing.T) {
 	}
 }
 
+func TestTierName(t *testing.T) {
+	tests := []struct {
+		count int
+		want  string
+	}{
+		{0, "normal"},
+		{FailureThresholdEscalate - 1, "normal"},
+		{FailureThresholdEscalate, "escalate"},
+		{FailureThresholdSoftLock, "soft-lock"},
+		{FailureThresholdHardLock, "hard-lock"},
+		{FailureThresholdHardLock + 10, "hard-lock"},
+	}
+	for _, tt := range tests {
+		if got := TierName(tt.count); got != tt.want {
+			t.Errorf("TierName(%d) = %q, want %q", tt.count, got, tt.want)
+		}
+	}
+}
+
+func TestFailureTracker_Status(t *testing.T) {
+	ft := NewFailureTracker()
+	defer ft.Stop()
+
+	// Empty tracker.
+	s := ft.Status()
+	if s.Total != 0 {
+		t.Fatalf("empty tracker: want total=0, got %d", s.Total)
+	}
+	if len(s.Keys) != 0 {
+		t.Fatalf("empty tracker: want 0 keys, got %d", len(s.Keys))
+	}
+
+	// Add some keys at different tiers.
+	ft.RecordFailure("a")
+	for i := 0; i < FailureThresholdSoftLock; i++ {
+		ft.RecordFailure("b")
+	}
+
+	s = ft.Status()
+	if s.Total != 2 {
+		t.Fatalf("want total=2, got %d", s.Total)
+	}
+
+	byKey := make(map[string]KeyStatus)
+	for _, ks := range s.Keys {
+		byKey[ks.Key] = ks
+	}
+
+	aStatus := byKey["a"]
+	if aStatus.Failures != 1 || aStatus.Tier != "normal" {
+		t.Fatalf("key a: want 1/normal, got %d/%s", aStatus.Failures, aStatus.Tier)
+	}
+	if aStatus.RetryAfterSec != RetryAfterNormalSec {
+		t.Fatalf("key a retryAfter: want %d, got %d", RetryAfterNormalSec, aStatus.RetryAfterSec)
+	}
+
+	bStatus := byKey["b"]
+	if bStatus.Tier != "soft-lock" {
+		t.Fatalf("key b: want soft-lock, got %s", bStatus.Tier)
+	}
+	if bStatus.RetryAfterSec != RetryAfterSoftLockSec {
+		t.Fatalf("key b retryAfter: want %d, got %d", RetryAfterSoftLockSec, bStatus.RetryAfterSec)
+	}
+	if bStatus.LastFailure == "" {
+		t.Fatal("key b: LastFailure should not be empty")
+	}
+}
+
 func TestFailureTracker_Timestamps(t *testing.T) {
 	ft := NewFailureTracker()
 	defer ft.Stop()

--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -936,6 +936,10 @@ func (s *Server) setupRoutes() {
 	api.Get("/namespaces", namespaces.ListNamespaces)
 	api.Get("/namespaces/:name/access", namespaces.GetNamespaceAccess)
 
+	// Admin visibility routes — rate-limit metrics (#8676 Phase 3).
+	adminHandler := handlers.NewAdminHandler(failureTracker)
+	api.Get("/admin/rate-limit-status", adminHandler.GetRateLimitStatus)
+
 	// Mission knowledge base routes (validate, share — protected)
 	missions.RegisterRoutes(api.Group("/missions"))
 


### PR DESCRIPTION
## Summary
- Add `GET /api/admin/rate-limit-status` endpoint returning a snapshot of all tracked rate-limit keys with failure count, tier, last-failure timestamp, and Retry-After value
- Add `Status()` method to `FailureTracker` and supporting types (`KeyStatus`, `StatusResponse`, `TierName`)
- Emit structured `slog.Error` with `event=rate_limit_hard_lock` when a key crosses the hard-lock threshold (21+ failures) for GA4 error monitor pickup
- Refactor `GetRetryAfter` to share `retryAfterForCount` helper, removing duplicated tier-switch logic
- Demo mode returns `{ keys: [], total: 0 }`

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` passes (new tests for `Status()` and `TierName()`)
- [x] `npm run build` passes
- [ ] CI build/lint pass

Fixes #8676