### PR TITLE
🐛 fix(missions): preserve 'completed' status on stale-session detection when agent already responded (Issue 9157)

### DIFF
--- a/web/src/hooks/useMissions.tsx
+++ b/web/src/hooks/useMissions.tsx
@@ -1154,10 +1154,44 @@ export function MissionProvider({ children }: { children: ReactNode }) {
               return prev.map(m => {
                 if (!m.context?.needsReconnect) return m
                 if (missionsToMarkStale.includes(m.id)) {
-                  // #6384 item 2 (dup of #6380) — rely on status 'failed' +
-                  // the explicit system message to prompt the user to retry.
-                  // A separate `needsRestart` flag was never read anywhere,
-                  // so carrying it here was dead state.
+                  // Issue 9157: if the agent's LAST message was a substantive
+                  // assistant response, the mission almost certainly completed
+                  // before the session went stale — the only thing missing is
+                  // the explicit `done` event. Marking such missions 'failed'
+                  // contradicts the visible chat history and tells users to
+                  // retry work that actually finished. Promote them to
+                  // 'completed' with a softer note instead. Truly-failed
+                  // (no assistant response, or last message is a system
+                  // message) keeps the original 'failed' + retry CTA.
+                  const lastMsg = m.messages[m.messages.length - 1]
+                  const lastWasSuccessfulAssistant =
+                    lastMsg !== undefined &&
+                    lastMsg.role === 'assistant' &&
+                    lastMsg.content.trim().length > 0
+                  if (lastWasSuccessfulAssistant) {
+                    return {
+                      ...m,
+                      status: 'completed' as MissionStatus,
+                      currentStep: undefined,
+                      updatedAt: new Date(),
+                      context: {
+                        ...m.context,
+                        needsReconnect: false },
+                      messages: [
+                        ...m.messages,
+                        {
+                          id: `msg-reconnect-stale-success-${m.id}-${Date.now()}`,
+                          role: 'system' as const,
+                          content: `_Session expired before we could confirm completion. The agent's last response is preserved above — marking this mission complete._`,
+                          timestamp: new Date() }
+                      ]
+                    }
+                  }
+                  // No (successful) assistant response on record — really did
+                  // get stranded. Keep the original failed-with-retry-CTA
+                  // behaviour. #6384 item 2 (dup of #6380): rely on status
+                  // 'failed' + the explicit system message; a separate
+                  // `needsRestart` flag was never read anywhere.
                   return {
                     ...m,
                     status: 'failed' as MissionStatus,


### PR DESCRIPTION
## Summary

Reported by @ghanshyam2005singh: missions whose last visible agent message was a successful response were being marked **Failed** after 30 minutes of inactivity, with a "Mission session expired — click Retry" CTA. The mismatch between the chat (visibly successful) and the status (Failed) is misleading and tells users to retry work that already completed.

## Root cause

In `web/src/hooks/useMissions.tsx` around line 1156, the stale-detection branch unconditionally flips any mission with `needsReconnect=true` and `ageMs > MISSION_RECONNECT_MAX_AGE_MS` to status `'failed'`.

Mission status is set to `'running'` / `'waiting_input'` before the WebSocket connect+replay happens, and only transitions to `'completed'` when the explicit `done` event arrives. If the agent finished but the `done` event was lost (or never sent before the WS dropped), the mission stays `'running'` indefinitely — and on the next reload, this branch fails it.

## Fix

Before falling through to the `'failed'` path, check the **last** message in the mission. If it's `role: 'assistant'` with non-empty trimmed content, the agent demonstrably responded — promote to `'completed'` with a softer system note instead.

```ts
const lastMsg = m.messages[m.messages.length - 1]
const lastWasSuccessfulAssistant =
  lastMsg !== undefined &&
  lastMsg.role === 'assistant' &&
  lastMsg.content.trim().length > 0
if (lastWasSuccessfulAssistant) {
  return { ...m, status: 'completed', /* softer note */ }
}
// otherwise: keep original 'failed' + retry CTA behaviour
```

Truly-stranded missions (no assistant response or only system messages) keep the existing `'failed' + retry CTA` behaviour.

## Why no new `'expired'` status

Adding a new `MissionStatus` enum value ripples to every place that handles status (badges, filters, leaderboard credits). The narrower fix here addresses the exact reporter complaint — last response was successful → don't show failed — without that ripple.

## Test plan

- [ ] Manual: start a mission, get a successful response, leave the tab idle for >30min, reopen — mission should show `Completed` with a small italic system note about the expired session, NOT `Failed` with a Retry CTA.
- [ ] Manual: start a mission, kill the agent before it responds, leave idle >30min, reopen — should still show `Failed` with the Retry CTA (unchanged behaviour).

Fixes #9157