### PR TITLE
test(coverage): add localStorage error paths, DataTable rows, and pipeline mutations

### DIFF
--- a/web/src/components/charts/__tests__/DataTable.test.tsx
+++ b/web/src/components/charts/__tests__/DataTable.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from 'vitest'
-import { render } from '@testing-library/react'
+import { render, screen, fireEvent } from '@testing-library/react'
 
 vi.mock('../../../lib/demoMode', () => ({
   isDemoMode: () => true, getDemoMode: () => true, isNetlifyDeployment: false,
@@ -29,9 +29,66 @@ vi.mock('../../../hooks/useTokenUsage', () => ({
 
 import { DataTable } from '../DataTable'
 
+const cols = [
+  { key: 'name' as const, header: 'Name' },
+  { key: 'value' as const, header: 'Value' },
+]
+
+type Row = { name: string; value: string }
+
 describe('DataTable', () => {
   it('renders without crashing', () => {
     const { container } = render(<DataTable data={[]} columns={[]} />)
     expect(container).toBeTruthy()
+  })
+
+  it('shows empty state when data is empty', () => {
+    render(<DataTable data={[]} columns={cols} />)
+    expect(screen.getByText('common.noData')).toBeTruthy()
+  })
+
+  it('renders rows from data', () => {
+    const data: Row[] = [{ name: 'foo', value: 'bar' }]
+    render(<DataTable data={data} columns={cols} />)
+    expect(screen.getByText('foo')).toBeTruthy()
+    expect(screen.getByText('bar')).toBeTruthy()
+  })
+
+  it('renders multiple rows', () => {
+    const data: Row[] = [
+      { name: 'a', value: '1' },
+      { name: 'b', value: '2' },
+    ]
+    render(<DataTable data={data} columns={cols} />)
+    expect(screen.getByText('a')).toBeTruthy()
+    expect(screen.getByText('b')).toBeTruthy()
+  })
+
+  it('calls onRowClick when row is clicked', () => {
+    const onRowClick = vi.fn()
+    const data: Row[] = [{ name: 'clickable', value: 'row' }]
+    render(<DataTable data={data} columns={cols} onRowClick={onRowClick} />)
+    fireEvent.click(screen.getByText('clickable'))
+    expect(onRowClick).toHaveBeenCalledWith(data[0])
+  })
+
+  it('uses custom render function when provided', () => {
+    const customCols = [
+      { key: 'name' as const, header: 'Name', render: (v: Row['name']) => `custom:${v}` },
+      { key: 'value' as const, header: 'Value' },
+    ]
+    const data: Row[] = [{ name: 'foo', value: 'bar' }]
+    render(<DataTable data={data} columns={customCols} />)
+    expect(screen.getByText('custom:foo')).toBeTruthy()
+  })
+
+  it('renders title when provided', () => {
+    render(<DataTable data={[]} columns={[]} title="My Table" />)
+    expect(screen.getByText('My Table')).toBeTruthy()
+  })
+
+  it('does not render title element when title is omitted', () => {
+    const { container } = render(<DataTable data={[]} columns={[]} />)
+    expect(container.querySelector('h4')).toBeNull()
   })
 })

--- a/web/src/hooks/__tests__/useGitHubPipelines.test.ts
+++ b/web/src/hooks/__tests__/useGitHubPipelines.test.ts
@@ -3,7 +3,7 @@
  * The hooks themselves delegate to useCache; we test the config they
  * pass rather than re-testing the cache layer.
  */
-import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { renderHook } from '@testing-library/react'
 
 const lastCacheArgs: { calls: Array<Record<string, unknown>> } = { calls: [] }
@@ -49,6 +49,9 @@ import {
   usePipelineMatrix,
   usePipelineFlow,
   usePipelineFailures,
+  useUnifiedPipelineData,
+  usePipelineMutations,
+  fetchPipelineLog,
 } from '../useGitHubPipelines'
 
 describe('getPipelineRepos', () => {
@@ -156,5 +159,101 @@ describe('hooks pass correct useCache config', () => {
   it('usePipelineFailures uses key containing gh-pipelines-failures', () => {
     renderHook(() => usePipelineFailures('kubestellar/console'))
     expect(lastCacheArgs.calls.some(a => (a.key as string).includes('gh-pipelines-failures'))).toBe(true)
+  })
+
+  it('useUnifiedPipelineData with null repo uses key gh-pipelines-all:all:14', () => {
+    renderHook(() => useUnifiedPipelineData(null))
+    expect(lastCacheArgs.calls.some(a => a.key === 'gh-pipelines-all:all:14')).toBe(true)
+  })
+
+  it('useUnifiedPipelineData with repo includes repo and days in key', () => {
+    renderHook(() => useUnifiedPipelineData('kubestellar/console', 7))
+    expect(lastCacheArgs.calls.some(a => (a.key as string).includes('kubestellar/console') && (a.key as string).includes(':7'))).toBe(true)
+  })
+})
+
+describe('usePipelineMutations', () => {
+  afterEach(() => { vi.restoreAllMocks() })
+
+  it('run calls fetch with POST and correct params on rerun', async () => {
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve({}),
+    })
+    vi.stubGlobal('fetch', mockFetch)
+    const { result } = renderHook(() => usePipelineMutations())
+    const res = await result.current.run('rerun', 'kubestellar/console', 42)
+    expect(res.ok).toBe(true)
+    expect(res.status).toBe(200)
+    expect(mockFetch).toHaveBeenCalledWith(
+      expect.stringContaining('op=rerun'),
+      expect.objectContaining({ method: 'POST' })
+    )
+    vi.unstubAllGlobals()
+  })
+
+  it('run returns error shape when fetch throws', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('network failure')))
+    const { result } = renderHook(() => usePipelineMutations())
+    const res = await result.current.run('cancel', 'kubestellar/console', 99)
+    expect(res.ok).toBe(false)
+    expect(res.status).toBe(0)
+    expect(res.error).toBe('network failure')
+    vi.unstubAllGlobals()
+  })
+
+  it('run returns ok:false when server returns non-ok status', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: false,
+      status: 422,
+      json: () => Promise.resolve({ error: 'unprocessable' }),
+    }))
+    const { result } = renderHook(() => usePipelineMutations())
+    const res = await result.current.run('rerun', 'kubestellar/console', 7)
+    expect(res.ok).toBe(false)
+    expect(res.status).toBe(422)
+    expect(res.error).toBe('unprocessable')
+    vi.unstubAllGlobals()
+  })
+})
+
+describe('fetchPipelineLog', () => {
+  afterEach(() => { vi.restoreAllMocks() })
+
+  it('returns log shape on success', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve({ log: 'hello world', lines: 1, truncatedFrom: 0 }),
+    }))
+    const res = await fetchPipelineLog('kubestellar/console', 55)
+    expect('log' in res).toBe(true)
+    if ('log' in res) {
+      expect(res.log).toBe('hello world')
+      expect(res.lines).toBe(1)
+      expect(res.truncatedFrom).toBe(0)
+    }
+    vi.unstubAllGlobals()
+  })
+
+  it('returns error shape when server returns non-ok', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: false,
+      status: 404,
+      json: () => Promise.resolve({ error: 'not found' }),
+    }))
+    const res = await fetchPipelineLog('kubestellar/console', 55)
+    expect('error' in res).toBe(true)
+    if ('error' in res) expect(res.error).toBe('not found')
+    vi.unstubAllGlobals()
+  })
+
+  it('returns error shape when fetch throws', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('timeout')))
+    const res = await fetchPipelineLog('kubestellar/console', 55)
+    expect('error' in res).toBe(true)
+    if ('error' in res) expect(res.error).toBe('timeout')
+    vi.unstubAllGlobals()
   })
 })

--- a/web/src/lib/utils/__tests__/localStorage.test.ts
+++ b/web/src/lib/utils/__tests__/localStorage.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach } from 'vitest'
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest'
 import { safeGetItem, safeSetItem, safeRemoveItem, safeGetJSON, safeSetJSON } from '../localStorage'
 
 describe('safeGetItem', () => {
@@ -16,20 +16,32 @@ describe('safeGetItem', () => {
 
 describe('safeSetItem', () => {
   beforeEach(() => { localStorage.clear() })
+  afterEach(() => { vi.restoreAllMocks() })
 
   it('stores a value and returns true', () => {
     expect(safeSetItem('key', 'val')).toBe(true)
     expect(localStorage.getItem('key')).toBe('val')
   })
+
+  it('returns false when setItem throws (quota exceeded)', () => {
+    vi.spyOn(Storage.prototype, 'setItem').mockImplementation(() => { throw new DOMException('QuotaExceededError') })
+    expect(safeSetItem('key', 'val')).toBe(false)
+  })
 })
 
 describe('safeRemoveItem', () => {
   beforeEach(() => { localStorage.clear() })
+  afterEach(() => { vi.restoreAllMocks() })
 
   it('removes a key and returns true', () => {
     localStorage.setItem('key', 'val')
     expect(safeRemoveItem('key')).toBe(true)
     expect(localStorage.getItem('key')).toBeNull()
+  })
+
+  it('returns false when removeItem throws', () => {
+    vi.spyOn(Storage.prototype, 'removeItem').mockImplementation(() => { throw new Error('storage error') })
+    expect(safeRemoveItem('key')).toBe(false)
   })
 })
 
@@ -58,6 +70,7 @@ describe('safeGetJSON', () => {
 
 describe('safeSetJSON', () => {
   beforeEach(() => { localStorage.clear() })
+  afterEach(() => { vi.restoreAllMocks() })
 
   it('stores JSON and returns true', () => {
     expect(safeSetJSON('key', { x: 1 })).toBe(true)
@@ -67,5 +80,10 @@ describe('safeSetJSON', () => {
   it('handles arrays', () => {
     expect(safeSetJSON('arr', [1, 2, 3])).toBe(true)
     expect(JSON.parse(localStorage.getItem('arr')!)).toEqual([1, 2, 3])
+  })
+
+  it('returns false when setItem throws (quota exceeded)', () => {
+    vi.spyOn(Storage.prototype, 'setItem').mockImplementation(() => { throw new DOMException('QuotaExceededError') })
+    expect(safeSetJSON('key', { x: 1 })).toBe(false)
   })
 })


### PR DESCRIPTION
## Summary

- Covers `safeSetItem`, `safeRemoveItem`, `safeSetJSON` error catch blocks in `localStorage.ts` (trigger via `vi.spyOn(Storage.prototype, ...).mockImplementation(() => { throw ... })`)
- Covers `DataTable` tbody rendering, row click handler, custom render function, empty state, and title prop
- Covers `useUnifiedPipelineData`, `usePipelineMutations` (POST rerun/cancel success + error paths), and `fetchPipelineLog` (success + HTTP error + network throw) in `useGitHubPipelines.ts`

Targets ≥91% line coverage (currently 90.48%).

## Test plan
- [ ] CI coverage-gate passes
- [ ] All new tests pass in shards 1-12
- [ ] Badge updates to ≥91% after merge + coverage-hourly run