### PR TITLE
fix(acmm): contain RepoPicker divider to page content width

### DIFF
--- a/web/src/components/acmm/RepoPicker.tsx
+++ b/web/src/components/acmm/RepoPicker.tsx
@@ -24,6 +24,15 @@ const REPO_RE = /^[\w.-]+\/[\w.-]+$/
 const BADGE_SITE = 'https://console.kubestellar.io'
 const COPIED_FEEDBACK_MS = 1500
 
+/** Max width for the repo-input form on wide viewports. A GitHub slug
+ *  like `owner/repo` is typically 20-40 chars; capping here keeps the
+ *  sticky header from stretching into a messy unplanned-looking bar
+ *  on 1536px+ displays (issue #8857). */
+const REPO_FORM_MAX_WIDTH_PX = 560
+/** Minimum width for the repo-input form so the input + Scan button
+ *  don't collapse below usability on narrow viewports. */
+const REPO_FORM_MIN_WIDTH_PX = 300
+
 /** Hex equivalents of the shields.io named colors used in acmm-badge.mts
  *  LEVEL_COLORS (lightgrey, yellow, yellowgreen, brightgreen, blueviolet).
  *  Hex values are needed here because the inline badge SVG preview renders
@@ -117,7 +126,13 @@ export function RepoPicker() {
     : '—'
 
   return (
-    <div className="sticky top-0 z-20 bg-background/95 backdrop-blur-sm border-b border-border">
+    // Issue 8857 — the `border-b` used to live on this outer sticky wrapper,
+    // which stretched the divider edge-to-edge across the viewport while the
+    // inner content was capped at `max-w-screen-2xl mx-auto px-6`. On wide
+    // screens that produced a full-width bar that didn't align with anything
+    // else on the page ("messy and unplanned"). The divider now sits on the
+    // last inner container so it aligns with the page content width.
+    <div className="sticky top-0 z-20 bg-background/95 backdrop-blur-sm">
       <div className="max-w-screen-2xl mx-auto px-6 pt-2 pb-0">
         <button
           type="button"
@@ -135,7 +150,11 @@ export function RepoPicker() {
             e.preventDefault()
             submit(input)
           }}
-          className="flex items-center gap-2 flex-1 min-w-[300px]"
+          className="flex items-center gap-2 flex-1"
+          style={{
+            minWidth: `${REPO_FORM_MIN_WIDTH_PX}px`,
+            maxWidth: `${REPO_FORM_MAX_WIDTH_PX}px`,
+          }}
         >
           <div className="relative flex-1">
             <Input
@@ -291,7 +310,7 @@ export function RepoPicker() {
         </div>
       )}
 
-      <div className="max-w-screen-2xl mx-auto px-6 pb-2 text-xs text-muted-foreground">
+      <div className="max-w-screen-2xl mx-auto px-6 pb-2 text-xs text-muted-foreground border-b border-border/60">
         {error ? (
           <div className="flex items-center gap-1.5 text-red-400">
             <AlertCircle className="w-3.5 h-3.5" />


### PR DESCRIPTION
## Summary

Fixes the messy, unplanned-looking horizontal bar under the ACMM RepoPicker header reported in #8857.

The sticky RepoPicker wrapper had `border-b border-border` on its outer container, so the divider stretched edge-to-edge across the viewport while the inner content was capped at `max-w-screen-2xl mx-auto px-6`. On wide screens the divider did not align with anything else on the page.

## Changes

- Remove `border-b border-border` from the outer sticky wrapper.
- Add `border-b border-border/60` to the last inner `max-w-screen-2xl` container so the divider aligns with the rest of the dashboard content.
- Cap the repo-input form at `REPO_FORM_MAX_WIDTH_PX` (560px) so on wide monitors the form does not stretch across the header row.
- All magic numbers use named constants with comments.

## Test plan

- [x] `npm run build` passes locally
- [x] ESLint clean on the edited file
- [ ] Visual check: /acmm header divider aligns with content max-width on 1920px+ monitors
- [ ] Visual check: form does not dominate the header on wide displays

Fixes #8857