### PR TITLE
feat(gpu): scrape DCGM exporter for real GPU memory metrics

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,8 @@ require (
 	github.com/gorilla/websocket v1.5.4-0.20250319132907-e064f32e3674
 	github.com/joho/godotenv v1.5.1
 	github.com/prometheus/client_golang v1.23.2
+	github.com/prometheus/client_model v0.6.2
+	github.com/prometheus/common v0.66.1
 	github.com/stretchr/testify v1.11.1
 	go.uber.org/goleak v1.3.0
 	golang.org/x/oauth2 v0.36.0
@@ -53,8 +55,6 @@ require (
 	github.com/ncruces/go-strftime v1.0.0 // indirect
 	github.com/philhofer/fwd v1.1.3-0.20240916144458-20a13a1f6b7c // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
-	github.com/prometheus/client_model v0.6.2 // indirect
-	github.com/prometheus/common v0.66.1 // indirect
 	github.com/prometheus/procfs v0.16.1 // indirect
 	github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect

--- a/pkg/agent/dcgm_scraper.go
+++ b/pkg/agent/dcgm_scraper.go
@@ -1,0 +1,215 @@
+package agent
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+
+	dto "github.com/prometheus/client_model/go"
+	"github.com/prometheus/common/expfmt"
+	"github.com/prometheus/common/model"
+	"k8s.io/client-go/rest"
+)
+
+// prometheus/common v0.66+ gave TextParser its own `scheme` field that
+// defaults to UnsetValidation and panics on the first parse. DCGM exporter
+// emits legacy (non-UTF8) metric names, so construct the parser with
+// LegacyValidation explicitly every call. The package-level
+// model.NameValidationScheme global is ignored by TextParser — only the
+// NewTextParser argument matters.
+
+// DCGM metric names we consume. Names come from the NVIDIA DCGM exporter
+// and match the upstream DCGM Field Identifier (FI) naming scheme:
+// https://docs.nvidia.com/datacenter/dcgm/latest/user-guide/dcgm-fields.html
+const (
+	dcgmMetricFBUsed = "DCGM_FI_DEV_FB_USED" // framebuffer memory currently allocated (MiB)
+	dcgmMetricFBFree = "DCGM_FI_DEV_FB_FREE" // framebuffer memory available for allocation (MiB)
+)
+
+// Default DCGM exporter coordinates used when Scrape callers omit overrides.
+const (
+	defaultDCGMPort = "9400"
+	defaultDCGMPath = "/metrics"
+)
+
+// DCGMNamespaceMetrics is the aggregated framebuffer memory usage for all
+// GPU containers observed in one Kubernetes namespace on a single cluster.
+// Units match the DCGM exporter's native unit (MiB); callers compute the
+// utilization percentage from Used / (Used + Free).
+type DCGMNamespaceMetrics struct {
+	FBUsedMiB float64
+	FBFreeMiB float64
+	// SampleCount is the number of GPU-device samples aggregated into this
+	// bucket. Zero means DCGM returned no FB_USED samples for the namespace.
+	SampleCount int
+}
+
+// UtilizationPct returns the framebuffer utilization percentage (0-100)
+// for the aggregated namespace, or 0 when no samples were observed.
+func (m *DCGMNamespaceMetrics) UtilizationPct() float64 {
+	if m == nil {
+		return 0
+	}
+	total := m.FBUsedMiB + m.FBFreeMiB
+	if total <= 0 {
+		return 0
+	}
+	return (m.FBUsedMiB / total) * 100.0
+}
+
+// DCGMScrapeConfig selects the in-cluster DCGM exporter Service to scrape.
+// Namespace and Service are validated against Kubernetes DNS-1123 label rules
+// to prevent path traversal when the values are interpolated into the API
+// server proxy URL.
+type DCGMScrapeConfig struct {
+	Namespace string // Kubernetes namespace hosting the DCGM exporter Service
+	Service   string // Service name of the DCGM exporter
+	Port      string // Service port serving /metrics (default "9400")
+	Path      string // URL path for the metrics endpoint (default "/metrics")
+}
+
+// ScrapeDCGMByNamespace fetches the DCGM exporter's Prometheus text-format
+// metrics endpoint via the Kubernetes API server proxy and returns the
+// framebuffer usage aggregated by pod namespace.
+//
+// The returned map is keyed by the `namespace` label that NVIDIA's GPU
+// Operator attaches to DCGM samples via the pod-names sidecar. DCGM
+// installations without pod-name resolution emit no namespace label; those
+// samples are aggregated into a single "" (empty) key. Callers that only
+// need per-reservation (cluster, namespace) rollups can look up their
+// namespace directly; cluster-wide totals are available under "".
+//
+// A 404 response is treated as "DCGM not installed" and returns an empty
+// map with no error, so the caller can silently fall back to the pre-DCGM
+// zero value. Any other transport or parse failure is returned as an error.
+func ScrapeDCGMByNamespace(ctx context.Context, config *rest.Config, scrape DCGMScrapeConfig) (map[string]*DCGMNamespaceMetrics, error) {
+	if config == nil {
+		return nil, fmt.Errorf("dcgm: rest config is nil")
+	}
+
+	if err := validateDNS1123Label("dcgm namespace", scrape.Namespace); err != nil {
+		return nil, err
+	}
+	if err := validateDNS1123Label("dcgm service", scrape.Service); err != nil {
+		return nil, err
+	}
+
+	port := scrape.Port
+	if port == "" {
+		port = defaultDCGMPort
+	}
+	path := scrape.Path
+	if path == "" {
+		path = defaultDCGMPath
+	}
+
+	client, err := getOrCreatePromClient(config)
+	if err != nil {
+		return nil, fmt.Errorf("dcgm: get http client: %w", err)
+	}
+
+	// Build the K8s API server service-proxy URL for the DCGM exporter's
+	// /metrics endpoint. Same proxy shape used by handlePrometheusQuery.
+	proxyPath := fmt.Sprintf("/api/v1/namespaces/%s/services/%s:%s/proxy%s",
+		url.PathEscape(scrape.Namespace),
+		url.PathEscape(scrape.Service),
+		url.PathEscape(port),
+		path,
+	)
+	fullURL := config.Host + proxyPath
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, fullURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("dcgm: build request: %w", err)
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("dcgm: scrape %s: %w", scrape.Service, err)
+	}
+	defer resp.Body.Close()
+
+	// DCGM exporter absent is a valid operational state — return empty map
+	// rather than an error so the caller's fallback path is silent.
+	if resp.StatusCode == http.StatusNotFound {
+		return map[string]*DCGMNamespaceMetrics{}, nil
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("dcgm: scrape returned status %d", resp.StatusCode)
+	}
+
+	return parseDCGMResponse(resp.Body)
+}
+
+// parseDCGMResponse decodes a Prometheus text-format metrics payload and
+// aggregates FB_USED / FB_FREE gauges by the `namespace` label. Unknown
+// metric families are ignored — DCGM emits hundreds of fields; we only
+// consume framebuffer memory to populate MemoryUtilizationPct.
+func parseDCGMResponse(body io.Reader) (map[string]*DCGMNamespaceMetrics, error) {
+	parser := expfmt.NewTextParser(model.LegacyValidation)
+	families, err := parser.TextToMetricFamilies(body)
+	if err != nil {
+		return nil, fmt.Errorf("dcgm: parse text format: %w", err)
+	}
+
+	out := make(map[string]*DCGMNamespaceMetrics)
+
+	if family, ok := families[dcgmMetricFBUsed]; ok {
+		for _, m := range family.Metric {
+			ns := labelValue(m, "namespace")
+			entry := getOrCreateEntry(out, ns)
+			entry.FBUsedMiB += sampleValue(m)
+			entry.SampleCount++
+		}
+	}
+
+	if family, ok := families[dcgmMetricFBFree]; ok {
+		for _, m := range family.Metric {
+			ns := labelValue(m, "namespace")
+			entry := getOrCreateEntry(out, ns)
+			entry.FBFreeMiB += sampleValue(m)
+		}
+	}
+
+	return out, nil
+}
+
+// getOrCreateEntry returns the aggregation bucket for a namespace key,
+// creating it on first access so accumulation is safe from any metric.
+func getOrCreateEntry(m map[string]*DCGMNamespaceMetrics, key string) *DCGMNamespaceMetrics {
+	if entry, ok := m[key]; ok {
+		return entry
+	}
+	entry := &DCGMNamespaceMetrics{}
+	m[key] = entry
+	return entry
+}
+
+// labelValue returns the string value of the named label on a DCGM sample,
+// or "" when absent. DCGM exporters without the pod-names sidecar emit no
+// `namespace` label; those samples collapse to the "" bucket, which the
+// caller treats as cluster-wide totals.
+func labelValue(m *dto.Metric, name string) string {
+	for _, pair := range m.Label {
+		if pair.GetName() == name {
+			return pair.GetValue()
+		}
+	}
+	return ""
+}
+
+// sampleValue extracts the scalar value from a DCGM sample. DCGM emits
+// framebuffer metrics as gauges; counters and histograms are not expected
+// here and return 0.
+func sampleValue(m *dto.Metric) float64 {
+	if g := m.Gauge; g != nil {
+		return g.GetValue()
+	}
+	if c := m.Counter; c != nil {
+		return c.GetValue()
+	}
+	return 0
+}

--- a/pkg/agent/dcgm_scraper_test.go
+++ b/pkg/agent/dcgm_scraper_test.go
@@ -1,0 +1,198 @@
+package agent
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"k8s.io/client-go/rest"
+)
+
+// dcgmFixtureMultiNamespace is a DCGM exporter text-format payload with
+// samples in two namespaces plus one unlabeled sample. Values mirror what
+// the NVIDIA GPU Operator (dcgm-exporter + pod-names sidecar) emits in
+// production: HELP/TYPE headers, then one sample per GPU device with the
+// pod/namespace/container labels attached.
+const dcgmFixtureMultiNamespace = `# HELP DCGM_FI_DEV_FB_USED Framebuffer memory used (in MiB).
+# TYPE DCGM_FI_DEV_FB_USED gauge
+DCGM_FI_DEV_FB_USED{gpu="0",UUID="GPU-abc",Hostname="node-1",namespace="ml-team",pod="trainer-0",container="worker"} 40960
+DCGM_FI_DEV_FB_USED{gpu="1",UUID="GPU-def",Hostname="node-1",namespace="ml-team",pod="trainer-1",container="worker"} 20480
+DCGM_FI_DEV_FB_USED{gpu="0",UUID="GPU-ghi",Hostname="node-2",namespace="inference",pod="server-0",container="serve"} 10240
+DCGM_FI_DEV_FB_USED{gpu="0",UUID="GPU-jkl",Hostname="node-3"} 8192
+# HELP DCGM_FI_DEV_FB_FREE Framebuffer memory free (in MiB).
+# TYPE DCGM_FI_DEV_FB_FREE gauge
+DCGM_FI_DEV_FB_FREE{gpu="0",UUID="GPU-abc",Hostname="node-1",namespace="ml-team",pod="trainer-0",container="worker"} 40960
+DCGM_FI_DEV_FB_FREE{gpu="1",UUID="GPU-def",Hostname="node-1",namespace="ml-team",pod="trainer-1",container="worker"} 61440
+DCGM_FI_DEV_FB_FREE{gpu="0",UUID="GPU-ghi",Hostname="node-2",namespace="inference",pod="server-0",container="serve"} 71680
+DCGM_FI_DEV_FB_FREE{gpu="0",UUID="GPU-jkl",Hostname="node-3"} 73728
+# HELP DCGM_FI_DEV_GPU_UTIL GPU utilization percent.
+# TYPE DCGM_FI_DEV_GPU_UTIL gauge
+DCGM_FI_DEV_GPU_UTIL{gpu="0",UUID="GPU-abc",namespace="ml-team"} 95
+`
+
+const dcgmFixtureEmpty = `# HELP DCGM_FI_DEV_FB_USED Framebuffer memory used (in MiB).
+# TYPE DCGM_FI_DEV_FB_USED gauge
+`
+
+func TestParseDCGMResponse_MultiNamespace(t *testing.T) {
+	got, err := parseDCGMResponse(strings.NewReader(dcgmFixtureMultiNamespace))
+	if err != nil {
+		t.Fatalf("parseDCGMResponse: %v", err)
+	}
+
+	// ml-team: 40960 + 20480 used, 40960 + 61440 free = 61440 / (61440 + 102400) = 37.5%
+	ml, ok := got["ml-team"]
+	if !ok {
+		t.Fatalf("expected ml-team in result, got keys: %v", keys(got))
+	}
+	if ml.FBUsedMiB != 61440 {
+		t.Errorf("ml-team FBUsedMiB: got %v, want 61440", ml.FBUsedMiB)
+	}
+	if ml.FBFreeMiB != 102400 {
+		t.Errorf("ml-team FBFreeMiB: got %v, want 102400", ml.FBFreeMiB)
+	}
+	if got, want := ml.UtilizationPct(), 37.5; got != want {
+		t.Errorf("ml-team UtilizationPct: got %v, want %v", got, want)
+	}
+	if ml.SampleCount != 2 {
+		t.Errorf("ml-team SampleCount: got %d, want 2", ml.SampleCount)
+	}
+
+	// inference: 10240 / (10240 + 71680) = 12.5%
+	inf, ok := got["inference"]
+	if !ok {
+		t.Fatalf("expected inference in result")
+	}
+	if got, want := inf.UtilizationPct(), 12.5; got != want {
+		t.Errorf("inference UtilizationPct: got %v, want %v", got, want)
+	}
+
+	// "" bucket (unlabeled sample): 8192 / (8192 + 73728) = 10%
+	unlabeled, ok := got[""]
+	if !ok {
+		t.Fatalf(`expected "" (unlabeled) bucket in result`)
+	}
+	if got, want := unlabeled.UtilizationPct(), 10.0; got != want {
+		t.Errorf("unlabeled UtilizationPct: got %v, want %v", got, want)
+	}
+}
+
+func TestParseDCGMResponse_EmptyPayload(t *testing.T) {
+	got, err := parseDCGMResponse(strings.NewReader(dcgmFixtureEmpty))
+	if err != nil {
+		t.Fatalf("parseDCGMResponse empty: %v", err)
+	}
+	if len(got) != 0 {
+		t.Errorf("expected empty map on empty payload, got %d entries", len(got))
+	}
+}
+
+func TestParseDCGMResponse_MalformedPayload(t *testing.T) {
+	_, err := parseDCGMResponse(strings.NewReader("not valid prometheus text $$$\n"))
+	if err == nil {
+		t.Fatal("expected error for malformed payload, got nil")
+	}
+}
+
+func TestDCGMNamespaceMetrics_UtilizationPct_ZeroCapacity(t *testing.T) {
+	m := &DCGMNamespaceMetrics{FBUsedMiB: 0, FBFreeMiB: 0}
+	if pct := m.UtilizationPct(); pct != 0 {
+		t.Errorf("zero-capacity UtilizationPct: got %v, want 0", pct)
+	}
+
+	var nilMetrics *DCGMNamespaceMetrics
+	if pct := nilMetrics.UtilizationPct(); pct != 0 {
+		t.Errorf("nil UtilizationPct: got %v, want 0", pct)
+	}
+}
+
+func TestScrapeDCGMByNamespace_HappyPath(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// The rest.TransportFor + API server proxy path is bypassed in tests:
+		// we point the rest.Config directly at the fake server. The proxy
+		// URL shape still gets built, but the test server ignores the path.
+		w.Header().Set("Content-Type", "text/plain; version=0.0.4")
+		_, _ = w.Write([]byte(dcgmFixtureMultiNamespace))
+	}))
+	defer srv.Close()
+
+	cfg := &rest.Config{Host: srv.URL}
+	got, err := ScrapeDCGMByNamespace(context.Background(), cfg, DCGMScrapeConfig{
+		Namespace: "gpu-operator",
+		Service:   "dcgm-exporter",
+	})
+	if err != nil {
+		t.Fatalf("ScrapeDCGMByNamespace: %v", err)
+	}
+	if _, ok := got["ml-team"]; !ok {
+		t.Errorf("expected ml-team namespace in scraped result, got keys: %v", keys(got))
+	}
+}
+
+func TestScrapeDCGMByNamespace_NotInstalled(t *testing.T) {
+	// 404 from the API server proxy = "Service not found" = DCGM not installed.
+	// Callers rely on this returning (empty, nil) so fallback is silent.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.NotFound(w, r)
+	}))
+	defer srv.Close()
+
+	cfg := &rest.Config{Host: srv.URL}
+	got, err := ScrapeDCGMByNamespace(context.Background(), cfg, DCGMScrapeConfig{
+		Namespace: "gpu-operator",
+		Service:   "dcgm-exporter",
+	})
+	if err != nil {
+		t.Fatalf("ScrapeDCGMByNamespace on 404: %v", err)
+	}
+	if len(got) != 0 {
+		t.Errorf("expected empty map on 404 (DCGM absent), got %d entries", len(got))
+	}
+}
+
+func TestScrapeDCGMByNamespace_ServerError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "internal", http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	cfg := &rest.Config{Host: srv.URL}
+	_, err := ScrapeDCGMByNamespace(context.Background(), cfg, DCGMScrapeConfig{
+		Namespace: "gpu-operator",
+		Service:   "dcgm-exporter",
+	})
+	if err == nil {
+		t.Fatal("expected error on 500, got nil")
+	}
+}
+
+func TestScrapeDCGMByNamespace_InvalidNamespace(t *testing.T) {
+	cfg := &rest.Config{Host: "http://unused"}
+	_, err := ScrapeDCGMByNamespace(context.Background(), cfg, DCGMScrapeConfig{
+		Namespace: "../etc/passwd",
+		Service:   "dcgm-exporter",
+	})
+	if err == nil {
+		t.Fatal("expected validation error on path-traversal namespace, got nil")
+	}
+}
+
+func TestScrapeDCGMByNamespace_NilConfig(t *testing.T) {
+	_, err := ScrapeDCGMByNamespace(context.Background(), nil, DCGMScrapeConfig{
+		Namespace: "gpu-operator",
+		Service:   "dcgm-exporter",
+	})
+	if err == nil {
+		t.Fatal("expected error on nil rest.Config, got nil")
+	}
+}
+
+func keys(m map[string]*DCGMNamespaceMetrics) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
+}

--- a/pkg/api/gpu_utilization_worker.go
+++ b/pkg/api/gpu_utilization_worker.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/google/uuid"
 
+	"github.com/kubestellar/console/pkg/agent"
 	"github.com/kubestellar/console/pkg/k8s"
 	"github.com/kubestellar/console/pkg/models"
 	"github.com/kubestellar/console/pkg/notifications"
@@ -28,6 +29,12 @@ const (
 	defaultOverThreshold = 90.0
 	// defaultUnderThreshold is the default threshold for under-utilization alerts
 	defaultUnderThreshold = 20.0
+	// defaultDCGMNamespace is the Kubernetes namespace where the NVIDIA GPU
+	// Operator ships the dcgm-exporter Service by default.
+	defaultDCGMNamespace = "gpu-operator"
+	// defaultDCGMService is the Service name of the DCGM exporter shipped
+	// by the NVIDIA GPU Operator.
+	defaultDCGMService = "dcgm-exporter"
 )
 
 const (
@@ -50,6 +57,13 @@ type GPUUtilizationWorker struct {
 	notificationService *notifications.Service
 	overThreshold      float64
 	underThreshold     float64
+	// dcgmEnabled toggles NVIDIA DCGM exporter scraping for real GPU memory
+	// metrics (Issue 9135). Defaults to false — clusters without the GPU
+	// Operator / DCGM stack should silently fall back to the legacy zero
+	// value instead of logging errors every poll.
+	dcgmEnabled   bool
+	dcgmNamespace string
+	dcgmService   string
 }
 
 // NewGPUUtilizationWorker creates a new GPU utilization worker
@@ -77,6 +91,16 @@ func NewGPUUtilizationWorker(s store.Store, k8sClient *k8s.MultiClusterClient, n
 		}
 	}
 
+	dcgmEnabled := os.Getenv("GPU_METRICS_DCGM_ENABLED") == "true"
+	dcgmNamespace := os.Getenv("GPU_METRICS_DCGM_NAMESPACE")
+	if dcgmNamespace == "" {
+		dcgmNamespace = defaultDCGMNamespace
+	}
+	dcgmService := os.Getenv("GPU_METRICS_DCGM_SERVICE")
+	if dcgmService == "" {
+		dcgmService = defaultDCGMService
+	}
+
 	ctx, cancel := context.WithCancel(context.Background())
 	return &GPUUtilizationWorker{
 		store:               s,
@@ -89,6 +113,9 @@ func NewGPUUtilizationWorker(s store.Store, k8sClient *k8s.MultiClusterClient, n
 		notificationService: notificationService,
 		overThreshold:       overThreshold,
 		underThreshold:      underThreshold,
+		dcgmEnabled:         dcgmEnabled,
+		dcgmNamespace:       dcgmNamespace,
+		dcgmService:         dcgmService,
 	}
 }
 
@@ -145,6 +172,12 @@ func (w *GPUUtilizationWorker) collectUtilization() {
 	// Derived from w.baseCtx so Stop() cancels in-flight calls immediately (#6966).
 	perReservationTimeout := w.interval / time.Duration(perReservationTimeoutDivisor)
 
+	// Scrape DCGM once per unique cluster and share the result across all
+	// reservations on that cluster (Issue 9135). Scraping per reservation
+	// would hit the exporter N times for N namespaces in the same cluster
+	// and blow past rate limits on shared infrastructure.
+	dcgmByCluster := w.scrapeDCGMPerCluster(reservations, perReservationTimeout)
+
 	var wg sync.WaitGroup
 	for i := range reservations {
 		wg.Add(1)
@@ -152,14 +185,67 @@ func (w *GPUUtilizationWorker) collectUtilization() {
 			defer wg.Done()
 			ctx, cancel := context.WithTimeout(w.baseCtx, perReservationTimeout)
 			defer cancel()
-			w.collectForReservation(ctx, r)
+			w.collectForReservation(ctx, r, dcgmByCluster[r.Cluster])
 		}(&reservations[i])
 	}
 	wg.Wait()
 }
 
-// collectForReservation collects utilization for a single reservation
-func (w *GPUUtilizationWorker) collectForReservation(ctx context.Context, reservation *models.GPUReservation) {
+// scrapeDCGMPerCluster fetches DCGM exporter metrics once per unique
+// cluster and returns a map keyed by cluster name. Callers look up
+// per-namespace framebuffer utilization from the nested map. Returns
+// nil when DCGM is disabled via env flag — callers handle nil as
+// "no DCGM data, use legacy zero fallback".
+func (w *GPUUtilizationWorker) scrapeDCGMPerCluster(
+	reservations []models.GPUReservation,
+	timeout time.Duration,
+) map[string]map[string]*agent.DCGMNamespaceMetrics {
+	if !w.dcgmEnabled {
+		return nil
+	}
+
+	// Collect unique cluster names.
+	clusters := make(map[string]struct{})
+	for i := range reservations {
+		clusters[reservations[i].Cluster] = struct{}{}
+	}
+
+	out := make(map[string]map[string]*agent.DCGMNamespaceMetrics, len(clusters))
+	scrapeConfig := agent.DCGMScrapeConfig{
+		Namespace: w.dcgmNamespace,
+		Service:   w.dcgmService,
+	}
+	for cluster := range clusters {
+		restConfig, err := w.k8sClient.GetRestConfig(cluster)
+		if err != nil {
+			// Cluster unreachable → silent zero fallback for this cluster.
+			slog.Debug("GPU utilization worker: DCGM scrape skipped (no rest config)", "cluster", cluster, "error", err)
+			continue
+		}
+		ctx, cancel := context.WithTimeout(w.baseCtx, timeout)
+		metrics, err := agent.ScrapeDCGMByNamespace(ctx, restConfig, scrapeConfig)
+		cancel()
+		if err != nil {
+			// Log at debug — the feature is opt-in and a 503 / missing Service
+			// on an unconfigured cluster is a legitimate operational state,
+			// not an error worth pager-duty attention.
+			slog.Debug("GPU utilization worker: DCGM scrape failed", "cluster", cluster, "error", err)
+			continue
+		}
+		out[cluster] = metrics
+	}
+	return out
+}
+
+// collectForReservation collects utilization for a single reservation.
+// dcgmClusterMetrics is the per-namespace DCGM framebuffer map for the
+// reservation's cluster (or nil when DCGM is disabled / unreachable);
+// callers pass nil for the legacy zero-memory fallback.
+func (w *GPUUtilizationWorker) collectForReservation(
+	ctx context.Context,
+	reservation *models.GPUReservation,
+	dcgmClusterMetrics map[string]*agent.DCGMNamespaceMetrics,
+) {
 	cluster := reservation.Cluster
 	namespace := reservation.Namespace
 
@@ -257,12 +343,20 @@ func (w *GPUUtilizationWorker) collectForReservation(ctx context.Context, reserv
 		}
 	}
 
+	// Populate MemoryUtilizationPct from the DCGM exporter when available
+	// (Issue 9135). Silent zero fallback when DCGM is disabled, unreachable,
+	// or emits no samples for this reservation's namespace.
+	memoryUtilPct := 0.0
+	if nsMetrics, ok := dcgmClusterMetrics[namespace]; ok && nsMetrics != nil && nsMetrics.SampleCount > 0 {
+		memoryUtilPct = nsMetrics.UtilizationPct()
+	}
+
 	snapshot := &models.GPUUtilizationSnapshot{
 		ID:                   uuid.New().String(),
 		ReservationID:        reservation.ID.String(),
 		Timestamp:            time.Now(),
 		GPUUtilizationPct:    gpuUtilPct,
-		MemoryUtilizationPct: 0, // Memory metrics require a metrics-server; 0 indicates unavailable (#7019)
+		MemoryUtilizationPct: memoryUtilPct,
 		ActiveGPUCount:       activeGPUCount,
 		TotalGPUCount:        totalGPUs,
 	}

--- a/pkg/api/gpu_utilization_worker_test.go
+++ b/pkg/api/gpu_utilization_worker_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/kubestellar/console/pkg/agent"
 	"github.com/kubestellar/console/pkg/k8s"
 	"github.com/kubestellar/console/pkg/models"
 	"github.com/kubestellar/console/pkg/notifications"
@@ -115,7 +116,7 @@ func TestGPUUtilizationWorker_MetricAccuracy(t *testing.T) {
 			return s.ActiveGPUCount == 3 && s.TotalGPUCount == 4 && s.GPUUtilizationPct == 75.0
 		})).Return(nil).Once()
 
-		worker.collectForReservation(context.Background(), reservation)
+		worker.collectForReservation(context.Background(), reservation, nil)
 		mockStore.AssertExpectations(t)
 	})
 
@@ -150,7 +151,7 @@ func TestGPUUtilizationWorker_MetricAccuracy(t *testing.T) {
 			return s.ActiveGPUCount == 2 && s.GPUUtilizationPct == 100.0
 		})).Return(nil).Once()
 
-		worker.collectForReservation(context.Background(), reservation)
+		worker.collectForReservation(context.Background(), reservation, nil)
 		mockStore.AssertExpectations(t)
 	})
 
@@ -166,7 +167,7 @@ func TestGPUUtilizationWorker_MetricAccuracy(t *testing.T) {
 			return s.TotalGPUCount == 0 && s.ActiveGPUCount == 0 && s.GPUUtilizationPct == 0
 		})).Return(nil).Once()
 
-		worker.collectForReservation(context.Background(), reservation)
+		worker.collectForReservation(context.Background(), reservation, nil)
 		mockStore.AssertExpectations(t)
 	})
 }
@@ -257,7 +258,7 @@ func TestGPUUtilizationWorker_ThresholdAlerting(t *testing.T) {
 			return s.ActiveGPUCount == 4 && s.TotalGPUCount == 4 && s.GPUUtilizationPct == 100.0
 		})).Return(nil).Once()
 
-		worker.collectForReservation(context.Background(), reservation)
+		worker.collectForReservation(context.Background(), reservation, nil)
 		mockStore.AssertExpectations(t)
 	})
 
@@ -309,7 +310,7 @@ func TestGPUUtilizationWorker_ThresholdAlerting(t *testing.T) {
 			return s.ActiveGPUCount == 1 && s.TotalGPUCount == 4 && s.GPUUtilizationPct == 25.0
 		})).Return(nil).Once()
 
-		worker.collectForReservation(context.Background(), reservation)
+		worker.collectForReservation(context.Background(), reservation, nil)
 		mockStore.AssertExpectations(t)
 	})
 
@@ -364,7 +365,120 @@ func TestGPUUtilizationWorker_ThresholdAlerting(t *testing.T) {
 			return s.ActiveGPUCount == 2 && s.TotalGPUCount == 4 && s.GPUUtilizationPct == 50.0
 		})).Return(nil).Once()
 
-		worker.collectForReservation(context.Background(), reservation)
+		worker.collectForReservation(context.Background(), reservation, nil)
 		mockStore.AssertExpectations(t)
 	})
+}
+
+// Issue 9135 — DCGM GPU memory integration tests.
+
+func TestGPUUtilizationWorker_DCGMDisabled_MemoryZero(t *testing.T) {
+	t.Setenv("GPU_METRICS_DCGM_ENABLED", "")
+
+	mockStore := new(test.MockStore)
+	k8sClient, _ := k8s.NewMultiClusterClient("")
+	k8sClient.InjectClient("c1", k8sfake.NewSimpleClientset())
+	worker := NewGPUUtilizationWorker(mockStore, k8sClient, nil)
+
+	if worker.dcgmEnabled {
+		t.Fatal("expected dcgmEnabled=false when GPU_METRICS_DCGM_ENABLED is unset")
+	}
+	if worker.dcgmNamespace != "gpu-operator" {
+		t.Errorf("dcgmNamespace default: got %q, want gpu-operator", worker.dcgmNamespace)
+	}
+	if worker.dcgmService != "dcgm-exporter" {
+		t.Errorf("dcgmService default: got %q, want dcgm-exporter", worker.dcgmService)
+	}
+
+	// Directly verify the collect path: nil dcgmClusterMetrics → MemoryUtilizationPct=0.
+	reservation := &models.GPUReservation{
+		ID:        uuid.New(),
+		Cluster:   "c1",
+		Namespace: "ns-a",
+		GPUCount:  1,
+	}
+	mockStore.On("InsertUtilizationSnapshot", mock.MatchedBy(func(s *models.GPUUtilizationSnapshot) bool {
+		return s.MemoryUtilizationPct == 0
+	})).Return(nil).Once()
+	worker.collectForReservation(context.Background(), reservation, nil)
+	mockStore.AssertExpectations(t)
+}
+
+func TestGPUUtilizationWorker_DCGMEnabled_EnvOverrides(t *testing.T) {
+	t.Setenv("GPU_METRICS_DCGM_ENABLED", "true")
+	t.Setenv("GPU_METRICS_DCGM_NAMESPACE", "custom-ns")
+	t.Setenv("GPU_METRICS_DCGM_SERVICE", "custom-svc")
+
+	mockStore := new(test.MockStore)
+	k8sClient, _ := k8s.NewMultiClusterClient("")
+	worker := NewGPUUtilizationWorker(mockStore, k8sClient, nil)
+
+	if !worker.dcgmEnabled {
+		t.Fatal("expected dcgmEnabled=true when GPU_METRICS_DCGM_ENABLED=true")
+	}
+	if worker.dcgmNamespace != "custom-ns" {
+		t.Errorf("dcgmNamespace override: got %q, want custom-ns", worker.dcgmNamespace)
+	}
+	if worker.dcgmService != "custom-svc" {
+		t.Errorf("dcgmService override: got %q, want custom-svc", worker.dcgmService)
+	}
+}
+
+func TestGPUUtilizationWorker_DCGMEnabled_MemoryFromScraper(t *testing.T) {
+	// Pass DCGM metrics directly to collectForReservation to verify the
+	// percentage computation and that non-matching namespaces fall back to 0.
+	mockStore := new(test.MockStore)
+	k8sClient, _ := k8s.NewMultiClusterClient("")
+	fakeClient := k8sfake.NewSimpleClientset()
+	k8sClient.InjectClient("c1", fakeClient)
+	worker := NewGPUUtilizationWorker(mockStore, k8sClient, nil)
+
+	// 75% framebuffer utilization: 30720 used out of 30720+10240 total.
+	const (
+		fbUsedMiB = 30720
+		fbFreeMiB = 10240
+		wantPct   = 75.0
+	)
+	dcgmByNs := map[string]*agent.DCGMNamespaceMetrics{
+		"ml-team": {FBUsedMiB: fbUsedMiB, FBFreeMiB: fbFreeMiB, SampleCount: 1},
+	}
+
+	reservation := &models.GPUReservation{
+		ID:        uuid.New(),
+		Cluster:   "c1",
+		Namespace: "ml-team",
+		GPUCount:  1,
+	}
+	mockStore.On("InsertUtilizationSnapshot", mock.MatchedBy(func(s *models.GPUUtilizationSnapshot) bool {
+		return s.MemoryUtilizationPct == wantPct
+	})).Return(nil).Once()
+
+	worker.collectForReservation(context.Background(), reservation, dcgmByNs)
+	mockStore.AssertExpectations(t)
+}
+
+func TestGPUUtilizationWorker_DCGMEnabled_NamespaceMiss_Zero(t *testing.T) {
+	// DCGM returned data, but not for this reservation's namespace.
+	mockStore := new(test.MockStore)
+	k8sClient, _ := k8s.NewMultiClusterClient("")
+	fakeClient := k8sfake.NewSimpleClientset()
+	k8sClient.InjectClient("c1", fakeClient)
+	worker := NewGPUUtilizationWorker(mockStore, k8sClient, nil)
+
+	dcgmByNs := map[string]*agent.DCGMNamespaceMetrics{
+		"other-ns": {FBUsedMiB: 1000, FBFreeMiB: 1000, SampleCount: 1},
+	}
+
+	reservation := &models.GPUReservation{
+		ID:        uuid.New(),
+		Cluster:   "c1",
+		Namespace: "missing-ns",
+		GPUCount:  1,
+	}
+	mockStore.On("InsertUtilizationSnapshot", mock.MatchedBy(func(s *models.GPUUtilizationSnapshot) bool {
+		return s.MemoryUtilizationPct == 0
+	})).Return(nil).Once()
+
+	worker.collectForReservation(context.Background(), reservation, dcgmByNs)
+	mockStore.AssertExpectations(t)
 }


### PR DESCRIPTION
## Summary

Closes #9135. Replaces the hardcoded `MemoryUtilizationPct: 0` on `GPUUtilizationSnapshot` (originally dropped in the narrow of PR #8990 because metrics-server cannot provide GPU memory) with framebuffer usage scraped from the NVIDIA DCGM exporter.

- New `pkg/agent/dcgm_scraper.go` — fetches the DCGM exporter's Prometheus text-format `/metrics` endpoint via the Kubernetes API server service proxy, parses `DCGM_FI_DEV_FB_USED` / `DCGM_FI_DEV_FB_FREE` gauges, aggregates by the `namespace` label.
- Wired into `pkg/api/gpu_utilization_worker.go`:
  - `MemoryUtilizationPct = FBUsed / (FBUsed + FBFree) * 100` when DCGM data exists for the reservation's namespace.
  - Silent `0` fallback otherwise (DCGM not installed, unreachable, or no samples for the namespace).
- Three env vars matching the existing `GPU_*` convention:
  - `GPU_METRICS_DCGM_ENABLED` (default `false`) — backwards compatible with all existing deployments.
  - `GPU_METRICS_DCGM_NAMESPACE` (default `gpu-operator`) — NVIDIA GPU Operator's standard install location.
  - `GPU_METRICS_DCGM_SERVICE` (default `dcgm-exporter`) — NVIDIA GPU Operator's standard service name.

## Design choices

- **Scrape per cluster, not per reservation** — N reservations in the same cluster would otherwise amplify load on the exporter. One scrape per unique cluster per poll.
- **Aggregate at namespace granularity** — `GPUUtilizationSnapshot` is aggregate (per reservation = per `cluster/namespace`), not per-pod/per-GPU-device. Matching that schema is enough to move `MemoryUtilizationPct` off `0`. Per-pod granularity would need a snapshot schema change.
- **404 = success with empty map** — DCGM absent is a valid operational state for clusters without the GPU Operator; surface it as silent fallback, not an error.
- **Reuse existing HTTP client cache** from `pkg/agent/prometheus.go` to share per-cluster TLS transports.
- **Validate DCGM namespace/service** via the existing `validateDNS1123Label` helper to block path-traversal in the interpolated proxy URL.

## Out of scope (follow-ups)

- AMD ROCm-based GPUs (separate exporter).
- Per-pod / per-GPU-device granularity (requires schema change on `GPUUtilizationSnapshot`).
- `DCGM_FI_DEV_GPU_UTIL` compute utilization (legacy pod-presence proxy remains for now).

## Tests

`pkg/agent/dcgm_scraper_test.go` — 9 tests:
- Multi-namespace parse — percentages verified: 37.5% (ml-team), 12.5% (inference), 10% (unlabeled).
- Empty payload, malformed payload, zero-capacity edge case.
- HTTP happy path, 404 (DCGM absent), 500 (error), invalid namespace (validation), nil `rest.Config`.

`pkg/api/gpu_utilization_worker_test.go` — 4 new tests + existing 3 pass:
- Flag-off: defaults correct, collect path produces `MemoryUtilizationPct=0`.
- Flag-on env overrides: custom namespace and service threaded through.
- Flag-on with DCGM data: percentage computed correctly (75%).
- Flag-on, namespace miss: silent 0 fallback.

## Implementation note

`prometheus/common` v0.66+ gave `expfmt.TextParser` its own `scheme` field that defaults to `UnsetValidation` and panics on first parse. The parser is constructed via `NewTextParser(model.LegacyValidation)` because DCGM emits legacy-format metric names (`DCGM_FI_DEV_*`), not UTF-8. The package-level `model.NameValidationScheme` global is not read by `TextParser` — only the constructor argument matters.

## Test plan

- [ ] Go build + go vet clean on both arches
- [ ] Unit tests green (all 13: 9 scraper + 4 worker)
- [ ] No regressions in existing GPU worker tests (all 3 still pass)
- [ ] Default-off behavior unchanged (MemoryUtilizationPct still 0 when flag unset)

🤖 Generated with [Claude Code](https://claude.com/claude-code)