### PR TITLE
fix(clusters): stabilize RenameModal close-animation test (#8952)

### DIFF
--- a/web/src/components/clusters/components/RenameModal.test.tsx
+++ b/web/src/components/clusters/components/RenameModal.test.tsx
@@ -104,17 +104,17 @@ describe('RenameModal', () => {
 
     const input = screen.getByDisplayValue('my-cluster')
     fireEvent.change(input, { target: { value: 'new-name' } })
-    fireEvent.click(screen.getByText('Rename'))
+    fireEvent.click(screen.getByText('cluster.renameContext.rename'))
 
     await waitFor(() => {
       expect(defaultProps.onClose).toHaveBeenCalled()
     })
 
-    // After success, label should be "Renamed", not "Rename".
-    expect(screen.queryByText('Rename')).toBeNull()
-    expect(screen.getByText('Renamed')).toBeTruthy()
+    // After success, label should be "Renamed" (renamed key), not "Rename" (rename key).
+    expect(screen.queryByText('cluster.renameContext.rename')).toBeNull()
+    expect(screen.getByText('cluster.renameContext.renamed')).toBeTruthy()
     // Button should remain disabled while the modal is closing.
-    expect(screen.getByText('Renamed').closest('button')?.disabled).toBe(true)
+    expect(screen.getByText('cluster.renameContext.renamed').closest('button')?.disabled).toBe(true)
   })
 
   it('shows error message when onRename rejects', async () => {


### PR DESCRIPTION
Fixes #8952

## Root cause

The #8927 regression test was added by PR #8931 (commit d483ebbb) using hardcoded English button labels (`'Rename'`, `'Renamed'`). PR #8932 (commit 1b43d46, i18n refactor) then migrated `RenameModal.tsx` to use `t()` translation keys and updated the other tests in the file, but missed this one because the two PRs rebased through each other in quick succession.

On `main`, the button now renders `cluster.renameContext.rename` / `.renamed` (the `useTranslation` mock returns each key verbatim) — but the test was still asserting on the pre-i18n English strings, so `getByText('Rename')` couldn't find the button.

## Fix

Switched the three label assertions in the #8927 regression test to the translation keys (`cluster.renameContext.rename` / `.renamed`), matching the pattern already used by every other test in `RenameModal.test.tsx`.

No source change needed — the fix from #8931 (sticky `'success'` phase so the button stays labeled "Renamed" through the close animation) is intact and still works at runtime.

## Verification

- `npx vitest run src/components/clusters/components/RenameModal.test.tsx` → 9/9 pass (was 8/9)
- `npm run build` → clean
- `npx tsc --noEmit` → clean