### PR TITLE
refactor: extract InlineAIAssist result types from CardFactoryModal.tsx (#8608) [part 5]

### DIFF
--- a/web/src/components/dashboard/CardFactoryModal.tsx
+++ b/web/src/components/dashboard/CardFactoryModal.tsx
@@ -27,6 +27,11 @@ import {
   type AiCardT1Result,
   type AiCardT2Result,
   type AiMode } from './cardFactoryAiTypes'
+import {
+  validateT1AssistResult,
+  validateT2AssistResult,
+  type T1AssistResult,
+  type T2AssistResult } from './cardFactoryAssistTypes'
 
 interface CardFactoryModalProps {
   isOpen: boolean
@@ -543,38 +548,6 @@ const T2_TEMPLATES: T2Template[] = [
   )
 }` },
 ]
-
-// ============================================================================
-// Inline AI Assist Result Types
-// ============================================================================
-
-interface T1AssistResult {
-  title?: string
-  description?: string
-  layout?: 'list' | 'stats' | 'stats-and-list'
-  width?: number
-  columns?: DynamicCardColumn[]
-  data?: Record<string, unknown>[]
-}
-
-interface T2AssistResult {
-  title?: string
-  description?: string
-  width?: number
-  sourceCode?: string
-}
-
-function validateT1AssistResult(data: unknown): { valid: true; result: T1AssistResult } | { valid: false; error: string } {
-  const obj = data as Record<string, unknown>
-  if (!obj.columns && !obj.data && !obj.title) return { valid: false, error: 'Response must include title, columns, or data' }
-  return { valid: true, result: obj as T1AssistResult }
-}
-
-function validateT2AssistResult(data: unknown): { valid: true; result: T2AssistResult } | { valid: false; error: string } {
-  const obj = data as Record<string, unknown>
-  if (!obj.sourceCode && !obj.title) return { valid: false, error: 'Response must include sourceCode or title' }
-  return { valid: true, result: obj as T2AssistResult }
-}
 
 // ============================================================================
 // Main Component

--- a/web/src/components/dashboard/cardFactoryAssistTypes.ts
+++ b/web/src/components/dashboard/cardFactoryAssistTypes.ts
@@ -1,0 +1,39 @@
+import type { DynamicCardColumn } from '../../lib/dynamic-cards/types'
+
+// ============================================================================
+// Inline AI Assist Result Types
+// ============================================================================
+//
+// Types and validators for partial card edits returned by the InlineAIAssist
+// component. These are the smaller siblings of the full AiCardT1Result /
+// AiCardT2Result types in cardFactoryAiTypes.ts — assist responses can omit
+// most fields, since they patch an in-progress card definition rather than
+// replacing it.
+
+export interface T1AssistResult {
+  title?: string
+  description?: string
+  layout?: 'list' | 'stats' | 'stats-and-list'
+  width?: number
+  columns?: DynamicCardColumn[]
+  data?: Record<string, unknown>[]
+}
+
+export interface T2AssistResult {
+  title?: string
+  description?: string
+  width?: number
+  sourceCode?: string
+}
+
+export function validateT1AssistResult(data: unknown): { valid: true; result: T1AssistResult } | { valid: false; error: string } {
+  const obj = data as Record<string, unknown>
+  if (!obj.columns && !obj.data && !obj.title) return { valid: false, error: 'Response must include title, columns, or data' }
+  return { valid: true, result: obj as T1AssistResult }
+}
+
+export function validateT2AssistResult(data: unknown): { valid: true; result: T2AssistResult } | { valid: false; error: string } {
+  const obj = data as Record<string, unknown>
+  if (!obj.sourceCode && !obj.title) return { valid: false, error: 'Response must include sourceCode or title' }
+  return { valid: true, result: obj as T2AssistResult }
+}


### PR DESCRIPTION
## Summary

Fifth bounded extraction from `web/src/components/dashboard/CardFactoryModal.tsx` (scanner bead `scanner-beads-9fp`, tracked by #8608).

Move the `T1AssistResult` / `T2AssistResult` interfaces and their `validateT1AssistResult` / `validateT2AssistResult` helpers out of `CardFactoryModal.tsx` and into a new sibling module `cardFactoryAssistTypes.ts`.

These mirror the pattern established in #8838, which extracted the larger `AiCardT1Result` / `AiCardT2Result` types into `cardFactoryAiTypes.ts`. The Assist types are the partial-edit siblings: they describe responses from `InlineAIAssist` (which patches an in-progress card) rather than `AiGenerationPanel` (which generates a full card definition).

## Prior extractions (all landed)
- #8834: `T1_TEMPLATES` + `T1Template` (106 LOC) -> `cardFactoryTemplates.ts`
- #8838: `AiCardT1/T2Result` types + validators (31 LOC) -> `cardFactoryAiTypes.ts`
- #8861: `T1Preview` / `T2Preview` / `TemplateDropdown` (108 LOC) -> `cardFactoryPreviews.tsx`
- #8898: `FieldSuggestChips` subcomponent (65 LOC) -> `FieldSuggestChips.tsx`

## Stats
- Net change in `CardFactoryModal.tsx`: -27 LOC (1383 -> 1356)
- New file: 39 LOC

## Verification
- `npx tsc --noEmit` -> zero errors
- `npx eslint` on touched files -> output unchanged from `main` (same 1 pre-existing error + 11 pre-existing warnings, all in code not touched by this PR)
- `npx vitest run` on the 4 test files that touch `CardFactoryModal` -> 28/28 pass

## Test plan
- [ ] CI build/lint passes
- [ ] CardFactoryModal still renders and the inline AI assist still patches T1/T2 fields end-to-end (no behavior change)

Refs #8608