### PR TITLE
🐛 fix(attribution): repair bot roundtrip (closes #9094)

### DIFF
--- a/.github/workflows/console-app-roundtrip.yml
+++ b/.github/workflows/console-app-roundtrip.yml
@@ -29,6 +29,10 @@ env:
   TEST_REPO_OWNER: "kubestellar"
   TEST_REPO_NAME: "console"
   TEST_LABEL: "test/auto-delete"
+  # Color shown in the GitHub UI for the managed test label (hex without '#').
+  # Neutral gray so it does not collide with severity or status label colors.
+  TEST_LABEL_COLOR: "ededed"
+  TEST_LABEL_DESCRIPTION: "Ephemeral label used by the console-app-roundtrip workflow; issues tagged with this are auto-closed and auto-locked."
 
 jobs:
   roundtrip:
@@ -46,6 +50,51 @@ jobs:
 
       - name: Install pyjwt
         run: pip install --quiet pyjwt cryptography
+
+      # The App installation has issues:write (apply existing labels) but
+      # cannot CREATE a missing label — that requires broader repo scopes
+      # the App intentionally does not hold. If TEST_LABEL does not exist,
+      # the App's create-issue call fails with HTTP 403 "unauthorized"
+      # before the attribution check can even run (see issue #9094).
+      # Pre-create the label with GITHUB_TOKEN (which has issues:write on
+      # the workflow repo) so the App never has to.
+      - name: Ensure test label exists
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -e
+          LABEL_URL="https://api.github.com/repos/${TEST_REPO_OWNER}/${TEST_REPO_NAME}/labels/$(python3 -c "import urllib.parse,os; print(urllib.parse.quote(os.environ['TEST_LABEL'], safe=''))")"
+          HTTP=$(curl -sS -o /dev/null -w "%{http_code}" \
+            -H "Authorization: Bearer $GH_TOKEN" \
+            -H "Accept: application/vnd.github+json" \
+            "$LABEL_URL")
+          if [ "$HTTP" = "200" ]; then
+            echo "✓ Label '${TEST_LABEL}' already exists"
+            exit 0
+          fi
+          if [ "$HTTP" != "404" ]; then
+            echo "::error::Unexpected HTTP $HTTP while looking up label '${TEST_LABEL}'"
+            exit 1
+          fi
+          echo "Label '${TEST_LABEL}' missing, creating..."
+          CREATE_HTTP=$(curl -sS -o /tmp/label-create.json -w "%{http_code}" -X POST \
+            -H "Authorization: Bearer $GH_TOKEN" \
+            -H "Accept: application/vnd.github+json" \
+            -d "$(python3 -c "
+          import json, os
+          print(json.dumps({
+              'name': os.environ['TEST_LABEL'],
+              'color': os.environ['TEST_LABEL_COLOR'],
+              'description': os.environ['TEST_LABEL_DESCRIPTION'],
+          }))
+          ")" \
+            "https://api.github.com/repos/${TEST_REPO_OWNER}/${TEST_REPO_NAME}/labels")
+          if [ "$CREATE_HTTP" != "201" ]; then
+            echo "::error::Failed to create label '${TEST_LABEL}' — HTTP $CREATE_HTTP"
+            cat /tmp/label-create.json || true
+            exit 1
+          fi
+          echo "✓ Created label '${TEST_LABEL}'"
 
       - name: Create + verify + cleanup test issue
         env:
@@ -99,7 +148,7 @@ jobs:
           )
 
           echo "Creating test issue..."
-          CREATE_RESP=$(curl -sS -X POST \
+          CREATE_HTTP=$(curl -sS -o /tmp/app-create.json -w "%{http_code}" -X POST \
             -H "Authorization: Bearer $TOKEN" \
             -H "Accept: application/vnd.github+json" \
             -H "X-GitHub-Api-Version: 2022-11-28" \
@@ -113,10 +162,15 @@ jobs:
           ")" \
             "https://api.github.com/repos/${TEST_REPO_OWNER}/${TEST_REPO_NAME}/issues")
 
-          ISSUE_NUMBER=$(echo "$CREATE_RESP" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('number',''))")
+          if [ "$CREATE_HTTP" != "201" ]; then
+            echo "::error::Issue creation failed — HTTP $CREATE_HTTP"
+            cat /tmp/app-create.json || true
+            exit 1
+          fi
+          ISSUE_NUMBER=$(python3 -c "import json; print(json.load(open('/tmp/app-create.json')).get('number',''))")
           if [ -z "$ISSUE_NUMBER" ]; then
-            echo "::error::Issue creation failed"
-            echo "$CREATE_RESP"
+            echo "::error::Issue created but response lacks issue number"
+            cat /tmp/app-create.json || true
             exit 1
           fi
           echo "Created issue #$ISSUE_NUMBER"
@@ -178,26 +232,34 @@ jobs:
               console.log(`Issue already open: #${existing.data[0].number}`);
               return;
             }
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
             await github.rest.issues.create({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              title: `🚨 kubestellar-console-bot roundtrip failed — attribution contract broken`,
+              title: `🚨 kubestellar-console-bot roundtrip failed`,
               body: [
                 '## Console App Roundtrip Failure',
                 '',
-                `**Run:** ${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,
+                `**Run:** ${runUrl}`,
                 `**Time:** ${new Date().toISOString()}`,
                 '',
-                'The roundtrip workflow tried to create a test issue via the \`kubestellar-console-bot\` App and GitHub did NOT stamp \`performed_via_github_app.slug = kubestellar-console-bot\` on the result.',
+                'The roundtrip workflow for the \`kubestellar-console-bot\` App failed. Inspect the run log to determine which step broke; the failure could be in any of the following phases.',
+                '',
+                '### Possible failure phases',
+                '1. **Label bootstrap** — \`GITHUB_TOKEN\` could not look up or create the \`test/auto-delete\` label (unexpected — this token has full issues:write on the workflow repo).',
+                '2. **Credential exchange** — App JWT could not be exchanged for an installation token (private key rotated, installation revoked, permissions removed).',
+                '3. **Issue creation** — App\'s installation token was rejected when creating the test issue (scopes drift, label unauthorized, rate limit).',
+                '4. **Attribution check** — Issue was created but GitHub did NOT stamp \`performed_via_github_app.slug = kubestellar-console-bot\` on the result (App renamed, API regression).',
                 '',
                 '### Effect',
-                '**The rewards classifier gate is broken.** All console-submitted issues created today will score as web-UI submissions (50 pts) instead of console submissions (300/100 pts).',
+                'If phase 4 failed, **the rewards classifier gate is broken** — all console-submitted issues created today will score as web-UI submissions (50 pts) instead of console submissions (300/100 pts). If phases 1–3 failed, attribution is unverified for this run but the upstream bot may still be functioning in production.',
                 '',
                 '### Likely causes',
                 '- App permissions changed (re-check Settings → GitHub Apps → kubestellar-console-bot)',
                 '- App installation revoked on target account',
                 '- GitHub temporarily dropped \`performed_via_github_app\` from API responses',
                 '- App renamed (update \`KUBESTELLAR_CONSOLE_APP_SLUG\` env var)',
+                '- Missing \`test/auto-delete\` label the App lacks permission to create',
               ].join('\n'),
               labels: ['console-app-roundtrip-failure', 'priority/critical', 'ai-needs-human'],
             });


### PR DESCRIPTION
## Failure mode

The nightly **Console App Roundtrip** workflow (`.github/workflows/console-app-roundtrip.yml`) has been failing in production ([run 24652692307](https://github.com/kubestellar/console/actions/runs/24652692307)). The generic failure issue (#9094) claims the attribution contract is broken, but the real failure is much earlier in the pipeline — at issue creation, not at attribution verification.

Actual error from the failing run:

```json
{
  "message": "You do not have permission to create labels on this repository.",
  "errors": [{"resource": "Repository", "field": "label", "code": "unauthorized"}],
  "status": "403"
}
```

## Root cause

The `kubestellar-console-bot` GitHub App is intentionally scoped to `issues: write` only, which lets it **apply existing labels** but does **not** let it **create new labels** (that needs broader repo metadata scopes the App does not hold).

The workflow passes `labels: ['test/auto-delete']` when creating the test issue. When GitHub's Issues API processes that request and the label doesn't yet exist in the repo, it tries to create the label on-demand — which requires scopes the App lacks. The create-issue call returns 403 and the workflow fails before the attribution check can even run.

Verified: `gh api repos/kubestellar/console/labels/test%2Fauto-delete` → 404.

## Fix summary

1. **Add pre-step `Ensure test label exists`** — uses the workflow's built-in `GITHUB_TOKEN` (which has full `issues: write` on the workflow repo, including label creation) to look up `test/auto-delete` and create it if missing. Fast path on 200, create on 404, fail loudly on anything else. Idempotent across runs.
2. **Tighten the `Create test issue` step** — capture HTTP status and dump the GitHub error body on non-201 responses, so future failures surface the actual cause instead of a generic "Issue creation failed" message.
3. **Rewrite the failure-issue body** — enumerates the four possible failure phases (label bootstrap, credential exchange, issue creation, attribution check) so the on-call can tell which part of the contract is broken without reading the run log. Also qualifies the effect sentence — rewards scoring is only broken when phase 4 (attribution) fails, not phases 1–3.

## Files changed

- `.github/workflows/console-app-roundtrip.yml`

## Gates passed

- `go build ./...` — PASS
- `go test ./... -run Attribution -count=1` — PASS
- `yaml.safe_load` on the modified workflow — PASS
- No frontend code changed; TypeScript/lint gate not required.

## Verification after merge

On the next scheduled run (06:00 UTC) or a manual `workflow_dispatch`, expect:

1. "Ensure test label exists" step to create `test/auto-delete` on first run, then report "already exists" on subsequent runs.
2. "Create + verify + cleanup test issue" step to proceed past issue creation, perform the attribution check, and close/lock the test issue.
3. `#9094` to be auto-closed by this PR merging.

Fixes #9094