### PR TITLE
fix: show card count for Multi-Tenancy dashboard in sidebar (#8842)

### DIFF
--- a/web/src/components/layout/Sidebar.tsx
+++ b/web/src/components/layout/Sidebar.tsx
@@ -46,7 +46,8 @@ const HREF_TO_DASHBOARD_ID: Record<string, string> = {
   '/logs': 'logs', '/data-compliance': 'data-compliance', '/arcade': 'arcade',
   '/deploy': 'deploy', '/ai-agents': 'ai-agents',
   '/llm-d-benchmarks': 'llm-d-benchmarks', '/cluster-admin': 'cluster-admin',
-  '/insights': 'insights', '/drasi': 'drasi' }
+  '/insights': 'insights', '/drasi': 'drasi',
+  '/multi-tenancy': 'multi-tenancy' }
 
 /** Prefix for custom dashboard routes */
 const CUSTOM_DASHBOARD_PREFIX = '/custom-dashboard/'


### PR DESCRIPTION
## Summary

**Fixes #8842** — Every dashboard except Multi-Tenancy showed a card count beside its sidebar entry. The cause is a single missing entry in the `HREF_TO_DASHBOARD_ID` map in `web/src/components/layout/Sidebar.tsx`.

The sidebar renders the count via:
```ts
const dashId = HREF_TO_DASHBOARD_ID[item.href]
const count = dashId ? DASHBOARD_CONFIGS[dashId]?.cards?.length : null
```

With no key for `/multi-tenancy`, `dashId` was undefined, so `count` was null and the count span rendered nothing.

## Fix

One-line addition to the map:
```ts
'/multi-tenancy': 'multi-tenancy'
```

Confirmed dashboard config id in `web/src/config/dashboards/multi-tenancy.ts` is `'multi-tenancy'` — matches `DASHBOARD_CONFIGS` keying.

## Test plan
- [x] `npx eslint web/src/components/layout/Sidebar.tsx` — clean (1 pre-existing `no-restricted-syntax` warning on unchanged `<input>` line 373)
- [ ] Manual verify: Multi-Tenancy sidebar entry shows card count matching `DASHBOARD_CONFIGS['multi-tenancy'].cards.length`

Fixes #8842