### PR TITLE
fix(pods): reconcile detailed pod list with cluster summary count

### DIFF
--- a/web/src/components/drilldown/views/MultiClusterSummaryDrillDown.tsx
+++ b/web/src/components/drilldown/views/MultiClusterSummaryDrillDown.tsx
@@ -166,7 +166,21 @@ function getStatusBadge(status: string) {
 
 export function MultiClusterSummaryDrillDown({ data, viewType }: MultiClusterSummaryDrillDownProps) {
   const { t } = useTranslation()
-  const { clusters, deduplicatedClusters, pods, deployments, events, helmReleases, operatorSubscriptions, securityIssues } = useClusterData()
+  const {
+    clusters,
+    deduplicatedClusters,
+    pods,
+    // Per-cluster errors emitted by the pods SSE stream (#9353). Used
+    // below to render an RBAC- vs transient-failure-aware warning when
+    // the all-pods drill-down list is empty but the cluster summary
+    // reports a non-zero pod count.
+    podClusterErrors,
+    deployments,
+    events,
+    helmReleases,
+    operatorSubscriptions,
+    securityIssues,
+  } = useClusterData()
   // Issue 8844 — The all-alerts drill-down must read from the same AlertsContext
   // source that powers the Alerts dashboard stat blocks (firing / resolved
   // counts). Sourcing alerts from pods (non-Running pods were used as a
@@ -602,9 +616,52 @@ export function MultiClusterSummaryDrillDown({ data, viewType }: MultiClusterSum
                     {expectedPodCountFromClusters === 1 ? '' : 's'}, but the
                     detailed list is empty.
                   </div>
-                  <div className="text-muted-foreground mt-1">
-                    This usually means the current user lacks list-pods RBAC on one or more clusters, or the pods endpoint is temporarily unreachable — the per-cluster summary includes the count but the detail view can&apos;t enumerate individual pods.
-                  </div>
+                  {/*
+                    Per-cluster error breakdown (#9353). When the backend
+                    emits `cluster_error` SSE events we show a typed list
+                    so the user can see which clusters were denied by
+                    RBAC (auth) vs. which failed transiently (timeout /
+                    network / unknown). Without this block the warning
+                    conflated every failure mode into a single message.
+                  */}
+                  {podClusterErrors.length > 0 ? (
+                    <>
+                      <div className="text-muted-foreground mt-1">
+                        The pods endpoint returned an error for
+                        {' '}
+                        {podClusterErrors.length}
+                        {' '}
+                        cluster{podClusterErrors.length === 1 ? '' : 's'}:
+                      </div>
+                      <ul className="mt-2 space-y-1 text-muted-foreground">
+                        {podClusterErrors.map(err => {
+                          const isAuth = err.errorType === 'auth'
+                          const isTimeout = err.errorType === 'timeout'
+                          const kindLabel = isAuth
+                            ? 'RBAC denied (list-pods)'
+                            : isTimeout
+                              ? 'Transient timeout'
+                              : `Endpoint failure (${err.errorType})`
+                          return (
+                            <li key={`${err.cluster}-${err.errorType}`} className="flex items-start gap-2">
+                              <Server className="w-3 h-3 mt-0.5 shrink-0" />
+                              <span>
+                                <span className="font-mono">{err.cluster.split('/').pop()}</span>
+                                {' — '}
+                                <span className={isAuth ? 'text-red-400' : 'text-yellow-400'}>
+                                  {kindLabel}
+                                </span>
+                              </span>
+                            </li>
+                          )
+                        })}
+                      </ul>
+                    </>
+                  ) : (
+                    <div className="text-muted-foreground mt-1">
+                      This usually means the current user lacks list-pods RBAC on one or more clusters, or the pods endpoint is temporarily unreachable — the per-cluster summary includes the count but the detail view can&apos;t enumerate individual pods.
+                    </div>
+                  )}
                 </div>
               </div>
             </div>

--- a/web/src/components/drilldown/views/MultiClusterSummaryDrillDown.tsx
+++ b/web/src/components/drilldown/views/MultiClusterSummaryDrillDown.tsx
@@ -170,7 +170,7 @@ export function MultiClusterSummaryDrillDown({ data, viewType }: MultiClusterSum
     clusters,
     deduplicatedClusters,
     pods,
-    // Per-cluster errors emitted by the pods SSE stream (#9353). Used
+    // Per-cluster errors emitted by the pods SSE stream (Issue 9353). Used
     // below to render an RBAC- vs transient-failure-aware warning when
     // the all-pods drill-down list is empty but the cluster summary
     // reports a non-zero pod count.
@@ -617,7 +617,7 @@ export function MultiClusterSummaryDrillDown({ data, viewType }: MultiClusterSum
                     detailed list is empty.
                   </div>
                   {/*
-                    Per-cluster error breakdown (#9353). When the backend
+                    Per-cluster error breakdown (Issue 9353). When the backend
                     emits `cluster_error` SSE events we show a typed list
                     so the user can see which clusters were denied by
                     RBAC (auth) vs. which failed transiently (timeout /

--- a/web/src/hooks/__tests__/useClusterData.test.ts
+++ b/web/src/hooks/__tests__/useClusterData.test.ts
@@ -136,7 +136,7 @@ describe('useClusterData', () => {
     expect(result.current.events).toEqual([])
   })
 
-  // 5. #9353 — podClusterErrors forwarded from useAllPods
+  // 5. Issue 9353 — podClusterErrors forwarded from useAllPods
   it('forwards podClusterErrors from useAllPods so the drill-down can distinguish RBAC vs transient failures', async () => {
     const clusterErrors = [
       { cluster: 'prod-east', errorType: 'auth', message: 'pods is forbidden' },
@@ -150,7 +150,7 @@ describe('useClusterData', () => {
     expect(result.current.podClusterErrors).toEqual(clusterErrors)
   })
 
-  // 6. #9353 — podClusterErrors coalesces to [] when useAllPods omits it
+  // 6. Issue 9353 — podClusterErrors coalesces to [] when useAllPods omits it
   it('coalesces podClusterErrors to empty array when useAllPods does not provide one', async () => {
     mockUseAllPods.mockReturnValue({ pods: [] })
 

--- a/web/src/hooks/__tests__/useClusterData.test.ts
+++ b/web/src/hooks/__tests__/useClusterData.test.ts
@@ -135,4 +135,28 @@ describe('useClusterData', () => {
     expect(result.current.pods).toEqual([])
     expect(result.current.events).toEqual([])
   })
+
+  // 5. #9353 — podClusterErrors forwarded from useAllPods
+  it('forwards podClusterErrors from useAllPods so the drill-down can distinguish RBAC vs transient failures', async () => {
+    const clusterErrors = [
+      { cluster: 'prod-east', errorType: 'auth', message: 'pods is forbidden' },
+      { cluster: 'prod-west', errorType: 'timeout', message: 'context deadline exceeded' },
+    ]
+    mockUseAllPods.mockReturnValue({ pods: [], clusterErrors })
+
+    const { useClusterData } = await import('../useClusterData')
+    const { result } = renderHook(() => useClusterData())
+
+    expect(result.current.podClusterErrors).toEqual(clusterErrors)
+  })
+
+  // 6. #9353 — podClusterErrors coalesces to [] when useAllPods omits it
+  it('coalesces podClusterErrors to empty array when useAllPods does not provide one', async () => {
+    mockUseAllPods.mockReturnValue({ pods: [] })
+
+    const { useClusterData } = await import('../useClusterData')
+    const { result } = renderHook(() => useClusterData())
+
+    expect(result.current.podClusterErrors).toEqual([])
+  })
 })

--- a/web/src/hooks/mcp/__tests__/workloads.test.ts
+++ b/web/src/hooks/mcp/__tests__/workloads.test.ts
@@ -330,6 +330,45 @@ describe('useAllPods', () => {
     await waitFor(() => expect(result.current.isLoading).toBe(false))
     expect(Array.isArray(result.current.pods)).toBe(true)
   })
+
+  // #9353 — per-cluster error surfacing.  The backend emits a
+  // `cluster_error` SSE event when an individual cluster's pods list
+  // fails (e.g. 403 from RBAC denial).  useAllPods must forward those
+  // events as `clusterErrors` so the multi-cluster drill-down can
+  // distinguish RBAC denial from a transient endpoint failure when the
+  // cluster summary count disagrees with the list length.
+  it('surfaces per-cluster errors from SSE cluster_error events', async () => {
+    // Simulate the SSE stream invoking onClusterError for a 403 and a timeout.
+    mockFetchSSE.mockImplementation(async (opts: {
+      onClusterError?: (cluster: string, message: string) => void
+    }) => {
+      opts.onClusterError?.('rbac-cluster', 'pods is forbidden: User "u" cannot list resource "pods"')
+      opts.onClusterError?.('slow-cluster', 'context deadline exceeded')
+      return []
+    })
+
+    const { result } = renderHook(() => useAllPods('rbac-test-unique'))
+    await waitFor(() => expect(result.current.isLoading).toBe(false), { timeout: 5000 })
+
+    // Both events surface in clusterErrors, classified by type.  The RBAC
+    // denial is 'auth' (matches /forbidden/i) and the timeout is 'timeout'.
+    expect(result.current.clusterErrors).toHaveLength(2)
+    const rbac = result.current.clusterErrors.find(e => e.cluster === 'rbac-cluster')
+    const slow = result.current.clusterErrors.find(e => e.cluster === 'slow-cluster')
+    expect(rbac?.errorType).toBe('auth')
+    expect(slow?.errorType).toBe('timeout')
+  })
+
+  it('returns empty clusterErrors when the stream succeeds for every cluster', async () => {
+    mockFetchSSE.mockResolvedValue([
+      { name: 'p1', namespace: 'n', cluster: 'c1', status: 'Running', ready: '1/1', restarts: 0, age: '1d' },
+    ])
+
+    const { result } = renderHook(() => useAllPods('happy-test-unique'))
+    await waitFor(() => expect(result.current.isLoading).toBe(false), { timeout: 5000 })
+
+    expect(result.current.clusterErrors).toEqual([])
+  })
 })
 
 // ===========================================================================

--- a/web/src/hooks/mcp/__tests__/workloads.test.ts
+++ b/web/src/hooks/mcp/__tests__/workloads.test.ts
@@ -331,7 +331,7 @@ describe('useAllPods', () => {
     expect(Array.isArray(result.current.pods)).toBe(true)
   })
 
-  // #9353 — per-cluster error surfacing.  The backend emits a
+  // Issue 9353 — per-cluster error surfacing.  The backend emits a
   // `cluster_error` SSE event when an individual cluster's pods list
   // fails (e.g. 403 from RBAC denial).  useAllPods must forward those
   // events as `clusterErrors` so the multi-cluster drill-down can

--- a/web/src/hooks/mcp/workloads.ts
+++ b/web/src/hooks/mcp/workloads.ts
@@ -14,7 +14,7 @@ import { classifyError, type ClusterErrorType } from '../../lib/errorClassifier'
 
 /**
  * Per-cluster error surfaced by `useAllPods` when the backend emits a
- * `cluster_error` SSE event for a particular cluster (#9353). Lets the
+ * `cluster_error` SSE event for a particular cluster (Issue 9353). Lets the
  * drill-down distinguish an RBAC denial ({@link ClusterErrorType} === 'auth')
  * from a transient 5xx/timeout failure so the UI can render a specific
  * explanation instead of a generic "detailed list is empty" warning.
@@ -458,7 +458,7 @@ export function useAllPods(cluster?: string, namespace?: string, forceLive = fal
   const [isRefreshing, setIsRefreshing] = useState(false)
   const [lastUpdated, setLastUpdated] = useState<Date | null>(cached?.timestamp || null)
   const [error, setError] = useState<string | null>(null)
-  // Per-cluster errors from the SSE `cluster_error` event (#9353). Lets
+  // Per-cluster errors from the SSE `cluster_error` event (Issue 9353). Lets
   // consumers (drill-downs) distinguish an RBAC denial on one or more
   // clusters from a globally-transient failure so the UI can show a
   // specific "lacks list-pods RBAC on cluster X" message instead of a
@@ -595,7 +595,7 @@ export function useAllPods(cluster?: string, namespace?: string, forceLive = fal
     isRefreshing,
     lastUpdated,
     error,
-    // Per-cluster errors surfaced from the SSE stream (#9353) so the
+    // Per-cluster errors surfaced from the SSE stream (Issue 9353) so the
     // multi-cluster drill-down can explain an empty list with "lacks
     // list-pods RBAC on cluster X" rather than a generic warning.
     clusterErrors,

--- a/web/src/hooks/mcp/workloads.ts
+++ b/web/src/hooks/mcp/workloads.ts
@@ -10,6 +10,20 @@ import { REFRESH_INTERVAL_MS, MIN_REFRESH_INDICATOR_MS, getEffectiveInterval, LO
 import { subscribePolling } from './pollingManager'
 import { MCP_HOOK_TIMEOUT_MS, LOCAL_AGENT_HTTP_URL } from '../../lib/constants/network'
 import type { PodInfo, PodIssue, Deployment, DeploymentIssue, Job, HPA, ReplicaSet, StatefulSet, DaemonSet, CronJob } from './types'
+import { classifyError, type ClusterErrorType } from '../../lib/errorClassifier'
+
+/**
+ * Per-cluster error surfaced by `useAllPods` when the backend emits a
+ * `cluster_error` SSE event for a particular cluster (#9353). Lets the
+ * drill-down distinguish an RBAC denial ({@link ClusterErrorType} === 'auth')
+ * from a transient 5xx/timeout failure so the UI can render a specific
+ * explanation instead of a generic "detailed list is empty" warning.
+ */
+export interface PodClusterError {
+  cluster: string
+  errorType: ClusterErrorType
+  message: string
+}
 
 // ---------------------------------------------------------------------------
 // Shared Workloads State - enables cache reset notifications to all consumers
@@ -444,6 +458,14 @@ export function useAllPods(cluster?: string, namespace?: string, forceLive = fal
   const [isRefreshing, setIsRefreshing] = useState(false)
   const [lastUpdated, setLastUpdated] = useState<Date | null>(cached?.timestamp || null)
   const [error, setError] = useState<string | null>(null)
+  // Per-cluster errors from the SSE `cluster_error` event (#9353). Lets
+  // consumers (drill-downs) distinguish an RBAC denial on one or more
+  // clusters from a globally-transient failure so the UI can show a
+  // specific "lacks list-pods RBAC on cluster X" message instead of a
+  // generic "detailed list is empty" warning.
+  const [clusterErrors, setClusterErrors] = useState<PodClusterError[]>(
+    [],
+  )
   const sseAbortRef = useRef<AbortController | null>(null)
 
   const refetch = useCallback(async (silent = false) => {
@@ -455,6 +477,7 @@ export function useAllPods(cluster?: string, namespace?: string, forceLive = fal
       setPods(demoPods)
       setIsLoading(false)
       setError(null)
+      setClusterErrors([])
       setLastUpdated(new Date())
       return
     }
@@ -468,6 +491,11 @@ export function useAllPods(cluster?: string, namespace?: string, forceLive = fal
     sseAbortRef.current?.abort()
     const abortController = new AbortController()
     sseAbortRef.current = abortController
+
+    // Collect per-cluster error events during this refetch. We replace the
+    // previous snapshot atomically when the stream settles so a transient
+    // flash of "cluster X failed" isn't left stale after a retry succeeds.
+    const collectedErrors: PodClusterError[] = []
 
     // Use SSE streaming for progressive multi-cluster data
     try {
@@ -484,6 +512,19 @@ export function useAllPods(cluster?: string, namespace?: string, forceLive = fal
           setPods(prev => [...prev, ...items])
           setIsLoading(false)
         },
+        onClusterError: (clusterName, errorMessage) => {
+          // Classify the raw backend error so consumers can render an
+          // RBAC-specific message (auth) instead of "transient failure"
+          // (timeout/network/unknown). Backend error strings already
+          // contain enough context ("pods is forbidden", "401",
+          // "unauthorized", etc.) for the classifier to match.
+          const classified = classifyError(errorMessage)
+          collectedErrors.push({
+            cluster: clusterName,
+            errorType: classified.type,
+            message: errorMessage,
+          })
+        },
       })
 
       const now = new Date()
@@ -492,6 +533,7 @@ export function useAllPods(cluster?: string, namespace?: string, forceLive = fal
 
       setPods(allPods)
       setError(null)
+      setClusterErrors(collectedErrors)
       setLastUpdated(now)
     } catch (err) {
       if (err instanceof DOMException && err.name === 'AbortError') return
@@ -500,6 +542,10 @@ export function useAllPods(cluster?: string, namespace?: string, forceLive = fal
       if (!silent && !podsCache) {
         setError(message)
       }
+      // Even on catastrophic failure, surface any per-cluster errors we
+      // collected before the stream aborted so the UI can still explain
+      // the partial state.
+      setClusterErrors(collectedErrors)
     } finally {
       if (!silent) {
         setIsLoading(false)
@@ -536,13 +582,24 @@ export function useAllPods(cluster?: string, namespace?: string, forceLive = fal
       if (state.isResetting) {
         setIsLoading(true)
         setPods([])
+        setClusterErrors([])
         setLastUpdated(null)
       }
     }
     return subscribeWorkloadsCache(handleCacheReset)
   }, [])
 
-  return { pods, isLoading, isRefreshing, lastUpdated, error, refetch: () => refetch(false) }
+  return {
+    pods,
+    isLoading,
+    isRefreshing,
+    lastUpdated,
+    error,
+    // Per-cluster errors surfaced from the SSE stream (#9353) so the
+    // multi-cluster drill-down can explain an empty list with "lacks
+    // list-pods RBAC on cluster X" rather than a generic warning.
+    clusterErrors,
+    refetch: () => refetch(false) }
 }
 
 // ---------------------------------------------------------------------------

--- a/web/src/hooks/useClusterData.ts
+++ b/web/src/hooks/useClusterData.ts
@@ -18,7 +18,7 @@ export function useClusterData() {
   //
   // `podClusterErrors` surfaces per-cluster SSE `cluster_error` events so
   // the all-pods drill-down can distinguish an RBAC denial from a
-  // transient failure when the count disagrees with the list (#9353).
+  // transient failure when the count disagrees with the list (Issue 9353).
   const { pods, clusterErrors: podClusterErrors } = useAllPods()
   const { deployments } = useDeployments()
   const { namespaces } = useNamespaces()

--- a/web/src/hooks/useClusterData.ts
+++ b/web/src/hooks/useClusterData.ts
@@ -15,7 +15,11 @@ export function useClusterData() {
   // Use useAllPods (no pagination limit) so the multi-cluster drill-down
   // sees every pod. usePods() defaults to limit=10 and was causing the
   // stat block (total pod count) and drill-down list to disagree. #6100
-  const { pods } = useAllPods()
+  //
+  // `podClusterErrors` surfaces per-cluster SSE `cluster_error` events so
+  // the all-pods drill-down can distinguish an RBAC denial from a
+  // transient failure when the count disagrees with the list (#9353).
+  const { pods, clusterErrors: podClusterErrors } = useAllPods()
   const { deployments } = useDeployments()
   const { namespaces } = useNamespaces()
   const { events } = useEvents()
@@ -27,6 +31,7 @@ export function useClusterData() {
     clusters: clusters || [],
     deduplicatedClusters: deduplicatedClusters || [],
     pods: pods || [],
+    podClusterErrors: podClusterErrors || [],
     deployments: deployments || [],
     namespaces: namespaces || [],
     events: events || [],


### PR DESCRIPTION
## Summary

Fixes the "All Pods" drill-down showing `Total: 93` but an empty list
with no indication of _why_ the detail list is empty.

- Surface per-cluster `cluster_error` SSE events through `useAllPods`
  as a new `clusterErrors` field (`{ cluster, errorType, message }`).
- Classify each via the existing `errorClassifier`
  (auth / timeout / network / certificate / unknown) so the UI can tell
  RBAC denials (`auth`) apart from transient failures.
- Thread the list through `useClusterData` as `podClusterErrors` and
  render a per-cluster breakdown in `MultiClusterSummaryDrillDown`:
  RBAC denials show "RBAC denied (list-pods)" in red, transient
  timeouts show "Transient timeout" in yellow, everything else shows
  "Endpoint failure (<type>)".

## Why this works without backend changes

The backend already emits the right signals:

- `pkg/api/handlers/sse.go` emits `cluster_error` SSE events for each
  failing cluster (see `streamClusters` and `sseEventClusterError`).
- `pkg/api/handlers/mcp_workloads.go:GetPods` annotates its JSON
  response with `clusterErrors` via `clusterErrorTracker.annotate()`.

The frontend just wasn't listening — `useAllPods` passed
`onClusterData` to `fetchSSE` but not `onClusterError`, so the signal
was silently dropped. This PR wires it through.

## Acceptance criteria

- [x] Pod list reflects actual user RBAC permissions per-cluster
  (per-cluster fetch already independent; no change needed).
- [x] Per-cluster RBAC denial = empty list for THAT cluster, not
  globally (already true; this PR just makes it _visible_).
- [x] 4xx/5xx errors propagated to frontend (`cluster_error` events
  now reach the UI).
- [x] Frontend distinguishes RBAC denial (`auth`) vs. transient
  failure (`timeout`/`network`/`unknown`).
- [x] Error messages differentiate RBAC vs. endpoint failure.

## Test plan

- [x] `go test ./pkg/api/handlers/...` (backend unchanged, still green)
- [x] New unit tests in `workloads.test.ts` covering the cluster_error
  callback path (auth + timeout classification).
- [x] New unit tests in `useClusterData.test.ts` covering
  `podClusterErrors` pass-through and coalescing.
- [ ] Manual: visit All Pods drill-down with a namespaced role that
  denies list-pods on one cluster — expect "RBAC denied (list-pods)"
  line for that cluster only.

Fixes #9353