### PR TITLE
🐛 fix(cards): guard NaN timestamps + force re-render on SSE reconnect

### DIFF
--- a/web/src/components/cards/CardWrapper.tsx
+++ b/web/src/components/cards/CardWrapper.tsx
@@ -80,15 +80,41 @@ function pushEscapeHandler(close: () => void): () => void {
 /** One hour in milliseconds — default snooze duration for card swaps */
 const ONE_HOUR_MS = 60 * 60 * 1000
 
-// Format relative time (e.g., "2m ago", "1h ago")
+// ---------------------------------------------------------------------------
+// Relative-time formatting for the card header "last updated" label.
+// Named constants (not magic numbers) so every threshold is explicit.
+// ---------------------------------------------------------------------------
+/** Seconds in one minute — rollover from "Xs" to "Xm" */
+const SECONDS_PER_MINUTE = 60
+/** Minutes in one hour — rollover from "Xm" to "Xh" */
+const MINUTES_PER_HOUR = 60
+/** Hours in one day — rollover from "Xh" to "Xd" */
+const HOURS_PER_DAY = 24
+/** Fallback when the timestamp isn't a valid Date — prevents "NaNd" (#9095) */
+const INVALID_TIMESTAMP_LABEL = 'Unknown'
+/**
+ * Re-render interval for the "last updated" label in ms. When SSE refresh
+ * fails, the card's lastUpdated prop is frozen at the last successful fetch,
+ * so without this ticker the label would render "5d ago" forever (#9104).
+ * One minute is enough resolution for an "Xm/Xh/Xd" label and is cheap.
+ */
+const LAST_UPDATED_TICK_MS = 60_000
+
+// Format relative time (e.g., "2m", "1h", "5d")
 function formatTimeAgo(date: Date): string {
-  const seconds = Math.floor((Date.now() - date.getTime()) / 1000)
-  if (seconds < 60) return 'now'
-  const minutes = Math.floor(seconds / 60)
-  if (minutes < 60) return `${minutes}m`
-  const hours = Math.floor(minutes / 60)
-  if (hours < 24) return `${hours}h`
-  const days = Math.floor(hours / 24)
+  // Guard against invalid Date values (e.g. `new Date('')` → NaN getTime()).
+  // Without this, every downstream Math.floor produced NaN and the UI showed
+  // "NaNm" / "NaNd" in the CardWrapper header (#9095).
+  const ts = date?.getTime?.()
+  if (ts === undefined || Number.isNaN(ts)) return INVALID_TIMESTAMP_LABEL
+
+  const seconds = Math.floor((Date.now() - ts) / 1000)
+  if (seconds < SECONDS_PER_MINUTE) return 'now'
+  const minutes = Math.floor(seconds / SECONDS_PER_MINUTE)
+  if (minutes < MINUTES_PER_HOUR) return `${minutes}m`
+  const hours = Math.floor(minutes / MINUTES_PER_HOUR)
+  if (hours < HOURS_PER_DAY) return `${hours}h`
+  const days = Math.floor(hours / HOURS_PER_DAY)
   return `${days}d`
 }
 
@@ -475,6 +501,20 @@ export function CardWrapper({
   // Track visual spinning state separately to ensure minimum spin duration
   const [isVisuallySpinning, setIsVisuallySpinning] = useState(false)
   const spinStartRef = useRef<number | null>(null)
+
+  // Tick counter that forces the "last updated" label to re-render at a fixed
+  // cadence (#9104). Without this, when the refresh source (e.g. SSE stream)
+  // returns 404 repeatedly, `lastUpdated` is frozen at the last successful
+  // fetch and the label shows a stale "5d ago" that never advances even as
+  // real-world time passes. The setInterval below bumps this every minute so
+  // formatTimeAgo() is called with a current Date.now() and the label advances.
+  const [, setLastUpdatedTick] = useState(0)
+  useEffect(() => {
+    const id = setInterval(() => {
+      setLastUpdatedTick(t => t + 1)
+    }, LAST_UPDATED_TICK_MS)
+    return () => clearInterval(id)
+  }, [])
 
   // Child-reported data state (from card components via CardDataContext)
   // Declared early so it can be used in the refresh animation effect below
@@ -1026,14 +1066,30 @@ export function CardWrapper({
                 {!onRefresh && (isVisuallySpinning || effectiveIsLoading || forceSkeletonForOffline) && !effectiveIsFailed && (
                   <RefreshCw className="w-3 h-3 text-blue-400 animate-spin" aria-hidden="true" />
                 )}
-                {/* Last updated indicator — use prop or child-reported timestamp */}
+                {/* Last updated indicator — use prop or child-reported timestamp.
+                  * Still rendered when refresh is failing (#9104): hiding the
+                  * timestamp on failure removed the only signal about data age,
+                  * so users saw "Refresh Failed" with no idea whether the data
+                  * they were looking at was 2 minutes or 5 days old. Now it
+                  * shows the stale timestamp with an orange tint + "(stale)"
+                  * tooltip when failed, and is suppressed only during
+                  * loading/spinning (where no meaningful age exists yet). */}
                 {(() => {
                   const effectiveLastUpdated = lastUpdated ?? childDataState?.lastUpdated
-                  return !isVisuallySpinning && !effectiveIsLoading && !effectiveIsFailed && effectiveLastUpdated ? (
-                    <span className="text-2xs text-muted-foreground" title={effectiveLastUpdated.toLocaleString()}>
+                  if (isVisuallySpinning || effectiveIsLoading || !effectiveLastUpdated) {
+                    return null
+                  }
+                  const title = effectiveIsFailed
+                    ? `${effectiveLastUpdated.toLocaleString()} (stale — refresh failing)`
+                    : effectiveLastUpdated.toLocaleString()
+                  const className = effectiveIsFailed
+                    ? 'text-2xs text-orange-400'
+                    : 'text-2xs text-muted-foreground'
+                  return (
+                    <span className={className} title={title}>
                       {formatTimeAgo(effectiveLastUpdated)}
                     </span>
-                  ) : null
+                  )
                 })()}
               </div>
               <div className="flex items-center gap-1 flex-shrink-0">

--- a/web/src/components/cards/HelmReleaseStatus.tsx
+++ b/web/src/components/cards/HelmReleaseStatus.tsx
@@ -174,13 +174,31 @@ export function HelmReleaseStatus({ config }: HelmReleaseStatusProps) {
     }
   }
 
-  const formatTime = (timestamp: string) => {
-    const date = new Date(timestamp)
-    const now = new Date()
-    const diff = now.getTime() - date.getTime()
+  // Time unit constants (milliseconds) — used to format the relative "X ago" label
+  // on each release row. Backend sometimes returns an empty string, `null`, or a
+  // non-ISO timestamp (e.g. when a release has never been upgraded), which made
+  // `new Date(timestamp).getTime()` return NaN and rendered "NaNd ago" (#9095).
+  const MS_PER_HOUR = 3_600_000
+  const MS_PER_DAY = 86_400_000
+  /** Fallback shown when `timestamp` is missing/invalid — prevents "NaNd ago" (#9095). */
+  const UNKNOWN_TIME_LABEL = 'Unknown'
 
-    if (diff < 86400000) return `${Math.floor(diff / 3600000)}h ago`
-    return `${Math.floor(diff / 86400000)}d ago`
+  const formatTime = (timestamp: string | null | undefined) => {
+    // Guard against missing / empty input before constructing a Date —
+    // `new Date('')` and `new Date(null as unknown as string)` both produce
+    // Invalid Date whose getTime() is NaN, which poisons every math op below.
+    if (!timestamp) return UNKNOWN_TIME_LABEL
+    const date = new Date(timestamp)
+    const parsed = date.getTime()
+    if (Number.isNaN(parsed)) return UNKNOWN_TIME_LABEL
+
+    const diff = new Date().getTime() - parsed
+    // Negative diffs (clock skew / future timestamps) — treat as "just now" rather
+    // than rendering a negative number of hours ago.
+    if (diff < 0) return `0h ago`
+
+    if (diff < MS_PER_DAY) return `${Math.floor(diff / MS_PER_HOUR)}h ago`
+    return `${Math.floor(diff / MS_PER_DAY)}d ago`
   }
 
   // Counts from namespace-filtered releases (pre-pagination summary)
@@ -353,7 +371,7 @@ export function HelmReleaseStatus({ config }: HelmReleaseStatusProps) {
                     {release.cluster && <div className="shrink-0"><ClusterBadge cluster={release.cluster} size="sm" /></div>}
                     <span className="truncate" title={`Chart: ${release.chart}, Version: ${release.version}`}>{release.chart}@{release.version}</span>
                     <span className="shrink-0 whitespace-nowrap" title={`Helm revision: ${release.revision}`}>Rev {release.revision}</span>
-                    <span className="ml-auto shrink-0 whitespace-nowrap" title={`Last updated: ${new Date(release.updated).toLocaleString()}`}>{formatTime(release.updated)}</span>
+                    <span className="ml-auto shrink-0 whitespace-nowrap" title={`Last updated: ${release.updated && !Number.isNaN(new Date(release.updated).getTime()) ? new Date(release.updated).toLocaleString() : UNKNOWN_TIME_LABEL}`}>{formatTime(release.updated)}</span>
                   </div>
                 </div>
               )

--- a/web/src/components/cards/__tests__/HelmReleaseStatus.test.tsx
+++ b/web/src/components/cards/__tests__/HelmReleaseStatus.test.tsx
@@ -227,4 +227,39 @@ describe('HelmReleaseStatus', () => {
       expect(screen.getByText('default')).toBeTruthy()
     })
   })
+
+  // Regression: #9095 — invalid/empty `updated` timestamps rendered "NaNd ago"
+  describe('Timestamp guard (#9095)', () => {
+    it('renders "Unknown" instead of NaN when updated is an empty string', async () => {
+      const { useCachedHelmReleases } = await import('../../../hooks/useCachedData')
+      vi.mocked(useCachedHelmReleases).mockReturnValue({
+        releases: [makeRelease({ updated: '' })],
+        isLoading: false, isRefreshing: false, isFailed: false, consecutiveFailures: 0, isDemoFallback: false,
+      } as never)
+      render(<HelmReleaseStatus />)
+      expect(screen.getByText('Unknown')).toBeTruthy()
+      expect(screen.queryByText(/NaN/)).toBeNull()
+    })
+
+    it('renders "Unknown" instead of NaN when updated is a non-ISO string', async () => {
+      const { useCachedHelmReleases } = await import('../../../hooks/useCachedData')
+      vi.mocked(useCachedHelmReleases).mockReturnValue({
+        releases: [makeRelease({ updated: 'not-a-real-date' })],
+        isLoading: false, isRefreshing: false, isFailed: false, consecutiveFailures: 0, isDemoFallback: false,
+      } as never)
+      render(<HelmReleaseStatus />)
+      expect(screen.getByText('Unknown')).toBeTruthy()
+      expect(screen.queryByText(/NaN/)).toBeNull()
+    })
+
+    it('renders a normal "h ago" label when updated is a valid ISO timestamp', async () => {
+      const { useCachedHelmReleases } = await import('../../../hooks/useCachedData')
+      vi.mocked(useCachedHelmReleases).mockReturnValue({
+        releases: [makeRelease({ updated: new Date(Date.now() - 2 * 3_600_000).toISOString() })],
+        isLoading: false, isRefreshing: false, isFailed: false, consecutiveFailures: 0, isDemoFallback: false,
+      } as never)
+      render(<HelmReleaseStatus />)
+      expect(screen.getByText(/\d+h ago/)).toBeTruthy()
+    })
+  })
 })

--- a/web/src/lib/sseClient.ts
+++ b/web/src/lib/sseClient.ts
@@ -412,9 +412,13 @@ export function fetchSSE<T>(options: SSEFetchOptions<T>): Promise<T[]> {
             return
           }
 
-          // No data at all — clean up and reject
+          // No data at all — clean up and reject. Pass wasAborted=true so the
+          // empty accumulated array is NOT written to the result cache (#9104):
+          // caching a failed result meant the manual refresh button hit the
+          // 10-second TTL cache and silently reused the failure instead of
+          // retrying, so the card's lastUpdated timestamp never advanced.
           clearTimeout(timeoutId)
-          cleanup()
+          cleanup(/* wasAborted */ true)
           reject(new Error(`SSE stream error: ${err.message}`))
         })
     }


### PR DESCRIPTION
## Summary

Bundled fix for two related timestamp regressions on card components.

- **#9095** — `HelmReleaseStatus.formatTime()` passes the backend `release.updated` string into `new Date()` without validation. When the backend returns an empty string / `null` / a non-ISO value, `getTime()` yields `NaN`, which poisons every `Math.floor` below it and the card renders **"NaNd ago"**. Now guarded with an empty-string short-circuit + `Number.isNaN(getTime())` check, falling back to `"Unknown"`. The absolute-date tooltip is guarded against the same inputs so it no longer renders `"Invalid Date"`. All thresholds (`MS_PER_HOUR`, `MS_PER_DAY`, `UNKNOWN_TIME_LABEL`) are named constants.

- **#9104** — Three issues combined to freeze the `CardWrapper` header timestamp at `"5d ago"` when the SSE refresh stream 404s:

  1. **Timestamp was hidden on failure.** `!effectiveIsFailed` removed the only signal of data age. Now the label keeps rendering when failed, using an orange tint + `"(stale — refresh failing)"` tooltip so users can see both "refresh is failing" and "your data is N old."
  2. **No ticker.** The label was only re-evaluated when `lastUpdated` changed, so when every refresh attempt 404'd the displayed age never advanced. Added `LAST_UPDATED_TICK_MS = 60_000` — a minute-resolution ticker inside `CardWrapper` bumps an internal counter so `formatTimeAgo()` is re-called with a current `Date.now()`.
  3. **`formatTimeAgo` returned "NaN…"** on invalid Date inputs. Now guards and returns `"Unknown"`.
  4. **sseClient cached failure results.** After all retries exhausted with zero data, `cleanup()` was called without `wasAborted`, so the empty accumulator was written to `resultCache` and a manual refresh within the 10 s TTL silently replayed the failure. Switched to `cleanup(/* wasAborted */ true)` matching the existing partial-data / timeout behavior.

## No magic numbers

Every literal I touched is a named constant with a comment:
`SECONDS_PER_MINUTE`, `MINUTES_PER_HOUR`, `HOURS_PER_DAY`, `INVALID_TIMESTAMP_LABEL`, `LAST_UPDATED_TICK_MS`, `MS_PER_HOUR`, `MS_PER_DAY`, `UNKNOWN_TIME_LABEL`.

## Test plan

- [x] `npm run build` — passes
- [x] `npx tsc --noEmit` — passes
- [x] `npm run lint` — no new errors in touched files (baseline-equal count of 12 pre-existing warnings/errors unrelated to this PR)
- [x] `npx vitest run src/components/cards/__tests__/HelmReleaseStatus.test.tsx` — 14/14 passing (3 new regression tests for empty string, non-ISO string, valid ISO)
- [x] `npx vitest run src/lib/__tests__/sseClient*.test.ts` — 60/60 passing
- [ ] Manually verify in demo mode: Helm Release card with a release whose `updated` is `""` renders **"Unknown"** instead of **"NaNd ago"**
- [ ] Manually verify: with SSE endpoint returning 404, CardWrapper header shows `"5d ago"` in orange with `"(stale — refresh failing)"` tooltip, and the age advances over time (next tick at 60 s)

Fixes #9095, Fixes #9104