### PR TITLE
🐛 fix(e2e): skip dashboard-nav recovery reload when link not in primary nav

### DIFF
--- a/web/e2e/perf/dashboard-nav.spec.ts
+++ b/web/e2e/perf/dashboard-nav.spec.ts
@@ -122,20 +122,41 @@ async function measureNavigation(
 
   const link = page.locator(linkSelector).first()
 
+  // Timeouts for link discovery: fast path avoids triggering an expensive reload
+  // when the route simply isn't in the primary nav (a config choice, not a crash).
+  const LINK_ATTACH_TIMEOUT_MS = 3_000
+  const LINK_VISIBLE_TIMEOUT_MS = 2_000
+  const SIDEBAR_PRESENCE_TIMEOUT_MS = 500
+  const RELOAD_SIDEBAR_TIMEOUT_MS = 10_000
+
   // Check if link exists and is visible (scroll into view for long sidebars)
   try {
-    await link.waitFor({ state: 'attached', timeout: 3_000 })
+    await link.waitFor({ state: 'attached', timeout: LINK_ATTACH_TIMEOUT_MS })
     await link.scrollIntoViewIfNeeded()
-    await link.waitFor({ state: 'visible', timeout: 2_000 })
+    await link.waitFor({ state: 'visible', timeout: LINK_VISIBLE_TIMEOUT_MS })
   } catch {
-    // If sidebar link not found, the page may have crashed from a previous nav.
-    // Try recovering by reloading and waiting for the sidebar.
+    // Distinguish "sidebar missing (page crashed)" from "link not in primaryNav
+    // for this dashboard config". Only reload in the crash case — when the sidebar
+    // itself is missing. If the sidebar is present but the link isn't, the route
+    // simply isn't configured in primaryNav, so skip fast without a 10s reload.
+    const sidebar = page.locator('[data-testid="sidebar"]').first()
+    const sidebarPresent = await sidebar
+      .waitFor({ state: 'attached', timeout: SIDEBAR_PRESENCE_TIMEOUT_MS })
+      .then(() => true)
+      .catch(() => false)
+
+    if (sidebarPresent) {
+      console.log(`  SKIP ${target.name}: not in primary nav (${linkSelector})`)
+      return null
+    }
+
+    // Sidebar is gone — attempt recovery with a reload.
     try {
       await page.reload({ waitUntil: 'domcontentloaded' })
-      await page.waitForSelector('[data-testid="sidebar"]', { timeout: 10_000 })
-      await link.waitFor({ state: 'attached', timeout: 3_000 })
+      await page.waitForSelector('[data-testid="sidebar"]', { timeout: RELOAD_SIDEBAR_TIMEOUT_MS })
+      await link.waitFor({ state: 'attached', timeout: LINK_ATTACH_TIMEOUT_MS })
       await link.scrollIntoViewIfNeeded()
-      await link.waitFor({ state: 'visible', timeout: 2_000 })
+      await link.waitFor({ state: 'visible', timeout: LINK_VISIBLE_TIMEOUT_MS })
     } catch {
       console.log(`  SKIP ${target.name}: sidebar link not found after recovery (${linkSelector})`)
       return null


### PR DESCRIPTION
## Summary

Nightly suites #8982 (nav-test) and #8983 (perf-test) have been consistently wall-clock-killed at 300s. Root cause: the recovery branch in `measureNavigation()` (`web/e2e/perf/dashboard-nav.spec.ts`) does a full page reload + 10s sidebar wait for every missing sidebar link, even though many `DASHBOARDS` entries (compute, security, gitops, pods, deployments, services, events, storage, network, nodes, workloads, gpu-reservations, helm, operators, cost, logs, data-compliance) are not present in the sidebar's `primaryNav` config. Each miss burned ~15-18s.

With ~14 missing routes per scenario, recovery alone consumed ~210-250s of the 300s budget defined by `PLAYWRIGHT_SUITE_TIMEOUT_SECS` in `scripts/run-all-tests.sh`.

## Fix

On initial link-miss, probe the sidebar with a 500ms budget.
- Sidebar present + link missing → skip immediately (route not in `primaryNav`).
- Sidebar missing → reload (the actual crashed-page case the recovery branch was designed for).

Named constants throughout, no hex colors, no new magic numbers.

## Scope

This addresses the wall-clock timeout root cause for `nav-test` and `perf-test`. The other 5 nightly-regression suites (#8981 console-error-scan, #8984 ui-compliance-test, #8985 cache-test, #8986 benchmark-test, #8987 ai-ml-test) have different root causes (route-scan budget, Vite preview 503 flood, per-test 60s × N > 300s) and have been lane-transferred to the feature lane:

- scanner-beads-4sb7 — #8981
- scanner-beads-7lc8 — #8984
- scanner-beads-0vru — #8985
- scanner-beads-ez9w — #8986
- scanner-beads-c37c — #8987

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npm run lint` — no new issues in the edited file
- [x] `npm run build` — passes
- [ ] Watch next nightly: nav-test and perf-test should progress past cold-nav + warm-nav instead of being killed mid-warm-nav

Fixes #8982, Fixes #8983