### PR TITLE
🐛 fix(e2e): four hardcoded-values defects across the test suite (Issues 9240, 9241, 9242, 9243)

### DIFF
--- a/web/e2e/compliance/i18n-compliance.spec.ts
+++ b/web/e2e/compliance/i18n-compliance.spec.ts
@@ -193,7 +193,15 @@ test('i18n compliance — internationalization audit', async ({ page }) => {
   console.log('[i18n] Phase 1: Locale file validation')
 
   const localeDir = path.resolve(__dirname, '../../src/locales/en')
-  const localeFiles = ['common.json', 'cards.json', 'status.json', 'errors.json']
+  // Issue 9243: previously this list was hardcoded as
+  // ['common.json', 'cards.json', 'status.json', 'errors.json']. Any new
+  // namespace under src/locales/en/ (e.g., missions.json, ai.json) was
+  // silently ignored — missing-key validation, empty-value checks, and
+  // plural-form checks would not apply. Discover namespaces by scanning
+  // the directory so additions are automatically covered.
+  const localeFiles = fs.readdirSync(localeDir)
+    .filter(f => f.endsWith('.json'))
+    .sort()
 
   let totalKeys = 0
   let emptyValues = 0

--- a/web/e2e/compliance/security-compliance.spec.ts
+++ b/web/e2e/compliance/security-compliance.spec.ts
@@ -35,7 +35,15 @@ interface SecurityReport {
 
 const IS_CI = !!process.env.CI
 const CI_TIMEOUT_MULTIPLIER = 2
-const BASE_URL = process.env.PLAYWRIGHT_BASE_URL || 'http://localhost:5174'
+// Issue 9242: previous fallback was 'http://localhost:5174' (Vite dev
+// server), which diverges from playwright.config.ts:72 which uses
+// 'http://localhost:8080' (the Go backend that serves both API and the
+// built frontend). When the env var was unset, multi-page security
+// checks at lines 707-751 and the auth-bypass check at line 772
+// navigated to the wrong port and silently failed/skipped. Match the
+// project default so explicit-URL navigations work in both
+// configurations.
+const BASE_URL = process.env.PLAYWRIGHT_BASE_URL || 'http://localhost:8080'
 
 // ---------------------------------------------------------------------------
 // Helpers

--- a/web/e2e/user-flows/card-drag-and-reorder.spec.ts
+++ b/web/e2e/user-flows/card-drag-and-reorder.spec.ts
@@ -6,6 +6,7 @@ import {
   NETWORK_IDLE_TIMEOUT_MS,
 } from '../helpers/setup'
 import { assertTouchTargetSize } from '../helpers/ux-assertions'
+import { STORAGE_KEY_MAIN_DASHBOARD_CARDS } from '../../src/lib/constants/storage'
 
 /**
  * Card drag-and-reorder UX tests.
@@ -92,30 +93,37 @@ test.describe('Card Drag and Reorder', () => {
       return
     }
 
-    // Capture current card order from localStorage
-    const orderBefore = await page.evaluate(() => {
-      return localStorage.getItem('kubestellar-card-order')
-        || localStorage.getItem('dashboard-card-order')
-        || localStorage.getItem('card-layout')
-        || null
-    })
+    // Issue 9241: previously this test guessed at three speculative
+    // localStorage keys ('kubestellar-card-order', 'dashboard-card-order',
+    // 'card-layout') — none of which match the canonical key. If all three
+    // missed, orderBefore was null and the test silently passed even when
+    // the app didn't persist card order at all. Use the exported key from
+    // src/lib/constants/storage.ts so a renaming refactor on the source
+    // breaks this test (intended), and so the test actually exercises the
+    // persistence path.
+    const orderBefore = await page.evaluate(
+      (key) => localStorage.getItem(key),
+      STORAGE_KEY_MAIN_DASHBOARD_CARDS,
+    )
+
+    // Persistence is only meaningful if the card-order hook has written
+    // something. Without it, the test would pass vacuously — make the
+    // failure visible instead of silently annotating.
+    expect(
+      orderBefore,
+      `Expected localStorage key "${STORAGE_KEY_MAIN_DASHBOARD_CARDS}" to be populated by ` +
+      `the card-order persistence hook before reload. If the hook stopped writing, this is a regression.`,
+    ).not.toBeNull()
 
     await page.reload()
     await page.waitForLoadState('networkidle', { timeout: NETWORK_IDLE_TIMEOUT_MS }).catch(() => {})
 
-    const orderAfter = await page.evaluate(() => {
-      return localStorage.getItem('kubestellar-card-order')
-        || localStorage.getItem('dashboard-card-order')
-        || localStorage.getItem('card-layout')
-        || null
-    })
+    const orderAfter = await page.evaluate(
+      (key) => localStorage.getItem(key),
+      STORAGE_KEY_MAIN_DASHBOARD_CARDS,
+    )
 
-    // If there is a persisted order, it should survive reload
-    if (orderBefore !== null) {
-      expect(orderAfter).toBe(orderBefore)
-    } else {
-      test.info().annotations.push({ type: 'ux-finding', description: 'No card order found in localStorage — order may not persist' })
-    }
+    expect(orderAfter).toBe(orderBefore)
   })
 
   test('touch targets on drag handles meet 44px minimum', async ({ page }) => {

--- a/web/e2e/user-flows/cluster-investigation.spec.ts
+++ b/web/e2e/user-flows/cluster-investigation.spec.ts
@@ -11,9 +11,13 @@ const DRILLDOWN_TIMEOUT_MS = 5_000
 test.describe('Cluster Investigation — "My cluster has issues"', () => {
   test('clusters page loads within acceptable time', async ({ page }) => {
     await setupDemoAndNavigate(page, '/clusters')
-    // Wait for meaningful content — either a cluster list or the page container
+    // Issue 9240: previously this test only asserted body visibility +
+    // textContent length, ignoring the imported assertLoadTime and the
+    // CLUSTER_LOAD_MAX_MS budget on line 6. A page taking 10s to load
+    // would still pass. Use the existing helper so a perf regression
+    // actually fails the suite.
+    await assertLoadTime(page, 'body', CLUSTER_LOAD_MAX_MS)
     const body = page.locator('body')
-    await expect(body).toBeVisible({ timeout: ELEMENT_VISIBLE_TIMEOUT_MS })
     const content = await body.textContent()
     expect(content?.length).toBeGreaterThan(50)
   })


### PR DESCRIPTION
## Summary

Four `web/e2e/` issues filed by @khushiiagrawal in the same 2026-04-20 batch, all sharing one root cause: a hardcoded value in a test file either diverges from canonical config or is ignored entirely, so a regression the test was meant to catch slips through silently.

## Per-issue changes

| Issue | File | Defect | Fix |
|---|---|---|---|
| **#9240** | `web/e2e/user-flows/cluster-investigation.spec.ts` | Imports `assertLoadTime` and defines `CLUSTER_LOAD_MAX_MS = 3_000`, but never calls the helper. A 10s page load would still pass. | Wire `assertLoadTime(page, 'body', CLUSTER_LOAD_MAX_MS)` after navigation. |
| **#9241** | `web/e2e/user-flows/card-drag-and-reorder.spec.ts` | Reads three speculative localStorage keys (`kubestellar-card-order`, `dashboard-card-order`, `card-layout`); none match canonical `STORAGE_KEY_MAIN_DASHBOARD_CARDS = 'kubestellar-main-dashboard-cards'`. All three miss → `null` → silent pass. | Import the canonical constant; assert non-null before reload. |
| **#9242** | `web/e2e/compliance/security-compliance.spec.ts` | `BASE_URL` fallback `'http://localhost:5174'` (Vite) diverges from `playwright.config.ts:72` default `'http://localhost:8080'` (Go backend). Multi-page security checks navigate to the wrong port without `PLAYWRIGHT_BASE_URL` set. | Match the project default. |
| **#9243** | `web/e2e/compliance/i18n-compliance.spec.ts` | Hardcoded list of 4 locale namespace files; any new namespace silently ignored by missing-key / empty-value / plural-form checks. | `fs.readdirSync(localeDir).filter(f => f.endsWith('.json')).sort()` — proactive against drift. |

## Why bundled

- Same reporter, same batch, same root-cause class
- All 4 files in `web/e2e/`, no overlap risk
- All 4 fixes scoped (no new files, no helper refactors, no test restructuring)
- Closing 4 issues in one PR is cheaper for both reviewers and CI than four separate PRs touching the same dir

## Test plan

- [x] Diff is small (4 files, +52/-24)
- [ ] CI runs Playwright; the new `assertLoadTime` and canonical localStorage assertions will gate

Fixes #9240
Fixes #9241
Fixes #9242
Fixes #9243