### PR TITLE
🐛 fix(cards): align Compliance Score card total with drilldown bucket sum

### DIFF
--- a/web/src/components/cards/ComplianceCards.test.tsx
+++ b/web/src/components/cards/ComplianceCards.test.tsx
@@ -533,4 +533,70 @@ describe('ComplianceScoreBreakdownModal', () => {
 
     expect(screen.queryByText('Compliance Score Breakdown')).not.toBeInTheDocument()
   })
+
+  // Regression test for #8974: earlier versions of the Overview tab summed
+  // Kubescape's pass/fail/total counts with Kyverno's policies/violations into
+  // a single "Total Checks / Passing / Failing" row. Because Kyverno violations
+  // are event counts (one per offending resource, not per policy), the numbers
+  // didn't add up — users saw totals like "126 checks, 121 passing, 167 failing".
+  //
+  // Invariant to pin: within each tool's section on the Overview tab, the
+  // bucket values must be internally consistent with the labels shown.
+  // Kubescape's section uses a checks/passed/failed model where passed + failed
+  // == total. Kyverno's section uses a policies/violations model (no pass/fail
+  // relationship is implied or displayed).
+  it('overview tab shows per-tool counts that reconcile without mixing Kubescape checks and Kyverno violations (#8974)', () => {
+    // Kubescape with a much smaller totalControls than Kyverno's violations.
+    // Before the fix, "Total Checks" would have been 116 + 10 = 126, "Passing"
+    // would have been 110 + max(0, 10 - 167) = 110, and "Failing" would have
+    // been 6 + 167 = 173 — mirroring the shape of the issue.
+    const kubescapeSmall = {
+      totalControls: 116,
+      passedControls: 110,
+      failedControls: 6,
+      frameworks: [],
+    }
+    const kyvernoManyViolations = {
+      totalPolicies: 10,
+      totalViolations: 167,
+      enforcingCount: 4,
+      auditCount: 6,
+    }
+
+    render(
+      <ComplianceScoreBreakdownModal
+        isOpen={true}
+        onClose={vi.fn()}
+        score={70}
+        breakdown={defaultBreakdown}
+        kubescapeData={kubescapeSmall}
+        kyvernoData={kyvernoManyViolations}
+      />,
+    )
+
+    // Kubescape section: passed + failed == total, so 110 + 6 == 116.
+    const kubescapeHeading = screen.getByText('Kubescape checks')
+    const kubescapeSection = kubescapeHeading.parentElement!
+    const totalChecksLabel = within(kubescapeSection).getByText('Total Checks')
+    expect(within(totalChecksLabel.parentElement!).getByText('116')).toBeInTheDocument()
+    const passingLabel = within(kubescapeSection).getByText('Passing')
+    expect(within(passingLabel.parentElement!).getByText('110')).toBeInTheDocument()
+    const failingLabel = within(kubescapeSection).getByText('Failing')
+    expect(within(failingLabel.parentElement!).getByText('6')).toBeInTheDocument()
+
+    // Kyverno section: uses its native vocabulary (policies + violations).
+    // The violation count is NOT summed with Kubescape failures, and is NOT
+    // labeled "Failing".
+    const kyvernoHeading = screen.getByText('Kyverno policies')
+    const kyvernoSection = kyvernoHeading.parentElement!
+    const policiesLabel = within(kyvernoSection).getByText('Policies')
+    expect(within(policiesLabel.parentElement!).getByText('10')).toBeInTheDocument()
+    const violationsLabel = within(kyvernoSection).getByText('Violations')
+    expect(within(violationsLabel.parentElement!).getByText('167')).toBeInTheDocument()
+
+    // And the pre-fix aggregate row must no longer exist.
+    expect(screen.queryByText((_, el) =>
+      !!el && el.tagName === 'P' && el.textContent === '126',
+    )).not.toBeInTheDocument()
+  })
 })

--- a/web/src/components/cards/compliance/ComplianceScoreBreakdownModal.tsx
+++ b/web/src/components/cards/compliance/ComplianceScoreBreakdownModal.tsx
@@ -147,18 +147,31 @@ function OverviewTab({ score, breakdown, scoreCtx, kubescapeData, kyvernoData }:
   kubescapeData?: ComplianceScoreBreakdownModalProps['kubescapeData']
   kyvernoData?: ComplianceScoreBreakdownModalProps['kyvernoData']
 }) {
-  // Aggregate checks across tools to show a global total even when an individual tool is empty.
+  // Kubescape uses a true "checks" model where passed + failed == total per control.
+  // Kyverno, on the other hand, reports policies and violations — a single policy can
+  // have N violations (one per offending resource), so violations often EXCEEDS the
+  // policy count and passed != (policies - violations). Prior to #8974, the Overview
+  // tab summed Kubescape's controls with Kyverno's policies/violations into a single
+  // "Total Checks / Passing / Failing" row. That produced impossible totals like
+  // "126 checks, 121 passing, 167 failing" because Kyverno's violations are
+  // incommensurable with Kubescape's pass/fail counts.
+  //
+  // Fix: show each tool's counts in its own row with its own labels, so the numbers
+  // in each row add up correctly (Kubescape: passed + failed == total) and Kyverno
+  // uses its native vocabulary (policies / violations) without implying a pass/fail
+  // relationship. Also display an aggregated "Total Checks" row ONLY across tools
+  // that share the same pass+fail==total model (currently just Kubescape), so the
+  // top-line number always reconciles with the per-bucket sums.
   const kubescapeTotal = kubescapeData?.totalControls ?? 0
   const kubescapePassed = kubescapeData?.passedControls ?? 0
   const kubescapeFailed = kubescapeData?.failedControls ?? 0
 
-  const kyvernoTotal = kyvernoData?.totalPolicies ?? 0
-  const kyvernoFailed = kyvernoData?.totalViolations ?? 0
-  const kyvernoPassed = Math.max(0, kyvernoTotal - kyvernoFailed)
+  const kyvernoTotalPolicies = kyvernoData?.totalPolicies ?? 0
+  const kyvernoTotalViolations = kyvernoData?.totalViolations ?? 0
 
-  const totalChecks = kubescapeTotal + kyvernoTotal
-  const totalPassed = kubescapePassed + kyvernoPassed
-  const totalFailed = kubescapeFailed + kyvernoFailed
+  const hasKubescapeChecks = kubescapeTotal > 0
+  const hasKyvernoPolicies = kyvernoTotalPolicies > 0
+  const hasAnyToolData = hasKubescapeChecks || hasKyvernoPolicies
 
   const scoreColorClass = score >= SCORE_GOOD_THRESHOLD
     ? 'text-green-400'
@@ -189,12 +202,31 @@ function OverviewTab({ score, breakdown, scoreCtx, kubescapeData, kyvernoData }:
         <p className="text-xs text-muted-foreground mt-0.5">{scoreCtx.description}</p>
       </div>
 
-      {/* Aggregate stats — makes the Overview tab informative even when a single tool is connected. */}
-      {totalChecks > 0 && (
-        <div className="grid grid-cols-2 sm:grid-cols-3 gap-3">
-          <StatBox label="Total Checks" value={totalChecks} />
-          <StatBox label="Passing" value={totalPassed} color="text-green-400" />
-          <StatBox label="Failing" value={totalFailed} color="text-red-400" />
+      {/* Per-tool stats. Each row's numbers use the tool's native semantics and
+          reconcile internally (Kubescape: passed + failed == total). Mixing them
+          into a single aggregate row hides the fact that Kyverno violations are
+          event counts, not "failed checks", and led to impossible totals (#8974). */}
+      {hasKubescapeChecks && (
+        <div>
+          <h4 className="text-xs font-medium text-muted-foreground mb-2">Kubescape checks</h4>
+          <div className="grid grid-cols-2 sm:grid-cols-3 gap-3">
+            <StatBox label="Total Checks" value={kubescapeTotal} />
+            <StatBox label="Passing" value={kubescapePassed} color="text-green-400" />
+            <StatBox label="Failing" value={kubescapeFailed} color="text-red-400" />
+          </div>
+        </div>
+      )}
+      {hasKyvernoPolicies && (
+        <div>
+          <h4 className="text-xs font-medium text-muted-foreground mb-2">Kyverno policies</h4>
+          <div className="grid grid-cols-2 gap-3">
+            <StatBox label="Policies" value={kyvernoTotalPolicies} />
+            <StatBox label="Violations" value={kyvernoTotalViolations} color="text-red-400" />
+          </div>
+          <p className="text-[11px] text-muted-foreground mt-1.5">
+            Violations count individual offending resources — a single policy may contribute
+            multiple violations, so the violation count is not comparable to the policy count.
+          </p>
         </div>
       )}
 
@@ -222,7 +254,7 @@ function OverviewTab({ score, breakdown, scoreCtx, kubescapeData, kyvernoData }:
       )}
 
       {/* Empty state — no tool data at all */}
-      {totalChecks === 0 && (!breakdown || breakdown.length === 0) && (
+      {!hasAnyToolData && (!breakdown || breakdown.length === 0) && (
         <div className="text-center py-4 text-muted-foreground">
           <p className="text-sm">No compliance tools are reporting data.</p>
           <p className="text-xs mt-1">Install Kubescape or Kyverno in a connected cluster to see detailed breakdowns.</p>

--- a/web/src/components/cards/compliance/ComplianceScoreBreakdownModal.tsx
+++ b/web/src/components/cards/compliance/ComplianceScoreBreakdownModal.tsx
@@ -202,10 +202,12 @@ function OverviewTab({ score, breakdown, scoreCtx, kubescapeData, kyvernoData }:
         <p className="text-xs text-muted-foreground mt-0.5">{scoreCtx.description}</p>
       </div>
 
-      {/* Per-tool stats. Each row's numbers use the tool's native semantics and
-          reconcile internally (Kubescape: passed + failed == total). Mixing them
-          into a single aggregate row hides the fact that Kyverno violations are
-          event counts, not "failed checks", and led to impossible totals (#8974). */}
+      {/*
+       * Per-tool stats. Each row's numbers use the tool's native semantics and
+       * reconcile internally (Kubescape: passed + failed == total). Mixing them
+       * into a single aggregate row hides the fact that Kyverno violations are
+       * event counts, not "failed checks", and led to impossible totals (issue 8974).
+       */}
       {hasKubescapeChecks && (
         <div>
           <h4 className="text-xs font-medium text-muted-foreground mb-2">Kubescape checks</h4>


### PR DESCRIPTION
Fixes #8974

The Compliance Score drilldown Overview tab was mixing Kubescape's pass/fail "check" counts with Kyverno's policies/violations into a single aggregate row (Total Checks / Passing / Failing). Because Kyverno violations are per-resource event counts — a single policy can yield many violations — the numbers didn't add up. Users saw impossible totals like "126 checks, 121 passing, 167 failing" (167 > 126).

## Root cause

In `ComplianceScoreBreakdownModal`'s `OverviewTab`:

```ts
const kyvernoTotal = kyvernoData?.totalPolicies ?? 0
const kyvernoFailed = kyvernoData?.totalViolations ?? 0
const kyvernoPassed = Math.max(0, kyvernoTotal - kyvernoFailed)  // often 0 when violations > policies

const totalChecks = kubescapeTotal + kyvernoTotal               // policies treated as "checks"
const totalPassed = kubescapePassed + kyvernoPassed
const totalFailed = kubescapeFailed + kyvernoFailed             // violations summed into "failed"
```

Kubescape is a true checks model (passed + failed == total). Kyverno is not — `totalViolations` is a count of offending resources across policies, so it routinely exceeds `totalPolicies` and has no natural "passed" counterpart. The aggregate row made this invisible and produced contradictory totals.

## Fix

Show each tool's stats in its own Overview section with its own labels. Kubescape's section keeps the checks/passed/failed model (reconciles internally). Kyverno's section uses its native vocabulary (Policies / Violations) with a short caption explaining that violations aren't comparable to the policy count.

- Top-line numbers now always reconcile with the per-bucket sums shown beneath them (within each tool section).
- No loss of information — all the same data is displayed, just grouped honestly.
- Adds a regression test pinning the invariant (with numbers shaped like the reported issue).

## Test plan

- [x] Vitest: all 13 `ComplianceCards.test.tsx` tests pass, including the new #8974 regression test
- [x] `npm run build` passes
- [x] `npx tsc --noEmit` passes
- [ ] Manual smoke: open Compliance Score card → click gauge → verify Overview shows two sections (when both tools have data) and Kubescape section has passed + failed == total