### PR TITLE
fix(tests): resolve 13 Coverage Suite failures from run #1186

### DIFF
--- a/web/src/hooks/__tests__/useBonusPoints.test.ts
+++ b/web/src/hooks/__tests__/useBonusPoints.test.ts
@@ -103,7 +103,7 @@ describe('useBonusPoints — successful fetch', () => {
     authenticatedUser('bob')
     mockFetchBonus({ login: 'bob', total_bonus_points: 150, entries: [] })
     const { result } = renderHook(() => useBonusPoints())
-    await waitFor(() => !result.current.isBonusLoading)
+    await waitFor(() => expect(result.current.isBonusLoading).toBe(false))
     expect(result.current.bonusPoints).toBe(150)
   })
 
@@ -112,7 +112,7 @@ describe('useBonusPoints — successful fetch', () => {
     const entries = [{ issue_number: 1, points: 50, reason: 'PR fix', created_at: '2026-01-01', state: 'closed' }]
     mockFetchBonus({ login: 'bob', total_bonus_points: 50, entries })
     const { result } = renderHook(() => useBonusPoints())
-    await waitFor(() => !result.current.isBonusLoading)
+    await waitFor(() => expect(result.current.isBonusLoading).toBe(false))
     expect(result.current.bonusEntries).toHaveLength(1)
   })
 
@@ -120,7 +120,7 @@ describe('useBonusPoints — successful fetch', () => {
     authenticatedUser('alice')
     mockFetchBonus({ login: 'alice', total_bonus_points: 75, entries: [] })
     renderHook(() => useBonusPoints())
-    await waitFor(() => localStorage.getItem(`${CACHE_KEY_PREFIX}:alice`) !== null)
+    await waitFor(() => expect(localStorage.getItem(`${CACHE_KEY_PREFIX}:alice`)).not.toBeNull())
     const cached = JSON.parse(localStorage.getItem(`${CACHE_KEY_PREFIX}:alice`)!)
     expect(cached.data.total_bonus_points).toBe(75)
   })
@@ -158,7 +158,7 @@ describe('useBonusPoints — error handling', () => {
     authenticatedUser('eve')
     globalThis.fetch = vi.fn().mockResolvedValue({ ok: false, status: 404 })
     const { result } = renderHook(() => useBonusPoints())
-    await waitFor(() => !result.current.isBonusLoading)
+    await waitFor(() => expect(result.current.isBonusLoading).toBe(false))
     expect(result.current.bonusPoints).toBe(0)
     expect(result.current.bonusEntries).toHaveLength(0)
   })
@@ -167,7 +167,7 @@ describe('useBonusPoints — error handling', () => {
     authenticatedUser('frank')
     globalThis.fetch = vi.fn().mockResolvedValue({ ok: false, status: 500 })
     const { result } = renderHook(() => useBonusPoints())
-    await waitFor(() => !result.current.isBonusLoading)
+    await waitFor(() => expect(result.current.isBonusLoading).toBe(false))
     expect(result.current.bonusPoints).toBe(0)
   })
 
@@ -175,7 +175,7 @@ describe('useBonusPoints — error handling', () => {
     authenticatedUser('grace')
     globalThis.fetch = vi.fn().mockRejectedValue(new Error('Network error'))
     const { result } = renderHook(() => useBonusPoints())
-    await waitFor(() => !result.current.isBonusLoading)
+    await waitFor(() => expect(result.current.isBonusLoading).toBe(false))
     expect(result.current.bonusPoints).toBe(0)
   })
 
@@ -187,7 +187,7 @@ describe('useBonusPoints — error handling', () => {
       json: async () => { throw new Error('bad json') },
     })
     const { result } = renderHook(() => useBonusPoints())
-    await waitFor(() => !result.current.isBonusLoading)
+    await waitFor(() => expect(result.current.isBonusLoading).toBe(false))
     expect(result.current.bonusPoints).toBe(0)
   })
 })

--- a/web/src/hooks/__tests__/useGatewayStatus.test.ts
+++ b/web/src/hooks/__tests__/useGatewayStatus.test.ts
@@ -137,7 +137,7 @@ describe('useGatewayStatus — successful API response', () => {
   it('populates gateways from API response', async () => {
     mockFetchOk([makeGateway('prod-gw', 'prod')])
     const { result } = renderHook(() => useGatewayStatus())
-    await waitFor(() => !result.current.isLoading)
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
     expect(result.current.gateways).toHaveLength(1)
     expect(result.current.gateways[0].name).toBe('prod-gw')
   })
@@ -145,28 +145,28 @@ describe('useGatewayStatus — successful API response', () => {
   it('sets isDemoData=false on successful fetch', async () => {
     mockFetchOk([makeGateway()])
     const { result } = renderHook(() => useGatewayStatus())
-    await waitFor(() => !result.current.isLoading)
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
     expect(result.current.isDemoData).toBe(false)
   })
 
   it('sets consecutiveFailures=0 on success', async () => {
     mockFetchOk([makeGateway()])
     const { result } = renderHook(() => useGatewayStatus())
-    await waitFor(() => !result.current.isLoading)
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
     expect(result.current.consecutiveFailures).toBe(0)
   })
 
   it('sets lastRefresh to a number on success', async () => {
     mockFetchOk([makeGateway()])
     const { result } = renderHook(() => useGatewayStatus())
-    await waitFor(() => !result.current.isLoading)
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
     expect(typeof result.current.lastRefresh).toBe('number')
   })
 
   it('saves result to localStorage cache', async () => {
     mockFetchOk([makeGateway()])
     renderHook(() => useGatewayStatus())
-    await waitFor(() => localStorage.getItem(CACHE_KEY) !== null)
+    await waitFor(() => expect(localStorage.getItem(CACHE_KEY)).not.toBeNull())
     const cached = JSON.parse(localStorage.getItem(CACHE_KEY)!)
     expect(cached.isDemoData).toBe(false)
     expect(cached.data).toHaveLength(1)
@@ -175,7 +175,7 @@ describe('useGatewayStatus — successful API response', () => {
   it('handles empty items array (no gateways configured)', async () => {
     mockFetchOk([])
     const { result } = renderHook(() => useGatewayStatus())
-    await waitFor(() => !result.current.isLoading)
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
     expect(result.current.gateways).toHaveLength(0)
     expect(result.current.isDemoData).toBe(false)
   })
@@ -183,7 +183,7 @@ describe('useGatewayStatus — successful API response', () => {
   it('isFailed is false after success', async () => {
     mockFetchOk([makeGateway()])
     const { result } = renderHook(() => useGatewayStatus())
-    await waitFor(() => !result.current.isLoading)
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
     expect(result.current.isFailed).toBe(false)
   })
 })
@@ -192,7 +192,7 @@ describe('useGatewayStatus — error fallback (demo data)', () => {
   it('falls back to demo data on 503 response', async () => {
     mockFetch503()
     const { result } = renderHook(() => useGatewayStatus())
-    await waitFor(() => !result.current.isLoading)
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
     expect(result.current.isDemoData).toBe(true)
     expect(result.current.gateways.length).toBeGreaterThan(0)
   })
@@ -200,21 +200,21 @@ describe('useGatewayStatus — error fallback (demo data)', () => {
   it('falls back to demo data on network error', async () => {
     mockFetchError('Network error')
     const { result } = renderHook(() => useGatewayStatus())
-    await waitFor(() => !result.current.isLoading)
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
     expect(result.current.isDemoData).toBe(true)
   })
 
   it('falls back to demo data on non-503 HTTP error', async () => {
     mockFetchHttpError(500)
     const { result } = renderHook(() => useGatewayStatus())
-    await waitFor(() => !result.current.isLoading)
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
     expect(result.current.isDemoData).toBe(true)
   })
 
   it('increments consecutiveFailures on error', async () => {
     mockFetchError()
     const { result } = renderHook(() => useGatewayStatus())
-    await waitFor(() => !result.current.isLoading)
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
     expect(result.current.consecutiveFailures).toBe(1)
   })
 
@@ -222,7 +222,7 @@ describe('useGatewayStatus — error fallback (demo data)', () => {
     mockClusters.mockReturnValue([{ name: 'my-cluster', reachable: true }])
     mockFetchError()
     const { result } = renderHook(() => useGatewayStatus())
-    await waitFor(() => !result.current.isLoading)
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
     const clusterGateways = result.current.gateways.filter(gw => gw.cluster === 'my-cluster')
     expect(clusterGateways.length).toBeGreaterThan(0)
   })
@@ -231,7 +231,7 @@ describe('useGatewayStatus — error fallback (demo data)', () => {
     mockClusters.mockReturnValue([])
     mockFetchError()
     const { result } = renderHook(() => useGatewayStatus())
-    await waitFor(() => !result.current.isLoading)
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
     const clusterNames = new Set(result.current.gateways.map(gw => gw.cluster))
     expect(clusterNames.size).toBeGreaterThan(0)
   })
@@ -239,7 +239,7 @@ describe('useGatewayStatus — error fallback (demo data)', () => {
   it('saves demo data to cache on fallback', async () => {
     mockFetchError()
     renderHook(() => useGatewayStatus())
-    await waitFor(() => localStorage.getItem(CACHE_KEY) !== null)
+    await waitFor(() => expect(localStorage.getItem(CACHE_KEY)).not.toBeNull())
     const cached = JSON.parse(localStorage.getItem(CACHE_KEY)!)
     expect(cached.isDemoData).toBe(true)
   })
@@ -247,7 +247,7 @@ describe('useGatewayStatus — error fallback (demo data)', () => {
   it('isFailed becomes true after 3 consecutive failures', async () => {
     mockFetchError()
     const { result } = renderHook(() => useGatewayStatus())
-    await waitFor(() => !result.current.isLoading)
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
     expect(result.current.consecutiveFailures).toBe(1)
     expect(result.current.isFailed).toBe(false)
   })
@@ -307,7 +307,7 @@ describe('useGatewayStatus — refetch registration', () => {
   it('registers with modeTransition.registerRefetch on mount', async () => {
     mockFetchOk([])
     renderHook(() => useGatewayStatus())
-    await waitFor(() => mockRegisterRefetch.mock.calls.length > 0)
+    await waitFor(() => expect(mockRegisterRefetch.mock.calls.length).toBeGreaterThan(0))
     expect(mockRegisterRefetch).toHaveBeenCalledWith('gateway-status', expect.any(Function))
   })
 
@@ -316,7 +316,7 @@ describe('useGatewayStatus — refetch registration', () => {
     mockRegisterRefetch.mockReturnValue(mockCleanup)
     mockFetchOk([])
     const { unmount } = renderHook(() => useGatewayStatus())
-    await waitFor(() => mockRegisterRefetch.mock.calls.length > 0)
+    await waitFor(() => expect(mockRegisterRefetch.mock.calls.length).toBeGreaterThan(0))
     unmount()
     expect(mockCleanup).toHaveBeenCalled()
   })
@@ -327,7 +327,7 @@ describe('useGatewayStatus — auth headers', () => {
     localStorage.setItem('kc-auth-token', 'my-token')
     mockFetchOk([])
     renderHook(() => useGatewayStatus())
-    await waitFor(() => (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls.length > 0)
+    await waitFor(() => expect((globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls.length).toBeGreaterThan(0))
     const [, options] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0]
     expect(options?.headers?.['Authorization']).toBe('Bearer my-token')
   })
@@ -336,7 +336,7 @@ describe('useGatewayStatus — auth headers', () => {
     localStorage.removeItem('kc-auth-token')
     mockFetchOk([])
     renderHook(() => useGatewayStatus())
-    await waitFor(() => (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls.length > 0)
+    await waitFor(() => expect((globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls.length).toBeGreaterThan(0))
     const [, options] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0]
     expect(options?.headers?.['Authorization']).toBeUndefined()
   })
@@ -354,7 +354,7 @@ describe('useGatewayStatus — clustersLoading', () => {
     mockClustersLoading.mockReturnValue(false)
     mockFetchOk([])
     renderHook(() => useGatewayStatus())
-    await waitFor(() => (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls.length > 0)
+    await waitFor(() => expect((globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls.length).toBeGreaterThan(0))
     expect(globalThis.fetch).toHaveBeenCalled()
   })
 })

--- a/web/src/hooks/__tests__/useIntoto-hook.test.tsx
+++ b/web/src/hooks/__tests__/useIntoto-hook.test.tsx
@@ -83,7 +83,7 @@ describe('useIntoto — demo mode', () => {
   it('returns isDemoData=true in demo mode', async () => {
     mockIsDemoMode.mockReturnValue(true)
     const { result } = renderHook(() => useIntoto())
-    await waitFor(() => !result.current.isLoading)
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
     expect(result.current.isDemoData).toBe(true)
   })
 
@@ -91,7 +91,7 @@ describe('useIntoto — demo mode', () => {
     mockIsDemoMode.mockReturnValue(true)
     mockClusters.mockReturnValue([])
     const { result } = renderHook(() => useIntoto())
-    await waitFor(() => !result.current.isLoading)
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
     expect(Object.keys(result.current.statuses)).toHaveLength(3)
     expect(result.current.statuses['us-east-1']).toBeDefined()
     expect(result.current.statuses['eu-central-1']).toBeDefined()
@@ -102,7 +102,7 @@ describe('useIntoto — demo mode', () => {
     mockIsDemoMode.mockReturnValue(true)
     mockClusters.mockReturnValue(['prod-cluster', 'staging-cluster'])
     const { result } = renderHook(() => useIntoto())
-    await waitFor(() => !result.current.isLoading)
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
     expect(result.current.statuses['prod-cluster']).toBeDefined()
     expect(result.current.statuses['staging-cluster']).toBeDefined()
   })
@@ -110,7 +110,7 @@ describe('useIntoto — demo mode', () => {
   it('demo statuses have installed=true and no error', async () => {
     mockIsDemoMode.mockReturnValue(true)
     const { result } = renderHook(() => useIntoto())
-    await waitFor(() => !result.current.isLoading)
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
     const statuses = Object.values(result.current.statuses)
     expect(statuses.every(s => s.installed)).toBe(true)
     expect(statuses.every(s => !s.error)).toBe(true)
@@ -119,14 +119,14 @@ describe('useIntoto — demo mode', () => {
   it('sets clustersChecked to number of demo clusters', async () => {
     mockIsDemoMode.mockReturnValue(true)
     const { result } = renderHook(() => useIntoto())
-    await waitFor(() => !result.current.isLoading)
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
     expect(result.current.clustersChecked).toBe(3)
   })
 
   it('sets lastRefresh to a Date in demo mode', async () => {
     mockIsDemoMode.mockReturnValue(true)
     const { result } = renderHook(() => useIntoto())
-    await waitFor(() => !result.current.isLoading)
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
     expect(result.current.lastRefresh).toBeInstanceOf(Date)
   })
 
@@ -140,7 +140,7 @@ describe('useIntoto — demo mode', () => {
   it('installed=true when demo statuses are populated', async () => {
     mockIsDemoMode.mockReturnValue(true)
     const { result } = renderHook(() => useIntoto())
-    await waitFor(() => !result.current.isLoading)
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
     expect(result.current.installed).toBe(true)
   })
 })
@@ -155,7 +155,7 @@ describe('useIntoto — no clusters', () => {
     mockClusters.mockReturnValue([])
     mockClustersLoading.mockReturnValue(false)
     const { result } = renderHook(() => useIntoto())
-    await waitFor(() => !result.current.isLoading)
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
     expect(result.current.isLoading).toBe(false)
   })
 
@@ -164,26 +164,26 @@ describe('useIntoto — no clusters', () => {
     mockClusters.mockReturnValue([])
     mockClustersLoading.mockReturnValue(false)
     const { result } = renderHook(() => useIntoto())
-    await waitFor(() => !result.current.isLoading)
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
     expect(result.current.statuses).toEqual({})
     expect(result.current.installed).toBe(false)
   })
 
   it('totalClusters is 0 when no clusters', async () => {
     const { result } = renderHook(() => useIntoto())
-    await waitFor(() => !result.current.isLoading)
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
     expect(result.current.totalClusters).toBe(0)
   })
 
   it('hasErrors is false when no clusters', async () => {
     const { result } = renderHook(() => useIntoto())
-    await waitFor(() => !result.current.isLoading)
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
     expect(result.current.hasErrors).toBe(false)
   })
 
   it('isFailed is false initially', async () => {
     const { result } = renderHook(() => useIntoto())
-    await waitFor(() => !result.current.isLoading)
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
     expect(result.current.isFailed).toBe(false)
   })
 })
@@ -200,7 +200,7 @@ describe('useIntoto — cluster fetch: CRD not installed', () => {
       Promise.all(tasks.map(t => t().then(v => ({ status: 'fulfilled' as const, value: v }))))
     )
     const { result } = renderHook(() => useIntoto())
-    await waitFor(() => !result.current.isLoading)
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
     expect(result.current.statuses['cluster-a']?.installed).toBe(false)
   })
 })
@@ -239,20 +239,20 @@ describe('useIntoto — cluster fetch: CRD installed', () => {
 
   it('marks cluster as installed when CRD found and layouts fetched', async () => {
     const { result } = renderHook(() => useIntoto())
-    await waitFor(() => !result.current.isLoading)
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
     expect(result.current.statuses['cluster-b']?.installed).toBe(true)
   })
 
   it('populates layouts from API response', async () => {
     const { result } = renderHook(() => useIntoto())
-    await waitFor(() => !result.current.isLoading)
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
     expect(result.current.statuses['cluster-b']?.layouts).toHaveLength(1)
     expect(result.current.statuses['cluster-b']?.layouts[0].name).toBe('build-layout')
   })
 
   it('steps are mapped from spec.steps', async () => {
     const { result } = renderHook(() => useIntoto())
-    await waitFor(() => !result.current.isLoading)
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
     const steps = result.current.statuses['cluster-b']?.layouts[0].steps ?? []
     expect(steps).toHaveLength(2)
     expect(steps[0].name).toBe('clone')
@@ -261,20 +261,20 @@ describe('useIntoto — cluster fetch: CRD installed', () => {
 
   it('steps with no pubkeys show unknown functionary', async () => {
     const { result } = renderHook(() => useIntoto())
-    await waitFor(() => !result.current.isLoading)
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
     const steps = result.current.statuses['cluster-b']?.layouts[0].steps ?? []
     expect(steps[1].functionary).toBe('unknown')
   })
 
   it('installed is true when at least one cluster is installed', async () => {
     const { result } = renderHook(() => useIntoto())
-    await waitFor(() => !result.current.isLoading)
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
     expect(result.current.installed).toBe(true)
   })
 
   it('saves result to localStorage cache', async () => {
     renderHook(() => useIntoto())
-    await waitFor(() => localStorage.getItem('kc-intoto-cache') !== null)
+    await waitFor(() => expect(localStorage.getItem('kc-intoto-cache')).not.toBeNull())
     const cached = localStorage.getItem('kc-intoto-cache')
     expect(cached).toBeTruthy()
   })
@@ -315,7 +315,7 @@ describe('useIntoto — link verification', () => {
     )
 
     const { result } = renderHook(() => useIntoto())
-    await waitFor(() => !result.current.isLoading)
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
     const step = result.current.statuses['c1']?.layouts[0]?.steps[0]
     expect(step?.status).toBe('verified')
   })
@@ -334,7 +334,7 @@ describe('useIntoto — cluster fetch: errors', () => {
     )
 
     const { result } = renderHook(() => useIntoto())
-    await waitFor(() => !result.current.isLoading)
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
     expect(result.current.statuses['bad-cluster']?.error).toBeTruthy()
   })
 
@@ -346,7 +346,7 @@ describe('useIntoto — cluster fetch: errors', () => {
     )
 
     const { result } = renderHook(() => useIntoto())
-    await waitFor(() => !result.current.isLoading)
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
     expect(result.current.hasErrors).toBe(true)
   })
 
@@ -358,7 +358,7 @@ describe('useIntoto — cluster fetch: errors', () => {
     )
 
     const { result } = renderHook(() => useIntoto())
-    await waitFor(() => !result.current.isLoading)
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
     expect(result.current.consecutiveFailures).toBeGreaterThan(0)
   })
 })
@@ -370,19 +370,19 @@ describe('useIntoto — cluster fetch: errors', () => {
 describe('useIntoto — mode transition', () => {
   it('registers a cache reset handler on mount', async () => {
     renderHook(() => useIntoto())
-    await waitFor(() => mockRegisterCacheReset.mock.calls.length > 0)
+    await waitFor(() => expect(mockRegisterCacheReset.mock.calls.length).toBeGreaterThan(0))
     expect(mockRegisterCacheReset).toHaveBeenCalledWith('intoto', expect.any(Function))
   })
 
   it('registers a refetch handler on mount', async () => {
     renderHook(() => useIntoto())
-    await waitFor(() => mockRegisterRefetch.mock.calls.length > 0)
+    await waitFor(() => expect(mockRegisterRefetch.mock.calls.length).toBeGreaterThan(0))
     expect(mockRegisterRefetch).toHaveBeenCalledWith('intoto', expect.any(Function))
   })
 
   it('unregisters cache reset on unmount', async () => {
     const { unmount } = renderHook(() => useIntoto())
-    await waitFor(() => mockRegisterCacheReset.mock.calls.length > 0)
+    await waitFor(() => expect(mockRegisterCacheReset.mock.calls.length).toBeGreaterThan(0))
     unmount()
     expect(mockUnregisterCacheReset).toHaveBeenCalledWith('intoto')
   })
@@ -390,7 +390,7 @@ describe('useIntoto — mode transition', () => {
   it('cache reset handler clears statuses', async () => {
     mockIsDemoMode.mockReturnValue(true)
     const { result } = renderHook(() => useIntoto())
-    await waitFor(() => !result.current.isLoading)
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
     expect(Object.keys(result.current.statuses).length).toBeGreaterThan(0)
 
     const cacheResetCall = mockRegisterCacheReset.mock.calls.find(

--- a/web/src/hooks/__tests__/useServiceImportsCard.test.ts
+++ b/web/src/hooks/__tests__/useServiceImportsCard.test.ts
@@ -130,21 +130,21 @@ describe('useServiceImportsCard — successful API response', () => {
   it('populates imports from API response', async () => {
     mockFetchOk([makeServiceImport('my-svc')])
     const { result } = renderHook(() => useServiceImportsCard())
-    await waitFor(() => !result.current.isLoading)
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
     expect(result.current.imports).toHaveLength(1)
   })
 
   it('sets isDemoData=false on successful fetch', async () => {
     mockFetchOk([makeServiceImport()])
     const { result } = renderHook(() => useServiceImportsCard())
-    await waitFor(() => !result.current.isLoading)
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
     expect(result.current.isDemoData).toBe(false)
   })
 
   it('handles empty items array legitimately', async () => {
     mockFetchOk([])
     const { result } = renderHook(() => useServiceImportsCard())
-    await waitFor(() => !result.current.isLoading)
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
     expect(result.current.imports).toHaveLength(0)
     expect(result.current.isDemoData).toBe(false)
   })
@@ -152,21 +152,21 @@ describe('useServiceImportsCard — successful API response', () => {
   it('sets consecutiveFailures=0 on success', async () => {
     mockFetchOk()
     const { result } = renderHook(() => useServiceImportsCard())
-    await waitFor(() => !result.current.isLoading)
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
     expect(result.current.consecutiveFailures).toBe(0)
   })
 
   it('sets lastRefresh to a number on success', async () => {
     mockFetchOk()
     const { result } = renderHook(() => useServiceImportsCard())
-    await waitFor(() => !result.current.isLoading)
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
     expect(typeof result.current.lastRefresh).toBe('number')
   })
 
   it('saves to localStorage cache on success', async () => {
     mockFetchOk([makeServiceImport()])
     renderHook(() => useServiceImportsCard())
-    await waitFor(() => localStorage.getItem(CACHE_KEY) !== null)
+    await waitFor(() => expect(localStorage.getItem(CACHE_KEY)).not.toBeNull())
     const cached = JSON.parse(localStorage.getItem(CACHE_KEY)!)
     expect(cached.isDemoData).toBe(false)
   })
@@ -174,7 +174,7 @@ describe('useServiceImportsCard — successful API response', () => {
   it('isFailed=false on success', async () => {
     mockFetchOk()
     const { result } = renderHook(() => useServiceImportsCard())
-    await waitFor(() => !result.current.isLoading)
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
     expect(result.current.isFailed).toBe(false)
   })
 })
@@ -183,7 +183,7 @@ describe('useServiceImportsCard — error fallback', () => {
   it('falls back to demo data on 503 response', async () => {
     mockFetch503()
     const { result } = renderHook(() => useServiceImportsCard())
-    await waitFor(() => !result.current.isLoading)
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
     expect(result.current.isDemoData).toBe(true)
     expect(result.current.imports.length).toBeGreaterThan(0)
   })
@@ -191,21 +191,21 @@ describe('useServiceImportsCard — error fallback', () => {
   it('falls back to demo data on network error', async () => {
     mockFetchError()
     const { result } = renderHook(() => useServiceImportsCard())
-    await waitFor(() => !result.current.isLoading)
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
     expect(result.current.isDemoData).toBe(true)
   })
 
   it('falls back to demo data on non-503 HTTP error', async () => {
     mockFetchHttpError(500)
     const { result } = renderHook(() => useServiceImportsCard())
-    await waitFor(() => !result.current.isLoading)
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
     expect(result.current.isDemoData).toBe(true)
   })
 
   it('increments consecutiveFailures on error', async () => {
     mockFetchError()
     const { result } = renderHook(() => useServiceImportsCard())
-    await waitFor(() => !result.current.isLoading)
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
     expect(result.current.consecutiveFailures).toBe(1)
   })
 
@@ -213,7 +213,7 @@ describe('useServiceImportsCard — error fallback', () => {
     mockClusters.mockReturnValue([{ name: 'prod', reachable: true }])
     mockFetchError()
     const { result } = renderHook(() => useServiceImportsCard())
-    await waitFor(() => !result.current.isLoading)
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
     const clusterImports = result.current.imports.filter(
       i => i.metadata?.labels?.['multicluster.kubernetes.io/cluster'] === 'prod'
         || (i.status?.clusters ?? []).some((c: { cluster: string }) => c.cluster === 'prod')
@@ -226,7 +226,7 @@ describe('useServiceImportsCard — error fallback', () => {
   it('saves demo data to cache on fallback', async () => {
     mockFetchError()
     renderHook(() => useServiceImportsCard())
-    await waitFor(() => localStorage.getItem(CACHE_KEY) !== null)
+    await waitFor(() => expect(localStorage.getItem(CACHE_KEY)).not.toBeNull())
     const cached = JSON.parse(localStorage.getItem(CACHE_KEY)!)
     expect(cached.isDemoData).toBe(true)
   })
@@ -279,7 +279,7 @@ describe('useServiceImportsCard — clustersLoading', () => {
     mockClustersLoading.mockReturnValue(false)
     mockFetchOk([])
     renderHook(() => useServiceImportsCard())
-    await waitFor(() => (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls.length > 0)
+    await waitFor(() => expect((globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls.length).toBeGreaterThan(0))
     expect(globalThis.fetch).toHaveBeenCalled()
   })
 })
@@ -289,7 +289,7 @@ describe('useServiceImportsCard — auth headers', () => {
     localStorage.setItem('kc-auth-token', 'test-token')
     mockFetchOk([])
     renderHook(() => useServiceImportsCard())
-    await waitFor(() => (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls.length > 0)
+    await waitFor(() => expect((globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls.length).toBeGreaterThan(0))
     const [, options] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0]
     expect(options?.headers?.['Authorization']).toBe('Bearer test-token')
   })


### PR DESCRIPTION
## Summary

The 13 failing tests from [Coverage Suite run #1186](https://github.com/kubestellar/console/actions/runs/24708090643) are flaky due to a shared anti-pattern in the tests added by PR #9329.

The tests use:
```ts
await waitFor(() => !result.current.isLoading)
```

But `@testing-library/react`'s `waitFor` resolves as soon as the callback does not throw — returning `false` is still "no throw," so `waitFor` returns immediately without actually waiting for the hook to finish loading. When the async `fetch().then(setState)` chain hasn't resolved by the time the assertion runs, tests fail with:

```
expected +0 to be 150 // Object.is equality
expected [] to have a length of 1 but got +0
```

## Fix

Wrap every waiting condition in `expect(...)` so `waitFor` actually retries until the condition is met (or times out). Applied to:

- `src/hooks/__tests__/useBonusPoints.test.ts`
- `src/hooks/__tests__/useGatewayStatus.test.ts`
- `src/hooks/__tests__/useIntoto-hook.test.tsx`
- `src/hooks/__tests__/useServiceImportsCard.test.ts`

Also fixed the same class of bug in localStorage-polling and mock-call-count `waitFor` callbacks in the same files.

Classification: **test update needed** (tests were correct in intent but incorrectly used `waitFor`). The hook source is unchanged — no regressions.

## Test plan

- [x] `npm test -- src/hooks/__tests__/useBonusPoints.test.ts --no-coverage --run` — 14/14 pass
- [x] `npm test -- src/hooks/__tests__/useGatewayStatus.test.ts --no-coverage --run` — 28/28 pass
- [x] `npm test -- src/hooks/__tests__/useServiceImportsCard.test.ts --no-coverage --run` — 22/22 pass
- [x] `npm test -- src/hooks/__tests__/useIntoto-hook.test.tsx --no-coverage --run` — 32/32 pass
- [x] CI Coverage Suite run passes

Fixes #9333