### PR TITLE
✨:  Make SQLite connection pool settings configurable via environment var…

### DIFF
--- a/pkg/store/sqlite.go
+++ b/pkg/store/sqlite.go
@@ -192,6 +192,60 @@ func getEnvInt(key string, defaultVal int) int {
 	return defaultVal
 }
 
+// getEnvDuration reads a duration from the environment, falling back to defaultVal.
+func getEnvDuration(key string, defaultVal time.Duration) time.Duration {
+	if v := os.Getenv(key); v != "" {
+		if d, err := time.ParseDuration(v); err == nil {
+			return d
+		}
+	}
+	return defaultVal
+}
+
+// configureConnectionPool sets SQLite connection pool parameters from environment variables.
+// Reads KC_SQLITE_MAX_OPEN_CONNS, KC_SQLITE_MAX_IDLE_CONNS, KC_SQLITE_CONN_MAX_LIFETIME,
+// and KC_SQLITE_CONN_MAX_IDLE_TIME, validates bounds, and logs the final configuration.
+func configureConnectionPool(db *sql.DB) {
+	maxOpen := getEnvInt("KC_SQLITE_MAX_OPEN_CONNS", sqliteDefaultMaxOpenConns)
+	maxIdle := getEnvInt("KC_SQLITE_MAX_IDLE_CONNS", sqliteDefaultMaxIdleConns)
+	lifetime := getEnvDuration("KC_SQLITE_CONN_MAX_LIFETIME", sqliteDefaultConnMaxLifetime)
+	idleTime := getEnvDuration("KC_SQLITE_CONN_MAX_IDLE_TIME", sqliteDefaultConnMaxIdleTime)
+
+	// Validate and clamp maxOpen to prevent zero or negative values
+	if maxOpen < 1 {
+		slog.Warn("[SQLite] KC_SQLITE_MAX_OPEN_CONNS must be >= 1, using default",
+			"value", maxOpen, "default", sqliteDefaultMaxOpenConns)
+		maxOpen = sqliteDefaultMaxOpenConns
+	}
+
+	// Validate maxIdle <= maxOpen to prevent idle pool larger than open pool
+	if maxIdle > maxOpen {
+		slog.Warn("[SQLite] KC_SQLITE_MAX_IDLE_CONNS cannot exceed KC_SQLITE_MAX_OPEN_CONNS, clamping",
+			"max_idle", maxIdle, "max_open", maxOpen)
+		maxIdle = maxOpen
+	}
+
+	// Validate lifetime >= 30s to prevent excessive connection churn
+	minLifetime := 30 * time.Second
+	if lifetime < minLifetime {
+		slog.Warn("[SQLite] KC_SQLITE_CONN_MAX_LIFETIME must be >= 30s, using default",
+			"value", lifetime, "default", sqliteDefaultConnMaxLifetime)
+		lifetime = sqliteDefaultConnMaxLifetime
+	}
+
+	db.SetMaxOpenConns(maxOpen)
+	db.SetMaxIdleConns(maxIdle)
+	db.SetConnMaxLifetime(lifetime)
+	db.SetConnMaxIdleTime(idleTime)
+
+	slog.Info("[SQLite] connection pool configured",
+		"max_open_conns", maxOpen,
+		"max_idle_conns", maxIdle,
+		"conn_max_lifetime", lifetime,
+		"conn_max_idle_time", idleTime,
+	)
+}
+
 // SQLiteStore implements Store using SQLite
 type SQLiteStore struct {
 	db *sql.DB
@@ -222,10 +276,7 @@ func NewSQLiteStore(dbPath string) (*SQLiteStore, error) {
 	db := sql.OpenDB(&fkConnector{driver: drv, dsn: dsn})
 
 	// Configure connection pool for resource management under high load
-	db.SetMaxOpenConns(getEnvInt("KC_SQLITE_MAX_OPEN_CONNS", sqliteDefaultMaxOpenConns))
-	db.SetMaxIdleConns(getEnvInt("KC_SQLITE_MAX_IDLE_CONNS", sqliteDefaultMaxIdleConns))
-	db.SetConnMaxLifetime(sqliteDefaultConnMaxLifetime)
-	db.SetConnMaxIdleTime(sqliteDefaultConnMaxIdleTime)
+	configureConnectionPool(db)
 
 	store := &SQLiteStore{db: db}
 	if err := store.migrate(); err != nil {

--- a/pkg/store/sqlite.go
+++ b/pkg/store/sqlite.go
@@ -100,6 +100,9 @@ const (
 	sqliteDefaultConnMaxLifetime = 5 * time.Minute
 	// sqliteDefaultConnMaxIdleTime closes long-idle connections
 	sqliteDefaultConnMaxIdleTime = 2 * time.Minute
+	// sqliteMinConnLifetime is the minimum allowed connection lifetime
+	// to prevent excessive connection churn
+	sqliteMinConnLifetime = 30 * time.Second
 	// sqliteBusyTimeoutMs is the millisecond duration that a writer will
 	// wait for the SQLite write lock before returning SQLITE_BUSY. Under
 	// WAL mode only one writer holds the lock at a time; this timeout
@@ -226,8 +229,7 @@ func configureConnectionPool(db *sql.DB) {
 	}
 
 	// Validate lifetime >= 30s to prevent excessive connection churn
-	minLifetime := 30 * time.Second
-	if lifetime < minLifetime {
+	if lifetime < sqliteMinConnLifetime {
 		slog.Warn("[SQLite] KC_SQLITE_CONN_MAX_LIFETIME must be >= 30s, using default",
 			"value", lifetime, "default", sqliteDefaultConnMaxLifetime)
 		lifetime = sqliteDefaultConnMaxLifetime

--- a/pkg/store/sqlite_test.go
+++ b/pkg/store/sqlite_test.go
@@ -1,6 +1,7 @@
 package store
 
 import (
+	"database/sql"
 	"encoding/json"
 	"path/filepath"
 	"sync"
@@ -509,6 +510,26 @@ func TestHelpers(t *testing.T) {
 		require.Equal(t, defaultVal, got)
 	})
 
+	t.Run("getEnvDuration returns default for unset var", func(t *testing.T) {
+		const defaultVal = 5 * time.Minute
+		got := getEnvDuration("KC_TEST_NONEXISTENT_DURATION_XYZ", defaultVal)
+		require.Equal(t, defaultVal, got)
+	})
+
+	t.Run("getEnvDuration parses valid duration", func(t *testing.T) {
+		t.Setenv("KC_TEST_DURATION", "10m")
+		const defaultVal = 5 * time.Minute
+		got := getEnvDuration("KC_TEST_DURATION", defaultVal)
+		require.Equal(t, 10*time.Minute, got)
+	})
+
+	t.Run("getEnvDuration falls back to default on invalid duration", func(t *testing.T) {
+		t.Setenv("KC_TEST_DURATION_INVALID", "invalid")
+		const defaultVal = 5 * time.Minute
+		got := getEnvDuration("KC_TEST_DURATION_INVALID", defaultVal)
+		require.Equal(t, defaultVal, got)
+	})
+
 	t.Run("nullString empty returns invalid NullString", func(t *testing.T) {
 		ns := nullString("")
 		require.False(t, ns.Valid)
@@ -523,5 +544,64 @@ func TestHelpers(t *testing.T) {
 	t.Run("boolToInt converts correctly", func(t *testing.T) {
 		require.Equal(t, 1, boolToInt(true))
 		require.Equal(t, 0, boolToInt(false))
+	})
+
+	t.Run("configureConnectionPool applies defaults when env vars unset", func(t *testing.T) {
+		// Clear any existing env vars
+		t.Setenv("KC_SQLITE_MAX_OPEN_CONNS", "")
+		t.Setenv("KC_SQLITE_MAX_IDLE_CONNS", "")
+		t.Setenv("KC_SQLITE_CONN_MAX_LIFETIME", "")
+		t.Setenv("KC_SQLITE_CONN_MAX_IDLE_TIME", "")
+
+		db, err := sql.Open("sqlite", ":memory:")
+		require.NoError(t, err)
+		defer db.Close()
+
+		configureConnectionPool(db)
+
+		// Verify defaults are applied
+		require.Equal(t, sqliteDefaultMaxOpenConns, getEnvInt("KC_SQLITE_MAX_OPEN_CONNS", sqliteDefaultMaxOpenConns))
+	})
+
+	t.Run("configureConnectionPool validates maxOpen >= 1", func(t *testing.T) {
+		t.Setenv("KC_SQLITE_MAX_OPEN_CONNS", "0")
+		t.Setenv("KC_SQLITE_MAX_IDLE_CONNS", "5")
+		t.Setenv("KC_SQLITE_CONN_MAX_LIFETIME", "10m")
+		t.Setenv("KC_SQLITE_CONN_MAX_IDLE_TIME", "2m")
+
+		db, err := sql.Open("sqlite", ":memory:")
+		require.NoError(t, err)
+		defer db.Close()
+
+		// Should not panic and should log warning
+		configureConnectionPool(db)
+	})
+
+	t.Run("configureConnectionPool validates maxIdle <= maxOpen", func(t *testing.T) {
+		t.Setenv("KC_SQLITE_MAX_OPEN_CONNS", "10")
+		t.Setenv("KC_SQLITE_MAX_IDLE_CONNS", "20")
+		t.Setenv("KC_SQLITE_CONN_MAX_LIFETIME", "10m")
+		t.Setenv("KC_SQLITE_CONN_MAX_IDLE_TIME", "2m")
+
+		db, err := sql.Open("sqlite", ":memory:")
+		require.NoError(t, err)
+		defer db.Close()
+
+		// Should not panic and should log warning
+		configureConnectionPool(db)
+	})
+
+	t.Run("configureConnectionPool validates lifetime >= 30s", func(t *testing.T) {
+		t.Setenv("KC_SQLITE_MAX_OPEN_CONNS", "25")
+		t.Setenv("KC_SQLITE_MAX_IDLE_CONNS", "5")
+		t.Setenv("KC_SQLITE_CONN_MAX_LIFETIME", "10s")
+		t.Setenv("KC_SQLITE_CONN_MAX_IDLE_TIME", "2m")
+
+		db, err := sql.Open("sqlite", ":memory:")
+		require.NoError(t, err)
+		defer db.Close()
+
+		// Should not panic and should log warning
+		configureConnectionPool(db)
 	})
 }


### PR DESCRIPTION
…iables

Add configureConnectionPool() function that reads all four pool settings from environment variables with validation and logging:
- KC_SQLITE_MAX_OPEN_CONNS (default: 25)
- KC_SQLITE_MAX_IDLE_CONNS (default: 5)
- KC_SQLITE_CONN_MAX_LIFETIME (default: 5m)
- KC_SQLITE_CONN_MAX_IDLE_TIME (default: 2m)

Validation rules:
- maxOpen >= 1 (clamps to default if invalid)
- maxIdle <= maxOpen (clamps to maxOpen if invalid)
- lifetime >= 30s (clamps to default if invalid)

Adds getEnvDuration() helper for time-based env vars, following the existing getEnvInt() pattern. Logs final configuration for observability.

Fixes inconsistent configurability where lifetime/idle time were hardcoded.

### 📌 Fixes

Fixes #8993 

---

### 📝 Summary of Changes

- Short description of what was changed
- Include links to related issues/discussions if any

---

### Changes Made

<!-- Provide a detailed list of changes made in this PR. -->

- [x] Updated ...
- [x] Refactored ...
- [ ] Fixed ...
- [ ] Added tests for ...

---

### Checklist

Please ensure the following before submitting your PR:

- [x] I used a coding agent (Claude Code, Copilot, Gemini, or Codex) to generate/review this code
- [x] I have reviewed the project's contribution guidelines
- [ ] New cards target [console-marketplace](https://github.com/kubestellar/console-marketplace), not this repo
- [ ] isDemoData is wired correctly (cards show Demo badge when using demo data)
- [ ] I have written unit tests for the changes (if applicable)
- [x] I have tested the changes locally and ensured they work as expected
- [x] All commits are signed with DCO (`git commit -s`)

---

### Screenshots or Logs (if applicable)

<!-- Add any relevant screenshots or logs to help visualize/test the changes. -->

---

### 👀 Reviewer Notes

_Add any special notes for the reviewer here_
