### PR TITLE
🐛 : fix(security): allow iframe embedding for /embed/* routes

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -176,6 +176,17 @@
   [headers.values]
     Cache-Control = "public, max-age=31536000, immutable"
 
+# Embed routes allow iframe embedding for CI/CD pipeline cards.
+# Overrides global X-Frame-Options: DENY and CSP frame-ancestors 'none' to enable framing.
+# These routes display public GitHub Actions data and are designed for embedding.
+[[headers]]
+  for = "/embed/*"
+  [headers.values]
+    X-Frame-Options = "SAMEORIGIN"
+    Content-Security-Policy = "default-src 'self'; script-src 'self' 'unsafe-eval' https://www.googletagmanager.com https://analytics.kubestellar.io; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: https://github.com https://avatars.githubusercontent.com https://raw.githubusercontent.com https://api.dicebear.com; connect-src 'self' https://www.google-analytics.com https://region1.google-analytics.com https://analytics.google.com https://fonts.googleapis.com https://www.googleapis.com https://www.googletagmanager.com https://api.github.com https://api.dicebear.com https://fonts.gstatic.com https://analytics.kubestellar.io https://raw.githubusercontent.com; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'self'; frame-src 'self'; worker-src 'self' blob:; manifest-src 'self'"
+    Cache-Control = "no-cache, no-store, must-revalidate"
+    Pragma = "no-cache"
+
 # HTML files must always revalidate to pick up new chunk references after deploys
 [[headers]]
   for = "/*.html"

--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -415,7 +415,11 @@ func (s *Server) setupMiddleware() {
 	// Security headers (#7037 CSP, #7038 HSTS)
 	s.app.Use(func(c *fiber.Ctx) error {
 		c.Set("X-Content-Type-Options", "nosniff")
-		c.Set("X-Frame-Options", "DENY")
+		// Skip X-Frame-Options: DENY for /embed/* routes to allow iframe embedding
+		// These routes display public CI/CD data and are designed for embedding
+		if !strings.HasPrefix(c.Path(), "/embed/") {
+			c.Set("X-Frame-Options", "DENY")
+		}
 		c.Set("X-XSS-Protection", "0") // Disabled per OWASP — modern browsers don't need it and it can introduce vulnerabilities
 		c.Set("Referrer-Policy", "strict-origin-when-cross-origin")
 		c.Set("Permissions-Policy", "camera=(), microphone=(), geolocation=()")


### PR DESCRIPTION
The /embed/:cardType route is designed for iframe embedding but was blocked by global X-Frame-Options: DENY and CSP frame-ancestors 'none' headers.

Changes:
- Add path check in Go middleware to skip X-Frame-Options: DENY for /embed/*
- Add Netlify headers section to override security headers for /embed/*
- Set X-Frame-Options to SAMEORIGIN for embed routes
- Set CSP frame-ancestors and frame-src to 'self' for embed routes

Security rationale:
- Embed routes display public CI/CD data (GitHub Actions)
- No sensitive actions or authentication required
- Rate limiting (60 req/min) already prevents abuse
- Targeted fix preserves security for all other routes

Fixes: Embed route blocked by global security headers

### 📌 Fixes

Fixes #9047

---

### Changes Made

<!-- Provide a detailed list of changes made in this PR. -->

- [ ] Updated ...
- [ ] Refactored ...
- [x] Fixed ...
- [ ] Added tests for ...

---

### Checklist

Please ensure the following before submitting your PR:

- [x] I used a coding agent (Claude Code, Copilot, Gemini, or Codex) to generate/review this code
- [x] I have reviewed the project's contribution guidelines
- [ ] New cards target [console-marketplace](https://github.com/kubestellar/console-marketplace), not this repo
- [ ] isDemoData is wired correctly (cards show Demo badge when using demo data)
- [ ] I have written unit tests for the changes (if applicable)
- [x] I have tested the changes locally and ensured they work as expected
- [x] All commits are signed with DCO (`git commit -s`)

---

### Screenshots or Logs (if applicable)

<!-- Add any relevant screenshots or logs to help visualize/test the changes. -->

---

### 👀 Reviewer Notes

_Add any special notes for the reviewer here_
