### PR TITLE
fix(ci): add least-privilege permissions to GitHub Actions workflows

### DIFF
--- a/.github/workflows/auto-qa-tuner.yml
+++ b/.github/workflows/auto-qa-tuner.yml
@@ -799,7 +799,7 @@ jobs:
   # ============================================================
   copilot-stall-check:
     permissions:
-      contents: write
+      contents: read
       issues: write
       pull-requests: read
     if: >

--- a/.github/workflows/auto-qa.yml
+++ b/.github/workflows/auto-qa.yml
@@ -50,9 +50,8 @@ permissions: read-all
 jobs:
   auto-qa:
     permissions:
-      contents: write
+      contents: read
       issues: write
-      pull-requests: write
       actions: read
     runs-on: ubuntu-latest
     timeout-minutes: 20

--- a/.github/workflows/pr-verifier.yml
+++ b/.github/workflows/pr-verifier.yml
@@ -4,11 +4,12 @@ on:
   pull_request_target:
     types: [opened, edited, synchronize, reopened]
 
-permissions:
-  checks: write
-  pull-requests: read
+permissions: read-all
 
 jobs:
   verify:
+    permissions:
+      checks: write
+      pull-requests: read
     uses: kubestellar/infra/.github/workflows/reusable-pr-verifier.yml@88f4d5fff50ceea648cdd3848ed1835ebded5fe3 # main
     secrets: inherit

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -7,13 +7,14 @@ on:
     branches: [ "main" ]
   workflow_dispatch:
 
-permissions:
-  security-events: write
-  contents: read
-  actions: read
-  id-token: write
+permissions: read-all
 
 jobs:
   analysis:
+    permissions:
+      security-events: write
+      contents: read
+      actions: read
+      id-token: write
     uses: kubestellar/infra/.github/workflows/reusable-scorecard.yml@88f4d5fff50ceea648cdd3848ed1835ebded5fe3 # main
     secrets: inherit


### PR DESCRIPTION
## Summary
- Adds `permissions: read-all` at workflow level for `scorecard.yml` and `pr-verifier.yml`, moving write scopes down to job level
- Removes unused `contents: write` and `pull-requests: write` from `auto-qa.yml` job (workflow only creates issues, no git push or PR creation)
- Removes unused `contents: write` from `copilot-stall-check` job in `auto-qa-tuner.yml` (only manages labels/comments, no git push)
- Eliminates all 12 CodeQL TokenPermissionsID alerts (high severity)

Fixes #9123

## Workflows changed

| File | Change |
|------|--------|
| `scorecard.yml` | Top-level → `read-all`; write scopes moved to job level |
| `pr-verifier.yml` | Top-level → `read-all`; write scopes moved to job level |
| `auto-qa.yml` | Removed unused `contents: write` + `pull-requests: write` from job |
| `auto-qa-tuner.yml` | Reduced `copilot-stall-check` job from `contents: write` to `contents: read` |

## Test plan
- [ ] YAML syntax valid for all four edited workflow files (validated with `python3 -c "import yaml; yaml.safe_load(..."`)
- [ ] No workflow functionality changed — only permissions scoping tightened
- [ ] `auto-qa.yml` still creates issues (only `issues: write` needed; no git operations performed)
- [ ] `copilot-stall-check` still manages labels and comments (only `issues: write` needed)
- [ ] Reusable workflow calls (`scorecard`, `pr-verifier`) retain all needed write scopes at job level