### PR TITLE
🐛 fix(resolutions): cap Save Resolution prompt size + accurate error (Fixes #9162)

### DIFF
--- a/web/src/components/missions/SaveResolutionDialog.tsx
+++ b/web/src/components/missions/SaveResolutionDialog.tsx
@@ -47,6 +47,70 @@ interface SaveResolutionDialogProps {
 const AI_SUMMARY_TIMEOUT_MS = 60_000
 
 /**
+ * Maximum number of recent mission messages to include in the AI summary prompt.
+ * Older messages add diminishing context for a fix-summary while inflating the
+ * payload. Mirrors `MAX_RESENT_MESSAGES` in useMissions.tsx (used for reconnect
+ * history) — same rationale: keep the WebSocket frame small enough that the
+ * agent's 1 MB read limit is never the failure mode (#9162).
+ */
+const MAX_SUMMARY_MESSAGES = 20
+
+/**
+ * Per-message character cap when building the conversation snippet sent to the
+ * AI. Tool outputs (pod logs, YAML manifests, kubectl describe) are routinely
+ * tens of kilobytes; concatenating a handful of them blows past the agent's
+ * 1 MB WebSocket frame limit, which closes the connection and surfaces the
+ * misleading "Could not reach the local agent" error (#9162).
+ */
+const MAX_MESSAGE_CHARS = 4_000
+
+/**
+ * Hard cap on the assembled prompt sent to the agent. The agent rejects
+ * prompts longer than `maxPromptChars` (100_000) with a `prompt_too_large`
+ * error, and frames larger than `wsMaxMessageBytes` (1 MB) cause the agent
+ * to close the connection without a response. We stay well under both so a
+ * very long mission never triggers either failure mode (#9162).
+ */
+const MAX_PROMPT_CHARS = 80_000
+
+/** Marker appended when message content was truncated. */
+const TRUNCATION_MARKER = '… [truncated]'
+
+/** Marker appended when the conversation tail was truncated. */
+const CONVERSATION_TRUNCATION_MARKER = '\n\n[…earlier conversation omitted…]'
+
+/**
+ * Build the conversation snippet sent to the AI for summary generation.
+ * Caps both per-message size and the total assembled length so the resulting
+ * WebSocket frame stays under the agent's read limit (#9162).
+ */
+function buildConversationSnippet(messages: Mission['messages']): string {
+  // Take only the most recent messages — older context adds little to a
+  // resolution summary and risks blowing past the agent's read limit.
+  const recent = messages.slice(-MAX_SUMMARY_MESSAGES)
+  const omittedCount = messages.length - recent.length
+
+  const lines = recent.map(m => {
+    const content = m.content.length > MAX_MESSAGE_CHARS
+      ? m.content.slice(0, MAX_MESSAGE_CHARS) + TRUNCATION_MARKER
+      : m.content
+    return `${m.role.toUpperCase()}: ${content}`
+  })
+
+  let snippet = lines.join('\n\n')
+  if (omittedCount > 0) {
+    snippet = CONVERSATION_TRUNCATION_MARKER.trimStart() + ` (${omittedCount} earlier messages)\n\n` + snippet
+  }
+
+  // Final safety net: if the assembled snippet is still too large (e.g. all
+  // 20 recent messages were near the per-message cap), trim from the head.
+  if (snippet.length > MAX_PROMPT_CHARS) {
+    snippet = CONVERSATION_TRUNCATION_MARKER + snippet.slice(snippet.length - MAX_PROMPT_CHARS)
+  }
+  return snippet
+}
+
+/**
  * Detect whether an error message indicates an AI provider rate limit / quota error.
  * Matches HTTP 429 status codes, "rate limit", "quota", and "too many requests" patterns.
  */
@@ -74,18 +138,40 @@ const RATE_LIMIT_MESSAGE =
 async function generateAISummary(mission: Mission): Promise<AISummary> {
   return new Promise((resolve, reject) => {
     const ws = new WebSocket(LOCAL_AGENT_WS_URL)
-    const timeout = setTimeout(() => {
-      ws.close()
-      reject(new Error('Timeout waiting for AI summary'))
-    }, AI_SUMMARY_TIMEOUT_MS)
 
     let responseContent = ''
+    // #9162 — Track whether the connection ever opened. If the agent closes
+    // the socket mid-request (e.g. because our payload exceeded its 1 MB
+    // read limit), `onerror` would otherwise fire the misleading "Could not
+    // reach the local agent" message even though the agent is running and
+    // already accepted our connection.
+    let didOpen = false
+    // #9162 — Once we have received an explicit `error` or `result` frame,
+    // we have already settled the promise; suppress any subsequent
+    // onerror/onclose handlers from rejecting again.
+    let settled = false
+    let timeout: ReturnType<typeof setTimeout> | undefined
+    const settle = (fn: () => void) => {
+      if (settled) return
+      settled = true
+      if (timeout !== undefined) clearTimeout(timeout)
+      fn()
+    }
+    timeout = setTimeout(() => {
+      settle(() => {
+        ws.close()
+        reject(new Error('Timeout waiting for AI summary'))
+      })
+    }, AI_SUMMARY_TIMEOUT_MS)
 
     ws.onopen = () => {
-      // Build conversation context
-      const conversation = mission.messages
-        .map(m => `${m.role.toUpperCase()}: ${m.content}`)
-        .join('\n\n')
+      didOpen = true
+      // #9162 — Build conversation context with size caps so the assembled
+      // WebSocket frame stays under the agent's 1 MB read limit. Without
+      // this, long missions (with large tool outputs) would silently exceed
+      // the limit, the agent would close the socket, and the client would
+      // surface a misleading "Could not reach the local agent" error.
+      const conversation = buildConversationSnippet(mission.messages)
 
       const prompt = `You are helping save a resolution for future reuse. Analyze this mission conversation and create a structured summary.
 
@@ -123,47 +209,49 @@ Return ONLY valid JSON, no markdown code blocks or explanation.`
         if (message.type === 'stream') {
           responseContent += message.payload?.content || ''
         } else if (message.type === 'result') {
-          clearTimeout(timeout)
-          ws.close()
-
           const content = message.payload?.content || message.payload?.output || responseContent
+          settle(() => {
+            ws.close()
 
-          // Check if the result content itself indicates a rate limit error
-          if (isRateLimitError(content)) {
-            reject(new Error(RATE_LIMIT_MESSAGE))
-            return
-          }
-
-          // Try to parse JSON from response
-          try {
-            // Extract JSON if wrapped in code blocks
-            const jsonMatch = content.match(/\{[\s\S]*\}/)
-            if (jsonMatch) {
-              const parsed = JSON.parse(jsonMatch[0])
-              resolve({
-                title: parsed.title || mission.title,
-                issueType: parsed.issueType || 'Unknown',
-                resourceKind: parsed.resourceKind,
-                problem: parsed.problem || '',
-                solution: parsed.solution || '',
-                steps: Array.isArray(parsed.steps) ? parsed.steps : [],
-                yaml: parsed.yaml })
-            } else {
-              reject(new Error('Could not parse AI response as JSON'))
+            // Check if the result content itself indicates a rate limit error
+            if (isRateLimitError(content)) {
+              reject(new Error(RATE_LIMIT_MESSAGE))
+              return
             }
-          } catch {
-            reject(new Error('Failed to parse AI summary response'))
-          }
+
+            // Try to parse JSON from response
+            try {
+              // Extract JSON if wrapped in code blocks
+              const jsonMatch = content.match(/\{[\s\S]*\}/)
+              if (jsonMatch) {
+                const parsed = JSON.parse(jsonMatch[0])
+                resolve({
+                  title: parsed.title || mission.title,
+                  issueType: parsed.issueType || 'Unknown',
+                  resourceKind: parsed.resourceKind,
+                  problem: parsed.problem || '',
+                  solution: parsed.solution || '',
+                  steps: Array.isArray(parsed.steps) ? parsed.steps : [],
+                  yaml: parsed.yaml })
+              } else {
+                reject(new Error('Could not parse AI response as JSON'))
+              }
+            } catch {
+              reject(new Error('Failed to parse AI summary response'))
+            }
+          })
         } else if (message.type === 'error') {
-          clearTimeout(timeout)
-          ws.close()
           const errorMsg = message.payload?.message || 'AI request failed'
-          // Surface a clear rate-limit message instead of the generic backend error
-          if (isRateLimitError(errorMsg) || isRateLimitError(message.payload?.code || '')) {
-            reject(new Error(RATE_LIMIT_MESSAGE))
-          } else {
-            reject(new Error(errorMsg))
-          }
+          const errorCode = message.payload?.code || ''
+          settle(() => {
+            ws.close()
+            // Surface a clear rate-limit message instead of the generic backend error
+            if (isRateLimitError(errorMsg) || isRateLimitError(errorCode)) {
+              reject(new Error(RATE_LIMIT_MESSAGE))
+            } else {
+              reject(new Error(errorMsg))
+            }
+          })
         }
       } catch {
         // Ignore parse errors for non-JSON messages
@@ -171,12 +259,41 @@ Return ONLY valid JSON, no markdown code blocks or explanation.`
     }
 
     ws.onerror = () => {
-      clearTimeout(timeout)
-      reject(new Error('Could not reach the local agent — make sure kc-agent is running'))
+      settle(() => {
+        // #9162 — Distinguish a real "agent unreachable" failure from an
+        // abnormal close after the connection was already established.
+        // If `didOpen` is true, the agent accepted the WebSocket and then
+        // closed it (commonly because we exceeded its 1 MB read limit, or
+        // it crashed mid-request). Telling the user "make sure kc-agent is
+        // running" in that case is misleading — chat is still working.
+        if (didOpen) {
+          reject(new Error('Lost connection to local agent while generating summary. The mission conversation may be too large; try Regenerate or save with a manual summary.'))
+        } else {
+          reject(new Error('Could not reach the local agent — make sure kc-agent is running'))
+        }
+      })
     }
 
-    ws.onclose = () => {
-      clearTimeout(timeout)
+    ws.onclose = (event) => {
+      // #9162 — A close without a prior `result`/`error`/`onerror` (e.g.
+      // server hangup after we exceeded the read limit) would otherwise
+      // leave the promise pending until the AI summary timeout. Reject
+      // explicitly so the user sees actionable feedback immediately.
+      settle(() => {
+        if (didOpen) {
+          // 1009 = Message Too Big (RFC 6455). Emit a precise hint when the
+          // close code matches; otherwise stick to the generic "lost
+          // connection" message which already mentions size as a likely cause.
+          const isTooBig = event.code === 1009
+          reject(new Error(
+            isTooBig
+              ? 'Mission conversation is too large for the agent to summarize. Try Regenerate after a shorter run or save with a manual summary.'
+              : 'Connection to local agent closed before the summary completed. Try Regenerate or save with a manual summary.'
+          ))
+        } else {
+          reject(new Error('Could not reach the local agent — make sure kc-agent is running'))
+        }
+      })
     }
   })
 }


### PR DESCRIPTION
Fixes #9162

## Root cause

Save Resolution failed with **"Could not reach the local agent — make sure kc-agent is running"** even when chat against the same agent was streaming successfully in the background. The misleading error masked two real problems:

1. **Oversized payload.** `SaveResolutionDialog.generateAISummary()` concatenated **every** message of the mission at full length into a single prompt. Tool outputs (pod logs, `kubectl describe`, YAML manifests) routinely run tens of kilobytes; a handful of them push the WebSocket frame past the agent's 1 MB read limit (`wsMaxMessageBytes` in `pkg/agent/server_ai.go`). When that happens, gorilla/websocket closes the connection with code 1009 (Message Too Big) — no `result`/`error` frame is ever sent.

2. **Misleading error path.** Any abnormal close — including the read-limit hangup above — fired the generic `ws.onerror` reject path, which always claimed the agent was unreachable. The user saw "make sure kc-agent is running" while their chat continued to stream messages from that very same agent.

## Fix

In `web/src/components/missions/SaveResolutionDialog.tsx`:

- New `buildConversationSnippet()` helper bounds the prompt at three layers:
  - Take only the most recent **20** messages (mirrors `MAX_RESENT_MESSAGES` in `useMissions.tsx`, used for reconnect history).
  - Cap each message at **4_000** chars before concatenation.
  - Final safety net trims the head if the assembled snippet still exceeds **80_000** chars — well under both the agent's 100K prompt cap (`maxPromptChars`) and the 1 MB frame limit (`wsMaxMessageBytes`).
- Track \`didOpen\` so \`ws.onerror\` / \`ws.onclose\` after a successful upgrade no longer falsely report the agent as unreachable.
- Add a real \`ws.onclose\` reject path so a server hangup surfaces immediately instead of waiting out the 60s summary timeout.
- Detect close code **1009 (Message Too Big)** and surface a precise "conversation too large" hint pointing the user at Regenerate / manual summary.
- Centralize promise resolution behind a \`settle()\` guard so a late \`result\` / \`error\` after timeout (or vice versa) cannot double-reject.

No magic numbers introduced — every cap and marker is a named const with a comment explaining the chosen bound and the failure it prevents. Companion to #9213 which fixed the render-avalanche freeze on the same modal (#9163); this one fixes the save-side failure.

## Test plan

- [ ] Open AI Mission with short conversation → click **Save Resolution** → AI summary generates successfully (unchanged behavior).
- [ ] Open AI Mission with a long conversation containing large tool outputs (pod logs, full YAML) → click **Save Resolution** → no "Could not reach the local agent" error; summary either generates or surfaces the new "conversation too large" hint.
- [ ] Stop kc-agent, then click **Save Resolution** → still shows the original "Could not reach the local agent — make sure kc-agent is running" message (real unreachable case is preserved).
- [ ] Click **Regenerate** after a previous error → reconnects and retries cleanly without double-rejecting.