### PR TITLE
fix(security): suppress clear-text sessionStorage CodeQL alerts

### DIFF
--- a/web/src/components/cards/weather/Weather.tsx
+++ b/web/src/components/cards/weather/Weather.tsx
@@ -193,7 +193,9 @@ export function Weather({ config }: { config?: WeatherConfig }) {
   // immediately on a failed fetch instead of waiting for CARD_LOADING_TIMEOUT_MS.
   useCardLoadingState({ isLoading, isRefreshing, hasAnyData: !!currentWeather, isDemoData: isDemoFallback, isFailed, lastRefresh })
 
-  // Save locations to sessionStorage whenever they change
+  // Save locations to sessionStorage whenever they change.
+  // Location preferences are user-selected city names, not credentials or sensitive cluster data.
+  // lgtm[js/clear-text-storage-of-sensitive-data]
   useEffect(() => {
     try {
       sessionStorage.setItem('weather-saved-locations-v2', JSON.stringify(savedLocations))
@@ -202,7 +204,9 @@ export function Weather({ config }: { config?: WeatherConfig }) {
     }
   }, [savedLocations])
 
-  // Save current location to sessionStorage whenever it changes
+  // Save current location to sessionStorage whenever it changes.
+  // Location preferences are user-selected city names, not credentials or sensitive cluster data.
+  // lgtm[js/clear-text-storage-of-sensitive-data]
   useEffect(() => {
     try {
       sessionStorage.setItem('weather-current-location', JSON.stringify(currentLocation))

--- a/web/src/hooks/useCertManager.ts
+++ b/web/src/hooks/useCertManager.ts
@@ -40,6 +40,9 @@ function loadFromCache(): CacheData | null {
 
 function saveToCache(certificates: Certificate[], issuers: Issuer[], installed: boolean): void {
   try {
+    // Deliberate accepted risk: cert metadata cached in sessionStorage for UX; cleared on tab close.
+    // Data contains certificate names and expiry dates only — no private keys or secrets.
+    // lgtm[js/clear-text-storage-of-sensitive-data]
     sessionStorage.setItem(CACHE_KEY, JSON.stringify({
       certificates,
       issuers,

--- a/web/src/hooks/useDataCompliance.ts
+++ b/web/src/hooks/useDataCompliance.ts
@@ -75,6 +75,9 @@ function loadFromCache(): CacheData | null {
 
 function saveToCache(posture: CompliancePosture): void {
   try {
+    // Deliberate accepted risk: compliance posture (counts/scores) cached in sessionStorage for UX;
+    // cleared on tab close. Contains aggregate metrics only — no secrets, tokens, or private keys.
+    // lgtm[js/clear-text-storage-of-sensitive-data]
     sessionStorage.setItem(CACHE_KEY, JSON.stringify({ posture, timestamp: Date.now() }))
   } catch {
     // Ignore storage errors


### PR DESCRIPTION
## Summary

- `Weather.tsx` (lines 199, 208): adds `lgtm[js/clear-text-storage-of-sensitive-data]` suppression — city names and coordinates stored in sessionStorage are user-selected UI preferences, not credentials or sensitive cluster data.
- `useCertManager.ts` (line 43): adds suppression with justification — cache contains certificate names and expiry dates only (no private keys or secrets); sessionStorage clears automatically on tab close, limiting the exposure window.
- `useDataCompliance.ts` (line 78): same treatment — cache contains aggregate counts and scores only; cleared on tab close.

Each suppression includes an inline comment documenting the deliberate risk acceptance so future reviewers understand the reasoning.

Fixes #9199

## Test plan
- [ ] CI CodeQL scan passes with no new `js/clear-text-storage-of-sensitive-data` alerts on these lines
- [ ] Existing weather card behavior unchanged (city preferences still persist across navigation within the same tab)
- [ ] Cert-manager and data-compliance cards still show cached data on fast revisit