### PR TITLE
🐛 fix(security): sanitize remaining XSS call sites (#9029)

### DIFF
--- a/web/src/components/agent/AgentSelector.tsx
+++ b/web/src/components/agent/AgentSelector.tsx
@@ -16,6 +16,7 @@ import type { MissionExport } from '../../lib/missions/types'
 import { cn } from '../../lib/cn'
 import { useModalState } from '../../lib/modals'
 import { safeGetItem, safeSetItem } from '../../lib/utils/localStorage'
+import { sanitizeUrl } from '../../lib/utils/sanitizeUrl'
 import { AgentApprovalDialog, hasApprovedAgents } from './AgentApprovalDialog'
 import { MissionDetailView } from '../missions/MissionDetailView'
 import { ClusterSelectionDialog } from '../missions/ClusterSelectionDialog'
@@ -361,7 +362,7 @@ export function AgentSelector({ compact = false, className = '' }: AgentSelector
         )}
         {!agent.available && agent.installUrl && !agent.installMissionId && (
           <a
-            href={agent.installUrl}
+            href={sanitizeUrl(agent.installUrl)}
             target="_blank"
             rel="noopener noreferrer"
             onClick={(e) => e.stopPropagation()}

--- a/web/src/components/drilldown/views/OperatorDrillDown.tsx
+++ b/web/src/components/drilldown/views/OperatorDrillDown.tsx
@@ -10,6 +10,7 @@ import {
   Package, FileText, ExternalLink
 } from 'lucide-react'
 import { cn } from '../../../lib/cn'
+import { sanitizeUrl } from '../../../lib/utils/sanitizeUrl'
 import { LOCAL_AGENT_WS_URL } from '../../../lib/constants'
 import { ConsoleAIIcon } from '../../ui/ConsoleAIIcon'
 import {
@@ -465,7 +466,7 @@ Please:
                   {csvInfo.links.map((link, i) => (
                     <a
                       key={i}
-                      href={link.url}
+                      href={sanitizeUrl(link.url)}
                       target="_blank"
                       rel="noopener noreferrer"
                       className="flex items-center gap-1 px-3 py-1.5 rounded-lg bg-secondary/50 text-sm text-foreground hover:bg-secondary transition-colors"

--- a/web/src/lib/utils/sanitizeUrl.ts
+++ b/web/src/lib/utils/sanitizeUrl.ts
@@ -1,0 +1,28 @@
+/**
+ * sanitizeUrl — Block dangerous URL schemes (javascript:, data:, vbscript:) to
+ * prevent DOM-based XSS when user-controllable values flow into `href` /
+ * similar URL attributes.
+ *
+ * Follow-up to #9028 / addresses CodeQL js/xss alerts 272 + 181 (#9029).
+ *
+ * Returns a safe placeholder ('about:blank') when the input is unsafe or
+ * malformed. Accepts absolute http(s), mailto:, tel:, and protocol-relative
+ * (//) URLs as well as relative paths.
+ */
+
+// Schemes we explicitly refuse to emit into the DOM
+const BLOCKED_SCHEME_PATTERN = /^\s*(javascript|data|vbscript|file):/i
+// Placeholder returned for unsafe inputs — renders as a no-op link
+const SAFE_FALLBACK_URL = 'about:blank'
+
+export function sanitizeUrl(url: string | null | undefined): string {
+  if (!url) return SAFE_FALLBACK_URL
+  const trimmed = String(url).trim()
+  if (!trimmed) return SAFE_FALLBACK_URL
+  if (BLOCKED_SCHEME_PATTERN.test(trimmed)) return SAFE_FALLBACK_URL
+  // Also catch obfuscated schemes with embedded control chars / whitespace
+  // e.g. "java\tscript:alert(1)" — normalize and re-check.
+  const normalized = trimmed.replace(/[\u0000-\u001F\u007F]/g, '')
+  if (BLOCKED_SCHEME_PATTERN.test(normalized)) return SAFE_FALLBACK_URL
+  return trimmed
+}


### PR DESCRIPTION
## Summary
Follow-up to #9028 — two CodeQL `js/xss` alerts remained open after that PR merged:
- Alert 272 — `web/src/components/agent/AgentSelector.tsx:364`
- Alert 181 — `web/src/components/drilldown/views/OperatorDrillDown.tsx:468`

These are **not** `ReactMarkdown` surfaces (neither file uses it). Both are `href={userControllableUrl}` sinks on `<a>` tags where the URL comes in from a WebSocket message path — the XSS vector is a `javascript:`-scheme URL, which `rehype-sanitize` would not address.

Adds a minimal `sanitizeUrl()` helper that blocks `javascript:`, `data:`, `vbscript:`, `file:`, and control-char-obfuscated variants, returning `about:blank` as a safe fallback. Applied at both sinks.

Fixes #9029

## Test plan
- [x] `npm run build` passes locally
- [ ] CI build/lint green
- [ ] CodeQL re-scan clears alerts 272 and 181 (post-merge)