### PR TITLE
✨: implement Lima card data layer with API-first hook and backend endpoint

### DIFF
--- a/pkg/api/auth_sweep_test.go
+++ b/pkg/api/auth_sweep_test.go
@@ -50,6 +50,7 @@ func TestProtectedRoutes_UnauthenticatedReturn401(t *testing.T) {
 		{"GET", "/api/mcp/configmaps"},
 		{"GET", "/api/mcp/resource-yaml"},
 		{"GET", "/api/mcp/pods/logs"},
+		{"GET", "/api/lima"},
 		// Exec / mutating MCP tool calls
 		{"POST", "/api/mcp/tools/ops/call"},
 		{"POST", "/api/mcp/tools/deploy/call"},

--- a/pkg/api/handlers/demo_data.go
+++ b/pkg/api/handlers/demo_data.go
@@ -374,6 +374,56 @@ func getDemoFlatcarNodes() []k8s.FlatcarNodeInfo {
 	}
 }
 
+// getDemoLimaInstances returns demo Lima instances for GET /api/lima.
+func getDemoLimaInstances() []LimaInstanceSummary {
+	return []LimaInstanceSummary{
+		{
+			Name:        "lima-k3s",
+			Status:      "running",
+			CPUCores:    4,
+			MemoryGB:    8,
+			DiskGB:      60,
+			Arch:        "x86_64",
+			OS:          "Ubuntu 22.04 LTS",
+			LimaVersion: "0.18.0",
+			LastSeen:    time.Now().Add(-30 * time.Second).UTC().Format(time.RFC3339),
+		},
+		{
+			Name:        "lima-default",
+			Status:      "running",
+			CPUCores:    2,
+			MemoryGB:    4,
+			DiskGB:      30,
+			Arch:        "x86_64",
+			OS:          "Ubuntu 22.04 LTS",
+			LimaVersion: "0.18.0",
+			LastSeen:    time.Now().Add(-45 * time.Second).UTC().Format(time.RFC3339),
+		},
+		{
+			Name:        "lima-dev",
+			Status:      "running",
+			CPUCores:    4,
+			MemoryGB:    8,
+			DiskGB:      80,
+			Arch:        "aarch64",
+			OS:          "Ubuntu 23.10",
+			LimaVersion: "0.17.2",
+			LastSeen:    time.Now().Add(-2 * time.Minute).UTC().Format(time.RFC3339),
+		},
+		{
+			Name:        "lima-test",
+			Status:      "stopped",
+			CPUCores:    2,
+			MemoryGB:    4,
+			DiskGB:      20,
+			Arch:        "x86_64",
+			OS:          "Fedora 39",
+			LimaVersion: "0.17.2",
+			LastSeen:    time.Now().Add(-30 * time.Minute).UTC().Format(time.RFC3339),
+		},
+	}
+}
+
 // Demo NVIDIA Operator Status
 func getDemoNVIDIAOperatorStatus() []*k8s.NVIDIAOperatorStatus {
 	return []*k8s.NVIDIAOperatorStatus{
@@ -549,14 +599,14 @@ func getDemoWorkloads() []v1alpha1.Workload {
 // Demo pod network stats — realistic throughput for multi-tenancy topology
 func getDemoPodNetworkStats() []PodNetworkStats {
 	/** Realistic throughput values (bytes/sec) for demo visualization */
-	const kvEth0RxRate int64 = 10240  // 10 KB/s — KubeVirt data-plane rx
-	const kvEth0TxRate int64 = 5120   // 5 KB/s — KubeVirt data-plane tx
-	const kvEth1RxRate int64 = 2560   // 2.5 KB/s — KubeVirt control-plane rx
-	const kvEth1TxRate int64 = 1280   // 1.3 KB/s — KubeVirt control-plane tx
-	const k3sEth0RxRate int64 = 5120  // 5 KB/s — K3s management rx
-	const k3sEth0TxRate int64 = 2560  // 2.5 KB/s — K3s management tx
-	const k3sEth1RxRate int64 = 1280  // 1.3 KB/s — K3s control-plane rx
-	const k3sEth1TxRate int64 = 640   // 0.6 KB/s — K3s control-plane tx
+	const kvEth0RxRate int64 = 10240 // 10 KB/s — KubeVirt data-plane rx
+	const kvEth0TxRate int64 = 5120  // 5 KB/s — KubeVirt data-plane tx
+	const kvEth1RxRate int64 = 2560  // 2.5 KB/s — KubeVirt control-plane rx
+	const kvEth1TxRate int64 = 1280  // 1.3 KB/s — KubeVirt control-plane tx
+	const k3sEth0RxRate int64 = 5120 // 5 KB/s — K3s management rx
+	const k3sEth0TxRate int64 = 2560 // 2.5 KB/s — K3s management tx
+	const k3sEth1RxRate int64 = 1280 // 1.3 KB/s — K3s control-plane rx
+	const k3sEth1TxRate int64 = 640  // 0.6 KB/s — K3s control-plane tx
 
 	return []PodNetworkStats{
 		{

--- a/pkg/api/handlers/lima.go
+++ b/pkg/api/handlers/lima.go
@@ -1,0 +1,252 @@
+package handlers
+
+import (
+	"context"
+	"math"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/gofiber/fiber/v2"
+	"github.com/kubestellar/console/pkg/k8s"
+	"k8s.io/apimachinery/pkg/api/resource"
+)
+
+// limaListTimeout is the timeout for listing Lima nodes across all clusters.
+const limaListTimeout = 30 * time.Second
+
+// LimaHandlers handles Lima VM status API endpoints.
+type LimaHandlers struct {
+	k8sClient *k8s.MultiClusterClient
+}
+
+// NewLimaHandlers creates a new Lima handlers instance.
+func NewLimaHandlers(k8sClient *k8s.MultiClusterClient) *LimaHandlers {
+	return &LimaHandlers{k8sClient: k8sClient}
+}
+
+// LimaInstanceSummary represents a Lima instance returned by GET /api/lima.
+type LimaInstanceSummary struct {
+	Name        string `json:"name"`
+	Status      string `json:"status"`
+	CPUCores    int    `json:"cpuCores"`
+	MemoryGB    int    `json:"memoryGB"`
+	DiskGB      int    `json:"diskGB"`
+	Arch        string `json:"arch"`
+	OS          string `json:"os"`
+	LimaVersion string `json:"limaVersion"`
+	LastSeen    string `json:"lastSeen"`
+}
+
+// LimaListResponse is the response for GET /api/lima.
+type LimaListResponse struct {
+	LimaInstances []LimaInstanceSummary `json:"limaInstances"`
+	IsDemoData    bool                  `json:"isDemoData"`
+}
+
+// ListLima returns Lima instances discovered from Kubernetes nodes.
+//
+// Contract:
+//   - 200 + { limaInstances: [...], isDemoData: false } when at least one cluster
+//     query succeeded (including a legitimate empty list when no Lima nodes exist)
+//   - 503 + { limaInstances: [], isDemoData: true } when no live cluster path is
+//     available (no client or all cluster queries failed)
+//
+// GET /api/lima
+func (h *LimaHandlers) ListLima(c *fiber.Ctx) error {
+	if isDemoMode(c) {
+		return c.JSON(LimaListResponse{
+			LimaInstances: getDemoLimaInstances(),
+			IsDemoData:    true,
+		})
+	}
+
+	if h.k8sClient == nil {
+		return c.Status(fiber.StatusServiceUnavailable).JSON(LimaListResponse{
+			LimaInstances: []LimaInstanceSummary{},
+			IsDemoData:    true,
+		})
+	}
+
+	cluster := c.Query("cluster")
+	if cluster != "" {
+		if err := mcpValidateName("cluster", cluster); err != nil {
+			return err
+		}
+	}
+
+	ctx, cancel := context.WithTimeout(c.Context(), limaListTimeout)
+	defer cancel()
+
+	clusters := make([]k8s.ClusterInfo, 0)
+	if cluster != "" {
+		clusters = append(clusters, k8s.ClusterInfo{Name: cluster, Context: cluster})
+	} else {
+		deduplicated, err := h.k8sClient.DeduplicatedClusters(ctx)
+		if err != nil {
+			return c.Status(fiber.StatusServiceUnavailable).JSON(LimaListResponse{
+				LimaInstances: []LimaInstanceSummary{},
+				IsDemoData:    true,
+			})
+		}
+		clusters = deduplicated
+	}
+
+	if len(clusters) == 0 {
+		return c.Status(fiber.StatusServiceUnavailable).JSON(LimaListResponse{
+			LimaInstances: []LimaInstanceSummary{},
+			IsDemoData:    true,
+		})
+	}
+
+	instances := make([]LimaInstanceSummary, 0)
+	successfulClusterQueries := 0
+
+	for _, cl := range clusters {
+		nodes, err := h.k8sClient.GetNodes(ctx, cl.Name)
+		if err != nil {
+			continue
+		}
+
+		successfulClusterQueries++
+		for _, node := range nodes {
+			if !isLimaNode(node) {
+				continue
+			}
+			instances = append(instances, mapNodeToLimaInstance(node))
+		}
+	}
+
+	if successfulClusterQueries == 0 {
+		return c.Status(fiber.StatusServiceUnavailable).JSON(LimaListResponse{
+			LimaInstances: []LimaInstanceSummary{},
+			IsDemoData:    true,
+		})
+	}
+
+	return c.JSON(LimaListResponse{
+		LimaInstances: instances,
+		IsDemoData:    false,
+	})
+}
+
+func isLimaNode(node k8s.NodeInfo) bool {
+	if strings.HasPrefix(strings.ToLower(node.Name), "lima-") {
+		return true
+	}
+
+	if node.Labels != nil {
+		if _, ok := node.Labels["lima.sh/instance"]; ok {
+			return true
+		}
+	}
+
+	return strings.Contains(strings.ToLower(node.OSImage), "lima")
+}
+
+func mapNodeToLimaInstance(node k8s.NodeInfo) LimaInstanceSummary {
+	status := limaNodeStatus(node.Conditions)
+
+	limaVersion := "unknown"
+	if node.Labels != nil {
+		if v, ok := node.Labels["lima.sh/version"]; ok && strings.TrimSpace(v) != "" {
+			limaVersion = v
+		}
+	}
+
+	return LimaInstanceSummary{
+		Name:        node.Name,
+		Status:      status,
+		CPUCores:    parseCPUCores(node.CPUCapacity),
+		MemoryGB:    parseCapacityGB(node.MemoryCapacity),
+		DiskGB:      parseCapacityGB(node.StorageCapacity),
+		Arch:        valueOrUnknown(node.Architecture),
+		OS:          firstNonEmpty(node.OSImage, node.OS, "Linux"),
+		LimaVersion: limaVersion,
+		LastSeen:    time.Now().UTC().Format(time.RFC3339),
+	}
+}
+
+func limaNodeStatus(conditions []k8s.NodeCondition) string {
+	hasPressure := false
+	isReady := false
+
+	for _, c := range conditions {
+		if c.Type == "Ready" && strings.EqualFold(c.Status, "True") {
+			isReady = true
+		}
+
+		if (c.Type == "DiskPressure" || c.Type == "MemoryPressure" || c.Type == "PIDPressure") && strings.EqualFold(c.Status, "True") {
+			hasPressure = true
+		}
+	}
+
+	if hasPressure {
+		return "broken"
+	}
+
+	if isReady {
+		return "running"
+	}
+
+	return "stopped"
+}
+
+func parseCPUCores(raw string) int {
+	quantity, err := resource.ParseQuantity(strings.TrimSpace(raw))
+	if err != nil {
+		if strings.HasSuffix(raw, "m") {
+			milliRaw := strings.TrimSpace(strings.TrimSuffix(raw, "m"))
+			milli, convErr := strconv.Atoi(milliRaw)
+			if convErr == nil && milli > 0 {
+				return int(math.Ceil(float64(milli) / 1000.0))
+			}
+		}
+
+		cores, convErr := strconv.Atoi(strings.TrimSpace(raw))
+		if convErr == nil && cores > 0 {
+			return cores
+		}
+
+		return 0
+	}
+
+	milli := quantity.MilliValue()
+	if milli <= 0 {
+		return 0
+	}
+
+	return int(math.Ceil(float64(milli) / 1000.0))
+}
+
+func parseCapacityGB(raw string) int {
+	quantity, err := resource.ParseQuantity(strings.TrimSpace(raw))
+	if err != nil {
+		return 0
+	}
+
+	bytes := quantity.Value()
+	if bytes <= 0 {
+		return 0
+	}
+
+	const bytesPerGiB = 1024 * 1024 * 1024
+	return int(math.Round(float64(bytes) / float64(bytesPerGiB)))
+}
+
+func valueOrUnknown(v string) string {
+	trimmed := strings.TrimSpace(v)
+	if trimmed == "" {
+		return "unknown"
+	}
+	return trimmed
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, v := range values {
+		if strings.TrimSpace(v) != "" {
+			return v
+		}
+	}
+	return ""
+}

--- a/pkg/api/handlers/lima_test.go
+++ b/pkg/api/handlers/lima_test.go
@@ -1,0 +1,153 @@
+package handlers
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	k8sfake "k8s.io/client-go/kubernetes/fake"
+	k8stesting "k8s.io/client-go/testing"
+)
+
+func TestLimaList_DemoModeReturnsDemoData(t *testing.T) {
+	env := setupTestEnv(t)
+	handler := NewLimaHandlers(env.K8sClient)
+	env.App.Get("/api/lima", handler.ListLima)
+
+	req, err := http.NewRequest(http.MethodGet, "/api/lima", nil)
+	require.NoError(t, err)
+	req.Header.Set("X-Demo-Mode", "true")
+
+	resp, err := env.App.Test(req, 5000)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+	var payload LimaListResponse
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&payload))
+	assert.True(t, payload.IsDemoData)
+	assert.NotEmpty(t, payload.LimaInstances)
+}
+
+func TestLimaList_NoClientReturns503DemoFallback(t *testing.T) {
+	env := setupTestEnv(t)
+	handler := NewLimaHandlers(nil)
+	env.App.Get("/api/lima", handler.ListLima)
+
+	req, err := http.NewRequest(http.MethodGet, "/api/lima", nil)
+	require.NoError(t, err)
+
+	resp, err := env.App.Test(req, 5000)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusServiceUnavailable, resp.StatusCode)
+
+	var payload LimaListResponse
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&payload))
+	assert.True(t, payload.IsDemoData)
+	assert.Len(t, payload.LimaInstances, 0)
+}
+
+func TestLimaList_ReachableClusterNoLimaReturns200LiveEmpty(t *testing.T) {
+	env := setupTestEnv(t)
+	handler := NewLimaHandlers(env.K8sClient)
+	env.App.Get("/api/lima", handler.ListLima)
+
+	req, err := http.NewRequest(http.MethodGet, "/api/lima", nil)
+	require.NoError(t, err)
+
+	resp, err := env.App.Test(req, 5000)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+	var payload LimaListResponse
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&payload))
+	assert.False(t, payload.IsDemoData)
+	assert.Len(t, payload.LimaInstances, 0)
+}
+
+func TestLimaList_AllClusterQueriesFailReturns503DemoFallback(t *testing.T) {
+	env := setupTestEnv(t)
+	handler := NewLimaHandlers(env.K8sClient)
+	env.App.Get("/api/lima", handler.ListLima)
+
+	client, err := env.K8sClient.GetClient("test-cluster")
+	require.NoError(t, err)
+
+	fakeClient, ok := client.(*k8sfake.Clientset)
+	require.True(t, ok)
+
+	fakeClient.PrependReactor("list", "nodes", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		return true, nil, errors.New("dial tcp 10.0.0.1:443: connect: connection refused")
+	})
+
+	req, err := http.NewRequest(http.MethodGet, "/api/lima", nil)
+	require.NoError(t, err)
+
+	resp, err := env.App.Test(req, 5000)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusServiceUnavailable, resp.StatusCode)
+
+	var payload LimaListResponse
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&payload))
+	assert.True(t, payload.IsDemoData)
+	assert.Len(t, payload.LimaInstances, 0)
+}
+
+func TestLimaList_LimaNodeDetectedFromLabels(t *testing.T) {
+	env := setupTestEnv(t)
+	handler := NewLimaHandlers(env.K8sClient)
+	env.App.Get("/api/lima", handler.ListLima)
+
+	client, err := env.K8sClient.GetClient("test-cluster")
+	require.NoError(t, err)
+
+	_, err = client.CoreV1().Nodes().Create(context.Background(), &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "worker-1",
+			Labels: map[string]string{
+				"lima.sh/instance": "default",
+				"lima.sh/version":  "0.18.0",
+			},
+		},
+		Status: corev1.NodeStatus{
+			NodeInfo: corev1.NodeSystemInfo{
+				OSImage:      "Ubuntu 22.04 LTS",
+				Architecture: "x86_64",
+			},
+			Capacity: corev1.ResourceList{
+				corev1.ResourceCPU:              resource.MustParse("4000m"),
+				corev1.ResourceMemory:           resource.MustParse("8Gi"),
+				corev1.ResourceEphemeralStorage: resource.MustParse("60Gi"),
+			},
+			Conditions: []corev1.NodeCondition{
+				{Type: corev1.NodeReady, Status: corev1.ConditionTrue},
+			},
+		},
+	}, metav1.CreateOptions{})
+	require.NoError(t, err)
+
+	req, err := http.NewRequest(http.MethodGet, "/api/lima", nil)
+	require.NoError(t, err)
+
+	resp, err := env.App.Test(req, 5000)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+	var payload LimaListResponse
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&payload))
+	require.Len(t, payload.LimaInstances, 1)
+	assert.False(t, payload.IsDemoData)
+	assert.Equal(t, "worker-1", payload.LimaInstances[0].Name)
+	assert.Equal(t, "running", payload.LimaInstances[0].Status)
+	assert.Equal(t, 4, payload.LimaInstances[0].CPUCores)
+	assert.Equal(t, 8, payload.LimaInstances[0].MemoryGB)
+	assert.Equal(t, 60, payload.LimaInstances[0].DiskGB)
+	assert.Equal(t, "0.18.0", payload.LimaInstances[0].LimaVersion)
+}

--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -434,10 +434,10 @@ func (s *Server) setupMiddleware() {
 		// runs on a different port than the backend (cross-origin).
 		// See: web/src/lib/constants/network.ts (LOCAL_AGENT_HTTP_URL,
 		// LOCAL_AGENT_WS_URL) for the exact URLs the frontend uses.
-		const kcAgentLoopback = "http://127.0.0.1:8585"    // kc-agent HTTP on loopback IP
-		const kcAgentLoopbackWS = "ws://127.0.0.1:8585"    // kc-agent WebSocket on loopback IP
-		const kcAgentLocalhost = "http://localhost:8585"    // kc-agent HTTP on localhost
-		const kcAgentLocalhostWS = "ws://localhost:8585"    // kc-agent WebSocket on localhost
+		const kcAgentLoopback = "http://127.0.0.1:8585"  // kc-agent HTTP on loopback IP
+		const kcAgentLoopbackWS = "ws://127.0.0.1:8585"  // kc-agent WebSocket on loopback IP
+		const kcAgentLocalhost = "http://localhost:8585" // kc-agent HTTP on localhost
+		const kcAgentLocalhostWS = "ws://localhost:8585" // kc-agent WebSocket on localhost
 
 		// script-src includes 'wasm-unsafe-eval' because the SQLite cache
 		// worker compiles a WebAssembly module at runtime; without it the
@@ -661,8 +661,8 @@ func (s *Server) setupRoutes() {
 	authLimiterMaxRequests := 10         // max requests per window
 	authLimiterWindow := 1 * time.Minute // sliding window duration
 	authLimiter := limiter.New(limiter.Config{
-		Max:        authLimiterMaxRequests,
-		Expiration: authLimiterWindow,
+		Max:          authLimiterMaxRequests,
+		Expiration:   authLimiterWindow,
 		KeyGenerator: middleware.CompositeKey,
 		LimitReached: func(c *fiber.Ctx) error {
 			ip := c.IP()
@@ -701,7 +701,7 @@ func (s *Server) setupRoutes() {
 
 	// Public endpoint rate limiter — loose limit to prevent DoS on unauthenticated
 	// routes (active-users, ping, nightly-e2e, youtube, medium, analytics) (#7029).
-	publicLimiterMaxRequests := 60        // max requests per window per IP
+	publicLimiterMaxRequests := 60         // max requests per window per IP
 	publicLimiterWindow := 1 * time.Minute // sliding window duration
 	publicLimiter := limiter.New(limiter.Config{
 		Max:        publicLimiterMaxRequests,
@@ -1103,6 +1103,10 @@ func (s *Server) setupRoutes() {
 	// CRD routes (Custom Resource Definition browser)
 	crdHandlers := handlers.NewCRDHandlers(s.k8sClient)
 	api.Get("/crds", crdHandlers.ListCRDs)
+
+	// Lima routes (Lima VM status)
+	limaHandlers := handlers.NewLimaHandlers(s.k8sClient)
+	api.Get("/lima", limaHandlers.ListLima)
 
 	// MCS ServiceExport routes
 	svcExportHandlers := handlers.NewServiceExportHandlers(s.k8sClient)

--- a/presets/cncf-lima.json
+++ b/presets/cncf-lima.json
@@ -5,6 +5,6 @@
   "description": "Lima virtual machine instances and resource usage.",
   "category": "Runtime",
   "project": "lima",
-  "cncf_status": "sandbox",
+  "cncf_status": "incubating",
   "config": {}
 }

--- a/web/src/components/cards/lima_status/useLimaStatus.ts
+++ b/web/src/components/cards/lima_status/useLimaStatus.ts
@@ -1,9 +1,9 @@
-import { useCache } from '../../../lib/cache'
+import { useState, useEffect, useCallback, useRef } from 'react'
+import { useClusters } from '../../../hooks/useMCP'
+import { STORAGE_KEY_TOKEN } from '../../../lib/constants'
+import { FETCH_DEFAULT_TIMEOUT_MS } from '../../../lib/constants/network'
 import { useCardLoadingState } from '../CardDataContext'
 import { LIMA_DEMO_DATA, type LimaDemoData, type LimaInstance } from './demoData'
-import { FETCH_DEFAULT_TIMEOUT_MS } from '../../../lib/constants/network'
-import { authFetch } from '../../../lib/api'
-import { LOCAL_AGENT_HTTP_URL } from '../../../lib/constants/network'
 
 export interface LimaStatus {
   instances: LimaInstance[]
@@ -29,144 +29,85 @@ const INITIAL_DATA: LimaStatus = {
   lastCheckTime: new Date().toISOString(),
 }
 
-const CACHE_KEY = 'lima-status'
+const CACHE_EXPIRY_MS = 300_000
+const REFRESH_INTERVAL_MS = 120_000
+const FAILURE_THRESHOLD = 3
+const LIMA_CACHE_KEY = 'kc-lima-cache'
+const STATUS_SERVICE_UNAVAILABLE = 503
 
-/**
- * NodeInfo shape returned by the console backend at GET /api/mcp/nodes.
- * Only the fields we need for Lima detection are typed here.
- * Backend returns flat cpuCapacity/memoryCapacity fields, not nested capacity object.
- */
-interface BackendNodeInfo {
-  name?: string
-  osImage?: string
-  labels?: Record<string, string>
-  conditions?: Array<{ type?: string; status?: string }>
-  cpuCapacity?: string
-  memoryCapacity?: string
+interface LimaListResponse {
+  limaInstances: LimaInstance[]
+  isDemoData: boolean
 }
 
-/**
- * Fetch Lima VM status via the console backend proxy.
- *
- * Lima nodes are identified by:
- * - A `lima.sh/instance` label on the node
- * - Node name starting with "lima-"
- * - The osImage or annotation containing "lima"
- *
- * Uses GET /api/mcp/nodes which proxies through the backend to all connected
- * clusters. The backend returns { nodes: NodeInfo[], source: string }.
- */
-async function fetchLimaStatus(): Promise<LimaStatus> {
-  const resp = await authFetch(`${LOCAL_AGENT_HTTP_URL}/nodes`, {
-    headers: { Accept: 'application/json' },
-    signal: AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS),
-  })
+interface CachedData {
+  data: LimaStatus
+  timestamp: number
+  isDemoData: boolean
+}
 
-  if (!resp.ok) {
-    throw new Error(`HTTP ${resp.status}`)
+function authHeaders(): Record<string, string> {
+  const token = localStorage.getItem(STORAGE_KEY_TOKEN)
+  const headers: Record<string, string> = { Accept: 'application/json' }
+  if (token) {
+    headers.Authorization = `Bearer ${token}`
   }
+  return headers
+}
 
-  const body: { nodes?: BackendNodeInfo[] } = await resp.json()
-  const allNodes = Array.isArray(body?.nodes) ? body.nodes : []
-
-  // Detect Lima nodes by name prefix, label, or OS image
-  // Note: Backend only exposes labels, not annotations
-  const limaNodes = allNodes.filter(
-    (n) =>
-      n.name?.startsWith('lima-') ||
-      n.labels?.['lima.sh/instance'] !== undefined ||
-      n.osImage?.toLowerCase().includes('lima'),
-  )
-
-  if (limaNodes.length === 0) {
-    return {
-      ...INITIAL_DATA,
-      health: 'not-detected',
-      lastCheckTime: new Date().toISOString(),
+function loadFromCache(): CachedData | null {
+  try {
+    const stored = localStorage.getItem(LIMA_CACHE_KEY)
+    if (!stored) {
+      return null
     }
-  }
 
-  /**
-   * Parse CPU quantity strings like "4", "4000m" to integer Core count.
-   */
-  function parseCpuCores(cpu?: string): number {
-    if (!cpu) return 0
-    if (cpu.endsWith('m')) return Math.ceil(parseInt(cpu) / 1000)
-    return parseInt(cpu) || 0
-  }
-
-  /**
-   * Parse memory quantity strings like "8Gi", "4096Mi" to integer GB.
-   */
-  function parseMemoryGB(mem?: string): number {
-    if (!mem) return 0
-    const gib = mem.match(/^(\d+)Gi$/)
-    if (gib) return parseInt(gib[1])
-    const mib = mem.match(/^(\d+)Mi$/)
-    if (mib) return Math.round(parseInt(mib[1]) / 1024)
-    const ki = mem.match(/^(\d+)Ki$/)
-    if (ki) return Math.round(parseInt(ki[1]) / (1024 * 1024))
-    return 0
-  }
-
-  const instances: LimaInstance[] = limaNodes.map((n) => {
-    const isReady =
-      n.conditions?.some((c) => c.type === 'Ready' && c.status === 'True') ??
-      false
-    const hasPressure =
-      n.conditions?.some(
-        (c) =>
-          (c.type === 'DiskPressure' ||
-            c.type === 'MemoryPressure' ||
-            c.type === 'PIDPressure') &&
-          c.status === 'True',
-      ) ?? false
-
-    const nodeStatus: 'running' | 'stopped' | 'broken' = hasPressure
-      ? 'broken'
-      : isReady
-        ? 'running'
-        : 'stopped'
-
-    // Try to extract Lima version from label (best effort)
-    const limaVersion = n.labels?.['lima.sh/version'] ?? 'unknown'
-
-    return {
-      name: n.name ?? 'unknown',
-      status: nodeStatus,
-      cpuCores: parseCpuCores(n.cpuCapacity),
-      memoryGB: parseMemoryGB(n.memoryCapacity),
-      diskGB: 0, // disk info not in standard node capacity
-      arch:
-        n.labels?.['kubernetes.io/arch'] ??
-        n.labels?.['beta.kubernetes.io/arch'] ??
-        'unknown',
-      os: n.osImage ?? 'Linux',
-      limaVersion,
-      lastSeen: new Date().toISOString(),
+    const parsed = JSON.parse(stored) as CachedData
+    if (Date.now() - parsed.timestamp < CACHE_EXPIRY_MS) {
+      return parsed
     }
-  })
+  } catch {
+    // Ignore storage/parse errors
+  }
 
-  const runningNodes = instances.filter((i) => i.status === 'running').length
-  const stoppedNodes = instances.filter((i) => i.status === 'stopped').length
-  const brokenNodes = instances.filter((i) => i.status === 'broken').length
+  return null
+}
 
-  const totalCpuCores = instances.reduce((s, i) => s + i.cpuCores, 0)
-  const totalMemoryGB = instances.reduce((s, i) => s + i.memoryGB, 0)
+function saveToCache(data: LimaStatus, isDemoData: boolean): void {
+  try {
+    localStorage.setItem(LIMA_CACHE_KEY, JSON.stringify({
+      data,
+      timestamp: Date.now(),
+      isDemoData,
+    }))
+  } catch {
+    // Ignore quota errors
+  }
+}
 
-  const health: 'healthy' | 'degraded' =
-    brokenNodes > 0 || stoppedNodes > 0 ? 'degraded' : 'healthy'
+function buildLimaStatus(instances: LimaInstance[], lastCheckTime?: string): LimaStatus {
+  const runningNodes = instances.filter(i => i.status === 'running').length
+  const stoppedNodes = instances.filter(i => i.status === 'stopped').length
+  const brokenNodes = instances.filter(i => i.status === 'broken').length
+
+  const totalCpuCores = instances.reduce((sum, i) => sum + i.cpuCores, 0)
+  const totalMemoryGB = instances.reduce((sum, i) => sum + i.memoryGB, 0)
+
+  const health: 'healthy' | 'degraded' | 'not-detected' =
+    instances.length === 0
+      ? 'not-detected'
+      : (brokenNodes > 0 || stoppedNodes > 0 ? 'degraded' : 'healthy')
 
   return {
     instances,
-    totalNodes: limaNodes.length,
+    totalNodes: instances.length,
     runningNodes,
     stoppedNodes,
     brokenNodes,
     health,
     totalCpuCores,
     totalMemoryGB,
-    lastCheckTime: new Date().toISOString(),
+    lastCheckTime: lastCheckTime || new Date().toISOString(),
   }
 }
 
@@ -184,6 +125,17 @@ function toDemoStatus(demo: LimaDemoData): LimaStatus {
   }
 }
 
+function getDemoLimaStatus(noReachableClusters: boolean): LimaStatus {
+  const demoStatus = toDemoStatus(LIMA_DEMO_DATA)
+
+  if (noReachableClusters) {
+    // Keep demo fallback shape stable while ensuring recency indicators remain current.
+    return { ...demoStatus, lastCheckTime: new Date().toISOString() }
+  }
+
+  return demoStatus
+}
+
 export interface UseLimaStatusResult {
   data: LimaStatus
   loading: boolean
@@ -191,42 +143,123 @@ export interface UseLimaStatusResult {
   consecutiveFailures: number
   showSkeleton: boolean
   showEmptyState: boolean
-  /** True when displaying demo/fallback data (no real cluster connected) */
   isDemoData: boolean
 }
 
 export function useLimaStatus(): UseLimaStatusResult {
-  const { data, isLoading, isFailed, consecutiveFailures, isDemoFallback } =
-    useCache<LimaStatus>({
-      key: CACHE_KEY,
-      category: 'default',
-      initialData: INITIAL_DATA,
-      demoData: toDemoStatus(LIMA_DEMO_DATA),
-      persist: true,
-      fetcher: fetchLimaStatus,
-    })
+  const { deduplicatedClusters: clusters, isLoading: clustersLoading } = useClusters()
 
-  const effectiveIsDemoData = isDemoFallback && !isLoading
+  // Initialize from cache using a snapshot to avoid reading refs during render.
+  const cachedData = useRef(loadFromCache())
+  const cachedSnapshot = cachedData.current
 
-  // hasAnyData is true only when Lima nodes exist.
-  // 'not-detected' is NOT counted as "has data" so the empty state shows properly.
+  const [data, setData] = useState<LimaStatus>(cachedSnapshot?.data || INITIAL_DATA)
+  const [isDemoData, setIsDemoData] = useState(cachedSnapshot?.isDemoData ?? true)
+  const [isLoading, setIsLoading] = useState(!cachedSnapshot)
+  const [isRefreshing, setIsRefreshing] = useState(false)
+  const [consecutiveFailures, setConsecutiveFailures] = useState(0)
+  const [lastRefresh, setLastRefresh] = useState<number | null>(cachedSnapshot?.timestamp || null)
+
+  const initialLoadDone = useRef(!!cachedSnapshot)
+
+  // Keep refetch stable while still reading current cluster reachability.
+  // This avoids interval thrash from array identity changes in useClusters.
+  const clustersRef = useRef(clusters)
+  clustersRef.current = clusters
+
+  const refetch = useCallback(async (silent = false) => {
+    if (!silent && !initialLoadDone.current) {
+      setIsLoading(true)
+    }
+
+    if (silent && initialLoadDone.current) {
+      setIsRefreshing(true)
+    }
+
+    try {
+      const res = await fetch('/api/lima', {
+        headers: authHeaders(),
+        signal: AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS),
+      })
+
+      if (res.status === STATUS_SERVICE_UNAVAILABLE) {
+        throw new Error('Service unavailable')
+      }
+
+      if (!res.ok) {
+        throw new Error(`HTTP ${res.status}: ${res.statusText}`)
+      }
+
+      const response = (await res.json()) as LimaListResponse
+      if (response.isDemoData) {
+        throw new Error('Backend returned demo data indicator')
+      }
+
+      const liveInstances = response.limaInstances || []
+      const liveStatus = buildLimaStatus(liveInstances)
+
+      setData(liveStatus)
+      setIsDemoData(false)
+      setConsecutiveFailures(0)
+      setLastRefresh(Date.now())
+      initialLoadDone.current = true
+      saveToCache(liveStatus, false)
+    } catch {
+      const currentClusters = clustersRef.current
+      const reachableClusterCount = (currentClusters || []).filter(c => c.reachable !== false).length
+      const demoStatus = getDemoLimaStatus(reachableClusterCount === 0)
+
+      setData(demoStatus)
+      setIsDemoData(true)
+      setConsecutiveFailures(prev => prev + 1)
+      setLastRefresh(Date.now())
+      initialLoadDone.current = true
+      saveToCache(demoStatus, true)
+     } finally {
+       setIsLoading(false)
+       setIsRefreshing(false)
+     }
+  }, [])
+
+  // Initial load after cluster metadata finishes loading.
+  useEffect(() => {
+    if (!clustersLoading) {
+      refetch()
+    }
+  }, [clustersLoading]) // eslint-disable-line react-hooks/exhaustive-deps
+
+  // Auto-refresh in background once the initial load has completed.
+  useEffect(() => {
+    if (!initialLoadDone.current) {
+      return
+    }
+
+    const interval = setInterval(() => {
+      refetch(true)
+    }, REFRESH_INTERVAL_MS)
+
+    return () => clearInterval(interval)
+  }, [refetch])
+
   const hasAnyData = data.totalNodes > 0
 
   const { showSkeleton, showEmptyState } = useCardLoadingState({
-    isLoading,
+    isLoading: (isLoading || clustersLoading) && !hasAnyData,
+    isRefreshing,
     hasAnyData,
-    isFailed,
+    isFailed: consecutiveFailures >= FAILURE_THRESHOLD,
     consecutiveFailures,
-    isDemoData: effectiveIsDemoData,
+    isDemoData,
+    lastRefresh,
   })
 
   return {
     data,
-    loading: isLoading,
-    error: isFailed && !hasAnyData,
+    loading: isLoading || clustersLoading,
+    error: consecutiveFailures >= FAILURE_THRESHOLD && !hasAnyData,
     consecutiveFailures,
     showSkeleton,
     showEmptyState,
-    isDemoData: effectiveIsDemoData,
+    isDemoData,
   }
 }

--- a/web/src/components/dashboard/shared/cardCatalog.ts
+++ b/web/src/components/dashboard/shared/cardCatalog.ts
@@ -309,6 +309,7 @@ export const CARD_CATALOG = {
   'Misc': [
     { type: 'buildpacks_status', title: 'Buildpacks Status', description: 'Cloud Native Buildpacks detection, builders, and image build status', visualization: 'status' },
     { type: 'flatcar_status', title: 'Flatcar Container Linux', description: 'Flatcar node OS versions, update status, and version distribution', visualization: 'status' },
+    { type: 'lima_status', title: 'Lima', description: 'Lima virtual machine instances, runtime health, and resource usage', visualization: 'status' },
     { type: 'artifact_hub_status', title: 'Artifact Hub', description: 'Artifact Hub package discovery and repository sync status', visualization: 'status' },
     { type: 'crio_status', title: 'CRI-O', description: 'CRI-O container runtime metrics, image pulls, and pod sandbox status', visualization: 'status' },
     { type: 'github_activity', title: 'GitHub Activity', description: 'Monitor GitHub repository activity - PRs, issues, releases, and contributors', visualization: 'table' },

--- a/web/src/test/card-loading-standard.test.ts
+++ b/web/src/test/card-loading-standard.test.ts
@@ -119,7 +119,6 @@ const KNOWN_VIOLATIONS: Record<string, Set<string>> = {
   'Kubectl.tsx': new Set(['bare-isLoading', 'missing-isRefreshing']),
   'kubevela_status/useKubeVelaStatus.ts': new Set(['bare-isLoading']),
   'KustomizationStatus.tsx': new Set(['bare-isLoading', 'missing-isRefreshing']),
-  'lima_status/useLimaStatus.ts': new Set(['bare-isLoading']),
   'llmd/NightlyE2EStatus.tsx': new Set(['bare-isLoading']),
   'NamespaceMonitor.tsx': new Set(['bare-isLoading']),
   'NamespaceRBAC.tsx': new Set(['missing-isRefreshing']),


### PR DESCRIPTION
## Summary
Completes the data layer for the Lima monitoring card, which was disabled in #2211 due to missing live data wiring.

## Changes
### Backend
- `pkg/api/handlers/lima.go` — new `GET /api/lima` handler using `DeduplicatedClusters()` for cross-cluster Lima node aggregation; returns `503 + isDemoData:true` when no clusters reachable, `200 + isDemoData:false` on live success, `200 + empty array` when clusters are reachable but no Lima nodes detected
- `pkg/api/handlers/demo_data.go` — demo payload for Lima endpoint
- `pkg/api/server.go` — authenticated route registration
- `pkg/api/auth_sweep_test.go` — auth protection coverage
- `pkg/api/handlers/lima_test.go` — handler tests (success, demo mode, cluster-unavailable)

### Frontend
- `useLimaStatus.ts` — rewritten to API-first + demo fallback pattern (mirrors `useCRDs.ts`); wires `isRefreshing` and `isDemoData` into `useCardLoadingState`; includes `initialLoadDone` ref and `clustersRef` anti-churn pattern
- `cardCatalog.ts` — adds Lima to Browse Cards catalog
- `card-loading-standard.test.ts` — removes Lima from known violations (now compliant)
- `presets/cncf-lima.json` — updates maturity from `sandbox` to `incubating`

## Testing
- `go test ./pkg/api/handlers -run Lima -count=1` ✅
- `go test ./pkg/api -run TestProtectedRoutes_UnauthenticatedReturn401 -count=1` ✅
- Changed-file ESLint ✅
- `npm run build` ✅ (BUILD_EXIT:0)

## Lint Baseline Note
Full `npm run lint` reports 1,200 pre-existing violations in files not touched by this PR (e.g., `DashboardGrid.tsx`, `registerHooks.ts`). All Lima-specific files pass changed-file ESLint. Happy to open a separate tracking issue for the baseline lint debt if useful.

## Related
Closes kubestellar/console-marketplace#44
