### PR TITLE
✨ feat(settings): add 'Your Affiliate Link' block to Profile section

### DIFF
--- a/web/src/components/settings/Settings.tsx
+++ b/web/src/components/settings/Settings.tsx
@@ -414,6 +414,7 @@ export function Settings() {
             <ProfileSection
               initialEmail={user?.email || ''}
               initialSlackId={user?.slack_id || ''}
+              githubLogin={user?.github_login}
               refreshUser={refreshUser}
               isLoading={isUserLoading}
             />

--- a/web/src/components/settings/sections/ProfileSection.tsx
+++ b/web/src/components/settings/sections/ProfileSection.tsx
@@ -1,6 +1,6 @@
-import { useState, useEffect, useRef } from 'react'
+import { useState, useEffect, useRef, useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
-import { Save, User, Loader2, AlertCircle, RefreshCw } from 'lucide-react'
+import { Save, User, Loader2, AlertCircle, RefreshCw, Check, Copy, Share2 } from 'lucide-react'
 import { STORAGE_KEY_TOKEN, FETCH_DEFAULT_TIMEOUT_MS } from '../../../lib/constants'
 import { UI_FEEDBACK_TIMEOUT_MS } from '../../../lib/constants/network'
 import { safeGetItem } from '../../../lib/utils/localStorage'
@@ -8,15 +8,43 @@ import { safeGetItem } from '../../../lib/utils/localStorage'
 interface ProfileSectionProps {
   initialEmail: string
   initialSlackId: string
+  /** GitHub login used to populate the affiliate link. Empty = section hidden / disabled. */
+  githubLogin?: string
   refreshUser: () => Promise<void>
   isLoading?: boolean
 }
+
+/** Channels shown in the affiliate-link medium picker. Values mirror GA4
+ *  utm_medium conventions so attribution stays consistent with the existing
+ *  intern_outreach tracking. */
+const AFFILIATE_CHANNELS = [
+  { value: 'linkedin', label: 'LinkedIn' },
+  { value: 'twitter',  label: 'Twitter / X' },
+  { value: 'email',    label: 'Email' },
+  { value: 'sms',      label: 'SMS / text' },
+  { value: 'blog',     label: 'Blog' },
+  { value: 'youtube',  label: 'YouTube' },
+  { value: 'devto',    label: 'dev.to' },
+  { value: 'github',   label: 'GitHub (comment/README)' },
+  { value: 'other',    label: 'Other' },
+] as const
+
+/** Base URL users will share. The leaderboard's backend (affiliate-clicks
+ *  Netlify function) listens on console.kubestellar.io only, so that's the
+ *  canonical destination regardless of where the user is viewing this UI. */
+const AFFILIATE_BASE_URL = 'https://console.kubestellar.io'
+/** utm_source is fixed: these are personal shares by a contributor. */
+const AFFILIATE_UTM_SOURCE = 'social'
+/** utm_campaign for GitHub-identity shares (the new, forward-going scheme). */
+const AFFILIATE_UTM_CAMPAIGN = 'contributor_affiliate'
+/** How long to flash the "Copied!" label after a successful copy. */
+const AFFILIATE_COPY_FLASH_MS = 1500
 
 // Basic email format check: non-empty local + "@" + domain + "." + TLD, no whitespace.
 // Intentionally not RFC-perfect — matches HTML5 type=email's spirit and blocks obvious junk.
 const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
 
-export function ProfileSection({ initialEmail, initialSlackId, refreshUser, isLoading }: ProfileSectionProps) {
+export function ProfileSection({ initialEmail, initialSlackId, githubLogin, refreshUser, isLoading }: ProfileSectionProps) {
   const { t } = useTranslation()
   const [email, setEmail] = useState(initialEmail)
   const [slackId, setSlackId] = useState(initialSlackId)
@@ -25,7 +53,39 @@ export function ProfileSection({ initialEmail, initialSlackId, refreshUser, isLo
   const [isRefreshing, setIsRefreshing] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const [emailError, setEmailError] = useState<string | null>(null)
+  const [affiliateChannel, setAffiliateChannel] = useState<string>(AFFILIATE_CHANNELS[0].value)
+  const [affiliateCopied, setAffiliateCopied] = useState(false)
   const timeoutRef = useRef<number>(undefined)
+  const copyTimeoutRef = useRef<number>(undefined)
+
+  // Canonical affiliate URL for the current user. Lowercased login to match
+  // the affiliate-clicks Netlify function's lookup key and the leaderboard's
+  // case-insensitive rendering. utm_term goes last so the string is readable
+  // when displayed in the textarea.
+  const affiliateUrl = useMemo(() => {
+    if (!githubLogin) return ''
+    const term = githubLogin.toLowerCase()
+    const params = new URLSearchParams({
+      utm_source: AFFILIATE_UTM_SOURCE,
+      utm_medium: affiliateChannel,
+      utm_campaign: AFFILIATE_UTM_CAMPAIGN,
+      utm_term: term,
+    })
+    return `${AFFILIATE_BASE_URL}/?${params.toString()}`
+  }, [githubLogin, affiliateChannel])
+
+  const handleCopyAffiliate = async () => {
+    if (!affiliateUrl) return
+    try {
+      await navigator.clipboard.writeText(affiliateUrl)
+      setAffiliateCopied(true)
+      if (copyTimeoutRef.current) clearTimeout(copyTimeoutRef.current)
+      copyTimeoutRef.current = window.setTimeout(() => setAffiliateCopied(false), AFFILIATE_COPY_FLASH_MS)
+    } catch {
+      // Clipboard API can reject on non-secure contexts or denied permission.
+      // The URL is already visible in the input, so users can copy manually.
+    }
+  }
 
   const handleEmailChange = (value: string) => {
     setEmail(value)
@@ -37,11 +97,14 @@ export function ProfileSection({ initialEmail, initialSlackId, refreshUser, isLo
     }
   }
 
-  // Cleanup timeout on unmount
+  // Cleanup timeouts on unmount
   useEffect(() => {
     return () => {
       if (timeoutRef.current) {
         clearTimeout(timeoutRef.current)
+      }
+      if (copyTimeoutRef.current) {
+        clearTimeout(copyTimeoutRef.current)
       }
     }
   }, [])
@@ -161,6 +224,66 @@ export function ProfileSection({ initialEmail, initialSlackId, refreshUser, isLo
             )}
             {isRefreshing ? t('settings.profile.refreshing') : isSaving ? t('settings.profile.saving') : profileSaved ? t('settings.profile.saved') : t('settings.profile.saveProfile')}
           </button>
+
+          {/* Affiliate link block — renders the canonical share URL for the
+              contributor leaderboard's "Social" column. Requires a GitHub
+              login; shows an explanatory placeholder otherwise. */}
+          <div className="pt-6 mt-2 border-t border-border/50">
+            <div className="flex items-center gap-2 mb-2">
+              <Share2 className="w-4 h-4 text-muted-foreground" />
+              <h3 className="text-sm font-medium text-foreground">{t('settings.profile.affiliateTitle')}</h3>
+            </div>
+            <p className="text-xs text-muted-foreground mb-3">{t('settings.profile.affiliateSubtitle')}</p>
+
+            {!githubLogin ? (
+              <p className="text-xs text-muted-foreground italic">
+                {t('settings.profile.affiliateLoginMissing')}
+              </p>
+            ) : (
+              <>
+                <div className="mb-3">
+                  <label htmlFor="affiliate-channel" className="block text-xs text-muted-foreground mb-1">
+                    {t('settings.profile.affiliateChannelLabel')}
+                  </label>
+                  <select
+                    id="affiliate-channel"
+                    value={affiliateChannel}
+                    onChange={(e) => setAffiliateChannel(e.target.value)}
+                    className="w-full sm:w-auto px-3 py-2 rounded-lg bg-secondary border border-border text-foreground text-sm"
+                  >
+                    {AFFILIATE_CHANNELS.map((ch) => (
+                      <option key={ch.value} value={ch.value}>{ch.label}</option>
+                    ))}
+                  </select>
+                  <p className="mt-1 text-[11px] text-muted-foreground">{t('settings.profile.affiliateChannelHint')}</p>
+                </div>
+
+                <div className="flex flex-col sm:flex-row gap-2">
+                  <input
+                    id="affiliate-url"
+                    type="text"
+                    value={affiliateUrl}
+                    readOnly
+                    onFocus={(e) => e.currentTarget.select()}
+                    className="flex-1 px-3 py-2 rounded-lg bg-secondary border border-border text-foreground text-xs font-mono select-all"
+                    aria-label={t('settings.profile.affiliateTitle')}
+                  />
+                  <button
+                    type="button"
+                    onClick={handleCopyAffiliate}
+                    className="flex items-center justify-center gap-2 px-4 py-2 rounded-lg bg-purple-500/10 text-purple-400 hover:bg-purple-500/20 border border-purple-500/30 text-sm whitespace-nowrap transition-colors"
+                  >
+                    {affiliateCopied ? <Check className="w-4 h-4" /> : <Copy className="w-4 h-4" />}
+                    {affiliateCopied ? t('settings.profile.affiliateCopied') : t('settings.profile.affiliateCopy')}
+                  </button>
+                </div>
+
+                <p className="mt-3 text-[11px] leading-relaxed text-muted-foreground">
+                  {t('settings.profile.affiliateFootnote')}
+                </p>
+              </>
+            )}
+          </div>
         </div>
       )}
     </div>

--- a/web/src/locales/en/common.json
+++ b/web/src/locales/en/common.json
@@ -363,7 +363,15 @@
       "saved": "Saved!",
       "saveProfile": "Save Profile",
       "saveFailed": "Failed to save profile",
-      "invalidEmail": "Enter a valid email address."
+      "invalidEmail": "Enter a valid email address.",
+      "affiliateTitle": "Your Affiliate Link",
+      "affiliateSubtitle": "Share this link to earn credits on the contributor leaderboard",
+      "affiliateChannelLabel": "Channel",
+      "affiliateChannelHint": "Pick the channel you're sharing on — helps us attribute traffic",
+      "affiliateCopy": "Copy link",
+      "affiliateCopied": "Copied!",
+      "affiliateLoginMissing": "Sign in with GitHub to generate your affiliate link.",
+      "affiliateFootnote": "Counts update within 24–48h (Google Analytics attribution lag). Chat apps like WhatsApp and Discord strip query strings from link previews — prefer email, SMS, GitHub comments, or plain-text shares."
     },
     "notifications": {
       "title": "Alert Notifications",


### PR DESCRIPTION
## Summary

Contributors share affiliate links to earn credits on the leaderboard's "Social" column but until now had to hand-craft the URL. Multiple failure modes were observed on 2026-04-20:

- `utm_campaign=intern_outreach` + `utm_term=<github-login>` — legacy campaign + new term shape, silently dropped by the Netlify function (now recovered by #9153).
- `utm_term` omitted entirely.
- `utm_campaign` spelled inconsistently.

This PR adds a "Your Affiliate Link" block under `Settings > Profile` that generates the canonical URL automatically from the signed-in user's `github_login`.

## Behavior

Rendered URL shape:

```
https://console.kubestellar.io/?
  utm_source=social&
  utm_medium=<picker>&
  utm_campaign=contributor_affiliate&
  utm_term=<github-login lowercased>
```

Features:
- **Channel picker** (LinkedIn, Twitter/X, email, SMS, blog, YouTube, dev.to, GitHub comment, other) → `utm_medium` value.
- **Copy-to-clipboard** with transient "Copied!" state.
- **Footnote** explaining the 24-48h GA4 attribution lag and chat-app UTM stripping (mirrors the leaderboard footnote added in kubestellar/docs#1499).
- **Graceful fallback** when `github_login` is missing (demo mode, token-only sessions): explanatory placeholder, no broken URL.

## Conventions followed

- All user-visible strings via `t()` (keys added under `settings.profile.affiliate*` in `web/src/locales/en/common.json`).
- All numeric literals named constants (`AFFILIATE_COPY_FLASH_MS`, etc.) with short comments.
- `isDemoData` wiring unaffected (this is a settings section, not a card).

## Files

- `web/src/components/settings/sections/ProfileSection.tsx` — affiliate block + channel picker + copy handler.
- `web/src/components/settings/Settings.tsx` — wire `user.github_login` through to the section.
- `web/src/locales/en/common.json` — 8 new i18n keys under `settings.profile`.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npm run build` clean (all post-build safety checks pass)
- [ ] Manual: `/settings`, expand Profile, verify URL updates as channel changes and Copy button works.
- [ ] Manual: verify the no-login fallback renders correctly in demo mode.

## Related

- `kubestellar/console#9153` — Netlify function fix for dropped utm_term rows.
- `kubestellar/docs#1499` — leaderboard footnote explaining why counts may look stuck.