### PR TITLE
fix(e2e): restore clusters-page testid for cross-browser nightly

### DIFF
--- a/web/src/components/clusters/Clusters.tsx
+++ b/web/src/components/clusters/Clusters.tsx
@@ -435,6 +435,7 @@ export function Clusters() {
 
   return (
     <DashboardPage
+      testId="clusters-page"
       title={t('navigation.clusters')}
       subtitle={t('cluster.subtitle')}
       icon="Server"

--- a/web/src/lib/dashboards/DashboardPage.tsx
+++ b/web/src/lib/dashboards/DashboardPage.tsx
@@ -82,6 +82,15 @@ export interface DashboardPageProps {
   isDemoData?: boolean
   /** Custom drag-end handler (called after card reorder, e.g. for workload drops) */
   onDragEnd?: (event: DragEndEvent) => void
+  /**
+   * Optional `data-testid` applied to the outer page wrapper. Pages that
+   * embed DashboardPage (Clusters, Events, etc.) can pass a route-specific
+   * id so cross-browser Playwright specs have a stable mount selector that
+   * survives refactors. See issue 9344 — Clusters.spec.ts expects
+   * `clusters-page` but the testid was lost when the page migrated to
+   * DashboardPage.
+   */
+  testId?: string
 }
 
 // ============================================================================
@@ -108,7 +117,8 @@ export function DashboardPage({
   rightExtra,
   emptyState,
   isDemoData = false,
-  onDragEnd: externalDragEnd }: DashboardPageProps) {
+  onDragEnd: externalDragEnd,
+  testId }: DashboardPageProps) {
   const [searchParams, setSearchParams] = useSearchParams()
   const location = useLocation()
   // Capture the route path at mount time — KeepAlive keeps this component alive
@@ -328,7 +338,7 @@ export function DashboardPage({
     // fixed-position children (FAB, customizer, modals) must live OUTSIDE it
     // to avoid clipping when ancestors create a new containing block (issue 8464).
     <>
-    <div className="pt-16 min-w-0 max-w-full overflow-x-hidden">
+    <div className="pt-16 min-w-0 max-w-full overflow-x-hidden" data-testid={testId}>
       {/* Header */}
       <DashboardHeader
         title={title}

--- a/web/src/lib/dashboards/__tests__/DashboardPage.test.tsx
+++ b/web/src/lib/dashboards/__tests__/DashboardPage.test.tsx
@@ -283,6 +283,25 @@ describe('DashboardPage', () => {
     expect(screen.getByTestId('header-extra')).toBeInTheDocument()
   })
 
+  // Issue 9344 — pages that embed DashboardPage (Clusters, Events, ...) need
+  // a stable route-specific testid on the page wrapper so cross-browser
+  // Playwright specs can synchronize on "page mounted". This is a contract
+  // test: if the prop is dropped, the nightly cross-browser suite regresses.
+  it('applies testId to the outer page wrapper when provided', () => {
+    const { container } = renderPage({ testId: 'clusters-page' })
+    expect(container.querySelector('[data-testid="clusters-page"]')).not.toBeNull()
+  })
+
+  it('omits data-testid on the wrapper when testId is not provided', () => {
+    const { container } = renderPage()
+    // The outer wrapper is the first div inside the test render. Without an
+    // explicit testId it must not emit a stray `data-testid` attribute —
+    // keeps existing selectors (dashboard-page, etc.) unambiguous.
+    const wrapper = container.querySelector('div.pt-16')
+    expect(wrapper).not.toBeNull()
+    expect(wrapper?.hasAttribute('data-testid')).toBe(false)
+  })
+
   it('opens customizer when floating action button is clicked', () => {
     const setShowAddCard = vi.fn()
     mockUseDashboard.mockReturnValue(makeDashboardReturn({ setShowAddCard }))


### PR DESCRIPTION
Fixes #9344

## Summary

The Playwright Cross-Browser (Nightly) workflow has been red for 10+ consecutive nights on webkit + firefox. Root cause: when /clusters migrated to the shared DashboardPage wrapper, the data-testid="clusters-page" attribute that Clusters.spec.ts synchronizes on was dropped from the DOM. Every Clusters spec (13+ tests) times out waiting for the page to mount.

- Adds a testId prop to DashboardPage — same pattern Dashboard.tsx / Settings.tsx already use for dashboard-page / settings-page.
- Wires testId="clusters-page" through Clusters.tsx.
- Adds two contract unit tests so this cannot silently regress again.

## Scope note

The same nightly run also surfaces separate failures that are out of scope here (mobile h3 hidden, cluster count 3 vs 0, responsive tablet/laptop overflow, custom-dashboard sidebar, smoke console errors). Those have distinct root causes and warrant separate PRs. This PR fixes the single largest source of failures (the 13+ Clusters tests).

## Test plan

- [ ] CI builds and lints pass
- [ ] Nightly run shows Clusters.spec.ts tests passing on webkit + firefox
- [ ] Follow-up issues filed for the out-of-scope failures listed above