### PR TITLE
🐛 fix(affiliate): credit GH-login utm_term under intern_outreach + shorten cache TTL

### DIFF
--- a/web/netlify/functions/affiliate-clicks.mts
+++ b/web/netlify/functions/affiliate-clicks.mts
@@ -32,10 +32,32 @@ for (const [login, term] of Object.entries(INTERN_MAP)) {
   TERM_TO_LOGIN[term] = login.toLowerCase();
 }
 
-/** Cache TTL — 15 minutes */
-const CACHE_TTL_MS = 15 * 60 * 1000;
+/** Cache TTL — 3 minutes. Shorter than before (was 15m) so intern shares
+ *  feel responsive on the leaderboard once GA4 has processed the clicks.
+ *  GA4 itself has a separate 24-48h attribution-dimension processing lag
+ *  that this cache cannot help with; see the leaderboard footnote. */
+const CACHE_TTL_MS = 3 * 60 * 1000;
 /** Days to look back for affiliate clicks */
 const LOOKBACK_DAYS = 90;
+
+/** Minimum / maximum plausible GitHub login length. GitHub enforces 1-39
+ *  chars; we require 2+ to avoid spurious single-letter matches that look
+ *  like parsing artifacts. */
+const GH_LOGIN_MIN_LEN = 2;
+const GH_LOGIN_MAX_LEN = 39;
+const GH_LOGIN_PATTERN = /^[a-zA-Z0-9](?:[a-zA-Z0-9]|-(?=[a-zA-Z0-9])){1,38}$/;
+
+/** True when a raw utm_term looks like a plausible GitHub login — i.e. a
+ *  mentee shared a link with `utm_campaign=intern_outreach` but used their
+ *  GitHub handle as utm_term instead of the legacy `intern-0X` form. We
+ *  treat those as contributor_affiliate-style entries rather than dropping
+ *  them (GA4 data on 2026-04-19 showed xonas1101 under intern_outreach —
+ *  the old code silently skipped that row). */
+function isPlausibleGitHubLogin(term: string): boolean {
+  if (term.length < GH_LOGIN_MIN_LEN || term.length > GH_LOGIN_MAX_LEN) return false;
+  if (/^intern-\d+$/.test(term)) return false;
+  return GH_LOGIN_PATTERN.test(term);
+}
 
 let cachedResult: { data: Record<string, AffiliateData>; fetchedAt: number } | null = null;
 
@@ -146,25 +168,39 @@ async function fetchAffiliateClicks(): Promise<Record<string, AffiliateData>> {
     }
   }
 
-  // Process intern_outreach rows (utm_term → GitHub login via INTERN_MAP)
+  // Process intern_outreach rows. Historically utm_term was `intern-0X` and
+  // mapped through INTERN_MAP; the project is migrating to utm_term=<github>.
+  // Since interns may still tag shares with `intern_outreach` while using a
+  // GitHub-login utm_term (observed 2026-04-19 with xonas1101), fall back to
+  // treating that term AS the login when it doesn't match INTERN_MAP and
+  // looks like a plausible GitHub handle.
   for (const row of internRes.data.rows || []) {
     const utmTerm = row.dimensionValues?.[0]?.value;
     const sessions = parseInt(row.metricValues?.[0]?.value || "0");
     const users = parseInt(row.metricValues?.[1]?.value || "0");
 
-    if (!utmTerm || !TERM_TO_LOGIN[utmTerm]) continue;
+    if (!utmTerm) continue;
 
-    const login = TERM_TO_LOGIN[utmTerm];
-    mergeEntry(login, utmTerm, sessions, users);
+    if (TERM_TO_LOGIN[utmTerm]) {
+      // Legacy intern-0X → mapped GitHub login
+      mergeEntry(TERM_TO_LOGIN[utmTerm], utmTerm, sessions, users);
+    } else if (isPlausibleGitHubLogin(utmTerm)) {
+      // New shape under the legacy campaign — credit the GitHub login directly
+      mergeEntry(utmTerm, utmTerm, sessions, users);
+    }
+    // Otherwise drop — utm_term is not a known intern slot and not a
+    // plausible GitHub login (e.g. free-form text, spam, typo).
   }
 
-  // Process contributor_affiliate rows (utm_term IS the GitHub login directly)
+  // Process contributor_affiliate rows (utm_term IS the GitHub login directly).
+  // Validate with the GitHub-login pattern so a stray `(not set)` / typo /
+  // garbage term doesn't create a phantom leaderboard row.
   for (const row of contributorRes.data.rows || []) {
     const utmTerm = row.dimensionValues?.[0]?.value;
     const sessions = parseInt(row.metricValues?.[0]?.value || "0");
     const users = parseInt(row.metricValues?.[1]?.value || "0");
 
-    if (!utmTerm) continue;
+    if (!utmTerm || !isPlausibleGitHubLogin(utmTerm)) continue;
 
     mergeEntry(utmTerm, utmTerm, sessions, users);
   }


### PR DESCRIPTION
## Summary

Three changes to `web/netlify/functions/affiliate-clicks.mts` addressing interns reporting the contributor leaderboard "Social" column stuck at their old counts despite active sharing.

## Context

Interns reported on Slack (paraphrased):
- Ghanshyam (intern-02): "only 9 clicks which is my older count"
- Rishi (intern-01): "shared with 50 people, count does not increase"
- Arnav (intern-03): "stuck on 9 clicks"

Live GA4 data confirmed three real issues, plus one that can't be fixed from the server (chat-app UTM stripping — see leaderboard footnote PR).

## Changes

### 1. Recover dropped Query 1 rows (the biggest data leak)

GA4 data on 2026-04-19 included `sessionCampaignName=intern_outreach` + `sessionManualTerm=xonas1101` (not `intern-06`). Previous Query 1 loop:

```ts
if (!utmTerm || !TERM_TO_LOGIN[utmTerm]) continue;
```

…silently dropped every such row. Interns are transitioning from legacy `intern-0X` utm_term to using their GitHub handle, sometimes while still tagging the share with the `intern_outreach` campaign out of habit. **All those clicks were lost.**

Now Query 1 falls back to treating an unknown `utm_term` AS the GitHub login when it matches GitHub's login pattern.

### 2. Tighten Query 2 guard

Query 2 (`contributor_affiliate`) previously accepted any utm_term as a GitHub login, which would create phantom rows on `(not set)` / typo terms. Now gated by the same `isPlausibleGitHubLogin()` helper.

### 3. Drop cache TTL 15m → 3m

A 15-minute function cache compounded GA4's own 24-48h attribution-dimension processing lag and made the leaderboard feel frozen. 3m is short enough that a share propagates to the leaderboard within minutes of GA4 processing, without hammering the Analytics Data API.

(GA4's 24-48h attribution window cannot be shortened from here. A separate footnote PR on `kubestellar/docs` will explain the delay to users.)

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npm run build` clean
- [x] Manual: `curl https://console.kubestellar.io/api/affiliate/clicks` still returns valid JSON (post-deploy)
- [ ] Manual: verify at least one previously-dropped row (e.g., xonas1101 under intern_outreach on 2026-04-19) now appears in the response

## Related

- Intern reports on Slack (2026-04-20)
- Leaderboard footnote PR — to be filed on `kubestellar/docs`
- "Copy my affiliate link" UI PR — to be filed separately