### PR TITLE
security: scope copilot-automation.yml token permissions to read-all + job-level

### DIFF
--- a/.github/workflows/copilot-automation.yml
+++ b/.github/workflows/copilot-automation.yml
@@ -10,11 +10,7 @@ on:
   pull_request_target:
     types: [opened, synchronize, ready_for_review]
 
-permissions:
-  contents: write
-  pull-requests: write
-  issues: write
-  statuses: write
+permissions: read-all
 
 concurrency:
   group: copilot-automation-${{ github.event.pull_request.number || github.event.inputs.pr_number || github.sha }}
@@ -22,6 +18,11 @@ concurrency:
 
 jobs:
   copilot-automation:
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+      statuses: write
     uses: kubestellar/infra/.github/workflows/reusable-copilot-automation.yml@main
     with:
       pr_number: ${{ github.event.inputs.pr_number || '' }}


### PR DESCRIPTION
## Summary

Fixes 2 CodeQL `TokenPermissionsID` high-severity alerts in `copilot-automation.yml`.

**Before**: top-level permissions `contents: write, pull-requests: write, issues: write, statuses: write` — overly broad default that grants write access to all jobs.

**After**: `permissions: read-all` at top level, write permissions scoped to the single job that calls the reusable workflow.

This follows the [OpenSSF Scorecard recommendation](https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions): restrict permissions at the workflow level, escalate only at the job level.

## Alerts resolved
- https://github.com/kubestellar/console/security/code-scanning/438
- https://github.com/kubestellar/console/security/code-scanning/439

## Also dismissed (false positives)
10 additional `TokenPermissionsID` alerts were dismissed via the API as false positives — those workflows already have `read-all` at the top level with only minimum job-level write permissions (the recommended pattern).