### PR TITLE
fix: surface 401 as expired-token error on feedback submit

### DIFF
--- a/pkg/api/handlers/feedback.go
+++ b/pkg/api/handlers/feedback.go
@@ -8,6 +8,7 @@ import (
 	"encoding/base64"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -32,6 +33,13 @@ import (
 
 // githubAPITimeout is the timeout for HTTP requests to the GitHub API.
 const githubAPITimeout = 10 * time.Second
+
+// errGitHubUnauthorized is returned when GitHub rejects the FEEDBACK_GITHUB_TOKEN
+// as invalid or expired (HTTP 401). Callers should branch on this with errors.Is
+// and surface a user-visible "refresh your PAT" message instead of the generic
+// 502 Bad Gateway wrapper, which sends contributors on wild goose chases looking
+// for OAuth app setup issues (#6186).
+var errGitHubUnauthorized = errors.New("github: token invalid or expired")
 
 // githubAPIBase is the default public GitHub API base URL.
 // Used as the fallback by resolveGitHubAPIBase() when GITHUB_URL is unset.
@@ -286,6 +294,13 @@ func (h *FeedbackHandler) CreateFeatureRequest(c *fiber.Ctx) error {
 		if cErr := h.store.CloseFeatureRequest(request.ID, false); cErr != nil {
 			slog.Warn("[Feedback] failed to close orphaned feature request",
 				"request_id", request.ID, "error", cErr)
+		}
+		// #6186: distinguish an expired/invalid FEEDBACK_GITHUB_TOKEN (the
+		// GitHub API returned 401) from other upstream failures. The generic
+		// "create a GitHub OAuth app" guidance the client shows on generic
+		// errors misleads users whose real problem is a stale PAT.
+		if errors.Is(err, errGitHubUnauthorized) {
+			return fiber.NewError(fiber.StatusUnauthorized, "FEEDBACK_GITHUB_TOKEN is invalid or expired. Refresh the PAT in your .env and restart the console.")
 		}
 		return fiber.NewError(fiber.StatusBadGateway, fmt.Sprintf("Failed to create GitHub issue: %v", err))
 	}
@@ -1961,6 +1976,9 @@ func (h *FeedbackHandler) postGitHubIssue(repoOwner, repoName, title, body strin
 		respBody, readErr := io.ReadAll(resp.Body)
 		if readErr != nil {
 			respBody = []byte("(failed to read response body)")
+		}
+		if resp.StatusCode == http.StatusUnauthorized {
+			return 0, "", fmt.Errorf("%w: %s", errGitHubUnauthorized, string(respBody))
 		}
 		return 0, "", fmt.Errorf("GitHub API returned %d: %s", resp.StatusCode, string(respBody))
 	}


### PR DESCRIPTION
## Summary

When `FEEDBACK_GITHUB_TOKEN` is invalid or expired, GitHub rejects the issue-creation POST with HTTP 401. The handler was collapsing every upstream error into a generic 502 Bad Gateway, which the frontend pairs with static "create a GitHub OAuth app" guidance. Users whose real problem is a stale PAT end up hunting for nonexistent OAuth-app configuration.

### Fix

Three small changes in `pkg/api/handlers/feedback.go`:
1. Add `errors` import.
2. Add `errGitHubUnauthorized` sentinel.
3. In `postGitHubIssue`, when `resp.StatusCode == http.StatusUnauthorized`, return `fmt.Errorf("%w: %s", errGitHubUnauthorized, respBody)` — preserving both the sentinel (for `errors.Is`) and the original body for logging.
4. In `createFeatureRequest`, when `errors.Is(err, errGitHubUnauthorized)`, return HTTP 401 with message `"FEEDBACK_GITHUB_TOKEN is invalid or expired. Refresh the PAT in your .env and restart the console."` — all other errors continue to map to the existing 502 path.

### Scope

+18 / -2 in a single file. Zero behavior change for the happy-path (2xx) and non-401 error paths.

Addresses scanner bead `scanner-beads-t2c` (local-dev reporter hit this with an expired PAT on the Contribute flow — no dedicated GH issue was filed, the bead note captures the reproduction).

## Test plan
- [x] `go build ./pkg/api/handlers/...` — clean
- [x] `go vet ./pkg/api/handlers/...` — clean
- [x] `go test ./pkg/api/handlers/...` — passes