### PR TITLE
fix: add Token settings validation (warning < critical, limit > 0 confirm)

### DIFF
--- a/web/src/components/settings/sections/TokenUsageSection.tsx
+++ b/web/src/components/settings/sections/TokenUsageSection.tsx
@@ -19,13 +19,30 @@ export function TokenUsageSection({ usage, updateSettings, resetUsage, isDemoDat
   const [warningThreshold, setWarningThreshold] = useState(usage.warningThreshold * 100)
   const [criticalThreshold, setCriticalThreshold] = useState(usage.criticalThreshold * 100)
   const [saved, setSaved] = useState(false)
+  const [thresholdError, setThresholdError] = useState<string | null>(null)
   const savedTimerRef = useRef<ReturnType<typeof setTimeout>>(undefined)
+
+  // Token limit value that effectively disables all AI operations
+  const DISABLED_TOKEN_LIMIT = 0
 
   useEffect(() => {
     return () => clearTimeout(savedTimerRef.current)
   }, [])
 
   const handleSaveTokenSettings = () => {
+    // #8869: warning must be strictly less than critical, otherwise alert semantics invert
+    if (warningThreshold >= criticalThreshold) {
+      setThresholdError(t('settings.tokens.validation.warningMustBeLower'))
+      return
+    }
+    setThresholdError(null)
+
+    // #8870: a limit of 0 silently disables all AI operations; require explicit confirmation
+    if (tokenLimit === DISABLED_TOKEN_LIMIT) {
+      const confirmed = window.confirm(t('settings.tokens.validation.limitZeroConfirm'))
+      if (!confirmed) return
+    }
+
     updateSettings({
       limit: tokenLimit,
       warningThreshold: warningThreshold / 100,
@@ -171,6 +188,12 @@ export function TokenUsageSection({ usage, updateSettings, resetUsage, isDemoDat
             </p>
           </div>
         </div>
+
+        {thresholdError && (
+          <p role="alert" className="text-sm text-red-400">
+            {thresholdError}
+          </p>
+        )}
 
         <button
           onClick={handleSaveTokenSettings}

--- a/web/src/locales/en/common.json
+++ b/web/src/locales/en/common.json
@@ -276,7 +276,11 @@
       "remaining": "{{count}} remaining",
       "monthlyLimitHint": "Maximum tokens per month",
       "warningAtHint": "Warning at {{percent}}% usage",
-      "criticalAtHint": "Critical at {{percent}}% usage"
+      "criticalAtHint": "Critical at {{percent}}% usage",
+      "validation": {
+        "warningMustBeLower": "Warning threshold must be lower than critical threshold.",
+        "limitZeroConfirm": "Setting limit to 0 disables all AI operations. Continue?"
+      }
     },
     "github": {
       "title": "GitHub Integration",


### PR DESCRIPTION
## Summary

Two validation gaps in **Settings > Token Usage** are silently breaking alert semantics or disabling AI ops without warning. Both fixes live in `TokenUsageSection.tsx` (the only place the Save handler runs).

- **Fixes #8869** — warning threshold could be set >= critical threshold, inverting the alert order so users hit critical before warning. Now Save is blocked with an inline `text-red-400` error and `updateSettings` is not called when `warningThreshold >= criticalThreshold`.
- **Fixes #8870** — token limit could be set to `0`, which silently disables all AI operations because every usage check immediately fails the budget. Now Save prompts an explicit `window.confirm()` when `tokenLimit === 0`, so the user can't accidentally nuke their AI budget.

## Files touched (2)

- `web/src/components/settings/sections/TokenUsageSection.tsx` — validation in `handleSaveTokenSettings` + inline error render
- `web/src/locales/en/common.json` — adds `settings.tokens.validation.warningMustBeLower` and `settings.tokens.validation.limitZeroConfirm`

Other locales fall back to English per i18next config.

## Test plan

- [x] `python3 -c "import json; json.load(...)"` — JSON valid
- [x] `npx tsc --noEmit` — zero error output
- [x] `npx eslint TokenUsageSection.tsx` — no new errors (3 pre-existing warnings about `<input>` vs `<Input>` unchanged)
- [x] `npx vitest run` for 3 test files referencing TokenUsageSection — 28/28 pass
- [ ] Manual: open Settings, set warning=80 / critical=70, click Save, see inline error, no settings change
- [ ] Manual: set token limit=0, click Save, confirm prompt appears, cancel = no change, confirm = saves