### PR TITLE
🐛 fix(gpu): centralize GPU resource names + fix multi-accelerator sum + tests (Issue 9204 follow-up)

### DIFF
--- a/pkg/k8s/client_gpu.go
+++ b/pkg/k8s/client_gpu.go
@@ -52,26 +52,12 @@ func (m *MultiClusterClient) GetGPUNodes(ctx context.Context, contextName string
 				continue
 			}
 			for _, container := range pod.Spec.Containers {
-				// Check GPU requests (NVIDIA, AMD, Intel GPU, Intel Gaudi/Habana)
-				// Intel Gaudi is classified as AcceleratorGPU, so track in gpuAllocationByNode
-				if gpuReq, ok := container.Resources.Requests["nvidia.com/gpu"]; ok {
-					gpuAllocationByNode[nodeName] += int(gpuReq.Value())
-				}
-				if gpuReq, ok := container.Resources.Requests["amd.com/gpu"]; ok {
-					gpuAllocationByNode[nodeName] += int(gpuReq.Value())
-				}
-				if gpuReq, ok := container.Resources.Requests["gpu.intel.com/i915"]; ok {
-					gpuAllocationByNode[nodeName] += int(gpuReq.Value())
-				}
-				if gpuReq, ok := container.Resources.Requests["habana.ai/gaudi"]; ok {
-					gpuAllocationByNode[nodeName] += int(gpuReq.Value())
-				}
-				if gpuReq, ok := container.Resources.Requests["habana.ai/gaudi2"]; ok {
-					gpuAllocationByNode[nodeName] += int(gpuReq.Value())
-				}
-				if gpuReq, ok := container.Resources.Requests["intel.com/gaudi"]; ok {
-					gpuAllocationByNode[nodeName] += int(gpuReq.Value())
-				}
+				// Sum GPU requests (NVIDIA, AMD, Intel GPU, Intel Gaudi/Habana)
+				// via the shared GPUResourceNames list in gpu_resources.go so this
+				// path and the pod-level tracker in client_resources.go cannot
+				// drift. Intel Gaudi is classified as AcceleratorGPU, so it rolls
+				// into gpuAllocationByNode alongside nvidia/amd/i915.
+				gpuAllocationByNode[nodeName] += SumGPURequested(container.Resources.Requests)
 				// Check TPU requests (Google Cloud)
 				if tpuReq, ok := container.Resources.Requests["google.com/tpu"]; ok {
 					tpuAllocationByNode[nodeName] += int(tpuReq.Value())

--- a/pkg/k8s/client_resources.go
+++ b/pkg/k8s/client_resources.go
@@ -15,30 +15,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-// gpuResourceNames lists every accelerator resource name the console treats
-// as a "GPU" for the purposes of pod-level resource tracking. Must stay in
-// sync with the node-inventory tracker in client_gpu.go — these are the
-// same names checked there when summing allocatable per node (Issue 9090).
-var gpuResourceNames = []string{
-	"nvidia.com/gpu",
-	"amd.com/gpu",
-	"gpu.intel.com/i915",
-	"habana.ai/gaudi",
-	"habana.ai/gaudi2",
-	"intel.com/gaudi",
-}
-
-// isGPUResourceName reports whether the given Kubernetes resource name is a
-// known GPU / AI accelerator. Exact match; no vendor-prefix heuristics.
-func isGPUResourceName(name string) bool {
-	for _, n := range gpuResourceNames {
-		if name == n {
-			return true
-		}
-	}
-	return false
-}
-
 func (m *MultiClusterClient) GetPods(ctx context.Context, contextName, namespace string) ([]PodInfo, error) {
 	client, err := m.GetClient(contextName)
 	if err != nil {
@@ -87,24 +63,16 @@ func (m *MultiClusterClient) GetPods(ctx context.Context, contextName, namespace
 					ci.Message = cs.State.Terminated.Message
 				}
 			}
-			// Check for GPU/accelerator resource requests. Keep this list in sync
-			// with the node-inventory tracker in client_gpu.go; without the Intel
-			// and Habana/Gaudi entries, pod views reported GPURequested=0 on
-			// Intel-GPU / Gaudi accelerator clusters even though the node
-			// inventory saw them (Issue 9090).
-			if c.Resources.Requests != nil {
-				for resourceName, qty := range c.Resources.Requests {
-					if isGPUResourceName(string(resourceName)) {
-						ci.GPURequested = int(qty.Value())
-					}
-				}
-			}
-			if ci.GPURequested == 0 && c.Resources.Limits != nil {
-				for resourceName, qty := range c.Resources.Limits {
-					if isGPUResourceName(string(resourceName)) {
-						ci.GPURequested = int(qty.Value())
-					}
-				}
+			// Check for GPU / accelerator resource requests using the shared
+			// SumGPURequested helper (pkg/k8s/gpu_resources.go). Sums across ALL
+			// known GPU resource names so containers requesting more than one
+			// accelerator type (e.g., nvidia.com/gpu=1 + habana.ai/gaudi=2) are
+			// counted correctly. Previously each matching name overwrote the
+			// previous, so the final value depended on map iteration order
+			// (flagged on PR Issue 9204 follow-up review).
+			ci.GPURequested = SumGPURequested(c.Resources.Requests)
+			if ci.GPURequested == 0 {
+				ci.GPURequested = SumGPURequested(c.Resources.Limits)
 			}
 			containers = append(containers, ci)
 		}

--- a/pkg/k8s/gpu_resources.go
+++ b/pkg/k8s/gpu_resources.go
@@ -1,0 +1,49 @@
+package k8s
+
+import (
+	corev1 "k8s.io/api/core/v1"
+)
+
+// GPUResourceNames lists every Kubernetes resource name the console treats
+// as a "GPU" / AI accelerator for tracking purposes. Single source of truth
+// shared between:
+//   - client_resources.go (pod-level GPURequested sums)
+//   - client_gpu.go (node-level inventory sums)
+//
+// Both paths must read from the same list so pod views and node views can't
+// drift (Issue 9090). Keep this sorted by vendor for readability.
+var GPUResourceNames = []corev1.ResourceName{
+	"nvidia.com/gpu",
+	"amd.com/gpu",
+	"gpu.intel.com/i915",
+	"habana.ai/gaudi",
+	"habana.ai/gaudi2",
+	"intel.com/gaudi",
+}
+
+// IsGPUResourceName reports whether the given Kubernetes resource name is a
+// known GPU / AI accelerator. Exact match; no vendor-prefix heuristics.
+func IsGPUResourceName(name corev1.ResourceName) bool {
+	for _, n := range GPUResourceNames {
+		if name == n {
+			return true
+		}
+	}
+	return false
+}
+
+// SumGPURequested returns the total count of GPU / accelerator devices
+// requested by a container's resource map across ALL known GPU resource
+// names. This matters when a single container requests more than one
+// accelerator type (e.g., nvidia.com/gpu=1 and habana.ai/gaudi=2) — the
+// previous GetPods loop overwrote per-name, so the final value depended on
+// map iteration order and undercounted the total.
+func SumGPURequested(rl corev1.ResourceList) int {
+	total := 0
+	for _, name := range GPUResourceNames {
+		if qty, ok := rl[name]; ok {
+			total += int(qty.Value())
+		}
+	}
+	return total
+}

--- a/pkg/k8s/gpu_resources_test.go
+++ b/pkg/k8s/gpu_resources_test.go
@@ -1,0 +1,112 @@
+package k8s
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+)
+
+// Keep each row's expected sum honest: the hand-written totals prove the
+// SumGPURequested contract (sum across ALL known GPU resource names) without
+// looping the implementation under test.
+func TestIsGPUResourceName(t *testing.T) {
+	known := []corev1.ResourceName{
+		"nvidia.com/gpu",
+		"amd.com/gpu",
+		"gpu.intel.com/i915",
+		"habana.ai/gaudi",
+		"habana.ai/gaudi2",
+		"intel.com/gaudi",
+	}
+	for _, name := range known {
+		if !IsGPUResourceName(name) {
+			t.Errorf("IsGPUResourceName(%q) = false, want true", name)
+		}
+	}
+
+	unknown := []corev1.ResourceName{
+		"cpu",
+		"memory",
+		"ephemeral-storage",
+		// Adjacent names that must NOT match — no prefix-based heuristics.
+		"google.com/tpu",
+		"intel.com/xpu",
+		"ibm.com/aiu",
+		"nvidia.com/mig-4g.20gb",
+	}
+	for _, name := range unknown {
+		if IsGPUResourceName(name) {
+			t.Errorf("IsGPUResourceName(%q) = true, want false", name)
+		}
+	}
+}
+
+func TestSumGPURequested(t *testing.T) {
+	q := func(n int64) resource.Quantity { return *resource.NewQuantity(n, resource.DecimalSI) }
+
+	cases := []struct {
+		name string
+		in   corev1.ResourceList
+		want int
+	}{
+		{
+			name: "empty list",
+			in:   corev1.ResourceList{},
+			want: 0,
+		},
+		{
+			name: "single nvidia request",
+			in:   corev1.ResourceList{"nvidia.com/gpu": q(2)},
+			want: 2,
+		},
+		{
+			name: "single gaudi request",
+			in:   corev1.ResourceList{"habana.ai/gaudi": q(4)},
+			want: 4,
+		},
+		{
+			// Regression for the Copilot review on PR Issue 9204: the previous
+			// pod-tracker overwrote ci.GPURequested per matching resource name,
+			// so a container with BOTH nvidia and gaudi returned whichever came
+			// last in Go's randomized map iteration. SumGPURequested must
+			// return the total (3) deterministically.
+			name: "multi-accelerator sums both",
+			in: corev1.ResourceList{
+				"nvidia.com/gpu":  q(1),
+				"habana.ai/gaudi": q(2),
+			},
+			want: 3,
+		},
+		{
+			name: "all six known names sum",
+			in: corev1.ResourceList{
+				"nvidia.com/gpu":     q(1),
+				"amd.com/gpu":        q(1),
+				"gpu.intel.com/i915": q(1),
+				"habana.ai/gaudi":    q(1),
+				"habana.ai/gaudi2":   q(1),
+				"intel.com/gaudi":    q(1),
+			},
+			want: 6,
+		},
+		{
+			name: "non-GPU resources ignored",
+			in: corev1.ResourceList{
+				"cpu":            q(4),
+				"memory":         q(1024),
+				"nvidia.com/gpu": q(1),
+			},
+			want: 1,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := SumGPURequested(tc.in)
+			if got != tc.want {
+				t.Errorf("SumGPURequested(%v) = %d, want %d", tc.in, got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Follow-up PR addressing the 3 Copilot review findings on #9204:

1. **Multi-accelerator undercount (real bug)** — `ci.GPURequested` was overwritten per matching resource name, so a container requesting both `nvidia.com/gpu` and `habana.ai/gaudi` returned whichever came last in Go's randomized map iteration.
2. **Duplicate list** between `client_resources.go` and `client_gpu.go` — exact drift surface that Issue 9090 originally suffered.
3. **No test coverage** for the Intel / Gaudi names introduced in #9204.

## Changes

- **New** `pkg/k8s/gpu_resources.go` — single source of truth:
  - `GPUResourceNames` (exported slice)
  - `IsGPUResourceName(name)` predicate
  - `SumGPURequested(rl)` — sums across ALL known names (fixes #1)
- `pkg/k8s/client_resources.go` — uses `SumGPURequested` on Requests, falls back to Limits.
- `pkg/k8s/client_gpu.go` — replaces six repeated `if ok` blocks with a single `SumGPURequested` call on the Gaudi-era path, so pod and node trackers read the same list.
- **New** `pkg/k8s/gpu_resources_test.go`:
  - `TestIsGPUResourceName` — 6 known names (true) + 7 adjacent names including `google.com/tpu`, `intel.com/xpu`, `nvidia.com/mig-4g.20gb` (false)
  - `TestSumGPURequested` — empty, single-name, **multi-accelerator regression** (nvidia=1 + gaudi=2 → 3), all-six-summed, non-GPU ignored

## Context

Related PR: #9204 (original #9090 fix, merged 2026-04-20).
Copilot review comments addressed:
- `client_resources.go:39` — centralize shared list
- `client_resources.go:107` — add unit test coverage
- `client_resources.go:106` — sum instead of overwrite (bug)