### PR TITLE
fix(security): replace Math.random() with crypto API, sanitize format strings

### DIFF
--- a/web/src/components/missions/SaveResolutionDialog.tsx
+++ b/web/src/components/missions/SaveResolutionDialog.tsx
@@ -108,7 +108,7 @@ Return ONLY valid JSON, no markdown code blocks or explanation.`
 
       ws.send(JSON.stringify({
         type: 'chat',
-        id: `summary-${Date.now()}`,
+        id: `summary-${crypto.randomUUID()}`,
         payload: {
           prompt: prompt,
           sessionId: `resolution-${mission.id}`,

--- a/web/src/hooks/useActiveUsers.ts
+++ b/web/src/hooks/useActiveUsers.ts
@@ -74,7 +74,11 @@ function getBackoffDelay(attempt: number): number {
     WS_RECONNECT_BASE_DELAY_MS * Math.pow(2, attempt),
     WS_RECONNECT_MAX_DELAY_MS,
   )
-  const jitter = Math.random() * BACKOFF_JITTER_MAX_MS
+  // Use crypto.getRandomValues() for unbiased jitter — Math.random() is not
+  // cryptographically secure. BACKOFF_JITTER_MAX_MS fits comfortably in Uint32.
+  const arr = new Uint32Array(1)
+  crypto.getRandomValues(arr)
+  const jitter = (arr[0] / 0x100000000) * BACKOFF_JITTER_MAX_MS
   return delay + jitter
 }
 
@@ -114,10 +118,14 @@ function getSessionId(): string {
   let id = sessionStorage.getItem('kc-session-id')
   if (!id) {
     // crypto.randomUUID() requires a secure context (HTTPS / localhost).
-    // Fall back to Math.random-based ID for HTTP contexts.
-    id = typeof crypto.randomUUID === 'function'
-      ? crypto.randomUUID()
-      : `${Date.now().toString(36)}-${Math.random().toString(36).slice(2)}`
+    // Fall back to crypto.getRandomValues() for HTTP contexts where randomUUID is unavailable.
+    if (typeof crypto.randomUUID === 'function') {
+      id = crypto.randomUUID()
+    } else {
+      const arr = new Uint8Array(9)
+      crypto.getRandomValues(arr)
+      id = `${Date.now().toString(36)}-${Array.from(arr).map(b => b.toString(36).padStart(2, '0')).join('')}`
+    }
     sessionStorage.setItem('kc-session-id', id)
   }
   return id
@@ -147,7 +155,11 @@ function startHeartbeat() {
 
   // Subsequent heartbeats with jitter to spread them out
   function scheduleNextHeartbeat() {
-    const jitter = Math.random() * HEARTBEAT_JITTER
+    // Use crypto.getRandomValues() — Math.random() is not cryptographically secure.
+    // HEARTBEAT_JITTER fits well within a Uint32.
+    const arr = new Uint32Array(1)
+    crypto.getRandomValues(arr)
+    const jitter = (arr[0] / 0x100000000) * HEARTBEAT_JITTER
     heartbeatTimeoutId = setTimeout(() => {
       sendHeartbeat()
       scheduleNextHeartbeat()

--- a/web/src/hooks/useMissions.tsx
+++ b/web/src/hooks/useMissions.tsx
@@ -233,7 +233,7 @@ const SELECTED_AGENT_KEY = 'kc_selected_agent'
 let requestIdCounter = 0
 function generateRequestId(prefix = 'claude'): string {
   requestIdCounter += 1
-  return `${prefix}-${Date.now()}-${requestIdCounter}-${Math.random().toString(36).substr(2, 6)}`
+  return `${prefix}-${Date.now()}-${requestIdCounter}-${crypto.randomUUID().replace(/-/g, '').slice(0, 6)}`
 }
 
 /**
@@ -2417,7 +2417,7 @@ The WebSocket connection to the agent at \`${LOCAL_AGENT_WS_URL}\` was lost and 
     // available, otherwise generate a new one. This ensures the ID returned
     // to callers before review confirmation stays valid after confirmation.
     const preGenId = params.context?.__preGeneratedMissionId as string | undefined
-    const missionId = preGenId || `mission-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`
+    const missionId = preGenId || `mission-${Date.now()}-${crypto.randomUUID().replace(/-/g, '').slice(0, 9)}`
     // Strip the internal marker from context before persisting
     if (preGenId && params.context) {
       const { __preGeneratedMissionId: _, ...cleanContext } = params.context
@@ -2716,7 +2716,7 @@ Install the console locally with the KubeStellar Console agent to use AI mission
 
   // Save a mission to library without running it
   const saveMission = (params: SaveMissionParams): string => {
-    const missionId = `mission-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`
+    const missionId = `mission-${Date.now()}-${crypto.randomUUID().replace(/-/g, '').slice(0, 9)}`
 
     const mission: Mission = {
       id: missionId,

--- a/web/src/lib/utils/localStorage.ts
+++ b/web/src/lib/utils/localStorage.ts
@@ -4,6 +4,15 @@
  */
 
 /**
+ * Sanitize a localStorage key for safe use in log messages.
+ * encodeURIComponent() escapes special characters (including format-string
+ * metacharacters) so the key cannot inject unexpected content into log output.
+ */
+function sanitizeKeyForLog(key: string): string {
+  return encodeURIComponent(key)
+}
+
+/**
  * Safely get an item from localStorage
  * @param key - The key to retrieve
  * @returns The stored value or null if not found or error occurs
@@ -13,7 +22,7 @@ export function safeGetItem(key: string): string | null {
     return localStorage.getItem(key)
   } catch (error) {
     // localStorage may throw in private browsing mode or when disabled
-    console.error(`Failed to read from localStorage: ${key}`, error)
+    console.error('Failed to read from localStorage:', sanitizeKeyForLog(key), error)
     return null
   }
 }
@@ -30,7 +39,7 @@ export function safeSetItem(key: string, value: string): boolean {
     return true
   } catch (error) {
     // localStorage may throw in private browsing mode, when quota exceeded, or when disabled
-    console.error(`Failed to write to localStorage: ${key}`, error)
+    console.error('Failed to write to localStorage:', sanitizeKeyForLog(key), error)
     return false
   }
 }
@@ -45,7 +54,7 @@ export function safeRemoveItem(key: string): boolean {
     localStorage.removeItem(key)
     return true
   } catch (error) {
-    console.error(`Failed to remove from localStorage: ${key}`, error)
+    console.error('Failed to remove from localStorage:', sanitizeKeyForLog(key), error)
     return false
   }
 }
@@ -62,7 +71,7 @@ export function safeGetJSON<T = unknown>(key: string): T | null {
       return JSON.parse(item) as T
     }
   } catch (error) {
-    console.error(`Failed to read/parse JSON from localStorage: ${key}`, error)
+    console.error('Failed to read/parse JSON from localStorage:', sanitizeKeyForLog(key), error)
   }
   return null
 }
@@ -78,7 +87,7 @@ export function safeSetJSON<T = unknown>(key: string, value: T): boolean {
     localStorage.setItem(key, JSON.stringify(value))
     return true
   } catch (error) {
-    console.error(`Failed to write JSON to localStorage: ${key}`, error)
+    console.error('Failed to write JSON to localStorage:', sanitizeKeyForLog(key), error)
     return false
   }
 }


### PR DESCRIPTION
## Summary
- Replaces \`Math.random()\` with \`crypto.randomUUID()\` / \`crypto.getRandomValues()\` in 3 files, eliminating 3 CodeQL \`js/insecure-randomness\` high-severity alerts
- Sanitizes user-controlled \`key\` parameter before use in \`console.error()\` template literals in \`localStorage.ts\`, eliminating 3 CodeQL \`js/tainted-format-string\` high-severity alerts
- Adds \`sanitizeKeyForLog()\` helper using \`encodeURIComponent()\` to safely escape any special characters in localStorage key names before logging

**Files changed:**
- \`web/src/components/missions/SaveResolutionDialog.tsx\` — WebSocket request ID now uses \`crypto.randomUUID()\` instead of \`Date.now()\` (predictable, no randomness)
- \`web/src/hooks/useActiveUsers.ts\` — backoff jitter and heartbeat jitter use \`crypto.getRandomValues()\` (Uint32Array); session ID fallback for non-secure contexts uses \`crypto.getRandomValues()\` (Uint8Array) instead of \`Math.random()\`
- \`web/src/hooks/useMissions.tsx\` — \`generateRequestId()\`, \`startMission()\`, and \`saveMission()\` ID generation all use \`crypto.randomUUID()\` instead of \`Math.random().toString(36)\`
- \`web/src/lib/utils/localStorage.ts\` — all \`console.error()\` calls now pass the sanitized key as a separate argument (not interpolated into a format string)

Fixes #9125

## Test plan
- [ ] \`npm run build\` passes (verified locally)
- [ ] \`npm run lint\` passes (verified locally)
- [ ] Missions create, start, and save correctly (IDs remain unique)
- [ ] Reconnect backoff jitter still works as expected
- [ ] localStorage error logging still prints the key name correctly