### PR TITLE
🐛 fix(api): allow DELETE method in CORS for local cluster removal (Fixes #9155)

### DIFF
--- a/pkg/agent/server.go
+++ b/pkg/agent/server.go
@@ -559,13 +559,19 @@ func (s *Server) Start() error {
 	// has to simulate the user identity. Handler in server_exec.go.
 	mux.HandleFunc("/ws/exec", s.handleExec)
 
-	// CORS preflight - uses isAllowedOrigin() instead of wildcard to restrict access
+	// CORS preflight - uses isAllowedOrigin() instead of wildcard to restrict access.
+	// #9155: The catchall preflight must advertise the same superset of methods
+	// supported by individual handlers (GET/POST/PUT/DELETE/PATCH), so that any
+	// preflight that falls through to "/" (e.g. due to a path typo or future
+	// route refactor) does not silently strip DELETE/PUT/PATCH from the
+	// browser's allowed methods. Per-handler setCORSHeaders() calls still
+	// narrow this to the exact methods each endpoint accepts.
 	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
 		origin := r.Header.Get("Origin")
 		if s.isAllowedOrigin(origin) {
 			w.Header().Set("Access-Control-Allow-Origin", origin)
 		}
-		w.Header().Set("Access-Control-Allow-Methods", "GET, POST, OPTIONS")
+		w.Header().Set("Access-Control-Allow-Methods", catchallCORSAllowedMethods)
 		w.Header().Set("Access-Control-Allow-Headers", "Content-Type, Authorization")
 		w.Header().Set("Access-Control-Allow-Private-Network", "true")
 		if r.Method == "OPTIONS" {

--- a/pkg/agent/server_http.go
+++ b/pkg/agent/server_http.go
@@ -1961,6 +1961,18 @@ func (s *Server) handleClusterHealthHTTP(w http.ResponseWriter, r *http.Request)
 // back-compat for every GET-only handler that still passes no methods.
 const defaultCORSAllowedMethods = "GET, OPTIONS"
 
+// catchallCORSAllowedMethods is the Access-Control-Allow-Methods value used
+// by the mux fallback ("/") preflight handler. It is intentionally the
+// superset of HTTP verbs supported by any registered handler so that a
+// preflight which falls through to "/" (e.g. due to a path typo or future
+// route refactor) does not silently strip DELETE/PUT/PATCH from the
+// browser's allowed methods. See #9155 — local-cluster delete was reported
+// as blocked when the fallback advertised only "GET, POST, OPTIONS".
+// Per-handler setCORSHeaders() calls still narrow this to the exact
+// methods each endpoint accepts, so this superset never relaxes auth on a
+// real route.
+const catchallCORSAllowedMethods = "GET, POST, PUT, PATCH, DELETE, OPTIONS"
+
 // setCORSHeaders sets common CORS headers for HTTP endpoints. An optional
 // list of HTTP methods may be supplied to override the default
 // Access-Control-Allow-Methods value — this is required for POST/PUT/DELETE

--- a/pkg/agent/server_test.go
+++ b/pkg/agent/server_test.go
@@ -2321,6 +2321,36 @@ func TestServer_HandleLocalClusters_OPTIONS(t *testing.T) {
 	}
 }
 
+// TestHandleLocalClusters_CORSAdvertisesDELETE pins the fix for #9155: the
+// OPTIONS preflight on /local-clusters must advertise DELETE in
+// Access-Control-Allow-Methods so the browser permits the cluster-delete
+// fetch from the SPA origin. Before the audit (#8201) this handler fell
+// through to the default "GET, OPTIONS", which Chrome rejected for the
+// DELETE preflight; this test prevents that regression from coming back.
+func TestHandleLocalClusters_CORSAdvertisesDELETE(t *testing.T) {
+	server := &Server{
+		allowedOrigins: []string{"http://localhost:8080"},
+	}
+
+	req := httptest.NewRequest("OPTIONS", "/local-clusters?tool=kind&name=testing", nil)
+	req.Header.Set("Origin", "http://localhost:8080")
+	req.Header.Set("Access-Control-Request-Method", "DELETE")
+	w := httptest.NewRecorder()
+
+	server.handleLocalClusters(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("Expected 200 for OPTIONS preflight, got %d", w.Code)
+	}
+
+	methods := w.Header().Get("Access-Control-Allow-Methods")
+	for _, want := range []string{"GET", "POST", "DELETE", "OPTIONS"} {
+		if !strings.Contains(methods, want) {
+			t.Errorf("expected Access-Control-Allow-Methods to include %q (Fixes #9155), got %q", want, methods)
+		}
+	}
+}
+
 func TestErrorPayload(t *testing.T) {
 	// Test creating an error payload directly
 	payload := protocol.ErrorPayload{


### PR DESCRIPTION
## Summary

Fixes #9155 — `Settings → Local Clusters → Delete` on a kind cluster failed with:

```
Access to fetch at 'http://127.0.0.1:8585/local-clusters?tool=kind&name=testing'
from origin 'http://localhost:8080' has been blocked by CORS policy:
Method DELETE is not allowed by Access-Control-Allow-Methods in preflight response.
```

The `/local-clusters` preflight handler was already audited in #8201 to advertise `GET/POST/DELETE/OPTIONS`, but there was no regression test pinning the DELETE method, and the mux fallback (`"/"`) preflight still silently advertised only `"GET, POST, OPTIONS"` — so any preflight that fell through to the catchall stripped `DELETE/PUT/PATCH` from the browser's allowed methods.

## Changes

- Adds `TestHandleLocalClusters_CORSAdvertisesDELETE` — a regression test that fails if the OPTIONS preflight on `/local-clusters` ever drops `DELETE` again.
- Promotes the catchall preflight `Access-Control-Allow-Methods` to the superset of HTTP verbs supported by any registered handler (`GET/POST/PUT/PATCH/DELETE/OPTIONS`), via a named constant `catchallCORSAllowedMethods`. Per-handler `setCORSHeaders()` calls still narrow this to the exact methods each endpoint accepts, so this superset never relaxes auth on a real route.

## Test plan

- [x] `TestHandleLocalClusters_CORSAdvertisesDELETE` asserts all 4 methods (`GET/POST/DELETE/OPTIONS`) are present in the preflight response.
- [ ] Manual: `Settings → Local Clusters → Create kind cluster → Delete` on origin `http://localhost:8080` against agent `http://127.0.0.1:8585` succeeds without CORS error.

Fixes #9155