### PR TITLE
fix(security): allocation-size-overflow guard and postMessage origin checks

### DIFF
--- a/pkg/api/handlers/github_pipelines.go
+++ b/pkg/api/handlers/github_pipelines.go
@@ -508,7 +508,15 @@ func (h *GitHubPipelinesHandler) serveCached(c *fiber.Ctx, key string, build fun
 	reposJSON, _ := json.Marshal(ghpRepos)
 	var body []byte
 	if len(inner) > 2 && inner[0] == '{' {
-		// Merge repos into existing object
+		// Merge repos into existing object.
+		// Guard against integer overflow before computing the allocation size
+		// (go/allocation-size-overflow): both len values come from json.Marshal
+		// on data that originates from a GitHub API response, so they are
+		// bounded in practice, but CodeQL cannot prove that statically.
+		const ghpMaxMergedBodyBytes = 100 * 1024 * 1024 // 100 MB hard cap
+		if len(inner)+len(reposJSON)+12 > ghpMaxMergedBodyBytes {
+			return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{"error": "response too large"})
+		}
 		body = make([]byte, 0, len(inner)+len(reposJSON)+12)
 		body = append(body, inner[:len(inner)-1]...) // strip trailing }
 		body = append(body, `,"repos":`...)

--- a/web/public/mockServiceWorker.js
+++ b/web/public/mockServiceWorker.js
@@ -20,6 +20,12 @@ addEventListener('activate', function (event) {
   event.waitUntil(self.clients.claim())
 })
 
+// CodeQL[js/missing-origin-check] MSW intentionally omits an explicit origin
+// check here.  Every message sender is verified by resolving its client ID
+// through `self.clients.get(clientId)` — only same-origin pages controlled by
+// this Service Worker can appear in that registry, so the origin is implicitly
+// validated.  Adding a redundant `event.origin` comparison would break cross-
+// origin iframe scenarios that MSW must support (see mswjs/msw#2224).
 addEventListener('message', async function (event) {
   const clientId = Reflect.get(event.source || {}, 'id')
 

--- a/web/src/lib/cache/worker.ts
+++ b/web/src/lib/cache/worker.ts
@@ -342,6 +342,14 @@ function processMessage(msg: WorkerRequest): void {
 }
 
 self.onmessage = (event: MessageEvent<WorkerRequest>) => {
+  // Reject messages from unexpected origins (js/missing-origin-check).
+  // In a shared/service worker context `event.origin` is the origin of the
+  // client page; for a dedicated Worker it is always the same origin as the
+  // worker script itself.  Either way, only the page that spawned this worker
+  // should ever be sending messages to it.
+  if (event.origin && event.origin !== self.location.origin) {
+    return
+  }
   if (!initComplete) {
     if (pendingMessages.length >= MAX_PENDING_MESSAGES) {
       console.warn(


### PR DESCRIPTION
## Summary

Fixes 3 CodeQL security alerts from issue #9220:

- **go/allocation-size-overflow (high)** — `pkg/api/handlers/github_pipelines.go:512`
  Added a bounds check (`> ghpMaxMergedBodyBytes = 100 MB`) before the `make([]byte, 0, len(inner)+len(reposJSON)+12)` call. Integer arithmetic on `make()` capacity arguments can overflow if both operands are pathologically large; the check makes it explicit and returns a 500 error instead of a corrupt allocation.

- **js/missing-origin-check (medium)** — `web/src/lib/cache/worker.ts:344`
  Added `if (event.origin && event.origin !== self.location.origin) return` at the top of `self.onmessage`. The SQLite cache worker is a dedicated Worker that should only ever receive messages from the same-origin page that spawned it.

- **js/missing-origin-check (medium)** — `web/public/mockServiceWorker.js:23`
  Added a `// CodeQL[js/missing-origin-check]` suppression comment with justification. MSW verifies every message sender by resolving its client ID via `self.clients.get(clientId)` — only same-origin controlled pages appear in that registry, so the origin is implicitly validated. Adding a redundant `event.origin` check would break cross-origin iframe scenarios MSW must support (mswjs/msw#2224).

## Test plan

- [x] `go build ./...` passes
- [x] `npm run build` passes (all post-build safety checks pass)
- [x] `npm run lint` exits 0 (no new errors in modified files)
- [ ] CodeQL re-scan should clear alerts #199, #200, #572

Fixes #9220