### PR TITLE
🐛 fix(nightly): recover compliance/perf harnesses + raise suite timeouts

### DIFF
--- a/scripts/run-all-tests.sh
+++ b/scripts/run-all-tests.sh
@@ -288,9 +288,30 @@ if [ -z "$FAST_MODE" ]; then
 
         # Per-suite wall-clock cap (seconds). Prevents a single hanging suite
         # (e.g. benchmark retries against unresponsive external services) from
-        # consuming the entire nightly workflow budget. 5 minutes is generous
-        # for any single Playwright suite; most finish in under 2 minutes.
+        # consuming the entire nightly workflow budget. 5 minutes is the default
+        # and is generous for most Playwright suites. A handful of heavier
+        # suites exceed this routinely (#8981, #8986, #8987) — they get an
+        # explicit override below. Keep the default tight so a genuinely hung
+        # suite still fails fast.
         PLAYWRIGHT_SUITE_TIMEOUT_SECS=300
+
+        # Per-suite timeout overrides (seconds). Only list suites that need
+        # MORE time than the default. See:
+        #   #8981 console-error-scan: 38+ routes × ~5s settle ≈ 250-270s, right
+        #     at the 300s cap. Bumping to 600s gives headroom for additional
+        #     routes without re-firing nightly regressions.
+        #   #8984 ui-compliance-test: renders every registered card type; total
+        #     card count keeps growing as we add cards.
+        #   #8985 cache-test: renders all cards via the same compliance harness.
+        #   #8986 benchmark-test: 12 tests × up to 60s each ≈ 720s worst case.
+        #   #8987 ai-ml-test: 15 tests × up to 300s each in pathological cases.
+        declare -A PLAYWRIGHT_SUITE_TIMEOUT_OVERRIDES=(
+          ["console-error-scan"]=600
+          ["ui-compliance-test"]=600
+          ["cache-test"]=600
+          ["benchmark-test"]=600
+          ["ai-ml-test"]=600
+        )
 
         for script in "${PLAYWRIGHT_SCRIPTS[@]}"; do
           SUITE_NAME=$(basename "$script" .sh)
@@ -304,19 +325,22 @@ if [ -z "$FAST_MODE" ]; then
             continue
           fi
 
+          # Resolve the per-suite timeout (override wins, else default).
+          SUITE_TIMEOUT_SECS="${PLAYWRIGHT_SUITE_TIMEOUT_OVERRIDES[$SUITE_NAME]:-$PLAYWRIGHT_SUITE_TIMEOUT_SECS}"
+
           echo -e "  ${BOLD}▶ ${SUITE_NAME}${NC}"
           SUITE_START=$(date +%s)
           SUITE_OUTPUT="/tmp/suite-${SUITE_NAME}.log"
           SUITE_EXIT=0
-          timeout "${PLAYWRIGHT_SUITE_TIMEOUT_SECS}" bash "$script" > "$SUITE_OUTPUT" 2>&1 || SUITE_EXIT=$?
+          timeout "${SUITE_TIMEOUT_SECS}" bash "$script" > "$SUITE_OUTPUT" 2>&1 || SUITE_EXIT=$?
           SUITE_END=$(date +%s)
           SUITE_DURATION=$((SUITE_END - SUITE_START))
 
           # timeout(1) returns 124 when the command is killed by the timer
           TIMEOUT_EXIT_CODE=124
           if [ "$SUITE_EXIT" -eq "$TIMEOUT_EXIT_CODE" ]; then
-            echo -e "    ${RED}⏱  TIMEOUT${NC} after ${PLAYWRIGHT_SUITE_TIMEOUT_SECS}s"
-            echo "Suite killed after ${PLAYWRIGHT_SUITE_TIMEOUT_SECS}s wall-clock timeout" >> "$SUITE_OUTPUT"
+            echo -e "    ${RED}⏱  TIMEOUT${NC} after ${SUITE_TIMEOUT_SECS}s"
+            echo "Suite killed after ${SUITE_TIMEOUT_SECS}s wall-clock timeout" >> "$SUITE_OUTPUT"
           fi
 
           if [ "$SUITE_EXIT" -eq 0 ]; then

--- a/web/src/components/cards/ResourceTrend.tsx
+++ b/web/src/components/cards/ResourceTrend.tsx
@@ -180,15 +180,13 @@ export function ResourceTrend() {
     }
   }, [currentTotals, history.length])
 
-  if (isLoading && history.length === 0) {
-    return (
-      <div className="h-full flex items-center justify-center">
-        <div className="animate-pulse text-muted-foreground">Loading resources...</div>
-      </div>
-    )
-  }
-
   // Get visible lines based on view
+  // IMPORTANT: this runs unconditionally before any early return so the
+  // hook order below (useMemo for chartOption) stays stable across renders.
+  // Moving the early return above this block caused React error #310
+  // ("Rendered more hooks than during the previous render") when the
+  // loading state flipped, because the useMemo below was skipped on the
+  // first render and then called on later renders.
   const getLines = () => {
     switch (view) {
       case 'compute':
@@ -255,6 +253,15 @@ export function ResourceTrend() {
       itemStyle: { color: line.color },
     })),
   }), [history, lines])
+
+  // Loading gate — runs AFTER all hooks to keep hook order stable (React #310).
+  if (isLoading && history.length === 0) {
+    return (
+      <div className="h-full flex items-center justify-center">
+        <div className="animate-pulse text-muted-foreground">Loading resources...</div>
+      </div>
+    )
+  }
 
   return (
     <div className="h-full flex flex-col">

--- a/web/src/pages/AllCardsPerfTest.tsx
+++ b/web/src/pages/AllCardsPerfTest.tsx
@@ -2,6 +2,12 @@ import React, { useEffect, useMemo } from 'react'
 import { CardWrapper } from '../components/cards/CardWrapper'
 import { DEMO_DATA_CARDS, getCardComponent, getRegisteredCardTypes } from '../components/cards/cardRegistry'
 import { formatCardTitle } from '../lib/formatCardTitle'
+// Some card types (ACMM Level, ACMM Recommendations, ACMM Feedback Loops)
+// call useACMM() and will throw "useACMM must be used within an ACMMProvider"
+// if rendered outside the normal /acmm route. The perf test harness
+// renders EVERY registered card type, so we wrap the whole page in
+// ACMMProvider to avoid spurious render crashes.
+import { ACMMProvider } from '../components/acmm/ACMMProvider'
 
 const DEFAULT_BATCH_SIZE = 24
 
@@ -100,48 +106,50 @@ export function AllCardsPerfTest() {
   }, [allCardTypes, batch, batchSize, selected])
 
   return (
-    <div className="p-4">
-      <div
-        data-testid="ttfi-manifest"
-        data-ttfi-total-cards={allCardTypes.length}
-        data-ttfi-batch={batch}
-        data-ttfi-batch-size={batchSize}
-        data-ttfi-selected={selected.length}
-        className="mb-4 text-xs text-muted-foreground"
-      >
-        all-cards batch {batch + 1} / {Math.max(1, Math.ceil(allCardTypes.length / batchSize))}
-      </div>
+    <ACMMProvider>
+      <div className="p-4">
+        <div
+          data-testid="ttfi-manifest"
+          data-ttfi-total-cards={allCardTypes.length}
+          data-ttfi-batch={batch}
+          data-ttfi-batch-size={batchSize}
+          data-ttfi-selected={selected.length}
+          className="mb-4 text-xs text-muted-foreground"
+        >
+          all-cards batch {batch + 1} / {Math.max(1, Math.ceil(allCardTypes.length / batchSize))}
+        </div>
 
-      <div className="grid grid-cols-1 md:grid-cols-12 gap-4 auto-rows-[minmax(180px,auto)]">
-        {selected.map((item) => {
-          const CardComponent = getCardComponent(item.cardType)
-          const title = formatCardTitle(item.cardType)
+        <div className="grid grid-cols-1 md:grid-cols-12 gap-4 auto-rows-[minmax(180px,auto)]">
+          {selected.map((item) => {
+            const CardComponent = getCardComponent(item.cardType)
+            const title = formatCardTitle(item.cardType)
 
-          return (
-            <div key={item.cardId} className="md:col-span-4">
-              <CardWrapper
-                cardId={item.cardId}
-                cardType={item.cardType}
-                title={title}
-                isDemoData={DEMO_DATA_CARDS.has(item.cardType)}
-                isRefreshing={false}
-                skeletonType="status"
-                skeletonRows={4}
-              >
-                <CardErrorBoundary cardType={item.cardType}>
-                  {CardComponent ? (
-                    <CardComponent config={{ perfMode: true }} />
-                  ) : (
-                    <div data-testid={`ttfi-missing-${item.cardType}`} className="text-xs text-yellow-300">
-                      Missing card component: {item.cardType}
-                    </div>
-                  )}
-                </CardErrorBoundary>
-              </CardWrapper>
-            </div>
-          )
-        })}
+            return (
+              <div key={item.cardId} className="md:col-span-4">
+                <CardWrapper
+                  cardId={item.cardId}
+                  cardType={item.cardType}
+                  title={title}
+                  isDemoData={DEMO_DATA_CARDS.has(item.cardType)}
+                  isRefreshing={false}
+                  skeletonType="status"
+                  skeletonRows={4}
+                >
+                  <CardErrorBoundary cardType={item.cardType}>
+                    {CardComponent ? (
+                      <CardComponent config={{ perfMode: true }} />
+                    ) : (
+                      <div data-testid={`ttfi-missing-${item.cardType}`} className="text-xs text-yellow-300">
+                        Missing card component: {item.cardType}
+                      </div>
+                    )}
+                  </CardErrorBoundary>
+                </CardWrapper>
+              </div>
+            )
+          })}
+        </div>
       </div>
-    </div>
+    </ACMMProvider>
   )
 }

--- a/web/src/pages/CompliancePerfTest.tsx
+++ b/web/src/pages/CompliancePerfTest.tsx
@@ -3,6 +3,12 @@ import { useSearchParams } from 'react-router-dom'
 import { CardWrapper } from '../components/cards/CardWrapper'
 import { DEMO_DATA_CARDS, getCardComponent, getRegisteredCardTypes } from '../components/cards/cardRegistry'
 import { formatCardTitle } from '../lib/formatCardTitle'
+// Some card types (ACMM Level, ACMM Recommendations, ACMM Feedback Loops)
+// call useACMM() and will throw "useACMM must be used within an ACMMProvider"
+// if rendered outside the normal /acmm route. The compliance test harness
+// renders EVERY registered card type, so we wrap the whole page in
+// ACMMProvider to avoid spurious render crashes (issues #8984, #8985).
+import { ACMMProvider } from '../components/acmm/ACMMProvider'
 
 const DEFAULT_BATCH_SIZE = 24
 
@@ -104,48 +110,50 @@ export function CompliancePerfTest() {
     selected }
 
   return (
-    <div className="p-4">
-      <div
-        data-testid="compliance-manifest"
-        data-compliance-total-cards={allCardTypes.length}
-        data-compliance-batch={batch}
-        data-compliance-batch-size={batchSize}
-        data-compliance-selected={selected.length}
-        className="mb-4 text-xs text-muted-foreground"
-      >
-        compliance batch {batch + 1} / {Math.max(1, Math.ceil(allCardTypes.length / batchSize))}
-      </div>
+    <ACMMProvider>
+      <div className="p-4">
+        <div
+          data-testid="compliance-manifest"
+          data-compliance-total-cards={allCardTypes.length}
+          data-compliance-batch={batch}
+          data-compliance-batch-size={batchSize}
+          data-compliance-selected={selected.length}
+          className="mb-4 text-xs text-muted-foreground"
+        >
+          compliance batch {batch + 1} / {Math.max(1, Math.ceil(allCardTypes.length / batchSize))}
+        </div>
 
-      <div className="grid grid-cols-1 md:grid-cols-12 gap-4 auto-rows-[minmax(180px,auto)]">
-        {selected.map((item) => {
-          const CardComponent = getCardComponent(item.cardType)
-          const title = formatCardTitle(item.cardType)
+        <div className="grid grid-cols-1 md:grid-cols-12 gap-4 auto-rows-[minmax(180px,auto)]">
+          {selected.map((item) => {
+            const CardComponent = getCardComponent(item.cardType)
+            const title = formatCardTitle(item.cardType)
 
-          return (
-            <div key={item.cardId} className="md:col-span-4">
-              <CardWrapper
-                cardId={item.cardId}
-                cardType={item.cardType}
-                title={title}
-                isDemoData={DEMO_DATA_CARDS.has(item.cardType)}
-                isRefreshing={false}
-                skeletonType="status"
-                skeletonRows={4}
-              >
-                <CardErrorBoundary cardType={item.cardType}>
-                  {CardComponent ? (
-                    <CardComponent config={{ perfMode: true }} />
-                  ) : (
-                    <div data-testid={`compliance-missing-${item.cardType}`} className="text-xs text-yellow-300">
-                      Missing card component: {item.cardType}
-                    </div>
-                  )}
-                </CardErrorBoundary>
-              </CardWrapper>
-            </div>
-          )
-        })}
+            return (
+              <div key={item.cardId} className="md:col-span-4">
+                <CardWrapper
+                  cardId={item.cardId}
+                  cardType={item.cardType}
+                  title={title}
+                  isDemoData={DEMO_DATA_CARDS.has(item.cardType)}
+                  isRefreshing={false}
+                  skeletonType="status"
+                  skeletonRows={4}
+                >
+                  <CardErrorBoundary cardType={item.cardType}>
+                    {CardComponent ? (
+                      <CardComponent config={{ perfMode: true }} />
+                    ) : (
+                      <div data-testid={`compliance-missing-${item.cardType}`} className="text-xs text-yellow-300">
+                        Missing card component: {item.cardType}
+                      </div>
+                    )}
+                  </CardErrorBoundary>
+                </CardWrapper>
+              </div>
+            )
+          })}
+        </div>
       </div>
-    </div>
+    </ACMMProvider>
   )
 }


### PR DESCRIPTION
## Summary

Recovers five nightly regression suites that auto-fired from run 24622826282:

- `console-error-scan` (#8981) — 38+ route scans at ~5s settle were right at the 300s per-suite cap.
- `ui-compliance-test` (#8984) and `cache-test` (#8985) — `/__compliance/all-cards` renders every registered card, including ACMM cards that throw `useACMM must be used within an ACMMProvider` outside `/acmm`. The crash also uncovered a hook-order bug in `ResourceTrend` (React error #310) where a loading early-return ran before `useMemo(chartOption)`.
- `benchmark-test` (#8986) and `ai-ml-test` (#8987) — per-test budgets inside these suites exceed 300s in worst cases, so the outer suite cap was killing them before their own retries completed.

## Changes

- `web/src/pages/CompliancePerfTest.tsx`, `web/src/pages/AllCardsPerfTest.tsx` — wrap the card grid in `<ACMMProvider>` so ACMM-dependent cards have the context they need when rendered outside `/acmm`.
- `web/src/components/cards/ResourceTrend.tsx` — move the `isLoading` early return below all hooks so hook order stays stable across renders (React #310 fix).
- `scripts/run-all-tests.sh` — add `PLAYWRIGHT_SUITE_TIMEOUT_OVERRIDES` associative array. Default stays at 300s so a genuinely hung suite still fails fast; the five heavy suites above get 600s.

Fixes #8981, Fixes #8984, Fixes #8985, Fixes #8986, Fixes #8987

## Test plan

- [x] `npm run build` passes (flock-guarded)
- [x] `npx tsc --noEmit` clean
- [ ] Nightly workflow next run — all five suites should move to PASS
- [ ] Compliance/perf harness loads in preview without ACMM-provider console errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)