### PR TITLE
✨ : Add health check endpoint for GitHub token validation

### DIFF
--- a/pkg/api/handlers/github_pipelines.go
+++ b/pkg/api/handlers/github_pipelines.go
@@ -366,6 +366,29 @@ func NewGitHubPipelinesHandler(githubToken string) *GitHubPipelinesHandler {
 	}
 }
 
+// HandleHealth validates the GitHub token by calling GitHub's /user endpoint.
+// Returns 503 if token is missing or invalid, 200 if token is valid.
+func (h *GitHubPipelinesHandler) HandleHealth(c *fiber.Ctx) error {
+	if h.token == "" {
+		return c.Status(fiber.StatusServiceUnavailable).JSON(fiber.Map{"error": "GITHUB_TOKEN not configured"})
+	}
+
+	ctx, cancel := context.WithTimeout(c.UserContext(), 10*time.Second)
+	defer cancel()
+
+	res, err := h.ghGet(ctx, "/user")
+	if err != nil {
+		return c.Status(fiber.StatusServiceUnavailable).JSON(fiber.Map{"error": "GitHub token validation failed"})
+	}
+	defer res.Body.Close()
+
+	if res.StatusCode >= 400 {
+		return c.Status(fiber.StatusServiceUnavailable).JSON(fiber.Map{"error": "GitHub token validation failed"})
+	}
+
+	return c.JSON(fiber.Map{"status": "ok"})
+}
+
 // Serve routes a request to the right view.
 func (h *GitHubPipelinesHandler) Serve(c *fiber.Ctx) error {
 	view := c.Query("view", "pulse")

--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -848,6 +848,7 @@ func (s *Server) setupRoutes() {
 	githubPipelines := handlers.NewGitHubPipelinesHandler(s.config.GitHubToken)
 	api.Get("/github-pipelines", githubPipelines.Serve)
 	api.Post("/github-pipelines", githubPipelines.Serve)
+	api.Get("/github-pipelines/health", githubPipelines.HandleHealth)
 
 	api.Get("/github/*", githubProxy.Proxy)
 


### PR DESCRIPTION
Add /api/github-pipelines/health endpoint to proactively validate GitHub token before API calls fail. Uses existing ghGet() helper with 10-second timeout. Returns 503 on missing/invalid token, 200 with valid status on success.

Complements existing /api/github/token/status (checks presence only) by validating actual token health via GitHub /user endpoint.

### 📌 Fixes

Fixes #9063
---

### Changes Made

<!-- Provide a detailed list of changes made in this PR. -->

- [x] Updated ...
- [x] Refactored ...
- [ ] Fixed ...
- [ ] Added tests for ...

---

### Checklist

Please ensure the following before submitting your PR:

- [x] I used a coding agent (Claude Code, Copilot, Gemini, or Codex) to generate/review this code
- [x] I have reviewed the project's contribution guidelines
- [ ] New cards target [console-marketplace](https://github.com/kubestellar/console-marketplace), not this repo
- [ ] isDemoData is wired correctly (cards show Demo badge when using demo data)
- [ ] I have written unit tests for the changes (if applicable)
- [x] I have tested the changes locally and ensured they work as expected
- [x] All commits are signed with DCO (`git commit -s`)

---

### Screenshots or Logs (if applicable)

<!-- Add any relevant screenshots or logs to help visualize/test the changes. -->

---

### 👀 Reviewer Notes

_Add any special notes for the reviewer here_
