### PR TITLE
🐛 fix(backend): surface silently-swallowed K8s API errors

### DIFF
--- a/pkg/api/handlers/workloads.go
+++ b/pkg/api/handlers/workloads.go
@@ -635,6 +635,23 @@ func (h *WorkloadHandlers) EvaluateClusterQuery(c *fiber.Ctx) error {
 		return c.Status(400).JSON(fiber.Map{"error": "invalid request"})
 	}
 
+	// Validate the label selector up front so we can return a specific
+	// 400 Bad Request with the parser's error message instead of silently
+	// matching zero clusters and returning a 200 OK with an empty result
+	// set (issue #9092). Matching code below may re-parse, but doing it
+	// here guarantees we never swallow the parse error.
+	if query.LabelSelector != "" {
+		if _, selErr := labels.Parse(query.LabelSelector); selErr != nil {
+			slog.Info("[Workloads] invalid label selector in cluster query",
+				"selector", query.LabelSelector, "error", selErr)
+			return c.Status(400).JSON(fiber.Map{
+				"error":         "invalid label selector",
+				"labelSelector": query.LabelSelector,
+				"detail":        selErr.Error(),
+			})
+		}
+	}
+
 	ctx, cancel := context.WithTimeout(c.Context(), workloadListTimeout)
 	defer cancel()
 
@@ -721,10 +738,15 @@ func clusterMatchesQuery(health k8s.ClusterHealth, nodes []k8s.NodeInfo, query *
 	return true
 }
 
-// clusterMatchesLabelSelector returns true if at least one node matches the selector
+// clusterMatchesLabelSelector returns true if at least one node matches the selector.
+// The EvaluateClusterQuery handler validates the selector up front and returns
+// 400 on parse errors (issue #9092); we still log here as a defense-in-depth
+// signal in case any future caller feeds an unvalidated selector string.
 func clusterMatchesLabelSelector(nodes []k8s.NodeInfo, selectorStr string) bool {
 	selector, err := labels.Parse(selectorStr)
 	if err != nil {
+		slog.Warn("[Workloads] label selector parse failed in matcher (should have been validated upstream)",
+			"selector", selectorStr, "error", err)
 		return false
 	}
 	for _, node := range nodes {

--- a/pkg/k8s/client_gpu.go
+++ b/pkg/k8s/client_gpu.go
@@ -30,8 +30,16 @@ func (m *MultiClusterClient) GetGPUNodes(ctx context.Context, contextName string
 	}
 
 	// Fetch all pods once upfront to calculate accelerator allocations per node
-	// This is much faster than querying pods per-node for large clusters
-	allPods, _ := client.CoreV1().Pods("").List(ctx, metav1.ListOptions{})
+	// This is much faster than querying pods per-node for large clusters.
+	// A failure here is non-fatal — we still return the node inventory with
+	// zero allocations, but we log the error so operators can see RBAC /
+	// connectivity problems rather than seeing silently wrong allocation
+	// numbers in the UI (issue #9091).
+	allPods, allPodsErr := client.CoreV1().Pods("").List(ctx, metav1.ListOptions{})
+	if allPodsErr != nil {
+		slog.Error("[GPUNodes] failed to list pods for allocation accounting",
+			"cluster", contextName, "error", allPodsErr)
+	}
 	// Track allocations by node and accelerator type
 	gpuAllocationByNode := make(map[string]int) // GPU allocations
 	tpuAllocationByNode := make(map[string]int) // TPU allocations
@@ -342,14 +350,27 @@ func (m *MultiClusterClient) GetGPUNodeHealth(ctx context.Context, contextName s
 		operatorPods = append(operatorPods, pods.Items...)
 	}
 
-	// 4. Find non-running pods for stuck pod detection (exclude Succeeded/Running)
-	allPods, _ := client.CoreV1().Pods("").List(ctx, metav1.ListOptions{})
+	// 4. Find non-running pods for stuck pod detection (exclude Succeeded/Running).
+	// A failure here is non-fatal — we still return per-node health, but we
+	// log so operators can see why stuck-pod detection is effectively
+	// disabled (issue #9091).
+	allPods, allPodsErr := client.CoreV1().Pods("").List(ctx, metav1.ListOptions{})
+	if allPodsErr != nil {
+		slog.Error("[GPUNodeHealth] failed to list pods for stuck pod detection",
+			"cluster", contextName, "error", allPodsErr)
+	}
 
-	// 5. Get warning events from the last hour for GPU reset detection
+	// 5. Get warning events from the last hour for GPU reset detection.
+	// Non-fatal, but log so operators can see why GPU-reset signals are
+	// missing instead of silently getting a clean health state (issue #9091).
 	oneHourAgo := time.Now().Add(-1 * time.Hour)
-	events, _ := client.CoreV1().Events("").List(ctx, metav1.ListOptions{
+	events, eventsErr := client.CoreV1().Events("").List(ctx, metav1.ListOptions{
 		FieldSelector: "type=Warning",
 	})
+	if eventsErr != nil {
+		slog.Error("[GPUNodeHealth] failed to list warning events for GPU reset detection",
+			"cluster", contextName, "error", eventsErr)
+	}
 
 	// 6. Build health status for each GPU node
 	checkedAt := time.Now().UTC().Format(time.RFC3339)

--- a/pkg/k8s/client_resources.go
+++ b/pkg/k8s/client_resources.go
@@ -3,6 +3,7 @@ package k8s
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"sort"
 	"strings"
 	"time"
@@ -718,7 +719,10 @@ func (m *MultiClusterClient) GetServices(ctx context.Context, contextName, names
 	// real number of ready addresses backing each service. We list in the
 	// same namespace scope as the Services list call so the result set is
 	// comparable. If this call fails we still return services with
-	// Endpoints=0 rather than failing the whole request (issue #6150).
+	// Endpoints=0 rather than failing the whole request (issue #6150), but
+	// we log the error so operators can see RBAC / connectivity problems
+	// instead of silently seeing every service report zero ready endpoints
+	// (issue #9091).
 	endpointReadyCounts := make(map[string]int) // key: "<namespace>/<name>"
 	if epList, epErr := client.CoreV1().Endpoints(namespace).List(ctx, metav1.ListOptions{}); epErr == nil {
 		for _, ep := range epList.Items {
@@ -728,6 +732,9 @@ func (m *MultiClusterClient) GetServices(ctx context.Context, contextName, names
 			}
 			endpointReadyCounts[ep.Namespace+"/"+ep.Name] = ready
 		}
+	} else {
+		slog.Error("[Services] failed to list endpoints for readiness counts",
+			"cluster", contextName, "namespace", namespace, "error", epErr)
 	}
 
 	var result []Service


### PR DESCRIPTION
## Summary

Fixes #9091, Fixes #9092.

Several Kubernetes-facing backend paths were silently swallowing errors, causing the UI to display a clean health state, zero usage, or zero query matches instead of surfacing a real failure (RBAC, connectivity, or malformed input).

This PR adds structured `slog` error logs at each drop site and, for the cluster-query handler, converts an invalid label selector into a proper `400 Bad Request` response.

## Changes

### `pkg/k8s/client_gpu.go`

- `GetGPUNodes` (line 34): the `allPods, _ := ...` pattern for GPU/TPU/AIU/XPU allocation accounting now logs at `slog.Error` when the pod list fails. Behavior preserved — we still return the node inventory with zero allocations — but operators can see why.
- `GetGPUNodeHealth` (line 346): the `allPods, _ := ...` pattern for stuck-pod detection now logs at `slog.Error`.
- `GetGPUNodeHealth` (line 350): the `events, _ := ...` pattern for GPU-reset warning-event detection now logs at `slog.Error`.

### `pkg/k8s/client_resources.go`

- `GetServices` (line 723): added `log/slog` import and an `else` branch that logs at `slog.Error` when the endpoints list fails. Behavior preserved (endpoint counts fall back to zero per #6150) but operators see RBAC/connectivity failures instead of silently reporting zero ready endpoints.

### `pkg/api/handlers/workloads.go`

- `EvaluateClusterQuery`: added up-front selector validation via `labels.Parse`. If the selector is malformed we return `400 Bad Request` with the parser's error message, the offending selector string, and a stable `error: "invalid label selector"` key. This replaces the old behavior where a bad selector would silently produce a `200 OK` with zero matches.
- `clusterMatchesLabelSelector`: the pre-existing `if err != nil { return false }` branch now logs at `slog.Warn` as defense-in-depth in case any future caller passes an unvalidated selector.

## Design notes

- No magic numbers introduced. All new code uses existing constants / the package logger.
- No behavior change for successful paths.
- For the GPU / endpoints sites the contract with callers is deliberately preserved (fail-soft, return partial data) because the UI handles partial/empty state — but now operators get log visibility.
- For the cluster-query handler the contract is changed: previously malformed selectors produced `200 OK` with an empty result, now they produce `400 Bad Request`. This matches the issue author's expected behavior and is the only user-visible change.

## Test plan

- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] `npm run build` passes (frontend not touched, but verified)
- [x] `npx tsc --noEmit` passes
- [ ] Manual: confirm `/api/cluster-groups/evaluate` with body `{"labelSelector":"app==nginx"}` returns 400
- [ ] Manual: confirm `/api/cluster-groups/evaluate` with a valid selector still returns 200
- [ ] Manual: with restricted RBAC, confirm `[GPUNodes]` / `[GPUNodeHealth]` / `[Services]` error lines now appear in backend logs