### PR TITLE
fix: dashboard Nodes drillDown aggregates nodes across clusters (#8840)

### DIFF
--- a/web/src/components/drilldown/views/MultiClusterSummaryDrillDown.tsx
+++ b/web/src/components/drilldown/views/MultiClusterSummaryDrillDown.tsx
@@ -3,7 +3,7 @@ import { Search, Server, Layers, Rocket, Box, Settings as SettingsIcon, AlertCir
 import { useClusterData } from '../../../hooks/useClusterData'
 import { useDrillDownActions } from '../../../hooks/useDrillDown'
 import type { DrillDownViewType } from '../../../hooks/useDrillDown'
-import { useCachedNodes, useCachedPVCs } from '../../../hooks/useCachedData'
+import { useCachedAllNodes, useCachedPVCs } from '../../../hooks/useCachedData'
 import { useAlerts } from '../../../hooks/useAlerts'
 import { useTranslation } from 'react-i18next'
 import { formatRelativeTime } from '../../../lib/formatters'
@@ -175,13 +175,22 @@ export function MultiClusterSummaryDrillDown({ data, viewType }: MultiClusterSum
   // synthetic pod-alerts never carry status='resolved'. Using the real
   // alerts list here keeps the count and the list in lock-step.
   const { alerts: contextAlerts } = useAlerts()
+  // Use useCachedAllNodes (not useCachedNodes) for the cumulative,
+  // cross-cluster drill-down list so the UI never substitutes four
+  // hard-coded demo nodes for a real-but-empty live result (Issue 8840).
+  // useCachedNodes() without a cluster has demoWhenEmpty=true, which made
+  // the landing-dashboard Nodes stat block drill-down masquerade demo data
+  // as real. The per-cluster drill-down always passed a cluster name, so
+  // it bypassed that fallback — that's why it worked. useCachedAllNodes
+  // additionally iterates DeduplicatedClusters() to avoid double-counting
+  // nodes when multiple contexts point to the same API server.
   const {
     nodes: rawCachedNodes,
     lastRefresh: nodesLastRefresh,
     isLoading: nodesIsLoading,
     isFailed: nodesIsFailed,
     isDemoFallback: nodesIsDemoFallback,
-  } = useCachedNodes()
+  } = useCachedAllNodes()
   const { pvcs: cachedPVCs } = useCachedPVCs()
   // Guard against undefined to prevent crashes when APIs return 404/500/empty
   const cachedNodes = rawCachedNodes || []

--- a/web/src/components/drilldown/views/__tests__/MultiClusterSummaryDrillDown.test.tsx
+++ b/web/src/components/drilldown/views/__tests__/MultiClusterSummaryDrillDown.test.tsx
@@ -48,6 +48,7 @@ vi.mock('../../../../hooks/useAlerts', () => ({
 
 vi.mock('../../../../hooks/useCachedData', () => ({
   useCachedNodes: () => ({ nodes: [], lastRefresh: Date.now(), isLoading: false, isFailed: false, isDemoFallback: false, isRefreshing: false, consecutiveFailures: 0, refetch: vi.fn() }),
+  useCachedAllNodes: () => ({ nodes: [], lastRefresh: Date.now(), isLoading: false, isFailed: false, isDemoFallback: false, isRefreshing: false, consecutiveFailures: 0, refetch: vi.fn() }),
   useCachedPVCs: () => ({ pvcs: [], lastRefresh: Date.now(), isLoading: false, isFailed: false, isDemoFallback: false, isRefreshing: false, consecutiveFailures: 0, refetch: vi.fn() }),
 }))
 

--- a/web/src/hooks/useCachedData.ts
+++ b/web/src/hooks/useCachedData.ts
@@ -20,7 +20,7 @@ import { useCache, type RefreshCategory } from '../lib/cache'
 import { isBackendUnavailable, authFetch } from '../lib/api'
 import { kubectlProxy } from '../lib/kubectlProxy'
 import { fetchSSE } from '../lib/sseClient'
-import { clusterCacheRef } from './mcp/shared'
+import { clusterCacheRef, deduplicateClustersByServer } from './mcp/shared'
 import { isAgentUnavailable } from './useLocalAgent'
 import { LOCAL_AGENT_HTTP_URL, STORAGE_KEY_TOKEN } from '../lib/constants'
 import { FETCH_DEFAULT_TIMEOUT_MS, AI_PREDICTION_TIMEOUT_MS, KUBECTL_EXTENDED_TIMEOUT_MS } from '../lib/constants/network'
@@ -1371,6 +1371,108 @@ export function useCachedNodes(
     isLoading: result.isLoading,
     isRefreshing: result.isRefreshing,
     isDemoFallback: effectiveIsDemoFallback,
+    error: result.error,
+    isFailed: result.isFailed,
+    consecutiveFailures: result.consecutiveFailures,
+    lastRefresh: result.lastRefresh,
+    refetch: result.refetch }
+}
+
+/**
+ * Hook for fetching a cumulative, cross-cluster node list for the landing
+ * dashboard's "Nodes" stat-block drill-down (#8840).
+ *
+ * Differs from {@link useCachedNodes} (no cluster arg) in two ways:
+ *
+ * 1. It iterates DEDUPLICATED clusters from the shared cluster cache via
+ *    {@link deduplicateClustersByServer}. The generic fan-out in
+ *    {@link fetchFromAllClusters} only filters out long-context aliases by
+ *    name, which can still double-count when two short-named contexts point
+ *    to the same API server. See MEMORY.md: "ALWAYS use
+ *    DeduplicatedClusters() when iterating clusters".
+ *
+ * 2. It DOES NOT fall back to demo data on empty live results. The drill-down
+ *    is expected to render an authoritative cross-cluster list (or the
+ *    existing "summary reports N nodes but list is empty" explainer),
+ *    NOT four hard-coded fake nodes. The parent stat block (on the Dashboard)
+ *    retains the original {@link useCachedNodes} optimistic-demo behaviour so
+ *    tiles never flash empty. Only the drill-down is switched to this hook.
+ *
+ * An `isDemoFallback` field is still returned (always `false` in live mode,
+ * `true` only when the whole app is in demo mode) so the drill-down can keep
+ * its existing `nodesIsDemoFallback` wiring intact — see the task's
+ * `isDemoData` preservation rule.
+ */
+export function useCachedAllNodes(): CachedHookResult<NodeInfo[]> & { nodes: NodeInfo[] } {
+  const key = 'nodes:all:dedup'
+
+  const result = useCache({
+    key,
+    category: 'pods' as RefreshCategory,
+    initialData: [] as NodeInfo[],
+    demoData: getDemoCachedNodes(),
+    // IMPORTANT: no demoWhenEmpty — we never want to mask a real empty /
+    // partially-failed cross-cluster result with four hard-coded fake nodes
+    // in the drill-down list. The drill-down has its own empty-state
+    // explainer (RBAC hint, summary-vs-list mismatch) that is much more
+    // useful than synthetic demo data.
+    persist: true,
+    fetcher: async () => {
+      const allClusters = clusterCacheRef.clusters || []
+      // Apply the same deduplication that useClusters().deduplicatedClusters
+      // uses — multiple kubeconfig contexts can point to the same API
+      // server, and without dedup each node would be listed once per
+      // context. See MEMORY.md: feedback_dedupe_clusters.md.
+      const deduped = deduplicateClustersByServer(allClusters)
+      const reachable = deduped.filter(
+        (c) => c.reachable !== false && !c.name.includes('/'),
+      )
+      if (reachable.length === 0) {
+        throw new Error(
+          'No reachable clusters (agent connecting or backend not authenticated)',
+        )
+      }
+
+      // Fan out per-cluster fetches in parallel. Each per-cluster call is
+      // identical to what useCachedNodes(clusterName) would do — using the
+      // same /api/mcp/nodes endpoint that already works on the per-cluster
+      // drill-down, so the "live data path exists" invariant from the
+      // issue description holds.
+      const tasks = reachable.map((cluster) => async () => {
+        try {
+          const raw = await fetchAPI<unknown>('nodes', { cluster: cluster.name })
+          const data = validateArrayResponse<{ nodes: NodeInfo[] }>(
+            NodesResponseSchema,
+            raw,
+            '/api/mcp/nodes',
+            'nodes',
+          )
+          return (data.nodes || []).map((n) => ({ ...n, cluster: cluster.name }))
+        } catch {
+          // Per-cluster failure: tolerate it so a single unreachable cluster
+          // doesn't wipe the whole aggregate. Accumulated nodes from other
+          // clusters still render; the drill-down's empty-state explainer
+          // handles the all-failed case.
+          return [] as NodeInfo[]
+        }
+      })
+
+      const accumulated: NodeInfo[] = []
+      async function handleSettled(res: PromiseSettledResult<NodeInfo[]>) {
+        if (res.status === 'fulfilled') {
+          accumulated.push(...res.value)
+        }
+      }
+      await settledWithConcurrency(tasks, undefined, handleSettled)
+      return accumulated
+    } })
+
+  return {
+    nodes: result.data,
+    data: result.data,
+    isLoading: result.isLoading,
+    isRefreshing: result.isRefreshing,
+    isDemoFallback: result.isDemoFallback,
     error: result.error,
     isFailed: result.isFailed,
     consecutiveFailures: result.consecutiveFailures,

--- a/web/src/hooks/useCachedData.ts
+++ b/web/src/hooks/useCachedData.ts
@@ -1380,7 +1380,7 @@ export function useCachedNodes(
 
 /**
  * Hook for fetching a cumulative, cross-cluster node list for the landing
- * dashboard's "Nodes" stat-block drill-down (#8840).
+ * dashboard's "Nodes" stat-block drill-down (Issue 8840).
  *
  * Differs from {@link useCachedNodes} (no cluster arg) in two ways:
  *


### PR DESCRIPTION
## Summary

The landing dashboard's Nodes stat block drill-down silently showed four hard-coded demo nodes (`prod-east` / `vllm-d` / `kind-local`) even when the user was in live mode. The per-cluster Nodes drill-down on the **My Clusters** dashboard was unaffected, so the live data path already existed — the cumulative cross-cluster drill-down just wasn't connected to it.

**Root cause.** `MultiClusterSummaryDrillDown` called `useCachedNodes()` with no cluster argument, and `useCachedNodes` sets `demoWhenEmpty: true` whenever cluster is unset. If the `/api/mcp/nodes` fan-out returned empty (RBAC on the managed clusters, partial endpoint failure, agent still connecting), the cache layer substituted the demo dataset and the drill-down rendered those fake nodes as if they were real. The per-cluster call — which does pass a cluster name — has `demoWhenEmpty: false`, so it always showed real (possibly empty) data.

## Change

- **New hook `useCachedAllNodes()`** (`web/src/hooks/useCachedData.ts`) — a sibling of `useCachedNodes()` designed specifically for the cumulative cross-cluster drill-down:
  - Iterates **deduplicated** clusters from the shared cluster cache via `deduplicateClustersByServer()`. The generic `fetchFromAllClusters()` fan-out only filters long context names, which can still double-count when two short-named contexts point to the same API server. Per MEMORY.md: *"ALWAYS use `DeduplicatedClusters()` when iterating clusters."*
  - Fans out per-cluster `/api/mcp/nodes` fetches in parallel using the same endpoint the per-cluster drill-down uses — tagging each node with its `cluster` so the user can see where it came from.
  - Never falls back to demo data on empty live results. The drill-down already renders an empty-state explainer (*"summary reports N nodes but list is empty — likely RBAC"*) that is far more useful than four synthetic placeholders.
  - Still exposes `isDemoFallback` so the existing demo-mode badge wiring stays intact — it's just always `false` in live mode (only `true` when the whole app is in demo mode).
- **`MultiClusterSummaryDrillDown`** switches to the new hook for the `all-nodes` view. All other views (`all-pods`, `all-services`, etc.) are untouched.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npm run build` clean
- [x] `MultiClusterSummaryDrillDown.test.tsx` — updated mock to include `useCachedAllNodes`, renders without crashing.
- [x] `useCachedData` test suites (408 tests) — all passing.
- [ ] **Manual:** click the Nodes stat block on the landing dashboard in live mode with real clusters → drill-down shows a cumulative cross-cluster node list (not the demo `prod-east` / `vllm-d` / `kind-local` nodes).
- [ ] **Manual:** same as above in demo mode → still shows the expected demo nodes with the yellow Demo badge.
- [ ] **Manual:** multiple kubeconfig contexts pointing to the same API server → each node appears exactly once (deduplication respected).
- [ ] **Manual:** per-cluster Nodes drill-down on **My Clusters** → continues to work unchanged.

Fixes #8840