### PR TITLE
🐛 fix(e2e): fail fast on batch overflow + drop bogus baseURL override (Issue 9208 follow-up)

### DIFF
--- a/web/e2e/compliance/card-loading-compliance.spec.ts
+++ b/web/e2e/compliance/card-loading-compliance.spec.ts
@@ -904,9 +904,14 @@ test.describe('card loading compliance (per-batch split — Issue 9088)', () => 
   let sharedPage: Page
 
   test.beforeAll(async ({ browser }) => {
-    const context = await browser.newContext({
-      baseURL: process.env.PLAYWRIGHT_BASE_URL,
-    })
+    // Do NOT override baseURL here — playwright.config.ts already provides a
+    // sensible default (PLAYWRIGHT_BASE_URL || http://localhost:8080). Passing
+    // `baseURL: process.env.PLAYWRIGHT_BASE_URL` when the env var is unset
+    // assigned `undefined` to the context, which broke relative navigations
+    // (e.g. `page.goto('/__compliance/all-cards?...')`) with "invalid URL".
+    // Dropping the override lets the project-level baseURL flow through.
+    // See Issue 9208 follow-up (Copilot review comment on line 909).
+    const context = await browser.newContext()
     sharedPage = await context.newPage()
 
     // Capture browser console for debugging
@@ -937,6 +942,20 @@ test.describe('card loading compliance (per-batch split — Issue 9088)', () => 
     complianceState.allBatchResults = []
     complianceState.setupDone = true
     console.log(`[Compliance] Total cards: ${complianceState.totalCards}, batches: ${complianceState.totalBatches}`)
+
+    // Fail fast if the manifest has outgrown our pre-declared test count.
+    // Playwright requires test() declarations at load time, so we can't size
+    // the per-batch loops dynamically. Without this guard, extra batches are
+    // silently dropped from the cold/warm phases AND the aggregate report —
+    // those cards effectively escape compliance checking. See Issue 9208
+    // follow-up (Copilot review comment on line 955).
+    expect(
+      complianceState.totalBatches,
+      `Manifest has ${complianceState.totalCards} cards (${complianceState.totalBatches} batches of ${BATCH_SIZE}), ` +
+        `which exceeds MAX_EXPECTED_BATCHES=${MAX_EXPECTED_BATCHES}. ` +
+        `Bump MAX_EXPECTED_BATCHES in card-loading-compliance.spec.ts to at least ${complianceState.totalBatches} ` +
+        `so all batches are covered by pre-declared cold/warm tests.`,
+    ).toBeLessThanOrEqual(MAX_EXPECTED_BATCHES)
 
     await sharedPage.waitForLoadState('networkidle', { timeout: NETWORK_SETTLE_TIMEOUT_MS }).catch(() => { /* best-effort */ })
   })


### PR DESCRIPTION
## Summary

Follow-up to #9208 (the compliance-suite per-batch split for Issue 9088), addressing two Copilot review comments on the merged PR. Both are real correctness issues that would bite silently rather than noisily.

Both fixes are in `web/e2e/compliance/card-loading-compliance.spec.ts`.

## Fix 1 — Fail fast on batch overflow (Copilot comment on line 955)

> The suite pre-declares tests only up to `MAX_EXPECTED_BATCHES`, but `totalBatches` is derived from the manifest at runtime. If the card count grows such that `totalBatches > MAX_EXPECTED_BATCHES`, the extra batches will never run and the aggregate report/assertions will silently ignore those cards.

The cold/warm phase loops are sized by the compile-time `MAX_EXPECTED_BATCHES` constant (16), but `totalBatches` comes from the runtime manifest. Playwright requires `test()` declarations at load time, so we can't size these loops dynamically. Previously, if the manifest outgrew the cap, the overflow batches were silently dropped from **both** the cold/warm phases **and** the aggregate report — those cards escaped compliance checking without any signal.

**What changed**: added an `expect(complianceState.totalBatches).toBeLessThanOrEqual(MAX_EXPECTED_BATCHES)` assertion in the `setup — mocks + warmup + manifest` test (the first test in the serial describe block, so it runs unconditionally). The failure message quotes the observed batch count and tells the next dev which constant to bump. Fail fast > silent dropping.

## Fix 2 — Drop bogus `baseURL` override in `sharedPage` context (Copilot comment on line 909)

> `sharedPage` is created with `baseURL: process.env.PLAYWRIGHT_BASE_URL`, which will be `undefined` in most runs (the config already provides a default baseURL). Since `navigateToBatch()` calls `page.goto('/__compliance/all-cards?...')` with a relative URL, this can fail with an invalid URL error.

`playwright.config.ts:65` already defines `baseURL: process.env.PLAYWRIGHT_BASE_URL || 'http://localhost:8080'`. The override in the `beforeAll` context was passing the raw env var — which is `undefined` in the common case — and clobbering the project default. Relative navigations (`page.goto('/__compliance/...')`) would then fail with an invalid-URL error.

**What changed**: dropped the `baseURL` override from `browser.newContext()` entirely. The project-level baseURL now flows through unchanged.

## Test plan

- [ ] CI: build, lint, typecheck
- [ ] CI: compliance e2e suite passes end-to-end on the default baseURL
- [ ] The new `expect` assertion reports a clear actionable message if `totalBatches` ever exceeds `MAX_EXPECTED_BATCHES` (not directly exercised by CI — validated by inspection; to test locally, temporarily lower `MAX_EXPECTED_BATCHES` to 1 and confirm the setup test fails with the bump-it message)

Original PR: #9208.