### PR TITLE
fix(nodes): surface per-cluster RBAC errors when nodes list returns empty

### DIFF
--- a/web/src/components/drilldown/views/MultiClusterSummaryDrillDown.tsx
+++ b/web/src/components/drilldown/views/MultiClusterSummaryDrillDown.tsx
@@ -204,7 +204,15 @@ export function MultiClusterSummaryDrillDown({ data, viewType }: MultiClusterSum
     isLoading: nodesIsLoading,
     isFailed: nodesIsFailed,
     isDemoFallback: nodesIsDemoFallback,
+    // Per-cluster errors emitted by the cross-cluster nodes REST fan-out
+    // (Issue 9355). Used below to render an RBAC- vs transient-failure-aware
+    // warning when the all-nodes drill-down list is empty but the cluster
+    // summary reports a non-zero node count. Guarded against undefined to
+    // keep older test mocks and mid-upgrade hook shapes crash-safe (see
+    // MEMORY.md: "ALWAYS guard `.join()` and `for...of` against undefined").
+    clusterErrors: rawNodeClusterErrors,
   } = useCachedAllNodes()
+  const nodeClusterErrors = rawNodeClusterErrors || []
   const { pvcs: cachedPVCs } = useCachedPVCs()
   // Guard against undefined to prevent crashes when APIs return 404/500/empty
   const cachedNodes = rawCachedNodes || []
@@ -597,11 +605,55 @@ export function MultiClusterSummaryDrillDown({ data, viewType }: MultiClusterSum
                     {expectedNodeCountFromClusters === 1 ? '' : 's'}, but the
                     detailed list is empty.
                   </div>
-                  <div className="text-muted-foreground mt-1">
-                    {nodesIsFailed
-                      ? 'The node list endpoint is currently unreachable.'
-                      : 'This usually means the current user lacks list-nodes RBAC on one or more clusters, so the detail view can\'t enumerate nodes even though the per-cluster summary includes their count.'}
-                  </div>
+                  {/*
+                    Per-cluster error breakdown (Issue 9355). When the
+                    `useCachedAllNodes` fan-out captures per-cluster
+                    `/api/mcp/nodes` failures we show a typed list so the
+                    user can see which clusters were denied by RBAC (auth)
+                    vs. which failed transiently (timeout / network /
+                    unknown). Without this block the warning conflated
+                    every failure mode into a single message.
+                  */}
+                  {nodeClusterErrors.length > 0 ? (
+                    <>
+                      <div className="text-muted-foreground mt-1">
+                        The nodes endpoint returned an error for
+                        {' '}
+                        {nodeClusterErrors.length}
+                        {' '}
+                        cluster{nodeClusterErrors.length === 1 ? '' : 's'}:
+                      </div>
+                      <ul className="mt-2 space-y-1 text-muted-foreground">
+                        {nodeClusterErrors.map(err => {
+                          const isAuth = err.errorType === 'auth'
+                          const isTimeout = err.errorType === 'timeout'
+                          const kindLabel = isAuth
+                            ? 'RBAC denied (list-nodes)'
+                            : isTimeout
+                              ? 'Transient timeout'
+                              : `Endpoint failure (${err.errorType})`
+                          return (
+                            <li key={`${err.cluster}-${err.errorType}`} className="flex items-start gap-2">
+                              <Server className="w-3 h-3 mt-0.5 shrink-0" />
+                              <span>
+                                <span className="font-mono">{err.cluster.split('/').pop()}</span>
+                                {' — '}
+                                <span className={isAuth ? 'text-red-400' : 'text-yellow-400'}>
+                                  {kindLabel}
+                                </span>
+                              </span>
+                            </li>
+                          )
+                        })}
+                      </ul>
+                    </>
+                  ) : (
+                    <div className="text-muted-foreground mt-1">
+                      {nodesIsFailed
+                        ? 'The node list endpoint is currently unreachable.'
+                        : 'This usually means the current user lacks list-nodes RBAC on one or more clusters, so the detail view can\'t enumerate nodes even though the per-cluster summary includes their count.'}
+                    </div>
+                  )}
                 </div>
               </div>
             </div>

--- a/web/src/components/drilldown/views/__tests__/MultiClusterSummaryDrillDown.test.tsx
+++ b/web/src/components/drilldown/views/__tests__/MultiClusterSummaryDrillDown.test.tsx
@@ -48,7 +48,10 @@ vi.mock('../../../../hooks/useAlerts', () => ({
 
 vi.mock('../../../../hooks/useCachedData', () => ({
   useCachedNodes: () => ({ nodes: [], lastRefresh: Date.now(), isLoading: false, isFailed: false, isDemoFallback: false, isRefreshing: false, consecutiveFailures: 0, refetch: vi.fn() }),
-  useCachedAllNodes: () => ({ nodes: [], lastRefresh: Date.now(), isLoading: false, isFailed: false, isDemoFallback: false, isRefreshing: false, consecutiveFailures: 0, refetch: vi.fn() }),
+  // `clusterErrors` is the Issue 9355 addition — per-cluster RBAC/timeout
+  // breakdown the drill-down uses when the nodes list comes back empty but
+  // the cluster summary reported a non-zero count.
+  useCachedAllNodes: () => ({ nodes: [], clusterErrors: [], lastRefresh: Date.now(), isLoading: false, isFailed: false, isDemoFallback: false, isRefreshing: false, consecutiveFailures: 0, refetch: vi.fn() }),
   useCachedPVCs: () => ({ pvcs: [], lastRefresh: Date.now(), isLoading: false, isFailed: false, isDemoFallback: false, isRefreshing: false, consecutiveFailures: 0, refetch: vi.fn() }),
 }))
 

--- a/web/src/hooks/__tests__/useCachedNodes.test.ts
+++ b/web/src/hooks/__tests__/useCachedNodes.test.ts
@@ -49,7 +49,9 @@ vi.mock('../../lib/constants/network', () => ({
   KUBECTL_EXTENDED_TIMEOUT_MS: 60000,
 }))
 
-import { useCachedNodes, useCachedCoreDNSStatus } from '../useCachedNodes'
+import { useCachedNodes, useCachedCoreDNSStatus, useCachedAllNodes } from '../useCachedNodes'
+import { fetchAPI } from '../../lib/cache/fetcherUtils'
+import { settledWithConcurrency } from '../../lib/utils/concurrency'
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -168,5 +170,110 @@ describe('useCachedCoreDNSStatus', () => {
     renderHook(() => useCachedCoreDNSStatus('my-cluster'))
     const callArgs = mockUseCache.mock.calls[0][0]
     expect(callArgs.key).toContain('my-cluster')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// useCachedAllNodes — Issue 9355 per-cluster error surfacing
+// ---------------------------------------------------------------------------
+
+describe('useCachedAllNodes — Issue 9355 clusterErrors surfacing', () => {
+  // Helper: capture the fetcher passed to useCache so we can invoke it
+  // directly with a given cluster cache + fetchAPI behaviour, then read the
+  // per-cluster errors from the hook's returned `clusterErrors`.
+  async function runFetcherAndGetErrors(
+    clusters: Array<{ name: string; reachable?: boolean }>,
+    fetchBehaviour: (cluster: string) => Promise<unknown>,
+  ) {
+    mockClusterCacheRef.clusters = clusters
+    // Run each fan-out task sequentially so we can deterministically
+    // observe which clusters produced errors.
+    vi.mocked(settledWithConcurrency).mockImplementation(
+      async (tasks, _concurrency, handleSettled) => {
+        const results: PromiseSettledResult<unknown>[] = []
+        for (const task of tasks) {
+          try {
+            const value = await task()
+            const res: PromiseSettledResult<unknown> = { status: 'fulfilled', value }
+            results.push(res)
+            if (handleSettled) await handleSettled(res as PromiseSettledResult<never>)
+          } catch (reason) {
+            const res: PromiseSettledResult<unknown> = { status: 'rejected', reason }
+            results.push(res)
+            if (handleSettled) await handleSettled(res as PromiseSettledResult<never>)
+          }
+        }
+        return results as never
+      },
+    )
+    vi.mocked(fetchAPI).mockImplementation(
+      async (_endpoint, params) => fetchBehaviour(params?.cluster as string),
+    )
+
+    // Render the hook so useCache is invoked and the fetcher option is
+    // captured. The hook itself returns `clusterErrors: []` initially
+    // because the module-level snapshot is empty until the fetcher runs.
+    const { result, rerender } = renderHook(() => useCachedAllNodes())
+
+    // Pull the fetcher out of the most recent mockUseCache invocation and
+    // run it — this mirrors what useCache does internally when it decides
+    // to refresh the cache.
+    const fetcherArg = mockUseCache.mock.calls.at(-1)?.[0] as {
+      fetcher: () => Promise<unknown>
+    }
+    expect(typeof fetcherArg?.fetcher).toBe('function')
+    await fetcherArg.fetcher()
+
+    // Re-render so useSyncExternalStore picks up the published snapshot.
+    rerender()
+    return result.current.clusterErrors
+  }
+
+  it('exposes clusterErrors as an array on the hook return', () => {
+    const { result } = renderHook(() => useCachedAllNodes())
+    expect(Array.isArray(result.current.clusterErrors)).toBe(true)
+  })
+
+  // Issue 9355 — the core acceptance criterion: when one cluster's
+  // `/api/mcp/nodes` returns 403 Forbidden (RBAC denial) and another
+  // returns context deadline exceeded (transient), the hook surfaces
+  // both as typed per-cluster entries so the drill-down can render
+  // "RBAC denied" vs "Transient timeout" instead of a single generic
+  // warning.
+  it('surfaces per-cluster RBAC denials and transient failures separately', async () => {
+    const errors = await runFetcherAndGetErrors(
+      [
+        { name: 'rbac-cluster', reachable: true },
+        { name: 'slow-cluster', reachable: true },
+        { name: 'happy-cluster', reachable: true },
+      ],
+      async (cluster) => {
+        if (cluster === 'rbac-cluster') {
+          throw new Error('nodes is forbidden: User "u" cannot list resource "nodes"')
+        }
+        if (cluster === 'slow-cluster') {
+          throw new Error('context deadline exceeded')
+        }
+        return { nodes: [{ name: 'n1', cluster, status: 'Ready' }] }
+      },
+    )
+
+    expect(errors).toHaveLength(2)
+    const rbac = errors.find(e => e.cluster === 'rbac-cluster')
+    const slow = errors.find(e => e.cluster === 'slow-cluster')
+    expect(rbac?.errorType).toBe('auth')
+    expect(slow?.errorType).toBe('timeout')
+  })
+
+  it('returns empty clusterErrors when every cluster succeeds', async () => {
+    const errors = await runFetcherAndGetErrors(
+      [
+        { name: 'c1', reachable: true },
+        { name: 'c2', reachable: true },
+      ],
+      async (cluster) => ({ nodes: [{ name: `n-${cluster}`, cluster, status: 'Ready' }] }),
+    )
+
+    expect(errors).toEqual([])
   })
 })

--- a/web/src/hooks/mcp/__tests__/compute.test.ts
+++ b/web/src/hooks/mcp/__tests__/compute.test.ts
@@ -242,6 +242,49 @@ describe('useNodes', () => {
     expect(result.current.nodes.length).toBeGreaterThan(0)
     expect(result.current.error).toBeNull()
   })
+
+  // Issue 9355 — per-cluster error surfacing.  The backend emits a
+  // `cluster_error` SSE event when an individual cluster's nodes list
+  // fails (e.g. 403 from RBAC denial).  useNodes must forward those
+  // events as `clusterErrors` so the multi-cluster drill-down can
+  // distinguish RBAC denial from a transient endpoint failure when the
+  // cluster summary count disagrees with the list length.
+  it('surfaces per-cluster errors from SSE cluster_error events', async () => {
+    // Simulate the SSE stream invoking onClusterError for a 403 and a timeout.
+    mockFetchSSE.mockImplementation(async (opts: {
+      onClusterError?: (cluster: string, message: string) => void
+    }) => {
+      opts.onClusterError?.('rbac-cluster', 'nodes is forbidden: User "u" cannot list resource "nodes"')
+      opts.onClusterError?.('slow-cluster', 'context deadline exceeded')
+      return []
+    })
+
+    const { result } = renderHook(() => useNodes('rbac-test-unique-nodes'))
+    await waitFor(() => expect(result.current.isLoading).toBe(false), { timeout: 5000 })
+
+    // Both events surface in clusterErrors, classified by type.  The RBAC
+    // denial is 'auth' (matches /forbidden/i) and the timeout is 'timeout'.
+    expect(result.current.clusterErrors).toHaveLength(2)
+    const rbac = result.current.clusterErrors.find(e => e.cluster === 'rbac-cluster')
+    const slow = result.current.clusterErrors.find(e => e.cluster === 'slow-cluster')
+    expect(rbac?.errorType).toBe('auth')
+    expect(slow?.errorType).toBe('timeout')
+  })
+
+  it('returns empty clusterErrors when the stream succeeds for every cluster', async () => {
+    mockFetchSSE.mockResolvedValue([
+      {
+        name: 'n1', cluster: 'c1', status: 'Ready', roles: ['worker'],
+        kubeletVersion: 'v1.28.4', cpuCapacity: '8', memoryCapacity: '16Gi',
+        podCapacity: '110', conditions: [], unschedulable: false,
+      },
+    ])
+
+    const { result } = renderHook(() => useNodes('happy-test-unique-nodes'))
+    await waitFor(() => expect(result.current.isLoading).toBe(false), { timeout: 5000 })
+
+    expect(result.current.clusterErrors).toEqual([])
+  })
 })
 
 // ===========================================================================

--- a/web/src/hooks/mcp/compute.ts
+++ b/web/src/hooks/mcp/compute.ts
@@ -9,7 +9,22 @@ import { STORAGE_KEY_TOKEN } from '../../lib/constants'
 import { GPU_POLL_INTERVAL_MS, getEffectiveInterval, LOCAL_AGENT_URL, agentFetch } from './shared'
 import { subscribePolling } from './pollingManager'
 import { MCP_EXTENDED_TIMEOUT_MS, MCP_HOOK_TIMEOUT_MS, LOCAL_AGENT_HTTP_URL } from '../../lib/constants/network'
+import { classifyError, type ClusterErrorType } from '../../lib/errorClassifier'
 import type { GPUNode, NodeInfo, NVIDIAOperatorStatus } from './types'
+
+/**
+ * Per-cluster error surfaced by {@link useNodes} when the backend emits a
+ * `cluster_error` SSE event for a particular cluster (Issue 9355). Lets
+ * consumers distinguish an RBAC denial ({@link ClusterErrorType} === 'auth')
+ * from a transient 5xx/timeout failure so the UI can render a specific
+ * "lacks list-nodes RBAC" explanation instead of a generic "detailed list
+ * is empty" warning.
+ */
+export interface NodeClusterError {
+  cluster: string
+  errorType: ClusterErrorType
+  message: string
+}
 
 // Module-level cache for GPU nodes (persists across navigation)
 interface GPUNodeCache {
@@ -429,6 +444,12 @@ export function useNodes(cluster?: string) {
   const [nodes, setNodes] = useState<NodeInfo[]>([])
   const [isLoading, setIsLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
+  // Per-cluster errors from the SSE `cluster_error` event (Issue 9355). Lets
+  // consumers (drill-downs) distinguish an RBAC denial on one or more
+  // clusters from a globally-transient failure so the UI can show a
+  // specific "lacks list-nodes RBAC on cluster X" message instead of a
+  // generic "detailed list is empty" warning.
+  const [clusterErrors, setClusterErrors] = useState<NodeClusterError[]>([])
   const { isDemoMode: demoMode } = useDemoMode()
 
   // Track previous cluster to detect actual changes (not just initial mount)
@@ -441,6 +462,7 @@ export function useNodes(cluster?: string) {
       setNodes([])
       setIsLoading(true)
       setError(null)
+      setClusterErrors([])
       prevClusterRef.current = cluster
     }
   }, [cluster])
@@ -452,6 +474,7 @@ export function useNodes(cluster?: string) {
       setNodes(demoNodes)
       setIsLoading(false)
       setError(null)
+      setClusterErrors([])
       return
     }
     setIsLoading(true)
@@ -486,6 +509,7 @@ export function useNodes(cluster?: string) {
             }))
             setNodes(mappedNodes)
             setError(null)
+            setClusterErrors([])
             setIsLoading(false)
             reportAgentDataSuccess()
             return
@@ -495,6 +519,12 @@ export function useNodes(cluster?: string) {
         console.error(`[useNodes] Local agent failed for ${cluster}:`, err)
       }
     }
+
+    // Collect per-cluster error events during this refetch. We replace the
+    // previous snapshot atomically when the stream settles so a transient
+    // flash of "cluster X failed" isn't left stale after a retry succeeds
+    // (Issue 9355).
+    const collectedErrors: NodeClusterError[] = []
 
     // Use SSE streaming for progressive multi-cluster data
     try {
@@ -509,15 +539,33 @@ export function useNodes(cluster?: string) {
           setNodes(prev => [...prev, ...items])
           setIsLoading(false)
         },
+        onClusterError: (clusterName, errorMessage) => {
+          // Classify the raw backend error so consumers can render an
+          // RBAC-specific message (auth) instead of "transient failure"
+          // (timeout/network/unknown). Backend error strings already
+          // contain enough context ("nodes is forbidden", "401",
+          // "unauthorized", etc.) for the classifier to match.
+          const classified = classifyError(errorMessage)
+          collectedErrors.push({
+            cluster: clusterName,
+            errorType: classified.type,
+            message: errorMessage,
+          })
+        },
       })
 
       setNodes(allNodes)
       setError(null)
+      setClusterErrors(collectedErrors)
     } catch {
       // On error, show empty state instead of fabricating placeholder nodes
-      // that would masquerade as real Ready nodes (#7351)
+      // that would masquerade as real Ready nodes (#7351).  Even on
+      // catastrophic failure, surface any per-cluster errors we collected
+      // before the stream aborted so the UI can still explain the partial
+      // state (Issue 9355).
       setError(null)
       setNodes([])
+      setClusterErrors(collectedErrors)
     } finally {
       setIsLoading(false)
     }
@@ -545,7 +593,10 @@ export function useNodes(cluster?: string) {
     refetch()
   }, [demoMode, refetch])
 
-  return { nodes, isLoading, error, refetch }
+  // Per-cluster errors surfaced from the SSE stream (Issue 9355) so the
+  // multi-cluster drill-down can explain an empty list with "lacks
+  // list-nodes RBAC on cluster X" rather than a generic warning.
+  return { nodes, isLoading, error, clusterErrors, refetch }
 }
 
 // Hook to get NVIDIA operator status

--- a/web/src/hooks/useCachedNodes.ts
+++ b/web/src/hooks/useCachedNodes.ts
@@ -4,6 +4,7 @@
  * Extracted from useCachedData.ts for maintainability.
  */
 
+import { useSyncExternalStore } from 'react'
 import { useCache, type RefreshCategory } from '../lib/cache'
 import { clusterCacheRef, deduplicateClustersByServer } from './mcp/shared'
 import { fetchAPI, fetchFromAllClusters, fetchViaSSE } from '../lib/cache/fetcherUtils'
@@ -11,7 +12,46 @@ import { settledWithConcurrency } from '../lib/utils/concurrency'
 import { NodesResponseSchema } from '../lib/schemas'
 import { validateArrayResponse } from '../lib/schemas/validate'
 import { getDemoCachedNodes, getDemoCoreDNSStatus } from './useCachedData/demoData'
+import { classifyError, type ClusterErrorType } from '../lib/errorClassifier'
 import type { NodeInfo, PodInfo } from './useMCP'
+
+/**
+ * Per-cluster error surfaced by {@link useCachedAllNodes} when a particular
+ * cluster's `/api/mcp/nodes` REST call fails during the fan-out (Issue 9355).
+ * Lets the multi-cluster drill-down distinguish an RBAC denial
+ * ({@link ClusterErrorType} === 'auth') from a transient 5xx/timeout failure
+ * so the UI can render a specific "lacks list-nodes RBAC on cluster X"
+ * explanation instead of a generic "detailed list is empty" warning.
+ */
+export interface NodeClusterError {
+  cluster: string
+  errorType: ClusterErrorType
+  message: string
+}
+
+// Module-level subscribable snapshot of the most recent per-cluster errors
+// emitted by the {@link useCachedAllNodes} fetcher. We use a module-level
+// subscribable (rather than per-hook React state) because `useCache`'s
+// `fetcher` is invoked outside React and does not have access to a
+// component-scoped setState. `useSyncExternalStore` in the hook return gives
+// every consumer a fresh snapshot that re-renders when the fetcher publishes
+// a new error list (Issue 9355).
+let nodeClusterErrorsSnapshot: readonly NodeClusterError[] = []
+const nodeClusterErrorsListeners = new Set<() => void>()
+
+function subscribeNodeClusterErrors(listener: () => void) {
+  nodeClusterErrorsListeners.add(listener)
+  return () => nodeClusterErrorsListeners.delete(listener)
+}
+
+function getNodeClusterErrorsSnapshot(): readonly NodeClusterError[] {
+  return nodeClusterErrorsSnapshot
+}
+
+function publishNodeClusterErrors(next: readonly NodeClusterError[]) {
+  nodeClusterErrorsSnapshot = next
+  nodeClusterErrorsListeners.forEach(listener => listener())
+}
 
 // ============================================================================
 // Shared types
@@ -124,7 +164,13 @@ export function useCachedNodes(
  * its existing `nodesIsDemoFallback` wiring intact — see the task's
  * `isDemoData` preservation rule.
  */
-export function useCachedAllNodes(): CachedHookResult<NodeInfo[]> & { nodes: NodeInfo[] } {
+export function useCachedAllNodes(): CachedHookResult<NodeInfo[]> & {
+  nodes: NodeInfo[]
+  // Per-cluster errors captured during the REST fan-out (Issue 9355) so the
+  // multi-cluster drill-down can explain an empty list with
+  // "lacks list-nodes RBAC on cluster X" instead of a generic warning.
+  clusterErrors: readonly NodeClusterError[]
+} {
   const key = 'nodes:all:dedup'
 
   const result = useCache({
@@ -149,10 +195,21 @@ export function useCachedAllNodes(): CachedHookResult<NodeInfo[]> & { nodes: Nod
         (c) => c.reachable !== false && !c.name.includes('/'),
       )
       if (reachable.length === 0) {
+        // Reset any stale per-cluster errors from a prior fetch before
+        // throwing so consumers that still subscribe don't see a stale
+        // "cluster X denied" after the user has logged out / lost creds
+        // (Issue 9355).
+        publishNodeClusterErrors([])
         throw new Error(
           'No reachable clusters (agent connecting or backend not authenticated)',
         )
       }
+
+      // Collect per-cluster errors during this fetch. We replace the
+      // previous module-level snapshot atomically after the fan-out settles
+      // so a transient flash of "cluster X failed" isn't left stale after
+      // a retry succeeds (Issue 9355).
+      const collectedErrors: NodeClusterError[] = []
 
       // Fan out per-cluster fetches in parallel. Each per-cluster call is
       // identical to what useCachedNodes(clusterName) would do — using the
@@ -169,11 +226,21 @@ export function useCachedAllNodes(): CachedHookResult<NodeInfo[]> & { nodes: Nod
             'nodes',
           )
           return (data.nodes || []).map((n) => ({ ...n, cluster: cluster.name }))
-        } catch {
+        } catch (err) {
           // Per-cluster failure: tolerate it so a single unreachable cluster
           // doesn't wipe the whole aggregate. Accumulated nodes from other
-          // clusters still render; the drill-down's empty-state explainer
-          // handles the all-failed case.
+          // clusters still render.  Issue 9355 — classify the error (auth /
+          // timeout / network / certificate / unknown) so the drill-down
+          // can tell the user which clusters denied list-nodes RBAC vs.
+          // which failed transiently, instead of a generic empty-state
+          // warning that conflated every failure mode.
+          const message = err instanceof Error ? err.message : String(err)
+          const classified = classifyError(message)
+          collectedErrors.push({
+            cluster: cluster.name,
+            errorType: classified.type,
+            message,
+          })
           return [] as NodeInfo[]
         }
       })
@@ -185,8 +252,22 @@ export function useCachedAllNodes(): CachedHookResult<NodeInfo[]> & { nodes: Nod
         }
       }
       await settledWithConcurrency(tasks, undefined, handleSettled)
+      // Publish the final per-cluster error snapshot so every consumer
+      // subscribed via `useSyncExternalStore` re-renders with the fresh
+      // list (Issue 9355).
+      publishNodeClusterErrors(collectedErrors)
       return accumulated
     } })
+
+  // Subscribe every caller to the module-level per-cluster errors snapshot.
+  // The fetcher lives outside React, so we cannot use component-scoped
+  // useState for the error list — useSyncExternalStore is the canonical
+  // bridge from a mutable external store to React render (Issue 9355).
+  const clusterErrors = useSyncExternalStore(
+    subscribeNodeClusterErrors,
+    getNodeClusterErrorsSnapshot,
+    getNodeClusterErrorsSnapshot,
+  )
 
   return {
     nodes: result.data,
@@ -198,6 +279,10 @@ export function useCachedAllNodes(): CachedHookResult<NodeInfo[]> & { nodes: Nod
     isFailed: result.isFailed,
     consecutiveFailures: result.consecutiveFailures,
     lastRefresh: result.lastRefresh,
+    // Per-cluster errors surfaced from the REST fan-out (Issue 9355) so the
+    // multi-cluster drill-down can explain an empty list with "lacks
+    // list-nodes RBAC on cluster X" rather than a generic warning.
+    clusterErrors,
     refetch: result.refetch }
 }
 


### PR DESCRIPTION
## Summary

Mirrors the pods fix from PR #9354 but for the nodes endpoint. The
`/api/mcp/nodes` fan-out returned an empty list when the caller lacked
list-nodes RBAC on one or more clusters, so the "All Nodes" drill-down
showed a generic "detailed list is empty" warning with no way for the
user to know whether to fix their role bindings, retry, or file a bug.

- `useCachedAllNodes` (REST per-cluster fan-out — drives the drill-down)
  now captures each failed cluster in the per-task `catch` block,
  classifies the error via `errorClassifier` (auth / timeout / network /
  certificate / unknown), and publishes the snapshot to a module-level
  subscribable. Consumers read via `useSyncExternalStore` so every
  fetch refreshes the `clusterErrors` array.
- `useNodes` (SSE-based) subscribes to the backend's `cluster_error`
  SSE event and exposes the same `clusterErrors` shape for parity with
  `useAllPods`.
- `MultiClusterSummaryDrillDown` renders a per-cluster breakdown when
  the nodes list is empty but the summary reported a non-zero count:
  "RBAC denied (list-nodes)" in red for 403s, "Transient timeout" in
  yellow for 5xx/timeouts.

Backend already captures per-cluster errors via
`clusterErrorTracker.annotate()` and the SSE `cluster_error` event;
this change wires the existing signal through to the UI so the
acceptance criteria are met without backend work.

Fixes #9355

## Test plan

- [x] Unit test: `useNodes` forwards classified errors from
      `cluster_error` SSE events (auth vs timeout)
- [x] Unit test: `useNodes` emits empty `clusterErrors` when the
      stream succeeds for every cluster
- [x] Unit test: `useCachedAllNodes` surfaces per-cluster RBAC
      denials and transient failures separately from the REST fan-out
- [x] Unit test: `useCachedAllNodes` returns empty `clusterErrors`
      when every cluster succeeds
- [x] Drill-down test updated to include `clusterErrors: []` in the
      mocked hook shape
- [ ] Manual: in demo mode, verify the all-nodes drill-down still
      renders the cached node list normally
- [ ] Manual: in live mode with a cluster that lacks list-nodes
      RBAC, verify the drill-down shows "RBAC denied (list-nodes)"
      for that cluster