### PR TITLE
🐛 fix(acmm): read Netlify Blobs directly in badge fn to fix L2 regression

### DIFF
--- a/web/netlify/functions/acmm-badge.mts
+++ b/web/netlify/functions/acmm-badge.mts
@@ -12,9 +12,13 @@
  * Output: { schemaVersion, label, message, color, namedLogo } per shields.io spec
  */
 
+import { getStore } from "@netlify/blobs";
+
 const GITHUB_API = "https://api.github.com";
 const REPO_RE = /^[\w.-]+\/[\w.-]+$/;
 const API_TIMEOUT_MS = 15_000;
+const BLOB_CACHE_STORE = "acmm-scan";
+const BLOB_CACHE_TTL_MS = 60 * 60 * 1000;
 const LEVEL_COMPLETION_THRESHOLD = 0.7;
 /** Maximum maturity level scanned (L6 = Fully Autonomous). L1 is the
  *  starting level; threshold walk gates L2 through MAX_LEVEL. */
@@ -149,6 +153,27 @@ function computeLevel(detectedIds: Set<string>): { level: number; totalDetected:
 }
 
 async function fetchDetectedIds(origin: string, repo: string, force = false): Promise<string[]> {
+  // Fast path: read directly from Netlify Blobs (same store the scan function writes to).
+  // This avoids a same-origin HTTP round-trip that frequently times out inside
+  // Netlify Functions (cold-start + CDN routing overhead exceeds API_TIMEOUT_MS).
+  if (!force) {
+    try {
+      const store = getStore(BLOB_CACHE_STORE);
+      const cacheKey = `scan:${repo}`;
+      const raw = await store.get(cacheKey, { type: "json" });
+      if (raw) {
+        const entry = raw as { scannedAt?: string; detectedIds?: string[] };
+        const age = entry.scannedAt ? Date.now() - new Date(entry.scannedAt).getTime() : Infinity;
+        if (age < BLOB_CACHE_TTL_MS) {
+          return entry.detectedIds || [];
+        }
+      }
+    } catch {
+      // blob read failed — fall through to HTTP
+    }
+  }
+
+  // HTTP path: call the scan endpoint (forces a fresh GitHub scan when force=true).
   const forceParam = force ? "&force=true" : "";
   const url = `${origin}/api/acmm/scan?repo=${encodeURIComponent(repo)}${forceParam}`;
   const res = await fetch(url, { signal: AbortSignal.timeout(API_TIMEOUT_MS) });


### PR DESCRIPTION
## Summary

Same-origin HTTP calls from Netlify Functions to `/api/acmm/scan` time out (CDN routing + cold starts exceed the 15s timeout), causing the badge to fall back to `fetchDetectedIdsDirect()` — a GitHub tree scan that only covers a subset of criteria. This produces a wrong L2 even when the repo has all the L3+ files.

**Fix:** badge function now reads from Netlify Blobs directly (same store the scan function writes to) as the primary path. If the blob is fresh (< 1h) it returns immediately without any HTTP call. Stale or missing falls through to the HTTP scan. `force=true` bypasses the blob read for an on-demand fresh scan.

Fixes the L2 regression introduced when same-origin timeouts caused the fallback to run after #9136 added `.claude/settings.json` + `session-summary.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)