### PR TITLE
fix: Alerts Resolved drillDown matches stat block count (#8844)

### DIFF
--- a/web/src/components/drilldown/views/MultiClusterSummaryDrillDown.tsx
+++ b/web/src/components/drilldown/views/MultiClusterSummaryDrillDown.tsx
@@ -81,7 +81,7 @@ function getViewConfig(viewType: DrillDownViewType) {
         bgColor: 'bg-red-500/20',
         dataKey: 'alerts',
         nameKey: 'name',
-        // #8844 — The alerts drill-down is opened with filter='firing' or
+        // Issue 8844 — The alerts drill-down is opened with filter='firing' or
         // filter='resolved' from the Alerts dashboard stat blocks. Those
         // filters are compared against this getStatus() result, so it must
         // return the alert's lifecycle status (firing | resolved), not its
@@ -167,7 +167,7 @@ function getStatusBadge(status: string) {
 export function MultiClusterSummaryDrillDown({ data, viewType }: MultiClusterSummaryDrillDownProps) {
   const { t } = useTranslation()
   const { clusters, deduplicatedClusters, pods, deployments, events, helmReleases, operatorSubscriptions, securityIssues } = useClusterData()
-  // #8844 — The all-alerts drill-down must read from the same AlertsContext
+  // Issue 8844 — The all-alerts drill-down must read from the same AlertsContext
   // source that powers the Alerts dashboard stat blocks (firing / resolved
   // counts). Sourcing alerts from pods (non-Running pods were used as a
   // synthetic stand-in) diverged from the stat counts: the "Resolved" block
@@ -273,7 +273,7 @@ export function MultiClusterSummaryDrillDown({ data, viewType }: MultiClusterSum
           ...e,
           status: e.type || 'Normal' }))
       case 'all-alerts':
-        // #8844 — Use real alerts from AlertsContext so the drill-down list
+        // Issue 8844 — Use real alerts from AlertsContext so the drill-down list
         // matches the Alerts dashboard stat blocks (firing / resolved). The
         // previous implementation synthesized "alerts" from non-Running
         // pods, which never produced status='resolved' items and left the

--- a/web/src/components/drilldown/views/MultiClusterSummaryDrillDown.tsx
+++ b/web/src/components/drilldown/views/MultiClusterSummaryDrillDown.tsx
@@ -4,6 +4,7 @@ import { useClusterData } from '../../../hooks/useClusterData'
 import { useDrillDownActions } from '../../../hooks/useDrillDown'
 import type { DrillDownViewType } from '../../../hooks/useDrillDown'
 import { useCachedNodes, useCachedPVCs } from '../../../hooks/useCachedData'
+import { useAlerts } from '../../../hooks/useAlerts'
 import { useTranslation } from 'react-i18next'
 import { formatRelativeTime } from '../../../lib/formatters'
 
@@ -80,7 +81,15 @@ function getViewConfig(viewType: DrillDownViewType) {
         bgColor: 'bg-red-500/20',
         dataKey: 'alerts',
         nameKey: 'name',
-        getStatus: (item: { severity?: string; state?: string }) => item.severity || item.state || 'unknown' }
+        // #8844 — The alerts drill-down is opened with filter='firing' or
+        // filter='resolved' from the Alerts dashboard stat blocks. Those
+        // filters are compared against this getStatus() result, so it must
+        // return the alert's lifecycle status (firing | resolved), not its
+        // severity. Otherwise the preFilter drops every item and the
+        // drill-down list appears empty even though the stat block shows a
+        // non-zero count.
+        getStatus: (item: { status?: string; severity?: string; state?: string }) =>
+          item.status || item.severity || item.state || 'unknown' }
     case 'all-helm':
       return {
         icon: Ship,
@@ -158,6 +167,14 @@ function getStatusBadge(status: string) {
 export function MultiClusterSummaryDrillDown({ data, viewType }: MultiClusterSummaryDrillDownProps) {
   const { t } = useTranslation()
   const { clusters, deduplicatedClusters, pods, deployments, events, helmReleases, operatorSubscriptions, securityIssues } = useClusterData()
+  // #8844 — The all-alerts drill-down must read from the same AlertsContext
+  // source that powers the Alerts dashboard stat blocks (firing / resolved
+  // counts). Sourcing alerts from pods (non-Running pods were used as a
+  // synthetic stand-in) diverged from the stat counts: the "Resolved" block
+  // could show e.g. 18 while the drill-down list was always empty because
+  // synthetic pod-alerts never carry status='resolved'. Using the real
+  // alerts list here keeps the count and the list in lock-step.
+  const { alerts: contextAlerts } = useAlerts()
   const {
     nodes: rawCachedNodes,
     lastRefresh: nodesLastRefresh,
@@ -197,7 +214,8 @@ export function MultiClusterSummaryDrillDown({ data, viewType }: MultiClusterSum
 
   const {
     drillToCluster, drillToNamespace, drillToDeployment, drillToPod,
-    drillToNode, drillToEvents, drillToHelm, drillToOperator, drillToPVC
+    drillToNode, drillToEvents, drillToHelm, drillToOperator, drillToPVC,
+    drillToAlert
   } = useDrillDownActions()
 
   const filter = data.filter as string | undefined
@@ -255,15 +273,18 @@ export function MultiClusterSummaryDrillDown({ data, viewType }: MultiClusterSum
           ...e,
           status: e.type || 'Normal' }))
       case 'all-alerts':
-        // Mock alerts from security issues and pod issues
-        return pods
-          .filter(p => p.status !== 'Running')
-          .map(p => ({
-            name: `Pod ${p.name} ${p.status}`,
-            namespace: p.namespace,
-            cluster: p.cluster || '',
-            severity: p.status === 'Failed' ? 'critical' : 'warning',
-            status: p.status }))
+        // #8844 — Use real alerts from AlertsContext so the drill-down list
+        // matches the Alerts dashboard stat blocks (firing / resolved). The
+        // previous implementation synthesized "alerts" from non-Running
+        // pods, which never produced status='resolved' items and left the
+        // Resolved drill-down permanently empty regardless of the count.
+        return (contextAlerts || []).map(a => ({
+          ...a,
+          name: a.ruleName || a.message || a.id,
+          namespace: a.namespace,
+          cluster: a.cluster || '',
+          severity: a.severity,
+          status: a.status }))
       case 'all-helm':
         return helmReleases.map(h => ({
           ...h,
@@ -305,7 +326,7 @@ export function MultiClusterSummaryDrillDown({ data, viewType }: MultiClusterSum
       default:
         return []
     }
-  }, [viewType, clusters, deduplicatedClusters, pods, deployments, events, helmReleases, operatorSubscriptions, securityIssues, cachedNodes, cachedPVCs])
+  }, [viewType, clusters, deduplicatedClusters, pods, deployments, events, helmReleases, operatorSubscriptions, securityIssues, cachedNodes, cachedPVCs, contextAlerts])
 
   // Apply initial filter from data prop
   const preFilteredItems = (() => {
@@ -388,6 +409,9 @@ export function MultiClusterSummaryDrillDown({ data, viewType }: MultiClusterSum
         break
       case 'all-events':
         drillToEvents(cluster, namespace, (item.involvedObject as string) || name)
+        break
+      case 'all-alerts':
+        drillToAlert(cluster, namespace || undefined, name, item)
         break
       case 'all-helm':
         drillToHelm(cluster, namespace, name, item)

--- a/web/src/components/drilldown/views/__tests__/MultiClusterSummaryDrillDown.test.tsx
+++ b/web/src/components/drilldown/views/__tests__/MultiClusterSummaryDrillDown.test.tsx
@@ -40,7 +40,7 @@ vi.mock('../../../../hooks/useDrillDown', () => ({
   useDrillDownActions: () => ({ drillToCluster: vi.fn(), drillToNamespace: vi.fn(), drillToDeployment: vi.fn(), drillToPod: vi.fn(), drillToNode: vi.fn(), drillToEvents: [], drillToHelm: null, drillToOperator: null, drillToAlert: vi.fn() }),
 }))
 
-// #8844 — MultiClusterSummaryDrillDown now reads alerts from useAlerts so the
+// Issue 8844 — MultiClusterSummaryDrillDown now reads alerts from useAlerts so the
 // all-alerts drill-down matches the Alerts dashboard stat blocks.
 vi.mock('../../../../hooks/useAlerts', () => ({
   useAlerts: () => ({ alerts: [], stats: { total: 0, firing: 0, resolved: 0, critical: 0, warning: 0, info: 0, acknowledged: 0 } }),

--- a/web/src/components/drilldown/views/__tests__/MultiClusterSummaryDrillDown.test.tsx
+++ b/web/src/components/drilldown/views/__tests__/MultiClusterSummaryDrillDown.test.tsx
@@ -37,7 +37,13 @@ vi.mock('../../../../hooks/useClusterData', () => ({
 }))
 
 vi.mock('../../../../hooks/useDrillDown', () => ({
-  useDrillDownActions: () => ({ drillToCluster: vi.fn(), drillToNamespace: vi.fn(), drillToDeployment: vi.fn(), drillToPod: vi.fn(), drillToNode: vi.fn(), drillToEvents: [], drillToHelm: null, drillToOperator: null }),
+  useDrillDownActions: () => ({ drillToCluster: vi.fn(), drillToNamespace: vi.fn(), drillToDeployment: vi.fn(), drillToPod: vi.fn(), drillToNode: vi.fn(), drillToEvents: [], drillToHelm: null, drillToOperator: null, drillToAlert: vi.fn() }),
+}))
+
+// #8844 — MultiClusterSummaryDrillDown now reads alerts from useAlerts so the
+// all-alerts drill-down matches the Alerts dashboard stat blocks.
+vi.mock('../../../../hooks/useAlerts', () => ({
+  useAlerts: () => ({ alerts: [], stats: { total: 0, firing: 0, resolved: 0, critical: 0, warning: 0, info: 0, acknowledged: 0 } }),
 }))
 
 vi.mock('../../../../hooks/useCachedData', () => ({


### PR DESCRIPTION
## Summary

The Alerts dashboard "Resolved" stat block showed a count (e.g. 18) but clicking it opened an empty drill-down list. Classic count-vs-filter mismatch.

- **Count source**: `AlertsContext` — `stats.resolved = deduped.filter(a => a.status === 'resolved').length` (real alerts).
- **List source (before)**: `MultiClusterSummaryDrillDown` synthesized "alerts" from `pods.filter(p => p.status !== 'Running')`. Those synthetic items carry the pod's status (`Pending`, `CrashLoopBackOff`, …), never `'resolved'`, so the preFilter for `filter === 'resolved'` matched zero items every time.
- Secondary issue: `getStatus()` for `all-alerts` returned `severity || state` (e.g. `'critical'`, `'warning'`), so even the `'firing'` filter never matched the lifecycle status.

## Change

`web/src/components/drilldown/views/MultiClusterSummaryDrillDown.tsx`
- Import `useAlerts` and source the `all-alerts` list from the same `AlertsContext` that powers the stat blocks, so count and list are in lock-step.
- Update `all-alerts` `getStatus` to prefer `item.status` (firing/resolved) so the `filter` passed by the stat block actually matches.
- Wire `handleItemClick` for `all-alerts` to `drillToAlert(cluster, namespace, name, item)`.
- Guard context alerts with `(contextAlerts || [])` per MEMORY.md.

`web/src/components/drilldown/views/__tests__/MultiClusterSummaryDrillDown.test.tsx`
- Mock `useAlerts` and add `drillToAlert` to the `useDrillDownActions` mock.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npm run build` clean (all post-build safety checks pass)
- [ ] Manual: on Alerts dashboard, click the Resolved stat block — drill-down list length should equal the stat value
- [ ] Manual: click the Firing stat block — drill-down list length should equal \`stats.firing\`

Fixes #8844