### PR TITLE
🐛 fix(nightly): tighten console-error-scan per-route timeouts (#9097)

### DIFF
--- a/web/e2e/console-errors/console-error-scan.spec.ts
+++ b/web/e2e/console-errors/console-error-scan.spec.ts
@@ -22,11 +22,26 @@ import { setupAuth, setupLiveMocks } from '../mocks/liveMocks'
 // Constants
 // ---------------------------------------------------------------------------
 
-/** Time to wait after navigating to each route for console output to settle */
-const SETTLE_MS = 4_000
+/**
+ * Time to wait after navigating to each route for console output to settle.
+ * 2s is enough for Playwright to capture console messages and for lazy-loaded
+ * chunks to finish parsing in headless Chromium. Was 4s but the cumulative
+ * 38-route budget repeatedly tripped the 600s suite cap (#8981, #9097), so we
+ * trade a bit of settle time for a comfortable margin under the suite cap.
+ */
+const SETTLE_MS = 2_000
 
-/** Max time to wait for route navigation (some lazy-loaded chunks are large) */
-const NAV_TIMEOUT_MS = 30_000
+/**
+ * Max time to wait for an individual route navigation. A route that exceeds
+ * this is treated as a hang — capping it prevents one slow route from
+ * eating the entire suite budget. The initial priming load uses a longer
+ * timeout (PRIME_NAV_TIMEOUT_MS) because `networkidle` can legitimately take
+ * longer on the first paint.
+ */
+const NAV_TIMEOUT_MS = 15_000
+
+/** Longer timeout for the initial priming load (waits on `networkidle`). */
+const PRIME_NAV_TIMEOUT_MS = 30_000
 
 /** Routes that require special params or are not visitable directly */
 const _SKIP_ROUTES = new Set([
@@ -280,10 +295,10 @@ test('console error scan — all routes', async ({ page }) => {
 
   // Prime the app — initial load
   console.log('[ConsoleErrorScan] Priming app with initial load...')
-  await page.goto('/', { waitUntil: 'networkidle', timeout: NAV_TIMEOUT_MS })
+  await page.goto('/', { waitUntil: 'networkidle', timeout: PRIME_NAV_TIMEOUT_MS })
   await page.waitForFunction(
     () => document.body.innerText.length > 0,
-    { timeout: NAV_TIMEOUT_MS },
+    { timeout: PRIME_NAV_TIMEOUT_MS },
   )
 
   // Set auth token in localStorage (ProtectedRoute checks this)


### PR DESCRIPTION
## Summary

The `console-error-scan` Playwright suite has been hitting its 600s wall-clock cap (#8981, #9097) because the cumulative budget across 38 routes was right at the edge:

- 4s `SETTLE_MS` × 38 routes = 152s of pure wait time
- `/users` page consistently takes 16-18s to load (vs ~5s for most routes)
- A single route stalling up to `NAV_TIMEOUT_MS` (30s) easily pushes cumulative time over the suite cap

## Changes

- `web/e2e/console-errors/console-error-scan.spec.ts`
  - `SETTLE_MS`: 4_000 → 2_000 — still enough for Playwright to capture console output and for lazy-loaded chunks to parse in headless Chromium
  - `NAV_TIMEOUT_MS`: 30_000 → 15_000 — caps any single hung route to 15s instead of 30s
  - New `PRIME_NAV_TIMEOUT_MS = 30_000` — keeps the longer timeout for the initial priming load only (which uses `networkidle` and legitimately needs longer)

## Budget after change

- **Typical**: ~140s for 38 routes (well under 600s cap)
- **Worst case**: ~646s if every single route stalls to `NAV_TIMEOUT_MS` — but that scenario indicates a real hang, not a budget problem (the suite cap correctly catches it)

## Test plan

- [ ] Nightly Test Suite — `console-error-scan` should move to PASS
- [ ] No new uncaught exceptions surfaced in any route's report
- [ ] All 38 routes complete within the 600s cap

Fixes #9097