### PR TITLE
fix(build): remove unused imports after refactor-split cascade

### DIFF
--- a/web/src/components/cards/drasi/DrasiFlowLine.tsx
+++ b/web/src/components/cards/drasi/DrasiFlowLine.tsx
@@ -3,7 +3,6 @@
  *
  * Exports: FlowLine, flowStateColors, seededRand, TRAFFIC_PATTERNS
  */
-import React from 'react'
 import { useReducedMotion } from 'framer-motion'
 import {
   FLOW_COLOR_ACTIVE_STROKE, FLOW_COLOR_ACTIVE_DOT,

--- a/web/src/components/cards/drasi/DrasiReactiveGraph.tsx
+++ b/web/src/components/cards/drasi/DrasiReactiveGraph.tsx
@@ -22,7 +22,7 @@
  *                             QueryConfigModal, ConnectionsModal, RowDetailDrawer
  *   DrasiStreamSamples.tsx  — StreamSampleDrawer, STREAM_SAMPLES
  */
-import React, { useState, useEffect, useMemo, useCallback, useRef, useLayoutEffect } from 'react'
+import { useState, useEffect, useMemo, useCallback, useRef, useLayoutEffect } from 'react'
 import { AnimatePresence } from 'framer-motion'
 import { Search, Plus, Settings, Rocket, Code2, Zap, Server } from 'lucide-react'
 import { useNavigate } from 'react-router-dom'

--- a/web/src/components/cards/drasi/DrasiStreamSamples.tsx
+++ b/web/src/components/cards/drasi/DrasiStreamSamples.tsx
@@ -4,7 +4,7 @@
  *
  * Exports: StreamSampleDrawer, STREAM_SAMPLES, StreamSample
  */
-import React, { useState, useEffect } from 'react'
+import { useState, useEffect } from 'react'
 import { motion } from 'framer-motion'
 import { X, Code2, Copy, Check } from 'lucide-react'
 import { useTranslation } from 'react-i18next'

--- a/web/src/components/mission-control/FlightPlanBlueprint.tsx
+++ b/web/src/components/mission-control/FlightPlanBlueprint.tsx
@@ -40,9 +40,7 @@ import { DependencyPath, DependencyLabel, computeEdgeMidpoint } from './svg/Depe
 import { PhaseTimeline } from './svg/PhaseTimeline'
 import type {
   MissionControlState,
-  OverlayMode,
-  BlueprintLayout,
-  DependencyEdge } from './types'
+  OverlayMode } from './types'
 import { useClusters } from '../../hooks/mcp/clusters'
 import { detectCloudProvider } from '../ui/CloudProviderIcon'
 import { fetchMissionContent } from '../missions/browser/missionCache'

--- a/web/src/hooks/useMissions.tsx
+++ b/web/src/hooks/useMissions.tsx
@@ -17,13 +17,12 @@ export type {
 } from './useMissionTypes'
 export { INACTIVE_MISSION_STATUSES, isActiveMission } from './useMissionTypes'
 import type {
-  MissionStatus, Mission, MissionMessage, MissionFeedback, MatchedResolution,
+  MissionStatus, Mission, MissionMessage, MissionFeedback,
   StartMissionParams, PendingReviewEntry, SaveMissionParams, SavedMissionUpdates,
 } from './useMissionTypes'
-import { INACTIVE_MISSION_STATUSES } from './useMissionTypes'
 import {
-  MISSIONS_STORAGE_KEY, CROSS_TAB_ECHO_IGNORE_MS, UNREAD_MISSIONS_KEY,
-  SELECTED_AGENT_KEY, KAGENTI_SELECTED_AGENT_KEY,
+  MISSIONS_STORAGE_KEY, CROSS_TAB_ECHO_IGNORE_MS,
+  SELECTED_AGENT_KEY,
   loadMissions, saveMissions, loadUnreadMissionIds, saveUnreadMissionIds,
   mergeMissions, getSelectedKagentiAgentFromStorage,
 } from './useMissionStorage'


### PR DESCRIPTION
## Summary

Hotfix for `main` — the rapid refactor-split cascade (PRs #9289, #9290, #9291, #9292, #9293, #9295, #9302) moved code into sub-modules but left orphaned imports in the parent files. Each subsequent merge triggered post-merge-verify, which filed a new build-broken issue.

Errors from the post-merge-verify log on current `main` SHA `a6aaad82`:

```
src/hooks/useMissions.tsx(20,60): error TS6196: 'MatchedResolution' is declared but never used.
src/hooks/useMissions.tsx(23,1): error TS6133: 'INACTIVE_MISSION_STATUSES' is declared but its value is never read.
src/hooks/useMissions.tsx(25,51): error TS6133: 'UNREAD_MISSIONS_KEY' is declared but its value is never read.
src/hooks/useMissions.tsx(26,23): error TS6133: 'KAGENTI_SELECTED_AGENT_KEY' is declared but its value is never read.
src/components/mission-control/FlightPlanBlueprint.tsx(44,3): error TS6196: 'BlueprintLayout' is declared but never used.
src/components/mission-control/FlightPlanBlueprint.tsx(45,3): error TS6196: 'DependencyEdge' is declared but never used.
src/components/cards/drasi/DrasiFlowLine.tsx(6,1): error TS6133: 'React' is declared but its value is never read.
src/components/cards/drasi/DrasiReactiveGraph.tsx(25,8): error TS6133: 'React' is declared but its value is never read.
src/components/cards/drasi/DrasiStreamSamples.tsx(7,8): error TS6133: 'React' is declared but its value is never read.
```

## Fix

- \`useMissions.tsx\` — drop the local \`import type\` for \`MatchedResolution\` and locally-imported \`INACTIVE_MISSION_STATUSES\` (both still re-exported via the sibling \`export type\` / \`export { ... }\` blocks, so public API is unchanged). Drop \`UNREAD_MISSIONS_KEY\` and \`KAGENTI_SELECTED_AGENT_KEY\` from the storage import list — they're now consumed only by sub-modules.
- \`FlightPlanBlueprint.tsx\` — drop \`BlueprintLayout\` and \`DependencyEdge\` from the type-only import; both moved to \`BlueprintLayout.ts\`.
- \`DrasiFlowLine.tsx\`, \`DrasiReactiveGraph.tsx\`, \`DrasiStreamSamples.tsx\` — drop the legacy default \`React\` import (new JSX transform, no \`React.X\` references in any of the three).

Closes #9296, Closes #9297, Closes #9298, Closes #9299, Closes #9300, Closes #9301, Closes #9304.

## Test plan

- [ ] Post-merge-verify build passes on this PR's head
- [ ] No new TS6133/TS6196 errors introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)