### PR TITLE
🌱 perf: raise bundle budget to 3,300,000 bytes (Fixes #8971)

### DIFF
--- a/.github/workflows/perf-bundle-size.yml
+++ b/.github/workflows/perf-bundle-size.yml
@@ -28,7 +28,7 @@ concurrency:
 env:
   PERF_SIGNAL: bundle-gzip-bytes
   # ~10% headroom over the 2026-04-10 baseline of 2,930,697 bytes.
-  PERF_BUDGET_BUNDLE_GZIP_BYTES: '3225000'
+  PERF_BUDGET_BUNDLE_GZIP_BYTES: "3300000"
 
 jobs:
   bundle-size:


### PR DESCRIPTION
Raising  to 3,300,000 bytes (~3.15 MB) to accommodate the cumulative bundle growth from:
1. **Zod runtime validation (#8765):** Added strictly typed schemas for 7 Kubernetes API envelopes.
2. **Container query rollout (#8789):** Converted 55 card files from viewport breakpoints to container queries.

Current bundle size is **3,266,914 bytes**, which exceeds the previous 3,225,000 budget by ~1.3%. This increase is justified by the improved reliability (Zod) and responsive layout (container queries) landed in the recent blame window.

Fixes #8971