### PR TITLE
fix: subscribe FluentdStatus to demo mode toggle

### DIFF
--- a/web/src/components/cards/fluentd_status/useFluentdStatus.ts
+++ b/web/src/components/cards/fluentd_status/useFluentdStatus.ts
@@ -1,5 +1,6 @@
 import { useCache } from '../../../lib/cache'
 import { useCardLoadingState } from '../CardDataContext'
+import { useDemoMode } from '../../../hooks/useDemoMode'
 import { FLUENTD_DEMO_DATA, type FluentdDemoData } from './demoData'
 import { FETCH_DEFAULT_TIMEOUT_MS } from '../../../lib/constants'
 import { authFetch } from '../../../lib/api'
@@ -302,7 +303,13 @@ export interface UseFluentdStatusResult {
 }
 
 export function useFluentdStatus(): UseFluentdStatusResult {
-  const { data, isLoading, isRefreshing, isFailed, consecutiveFailures, isDemoFallback } =
+  // #8836: subscribe to demo mode toggles so the card swaps to demo data
+  // immediately (and shows the Demo badge / yellow outline) when the user
+  // flips demo mode on, instead of only switching when the cache layer falls
+  // back after a fetch failure.
+  const { isDemoMode } = useDemoMode()
+
+  const { data: liveData, isLoading, isRefreshing, isFailed, consecutiveFailures, isDemoFallback } =
     useCache<FluentdStatus>({
       key: CACHE_KEY,
       category: 'default',
@@ -312,11 +319,12 @@ export function useFluentdStatus(): UseFluentdStatusResult {
       fetcher: fetchFluentdStatus,
     })
 
-  const effectiveIsDemoData = isDemoFallback && !isLoading
+  const data = isDemoMode ? FLUENTD_DEMO_DATA : liveData
+  const effectiveIsDemoData = isDemoMode || (isDemoFallback && !isLoading)
   const hasAnyData = (data.pods?.total ?? 0) > 0
 
   const { showSkeleton, showEmptyState } = useCardLoadingState({
-    isLoading,
+    isLoading: isLoading && !isDemoMode,
     isRefreshing,
     hasAnyData,
     isFailed,
@@ -326,10 +334,10 @@ export function useFluentdStatus(): UseFluentdStatusResult {
 
   return {
     data,
-    loading: isLoading,
+    loading: isLoading && !isDemoMode,
     isRefreshing,
-    isDemoFallback,
-    error: isFailed && !hasAnyData,
+    isDemoFallback: effectiveIsDemoData,
+    error: isFailed && !hasAnyData && !isDemoMode,
     consecutiveFailures,
     showSkeleton,
     showEmptyState,


### PR DESCRIPTION
## Summary

Targeted partial fix for the FluentdStatus card finding from Auto-QA #8836 ("stale data and freshness indicator issues").

The Fluentd status card's data hook only honored the cache layer's `isDemoFallback` flag, which is only set when a fetch fails. It did not subscribe to the global demo-mode toggle, so flipping demo mode on did not swap the card to demo data and the Demo badge / yellow outline did not appear.

`useFluentdStatus` now calls `useDemoMode()`:

- When demo mode is on, the hook returns `FLUENTD_DEMO_DATA` directly.
- `isDemoMode` is OR'd into the `isDemoData` flag passed to `useCardLoadingState`, matching the pattern used by `StorageOverview`, `PVCStatus`, `ClusterHealth`, and other sibling cards.
- `isLoading` and the error gate are suppressed in demo mode so the card never shows a skeleton or error state for synthetic data.

Single-file change, ~14 lines added.

## Verification

- `npx tsc --noEmit` — 0 errors
- `npx eslint src/components/cards/fluentd_status/useFluentdStatus.ts` — clean
- `npx vitest run src/components/cards/fluentd_status` — 7/7 tests pass

## Follow-up

Auto-QA #8836 lists more cards. Per prior scanner investigation:

- `KagentTopology` was a false positive (already wires demo mode).
- `KedaStatus` is the next confirmed true positive and a good candidate for a follow-up PR using the same pattern applied here.

Addresses #8836