### PR TITLE
test(hooks): fix waitFor boolean return anti-pattern

### DIFF
--- a/web/src/hooks/__tests__/useBonusPoints.test.ts
+++ b/web/src/hooks/__tests__/useBonusPoints.test.ts
@@ -101,8 +101,7 @@ describe('useBonusPoints — successful fetch', () => {
     authenticatedUser('bob')
     mockFetchBonus({ login: 'bob', total_bonus_points: 150, entries: [] })
     const { result } = renderHook(() => useBonusPoints())
-    await waitFor(() => result.current.bonusPoints === 150)
-    expect(result.current.bonusPoints).toBe(150)
+    await waitFor(() => expect(result.current.bonusPoints).toBe(150))
   })
 
   it('returns bonus entries from API', async () => {
@@ -110,15 +109,14 @@ describe('useBonusPoints — successful fetch', () => {
     const entries = [{ issue_number: 1, points: 50, reason: 'PR fix', created_at: '2026-01-01', state: 'closed' }]
     mockFetchBonus({ login: 'bob', total_bonus_points: 50, entries })
     const { result } = renderHook(() => useBonusPoints())
-    await waitFor(() => result.current.bonusEntries.length > 0)
-    expect(result.current.bonusEntries).toHaveLength(1)
+    await waitFor(() => expect(result.current.bonusEntries).toHaveLength(1))
   })
 
   it('saves result to localStorage cache', async () => {
     authenticatedUser('alice')
     mockFetchBonus({ login: 'alice', total_bonus_points: 75, entries: [] })
     renderHook(() => useBonusPoints())
-    await waitFor(() => localStorage.getItem(`${CACHE_KEY_PREFIX}:alice`) !== null)
+    await waitFor(() => expect(localStorage.getItem(`${CACHE_KEY_PREFIX}:alice`)).not.toBeNull())
     const cached = JSON.parse(localStorage.getItem(`${CACHE_KEY_PREFIX}:alice`)!)
     expect(cached.data.total_bonus_points).toBe(75)
   })
@@ -156,7 +154,7 @@ describe('useBonusPoints — error handling', () => {
     authenticatedUser('eve')
     vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: false, status: 404 }))
     const { result } = renderHook(() => useBonusPoints())
-    await waitFor(() => !result.current.isBonusLoading)
+    await waitFor(() => expect(result.current.isBonusLoading).toBe(false))
     expect(result.current.bonusPoints).toBe(0)
     expect(result.current.bonusEntries).toHaveLength(0)
   })
@@ -165,7 +163,7 @@ describe('useBonusPoints — error handling', () => {
     authenticatedUser('frank')
     vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: false, status: 500 }))
     const { result } = renderHook(() => useBonusPoints())
-    await waitFor(() => !result.current.isBonusLoading)
+    await waitFor(() => expect(result.current.isBonusLoading).toBe(false))
     expect(result.current.bonusPoints).toBe(0)
   })
 
@@ -173,7 +171,7 @@ describe('useBonusPoints — error handling', () => {
     authenticatedUser('grace')
     vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('Network error')))
     const { result } = renderHook(() => useBonusPoints())
-    await waitFor(() => !result.current.isBonusLoading)
+    await waitFor(() => expect(result.current.isBonusLoading).toBe(false))
     expect(result.current.bonusPoints).toBe(0)
   })
 
@@ -185,7 +183,7 @@ describe('useBonusPoints — error handling', () => {
       json: async () => { throw new Error('bad json') },
     }))
     const { result } = renderHook(() => useBonusPoints())
-    await waitFor(() => !result.current.isBonusLoading)
+    await waitFor(() => expect(result.current.isBonusLoading).toBe(false))
     expect(result.current.bonusPoints).toBe(0)
   })
 })

--- a/web/src/hooks/__tests__/useGatewayStatus.test.ts
+++ b/web/src/hooks/__tests__/useGatewayStatus.test.ts
@@ -129,7 +129,7 @@ describe('useGatewayStatus — successful API response', () => {
   it('populates gateways from API response', async () => {
     mockFetchOk([makeGateway('prod-gw', 'prod')])
     const { result } = renderHook(() => useGatewayStatus())
-    await waitFor(() => result.current.gateways.length > 0)
+    await waitFor(() => expect(result.current.gateways.length).toBeGreaterThan(0))
     expect(result.current.gateways).toHaveLength(1)
     expect(result.current.gateways[0].name).toBe('prod-gw')
   })
@@ -137,28 +137,27 @@ describe('useGatewayStatus — successful API response', () => {
   it('sets isDemoData=false on successful fetch', async () => {
     mockFetchOk([makeGateway()])
     const { result } = renderHook(() => useGatewayStatus())
-    await waitFor(() => result.current.isDemoData === false)
-    expect(result.current.isDemoData).toBe(false)
+    await waitFor(() => expect(result.current.isDemoData).toBe(false))
   })
 
   it('sets consecutiveFailures=0 on success', async () => {
     mockFetchOk([makeGateway()])
     const { result } = renderHook(() => useGatewayStatus())
-    await waitFor(() => !result.current.isLoading)
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
     expect(result.current.consecutiveFailures).toBe(0)
   })
 
   it('sets lastRefresh to a number on success', async () => {
     mockFetchOk([makeGateway()])
     const { result } = renderHook(() => useGatewayStatus())
-    await waitFor(() => !result.current.isLoading)
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
     expect(typeof result.current.lastRefresh).toBe('number')
   })
 
   it('saves result to localStorage cache', async () => {
     mockFetchOk([makeGateway()])
     renderHook(() => useGatewayStatus())
-    await waitFor(() => localStorage.getItem(CACHE_KEY) !== null)
+    await waitFor(() => expect(localStorage.getItem(CACHE_KEY)).not.toBeNull())
     const cached = JSON.parse(localStorage.getItem(CACHE_KEY)!)
     expect(cached.isDemoData).toBe(false)
     expect(cached.data).toHaveLength(1)
@@ -167,7 +166,7 @@ describe('useGatewayStatus — successful API response', () => {
   it('handles empty items array (no gateways configured)', async () => {
     mockFetchOk([])
     const { result } = renderHook(() => useGatewayStatus())
-    await waitFor(() => !result.current.isLoading)
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
     expect(result.current.gateways).toHaveLength(0)
     expect(result.current.isDemoData).toBe(false)
   })
@@ -175,7 +174,7 @@ describe('useGatewayStatus — successful API response', () => {
   it('isFailed is false after success', async () => {
     mockFetchOk([makeGateway()])
     const { result } = renderHook(() => useGatewayStatus())
-    await waitFor(() => !result.current.isLoading)
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
     expect(result.current.isFailed).toBe(false)
   })
 })
@@ -184,7 +183,7 @@ describe('useGatewayStatus — error fallback (demo data)', () => {
   it('falls back to demo data on 503 response', async () => {
     mockFetch503()
     const { result } = renderHook(() => useGatewayStatus())
-    await waitFor(() => !result.current.isLoading)
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
     expect(result.current.isDemoData).toBe(true)
     expect(result.current.gateways.length).toBeGreaterThan(0)
   })
@@ -192,21 +191,21 @@ describe('useGatewayStatus — error fallback (demo data)', () => {
   it('falls back to demo data on network error', async () => {
     mockFetchError('Network error')
     const { result } = renderHook(() => useGatewayStatus())
-    await waitFor(() => !result.current.isLoading)
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
     expect(result.current.isDemoData).toBe(true)
   })
 
   it('falls back to demo data on non-503 HTTP error', async () => {
     mockFetchHttpError(500)
     const { result } = renderHook(() => useGatewayStatus())
-    await waitFor(() => !result.current.isLoading)
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
     expect(result.current.isDemoData).toBe(true)
   })
 
   it('increments consecutiveFailures on error', async () => {
     mockFetchError()
     const { result } = renderHook(() => useGatewayStatus())
-    await waitFor(() => result.current.consecutiveFailures > 0)
+    await waitFor(() => expect(result.current.consecutiveFailures).toBeGreaterThan(0))
     expect(result.current.consecutiveFailures).toBe(1)
   })
 
@@ -214,7 +213,7 @@ describe('useGatewayStatus — error fallback (demo data)', () => {
     mockUseClusters.mockReturnValue({ deduplicatedClusters: [{ name: 'my-cluster', reachable: true }], isLoading: false })
     mockFetchError()
     const { result } = renderHook(() => useGatewayStatus())
-    await waitFor(() => result.current.gateways.length > 0)
+    await waitFor(() => expect(result.current.gateways.length).toBeGreaterThan(0))
     const clusterGateways = result.current.gateways.filter(gw => gw.cluster === 'my-cluster')
     expect(clusterGateways.length).toBeGreaterThan(0)
   })
@@ -223,7 +222,7 @@ describe('useGatewayStatus — error fallback (demo data)', () => {
     mockUseClusters.mockReturnValue({ deduplicatedClusters: [], isLoading: false })
     mockFetchError()
     const { result } = renderHook(() => useGatewayStatus())
-    await waitFor(() => result.current.gateways.length > 0)
+    await waitFor(() => expect(result.current.gateways.length).toBeGreaterThan(0))
     const clusterNames = new Set(result.current.gateways.map(gw => gw.cluster))
     expect(clusterNames.size).toBeGreaterThan(0)
   })
@@ -231,7 +230,7 @@ describe('useGatewayStatus — error fallback (demo data)', () => {
   it('saves demo data to cache on fallback', async () => {
     mockFetchError()
     renderHook(() => useGatewayStatus())
-    await waitFor(() => localStorage.getItem(CACHE_KEY) !== null)
+    await waitFor(() => expect(localStorage.getItem(CACHE_KEY)).not.toBeNull())
     const cached = JSON.parse(localStorage.getItem(CACHE_KEY)!)
     expect(cached.isDemoData).toBe(true)
   })
@@ -239,7 +238,7 @@ describe('useGatewayStatus — error fallback (demo data)', () => {
   it('isFailed becomes true after 3 consecutive failures', async () => {
     mockFetchError()
     const { result } = renderHook(() => useGatewayStatus())
-    await waitFor(() => !result.current.isLoading)
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
     expect(result.current.consecutiveFailures).toBe(1)
     expect(result.current.isFailed).toBe(false)
   })
@@ -299,7 +298,7 @@ describe('useGatewayStatus — refetch registration', () => {
   it('registers with modeTransition.registerRefetch on mount', async () => {
     mockFetchOk([])
     renderHook(() => useGatewayStatus())
-    await waitFor(() => mockRegisterRefetch.mock.calls.length > 0)
+    await waitFor(() => expect(mockRegisterRefetch.mock.calls.length).toBeGreaterThan(0))
     expect(mockRegisterRefetch).toHaveBeenCalledWith('gateway-status', expect.any(Function))
   })
 
@@ -308,7 +307,7 @@ describe('useGatewayStatus — refetch registration', () => {
     mockRegisterRefetch.mockReturnValue(mockCleanup)
     mockFetchOk([])
     const { unmount } = renderHook(() => useGatewayStatus())
-    await waitFor(() => mockRegisterRefetch.mock.calls.length > 0)
+    await waitFor(() => expect(mockRegisterRefetch.mock.calls.length).toBeGreaterThan(0))
     unmount()
     expect(mockCleanup).toHaveBeenCalled()
   })
@@ -319,7 +318,7 @@ describe('useGatewayStatus — auth headers', () => {
     localStorage.setItem('kc-auth-token', 'my-token')
     mockFetchOk([])
     renderHook(() => useGatewayStatus())
-    await waitFor(() => (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls.length > 0)
+    await waitFor(() => expect((globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls.length).toBeGreaterThan(0))
     const [, options] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0]
     expect(options?.headers?.['Authorization']).toBe('Bearer my-token')
   })
@@ -328,7 +327,7 @@ describe('useGatewayStatus — auth headers', () => {
     localStorage.removeItem('kc-auth-token')
     mockFetchOk([])
     renderHook(() => useGatewayStatus())
-    await waitFor(() => (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls.length > 0)
+    await waitFor(() => expect((globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls.length).toBeGreaterThan(0))
     const [, options] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0]
     expect(options?.headers?.['Authorization']).toBeUndefined()
   })
@@ -346,7 +345,7 @@ describe('useGatewayStatus — clustersLoading', () => {
     mockUseClusters.mockReturnValue({ deduplicatedClusters: [], isLoading: false })
     mockFetchOk([])
     renderHook(() => useGatewayStatus())
-    await waitFor(() => (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls.length > 0)
+    await waitFor(() => expect((globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls.length).toBeGreaterThan(0))
     expect(globalThis.fetch).toHaveBeenCalled()
   })
 })

--- a/web/src/hooks/__tests__/useServiceImportsCard.test.ts
+++ b/web/src/hooks/__tests__/useServiceImportsCard.test.ts
@@ -123,21 +123,20 @@ describe('useServiceImportsCard — successful API response', () => {
   it('populates imports from API response', async () => {
     mockFetchOk([makeServiceImport('my-svc')])
     const { result } = renderHook(() => useServiceImportsCard())
-    await waitFor(() => result.current.imports.length > 0)
+    await waitFor(() => expect(result.current.imports.length).toBeGreaterThan(0))
     expect(result.current.imports).toHaveLength(1)
   })
 
   it('sets isDemoData=false on successful fetch', async () => {
     mockFetchOk([makeServiceImport()])
     const { result } = renderHook(() => useServiceImportsCard())
-    await waitFor(() => result.current.isDemoData === false)
-    expect(result.current.isDemoData).toBe(false)
+    await waitFor(() => expect(result.current.isDemoData).toBe(false))
   })
 
   it('handles empty items array legitimately', async () => {
     mockFetchOk([])
     const { result } = renderHook(() => useServiceImportsCard())
-    await waitFor(() => !result.current.isLoading)
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
     expect(result.current.imports).toHaveLength(0)
     expect(result.current.isDemoData).toBe(false)
   })
@@ -145,21 +144,21 @@ describe('useServiceImportsCard — successful API response', () => {
   it('sets consecutiveFailures=0 on success', async () => {
     mockFetchOk()
     const { result } = renderHook(() => useServiceImportsCard())
-    await waitFor(() => !result.current.isLoading)
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
     expect(result.current.consecutiveFailures).toBe(0)
   })
 
   it('sets lastRefresh to a number on success', async () => {
     mockFetchOk()
     const { result } = renderHook(() => useServiceImportsCard())
-    await waitFor(() => !result.current.isLoading)
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
     expect(typeof result.current.lastRefresh).toBe('number')
   })
 
   it('saves to localStorage cache on success', async () => {
     mockFetchOk([makeServiceImport()])
     renderHook(() => useServiceImportsCard())
-    await waitFor(() => localStorage.getItem(CACHE_KEY) !== null)
+    await waitFor(() => expect(localStorage.getItem(CACHE_KEY)).not.toBeNull())
     const cached = JSON.parse(localStorage.getItem(CACHE_KEY)!)
     expect(cached.isDemoData).toBe(false)
   })
@@ -167,7 +166,7 @@ describe('useServiceImportsCard — successful API response', () => {
   it('isFailed=false on success', async () => {
     mockFetchOk()
     const { result } = renderHook(() => useServiceImportsCard())
-    await waitFor(() => !result.current.isLoading)
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
     expect(result.current.isFailed).toBe(false)
   })
 })
@@ -176,7 +175,7 @@ describe('useServiceImportsCard — error fallback', () => {
   it('falls back to demo data on 503 response', async () => {
     mockFetch503()
     const { result } = renderHook(() => useServiceImportsCard())
-    await waitFor(() => !result.current.isLoading)
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
     expect(result.current.isDemoData).toBe(true)
     expect(result.current.imports.length).toBeGreaterThan(0)
   })
@@ -184,21 +183,21 @@ describe('useServiceImportsCard — error fallback', () => {
   it('falls back to demo data on network error', async () => {
     mockFetchError()
     const { result } = renderHook(() => useServiceImportsCard())
-    await waitFor(() => !result.current.isLoading)
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
     expect(result.current.isDemoData).toBe(true)
   })
 
   it('falls back to demo data on non-503 HTTP error', async () => {
     mockFetchHttpError(500)
     const { result } = renderHook(() => useServiceImportsCard())
-    await waitFor(() => !result.current.isLoading)
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
     expect(result.current.isDemoData).toBe(true)
   })
 
   it('increments consecutiveFailures on error', async () => {
     mockFetchError()
     const { result } = renderHook(() => useServiceImportsCard())
-    await waitFor(() => !result.current.isLoading)
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
     expect(result.current.consecutiveFailures).toBe(1)
   })
 
@@ -206,7 +205,7 @@ describe('useServiceImportsCard — error fallback', () => {
     mockUseClusters.mockReturnValue({ deduplicatedClusters: [{ name: 'prod', reachable: true }], isLoading: false })
     mockFetchError()
     const { result } = renderHook(() => useServiceImportsCard())
-    await waitFor(() => result.current.imports.length > 0)
+    await waitFor(() => expect(result.current.imports.length).toBeGreaterThan(0))
     const clusterImports = result.current.imports.filter(
       i => i.metadata?.labels?.['multicluster.kubernetes.io/cluster'] === 'prod'
         || (i.status?.clusters ?? []).some((c: { cluster: string }) => c.cluster === 'prod')
@@ -219,7 +218,7 @@ describe('useServiceImportsCard — error fallback', () => {
   it('saves demo data to cache on fallback', async () => {
     mockFetchError()
     renderHook(() => useServiceImportsCard())
-    await waitFor(() => localStorage.getItem(CACHE_KEY) !== null)
+    await waitFor(() => expect(localStorage.getItem(CACHE_KEY)).not.toBeNull())
     const cached = JSON.parse(localStorage.getItem(CACHE_KEY)!)
     expect(cached.isDemoData).toBe(true)
   })
@@ -272,7 +271,7 @@ describe('useServiceImportsCard — clustersLoading', () => {
     mockUseClusters.mockReturnValue({ deduplicatedClusters: [], isLoading: false })
     mockFetchOk([])
     renderHook(() => useServiceImportsCard())
-    await waitFor(() => (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls.length > 0)
+    await waitFor(() => expect((globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls.length).toBeGreaterThan(0))
     expect(globalThis.fetch).toHaveBeenCalled()
   })
 })
@@ -282,7 +281,7 @@ describe('useServiceImportsCard — auth headers', () => {
     localStorage.setItem('kc-auth-token', 'test-token')
     mockFetchOk([])
     renderHook(() => useServiceImportsCard())
-    await waitFor(() => (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls.length > 0)
+    await waitFor(() => expect((globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls.length).toBeGreaterThan(0))
     const [, options] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0]
     expect(options?.headers?.['Authorization']).toBe('Bearer test-token')
   })


### PR DESCRIPTION
## Summary

- `waitFor(fn)` in `@testing-library/react` **only retries when the callback throws**. Returning `false` resolves immediately, leaving state stale and causing assertions to fail.
- Converts all boolean-expression `waitFor` callbacks to `expect()`-based assertions across three test files: `useBonusPoints`, `useServiceImportsCard`, `useGatewayStatus`.

**Root cause example:**
```ts
// Before — resolves immediately when bonusPoints is 0 (returns false, no throw)
await waitFor(() => result.current.bonusPoints === 150)

// After — retries until bonusPoints reaches 150 (throws AssertionError until then)
await waitFor(() => expect(result.current.bonusPoints).toBe(150))
```

**Evidence:** `useServiceImportsCard` test suite completed in 97ms for 22 tests — far less than the 1000ms `waitFor` default timeout, confirming all `waitFor` calls were resolving immediately.

## Test plan
- [ ] Shards 6 and 8 pass in CI (no more `expected +0 to be 150` or `expected [] to have a length of 1`)
- [ ] All 3 affected test files pass locally