### PR TITLE
fix: validate Slack webhook URL before test/save (#8874)

### DIFF
--- a/web/src/components/settings/sections/SlackNotificationSettings.tsx
+++ b/web/src/components/settings/sections/SlackNotificationSettings.tsx
@@ -1,8 +1,13 @@
+import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { Check, X } from 'lucide-react'
 import { Slack } from '@/lib/icons'
 import { NotificationConfig } from '../../../types/alerts'
 import type { TestResultState } from './NotificationSettingsSection'
+
+// Strict Slack incoming webhook URL: https://hooks.slack.com/services/<token>.
+// Blocks arbitrary text/URLs from being POSTed to a non-Slack endpoint.
+const SLACK_WEBHOOK_REGEX = /^https:\/\/hooks\.slack\.com\/services\/\S+$/
 
 interface SlackNotificationSettingsProps {
   config: NotificationConfig
@@ -26,10 +31,26 @@ export function SlackNotificationSettings({
   isLoading,
 }: SlackNotificationSettingsProps) {
   const { t } = useTranslation()
+  const [urlError, setUrlError] = useState<string | null>(null)
+
+  const handleUrlChange = (value: string) => {
+    updateConfig({ slackWebhookUrl: value })
+    const trimmed = value.trim()
+    if (trimmed.length > 0 && !SLACK_WEBHOOK_REGEX.test(trimmed)) {
+      setUrlError(t('settings.notifications.slack.invalidWebhookUrl'))
+    } else {
+      setUrlError(null)
+    }
+  }
 
   const handleTestSlack = async () => {
     if (!config.slackWebhookUrl) {
       setTestResult({ type: 'slack', success: false, message: t('settings.notifications.slack.configureFirst') })
+      return
+    }
+    if (!SLACK_WEBHOOK_REGEX.test(config.slackWebhookUrl.trim())) {
+      setUrlError(t('settings.notifications.slack.invalidWebhookUrl'))
+      setTestResult({ type: 'slack', success: false, message: t('settings.notifications.slack.invalidWebhookUrl') })
       return
     }
 
@@ -63,10 +84,15 @@ export function SlackNotificationSettings({
         <input
           type="text"
           value={config.slackWebhookUrl || ''}
-          onChange={e => updateConfig({ slackWebhookUrl: e.target.value })}
+          onChange={e => handleUrlChange(e.target.value)}
           placeholder="https://hooks.slack.com/services/..."
+          aria-invalid={!!urlError}
+          aria-describedby={urlError ? 'slack-webhook-url-error' : undefined}
           className="w-full px-3 py-2 rounded-lg bg-secondary border border-border text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-purple-500"
         />
+        {urlError && (
+          <p id="slack-webhook-url-error" role="alert" className="mt-1 text-xs text-red-400">{urlError}</p>
+        )}
         <p className="text-xs text-muted-foreground mt-1">
           {t('settings.notifications.slack.webhookHint')}
         </p>
@@ -90,7 +116,7 @@ export function SlackNotificationSettings({
 
       <button
         onClick={handleTestSlack}
-        disabled={isLoading}
+        disabled={isLoading || !!urlError}
         className="px-4 py-2 text-sm rounded-lg bg-purple-500 text-white hover:bg-purple-600 transition-colors disabled:opacity-50"
       >
         {isLoading ? t('settings.notifications.slack.testing') : t('settings.notifications.slack.testNotification')}

--- a/web/src/locales/en/common.json
+++ b/web/src/locales/en/common.json
@@ -385,7 +385,8 @@
         "testNotification": "Test Slack Notification",
         "configureFirst": "Please configure Slack webhook URL first",
         "testSuccess": "Test notification sent successfully!",
-        "testFailed": "Failed to send test notification"
+        "testFailed": "Failed to send test notification",
+        "invalidWebhookUrl": "Enter a valid Slack webhook URL (https://hooks.slack.com/services/...)."
       },
       "email": {
         "title": "Email Integration",


### PR DESCRIPTION
## Summary

The Slack notification webhook URL field in **Settings -> Notifications -> Slack** accepted any text. Clicking **Test Slack Notification** would POST a test payload to an arbitrary URL because the only check was non-empty.

Adds a lightweight client-side regex check that mirrors the just-merged profile email validation (#8890):

- Validates on every keystroke and shows an inline error below the input.
- Returns early in `handleTestSlack` if the URL doesn't match.
- Disables the **Test** button while `urlError` is set.
- Wires `aria-invalid` / `aria-describedby` + `role=alert` for screen readers.

The regex enforces Slack's documented incoming webhook format: `https://hooks.slack.com/services/<token>`. Strict by design — the field is explicitly labeled "Slack Webhook URL", not a generic notification endpoint.

Adds one i18n key: `settings.notifications.slack.invalidWebhookUrl`.

Fixes #8874

## Test plan

- [x] `python3 -c "import json; json.load(...)"` — `common.json` still valid
- [x] `npx tsc --noEmit` — clean
- [x] `npx eslint SlackNotificationSettings.tsx` — no new errors (2 pre-existing `no-restricted-syntax` warnings on raw `<input>` are unrelated)
- [x] `npx vitest run` on both Slack-touching test files — 7/7 pass
- [ ] Manual: paste `not-a-url` -> see inline error, Test button disables; paste `https://hooks.slack.com/services/T00/B00/xxx` -> error clears, Test enables