### PR TITLE
fix: keyboard navigation for 3 list-style cards (partial #8883)

### DIFF
--- a/web/src/components/cards/KustomizationStatus.tsx
+++ b/web/src/components/cards/KustomizationStatus.tsx
@@ -343,23 +343,49 @@ export function KustomizationStatus({ config }: KustomizationStatusProps) {
             </div>
           </div>
 
-          {/* Kustomizations list */}
-          <div ref={containerRef} className="flex-1 space-y-2 overflow-y-auto" style={containerStyle}>
+          {/* Kustomizations list — #8883: roving-tabindex keyboard nav.
+              Arrow Up/Down moves focus, Home/End jumps to ends, Enter/Space drills in. */}
+          <div ref={containerRef} className="flex-1 space-y-2 overflow-y-auto" style={containerStyle} role="list">
             {kustomizations.map((ks, idx) => {
               const StatusIcon = getStatusIcon(ks.status)
               const color = getStatusColor(ks.status)
+              const activate = () => drillToKustomization(selectedCluster, ks.namespace, ks.name, {
+                path: ks.path,
+                sourceRef: ks.sourceRef,
+                status: ks.status,
+                lastApplied: ks.lastApplied,
+                revision: ks.revision })
+              const handleKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
+                const list = e.currentTarget.parentElement
+                const items = list ? Array.from(list.querySelectorAll<HTMLDivElement>('[data-keynav-item="kustomization"]')) : []
+                if (e.key === 'Enter' || e.key === ' ') {
+                  e.preventDefault()
+                  activate()
+                } else if (e.key === 'ArrowDown' && idx < kustomizations.length - 1) {
+                  e.preventDefault()
+                  items[idx + 1]?.focus()
+                } else if (e.key === 'ArrowUp' && idx > 0) {
+                  e.preventDefault()
+                  items[idx - 1]?.focus()
+                } else if (e.key === 'Home') {
+                  e.preventDefault()
+                  items[0]?.focus()
+                } else if (e.key === 'End') {
+                  e.preventDefault()
+                  items[items.length - 1]?.focus()
+                }
+              }
 
               return (
                 <div
                   key={idx}
-                  onClick={() => drillToKustomization(selectedCluster, ks.namespace, ks.name, {
-                    path: ks.path,
-                    sourceRef: ks.sourceRef,
-                    status: ks.status,
-                    lastApplied: ks.lastApplied,
-                    revision: ks.revision })}
-                  className={`p-3 rounded-lg cursor-pointer group ${ks.status === 'NotReady' ? 'bg-red-500/10 border border-red-500/20' : 'bg-secondary/30'} hover:bg-secondary/50 transition-colors`}
-                  title={`Click to view ${ks.name} details`}
+                  data-keynav-item="kustomization"
+                  role="button"
+                  tabIndex={0}
+                  onClick={activate}
+                  onKeyDown={handleKeyDown}
+                  className={`p-3 rounded-lg cursor-pointer group ${ks.status === 'NotReady' ? 'bg-red-500/10 border border-red-500/20' : 'bg-secondary/30'} hover:bg-secondary/50 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-cyan-400`}
+                  title={`Click or press Enter to view ${ks.name} details`}
                 >
                   <div className="flex flex-wrap items-center justify-between gap-y-2 mb-1">
                     <div className="flex items-center gap-2">

--- a/web/src/components/cards/NetworkOverview.tsx
+++ b/web/src/components/cards/NetworkOverview.tsx
@@ -308,15 +308,47 @@ export function NetworkOverview() {
       {stats.namespaces.length > 0 && (
         <div className="flex-1">
           <div className="text-xs text-muted-foreground mb-2">Top Namespaces</div>
-          <div className="space-y-1.5">
-            {stats.namespaces.slice(0, 5).map(([name, count]) => {
+          {/* #8883: Top Namespaces is a roving-tabindex list; arrow keys
+              traverse siblings, Home/End jump to ends, Enter/Space activate. */}
+          <div className="space-y-1.5" role="list">
+            {stats.namespaces.slice(0, 5).map(([name, count], idx, arr) => {
               const svc = filteredServices.find(s => s.namespace === name)
+              const isInteractive = !!(svc?.cluster && svc?.namespace)
+              const activate = () => {
+                if (svc?.cluster && svc?.namespace) {
+                  drillToService(svc.cluster, svc.namespace, svc.name)
+                }
+              }
+              const handleKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
+                if (!isInteractive) return
+                const list = e.currentTarget.parentElement
+                const items = list ? Array.from(list.querySelectorAll<HTMLDivElement>('[data-keynav-item="namespace"]')) : []
+                if (e.key === 'Enter' || e.key === ' ') {
+                  e.preventDefault()
+                  activate()
+                } else if (e.key === 'ArrowDown' && idx < arr.length - 1) {
+                  e.preventDefault()
+                  items[idx + 1]?.focus()
+                } else if (e.key === 'ArrowUp' && idx > 0) {
+                  e.preventDefault()
+                  items[idx - 1]?.focus()
+                } else if (e.key === 'Home') {
+                  e.preventDefault()
+                  items[0]?.focus()
+                } else if (e.key === 'End') {
+                  e.preventDefault()
+                  items[items.length - 1]?.focus()
+                }
+              }
               return (
                 <div
                   key={name}
-                  className={`flex flex-wrap items-center justify-between gap-y-2 gap-2 p-2 rounded bg-secondary/30 ${svc ? 'cursor-pointer hover:bg-secondary/50' : 'cursor-default'} transition-colors`}
-                  onClick={() => svc?.cluster && svc?.namespace && drillToService(svc.cluster, svc.namespace, svc.name)}
-                  title={`${count} service${count !== 1 ? 's' : ''} in namespace ${name}${svc ? ' - Click to view' : ''}`}
+                  data-keynav-item="namespace"
+                  className={`flex flex-wrap items-center justify-between gap-y-2 gap-2 p-2 rounded bg-secondary/30 ${isInteractive ? 'cursor-pointer hover:bg-secondary/50' : 'cursor-default'} transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-cyan-400`}
+                  onClick={activate}
+                  onKeyDown={handleKeyDown}
+                  {...(isInteractive ? { role: 'button' as const, tabIndex: 0 } : { role: 'listitem' as const })}
+                  title={`${count} service${count !== 1 ? 's' : ''} in namespace ${name}${isInteractive ? ' - Click or press Enter to view' : ''}`}
                 >
                   <span className="text-sm text-foreground truncate min-w-0 flex-1">{name}</span>
                   <span className="text-xs text-muted-foreground shrink-0">{count} services</span>

--- a/web/src/components/cards/OperatorStatus.tsx
+++ b/web/src/components/cards/OperatorStatus.tsx
@@ -266,19 +266,49 @@ function OperatorStatusInternal({ config: _config }: OperatorStatusProps) {
           </div>
 
           {/* Operators list */}
-          <div ref={containerRef} className="flex-1 space-y-2 overflow-y-auto" style={containerStyle}>
-            {operators.map((op) => {
+          <div ref={containerRef} className="flex-1 space-y-2 overflow-y-auto" style={containerStyle} role="list">
+            {operators.map((op, idx) => {
               const StatusIcon = getStatusIcon(op.status)
               const color = getStatusColor(op.status)
+              const activate = () => {
+                if (op.cluster) {
+                  drillToOperator(op.cluster, op.namespace, op.name, {
+                    status: op.status,
+                    version: op.version,
+                    upgradeAvailable: op.upgradeAvailable })
+                }
+              }
+              // #8883: roving-tabindex keyboard nav for the operators list.
+              const handleKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
+                const list = e.currentTarget.parentElement
+                const items = list ? Array.from(list.querySelectorAll<HTMLDivElement>('[data-keynav-item="operator"]')) : []
+                if (e.key === 'Enter' || e.key === ' ') {
+                  e.preventDefault()
+                  activate()
+                } else if (e.key === 'ArrowDown' && idx < operators.length - 1) {
+                  e.preventDefault()
+                  items[idx + 1]?.focus()
+                } else if (e.key === 'ArrowUp' && idx > 0) {
+                  e.preventDefault()
+                  items[idx - 1]?.focus()
+                } else if (e.key === 'Home') {
+                  e.preventDefault()
+                  items[0]?.focus()
+                } else if (e.key === 'End') {
+                  e.preventDefault()
+                  items[items.length - 1]?.focus()
+                }
+              }
 
               return (
                 <div
                   key={`${op.cluster || 'unknown'}-${op.namespace}-${op.name}`}
-                  onClick={() => op.cluster && drillToOperator(op.cluster, op.namespace, op.name, {
-                    status: op.status,
-                    version: op.version,
-                    upgradeAvailable: op.upgradeAvailable })}
-                  className="p-3 rounded-lg bg-secondary/30 hover:bg-secondary/50 transition-colors cursor-pointer group"
+                  data-keynav-item="operator"
+                  role="button"
+                  tabIndex={0}
+                  onClick={activate}
+                  onKeyDown={handleKeyDown}
+                  className="p-3 rounded-lg bg-secondary/30 hover:bg-secondary/50 transition-colors cursor-pointer group focus:outline-none focus-visible:ring-2 focus-visible:ring-cyan-400"
                 >
                   <div className="flex flex-wrap items-center justify-between gap-y-2">
                     <div className="flex items-center gap-2">


### PR DESCRIPTION
## Summary

Targeted partial fix for the Auto-QA keyboard-nav gaps in #8883. Adds roving-tabindex keyboard navigation to clickable list items in three K-U cards:

- **`NetworkOverview.tsx`** — Top Namespaces list
- **`KustomizationStatus.tsx`** — Kustomizations list
- **`OperatorStatus.tsx`** — Operators list

Each list item now supports:
- `role="button"` + `tabIndex={0}` for screen readers and Tab traversal
- **Enter / Space** — activate (drill-down)
- **ArrowUp / ArrowDown** — move focus between siblings
- **Home / End** — jump to first / last item
- `focus-visible:ring-2 ring-cyan-400` for visible keyboard focus

Container `<div>`s gain `role="list"` so the list semantics are exposed to AT.

Existing mouse behavior (onClick, cursor-pointer, hover) is unchanged.

## Scope

Partial — closes some of the keyboard-nav findings in #8883. Cards starting with A/B/C/H were intentionally left untouched to avoid conflict with the parallel #8884 ARIA-gaps work. Other K-U cards with similar gaps (e.g. `NamespaceMonitor`, `OPAPolicies`, `NamespaceQuotas`) remain as follow-ups.

## Test plan

- [x] `npx tsc --noEmit` — zero errors
- [x] `npx eslint` on touched files — no new errors (pre-existing 2 errors / 2 warnings in `KustomizationStatus.tsx` are unchanged)
- [x] `npx vitest run` on `KustomizationStatus.test.tsx` and `NetworkOverview.test.tsx` — 23/23 passing
- [ ] Manual: Tab into the three cards, arrow through items, press Enter to drill in
- [ ] Screen reader: announce items as buttons within a list

Addresses #8883