### PR TITLE
fix: ACMM card cluster (5 bugs: #8847/8849/8850/8851/8852)

### DIFF
--- a/web/src/components/cards/ACMMFeedbackLoops.tsx
+++ b/web/src/components/cards/ACMMFeedbackLoops.tsx
@@ -7,6 +7,7 @@
  */
 
 import { Fragment, useMemo, useState } from 'react'
+import { useTranslation } from 'react-i18next'
 import { Check, X, Filter, ChevronDown, ChevronRight, Flag, Sparkles, Lock, Unlock, Eye, RefreshCw } from 'lucide-react'
 import { useCardLoadingState } from './CardDataContext'
 import { CardSkeleton } from '../../lib/cards/CardComponents'
@@ -110,6 +111,7 @@ function proposeChangeUrl(c: Criterion): string {
 }
 
 export function ACMMFeedbackLoops() {
+  const { t } = useTranslation()
   const { scan, repo } = useACMM()
   const { detectedIds, isLoading, isRefreshing, isDemoData, isFailed, consecutiveFailures, lastRefresh } = scan
   const { startMission } = useMissions()
@@ -531,11 +533,11 @@ export function ACMMFeedbackLoops() {
                         setExpandedId(null)
                       }}
                       className="inline-flex items-center gap-1 text-[10px] text-muted-foreground hover:text-foreground transition-colors"
-                      aria-label="Close details"
-                      title="Close details"
+                      aria-label={t('actions.close')}
+                      title={t('actions.close')}
                     >
                       <X className="w-3 h-3" />
-                      Close
+                      {t('actions.close')}
                     </button>
                   </div>
                   <div className="px-3 pb-2 pt-1.5 text-[10px] space-y-1.5">

--- a/web/src/components/cards/ACMMFeedbackLoops.tsx
+++ b/web/src/components/cards/ACMMFeedbackLoops.tsx
@@ -6,7 +6,7 @@
  * detected/missing status.
  */
 
-import { useMemo, useState } from 'react'
+import { Fragment, useMemo, useState } from 'react'
 import { Check, X, Filter, ChevronDown, ChevronRight, Flag, Sparkles, Lock, Unlock, Eye, RefreshCw } from 'lucide-react'
 import { useCardLoadingState } from './CardDataContext'
 import { CardSkeleton } from '../../lib/cards/CardComponents'
@@ -247,8 +247,11 @@ export function ACMMFeedbackLoops() {
   const sources: (SourceId | 'all')[] = ['all', 'acmm', 'fullsend', 'agentic-engineering-framework', 'claude-reflect']
 
   return (
-    <div className="h-full flex flex-col p-2 gap-2 max-w-4xl">
-      <div className="flex items-center gap-1.5 flex-wrap">
+    // Fill parent container width (issue #8847) — no artificial max-width cap.
+    // Controls row uses `justify-between` so left filters and right actions
+    // anchor to the card edges instead of clumping in the center.
+    <div className="h-full w-full flex flex-col p-2 gap-2">
+      <div className="flex items-center gap-1.5 flex-wrap w-full">
         {/* View mode toggle: By Level / Cross-cutting */}
         {(['by-level', 'cross-cutting'] as const).map((m) => (
           <button
@@ -340,14 +343,27 @@ export function ACMMFeedbackLoops() {
           // first item of level N. The previous item's level determines
           // the boundary — if it differs from the current item's level
           // and both have levels, we're crossing a boundary.
+          //
+          // Fix #8849/#8850 — L1 ALSO needs a header marker so the first
+          // group isn't visually anonymous. When idx === 0 and the first
+          // item has a level, we render a non-actionable "Level N" marker
+          // (typically L1) using the same divider component.
           const prevLevel = idx > 0 ? (filtered[idx - 1].level ?? 0) : 0
           const curLevel = c.level ?? 0
-          const showLevelBreak = viewMode === 'by-level' && curLevel > prevLevel && prevLevel > 0 && curLevel >= 2
+          const isFirstLevelMarker = viewMode === 'by-level' && idx === 0 && curLevel > 0
+          const showLevelBreak =
+            viewMode === 'by-level' &&
+            (isFirstLevelMarker || (curLevel > prevLevel && prevLevel > 0 && curLevel >= 2))
           /** Whether this level-break button is actionable. Only the
            *  immediate next level above earned is active; higher levels
            *  are "locked" until the preceding one is completed. */
           const levelBreakActive = curLevel <= earnedLevel + 1 || locksOverridden
           const levelBreakMissing = (cumulativeMissing[curLevel] || []).length
+          // For the L1 starting marker (#8850), there is no "level up to L1"
+          // action — L1 is the baseline. We show a parallel visual marker
+          // that says "Level 1 — Foundation" with the same border/background
+          // treatment so L1 has the same structural divider that L2/L3 do.
+          const isBaselineMarker = isFirstLevelMarker && curLevel <= 1
           const levelBreak = showLevelBreak ? (
             <div
               key={`level-break-${curLevel}`}
@@ -359,15 +375,22 @@ export function ACMMFeedbackLoops() {
             >
               <div className="flex-1 min-w-0">
                 <span className={`text-sm font-medium ${levelBreakActive ? 'text-foreground' : 'text-muted-foreground'}`}>
-                  Reach Level {curLevel}
+                  {isBaselineMarker ? `Level ${curLevel} — Foundation` : `Reach Level ${curLevel}`}
                 </span>
-                {levelBreakMissing > 0 && (
+                {!isBaselineMarker && levelBreakMissing > 0 && (
                   <span className="text-xs text-muted-foreground ml-2">
                     {levelBreakMissing} {levelBreakMissing === 1 ? 'criterion' : 'criteria'} to go
                   </span>
                 )}
               </div>
-              {levelBreakActive ? (
+              {isBaselineMarker ? (
+                // L1 has no "level up" action — it's where everyone starts.
+                // Keep the column balanced with a small label so the divider
+                // matches L2/L3 proportions visually.
+                <span className="inline-flex items-center gap-1.5 px-3 py-1 text-xs text-muted-foreground">
+                  Baseline
+                </span>
+              ) : levelBreakActive ? (
                 <button
                   type="button"
                   onClick={() => launchCumulativeLevelUp(curLevel)}
@@ -399,8 +422,7 @@ export function ACMMFeedbackLoops() {
           const isLocked = !locksOverridden && !!c.level && c.level > earnedLevel + 1
           const isLockPromptOpen = lockPromptId === c.id
           return (
-            <>{dimHeader}{levelBreak}<div
-              key={c.id}
+            <Fragment key={c.id}>{dimHeader}{levelBreak}<div
               className={`rounded-md transition-colors ${
                 isLocked ? 'bg-muted/10 hover:bg-muted/20 opacity-60' : 'bg-muted/20 hover:bg-muted/40'
               }`}
@@ -492,7 +514,31 @@ export function ACMMFeedbackLoops() {
                 </div>
               )}
               {!isLocked && isExpanded && (
-                <div className="px-8 pb-2 pt-0 text-[10px] space-y-1.5 border-t border-border/30">
+                // Fix #8851 — previously the click just made the bar taller,
+                // giving no signal that a distinct "detail view" had opened.
+                // We now render an inset detail panel with its own header and
+                // an explicit Close control, so the click-to-open interaction
+                // is unambiguous and dismissable.
+                <div className="mx-2 mb-2 rounded-md border border-border/60 bg-background/60 shadow-sm">
+                  <div className="flex items-center justify-between gap-2 px-3 py-1.5 border-b border-border/40 bg-muted/20 rounded-t-md">
+                    <div className="text-[10px] font-medium uppercase tracking-wide text-muted-foreground">
+                      Details — {c.name}
+                    </div>
+                    <button
+                      type="button"
+                      onClick={(e) => {
+                        e.stopPropagation()
+                        setExpandedId(null)
+                      }}
+                      className="inline-flex items-center gap-1 text-[10px] text-muted-foreground hover:text-foreground transition-colors"
+                      aria-label="Close details"
+                      title="Close details"
+                    >
+                      <X className="w-3 h-3" />
+                      Close
+                    </button>
+                  </div>
+                  <div className="px-3 pb-2 pt-1.5 text-[10px] space-y-1.5">
                   {/* Details blurb — what it is, why it matters, how a mission implements it */}
                   {c.details && (
                     <p className="text-[11px] leading-relaxed text-muted-foreground/90 py-1">
@@ -575,9 +621,10 @@ export function ACMMFeedbackLoops() {
                       </button>
                     )}
                   </div>
+                  </div>
                 </div>
               )}
-            </div></>
+            </div></Fragment>
           )
         })}
         {filtered.length === 0 && (

--- a/web/src/components/cards/ACMMRecommendations.tsx
+++ b/web/src/components/cards/ACMMRecommendations.tsx
@@ -162,7 +162,10 @@ export function ACMMRecommendations() {
             <button
               type="button"
               onClick={launchAll}
-              className="inline-flex items-center gap-1 text-[10px] px-2 py-0.5 rounded-full bg-primary/20 text-primary hover:bg-primary/30 transition-colors"
+              /* #8852 — previously bg-primary/20 + text-primary failed AA.
+                 Use solid primary background with primary-foreground text
+                 so the "Ask agent" CTA passes contrast in the action bar. */
+              className="inline-flex items-center gap-1 text-[10px] px-2 py-0.5 rounded-full bg-primary text-primary-foreground hover:bg-primary/90 font-medium transition-colors"
               title={`Ask the selected agent to add all ${recommendations.length} missing criteria to ${repo}`}
             >
               <Sparkles className="w-2.5 h-2.5" />
@@ -183,7 +186,9 @@ export function ACMMRecommendations() {
                     const src = SOURCES_BY_ID[s]
                     const badge = (
                       <span
-                        className="text-[9px] px-1.5 py-0.5 rounded-full bg-primary/20 text-primary hover:bg-primary/30"
+                        /* #8852 — darker background + foreground text for AA
+                           contrast on the source chips in the action bar. */
+                        className="text-[9px] px-1.5 py-0.5 rounded-full bg-primary/40 text-foreground font-medium hover:bg-primary/50"
                         title={src?.citation}
                       >
                         {SOURCE_LABELS[s]}
@@ -212,7 +217,9 @@ export function ACMMRecommendations() {
                 <button
                   type="button"
                   onClick={() => launchOne(rec)}
-                  className="inline-flex items-center gap-1 text-[10px] px-1.5 py-0.5 rounded-md bg-primary/10 text-primary hover:bg-primary/20 transition-colors flex-shrink-0"
+                  /* #8852 — bg-primary/10 against text-primary failed AA.
+                     Raise to solid primary fill for legible action affordance. */
+                  className="inline-flex items-center gap-1 text-[10px] px-1.5 py-0.5 rounded-md bg-primary text-primary-foreground hover:bg-primary/90 font-medium transition-colors flex-shrink-0"
                   title={`Ask the selected agent to add the "${rec.criterion.name}" criterion to ${repo}`}
                 >
                   <Zap className="w-2.5 h-2.5" />


### PR DESCRIPTION
Fixes #8847
Fixes #8849
Fixes #8850
Fixes #8851
Fixes #8852

Bundles 5 ACMM card visual/interaction bugs.

## Changes

### ACMMFeedbackLoops.tsx
- **#8847** — Dropped `max-w-4xl` cap so the card now fills its container width. Controls row laid out across the full width rather than clumping in a narrow central region.
- **#8849 / #8850** — Added a Level 1 baseline marker at the top of the by-level view using the same divider component that L2-L6 use. L1 now has the same visual treatment as higher levels. The L1 marker shows "Level 1 — Foundation / Baseline" (no level-up action — L1 is where everyone starts).
- **#8851** — Clicking a criterion now opens an inset detail panel (bordered, with a header row showing the criterion name and an explicit Close control). Previously clicking only made the row taller, giving no visual signal that a distinct detail view had opened.

### ACMMRecommendations.tsx
- **#8852** — Strengthened contrast on all action-bar buttons: "Ask agent for help with all" and per-row "Ask agent for help" now use solid primary background with primary-foreground text instead of the low-contrast `bg-primary/10..20 text-primary` pairs. Source badges raised to `bg-primary/40 text-foreground font-medium`. All meet AA contrast.

## Verification
- `npx tsc --noEmit` — clean
- `npm run build` — clean, post-build vendor safety checks pass