### PR TITLE
fix: wrap Settings sync status + PagerDuty strings in t() for i18n

### DIFF
--- a/web/src/components/settings/sections/PagerDutyNotificationSettings.tsx
+++ b/web/src/components/settings/sections/PagerDutyNotificationSettings.tsx
@@ -28,7 +28,7 @@ export function PagerDutyNotificationSettings({
 
   const handleTestPagerDuty = async () => {
     if (!config.pagerdutyRoutingKey) {
-      setTestResult({ type: 'pagerduty', success: false, message: 'PagerDuty routing key is required' })
+      setTestResult({ type: 'pagerduty', success: false, message: t('settings.notifications.pagerduty.routingKeyRequired') })
       return
     }
 
@@ -37,12 +37,12 @@ export function PagerDutyNotificationSettings({
       await testNotification('pagerduty', {
         pagerdutyRoutingKey: config.pagerdutyRoutingKey,
       })
-      setTestResult({ type: 'pagerduty', success: true, message: 'Test notification sent and resolved successfully' })
+      setTestResult({ type: 'pagerduty', success: true, message: t('settings.notifications.pagerduty.testSuccess') })
     } catch (error) {
       setTestResult({
         type: 'pagerduty',
         success: false,
-        message: error instanceof Error ? error.message : 'Failed to send test notification',
+        message: error instanceof Error ? error.message : t('settings.notifications.pagerduty.testFailed'),
       })
     }
   }
@@ -75,7 +75,7 @@ export function PagerDutyNotificationSettings({
         disabled={isLoading}
         className="px-4 py-2 text-sm rounded-lg bg-purple-500 text-white hover:bg-purple-600 transition-colors disabled:opacity-50"
       >
-        {isLoading ? 'Testing...' : t('settings.notifications.pagerduty.testNotification', 'Test PagerDuty')}
+        {isLoading ? t('settings.notifications.pagerduty.testing') : t('settings.notifications.pagerduty.testNotification', 'Test PagerDuty')}
       </button>
 
       {testResult && testResult.type === 'pagerduty' && (

--- a/web/src/components/settings/sections/SettingsBackupSection.tsx
+++ b/web/src/components/settings/sections/SettingsBackupSection.tsx
@@ -20,12 +20,18 @@ const STATUS_ICONS: Record<SyncStatus, { icon: typeof Check; className: string }
   offline: { icon: WifiOff, className: 'text-yellow-400' },
 }
 
-function formatLastSaved(date: Date | null, t: (key: string) => string): string {
-  if (!date) return t('settings.backup.never')
+// Pre-resolved labels passed in from the caller so this helper does not
+// need to depend on i18next's overloaded TFunction generic.
+interface LastSavedLabels {
+  never: string
+  justNow: string
+}
+function formatLastSaved(date: Date | null, labels: LastSavedLabels): string {
+  if (!date) return labels.never
   const now = new Date()
   const diffMs = now.getTime() - date.getTime()
   const diffSec = Math.floor(diffMs / 1000)
-  if (diffSec < 5) return t('settings.backup.justNow')
+  if (diffSec < 5) return labels.justNow
   if (diffSec < 60) return `${diffSec}s ago`
   const diffMin = Math.floor(diffSec / 60)
   if (diffMin < 60) return `${diffMin}m ago`
@@ -118,7 +124,12 @@ export function SettingsBackupSection({
               <div>
                 <p className={`text-sm font-medium ${status.className}`}>{statusLabel}</p>
                 <p className="text-xs text-muted-foreground">
-                  {t('settings.backup.lastSaved', { time: formatLastSaved(lastSaved, t) })}
+                  {t('settings.backup.lastSaved', {
+                    time: formatLastSaved(lastSaved, {
+                      never: t('settings.backup.never'),
+                      justNow: t('settings.backup.justNow'),
+                    }),
+                  })}
                 </p>
               </div>
             </div>

--- a/web/src/components/settings/sections/SettingsBackupSection.tsx
+++ b/web/src/components/settings/sections/SettingsBackupSection.tsx
@@ -12,20 +12,20 @@ interface SettingsBackupSectionProps {
   onImport: (file: File) => Promise<void>
 }
 
-const STATUS_CONFIG: Record<SyncStatus, { icon: typeof Check; label: string; className: string }> = {
-  idle: { icon: HardDrive, label: 'Initializing...', className: 'text-muted-foreground' },
-  saving: { icon: Loader2, label: 'Saving...', className: 'text-blue-400' },
-  saved: { icon: Check, label: 'Saved', className: 'text-green-400' },
-  error: { icon: AlertCircle, label: 'Save failed', className: 'text-red-400' },
-  offline: { icon: WifiOff, label: 'Backend offline', className: 'text-yellow-400' },
+const STATUS_ICONS: Record<SyncStatus, { icon: typeof Check; className: string }> = {
+  idle: { icon: HardDrive, className: 'text-muted-foreground' },
+  saving: { icon: Loader2, className: 'text-blue-400' },
+  saved: { icon: Check, className: 'text-green-400' },
+  error: { icon: AlertCircle, className: 'text-red-400' },
+  offline: { icon: WifiOff, className: 'text-yellow-400' },
 }
 
-function formatLastSaved(date: Date | null): string {
-  if (!date) return 'Never'
+function formatLastSaved(date: Date | null, t: (key: string) => string): string {
+  if (!date) return t('settings.backup.never')
   const now = new Date()
   const diffMs = now.getTime() - date.getTime()
   const diffSec = Math.floor(diffMs / 1000)
-  if (diffSec < 5) return 'Just now'
+  if (diffSec < 5) return t('settings.backup.justNow')
   if (diffSec < 60) return `${diffSec}s ago`
   const diffMin = Math.floor(diffSec / 60)
   if (diffMin < 60) return `${diffMin}m ago`
@@ -51,7 +51,15 @@ export function SettingsBackupSection({
     return () => clearTimeout(importSuccessTimerRef.current)
   }, [])
 
-  const status = STATUS_CONFIG[syncStatus]
+  const STATUS_LABELS: Record<SyncStatus, string> = {
+    idle: t('settings.backup.initializing'),
+    saving: t('settings.backup.saving'),
+    saved: t('settings.backup.saved'),
+    error: t('settings.backup.saveFailed'),
+    offline: t('settings.backup.backendOffline'),
+  }
+  const status = STATUS_ICONS[syncStatus]
+  const statusLabel = STATUS_LABELS[syncStatus]
   const StatusIcon = status.icon
 
   const handleExport = async () => {
@@ -108,9 +116,9 @@ export function SettingsBackupSection({
             <div className="flex items-center gap-3">
               <StatusIcon className={`w-4 h-4 ${status.className} ${syncStatus === 'saving' ? 'animate-spin' : ''}`} />
               <div>
-                <p className={`text-sm font-medium ${status.className}`}>{status.label}</p>
+                <p className={`text-sm font-medium ${status.className}`}>{statusLabel}</p>
                 <p className="text-xs text-muted-foreground">
-                  Last saved: {formatLastSaved(lastSaved)}
+                  {t('settings.backup.lastSaved', { time: formatLastSaved(lastSaved, t) })}
                 </p>
               </div>
             </div>

--- a/web/src/locales/en/common.json
+++ b/web/src/locales/en/common.json
@@ -411,6 +411,16 @@
         "quietHoursDesc": "Suppress desktop notifications during a recurring daily window.",
         "quietHoursDontNotifyBetween": "Don't notify between",
         "quietHoursAnd": "and"
+      },
+      "pagerduty": {
+        "title": "PagerDuty",
+        "routingKey": "Integration / Routing Key",
+        "routingKeyHint": "Find this under Services > Integrations > Events API v2 in PagerDuty",
+        "routingKeyRequired": "PagerDuty routing key is required",
+        "testing": "Testing...",
+        "testNotification": "Test PagerDuty",
+        "testSuccess": "Test notification sent and resolved successfully",
+        "testFailed": "Failed to send test notification"
       }
     },
     "persistence": {


### PR DESCRIPTION
## Summary

Closes two hardcoded-English-strings bugs from @aashu2006's Settings audit wave, using the same pattern landed in PR #8875 for Quiet Hours.

- **#8871** — sync status labels (5 strings in `SettingsBackupSection.tsx`: `"Initializing..."`, `"Saving..."`, `"Saved"`, `"Save failed"`, `"Backend offline"`, plus `"Last saved: ..."`, `"Never"`, `"Just now"`). The existing `settings.backup.*` keys in `en/common.json` are now wired up. The module-level `STATUS_CONFIG` was split into `STATUS_ICONS` (icon/color only, still module-level) and an in-component `STATUS_LABELS` that calls `t()` at render time.
- **#8873** — PagerDuty validation + test messages (4 strings in `PagerDutyNotificationSettings.tsx`: `"PagerDuty routing key is required"`, `"Test notification sent and resolved successfully"`, `"Failed to send test notification"`, and the in-flight `"Testing..."` button label). Adds a new `settings.notifications.pagerduty.*` block in `en/common.json` parallel to `settings.notifications.browser.*`.

Other locales (hi/it/zh/ja/de/pt/fr/es) fall back to English per the i18next config — per-locale translations can follow without blocking this fix.

## Files

- `web/src/components/settings/sections/SettingsBackupSection.tsx`
- `web/src/components/settings/sections/PagerDutyNotificationSettings.tsx`
- `web/src/locales/en/common.json` (added `settings.notifications.pagerduty.*`; `settings.backup.*` keys already existed)

## Test plan

- [x] `python3 -c "import json; json.load(...)"` on `en/common.json` — JSON valid
- [x] ESLint on touched files — 0 new errors (2 pre-existing `no-restricted-syntax` warnings unrelated to this change)
- [x] vitest run on `MiscSections.test.tsx`, `NotificationSettings.test.tsx`, `Settings.test.tsx` — 19/19 pass

Fixes #8871, Fixes #8873