### PR TITLE
fix: preserve Add Cluster dialog form data across tab switches

### DIFF
--- a/web/src/components/clusters/AddClusterDialog.tsx
+++ b/web/src/components/clusters/AddClusterDialog.tsx
@@ -228,9 +228,13 @@ export function AddClusterDialog({ open, onClose }: AddClusterDialogProps) {
   }
 
   // Clear stale close timers when the dialog is closed (#7593)
+  // Also reset per-tab form state on close so the next open starts fresh.
+  // (During a single open session, state is preserved across tab switches — see #8913.)
   useEffect(() => {
     if (!open) {
       clearTimeout(closeTimerRef.current)
+      resetConnectState()
+      resetImportState()
     }
   }, [open])
 
@@ -276,9 +280,11 @@ export function AddClusterDialog({ open, onClose }: AddClusterDialogProps) {
               key={tab.id}
               onClick={() => {
                 if (!tab.disabled) {
+                  // Preserve each tab's form state when switching tabs so users
+                  // don't lose work if they click the wrong tab by mistake (#8913).
+                  // State is still cleared on dialog close (handleClose) and on
+                  // successful import/add via resetImportState / resetConnectState.
                   setActiveTab(tab.id)
-                  if (tab.id !== 'connect') resetConnectState()
-                  if (tab.id !== 'import') resetImportState()
                 }
               }}
               disabled={tab.disabled}

--- a/web/src/components/clusters/__tests__/AddClusterDialog.test.tsx
+++ b/web/src/components/clusters/__tests__/AddClusterDialog.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from 'vitest'
-import { render } from '@testing-library/react'
+import { render, fireEvent } from '@testing-library/react'
 
 vi.mock('../../../lib/demoMode', () => ({
   isDemoMode: () => true, getDemoMode: () => true, isNetlifyDeployment: false,
@@ -38,5 +38,32 @@ describe('AddClusterDialog', () => {
   it('renders without crashing', () => {
     const { container } = render(<AddClusterDialog open={false} onClose={() => {}} />)
     expect(container).toBeTruthy()
+  })
+
+  // Regression test for #8913 — switching tabs must not wipe the form data
+  // entered in another tab. Previously, the tab onClick called resetConnectState()
+  // / resetImportState() which cleared user input on every tab switch.
+  it('preserves import-tab kubeconfig textarea across tab switches (#8913)', () => {
+    const { getByPlaceholderText, getByText } = render(
+      <AddClusterDialog open={true} onClose={() => {}} />
+    )
+
+    // Start on the default tab, switch to Import, type something, then switch
+    // to Connect and back to Import — the text must still be there.
+    const importTab = getByText('cluster.addClusterImport')
+    fireEvent.click(importTab)
+
+    const textarea = getByPlaceholderText(/apiVersion/i) as HTMLTextAreaElement
+    const SAMPLE_KUBECONFIG = 'apiVersion: v1\nkind: Config'
+    fireEvent.change(textarea, { target: { value: SAMPLE_KUBECONFIG } })
+    expect(textarea.value).toBe(SAMPLE_KUBECONFIG)
+
+    // Switch to Connect tab
+    fireEvent.click(getByText('cluster.addClusterConnect'))
+    // Switch back to Import tab
+    fireEvent.click(getByText('cluster.addClusterImport'))
+
+    const textareaAfter = getByPlaceholderText(/apiVersion/i) as HTMLTextAreaElement
+    expect(textareaAfter.value).toBe(SAMPLE_KUBECONFIG)
   })
 })


### PR DESCRIPTION
## Summary
- The Add Cluster dialog's tab buttons called `resetConnectState()` and `resetImportState()` on every tab switch, wiping all form fields (kubeconfig YAML, server URL, token, cert data, etc.) the moment the user clicked a different tab.
- Clicking the wrong tab by mistake caused users to lose all their work.
- Remove the per-switch resets and move cleanup into the existing dialog-close effect, so state is preserved across tab switches during a single open session but the next open still starts fresh.

Fixes #8913

## Changes
- `web/src/components/clusters/AddClusterDialog.tsx`: remove `resetConnectState()` / `resetImportState()` calls from the tab `onClick`; add them to the `!open` branch of the existing close effect.
- `web/src/components/clusters/__tests__/AddClusterDialog.test.tsx`: regression test — type in Import tab, switch to Connect, switch back, assert textarea value is preserved.

## Test plan
- [x] `npx tsc --noEmit` — zero errors
- [x] `npx eslint` on touched files — zero warnings/errors
- [x] `npx vitest run src/components/clusters/` — all 85 tests pass, including new regression test for #8913
- [ ] Manual: open Add Cluster dialog, paste kubeconfig in Import tab, switch to Connect tab, switch back — kubeconfig should still be there
- [ ] Manual: close dialog, reopen — form starts empty