### PR TITLE
fix(e2e): restore drilldown-modal testid for UX Journey tests

### DIFF
--- a/web/src/components/cards/CardWrapper.tsx
+++ b/web/src/components/cards/CardWrapper.tsx
@@ -1572,12 +1572,14 @@ export function CardWrapper({
             isOpen={isExpanded}
             onClose={() => setIsExpanded(false)}
             size={FULLSCREEN_EXPANDED_CARDS.has(cardType) ? 'full' : LARGE_EXPANDED_CARDS.has(cardType) ? 'xl' : 'lg'}
+            testId="drilldown-modal"
           >
             <BaseModal.Header
               title={title}
               icon={Maximize2}
               onClose={() => setIsExpanded(false)}
               showBack={false}
+              closeTestId="drilldown-close"
             />
             <BaseModal.Content className={cn(
               'overflow-auto scroll-enhanced flex flex-col',

--- a/web/src/lib/modals/BaseModal.tsx
+++ b/web/src/lib/modals/BaseModal.tsx
@@ -99,6 +99,7 @@ export function BaseModal({
   closeOnBackdrop = true,
   closeOnEscape = true,
   enableBackspace = true,
+  testId,
 }: BaseModalProps) {
   const backdropRef = useRef<HTMLDivElement>(null)
   const modalRef = useRef<HTMLDivElement>(null)
@@ -142,6 +143,7 @@ export function BaseModal({
           role="dialog"
           aria-modal="true"
           aria-labelledby={titleId}
+          data-testid={testId}
           className={`glass w-full ${SIZE_CLASSES[size]} ${HEIGHT_CLASSES[size]} rounded-xl flex flex-col overflow-hidden ${className}`}
           onClick={(e) => e.stopPropagation()}
         >
@@ -171,6 +173,7 @@ function ModalHeader({
   showBack = true,
   extra,
   children,
+  closeTestId,
 }: ModalHeaderProps) {
   const titleId = useContext(ModalTitleIdContext)
   const { escapeEnabled } = useContext(ModalEscapeContext)
@@ -232,6 +235,7 @@ function ModalHeader({
               className="p-2 rounded-lg hover:bg-card/50 text-muted-foreground hover:text-foreground transition-colors"
               title={closeTitle}
               aria-label={closeAriaLabel}
+              data-testid={closeTestId}
             >
               <X className="w-5 h-5" aria-hidden="true" />
             </button>

--- a/web/src/lib/modals/types.ts
+++ b/web/src/lib/modals/types.ts
@@ -287,6 +287,8 @@ export interface BaseModalProps {
   closeOnEscape?: boolean
   /** Whether to enable Backspace/Space to close (default true) */
   enableBackspace?: boolean
+  /** data-testid for the dialog element (for E2E tests) */
+  testId?: string
 }
 
 export interface ModalHeaderProps {
@@ -308,6 +310,8 @@ export interface ModalHeaderProps {
   extra?: ReactNode
   /** Children (below title) */
   children?: ReactNode
+  /** data-testid for the close button (for E2E tests) */
+  closeTestId?: string
 }
 
 export interface ModalContentProps {


### PR DESCRIPTION
## Summary

- Adds optional `testId` prop to `BaseModal` that attaches `data-testid` to the dialog element
- Adds optional `closeTestId` prop to `BaseModal.Header` that attaches `data-testid` to the close button
- Wires `data-testid="drilldown-modal"` and `data-testid="drilldown-close"` in `CardWrapper`'s expanded-card `BaseModal` so the E2E tests can locate them

## Root cause

The UX Journey test `clicking expand on a card opens drilldown modal` clicks the card expand (Maximize2) button which calls `setIsExpanded(true)` to open an in-place `BaseModal`. The test then looks for `data-testid="drilldown-modal"` — but that testid was only on `DrillDownModal.tsx` (the slide-in drill-down panel), not on this expanded-card modal. The fix adds testid passthrough props to `BaseModal` and `BaseModal.Header` and connects them in `CardWrapper`.

## Test plan

- [ ] Click any card expand button — modal appears with `data-testid="drilldown-modal"` on the dialog
- [ ] Close button has `data-testid="drilldown-close"`
- [ ] Escape key still closes the modal (unchanged behavior)
- [ ] Existing `DrillDownModal` testids are unaffected (they live in a separate component)

Fixes #9166