### PR TITLE
fix: guard notification-verified localStorage write against quota errors

### DIFF
--- a/web/src/lib/__tests__/notificationStatus.test.ts
+++ b/web/src/lib/__tests__/notificationStatus.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach} from 'vitest'
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest'
 import { isBrowserNotifVerified, setBrowserNotifVerified } from '../notificationStatus'
 
 describe('isBrowserNotifVerified', () => {
@@ -45,5 +45,37 @@ describe('setBrowserNotifVerified', () => {
     const stored = JSON.parse(localStorage.getItem('kc_browser_notif_verified')!)
     expect(stored.verified).toBe(true)
     expect(typeof stored.at).toBe('number')
+  })
+
+  it('returns true when persistence succeeds', () => {
+    expect(setBrowserNotifVerified(true)).toBe(true)
+  })
+
+  describe('when localStorage.setItem throws (#8866)', () => {
+    let setItemSpy: ReturnType<typeof vi.spyOn>
+    let warnSpy: ReturnType<typeof vi.spyOn>
+
+    beforeEach(() => {
+      setItemSpy = vi.spyOn(window.localStorage, 'setItem').mockImplementation(() => {
+        // Simulate browser quota / private-browsing failure mode
+        throw new DOMException('quota exceeded', 'QuotaExceededError')
+      })
+      warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    })
+
+    afterEach(() => {
+      setItemSpy.mockRestore()
+      warnSpy.mockRestore()
+    })
+
+    it('returns false instead of throwing', () => {
+      expect(() => setBrowserNotifVerified(true)).not.toThrow()
+      expect(setBrowserNotifVerified(true)).toBe(false)
+    })
+
+    it('logs a warning so the failure is observable', () => {
+      setBrowserNotifVerified(true)
+      expect(warnSpy).toHaveBeenCalled()
+    })
   })
 })

--- a/web/src/lib/notificationStatus.ts
+++ b/web/src/lib/notificationStatus.ts
@@ -16,7 +16,23 @@ export function isBrowserNotifVerified(): boolean {
   }
 }
 
-/** Persist whether the user has verified browser notifications */
-export function setBrowserNotifVerified(verified: boolean): void {
-  localStorage.setItem(STORAGE_KEY, JSON.stringify({ verified, at: Date.now() }))
+/**
+ * Persist whether the user has verified browser notifications.
+ * Returns true if the value was successfully written to localStorage,
+ * false if the write failed (e.g., quota exceeded, private-browsing
+ * mode, or storage disabled). Without this guard, setItem could throw
+ * uncaught — crashing the click handler — or silently appear to succeed
+ * while the value evaporates on reload (#8866).
+ */
+export function setBrowserNotifVerified(verified: boolean): boolean {
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify({ verified, at: Date.now() }))
+    return true
+  } catch (e) {
+    // Common causes: QuotaExceededError, SecurityError (private browsing
+    // with storage disabled), or browser storage policies. Log so the
+    // failure isn't completely silent for users / support.
+    console.warn('[notificationStatus] Failed to persist verification flag:', e)
+    return false
+  }
 }


### PR DESCRIPTION
## Summary

`setBrowserNotifVerified()` (used by the Active Alerts header indicator and the browser-notifications settings panel) called `localStorage.setItem` with no try/catch. When the write fails — quota exceeded, private-browsing mode with storage disabled, browser storage policies — the call either threw uncaught (crashing the click handler) or silently appeared to succeed while the value evaporated on the next reload. Either way the user sees their "verified" choice quietly revert.

This PR wraps the write in try/catch, logs a `console.warn` so the failure is observable, and returns a boolean so callers can react in the future. The change is additive: existing call sites work unchanged because they were already treating the helper as fire-and-forget — they just no longer crash.

Scope is intentionally narrow (one source file + tests). The deeper revert-optimistic-UI-on-failure work and the broader `settingsSync.ts` audit are good follow-ups; this addresses the specific crash/silent-revert path that #8866 reports.

## Files

- `web/src/lib/notificationStatus.ts` — try/catch around `setItem`, return boolean, log on failure
- `web/src/lib/__tests__/notificationStatus.test.ts` — new tests for the failure path

## Test plan

- [x] `npx tsc --noEmit` — zero errors
- [x] `npx eslint` on touched files — clean
- [x] `npx vitest run src/lib/__tests__/notificationStatus.test.ts` — 9/9 pass (3 new tests cover quota-exceeded path)
- [ ] Manual: in DevTools, monkey-patch `localStorage.setItem` to throw, click "Yes" on the notification verify flow, confirm no uncaught exception and warning logged

Fixes #8866