### PR TITLE
fix(deps): align react to 19.2.5 to match react-dom

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -34,7 +34,7 @@
         "isomorphic-dompurify": "^3.9.0",
         "js-yaml": "^4.1.1",
         "lucide-react": "^1.7.0",
-        "react": "^19.2.4",
+        "react": "^19.2.5",
         "react-dom": "^19.2.5",
         "react-i18next": "^17.0.2",
         "react-is": "^19.2.5",
@@ -8801,9 +8801,9 @@
       "license": "MIT"
     },
     "node_modules/react": {
-      "version": "19.2.4",
-      "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
-      "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
+      "version": "19.2.5",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.5.tgz",
+      "integrity": "sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA==",
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"

--- a/web/package.json
+++ b/web/package.json
@@ -73,7 +73,7 @@
     "isomorphic-dompurify": "^3.9.0",
     "js-yaml": "^4.1.1",
     "lucide-react": "^1.7.0",
-    "react": "^19.2.4",
+    "react": "^19.2.5",
     "react-dom": "^19.2.5",
     "react-i18next": "^17.0.2",
     "react-is": "^19.2.5",


### PR DESCRIPTION
Dependabot PR #9206 bumped react-dom from 19.2.4 to 19.2.5 without updating react, causing 856 'Incompatible React versions' test failures. Aligns react to ^19.2.5 and updates package-lock.