### PR TITLE
fix: update AlertRuleEditor test for duration preset chips

### DIFF
--- a/web/src/components/alerts/AlertRuleEditor.tsx
+++ b/web/src/components/alerts/AlertRuleEditor.tsx
@@ -480,7 +480,7 @@ export function AlertRuleEditor({ isOpen = true, rule, onSave, onCancel }: Alert
             {/* Duration */}
             <div>
               <label htmlFor="alertRuleDuration" className="block text-xs text-muted-foreground mb-1">
-                Duration (seconds before alerting)
+                {t('alerts.durationSeconds')}
               </label>
               <div className="flex items-center gap-2 flex-wrap">
                 {DURATION_PRESETS.map(preset => (


### PR DESCRIPTION
## Summary
- PR #8742 added duration preset chips to AlertRuleEditor but replaced `t('alerts.durationSeconds')` with a hardcoded string in the duration label
- This broke the a11y label-input association test which relies on the i18n mock returning translation keys verbatim
- Restored the `t('alerts.durationSeconds')` call to fix the test and maintain i18n compliance

Fixes #8792

## Test plan
- [x] `npx vitest run src/components/alerts/AlertRuleEditor.test.tsx` — all 13 tests pass
- [x] `npm run build` — passes with all post-build safety checks