### PR TITLE
fix: confirm before kubeconfig upload overwrites pasted YAML

### DIFF
--- a/web/src/components/clusters/add-cluster/ImportTab.tsx
+++ b/web/src/components/clusters/add-cluster/ImportTab.tsx
@@ -38,6 +38,20 @@ export function ImportTab({
 
   const newCount = previewContexts.filter((c) => c.isNew).length
 
+  // Wrap the upload handler to confirm before overwriting existing pasted YAML.
+  // Fixes #8917 — uploading a file used to silently replace pasted content.
+  const handleFileUploadWithConfirm = (e: React.ChangeEvent<HTMLInputElement>) => {
+    if (kubeconfigYaml.trim().length > 0) {
+      const confirmed = window.confirm(t('cluster.importOverwriteConfirm'))
+      if (!confirmed) {
+        // Clear the file input so re-selecting the same file still fires onChange next time.
+        if (fileInputRef.current) fileInputRef.current.value = ''
+        return
+      }
+    }
+    handleFileUpload(e)
+  }
+
   return (
     <div className="space-y-4">
       {importState === 'done' ? (
@@ -71,7 +85,7 @@ export function ImportTab({
               ref={fileInputRef}
               type="file"
               accept=".yaml,.yml,.conf,.config"
-              onChange={handleFileUpload}
+              onChange={handleFileUploadWithConfirm}
               className="hidden"
             />
             <button

--- a/web/src/components/clusters/add-cluster/__tests__/ImportTab.test.tsx
+++ b/web/src/components/clusters/add-cluster/__tests__/ImportTab.test.tsx
@@ -1,8 +1,8 @@
 /**
  * ImportTab component smoke tests
  */
-import { describe, it, expect, vi } from 'vitest'
-import { render } from '@testing-library/react'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, fireEvent } from '@testing-library/react'
 import { createRef } from 'react'
 
 vi.mock('../../../../lib/demoMode', () => ({
@@ -58,5 +58,89 @@ describe('ImportTab', () => {
       />
     )
     expect(container).toBeTruthy()
+  })
+
+  describe('upload overwrite confirmation (#8917)', () => {
+    let confirmSpy: ReturnType<typeof vi.spyOn>
+
+    beforeEach(() => {
+      confirmSpy = vi.spyOn(window, 'confirm')
+    })
+
+    afterEach(() => {
+      confirmSpy.mockRestore()
+    })
+
+    // Test fixture: a minimal File that satisfies the onChange handler contract.
+    // We don't actually exercise FileReader here — that logic lives in the parent
+    // (AddClusterDialog.handleFileUpload). We only verify the confirmation gate.
+    const makeFileChangeEvent = (): React.ChangeEvent<HTMLInputElement> => {
+      const file = new File(['apiVersion: v1'], 'kubeconfig.yaml', { type: 'text/yaml' })
+      return {
+        target: { files: [file] as unknown as FileList, value: '' },
+      } as unknown as React.ChangeEvent<HTMLInputElement>
+    }
+
+    const renderTab = (
+      kubeconfigYaml: string,
+      handleFileUpload: (e: React.ChangeEvent<HTMLInputElement>) => void,
+    ) => {
+      const fileInputRef = createRef<HTMLInputElement>()
+      return render(
+        <ImportTab
+          kubeconfigYaml={kubeconfigYaml}
+          setKubeconfigYaml={vi.fn()}
+          importState="idle"
+          setImportState={vi.fn()}
+          previewContexts={[]}
+          setPreviewContexts={vi.fn()}
+          errorMessage=""
+          setErrorMessage={vi.fn()}
+          importedCount={0}
+          fileInputRef={fileInputRef as React.RefObject<HTMLInputElement | null>}
+          handleFileUpload={handleFileUpload}
+          handlePreview={vi.fn()}
+          handleImport={vi.fn()}
+        />,
+      )
+    }
+
+    it('uploads without confirmation when pasted YAML is empty', () => {
+      const handleFileUpload = vi.fn()
+      const { container } = renderTab('', handleFileUpload)
+      const input = container.querySelector('input[type="file"]') as HTMLInputElement
+      fireEvent.change(input, makeFileChangeEvent())
+      expect(confirmSpy).not.toHaveBeenCalled()
+      expect(handleFileUpload).toHaveBeenCalledTimes(1)
+    })
+
+    it('uploads without confirmation when pasted YAML is whitespace only', () => {
+      const handleFileUpload = vi.fn()
+      const { container } = renderTab('   \n  ', handleFileUpload)
+      const input = container.querySelector('input[type="file"]') as HTMLInputElement
+      fireEvent.change(input, makeFileChangeEvent())
+      expect(confirmSpy).not.toHaveBeenCalled()
+      expect(handleFileUpload).toHaveBeenCalledTimes(1)
+    })
+
+    it('prompts for confirmation when pasted YAML exists and proceeds on accept', () => {
+      confirmSpy.mockReturnValue(true)
+      const handleFileUpload = vi.fn()
+      const { container } = renderTab('apiVersion: v1', handleFileUpload)
+      const input = container.querySelector('input[type="file"]') as HTMLInputElement
+      fireEvent.change(input, makeFileChangeEvent())
+      expect(confirmSpy).toHaveBeenCalledTimes(1)
+      expect(handleFileUpload).toHaveBeenCalledTimes(1)
+    })
+
+    it('does NOT call the parent upload handler when the user cancels the confirm', () => {
+      confirmSpy.mockReturnValue(false)
+      const handleFileUpload = vi.fn()
+      const { container } = renderTab('apiVersion: v1', handleFileUpload)
+      const input = container.querySelector('input[type="file"]') as HTMLInputElement
+      fireEvent.change(input, makeFileChangeEvent())
+      expect(confirmSpy).toHaveBeenCalledTimes(1)
+      expect(handleFileUpload).not.toHaveBeenCalled()
+    })
   })
 })

--- a/web/src/locales/en/common.json
+++ b/web/src/locales/en/common.json
@@ -2981,6 +2981,7 @@
     "addClusterConnectDesc": "Add a cluster by entering connection details manually.",
     "importPaste": "Paste your kubeconfig YAML below, or upload a file:",
     "importUpload": "Upload file",
+    "importOverwriteConfirm": "This will replace the kubeconfig YAML you've already pasted. Continue?",
     "importPreview": "Preview",
     "importPreviewDesc": "The following contexts were found:",
     "importButton": "Import {{count}} Cluster(s)",


### PR DESCRIPTION
## Summary

Fixes #8917 — uploading a kubeconfig file used to silently overwrite YAML the user had already pasted into the Import tab, with no warning.

Now, if the textarea already contains non-whitespace content when the user picks a file, they get a `window.confirm()` asking if they want to replace it. If they cancel, the file input is cleared (so re-selecting the same file still fires onChange next time) and the pasted YAML is preserved.

## Changes

- `web/src/components/clusters/add-cluster/ImportTab.tsx` — wraps the `handleFileUpload` prop in `handleFileUploadWithConfirm`, which gates the real handler on a `window.confirm()` call when `kubeconfigYaml.trim().length > 0`.
- `web/src/locales/en/common.json` — new i18n key `cluster.importOverwriteConfirm`.
- `web/src/components/clusters/add-cluster/__tests__/ImportTab.test.tsx` — 4 new tests covering: empty YAML (no confirm), whitespace-only YAML (no confirm), confirm accepted (upload proceeds), confirm cancelled (upload blocked).

## Design notes

The actual `handleFileUpload` implementation lives on `AddClusterDialog.tsx` (it owns the YAML state via `resetImportState`). Rather than modify that file — which PR #8929 (`fix/add-cluster-tab-state-8913`) is already changing for tab-state preservation — the confirmation gate is kept entirely inside `ImportTab.tsx`. No merge conflict risk.

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npx vitest run src/components/clusters/add-cluster/__tests__/ImportTab.test.tsx` — 5/5 pass
- [ ] Manual: paste YAML in Import tab, click Upload File, confirm prompt appears; cancel preserves pasted content, accept replaces it
- [ ] Manual: with empty textarea, click Upload File, no prompt (existing behavior)

Fixes #8917