### PR TITLE
🐛 fix(e2e): assert measured values in perf + RCE-scan tests (Issues 9232, 9235)

### DIFF
--- a/web/e2e/nightly/rce-vector-scan.spec.ts
+++ b/web/e2e/nightly/rce-vector-scan.spec.ts
@@ -571,9 +571,47 @@ test('RCE vector scan — all attack surfaces', async ({ page }, testInfo) => {
     contentType: 'application/json',
   })
 
-  // FAIL the test if any CRITICAL checks failed
+  // ── Issue 9235: fail the test on ANY security finding ────────────────
+  //
+  // Before this block, only `summary.criticalFails` was asserted. A `fail`
+  // at `high`/`medium`/`low` severity (e.g. an IFrame with no sandbox, an
+  // inline event handler, token exposure in a data-* attribute) was written
+  // to `rce-vector-report.md` and `rce-vector-report.json` as a PASS — the
+  // report recorded the defect, but the Playwright run still exited 0, so
+  // the nightly job went green and nobody looked at the report.
+  //
+  // We assert three separate budgets so the failure message pinpoints the
+  // severity bucket that regressed:
+  //   - criticalFails MUST be 0 (e.g. javascript: URIs, CSP bypass, path traversal)
+  //   - highFails     MUST be 0 (e.g. inline scripts, token in DOM, external WS)
+  //   - medium/low    counted in the aggregate `fail` budget below
+  //
+  // The aggregate `fail` budget catches low-severity findings too, so even
+  // a lone medium fail exits non-zero and surfaces in CI logs.
+  const TOTAL_FAIL_BUDGET = 0
+  const CRITICAL_FAIL_BUDGET = 0
+  const HIGH_FAIL_BUDGET = 0
+
   expect(
     summary.criticalFails,
     `${summary.criticalFails} CRITICAL security check(s) failed — see rce-vector-report.md`
-  ).toBe(0)
+  ).toBe(CRITICAL_FAIL_BUDGET)
+
+  expect(
+    summary.highFails,
+    `${summary.highFails} HIGH-severity security check(s) failed — see rce-vector-report.md`
+  ).toBe(HIGH_FAIL_BUDGET)
+
+  // Aggregate sweep: catches medium/low fails that aren't covered by the
+  // two severity-specific assertions above. Listing the failing check names
+  // in the message saves the developer a round-trip to the artifact.
+  if (summary.fail > 0) {
+    const failingChecks = checks
+      .filter((c) => c.status === 'fail')
+      .map((c) => `[${c.severity}] ${c.phase}: ${c.name} — ${c.details}`)
+    expect(
+      summary.fail,
+      `${summary.fail} security check(s) failed:\n${failingChecks.join('\n')}`
+    ).toBe(TOTAL_FAIL_BUDGET)
+  }
 })

--- a/web/e2e/perf/all-cards-ttfi.spec.ts
+++ b/web/e2e/perf/all-cards-ttfi.spec.ts
@@ -10,6 +10,35 @@ type PerfMode = 'live-cold' | 'live-warm' | 'demo-cold' | 'demo-warm'
 type DataSource = 'cache' | 'stream' | 'network' | 'demo'
 type Status = 'ok' | 'timeout' | 'error'
 
+// Issue 9232: this spec used to measure TTFI, timeouts, and p95 per mode, write
+// them to ttfi-report.json, and return without asserting anything. A shared
+// `compare-ttfi.mjs` script existed but was only invoked from two of the three
+// CI workflows that run this spec (and even then one wrapped it in `|| true`),
+// so regressions to TTFI silently passed every time the spec ran standalone.
+// The block below wires the same budgets that `compare-ttfi.mjs` uses —
+// `baseline/ttfi-baseline.json` — directly into the test's `afterAll`, so a
+// per-card TTFI, p95, or timeout-count breach fails the Playwright run
+// regardless of which workflow invoked it.
+const TTFI_BASELINE_PATH = path.resolve(__dirname, 'baseline/ttfi-baseline.json')
+// Percent tolerance applied on top of the baseline budgets. Mirrors the
+// `CI_TOLERANCE_PCT` env var consumed by compare-ttfi.mjs so both the in-test
+// gate and the post-test workflow gate agree. Default 0 matches the script's
+// default; the perf-ttfi.yml workflow sets it to 15 to absorb CI-runner noise.
+const TTFI_DEFAULT_TOLERANCE_PCT = 0
+const TTFI_IN_TEST_TOLERANCE_PCT = Number(
+  process.env.CI_TOLERANCE_PCT || String(TTFI_DEFAULT_TOLERANCE_PCT)
+)
+const TTFI_TOLERANCE_FACTOR = 1 + TTFI_IN_TEST_TOLERANCE_PCT / 100
+
+interface TTFIModeBudget {
+  max_ttfi_ms: number
+  max_p95_ms: number
+  max_timeout_count: number
+}
+interface TTFIBaseline {
+  budgets: Partial<Record<PerfMode, TTFIModeBudget>>
+}
+
 interface ManifestItem {
   cardType: string
   cardId: string
@@ -451,4 +480,71 @@ test.afterAll(async () => {
 
   fs.writeFileSync(path.join(outDir, 'ttfi-report.json'), JSON.stringify(report, null, 2))
   fs.writeFileSync(path.join(outDir, 'ttfi-summary.md'), `${summaryLines.join('\n')}\n`)
+
+  // ── Issue 9232: in-test TTFI budget assertions ───────────────────────────
+  // Use try/catch for atomic read (avoids existsSync → readFileSync TOCTOU).
+  let baselineContent: string | null = null
+  try {
+    baselineContent = fs.readFileSync(TTFI_BASELINE_PATH, 'utf-8')
+  } catch {
+    // Baseline intentionally absent — skip the gate rather than fail. The spec
+    // is still useful as a reporting tool in that case; CI will regenerate
+    // the baseline on the next run.
+    console.log(`[TTFI] baseline missing at ${TTFI_BASELINE_PATH} — skipping in-test budget assertion`)
+    return
+  }
+
+  const baseline = JSON.parse(baselineContent) as TTFIBaseline
+  const failures: string[] = []
+
+  // Percentile index — compare-ttfi.mjs uses the 95th percentile for p95.
+  const P95_PERCENTILE = 0.95
+
+  for (const mode of ['live-cold', 'live-warm', 'demo-cold', 'demo-warm'] as const) {
+    const modeCards = byMode.get(mode) || []
+    if (modeCards.length === 0) continue // mode was skipped (e.g. live modes in CI)
+    const budget = baseline.budgets?.[mode]
+    if (!budget) {
+      failures.push(`${mode}: missing budget in ttfi-baseline.json`)
+      continue
+    }
+
+    const okCards = modeCards.filter((c) => c.status === 'ok')
+    const timeoutCards = modeCards.filter((c) => c.status === 'timeout')
+    const values = okCards.map((c) => c.ttfi_ms).sort((a, b) => a - b)
+    const p95 = values.length
+      ? values[Math.max(0, Math.ceil(values.length * P95_PERCENTILE) - 1)]
+      : -1
+
+    const effectiveP95 = Math.round(budget.max_p95_ms * TTFI_TOLERANCE_FACTOR)
+    const effectiveTtfi = Math.round(budget.max_ttfi_ms * TTFI_TOLERANCE_FACTOR)
+
+    if (timeoutCards.length > budget.max_timeout_count) {
+      failures.push(
+        `${mode}: timeout count ${timeoutCards.length} > budget ${budget.max_timeout_count}`
+      )
+    }
+    if (p95 > effectiveP95) {
+      failures.push(`${mode}: p95 ${p95}ms > budget ${effectiveP95}ms`)
+    }
+    for (const card of okCards) {
+      if (card.ttfi_ms > effectiveTtfi) {
+        failures.push(
+          `${mode}:${card.cardType} ttfi ${card.ttfi_ms}ms > max ${effectiveTtfi}ms`
+        )
+      }
+    }
+  }
+
+  // Cap the failure message length — a perf regression can produce hundreds
+  // of over-budget cards and the full list drowns out the actual signal.
+  const MAX_FAILURES_IN_MESSAGE = 20
+  const displayed = failures.slice(0, MAX_FAILURES_IN_MESSAGE)
+  const suffix = failures.length > MAX_FAILURES_IN_MESSAGE
+    ? `\n…and ${failures.length - MAX_FAILURES_IN_MESSAGE} more (see ttfi-report.json)`
+    : ''
+  expect(
+    failures.length,
+    `TTFI budget breached (${failures.length} failure(s)):\n${displayed.join('\n')}${suffix}`
+  ).toBe(0)
 })

--- a/web/e2e/perf/dashboard-nav.spec.ts
+++ b/web/e2e/perf/dashboard-nav.spec.ts
@@ -921,18 +921,59 @@ test.afterAll(async () => {
   fs.writeFileSync(path.join(outDir, 'nav-summary.md'), lines.join('\n'))
   console.log(lines.join('\n'))
 
-  // ── Navigation threshold assertions ───────────────────────────────────
-  const warmMetrics = navReport.metrics.filter(
-    (m) => m.scenario === 'warm-nav' && m.cardsFound > 0 && m.totalMs > 0
-  )
-  if (warmMetrics.length > 0) {
-    const avgWarmTotal = Math.round(
-      warmMetrics.reduce((s, m) => s + m.totalMs, 0) / warmMetrics.length
-    )
-    console.log(`[Nav] warm-nav avg total: ${avgWarmTotal}ms (threshold: 3000ms)`)
-    expect(
-      avgWarmTotal,
-      `warm-nav avg total ${avgWarmTotal}ms exceeds 3000ms threshold`
-    ).toBeLessThan(3000)
+  // ── Issue 9232: per-scenario navigation threshold assertions ──────────
+  //
+  // Before this block, every scenario except `warm-nav` measured timings
+  // and wrote them to `nav-report.json` / `nav-summary.md` without ever
+  // asserting against a budget. A dashboard navigation that regressed from
+  // 500ms to 4s (the exact example in Issue 9232) would pass.
+  //
+  // The per-scenario budgets below are sized from observed ranges in the
+  // generated `nav-summary.md`:
+  //   - cold-nav:     first visit, must fetch chunks + render
+  //   - warm-nav:     chunks cached, already <2s in practice
+  //   - from-main:    pre-warmed; measures just the transition cost
+  //   - from-clusters: pre-warmed; measures just the transition cost
+  //   - rapid-nav:    user clicks faster than the app; only the final
+  //                   nav is measured end-to-end, so budget matches warm-nav
+  //   - back-nav:     router `goBack()` + cached cards — should be fastest
+  //
+  // Each budget intentionally leaves ~30-50% headroom over the observed
+  // mean so legitimate growth (new cards, websocket events) doesn't flap
+  // CI, while the kind of regression Issue 9232 calls out ("TTFI going
+  // from 500ms to 3000ms") gets caught.
+  const COLD_NAV_AVG_MS_BUDGET = 5_000
+  const WARM_NAV_AVG_MS_BUDGET = 3_000
+  const FROM_MAIN_AVG_MS_BUDGET = 4_000
+  const FROM_CLUSTERS_AVG_MS_BUDGET = 4_000
+  const RAPID_NAV_AVG_MS_BUDGET = 3_000
+  const BACK_NAV_AVG_MS_BUDGET = 3_000
+
+  const SCENARIO_BUDGETS: Record<Scenario, number> = {
+    'cold-nav': COLD_NAV_AVG_MS_BUDGET,
+    'warm-nav': WARM_NAV_AVG_MS_BUDGET,
+    'from-main': FROM_MAIN_AVG_MS_BUDGET,
+    'from-clusters': FROM_CLUSTERS_AVG_MS_BUDGET,
+    'rapid-nav': RAPID_NAV_AVG_MS_BUDGET,
+    'back-nav': BACK_NAV_AVG_MS_BUDGET,
   }
+
+  const scenarioFailures: string[] = []
+  for (const scenario of Object.keys(SCENARIO_BUDGETS) as Scenario[]) {
+    const metrics = navReport.metrics.filter(
+      (m) => m.scenario === scenario && m.cardsFound > 0 && m.totalMs > 0
+    )
+    if (metrics.length === 0) continue
+    const avg = Math.round(metrics.reduce((s, m) => s + m.totalMs, 0) / metrics.length)
+    const budget = SCENARIO_BUDGETS[scenario]
+    console.log(`[Nav] ${scenario} avg total: ${avg}ms (budget: ${budget}ms, n=${metrics.length})`)
+    if (avg >= budget) {
+      scenarioFailures.push(`${scenario} avg total ${avg}ms >= ${budget}ms budget (n=${metrics.length})`)
+    }
+  }
+
+  expect(
+    scenarioFailures.length,
+    `Navigation-scenario avg budgets breached:\n${scenarioFailures.join('\n')}`
+  ).toBe(0)
 })


### PR DESCRIPTION
## Summary

Two `web/e2e/` issues filed by @khushiiagrawal in the same 2026-04-20 batch, sharing one root cause: a test runs, measures data, and writes it to a report file — but never actually asserts against the measured value, so regressions the test was meant to catch exit 0 silently. Same defect class that PR #9252 fixed for Issues 9240/9241/9242/9243.

## Per-issue changes

| Issue | File | Defect | Fix |
|---|---|---|---|
| **#9232** | `web/e2e/perf/all-cards-ttfi.spec.ts` | Measures per-card TTFI for 4 modes, writes `ttfi-report.json`, asserts only that `seenTypes.size === expectedTypes.size` (card-type rendering, not perf). A `compare-ttfi.mjs` script exists with the right budgets in `baseline/ttfi-baseline.json`, but only two of three workflows run it and one wraps it in `\|\| true`. | Load the same `baseline/ttfi-baseline.json` and assert `timeout count`, `p95`, and per-card `ttfi_ms` against the per-mode budgets in `afterAll`. Honour the same `CI_TOLERANCE_PCT` env var `compare-ttfi.mjs` uses so the in-test and post-test gates agree. |
| **#9232** | `web/e2e/perf/dashboard-nav.spec.ts` | Six scenarios are measured (`cold-nav`, `warm-nav`, `from-main`, `from-clusters`, `rapid-nav`, `back-nav`). Only `warm-nav` has an assertion — the other five write to `nav-report.json` and return. A dashboard navigation regressing from 500ms to 4s in any non-warm scenario passes. | Add per-scenario avg-total budgets (`COLD_NAV_AVG_MS_BUDGET` etc.), loop over all six scenarios, collect failures, and assert `failures.length === 0` in `afterAll`. Named constants throughout; comment explains how each budget was sized. |
| **#9235** | `web/e2e/nightly/rce-vector-scan.spec.ts` | Asserts only `summary.criticalFails === 0`. A `fail`-status check at `high`/`medium`/`low` severity (e.g. IFrame missing sandbox, inline event handler, token in data-* attr) is recorded in `rce-vector-report.md` and `rce-vector-report.json` but still exits 0 — the nightly goes green. | Add two more assertions: `summary.highFails === 0` and aggregate `summary.fail === 0` (with the failing check names appended to the message so developers don't have to open the artifact). Preserves the existing report-writing path unchanged. |

### Verified already asserting (no change needed)

| File | Existing assertion |
|---|---|
| `web/e2e/perf/dashboard-perf.spec.ts` | Per-mode first-card threshold (demo 3s, live 5s, live+cache 2s) + 20% baseline regression gate (max 5 regressions). |
| `web/e2e/perf/react-commits.spec.ts` | `expect(count).toBeLessThanOrEqual(PERF_BUDGET_NAVIGATION_COMMITS)` at end of test. |
| `web/e2e/perf/react-commits-idle.spec.ts` | `expect(rate).toBeLessThanOrEqual(PERF_BUDGET_IDLE_COMMITS_PER_SEC)` at end of test. |

## Why bundled

- Same reporter, same batch, same root-cause class (measure-but-don't-assert)
- Both files in `web/e2e/`, no overlap risk
- Both fixes scoped (no new helper files, no test restructuring, reuses existing budget files)
- Closing 2 issues in one PR is cheaper for reviewers and CI than two separate PRs touching the same dir

## Test plan

- [x] Diff is small (3 files, +189/-14)
- [x] DCO signed
- [x] All numeric literals named constants with rationale comments
- [x] Source-code comments use `Issue 9232` / `Issue 9235` phrasing (avoids `ui-ux-standard` hex-ratchet false positives)
- [ ] CI runs Playwright perf and nightly suites; the new in-test assertions will gate

Fixes #9232
Fixes #9235