### PR TITLE
refactor: extract filter-state helpers from MissionBrowser.tsx (#8624) [part 4]

### DIFF
--- a/web/src/components/missions/MissionBrowser.tsx
+++ b/web/src/components/missions/MissionBrowser.tsx
@@ -74,6 +74,10 @@ import {
   toWordSet,
   findBestDeepLinkMatch,
 } from './missionBrowserDeepLink'
+import {
+  computeActiveFilterCount,
+  filterDirectoryEntries,
+} from './missionBrowserFilterState'
 
 // ============================================================================
 // Types
@@ -920,20 +924,7 @@ export function MissionBrowser({ isOpen, onClose, onImport, initialMission, onUs
   // Filtered directory entries
   // ============================================================================
 
-  const filteredEntries = (() => {
-    let entries = directoryEntries
-
-    if (searchQuery) {
-      const q = searchQuery.toLowerCase()
-      entries = entries.filter(
-        (e) =>
-          e.name.toLowerCase().includes(q) ||
-          e.description?.toLowerCase().includes(q)
-      )
-    }
-
-    return entries
-  })()
+  const filteredEntries = filterDirectoryEntries(directoryEntries, searchQuery)
 
   // ============================================================================
   // Filtered recommendations
@@ -942,18 +933,16 @@ export function MissionBrowser({ isOpen, onClose, onImport, initialMission, onUs
   // Compute dynamic facet counts from unfiltered recommendations
   const facetCounts = useMemo(() => computeFacetCounts(recommendations), [recommendations])
 
-  const activeFilterCount = (() => {
-    let count = 0
-    if (minMatchPercent > 0) count++
-    if (categoryFilter !== 'All') count++
-    if (matchSourceFilter !== 'all') count++
-    if (maturityFilter !== 'All') count++
-    if (missionClassFilter !== 'All') count++
-    if (difficultyFilter !== 'All') count++
-    if (selectedTags.size > 0) count++
-    if (cncfFilter) count++
-    return count
-  })()
+  const activeFilterCount = computeActiveFilterCount({
+    minMatchPercent,
+    categoryFilter,
+    matchSourceFilter,
+    maturityFilter,
+    missionClassFilter,
+    difficultyFilter,
+    selectedTags,
+    cncfFilter,
+  })
 
   const clearAllFilters = () => {
     setMinMatchPercent(0)

--- a/web/src/components/missions/missionBrowserFilterState.ts
+++ b/web/src/components/missions/missionBrowserFilterState.ts
@@ -1,0 +1,96 @@
+/**
+ * Pure helpers describing the *state* of MissionBrowser's recommendation
+ * filter controls (active count, cleared sentinel values) and a small helper
+ * for filtering the directory listing by free-text search.
+ *
+ * Extracted from MissionBrowser.tsx so the component file can stay focused on
+ * React rendering. None of these touch React state, refs, or the DOM — they
+ * are pure functions / constants safe to unit-test or reuse.
+ *
+ * The "filter state" types here intentionally mirror the local useState
+ * variables in MissionBrowser; they are not exported as a single object type
+ * so the component can keep its individual setters without an extra reducer
+ * layer.
+ */
+
+import type { BrowseEntry } from '../../lib/missions/types'
+
+// ============================================================================
+// Active filter count
+// ============================================================================
+
+/**
+ * Sentinel value for the "Match %" filter when no minimum is enforced.
+ * Mirrors the `minMatchPercent === 0` "Any" choice in the chip group.
+ */
+export const NO_MIN_MATCH_PERCENT = 0
+
+/**
+ * Sentinel value for category-style chip filters that means "do not filter".
+ * Used for category, maturity, missionClass, and difficulty filters.
+ */
+export const FILTER_SENTINEL_ALL = 'All'
+
+/**
+ * Sentinel value for the source filter that means "do not filter".
+ */
+export const FILTER_SENTINEL_SOURCE_ALL = 'all' as const
+
+/**
+ * Snapshot of the recommendation filter state as displayed in the filter bar.
+ * Each property mirrors a single useState in MissionBrowser. Kept as a plain
+ * structural type so callers can pass `{ ... }` literals without imports.
+ */
+export interface RecommendationFilterState {
+  minMatchPercent: number
+  categoryFilter: string
+  matchSourceFilter: 'all' | 'cluster' | 'community'
+  maturityFilter: string
+  missionClassFilter: string
+  difficultyFilter: string
+  selectedTags: Set<string>
+  cncfFilter: string
+}
+
+/**
+ * Counts how many of the recommendation filters are currently set to a
+ * non-default value. Drives the small purple badge on the filter toggle
+ * button and the "Clear all" affordance.
+ */
+export function computeActiveFilterCount(state: RecommendationFilterState): number {
+  let count = 0
+  if (state.minMatchPercent > NO_MIN_MATCH_PERCENT) count++
+  if (state.categoryFilter !== FILTER_SENTINEL_ALL) count++
+  if (state.matchSourceFilter !== FILTER_SENTINEL_SOURCE_ALL) count++
+  if (state.maturityFilter !== FILTER_SENTINEL_ALL) count++
+  if (state.missionClassFilter !== FILTER_SENTINEL_ALL) count++
+  if (state.difficultyFilter !== FILTER_SENTINEL_ALL) count++
+  if (state.selectedTags.size > 0) count++
+  if (state.cncfFilter) count++
+  return count
+}
+
+// ============================================================================
+// Directory entry filtering
+// ============================================================================
+
+/**
+ * Filters a directory listing by a case-insensitive substring search across
+ * the entry name and description. Empty queries return the input unchanged.
+ *
+ * Unlike `andMatch` in `missionBrowserFilters.ts`, this uses simple
+ * substring matching (no AND tokenization) because directory entries do
+ * not have rich metadata to match against.
+ */
+export function filterDirectoryEntries(
+  entries: BrowseEntry[],
+  query: string,
+): BrowseEntry[] {
+  if (!query) return entries
+  const q = query.toLowerCase()
+  return entries.filter(
+    (e) =>
+      e.name.toLowerCase().includes(q) ||
+      e.description?.toLowerCase().includes(q),
+  )
+}


### PR DESCRIPTION
## Summary

Fourth bounded extraction from `MissionBrowser.tsx` (now 1920 LOC, down from 1931). Pulls two pure helpers and four named sentinel constants into a new sibling module `missionBrowserFilterState.ts` (96 LOC).

- `computeActiveFilterCount(state)` — replaces the inline IIFE that counts how many recommendation filters are set to a non-default value (drives the purple badge on the filter toggle button).
- `filterDirectoryEntries(entries, query)` — replaces the inline IIFE that applies a case-insensitive substring search across directory listing entries (name + description).
- `NO_MIN_MATCH_PERCENT` / `FILTER_SENTINEL_ALL` / `FILTER_SENTINEL_SOURCE_ALL` — name the previously magic literals (`0`, `'All'`, `'all'`) used as the sentinel "do not filter" values across the chip-group filters.

Zero behavior change. Continues the bounded-extraction sequence: #8835 (constants + helpers), #8900 (filter/facet helpers), #8906 (deep-link helpers).

Refs #8624.

## Test plan

- [x] `npx tsc --noEmit` — zero errors
- [x] `npx eslint` on touched files — clean (no new errors; only pre-existing `<Input>`/`<Select>` warnings)
- [x] `npx vitest run MissionBrowser.test.tsx ui-ux-standards.test.ts` — 16/16 pass
- [x] `npm run build` — green
- [ ] Smoke test: open the mission browser, toggle filters, verify the purple badge count updates and "Clear all" still resets every chip
- [ ] Smoke test: type in the directory search, confirm directory entries filter correctly