### PR TITLE
fix: cluster info cards no longer overflow on hover (#8841)

### DIFF
--- a/web/src/components/clusters/components/ClusterGrid.tsx
+++ b/web/src/components/clusters/components/ClusterGrid.tsx
@@ -327,7 +327,7 @@ const FullClusterCard = memo(function FullClusterCard({
       role="button"
       tabIndex={0}
       aria-label={`Select cluster ${cluster.context || cluster.name}`}
-      className="relative p-[1px] rounded-lg cursor-pointer transition-all hover:scale-[1.02] overflow-hidden h-full"
+      className="relative p-[1px] rounded-lg cursor-pointer transition-all hover:shadow-lg hover:-translate-y-0.5 overflow-hidden h-full"
       style={{
         /* Card view: prominent gradient — provider at 50%, theme at 38% */
         background: `linear-gradient(135deg, color-mix(in srgb, ${providerColor} 50%, transparent) 0%, color-mix(in srgb, ${themeColor} 38%, transparent) 100%)` }}
@@ -580,7 +580,7 @@ const ListClusterCard = memo(function ListClusterCard({
       role="button"
       tabIndex={0}
       aria-label={`Select cluster ${cluster.context || cluster.name}`}
-      className="relative p-[1px] rounded-lg cursor-pointer transition-all hover:scale-[1.01] overflow-hidden"
+      className="relative p-[1px] rounded-lg cursor-pointer transition-all hover:shadow-lg hover:-translate-y-0.5 overflow-hidden"
       style={{
         /* List view: subtle gradient — provider at 38%, theme at 25% */
         background: `linear-gradient(90deg, color-mix(in srgb, ${providerColor} 38%, transparent) 0%, color-mix(in srgb, ${themeColor} 25%, transparent) 100%)` }}
@@ -770,7 +770,7 @@ const CompactClusterCard = memo(function CompactClusterCard({
       role="button"
       tabIndex={0}
       aria-label={`Select cluster ${cluster.context || cluster.name}`}
-      className="relative p-[1px] rounded-lg cursor-pointer transition-all hover:scale-[1.02] overflow-hidden"
+      className="relative p-[1px] rounded-lg cursor-pointer transition-all hover:shadow-lg hover:-translate-y-0.5 overflow-hidden"
       style={{
         /* Grid view: subtle gradient — provider at 38%, theme at 25% */
         background: `linear-gradient(135deg, color-mix(in srgb, ${providerColor} 38%, transparent) 0%, color-mix(in srgb, ${themeColor} 25%, transparent) 100%)` }}
@@ -931,7 +931,7 @@ export const ClusterGrid = memo(function ClusterGrid({
   return (
     <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={handleDragEnd}>
       <SortableContext items={clusterIds} strategy={sortingStrategy}>
-        <div className={`${gridClasses[layoutMode]} mb-6 overflow-hidden px-2 -mx-2 py-1 -my-1`}>
+        <div className={`${gridClasses[layoutMode]} mb-6 pt-1`}>
           {clusters.map((cluster) => {
             const clusterKey = cluster.name.split('/')[0]
             const gpuInfo = gpuByCluster[clusterKey] || gpuByCluster[cluster.name]


### PR DESCRIPTION
## Summary

The prior fix (#8569) wrapped the cluster grid in `overflow-hidden` with `px-2 -mx-2 py-1 -my-1` to absorb the `hover:scale-[1.02]` growth on edge cards. But `-mx-2` extended the grid 8px beyond its parent on each side — which is exactly the overflow users were still seeing on the My Clusters dashboard (#8841).

Root cause: a negative margin on the grid cannot "absorb" hover-scale growth — it just pushes the grid (and its overflowing children) outside the parent content area.

## Change

`web/src/components/clusters/components/ClusterGrid.tsx`:
- Replace `hover:scale-[1.02]` / `hover:scale-[1.01]` on all three card variants (`FullClusterCard`, `ListClusterCard`, `CompactClusterCard`) with `hover:shadow-lg hover:-translate-y-0.5`. This preserves the hover "lift" aesthetic but keeps the card's horizontal footprint constant.
- Drop `overflow-hidden px-2 -mx-2 py-1 -my-1` from the grid container; replace with just `pt-1` to give the upward translate room inside the container.

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npm run build` — clean (all post-build safety checks pass)
- [ ] Visual verification that edge cluster cards don't overflow on hover in grid/list/compact modes on the My Clusters dashboard

Fixes #8841