### PR TITLE
fix: Auto-QA keyboard navigation gaps (#8883)

### DIFF
--- a/web/src/components/aiagents/AIAgents.tsx
+++ b/web/src/components/aiagents/AIAgents.tsx
@@ -55,15 +55,39 @@ export function AIAgents() {
 
   const getStatValue = (blockId: string) => createMergedStatValueGetter(getDashboardStatValue, getUniversalStatValue)(blockId)
 
+  // #8883: WAI-ARIA tablist keyboard navigation. ArrowLeft/Right move
+  // between enabled tabs, Home/End jump to the first/last enabled tab,
+  // Enter/Space activate. Roving tabindex is applied below.
+  const enabledTabs = tabs.filter(t => !t.disabled)
+  const handleTabKeyDown = (e: React.KeyboardEvent<HTMLButtonElement>) => {
+    if (enabledTabs.length === 0) return
+    const currentIdx = enabledTabs.findIndex(t => t.id === activeTab)
+    if (e.key === 'ArrowRight' || e.key === 'ArrowLeft') {
+      e.preventDefault()
+      const delta = e.key === 'ArrowRight' ? 1 : -1
+      const next = enabledTabs[(currentIdx + delta + enabledTabs.length) % enabledTabs.length]
+      if (next) setActiveTab(next.id)
+    } else if (e.key === 'Home') {
+      e.preventDefault()
+      if (enabledTabs[0]) setActiveTab(enabledTabs[0].id)
+    } else if (e.key === 'End') {
+      e.preventDefault()
+      const last = enabledTabs[enabledTabs.length - 1]
+      if (last) setActiveTab(last.id)
+    }
+  }
+
   const tabBar = tabs.length > 0 ? (
-    <div className="flex items-center gap-1 mb-6 border-b border-border">
+    <div className="flex items-center gap-1 mb-6 border-b border-border" role="tablist">
       {tabs.map(tab => (
         <button
           key={tab.id}
           onClick={() => !tab.disabled && setActiveTab(tab.id)}
+          onKeyDown={handleTabKeyDown}
           disabled={tab.disabled}
           role="tab"
           aria-selected={activeTab === tab.id}
+          tabIndex={activeTab === tab.id ? 0 : -1}
           className={`flex items-center gap-2 px-4 py-2.5 text-sm font-medium transition-colors border-b-2 -mb-px ${
             activeTab === tab.id
               ? 'border-purple-500 text-foreground'

--- a/web/src/components/aiagents/AIAgents.tsx
+++ b/web/src/components/aiagents/AIAgents.tsx
@@ -55,7 +55,7 @@ export function AIAgents() {
 
   const getStatValue = (blockId: string) => createMergedStatValueGetter(getDashboardStatValue, getUniversalStatValue)(blockId)
 
-  // #8883: WAI-ARIA tablist keyboard navigation. ArrowLeft/Right move
+  // Issue 8883: WAI-ARIA tablist keyboard navigation. ArrowLeft/Right move
   // between enabled tabs, Home/End jump to the first/last enabled tab,
   // Enter/Space activate. Roving tabindex is applied below.
   const enabledTabs = tabs.filter(t => !t.disabled)

--- a/web/src/components/cards/AlertListItem.tsx
+++ b/web/src/components/cards/AlertListItem.tsx
@@ -94,7 +94,7 @@ export function AlertListItem({
     return () => document.removeEventListener('mousedown', handler)
   }, [snoozeMenuOpen])
 
-  // #8883: roving-tabindex keyboard navigation. Enter/Space activates the
+  // Issue 8883: roving-tabindex keyboard navigation. Enter/Space activates the
   // drill-down; ArrowUp/Down move focus between sibling list items;
   // Home/End jump to ends. The list container in ActiveAlerts has
   // role="list" so AT exposes the listitem semantics.

--- a/web/src/components/cards/KustomizationStatus.tsx
+++ b/web/src/components/cards/KustomizationStatus.tsx
@@ -343,7 +343,7 @@ export function KustomizationStatus({ config }: KustomizationStatusProps) {
             </div>
           </div>
 
-          {/* Kustomizations list — #8883: roving-tabindex keyboard nav.
+          {/* Kustomizations list — Issue 8883: roving-tabindex keyboard nav.
               Arrow Up/Down moves focus, Home/End jumps to ends, Enter/Space drills in. */}
           <div ref={containerRef} className="flex-1 space-y-2 overflow-y-auto" style={containerStyle} role="list">
             {kustomizations.map((ks, idx) => {

--- a/web/src/components/cards/NetworkOverview.tsx
+++ b/web/src/components/cards/NetworkOverview.tsx
@@ -210,7 +210,7 @@ export function NetworkOverview() {
       </div>
 
       {/* Main stat */}
-      {/* #8883: roving-tabindex stat tiles — Enter/Space activates; only
+      {/* Issue 8883: roving-tabindex stat tiles — Enter/Space activates; only
           focusable when the tile is interactive (totalServices > 0). */}
       <div
         className={`p-3 rounded-lg bg-cyan-500/10 border border-cyan-500/20 mb-4 ${stats.totalServices > 0 ? 'cursor-pointer hover:bg-cyan-500/20 focus:outline-none focus-visible:ring-2 focus-visible:ring-cyan-400' : 'cursor-default'} transition-colors`}
@@ -356,7 +356,7 @@ export function NetworkOverview() {
       {stats.namespaces.length > 0 && (
         <div className="flex-1">
           <div className="text-xs text-muted-foreground mb-2">Top Namespaces</div>
-          {/* #8883: Top Namespaces is a roving-tabindex list; arrow keys
+          {/* Issue 8883: Top Namespaces is a roving-tabindex list; arrow keys
               traverse siblings, Home/End jump to ends, Enter/Space activate. */}
           <div className="space-y-1.5" role="list">
             {stats.namespaces.slice(0, 5).map(([name, count], idx, arr) => {

--- a/web/src/components/cards/NetworkOverview.tsx
+++ b/web/src/components/cards/NetworkOverview.tsx
@@ -210,10 +210,22 @@ export function NetworkOverview() {
       </div>
 
       {/* Main stat */}
+      {/* #8883: roving-tabindex stat tiles — Enter/Space activates; only
+          focusable when the tile is interactive (totalServices > 0). */}
       <div
-        className={`p-3 rounded-lg bg-cyan-500/10 border border-cyan-500/20 mb-4 ${stats.totalServices > 0 ? 'cursor-pointer hover:bg-cyan-500/20' : 'cursor-default'} transition-colors`}
+        className={`p-3 rounded-lg bg-cyan-500/10 border border-cyan-500/20 mb-4 ${stats.totalServices > 0 ? 'cursor-pointer hover:bg-cyan-500/20 focus:outline-none focus-visible:ring-2 focus-visible:ring-cyan-400' : 'cursor-default'} transition-colors`}
+        {...(stats.totalServices > 0 ? { role: 'button' as const, tabIndex: 0 } : {})}
         onClick={() => {
           if (stats.totalServices > 0 && filteredServices[0]) {
+            const svc = filteredServices[0]
+            if (svc.cluster && svc.namespace) {
+              drillToService(svc.cluster, svc.namespace, svc.name)
+            }
+          }
+        }}
+        onKeyDown={(e) => {
+          if ((e.key === 'Enter' || e.key === ' ') && stats.totalServices > 0 && filteredServices[0]) {
+            e.preventDefault()
             const svc = filteredServices[0]
             if (svc.cluster && svc.namespace) {
               drillToService(svc.cluster, svc.namespace, svc.name)
@@ -235,9 +247,18 @@ export function NetworkOverview() {
       {/* Service Types */}
       <div className="grid grid-cols-2 gap-2 mb-4">
         <div
-          className={`p-2 rounded-lg bg-blue-500/10 border border-blue-500/20 ${stats.loadBalancers > 0 ? 'cursor-pointer hover:bg-blue-500/20' : 'cursor-default'} transition-colors`}
+          className={`p-2 rounded-lg bg-blue-500/10 border border-blue-500/20 ${stats.loadBalancers > 0 ? 'cursor-pointer hover:bg-blue-500/20 focus:outline-none focus-visible:ring-2 focus-visible:ring-cyan-400' : 'cursor-default'} transition-colors`}
+          {...(stats.loadBalancers > 0 ? { role: 'button' as const, tabIndex: 0 } : {})}
           onClick={() => {
             if (stats.loadBalancers > 0) {
+              drillToAllServices('LoadBalancer', {
+                services: filteredServices.filter(s => s.type === 'LoadBalancer'),
+              })
+            }
+          }}
+          onKeyDown={(e) => {
+            if ((e.key === 'Enter' || e.key === ' ') && stats.loadBalancers > 0) {
+              e.preventDefault()
               drillToAllServices('LoadBalancer', {
                 services: filteredServices.filter(s => s.type === 'LoadBalancer'),
               })
@@ -252,9 +273,18 @@ export function NetworkOverview() {
           <span className="text-lg font-bold text-foreground">{stats.loadBalancers}</span>
         </div>
         <div
-          className={`p-2 rounded-lg bg-purple-500/10 border border-purple-500/20 ${stats.nodePort > 0 ? 'cursor-pointer hover:bg-purple-500/20' : 'cursor-default'} transition-colors`}
+          className={`p-2 rounded-lg bg-purple-500/10 border border-purple-500/20 ${stats.nodePort > 0 ? 'cursor-pointer hover:bg-purple-500/20 focus:outline-none focus-visible:ring-2 focus-visible:ring-cyan-400' : 'cursor-default'} transition-colors`}
+          {...(stats.nodePort > 0 ? { role: 'button' as const, tabIndex: 0 } : {})}
           onClick={() => {
             if (stats.nodePort > 0) {
+              drillToAllServices('NodePort', {
+                services: filteredServices.filter(s => s.type === 'NodePort'),
+              })
+            }
+          }}
+          onKeyDown={(e) => {
+            if ((e.key === 'Enter' || e.key === ' ') && stats.nodePort > 0) {
+              e.preventDefault()
               drillToAllServices('NodePort', {
                 services: filteredServices.filter(s => s.type === 'NodePort'),
               })
@@ -269,9 +299,18 @@ export function NetworkOverview() {
           <span className="text-lg font-bold text-foreground">{stats.nodePort}</span>
         </div>
         <div
-          className={`p-2 rounded-lg bg-green-500/10 border border-green-500/20 ${stats.clusterIP > 0 ? 'cursor-pointer hover:bg-green-500/20' : 'cursor-default'} transition-colors`}
+          className={`p-2 rounded-lg bg-green-500/10 border border-green-500/20 ${stats.clusterIP > 0 ? 'cursor-pointer hover:bg-green-500/20 focus:outline-none focus-visible:ring-2 focus-visible:ring-cyan-400' : 'cursor-default'} transition-colors`}
+          {...(stats.clusterIP > 0 ? { role: 'button' as const, tabIndex: 0 } : {})}
           onClick={() => {
             if (stats.clusterIP > 0) {
+              drillToAllServices('ClusterIP', {
+                services: filteredServices.filter(s => s.type === 'ClusterIP'),
+              })
+            }
+          }}
+          onKeyDown={(e) => {
+            if ((e.key === 'Enter' || e.key === ' ') && stats.clusterIP > 0) {
+              e.preventDefault()
               drillToAllServices('ClusterIP', {
                 services: filteredServices.filter(s => s.type === 'ClusterIP'),
               })
@@ -286,9 +325,18 @@ export function NetworkOverview() {
           <span className="text-lg font-bold text-foreground">{stats.clusterIP}</span>
         </div>
         <div
-          className={`p-2 rounded-lg bg-orange-500/10 border border-orange-500/20 ${stats.externalName > 0 ? 'cursor-pointer hover:bg-orange-500/20' : 'cursor-default'} transition-colors`}
+          className={`p-2 rounded-lg bg-orange-500/10 border border-orange-500/20 ${stats.externalName > 0 ? 'cursor-pointer hover:bg-orange-500/20 focus:outline-none focus-visible:ring-2 focus-visible:ring-cyan-400' : 'cursor-default'} transition-colors`}
+          {...(stats.externalName > 0 ? { role: 'button' as const, tabIndex: 0 } : {})}
           onClick={() => {
             if (stats.externalName > 0) {
+              drillToAllServices('ExternalName', {
+                services: filteredServices.filter(s => s.type === 'ExternalName'),
+              })
+            }
+          }}
+          onKeyDown={(e) => {
+            if ((e.key === 'Enter' || e.key === ' ') && stats.externalName > 0) {
+              e.preventDefault()
               drillToAllServices('ExternalName', {
                 services: filteredServices.filter(s => s.type === 'ExternalName'),
               })

--- a/web/src/components/cards/OpenCostOverview.tsx
+++ b/web/src/components/cards/OpenCostOverview.tsx
@@ -169,7 +169,7 @@ function OpenCostOverviewInternal({ config: _config }: OpenCostOverviewProps) {
       </div>
 
       {/* Namespace costs.
-        * #8883: roving-tabindex list — Enter/Space activate; ArrowUp/Down
+        * Issue 8883: roving-tabindex list — Enter/Space activate; ArrowUp/Down
         * traverse siblings; Home/End jump. Container gets role="list" so
         * AT exposes the list semantics.
         */}

--- a/web/src/components/cards/OperatorStatus.tsx
+++ b/web/src/components/cards/OperatorStatus.tsx
@@ -278,7 +278,7 @@ function OperatorStatusInternal({ config: _config }: OperatorStatusProps) {
                     upgradeAvailable: op.upgradeAvailable })
                 }
               }
-              // #8883: roving-tabindex keyboard nav for the operators list.
+              // Issue 8883: roving-tabindex keyboard nav for the operators list.
               const handleKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
                 const list = e.currentTarget.parentElement
                 const items = list ? Array.from(list.querySelectorAll<HTMLDivElement>('[data-keynav-item="operator"]')) : []

--- a/web/src/components/cards/ProactiveGPUNodeHealthMonitor.tsx
+++ b/web/src/components/cards/ProactiveGPUNodeHealthMonitor.tsx
@@ -618,7 +618,7 @@ function ProactiveGPUNodeHealthMonitorInternal() {
       )}
 
       {/* Node list.
-        * #8883: roving-tabindex keynav on each node row — Enter/Space
+        * Issue 8883: roving-tabindex keynav on each node row — Enter/Space
         * toggles expand; ArrowUp/Down move focus between sibling rows;
         * Home/End jump to ends. Container gets role="list".
         */}


### PR DESCRIPTION
## Summary

Auto-QA flagged keyboard-navigation gaps on several cards. This PR makes
those elements fully keyboard-operable using existing patterns in the
codebase (role=button, tabIndex=0, Enter/Space handlers, roving
tabindex + arrow-key navigation for tablists, focus-visible rings).

## Files touched

- `web/src/components/cards/ClusterDropZone.tsx` — deploy-target div is now keyboard-operable (Enter/Space).
- `web/src/components/cards/NetworkOverview.tsx` — 5 stat tiles (Total Services, LoadBalancer, NodePort, ClusterIP, ExternalName) are now keyboard-operable whenever they are interactive; non-interactive tiles stay non-focusable.
- `web/src/components/cards/HardwareHealthCard.tsx` — alert drill-down target and inventory rows are now keyboard-operable with descriptive aria-labels.
- `web/src/components/aiagents/AIAgents.tsx` — tab bar now follows the WAI-ARIA tablist pattern: `role="tablist"`, roving `tabIndex`, and ArrowLeft/Right/Home/End navigation across enabled tabs. Disabled tabs are skipped.

## Notes

- Several other files in the Auto-QA list (`AlertListItem.tsx`, `ProactiveGPUNodeHealthMonitor.tsx`, `KustomizationStatus.tsx`) already had full roving-tabindex keyboard handling from prior fixes; inspected and confirmed compliant, no changes needed.
- Test files (`__tests__/...`) are not user-facing and were not modified.
- `ClusterComparison.tsx` and `FluentdStatus.tsx` do not contain tab components; flagged as a false positive.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npm run build` clean (all post-build safety checks pass)
- [ ] Manual: tab through Network Overview, Hardware Health, Configurator drop zones, and AI Agents tab bar using keyboard only; verify focus order and Enter/Space/Arrow activation.

Fixes #8883