### PR TITLE
🐛 fix(feedback): Discard closes parent modal cleanly (Fixes #9152)

### DIFF
--- a/web/src/components/feedback/FeatureRequestModal.test.tsx
+++ b/web/src/components/feedback/FeatureRequestModal.test.tsx
@@ -1,9 +1,96 @@
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
 import * as FeatureRequestModalModule from './FeatureRequestModal'
+import { FeatureRequestModal } from './FeatureRequestModal'
+
+// Mock heavy/lazy deps so the modal mounts cleanly in jsdom
+vi.mock('../../hooks/useFeatureRequests', () => ({
+  useFeatureRequests: () => ({
+    createRequest: vi.fn(),
+    isSubmitting: false,
+    requests: [],
+    isLoading: false,
+    isRefreshing: false,
+    refresh: vi.fn(),
+    requestUpdate: vi.fn(),
+    closeRequest: vi.fn(),
+    isDemoMode: false,
+    summaries: [],
+    error: null,
+  }),
+  useNotifications: () => ({
+    notifications: [],
+    isRefreshing: false,
+    refresh: vi.fn(),
+    getUnreadCountForRequest: () => 0,
+    markRequestNotificationsAsRead: vi.fn(),
+  }),
+}))
+
+vi.mock('../../lib/auth', () => ({
+  useAuth: () => ({ user: { github_login: 'tester' }, isAuthenticated: true, token: 'real-token' }),
+}))
+
+vi.mock('../../hooks/useRewards', () => ({
+  useRewards: () => ({ githubRewards: null, githubPoints: 0, refreshGitHubRewards: vi.fn() }),
+}))
+
+vi.mock('../../hooks/useFeedbackDrafts', () => ({
+  useFeedbackDrafts: () => ({
+    drafts: [],
+    draftCount: 0,
+    saveDraft: vi.fn(),
+    deleteDraft: vi.fn(),
+    clearAllDrafts: vi.fn(),
+  }),
+}))
+
+vi.mock('../ui/Toast', () => ({
+  useToast: () => ({ showToast: vi.fn() }),
+}))
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (_k: string, fallback?: string) => fallback || _k }),
+  initReactI18next: { type: '3rdParty', init: vi.fn() },
+}))
 
 describe('FeatureRequestModal Component', () => {
+  beforeEach(() => {
+    document.body.innerHTML = ''
+  })
+
   it('exports FeatureRequestModal component', () => {
     expect(FeatureRequestModalModule.FeatureRequestModal).toBeDefined()
     expect(typeof FeatureRequestModalModule.FeatureRequestModal).toBe('function')
+  })
+
+  // Regression test for #9152 — clicking Discard after typing must close
+  // both the discard confirmation AND the parent feedback modal.
+  it('closes the parent modal when Discard is clicked from the unsaved-changes prompt', async () => {
+    const onClose = vi.fn()
+    render(<FeatureRequestModal isOpen onClose={onClose} initialTab="submit" />)
+
+    // Type something into the description so handleClose enters the dirty path
+    const textarea = await screen.findByRole('textbox')
+    fireEvent.change(textarea, { target: { value: 'Some unsaved feedback text.' } })
+
+    // Click the modal's X close button (header)
+    const closeButtons = screen.getAllByRole('button').filter(b => b.querySelector('svg'))
+    // The header X is the first button rendered above tabs; click any close
+    // button until the discard prompt appears.
+    for (const btn of closeButtons) {
+      fireEvent.click(btn)
+      if (screen.queryByText(/Discard/)) break
+    }
+
+    // Discard confirmation must be visible
+    const discardBtn = await screen.findByText(/^Discard$/)
+    expect(discardBtn).toBeInTheDocument()
+
+    // Click Discard
+    fireEvent.click(discardBtn)
+
+    // Parent's onClose must have been called exactly once
+    await waitFor(() => expect(onClose).toHaveBeenCalledTimes(1))
   })
 })

--- a/web/src/components/feedback/FeatureRequestModal.tsx
+++ b/web/src/components/feedback/FeatureRequestModal.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef } from 'react'
+import { useState, useEffect, useRef, useCallback } from 'react'
 import { X } from 'lucide-react'
 import { StatusBadge } from '../ui/StatusBadge'
 import { BaseModal } from '../../lib/modals'
@@ -188,7 +188,21 @@ export function FeatureRequestModal({ isOpen, onClose, initialTab, initialReques
     }, SUCCESS_DISPLAY_MS)
   }
 
-  const forceClose = () => {
+  // Stable refs so handleClose/forceClose don't depend on every keystroke.
+  // The previous unmemoized closures rebuilt on every render, churning
+  // BaseModal's onClose prop and re-registering the keydown listener.
+  const onCloseRef = useRef(onClose)
+  onCloseRef.current = onClose
+  const descriptionRef = useRef(description)
+  descriptionRef.current = description
+  const isSubmittingRef = useRef(isSubmitting)
+  isSubmittingRef.current = isSubmitting
+  const showDiscardRef = useRef(showDiscardConfirm)
+  showDiscardRef.current = showDiscardConfirm
+
+  const forceClose = useCallback(() => {
+    // Hide the discard confirmation first so a stale ref can't cause
+    // handleClose to re-open it on the next paint.
     setShowDiscardConfirm(false)
     setDescription('')
     setRequestType(initialRequestType || 'bug')
@@ -198,23 +212,33 @@ export function FeatureRequestModal({ isOpen, onClose, initialTab, initialReques
     setScreenshots([])
     setEditingDraftId(null)
     setActiveTab(initialTab || 'submit')
-    onClose()
-  }
+    // Call parent's close last so all internal resets are batched into the
+    // same render as the unmount. (Fixes #9152 — the unmemoized callbacks
+    // and missing showDiscard guard let the parent modal stay open after
+    // clicking Discard.)
+    onCloseRef.current()
+  }, [initialRequestType, initialTab])
 
-  const handleSaveAndClose = () => {
+  const handleSaveAndClose = useCallback(() => {
     handleSaveDraft()
     forceClose()
-  }
+  }, [handleSaveDraft, forceClose])
 
-  const handleClose = () => {
-    if (!isSubmitting) {
-      if (description.trim() !== '') {
-        setShowDiscardConfirm(true)
-        return
-      }
+  const handleClose = useCallback(() => {
+    if (isSubmittingRef.current) return
+    // If the discard dialog is already showing, an Esc/Space coming from
+    // BaseModal's keydown handler must NOT just re-set the same flag —
+    // that traps the user. Treat the second close attempt as Discard.
+    if (showDiscardRef.current) {
       forceClose()
+      return
     }
-  }
+    if (descriptionRef.current.trim() !== '') {
+      setShowDiscardConfirm(true)
+      return
+    }
+    forceClose()
+  }, [forceClose])
 
   return (
     <BaseModal isOpen={isOpen} onClose={handleClose} size="lg" closeOnBackdrop={false} closeOnEscape={true} className="!h-[80vh]">


### PR DESCRIPTION
## Summary

Closes #9152 — clicking **Discard** in the unsaved-changes prompt now closes both the prompt **and** the parent feedback modal in one action.

Two interacting bugs caused the regression:

1. **Stale callbacks.** forceClose and handleClose were inline closures recreated on every render. Each keystroke rebuilt them, churning BaseModal's onClose prop and re-registering the global keydown listener. In some click sequences the Discard button bound to a closure whose onClose no longer pointed at the parent's setIsOpen(false).
2. **Trap when discard prompt is up.** handleClose had no guard for showDiscardConfirm. An ESC keypress arriving while the discard prompt was visible just re-set showDiscardConfirm=true (a no-op), so the user appeared stuck.

## Fix

- Memoize forceClose and handleClose with useCallback
- Use refs for description, isSubmitting, and showDiscardConfirm so the memoized callbacks read fresh state without changing identity
- Use an onCloseRef so the latest parent handler is invoked even when the parent passes an inline arrow (CardWrapper, FeatureRequestButton)
- Treat a close attempt while the discard prompt is already up as Discard

## Test plan
- [x] Regression test in FeatureRequestModal.test.tsx: types into the description, clicks header close, clicks Discard, asserts onClose fires once
- [ ] CI: build, lint, unit tests, ts-null-safety, ui-ux-standard

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>