### PR TITLE
fix: send X-Requested-With on all /api requests (#8830)

### DIFF
--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -418,6 +418,9 @@ class ApiClient {
   private getHeaders(): Record<string, string> {
     const headers: Record<string, string> = {
       'Content-Type': 'application/json',
+      // #8830 — the /api group middleware rejects state-changing requests
+      // (POST/PUT/DELETE/PATCH) without this header. Harmless on GET.
+      'X-Requested-With': 'XMLHttpRequest',
     }
     const token = localStorage.getItem(STORAGE_KEY_TOKEN)
     if (token) {
@@ -679,6 +682,12 @@ export function authFetch(input: RequestInfo | URL, init?: RequestInit): Promise
 
   if (token && token !== DEMO_TOKEN_VALUE && !headers.has('Authorization')) {
     headers.set('Authorization', `Bearer ${token}`)
+  }
+  // #8830 — /api group RequireCSRF middleware rejects state-changing requests
+  // without this header; safeHTTPMethods pass through unconditionally, so
+  // setting it on every authFetch is correct and harmless for GET/HEAD.
+  if (!headers.has('X-Requested-With')) {
+    headers.set('X-Requested-With', 'XMLHttpRequest')
   }
 
   // Use caller-provided signal if present, otherwise apply default timeout


### PR DESCRIPTION
## Summary

**Fixes #8830** — Submitting a bug report via Feedback → Contribute fails with `CSRF header required`.

### Root cause

PR #8738 ("feat: extract CSRF middleware for consistent protection") landed `csrfGuard := middleware.RequireCSRF()` on the whole `/api` Fiber group in `pkg/api/server.go:834`. The middleware rejects any POST/PUT/DELETE/PATCH that lacks `X-Requested-With: XMLHttpRequest`.

But the frontend `api.post/put/delete` helpers use a shared `getHeaders()` that only emits `Content-Type` + `Authorization` — no `X-Requested-With`. The one-off inline fetch in `/auth/refresh` was updated in #6588, but every other API write went un-updated. Locally, where the Go backend actually serves `/api/*`, this 403's everything that calls `api.post` — including `POST /api/feedback/requests` (the bug-report flow).

Production probably didn't see the full blast radius because `console.kubestellar.io` serves `/api` via Netlify Functions, which don't enforce this Go middleware.

### Fix

Two lines in `web/src/lib/api.ts`:
- Add `X-Requested-With: XMLHttpRequest` to `ApiClient.getHeaders()` (used by `post`/`put`/`delete`).
- Set the same header in `authFetch` when callers don't override it.

Safe on GET/HEAD because the middleware's `safeHTTPMethods` set passes those through unconditionally (see `pkg/api/middleware/csrf.go:43`).

## Test plan
- [x] `npx vitest run src/lib/__tests__/api.test.ts` — 46/46 passing
- [x] `npx tsc --noEmit` — clean
- [x] `npx eslint web/src/lib/api.ts` — no new errors (4 pre-existing `preserve-caught-error` on main unchanged)
- [ ] Manual: local dev, submit bug report via Feedback → Contribute, confirm `POST /api/feedback/requests` returns 200

Fixes #8830