### PR TITLE
fix(ci): harden Coverage Gate — reduce 12% failure rate

### DIFF
--- a/.github/workflows/coverage-gate.yml
+++ b/.github/workflows/coverage-gate.yml
@@ -44,7 +44,8 @@ jobs:
 
       - name: Install dependencies
         working-directory: web
-        run: npm ci
+        # Retry once on transient npm registry failures (see #9107)
+        run: npm ci || npm ci
 
       - name: Run smoke tests with coverage (modified files only)
         working-directory: web

--- a/.github/workflows/coverage-hourly.yml
+++ b/.github/workflows/coverage-hourly.yml
@@ -15,8 +15,11 @@ on:
   workflow_dispatch:
 
 concurrency:
+  # Only one coverage run at a time. When a burst of merges hits main, cancel
+  # the queued run in favour of the latest commit so orphaned runs don't pile
+  # up and inflate the weekly failure/cancellation count (see #9107).
   group: coverage-suite
-  cancel-in-progress: false
+  cancel-in-progress: true
 
 permissions:
   contents: read
@@ -50,7 +53,8 @@ jobs:
 
       - name: Install dependencies
         working-directory: web
-        run: npm ci
+        # Retry once on transient npm registry failures (see #9107)
+        run: npm ci || npm ci
 
       - name: Run shard ${{ matrix.shard }}/${{ env.TOTAL_SHARDS }} with coverage
         id: test
@@ -142,7 +146,8 @@ jobs:
 
       - name: Install dependencies
         working-directory: web
-        run: npm ci
+        # Retry once on transient npm registry failures (see #9107)
+        run: npm ci || npm ci
 
       - name: Download all shard coverage
         uses: actions/download-artifact@v4

--- a/web/src/components/clusters/components/RenameModal.test.tsx
+++ b/web/src/components/clusters/components/RenameModal.test.tsx
@@ -106,15 +106,17 @@ describe('RenameModal', () => {
     fireEvent.change(input, { target: { value: 'new-name' } })
     fireEvent.click(screen.getByText('cluster.renameContext.rename'))
 
+    // Wait for both onClose and the 'success' phase DOM update together.
+    // Asserting both inside waitFor avoids a race where onClose fires before
+    // the setPhase('success') re-render has been flushed to the DOM (#9107).
     await waitFor(() => {
       expect(defaultProps.onClose).toHaveBeenCalled()
+      // Label must be "Renamed", not "Rename", so the button does not flash.
+      expect(screen.queryByText('cluster.renameContext.rename')).toBeNull()
+      expect(screen.getByText('cluster.renameContext.renamed')).toBeTruthy()
+      // Button must remain disabled while the modal is closing.
+      expect(screen.getByText('cluster.renameContext.renamed').closest('button')?.disabled).toBe(true)
     })
-
-    // After success, label should be "Renamed" (renamed key), not "Rename" (rename key).
-    expect(screen.queryByText('cluster.renameContext.rename')).toBeNull()
-    expect(screen.getByText('cluster.renameContext.renamed')).toBeTruthy()
-    // Button should remain disabled while the modal is closing.
-    expect(screen.getByText('cluster.renameContext.renamed').closest('button')?.disabled).toBe(true)
   })
 
   it('shows error message when onRename rejects', async () => {


### PR DESCRIPTION
## Summary

Root causes identified from failed Coverage Suite run logs (issue #9107):

- **Flaky RenameModal test** (drives the 12 hard failures): `shows "Renamed" (not "Rename") after successful rename` was asserting DOM state synchronously right after `waitFor(() => onClose called)`. The `setPhase('success')` re-render fires in the same React microtask batch as `onClose()` — so in CI the DOM hadn't flushed yet when the bare `expect` ran. Fix: move all three assertions inside the same `waitFor` so React has settled before asserting.

- **23 orphaned cancellations**: Coverage Suite had `cancel-in-progress: false`, so a burst of squash-merges to main queued multiple parallel runs. GitHub cancelled the queued ones when they became stale, inflating the weekly cancellation count. Fix: switch to `cancel-in-progress: true` — the latest commit always wins, stale intermediate runs are cleanly cancelled rather than orphaned.

- **Transient `npm ci` failures**: Added `npm ci || npm ci` retry to both Coverage Gate and Coverage Suite (test-shard and merge-coverage jobs) to survive intermittent npm registry timeouts.

## Files changed

| File | Change |
|------|--------|
| `web/src/components/clusters/components/RenameModal.test.tsx` | Fold DOM assertions into `waitFor` to fix timing race |
| `.github/workflows/coverage-hourly.yml` | `cancel-in-progress: true` + `npm ci` retry |
| `.github/workflows/coverage-gate.yml` | `npm ci` retry |

Fixes #9107

## Test plan
- [x] `npx vitest run src/components/clusters/components/RenameModal.test.tsx` — all 9 tests pass
- [x] `npm run build` passes
- [x] Coverage Gate workflow YAML is valid
- [x] Concurrency group change prevents orphaned queued runs
- [x] Previously-flaky RenameModal test now waits for React render to settle