### PR TITLE
🌱 : add unit tests for namespace handlers

### DIFF
--- a/pkg/api/handlers/namespaces_test.go
+++ b/pkg/api/handlers/namespaces_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/kubestellar/console/pkg/models"
 	"github.com/kubestellar/console/pkg/test"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -25,7 +26,9 @@ func TestNamespaceHandlers(t *testing.T) {
 	env.App.Get("/api/namespaces/:name/access", h.GetNamespaceAccess)
 
 	// Seed some namespaces into the fake cluster
-	fakeClient, _ := env.K8sClient.GetClient("test-cluster")
+	fakeClient, err := env.K8sClient.GetClient("test-cluster")
+	require.NoError(t, err)
+	require.NotNil(t, fakeClient)
 	_, _ = fakeClient.CoreV1().Namespaces().Create(t.Context(), &corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{Name: "ns-1"},
 		Status:     corev1.NamespaceStatus{Phase: corev1.NamespaceActive},

--- a/pkg/api/handlers/namespaces_test.go
+++ b/pkg/api/handlers/namespaces_test.go
@@ -1,0 +1,124 @@
+package handlers
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gofiber/fiber/v2"
+	"github.com/google/uuid"
+	"github.com/kubestellar/console/pkg/models"
+	"github.com/kubestellar/console/pkg/test"
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestNamespaceHandlers(t *testing.T) {
+	env := setupTestEnv(t)
+	h := NewNamespaceHandler(env.Store, env.K8sClient)
+
+	// Register routes on the test app
+	env.App.Get("/api/namespaces", h.ListNamespaces)
+	env.App.Get("/api/namespaces/:name/access", h.GetNamespaceAccess)
+
+	// Seed some namespaces into the fake cluster
+	fakeClient, _ := env.K8sClient.GetClient("test-cluster")
+	_, _ = fakeClient.CoreV1().Namespaces().Create(t.Context(), &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{Name: "ns-1"},
+		Status:     corev1.NamespaceStatus{Phase: corev1.NamespaceActive},
+	}, metav1.CreateOptions{})
+
+	t.Run("ListNamespaces - Success", func(t *testing.T) {
+		req := httptest.NewRequest("GET", "/api/namespaces?cluster=test-cluster", nil)
+		resp, _ := env.App.Test(req)
+
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+		var result []models.NamespaceDetails
+		json.NewDecoder(resp.Body).Decode(&result)
+		assert.Len(t, result, 1)
+		assert.Equal(t, "ns-1", result[0].Name)
+	})
+
+	t.Run("ListNamespaces - Missing Cluster", func(t *testing.T) {
+		req := httptest.NewRequest("GET", "/api/namespaces", nil)
+		resp, _ := env.App.Test(req)
+
+		assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+	})
+
+	t.Run("ListNamespaces - Unauthorized", func(t *testing.T) {
+		unknownUserID := uuid.New()
+		// Mock store to return nil (user not found)
+		env.Store.(*test.MockStore).On("GetUser", unknownUserID).Return(nil, nil)
+
+		// Use a temporary app to inject a different user ID
+		app := fiber.New()
+		app.Get("/api/namespaces", func(c *fiber.Ctx) error {
+			c.Locals("userID", unknownUserID)
+			return h.ListNamespaces(c)
+		})
+
+		req := httptest.NewRequest("GET", "/api/namespaces?cluster=test-cluster", nil)
+		resp, _ := app.Test(req)
+
+		assert.Equal(t, http.StatusForbidden, resp.StatusCode)
+	})
+
+	t.Run("GetNamespaceAccess - Admin Success", func(t *testing.T) {
+		// Seed a RoleBinding
+		_, _ = fakeClient.RbacV1().RoleBindings("ns-1").Create(t.Context(), &rbacv1.RoleBinding{
+			ObjectMeta: metav1.ObjectMeta{Name: "rb-1", Namespace: "ns-1"},
+			RoleRef:    rbacv1.RoleRef{APIGroup: "rbac.authorization.k8s.io", Kind: "ClusterRole", Name: "admin"},
+			Subjects: []rbacv1.Subject{
+				{Kind: "User", Name: "admin-user", APIGroup: "rbac.authorization.k8s.io"},
+			},
+		}, metav1.CreateOptions{})
+
+		req := httptest.NewRequest("GET", "/api/namespaces/ns-1/access?cluster=test-cluster", nil)
+		resp, _ := env.App.Test(req)
+
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+		var result struct {
+			Namespace string                        `json:"namespace"`
+			Cluster   string                        `json:"cluster"`
+			Bindings  []models.NamespaceAccessEntry `json:"bindings"`
+		}
+		json.NewDecoder(resp.Body).Decode(&result)
+		assert.Equal(t, "ns-1", result.Namespace)
+		assert.Len(t, result.Bindings, 1)
+		assert.Equal(t, "rb-1", result.Bindings[0].BindingName)
+		assert.Equal(t, "User", result.Bindings[0].SubjectKind)
+		assert.Equal(t, "admin-user", result.Bindings[0].SubjectName)
+	})
+
+	t.Run("GetNamespaceAccess - Forbidden for Non-Admin", func(t *testing.T) {
+		viewerID := uuid.New()
+		env.Store.(*test.MockStore).On("GetUser", viewerID).Return(&models.User{
+			ID:   viewerID,
+			Role: models.UserRoleViewer,
+		}, nil)
+
+		app := fiber.New()
+		app.Get("/api/namespaces/:name/access", func(c *fiber.Ctx) error {
+			c.Locals("userID", viewerID)
+			return h.GetNamespaceAccess(c)
+		})
+
+		req := httptest.NewRequest("GET", "/api/namespaces/ns-1/access?cluster=test-cluster", nil)
+		resp, _ := app.Test(req)
+
+		assert.Equal(t, http.StatusForbidden, resp.StatusCode)
+	})
+
+	t.Run("GetNamespaceAccess - Missing Parameters", func(t *testing.T) {
+		req := httptest.NewRequest("GET", "/api/namespaces/ns-1/access", nil)
+		resp, _ := env.App.Test(req)
+
+		assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+	})
+}


### PR DESCRIPTION
### 📌 Fixes

Part of the unit test coverage audit.

---

### 📝 Summary of Changes

- Implemented comprehensive unit tests for `NamespaceHandler` in `pkg/api/handlers/namespaces.go`.
- Added test cases for `ListNamespaces` and `GetNamespaceAccess` covering success, authorization, and error paths.
- Verified RBAC enforcement for non-admin users attempting to access namespace access details.

---

### Changes Made

- [x] Added `pkg/api/handlers/namespaces_test.go`
- [x] Implemented `TestNamespaceHandlers` with sub-tests for both `ListNamespaces` and `GetNamespaceAccess` handlers.
- [x] Verified `requireViewerOrAbove` security gate for namespace listing.
- [x] Verified `models.UserRoleAdmin` enforcement for access enumeration.

---

### Checklist

Please ensure the following before submitting your PR:

- [x] I used a coding agent (Claude Code, Copilot, Gemini, or Codex) to generate/review this code
- [x] I have reviewed the project's contribution guidelines
- [ ] New cards target [console-marketplace](https://github.com/kubestellar/console-marketplace), not this repo
- [ ] isDemoData is wired correctly (cards show Demo badge when using demo data)
- [x] I have written unit tests for the changes (if applicable)
- [x] I have tested the changes locally and ensured they work as expected
- [x] All commits are signed with DCO (`git commit -s`)

---

### Screenshots or Logs (if applicable)

```bash
=== RUN   TestNamespaceHandlers
=== RUN   TestNamespaceHandlers/ListNamespaces_-_Success
=== RUN   TestNamespaceHandlers/ListNamespaces_-_Missing_Cluster
=== RUN   TestNamespaceHandlers/ListNamespaces_-_Unauthorized
=== RUN   TestNamespaceHandlers/GetNamespaceAccess_-_Admin_Success
=== RUN   TestNamespaceHandlers/GetNamespaceAccess_-_Forbidden_for_Non-Admin
2026/04/18 19:54:20 WARN [rbac] SECURITY: non-admin attempted to read namespace access user_id=840d65d0-361f-425f-8421-a84da404cddb github_login=""
=== RUN   TestNamespaceHandlers/GetNamespaceAccess_-_Missing_Parameters
--- PASS: TestNamespaceHandlers (0.00s)
    --- PASS: TestNamespaceHandlers/ListNamespaces_-_Success (0.00s)
    --- PASS: TestNamespaceHandlers/ListNamespaces_-_Missing_Cluster (0.00s)
    --- PASS: TestNamespaceHandlers/ListNamespaces_-_Unauthorized (0.00s)
    --- PASS: TestNamespaceHandlers/GetNamespaceAccess_-_Admin_Success (0.00s)
    --- PASS: TestNamespaceHandlers/GetNamespaceAccess_-_Forbidden_for_Non-Admin (0.00s)
    --- PASS: TestNamespaceHandlers/GetNamespaceAccess_-_Missing_Parameters (0.00s)
PASS
ok      github.com/kubestellar/console/pkg/api/handlers 0.017s
```

---

### 👀 Reviewer Notes

These tests close a significant gap in our API handler coverage identified during the recent audit. They follow the project's established testing patterns using a mock store and fake Kubernetes clients.
