### PR TITLE
fix: reduce benchmark retry storms causing nightly test suite timeout

### DIFF
--- a/.github/workflows/nightly-test-suite.yml
+++ b/.github/workflows/nightly-test-suite.yml
@@ -24,17 +24,16 @@ jobs:
       issues: write
     if: github.repository == 'kubestellar/console'
     runs-on: ubuntu-latest
-    # The suite bundles 13 Playwright specs after the Go and security tests.
-    # One of them (benchmark-dashboard, which hits live Google Drive + GitHub
-    # Actions + Netlify functions) had been burning 20+ minutes on retry
-    # storms and pushing the total over 90m, cancelling three nights in a row
-    # (run 24439970651, plus two earlier runs on 2026-04-13 and 04-14).
-    # 120m covers the worst case with headroom;
-    # the per-test timeout in benchmarks.config.ts is also being cut from 5m
-    # to 2m in the same PR, which should actually bring total runtime back
-    # under 90m — the 120m bump is belt-and-suspenders in case one of the
-    # other Playwright specs inherits a similar pattern.
-    timeout-minutes: 120
+    # Three layers prevent benchmark retry storms from blowing the budget:
+    #   1. benchmarks.config.ts: retries=0, per-test timeout=60s (was 120s)
+    #   2. run-all-tests.sh: per-suite wall-clock cap of 5m via timeout(1)
+    #   3. This workflow-level backstop at 90m
+    # Previously the workflow ran at 120m with no per-suite cap, and benchmark
+    # specs retrying against live Google Drive / GitHub Actions / Netlify
+    # pushed total runtime past 90m on three consecutive nights (2026-04-13
+    # through 04-15). With per-suite caps the total should stay under 60m;
+    # 90m provides headroom without masking real hangs.
+    timeout-minutes: 90
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/scripts/run-all-tests.sh
+++ b/scripts/run-all-tests.sh
@@ -286,6 +286,12 @@ if [ -z "$FAST_MODE" ]; then
         # Export PLAYWRIGHT_BASE_URL so Playwright configs skip their own webServer
         export PLAYWRIGHT_BASE_URL="http://127.0.0.1:${PREVIEW_PORT}"
 
+        # Per-suite wall-clock cap (seconds). Prevents a single hanging suite
+        # (e.g. benchmark retries against unresponsive external services) from
+        # consuming the entire nightly workflow budget. 5 minutes is generous
+        # for any single Playwright suite; most finish in under 2 minutes.
+        PLAYWRIGHT_SUITE_TIMEOUT_SECS=300
+
         for script in "${PLAYWRIGHT_SCRIPTS[@]}"; do
           SUITE_NAME=$(basename "$script" .sh)
           TOTAL=$((TOTAL + 1))
@@ -302,9 +308,16 @@ if [ -z "$FAST_MODE" ]; then
           SUITE_START=$(date +%s)
           SUITE_OUTPUT="/tmp/suite-${SUITE_NAME}.log"
           SUITE_EXIT=0
-          bash "$script" > "$SUITE_OUTPUT" 2>&1 || SUITE_EXIT=$?
+          timeout "${PLAYWRIGHT_SUITE_TIMEOUT_SECS}" bash "$script" > "$SUITE_OUTPUT" 2>&1 || SUITE_EXIT=$?
           SUITE_END=$(date +%s)
           SUITE_DURATION=$((SUITE_END - SUITE_START))
+
+          # timeout(1) returns 124 when the command is killed by the timer
+          TIMEOUT_EXIT_CODE=124
+          if [ "$SUITE_EXIT" -eq "$TIMEOUT_EXIT_CODE" ]; then
+            echo -e "    ${RED}⏱  TIMEOUT${NC} after ${PLAYWRIGHT_SUITE_TIMEOUT_SECS}s"
+            echo "Suite killed after ${PLAYWRIGHT_SUITE_TIMEOUT_SECS}s wall-clock timeout" >> "$SUITE_OUTPUT"
+          fi
 
           if [ "$SUITE_EXIT" -eq 0 ]; then
             echo -e "    ${GREEN}✓ PASS${NC}  (${SUITE_DURATION}s)"

--- a/web/e2e/benchmarks/benchmarks.config.ts
+++ b/web/e2e/benchmarks/benchmarks.config.ts
@@ -22,16 +22,15 @@ function getWebServer() {
   }
 }
 
-// Per-test timeout. The in-test waitForFunction assertions use 15-30s
-// timeouts (STREAM_DATA_TIMEOUT_MS, NETLIFY_FETCH_TIMEOUT_MS in the spec),
-// so the outer Playwright timeout only matters as a backstop when a page
-// hangs. 5 minutes was vastly over-budget — a single retry storm against
-// live Google Drive / GitHub Actions / Netlify could eat 20+ minutes and
-// cancel the whole nightly-test-suite workflow at 90m (seen on 2026-04-13
-// through 04-15). 2 minutes is enough backstop for the slowest real case
-// (SSE streaming + chart render on a cold preview server) without letting
-// a hang compound across all 12 tests.
-const PER_TEST_TIMEOUT_MS = 120_000
+// Per-test timeout backstop. The in-test waitForFunction assertions use
+// 15-30s timeouts (STREAM_DATA_TIMEOUT_MS, NETLIFY_FETCH_TIMEOUT_MS in the
+// spec), so this outer Playwright timeout only fires when a page truly hangs.
+// 60s is enough for the slowest real case (SSE stream + chart render on a
+// cold preview server) while preventing a single hang from eating minutes
+// of wall time — with 12 tests, even 2m × 12 = 24m was too much headroom
+// when the nightly-test-suite workflow has a 120m budget shared with Go +
+// security suites.
+const PER_TEST_TIMEOUT_MS = 60_000
 
 export default defineConfig({
   testDir: '.',


### PR DESCRIPTION
## Summary

- Cut benchmark per-test timeout from 120s to 60s (in-test assertions use 15-30s, so 60s is ample backstop)
- Add per-suite 5-minute wall-clock cap in `run-all-tests.sh` via `timeout(1)` — a hanging suite now fails fast instead of consuming the entire workflow budget
- Lower workflow timeout from 120m to 90m — with per-suite caps the total should stay under 60m; 90m provides headroom

The root cause was that individual benchmark tests could hang for up to 2 minutes each against live external services (Google Drive, GitHub Actions, Netlify), and with 12 tests that compounds to 24+ minutes just for benchmarks, leaving insufficient budget for Go + security suites and triggering cancellation at the workflow-level timeout.

bead: az5

## Test plan

- [ ] Verify `npm run build` passes (confirmed locally)
- [ ] Nightly workflow completes within 90m on next run
- [ ] Benchmark suite finishes within the 5-minute per-suite cap

🤖 Generated with [Claude Code](https://claude.com/claude-code)