### PR TITLE
fix: show Next button when Cloud IAM auth is selected in Add Cluster

### DIFF
--- a/web/src/components/clusters/add-cluster/ConnectTab.tsx
+++ b/web/src/components/clusters/add-cluster/ConnectTab.tsx
@@ -329,15 +329,19 @@ export function ConnectTab({
                 >
                   {t('cluster.connectBack')}
                 </button>
-                {authType !== 'cloud-iam' && (
-                  <button
-                    onClick={() => goToConnectStep(3)}
-                    disabled={authType === 'token' ? !token.trim() : (!certData.trim() || !keyData.trim())}
-                    className="px-4 py-2 text-sm font-medium rounded-lg bg-secondary text-foreground hover:bg-black/5 dark:hover:bg-white/10 transition-colors disabled:opacity-50 disabled:cursor-not-allowed border border-border dark:border-white/10"
-                  >
-                    {t('cluster.connectNext')}
-                  </button>
-                )}
+                <button
+                  onClick={() => goToConnectStep(3)}
+                  disabled={
+                    authType === 'token'
+                      ? !token.trim()
+                      : authType === 'certificate'
+                        ? (!certData.trim() || !keyData.trim())
+                        : false // cloud-iam: user authenticates via CLI, no UI input required to proceed
+                  }
+                  className="px-4 py-2 text-sm font-medium rounded-lg bg-secondary text-foreground hover:bg-black/5 dark:hover:bg-white/10 transition-colors disabled:opacity-50 disabled:cursor-not-allowed border border-border dark:border-white/10"
+                >
+                  {t('cluster.connectNext')}
+                </button>
               </div>
             </div>
           )}

--- a/web/src/components/clusters/add-cluster/__tests__/ConnectTab.test.tsx
+++ b/web/src/components/clusters/add-cluster/__tests__/ConnectTab.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from 'vitest'
-import { render } from '@testing-library/react'
+import { render, screen } from '@testing-library/react'
 
 vi.mock('../../../../lib/demoMode', () => ({
   isDemoMode: () => true, getDemoMode: () => true, isNetlifyDeployment: false,
@@ -74,5 +74,49 @@ describe('ConnectTab', () => {
       />
     )
     expect(container).toBeTruthy()
+  })
+
+  // Regression: #8914 — when Cloud IAM auth is selected, the Next button must
+  // still be rendered and enabled so the user can advance to step 3.
+  it('renders an enabled Next button on step 2 when authType is cloud-iam', () => {
+    render(
+      <ConnectTab
+        connectStep={2}
+        setConnectStep={vi.fn()}
+        connectState="idle"
+        serverUrl="https://example.com"
+        setServerUrl={vi.fn()}
+        authType="cloud-iam"
+        setAuthType={vi.fn()}
+        token=""
+        setToken={vi.fn()}
+        certData=""
+        setCertData={vi.fn()}
+        keyData=""
+        setKeyData={vi.fn()}
+        caData=""
+        setCaData={vi.fn()}
+        skipTls={false}
+        setSkipTls={vi.fn()}
+        contextName=""
+        setContextName={vi.fn()}
+        clusterName=""
+        setClusterName={vi.fn()}
+        namespace=""
+        setNamespace={vi.fn()}
+        testResult={null}
+        connectError=""
+        showAdvanced={false}
+        setShowAdvanced={vi.fn()}
+        selectedCloudProvider="eks"
+        setSelectedCloudProvider={vi.fn()}
+        goToConnectStep={vi.fn()}
+        handleTestConnection={vi.fn()}
+        handleAddCluster={vi.fn()}
+      />
+    )
+    const nextBtn = screen.getByRole('button', { name: 'cluster.connectNext' })
+    expect(nextBtn).toBeTruthy()
+    expect((nextBtn as HTMLButtonElement).disabled).toBe(false)
   })
 })


### PR DESCRIPTION
## Summary

In the Add Cluster dialog, selecting **Cloud IAM** on step 2 (Authentication) removed the Next button entirely, so the flow was stuck — users could not proceed to step 3 (Context Settings) without switching auth types.

Root cause: `ConnectTab.tsx` wrapped the Next button in `{authType !== 'cloud-iam' && (...)}`. Cloud IAM flows don't require token/cert input in the UI (the user authenticates via the vendor CLI — `aws sso login`, `gcloud auth login`, `az login`, `oc login`), so the button was wrongly omitted instead of being enabled.

## Fix

- Always render the Next button on step 2.
- Fold the `cloud-iam` case into the `disabled` predicate as `false` (always enabled) so the user can proceed once they've run the CLI auth commands.
- Keeps existing token/certificate disable logic intact (token must be non-empty; cert+key must both be non-empty).

## Test plan

- [x] `npx tsc --noEmit` — zero errors
- [x] `npx eslint ConnectTab.tsx` — no new errors (9 pre-existing warnings about raw `<input>`/`<textarea>` in other lines)
- [x] `npx vitest run ConnectTab.test.tsx` — 2/2 pass, including new regression test asserting the Next button is rendered and enabled when `authType="cloud-iam"`
- [ ] Manual: open Add Cluster → Connect tab → enter URL → Next → click Cloud IAM → verify Next button visible/enabled → click → reaches step 3

Fixes #8914