### PR TITLE
fix(tests): resolve 3 Coverage Suite failures from test-split cascade

### DIFF
--- a/web/src/hooks/__tests__/useAIPredictions.test.ts
+++ b/web/src/hooks/__tests__/useAIPredictions.test.ts
@@ -483,10 +483,13 @@ describe('useAIPredictions', () => {
     const { result } = renderHook(() => useAIPredictions())
 
     // Start analyze — don't await, let timers drive it
-    const _done = false
+    let done = false
     act(() => {
       result.current.analyze().then(() => { done = true })
     })
+    // Reference `done` so TS/ESLint doesn't flag it as unused — the variable
+    // exists to anchor the promise settlement for debugging if the test hangs.
+    void done
 
     // Advance past all internal delays (triggerAnalysis demo delay + RETRY_DELAY_MS)
     await act(async () => {

--- a/web/src/hooks/__tests__/useCachedData.progressive-gpu.test.ts
+++ b/web/src/hooks/__tests__/useCachedData.progressive-gpu.test.ts
@@ -26,6 +26,12 @@ const mockFetchProwJobs = vi.fn()
 const mockFetchLLMdServers = vi.fn()
 const mockFetchLLMdModels = vi.fn()
 
+// Shared mutable cluster-cache ref — the hoisted `vi.mock('../mcp/shared', ...)`
+// below returns this same object reference, so tests can mutate `.clusters`
+// directly instead of calling `vi.doMock` (which is unreliable on the first
+// test-after-resetModules in CI — see kubestellar/console#9305).
+const mockClusterCacheRef = vi.hoisted(() => ({ clusters: [] as Array<{ name: string; context?: string; reachable?: boolean }> }))
+
 vi.mock('../../lib/cache', () => ({
   useCache: (...args: unknown[]) => mockUseCache(...args),
   REFRESH_RATES: {
@@ -51,7 +57,7 @@ vi.mock('../../lib/sseClient', () => ({
 }))
 
 vi.mock('../mcp/shared', () => ({
-  clusterCacheRef: { clusters: [] },
+  clusterCacheRef: mockClusterCacheRef,
 }))
 
 vi.mock('../useLocalAgent', () => ({
@@ -139,6 +145,8 @@ describe('useCachedData', () => {
     localStorage.clear()
     // Set a valid token so fetchAPI doesn't throw
     localStorage.setItem('kc_token', 'test-jwt-token')
+    // Reset the shared cluster cache so tests start with a clean slate
+    mockClusterCacheRef.clusters = []
     // Default useCache implementation
     mockUseCache.mockImplementation((opts: { initialData: unknown }) =>
       makeCacheResult(opts.initialData)
@@ -174,17 +182,14 @@ describe('useCachedData', () => {
         return makeCacheResult([])
       })
 
-      // clusterCacheRef has clusters — should be used instead of backend
-      vi.doMock('../mcp/shared', () => ({
-        clusterCacheRef: {
-          clusters: [
-            { name: 'agent-c1', reachable: true },
-            { name: 'agent-c2', reachable: undefined }, // pending health check — included
-            { name: 'agent-c3', reachable: false }, // unreachable — excluded
-            { name: 'ns/long-path-name', reachable: true }, // long path — excluded
-          ],
-        },
-      }))
+      // Mutate the shared mock ref directly — avoids the `vi.doMock` +
+      // `resetModules` race that caused kubestellar/console#9305.
+      mockClusterCacheRef.clusters = [
+        { name: 'agent-c1', reachable: true },
+        { name: 'agent-c2', reachable: undefined }, // pending health check — included
+        { name: 'agent-c3', reachable: false }, // unreachable — excluded
+        { name: 'ns/long-path-name', reachable: true }, // long path — excluded
+      ]
 
       const podRes = { ok: true, text: vi.fn().mockResolvedValue(JSON.stringify({ pods: [{ name: 'p1' }] })) }
       vi.stubGlobal('fetch', vi.fn().mockResolvedValue(podRes))

--- a/web/src/hooks/__tests__/useCachedData.security-gitops.test.ts
+++ b/web/src/hooks/__tests__/useCachedData.security-gitops.test.ts
@@ -26,6 +26,12 @@ const mockFetchProwJobs = vi.fn()
 const mockFetchLLMdServers = vi.fn()
 const mockFetchLLMdModels = vi.fn()
 
+// Shared mutable cluster-cache ref — the hoisted `vi.mock('../mcp/shared', ...)`
+// below returns this same object reference, so tests can mutate `.clusters`
+// directly instead of calling `vi.doMock` (which is unreliable on the first
+// test-after-resetModules in CI — see kubestellar/console#9305).
+const mockClusterCacheRef = vi.hoisted(() => ({ clusters: [] as Array<{ name: string; context?: string; reachable?: boolean }> }))
+
 vi.mock('../../lib/cache', () => ({
   useCache: (...args: unknown[]) => mockUseCache(...args),
   REFRESH_RATES: {
@@ -51,7 +57,7 @@ vi.mock('../../lib/sseClient', () => ({
 }))
 
 vi.mock('../mcp/shared', () => ({
-  clusterCacheRef: { clusters: [] },
+  clusterCacheRef: mockClusterCacheRef,
 }))
 
 vi.mock('../useLocalAgent', () => ({
@@ -139,6 +145,8 @@ describe('useCachedData', () => {
     localStorage.clear()
     // Set a valid token so fetchAPI doesn't throw
     localStorage.setItem('kc_token', 'test-jwt-token')
+    // Reset the shared cluster cache so tests start with a clean slate
+    mockClusterCacheRef.clusters = []
     // Default useCache implementation
     mockUseCache.mockImplementation((opts: { initialData: unknown }) =>
       makeCacheResult(opts.initialData)
@@ -174,11 +182,9 @@ describe('useCachedData', () => {
         return makeCacheResult([])
       })
 
-      vi.doMock('../mcp/shared', () => ({
-        clusterCacheRef: {
-          clusters: [{ name: 'prod', context: 'prod-ctx', reachable: true }],
-        },
-      }))
+      // Mutate the shared mock ref directly — avoids the `vi.doMock` +
+      // `resetModules` race that caused kubestellar/console#9305.
+      mockClusterCacheRef.clusters = [{ name: 'prod', context: 'prod-ctx', reachable: true }]
       mockIsAgentUnavailable.mockReturnValue(false)
 
       mockKubectlProxy.exec.mockResolvedValue({

--- a/web/src/hooks/useVersionCheck-fetch-update.test.tsx
+++ b/web/src/hooks/useVersionCheck-fetch-update.test.tsx
@@ -61,6 +61,14 @@ function wrapper({ children }: { children: React.ReactNode }) {
   return <VersionCheckProvider>{children}</VersionCheckProvider>
 }
 
+/** Subset of the proxy URL used to identify calls to the releases endpoint */
+const RELEASES_API_PATH = '/api/github/repos/kubestellar/console/releases'
+
+/** Returns true when a fetch mock call is targeting the GitHub releases endpoint */
+function isReleasesApiCall(call: unknown[]): boolean {
+  return typeof call[0] === 'string' && (call[0] as string).includes(RELEASES_API_PATH)
+}
+
 // ---------------------------------------------------------------------------
 // parseReleaseTag
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Fixes the three test failures from [Coverage Suite run #1164](https://github.com/kubestellar/console/actions/runs/24699444692), which were introduced when PR #9302 split `useVersionCheck.test.tsx` and `useCachedData.test.ts` into focused modules:

- **`useVersionCheck-fetch-update.test.tsx:700`** — `ReferenceError: isReleasesApiCall is not defined`. The helper stayed with the `-parse-provider` split; inlined a 3-line copy so each split is self-contained.
- **`useCachedData.security-gitops.test.ts > useCachedSecurityIssues fetcher: agent kubectl finds privileged containers`** — the first-test-of-the-file `vi.doMock('../mcp/shared', ...)` didn't win against the hoisted `vi.mock` factory on re-import, so `clusterCacheRef.clusters` stayed `[]` and the fetcher fell through to the REST path where `authFetch` was unmocked (`Cannot read properties of undefined (reading 'ok')`).
- **`useCachedData.progressive-gpu.test.ts > fetchClusters prefers local agent clusters over backend`** — same race, surfacing as `No clusters available (agent connecting or backend not authenticated)`.

Fix for the two `useCachedData` splits: expose a mutable `mockClusterCacheRef` via `vi.hoisted()`, point the hoisted `vi.mock('../mcp/shared', ...)` factory at it, and have the two first-tests mutate `.clusters` directly instead of re-mocking. `beforeEach` resets the array so tests stay independent. Every other `vi.doMock` call in these files is left untouched — those run after the module registry has warmed up and work correctly.

Bonus: repaired the unrelated unhandled-rejection `ReferenceError: done is not defined` at `useAIPredictions.test.ts:488` (`const _done = false` declared a never-assigned binding; renamed to `let done` and added `void done` so the unused-var lint stays quiet).

Fixes #9305

## Test plan

- [x] `npx vitest run src/hooks/__tests__/useCachedData.security-gitops.test.ts src/hooks/__tests__/useCachedData.progressive-gpu.test.ts src/hooks/useVersionCheck-fetch-update.test.tsx` — 115/115 pass
- [x] `npx vitest run src/hooks/__tests__/useAIPredictions.test.ts` — 48/48 pass, no more `done is not defined`
- [x] Full `src/hooks/__tests__/` run — 4129 pass
- [ ] CI Coverage Suite green on this PR