### PR TITLE
fix(acmm): L2 Instructed gate uses OR-group for agent instruction files (Fixes #9169)

### DIFF
--- a/web/netlify/functions/acmm-badge.mts
+++ b/web/netlify/functions/acmm-badge.mts
@@ -35,6 +35,21 @@ const MAX_LEVEL = 6;
 const BADGE_CACHE_SECONDS = 3600;
 
 /**
+ * Agent instruction files are an OR group for L2: any one vendor-specific or
+ * vendor-neutral file satisfies the "Instructed" signal. A project using the
+ * vendor-agnostic AGENTS.md (agents.md spec) should reach L2 just as easily
+ * as one that stacks multiple vendor-specific configs. The virtual criterion
+ * "acmm:agent-instructions" is synthesised in computeLevel() before the level
+ * walk if any member of this set is present in detectedIds. Issue #9169.
+ */
+const AGENT_INSTRUCTION_FILE_IDS = new Set([
+  "acmm:claude-md",
+  "acmm:copilot-instructions",
+  "acmm:agents-md",
+  "acmm:cursor-rules",
+]);
+
+/**
  * ACMM criteria grouped by level. MUST mirror the scannable entries in
  * acmm-scan.mts CRITERIA (IDs and level assignments).
  *
@@ -43,13 +58,14 @@ const BADGE_CACHE_SECONDS = 3600;
  * taxonomy, so the badge always computed to L1 ("5/10" for kubestellar/
  * console) regardless of the repo's real maturity. When adding / renaming
  * criteria in acmm-scan.mts, update this map and the LEVEL_NAMES below.
+ *
+ * L2 uses a virtual "acmm:agent-instructions" criterion (synthesised in
+ * computeLevel) rather than the four individual instruction-file IDs, so that
+ * any one vendor-neutral or vendor-specific file satisfies the L2 gate.
  */
 const ACMM_IDS_BY_LEVEL: Record<number, string[]> = {
   2: [
-    "acmm:claude-md",
-    "acmm:copilot-instructions",
-    "acmm:agents-md",
-    "acmm:cursor-rules",
+    "acmm:agent-instructions", // virtual OR: any of claude-md / agents-md / copilot-instructions / cursor-rules
     "acmm:prompts-catalog",
     "acmm:editor-config",
   ],
@@ -126,7 +142,15 @@ function corsHeaders(origin: string | null): Record<string, string> {
   return headers;
 }
 
-function computeLevel(detectedIds: Set<string>): { level: number; totalDetected: number; totalAcmm: number } {
+function computeLevel(rawDetectedIds: Set<string>): { level: number; totalDetected: number; totalAcmm: number } {
+  // Synthesise the virtual L2 criterion before the level walk.
+  // Any one instruction file (vendor-neutral AGENTS.md or vendor-specific
+  // CLAUDE.md / copilot-instructions / .cursorrules) satisfies the group.
+  const detectedIds = new Set(rawDetectedIds);
+  if ([...AGENT_INSTRUCTION_FILE_IDS].some((id) => detectedIds.has(id))) {
+    detectedIds.add("acmm:agent-instructions");
+  }
+
   let currentLevel = 1;
   let totalDetected = 0;
   let totalAcmm = 0;
@@ -137,8 +161,11 @@ function computeLevel(detectedIds: Set<string>): { level: number; totalDetected:
     totalAcmm += required.length;
     totalDetected += detected;
     if (required.length === 0 || stopPromotion) continue;
+    // L2 "Instructed" is reached with any single criterion (the project has
+    // started using AI tooling); higher levels use the 70 % threshold.
+    const threshold = n === 2 ? 1 / required.length : LEVEL_COMPLETION_THRESHOLD;
     const ratio = detected / required.length;
-    if (ratio >= LEVEL_COMPLETION_THRESHOLD) {
+    if (ratio >= threshold) {
       currentLevel = n;
     } else {
       // Stop promoting levels after the first gap, but keep counting
@@ -195,7 +222,8 @@ async function fetchDetectedIds(origin: string, repo: string, force = false): Pr
  * on any repo), so every fallback path computed to L1.
  */
 const BADGE_FALLBACK_PATHS: Record<string, readonly string[]> = {
-  // L2
+  // L2 — individual instruction files still detected; computeLevel synthesises
+  // the virtual "acmm:agent-instructions" from any one of these matches.
   "acmm:claude-md": ["CLAUDE.md", ".claude/CLAUDE.md"],
   "acmm:copilot-instructions": [".github/copilot-instructions.md"],
   "acmm:agents-md": ["AGENTS.md"],

--- a/web/src/lib/acmm/computeLevel.ts
+++ b/web/src/lib/acmm/computeLevel.ts
@@ -8,6 +8,31 @@ const LEVEL_COMPLETION_THRESHOLD = 0.7
 /** Level 0 = prerequisites (soft indicator, not gating) */
 const PREREQUISITE_LEVEL = 0
 
+/**
+ * Agent instruction files are an OR group for L2: any one vendor-specific or
+ * vendor-neutral file satisfies "Instructed." A virtual criterion
+ * "acmm:agent-instructions" is synthesised before the level walk if any
+ * member of this set is present in detectedIds. Issue #9169 / kubebuilder#5651.
+ */
+const AGENT_INSTRUCTION_FILE_IDS = new Set([
+  'acmm:claude-md',
+  'acmm:copilot-instructions',
+  'acmm:agents-md',
+  'acmm:cursor-rules',
+])
+
+/** Virtual criterion representing the OR group above (not in acmm.ts source). */
+const VIRTUAL_AGENT_INSTRUCTIONS: Criterion = {
+  id: 'acmm:agent-instructions',
+  source: 'acmm',
+  level: 2,
+  category: 'feedback-loop',
+  name: 'Agent instructions (any)',
+  description: 'Any one of CLAUDE.md, AGENTS.md, .github/copilot-instructions.md, or .cursorrules.',
+  rationale: 'Any vendor-neutral or vendor-specific instruction file satisfies the L2 Instructed signal.',
+  detection: { type: 'any-of', pattern: ['CLAUDE.md', 'AGENTS.md', '.github/copilot-instructions.md', '.cursorrules'] },
+}
+
 export interface LevelComputation {
   level: number
   levelName: string
@@ -31,11 +56,15 @@ const ACMM_CRITERIA = acmmSource.criteria.filter((c) => c.source === 'acmm')
 const ACMM_LEVELS = acmmSource.levels ?? []
 
 /** Return scannable criteria for a given level (non-scannable items are
- *  displayed in the UI but excluded from threshold calculations). */
+ *  displayed in the UI but excluded from threshold calculations).
+ *  For L2, the four individual instruction-file criteria are replaced by the
+ *  virtual OR-group criterion so any one file satisfies the level gate. */
 function scannableCriteriaForLevel(level: number): Criterion[] {
-  return ACMM_CRITERIA.filter(
-    (c) => c.level === level && c.scannable !== false,
-  )
+  const raw = ACMM_CRITERIA.filter((c) => c.level === level && c.scannable !== false)
+  if (level !== 2) return raw
+  // Replace individual instruction-file entries with the virtual OR-group
+  const rest = raw.filter((c) => !AGENT_INSTRUCTION_FILE_IDS.has(c.id))
+  return [VIRTUAL_AGENT_INSTRUCTIONS, ...rest]
 }
 
 /** Return ALL criteria for a given level (including non-scannable). */
@@ -47,7 +76,13 @@ function levelDef(n: number) {
   return ACMM_LEVELS.find((l) => l.n === n)
 }
 
-export function computeLevel(detectedIds: Set<string>): LevelComputation {
+export function computeLevel(rawDetectedIds: Set<string>): LevelComputation {
+  // Synthesise the virtual L2 OR-group criterion before the level walk.
+  const detectedIds = new Set(rawDetectedIds)
+  if ([...AGENT_INSTRUCTION_FILE_IDS].some((id) => detectedIds.has(id))) {
+    detectedIds.add('acmm:agent-instructions')
+  }
+
   const detectedByLevel: Record<number, number> = {}
   const requiredByLevel: Record<number, number> = {}
 
@@ -63,8 +98,10 @@ export function computeLevel(detectedIds: Set<string>): LevelComputation {
     const required = requiredByLevel[n]
     const detected = detectedByLevel[n]
     if (required === 0) continue
+    // L2 "Instructed" is reached with any single criterion; higher levels use 70%
+    const threshold = n === 2 ? 1 / required : LEVEL_COMPLETION_THRESHOLD
     const ratio = detected / required
-    if (ratio >= LEVEL_COMPLETION_THRESHOLD) {
+    if (ratio >= threshold) {
       currentLevel = n
     } else {
       break


### PR DESCRIPTION
## Summary

- Any one of `AGENTS.md` / `CLAUDE.md` / `.github/copilot-instructions.md` / `.cursorrules` now satisfies the L2 "Instructed" gate
- The four individual instruction-file IDs are replaced by a virtual `acmm:agent-instructions` OR-group criterion in both the badge function and the frontend `computeLevel()`
- L2 promotion threshold changed from 70% to **any-one** (1/N); L3+ keeps the 70% threshold
- Individual files are still detected and reported in scan results so the dashboard shows which tools the project uses

Fixes #9169
Reported-by: camilamacedo86 in kubernetes-sigs/kubebuilder#5651 — valid critique that vendor-neutral AGENTS.md was penalised vs stacking multiple vendor-specific configs

## Files changed

| File | Change |
|---|---|
| `web/netlify/functions/acmm-badge.mts` | `AGENT_INSTRUCTION_FILE_IDS` constant, virtual criterion synthesis in `computeLevel()`, `ACMM_IDS_BY_LEVEL[2]` reduced to 3 criteria |
| `web/src/lib/acmm/computeLevel.ts` | Mirror the same synthesis + virtual criterion; `scannableCriteriaForLevel(2)` returns virtual OR-group |

## Test plan

- [ ] CI build/lint passes
- [ ] ACMM badge for `kubernetes-sigs/kubebuilder` (has `AGENTS.md` only) shows L2 after deploy
- [ ] ACMM badge for `kubestellar/console` still shows L5 (no regression)
- [ ] A repo with only `CLAUDE.md` shows L2

🤖 Generated with [Claude Code](https://claude.ai/claude-code)