### PR TITLE
security: override follow-redirects to fix GHSA-r4q5-vmmm-2653

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -5441,9 +5441,9 @@
       "license": "ISC"
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.11",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
-      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
       "dev": true,
       "funding": [
         {

--- a/web/package.json
+++ b/web/package.json
@@ -140,6 +140,7 @@
     "@react-three/drei": {
       "three-mesh-bvh": "^0.8.0"
     },
-    "minimatch": "^10.2.1"
+    "minimatch": "^10.2.1",
+    "follow-redirects": "^1.15.12"
   }
 }


### PR DESCRIPTION
## Summary

Adds an npm `overrides` entry to pin `follow-redirects` to `^1.15.12`, resolving GHSA-r4q5-vmmm-2653.

**Vulnerability**: `follow-redirects <=1.15.11` leaks Custom Authentication Headers to cross-domain redirect targets when a redirect occurs between origins.

**Dependency chain**: `wait-on → axios → follow-redirects`

**Fix**: npm `overrides` forces the resolved version to `^1.15.12` (latest: 1.16.0) regardless of what `axios` specifies as its range. No direct dependency changes.

```
Before: follow-redirects@1.15.11 — 1 moderate vulnerability
After:  follow-redirects@1.16.0  — 0 vulnerabilities
```

Resolves CodeQL `VulnerabilitiesID` alert:
- https://github.com/kubestellar/console/security/code-scanning/16