### PR TITLE
🐛 : Fix path traversal vulnerability in GitOps handlers

### DIFF
--- a/pkg/agent/server_gitops.go
+++ b/pkg/agent/server_gitops.go
@@ -120,6 +120,35 @@ func validateGitopsBranchName(branch string) error {
 	return nil
 }
 
+// validateGitopsPath validates a repository path parameter.
+// SECURITY: Prevents path traversal attacks and flag injection.
+func validateGitopsPath(path string) error {
+	if path == "" {
+		return nil // Empty path is OK - refers to repo root
+	}
+	// Block null bytes
+	if strings.ContainsRune(path, 0) {
+		return fmt.Errorf("path contains null bytes")
+	}
+	// Only allow alphanumeric, -, _, /, . (common in git repo paths)
+	for _, char := range path {
+		if !((char >= 'a' && char <= 'z') ||
+			(char >= 'A' && char <= 'Z') ||
+			(char >= '0' && char <= '9') ||
+			char == '-' || char == '_' || char == '/' || char == '.') {
+			return fmt.Errorf("invalid character in path: %c", char)
+		}
+	}
+	// Block dangerous patterns
+	if strings.HasPrefix(path, "-") {
+		return fmt.Errorf("path cannot start with '-'")
+	}
+	if strings.Contains(path, "..") {
+		return fmt.Errorf("path traversal (..) is not allowed")
+	}
+	return nil
+}
+
 // gitopsCloneRepo mirrors the backend cloneRepo helper.
 func gitopsCloneRepo(ctx context.Context, repoURL, branch string) (string, error) {
 	if err := validateGitopsRepoURL(repoURL); err != nil {
@@ -318,6 +347,13 @@ func (s *Server) handleDetectDrift(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
+	// Validate path parameter to prevent path traversal attacks.
+	if err := validateGitopsPath(req.Path); err != nil {
+		w.WriteHeader(http.StatusBadRequest)
+		writeJSON(w, map[string]string{"error": fmt.Sprintf("invalid path: %v", err)})
+		return
+	}
+
 	ctx, cancel := context.WithTimeout(r.Context(), gitopsDefaultTimeout)
 	defer cancel()
 
@@ -426,6 +462,13 @@ func (s *Server) handleGitopsSync(w http.ResponseWriter, r *http.Request) {
 			writeJSON(w, map[string]string{"error": fmt.Sprintf("invalid %s: %v", field, err)})
 			return
 		}
+	}
+
+	// Validate path parameter to prevent path traversal attacks.
+	if err := validateGitopsPath(req.Path); err != nil {
+		w.WriteHeader(http.StatusBadRequest)
+		writeJSON(w, map[string]string{"error": fmt.Sprintf("invalid path: %v", err)})
+		return
 	}
 
 	ctx, cancel := context.WithTimeout(r.Context(), gitopsDefaultTimeout)

--- a/pkg/api/handlers/gitops.go
+++ b/pkg/api/handlers/gitops.go
@@ -1388,6 +1388,11 @@ func (h *GitOpsHandlers) detectDriftViaKubectl(ctx context.Context, req DetectDr
 		}
 	}
 
+	// Validate path parameter to prevent path traversal attacks
+	if err := validatePath(req.Path); err != nil {
+		return nil, fmt.Errorf("invalid path: %w", err)
+	}
+
 	// Clone the repo to a temp directory
 	tempDir, err := cloneRepo(ctx, req.RepoURL, req.Branch)
 	if err != nil {
@@ -1519,6 +1524,11 @@ func (h *GitOpsHandlers) syncViaKubectl(ctx context.Context, req SyncRequest) (*
 		if err := validateK8sName(val, field); err != nil {
 			return nil, fmt.Errorf("invalid %s: %w", field, err)
 		}
+	}
+
+	// Validate path parameter to prevent path traversal attacks
+	if err := validatePath(req.Path); err != nil {
+		return nil, fmt.Errorf("invalid path: %w", err)
 	}
 
 	// Clone the repo
@@ -1715,6 +1725,35 @@ func validateBranchName(branch string) error {
 		return fmt.Errorf("branch name cannot contain '..'")
 	}
 
+	return nil
+}
+
+// validatePath validates a repository path parameter.
+// SECURITY: Prevents path traversal attacks and flag injection.
+func validatePath(path string) error {
+	if path == "" {
+		return nil // Empty path is OK - refers to repo root
+	}
+	// Block null bytes
+	if strings.ContainsRune(path, 0) {
+		return fmt.Errorf("path contains null bytes")
+	}
+	// Only allow alphanumeric, -, _, /, . (common in git repo paths)
+	for _, char := range path {
+		if !((char >= 'a' && char <= 'z') ||
+			(char >= 'A' && char <= 'Z') ||
+			(char >= '0' && char <= '9') ||
+			char == '-' || char == '_' || char == '/' || char == '.') {
+			return fmt.Errorf("invalid character in path: %c", char)
+		}
+	}
+	// Block dangerous patterns
+	if strings.HasPrefix(path, "-") {
+		return fmt.Errorf("path cannot start with '-'")
+	}
+	if strings.Contains(path, "..") {
+		return fmt.Errorf("path traversal (..) is not allowed")
+	}
 	return nil
 }
 


### PR DESCRIPTION
## Summary

Add validation for 
eq.Path parameter to prevent path traversal attacks via ../ sequences. The vulnerability allowed checking files outside the temp directory in isKustomizeDir function.

## Fixes - #9023 

## Changes

- Add alidateGitopsPath in pkg/agent/server_gitops.go
- Add alidatePath in pkg/api/handlers/gitops.go
- Call validation in handleDetectDrift and handleGitopsSync (agent)
- Call validation in detectDriftViaKubectl and syncViaKubectl (backend)
- Blocks .., null bytes, and dangerous characters
- Follows existing validation patterns (alidateBranchName)

## Security Impact

Prevents path traversal attacks that could allow checking file existence outside the intended temp directory. The fix is applied to both agent and backend handlers for defense-in-depth.

## Testing

- Both packages build successfully
- Validation is called before path construction in all 4 vulnerable locations
- No breaking changes to existing functionality