### PR TITLE
fix(e2e): replace page.evaluate() with addInitScript() for webkit auth

### DIFF
--- a/web/e2e/Clusters.spec.ts
+++ b/web/e2e/Clusters.spec.ts
@@ -43,9 +43,12 @@ async function setupClustersTest(page: Page) {
     }
   })
 
-  // Set auth token
-  await page.goto('/login')
-  await page.evaluate(() => {
+  // Seed localStorage BEFORE any page script runs so the auth guard sees
+  // the token on first execution. page.evaluate() runs after the page has
+  // already parsed and executed scripts, which is too late for webkit/Safari
+  // where the auth redirect fires synchronously on script evaluation.
+  // page.addInitScript() injects the snippet ahead of any page code (#9096).
+  await page.addInitScript(() => {
     localStorage.setItem('token', 'test-token')
     localStorage.setItem('demo-user-onboarded', 'true')
   })

--- a/web/e2e/Dashboard.spec.ts
+++ b/web/e2e/Dashboard.spec.ts
@@ -36,9 +36,12 @@ async function setupDashboardTest(page: Page) {
     })
   )
 
-  // Set token before navigating
-  await page.goto('/login')
-  await page.evaluate(() => {
+  // Seed localStorage BEFORE any page script runs so the auth guard sees
+  // the token on first execution. page.evaluate() runs after the page has
+  // already parsed and executed scripts, which is too late for webkit/Safari
+  // where the auth redirect fires synchronously on script evaluation.
+  // page.addInitScript() injects the snippet ahead of any page code (#9096).
+  await page.addInitScript(() => {
     localStorage.setItem('token', 'test-token')
     localStorage.setItem('demo-user-onboarded', 'true')
   })
@@ -145,9 +148,6 @@ test.describe('Dashboard Page', () => {
 
   test.describe('Data Loading', () => {
     test('shows loading state initially', async ({ page }) => {
-      // Reset to fresh page without mocks set up yet
-      await page.goto('/login')
-
       // Delay the API response to see loading state
       await page.route('**/api/mcp/**', async (route) => {
         await new Promise((resolve) => setTimeout(resolve, 2000))
@@ -158,7 +158,8 @@ test.describe('Dashboard Page', () => {
         })
       })
 
-      await page.evaluate(() => {
+      // Seed localStorage BEFORE any page script runs (#9096).
+      await page.addInitScript(() => {
         localStorage.setItem('token', 'test-token')
         localStorage.setItem('demo-user-onboarded', 'true')
       })
@@ -170,9 +171,6 @@ test.describe('Dashboard Page', () => {
     })
 
     test('handles API errors gracefully', async ({ page }) => {
-      // Reset and mock error
-      await page.goto('/login')
-
       await page.route('**/api/mcp/clusters', (route) =>
         route.fulfill({
           status: 500,
@@ -181,7 +179,8 @@ test.describe('Dashboard Page', () => {
         })
       )
 
-      await page.evaluate(() => {
+      // Seed localStorage BEFORE any page script runs (#9096).
+      await page.addInitScript(() => {
         localStorage.setItem('token', 'test-token')
         localStorage.setItem('demo-user-onboarded', 'true')
       })
@@ -330,8 +329,8 @@ test.describe('Dashboard Page', () => {
         })
       })
 
-      await page.goto('/login')
-      await page.evaluate(() => {
+      // Seed localStorage BEFORE any page script runs (#9096).
+      await page.addInitScript(() => {
         localStorage.setItem('token', 'test-token')
         localStorage.setItem('demo-user-onboarded', 'true')
       })

--- a/web/e2e/Events.spec.ts
+++ b/web/e2e/Events.spec.ts
@@ -43,9 +43,12 @@ async function setupEventsTest(page: Page) {
     })
   )
 
-  // Set auth token
-  await page.goto('/login')
-  await page.evaluate(() => {
+  // Seed localStorage BEFORE any page script runs so the auth guard sees
+  // the token on first execution. page.evaluate() runs after the page has
+  // already parsed and executed scripts, which is too late for webkit/Safari
+  // where the auth redirect fires synchronously on script evaluation.
+  // page.addInitScript() injects the snippet ahead of any page code (#9096).
+  await page.addInitScript(() => {
     localStorage.setItem('token', 'test-token')
     localStorage.setItem('demo-user-onboarded', 'true')
   })

--- a/web/e2e/Login.spec.ts
+++ b/web/e2e/Login.spec.ts
@@ -61,10 +61,12 @@ test.describe('Login Page', () => {
       })
     )
 
-    await page.goto('/login')
-
-    // Set localStorage values to simulate a logged-in session
-    await page.evaluate(() => {
+    // Seed localStorage BEFORE any page script runs so the auth guard sees
+    // the token on first execution. page.evaluate() runs after the page has
+    // already parsed and executed scripts, which is too late for webkit/Safari
+    // where the auth redirect fires synchronously on script evaluation.
+    // page.addInitScript() injects the snippet ahead of any page code (#9096).
+    await page.addInitScript(() => {
       localStorage.setItem('token', 'test-token')
       localStorage.setItem('demo-user-onboarded', 'true')
     })

--- a/web/e2e/Settings.spec.ts
+++ b/web/e2e/Settings.spec.ts
@@ -28,9 +28,12 @@ async function setupSettingsTest(page: Page) {
     })
   )
 
-  // Set auth token
-  await page.goto('/login')
-  await page.evaluate(() => {
+  // Seed localStorage BEFORE any page script runs so the auth guard sees
+  // the token on first execution. page.evaluate() runs after the page has
+  // already parsed and executed scripts, which is too late for webkit/Safari
+  // where the auth redirect fires synchronously on script evaluation.
+  // page.addInitScript() injects the snippet ahead of any page code (#9096).
+  await page.addInitScript(() => {
     localStorage.setItem('token', 'test-token')
     localStorage.setItem('demo-user-onboarded', 'true')
   })

--- a/web/e2e/Sidebar.spec.ts
+++ b/web/e2e/Sidebar.spec.ts
@@ -43,9 +43,12 @@ async function setupSidebarTest(page: Page) {
     }
   })
 
-  // Set auth token
-  await page.goto('/login')
-  await page.evaluate(() => {
+  // Seed localStorage BEFORE any page script runs so the auth guard sees
+  // the token on first execution. page.evaluate() runs after the page has
+  // already parsed and executed scripts, which is too late for webkit/Safari
+  // where the auth redirect fires synchronously on script evaluation.
+  // page.addInitScript() injects the snippet ahead of any page code (#9096).
+  await page.addInitScript(() => {
     localStorage.setItem('token', 'test-token')
     localStorage.setItem('demo-user-onboarded', 'true')
   })

--- a/web/e2e/Tour.spec.ts
+++ b/web/e2e/Tour.spec.ts
@@ -1,9 +1,18 @@
 import { test, expect, Page } from '@playwright/test'
 
 /**
- * Sets up authentication and MCP mocks for tour tests
+ * Sets up authentication and MCP mocks for tour tests.
+ *
+ * Uses page.addInitScript() so localStorage is seeded BEFORE any page script
+ * runs. page.evaluate() runs after scripts execute and is too late for
+ * webkit/Safari where the auth redirect fires synchronously (#9096).
+ *
+ * @param tourCompleted - seed `kubestellar-console-tour-completed` in localStorage.
+ *   Pass `true` to simulate a returning user (no welcome prompt).
+ *   Pass `false` to simulate a new user (tour prompt shown).
+ *   Defaults to `true` so most tests start on the dashboard without the prompt.
  */
-async function setupTourTest(page: Page) {
+async function setupTourTest(page: Page, tourCompleted: boolean = true) {
   // Mock authentication
   await page.route('**/api/me', (route) =>
     route.fulfill({
@@ -28,23 +37,27 @@ async function setupTourTest(page: Page) {
     })
   )
 
-  // Set auth token
-  await page.goto('/login')
-  await page.evaluate(() => {
+  // Seed localStorage BEFORE any page script runs so the auth guard sees the
+  // token on first execution. page.evaluate() runs after the page has already
+  // parsed and executed scripts, which is too late for webkit/Safari where the
+  // auth redirect fires synchronously on script evaluation.
+  // page.addInitScript() injects the snippet ahead of any page code (#9096).
+  const completed = tourCompleted
+  await page.addInitScript((isCompleted: boolean) => {
     localStorage.setItem('token', 'test-token')
     localStorage.setItem('demo-user-onboarded', 'true')
-  })
+    if (isCompleted) {
+      localStorage.setItem('kubestellar-console-tour-completed', 'true')
+    } else {
+      localStorage.removeItem('kubestellar-console-tour-completed')
+    }
+  }, completed)
 }
 
 test.describe('Tour/Onboarding', () => {
   test.describe('Tour Prompt for New Users', () => {
     test('shows welcome prompt when tour not completed', async ({ page }) => {
-      await setupTourTest(page)
-
-      // Clear tour completed flag to simulate new user
-      await page.evaluate(() => {
-        localStorage.removeItem('kubestellar-console-tour-completed')
-      })
+      await setupTourTest(page, false)
 
       await page.goto('/')
       await page.waitForLoadState('domcontentloaded')
@@ -54,12 +67,7 @@ test.describe('Tour/Onboarding', () => {
     })
 
     test('hides tour for users who completed it', async ({ page }) => {
-      await setupTourTest(page)
-
-      // Set tour completed flag
-      await page.evaluate(() => {
-        localStorage.setItem('kubestellar-console-tour-completed', 'true')
-      })
+      await setupTourTest(page, true)
 
       await page.goto('/')
       await page.waitForLoadState('domcontentloaded')
@@ -71,11 +79,7 @@ test.describe('Tour/Onboarding', () => {
 
   test.describe('Dashboard Display', () => {
     test('displays dashboard page when tour completed', async ({ page }) => {
-      await setupTourTest(page)
-
-      await page.evaluate(() => {
-        localStorage.setItem('kubestellar-console-tour-completed', 'true')
-      })
+      await setupTourTest(page, true)
 
       await page.goto('/')
       await page.waitForLoadState('domcontentloaded')
@@ -84,11 +88,7 @@ test.describe('Tour/Onboarding', () => {
     })
 
     test('shows cards grid', async ({ page }) => {
-      await setupTourTest(page)
-
-      await page.evaluate(() => {
-        localStorage.setItem('kubestellar-console-tour-completed', 'true')
-      })
+      await setupTourTest(page, true)
 
       await page.goto('/')
       await page.waitForLoadState('domcontentloaded')
@@ -100,12 +100,7 @@ test.describe('Tour/Onboarding', () => {
 
   test.describe('Tour Completion State', () => {
     test('tour completed flag persists after page reload', async ({ page }) => {
-      await setupTourTest(page)
-
-      // Set tour completed flag
-      await page.evaluate(() => {
-        localStorage.setItem('kubestellar-console-tour-completed', 'true')
-      })
+      await setupTourTest(page, true)
 
       await page.goto('/')
       await page.waitForLoadState('domcontentloaded')
@@ -124,11 +119,7 @@ test.describe('Tour/Onboarding', () => {
 
   test.describe('Keyboard Navigation', () => {
     test('escape key does not crash the page', async ({ page }) => {
-      await setupTourTest(page)
-
-      await page.evaluate(() => {
-        localStorage.removeItem('kubestellar-console-tour-completed')
-      })
+      await setupTourTest(page, false)
 
       await page.goto('/')
       await page.waitForLoadState('domcontentloaded')
@@ -141,11 +132,7 @@ test.describe('Tour/Onboarding', () => {
     })
 
     test('arrow keys work on page', async ({ page }) => {
-      await setupTourTest(page)
-
-      await page.evaluate(() => {
-        localStorage.setItem('kubestellar-console-tour-completed', 'true')
-      })
+      await setupTourTest(page, true)
 
       await page.goto('/')
       await page.waitForLoadState('domcontentloaded')
@@ -163,11 +150,7 @@ test.describe('Tour/Onboarding', () => {
 
   test.describe('Responsive Design', () => {
     test('adapts to mobile viewport', async ({ page }) => {
-      await setupTourTest(page)
-
-      await page.evaluate(() => {
-        localStorage.setItem('kubestellar-console-tour-completed', 'true')
-      })
+      await setupTourTest(page, true)
 
       await page.goto('/')
       await page.setViewportSize({ width: 375, height: 667 })
@@ -176,11 +159,7 @@ test.describe('Tour/Onboarding', () => {
     })
 
     test('adapts to tablet viewport', async ({ page }) => {
-      await setupTourTest(page)
-
-      await page.evaluate(() => {
-        localStorage.setItem('kubestellar-console-tour-completed', 'true')
-      })
+      await setupTourTest(page, true)
 
       await page.goto('/')
       await page.setViewportSize({ width: 768, height: 1024 })
@@ -191,11 +170,7 @@ test.describe('Tour/Onboarding', () => {
 
   test.describe('Accessibility', () => {
     test('page is keyboard navigable', async ({ page }) => {
-      await setupTourTest(page)
-
-      await page.evaluate(() => {
-        localStorage.setItem('kubestellar-console-tour-completed', 'true')
-      })
+      await setupTourTest(page, true)
 
       await page.goto('/')
       await page.waitForLoadState('domcontentloaded')
@@ -213,11 +188,7 @@ test.describe('Tour/Onboarding', () => {
     })
 
     test('page has proper heading', async ({ page }) => {
-      await setupTourTest(page)
-
-      await page.evaluate(() => {
-        localStorage.setItem('kubestellar-console-tour-completed', 'true')
-      })
+      await setupTourTest(page, true)
 
       await page.goto('/')
       await page.waitForLoadState('domcontentloaded')

--- a/web/e2e/custom-dashboard.spec.ts
+++ b/web/e2e/custom-dashboard.spec.ts
@@ -49,9 +49,12 @@ async function setupCustomDashboardTest(page: Page) {
     }
   })
 
-  // Set auth token
-  await page.goto('/login')
-  await page.evaluate(() => {
+  // Seed localStorage BEFORE any page script runs so the auth guard sees
+  // the token on first execution. page.evaluate() runs after the page has
+  // already parsed and executed scripts, which is too late for webkit/Safari
+  // where the auth redirect fires synchronously on script evaluation.
+  // page.addInitScript() injects the snippet ahead of any page code (#9096).
+  await page.addInitScript(() => {
     localStorage.setItem('token', 'test-token')
     localStorage.setItem('demo-user-onboarded', 'true')
   })

--- a/web/e2e/navbar-responsive.spec.ts
+++ b/web/e2e/navbar-responsive.spec.ts
@@ -23,8 +23,12 @@ async function setupPage(page: Page) {
     })
   )
 
-  await page.goto('/login')
-  await page.evaluate(() => {
+  // Seed localStorage BEFORE any page script runs so the auth guard sees
+  // the token on first execution. page.evaluate() runs after the page has
+  // already parsed and executed scripts, which is too late for webkit/Safari
+  // where the auth redirect fires synchronously on script evaluation.
+  // page.addInitScript() injects the snippet ahead of any page code (#9096).
+  await page.addInitScript(() => {
     localStorage.setItem('token', 'test-token')
     localStorage.setItem('demo-user-onboarded', 'true')
   })

--- a/web/e2e/responsive-regression.spec.ts
+++ b/web/e2e/responsive-regression.spec.ts
@@ -28,8 +28,12 @@ const KEY_ROUTES = [
 ]
 
 async function setupDemoMode(page: Page) {
-  await page.goto('/login')
-  await page.evaluate(() => {
+  // Seed localStorage BEFORE any page script runs so the auth guard sees
+  // the token on first execution. page.evaluate() runs after the page has
+  // already parsed and executed scripts, which is too late for webkit/Safari
+  // where the auth redirect fires synchronously on script evaluation.
+  // page.addInitScript() injects the snippet ahead of any page code (#9096).
+  await page.addInitScript(() => {
     localStorage.setItem('token', 'demo-token')
     localStorage.setItem('kc-demo-mode', 'true')
     localStorage.setItem('demo-user-onboarded', 'true')

--- a/web/e2e/spa-routes.spec.ts
+++ b/web/e2e/spa-routes.spec.ts
@@ -62,8 +62,12 @@ const ALL_ROUTES = [
 ]
 
 async function setupDemoMode(page: Page) {
-  await page.goto('/login')
-  await page.evaluate(() => {
+  // Seed localStorage BEFORE any page script runs so the auth guard sees
+  // the token on first execution. page.evaluate() runs after the page has
+  // already parsed and executed scripts, which is too late for webkit/Safari
+  // where the auth redirect fires synchronously on script evaluation.
+  // page.addInitScript() injects the snippet ahead of any page code (#9096).
+  await page.addInitScript(() => {
     localStorage.setItem('token', 'demo-token')
     localStorage.setItem('kc-demo-mode', 'true')
     localStorage.setItem('demo-user-onboarded', 'true')


### PR DESCRIPTION
## Summary

- **Root cause**: WebKit/Safari fires the auth guard synchronously on script evaluation. All 11 nightly test files were seeding `localStorage` via `page.evaluate()` after `page.goto('/login')`, which means the token arrived after the app had already checked auth state and initiated the redirect to `/login`. Chromium is lenient about timing, WebKit is not.
- **Fix (Option B — auth bypass via `addInitScript`)**: Replace every `page.evaluate(() => localStorage.setItem(...))` that precedes a navigation with `page.addInitScript()`. `addInitScript` injects the seed script before any page code runs, so the auth guard sees the token on its very first read — exactly how `helpers/setup.ts::setupDemoMode` already works.
- **Tour.spec.ts** was additionally refactored: accepted a new `tourCompleted` boolean so tour state is seeded atomically in the same `addInitScript` call, avoiding a second race-prone `page.evaluate()` for the tour flag.

Fixes #9096

## Test plan
- [ ] `npm run build` passes locally (verified)
- [ ] WebKit no longer gets redirected to `/login` when navigating to authenticated routes
- [ ] All 11 affected spec files now use `addInitScript` for the auth seed
- [ ] Chromium and Firefox tests unaffected
- [ ] Tour tests pass with the refactored `tourCompleted` boolean parameter