### PR TITLE
fix(security): move lgtm suppressions inline on flagged setItem lines (Fixes #9211)

### DIFF
--- a/web/src/components/cards/weather/Weather.tsx
+++ b/web/src/components/cards/weather/Weather.tsx
@@ -195,10 +195,9 @@ export function Weather({ config }: { config?: WeatherConfig }) {
 
   // Save locations to sessionStorage whenever they change.
   // Location preferences are user-selected city names, not credentials or sensitive cluster data.
-  // lgtm[js/clear-text-storage-of-sensitive-data]
   useEffect(() => {
     try {
-      sessionStorage.setItem('weather-saved-locations-v2', JSON.stringify(savedLocations))
+      sessionStorage.setItem('weather-saved-locations-v2', JSON.stringify(savedLocations)) // lgtm[js/clear-text-storage-of-sensitive-data]
     } catch {
       // Ignore storage errors (e.g. private browsing, quota exceeded)
     }
@@ -206,10 +205,9 @@ export function Weather({ config }: { config?: WeatherConfig }) {
 
   // Save current location to sessionStorage whenever it changes.
   // Location preferences are user-selected city names, not credentials or sensitive cluster data.
-  // lgtm[js/clear-text-storage-of-sensitive-data]
   useEffect(() => {
     try {
-      sessionStorage.setItem('weather-current-location', JSON.stringify(currentLocation))
+      sessionStorage.setItem('weather-current-location', JSON.stringify(currentLocation)) // lgtm[js/clear-text-storage-of-sensitive-data]
     } catch {
       // Ignore storage errors (e.g. private browsing, quota exceeded)
     }

--- a/web/src/hooks/useCertManager.ts
+++ b/web/src/hooks/useCertManager.ts
@@ -42,8 +42,7 @@ function saveToCache(certificates: Certificate[], issuers: Issuer[], installed: 
   try {
     // Deliberate accepted risk: cert metadata cached in sessionStorage for UX; cleared on tab close.
     // Data contains certificate names and expiry dates only — no private keys or secrets.
-    // lgtm[js/clear-text-storage-of-sensitive-data]
-    sessionStorage.setItem(CACHE_KEY, JSON.stringify({
+    sessionStorage.setItem(CACHE_KEY, JSON.stringify({ // lgtm[js/clear-text-storage-of-sensitive-data]
       certificates,
       issuers,
       installed,

--- a/web/src/hooks/useDataCompliance.ts
+++ b/web/src/hooks/useDataCompliance.ts
@@ -77,8 +77,7 @@ function saveToCache(posture: CompliancePosture): void {
   try {
     // Deliberate accepted risk: compliance posture (counts/scores) cached in sessionStorage for UX;
     // cleared on tab close. Contains aggregate metrics only — no secrets, tokens, or private keys.
-    // lgtm[js/clear-text-storage-of-sensitive-data]
-    sessionStorage.setItem(CACHE_KEY, JSON.stringify({ posture, timestamp: Date.now() }))
+    sessionStorage.setItem(CACHE_KEY, JSON.stringify({ posture, timestamp: Date.now() })) // lgtm[js/clear-text-storage-of-sensitive-data]
   } catch {
     // Ignore storage errors
   }


### PR DESCRIPTION
## Summary

PR #9201 added `// lgtm[js/clear-text-storage-of-sensitive-data]` suppression comments for these 4 locations but placed them on the **line before** the flagged `sessionStorage.setItem()` call. CodeQL requires the annotation to appear on the **same line** as the flagged expression — a preceding comment line is not recognised.

This PR moves the inline suppression to the correct position for all 4 remaining open alerts:

| Alert | File | Line |
|-------|------|------|
| #613 | `web/src/components/cards/weather/Weather.tsx` | 201 |
| #614 | `web/src/components/cards/weather/Weather.tsx` | 212 |
| #615 | `web/src/hooks/useCertManager.ts` | 46 |
| #616 | `web/src/hooks/useDataCompliance.ts` | 81 |

No logic changes — justification comments are preserved on the preceding lines for human reviewers.

Fixes #9211