### PR TITLE
🐛 : Fix XSS vulnerabilities in ReactMarkdown components

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -77,6 +77,7 @@
     "react-is": "^19.2.5",
     "react-markdown": "^10.1.0",
     "react-router-dom": "^7.13.1",
+    "rehype-sanitize": "^6.0.0",
     "remark-breaks": "^4.0.0",
     "remark-gfm": "^4.0.1",
     "sucrase": "^3.35.1",

--- a/web/src/components/layout/mission-sidebar/MemoizedMessage.tsx
+++ b/web/src/components/layout/mission-sidebar/MemoizedMessage.tsx
@@ -9,6 +9,7 @@ import {
 import ReactMarkdown from 'react-markdown'
 import remarkGfm from 'remark-gfm'
 import remarkBreaks from 'remark-breaks'
+import rehypeSanitize from 'rehype-sanitize'
 import { cn } from '../../../lib/cn'
 import { AgentIcon } from '../../agent/AgentIcon'
 import { buildReleaseNotesComponents } from '../../../lib/markdown/releaseNotesComponents'
@@ -104,14 +105,14 @@ export const MemoizedMessage = memo(function MemoizedMessage({ msg, missionAgent
             <div className="space-y-4">
               {parsedContent.before && (
                 <div className={proseClasses}>
-                  <ReactMarkdown remarkPlugins={[remarkGfm, remarkBreaks]} components={markdownComponents}>
+                  <ReactMarkdown remarkPlugins={[remarkGfm, remarkBreaks]} rehypePlugins={[rehypeSanitize]} components={markdownComponents}>
                     {parsedContent.before.replace(/\r\n/g, '\n')}
                   </ReactMarkdown>
                 </div>
               )}
               <div className="mt-4 p-3 rounded-lg bg-purple-500/10 border border-purple-500/30">
                 <div className={cn(proseClasses, "text-purple-700 dark:text-purple-200")}>
-                  <ReactMarkdown remarkPlugins={[remarkGfm, remarkBreaks]} components={markdownComponents}>
+                  <ReactMarkdown remarkPlugins={[remarkGfm, remarkBreaks]} rehypePlugins={[rehypeSanitize]} components={markdownComponents}>
                     {parsedContent.request.replace(/\r\n/g, '\n')}
                   </ReactMarkdown>
                 </div>
@@ -119,7 +120,7 @@ export const MemoizedMessage = memo(function MemoizedMessage({ msg, missionAgent
             </div>
           ) : (
             <div className={proseClasses}>
-              <ReactMarkdown remarkPlugins={[remarkGfm, remarkBreaks]} components={markdownComponents}>
+              <ReactMarkdown remarkPlugins={[remarkGfm, remarkBreaks]} rehypePlugins={[rehypeSanitize]} components={markdownComponents}>
                 {msg.content.replace(/\r\n/g, '\n')}
               </ReactMarkdown>
             </div>

--- a/web/src/components/mission-control/ClusterAssignmentPanel.tsx
+++ b/web/src/components/mission-control/ClusterAssignmentPanel.tsx
@@ -10,6 +10,7 @@ import { Loader2, Wand2, Shuffle, LayoutGrid, Table } from 'lucide-react'
 import { motion } from 'framer-motion'
 import ReactMarkdown from 'react-markdown'
 import remarkGfm from 'remark-gfm'
+import rehypeSanitize from 'rehype-sanitize'
 import { Button } from '../ui/Button'
 import { ClusterReadinessCard } from './ClusterReadinessCard'
 import { AssignmentMatrix } from './AssignmentMatrix'
@@ -125,7 +126,8 @@ export function ClusterAssignmentPanel({
         storageGB: c.storageGB,
         cpuUsageCores: c.cpuUsageCores,
         memoryUsageGB: c.memoryUsageGB,
-        namespaces: c.namespaces?.length ?? 0 })),
+        namespaces: c.namespaces?.length ?? 0
+      })),
       null,
       2
     )
@@ -243,36 +245,37 @@ export function ClusterAssignmentPanel({
                 // Merge helm-generated notes with AI warnings (dedupe by checking if AI already mentions the project)
                 const mergedAssignment = aiAssignment && helmNotes.length > 0
                   ? {
-                      ...aiAssignment,
-                      warnings: [
-                        ...helmNotes.filter(note => {
-                          // Don't add helm note if AI already has a warning about the same project
-                          const aiWarnings = aiAssignment.warnings ?? []
-                          return !aiWarnings.some(w => {
-                            // Compare by checking if both mention the same project name
-                            const noteProject = note.split(' already')[0].toLowerCase()
-                            return w.toLowerCase().includes(noteProject)
-                          })
-                        }),
-                        ...(aiAssignment.warnings ?? []),
-                      ] }
+                    ...aiAssignment,
+                    warnings: [
+                      ...helmNotes.filter(note => {
+                        // Don't add helm note if AI already has a warning about the same project
+                        const aiWarnings = aiAssignment.warnings ?? []
+                        return !aiWarnings.some(w => {
+                          // Compare by checking if both mention the same project name
+                          const noteProject = note.split(' already')[0].toLowerCase()
+                          return w.toLowerCase().includes(noteProject)
+                        })
+                      }),
+                      ...(aiAssignment.warnings ?? []),
+                    ]
+                  }
                   : aiAssignment
                 return (
-                <div key={cluster.name} data-testid={`mission-control-cluster-${cluster.name}`}>
-                <ClusterReadinessCard
-                  cluster={cluster}
-                  assignment={mergedAssignment}
-                  onToggleProject={(name, assigned) =>
-                    onSetAssignment(cluster.name, name, assigned)
-                  }
-                  availableProjects={projectNames}
-                  isRecommended={state.assignments.some(
-                    (a) => a.clusterName === cluster.name && a.projectNames.length > 0
-                  )}
-                  installedOnCluster={installedOnCluster}
-                  projects={state.projects}
-                />
-                </div>
+                  <div key={cluster.name} data-testid={`mission-control-cluster-${cluster.name}`}>
+                    <ClusterReadinessCard
+                      cluster={cluster}
+                      assignment={mergedAssignment}
+                      onToggleProject={(name, assigned) =>
+                        onSetAssignment(cluster.name, name, assigned)
+                      }
+                      availableProjects={projectNames}
+                      isRecommended={state.assignments.some(
+                        (a) => a.clusterName === cluster.name && a.projectNames.length > 0
+                      )}
+                      installedOnCluster={installedOnCluster}
+                      projects={state.projects}
+                    />
+                  </div>
                 )
               })}
             </div>
@@ -352,7 +355,7 @@ function AIAssignmentStreamPreview({ planningMission }: { planningMission?: Miss
         className="px-4 py-3 max-h-40 overflow-y-auto text-xs text-foreground/80 leading-relaxed prose prose-invert prose-xs max-w-none [&_ul]:my-1 [&_ol]:my-1 [&_li]:my-0.5 [&_p]:my-1 [&_strong]:text-foreground/90"
       >
         {displayText ? (
-          <ReactMarkdown remarkPlugins={[remarkGfm]}>
+          <ReactMarkdown remarkPlugins={[remarkGfm]} rehypePlugins={[rehypeSanitize]}>
             {displayText}
           </ReactMarkdown>
         ) : (

--- a/web/src/components/mission-control/FixerDefinitionPanel.tsx
+++ b/web/src/components/mission-control/FixerDefinitionPanel.tsx
@@ -16,6 +16,7 @@ import { fetchMissionContent } from '../missions/browser/missionCache'
 import type { MissionExport } from '../../lib/missions/types'
 import ReactMarkdown from 'react-markdown'
 import remarkGfm from 'remark-gfm'
+import rehypeSanitize from 'rehype-sanitize'
 import { cn } from '../../lib/cn'
 import { useGlobalFilters } from '../../hooks/useGlobalFilters'
 import { useModalState } from '../../lib/modals'
@@ -85,7 +86,8 @@ export function FixerDefinitionPanel({
       reason: 'Manually added',
       category: 'Custom',
       priority: 'recommended',
-      dependencies: [] })
+      dependencies: []
+    })
     setManualName('')
     setShowManualAdd(false)
   }
@@ -122,7 +124,8 @@ export function FixerDefinitionPanel({
   const priorityCounts = {
     required: state.projects.filter((p) => p.priority === 'required').length,
     recommended: state.projects.filter((p) => p.priority === 'recommended').length,
-    optional: state.projects.filter((p) => p.priority === 'optional').length }
+    optional: state.projects.filter((p) => p.priority === 'optional').length
+  }
 
   const totalDeps = new Set(state.projects.flatMap((p) => p.dependencies)).size
 
@@ -402,11 +405,11 @@ function ExecutiveAnalysis({
   projects,
   missionTitle,
   missionDescription }: {
-  aiContent: string
-  projects: PayloadProject[]
-  missionTitle: string
-  missionDescription: string
-}) {
+    aiContent: string
+    projects: PayloadProject[]
+    missionTitle: string
+    missionDescription: string
+  }) {
   const [expanded, setExpanded] = useState(true)
 
   // Extract the non-JSON text from the AI response
@@ -453,6 +456,7 @@ function ExecutiveAnalysis({
               <div className="text-xs text-foreground/80 leading-relaxed prose prose-invert prose-xs max-w-none [&_table]:text-[10px] [&_th]:px-2 [&_th]:py-1 [&_td]:px-2 [&_td]:py-1 [&_table]:border-collapse [&_th]:border [&_th]:border-border/30 [&_td]:border [&_td]:border-border/30 [&_th]:bg-secondary/50 [&_ul]:my-1 [&_ol]:my-1 [&_li]:my-0.5 [&_p]:my-1.5 [&_h1]:text-sm [&_h2]:text-xs [&_h3]:text-xs [&_h4]:text-[11px] [&_strong]:text-foreground/90 [&_code]:text-[10px] [&_code]:bg-secondary/60 [&_code]:px-1 [&_code]:rounded">
                 <ReactMarkdown
                   remarkPlugins={[remarkGfm]}
+                  rehypePlugins={[rehypeSanitize]}
                   components={{
                     td: ({ children, ...props }) => {
                       const raw = String(children ?? '')
@@ -474,7 +478,8 @@ function ExecutiveAnalysis({
                         indicator = <span className="inline-block w-2 h-2 rounded-full bg-emerald-400 mr-1.5 align-middle" />
                       }
                       return <td {...props}>{indicator}{displayChildren}</td>
-                    } }}
+                    }
+                  }}
                 >
                   {analysisText}
                 </ReactMarkdown>
@@ -616,7 +621,8 @@ const ALTERNATIVES: Record<string, { name: string; displayName: string; reason: 
   calico: [
     { name: 'cilium', displayName: 'Cilium', reason: 'eBPF-based networking and security' },
     { name: 'antrea', displayName: 'Antrea', reason: 'Kubernetes-native CNI using Open vSwitch' },
-  ] }
+  ]
+}
 
 /** Display info for original projects when swapping back */
 const ALTERNATIVES_DISPLAY: Record<string, { displayName: string; reason: string }> = {
@@ -628,16 +634,17 @@ const ALTERNATIVES_DISPLAY: Record<string, { displayName: string; reason: string
   prometheus: { displayName: 'Prometheus', reason: 'CNCF monitoring and alerting toolkit' },
   cilium: { displayName: 'Cilium', reason: 'eBPF-based networking and security' },
   'cert-manager': { displayName: 'cert-manager', reason: 'Automated TLS certificate management' },
-  'trivy-operator': { displayName: 'Trivy Operator', reason: 'Aqua vulnerability scanning for Kubernetes' } }
+  'trivy-operator': { displayName: 'Trivy Operator', reason: 'Aqua vulnerability scanning for Kubernetes' }
+}
 
 function ProjectDetailPanel({
   project,
   allProjects,
   onReplace }: {
-  project: PayloadProject
-  allProjects: PayloadProject[]
-  onReplace?: (oldName: string, newProject: PayloadProject) => void
-}) {
+    project: PayloadProject
+    allProjects: PayloadProject[]
+    onReplace?: (oldName: string, newProject: PayloadProject) => void
+  }) {
   const [mission, setMission] = useState<MissionExport | null>(null)
   const [loadingSteps, setLoadingSteps] = useState(false)
   const fetchedRef = useRef<string>('')
@@ -653,10 +660,11 @@ function ProjectDetailPanel({
       type: 'custom',
       tags: [],
       steps: [],
-      metadata: { source: project.kbPath } }
+      metadata: { source: project.kbPath }
+    }
     fetchMissionContent(indexMission)
       .then(({ mission: m }) => setMission(m))
-      .catch(() => {/* ignore */})
+      .catch(() => {/* ignore */ })
       .finally(() => setLoadingSteps(false))
   }, [project.kbPath, project.displayName, project.reason])
 
@@ -675,7 +683,8 @@ function ProjectDetailPanel({
       displayName: ALTERNATIVES_DISPLAY[lookupKey]?.displayName ?? lookupKey,
       reason: ALTERNATIVES_DISPLAY[lookupKey]?.reason ?? 'Original AI recommendation',
       isCurrent: false,
-      isOriginal: true })
+      isOriginal: true
+    })
   }
 
   // Add all known alternatives
@@ -683,7 +692,8 @@ function ProjectDetailPanel({
     allAlts.push({
       ...alt,
       isCurrent: alt.name === project.name,
-      isOriginal: false })
+      isOriginal: false
+    })
   }
 
   // Add the current project to the list if not already present (so user sees "Selected" marker)
@@ -693,7 +703,8 @@ function ProjectDetailPanel({
       displayName: project.displayName,
       reason: project.reason ?? '',
       isCurrent: true,
-      isOriginal: false })
+      isOriginal: false
+    })
   }
 
   // Filter out projects that are already in the payload under a different slot
@@ -717,8 +728,8 @@ function ProjectDetailPanel({
           <span className={cn(
             'text-[10px] px-1.5 py-0.5 rounded-full font-medium',
             project.priority === 'required' ? 'bg-red-500/10 text-red-400' :
-            project.priority === 'recommended' ? 'bg-blue-500/10 text-blue-400' :
-            'bg-gray-500/10 text-gray-400 dark:text-gray-500'
+              project.priority === 'recommended' ? 'bg-blue-500/10 text-blue-400' :
+                'bg-gray-500/10 text-gray-400 dark:text-gray-500'
           )}>
             {project.priority}
           </span>
@@ -824,7 +835,8 @@ function ProjectDetailPanel({
                         reason: alt.reason,
                         category: project.category,
                         priority: project.priority,
-                        dependencies: project.dependencies })}
+                        dependencies: project.dependencies
+                      })}
                       className="text-[10px] px-2 py-0.5 rounded bg-primary/10 text-primary hover:bg-primary/20 transition-colors"
                     >
                       Swap
@@ -858,7 +870,8 @@ const CATEGORY_ICONS: Record<string, React.ReactNode> = {
   'Authentication & IAM': <Lock className="w-3 h-3 text-violet-400" />,
   'Secrets Management': <Lock className="w-3 h-3 text-emerald-400" />,
   'Storage': <Box className="w-3 h-3 text-green-400" />,
-  'Custom': <Layers className="w-3 h-3 text-slate-400" /> }
+  'Custom': <Layers className="w-3 h-3 text-slate-400" />
+}
 
 function CategoryIcon({ category }: { category: string }) {
   return CATEGORY_ICONS[category] ?? <Layers className="w-3 h-3 text-slate-400" />
@@ -908,7 +921,7 @@ function AIStreamingPreview({ planningMission }: { planningMission: Mission | nu
         className="px-4 py-3 max-h-48 overflow-y-auto text-xs text-foreground/80 leading-relaxed prose prose-invert prose-xs max-w-none [&_ul]:my-1 [&_ol]:my-1 [&_li]:my-0.5 [&_p]:my-1 [&_h1]:text-sm [&_h2]:text-xs [&_h3]:text-xs [&_strong]:text-foreground/90"
       >
         {displayText ? (
-          <ReactMarkdown remarkPlugins={[remarkGfm]}>
+          <ReactMarkdown remarkPlugins={[remarkGfm]} rehypePlugins={[rehypeSanitize]}>
             {displayText}
           </ReactMarkdown>
         ) : (
@@ -931,10 +944,10 @@ function AISuggestErrorBanner({
   errorContent,
   onRetry,
   disabled }: {
-  errorContent: string
-  onRetry: () => void
-  disabled: boolean
-}) {
+    errorContent: string
+    onRetry: () => void
+    disabled: boolean
+  }) {
   // Fall back to a generic message when the failed mission has no system
   // message attached (e.g. silent WebSocket failure).
   const message = errorContent.trim() ||
@@ -955,7 +968,7 @@ function AISuggestErrorBanner({
             AI Suggest failed
           </div>
           <div className="text-xs text-foreground/85 leading-relaxed prose prose-invert prose-xs max-w-none [&_p]:my-1 [&_strong]:text-foreground [&_code]:bg-secondary/60 [&_code]:px-1 [&_code]:rounded [&_a]:text-primary [&_a]:underline">
-            <ReactMarkdown remarkPlugins={[remarkGfm]}>
+            <ReactMarkdown remarkPlugins={[remarkGfm]} rehypePlugins={[rehypeSanitize]}>
               {message}
             </ReactMarkdown>
           </div>
@@ -985,9 +998,9 @@ const CLUSTER_CHIP_MIN_HEIGHT_PX = 40
 function TargetClusterSelector({
   selected,
   onChange }: {
-  selected: string[]
-  onChange: (clusters: string[]) => void
-}) {
+    selected: string[]
+    onChange: (clusters: string[]) => void
+  }) {
   const { availableClusters, clusterInfoMap } = useGlobalFilters()
   const { isOpen, close: closeDropdown, toggle: toggleDropdown } = useModalState()
   const ref = useRef<HTMLDivElement>(null)


### PR DESCRIPTION
Add rehype-sanitize plugin to ReactMarkdown instances that render AI-generated content to prevent XSS attacks from malicious HTML tags like \<img onerror>\, \<script>\, and \<iframe>\.

## Fixed files
- **MemoizedMessage.tsx** (3 instances) - AI agent messages via WebSocket
- **ClusterAssignmentPanel.tsx** (1 instance) - AI streaming text during cluster assignment  
- **FixerDefinitionPanel.tsx** (3 instances) - AI reasoning and error messages

## Changes
- Added \ehype-sanitize@^6.0.0\ dependency
- Added \ehypePlugins={[rehypeSanitize]}\ to all 7 ReactMarkdown instances across the 3 high-priority files

## Security Impact
This addresses the high-priority XSS vulnerabilities identified in the security report. The fix prevents AI-generated content from executing arbitrary JavaScript by sanitizing HTML before rendering.

## Scope
Low-risk files (WhatsNewModal, FeedbackDialogs, SubmitTab) were not modified as they render trusted content (GitHub API) or are self-XSS only (user preview).

## Testing
- Build: Pending
- Lint: Pending

Security fix for #5808