### PR TITLE
fix: auto-generate nightly release notes from merged PR titles

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -66,6 +66,10 @@ checksum:
   name_template: "checksums.txt"
 
 changelog:
+  # Use GitHub's auto-generated release notes (based on merged PR titles)
+  # instead of raw commit messages. This populates the release body so the
+  # "What's New" modal has content for nightly and weekly releases.
+  use: github
   sort: asc
   filters:
     exclude:


### PR DESCRIPTION
## Summary
- Adds `use: github` to the GoReleaser changelog config so releases use GitHub's auto-generated release notes (based on merged PR titles) instead of raw commit messages
- This populates the release body for nightly and weekly releases, fixing the "No release notes available" message in the What's New modal

Fixes #8778

## Test plan
- [ ] Next nightly release should have auto-generated release notes body
- [ ] What's New modal should display PR titles instead of "No release notes available"