### PR TITLE
security: pin unpinned commands to fix PinnedDependenciesID alerts

### DIFF
--- a/.github/workflows/console-app-roundtrip.yml
+++ b/.github/workflows/console-app-roundtrip.yml
@@ -49,7 +49,7 @@ jobs:
           python-version: "3.12"
 
       - name: Install pyjwt
-        run: pip install --quiet pyjwt cryptography
+        run: pip install --quiet pyjwt==2.12.1 cryptography==46.0.7
 
       # The App installation has issues:write (apply existing labels) but
       # cannot CREATE a missing label — that requires broader repo scopes
@@ -117,11 +117,12 @@ jobs:
           )
 
           # 2. Exchange for installation token
-          TOKEN=$(curl -sS -X POST \
+          curl -sS -X POST \
             -H "Authorization: Bearer $JWT" \
             -H "Accept: application/vnd.github+json" \
             "https://api.github.com/app/installations/$INSTALLATION_ID/access_tokens" \
-            | python3 -c "import sys,json; print(json.load(sys.stdin)['token'])")
+            -o /tmp/app-install-token.json
+          TOKEN=$(python3 -c "import json; print(json.load(open('/tmp/app-install-token.json'))['token'])")
 
           if [ -z "$TOKEN" ] || [ "$TOKEN" = "null" ]; then
             echo "::error::Failed to obtain installation token"

--- a/.github/workflows/console-app-smoke.yml
+++ b/.github/workflows/console-app-smoke.yml
@@ -44,7 +44,7 @@ jobs:
           python-version: "3.12"
 
       - name: Install pyjwt (for signing App JWT)
-        run: pip install --quiet pyjwt cryptography
+        run: pip install --quiet pyjwt==2.12.1 cryptography==46.0.7
 
       - name: Mint App JWT and exchange for installation token
         env:

--- a/.github/workflows/ga4-error-monitor.yml
+++ b/.github/workflows/ga4-error-monitor.yml
@@ -54,7 +54,7 @@ jobs:
           node-version: '22'
 
       - name: Install googleapis
-        run: npm install googleapis@144
+        run: npm install --ignore-scripts googleapis@144.0.0
 
       - name: Query GA4 and create issues
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8

--- a/.github/workflows/ga4-mobile-monitor.yml
+++ b/.github/workflows/ga4-mobile-monitor.yml
@@ -65,7 +65,7 @@ jobs:
           node-version: '22'
 
       - name: Install googleapis
-        run: npm install googleapis@144
+        run: npm install --ignore-scripts googleapis@144.0.0
 
       - name: Check mobile traffic health
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8

--- a/.github/workflows/nil-safety.yml
+++ b/.github/workflows/nil-safety.yml
@@ -45,7 +45,7 @@ jobs:
           go-version: ${{ env.GO_VERSION }}
 
       - name: Install nilaway
-        run: go install go.uber.org/nilaway/cmd/nilaway@latest
+        run: go install go.uber.org/nilaway/cmd/nilaway@v0.0.0-20260318203545-ad240b12fb4c
 
       - name: Install build dependencies
         run: sudo apt-get install -y -qq gcc musl-tools > /dev/null 2>&1
@@ -134,7 +134,7 @@ jobs:
           go-version: ${{ env.GO_VERSION }}
 
       - name: Install nilaway
-        run: go install go.uber.org/nilaway/cmd/nilaway@latest
+        run: go install go.uber.org/nilaway/cmd/nilaway@v0.0.0-20260318203545-ad240b12fb4c
 
       - name: Install build dependencies
         run: sudo apt-get install -y -qq gcc musl-tools > /dev/null 2>&1

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build stage - Backend
-FROM golang:1.25-alpine AS backend-builder
+FROM golang:1.25-alpine@sha256:5caaf1cca9dc351e13deafbc3879fd4754801acba8653fa9540cea125d01a71f AS backend-builder
 
 WORKDIR /app
 
@@ -18,7 +18,7 @@ ARG TARGETARCH
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=${TARGETARCH} go build -ldflags="-s -w -X github.com/kubestellar/console/pkg/api.Version=${APP_VERSION}" -o console ./cmd/console
 
 # Build stage - Frontend
-FROM node:22-alpine AS frontend-builder
+FROM node:22-alpine@sha256:8ea2348b068a9544dae7317b4f3aafcdc032df1647bb7d768a05a5cad1a7683f AS frontend-builder
 
 WORKDIR /app
 
@@ -39,7 +39,7 @@ ENV VITE_COMMIT_HASH=${COMMIT_HASH}
 RUN npm run build
 
 # Final stage
-FROM alpine:3.20
+FROM alpine:3.20@sha256:d9e853e87e55526f6b2917df91a2115c36dd7c696a35be12163d44e6e2a4b6bc
 
 WORKDIR /app
 

--- a/scripts/dependency-audit-test.sh
+++ b/scripts/dependency-audit-test.sh
@@ -131,7 +131,7 @@ echo -e "${BOLD}Phase 2: govulncheck (Go backend)${NC}"
 if command -v go &>/dev/null; then
   if ! command -v govulncheck &>/dev/null; then
     echo -e "  ${DIM}Installing govulncheck...${NC}"
-    go install golang.org/x/vuln/cmd/govulncheck@latest 2>/dev/null
+    go install golang.org/x/vuln/cmd/govulncheck@v1.2.0 2>/dev/null
   fi
 
   if command -v govulncheck &>/dev/null; then

--- a/scripts/gosec-test.sh
+++ b/scripts/gosec-test.sh
@@ -52,7 +52,7 @@ fi
 
 if ! command -v gosec &>/dev/null; then
   echo -e "${YELLOW}Installing gosec...${NC}"
-  go install github.com/securego/gosec/v2/cmd/gosec@latest
+  go install github.com/securego/gosec/v2/cmd/gosec@v2.25.0
 fi
 
 # ============================================================================

--- a/scripts/secret-scan-test.sh
+++ b/scripts/secret-scan-test.sh
@@ -57,7 +57,7 @@ if ! command -v gitleaks &>/dev/null; then
   if command -v brew &>/dev/null; then
     brew install gitleaks
   elif command -v go &>/dev/null; then
-    go install github.com/gitleaks/gitleaks/v8@latest
+    go install github.com/gitleaks/gitleaks/v8@v8.30.1
     # go install places binaries in GOPATH/bin which may not be on PATH
     export PATH="$(go env GOPATH)/bin:$PATH"
   else

--- a/scripts/ts-sast-test.sh
+++ b/scripts/ts-sast-test.sh
@@ -59,7 +59,7 @@ if ! command -v semgrep &>/dev/null; then
   if command -v brew &>/dev/null; then
     brew install semgrep 2>/dev/null
   elif command -v pip3 &>/dev/null; then
-    pip3 install semgrep 2>/dev/null
+    pip3 install semgrep==1.160.0 2>/dev/null
   else
     echo -e "${RED}ERROR: Cannot install semgrep — install manually: brew install semgrep${NC}"
     exit 1


### PR DESCRIPTION
## Summary

Fixes 14 `PinnedDependenciesID` (medium severity) Scorecard alerts across Dockerfile, CI workflows, and test scripts by pinning all unpinned dependency install commands to specific versions.

### Changes

**Dockerfile (3 alerts)** — pin base images to SHA digests:
- `golang:1.25-alpine` → `@sha256:5caaf1cca9dc351e13deafbc3879fd4754801acba8653fa9540cea125d01a71f`
- `node:22-alpine` → `@sha256:8ea2348b068a9544dae7317b4f3aafcdc032df1647bb7d768a05a5cad1a7683f`
- `alpine:3.20` → `@sha256:d9e853e87e55526f6b2917df91a2115c36dd7c696a35be12163d44e6e2a4b6bc`

**CI Workflows (9 alerts)**:
- `nil-safety.yml` (×2): pin nilaway `@latest` → `@v0.0.0-20260318203545-ad240b12fb4c`
- `ga4-error-monitor.yml`: `npm install googleapis@144` → `npm install --ignore-scripts googleapis@144.0.0`
- `ga4-mobile-monitor.yml`: same as above
- `console-app-roundtrip.yml` (pipCommand + downloadThenRun): pin `pyjwt==2.12.1 cryptography==46.0.7`; refactor curl-pipe-python to save response to file first
- `console-app-smoke.yml` (pipCommand): pin `pyjwt==2.12.1 cryptography==46.0.7`

**Test Scripts (4 alerts)**:
- `scripts/gosec-test.sh`: `gosec@latest` → `gosec@v2.25.0`
- `scripts/secret-scan-test.sh`: `gitleaks/v8@latest` → `gitleaks/v8@v8.30.1`
- `scripts/dependency-audit-test.sh`: `govulncheck@latest` → `govulncheck@v1.2.0`
- `scripts/ts-sast-test.sh`: `pip3 install semgrep` → `pip3 install semgrep==1.160.0`

## Test plan
- [ ] CI build/lint pass
- [ ] nil-safety workflow runs with pinned nilaway version
- [ ] ga4 monitors install googleapis without postinstall scripts
- [ ] App smoke/roundtrip workflows install pinned pyjwt/cryptography

Fixes #9272