### PR TITLE
🐛 fix(acmm): repair sidebar count, search filter, info bar, README badge

### DIFF
--- a/web/netlify/functions/acmm-badge.mts
+++ b/web/netlify/functions/acmm-badge.mts
@@ -16,6 +16,9 @@ const GITHUB_API = "https://api.github.com";
 const REPO_RE = /^[\w.-]+\/[\w.-]+$/;
 const API_TIMEOUT_MS = 15_000;
 const LEVEL_COMPLETION_THRESHOLD = 0.7;
+/** Maximum maturity level scanned (L6 = Fully Autonomous). L1 is the
+ *  starting level; threshold walk gates L2 through MAX_LEVEL. */
+const MAX_LEVEL = 6;
 /**
  * Badge cache window. ACMM level changes slowly (file-tree shape, not commit
  * activity), so a 1 h cache is plenty. This is shared across three layers:
@@ -27,7 +30,16 @@ const LEVEL_COMPLETION_THRESHOLD = 0.7;
  */
 const BADGE_CACHE_SECONDS = 3600;
 
-/** ACMM criteria grouped by level. Mirrors acmm-scan.mts CRITERIA entries. */
+/**
+ * ACMM criteria grouped by level. MUST mirror the scannable entries in
+ * acmm-scan.mts CRITERIA (IDs and level assignments).
+ *
+ * Issue #8979: the previous map used legacy short IDs (acmm:pr-template,
+ * acmm:style-config, acmm:test-suite, …) that no longer exist in the scan
+ * taxonomy, so the badge always computed to L1 ("5/10" for kubestellar/
+ * console) regardless of the repo's real maturity. When adding / renaming
+ * criteria in acmm-scan.mts, update this map and the LEVEL_NAMES below.
+ */
 const ACMM_IDS_BY_LEVEL: Record<number, string[]> = {
   2: [
     "acmm:claude-md",
@@ -35,20 +47,17 @@ const ACMM_IDS_BY_LEVEL: Record<number, string[]> = {
     "acmm:agents-md",
     "acmm:cursor-rules",
     "acmm:prompts-catalog",
-    "acmm:pr-template",
-    "acmm:issue-template",
-    "acmm:contrib-guide",
-    "acmm:style-config",
     "acmm:editor-config",
   ],
   3: [
-    "acmm:coverage-gate",
     "acmm:pr-acceptance-metric",
-    "acmm:test-suite",
-    "acmm:e2e-tests",
     "acmm:pr-review-rubric",
     "acmm:quality-dashboard",
     "acmm:ci-matrix",
+    "acmm:layered-safety",
+    "acmm:mechanical-enforcement",
+    "acmm:session-summary",
+    "acmm:structural-gates",
   ],
   4: [
     "acmm:auto-qa-tuning",
@@ -58,25 +67,36 @@ const ACMM_IDS_BY_LEVEL: Record<number, string[]> = {
     "acmm:ai-fix-workflow",
     "acmm:tier-classifier",
     "acmm:security-ai-md",
+    "acmm:session-continuity",
+    "acmm:cross-session-knowledge",
   ],
   5: [
+    "acmm:github-actions-ai",
+    "acmm:auto-qa-self-tuning",
+    "acmm:public-metrics",
+    "acmm:policy-as-code",
+    "acmm:reflection-log",
+  ],
+  6: [
     "acmm:auto-issue-gen",
     "acmm:multi-agent-orchestration",
     "acmm:strategic-dashboard",
     "acmm:merge-queue",
-    "acmm:policy-as-code",
-    "acmm:public-metrics",
-    "acmm:reflection-log",
+    "acmm:risk-assessment-config",
+    "acmm:observability-runbook",
   ],
 };
 
-/** Shields.io color bands by level — matches the ACMM gauge on Card 1. */
+/** Shields.io color bands by level — matches the ACMM gauge on Card 1.
+ *  Level 6 (Fully Autonomous) extends the gradient beyond the original
+ *  five bands; `blue` stays within shields.io's named-color palette. */
 const LEVEL_COLORS: Record<number, string> = {
   1: "lightgrey",
   2: "yellow",
   3: "yellowgreen",
   4: "brightgreen",
   5: "blueviolet",
+  6: "blue",
 };
 
 const LEVEL_NAMES: Record<number, string> = {
@@ -84,7 +104,8 @@ const LEVEL_NAMES: Record<number, string> = {
   2: "Instructed",
   3: "Measured",
   4: "Adaptive",
-  5: "Self-Sustaining",
+  5: "Semi-Automated",
+  6: "Fully Autonomous",
 };
 
 const ALLOWED_ORIGIN_RE = /^https?:\/\/(.*\.kubestellar\.io|localhost(:\d+)?)$/;
@@ -105,17 +126,23 @@ function computeLevel(detectedIds: Set<string>): { level: number; totalDetected:
   let currentLevel = 1;
   let totalDetected = 0;
   let totalAcmm = 0;
-  for (let n = 2; n <= 5; n++) {
-    const required = ACMM_IDS_BY_LEVEL[n];
+  let stopPromotion = false;
+  for (let n = 2; n <= MAX_LEVEL; n++) {
+    const required = ACMM_IDS_BY_LEVEL[n] ?? [];
     const detected = required.filter((id) => detectedIds.has(id)).length;
     totalAcmm += required.length;
     totalDetected += detected;
-    if (required.length === 0) continue;
+    if (required.length === 0 || stopPromotion) continue;
     const ratio = detected / required.length;
     if (ratio >= LEVEL_COMPLETION_THRESHOLD) {
       currentLevel = n;
     } else {
-      break;
+      // Stop promoting levels after the first gap, but keep counting
+      // detected / total across every level so the "X / Y" pill in the
+      // badge reflects the full criterion catalog (not just the levels
+      // up to the current gate). This matches the frontend pill the
+      // user sees inside the dashboard.
+      stopPromotion = true;
     }
   }
   return { level: currentLevel, totalDetected, totalAcmm };
@@ -131,26 +158,127 @@ async function fetchDetectedIds(origin: string, repo: string): Promise<string[]>
   return body.detectedIds || [];
 }
 
-/** Fallback: call GitHub directly if the scan endpoint isn't reachable from this function. */
+/**
+ * Fallback: call GitHub directly when the scan endpoint isn't reachable
+ * from this function (same-origin fetch timed out, scan function cold-
+ * started, etc.). Detects a representative subset of criteria by path —
+ * enough to produce a plausible level for the badge so we never show
+ * "custom badge inaccessible" (issue #8979). Previously this used a
+ * naive `id.replace("acmm:", "").replace(/-/g, "_") + ".md"` heuristic
+ * that never matched anything real (e.g. `claude_md.md` is not a file
+ * on any repo), so every fallback path computed to L1.
+ */
+const BADGE_FALLBACK_PATHS: Record<string, readonly string[]> = {
+  // L2
+  "acmm:claude-md": ["CLAUDE.md", ".claude/CLAUDE.md"],
+  "acmm:copilot-instructions": [".github/copilot-instructions.md"],
+  "acmm:agents-md": ["AGENTS.md"],
+  "acmm:cursor-rules": [".cursorrules", ".cursor/rules"],
+  "acmm:prompts-catalog": [
+    "prompts/",
+    ".prompts/",
+    "docs/prompts/",
+    ".github/prompts/",
+    ".github/agents/",
+  ],
+  "acmm:editor-config": [".editorconfig"],
+  // L3
+  "acmm:pr-review-rubric": [
+    ".github/review-rubric.md",
+    "docs/review-criteria.md",
+    ".github/prompts/review.md",
+  ],
+  "acmm:ci-matrix": [
+    ".github/workflows/ci.yml",
+    ".github/workflows/test.yml",
+    ".github/workflows/build.yml",
+    ".github/workflows/build-deploy.yml",
+  ],
+  "acmm:layered-safety": [".claude/settings.json", ".claude/settings.local.json"],
+  "acmm:mechanical-enforcement": [".claude/settings.json"],
+  "acmm:structural-gates": [".claude/settings.json"],
+  // L4
+  "acmm:security-ai-md": [
+    "docs/security/SECURITY-AI.md",
+    "SECURITY-AI.md",
+    "docs/SECURITY-AI.md",
+  ],
+  "acmm:ai-fix-workflow": [
+    ".github/workflows/ai-fix.yml",
+    ".github/workflows/ai-fix-requested.yml",
+    ".github/workflows/claude.yml",
+  ],
+  "acmm:nightly-compliance": [
+    ".github/workflows/nightly-compliance.yml",
+    ".github/workflows/nightly.yml",
+    ".github/workflows/nightly-test.yml",
+  ],
+  "acmm:auto-label": [
+    ".github/labeler.yml",
+    ".github/workflows/labeler.yml",
+    ".github/workflows/triage.yml",
+  ],
+  // L5
+  "acmm:github-actions-ai": [
+    ".github/workflows/claude.yml",
+    ".github/workflows/claude-code-review.yml",
+  ],
+  // L6
+  "acmm:merge-queue": [
+    ".github/workflows/merge-queue.yml",
+    ".github/merge-queue.yml",
+    ".prow.yaml",
+    "tide.yaml",
+  ],
+};
+
+function pathMatches(paths: Set<string>, pattern: string): boolean {
+  if (pattern.endsWith("/")) {
+    for (const path of paths) {
+      if (path.startsWith(pattern)) return true;
+    }
+    return false;
+  }
+  return paths.has(pattern);
+}
+
 async function fetchDetectedIdsDirect(repo: string, token: string): Promise<string[]> {
   const headers: Record<string, string> = {
     Accept: "application/vnd.github.v3+json",
   };
   if (token) headers["Authorization"] = `Bearer ${token}`;
-  const res = await fetch(`${GITHUB_API}/repos/${repo}/git/trees/HEAD?recursive=1`, {
+
+  // The trees endpoint requires a branch name or SHA, not "HEAD" — resolve
+  // the default branch first. See acmm-scan.mts for the same pattern.
+  const repoRes = await fetch(`${GITHUB_API}/repos/${repo}`, {
     headers,
     signal: AbortSignal.timeout(API_TIMEOUT_MS),
   });
+  if (!repoRes.ok) throw new Error(`repo API ${repoRes.status}`);
+  const repoInfo = (await repoRes.json()) as { default_branch?: string };
+  const branch = repoInfo.default_branch || "main";
+
+  const res = await fetch(
+    `${GITHUB_API}/repos/${repo}/git/trees/${branch}?recursive=1`,
+    {
+      headers,
+      signal: AbortSignal.timeout(API_TIMEOUT_MS),
+    },
+  );
   if (!res.ok) throw new Error(`tree API ${res.status}`);
   const body = (await res.json()) as { tree?: { path: string }[] };
   const paths = new Set((body.tree || []).map((e) => e.path));
 
-  const allIds = Object.values(ACMM_IDS_BY_LEVEL).flat();
-  return allIds.filter((id) => {
-    /** Rough match: use a subset of the real detection rules since this
-     * fallback only runs when the scan endpoint is unreachable. */
-    return paths.has(id.replace("acmm:", "").replace(/-/g, "_") + ".md");
-  });
+  const detected: string[] = [];
+  for (const [id, patterns] of Object.entries(BADGE_FALLBACK_PATHS)) {
+    for (const p of patterns) {
+      if (pathMatches(paths, p)) {
+        detected.push(id);
+        break;
+      }
+    }
+  }
+  return detected;
 }
 
 export default async (req: Request) => {

--- a/web/netlify/functions/acmm-scan.mts
+++ b/web/netlify/functions/acmm-scan.mts
@@ -419,32 +419,46 @@ async function searchAllPages(
 
 function demoScan(repo: string): ScanResult {
   const weeks = lastNWeeks(WEEKS_OF_HISTORY);
+  // Issue #8978: match the current CRITERIA IDs so the demo fallback
+  // doesn't compute down to L1 for repos that are clearly at a higher
+  // maturity level (e.g. kubestellar/console is L5 in reality). The IDs
+  // here must track CRITERIA[].id above; sync both when IDs change.
   return {
     repo,
     scannedAt: new Date().toISOString(),
     detectedIds: [
+      "acmm:prereq-test-suite",
+      "acmm:prereq-e2e",
+      "acmm:prereq-cicd",
+      "acmm:prereq-pr-template",
+      "acmm:prereq-issue-template",
+      "acmm:prereq-contrib-guide",
+      "acmm:prereq-code-style",
+      "acmm:prereq-coverage-gate",
       "acmm:claude-md",
       "acmm:copilot-instructions",
-      "acmm:pr-template",
-      "acmm:contrib-guide",
-      "acmm:style-config",
+      "acmm:agents-md",
+      "acmm:prompts-catalog",
       "acmm:editor-config",
-      "acmm:coverage-gate",
-      "acmm:test-suite",
-      "acmm:e2e-tests",
+      "acmm:pr-acceptance-metric",
+      "acmm:pr-review-rubric",
+      "acmm:quality-dashboard",
       "acmm:ci-matrix",
+      "acmm:auto-qa-tuning",
       "acmm:nightly-compliance",
       "acmm:auto-label",
       "acmm:ai-fix-workflow",
+      "acmm:tier-classifier",
       "acmm:security-ai-md",
+      "acmm:github-actions-ai",
+      "acmm:auto-qa-self-tuning",
       "acmm:public-metrics",
-      "acmm:reflection-log",
+      "acmm:policy-as-code",
+      "acmm:strategic-dashboard",
       "fullsend:test-coverage",
       "fullsend:ci-cd-maturity",
-      "aef:structural-gates",
       "aef:session-continuity",
-      "claude-reflect:preference-index",
-      "claude-reflect:session-summary",
+      "aef:cross-tool-config",
     ],
     weeklyActivity: weeks.map((w, i) => ({
       week: w,

--- a/web/src/components/acmm/RepoPicker.tsx
+++ b/web/src/components/acmm/RepoPicker.tsx
@@ -310,7 +310,11 @@ export function RepoPicker() {
         </div>
       )}
 
-      <div className="max-w-screen-2xl mx-auto px-6 pb-2 text-xs text-muted-foreground border-b border-border/60">
+      {/* Info bar (issue #8977): removed the bottom border that bled through
+          as an underline beneath the inline text (e.g. "request timed out").
+          The sticky wrapper's backdrop-blur + bg-background/95 already give
+          enough visual separation from the scrollable page content. */}
+      <div className="max-w-screen-2xl mx-auto px-6 pb-2 text-xs text-muted-foreground">
         {error ? (
           <div className="flex items-center gap-1.5 text-red-400">
             <AlertCircle className="w-3.5 h-3.5" />

--- a/web/src/components/layout/Sidebar.tsx
+++ b/web/src/components/layout/Sidebar.tsx
@@ -48,7 +48,7 @@ const HREF_TO_DASHBOARD_ID: Record<string, string> = {
   '/deploy': 'deploy', '/ai-agents': 'ai-agents',
   '/llm-d-benchmarks': 'llm-d-benchmarks', '/cluster-admin': 'cluster-admin',
   '/insights': 'insights', '/drasi': 'drasi',
-  '/multi-tenancy': 'multi-tenancy' }
+  '/multi-tenancy': 'multi-tenancy', '/acmm': 'acmm' }
 
 /** Prefix for custom dashboard routes */
 const CUSTOM_DASHBOARD_PREFIX = '/custom-dashboard/'

--- a/web/src/hooks/useCachedACMMScan.ts
+++ b/web/src/hooks/useCachedACMMScan.ts
@@ -10,11 +10,25 @@ import { useCallback, useRef, useSyncExternalStore } from 'react'
 import { useCache, type RefreshCategory } from '../lib/cache'
 import { computeLevel, type LevelComputation } from '../lib/acmm/computeLevel'
 import { computeRecommendations, type Recommendation } from '../lib/acmm/computeRecommendations'
-import { FETCH_DEFAULT_TIMEOUT_MS } from '../lib/constants'
 
 const API_PATH = '/api/acmm/scan'
 /** Scan results change slowly; 10-min refresh avoids GitHub rate limits. */
 const REFRESH_CATEGORY: RefreshCategory = 'costs'
+
+/**
+ * ACMM scan timeout (issue #8978).
+ *
+ * A cold scan of a large repo (like kubestellar/console, ~1600 files) fans
+ * out into up to 12 GitHub API calls from the Netlify Function: 1 repo info
+ * + 1 full-tree fetch + up to 10 paginated search pages for weekly activity.
+ * Each GitHub call has its own 15s timeout inside the function. The default
+ * 10s browser fetch timeout (FETCH_DEFAULT_TIMEOUT_MS) was too tight and
+ * aborted healthy live scans, making the UI show "request timed out" even
+ * though the backend would eventually answer (and cache the result, so the
+ * next visit worked). 30s covers the realistic worst case without hanging
+ * the tab indefinitely.
+ */
+const ACMM_SCAN_TIMEOUT_MS = 30_000
 
 export interface WeeklyActivity {
   week: string
@@ -78,32 +92,55 @@ function demoScan(repo: string): ACMMScanData {
       humanIssues: 3,
     })
   }
+  // Issue #8978: detectedIds must use the CURRENT criterion IDs from
+  // web/src/lib/acmm/sources/acmm.ts — the previous list used legacy short
+  // IDs (acmm:pr-template, acmm:style-config, …) that no longer exist in
+  // the taxonomy, so the demo fallback computed to L1 even for well-tooled
+  // repos like kubestellar/console which should land at L5. Keep this set
+  // in sync with acmm-scan.mts when criteria IDs change.
   return {
     repo,
     scannedAt: new Date().toISOString(),
     detectedIds: [
+      // L0 prerequisites
+      'acmm:prereq-test-suite',
+      'acmm:prereq-e2e',
+      'acmm:prereq-cicd',
+      'acmm:prereq-pr-template',
+      'acmm:prereq-issue-template',
+      'acmm:prereq-contrib-guide',
+      'acmm:prereq-code-style',
+      'acmm:prereq-coverage-gate',
+      // L2 — Instructed
       'acmm:claude-md',
       'acmm:copilot-instructions',
-      'acmm:pr-template',
-      'acmm:contrib-guide',
-      'acmm:style-config',
+      'acmm:agents-md',
+      'acmm:prompts-catalog',
       'acmm:editor-config',
-      'acmm:coverage-gate',
-      'acmm:test-suite',
-      'acmm:e2e-tests',
+      // L3 — Measured / Enforced
+      'acmm:pr-acceptance-metric',
+      'acmm:pr-review-rubric',
+      'acmm:quality-dashboard',
       'acmm:ci-matrix',
+      // L4 — Adaptive / Structured
+      'acmm:auto-qa-tuning',
       'acmm:nightly-compliance',
       'acmm:auto-label',
       'acmm:ai-fix-workflow',
+      'acmm:tier-classifier',
       'acmm:security-ai-md',
+      // L5 — Semi-Automated
+      'acmm:github-actions-ai',
+      'acmm:auto-qa-self-tuning',
       'acmm:public-metrics',
-      'acmm:reflection-log',
+      'acmm:policy-as-code',
+      // L6 — Fully Autonomous
+      'acmm:strategic-dashboard',
+      // Other sources
       'fullsend:test-coverage',
       'fullsend:ci-cd-maturity',
-      'aef:structural-gates',
       'aef:session-continuity',
-      'claude-reflect:preference-index',
-      'claude-reflect:session-summary',
+      'aef:cross-tool-config',
     ],
     weeklyActivity: weeks,
   }
@@ -149,7 +186,7 @@ function getDemoFallback(repo: string): boolean {
 async function fetchACMMScan(repo: string, force: boolean): Promise<ACMMScanData> {
   const qs = force ? `&force=true` : ''
   const res = await fetch(`${API_PATH}?repo=${encodeURIComponent(repo)}${qs}`, {
-    signal: AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS),
+    signal: AbortSignal.timeout(ACMM_SCAN_TIMEOUT_MS),
   })
   if (!res.ok) {
     throw new Error(`ACMM scan failed: ${res.status} ${res.statusText}`)


### PR DESCRIPTION
## Summary

Four related bugs on the ACMM dashboard, fixed in one PR.

- **Sidebar card count (#8976)** — added `/acmm` to `HREF_TO_DASHBOARD_ID` in `Sidebar.tsx` so the ACMM entry reads its 3-card count from the dashboard config, matching every other sidebar link.
- **Info-bar underline (#8977)** — removed the `border-b border-border/60` underline that bled through beneath the inline scan status / error text (e.g. "request timed out"). The sticky wrapper's `backdrop-blur` + `bg-background/95` still separate the header from scrolling content.
- **`kubestellar/console` search timeout (#8978)** — raised the browser-side scan fetch timeout to 30 s under a new `ACMM_SCAN_TIMEOUT_MS` constant. A cold scan of a 1,600+ file repo fans out into up to 12 GitHub API calls (repo info + full tree + 10 paginated search pages) each with a 15 s budget inside the Netlify Function; the old 10 s browser timeout fired just before the response arrived, producing "request timed out" for healthy scans.
- **README badge (#8979)** — the badge function's `ACMM_IDS_BY_LEVEL` map used legacy short IDs (`acmm:pr-template`, `acmm:style-config`, `acmm:test-suite`, …) that no longer exist in the scan taxonomy, so every repo pinned to L1 regardless of maturity. Rebuilt the map from the current scan catalog, extended coverage to L6 (with color + name), and replaced the broken direct-from-GitHub fallback heuristic with a proper path-based detection table.

Also refreshed the `demoFallback` `detectedIds` in both the hook (`useCachedACMMScan.ts`) and the Netlify Function (`acmm-scan.mts`) to use the current criterion IDs — the previous set used the same legacy IDs as the badge map, which is why the demo fallback rendered as L1 for `kubestellar/console` even though the repo is at L5 in reality.

## Files touched

- `web/src/components/layout/Sidebar.tsx` — sidebar HREF map (#8976)
- `web/src/components/acmm/RepoPicker.tsx` — info-bar border removal (#8977)
- `web/src/hooks/useCachedACMMScan.ts` — 30s timeout + demo fallback IDs (#8978)
- `web/netlify/functions/acmm-scan.mts` — demo fallback IDs (#8978)
- `web/netlify/functions/acmm-badge.mts` — ID map sync, L6 coverage, real fallback detection (#8979)

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npm run build` clean
- [x] `npm run lint` — no new errors in the touched files (pre-existing errors elsewhere unchanged)
- [x] `useCachedACMMScan.test.tsx` still green (11/11 — covers demo-data shape, detectedIds size, source diversity, level computation)
- [ ] Manual check: `/acmm` sidebar entry shows "3" count
- [ ] Manual check: info bar under ACMM search renders with no underline under inline text
- [ ] Manual check: scan of `kubestellar/console` completes without timing out on a cold run
- [ ] Manual check: `https://img.shields.io/endpoint?url=…%2Facmm%2Fbadge%3Frepo%3Dkubestellar%252Fconsole` renders a non-L1 level for `kubestellar/console` after deploy

Fixes #8976
Fixes #8977
Fixes #8978
Fixes #8979