### PR TITLE
fix: gate Add Cluster button on test-connection result

### DIFF
--- a/web/src/components/clusters/AddClusterDialog.tsx
+++ b/web/src/components/clusters/AddClusterDialog.tsx
@@ -346,6 +346,7 @@ export function AddClusterDialog({ open, onClose }: AddClusterDialogProps) {
               namespace={namespace}
               setNamespace={setNamespace}
               testResult={testResult}
+              resetTestResult={() => setTestResult(null)}
               connectError={connectError}
               showAdvanced={showAdvanced}
               setShowAdvanced={setShowAdvanced}

--- a/web/src/components/clusters/add-cluster/ConnectTab.tsx
+++ b/web/src/components/clusters/add-cluster/ConnectTab.tsx
@@ -53,6 +53,7 @@ interface ConnectTabProps {
   namespace: string
   setNamespace: (ns: string) => void
   testResult: { reachable: boolean; serverVersion?: string; error?: string } | null
+  resetTestResult: () => void
   connectError: string
   showAdvanced: boolean
   setShowAdvanced: (show: boolean) => void
@@ -88,6 +89,7 @@ export function ConnectTab({
   namespace,
   setNamespace,
   testResult,
+  resetTestResult,
   connectError,
   showAdvanced,
   setShowAdvanced,
@@ -403,7 +405,7 @@ export function ConnectTab({
 
               <div className="flex items-center justify-between gap-2 pt-1">
                 <button
-                  onClick={() => setConnectStep(2)}
+                  onClick={() => { resetTestResult(); setConnectStep(2) }}
                   className="px-4 py-2 text-sm font-medium rounded-lg bg-secondary text-foreground hover:bg-black/5 dark:hover:bg-white/10 transition-colors border border-border dark:border-white/10"
                 >
                   {t('cluster.connectBack')}
@@ -425,7 +427,8 @@ export function ConnectTab({
                   </button>
                   <button
                     onClick={handleAddCluster}
-                    disabled={connectState === 'adding' || !contextName.trim() || !clusterName.trim()}
+                    disabled={connectState === 'adding' || !contextName.trim() || !clusterName.trim() || testResult?.reachable === false}
+                    title={testResult?.reachable === false ? t('cluster.connectAddDisabledAfterTestFail') : undefined}
                     className="flex items-center gap-1.5 px-4 py-2 text-sm font-medium rounded-lg bg-purple-600 text-white hover:bg-purple-500 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
                   >
                     {connectState === 'adding' ? (

--- a/web/src/components/clusters/add-cluster/__tests__/ConnectTab.test.tsx
+++ b/web/src/components/clusters/add-cluster/__tests__/ConnectTab.test.tsx
@@ -62,6 +62,7 @@ describe('ConnectTab', () => {
         namespace=""
         setNamespace={vi.fn()}
         testResult={null}
+        resetTestResult={vi.fn()}
         connectError=""
         showAdvanced={false}
         setShowAdvanced={vi.fn()}

--- a/web/src/locales/en/common.json
+++ b/web/src/locales/en/common.json
@@ -3016,6 +3016,7 @@
     "connectTestSuccess": "Connected",
     "connectTestFailed": "Connection failed",
     "connectAddButton": "Add Cluster",
+    "connectAddDisabledAfterTestFail": "Connection test failed. Edit connection settings or re-run the test before adding.",
     "connectAdding": "Adding...",
     "connectSuccess": "Cluster added successfully",
     "connectNext": "Next",


### PR DESCRIPTION
## Summary
- After a failed connection test in the Add Cluster dialog, the **Add Cluster** button stayed enabled, letting users submit clusters that were known to be unreachable (#8915).
- Now the Add Cluster button is disabled while `testResult?.reachable === false`, with a tooltip explaining why. A new translation key `connectAddDisabledAfterTestFail` supplies the tooltip.
- Clicking **Back** from step 3 (context settings) to step 2 (auth) clears the stale `testResult` so the button re-enables automatically once the user edits their config and re-runs the test.

Very small change: 4 files, ~10 insertions.

Fixes #8915

## Test plan
- [x] `npx tsc --noEmit` — zero errors
- [x] `npx eslint` on touched files — zero errors (pre-existing warnings only)
- [x] `npx vitest run src/components/clusters/` — 84 tests pass
- [ ] Manual: in Add Cluster dialog, run a test that fails, verify Add Cluster button is greyed out with tooltip
- [ ] Manual: click Back → step 2, return to step 3, verify Add button is enabled again