### PR TITLE
fix: address Copilot review comments on CI/CD stats (PR #8770)

### DIFF
--- a/web/src/components/cicd/useCICDStats.ts
+++ b/web/src/components/cicd/useCICDStats.ts
@@ -54,6 +54,7 @@ export function useCICDStats(): CICDStatsResult {
         streakKind: 'mixed' as const,
         totalWorkflows: 0,
         openPRs: 0,
+        runsToday: 0,
         isDemo: true,
         matrixDays: 0,
       }
@@ -129,21 +130,12 @@ export function useCICDStats(): CICDStatsResult {
       if (todayCell && todayCell.conclusion !== null) runsToday++
     }
 
-    // --- Open PRs (deduplicate PR numbers from ALL data sources) ---
+    // --- Open PRs (only in-progress/queued runs from flow) ---
     const prNumbers = new Set<string>()
-    // From flow (in-flight runs)
     for (const r of (flow?.runs || [])) {
       if (r.run.pullRequests) {
         for (const pr of r.run.pullRequests) {
           prNumbers.add(`${r.run.repo}#${pr.number}`)
-        }
-      }
-    }
-    // From failures (recent failed runs may reference PRs)
-    for (const r of (failures?.runs || [])) {
-      if (r.pullRequests) {
-        for (const pr of r.pullRequests) {
-          prNumbers.add(`${r.repo}#${pr.number}`)
         }
       }
     }
@@ -193,7 +185,7 @@ export function useCICDStats(): CICDStatsResult {
         return {
           value: computed.openPRs,
           sublabel: computed.openPRs > 0
-            ? 'PRs with active workflows'
+            ? 'PRs with in-progress CI'
             : 'no PRs running CI',
           isDemo: computed.isDemo,
           modeHints: ['sparkline', 'numeric'],
@@ -209,7 +201,7 @@ export function useCICDStats(): CICDStatsResult {
           modeHints: ['numeric', 'heatmap', 'trend'],
         }
 
-      case 'cicd_avg_duration': {
+      case 'cicd_runs_today': {
         return {
           value: computed.runsToday ?? 0,
           sublabel: 'workflows ran today',

--- a/web/src/components/ui/StatsBlockDefinitions.ts
+++ b/web/src/components/ui/StatsBlockDefinitions.ts
@@ -430,7 +430,7 @@ export const CICD_STAT_BLOCKS: StatBlockConfig[] = [
   { id: 'cicd_pass_rate', name: 'Pass Rate', icon: 'Percent', visible: true, color: 'green', displayMode: 'ring' },
   { id: 'cicd_open_prs', name: 'Active PR Runs', icon: 'ClipboardList', visible: true, color: 'blue', displayMode: 'sparkline' },
   { id: 'cicd_failed_24h', name: 'Failed (24h)', icon: 'XCircle', visible: true, color: 'red' },
-  { id: 'cicd_avg_duration', name: 'Runs Today', icon: 'Clock', visible: true, color: 'cyan' },
+  { id: 'cicd_runs_today', name: 'Runs Today', icon: 'Clock', visible: true, color: 'cyan' },
   { id: 'cicd_streak', name: 'Nightly Streak', icon: 'Activity', visible: true, color: 'purple', displayMode: 'sparkline' },
   { id: 'cicd_total_workflows', name: 'Total Workflows', icon: 'Workflow', visible: true, color: 'yellow' },
 ]


### PR DESCRIPTION
## Summary

Addresses 3 Copilot review comments from merged PR #8770:

- **openPRs stat accuracy**: Filtered `computed.openPRs` to only count PRs from `flow` (in-progress/queued runs), excluding historical failures. The stat is labeled "Active PR Runs" so it should only reflect currently running CI, not past failures.
- **Missing fallback property**: Added `runsToday: 0` to the `useMemo` fallback branch when `pipelineData` is null, preventing potential undefined access at `computed.runsToday`.
- **Mismatched stat id**: Renamed `cicd_avg_duration` to `cicd_runs_today` in both `useCICDStats.ts` and `StatsBlockDefinitions.ts` to match the actual data the stat now represents.

Fixes #8780

## Test plan
- [ ] CI/CD dashboard loads without errors
- [ ] "Active PR Runs" stat only counts PRs with in-progress CI (not historical failures)
- [ ] "Runs Today" stat displays correctly
- [ ] No TypeScript errors in build