### PR TITLE
fix: disable Token Settings Save button during post-save feedback (#8876)

### DIFF
--- a/web/src/components/settings/sections/TokenUsageSection.tsx
+++ b/web/src/components/settings/sections/TokenUsageSection.tsx
@@ -197,7 +197,8 @@ export function TokenUsageSection({ usage, updateSettings, resetUsage, isDemoDat
 
         <button
           onClick={handleSaveTokenSettings}
-          className="flex items-center gap-2 px-4 py-2 rounded-lg bg-purple-500 text-white hover:bg-purple-600"
+          disabled={saved}
+          className="flex items-center gap-2 px-4 py-2 rounded-lg bg-purple-500 text-white hover:bg-purple-600 disabled:opacity-50 disabled:cursor-not-allowed"
         >
           <Save className="w-4 h-4" />
           {saved ? t('settings.tokens.saved') : t('settings.tokens.saveSettings')}


### PR DESCRIPTION
## Summary

**Fixes #8876** — While the Token Settings Save button sits in the short \"Saved!\" feedback window after a successful save, there was no visual/interaction guard against clicking again. The user could submit the same settings multiple times in quick succession (the `saved` state lingers for `UI_FEEDBACK_TIMEOUT_MS` after a save, but the button stayed interactable).

## Fix

Two-line change in `TokenUsageSection.tsx`:
- `disabled={saved}` on the `<button>`
- Added `disabled:opacity-50 disabled:cursor-not-allowed` Tailwind classes for the standard visual treatment

## Scope

+2 / -1 in a single file. No behavior change during normal use; only the post-save feedback window is now gated.

## Test plan
- [x] `npx tsc --noEmit` — clean
- [x] `npx eslint` on touched file — 3 pre-existing warnings unchanged, 0 new errors

Fixes #8876