### PR TITLE
🐛 fix(feedback): add backdrop and outside-click close to feedback modal

### DIFF
--- a/web/src/components/feedback/FeedbackModal.tsx
+++ b/web/src/components/feedback/FeedbackModal.tsx
@@ -294,8 +294,24 @@ export function FeedbackModal({ isOpen, onClose, initialType = 'feature' }: Feed
 
   const coins = type === 'bug' ? REWARD_ACTIONS.bug_report.coins : REWARD_ACTIONS.feature_suggestion.coins
 
+  // Close on backdrop click — only when the click target is the backdrop
+  // itself, not any child element (so clicks inside the modal content do
+  // not dismiss it). Routes through handleClose() so the unsaved-changes
+  // confirmation flow runs if the user has typed anything. (Fixes #9159)
+  const handleBackdropClick = (e: React.MouseEvent<HTMLDivElement>) => {
+    if (e.target === e.currentTarget) {
+      handleClose()
+    }
+  }
+
   return createPortal(
-    <div className="fixed inset-0 z-modal flex items-center justify-center bg-black/60 backdrop-blur-sm">
+    <div
+      className="fixed inset-0 z-modal flex items-center justify-center bg-black/60 backdrop-blur-sm"
+      onClick={handleBackdropClick}
+      role="dialog"
+      aria-modal="true"
+      aria-label="Submit Feedback"
+    >
       <ConfirmDialog
         isOpen={showDiscardConfirm}
         onClose={() => setShowDiscardConfirm(false)}


### PR DESCRIPTION
Fixes #9159

## Summary

The Feedback/Contribute modal could not be dismissed by clicking on the backdrop / dimmed overlay area. Only the X button and Escape key worked.

## Root cause

`web/src/components/feedback/FeedbackModal.tsx` rendered the dimmed-backdrop wrapper (`<div className="fixed inset-0 ... bg-black/60 backdrop-blur-sm">`) but the wrapper had no `onClick` handler, so clicks on the background did nothing.

## Fix

- Added `onClick={handleBackdropClick}` to the backdrop wrapper.
- The handler only closes when `e.target === e.currentTarget`, so clicks inside the modal content do not dismiss the modal.
- Routes through the existing `handleClose()` flow, which already preserves the unsaved-changes confirmation dialog when the user has typed a draft.
- Added `role="dialog"`, `aria-modal="true"`, and `aria-label="Submit Feedback"` for a11y.

ESC, Space, and the X button continue to work as before. The `<ConfirmDialog>` for unsaved changes remains the gate when there's draft text.

## Test plan

- [ ] Open the feedback modal with no input — click outside, modal closes
- [ ] Open the feedback modal, type a title — click outside, "Discard unsaved changes?" confirmation appears
- [ ] Click inside the modal content (header, form, buttons) — modal stays open
- [ ] ESC still closes the modal
- [ ] X button still closes the modal