### PR TITLE
refactor(missions): split MissionBrowser.tsx into focused subcomponents

### DIFF
--- a/web/src/components/missions/MissionBrowser.tsx
+++ b/web/src/components/missions/MissionBrowser.tsx
@@ -3,13 +3,19 @@
  *
  * Full-screen file-explorer-style dialog for browsing and importing mission files.
  * Sources: KubeStellar Community repo, GitHub repos with kubestellar-missions, local files.
+ *
+ * This component owns all state and data-fetching logic. Presentation is split
+ * into focused subcomponents (issue #8624):
+ *   - MissionBrowserTopBar      — search, filter toggle, view-mode, close
+ *   - MissionBrowserFilterPanel — filter pill rows
+ *   - MissionBrowserTabBar      — tab navigation
+ *   - MissionBrowserSidebar     — file tree + drop zone
+ *   - MissionBrowserRecommendedTab
+ *   - MissionBrowserInstallersTab
+ *   - MissionBrowserFixesTab
  */
 
 import { useState, useEffect, useRef, useMemo, useCallback } from 'react'
-import {
-  Search, X, Upload, Filter, Grid3X3, List, Sparkles, CheckCircle,
-  Loader2, ExternalLink, RefreshCw } from 'lucide-react'
-import { cn } from '../../lib/cn'
 import { api } from '../../lib/api'
 import { isDemoMode } from '../../lib/demoMode'
 import { useAuth } from '../../lib/auth'
@@ -21,43 +27,40 @@ import {
   emitFixerViewed,
   emitFixerImported,
   emitFixerImportError,
-  emitFixerGitHubLink,
-  emitFixerLinkCopied } from '../../lib/analytics'
+  emitFixerLinkCopied,
+} from '../../lib/analytics'
 import type {
   MissionExport,
   MissionMatch,
   BrowseEntry,
-  FileScanResult } from '../../lib/missions/types'
+  FileScanResult,
+} from '../../lib/missions/types'
 import { validateMissionExport } from '../../lib/missions/types'
 import { parseFileContent, type UnstructuredPreview } from '../../lib/missions/fileParser'
 import type { ApiGroupMapping } from '../../lib/missions/apiGroupMapping'
 import { fullScan } from '../../lib/missions/scanner/index'
 import { ScanProgressOverlay } from './ScanProgressOverlay'
-import { CollapsibleSection } from '../ui/CollapsibleSection'
-import { InstallerCard } from './InstallerCard'
-import { FixerCard } from './FixerCard'
 import { MissionDetailView } from './MissionDetailView'
 import { ImproveMissionDialog } from './ImproveMissionDialog'
 import { UnstructuredFilePreview } from './UnstructuredFilePreview'
-import { useTranslation } from 'react-i18next'
 import {
-  TreeNodeItem, DirectoryListing, RecommendationCard, EmptyState, MissionFetchErrorBanner,
-  getMissionShareUrl, updateNodeInTree, removeNodeFromTree,
-  missionCache, startMissionCacheFetch, resetMissionCache,
-  fetchMissionContent, BROWSER_TABS,
-  VirtualizedMissionGrid,
-  getCachedRecommendations, setCachedRecommendations,
-  fetchTreeChildren, fetchDirectoryEntries, fetchNodeFileContent } from './browser'
+  getMissionShareUrl,
+  updateNodeInTree,
+  removeNodeFromTree,
+  missionCache,
+  startMissionCacheFetch,
+  fetchMissionContent,
+  getCachedRecommendations,
+  setCachedRecommendations,
+  fetchTreeChildren,
+  fetchDirectoryEntries,
+  fetchNodeFileContent,
+} from './browser'
 import type { TreeNode, ViewMode, BrowserTab } from './browser'
 import { copyToClipboard } from '../../lib/clipboard'
 import { useToast } from '../ui/Toast'
 import {
-  CATEGORY_FILTERS,
-  SIDEBAR_WIDTH,
-  MISSION_FILE_ACCEPT,
   isMissionFile,
-  CNCF_CATEGORIES,
-  MATURITY_LEVELS,
   loadWatchedRepos,
   saveWatchedRepos,
   loadWatchedPaths,
@@ -78,6 +81,13 @@ import {
   computeActiveFilterCount,
   filterDirectoryEntries,
 } from './missionBrowserFilterState'
+import { MissionBrowserTopBar } from './MissionBrowserTopBar'
+import { MissionBrowserFilterPanel } from './MissionBrowserFilterPanel'
+import { MissionBrowserTabBar } from './MissionBrowserTabBar'
+import { MissionBrowserSidebar } from './MissionBrowserSidebar'
+import { MissionBrowserRecommendedTab } from './MissionBrowserRecommendedTab'
+import { MissionBrowserInstallersTab } from './MissionBrowserInstallersTab'
+import { MissionBrowserFixesTab } from './MissionBrowserFixesTab'
 
 // ============================================================================
 // Layout constants
@@ -123,7 +133,6 @@ interface MissionBrowserProps {
 // ============================================================================
 
 export function MissionBrowser({ isOpen, onClose, onImport, initialMission, onUseInMissionControl }: MissionBrowserProps) {
-  const { t } = useTranslation(['common', 'cards'])
   const { user, isAuthenticated } = useAuth()
   const { clusterContext } = useClusterContext()
   const clusterContextRef = useRef(clusterContext)
@@ -193,8 +202,6 @@ export function MissionBrowser({ isOpen, onClose, onImport, initialMission, onUs
   const [addingPath, setAddingPath] = useState(false)
   const [newRepoValue, setNewRepoValue] = useState('')
   const [newPathValue, setNewPathValue] = useState('')
-
-  const fileInputRef = useRef<HTMLInputElement>(null)
 
   // Tab state
   const [activeTab, setActiveTab] = useState<BrowserTab>('recommended')
@@ -878,7 +885,62 @@ export function MissionBrowser({ isOpen, onClose, onImport, initialMission, onUs
   }, [isOpen])
 
   // ============================================================================
-  // Render helpers
+  // Handlers wired to sidebar watched-source management
+  // ============================================================================
+
+  const handleAddRepo = (val: string) => {
+    const updated = [...watchedRepos, val]
+    setWatchedRepos(updated)
+    saveWatchedRepos(updated)
+    showToast(`Added repository "${val}"`, 'success')
+  }
+
+  const handleRemoveRepo = (path: string) => {
+    const updated = watchedRepos.filter(r => r !== path)
+    setWatchedRepos(updated)
+    saveWatchedRepos(updated)
+    showToast(`Removed repository "${path}"`, 'info')
+  }
+
+  const handleAddPath = (val: string) => {
+    const updated = [...watchedPaths, val]
+    setWatchedPaths(updated)
+    saveWatchedPaths(updated)
+    showToast(`Added path "${val}"`, 'success')
+  }
+
+  const handleRemovePath = (path: string) => {
+    const updated = watchedPaths.filter(p => p !== path)
+    setWatchedPaths(updated)
+    saveWatchedPaths(updated)
+    showToast(`Removed path "${path}"`, 'info')
+  }
+
+  const handleRefreshNode = (child: TreeNode) => {
+    // Re-expand after a tick to trigger the useEffect
+    setTimeout(() => {
+      toggleNode(child)
+      selectNode(child)
+    }, 50)
+  }
+
+  // ============================================================================
+  // Directory-entry import (recommended tab, tree navigation)
+  // ============================================================================
+
+  const handleImportDirectoryEntry = async (entry: BrowseEntry) => {
+    try {
+      const { data: content } = await api.get<string>(
+        `/api/missions/file?path=${encodeURIComponent(entry.path)}`,
+      )
+      const raw = typeof content === 'string' ? content : JSON.stringify(content, null, 2)
+      const parsed = typeof content === 'string' ? JSON.parse(content) : content
+      handleImport(parsed, raw)
+    } catch { /* skip */ }
+  }
+
+  // ============================================================================
+  // Render
   // ============================================================================
 
   if (!isOpen) return null
@@ -900,455 +962,94 @@ export function MissionBrowser({ isOpen, onClose, onImport, initialMission, onUs
         bottom: `${MODAL_SIDE_INSET_PX}px`,
       }}
     >
-      {/* ================================================================== */}
-      {/* Top bar: search + filters */}
-      {/* ================================================================== */}
-      <div className="flex items-center gap-3 px-4 py-3 bg-card border-b border-border">
-        <div className="flex-1 relative">
-          <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-muted-foreground" />
-          <input
-            type="text"
-            value={searchQuery}
-            onChange={(e) => setSearchQuery(e.target.value)}
-            placeholder={activeTab === 'installers' ? 'Search installers… (AND logic: "argo events" = argo AND events)' : activeTab === 'fixes' ? 'Search fixes…' : 'Search missions by name, tag, or description…'}
-            className="w-full pl-10 pr-4 py-2 bg-secondary border border-border rounded-lg text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-purple-500/40"
-            data-testid="mission-search"
-            autoFocus
-          />
-        </div>
+      {/* Top bar: search + filter toggle + view mode + close */}
+      <MissionBrowserTopBar
+        searchQuery={searchQuery}
+        onSearchChange={setSearchQuery}
+        activeTab={activeTab}
+        showFilters={showFilters}
+        onToggleFilters={() => setShowFilters(!showFilters)}
+        activeFilterCount={activeFilterCount}
+        viewMode={viewMode}
+        onViewModeChange={setViewMode}
+        onClose={onClose}
+      />
 
-        <button
-          onClick={() => setShowFilters(!showFilters)}
-          className={cn(
-            'p-2 rounded-lg transition-colors relative',
-            showFilters
-              ? 'bg-purple-500/20 text-purple-400'
-              : 'hover:bg-secondary text-muted-foreground hover:text-foreground'
-          )}
-          title="Toggle filters"
-        >
-          <Filter className="w-5 h-5" />
-          {activeFilterCount > 0 && (
-            <span className="absolute -top-1 -right-1 w-4 h-4 rounded-full bg-purple-500 text-white text-[9px] font-bold flex items-center justify-center">
-              {activeFilterCount}
-            </span>
-          )}
-        </button>
-
-        <div className="flex items-center border border-border rounded-lg overflow-hidden">
-          <button
-            onClick={() => setViewMode('grid')}
-            className={cn(
-              'p-2 transition-colors',
-              viewMode === 'grid'
-                ? 'bg-purple-500/20 text-purple-400'
-                : 'text-muted-foreground hover:text-foreground'
-            )}
-          >
-            <Grid3X3 className="w-4 h-4" />
-          </button>
-          <button
-            onClick={() => setViewMode('list')}
-            className={cn(
-              'p-2 transition-colors',
-              viewMode === 'list'
-                ? 'bg-purple-500/20 text-purple-400'
-                : 'text-muted-foreground hover:text-foreground'
-            )}
-          >
-            <List className="w-4 h-4" />
-          </button>
-        </div>
-
-        {/* #6308: close button moved to the RIGHT end of the top bar to
-            match every other modal in the app (BaseModal etc). Having
-            it on the left was a confusing one-off — users trained to
-            close modals via the top-right X were not finding it. */}
-        <button
-          onClick={onClose}
-          className="p-2 rounded-lg hover:bg-secondary text-muted-foreground hover:text-foreground transition-colors"
-          title="Close (Esc)"
-          aria-label="Close mission browser"
-        >
-          <X className="w-5 h-5" />
-        </button>
-      </div>
-
-      {/* Filter bar — constrained height on mobile with scroll */}
+      {/* Filter panel */}
       {showFilters && (
-        <div className="px-4 py-2.5 bg-card border-b border-border space-y-2 max-h-[40vh] md:max-h-[50vh] overflow-y-auto">
-          {/* Row 1: Clear all + Match % + Source + Category */}
-          <div className="flex items-center gap-3 flex-wrap">
-            {activeFilterCount > 0 && (
-              <button
-                onClick={clearAllFilters}
-                className="inline-flex items-center gap-1 px-2 py-1 text-[11px] rounded-full bg-red-500/10 text-red-400 hover:bg-red-500/20 border border-red-500/20 transition-colors"
-              >
-                <X className="w-3 h-3" />
-                Clear all
-              </button>
-            )}
-
-            <span className="text-xs text-muted-foreground font-medium">Match:</span>
-            <div className="flex items-center gap-1">
-              {[0, 25, 50, 75].map((pct) => (
-                <button
-                  key={pct}
-                  onClick={() => setMinMatchPercent(pct)}
-                  className={cn(
-                    'px-2 py-0.5 text-[11px] rounded-full transition-colors tabular-nums',
-                    minMatchPercent === pct
-                      ? 'bg-purple-500/20 text-purple-400 border border-purple-500/30'
-                      : 'bg-secondary text-muted-foreground hover:text-foreground border border-transparent'
-                  )}
-                >
-                  {pct === 0 ? 'Any' : `≥${pct}%`}
-                </button>
-              ))}
-            </div>
-
-            <div className="w-px h-4 bg-border" />
-
-            <span className="text-xs text-muted-foreground font-medium">Source:</span>
-            <div className="flex items-center gap-1">
-              {([['all', 'All', null], ['cluster', '🎯 Cluster', facetCounts.clusterMatched], ['community', '🌐 Community', facetCounts.community]] as const).map(([val, label, count]) => (
-                <button
-                  key={val}
-                  onClick={() => setMatchSourceFilter(val)}
-                  className={cn(
-                    'px-2 py-0.5 text-[11px] rounded-full transition-colors',
-                    matchSourceFilter === val
-                      ? 'bg-purple-500/20 text-purple-400 border border-purple-500/30'
-                      : 'bg-secondary text-muted-foreground hover:text-foreground border border-transparent'
-                  )}
-                >
-                  {label}{count != null ? ` (${count})` : ''}
-                </button>
-              ))}
-            </div>
-
-            <div className="w-px h-4 bg-border" />
-
-            <span className="text-xs text-muted-foreground font-medium">Category:</span>
-            <div className="flex items-center gap-1">
-              {CATEGORY_FILTERS.map((cat) => (
-                <button
-                  key={cat}
-                  onClick={() => setCategoryFilter(cat)}
-                  className={cn(
-                    'px-2 py-0.5 text-[11px] rounded-full transition-colors',
-                    categoryFilter === cat
-                      ? 'bg-purple-500/20 text-purple-400 border border-purple-500/30'
-                      : 'bg-secondary text-muted-foreground hover:text-foreground border border-transparent'
-                  )}
-                >
-                  {cat}
-                </button>
-              ))}
-            </div>
-          </div>
-
-          {/* Row 2: Class + Maturity + Difficulty + CNCF Project */}
-          <div className="flex items-center gap-3 flex-wrap">
-            <span className="text-xs text-muted-foreground font-medium">Class:</span>
-            <div className="flex items-center gap-1">
-              {['All', ...Array.from(facetCounts.missionClass.keys())].map((cls) => (
-                <button
-                  key={cls}
-                  onClick={() => setMissionClassFilter(cls)}
-                  className={cn(
-                    'px-2 py-0.5 text-[11px] rounded-full transition-colors capitalize',
-                    missionClassFilter === cls
-                      ? 'bg-purple-500/20 text-purple-400 border border-purple-500/30'
-                      : 'bg-secondary text-muted-foreground hover:text-foreground border border-transparent'
-                  )}
-                >
-                  {cls === 'All' ? cls : `${cls} (${facetCounts.missionClass.get(cls) || 0})`}
-                </button>
-              ))}
-            </div>
-
-            <div className="w-px h-4 bg-border" />
-
-            <span className="text-xs text-muted-foreground font-medium">Maturity:</span>
-            <div className="flex items-center gap-1">
-              {['All', ...Array.from(facetCounts.maturity.keys())].map((mat) => (
-                <button
-                  key={mat}
-                  onClick={() => setMaturityFilter(mat)}
-                  className={cn(
-                    'px-2 py-0.5 text-[11px] rounded-full transition-colors capitalize',
-                    maturityFilter === mat
-                      ? 'bg-purple-500/20 text-purple-400 border border-purple-500/30'
-                      : 'bg-secondary text-muted-foreground hover:text-foreground border border-transparent'
-                  )}
-                >
-                  {mat === 'All' ? mat : `${mat} (${facetCounts.maturity.get(mat) || 0})`}
-                </button>
-              ))}
-            </div>
-
-            <div className="w-px h-4 bg-border" />
-
-            <span className="text-xs text-muted-foreground font-medium">Difficulty:</span>
-            <div className="flex items-center gap-1">
-              {['All', ...Array.from(facetCounts.difficulty.keys())].map((diff) => (
-                <button
-                  key={diff}
-                  onClick={() => setDifficultyFilter(diff)}
-                  className={cn(
-                    'px-2 py-0.5 text-[11px] rounded-full transition-colors capitalize',
-                    difficultyFilter === diff
-                      ? 'bg-purple-500/20 text-purple-400 border border-purple-500/30'
-                      : 'bg-secondary text-muted-foreground hover:text-foreground border border-transparent'
-                  )}
-                >
-                  {diff === 'All' ? diff : `${diff} (${facetCounts.difficulty.get(diff) || 0})`}
-                </button>
-              ))}
-            </div>
-
-            <div className="w-px h-4 bg-border" />
-
-            <span className="text-xs text-muted-foreground font-medium">CNCF:</span>
-            <input
-              type="text"
-              value={cncfFilter}
-              onChange={(e) => setCncfFilter(e.target.value)}
-              placeholder="e.g. Istio, Envoy…"
-              className="w-36 px-2 py-0.5 text-[11px] bg-secondary border border-border rounded-lg text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-purple-500/40"
-            />
-          </div>
-
-          {/* Row 3: Top tags */}
-          {facetCounts.topTags.length > 0 && (
-            <div className="flex items-center gap-2 flex-wrap">
-              <span className="text-xs text-muted-foreground font-medium">Tags:</span>
-              {facetCounts.topTags.map(({ tag, count }: { tag: string; count: number }) => (
-                <button
-                  key={tag}
-                  onClick={() => {
-                    setSelectedTags((prev: Set<string>) => {
-                      const next = new Set(prev)
-                      if (next.has(tag)) next.delete(tag)
-                      else next.add(tag)
-                      return next
-                    })
-                  }}
-                  className={cn(
-                    'px-2 py-0.5 text-[11px] rounded-full transition-colors',
-                    selectedTags.has(tag)
-                      ? 'bg-purple-500/20 text-purple-400 border border-purple-500/30'
-                      : 'bg-secondary text-muted-foreground hover:text-foreground border border-transparent'
-                  )}
-                >
-                  {tag} <span className="opacity-60">({count})</span>
-                </button>
-              ))}
-              {selectedTags.size > 0 && (
-                <button
-                  onClick={() => setSelectedTags(new Set())}
-                  className="text-[11px] text-muted-foreground hover:text-foreground underline"
-                >
-                  clear tags
-                </button>
-              )}
-            </div>
-          )}
-
-          {/* Active filter summary — always show count when recommendations are loaded */}
-          {recommendations.length > 0 && (
-            <div className="text-[11px] text-muted-foreground">
-              Showing {filteredRecommendations.length} of {recommendations.length} missions
-              {activeFilterCount > 0 && ' (filtered)'}
-            </div>
-          )}
-        </div>
+        <MissionBrowserFilterPanel
+          activeFilterCount={activeFilterCount}
+          onClearAllFilters={clearAllFilters}
+          minMatchPercent={minMatchPercent}
+          onMinMatchPercentChange={setMinMatchPercent}
+          matchSourceFilter={matchSourceFilter}
+          onMatchSourceFilterChange={setMatchSourceFilter}
+          categoryFilter={categoryFilter}
+          onCategoryFilterChange={setCategoryFilter}
+          missionClassFilter={missionClassFilter}
+          onMissionClassFilterChange={setMissionClassFilter}
+          maturityFilter={maturityFilter}
+          onMaturityFilterChange={setMaturityFilter}
+          difficultyFilter={difficultyFilter}
+          onDifficultyFilterChange={setDifficultyFilter}
+          cncfFilter={cncfFilter}
+          onCncfFilterChange={setCncfFilter}
+          selectedTags={selectedTags}
+          onTagToggle={(tag) => {
+            setSelectedTags((prev) => {
+              const next = new Set(prev)
+              if (next.has(tag)) next.delete(tag)
+              else next.add(tag)
+              return next
+            })
+          }}
+          onClearTags={() => setSelectedTags(new Set())}
+          facetCounts={facetCounts}
+          recommendationsTotal={recommendations.length}
+          filteredRecommendationsCount={filteredRecommendations.length}
+        />
       )}
 
-      {/* ================================================================== */}
       {/* Tab bar */}
-      {/* ================================================================== */}
-      <div className="flex items-center gap-1 px-4 py-1.5 bg-card border-b border-border overflow-x-auto scrollbar-hide">
-        {BROWSER_TABS.map(tab => (
-          <button
-            key={tab.id}
-            onClick={() => { setSelectedMission(null); setActiveTab(tab.id) }}
-            className={cn(
-              'inline-flex items-center gap-1.5 px-3 py-1.5 text-sm rounded-md transition-colors',
-              activeTab === tab.id
-                ? 'bg-purple-500/20 text-purple-400 font-medium'
-                : 'text-muted-foreground hover:text-foreground hover:bg-secondary'
-            )}
-          >
-            <span>{tab.icon}</span>
-            {tab.label}
-            {tab.id === 'installers' && (
-              <span className="text-2xs bg-secondary px-1.5 py-0.5 rounded-full min-w-[28px] text-center tabular-nums">{installerMissions.length || '–'}</span>
-            )}
-            {tab.id === 'fixes' && (
-              <span className="text-2xs bg-secondary px-1.5 py-0.5 rounded-full min-w-[28px] text-center tabular-nums">{fixerMissions.length || '–'}</span>
-            )}
-          </button>
-        ))}
-        <button
-          onClick={() => resetMissionCache()}
-          className="ml-auto inline-flex items-center gap-1 px-2 py-1 text-xs text-muted-foreground hover:text-foreground hover:bg-secondary rounded transition-colors"
-          title={activeTab === 'installers' ? 'Refresh installers' : activeTab === 'fixes' ? 'Refresh fixes' : 'Refresh all mission data'}
-        >
-          <RefreshCw className={cn('w-3.5 h-3.5', (activeTab === 'installers' ? !missionCache.installersDone : activeTab === 'fixes' ? !missionCache.fixesDone : (!missionCache.installersDone || !missionCache.fixesDone)) && 'animate-spin')} />
-        </button>
-      </div>
+      <MissionBrowserTabBar
+        activeTab={activeTab}
+        onTabChange={(tab) => { setSelectedMission(null); setActiveTab(tab) }}
+        installerCount={installerMissions.length}
+        fixerCount={fixerMissions.length}
+      />
 
-      {/* ================================================================== */}
-      {/* Main content: sidebar + panel */}
-      {/* ================================================================== */}
+      {/* Main content: sidebar + right panel */}
       <div className="flex-1 flex overflow-hidden">
         {/* Left sidebar — file tree (hidden on mobile, shown on md+) */}
-        <div
-          data-testid="mission-tree"
-          className="hidden md:flex flex-col border-r border-border bg-card overflow-y-auto"
-          style={{ width: SIDEBAR_WIDTH, minWidth: SIDEBAR_WIDTH }}
-        >
-          <div className="p-3 space-y-1">
-            {treeNodes.map((node) => (
-              <div key={node.id}>
-                <div>
-                  <TreeNodeItem
-                    node={node}
-                    depth={0}
-                    expandedNodes={expandedNodes}
-                    selectedPath={selectedPath}
-                    onToggle={toggleNode}
-                    onSelect={selectNode}
-                    onRemove={node.id === 'github' ? (child) => {
-                      const updated = watchedRepos.filter(r => r !== child.path)
-                      setWatchedRepos(updated)
-                      saveWatchedRepos(updated)
-                      showToast(`Removed repository "${child.path}"`, 'info')
-                    } : node.id === 'local' ? (child) => {
-                      const updated = watchedPaths.filter(p => p !== child.path)
-                      setWatchedPaths(updated)
-                      saveWatchedPaths(updated)
-                      showToast(`Removed path "${child.path}"`, 'info')
-                    } : undefined}
-                    onRefresh={(node.id === 'github' || node.id === 'local') ? (child) => {
-                      // Mark node as unloaded to force re-fetch
-                      setTreeNodes((prev) =>
-                        updateNodeInTree(prev, child.id, {
-                          loaded: false,
-                          loading: false,
-                          children: [] })
-                      )
-                      // Collapse and re-expand to trigger load
-                      setExpandedNodes((prev) => {
-                        const next = new Set(prev)
-                        next.delete(child.id)
-                        return next
-                      })
-                      // Re-expand after a tick to trigger the useEffect
-                      setTimeout(() => {
-                        toggleNode(child)
-                        selectNode(child)
-                      }, 50)
-                    } : undefined}
-                    onAdd={node.id === 'github' ? () => setAddingRepo(!addingRepo)
-                      : node.id === 'local' ? () => setAddingPath(!addingPath)
-                      : undefined}
-                  />
-                </div>
-
-                {/* Inline add repo form */}
-                {node.id === 'github' && addingRepo && (
-                  <div className="ml-6 mt-1 mb-2">
-                    <form onSubmit={(e) => {
-                      e.preventDefault()
-                      const val = newRepoValue.trim()
-                      if (val && !watchedRepos.includes(val)) {
-                        const updated = [...watchedRepos, val]
-                        setWatchedRepos(updated)
-                        saveWatchedRepos(updated)
-                        showToast(`Added repository "${val}"`, 'success')
-                      }
-                      setNewRepoValue('')
-                      setAddingRepo(false)
-                    }} className="flex items-center gap-1">
-                      <input
-                        type="text"
-                        value={newRepoValue}
-                        onChange={(e) => setNewRepoValue(e.target.value)}
-                        placeholder="owner/repo (e.g., kubara-io/kubara or your-org/runbooks)"
-                        className="flex-1 px-2 py-1 text-xs bg-secondary border border-border rounded text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-purple-500/40"
-                        autoFocus
-                        onKeyDown={(e) => { if (e.key === 'Escape') { setAddingRepo(false); setNewRepoValue('') } }}
-                      />
-                      <button type="submit" className="p-1 text-xs text-green-400 hover:text-green-300 min-h-11 min-w-11 flex items-center justify-center"><CheckCircle className="w-3.5 h-3.5" /></button>
-                      <button type="button" onClick={() => { setAddingRepo(false); setNewRepoValue('') }} className="p-1 text-xs text-muted-foreground hover:text-foreground min-h-11 min-w-11 flex items-center justify-center"><X className="w-3.5 h-3.5" /></button>
-                    </form>
-                  </div>
-                )}
-
-                {/* Inline add path form */}
-                {node.id === 'local' && addingPath && (
-                  <div className="ml-6 mt-1 mb-2">
-                    <form onSubmit={(e) => {
-                      e.preventDefault()
-                      const val = newPathValue.trim()
-                      if (val && !watchedPaths.includes(val)) {
-                        const updated = [...watchedPaths, val]
-                        setWatchedPaths(updated)
-                        saveWatchedPaths(updated)
-                        showToast(`Added path "${val}"`, 'success')
-                      }
-                      setNewPathValue('')
-                      setAddingPath(false)
-                    }} className="flex items-center gap-1">
-                      <input
-                        type="text"
-                        value={newPathValue}
-                        onChange={(e) => setNewPathValue(e.target.value)}
-                        placeholder="/path/to/missions"
-                        className="flex-1 px-2 py-1 text-xs bg-secondary border border-border rounded text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-purple-500/40"
-                        autoFocus
-                        onKeyDown={(e) => { if (e.key === 'Escape') { setAddingPath(false); setNewPathValue('') } }}
-                      />
-                      <button type="submit" className="p-1 text-xs text-green-400 hover:text-green-300 min-h-11 min-w-11 flex items-center justify-center"><CheckCircle className="w-3.5 h-3.5" /></button>
-                      <button type="button" onClick={() => { setAddingPath(false); setNewPathValue('') }} className="p-1 text-xs text-muted-foreground hover:text-foreground min-h-11 min-w-11 flex items-center justify-center"><X className="w-3.5 h-3.5" /></button>
-                    </form>
-                  </div>
-                )}
-              </div>
-            ))}
-          </div>
-
-          {/* Drop zone for local files */}
-          <div className="mt-auto p-3 border-t border-border">
-            <div
-              onDragOver={(e) => { e.preventDefault(); setIsDragging(true) }}
-              onDragLeave={() => setIsDragging(false)}
-              onDrop={handleDrop}
-              onClick={() => fileInputRef.current?.click()}
-              className={cn(
-                'flex flex-col items-center gap-2 p-4 rounded-lg border-2 border-dashed cursor-pointer transition-colors',
-                isDragging
-                  ? 'border-purple-400 bg-purple-500/10'
-                  : 'border-border hover:border-muted-foreground'
-              )}
-            >
-              <Upload className="w-5 h-5 text-muted-foreground" />
-              <span className="text-xs text-muted-foreground text-center">
-                Drop mission file (JSON, YAML, MD) or click to browse
-              </span>
-            </div>
-            <input
-              ref={fileInputRef}
-              type="file"
-              accept={MISSION_FILE_ACCEPT}
-              onChange={handleFileSelect}
-              className="hidden"
-            />
-          </div>
-        </div>
+        <MissionBrowserSidebar
+          treeNodes={treeNodes}
+          expandedNodes={expandedNodes}
+          selectedPath={selectedPath}
+          onToggleNode={toggleNode}
+          onSelectNode={selectNode}
+          isDragging={isDragging}
+          onDragOver={() => setIsDragging(true)}
+          onDragLeave={() => setIsDragging(false)}
+          onDrop={handleDrop}
+          onFileSelect={handleFileSelect}
+          watchedRepos={watchedRepos}
+          onRemoveRepo={handleRemoveRepo}
+          onRefreshNode={handleRefreshNode}
+          watchedPaths={watchedPaths}
+          onRemovePath={handleRemovePath}
+          addingRepo={addingRepo}
+          setAddingRepo={setAddingRepo}
+          newRepoValue={newRepoValue}
+          setNewRepoValue={setNewRepoValue}
+          onAddRepo={handleAddRepo}
+          addingPath={addingPath}
+          setAddingPath={setAddingPath}
+          newPathValue={newPathValue}
+          setNewPathValue={setNewPathValue}
+          onAddPath={handleAddPath}
+          setTreeNodes={setTreeNodes}
+          setExpandedNodes={setExpandedNodes}
+        />
 
         {/* Right panel */}
         <div data-testid="mission-grid" className="flex-1 flex flex-col overflow-hidden relative bg-background">
@@ -1361,9 +1062,9 @@ export function MissionBrowser({ isOpen, onClose, onImport, initialMission, onUs
           />
 
           <div className="flex-1 overflow-y-auto p-4">
-            {/* ============================================================ */}
+            {/* ================================================================ */}
             {/* MISSION DETAIL VIEW (renders above any tab when a mission is selected) */}
-            {/* ============================================================ */}
+            {/* ================================================================ */}
             {selectedMission && (
               <>
                 <MissionDetailView
@@ -1397,9 +1098,9 @@ export function MissionBrowser({ isOpen, onClose, onImport, initialMission, onUs
               </>
             )}
 
-            {/* ============================================================ */}
+            {/* ================================================================ */}
             {/* UNSTRUCTURED FILE PREVIEW (YAML/MD not parseable as a mission) */}
-            {/* ============================================================ */}
+            {/* ================================================================ */}
             {!selectedMission && unstructuredContent && (() => {
               // Derive Kubara chart name from selectedPath (e.g. "kubara/cert-manager/Chart.yaml" → "cert-manager")
               const kubaraChartName = selectedPath?.startsWith('kubara/')
@@ -1427,375 +1128,75 @@ export function MissionBrowser({ isOpen, onClose, onImport, initialMission, onUs
               )
             })()}
 
-            {/* ============================================================ */}
-            {/* RECOMMENDED TAB (existing content) */}
-            {/* ============================================================ */}
-            {!selectedMission && !unstructuredContent && activeTab === 'recommended' && (<>
-            {/* Token / rate-limit guidance banner */}
-            {tokenError && (
-              <div className="mb-4 rounded-lg border border-yellow-500/30 bg-yellow-500/10 p-4">
-                <div className="flex items-start gap-3">
-                  <span className="text-yellow-400 text-lg mt-0.5">⚠️</span>
-                  <div className="text-sm space-y-2">
-                    <p className="font-medium text-yellow-300">
-                      {tokenError === 'rate_limited'
-                        ? 'GitHub API rate limit reached'
-                        : 'GitHub token is invalid or expired'}
-                    </p>
-                    <p className="text-muted-foreground">
-                      The fix browser needs a GitHub personal access token to fetch missions.
-                      Add one to your <code className="px-1.5 py-0.5 bg-white/10 rounded text-xs font-mono">.env</code> file and restart the console:
-                    </p>
-                    <ol className="text-muted-foreground list-decimal list-inside space-y-1.5 ml-1">
-                      <li>
-                        <a
-                          href="https://github.com/settings/tokens/new?description=KubeStellar+Console&scopes=public_repo"
-                          target="_blank"
-                          rel="noopener noreferrer"
-                          className="text-purple-400 hover:text-purple-300 underline"
-                        >
-                          Create a GitHub personal access token
-                        </a>
-                        {' '}(only <code className="px-1 py-0.5 bg-white/10 rounded text-xs font-mono">public_repo</code> scope needed)
-                      </li>
-                      <li>
-                        Add it to your <code className="px-1 py-0.5 bg-white/10 rounded text-xs font-mono">.env</code> file:
-                        <pre className="mt-1 px-3 py-2 bg-black/40 rounded text-xs font-mono text-purple-300 select-all">GITHUB_TOKEN=ghp_your_token_here</pre>
-                      </li>
-                      <li>{t('common.restartConsole')}</li>
-                    </ol>
-                  </div>
-                </div>
-              </div>
-            )}
-
-            {/* Recommended for You */}
-            {!selectedMission && missionFetchError && recommendations.length === 0 && !loadingRecommendations && (
-              <div className="mb-4">
-                <MissionFetchErrorBanner message={missionFetchError} />
-              </div>
-            )}
-
-            {/* Recommended for You */}
-            {!selectedMission && (recommendations.length > 0 || loadingRecommendations) && (
-              <CollapsibleSection
-                title={hasCluster ? 'Recommended for Your Cluster' : 'Explore CNCF Fixes'}
-                defaultOpen={true}
-                badge={
-                  <span className="flex items-center gap-2 text-xs text-purple-400">
-                    <span className="flex items-center gap-1">
-                      <Sparkles className="w-3.5 h-3.5" />
-                      {filteredRecommendations.length}
-                    </span>
-                    <button
-                      onClick={(e) => { e.stopPropagation(); resetMissionCache(); }}
-                      className="p-0.5 rounded hover:bg-secondary/80 text-muted-foreground hover:text-foreground transition-colors"
-                      title="Refresh recommendations"
-                    >
-                      <RefreshCw className="w-3 h-3" />
-                    </button>
-                  </span>
-                }
-                className="mb-6"
-              >
-                {/* Context subtitle */}
-                {!loadingRecommendations && (
-                  <p className="text-xs text-muted-foreground mb-3 -mt-1">
-                    {hasCluster
-                      ? '🎯 Matched based on your cluster resources, labels, and detected issues'
-                      : '🌐 Showing popular CNCF community fixes — connect a cluster for personalized recommendations'}
-                  </p>
-                )}
-                {loadingRecommendations ? (
-                  <div className="space-y-3">
-                    <div className="flex items-center gap-2 text-sm text-muted-foreground py-2">
-                      <Loader2 className="w-4 h-4 animate-spin text-purple-400" />
-                      <span className="flex-1">
-                        {searchProgress.step === 'Connecting' && 'Connecting to knowledge base…'}
-                        {searchProgress.step === 'Scanning' && (
-                          <>
-                            Scanning <span className="text-purple-400 font-mono">{searchProgress.detail}</span>
-                          </>
-                        )}
-                        {searchProgress.step === 'Error' && searchProgress.detail}
-                      </span>
-                      {searchProgress.found > 0 && (
-                        <span className="text-xs text-purple-400 tabular-nums">
-                          {searchProgress.found} found · {searchProgress.scanned} scanned
-                        </span>
-                      )}
-                    </div>
-                    {/* Show cards progressively as they arrive */}
-                    {filteredRecommendations.length > 0 && (
-                      <VirtualizedMissionGrid
-                        items={filteredRecommendations}
-                        viewMode="grid"
-                        maxColumns={3}
-                        className="flex-1 h-[calc(90vh-360px)]"
-                        renderItem={(match) => (
-                          <RecommendationCard
-                            match={match}
-                            onSelect={() => selectCardMission(match.mission)}
-                            onImport={() => handleImport(match.mission)}
-                            onCopyLink={(e) => handleCopyLink(match.mission, e)}
-                          />
-                        )}
-                      />
-                    )}
-                  </div>
-                ) : (
-                  <VirtualizedMissionGrid
-                    items={filteredRecommendations}
-                    viewMode="grid"
-                    maxColumns={3}
-                    className="flex-1 h-[calc(90vh-360px)]"
-                    renderItem={(match) => (
-                      <RecommendationCard
-                        match={match}
-                        onSelect={() => selectCardMission(match.mission)}
-                        onImport={() => handleImport(match.mission)}
-                      />
-                    )}
-                  />
-                )}
-              </CollapsibleSection>
-            )}
-
-            {/* Browse on GitHub link */}
-            {!selectedMission && !loading && (
-              <div className="flex items-center gap-2 mb-4 px-1">
-                <a
-                  href="https://github.com/kubestellar/console-kb/tree/master/fixes"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="inline-flex items-center gap-1.5 text-xs text-muted-foreground hover:text-purple-400 transition-colors"
-                  onClick={() => emitFixerGitHubLink()}
-                >
-                  <ExternalLink className="w-3.5 h-3.5" />
-                  Browse all fixes on GitHub
-                </a>
-                {searchProgress.step === 'Done' && searchProgress.found > 0 && (
-                  <span className="text-xs text-muted-foreground/60 ml-auto">
-                    {searchProgress.detail}
-                  </span>
-                )}
-              </div>
-            )}
-
-            {/* Directory listing */}
-            {loading ? (
-              <div className="flex items-center justify-center py-16">
-                <Loader2 className="w-6 h-6 text-muted-foreground animate-spin" />
-              </div>
-            ) : filteredEntries.length > 0 ? (
-              <DirectoryListing
-                entries={filteredEntries}
+            {/* ================================================================ */}
+            {/* RECOMMENDED TAB */}
+            {/* ================================================================ */}
+            {!selectedMission && !unstructuredContent && activeTab === 'recommended' && (
+              <MissionBrowserRecommendedTab
+                tokenError={tokenError}
+                missionFetchError={missionFetchError}
+                loadingRecommendations={loadingRecommendations}
+                searchProgress={searchProgress}
+                hasCluster={hasCluster}
+                recommendations={recommendations}
+                filteredRecommendations={filteredRecommendations}
+                onSelectMission={selectCardMission}
+                onImportMission={handleImport}
+                onCopyLink={handleCopyLink}
+                loading={loading}
+                filteredEntries={filteredEntries}
+                selectedPath={selectedPath}
                 viewMode={viewMode}
-                onSelect={(entry) => {
-                  const entrySource = selectedPath?.startsWith('github/') ? 'github' as const : 'community' as const
-                  const node: TreeNode = {
-                    id: entry.path,
-                    name: entry.name,
-                    path: entry.path,
-                    type: entry.type,
-                    source: entrySource,
-                    loaded: entry.type === 'file' }
-                  if (entry.type === 'file') {
-                    selectNode(node)
-                  } else {
-                    toggleNode(node)
-                    selectNode(node)
-                  }
-                }}
-                onImport={async (entry) => {
-                  try {
-                    const { data: content } = await api.get<string>(
-                      `/api/missions/file?path=${encodeURIComponent(entry.path)}`
-                    )
-                    const raw = typeof content === 'string' ? content : JSON.stringify(content, null, 2)
-                    const parsed = typeof content === 'string' ? JSON.parse(content) : content
-                    handleImport(parsed, raw)
-                  } catch { /* skip */ }
-                }}
+                onImportDirectoryEntry={handleImportDirectoryEntry}
+                onToggleNode={toggleNode}
+                onSelectNode={selectNode}
               />
-            ) : selectedPath ? (
-              <EmptyState message="No files in this directory" />
-            ) : (
-              <EmptyState message="Select a folder from the sidebar to browse missions" />
             )}
-            </>)}
 
-            {/* ============================================================ */}
+            {/* ================================================================ */}
             {/* INSTALLERS TAB */}
-            {/* ============================================================ */}
+            {/* ================================================================ */}
             {!selectedMission && !unstructuredContent && activeTab === 'installers' && (
-              <div className="space-y-4">
-                {/* Installer filters */}
-                <div className="flex flex-wrap items-center gap-2">
-                  <div className="flex-1 relative min-w-[200px]">
-                    <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-muted-foreground" />
-                    <input
-                      type="text"
-                      value={installerSearch}
-                      onChange={(e) => handleInstallerSearchChange(e.target.value)}
-                      placeholder="Search installers…"
-                      className="w-full pl-10 pr-4 py-1.5 bg-secondary border border-border rounded-lg text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-purple-500/40"
-                    />
-                  </div>
-                  {!installerSearch && searchQuery && (
-                    <span className="text-xs text-purple-400 flex items-center gap-1">
-                      <Filter className="w-3 h-3" />
-                      Filtered by global search: &quot;{searchQuery}&quot;
-                    </span>
-                  )}
-                  <select
-                    value={installerCategoryFilter}
-                    onChange={(e) => setInstallerCategoryFilter(e.target.value)}
-                    className="px-2.5 py-1.5 text-xs bg-secondary border border-border rounded-lg text-foreground"
-                  >
-                    {CNCF_CATEGORIES.map(cat => (
-                      <option key={cat} value={cat}>{cat === 'All' ? 'All Categories' : cat}</option>
-                    ))}
-                  </select>
-                  <select
-                    value={installerMaturityFilter}
-                    onChange={(e) => setInstallerMaturityFilter(e.target.value)}
-                    className="px-2.5 py-1.5 text-xs bg-secondary border border-border rounded-lg text-foreground"
-                  >
-                    {MATURITY_LEVELS.map(m => (
-                      <option key={m} value={m}>{m === 'All' ? 'All Maturity' : m.charAt(0).toUpperCase() + m.slice(1)}</option>
-                    ))}
-                  </select>
-                </div>
-
-                {/* Fetch error banner */}
-                {missionFetchError && installerMissions.length === 0 && (
-                  <MissionFetchErrorBanner message={missionFetchError} />
-                )}
-
-                {/* Installer grid */}
-                {loadingInstallers && filteredInstallers.length === 0 ? (
-                  <div className="flex items-center gap-2 text-sm text-muted-foreground py-8 justify-center">
-                    <Loader2 className="w-4 h-4 animate-spin text-purple-400" />
-                    Loading CNCF installers…
-                  </div>
-                ) : filteredInstallers.length === 0 && !loadingInstallers ? (
-                  <EmptyState message={installerMissions.length > 0 ? 'No installers match your filters' : 'No installer missions found'} />
-                ) : (
-                  <>
-                    {loadingInstallers && (
-                      <div className="flex items-center gap-2 text-sm text-muted-foreground py-2">
-                        <Loader2 className="w-4 h-4 animate-spin text-purple-400" />
-                        Loading… {installerMissions.length} found so far
-                      </div>
-                    )}
-                    <VirtualizedMissionGrid
-                      items={filteredInstallers}
-                      viewMode={viewMode}
-                      maxColumns={4}
-                      className="flex-1 h-[calc(90vh-280px)]"
-                      renderItem={(mission) => (
-                        <InstallerCard
-                          mission={mission}
-                          compact={viewMode === 'list'}
-                          onSelect={() => selectCardMission(mission)}
-                          onImport={() => handleImport(mission)}
-                          onCopyLink={(e) => handleCopyLink(mission, e)}
-                        />
-                      )}
-                    />
-                  </>
-                )}
-
-                {/* Count footer */}
-                {filteredInstallers.length > 0 && (
-                  <p className="text-xs text-muted-foreground text-center pt-2">
-                    {loadingInstallers ? `${filteredInstallers.length} loaded…` : `Showing ${filteredInstallers.length} of ${installerMissions.length} installer missions`}
-                  </p>
-                )}
-              </div>
+              <MissionBrowserInstallersTab
+                installerMissions={installerMissions}
+                filteredInstallers={filteredInstallers}
+                loadingInstallers={loadingInstallers}
+                missionFetchError={missionFetchError}
+                installerSearch={installerSearch}
+                onInstallerSearchChange={handleInstallerSearchChange}
+                globalSearchActive={!!searchQuery}
+                globalSearchQuery={searchQuery}
+                installerCategoryFilter={installerCategoryFilter}
+                onInstallerCategoryFilterChange={setInstallerCategoryFilter}
+                installerMaturityFilter={installerMaturityFilter}
+                onInstallerMaturityFilterChange={setInstallerMaturityFilter}
+                viewMode={viewMode}
+                onSelectMission={selectCardMission}
+                onImportMission={handleImport}
+                onCopyLink={handleCopyLink}
+              />
             )}
 
-            {/* ============================================================ */}
+            {/* ================================================================ */}
             {/* FIXES TAB */}
-            {/* ============================================================ */}
+            {/* ================================================================ */}
             {!selectedMission && !unstructuredContent && activeTab === 'fixes' && (
-              <div className="space-y-4">
-                {/* Fixer filters */}
-                <div className="flex flex-wrap items-center gap-2">
-                  <div className="flex-1 relative min-w-[200px]">
-                    <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-muted-foreground" />
-                    <input
-                      type="text"
-                      value={fixerSearch}
-                      onChange={(e) => handleFixerSearchChange(e.target.value)}
-                      placeholder="Search fixes…"
-                      className="w-full pl-10 pr-4 py-1.5 bg-secondary border border-border rounded-lg text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-purple-500/40"
-                    />
-                  </div>
-                  {!fixerSearch && searchQuery && (
-                    <span className="text-xs text-purple-400 flex items-center gap-1">
-                      <Filter className="w-3 h-3" />
-                      Filtered by global search: &quot;{searchQuery}&quot;
-                    </span>
-                  )}
-                  <select
-                    value={fixerTypeFilter}
-                    onChange={(e) => setFixerTypeFilter(e.target.value)}
-                    className="px-2.5 py-1.5 text-xs bg-secondary border border-border rounded-lg text-foreground"
-                  >
-                    {CATEGORY_FILTERS.map(cat => (
-                      <option key={cat} value={cat}>{cat === 'All' ? 'All Types' : cat}</option>
-                    ))}
-                  </select>
-                </div>
-
-                {/* Fetch error banner */}
-                {missionFetchError && fixerMissions.length === 0 && (
-                  <MissionFetchErrorBanner message={missionFetchError} />
-                )}
-
-                {/* Fixer grid */}
-                {loadingFixers && filteredFixers.length === 0 ? (
-                  <div className="flex items-center gap-2 text-sm text-muted-foreground py-8 justify-center">
-                    <Loader2 className="w-4 h-4 animate-spin text-purple-400" />
-                    Loading fixes…
-                  </div>
-                ) : filteredFixers.length === 0 && !loadingFixers ? (
-                  <EmptyState message={fixerMissions.length > 0 ? 'No fixes match your filters' : 'No fixer missions found'} />
-                ) : (
-                  <>
-                    {loadingFixers && (
-                      <div className="flex items-center gap-2 text-sm text-muted-foreground py-2">
-                        <Loader2 className="w-4 h-4 animate-spin text-purple-400" />
-                        Loading… {fixerMissions.length} found so far
-                      </div>
-                    )}
-                    <VirtualizedMissionGrid
-                      items={filteredFixers}
-                      viewMode={viewMode}
-                      maxColumns={3}
-                      className="flex-1 h-[calc(90vh-280px)]"
-                      renderItem={(mission) => (
-                        <FixerCard
-                          mission={mission}
-                          compact={viewMode === 'list'}
-                          onSelect={() => selectCardMission(mission)}
-                          onImport={() => handleImport(mission)}
-                          onCopyLink={(e) => handleCopyLink(mission, e)}
-                        />
-                      )}
-                    />
-                  </>
-                )}
-
-                {/* Count footer */}
-                {filteredFixers.length > 0 && (
-                  <p className="text-xs text-muted-foreground text-center pt-2">
-                    {loadingFixers ? `${filteredFixers.length} loaded…` : `Showing ${filteredFixers.length} of ${fixerMissions.length} fixer missions`}
-                  </p>
-                )}
-              </div>
+              <MissionBrowserFixesTab
+                fixerMissions={fixerMissions}
+                filteredFixers={filteredFixers}
+                loadingFixers={loadingFixers}
+                missionFetchError={missionFetchError}
+                fixerSearch={fixerSearch}
+                onFixerSearchChange={handleFixerSearchChange}
+                globalSearchActive={!!searchQuery}
+                globalSearchQuery={searchQuery}
+                fixerTypeFilter={fixerTypeFilter}
+                onFixerTypeFilterChange={setFixerTypeFilter}
+                viewMode={viewMode}
+                onSelectMission={selectCardMission}
+                onImportMission={handleImport}
+                onCopyLink={handleCopyLink}
+              />
             )}
           </div>
         </div>
@@ -1804,4 +1205,3 @@ export function MissionBrowser({ isOpen, onClose, onImport, initialMission, onUs
     </div>
   )
 }
-

--- a/web/src/components/missions/MissionBrowserFilterPanel.tsx
+++ b/web/src/components/missions/MissionBrowserFilterPanel.tsx
@@ -1,0 +1,276 @@
+/**
+ * MissionBrowserFilterPanel
+ *
+ * The collapsible filter bar rendered below the top bar in the Mission Browser.
+ * Contains: match-percent buttons, source filter, category filter, class filter,
+ * maturity filter, difficulty filter, CNCF project text input, and top-tag chips.
+ *
+ * Extracted from MissionBrowser.tsx (issue #8624).
+ */
+
+import { X } from 'lucide-react'
+import { cn } from '../../lib/cn'
+import { CATEGORY_FILTERS } from './missionBrowserConstants'
+
+interface FacetCounts {
+  clusterMatched: number
+  community: number
+  missionClass: Map<string, number>
+  maturity: Map<string, number>
+  difficulty: Map<string, number>
+  topTags: { tag: string; count: number }[]
+}
+
+interface MissionBrowserFilterPanelProps {
+  activeFilterCount: number
+  onClearAllFilters: () => void
+
+  minMatchPercent: number
+  onMinMatchPercentChange: (value: number) => void
+
+  matchSourceFilter: 'all' | 'cluster' | 'community'
+  onMatchSourceFilterChange: (value: 'all' | 'cluster' | 'community') => void
+
+  categoryFilter: string
+  onCategoryFilterChange: (value: string) => void
+
+  missionClassFilter: string
+  onMissionClassFilterChange: (value: string) => void
+
+  maturityFilter: string
+  onMaturityFilterChange: (value: string) => void
+
+  difficultyFilter: string
+  onDifficultyFilterChange: (value: string) => void
+
+  cncfFilter: string
+  onCncfFilterChange: (value: string) => void
+
+  selectedTags: Set<string>
+  onTagToggle: (tag: string) => void
+  onClearTags: () => void
+
+  facetCounts: FacetCounts
+
+  recommendationsTotal: number
+  filteredRecommendationsCount: number
+}
+
+/** Match-percentage options shown as pill buttons in the filter bar. */
+const MATCH_PCT_OPTIONS = [0, 25, 50, 75] as const
+
+export function MissionBrowserFilterPanel({
+  activeFilterCount,
+  onClearAllFilters,
+  minMatchPercent,
+  onMinMatchPercentChange,
+  matchSourceFilter,
+  onMatchSourceFilterChange,
+  categoryFilter,
+  onCategoryFilterChange,
+  missionClassFilter,
+  onMissionClassFilterChange,
+  maturityFilter,
+  onMaturityFilterChange,
+  difficultyFilter,
+  onDifficultyFilterChange,
+  cncfFilter,
+  onCncfFilterChange,
+  selectedTags,
+  onTagToggle,
+  onClearTags,
+  facetCounts,
+  recommendationsTotal,
+  filteredRecommendationsCount,
+}: MissionBrowserFilterPanelProps) {
+  return (
+    <div className="px-4 py-2.5 bg-card border-b border-border space-y-2 max-h-[40vh] md:max-h-[50vh] overflow-y-auto">
+      {/* Row 1: Clear all + Match % + Source + Category */}
+      <div className="flex items-center gap-3 flex-wrap">
+        {activeFilterCount > 0 && (
+          <button
+            onClick={onClearAllFilters}
+            className="inline-flex items-center gap-1 px-2 py-1 text-[11px] rounded-full bg-red-500/10 text-red-400 hover:bg-red-500/20 border border-red-500/20 transition-colors"
+          >
+            <X className="w-3 h-3" />
+            Clear all
+          </button>
+        )}
+
+        <span className="text-xs text-muted-foreground font-medium">Match:</span>
+        <div className="flex items-center gap-1">
+          {MATCH_PCT_OPTIONS.map((pct) => (
+            <button
+              key={pct}
+              onClick={() => onMinMatchPercentChange(pct)}
+              className={cn(
+                'px-2 py-0.5 text-[11px] rounded-full transition-colors tabular-nums',
+                minMatchPercent === pct
+                  ? 'bg-purple-500/20 text-purple-400 border border-purple-500/30'
+                  : 'bg-secondary text-muted-foreground hover:text-foreground border border-transparent',
+              )}
+            >
+              {pct === 0 ? 'Any' : `≥${pct}%`}
+            </button>
+          ))}
+        </div>
+
+        <div className="w-px h-4 bg-border" />
+
+        <span className="text-xs text-muted-foreground font-medium">Source:</span>
+        <div className="flex items-center gap-1">
+          {(
+            [
+              ['all', 'All', null],
+              ['cluster', '🎯 Cluster', facetCounts.clusterMatched],
+              ['community', '🌐 Community', facetCounts.community],
+            ] as const
+          ).map(([val, label, count]) => (
+            <button
+              key={val}
+              onClick={() => onMatchSourceFilterChange(val)}
+              className={cn(
+                'px-2 py-0.5 text-[11px] rounded-full transition-colors',
+                matchSourceFilter === val
+                  ? 'bg-purple-500/20 text-purple-400 border border-purple-500/30'
+                  : 'bg-secondary text-muted-foreground hover:text-foreground border border-transparent',
+              )}
+            >
+              {label}
+              {count != null ? ` (${count})` : ''}
+            </button>
+          ))}
+        </div>
+
+        <div className="w-px h-4 bg-border" />
+
+        <span className="text-xs text-muted-foreground font-medium">Category:</span>
+        <div className="flex items-center gap-1">
+          {CATEGORY_FILTERS.map((cat) => (
+            <button
+              key={cat}
+              onClick={() => onCategoryFilterChange(cat)}
+              className={cn(
+                'px-2 py-0.5 text-[11px] rounded-full transition-colors',
+                categoryFilter === cat
+                  ? 'bg-purple-500/20 text-purple-400 border border-purple-500/30'
+                  : 'bg-secondary text-muted-foreground hover:text-foreground border border-transparent',
+              )}
+            >
+              {cat}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {/* Row 2: Class + Maturity + Difficulty + CNCF Project */}
+      <div className="flex items-center gap-3 flex-wrap">
+        <span className="text-xs text-muted-foreground font-medium">Class:</span>
+        <div className="flex items-center gap-1">
+          {['All', ...Array.from(facetCounts.missionClass.keys())].map((cls) => (
+            <button
+              key={cls}
+              onClick={() => onMissionClassFilterChange(cls)}
+              className={cn(
+                'px-2 py-0.5 text-[11px] rounded-full transition-colors capitalize',
+                missionClassFilter === cls
+                  ? 'bg-purple-500/20 text-purple-400 border border-purple-500/30'
+                  : 'bg-secondary text-muted-foreground hover:text-foreground border border-transparent',
+              )}
+            >
+              {cls === 'All' ? cls : `${cls} (${facetCounts.missionClass.get(cls) || 0})`}
+            </button>
+          ))}
+        </div>
+
+        <div className="w-px h-4 bg-border" />
+
+        <span className="text-xs text-muted-foreground font-medium">Maturity:</span>
+        <div className="flex items-center gap-1">
+          {['All', ...Array.from(facetCounts.maturity.keys())].map((mat) => (
+            <button
+              key={mat}
+              onClick={() => onMaturityFilterChange(mat)}
+              className={cn(
+                'px-2 py-0.5 text-[11px] rounded-full transition-colors capitalize',
+                maturityFilter === mat
+                  ? 'bg-purple-500/20 text-purple-400 border border-purple-500/30'
+                  : 'bg-secondary text-muted-foreground hover:text-foreground border border-transparent',
+              )}
+            >
+              {mat === 'All' ? mat : `${mat} (${facetCounts.maturity.get(mat) || 0})`}
+            </button>
+          ))}
+        </div>
+
+        <div className="w-px h-4 bg-border" />
+
+        <span className="text-xs text-muted-foreground font-medium">Difficulty:</span>
+        <div className="flex items-center gap-1">
+          {['All', ...Array.from(facetCounts.difficulty.keys())].map((diff) => (
+            <button
+              key={diff}
+              onClick={() => onDifficultyFilterChange(diff)}
+              className={cn(
+                'px-2 py-0.5 text-[11px] rounded-full transition-colors capitalize',
+                difficultyFilter === diff
+                  ? 'bg-purple-500/20 text-purple-400 border border-purple-500/30'
+                  : 'bg-secondary text-muted-foreground hover:text-foreground border border-transparent',
+              )}
+            >
+              {diff === 'All' ? diff : `${diff} (${facetCounts.difficulty.get(diff) || 0})`}
+            </button>
+          ))}
+        </div>
+
+        <div className="w-px h-4 bg-border" />
+
+        <span className="text-xs text-muted-foreground font-medium">CNCF:</span>
+        <input
+          type="text"
+          value={cncfFilter}
+          onChange={(e) => onCncfFilterChange(e.target.value)}
+          placeholder="e.g. Istio, Envoy…"
+          className="w-36 px-2 py-0.5 text-[11px] bg-secondary border border-border rounded-lg text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-purple-500/40"
+        />
+      </div>
+
+      {/* Row 3: Top tags */}
+      {facetCounts.topTags.length > 0 && (
+        <div className="flex items-center gap-2 flex-wrap">
+          <span className="text-xs text-muted-foreground font-medium">Tags:</span>
+          {facetCounts.topTags.map(({ tag, count }: { tag: string; count: number }) => (
+            <button
+              key={tag}
+              onClick={() => onTagToggle(tag)}
+              className={cn(
+                'px-2 py-0.5 text-[11px] rounded-full transition-colors',
+                selectedTags.has(tag)
+                  ? 'bg-purple-500/20 text-purple-400 border border-purple-500/30'
+                  : 'bg-secondary text-muted-foreground hover:text-foreground border border-transparent',
+              )}
+            >
+              {tag} <span className="opacity-60">({count})</span>
+            </button>
+          ))}
+          {selectedTags.size > 0 && (
+            <button
+              onClick={onClearTags}
+              className="text-[11px] text-muted-foreground hover:text-foreground underline"
+            >
+              clear tags
+            </button>
+          )}
+        </div>
+      )}
+
+      {/* Active filter summary */}
+      {recommendationsTotal > 0 && (
+        <div className="text-[11px] text-muted-foreground">
+          Showing {filteredRecommendationsCount} of {recommendationsTotal} missions
+          {activeFilterCount > 0 && ' (filtered)'}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/web/src/components/missions/MissionBrowserFixesTab.tsx
+++ b/web/src/components/missions/MissionBrowserFixesTab.tsx
@@ -1,0 +1,141 @@
+/**
+ * MissionBrowserFixesTab
+ *
+ * Content panel for the "Fixes" tab inside the Mission Browser.
+ * Renders: search input, type filter, fetch-error banner, and a virtualised
+ * grid/list of FixerCard items.
+ *
+ * Extracted from MissionBrowser.tsx (issue #8624).
+ */
+
+import { Search, Filter, Loader2 } from 'lucide-react'
+import { FixerCard } from './FixerCard'
+import { EmptyState, MissionFetchErrorBanner, VirtualizedMissionGrid } from './browser'
+import type { ViewMode } from './browser'
+import type { MissionExport } from '../../lib/missions/types'
+import { CATEGORY_FILTERS } from './missionBrowserConstants'
+
+interface MissionBrowserFixesTabProps {
+  fixerMissions: MissionExport[]
+  filteredFixers: MissionExport[]
+  loadingFixers: boolean
+  missionFetchError: string | null
+
+  fixerSearch: string
+  onFixerSearchChange: (value: string) => void
+  /** When the user types in the tab-local search but a global search is also active */
+  globalSearchActive: boolean
+  globalSearchQuery: string
+
+  fixerTypeFilter: string
+  onFixerTypeFilterChange: (value: string) => void
+
+  viewMode: ViewMode
+  onSelectMission: (mission: MissionExport) => void
+  onImportMission: (mission: MissionExport) => void
+  onCopyLink: (mission: MissionExport, e: React.MouseEvent) => void
+}
+
+export function MissionBrowserFixesTab({
+  fixerMissions,
+  filteredFixers,
+  loadingFixers,
+  missionFetchError,
+  fixerSearch,
+  onFixerSearchChange,
+  globalSearchActive,
+  globalSearchQuery,
+  fixerTypeFilter,
+  onFixerTypeFilterChange,
+  viewMode,
+  onSelectMission,
+  onImportMission,
+  onCopyLink,
+}: MissionBrowserFixesTabProps) {
+  return (
+    <div className="space-y-4">
+      {/* Fixer filters */}
+      <div className="flex flex-wrap items-center gap-2">
+        <div className="flex-1 relative min-w-[200px]">
+          <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-muted-foreground" />
+          <input
+            type="text"
+            value={fixerSearch}
+            onChange={(e) => onFixerSearchChange(e.target.value)}
+            placeholder="Search fixes…"
+            className="w-full pl-10 pr-4 py-1.5 bg-secondary border border-border rounded-lg text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-purple-500/40"
+          />
+        </div>
+        {!fixerSearch && globalSearchActive && (
+          <span className="text-xs text-purple-400 flex items-center gap-1">
+            <Filter className="w-3 h-3" />
+            Filtered by global search: &quot;{globalSearchQuery}&quot;
+          </span>
+        )}
+        <select
+          value={fixerTypeFilter}
+          onChange={(e) => onFixerTypeFilterChange(e.target.value)}
+          className="px-2.5 py-1.5 text-xs bg-secondary border border-border rounded-lg text-foreground"
+        >
+          {CATEGORY_FILTERS.map((cat) => (
+            <option key={cat} value={cat}>
+              {cat === 'All' ? 'All Types' : cat}
+            </option>
+          ))}
+        </select>
+      </div>
+
+      {/* Fetch error banner */}
+      {missionFetchError && fixerMissions.length === 0 && (
+        <MissionFetchErrorBanner message={missionFetchError} />
+      )}
+
+      {/* Fixer grid */}
+      {loadingFixers && filteredFixers.length === 0 ? (
+        <div className="flex items-center gap-2 text-sm text-muted-foreground py-8 justify-center">
+          <Loader2 className="w-4 h-4 animate-spin text-purple-400" />
+          Loading fixes…
+        </div>
+      ) : filteredFixers.length === 0 && !loadingFixers ? (
+        <EmptyState
+          message={
+            fixerMissions.length > 0 ? 'No fixes match your filters' : 'No fixer missions found'
+          }
+        />
+      ) : (
+        <>
+          {loadingFixers && (
+            <div className="flex items-center gap-2 text-sm text-muted-foreground py-2">
+              <Loader2 className="w-4 h-4 animate-spin text-purple-400" />
+              Loading… {fixerMissions.length} found so far
+            </div>
+          )}
+          <VirtualizedMissionGrid
+            items={filteredFixers}
+            viewMode={viewMode}
+            maxColumns={3}
+            className="flex-1 h-[calc(90vh-280px)]"
+            renderItem={(mission) => (
+              <FixerCard
+                mission={mission}
+                compact={viewMode === 'list'}
+                onSelect={() => onSelectMission(mission)}
+                onImport={() => onImportMission(mission)}
+                onCopyLink={(e) => onCopyLink(mission, e)}
+              />
+            )}
+          />
+        </>
+      )}
+
+      {/* Count footer */}
+      {filteredFixers.length > 0 && (
+        <p className="text-xs text-muted-foreground text-center pt-2">
+          {loadingFixers
+            ? `${filteredFixers.length} loaded…`
+            : `Showing ${filteredFixers.length} of ${fixerMissions.length} fixer missions`}
+        </p>
+      )}
+    </div>
+  )
+}

--- a/web/src/components/missions/MissionBrowserInstallersTab.tsx
+++ b/web/src/components/missions/MissionBrowserInstallersTab.tsx
@@ -1,0 +1,159 @@
+/**
+ * MissionBrowserInstallersTab
+ *
+ * Content panel for the "Installers" tab inside the Mission Browser.
+ * Renders: search input, category/maturity filters, fetch-error banner,
+ * and a virtualised grid/list of InstallerCard items.
+ *
+ * Extracted from MissionBrowser.tsx (issue #8624).
+ */
+
+import { Search, Filter, Loader2 } from 'lucide-react'
+import { InstallerCard } from './InstallerCard'
+import { EmptyState, MissionFetchErrorBanner, VirtualizedMissionGrid } from './browser'
+import type { ViewMode } from './browser'
+import type { MissionExport } from '../../lib/missions/types'
+import { CNCF_CATEGORIES, MATURITY_LEVELS } from './missionBrowserConstants'
+
+interface MissionBrowserInstallersTabProps {
+  installerMissions: MissionExport[]
+  filteredInstallers: MissionExport[]
+  loadingInstallers: boolean
+  missionFetchError: string | null
+
+  installerSearch: string
+  onInstallerSearchChange: (value: string) => void
+  /** When the user types in the tab-local search but a global search is active */
+  globalSearchActive: boolean
+  globalSearchQuery: string
+
+  installerCategoryFilter: string
+  onInstallerCategoryFilterChange: (value: string) => void
+
+  installerMaturityFilter: string
+  onInstallerMaturityFilterChange: (value: string) => void
+
+  viewMode: ViewMode
+  onSelectMission: (mission: MissionExport) => void
+  onImportMission: (mission: MissionExport) => void
+  onCopyLink: (mission: MissionExport, e: React.MouseEvent) => void
+}
+
+export function MissionBrowserInstallersTab({
+  installerMissions,
+  filteredInstallers,
+  loadingInstallers,
+  missionFetchError,
+  installerSearch,
+  onInstallerSearchChange,
+  globalSearchActive,
+  globalSearchQuery,
+  installerCategoryFilter,
+  onInstallerCategoryFilterChange,
+  installerMaturityFilter,
+  onInstallerMaturityFilterChange,
+  viewMode,
+  onSelectMission,
+  onImportMission,
+  onCopyLink,
+}: MissionBrowserInstallersTabProps) {
+  return (
+    <div className="space-y-4">
+      {/* Installer filters */}
+      <div className="flex flex-wrap items-center gap-2">
+        <div className="flex-1 relative min-w-[200px]">
+          <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-muted-foreground" />
+          <input
+            type="text"
+            value={installerSearch}
+            onChange={(e) => onInstallerSearchChange(e.target.value)}
+            placeholder="Search installers…"
+            className="w-full pl-10 pr-4 py-1.5 bg-secondary border border-border rounded-lg text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-purple-500/40"
+          />
+        </div>
+        {!installerSearch && globalSearchActive && (
+          <span className="text-xs text-purple-400 flex items-center gap-1">
+            <Filter className="w-3 h-3" />
+            Filtered by global search: &quot;{globalSearchQuery}&quot;
+          </span>
+        )}
+        <select
+          value={installerCategoryFilter}
+          onChange={(e) => onInstallerCategoryFilterChange(e.target.value)}
+          className="px-2.5 py-1.5 text-xs bg-secondary border border-border rounded-lg text-foreground"
+        >
+          {CNCF_CATEGORIES.map((cat) => (
+            <option key={cat} value={cat}>
+              {cat === 'All' ? 'All Categories' : cat}
+            </option>
+          ))}
+        </select>
+        <select
+          value={installerMaturityFilter}
+          onChange={(e) => onInstallerMaturityFilterChange(e.target.value)}
+          className="px-2.5 py-1.5 text-xs bg-secondary border border-border rounded-lg text-foreground"
+        >
+          {MATURITY_LEVELS.map((m) => (
+            <option key={m} value={m}>
+              {m === 'All' ? 'All Maturity' : m.charAt(0).toUpperCase() + m.slice(1)}
+            </option>
+          ))}
+        </select>
+      </div>
+
+      {/* Fetch error banner */}
+      {missionFetchError && installerMissions.length === 0 && (
+        <MissionFetchErrorBanner message={missionFetchError} />
+      )}
+
+      {/* Installer grid */}
+      {loadingInstallers && filteredInstallers.length === 0 ? (
+        <div className="flex items-center gap-2 text-sm text-muted-foreground py-8 justify-center">
+          <Loader2 className="w-4 h-4 animate-spin text-purple-400" />
+          Loading CNCF installers…
+        </div>
+      ) : filteredInstallers.length === 0 && !loadingInstallers ? (
+        <EmptyState
+          message={
+            installerMissions.length > 0
+              ? 'No installers match your filters'
+              : 'No installer missions found'
+          }
+        />
+      ) : (
+        <>
+          {loadingInstallers && (
+            <div className="flex items-center gap-2 text-sm text-muted-foreground py-2">
+              <Loader2 className="w-4 h-4 animate-spin text-purple-400" />
+              Loading… {installerMissions.length} found so far
+            </div>
+          )}
+          <VirtualizedMissionGrid
+            items={filteredInstallers}
+            viewMode={viewMode}
+            maxColumns={4}
+            className="flex-1 h-[calc(90vh-280px)]"
+            renderItem={(mission) => (
+              <InstallerCard
+                mission={mission}
+                compact={viewMode === 'list'}
+                onSelect={() => onSelectMission(mission)}
+                onImport={() => onImportMission(mission)}
+                onCopyLink={(e) => onCopyLink(mission, e)}
+              />
+            )}
+          />
+        </>
+      )}
+
+      {/* Count footer */}
+      {filteredInstallers.length > 0 && (
+        <p className="text-xs text-muted-foreground text-center pt-2">
+          {loadingInstallers
+            ? `${filteredInstallers.length} loaded…`
+            : `Showing ${filteredInstallers.length} of ${installerMissions.length} installer missions`}
+        </p>
+      )}
+    </div>
+  )
+}

--- a/web/src/components/missions/MissionBrowserRecommendedTab.tsx
+++ b/web/src/components/missions/MissionBrowserRecommendedTab.tsx
@@ -1,0 +1,279 @@
+/**
+ * MissionBrowserRecommendedTab
+ *
+ * Content panel for the "Recommended" tab inside the Mission Browser.
+ * Renders: token/rate-limit warning, fetch-error banner, cluster-matched
+ * recommendations (with progressive loading), "Browse on GitHub" link, and
+ * the directory listing for tree-navigation.
+ *
+ * Extracted from MissionBrowser.tsx (issue #8624).
+ */
+
+import { Loader2, Sparkles, RefreshCw, ExternalLink } from 'lucide-react'
+import { emitFixerGitHubLink } from '../../lib/analytics'
+import { useTranslation } from 'react-i18next'
+import { CollapsibleSection } from '../ui/CollapsibleSection'
+import {
+  RecommendationCard,
+  EmptyState,
+  MissionFetchErrorBanner,
+  VirtualizedMissionGrid,
+  DirectoryListing,
+  resetMissionCache,
+} from './browser'
+import type { TreeNode, ViewMode } from './browser'
+import type { MissionMatch, MissionExport, BrowseEntry } from '../../lib/missions/types'
+
+interface SearchProgress {
+  step: string
+  detail: string
+  found: number
+  scanned: number
+}
+
+interface MissionBrowserRecommendedTabProps {
+  tokenError: 'rate_limited' | 'token_invalid' | null
+  missionFetchError: string | null
+  loadingRecommendations: boolean
+  searchProgress: SearchProgress
+  hasCluster: boolean
+  recommendations: MissionMatch[]
+  filteredRecommendations: MissionMatch[]
+  onSelectMission: (mission: MissionExport) => void
+  onImportMission: (mission: MissionExport) => void
+  onCopyLink: (mission: MissionExport, e: React.MouseEvent) => void
+
+  // Directory listing (tree navigation)
+  loading: boolean
+  filteredEntries: BrowseEntry[]
+  selectedPath: string | null
+  viewMode: ViewMode
+  /** Called when the user imports a file from the directory listing (parent handles API fetch) */
+  onImportDirectoryEntry: (entry: BrowseEntry) => void
+  onToggleNode: (node: TreeNode) => void
+  onSelectNode: (node: TreeNode) => void
+}
+
+export function MissionBrowserRecommendedTab({
+  tokenError,
+  missionFetchError,
+  loadingRecommendations,
+  searchProgress,
+  hasCluster,
+  recommendations,
+  filteredRecommendations,
+  onSelectMission,
+  onImportMission,
+  onCopyLink,
+  loading,
+  filteredEntries,
+  selectedPath,
+  viewMode,
+  onImportDirectoryEntry,
+  onToggleNode,
+  onSelectNode,
+}: MissionBrowserRecommendedTabProps) {
+  const { t } = useTranslation(['common'])
+
+  return (
+    <>
+      {/* Token / rate-limit guidance banner */}
+      {tokenError && (
+        <div className="mb-4 rounded-lg border border-yellow-500/30 bg-yellow-500/10 p-4">
+          <div className="flex items-start gap-3">
+            <span className="text-yellow-400 text-lg mt-0.5">⚠️</span>
+            <div className="text-sm space-y-2">
+              <p className="font-medium text-yellow-300">
+                {tokenError === 'rate_limited'
+                  ? 'GitHub API rate limit reached'
+                  : 'GitHub token is invalid or expired'}
+              </p>
+              <p className="text-muted-foreground">
+                The fix browser needs a GitHub personal access token to fetch missions. Add one to
+                your{' '}
+                <code className="px-1.5 py-0.5 bg-white/10 rounded text-xs font-mono">.env</code>{' '}
+                file and restart the console:
+              </p>
+              <ol className="text-muted-foreground list-decimal list-inside space-y-1.5 ml-1">
+                <li>
+                  <a
+                    href="https://github.com/settings/tokens/new?description=KubeStellar+Console&scopes=public_repo"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="text-purple-400 hover:text-purple-300 underline"
+                  >
+                    Create a GitHub personal access token
+                  </a>{' '}
+                  (only{' '}
+                  <code className="px-1 py-0.5 bg-white/10 rounded text-xs font-mono">
+                    public_repo
+                  </code>{' '}
+                  scope needed)
+                </li>
+                <li>
+                  Add it to your{' '}
+                  <code className="px-1 py-0.5 bg-white/10 rounded text-xs font-mono">.env</code>{' '}
+                  file:
+                  <pre className="mt-1 px-3 py-2 bg-black/40 rounded text-xs font-mono text-purple-300 select-all">
+                    GITHUB_TOKEN=ghp_your_token_here
+                  </pre>
+                </li>
+                <li>{t('common.restartConsole')}</li>
+              </ol>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* Fetch error — only shown when there are no recommendations to display */}
+      {missionFetchError && recommendations.length === 0 && !loadingRecommendations && (
+        <div className="mb-4">
+          <MissionFetchErrorBanner message={missionFetchError} />
+        </div>
+      )}
+
+      {/* Recommended for You / Explore CNCF Fixes */}
+      {(recommendations.length > 0 || loadingRecommendations) && (
+        <CollapsibleSection
+          title={hasCluster ? 'Recommended for Your Cluster' : 'Explore CNCF Fixes'}
+          defaultOpen={true}
+          badge={
+            <span className="flex items-center gap-2 text-xs text-purple-400">
+              <span className="flex items-center gap-1">
+                <Sparkles className="w-3.5 h-3.5" />
+                {filteredRecommendations.length}
+              </span>
+              <button
+                onClick={(e) => {
+                  e.stopPropagation()
+                  resetMissionCache()
+                }}
+                className="p-0.5 rounded hover:bg-secondary/80 text-muted-foreground hover:text-foreground transition-colors"
+                title="Refresh recommendations"
+              >
+                <RefreshCw className="w-3 h-3" />
+              </button>
+            </span>
+          }
+          className="mb-6"
+        >
+          {/* Context subtitle */}
+          {!loadingRecommendations && (
+            <p className="text-xs text-muted-foreground mb-3 -mt-1">
+              {hasCluster
+                ? '🎯 Matched based on your cluster resources, labels, and detected issues'
+                : '🌐 Showing popular CNCF community fixes — connect a cluster for personalized recommendations'}
+            </p>
+          )}
+
+          {loadingRecommendations ? (
+            <div className="space-y-3">
+              <div className="flex items-center gap-2 text-sm text-muted-foreground py-2">
+                <Loader2 className="w-4 h-4 animate-spin text-purple-400" />
+                <span className="flex-1">
+                  {searchProgress.step === 'Connecting' && 'Connecting to knowledge base…'}
+                  {searchProgress.step === 'Scanning' && (
+                    <>
+                      Scanning{' '}
+                      <span className="text-purple-400 font-mono">{searchProgress.detail}</span>
+                    </>
+                  )}
+                  {searchProgress.step === 'Error' && searchProgress.detail}
+                </span>
+                {searchProgress.found > 0 && (
+                  <span className="text-xs text-purple-400 tabular-nums">
+                    {searchProgress.found} found · {searchProgress.scanned} scanned
+                  </span>
+                )}
+              </div>
+              {/* Progressive cards while loading */}
+              {filteredRecommendations.length > 0 && (
+                <VirtualizedMissionGrid
+                  items={filteredRecommendations}
+                  viewMode="grid"
+                  maxColumns={3}
+                  className="flex-1 h-[calc(90vh-360px)]"
+                  renderItem={(match) => (
+                    <RecommendationCard
+                      match={match}
+                      onSelect={() => onSelectMission(match.mission)}
+                      onImport={() => onImportMission(match.mission)}
+                      onCopyLink={(e) => onCopyLink(match.mission, e)}
+                    />
+                  )}
+                />
+              )}
+            </div>
+          ) : (
+            <VirtualizedMissionGrid
+              items={filteredRecommendations}
+              viewMode="grid"
+              maxColumns={3}
+              className="flex-1 h-[calc(90vh-360px)]"
+              renderItem={(match) => (
+                <RecommendationCard
+                  match={match}
+                  onSelect={() => onSelectMission(match.mission)}
+                  onImport={() => onImportMission(match.mission)}
+                />
+              )}
+            />
+          )}
+        </CollapsibleSection>
+      )}
+
+      {/* Browse on GitHub link */}
+      {!loading && (
+        <div className="flex items-center gap-2 mb-4 px-1">
+          <a
+            href="https://github.com/kubestellar/console-kb/tree/master/fixes"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-flex items-center gap-1.5 text-xs text-muted-foreground hover:text-purple-400 transition-colors"
+            onClick={() => emitFixerGitHubLink()}
+          >
+            <ExternalLink className="w-3.5 h-3.5" />
+            Browse all fixes on GitHub
+          </a>
+          {searchProgress.step === 'Done' && searchProgress.found > 0 && (
+            <span className="text-xs text-muted-foreground/60 ml-auto">{searchProgress.detail}</span>
+          )}
+        </div>
+      )}
+
+      {/* Directory listing (tree-navigated folder contents) */}
+      {loading ? (
+        <div className="flex items-center justify-center py-16">
+          <Loader2 className="w-6 h-6 text-muted-foreground animate-spin" />
+        </div>
+      ) : filteredEntries.length > 0 ? (
+        <DirectoryListing
+          entries={filteredEntries}
+          viewMode={viewMode}
+          onSelect={(entry) => {
+            const entrySource = selectedPath?.startsWith('github/') ? ('github' as const) : ('community' as const)
+            const node: TreeNode = {
+              id: entry.path,
+              name: entry.name,
+              path: entry.path,
+              type: entry.type,
+              source: entrySource,
+              loaded: entry.type === 'file',
+            }
+            if (entry.type === 'file') {
+              onSelectNode(node)
+            } else {
+              onToggleNode(node)
+              onSelectNode(node)
+            }
+          }}
+          onImport={onImportDirectoryEntry}
+        />
+      ) : selectedPath ? (
+        <EmptyState message="No files in this directory" />
+      ) : (
+        <EmptyState message="Select a folder from the sidebar to browse missions" />
+      )}
+    </>
+  )
+}

--- a/web/src/components/missions/MissionBrowserSidebar.tsx
+++ b/web/src/components/missions/MissionBrowserSidebar.tsx
@@ -1,0 +1,273 @@
+/**
+ * MissionBrowserSidebar
+ *
+ * The left-hand file-tree sidebar of the Mission Browser. Renders the tree of
+ * community / GitHub / local source nodes with inline "add repo" and "add path"
+ * forms, plus a drag-and-drop / click-to-upload drop zone at the bottom.
+ *
+ * Extracted from MissionBrowser.tsx (issue #8624).
+ */
+
+import { useRef } from 'react'
+import { Upload, CheckCircle, X } from 'lucide-react'
+import { cn } from '../../lib/cn'
+import { SIDEBAR_WIDTH, MISSION_FILE_ACCEPT } from './missionBrowserConstants'
+import { TreeNodeItem, updateNodeInTree } from './browser'
+import type { TreeNode } from './browser'
+
+interface MissionBrowserSidebarProps {
+  treeNodes: TreeNode[]
+  expandedNodes: Set<string>
+  selectedPath: string | null
+  onToggleNode: (node: TreeNode) => void
+  onSelectNode: (node: TreeNode) => void
+
+  isDragging: boolean
+  onDragOver: () => void
+  onDragLeave: () => void
+  onDrop: (e: React.DragEvent) => void
+  onFileSelect: (e: React.ChangeEvent<HTMLInputElement>) => void
+
+  watchedRepos: string[]
+  onRemoveRepo: (path: string) => void
+  onRefreshNode: (child: TreeNode) => void
+
+  watchedPaths: string[]
+  onRemovePath: (path: string) => void
+
+  addingRepo: boolean
+  setAddingRepo: (value: boolean) => void
+  newRepoValue: string
+  setNewRepoValue: (value: string) => void
+  onAddRepo: (val: string) => void
+
+  addingPath: boolean
+  setAddingPath: (value: boolean) => void
+  newPathValue: string
+  setNewPathValue: (value: string) => void
+  onAddPath: (val: string) => void
+
+  setTreeNodes: React.Dispatch<React.SetStateAction<TreeNode[]>>
+  setExpandedNodes: React.Dispatch<React.SetStateAction<Set<string>>>
+}
+
+export function MissionBrowserSidebar({
+  treeNodes,
+  expandedNodes,
+  selectedPath,
+  onToggleNode,
+  onSelectNode,
+  isDragging,
+  onDragOver,
+  onDragLeave,
+  onDrop,
+  onFileSelect,
+  watchedRepos,
+  onRemoveRepo,
+  onRefreshNode,
+  watchedPaths,
+  onRemovePath,
+  addingRepo,
+  setAddingRepo,
+  newRepoValue,
+  setNewRepoValue,
+  onAddRepo,
+  addingPath,
+  setAddingPath,
+  newPathValue,
+  setNewPathValue,
+  onAddPath,
+  setTreeNodes,
+  setExpandedNodes,
+}: MissionBrowserSidebarProps) {
+  const fileInputRef = useRef<HTMLInputElement>(null)
+
+  return (
+    <div
+      data-testid="mission-tree"
+      className="hidden md:flex flex-col border-r border-border bg-card overflow-y-auto"
+      style={{ width: SIDEBAR_WIDTH, minWidth: SIDEBAR_WIDTH }}
+    >
+      <div className="p-3 space-y-1">
+        {treeNodes.map((node) => (
+          <div key={node.id}>
+            <div>
+              <TreeNodeItem
+                node={node}
+                depth={0}
+                expandedNodes={expandedNodes}
+                selectedPath={selectedPath}
+                onToggle={onToggleNode}
+                onSelect={onSelectNode}
+                onRemove={
+                  node.id === 'github'
+                    ? (child) => onRemoveRepo(child.path)
+                    : node.id === 'local'
+                      ? (child) => onRemovePath(child.path)
+                      : undefined
+                }
+                onRefresh={
+                  node.id === 'github' || node.id === 'local'
+                    ? (child) => {
+                        // Mark node as unloaded to force re-fetch
+                        setTreeNodes((prev) =>
+                          updateNodeInTree(prev, child.id, {
+                            loaded: false,
+                            loading: false,
+                            children: [],
+                          }),
+                        )
+                        // Collapse so re-expand triggers load
+                        setExpandedNodes((prev) => {
+                          const next = new Set(prev)
+                          next.delete(child.id)
+                          return next
+                        })
+                        onRefreshNode(child)
+                      }
+                    : undefined
+                }
+                onAdd={
+                  node.id === 'github'
+                    ? () => setAddingRepo(!addingRepo)
+                    : node.id === 'local'
+                      ? () => setAddingPath(!addingPath)
+                      : undefined
+                }
+              />
+            </div>
+
+            {/* Inline add-repo form */}
+            {node.id === 'github' && addingRepo && (
+              <div className="ml-6 mt-1 mb-2">
+                <form
+                  onSubmit={(e) => {
+                    e.preventDefault()
+                    const val = newRepoValue.trim()
+                    if (val && !watchedRepos.includes(val)) {
+                      onAddRepo(val)
+                    }
+                    setNewRepoValue('')
+                    setAddingRepo(false)
+                  }}
+                  className="flex items-center gap-1"
+                >
+                  <input
+                    type="text"
+                    value={newRepoValue}
+                    onChange={(e) => setNewRepoValue(e.target.value)}
+                    placeholder="owner/repo (e.g., kubara-io/kubara or your-org/runbooks)"
+                    className="flex-1 px-2 py-1 text-xs bg-secondary border border-border rounded text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-purple-500/40"
+                    autoFocus
+                    onKeyDown={(e) => {
+                      if (e.key === 'Escape') {
+                        setAddingRepo(false)
+                        setNewRepoValue('')
+                      }
+                    }}
+                  />
+                  <button
+                    type="submit"
+                    className="p-1 text-xs text-green-400 hover:text-green-300 min-h-11 min-w-11 flex items-center justify-center"
+                  >
+                    <CheckCircle className="w-3.5 h-3.5" />
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => {
+                      setAddingRepo(false)
+                      setNewRepoValue('')
+                    }}
+                    className="p-1 text-xs text-muted-foreground hover:text-foreground min-h-11 min-w-11 flex items-center justify-center"
+                  >
+                    <X className="w-3.5 h-3.5" />
+                  </button>
+                </form>
+              </div>
+            )}
+
+            {/* Inline add-path form */}
+            {node.id === 'local' && addingPath && (
+              <div className="ml-6 mt-1 mb-2">
+                <form
+                  onSubmit={(e) => {
+                    e.preventDefault()
+                    const val = newPathValue.trim()
+                    if (val && !watchedPaths.includes(val)) {
+                      onAddPath(val)
+                    }
+                    setNewPathValue('')
+                    setAddingPath(false)
+                  }}
+                  className="flex items-center gap-1"
+                >
+                  <input
+                    type="text"
+                    value={newPathValue}
+                    onChange={(e) => setNewPathValue(e.target.value)}
+                    placeholder="/path/to/missions"
+                    className="flex-1 px-2 py-1 text-xs bg-secondary border border-border rounded text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-purple-500/40"
+                    autoFocus
+                    onKeyDown={(e) => {
+                      if (e.key === 'Escape') {
+                        setAddingPath(false)
+                        setNewPathValue('')
+                      }
+                    }}
+                  />
+                  <button
+                    type="submit"
+                    className="p-1 text-xs text-green-400 hover:text-green-300 min-h-11 min-w-11 flex items-center justify-center"
+                  >
+                    <CheckCircle className="w-3.5 h-3.5" />
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => {
+                      setAddingPath(false)
+                      setNewPathValue('')
+                    }}
+                    className="p-1 text-xs text-muted-foreground hover:text-foreground min-h-11 min-w-11 flex items-center justify-center"
+                  >
+                    <X className="w-3.5 h-3.5" />
+                  </button>
+                </form>
+              </div>
+            )}
+          </div>
+        ))}
+      </div>
+
+      {/* Drop zone for local files */}
+      <div className="mt-auto p-3 border-t border-border">
+        <div
+          onDragOver={(e) => {
+            e.preventDefault()
+            onDragOver()
+          }}
+          onDragLeave={onDragLeave}
+          onDrop={onDrop}
+          onClick={() => fileInputRef.current?.click()}
+          className={cn(
+            'flex flex-col items-center gap-2 p-4 rounded-lg border-2 border-dashed cursor-pointer transition-colors',
+            isDragging
+              ? 'border-purple-400 bg-purple-500/10'
+              : 'border-border hover:border-muted-foreground',
+          )}
+        >
+          <Upload className="w-5 h-5 text-muted-foreground" />
+          <span className="text-xs text-muted-foreground text-center">
+            Drop mission file (JSON, YAML, MD) or click to browse
+          </span>
+        </div>
+        <input
+          ref={fileInputRef}
+          type="file"
+          accept={MISSION_FILE_ACCEPT}
+          onChange={onFileSelect}
+          className="hidden"
+        />
+      </div>
+    </div>
+  )
+}

--- a/web/src/components/missions/MissionBrowserTabBar.tsx
+++ b/web/src/components/missions/MissionBrowserTabBar.tsx
@@ -1,0 +1,79 @@
+/**
+ * MissionBrowserTabBar
+ *
+ * The horizontal tab navigation row (Recommended / Installers / Fixes / Browse)
+ * plus the global refresh button at the right edge.
+ *
+ * Extracted from MissionBrowser.tsx (issue #8624).
+ */
+
+import { RefreshCw } from 'lucide-react'
+import { cn } from '../../lib/cn'
+import { BROWSER_TABS, missionCache, resetMissionCache } from './browser'
+import type { BrowserTab } from './browser'
+
+interface MissionBrowserTabBarProps {
+  activeTab: BrowserTab
+  onTabChange: (tab: BrowserTab) => void
+  installerCount: number
+  fixerCount: number
+}
+
+export function MissionBrowserTabBar({
+  activeTab,
+  onTabChange,
+  installerCount,
+  fixerCount,
+}: MissionBrowserTabBarProps) {
+  const isRefreshing =
+    activeTab === 'installers'
+      ? !missionCache.installersDone
+      : activeTab === 'fixes'
+        ? !missionCache.fixesDone
+        : !missionCache.installersDone || !missionCache.fixesDone
+
+  return (
+    <div className="flex items-center gap-1 px-4 py-1.5 bg-card border-b border-border overflow-x-auto scrollbar-hide">
+      {BROWSER_TABS.map((tab) => (
+        <button
+          key={tab.id}
+          onClick={() => onTabChange(tab.id)}
+          className={cn(
+            'inline-flex items-center gap-1.5 px-3 py-1.5 text-sm rounded-md transition-colors',
+            activeTab === tab.id
+              ? 'bg-purple-500/20 text-purple-400 font-medium'
+              : 'text-muted-foreground hover:text-foreground hover:bg-secondary',
+          )}
+        >
+          <span>{tab.icon}</span>
+          {tab.label}
+          {tab.id === 'installers' && (
+            <span className="text-2xs bg-secondary px-1.5 py-0.5 rounded-full min-w-[28px] text-center tabular-nums">
+              {installerCount || '–'}
+            </span>
+          )}
+          {tab.id === 'fixes' && (
+            <span className="text-2xs bg-secondary px-1.5 py-0.5 rounded-full min-w-[28px] text-center tabular-nums">
+              {fixerCount || '–'}
+            </span>
+          )}
+        </button>
+      ))}
+
+      {/* Refresh all mission data */}
+      <button
+        onClick={() => resetMissionCache()}
+        className="ml-auto inline-flex items-center gap-1 px-2 py-1 text-xs text-muted-foreground hover:text-foreground hover:bg-secondary rounded transition-colors"
+        title={
+          activeTab === 'installers'
+            ? 'Refresh installers'
+            : activeTab === 'fixes'
+              ? 'Refresh fixes'
+              : 'Refresh all mission data'
+        }
+      >
+        <RefreshCw className={cn('w-3.5 h-3.5', isRefreshing && 'animate-spin')} />
+      </button>
+    </div>
+  )
+}

--- a/web/src/components/missions/MissionBrowserTopBar.tsx
+++ b/web/src/components/missions/MissionBrowserTopBar.tsx
@@ -1,0 +1,117 @@
+/**
+ * MissionBrowserTopBar
+ *
+ * The top control strip of the Mission Browser: global search input, filter
+ * toggle button (with active-filter badge), grid/list view-mode toggle, and
+ * close button.
+ *
+ * Extracted from MissionBrowser.tsx (issue #8624).
+ */
+
+import { Search, Filter, Grid3X3, List, X } from 'lucide-react'
+import { cn } from '../../lib/cn'
+import type { ViewMode, BrowserTab } from './browser'
+
+interface MissionBrowserTopBarProps {
+  searchQuery: string
+  onSearchChange: (value: string) => void
+  activeTab: BrowserTab
+  showFilters: boolean
+  onToggleFilters: () => void
+  activeFilterCount: number
+  viewMode: ViewMode
+  onViewModeChange: (mode: ViewMode) => void
+  onClose: () => void
+}
+
+export function MissionBrowserTopBar({
+  searchQuery,
+  onSearchChange,
+  activeTab,
+  showFilters,
+  onToggleFilters,
+  activeFilterCount,
+  viewMode,
+  onViewModeChange,
+  onClose,
+}: MissionBrowserTopBarProps) {
+  const searchPlaceholder =
+    activeTab === 'installers'
+      ? 'Search installers… (AND logic: "argo events" = argo AND events)'
+      : activeTab === 'fixes'
+        ? 'Search fixes…'
+        : 'Search missions by name, tag, or description…'
+
+  return (
+    <div className="flex items-center gap-3 px-4 py-3 bg-card border-b border-border">
+      {/* Global search input */}
+      <div className="flex-1 relative">
+        <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-muted-foreground" />
+        <input
+          type="text"
+          value={searchQuery}
+          onChange={(e) => onSearchChange(e.target.value)}
+          placeholder={searchPlaceholder}
+          className="w-full pl-10 pr-4 py-2 bg-secondary border border-border rounded-lg text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-purple-500/40"
+          data-testid="mission-search"
+          autoFocus
+        />
+      </div>
+
+      {/* Filter toggle */}
+      <button
+        onClick={onToggleFilters}
+        className={cn(
+          'p-2 rounded-lg transition-colors relative',
+          showFilters
+            ? 'bg-purple-500/20 text-purple-400'
+            : 'hover:bg-secondary text-muted-foreground hover:text-foreground',
+        )}
+        title="Toggle filters"
+      >
+        <Filter className="w-5 h-5" />
+        {activeFilterCount > 0 && (
+          <span className="absolute -top-1 -right-1 w-4 h-4 rounded-full bg-purple-500 text-white text-[9px] font-bold flex items-center justify-center">
+            {activeFilterCount}
+          </span>
+        )}
+      </button>
+
+      {/* Grid / list view-mode toggle */}
+      <div className="flex items-center border border-border rounded-lg overflow-hidden">
+        <button
+          onClick={() => onViewModeChange('grid')}
+          className={cn(
+            'p-2 transition-colors',
+            viewMode === 'grid'
+              ? 'bg-purple-500/20 text-purple-400'
+              : 'text-muted-foreground hover:text-foreground',
+          )}
+        >
+          <Grid3X3 className="w-4 h-4" />
+        </button>
+        <button
+          onClick={() => onViewModeChange('list')}
+          className={cn(
+            'p-2 transition-colors',
+            viewMode === 'list'
+              ? 'bg-purple-500/20 text-purple-400'
+              : 'text-muted-foreground hover:text-foreground',
+          )}
+        >
+          <List className="w-4 h-4" />
+        </button>
+      </div>
+
+      {/* Close button — right-aligned per #6308 to match BaseModal convention */}
+      <button
+        onClick={onClose}
+        className="p-2 rounded-lg hover:bg-secondary text-muted-foreground hover:text-foreground transition-colors"
+        title="Close (Esc)"
+        aria-label="Close mission browser"
+      >
+        <X className="w-5 h-5" />
+      </button>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary

Splits the 1807-line `MissionBrowser.tsx` into 7 focused subcomponent files, keeping `MissionBrowser.tsx` as the thin orchestrator that owns all state and data-fetching logic.

**New files under `web/src/components/missions/`:**
- `MissionBrowserTopBar.tsx` — search input, filter toggle, view-mode toggle, close button
- `MissionBrowserFilterPanel.tsx` — all filter pill rows (match %, source, category, class, maturity, difficulty, CNCF project, top tags)
- `MissionBrowserTabBar.tsx` — tab navigation (Recommended / Installers / Fixes / Browse) + refresh button
- `MissionBrowserSidebar.tsx` — file tree with inline add-repo/add-path forms + drag-and-drop zone
- `MissionBrowserRecommendedTab.tsx` — recommendations panel, browse-on-GitHub link, directory listing
- `MissionBrowserInstallersTab.tsx` — installer search, category/maturity filters, virtualised grid
- `MissionBrowserFixesTab.tsx` — fixer search, type filter, virtualised grid

**No behaviour change.** All state, effects, and data-fetching remain in `MissionBrowser.tsx`. The public API (`MissionBrowserProps`) is unchanged, so the existing test file continues to work without modification.

Fixes #8624

## Test plan

- [ ] Open Mission Browser — all tabs (Recommended, Installers, Fixes) render correctly
- [ ] Search, filter, and tag chips work as before
- [ ] File tree sidebar: expand nodes, add/remove repos and paths, drag-and-drop file
- [ ] Deep-link to a mission via `?mission=install-prometheus` auto-selects it
- [ ] Import flow (scan overlay → accept/dismiss) unaffected
- [ ] Escape key closes detail view then closes browser
- [ ] Existing `MissionBrowser.test.tsx` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)