### PR TITLE
fix: add keyboard navigation to 3 cards (partial #8837)

### DIFF
--- a/web/src/components/cards/ClusterDropZone.tsx
+++ b/web/src/components/cards/ClusterDropZone.tsx
@@ -169,6 +169,15 @@ function DroppableCluster({ cluster, workload, onDeploy }: DroppableClusterProps
           : 'bg-gray-50 dark:bg-secondary/50 border-gray-200 dark:border-border hover:border-blue-300 dark:hover:border-blue-600'
       )}
       onClick={handleClick}
+      onKeyDown={(e) => {
+        // Issue #8837: Enter/Space activates drop-zone click, matching mouse behavior
+        if (e.key === "Enter" || e.key === " ") {
+          e.preventDefault()
+          handleClick()
+        }
+      }}
+      role="button"
+      tabIndex={0}
     >
       <div className="flex-shrink-0 mt-0.5">
         <Server className={cn('w-5 h-5', isOver ? 'text-blue-500' : 'text-blue-400')} />

--- a/web/src/components/cards/HardwareHealthCard.tsx
+++ b/web/src/components/cards/HardwareHealthCard.tsx
@@ -674,10 +674,21 @@ export function HardwareHealthCard() {
               >
                 <div className="flex items-start justify-between gap-1">
                   <div
-                    className="min-w-0 flex items-start gap-2 flex-1 cursor-pointer"
+                    className="min-w-0 flex items-start gap-2 flex-1 cursor-pointer focus:outline-none focus-visible:ring-2 focus-visible:ring-cyan-400 rounded"
+                    role="button"
+                    tabIndex={0}
                     onClick={() => drillToNode(alert.cluster, alert.nodeName, {
                       issue: `${getDeviceLabel(alert.deviceType)} disappeared: ${alert.previousCount} → ${alert.currentCount}`
                     })}
+                    onKeyDown={(e) => {
+                      // Issue #8837: keyboard activation for alert drill-down
+                      if (e.key === "Enter" || e.key === " ") {
+                        e.preventDefault()
+                        drillToNode(alert.cluster, alert.nodeName, {
+                          issue: `${getDeviceLabel(alert.deviceType)} disappeared: ${alert.previousCount} → ${alert.currentCount}`
+                        })
+                      }
+                    }}
                   >
                     <DeviceIcon
                       deviceType={alert.deviceType}
@@ -794,8 +805,17 @@ export function HardwareHealthCard() {
             {paginatedInventory.map((node) => (
               <div
                 key={`${node.cluster}/${node.nodeName}`}
-                className="p-2 rounded text-xs transition-colors group bg-muted/20 hover:bg-muted/40 cursor-pointer"
+                className="p-2 rounded text-xs transition-colors group bg-muted/20 hover:bg-muted/40 cursor-pointer focus:outline-none focus-visible:ring-2 focus-visible:ring-cyan-400"
+                role="button"
+                tabIndex={0}
                 onClick={() => drillToNode(node.cluster, node.nodeName)}
+                onKeyDown={(e) => {
+                  // Issue #8837: keyboard activation for inventory node drill-down
+                  if (e.key === "Enter" || e.key === " ") {
+                    e.preventDefault()
+                    drillToNode(node.cluster, node.nodeName)
+                  }
+                }}
               >
                 <div className="flex items-start justify-between gap-1">
                   <div className="min-w-0 flex items-start gap-2 flex-1">

--- a/web/src/components/cards/PodSweeper.tsx
+++ b/web/src/components/cards/PodSweeper.tsx
@@ -335,9 +335,22 @@ function PodSweeperInternal(_props: CardComponentProps) {
                 return (
                   <div
                     key={colIdx}
+                    role="button"
+                    tabIndex={0}
+                    aria-label={`Cell row ${rowIdx + 1} column ${colIdx + 1}`}
                     onClick={() => handleClick(rowIdx, colIdx)}
                     onContextMenu={(e) => handleRightClick(e, rowIdx, colIdx)}
-                    className={`${cellSize} flex items-center justify-center border border-border/50 cursor-pointer transition-colors ${bgClass}`}
+                    onKeyDown={(e) => {
+                      // Issue #8837: Enter/Space reveal, F to toggle flag (matches right-click)
+                      if (e.key === "Enter" || e.key === " ") {
+                        e.preventDefault()
+                        handleClick(rowIdx, colIdx)
+                      } else if (e.key === "f" || e.key === "F") {
+                        e.preventDefault()
+                        handleRightClick(e as unknown as React.MouseEvent, rowIdx, colIdx)
+                      }
+                    }}
+                    className={`${cellSize} flex items-center justify-center border border-border/50 cursor-pointer transition-colors ${bgClass} focus:outline-none focus-visible:ring-2 focus-visible:ring-cyan-400`}
                   >
                     {content}
                   </div>


### PR DESCRIPTION
Addresses #8837 (partial — A11y Auto-QA finding).

## What

Adds `onKeyDown` handlers + `role="button"` + `tabIndex=0` to clickable `<div>` elements in 3 components so they can be activated via keyboard, not just mouse.

## Components fixed

- **ClusterDropZone.tsx** — Enter/Space triggers the workload-drop click handler
- **HardwareHealthCard.tsx** — Enter/Space drills into the node for both the alert row and the inventory row (2 divs)
- **PodSweeper.tsx** — Enter/Space reveals the cell; `F` toggles a flag (mirrors right-click)

Focus rings (`focus-visible:ring-2 focus-visible:ring-cyan-400`) added for visual feedback.

## Scope

Partial per the Auto-QA PR guidance (keep changes under 50 lines). Follow-up PRs will cover the remaining components listed in #8837 (`PodSweeper` snooze menu, `ProactiveGPUNodeHealthMonitor`, `ActiveAlerts`, `NetworkOverview`, `GPUTaintFilter`, `KustomizationStatus`, and the Tab components).

## Verification

- `npm run build` — passes
- `npx tsc --noEmit` — clean