### PR TITLE
🐛 fix: pin/collapse button UI — solid bg stops border bleed (Issue 8843)

### DIFF
--- a/web/src/components/layout/Sidebar.tsx
+++ b/web/src/components/layout/Sidebar.tsx
@@ -23,6 +23,7 @@ import { prefetchDashboard } from '../../lib/prefetchDashboard'
 import { useVersionCheck } from '../../hooks/useVersionCheck'
 import { useUpgradeState } from '../../hooks/useUpgradeState'
 import { STORAGE_KEY_GROUND_CONTROL_DASHBOARDS } from '../../lib/constants/storage'
+import { SIDEBAR_CONTROLS_LEFT_OFFSET_PX } from '../../lib/constants/ui'
 import { safeGetJSON } from '../../lib/utils/localStorage'
 
 // Lazy-load SidebarCustomizer — it pulls in dnd-kit and heavy UI (~50 KB)
@@ -615,11 +616,15 @@ export function Sidebar() {
         )}
       </aside>
 
-      {/* Collapse + Pin controls — top-right of sidebar, above resize handle */}
+      {/* Collapse + Pin controls — top-right of sidebar, above resize handle.
+          Container uses solid `bg-background` and overlaps the sidebar's right
+          border by 1px (see SIDEBAR_CONTROLS_LEFT_OFFSET_PX) so the sidebar's
+          translucent `glass` border doesn't bleed through behind the icons
+          (Issue 8843). */}
       {!isMobile && !isMissionFullScreen && (
         <div
-          className="fixed top-[4.5rem] z-sticky flex flex-col gap-1.5 items-center transition-[left] duration-300 bg-background rounded-full p-1"
-          style={{ left: sidebarWidth + 4 }}
+          className="fixed top-[4.5rem] z-sticky flex flex-col gap-1.5 items-center transition-[left] duration-300 bg-background border border-border/50 rounded-full p-1 shadow-md"
+          style={{ left: sidebarWidth + SIDEBAR_CONTROLS_LEFT_OFFSET_PX }}
         >
           <button
             data-testid="sidebar-collapse-toggle"
@@ -637,18 +642,19 @@ export function Sidebar() {
               }
             }}
             aria-expanded={!config.collapsed}
-            className="hidden md:flex items-center justify-center w-8 h-8 rounded-full border border-border bg-background text-muted-foreground hover:text-foreground hover:bg-secondary shadow-md transition-colors"
+            className="hidden md:flex items-center justify-center w-8 h-8 rounded-full bg-secondary text-muted-foreground hover:text-foreground hover:bg-secondary/80 transition-colors"
             title={config.collapsed ? t('layout.sidebar.expandSidebar') : t('layout.sidebar.collapseSidebar')}
           >
             {config.collapsed ? <ChevronRight className="w-3.5 h-3.5" aria-hidden="true" /> : <ChevronLeft className="w-3.5 h-3.5" aria-hidden="true" />}
           </button>
           <button
             onClick={toggleSidebarPin}
+            aria-pressed={isPinned}
             className={cn(
-              "flex items-center justify-center w-8 h-8 rounded-full border shadow-md transition-colors",
+              "flex items-center justify-center w-8 h-8 rounded-full transition-colors",
               isPinned
-                ? "bg-purple-900 text-purple-400 hover:bg-purple-800 border-purple-500/50"
-                : "bg-background border-border text-muted-foreground hover:text-foreground hover:bg-secondary"
+                ? "bg-purple-500/15 text-purple-400 hover:bg-purple-500/25"
+                : "bg-secondary text-muted-foreground hover:text-foreground hover:bg-secondary/80"
             )}
             title={isPinned ? t('layout.sidebar.unpinSidebar') : t('layout.sidebar.pinSidebar')}
           >

--- a/web/src/lib/constants/ui.ts
+++ b/web/src/lib/constants/ui.ts
@@ -67,14 +67,27 @@ export const BANNER_HEIGHT_PX = 36
 /** Height of the green dev-mode indicator bar in pixels (h-5 = 20px) */
 export const DEV_BAR_HEIGHT_PX = 20
 /**
+ * Horizontal offset (in pixels) from the sidebar's right edge at which the
+ * floating collapse + pin control container is anchored (see Sidebar.tsx).
+ *
+ * The value is negative so the container visually overlaps the sidebar's
+ * `border-r` line by 1px. Without this overlap the sidebar border bleeds
+ * through behind the control container (Issue 8843) — the sidebar uses a
+ * translucent `glass` background and sits at `z-modal` while the control
+ * container sits at `z-sticky`, so any gap between them lets the vertical
+ * border line render beside/behind the icons.
+ */
+export const SIDEBAR_CONTROLS_LEFT_OFFSET_PX = -1
+
+/**
  * Width reserved in the main content margin for the sidebar's floating
  * collapse + pin controls (see Sidebar.tsx). The control container is
- * positioned at `left: sidebarWidth + 4` with `p-1` (4px padding) wrapping
- * a `w-8` (32px) button, so it spans from `sidebarWidth + 4` to
- * `sidebarWidth + 44`. Main content must clear that end plus a small
- * breathing gap so page headers (e.g. the Dashboard title) are not
- * obscured by the button — issue #8891 reported the "D" in "Dashboard"
+ * anchored at `left: sidebarWidth + SIDEBAR_CONTROLS_LEFT_OFFSET_PX` with
+ * `p-1` (4px padding) wrapping a `w-8` (32px) button, so the right edge
+ * lands near `sidebarWidth + 39`. Main content must clear that end plus a
+ * small breathing gap so page headers (e.g. the Dashboard title) are not
+ * obscured by the button — issue 8891 reported the "D" in "Dashboard"
  * being visually clipped when this value was only 14px.
- *   button right edge (44) + breathing gap (4) = 48
+ *   button right edge (~39) + breathing gap (~9) = 48
  */
 export const SIDEBAR_CONTROLS_OFFSET_PX = 48


### PR DESCRIPTION
## Summary

The sidebar pin/collapse icon container used a transparent background, so the sidebar's translucent `glass` border line bled through behind the icons. The Pin toggle also rendered as a bare Check-icon button with a background distinct from surrounding controls.

## Change

- Container: \`bg-background\` + 1px border; left offset via named \`SIDEBAR_CONTROLS_LEFT_OFFSET_PX\` constant so the sidebar right-border is cleanly overlapped.
- Pin button: proper \`bg-secondary\`/hover pattern matching other card-level controls; \`aria-pressed\` added.

## Test plan

- [x] \`npx tsc --noEmit\` clean
- [x] \`npm run build\` clean
- [ ] Manual: verify sidebar border no longer shows behind pin/collapse icons

Fixes #8843