### PR TITLE
✨ : feat(api): validate PIPELINE_REPOS format at startup

### DIFF
--- a/pkg/api/handlers/github_pipelines.go
+++ b/pkg/api/handlers/github_pipelines.go
@@ -13,6 +13,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"log/slog"
 	"net/http"
 	"os"
 	"regexp"
@@ -75,6 +76,10 @@ func ghpGetRepos() []string {
 	for _, s := range strings.Split(env, ",") {
 		s = strings.TrimSpace(s)
 		if s != "" {
+			if !ghpValidRepoPattern.MatchString(s) {
+				slog.Warn("[GitHubPipelines] Invalid repo slug in PIPELINE_REPOS, skipping", "repo", s)
+				continue
+			}
 			repos = append(repos, s)
 		}
 	}

--- a/pkg/api/handlers/github_pipelines_test.go
+++ b/pkg/api/handlers/github_pipelines_test.go
@@ -2,6 +2,7 @@ package handlers
 
 import (
 	"net/http/httptest"
+	"os"
 	"testing"
 	"time"
 
@@ -181,5 +182,93 @@ func TestGHPStreakKind(t *testing.T) {
 			}
 			t.Errorf("ghpStreakKind(%s) = %q, want %q", inStr, got, tc.want)
 		}
+	}
+}
+
+func TestGHPGetRepos(t *testing.T) {
+	// Save and restore original env var
+	oldEnv := os.Getenv("PIPELINE_REPOS")
+	defer func() {
+		if oldEnv == "" {
+			os.Unsetenv("PIPELINE_REPOS")
+		} else {
+			os.Setenv("PIPELINE_REPOS", oldEnv)
+		}
+	}()
+
+	tests := []struct {
+		name     string
+		env      string
+		wantLen  int
+		contains []string
+	}{
+		{
+			name:     "empty env var returns defaults",
+			env:      "",
+			wantLen:  len(ghpDefaultRepos),
+			contains: ghpDefaultRepos,
+		},
+		{
+			name:     "valid repos are parsed",
+			env:      "owner/repo1,owner/repo2",
+			wantLen:  2,
+			contains: []string{"owner/repo1", "owner/repo2"},
+		},
+		{
+			name:     "mix of valid and invalid skips invalid",
+			env:      "owner/repo1,../etc/passwd,owner/repo2",
+			wantLen:  2,
+			contains: []string{"owner/repo1", "owner/repo2"},
+		},
+		{
+			name:     "all invalid returns defaults",
+			env:      "../etc/passwd,noslash,owner/repo/extra",
+			wantLen:  len(ghpDefaultRepos),
+			contains: ghpDefaultRepos,
+		},
+		{
+			name:     "whitespace only returns defaults",
+			env:      "   ,  ,   ",
+			wantLen:  len(ghpDefaultRepos),
+			contains: ghpDefaultRepos,
+		},
+		{
+			name:     "valid repos with extra whitespace are trimmed",
+			env:      "  owner/repo1  ,  owner/repo2  ",
+			wantLen:  2,
+			contains: []string{"owner/repo1", "owner/repo2"},
+		},
+		{
+			name:     "path traversal attempts are skipped",
+			env:      "evil/../passwd,owner/../../repo,owner/repo",
+			wantLen:  1,
+			contains: []string{"owner/repo"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.env == "" {
+				os.Unsetenv("PIPELINE_REPOS")
+			} else {
+				os.Setenv("PIPELINE_REPOS", tc.env)
+			}
+			got := ghpGetRepos()
+			if len(got) != tc.wantLen {
+				t.Errorf("ghpGetRepos() length = %d, want %d", len(got), tc.wantLen)
+			}
+			for _, want := range tc.contains {
+				found := false
+				for _, g := range got {
+					if g == want {
+						found = true
+						break
+					}
+				}
+				if !found {
+					t.Errorf("ghpGetRepos() does not contain %q, got %v", want, got)
+				}
+			}
+		})
 	}
 }


### PR DESCRIPTION
Add validation for PIPELINE_REPOS environment variable at initialization to catch malformed repo slugs before runtime GitHub API errors.

- Uses existing ghpValidRepoPattern regex in ghpGetRepos()
- Skips invalid entries with slog.Warn() message
- Falls back to ghpDefaultRepos if all entries invalid
- Prevents path traversal security risk
- Zero per-request overhead (runs once at init)
- Backward compatible with graceful fallback

Fixes security issue where invalid repo formats could cause runtime API failures instead of failing fast at startup.

### 📌 Fixes

Fixes #9056

---

### 📝 Summary of Changes

- Short description of what was changed
- Include links to related issues/discussions if any

---

### Changes Made

<!-- Provide a detailed list of changes made in this PR. -->

- [x] Updated ...
- [x] Refactored ...
- [ ] Fixed ...
- [ ] Added tests for ...

---

### Checklist

Please ensure the following before submitting your PR:

- [x] I used a coding agent (Claude Code, Copilot, Gemini, or Codex) to generate/review this code
- [x] I have reviewed the project's contribution guidelines
- [ ] New cards target [console-marketplace](https://github.com/kubestellar/console-marketplace), not this repo
- [ ] isDemoData is wired correctly (cards show Demo badge when using demo data)
- [ ] I have written unit tests for the changes (if applicable)
- [x] I have tested the changes locally and ensured they work as expected
- [x] All commits are signed with DCO (`git commit -s`)

---

### Screenshots or Logs (if applicable)

<!-- Add any relevant screenshots or logs to help visualize/test the changes. -->

---

### 👀 Reviewer Notes

_Add any special notes for the reviewer here_
