### PR TITLE
fix(tests): resolve 23 Coverage Suite failures from run #1190

### DIFF
--- a/web/src/hooks/__tests__/useBonusPoints.test.ts
+++ b/web/src/hooks/__tests__/useBonusPoints.test.ts
@@ -101,7 +101,9 @@ describe('useBonusPoints — successful fetch', () => {
     authenticatedUser('bob')
     mockFetchBonus({ login: 'bob', total_bonus_points: 150, entries: [] })
     const { result } = renderHook(() => useBonusPoints())
-    await waitFor(() => result.current.bonusPoints === 150)
+    // waitFor only re-polls when the callback throws; a boolean return resolves
+    // immediately via onDone(null, false). Use expect() so it actually waits.
+    await waitFor(() => expect(result.current.bonusPoints).toBe(150))
     expect(result.current.bonusPoints).toBe(150)
   })
 
@@ -110,7 +112,7 @@ describe('useBonusPoints — successful fetch', () => {
     const entries = [{ issue_number: 1, points: 50, reason: 'PR fix', created_at: '2026-01-01', state: 'closed' }]
     mockFetchBonus({ login: 'bob', total_bonus_points: 50, entries })
     const { result } = renderHook(() => useBonusPoints())
-    await waitFor(() => result.current.bonusEntries.length > 0)
+    await waitFor(() => expect(result.current.bonusEntries.length).toBeGreaterThan(0))
     expect(result.current.bonusEntries).toHaveLength(1)
   })
 

--- a/web/src/hooks/__tests__/useCachedGPU.test.ts
+++ b/web/src/hooks/__tests__/useCachedGPU.test.ts
@@ -85,7 +85,9 @@ beforeEach(() => {
 describe('useCachedGPUNodes', () => {
   it('exposes gpuNodes and standard cache fields', () => {
     const { result } = renderHook(() => useCachedGPUNodes())
-    expect(result.current).toHaveProperty('gpuNodes')
+    // Hook exposes `nodes` (matches backend /api/mcp/gpu-nodes response shape),
+    // not `gpuNodes`. See useCachedGPU.ts useCachedGPUNodes().
+    expect(result.current).toHaveProperty('nodes')
     expect(result.current).toHaveProperty('isLoading')
     expect(result.current).toHaveProperty('isDemoFallback')
     expect(result.current).toHaveProperty('refetch')
@@ -95,7 +97,7 @@ describe('useCachedGPUNodes', () => {
     const nodes = [{ name: 'gpu-0', cluster: 'c1', gpuCount: 4 }]
     mockUseCache.mockReturnValue(defaultCache({ data: nodes }))
     const { result } = renderHook(() => useCachedGPUNodes())
-    expect(result.current.gpuNodes).toEqual(nodes)
+    expect(result.current.nodes).toEqual(nodes)
   })
 
   it('uses cluster in cache key when provided', () => {
@@ -117,8 +119,10 @@ describe('useCachedGPUNodes', () => {
 describe('useCachedGPUNodeHealth', () => {
   it('exposes healthStatuses field', () => {
     const { result } = renderHook(() => useCachedGPUNodeHealth())
-    expect(result.current).toHaveProperty('healthStatuses')
-    expect(Array.isArray(result.current.healthStatuses)).toBe(true)
+    // Hook exposes `nodes` (matches backend /api/mcp/gpu-nodes/health response
+    // shape), not `healthStatuses`. See useCachedGPU.ts useCachedGPUNodeHealth().
+    expect(result.current).toHaveProperty('nodes')
+    expect(Array.isArray(result.current.nodes)).toBe(true)
   })
 
   it('cluster key included when cluster provided', () => {

--- a/web/src/hooks/__tests__/useGatewayStatus.test.ts
+++ b/web/src/hooks/__tests__/useGatewayStatus.test.ts
@@ -129,7 +129,9 @@ describe('useGatewayStatus — successful API response', () => {
   it('populates gateways from API response', async () => {
     mockFetchOk([makeGateway('prod-gw', 'prod')])
     const { result } = renderHook(() => useGatewayStatus())
-    await waitFor(() => result.current.gateways.length > 0)
+    // waitFor only re-polls when the callback throws; a boolean return resolves
+    // immediately via onDone(null, false). Use expect() so it actually waits.
+    await waitFor(() => expect(result.current.gateways.length).toBeGreaterThan(0))
     expect(result.current.gateways).toHaveLength(1)
     expect(result.current.gateways[0].name).toBe('prod-gw')
   })
@@ -137,28 +139,28 @@ describe('useGatewayStatus — successful API response', () => {
   it('sets isDemoData=false on successful fetch', async () => {
     mockFetchOk([makeGateway()])
     const { result } = renderHook(() => useGatewayStatus())
-    await waitFor(() => result.current.isDemoData === false)
+    await waitFor(() => expect(result.current.isDemoData).toBe(false))
     expect(result.current.isDemoData).toBe(false)
   })
 
   it('sets consecutiveFailures=0 on success', async () => {
     mockFetchOk([makeGateway()])
     const { result } = renderHook(() => useGatewayStatus())
-    await waitFor(() => !result.current.isLoading)
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
     expect(result.current.consecutiveFailures).toBe(0)
   })
 
   it('sets lastRefresh to a number on success', async () => {
     mockFetchOk([makeGateway()])
     const { result } = renderHook(() => useGatewayStatus())
-    await waitFor(() => !result.current.isLoading)
+    await waitFor(() => expect(typeof result.current.lastRefresh).toBe('number'))
     expect(typeof result.current.lastRefresh).toBe('number')
   })
 
   it('saves result to localStorage cache', async () => {
     mockFetchOk([makeGateway()])
     renderHook(() => useGatewayStatus())
-    await waitFor(() => localStorage.getItem(CACHE_KEY) !== null)
+    await waitFor(() => expect(localStorage.getItem(CACHE_KEY)).not.toBeNull())
     const cached = JSON.parse(localStorage.getItem(CACHE_KEY)!)
     expect(cached.isDemoData).toBe(false)
     expect(cached.data).toHaveLength(1)
@@ -167,7 +169,7 @@ describe('useGatewayStatus — successful API response', () => {
   it('handles empty items array (no gateways configured)', async () => {
     mockFetchOk([])
     const { result } = renderHook(() => useGatewayStatus())
-    await waitFor(() => !result.current.isLoading)
+    await waitFor(() => expect(result.current.isDemoData).toBe(false))
     expect(result.current.gateways).toHaveLength(0)
     expect(result.current.isDemoData).toBe(false)
   })
@@ -175,7 +177,7 @@ describe('useGatewayStatus — successful API response', () => {
   it('isFailed is false after success', async () => {
     mockFetchOk([makeGateway()])
     const { result } = renderHook(() => useGatewayStatus())
-    await waitFor(() => !result.current.isLoading)
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
     expect(result.current.isFailed).toBe(false)
   })
 })
@@ -183,8 +185,9 @@ describe('useGatewayStatus — successful API response', () => {
 describe('useGatewayStatus — error fallback (demo data)', () => {
   it('falls back to demo data on 503 response', async () => {
     mockFetch503()
+    mockUseClusters.mockReturnValue({ deduplicatedClusters: [{ name: 'c1', reachable: true }], isLoading: false })
     const { result } = renderHook(() => useGatewayStatus())
-    await waitFor(() => !result.current.isLoading)
+    await waitFor(() => expect(result.current.gateways.length).toBeGreaterThan(0))
     expect(result.current.isDemoData).toBe(true)
     expect(result.current.gateways.length).toBeGreaterThan(0)
   })
@@ -192,21 +195,21 @@ describe('useGatewayStatus — error fallback (demo data)', () => {
   it('falls back to demo data on network error', async () => {
     mockFetchError('Network error')
     const { result } = renderHook(() => useGatewayStatus())
-    await waitFor(() => !result.current.isLoading)
+    await waitFor(() => expect(result.current.consecutiveFailures).toBeGreaterThan(0))
     expect(result.current.isDemoData).toBe(true)
   })
 
   it('falls back to demo data on non-503 HTTP error', async () => {
     mockFetchHttpError(500)
     const { result } = renderHook(() => useGatewayStatus())
-    await waitFor(() => !result.current.isLoading)
+    await waitFor(() => expect(result.current.consecutiveFailures).toBeGreaterThan(0))
     expect(result.current.isDemoData).toBe(true)
   })
 
   it('increments consecutiveFailures on error', async () => {
     mockFetchError()
     const { result } = renderHook(() => useGatewayStatus())
-    await waitFor(() => result.current.consecutiveFailures > 0)
+    await waitFor(() => expect(result.current.consecutiveFailures).toBeGreaterThan(0))
     expect(result.current.consecutiveFailures).toBe(1)
   })
 
@@ -214,7 +217,7 @@ describe('useGatewayStatus — error fallback (demo data)', () => {
     mockUseClusters.mockReturnValue({ deduplicatedClusters: [{ name: 'my-cluster', reachable: true }], isLoading: false })
     mockFetchError()
     const { result } = renderHook(() => useGatewayStatus())
-    await waitFor(() => result.current.gateways.length > 0)
+    await waitFor(() => expect(result.current.gateways.length).toBeGreaterThan(0))
     const clusterGateways = result.current.gateways.filter(gw => gw.cluster === 'my-cluster')
     expect(clusterGateways.length).toBeGreaterThan(0)
   })
@@ -223,7 +226,7 @@ describe('useGatewayStatus — error fallback (demo data)', () => {
     mockUseClusters.mockReturnValue({ deduplicatedClusters: [], isLoading: false })
     mockFetchError()
     const { result } = renderHook(() => useGatewayStatus())
-    await waitFor(() => result.current.gateways.length > 0)
+    await waitFor(() => expect(result.current.gateways.length).toBeGreaterThan(0))
     const clusterNames = new Set(result.current.gateways.map(gw => gw.cluster))
     expect(clusterNames.size).toBeGreaterThan(0)
   })
@@ -231,7 +234,7 @@ describe('useGatewayStatus — error fallback (demo data)', () => {
   it('saves demo data to cache on fallback', async () => {
     mockFetchError()
     renderHook(() => useGatewayStatus())
-    await waitFor(() => localStorage.getItem(CACHE_KEY) !== null)
+    await waitFor(() => expect(localStorage.getItem(CACHE_KEY)).not.toBeNull())
     const cached = JSON.parse(localStorage.getItem(CACHE_KEY)!)
     expect(cached.isDemoData).toBe(true)
   })
@@ -239,7 +242,7 @@ describe('useGatewayStatus — error fallback (demo data)', () => {
   it('isFailed becomes true after 3 consecutive failures', async () => {
     mockFetchError()
     const { result } = renderHook(() => useGatewayStatus())
-    await waitFor(() => !result.current.isLoading)
+    await waitFor(() => expect(result.current.consecutiveFailures).toBeGreaterThan(0))
     expect(result.current.consecutiveFailures).toBe(1)
     expect(result.current.isFailed).toBe(false)
   })

--- a/web/src/hooks/__tests__/useIntoto-hook.test.tsx
+++ b/web/src/hooks/__tests__/useIntoto-hook.test.tsx
@@ -192,7 +192,7 @@ describe('useIntoto — cluster fetch: CRD not installed', () => {
       Promise.all(tasks.map(t => t().then(v => ({ status: 'fulfilled' as const, value: v }))))
     )
     const { result } = renderHook(() => useIntoto())
-    await waitFor(() => result.current.statuses['cluster-a'] !== undefined)
+    await waitFor(() => expect(result.current.statuses['cluster-a']).toBeDefined())
     expect(result.current.statuses['cluster-a']?.installed).toBe(false)
   })
 })
@@ -231,20 +231,26 @@ describe('useIntoto — cluster fetch: CRD installed', () => {
 
   it('marks cluster as installed when CRD found and layouts fetched', async () => {
     const { result } = renderHook(() => useIntoto())
-    await waitFor(() => !result.current.isLoading)
+    // waitFor only re-polls when the callback throws; a boolean return resolves
+    // immediately via onDone(null, false). Use expect() so it actually waits.
+    await waitFor(() => expect(result.current.statuses['cluster-b']?.installed).toBe(true))
     expect(result.current.statuses['cluster-b']?.installed).toBe(true)
   })
 
   it('populates layouts from API response', async () => {
     const { result } = renderHook(() => useIntoto())
-    await waitFor(() => !result.current.isLoading)
+    await waitFor(() =>
+      expect(result.current.statuses['cluster-b']?.layouts?.length).toBeGreaterThan(0)
+    )
     expect(result.current.statuses['cluster-b']?.layouts).toHaveLength(1)
     expect(result.current.statuses['cluster-b']?.layouts[0].name).toBe('build-layout')
   })
 
   it('steps are mapped from spec.steps', async () => {
     const { result } = renderHook(() => useIntoto())
-    await waitFor(() => !result.current.isLoading)
+    await waitFor(() =>
+      expect(result.current.statuses['cluster-b']?.layouts[0]?.steps?.length).toBeGreaterThanOrEqual(2)
+    )
     const steps = result.current.statuses['cluster-b']?.layouts[0].steps ?? []
     expect(steps).toHaveLength(2)
     expect(steps[0].name).toBe('clone')
@@ -253,20 +259,22 @@ describe('useIntoto — cluster fetch: CRD installed', () => {
 
   it('steps with no pubkeys show unknown functionary', async () => {
     const { result } = renderHook(() => useIntoto())
-    await waitFor(() => !result.current.isLoading)
+    await waitFor(() =>
+      expect(result.current.statuses['cluster-b']?.layouts[0]?.steps?.length).toBeGreaterThanOrEqual(2)
+    )
     const steps = result.current.statuses['cluster-b']?.layouts[0].steps ?? []
     expect(steps[1].functionary).toBe('unknown')
   })
 
   it('installed is true when at least one cluster is installed', async () => {
     const { result } = renderHook(() => useIntoto())
-    await waitFor(() => result.current.installed === true)
+    await waitFor(() => expect(result.current.installed).toBe(true))
     expect(result.current.installed).toBe(true)
   })
 
   it('saves result to localStorage cache', async () => {
     renderHook(() => useIntoto())
-    await waitFor(() => localStorage.getItem('kc-intoto-cache') !== null)
+    await waitFor(() => expect(localStorage.getItem('kc-intoto-cache')).not.toBeNull())
     const cached = localStorage.getItem('kc-intoto-cache')
     expect(cached).toBeTruthy()
   })
@@ -307,7 +315,7 @@ describe('useIntoto — link verification', () => {
     )
 
     const { result } = renderHook(() => useIntoto())
-    await waitFor(() => !result.current.isLoading)
+    await waitFor(() => expect(result.current.statuses['c1']?.layouts[0]?.steps[0]?.status).toBe('verified'))
     const step = result.current.statuses['c1']?.layouts[0]?.steps[0]
     expect(step?.status).toBe('verified')
   })
@@ -329,7 +337,7 @@ describe('useIntoto — cluster fetch: errors', () => {
     )
 
     const { result } = renderHook(() => useIntoto())
-    await waitFor(() => result.current.statuses['bad-cluster'] !== undefined)
+    await waitFor(() => expect(result.current.statuses['bad-cluster']).toBeDefined())
     expect(result.current.statuses['bad-cluster']?.error).toBeTruthy()
   })
 
@@ -344,7 +352,7 @@ describe('useIntoto — cluster fetch: errors', () => {
     )
 
     const { result } = renderHook(() => useIntoto())
-    await waitFor(() => result.current.statuses['err-cluster'] !== undefined)
+    await waitFor(() => expect(result.current.hasErrors).toBe(true))
     expect(result.current.hasErrors).toBe(true)
   })
 
@@ -359,7 +367,7 @@ describe('useIntoto — cluster fetch: errors', () => {
     )
 
     const { result } = renderHook(() => useIntoto())
-    await waitFor(() => result.current.consecutiveFailures > 0)
+    await waitFor(() => expect(result.current.consecutiveFailures).toBeGreaterThan(0))
     expect(result.current.consecutiveFailures).toBeGreaterThan(0)
   })
 })

--- a/web/src/hooks/__tests__/useServiceImportsCard.test.ts
+++ b/web/src/hooks/__tests__/useServiceImportsCard.test.ts
@@ -123,21 +123,23 @@ describe('useServiceImportsCard — successful API response', () => {
   it('populates imports from API response', async () => {
     mockFetchOk([makeServiceImport('my-svc')])
     const { result } = renderHook(() => useServiceImportsCard())
-    await waitFor(() => result.current.imports.length > 0)
+    // waitFor only re-polls when the callback throws; a boolean return resolves
+    // immediately via onDone(null, false). Use expect() so it actually waits.
+    await waitFor(() => expect(result.current.imports.length).toBeGreaterThan(0))
     expect(result.current.imports).toHaveLength(1)
   })
 
   it('sets isDemoData=false on successful fetch', async () => {
     mockFetchOk([makeServiceImport()])
     const { result } = renderHook(() => useServiceImportsCard())
-    await waitFor(() => result.current.isDemoData === false)
+    await waitFor(() => expect(result.current.isDemoData).toBe(false))
     expect(result.current.isDemoData).toBe(false)
   })
 
   it('handles empty items array legitimately', async () => {
     mockFetchOk([])
     const { result } = renderHook(() => useServiceImportsCard())
-    await waitFor(() => !result.current.isLoading)
+    await waitFor(() => expect(result.current.isDemoData).toBe(false))
     expect(result.current.imports).toHaveLength(0)
     expect(result.current.isDemoData).toBe(false)
   })
@@ -145,21 +147,21 @@ describe('useServiceImportsCard — successful API response', () => {
   it('sets consecutiveFailures=0 on success', async () => {
     mockFetchOk()
     const { result } = renderHook(() => useServiceImportsCard())
-    await waitFor(() => !result.current.isLoading)
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
     expect(result.current.consecutiveFailures).toBe(0)
   })
 
   it('sets lastRefresh to a number on success', async () => {
     mockFetchOk()
     const { result } = renderHook(() => useServiceImportsCard())
-    await waitFor(() => !result.current.isLoading)
+    await waitFor(() => expect(typeof result.current.lastRefresh).toBe('number'))
     expect(typeof result.current.lastRefresh).toBe('number')
   })
 
   it('saves to localStorage cache on success', async () => {
     mockFetchOk([makeServiceImport()])
     renderHook(() => useServiceImportsCard())
-    await waitFor(() => localStorage.getItem(CACHE_KEY) !== null)
+    await waitFor(() => expect(localStorage.getItem(CACHE_KEY)).not.toBeNull())
     const cached = JSON.parse(localStorage.getItem(CACHE_KEY)!)
     expect(cached.isDemoData).toBe(false)
   })
@@ -167,7 +169,7 @@ describe('useServiceImportsCard — successful API response', () => {
   it('isFailed=false on success', async () => {
     mockFetchOk()
     const { result } = renderHook(() => useServiceImportsCard())
-    await waitFor(() => !result.current.isLoading)
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
     expect(result.current.isFailed).toBe(false)
   })
 })
@@ -176,7 +178,7 @@ describe('useServiceImportsCard — error fallback', () => {
   it('falls back to demo data on 503 response', async () => {
     mockFetch503()
     const { result } = renderHook(() => useServiceImportsCard())
-    await waitFor(() => !result.current.isLoading)
+    await waitFor(() => expect(result.current.imports.length).toBeGreaterThan(0))
     expect(result.current.isDemoData).toBe(true)
     expect(result.current.imports.length).toBeGreaterThan(0)
   })
@@ -184,21 +186,21 @@ describe('useServiceImportsCard — error fallback', () => {
   it('falls back to demo data on network error', async () => {
     mockFetchError()
     const { result } = renderHook(() => useServiceImportsCard())
-    await waitFor(() => !result.current.isLoading)
+    await waitFor(() => expect(result.current.consecutiveFailures).toBeGreaterThan(0))
     expect(result.current.isDemoData).toBe(true)
   })
 
   it('falls back to demo data on non-503 HTTP error', async () => {
     mockFetchHttpError(500)
     const { result } = renderHook(() => useServiceImportsCard())
-    await waitFor(() => !result.current.isLoading)
+    await waitFor(() => expect(result.current.consecutiveFailures).toBeGreaterThan(0))
     expect(result.current.isDemoData).toBe(true)
   })
 
   it('increments consecutiveFailures on error', async () => {
     mockFetchError()
     const { result } = renderHook(() => useServiceImportsCard())
-    await waitFor(() => !result.current.isLoading)
+    await waitFor(() => expect(result.current.consecutiveFailures).toBe(1))
     expect(result.current.consecutiveFailures).toBe(1)
   })
 
@@ -206,7 +208,7 @@ describe('useServiceImportsCard — error fallback', () => {
     mockUseClusters.mockReturnValue({ deduplicatedClusters: [{ name: 'prod', reachable: true }], isLoading: false })
     mockFetchError()
     const { result } = renderHook(() => useServiceImportsCard())
-    await waitFor(() => result.current.imports.length > 0)
+    await waitFor(() => expect(result.current.imports.length).toBeGreaterThan(0))
     const clusterImports = result.current.imports.filter(
       i => i.metadata?.labels?.['multicluster.kubernetes.io/cluster'] === 'prod'
         || (i.status?.clusters ?? []).some((c: { cluster: string }) => c.cluster === 'prod')
@@ -219,7 +221,7 @@ describe('useServiceImportsCard — error fallback', () => {
   it('saves demo data to cache on fallback', async () => {
     mockFetchError()
     renderHook(() => useServiceImportsCard())
-    await waitFor(() => localStorage.getItem(CACHE_KEY) !== null)
+    await waitFor(() => expect(localStorage.getItem(CACHE_KEY)).not.toBeNull())
     const cached = JSON.parse(localStorage.getItem(CACHE_KEY)!)
     expect(cached.isDemoData).toBe(true)
   })


### PR DESCRIPTION
## Summary

Follow-up to #9349 which fixed the mock patterns (stubGlobal, stable cluster refs, most field names) but left 12 tests still failing across two categories that the Coverage Suite #1190 report called out:

1. **useCachedGPU alias field names**
   - `useCachedGPUNodes` exposes `nodes` (not `gpuNodes`) — matches the backend `/api/mcp/gpu-nodes` response shape
   - `useCachedGPUNodeHealth` exposes `nodes` (not `healthStatuses`) — matches `/api/mcp/gpu-nodes/health`

2. **waitFor boolean predicates**
   `@testing-library/dom`'s `waitFor` only re-polls when the callback **throws**. A returned boolean resolves immediately via `onDone(null, result)` — so `waitFor(() => result.current.gateways.length > 0)` returns `false` right after render and the subsequent assertion then runs against pre-fetch state and fails. Rewrite as `waitFor(() => expect(result.current.gateways.length).toBeGreaterThan(0))` throughout `useGatewayStatus`, `useServiceImportsCard`, `useIntoto-hook`, and `useBonusPoints` tests. Same fix applied to `waitFor(() => !result.current.isLoading)` and `waitFor(() => localStorage.getItem(X) !== null)`.

## Files touched

- `src/hooks/__tests__/useBonusPoints.test.ts`
- `src/hooks/__tests__/useCachedGPU.test.ts`
- `src/hooks/__tests__/useGatewayStatus.test.ts`
- `src/hooks/__tests__/useIntoto-hook.test.tsx`
- `src/hooks/__tests__/useServiceImportsCard.test.ts`

## Test plan

- [x] All 8 originally-failing test files pass (162/162)
- [x] 10 consecutive full runs of the affected files — all 10 passed (no remaining flakes)

Fixes #9345