### PR TITLE
test(hooks): add tests for 9 previously untested hook modules toward 91% coverage

### DIFF
--- a/web/src/hooks/__tests__/useCachedGPU.test.ts
+++ b/web/src/hooks/__tests__/useCachedGPU.test.ts
@@ -1,0 +1,166 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook } from '@testing-library/react'
+
+// ---------------------------------------------------------------------------
+// Hoisted mocks
+// ---------------------------------------------------------------------------
+
+const { mockUseCache } = vi.hoisted(() => ({
+  mockUseCache: vi.fn(),
+}))
+
+vi.mock('../../lib/cache', () => ({
+  useCache: (...args: unknown[]) => mockUseCache(...args),
+}))
+
+vi.mock('../../lib/cache/fetcherUtils', () => ({
+  fetchAPI: vi.fn(),
+  fetchFromAllClusters: vi.fn(),
+  fetchViaSSE: vi.fn(),
+  getToken: vi.fn(() => null),
+  AGENT_HTTP_TIMEOUT_MS: 30000,
+}))
+
+vi.mock('../../lib/constants', () => ({
+  LOCAL_AGENT_HTTP_URL: 'http://localhost:8585',
+}))
+
+vi.mock('../../lib/constants/network', () => ({
+  FETCH_DEFAULT_TIMEOUT_MS: 5000,
+  AI_PREDICTION_TIMEOUT_MS: 30000,
+}))
+
+vi.mock('../useCachedData/demoData', () => ({
+  getDemoGPUNodes: () => [],
+  getDemoCachedGPUNodeHealth: () => [],
+  getDemoCachedWarningEvents: () => [],
+  HW_INITIAL_DATA: { status: 'unknown', clusters: [] },
+  HW_DEMO_DATA: { status: 'ok', clusters: [] },
+}))
+
+vi.mock('../../lib/schemas', () => ({
+  GPUNodesResponseSchema: {},
+  GPUNodeHealthResponseSchema: {},
+}))
+
+vi.mock('../../lib/schemas/validate', () => ({
+  validateArrayResponse: vi.fn((_, raw: unknown) => raw),
+}))
+
+import {
+  useCachedGPUNodes,
+  useCachedGPUNodeHealth,
+  useCachedHardwareHealth,
+  useCachedWarningEvents,
+} from '../useCachedGPU'
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function defaultCache(overrides = {}) {
+  return {
+    data: [],
+    isLoading: false,
+    isRefreshing: false,
+    isDemoFallback: false,
+    error: null,
+    isFailed: false,
+    consecutiveFailures: 0,
+    lastRefresh: null,
+    refetch: vi.fn(),
+    ...overrides,
+  }
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  mockUseCache.mockReturnValue(defaultCache())
+})
+
+// ---------------------------------------------------------------------------
+// useCachedGPUNodes
+// ---------------------------------------------------------------------------
+
+describe('useCachedGPUNodes', () => {
+  it('exposes gpuNodes and standard cache fields', () => {
+    const { result } = renderHook(() => useCachedGPUNodes())
+    expect(result.current).toHaveProperty('gpuNodes')
+    expect(result.current).toHaveProperty('isLoading')
+    expect(result.current).toHaveProperty('isDemoFallback')
+    expect(result.current).toHaveProperty('refetch')
+  })
+
+  it('gpuNodes aliases data', () => {
+    const nodes = [{ name: 'gpu-0', cluster: 'c1', gpuCount: 4 }]
+    mockUseCache.mockReturnValue(defaultCache({ data: nodes }))
+    const { result } = renderHook(() => useCachedGPUNodes())
+    expect(result.current.gpuNodes).toEqual(nodes)
+  })
+
+  it('uses cluster in cache key when provided', () => {
+    renderHook(() => useCachedGPUNodes('prod'))
+    expect(mockUseCache.mock.calls[0][0].key).toContain('prod')
+  })
+
+  it('isLoading forwarded correctly', () => {
+    mockUseCache.mockReturnValue(defaultCache({ isLoading: true }))
+    const { result } = renderHook(() => useCachedGPUNodes())
+    expect(result.current.isLoading).toBe(true)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// useCachedGPUNodeHealth
+// ---------------------------------------------------------------------------
+
+describe('useCachedGPUNodeHealth', () => {
+  it('exposes healthStatuses field', () => {
+    const { result } = renderHook(() => useCachedGPUNodeHealth())
+    expect(result.current).toHaveProperty('healthStatuses')
+    expect(Array.isArray(result.current.healthStatuses)).toBe(true)
+  })
+
+  it('cluster key included when cluster provided', () => {
+    renderHook(() => useCachedGPUNodeHealth('my-cluster'))
+    expect(mockUseCache.mock.calls[0][0].key).toContain('my-cluster')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// useCachedHardwareHealth
+// ---------------------------------------------------------------------------
+
+describe('useCachedHardwareHealth', () => {
+  it('exposes data field with hardware health', () => {
+    const hwData = { status: 'ok', clusters: [] }
+    mockUseCache.mockReturnValue(defaultCache({ data: hwData }))
+    const { result } = renderHook(() => useCachedHardwareHealth())
+    expect(result.current.data).toEqual(hwData)
+  })
+
+  it('returns standard cache fields', () => {
+    const { result } = renderHook(() => useCachedHardwareHealth())
+    expect(result.current).toHaveProperty('isLoading')
+    expect(result.current).toHaveProperty('isDemoFallback')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// useCachedWarningEvents
+// ---------------------------------------------------------------------------
+
+describe('useCachedWarningEvents', () => {
+  it('exposes events field', () => {
+    const events = [{ name: 'evt-1', message: 'OOMKilled', cluster: 'c1', namespace: 'default', reason: 'OOMKilled', type: 'Warning', count: 1 }]
+    mockUseCache.mockReturnValue(defaultCache({ data: events }))
+    const { result } = renderHook(() => useCachedWarningEvents())
+    expect(result.current).toHaveProperty('events')
+    expect(result.current.events).toEqual(events)
+  })
+
+  it('cluster in cache key when provided', () => {
+    renderHook(() => useCachedWarningEvents('prod-cluster'))
+    expect(mockUseCache.mock.calls[0][0].key).toContain('prod-cluster')
+  })
+})

--- a/web/src/hooks/__tests__/useCachedGitOps.test.ts
+++ b/web/src/hooks/__tests__/useCachedGitOps.test.ts
@@ -1,0 +1,209 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook } from '@testing-library/react'
+
+// ---------------------------------------------------------------------------
+// Hoisted mocks
+// ---------------------------------------------------------------------------
+
+const { mockUseCache } = vi.hoisted(() => ({
+  mockUseCache: vi.fn(),
+}))
+
+vi.mock('../../lib/cache', () => ({
+  useCache: (...args: unknown[]) => mockUseCache(...args),
+}))
+
+vi.mock('../../lib/cache/fetcherUtils', () => ({
+  fetchGitOpsAPI: vi.fn(),
+  fetchViaGitOpsSSE: vi.fn(),
+  fetchRbacAPI: vi.fn(),
+}))
+
+vi.mock('../useCachedData/demoData', () => ({
+  getDemoHelmReleases: () => [],
+  getDemoHelmHistory: () => [],
+  getDemoHelmValues: () => ({ values: {} }),
+  getDemoOperators: () => [],
+  getDemoOperatorSubscriptions: () => [],
+  getDemoGitOpsDrifts: () => [],
+  getDemoBuildpackImages: () => [],
+  getDemoK8sRoles: () => [],
+  getDemoK8sRoleBindings: () => [],
+  getDemoK8sServiceAccountsRbac: () => [],
+}))
+
+import {
+  useCachedHelmReleases,
+  useCachedHelmHistory,
+  useCachedHelmValues,
+  useCachedOperators,
+  useCachedOperatorSubscriptions,
+  useCachedGitOpsDrifts,
+  useCachedBuildpackImages,
+  useCachedK8sRoles,
+  useCachedK8sRoleBindings,
+  useCachedK8sServiceAccounts,
+} from '../useCachedGitOps'
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function defaultCache(overrides = {}) {
+  return {
+    data: [],
+    isLoading: false,
+    isRefreshing: false,
+    isDemoFallback: false,
+    error: null,
+    isFailed: false,
+    consecutiveFailures: 0,
+    lastRefresh: null,
+    refetch: vi.fn(),
+    ...overrides,
+  }
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  mockUseCache.mockReturnValue(defaultCache())
+})
+
+// ---------------------------------------------------------------------------
+// useCachedHelmReleases
+// ---------------------------------------------------------------------------
+
+describe('useCachedHelmReleases', () => {
+  it('exposes releases and standard cache fields', () => {
+    const releases = [{ name: 'nginx', namespace: 'default', chart: 'nginx-1.0', status: 'deployed', cluster: 'c1' }]
+    mockUseCache.mockReturnValue(defaultCache({ data: releases }))
+    const { result } = renderHook(() => useCachedHelmReleases())
+    expect(result.current.releases).toEqual(releases)
+    expect(result.current).toHaveProperty('isLoading')
+    expect(result.current).toHaveProperty('isDemoFallback')
+  })
+
+  it('uses cluster in cache key when provided', () => {
+    renderHook(() => useCachedHelmReleases('prod'))
+    expect(mockUseCache.mock.calls[0][0].key).toContain('prod')
+  })
+
+  it('uses all in cache key when no cluster provided', () => {
+    renderHook(() => useCachedHelmReleases())
+    expect(mockUseCache.mock.calls[0][0].key).toContain('all')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// useCachedHelmHistory
+// ---------------------------------------------------------------------------
+
+describe('useCachedHelmHistory', () => {
+  it('exposes history field', () => {
+    const history = [{ revision: 1, status: 'deployed', chart: 'nginx-1.0', updated: '', description: '', cluster: 'c1' }]
+    mockUseCache.mockReturnValue(defaultCache({ data: history }))
+    const { result } = renderHook(() => useCachedHelmHistory('c1', 'nginx', 'default'))
+    expect(result.current.history).toEqual(history)
+  })
+
+  it('includes release name in cache key', () => {
+    renderHook(() => useCachedHelmHistory('c1', 'myrelease', 'default'))
+    expect(mockUseCache.mock.calls[0][0].key).toContain('myrelease')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// useCachedHelmValues
+// ---------------------------------------------------------------------------
+
+describe('useCachedHelmValues', () => {
+  it('exposes values field', () => {
+    const valuesData = { replicaCount: 2 }
+    mockUseCache.mockReturnValue(defaultCache({ data: valuesData }))
+    const { result } = renderHook(() => useCachedHelmValues('c1', 'nginx', 'default'))
+    expect(result.current.values).toEqual(valuesData)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// useCachedOperators
+// ---------------------------------------------------------------------------
+
+describe('useCachedOperators', () => {
+  it('exposes operators field', () => {
+    const operators = [{ name: 'cert-manager', namespace: 'cert-manager', version: '1.0', status: 'Succeeded', cluster: 'c1' }]
+    mockUseCache.mockReturnValue(defaultCache({ data: operators }))
+    const { result } = renderHook(() => useCachedOperators())
+    expect(result.current.operators).toEqual(operators)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// useCachedOperatorSubscriptions
+// ---------------------------------------------------------------------------
+
+describe('useCachedOperatorSubscriptions', () => {
+  it('exposes subscriptions field', () => {
+    mockUseCache.mockReturnValue(defaultCache({ data: [] }))
+    const { result } = renderHook(() => useCachedOperatorSubscriptions())
+    expect(result.current).toHaveProperty('subscriptions')
+    expect(Array.isArray(result.current.subscriptions)).toBe(true)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// useCachedGitOpsDrifts
+// ---------------------------------------------------------------------------
+
+describe('useCachedGitOpsDrifts', () => {
+  it('exposes drifts field', () => {
+    mockUseCache.mockReturnValue(defaultCache({ data: [] }))
+    const { result } = renderHook(() => useCachedGitOpsDrifts())
+    expect(result.current).toHaveProperty('drifts')
+  })
+
+  it('isLoading is false by default', () => {
+    const { result } = renderHook(() => useCachedGitOpsDrifts())
+    expect(result.current.isLoading).toBe(false)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// useCachedBuildpackImages
+// ---------------------------------------------------------------------------
+
+describe('useCachedBuildpackImages', () => {
+  it('exposes images field', () => {
+    mockUseCache.mockReturnValue(defaultCache({ data: [] }))
+    const { result } = renderHook(() => useCachedBuildpackImages())
+    expect(result.current).toHaveProperty('images')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// RBAC hooks
+// ---------------------------------------------------------------------------
+
+describe('useCachedK8sRoles', () => {
+  it('exposes roles field', () => {
+    mockUseCache.mockReturnValue(defaultCache({ data: [] }))
+    const { result } = renderHook(() => useCachedK8sRoles())
+    expect(result.current).toHaveProperty('roles')
+  })
+})
+
+describe('useCachedK8sRoleBindings', () => {
+  it('exposes roleBindings field', () => {
+    mockUseCache.mockReturnValue(defaultCache({ data: [] }))
+    const { result } = renderHook(() => useCachedK8sRoleBindings())
+    expect(result.current).toHaveProperty('roleBindings')
+  })
+})
+
+describe('useCachedK8sServiceAccounts', () => {
+  it('exposes serviceAccounts field', () => {
+    mockUseCache.mockReturnValue(defaultCache({ data: [] }))
+    const { result } = renderHook(() => useCachedK8sServiceAccounts())
+    expect(result.current).toHaveProperty('serviceAccounts')
+  })
+})

--- a/web/src/hooks/__tests__/useCachedK8sResources.test.ts
+++ b/web/src/hooks/__tests__/useCachedK8sResources.test.ts
@@ -1,0 +1,189 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook } from '@testing-library/react'
+
+// ---------------------------------------------------------------------------
+// Hoisted mocks
+// ---------------------------------------------------------------------------
+
+const { mockUseCache } = vi.hoisted(() => ({
+  mockUseCache: vi.fn(),
+}))
+
+vi.mock('../../lib/cache', () => ({
+  useCache: (...args: unknown[]) => mockUseCache(...args),
+}))
+
+vi.mock('../../lib/cache/fetcherUtils', () => ({
+  fetchAPI: vi.fn(),
+  fetchFromAllClusters: vi.fn(),
+  fetchViaSSE: vi.fn(),
+  getToken: vi.fn(() => null),
+}))
+
+vi.mock('../../lib/constants/network', () => ({
+  FETCH_DEFAULT_TIMEOUT_MS: 5000,
+}))
+
+vi.mock('../useCachedData/demoData', () => ({
+  getDemoPVCs: () => [],
+  getDemoNamespaces: () => [],
+  getDemoJobs: () => [],
+  getDemoHPAs: () => [],
+  getDemoConfigMaps: () => [],
+  getDemoSecrets: () => [],
+  getDemoServiceAccounts: () => [],
+  getDemoReplicaSets: () => [],
+  getDemoStatefulSets: () => [],
+  getDemoDaemonSets: () => [],
+  getDemoCronJobs: () => [],
+  getDemoIngresses: () => [],
+  getDemoNetworkPolicies: () => [],
+}))
+
+import {
+  useCachedPVCs,
+  useCachedNamespaces,
+  useCachedJobs,
+  useCachedHPAs,
+  useCachedConfigMaps,
+  useCachedSecrets,
+  useCachedServiceAccounts,
+  useCachedReplicaSets,
+  useCachedStatefulSets,
+  useCachedDaemonSets,
+  useCachedCronJobs,
+  useCachedIngresses,
+  useCachedNetworkPolicies,
+} from '../useCachedK8sResources'
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function defaultCache(overrides = {}) {
+  return {
+    data: [],
+    isLoading: false,
+    isRefreshing: false,
+    isDemoFallback: false,
+    error: null,
+    isFailed: false,
+    consecutiveFailures: 0,
+    lastRefresh: null,
+    refetch: vi.fn(),
+    ...overrides,
+  }
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  mockUseCache.mockReturnValue(defaultCache())
+})
+
+// ---------------------------------------------------------------------------
+// Each hook: test the alias field + cache key
+// ---------------------------------------------------------------------------
+
+describe('useCachedPVCs', () => {
+  it('exposes pvcs field', () => {
+    const { result } = renderHook(() => useCachedPVCs())
+    expect(result.current).toHaveProperty('pvcs')
+    expect(Array.isArray(result.current.pvcs)).toBe(true)
+  })
+  it('includes cluster in key', () => {
+    renderHook(() => useCachedPVCs('c1'))
+    expect(mockUseCache.mock.calls[0][0].key).toContain('c1')
+  })
+})
+
+describe('useCachedNamespaces', () => {
+  it('exposes namespaces field', () => {
+    const { result } = renderHook(() => useCachedNamespaces())
+    expect(result.current).toHaveProperty('namespaces')
+  })
+})
+
+describe('useCachedJobs', () => {
+  it('exposes jobs field', () => {
+    const { result } = renderHook(() => useCachedJobs())
+    expect(result.current).toHaveProperty('jobs')
+  })
+  it('includes cluster in key', () => {
+    renderHook(() => useCachedJobs('prod'))
+    expect(mockUseCache.mock.calls[0][0].key).toContain('prod')
+  })
+})
+
+describe('useCachedHPAs', () => {
+  it('exposes hpas field', () => {
+    const { result } = renderHook(() => useCachedHPAs())
+    expect(result.current).toHaveProperty('hpas')
+  })
+})
+
+describe('useCachedConfigMaps', () => {
+  it('exposes configMaps field', () => {
+    const { result } = renderHook(() => useCachedConfigMaps())
+    expect(result.current).toHaveProperty('configMaps')
+  })
+})
+
+describe('useCachedSecrets', () => {
+  it('exposes secrets field', () => {
+    const { result } = renderHook(() => useCachedSecrets())
+    expect(result.current).toHaveProperty('secrets')
+  })
+})
+
+describe('useCachedServiceAccounts', () => {
+  it('exposes serviceAccounts field', () => {
+    const { result } = renderHook(() => useCachedServiceAccounts())
+    expect(result.current).toHaveProperty('serviceAccounts')
+  })
+})
+
+describe('useCachedReplicaSets', () => {
+  it('exposes replicaSets field', () => {
+    const { result } = renderHook(() => useCachedReplicaSets())
+    expect(result.current).toHaveProperty('replicaSets')
+  })
+})
+
+describe('useCachedStatefulSets', () => {
+  it('exposes statefulSets field', () => {
+    const { result } = renderHook(() => useCachedStatefulSets())
+    expect(result.current).toHaveProperty('statefulSets')
+  })
+})
+
+describe('useCachedDaemonSets', () => {
+  it('exposes daemonSets field', () => {
+    const { result } = renderHook(() => useCachedDaemonSets())
+    expect(result.current).toHaveProperty('daemonSets')
+  })
+})
+
+describe('useCachedCronJobs', () => {
+  it('exposes cronJobs field', () => {
+    const { result } = renderHook(() => useCachedCronJobs())
+    expect(result.current).toHaveProperty('cronJobs')
+  })
+})
+
+describe('useCachedIngresses', () => {
+  it('exposes ingresses field', () => {
+    const { result } = renderHook(() => useCachedIngresses())
+    expect(result.current).toHaveProperty('ingresses')
+  })
+})
+
+describe('useCachedNetworkPolicies', () => {
+  it('exposes networkPolicies field', () => {
+    const { result } = renderHook(() => useCachedNetworkPolicies())
+    expect(result.current).toHaveProperty('networkPolicies')
+  })
+  it('includes cluster in key', () => {
+    renderHook(() => useCachedNetworkPolicies('staging'))
+    expect(mockUseCache.mock.calls[0][0].key).toContain('staging')
+  })
+})

--- a/web/src/hooks/__tests__/useCachedNodes.test.ts
+++ b/web/src/hooks/__tests__/useCachedNodes.test.ts
@@ -1,0 +1,172 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook } from '@testing-library/react'
+
+// ---------------------------------------------------------------------------
+// Hoisted mocks
+// ---------------------------------------------------------------------------
+
+const { mockUseCache, mockClusterCacheRef } = vi.hoisted(() => ({
+  mockUseCache: vi.fn(),
+  mockClusterCacheRef: {
+    clusters: [] as Array<{ name: string; context?: string; server?: string; reachable?: boolean }>,
+  },
+}))
+
+vi.mock('../../lib/cache', () => ({
+  useCache: (...args: unknown[]) => mockUseCache(...args),
+}))
+
+vi.mock('../mcp/shared', () => ({
+  clusterCacheRef: mockClusterCacheRef,
+  deduplicateClustersByServer: (clusters: unknown[]) => clusters,
+}))
+
+vi.mock('../../lib/cache/fetcherUtils', () => ({
+  fetchAPI: vi.fn(),
+  fetchFromAllClusters: vi.fn(),
+  fetchViaSSE: vi.fn(),
+}))
+
+vi.mock('../../lib/utils/concurrency', () => ({
+  settledWithConcurrency: vi.fn(async () => []),
+}))
+
+vi.mock('../../lib/schemas', () => ({
+  NodesResponseSchema: {},
+}))
+
+vi.mock('../../lib/schemas/validate', () => ({
+  validateArrayResponse: vi.fn((_, raw: unknown) => raw),
+}))
+
+vi.mock('../useCachedData/demoData', () => ({
+  getDemoCachedNodes: () => [{ name: 'demo-node', status: 'Ready', cluster: 'demo' }],
+  getDemoCoreDNSStatus: () => [],
+}))
+
+vi.mock('../../lib/constants/network', () => ({
+  FETCH_DEFAULT_TIMEOUT_MS: 5000,
+  KUBECTL_EXTENDED_TIMEOUT_MS: 60000,
+}))
+
+import { useCachedNodes, useCachedCoreDNSStatus } from '../useCachedNodes'
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function defaultCache(overrides = {}) {
+  return {
+    data: [],
+    isLoading: false,
+    isRefreshing: false,
+    isDemoFallback: false,
+    error: null,
+    isFailed: false,
+    consecutiveFailures: 0,
+    lastRefresh: null,
+    refetch: vi.fn(),
+    ...overrides,
+  }
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  mockClusterCacheRef.clusters = []
+  mockUseCache.mockReturnValue(defaultCache())
+})
+
+// ---------------------------------------------------------------------------
+// useCachedNodes
+// ---------------------------------------------------------------------------
+
+describe('useCachedNodes', () => {
+  it('returns expected fields', () => {
+    const { result } = renderHook(() => useCachedNodes())
+    expect(result.current).toHaveProperty('nodes')
+    expect(result.current).toHaveProperty('data')
+    expect(result.current).toHaveProperty('isLoading')
+    expect(result.current).toHaveProperty('isRefreshing')
+    expect(result.current).toHaveProperty('isDemoFallback')
+    expect(result.current).toHaveProperty('error')
+    expect(result.current).toHaveProperty('isFailed')
+    expect(result.current).toHaveProperty('consecutiveFailures')
+    expect(result.current).toHaveProperty('lastRefresh')
+    expect(result.current).toHaveProperty('refetch')
+  })
+
+  it('nodes aliases data', () => {
+    const nodes = [{ name: 'n1', status: 'Ready', cluster: 'c1' }]
+    mockUseCache.mockReturnValue(defaultCache({ data: nodes }))
+    const { result } = renderHook(() => useCachedNodes())
+    expect(result.current.nodes).toEqual(nodes)
+    expect(result.current.data).toEqual(nodes)
+  })
+
+  it('passes a cache key based on cluster arg', () => {
+    renderHook(() => useCachedNodes('prod'))
+    const callArgs = mockUseCache.mock.calls[0][0]
+    expect(callArgs.key).toContain('prod')
+  })
+
+  it('passes default key when no cluster given', () => {
+    renderHook(() => useCachedNodes())
+    const callArgs = mockUseCache.mock.calls[0][0]
+    expect(callArgs.key).toContain('all')
+  })
+
+  it('exposes isLoading from cache', () => {
+    mockUseCache.mockReturnValue(defaultCache({ isLoading: true }))
+    const { result } = renderHook(() => useCachedNodes())
+    expect(result.current.isLoading).toBe(true)
+  })
+
+  it('exposes isDemoFallback from cache', () => {
+    mockUseCache.mockReturnValue(defaultCache({ isDemoFallback: true }))
+    const { result } = renderHook(() => useCachedNodes())
+    expect(result.current.isDemoFallback).toBe(true)
+  })
+
+  it('refetch is a function', () => {
+    const { result } = renderHook(() => useCachedNodes())
+    expect(typeof result.current.refetch).toBe('function')
+  })
+
+  it('initialData is an empty array (no crash on first render)', () => {
+    const { result } = renderHook(() => useCachedNodes())
+    expect(Array.isArray(result.current.nodes)).toBe(true)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// useCachedCoreDNSStatus
+// ---------------------------------------------------------------------------
+
+describe('useCachedCoreDNSStatus', () => {
+  it('returns expected fields', () => {
+    const { result } = renderHook(() => useCachedCoreDNSStatus())
+    expect(result.current).toHaveProperty('clusters')
+    expect(result.current).toHaveProperty('isLoading')
+    expect(result.current).toHaveProperty('isDemoFallback')
+    expect(result.current).toHaveProperty('refetch')
+  })
+
+  it('clusters aliases data', () => {
+    const clusterData = [{ cluster: 'c1', pods: [], healthy: true, totalRestarts: 0 }]
+    mockUseCache.mockReturnValue(defaultCache({ data: clusterData }))
+    const { result } = renderHook(() => useCachedCoreDNSStatus())
+    expect(result.current.clusters).toEqual(clusterData)
+  })
+
+  it('passes a key containing coredns', () => {
+    renderHook(() => useCachedCoreDNSStatus())
+    const callArgs = mockUseCache.mock.calls[0][0]
+    expect(callArgs.key).toContain('coredns')
+  })
+
+  it('passes cluster name in key when cluster provided', () => {
+    renderHook(() => useCachedCoreDNSStatus('my-cluster'))
+    const callArgs = mockUseCache.mock.calls[0][0]
+    expect(callArgs.key).toContain('my-cluster')
+  })
+})

--- a/web/src/hooks/__tests__/useDebouncedValue.test.ts
+++ b/web/src/hooks/__tests__/useDebouncedValue.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+import { useDebouncedValue } from '../useDebouncedValue'
+
+afterEach(() => {
+  vi.useRealTimers()
+})
+
+describe('useDebouncedValue', () => {
+  it('returns initial value immediately', () => {
+    const { result } = renderHook(() => useDebouncedValue('hello', 300))
+    expect(result.current).toBe('hello')
+  })
+
+  it('does not update value before delay elapses', () => {
+    vi.useFakeTimers()
+    const { result, rerender } = renderHook(
+      ({ value }) => useDebouncedValue(value, 300),
+      { initialProps: { value: 'initial' } },
+    )
+    rerender({ value: 'updated' })
+    expect(result.current).toBe('initial')
+    vi.useRealTimers()
+  })
+
+  it('updates value after delay elapses', () => {
+    vi.useFakeTimers()
+    const { result, rerender } = renderHook(
+      ({ value }) => useDebouncedValue(value, 300),
+      { initialProps: { value: 'initial' } },
+    )
+    rerender({ value: 'updated' })
+    act(() => { vi.advanceTimersByTime(300) })
+    expect(result.current).toBe('updated')
+    vi.useRealTimers()
+  })
+
+  it('resets the timer when value changes rapidly', () => {
+    vi.useFakeTimers()
+    const { result, rerender } = renderHook(
+      ({ value }) => useDebouncedValue(value, 300),
+      { initialProps: { value: 'a' } },
+    )
+    rerender({ value: 'b' })
+    act(() => { vi.advanceTimersByTime(200) })
+    rerender({ value: 'c' })
+    act(() => { vi.advanceTimersByTime(200) })
+    // Only 200ms since last change — not debounced yet
+    expect(result.current).toBe('a')
+    act(() => { vi.advanceTimersByTime(100) })
+    expect(result.current).toBe('c')
+    vi.useRealTimers()
+  })
+
+  it('updates synchronously when delayMs is 0', () => {
+    vi.useFakeTimers()
+    const { result, rerender } = renderHook(
+      ({ value }) => useDebouncedValue(value, 0),
+      { initialProps: { value: 'initial' } },
+    )
+    act(() => { rerender({ value: 'instant' }) })
+    expect(result.current).toBe('instant')
+    vi.useRealTimers()
+  })
+
+  it('updates synchronously when delayMs is negative', () => {
+    vi.useFakeTimers()
+    const { result, rerender } = renderHook(
+      ({ value }) => useDebouncedValue(value, -1),
+      { initialProps: { value: 'initial' } },
+    )
+    act(() => { rerender({ value: 'instant' }) })
+    expect(result.current).toBe('instant')
+    vi.useRealTimers()
+  })
+
+  it('works with non-string values', () => {
+    vi.useFakeTimers()
+    const { result, rerender } = renderHook(
+      ({ value }) => useDebouncedValue(value, 100),
+      { initialProps: { value: 42 } },
+    )
+    rerender({ value: 99 })
+    act(() => { vi.advanceTimersByTime(100) })
+    expect(result.current).toBe(99)
+    vi.useRealTimers()
+  })
+
+  it('works with object values', () => {
+    vi.useFakeTimers()
+    const obj1 = { x: 1 }
+    const obj2 = { x: 2 }
+    const { result, rerender } = renderHook(
+      ({ value }) => useDebouncedValue(value, 100),
+      { initialProps: { value: obj1 } },
+    )
+    rerender({ value: obj2 })
+    act(() => { vi.advanceTimersByTime(100) })
+    expect(result.current).toEqual({ x: 2 })
+    vi.useRealTimers()
+  })
+})

--- a/web/src/hooks/__tests__/useKeepAliveActive.test.tsx
+++ b/web/src/hooks/__tests__/useKeepAliveActive.test.tsx
@@ -1,0 +1,29 @@
+import { describe, it, expect } from 'vitest'
+import { renderHook } from '@testing-library/react'
+import React from 'react'
+import { useKeepAliveActive, KeepAliveActiveContext } from '../useKeepAliveActive'
+
+describe('useKeepAliveActive', () => {
+  it('returns true by default (outside any KeepAliveActiveContext)', () => {
+    const { result } = renderHook(() => useKeepAliveActive())
+    expect(result.current).toBe(true)
+  })
+
+  it('returns true when context value is true', () => {
+    const wrapper = ({ children }: { children: React.ReactNode }) =>
+      React.createElement(KeepAliveActiveContext.Provider, { value: true }, children)
+    const { result } = renderHook(() => useKeepAliveActive(), { wrapper })
+    expect(result.current).toBe(true)
+  })
+
+  it('returns false when context value is false', () => {
+    const wrapper = ({ children }: { children: React.ReactNode }) =>
+      React.createElement(KeepAliveActiveContext.Provider, { value: false }, children)
+    const { result } = renderHook(() => useKeepAliveActive(), { wrapper })
+    expect(result.current).toBe(false)
+  })
+
+  it('KeepAliveActiveContext has a default value of true', () => {
+    expect(KeepAliveActiveContext['_currentValue']).toBe(true)
+  })
+})

--- a/web/src/hooks/__tests__/useMissionTypes.test.ts
+++ b/web/src/hooks/__tests__/useMissionTypes.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect } from 'vitest'
+import { isActiveMission, INACTIVE_MISSION_STATUSES } from '../useMissionTypes'
+import type { MissionStatus } from '../useMissionTypes'
+
+describe('INACTIVE_MISSION_STATUSES', () => {
+  it('contains saved, completed, failed, cancelled', () => {
+    expect(INACTIVE_MISSION_STATUSES.has('saved')).toBe(true)
+    expect(INACTIVE_MISSION_STATUSES.has('completed')).toBe(true)
+    expect(INACTIVE_MISSION_STATUSES.has('failed')).toBe(true)
+    expect(INACTIVE_MISSION_STATUSES.has('cancelled')).toBe(true)
+  })
+
+  it('does not contain active statuses', () => {
+    const activeStatuses: MissionStatus[] = ['pending', 'running', 'waiting_input', 'blocked', 'cancelling']
+    for (const status of activeStatuses) {
+      expect(INACTIVE_MISSION_STATUSES.has(status)).toBe(false)
+    }
+  })
+})
+
+describe('isActiveMission', () => {
+  it('returns false for saved missions', () => {
+    expect(isActiveMission({ status: 'saved' })).toBe(false)
+  })
+
+  it('returns false for completed missions', () => {
+    expect(isActiveMission({ status: 'completed' })).toBe(false)
+  })
+
+  it('returns false for failed missions', () => {
+    expect(isActiveMission({ status: 'failed' })).toBe(false)
+  })
+
+  it('returns false for cancelled missions', () => {
+    expect(isActiveMission({ status: 'cancelled' })).toBe(false)
+  })
+
+  it('returns true for pending missions', () => {
+    expect(isActiveMission({ status: 'pending' })).toBe(true)
+  })
+
+  it('returns true for running missions', () => {
+    expect(isActiveMission({ status: 'running' })).toBe(true)
+  })
+
+  it('returns true for waiting_input missions', () => {
+    expect(isActiveMission({ status: 'waiting_input' })).toBe(true)
+  })
+
+  it('returns true for blocked missions', () => {
+    expect(isActiveMission({ status: 'blocked' })).toBe(true)
+  })
+
+  it('returns true for cancelling missions', () => {
+    expect(isActiveMission({ status: 'cancelling' })).toBe(true)
+  })
+})

--- a/web/src/hooks/__tests__/usePredictionFeedback-expand.test.ts
+++ b/web/src/hooks/__tests__/usePredictionFeedback-expand.test.ts
@@ -1,0 +1,252 @@
+/**
+ * Supplemental tests for usePredictionFeedback.ts covering branches
+ * not tested by the existing usePredictionFeedback.test.ts:
+ * - removeFeedback
+ * - getStats (with provider breakdown)
+ * - clearFeedback
+ * - getFeedbackContext exported function
+ * - storage event listener
+ * - singleton feedback trimming at MAX_FEEDBACK_ENTRIES
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { renderHook, act, waitFor } from '@testing-library/react'
+
+vi.mock('../../lib/constants', async (importOriginal) => {
+  const actual = await importOriginal() as Record<string, unknown>
+  return { ...actual, LOCAL_AGENT_HTTP_URL: 'http://localhost:8585' }
+})
+
+vi.mock('../../lib/constants/network', async (importOriginal) => {
+  const actual = await importOriginal() as Record<string, unknown>
+  return { ...actual, FETCH_DEFAULT_TIMEOUT_MS: 10000 }
+})
+
+vi.mock('../../lib/analytics', () => ({
+  emitPredictionFeedbackSubmitted: vi.fn(),
+}))
+
+import { usePredictionFeedback, getFeedbackContext } from '../usePredictionFeedback'
+
+const originalFetch = globalThis.fetch
+
+beforeEach(() => {
+  localStorage.clear()
+  vi.clearAllMocks()
+  globalThis.fetch = vi.fn().mockResolvedValue({ ok: true })
+})
+
+afterEach(() => {
+  globalThis.fetch = originalFetch
+})
+
+// ---------------------------------------------------------------------------
+// removeFeedback
+// ---------------------------------------------------------------------------
+
+describe('usePredictionFeedback — removeFeedback', () => {
+  it('removes an existing feedback entry', () => {
+    const { result } = renderHook(() => usePredictionFeedback())
+    act(() => {
+      result.current.submitFeedback('pred-1', 'accurate', 'anomaly')
+    })
+    expect(result.current.getFeedback('pred-1')).toBe('accurate')
+    act(() => {
+      result.current.removeFeedback('pred-1')
+    })
+    expect(result.current.getFeedback('pred-1')).toBeNull()
+  })
+
+  it('decrements feedbackCount after removal', () => {
+    const { result } = renderHook(() => usePredictionFeedback())
+    act(() => {
+      result.current.submitFeedback('pred-a', 'accurate', 'anomaly')
+      result.current.submitFeedback('pred-b', 'inaccurate', 'anomaly')
+    })
+    const countBefore = result.current.feedbackCount
+    act(() => {
+      result.current.removeFeedback('pred-a')
+    })
+    expect(result.current.feedbackCount).toBe(countBefore - 1)
+  })
+
+  it('does nothing when removing a non-existent entry', () => {
+    const { result } = renderHook(() => usePredictionFeedback())
+    const countBefore = result.current.feedbackCount
+    act(() => {
+      result.current.removeFeedback('does-not-exist')
+    })
+    expect(result.current.feedbackCount).toBe(countBefore)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// clearFeedback
+// ---------------------------------------------------------------------------
+
+describe('usePredictionFeedback — clearFeedback', () => {
+  it('removes all feedback entries', () => {
+    const { result } = renderHook(() => usePredictionFeedback())
+    act(() => {
+      result.current.submitFeedback('p1', 'accurate', 'anomaly')
+      result.current.submitFeedback('p2', 'inaccurate', 'trend')
+    })
+    expect(result.current.feedbackCount).toBeGreaterThan(0)
+    act(() => {
+      result.current.clearFeedback()
+    })
+    expect(result.current.feedbackCount).toBe(0)
+  })
+
+  it('persists the cleared state to localStorage', () => {
+    const { result } = renderHook(() => usePredictionFeedback())
+    act(() => {
+      result.current.submitFeedback('p1', 'accurate', 'anomaly')
+      result.current.clearFeedback()
+    })
+    const stored = localStorage.getItem('kubestellar-prediction-feedback')
+    const parsed = JSON.parse(stored || '[]')
+    expect(parsed).toHaveLength(0)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// getStats
+// ---------------------------------------------------------------------------
+
+describe('usePredictionFeedback — getStats', () => {
+  it('returns zero stats when no feedback', () => {
+    const { result } = renderHook(() => usePredictionFeedback())
+    act(() => { result.current.clearFeedback() })
+    const stats = result.current.getStats()
+    expect(stats.totalPredictions).toBe(0)
+    expect(stats.accuracyRate).toBe(0)
+    expect(stats.accurateFeedback).toBe(0)
+    expect(stats.inaccurateFeedback).toBe(0)
+  })
+
+  it('computes accuracy rate correctly', () => {
+    const { result } = renderHook(() => usePredictionFeedback())
+    act(() => {
+      result.current.clearFeedback()
+      result.current.submitFeedback('s1', 'accurate', 'anomaly')
+      result.current.submitFeedback('s2', 'accurate', 'anomaly')
+      result.current.submitFeedback('s3', 'inaccurate', 'anomaly')
+    })
+    const stats = result.current.getStats()
+    expect(stats.totalPredictions).toBe(3)
+    expect(stats.accurateFeedback).toBe(2)
+    expect(stats.inaccurateFeedback).toBe(1)
+    expect(stats.accuracyRate).toBeCloseTo(2 / 3)
+  })
+
+  it('breaks down stats by provider', () => {
+    const { result } = renderHook(() => usePredictionFeedback())
+    act(() => {
+      result.current.clearFeedback()
+      result.current.submitFeedback('q1', 'accurate', 'anomaly', 'openai')
+      result.current.submitFeedback('q2', 'inaccurate', 'anomaly', 'openai')
+      result.current.submitFeedback('q3', 'accurate', 'trend', 'gemini')
+    })
+    const stats = result.current.getStats()
+    expect(stats.byProvider).toHaveProperty('openai')
+    expect(stats.byProvider['openai'].total).toBe(2)
+    expect(stats.byProvider['openai'].accurate).toBe(1)
+    expect(stats.byProvider['openai'].accuracyRate).toBeCloseTo(0.5)
+    expect(stats.byProvider['gemini'].total).toBe(1)
+  })
+
+  it('groups entries without provider under "unknown"', () => {
+    const { result } = renderHook(() => usePredictionFeedback())
+    act(() => {
+      result.current.clearFeedback()
+      result.current.submitFeedback('r1', 'accurate', 'anomaly')
+    })
+    const stats = result.current.getStats()
+    expect(stats.byProvider).toHaveProperty('unknown')
+    expect(stats.byProvider['unknown'].total).toBeGreaterThan(0)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// getFeedbackContext (exported pure function)
+// ---------------------------------------------------------------------------
+
+describe('getFeedbackContext', () => {
+  it('returns "No prediction feedback recorded yet." when empty', () => {
+    const { result } = renderHook(() => usePredictionFeedback())
+    act(() => { result.current.clearFeedback() })
+    const ctx = getFeedbackContext()
+    expect(ctx).toContain('No prediction feedback recorded yet.')
+  })
+
+  it('includes accurate/inaccurate counts when feedback exists', () => {
+    const { result } = renderHook(() => usePredictionFeedback())
+    act(() => {
+      result.current.clearFeedback()
+      result.current.submitFeedback('c1', 'accurate', 'anomaly')
+      result.current.submitFeedback('c2', 'inaccurate', 'trend')
+    })
+    const ctx = getFeedbackContext()
+    expect(ctx).toContain('Accurate:')
+    expect(ctx).toContain('Inaccurate:')
+  })
+
+  it('mentions prediction types that were often inaccurate', () => {
+    const { result } = renderHook(() => usePredictionFeedback())
+    act(() => {
+      result.current.clearFeedback()
+      for (let i = 0; i < 3; i++) {
+        result.current.submitFeedback(`bad-${i}`, 'inaccurate', 'anomaly')
+      }
+      result.current.submitFeedback('good-1', 'accurate', 'trend')
+    })
+    const ctx = getFeedbackContext()
+    expect(ctx).toContain('anomaly')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Storage event listener (cross-tab sync)
+// ---------------------------------------------------------------------------
+
+describe('usePredictionFeedback — storage event sync', () => {
+  it('re-reads localStorage on storage event for the feedback key', async () => {
+    const { result } = renderHook(() => usePredictionFeedback())
+    act(() => { result.current.clearFeedback() })
+
+    const newData = [
+      {
+        predictionId: 'ext-1',
+        feedback: 'accurate',
+        timestamp: new Date().toISOString(),
+        predictionType: 'anomaly',
+      },
+    ]
+    localStorage.setItem('kubestellar-prediction-feedback', JSON.stringify(newData))
+
+    act(() => {
+      window.dispatchEvent(new StorageEvent('storage', {
+        key: 'kubestellar-prediction-feedback',
+        newValue: JSON.stringify(newData),
+      }))
+    })
+
+    await waitFor(() => result.current.feedbackCount > 0)
+    expect(result.current.getFeedback('ext-1')).toBe('accurate')
+  })
+
+  it('ignores storage events for other keys', async () => {
+    const { result } = renderHook(() => usePredictionFeedback())
+    act(() => { result.current.clearFeedback() })
+    const before = result.current.feedbackCount
+
+    act(() => {
+      window.dispatchEvent(new StorageEvent('storage', {
+        key: 'some-other-key',
+        newValue: 'value',
+      }))
+    })
+
+    expect(result.current.feedbackCount).toBe(before)
+  })
+})

--- a/web/src/hooks/__tests__/useUpgradeState.test.ts
+++ b/web/src/hooks/__tests__/useUpgradeState.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect, afterEach } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+import { useUpgradeState } from '../useUpgradeState'
+import { setUpgradeState, getUpgradeState } from '../../lib/upgradeState'
+
+afterEach(() => {
+  // Reset singleton to idle after each test
+  setUpgradeState({ phase: 'idle' })
+})
+
+describe('useUpgradeState', () => {
+  it('returns idle state initially', () => {
+    const { result } = renderHook(() => useUpgradeState())
+    expect(result.current.phase).toBe('idle')
+  })
+
+  it('reflects state changes from setUpgradeState', () => {
+    const { result } = renderHook(() => useUpgradeState())
+    act(() => {
+      setUpgradeState({ phase: 'triggering' })
+    })
+    expect(result.current.phase).toBe('triggering')
+  })
+
+  it('reflects restarting phase', () => {
+    const { result } = renderHook(() => useUpgradeState())
+    act(() => {
+      setUpgradeState({ phase: 'restarting' })
+    })
+    expect(result.current.phase).toBe('restarting')
+  })
+
+  it('reflects complete phase', () => {
+    const { result } = renderHook(() => useUpgradeState())
+    act(() => {
+      setUpgradeState({ phase: 'complete' })
+    })
+    expect(result.current.phase).toBe('complete')
+  })
+
+  it('reflects error phase with message', () => {
+    const { result } = renderHook(() => useUpgradeState())
+    act(() => {
+      setUpgradeState({ phase: 'error', errorMessage: 'something went wrong' })
+    })
+    expect(result.current.phase).toBe('error')
+    expect(result.current.errorMessage).toBe('something went wrong')
+  })
+
+  it('multiple hook instances all receive the same update', () => {
+    const { result: r1 } = renderHook(() => useUpgradeState())
+    const { result: r2 } = renderHook(() => useUpgradeState())
+    act(() => {
+      setUpgradeState({ phase: 'complete' })
+    })
+    expect(r1.current.phase).toBe('complete')
+    expect(r2.current.phase).toBe('complete')
+  })
+
+  it('getUpgradeState returns current state synchronously', () => {
+    act(() => {
+      setUpgradeState({ phase: 'triggering' })
+    })
+    expect(getUpgradeState().phase).toBe('triggering')
+  })
+})


### PR DESCRIPTION
## Summary

- Adds supplemental tests for `usePredictionFeedback` covering `removeFeedback`, `clearFeedback`, `getStats` (with provider breakdown), `getFeedbackContext`, and storage event listener cross-tab sync
- Adds first-ever tests for 8 hook files with zero dedicated test coverage: `useDebouncedValue`, `useKeepAliveActive`, `useMissionTypes`, `useUpgradeState`, `useCachedNodes`, `useCachedGitOps`, `useCachedGPU`, `useCachedK8sResources`

## Test plan

- [ ] CI build/lint passes
- [ ] All new tests use `vi.mock()` with proper path resolution from `hooks/__tests__/`
- [ ] `useDebouncedValue` uses `vi.useFakeTimers()` for timer control
- [ ] `useUpgradeState` tests reset singleton in `afterEach` to avoid cross-test contamination
- [ ] `useCached*` tests mock `useCache` from `../../lib/cache` to isolate hook surface area

🤖 Generated with [Claude Code](https://claude.com/claude-code)