### PR TITLE
fix(acmm): surface server-side demoFallback as isDemoData (#8848)

### DIFF
--- a/web/src/hooks/__tests__/useCachedACMMScan.test.tsx
+++ b/web/src/hooks/__tests__/useCachedACMMScan.test.tsx
@@ -152,7 +152,7 @@ describe('useCachedACMMScan', () => {
     await expect(fetcher()).rejects.toThrow(/503/)
   })
 
-  // Regression test for kubestellar/console#8848:
+  // Regression test for kubestellar/consoleIssue 8848:
   // When the Netlify Function can't reach GitHub (missing token, rate limit,
   // network failure, etc.) it returns HTTP 200 with `demoFallback: true` and
   // a plausible demo catalog. Before the fix, the hook threw that flag away

--- a/web/src/hooks/__tests__/useCachedACMMScan.test.tsx
+++ b/web/src/hooks/__tests__/useCachedACMMScan.test.tsx
@@ -151,4 +151,58 @@ describe('useCachedACMMScan', () => {
     }) as Response) as typeof globalThis.fetch
     await expect(fetcher()).rejects.toThrow(/503/)
   })
+
+  // Regression test for kubestellar/console#8848:
+  // When the Netlify Function can't reach GitHub (missing token, rate limit,
+  // network failure, etc.) it returns HTTP 200 with `demoFallback: true` and
+  // a plausible demo catalog. Before the fix, the hook threw that flag away
+  // and reported `isDemoData: false`, so the user saw the demo catalog of
+  // kubestellar/console as if it were a real scan. The fix routes the flag
+  // through a per-repo store that useSyncExternalStore picks up on re-render.
+  it('flips isDemoData to true when the server returns demoFallback:true', async () => {
+    // Isolate the module graph so the per-repo demoFallback store starts
+    // fresh for this test — stale state from other tests in the same file
+    // would otherwise pre-flip the flag and mask a real regression.
+    vi.resetModules()
+    const REPO = 'demo-fallback-test/repo'
+    const { useCachedACMMScan: freshHook } = await import('../useCachedACMMScan')
+    globalThis.fetch = vi.fn(async () => ({
+      ok: true,
+      status: 200,
+      headers: new Headers({ 'content-type': 'application/json' }),
+      json: async () => ({
+        repo: REPO,
+        scannedAt: new Date().toISOString(),
+        detectedIds: ['acmm:claude-md'],
+        weeklyActivity: [],
+        demoFallback: true,
+        error: 'GitHub token not configured',
+      }),
+    }) as Response) as typeof globalThis.fetch
+    const { result } = renderHook(() => freshHook(REPO))
+    const fetcher = lastArgs.current?.fetcher as () => Promise<unknown>
+    await act(async () => { await fetcher() })
+    expect(result.current.isDemoData).toBe(true)
+  })
+
+  it('leaves isDemoData false on a clean live response (no demoFallback flag)', async () => {
+    vi.resetModules()
+    const REPO = 'clean-live/repo'
+    const { useCachedACMMScan: freshHook } = await import('../useCachedACMMScan')
+    globalThis.fetch = vi.fn(async () => ({
+      ok: true,
+      status: 200,
+      headers: new Headers({ 'content-type': 'application/json' }),
+      json: async () => ({
+        repo: REPO,
+        scannedAt: new Date().toISOString(),
+        detectedIds: ['acmm:claude-md'],
+        weeklyActivity: [],
+      }),
+    }) as Response) as typeof globalThis.fetch
+    const { result } = renderHook(() => freshHook(REPO))
+    const fetcher = lastArgs.current?.fetcher as () => Promise<unknown>
+    await act(async () => { await fetcher() })
+    expect(result.current.isDemoData).toBe(false)
+  })
 })

--- a/web/src/hooks/useCachedACMMScan.ts
+++ b/web/src/hooks/useCachedACMMScan.ts
@@ -117,7 +117,7 @@ function demoScan(repo: string): ACMMScanData {
  * GITHUB_TOKEN, rate-limited, network error, etc.). The response still
  * contains a plausible demo catalog so the dashboard renders, but the
  * user MUST be told it's demo data — otherwise they see a working-looking
- * scan of kubestellar/console that doesn't match reality (bug #8848).
+ * scan of kubestellar/console that doesn't match reality (bug Issue 8848).
  *
  * We can't surface that flag through `useCache` (which only tracks its
  * own demo-fallback path — triggered when the fetcher errors, not when
@@ -163,7 +163,7 @@ async function fetchACMMScan(repo: string, force: boolean): Promise<ACMMScanData
   }
   const body = (await res.json()) as ACMMScanData & { demoFallback?: boolean }
   // Track the server-signalled demoFallback flag so the hook can expose it
-  // via isDemoData even though the HTTP call itself succeeded (see bug #8848:
+  // via isDemoData even though the HTTP call itself succeeded (see bug Issue 8848:
   // the Netlify function returns 200 with demoFallback:true when upstream
   // GitHub is unreachable, and without this signal the UI silently shows the
   // demo catalog as if it were a live scan of the user's repo).

--- a/web/src/hooks/useCachedACMMScan.ts
+++ b/web/src/hooks/useCachedACMMScan.ts
@@ -6,7 +6,7 @@
  * changes the cache key and triggers a fresh fetch.
  */
 
-import { useCallback, useRef } from 'react'
+import { useCallback, useRef, useSyncExternalStore } from 'react'
 import { useCache, type RefreshCategory } from '../lib/cache'
 import { computeLevel, type LevelComputation } from '../lib/acmm/computeLevel'
 import { computeRecommendations, type Recommendation } from '../lib/acmm/computeRecommendations'
@@ -109,6 +109,43 @@ function demoScan(repo: string): ACMMScanData {
   }
 }
 
+/**
+ * Per-repo demo-fallback flag store.
+ *
+ * The Netlify Function (`/api/acmm/scan`) returns HTTP 200 with a
+ * `demoFallback: true` body when its live GitHub fetch fails (missing
+ * GITHUB_TOKEN, rate-limited, network error, etc.). The response still
+ * contains a plausible demo catalog so the dashboard renders, but the
+ * user MUST be told it's demo data — otherwise they see a working-looking
+ * scan of kubestellar/console that doesn't match reality (bug #8848).
+ *
+ * We can't surface that flag through `useCache` (which only tracks its
+ * own demo-fallback path — triggered when the fetcher errors, not when
+ * it succeeds with a demoFallback-flagged body). Instead, we keep a
+ * lightweight per-repo store updated by the fetcher and subscribe to it
+ * via useSyncExternalStore so any re-render picks up the latest flag.
+ */
+const demoFallbackByRepo = new Map<string, boolean>()
+const demoFallbackSubs = new Set<() => void>()
+
+function subscribeDemoFallback(notify: () => void): () => void {
+  demoFallbackSubs.add(notify)
+  return () => {
+    demoFallbackSubs.delete(notify)
+  }
+}
+
+function setDemoFallback(repo: string, value: boolean): void {
+  const prev = demoFallbackByRepo.get(repo) ?? false
+  if (prev === value) return
+  demoFallbackByRepo.set(repo, value)
+  for (const notify of demoFallbackSubs) notify()
+}
+
+function getDemoFallback(repo: string): boolean {
+  return demoFallbackByRepo.get(repo) ?? false
+}
+
 async function fetchACMMScan(repo: string, force: boolean): Promise<ACMMScanData> {
   const qs = force ? `&force=true` : ''
   const res = await fetch(`${API_PATH}?repo=${encodeURIComponent(repo)}${qs}`, {
@@ -125,6 +162,12 @@ async function fetchACMMScan(repo: string, force: boolean): Promise<ACMMScanData
     throw new Error('ACMM scan is not available on this deployment — showing demo data')
   }
   const body = (await res.json()) as ACMMScanData & { demoFallback?: boolean }
+  // Track the server-signalled demoFallback flag so the hook can expose it
+  // via isDemoData even though the HTTP call itself succeeded (see bug #8848:
+  // the Netlify function returns 200 with demoFallback:true when upstream
+  // GitHub is unreachable, and without this signal the UI silently shows the
+  // demo catalog as if it were a live scan of the user's repo).
+  setDemoFallback(repo, Boolean(body.demoFallback))
   return body
 }
 
@@ -151,6 +194,15 @@ export function useCachedACMMScan(repo: string = DEFAULT_REPO): UseACMMScanResul
     await refetch()
   }, [refetch])
 
+  // Subscribe to the per-repo demo-fallback flag set by the fetcher. This
+  // re-renders the hook whenever the Netlify Function flips between live
+  // and demo-fallback responses for this repo.
+  const serverDemoFallback = useSyncExternalStore(
+    subscribeDemoFallback,
+    () => getDemoFallback(repo),
+    () => false,
+  )
+
   // When the Netlify Function isn't available (localhost / cluster deploy),
   // the fetcher throws "ACMM scan is not available on this deployment".
   // Detect this from the error string (available on the FIRST failure) rather
@@ -167,7 +219,9 @@ export function useCachedACMMScan(repo: string = DEFAULT_REPO): UseACMMScanResul
   const recommendations = computeRecommendations(detectedIds, level)
 
   const isDemoData =
-    (cacheResult.isDemoFallback && !cacheResult.isLoading) || apiUnavailable
+    (cacheResult.isDemoFallback && !cacheResult.isLoading) ||
+    apiUnavailable ||
+    serverDemoFallback
 
   return {
     data: effectiveData,


### PR DESCRIPTION
## Summary

When `/api/acmm/scan` cant reach GitHub (missing `GITHUB_TOKEN`, rate-limited, network error, etc.), the Netlify Function returns HTTP 200 with `demoFallback: true` plus a plausible demo catalog. Before this fix, `useCachedACMMScan` threw that flag away and reported `isDemoData: false`, so searching for `kubestellar/console` (or any repo, when the function had no token) on the ACMM dashboard silently rendered the demo catalog as if it were a live scan — no Demo badge, no yellow outline.

## Fix

- Route the server-side `demoFallback` flag through a per-repo external store in `useCachedACMMScan`.
- Subscribe via `useSyncExternalStore` so `isDemoData` flips true on the very first demo-fallback response (no waiting for three consecutive fetcher rejections).
- No card-level changes needed — `isDemoData` is already wired through `useCardLoadingState`.

## Tests

Added two regression tests in `useCachedACMMScan.test.tsx`:
- `isDemoData` flips to true when the server returns `demoFallback: true` (regression for #8848).
- `isDemoData` stays false on a clean live response.

All 11 hook tests pass. `npm run build` and `npx tsc --noEmit` both clean.

## Test plan

- [x] Unit tests pass locally
- [x] `npm run build` passes
- [x] `npx tsc --noEmit` clean
- [ ] On Netlify preview, load `/acmm?repo=kubestellar/console` with the GITHUB_TOKEN env var cleared — Demo badge and yellow outline should now show on all four cards.

Fixes #8848