### PR TITLE
fix: validate SMTP port input and prevent silent default-revert (#8868)

### DIFF
--- a/web/src/components/settings/sections/EmailNotificationSettings.tsx
+++ b/web/src/components/settings/sections/EmailNotificationSettings.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { Mail, Check, X } from 'lucide-react'
 import { NotificationConfig } from '../../../types/alerts'
@@ -5,6 +6,10 @@ import type { TestResultState } from './NotificationSettingsSection'
 
 /** Default SMTP port for email configuration */
 const DEFAULT_SMTP_PORT = 587
+/** Minimum valid TCP port number (inclusive) */
+const MIN_PORT = 1
+/** Maximum valid TCP port number (inclusive) */
+const MAX_PORT = 65535
 
 interface EmailNotificationSettingsProps {
   config: NotificationConfig
@@ -28,10 +33,37 @@ export function EmailNotificationSettings({
   isLoading,
 }: EmailNotificationSettingsProps) {
   const { t } = useTranslation()
+  const [portRaw, setPortRaw] = useState<string>(
+    config.emailSMTPPort != null ? String(config.emailSMTPPort) : String(DEFAULT_SMTP_PORT),
+  )
+  const [portError, setPortError] = useState<string | null>(null)
+
+  const handlePortChange = (value: string) => {
+    setPortRaw(value)
+    const trimmed = value.trim()
+    // Empty, non-integer, or out-of-range values are rejected. We only push a
+    // valid integer to the shared config so a cleared field never silently
+    // reverts to the default — the user sees an inline error instead.
+    if (trimmed.length === 0 || !/^\d+$/.test(trimmed)) {
+      setPortError(t('settings.notifications.email.invalidSmtpPort'))
+      return
+    }
+    const parsed = parseInt(trimmed, 10)
+    if (parsed < MIN_PORT || parsed > MAX_PORT) {
+      setPortError(t('settings.notifications.email.invalidSmtpPort'))
+      return
+    }
+    setPortError(null)
+    updateConfig({ emailSMTPPort: parsed })
+  }
 
   const handleTestEmail = async () => {
     if (!config.emailSMTPHost || !config.emailFrom || !config.emailTo) {
       setTestResult({ type: 'email', success: false, message: t('settings.notifications.email.configureFirst') })
+      return
+    }
+    if (portError) {
+      setTestResult({ type: 'email', success: false, message: portError })
       return
     }
 
@@ -82,11 +114,18 @@ export function EmailNotificationSettings({
           </label>
           <input
             type="number"
-            value={config.emailSMTPPort || DEFAULT_SMTP_PORT}
-            onChange={e => updateConfig({ emailSMTPPort: parseInt(e.target.value) })}
+            value={portRaw}
+            onChange={e => handlePortChange(e.target.value)}
             placeholder={String(DEFAULT_SMTP_PORT)}
+            min={MIN_PORT}
+            max={MAX_PORT}
+            aria-invalid={!!portError}
+            aria-describedby={portError ? 'email-smtp-port-error' : undefined}
             className="w-full px-3 py-2 rounded-lg bg-secondary border border-border text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-purple-500"
           />
+          {portError && (
+            <p id="email-smtp-port-error" role="alert" className="mt-1 text-xs text-red-400">{portError}</p>
+          )}
         </div>
       </div>
 
@@ -149,7 +188,7 @@ export function EmailNotificationSettings({
 
       <button
         onClick={handleTestEmail}
-        disabled={isLoading}
+        disabled={isLoading || !!portError}
         className="px-4 py-2 text-sm rounded-lg bg-purple-500 text-white hover:bg-purple-600 transition-colors disabled:opacity-50"
       >
         {isLoading ? t('settings.notifications.email.testing') : t('settings.notifications.email.testNotification')}

--- a/web/src/locales/en/common.json
+++ b/web/src/locales/en/common.json
@@ -401,7 +401,8 @@
         "testNotification": "Test Email Notification",
         "configureFirst": "Please configure all required email fields first",
         "testSuccess": "Test email sent successfully!",
-        "testFailed": "Failed to send test email"
+        "testFailed": "Failed to send test email",
+        "invalidSmtpPort": "SMTP port must be a number between 1 and 65535."
       },
       "tip": "Configure notification channels here, then add them to specific alert rules in the Alert Rules editor. Each rule can have multiple notification channels with different configurations.",
       "browser": {


### PR DESCRIPTION
## Summary

Fixes #8868 — the SMTP port field in Email notification settings silently snapped back to the default (587) whenever the user cleared it (or typed something non-numeric), so there was no way to tell the value was being discarded.

The previous handler did `parseInt(e.target.value)` and the displayed value was `config.emailSMTPPort || DEFAULT_SMTP_PORT`, so any empty/NaN state was coerced back to 587 on the next render.

## Fix (Option A — inline validation)

Mirrors the pattern shipped today for Slack webhook URL (#8874), webhook URL (#8867), and the other notification validation fixes:

- Track the port as a raw string locally (`portRaw`) so the user can clear it and see what they typed.
- Validate as integer in `[1, 65535]`.
- Surface an inline `role="alert"` error with `aria-describedby` wiring on the input.
- Disable the **Test Email Notification** button while the port is invalid.
- Only push valid integers into the shared `NotificationConfig` — so a transient invalid keystroke never overwrites a previously valid saved value.

## Files

- `web/src/components/settings/sections/EmailNotificationSettings.tsx` (~44 LOC)
- `web/src/locales/en/common.json` (1 new key: `settings.notifications.email.invalidSmtpPort`)

## Verification

- [x] `python3 -c "import json; json.load(open('web/src/locales/en/common.json'))"` — JSON valid
- [x] `npx tsc --noEmit` — zero errors
- [x] `npx eslint EmailNotificationSettings.tsx` — 0 errors (only pre-existing `<input>` vs `<Input>` warnings, unchanged)
- [x] `npx vitest run NotificationSettings.test.tsx` — 6/6 passing

## Test plan

- [ ] Open Settings → Notifications → Email
- [ ] Clear the SMTP Port field — verify inline error appears, field stays empty (does not snap back to 587)
- [ ] Type `99999` — verify error stays
- [ ] Type `465` — verify error clears, Test button re-enables
- [ ] Reload the page — verify saved port persists