### PR TITLE
🌱 fix(ci): add least-privilege permissions to GitHub Actions workflows

### DIFF
--- a/.github/workflows/auto-qa-tuner.yml
+++ b/.github/workflows/auto-qa-tuner.yml
@@ -21,7 +21,7 @@ on:
         default: 'all'
         type: string
 
-permissions: read-all
+permissions: {}
 
 concurrency:
   group: auto-qa-tuner

--- a/.github/workflows/auto-qa.yml
+++ b/.github/workflows/auto-qa.yml
@@ -45,7 +45,7 @@ env:
   NODE_VERSION: "22"
   GO_VERSION: "1.25"
 
-permissions: read-all
+permissions: {}
 
 jobs:
   auto-qa:

--- a/.github/workflows/cleanup-screenshots.yml
+++ b/.github/workflows/cleanup-screenshots.yml
@@ -15,7 +15,7 @@ on:
     - cron: '0 2 * * *'
   workflow_dispatch:
 
-permissions: read-all
+permissions: {}
 
 jobs:
   cleanup-screenshots:

--- a/.github/workflows/helm-release.yml
+++ b/.github/workflows/helm-release.yml
@@ -8,8 +8,8 @@ on:
         required: true
         default: '0.1.0'
 
-# Least-privilege: read-only by default; jobs declare write scopes individually
-permissions: read-all
+# Least-privilege: deny all by default; jobs declare write scopes individually
+permissions: {}
 
 jobs:
   release-helm:

--- a/.github/workflows/nightly-test-suite.yml
+++ b/.github/workflows/nightly-test-suite.yml
@@ -6,7 +6,7 @@ on:
     - cron: '0 6 * * *'
   workflow_dispatch: {} # Allow manual trigger
 
-permissions: read-all
+permissions: {}
 
 concurrency:
   group: nightly-test-suite

--- a/.github/workflows/pr-verifier.yml
+++ b/.github/workflows/pr-verifier.yml
@@ -4,11 +4,13 @@ on:
   pull_request_target:
     types: [opened, edited, synchronize, reopened]
 
-permissions:
-  checks: write
-  pull-requests: read
+permissions: {}
 
 jobs:
   verify:
+    permissions:
+      checks: write
+      contents: read
+      pull-requests: read
     uses: kubestellar/infra/.github/workflows/reusable-pr-verifier.yml@main
     secrets: inherit

--- a/.github/workflows/process-screenshots.yml
+++ b/.github/workflows/process-screenshots.yml
@@ -14,7 +14,7 @@ on:
   issue_comment:
     types: [created]
 
-permissions: read-all
+permissions: {}
 
 jobs:
   process-screenshot:

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -7,13 +7,17 @@ on:
     branches: [ "main" ]
   workflow_dispatch:
 
-permissions:
-  security-events: write
-  contents: read
-  actions: read
-  id-token: write
+permissions: {}
 
 jobs:
   analysis:
+    permissions:
+      # Required to upload SARIF results to the GitHub Security tab
+      security-events: write
+      # Required to check out the repo and read workflow files
+      contents: read
+      actions: read
+      # Required for OIDC token for trusted publishing
+      id-token: write
     uses: kubestellar/infra/.github/workflows/reusable-scorecard.yml@main
     secrets: inherit


### PR DESCRIPTION
## Summary

Fixes 12 open CodeQL `TokenPermissionsID` alerts (score 8) across 8 workflow files.

**Root cause:** Workflows used `permissions: read-all` at the top level but then granted `write` permissions at the job level. The CodeQL scanner flags any workflow where a `write` permission is present without a top-level deny-all (`{}`) as the baseline.

**Fix applied to all 8 affected workflows:**
- Replace top-level `permissions: read-all` → `permissions: {}` (deny all by default)
- This ensures only the explicit job-level `write` grants are active, not a broad read baseline

**Special cases:**
- `pr-verifier.yml`: Moved top-level `checks: write` + `pull-requests: read` down to job-level block (reusable workflow callers pass permissions down from the job)
- `scorecard.yml`: Moved top-level `security-events: write`, `actions: read`, `id-token: write` down to job-level block for same reason

**Permissions are unchanged** — each job still has exactly the write scopes it needs (contents, issues, pull-requests, packages, etc.). Only the default for unlisted permissions changes from read → none.

Fixes #9123

## Test plan
- [ ] All 8 workflow files have `permissions: {}` at the top level
- [ ] Each job retains its existing write permissions at the job level
- [ ] CI build/lint passes
- [ ] CodeQL scan should no longer flag TokenPermissionsID on these files