### PR TITLE
✨ feat(acmm): add .claude/settings.json + session-summary.md to unlock L5 badge

### DIFF
--- a/.claude/session-summary.md
+++ b/.claude/session-summary.md
@@ -1,0 +1,54 @@
+# KubeStellar Console — Session Summary
+
+## What this project is
+
+KubeStellar Console is a standalone Kubernetes dashboard and AI mission platform. It is **not** related to the legacy `kubestellar/kubestellar` project (BindingPolicy, WECs, ITSs). They share an org name only.
+
+## Architecture
+
+- **Backend**: Go + Fiber v2, port 8080. Serves both the API and the built frontend.
+- **Frontend**: React + TypeScript + Tailwind CSS + Vite, port 5174 in dev.
+- **kc-agent**: Local WebSocket bridge (port 8585) connecting the browser to kubeconfig + MCP servers.
+- **Production**: Netlify (console.kubestellar.io). API routes via Netlify Functions (`web/netlify/functions/*.mts`), not the Go backend.
+- **Database**: SQLite WASM in a Web Worker (off-main-thread), IndexedDB fallback.
+
+## Key directories
+
+```
+cmd/console/       Server entry point
+cmd/kc-agent/      Local agent (kubeconfig + MCP bridge)
+pkg/api/           HTTP/WS server + handlers
+pkg/store/         SQLite database layer
+web/src/           React + TypeScript frontend
+  components/cards/  Dashboard card components
+  hooks/             useCached* data-fetching hooks
+  lib/               Cache, card registry, demo data, themes
+web/netlify/functions/  Netlify serverless API (production)
+deploy/helm/       Helm chart
+```
+
+## Critical rules for agents
+
+- **Feature branches only** — never commit to main directly; always use `git worktree add /tmp/kubestellar-console-<slug> -b <branch>`
+- **DCO required** — every commit must use `git commit -s` (`Signed-off-by: Andy Anderson <andy@clubanderson.com>`)
+- **isDemoData wiring** — every card using `useCached*` MUST pass `isDemoData` and `isRefreshing` to `useCardLoadingState()`
+- **No magic numbers** — every numeric literal must be a named constant
+- **DeduplicatedClusters()** — always use when iterating clusters (multiple contexts can point to the same cluster)
+- **Guard arrays** — never call `.join()`, `.map()`, `.filter()` on values that might be `undefined`
+- **Netlify parity** — Go API handlers need matching Netlify Function counterparts; MSW passthrough rules required for demo mode
+
+## Starting the console
+
+```bash
+cd /tmp/kubestellar-console && bash startup-oauth.sh
+```
+
+Frontend URL: `http://localhost:8080` (served by Go backend, not Vite).
+
+## Active subsystems
+
+- **ACMM dashboard** (`/acmm`) — AI Capability Maturity Model scanner. Badge via `/api/acmm/badge?repo=owner/name` (shields.io endpoint).
+- **AI Missions** — guided install/solution missions defined in `kubestellar/console-kb` under `fixes/cncf-install/`.
+- **Drasi dashboard** (`/drasi`) — reactive-pipeline topology view.
+- **Benchmark cards** — Google Drive API backed; require `GOOGLE_DRIVE_API_KEY` in `.env`.
+- **Nightly E2E** — runs at 1 AM ET via GitHub Actions; failures open rolling incident issues.

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,33 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(npm run build)",
+      "Bash(npm run lint)",
+      "Bash(npm run dev*)",
+      "Bash(go build*)",
+      "Bash(go test*)",
+      "Bash(go run*)",
+      "Bash(git status)",
+      "Bash(git diff*)",
+      "Bash(git log*)",
+      "Bash(git add*)",
+      "Bash(git commit*)",
+      "Bash(git checkout*)",
+      "Bash(git branch*)",
+      "Bash(git worktree*)",
+      "Bash(git pull*)",
+      "Bash(git push*)",
+      "Bash(curl*)",
+      "Bash(lsof*)",
+      "Bash(kill*)",
+      "Bash(cat*)",
+      "Bash(ls*)",
+      "Bash(jq*)"
+    ],
+    "deny": [
+      "Bash(rm -rf /)",
+      "Bash(git push --force origin main)",
+      "Bash(git push --force origin master)"
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

- Adds `.claude/settings.json` — satisfies `acmm:layered-safety`, `acmm:mechanical-enforcement`, and `acmm:structural-gates` (3 L3 criteria in one file)
- Adds `.claude/session-summary.md` — satisfies `acmm:session-summary` (L3) and `acmm:session-continuity` (L4), tipping L4 past the 70% promotion threshold

**Before:** L2 · Instructed · 20/34
**After:** L5 · Semi-Automated · 27/34

The `computeLevel()` function in `acmm-badge.mts` uses a 70% threshold per level and stops at the first gap. Previously L3 was blocked at 4/8 (50%) because `.claude/settings.json` didn't exist (only `settings.local.json`, which is gitignored). Adding it unblocks the entire promotion chain: L3 → L4 → L5.

## Test plan

- [ ] After merge, verify badge shows `L5 · Semi-Automated` within 1h of CDN cache expiry

🤖 Generated with [Claude Code](https://claude.com/claude-code)