### PR TITLE
test(hooks): fix flaky waitFor conditions in coverage tests

### DIFF
--- a/web/src/hooks/__tests__/useBonusPoints.test.ts
+++ b/web/src/hooks/__tests__/useBonusPoints.test.ts
@@ -103,7 +103,7 @@ describe('useBonusPoints — successful fetch', () => {
     authenticatedUser('bob')
     mockFetchBonus({ login: 'bob', total_bonus_points: 150, entries: [] })
     const { result } = renderHook(() => useBonusPoints())
-    await waitFor(() => !result.current.isBonusLoading)
+    await waitFor(() => result.current.bonusPoints === 150)
     expect(result.current.bonusPoints).toBe(150)
   })
 
@@ -112,7 +112,7 @@ describe('useBonusPoints — successful fetch', () => {
     const entries = [{ issue_number: 1, points: 50, reason: 'PR fix', created_at: '2026-01-01', state: 'closed' }]
     mockFetchBonus({ login: 'bob', total_bonus_points: 50, entries })
     const { result } = renderHook(() => useBonusPoints())
-    await waitFor(() => !result.current.isBonusLoading)
+    await waitFor(() => result.current.bonusEntries.length > 0)
     expect(result.current.bonusEntries).toHaveLength(1)
   })
 

--- a/web/src/hooks/__tests__/useGatewayStatus.test.ts
+++ b/web/src/hooks/__tests__/useGatewayStatus.test.ts
@@ -137,7 +137,7 @@ describe('useGatewayStatus — successful API response', () => {
   it('populates gateways from API response', async () => {
     mockFetchOk([makeGateway('prod-gw', 'prod')])
     const { result } = renderHook(() => useGatewayStatus())
-    await waitFor(() => !result.current.isLoading)
+    await waitFor(() => result.current.gateways.length > 0)
     expect(result.current.gateways).toHaveLength(1)
     expect(result.current.gateways[0].name).toBe('prod-gw')
   })
@@ -145,7 +145,7 @@ describe('useGatewayStatus — successful API response', () => {
   it('sets isDemoData=false on successful fetch', async () => {
     mockFetchOk([makeGateway()])
     const { result } = renderHook(() => useGatewayStatus())
-    await waitFor(() => !result.current.isLoading)
+    await waitFor(() => result.current.isDemoData === false)
     expect(result.current.isDemoData).toBe(false)
   })
 
@@ -214,7 +214,7 @@ describe('useGatewayStatus — error fallback (demo data)', () => {
   it('increments consecutiveFailures on error', async () => {
     mockFetchError()
     const { result } = renderHook(() => useGatewayStatus())
-    await waitFor(() => !result.current.isLoading)
+    await waitFor(() => result.current.consecutiveFailures > 0)
     expect(result.current.consecutiveFailures).toBe(1)
   })
 
@@ -222,7 +222,7 @@ describe('useGatewayStatus — error fallback (demo data)', () => {
     mockClusters.mockReturnValue([{ name: 'my-cluster', reachable: true }])
     mockFetchError()
     const { result } = renderHook(() => useGatewayStatus())
-    await waitFor(() => !result.current.isLoading)
+    await waitFor(() => result.current.gateways.length > 0)
     const clusterGateways = result.current.gateways.filter(gw => gw.cluster === 'my-cluster')
     expect(clusterGateways.length).toBeGreaterThan(0)
   })
@@ -231,7 +231,7 @@ describe('useGatewayStatus — error fallback (demo data)', () => {
     mockClusters.mockReturnValue([])
     mockFetchError()
     const { result } = renderHook(() => useGatewayStatus())
-    await waitFor(() => !result.current.isLoading)
+    await waitFor(() => result.current.gateways.length > 0)
     const clusterNames = new Set(result.current.gateways.map(gw => gw.cluster))
     expect(clusterNames.size).toBeGreaterThan(0)
   })

--- a/web/src/hooks/__tests__/useIntoto-hook.test.tsx
+++ b/web/src/hooks/__tests__/useIntoto-hook.test.tsx
@@ -200,7 +200,7 @@ describe('useIntoto — cluster fetch: CRD not installed', () => {
       Promise.all(tasks.map(t => t().then(v => ({ status: 'fulfilled' as const, value: v }))))
     )
     const { result } = renderHook(() => useIntoto())
-    await waitFor(() => !result.current.isLoading)
+    await waitFor(() => result.current.statuses['cluster-a'] !== undefined)
     expect(result.current.statuses['cluster-a']?.installed).toBe(false)
   })
 })
@@ -268,7 +268,7 @@ describe('useIntoto — cluster fetch: CRD installed', () => {
 
   it('installed is true when at least one cluster is installed', async () => {
     const { result } = renderHook(() => useIntoto())
-    await waitFor(() => !result.current.isLoading)
+    await waitFor(() => result.current.installed === true)
     expect(result.current.installed).toBe(true)
   })
 
@@ -330,11 +330,14 @@ describe('useIntoto — cluster fetch: errors', () => {
     mockClusters.mockReturnValue(['bad-cluster'])
     mockKubectlExec.mockRejectedValue(new Error('connection refused'))
     mockSettledWithConcurrency.mockImplementation(async (tasks: (() => Promise<unknown>)[]) =>
-      Promise.all(tasks.map(t => t().then(v => ({ status: 'fulfilled' as const, value: v }))))
+      Promise.all(tasks.map(t => t()
+        .then(v => ({ status: 'fulfilled' as const, value: v }))
+        .catch((e: Error) => ({ status: 'rejected' as const, reason: e }))
+      ))
     )
 
     const { result } = renderHook(() => useIntoto())
-    await waitFor(() => !result.current.isLoading)
+    await waitFor(() => result.current.statuses['bad-cluster'] !== undefined)
     expect(result.current.statuses['bad-cluster']?.error).toBeTruthy()
   })
 
@@ -342,11 +345,14 @@ describe('useIntoto — cluster fetch: errors', () => {
     mockClusters.mockReturnValue(['err-cluster'])
     mockKubectlExec.mockRejectedValue(new Error('timeout'))
     mockSettledWithConcurrency.mockImplementation(async (tasks: (() => Promise<unknown>)[]) =>
-      Promise.all(tasks.map(t => t().then(v => ({ status: 'fulfilled' as const, value: v }))))
+      Promise.all(tasks.map(t => t()
+        .then(v => ({ status: 'fulfilled' as const, value: v }))
+        .catch((e: Error) => ({ status: 'rejected' as const, reason: e }))
+      ))
     )
 
     const { result } = renderHook(() => useIntoto())
-    await waitFor(() => !result.current.isLoading)
+    await waitFor(() => result.current.statuses['err-cluster'] !== undefined)
     expect(result.current.hasErrors).toBe(true)
   })
 
@@ -354,11 +360,14 @@ describe('useIntoto — cluster fetch: errors', () => {
     mockClusters.mockReturnValue(['err-cluster'])
     mockKubectlExec.mockRejectedValue(new Error('timeout'))
     mockSettledWithConcurrency.mockImplementation(async (tasks: (() => Promise<unknown>)[]) =>
-      Promise.all(tasks.map(t => t().then(v => ({ status: 'fulfilled' as const, value: v }))))
+      Promise.all(tasks.map(t => t()
+        .then(v => ({ status: 'fulfilled' as const, value: v }))
+        .catch((e: Error) => ({ status: 'rejected' as const, reason: e }))
+      ))
     )
 
     const { result } = renderHook(() => useIntoto())
-    await waitFor(() => !result.current.isLoading)
+    await waitFor(() => result.current.consecutiveFailures > 0)
     expect(result.current.consecutiveFailures).toBeGreaterThan(0)
   })
 })

--- a/web/src/hooks/__tests__/useServiceImportsCard.test.ts
+++ b/web/src/hooks/__tests__/useServiceImportsCard.test.ts
@@ -130,14 +130,14 @@ describe('useServiceImportsCard — successful API response', () => {
   it('populates imports from API response', async () => {
     mockFetchOk([makeServiceImport('my-svc')])
     const { result } = renderHook(() => useServiceImportsCard())
-    await waitFor(() => !result.current.isLoading)
+    await waitFor(() => result.current.imports.length > 0)
     expect(result.current.imports).toHaveLength(1)
   })
 
   it('sets isDemoData=false on successful fetch', async () => {
     mockFetchOk([makeServiceImport()])
     const { result } = renderHook(() => useServiceImportsCard())
-    await waitFor(() => !result.current.isLoading)
+    await waitFor(() => result.current.isDemoData === false)
     expect(result.current.isDemoData).toBe(false)
   })
 
@@ -213,7 +213,7 @@ describe('useServiceImportsCard — error fallback', () => {
     mockClusters.mockReturnValue([{ name: 'prod', reachable: true }])
     mockFetchError()
     const { result } = renderHook(() => useServiceImportsCard())
-    await waitFor(() => !result.current.isLoading)
+    await waitFor(() => result.current.imports.length > 0)
     const clusterImports = result.current.imports.filter(
       i => i.metadata?.labels?.['multicluster.kubernetes.io/cluster'] === 'prod'
         || (i.status?.clusters ?? []).some((c: { cluster: string }) => c.cluster === 'prod')


### PR DESCRIPTION
## Summary

- Replace `waitFor(() => !isLoading)` with data-driven conditions in 4 test files
- `isLoading` can start as `false` when a cached localStorage snapshot is present, causing `waitFor` to resolve immediately before the fetch completes
- Also fixes `settledWithConcurrency` mock in `useIntoto` error tests: added `.catch` so rejected promises return `{ status: 'rejected', reason }` instead of propagating through `Promise.all`

## Files changed

- `useBonusPoints.test.ts`: wait for `bonusPoints === 150` / `bonusEntries.length > 0`
- `useGatewayStatus.test.ts`: wait for `isDemoData === false`, `gateways.length > 0`, `consecutiveFailures > 0`
- `useServiceImportsCard.test.ts`: wait for `isDemoData === false`, `imports.length > 0`
- `useIntoto-hook.test.tsx`: wait for `statuses[cluster] !== undefined`, `installed === true`, `consecutiveFailures > 0`; fix `.catch` in rejection mock

## Test plan
- [ ] CI passes (coverage-gate + coverage-hourly shards)
- [ ] All previously-failing tests now pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)