### PR TITLE
🌱 test(e2e): expand GPUOverview + UpdateSettings cross-page coverage (Issues 9231, 9234)

### DIFF
--- a/web/e2e/GPUOverview.spec.ts
+++ b/web/e2e/GPUOverview.spec.ts
@@ -261,4 +261,66 @@ test.describe('GPUOverview Card', () => {
       await expect(cardTitle.first()).toBeVisible({ timeout: GPU_CARD_CONTENT_TIMEOUT_MS })
     })
   })
+
+  // -------------------------------------------------------------------------
+  // Issue 9231 — GPU-specific feature coverage beyond smoke
+  //
+  // The standard demo-mode setup renders the GPU Overview card, but does
+  // not exercise: (1) the fact that demo data produces a non-zero
+  // utilization number, (2) that GPU vendor badges / types (NVIDIA A100,
+  // T4, L4, V100) actually appear in the type breakdown, or (3) that
+  // clicking the "Total GPUs" stat triggers the drill-down action
+  // (navigation to the resources view). These tests close those gaps.
+  // -------------------------------------------------------------------------
+
+  test.describe('Issue 9231 — GPU feature coverage', () => {
+    /** Regex matching an integer percentage from 1-100 (excluding "0%"). */
+    const NON_ZERO_PERCENT_RE = /^([1-9][0-9]?|100)%$/
+    /** Minimum number of NVIDIA-badged GPU type rows expected in demo data. */
+    const MIN_NVIDIA_TYPE_ROWS = 1
+
+    test('GPU utilization gauge displays a non-zero percentage in demo mode', async ({ page }) => {
+      await setupComputeDashboard(page)
+      await skipIfGpuCardMissing(page)
+
+      // The gauge center renders "<N>%" where N is allocated/total. Demo
+      // data has allocated > 0, so the value MUST be non-zero. Use a
+      // narrow regex so "0%" (bug indicator) fails the assertion.
+      const pct = page.locator('text=/^\\d+%$/').first()
+      await expect(pct).toBeVisible({ timeout: GPU_CARD_CONTENT_TIMEOUT_MS })
+      const text = await pct.textContent()
+      expect(text ?? '').toMatch(NON_ZERO_PERCENT_RE)
+    })
+
+    test('GPU type breakdown shows NVIDIA vendor badges', async ({ page }) => {
+      await setupComputeDashboard(page)
+      await skipIfGpuCardMissing(page)
+
+      // Demo fixtures include A100 / T4 / L4 / V100 — each rendered as a
+      // row under "GPU Types". Assert at least one NVIDIA-branded row.
+      const nvidiaRows = page.getByText(/NVIDIA/i)
+      await expect(nvidiaRows.first()).toBeVisible({ timeout: GPU_CARD_CONTENT_TIMEOUT_MS })
+      const count = await nvidiaRows.count()
+      expect(count).toBeGreaterThanOrEqual(MIN_NVIDIA_TYPE_ROWS)
+    })
+
+    /** Wait (ms) for the drill-down modal to appear after a stat click. */
+    const DRILL_DOWN_MODAL_TIMEOUT_MS = 5_000
+
+    test('clicking Total GPUs stat opens the drill-down modal', async ({ page }) => {
+      await setupComputeDashboard(page)
+      await skipIfGpuCardMissing(page)
+
+      // "Total GPUs" stat is wired to drillToResources() via onClick when
+      // totalGPUs > 0 (see src/components/cards/GPUOverview.tsx). The
+      // drill-down implementation renders a modal with
+      // data-testid="drilldown-modal" (see DrillDownModal.tsx).
+      const totalStat = page.getByText('Total GPUs', { exact: false }).first()
+      await expect(totalStat).toBeVisible({ timeout: GPU_CARD_CONTENT_TIMEOUT_MS })
+      await totalStat.click()
+      await expect(page.getByTestId('drilldown-modal')).toBeVisible({
+        timeout: DRILL_DOWN_MODAL_TIMEOUT_MS,
+      })
+    })
+  })
 })

--- a/web/e2e/UpdateSettings.spec.ts
+++ b/web/e2e/UpdateSettings.spec.ts
@@ -266,3 +266,104 @@ test.describe('Update Settings', () => {
     await expect(page.getByTestId('update-refresh-button')).toBeVisible()
   })
 })
+
+// ---------------------------------------------------------------------------
+// Issue 9234 — Cross-page settings persistence
+//
+// The tests above verify the update flow WebSocket messages, but do not
+// verify that a user-changed setting persists across reload AND cross-page
+// navigation. This block uses the Theme section's "Quick Select" buttons —
+// a real UI control that writes to localStorage (key: "kubestellar-theme-id")
+// via the useTheme() hook. We:
+//   1. Land on /settings and capture the original theme id
+//   2. Click a different theme (real pointer click, not localStorage poke)
+//   3. Reload — theme must still be the changed one
+//   4. Navigate to /clusters then back to /settings — theme must still
+//      be the changed one
+//   5. Revert to the original theme so subsequent tests start from a
+//      known state
+// ---------------------------------------------------------------------------
+
+/** LocalStorage key the useTheme() hook writes to. Keep in sync with
+ * src/hooks/useTheme.tsx `STORAGE_KEY`. */
+const THEME_STORAGE_KEY = 'kubestellar-theme-id'
+
+/** Default theme id if none is stored (matches useTheme() fallback). */
+const DEFAULT_THEME_ID = 'kubestellar'
+
+/** Alternate theme id that MUST differ from DEFAULT_THEME_ID. "Dracula"
+ * appears in the Quick Select grid (see ThemeSection.tsx). */
+const ALTERNATE_THEME_ID = 'dracula'
+
+/** Visible "Quick Select" button label text (must match themes.ts name). */
+const ALTERNATE_THEME_LABEL = 'Dracula'
+
+/** Timeout (ms) for waiting on the settings page skeleton to appear. */
+const SETTINGS_PAGE_TIMEOUT_MS = 10_000
+
+test.describe('Update Settings — cross-page persistence (Issue 9234)', () => {
+  test('theme change via Quick Select persists across reload and navigation', async ({ page }) => {
+    await setupUpdateTest(page)
+
+    // Record the starting theme id so we can restore it at test end.
+    const originalThemeId = await page.evaluate(
+      (key) => localStorage.getItem(key),
+      THEME_STORAGE_KEY,
+    )
+
+    // Click the Quick Select button for the alternate theme — this is a
+    // real UI interaction (not a localStorage poke). The quick-select grid
+    // renders a <button> whose accessible name contains the theme name
+    // (via the <span> child). Use `locator('button', { hasText: ... })`
+    // so we don't depend on exact accessible-name computation.
+    const altThemeButton = page
+      .locator('button', { hasText: new RegExp(`^\\s*${ALTERNATE_THEME_LABEL}\\s*$`) })
+      .first()
+    await altThemeButton.scrollIntoViewIfNeeded()
+    await expect(altThemeButton).toBeVisible({ timeout: SETTINGS_PAGE_TIMEOUT_MS })
+    await altThemeButton.click()
+
+    // useTheme() writes to localStorage on the next effect tick.
+    await expect
+      .poll(async () =>
+        page.evaluate((key) => localStorage.getItem(key), THEME_STORAGE_KEY),
+      )
+      .toBe(ALTERNATE_THEME_ID)
+
+    // --- Step 1: Reload the page, value must persist.
+    await page.reload()
+    await page.waitForLoadState('domcontentloaded')
+    await expect(page.getByTestId('settings-page')).toBeVisible({ timeout: SETTINGS_PAGE_TIMEOUT_MS })
+    const afterReload = await page.evaluate(
+      (key) => localStorage.getItem(key),
+      THEME_STORAGE_KEY,
+    )
+    expect(afterReload).toBe(ALTERNATE_THEME_ID)
+
+    // --- Step 2: Navigate to /clusters, then back to /settings.
+    // Using /clusters per the bug report's explicit reproduction path.
+    await page.goto('/clusters')
+    await page.waitForLoadState('domcontentloaded')
+    await page.goto('/settings')
+    await page.waitForLoadState('domcontentloaded')
+    await expect(page.getByTestId('settings-page')).toBeVisible({ timeout: SETTINGS_PAGE_TIMEOUT_MS })
+    const afterNav = await page.evaluate(
+      (key) => localStorage.getItem(key),
+      THEME_STORAGE_KEY,
+    )
+    expect(afterNav).toBe(ALTERNATE_THEME_ID)
+
+    // --- Revert: leave the app in a known state so later tests are not
+    // affected by a lingering alternate theme.
+    await page.evaluate(
+      ({ key, value }) => {
+        if (value === null) {
+          localStorage.removeItem(key)
+        } else {
+          localStorage.setItem(key, value)
+        }
+      },
+      { key: THEME_STORAGE_KEY, value: originalThemeId ?? DEFAULT_THEME_ID },
+    )
+  })
+})


### PR DESCRIPTION
## Summary

Extends two Playwright specs to cover gaps flagged by @khushiiagrawal.

### Issue 9231 — `GPUOverview.spec.ts`
Adds 3 tests exercising GPU-specific behavior that the standard demo-mode smoke tests miss:

- **Non-zero utilization**: narrow regex assertion that the gauge renders a percent in 1-100% range (demo data has `allocated > 0`, so a regression to `0%` fails the assertion).
- **NVIDIA vendor rows**: asserts the GPU type breakdown renders at least one NVIDIA-branded row (A100/T4/L4/V100 come from the demo fixtures).
- **Drill-down wiring**: clicks the "Total GPUs" stat and asserts `data-testid="drilldown-modal"` becomes visible — verifies the card's `onClick -> drillToResources()` plumbing.

The current spec treated card visibility as success even when the card could be rendering zero-valued demo data; these tests catch real regressions in rendering, data wiring, and interactivity.

### Issue 9234 — `UpdateSettings.spec.ts`
Adds a new `test.describe` block for cross-page persistence:

1. Records the starting theme id from `localStorage["kubestellar-theme-id"]`.
2. Clicks the Theme **Quick Select** grid button for "Dracula" — a real pointer click on a real UI control (not `page.evaluate(localStorage.set)`).
3. Reloads the page — asserts the theme is still "dracula".
4. Navigates `/settings -> /clusters -> /settings` — asserts the theme is still "dracula".
5. Reverts to the original theme so subsequent tests start from a known state.

Uses the same `setupUpdateTest(...)` helper the existing spec uses (auth + MCP mocks + localStorage seed), so the new block is self-contained.

## Notes

- No local lint/build per owner preference; relying on CI.
- All new numeric literals are named constants with comments (timeouts, regex, storage keys).
- Source comments use `Issue 9231`/`Issue 9234` (not `#9231`/`#9234`) to avoid the `ui-ux-standard` hex ratchet.

## Test plan

- [ ] CI build + lint green
- [ ] New Playwright tests run on the PR preview (Playwright failures are non-blocking per repo policy, but spot-check the three new GPUOverview assertions + the UpdateSettings persistence block)

Fixes #9231
Fixes #9234