### PR TITLE
fix(tests): update cache tests from localStorage to sessionStorage (#9161)

### DIFF
--- a/web/src/hooks/__tests__/useCertManager.test.ts
+++ b/web/src/hooks/__tests__/useCertManager.test.ts
@@ -137,14 +137,14 @@ describe('useCertManager', () => {
     vi.resetModules()
     vi.clearAllMocks()
     vi.useFakeTimers({ shouldAdvanceTime: true })
-    localStorage.clear()
+    sessionStorage.clear()
     mockUseDemoMode.mockReturnValue({ isDemoMode: false })
   })
 
   afterEach(() => {
     vi.useRealTimers()
     vi.restoreAllMocks()
-    localStorage.clear()
+    sessionStorage.clear()
   })
 
   // Lazy-load module after mocks are set up
@@ -856,11 +856,11 @@ describe('useCertManager', () => {
   })
 
   // ========================================================================
-  // Cache (localStorage)
+  // Cache (sessionStorage)
   // ========================================================================
 
-  describe('localStorage cache', () => {
-    it('saves fetched data to localStorage', async () => {
+  describe('sessionStorage cache', () => {
+    it('saves fetched data to sessionStorage', async () => {
       setClusters('cluster-1')
 
       mockKubectlProxy.exec.mockImplementation(async (args: string[]) => {
@@ -883,7 +883,7 @@ describe('useCertManager', () => {
         expect(result.current.certificates.length).toBe(1)
       })
 
-      const cached = localStorage.getItem('kc-cert-manager-cache')
+      const cached = sessionStorage.getItem('kc-cert-manager-cache')
       expect(cached).toBeTruthy()
 
       const parsed = JSON.parse(cached!)
@@ -913,7 +913,7 @@ describe('useCertManager', () => {
         installed: true,
         timestamp: Date.now() - 10000,
       }
-      localStorage.setItem('kc-cert-manager-cache', JSON.stringify(cacheData))
+      sessionStorage.setItem('kc-cert-manager-cache', JSON.stringify(cacheData))
 
       const { useCertManager } = await loadModule()
       const { result } = renderHook(() => useCertManager())
@@ -925,8 +925,8 @@ describe('useCertManager', () => {
       expect(result.current.isLoading).toBe(false)
     })
 
-    it('handles corrupted localStorage cache gracefully', async () => {
-      localStorage.setItem('kc-cert-manager-cache', 'NOT_VALID_JSON')
+    it('handles corrupted sessionStorage cache gracefully', async () => {
+      sessionStorage.setItem('kc-cert-manager-cache', 'NOT_VALID_JSON')
 
       const { useCertManager } = await loadModule()
       const { result } = renderHook(() => useCertManager())
@@ -959,7 +959,7 @@ describe('useCertManager', () => {
         installed: true,
         timestamp: Date.now(),
       }
-      localStorage.setItem('kc-cert-manager-cache', JSON.stringify(cacheData))
+      sessionStorage.setItem('kc-cert-manager-cache', JSON.stringify(cacheData))
 
       const { useCertManager } = await loadModule()
       const { result } = renderHook(() => useCertManager())

--- a/web/src/hooks/__tests__/useDataCompliance.test.ts
+++ b/web/src/hooks/__tests__/useDataCompliance.test.ts
@@ -84,7 +84,7 @@ import {
   unregisterCacheReset,
 } from '../../lib/modeTransition'
 
-/** localStorage cache key used by the hook */
+/** sessionStorage cache key used by the hook */
 const CACHE_KEY = 'kc-data-compliance-cache'
 
 // ---------------------------------------------------------------------------
@@ -93,7 +93,7 @@ const CACHE_KEY = 'kc-data-compliance-cache'
 
 beforeEach(() => {
   vi.useFakeTimers({ shouldAdvanceTime: true })
-  localStorage.clear()
+  sessionStorage.clear()
   mockDemoMode = false
   mockClustersLoading = false
   mockAllClusters = []
@@ -625,9 +625,9 @@ describe('useDataCompliance', () => {
     unmount()
   })
 
-  // ── 17. Cache: saves to localStorage after successful fetch ────────────
+  // ── 17. Cache: saves to sessionStorage after successful fetch ────────────
 
-  it('saves compliance posture to localStorage cache after fetch', async () => {
+  it('saves compliance posture to sessionStorage cache after fetch', async () => {
     mockDemoMode = false
     mockAllClusters = [{ name: 'cache-cluster', reachable: true }]
 
@@ -643,7 +643,7 @@ describe('useDataCompliance', () => {
       expect(result.current.isLoading).toBe(false)
     })
 
-    const cachedStr = localStorage.getItem(CACHE_KEY)
+    const cachedStr = sessionStorage.getItem(CACHE_KEY)
     expect(cachedStr).not.toBeNull()
     const cached = JSON.parse(cachedStr!)
     expect(cached).toHaveProperty('posture')
@@ -657,7 +657,7 @@ describe('useDataCompliance', () => {
     unmount()
   })
 
-  // ── 18. Cache: loads from localStorage on mount ────────────────────────
+  // ── 18. Cache: loads from sessionStorage on mount ────────────────────────
 
   it('loads cached data on mount and skips initial loading state', () => {
     const cachedPosture = {
@@ -681,7 +681,7 @@ describe('useDataCompliance', () => {
       },
       timestamp: Date.now() - 30_000,
     }
-    localStorage.setItem(CACHE_KEY, JSON.stringify(cachedPosture))
+    sessionStorage.setItem(CACHE_KEY, JSON.stringify(cachedPosture))
 
     const { result, unmount } = renderHook(() => useDataCompliance())
 
@@ -857,10 +857,10 @@ describe('useDataCompliance', () => {
     unmount()
   })
 
-  // ── 23. Handles corrupt localStorage gracefully ───────────────────────
+  // ── 23. Handles corrupt sessionStorage gracefully ───────────────────────
 
-  it('handles corrupt localStorage cache gracefully', () => {
-    localStorage.setItem(CACHE_KEY, 'NOT_VALID_JSON')
+  it('handles corrupt sessionStorage cache gracefully', () => {
+    sessionStorage.setItem(CACHE_KEY, 'NOT_VALID_JSON')
 
     // Should not throw — loadFromCache returns null on parse error
     const { result, unmount } = renderHook(() => useDataCompliance())


### PR DESCRIPTION
## Summary

- PR #9147 moved `useCertManager.ts` and `useDataCompliance.ts` caches from `localStorage` to `sessionStorage` for security
- The test files still used `localStorage` for mock setup and assertions, causing 7 test failures in the Coverage Suite
- This PR updates all cache-related `localStorage` references in both test files to `sessionStorage`

## Changes

**`web/src/hooks/__tests__/useCertManager.test.ts`**
- `beforeEach`/`afterEach`: `localStorage.clear()` → `sessionStorage.clear()`
- Describe block: `localStorage cache` → `sessionStorage cache`
- All `localStorage.getItem/setItem` calls in cache tests → `sessionStorage`

**`web/src/hooks/__tests__/useDataCompliance.test.ts`**
- `beforeEach`: `localStorage.clear()` → `sessionStorage.clear()`
- Cache read/write assertions: `localStorage.getItem/setItem` → `sessionStorage`
- Comment and describe label updated to reference `sessionStorage`

## Test plan
- [ ] All 7 previously failing tests now pass against the sessionStorage-backed hooks
- [ ] No other test logic changed — only storage backend references updated

Fixes #9161