### PR TITLE
fix: ACMM card cluster — 6 UX + data fixes

### DIFF
--- a/web/src/components/cards/ACMMFeedbackLoops.tsx
+++ b/web/src/components/cards/ACMMFeedbackLoops.tsx
@@ -247,7 +247,7 @@ export function ACMMFeedbackLoops() {
   const sources: (SourceId | 'all')[] = ['all', 'acmm', 'fullsend', 'agentic-engineering-framework', 'claude-reflect']
 
   return (
-    // #8847: dropped `max-w-4xl` on the outer wrapper — it was clamping the
+    // Issue 8847: dropped `max-w-4xl` on the outer wrapper — it was clamping the
     // card's inner layout well narrower than the card frame, leaving a dead
     // band on the right and pushing filter controls far from the list
     // content. The card's grid cell already governs width; using `w-full`
@@ -345,7 +345,7 @@ export function ACMMFeedbackLoops() {
           // first item of level N. The previous item's level determines
           // the boundary — if it differs from the current item's level
           // and both have levels, we're crossing a boundary.
-          // #8849: Use a sentinel for "not yet seen" so the boundary
+          // Issue 8849: Use a sentinel for "not yet seen" so the boundary
           // between the L1 (level 0) prerequisite tier and L2 gets a
           // divider — the old guard `prevLevel > 0` skipped it because
           // level=0 tests falsy. -1 sentinel only suppresses the divider
@@ -414,7 +414,7 @@ export function ACMMFeedbackLoops() {
           const isLocked = !locksOverridden && !!c.level && c.level > earnedLevel + 1
           const isLockPromptOpen = lockPromptId === c.id
           return (
-            // #8851: expanded rows get a distinct surface (ring + brighter
+            // Issue 8851: expanded rows get a distinct surface (ring + brighter
             // bg) so the click→expand affordance is obvious. Prior styling
             // only showed the expanded details block below the row with no
             // visual change to the row itself, so users didn't realize a
@@ -442,7 +442,7 @@ export function ACMMFeedbackLoops() {
                 aria-expanded={isLocked ? isLockPromptOpen : isExpanded}
                 title={isLocked ? `Locked — finish L${earnedLevel} first` : 'Show detection rule'}
               >
-                {/* #8851: brighter chevron colour when expanded so the
+                {/* Issue 8851: brighter chevron colour when expanded so the
                     state change is immediately visible even before the
                     user scans the row for the details block below. */}
                 {isLocked ? (
@@ -461,7 +461,7 @@ export function ACMMFeedbackLoops() {
                 ) : (
                   <X className="w-4 h-4 text-muted-foreground/40 flex-shrink-0" />
                 )}
-                {/* Fixed-width level column for clean alignment. #8850:
+                {/* Fixed-width level column for clean alignment. Issue 8850:
                     L1 items (internally `level: 0` — the "prerequisite" /
                     Assisted tier) previously rendered blank because
                     `c.level ? ...` treats 0 as falsy. Using `!= null`

--- a/web/src/components/cards/ACMMFeedbackLoops.tsx
+++ b/web/src/components/cards/ACMMFeedbackLoops.tsx
@@ -247,8 +247,13 @@ export function ACMMFeedbackLoops() {
   const sources: (SourceId | 'all')[] = ['all', 'acmm', 'fullsend', 'agentic-engineering-framework', 'claude-reflect']
 
   return (
-    <div className="h-full flex flex-col p-2 gap-2 max-w-4xl">
-      <div className="flex items-center gap-1.5 flex-wrap">
+    // #8847: dropped `max-w-4xl` on the outer wrapper — it was clamping the
+    // card's inner layout well narrower than the card frame, leaving a dead
+    // band on the right and pushing filter controls far from the list
+    // content. The card's grid cell already governs width; using `w-full`
+    // lets the toolbar and list fill the actual card surface.
+    <div className="h-full w-full flex flex-col p-2 gap-2">
+      <div className="flex items-center gap-1.5 flex-wrap w-full">
         {/* View mode toggle: By Level / Cross-cutting */}
         {(['by-level', 'cross-cutting'] as const).map((m) => (
           <button
@@ -340,9 +345,19 @@ export function ACMMFeedbackLoops() {
           // first item of level N. The previous item's level determines
           // the boundary — if it differs from the current item's level
           // and both have levels, we're crossing a boundary.
-          const prevLevel = idx > 0 ? (filtered[idx - 1].level ?? 0) : 0
-          const curLevel = c.level ?? 0
-          const showLevelBreak = viewMode === 'by-level' && curLevel > prevLevel && prevLevel > 0 && curLevel >= 2
+          // #8849: Use a sentinel for "not yet seen" so the boundary
+          // between the L1 (level 0) prerequisite tier and L2 gets a
+          // divider — the old guard `prevLevel > 0` skipped it because
+          // level=0 tests falsy. -1 sentinel only suppresses the divider
+          // on the very first row.
+          const UNSET_LEVEL = -1
+          const prevLevel = idx > 0 ? (filtered[idx - 1].level ?? UNSET_LEVEL) : UNSET_LEVEL
+          const curLevel = c.level ?? UNSET_LEVEL
+          const showLevelBreak =
+            viewMode === 'by-level'
+            && curLevel > prevLevel
+            && prevLevel !== UNSET_LEVEL
+            && curLevel >= 2
           /** Whether this level-break button is actionable. Only the
            *  immediate next level above earned is active; higher levels
            *  are "locked" until the preceding one is completed. */
@@ -399,10 +414,19 @@ export function ACMMFeedbackLoops() {
           const isLocked = !locksOverridden && !!c.level && c.level > earnedLevel + 1
           const isLockPromptOpen = lockPromptId === c.id
           return (
+            // #8851: expanded rows get a distinct surface (ring + brighter
+            // bg) so the click→expand affordance is obvious. Prior styling
+            // only showed the expanded details block below the row with no
+            // visual change to the row itself, so users didn't realize a
+            // click did anything.
             <>{dimHeader}{levelBreak}<div
               key={c.id}
               className={`rounded-md transition-colors ${
-                isLocked ? 'bg-muted/10 hover:bg-muted/20 opacity-60' : 'bg-muted/20 hover:bg-muted/40'
+                isLocked
+                  ? 'bg-muted/10 hover:bg-muted/20 opacity-60'
+                  : isExpanded
+                    ? 'bg-muted/50 ring-1 ring-primary/30'
+                    : 'bg-muted/20 hover:bg-muted/40'
               }`}
             >
               <button
@@ -418,10 +442,13 @@ export function ACMMFeedbackLoops() {
                 aria-expanded={isLocked ? isLockPromptOpen : isExpanded}
                 title={isLocked ? `Locked — finish L${earnedLevel} first` : 'Show detection rule'}
               >
+                {/* #8851: brighter chevron colour when expanded so the
+                    state change is immediately visible even before the
+                    user scans the row for the details block below. */}
                 {isLocked ? (
                   <Lock className="w-3 h-3 text-muted-foreground/60 flex-shrink-0" />
                 ) : isExpanded ? (
-                  <ChevronDown className="w-3 h-3 text-muted-foreground/60 flex-shrink-0" />
+                  <ChevronDown className="w-3 h-3 text-primary flex-shrink-0" />
                 ) : (
                   <ChevronRight className="w-3 h-3 text-muted-foreground/60 flex-shrink-0" />
                 )}
@@ -434,9 +461,16 @@ export function ACMMFeedbackLoops() {
                 ) : (
                   <X className="w-4 h-4 text-muted-foreground/40 flex-shrink-0" />
                 )}
-                {/* Fixed-width level column for clean alignment */}
+                {/* Fixed-width level column for clean alignment. #8850:
+                    L1 items (internally `level: 0` — the "prerequisite" /
+                    Assisted tier) previously rendered blank because
+                    `c.level ? ...` treats 0 as falsy. Using `!= null`
+                    gives every level-tagged item a badge. Displayed as
+                    `L1` to match the user-facing "L1 Assisted" framing —
+                    the internal 0-based numbering is an implementation
+                    detail. */}
                 <span className="text-[10px] font-mono text-muted-foreground w-6 text-right flex-shrink-0">
-                  {c.level ? `L${c.level}` : ''}
+                  {c.level != null ? `L${c.level === 0 ? 1 : c.level}` : ''}
                 </span>
                 <div className="min-w-0 flex-1">
                   <div className="text-xs font-medium truncate">{c.name}</div>

--- a/web/src/components/cards/ACMMRecommendations.tsx
+++ b/web/src/components/cards/ACMMRecommendations.tsx
@@ -158,7 +158,7 @@ export function ACMMRecommendations() {
           <div className="text-[10px] text-muted-foreground uppercase tracking-wide">
             Top recommendations
           </div>
-          {/* #8852: same contrast fix as the per-row "Ask agent for help"
+          {/* Issue 8852: same contrast fix as the per-row "Ask agent for help"
               below — filled primary surface with primary-foreground. */}
           {recommendations.length > 0 && (
             <button
@@ -183,7 +183,7 @@ export function ACMMRecommendations() {
                 <div className="flex gap-1 flex-shrink-0">
                   {rec.sources.map((s) => {
                     const src = SOURCES_BY_ID[s]
-                    // #8852: bumped bg opacity (40 → up from 20) and use
+                    // Issue 8852: bumped bg opacity (40 → up from 20) and use
                     // text-primary-foreground-like shade so the "ACMM" /
                     // other source chips have WCAG-passing contrast against
                     // the dark card background instead of the prior
@@ -216,7 +216,7 @@ export function ACMMRecommendations() {
                 <code className="text-[9px] font-mono text-muted-foreground/70 truncate flex-1" title={`Detection (${rec.criterion.detection.type})`}>
                   {detectionLabel(rec.criterion.detection)}
                 </code>
-                {/* #8852: higher-contrast "Ask agent for help" control —
+                {/* Issue 8852: higher-contrast "Ask agent for help" control —
                     prior bg-primary/10 + text-primary failed WCAG AA against
                     the muted card background. Using the filled primary
                     surface with primary-foreground mirrors other action

--- a/web/src/components/cards/ACMMRecommendations.tsx
+++ b/web/src/components/cards/ACMMRecommendations.tsx
@@ -158,11 +158,13 @@ export function ACMMRecommendations() {
           <div className="text-[10px] text-muted-foreground uppercase tracking-wide">
             Top recommendations
           </div>
+          {/* #8852: same contrast fix as the per-row "Ask agent for help"
+              below — filled primary surface with primary-foreground. */}
           {recommendations.length > 0 && (
             <button
               type="button"
               onClick={launchAll}
-              className="inline-flex items-center gap-1 text-[10px] px-2 py-0.5 rounded-full bg-primary/20 text-primary hover:bg-primary/30 transition-colors"
+              className="inline-flex items-center gap-1 text-[10px] px-2 py-1 rounded-full bg-primary text-primary-foreground hover:bg-primary/90 transition-colors font-medium"
               title={`Ask the selected agent to add all ${recommendations.length} missing criteria to ${repo}`}
             >
               <Sparkles className="w-2.5 h-2.5" />
@@ -181,9 +183,14 @@ export function ACMMRecommendations() {
                 <div className="flex gap-1 flex-shrink-0">
                   {rec.sources.map((s) => {
                     const src = SOURCES_BY_ID[s]
+                    // #8852: bumped bg opacity (40 → up from 20) and use
+                    // text-primary-foreground-like shade so the "ACMM" /
+                    // other source chips have WCAG-passing contrast against
+                    // the dark card background instead of the prior
+                    // low-contrast primary/20 wash.
                     const badge = (
                       <span
-                        className="text-[9px] px-1.5 py-0.5 rounded-full bg-primary/20 text-primary hover:bg-primary/30"
+                        className="text-[9px] px-1.5 py-0.5 rounded-full bg-primary/40 text-primary-foreground hover:bg-primary/60"
                         title={src?.citation}
                       >
                         {SOURCE_LABELS[s]}
@@ -209,10 +216,15 @@ export function ACMMRecommendations() {
                 <code className="text-[9px] font-mono text-muted-foreground/70 truncate flex-1" title={`Detection (${rec.criterion.detection.type})`}>
                   {detectionLabel(rec.criterion.detection)}
                 </code>
+                {/* #8852: higher-contrast "Ask agent for help" control —
+                    prior bg-primary/10 + text-primary failed WCAG AA against
+                    the muted card background. Using the filled primary
+                    surface with primary-foreground mirrors other action
+                    buttons in the app. */}
                 <button
                   type="button"
                   onClick={() => launchOne(rec)}
-                  className="inline-flex items-center gap-1 text-[10px] px-1.5 py-0.5 rounded-md bg-primary/10 text-primary hover:bg-primary/20 transition-colors flex-shrink-0"
+                  className="inline-flex items-center gap-1 text-[10px] px-2 py-1 rounded-md bg-primary text-primary-foreground hover:bg-primary/90 transition-colors flex-shrink-0 font-medium"
                   title={`Ask the selected agent to add the "${rec.criterion.name}" criterion to ${repo}`}
                 >
                   <Zap className="w-2.5 h-2.5" />

--- a/web/src/hooks/useCachedACMMScan.ts
+++ b/web/src/hooks/useCachedACMMScan.ts
@@ -29,6 +29,12 @@ export interface ACMMScanData {
   scannedAt: string
   detectedIds: string[]
   weeklyActivity: WeeklyActivity[]
+  /** Set by the Netlify Function (and Go backend) when the live GitHub
+   *  scan failed and the response body is a demo-catalog fallback rather
+   *  than a real scan. Drives the Demo badge on the cards so users can
+   *  tell "real scan of my repo" apart from "GitHub is rate-limited, here's
+   *  a canned catalog". #8848. */
+  demoFallback?: boolean
 }
 
 export interface UseACMMScanResult {
@@ -124,7 +130,7 @@ async function fetchACMMScan(repo: string, force: boolean): Promise<ACMMScanData
   if (!ct.includes('application/json')) {
     throw new Error('ACMM scan is not available on this deployment — showing demo data')
   }
-  const body = (await res.json()) as ACMMScanData & { demoFallback?: boolean }
+  const body = (await res.json()) as ACMMScanData
   return body
 }
 
@@ -160,6 +166,15 @@ export function useCachedACMMScan(repo: string = DEFAULT_REPO): UseACMMScanResul
   const apiUnavailable =
     (cacheResult.error?.includes('not available') ?? false) ||
     (cacheResult.isFailed && cacheResult.data.detectedIds.length === 0)
+  // #8848: the Netlify Function / Go handler returns `demoFallback: true`
+  // when the upstream GitHub scan failed (rate limit, network error) —
+  // the response still has a 200 status with the canned demo catalog so
+  // the card renders something, but we MUST NOT present that as a real
+  // scan of the user's repo. Surface it through isDemoData so the standard
+  // Demo badge + yellow outline appear, preventing the reporter's case
+  // where searching `kubestellar/console` silently returned demo data
+  // that looked live.
+  const serverMarkedDemo = cacheResult.data.demoFallback === true
   const effectiveData = apiUnavailable ? demoScan(repo) : cacheResult.data
 
   const detectedIds = new Set(effectiveData.detectedIds ?? [])
@@ -167,7 +182,7 @@ export function useCachedACMMScan(repo: string = DEFAULT_REPO): UseACMMScanResul
   const recommendations = computeRecommendations(detectedIds, level)
 
   const isDemoData =
-    (cacheResult.isDemoFallback && !cacheResult.isLoading) || apiUnavailable
+    (cacheResult.isDemoFallback && !cacheResult.isLoading) || apiUnavailable || serverMarkedDemo
 
   return {
     data: effectiveData,

--- a/web/src/hooks/useCachedACMMScan.ts
+++ b/web/src/hooks/useCachedACMMScan.ts
@@ -33,7 +33,7 @@ export interface ACMMScanData {
    *  scan failed and the response body is a demo-catalog fallback rather
    *  than a real scan. Drives the Demo badge on the cards so users can
    *  tell "real scan of my repo" apart from "GitHub is rate-limited, here's
-   *  a canned catalog". #8848. */
+   *  a canned catalog". Issue 8848. */
   demoFallback?: boolean
 }
 
@@ -166,7 +166,7 @@ export function useCachedACMMScan(repo: string = DEFAULT_REPO): UseACMMScanResul
   const apiUnavailable =
     (cacheResult.error?.includes('not available') ?? false) ||
     (cacheResult.isFailed && cacheResult.data.detectedIds.length === 0)
-  // #8848: the Netlify Function / Go handler returns `demoFallback: true`
+  // Issue 8848: the Netlify Function / Go handler returns `demoFallback: true`
   // when the upstream GitHub scan failed (rate limit, network error) —
   // the response still has a 200 status with the canned demo catalog so
   // the card renders something, but we MUST NOT present that as a real


### PR DESCRIPTION
## Summary

Six ACMM-card bugs from @xonas1101 fixed together since they all touch the
same two components (`ACMMFeedbackLoops`, `ACMMRecommendations`) plus the
ACMM scan hook.

## Fixes (per-issue)

| Issue | Fix |
|---|---|
| #8852 | Higher-contrast controls on the Your Role + Next Steps card — filled `bg-primary` + `text-primary-foreground` for both the per-row and aggregate "Ask agent for help" buttons, plus the source/ACMM badge chips. |
| #8847 | Feedback Loop Inventory was `max-w-4xl` — narrower than the card frame it sat inside — so the toolbar bunched at the left and there was a dead band on the right. Dropped the cap; toolbar + list now fill the card. |
| #8849 | Divider between L1 (internal `level: 0`, the "Prerequisites / Assisted" tier) and L2 now renders. Prior guard `prevLevel > 0` short-circuited because `0` tests falsy; swapped in a `-1` sentinel for "not yet seen". |
| #8850 | L1 tasks now render the `L1` marker in the level column. Previously rendered blank because `c.level ? 'L${c.level}' : ''` treats `0` as falsy. Displayed as `L1` to match the user-facing "L1 Assisted" framing; the internal 0-based numbering stays an implementation detail. |
| #8851 | Task expansion is now visible at a glance — expanded rows get a distinct `bg-muted/50` surface with a `ring-1 ring-primary/30` ring, and the chevron flips to `text-primary`. Chose this over a modal to keep the in-line mental model; happy to iterate to a modal in a follow-up if the extra visibility isn't enough. |
| #8848 | `useCachedACMMScan` now honours the server's `demoFallback: true` flag. The Netlify Function and Go handler both return a demo-catalog payload with that flag set when the upstream GitHub scan fails (rate limit, network error); the frontend used to render those IDs as if they were a real scan. It now surfaces `isDemoData = true` so the standard Demo badge + yellow outline appear. |

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npm run build` clean (incl. post-build vendor-safety checks)
- [x] `vitest run` for `useCachedACMMScan` + `lib/acmm` — 64/64 pass
- [ ] Manual: verify all 6 fixes visually on the ACMM dashboard

Fixes #8847
Fixes #8848
Fixes #8849
Fixes #8850
Fixes #8851
Fixes #8852