### PR TITLE
🐛 fix(studio): scope outside-click to modal backdrop only

### DIFF
--- a/web/src/lib/modals/BaseModal.tsx
+++ b/web/src/lib/modals/BaseModal.tsx
@@ -102,6 +102,13 @@ export function BaseModal({
 }: BaseModalProps) {
   const backdropRef = useRef<HTMLDivElement>(null)
   const modalRef = useRef<HTMLDivElement>(null)
+  // #9165 — Track where mousedown started so we don't treat
+  // "press inside the modal, drag out, release on backdrop" as an
+  // outside-click. Without this, a click that began on a sidebar
+  // item near the modal edge can fire its `click` event on the
+  // backdrop (because click target is the deepest common ancestor
+  // of mousedown+mouseup) and unexpectedly close the modal.
+  const mouseDownOnBackdropRef = useRef(false)
   const titleId = useId()
 
   // Set up keyboard navigation (ESC and Space/Backspace to close)
@@ -118,11 +125,43 @@ export function BaseModal({
 
   if (!isOpen) return null
 
+  // #9165 — Outside-click detection.
+  //
+  // A click is treated as an outside-click ONLY when:
+  //   1. closeOnBackdrop is enabled, AND
+  //   2. the mousedown started on the backdrop (not on modal content
+  //      that the user later dragged out of), AND
+  //   3. the mouseup target is NOT contained within the modal content.
+  //
+  // The previous implementation used `e.target === e.currentTarget`,
+  // which failed in two ways:
+  //   - mousedown-inside-then-mouseup-on-backdrop fires `click` on the
+  //     backdrop with `target === currentTarget`, closing the modal
+  //     even though the user's intent was to interact with internal
+  //     content (the "click near sidebar edge" symptom in #9165).
+  //   - clicks that bubble through nested wrappers may not satisfy the
+  //     strict `target === currentTarget` equality even when they are
+  //     genuinely on the backdrop.
+  //
+  // Using a ref-based `contains()` check on the modal element, plus
+  // mousedown tracking, eliminates both failure modes.
+  const handleBackdropMouseDown = (e: React.MouseEvent) => {
+    // Only register as a backdrop-mousedown if the press is NOT on
+    // the modal content. modalRef.current can be null briefly during
+    // unmount; treat that as not-on-modal so we still gate on (3).
+    const target = e.target as Node
+    mouseDownOnBackdropRef.current = !modalRef.current || !modalRef.current.contains(target)
+  }
+
   const handleBackdropClick = (e: React.MouseEvent) => {
-    // Close if clicking on backdrop or centering wrapper (not on modal content)
-    if (closeOnBackdrop && e.target === e.currentTarget) {
-      onClose()
-    }
+    if (!closeOnBackdrop) return
+    const startedOnBackdrop = mouseDownOnBackdropRef.current
+    // Reset for the next gesture so a stale value can't leak across clicks.
+    mouseDownOnBackdropRef.current = false
+    if (!startedOnBackdrop) return
+    const target = e.target as Node
+    if (modalRef.current && modalRef.current.contains(target)) return
+    onClose()
   }
 
   // Use React Portal to render modal at document.body level
@@ -131,10 +170,12 @@ export function BaseModal({
     <div
       ref={backdropRef}
       className="fixed inset-0 bg-black/60 backdrop-blur-sm z-modal isolate p-4 overflow-y-auto overscroll-contain"
+      onMouseDown={handleBackdropMouseDown}
       onClick={handleBackdropClick}
     >
       <div
         className="min-h-full flex items-center justify-center"
+        onMouseDown={handleBackdropMouseDown}
         onClick={handleBackdropClick}
       >
         <div
@@ -143,6 +184,7 @@ export function BaseModal({
           aria-modal="true"
           aria-labelledby={titleId}
           className={`glass w-full ${SIZE_CLASSES[size]} ${HEIGHT_CLASSES[size]} rounded-xl flex flex-col overflow-hidden ${className}`}
+          onMouseDown={(e) => e.stopPropagation()}
           onClick={(e) => e.stopPropagation()}
         >
           <ModalTitleIdContext.Provider value={titleId}>

--- a/web/src/lib/modals/__tests__/BaseModal.test.tsx
+++ b/web/src/lib/modals/__tests__/BaseModal.test.tsx
@@ -51,9 +51,12 @@ describe('BaseModal', () => {
         <p>Content</p>
       </BaseModal>
     )
-    // Click on the backdrop (the outermost fixed element)
+    // Click on the backdrop (the outermost fixed element).
+    // BaseModal requires mousedown + click on the backdrop to trigger
+    // close (mousedown-tracking guard added in #9165).
     const backdrop = document.querySelector('.fixed.inset-0')
     if (backdrop) {
+      fireEvent.mouseDown(backdrop)
       fireEvent.click(backdrop)
       expect(onClose).toHaveBeenCalledTimes(1)
     }
@@ -68,6 +71,7 @@ describe('BaseModal', () => {
     )
     const backdrop = document.querySelector('.fixed.inset-0')
     if (backdrop) {
+      fireEvent.mouseDown(backdrop)
       fireEvent.click(backdrop)
       expect(onClose).not.toHaveBeenCalled()
     }
@@ -80,7 +84,51 @@ describe('BaseModal', () => {
         <p>Inner content</p>
       </BaseModal>
     )
-    fireEvent.click(screen.getByText('Inner content'))
+    const inner = screen.getByText('Inner content')
+    fireEvent.mouseDown(inner)
+    fireEvent.click(inner)
+    expect(onClose).not.toHaveBeenCalled()
+  })
+
+  // #9165 — Regression: pressing mouse inside the modal then releasing
+  // on the backdrop must NOT close the modal. The browser dispatches the
+  // synthetic `click` event on the deepest common ancestor (the backdrop),
+  // which previously bypassed the modal-content stopPropagation guard
+  // and triggered an unintended close when users clicked near the edge
+  // of internal sidebar items.
+  it('does not call onClose when mousedown starts inside modal but mouseup is on backdrop (#9165)', () => {
+    const onClose = vi.fn()
+    render(
+      <BaseModal isOpen={true} onClose={onClose}>
+        <p>Inner content</p>
+      </BaseModal>
+    )
+    const inner = screen.getByText('Inner content')
+    const backdrop = document.querySelector('.fixed.inset-0') as HTMLElement
+    // Press inside the modal content
+    fireEvent.mouseDown(inner)
+    // Release on the backdrop, which is what synthesizes the click event
+    // on the deepest common ancestor.
+    fireEvent.click(backdrop)
+    expect(onClose).not.toHaveBeenCalled()
+  })
+
+  // #9165 — Regression: when mousedown happens on the backdrop and
+  // mouseup happens on the modal content (e.g. user starts dragging
+  // outside and releases on a sidebar item), the modal must not close.
+  it('does not call onClose when click target is inside modal even if mousedown was on backdrop (#9165)', () => {
+    const onClose = vi.fn()
+    render(
+      <BaseModal isOpen={true} onClose={onClose}>
+        <p>Inner content</p>
+      </BaseModal>
+    )
+    const inner = screen.getByText('Inner content')
+    const backdrop = document.querySelector('.fixed.inset-0') as HTMLElement
+    fireEvent.mouseDown(backdrop)
+    // click bubbles up from the inner element; the contains() check
+    // must reject it even though mousedown was on the backdrop.
+    fireEvent.click(inner)
     expect(onClose).not.toHaveBeenCalled()
   })
 


### PR DESCRIPTION
Fixes #9165