### PR TITLE
✨ : feat(api): add stale cache fallback to GitHub Pipelines handler

### DIFF
--- a/pkg/api/handlers/github_pipelines.go
+++ b/pkg/api/handlers/github_pipelines.go
@@ -13,6 +13,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"log/slog"
 	"net/http"
 	"os"
 	"regexp"
@@ -32,6 +33,7 @@ import (
 
 const (
 	ghpCacheTTL              = 2 * time.Minute
+	ghpCacheStaleTTL         = 1 * time.Hour // Serve stale data for 1h after expiration when GitHub rate-limits
 	ghpMatrixDefaultDays     = 14
 	ghpMatrixMaxDays         = 90
 	ghpHistoryRetentionDays  = 90
@@ -436,6 +438,15 @@ func (h *GitHubPipelinesHandler) serveCached(c *fiber.Ctx, key string, build fun
 		return build(c)
 	})
 	if err != nil {
+		// Try stale cache for GitHub API failures (rate limits, network errors)
+		if stale := h.getStale(key); stale != nil {
+			slog.Info("[github-pipelines] serving stale cache on error", "key", key, "error", err)
+			c.Set("X-Cache", "STALE")
+			c.Set(fiber.HeaderContentType, fiber.MIMEApplicationJSON)
+			c.Set(fiber.HeaderCacheControl, fmt.Sprintf("public, max-age=%d", int(ghpCacheTTL.Seconds())))
+			return c.Send(stale.body)
+		}
+		// No stale available - return error
 		// Distinguish client-validation errors (unknown repo, bad params) from
 		// upstream GitHub failures so callers get the correct HTTP status.
 		status := fiber.StatusBadGateway
@@ -475,6 +486,26 @@ func (h *GitHubPipelinesHandler) serveCached(c *fiber.Ctx, key string, build fun
 	c.Set(fiber.HeaderContentType, fiber.MIMEApplicationJSON)
 	c.Set(fiber.HeaderCacheControl, fmt.Sprintf("public, max-age=%d", int(ghpCacheTTL.Seconds())))
 	return c.Send(body)
+}
+
+// getStale returns a cached entry even if expired, as long as it is within ghpCacheStaleTTL.
+// Used to serve stale data when GitHub rate-limits us — better than an error.
+func (h *GitHubPipelinesHandler) getStale(key string) *ghpCacheEntry {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
+	entry, ok := h.cache[key]
+	if !ok {
+		return nil
+	}
+	// Check if entry is within stale window (exp - TTL + staleTTL)
+	staleCutoff := entry.exp.Add(-ghpCacheTTL).Add(ghpCacheStaleTTL)
+	if time.Now().After(staleCutoff) {
+		return nil
+	}
+	// Return a copy to prevent mutation after lock release
+	// Note: cache stores values (not pointers like missions.go), so we create a new entry
+	cp := entry
+	return &cp
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Add stale-while-revalidate pattern to serve cached data when GitHub API rate limits are hit. Mirrors the proven pattern from missions.go.

- Add ghpCacheStaleTTL constant (1 hour)
- Add getStale() method to return expired cache within stale window
- Modify serveCached() error path to fallback to stale cache
- Add X-Cache: STALE header for observability
- Add structured logging for stale cache serves

This prevents CI/CD dashboard errors during active development when GitHub's 5,000 req/hr limit (60 req/hr unauthenticated) is exhausted.

### 📌 Fixes

Fixes #9052

---

### Changes Made

<!-- Provide a detailed list of changes made in this PR. -->

- [x] Updated ...
- [x] Refactored ...
- [ ] Fixed ...
- [ ] Added tests for ...

---

### Checklist

Please ensure the following before submitting your PR:

- [x] I used a coding agent (Claude Code, Copilot, Gemini, or Codex) to generate/review this code
- [x] I have reviewed the project's contribution guidelines
- [ ] New cards target [console-marketplace](https://github.com/kubestellar/console-marketplace), not this repo
- [ ] isDemoData is wired correctly (cards show Demo badge when using demo data)
- [ ] I have written unit tests for the changes (if applicable)
- [x] I have tested the changes locally and ensured they work as expected
- [x] All commits are signed with DCO (`git commit -s`)

---

### Screenshots or Logs (if applicable)

<!-- Add any relevant screenshots or logs to help visualize/test the changes. -->

---

### 👀 Reviewer Notes

_Add any special notes for the reviewer here_
