### PR TITLE
fix(a11y): add aria-label to stat block move-up button

### DIFF
--- a/web/src/components/dashboard/StatBlockFactoryModal.tsx
+++ b/web/src/components/dashboard/StatBlockFactoryModal.tsx
@@ -492,6 +492,8 @@ export function StatBlockFactoryModal({ isOpen, onClose, onStatsCreated, embedde
                               onClick={() => moveBlock(idx, 'up')}
                               disabled={idx === 0}
                               className="p-0.5 text-muted-foreground hover:text-foreground disabled:opacity-20"
+                              title={t('dashboard.statFactory.moveBlockUp')}
+                              aria-label={t('dashboard.statFactory.moveBlockUp')}
                             >
                               <GripVertical className="w-3 h-3" />
                             </button>

--- a/web/src/locales/en/common.json
+++ b/web/src/locales/en/common.json
@@ -1147,7 +1147,8 @@
       "blocksCount_other": "{{count}} blocks",
       "deleteStatBlock": "Delete stat block",
       "addAtLeastOne": "Add at least one stat block.",
-      "changeIcon": "Change icon"
+      "changeIcon": "Change icon",
+      "moveBlockUp": "Move stat block up"
     },
     "aiAssist": {
       "describeWhatYouWant": "AI Assist — describe what you want",


### PR DESCRIPTION
## Summary
- Adds `title` + `aria-label` to the icon-only move-up button in `StatBlockFactoryModal.tsx` (uses `GripVertical` with no accessible name)
- New i18n key `dashboard.statFactory.moveBlockUp` in `web/src/locales/en/common.json`

Addresses #8884 (partial — one confirmed true-positive ARIA gap; the issue contains many findings still being triaged)

## Test plan
- [x] `npx tsc --noEmit` — 0 errors
- [x] `npx eslint` on touched files — no new errors (only pre-existing `no-restricted-syntax` warnings)
- [x] JSON validates