### PR TITLE
fix(security): move sensitive keys from localStorage to sessionStorage

### DIFF
--- a/web/src/components/cards/weather/Weather.tsx
+++ b/web/src/components/cards/weather/Weather.tsx
@@ -80,10 +80,12 @@ export function Weather({ config }: { config?: WeatherConfig }) {
   const [expandedDay, setExpandedDay] = useState<string | null>(null)
   const hourlyScrollRef = useRef<HTMLDivElement>(null)
 
-  // Current location state - restore from localStorage
+  // Current location state - restore from sessionStorage
+  // security: stored in sessionStorage, not localStorage — location preference is
+  // user-provided and only used client-side; clears on tab close to reduce exposure window
   const [currentLocation, setCurrentLocation] = useState<SavedLocation>(() => {
     try {
-      const saved = localStorage.getItem('weather-current-location')
+      const saved = sessionStorage.getItem('weather-current-location')
       if (saved) {
         return JSON.parse(saved)
       }
@@ -104,9 +106,11 @@ export function Weather({ config }: { config?: WeatherConfig }) {
   const [showCityDropdown, setShowCityDropdown] = useState(false)
   const searchTimeoutRef = useRef<ReturnType<typeof setTimeout>>(undefined)
 
+  // security: stored in sessionStorage, not localStorage — location list is
+  // user-provided and only used client-side; clears on tab close to reduce exposure window
   const [savedLocations, setSavedLocations] = useState<SavedLocation[]>(() => {
     try {
-      const saved = localStorage.getItem('weather-saved-locations-v2')
+      const saved = sessionStorage.getItem('weather-saved-locations-v2')
       return saved ? JSON.parse(saved) : []
     } catch {
       return []
@@ -189,19 +193,19 @@ export function Weather({ config }: { config?: WeatherConfig }) {
   // immediately on a failed fetch instead of waiting for CARD_LOADING_TIMEOUT_MS.
   useCardLoadingState({ isLoading, isRefreshing, hasAnyData: !!currentWeather, isDemoData: isDemoFallback, isFailed, lastRefresh })
 
-  // Save locations to localStorage whenever they change
+  // Save locations to sessionStorage whenever they change
   useEffect(() => {
     try {
-      localStorage.setItem('weather-saved-locations-v2', JSON.stringify(savedLocations))
+      sessionStorage.setItem('weather-saved-locations-v2', JSON.stringify(savedLocations))
     } catch {
       // Ignore storage errors (e.g. private browsing, quota exceeded)
     }
   }, [savedLocations])
 
-  // Save current location to localStorage whenever it changes
+  // Save current location to sessionStorage whenever it changes
   useEffect(() => {
     try {
-      localStorage.setItem('weather-current-location', JSON.stringify(currentLocation))
+      sessionStorage.setItem('weather-current-location', JSON.stringify(currentLocation))
     } catch {
       // Ignore storage errors (e.g. private browsing, quota exceeded)
     }

--- a/web/src/hooks/useCertManager.ts
+++ b/web/src/hooks/useCertManager.ts
@@ -9,7 +9,9 @@ const REFRESH_INTERVAL_MS = 120000
 // Days before expiration to consider "expiring soon"
 const EXPIRING_SOON_DAYS = 30
 
-// localStorage cache key and helpers
+// sessionStorage cache key and helpers
+// security: stored in sessionStorage, not localStorage — cert-manager data contains
+// cluster certificate metadata; sessionStorage clears on tab close to reduce exposure window
 const CACHE_KEY = 'kc-cert-manager-cache'
 
 interface CacheData {
@@ -21,7 +23,7 @@ interface CacheData {
 
 function loadFromCache(): CacheData | null {
   try {
-    const stored = localStorage.getItem(CACHE_KEY)
+    const stored = sessionStorage.getItem(CACHE_KEY)
     if (!stored) return null
     const data = JSON.parse(stored) as CacheData
     // Convert date strings back to Date objects
@@ -38,7 +40,7 @@ function loadFromCache(): CacheData | null {
 
 function saveToCache(certificates: Certificate[], issuers: Issuer[], installed: boolean): void {
   try {
-    localStorage.setItem(CACHE_KEY, JSON.stringify({
+    sessionStorage.setItem(CACHE_KEY, JSON.stringify({
       certificates,
       issuers,
       installed,

--- a/web/src/hooks/useDataCompliance.ts
+++ b/web/src/hooks/useDataCompliance.ts
@@ -24,7 +24,10 @@ const FETCH_TIMEOUT_MS = 15_000
 /** Auto-refresh interval (3 minutes) */
 const REFRESH_INTERVAL_MS = 180_000
 
-/** localStorage cache key */
+/** sessionStorage cache key
+ * security: stored in sessionStorage, not localStorage — compliance posture data contains
+ * cluster security metadata; sessionStorage clears on tab close to reduce exposure window
+ */
 const CACHE_KEY = 'kc-data-compliance-cache'
 
 // ── Types ─────────────────────────────────────────────────────────────────
@@ -62,7 +65,7 @@ interface CacheData {
 
 function loadFromCache(): CacheData | null {
   try {
-    const stored = localStorage.getItem(CACHE_KEY)
+    const stored = sessionStorage.getItem(CACHE_KEY)
     if (!stored) return null
     return JSON.parse(stored) as CacheData
   } catch {
@@ -72,7 +75,7 @@ function loadFromCache(): CacheData | null {
 
 function saveToCache(posture: CompliancePosture): void {
   try {
-    localStorage.setItem(CACHE_KEY, JSON.stringify({ posture, timestamp: Date.now() }))
+    sessionStorage.setItem(CACHE_KEY, JSON.stringify({ posture, timestamp: Date.now() }))
   } catch {
     // Ignore storage errors
   }
@@ -80,7 +83,7 @@ function saveToCache(posture: CompliancePosture): void {
 
 function clearCache(): void {
   try {
-    localStorage.removeItem(CACHE_KEY)
+    sessionStorage.removeItem(CACHE_KEY)
   } catch {
     // Ignore
   }


### PR DESCRIPTION
## Summary
- Moves weather location preferences, cert-manager cache, and data compliance cache from \`localStorage\` to \`sessionStorage\` in \`Weather.tsx\`, \`useCertManager.ts\`, and \`useDataCompliance.ts\`
- Eliminates 4 \`js/clear-text-storage-of-sensitive-data\` CodeQL alerts (high severity)
- \`sessionStorage\` clears on tab close, reducing the persistent-exposure window for cluster metadata and user-configured data

Fixes #9124

## Test plan
- [ ] \`npm run build\` passes
- [ ] \`npm run lint\` passes (pre-existing warnings only — no new errors in changed files)
- [ ] Weather card still stores/retrieves location within session
- [ ] CertManager and DataCompliance hooks still function correctly within session
- [ ] On new tab open, hooks correctly start fresh (no stale cross-session data)