### PR TITLE
✨ : Add resource limits to db-restore init container

### DIFF
--- a/deploy/helm/kubestellar-console/templates/deployment.yaml
+++ b/deploy/helm/kubestellar-console/templates/deployment.yaml
@@ -45,6 +45,8 @@ spec:
           # on clusters enforcing PodSecurity restricted.
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
+          resources:
+            {{- toYaml .Values.backup.resources | nindent 12 }}
           command:
             - /bin/sh
             - -c


### PR DESCRIPTION
Add resource limits to the db-restore init container in the Helm deployment template. The init container previously had no explicit resource limits, only securityContext. During database restore, a runaway init container could consume node resources before the main pod starts, affecting other workloads.

This change reuses .Values.backup.resources (defined in values.yaml:187-193) which mirrors the backup CronJob approach (cronjob-db-backup.yaml:37-38). The init container performs simple file copy operations, so the backup job's limits (200m CPU, 256Mi memory) are appropriate.

This 2-line change prevents resource exhaustion while reusing existing configuration—no new values to maintain. Follows Kubernetes best practices, ensures consistency with the backup CronJob, and is fully backward compatible.

### 📌 Fixes

Fixes #9067
---

### Changes Made

<!-- Provide a detailed list of changes made in this PR. -->

- [x] Updated ...
- [x] Refactored ...
- [x] Fixed ...
- [ ] Added tests for ...

---

### Checklist

Please ensure the following before submitting your PR:

- [x] I used a coding agent (Claude Code, Copilot, Gemini, or Codex) to generate/review this code
- [x] I have reviewed the project's contribution guidelines
- [ ] New cards target [console-marketplace](https://github.com/kubestellar/console-marketplace), not this repo
- [ ] isDemoData is wired correctly (cards show Demo badge when using demo data)
- [ ] I have written unit tests for the changes (if applicable)
- [x] I have tested the changes locally and ensured they work as expected
- [x] All commits are signed with DCO (`git commit -s`)

---

### Screenshots or Logs (if applicable)

<!-- Add any relevant screenshots or logs to help visualize/test the changes. -->

---

### 👀 Reviewer Notes

_Add any special notes for the reviewer here_
