### PR TITLE
fix(coverage): exclude .md files from v8 coverage scope

### DIFF
--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -283,6 +283,7 @@ export default defineConfig(({ mode }) => ({
         '**/*.test.{ts,tsx}',
         '**/*.spec.{ts,tsx}',
         '**/*.d.ts',
+        '**/*.md',
         '**/demo*Data*.{ts,tsx}',
         '**/icons.{ts,tsx}',
       ],


### PR DESCRIPTION
Adds **.md to vitest v8 coverage exclude list. STORAGE_OPTIMIZATION.md in src/lib/cache/ was matched by the src/lib/** include pattern, causing RolldownError in 856 test shards when the V8 provider tried to parse Markdown as JavaScript.