### PR TITLE
✨ feat(rewards): Phase 2 of RFC #8862 — public badge endpoint

### DIFF
--- a/pkg/api/handlers/rewards_badge.go
+++ b/pkg/api/handlers/rewards_badge.go
@@ -1,0 +1,267 @@
+package handlers
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"html/template"
+	"log/slog"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/gofiber/fiber/v2"
+	"github.com/kubestellar/console/pkg/rewards"
+)
+
+// Phase 2 of RFC #8862 — public, unauthenticated contributor-tier badge.
+//
+// Serves a shields.io-style SVG pill that GitHub READMEs embed via Camo
+// (GitHub's image proxy). Tier comes from the same scored-contribution flow
+// that powers /api/rewards/github, mapped through pkg/rewards.GetContributorLevel
+// (ported in Phase 1).
+//
+// Notes: public route (no JWTAuth); rate-limited by the existing publicLimiter
+// (60 req/min/IP); SVG everywhere including errors so Camo always has something
+// to show; max-age=3600 on success so a user's tier doesn't get re-fetched
+// every README render; no-store on errors so transient failures don't stick.
+
+// Badge rendering + transport constants.
+const (
+	badgeContentType         = "image/svg+xml; charset=utf-8" // success Content-Type
+	badgeCacheMaxAgeSeconds  = 3600                           // 1h — tier rarely flips
+	badgeCacheControlSuccess = "public, max-age=3600"         // matches badgeCacheMaxAgeSeconds
+	badgeCacheControlError   = "no-store"                     // transient errors: do not cache
+	badgeLoginHashPrefixLen  = 16                             // 16 hex = 64b SHA-256 prefix for analytics
+	badgeLabelText           = "kubestellar"                  // left-hand segment, tier-agnostic
+	badgeUnknownTierName     = "unknown"                      // no GitHub activity / 404
+	badgeUnknownTierColor    = "#9e9e9e"                      // observer-gray hex
+	badgeErrorTierName       = "error"                        // upstream 5xx / timeout
+	badgeErrorTierColor      = "#e05d44"                      // shields.io red
+	badgeLabelColor          = "#555"                         // shields.io dark-gray label
+	badgeHeightPx            = 20                             // SVG pill height
+	badgeLabelWidthPx        = 82                             // tuned for "kubestellar" (11 chars)
+	badgeValueWidthPx        = 72                             // tuned for "Commander" (9 chars)
+	badgeTotalWidthPx        = badgeLabelWidthPx + badgeValueWidthPx
+	badgeLabelMidPx          = badgeLabelWidthPx / 2 // text-anchor centre of label
+	badgeValueMidPx          = badgeLabelWidthPx + (badgeValueWidthPx / 2)
+	badgeTextBaselinePx      = 14 // y offset for main text
+	badgeTextShadowPx        = 15 // y offset for drop shadow
+	badgeFontSizePx          = 11 // shields.io default
+	badgeCornerRadiusPx      = 3  // shields.io default
+)
+
+// Named HTTP statuses so the three render paths are self-documenting.
+const (
+	badgeStatusOK      = fiber.StatusOK
+	badgeStatusBadGate = fiber.StatusBadGateway
+)
+
+// badgeRewardsFetcher is the narrow seam BadgeHandler depends on. Defining
+// it as an interface lets the test substitute a fake without importing the
+// whole RewardsHandler's transitive dependencies. cacheHit reports whether
+// the response came from the in-memory cache; used for GA4 analytics only.
+type badgeRewardsFetcher interface {
+	fetchUserRewardsForBadge(login string) (resp *GitHubRewardsResponse, cacheHit bool, err error)
+}
+
+// errBadgeUnknownLogin signals an empty/404 upstream. Handler maps this to
+// the "unknown" tier SVG (200, cached) instead of an error SVG (502, no-store).
+var errBadgeUnknownLogin = errors.New("unknown github login")
+
+// fetchUserRewardsForBadge adapts RewardsHandler to badgeRewardsFetcher.
+// Shares the authenticated path's cache map + TTL (rewardsCacheTTL); unlike
+// GetGitHubRewards it does NOT fall back to stale cache on upstream failure
+// because the badge handler needs to pick between success/unknown/error.
+func (h *RewardsHandler) fetchUserRewardsForBadge(login string) (*GitHubRewardsResponse, bool, error) {
+	h.mu.RLock()
+	if entry, ok := h.cache[login]; ok && time.Since(entry.fetchedAt) < rewardsCacheTTL {
+		h.mu.RUnlock()
+		resp := *entry.response
+		return &resp, true, nil
+	}
+	h.mu.RUnlock()
+
+	token := h.resolveToken()
+	resp, err := h.fetchUserRewards(login, token)
+	if err != nil {
+		// Treat "not found"/"unprocessable" as unknown-login so the caller
+		// renders the gray badge instead of the red error one.
+		msg := err.Error()
+		if strings.Contains(msg, "404") || strings.Contains(msg, "422") {
+			return nil, false, errBadgeUnknownLogin
+		}
+		return nil, false, err
+	}
+
+	// Populate the shared cache so later authenticated or badge calls
+	// don't re-hit GitHub.
+	h.mu.Lock()
+	h.cache[login] = &rewardsCacheEntry{
+		response:  resp,
+		fetchedAt: time.Now(),
+	}
+	h.mu.Unlock()
+
+	return resp, false, nil
+}
+
+// BadgeHandler serves the public contributor-tier badge SVG.
+type BadgeHandler struct {
+	fetcher badgeRewardsFetcher
+}
+
+// NewBadgeHandler wraps a fetcher (usually *RewardsHandler) and exposes
+// GetBadge.
+func NewBadgeHandler(fetcher badgeRewardsFetcher) *BadgeHandler {
+	return &BadgeHandler{fetcher: fetcher}
+}
+
+// totalPointsFromResponse keeps the coin lookup in one place so the test
+// fake can model it without duplicating shape knowledge.
+func totalPointsFromResponse(resp *GitHubRewardsResponse) int {
+	if resp == nil {
+		return 0
+	}
+	return resp.TotalPoints
+}
+
+// GetBadge renders an SVG tier badge for :github_login (public, rate-limited).
+func (h *BadgeHandler) GetBadge(c *fiber.Ctx) error {
+	login := strings.TrimSpace(c.Params("github_login"))
+	if login == "" {
+		return renderBadgeSVG(c, badgeStatusBadGate, badgeErrorTierName, badgeErrorTierColor, badgeCacheControlError)
+	}
+
+	resp, cacheHit, err := h.fetcher.fetchUserRewardsForBadge(login)
+	switch {
+	case errors.Is(err, errBadgeUnknownLogin):
+		emitBadgeFetchedEvent(login, badgeUnknownTierName, cacheHit)
+		return renderBadgeSVG(c, badgeStatusOK, badgeUnknownTierName, badgeUnknownTierColor, badgeCacheControlSuccess)
+	case err != nil:
+		slog.Error("[rewards/badge] upstream fetch failed", "login", login, "error", err)
+		emitBadgeFetchedEvent(login, badgeErrorTierName, cacheHit)
+		return renderBadgeSVG(c, badgeStatusBadGate, badgeErrorTierName, badgeErrorTierColor, badgeCacheControlError)
+	}
+
+	tier := rewards.GetContributorLevel(totalPointsFromResponse(resp))
+	fill := tierColorHex(tier.Color)
+
+	emitBadgeFetchedEvent(login, tier.Name, cacheHit)
+	return renderBadgeSVG(c, badgeStatusOK, tier.Name, fill, badgeCacheControlSuccess)
+}
+
+// tierColorHex maps a Tailwind color-family name (from Tier.Color) to a
+// concrete hex. Kept here (not in pkg/rewards) because it's a rendering
+// concern — the tier data itself stays style-agnostic.
+func tierColorHex(color string) string {
+	switch color {
+	case "gray":
+		return "#6b7280"
+	case "blue":
+		return "#3b82f6"
+	case "cyan":
+		return "#06b6d4"
+	case "green":
+		return "#10b981"
+	case "purple":
+		return "#8b5cf6"
+	case "orange":
+		return "#f97316"
+	case "red":
+		return "#ef4444"
+	case "yellow":
+		return "#f59e0b"
+	}
+	// Unrecognized family — fall back to unknown-gray so the badge still
+	// renders rather than emitting invalid SVG.
+	return badgeUnknownTierColor
+}
+
+// badgeTemplateData is the shape the SVG template receives.
+type badgeTemplateData struct {
+	Label, Value                   string
+	LabelColor, ValueColor         string
+	Height, LabelWidth, ValueWidth int
+	TotalWidth                     int
+	LabelMid, ValueMid             int
+	TextBaseline, TextShadow       int
+	FontSize, CornerRadius         int
+}
+
+// badgeSVGTemplate is a minimal shields.io-style two-segment pill.
+// html/template escapes {{.Label}}/{{.Value}} so a crafted tier name could
+// never inject raw SVG (defensive — tier names come from our own constant).
+var badgeSVGTemplate = template.Must(template.New("badge").Parse(`<svg xmlns="http://www.w3.org/2000/svg" width="{{.TotalWidth}}" height="{{.Height}}" role="img" aria-label="{{.Label}}: {{.Value}}">
+<linearGradient id="s" x2="0" y2="100%">
+<stop offset="0" stop-color="#bbb" stop-opacity=".1"/>
+<stop offset="1" stop-opacity=".1"/>
+</linearGradient>
+<clipPath id="r"><rect width="{{.TotalWidth}}" height="{{.Height}}" rx="{{.CornerRadius}}" fill="#fff"/></clipPath>
+<g clip-path="url(#r)">
+<rect width="{{.LabelWidth}}" height="{{.Height}}" fill="{{.LabelColor}}"/>
+<rect x="{{.LabelWidth}}" width="{{.ValueWidth}}" height="{{.Height}}" fill="{{.ValueColor}}"/>
+<rect width="{{.TotalWidth}}" height="{{.Height}}" fill="url(#s)"/>
+</g>
+<g fill="#fff" text-anchor="middle" font-family="Verdana,Geneva,DejaVu Sans,sans-serif" font-size="{{.FontSize}}">
+<text x="{{.LabelMid}}" y="{{.TextShadow}}" fill="#010101" fill-opacity=".3">{{.Label}}</text>
+<text x="{{.LabelMid}}" y="{{.TextBaseline}}">{{.Label}}</text>
+<text x="{{.ValueMid}}" y="{{.TextShadow}}" fill="#010101" fill-opacity=".3">{{.Value}}</text>
+<text x="{{.ValueMid}}" y="{{.TextBaseline}}">{{.Value}}</text>
+</g>
+</svg>`))
+
+// renderBadgeSVG writes the SVG response + headers. All three paths (success,
+// unknown, error) go through this single serializer.
+func renderBadgeSVG(c *fiber.Ctx, status int, tierName, tierColor, cacheControl string) error {
+	data := badgeTemplateData{
+		Label:        badgeLabelText,
+		Value:        tierName,
+		LabelColor:   badgeLabelColor,
+		ValueColor:   tierColor,
+		Height:       badgeHeightPx,
+		LabelWidth:   badgeLabelWidthPx,
+		ValueWidth:   badgeValueWidthPx,
+		TotalWidth:   badgeTotalWidthPx,
+		LabelMid:     badgeLabelMidPx,
+		ValueMid:     badgeValueMidPx,
+		TextBaseline: badgeTextBaselinePx,
+		TextShadow:   badgeTextShadowPx,
+		FontSize:     badgeFontSizePx,
+		CornerRadius: badgeCornerRadiusPx,
+	}
+
+	var buf bytes.Buffer
+	if err := badgeSVGTemplate.Execute(&buf, data); err != nil {
+		slog.Error("[rewards/badge] template execute failed", "error", err)
+		c.Set(fiber.HeaderContentType, badgeContentType)
+		c.Set(fiber.HeaderCacheControl, badgeCacheControlError)
+		return c.Status(http.StatusInternalServerError).SendString(
+			`<svg xmlns="http://www.w3.org/2000/svg" width="1" height="1"/>`,
+		)
+	}
+
+	c.Set(fiber.HeaderContentType, badgeContentType)
+	c.Set(fiber.HeaderCacheControl, cacheControl)
+	return c.Status(status).Send(buf.Bytes())
+}
+
+// emitBadgeFetchedEvent is the GA4 emission seam. Phase 2 does NOT add an
+// outbound network dependency — the codebase has no server-side GA4 helper
+// (analytics_proxy.go is a client-forwarding proxy). We log at debug level;
+// a future phase can wire mp.google-analytics.com behind the same env-gated
+// config as the client proxy without changing this signature.
+func emitBadgeFetchedEvent(login, tierName string, cacheHit bool) {
+	sum := sha256.Sum256([]byte(login))
+	hashHex := hex.EncodeToString(sum[:])
+	if len(hashHex) > badgeLoginHashPrefixLen {
+		hashHex = hashHex[:badgeLoginHashPrefixLen]
+	}
+	slog.Debug(
+		"[rewards/badge] badge_fetched",
+		"tier", tierName,
+		"login_hashed", hashHex,
+		"cache_hit", cacheHit,
+	)
+}

--- a/pkg/api/handlers/rewards_badge_test.go
+++ b/pkg/api/handlers/rewards_badge_test.go
@@ -1,0 +1,176 @@
+package handlers
+
+import (
+	"errors"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/gofiber/fiber/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// fakeBadgeFetcher is a test double for badgeRewardsFetcher. The handler
+// only needs three distinct outcomes — success with a point total, unknown
+// login, and upstream error — so a struct of canned responses keyed by
+// login is enough without pulling in a mocking library.
+type fakeBadgeFetcher struct {
+	points   map[string]int
+	unknown  map[string]bool
+	errorFor map[string]error
+	lastHit  bool // cache_hit value to return for the next call
+}
+
+func (f *fakeBadgeFetcher) fetchUserRewardsForBadge(login string) (*GitHubRewardsResponse, bool, error) {
+	if err, ok := f.errorFor[login]; ok {
+		return nil, f.lastHit, err
+	}
+	if f.unknown[login] {
+		return nil, f.lastHit, errBadgeUnknownLogin
+	}
+	if pts, ok := f.points[login]; ok {
+		return &GitHubRewardsResponse{TotalPoints: pts}, f.lastHit, nil
+	}
+	// Default to unknown so a missing test setup is obvious.
+	return nil, f.lastHit, errBadgeUnknownLogin
+}
+
+// newBadgeTestApp builds a bare Fiber app with just the badge route. The
+// real server.go mounts publicLimiter — we skip it here because we're
+// testing the handler, not the rate limit middleware (which is covered by
+// the existing publicLimiter tests).
+func newBadgeTestApp(fetcher badgeRewardsFetcher) *fiber.App {
+	app := fiber.New()
+	h := NewBadgeHandler(fetcher)
+	app.Get("/api/rewards/badge/:github_login", h.GetBadge)
+	return app
+}
+
+// ---------- success path: known login renders tier SVG ----------
+
+func TestBadgeHandler_KnownLogin_RendersTierSVG(t *testing.T) {
+	// 5000 coins → Pilot (see pkg/rewards/tiers.go).
+	const pilotCoins = 5000
+	const expectedTierName = "Pilot"
+
+	fetcher := &fakeBadgeFetcher{
+		points:  map[string]int{"alice": pilotCoins},
+		lastHit: false,
+	}
+	app := newBadgeTestApp(fetcher)
+
+	req, err := http.NewRequest("GET", "/api/rewards/badge/alice", nil)
+	require.NoError(t, err)
+
+	resp, err := app.Test(req, fiberTestTimeout)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, badgeContentType, resp.Header.Get(fiber.HeaderContentType))
+	assert.Equal(t, badgeCacheControlSuccess, resp.Header.Get(fiber.HeaderCacheControl))
+
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	svg := string(body)
+	assert.True(t, strings.HasPrefix(svg, "<svg "), "response should start with <svg: %s", svg[:min(len(svg), 40)])
+	assert.Contains(t, svg, expectedTierName, "SVG should embed the tier name")
+	assert.Contains(t, svg, badgeLabelText, "SVG should embed the label segment")
+}
+
+// ---------- unknown login fallback ----------
+
+func TestBadgeHandler_UnknownLogin_RendersUnknownSVG(t *testing.T) {
+	fetcher := &fakeBadgeFetcher{
+		unknown: map[string]bool{"nobody": true},
+	}
+	app := newBadgeTestApp(fetcher)
+
+	req, err := http.NewRequest("GET", "/api/rewards/badge/nobody", nil)
+	require.NoError(t, err)
+
+	resp, err := app.Test(req, fiberTestTimeout)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, resp.StatusCode,
+		"unknown-login fallback must still return 200 so Camo caches the SVG")
+	assert.Equal(t, badgeContentType, resp.Header.Get(fiber.HeaderContentType))
+	assert.Equal(t, badgeCacheControlSuccess, resp.Header.Get(fiber.HeaderCacheControl))
+
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	svg := string(body)
+	assert.Contains(t, svg, badgeUnknownTierName, "SVG should use the unknown tier name")
+}
+
+// ---------- upstream 5xx / timeout ----------
+
+func TestBadgeHandler_UpstreamError_RendersErrorSVGNoStore(t *testing.T) {
+	fetcher := &fakeBadgeFetcher{
+		errorFor: map[string]error{
+			"broken": errors.New("upstream 503: service unavailable"),
+		},
+	}
+	app := newBadgeTestApp(fetcher)
+
+	req, err := http.NewRequest("GET", "/api/rewards/badge/broken", nil)
+	require.NoError(t, err)
+
+	resp, err := app.Test(req, fiberTestTimeout)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusBadGateway, resp.StatusCode,
+		"upstream error must surface as 502 so clients can distinguish from unknown-login")
+	assert.Equal(t, badgeContentType, resp.Header.Get(fiber.HeaderContentType))
+	assert.Equal(t, badgeCacheControlError, resp.Header.Get(fiber.HeaderCacheControl))
+
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	svg := string(body)
+	assert.Contains(t, svg, badgeErrorTierName, "SVG should use the error tier name")
+}
+
+// ---------- cache_hit plumbing ----------
+
+func TestBadgeHandler_CacheHit_StillRendersOK(t *testing.T) {
+	// A cache-hit flip is a separate signal from the response body — the
+	// handler must still render a 200 SVG whether cache_hit is true or
+	// false. Regression guard against a future refactor that accidentally
+	// short-circuits the render path when the fetcher reports a cache hit.
+	const observerCoins = 0 // 0 coins → Observer tier
+	const expectedTierName = "Observer"
+
+	fetcher := &fakeBadgeFetcher{
+		points:  map[string]int{"carol": observerCoins},
+		lastHit: true,
+	}
+	app := newBadgeTestApp(fetcher)
+
+	req, err := http.NewRequest("GET", "/api/rewards/badge/carol", nil)
+	require.NoError(t, err)
+
+	resp, err := app.Test(req, fiberTestTimeout)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	assert.Contains(t, string(body), expectedTierName)
+}
+
+// ---------- tier color fallback ----------
+
+func TestTierColorHex_AllKnownColors(t *testing.T) {
+	// Every Tailwind color-family name listed on ContributorLevels must map
+	// to a non-empty hex string. Drift here would surface the unknown-gray
+	// fallback on a valid tier, which is a subtle visual regression.
+	knownColors := []string{"gray", "blue", "cyan", "green", "purple", "orange", "red", "yellow"}
+	for _, c := range knownColors {
+		hex := tierColorHex(c)
+		assert.NotEmpty(t, hex, "color %q must have a hex mapping", c)
+		assert.True(t, strings.HasPrefix(hex, "#"), "color %q mapped to %q; expected #-prefixed hex", c, hex)
+	}
+
+	// An unrecognized family falls back to the unknown-badge gray, never
+	// to an empty string.
+	fallback := tierColorHex("not-a-real-color")
+	assert.Equal(t, badgeUnknownTierColor, fallback)
+}

--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -1171,6 +1171,13 @@ func (s *Server) setupRoutes() {
 	})
 	api.Get("/rewards/github", rewardsHandler.GetGitHubRewards)
 
+	// Public contributor-tier badge (RFC #8862 Phase 2). SVG response, no
+	// auth required, rate-limited via publicLimiter (60 req/min/IP). Mounted
+	// on s.app, not `api`, because the `api` group is gated by JWTAuth and
+	// this endpoint must be reachable from READMEs via Camo.
+	badgeHandler := handlers.NewBadgeHandler(rewardsHandler)
+	s.app.Get("/api/rewards/badge/:github_login", publicLimiter, badgeHandler.GetBadge)
+
 	// Persistent per-user reward balances (issue #6011). Every authenticated
 	// user can read and mutate their own row — no RBAC gate needed because
 	// the handler scopes every query by the JWT-derived user id.


### PR DESCRIPTION
Phase 2/3 of #8862. Builds on Phase 1 (commit [`6adc91a6`](https://github.com/kubestellar/console/commit/6adc91a6)) which ported `ContributorLevels` + `GetContributorLevel` to `pkg/rewards`.

## Summary

Adds `GET /api/rewards/badge/:github_login` as a **public, unauthenticated** endpoint that returns a shields.io-style SVG contributor-tier pill suitable for embedding in READMEs via Camo (GitHub's image proxy). The login is supplied in the path; no user data is exposed beyond tier name/color, all of which is already derivable from public GitHub activity.

## New handler + route wiring

- `pkg/api/handlers/rewards_badge.go` — `BadgeHandler` + `GetBadge` + inline `text/template` SVG renderer. Reuses `RewardsHandler` through a narrow `badgeRewardsFetcher` interface so the tier pipeline and in-memory cache stay shared with the authenticated `/api/rewards/github` endpoint (no duplicate GitHub hits).
- `pkg/api/server.go` — single-line route mounted on `s.app` (NOT the authenticated `api` group), beside `/api/rewards/github`, guarded by the pre-existing `publicLimiter`.

## SVG rendering + caching strategy

- `text/template` renders a two-segment pill (label + tier). The `html/template` package HTML-escapes `{{.Label}}` and `{{.Value}}` — defensive, since tier names come from a constant, but cheap insurance against a future refactor that makes them caller-supplied.
- **Success + unknown-login** → `Cache-Control: public, max-age=3600`. One hour is the same order of magnitude as `rewardsCacheTTL` (10 min) and prevents every README render from hammering GitHub. Camo caches off this header, so embedded badges stay cheap.
- **Upstream 5xx / timeout** → `Cache-Control: no-store` so transient failures don't get pinned in Camo.
- Errors still return SVG (not JSON) so Camo always has something to display.

## Rate limit

Reuses the existing `publicLimiter` (60 req/min/IP, sliding window) — same budget already used by `/api/ping`, `/api/active-users`, `/api/public/nightly-e2e/*`, and analytics proxies. No new middleware needed.

## GA4 event shape

`emitBadgeFetchedEvent` emits `badge_fetched` with params `{tier: <name>, login_hashed: <sha256-hex[:16]>, cache_hit: <bool>}`. For Phase 2 the emission is logged at `slog.Debug`; the codebase has no server-side GA4 helper today (`analytics_proxy.go` is a client-forwarding proxy). The signature is stable so a later phase can wire `mp.google-analytics.com` behind the same env-gated config without touching callers.

## Test coverage

`pkg/api/handlers/rewards_badge_test.go` covers:

- **Known tier** — Pilot at 5000 coins renders a 200 SVG with `max-age=3600`, correct `Content-Type`, and the tier name + label text embedded.
- **Unknown login** — 200 SVG (still cacheable) with the gray `unknown` tier label so Camo caches the deterministic output.
- **Upstream error** — 502 with `no-store` and the red `error` tier label.
- **Cache-hit path** — `cache_hit=true` still renders a 200 SVG (regression guard against a refactor that short-circuits on cache hits).
- **`tierColorHex`** — every `Color` family listed on `ContributorLevels` maps to a non-empty `#`-prefixed hex; unknown families fall back to observer-gray.

Seam is an interface (`badgeRewardsFetcher`) with a three-field struct fake — no mocking library added. All existing tests still pass.

## Verification gates (all clean)

- [x] `flock /tmp/kubestellar-console-build.lock -c "go build ./..."`
- [x] `go test ./pkg/api/... ./pkg/rewards/...`
- [x] `flock /tmp/kubestellar-console-build.lock -c "cd web && npm run build"`
- [x] `cd web && npx tsc --noEmit`

## Scope

- `pkg/api/handlers/rewards_badge.go`: 267 LOC (under the 300 LOC cap)
- `pkg/api/handlers/rewards_badge_test.go`: 176 LOC (tests)
- `pkg/api/server.go`: +7 LOC (route wire)

Phase 3 will cover documentation, client-side references, and optionally wire the GA4 emission to the actual measurement protocol. The RFC epic (#8862) stays open until Phase 3 lands.