### PR TITLE
🌱 :add unit tests for gpu utilization worker and metric accuracy

### DIFF
--- a/pkg/api/gpu_utilization_worker_test.go
+++ b/pkg/api/gpu_utilization_worker_test.go
@@ -1,0 +1,205 @@
+package api
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/kubestellar/console/pkg/k8s"
+	"github.com/kubestellar/console/pkg/models"
+	"github.com/kubestellar/console/pkg/test"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8sfake "k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/tools/clientcmd/api"
+)
+
+func TestGPUUtilizationWorker_MetricAccuracy(t *testing.T) {
+	mockStore := new(test.MockStore)
+	k8sClient, _ := k8s.NewMultiClusterClient("")
+	fakeClient := k8sfake.NewSimpleClientset()
+	k8sClient.InjectClient("test-cluster", fakeClient)
+	k8sClient.SetRawConfig(&api.Config{
+		Clusters: map[string]*api.Cluster{
+			"test-cluster": {Server: "https://test-cluster:6443"},
+		},
+		Contexts: map[string]*api.Context{
+			"test-cluster": {Cluster: "test-cluster"},
+		},
+	})
+
+	worker := NewGPUUtilizationWorker(mockStore, k8sClient)
+
+	t.Run("collectForReservation - Accurate GPU calculation", func(t *testing.T) {
+		reservation := &models.GPUReservation{
+			ID:        uuid.New(),
+			Cluster:   "test-cluster",
+			Namespace: "test-ns",
+			GPUCount:  4,
+		}
+
+		// Mock pods in the fake k8s client
+		// Pod 1: Running, 2 GPUs (nvidia)
+		pod1 := &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{Name: "pod-1", Namespace: "test-ns"},
+			Status:     corev1.PodStatus{Phase: corev1.PodRunning},
+			Spec: corev1.PodSpec{
+				Containers: []corev1.Container{
+					{
+						Resources: corev1.ResourceRequirements{
+							Requests: corev1.ResourceList{
+								"nvidia.com/gpu": resource.MustParse("2"),
+							},
+						},
+					},
+				},
+			},
+		}
+		// Pod 2: Running, 1 GPU (amd)
+		pod2 := &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{Name: "pod-2", Namespace: "test-ns"},
+			Status:     corev1.PodStatus{Phase: corev1.PodRunning},
+			Spec: corev1.PodSpec{
+				Containers: []corev1.Container{
+					{
+						Resources: corev1.ResourceRequirements{
+							Requests: corev1.ResourceList{
+								"amd.com/gpu": resource.MustParse("1"),
+							},
+						},
+					},
+				},
+			},
+		}
+		// Pod 3: Pending, 1 GPU (should be ignored)
+		pod3 := &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{Name: "pod-3", Namespace: "test-ns"},
+			Status:     corev1.PodStatus{Phase: corev1.PodPending},
+			Spec: corev1.PodSpec{
+				Containers: []corev1.Container{
+					{
+						Resources: corev1.ResourceRequirements{
+							Requests: corev1.ResourceList{
+								"nvidia.com/gpu": resource.MustParse("1"),
+							},
+						},
+					},
+				},
+			},
+		}
+		// Pod 4: Running, 0 GPUs (system pod, should be ignored)
+		pod4 := &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{Name: "pod-4", Namespace: "test-ns"},
+			Status:     corev1.PodStatus{Phase: corev1.PodRunning},
+			Spec: corev1.PodSpec{
+				Containers: []corev1.Container{{Name: "system"}},
+			},
+		}
+
+		_, _ = fakeClient.CoreV1().Pods("test-ns").Create(context.Background(), pod1, metav1.CreateOptions{})
+		_, _ = fakeClient.CoreV1().Pods("test-ns").Create(context.Background(), pod2, metav1.CreateOptions{})
+		_, _ = fakeClient.CoreV1().Pods("test-ns").Create(context.Background(), pod3, metav1.CreateOptions{})
+		_, _ = fakeClient.CoreV1().Pods("test-ns").Create(context.Background(), pod4, metav1.CreateOptions{})
+
+		// Expected call to InsertUtilizationSnapshot
+		mockStore.On("InsertUtilizationSnapshot", mock.MatchedBy(func(s *models.GPUUtilizationSnapshot) bool {
+			// pod1 (2) + pod2 (1) = 3 active GPUs
+			// totalGPUs = reservation.GPUCount = 4
+			// Utilization = (3/4) * 100 = 75%
+			return s.ActiveGPUCount == 3 && s.TotalGPUCount == 4 && s.GPUUtilizationPct == 75.0
+		})).Return(nil).Once()
+
+		worker.collectForReservation(context.Background(), reservation)
+		mockStore.AssertExpectations(t)
+	})
+
+	t.Run("collectForReservation - Cap exceeded", func(t *testing.T) {
+		reservation := &models.GPUReservation{
+			ID:        uuid.New(),
+			Cluster:   "test-cluster",
+			Namespace: "cap-ns",
+			GPUCount:  2,
+		}
+
+		// Pod asking for 4 GPUs (exceeds reservation of 2)
+		pod := &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{Name: "pod-big", Namespace: "cap-ns"},
+			Status:     corev1.PodStatus{Phase: corev1.PodRunning},
+			Spec: corev1.PodSpec{
+				Containers: []corev1.Container{
+					{
+						Resources: corev1.ResourceRequirements{
+							Requests: corev1.ResourceList{
+								"nvidia.com/gpu": resource.MustParse("4"),
+							},
+						},
+					},
+				},
+			},
+		}
+		_, _ = fakeClient.CoreV1().Pods("cap-ns").Create(context.Background(), pod, metav1.CreateOptions{})
+
+		mockStore.On("InsertUtilizationSnapshot", mock.MatchedBy(func(s *models.GPUUtilizationSnapshot) bool {
+			// Should cap at reservation total (2)
+			return s.ActiveGPUCount == 2 && s.GPUUtilizationPct == 100.0
+		})).Return(nil).Once()
+
+		worker.collectForReservation(context.Background(), reservation)
+		mockStore.AssertExpectations(t)
+	})
+
+	t.Run("collectForReservation - Zero total GPUs", func(t *testing.T) {
+		reservation := &models.GPUReservation{
+			ID:        uuid.New(),
+			Cluster:   "test-cluster",
+			Namespace: "zero-ns",
+			GPUCount:  0,
+		}
+
+		mockStore.On("InsertUtilizationSnapshot", mock.MatchedBy(func(s *models.GPUUtilizationSnapshot) bool {
+			return s.TotalGPUCount == 0 && s.ActiveGPUCount == 0 && s.GPUUtilizationPct == 0
+		})).Return(nil).Once()
+
+		worker.collectForReservation(context.Background(), reservation)
+		mockStore.AssertExpectations(t)
+	})
+}
+
+func TestGPUUtilizationWorker_Cleanup(t *testing.T) {
+	mockStore := new(test.MockStore)
+	worker := NewGPUUtilizationWorker(mockStore, nil)
+
+	t.Run("cleanupOldSnapshots calls store", func(t *testing.T) {
+		mockStore.On("DeleteOldUtilizationSnapshots", mock.Anything).Return(int64(5), nil).Once()
+		worker.cleanupOldSnapshots()
+		mockStore.AssertExpectations(t)
+	})
+}
+
+func TestGPUUtilizationWorker_IntervalFromEnv(t *testing.T) {
+	os.Setenv("GPU_UTIL_POLL_INTERVAL_MS", "5000")
+	defer os.Unsetenv("GPU_UTIL_POLL_INTERVAL_MS")
+
+	worker := NewGPUUtilizationWorker(nil, nil)
+	assert.Equal(t, 5*time.Second, worker.interval)
+}
+
+func TestGPUUtilizationWorker_StopCancel(t *testing.T) {
+	worker := NewGPUUtilizationWorker(nil, nil)
+
+	ctx := worker.baseCtx
+	worker.Stop()
+
+	// baseCtx should be cancelled
+	select {
+	case <-ctx.Done():
+		// ok
+	default:
+		t.Fatal("worker context not cancelled on stop (#6966)")
+	}
+}

--- a/pkg/test/mock_store.go
+++ b/pkg/test/mock_store.go
@@ -59,7 +59,7 @@ func (m *MockStore) GetOnboardingResponses(userID uuid.UUID) ([]models.Onboardin
 }
 func (m *MockStore) SetUserOnboarded(userID uuid.UUID) error { return nil }
 
-func (m *MockStore) GetDashboard(id uuid.UUID) (*models.Dashboard, error)            { return nil, nil }
+func (m *MockStore) GetDashboard(id uuid.UUID) (*models.Dashboard, error) { return nil, nil }
 func (m *MockStore) GetUserDashboards(userID uuid.UUID, limit, offset int) ([]models.Dashboard, error) {
 	return nil, nil
 }
@@ -147,7 +147,7 @@ func (m *MockStore) CreateNotification(notification *models.Notification) error 
 func (m *MockStore) GetUserNotifications(userID uuid.UUID, limit int) ([]models.Notification, error) {
 	return nil, nil
 }
-func (m *MockStore) GetUnreadNotificationCount(userID uuid.UUID) (int, error) { return 0, nil }
+func (m *MockStore) GetUnreadNotificationCount(userID uuid.UUID) (int, error)        { return 0, nil }
 func (m *MockStore) MarkNotificationReadByUser(id uuid.UUID, userID uuid.UUID) error { return nil }
 func (m *MockStore) MarkAllNotificationsRead(userID uuid.UUID) error                 { return nil }
 
@@ -173,7 +173,8 @@ func (m *MockStore) GetClusterReservedGPUCount(cluster string, excludeID *uuid.U
 }
 
 func (m *MockStore) InsertUtilizationSnapshot(snapshot *models.GPUUtilizationSnapshot) error {
-	return nil
+	args := m.Called(snapshot)
+	return args.Error(0)
 }
 func (m *MockStore) GetUtilizationSnapshots(reservationID string, limit int) ([]models.GPUUtilizationSnapshot, error) {
 	return nil, nil
@@ -181,8 +182,17 @@ func (m *MockStore) GetUtilizationSnapshots(reservationID string, limit int) ([]
 func (m *MockStore) GetBulkUtilizationSnapshots(reservationIDs []string) (map[string][]models.GPUUtilizationSnapshot, error) {
 	return nil, nil
 }
-func (m *MockStore) DeleteOldUtilizationSnapshots(before time.Time) (int64, error) { return 0, nil }
-func (m *MockStore) ListActiveGPUReservations() ([]models.GPUReservation, error)   { return nil, nil }
+func (m *MockStore) DeleteOldUtilizationSnapshots(before time.Time) (int64, error) {
+	args := m.Called(before)
+	return args.Get(0).(int64), args.Error(1)
+}
+func (m *MockStore) ListActiveGPUReservations() ([]models.GPUReservation, error) {
+	args := m.Called()
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).([]models.GPUReservation), args.Error(1)
+}
 
 func (m *MockStore) RevokeToken(jti string, expiresAt time.Time) error { return nil }
 func (m *MockStore) IsTokenRevoked(jti string) (bool, error)           { return false, nil }


### PR DESCRIPTION
### 📌 Fixes

Part of the backend test coverage and metric reliability audit.

---

### 📝 Summary of Changes

- Implemented unit tests for `GPUUtilizationWorker` in `pkg/api/gpu_utilization_worker.go`.
- Verified the accuracy of GPU utilization metrics by simulating various pod states and resource requests.
- Updated `MockStore` to support dynamic mocking of GPU reservation and snapshot operations.
- Validated lifecycle management ensuring contexts are cancelled when the worker stops.

---

### Changes Made

- [x] Added `pkg/api/gpu_utilization_worker_test.go`
- [x] Updated `pkg/test/mock_store.go` to use `mock.Called()` for GPU methods.
- [x] Implemented pod counting validation logic (ignoring `Pending` pods, summing `nvidia` and `amd` GPUs).
- [x] Implemented capping logic test to ensure utilization doesn't exceed 100% even if clusters are over-subscribed.
- [x] Implemented retention cleanup validation.

---

### Checklist

Please ensure the following before submitting your PR:

- [x] I used a coding agent (Claude Code, Copilot, Gemini, or Codex) to generate/review this code
- [x] I have reviewed the project's contribution guidelines
- [ ] New cards target [console-marketplace](https://github.com/kubestellar/console-marketplace), not this repo
- [ ] isDemoData is wired correctly (cards show Demo badge when using demo data)
- [x] I have written unit tests for the changes (if applicable)
- [x] I have tested the changes locally and ensured they work as expected
- [x] All commits are signed with DCO (`git commit -s`)

---

### Screenshots or Logs (if applicable)

```bash
=== RUN   TestGPUUtilizationWorker_MetricAccuracy
    --- PASS: TestGPUUtilizationWorker_MetricAccuracy/collectForReservation_-_Accurate_GPU_calculation (0.00s)
    --- PASS: TestGPUUtilizationWorker_MetricAccuracy/collectForReservation_-_Cap_exceeded (0.00s)
    --- PASS: TestGPUUtilizationWorker_MetricAccuracy/collectForReservation_-_Zero_total_GPUs (0.00s)
--- PASS: TestGPUUtilizationWorker_MetricAccuracy (0.00s)
=== RUN   TestGPUUtilizationWorker_Cleanup
    --- PASS: TestGPUUtilizationWorker_Cleanup/cleanupOldSnapshots_calls_store (0.00s)
--- PASS: TestGPUUtilizationWorker_Cleanup (0.00s)
=== RUN   TestGPUUtilizationWorker_IntervalFromEnv
--- PASS: TestGPUUtilizationWorker_IntervalFromEnv (0.00s)
=== RUN   TestGPUUtilizationWorker_StopCancel
--- PASS: TestGPUUtilizationWorker_StopCancel (0.00s)
PASS
ok      github.com/kubestellar/console/pkg/api  0.015s
```

---

### 👀 Reviewer Notes

The `GPUUtilizationWorker` relies on pod presence as a proxy for utilization when a full metrics-server is unavailable. These tests ensure that the proxy calculation is accurate and properly filters out non-GPU pods and non-running pods, preventing inflated utilization metrics.
