### PR TITLE
fix(tests): correct analytics-session and useMissionStorage test failures

### DIFF
--- a/web/src/hooks/useMissionStorage.test.ts
+++ b/web/src/hooks/useMissionStorage.test.ts
@@ -284,8 +284,8 @@ describe('saveUnreadMissionIds', () => {
 // ── mergeMissions ───────────────────────────────────────────────────────────
 
 describe('mergeMissions', () => {
-  it('returns prev missions when reloaded is empty', () => {
-    const prev = [makeMission({ status: 'completed', id: 'a' })]
+  it('keeps active prev missions when reloaded is empty', () => {
+    const prev = [makeMission({ status: 'running', id: 'a' })]
     const result = mergeMissions(prev, [])
     expect(result).toHaveLength(1)
   })

--- a/web/src/lib/analytics-session.test.ts
+++ b/web/src/lib/analytics-session.test.ts
@@ -49,6 +49,14 @@ afterEach(() => {
 // ── isAutomatedEnvironment ──────────────────────────────────────────────────
 
 describe('isAutomatedEnvironment', () => {
+  beforeEach(() => {
+    // JSDOM lacks plugins and languages by default — simulate a real browser
+    Object.defineProperty(navigator, 'plugins', { value: { length: 1 }, configurable: true, writable: true })
+    Object.defineProperty(navigator, 'languages', { value: ['en-US'], configurable: true, writable: true })
+    Object.defineProperty(navigator, 'userAgent', { value: 'Chrome/120', configurable: true })
+    Object.defineProperty(navigator, 'webdriver', { value: false, configurable: true })
+  })
+
   it('returns false for a normal browser environment', () => {
     expect(isAutomatedEnvironment()).toBe(false)
   })

--- a/web/src/lib/analytics-session.ts
+++ b/web/src/lib/analytics-session.ts
@@ -242,6 +242,10 @@ export function getAndResetEngagementMs(): number {
 export function resetSessionEngagement() {
   sessionEngagementMs = 0
   sessionPageViewCount = 0
+  accumulatedEngagementMs = 0
+  engagementStartMs = 0
+  lastInteractionMs = 0
+  isUserActive = false
 }
 
 /** Increment the page view counter */
@@ -306,6 +310,7 @@ export function getUtmParams(): UtmParams {
  * Only used by analytics-core.ts — prefer captureUtmParams() from analytics.ts.
  */
 export function _loadUtmParams(): UtmParams | null {
+  utmParams = {}
   const params = new URLSearchParams(window.location.search)
   const utmKeys = ['utm_source', 'utm_medium', 'utm_campaign', 'utm_term', 'utm_content']
   for (const key of utmKeys) {


### PR DESCRIPTION
## Summary

Fixes 4 test failures introduced by the coverage PRs (#9309, #9311):

- **`resetSessionEngagement`**: also resets `accumulatedEngagementMs`, `engagementStartMs`, `lastInteractionMs`, `isUserActive` — fake-timer tests were seeing stale state from prior tests causing `peekSessionEngagementMs` to return -1499
- **`_loadUtmParams`**: resets `utmParams = {}` on each call to prevent cross-test pollution (previous test left `utm_source='xxx...'` in module state)
- **`analytics-session.test`**: adds `beforeEach` in `isAutomatedEnvironment` describe to mock `navigator.plugins`/`languages`/`userAgent` — JSDOM has empty plugins/languages by default which was incorrectly triggering the automation detection check
- **`useMissionStorage.test`**: fixes `mergeMissions` test to use `status: 'running'` — completed missions are intentionally dropped when absent from the reloaded list (per `INACTIVE_MISSION_STATUSES`)

## Test plan
- [ ] CI build/lint passes
- [ ] All test shards green