### PR TITLE
fix: i18n hardcoded English strings across cluster admin/groups/rename dialogs

### DIFF
--- a/web/src/components/cluster-admin/ClusterAdmin.tsx
+++ b/web/src/components/cluster-admin/ClusterAdmin.tsx
@@ -1,3 +1,4 @@
+import { useTranslation } from 'react-i18next'
 import { useClusters } from '../../hooks/useMCP'
 import { useUniversalStats, createMergedStatValueGetter } from '../../hooks/useUniversalStats'
 import { StatBlockValue } from '../ui/StatsOverview'
@@ -10,6 +11,7 @@ const STORAGE_KEY = 'kubestellar-cluster-admin-cards'
 const DEFAULT_CARDS = getDefaultCards('cluster-admin')
 
 export function ClusterAdmin() {
+  const { t } = useTranslation()
   // Use deduplicatedClusters so the stat blocks count physical clusters, not
   // kubeconfig contexts. Multiple contexts (long path + short alias + per-user
   // SA variants) commonly point to the same server — the raw list double-counts
@@ -42,10 +44,10 @@ export function ClusterAdmin() {
       // made the sidebar disagree with itself (ClusterAdmin showed 10 while
       // My Clusters and Dashboard showed 12 for the same 12 physical clusters
       // with 2 offline).
-      case 'clusters': return { value: clusters.length, sublabel: 'total', isDemo: isDemoData }
-      case 'healthy': return { value: healthy.length, sublabel: 'healthy', isDemo: isDemoData }
-      case 'degraded': return { value: degraded.length, sublabel: 'degraded', isDemo: isDemoData }
-      case 'offline': return { value: offline.length, sublabel: 'offline', isDemo: isDemoData }
+      case 'clusters': return { value: clusters.length, sublabel: t('clusterAdmin.statTotal'), isDemo: isDemoData }
+      case 'healthy': return { value: healthy.length, sublabel: t('clusterAdmin.statHealthy'), isDemo: isDemoData }
+      case 'degraded': return { value: degraded.length, sublabel: t('clusterAdmin.statDegraded'), isDemo: isDemoData }
+      case 'offline': return { value: offline.length, sublabel: t('clusterAdmin.statOffline'), isDemo: isDemoData }
       default: return { value: '-', isDemo: isDemoData }
     }
   }
@@ -54,8 +56,8 @@ export function ClusterAdmin() {
 
   return (
     <DashboardPage
-      title="Cluster Admin"
-      subtitle="Multi-cluster operations, health, and infrastructure management"
+      title={t('clusterAdmin.title')}
+      subtitle={t('clusterAdmin.subtitle')}
       icon="ShieldAlert"
       rightExtra={<RotatingTip page="cluster-admin" />}
       storageKey={STORAGE_KEY}
@@ -69,12 +71,12 @@ export function ClusterAdmin() {
       hasData={hasData}
       isDemoData={isDemoData}
       emptyState={{
-        title: 'Cluster Admin Dashboard',
-        description: 'Add cards to manage cluster health, node operations, upgrades, and security across your infrastructure.' }}
+        title: t('clusterAdmin.emptyTitle'),
+        description: t('clusterAdmin.emptyDescription') }}
     >
       {error && (
         <div className="mb-4 p-4 rounded-lg bg-red-500/10 border border-red-500/20 text-red-400">
-          <div className="font-medium">Error loading cluster data</div>
+          <div className="font-medium">{t('clusterAdmin.errorLoadingData')}</div>
           <div className="text-sm text-muted-foreground">{error}</div>
         </div>
       )}

--- a/web/src/components/clusters/ClusterDetailModal.tsx
+++ b/web/src/components/clusters/ClusterDetailModal.tsx
@@ -178,8 +178,8 @@ export function ClusterDetailModal({ clusterName, clusterUser, onClose, onRename
     ].slice(0, 10).join('\n')
 
     startMission({
-      title: `Diagnose ${clusterName.split('/').pop()}`,
-      description: `Analyzing cluster health and identifying issues`,
+      title: t('cluster.diagnoseMissionTitle', { cluster: clusterName.split('/').pop() }),
+      description: t('cluster.diagnoseMissionDescription'),
       type: 'troubleshoot',
       cluster: clusterName,
       initialPrompt: `Analyze the health of Kubernetes cluster "${clusterName}" and identify any issues that need attention.
@@ -216,8 +216,8 @@ Please analyze this cluster and provide:
     ].join('\n')
 
     startMission({
-      title: `Repair ${clusterName.split('/').pop()}`,
-      description: `Automatically fixing cluster issues`,
+      title: t('cluster.repairMissionTitle', { cluster: clusterName.split('/').pop() }),
+      description: t('cluster.repairMissionDescription'),
       type: 'repair',
       cluster: clusterName,
       initialPrompt: `I need help repairing issues in Kubernetes cluster "${clusterName}".

--- a/web/src/components/clusters/Clusters.tsx
+++ b/web/src/components/clusters/Clusters.tsx
@@ -121,7 +121,7 @@ export function Clusters() {
       try {
         JSON.parse(savedOrder)
       } catch {
-        showToast('Cluster sort preferences were corrupted and have been reset to defaults.', 'warning')
+        showToast(t('cluster.sortPreferencesCorrupted'), 'warning')
       }
     }
   }, []) // eslint-disable-line react-hooks/exhaustive-deps
@@ -149,7 +149,7 @@ export function Clusters() {
   }, [location.key]) // eslint-disable-line react-hooks/exhaustive-deps
 
   const handleRenameContext = async (oldName: string, newName: string) => {
-    if (!isConnected) throw new Error('Local agent not connected')
+    if (!isConnected) throw new Error(t('cluster.renameNoAgent'))
     // Use agentFetch so the Authorization: Bearer <KC_AGENT_TOKEN> header
     // is injected — plain fetch() is rejected with 401 when the agent has
     // a token configured (#6133).

--- a/web/src/components/clusters/add-cluster/ConnectTab.tsx
+++ b/web/src/components/clusters/add-cluster/ConnectTab.tsx
@@ -390,7 +390,7 @@ export function ConnectTab({
                   {testResult.reachable ? (
                     <>
                       <Check className="w-4 h-4 shrink-0" />
-                      {t('cluster.connectTestSuccess')} — Kubernetes {testResult.serverVersion}
+                      {t('cluster.connectTestSuccessKubernetes', { version: testResult.serverVersion })}
                     </>
                   ) : (
                     <>

--- a/web/src/components/clusters/components/ClusterGroups.tsx
+++ b/web/src/components/clusters/components/ClusterGroups.tsx
@@ -68,7 +68,7 @@ export function ClusterGroups({
           className="flex items-center gap-2 text-sm font-medium text-muted-foreground hover:text-foreground transition-colors"
         >
           <FolderOpen className="w-4 h-4" />
-          <span>Cluster Groups ({clusterGroups.length})</span>
+          <span>{t('clusters.groups.title', { count: clusterGroups.length })}</span>
           {showGroups ? <ChevronDown className="w-4 h-4" /> : <ChevronRight className="w-4 h-4" />}
         </button>
         <button
@@ -76,7 +76,7 @@ export function ClusterGroups({
           className="flex items-center gap-1 text-xs text-primary hover:text-primary/80 transition-colors"
         >
           <Plus className="w-3.5 h-3.5" />
-          New Group
+          {t('clusters.groups.newGroup')}
         </button>
       </div>
 
@@ -87,13 +87,13 @@ export function ClusterGroups({
             <div className="glass p-4 rounded-lg space-y-3">
               <input
                 type="text"
-                placeholder="Group name..."
+                placeholder={t('clusters.groups.namePlaceholder')}
                 value={formState.name}
                 onChange={(e) => setFormState(prev => ({ ...prev, name: e.target.value }))}
                 className="w-full px-3 py-2 text-sm bg-secondary/50 border border-border rounded-lg text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-primary"
                 autoFocus
               />
-              <div className="text-xs text-muted-foreground mb-1">Select clusters for this group:</div>
+              <div className="text-xs text-muted-foreground mb-1">{t('clusters.groups.selectClustersLabel')}</div>
               <div className="flex flex-wrap gap-2">
                 {pickerClusters.map((cluster) => {
                   const isInGroup = formState.clusters.includes(cluster.name)
@@ -139,7 +139,7 @@ export function ClusterGroups({
                   onClick={handleCancel}
                   className="px-3 py-1.5 text-sm text-muted-foreground hover:text-foreground"
                 >
-                  Cancel
+                  {t('clusters.groups.cancel')}
                 </button>
                 <button
                   onClick={handleCreateGroup}
@@ -147,7 +147,7 @@ export function ClusterGroups({
                   className="flex items-center gap-1 px-3 py-1.5 text-sm bg-primary text-primary-foreground rounded-lg hover:bg-primary/80 disabled:opacity-50 disabled:cursor-not-allowed"
                 >
                   <Check className="w-3.5 h-3.5" />
-                  Create
+                  {t('clusters.groups.create')}
                 </button>
               </div>
             </div>
@@ -180,7 +180,7 @@ export function ClusterGroups({
                   setDeleteConfirmId(group.id)
                 }}
                 className="p-1.5 rounded hover:bg-red-500/20 text-muted-foreground hover:text-red-400 transition-colors"
-                title="Delete group"
+                title={t('clusters.groups.deleteTooltip')}
               >
                 <Trash2 className="w-4 h-4" />
               </button>

--- a/web/src/components/clusters/components/RenameModal.test.tsx
+++ b/web/src/components/clusters/components/RenameModal.test.tsx
@@ -44,7 +44,7 @@ describe('RenameModal', () => {
   it('renders the modal with current display name pre-filled', () => {
     render(<RenameModal {...defaultProps} />)
 
-    expect(screen.getByText('Rename Context')).toBeTruthy()
+    expect(screen.getByText('cluster.renameContext.title')).toBeTruthy()
     expect(screen.getByDisplayValue('my-cluster')).toBeTruthy()
     expect(screen.getByText(/my-cluster/)).toBeTruthy()
   })
@@ -56,7 +56,7 @@ describe('RenameModal', () => {
     fireEvent.change(input, { target: { value: '' } })
 
     // The Rename button should be disabled when name is empty
-    const renameBtn = screen.getByText('Rename')
+    const renameBtn = screen.getByText('cluster.renameContext.rename')
     expect(renameBtn.closest('button')?.disabled).toBe(true)
   })
 
@@ -66,10 +66,10 @@ describe('RenameModal', () => {
     const input = screen.getByDisplayValue('my-cluster')
     fireEvent.change(input, { target: { value: 'has space' } })
 
-    fireEvent.click(screen.getByText('Rename'))
+    fireEvent.click(screen.getByText('cluster.renameContext.rename'))
 
     await waitFor(() => {
-      expect(screen.getByText('Name cannot contain spaces')).toBeTruthy()
+      expect(screen.getByText('cluster.renameContext.errorSpaces')).toBeTruthy()
     })
   })
 
@@ -77,10 +77,10 @@ describe('RenameModal', () => {
     render(<RenameModal {...defaultProps} />)
 
     // Name is already 'my-cluster', click rename without changing
-    fireEvent.click(screen.getByText('Rename'))
+    fireEvent.click(screen.getByText('cluster.renameContext.rename'))
 
     await waitFor(() => {
-      expect(screen.getByText('Name is unchanged')).toBeTruthy()
+      expect(screen.getByText('cluster.renameContext.errorUnchanged')).toBeTruthy()
     })
   })
 
@@ -89,7 +89,7 @@ describe('RenameModal', () => {
 
     const input = screen.getByDisplayValue('my-cluster')
     fireEvent.change(input, { target: { value: 'new-name' } })
-    fireEvent.click(screen.getByText('Rename'))
+    fireEvent.click(screen.getByText('cluster.renameContext.rename'))
 
     await waitFor(() => {
       expect(defaultProps.onRename).toHaveBeenCalledWith('cluster-1', 'new-name')
@@ -123,7 +123,7 @@ describe('RenameModal', () => {
 
     const input = screen.getByDisplayValue('my-cluster')
     fireEvent.change(input, { target: { value: 'new-name' } })
-    fireEvent.click(screen.getByText('Rename'))
+    fireEvent.click(screen.getByText('cluster.renameContext.rename'))
 
     await waitFor(() => {
       expect(screen.getByText('Server error')).toBeTruthy()
@@ -132,7 +132,7 @@ describe('RenameModal', () => {
 
   it('does not render when isOpen is false', () => {
     render(<RenameModal {...defaultProps} isOpen={false} />)
-    expect(screen.queryByText('Rename Context')).toBeNull()
+    expect(screen.queryByText('cluster.renameContext.title')).toBeNull()
   })
 
   it('calls onClose when Escape key is pressed', () => {

--- a/web/src/components/clusters/components/RenameModal.tsx
+++ b/web/src/components/clusters/components/RenameModal.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react'
+import { useTranslation } from 'react-i18next'
 import { Check, Loader2, Edit3 } from 'lucide-react'
 import { BaseModal } from '../../../lib/modals'
 
@@ -17,21 +18,22 @@ interface RenameModalProps {
 type RenamePhase = 'idle' | 'renaming' | 'success'
 
 export function RenameModal({ isOpen = true, clusterName, currentDisplayName, onClose, onRename }: RenameModalProps) {
+  const { t } = useTranslation()
   const [newName, setNewName] = useState(currentDisplayName)
   const [phase, setPhase] = useState<RenamePhase>('idle')
   const [error, setError] = useState<string | null>(null)
 
   const handleRename = async () => {
     if (!newName.trim()) {
-      setError('Name cannot be empty')
+      setError(t('cluster.renameContext.errorEmpty'))
       return
     }
     if (newName.includes(' ')) {
-      setError('Name cannot contain spaces')
+      setError(t('cluster.renameContext.errorSpaces'))
       return
     }
     if (newName.trim() === currentDisplayName) {
-      setError('Name is unchanged')
+      setError(t('cluster.renameContext.errorUnchanged'))
       return
     }
 
@@ -46,7 +48,7 @@ export function RenameModal({ isOpen = true, clusterName, currentDisplayName, on
       onClose()
     } catch (err) {
       setPhase('idle')
-      setError(err instanceof Error ? err.message : 'Failed to rename context')
+      setError(err instanceof Error ? err.message : t('cluster.renameContext.errorFailed'))
     }
   }
 
@@ -55,7 +57,7 @@ export function RenameModal({ isOpen = true, clusterName, currentDisplayName, on
   return (
     <BaseModal isOpen={isOpen} onClose={onClose} size="sm" closeOnBackdrop={false}>
       <BaseModal.Header
-        title="Rename Context"
+        title={t('cluster.renameContext.title')}
         icon={Edit3}
         onClose={onClose}
         showBack={false}
@@ -63,11 +65,11 @@ export function RenameModal({ isOpen = true, clusterName, currentDisplayName, on
 
       <BaseModal.Content>
         <p className="text-sm text-muted-foreground mb-4">
-          Current: <span className="text-foreground font-mono text-xs break-all">{currentDisplayName}</span>
+          {t('cluster.renameContext.currentLabel')} <span className="text-foreground font-mono text-xs break-all">{currentDisplayName}</span>
         </p>
 
         <div className="mb-4">
-          <label htmlFor="new-context-name" className="block text-sm text-muted-foreground mb-1">New name</label>
+          <label htmlFor="new-context-name" className="block text-sm text-muted-foreground mb-1">{t('cluster.renameContext.newNameLabel')}</label>
           <input
             id="new-context-name"
             type="text"
@@ -82,14 +84,14 @@ export function RenameModal({ isOpen = true, clusterName, currentDisplayName, on
 
         {error && <p className="text-sm text-red-400 mb-4">{error}</p>}
 
-        <p className="text-xs text-muted-foreground">This updates your kubeconfig via the local agent.</p>
+        <p className="text-xs text-muted-foreground">{t('cluster.renameContext.updatesKubeconfigHint')}</p>
       </BaseModal.Content>
 
       <BaseModal.Footer showKeyboardHints>
         <div className="flex-1" />
         <div className="flex gap-2">
           <button onClick={onClose} className="px-4 py-2 rounded-lg text-sm text-muted-foreground hover:text-foreground hover:bg-secondary/50">
-            Cancel
+            {t('cluster.renameContext.cancel')}
           </button>
           <button
             onClick={handleRename}
@@ -97,11 +99,11 @@ export function RenameModal({ isOpen = true, clusterName, currentDisplayName, on
             className="flex items-center gap-2 px-4 py-2 rounded-lg text-sm bg-primary text-primary-foreground hover:bg-primary/80 disabled:opacity-50"
           >
             {phase === 'renaming' ? (
-              <><Loader2 className="w-4 h-4 animate-spin" />Renaming...</>
+              <><Loader2 className="w-4 h-4 animate-spin" />{t('cluster.renameContext.renaming')}</>
             ) : phase === 'success' ? (
-              <><Check className="w-4 h-4" />Renamed</>
+              <><Check className="w-4 h-4" />{t('cluster.renameContext.renamed')}</>
             ) : (
-              <><Check className="w-4 h-4" />Rename</>
+              <><Check className="w-4 h-4" />{t('cluster.renameContext.rename')}</>
             )}
           </button>
         </div>

--- a/web/src/locales/en/common.json
+++ b/web/src/locales/en/common.json
@@ -3050,7 +3050,28 @@
     "removeClusterSuccess": "Removed cluster \"{{name}}\" from kubeconfig",
     "removeClusterError": "Failed to remove cluster from kubeconfig",
     "removeClusterNoAgent": "Local agent not connected",
-    "removeClusterAgentTooOld": "Your local kc-agent is out of date and doesn't support removing clusters from the kubeconfig. Please upgrade kc-agent to the latest release and try again."
+    "removeClusterAgentTooOld": "Your local kc-agent is out of date and doesn't support removing clusters from the kubeconfig. Please upgrade kc-agent to the latest release and try again.",
+    "renameNoAgent": "Local agent not connected",
+    "sortPreferencesCorrupted": "Cluster sort preferences were corrupted and have been reset to defaults.",
+    "connectTestSuccessKubernetes": "Connected — Kubernetes {{version}}",
+    "renameContext": {
+      "title": "Rename Context",
+      "currentLabel": "Current:",
+      "newNameLabel": "New name",
+      "updatesKubeconfigHint": "This updates your kubeconfig via the local agent.",
+      "cancel": "Cancel",
+      "rename": "Rename",
+      "renaming": "Renaming...",
+      "renamed": "Renamed",
+      "errorEmpty": "Name cannot be empty",
+      "errorSpaces": "Name cannot contain spaces",
+      "errorUnchanged": "Name is unchanged",
+      "errorFailed": "Failed to rename context"
+    },
+    "diagnoseMissionTitle": "Diagnose {{cluster}}",
+    "diagnoseMissionDescription": "Analyzing cluster health and identifying issues",
+    "repairMissionTitle": "Repair {{cluster}}",
+    "repairMissionDescription": "Automatically fixing cluster issues"
   },
   "remediation": {
     "title": "AI Remediation Console",
@@ -3388,8 +3409,25 @@
       "deleteTitle": "Delete Cluster Group",
       "deleteMessage": "Are you sure you want to delete this cluster group? This action cannot be undone.",
       "deleteConfirm": "Delete cluster group \"{{name}}\"? This cannot be undone.",
-      "title": "Cluster Groups ({{count}})"
+      "title": "Cluster Groups ({{count}})",
+      "newGroup": "New Group",
+      "namePlaceholder": "Group name...",
+      "selectClustersLabel": "Select clusters for this group:",
+      "cancel": "Cancel",
+      "create": "Create",
+      "deleteTooltip": "Delete group"
     }
+  },
+  "clusterAdmin": {
+    "title": "Cluster Admin",
+    "subtitle": "Multi-cluster operations, health, and infrastructure management",
+    "emptyTitle": "Cluster Admin Dashboard",
+    "emptyDescription": "Add cards to manage cluster health, node operations, upgrades, and security across your infrastructure.",
+    "errorLoadingData": "Error loading cluster data",
+    "statTotal": "total",
+    "statHealthy": "healthy",
+    "statDegraded": "degraded",
+    "statOffline": "offline"
   },
   "discardUnsavedChanges": "Discard unsaved changes?",
   "discardUnsavedChangesMessage": "You have unsaved changes that will be lost.",


### PR DESCRIPTION
## Summary

Eight i18n bugs shared a common root cause: components rendering hardcoded English strings regardless of the selected language. Fixed together since all new keys land in `web/src/locales/en/common.json` (bundling avoids merge conflicts).

### Components touched

- `RenameModal` — dialog title, current/new-name labels, hint, buttons, validation errors
- `ConnectTab` — test-success message `"Connected — Kubernetes <version>"` collapsed into a single interpolated key
- `ClusterAdmin` — page title, subtitle, empty state, error heading, stat sublabels (`total`/`healthy`/`degraded`/`offline`)
- `ClusterGroups` — `New Group` button, name placeholder, `Select clusters for this group`, Cancel/Create buttons, delete tooltip, header count
- `Clusters` — corrupted sort-preference warning toast + `Local agent not connected` rename error
- `ClusterDetailModal` — AI mission title/description for Diagnose and Repair actions

### New translation keys (all under `web/src/locales/en/common.json`)

- `cluster.renameContext.{title,currentLabel,newNameLabel,updatesKubeconfigHint,cancel,rename,renaming,errorEmpty,errorSpaces,errorUnchanged,errorFailed}`
- `cluster.connectTestSuccessKubernetes` (`"Connected — Kubernetes {{version}}"`)
- `cluster.sortPreferencesCorrupted`
- `cluster.renameNoAgent`
- `cluster.diagnoseMissionTitle`, `cluster.diagnoseMissionDescription`
- `cluster.repairMissionTitle`, `cluster.repairMissionDescription`
- `clusters.groups.{newGroup,namePlaceholder,selectClustersLabel,cancel,create,deleteTooltip}` (reused existing `clusters.groups.title` for the header count)
- `clusterAdmin.{title,subtitle,emptyTitle,emptyDescription,errorLoadingData,statTotal,statHealthy,statDegraded,statOffline}`

### Test plan

- [x] `npx tsc --noEmit` — clean (no new TS errors)
- [x] `npm run lint` — baseline error count unchanged (15 pre-existing errors in unrelated files, 0 new errors from this change)
- [x] Updated `RenameModal.test.tsx` expectations to match new i18n keys (the test's `useTranslation` mock returns the key verbatim)
- [ ] Manually verify each dialog renders translated text when locale is switched to a non-English option (caught by CI and smoke tests)

Fixes #8918
Fixes #8919
Fixes #8920
Fixes #8921
Fixes #8922
Fixes #8923
Fixes #8925
Fixes #8926