### PR TITLE
🐛 fix(ui): add loading/error states to auto-QA flagged components (#9036)

### DIFF
--- a/web/src/components/feedback/FeatureRequestButton.tsx
+++ b/web/src/components/feedback/FeatureRequestButton.tsx
@@ -22,7 +22,9 @@ export function FeatureRequestButton() {
   // PR #6573 item B — use the lean `summaries` return (typed as
   // FeatureRequestSummary[]) instead of `requests`. The count_only endpoint
   // only sends {id, status}, so the full FeatureRequest[] type was a lie.
-  const { summaries, isLoading: summariesLoading } = useFeatureRequests(undefined, { countOnly: true })
+  // Auto-QA #9036 — also pull the hook's `error` so a fetch failure surfaces
+  // to the user via the button tooltip instead of failing silently.
+  const { summaries, isLoading: summariesLoading, error: summariesError } = useFeatureRequests(undefined, { countOnly: true })
   const isLoadingFeedback = notificationsLoading || summariesLoading
 
   // issue 6475 — Unify the navbar badge count with the Updates tab.
@@ -61,9 +63,15 @@ export function FeatureRequestButton() {
         onClick={openModal}
         data-tour="feedback"
         className={`relative p-2 w-9 h-9 flex items-center justify-center rounded-lg hover:bg-secondary/50 transition-colors ${
-          unreadCount > 0 ? 'text-foreground' : 'text-muted-foreground hover:text-foreground'
+          summariesError ? 'text-red-400' : unreadCount > 0 ? 'text-foreground' : 'text-muted-foreground hover:text-foreground'
         }`}
-        title={unreadCount > 0 ? `${unreadCount} updates on your feedback` : 'Report a bug or request a feature'}
+        title={
+          summariesError
+            ? `Couldn't load feedback status: ${summariesError}`
+            : unreadCount > 0
+              ? `${unreadCount} updates on your feedback`
+              : 'Report a bug or request a feature'
+        }
       >
         {isLoadingFeedback ? <Loader2 className="w-5 h-5 animate-spin" /> : <Bug className="w-5 h-5" />}
         {!isLoadingFeedback && unreadCount > 0 && (

--- a/web/src/components/missions/CardRequestDialog.tsx
+++ b/web/src/components/missions/CardRequestDialog.tsx
@@ -5,7 +5,7 @@
 
 import { useState, useCallback } from 'react'
 import { useTranslation } from 'react-i18next'
-import { LayoutGrid, X, Send, Loader2 } from 'lucide-react'
+import { LayoutGrid, X, Send, Loader2, AlertTriangle } from 'lucide-react'
 import { api } from '../../lib/api'
 import { emitGroundControlCardRequestOpened } from '../../lib/analytics'
 import { useToast } from '../ui/Toast'
@@ -69,12 +69,15 @@ export function CardRequestDialog({ missingProjects, onClose }: CardRequestDialo
             {submitted.has(project) ? (
               <span className="text-[10px] text-green-400 font-medium">{t('orbit.cardRequestRequested')}</span>
             ) : failedProjects.has(project) ? (
+              // Auto-QA #9036 — explicit inline error + retry affordance so
+              // the failed state is visible beyond the one-shot toast.
               <button
                 onClick={() => handleRequest(project)}
                 disabled={submittingProjects.has(project)}
                 className="flex items-center gap-1 px-2 py-1 text-[10px] font-medium text-red-400 hover:bg-red-500/10 rounded transition-colors"
+                title="Request failed — click to retry"
               >
-                <Send className="w-2.5 h-2.5" />
+                <AlertTriangle className="w-2.5 h-2.5" />
                 {t('orbit.cardRequestRetry')}
               </button>
             ) : (

--- a/web/src/components/missions/CardRequestDialog.tsx
+++ b/web/src/components/missions/CardRequestDialog.tsx
@@ -70,7 +70,7 @@ export function CardRequestDialog({ missingProjects, onClose }: CardRequestDialo
               <span className="text-[10px] text-green-400 font-medium">{t('orbit.cardRequestRequested')}</span>
             ) : failedProjects.has(project) ? (
               // Auto-QA #9036 — explicit inline error + retry affordance so
-              // the failed state is visible beyond the one-shot toast.
+              // the failed state persists beyond the one-shot toast.
               <button
                 onClick={() => handleRequest(project)}
                 disabled={submittingProjects.has(project)}

--- a/web/src/components/updates/WhatsNewModal.tsx
+++ b/web/src/components/updates/WhatsNewModal.tsx
@@ -1,5 +1,5 @@
 import { useState, useMemo, useCallback, useEffect } from 'react'
-import { Download, Clock, SkipForward, ChevronDown, Copy, Check } from 'lucide-react'
+import { Download, Clock, SkipForward, ChevronDown, Copy, Check, Loader2 } from 'lucide-react'
 import ReactMarkdown from 'react-markdown'
 import remarkGfm from 'remark-gfm'
 import remarkBreaks from 'remark-breaks'
@@ -81,6 +81,11 @@ export function WhatsNewModal({ isOpen, onClose }: WhatsNewModalProps) {
   const [showSnoozeMenu, setShowSnoozeMenu] = useState(false)
   const [copiedCommand, setCopiedCommand] = useState<string | null>(null)
   const [recentPRs, setRecentPRs] = useState<Array<{ number: number; title: string; merged_at: string }>>([])
+  // Auto-QA #9036 — surface loading/error state for the PR fallback fetch
+  // so users see either a spinner while the list is being fetched or a
+  // short error message if GitHub is unreachable, instead of an empty modal.
+  const [prsLoading, setPrsLoading] = useState(false)
+  const [prsError, setPrsError] = useState<string | null>(null)
 
   const markdownComponents = useMemo(() => buildReleaseNotesComponents('sm'), [])
 
@@ -92,6 +97,8 @@ export function WhatsNewModal({ isOpen, onClose }: WhatsNewModalProps) {
     if (hasReleaseNotes || !isOpen) return
     let cancelled = false
     const fetchPRs = async () => {
+      setPrsLoading(true)
+      setPrsError(null)
       try {
         // Step 1: Get the date of the currently running commit
         let sinceDate: string | null = null
@@ -111,7 +118,11 @@ export function WhatsNewModal({ isOpen, onClose }: WhatsNewModalProps) {
           `/api/github/repos/kubestellar/console/pulls?state=closed&sort=updated&direction=desc&per_page=${MAX_RECENT_PRS}`,
           { credentials: 'include', signal: AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS) },
         )
-        if (!resp.ok || cancelled) return
+        if (cancelled) return
+        if (!resp.ok) {
+          setPrsError(`GitHub responded ${resp.status}`)
+          return
+        }
         const data = await resp.json()
         if (cancelled) return
         const merged = (data || [])
@@ -127,8 +138,13 @@ export function WhatsNewModal({ isOpen, onClose }: WhatsNewModalProps) {
             merged_at: pr.merged_at,
           }))
         setRecentPRs(merged)
-      } catch {
-        // Silently fail — the modal still shows "no release notes"
+      } catch (err) {
+        if (cancelled) return
+        // Don't surface AbortError (user closed modal) as an error
+        const message = err instanceof Error ? err.message : 'Network error'
+        setPrsError(message)
+      } finally {
+        if (!cancelled) setPrsLoading(false)
       }
     }
     fetchPRs()
@@ -237,6 +253,17 @@ export function WhatsNewModal({ isOpen, onClose }: WhatsNewModalProps) {
               >
                 {latestRelease?.releaseNotes ?? ''}
               </ReactMarkdown>
+            </div>
+          ) : prsLoading ? (
+            // Auto-QA #9036 — loading state for the PR fallback fetch
+            <div className="flex items-center justify-center gap-2 py-6 text-sm text-muted-foreground">
+              <Loader2 className="w-4 h-4 animate-spin" />
+              <span>Loading recent pull requests…</span>
+            </div>
+          ) : prsError ? (
+            // Auto-QA #9036 — error state replaces the old silent failure
+            <div className="p-3 rounded-lg bg-red-500/10 border border-red-500/20 text-xs text-red-400">
+              Couldn&apos;t load recent pull requests: {prsError}
             </div>
           ) : recentPRs.length > 0 ? (
             <div className="space-y-1">


### PR DESCRIPTION
## Summary
- Adds visible loading and error states to three components Auto-QA flagged in #9036 where fetch paths were silently swallowing failures:
  - `WhatsNewModal` — PR fallback fetch now shows a spinner while loading and an inline error banner on failure (was previously a silent `catch {}`).
  - `FeatureRequestButton` — navbar bug-icon now surfaces the feedback-hook `error` via a red tint and tooltip.
  - `CardRequestDialog` — failed card-request state now shows an `AlertTriangle` icon with a retry tooltip so the failure is visible beyond the one-shot toast.
- Most other files in the issue body (`ACMMFeedbackLoops`, `GPUInventoryHistory`, `SubmitTab`, `FeedbackModal`, `CreateNamespaceModal`, `GrantAccessModal`, `ReservationFormModal`, `CardRequestDialog`'s loading state, `main.tsx`) already had loading/error states or were `*.test.tsx` test files (which don't fetch). They were false positives from the Auto-QA heuristic.
- Scope kept narrow per the issue's size-S guidance; no card-registry or hook refactors.

Fixes #9036

## Test plan
- [x] `npm run build --prefix web` passes
- [x] Lint clean on touched files (2 pre-existing warnings only)
- [ ] WhatsNewModal shows spinner then PR list; red error banner if GitHub 5xx
- [ ] FeatureRequestButton goes red-tinted with error tooltip when `/api/feedback/requests` fails
- [ ] CardRequestDialog retry button shows AlertTriangle icon on failure