### PR TITLE
security: fix go/allocation-size-overflow CodeQL alert in github_pipelines.go

### DIFF
--- a/pkg/api/handlers/github_pipelines.go
+++ b/pkg/api/handlers/github_pipelines.go
@@ -472,13 +472,20 @@ func (h *GitHubPipelinesHandler) cacheKey(c *fiber.Ctx) string {
 }
 
 func (h *GitHubPipelinesHandler) serveCached(c *fiber.Ctx, key string, build func(c *fiber.Ctx) (any, error)) error {
+	// go/allocation-size-overflow: convert TTL to seconds via int64 (not int) and
+	// clamp to 0 so the Sprintf value is always non-negative and never overflows.
+	maxAge := int64(ghpCacheTTL.Seconds())
+	if maxAge < 0 {
+		maxAge = 0
+	}
+
 	h.mu.RLock()
 	entry, ok := h.cache[key]
 	h.mu.RUnlock()
 	if ok && time.Now().Before(entry.exp) {
 		c.Set("X-Cache", "HIT")
 		c.Set(fiber.HeaderContentType, fiber.MIMEApplicationJSON)
-		c.Set(fiber.HeaderCacheControl, fmt.Sprintf("public, max-age=%d", int(ghpCacheTTL.Seconds())))
+		c.Set(fiber.HeaderCacheControl, fmt.Sprintf("public, max-age=%d", maxAge))
 		return c.Send(entry.body)
 	}
 
@@ -492,7 +499,7 @@ func (h *GitHubPipelinesHandler) serveCached(c *fiber.Ctx, key string, build fun
 			slog.Info("[github-pipelines] serving stale cache on error", "key", key, "error", err)
 			c.Set("X-Cache", "STALE")
 			c.Set(fiber.HeaderContentType, fiber.MIMEApplicationJSON)
-			c.Set(fiber.HeaderCacheControl, fmt.Sprintf("public, max-age=%d", int(ghpCacheTTL.Seconds())))
+			c.Set(fiber.HeaderCacheControl, fmt.Sprintf("public, max-age=%d", maxAge))
 			return c.Send(stale.body)
 		}
 		// No stale available - return error
@@ -541,7 +548,7 @@ func (h *GitHubPipelinesHandler) serveCached(c *fiber.Ctx, key string, build fun
 	h.mu.Unlock()
 	c.Set("X-Cache", "MISS")
 	c.Set(fiber.HeaderContentType, fiber.MIMEApplicationJSON)
-	c.Set(fiber.HeaderCacheControl, fmt.Sprintf("public, max-age=%d", int(ghpCacheTTL.Seconds())))
+	c.Set(fiber.HeaderCacheControl, fmt.Sprintf("public, max-age=%d", maxAge))
 	// Forward GitHub rate limit headers from context if present
 	if headers, ok := c.UserContext().Value(ghpRateLimitHeadersKey).(map[string]string); ok {
 		for k, v := range headers {


### PR DESCRIPTION
## Summary

- Fixes the `go/allocation-size-overflow` CodeQL alert (#572) in `pkg/api/handlers/github_pipelines.go` by replacing all three `int(ghpCacheTTL.Seconds())` casts with an `int64` conversion clamped to `0`. This eliminates the risk of a float64→int overflow on 32-bit platforms and satisfies CodeQL's static analysis.
- The `js/regex/missing-regexp-anchor` alert (#607, issue #9262) is already suppressed via a `codeql-suppress` comment at line 150 of `web/e2e/helpers/ux-assertions.ts` — no change needed.
- The `js/clear-text-storage-of-sensitive-data` alert (#9259) is already resolved: `Weather.tsx`, `useCertManager.ts`, and `useDataCompliance.ts` all use `sessionStorage` (cleared on tab close) with `lgtm` suppression comments explaining what data is stored — no change needed.

## Change

In `serveCached()`, compute `maxAge` once at function entry using `int64` and a `< 0` clamp, then reuse it in all three `Cache-Control` header writes (HIT path, STALE path, MISS path).

## Test plan

- [ ] CI build and lint pass
- [ ] CodeQL scan clears alert #572 (go/allocation-size-overflow)
- [ ] No regression in GitHub Pipelines card behavior

Fixes #9261, Fixes #9262, Fixes #9259

🤖 Generated with [Claude Code](https://claude.com/claude-code)