### PR TITLE
fix(feedback): clear form state on success to skip unsaved-changes prompt

### DIFF
--- a/web/src/components/feedback/FeatureRequestModal.test.tsx
+++ b/web/src/components/feedback/FeatureRequestModal.test.tsx
@@ -3,10 +3,14 @@ import { render, screen, fireEvent, waitFor } from '@testing-library/react'
 import * as FeatureRequestModalModule from './FeatureRequestModal'
 import { FeatureRequestModal } from './FeatureRequestModal'
 
-// Mock heavy/lazy deps so the modal mounts cleanly in jsdom
+// Mock heavy/lazy deps so the modal mounts cleanly in jsdom.
+// createRequest is declared outside the factory so individual tests can
+// swap its implementation (e.g. to simulate a successful submission).
+const createRequestMock = vi.fn()
+
 vi.mock('../../hooks/useFeatureRequests', () => ({
   useFeatureRequests: () => ({
-    createRequest: vi.fn(),
+    createRequest: createRequestMock,
     isSubmitting: false,
     requests: [],
     isLoading: false,
@@ -57,6 +61,7 @@ vi.mock('react-i18next', () => ({
 describe('FeatureRequestModal Component', () => {
   beforeEach(() => {
     document.body.innerHTML = ''
+    createRequestMock.mockReset()
   })
 
   it('exports FeatureRequestModal component', () => {
@@ -92,5 +97,51 @@ describe('FeatureRequestModal Component', () => {
 
     // Parent's onClose must have been called exactly once
     await waitFor(() => expect(onClose).toHaveBeenCalledTimes(1))
+  })
+
+  // Regression test for Issue 9358 — after a successful submission the
+  // form shows the "Request Submitted" confirmation view. Clicking Close
+  // must dismiss the modal cleanly, WITHOUT re-surfacing the unsaved-
+  // changes (Save Draft) prompt, even though the internal description
+  // state has not yet been reset by the SUCCESS_DISPLAY_MS timer.
+  it('closes cleanly after successful submission without prompting to save as draft', async () => {
+    const onClose = vi.fn()
+    // Simulate a successful issue creation — onSubmit resolves with a URL.
+    createRequestMock.mockResolvedValue({
+      github_issue_url: 'https://github.com/kubestellar/console/issues/1234',
+      screenshots_uploaded: 0,
+      screenshots_failed: 0,
+    })
+
+    render(<FeatureRequestModal isOpen onClose={onClose} initialTab="submit" />)
+
+    // Fill the description with a valid title (≥10 chars) + body (≥20 chars, ≥3 words).
+    const textarea = await screen.findByRole('textbox')
+    fireEvent.change(textarea, {
+      target: {
+        value:
+          'This is a valid bug title\nThis bug happens when the console crashes on load and users cannot proceed.',
+      },
+    })
+
+    // Submit the form.
+    const submitBtn = screen.getByRole('button', { name: /^Submit/i })
+    fireEvent.click(submitBtn)
+
+    // Wait for the success view to appear.
+    await screen.findByText(/Request Submitted/i)
+
+    // At this point the description state is intentionally still populated —
+    // the modal clears it on a 5s timer. But the content has already been
+    // filed as a GitHub issue, so closing must NOT prompt "Unsaved changes".
+    const closeBtn = await screen.findByRole('button', { name: /^Close$/i })
+    fireEvent.click(closeBtn)
+
+    // Parent's onClose must be invoked…
+    await waitFor(() => expect(onClose).toHaveBeenCalledTimes(1))
+
+    // …and the Unsaved-changes dialog must NOT appear.
+    expect(screen.queryByText(/Unsaved changes/i)).not.toBeInTheDocument()
+    expect(screen.queryByText(/Save Draft & Close/i)).not.toBeInTheDocument()
   })
 })

--- a/web/src/components/feedback/FeatureRequestModal.tsx
+++ b/web/src/components/feedback/FeatureRequestModal.tsx
@@ -199,6 +199,13 @@ export function FeatureRequestModal({ isOpen, onClose, initialTab, initialReques
   isSubmittingRef.current = isSubmitting
   const showDiscardRef = useRef(showDiscardConfirm)
   showDiscardRef.current = showDiscardConfirm
+  // Issue 9358: after a successful submission the form is showing the
+  // "Request Submitted" confirmation view. The description/screenshots
+  // state may still be populated (we clear it on the SUCCESS_DISPLAY_MS
+  // timer), but the content has already been filed as a GitHub issue —
+  // it is NOT unsaved. Close must skip the unsaved-changes prompt.
+  const successRef = useRef(success)
+  successRef.current = success
 
   const forceClose = useCallback(() => {
     // Hide the discard confirmation first so a stale ref can't cause
@@ -230,6 +237,14 @@ export function FeatureRequestModal({ isOpen, onClose, initialTab, initialReques
     // BaseModal's keydown handler must NOT just re-set the same flag —
     // that traps the user. Treat the second close attempt as Discard.
     if (showDiscardRef.current) {
+      forceClose()
+      return
+    }
+    // Issue 9358: once the submission succeeded, the form content has
+    // been filed as a GitHub issue — it is not "unsaved". Close cleanly
+    // without prompting, even if the description/screenshots state has
+    // not yet been reset by the SUCCESS_DISPLAY_MS timer.
+    if (successRef.current) {
       forceClose()
       return
     }


### PR DESCRIPTION
## Summary

Fixes #9358 — reported by @Abhishek-Punhani.

After a successful feedback/issue submission, the modal shows the green "Request Submitted" confirmation view. The underlying `description` / `screenshots` state is intentionally left populated until the `SUCCESS_DISPLAY_MS` timer (5s) resets it. If the user clicked **Close** during that window, `handleClose` ran the dirty-field check (`descriptionRef.current.trim() !== ''`) and incorrectly surfaced the "Unsaved changes" dialog, asking the user to save a draft of content that had already been filed as a GitHub issue.

## Fix

In `FeatureRequestModal.tsx`, short-circuit the dirty-field check in `handleClose` when the `success` state is set. The content is no longer unsaved — it lives on GitHub — so `Close` skips the discard prompt and `forceClose` runs, resetting state and dismissing the modal cleanly.

- Added `successRef` so the stable `handleClose` callback can read the latest success state without being rebuilt on every keystroke (matches the existing `descriptionRef` / `isSubmittingRef` pattern).
- Minimal scope: one component file + its test. No surrounding refactor.

## Test plan

- [x] Added regression test `closes cleanly after successful submission without prompting to save as draft` in `FeatureRequestModal.test.tsx` — mocks `createRequest` to resolve with a GitHub issue URL, submits the form, waits for the success view, clicks **Close**, and asserts:
  - Parent `onClose` is invoked exactly once.
  - The "Unsaved changes" dialog never appears.
  - The "Save Draft & Close" button never appears.
- [ ] Existing regression test for #9152 (Discard path) still passes.
- [ ] Manual: open modal, fill a bug, Submit, wait for green checkmark, click Close — closes cleanly.