### PR TITLE
refactor: extract constants from MissionBrowser.tsx

### DIFF
--- a/web/src/components/missions/MissionBrowser.tsx
+++ b/web/src/components/missions/MissionBrowser.tsx
@@ -50,6 +50,19 @@ import {
 import type { TreeNode, ViewMode, BrowserTab } from './browser'
 import { copyToClipboard } from '../../lib/clipboard'
 import { useToast } from '../ui/Toast'
+import {
+  CATEGORY_FILTERS,
+  SIDEBAR_WIDTH,
+  MISSION_FILE_ACCEPT,
+  isHiddenEntry,
+  isMissionFile,
+  CNCF_CATEGORIES,
+  MATURITY_LEVELS,
+  loadWatchedRepos,
+  saveWatchedRepos,
+  loadWatchedPaths,
+  saveWatchedPaths,
+} from './missionBrowserConstants'
 
 // ============================================================================
 // Types
@@ -63,83 +76,6 @@ interface MissionBrowserProps {
   initialMission?: string
   /** Callback when user clicks "Use in Mission Control" on a Kubara chart (#8483) */
   onUseInMissionControl?: (chartName: string) => void
-}
-
-// ============================================================================
-// Constants
-// ============================================================================
-
-const CATEGORY_FILTERS = [
-  'All',
-  'Troubleshoot',
-  'Deploy',
-  'Upgrade',
-  'Analyze',
-  'Repair',
-  'Custom',
-] as const
-
-const SIDEBAR_WIDTH = 280
-const WATCHED_REPOS_KEY = 'kc_mission_watched_repos'
-const WATCHED_PATHS_KEY = 'kc_mission_watched_paths'
-
-/** File extensions accepted by the mission browser */
-const MISSION_FILE_EXTENSIONS = ['.json', '.yaml', '.yml', '.md'] as const
-const MISSION_FILE_ACCEPT = '.json,.yaml,.yml,.md,application/json,text/yaml,text/markdown'
-
-/**
- * #6421 — Matches any filesystem entry whose name begins with a dot.
- * This exhaustively hides ALL dot-prefixed directories and files (the
- * standard Unix hidden-entry convention) from the mission browser UI.
- * The previous implementation only hid an enumerated set (.github, .gitkeep,
- * index.json) which let .gitlab, .assets, .vscode, .well-known, etc. leak
- * through whenever a new one was added to a source repo.
- */
-const HIDDEN_ENTRY_REGEX = /^\./
-
-/**
- * Returns true if an entry should be hidden from the browser listing.
- * Hides dot-prefixed entries (directories AND files) and the legacy
- * `index.json` manifest which is internal routing state, not a mission.
- */
-function isHiddenEntry(name: string): boolean {
-  if (HIDDEN_ENTRY_REGEX.test(name)) return true
-  if (name === 'index.json') return true
-  return false
-}
-
-/** Check if a filename has a supported mission file extension */
-function isMissionFile(name: string): boolean {
-  const lower = name.toLowerCase()
-  return MISSION_FILE_EXTENSIONS.some(ext => lower.endsWith(ext))
-}
-
-const CNCF_CATEGORIES = [
-  'All', 'Observability', 'Orchestration', 'Runtime', 'Provisioning',
-  'Security', 'Service Mesh', 'App Definition', 'Serverless',
-  'Storage', 'Streaming', 'Networking',
-] as const
-
-const MATURITY_LEVELS = ['All', 'graduated', 'incubating', 'sandbox'] as const
-
-function loadWatchedRepos(): string[] {
-  try {
-    return JSON.parse(localStorage.getItem(WATCHED_REPOS_KEY) || '[]')
-  } catch { return [] }
-}
-
-function saveWatchedRepos(repos: string[]) {
-  localStorage.setItem(WATCHED_REPOS_KEY, JSON.stringify(repos))
-}
-
-function loadWatchedPaths(): string[] {
-  try {
-    return JSON.parse(localStorage.getItem(WATCHED_PATHS_KEY) || '[]')
-  } catch { return [] }
-}
-
-function saveWatchedPaths(paths: string[]) {
-  localStorage.setItem(WATCHED_PATHS_KEY, JSON.stringify(paths))
 }
 
 // ============================================================================

--- a/web/src/components/missions/missionBrowserConstants.ts
+++ b/web/src/components/missions/missionBrowserConstants.ts
@@ -1,0 +1,81 @@
+/**
+ * Constants and small pure helpers used by MissionBrowser.
+ *
+ * Extracted from MissionBrowser.tsx to keep that component file focused on
+ * React rendering logic. These are module-level constants, regexes, and
+ * localStorage accessors with no React or DOM-framework dependencies beyond
+ * `localStorage`.
+ */
+
+export const CATEGORY_FILTERS = [
+  'All',
+  'Troubleshoot',
+  'Deploy',
+  'Upgrade',
+  'Analyze',
+  'Repair',
+  'Custom',
+] as const
+
+export const SIDEBAR_WIDTH = 280
+export const WATCHED_REPOS_KEY = 'kc_mission_watched_repos'
+export const WATCHED_PATHS_KEY = 'kc_mission_watched_paths'
+
+/** File extensions accepted by the mission browser */
+export const MISSION_FILE_EXTENSIONS = ['.json', '.yaml', '.yml', '.md'] as const
+export const MISSION_FILE_ACCEPT = '.json,.yaml,.yml,.md,application/json,text/yaml,text/markdown'
+
+/**
+ * #6421 — Matches any filesystem entry whose name begins with a dot.
+ * This exhaustively hides ALL dot-prefixed directories and files (the
+ * standard Unix hidden-entry convention) from the mission browser UI.
+ * The previous implementation only hid an enumerated set (.github, .gitkeep,
+ * index.json) which let .gitlab, .assets, .vscode, .well-known, etc. leak
+ * through whenever a new one was added to a source repo.
+ */
+export const HIDDEN_ENTRY_REGEX = /^\./
+
+/**
+ * Returns true if an entry should be hidden from the browser listing.
+ * Hides dot-prefixed entries (directories AND files) and the legacy
+ * `index.json` manifest which is internal routing state, not a mission.
+ */
+export function isHiddenEntry(name: string): boolean {
+  if (HIDDEN_ENTRY_REGEX.test(name)) return true
+  if (name === 'index.json') return true
+  return false
+}
+
+/** Check if a filename has a supported mission file extension */
+export function isMissionFile(name: string): boolean {
+  const lower = name.toLowerCase()
+  return MISSION_FILE_EXTENSIONS.some(ext => lower.endsWith(ext))
+}
+
+export const CNCF_CATEGORIES = [
+  'All', 'Observability', 'Orchestration', 'Runtime', 'Provisioning',
+  'Security', 'Service Mesh', 'App Definition', 'Serverless',
+  'Storage', 'Streaming', 'Networking',
+] as const
+
+export const MATURITY_LEVELS = ['All', 'graduated', 'incubating', 'sandbox'] as const
+
+export function loadWatchedRepos(): string[] {
+  try {
+    return JSON.parse(localStorage.getItem(WATCHED_REPOS_KEY) || '[]')
+  } catch { return [] }
+}
+
+export function saveWatchedRepos(repos: string[]) {
+  localStorage.setItem(WATCHED_REPOS_KEY, JSON.stringify(repos))
+}
+
+export function loadWatchedPaths(): string[] {
+  try {
+    return JSON.parse(localStorage.getItem(WATCHED_PATHS_KEY) || '[]')
+  } catch { return [] }
+}
+
+export function saveWatchedPaths(paths: string[]) {
+  localStorage.setItem(WATCHED_PATHS_KEY, JSON.stringify(paths))
+}


### PR DESCRIPTION
## Summary

Extract module-level constants and small pure helpers from the 2134-line `MissionBrowser.tsx` into a new sibling file `web/src/components/missions/missionBrowserConstants.ts`.

This is a zero-behavior-change code movement. No logic, state, or rendering was modified.

## What moved

From `MissionBrowser.tsx` -> `missionBrowserConstants.ts`:

- Constants: `CATEGORY_FILTERS`, `SIDEBAR_WIDTH`, `WATCHED_REPOS_KEY`, `WATCHED_PATHS_KEY`, `MISSION_FILE_EXTENSIONS`, `MISSION_FILE_ACCEPT`, `HIDDEN_ENTRY_REGEX`, `CNCF_CATEGORIES`, `MATURITY_LEVELS`
- Pure helpers: `isHiddenEntry`, `isMissionFile`, `loadWatchedRepos`, `saveWatchedRepos`, `loadWatchedPaths`, `saveWatchedPaths`

All moved items were used only within `MissionBrowser.tsx` (verified by grep across the `src` tree).

## LOC impact

- `MissionBrowser.tsx`: **2134 -> 2070** lines (-64)
- `missionBrowserConstants.ts`: **+81** lines (new)
- Net: +17 lines (due to `export` keywords and a file-level doc comment)

## Verification

- `npx tsc --noEmit`: clean (exit 0)
- `npx eslint` on both files: 0 errors (10 pre-existing warnings in MissionBrowser for raw `<input>`/`<select>` usage in unchanged code)
- `npx vitest run src/components/missions/`: **39/39 tests pass**, including the 9 MissionBrowser tests

## Context

Partial progress on #8624 (Auto-QA flag on oversized source files). `MissionBrowser.tsx` is still 2070 lines and needs further decomposition; more extractions will follow in subsequent PRs. Keeping this PR small and safe by design.

## Test plan

- [x] TypeScript check passes
- [x] ESLint passes (no new errors)
- [x] All mission tests pass
- [ ] CI build + lint pass