### PR TITLE
fix: add aria-label to icon-only buttons on 3 cards

### DIFF
--- a/web/src/components/cards/ClusterGroups.tsx
+++ b/web/src/components/cards/ClusterGroups.tsx
@@ -359,6 +359,7 @@ function DroppableGroup({ group, isExpanded, clusterHealthMap, onToggle, onEdit,
             onClick={onEdit}
             className="p-1 rounded hover:bg-gray-900/10 dark:hover:bg-white/10 text-muted-foreground hover:text-foreground transition-colors"
             title={t('cards:clusterGroups.editGroup')}
+            aria-label={t('cards:clusterGroups.editGroup')}
           >
             <Edit2 className="w-3 h-3" />
           </button>
@@ -366,6 +367,7 @@ function DroppableGroup({ group, isExpanded, clusterHealthMap, onToggle, onEdit,
             onClick={onDelete}
             className="p-1 rounded hover:bg-red-500/20 text-muted-foreground hover:text-red-400 transition-colors"
             title={t('cards:clusterGroups.deleteGroup')}
+            aria-label={t('cards:clusterGroups.deleteGroup')}
           >
             <Trash2 className="w-3 h-3" />
           </button>

--- a/web/src/components/cards/HardwareHealthCard.tsx
+++ b/web/src/components/cards/HardwareHealthCard.tsx
@@ -545,7 +545,9 @@ export function HardwareHealthCard() {
                     ? 'bg-yellow-500/20 text-yellow-400'
                     : 'bg-muted/30 text-muted-foreground hover:text-foreground'
                 )}
-                title={showSnoozed ? 'Hide snoozed alerts' : 'Show snoozed alerts'}
+                title={showSnoozed ? t('cards:hardwareHealth.hideSnoozedAlerts') : t('cards:hardwareHealth.showSnoozedAlerts')}
+                aria-label={showSnoozed ? t('cards:hardwareHealth.hideSnoozedAlerts') : t('cards:hardwareHealth.showSnoozedAlerts')}
+                aria-pressed={showSnoozed}
               >
                 <BellOff className="w-3.5 h-3.5" />
                 <span className="font-medium">{snoozedAlertCount}</span>
@@ -558,7 +560,10 @@ export function HardwareHealthCard() {
                 <button
                   onClick={() => setSnoozeAllMenuOpen(!snoozeAllMenuOpen)}
                   className="p-1.5 text-muted-foreground hover:text-foreground hover:bg-muted/50 rounded-md transition-colors"
-                  title="Snooze all visible alerts"
+                  title={t('cards:hardwareHealth.snoozeAllVisible')}
+                  aria-label={t('cards:hardwareHealth.snoozeAllVisible')}
+                  aria-haspopup="menu"
+                  aria-expanded={snoozeAllMenuOpen}
                 >
                   <MoreVertical className="w-4 h-4" />
                 </button>

--- a/web/src/components/cards/IframeEmbed.tsx
+++ b/web/src/components/cards/IframeEmbed.tsx
@@ -195,6 +195,7 @@ export function IframeEmbed({ config }: { config?: IframeEmbedConfig }) {
                   onClick={openInNewTab}
                   className="p-1 hover:bg-secondary rounded text-muted-foreground hover:text-foreground"
                   title={t('cards:iframeEmbed.openInNewTab')}
+                  aria-label={t('cards:iframeEmbed.openInNewTab')}
                 >
                   <ExternalLink className="w-4 h-4" />
                 </button>
@@ -208,6 +209,8 @@ export function IframeEmbed({ config }: { config?: IframeEmbedConfig }) {
                   : 'hover:bg-secondary text-muted-foreground hover:text-foreground'
               }`}
               title={t('cards:iframeEmbed.settings')}
+              aria-label={t('cards:iframeEmbed.settings')}
+              aria-expanded={showSettings}
             >
               <Settings className="w-4 h-4" />
             </button>
@@ -223,6 +226,7 @@ export function IframeEmbed({ config }: { config?: IframeEmbedConfig }) {
                 <button
                   onClick={() => setShowSettings(false)}
                   className="p-1 rounded hover:bg-secondary text-muted-foreground"
+                  aria-label={t('cards:iframeEmbed.closeSettingsAria')}
                 >
                   <X className="w-4 h-4" />
                 </button>

--- a/web/src/locales/en/cards.json
+++ b/web/src/locales/en/cards.json
@@ -1089,7 +1089,10 @@
     "infiniband": "InfiniBand",
     "monitoring": "Monitoring",
     "deviceDisappearances": "Device Disappearances",
-    "noDevicesDetected": "No devices detected"
+    "noDevicesDetected": "No devices detected",
+    "hideSnoozedAlerts": "Hide snoozed alerts",
+    "showSnoozedAlerts": "Show snoozed alerts",
+    "snoozeAllVisible": "Snooze all visible alerts"
   },
   "networkOverview": {
     "policies": "Policies",
@@ -3346,7 +3349,8 @@
     "noUrlConfigured": "No URL configured",
     "clickSettings": "Click settings to add a URL",
     "autoRefreshEvery": "Auto-refreshes every {{seconds}}s",
-    "titlePlaceholder": "My Dashboard"
+    "titlePlaceholder": "My Dashboard",
+    "closeSettingsAria": "Close settings"
   },
   "namespaceOverview": {
     "noNamespaces": "No namespaces",


### PR DESCRIPTION
Addresses #8884 — partial progress on Auto-QA ARIA label gaps.

## What

Adds `aria-label` (and where applicable `aria-expanded` / `aria-pressed` / `aria-haspopup`) to icon-only buttons that previously relied on `title` only or had no accessible name at all.

## Cards changed

| Card | What was missing |
|---|---|
| `IframeEmbed.tsx` | close-settings X (no name), open-in-new-tab + settings toggle (`title` only) |
| `ClusterGroups.tsx` | edit + delete group icon buttons (`title` only) |
| `HardwareHealthCard.tsx` | snooze-toggle + snooze-all menu trigger (also replaces two hardcoded English `title` strings with i18n keys) |

New keys in `web/src/locales/en/cards.json`:
- `iframeEmbed.closeSettingsAria`
- `hardwareHealth.hideSnoozedAlerts`, `hardwareHealth.showSnoozedAlerts`, `hardwareHealth.snoozeAllVisible`

## What's left for follow-up

The Auto-QA scanner reported 10 `role="button"` findings and 2 icon-only-button findings. Most of the `role="button"` findings are **false positives** — the flagged elements (in `ArgoCDApplications`, `ComplianceCards`, `ComplianceDrift`, `KyvernoPolicies`, `CrossClusterPolicyComparison`, `Missions`, `WorkloadDeployment`) already carry `aria-label` 1–2 lines after `role="button"`, but the scanner regex doesn't span multi-line JSX. Worth tightening the scanner heuristic in a separate change.

Real remaining gaps for follow-up PRs:
- `StatBlockFactoryModal.tsx:502` (icon-only)
- `ClusterCosts.tsx:679` already has `aria-label` (false positive)
- The four "modal without `role=\"dialog\"`" findings — `RSSFeed`, `GPUTaintFilter`, `NightlyE2EStatus`, `PortalTooltip` — are also false positives (those files don't contain inline modal markup; they import shared modal components).

Issue stays open intentionally.

## Test plan
- [x] `npx tsc --noEmit` — zero errors
- [x] `npx eslint` on touched files — no new errors (10 pre-existing errors unchanged)
- [x] `npx vitest run` on `IframeEmbed.test.tsx` + `ClusterGroups.test.tsx` — 9/9 pass
- [x] JSON validity check on `cards.json`