### PR TITLE
fix: add keyboard navigation to 3 more cards (batch 2 of #8883)

### DIFF
--- a/web/src/components/cards/AlertListItem.tsx
+++ b/web/src/components/cards/AlertListItem.tsx
@@ -94,11 +94,41 @@ export function AlertListItem({
     return () => document.removeEventListener('mousedown', handler)
   }, [snoozeMenuOpen])
 
+  // #8883: roving-tabindex keyboard navigation. Enter/Space activates the
+  // drill-down; ArrowUp/Down move focus between sibling list items;
+  // Home/End jump to ends. The list container in ActiveAlerts has
+  // role="list" so AT exposes the listitem semantics.
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
+    const list = e.currentTarget.parentElement
+    const items = list ? Array.from(list.querySelectorAll<HTMLDivElement>('[data-keynav-item="alert"]')) : []
+    const idx = items.indexOf(e.currentTarget)
+    if (e.key === 'Enter' || e.key === ' ') {
+      e.preventDefault()
+      onAlertClick(alert)
+    } else if (e.key === 'ArrowDown' && idx >= 0 && idx < items.length - 1) {
+      e.preventDefault()
+      items[idx + 1]?.focus()
+    } else if (e.key === 'ArrowUp' && idx > 0) {
+      e.preventDefault()
+      items[idx - 1]?.focus()
+    } else if (e.key === 'Home') {
+      e.preventDefault()
+      items[0]?.focus()
+    } else if (e.key === 'End') {
+      e.preventDefault()
+      items[items.length - 1]?.focus()
+    }
+  }
+
   return (
     <div
       key={alert.id}
+      data-keynav-item="alert"
+      role="button"
+      tabIndex={0}
       onClick={() => onAlertClick(alert)}
-      className="p-2 rounded-lg bg-secondary/30 border border-border/50 hover:bg-secondary/50 cursor-pointer transition-colors group"
+      onKeyDown={handleKeyDown}
+      className="p-2 rounded-lg bg-secondary/30 border border-border/50 hover:bg-secondary/50 cursor-pointer transition-colors group focus:outline-none focus-visible:ring-2 focus-visible:ring-cyan-400"
     >
       <div className="flex items-start gap-2">
         <span className="text-lg">{getSeverityIcon(alert.severity)}</span>

--- a/web/src/components/cards/OpenCostOverview.tsx
+++ b/web/src/components/cards/OpenCostOverview.tsx
@@ -169,9 +169,10 @@ function OpenCostOverviewInternal({ config: _config }: OpenCostOverviewProps) {
       </div>
 
       {/* Namespace costs.
-          #8883: roving-tabindex list — Enter/Space activate; ArrowUp/Down
-          traverse siblings; Home/End jump. Container gets role="list" so
-          AT exposes the list semantics. */}
+        * #8883: roving-tabindex list — Enter/Space activate; ArrowUp/Down
+        * traverse siblings; Home/End jump. Container gets role="list" so
+        * AT exposes the list semantics.
+        */}
       <div ref={containerRef} className="flex-1 overflow-y-auto space-y-2" style={containerStyle}>
         <p className="text-xs text-muted-foreground font-medium mb-2">Cost by Namespace</p>
         <div role="list" className="space-y-2">

--- a/web/src/components/cards/OpenCostOverview.tsx
+++ b/web/src/components/cards/OpenCostOverview.tsx
@@ -168,21 +168,51 @@ function OpenCostOverviewInternal({ config: _config }: OpenCostOverviewProps) {
         <p className="text-xl font-bold text-foreground">${totalCost.toLocaleString()}</p>
       </div>
 
-      {/* Namespace costs */}
+      {/* Namespace costs.
+          #8883: roving-tabindex list — Enter/Space activate; ArrowUp/Down
+          traverse siblings; Home/End jump. Container gets role="list" so
+          AT exposes the list semantics. */}
       <div ref={containerRef} className="flex-1 overflow-y-auto space-y-2" style={containerStyle}>
         <p className="text-xs text-muted-foreground font-medium mb-2">Cost by Namespace</p>
-        {filteredCosts.map(ns => (
+        <div role="list" className="space-y-2">
+        {filteredCosts.map((ns, idx, arr) => {
+          const activate = () => drillToCost('all', {
+            namespace: ns.namespace,
+            cpuCost: ns.cpuCost,
+            memCost: ns.memCost,
+            storageCost: ns.storageCost,
+            totalCost: ns.totalCost,
+            source: 'opencost',
+          })
+          const handleKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
+            const list = e.currentTarget.parentElement
+            const items = list ? Array.from(list.querySelectorAll<HTMLDivElement>('[data-keynav-item="opencost-ns"]')) : []
+            if (e.key === 'Enter' || e.key === ' ') {
+              e.preventDefault()
+              activate()
+            } else if (e.key === 'ArrowDown' && idx < arr.length - 1) {
+              e.preventDefault()
+              items[idx + 1]?.focus()
+            } else if (e.key === 'ArrowUp' && idx > 0) {
+              e.preventDefault()
+              items[idx - 1]?.focus()
+            } else if (e.key === 'Home') {
+              e.preventDefault()
+              items[0]?.focus()
+            } else if (e.key === 'End') {
+              e.preventDefault()
+              items[items.length - 1]?.focus()
+            }
+          }
+          return (
           <div
             key={ns.namespace}
-            onClick={() => drillToCost('all', {
-              namespace: ns.namespace,
-              cpuCost: ns.cpuCost,
-              memCost: ns.memCost,
-              storageCost: ns.storageCost,
-              totalCost: ns.totalCost,
-              source: 'opencost',
-            })}
-            className="p-2 rounded-lg bg-secondary/30 hover:bg-secondary/50 transition-colors cursor-pointer group"
+            data-keynav-item="opencost-ns"
+            role="button"
+            tabIndex={0}
+            onClick={activate}
+            onKeyDown={handleKeyDown}
+            className="p-2 rounded-lg bg-secondary/30 hover:bg-secondary/50 transition-colors cursor-pointer group focus:outline-none focus-visible:ring-2 focus-visible:ring-cyan-400"
           >
             <div className="flex flex-wrap items-center justify-between gap-y-2 mb-1.5">
               <div className="flex items-center gap-2">
@@ -212,7 +242,9 @@ function OpenCostOverviewInternal({ config: _config }: OpenCostOverviewProps) {
               <span>Storage: ${ns.storageCost}</span>
             </div>
           </div>
-        ))}
+          )
+        })}
+        </div>
       </div>
 
       {/* Pagination */}

--- a/web/src/components/cards/ProactiveGPUNodeHealthMonitor.tsx
+++ b/web/src/components/cards/ProactiveGPUNodeHealthMonitor.tsx
@@ -617,17 +617,46 @@ function ProactiveGPUNodeHealthMonitorInternal() {
         </div>
       )}
 
-      {/* Node list */}
-      <div className="flex-1 overflow-auto space-y-1">
-        {paginatedNodes.map(node => {
+      {/* Node list.
+          #8883: roving-tabindex keynav on each node row — Enter/Space
+          toggles expand; ArrowUp/Down move focus between sibling rows;
+          Home/End jump to ends. Container gets role="list". */}
+      <div role="list" className="flex-1 overflow-auto space-y-1">
+        {paginatedNodes.map((node, idx, arr) => {
           const isExpanded = expandedNode === `${node.cluster}/${node.nodeName}`
           const nodeKey = `${node.cluster}/${node.nodeName}`
+          const toggleExpand = () => setExpandedNode(isExpanded ? null : nodeKey)
+          const handleRowKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
+            const list = e.currentTarget.closest('[role="list"]')
+            const items = list ? Array.from(list.querySelectorAll<HTMLDivElement>('[data-keynav-item="gpu-node"]')) : []
+            if (e.key === 'Enter' || e.key === ' ') {
+              e.preventDefault()
+              toggleExpand()
+            } else if (e.key === 'ArrowDown' && idx < arr.length - 1) {
+              e.preventDefault()
+              items[idx + 1]?.focus()
+            } else if (e.key === 'ArrowUp' && idx > 0) {
+              e.preventDefault()
+              items[idx - 1]?.focus()
+            } else if (e.key === 'Home') {
+              e.preventDefault()
+              items[0]?.focus()
+            } else if (e.key === 'End') {
+              e.preventDefault()
+              items[items.length - 1]?.focus()
+            }
+          }
           return (
             <div key={nodeKey} className="rounded-lg border border-border bg-secondary overflow-hidden">
               {/* Node row */}
               <div
-                className="group flex items-center gap-2 px-3 py-2 cursor-pointer hover:bg-secondary transition-colors"
-                onClick={() => setExpandedNode(isExpanded ? null : nodeKey)}
+                data-keynav-item="gpu-node"
+                role="button"
+                tabIndex={0}
+                aria-expanded={isExpanded}
+                className="group flex items-center gap-2 px-3 py-2 cursor-pointer hover:bg-secondary transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-cyan-400"
+                onClick={toggleExpand}
+                onKeyDown={handleRowKeyDown}
               >
                 {isExpanded ? (
                   <ChevronDown className="w-3.5 h-3.5 text-white/30 shrink-0" />

--- a/web/src/components/cards/ProactiveGPUNodeHealthMonitor.tsx
+++ b/web/src/components/cards/ProactiveGPUNodeHealthMonitor.tsx
@@ -618,9 +618,10 @@ function ProactiveGPUNodeHealthMonitorInternal() {
       )}
 
       {/* Node list.
-          #8883: roving-tabindex keynav on each node row — Enter/Space
-          toggles expand; ArrowUp/Down move focus between sibling rows;
-          Home/End jump to ends. Container gets role="list". */}
+        * #8883: roving-tabindex keynav on each node row — Enter/Space
+        * toggles expand; ArrowUp/Down move focus between sibling rows;
+        * Home/End jump to ends. Container gets role="list".
+        */}
       <div role="list" className="flex-1 overflow-auto space-y-1">
         {paginatedNodes.map((node, idx, arr) => {
           const isExpanded = expandedNode === `${node.cluster}/${node.nodeName}`


### PR DESCRIPTION
## Summary

Second-wave partial fix for the Auto-QA keyboard-nav gaps in #8883, continuing the work landed in #8902. Adds roving-tabindex keyboard navigation to clickable list items in three more cards:

- **`AlertListItem.tsx`** (used by `ActiveAlerts`) — alert rows
- **`OpenCostOverview.tsx`** — Cost by Namespace list
- **`ProactiveGPUNodeHealthMonitor.tsx`** — GPU node rows (toggle expand)

Each list item now supports:
- `role="button"` + `tabIndex={0}` for screen readers and Tab traversal
- **Enter / Space** — activate (drill-down or toggle expand)
- **ArrowUp / ArrowDown** — move focus between siblings
- **Home / End** — jump to first / last item
- `focus-visible:ring-2 ring-cyan-400` for visible keyboard focus

Container `<div>`s for `OpenCostOverview` and `ProactiveGPUNodeHealthMonitor` gain `role="list"` so the list semantics are exposed to AT. `ActiveAlerts` already wraps `AlertListItem` instances in a list-like container; the data-attribute selector is scoped to its parent, so no change there.

GPU node rows additionally gain `aria-expanded` so AT announces the collapsed/expanded state alongside the keyboard activation.

Existing mouse behavior (onClick, cursor-pointer, hover) is unchanged.

## Scope

Partial — closes more of the keyboard-nav findings in #8883. Cards touched by #8902 (`NetworkOverview`, `KustomizationStatus`, `OperatorStatus`) and by parallel ARIA-gaps work (`IframeEmbed`, `ClusterGroups`, `HardwareHealthCard`) were intentionally left alone.

## Test plan

- [x] `npx tsc --noEmit` — zero errors
- [x] `npx eslint` on touched files — no new errors (pre-existing 2 errors / 5 warnings in `ProactiveGPUNodeHealthMonitor.tsx` are unchanged)
- [x] `npx vitest run` on `OpenCostOverview.test.tsx`, `AlertListItem.test.tsx`, `ProactiveGPUNodeHealthMonitor.test.tsx` — 25/25 passing
- [ ] Manual: Tab into each card, arrow through items, press Enter to activate
- [ ] Screen reader: announce items as buttons within a list; node rows announce expanded state

Addresses #8883