### PR TITLE
🐛 fix: remove console.error from DynamicCard

### DIFF
--- a/web/src/components/cards/DynamicCard.tsx
+++ b/web/src/components/cards/DynamicCard.tsx
@@ -101,8 +101,8 @@ export function Tier1CardRuntime({ cardDefinition }: Tier1Props) {
   const data = isInvalidConfig
     ? []
     : (cardDefinition?.dataSource === 'static'
-        ? (cardDefinition?.staticData || [])
-        : apiData)
+      ? (cardDefinition?.staticData || [])
+      : apiData)
 
   // Report loading state to CardWrapper so header stays in sync with body (#5208)
   const isApiSource = !isInvalidConfig && cardDefinition?.dataSource === 'api'
@@ -409,7 +409,6 @@ export function Tier2CardRuntime({ definition, config }: Tier2Props) {
       } catch (err) {
         if (cancelled) return
         const message = err instanceof Error ? err.message : String(err)
-        console.error(`[DynamicCard] Unexpected compile error:`, err)
         setError(`Unexpected error: ${message}`)
         setCompiling(false)
       }


### PR DESCRIPTION
fixes - #8816 

PR - 4: DynamicCard console.error handling

File: src/components/cards/DynamicCard.tsx:412
Change: Replace console.error('[DynamicCard] Unexpected compile error:', err) with user-visible error display

- Remove console.error('[DynamicCard] Unexpected compile error:', err)
- User-visible error handling via setError already present
- Addresses Auto-QA finding: console.error without user-visible error handling