### PR TITLE
refactor: extract deep-link match helpers from MissionBrowser.tsx (#8624) [part 3]

### DIFF
--- a/web/src/components/missions/MissionBrowser.tsx
+++ b/web/src/components/missions/MissionBrowser.tsx
@@ -42,7 +42,7 @@ import { UnstructuredFilePreview } from './UnstructuredFilePreview'
 import { useTranslation } from 'react-i18next'
 import {
   TreeNodeItem, DirectoryListing, RecommendationCard, EmptyState, MissionFetchErrorBanner,
-  getMissionSlug, getMissionShareUrl, updateNodeInTree, removeNodeFromTree,
+  getMissionShareUrl, updateNodeInTree, removeNodeFromTree,
   missionCache, startMissionCacheFetch, resetMissionCache,
   fetchMissionContent, BROWSER_TABS,
   VirtualizedMissionGrid,
@@ -69,6 +69,11 @@ import {
   computeFacetCounts,
   filterRecommendations,
 } from './missionBrowserFilters'
+import {
+  HIGH_CONFIDENCE_THRESHOLD,
+  toWordSet,
+  findBestDeepLinkMatch,
+} from './missionBrowserDeepLink'
 
 // ============================================================================
 // Types
@@ -413,68 +418,14 @@ export function MissionBrowser({ isOpen, onClose, onImport, initialMission, onUs
     const slug = deepLinkSlugRef.current
     if (!slug || !isOpen || selectedMission) return
 
-    /**
-     * Fuzzy deep-link matching: converts both the URL slug and mission metadata
-     * into normalized word-sets so that `/missions/install-open-policy-agent-opa`
-     * can match a mission titled "Install and Configure Open Policy Agent Opa-".
-     *
-     * Strategy (in priority order):
-     *  1. Exact slug match (`getMissionSlug(m) === slug`)
-     *  2. cncfProject match (strip "install-" prefix from slug)
-     *  3. Fuzzy word-overlap: extract meaningful words from the slug and from
-     *     the mission title+cncfProject, then pick the mission whose word
-     *     overlap ratio is highest (≥ threshold).
-     */
-    const FILLER_WORDS = new Set(['and', 'on', 'for', 'the', 'in', 'with', 'a', 'an', 'to', 'of', 'kubernetes', 'k8s'])
-    const MIN_WORD_OVERLAP_RATIO = 0.6
-
-    /** Extract unique meaningful lowercase words, stripping filler and short fragments */
-    const toWordSet = (s: string): Set<string> =>
-      new Set(
-        s.toLowerCase()
-          .replace(/[^a-z0-9]+/g, ' ')
-          .split(' ')
-          .filter((w) => w.length > 1 && !FILLER_WORDS.has(w))
-      )
-
+    // Fuzzy deep-link matching: converts both the URL slug and mission metadata
+    // into normalized word-sets so that `/missions/install-open-policy-agent-opa`
+    // can match a mission titled "Install and Configure Open Policy Agent Opa-".
+    // Pure helpers live in `./missionBrowserDeepLink`.
     const slugWordSet = toWordSet(slug)
 
-    /** Score how well a mission matches the deep-link slug (0–1) */
-    const scoreMission = (m: MissionExport, isInstaller: boolean): number => {
-      // Exact slug match
-      if (getMissionSlug(m) === slug) return 1
-
-      // cncfProject match (installers only — fixers use slug/title matching)
-      if (isInstaller) {
-        const project = (m.cncfProject || '').toLowerCase()
-        const slugProject = slug.replace(/^install-/, '')
-        if (project && (project === slugProject || project === slug)) return 0.95
-      }
-
-      // Fuzzy word-overlap (set intersection) on title + cncfProject
-      const missionWordSet = toWordSet(`${m.title || ''} ${m.cncfProject || ''}`)
-      if (slugWordSet.size === 0 || missionWordSet.size === 0) return 0
-      let matched = 0
-      for (const w of slugWordSet) { if (missionWordSet.has(w)) matched++ }
-      return matched / slugWordSet.size
-    }
-
-    /** Minimum score to permanently consume the deep-link ref (#5654) */
-    const HIGH_CONFIDENCE_THRESHOLD = 0.9
-
-    /** Find best-scoring mission at or above threshold in a list */
-    const findBest = (list: MissionExport[], isInstaller: boolean): { match?: MissionExport; score: number } => {
-      let best: MissionExport | undefined
-      let bestScore = MIN_WORD_OVERLAP_RATIO
-      for (const m of list) {
-        const score = scoreMission(m, isInstaller)
-        if (score >= bestScore) { best = m; bestScore = score }
-      }
-      return { match: best, score: bestScore }
-    }
-
     // Search installers first, then fixers
-    const installer = findBest(installerMissions, true)
+    const installer = findBestDeepLinkMatch(installerMissions, slug, slugWordSet, true)
     if (installer.match) {
       setActiveTab('installers')
       selectCardMission(installer.match)
@@ -484,7 +435,7 @@ export function MissionBrowser({ isOpen, onClose, onImport, initialMission, onUs
       return
     }
 
-    const fixer = findBest(fixerMissions, false)
+    const fixer = findBestDeepLinkMatch(fixerMissions, slug, slugWordSet, false)
     if (fixer.match) {
       setActiveTab('fixes')
       selectCardMission(fixer.match)

--- a/web/src/components/missions/missionBrowserDeepLink.ts
+++ b/web/src/components/missions/missionBrowserDeepLink.ts
@@ -1,0 +1,149 @@
+/**
+ * Deep-link matching helpers for MissionBrowser.
+ *
+ * Extracted from MissionBrowser.tsx so the component can stay focused on React
+ * rendering. These pure helpers implement fuzzy matching of a URL slug against
+ * mission metadata so that a deep-link such as
+ * `/missions/install-open-policy-agent-opa` can resolve to a mission titled
+ * "Install and Configure Open Policy Agent Opa-".
+ *
+ * Strategy (in priority order, see `scoreMission`):
+ *   1. Exact slug match (`getMissionSlug(m) === slug`)
+ *   2. cncfProject match (strip "install-" prefix from slug; installers only)
+ *   3. Fuzzy word-overlap: extract meaningful words from the slug and from the
+ *      mission title+cncfProject, then pick the mission whose word overlap
+ *      ratio is highest (>= MIN_WORD_OVERLAP_RATIO).
+ *
+ * None of these functions touch React state, refs, the DOM, or any browser
+ * API — they are pure functions of their arguments and safe to unit-test or
+ * reuse from other components.
+ */
+
+import type { MissionExport } from '../../lib/missions/types'
+import { getMissionSlug } from './browser'
+
+// ============================================================================
+// Constants
+// ============================================================================
+
+/**
+ * Words stripped from slug/title token sets before computing overlap. These
+ * are common English stopwords plus generic Kubernetes terms that would
+ * otherwise inflate the overlap score for every mission.
+ */
+export const FILLER_WORDS: ReadonlySet<string> = new Set([
+  'and', 'on', 'for', 'the', 'in', 'with', 'a', 'an', 'to', 'of',
+  'kubernetes', 'k8s',
+])
+
+/**
+ * Minimum fraction of slug words that must appear in a mission's word set
+ * for that mission to be considered a candidate match.
+ */
+export const MIN_WORD_OVERLAP_RATIO = 0.6
+
+/**
+ * Score at or above which a deep-link match is considered "high confidence"
+ * and the deep-link slug ref is permanently consumed. Lower-scoring matches
+ * are kept tentative so that a better match can replace them once more
+ * missions finish loading (#5654).
+ */
+export const HIGH_CONFIDENCE_THRESHOLD = 0.9
+
+/**
+ * Match score returned for an exact slug equality.
+ */
+const EXACT_SLUG_MATCH_SCORE = 1
+
+/**
+ * Match score returned when the slug matches the mission's cncfProject
+ * (with or without the "install-" prefix). Slightly below an exact slug
+ * match so an exact title hit always wins.
+ */
+const CNCF_PROJECT_MATCH_SCORE = 0.95
+
+/**
+ * Minimum word length that survives slug/title tokenization. Single-letter
+ * fragments are too noisy to contribute meaningful overlap.
+ */
+const MIN_TOKEN_LENGTH = 1
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+/**
+ * Extract the unique meaningful lowercase words from a string, stripping
+ * filler words and short fragments. Used to build comparable token sets
+ * for both the URL slug and a mission's title+cncfProject.
+ */
+export function toWordSet(s: string): Set<string> {
+  return new Set(
+    s.toLowerCase()
+      .replace(/[^a-z0-9]+/g, ' ')
+      .split(' ')
+      .filter((w) => w.length > MIN_TOKEN_LENGTH && !FILLER_WORDS.has(w))
+  )
+}
+
+/**
+ * Score how well a single mission matches the deep-link slug.
+ *
+ * Returns a value in [0, 1]:
+ *   - 1.0 — exact slug equality
+ *   - 0.95 — cncfProject match (installers only)
+ *   - 0..1 — fuzzy word overlap ratio (matched / slugWordSet.size)
+ *
+ * `isInstaller` controls whether the cncfProject shortcut is applied;
+ * fixers always fall through to the fuzzy overlap path.
+ */
+export function scoreMission(
+  m: MissionExport,
+  slug: string,
+  slugWordSet: Set<string>,
+  isInstaller: boolean,
+): number {
+  // Exact slug match
+  if (getMissionSlug(m) === slug) return EXACT_SLUG_MATCH_SCORE
+
+  // cncfProject match (installers only — fixers use slug/title matching)
+  if (isInstaller) {
+    const project = (m.cncfProject || '').toLowerCase()
+    const slugProject = slug.replace(/^install-/, '')
+    if (project && (project === slugProject || project === slug)) {
+      return CNCF_PROJECT_MATCH_SCORE
+    }
+  }
+
+  // Fuzzy word-overlap (set intersection) on title + cncfProject
+  const missionWordSet = toWordSet(`${m.title || ''} ${m.cncfProject || ''}`)
+  if (slugWordSet.size === 0 || missionWordSet.size === 0) return 0
+  let matched = 0
+  for (const w of slugWordSet) {
+    if (missionWordSet.has(w)) matched++
+  }
+  return matched / slugWordSet.size
+}
+
+/**
+ * Find the best-scoring mission at or above MIN_WORD_OVERLAP_RATIO in a list.
+ * Returns the matched mission (if any) and the winning score so the caller
+ * can decide whether to permanently consume the deep-link ref.
+ */
+export function findBestDeepLinkMatch(
+  list: MissionExport[],
+  slug: string,
+  slugWordSet: Set<string>,
+  isInstaller: boolean,
+): { match?: MissionExport; score: number } {
+  let best: MissionExport | undefined
+  let bestScore = MIN_WORD_OVERLAP_RATIO
+  for (const m of list) {
+    const score = scoreMission(m, slug, slugWordSet, isInstaller)
+    if (score >= bestScore) {
+      best = m
+      bestScore = score
+    }
+  }
+  return { match: best, score: bestScore }
+}


### PR DESCRIPTION
## Summary

Third bounded extraction from `web/src/components/missions/MissionBrowser.tsx` for issue #8624. Moves the fuzzy deep-link matching logic out of the inline `useEffect` and into a new pure-helpers module: `missionBrowserDeepLink.ts`.

This continues the plan tracked under scanner bead `scanner-beads-wsm`:
- #8835 — extracted module constants + small pure helpers
- #8900 — extracted filter/facet helpers
- this PR — extracts deep-link match helpers (part 3)

## What moved

**New file**: `web/src/components/missions/missionBrowserDeepLink.ts`
- Constants (all named, no magic numbers): `FILLER_WORDS`, `MIN_WORD_OVERLAP_RATIO`, `HIGH_CONFIDENCE_THRESHOLD`, plus the previously-bare scoring values now exposed as named constants (`EXACT_SLUG_MATCH_SCORE`, `CNCF_PROJECT_MATCH_SCORE`, `MIN_TOKEN_LENGTH`).
- `toWordSet(s)` — tokenize + filter stopwords/short fragments
- `scoreMission(m, slug, slugWordSet, isInstaller)` — exact slug → cncfProject → fuzzy overlap, returns `[0..1]`
- `findBestDeepLinkMatch(list, slug, slugWordSet, isInstaller)` — best-scoring mission at or above the overlap ratio

**MissionBrowser.tsx**: deep-link `useEffect` now imports and calls `findBestDeepLinkMatch()` in place of the inline `findBest()`. The unused `getMissionSlug` import is dropped (it now lives behind `scoreMission` inside the new module).

## Behavior

Zero behavior change. The same priority ladder (exact slug → cncfProject → fuzzy overlap) and the same high-confidence threshold (0.9) for permanently consuming the deep-link ref (#5654).

LOC delta:
- `MissionBrowser.tsx`: 1980 → 1931 (-49)
- `missionBrowserDeepLink.ts`: +149

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npx eslint` on touched files — 0 errors (10 pre-existing warnings unchanged)
- [x] `npx vitest run MissionBrowser.test.tsx ui-ux-standards.test.ts` — 16/16 pass
- [ ] CI build/lint/preview pass