### PR TITLE
fix(ci): raise nightly suite wall-clock caps and test timeouts

### DIFF
--- a/scripts/run-all-tests.sh
+++ b/scripts/run-all-tests.sh
@@ -305,12 +305,18 @@ if [ -z "$FAST_MODE" ]; then
         #   #8985 cache-test: renders all cards via the same compliance harness.
         #   #8986 benchmark-test: 12 tests × up to 60s each ≈ 720s worst case.
         #   #8987 ai-ml-test: 15 tests × up to 300s each in pathological cases.
+        #   #9098 nav-test: 6 serial scenarios (warmup/cold/warm/from-main/
+        #     from-clusters/rapid-nav) × ~60-120s each ≈ 480-720s total.
+        #     Default 300s cap killed it mid-run after warm-nav completed.
+        #   #9099 perf-test: same serial scenario structure as nav-test.
         declare -A PLAYWRIGHT_SUITE_TIMEOUT_OVERRIDES=(
           ["console-error-scan"]=600
           ["ui-compliance-test"]=600
           ["cache-test"]=600
           ["benchmark-test"]=600
           ["ai-ml-test"]=600
+          ["nav-test"]=600
+          ["perf-test"]=600
         )
 
         for script in "${PLAYWRIGHT_SCRIPTS[@]}"; do

--- a/web/e2e/compliance/card-cache-compliance.spec.ts
+++ b/web/e2e/compliance/card-cache-compliance.spec.ts
@@ -114,6 +114,18 @@ const _WARM_POLL_INTERVAL_MS = 50
 const EVALUATE_RETRY_ATTEMPTS = 3
 /** Delay between evaluate retries (ms) */
 const EVALUATE_RETRY_DELAY_MS = 500
+/**
+ * Timeout for navigateToBatch calls (ms). Must be generous enough for CI
+ * preview servers under load. 20s default is too tight when the server is
+ * already serving other suites (#9101).
+ */
+const BATCH_NAV_TIMEOUT_MS = !!process.env.CI ? 90_000 : 45_000
+/**
+ * Overall test timeout (ms). 300s base × 2 CI multiplier = 600s, matching
+ * the suite wall-clock cap in run-all-tests.sh (#9101).
+ */
+const CACHE_TEST_TIMEOUT_MS = 300_000
+const CI_TIMEOUT_MULTIPLIER = 2
 
 
 // Mock data, setupAuth, setupLiveMocks, setLiveColdMode, navigateToBatch,
@@ -527,7 +539,13 @@ function writeReport(report: CacheComplianceReport, outDir: string) {
 
 test.describe.configure({ mode: 'serial' })
 
-test('card cache compliance — storage and retrieval', async ({ page }) => {
+test('card cache compliance — storage and retrieval', async ({ page }, testInfo) => {
+  // 300s base × 2 CI multiplier = 600s, matching the suite wall-clock cap in
+  // run-all-tests.sh. No testInfo.setTimeout was set before (#9101), so the
+  // test ran against the global config timeout (1200s) which meant timeout
+  // errors only surfaced as wall-clock kills.
+  testInfo.setTimeout(!!process.env.CI ? CACHE_TEST_TIMEOUT_MS * CI_TIMEOUT_MULTIPLIER : CACHE_TEST_TIMEOUT_MS)
+
   const allBatchResults: Array<{ batchIndex: number; cards: CardCacheResult[] }> = []
   const coldSnapshots: Map<string, ColdLoadSnapshot> = new Map()
   let totalCards = 0
@@ -588,7 +606,7 @@ test('card cache compliance — storage and retrieval', async ({ page }) => {
       localStorage.setItem('token', 'test-token')
     })
 
-    const manifest = await navigateToBatch(page, batch)
+    const manifest = await navigateToBatch(page, batch, BATCH_NAV_TIMEOUT_MS)
     const selected = manifest.selected || []
     if (selected.length === 0) continue
 
@@ -675,7 +693,7 @@ test('card cache compliance — storage and retrieval', async ({ page }) => {
         console.log(`[CacheTest] Phase 6 batch ${batch}: soft nav OK`)
       } catch {
         console.log(`[CacheTest] Phase 6 batch ${batch}: soft nav failed, falling back to page.goto`)
-        manifest = await navigateToBatch(page, batch)
+        manifest = await navigateToBatch(page, batch, BATCH_NAV_TIMEOUT_MS)
       }
       if (!manifest) {
         console.log(`[CacheTest] Phase 6 batch ${batch}: no manifest, skipping`)

--- a/web/e2e/compliance/card-loading-compliance.spec.ts
+++ b/web/e2e/compliance/card-loading-compliance.spec.ts
@@ -730,7 +730,10 @@ function writeReport(report: ComplianceReport, outDir: string) {
 test.describe.configure({ mode: 'serial' })
 
 test('card loading compliance — cold + warm', async ({ page }, testInfo) => {
-  const COMPLIANCE_TIMEOUT_MS = 180_000 // 8 batches cold + warm needs more time
+  // 300s base × 2 CI multiplier = 600s, matching the suite wall-clock cap in
+  // run-all-tests.sh. Previous value (180s × 2 = 360s) caused the test to
+  // self-terminate on CI before all batches completed (#9100).
+  const COMPLIANCE_TIMEOUT_MS = 300_000
   testInfo.setTimeout(IS_CI ? COMPLIANCE_TIMEOUT_MS * CI_TIMEOUT_MULTIPLIER : COMPLIANCE_TIMEOUT_MS)
   const allBatchResults: BatchResult[] = []
   let totalCards = 0


### PR DESCRIPTION
## Summary

Four nightly Playwright suites were killed or timed out in the 2026-04-20 run due to mismatches between wall-clock caps and per-test timeouts.

**Root causes:**
- `nav-test` and `perf-test`: run 6 serial scenarios totalling 480-720s but had only the 300s default wall-clock cap in `run-all-tests.sh`, so both were killed mid-run after `warm-nav` completed
- `ui-compliance-test`: `testInfo.setTimeout` was set to `180_000 × 2 (CI) = 360s` but cold + warm iteration over all batches takes ~392s on CI, causing the test to self-terminate
- `cache-test`: no `testInfo.setTimeout` was set at all; `navigateToBatch` was called without an explicit timeout, hitting the 20s default on a preview server under load, causing `Execution context was destroyed` errors

**Fixes:**
- `scripts/run-all-tests.sh`: add `nav-test` and `perf-test` to `PLAYWRIGHT_SUITE_TIMEOUT_OVERRIDES` at 600s (matching other heavy suites)
- `card-loading-compliance.spec.ts`: raise `COMPLIANCE_TIMEOUT_MS` from `180_000` to `300_000` so `300s x 2 (CI) = 600s` matches the wall-clock cap
- `card-cache-compliance.spec.ts`: add `BATCH_NAV_TIMEOUT_MS` (90s CI / 45s local), `CACHE_TEST_TIMEOUT_MS` (300s x 2 CI = 600s), and `CI_TIMEOUT_MULTIPLIER` constants; wire `testInfo.setTimeout`; pass `BATCH_NAV_TIMEOUT_MS` to all `navigateToBatch` calls

## Test plan
- [ ] Verify nightly suite passes on next scheduled run at 6 AM UTC
- [ ] Manually trigger nightly via `workflow_dispatch` on `nightly-test-suite.yml` if needed
- [ ] Confirm `nav-test`, `perf-test`, `ui-compliance-test`, `cache-test` all pass

Fixes #9098, Fixes #9099, Fixes #9100, Fixes #9101