### PR TITLE
refactor: extract AI card result types from CardFactoryModal.tsx (#8608) [part 2]

### DIFF
--- a/web/src/components/dashboard/CardFactoryModal.tsx
+++ b/web/src/components/dashboard/CardFactoryModal.tsx
@@ -21,6 +21,12 @@ import { useAIMode } from '../../hooks/useAIMode'
 import { StatusBadge } from '../ui/StatusBadge'
 import { wrapAbbreviations } from '../shared/TechnicalAcronym'
 import { T1_TEMPLATES, type T1Template } from './cardFactoryTemplates'
+import {
+  validateT1Result,
+  validateT2Result,
+  type AiCardT1Result,
+  type AiCardT2Result,
+  type AiMode } from './cardFactoryAiTypes'
 
 interface CardFactoryModalProps {
   isOpen: boolean
@@ -1366,43 +1372,6 @@ function TemplateDropdown<T extends { name: string }>({
 // ============================================================================
 // AI Create Tab
 // ============================================================================
-
-interface AiCardT1Result {
-  title: string
-  description: string
-  layout: 'list' | 'stats' | 'stats-and-list'
-  defaultWidth: number
-  defaultLimit: number
-  columns: DynamicCardColumn[]
-  searchFields: string[]
-  staticData: Record<string, unknown>[]
-}
-
-interface AiCardT2Result {
-  title: string
-  description: string
-  defaultWidth: number
-  sourceCode: string
-}
-
-type AiMode = 'tier1' | 'tier2'
-
-function validateT1Result(data: unknown): { valid: true; result: AiCardT1Result } | { valid: false; error: string } {
-  const obj = data as Record<string, unknown>
-  if (!obj.title || typeof obj.title !== 'string') return { valid: false, error: 'Missing or invalid "title"' }
-  if (!obj.columns || !Array.isArray(obj.columns)) return { valid: false, error: 'Missing or invalid "columns" array' }
-  if (!['list', 'stats', 'stats-and-list'].includes(obj.layout as string)) {
-    (obj as Record<string, unknown>).layout = 'list' // default
-  }
-  return { valid: true, result: obj as unknown as AiCardT1Result }
-}
-
-function validateT2Result(data: unknown): { valid: true; result: AiCardT2Result } | { valid: false; error: string } {
-  const obj = data as Record<string, unknown>
-  if (!obj.title || typeof obj.title !== 'string') return { valid: false, error: 'Missing or invalid "title"' }
-  if (!obj.sourceCode || typeof obj.sourceCode !== 'string') return { valid: false, error: 'Missing or invalid "sourceCode"' }
-  return { valid: true, result: obj as unknown as AiCardT2Result }
-}
 
 function T1Preview({ result }: { result: AiCardT1Result }) {
   return (

--- a/web/src/components/dashboard/cardFactoryAiTypes.ts
+++ b/web/src/components/dashboard/cardFactoryAiTypes.ts
@@ -1,0 +1,45 @@
+import type { DynamicCardColumn } from '../../lib/dynamic-cards/types'
+
+// ============================================================================
+// AI Card Generation Result Types
+// ============================================================================
+//
+// Types and validators for AI-generated card definitions returned by the
+// AiGenerationPanel. T1 = declarative (column-based), T2 = custom code.
+
+export interface AiCardT1Result {
+  title: string
+  description: string
+  layout: 'list' | 'stats' | 'stats-and-list'
+  defaultWidth: number
+  defaultLimit: number
+  columns: DynamicCardColumn[]
+  searchFields: string[]
+  staticData: Record<string, unknown>[]
+}
+
+export interface AiCardT2Result {
+  title: string
+  description: string
+  defaultWidth: number
+  sourceCode: string
+}
+
+export type AiMode = 'tier1' | 'tier2'
+
+export function validateT1Result(data: unknown): { valid: true; result: AiCardT1Result } | { valid: false; error: string } {
+  const obj = data as Record<string, unknown>
+  if (!obj.title || typeof obj.title !== 'string') return { valid: false, error: 'Missing or invalid "title"' }
+  if (!obj.columns || !Array.isArray(obj.columns)) return { valid: false, error: 'Missing or invalid "columns" array' }
+  if (!['list', 'stats', 'stats-and-list'].includes(obj.layout as string)) {
+    (obj as Record<string, unknown>).layout = 'list' // default
+  }
+  return { valid: true, result: obj as unknown as AiCardT1Result }
+}
+
+export function validateT2Result(data: unknown): { valid: true; result: AiCardT2Result } | { valid: false; error: string } {
+  const obj = data as Record<string, unknown>
+  if (!obj.title || typeof obj.title !== 'string') return { valid: false, error: 'Missing or invalid "title"' }
+  if (!obj.sourceCode || typeof obj.sourceCode !== 'string') return { valid: false, error: 'Missing or invalid "sourceCode"' }
+  return { valid: true, result: obj as unknown as AiCardT2Result }
+}


### PR DESCRIPTION
## Summary

Bounded extraction (part 2) from `web/src/components/dashboard/CardFactoryModal.tsx`. Pure code movement, zero behavior change.

**Extracted:** AI card result types and validators used by the AI Create tab.
- `AiCardT1Result`, `AiCardT2Result` interfaces
- `AiMode` type alias
- `validateT1Result`, `validateT2Result` functions

**Destination:** New file `web/src/components/dashboard/cardFactoryAiTypes.ts` (45 LOC). Sits alongside the existing `cardFactoryTemplates.ts` from #8834.

**LOC delta:**
- `CardFactoryModal.tsx`: 1587 -> 1556 lines (-31)
- `cardFactoryAiTypes.ts`: new, 45 lines
- Diff: 6 insertions, 37 deletions

All references to the moved symbols are local to `CardFactoryModal.tsx`; the new module is consumed via a single import.

## Verification

- `npx tsc --noEmit` -> clean
- `npx eslint` on touched files -> 12 problems, all pre-existing (verified by stashing changes and re-running). Zero new lint issues introduced.
- Vitest run on the 4 related test files -> 28 passed, 0 failed:
  - `CardFactoryModal.test.tsx`
  - `AddCardModal.test.tsx`
  - `__tests__/AddCardModal.test.tsx`
  - `customizer/sections/__tests__/CardCatalogSection.test.tsx`

## Notes

Partial progress on #8608; follow-up to PR #8834 (which extracted `T1_TEMPLATES`). Further extractions to come — `T2_TEMPLATES` (~750 LOC) is too large for a single bounded PR and will need its own strategy.

## Test plan

- [x] Typecheck passes
- [x] No new lint errors
- [x] Existing tests pass
- [ ] CI build/lint/preview pass