### PR TITLE
fix(security): property allowlists and safe escaping for DOM injection cluster

### DIFF
--- a/web/e2e/compliance/i18n-compliance.spec.ts
+++ b/web/e2e/compliance/i18n-compliance.spec.ts
@@ -113,9 +113,12 @@ function safeGetByPath(obj: Record<string, unknown>, dotPath: string): unknown {
 /**
  * Escape a string for safe inclusion in a Markdown table cell.
  * Prevents markdown injection via pipe characters, backticks, or HTML tags.
+ * Backslashes are escaped first so that subsequent replacements cannot be
+ * reinterpreted as escape sequences by the Markdown renderer.
  */
 function escapeMdCell(text: string): string {
   return text
+    .replace(/\\/g, '\\\\')
     .replace(/\|/g, '\\|')
     .replace(/`/g, '\\`')
     .replace(/</g, '&lt;')

--- a/web/e2e/compliance/i18n-compliance.spec.ts
+++ b/web/e2e/compliance/i18n-compliance.spec.ts
@@ -73,7 +73,7 @@ function writeReport(report: I18nReport, outDir: string) {
       c.status === 'fail' ? 'FAIL' :
       c.status === 'warn' ? 'WARN' :
       c.status === 'info' ? 'INFO' : 'SKIP'
-    lines.push(`| ${c.category} | ${c.name} | ${c.severity} | ${statusIcon} | ${c.details.replace(/\|/g, '\\|')} |`)
+    lines.push(`| ${escapeMdCell(c.category)} | ${escapeMdCell(c.name)} | ${c.severity} | ${statusIcon} | ${escapeMdCell(c.details)} |`)
   }
 
   lines.push('')
@@ -92,6 +92,34 @@ function flattenKeys(obj: Record<string, unknown>, prefix = ''): string[] {
     }
   }
   return keys
+}
+
+/**
+ * Safely traverse a nested object using a dot-notation key path.
+ * Guards against prototype-pollution by refusing to descend into
+ * __proto__, constructor, or prototype segments.
+ */
+const UNSAFE_KEY_SEGMENTS = new Set(['__proto__', 'constructor', 'prototype'])
+
+function safeGetByPath(obj: Record<string, unknown>, dotPath: string): unknown {
+  let val: unknown = obj
+  for (const segment of dotPath.split('.')) {
+    if (UNSAFE_KEY_SEGMENTS.has(segment)) return undefined
+    val = (val as Record<string, unknown>)?.[segment]
+  }
+  return val
+}
+
+/**
+ * Escape a string for safe inclusion in a Markdown table cell.
+ * Prevents markdown injection via pipe characters, backticks, or HTML tags.
+ */
+function escapeMdCell(text: string): string {
+  return text
+    .replace(/\|/g, '\\|')
+    .replace(/`/g, '\\`')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
 }
 
 // ---------------------------------------------------------------------------
@@ -197,11 +225,7 @@ test('i18n compliance — internationalization audit', async ({ page }) => {
 
     // Check for empty values
     for (const key of keys) {
-      const parts = key.split('.')
-      let val: unknown = data
-      for (const p of parts) {
-        val = (val as Record<string, unknown>)?.[p]
-      }
+      const val = safeGetByPath(data, key)
       if (val === '' || val === null || val === undefined) {
         emptyValues++
         if (emptyKeyExamples.length < 5) {
@@ -228,9 +252,7 @@ test('i18n compliance — internationalization audit', async ({ page }) => {
     const filePath = path.join(localeDir, `${ns}.json`)
     const data = JSON.parse(fs.readFileSync(filePath, 'utf-8'))
     for (const key of keys) {
-      const parts = key.split('.')
-      let val: unknown = data
-      for (const p of parts) val = (val as Record<string, unknown>)?.[p]
+      const val = safeGetByPath(data, key)
       if (typeof val === 'string' && val.includes('{{')) {
         interpolationKeys.push(`${ns}:${key}`)
         // Check for malformed interpolation (missing closing braces)
@@ -277,9 +299,7 @@ test('i18n compliance — internationalization audit', async ({ page }) => {
     const filePath = path.join(localeDir, `${ns}.json`)
     const data = JSON.parse(fs.readFileSync(filePath, 'utf-8'))
     for (const key of keys) {
-      const parts = key.split('.')
-      let val: unknown = data
-      for (const p of parts) val = (val as Record<string, unknown>)?.[p]
+      const val = safeGetByPath(data, key)
       if (typeof val === 'string' && val.includes('{{count}}')) {
         pluralKeys.push(`${ns}:${key}`)
         const baseKey = key.replace(/_one$|_other$|_zero$|_two$|_few$|_many$/, '')

--- a/web/e2e/console-errors/console-error-scan.spec.ts
+++ b/web/e2e/console-errors/console-error-scan.spec.ts
@@ -139,9 +139,12 @@ function getOutputDir(): string {
 /**
  * Escape a string for safe inclusion in a Markdown table cell.
  * Prevents markdown injection via pipe characters, backticks, or HTML tags.
+ * Backslashes are escaped first so that subsequent replacements cannot be
+ * reinterpreted as escape sequences by the Markdown renderer.
  */
 function escapeMdCell(text: string): string {
   return text
+    .replace(/\\/g, '\\\\')
     .replace(/\|/g, '\\|')
     .replace(/`/g, '\\`')
     .replace(/</g, '&lt;')

--- a/web/e2e/console-errors/console-error-scan.spec.ts
+++ b/web/e2e/console-errors/console-error-scan.spec.ts
@@ -136,6 +136,18 @@ function getOutputDir(): string {
   return dir
 }
 
+/**
+ * Escape a string for safe inclusion in a Markdown table cell.
+ * Prevents markdown injection via pipe characters, backticks, or HTML tags.
+ */
+function escapeMdCell(text: string): string {
+  return text
+    .replace(/\|/g, '\\|')
+    .replace(/`/g, '\\`')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+}
+
 /** Deduplicate entries by message text within a route */
 function dedup(entries: ConsoleEntry[]): ConsoleEntry[] {
   const seen = new Set<string>()
@@ -232,8 +244,8 @@ function generateMarkdown(report: ScanReport): string {
         : e.type === 'error' ? '❌'
         : e.type === 'warning' ? '⚠️'
         : 'ℹ️'
-      // Truncate long messages and escape pipes
-      const msg = e.text.slice(0, 200).replace(/\|/g, '\\|').replace(/\n/g, ' ')
+      // Truncate long messages and escape markdown-injection characters
+      const msg = escapeMdCell(e.text.slice(0, 200).replace(/\n/g, ' '))
       lines.push(`| ${typeIcon} ${e.type} | ${msg} |`)
     }
     lines.push('')

--- a/web/src/components/cards/IframeEmbed.tsx
+++ b/web/src/components/cards/IframeEmbed.tsx
@@ -25,6 +25,29 @@ const STORAGE_KEY = 'iframe_embed_saved'
 const DEFAULT_HEIGHT = 400
 const DEFAULT_SANDBOX = ['allow-scripts', 'allow-same-origin', 'allow-forms', 'allow-popups']
 
+/**
+ * Allowed URL schemes for iframe embedding.
+ * javascript:, data:, and other schemes must never be loaded in an iframe src
+ * because they bypass sandbox restrictions and execute in the embedder's origin.
+ */
+const ALLOWED_URL_SCHEMES = ['http:', 'https:']
+
+/**
+ * Validate a URL before using it as an iframe src.
+ * Returns the original URL if it has an allowed scheme, or an empty string
+ * if the scheme is disallowed (e.g. javascript:, data:, blob:).
+ * This prevents XSS-through-DOM attacks via scheme injection.
+ */
+function sanitizeIframeUrl(url: string): string {
+  try {
+    const parsed = new URL(url)
+    return ALLOWED_URL_SCHEMES.includes(parsed.protocol) ? url : ''
+  } catch {
+    // Relative or malformed URLs — disallow
+    return ''
+  }
+}
+
 // Preset embeds for quick setup
 const PRESET_EMBEDS = [
   { title: 'Grafana', url: 'http://localhost:3000', icon: '📊' },
@@ -45,7 +68,7 @@ export function IframeEmbed({ config }: { config?: IframeEmbedConfig }) {
     return `embed_${Date.now()}`
   })
 
-  const [url, setUrl] = useState(config?.url || '')
+  const [url, setUrl] = useState(sanitizeIframeUrl(config?.url || ''))
   const [title, setTitle] = useState(config?.title || 'Embed')
   const [refreshInterval, setRefreshInterval] = useState(config?.refreshInterval || 0)
   const [height, setHeight] = useState(config?.height || DEFAULT_HEIGHT)
@@ -71,12 +94,15 @@ export function IframeEmbed({ config }: { config?: IframeEmbedConfig }) {
     if (!config?.url) {
       const saved = savedEmbeds.find(e => e.id === instanceId)
       if (saved) {
-        setUrl(saved.url)
+        // Sanitize URL loaded from localStorage to guard against scheme injection
+        // (e.g. javascript: or data: URLs stored by a compromised page)
+        const safeUrl = sanitizeIframeUrl(saved.url)
+        setUrl(safeUrl)
         setTitle(saved.title)
         setRefreshInterval(saved.refreshInterval)
-        setUrlInput(saved.url)
+        setUrlInput(safeUrl)
         setTitleInput(saved.title)
-        setShowSettings(false)
+        setShowSettings(!safeUrl)
       }
     }
   }, [instanceId, config?.url, savedEmbeds])
@@ -120,7 +146,8 @@ export function IframeEmbed({ config }: { config?: IframeEmbedConfig }) {
   const handleSaveConfig = () => {
     if (!urlInput.trim()) return
 
-    const newUrl = urlInput.trim()
+    const newUrl = sanitizeIframeUrl(urlInput.trim())
+    if (!newUrl) return
     const newTitle = titleInput.trim() || 'Embed'
 
     setUrl(newUrl)

--- a/web/src/components/drilldown/views/SecretDrillDown.tsx
+++ b/web/src/components/drilldown/views/SecretDrillDown.tsx
@@ -25,6 +25,9 @@ import { maskKubernetesYamlData } from '../../../lib/yamlMask'
 /** @deprecated use `maskKubernetesYamlData` from `lib/yamlMask` */
 export const maskSecretYaml = maskKubernetesYamlData
 
+/** Property names that must never be used as object keys (prototype pollution prevention). */
+const UNSAFE_PROP_NAMES = new Set(['__proto__', 'constructor', 'prototype'])
+
 export function SecretDrillDown({ data }: Props) {
   const { t } = useTranslation()
   const cluster = data.cluster as string
@@ -96,10 +99,9 @@ export function SecretDrillDown({ data }: Props) {
         const secret = JSON.parse(output)
         // Decode base64 data (use null-prototype object to prevent prototype pollution)
         const decodedData: Record<string, string> = Object.create(null) as Record<string, string>
-        const unsafeKeys = new Set(['__proto__', 'constructor', 'prototype'])
         if (secret.data) {
           for (const [key, value] of Object.entries(secret.data)) {
-            if (unsafeKeys.has(key)) continue
+            if (UNSAFE_PROP_NAMES.has(key)) continue
             try {
               decodedData[key] = atob(value as string)
             } catch {

--- a/web/src/lib/missions/scanner/standalone.ts
+++ b/web/src/lib/missions/scanner/standalone.ts
@@ -58,10 +58,13 @@ export function scanMissionFile(jsonContent: string): FileScanResult {
 /**
  * Escape a string for safe inclusion in a Markdown table cell.
  * Prevents markdown injection via pipe characters, backticks, or HTML tags.
+ * Backslashes are escaped first so that subsequent replacements cannot be
+ * reinterpreted as escape sequences by the Markdown renderer.
  * Used for all user/API-derived text inserted into table rows.
  */
 function escapeMdCell(text: string): string {
   return text
+    .replace(/\\/g, '\\\\')
     .replace(/\|/g, '\\|')
     .replace(/`/g, '\\`')
     .replace(/</g, '&lt;')

--- a/web/src/lib/missions/scanner/standalone.ts
+++ b/web/src/lib/missions/scanner/standalone.ts
@@ -56,6 +56,19 @@ export function scanMissionFile(jsonContent: string): FileScanResult {
 }
 
 /**
+ * Escape a string for safe inclusion in a Markdown table cell.
+ * Prevents markdown injection via pipe characters, backticks, or HTML tags.
+ * Used for all user/API-derived text inserted into table rows.
+ */
+function escapeMdCell(text: string): string {
+  return text
+    .replace(/\|/g, '\\|')
+    .replace(/`/g, '\\`')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+}
+
+/**
  * Format scan results as a markdown table suitable for PR comments.
  *
  * Output example:
@@ -105,8 +118,8 @@ export function formatScanResultAsMarkdown(
 
   for (const f of result.findings) {
     const sev = `${severityIcon[f.severity] ?? ''} ${f.severity}`
-    const msg = f.message.replace(/\|/g, '\\|')
-    const path = (f.path || '—').replace(/\|/g, '\\|')
+    const msg = escapeMdCell(f.message)
+    const path = escapeMdCell(f.path || '—')
     lines.push(`| ${sev} | \`${f.code}\` | ${msg} | \`${path}\` |`)
   }
 


### PR DESCRIPTION
## Summary

- Adds module-scoped `UNSAFE_PROP_NAMES` constant in `SecretDrillDown` to consolidate the prototype-pollution guard used when decoding K8s secret data keys from the API
- Adds `sanitizeIframeUrl()` in `IframeEmbed` that allows only `http:`/`https:` schemes; applied at all URL ingestion points (config prop, localStorage load, save handler) to block `javascript:`/`data:` scheme injection into the iframe `src`
- Replaces three `(val as Record<string,unknown>)?.[p]` dynamic property access patterns in `i18n-compliance.spec.ts` with a `safeGetByPath()` helper that rejects `__proto__`, `constructor`, and `prototype` path segments
- Replaces incomplete pipe-only markdown escaping (`.replace(/\|/g, '\\|')`) in `i18n-compliance.spec.ts`, `console-error-scan.spec.ts`, and `standalone.ts` with a full `escapeMdCell()` helper that also escapes backticks and HTML angle brackets — closes 4 `js/incomplete-sanitization` alerts

Fixes #9126

Eliminates 8 CodeQL high-severity alerts:
- 3 × `js/remote-property-injection`
- 1 × `js/xss-through-dom`
- 4 × `js/incomplete-sanitization`

## Test plan
- [ ] `npm run build` passes (verified locally)
- [ ] `npm run lint` passes (verified locally)
- [ ] Drill-down views render pod/secret data correctly (existing E2E coverage)
- [ ] IframeEmbed rejects `javascript:` and `data:` URLs; accepts `http:`/`https:`
- [ ] Mission scan markdown report renders without broken table cells