### PR TITLE
fix(security): add least-privilege permissions to remaining workflows

### DIFF
--- a/.github/workflows/ai-fix.yml
+++ b/.github/workflows/ai-fix.yml
@@ -12,13 +12,16 @@ on:
   pull_request_target:
     types: [opened]
 
-permissions:
-  contents: write
-  issues: write
-  pull-requests: write
+# Least-privilege: read-only by default; the reusable workflow manages issues,
+# creates PRs, and may push branch commits on behalf of Copilot.
+permissions: read-all
 
 jobs:
   ai-fix:
+    permissions:
+      contents: write
+      issues: write
+      pull-requests: write
     uses: kubestellar/infra/.github/workflows/reusable-ai-fix.yml@main
     with:
       issue_number: ${{ github.event.inputs.issue_number || '' }}

--- a/.github/workflows/copilot-dco.yml
+++ b/.github/workflows/copilot-dco.yml
@@ -4,6 +4,13 @@ on:
   pull_request:
     types: [opened, synchronize, reopened]
 
+# Least-privilege: read-only by default; the reusable workflow sets commit
+# statuses and manages DCO labels on PRs.
+permissions: read-all
+
 jobs:
   copilot-dco:
+    permissions:
+      statuses: write
+      pull-requests: write
     uses: kubestellar/infra/.github/workflows/reusable-copilot-dco.yml@main


### PR DESCRIPTION
## Summary

Fixes the remaining open CodeQL `TokenPermissionsID` alerts from issue #9167.

- **`ai-fix.yml`**: Top-level `permissions` block had `contents: write` which is too broad. Changed to `permissions: read-all` at top level and moved write grants (`contents`, `issues`, `pull-requests`) to job level.
- **`copilot-dco.yml`**: Had no top-level `permissions` block at all. Added `permissions: read-all` at top level and added job-level grants (`statuses: write`, `pull-requests: write`) needed by the reusable DCO workflow.

The other 8 files listed in the issue (`auto-qa-tuner.yml`, `cleanup-screenshots.yml`, `copilot-automation.yml`, `helm-release.yml`, `nightly-test-suite.yml`, `pr-verifier.yml`, `process-screenshots.yml`, `scorecard.yml`) were already fixed by PR #9141 — the CodeQL alerts for those files will auto-dismiss on the next scan.

This follows the same pattern established in PR #9141: `permissions: read-all` at workflow top level, minimal write scopes declared only at the job level.

Fixes #9167