### PR TITLE
fix: rename Predictive Health Monitor to AI Cluster Issue Predictor (#8845)

### DIFF
--- a/web/src/components/cards/cardMetadata.ts
+++ b/web/src/components/cards/cardMetadata.ts
@@ -203,7 +203,7 @@ export const CARD_TITLES: Record<string, string> = {
   console_ai_issues: 'AI Issues',
   console_ai_kubeconfig_audit: 'AI Kubeconfig Audit',
   console_ai_health_check: 'AI Health Check',
-  console_ai_offline_detection: 'Predictive Health Monitor',
+  console_ai_offline_detection: 'AI Cluster Issue Predictor',
 
   // stock_market_ticker — registered via unified descriptor system
 

--- a/web/src/components/cards/console-missions/ConsoleOfflineDetectionCard.tsx
+++ b/web/src/components/cards/console-missions/ConsoleOfflineDetectionCard.tsx
@@ -219,7 +219,7 @@ function generatePredictionId(type: string, name: string, cluster?: string): str
   return `heuristic-${type}-${name}-${cluster || 'unknown'}`
 }
 
-// Card 4: Predictive Health Monitor - Detect issues, predict failures, group by root cause
+// Card 4: AI Cluster Issue Predictor - Detect issues, predict failures, group by root cause
 export function ConsoleOfflineDetectionCard(_props: ConsoleMissionCardProps) {
   const { t } = useTranslation(['cards', 'common'])
   const { startMission, missions } = useMissions()

--- a/web/src/locales/de/cards.json
+++ b/web/src/locales/de/cards.json
@@ -226,7 +226,7 @@
     "console_ai_issues": "AI Issues",
     "console_ai_kubeconfig_audit": "AI Kubeconfig Audit",
     "console_ai_health_check": "AI Health Check",
-    "console_ai_offline_detection": "Predictive Health Monitor",
+    "console_ai_offline_detection": "AI Cluster Issue Predictor",
     "stock_market_ticker": "Stock Market Ticker",
     "prow_jobs": "PROW Jobs",
     "prow_status": "PROW Status",

--- a/web/src/locales/en/cards.json
+++ b/web/src/locales/en/cards.json
@@ -227,7 +227,7 @@
     "console_ai_issues": "AI Issues",
     "console_ai_kubeconfig_audit": "AI Kubeconfig Audit",
     "console_ai_health_check": "AI Health Check",
-    "console_ai_offline_detection": "Predictive Health Monitor",
+    "console_ai_offline_detection": "AI Cluster Issue Predictor",
     "stock_market_ticker": "Stock Market Ticker",
     "prow_jobs": "PROW Jobs",
     "prow_status": "PROW Status",

--- a/web/src/locales/es/cards.json
+++ b/web/src/locales/es/cards.json
@@ -226,7 +226,7 @@
     "console_ai_issues": "AI Issues",
     "console_ai_kubeconfig_audit": "AI Kubeconfig Audit",
     "console_ai_health_check": "AI Health Check",
-    "console_ai_offline_detection": "Predictive Health Monitor",
+    "console_ai_offline_detection": "AI Cluster Issue Predictor",
     "stock_market_ticker": "Stock Market Ticker",
     "prow_jobs": "PROW Jobs",
     "prow_status": "PROW Status",

--- a/web/src/locales/fr/cards.json
+++ b/web/src/locales/fr/cards.json
@@ -226,7 +226,7 @@
     "console_ai_issues": "AI Issues",
     "console_ai_kubeconfig_audit": "AI Kubeconfig Audit",
     "console_ai_health_check": "AI Health Check",
-    "console_ai_offline_detection": "Predictive Health Monitor",
+    "console_ai_offline_detection": "AI Cluster Issue Predictor",
     "stock_market_ticker": "Stock Market Ticker",
     "prow_jobs": "PROW Jobs",
     "prow_status": "PROW Status",

--- a/web/src/locales/hi/cards.json
+++ b/web/src/locales/hi/cards.json
@@ -226,7 +226,7 @@
     "console_ai_issues": "AI Issues",
     "console_ai_kubeconfig_audit": "AI Kubeconfig Audit",
     "console_ai_health_check": "AI Health Check",
-    "console_ai_offline_detection": "Predictive Health Monitor",
+    "console_ai_offline_detection": "AI Cluster Issue Predictor",
     "stock_market_ticker": "Stock Market Ticker",
     "prow_jobs": "PROW Jobs",
     "prow_status": "PROW Status",

--- a/web/src/locales/it/cards.json
+++ b/web/src/locales/it/cards.json
@@ -226,7 +226,7 @@
     "console_ai_issues": "AI Issues",
     "console_ai_kubeconfig_audit": "AI Kubeconfig Audit",
     "console_ai_health_check": "AI Health Check",
-    "console_ai_offline_detection": "Predictive Health Monitor",
+    "console_ai_offline_detection": "AI Cluster Issue Predictor",
     "stock_market_ticker": "Stock Market Ticker",
     "prow_jobs": "PROW Jobs",
     "prow_status": "PROW Status",

--- a/web/src/locales/ja/cards.json
+++ b/web/src/locales/ja/cards.json
@@ -226,7 +226,7 @@
     "console_ai_issues": "AI Issues",
     "console_ai_kubeconfig_audit": "AI Kubeconfig Audit",
     "console_ai_health_check": "AI Health Check",
-    "console_ai_offline_detection": "Predictive Health Monitor",
+    "console_ai_offline_detection": "AI Cluster Issue Predictor",
     "stock_market_ticker": "Stock Market Ticker",
     "prow_jobs": "PROW Jobs",
     "prow_status": "PROW Status",

--- a/web/src/locales/pt/cards.json
+++ b/web/src/locales/pt/cards.json
@@ -226,7 +226,7 @@
     "console_ai_issues": "AI Issues",
     "console_ai_kubeconfig_audit": "AI Kubeconfig Audit",
     "console_ai_health_check": "AI Health Check",
-    "console_ai_offline_detection": "Predictive Health Monitor",
+    "console_ai_offline_detection": "AI Cluster Issue Predictor",
     "stock_market_ticker": "Stock Market Ticker",
     "prow_jobs": "PROW Jobs",
     "prow_status": "PROW Status",

--- a/web/src/locales/zh/cards.json
+++ b/web/src/locales/zh/cards.json
@@ -226,7 +226,7 @@
     "console_ai_issues": "AI Issues",
     "console_ai_kubeconfig_audit": "AI Kubeconfig Audit",
     "console_ai_health_check": "AI Health Check",
-    "console_ai_offline_detection": "Predictive Health Monitor",
+    "console_ai_offline_detection": "AI Cluster Issue Predictor",
     "stock_market_ticker": "Stock Market Ticker",
     "prow_jobs": "PROW Jobs",
     "prow_status": "PROW Status",


### PR DESCRIPTION
## Summary

Two cards had confusingly similar titles:

- `predictive_health` - "**Predictive Health**" (trend-based forecasting)
- `console_ai_offline_detection` - "**Predictive Health Monitor**" (AI root-cause grouping + offline/GPU/resource detection)

Reporter (#8845) noted users could not tell them apart in card pickers and dashboards.

This PR renames the AI offline detection card title from "Predictive Health Monitor" to **"AI Cluster Issue Predictor"**:

- Leads with "AI" to highlight the distinguishing feature (LLM-driven root-cause grouping) vs. the trend-based card
- Uses "Issue" instead of "Health" to better reflect the detection + grouping semantics

## Changes

- `web/src/components/cards/cardMetadata.ts` - title constant
- `web/src/components/cards/console-missions/ConsoleOfflineDetectionCard.tsx` - file-header comment
- 9 locale `cards.json` files (en/es/fr/de/it/pt/ja/zh/hi) - none had real translations; the English string was copy-pasted across all locales, so all updated to the new English string

11 files, 11 insertions, 11 deletions.

## Test plan

- [x] All locale JSON files validate (`python3 -c "json.load(open(f))"`)
- [x] `npx tsc --noEmit` - zero errors
- [x] `npx eslint <touched files>` - no new errors (3 pre-existing errors in ConsoleOfflineDetectionCard.tsx at lines 665-669 unrelated to this change)
- [x] `grep -r "Predictive Health Monitor" web/src/` - zero matches
- [ ] Visually verify the new title appears in the card picker, on the dashboard card, and in the AI Missions panel

Fixes #8845