### PR TITLE
fix(cards): propagate isDemoFallback to ResourceQuota and Ingress status badges

### DIFF
--- a/web/src/config/cards/ingress-status.ts
+++ b/web/src/config/cards/ingress-status.ts
@@ -95,7 +95,11 @@ export const ingressStatusConfig: UnifiedCardConfig = {
   },
 
   // Metadata
-  isDemoData: true,
+  // Note: `isDemoData` is intentionally omitted. The underlying
+  // `useIngresses` hook reports `isDemoFallback` at fetch time and the
+  // unified wrapper (`useUnifiedIngresses`) propagates it as `isDemoData`.
+  // Hardcoding `isDemoData: true` here caused the Demo badge to appear on
+  // live agent data — see Issue 9357.
   isLive: true,
 }
 

--- a/web/src/config/cards/resource-quota-status.ts
+++ b/web/src/config/cards/resource-quota-status.ts
@@ -95,7 +95,11 @@ export const resourceQuotaStatusConfig: UnifiedCardConfig = {
   },
 
   // Metadata
-  isDemoData: true,
+  // Note: `isDemoData` is intentionally omitted. The underlying
+  // `useResourceQuotas` hook reports `isDemoFallback` at fetch time and the
+  // unified wrapper (`useUnifiedResourceQuotas`) propagates it as
+  // `isDemoData`. Hardcoding `isDemoData: true` here caused the Demo badge
+  // to appear on live agent data — see Issue 9356.
   isLive: true,
 }
 

--- a/web/src/hooks/mcp/__tests__/networking.test.ts
+++ b/web/src/hooks/mcp/__tests__/networking.test.ts
@@ -1305,3 +1305,74 @@ describe('useIngresses — agent skipped when no cluster', () => {
     expect(mockReportAgentDataSuccess).not.toHaveBeenCalled()
   })
 })
+
+// ===========================================================================
+// useIngresses - isDemoFallback wiring (Issue 9357)
+// ===========================================================================
+
+describe('useIngresses — isDemoFallback wiring (Issue 9357)', () => {
+  it('returns isDemoFallback: true when serving demo data in demo mode', async () => {
+    mockIsDemoMode.mockReturnValue(true)
+
+    const { result } = renderHook(() => useIngresses())
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+    expect(result.current.isDemoFallback).toBe(true)
+    // Demo mode must produce non-empty demo ingress data so the Demo badge
+    // shows with actual content (not a fake "empty live" view).
+    expect(result.current.ingresses.length).toBeGreaterThan(0)
+    // Live API must NOT be called in demo mode.
+    expect(mockApiGet).not.toHaveBeenCalled()
+  })
+
+  it('returns isDemoFallback: false when serving live API data', async () => {
+    const liveIngresses = [{ name: 'live-ingress', namespace: 'prod', cluster: 'c1', hosts: ['x.example.com'] }]
+    mockApiGet.mockResolvedValue({ data: { ingresses: liveIngresses } })
+
+    const { result } = renderHook(() => useIngresses())
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+    expect(result.current.isDemoFallback).toBe(false)
+    expect(result.current.ingresses).toEqual(liveIngresses)
+  })
+
+  it('returns isDemoFallback: false when live API fails (empty, not demo)', async () => {
+    mockApiGet.mockRejectedValue(new Error('network error'))
+
+    const { result } = renderHook(() => useIngresses())
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+    expect(result.current.isDemoFallback).toBe(false)
+    expect(result.current.ingresses).toEqual([])
+  })
+
+  it('transitions isDemoFallback from true to false when demo mode is disabled', async () => {
+    mockIsDemoMode.mockReturnValue(true)
+    mockUseDemoMode.mockReturnValue({ isDemoMode: true })
+    const { result, rerender } = renderHook(
+      ({ demo }) => {
+        mockIsDemoMode.mockReturnValue(demo)
+        mockUseDemoMode.mockReturnValue({ isDemoMode: demo })
+        return useIngresses()
+      },
+      { initialProps: { demo: true } }
+    )
+
+    await waitFor(() => expect(result.current.isDemoFallback).toBe(true))
+
+    mockApiGet.mockResolvedValue({ data: { ingresses: [] } })
+    rerender({ demo: false })
+
+    await waitFor(() => expect(result.current.isDemoFallback).toBe(false))
+  })
+
+  it('filters demo ingresses by cluster when cluster is provided', async () => {
+    mockIsDemoMode.mockReturnValue(true)
+
+    const { result } = renderHook(() => useIngresses('eks-prod-us-east-1'))
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+    expect(result.current.isDemoFallback).toBe(true)
+    expect(result.current.ingresses.every(i => i.cluster === 'eks-prod-us-east-1')).toBe(true)
+  })
+})

--- a/web/src/hooks/mcp/__tests__/storage.test.ts
+++ b/web/src/hooks/mcp/__tests__/storage.test.ts
@@ -1188,6 +1188,69 @@ describe('useResourceQuotas — additional branches', () => {
   })
 })
 
+// ===========================================================================
+// useResourceQuotas - isDemoFallback wiring (Issue 9356)
+// ===========================================================================
+
+describe('useResourceQuotas — isDemoFallback wiring (Issue 9356)', () => {
+  it('returns isDemoFallback: true when serving demo data in demo mode', async () => {
+    mockIsDemoMode.mockReturnValue(true)
+
+    const { result } = renderHook(() => useResourceQuotas())
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+    expect(result.current.isDemoFallback).toBe(true)
+  })
+
+  it('returns isDemoFallback: false when serving live API data', async () => {
+    const liveQuotas = [{ name: 'live-quota', namespace: 'prod', cluster: 'c1', hard: { pods: '100' }, used: { pods: '20' }, age: '1d' }]
+    mockApiGet.mockResolvedValue({ data: { resourceQuotas: liveQuotas } })
+
+    const { result } = renderHook(() => useResourceQuotas())
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+    expect(result.current.isDemoFallback).toBe(false)
+    expect(result.current.resourceQuotas).toEqual(liveQuotas)
+  })
+
+  it('returns isDemoFallback: false when live API fails (empty, not demo)', async () => {
+    mockApiGet.mockRejectedValue(new Error('API error'))
+
+    const { result } = renderHook(() => useResourceQuotas())
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+    expect(result.current.isDemoFallback).toBe(false)
+    expect(result.current.resourceQuotas).toEqual([])
+  })
+
+  it('returns isDemoFallback: false when forceLive bypasses demo mode', async () => {
+    mockIsDemoMode.mockReturnValue(true)
+    const liveQuotas = [{ name: 'live-quota', namespace: 'prod', cluster: 'c1', hard: { pods: '100' }, used: { pods: '20' }, age: '1d' }]
+    mockApiGet.mockResolvedValue({ data: { resourceQuotas: liveQuotas } })
+
+    const { result } = renderHook(() => useResourceQuotas(undefined, undefined, true))
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+    // forceLive=true skips demo data, so isDemoFallback must be false
+    // even though global demo mode is on.
+    expect(result.current.isDemoFallback).toBe(false)
+    expect(result.current.resourceQuotas).toEqual(liveQuotas)
+  })
+
+  it('transitions isDemoFallback from true to false when demo mode is disabled', async () => {
+    mockIsDemoMode.mockReturnValue(true)
+    const { result } = renderHook(() => useResourceQuotas())
+
+    await waitFor(() => expect(result.current.isDemoFallback).toBe(true))
+
+    mockIsDemoMode.mockReturnValue(false)
+    mockApiGet.mockResolvedValue({ data: { resourceQuotas: [] } })
+    await act(async () => { result.current.refetch() })
+
+    await waitFor(() => expect(result.current.isDemoFallback).toBe(false))
+  })
+})
+
 describe('useLimitRanges — additional branches', () => {
   it('filters demo limit ranges by both cluster and namespace', async () => {
     mockIsDemoMode.mockReturnValue(true)

--- a/web/src/hooks/mcp/networking.ts
+++ b/web/src/hooks/mcp/networking.ts
@@ -10,6 +10,7 @@ import { REFRESH_INTERVAL_MS, MIN_REFRESH_INDICATOR_MS, getEffectiveInterval, LO
 import { subscribePolling } from './pollingManager'
 import { MCP_HOOK_TIMEOUT_MS, DEPLOY_ABORT_TIMEOUT_MS, SERVICES_CACHE_TTL_MS, LOCAL_AGENT_HTTP_URL } from '../../lib/constants/network'
 import type { Service, Ingress, NetworkPolicy } from './types'
+import { getDemoIngresses } from '../useCachedData/demoData'
 
 // ---------------------------------------------------------------------------
 // Shared Networking State - enables cache reset notifications to all consumers
@@ -353,16 +354,36 @@ export function useServices(cluster?: string, namespace?: string) {
   }
 }
 
+// Hook to get Ingresses.
+// Returns `isDemoFallback: true` when the hook is serving demo data so callers
+// can render the Demo badge only for true demo output. See Issue 9357.
 export function useIngresses(cluster?: string, namespace?: string) {
   const [ingresses, setIngresses] = useState<Ingress[]>([])
   const [isLoading, setIsLoading] = useState(true)
   const [isRefreshing, setIsRefreshing] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const [consecutiveFailures, setConsecutiveFailures] = useState(0)
+  const [isDemoFallback, setIsDemoFallback] = useState(false)
   const { isDemoMode: demoMode } = useDemoMode()
   const initialMountRef = useRef(true)
 
   const refetch = useCallback(async () => {
+    // If demo mode is enabled, use demo data so the Demo badge correctly
+    // reflects the data source. Previously this hook relied on an empty live
+    // response plus a hardcoded `isDemoData: true` in the card config,
+    // producing false positive Demo badges on live data. See Issue 9357.
+    if (isDemoMode()) {
+      const demoIngresses = getDemoIngresses().filter(i =>
+        (!cluster || i.cluster === cluster) && (!namespace || i.namespace === namespace)
+      )
+      setIngresses(demoIngresses)
+      setIsDemoFallback(true)
+      setError(null)
+      setConsecutiveFailures(0)
+      setIsLoading(false)
+      setIsRefreshing(false)
+      return
+    }
     setIsLoading(true)
     setIsRefreshing(true)
     if (cluster && !isAgentUnavailable()) {
@@ -380,6 +401,7 @@ export function useIngresses(cluster?: string, namespace?: string) {
         if (response.ok) {
           const data = await response.json()
           setIngresses(data.ingresses || [])
+          setIsDemoFallback(false)
           setError(null)
           setConsecutiveFailures(0)
           setIsLoading(false)
@@ -397,6 +419,7 @@ export function useIngresses(cluster?: string, namespace?: string) {
       if (namespace) params.append('namespace', namespace)
       const { data } = await api.get<{ ingresses: Ingress[] }>(`${LOCAL_AGENT_HTTP_URL}/ingresses?${params}`)
       setIngresses(data.ingresses || [])
+      setIsDemoFallback(false)
       setError(null)
       setConsecutiveFailures(0)
     } catch {
@@ -404,6 +427,7 @@ export function useIngresses(cluster?: string, namespace?: string) {
       setError(null)
       setConsecutiveFailures(prev => prev + 1)
       setIngresses([])
+      setIsDemoFallback(false)
     } finally {
       setIsLoading(false)
       setIsRefreshing(false)
@@ -430,7 +454,7 @@ export function useIngresses(cluster?: string, namespace?: string) {
     refetch()
   }, [demoMode, refetch])
 
-  return { ingresses, isLoading, isRefreshing, error, refetch, consecutiveFailures, isFailed: consecutiveFailures >= 3 }
+  return { ingresses, isLoading, isRefreshing, error, refetch, consecutiveFailures, isFailed: consecutiveFailures >= 3, isDemoFallback }
 }
 
 // Hook to get NetworkPolicies

--- a/web/src/hooks/mcp/storage.ts
+++ b/web/src/hooks/mcp/storage.ts
@@ -422,10 +422,13 @@ export function usePVs(cluster?: string) {
 // Hook to get ResourceQuotas
 // When forceLive is true, skip demo mode fallback and always query the real API.
 // Used by GPU Reservations to show live data when running in-cluster with OAuth.
+// Returns `isDemoFallback: true` when the hook is serving demo data so callers
+// can render the Demo badge only for true demo output. See Issue 9356.
 export function useResourceQuotas(cluster?: string, namespace?: string, forceLive = false) {
   const [resourceQuotas, setResourceQuotas] = useState<ResourceQuota[]>([])
   const [isLoading, setIsLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
+  const [isDemoFallback, setIsDemoFallback] = useState(false)
 
   const refetch = useCallback(async () => {
     // If demo mode is enabled, use demo data (unless forceLive overrides)
@@ -434,6 +437,7 @@ export function useResourceQuotas(cluster?: string, namespace?: string, forceLiv
         (!cluster || q.cluster === cluster) && (!namespace || q.namespace === namespace)
       )
       setResourceQuotas(demoQuotas)
+      setIsDemoFallback(true)
       setIsLoading(false)
       setError(null)
       return
@@ -445,12 +449,14 @@ export function useResourceQuotas(cluster?: string, namespace?: string, forceLiv
       if (namespace) params.append('namespace', namespace)
       const { data } = await api.get<{ resourceQuotas: ResourceQuota[] }>(`${LOCAL_AGENT_HTTP_URL}/resourcequotas?${params}`)
       setResourceQuotas(data.resourceQuotas || [])
+      setIsDemoFallback(false)
       setError(null)
     } catch {
       // Don't show error - ResourceQuotas are optional
       setError(null)
       // Don't fall back to demo data - show empty instead
       setResourceQuotas([])
+      setIsDemoFallback(false)
     } finally {
       setIsLoading(false)
     }
@@ -476,7 +482,7 @@ export function useResourceQuotas(cluster?: string, namespace?: string, forceLiv
     }
   }, [refetch, cluster, namespace])
 
-  return { resourceQuotas, isLoading, error, refetch }
+  return { resourceQuotas, isLoading, error, refetch, isDemoFallback }
 }
 
 // Hook to get LimitRanges

--- a/web/src/lib/unified/__tests__/registerHooks-hooks.test.ts
+++ b/web/src/lib/unified/__tests__/registerHooks-hooks.test.ts
@@ -608,6 +608,34 @@ describe('additional resource wrapper hooks', () => {
     expect(result.current.data).toEqual([{ name: 'ing1' }])
   })
 
+  // Issue 9357: useUnifiedIngresses must propagate isDemoFallback as
+  // isDemoData so UnifiedCard can suppress the Demo badge on live data.
+  it('useUnifiedIngresses propagates isDemoFallback as isDemoData', () => {
+    mockUseIngresses.mockReturnValue({
+      ingresses: [{ name: 'demo-ing' }],
+      isLoading: false,
+      error: null,
+      refetch: vi.fn(),
+      isDemoFallback: true,
+    })
+    const hook = getHook('useIngresses')
+    const { result } = renderHook(() => hook({ cluster: 'c', namespace: 'n' }))
+    expect(result.current.isDemoData).toBe(true)
+  })
+
+  it('useUnifiedIngresses reports isDemoData: false when live', () => {
+    mockUseIngresses.mockReturnValue({
+      ingresses: [{ name: 'live-ing' }],
+      isLoading: false,
+      error: null,
+      refetch: vi.fn(),
+      isDemoFallback: false,
+    })
+    const hook = getHook('useIngresses')
+    const { result } = renderHook(() => hook({ cluster: 'c', namespace: 'n' }))
+    expect(result.current.isDemoData).toBe(false)
+  })
+
   it('useUnifiedStatefulSets maps statefulsets to data', () => {
     mockUseStatefulSets.mockReturnValue({
       statefulsets: [{ name: 'ss1' }],
@@ -679,6 +707,34 @@ describe('additional resource wrapper hooks', () => {
     const hook = getHook('useResourceQuotas')
     const { result } = renderHook(() => hook({ cluster: 'c', namespace: 'n' }))
     expect(result.current.data).toEqual([{ name: 'rq1' }])
+  })
+
+  // Issue 9356: useUnifiedResourceQuotas must propagate isDemoFallback as
+  // isDemoData so UnifiedCard can suppress the Demo badge on live data.
+  it('useUnifiedResourceQuotas propagates isDemoFallback as isDemoData', () => {
+    mockUseResourceQuotas.mockReturnValue({
+      resourceQuotas: [{ name: 'demo-rq' }],
+      isLoading: false,
+      error: null,
+      refetch: vi.fn(),
+      isDemoFallback: true,
+    })
+    const hook = getHook('useResourceQuotas')
+    const { result } = renderHook(() => hook({ cluster: 'c', namespace: 'n' }))
+    expect(result.current.isDemoData).toBe(true)
+  })
+
+  it('useUnifiedResourceQuotas reports isDemoData: false when live', () => {
+    mockUseResourceQuotas.mockReturnValue({
+      resourceQuotas: [{ name: 'live-rq' }],
+      isLoading: false,
+      error: null,
+      refetch: vi.fn(),
+      isDemoFallback: false,
+    })
+    const hook = getHook('useResourceQuotas')
+    const { result } = renderHook(() => hook({ cluster: 'c', namespace: 'n' }))
+    expect(result.current.isDemoData).toBe(false)
   })
 
   it('useUnifiedLimitRanges maps limitRanges to data', () => {

--- a/web/src/lib/unified/card/UnifiedCard.tsx
+++ b/web/src/lib/unified/card/UnifiedCard.tsx
@@ -61,7 +61,7 @@ export function UnifiedCard({
   }, [config, instanceConfig])
 
   // Fetch data using the configured data source (skipped if overrideData provided)
-  const { data: fetchedData, isLoading: isDataLoading, error, refetch } = useDataSource(
+  const { data: fetchedData, isLoading: isDataLoading, error, refetch, isDemoData: hookIsDemoData } = useDataSource(
     mergedConfig.dataSource,
     { skip: !!overrideData }
   )
@@ -75,6 +75,15 @@ export function UnifiedCard({
   // Determine if we have any data
   const hasAnyData = Array.isArray(data) ? data.length > 0 : !!data
 
+  // Prefer hook-reported demo state over static config metadata:
+  // - Static `config.isDemoData: true` is a false-positive source because
+  //   it stays `true` even when the hook is serving real live data.
+  // - When the hook explicitly reports demo state (`true` or `false`), use
+  //   it directly. When the hook does not report demo state
+  //   (`hookIsDemoData === undefined`), fall back to the config metadata.
+  // See Issues 9356 and 9357 for the regression this fixes.
+  const effectiveIsDemoData = hookIsDemoData !== undefined ? hookIsDemoData : mergedConfig.isDemoData
+
   // Report loading state to CardWrapper for refresh icon animation and skeleton coordination
   // This enables the refresh icon to spin while data is loading or mode is switching
   useReportCardDataState({
@@ -84,7 +93,7 @@ export function UnifiedCard({
     isLoading: isLoading && !hasAnyData,      // Initial load or mode switch - show skeleton
     isRefreshing: isLoading && hasAnyData,     // Refresh - spin refresh icon
     hasData: !isLoading || hasAnyData,         // True once loading completes or has cached data
-    isDemoData: mergedConfig.isDemoData,       // From card config
+    isDemoData: effectiveIsDemoData,           // Hook-reported when available, else config
   })
 
   // Apply filtering if configured

--- a/web/src/lib/unified/card/__tests__/UnifiedCard.test.tsx
+++ b/web/src/lib/unified/card/__tests__/UnifiedCard.test.tsx
@@ -69,8 +69,9 @@ vi.mock('../../../../hooks/useDrillDown', () => ({
   useDrillDownActions: () => mockDrillDownActions,
 }))
 
+const mockUseReportCardDataState = vi.fn()
 vi.mock('../../../../components/cards/CardDataContext', () => ({
-  useReportCardDataState: vi.fn(),
+  useReportCardDataState: (state: unknown) => mockUseReportCardDataState(state),
 }))
 
 let mockIsModeSwitching = false
@@ -355,5 +356,47 @@ describe('UnifiedCard', () => {
     mockFilterReturn.filterControls = <div data-testid="filters">Filters</div>
     render(<UnifiedCard config={makeConfig()} />)
     expect(screen.getByTestId('filters')).toBeInTheDocument()
+  })
+
+  // -- isDemoData wiring (Issues 9356 and 9357) --
+
+  describe('isDemoData propagation (Issues 9356 and 9357)', () => {
+    it('uses hook-reported isDemoData: true over config', () => {
+      // Hook reports demo; config has no isDemoData set.
+      ;(mockDataSourceReturn as unknown as { isDemoData?: boolean }).isDemoData = true
+      render(<UnifiedCard config={makeConfig()} />)
+
+      expect(mockUseReportCardDataState).toHaveBeenCalled()
+      const lastCall = mockUseReportCardDataState.mock.calls.at(-1)?.[0]
+      expect(lastCall?.isDemoData).toBe(true)
+    })
+
+    it('uses hook-reported isDemoData: false over hardcoded config isDemoData: true', () => {
+      // Pre-fix regression case: config hardcoded isDemoData: true but hook
+      // returns live data with isDemoData: false. Must NOT show Demo badge.
+      ;(mockDataSourceReturn as unknown as { isDemoData?: boolean }).isDemoData = false
+      render(<UnifiedCard config={makeConfig({ isDemoData: true })} />)
+
+      const lastCall = mockUseReportCardDataState.mock.calls.at(-1)?.[0]
+      // Hook says live, so Demo badge must be suppressed.
+      expect(lastCall?.isDemoData).toBe(false)
+    })
+
+    it('falls back to config isDemoData when hook does not report it', () => {
+      // Hook returns no isDemoData field (legacy hooks).
+      delete (mockDataSourceReturn as unknown as { isDemoData?: boolean }).isDemoData
+      render(<UnifiedCard config={makeConfig({ isDemoData: true })} />)
+
+      const lastCall = mockUseReportCardDataState.mock.calls.at(-1)?.[0]
+      expect(lastCall?.isDemoData).toBe(true)
+    })
+
+    it('reports undefined isDemoData when neither hook nor config sets it', () => {
+      delete (mockDataSourceReturn as unknown as { isDemoData?: boolean }).isDemoData
+      render(<UnifiedCard config={makeConfig()} />)
+
+      const lastCall = mockUseReportCardDataState.mock.calls.at(-1)?.[0]
+      expect(lastCall?.isDemoData).toBeUndefined()
+    })
   })
 })

--- a/web/src/lib/unified/card/hooks/__tests__/useDataSource.test.ts
+++ b/web/src/lib/unified/card/hooks/__tests__/useDataSource.test.ts
@@ -304,6 +304,61 @@ describe('useDataSource — hook type', () => {
     // Should not throw
     result.current.refetch()
   })
+
+  // Issues 9356 and 9357: hooks that report demo-fallback state must
+  // propagate that through useDataSource so UnifiedCard can show the Demo
+  // badge only for actual demo output.
+  it('propagates isDemoData: true from hook return value', () => {
+    const mockHook = vi.fn().mockReturnValue({
+      data: [{ id: 'demo' }],
+      isLoading: false,
+      error: null,
+      refetch: vi.fn(),
+      isDemoData: true,
+    })
+    registerDataHook('useDemoDataTrueTest', mockHook)
+
+    const { result } = renderHook(() =>
+      useDataSource({ type: 'hook', hook: 'useDemoDataTrueTest' })
+    )
+
+    expect(result.current.isDemoData).toBe(true)
+  })
+
+  it('propagates isDemoData: false from hook return value', () => {
+    const mockHook = vi.fn().mockReturnValue({
+      data: [{ id: 'live' }],
+      isLoading: false,
+      error: null,
+      refetch: vi.fn(),
+      isDemoData: false,
+    })
+    registerDataHook('useDemoDataFalseTest', mockHook)
+
+    const { result } = renderHook(() =>
+      useDataSource({ type: 'hook', hook: 'useDemoDataFalseTest' })
+    )
+
+    expect(result.current.isDemoData).toBe(false)
+  })
+
+  it('returns isDemoData: undefined when hook does not report it', () => {
+    const mockHook = vi.fn().mockReturnValue({
+      data: [{ id: 1 }],
+      isLoading: false,
+      error: null,
+      refetch: vi.fn(),
+      // no isDemoData property - hook doesn't know its demo status
+    })
+    registerDataHook('useNoDemoDataTest', mockHook)
+
+    const { result } = renderHook(() =>
+      useDataSource({ type: 'hook', hook: 'useNoDemoDataTest' })
+    )
+
+    // When undefined, UnifiedCard falls back to the card config's isDemoData.
+    expect(result.current.isDemoData).toBeUndefined()
+  })
 })
 
 // ---------------------------------------------------------------------------

--- a/web/src/lib/unified/card/hooks/useDataSource.ts
+++ b/web/src/lib/unified/card/hooks/useDataSource.ts
@@ -14,6 +14,10 @@ import { FETCH_DEFAULT_TIMEOUT_MS } from '../../../constants'
 import { useKeepAliveActive } from '../../../../hooks/useKeepAliveActive'
 
 // Hook registry - populated by registerDataHook
+// `isDemoData` is optional: hooks that propagate demo-fallback state return
+// `true` when the data being returned came from a demo/mock source. This lets
+// UnifiedCard show the Demo badge only for true demo output. Hooks that do
+// not know their data source may omit this field. See Issues 9356 and 9357.
 const dataHookRegistry: Record<
   string,
   (params?: Record<string, unknown>) => {
@@ -21,6 +25,7 @@ const dataHookRegistry: Record<
     isLoading: boolean
     error: Error | null
     refetch?: () => void
+    isDemoData?: boolean
   }
 > = {}
 
@@ -70,6 +75,7 @@ export function registerDataHook(
     isLoading: boolean
     error: Error | null
     refetch?: () => void
+    isDemoData?: boolean
   }
 ) {
   dataHookRegistry[name] = hook
@@ -96,6 +102,15 @@ export interface UseDataSourceResult {
   isLoading: boolean
   error: Error | null
   refetch: () => void
+  /**
+   * `true` when the underlying data hook explicitly reports that the returned
+   * data is demo/mock. `undefined` when the hook does not report demo status
+   * (in which case callers should fall back to the card config's
+   * `isDemoData` metadata). `false` means the hook explicitly reports live
+   * data — this should override any hardcoded config metadata. See Issues
+   * 9356 and 9357.
+   */
+  isDemoData?: boolean
 }
 
 export interface UseDataSourceOptions {
@@ -216,7 +231,8 @@ function useHookDataSourceInternal(
     data: hookResult.data,
     isLoading: hookResult.isLoading,
     error: hookResult.error,
-    refetch: hookResult.refetch ?? (() => {}) }
+    refetch: hookResult.refetch ?? (() => {}),
+    isDemoData: hookResult.isDemoData }
 }
 
 /**

--- a/web/src/lib/unified/registerHooks.ts
+++ b/web/src/lib/unified/registerHooks.ts
@@ -178,7 +178,10 @@ function useUnifiedIngresses(params?: Record<string, unknown>) {
     data: result.ingresses,
     isLoading: result.isLoading,
     error: result.error ? new Error(result.error) : null,
-    refetch: result.refetch }
+    refetch: result.refetch,
+    // Propagate demo-fallback state so UnifiedCard can show the Demo badge
+    // only for actual demo output (Issue 9357).
+    isDemoData: result.isDemoFallback }
 }
 
 function useUnifiedNodes(params?: Record<string, unknown>) {
@@ -275,7 +278,10 @@ function useUnifiedResourceQuotas(params?: Record<string, unknown>) {
     data: result.resourceQuotas,
     isLoading: result.isLoading,
     error: result.error ? new Error(result.error) : null,
-    refetch: result.refetch }
+    refetch: result.refetch,
+    // Propagate demo-fallback state so UnifiedCard can show the Demo badge
+    // only for actual demo output (Issue 9356).
+    isDemoData: result.isDemoFallback }
 }
 
 function useUnifiedLimitRanges(params?: Record<string, unknown>) {


### PR DESCRIPTION
## Summary

Fixes #9356, Fixes #9357

Both the **Resource Quota Status** and **Ingress Status** cards were showing the Demo badge + yellow outline on live agent data. Shared root cause:

1. The card configs (`resource-quota-status.ts`, `ingress-status.ts`) hardcoded `isDemoData: true`.
2. The underlying MCP hooks (`useResourceQuotas`, `useIngresses`) didn't report their demo-fallback state.
3. `UnifiedCard` only read `config.isDemoData` — it had no way to know whether the hook was actually serving demo or live data.

So the badge was effectively pinned to ON.

## Fix (per `console-isDemoData-wiring` rule)

**Hook is authoritative for demo state; config is a fallback.**

- `useResourceQuotas` and `useIngresses` now expose `isDemoFallback: boolean` on their return value.
- `useIngresses` now explicitly serves demo ingresses when demo mode is on (previously relied on empty live response).
- `useUnifiedResourceQuotas` / `useUnifiedIngresses` propagate `isDemoFallback` as `isDemoData`.
- `useDataSource` forwards `isDemoData` from the registered hook.
- `UnifiedCard` prefers hook-reported `isDemoData` over config metadata; config is used only when the hook doesn't report (keeps existing cards working).
- Both card configs drop the hardcoded `isDemoData: true`.

## Test plan

- [x] `storage.test.ts` — `useResourceQuotas` reports correct `isDemoFallback` in demo, live, `forceLive`, error, and transition cases.
- [x] `networking.test.ts` — `useIngresses` reports correct `isDemoFallback` in demo, live, error, transition, and cluster-filter cases; demo mode does NOT call the live API.
- [x] `useDataSource.test.ts` — `isDemoData` propagates (`true` / `false` / `undefined`).
- [x] `UnifiedCard.test.tsx` — hook-reported `isDemoData: false` overrides hardcoded `config.isDemoData: true` (the regression case).
- [x] `registerHooks-hooks.test.ts` — both unified wrappers propagate `isDemoFallback` as `isDemoData` in either direction.
- [ ] Manual: load `/namespaces` on console.kubestellar.io with real agent data — verify Resource Quota card shows NO Demo badge.
- [ ] Manual: load `/network` on console.kubestellar.io with real agent data — verify Ingress card shows NO Demo badge.
- [ ] Manual: toggle demo mode on — verify both cards show Demo badge + yellow outline with demo data.

## Notes

- Issue references in code comments intentionally use the `Issue NNNN` form (not `#NNNN`) to avoid the ui-ux-standard hex-ratchet false positive on multi-line JSX comments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)