### PR TITLE
🐛 fix(drilldown): unify cluster overview tile navigation with lens buttons

### DIFF
--- a/web/src/components/drilldown/views/ClusterDrillDown.tsx
+++ b/web/src/components/drilldown/views/ClusterDrillDown.tsx
@@ -31,21 +31,28 @@ export function ClusterDrillDown({ data }: Props) {
   const [searchFilter, setSearchFilter] = useState('')
   const [activeLens, setActiveLens] = useState<TreeLens>('all')
   const [activeTab, setActiveTab] = useState<ClusterTab>('events')
-  const nodesSectionRef = useRef<HTMLDivElement>(null)
+  const resourceTreeRef = useRef<HTMLDivElement>(null)
 
-  /** Navigate to the nodes section in the resource tree */
-  const scrollToNodesSection = useCallback(() => {
+  /**
+   * Navigate to the Resource Tree tab with a given lens active.
+   *
+   * Scrolls the tab container (not an inner branch) into view so the user
+   * sees the lens buttons and the filtered branch together — keeping this
+   * flow consistent with clicking a lens button directly inside the tab.
+   */
+  const navigateToResourceTree = useCallback((lens: TreeLens) => {
     setActiveTab('resources')
-    setActiveLens('nodes')
+    setActiveLens(lens)
     setExpandedSections(prev => {
       const next = new Set(prev)
       next.add('cluster')
-      next.add('nodes')
+      if (lens === 'nodes') next.add('nodes')
+      if (lens === 'workloads') next.add('namespaces')
       return next
     })
     // Allow DOM to update before scrolling
     setTimeout(() => {
-      nodesSectionRef.current?.scrollIntoView({ behavior: 'smooth', block: 'nearest' })
+      resourceTreeRef.current?.scrollIntoView({ behavior: 'smooth', block: 'start' })
     }, SCROLL_AFTER_TAB_SWITCH_MS)
   }, [])
 
@@ -269,7 +276,7 @@ export function ClusterDrillDown({ data }: Props) {
         </div>
 
         <button
-          onClick={scrollToNodesSection}
+          onClick={() => navigateToResourceTree('nodes')}
           className="p-4 rounded-lg bg-card/50 border border-border text-left hover:bg-card hover:border-primary/50 transition-colors cursor-pointer w-full"
         >
           <div className="text-sm text-muted-foreground mb-2">{t('common.nodes')}</div>
@@ -277,10 +284,13 @@ export function ClusterDrillDown({ data }: Props) {
           <div className="text-xs text-green-400">{health?.readyNodes || 0} ready</div>
         </button>
 
-        <div className="p-4 rounded-lg bg-card/50 border border-border">
+        <button
+          onClick={() => navigateToResourceTree('workloads')}
+          className="p-4 rounded-lg bg-card/50 border border-border text-left hover:bg-card hover:border-primary/50 transition-colors cursor-pointer w-full"
+        >
           <div className="text-sm text-muted-foreground mb-2">{t('common.pods')}</div>
           <div className="text-2xl font-bold text-foreground">{health?.podCount || 0}</div>
-        </div>
+        </button>
 
         <div className="p-4 rounded-lg bg-card/50 border border-border">
           <div className="text-sm text-muted-foreground mb-2">{t('common.gpus')}</div>
@@ -439,7 +449,7 @@ export function ClusterDrillDown({ data }: Props) {
       )}
 
       {/* Tabs for Events and Resources */}
-      <div className="border-t border-border pt-4">
+      <div ref={resourceTreeRef} className="border-t border-border pt-4">
         <div className="border-b border-border mb-4">
           <div className="flex gap-0">
             {([
@@ -621,7 +631,7 @@ export function ClusterDrillDown({ data }: Props) {
                         </div>
 
                         {expandedSections.has('nodes') && (
-                          <div ref={nodesSectionRef} className="ml-6 border-l-2 border-blue-500/30 pl-4 mt-1 space-y-1">
+                          <div className="ml-6 border-l-2 border-blue-500/30 pl-4 mt-1 space-y-1">
                             {filteredNodes.slice(0, 20).map((node) => (
                               <button
                                 key={node.name}


### PR DESCRIPTION
## Summary

Fixes a UX inconsistency in `ClusterDrillDown` between two similar "expand" flows from the cluster overview:

- **Before:** Clicking the **Nodes** stat tile scrolled to an inner branch of the Resource Tree (`block: 'nearest'`), which hid the tab's lens buttons and made the node list appear **below** the Issues section — easy to miss.
- **Before:** Clicking the **Workloads** lens button (inside the tab) rendered the namespaces branch in place with the lens buttons still visible, making that list appear **above** the Issues section.
- The reporter saw the Nodes click as a "no-op" while the Workloads click worked as expected.

## Changes

- Replace `scrollToNodesSection` with a single `navigateToResourceTree(lens)` helper that activates the chosen `TreeLens` in the Resource Tree tab.
- Scroll the **Resource Tree tab container** into view (`block: 'start'`) instead of an inner branch — both entry paths now land on the same visible frame: lens buttons on top, selected branch below.
- Make the Pods stat tile symmetric with the Nodes tile: it now jumps to the **Workloads** lens, matching the implicit expectation the reporter described.
- Auto-expand the matching branch (`nodes` or `namespaces`) when arriving via a stat tile so content is immediately visible.

No magic numbers introduced; reuses the existing `SCROLL_AFTER_TAB_SWITCH_MS` constant and `TreeLens` type. No new hex colors, no new array iteration over possibly-undefined data.

## Test plan

- [ ] Open the cluster drilldown for any cluster
- [ ] Click the **Nodes** stat tile → Resource Tree tab becomes active with the Nodes lens, tab header is scrolled into view, the nodes branch is expanded
- [ ] Click the **Pods** stat tile → Resource Tree tab becomes active with the Workloads lens, tab header is scrolled into view, the namespaces branch is expanded
- [ ] Click lens buttons inside the Resource Tree (Nodes / Workloads) → still behave as before (no extra scroll), and the view matches what the stat tiles produce
- [ ] Verify on a cluster with issues present — both flows now show the filtered branch directly under the lens buttons instead of splitting behavior around the Issues section

Fixes #8975