### PR TITLE
fix(tests): resolve 3 Coverage Suite failures from PRs 9359 and 9361

### DIFF
--- a/web/src/components/feedback/FeatureRequestModal.test.tsx
+++ b/web/src/components/feedback/FeatureRequestModal.test.tsx
@@ -128,8 +128,11 @@ describe('FeatureRequestModal Component', () => {
     const submitBtn = screen.getByRole('button', { name: /^Submit/i })
     fireEvent.click(submitBtn)
 
-    // Wait for the success view to appear.
-    await screen.findByText(/Request Submitted/i)
+    // Wait for the success view to appear. The success view renders a plain
+    // (non-i18n) paragraph "Your request has been submitted for review." — use
+    // that as the anchor so the assertion doesn't depend on the mocked `t`
+    // returning the raw i18n key (feedback.requestSubmitted).
+    await screen.findByText(/Your request has been submitted for review/i)
 
     // At this point the description state is intentionally still populated —
     // the modal clears it on a 5s timer. But the content has already been

--- a/web/src/hooks/useCachedNodes.ts
+++ b/web/src/hooks/useCachedNodes.ts
@@ -29,6 +29,18 @@ export interface NodeClusterError {
   message: string
 }
 
+/**
+ * Per-cluster fan-out result returned by each {@link useCachedAllNodes}
+ * concurrency callback. Each task returns one of these synchronous tuples
+ * instead of mutating shared accumulators, keeping the callback safe under
+ * the concurrent-mutation-safety ratchet
+ * (src/test/concurrent-mutation-safety.test.ts).
+ */
+interface PerClusterNodeResult {
+  nodes: NodeInfo[]
+  error: NodeClusterError | null
+}
+
 // Module-level subscribable snapshot of the most recent per-cluster errors
 // emitted by the {@link useCachedAllNodes} fetcher. We use a module-level
 // subscribable (rather than per-hook React state) because `useCache`'s
@@ -205,18 +217,17 @@ export function useCachedAllNodes(): CachedHookResult<NodeInfo[]> & {
         )
       }
 
-      // Collect per-cluster errors during this fetch. We replace the
-      // previous module-level snapshot atomically after the fan-out settles
-      // so a transient flash of "cluster X failed" isn't left stale after
-      // a retry succeeds (Issue 9355).
-      const collectedErrors: NodeClusterError[] = []
-
       // Fan out per-cluster fetches in parallel. Each per-cluster call is
       // identical to what useCachedNodes(clusterName) would do — using the
       // same /api/mcp/nodes endpoint that already works on the per-cluster
       // drill-down, so the "live data path exists" invariant from the
       // issue description holds.
-      const tasks = reachable.map((cluster) => async () => {
+      //
+      // Concurrency-safety: each callback RETURNS a tagged { nodes, error }
+      // tuple instead of mutating outer-scope accumulators. Aggregation
+      // happens after `settledWithConcurrency` resolves (see P2-B static
+      // scan, src/test/concurrent-mutation-safety.test.ts).
+      const tasks = reachable.map((cluster) => async (): Promise<PerClusterNodeResult> => {
         try {
           const raw = await fetchAPI<unknown>('nodes', { cluster: cluster.name })
           const data = validateArrayResponse<{ nodes: NodeInfo[] }>(
@@ -225,7 +236,10 @@ export function useCachedAllNodes(): CachedHookResult<NodeInfo[]> & {
             '/api/mcp/nodes',
             'nodes',
           )
-          return (data.nodes || []).map((n) => ({ ...n, cluster: cluster.name }))
+          return {
+            nodes: (data.nodes || []).map((n) => ({ ...n, cluster: cluster.name })),
+            error: null,
+          }
         } catch (err) {
           // Per-cluster failure: tolerate it so a single unreachable cluster
           // doesn't wipe the whole aggregate. Accumulated nodes from other
@@ -236,25 +250,38 @@ export function useCachedAllNodes(): CachedHookResult<NodeInfo[]> & {
           // warning that conflated every failure mode.
           const message = err instanceof Error ? err.message : String(err)
           const classified = classifyError(message)
-          collectedErrors.push({
-            cluster: cluster.name,
-            errorType: classified.type,
-            message,
-          })
-          return [] as NodeInfo[]
+          return {
+            nodes: [],
+            error: {
+              cluster: cluster.name,
+              errorType: classified.type,
+              message,
+            },
+          }
         }
       })
 
-      const accumulated: NodeInfo[] = []
-      async function handleSettled(res: PromiseSettledResult<NodeInfo[]>) {
+      // Aggregate per-cluster results AFTER settlement. Both lists are
+      // produced by local consts inside handleSettled's caller scope — no
+      // outer-scope mutation from inside the concurrency callback.
+      const settledResults: PerClusterNodeResult[] = []
+      async function handleSettled(res: PromiseSettledResult<PerClusterNodeResult>) {
         if (res.status === 'fulfilled') {
-          accumulated.push(...res.value)
+          settledResults.push(res.value)
         }
       }
       await settledWithConcurrency(tasks, undefined, handleSettled)
+
+      const accumulated: NodeInfo[] = settledResults.flatMap((r) => r.nodes)
+      const collectedErrors: NodeClusterError[] = settledResults
+        .map((r) => r.error)
+        .filter((e): e is NodeClusterError => e !== null)
+
       // Publish the final per-cluster error snapshot so every consumer
       // subscribed via `useSyncExternalStore` re-renders with the fresh
-      // list (Issue 9355).
+      // list (Issue 9355). We replace the previous module-level snapshot
+      // atomically after the fan-out settles so a transient flash of
+      // "cluster X failed" isn't left stale after a retry succeeds.
       publishNodeClusterErrors(collectedErrors)
       return accumulated
     } })


### PR DESCRIPTION
## Summary

Coverage Suite run #1199 flagged 3 test failures introduced by our own recent merges:

- **`FeatureRequestModal > closes cleanly after successful submission without prompting to save as draft`** (from PR #9361)
- **`concurrent-mutation-safety.test.ts` ratchet — 2 failures** (from PR #9359)

## Fix 1 — FeatureRequestModal success-close test

The test anchored on `/Request Submitted/i`, but the scoped `react-i18next` mock in this file returns the raw i18n key when no fallback is provided:

```ts
useTranslation: () => ({ t: (_k, fallback) => fallback || _k })
```

`SuccessView` calls `t('feedback.requestSubmitted')` with no fallback, so the rendered text is the literal key `feedback.requestSubmitted`, which does not match the regex.

Anchor instead on the plain (non-i18n) paragraph `"Your request has been submitted for review."` that `SuccessView` renders right below the heading. Assertion is still meaningful (success view was reached) but no longer depends on the mock's key-returning behavior.

## Fix 2+3 — concurrent-mutation-safety ratchet

The P2-B static scan flagged:

```
hooks/useCachedNodes.ts
  L239: .push( on "collectedErrors" — collectedErrors.push({
```

PR #9359 introduced a per-cluster error collector that was declared in the fetcher scope but mutated from inside the `settledWithConcurrency` callback — the exact "interleaved await writes to a shared accumulator" pattern the ratchet catches.

Refactored to the established "return values, aggregate after settlement" pattern used by the 10 violations fixed in #6857. Each task now returns a tagged `PerClusterNodeResult { nodes, error }` tuple; the final node list and error list are built by `flatMap` / `filter` on the settled results. The module-level subscribable snapshot (used by `useSyncExternalStore` to bridge the fetcher-outside-React boundary) is unchanged — only the outer-scope mutation inside the callback is gone.

## Test plan

- [x] `npx vitest run src/components/feedback/FeatureRequestModal.test.tsx --no-coverage` — 3 passed
- [x] `npx vitest run src/test/concurrent-mutation-safety.test.ts --no-coverage` — 7 passed
- [x] `npx vitest run src/hooks/__tests__/useCachedNodes.test.ts --no-coverage` — 15 passed (no regression in existing hook suite)
- [ ] Coverage Suite green on CI

Fixes #9362