### PR TITLE
fix: dashboard title no longer obscured by nav button (#8891)

### DIFF
--- a/web/src/lib/constants/ui.ts
+++ b/web/src/lib/constants/ui.ts
@@ -66,5 +66,15 @@ export const NAVBAR_HEIGHT_PX = 64
 export const BANNER_HEIGHT_PX = 36
 /** Height of the green dev-mode indicator bar in pixels (h-5 = 20px) */
 export const DEV_BAR_HEIGHT_PX = 20
-/** Width reserved for the sidebar collapse/pin floating controls (p-1.5 + icon + gap) */
-export const SIDEBAR_CONTROLS_OFFSET_PX = 14
+/**
+ * Width reserved in the main content margin for the sidebar's floating
+ * collapse + pin controls (see Sidebar.tsx). The control container is
+ * positioned at `left: sidebarWidth + 4` with `p-1` (4px padding) wrapping
+ * a `w-8` (32px) button, so it spans from `sidebarWidth + 4` to
+ * `sidebarWidth + 44`. Main content must clear that end plus a small
+ * breathing gap so page headers (e.g. the Dashboard title) are not
+ * obscured by the button — issue #8891 reported the "D" in "Dashboard"
+ * being visually clipped when this value was only 14px.
+ *   button right edge (44) + breathing gap (4) = 48
+ */
+export const SIDEBAR_CONTROLS_OFFSET_PX = 48


### PR DESCRIPTION
## Summary

The "Dashboard" title on the home page was being visually clipped (showing as "ashboard") because the sidebar's circular collapse/pin control floated into the main content area. The float anchor (`left: sidebarWidth + 4`) plus the ~40px container width (`p-1` + `w-8` button) put the button's right edge at `sidebarWidth + 44`, while main content was only offset by `SIDEBAR_CONTROLS_OFFSET_PX = 14`, so the button covered the first ~30px of every page header anchored to the left edge.

## Change

- `web/src/lib/constants/ui.ts`: bump `SIDEBAR_CONTROLS_OFFSET_PX` from `14` to `48` (button right edge `44` + `4px` breathing gap) so the main content column clears the floating control container completely.
- Expanded the JSDoc on the constant to spell out the math that determines its value (button position + width + gap), so future tweaks to the sidebar control size don't silently regress the overlap.

The constant flows through `Layout.tsx`'s `main` element `marginLeft: sidebarWidthPx + SIDEBAR_CONTROLS_OFFSET_PX`, so this one change fixes the issue everywhere headers live at the top-left of the content area (Dashboard, My Clusters, etc.) — not just the home page.

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npm run build` — clean (all post-build safety checks pass)
- [ ] Visual verification on `http://localhost:8080/` that the full "Dashboard" title renders with the sidebar in both expanded and collapsed states, and that no page header overlaps the collapse/pin button.

Fixes #8891