### PR TITLE
fix: support Cmd/Ctrl+Enter to submit bug report modal

### DIFF
--- a/web/src/components/feedback/SubmitTab.tsx
+++ b/web/src/components/feedback/SubmitTab.tsx
@@ -461,6 +461,15 @@ export function SubmitForm({
               value={description}
               onChange={e => setDescription(e.target.value)}
               onPaste={handlePaste}
+              onKeyDown={e => {
+                // Cmd+Enter (Mac) / Ctrl+Enter (Win/Linux) submits the form,
+                // matching the convention used by GitHub, Slack, and other
+                // compose-style modals. See issue #8651.
+                if ((e.metaKey || e.ctrlKey) && e.key === 'Enter' && !isSubmitting) {
+                  e.preventDefault()
+                  e.currentTarget.form?.requestSubmit()
+                }
+              }}
               placeholder={
                 requestType === 'bug'
                   ? 'Example bug report: (replace this with a detailed bug report)\n\nWhat happened:\nThe GPU utilization card shows 0% even though pods are running.\n\nWhat I expected:\nGPU metrics should reflect actual usage from nvidia-smi.\n\nSteps to reproduce:\n1. Deploy a GPU workload\n2. Open the dashboard\n3. Check the GPU card'
@@ -481,7 +490,8 @@ export function SubmitForm({
             </div>
           )}
           <p className="text-2xs text-muted-foreground mt-1">
-            First line becomes the title. Add details below.
+            First line becomes the title. Add details below.{' '}
+            <span className="text-muted-foreground/70">{t('feedback.submitShortcutHint')}</span>
           </p>
         </div>
 

--- a/web/src/locales/en/common.json
+++ b/web/src/locales/en/common.json
@@ -1852,6 +1852,7 @@
     "submitFailed": "Unable to submit — GitHub login may be required.",
     "submitFailedGuidance": "You can open issues directly on GitHub. Coins will be accumulated and available in your console once you install a GitHub OAuth app.",
     "submitInfo": "Your request will be reviewed by a maintainer before being analyzed by our AI. Once approved, the AI will attempt to create a fix automatically and you'll receive a notification when ready.",
+    "submitShortcutHint": "Press Cmd/Ctrl+Enter to submit.",
     "loginBannerDemo": "Login with GitHub to submit feedback and manage requests",
     "loginBannerLocal": "Set up GitHub OAuth to submit feedback, earn coins, and track requests",
     "requestSubmitted": "Request Submitted!",


### PR DESCRIPTION
## Summary
- Add `onKeyDown` handler to the bug-report description textarea so Cmd+Enter (Mac) / Ctrl+Enter (Win/Linux) submits the form, matching the convention used by GitHub, Slack, and other compose-style modals.
- Add a small discoverability hint (`Press Cmd/Ctrl+Enter to submit.`) below the textarea, wrapped in `t()` for i18n.
- Guarded against firing while `isSubmitting` is true so a double-press cannot double-submit.

Fixes #8651

## Test plan
- [x] `npx tsc --noEmit` — zero errors
- [x] `npx eslint` on touched files — no new errors (only pre-existing `no-restricted-syntax` warnings on the raw `<textarea>` / `<input>`)
- [x] `npx vitest run src/components/feedback/FeedbackModal.test.tsx` — passes
- [x] `npm run build` — succeeds, all post-build safety checks pass
- [ ] Manual: open Feedback modal, type a title + description, press Cmd+Enter on Mac (or Ctrl+Enter on Win/Linux), verify form submits exactly once