### PR TITLE
refactor(e2e): extract shared setupAuth/setupDashboardTest/setupMCP helpers

### DIFF
--- a/web/e2e/Dashboard.spec.ts
+++ b/web/e2e/Dashboard.spec.ts
@@ -1,54 +1,5 @@
-import { test, expect, Page } from '@playwright/test'
-
-/**
- * Sets up authentication and MCP mocks for dashboard tests
- */
-async function setupDashboardTest(page: Page) {
-  // Mock authentication
-  await page.route('**/api/me', (route) =>
-    route.fulfill({
-      status: 200,
-      contentType: 'application/json',
-      body: JSON.stringify({
-        id: '1',
-        github_id: '12345',
-        github_login: 'testuser',
-        email: 'test@example.com',
-        onboarded: true,
-      }),
-    })
-  )
-
-  // Mock cluster data
-  await page.route('**/api/mcp/**', (route) =>
-    route.fulfill({
-      status: 200,
-      contentType: 'application/json',
-      body: JSON.stringify({
-        clusters: [
-          { name: 'cluster-1', context: 'ctx-1', healthy: true, nodeCount: 5, podCount: 45 },
-          { name: 'cluster-2', context: 'ctx-2', healthy: true, nodeCount: 3, podCount: 32 },
-        ],
-        issues: [],
-        events: [],
-        nodes: [],
-      }),
-    })
-  )
-
-  // Seed localStorage BEFORE any page script runs so the auth guard sees
-  // the token on first execution. page.evaluate() runs after the page has
-  // already parsed and executed scripts, which is too late for webkit/Safari
-  // where the auth redirect fires synchronously on script evaluation.
-  // page.addInitScript() injects the snippet ahead of any page code (#9096).
-  await page.addInitScript(() => {
-    localStorage.setItem('token', 'test-token')
-    localStorage.setItem('demo-user-onboarded', 'true')
-  })
-
-  await page.goto('/')
-  await page.waitForLoadState('domcontentloaded')
-}
+import { test, expect } from '@playwright/test'
+import { setupDashboardTest } from './helpers/setup'
 
 test.describe('Dashboard Page', () => {
   test.beforeEach(async ({ page }) => {

--- a/web/e2e/compliance/i18n-compliance.spec.ts
+++ b/web/e2e/compliance/i18n-compliance.spec.ts
@@ -2,6 +2,7 @@ import { test, expect, type Page } from '@playwright/test'
 import * as fs from 'fs'
 import * as path from 'path'
 import { fileURLToPath } from 'url'
+import { setupAuthLocalStorage } from '../helpers/setup'
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
 
@@ -156,16 +157,6 @@ async function setupMockServer(page: Page) {
       })
     }
     route.fulfill({ status: 200, contentType: 'application/json', body: '[]' })
-  })
-}
-
-async function setupAuth(page: Page) {
-  await page.addInitScript(() => {
-    localStorage.setItem('token', 'test-jwt-token')
-    localStorage.setItem('kc-demo-mode', 'false')
-    localStorage.setItem('kc-onboarding-complete', 'true')
-    localStorage.setItem('kc-tour-complete', 'true')
-    localStorage.setItem('kc-setup-complete', 'true')
   })
 }
 
@@ -387,7 +378,12 @@ test('i18n compliance — internationalization audit', async ({ page }) => {
     }
   })
 
-  await setupAuth(page)
+  await setupAuthLocalStorage(page, {
+    demoMode: false,
+    onboardingComplete: true,
+    tourComplete: true,
+    setupComplete: true,
+  })
   await setupMockServer(page)
   await page.goto('/', { waitUntil: 'domcontentloaded', timeout: IS_CI ? 60_000 : 30_000 })
   // Wait for page content to fully render

--- a/web/e2e/compliance/security-compliance.spec.ts
+++ b/web/e2e/compliance/security-compliance.spec.ts
@@ -2,6 +2,7 @@ import { test, expect, type Page } from '@playwright/test'
 import * as fs from 'fs'
 import * as path from 'path'
 import { fileURLToPath } from 'url'
+import { setupAuthLocalStorage } from '../helpers/setup'
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
 
@@ -118,16 +119,6 @@ async function setupMockServer(page: Page) {
   })
 }
 
-async function setupAuth(page: Page) {
-  await page.addInitScript(() => {
-    localStorage.setItem('token', 'test-jwt-token')
-    localStorage.setItem('kc-demo-mode', 'false')
-    localStorage.setItem('kc-onboarding-complete', 'true')
-    localStorage.setItem('kc-tour-complete', 'true')
-    localStorage.setItem('kc-setup-complete', 'true')
-  })
-}
-
 // ---------------------------------------------------------------------------
 // Test
 // ---------------------------------------------------------------------------
@@ -156,7 +147,12 @@ test('security compliance — frontend security audit', async ({ page }, testInf
 
   // ── Setup ──────────────────────────────────────────────────────────────
   console.log('[Security] Phase 1: Setup')
-  await setupAuth(page)
+  await setupAuthLocalStorage(page, {
+    demoMode: false,
+    onboardingComplete: true,
+    tourComplete: true,
+    setupComplete: true,
+  })
   await setupMockServer(page)
 
   // ── Phase 2: Load the app ──────────────────────────────────────────────

--- a/web/e2e/helpers/setup.ts
+++ b/web/e2e/helpers/setup.ts
@@ -200,3 +200,180 @@ export async function waitForDashboard(page: Page) {
     timeout: ELEMENT_VISIBLE_TIMEOUT_MS,
   })
 }
+
+// ---------------------------------------------------------------------------
+// Shared auth / MCP / dashboard setup helpers (#9233)
+//
+// These consolidate the copy-pasted setupAuth / setupDashboardTest / setupMCP
+// patterns that were duplicated across 10+ spec files. Each spec was defining
+// a local copy with subtly different user shapes / localStorage keys, so the
+// helpers below accept options that preserve the exact behavior of the
+// original local helpers.
+//
+// There are two distinct flavors of "auth setup" in the codebase:
+//   1. API-route mock: stub `/api/me` with a mock user (setupAuth)
+//   2. localStorage init: seed token + demo flags via addInitScript
+//      (setupAuthLocalStorage)
+//
+// Both are provided as separate helpers so callers pick the flavor that
+// matches their test's expectations.
+// ---------------------------------------------------------------------------
+
+/** Default user shape returned from a mocked `/api/me` call */
+export interface MockApiUser {
+  id: string
+  github_id: string
+  github_login: string
+  email: string
+  onboarded: boolean
+  role?: string
+}
+
+/** Default mock user for shared `setupAuth` (matches the legacy local copies) */
+export const DEFAULT_AUTH_USER: MockApiUser = {
+  id: '1',
+  github_id: '12345',
+  github_login: 'testuser',
+  email: 'test@example.com',
+  onboarded: true,
+}
+
+/**
+ * Mock the `/api/me` endpoint so the AuthProvider sees a valid user without
+ * contacting a real backend. Accepts an optional user override for specs
+ * that need a specific github_login / role.
+ *
+ * This is the API-route-mock flavor of auth setup. If your test wants to
+ * seed `localStorage` tokens + demo-mode flags, use `setupAuthLocalStorage`
+ * instead (or both, depending on what the app under test expects).
+ */
+export async function setupAuth(page: Page, user?: Partial<MockApiUser>): Promise<void> {
+  const u: MockApiUser = { ...DEFAULT_AUTH_USER, ...(user || {}) }
+  await page.route('**/api/me', (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(u),
+    })
+  )
+}
+
+/** Options for seeding auth state via localStorage */
+export interface AuthLocalStorageOptions {
+  /** Token value (default: 'test-jwt-token') */
+  token?: string
+  /** Whether to seed `kc-demo-mode` and, if so, its value (default: not set) */
+  demoMode?: boolean
+  /** Seed `demo-user-onboarded=true` (default: false) */
+  demoUserOnboarded?: boolean
+  /** Seed `kc-onboarding-complete=true` (default: false) */
+  onboardingComplete?: boolean
+  /** Seed `kc-tour-complete=true` (default: false) */
+  tourComplete?: boolean
+  /** Seed `kc-setup-complete=true` (default: false) */
+  setupComplete?: boolean
+}
+
+/**
+ * Seed `localStorage` with an auth token + onboarding/demo flags BEFORE any
+ * page script runs. This is the localStorage-init flavor of auth setup
+ * (see also `setupAuth` for the API-route-mock flavor).
+ *
+ * Uses `page.addInitScript` so the values are present on first script
+ * evaluation — avoiding a flash of the /login route on webkit/Safari where
+ * the auth redirect can fire synchronously (#9096).
+ */
+export async function setupAuthLocalStorage(
+  page: Page,
+  options?: AuthLocalStorageOptions
+): Promise<void> {
+  const opts = {
+    token: options?.token ?? 'test-jwt-token',
+    demoMode: options?.demoMode,
+    demoUserOnboarded: options?.demoUserOnboarded ?? false,
+    onboardingComplete: options?.onboardingComplete ?? false,
+    tourComplete: options?.tourComplete ?? false,
+    setupComplete: options?.setupComplete ?? false,
+  }
+  await page.addInitScript((o: typeof opts) => {
+    localStorage.setItem('token', o.token)
+    if (o.demoMode !== undefined) {
+      localStorage.setItem('kc-demo-mode', String(o.demoMode))
+    }
+    if (o.demoUserOnboarded) {
+      localStorage.setItem('demo-user-onboarded', 'true')
+    }
+    if (o.onboardingComplete) {
+      localStorage.setItem('kc-onboarding-complete', 'true')
+    }
+    if (o.tourComplete) {
+      localStorage.setItem('kc-tour-complete', 'true')
+    }
+    if (o.setupComplete) {
+      localStorage.setItem('kc-setup-complete', 'true')
+    }
+  }, opts)
+}
+
+/** Default clusters returned from a mocked MCP `**\/api/mcp/**` call */
+export const DEFAULT_MCP_CLUSTERS = [
+  { name: 'cluster-1', context: 'ctx-1', healthy: true, nodeCount: 5, podCount: 45 },
+  { name: 'cluster-2', context: 'ctx-2', healthy: true, nodeCount: 3, podCount: 32 },
+]
+
+/** Options for `setupMCP` — override cluster/issue/event/node payloads */
+export interface SetupMCPOptions {
+  clusters?: unknown[]
+  issues?: unknown[]
+  events?: unknown[]
+  nodes?: unknown[]
+}
+
+/**
+ * Mock the generic MCP endpoints (`**\/api/mcp/**`) with a default payload
+ * shape that matches what the dashboard cards expect. Accepts optional
+ * overrides for clusters / issues / events / nodes so specs can tailor the
+ * response without re-implementing the route handler.
+ */
+export async function setupMCP(page: Page, options?: SetupMCPOptions): Promise<void> {
+  const clusters = options?.clusters ?? DEFAULT_MCP_CLUSTERS
+  const issues = options?.issues ?? []
+  const events = options?.events ?? []
+  const nodes = options?.nodes ?? []
+
+  await page.route('**/api/mcp/**', (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        clusters,
+        issues,
+        events,
+        nodes,
+      }),
+    })
+  )
+}
+
+/**
+ * Combined dashboard test setup: auth mock + MCP mock + localStorage seed +
+ * navigation to `/`. Replaces the local `setupDashboardTest` helper that
+ * was defined in Dashboard.spec.ts (#9233).
+ *
+ * Behavior mirrors the original local implementation exactly — it seeds
+ * localStorage BEFORE any page script runs (via addInitScript) so the auth
+ * guard sees the token on first execution (#9096).
+ */
+export async function setupDashboardTest(page: Page): Promise<void> {
+  await setupAuth(page)
+  await setupMCP(page)
+  // Seed localStorage BEFORE any page script runs — page.evaluate() runs
+  // after the page has already parsed and executed scripts, which is too
+  // late for webkit/Safari where the auth redirect fires synchronously.
+  await page.addInitScript(() => {
+    localStorage.setItem('token', 'test-token')
+    localStorage.setItem('demo-user-onboarded', 'true')
+  })
+  await page.goto('/')
+  await page.waitForLoadState('domcontentloaded')
+}

--- a/web/e2e/mission-control-stress.spec.ts
+++ b/web/e2e/mission-control-stress.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect, Page} from '@playwright/test'
+import { setupAuth } from './helpers/setup'
 
 /**
  * Mission Control STRESS Tests
@@ -287,19 +288,6 @@ const MOCK_MCP_RESPONSES: Record<string, unknown> = {
 // Setup helpers
 // ---------------------------------------------------------------------------
 
-async function setupAuth(page: Page) {
-  await page.route('**/api/me', (route) =>
-    route.fulfill({
-      status: 200,
-      contentType: 'application/json',
-      body: JSON.stringify({
-        id: '1', github_id: '12345', github_login: 'stress-tester',
-        email: 'stress@test.com', onboarded: true, role: 'admin',
-      }),
-    })
-  )
-}
-
 async function setupClusterMocks(page: Page, clusters = STRESS_CLUSTERS) {
   await page.route('**/api/mcp/clusters', (route) =>
     route.fulfill({
@@ -369,7 +357,11 @@ async function setupGitHubMocks(page: Page) {
 }
 
 async function setupAllMocks(page: Page) {
-  await setupAuth(page)
+  await setupAuth(page, {
+    github_login: 'stress-tester',
+    email: 'stress@test.com',
+    role: 'admin',
+  })
   await setupClusterMocks(page)
   await setupGitHubMocks(page)
   await setupAgentMocks(page)

--- a/web/e2e/nightly/rce-vector-scan.spec.ts
+++ b/web/e2e/nightly/rce-vector-scan.spec.ts
@@ -2,6 +2,7 @@ import { test, expect, type Page } from '@playwright/test'
 import * as fs from 'fs'
 import * as path from 'path'
 import { fileURLToPath } from 'url'
+import { setupAuthLocalStorage } from '../helpers/setup'
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
 
@@ -123,14 +124,6 @@ function writeReport(report: RCEReport, outDir: string) {
 // Auth & mock setup
 // ---------------------------------------------------------------------------
 
-async function setupAuth(page: Page) {
-  await page.addInitScript(() => {
-    localStorage.setItem('token', 'test-jwt-token')
-    localStorage.setItem('kc-demo-mode', 'true')
-    localStorage.setItem('demo-user-onboarded', 'true')
-  })
-}
-
 async function setupMocks(page: Page) {
   await page.route('**/health', (route) =>
     route.fulfill({ status: 200, contentType: 'application/json', body: '{"status":"ok"}' })
@@ -170,7 +163,10 @@ test('RCE vector scan — all attack surfaces', async ({ page }, testInfo) => {
   // Phase 1: Setup
   // ══════════════════════════════════════════════════════════════════════
   console.log('[RCE] Phase 1: Setup')
-  await setupAuth(page)
+  await setupAuthLocalStorage(page, {
+    demoMode: true,
+    demoUserOnboarded: true,
+  })
   await setupMocks(page)
   await page.goto('/', { waitUntil: 'networkidle', timeout: PAGE_LOAD_TIMEOUT_MS })
 

--- a/web/e2e/perf/all-cards-ttfi.spec.ts
+++ b/web/e2e/perf/all-cards-ttfi.spec.ts
@@ -2,6 +2,7 @@ import { expect, test, type Page } from '@playwright/test'
 import * as fs from 'fs'
 import * as path from 'path'
 import { fileURLToPath } from 'url'
+import { setupAuth } from '../helpers/setup'
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
 
@@ -97,12 +98,6 @@ function getMockRESTData(url: string): Record<string, unknown> {
   const match = url.match(/\/api\/mcp\/([^/?]+)/)
   const endpoint = match?.[1] || ''
   return MOCK_DATA[endpoint] ? { ...MOCK_DATA[endpoint], source: 'mock' } : { items: [], source: 'mock' }
-}
-
-async function setupAuth(page: Page) {
-  await page.route('**/api/me', (route) =>
-    route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(mockUser) })
-  )
 }
 
 async function setupLiveMocks(page: Page) {
@@ -367,7 +362,7 @@ function summarizeMode(cards: CardTTFIMetric[]): string {
 }
 
 async function runMode(page: Page, mode: PerfMode): Promise<CardTTFIMetric[]> {
-  await setupAuth(page)
+  await setupAuth(page, mockUser)
   if (mode.startsWith('live')) {
     await setupLiveMocks(page)
   }


### PR DESCRIPTION
Fixes #9233

## Summary

Extracts the copy-pasted `setupAuth` / `setupDashboardTest` / `setupMCP` patterns from 6 Playwright spec files into the existing shared helper file at `web/e2e/helpers/setup.ts`.

Each replaced function calls through to the shared helper with identical behavior — this is an extraction-only refactor with no behavior changes.

## New shared helpers (in `web/e2e/helpers/setup.ts`)

- `setupAuth(page, user?)` — mocks `/api/me` with a default or overridden mock user (API-route-mock flavor).
- `setupAuthLocalStorage(page, options?)` — seeds localStorage tokens + demo / onboarding / tour / setup flags via `addInitScript` (localStorage-init flavor).
- `setupMCP(page, options?)` — mocks `**/api/mcp/**` with default clusters + empty issues/events/nodes, overridable per-test.
- `setupDashboardTest(page)` — combined auth + MCP + localStorage seed + navigation, used by `Dashboard.spec.ts`.

Two distinct auth flavors are exposed (API-mock vs localStorage-init) because both patterns existed in the codebase and each spec was implicitly relying on one or the other.

## Files touched

- `web/e2e/helpers/setup.ts` — added the shared helpers (+177 LOC)
- `web/e2e/Dashboard.spec.ts` — removed local `setupDashboardTest`, imported from helpers
- `web/e2e/perf/all-cards-ttfi.spec.ts` — removed local `setupAuth`, imported + passed `mockUser`
- `web/e2e/mission-control-stress.spec.ts` — removed local `setupAuth`, imported + passed `stress-tester` user override
- `web/e2e/compliance/security-compliance.spec.ts` — removed local `setupAuth`, imported `setupAuthLocalStorage`
- `web/e2e/compliance/i18n-compliance.spec.ts` — removed local `setupAuth`, imported `setupAuthLocalStorage`
- `web/e2e/nightly/rce-vector-scan.spec.ts` — removed local `setupAuth`, imported `setupAuthLocalStorage`

`mission-control-e2e.spec.ts` is intentionally left alone — it is being handled separately by #9230.

## Test plan

- [ ] CI lint passes
- [ ] CI build passes
- [ ] Existing Playwright specs still pass (behavior is identical — each helper preserves the exact route mock / localStorage payload of its original local copy)