### PR TITLE
🔒 fix(security): validate remaining gitops paths in server_gitops.go (#9030)

### DIFF
--- a/pkg/agent/server_gitops.go
+++ b/pkg/agent/server_gitops.go
@@ -177,7 +177,14 @@ func gitopsCloneRepo(ctx context.Context, repoURL, branch string) (string, error
 }
 
 // gitopsIsKustomizeDir mirrors the backend isKustomizeDir helper.
+// SECURITY: Re-validates the path at the sink so static analysis (CodeQL #561/#562)
+// can see that the path passed to os.Stat is sanitized even when this helper is
+// called with a value derived from user input. Callers already validate req.Path
+// at handler entry, but taint-tracking tools need the check adjacent to the sink.
 func gitopsIsKustomizeDir(path string) bool {
+	if err := validateGitopsPath(path); err != nil {
+		return false
+	}
 	if _, err := os.Stat(path + "/kustomization.yaml"); err == nil {
 		return true
 	}


### PR DESCRIPTION
## Summary
Follow-up to #9022 — two additional `server_gitops.go` call sites (previously lines 181, 184) were flagged by CodeQL (alerts 561, 562) but not covered by the initial fix. Routes them through the same `validateGitopsPath` helper already in that file.

Fixes #9030

## Test plan
- [x] `go build ./...` passes
- [ ] CI build/lint green