### PR TITLE
🐛 : fix(github-pipelines): add context timeout to ghGet requests

### DIFF
--- a/pkg/api/handlers/github_pipelines.go
+++ b/pkg/api/handlers/github_pipelines.go
@@ -482,6 +482,8 @@ func (h *GitHubPipelinesHandler) serveCached(c *fiber.Ctx, key string, build fun
 // ---------------------------------------------------------------------------
 
 func (h *GitHubPipelinesHandler) ghGet(ctx context.Context, path string) (*http.Response, error) {
+	ctx, cancel := context.WithTimeout(ctx, ghpHTTPTimeout)
+	defer cancel()
 	url := path
 	if !strings.HasPrefix(url, "http") {
 		url = ghpGitHubAPIBase + path


### PR DESCRIPTION
GET requests to GitHub API hang indefinitely if the API is unresponsive, causing request threads to block forever. Mutations already have timeout protection (line 1198), but GETs don't.

Wrap the context in ghGet with context.WithTimeout(ctx, ghpHTTPTimeout) and defer cancel. Uses existing 15s constant already defined at line 48.

Two-line change matching pattern used across all other handlers (workloads.go, topology.go, sse.go, mcp_workloads.go). Prevents goroutine leaks, enables proper cancellation propagation, uses existing constant for easy configuration, no API surface changes.

---

### Changes Made

<!-- Provide a detailed list of changes made in this PR. -->

- [x] Updated ...
- [x] Refactored ...
- [x] Fixed ...
- [ ] Added tests for ...

---

### Checklist

Please ensure the following before submitting your PR:

- [x] I used a coding agent (Claude Code, Copilot, Gemini, or Codex) to generate/review this code
- [x] I have reviewed the project's contribution guidelines
- [ ] New cards target [console-marketplace](https://github.com/kubestellar/console-marketplace), not this repo
- [ ] isDemoData is wired correctly (cards show Demo badge when using demo data)
- [ ] I have written unit tests for the changes (if applicable)
- [x] I have tested the changes locally and ensured they work as expected
- [x] All commits are signed with DCO (`git commit -s`)

---

### Screenshots or Logs (if applicable)

<!-- Add any relevant screenshots or logs to help visualize/test the changes. -->

---

### 👀 Reviewer Notes

_Add any special notes for the reviewer here_
