### PR TITLE
🐛 fix: Playwright Cross-Browser test assertions drift (Fixes #8980)

### DIFF
--- a/web/e2e/Dashboard.spec.ts
+++ b/web/e2e/Dashboard.spec.ts
@@ -248,9 +248,11 @@ test.describe('Dashboard Page', () => {
     test('has proper ARIA labels', async ({ page }) => {
       await expect(page.getByTestId('dashboard-page')).toBeVisible({ timeout: 10000 })
 
-      // Refresh button should have title for accessibility
+      // Refresh button should have title for accessibility. The actual i18n
+      // string is `common.refreshClusterData` → "Refresh cluster data"
+      // (see web/src/locales/en/common.json and DashboardHeader.tsx).
       const refreshButton = page.getByTestId('dashboard-refresh-button')
-      await expect(refreshButton).toHaveAttribute('title', 'Refresh data')
+      await expect(refreshButton).toHaveAttribute('title', 'Refresh cluster data')
     })
   })
 

--- a/web/e2e/helpers/setup.ts
+++ b/web/e2e/helpers/setup.ts
@@ -37,6 +37,8 @@ export const EXPECTED_ERROR_PATTERNS = [
   /localhost:8585/i, // Agent connection attempts in demo mode
   /127\.0\.0\.1:8585/i, // Agent connection attempts (IP form)
   /Cross-Origin Request Blocked/i, // CORS errors when backend/agent not running
+  /blocked by CORS policy/i, // Chromium CORS wording (Firefox uses pattern above)
+  /Access to fetch.*has been blocked by CORS/i, // Chromium-specific phrasing; Medium blog public fallback is cross-origin from vite preview (localhost:4173 → console.kubestellar.io)
   /Notification permission/i, // Firefox blocks notification requests outside user gestures
   /ERR_CONNECTION_REFUSED/i, // Backend/agent not running in CI
   /net::ERR_/i, // Any network-level Chrome error in demo mode

--- a/web/e2e/navbar-responsive.spec.ts
+++ b/web/e2e/navbar-responsive.spec.ts
@@ -55,18 +55,28 @@ test.describe('Navbar responsive layout', () => {
       const nav = page.locator('nav[data-tour="navbar"]')
       await expect(nav).toBeVisible()
 
-      // Logo / home button always visible
-      await expect(nav.getByRole('button', { name: /go home/i })).toBeVisible()
+      // Logo / home button always visible. The actual aria-label comes from
+      // i18n key `navbar.goHome` → "Go to home dashboard" (see Navbar.tsx),
+      // so the previous `/go home/i` substring regex never matched. Match
+      // on "home" (case-insensitive) and take .first() because the logo
+      // and the app-name button both carry the same aria-label.
+      await expect(nav.getByRole('button', { name: /home/i }).first()).toBeVisible()
 
-      // Theme toggle always visible
-      await expect(nav.locator('button[title*="theme" i]')).toBeVisible()
+      // Theme toggle always visible. The button uses aria-label (from i18n
+      // `navbar.themeToggle` → "Theme: <mode> (click to toggle)"), not a
+      // native `title` attribute — the tooltip is a Tooltip primitive
+      // (see components/ui/Tooltip.tsx), not a browser title.
+      await expect(nav.locator('button[aria-label*="theme" i]')).toBeVisible()
 
       // Alerts badge always visible
       await expect(nav.locator('[data-testid="alert-badge"], button[aria-label*="alert" i]').first()).toBeVisible()
 
-      // User profile dropdown always visible
+      // User profile dropdown always visible. UserProfileDropdown.tsx's
+      // trigger button has no aria-label or data-testid — it's identified
+      // by `aria-haspopup="true"` inside the nav element. Accept any of
+      // these locators so future relabeling won't re-break this test.
       await expect(
-        nav.locator('[data-testid="user-menu"], button[aria-label*="user" i], button[aria-label*="profile" i]').first()
+        nav.locator('[data-testid="user-menu"], button[aria-label*="user" i], button[aria-label*="profile" i], button[aria-haspopup="true"]').first()
       ).toBeVisible()
     })
   }
@@ -98,8 +108,13 @@ test.describe('Navbar responsive layout', () => {
     await setupPage(page)
 
     const nav = page.locator('nav[data-tour="navbar"]')
-    // Search container uses hidden sm:block
-    const searchWrapper = nav.locator('.hidden.sm\\:block')
+    // Search container uses `hidden sm:flex`. Multiple unrelated elements in
+    // the navbar share a `.hidden.sm:block` utility pair (e.g. the
+    // UserProfileDropdown name div and a StreakBadge progress pill), so use
+    // `.first()` to pick the outermost search wrapper and avoid strict-mode
+    // violations. The `.flex-1.max-w-md` identifiers on the search container
+    // are unique to this wrapper.
+    const searchWrapper = nav.locator('.hidden.sm\\:flex.flex-1, .hidden.sm\\:block.flex-1').first()
     await expect(searchWrapper).toBeVisible()
   })
 


### PR DESCRIPTION
## Summary

The nightly `Playwright Cross-Browser` workflow has failed **5 of the last 5 runs** with the same pattern — not a flake. Multiple test assertions had drifted out of sync with their targets (labels renamed via i18n, CSS classes reused on additional elements, browser-specific CORS wording). This PR applies targeted, **test-only** fixes that restore the signal without changing any product code.

## Root causes fixed

### 1. `Dashboard.spec.ts` — Accessibility > has proper ARIA labels
Expected `title="Refresh data"` but the refresh button title is sourced from the `common.refreshClusterData` i18n key → `"Refresh cluster data"` (see `DashboardHeader.tsx:146`). Updated the expectation to match the actual rendered title.

### 2. `navbar-responsive.spec.ts` — "core navbar items are accessible at {511/640/768/1024/1280px}" (5 tests)
- `getByRole('button', { name: /go home/i })` never matched because the aria-label is `"Go to home dashboard"` (no `"go home"` substring). Relaxed to `/home/i` and added `.first()` since both the logo button and the app-name button carry the same aria-label.
- `button[title*="theme" i]` targeted a `title` attribute the theme button doesn't have — it uses `aria-label` from the `navbar.themeToggle` i18n key, and the hover tooltip is a Tooltip primitive (not a browser title). Switched to `button[aria-label*="theme" i]`.
- UserProfileDropdown's trigger has no aria-label or data-testid; it's identifiable by `aria-haspopup="true"`. Added that selector to the OR list so the test is robust to future relabeling.

### 3. `navbar-responsive.spec.ts` — "search bar is in main nav bar at sm+ (640px)"
`.hidden.sm:block` now matches 2 elements (a StreakBadge progress pill + the UserProfileDropdown name div), causing a strict-mode violation. Narrowed to the search container's unique `.flex-1` identifier.

### 4. `smoke.spec.ts` — Route Loading / Error Handling / Mobile Viewport (~10 tests across all 4 browsers)
Chromium-phrased CORS errors (`"Access to fetch at … has been blocked by CORS policy"`) were not matched by the existing `/Cross-Origin Request Blocked/i` pattern (Firefox-only wording). This is triggered by `useMediumBlog` falling back to the public `console.kubestellar.io/api/medium/blog` endpoint when the preview server has no Go backend — a known expected condition, not a real regression. Added the Chromium pattern to `EXPECTED_ERROR_PATTERNS` in `helpers/setup.ts`.

## Out of scope (tracked on the issue bead for the reviewer lane)

These are genuine regressions that need deeper work than this PR's test-hygiene fixes:

- **Dashboard Data Accuracy tests** (`#6459`) — the deterministic cluster payload injected via `page.route()` isn't reaching the `/clusters` page (expected 3 clusters, got 0). Likely a mock-route precedence issue with the SWR cache or the clusters page using a different endpoint path than the mocked one.
- **responsive-regression.spec.ts overflow tests** at `laptop (1024x768)` and `tablet (768x1024)` — navbar buttons measurably extend past the viewport right edge (e.g., `right: 1294px` at `1024px` width). Real layout bug in the extended navbar item group, needs a design pass.

## Test plan

- [x] `npm run build` — passes (all post-build safety checks green)
- [x] `npx tsc --noEmit` — clean
- [ ] Next nightly run of `Playwright Cross-Browser (Nightly)` should show: navbar-responsive core tests green (5/5 per project × 4 projects = 20 tests), Dashboard ARIA test green, and smoke Route Loading tests green on all 4 browsers.

Fixes #8980