### PR TITLE
🐛 fix(e2e): make generic MCP mock delay deterministic (Issue 9086)

### DIFF
--- a/web/e2e/mocks/liveMocks.ts
+++ b/web/e2e/mocks/liveMocks.ts
@@ -290,13 +290,20 @@ export async function setupLiveMocks(page: Page, options?: LiveMockOptions): Pro
   }
 
   // 3. Generic MCP REST endpoints
+  //
+  // Issue 9086: the previous `const delay = 100 + Math.random() * 200` made
+  // every mock response arrive at a different time on each test run, which
+  // turned "card A appears before timeout X" assertions into flaky tests.
+  // Use a deterministic fixed delay (the midpoint of the old 100-300ms band)
+  // so test runs are reproducible. Variable delays, if ever needed to model
+  // real-world timing, should be driven by LiveMockOptions with a seed.
+  const GENERIC_MCP_DELAY_MS = 200
   await page.route('**/api/mcp/**', async (route) => {
     if (route.request().url().includes('/stream')) { await route.fallback(); return }
     const endpoint = route.request().url().match(/\/api\/mcp\/([^/?]+)/)?.[1] || ''
     if (shouldError(endpoint)) { await fulfillError(route, endpoint); return }
     await maybeDelay()
-    const delay = 100 + Math.random() * 200
-    await new Promise(r => setTimeout(r, delay))
+    await new Promise(r => setTimeout(r, GENERIC_MCP_DELAY_MS))
     route.fulfill({
       status: 200,
       contentType: 'application/json',


### PR DESCRIPTION
## Summary

`web/e2e/mocks/liveMocks.ts:298` used `100 + Math.random() * 200` for the generic MCP route's response delay, so every test run saw a different timing profile. Assertions like "card A content appears before timeout X" became intermittently flaky.

Replace with a deterministic fixed delay (200ms, midpoint of the old 100-300ms band) so test results are reproducible. Extracted to the named constant `GENERIC_MCP_DELAY_MS`.

If per-endpoint variable delays are ever needed to model real-world timing, the right design is to thread an explicit seed through `LiveMockOptions`, not to call `Math.random()` in the mock. Not in scope here.

## Reported by

@Arpit529Srivastava — #9086.

Fixes #9086