### PR TITLE
fix: use bounded fresh context for SQLite ROLLBACK (#8854)

### DIFF
--- a/pkg/store/sqlite.go
+++ b/pkg/store/sqlite.go
@@ -2500,7 +2500,7 @@ func (s *SQLiteStore) IncrementUserCoins(ctx context.Context, userID string, del
 	committed := false
 	defer func() {
 		if !committed {
-			_, _ = conn.ExecContext(ctx, "ROLLBACK")
+			rollbackConn(conn)
 		}
 	}()
 
@@ -2593,7 +2593,7 @@ func (s *SQLiteStore) ClaimDailyBonus(ctx context.Context, userID string, bonusA
 	committed := false
 	defer func() {
 		if !committed {
-			_, _ = conn.ExecContext(ctx, "ROLLBACK")
+			rollbackConn(conn)
 		}
 	}()
 
@@ -2796,7 +2796,7 @@ func (s *SQLiteStore) AddUserTokenDelta(ctx context.Context, userID string, cate
 	committed := false
 	defer func() {
 		if !committed {
-			_, _ = conn.ExecContext(ctx, "ROLLBACK")
+			rollbackConn(conn)
 		}
 	}()
 
@@ -2907,7 +2907,7 @@ func (s *SQLiteStore) ConsumeOAuthState(ctx context.Context, state string) (bool
 	committed := false
 	defer func() {
 		if !committed {
-			_, _ = conn.ExecContext(ctx, "ROLLBACK")
+			rollbackConn(conn)
 		}
 	}()
 
@@ -3063,4 +3063,21 @@ func (s *SQLiteStore) QueryAuditLogs(ctx context.Context, limit int, userID, act
 		entries = append(entries, e)
 	}
 	return entries, rows.Err()
+}
+
+// rollbackTimeout bounds the time a best-effort ROLLBACK is allowed to run on
+// a pinned connection. Must be long enough for SQLite to release its write
+// lock but short enough to avoid holding the pool when the pool is itself
+// shutting down.
+const rollbackTimeout = 5 * time.Second
+
+// rollbackConn executes ROLLBACK against a pinned connection using a fresh
+// bounded context. Use this from defers in BEGIN IMMEDIATE flows instead of
+// ExecContext(ctx, "ROLLBACK"): if the caller's ctx is already cancelled
+// (client disconnect, request timeout), a rollback on that ctx fails
+// immediately and leaves the transaction zombified on the connection (#8854).
+func rollbackConn(conn *sql.Conn) {
+	ctx, cancel := context.WithTimeout(context.Background(), rollbackTimeout)
+	defer cancel()
+	_, _ = conn.ExecContext(ctx, "ROLLBACK")
 }


### PR DESCRIPTION
## Summary

**Fixes #8854** — In BEGIN IMMEDIATE flows (`AddUserTokenDelta`, `IncrementUserCoins`, `ClaimDailyBonus`, oauth-state redeem), the defer used `conn.ExecContext(ctx, \"ROLLBACK\")` with the same context passed to the method. If the client disconnects or the request times out, that ctx is already cancelled; the subsequent ROLLBACK fails immediately, leaving the transaction zombified on the pinned connection.

### Fix

Adds a `rollbackConn(conn)` helper that uses `context.Background()` bounded by a 5-second `rollbackTimeout`, and applies it at all four rollback sites in `pkg/store/sqlite.go`:

```go
func rollbackConn(conn *sql.Conn) {
    ctx, cancel := context.WithTimeout(context.Background(), rollbackTimeout)
    defer cancel()
    _, _ = conn.ExecContext(ctx, "ROLLBACK")
}
```

### Scope

21 additions, 4 deletions across a single file. Zero behavior change on the happy path (committed flows). On the cancelled-ctx path, rollback now runs to completion instead of failing.

Credit @Pranjal6955 for the audit find.

## Test plan
- [x] `go build ./pkg/store/...` — clean
- [x] `go vet ./pkg/store/...` — clean
- [x] `go test ./pkg/store/...` — passes (TestSQLite, TestUser, TestClaim, TestAddUserToken, TestOAuthState)
- [x] All 4 sites call sites verified via `grep -c "rollbackConn(conn)"` = 4

Fixes #8854