### PR TITLE
fix: subscribe KedaStatus to demo mode toggles

### DIFF
--- a/web/src/components/cards/keda_status/useKedaStatus.ts
+++ b/web/src/components/cards/keda_status/useKedaStatus.ts
@@ -1,5 +1,6 @@
 import { useCache } from '../../../lib/cache'
 import { useCardLoadingState } from '../CardDataContext'
+import { useDemoMode } from '../../../hooks/useDemoMode'
 import { KEDA_DEMO_DATA, type KedaDemoData, type KedaScaledObject, type KedaTriggerType } from './demoData'
 import { FETCH_DEFAULT_TIMEOUT_MS } from '../../../lib/constants'
 import { authFetch } from '../../../lib/api'
@@ -222,8 +223,14 @@ export interface UseKedaStatusResult {
 }
 
 export function useKedaStatus(): UseKedaStatusResult {
+  // #8836: subscribe to demo mode toggles so the card swaps to demo data
+  // immediately (and shows the Demo badge / yellow outline) when the user
+  // flips demo mode on, instead of only switching when the cache layer falls
+  // back after a fetch failure.
+  const { isDemoMode } = useDemoMode()
+
   const {
-    data,
+    data: liveData,
     isLoading,
     isRefreshing,
     isFailed,
@@ -238,12 +245,14 @@ export function useKedaStatus(): UseKedaStatusResult {
     fetcher: fetchKedaStatus,
   })
 
-  const effectiveIsDemoData = isDemoFallback && !isLoading
+  const data = isDemoMode ? KEDA_DEMO_DATA : liveData
+  const effectiveIsDemoData = isDemoMode || (isDemoFallback && !isLoading)
 
   const hasAnyData = (data.operatorPods?.total ?? 0) > 0 || (data.scaledObjects || []).length > 0
 
   const { showSkeleton, showEmptyState } = useCardLoadingState({
-    isLoading,
+    isLoading: isLoading && !isDemoMode,
+    isRefreshing,
     hasAnyData,
     isFailed,
     consecutiveFailures,
@@ -252,9 +261,9 @@ export function useKedaStatus(): UseKedaStatusResult {
 
   return {
     data,
-    loading: isLoading,
+    loading: isLoading && !isDemoMode,
     isRefreshing,
-    error: isFailed && !hasAnyData,
+    error: isFailed && !hasAnyData && !isDemoMode,
     consecutiveFailures,
     showSkeleton,
     showEmptyState,


### PR DESCRIPTION
## Summary

Apply the same demo-mode subscription pattern PR #8901 added for `FluentdStatus` to `KedaStatus`.

The `useKedaStatus` hook now subscribes to `useDemoMode()` and swaps to `KEDA_DEMO_DATA` immediately when demo mode flips on, so the Demo badge and yellow outline render right away — instead of only after the cache layer falls back from a fetch failure.

Loading and error gating are also suppressed while in demo mode so the card never skeletons or errors over synthetic data.

## Why

Cards that only relied on the cache layer's `isDemoFallback` would not visually flip into demo mode when the user toggles demo mode unless a fetch failed first. This left users in demo sessions seeing live skeletons / errors, missing the Demo badge.

## Changes

- `web/src/components/cards/keda_status/useKedaStatus.ts` (~14 LOC) — import `useDemoMode`, swap to demo data and OR into `effectiveIsDemoData` while in demo mode, suppress loading/error gating.

## Verification

- `npx tsc --noEmit` — zero errors
- `npx eslint <touched file>` — clean
- `npx vitest run KedaStatus.test.tsx` — 1 passed

Addresses #8836 (partial — remaining cards still need the same fix).