### PR TITLE
✨ : Fix ServiceAccount token automount configuration override

### DIFF
--- a/deploy/helm/kubestellar-console/templates/deployment.yaml
+++ b/deploy/helm/kubestellar-console/templates/deployment.yaml
@@ -31,7 +31,7 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       serviceAccountName: {{ include "kubestellar-console.serviceAccountName" . }}
-      automountServiceAccountToken: true
+      automountServiceAccountToken: {{ .Values.serviceAccount.automount }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       {{- if and .Values.backup.enabled .Values.backup.autoRestore }}

--- a/deploy/helm/kubestellar-console/values.yaml
+++ b/deploy/helm/kubestellar-console/values.yaml
@@ -11,7 +11,8 @@ fullnameOverride: ""
 
 serviceAccount:
   create: true
-  automount: false
+  # Security: set to false if using kc-agent for all K8s operations (reduces attack surface)
+  automount: true
   annotations: {}
   name: ""
 


### PR DESCRIPTION
- Change deployment.yaml to respect values.yaml serviceAccount.automount setting
- Update values.yaml default to true for backward compatibility
- Add security comment explaining when to disable automount
- Console uses kc-agent for K8s operations, not ServiceAccount token
- Reduces attack surface by allowing token mount disable

---

### Changes Made

<!-- Provide a detailed list of changes made in this PR. -->

- [x] Updated ...
- [x] Refactored ...
- [x] Fixed ...
- [ ] Added tests for ...

---

### Checklist

Please ensure the following before submitting your PR:

- [x] I used a coding agent (Claude Code, Copilot, Gemini, or Codex) to generate/review this code
- [x] I have reviewed the project's contribution guidelines
- [ ] New cards target [console-marketplace](https://github.com/kubestellar/console-marketplace), not this repo
- [ ] isDemoData is wired correctly (cards show Demo badge when using demo data)
- [ ] I have written unit tests for the changes (if applicable)
- [x] I have tested the changes locally and ensured they work as expected
- [x] All commits are signed with DCO (`git commit -s`)

---

### Screenshots or Logs (if applicable)

<!-- Add any relevant screenshots or logs to help visualize/test the changes. -->

---

### 👀 Reviewer Notes

_Add any special notes for the reviewer here_
