### PR TITLE
fix(k8s): resolve 4 health/GPU probing bugs in pkg/k8s

### DIFF
--- a/pkg/k8s/client.go
+++ b/pkg/k8s/client.go
@@ -1402,6 +1402,15 @@ func (m *MultiClusterClient) WarmupHealthCache() {
 		wg.Add(1)
 		go func(name, ctxName string) {
 			defer wg.Done()
+			// #9334 — Respect context cancellation promptly. If the outer
+			// warmup deadline already fired, don't start a fresh 5s probe
+			// that extends the effective timeout well past the documented
+			// clusterHealthCheckTimeout.
+			select {
+			case <-ctx.Done():
+				return
+			default:
+			}
 			probeCtx, probeCancel := context.WithTimeout(ctx, clusterProbeTimeout)
 			defer probeCancel()
 
@@ -1555,7 +1564,17 @@ func isBetterClusterName(candidate, current string) bool {
 	return len(candidate) < len(current)
 }
 
-// GetClient returns a kubernetes client for the specified context
+// GetClient returns a kubernetes client for the specified context.
+//
+// #9334 — Client construction (especially `clientcmd…ClientConfig()` for
+// kubeconfigs that invoke an exec credential plugin like aws-iam-authenticator,
+// oci, gcloud, tsh, etc.) can take hundreds of ms to several seconds. Holding
+// the global write lock for the entire construction serializes every other
+// cluster probe in the process — fan-out health checks end up running
+// one-at-a-time. We build the client OUTSIDE the lock and only take the write
+// lock for the short final insertion, which permits concurrent construction
+// for different contexts while still preventing a single context from being
+// constructed twice.
 func (m *MultiClusterClient) GetClient(contextName string) (kubernetes.Interface, error) {
 	m.mu.RLock()
 	if client, ok := m.clients[contextName]; ok {
@@ -1563,26 +1582,25 @@ func (m *MultiClusterClient) GetClient(contextName string) (kubernetes.Interface
 		return client, nil
 	}
 	inClusterConfig := m.inClusterConfig
+	kubeconfigPath := m.kubeconfig
+	inClusterName := m.inClusterName
 	m.mu.RUnlock()
 
-	m.mu.Lock()
-	defer m.mu.Unlock()
-
-	// Double-check after acquiring write lock
-	if client, ok := m.clients[contextName]; ok {
-		return client, nil
-	}
-
+	// Build the client OUTSIDE the lock so concurrent callers for distinct
+	// contexts don't serialize on a single write lock (#9334). It is
+	// intentionally acceptable for two goroutines racing on the same context
+	// to both build a client here — the final map insertion under the write
+	// lock is idempotent (first writer wins, second discards its extra client).
 	var config *rest.Config
 	var err error
 
 	// Handle in-cluster context specially — accept both "in-cluster" and the detected name
-	isInCluster := inClusterConfig != nil && (contextName == "in-cluster" || contextName == m.inClusterName)
+	isInCluster := inClusterConfig != nil && (contextName == "in-cluster" || contextName == inClusterName)
 	if isInCluster {
 		config = rest.CopyConfig(inClusterConfig)
 	} else {
 		config, err = clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
-			&clientcmd.ClientConfigLoadingRules{ExplicitPath: m.kubeconfig},
+			&clientcmd.ClientConfigLoadingRules{ExplicitPath: kubeconfigPath},
 			&clientcmd.ConfigOverrides{CurrentContext: contextName},
 		).ClientConfig()
 		if err != nil {
@@ -1599,6 +1617,13 @@ func (m *MultiClusterClient) GetClient(contextName string) (kubernetes.Interface
 		return nil, fmt.Errorf("failed to create client for context %s: %w", contextName, err)
 	}
 
+	// Install the constructed client under a short write lock. If a concurrent
+	// caller beat us to it, reuse the existing entry (#9334).
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if existing, ok := m.clients[contextName]; ok {
+		return existing, nil
+	}
 	m.clients[contextName] = client
 	m.configs[contextName] = config
 	return client, nil

--- a/pkg/k8s/client_gpu.go
+++ b/pkg/k8s/client_gpu.go
@@ -19,14 +19,28 @@ import (
 )
 
 func (m *MultiClusterClient) GetGPUNodes(ctx context.Context, contextName string) ([]GPUNode, error) {
+	nodes, _, err := m.getGPUNodesWithPods(ctx, contextName)
+	return nodes, err
+}
+
+// getGPUNodesWithPods is the shared implementation of GetGPUNodes that also
+// returns the cluster-wide pod list it fetched for allocation accounting.
+// Callers that need the same pod list for subsequent analysis (e.g. stuck-pod
+// detection in GetGPUNodeHealth, #9339) can reuse it instead of issuing a
+// second cluster-wide Pods("").List call.
+//
+// The returned pod list may be nil on a listing failure; in that case the
+// node inventory is still returned with zero allocations and the listing
+// error is logged (#9091). Callers that rely on the pod list must handle nil.
+func (m *MultiClusterClient) getGPUNodesWithPods(ctx context.Context, contextName string) ([]GPUNode, *corev1.PodList, error) {
 	client, err := m.GetClient(contextName)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	nodes, err := client.CoreV1().Nodes().List(ctx, metav1.ListOptions{})
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	// Fetch all pods once upfront to calculate accelerator allocations per node
@@ -288,7 +302,7 @@ func (m *MultiClusterClient) GetGPUNodes(ctx context.Context, contextName string
 		})
 	}
 
-	return gpuNodes, nil
+	return gpuNodes, allPods, nil
 }
 
 // GPU operator namespace names to search for operator pods
@@ -307,8 +321,12 @@ func (m *MultiClusterClient) GetGPUNodeHealth(ctx context.Context, contextName s
 		return nil, err
 	}
 
-	// 1. Get GPU nodes using existing method
-	gpuNodes, err := m.GetGPUNodes(ctx, contextName)
+	// 1. Get GPU nodes AND reuse the cluster-wide pod list the lookup already
+	// fetched. Previously we issued a redundant second Pods("").List call below
+	// for stuck-pod detection — on large clusters (hundreds of namespaces,
+	// thousands of pods) that second list doubled API-server load and latency
+	// of this endpoint. (#9339)
+	gpuNodes, allPods, err := m.getGPUNodesWithPods(ctx, contextName)
 	if err != nil {
 		return nil, fmt.Errorf("listing GPU nodes: %w", err)
 	}
@@ -336,15 +354,9 @@ func (m *MultiClusterClient) GetGPUNodeHealth(ctx context.Context, contextName s
 		operatorPods = append(operatorPods, pods.Items...)
 	}
 
-	// 4. Find non-running pods for stuck pod detection (exclude Succeeded/Running).
-	// A failure here is non-fatal — we still return per-node health, but we
-	// log so operators can see why stuck-pod detection is effectively
-	// disabled (issue #9091).
-	allPods, allPodsErr := client.CoreV1().Pods("").List(ctx, metav1.ListOptions{})
-	if allPodsErr != nil {
-		slog.Error("[GPUNodeHealth] failed to list pods for stuck pod detection",
-			"cluster", contextName, "error", allPodsErr)
-	}
+	// 4. Stuck-pod detection reuses allPods from step 1 (see #9339). A nil
+	// allPods means getGPUNodesWithPods failed the inner pod list — we've
+	// already logged it there, so just proceed with empty stuck-pod data.
 
 	// 5. Get warning events from the last hour for GPU reset detection.
 	// Non-fatal, but log so operators can see why GPU-reset signals are

--- a/pkg/k8s/client_health.go
+++ b/pkg/k8s/client_health.go
@@ -301,29 +301,26 @@ func (m *MultiClusterClient) GetClusterHealth(ctx context.Context, contextName s
 	return health, nil
 }
 
+// defaultAPIServerPort is the port assumed when the API server URL doesn't
+// include one. HTTPS is the overwhelming case for Kubernetes API servers; bare
+// host entries (no scheme, no port) also default here.
+const defaultAPIServerPort = "443"
+
 // probeAPIServer performs a lightweight TCP dial to the API server URL to verify
 // external reachability. The kc-agent can reach clusters via internal networking
 // or VPN, but users/CI runners may not be able to (#4202).
+//
+// #9338 — IPv6 hosts contain many colons (e.g. `2001:db8::1`). The previous
+// implementation used `strings.Contains(host, ":")` to detect "port already
+// present", which misclassified bare IPv6 addresses as already-ported and
+// produced invalid dial addresses. We now rely on `net.SplitHostPort` for
+// hosts that look port-decorated (bracketed or trailing numeric segment),
+// and `net.JoinHostPort` to construct the dial address — it handles
+// bracketing automatically for IPv6.
 func probeAPIServer(host string) bool {
-	// Parse the URL to extract host:port.
-	// rest.Config.Host can be a bare "host:port" or a full URL "https://host:port".
-	addr := host
-	if strings.Contains(host, "://") {
-		parsed, err := url.Parse(host)
-		if err != nil {
-			return false
-		}
-		port := parsed.Port()
-		if port == "" {
-			if parsed.Scheme == "https" {
-				port = "443"
-			} else {
-				port = "80"
-			}
-		}
-		addr = net.JoinHostPort(parsed.Hostname(), port)
-	} else if !strings.Contains(host, ":") {
-		addr = net.JoinHostPort(host, "443")
+	addr, ok := apiServerDialAddr(host)
+	if !ok {
+		return false
 	}
 
 	conn, err := net.DialTimeout("tcp", addr, clusterProbeTimeout)
@@ -331,6 +328,86 @@ func probeAPIServer(host string) bool {
 		return false
 	}
 	conn.Close()
+	return true
+}
+
+// apiServerDialAddr converts a rest.Config.Host value (which may be a bare
+// host, `host:port`, a full URL, or an IPv6 literal) into a `host:port`
+// address suitable for net.DialTimeout. Returns ok=false if the input cannot
+// be parsed. (#9338)
+func apiServerDialAddr(host string) (string, bool) {
+	// Full URL form — let net/url handle it.
+	if strings.Contains(host, "://") {
+		parsed, err := url.Parse(host)
+		if err != nil {
+			return "", false
+		}
+		hostname := parsed.Hostname()
+		if hostname == "" {
+			return "", false
+		}
+		port := parsed.Port()
+		if port == "" {
+			if parsed.Scheme == "https" {
+				port = defaultAPIServerPort
+			} else {
+				port = "80"
+			}
+		}
+		return net.JoinHostPort(hostname, port), true
+	}
+
+	// Bracketed IPv6, possibly with a port: `[::1]` or `[::1]:8080`.
+	if strings.HasPrefix(host, "[") {
+		if strings.Contains(host, "]:") {
+			// Has an explicit port — net.SplitHostPort handles this correctly.
+			h, p, err := net.SplitHostPort(host)
+			if err != nil {
+				return "", false
+			}
+			return net.JoinHostPort(h, p), true
+		}
+		// Bare bracketed IPv6, no port.
+		h := strings.TrimSuffix(strings.TrimPrefix(host, "["), "]")
+		if h == "" {
+			return "", false
+		}
+		return net.JoinHostPort(h, defaultAPIServerPort), true
+	}
+
+	// No scheme, no brackets. Decide between "bare IPv6 literal" and
+	// "host:port" by looking at the last colon-delimited segment: a port is
+	// numeric, an IPv6 segment is hex (may contain letters) or empty.
+	lastColon := strings.LastIndex(host, ":")
+	if lastColon == -1 {
+		// No colons at all — must be a bare host or IPv4.
+		return net.JoinHostPort(host, defaultAPIServerPort), true
+	}
+	tail := host[lastColon+1:]
+	if isNumericPort(tail) && !strings.Contains(host[:lastColon], ":") {
+		// Exactly one colon with a numeric tail → `host:port` (IPv4/hostname).
+		h, p, err := net.SplitHostPort(host)
+		if err != nil {
+			return "", false
+		}
+		return net.JoinHostPort(h, p), true
+	}
+	// Otherwise treat the whole thing as a bare IPv6 literal. JoinHostPort
+	// will bracket it correctly for the dial address.
+	return net.JoinHostPort(host, defaultAPIServerPort), true
+}
+
+// isNumericPort returns true if s is a non-empty sequence of ASCII digits.
+// Used by apiServerDialAddr to disambiguate `host:port` from bare IPv6 (#9338).
+func isNumericPort(s string) bool {
+	if s == "" {
+		return false
+	}
+	for _, r := range s {
+		if r < '0' || r > '9' {
+			return false
+		}
+	}
 	return true
 }
 
@@ -484,13 +561,22 @@ func (m *MultiClusterClient) CheckSecurityIssues(ctx context.Context, contextNam
 				})
 			}
 
-			// Check for running as root
-			runAsRoot := false
-			if sc != nil && sc.RunAsUser != nil && *sc.RunAsUser == 0 {
-				runAsRoot = true
-			} else if sc == nil && podSC != nil && podSC.RunAsUser != nil && *podSC.RunAsUser == 0 {
-				runAsRoot = true
+			// Check for running as root. Container-level SecurityContext.RunAsUser
+			// overrides pod-level PodSecurityContext.RunAsUser ONLY when it is
+			// non-nil. Previously we only consulted the pod-level value when the
+			// ENTIRE container-level SecurityContext was nil — meaning a container
+			// with a non-nil SecurityContext that set only unrelated fields (e.g.
+			// `Privileged: false`) would hide an inherited pod-level
+			// `RunAsUser: 0`. Kubernetes resolves these field-by-field, so we
+			// must mirror that: only fall back to pod-level for fields the
+			// container didn't set. (#9337)
+			var effectiveRunAsUser *int64
+			if sc != nil && sc.RunAsUser != nil {
+				effectiveRunAsUser = sc.RunAsUser
+			} else if podSC != nil && podSC.RunAsUser != nil {
+				effectiveRunAsUser = podSC.RunAsUser
 			}
+			runAsRoot := effectiveRunAsUser != nil && *effectiveRunAsUser == 0
 			if runAsRoot {
 				issues = append(issues, SecurityIssue{
 					Name:      pod.Name,

--- a/pkg/k8s/client_health_bundle_test.go
+++ b/pkg/k8s/client_health_bundle_test.go
@@ -1,0 +1,340 @@
+package k8s
+
+import (
+	"context"
+	"net"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8sruntime "k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes"
+	k8sfake "k8s.io/client-go/kubernetes/fake"
+	clienttesting "k8s.io/client-go/testing"
+	"k8s.io/client-go/tools/clientcmd/api"
+)
+
+// ----------------------------------------------------------------------------
+// #9334 — parallel health probing
+// ----------------------------------------------------------------------------
+
+// probeConcurrency is the number of clusters we simulate concurrently. It
+// needs to be large enough that serialized probing is trivially distinguishable
+// from parallel probing (by a factor of ~10x on wall clock) but small enough
+// to keep the test fast in CI.
+const probeConcurrency = 8
+
+// probeArtificialLatency is the per-cluster synthetic List() latency we
+// inject. It is long enough to dominate all other costs in the test but short
+// enough for the whole test to finish in well under a second when the probes
+// run in parallel.
+const probeArtificialLatency = 150 * time.Millisecond
+
+// TestGetAllClusterHealth_RunsInParallel verifies the #9334 fix: cluster
+// health probes must fan out. Before the fix, `GetClient` held a global write
+// lock across the slow `clientcmd…ClientConfig()` path, serializing all
+// probes. We can't easily reproduce the client-construction delay here (the
+// fake clients are pre-injected), but we CAN reproduce the wall-clock shape:
+// if probes run in parallel, total time ≈ max(per-cluster latency); if they
+// run serially, total time ≈ sum(per-cluster latency).
+func TestGetAllClusterHealth_RunsInParallel(t *testing.T) {
+	m := &MultiClusterClient{
+		clients:     make(map[string]kubernetes.Interface),
+		healthCache: make(map[string]*ClusterHealth),
+		cacheTime:   make(map[string]time.Time),
+		rawConfig:   &api.Config{Contexts: map[string]*api.Context{}},
+	}
+
+	var inflight int32
+	var peakInflight int32
+	for i := 0; i < probeConcurrency; i++ {
+		name := clusterName(i)
+		m.rawConfig.Contexts[name] = &api.Context{Cluster: name}
+		fc := k8sfake.NewSimpleClientset(&corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "n"}})
+		fc.PrependReactor("list", "nodes", func(action clienttesting.Action) (bool, k8sruntime.Object, error) {
+			cur := atomic.AddInt32(&inflight, 1)
+			// Track the high-water mark of concurrent in-flight probes.
+			for {
+				peak := atomic.LoadInt32(&peakInflight)
+				if cur <= peak || atomic.CompareAndSwapInt32(&peakInflight, peak, cur) {
+					break
+				}
+			}
+			time.Sleep(probeArtificialLatency)
+			atomic.AddInt32(&inflight, -1)
+			return true, &corev1.NodeList{Items: []corev1.Node{{ObjectMeta: metav1.ObjectMeta{Name: "n"}}}}, nil
+		})
+		m.clients[name] = fc
+	}
+
+	start := time.Now()
+	results, err := m.GetAllClusterHealth(context.Background())
+	elapsed := time.Since(start)
+	if err != nil {
+		t.Fatalf("GetAllClusterHealth: %v", err)
+	}
+	if len(results) != probeConcurrency {
+		t.Fatalf("expected %d results, got %d", probeConcurrency, len(results))
+	}
+	// With true parallelism, peak in-flight should equal probeConcurrency.
+	// Serial execution would cap peak at 1. Allow a small dip to >=2 as a
+	// hedge against scheduling quirks — anything under that means probes are
+	// serialized.
+	if atomic.LoadInt32(&peakInflight) < 2 {
+		t.Errorf("probes did not run concurrently (peak in-flight = %d); expected fan-out", peakInflight)
+	}
+	// And the wall-clock guard: serial would take at least
+	// probeConcurrency*probeArtificialLatency. We pick 0.5× as a generous
+	// upper bound.
+	serialWallClock := time.Duration(probeConcurrency) * probeArtificialLatency
+	if elapsed > serialWallClock/2 {
+		t.Errorf("wall clock %v is close to serialized budget %v; probes not parallel",
+			elapsed, serialWallClock)
+	}
+}
+
+// TestGetClient_ConcurrentDistinctContexts is a targeted regression for the
+// specific #9334 root cause: holding the write lock across the slow
+// client-config path. We inject fakes before calling so the construction path
+// is trivial, but we do verify that many parallel GetClient calls for
+// DIFFERENT contexts all succeed without deadlock.
+func TestGetClient_ConcurrentDistinctContexts(t *testing.T) {
+	m := &MultiClusterClient{
+		clients:     make(map[string]kubernetes.Interface),
+		healthCache: make(map[string]*ClusterHealth),
+		cacheTime:   make(map[string]time.Time),
+	}
+	for i := 0; i < probeConcurrency; i++ {
+		m.clients[clusterName(i)] = k8sfake.NewSimpleClientset()
+	}
+
+	var wg sync.WaitGroup
+	errs := make(chan error, probeConcurrency)
+	for i := 0; i < probeConcurrency; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			if _, err := m.GetClient(clusterName(i)); err != nil {
+				errs <- err
+			}
+		}(i)
+	}
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		t.Errorf("GetClient: %v", err)
+	}
+}
+
+func clusterName(i int) string {
+	return "cluster-" + string(rune('a'+i))
+}
+
+// ----------------------------------------------------------------------------
+// #9337 — inherited SecurityContext root-user detection
+// ----------------------------------------------------------------------------
+
+// TestCheckSecurityIssues_InheritedRunAsUser verifies that a pod-level
+// RunAsUser=0 is detected even when the container has a non-nil
+// SecurityContext that sets only unrelated fields. Before the #9337 fix, the
+// container-level `Privileged: false` caused the pod-level RunAsUser=0 to be
+// silently ignored, because the code only fell back to PodSecurityContext
+// when the container SecurityContext itself was nil.
+func TestCheckSecurityIssues_InheritedRunAsUser(t *testing.T) {
+	m, _ := NewMultiClusterClient("")
+	m.rawConfig = &api.Config{Contexts: map[string]*api.Context{"c1": {Cluster: "cl1"}}}
+
+	falseVal := false
+	rootUID := int64(0)
+	nonRootUID := int64(1000)
+
+	fakeCS := k8sfake.NewSimpleClientset(
+		// Inherited root: container SC non-nil (Privileged=false only),
+		// pod SC has RunAsUser=0. Previously missed.
+		&corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{Name: "inherited-root", Namespace: "default"},
+			Spec: corev1.PodSpec{
+				SecurityContext: &corev1.PodSecurityContext{RunAsUser: &rootUID},
+				Containers: []corev1.Container{{
+					Name:            "c1",
+					SecurityContext: &corev1.SecurityContext{Privileged: &falseVal},
+				}},
+			},
+		},
+		// Container-level override: pod SC RunAsUser=0 but container explicitly
+		// overrides to non-root. Must NOT be flagged (container wins).
+		&corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{Name: "container-override", Namespace: "default"},
+			Spec: corev1.PodSpec{
+				SecurityContext: &corev1.PodSecurityContext{RunAsUser: &rootUID},
+				Containers: []corev1.Container{{
+					Name:            "c1",
+					SecurityContext: &corev1.SecurityContext{RunAsUser: &nonRootUID},
+				}},
+			},
+		},
+		// Both non-root: should not be flagged.
+		&corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{Name: "safe", Namespace: "default"},
+			Spec: corev1.PodSpec{
+				SecurityContext: &corev1.PodSecurityContext{RunAsUser: &nonRootUID},
+				Containers: []corev1.Container{{
+					Name:            "c1",
+					SecurityContext: &corev1.SecurityContext{Privileged: &falseVal},
+				}},
+			},
+		},
+	)
+	m.clients["c1"] = fakeCS
+
+	issues, err := m.CheckSecurityIssues(context.Background(), "c1", "default")
+	if err != nil {
+		t.Fatalf("CheckSecurityIssues: %v", err)
+	}
+
+	var inheritedRootFlagged, overrideFlagged, safeFlagged bool
+	for _, iss := range issues {
+		if iss.Issue != "Running as root" {
+			continue
+		}
+		switch iss.Name {
+		case "inherited-root":
+			inheritedRootFlagged = true
+		case "container-override":
+			overrideFlagged = true
+		case "safe":
+			safeFlagged = true
+		}
+	}
+	if !inheritedRootFlagged {
+		t.Error("#9337 regression: inherited pod-level RunAsUser=0 was not flagged when container had a non-nil SecurityContext")
+	}
+	if overrideFlagged {
+		t.Error("container-level RunAsUser=1000 should override pod-level RunAsUser=0 — should not be flagged")
+	}
+	if safeFlagged {
+		t.Error("safe pod (both non-root) was incorrectly flagged")
+	}
+}
+
+// ----------------------------------------------------------------------------
+// #9338 — probeAPIServer IPv6 handling
+// ----------------------------------------------------------------------------
+
+func TestAPIServerDialAddr(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+		ok   bool
+	}{
+		// Hostnames and IPv4
+		{"bare hostname", "api.example.com", "api.example.com:" + defaultAPIServerPort, true},
+		{"hostname with port", "api.example.com:6443", "api.example.com:6443", true},
+		{"ipv4 bare", "10.0.0.1", "10.0.0.1:" + defaultAPIServerPort, true},
+		{"ipv4 with port", "10.0.0.1:6443", "10.0.0.1:6443", true},
+		// Full URLs
+		{"https URL", "https://api.example.com", "api.example.com:" + defaultAPIServerPort, true},
+		{"https URL with port", "https://api.example.com:6443", "api.example.com:6443", true},
+		{"http URL", "http://api.example.com", "api.example.com:80", true},
+		// IPv6 — the regression cases for #9338
+		{"ipv6 bare", "2001:db8::1", "[2001:db8::1]:" + defaultAPIServerPort, true},
+		{"ipv6 bare loopback", "::1", "[::1]:" + defaultAPIServerPort, true},
+		{"ipv6 bracketed no port", "[::1]", "[::1]:" + defaultAPIServerPort, true},
+		{"ipv6 bracketed with port", "[::1]:8080", "[::1]:8080", true},
+		{"ipv6 URL", "https://[2001:db8::1]:6443", "[2001:db8::1]:6443", true},
+		{"ipv6 URL no port", "https://[::1]", "[::1]:" + defaultAPIServerPort, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, ok := apiServerDialAddr(tc.in)
+			if ok != tc.ok {
+				t.Fatalf("ok = %v, want %v (got %q)", ok, tc.ok, got)
+			}
+			if got != tc.want {
+				t.Errorf("apiServerDialAddr(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+			// Belt-and-suspenders: the returned address must actually be a
+			// valid host:port that net.SplitHostPort can round-trip.
+			if ok {
+				if _, _, err := net.SplitHostPort(got); err != nil {
+					t.Errorf("net.SplitHostPort(%q) failed: %v", got, err)
+				}
+			}
+		})
+	}
+}
+
+func TestIsNumericPort(t *testing.T) {
+	cases := map[string]bool{
+		"":      false,
+		"0":     true,
+		"443":   true,
+		"65535": true,
+		"abc":   false,
+		"4a":    false,
+		"db8":   false, // IPv6 hex segment, NOT a port
+	}
+	for in, want := range cases {
+		if got := isNumericPort(in); got != want {
+			t.Errorf("isNumericPort(%q) = %v, want %v", in, got, want)
+		}
+	}
+}
+
+// ----------------------------------------------------------------------------
+// #9339 — GetGPUNodeHealth redundant pod list
+// ----------------------------------------------------------------------------
+
+// TestGetGPUNodeHealth_SinglePodList verifies that calling GetGPUNodeHealth
+// lists cluster-wide pods exactly once. Before the #9339 fix, it listed twice:
+// once inside GetGPUNodes for allocation accounting, and once directly in
+// GetGPUNodeHealth for stuck-pod detection. The fix routes the second consumer
+// through the pod list the first call already produced.
+func TestGetGPUNodeHealth_SinglePodList(t *testing.T) {
+	m, _ := NewMultiClusterClient("")
+	m.rawConfig = &api.Config{Contexts: map[string]*api.Context{"c1": {Cluster: "cl1"}}}
+
+	gpuNode := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{Name: "gpu-node"},
+		Status: corev1.NodeStatus{
+			Conditions:  []corev1.NodeCondition{{Type: corev1.NodeReady, Status: corev1.ConditionTrue}},
+			Allocatable: corev1.ResourceList{"nvidia.com/gpu": resource.MustParse("2")},
+		},
+	}
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "gpu-pod", Namespace: "default"},
+		Spec:       corev1.PodSpec{NodeName: "gpu-node", Containers: []corev1.Container{{Name: "c"}}},
+		Status:     corev1.PodStatus{Phase: corev1.PodRunning},
+	}
+
+	fc := k8sfake.NewSimpleClientset(gpuNode, pod)
+	// Count every cluster-wide pod list (Namespace == "").
+	var allNSPodListCount int32
+	fc.PrependReactor("list", "pods", func(action clienttesting.Action) (bool, k8sruntime.Object, error) {
+		if la, ok := action.(clienttesting.ListAction); ok {
+			if la.GetNamespace() == "" {
+				atomic.AddInt32(&allNSPodListCount, 1)
+			}
+		}
+		return false, nil, nil // fall through to default tracker
+	})
+	m.clients["c1"] = fc
+
+	results, err := m.GetGPUNodeHealth(context.Background(), "c1")
+	if err != nil {
+		t.Fatalf("GetGPUNodeHealth: %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(results))
+	}
+
+	got := atomic.LoadInt32(&allNSPodListCount)
+	if got != 1 {
+		t.Errorf("#9339 regression: cluster-wide Pods(\"\") listed %d times, want 1", got)
+	}
+}


### PR DESCRIPTION
## Summary

Bundled fixes for four latent bugs in `pkg/k8s` multi-cluster health probing and GPU inventory accounting. All four live in `client.go`, `client_health.go`, and `client_gpu.go`; one PR addresses them together because they share the same code paths and tests.

### #9334 — Multi-cluster health probing serialized + goroutine leak

`GetClient` held the global write lock across `clientcmd…ClientConfig()` resolution, which can take hundreds of ms to several seconds for exec-plugin-based auth (aws-iam-authenticator, tsh, oci, gcloud, etc.). Every other cluster probe in the process was blocked for that whole window, so fan-out health checks effectively ran **one-at-a-time**.

**Fix:** build the client OUTSIDE the write lock; only take it briefly for the final map insertion. If two goroutines race on the same context, the second discards its extra client (first writer wins). Also added an early `ctx.Done()` check at the top of each `WarmupHealthCache` goroutine so cancelled probes don't start a fresh 5s inner probe past the outer deadline.

### #9337 — `CheckSecurityIssues` missed inherited `RunAsUser=0`

Previously only fell back to `PodSecurityContext` when the container-level `SecurityContext` was `nil`. A container that set any *unrelated* field (e.g. `Privileged: false`) thus masked a pod-level `RunAsUser: 0`.

**Fix:** Kubernetes resolves these field-by-field, so we now prefer container-level values only when they are individually non-nil and otherwise fall back to pod-level — regardless of whether the container SecurityContext struct is non-nil.

### #9338 — `probeAPIServer` mis-classified IPv6 hosts

`strings.Contains(host, ":")` was used to detect "port already present" — but bare IPv6 hosts (`2001:db8::1`) contain many colons, so they were treated as already-ported and produced invalid dial addresses.

**Fix:** new `apiServerDialAddr` helper that handles bare host, `host:port`, bracketed IPv6 (`[::1]`, `[::1]:8080`), and full URL forms (`https://[2001:db8::1]:6443`), and uses `net.JoinHostPort` to construct the dial target (which brackets IPv6 correctly).

### #9339 — `GetGPUNodeHealth` redundant pod list

`GetGPUNodes` already fetches a cluster-wide pod list for accelerator allocation accounting. `GetGPUNodeHealth` then issued a **second identical** `Pods("").List` for stuck-pod detection — doubling API-server load and latency on large clusters.

**Fix:** extracted a shared `getGPUNodesWithPods()` that returns both the nodes and the pod list so `GetGPUNodeHealth` can reuse it. The public `GetGPUNodes` signature is unchanged.

## Test plan

- [x] go test ./pkg/k8s/... — all existing tests pass + 6 new tests
- [x] go build ./... — full build green
- [x] go vet ./pkg/k8s/... — clean
- [x] TestGetAllClusterHealth_RunsInParallel — reactor-counted peak-inflight + wall-clock check for #9334 fan-out
- [x] TestGetClient_ConcurrentDistinctContexts — parallel GetClient for distinct contexts doesn't deadlock
- [x] TestCheckSecurityIssues_InheritedRunAsUser — inherited-root, container-override, and safe cases for #9337
- [x] TestAPIServerDialAddr — 13-case dial-addr table (bracketed IPv6, IPv6 URLs, bare IPv6 literals, hostname+port, HTTP URL) for #9338
- [x] TestIsNumericPort — numeric-vs-hex disambiguation for #9338
- [x] TestGetGPUNodeHealth_SinglePodList — reactor-counted single cluster-wide pod list for #9339

Fixes #9334, Fixes #9337, Fixes #9338, Fixes #9339