### PR TITLE
fix: RenameModal test uses i18n keys after i18n refactor (Issue 8952)

### DIFF
--- a/web/src/components/clusters/components/RenameModal.test.tsx
+++ b/web/src/components/clusters/components/RenameModal.test.tsx
@@ -104,17 +104,17 @@ describe('RenameModal', () => {
 
     const input = screen.getByDisplayValue('my-cluster')
     fireEvent.change(input, { target: { value: 'new-name' } })
-    fireEvent.click(screen.getByText('Rename'))
+    fireEvent.click(screen.getByText('cluster.renameContext.rename'))
 
     await waitFor(() => {
       expect(defaultProps.onClose).toHaveBeenCalled()
     })
 
-    // After success, label should be "Renamed", not "Rename".
-    expect(screen.queryByText('Rename')).toBeNull()
-    expect(screen.getByText('Renamed')).toBeTruthy()
+    // After success, label should be "renamed" key, not the "rename" key.
+    expect(screen.queryByText('cluster.renameContext.rename')).toBeNull()
+    expect(screen.getByText('cluster.renameContext.renamed')).toBeTruthy()
     // Button should remain disabled while the modal is closing.
-    expect(screen.getByText('Renamed').closest('button')?.disabled).toBe(true)
+    expect(screen.getByText('cluster.renameContext.renamed').closest('button')?.disabled).toBe(true)
   })
 
   it('shows error message when onRename rejects', async () => {


### PR DESCRIPTION
## Summary

PR #8932 swapped the RenameModal's hardcoded button text \`Rename\`/\`Renamed\` for i18n keys (\`cluster.renameContext.rename\` / \`.renamed\`). The regression test in Coverage Suite run #1070 was still matching the raw English strings, so it flagged on the keys the test's i18n mock returns.

Update the regression test to match the keys the mock returns.

## Test plan

- [x] \`npx vitest run src/components/clusters/components/RenameModal.test.tsx\` — 9/9 passing

Fixes #8952