### PR TITLE
fix: add confirmation dialog before cluster group delete (#8916)

### DIFF
--- a/web/src/components/clusters/ClusterGroupsSection.tsx
+++ b/web/src/components/clusters/ClusterGroupsSection.tsx
@@ -5,6 +5,7 @@ import type { ClusterInfo } from '../../hooks/mcp/types'
 import type { ClusterGroup } from '../../hooks/useGlobalFilters'
 import { deduplicateClustersByServer } from '../../hooks/mcp/shared'
 import { getClusterHealthState, isClusterUnreachable } from './utils'
+import { ConfirmDialog } from '../../lib/modals'
 
 export interface ClusterGroupsSectionProps {
   /** All clusters (unfiltered) for the new-group cluster picker */
@@ -36,6 +37,10 @@ export function ClusterGroupsSection({
   const [showGroupForm, setShowGroupForm] = useState(false)
   const [newGroupName, setNewGroupName] = useState('')
   const [newGroupClusters, setNewGroupClusters] = useState<string[]>([])
+  // Pending delete confirmation — null when no dialog is shown. Storing the
+  // whole group (id + name) lets the dialog show the name while the confirm
+  // handler deletes by id (#8916).
+  const [deleteConfirmGroup, setDeleteConfirmGroup] = useState<{ id: string; name: string } | null>(null)
 
   // Deduplicate clusters so contexts pointing at the same server are not
   // rendered twice in the picker (#5922). Uses the same helper as the main
@@ -194,7 +199,8 @@ export function ClusterGroupsSection({
               <button
                 onClick={(e) => {
                   e.stopPropagation()
-                  deleteClusterGroup(group.id)
+                  // Open confirmation dialog instead of deleting immediately (#8916).
+                  setDeleteConfirmGroup({ id: group.id, name: group.name })
                 }}
                 className="p-1.5 rounded hover:bg-red-500/20 text-muted-foreground hover:text-red-400 transition-colors"
                 title={t('cluster.deleteGroup')}
@@ -205,6 +211,27 @@ export function ClusterGroupsSection({
           ))}
         </div>
       )}
+
+      {/* Delete confirmation dialog — prevents accidental irreversible delete
+          of a cluster group (#8916). */}
+      <ConfirmDialog
+        isOpen={deleteConfirmGroup !== null}
+        onClose={() => setDeleteConfirmGroup(null)}
+        onConfirm={() => {
+          if (deleteConfirmGroup) {
+            deleteClusterGroup(deleteConfirmGroup.id)
+            setDeleteConfirmGroup(null)
+          }
+        }}
+        title={t('clusters.groups.deleteTitle')}
+        message={t('clusters.groups.deleteConfirm', {
+          name: deleteConfirmGroup?.name ?? '',
+          defaultValue: 'Delete cluster group "{{name}}"? This cannot be undone.',
+        })}
+        confirmLabel={t('actions.delete')}
+        cancelLabel={t('actions.cancel')}
+        variant="danger"
+      />
     </div>
   )
 }

--- a/web/src/components/clusters/__tests__/ClusterGroupsSection.test.tsx
+++ b/web/src/components/clusters/__tests__/ClusterGroupsSection.test.tsx
@@ -2,6 +2,8 @@
  * ClusterGroupsSection Component Tests
  */
 import { describe, it, expect, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import type { ClusterGroup } from '../../../hooks/useGlobalFilters'
 
 vi.mock('react-i18next', () => ({
   useTranslation: () => ({ t: (k: string) => k }),
@@ -12,5 +14,65 @@ describe('ClusterGroupsSection', () => {
     const mod = await import('../ClusterGroupsSection')
     expect(mod.ClusterGroupsSection).toBeDefined()
     expect(typeof mod.ClusterGroupsSection).toBe('function')
+  })
+
+  // Regression test for #8916 — clicking the trash icon on a cluster group
+  // must show a confirmation dialog instead of deleting immediately.
+  it('does not invoke deleteClusterGroup until the user confirms (#8916)', async () => {
+    const { ClusterGroupsSection } = await import('../ClusterGroupsSection')
+    const deleteClusterGroup = vi.fn()
+    const groups: ClusterGroup[] = [
+      { id: 'grp-1', name: 'production', clusters: ['c1', 'c2'] },
+    ]
+
+    render(
+      <ClusterGroupsSection
+        clusters={[]}
+        clusterGroups={groups}
+        addClusterGroup={vi.fn()}
+        deleteClusterGroup={deleteClusterGroup}
+        selectClusterGroup={vi.fn()}
+      />
+    )
+
+    // Section is collapsed by default — expand it.
+    fireEvent.click(screen.getByText('clusters.groups.title'))
+
+    // Click the delete (trash) button. It should open the confirm dialog,
+    // NOT call deleteClusterGroup directly.
+    const deleteButton = screen.getByTitle('cluster.deleteGroup')
+    fireEvent.click(deleteButton)
+    expect(deleteClusterGroup).not.toHaveBeenCalled()
+
+    // Dialog shows the group name and confirm label — confirming fires the delete.
+    const confirmButton = screen.getByText('actions.delete')
+    fireEvent.click(confirmButton)
+    expect(deleteClusterGroup).toHaveBeenCalledTimes(1)
+    expect(deleteClusterGroup).toHaveBeenCalledWith('grp-1')
+  })
+
+  it('cancelling the confirm dialog does not delete the group (#8916)', async () => {
+    const { ClusterGroupsSection } = await import('../ClusterGroupsSection')
+    const deleteClusterGroup = vi.fn()
+    const groups: ClusterGroup[] = [
+      { id: 'grp-2', name: 'staging', clusters: ['c3'] },
+    ]
+
+    render(
+      <ClusterGroupsSection
+        clusters={[]}
+        clusterGroups={groups}
+        addClusterGroup={vi.fn()}
+        deleteClusterGroup={deleteClusterGroup}
+        selectClusterGroup={vi.fn()}
+      />
+    )
+
+    fireEvent.click(screen.getByText('clusters.groups.title'))
+    fireEvent.click(screen.getByTitle('cluster.deleteGroup'))
+
+    // Clicking Cancel should close the dialog without calling delete.
+    fireEvent.click(screen.getByText('actions.cancel'))
+    expect(deleteClusterGroup).not.toHaveBeenCalled()
   })
 })

--- a/web/src/locales/en/common.json
+++ b/web/src/locales/en/common.json
@@ -3386,6 +3386,7 @@
     "groups": {
       "deleteTitle": "Delete Cluster Group",
       "deleteMessage": "Are you sure you want to delete this cluster group? This action cannot be undone.",
+      "deleteConfirm": "Delete cluster group \"{{name}}\"? This cannot be undone.",
       "title": "Cluster Groups ({{count}})"
     }
   },


### PR DESCRIPTION
## Summary

- Clicking the trash icon on a cluster group in **Cluster Admin** previously deleted the group instantly with no confirmation — inconsistent with the kubeconfig cluster removal flow and risky for an irreversible action.
- Gate the delete behind `ConfirmDialog` (variant=`danger`) with the group name interpolated into the message. Matches the pattern already used by the card version of `ClusterGroups` and by `LocalClustersSection`.
- Added a new i18n key `clusters.groups.deleteConfirm` with `{{name}}` interpolation: `Delete cluster group "{{name}}"? This cannot be undone.`

## Files

- `web/src/components/clusters/ClusterGroupsSection.tsx` — wire `ConfirmDialog`, new `deleteConfirmGroup` state, trash button now opens the dialog instead of calling `deleteClusterGroup` directly.
- `web/src/locales/en/common.json` — new `clusters.groups.deleteConfirm` key.
- `web/src/components/clusters/__tests__/ClusterGroupsSection.test.tsx` — two regression tests covering the confirm + cancel paths.

## Test plan

- [x] `npx tsc --noEmit` passes
- [x] `npx vitest run src/components/clusters/__tests__/ClusterGroupsSection.test.tsx` — 3/3 pass (new: confirm-path, cancel-path)
- [x] `npm run build` passes
- [ ] Manual: open Cluster Admin, click trash icon on a group, verify dialog appears, Cancel keeps the group, Delete removes it

Fixes #8916