### PR TITLE
refactor: extract FieldSuggestChips from CardFactoryModal.tsx (#8608) [part 4]

### DIFF
--- a/web/src/components/dashboard/CardFactoryModal.tsx
+++ b/web/src/components/dashboard/CardFactoryModal.tsx
@@ -16,11 +16,11 @@ import { AiGenerationPanel } from './AiGenerationPanel'
 import { LivePreviewPanel } from './LivePreviewPanel'
 import { InlineAIAssist } from './InlineAIAssist'
 import { CARD_T1_SYSTEM_PROMPT, CARD_T2_SYSTEM_PROMPT, CARD_INLINE_ASSIST_PROMPT, CODE_INLINE_ASSIST_PROMPT } from '../../lib/ai/prompts'
-import { generateSampleData, detectFieldFormat } from '../../lib/ai/sampleData'
-import { useAIMode } from '../../hooks/useAIMode'
+import { generateSampleData } from '../../lib/ai/sampleData'
 import { wrapAbbreviations } from '../shared/TechnicalAcronym'
 import { T1_TEMPLATES, type T1Template } from './cardFactoryTemplates'
 import { TemplateDropdown, T1Preview, T2Preview } from './cardFactoryPreviews'
+import { FieldSuggestChips } from './FieldSuggestChips'
 import {
   validateT1Result,
   validateT2Result,
@@ -543,71 +543,6 @@ const T2_TEMPLATES: T2Template[] = [
   )
 }` },
 ]
-
-// ============================================================================
-// Field Auto-Suggest Chips
-// ============================================================================
-
-function FieldSuggestChips({
-  dataJson,
-  existingFields,
-  onAddColumn }: {
-  dataJson: string
-  existingFields: Set<string>
-  onAddColumn: (col: DynamicCardColumn) => void
-}) {
-  const { isFeatureEnabled } = useAIMode()
-  const enabled = isFeatureEnabled('naturalLanguage')
-
-  const suggestedFields = useMemo(() => {
-    if (!enabled) return []
-    try {
-      const parsed = JSON.parse(dataJson)
-      if (!Array.isArray(parsed) || parsed.length === 0) return []
-      const allKeys = new Set<string>()
-      for (const row of parsed.slice(0, 10)) {
-        if (typeof row === 'object' && row) {
-          Object.keys(row).forEach(k => allKeys.add(k))
-        }
-      }
-      return [...allKeys].filter(k => !existingFields.has(k))
-    } catch {
-      return []
-    }
-  }, [dataJson, existingFields, enabled])
-
-  if (!enabled || suggestedFields.length === 0) return null
-
-  return (
-    <div className="flex items-center gap-1.5 flex-wrap">
-      <span className="text-xs text-muted-foreground/50">Fields:</span>
-      {suggestedFields.map(field => {
-        const sampleValues = (() => {
-          try {
-            const parsed = JSON.parse(dataJson)
-            return parsed.slice(0, 5).map((row: Record<string, unknown>) => row[field])
-          } catch { return [] }
-        })()
-        const detected = detectFieldFormat(field, sampleValues)
-
-        return (
-          <button
-            key={field}
-            onClick={() => onAddColumn({
-              field,
-              label: field.charAt(0).toUpperCase() + field.slice(1).replace(/([A-Z])/g, ' $1'),
-              format: detected.format,
-              badgeColors: detected.badgeColors,
-            })}
-            className="text-xs px-1.5 py-0.5 rounded bg-purple-500/10 text-purple-400/70 hover:bg-purple-500/20 hover:text-purple-400 transition-colors"
-          >
-            + {field}
-          </button>
-        )
-      })}
-    </div>
-  )
-}
 
 // ============================================================================
 // Inline AI Assist Result Types

--- a/web/src/components/dashboard/FieldSuggestChips.tsx
+++ b/web/src/components/dashboard/FieldSuggestChips.tsx
@@ -1,0 +1,73 @@
+import { useMemo } from 'react'
+import { detectFieldFormat } from '../../lib/ai/sampleData'
+import { useAIMode } from '../../hooks/useAIMode'
+import type { DynamicCardColumn } from '../../lib/dynamic-cards/types'
+
+interface FieldSuggestChipsProps {
+  dataJson: string
+  existingFields: Set<string>
+  onAddColumn: (col: DynamicCardColumn) => void
+}
+
+/**
+ * Renders a row of "+ field" chips suggesting columns to add to a T1 card,
+ * derived from the JSON sample data the author has supplied. Hidden when the
+ * naturalLanguage AI feature is disabled or no novel fields are present.
+ */
+export function FieldSuggestChips({
+  dataJson,
+  existingFields,
+  onAddColumn,
+}: FieldSuggestChipsProps) {
+  const { isFeatureEnabled } = useAIMode()
+  const enabled = isFeatureEnabled('naturalLanguage')
+
+  const suggestedFields = useMemo(() => {
+    if (!enabled) return []
+    try {
+      const parsed = JSON.parse(dataJson)
+      if (!Array.isArray(parsed) || parsed.length === 0) return []
+      const allKeys = new Set<string>()
+      for (const row of parsed.slice(0, 10)) {
+        if (typeof row === 'object' && row) {
+          Object.keys(row).forEach(k => allKeys.add(k))
+        }
+      }
+      return [...allKeys].filter(k => !existingFields.has(k))
+    } catch {
+      return []
+    }
+  }, [dataJson, existingFields, enabled])
+
+  if (!enabled || suggestedFields.length === 0) return null
+
+  return (
+    <div className="flex items-center gap-1.5 flex-wrap">
+      <span className="text-xs text-muted-foreground/50">Fields:</span>
+      {suggestedFields.map(field => {
+        const sampleValues = (() => {
+          try {
+            const parsed = JSON.parse(dataJson)
+            return parsed.slice(0, 5).map((row: Record<string, unknown>) => row[field])
+          } catch { return [] }
+        })()
+        const detected = detectFieldFormat(field, sampleValues)
+
+        return (
+          <button
+            key={field}
+            onClick={() => onAddColumn({
+              field,
+              label: field.charAt(0).toUpperCase() + field.slice(1).replace(/([A-Z])/g, ' $1'),
+              format: detected.format,
+              badgeColors: detected.badgeColors,
+            })}
+            className="text-xs px-1.5 py-0.5 rounded bg-purple-500/10 text-purple-400/70 hover:bg-purple-500/20 hover:text-purple-400 transition-colors"
+          >
+            + {field}
+          </button>
+        )
+      })}
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary

Continues the bounded extractions from `CardFactoryModal.tsx` started in #8834 (T1_TEMPLATES), #8838 (AI result types), and #8861 (T1Preview/T2Preview/TemplateDropdown).

This part lifts the `FieldSuggestChips` inline subcomponent — the row of `+ field` chips that proposes new T1 columns based on the JSON sample data the author has supplied — into its own sibling file, mirroring the structure of `cardFactoryPreviews.tsx` and `cardFactoryAiTypes.ts`.

Pure code movement; zero behavior change.

### Changes
- **New:** `web/src/components/dashboard/FieldSuggestChips.tsx` (73 LOC)
- `CardFactoryModal.tsx`: **1448 -> 1383 lines** (-65)
- Drop now-unused `detectFieldFormat` and `useAIMode` imports from CFM

### Verification
- `npx tsc --noEmit`: clean (zero errors)
- `eslint FieldSuggestChips.tsx`: clean
- `eslint CardFactoryModal.tsx`: same 1 pre-existing error + 11 pre-existing warnings as on `main` (no new lint regressions)
- `vitest` against the 4 CardFactoryModal-touching tests: **28 passed**

## Test plan
- [x] tsc passes
- [x] eslint shows no new errors/warnings vs main
- [x] CardFactoryModal-related vitest suites pass (28/28)
- [ ] CI build/lint/preview green

Refs #8608