### PR TITLE
✨: Fix/rbac timeout centralization

### DIFF
--- a/pkg/agent/server_rbac.go
+++ b/pkg/agent/server_rbac.go
@@ -25,12 +25,9 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/kubestellar/console/pkg/k8s"
 	"github.com/kubestellar/console/pkg/models"
 )
-
-// rbacRequestTimeout is the per-request deadline for single-cluster
-// permission checks. Matches pkg/api/handlers/rbac.go rbacDefaultTimeout.
-const rbacRequestTimeout = 10 * time.Second
 
 // rbacAnalysisTimeout is the per-request deadline for cross-cluster
 // permission summaries, which fan out over every context in the user's
@@ -75,7 +72,7 @@ func (s *Server) handleCanIHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	ctx, cancel := context.WithTimeout(r.Context(), rbacRequestTimeout)
+	ctx, cancel := context.WithTimeout(r.Context(), k8s.RBACDefaultTimeout)
 	defer cancel()
 
 	result, err := s.k8sClient.CheckCanI(ctx, req.Cluster, req)
@@ -112,7 +109,7 @@ func (s *Server) handleClusterPermissionsHTTP(w http.ResponseWriter, r *http.Req
 		return
 	}
 
-	ctx, cancel := context.WithTimeout(r.Context(), rbacRequestTimeout)
+	ctx, cancel := context.WithTimeout(r.Context(), k8s.RBACDefaultTimeout)
 	defer cancel()
 
 	cluster := r.URL.Query().Get("cluster")

--- a/pkg/api/handlers/rbac.go
+++ b/pkg/api/handlers/rbac.go
@@ -21,9 +21,6 @@ import (
 // rbacAnalysisTimeout is the timeout for RBAC analysis queries on large clusters.
 const rbacAnalysisTimeout = 60 * time.Second
 
-// rbacDefaultTimeout is the per-cluster timeout for standard RBAC queries.
-const rbacDefaultTimeout = 15 * time.Second
-
 // parseUUID parses a UUID string
 func parseUUID(s string) (uuid.UUID, error) {
 	return uuid.Parse(s)
@@ -185,7 +182,7 @@ func (h *RBACHandler) GetUserManagementSummary(c *fiber.Ctx) error {
 
 	// Count K8s service accounts (if k8s client is available)
 	if h.k8sClient != nil {
-		ctx, cancel := context.WithTimeout(c.Context(), rbacDefaultTimeout)
+		ctx, cancel := context.WithTimeout(c.Context(), k8s.RBACDefaultTimeout)
 		defer cancel()
 
 		total, clusters, err := h.k8sClient.CountServiceAccountsAllClusters(ctx)
@@ -222,7 +219,7 @@ func (h *RBACHandler) ListK8sServiceAccounts(c *fiber.Ctx) error {
 	cluster := c.Query("cluster")
 	namespace := c.Query("namespace")
 
-	ctx, cancel := context.WithTimeout(c.Context(), rbacDefaultTimeout)
+	ctx, cancel := context.WithTimeout(c.Context(), k8s.RBACDefaultTimeout)
 	defer cancel()
 
 	if cluster != "" {
@@ -311,7 +308,7 @@ func (h *RBACHandler) ListK8sRoles(c *fiber.Ctx) error {
 	namespace := c.Query("namespace")
 	includeSystem := c.Query("includeSystem") == "true"
 
-	ctx, cancel := context.WithTimeout(c.Context(), rbacDefaultTimeout)
+	ctx, cancel := context.WithTimeout(c.Context(), k8s.RBACDefaultTimeout)
 	defer cancel()
 
 	if cluster != "" {
@@ -359,7 +356,7 @@ func (h *RBACHandler) ListK8sRoleBindings(c *fiber.Ctx) error {
 	namespace := c.Query("namespace")
 	includeSystem := c.Query("includeSystem") == "true"
 
-	ctx, cancel := context.WithTimeout(c.Context(), rbacDefaultTimeout)
+	ctx, cancel := context.WithTimeout(c.Context(), k8s.RBACDefaultTimeout)
 	defer cancel()
 
 	if cluster == "" {
@@ -423,7 +420,7 @@ func (h *RBACHandler) ListK8sUsers(c *fiber.Ctx) error {
 		return fiber.NewError(fiber.StatusBadRequest, "Cluster parameter required")
 	}
 
-	ctx, cancel := context.WithTimeout(c.Context(), rbacDefaultTimeout)
+	ctx, cancel := context.WithTimeout(c.Context(), k8s.RBACDefaultTimeout)
 	defer cancel()
 
 	users, err := h.k8sClient.GetAllK8sUsers(ctx, cluster)

--- a/pkg/k8s/rbac.go
+++ b/pkg/k8s/rbac.go
@@ -41,6 +41,12 @@ const maxConcurrentClusterRBACQueries = 5
 // finishes comfortably within budget.
 const perClusterRBACTimeout = 15 * time.Second
 
+// RBACDefaultTimeout is the per-cluster timeout for standard RBAC queries.
+// Used by both pkg/api/handlers/rbac.go and pkg/agent/server_rbac.go for
+// single-cluster permission checks and RBAC data fetches. Centralized here
+// to prevent drift between API and agent timeout values.
+const RBACDefaultTimeout = 15 * time.Second
+
 // ListServiceAccounts returns all service accounts in a cluster
 func (m *MultiClusterClient) ListServiceAccounts(ctx context.Context, contextName, namespace string) ([]models.K8sServiceAccount, error) {
 	client, err := m.GetClient(contextName)


### PR DESCRIPTION

### 📌 Fixes

Fixes #8997 

---

### 📝 Summary of Changes

**Problem:** RBAC timeout inconsistency between API (15s) and agent (10s)

**Solution:** Centralized RBAC timeout constant

**Files modified:**
- [pkg/k8s/rbac.go](cci:7://file:///d:/Projects/console/pkg/k8s/rbac.go:0:0-0:0) - Added `RBACDefaultTimeout = 15 * time.Second` as single source of truth
- [pkg/api/handlers/rbac.go](cci:7://file:///d:/Projects/console/pkg/api/handlers/rbac.go:0:0-0:0) - Removed local constant, now uses `k8s.RBACDefaultTimeout` (5 usages)
- [pkg/agent/server_rbac.go](cci:7://file:///d:/Projects/console/pkg/agent/server_rbac.go:0:0-0:0) - Removed local constant, now uses `k8s.RBACDefaultTimeout` (2 usages)

**Impact:**
- Fixed bug: agent timeout changed from 10s → 15s to match API
- Eliminates drift risk between components
- Future timeout adjustments require one-line edit
- Zero runtime overhead (compile-time constant)
- Zero test impact
---

### Changes Made

<!-- Provide a detailed list of changes made in this PR. -->

- [ ] Updated ...
- [ ] Refactored ...
- [ ] Fixed ...
- [ ] Added tests for ...

---

### Checklist

Please ensure the following before submitting your PR:

- [ ] I used a coding agent (Claude Code, Copilot, Gemini, or Codex) to generate/review this code
- [ ] I have reviewed the project's contribution guidelines
- [ ] New cards target [console-marketplace](https://github.com/kubestellar/console-marketplace), not this repo
- [ ] isDemoData is wired correctly (cards show Demo badge when using demo data)
- [ ] I have written unit tests for the changes (if applicable)
- [ ] I have tested the changes locally and ensured they work as expected
- [ ] All commits are signed with DCO (`git commit -s`)

---

### Screenshots or Logs (if applicable)

<!-- Add any relevant screenshots or logs to help visualize/test the changes. -->

---

### 👀 Reviewer Notes

_Add any special notes for the reviewer here_
