### PR TITLE
fix: prevent RenameModal button flash during close animation (#8927)

### DIFF
--- a/web/src/components/clusters/components/RenameModal.test.tsx
+++ b/web/src/components/clusters/components/RenameModal.test.tsx
@@ -97,6 +97,26 @@ describe('RenameModal', () => {
     })
   })
 
+  // Regression for #8927: after a successful rename the button must NOT flip
+  // back to "Rename" while the modal is closing.
+  it('shows "Renamed" (not "Rename") after successful rename so close animation does not flash', async () => {
+    render(<RenameModal {...defaultProps} />)
+
+    const input = screen.getByDisplayValue('my-cluster')
+    fireEvent.change(input, { target: { value: 'new-name' } })
+    fireEvent.click(screen.getByText('Rename'))
+
+    await waitFor(() => {
+      expect(defaultProps.onClose).toHaveBeenCalled()
+    })
+
+    // After success, label should be "Renamed", not "Rename".
+    expect(screen.queryByText('Rename')).toBeNull()
+    expect(screen.getByText('Renamed')).toBeTruthy()
+    // Button should remain disabled while the modal is closing.
+    expect(screen.getByText('Renamed').closest('button')?.disabled).toBe(true)
+  })
+
   it('shows error message when onRename rejects', async () => {
     const failingRename = vi.fn().mockRejectedValue(new Error('Server error'))
     render(<RenameModal {...defaultProps} onRename={failingRename} />)

--- a/web/src/components/clusters/components/RenameModal.tsx
+++ b/web/src/components/clusters/components/RenameModal.tsx
@@ -10,35 +10,47 @@ interface RenameModalProps {
   onRename: (oldName: string, newName: string) => Promise<void>
 }
 
+// Phases for the rename action button. The 'success' phase is sticky: once we
+// enter it after a successful rename we stay there until the modal unmounts.
+// This prevents the button from flashing back to "Rename" during the close
+// animation (see #8927).
+type RenamePhase = 'idle' | 'renaming' | 'success'
+
 export function RenameModal({ isOpen = true, clusterName, currentDisplayName, onClose, onRename }: RenameModalProps) {
   const [newName, setNewName] = useState(currentDisplayName)
-  const [status, setStatus] = useState<{ renaming: boolean; error: string | null }>({ renaming: false, error: null })
+  const [phase, setPhase] = useState<RenamePhase>('idle')
+  const [error, setError] = useState<string | null>(null)
 
   const handleRename = async () => {
     if (!newName.trim()) {
-      setStatus(prev => ({ ...prev, error: 'Name cannot be empty' }))
+      setError('Name cannot be empty')
       return
     }
     if (newName.includes(' ')) {
-      setStatus(prev => ({ ...prev, error: 'Name cannot contain spaces' }))
+      setError('Name cannot contain spaces')
       return
     }
     if (newName.trim() === currentDisplayName) {
-      setStatus(prev => ({ ...prev, error: 'Name is unchanged' }))
+      setError('Name is unchanged')
       return
     }
 
-    setStatus({ renaming: true, error: null })
+    setPhase('renaming')
+    setError(null)
 
     try {
       await onRename(clusterName, newName.trim())
+      // Lock the button into the 'success' phase before triggering close so
+      // the label does not flip back to "Rename" while the modal fades out.
+      setPhase('success')
       onClose()
     } catch (err) {
-      setStatus({ renaming: false, error: err instanceof Error ? err.message : 'Failed to rename context' })
-    } finally {
-      setStatus(prev => ({ ...prev, renaming: false }))
+      setPhase('idle')
+      setError(err instanceof Error ? err.message : 'Failed to rename context')
     }
   }
+
+  const isBusy = phase === 'renaming' || phase === 'success'
 
   return (
     <BaseModal isOpen={isOpen} onClose={onClose} size="sm" closeOnBackdrop={false}>
@@ -68,7 +80,7 @@ export function RenameModal({ isOpen = true, clusterName, currentDisplayName, on
           />
         </div>
 
-        {status.error && <p className="text-sm text-red-400 mb-4">{status.error}</p>}
+        {error && <p className="text-sm text-red-400 mb-4">{error}</p>}
 
         <p className="text-xs text-muted-foreground">This updates your kubeconfig via the local agent.</p>
       </BaseModal.Content>
@@ -81,10 +93,16 @@ export function RenameModal({ isOpen = true, clusterName, currentDisplayName, on
           </button>
           <button
             onClick={handleRename}
-            disabled={status.renaming || !newName.trim()}
+            disabled={isBusy || !newName.trim()}
             className="flex items-center gap-2 px-4 py-2 rounded-lg text-sm bg-primary text-primary-foreground hover:bg-primary/80 disabled:opacity-50"
           >
-            {status.renaming ? <><Loader2 className="w-4 h-4 animate-spin" />Renaming...</> : <><Check className="w-4 h-4" />Rename</>}
+            {phase === 'renaming' ? (
+              <><Loader2 className="w-4 h-4 animate-spin" />Renaming...</>
+            ) : phase === 'success' ? (
+              <><Check className="w-4 h-4" />Renamed</>
+            ) : (
+              <><Check className="w-4 h-4" />Rename</>
+            )}
           </button>
         </div>
       </BaseModal.Footer>


### PR DESCRIPTION
## Summary

After a successful cluster context rename, the action button briefly flipped from the `Renaming...` spinner back to the idle `Rename` label while the modal was still fading out. The `finally` block in `handleRename` was resetting the transient busy state before the close animation finished.

## Root cause

In `RenameModal.tsx`:

```ts
try {
  await onRename(...)
  onClose()                     // starts modal fade-out
} catch (err) { ... }
finally {
  setStatus(prev => ({ ...prev, renaming: false })) // <-- flips label back to "Rename" mid-animation
}
```

The `finally` ran after `onClose()` and flipped `renaming: false`, causing a ~200ms flash of the idle `Rename` label during the close animation.

## Fix

Replace the boolean `renaming` flag with a `phase` enum (`idle | renaming | success`). On success we set `phase = 'success'` right before calling `onClose()` and never clear it — the component unmounts with the success label intact.

- Button now shows `Renamed` (with the check icon) after a successful rename instead of briefly reverting to `Rename`.
- Button stays disabled during the close animation.
- Error path correctly resets to `idle` so the user can retry.

## Test plan

- [x] `npx tsc --noEmit` passes
- [x] `npx vitest run src/components/clusters/components/RenameModal.test.tsx` passes (9/9, added regression test asserting the button reads `Renamed` and is disabled after success)
- [x] Lint clean on changed files
- [ ] Manual: rename a context and confirm no flash during close animation

Fixes #8927