### PR TITLE
🐛 : Fix inconsistent K8s name validation in GitOps handlers

### DIFF
--- a/pkg/api/handlers/gitops.go
+++ b/pkg/api/handlers/gitops.go
@@ -263,6 +263,13 @@ func (h *GitOpsHandlers) ListDrifts(c *fiber.Ctx) error {
 func (h *GitOpsHandlers) ListHelmReleases(c *fiber.Ctx) error {
 	cluster := c.Query("cluster")
 
+	// SECURITY: Validate cluster name before passing to helm CLI
+	if cluster != "" {
+		if err := validateK8sName(cluster, "cluster"); err != nil {
+			return c.Status(400).JSON(fiber.Map{"error": err.Error()})
+		}
+	}
+
 	// If specific cluster requested, query only that cluster
 	if cluster != "" {
 		return h.listHelmReleasesForCluster(c, cluster)
@@ -352,6 +359,13 @@ func (h *GitOpsHandlers) getHelmReleasesForCluster(ctx context.Context, cluster 
 // ListKustomizations returns Flux Kustomization resources
 func (h *GitOpsHandlers) ListKustomizations(c *fiber.Ctx) error {
 	cluster := c.Query("cluster")
+
+	// SECURITY: Validate cluster name before passing to kubectl CLI
+	if cluster != "" {
+		if err := validateK8sName(cluster, "cluster"); err != nil {
+			return c.Status(400).JSON(fiber.Map{"error": err.Error()})
+		}
+	}
 
 	// If specific cluster requested, query only that cluster
 	if cluster != "" {
@@ -538,6 +552,13 @@ var (
 // ListOperators returns OLM-managed operators (ClusterServiceVersions)
 func (h *GitOpsHandlers) ListOperators(c *fiber.Ctx) error {
 	cluster := c.Query("cluster")
+
+	// SECURITY: Validate cluster name before passing to kubectl CLI
+	if cluster != "" {
+		if err := validateK8sName(cluster, "cluster"); err != nil {
+			return c.Status(400).JSON(fiber.Map{"error": err.Error()})
+		}
+	}
 
 	// If specific cluster requested, query only that cluster
 	if cluster != "" {
@@ -944,6 +965,13 @@ func (h *GitOpsHandlers) fetchOperatorsFromCluster(ctx context.Context, cluster 
 // ListOperatorSubscriptions returns OLM subscriptions across clusters
 func (h *GitOpsHandlers) ListOperatorSubscriptions(c *fiber.Ctx) error {
 	cluster := c.Query("cluster")
+
+	// SECURITY: Validate cluster name before passing to kubectl CLI
+	if cluster != "" {
+		if err := validateK8sName(cluster, "cluster"); err != nil {
+			return c.Status(400).JSON(fiber.Map{"error": err.Error()})
+		}
+	}
 
 	if cluster != "" {
 		ctx, cancel := context.WithTimeout(c.Context(), subscriptionPerClusterTimeout)


### PR DESCRIPTION
Add cluster name validation to 4 GitOps handlers before passing cluster names to helm/kubectl CLI tools, matching the security pattern used by GetHelmHistory and GetHelmValues.

- ListHelmReleases: validate cluster before helm --kube-context
- ListKustomizations: validate cluster before kubectl --context
- ListOperators: validate cluster before kubectl --context
- ListOperatorSubscriptions: validate cluster before kubectl --context

All handlers now use validateK8sName to reject malformed input, preventing potential injection attacks and ensuring consistent behavior across all GitOps endpoints.

Fixes security anti-pattern where some handlers validated cluster names while others did not.

### 📌 Fixes

Fixes #9020 

---

### Changes Made

<!-- Provide a detailed list of changes made in this PR. -->

- [ ] Updated ...
- [ ] Refactored ...
- [x] Fixed ...
- [ ] Added tests for ...

---

### Checklist

Please ensure the following before submitting your PR:

- [x] I used a coding agent (Claude Code, Copilot, Gemini, or Codex) to generate/review this code
- [x] I have reviewed the project's contribution guidelines
- [ ] New cards target [console-marketplace](https://github.com/kubestellar/console-marketplace), not this repo
- [ ] isDemoData is wired correctly (cards show Demo badge when using demo data)
- [ ] I have written unit tests for the changes (if applicable)
- [x] I have tested the changes locally and ensured they work as expected
- [x] All commits are signed with DCO (`git commit -s`)

---

### Screenshots or Logs (if applicable)

<!-- Add any relevant screenshots or logs to help visualize/test the changes. -->

---

### 👀 Reviewer Notes

_Add any special notes for the reviewer here_
