### PR TITLE
✨ feat(e2e): add Playwright UX scan sweep and AI agent brief

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,7 +44,9 @@ coverage/
 web/playwright-report/
 web/test-results/
 web/blob-report/
+web/playwright/.cache/
 web/playwright/.auth/
+web/auth.json
 
 # Temp directories
 a2a-rebase/
@@ -70,6 +72,7 @@ vendor/
 *.bak
 web/.netlify/
 web/e2e/test-results/
+web/e2e/user-flows/test-results/
 
 # Storybook
 web/storybook-static/

--- a/docs/qa/AI-UX-ISSUE-AGENT-BRIEF.md
+++ b/docs/qa/AI-UX-ISSUE-AGENT-BRIEF.md
@@ -1,0 +1,86 @@
+# AI UX Issue Agent Brief
+
+Use this file as the operating brief for an AI agent that finds and reports UX issues from Playwright results.
+
+## Goal
+
+Identify and report only browser-reproduced UX issues from the UX scan output.
+
+Do not report code-scan-only findings.
+
+## Inputs
+
+1. Run the UX scan first:
+
+```bash
+./scripts/run-ux-scan.sh
+```
+
+Notes:
+- For localhost URLs, the script auto-starts a preview server when needed.
+- To disable auto-start behavior, set `UX_SCAN_AUTOSTART_SERVER=false`.
+
+2. Read these files:
+- `web/test-results/ux-scan/ux-findings.json`
+- `web/test-results/ux-scan/ux-summary.md`
+- `web/test-results/ux-scan/playwright-report/index.html`
+
+## Hard Rules
+
+1. Only use findings from `ux-findings.json`.
+2. Only report findings where `source.reproducedInBrowser` is `true`.
+3. If no findings exist, report "No browser-reproduced UX issues found" and stop.
+4. Every reported issue must include route or spec source, reproduction steps, expected, actual, and severity.
+5. Do not invent failures that are not present in Playwright artifacts.
+
+## Issue JSON Contract
+
+Use this shape for each issue:
+
+```json
+{
+  "issue": "Short title",
+  "steps": ["step 1", "step 2"],
+  "expected": "What should happen",
+  "actual": "What happened",
+  "severity": "high | medium | low"
+}
+```
+
+## Agent Procedure
+
+1. Parse `web/test-results/ux-scan/ux-findings.json`.
+2. Filter to valid browser-reproduced findings.
+3. Normalize severity:
+- `timedOut` or console/exception failures => `high`
+- assertion/navigation/visibility failures => `medium`
+- cosmetic-only regressions => `low`
+4. Deduplicate by issue title + source file + line.
+5. Write results to `web/test-results/ux-scan/reported-issues.md`.
+
+Do not modify this brief file. It is checked into git and should remain stable.
+
+
+## Reported Issues
+
+This section is intentionally left as an example template.
+Write real run output to `web/test-results/ux-scan/reported-issues.md`.
+
+---
+
+### Report Batch: YYYY-MM-DD HH:MM UTC
+
+- Status: Pending
+- Total findings: 0
+
+#### Issue 1
+
+```json
+{
+  "issue": "",
+  "steps": [],
+  "expected": "",
+  "actual": "",
+  "severity": ""
+}
+```

--- a/scripts/run-ux-scan.sh
+++ b/scripts/run-ux-scan.sh
@@ -1,0 +1,258 @@
+#!/usr/bin/env bash
+# Run Playwright UX sweep with browser-only reproduced findings output.
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+WEB_DIR="${ROOT_DIR}/web"
+UX_DIR="${WEB_DIR}/test-results/ux-scan"
+RAW_JSON="${UX_DIR}/ux-raw-results.json"
+FINDINGS_JSON="${UX_DIR}/ux-findings.json"
+SUMMARY_MD="${UX_DIR}/ux-summary.md"
+LEGACY_RAW_JSON="${WEB_DIR}/e2e/user-flows/test-results/ux-scan/ux-raw-results.json"
+
+DEFAULT_BASE_URL="http://localhost:8080"
+WAIT_ON_TIMEOUT_MS=120000
+
+BASE_URL="${PLAYWRIGHT_BASE_URL:-${DEFAULT_BASE_URL}}"
+STORAGE_STATE="${PLAYWRIGHT_STORAGE_STATE:-auth.json}"
+AUTO_START_SERVER="${UX_SCAN_AUTOSTART_SERVER:-true}"
+PREVIEW_PID=""
+PREVIEW_LOG=""
+
+mkdir -p "${UX_DIR}"
+
+cd "${WEB_DIR}"
+
+cleanup() {
+  if [[ -n "${PREVIEW_PID}" ]]; then
+    kill "${PREVIEW_PID}" >/dev/null 2>&1 || true
+  fi
+  if [[ -n "${PREVIEW_LOG}" ]]; then
+    rm -f "${PREVIEW_LOG}" || true
+  fi
+}
+
+trap cleanup EXIT
+
+if [[ ! -f "${STORAGE_STATE}" ]]; then
+  echo "Missing storage state file: ${WEB_DIR}/${STORAGE_STATE}"
+  echo "Generate one with: npx playwright codegen --save-storage=${STORAGE_STATE} ${BASE_URL}"
+  exit 1
+fi
+
+if ! curl -fsS "${BASE_URL}" >/dev/null 2>&1; then
+  BASE_HOST="$(node -e "const u=new URL(process.argv[1]); process.stdout.write(u.hostname)" "${BASE_URL}")"
+  BASE_PORT="$(node -e "const u=new URL(process.argv[1]); process.stdout.write(u.port || (u.protocol === 'https:' ? '443' : '80'))" "${BASE_URL}")"
+
+  if [[ "${AUTO_START_SERVER:-true}" == "true" ]] && [[ "${BASE_HOST}" == "localhost" || "${BASE_HOST}" == "127.0.0.1" ]]; then
+    echo "Base URL ${BASE_URL} is not reachable. Building and starting local preview server..."
+    npm run build
+    PREVIEW_LOG="$(mktemp -t ux-scan-preview.XXXXXX.log)"
+    npm run preview -- --host "${BASE_HOST}" --port "${BASE_PORT}" >"${PREVIEW_LOG}" 2>&1 &
+    PREVIEW_PID=$!
+
+    if ! npx wait-on "${BASE_URL}" --timeout "${WAIT_ON_TIMEOUT_MS}"; then
+      echo "Timed out waiting for preview server at ${BASE_URL}"
+      echo "Preview logs:"
+      cat "${PREVIEW_LOG}" || true
+      exit 1
+    fi
+  else
+    echo "Base URL ${BASE_URL} is not reachable."
+    echo "Start the app before scanning, or set UX_SCAN_AUTOSTART_SERVER=true for localhost URLs."
+    exit 1
+  fi
+fi
+
+echo "Running UX sweep against ${BASE_URL} with storage state ${STORAGE_STATE}"
+set +e
+PLAYWRIGHT_BASE_URL="${BASE_URL}" \
+PLAYWRIGHT_STORAGE_STATE="${STORAGE_STATE}" \
+npx playwright test --config=e2e/user-flows/ux-scan.config.ts
+PW_EXIT=$?
+set -e
+
+if [[ ! -f "${RAW_JSON}" ]]; then
+  if [[ -f "${LEGACY_RAW_JSON}" ]]; then
+    mkdir -p "$(dirname "${RAW_JSON}")"
+    cp "${LEGACY_RAW_JSON}" "${RAW_JSON}"
+  else
+    echo "Expected raw Playwright JSON not found at ${RAW_JSON}"
+    exit 1
+  fi
+fi
+
+RAW_JSON_PATH="${RAW_JSON}" FINDINGS_JSON_PATH="${FINDINGS_JSON}" SUMMARY_MD_PATH="${SUMMARY_MD}" node <<'NODE'
+const fs = require('fs')
+const path = require('path')
+
+const rawPath = process.env.RAW_JSON_PATH
+const findingsPath = process.env.FINDINGS_JSON_PATH
+const summaryPath = process.env.SUMMARY_MD_PATH
+
+const raw = JSON.parse(fs.readFileSync(rawPath, 'utf8'))
+
+function titlePathFor(test, suiteTitlePath) {
+  const list = []
+  if (Array.isArray(suiteTitlePath)) list.push(...suiteTitlePath)
+  if (test && test.title) list.push(test.title)
+  return list.filter(Boolean)
+}
+
+function flattenSuites(suites, parentTitles = [], out = []) {
+  for (const suite of suites || []) {
+    const nextTitles = suite.title ? [...parentTitles, suite.title] : [...parentTitles]
+
+    for (const spec of suite.specs || []) {
+      for (const test of spec.tests || []) {
+        out.push({
+          file: spec.file,
+          line: spec.line,
+          column: spec.column,
+          suiteTitlePath: nextTitles,
+          specTitle: spec.title,
+          test,
+        })
+      }
+    }
+
+    flattenSuites(suite.suites || [], nextTitles, out)
+  }
+  return out
+}
+
+function normalizeSeverity(status, message) {
+  if (status === 'timedOut') return 'high'
+  const lower = (message || '').toLowerCase()
+  if (lower.includes('console error') || lower.includes('exception')) return 'high'
+  if (
+    lower.includes('visual') ||
+    lower.includes('snapshot') ||
+    lower.includes('layout') ||
+    lower.includes('overflow') ||
+    lower.includes('truncat') ||
+    lower.includes('clipped') ||
+    lower.includes('color') ||
+    lower.includes('spacing')
+  ) return 'low'
+  if (lower.includes('tohaveurl') || lower.includes('tobevisible') || lower.includes('not.to')) return 'medium'
+  return 'medium'
+}
+
+function collectAttachments(results) {
+  const out = []
+  for (const result of results || []) {
+    for (const att of result.attachments || []) {
+      if (att && att.path) out.push(att.path)
+    }
+  }
+  return out
+}
+
+function firstFailureText(results) {
+  for (const result of results || []) {
+    for (const err of result.errors || []) {
+      if (err && (err.message || err.value)) {
+        return String(err.message || err.value)
+      }
+    }
+  }
+  return 'Playwright assertion failed in browser run.'
+}
+
+const tests = flattenSuites(raw.suites || [])
+const findings = []
+
+for (const item of tests) {
+  const status = item.test.status
+  // Only failed/timedOut/interrupted tests are considered issues.
+  if (!['failed', 'timedOut', 'interrupted'].includes(status)) continue
+
+  const failureText = firstFailureText(item.test.results)
+  const pathBits = titlePathFor(item.test, item.suiteTitlePath)
+  const prettyPath = pathBits.join(' > ')
+
+  const attachments = collectAttachments(item.test.results)
+  const steps = [
+    `Run test: ${prettyPath}`,
+    'Open browser at configured base URL and perform the same interaction path.',
+    'Observe assertion failure and attached artifact evidence.',
+  ]
+
+  findings.push({
+    issue: `${item.specTitle || item.test.title} failed`,
+    steps,
+    expected: 'User flow should complete without UX regressions or assertion failures.',
+    actual: failureText,
+    severity: normalizeSeverity(status, failureText),
+    source: {
+      file: item.file,
+      line: item.line,
+      project: item.test.projectName || 'chromium',
+      status,
+      reproducedInBrowser: true,
+      attachments,
+    },
+  })
+}
+
+const stats = {
+  totalTests: tests.length,
+  failedTests: findings.length,
+  passedTests: tests.filter((t) => t.test.status === 'passed').length,
+}
+
+fs.writeFileSync(
+  findingsPath,
+  JSON.stringify({
+    generatedAt: new Date().toISOString(),
+    reproducedInBrowserOnly: true,
+    stats,
+    findings,
+  }, null, 2),
+)
+
+const summaryLines = [
+  '# UX Scan Summary',
+  '',
+  `- Generated: ${new Date().toISOString()}`,
+  `- Total tests: ${stats.totalTests}`,
+  `- Passed tests: ${stats.passedTests}`,
+  `- Findings (browser reproduced): ${stats.failedTests}`,
+  '',
+]
+
+if (findings.length === 0) {
+  summaryLines.push('## Findings')
+  summaryLines.push('')
+  summaryLines.push('No browser-reproduced UX issues were detected in this run.')
+} else {
+  summaryLines.push('## Findings')
+  summaryLines.push('')
+  findings.forEach((f, idx) => {
+    summaryLines.push(`### ${idx + 1}. ${f.issue}`)
+    summaryLines.push(`- Severity: ${f.severity}`)
+    summaryLines.push(`- Expected: ${f.expected}`)
+    summaryLines.push(`- Actual: ${f.actual}`)
+    summaryLines.push(`- Source: ${f.source.file}:${f.source.line}`)
+    if (f.source.attachments.length > 0) {
+      summaryLines.push(`- Artifacts: ${f.source.attachments.join(', ')}`)
+    }
+    summaryLines.push('')
+  })
+}
+
+fs.writeFileSync(summaryPath, `${summaryLines.join('\n')}\n`)
+NODE
+
+echo ""
+echo "UX scan completed with Playwright exit code: ${PW_EXIT}"
+echo "Reports:"
+echo "  Raw Playwright JSON: ${RAW_JSON}"
+echo "  Browser findings JSON: ${FINDINGS_JSON}"
+echo "  Markdown summary: ${SUMMARY_MD}"
+echo "  HTML report: ${UX_DIR}/playwright-report/index.html"
+echo "  Artifacts (screenshots/traces/videos): ${UX_DIR}/artifacts"
+
+exit ${PW_EXIT}

--- a/web/PLAYWRIGHT.md
+++ b/web/PLAYWRIGHT.md
@@ -27,7 +27,7 @@ npm run test:e2e:report
 
 ```
 e2e/
-├── helpers/setup.ts        # Shared demo-mode setup + /api/me mock
+├── auth.setup.ts           # Authentication setup (runs first)
 ├── fixtures.ts             # Custom test fixtures and helpers
 ├── Login.spec.ts           # Login/authentication tests
 ├── Dashboard.spec.ts       # Dashboard page tests
@@ -39,6 +39,19 @@ e2e/
 ├── Events.spec.ts          # Events page tests
 ├── Settings.spec.ts        # Settings page tests
 └── DrillDown.spec.ts       # Drilldown modal tests
+
+The canonical location for Playwright specs is `web/e2e/`.
+The default `playwright.config.ts` now targets this folder directly.
+
+Default run (`npx playwright test`) is intentionally scoped to:
+- core UX/regression specs (`Login`, `Dashboard`, `Sidebar`, `Settings`, `smoke`, `spa-routes`, `keyboard-and-card-ops`)
+- `e2e/user-flows/**`
+
+Specialized/high-cost suites remain opt-in via dedicated configs:
+- `e2e/compliance/**`
+- `e2e/perf/**`
+- `e2e/nightly/**`
+- `e2e/visual/**`
 ```
 
 ## Test Coverage Areas

--- a/web/e2e/user-flows/post-login-dashboard-ux.spec.ts
+++ b/web/e2e/user-flows/post-login-dashboard-ux.spec.ts
@@ -1,0 +1,214 @@
+import { test, expect, type Page } from '@playwright/test'
+import { collectConsoleErrors } from '../helpers/ux-assertions'
+import { setMode } from '../mocks/liveMocks'
+
+const BASE_URL =
+  (globalThis as { process?: { env?: Record<string, string | undefined> } }).process?.env
+    ?.PLAYWRIGHT_BASE_URL || 'http://127.0.0.1:5174'
+
+const DASHBOARD_LOAD_TIMEOUT_MS = 20_000
+const ROUTE_LOAD_TIMEOUT_MS = 20_000
+const SEARCH_RESULTS_TIMEOUT_MS = 10_000
+const DIALOG_TIMEOUT_MS = 10_000
+const UX_SWEEP_TIMEOUT_MS = 240_000
+const MIN_BODY_TEXT_LENGTH = 20
+
+function routeMatcher(path: string): RegExp {
+  if (path === '/') {
+    return /\/($|\?)/
+  }
+
+  const escaped = path.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+  return new RegExp(`${escaped}(?:\\?.*)?$`)
+}
+
+async function loginAndOpenInitialDashboard(page: Page) {
+  await page.goto(`${BASE_URL}/login`, { waitUntil: 'domcontentloaded' })
+
+  // Simulate post-login auth state in a backend-independent way.
+  await setMode(page, 'demo')
+
+  await page.goto(`${BASE_URL}/`, { waitUntil: 'domcontentloaded' })
+
+  await expect(page).toHaveURL(routeMatcher('/'), { timeout: DASHBOARD_LOAD_TIMEOUT_MS })
+  await expect(page.getByTestId('dashboard-page')).toBeVisible({ timeout: DASHBOARD_LOAD_TIMEOUT_MS })
+  await expect(page.getByTestId('sidebar')).toBeVisible({ timeout: DASHBOARD_LOAD_TIMEOUT_MS })
+}
+
+async function assertRouteLoaded(page: Page, expectedPath: string) {
+  await expect(page).toHaveURL(routeMatcher(expectedPath), { timeout: ROUTE_LOAD_TIMEOUT_MS })
+  await expect(page.getByTestId('login-page')).toHaveCount(0)
+  await expect(page.locator('#main-content')).toBeVisible({ timeout: ROUTE_LOAD_TIMEOUT_MS })
+
+  const bodyText = await page.locator('body').innerText()
+  expect(bodyText.trim().length).toBeGreaterThan(MIN_BODY_TEXT_LENGTH)
+}
+
+async function clickSidebarRoute(page: Page, href: string) {
+  const link = page.locator(`[data-testid="sidebar"] a[href="${href}"]`).first()
+  await expect(link).toBeVisible({ timeout: ROUTE_LOAD_TIMEOUT_MS })
+  await link.scrollIntoViewIfNeeded()
+  await link.click()
+  await assertRouteLoaded(page, href)
+}
+
+async function getVisibleSidebarRoutes(page: Page): Promise<string[]> {
+  const routes = await page
+    .locator('[data-testid="sidebar"] a[href^="/"]')
+    .evaluateAll((nodes) => {
+      const seen = new Set<string>()
+      const hrefs: string[] = []
+
+      for (const node of nodes) {
+        const href = node.getAttribute('href')
+        if (!href || !href.startsWith('/')) continue
+        if (href.startsWith('/custom-dashboard/')) continue
+
+        if (!seen.has(href)) {
+          seen.add(href)
+          hrefs.push(href)
+        }
+      }
+
+      return hrefs
+    })
+
+  return routes
+}
+
+test.describe('Post-login initial dashboard UX sweep', () => {
+  test('all key landing-dashboard interactions and routes behave correctly', async ({ page }) => {
+    test.setTimeout(UX_SWEEP_TIMEOUT_MS)
+
+    const assertNoConsoleErrors = collectConsoleErrors(page)
+
+    await loginAndOpenInitialDashboard(page)
+
+    const sidebarRoutes = await getVisibleSidebarRoutes(page)
+    expect(sidebarRoutes.length).toBeGreaterThan(0)
+
+    for (const href of sidebarRoutes) {
+      await clickSidebarRoute(page, href)
+    }
+
+    await clickSidebarRoute(page, '/')
+    await expect(page.getByTestId('dashboard-page')).toBeVisible({ timeout: DASHBOARD_LOAD_TIMEOUT_MS })
+
+    // Refresh button should be clickable and keep the dashboard interactive.
+    const refreshButton = page.getByTestId('dashboard-refresh-button')
+    await expect(refreshButton).toBeVisible({ timeout: DASHBOARD_LOAD_TIMEOUT_MS })
+    await refreshButton.click()
+    await expect(refreshButton).toBeVisible({ timeout: DASHBOARD_LOAD_TIMEOUT_MS })
+
+    // Add Card should open and close a dialog.
+    const addCardButton = page.getByTestId('sidebar-add-card')
+    await expect(addCardButton).toBeVisible({ timeout: DASHBOARD_LOAD_TIMEOUT_MS })
+    await addCardButton.click()
+
+    const addCardDialog = page.getByRole('dialog')
+    await expect(addCardDialog).toBeVisible({ timeout: DIALOG_TIMEOUT_MS })
+    await page.keyboard.press('Escape')
+    await expect(addCardDialog).not.toBeVisible({ timeout: DIALOG_TIMEOUT_MS })
+
+    // "Add more..." customizer should also open/close correctly.
+    const addMoreButton = page
+      .getByTestId('sidebar')
+      .getByRole('button', { name: /add more/i })
+      .first()
+    await expect(addMoreButton).toBeVisible({ timeout: DASHBOARD_LOAD_TIMEOUT_MS })
+    await addMoreButton.click()
+
+    const customizerDialog = page.getByRole('dialog')
+    await expect(customizerDialog).toBeVisible({ timeout: DIALOG_TIMEOUT_MS })
+    await page.keyboard.press('Escape')
+    await expect(customizerDialog).not.toBeVisible({ timeout: DIALOG_TIMEOUT_MS })
+
+    // Sidebar collapse/expand should change visibility of Add Card action.
+    const collapseToggle = page.getByTestId('sidebar-collapse-toggle')
+    await expect(collapseToggle).toBeVisible({ timeout: DASHBOARD_LOAD_TIMEOUT_MS })
+
+    await collapseToggle.click()
+    await expect(addCardButton).not.toBeVisible({ timeout: DASHBOARD_LOAD_TIMEOUT_MS })
+
+    await collapseToggle.click()
+    await expect(addCardButton).toBeVisible({ timeout: DASHBOARD_LOAD_TIMEOUT_MS })
+
+    // Global search should find Settings and navigate there.
+    const searchInput = page.getByTestId('global-search-input')
+    await expect(searchInput).toBeVisible({ timeout: DASHBOARD_LOAD_TIMEOUT_MS })
+    await searchInput.click()
+    await searchInput.fill('settings')
+
+    const searchResults = page.getByTestId('global-search-results')
+    await expect(searchResults).toBeVisible({ timeout: SEARCH_RESULTS_TIMEOUT_MS })
+
+    const settingsResult = page
+      .getByTestId('global-search-result-item')
+      .filter({ hasText: /settings/i })
+      .first()
+
+    await expect(settingsResult).toBeVisible({ timeout: SEARCH_RESULTS_TIMEOUT_MS })
+    await settingsResult.click()
+    await assertRouteLoaded(page, '/settings')
+
+    // Logo button should return the user to the initial dashboard.
+    const homeLogoButton = page.locator('nav button[aria-label*="home" i]').first()
+    await expect(homeLogoButton).toBeVisible({ timeout: DASHBOARD_LOAD_TIMEOUT_MS })
+    await homeLogoButton.click()
+    await assertRouteLoaded(page, '/')
+    await expect(page.getByTestId('dashboard-page')).toBeVisible({ timeout: DASHBOARD_LOAD_TIMEOUT_MS })
+
+    // Clusters stat block should open a drilldown or navigate to clusters when count > 0.
+    const clustersStat = page.getByTestId('stat-block-clusters').first()
+    const clustersStatVisible = await clustersStat.isVisible().catch(() => false)
+
+    if (clustersStatVisible) {
+      const clusterCount = await clustersStat.evaluate((node) => {
+        const text = node.textContent ?? ''
+        const match = text.match(/\b\d+\b/)
+        return match ? Number(match[0]) : 0
+      })
+
+      if (clusterCount > 0) {
+        await clustersStat.click()
+
+        const drilldownModal = page.getByTestId('drilldown-modal')
+        const openedDrilldown = await drilldownModal
+          .isVisible({ timeout: DIALOG_TIMEOUT_MS })
+          .catch(() => false)
+
+        const navigatedToClusters = /\/clusters(?:\?.*)?$/.test(page.url())
+        expect(openedDrilldown || navigatedToClusters).toBe(true)
+
+        if (openedDrilldown) {
+          await page.getByTestId('drilldown-close').click()
+          await expect(drilldownModal).not.toBeVisible({ timeout: DIALOG_TIMEOUT_MS })
+        }
+
+        if (navigatedToClusters) {
+          await clickSidebarRoute(page, '/')
+        }
+      }
+    }
+
+    // First card should be interactive and support drilldown expansion when available.
+    const firstCard = page.locator('[data-card-type]').first()
+    await expect(firstCard).toBeVisible({ timeout: DASHBOARD_LOAD_TIMEOUT_MS })
+    await firstCard.hover()
+
+    const expandCardButton = firstCard
+      .locator('button[title*="xpand" i], button[aria-label*="xpand" i], button[title*="full screen" i], button[aria-label*="full screen" i]')
+      .first()
+
+    const hasExpandButton = await expandCardButton.isVisible().catch(() => false)
+    if (hasExpandButton) {
+      await expandCardButton.click()
+      const drilldownModal = page.getByTestId('drilldown-modal')
+      await expect(drilldownModal).toBeVisible({ timeout: DIALOG_TIMEOUT_MS })
+      await page.getByTestId('drilldown-close').click()
+      await expect(drilldownModal).not.toBeVisible({ timeout: DIALOG_TIMEOUT_MS })
+    }
+
+    assertNoConsoleErrors()
+  })
+})

--- a/web/e2e/user-flows/ux-scan.config.ts
+++ b/web/e2e/user-flows/ux-scan.config.ts
@@ -1,0 +1,49 @@
+import { defineConfig, devices } from '@playwright/test'
+
+const DEFAULT_BASE_URL = 'http://localhost:8080'
+const DEFAULT_STORAGE_STATE = 'auth.json'
+
+const UX_SWEEP_TIMEOUT_MS = 240_000
+const EXPECT_TIMEOUT_MS = 20_000
+const UX_ARTIFACTS_OUTPUT_DIR = '../../test-results/ux-scan/artifacts'
+const UX_HTML_REPORT_DIR = '../../test-results/ux-scan/playwright-report'
+const UX_RAW_RESULTS_FILE = '../../test-results/ux-scan/ux-raw-results.json'
+
+const baseURL =
+  (globalThis as { process?: { env?: Record<string, string | undefined> } }).process?.env
+    ?.PLAYWRIGHT_BASE_URL || DEFAULT_BASE_URL
+const storageState =
+  (globalThis as { process?: { env?: Record<string, string | undefined> } }).process?.env
+    ?.PLAYWRIGHT_STORAGE_STATE || DEFAULT_STORAGE_STATE
+
+export default defineConfig({
+  testDir: '.',
+  testMatch: ['**/*.spec.ts'],
+  fullyParallel: false,
+  workers: 1,
+  retries: 0,
+  timeout: UX_SWEEP_TIMEOUT_MS,
+  expect: {
+    timeout: EXPECT_TIMEOUT_MS,
+  },
+  // Keep UX scan outputs under web/test-results/ux-scan (repo-standard location).
+  outputDir: UX_ARTIFACTS_OUTPUT_DIR,
+  reporter: [
+    ['list'],
+    ['html', { outputFolder: UX_HTML_REPORT_DIR, open: 'never' }],
+    ['json', { outputFile: UX_RAW_RESULTS_FILE }],
+  ],
+  use: {
+    baseURL,
+    storageState,
+    screenshot: 'only-on-failure',
+    trace: 'retain-on-failure',
+    video: 'retain-on-failure',
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+})

--- a/web/package.json
+++ b/web/package.json
@@ -19,6 +19,7 @@
     "test:e2e:headed": "playwright test --headed",
     "test:e2e:debug": "playwright test --debug",
     "test:e2e:chromium": "playwright test --project=chromium",
+    "test:e2e:ux-sweep": "PLAYWRIGHT_BASE_URL=http://localhost:8080 PLAYWRIGHT_STORAGE_STATE=auth.json playwright test --config=e2e/user-flows/ux-scan.config.ts",
     "test:e2e:firefox": "playwright test --project=firefox",
     "test:e2e:webkit": "playwright test --project=webkit",
     "test:e2e:report": "playwright show-report",

--- a/web/playwright.config.ts
+++ b/web/playwright.config.ts
@@ -1,5 +1,10 @@
 import { defineConfig, devices } from '@playwright/test'
 
+const env =
+  (globalThis as { process?: { env?: Record<string, string | undefined> } }).process?.env ?? {}
+const isCI = Boolean(env.CI)
+
+
 /**
  * Playwright configuration for KubeStellar Console (kc)
  *
@@ -25,16 +30,16 @@ export default defineConfig({
   fullyParallel: true,
 
   // Fail the build on CI if test.only is left in
-  forbidOnly: !!process.env.CI,
+  forbidOnly: isCI,
 
   // Retry failed tests once in CI (balances flake detection vs run time)
-  retries: process.env.CI ? 1 : 0,
+  retries: isCI ? 1 : 0,
 
   // Workers — CI gets 4 workers per shard, local uses half of available cores
-  workers: process.env.CI ? 4 : '50%',
+  workers: isCI ? 4 : '50%',
 
   // Reporter configuration
-  reporter: process.env.CI
+  reporter: isCI
     ? [
         ['blob', { outputDir: 'blob-report' }],
         ['html', { outputFolder: 'playwright-report' }],
@@ -62,7 +67,7 @@ export default defineConfig({
     // real deployment, not a standalone vite dev server. Override with
     // PLAYWRIGHT_BASE_URL=http://localhost:5174 if running against a detached
     // vite dev server (e.g. for fast local UI iteration).
-    baseURL: process.env.PLAYWRIGHT_BASE_URL || 'http://localhost:8080',
+    baseURL: env.PLAYWRIGHT_BASE_URL || 'http://localhost:8080',
 
     // Collect trace on first retry
     trace: 'on-first-retry',
@@ -136,7 +141,7 @@ export default defineConfig({
   //
   // Local dev: just `npm run test:e2e` and playwright will start the backend
   // itself. Previously this was `webServer: undefined`, which hung on connect.
-  webServer: process.env.PLAYWRIGHT_BASE_URL
+  webServer: env.PLAYWRIGHT_BASE_URL
     ? undefined
     : {
         // Run `go run .` from the repo root (one level up from web/).
@@ -145,7 +150,7 @@ export default defineConfig({
         // Go backend can take a while to build on first run.
         // 3 minutes covers a cold `go run` compile on modest hardware.
         timeout: 180_000,
-        reuseExistingServer: !process.env.CI,
+        reuseExistingServer: !isCI,
         stdout: 'pipe',
         stderr: 'pipe',
       },


### PR DESCRIPTION
## Summary

Implements the Playwright UX scanning feature from #8055 (xonas1101) with all review feedback addressed.

- Adds `web/e2e/user-flows/post-login-dashboard-ux.spec.ts`: post-login dashboard UX sweep spec using named timeout constants and the existing `setMode(page, 'demo')` helper (not hand-rolled `localStorage` calls)
- Adds `web/e2e/user-flows/ux-scan.config.ts`: dedicated opt-in Playwright config; does not affect default `npm run test:e2e` runs
- Adds `scripts/run-ux-scan.sh`: runner with `mktemp` preview log, named `WAIT_ON_TIMEOUT_MS` constant, optional auto-start of preview server
- Adds `docs/qa/AI-UX-ISSUE-AGENT-BRIEF.md`: agent brief that writes run output to `web/test-results/ux-scan/reported-issues.md` (gitignored), never self-mutates
- Updates `web/package.json`: `test:e2e:ux-sweep` targets `http://localhost:8080` (Go-backend topology)
- Updates `web/playwright.config.ts`: refactors `process.env.CI` to `isCI` const; preserves `testIgnore: []`, blob reporter, baseURL, webServer, mobile projects, and all load-bearing config
- Updates `.gitignore`: ignores `playwright/.cache/`, `auth.json`, `e2e/user-flows/test-results/`
- Updates `web/PLAYWRIGHT.md`: documents canonical spec location and default vs specialized suite scope

## What was fixed vs the original PR

The original PR (#8055) went through two review rounds. All UX-scan-side feedback was addressed in the second commit. The one remaining blocker was `web/playwright.config.ts` — the PR branch had reverted `testIgnore: []` back to the old `['**/auth.setup.ts', ...]` array (removed in #9076 as dead code). This clean-room version applies only the approved `isCI` refactor to `playwright.config.ts` and preserves `testIgnore: []`.

Credit: original contribution by @xonas1101.

## Test plan

- [ ] `npm run test:e2e:ux-sweep` runs the UX sweep config against `http://localhost:8080`
- [ ] Default `npm run test:e2e` is unaffected (UX sweep is opt-in via dedicated config)
- [ ] `scripts/run-ux-scan.sh` produces `web/test-results/ux-scan/ux-findings.json` and `ux-summary.md`
- [ ] `web/playwright.config.ts` blob reporter, baseURL, webServer, mobile projects intact
- [ ] CI build/lint/card-standard pass

Fixes #8055