### PR TITLE
fix: resolve nightly consistency-test and gosec regressions

### DIFF
--- a/cmd/console/watchdog.go
+++ b/cmd/console/watchdog.go
@@ -256,6 +256,7 @@ func runWatchdog(cfg WatchdogConfig) error {
 		tlsCfg := &tls.Config{
 			Certificates: []tls.Certificate{cert},
 			NextProtos:   []string{"h2", "http/1.1"},
+			MinVersion:   tls.VersionTLS12,
 		}
 
 		// Listen on raw TCP, then peek each connection's first byte.

--- a/web/src/components/cards/ServiceStatus.tsx
+++ b/web/src/components/cards/ServiceStatus.tsx
@@ -388,9 +388,9 @@ export function ServiceStatus() {
                 {formattedPorts.length > 0 && (
                   <span
                     className="text-xs text-muted-foreground truncate max-w-[140px]"
-                    title={formattedPorts.join(', ')}
+                    title={(formattedPorts || []).join(', ')}
                   >
-                    {formattedPorts.join(', ')}
+                    {(formattedPorts || []).join(', ')}
                   </span>
                 )}
                 {/* Orphaned badge (#6164/#6165) */}

--- a/web/src/components/cards/drasi/DrasiReactiveGraph.tsx
+++ b/web/src/components/cards/drasi/DrasiReactiveGraph.tsx
@@ -40,6 +40,8 @@ import { useDrasiConnections, type DrasiConnection } from '../../../hooks/useDra
 // Constants
 // ---------------------------------------------------------------------------
 
+/** Timeout for Drasi proxy API calls (ms) */
+const DRASI_PROXY_TIMEOUT_MS = 10_000
 /** How often to refresh demo data values */
 const FLOW_ANIMATION_INTERVAL_MS = 3000
 /** Maximum rows shown in the results table */
@@ -2045,6 +2047,7 @@ export function DrasiReactiveGraph() {
           method: isCreate ? 'POST' : 'PUT',
           headers: { 'content-type': 'application/json' },
           body: JSON.stringify({ id: config.name, spec: { kind: config.kind } }),
+          signal: AbortSignal.timeout(DRASI_PROXY_TIMEOUT_MS),
         })
         refetchDrasi()
       } catch {
@@ -2079,6 +2082,7 @@ export function DrasiReactiveGraph() {
             id: config.name,
             spec: { mode: config.language.replace(/ QUERY$/, ''), query: config.queryText },
           }),
+          signal: AbortSignal.timeout(DRASI_PROXY_TIMEOUT_MS),
         })
         refetchDrasi()
       } catch {
@@ -2115,6 +2119,7 @@ export function DrasiReactiveGraph() {
             id: defaultName,
             spec: { kind: 'SSE', queries: queries.map(q => ({ id: q.id })) },
           }),
+          signal: AbortSignal.timeout(DRASI_PROXY_TIMEOUT_MS),
         })
         refetchDrasi()
       } catch {
@@ -2146,6 +2151,7 @@ export function DrasiReactiveGraph() {
           id: reactionName,
           spec: { kind: 'Result', queries: [{ id: queryId }] },
         }),
+        signal: AbortSignal.timeout(DRASI_PROXY_TIMEOUT_MS),
       })
       refetchDrasi()
     } catch {
@@ -2166,6 +2172,7 @@ export function DrasiReactiveGraph() {
           try {
             await fetch(`/api/drasi/proxy${drasiResourcePath(kind)}/${encodeURIComponent(id)}?${drasiProxyTarget()}`, {
               method: 'DELETE',
+              signal: AbortSignal.timeout(DRASI_PROXY_TIMEOUT_MS),
             })
             refetchDrasi()
           } catch {
@@ -2755,7 +2762,7 @@ export function DrasiReactiveGraph() {
                   onClick={() => handleQueryClick(query.id)}
                   onStop={() => toggleStopped(query.id)}
                   onPin={() => togglePin(query.id)}
-                  onExpand={() => setExpandedNode({ id: query.id, name: query.name, kind: query.language, type: 'query', extra: { sources: query.sourceIds.join(', ') || '(none)' } })}
+                  onExpand={() => setExpandedNode({ id: query.id, name: query.name, kind: query.language, type: 'query', extra: { sources: (query.sourceIds || []).join(', ') || '(none)' } })}
                   onConfigure={() => setConfiguringQuery(query)}
                   onDelete={() => deleteResource('query', query.id, query.name)}
                   onHoverEnter={() => setHoveredNodeId(query.id)}
@@ -2816,7 +2823,7 @@ export function DrasiReactiveGraph() {
                 isDimmed={hoveredNodeId !== null && hoveredNodeId !== reaction.id && !connectedNodeIds(hoveredNodeId).has(reaction.id)}
                 showDelete
                 onStop={() => toggleStopped(reaction.id)}
-                onExpand={() => setExpandedNode({ id: reaction.id, name: reaction.name, kind: reaction.kind, type: 'reaction', extra: { queries: reaction.queryIds.join(', ') || '(none)' } })}
+                onExpand={() => setExpandedNode({ id: reaction.id, name: reaction.name, kind: reaction.kind, type: 'reaction', extra: { queries: (reaction.queryIds || []).join(', ') || '(none)' } })}
                 onDelete={() => deleteResource('reaction', reaction.id, reaction.name)}
                 onHoverEnter={() => setHoveredNodeId(reaction.id)}
                 onHoverLeave={() => setHoveredNodeId(null)}

--- a/web/src/components/gpu/GPUReservationsTab.tsx
+++ b/web/src/components/gpu/GPUReservationsTab.tsx
@@ -184,9 +184,9 @@ export function GPUReservationsTab({
                       <div className="text-xs text-muted-foreground">{t('common:common.type')}</div>
                       <div
                         className="text-sm font-medium text-foreground truncate"
-                        title={acceptedTypes.join(', ')}
+                        title={(acceptedTypes || []).join(', ')}
                       >
-                        {acceptedTypes.join(', ')}
+                        {(acceptedTypes || []).join(', ')}
                       </div>
                     </div>
                   )

--- a/web/src/components/mission-control/MissionControlDialog.tsx
+++ b/web/src/components/mission-control/MissionControlDialog.tsx
@@ -168,7 +168,7 @@ export function MissionControlDialog({ open, onClose, initialKubaraChart }: Miss
   useEffect(() => {
     if (!open) return
     if (mc.staleClusterNames.length === 0) return
-    const names = mc.staleClusterNames.join(', ')
+    const names = (mc.staleClusterNames || []).join(', ')
     showToast(
       `Unassigned ${mc.staleClusterNames.length} cluster(s) from your previous session that no longer exist: ${names}`,
       'warning',

--- a/web/src/components/updates/WhatsNewModal.tsx
+++ b/web/src/components/updates/WhatsNewModal.tsx
@@ -98,7 +98,7 @@ export function WhatsNewModal({ isOpen, onClose }: WhatsNewModalProps) {
         if (commitHash && commitHash !== 'unknown') {
           const commitResp = await fetch(
             `/api/github/repos/kubestellar/console/commits/${commitHash}`,
-            { credentials: 'include' },
+            { credentials: 'include', signal: AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS) },
           )
           if (commitResp.ok) {
             const commitData = await commitResp.json()
@@ -109,7 +109,7 @@ export function WhatsNewModal({ isOpen, onClose }: WhatsNewModalProps) {
         // Step 2: Fetch recent merged PRs
         const resp = await fetch(
           `/api/github/repos/kubestellar/console/pulls?state=closed&sort=updated&direction=desc&per_page=${MAX_RECENT_PRS}`,
-          { credentials: 'include' },
+          { credentials: 'include', signal: AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS) },
         )
         if (!resp.ok || cancelled) return
         const data = await resp.json()
@@ -190,7 +190,9 @@ export function WhatsNewModal({ isOpen, onClose }: WhatsNewModalProps) {
   const handleCopyCommand = useCallback(async (cmd: string) => {
     await copyToClipboard(cmd)
     setCopiedCommand(cmd)
-    setTimeout(() => setCopiedCommand(null), 2000)
+    /** Delay before clearing the "copied" indicator so user sees feedback (ms) */
+    const COPY_FEEDBACK_CLEAR_MS = 2000
+    setTimeout(() => setCopiedCommand(null), COPY_FEEDBACK_CLEAR_MS)
   }, [])
 
   const manualCommands: { label: string; command: string }[] = useMemo(() => {

--- a/web/src/hooks/useAlerts.ts
+++ b/web/src/hooks/useAlerts.ts
@@ -1,5 +1,6 @@
 import { useState, useEffect, useContext } from 'react'
 import { AlertsContext } from '../contexts/AlertsContext'
+import { FETCH_DEFAULT_TIMEOUT_MS } from '../lib/constants'
 import type {
   Alert,
   AlertRule,
@@ -206,6 +207,7 @@ export function useSlackNotification() {
         const response = await fetch('/api/notifications/send', {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
+          signal: AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS),
           body: JSON.stringify({
             alert: {
               id: alert.id,

--- a/web/src/hooks/useCachedACMMScan.ts
+++ b/web/src/hooks/useCachedACMMScan.ts
@@ -10,6 +10,7 @@ import { useCallback, useRef } from 'react'
 import { useCache, type RefreshCategory } from '../lib/cache'
 import { computeLevel, type LevelComputation } from '../lib/acmm/computeLevel'
 import { computeRecommendations, type Recommendation } from '../lib/acmm/computeRecommendations'
+import { FETCH_DEFAULT_TIMEOUT_MS } from '../lib/constants'
 
 const API_PATH = '/api/acmm/scan'
 /** Scan results change slowly; 10-min refresh avoids GitHub rate limits. */
@@ -110,7 +111,9 @@ function demoScan(repo: string): ACMMScanData {
 
 async function fetchACMMScan(repo: string, force: boolean): Promise<ACMMScanData> {
   const qs = force ? `&force=true` : ''
-  const res = await fetch(`${API_PATH}?repo=${encodeURIComponent(repo)}${qs}`)
+  const res = await fetch(`${API_PATH}?repo=${encodeURIComponent(repo)}${qs}`, {
+    signal: AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS),
+  })
   if (!res.ok) {
     throw new Error(`ACMM scan failed: ${res.status} ${res.statusText}`)
   }


### PR DESCRIPTION
## Summary

- **Phase 1 (Magic Numbers)**: Extract raw `2000` literal in `WhatsNewModal.tsx` to named constant `COPY_FEEDBACK_CLEAR_MS`
- **Phase 3 (Join Guards)**: Guard 7 unguarded `.join()` calls with `(arr || [])` in `ServiceStatus`, `DrasiReactiveGraph`, `GPUReservationsTab`, and `MissionControlDialog`
- **Phase 5 (Fetch Timeout)**: Add `AbortSignal.timeout()` to 9 `fetch()` calls missing signal/timeout in `WhatsNewModal`, `useAlerts`, `useCachedACMMScan`, and `DrasiReactiveGraph`
- **gosec HIGH (TLS MinVersion)**: Set `MinVersion: tls.VersionTLS12` on `tls.Config` in `watchdog.go`

Fixes #8804, Fixes #8805

## Test plan

- [ ] `npm run build` passes
- [ ] `npm run lint` passes
- [ ] Consistency test phases 1, 3, 5 report zero new violations
- [ ] gosec no longer reports HIGH for TLS MinVersion