### PR TITLE
refactor: extract preview components from CardFactoryModal.tsx (#8608) [part 3]

### DIFF
--- a/web/src/components/dashboard/CardFactoryModal.tsx
+++ b/web/src/components/dashboard/CardFactoryModal.tsx
@@ -2,7 +2,7 @@ import { useState, useEffect, useRef, useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
 import {
   X, Plus, Code, Layers, Wand2, Eye, Save, Sparkles,
-  AlertTriangle, CheckCircle, Loader2, Trash2, LayoutTemplate } from 'lucide-react'
+  AlertTriangle, CheckCircle, Loader2, Trash2 } from 'lucide-react'
 import { BaseModal, ConfirmDialog } from '../../lib/modals'
 import { cn } from '../../lib/cn'
 import { saveDynamicCard, deleteDynamicCard, getAllDynamicCards } from '../../lib/dynamic-cards'
@@ -18,9 +18,9 @@ import { InlineAIAssist } from './InlineAIAssist'
 import { CARD_T1_SYSTEM_PROMPT, CARD_T2_SYSTEM_PROMPT, CARD_INLINE_ASSIST_PROMPT, CODE_INLINE_ASSIST_PROMPT } from '../../lib/ai/prompts'
 import { generateSampleData, detectFieldFormat } from '../../lib/ai/sampleData'
 import { useAIMode } from '../../hooks/useAIMode'
-import { StatusBadge } from '../ui/StatusBadge'
 import { wrapAbbreviations } from '../shared/TechnicalAcronym'
 import { T1_TEMPLATES, type T1Template } from './cardFactoryTemplates'
+import { TemplateDropdown, T1Preview, T2Preview } from './cardFactoryPreviews'
 import {
   validateT1Result,
   validateT2Result,
@@ -1330,116 +1330,8 @@ export function CardFactoryModal({ isOpen, onClose, onCardCreated, embedded = fa
 }
 
 // ============================================================================
-// Template Dropdown (generic)
-// ============================================================================
-
-function TemplateDropdown<T extends { name: string }>({
-  templates,
-  onSelect,
-  label }: {
-  templates: T[]
-  onSelect: (tpl: T) => void
-  label: string
-}) {
-  const [open, setOpen] = useState(false)
-
-  return (
-    <div className="relative">
-      <button
-        onClick={() => setOpen(!open)}
-        className="flex items-center gap-1.5 text-xs px-2.5 py-1.5 rounded-lg bg-secondary text-muted-foreground hover:text-foreground transition-colors"
-      >
-        <LayoutTemplate className="w-3 h-3" />
-        {label}
-      </button>
-      {open && (
-        <div className="absolute z-dropdown top-full mt-1 left-0 bg-card border border-border rounded-lg shadow-lg p-1.5 min-w-[200px]">
-          {templates.map(tpl => (
-            <button
-              key={tpl.name}
-              onClick={() => { onSelect(tpl); setOpen(false) }}
-              className="w-full text-left px-3 py-1.5 rounded-lg text-xs text-foreground hover:bg-secondary transition-colors"
-            >
-              {tpl.name}
-            </button>
-          ))}
-        </div>
-      )}
-    </div>
-  )
-}
-
-// ============================================================================
 // AI Create Tab
 // ============================================================================
-
-function T1Preview({ result }: { result: AiCardT1Result }) {
-  return (
-    <div>
-      <div className="flex items-center gap-2 mb-3">
-        <Layers className="w-4 h-4 text-purple-400" />
-        <span className="text-sm font-medium text-foreground">{result.title}</span>
-        <StatusBadge color="blue" size="xs">
-          {result.layout}
-        </StatusBadge>
-      </div>
-      {result.description && (
-        <p className="text-xs text-muted-foreground mb-3">{wrapAbbreviations(result.description)}</p>
-      )}
-      {result.columns && result.columns.length > 0 && (
-        <div className="text-xs">
-          <div className="flex gap-2 border-b border-border pb-1 mb-1">
-            {result.columns.map(col => (
-              <span key={col.field} className="flex-1 text-muted-foreground font-medium truncate">
-                {wrapAbbreviations(col.label)}
-              </span>
-            ))}
-          </div>
-          {(result.staticData || []).slice(0, 3).map((row, i) => (
-            <div key={i} className="flex gap-2 py-0.5">
-              {result.columns.map(col => {
-                const val = String(row[col.field] ?? '')
-                if (col.format === 'badge' && col.badgeColors) {
-                  const badgeClass = col.badgeColors[val] || 'bg-gray-500/20 text-muted-foreground dark:bg-gray-900/30 dark:text-muted-foreground'
-                  return (
-                    <span key={col.field} className={cn('flex-1 truncate text-xs px-1 py-0.5 rounded', badgeClass)}>
-                      {val}
-                    </span>
-                  )
-                }
-                return (
-                  <span key={col.field} className="flex-1 text-foreground truncate">
-                    {val}
-                  </span>
-                )
-              })}
-            </div>
-          ))}
-        </div>
-      )}
-    </div>
-  )
-}
-
-function T2Preview({ result }: { result: AiCardT2Result }) {
-  return (
-    <div>
-      <div className="flex items-center gap-2 mb-3">
-        <Code className="w-4 h-4 text-purple-400" />
-        <span className="text-sm font-medium text-foreground">{result.title}</span>
-        <StatusBadge color="purple" size="xs">
-          Custom Code
-        </StatusBadge>
-      </div>
-      {result.description && (
-        <p className="text-xs text-muted-foreground mb-2">{wrapAbbreviations(result.description)}</p>
-      )}
-      <pre className="text-xs px-3 py-2 rounded-lg bg-secondary text-foreground font-mono max-h-48 overflow-y-auto whitespace-pre-wrap">
-        {result.sourceCode}
-      </pre>
-    </div>
-  )
-}
 
 function AiCardTab({ onCardCreated }: { onCardCreated: (id: string) => void }) {
   const [aiMode, setAiMode] = useState<AiMode>('tier1')

--- a/web/src/components/dashboard/cardFactoryPreviews.tsx
+++ b/web/src/components/dashboard/cardFactoryPreviews.tsx
@@ -1,0 +1,120 @@
+import { useState } from 'react'
+import { Code, Layers, LayoutTemplate } from 'lucide-react'
+import { cn } from '../../lib/cn'
+import { StatusBadge } from '../ui/StatusBadge'
+import { wrapAbbreviations } from '../shared/TechnicalAcronym'
+import type { AiCardT1Result, AiCardT2Result } from './cardFactoryAiTypes'
+
+// ============================================================================
+// Template Dropdown (generic) + AI result previews
+// ============================================================================
+//
+// Presentational helpers used by CardFactoryModal:
+//  - TemplateDropdown: generic template picker rendered in the Declarative and
+//    Code tabs.
+//  - T1Preview / T2Preview: render the AI generation result in the AI tab's
+//    preview pane.
+
+export function TemplateDropdown<T extends { name: string }>({
+  templates,
+  onSelect,
+  label }: {
+  templates: T[]
+  onSelect: (tpl: T) => void
+  label: string
+}) {
+  const [open, setOpen] = useState(false)
+
+  return (
+    <div className="relative">
+      <button
+        onClick={() => setOpen(!open)}
+        className="flex items-center gap-1.5 text-xs px-2.5 py-1.5 rounded-lg bg-secondary text-muted-foreground hover:text-foreground transition-colors"
+      >
+        <LayoutTemplate className="w-3 h-3" />
+        {label}
+      </button>
+      {open && (
+        <div className="absolute z-dropdown top-full mt-1 left-0 bg-card border border-border rounded-lg shadow-lg p-1.5 min-w-[200px]">
+          {templates.map(tpl => (
+            <button
+              key={tpl.name}
+              onClick={() => { onSelect(tpl); setOpen(false) }}
+              className="w-full text-left px-3 py-1.5 rounded-lg text-xs text-foreground hover:bg-secondary transition-colors"
+            >
+              {tpl.name}
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}
+
+export function T1Preview({ result }: { result: AiCardT1Result }) {
+  return (
+    <div>
+      <div className="flex items-center gap-2 mb-3">
+        <Layers className="w-4 h-4 text-purple-400" />
+        <span className="text-sm font-medium text-foreground">{result.title}</span>
+        <StatusBadge color="blue" size="xs">
+          {result.layout}
+        </StatusBadge>
+      </div>
+      {result.description && (
+        <p className="text-xs text-muted-foreground mb-3">{wrapAbbreviations(result.description)}</p>
+      )}
+      {result.columns && result.columns.length > 0 && (
+        <div className="text-xs">
+          <div className="flex gap-2 border-b border-border pb-1 mb-1">
+            {result.columns.map(col => (
+              <span key={col.field} className="flex-1 text-muted-foreground font-medium truncate">
+                {wrapAbbreviations(col.label)}
+              </span>
+            ))}
+          </div>
+          {(result.staticData || []).slice(0, 3).map((row, i) => (
+            <div key={i} className="flex gap-2 py-0.5">
+              {result.columns.map(col => {
+                const val = String(row[col.field] ?? '')
+                if (col.format === 'badge' && col.badgeColors) {
+                  const badgeClass = col.badgeColors[val] || 'bg-gray-500/20 text-muted-foreground dark:bg-gray-900/30 dark:text-muted-foreground'
+                  return (
+                    <span key={col.field} className={cn('flex-1 truncate text-xs px-1 py-0.5 rounded', badgeClass)}>
+                      {val}
+                    </span>
+                  )
+                }
+                return (
+                  <span key={col.field} className="flex-1 text-foreground truncate">
+                    {val}
+                  </span>
+                )
+              })}
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}
+
+export function T2Preview({ result }: { result: AiCardT2Result }) {
+  return (
+    <div>
+      <div className="flex items-center gap-2 mb-3">
+        <Code className="w-4 h-4 text-purple-400" />
+        <span className="text-sm font-medium text-foreground">{result.title}</span>
+        <StatusBadge color="purple" size="xs">
+          Custom Code
+        </StatusBadge>
+      </div>
+      {result.description && (
+        <p className="text-xs text-muted-foreground mb-2">{wrapAbbreviations(result.description)}</p>
+      )}
+      <pre className="text-xs px-3 py-2 rounded-lg bg-secondary text-foreground font-mono max-h-48 overflow-y-auto whitespace-pre-wrap">
+        {result.sourceCode}
+      </pre>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary

Third bounded extraction from `web/src/components/dashboard/CardFactoryModal.tsx`, continuing the #8608 refactor after #8834 (T1 templates) and #8838 (AI result types).

Moves three presentational helpers into a new sibling file:

- `TemplateDropdown<T>` — generic template picker used in the Declarative and Code tabs.
- `T1Preview` — renders declarative (tier-1) AI generation results.
- `T2Preview` — renders custom-code (tier-2) AI generation results.

All three are self-contained, used only by `CardFactoryModal`, and have no callers outside this file. Imports in `CardFactoryModal.tsx` are trimmed accordingly (`LayoutTemplate`, `StatusBadge` no longer needed there).

### Stats
- `CardFactoryModal.tsx`: **1556 -> 1448 lines** (-108)
- New `cardFactoryPreviews.tsx`: **120 lines**
- Zero behavior change. Pure code movement.

## Verification
- `npx tsc --noEmit` — clean
- `npx eslint` on touched files — no new errors or warnings (pre-existing counts unchanged)
- `npx vitest run` on the 4 CardFactoryModal/AddCardModal/CardCatalogSection test files — **28/28 passing**

Partial progress on #8608; follow-up to #8834, #8838.

## Test plan
- [x] Typecheck clean
- [x] Lint clean (no new findings)
- [x] Unit tests pass (28/28)
- [ ] CI build/lint green
- [ ] Manual smoke: open Card Factory modal, verify template dropdowns and AI preview still render