### PR TITLE
🐛 fix(cards): remove noisy console.error calls across 5 card components (Issue 8816)

### DIFF
--- a/web/src/components/cards/CardChat.tsx
+++ b/web/src/components/cards/CardChat.tsx
@@ -112,8 +112,8 @@ export function CardChat({
       if (response.action && onApplyAction) {
         // Show that an action was taken
       }
-    } catch (error) {
-      console.error('Chat error:', error)
+    } catch {
+      // User-visible toast already surfaces the failure (#8816)
       showToast('Failed to send message. Please try again.', 'error')
     } finally {
       setIsLoading(false)

--- a/web/src/components/cards/DynamicCard.tsx
+++ b/web/src/components/cards/DynamicCard.tsx
@@ -435,7 +435,7 @@ export function Tier2CardRuntime({ definition, config }: Tier2Props) {
       } catch (err) {
         if (cancelled) return
         const message = err instanceof Error ? err.message : String(err)
-        console.error(`[DynamicCard] Unexpected compile error:`, err)
+        // Message is already surfaced to the user via setError below (#8816)
         setError(`Unexpected error: ${message}`)
         setCompiling(false)
       }

--- a/web/src/components/cards/MatchGame.tsx
+++ b/web/src/components/cards/MatchGame.tsx
@@ -73,8 +73,9 @@ export function MatchGame(_props: CardComponentProps) {
     if (stored) {
       try {
         setHighScores(JSON.parse(stored))
-      } catch (e) {
-        console.error('Failed to load high scores:', e)
+      } catch {
+        // User-visible toast already communicates the failure; no console
+        // noise needed (#8816).
         showToast(t('matchGame.errors.highScoresFailed', 'Could not load high scores.'), 'warning')
       }
     }

--- a/web/src/components/cards/StockMarketTicker.tsx
+++ b/web/src/components/cards/StockMarketTicker.tsx
@@ -161,9 +161,8 @@ async function fetchRealStockData(symbols: string[]): Promise<StockData[]> {
         sparklineData,
         lastUpdated: new Date() }
     })
-  } catch (error) {
-    console.error('Error fetching real stock data:', error)
-    // Fallback to mock data on error
+  } catch {
+    // Fallback to mock data on error (#8816 — silent fallback is the intended UX)
     return generateMockStockData(symbols)
   }
 }
@@ -232,9 +231,8 @@ async function searchStocks(query: string): Promise<StockSearchResult[]> {
         region: q.exchDisp || q.exchange || 'US',
         currency: q.currency || 'USD' }))
       .slice(0, 10)
-  } catch (error) {
-    console.error('Error searching stocks, using fallback:', error)
-    // Fallback to local search when API fails (e.g., CORS issues)
+  } catch {
+    // Fallback to local search when API fails (e.g., CORS issues) — #8816
     const queryLower = query.toLowerCase()
     return COMMON_STOCKS.filter(stock =>
       stock.symbol.toLowerCase().includes(queryLower) ||
@@ -612,8 +610,8 @@ export function StockMarketTicker({ config }: StockMarketTickerProps) {
       if (results.length > 0) {
         setShowStockDropdown(true)
       }
-    } catch (error) {
-      console.error('Stock search error:', error)
+    } catch {
+      // User-visible toast already surfaces the failure (#8816)
       showToast(t('cards:stockMarket.searchFailed', 'Stock search failed. Please try again.'), 'error')
       setStockSearchResults([])
       setShowStockDropdown(false)

--- a/web/src/components/cards/UserManagement.tsx
+++ b/web/src/components/cards/UserManagement.tsx
@@ -277,8 +277,8 @@ export function UserManagement({ config: _config }: UserManagementProps) {
       await updateUserRole(userId, newRole)
       showToast('User role updated successfully', 'success')
       emitUserRoleChanged(newRole)
-    } catch (error) {
-      console.error('Failed to update role:', error)
+    } catch {
+      // User-visible toast already surfaces the failure (#8816)
       showToast('Failed to update user role', 'error')
     }
   }
@@ -289,8 +289,8 @@ export function UserManagement({ config: _config }: UserManagementProps) {
       await deleteUser(userId)
       showToast('User deleted successfully', 'success')
       emitUserRemoved()
-    } catch (error) {
-      console.error('Failed to delete user:', error)
+    } catch {
+      // User-visible toast already surfaces the failure (#8816)
       showToast('Failed to delete user', 'error')
     }
   }


### PR DESCRIPTION
## Summary

Consolidated sweep addressing @khushal-winner's 5 in-flight PRs (#8820, #8821, #8822, #8823, #8824) which all target parent Auto-QA finding #8816 ("console.error without user-visible error handling"). Each original PR was substantively valid but the diffs were inflated with unrelated brace-style prettier churn from a differing editor config, and #8822 overlapped #8821.

This PR keeps only the substantive removals.

## Per-file (8 console.error removals)

| File | # | Why safe |
|---|---:|---|
| `MatchGame.tsx` | 1 | Toast already surfaces "Could not load high scores" |
| `StockMarketTicker.tsx` | 3 | Silent fallback to mock data is intended UX; search failure toast already shown |
| `CardChat.tsx` | 1 | Toast already shown to user on send failure |
| `DynamicCard.tsx` | 1 | `setError()` renders the message inline |
| `UserManagement.tsx` | 2 | Toasts surface role-update and delete failures |

## What changed semantically

At each site: `} catch (err) { console.error(...); <toast>; }` → `} catch { <toast>; }`. Where the bound error name was used only for the log, it's dropped (TS ≥ 4.4 optional catch binding). Each site gets a short comment citing Issue 8816.

## What did NOT change

No brace-style, import-order, semicolon, or quote-style changes. `+16/-17` across 5 files is exactly the console.error removals plus their comments.

## Once merged

Close PRs #8820 / #8821 / #8822 / #8823 / #8824 as superseded with a thank-you note to @khushal-winner.

## No `Fixes #` trailer

Parent issue #8816 was already closed 2026-04-18 by #8831 (which addressed the Auto-QA detector, not the actual console.error calls). This PR completes the remediation that #8831 didn't cover; the issue stays closed.