### PR TITLE
feat: show upgrade-in-progress state on navbar update indicator

### DIFF
--- a/web/src/components/layout/Sidebar.tsx
+++ b/web/src/components/layout/Sidebar.tsx
@@ -1,7 +1,7 @@
 import { useState, useRef, useEffect, useCallback, lazy, Suspense } from 'react'
 import { useTranslation } from 'react-i18next'
 import { NavLink, useNavigate, useLocation } from 'react-router-dom'
-import { Plus, ChevronLeft, ChevronRight, CheckCircle2, AlertTriangle, WifiOff, GripVertical, X, User, Pin, PinOff, Satellite } from 'lucide-react'
+import { Plus, ChevronLeft, ChevronRight, CheckCircle2, AlertTriangle, WifiOff, GripVertical, X, User, Pin, PinOff, Satellite, Loader2 } from 'lucide-react'
 import { iconRegistry } from '../../lib/icons'
 import { cn } from '../../lib/cn'
 import { Tooltip } from '../ui/Tooltip'
@@ -21,6 +21,7 @@ import { DASHBOARD_CONFIGS } from '../../config/dashboards/index'
 import { emitSidebarNavigated, emitDashboardRenamed } from '../../lib/analytics'
 import { prefetchDashboard } from '../../lib/prefetchDashboard'
 import { useVersionCheck } from '../../hooks/useVersionCheck'
+import { useUpgradeState } from '../../hooks/useUpgradeState'
 import { STORAGE_KEY_GROUND_CONTROL_DASHBOARDS } from '../../lib/constants/storage'
 import { safeGetJSON } from '../../lib/utils/localStorage'
 
@@ -66,6 +67,8 @@ export function Sidebar() {
   const { isFullScreen: isMissionFullScreen } = useMissions()
   const { viewerCount, hasError: viewersError, isLoading: viewersLoading } = useActiveUsers()
   const { hasUpdate, channel, latestMainSHA } = useVersionCheck()
+  const upgradeState = useUpgradeState()
+  const isUpgrading = upgradeState.phase === 'triggering' || upgradeState.phase === 'restarting'
   const { t } = useTranslation()
   const navigate = useNavigate()
   const location = useLocation()
@@ -584,14 +587,27 @@ export function Sidebar() {
                 {__COMMIT_HASH__.substring(0, 7)}
               </span>
             </div>
-            {/* Developer mode: warn when running an older commit */}
+            {/* Developer mode: warn when running an older commit, or show upgrade progress */}
             {channel === 'developer' && hasUpdate && (
               <div
-                className="flex items-center gap-1 text-2xs text-yellow-400/80"
-                title={`Behind main — latest: ${latestMainSHA?.substring(0, 7) ?? 'unknown'}`}
+                className={cn(
+                  'flex items-center gap-1 text-2xs',
+                  isUpgrading ? 'text-cyan-400/80' : 'text-yellow-400/80',
+                )}
+                title={isUpgrading
+                  ? t('update.upgrading', 'Upgrading...')
+                  : `Behind main — latest: ${latestMainSHA?.substring(0, 7) ?? 'unknown'}`}
               >
-                <AlertTriangle className="w-3 h-3" />
-                <span>{t('sidebar.behindMain', 'Behind main')}</span>
+                {isUpgrading ? (
+                  <Loader2 className="w-3 h-3 animate-spin" />
+                ) : (
+                  <AlertTriangle className="w-3 h-3" />
+                )}
+                <span>
+                  {isUpgrading
+                    ? t('update.upgrading', 'Upgrading...')
+                    : t('sidebar.behindMain', 'Behind main')}
+                </span>
               </div>
             )}
           </div>

--- a/web/src/components/layout/navbar/UpdateIndicator.tsx
+++ b/web/src/components/layout/navbar/UpdateIndicator.tsx
@@ -1,23 +1,36 @@
 import { useState, useRef, useEffect } from 'react'
 import { useTranslation } from 'react-i18next'
-import { Download } from 'lucide-react'
+import { Download, Loader2, Check, AlertTriangle } from 'lucide-react'
 import { useVersionCheck } from '../../../hooks/useVersionCheck'
+import { useUpgradeState } from '../../../hooks/useUpgradeState'
 import { useFeatureHints } from '../../../hooks/useFeatureHints'
 import { FeatureHintTooltip } from '../../ui/FeatureHintTooltip'
 import { WhatsNewModal, isUpdateSnoozed } from '../../updates/WhatsNewModal'
 import { isDemoMode } from '../../../lib/demoMode'
 import { useToast } from '../../ui/Toast'
 import { emitWhatsNewModalOpened } from '../../../lib/analytics'
+import { cn } from '../../../lib/cn'
 
 const UPDATE_TOAST_SESSION_KEY = 'kc-update-toast-seen'
+
+/** Icon size class shared across all upgrade phase icons */
+const ICON_SIZE = 'w-4 h-4'
+
+/** Dot indicator size class */
+const DOT_SIZE = 'w-2 h-2'
 
 export function UpdateIndicator() {
   const { t } = useTranslation()
   const { showToast } = useToast()
   const { hasUpdate, latestRelease, channel, autoUpdateStatus, latestMainSHA } = useVersionCheck()
+  const upgradeState = useUpgradeState()
   const [showModal, setShowModal] = useState(false)
   const updateHint = useFeatureHints('update-available')
   const prevHasUpdate = useRef(false)
+
+  const isUpgrading = upgradeState.phase === 'triggering' || upgradeState.phase === 'restarting'
+  const isUpgradeComplete = upgradeState.phase === 'complete'
+  const isUpgradeError = upgradeState.phase === 'error'
 
   useEffect(() => {
     if (hasUpdate && !prevHasUpdate.current) {
@@ -35,16 +48,38 @@ export function UpdateIndicator() {
     prevHasUpdate.current = hasUpdate
   }, [hasUpdate, latestRelease?.tag, showToast])
 
-  if (!hasUpdate || isDemoMode() || isUpdateSnoozed()) {
+  // Show indicator when there's an update available OR an upgrade is in progress/complete/error
+  const showIndicator = hasUpdate || isUpgrading || isUpgradeComplete || isUpgradeError
+  if (!showIndicator || isDemoMode() || (isUpdateSnoozed() && !isUpgrading && !isUpgradeComplete && !isUpgradeError)) {
     return null
   }
 
   const isDeveloperUpdate = channel === 'developer' && hasUpdate
   const devSHA = autoUpdateStatus?.latestSHA ?? latestMainSHA
 
-  if (!isDeveloperUpdate && !latestRelease) {
+  if (!isDeveloperUpdate && !latestRelease && !isUpgrading && !isUpgradeComplete && !isUpgradeError) {
     return null
   }
+
+  /** Resolve the button style based on upgrade phase */
+  const buttonClassName = cn(
+    'flex items-center gap-2 px-2 py-1.5 h-9 rounded-lg transition-colors',
+    isUpgradeError && 'bg-red-500/10 text-red-400 hover:bg-red-500/20',
+    isUpgradeComplete && 'bg-green-500/10 text-green-400 hover:bg-green-500/20',
+    isUpgrading && 'bg-cyan-500/10 text-cyan-400 hover:bg-cyan-500/20',
+    !isUpgrading && !isUpgradeComplete && !isUpgradeError && 'bg-green-500/10 text-green-400 hover:bg-green-500/20',
+  )
+
+  /** Resolve the tooltip title based on upgrade phase */
+  const buttonTitle = isUpgradeError
+    ? t('update.upgradeFailed', 'Upgrade failed')
+    : isUpgradeComplete
+      ? t('update.upgradeComplete', 'Upgrade complete — reloading...')
+      : isUpgrading
+        ? t('update.upgrading', 'Upgrading...')
+        : isDeveloperUpdate
+          ? `New commit: ${devSHA?.slice(0, 7) ?? 'unknown'}`
+          : t('update.availableTag', { tag: latestRelease?.tag ?? '' })
 
   return (
     <>
@@ -55,16 +90,29 @@ export function UpdateIndicator() {
             updateHint.action()
             emitWhatsNewModalOpened(latestRelease?.tag ?? devSHA?.slice(0, 7) ?? 'unknown')
           }}
-          className="flex items-center gap-2 px-2 py-1.5 h-9 rounded-lg bg-green-500/10 text-green-400 hover:bg-green-500/20 transition-colors"
-          title={isDeveloperUpdate
-            ? `New commit: ${devSHA?.slice(0, 7) ?? 'unknown'}`
-            : t('update.availableTag', { tag: latestRelease?.tag ?? '' })}
+          className={buttonClassName}
+          title={buttonTitle}
         >
-          <Download className="w-4 h-4" />
-          <span className="w-2 h-2 bg-green-400 rounded-full animate-pulse" />
+          {isUpgradeError ? (
+            <AlertTriangle className={ICON_SIZE} />
+          ) : isUpgradeComplete ? (
+            <Check className={ICON_SIZE} />
+          ) : isUpgrading ? (
+            <Loader2 className={cn(ICON_SIZE, 'animate-spin')} />
+          ) : (
+            <Download className={ICON_SIZE} />
+          )}
+
+          {/* Dot indicator: pulsing green for available, spinning cyan for upgrading, none for complete/error */}
+          {isUpgrading && (
+            <span className={cn(DOT_SIZE, 'bg-cyan-400 rounded-full animate-pulse')} />
+          )}
+          {!isUpgrading && !isUpgradeComplete && !isUpgradeError && (
+            <span className={cn(DOT_SIZE, 'bg-green-400 rounded-full animate-pulse')} />
+          )}
         </button>
 
-        {updateHint.isVisible && !showModal && (
+        {updateHint.isVisible && !showModal && !isUpgrading && !isUpgradeComplete && !isUpgradeError && (
           <FeatureHintTooltip
             message="An update is available — click here to see what's new and how to update"
             onDismiss={updateHint.dismiss}

--- a/web/src/hooks/useSelfUpgrade.ts
+++ b/web/src/hooks/useSelfUpgrade.ts
@@ -1,6 +1,7 @@
 import { useState, useEffect, useCallback, useRef } from 'react'
 import type { SelfUpgradeStatus } from '../types/updates'
 import { STORAGE_KEY_TOKEN } from '../lib/constants'
+import { setUpgradeState } from '../lib/upgradeState'
 
 /** Timeout for self-upgrade API calls (ms) */
 const SELF_UPGRADE_TIMEOUT_MS = 15_000
@@ -82,6 +83,7 @@ export function useSelfUpgrade() {
     setRestartComplete(false)
     setRestartError(null)
     setRestartElapsed(0)
+    setUpgradeState({ phase: 'restarting' })
 
     const controller = new AbortController()
     pollAbortRef.current = controller
@@ -106,6 +108,7 @@ export function useSelfUpgrade() {
         if (tickIntervalRef.current) { clearInterval(tickIntervalRef.current); tickIntervalRef.current = null }
         setIsRestarting(false)
         setRestartError('The console did not come back within the expected time. Try refreshing manually.')
+        setUpgradeState({ phase: 'error', errorMessage: 'The console did not come back within the expected time.' })
         return
       }
 
@@ -118,6 +121,7 @@ export function useSelfUpgrade() {
             if (tickIntervalRef.current) { clearInterval(tickIntervalRef.current); tickIntervalRef.current = null }
             setIsRestarting(false)
             setRestartComplete(true)
+            setUpgradeState({ phase: 'complete' })
             // Auto-reload after a brief pause so the user sees the success state
             setTimeout(() => window.location.reload(), RELOAD_DELAY_MS)
           }
@@ -139,6 +143,7 @@ export function useSelfUpgrade() {
   const triggerUpgrade = async (imageTag: string): Promise<{ success: boolean; error?: string }> => {
     setIsTriggering(true)
     setTriggerError(null)
+    setUpgradeState({ phase: 'triggering' })
     try {
       const token = getToken()
       const resp = await fetch('/api/self-upgrade/trigger', {
@@ -158,6 +163,7 @@ export function useSelfUpgrade() {
       const errorMsg = data.error ?? `Server returned ${resp.status}`
       setTriggerError(errorMsg)
       setIsTriggering(false)
+      setUpgradeState({ phase: 'error', errorMessage: errorMsg })
       return { success: false, error: errorMsg }
     } catch (err) {
       // If the trigger request itself fails (connection lost mid-request),
@@ -170,6 +176,7 @@ export function useSelfUpgrade() {
       }
       setTriggerError(msg)
       setIsTriggering(false)
+      setUpgradeState({ phase: 'error', errorMessage: msg })
       return { success: false, error: msg }
     }
   }

--- a/web/src/hooks/useUpgradeState.ts
+++ b/web/src/hooks/useUpgradeState.ts
@@ -1,0 +1,16 @@
+import { useSyncExternalStore } from 'react'
+import {
+  getUpgradeState,
+  subscribeUpgradeState,
+  type UpgradeState,
+} from '../lib/upgradeState'
+
+/**
+ * React hook to subscribe to the global upgrade state singleton.
+ *
+ * Uses useSyncExternalStore for tear-free reads that are compatible
+ * with concurrent rendering.
+ */
+export function useUpgradeState(): UpgradeState {
+  return useSyncExternalStore(subscribeUpgradeState, getUpgradeState, getUpgradeState)
+}

--- a/web/src/lib/upgradeState.ts
+++ b/web/src/lib/upgradeState.ts
@@ -1,0 +1,58 @@
+/**
+ * Global upgrade state singleton.
+ *
+ * Lightweight pub/sub store (same pattern as demoMode.ts) so that
+ * useSelfUpgrade() can publish upgrade progress and any component
+ * (UpdateIndicator, Sidebar) can subscribe without a shared Context.
+ */
+
+// ============================================================================
+// Types
+// ============================================================================
+
+export type UpgradePhase =
+  | 'idle'
+  | 'triggering'
+  | 'restarting'
+  | 'complete'
+  | 'error'
+
+export interface UpgradeState {
+  phase: UpgradePhase
+  /** Human-readable error message when phase === 'error' */
+  errorMessage?: string
+}
+
+type Listener = (state: UpgradeState) => void
+
+// ============================================================================
+// Module-level singleton
+// ============================================================================
+
+const IDLE_STATE: UpgradeState = { phase: 'idle' }
+
+let current: UpgradeState = IDLE_STATE
+const listeners = new Set<Listener>()
+
+// ============================================================================
+// Public API
+// ============================================================================
+
+/** Read the current upgrade state (non-reactive — use subscribe for updates) */
+export function getUpgradeState(): UpgradeState {
+  return current
+}
+
+/** Update the upgrade state and notify all subscribers */
+export function setUpgradeState(next: UpgradeState): void {
+  current = next
+  listeners.forEach((fn) => fn(current))
+}
+
+/** Subscribe to upgrade state changes. Returns an unsubscribe function. */
+export function subscribeUpgradeState(fn: Listener): () => void {
+  listeners.add(fn)
+  return () => {
+    listeners.delete(fn)
+  }
+}

--- a/web/src/locales/en/common.json
+++ b/web/src/locales/en/common.json
@@ -1894,7 +1894,10 @@
   },
   "update": {
     "available": "Update Available",
-    "availableTag": "Update available: {{tag}}"
+    "availableTag": "Update available: {{tag}}",
+    "upgrading": "Upgrading...",
+    "upgradeComplete": "Upgrade complete — reloading...",
+    "upgradeFailed": "Upgrade failed"
   },
   "drilldown": {
     "goBack": "Go back",


### PR DESCRIPTION
## Summary
- Adds a lightweight global upgrade state singleton (`upgradeState.ts`) using module-level pub/sub (same pattern as `demoMode.ts`)
- `useSelfUpgrade` hook now publishes phase transitions (triggering, restarting, complete, error) to the global store
- `UpdateIndicator` subscribes via `useUpgradeState` and shows phase-appropriate icons: spinning `Loader2` while upgrading, `Check` on completion, `AlertTriangle` on error
- Sidebar "Behind main" warning also switches to cyan spinning icon during upgrade instead of the static yellow warning

## Test plan
- [ ] Trigger a self-upgrade via Settings > Updates and verify the navbar icon changes from green download to spinning cyan loader
- [ ] Verify the sidebar "Behind main" text switches to "Upgrading..." with a spinning icon during upgrade
- [ ] After upgrade completes, verify a green check icon appears briefly before the page reloads
- [ ] If upgrade fails/times out, verify a red alert icon appears in the navbar
- [ ] Verify normal "update available" behavior is unchanged when no upgrade is in progress

Fixes #8799

🤖 Generated with [Claude Code](https://claude.com/claude-code)