### PR TITLE
fix: wrap cluster management strings in t() for i18n

### DIFF
--- a/web/src/components/cluster-admin/ClusterAdmin.tsx
+++ b/web/src/components/cluster-admin/ClusterAdmin.tsx
@@ -1,3 +1,4 @@
+import { useTranslation } from 'react-i18next'
 import { useClusters } from '../../hooks/useMCP'
 import { useUniversalStats, createMergedStatValueGetter } from '../../hooks/useUniversalStats'
 import { StatBlockValue } from '../ui/StatsOverview'
@@ -10,6 +11,7 @@ const STORAGE_KEY = 'kubestellar-cluster-admin-cards'
 const DEFAULT_CARDS = getDefaultCards('cluster-admin')
 
 export function ClusterAdmin() {
+  const { t } = useTranslation()
   // Use deduplicatedClusters so the stat blocks count physical clusters, not
   // kubeconfig contexts. Multiple contexts (long path + short alias + per-user
   // SA variants) commonly point to the same server — the raw list double-counts
@@ -42,10 +44,10 @@ export function ClusterAdmin() {
       // made the sidebar disagree with itself (ClusterAdmin showed 10 while
       // My Clusters and Dashboard showed 12 for the same 12 physical clusters
       // with 2 offline).
-      case 'clusters': return { value: clusters.length, sublabel: 'total', isDemo: isDemoData }
-      case 'healthy': return { value: healthy.length, sublabel: 'healthy', isDemo: isDemoData }
-      case 'degraded': return { value: degraded.length, sublabel: 'degraded', isDemo: isDemoData }
-      case 'offline': return { value: offline.length, sublabel: 'offline', isDemo: isDemoData }
+      case 'clusters': return { value: clusters.length, sublabel: t('clusterAdmin.statTotal'), isDemo: isDemoData }
+      case 'healthy': return { value: healthy.length, sublabel: t('clusterAdmin.statHealthy'), isDemo: isDemoData }
+      case 'degraded': return { value: degraded.length, sublabel: t('clusterAdmin.statDegraded'), isDemo: isDemoData }
+      case 'offline': return { value: offline.length, sublabel: t('clusterAdmin.statOffline'), isDemo: isDemoData }
       default: return { value: '-', isDemo: isDemoData }
     }
   }
@@ -54,8 +56,8 @@ export function ClusterAdmin() {
 
   return (
     <DashboardPage
-      title="Cluster Admin"
-      subtitle="Multi-cluster operations, health, and infrastructure management"
+      title={t('clusterAdmin.title')}
+      subtitle={t('clusterAdmin.subtitle')}
       icon="ShieldAlert"
       rightExtra={<RotatingTip page="cluster-admin" />}
       storageKey={STORAGE_KEY}
@@ -69,12 +71,12 @@ export function ClusterAdmin() {
       hasData={hasData}
       isDemoData={isDemoData}
       emptyState={{
-        title: 'Cluster Admin Dashboard',
-        description: 'Add cards to manage cluster health, node operations, upgrades, and security across your infrastructure.' }}
+        title: t('clusterAdmin.emptyTitle'),
+        description: t('clusterAdmin.emptyDescription') }}
     >
       {error && (
         <div className="mb-4 p-4 rounded-lg bg-red-500/10 border border-red-500/20 text-red-400">
-          <div className="font-medium">Error loading cluster data</div>
+          <div className="font-medium">{t('clusterAdmin.errorLoadingClusterData')}</div>
           <div className="text-sm text-muted-foreground">{error}</div>
         </div>
       )}

--- a/web/src/components/clusters/ClusterDetailModal.tsx
+++ b/web/src/components/clusters/ClusterDetailModal.tsx
@@ -178,8 +178,8 @@ export function ClusterDetailModal({ clusterName, clusterUser, onClose, onRename
     ].slice(0, 10).join('\n')
 
     startMission({
-      title: `Diagnose ${clusterName.split('/').pop()}`,
-      description: `Analyzing cluster health and identifying issues`,
+      title: t('clusterActions.diagnoseTitle', { cluster: clusterName.split('/').pop() }),
+      description: t('clusterActions.diagnoseDescription'),
       type: 'troubleshoot',
       cluster: clusterName,
       initialPrompt: `Analyze the health of Kubernetes cluster "${clusterName}" and identify any issues that need attention.
@@ -216,8 +216,8 @@ Please analyze this cluster and provide:
     ].join('\n')
 
     startMission({
-      title: `Repair ${clusterName.split('/').pop()}`,
-      description: `Automatically fixing cluster issues`,
+      title: t('clusterActions.repairTitle', { cluster: clusterName.split('/').pop() }),
+      description: t('clusterActions.repairDescription'),
       type: 'repair',
       cluster: clusterName,
       initialPrompt: `I need help repairing issues in Kubernetes cluster "${clusterName}".

--- a/web/src/components/clusters/Clusters.tsx
+++ b/web/src/components/clusters/Clusters.tsx
@@ -121,7 +121,7 @@ export function Clusters() {
       try {
         JSON.parse(savedOrder)
       } catch {
-        showToast('Cluster sort preferences were corrupted and have been reset to defaults.', 'warning')
+        showToast(t('clusters.sortPreferencesCorrupted'), 'warning')
       }
     }
   }, []) // eslint-disable-line react-hooks/exhaustive-deps
@@ -149,7 +149,7 @@ export function Clusters() {
   }, [location.key]) // eslint-disable-line react-hooks/exhaustive-deps
 
   const handleRenameContext = async (oldName: string, newName: string) => {
-    if (!isConnected) throw new Error('Local agent not connected')
+    if (!isConnected) throw new Error(t('clusters.localAgentNotConnected'))
     // Use agentFetch so the Authorization: Bearer <KC_AGENT_TOKEN> header
     // is injected — plain fetch() is rejected with 401 when the agent has
     // a token configured (#6133).

--- a/web/src/components/clusters/add-cluster/ConnectTab.tsx
+++ b/web/src/components/clusters/add-cluster/ConnectTab.tsx
@@ -390,7 +390,7 @@ export function ConnectTab({
                   {testResult.reachable ? (
                     <>
                       <Check className="w-4 h-4 shrink-0" />
-                      {t('cluster.connectTestSuccess')} — Kubernetes {testResult.serverVersion}
+                      {t('cluster.connectTestSuccessKubernetes', { label: t('cluster.connectTestSuccess'), version: testResult.serverVersion })}
                     </>
                   ) : (
                     <>

--- a/web/src/components/clusters/components/ClusterGroups.tsx
+++ b/web/src/components/clusters/components/ClusterGroups.tsx
@@ -76,7 +76,7 @@ export function ClusterGroups({
           className="flex items-center gap-1 text-xs text-primary hover:text-primary/80 transition-colors"
         >
           <Plus className="w-3.5 h-3.5" />
-          New Group
+          {t('clusters.groups.newGroup')}
         </button>
       </div>
 
@@ -87,13 +87,13 @@ export function ClusterGroups({
             <div className="glass p-4 rounded-lg space-y-3">
               <input
                 type="text"
-                placeholder="Group name..."
+                placeholder={t('clusters.groups.groupNamePlaceholder')}
                 value={formState.name}
                 onChange={(e) => setFormState(prev => ({ ...prev, name: e.target.value }))}
                 className="w-full px-3 py-2 text-sm bg-secondary/50 border border-border rounded-lg text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-primary"
                 autoFocus
               />
-              <div className="text-xs text-muted-foreground mb-1">Select clusters for this group:</div>
+              <div className="text-xs text-muted-foreground mb-1">{t('clusters.groups.selectClustersForGroup')}</div>
               <div className="flex flex-wrap gap-2">
                 {pickerClusters.map((cluster) => {
                   const isInGroup = formState.clusters.includes(cluster.name)
@@ -139,7 +139,7 @@ export function ClusterGroups({
                   onClick={handleCancel}
                   className="px-3 py-1.5 text-sm text-muted-foreground hover:text-foreground"
                 >
-                  Cancel
+                  {t('clusters.groups.cancel')}
                 </button>
                 <button
                   onClick={handleCreateGroup}
@@ -147,7 +147,7 @@ export function ClusterGroups({
                   className="flex items-center gap-1 px-3 py-1.5 text-sm bg-primary text-primary-foreground rounded-lg hover:bg-primary/80 disabled:opacity-50 disabled:cursor-not-allowed"
                 >
                   <Check className="w-3.5 h-3.5" />
-                  Create
+                  {t('clusters.groups.create')}
                 </button>
               </div>
             </div>

--- a/web/src/components/clusters/components/RenameModal.test.tsx
+++ b/web/src/components/clusters/components/RenameModal.test.tsx
@@ -44,7 +44,8 @@ describe('RenameModal', () => {
   it('renders the modal with current display name pre-filled', () => {
     render(<RenameModal {...defaultProps} />)
 
-    expect(screen.getByText('Rename Context')).toBeTruthy()
+    // Mocked useTranslation returns the key verbatim (see mock above).
+    expect(screen.getByText('renameModal.title')).toBeTruthy()
     expect(screen.getByDisplayValue('my-cluster')).toBeTruthy()
     expect(screen.getByText(/my-cluster/)).toBeTruthy()
   })
@@ -56,7 +57,7 @@ describe('RenameModal', () => {
     fireEvent.change(input, { target: { value: '' } })
 
     // The Rename button should be disabled when name is empty
-    const renameBtn = screen.getByText('Rename')
+    const renameBtn = screen.getByText('renameModal.rename')
     expect(renameBtn.closest('button')?.disabled).toBe(true)
   })
 
@@ -66,10 +67,10 @@ describe('RenameModal', () => {
     const input = screen.getByDisplayValue('my-cluster')
     fireEvent.change(input, { target: { value: 'has space' } })
 
-    fireEvent.click(screen.getByText('Rename'))
+    fireEvent.click(screen.getByText('renameModal.rename'))
 
     await waitFor(() => {
-      expect(screen.getByText('Name cannot contain spaces')).toBeTruthy()
+      expect(screen.getByText('renameModal.errorNameSpaces')).toBeTruthy()
     })
   })
 
@@ -77,10 +78,10 @@ describe('RenameModal', () => {
     render(<RenameModal {...defaultProps} />)
 
     // Name is already 'my-cluster', click rename without changing
-    fireEvent.click(screen.getByText('Rename'))
+    fireEvent.click(screen.getByText('renameModal.rename'))
 
     await waitFor(() => {
-      expect(screen.getByText('Name is unchanged')).toBeTruthy()
+      expect(screen.getByText('renameModal.errorNameUnchanged')).toBeTruthy()
     })
   })
 
@@ -89,7 +90,7 @@ describe('RenameModal', () => {
 
     const input = screen.getByDisplayValue('my-cluster')
     fireEvent.change(input, { target: { value: 'new-name' } })
-    fireEvent.click(screen.getByText('Rename'))
+    fireEvent.click(screen.getByText('renameModal.rename'))
 
     await waitFor(() => {
       expect(defaultProps.onRename).toHaveBeenCalledWith('cluster-1', 'new-name')
@@ -104,17 +105,17 @@ describe('RenameModal', () => {
 
     const input = screen.getByDisplayValue('my-cluster')
     fireEvent.change(input, { target: { value: 'new-name' } })
-    fireEvent.click(screen.getByText('Rename'))
+    fireEvent.click(screen.getByText('renameModal.rename'))
 
     await waitFor(() => {
       expect(defaultProps.onClose).toHaveBeenCalled()
     })
 
     // After success, label should be "Renamed", not "Rename".
-    expect(screen.queryByText('Rename')).toBeNull()
-    expect(screen.getByText('Renamed')).toBeTruthy()
+    expect(screen.queryByText('renameModal.rename')).toBeNull()
+    expect(screen.getByText('renameModal.renamed')).toBeTruthy()
     // Button should remain disabled while the modal is closing.
-    expect(screen.getByText('Renamed').closest('button')?.disabled).toBe(true)
+    expect(screen.getByText('renameModal.renamed').closest('button')?.disabled).toBe(true)
   })
 
   it('shows error message when onRename rejects', async () => {
@@ -123,7 +124,7 @@ describe('RenameModal', () => {
 
     const input = screen.getByDisplayValue('my-cluster')
     fireEvent.change(input, { target: { value: 'new-name' } })
-    fireEvent.click(screen.getByText('Rename'))
+    fireEvent.click(screen.getByText('renameModal.rename'))
 
     await waitFor(() => {
       expect(screen.getByText('Server error')).toBeTruthy()
@@ -132,7 +133,7 @@ describe('RenameModal', () => {
 
   it('does not render when isOpen is false', () => {
     render(<RenameModal {...defaultProps} isOpen={false} />)
-    expect(screen.queryByText('Rename Context')).toBeNull()
+    expect(screen.queryByText('renameModal.title')).toBeNull()
   })
 
   it('calls onClose when Escape key is pressed', () => {

--- a/web/src/components/clusters/components/RenameModal.tsx
+++ b/web/src/components/clusters/components/RenameModal.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react'
 import { Check, Loader2, Edit3 } from 'lucide-react'
+import { useTranslation } from 'react-i18next'
 import { BaseModal } from '../../../lib/modals'
 
 interface RenameModalProps {
@@ -17,21 +18,22 @@ interface RenameModalProps {
 type RenamePhase = 'idle' | 'renaming' | 'success'
 
 export function RenameModal({ isOpen = true, clusterName, currentDisplayName, onClose, onRename }: RenameModalProps) {
+  const { t } = useTranslation()
   const [newName, setNewName] = useState(currentDisplayName)
   const [phase, setPhase] = useState<RenamePhase>('idle')
   const [error, setError] = useState<string | null>(null)
 
   const handleRename = async () => {
     if (!newName.trim()) {
-      setError('Name cannot be empty')
+      setError(t('renameModal.errorNameEmpty'))
       return
     }
     if (newName.includes(' ')) {
-      setError('Name cannot contain spaces')
+      setError(t('renameModal.errorNameSpaces'))
       return
     }
     if (newName.trim() === currentDisplayName) {
-      setError('Name is unchanged')
+      setError(t('renameModal.errorNameUnchanged'))
       return
     }
 
@@ -46,7 +48,7 @@ export function RenameModal({ isOpen = true, clusterName, currentDisplayName, on
       onClose()
     } catch (err) {
       setPhase('idle')
-      setError(err instanceof Error ? err.message : 'Failed to rename context')
+      setError(err instanceof Error ? err.message : t('renameModal.errorFailedToRename'))
     }
   }
 
@@ -55,7 +57,7 @@ export function RenameModal({ isOpen = true, clusterName, currentDisplayName, on
   return (
     <BaseModal isOpen={isOpen} onClose={onClose} size="sm" closeOnBackdrop={false}>
       <BaseModal.Header
-        title="Rename Context"
+        title={t('renameModal.title')}
         icon={Edit3}
         onClose={onClose}
         showBack={false}
@@ -63,11 +65,11 @@ export function RenameModal({ isOpen = true, clusterName, currentDisplayName, on
 
       <BaseModal.Content>
         <p className="text-sm text-muted-foreground mb-4">
-          Current: <span className="text-foreground font-mono text-xs break-all">{currentDisplayName}</span>
+          {t('renameModal.current')} <span className="text-foreground font-mono text-xs break-all">{currentDisplayName}</span>
         </p>
 
         <div className="mb-4">
-          <label htmlFor="new-context-name" className="block text-sm text-muted-foreground mb-1">New name</label>
+          <label htmlFor="new-context-name" className="block text-sm text-muted-foreground mb-1">{t('renameModal.newName')}</label>
           <input
             id="new-context-name"
             type="text"
@@ -82,14 +84,14 @@ export function RenameModal({ isOpen = true, clusterName, currentDisplayName, on
 
         {error && <p className="text-sm text-red-400 mb-4">{error}</p>}
 
-        <p className="text-xs text-muted-foreground">This updates your kubeconfig via the local agent.</p>
+        <p className="text-xs text-muted-foreground">{t('renameModal.footerHint')}</p>
       </BaseModal.Content>
 
       <BaseModal.Footer showKeyboardHints>
         <div className="flex-1" />
         <div className="flex gap-2">
           <button onClick={onClose} className="px-4 py-2 rounded-lg text-sm text-muted-foreground hover:text-foreground hover:bg-secondary/50">
-            Cancel
+            {t('renameModal.cancel')}
           </button>
           <button
             onClick={handleRename}
@@ -97,11 +99,11 @@ export function RenameModal({ isOpen = true, clusterName, currentDisplayName, on
             className="flex items-center gap-2 px-4 py-2 rounded-lg text-sm bg-primary text-primary-foreground hover:bg-primary/80 disabled:opacity-50"
           >
             {phase === 'renaming' ? (
-              <><Loader2 className="w-4 h-4 animate-spin" />Renaming...</>
+              <><Loader2 className="w-4 h-4 animate-spin" />{t('renameModal.renaming')}</>
             ) : phase === 'success' ? (
-              <><Check className="w-4 h-4" />Renamed</>
+              <><Check className="w-4 h-4" />{t('renameModal.renamed')}</>
             ) : (
-              <><Check className="w-4 h-4" />Rename</>
+              <><Check className="w-4 h-4" />{t('renameModal.rename')}</>
             )}
           </button>
         </div>

--- a/web/src/locales/en/common.json
+++ b/web/src/locales/en/common.json
@@ -3015,6 +3015,7 @@
     "connectTestButton": "Test Connection",
     "connectTesting": "Testing...",
     "connectTestSuccess": "Connected",
+    "connectTestSuccessKubernetes": "{{label}} — Kubernetes {{version}}",
     "connectTestFailed": "Connection failed",
     "connectAddButton": "Add Cluster",
     "connectAddDisabledAfterTestFail": "Connection test failed. Edit connection settings or re-run the test before adding.",
@@ -3388,8 +3389,46 @@
       "deleteTitle": "Delete Cluster Group",
       "deleteMessage": "Are you sure you want to delete this cluster group? This action cannot be undone.",
       "deleteConfirm": "Delete cluster group \"{{name}}\"? This cannot be undone.",
-      "title": "Cluster Groups ({{count}})"
-    }
+      "title": "Cluster Groups ({{count}})",
+      "newGroup": "New Group",
+      "groupNamePlaceholder": "Group name...",
+      "selectClustersForGroup": "Select clusters for this group:",
+      "cancel": "Cancel",
+      "create": "Create"
+    },
+    "sortPreferencesCorrupted": "Cluster sort preferences were corrupted and have been reset to defaults.",
+    "localAgentNotConnected": "Local agent not connected"
+  },
+  "clusterAdmin": {
+    "title": "Cluster Admin",
+    "subtitle": "Multi-cluster operations, health, and infrastructure management",
+    "emptyTitle": "Cluster Admin Dashboard",
+    "emptyDescription": "Add cards to manage cluster health, node operations, upgrades, and security across your infrastructure.",
+    "errorLoadingClusterData": "Error loading cluster data",
+    "statTotal": "total",
+    "statHealthy": "healthy",
+    "statDegraded": "degraded",
+    "statOffline": "offline"
+  },
+  "renameModal": {
+    "title": "Rename Context",
+    "current": "Current:",
+    "newName": "New name",
+    "footerHint": "This updates your kubeconfig via the local agent.",
+    "cancel": "Cancel",
+    "rename": "Rename",
+    "renaming": "Renaming...",
+    "renamed": "Renamed",
+    "errorNameEmpty": "Name cannot be empty",
+    "errorNameSpaces": "Name cannot contain spaces",
+    "errorNameUnchanged": "Name is unchanged",
+    "errorFailedToRename": "Failed to rename context"
+  },
+  "clusterActions": {
+    "diagnoseTitle": "Diagnose {{cluster}}",
+    "diagnoseDescription": "Analyzing cluster health and identifying issues",
+    "repairTitle": "Repair {{cluster}}",
+    "repairDescription": "Automatically fixing cluster issues"
   },
   "discardUnsavedChanges": "Discard unsaved changes?",
   "discardUnsavedChangesMessage": "You have unsaved changes that will be lost.",


### PR DESCRIPTION
## Summary

Closes 8 hardcoded-English-strings bugs from @aashu2006's cluster-management audit, using the same `t()`-wrap pattern shipped in PRs #8885 and #8886.

- **#8918** `RenameModal.tsx` — dialog title, field label, hint text, validation errors (`Name cannot be empty` / `Name cannot contain spaces` / `Name is unchanged` / `Failed to rename context`) and the `Cancel`/`Rename`/`Renaming...`/`Renamed` button labels.
- **#8919** `ConnectTab.tsx` — the `— Kubernetes <version>` suffix after a successful connection test is now a single translated key `cluster.connectTestSuccessKubernetes` that composes the Connected label + version.
- **#8920** `ClusterAdmin.tsx` — stat block sublabels (`total` / `healthy` / `degraded` / `offline`).
- **#8921** `ClusterGroups.tsx` — `New Group` button, `Group name...` placeholder, `Select clusters for this group:` picker hint, `Cancel` and `Create`.
- **#8922** `Clusters.tsx` — the `Cluster sort preferences were corrupted...` warning toast.
- **#8923** `Clusters.tsx` — the `Local agent not connected` error thrown by the rename context handler.
- **#8925** `ClusterDetailModal.tsx` — AI diagnose/repair mission titles (`Diagnose <cluster>` / `Repair <cluster>`) and descriptions.
- **#8926** `ClusterAdmin.tsx` — page title, subtitle, empty-state title + description, and the `Error loading cluster data` heading.

New i18n keys live in `web/src/locales/en/common.json` under new `clusterAdmin.*`, `renameModal.*`, `clusterActions.*` blocks plus extensions of the existing `clusters.groups.*`, `clusters.*`, and `cluster.*` blocks. Other locales (hi/it/zh/ja/de/pt/fr/es) fall back to English per the i18next config — per-locale translations can follow without blocking this fix.

`RenameModal.test.tsx` was updated to look up translated labels by key (the existing mock returns the key verbatim).

## Files

- `web/src/components/clusters/components/RenameModal.tsx`
- `web/src/components/clusters/components/RenameModal.test.tsx`
- `web/src/components/cluster-admin/ClusterAdmin.tsx`
- `web/src/components/clusters/components/ClusterGroups.tsx`
- `web/src/components/clusters/Clusters.tsx`
- `web/src/components/clusters/ClusterDetailModal.tsx`
- `web/src/components/clusters/add-cluster/ConnectTab.tsx`
- `web/src/locales/en/common.json`

## Test plan

- [x] `python3 -c "import json; json.load(open('web/src/locales/en/common.json'))"` — JSON valid
- [x] `npm run build` (under `/tmp/kubestellar-console-build.lock`) — passed, post-build safety checks pass
- [x] `npx tsc --noEmit` — 0 errors

Fixes #8918, Fixes #8919, Fixes #8920, Fixes #8921, Fixes #8922, Fixes #8923, Fixes #8925, Fixes #8926
