### PR TITLE
✨ : Add Audit Logging for Auth Events

### DIFF
--- a/pkg/api/audit/audit.go
+++ b/pkg/api/audit/audit.go
@@ -14,8 +14,8 @@ import (
 	"sync"
 
 	"github.com/gofiber/fiber/v2"
+	"github.com/google/uuid"
 
-	"github.com/kubestellar/console/pkg/api/middleware"
 	"github.com/kubestellar/console/pkg/store"
 )
 
@@ -36,6 +36,11 @@ const (
 	ActionDeleteToken            = "delete_token"
 	ActionCreateResourceQuota    = "create_resource_quota"
 	ActionDeleteResourceQuota    = "delete_resource_quota"
+
+	// Authentication events
+	ActionUserLogin  = "user_login"
+	ActionUserLogout = "user_logout"
+	ActionAuthFailed = "auth_failed"
 )
 
 // storeMu guards the package-level store reference.
@@ -66,7 +71,8 @@ func getStore() store.Store {
 // Store write failures are logged but never propagated to the caller — audit
 // persistence is best-effort so it cannot break request handling.
 func Log(c *fiber.Ctx, action, targetType, targetID string, details ...string) {
-	userID := middleware.GetUserID(c)
+	// Inline GetUserID logic to avoid circular dependency with middleware package
+	userID, _ := c.Locals("userID").(uuid.UUID)
 	ip := c.IP()
 
 	attrs := []any{

--- a/pkg/api/handlers/auth.go
+++ b/pkg/api/handlers/auth.go
@@ -18,6 +18,7 @@ import (
 
 	"golang.org/x/oauth2"
 
+	"github.com/kubestellar/console/pkg/api/audit"
 	"github.com/kubestellar/console/pkg/api/middleware"
 	"github.com/kubestellar/console/pkg/models"
 	"github.com/kubestellar/console/pkg/store"
@@ -388,6 +389,7 @@ func (h *AuthHandler) devModeLogin(c *fiber.Ctx) error {
 	// to prevent leakage via browser history, Referer headers, and server logs (#4278).
 	// The frontend reads the token from the cookie via POST /auth/refresh.
 	h.setJWTCookie(c, jwtToken)
+	audit.Log(c, audit.ActionUserLogin, "user", user.ID.String(), user.GitHubLogin)
 
 	c.Set("Cache-Control", "no-store")
 	redirectURL := fmt.Sprintf("%s/auth/callback?onboarded=%t", h.frontendURL, user.Onboarded)
@@ -634,6 +636,7 @@ func (h *AuthHandler) GitHubCallback(c *fiber.Ctx) error {
 	// to prevent leakage via browser history, Referer headers, and server logs (#4278).
 	// The frontend reads the token from the cookie via POST /auth/refresh.
 	h.setJWTCookie(c, jwtToken)
+	audit.Log(c, audit.ActionUserLogin, "user", user.ID.String(), user.GitHubLogin)
 	slog.Info("[Auth] OAuth callback complete", "user", user.GitHubLogin, "frontendURL", h.frontendURL)
 
 	c.Set("Cache-Control", "no-store")
@@ -726,6 +729,7 @@ func (h *AuthHandler) Logout(c *fiber.Ctx) error {
 		CancelUserSSEStreams(claims.UserID)
 	}
 
+	audit.Log(c, audit.ActionUserLogout, "user", claims.UserID.String(), claims.GitHubLogin)
 	slog.Info("[Auth] token revoked, WS sessions closed", "user", claims.GitHubLogin, "jti", claims.ID)
 	return c.JSON(fiber.Map{"success": true, "message": "Token revoked"})
 }

--- a/pkg/api/middleware/auth.go
+++ b/pkg/api/middleware/auth.go
@@ -11,6 +11,8 @@ import (
 	"github.com/gofiber/fiber/v2"
 	"github.com/golang-jwt/jwt/v5"
 	"github.com/google/uuid"
+
+	"github.com/kubestellar/console/pkg/api/audit"
 )
 
 const (
@@ -428,6 +430,7 @@ func JWTAuth(secret string) fiber.Handler {
 
 		if tokenString == "" {
 			slog.Info("[Auth] missing authorization", "path", c.Path())
+			audit.Log(c, audit.ActionAuthFailed, "endpoint", c.Path(), "missing_authorization")
 			return fiber.NewError(fiber.StatusUnauthorized, "Missing authorization")
 		}
 
@@ -460,17 +463,20 @@ func JWTAuth(secret string) fiber.Handler {
 
 		if err != nil {
 			slog.Error("[Auth] token parse error", "path", c.Path(), "error", err)
+			audit.Log(c, audit.ActionAuthFailed, "endpoint", c.Path(), "token_parse_error")
 			return fiber.NewError(fiber.StatusUnauthorized, "Invalid token")
 		}
 
 		if !token.Valid {
 			slog.Info("[Auth] invalid token", "path", c.Path())
+			audit.Log(c, audit.ActionAuthFailed, "endpoint", c.Path(), "invalid_token")
 			return fiber.NewError(fiber.StatusUnauthorized, "Invalid token")
 		}
 
 		claims, ok := token.Claims.(*UserClaims)
 		if !ok {
 			slog.Info("[Auth] invalid token claims", "path", c.Path())
+			audit.Log(c, audit.ActionAuthFailed, "endpoint", c.Path(), "invalid_claims")
 			return fiber.NewError(fiber.StatusUnauthorized, "Invalid token claims")
 		}
 
@@ -487,6 +493,7 @@ func JWTAuth(secret string) fiber.Handler {
 			}
 			if revoked {
 				slog.Info("[Auth] revoked token used", "path", c.Path())
+				audit.Log(c, audit.ActionAuthFailed, "endpoint", c.Path(), "revoked_token")
 				return fiber.NewError(fiber.StatusUnauthorized, "Token has been revoked")
 			}
 		}


### PR DESCRIPTION
## Feature Description
Add three audit log calls to track authentication events: successful logins, logouts, and failed authentication attempts.

## Changes
- Add action constants: ActionUserLogin, ActionUserLogout, ActionAuthFailed
- Add login audit in GitHubCallback and devModeLogin handlers
- Add logout audit in Logout handler  
- Add auth failure audits in JWTAuth middleware (5 failure points: missing authorization, token parse error, invalid token, invalid claims, revoked token)
- Inline GetUserID logic in audit.Log to avoid circular dependency

## Fixes - #9025

## Security Value
Security monitoring and compliance require tracking authentication events. Currently, the audit system logs role changes, user deletions, and unauthorized attempts, but lacks visibility into login/logout events and auth failures. This implementation provides high security value for detecting compromised accounts and meeting compliance requirements (SOC2, HIPAA).

## Implementation
Leverages existing audit infrastructure (SQLite, slog, admin endpoint) already used 18+ times across the codebase. Three function calls, no new dependencies, follows established patterns. Audit writes are failure-tolerant and won't break request handling.

## Testing
Build passed: \go build ./...\ succeeded. No circular dependencies. Follows existing audit.Log patterns.