### PR TITLE
🐛 fix(cards): restore missing legend in Cluster Metrics per-cluster drilldown

### DIFF
--- a/web/src/components/charts/TimeSeriesChart.tsx
+++ b/web/src/components/charts/TimeSeriesChart.tsx
@@ -2,6 +2,16 @@ import { useMemo } from 'react'
 import ReactECharts from 'echarts-for-react'
 import { CHART_TOOLTIP_CONTENT_STYLE, CHART_TICK_COLOR, CHART_TOOLTIP_TEXT_COLOR } from '../../lib/constants'
 
+// MultiSeriesChart layout constants — keep the legend readable and consistent
+// with other multi-series charts (e.g. ResourceTrend, GPUUsageTrend). The
+// grid bottom must leave enough room for both the x-axis labels and the
+// legend row below them (fixes issue #8973 — per-cluster view had no legend,
+// so multi-cluster lines were unidentifiable).
+const MULTI_SERIES_LEGEND_FONT_SIZE = 10
+const MULTI_SERIES_LEGEND_ITEM_GAP = 12
+const MULTI_SERIES_GRID_BOTTOM_PX = 40    // x-axis labels + legend row
+const MULTI_SERIES_LEGEND_BOTTOM_PX = 0   // anchor legend flush to bottom
+
 interface DataPoint {
   time: string
   value: number
@@ -122,39 +132,53 @@ export function MultiSeriesChart({
   showGrid = false,
   title,
 }: MultiSeriesChartProps) {
-  const option = useMemo(() => ({
-    backgroundColor: 'transparent',
-    grid: { left: 40, right: 5, top: 5, bottom: 25 },
-    xAxis: {
-      type: 'category' as const,
-      data: data.map(d => d.time),
-      axisLabel: { color: '#888', fontSize: 10 },
-      axisLine: { lineStyle: { color: '#333' } },
-      axisTick: { show: false },
-    },
-    yAxis: {
-      type: 'value' as const,
-      axisLabel: { color: '#888', fontSize: 10 },
-      axisLine: { show: false },
-      axisTick: { show: false },
-      splitLine: showGrid ? { lineStyle: { color: '#333', type: 'dashed' as const } } : { show: false },
-    },
-    tooltip: {
-      trigger: 'axis' as const,
-      backgroundColor: (CHART_TOOLTIP_CONTENT_STYLE as Record<string, unknown>).backgroundColor as string,
-      borderColor: (CHART_TOOLTIP_CONTENT_STYLE as Record<string, unknown>).borderColor as string,
-      textStyle: { color: CHART_TOOLTIP_TEXT_COLOR, fontSize: 12 },
-    },
-    series: series.map(s => ({
-      name: s.name || s.dataKey,
-      type: 'line',
-      data: data.map(d => d[s.dataKey]),
-      smooth: true,
-      showSymbol: false,
-      lineStyle: { color: s.color, width: 2 },
-      itemStyle: { color: s.color },
-    })),
-  }), [data, series, showGrid])
+  const option = useMemo(() => {
+    const seriesNames = series.map(s => s.name || s.dataKey)
+    return {
+      backgroundColor: 'transparent',
+      grid: { left: 40, right: 5, top: 5, bottom: MULTI_SERIES_GRID_BOTTOM_PX },
+      xAxis: {
+        type: 'category' as const,
+        data: data.map(d => d.time),
+        axisLabel: { color: CHART_TICK_COLOR, fontSize: MULTI_SERIES_LEGEND_FONT_SIZE },
+        axisLine: { lineStyle: { color: '#333' } },
+        axisTick: { show: false },
+      },
+      yAxis: {
+        type: 'value' as const,
+        axisLabel: { color: CHART_TICK_COLOR, fontSize: MULTI_SERIES_LEGEND_FONT_SIZE },
+        axisLine: { show: false },
+        axisTick: { show: false },
+        splitLine: showGrid ? { lineStyle: { color: '#333', type: 'dashed' as const } } : { show: false },
+      },
+      tooltip: {
+        trigger: 'axis' as const,
+        backgroundColor: (CHART_TOOLTIP_CONTENT_STYLE as Record<string, unknown>).backgroundColor as string,
+        borderColor: (CHART_TOOLTIP_CONTENT_STYLE as Record<string, unknown>).borderColor as string,
+        textStyle: { color: CHART_TOOLTIP_TEXT_COLOR, fontSize: 12 },
+      },
+      // Legend identifies each line/series so multi-cluster comparisons
+      // are readable (issue #8973). Matches the pattern used in
+      // ResourceTrend and GPUUsageTrend for visual consistency.
+      legend: {
+        data: seriesNames,
+        bottom: MULTI_SERIES_LEGEND_BOTTOM_PX,
+        textStyle: { color: CHART_TICK_COLOR, fontSize: MULTI_SERIES_LEGEND_FONT_SIZE },
+        itemGap: MULTI_SERIES_LEGEND_ITEM_GAP,
+        icon: 'roundRect',
+        type: 'scroll' as const,
+      },
+      series: series.map(s => ({
+        name: s.name || s.dataKey,
+        type: 'line',
+        data: data.map(d => d[s.dataKey]),
+        smooth: true,
+        showSymbol: false,
+        lineStyle: { color: s.color, width: 2 },
+        itemStyle: { color: s.color },
+      })),
+    }
+  }, [data, series, showGrid])
 
   return (
     <div className="w-full">


### PR DESCRIPTION
Fixes #8973

The per-cluster view of the Cluster Metrics card was rendering the `MultiSeriesChart` without its legend, so users saw several colored lines but had no way to tell which cluster each line represented.

## Root cause

`MultiSeriesChart` in `web/src/components/charts/TimeSeriesChart.tsx` never configured ECharts' `legend` option. When `ClusterMetrics` switches to `per-cluster` chart mode, each cluster becomes its own series — without a legend, the lines are unidentifiable.

## Fix

- Added a scrollable legend below the x-axis in `MultiSeriesChart`, using `series[].name` (the cluster name) as the label.
- Matched the pattern already used in `ResourceTrend` and `GPUUsageTrend` (10px `CHART_TICK_COLOR` text, `roundRect` icon, bottom-anchored).
- Extended the ECharts `grid.bottom` from 25px to 40px to leave room for both the x-axis labels and the legend row.
- Replaced raw `'#888'`/`fontSize: 10` literals with `CHART_TICK_COLOR` and named constants (`MULTI_SERIES_LEGEND_FONT_SIZE`, `MULTI_SERIES_LEGEND_ITEM_GAP`, `MULTI_SERIES_GRID_BOTTOM_PX`, `MULTI_SERIES_LEGEND_BOTTOM_PX`) per CLAUDE.md no-magic-numbers rule.
- Used `type: 'scroll'` on the legend so wide cluster lists (e.g. 10+ clusters) stay within the card width.

`MultiSeriesChart` is only consumed by `ClusterMetrics` today, so no other callers are affected.

## Verification

- `npm run build` — passes
- `npx tsc --noEmit` — passes
- `npx vitest run src/components/charts/__tests__/TimeSeriesChart.test.tsx` — 17/17 pass (including existing MultiSeriesChart tests)