### PR TITLE
fix: wrap Profile/TokenUsage/OpsGenie strings in t() for i18n

### DIFF
--- a/web/src/components/settings/sections/OpsGenieNotificationSettings.tsx
+++ b/web/src/components/settings/sections/OpsGenieNotificationSettings.tsx
@@ -28,7 +28,7 @@ export function OpsGenieNotificationSettings({
 
   const handleTestOpsGenie = async () => {
     if (!config.opsgenieApiKey) {
-      setTestResult({ type: 'opsgenie', success: false, message: 'OpsGenie API key is required' })
+      setTestResult({ type: 'opsgenie', success: false, message: t('settings.notifications.opsgenie.apiKeyRequired') })
       return
     }
 
@@ -37,12 +37,12 @@ export function OpsGenieNotificationSettings({
       await testNotification('opsgenie', {
         opsgenieApiKey: config.opsgenieApiKey,
       })
-      setTestResult({ type: 'opsgenie', success: true, message: 'Test alert created and closed successfully' })
+      setTestResult({ type: 'opsgenie', success: true, message: t('settings.notifications.opsgenie.testSuccess') })
     } catch (error) {
       setTestResult({
         type: 'opsgenie',
         success: false,
-        message: error instanceof Error ? error.message : 'Failed to send test notification',
+        message: error instanceof Error ? error.message : t('settings.notifications.opsgenie.testFailed'),
       })
     }
   }
@@ -75,7 +75,7 @@ export function OpsGenieNotificationSettings({
         disabled={isLoading}
         className="px-4 py-2 text-sm rounded-lg bg-purple-500 text-white hover:bg-purple-600 transition-colors disabled:opacity-50"
       >
-        {isLoading ? 'Testing...' : t('settings.notifications.opsgenie.testNotification', 'Test OpsGenie')}
+        {isLoading ? t('settings.notifications.opsgenie.testing') : t('settings.notifications.opsgenie.testNotification', 'Test OpsGenie')}
       </button>
 
       {testResult && testResult.type === 'opsgenie' && (

--- a/web/src/components/settings/sections/ProfileSection.tsx
+++ b/web/src/components/settings/sections/ProfileSection.tsx
@@ -46,7 +46,7 @@ export function ProfileSection({ initialEmail, initialSlackId, refreshUser, isLo
         signal: AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS),
       })
       if (!response.ok) {
-        throw new Error('Failed to save profile')
+        throw new Error(t('settings.profile.saveFailed'))
       }
       // Refresh user data to update the dropdown
       setIsRefreshing(true)
@@ -55,7 +55,7 @@ export function ProfileSection({ initialEmail, initialSlackId, refreshUser, isLo
       setProfileSaved(true)
       timeoutRef.current = window.setTimeout(() => setProfileSaved(false), UI_FEEDBACK_TIMEOUT_MS)
     } catch (error) {
-      const message = error instanceof Error ? error.message : 'Failed to save profile'
+      const message = error instanceof Error ? error.message : t('settings.profile.saveFailed')
       setError(message)
       setIsRefreshing(false)
     } finally {

--- a/web/src/components/settings/sections/SettingsBackupSection.tsx
+++ b/web/src/components/settings/sections/SettingsBackupSection.tsx
@@ -25,16 +25,25 @@ const STATUS_ICONS: Record<SyncStatus, { icon: typeof Check; className: string }
 interface LastSavedLabels {
   never: string
   justNow: string
+  secondsAgo: (count: number) => string
+  minutesAgo: (count: number) => string
 }
+// Threshold (seconds) below which we render "Just now" instead of an exact
+// number of seconds. Matches the original hardcoded value.
+const JUST_NOW_THRESHOLD_SEC = 5
+// Boundary for switching from seconds-ago to minutes-ago / minutes-ago to
+// absolute time. 60s in a minute, 60m in an hour.
+const SECONDS_PER_MINUTE = 60
+const MINUTES_PER_HOUR = 60
 function formatLastSaved(date: Date | null, labels: LastSavedLabels): string {
   if (!date) return labels.never
   const now = new Date()
   const diffMs = now.getTime() - date.getTime()
   const diffSec = Math.floor(diffMs / 1000)
-  if (diffSec < 5) return labels.justNow
-  if (diffSec < 60) return `${diffSec}s ago`
-  const diffMin = Math.floor(diffSec / 60)
-  if (diffMin < 60) return `${diffMin}m ago`
+  if (diffSec < JUST_NOW_THRESHOLD_SEC) return labels.justNow
+  if (diffSec < SECONDS_PER_MINUTE) return labels.secondsAgo(diffSec)
+  const diffMin = Math.floor(diffSec / SECONDS_PER_MINUTE)
+  if (diffMin < MINUTES_PER_HOUR) return labels.minutesAgo(diffMin)
   return date.toLocaleTimeString()
 }
 
@@ -128,6 +137,8 @@ export function SettingsBackupSection({
                     time: formatLastSaved(lastSaved, {
                       never: t('settings.backup.never'),
                       justNow: t('settings.backup.justNow'),
+                      secondsAgo: (count: number) => t('settings.backup.secondsAgo', { count }),
+                      minutesAgo: (count: number) => t('settings.backup.minutesAgo', { count }),
                     }),
                   })}
                 </p>

--- a/web/src/components/settings/sections/TokenUsageSection.tsx
+++ b/web/src/components/settings/sections/TokenUsageSection.tsx
@@ -47,8 +47,8 @@ export function TokenUsageSection({ usage, updateSettings, resetUsage, isDemoDat
             <div className="flex items-center gap-2">
               <h2 className="text-lg font-medium text-foreground">{t('settings.tokens.title')}</h2>
               {isDemoData && (
-                <StatusBadge color="yellow" variant="outline" role="img" aria-label="Demo mode active">
-                  Demo Data
+                <StatusBadge color="yellow" variant="outline" role="img" aria-label={t('settings.tokens.demoBadgeAriaLabel')}>
+                  {t('settings.tokens.demoBadge')}
                 </StatusBadge>
               )}
             </div>
@@ -68,8 +68,7 @@ export function TokenUsageSection({ usage, updateSettings, resetUsage, isDemoDat
       {isDemoData && (
         <div className="mb-4 p-3 rounded-lg bg-yellow-500/10 border border-yellow-500/20">
           <p className="text-sm text-yellow-400/90">
-            <strong className="font-medium">Demo Mode:</strong> Showing simulated token usage data. 
-            To see live token consumption from your AI operations, ensure the kc-agent is running and connected.
+            <strong className="font-medium">{t('settings.tokens.demoModeLabel')}</strong> {t('settings.tokens.demoModeMessage')}
           </p>
         </div>
       )}
@@ -108,10 +107,10 @@ export function TokenUsageSection({ usage, updateSettings, resetUsage, isDemoDat
                   ? 'text-yellow-400'
                   : 'text-green-400'
               }`}>
-                {((usage.used / usage.limit) * 100).toFixed(1)}% used
+                {t('settings.tokens.percentUsed', { percent: ((usage.used / usage.limit) * 100).toFixed(1) })}
               </span>
               <span className="text-xs text-muted-foreground">
-                {Math.max(usage.limit - usage.used, 0).toLocaleString()} remaining
+                {t('settings.tokens.remaining', { count: Math.max(usage.limit - usage.used, 0).toLocaleString() })}
               </span>
             </div>
           </div>
@@ -130,7 +129,7 @@ export function TokenUsageSection({ usage, updateSettings, resetUsage, isDemoDat
               className="w-full px-3 py-2 rounded-lg bg-secondary border border-border text-foreground text-sm"
             />
             <p className="mt-1 text-xs text-muted-foreground">
-              Maximum tokens per month
+              {t('settings.tokens.monthlyLimitHint')}
             </p>
           </div>
           <div>
@@ -149,7 +148,7 @@ export function TokenUsageSection({ usage, updateSettings, resetUsage, isDemoDat
               <span className="absolute right-3 top-1/2 -translate-y-1/2 text-yellow-400 text-sm" aria-hidden="true">%</span>
             </div>
             <p className="mt-1 text-xs text-yellow-400/70">
-              Warning at {warningThreshold}% usage
+              {t('settings.tokens.warningAtHint', { percent: warningThreshold })}
             </p>
           </div>
           <div>
@@ -168,7 +167,7 @@ export function TokenUsageSection({ usage, updateSettings, resetUsage, isDemoDat
               <span className="absolute right-3 top-1/2 -translate-y-1/2 text-red-400 text-sm" aria-hidden="true">%</span>
             </div>
             <p className="mt-1 text-xs text-red-400/70">
-              Critical at {criticalThreshold}% usage
+              {t('settings.tokens.criticalAtHint', { percent: criticalThreshold })}
             </p>
           </div>
         </div>

--- a/web/src/locales/en/common.json
+++ b/web/src/locales/en/common.json
@@ -267,7 +267,16 @@
       "warningAt": "Warning at (%)",
       "criticalAt": "Critical at (%)",
       "saved": "Saved!",
-      "saveSettings": "Save Token Settings"
+      "saveSettings": "Save Token Settings",
+      "demoBadge": "Demo Data",
+      "demoBadgeAriaLabel": "Demo mode active",
+      "demoModeLabel": "Demo Mode:",
+      "demoModeMessage": "Showing simulated token usage data. To see live token consumption from your AI operations, ensure the kc-agent is running and connected.",
+      "percentUsed": "{{percent}}% used",
+      "remaining": "{{count}} remaining",
+      "monthlyLimitHint": "Maximum tokens per month",
+      "warningAtHint": "Warning at {{percent}}% usage",
+      "criticalAtHint": "Critical at {{percent}}% usage"
     },
     "github": {
       "title": "GitHub Integration",
@@ -345,7 +354,8 @@
       "refreshing": "Refreshing...",
       "saving": "Saving...",
       "saved": "Saved!",
-      "saveProfile": "Save Profile"
+      "saveProfile": "Save Profile",
+      "saveFailed": "Failed to save profile"
     },
     "notifications": {
       "title": "Alert Notifications",
@@ -420,6 +430,16 @@
         "testing": "Testing...",
         "testNotification": "Test PagerDuty",
         "testSuccess": "Test notification sent and resolved successfully",
+        "testFailed": "Failed to send test notification"
+      },
+      "opsgenie": {
+        "title": "OpsGenie",
+        "apiKey": "API Key",
+        "apiKeyHint": "Find this under Settings > API key management in OpsGenie",
+        "apiKeyRequired": "OpsGenie API key is required",
+        "testing": "Testing...",
+        "testNotification": "Test OpsGenie",
+        "testSuccess": "Test alert created and closed successfully",
         "testFailed": "Failed to send test notification"
       }
     },
@@ -509,6 +529,8 @@
       "backendOffline": "Backend offline",
       "never": "Never",
       "justNow": "Just now",
+      "secondsAgo": "{{count}}s ago",
+      "minutesAgo": "{{count}}m ago",
       "lastSaved": "Last saved: {{time}}",
       "encrypted": "AES-256 encrypted",
       "fileLocation": "File location",


### PR DESCRIPTION
## Summary

Fourth round of Settings-area i18n fixes following #8875 (Quiet Hours) and #8885 (sync status + PagerDuty). Wraps hardcoded strings across four Settings components so non-English locales render correctly.

- **ProfileSection** (#8877): wraps the profile-save error message (`Failed to save profile`) thrown on non-OK responses and surfaced via the catch fallback.
- **TokenUsageSection** (#8878): wraps the demo-mode badge label/aria-label, demo-mode banner, percent-used/remaining labels, and the three threshold hint lines (`Maximum tokens per month`, `Warning at X% usage`, `Critical at X% usage`). New keys live under `settings.tokens.*`.
- **OpsGenieNotificationSettings** (#8880): wraps the validation error (`OpsGenie API key is required`), the success/failure test messages, and the `Testing...` button state. New keys live under `settings.notifications.opsgenie.*` mirroring the `pagerduty` block.
- **SettingsBackupSection** (#8879): completes the issue by wrapping the seconds-ago and minutes-ago variants of `formatLastSaved`. The `Never` and `Just now` branches were already wrapped in #8885; the relative-time fallthroughs were not. Helper now takes label functions for the count-based variants so the i18next overload mismatch from #8885 stays avoided.

All new keys land in `web/src/locales/en/common.json` only; other locales fall back to English per i18next config.

## Verification

- `python3 -m json.tool` on `en/common.json`: valid
- `npx tsc --noEmit`: zero errors
- `npx eslint <touched files>`: zero new errors (7 pre-existing `<input>` warnings unrelated)
- `npx vitest run` on `ProfileSection.test.tsx`, `NotificationSettings.test.tsx`, `MiscSections.test.tsx`: 19/19 pass

## Test plan

- [ ] Switch console language to a non-English locale (e.g. via Settings > Appearance) and visit Settings
- [ ] Profile: trigger a save failure and confirm the error toast renders the localized fallback
- [ ] Token Usage: confirm threshold hints + demo banner render in the selected locale
- [ ] OpsGenie: click Test with no API key, confirm the validation error is localized; click Test with a bad key, confirm the failure message is localized
- [ ] Backup & Sync: save a setting, wait a few seconds, confirm the `Last saved` timestamp shows the localized seconds-ago / minutes-ago format

Fixes #8877
Fixes #8878
Fixes #8879
Fixes #8880