### PR TITLE
fix: wrap Quiet Hours section strings in t() for i18n (#8872)

### DIFF
--- a/web/src/components/settings/sections/BrowserNotificationSettings.tsx
+++ b/web/src/components/settings/sections/BrowserNotificationSettings.tsx
@@ -187,15 +187,18 @@ export function BrowserNotificationSettings() {
 /** Quiet hours configuration — recurring daily window where notifications are suppressed */
 function QuietHoursConfig() {
   const dnd = useDoNotDisturb()
+  const { t } = useTranslation()
 
   return (
     <div className="space-y-3 pt-4 border-t border-border">
       <div className="flex items-center gap-2">
         <Moon className="w-4 h-4 text-muted-foreground" />
-        <h4 className="text-sm font-medium text-foreground">Quiet Hours</h4>
+        <h4 className="text-sm font-medium text-foreground">
+          {t('settings.notifications.browser.quietHoursTitle')}
+        </h4>
       </div>
       <p className="text-xs text-muted-foreground">
-        Suppress desktop notifications during a recurring daily window.
+        {t('settings.notifications.browser.quietHoursDesc')}
       </p>
 
       <label className="flex items-center gap-2 cursor-pointer">
@@ -206,7 +209,7 @@ function QuietHoursConfig() {
           className="rounded border-border accent-primary"
         />
         <span className="text-sm text-foreground">
-          Don&apos;t notify between
+          {t('settings.notifications.browser.quietHoursDontNotifyBetween')}
         </span>
       </label>
 
@@ -218,7 +221,9 @@ function QuietHoursConfig() {
             onChange={(e) => dnd.setQuietHours(true, e.target.value)}
             className="px-2 py-1 text-sm bg-secondary border border-border rounded text-foreground"
           />
-          <span className="text-xs text-muted-foreground">and</span>
+          <span className="text-xs text-muted-foreground">
+            {t('settings.notifications.browser.quietHoursAnd')}
+          </span>
           <input
             type="time"
             value={dnd.quietHoursEnd}

--- a/web/src/locales/en/common.json
+++ b/web/src/locales/en/common.json
@@ -406,7 +406,11 @@
         "dndHint": "Also check that Do Not Disturb / Focus mode is off — the OS suppresses notifications while it's on.",
         "tryAgain": "Try Again",
         "blocked": "Browser notifications are blocked. Enable them in your browser's site settings for this page, then reload.",
-        "requestPermission": "Request Permission"
+        "requestPermission": "Request Permission",
+        "quietHoursTitle": "Quiet Hours",
+        "quietHoursDesc": "Suppress desktop notifications during a recurring daily window.",
+        "quietHoursDontNotifyBetween": "Don't notify between",
+        "quietHoursAnd": "and"
       }
     },
     "persistence": {


### PR DESCRIPTION
## Summary

**Fixes #8872** — The Quiet Hours sub-section of `BrowserNotificationSettings` had four hardcoded English strings (heading, description, checkbox label, time range separator) that always rendered in English regardless of the selected language.

### Fix

Wraps them in `t()` calls and adds four keys under the existing `settings.notifications.browser` namespace in `en/common.json`:

- `quietHoursTitle` = "Quiet Hours"
- `quietHoursDesc` = "Suppress desktop notifications during a recurring daily window."
- `quietHoursDontNotifyBetween` = "Don't notify between"
- `quietHoursAnd` = "and"

Other locales (hi/it/zh/ja/de/pt/fr/es) fall back to English per the i18next config — per-locale translations can be added in follow-ups without blocking this fix.

### Scope

+14 / -5 across 2 files. No behavior change; purely a presentation wrap.

## Test plan
- [x] JSON validity: `python3 -c "json.load(...)"` — valid
- [x] `npx eslint` on touched files — 0 new errors (4 pre-existing `no-restricted-syntax` warnings on raw `<input>` are unchanged)

Fixes #8872