### PR TITLE
🐛 : fix(security): allow iframe embedding for /embed/ routes

### DIFF
--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -415,7 +415,11 @@ func (s *Server) setupMiddleware() {
 	// Security headers (#7037 CSP, #7038 HSTS)
 	s.app.Use(func(c *fiber.Ctx) error {
 		c.Set("X-Content-Type-Options", "nosniff")
-		c.Set("X-Frame-Options", "DENY")
+		// Skip X-Frame-Options: DENY for /embed/* routes to allow iframe embedding
+		// These routes display public CI/CD data and are designed for embedding
+		if !strings.HasPrefix(c.Path(), "/embed/") {
+			c.Set("X-Frame-Options", "DENY")
+		}
 		c.Set("X-XSS-Protection", "0") // Disabled per OWASP — modern browsers don't need it and it can introduce vulnerabilities
 		c.Set("Referrer-Policy", "strict-origin-when-cross-origin")
 		c.Set("Permissions-Policy", "camera=(), microphone=(), geolocation=()")


### PR DESCRIPTION
Skip X-Frame-Options: DENY for /embed/* routes to allow iframe embedding. These routes display public CI/CD data and are designed for embedding. All other routes retain DENY for security.

Fixes broken embed functionality in EmbedCard.tsx and IframeEmbed.tsx which was blocked by global X-Frame-Options: DENY header.

---

### Changes Made

<!-- Provide a detailed list of changes made in this PR. -->

- [x] Updated ...
- [x] Refactored ...
- [x] Fixed ...
- [ ] Added tests for ...

---

### Checklist

Please ensure the following before submitting your PR:

- [x] I used a coding agent (Claude Code, Copilot, Gemini, or Codex) to generate/review this code
- [x] I have reviewed the project's contribution guidelines
- [ ] New cards target [console-marketplace](https://github.com/kubestellar/console-marketplace), not this repo
- [ ] isDemoData is wired correctly (cards show Demo badge when using demo data)
- [ ] I have written unit tests for the changes (if applicable)
- [x] I have tested the changes locally and ensured they work as expected
- [x] All commits are signed with DCO (`git commit -s`)

---

### Screenshots or Logs (if applicable)

<!-- Add any relevant screenshots or logs to help visualize/test the changes. -->

---

### 👀 Reviewer Notes

_Add any special notes for the reviewer here_
