### PR TITLE
feat: rollout container queries to remaining cards (Phase 3 of #8695)

### DIFF
--- a/web/src/components/cards/ArgoCDApplicationSets.tsx
+++ b/web/src/components/cards/ArgoCDApplicationSets.tsx
@@ -213,7 +213,7 @@ function ArgoCDApplicationSetsInternal({ config }: ArgoCDApplicationSetsProps) {
       />
 
       {/* Stats */}
-      <div className="grid grid-cols-2 sm:grid-cols-3 gap-2 mb-3">
+      <div className="grid grid-cols-2 @md:grid-cols-3 gap-2 mb-3">
         <div className="text-center p-2 rounded-lg bg-green-500/10">
           <p className="text-lg font-bold text-green-400">{stats.healthy}</p>
           <p className="text-xs text-muted-foreground">Healthy</p>

--- a/web/src/components/cards/ArgoCDApplications.tsx
+++ b/web/src/components/cards/ArgoCDApplications.tsx
@@ -237,7 +237,7 @@ function ArgoCDApplicationsInternal({ config }: ArgoCDApplicationsProps) {
       />
 
       {/* Stats */}
-      <div className="grid grid-cols-2 sm:grid-cols-4 gap-2 mb-3">
+      <div className="grid grid-cols-2 @md:grid-cols-4 gap-2 mb-3">
         <div className="text-center p-2 rounded-lg bg-green-500/10 cursor-pointer hover:bg-green-500/20"
              role="button" tabIndex={0}
              aria-label={`Show all applications (${stats.synced} synced)`}

--- a/web/src/components/cards/CRDHealth.tsx
+++ b/web/src/components/cards/CRDHealth.tsx
@@ -227,7 +227,7 @@ export function CRDHealth({ config: _config }: CRDHealthProps) {
           </div>
 
           {/* Summary */}
-          <div className="grid grid-cols-2 sm:grid-cols-4 gap-2 mb-4">
+          <div className="grid grid-cols-2 @md:grid-cols-4 gap-2 mb-4">
             <div className="p-2 rounded-lg bg-cyan-500/10 text-center">
               <span className="text-lg font-bold text-cyan-400">{statsSource.length}</span>
               <p className="text-xs text-muted-foreground">{t('crdHealth.crds')}</p>

--- a/web/src/components/cards/ClusterComparison.tsx
+++ b/web/src/components/cards/ClusterComparison.tsx
@@ -112,7 +112,7 @@ function ClusterComparisonInternal({ config }: ClusterComparisonProps) {
           <Skeleton variant="text" width={150} height={20} />
           <Skeleton variant="rounded" width={80} height={28} />
         </div>
-        <div className="grid grid-cols-2 sm:grid-cols-3 gap-2">
+        <div className="grid grid-cols-2 @md:grid-cols-3 gap-2">
           <Skeleton variant="rounded" height={150} />
           <Skeleton variant="rounded" height={150} />
           <Skeleton variant="rounded" height={150} />

--- a/web/src/components/cards/ClusterCosts.tsx
+++ b/web/src/components/cards/ClusterCosts.tsx
@@ -429,7 +429,7 @@ export function ClusterCosts({ config }: ClusterCostsProps) {
               title={t('cards:clusterCosts.pricingSettings')}
             >
               <Settings2 className="w-3.5 h-3.5" />
-              <span className="hidden sm:inline">{pricingMode === 'per-cluster' ? t('cards:clusterCosts.perCluster') : t('cards:clusterCosts.uniform')}</span>
+              <span className="hidden @sm:inline">{pricingMode === 'per-cluster' ? t('cards:clusterCosts.perCluster') : t('cards:clusterCosts.uniform')}</span>
             </button>
             {showSettingsMenu && (
               <div className="absolute top-full left-0 mt-1 w-52 bg-card border border-border rounded-lg shadow-lg z-20 py-2">
@@ -560,7 +560,7 @@ export function ClusterCosts({ config }: ClusterCostsProps) {
                   </a>
                 )}
               </div>
-              <div className="grid grid-cols-2 sm:grid-cols-3 gap-2 mb-2">
+              <div className="grid grid-cols-2 @md:grid-cols-3 gap-2 mb-2">
                 <div className="p-2 rounded bg-secondary/50">
                   <p className="text-muted-foreground mb-0.5">{t('common:common.cpu')}</p>
                   <p className="text-foreground font-medium">${cpuCost.toFixed(3)}/hr</p>

--- a/web/src/components/cards/ClusterHealth.tsx
+++ b/web/src/components/cards/ClusterHealth.tsx
@@ -264,7 +264,7 @@ export function ClusterHealth() {
       />
 
       {/* Stats */}
-      <div className="grid grid-cols-2 sm:grid-cols-4 gap-2 mb-4">
+      <div className="grid grid-cols-2 @md:grid-cols-4 gap-2 mb-4">
         <div className="p-3 rounded-lg bg-green-500/10 border border-green-500/20 min-w-0 overflow-hidden" title={t('clusterHealth.healthyTooltip', { count: healthyClusters })}>
           <div className="flex items-center gap-1.5 mb-1 min-w-0">
             <CheckCircle className="w-4 h-4 text-green-400 shrink-0" />
@@ -349,7 +349,7 @@ export function ClusterHealth() {
                     title="API server externally unreachable — cluster healthy internally but external access may be blocked"
                   >
                     <WifiOff className="w-3 h-3" />
-                    <span className="hidden sm:inline">ext. unreachable</span>
+                    <span className="hidden @sm:inline">ext. unreachable</span>
                   </span>
                 )}
                 {consoleUrl && (

--- a/web/src/components/cards/ClusterMetrics.tsx
+++ b/web/src/components/cards/ClusterMetrics.tsx
@@ -457,7 +457,7 @@ export function ClusterMetrics() {
 
       {/* Stats - show when we have time series data */}
       {data.length > 0 && (
-        <div className="mt-3 pt-3 border-t border-border/50 grid grid-cols-2 sm:grid-cols-3 gap-4">
+        <div className="mt-3 pt-3 border-t border-border/50 grid grid-cols-2 @md:grid-cols-3 gap-4">
           <div>
             <p className="text-xs text-muted-foreground">{t('cards:clusterMetrics.min')}</p>
             <p className="text-sm font-medium text-foreground">

--- a/web/src/components/cards/DataComplianceCards.tsx
+++ b/web/src/components/cards/DataComplianceCards.tsx
@@ -344,7 +344,7 @@ export function ExternalSecrets({ config: _config }: CardConfig) {
         </div>
       </div>
 
-      <div className="grid grid-cols-2 sm:grid-cols-3 gap-2 text-center text-xs">
+      <div className="grid grid-cols-2 @md:grid-cols-3 gap-2 text-center text-xs">
         <div className="p-2 rounded-lg bg-green-500/10">
           <CheckCircle2 className="w-4 h-4 text-green-400 mx-auto mb-1" />
           <p className="font-medium text-foreground">{esoStatus.synced}</p>
@@ -416,7 +416,7 @@ export function CertManager({ config: _config }: CardConfig) {
   if (isLoading && issuers.length === 0) {
     return (
       <div className="space-y-3">
-        <div className="animate-pulse grid grid-cols-2 sm:grid-cols-4 gap-1.5">
+        <div className="animate-pulse grid grid-cols-2 @md:grid-cols-4 gap-1.5">
           {[...Array(4)].map((_, i) => (
             <div key={i} className="p-2 rounded-lg bg-secondary/30 h-16" />
           ))}
@@ -443,7 +443,7 @@ export function CertManager({ config: _config }: CardConfig) {
         </span>
       </div>
 
-      <div className="grid grid-cols-2 sm:grid-cols-4 gap-1.5 text-center text-xs">
+      <div className="grid grid-cols-2 @md:grid-cols-4 gap-1.5 text-center text-xs">
         <div className="p-2 rounded-lg bg-green-500/10">
           <p className="text-lg font-bold text-green-400">{status.validCertificates}</p>
           <p className="text-muted-foreground">Valid</p>

--- a/web/src/components/cards/EventsTimeline.tsx
+++ b/web/src/components/cards/EventsTimeline.tsx
@@ -313,7 +313,7 @@ function EventsTimelineInternal() {
       </div>
 
       {/* Stats row */}
-      <div className="grid grid-cols-2 sm:grid-cols-3 gap-2 mb-4">
+      <div className="grid grid-cols-2 @md:grid-cols-3 gap-2 mb-4">
         <div className="p-2 rounded-lg bg-orange-500/10 border border-orange-500/20">
           <div className="flex items-center gap-1.5 mb-1">
             <AlertTriangle className="w-3 h-3 text-orange-400" aria-hidden="true" />

--- a/web/src/components/cards/GPUInventory.tsx
+++ b/web/src/components/cards/GPUInventory.tsx
@@ -131,7 +131,7 @@ export function GPUInventory({ config }: GPUInventoryProps) {
           <Skeleton variant="text" width={100} height={16} />
           <Skeleton variant="rounded" width={80} height={28} />
         </div>
-        <div className="grid grid-cols-2 sm:grid-cols-3 gap-2 mb-4">
+        <div className="grid grid-cols-2 @md:grid-cols-3 gap-2 mb-4">
           {[1, 2, 3].map(i => (
             <Skeleton key={i} variant="rounded" height={50} />
           ))}
@@ -223,7 +223,7 @@ export function GPUInventory({ config }: GPUInventoryProps) {
       />
 
       {/* Summary */}
-      <div className="grid grid-cols-2 sm:grid-cols-3 gap-2 mb-4">
+      <div className="grid grid-cols-2 @md:grid-cols-3 gap-2 mb-4">
         <div className="p-2 rounded-lg bg-secondary/30 text-center">
           <p className="text-lg font-bold text-foreground">{stats.totalGPUs}</p>
           <p className="text-xs text-muted-foreground">{t('common:common.total')}</p>

--- a/web/src/components/cards/GPUInventoryHistory.tsx
+++ b/web/src/components/cards/GPUInventoryHistory.tsx
@@ -887,7 +887,7 @@ export function GPUInventoryHistory() {
       </div>
 
       {/* Stats row — 2 columns on narrow widths, 4 columns from sm (>=640px) */}
-      <div className="grid grid-cols-2 sm:grid-cols-4 gap-2 mb-3">
+      <div className="grid grid-cols-2 @md:grid-cols-4 gap-2 mb-3">
         <div className="p-2 rounded-lg bg-blue-500/10 border border-blue-500/20" title={`${currentTotals.total} total GPUs`}>
           <div className="flex items-center gap-1 mb-1">
             <Cpu className="w-3 h-3 text-blue-400" />

--- a/web/src/components/cards/GPUOverview.tsx
+++ b/web/src/components/cards/GPUOverview.tsx
@@ -112,7 +112,7 @@ export function GPUOverview({ config: _config }: GPUOverviewProps) {
         <div className="flex justify-center mb-4">
           <Skeleton variant="circular" width={128} height={128} />
         </div>
-        <div className="grid grid-cols-2 sm:grid-cols-3 gap-2 mb-4">
+        <div className="grid grid-cols-2 @md:grid-cols-3 gap-2 mb-4">
           {[1, 2, 3].map(i => (
             <Skeleton key={i} variant="rounded" height={50} />
           ))}
@@ -296,7 +296,7 @@ export function GPUOverview({ config: _config }: GPUOverviewProps) {
       </div>
 
       {/* Stats */}
-      <div className="grid grid-cols-2 sm:grid-cols-3 gap-2 mb-4">
+      <div className="grid grid-cols-2 @md:grid-cols-3 gap-2 mb-4">
         <div
           className={`text-center ${totalGPUs > 0 ? 'cursor-pointer hover:bg-secondary/50 rounded-lg' : 'cursor-default'} transition-colors p-1`}
           onClick={() => totalGPUs > 0 && drillToResources()}

--- a/web/src/components/cards/GPUTaintFilter.tsx
+++ b/web/src/components/cards/GPUTaintFilter.tsx
@@ -236,7 +236,7 @@ export function GPUTaintFilterControl({
         aria-label="Tolerate GPU node taints" // ai-quality-ignore — a11y attribute, not displayed text
       >
         <Filter className="w-3 h-3" />
-        <span className="hidden sm:inline">Taints</span>
+        <span className="hidden @sm:inline">Taints</span>
         {activeCount > 0 && <span className="font-mono">{activeCount}</span>}
         <ChevronDown className="w-3 h-3" />
       </button>

--- a/web/src/components/cards/GPUUsageTrend.tsx
+++ b/web/src/components/cards/GPUUsageTrend.tsx
@@ -461,7 +461,7 @@ export function GPUUsageTrend() {
         />
       </div>
 
-      <div className="grid grid-cols-2 sm:grid-cols-4 gap-2 mb-4">
+      <div className="grid grid-cols-2 @md:grid-cols-4 gap-2 mb-4">
         <div className="p-2 rounded-lg bg-blue-500/10 border border-blue-500/20" title={`${currentTotals.available} total GPUs available`}>
           <div className="flex items-center gap-1 mb-1">
             <Cpu className="w-3 h-3 text-blue-400" />

--- a/web/src/components/cards/GPUUtilization.tsx
+++ b/web/src/components/cards/GPUUtilization.tsx
@@ -344,7 +344,7 @@ export function GPUUtilization() {
             <span className="text-sm font-bold text-foreground">{currentStats.utilization}%</span>
           </div>
         </div>
-        <div className="flex-1 grid grid-cols-2 sm:grid-cols-3 gap-2">
+        <div className="flex-1 grid grid-cols-2 @md:grid-cols-3 gap-2">
           <div className="p-2 rounded-lg bg-purple-500/10 border border-purple-500/20">
             <div className="text-xs text-purple-400 mb-1">{t('common.allocated')}</div>
             <span className="text-lg font-bold text-foreground">{currentStats.allocated}</span>

--- a/web/src/components/cards/GPUWorkloads.tsx
+++ b/web/src/components/cards/GPUWorkloads.tsx
@@ -193,7 +193,7 @@ export function GPUWorkloads({ config: _config }: GPUWorkloadsProps) {
           <Skeleton variant="text" width={100} height={16} />
           <Skeleton variant="rounded" width={80} height={28} />
         </div>
-        <div className="grid grid-cols-2 sm:grid-cols-4 gap-2 mb-3">
+        <div className="grid grid-cols-2 @md:grid-cols-4 gap-2 mb-3">
           {[1, 2, 3, 4].map(i => (
             <Skeleton key={i} variant="rounded" height={50} />
           ))}

--- a/web/src/components/cards/GatewayStatus.tsx
+++ b/web/src/components/cards/GatewayStatus.tsx
@@ -234,7 +234,7 @@ export function GatewayStatus({ config: _config }: GatewayStatusProps) {
       </div>
 
       {/* Stats */}
-      <div className="grid grid-cols-2 sm:grid-cols-3 gap-2 mb-3">
+      <div className="grid grid-cols-2 @md:grid-cols-3 gap-2 mb-3">
         <div className="p-2 rounded-lg bg-purple-500/10 border border-purple-500/20 text-center">
           <p className="text-2xs text-purple-400">{t('gatewayStatus.gateways')}</p>
           <p className="text-lg font-bold text-foreground">{stats.totalGateways}</p>

--- a/web/src/components/cards/GitHubActivity.tsx
+++ b/web/src/components/cards/GitHubActivity.tsx
@@ -727,7 +727,7 @@ export function GitHubActivity({ config, ref }: { config?: GitHubActivityConfig;
           <Skeleton variant="text" width={150} height={16} />
           <Skeleton variant="rounded" width={100} height={28} />
         </div>
-        <div className="grid grid-cols-2 sm:grid-cols-4 gap-2 mb-4">
+        <div className="grid grid-cols-2 @md:grid-cols-4 gap-2 mb-4">
           <Skeleton variant="rounded" height={60} />
           <Skeleton variant="rounded" height={60} />
           <Skeleton variant="rounded" height={60} />
@@ -821,7 +821,7 @@ export function GitHubActivity({ config, ref }: { config?: GitHubActivityConfig;
         )}
 
         {/* Placeholder Stats Grid */}
-        <div className="grid grid-cols-2 sm:grid-cols-4 gap-2 mb-4">
+        <div className="grid grid-cols-2 @md:grid-cols-4 gap-2 mb-4">
           <div className="bg-secondary/30 rounded-lg p-3 border border-border/50 opacity-50">
             <div className="flex items-center gap-2 mb-1">
               <GitPullRequest className="w-4 h-4 text-blue-400" />
@@ -1024,7 +1024,7 @@ export function GitHubActivity({ config, ref }: { config?: GitHubActivityConfig;
       </div>
 
       {/* Stats Grid */}
-      <div className="grid grid-cols-2 sm:grid-cols-4 gap-2 mb-3 flex-shrink-0">
+      <div className="grid grid-cols-2 @md:grid-cols-4 gap-2 mb-3 flex-shrink-0">
         <div className="bg-secondary/30 rounded-lg p-3 border border-border/50">
           <div className="flex items-center gap-2 mb-1">
             <GitPullRequest className="w-4 h-4 text-blue-400" />

--- a/web/src/components/cards/HardwareHealthCard.tsx
+++ b/web/src/components/cards/HardwareHealthCard.tsx
@@ -454,7 +454,7 @@ export function HardwareHealthCard() {
         </div>
       )}
       {/* Status Summary */}
-      <div className="grid grid-cols-2 sm:grid-cols-3 gap-1.5 sm:gap-2 mb-4">
+      <div className="grid grid-cols-2 @md:grid-cols-3 gap-1.5 @md:gap-2 mb-4">
         <div className={cn(
           'p-2 rounded-lg border',
           criticalCount > 0

--- a/web/src/components/cards/KagentStatusCard.tsx
+++ b/web/src/components/cards/KagentStatusCard.tsx
@@ -100,7 +100,7 @@ export function KagentStatusCard({ config }: KagentStatusCardProps) {
   if (showSkeleton) {
     return (
       <div className="space-y-3 p-1">
-        <div className="grid grid-cols-2 sm:grid-cols-3 gap-2">
+        <div className="grid grid-cols-2 @md:grid-cols-3 gap-2">
           {[1, 2, 3].map(i => <Skeleton key={i} className="h-16 rounded-lg" />)}
         </div>
         <Skeleton className="h-24 rounded-lg" />
@@ -126,7 +126,7 @@ export function KagentStatusCard({ config }: KagentStatusCardProps) {
   return (
     <div className="space-y-3 p-1">
       {/* Metric tiles */}
-      <div className="grid grid-cols-2 sm:grid-cols-3 gap-2">
+      <div className="grid grid-cols-2 @md:grid-cols-3 gap-2">
         <MetricTile
           icon={Bot}
           label="Agents"

--- a/web/src/components/cards/KagentiStatusCard.tsx
+++ b/web/src/components/cards/KagentiStatusCard.tsx
@@ -106,7 +106,7 @@ export function KagentiStatusCard({ config }: KagentiStatusCardProps) {
   if (showSkeleton) {
     return (
       <div className="space-y-3 p-1">
-        <div className="grid grid-cols-2 sm:grid-cols-3 gap-2">
+        <div className="grid grid-cols-2 @md:grid-cols-3 gap-2">
           {[1, 2, 3].map(i => <Skeleton key={i} className="h-16 rounded-lg" />)}
         </div>
         <Skeleton className="h-24 rounded-lg" />
@@ -132,7 +132,7 @@ export function KagentiStatusCard({ config }: KagentiStatusCardProps) {
   return (
     <div className="space-y-3 p-1">
       {/* Metric tiles */}
-      <div className="grid grid-cols-2 sm:grid-cols-3 gap-2">
+      <div className="grid grid-cols-2 @md:grid-cols-3 gap-2">
         <MetricTile
           icon={Bot}
           label="Agents"

--- a/web/src/components/cards/Kubedle.tsx
+++ b/web/src/components/cards/Kubedle.tsx
@@ -429,7 +429,7 @@ export function Kubedle(_props: CardComponentProps) {
               </button>
             </div>
 
-            <div className="grid grid-cols-2 sm:grid-cols-4 gap-2 text-center mb-4">
+            <div className="grid grid-cols-2 @md:grid-cols-4 gap-2 text-center mb-4">
               <div>
                 <div className="text-2xl font-bold text-foreground">{stats.played}</div>
                 <div className="text-xs text-muted-foreground">Played</div>

--- a/web/src/components/cards/KyvernoPolicies.tsx
+++ b/web/src/components/cards/KyvernoPolicies.tsx
@@ -257,7 +257,7 @@ Please proceed step by step.`,
       )}
 
       {/* Stats */}
-      <div className="grid grid-cols-2 sm:grid-cols-3 gap-2 mb-3">
+      <div className="grid grid-cols-2 @md:grid-cols-3 gap-2 mb-3">
         <div className="p-2 rounded-lg bg-cyan-500/10 border border-cyan-500/20 text-center">
           <p className="text-2xs text-cyan-400">Policies</p>
           <p className="text-lg font-bold text-foreground">{stats.totalPolicies}</p>

--- a/web/src/components/cards/PVCStatus.tsx
+++ b/web/src/components/cards/PVCStatus.tsx
@@ -238,7 +238,7 @@ function PVCStatusInternal() {
       />
 
       {/* Stats row */}
-      <div className="grid grid-cols-2 sm:grid-cols-4 gap-2 mb-4">
+      <div className="grid grid-cols-2 @md:grid-cols-4 gap-2 mb-4">
         <div className="p-2 rounded-lg bg-secondary/50 text-center">
           <div className="text-lg font-bold text-foreground">{stats.total}</div>
           <div className="text-xs text-muted-foreground">{t('common.total')}</div>

--- a/web/src/components/cards/PodHealthTrend.tsx
+++ b/web/src/components/cards/PodHealthTrend.tsx
@@ -391,7 +391,7 @@ export function PodHealthTrend() {
       </div>
 
       {/* Stats row */}
-      <div className="grid grid-cols-2 sm:grid-cols-3 gap-2 mb-4">
+      <div className="grid grid-cols-2 @md:grid-cols-3 gap-2 mb-4">
         <div className="p-2 rounded-lg bg-green-500/10 border border-green-500/20" title={hasReachableClusters ? `${currentStats.healthy} healthy pods` : 'No reachable clusters'}>
           <div className="flex items-center gap-1.5 mb-1">
             <CheckCircle className="w-3 h-3 text-green-400" />

--- a/web/src/components/cards/QuotaHeatmap.tsx
+++ b/web/src/components/cards/QuotaHeatmap.tsx
@@ -90,7 +90,7 @@ export function QuotaHeatmap() {
           staleThresholdMinutes={5}
         />
       </div>
-      <div className="grid grid-cols-2 sm:grid-cols-4 md:grid-cols-6 gap-1 max-h-[350px] overflow-y-auto">
+      <div className="grid grid-cols-2 @md:grid-cols-4 @lg:grid-cols-6 gap-1 max-h-[350px] overflow-y-auto">
         {namespaceData.slice(0, 60).map(ns => {
           const ratio = ns.podCount / maxPods
           const isSelected = selectedNs === `${ns.cluster}/${ns.namespace}`

--- a/web/src/components/cards/ResourceCapacity.tsx
+++ b/web/src/components/cards/ResourceCapacity.tsx
@@ -346,7 +346,7 @@ export function ResourceCapacity({ config: _config }: ResourceCapacityProps) {
       {/* Summary */}
       {/* Summary footer */}
       <div
-        className={`mt-3 pt-3 border-t border-border/50 grid ${totals.totalGPUs > 0 ? 'grid-cols-2 sm:grid-cols-4' : 'grid-cols-2 sm:grid-cols-3'} gap-2 text-center cursor-pointer hover:bg-secondary/30 rounded-lg transition-colors`}
+        className={`mt-3 pt-3 border-t border-border/50 grid ${totals.totalGPUs > 0 ? 'grid-cols-2 @md:grid-cols-4' : 'grid-cols-2 @md:grid-cols-3'} gap-2 text-center cursor-pointer hover:bg-secondary/30 rounded-lg transition-colors`}
         onClick={() => drillToResources()}
       >
         <div>

--- a/web/src/components/cards/ResourceTrend.tsx
+++ b/web/src/components/cards/ResourceTrend.tsx
@@ -313,7 +313,7 @@ export function ResourceTrend() {
       </div>
 
       {/* Stats row */}
-      <div className="grid grid-cols-2 sm:grid-cols-4 gap-2 mb-4">
+      <div className="grid grid-cols-2 @md:grid-cols-4 gap-2 mb-4">
         <div className="p-2 rounded-lg bg-blue-500/10 border border-blue-500/20" title={hasReachableClusters ? `${currentTotals.cpuCores} CPU cores total` : 'No reachable clusters'}>
           <div className="flex items-center gap-1 mb-1">
             <Cpu className="w-3 h-3 text-blue-400" />

--- a/web/src/components/cards/ServiceExports.tsx
+++ b/web/src/components/cards/ServiceExports.tsx
@@ -189,7 +189,7 @@ function ServiceExportsInternal({ config: _config }: ServiceExportsProps) {
       </div>
 
       {/* Stats */}
-      <div className="grid grid-cols-2 sm:grid-cols-3 gap-2 mb-3">
+      <div className="grid grid-cols-2 @md:grid-cols-3 gap-2 mb-3">
         <div className="p-2 rounded-lg bg-blue-500/10 border border-blue-500/20 text-center">
           <p className="text-2xs text-blue-400">{t('serviceExports.exports')}</p>
           <p className="text-lg font-bold text-foreground">{totalItems}</p>

--- a/web/src/components/cards/ServiceImports.tsx
+++ b/web/src/components/cards/ServiceImports.tsx
@@ -193,7 +193,7 @@ function ServiceImportsInternal({ config: _config }: ServiceImportsProps) {
       </div>
 
       {/* Stats */}
-      <div className="grid grid-cols-2 sm:grid-cols-3 gap-2 mb-3">
+      <div className="grid grid-cols-2 @md:grid-cols-3 gap-2 mb-3">
         <div className="p-2 rounded-lg bg-cyan-500/10 border border-cyan-500/20 text-center">
           <p className="text-2xs text-cyan-400">{t('serviceImports.imports')}</p>
           <p className="text-lg font-bold text-foreground">{stats.totalImports}</p>

--- a/web/src/components/cards/ServiceStatus.tsx
+++ b/web/src/components/cards/ServiceStatus.tsx
@@ -234,7 +234,7 @@ export function ServiceStatus() {
           <Skeleton variant="rounded" width={80} height={28} />
         </div>
         <Skeleton variant="rounded" height={32} className="mb-3" />
-        <div className="grid grid-cols-2 sm:grid-cols-4 gap-2 mb-3">
+        <div className="grid grid-cols-2 @md:grid-cols-4 gap-2 mb-3">
           {[1, 2, 3, 4].map(i => (
             <Skeleton key={i} variant="rounded" height={40} />
           ))}
@@ -302,7 +302,7 @@ export function ServiceStatus() {
       />
 
       {/* Stats row */}
-      <div className="grid grid-cols-2 sm:grid-cols-4 gap-2 mb-3">
+      <div className="grid grid-cols-2 @md:grid-cols-4 gap-2 mb-3">
         <div className="p-1.5 rounded-lg bg-secondary/50 text-center">
           <div className="text-sm font-bold text-foreground">{stats.total}</div>
           <div className="text-2xs text-muted-foreground">{t('common.total')}</div>

--- a/web/src/components/cards/StockMarketTicker.tsx
+++ b/web/src/components/cards/StockMarketTicker.tsx
@@ -465,7 +465,7 @@ function StockRow({
         </div>
 
         {/* Sparkline */}
-        <div className="hidden sm:block flex-shrink-0">
+        <div className="hidden @sm:block flex-shrink-0">
           <Sparkline data={stock.sparklineData} isPositive={isPositive} />
         </div>
 
@@ -801,7 +801,7 @@ export function StockMarketTicker({ config }: StockMarketTickerProps) {
       </div>
 
       {/* Portfolio summary */}
-      <div className="grid grid-cols-2 sm:grid-cols-3 gap-2 mb-3 p-2 bg-accent/30 rounded-lg text-xs">
+      <div className="grid grid-cols-2 @md:grid-cols-3 gap-2 mb-3 p-2 bg-accent/30 rounded-lg text-xs">
         <div className="text-center">
           <div className="text-muted-foreground">{t('stockMarket.avgChange')}</div>
           <div className={`font-semibold ${portfolioSummary.avgChange >= 0 ? 'text-green-500' : 'text-red-500'}`}>

--- a/web/src/components/cards/StorageOverview.tsx
+++ b/web/src/components/cards/StorageOverview.tsx
@@ -200,7 +200,7 @@ export function StorageOverview() {
       </div>
 
       {/* PVC Status breakdown */}
-      <div className="grid grid-cols-2 sm:grid-cols-3 gap-2 mb-4">
+      <div className="grid grid-cols-2 @md:grid-cols-3 gap-2 mb-4">
         <div
           className="p-2 rounded-lg bg-green-500/10 border border-green-500/20 cursor-default transition-colors"
           title={stats.boundPVCs > 0 ? `${stats.boundPVCs} PVC${stats.boundPVCs !== 1 ? 's' : ''} successfully bound` : 'No bound PVCs'}

--- a/web/src/components/cards/SudokuGame.tsx
+++ b/web/src/components/cards/SudokuGame.tsx
@@ -559,7 +559,7 @@ function SudokuGameInternal({ config: _config }: SudokuGameProps) {
             }`}
           >
             <Pencil className={iconSize} />
-            <span className={isMaximized ? 'inline' : 'hidden sm:inline'}>Notes</span>
+            <span className={isMaximized ? 'inline' : 'hidden @sm:inline'}>Notes</span>
           </button>
           <button
             onClick={handleHint}
@@ -567,7 +567,7 @@ function SudokuGameInternal({ config: _config }: SudokuGameProps) {
             className={`flex items-center justify-center gap-1 ${controlButtonSize} rounded bg-secondary/50 hover:bg-secondary transition-colors disabled:opacity-30 disabled:cursor-not-allowed`}
           >
             <Lightbulb className={iconSize} />
-            <span className={isMaximized ? 'inline' : 'hidden sm:inline'}>Hint</span>
+            <span className={isMaximized ? 'inline' : 'hidden @sm:inline'}>Hint</span>
           </button>
           <button
             onClick={undo}
@@ -595,14 +595,14 @@ function SudokuGameInternal({ config: _config }: SudokuGameProps) {
             className={`flex-1 flex items-center justify-center gap-1 ${controlButtonSize} rounded bg-secondary/50 hover:bg-secondary transition-colors disabled:opacity-30`}
           >
             {gameState.isPaused ? <Play className={iconSize} /> : <Pause className={iconSize} />}
-            <span className={isMaximized ? 'inline' : 'hidden sm:inline'}>{gameState.isPaused ? 'Resume' : 'Pause'}</span>
+            <span className={isMaximized ? 'inline' : 'hidden @sm:inline'}>{gameState.isPaused ? 'Resume' : 'Pause'}</span>
           </button>
           <button
             onClick={saveGame}
             className={`flex-1 flex items-center justify-center gap-1 ${controlButtonSize} rounded bg-secondary/50 hover:bg-secondary transition-colors`}
           >
             <Save className={iconSize} />
-            <span className={isMaximized ? 'inline' : 'hidden sm:inline'}>{t('common.save')}</span>
+            <span className={isMaximized ? 'inline' : 'hidden @sm:inline'}>{t('common.save')}</span>
           </button>
         </div>
       </div>

--- a/web/src/components/cards/TrestleScan.tsx
+++ b/web/src/components/cards/TrestleScan.tsx
@@ -364,7 +364,7 @@ Please proceed step by step. Start with verifying prerequisites (Python 3.9+, ku
 
               {/* Expanded details */}
               {isExpanded && (
-                <div className="mt-2 grid grid-cols-2 sm:grid-cols-3 gap-2 text-xs">
+                <div className="mt-2 grid grid-cols-2 @md:grid-cols-3 gap-2 text-xs">
                   <button
                     onClick={(e) => { e.stopPropagation(); drillToCompliance('pass', { profile: profile.name }) }}
                     className="flex items-center gap-1 text-green-400 hover:opacity-80 transition-opacity cursor-pointer"

--- a/web/src/components/cards/VClusterStatus.tsx
+++ b/web/src/components/cards/VClusterStatus.tsx
@@ -157,7 +157,7 @@ export function VClusterStatus({ config: _config }: VClusterStatusProps) {
         />
       </div>
       <CardSearchInput value={localSearch} onChange={setLocalSearch} placeholder={t('vclusterStatus.searchPlaceholder')} className="mb-3" />
-      <div className="grid grid-cols-2 sm:grid-cols-3 gap-2 mb-3">
+      <div className="grid grid-cols-2 @md:grid-cols-3 gap-2 mb-3">
         <div className="p-2 rounded-lg bg-purple-500/10 border border-purple-500/20 text-center"><p className="text-2xs text-purple-400">{t('vclusterStatus.total')}</p><p className="text-lg font-bold text-foreground">{stats.totalVClusters}</p></div>
         <div className="p-2 rounded-lg bg-green-500/10 border border-green-500/20 text-center"><p className="text-2xs text-green-400">{t('vclusterStatus.running')}</p><p className="text-lg font-bold text-foreground">{stats.runningCount}</p></div>
         <div className="p-2 rounded-lg bg-yellow-500/10 border border-yellow-500/20 text-center"><p className="text-2xs text-yellow-400">{t('vclusterStatus.paused')}</p><p className="text-lg font-bold text-foreground">{stats.pausedCount}</p></div>

--- a/web/src/components/cards/cloudevents_status/CloudEventsStatus.tsx
+++ b/web/src/components/cards/cloudevents_status/CloudEventsStatus.tsx
@@ -111,7 +111,7 @@ export function CloudEventsStatus() {
         </div>
       </div>
 
-      <div className="grid grid-cols-2 sm:grid-cols-4 gap-2">
+      <div className="grid grid-cols-2 @md:grid-cols-4 gap-2">
         <MetricTile
           label={t('cloudevents.brokers')}
           value={data.brokers.total}

--- a/web/src/components/cards/console-missions/ConsoleHealthCheckCard.tsx
+++ b/web/src/components/cards/console-missions/ConsoleHealthCheckCard.tsx
@@ -154,7 +154,7 @@ Please provide:
       </div>
 
       {/* Quick Stats */}
-      <div className="grid grid-cols-2 sm:grid-cols-3 gap-2 mb-2 text-center">
+      <div className="grid grid-cols-2 @md:grid-cols-3 gap-2 mb-2 text-center">
         <div
           className={cn(
             "p-2 rounded bg-green-500/10",

--- a/web/src/components/cards/console-missions/ConsoleOfflineDetectionCard.tsx
+++ b/web/src/components/cards/console-missions/ConsoleOfflineDetectionCard.tsx
@@ -874,7 +874,7 @@ Please:
       </div>
 
       {/* Status Summary */}
-      <div className="grid grid-cols-2 sm:grid-cols-3 gap-2 mb-4">
+      <div className="grid grid-cols-2 @md:grid-cols-3 gap-2 mb-4">
         <div
           className={cn(
             'p-2 rounded-lg border',

--- a/web/src/components/cards/coredns_status/CoreDNSStatus.tsx
+++ b/web/src/components/cards/coredns_status/CoreDNSStatus.tsx
@@ -47,7 +47,7 @@ export function CoreDNSStatus({ config }: CoreDNSStatusProps) {
   if (showSkeleton) {
     return (
       <div className="h-full flex flex-col min-h-card gap-3">
-        <div className="grid grid-cols-2 sm:grid-cols-3 gap-2">
+        <div className="grid grid-cols-2 @md:grid-cols-3 gap-2">
           {[1, 2, 3].map(i => <Skeleton key={i} variant="rounded" height={52} />)}
         </div>
         <Skeleton variant="rounded" height={64} />
@@ -70,7 +70,7 @@ export function CoreDNSStatus({ config }: CoreDNSStatusProps) {
     <div className="h-full flex flex-col min-h-card content-loaded overflow-hidden gap-3">
       {/* top stats — only pod-derivable metrics */}
       {totals && (
-        <div className="grid grid-cols-2 sm:grid-cols-3 gap-2">
+        <div className="grid grid-cols-2 @md:grid-cols-3 gap-2">
           <StatTile
             value={totals.totalPods.toString()}
             sub={t('coreDNSStatus.pods')}

--- a/web/src/components/cards/crossplane-status/CrossplaneManagedResources.tsx
+++ b/web/src/components/cards/crossplane-status/CrossplaneManagedResources.tsx
@@ -170,7 +170,7 @@ export function CrossplaneManagedResources() {
         className="mb-4"
       />
       {/* Stats */}
-      <div className="grid grid-cols-2 sm:grid-cols-4 gap-2 mb-4">
+      <div className="grid grid-cols-2 @md:grid-cols-4 gap-2 mb-4">
         <StatBox label={t('crossplaneManagedResources.ready')} value={readyCount} color="green" />
         <StatBox label={t('crossplaneManagedResources.notReady')} value={notReadyCount} color="orange" />
         <StatBox label={t('crossplaneManagedResources.error')} value={errorCount} color="red" />

--- a/web/src/components/cards/drasi/DrasiReactiveGraph.tsx
+++ b/web/src/components/cards/drasi/DrasiReactiveGraph.tsx
@@ -2599,7 +2599,7 @@ export function DrasiReactiveGraph() {
         </div>
       )}
       {/* Pipeline KPIs strip */}
-      <div className="flex-shrink-0 grid grid-cols-2 sm:grid-cols-4 gap-2 mb-2">
+      <div className="flex-shrink-0 grid grid-cols-2 @md:grid-cols-4 gap-2 mb-2">
         <KPIBox label={KPI_LABEL_EVENTS_PER_SEC} value={kpis.eventsPerSec} accent="emerald" />
         <KPIBox label={KPI_LABEL_RESULT_ROWS} value={kpis.matchRate} accent="cyan" />
         <KPIBox label={KPI_LABEL_SOURCES} value={kpis.activeSources} accent="emerald" />

--- a/web/src/components/cards/failover_timeline/FailoverTimeline.tsx
+++ b/web/src/components/cards/failover_timeline/FailoverTimeline.tsx
@@ -249,7 +249,7 @@ export function FailoverTimeline() {
       </div>
 
       {/* ── Summary stats ── */}
-      <div className="grid grid-cols-2 sm:grid-cols-3 gap-2">
+      <div className="grid grid-cols-2 @md:grid-cols-3 gap-2">
         <div className="p-2 rounded-lg bg-secondary/30 border border-red-500/20">
           <span className="text-xs text-red-400 block">
             {t('failoverTimeline.clusterDown', 'Down Events')}

--- a/web/src/components/cards/intoto_supply_chain/IntotoSupplyChain.tsx
+++ b/web/src/components/cards/intoto_supply_chain/IntotoSupplyChain.tsx
@@ -242,7 +242,7 @@ Please proceed step by step.`,
       {isLoading && !hasData && (
         <div className="space-y-3 animate-pulse">
           <div className="h-10 bg-secondary/50 rounded-lg" />
-          <div className="grid grid-cols-2 sm:grid-cols-3 gap-2">
+          <div className="grid grid-cols-2 @md:grid-cols-3 gap-2">
             <div className="h-12 bg-secondary/50 rounded-lg" />
             <div className="h-12 bg-secondary/50 rounded-lg" />
             <div className="h-12 bg-secondary/50 rounded-lg" />
@@ -340,7 +340,7 @@ Please proceed step by step.`,
       )}
 
       {/* Stats */}
-      <div className="grid grid-cols-2 sm:grid-cols-3 gap-2 mb-3">
+      <div className="grid grid-cols-2 @md:grid-cols-3 gap-2 mb-3">
         <div className="p-2 rounded-lg bg-cyan-500/10 border border-cyan-500/20 text-center">
           <p className="text-2xs text-cyan-400">{t('intoto_supply_chain.statsLayouts')}</p>
           <p className="text-lg font-bold text-foreground">{stats.totalLayouts}</p>

--- a/web/src/components/cards/kagenti/KagentiSecurity.tsx
+++ b/web/src/components/cards/kagenti/KagentiSecurity.tsx
@@ -50,7 +50,7 @@ export function KagentiSecurity({ config }: { config?: Record<string, unknown> }
           </div>
           <span className="text-lg font-bold text-white">{stats.pct}%</span>
         </div>
-        <div className="grid grid-cols-2 sm:grid-cols-3 gap-2 text-center">
+        <div className="grid grid-cols-2 @md:grid-cols-3 gap-2 text-center">
           <div className="rounded bg-green-400/10 py-1.5">
             <div className="text-sm font-bold text-green-400">{stats.strict}</div>
             <div className="text-xs text-muted-foreground">Strict</div>

--- a/web/src/components/cards/karmada_status/KarmadaStatus.tsx
+++ b/web/src/components/cards/karmada_status/KarmadaStatus.tsx
@@ -233,7 +233,7 @@ export function KarmadaStatus() {
       </div>
 
       {/* ── Stats grid ── */}
-      <div className="grid grid-cols-2 sm:grid-cols-4 gap-2">
+      <div className="grid grid-cols-2 @md:grid-cols-4 gap-2">
         <StatTile
           icon={<Globe className="w-4 h-4 text-blue-400" />}
           label={t('karmada.clusters', 'Clusters')}

--- a/web/src/components/cards/keda_status/KedaStatus.tsx
+++ b/web/src/components/cards/keda_status/KedaStatus.tsx
@@ -304,7 +304,7 @@ export function KedaStatus() {
 
       {/* ── Stats grid ── */}
       {scaledObjects.length > 0 && (
-        <div className="grid grid-cols-2 sm:grid-cols-4 gap-2">
+        <div className="grid grid-cols-2 @md:grid-cols-4 gap-2">
           <StatTile
             icon={<TrendingUp className="w-4 h-4 text-blue-400" />}
             label={t('keda.total', 'Total')}

--- a/web/src/components/cards/keycloak_status/KeycloakStatus.tsx
+++ b/web/src/components/cards/keycloak_status/KeycloakStatus.tsx
@@ -298,7 +298,7 @@ export function KeycloakStatus() {
 
       {/* ── Stats grid ── */}
       {realms.length > 0 && (
-        <div className="grid grid-cols-2 sm:grid-cols-4 gap-2">
+        <div className="grid grid-cols-2 @md:grid-cols-4 gap-2">
           <StatTile
             icon={<Globe className="w-4 h-4 text-blue-400" />}
             label={t('keycloak.realms')}

--- a/web/src/components/cards/kuberay_fleet/KubeRayFleet.tsx
+++ b/web/src/components/cards/kuberay_fleet/KubeRayFleet.tsx
@@ -50,7 +50,7 @@ export function KubeRayFleet() {
   if (showSkeleton) {
     return (
       <div className="h-full flex flex-col min-h-card gap-3 p-1">
-        <div className="grid grid-cols-2 sm:grid-cols-4 gap-2">
+        <div className="grid grid-cols-2 @md:grid-cols-4 gap-2">
           {Array.from({ length: 4 }).map((_, i) => (
             <Skeleton key={i} variant="rounded" height={48} />
           ))}
@@ -82,7 +82,7 @@ export function KubeRayFleet() {
   return (
     <div className="h-full flex flex-col min-h-card gap-3 p-1 overflow-hidden">
       {/* Fleet summary tiles */}
-      <div className="grid grid-cols-2 sm:grid-cols-4 gap-2">
+      <div className="grid grid-cols-2 @md:grid-cols-4 gap-2">
         <StatTile icon={Server} label="Clusters" value={`${readyClusters}/${rayClusters.length}`} color="text-blue-400" />
         <StatTile icon={Cpu} label="Workers" value={String(totalWorkers)} color="text-purple-400" />
         <StatTile icon={Layers} label="GPUs" value={String(data.totalGPUs)} color="text-green-400" />

--- a/web/src/components/cards/llmd/BenchmarkHero.tsx
+++ b/web/src/components/cards/llmd/BenchmarkHero.tsx
@@ -241,7 +241,7 @@ export function BenchmarkHero() {
       </div>
 
       {/* Hero metrics row */}
-      <div className="grid grid-cols-2 sm:grid-cols-4 gap-3 flex-1">
+      <div className="grid grid-cols-2 @md:grid-cols-4 gap-3 flex-1">
         <HeroMetric
           label="Output Throughput"
           value={fmtNum(throughput)}

--- a/web/src/components/cards/llmd/KVCacheMonitor.tsx
+++ b/web/src/components/cards/llmd/KVCacheMonitor.tsx
@@ -631,7 +631,7 @@ export function KVCacheMonitor() {
       </div>
 
       {/* Summary stats with glow */}
-      <div className={`grid grid-cols-2 sm:grid-cols-4 mb-4 ${isExpanded ? 'gap-4' : 'gap-2'}`}>
+      <div className={`grid grid-cols-2 @md:grid-cols-4 mb-4 ${isExpanded ? 'gap-4' : 'gap-2'}`}>
         <div className="bg-secondary/60 backdrop-blur-sm rounded-lg p-2 text-center border border-border/50">
           <div className="text-lg font-bold text-white flex items-center justify-center gap-1">
             {aggregateMetrics.avgUtil}%
@@ -774,14 +774,14 @@ export function KVCacheMonitor() {
               className={`h-full overflow-auto ${
                 isExpanded
                   ? (stats.length <= 2 ? 'flex items-center justify-evenly gap-16' :
-                     stats.length <= 4 ? 'grid grid-cols-2 sm:grid-cols-4 gap-8 place-items-center' :
-                     stats.length <= 6 ? 'grid grid-cols-2 sm:grid-cols-3 gap-6 place-items-center' :
-                     'grid grid-cols-2 sm:grid-cols-4 gap-4 place-items-center')
+                     stats.length <= 4 ? 'grid grid-cols-2 @md:grid-cols-4 gap-8 place-items-center' :
+                     stats.length <= 6 ? 'grid grid-cols-2 @md:grid-cols-3 gap-6 place-items-center' :
+                     'grid grid-cols-2 @md:grid-cols-4 gap-4 place-items-center')
                   : (stats.length <= 2 ? 'flex items-center justify-evenly gap-12' :
-                     stats.length <= 3 ? 'grid grid-cols-2 sm:grid-cols-3 gap-6 place-items-center' :
-                     stats.length <= 6 ? 'grid grid-cols-2 sm:grid-cols-3 gap-3 place-items-center' :
-                     stats.length <= 9 ? 'grid grid-cols-2 sm:grid-cols-3 gap-2 place-items-center' :
-                     'grid grid-cols-2 sm:grid-cols-4 gap-2 place-items-center')
+                     stats.length <= 3 ? 'grid grid-cols-2 @md:grid-cols-3 gap-6 place-items-center' :
+                     stats.length <= 6 ? 'grid grid-cols-2 @md:grid-cols-3 gap-3 place-items-center' :
+                     stats.length <= 9 ? 'grid grid-cols-2 @md:grid-cols-3 gap-2 place-items-center' :
+                     'grid grid-cols-2 @md:grid-cols-4 gap-2 place-items-center')
               }`}
               initial={{ opacity: 0, y: 10 }}
               animate={{ opacity: 1, y: 0 }}
@@ -815,13 +815,13 @@ export function KVCacheMonitor() {
               className={`grid h-full place-items-center overflow-auto ${
                 isExpanded
                   ? (stats.length <= 2 ? 'grid-cols-2 gap-6' :
-                     stats.length <= 4 ? 'grid-cols-2 sm:grid-cols-4 gap-4' :
-                     stats.length <= 6 ? 'grid-cols-2 sm:grid-cols-3 gap-4' :
-                     'grid-cols-2 sm:grid-cols-4 gap-3')
+                     stats.length <= 4 ? 'grid-cols-2 @md:grid-cols-4 gap-4' :
+                     stats.length <= 6 ? 'grid-cols-2 @md:grid-cols-3 gap-4' :
+                     'grid-cols-2 @md:grid-cols-4 gap-3')
                   : (stats.length <= 2 ? 'grid-cols-2 gap-2' :
-                     stats.length <= 3 ? 'grid-cols-2 sm:grid-cols-3 gap-1' :
-                     stats.length <= 6 ? 'grid-cols-2 sm:grid-cols-3 gap-1' :
-                     'grid-cols-2 sm:grid-cols-4 gap-1')
+                     stats.length <= 3 ? 'grid-cols-2 @md:grid-cols-3 gap-1' :
+                     stats.length <= 6 ? 'grid-cols-2 @md:grid-cols-3 gap-1' :
+                     'grid-cols-2 @md:grid-cols-4 gap-1')
               }`}
               initial={{ opacity: 0, y: 10 }}
               animate={{ opacity: 1, y: 0 }}

--- a/web/src/components/cards/llmd/LLMdAIInsights.tsx
+++ b/web/src/components/cards/llmd/LLMdAIInsights.tsx
@@ -86,7 +86,7 @@ function InsightCard({ insight, isExpanded, onToggle }: InsightCardProps) {
 
               {/* Metrics */}
               {insight.metrics && (
-                <div className="grid grid-cols-2 sm:grid-cols-3 gap-2">
+                <div className="grid grid-cols-2 @md:grid-cols-3 gap-2">
                   {Object.entries(insight.metrics).map(([key, value]) => (
                     <div key={key} className="bg-secondary rounded p-2 text-center">
                       <div className="text-xs text-muted-foreground truncate">{key}</div>

--- a/web/src/components/cards/llmd/LLMdConfigurator.tsx
+++ b/web/src/components/cards/llmd/LLMdConfigurator.tsx
@@ -258,7 +258,7 @@ ${Object.entries(params).map(([k, v]) => `    ${k}: ${v}`).join('\n')}`
             </div>
 
             {/* Expected impact */}
-            <div className="grid grid-cols-2 sm:grid-cols-3 gap-2 mb-4">
+            <div className="grid grid-cols-2 @md:grid-cols-3 gap-2 mb-4">
               <div className="bg-green-500/10 border border-green-500/20 rounded-lg p-2 text-center">
                 <div className="text-xs text-muted-foreground"><Acronym term="TTFT" /> Improvement</div>
                 <div className="text-lg font-bold text-green-400">

--- a/web/src/components/cards/llmd/NightlyE2EStatus.tsx
+++ b/web/src/components/cards/llmd/NightlyE2EStatus.tsx
@@ -895,7 +895,7 @@ export function NightlyE2EStatus() {
   if (showSkeleton) {
     return (
       <div className="p-4 h-full flex flex-col gap-3 overflow-hidden">
-        <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
+        <div className="grid grid-cols-2 @md:grid-cols-4 gap-3">
           {Array.from({ length: 4 }).map((_, i) => (
             <Skeleton key={i} variant="rounded" height={64} />
           ))}
@@ -917,7 +917,7 @@ export function NightlyE2EStatus() {
   return (
     <div className="p-4 h-full flex flex-col gap-3 overflow-hidden">
       {/* Stats row */}
-      <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
+      <div className="grid grid-cols-2 @md:grid-cols-4 gap-3">
         <motion.div
           initial={{ opacity: 0, y: 8 }}
           animate={{ opacity: 1, y: 0 }}

--- a/web/src/components/cards/multi-tenancy/tenant-isolation-setup/TenantIsolationSetup.tsx
+++ b/web/src/components/cards/multi-tenancy/tenant-isolation-setup/TenantIsolationSetup.tsx
@@ -204,7 +204,7 @@ export function TenantIsolationSetup() {
         <div className="text-xs text-muted-foreground mb-1.5 font-medium">
           {t('cards:multiTenancy.componentReadiness', 'Component Readiness')} ({data.readyCount}/{data.totalComponents})
         </div>
-        <div className="grid grid-cols-2 sm:grid-cols-4 gap-2">
+        <div className="grid grid-cols-2 @md:grid-cols-4 gap-2">
           {(data.components || []).map((component) => (
             <ReadinessBadge
               key={component.key}
@@ -217,7 +217,7 @@ export function TenantIsolationSetup() {
 
       {/* Isolation levels */}
       <div className="flex-1">
-        <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+        <div className="grid grid-cols-1 @md:grid-cols-2 gap-3">
           {/* Isolation level indicators */}
           <div>
             <div className="text-xs text-muted-foreground mb-1.5 font-medium">

--- a/web/src/components/cards/pipelines/NightlyReleasePulse.tsx
+++ b/web/src/components/cards/pipelines/NightlyReleasePulse.tsx
@@ -392,7 +392,7 @@ export function NightlyReleasePulse() {
           )}
         </div>
 
-        <div className="grid grid-cols-2 sm:grid-cols-3 gap-2">
+        <div className="grid grid-cols-2 @md:grid-cols-3 gap-2">
           <div className="rounded-lg bg-secondary/30 px-3 py-2">
             <div className="text-[11px] text-muted-foreground">Streak</div>
             <div className={cn('text-sm font-medium mt-0.5',

--- a/web/src/components/cards/trino_gateway/TrinoGateway.tsx
+++ b/web/src/components/cards/trino_gateway/TrinoGateway.tsx
@@ -41,7 +41,7 @@ export function TrinoGateway() {
   if (showSkeleton) {
     return (
       <div className="h-full flex flex-col min-h-card gap-3 p-1">
-        <div className="grid grid-cols-2 sm:grid-cols-4 gap-2">
+        <div className="grid grid-cols-2 @md:grid-cols-4 gap-2">
           {Array.from({ length: SUMMARY_TILE_COUNT }).map((_, i) => (
             <Skeleton key={i} variant="rounded" height={48} />
           ))}
@@ -76,7 +76,7 @@ export function TrinoGateway() {
   return (
     <div className="h-full flex flex-col min-h-card gap-3 p-1 overflow-hidden">
       {/* Summary tiles */}
-      <div className="grid grid-cols-2 sm:grid-cols-4 gap-2">
+      <div className="grid grid-cols-2 @md:grid-cols-4 gap-2">
         <StatTile icon={Database} label="Clusters" value={`${healthyClusters}/${trinoClusters.length}`} color="text-blue-400" />
         <StatTile icon={Server} label="Workers" value={String(data.totalWorkers)} color="text-purple-400" />
         <StatTile icon={Activity} label="Queries" value={String(data.totalActiveQueries)} color="text-green-400" />

--- a/web/src/components/cards/workload-monitor/ClusterHealthMonitor.tsx
+++ b/web/src/components/cards/workload-monitor/ClusterHealthMonitor.tsx
@@ -202,7 +202,7 @@ export function ClusterHealthMonitor({ config: _config }: ClusterHealthMonitorPr
     return (
       <div className="space-y-3">
         <Skeleton variant="text" width={160} height={20} />
-        <div className="grid grid-cols-2 sm:grid-cols-3 gap-2">
+        <div className="grid grid-cols-2 @md:grid-cols-3 gap-2">
           {Array.from({ length: 3 }).map((_, i) => (
             <Skeleton key={i} variant="rounded" height={48} />
           ))}
@@ -236,7 +236,7 @@ export function ClusterHealthMonitor({ config: _config }: ClusterHealthMonitorPr
       </div>
 
       {/* Stats grid */}
-      <div className="grid grid-cols-2 sm:grid-cols-3 gap-2 mb-3">
+      <div className="grid grid-cols-2 @md:grid-cols-3 gap-2 mb-3">
         <div className="rounded-md bg-card/50 border border-border p-2 text-center">
           <p className="text-lg font-semibold text-foreground">{stats.totalNodes}</p>
           <p className="text-2xs text-muted-foreground">{t('common.nodes')}</p>

--- a/web/src/components/cards/workload-monitor/GitHubCIMonitor.tsx
+++ b/web/src/components/cards/workload-monitor/GitHubCIMonitor.tsx
@@ -295,7 +295,7 @@ export function GitHubCIMonitor({ config, ref }: GitHubCIMonitorProps & { ref?: 
     return (
       <div className="space-y-3">
         <Skeleton variant="text" width={160} height={20} />
-        <div className="grid grid-cols-2 sm:grid-cols-4 gap-2">
+        <div className="grid grid-cols-2 @md:grid-cols-4 gap-2">
           {Array.from({ length: 4 }).map((_, i) => (
             <Skeleton key={i} variant="rounded" height={48} />
           ))}
@@ -410,7 +410,7 @@ export function GitHubCIMonitor({ config, ref }: GitHubCIMonitorProps & { ref?: 
       )}
 
       {/* Stats grid */}
-      <div className="grid grid-cols-2 sm:grid-cols-4 gap-2 mb-3">
+      <div className="grid grid-cols-2 @md:grid-cols-4 gap-2 mb-3">
         <div className="rounded-md bg-card/50 border border-border p-2 text-center">
           <p className="text-lg font-semibold text-green-400">{stats.successRate}%</p>
           <p className="text-2xs text-muted-foreground">Pass Rate</p>

--- a/web/src/components/cards/workload-monitor/ProwCIMonitor.tsx
+++ b/web/src/components/cards/workload-monitor/ProwCIMonitor.tsx
@@ -161,7 +161,7 @@ export function ProwCIMonitor({ config: _config }: ProwCIMonitorProps) {
     return (
       <div className="space-y-3">
         <Skeleton variant="text" width={140} height={20} />
-        <div className="grid grid-cols-2 sm:grid-cols-4 gap-2">
+        <div className="grid grid-cols-2 @md:grid-cols-4 gap-2">
           {Array.from({ length: 4 }).map((_, i) => (
             <Skeleton key={i} variant="rounded" height={48} />
           ))}
@@ -211,7 +211,7 @@ export function ProwCIMonitor({ config: _config }: ProwCIMonitorProps) {
       </div>
 
       {/* Stats grid */}
-      <div className="grid grid-cols-2 sm:grid-cols-4 gap-2 mb-3">
+      <div className="grid grid-cols-2 @md:grid-cols-4 gap-2 mb-3">
         <div className="rounded-md bg-card/50 border border-border p-2 text-center">
           <p className="text-lg font-semibold text-green-400">{stats.successRate}%</p>
           <p className="text-2xs text-muted-foreground">Success Rate</p>


### PR DESCRIPTION
## Summary
- Converts viewport breakpoints (`sm:`, `md:`, `lg:`) to container query breakpoints (`@sm:`, `@md:`, `@lg:`) in ~55 card files
- Cards now respond to their own container width (set in CardWrapper.tsx from Phase 2) rather than the viewport, fixing layout in narrow columns and side panels
- Mapping: `sm:grid-cols` → `@md:grid-cols` (450px), `md:grid-cols` → `@lg:grid-cols` (600px), `hidden sm:inline` → `hidden @sm:inline` (300px)
- Modal files excluded (render outside card container via portals)
- 60 files changed, 97 lines — all 1:1 class replacements, zero logic changes

## Test plan
- [ ] Cards render correctly at full width (3-4 column grids expand)
- [ ] Cards in narrow columns (1-col layout) gracefully collapse to 2-col grids
- [ ] Hidden text elements appear when card container is wide enough
- [ ] No visual regressions in dashboard layout
- [ ] Build and lint pass with no new issues

Fixes #8695

🤖 Generated with [Claude Code](https://claude.com/claude-code)