### PR TITLE
refactor: extract ManageCardsTab from CardFactoryModal.tsx (#8608) [part 7]

### DIFF
--- a/web/src/components/dashboard/CardFactoryModal.tsx
+++ b/web/src/components/dashboard/CardFactoryModal.tsx
@@ -2,7 +2,7 @@ import { useState, useEffect, useRef, useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
 import {
   X, Plus, Code, Layers, Wand2, Eye, Save, Sparkles,
-  AlertTriangle, CheckCircle, Loader2, Trash2 } from 'lucide-react'
+  AlertTriangle, CheckCircle, Loader2 } from 'lucide-react'
 import { BaseModal, ConfirmDialog } from '../../lib/modals'
 import { cn } from '../../lib/cn'
 import { saveDynamicCard, deleteDynamicCard, getAllDynamicCards } from '../../lib/dynamic-cards'
@@ -16,11 +16,11 @@ import { LivePreviewPanel } from './LivePreviewPanel'
 import { InlineAIAssist } from './InlineAIAssist'
 import { CARD_INLINE_ASSIST_PROMPT, CODE_INLINE_ASSIST_PROMPT } from '../../lib/ai/prompts'
 import { generateSampleData } from '../../lib/ai/sampleData'
-import { wrapAbbreviations } from '../shared/TechnicalAcronym'
 import { T1_TEMPLATES, type T1Template } from './cardFactoryTemplates'
 import { TemplateDropdown } from './cardFactoryPreviews'
 import { FieldSuggestChips } from './FieldSuggestChips'
 import { AiCardTab } from './cardFactoryAiTab'
+import { ManageCardsTab } from './cardFactoryManageTab'
 import {
   validateT1AssistResult,
   validateT2AssistResult,
@@ -1144,46 +1144,10 @@ export function CardFactoryModal({ isOpen, onClose, onCardCreated, embedded = fa
 
           {/* Manage */}
           {tab === 'manage' && (
-            <div className="space-y-3">
-              {existingCards.length === 0 ? (
-                <div className="flex flex-col items-center justify-center py-8 text-center">
-                  <Wand2 className="w-8 h-8 text-muted-foreground/40 mb-2" />
-                  <p className="text-sm text-muted-foreground">{t('dashboard.cardFactory.noCustomCards')}</p>
-                  <p className="text-xs text-muted-foreground/70 mt-1">
-                    {t('dashboard.cardFactory.useDeclarativeOrCode')}
-                  </p>
-                </div>
-              ) : (
-                existingCards.map(card => (
-                  <div key={card.id} className="rounded-lg bg-card/50 border border-border p-3 flex items-start gap-3">
-                    <div className="flex-1 min-w-0">
-                      <div className="flex items-center gap-2">
-                        <span className="text-sm font-medium text-foreground">{wrapAbbreviations(card.title)}</span>
-                        <span className={cn(
-                          'text-xs px-1.5 py-0.5 rounded',
-                          card.tier === 'tier1' ? 'bg-blue-500/20 text-blue-400' : 'bg-purple-500/20 text-purple-400',
-                        )}>
-                          {card.tier === 'tier1' ? t('dashboard.cardFactory.declarativeBadge') : t('dashboard.cardFactory.customCodeBadge')}
-                        </span>
-                      </div>
-                      {card.description && (
-                        <p className="text-xs text-muted-foreground mt-0.5">{wrapAbbreviations(card.description)}</p>
-                      )}
-                      <p className="text-xs text-muted-foreground/70 mt-1">
-                        ID: {card.id} · Created: {new Date(card.createdAt).toLocaleDateString()}
-                      </p>
-                    </div>
-                    <button
-                      onClick={() => setDeleteConfirmId(card.id)}
-                      className="p-1.5 rounded hover:bg-red-500/20 text-muted-foreground hover:text-red-400 transition-colors shrink-0"
-                      title={t('dashboard.cardFactory.deleteCard')}
-                    >
-                      <Trash2 className="w-4 h-4" />
-                    </button>
-                  </div>
-                ))
-              )}
-            </div>
+            <ManageCardsTab
+              existingCards={existingCards}
+              onDeleteRequest={setDeleteConfirmId}
+            />
           )}
         </div>
       </div>

--- a/web/src/components/dashboard/cardFactoryManageTab.tsx
+++ b/web/src/components/dashboard/cardFactoryManageTab.tsx
@@ -1,0 +1,78 @@
+import { useTranslation } from 'react-i18next'
+import { Wand2, Trash2 } from 'lucide-react'
+import { cn } from '../../lib/cn'
+import type { DynamicCardDefinition } from '../../lib/dynamic-cards/types'
+import { wrapAbbreviations } from '../shared/TechnicalAcronym'
+
+interface ManageCardsTabProps {
+  /** All dynamic cards currently saved by the user. */
+  existingCards: DynamicCardDefinition[]
+  /**
+   * Called with a card id when the user clicks the delete (trash) icon.
+   * The parent is responsible for surfacing a confirmation dialog and
+   * performing the actual deletion.
+   */
+  onDeleteRequest: (id: string) => void
+}
+
+/**
+ * "Manage" tab content for the Card Factory modal.
+ *
+ * Renders an empty-state when no custom cards exist, or a list of saved
+ * dynamic cards (with title, tier badge, description, id/createdAt metadata,
+ * and a delete affordance).
+ *
+ * Pure presentation: no internal state, no side effects. Extracted from
+ * `CardFactoryModal.tsx` (issue #8608, part 7) so the modal stays focused
+ * on its role as a tab host.
+ */
+export function ManageCardsTab({ existingCards, onDeleteRequest }: ManageCardsTabProps) {
+  const { t } = useTranslation()
+
+  if (existingCards.length === 0) {
+    return (
+      <div className="space-y-3">
+        <div className="flex flex-col items-center justify-center py-8 text-center">
+          <Wand2 className="w-8 h-8 text-muted-foreground/40 mb-2" />
+          <p className="text-sm text-muted-foreground">{t('dashboard.cardFactory.noCustomCards')}</p>
+          <p className="text-xs text-muted-foreground/70 mt-1">
+            {t('dashboard.cardFactory.useDeclarativeOrCode')}
+          </p>
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div className="space-y-3">
+      {existingCards.map(card => (
+        <div key={card.id} className="rounded-lg bg-card/50 border border-border p-3 flex items-start gap-3">
+          <div className="flex-1 min-w-0">
+            <div className="flex items-center gap-2">
+              <span className="text-sm font-medium text-foreground">{wrapAbbreviations(card.title)}</span>
+              <span className={cn(
+                'text-xs px-1.5 py-0.5 rounded',
+                card.tier === 'tier1' ? 'bg-blue-500/20 text-blue-400' : 'bg-purple-500/20 text-purple-400',
+              )}>
+                {card.tier === 'tier1' ? t('dashboard.cardFactory.declarativeBadge') : t('dashboard.cardFactory.customCodeBadge')}
+              </span>
+            </div>
+            {card.description && (
+              <p className="text-xs text-muted-foreground mt-0.5">{wrapAbbreviations(card.description)}</p>
+            )}
+            <p className="text-xs text-muted-foreground/70 mt-1">
+              ID: {card.id} · Created: {new Date(card.createdAt).toLocaleDateString()}
+            </p>
+          </div>
+          <button
+            onClick={() => onDeleteRequest(card.id)}
+            className="p-1.5 rounded hover:bg-red-500/20 text-muted-foreground hover:text-red-400 transition-colors shrink-0"
+            title={t('dashboard.cardFactory.deleteCard')}
+          >
+            <Trash2 className="w-4 h-4" />
+          </button>
+        </div>
+      ))}
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary

Seventh bounded extraction from `CardFactoryModal.tsx` (scanner bead `scanner-beads-9fp`, issue #8608).

- New file `web/src/components/dashboard/cardFactoryManageTab.tsx` contains a presentational `ManageCardsTab` component (78 LOC) — empty-state + saved-card list with delete affordance.
- CFM now delegates the entire `tab === 'manage'` JSX (~45 LOC) to that component via two props: `existingCards` and `onDeleteRequest`. The parent retains ownership of delete-confirmation state and actual deletion.
- Drops two now-unused imports from CFM (`Trash2`, `wrapAbbreviations`). The lingering `Trash2` reference at line 536 is inside a `T2_TEMPLATES` template literal (string source code), not a JSX usage.

Pure extraction. Zero behavior change.

CFM line count: **1232 -> 1196** (down 27% from the original 1693 across parts 1-7).

## Prior extractions (all landed)
- #8834 T1_TEMPLATES + T1Template
- #8838 T1/T2Result types + validators
- #8861 T1Preview/T2Preview/TemplateDropdown
- #8898 FieldSuggestChips
- #8904 T1AssistResult/T2AssistResult types + validators
- #8908 AiCardTab

## Test plan
- [x] `npx tsc --noEmit` — zero errors
- [x] `npx eslint` on touched files — no new errors
- [x] `CardFactoryModal.test.tsx` + `AddCardModal` tests + `CardCatalogSection` test — 28/28 pass
- [x] `npm run build` — passes
- [ ] Visually verify the Manage tab in the Card Factory still renders the empty state and the card list with the delete trash icon

Refs #8608

🤖 Generated with [Claude Code](https://claude.com/claude-code)