### PR TITLE
🐛 fix(drilldown): drilldown cluster — logs controls, deployment refresh, UI consistency, i18n (Issues 9282, 9283, 9284, 9285)

### DIFF
--- a/web/src/components/cards/UserManagement.tsx
+++ b/web/src/components/cards/UserManagement.tsx
@@ -275,23 +275,29 @@ export function UserManagement({ config: _config }: UserManagementProps) {
   const handleRoleChange = async (userId: string, newRole: UserRole) => {
     try {
       await updateUserRole(userId, newRole)
-      showToast('User role updated successfully', 'success')
+      // Issue 9285: route toast text through i18n so non-English users see
+      // the message translated (previously hardcoded English).
+      showToast(t('userManagement.toast.roleUpdateSuccess'), 'success')
       emitUserRoleChanged(newRole)
     } catch {
       // User-visible toast already surfaces the failure (#8816)
-      showToast('Failed to update user role', 'error')
+      showToast(t('userManagement.toast.roleUpdateError'), 'error')
     }
   }
 
+  // Issue 9284: the ConsoleUsersTab already wraps this handler in a
+  // ConfirmDialog (the app-styled modal). The extra window.confirm() call
+  // here caused a double-confirm flow AND fell back to a native browser
+  // popup that's blockable. Rely on the dialog-based confirmation.
   const handleDeleteUser = async (userId: string) => {
-    if (!confirm(t('userManagement.confirmDelete'))) return
     try {
       await deleteUser(userId)
-      showToast('User deleted successfully', 'success')
+      // Issue 9285: i18n for success/error toasts.
+      showToast(t('userManagement.toast.deleteSuccess'), 'success')
       emitUserRemoved()
     } catch {
       // User-visible toast already surfaces the failure (#8816)
-      showToast('Failed to delete user', 'error')
+      showToast(t('userManagement.toast.deleteError'), 'error')
     }
   }
 

--- a/web/src/components/cards/deploy/GitOpsDriftDetailModal.tsx
+++ b/web/src/components/cards/deploy/GitOpsDriftDetailModal.tsx
@@ -7,6 +7,7 @@
 
 import { useRef, useEffect } from 'react'
 import { GitBranch, Rocket } from 'lucide-react'
+import { useTranslation } from 'react-i18next'
 import { BaseModal } from '../../../lib/modals/BaseModal'
 import { StatusBadge } from '../../ui/StatusBadge'
 import { ClusterBadge } from '../../ui/ClusterBadge'
@@ -27,14 +28,27 @@ const SEVERITY_COLORS: Record<GitOpsDrift['severity'], 'red' | 'orange' | 'yello
   medium: 'orange',
   low: 'yellow' }
 
-const DRIFT_TYPE_LABELS: Record<GitOpsDrift['driftType'], string> = {
-  modified: 'Modified',
-  deleted: 'Missing in Cluster',
-  added: 'Not in Git' }
+/**
+ * Issue 9285: drift-type and severity labels used to be hardcoded English.
+ * Static key maps keep the i18n key references static (a template literal
+ * like `severity.${drift.severity}` breaks strict i18next-typescript typing).
+ */
+const DRIFT_TYPE_I18N_KEYS: Record<GitOpsDrift['driftType'], 'cards:gitopsDriftModal.driftType.modified' | 'cards:gitopsDriftModal.driftType.deleted' | 'cards:gitopsDriftModal.driftType.added'> = {
+  modified: 'cards:gitopsDriftModal.driftType.modified',
+  deleted: 'cards:gitopsDriftModal.driftType.deleted',
+  added: 'cards:gitopsDriftModal.driftType.added',
+}
+
+const SEVERITY_I18N_KEYS: Record<GitOpsDrift['severity'], 'cards:gitopsDriftModal.severity.high' | 'cards:gitopsDriftModal.severity.medium' | 'cards:gitopsDriftModal.severity.low'> = {
+  high: 'cards:gitopsDriftModal.severity.high',
+  medium: 'cards:gitopsDriftModal.severity.medium',
+  low: 'cards:gitopsDriftModal.severity.low',
+}
 
 export function GitOpsDriftDetailModal({ isOpen, onClose, drift }: GitOpsDriftDetailModalProps) {
   const openTimeRef = useRef<number>(0)
   const { startMission, openSidebar } = useMissions()
+  const { t } = useTranslation(['cards', 'common'])
 
   useEffect(() => {
     if (isOpen && drift) {
@@ -94,40 +108,40 @@ Please proceed step by step.`,
         onClose={handleClose}
         extra={
           <StatusBadge color={SEVERITY_COLORS[drift.severity] || 'yellow'} size="md">
-            {drift.severity} severity
+            {t('cards:gitopsDriftModal.severityBadge', { severity: t(SEVERITY_I18N_KEYS[drift.severity]) })}
           </StatusBadge>
         }
       />
       <BaseModal.Content>
         <div className="space-y-4">
-          {/* Resource info grid */}
+          {/* Resource info grid — Issue 9285: labels now i18n */}
           <div className="grid grid-cols-2 gap-4">
             <div>
-              <h4 className="text-xs font-medium text-muted-foreground mb-1">Kind</h4>
+              <h4 className="text-xs font-medium text-muted-foreground mb-1">{t('cards:gitopsDriftModal.kind')}</h4>
               <span className="text-sm font-medium text-foreground">{drift.kind}</span>
             </div>
             <div>
-              <h4 className="text-xs font-medium text-muted-foreground mb-1">Drift Type</h4>
+              <h4 className="text-xs font-medium text-muted-foreground mb-1">{t('cards:gitopsDriftModal.driftTypeLabel')}</h4>
               <StatusBadge
                 color={drift.driftType === 'deleted' ? 'red' : drift.driftType === 'added' ? 'blue' : 'yellow'}
                 size="sm"
               >
-                {DRIFT_TYPE_LABELS[drift.driftType] || drift.driftType}
+                {t(DRIFT_TYPE_I18N_KEYS[drift.driftType]) || drift.driftType}
               </StatusBadge>
             </div>
             <div>
-              <h4 className="text-xs font-medium text-muted-foreground mb-1">Namespace</h4>
+              <h4 className="text-xs font-medium text-muted-foreground mb-1">{t('cards:gitopsDriftModal.namespace')}</h4>
               <span className="text-sm text-foreground">{drift.namespace}</span>
             </div>
             <div>
-              <h4 className="text-xs font-medium text-muted-foreground mb-1">Cluster</h4>
+              <h4 className="text-xs font-medium text-muted-foreground mb-1">{t('cards:gitopsDriftModal.cluster')}</h4>
               <ClusterBadge cluster={drift.cluster} />
             </div>
           </div>
 
           {/* Git version */}
           <div>
-            <h4 className="text-xs font-medium text-muted-foreground mb-1">Git Version</h4>
+            <h4 className="text-xs font-medium text-muted-foreground mb-1">{t('cards:gitopsDriftModal.gitVersion')}</h4>
             <code className="px-2 py-1 rounded bg-secondary text-purple-400 font-mono text-xs">
               {drift.gitVersion}
             </code>
@@ -136,7 +150,7 @@ Please proceed step by step.`,
           {/* Details */}
           {drift.details && (
             <div>
-              <h4 className="text-xs font-medium text-muted-foreground mb-1">Details</h4>
+              <h4 className="text-xs font-medium text-muted-foreground mb-1">{t('cards:gitopsDriftModal.details')}</h4>
               <div className="bg-secondary/30 rounded-lg p-3">
                 <p className="text-xs text-foreground whitespace-pre-wrap">{drift.details}</p>
               </div>
@@ -146,8 +160,7 @@ Please proceed step by step.`,
           {/* Context */}
           <div className="bg-secondary/30 rounded-lg p-3">
             <p className="text-xs text-muted-foreground">
-              This {drift.kind} has drifted from its desired state in Git.
-              Use an AI Mission to investigate the cause and sync it back.
+              {t('cards:gitopsDriftModal.contextDescription', { kind: drift.kind })}
             </p>
           </div>
 
@@ -157,7 +170,7 @@ Please proceed step by step.`,
             className="w-full flex items-center justify-center gap-2 px-4 py-2.5 rounded-lg bg-blue-500/10 border border-blue-500/20 text-blue-400 hover:bg-blue-500/20 transition-colors text-sm"
           >
             <Rocket className="w-4 h-4" />
-            Sync with AI Mission
+            {t('cards:gitopsDriftModal.syncWithAI')}
           </button>
         </div>
       </BaseModal.Content>

--- a/web/src/components/cards/deploy/HelmHistoryDetailModal.tsx
+++ b/web/src/components/cards/deploy/HelmHistoryDetailModal.tsx
@@ -7,6 +7,7 @@
 
 import { useRef, useEffect } from 'react'
 import { RotateCcw, Rocket } from 'lucide-react'
+import { useTranslation } from 'react-i18next'
 import { BaseModal } from '../../../lib/modals/BaseModal'
 import { StatusBadge } from '../../ui/StatusBadge'
 import { useMissions } from '../../../hooks/useMissions'
@@ -36,6 +37,7 @@ export function HelmHistoryDetailModal({
   isOpen, onClose, entry, releaseName, clusterName, namespace, currentRevision }: HelmHistoryDetailModalProps) {
   const openTimeRef = useRef<number>(0)
   const { startMission, openSidebar } = useMissions()
+  const { t, i18n } = useTranslation(['cards', 'common'])
 
   useEffect(() => {
     if (isOpen && entry) {
@@ -90,7 +92,9 @@ Please proceed step by step.`,
   const isCurrent = entry.status === 'deployed'
   const formatDate = (timestamp: string) => {
     const date = new Date(timestamp)
-    return date.toLocaleDateString('en-US', {
+    // Issue 9285: use the active i18n locale so dates match the user's
+    // language (previously hardcoded to en-US).
+    return date.toLocaleDateString(i18n.language, {
       month: 'short', day: 'numeric', year: 'numeric',
       hour: '2-digit', minute: '2-digit' })
   }
@@ -109,22 +113,22 @@ Please proceed step by step.`,
       />
       <BaseModal.Content>
         <div className="space-y-4">
-          {/* Revision info grid */}
+          {/* Revision info grid — Issue 9285: labels now i18n */}
           <div className="grid grid-cols-2 gap-4">
             <div>
-              <h4 className="text-xs font-medium text-muted-foreground mb-1">Chart</h4>
+              <h4 className="text-xs font-medium text-muted-foreground mb-1">{t('cards:helmHistoryModal.chart')}</h4>
               <span className="text-sm font-medium text-foreground">{entry.chart}</span>
             </div>
             <div>
-              <h4 className="text-xs font-medium text-muted-foreground mb-1">App Version</h4>
-              <span className="text-sm text-foreground">{entry.app_version || 'N/A'}</span>
+              <h4 className="text-xs font-medium text-muted-foreground mb-1">{t('cards:helmHistoryModal.appVersion')}</h4>
+              <span className="text-sm text-foreground">{entry.app_version || t('cards:helmHistoryModal.notAvailable')}</span>
             </div>
             <div>
-              <h4 className="text-xs font-medium text-muted-foreground mb-1">Updated</h4>
+              <h4 className="text-xs font-medium text-muted-foreground mb-1">{t('cards:helmHistoryModal.updated')}</h4>
               <span className="text-sm text-foreground">{formatDate(entry.updated)}</span>
             </div>
             <div>
-              <h4 className="text-xs font-medium text-muted-foreground mb-1">Cluster</h4>
+              <h4 className="text-xs font-medium text-muted-foreground mb-1">{t('cards:helmHistoryModal.cluster')}</h4>
               <span className="text-sm text-foreground">{clusterName}</span>
             </div>
           </div>
@@ -132,7 +136,7 @@ Please proceed step by step.`,
           {/* Description */}
           {entry.description && (
             <div>
-              <h4 className="text-xs font-medium text-muted-foreground mb-1">Description</h4>
+              <h4 className="text-xs font-medium text-muted-foreground mb-1">{t('cards:helmHistoryModal.description')}</h4>
               <div className="bg-secondary/30 rounded-lg p-3">
                 <p className="text-xs text-foreground">{entry.description}</p>
               </div>
@@ -142,7 +146,7 @@ Please proceed step by step.`,
           {/* Current badge */}
           {isCurrent && (
             <div className="bg-green-500/10 border border-green-500/20 rounded-lg p-3 text-center">
-              <span className="text-sm font-medium text-green-400">Currently Deployed</span>
+              <span className="text-sm font-medium text-green-400">{t('cards:helmHistoryModal.currentlyDeployed')}</span>
             </div>
           )}
 
@@ -151,8 +155,7 @@ Please proceed step by step.`,
             <>
               <div className="bg-secondary/30 rounded-lg p-3">
                 <p className="text-xs text-muted-foreground">
-                  Rolling back to revision {entry.revision} will restore the release to this version.
-                  Use an AI Mission to safely execute and verify the rollback.
+                  {t('cards:helmHistoryModal.rollbackDescription', { revision: entry.revision })}
                 </p>
               </div>
               <button
@@ -160,7 +163,7 @@ Please proceed step by step.`,
                 className="w-full flex items-center justify-center gap-2 px-4 py-2.5 rounded-lg bg-blue-500/10 border border-blue-500/20 text-blue-400 hover:bg-blue-500/20 transition-colors text-sm"
               >
                 <Rocket className="w-4 h-4" />
-                Rollback with AI Mission
+                {t('cards:helmHistoryModal.rollbackWithAI')}
               </button>
             </>
           )}

--- a/web/src/components/cards/opa/PolicyDetailModal.tsx
+++ b/web/src/components/cards/opa/PolicyDetailModal.tsx
@@ -41,17 +41,17 @@ export function PolicyDetailModal({
       />
 
       <BaseModal.Content className="max-h-[50vh]">
-        {/* Policy Info */}
+        {/* Policy Info — Issue 9285: labels now i18n */}
         <div className="mb-4 pb-4 border-b border-border">
           <div className="flex items-center gap-4">
             <div className="flex-1">
-              <p className="text-xs text-muted-foreground mb-1">Enforcement Mode</p>
+              <p className="text-xs text-muted-foreground mb-1">{t('policyModal.enforcementMode')}</p>
               <span className={`px-2 py-1 rounded text-sm font-medium ${getModeColor(policy.mode)}`}>
                 {policy.mode}
               </span>
             </div>
             <div className="flex-1">
-              <p className="text-xs text-muted-foreground mb-1">Violations</p>
+              <p className="text-xs text-muted-foreground mb-1">{t('policyModal.violations')}</p>
               <p className={`text-2xl font-bold ${policy.violations > 0 ? 'text-yellow-400' : 'text-green-400'}`}>
                 {policy.violations}
               </p>
@@ -77,7 +77,9 @@ export function PolicyDetailModal({
                   <span className="text-xs text-muted-foreground">{violation.kind}</span>
                 </div>
                 <p className="text-sm text-muted-foreground mb-1">{violation.message}</p>
-                <span className="text-xs text-muted-foreground">Namespace: <span className="text-foreground">{violation.namespace}</span></span>
+                <span className="text-xs text-muted-foreground">
+                  {t('policyModal.namespaceLabel')} <span className="text-foreground">{violation.namespace}</span>
+                </span>
               </div>
             ))}
           </div>
@@ -91,7 +93,7 @@ export function PolicyDetailModal({
           rel="noopener noreferrer"
           className="text-sm text-purple-400 hover:text-purple-300 flex items-center gap-1"
         >
-          Policy Documentation
+          {t('policyModal.policyDocumentation')}
           <ExternalLink className="w-3 h-3" />
         </a>
         <div className="flex-1" />
@@ -103,13 +105,13 @@ export function PolicyDetailModal({
             }}
             className="px-4 py-2 bg-purple-500/20 text-purple-400 rounded-lg hover:bg-purple-500/30 transition-colors"
           >
-            Create Similar Policy
+            {t('policyModal.createSimilar')}
           </button>
           <button
             onClick={onClose}
             className="px-4 py-2 bg-secondary text-foreground rounded-lg hover:bg-secondary/80 transition-colors"
           >
-            Close
+            {t('common:actions.close')}
           </button>
         </div>
       </BaseModal.Footer>

--- a/web/src/components/dashboard/CreateDashboardModal.tsx
+++ b/web/src/components/dashboard/CreateDashboardModal.tsx
@@ -193,12 +193,12 @@ function CreateDashboardModalInner({
             </div>
             <div className="flex-1">
               <h3 className="text-sm font-medium text-foreground">
-                {selectedTemplate ? selectedTemplate.name : 'Start with a Card Collection'}
+                {selectedTemplate ? selectedTemplate.name : t('dashboard.create.startWithCollection')}
               </h3>
               <p className="text-xs text-muted-foreground">
                 {selectedTemplate
-                  ? `${selectedTemplate.cards.length} pre-configured cards`
-                  : 'Choose from pre-built card sets'
+                  ? t('dashboard.create.preConfiguredCards', { count: selectedTemplate.cards.length })
+                  : t('dashboard.create.chooseFromCollections')
                 }
               </p>
             </div>
@@ -212,7 +212,7 @@ function CreateDashboardModalInner({
           {/* Collection selection - categorized view */}
           {showTemplates && (
             <div className="ml-14 space-y-2 animate-fade-in max-h-64 overflow-y-auto">
-              <p className="text-xs text-muted-foreground">Select a collection by category:</p>
+              <p className="text-xs text-muted-foreground">{t('dashboard.create.selectByCategoryCollection')}</p>
 
               {TEMPLATE_CATEGORIES.map((category) => {
                 const categoryTemplates = DASHBOARD_TEMPLATES.filter(t => t.category === category.id)
@@ -285,7 +285,7 @@ function CreateDashboardModalInner({
     return (
       <div className="h-full flex flex-col overflow-hidden">
         <div className="flex-1 overflow-y-auto p-4">
-          <p className="text-xs text-muted-foreground mb-4">Name your dashboard and optionally start with a card collection.</p>
+          <p className="text-xs text-muted-foreground mb-4">{t('dashboard.create.descriptionCollection')}</p>
           {formContent}
         </div>
         <div className="border-t border-border px-4 py-3 flex items-center justify-end gap-2">

--- a/web/src/components/drilldown/views/DeploymentDrillDown.tsx
+++ b/web/src/components/drilldown/views/DeploymentDrillDown.tsx
@@ -4,7 +4,7 @@ import { LOCAL_AGENT_WS_URL } from '../../../lib/constants'
 import { useDrillDownActions } from '../../../hooks/useDrillDown'
 import { useCanI } from '../../../hooks/usePermissions'
 import { ClusterBadge } from '../../ui/ClusterBadge'
-import { FileText, Code, Info, Tag, Zap, Loader2, Copy, Check, Layers, Server, Box, Minus, Plus } from 'lucide-react'
+import { FileText, Code, Info, Tag, Zap, Loader2, Copy, Check, Layers, Server, Box, Minus, Plus, RefreshCw } from 'lucide-react'
 import { cn } from '../../../lib/cn'
 import { RETRY_DELAY_MS, UI_FEEDBACK_TIMEOUT_MS } from '../../../lib/constants/network'
 import { StatusIndicator } from '../../charts/StatusIndicator'
@@ -15,6 +15,45 @@ import { copyToClipboard } from '../../../lib/clipboard'
 /** Maximum replicas allowed via the UI scale widget. Kubernetes itself supports
  *  up to 2^31-1 but most real deployments won't exceed a few hundred. */
 const MAX_SCALE_REPLICAS = 100
+
+/**
+ * Classify a raw kubectl scale error into a stable i18n key. The caller
+ * runs `t(...)` on the result. Returning a static key literal keeps the
+ * keys compatible with i18next-typescript strict typing (no runtime
+ * template literals inside t()).
+ *
+ * Issue 9284: previously we surfaced the full kubectl stderr, which exposed
+ * internal cluster details (namespaces, group-version-kind, resource versions)
+ * that aren't useful to end users.
+ */
+type ScaleErrorKey =
+  | 'drilldown.scale.failedGeneric'
+  | 'drilldown.scale.failedForbidden'
+  | 'drilldown.scale.failedNotFound'
+  | 'drilldown.scale.failedInvalid'
+  | 'drilldown.scale.failedConflict'
+  | 'drilldown.scale.failedTimeout'
+
+function classifyScaleError(raw: string): ScaleErrorKey {
+  const lc = (raw || '').toLowerCase()
+  if (!raw) return 'drilldown.scale.failedGeneric'
+  if (lc.includes('forbidden') || lc.includes('cannot patch') || lc.includes('unauthorized')) {
+    return 'drilldown.scale.failedForbidden'
+  }
+  if (lc.includes('not found') || lc.includes('notfound')) {
+    return 'drilldown.scale.failedNotFound'
+  }
+  if (lc.includes('invalid') || lc.includes('must be') || lc.includes('out of range')) {
+    return 'drilldown.scale.failedInvalid'
+  }
+  if (lc.includes('conflict') || lc.includes('modified')) {
+    return 'drilldown.scale.failedConflict'
+  }
+  if (lc.includes('timeout') || lc.includes('timed out') || lc.includes('deadline')) {
+    return 'drilldown.scale.failedTimeout'
+  }
+  return 'drilldown.scale.failedGeneric'
+}
 
 interface Props {
   data: Record<string, unknown>
@@ -111,6 +150,9 @@ export function DeploymentDrillDown({ data }: Props) {
   const [canScale, setCanScale] = useState<boolean | null>(null)
   const [isScaling, setIsScaling] = useState(false)
   const [scaleError, setScaleError] = useState<string | null>(null)
+  // Issue 9283: add a Refresh control that clears cached tab outputs and
+  // refetches fresh data from the cluster.
+  const [isRefreshing, setIsRefreshing] = useState(false)
   const { checkPermission } = useCanI()
 
   // Track reason/message from the initial click payload but reconcile with
@@ -320,10 +362,12 @@ export function DeploymentDrillDown({ data }: Props) {
         // Refetch data to get updated status
         setTimeout(fetchData, RETRY_DELAY_MS)
       } else if (output.toLowerCase().includes('error') || output.toLowerCase().includes('forbidden')) {
-        setScaleError(output || 'Failed to scale deployment')
+        // Issue 9284: don't leak raw kubectl stderr — map to a friendly message.
+        setScaleError(t(classifyScaleError(output)))
       }
     } catch (err) {
-      setScaleError(err instanceof Error ? err.message : 'Unknown error')
+      // Issue 9284: don't leak raw stack traces; map through the same helper.
+      setScaleError(t(classifyScaleError(err instanceof Error ? err.message : '')))
     } finally {
       setIsScaling(false)
     }
@@ -332,6 +376,34 @@ export function DeploymentDrillDown({ data }: Props) {
   // Increment/decrement handlers that directly trigger scaling
   const handleDecrement = () => handleScaleTo(replicas - 1)
   const handleIncrement = () => handleScaleTo(replicas + 1)
+
+  // Issue 9283: Refresh all tab data. The per-tab fetchX helpers
+  // (fetchEvents/fetchDescribe/fetchYaml) short-circuit when their cached
+  // output is already set, so bypass them and re-run the kubectl calls
+  // directly, overwriting the cached state at the end.
+  const handleRefreshAll = async () => {
+    if (!agentConnected || isRefreshing) return
+    setIsRefreshing(true)
+    setEventsLoading(true)
+    setDescribeLoading(true)
+    setYamlLoading(true)
+    try {
+      const [, events, describe, yaml] = await Promise.all([
+        fetchData(),
+        runKubectl(['get', 'events', '-n', namespace, '--field-selector', `involvedObject.name=${deploymentName}`, '-o', 'wide']),
+        runKubectl(['describe', 'deployment', deploymentName, '-n', namespace]),
+        runKubectl(['get', 'deployment', deploymentName, '-n', namespace, '-o', 'yaml']),
+      ])
+      setEventsOutput(events)
+      setDescribeOutput(describe)
+      setYamlOutput(yaml)
+    } finally {
+      setEventsLoading(false)
+      setDescribeLoading(false)
+      setYamlLoading(false)
+      setIsRefreshing(false)
+    }
+  }
 
   // Track if we've already loaded data to prevent refetching
   const hasLoadedRef = useRef(false)
@@ -378,7 +450,7 @@ export function DeploymentDrillDown({ data }: Props) {
   return (
     <div className="flex flex-col h-full -m-6">
       {/* Header */}
-      <div className="px-6 pt-6 pb-4">
+      <div className="px-6 pt-6 pb-4 flex items-center justify-between gap-4">
         <div className="flex items-center gap-6 text-sm">
           <button
             onClick={() => drillToNamespace(cluster, namespace)}
@@ -403,6 +475,18 @@ export function DeploymentDrillDown({ data }: Props) {
             </svg>
           </button>
         </div>
+        {/* Issue 9283: Refresh all tabs — Events/Describe/YAML used to cache
+            forever with no way to refetch. */}
+        <button
+          type="button"
+          onClick={handleRefreshAll}
+          disabled={!agentConnected || isRefreshing}
+          title={t('drilldown.deployment.refreshAll')}
+          className="flex items-center gap-2 px-3 py-1.5 rounded-lg bg-card/50 border border-border text-sm text-foreground hover:bg-card disabled:opacity-50"
+        >
+          <RefreshCw className={cn('w-4 h-4', isRefreshing && 'animate-spin')} />
+          <span>{t('drilldown.deployment.refresh')}</span>
+        </button>
       </div>
 
       {/* Tabs */}

--- a/web/src/components/drilldown/views/LogsDrillDown.tsx
+++ b/web/src/components/drilldown/views/LogsDrillDown.tsx
@@ -1,11 +1,46 @@
-import { useState, useEffect, useRef } from 'react'
-import { Loader2, AlertCircle, Server, Layers, Box } from 'lucide-react'
+import { useState, useEffect, useRef, useMemo } from 'react'
+import { Loader2, AlertCircle, Server, Layers, Box, RefreshCw } from 'lucide-react'
 import { useDrillDownActions } from '../../../hooks/useDrillDown'
 import { ClusterBadge } from '../../ui/ClusterBadge'
 import { useTranslation } from 'react-i18next'
 
 interface Props {
   data: Record<string, unknown>
+}
+
+// Issue 9282: Logs drilldown controls (tail lines, Follow, Download, Refresh)
+// were wired to UI but did nothing. Logs are a static mock until a real API
+// lands (TODO in the pre-existing file). This implementation makes the controls
+// behave against the mock data so the UI is consistent with its labels.
+
+/** Simulated refresh spinner duration (ms). Matches the prior visual delay. */
+const REFRESH_SPINNER_MS = 500
+
+/** How often the "follow" tailer appends a new heartbeat line (ms). */
+const FOLLOW_TICK_MS = 1_000
+
+/** Valid tail-line choices. Kept as a named constant rather than a magic array. */
+const TAIL_LINE_OPTIONS = [50, 100, 500, 1000] as const
+
+/** Default tail lines on mount. */
+const DEFAULT_TAIL_LINES = 100
+
+/** Build the seed (static placeholder) log body. Extracted so Refresh can
+ *  regenerate the timestamp and tail slicing can operate on an array. */
+function buildSeedLogLines(pod: string, container: string | undefined, generatedAtISO: string): string[] {
+  const base = new Date(generatedAtISO).getTime()
+  const fmt = (offsetMs: number) => new Date(base + offsetMs).toISOString().replace('T', ' ').slice(0, 19)
+  return [
+    `# Fetching logs for pod: ${pod}`,
+    `# Container: ${container || 'all'}`,
+    `# Generated: ${generatedAtISO}`,
+    `[${fmt(0)}] Starting application...`,
+    `[${fmt(1_000)}] Initializing components...`,
+    `[${fmt(2_000)}] Server listening on port 8080`,
+    `[${fmt(3_000)}] Connected to database`,
+    `[${fmt(4_000)}] Health check passed`,
+    `[${fmt(5_000)}] Ready to accept connections`,
+  ]
 }
 
 export function LogsDrillDown({ data }: Props) {
@@ -16,44 +51,96 @@ export function LogsDrillDown({ data }: Props) {
   const container = data.container as string | undefined
   const { drillToCluster, drillToNamespace, drillToPod } = useDrillDownActions()
   const clusterShort = cluster?.split('/').pop() || cluster
-  const [tailLines, setTailLines] = useState(100)
+  const [tailLines, setTailLines] = useState<number>(DEFAULT_TAIL_LINES)
   const [isLoading, setIsLoading] = useState(false)
-  const [error, setError] = useState<string | null>(null)
+  const [error] = useState<string | null>(null)
+  const [follow, setFollow] = useState(false)
+  // Refresh bumps the generatedAt timestamp which regenerates the seed lines
+  // so the user sees that the fetch actually took effect.
+  const [generatedAt, setGeneratedAt] = useState<string>(() => new Date().toISOString())
+  // When follow is on we append heartbeat lines to a running buffer.
+  const [followLines, setFollowLines] = useState<string[]>([])
   const refreshTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const followIntervalRef = useRef<ReturnType<typeof setInterval> | null>(null)
+  const logContainerRef = useRef<HTMLDivElement>(null)
+
+  // Regenerate the seed log block whenever the tail selector changes or the
+  // user clicks Refresh. Memoized so tail slicing is cheap.
+  const seedLines = useMemo(
+    () => buildSeedLogLines(pod, container, generatedAt),
+    [pod, container, generatedAt],
+  )
+
+  // Combined view = seed + follow heartbeats, sliced to the requested tail.
+  const visibleLogLines = useMemo(() => {
+    const all = [...seedLines, ...followLines]
+    if (tailLines >= all.length) return all
+    return all.slice(all.length - tailLines)
+  }, [seedLines, followLines, tailLines])
+
+  const visibleLog = visibleLogLines.join('\n')
 
   useEffect(() => {
     return () => {
       if (refreshTimeoutRef.current !== null) clearTimeout(refreshTimeoutRef.current)
+      if (followIntervalRef.current !== null) clearInterval(followIntervalRef.current)
     }
   }, [])
 
-  // In a real implementation, this would fetch logs from the API
-  // For now, show a placeholder with the log fetch parameters
-  const mockLogs = `Fetching logs for pod: ${pod}
-Container: ${container || 'all'}
-Tail lines: ${tailLines}
+  // Follow mode: append a synthetic heartbeat line every FOLLOW_TICK_MS and
+  // auto-scroll to the bottom. Stops when follow is toggled off.
+  useEffect(() => {
+    if (!follow) {
+      if (followIntervalRef.current !== null) {
+        clearInterval(followIntervalRef.current)
+        followIntervalRef.current = null
+      }
+      return
+    }
+    followIntervalRef.current = setInterval(() => {
+      setFollowLines((prev) => {
+        const ts = new Date().toISOString().replace('T', ' ').slice(0, 19)
+        return [...prev, `[${ts}] (heartbeat)`]
+      })
+    }, FOLLOW_TICK_MS)
+    return () => {
+      if (followIntervalRef.current !== null) {
+        clearInterval(followIntervalRef.current)
+        followIntervalRef.current = null
+      }
+    }
+  }, [follow])
 
-[2024-01-16 10:00:00] Starting application...
-[2024-01-16 10:00:01] Initializing components...
-[2024-01-16 10:00:02] Server listening on port 8080
-[2024-01-16 10:00:03] Connected to database
-[2024-01-16 10:00:04] Health check passed
-[2024-01-16 10:00:05] Ready to accept connections
-
-Note: Live log streaming coming soon.
-Connect to kubestellar-ops MCP server to fetch real logs.`
-
-  // TODO: When real API is added, replace this with actual fetch logic.
-  // Currently logs are static placeholder text — no loading/error state needed.
+  // Auto-scroll when follow is on and new lines arrive.
+  useEffect(() => {
+    if (!follow) return
+    const el = logContainerRef.current
+    if (el) el.scrollTop = el.scrollHeight
+  }, [follow, followLines])
 
   const handleRefresh = () => {
-    // Placeholder for future API refresh
     setIsLoading(true)
-    setError(null)
     if (refreshTimeoutRef.current !== null) clearTimeout(refreshTimeoutRef.current)
     refreshTimeoutRef.current = setTimeout(() => {
+      // Bump the timestamp so seedLines regenerates with a new time,
+      // giving visible feedback that Refresh did something.
+      setGeneratedAt(new Date().toISOString())
+      setFollowLines([])
       setIsLoading(false)
-    }, 500)
+    }, REFRESH_SPINNER_MS)
+  }
+
+  const handleDownload = () => {
+    // Build a blob from the currently-visible log view and trigger a download.
+    const blob = new Blob([visibleLog], { type: 'text/plain;charset=utf-8' })
+    const url = URL.createObjectURL(blob)
+    const a = document.createElement('a')
+    a.href = url
+    a.download = `${pod || 'pod'}${container ? '-' + container : ''}-logs.txt`
+    document.body.appendChild(a)
+    a.click()
+    document.body.removeChild(a)
+    URL.revokeObjectURL(url)
   }
 
   return (
@@ -100,30 +187,52 @@ Connect to kubestellar-ops MCP server to fetch real logs.`
             onChange={(e) => setTailLines(Number(e.target.value))}
             disabled={isLoading}
             className="px-3 py-2 rounded-lg bg-card/50 border border-border text-foreground text-sm disabled:opacity-50"
+            aria-label={t('drilldown.logs.tailLinesLabel')}
           >
-            <option value={50}>Last 50 lines</option>
-            <option value={100}>Last 100 lines</option>
-            <option value={500}>Last 500 lines</option>
-            <option value={1000}>Last 1000 lines</option>
+            {TAIL_LINE_OPTIONS.map((n) => (
+              <option key={n} value={n}>{t('drilldown.logs.tailLinesOption', { count: n })}</option>
+            ))}
           </select>
           <label className="flex items-center gap-2 text-sm text-muted-foreground">
-            <input type="checkbox" className="rounded" disabled={isLoading} />
-            Follow logs
+            <input
+              type="checkbox"
+              className="rounded"
+              disabled={isLoading}
+              checked={follow}
+              onChange={(e) => setFollow(e.target.checked)}
+              aria-label={t('drilldown.logs.followLogs')}
+            />
+            {t('drilldown.logs.followLogs')}
           </label>
         </div>
         <div className="flex items-center gap-2">
-          <button className="px-3 py-2 rounded-lg bg-card/50 border border-border text-sm text-foreground hover:bg-card disabled:opacity-50" disabled={isLoading}>
-            Download
+          <button
+            type="button"
+            onClick={handleDownload}
+            disabled={isLoading || visibleLogLines.length === 0}
+            className="px-3 py-2 rounded-lg bg-card/50 border border-border text-sm text-foreground hover:bg-card disabled:opacity-50"
+          >
+            {t('drilldown.logs.download')}
           </button>
-          <button 
+          <button
+            type="button"
             onClick={handleRefresh}
             disabled={isLoading}
             className="px-3 py-2 rounded-lg bg-primary text-primary-foreground text-sm flex items-center gap-2 disabled:opacity-50"
           >
-            {isLoading && <Loader2 className="w-4 h-4 animate-spin" />}
-            Refresh
+            {isLoading
+              ? <Loader2 className="w-4 h-4 animate-spin" />
+              : <RefreshCw className="w-4 h-4" />}
+            {t('drilldown.logs.refresh')}
           </button>
         </div>
+      </div>
+
+      {/* Tail / generation summary so users can see changes took effect. */}
+      <div className="text-xs text-muted-foreground">
+        {t('drilldown.logs.showing', { lines: visibleLogLines.length, tail: tailLines })}
+        {' · '}
+        {t('drilldown.logs.generatedAt', { time: new Date(generatedAt).toLocaleTimeString() })}
       </div>
 
       {/* Error State */}
@@ -131,7 +240,7 @@ Connect to kubestellar-ops MCP server to fetch real logs.`
         <div className="p-4 rounded-lg bg-red-500/10 border border-red-500/20 text-red-400 flex items-center gap-2">
           <AlertCircle className="w-5 h-5" />
           <div>
-            <div className="font-medium">Failed to load logs</div>
+            <div className="font-medium">{t('drilldown.logs.failedToLoad')}</div>
             <div className="text-sm text-muted-foreground">{error}</div>
           </div>
         </div>
@@ -141,15 +250,26 @@ Connect to kubestellar-ops MCP server to fetch real logs.`
       {isLoading && (
         <div className="flex items-center justify-center p-8">
           <Loader2 className="w-6 h-6 animate-spin text-blue-400" />
-          <span className="ml-2 text-muted-foreground">Loading logs...</span>
+          <span className="ml-2 text-muted-foreground">{t('drilldown.logs.loadingLogs')}</span>
         </div>
       )}
 
       {/* Log Output */}
       {!isLoading && !error && (
-        <div className="rounded-lg bg-black/50 border border-border p-4 font-mono text-sm overflow-x-auto">
-          <pre className="text-green-400 whitespace-pre-wrap">{mockLogs}</pre>
+        <div
+          ref={logContainerRef}
+          className="rounded-lg bg-black/50 border border-border p-4 font-mono text-sm overflow-auto max-h-[60vh]"
+        >
+          <pre className="text-green-400 whitespace-pre-wrap">{visibleLog}</pre>
         </div>
+      )}
+
+      {/* Informational footer: logs are static mock data until the real log
+          streaming API lands. Retain the "coming soon" hint. */}
+      {!isLoading && !error && (
+        <p className="text-xs text-muted-foreground italic">
+          {t('drilldown.logs.mockNotice')}
+        </p>
       )}
     </div>
   )

--- a/web/src/components/layout/UserProfileDropdown.tsx
+++ b/web/src/components/layout/UserProfileDropdown.tsx
@@ -53,6 +53,9 @@ export function UserProfileDropdown({ user, onLogout, onPreferences }: UserProfi
     i18n.changeLanguage(langCode)
     emitLanguageChanged(langCode)
     setShowLanguageSubmenu(false)
+    // Issue 9284: close the outer profile dropdown after a language is picked
+    // so the user doesn't have to click again to dismiss it.
+    closeDropdown()
   }
 
   const handleLinkedInShare = () => {

--- a/web/src/components/layout/mission-sidebar/MissionChat.tsx
+++ b/web/src/components/layout/mission-sidebar/MissionChat.tsx
@@ -92,6 +92,10 @@ export function MissionChat({ mission, isFullScreen = false, fontSize = 'base' a
     setEditDescription(mission.description)
     setEditSteps((mission.importedFrom?.steps || []).map(s => ({ title: s.title, description: s.description })))
     setIsEditingMission(false)
+    // Issue 9284: clear the input validation error (too-long messages, etc.)
+    // when switching missions — the old error bled into the new mission
+    // context and looked stale.
+    setInputError(null)
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [mission.id])
 

--- a/web/src/locales/en/cards.json
+++ b/web/src/locales/en/cards.json
@@ -1196,7 +1196,13 @@
     "searchClusterUsers": "Search cluster users...",
     "searchServiceAccounts": "Search service accounts...",
     "searchConsoleUsers": "Search console users...",
-    "fullName": "Full Name"
+    "fullName": "Full Name",
+    "toast": {
+      "deleteSuccess": "User deleted successfully",
+      "deleteError": "Failed to delete user",
+      "roleUpdateSuccess": "User role updated successfully",
+      "roleUpdateError": "Failed to update user role"
+    }
   },
   "clusterComparison": {
     "selectClusters": "Select Clusters to Compare",
@@ -3788,5 +3794,44 @@
       "warning": "warning",
       "error": "error"
     }
+  },
+  "helmHistoryModal": {
+    "chart": "Chart",
+    "appVersion": "App Version",
+    "updated": "Updated",
+    "cluster": "Cluster",
+    "description": "Description",
+    "notAvailable": "N/A",
+    "currentlyDeployed": "Currently Deployed",
+    "rollbackWithAI": "Rollback with AI Mission",
+    "rollbackDescription": "Rolling back to revision {{revision}} will restore the release to this version. Use an AI Mission to safely execute and verify the rollback."
+  },
+  "gitopsDriftModal": {
+    "kind": "Kind",
+    "driftTypeLabel": "Drift Type",
+    "namespace": "Namespace",
+    "cluster": "Cluster",
+    "gitVersion": "Git Version",
+    "details": "Details",
+    "syncWithAI": "Sync with AI Mission",
+    "contextDescription": "This {{kind}} has drifted from its desired state in Git. Use an AI Mission to investigate the cause and sync it back.",
+    "severityBadge": "{{severity}} severity",
+    "severity": {
+      "high": "high",
+      "medium": "medium",
+      "low": "low"
+    },
+    "driftType": {
+      "modified": "Modified",
+      "deleted": "Missing in Cluster",
+      "added": "Not in Git"
+    }
+  },
+  "policyModal": {
+    "enforcementMode": "Enforcement Mode",
+    "violations": "Violations",
+    "namespaceLabel": "Namespace:",
+    "policyDocumentation": "Policy Documentation",
+    "createSimilar": "Create Similar Policy"
   }
 }

--- a/web/src/locales/en/common.json
+++ b/web/src/locales/en/common.json
@@ -949,6 +949,9 @@
       "preConfiguredCards_one": "{{count}} pre-configured card",
       "preConfiguredCards_other": "{{count}} pre-configured cards",
       "selectByCategory": "Select a template by category:",
+      "selectByCategoryCollection": "Select a collection by category:",
+      "startWithCollection": "Start with a Card Collection",
+      "chooseFromCollections": "Choose from pre-built card sets",
       "cards": "cards",
       "creating": "Creating...",
       "nameRequired": "Dashboard name is required",
@@ -2336,7 +2339,31 @@
       "alreadyAtMinimum": "Already at minimum (0 replicas)",
       "maximumReplicas": "Maximum is 10 replicas",
       "noPermission": "No permission to scale deployments in this namespace",
-      "scaleHint": "Click +/- to scale (0-10 replicas)"
+      "scaleHint": "Click +/- to scale (0-10 replicas)",
+      "failedGeneric": "Unable to scale deployment",
+      "failedForbidden": "You don't have permission to scale this deployment",
+      "failedNotFound": "Deployment not found — it may have been deleted",
+      "failedInvalid": "Invalid replica count",
+      "failedConflict": "Deployment was changed by someone else — please retry",
+      "failedTimeout": "The cluster didn't respond in time — please retry"
+    },
+    "logs": {
+      "followLogs": "Follow logs",
+      "download": "Download",
+      "refresh": "Refresh",
+      "loadingLogs": "Loading logs...",
+      "failedToLoad": "Failed to load logs",
+      "tailLinesLabel": "Tail lines",
+      "tailLinesOption": "Last {{count}} lines",
+      "tailLinesOption_one": "Last {{count}} line",
+      "tailLinesOption_other": "Last {{count}} lines",
+      "showing": "Showing {{lines}} of last {{tail}} lines",
+      "generatedAt": "Generated at {{time}}",
+      "mockNotice": "Live log streaming is not yet available — showing placeholder content. Connect the local agent to stream real logs when available."
+    },
+    "deployment": {
+      "refresh": "Refresh",
+      "refreshAll": "Refresh all tabs"
     },
     "node": {
       "nodeIssueDetected": "Node Issue Detected",


### PR DESCRIPTION
## Summary

Bundled fix for the four drilldown / detail-view issues filed today by @aashu2006.

| Issue | File(s) touched | Defect | Fix |
|-------|-----------------|--------|-----|
| #9282 | `web/src/components/drilldown/views/LogsDrillDown.tsx`, `web/src/locales/en/common.json` | Follow logs / Download / Refresh / tail-lines selector were wired to UI elements but had no handlers (or only a spinner). | Wire real handlers against the mock log data: Follow appends heartbeat lines every second and auto-scrolls; Download saves a `.txt` blob of the visible view; Refresh regenerates the \`Generated at\` timestamp and clears follow buffer; tail lines actually slices the visible line count. i18n all labels. |
| #9283 | `web/src/components/drilldown/views/DeploymentDrillDown.tsx`, `web/src/locales/en/common.json` | Events / Describe / YAML tabs cached their content and never refetched — no refresh button. | Add a **Refresh** control in the deployment drilldown header that clears the three caches and reruns all four kubectl calls (`fetchData`, events, describe, yaml) in parallel. Shows a spinning icon while refreshing. |
| #9284 (1) | `web/src/components/layout/UserProfileDropdown.tsx` | Language picker left the outer profile dropdown open after selecting a language. | Call `closeDropdown()` after `i18n.changeLanguage()` + submenu close. |
| #9284 (2) | `web/src/components/cards/UserManagement.tsx` | User delete showed a native `window.confirm()` popup (blockable) after the tab had already surfaced a styled ConfirmDialog — double-confirm flow. | Remove the redundant `window.confirm()` in `handleDeleteUser` — the `ConsoleUsersTab` already wraps deletes in the app's `ConfirmDialog`. Also route the role-update / delete success and error toasts through `t()`. |
| #9284 (3) | `web/src/components/drilldown/views/DeploymentDrillDown.tsx`, `web/src/locales/en/common.json` | Scale failures dumped raw kubectl stderr (resource versions, GVK, namespaces) into the UI. | Add a `classifyScaleError()` helper that returns a static i18n key based on simple substring match (forbidden / not found / invalid / conflict / timeout / generic). Six new `drilldown.scale.failed*` keys. |
| #9284 (4) | `web/src/components/layout/mission-sidebar/MissionChat.tsx` | Input validation error (e.g. message-too-long) persisted across mission switches. | Add `setInputError(null)` to the existing `useEffect` that resets editing state on `mission.id` change. |
| #9285 (1) | `web/src/components/cards/deploy/HelmHistoryDetailModal.tsx`, `web/src/locales/en/cards.json` | Labels (Chart, App Version, Updated, Cluster, Description, Currently Deployed, Rollback with AI Mission) and date formatting were hardcoded English / `en-US`. | i18n all labels via new `cards:helmHistoryModal.*` keys; format dates with `i18n.language` instead of hardcoded `'en-US'`. |
| #9285 (2) | `web/src/components/cards/deploy/GitOpsDriftDetailModal.tsx`, `web/src/locales/en/cards.json` | Resource-info labels and the three drift-type strings (Modified / Missing in Cluster / Not in Git) + severity text were hardcoded English. | i18n all labels; map `driftType` and `severity` enum values to static i18n key maps (no runtime template literals). |
| #9285 (3) | `web/src/components/cards/opa/PolicyDetailModal.tsx`, `web/src/locales/en/cards.json` | Enforcement Mode, Violations, Namespace, Policy Documentation, Create Similar Policy, Close were hardcoded English. | i18n via new `cards:policyModal.*` keys. |
| #9285 (4) | `web/src/components/dashboard/CreateDashboardModal.tsx`, `web/src/locales/en/common.json` | "Start with a Card Collection", "Choose from pre-built card sets", "Select a collection by category:" and the embedded-mode description were hardcoded English (while the rest of the modal already used `t()`). | Add `dashboard.create.startWithCollection`, `chooseFromCollections`, `selectByCategoryCollection` keys; reuse the existing `dashboard.create.descriptionCollection` for the embedded-mode subheading. |
| #9285 (5) | `web/src/components/cards/UserManagement.tsx`, `web/src/locales/en/cards.json` | Success / error toasts after deleting a user or changing a role were hardcoded English. | Add `cards:userManagement.toast.*` keys; route through `t()`. |

## Notes

- All new `t()` calls use static string keys; no runtime template literals. Enum-to-key mapping (drift-type, severity, scale-error) uses typed record lookups.
- Every new numeric literal is a named constant (`REFRESH_SPINNER_MS`, `FOLLOW_TICK_MS`, `DEFAULT_TAIL_LINES`, `TAIL_LINE_OPTIONS`).
- `isDemoData` wiring preserved on every card touched (no card body was rewired).
- Logs drilldown remains a mock until a real log-streaming API lands — a one-line italic notice below the log pane makes that explicit (previously a `[2024-01-16 ...]` hardcoded date made the \"live\" illusion worse).
- Ran `npx tsc --noEmit` locally; passes cleanly on this branch.

## Test plan

- [ ] Build/lint CI green
- [ ] Open any pod or deployment drilldown → Logs tab: Follow auto-scrolls; Download saves a `.txt`; Refresh updates the \"Generated at\" timestamp; tail-lines dropdown changes the line count shown.
- [ ] Open a deployment drilldown → click Refresh in header: Events / Describe / YAML re-run with fresh output.
- [ ] Profile menu → Language → picking a language closes the outer dropdown.
- [ ] User Management → delete a user: only one styled confirm dialog appears, no native popup.
- [ ] Scale a deployment with an invalid value: error is a friendly message, not raw kubectl stderr.
- [ ] Mission Chat: trigger an input error, switch missions — error clears.
- [ ] Switch language to a non-English locale: Helm History, GitOps Drift, Policy Violation, Create Dashboard modals pick up translated labels (or remain English since translation resources still fall back to en, but the keys are now translatable).

Fixes #9282, Fixes #9283, Fixes #9284, Fixes #9285