### PR TITLE
🐛 fix: Custom Card data field replaces sample on first focus & valid configs render (fixes #9058, #9061)

### DIFF
--- a/web/src/components/cards/DynamicCard.tsx
+++ b/web/src/components/cards/DynamicCard.tsx
@@ -29,9 +29,34 @@ export function DynamicCard({ config }: CardComponentProps) {
   const dynamicCardId = (typeof safeConfig.dynamicCardId === 'string' ? safeConfig.dynamicCardId : '') || ''
   const definition = getDynamicCard(dynamicCardId)
 
-  // Report demo state: dynamic cards depend on the agent for live API data
+  // Report demo state: dynamic cards depend on the agent for live API data.
+  //
+  // #9058 — Always include `hasData: true` in this report. Previously this
+  // call reported `{ isDemoData, isFailed, consecutiveFailures }` without
+  // `hasData`, leaving `hasData` as `undefined` (falsy). Because
+  // `useReportCardDataState` uses `useLayoutEffect` and parent layout
+  // effects fire AFTER children's, the meta-component's report runs LAST
+  // and overwrote the `hasData: true` that `Tier1CardRuntime` /
+  // `Tier2CardRuntime` had reported. CardWrapper then saw
+  // `!childDataState.hasData` for a rendered card and painted its generic
+  // "No data available" empty-state overlay (with a Retry button) on top
+  // of a perfectly valid custom card with valid inline/static data.
+  //
+  // Reporting `hasData: true` here is correct for BOTH branches:
+  //  - Error shell states below (missing id / missing definition /
+  //    invalid tier definition): the shell IS the rendered content, so
+  //    we tell CardWrapper not to paint its generic empty state over it.
+  //  - Tier runtime branch: the card's content (data rows, internal
+  //    empty-state message, or internal skeleton) IS the rendered
+  //    content, and the runtime handles its own internal loading/empty/
+  //    error UI.
   const { shouldUseDemoData } = useCardDemoState({ requires: 'agent' })
-  useReportCardDataState({ isDemoData: shouldUseDemoData, isFailed: false, consecutiveFailures: 0 })
+  useReportCardDataState({
+    isDemoData: shouldUseDemoData,
+    isFailed: false,
+    consecutiveFailures: 0,
+    hasData: true,
+  })
 
   if (!dynamicCardId) {
     return (

--- a/web/src/components/dashboard/CardFactoryModal.tsx
+++ b/web/src/components/dashboard/CardFactoryModal.tsx
@@ -40,6 +40,13 @@ type Tab = 'declarative' | 'code' | 'ai' | 'manage'
 const SAVE_MESSAGE_TIMEOUT_MS = 3000 // Duration to display save/error messages before auto-clearing
 const COPY_FEEDBACK_TIMEOUT_MS = 2000 // Duration to show "copied" feedback before resetting
 
+// #9061 — Initial sample JSON shown in the Tier 1 "Data (JSON array)" field.
+// Exported as a constant so the field's first-focus auto-select can compare
+// against the EXACT default string and skip auto-select once the user has
+// edited the value (typed/pasted their own content).
+const T1_SAMPLE_DATA_JSON =
+  '[\n  { "name": "item-1", "status": "healthy" },\n  { "name": "item-2", "status": "error" }\n]'
+
 const EXAMPLE_TSX = `// Example: Simple counter card
 export default function MyCard({ config }) {
   const [count, setCount] = useState(0)
@@ -559,7 +566,12 @@ export function CardFactoryModal({ isOpen, onClose, onCardCreated, embedded = fa
     { field: 'name', label: 'Name' },
     { field: 'status', label: 'Status', format: 'badge', badgeColors: { healthy: 'bg-green-500/20 text-green-400', error: 'bg-red-500/20 text-red-400' } },
   ])
-  const [t1DataJson, setT1DataJson] = useState('[\n  { "name": "item-1", "status": "healthy" },\n  { "name": "item-2", "status": "error" }\n]')
+  const [t1DataJson, setT1DataJson] = useState(T1_SAMPLE_DATA_JSON)
+  // #9061 — Track whether the user has already focused the JSON textarea
+  // at least once. On the FIRST focus we auto-select the pre-filled sample
+  // so that typing replaces it cleanly instead of appending to the sample
+  // (which produced invalid concatenated JSON like `[sample][new]`).
+  const t1DataJsonFirstFocusRef = useRef(true)
   const [t1Width, setT1Width] = useState(6)
 
   // Code (Tier 2) state
@@ -960,8 +972,26 @@ export function CardFactoryModal({ isOpen, onClose, onCardCreated, embedded = fa
                   <label className="text-xs text-muted-foreground block mb-1">{t('dashboard.cardFactory.dataLabel')}</label>
                   <textarea
                     value={t1DataJson}
-                    onChange={e => setT1DataJson(e.target.value)}
+                    onChange={e => {
+                      // After the first user edit, stop treating the field as "pristine
+                      // sample" so a re-focus after editing never re-selects their work.
+                      t1DataJsonFirstFocusRef.current = false
+                      setT1DataJson(e.target.value)
+                    }}
+                    onFocus={e => {
+                      // #9061 — On first focus, if the field still contains the
+                      // pristine sample JSON, select it all so typing replaces
+                      // the sample instead of appending to it.
+                      if (
+                        t1DataJsonFirstFocusRef.current &&
+                        t1DataJson === T1_SAMPLE_DATA_JSON
+                      ) {
+                        t1DataJsonFirstFocusRef.current = false
+                        e.currentTarget.select()
+                      }
+                    }}
                     rows={6}
+                    placeholder={T1_SAMPLE_DATA_JSON}
                     className="w-full text-xs px-3 py-2 rounded-lg bg-secondary text-foreground font-mono focus:outline-none focus:ring-1 focus:ring-inset focus:ring-purple-500/50"
                   />
                 </div>


### PR DESCRIPTION
## Summary

Fixes two Console Studio bugs on Custom Cards in a single focused PR.

### #9058 — Custom Cards Show "No Data Available" on Dashboard Despite Valid Config

**Root cause.** The meta-component `DynamicCard` (web/src/components/cards/DynamicCard.tsx) called `useReportCardDataState({ isDemoData, isFailed, consecutiveFailures })` without `hasData`, leaving `hasData` as `undefined` (falsy). Because `useReportCardDataState` uses `useLayoutEffect` and parent layout effects fire AFTER children's, the parent report ran LAST every render and overwrote the `hasData: true` that `Tier1CardRuntime` / `Tier2CardRuntime` had already reported. `CardWrapper` then saw `!childDataState.hasData` for a fully-rendered card and painted its generic "No data available" empty-state overlay (with a Retry button) on top of the valid custom card content sitting right behind it.

**Fix.** Always include `hasData: true` in the meta-component's report. The error-shell branches below (missing id / missing definition / invalid tier definition) are themselves the rendered content, and the tier runtime branch delegates to a runtime that owns its own internal loading/empty/error UI — so `hasData: true` is correct for both paths.

### #9061 — Custom Card "Data (JSON array)" Field Appends Instead of Replacing

**Root cause.** The Tier 1 "Data (JSON array)" textarea was initialized with a real value (pristine sample JSON). Clicking into the field placed the caret at the end, so typing appended to the sample, producing malformed concatenations like `[sample][new]`.

**Fix.** On first focus, if the field still contains the pristine sample JSON, select-all so typing replaces the sample cleanly. Any edit (typing, paste, template/AI apply) flips the ref, so re-focusing a modified field never re-selects the user's work. The sample string is now a module constant and is also exposed via the `placeholder` attribute as a secondary hint.

## Files changed

- `web/src/components/cards/DynamicCard.tsx`
- `web/src/components/dashboard/CardFactoryModal.tsx`

## Test plan

- [x] `npm run build` passes
- [x] `npx tsc --noEmit` passes
- [x] `npm run lint` introduces no new errors (remaining errors are pre-existing on unchanged lines)
- [x] `DynamicCard.test.tsx` — 47 tests pass
- [x] `CardFactoryModal.test.tsx` — 1 test passes
- [x] `card-factory-validation.test.ts` + `CardDataContext.test.tsx` — 58 tests pass
- [ ] Manual: Console Studio → Create Custom Card → add inline JSON data → add to dashboard → card renders data (not "No data available")
- [ ] Manual: Console Studio → Create Custom Card → click into pre-filled JSON field → type → sample is replaced, not appended

Fixes #9058
Fixes #9061