### PR TITLE
fix(HardwareHealthCard): fix hooks order violation and memoize sortedAlerts

### DIFF
--- a/web/src/components/cards/HardwareHealthCard.tsx
+++ b/web/src/components/cards/HardwareHealthCard.tsx
@@ -127,6 +127,9 @@ export function HardwareHealthCard() {
   const [sortDirection, setSortDirection] = useState<'asc' | 'desc'>('desc')
   const [currentPage, setCurrentPage] = useState(1)
   const [itemsPerPage, setItemsPerPage] = useState<number | 'unlimited'>(5)
+  // Declared here (with other state) to maintain stable hook order across renders.
+  // Previously declared after useEffect calls which violated rules of hooks (#4086).
+  const [clearAlertError, setClearAlertError] = useState<string | null>(null)
 
   const clusterFilterRef = useRef<HTMLDivElement>(null)
 
@@ -282,8 +285,9 @@ export function HardwareHealthCard() {
     return filteredAlerts.filter(a => !isSnoozed(a.id)).map(a => a.id)
   }, [filteredAlerts, isSnoozed])
 
-  // Sort alerts
-  const sortedAlerts = (() => {
+  // Sort alerts — memoized so sortedAlerts.length is stable across renders
+  // and won't cause totalPages → currentTotalPages → pagination useEffect to loop.
+  const sortedAlerts = useMemo(() => {
     const severityOrder: Record<string, number> = { critical: 0, warning: 1 }
 
     return [...filteredAlerts].sort((a, b) => {
@@ -305,7 +309,7 @@ export function HardwareHealthCard() {
       }
       return sortDirection === 'asc' ? cmp : -cmp
     })
-  })()
+  }, [filteredAlerts, sortField, sortDirection])
 
   // Pagination
   const effectivePerPage = itemsPerPage === 'unlimited' ? sortedAlerts.length : itemsPerPage
@@ -332,9 +336,6 @@ export function HardwareHealthCard() {
   const clearClusterFilter = () => {
     setLocalClusterFilter([])
   }
-
-  // Track clear-alert error for user feedback
-  const [clearAlertError, setClearAlertError] = useState<string | null>(null)
 
   // Clear an alert (after power cycle) — triggers refetch to update cached data
   const clearAlert = async (alertId: string) => {


### PR DESCRIPTION
## Summary

Two GA4-detected errors on the `/` (home) dashboard, both in `HardwareHealthCard.tsx`:

**1. React error #185 — "Rendered more hooks than during the previous render"**

`clearAlertError` (`useState`) was declared at line 337, *after* four `useEffect` calls (lines 144, 261, 271, 322). React requires hooks to be called in the same order on every render. Fix: move the declaration to line 130 with all other state declarations.

**2. "Maximum update depth exceeded" — setState loop**

`sortedAlerts` was an IIFE (`const sortedAlerts = (() => { ... })()`), creating a new array reference on every render. The unstable array length fed into `totalPages` → `currentTotalPages` → the pagination `useEffect`, which could trigger a cascade of re-renders. Fix: convert to `useMemo` with deps `[filteredAlerts, sortField, sortDirection]`, consistent with `sortedInventory` which was already memoized.

## Test plan

- [ ] Home dashboard loads without React error #185 in console
- [ ] Hardware Health card sorts/paginates without infinite re-render
- [ ] GA4 `ksc_error` count drops on next sampling window

Fixes #4086

🤖 Generated with [Claude Code](https://claude.com/claude-code)