### PR TITLE
🌱 test(e2e): add 404 route + onboarding flow specs (Issues 9236, 9238)

### DIFF
--- a/web/e2e/user-flows/not-found.spec.ts
+++ b/web/e2e/user-flows/not-found.spec.ts
@@ -1,0 +1,56 @@
+import { test, expect } from '@playwright/test'
+import {
+  setupDemoMode,
+  setupDemoAndNavigate,
+  ELEMENT_VISIBLE_TIMEOUT_MS,
+  waitForNetworkIdleBestEffort,
+} from '../helpers/setup'
+
+/**
+ * 404 / not-found route coverage.
+ *
+ * Issue 9236: no spec verified that an unmatched route renders meaningful
+ * content (not a blank screen) and exposes an affordance to return home.
+ *
+ * App.tsx line 646 uses `<Route path="*" element={<Navigate to={ROUTES.HOME}
+ * replace />} />` — any unmatched route under the authenticated dashboard
+ * redirects to `/`. These tests assert that behavior end-to-end so a future
+ * refactor to a dedicated 404 page (or a regression that leaves the user
+ * on a blank screen) is caught.
+ */
+
+/** Minimum body text length considered "not blank" */
+const MIN_BODY_TEXT_LENGTH = 50
+
+/** Unique suffix generator base for unmatched route path */
+const UNMATCHED_ROUTE_PREFIX = '/does-not-exist-'
+
+test.describe('404 / not-found route', () => {
+  test('unmatched route renders non-blank content with visible text', async ({ page }) => {
+    await setupDemoMode(page)
+    const unmatched = `${UNMATCHED_ROUTE_PREFIX}${Date.now()}`
+    await page.goto(unmatched)
+    await waitForNetworkIdleBestEffort(page)
+
+    // Body must render actual text — catches a true blank screen regression.
+    const body = page.locator('body')
+    await expect(body).toBeVisible({ timeout: ELEMENT_VISIBLE_TIMEOUT_MS })
+    const content = await body.textContent()
+    expect(content?.length ?? 0).toBeGreaterThan(MIN_BODY_TEXT_LENGTH)
+  })
+
+  test('unmatched route exposes a return-home affordance (sidebar or nav)', async ({ page }) => {
+    await setupDemoAndNavigate(page, `${UNMATCHED_ROUTE_PREFIX}${Date.now()}`)
+
+    // The current app redirects unmatched routes to HOME via <Navigate>, so
+    // the dashboard chrome (sidebar / navbar) should be visible. If a future
+    // change introduces a dedicated 404 page, this test should still pass as
+    // long as SOME navigation affordance back to / is rendered.
+    const sidebarOrNav = page
+      .locator('nav')
+      .or(page.locator('[data-testid*="sidebar"]'))
+      .or(page.getByRole('link', { name: /home|dashboard/i }))
+
+    await expect(sidebarOrNav.first()).toBeVisible({ timeout: ELEMENT_VISIBLE_TIMEOUT_MS })
+  })
+})

--- a/web/e2e/user-flows/onboarding.spec.ts
+++ b/web/e2e/user-flows/onboarding.spec.ts
@@ -1,0 +1,74 @@
+import { test, expect } from '@playwright/test'
+import {
+  setupDemoMode,
+  setupDemoAndNavigate,
+  ELEMENT_VISIBLE_TIMEOUT_MS,
+  NETWORK_IDLE_TIMEOUT_MS,
+} from '../helpers/setup'
+
+/**
+ * Onboarding-flow-after-login coverage.
+ *
+ * Issue 9238: no spec verified the first-time-user experience vs the
+ * returning-user experience. This spec focuses on the localStorage flag
+ * semantics documented in web/src/lib/constants/storage.ts:
+ *   - demo-user-onboarded (STORAGE_KEY_ONBOARDED)
+ *   - kubestellar-console-tour-completed (STORAGE_KEY_TOUR_COMPLETED)
+ *
+ * The existing onboarding-tour.spec.ts covers the tour tooltip / Skip /
+ * Next interactions. This spec complements it by verifying the page-level
+ * post-login state for first-time vs returning users.
+ */
+
+/** Tour completion localStorage key (mirrors STORAGE_KEY_TOUR_COMPLETED) */
+const TOUR_COMPLETED_KEY = 'kubestellar-console-tour-completed'
+
+/** Demo-user onboarded localStorage key (mirrors STORAGE_KEY_ONBOARDED) */
+const ONBOARDED_KEY = 'demo-user-onboarded'
+
+/** Timeout for tour tooltip / prompt appearance check */
+const TOUR_TOOLTIP_TIMEOUT_MS = 5_000
+
+/** Minimum body text length considered "dashboard rendered" */
+const MIN_BODY_TEXT_LENGTH = 50
+
+test.describe('Onboarding flow after login', () => {
+  test('first-time user has tour-completed cleared and dashboard renders', async ({ page }) => {
+    // Seed demo auth but explicitly clear the tour + onboarded flags so the
+    // app sees a fresh user. The tour is opt-in (started from Settings), so
+    // we assert the observable side of "first-time": dashboard loads AND
+    // the tour-completed flag is NOT set afterwards.
+    await setupDemoMode(page)
+    await page.addInitScript((keys) => {
+      localStorage.removeItem(keys.tour)
+      localStorage.removeItem(keys.onboarded)
+    }, { tour: TOUR_COMPLETED_KEY, onboarded: ONBOARDED_KEY })
+
+    await page.goto('/')
+    await page.waitForLoadState('networkidle', { timeout: NETWORK_IDLE_TIMEOUT_MS }).catch(() => {})
+
+    const body = page.locator('body')
+    await expect(body).toBeVisible({ timeout: ELEMENT_VISIBLE_TIMEOUT_MS })
+    const content = await body.textContent()
+    expect(content?.length ?? 0).toBeGreaterThan(MIN_BODY_TEXT_LENGTH)
+
+    // Tour must not be marked complete for a first-time user.
+    const tourFlag = await page.evaluate((key) => localStorage.getItem(key), TOUR_COMPLETED_KEY)
+    expect(tourFlag).not.toBe('true')
+  })
+
+  test('returning user (tour-completed=true) does not see tour overlay', async ({ page }) => {
+    // Returning users: tour dismissed previously. setupDemoAndNavigate sets
+    // demo-user-onboarded=true, and we also seed tour-completed=true.
+    await page.addInitScript((key) => {
+      localStorage.setItem(key, 'true')
+    }, TOUR_COMPLETED_KEY)
+    await setupDemoAndNavigate(page, '/')
+
+    // Tour overlay selectors mirror onboarding-tour.spec.ts so the matcher
+    // stays in sync with the Tour component's rendered DOM.
+    const tourOverlay = page.locator('[class*="tour"], [class*="joyride"], [class*="onboarding"]')
+    const hasTour = await tourOverlay.first().isVisible({ timeout: TOUR_TOOLTIP_TIMEOUT_MS }).catch(() => false)
+    expect(hasTour, 'Tour must not render for returning users with tour-completed=true').toBe(false)
+  })
+})


### PR DESCRIPTION
## Summary

Adds two new E2E spec files to close coverage gaps filed by @khushiiagrawal on 2026-04-20.

| Issue | New spec file | What it covers |
| --- | --- | --- |
| #9236 | `web/e2e/user-flows/not-found.spec.ts` | Navigates to `/does-not-exist-<timestamp>` and asserts (a) the page is non-blank and (b) a sidebar/nav affordance back to home is visible. Catches a blank-screen regression or a future refactor that strands the user. |
| #9238 | `web/e2e/user-flows/onboarding.spec.ts` | First-time path: clears `kubestellar-console-tour-completed` + `demo-user-onboarded`, verifies dashboard renders and tour-completed flag stays unset. Returning path: seeds `kubestellar-console-tour-completed=true` and verifies the tour overlay does NOT render. |

Both files are NEW — no existing specs were modified.

### Context

- `App.tsx` line 646 uses `<Route path="*" element={<Navigate to={ROUTES.HOME} replace />} />` so unmatched authenticated routes redirect to `/`. The 404 spec asserts that behavior so a regression that leaves the user on a blank screen (or a future refactor to a dedicated 404 page that forgets a home link) is caught.
- The existing `onboarding-tour.spec.ts` covers tooltip / Skip / Next interactions. The new `onboarding.spec.ts` complements it by covering the page-level post-login state for first-time vs returning users, which was not previously tested.
- Both files follow the established `setupDemoMode` / `setupDemoAndNavigate` pattern from `web/e2e/helpers/setup.ts`, use named constants for all numeric literals, and reuse the tour-selector style from `onboarding-tour.spec.ts`.

## Test plan

- [ ] CI build passes
- [ ] CI lint passes
- [ ] Playwright suite picks up both new specs under `web/e2e/user-flows/`

Fixes #9236
Fixes #9238