### PR TITLE
fix: clarify console-submitted vs GitHub-authored bug counts

### DIFF
--- a/web/src/components/feedback/UpdatesTab.tsx
+++ b/web/src/components/feedback/UpdatesTab.tsx
@@ -785,6 +785,10 @@ function GitHubContributionsSection({
       </div>
 
       {githubRewards && githubRewards.breakdown && (
+        // These badges count every issue/PR you authored across our orgs
+        // (kubestellar, llm-d) — NOT only items submitted via this console.
+        // The Rewards panel's "Submitted via console" line counts a different
+        // (smaller) population. See kubestellar/console#8893 for context.
         <div className="px-3 py-2 border-b border-border/50 flex-shrink-0">
           <div className="flex flex-wrap gap-1.5">
             {githubRewards.breakdown.prs_merged > 0 && (
@@ -798,12 +802,24 @@ function GitHubContributionsSection({
               </StatusBadge>
             )}
             {githubRewards.breakdown.bug_issues > 0 && (
-              <StatusBadge color="red" size="xs" rounded="full" icon={<Bug className="w-2.5 h-2.5" />}>
+              <StatusBadge
+                color="red"
+                size="xs"
+                rounded="full"
+                icon={<Bug className="w-2.5 h-2.5" />}
+                title="All bug-labeled GitHub issues you authored across our orgs. The Rewards panel's 'Report Bugs' counter only includes bugs submitted through this console and will be smaller."
+              >
                 {githubRewards.breakdown.bug_issues} Bugs
               </StatusBadge>
             )}
             {githubRewards.breakdown.feature_issues > 0 && (
-              <StatusBadge color="yellow" size="xs" rounded="full" icon={<Lightbulb className="w-2.5 h-2.5" />}>
+              <StatusBadge
+                color="yellow"
+                size="xs"
+                rounded="full"
+                icon={<Lightbulb className="w-2.5 h-2.5" />}
+                title="All feature-labeled GitHub issues you authored across our orgs. The Rewards panel's 'Suggest Features' counter only includes features submitted through this console and will be smaller."
+              >
                 {githubRewards.breakdown.feature_issues} Features
               </StatusBadge>
             )}

--- a/web/src/components/rewards/RewardsPanel.tsx
+++ b/web/src/components/rewards/RewardsPanel.tsx
@@ -98,7 +98,16 @@ export function RewardsPanel() {
           {/* LinkedIn Share */}
           <LinkedInShareCard />
 
-          {/* Bug Reports */}
+          {/*
+            Bug Reports / Feature Suggestions cards intentionally show
+            console-submitted counts only (sourced from local reward events).
+            This is NOT the same population as the "X Bugs" badge in the
+            Feedback → Updates tab, which counts every bug-labeled GitHub
+            issue authored by the user across our orgs (kubestellar, llm-d).
+            Tracked: kubestellar/console#8893 — the labels and tooltips
+            below make the distinction explicit so the two numbers no
+            longer look like a data inconsistency.
+          */}
           <div className="p-4 rounded-lg bg-red-500/5 border border-red-500/20">
             <div className="flex items-start gap-3">
               <div className="w-10 h-10 rounded-full bg-red-500/20 flex items-center justify-center flex-shrink-0">
@@ -112,8 +121,11 @@ export function RewardsPanel() {
                 <p className="text-sm text-muted-foreground">
                   Found a bug? Report it on GitHub to earn coins!
                 </p>
-                <p className="text-xs text-muted-foreground mt-2">
-                  Reports: {getActionCount('bug_report')}
+                <p
+                  className="text-xs text-muted-foreground mt-2"
+                  title="Bugs you submitted through this console. The 'Bugs' badge in Feedback → Updates counts every bug-labeled GitHub issue you authored across our orgs and may be larger."
+                >
+                  Submitted via console: {getActionCount('bug_report')}
                 </p>
               </div>
             </div>
@@ -133,8 +145,11 @@ export function RewardsPanel() {
                 <p className="text-sm text-muted-foreground">
                   Have an idea? Submit feature requests to earn coins!
                 </p>
-                <p className="text-xs text-muted-foreground mt-2">
-                  Suggestions: {getActionCount('feature_suggestion')}
+                <p
+                  className="text-xs text-muted-foreground mt-2"
+                  title="Features you submitted through this console. The 'Features' badge in Feedback → Updates counts every feature-labeled GitHub issue you authored across our orgs and may be larger."
+                >
+                  Submitted via console: {getActionCount('feature_suggestion')}
                 </p>
               </div>
             </div>


### PR DESCRIPTION
## Summary

Fixes #8893 — the "bug count inconsistency" between the Dashboard Rewards panel and the Feedback → Updates tab is **not a data bug**; it's two surfaces measuring genuinely different populations with the same word ("bugs").

| Surface | Source | What it actually counts |
|---|---|---|
| Rewards panel — "Reports: N" (`RewardsPanel.tsx:116`) | `getActionCount('bug_report')` over local `rewards.events` (localStorage) | Only bugs **submitted through this console UI** |
| Feedback → Updates — "X Bugs" badge (`UpdatesTab.tsx:802`) | `githubRewards.breakdown.bug_issues` from `/api/rewards/github` | **Every** bug-labeled GitHub issue the user authored across `kubestellar` + `llm-d` orgs (incl. issues opened directly on github.com long before they ever opened the console) |

The earlier fix (#7647) only patched pagination in the GitHub-side fetch, which would never have touched the local-events count. So the numbers were always destined to differ for any user with prior org activity.

## Fix

Smallest possible product fix — relabel and add tooltips so the two numbers no longer look like the same metric:

- Rewards panel: `Reports: N` → `Submitted via console: N` + `title=` tooltip explaining the Updates-tab badge will be larger
- Updates tab Bugs/Features badges: add inverse `title=` tooltip explaining the Rewards panel will be smaller
- Source comments on both files pointing at this issue so future contributors don't try to "reconcile" the counts (which would either undercount the Updates tab or overcount the Rewards panel)

No data-flow or hook changes. Same applies to the matching feature-suggestion counters.

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npx eslint <touched files>` — only pre-existing `Date.now` warning at line 577 (unrelated)
- [x] `npx vitest run` rewards + feedback suites — 70 tests pass
- [ ] Manual: hover both counters; verify tooltips render and read inversely

Fixes #8893