### PR TITLE
fix(release): disable cosign new-bundle-format so signing works on cosign v3.x

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -301,7 +301,19 @@ jobs:
           # Sign checksums file with keyless cosign (Sigstore OIDC)
           # The scorecard Signed-Releases check looks for .sig files
           # attached to GitHub release assets
+          #
+          # --new-bundle-format=false: cosign v3.x defaults this to true and
+          # then requires --bundle to be specified; with the flag enabled the
+          # legacy --output-signature / --output-certificate flags are silently
+          # ignored and cosign fails with
+          #   "create bundle file: open : no such file or directory"
+          # because no --bundle path is set. Disabling the new bundle format
+          # restores the legacy .sig/.pem output that the scorecard
+          # Signed-Releases check and prior releases rely on. See
+          # https://github.com/sigstore/cosign/releases/tag/v3.0.1 for the
+          # v3 --bundle-required change.
           cosign sign-blob --yes \
+            --new-bundle-format=false \
             --output-signature dist/checksums.txt.sig \
             --output-certificate dist/checksums.txt.pem \
             dist/checksums.txt


### PR DESCRIPTION
## Summary

The nightly release for `v0.3.22-nightly.20260421` failed with:

```
Error: signing dist/checksums.txt: create bundle file: open : no such file or directory
```

**Root cause**: `sigstore/cosign-installer@v4.1.1` does not pin `cosign-release`, so the installer picks its default. Between the 2026-04-20 run (cosign v2.4.3, success) and the 2026-04-21 run (cosign v3.0.5, failure) the default crossed into cosign v3.x. In cosign v3:

- `--new-bundle-format` now defaults to `true`
- `--bundle <path>` became **required** (per [v3.0.1 release notes](https://github.com/sigstore/cosign/releases/tag/v3.0.1))
- Legacy `--output-signature` / `--output-certificate` flags are silently ignored with a deprecation warning

So the workflow's legacy flags produced the two deprecation warnings in the log, then cosign tried to write to an unspecified `--bundle` path and failed with the empty-path `open` error.

## Fix

Pass `--new-bundle-format=false` to `cosign sign-blob`. This restores the legacy `.sig` / `.pem` output that:

- The OpenSSF scorecard `Signed-Releases` check looks for (per the existing workflow comment)
- Every prior kubestellar/console release already publishes

No consumer-visible artifact change — the release assets stay identical to pre-v3 behavior.

## Log evidence

From [run 24706281210](https://github.com/kubestellar/console/actions/runs/24706281210):

```
2026-04-21T06:55:02.5461356Z WARNING: --output-signature is deprecated when using --new-bundle-format and will be ignored
2026-04-21T06:55:02.5463664Z WARNING: --output-certificate is deprecated when using --new-bundle-format and will be ignored
2026-04-21T06:55:02.6515908Z Signing artifact...
2026-04-21T06:55:03.8226979Z Error: signing dist/checksums.txt: create bundle file: open : no such file or directory
```

Contrast with 4/20 success (run 24650806331):

```
2026-04-20T07:01:05.1759106Z INFO: Downloading bootstrap version 'v2.4.3' of cosign ...
```

## Test plan

- [x] `cosign sign-blob --new-bundle-format=false` is a valid flag in cosign v3.x (confirmed in `cmd/cosign/cli/options/signblob.go` at v3.0.5 — `BoolVar(&o.NewBundleFormat, "new-bundle-format", true, ...)`)
- [ ] Next nightly release (2026-04-22 05:45 UTC) completes the `Sign release artifacts with cosign` step and produces `checksums.txt.sig` + `checksums.txt.pem` on the release
- [ ] `helm-release` job runs (was skipped this time because `release` failed)

Fixes #9335, Fixes #9336