### PR TITLE
fix(tests): repair 3 localStorage.test.ts failures from PR 9369

### DIFF
--- a/web/src/lib/utils/__tests__/localStorage.test.ts
+++ b/web/src/lib/utils/__tests__/localStorage.test.ts
@@ -24,7 +24,11 @@ describe('safeSetItem', () => {
   })
 
   it('returns false when setItem throws (quota exceeded)', () => {
-    vi.spyOn(Storage.prototype, 'setItem').mockImplementation(() => { throw new DOMException('QuotaExceededError') })
+    // Issue 9372: the test setup (src/test/setup.ts) replaces window.localStorage
+    // with a plain object literal, so it does NOT inherit from Storage.prototype.
+    // Spying on Storage.prototype.setItem therefore never intercepts the mocked
+    // instance's method — we must spy directly on the localStorage instance.
+    vi.spyOn(window.localStorage, 'setItem').mockImplementation(() => { throw new DOMException('QuotaExceededError') })
     expect(safeSetItem('key', 'val')).toBe(false)
   })
 })
@@ -40,7 +44,8 @@ describe('safeRemoveItem', () => {
   })
 
   it('returns false when removeItem throws', () => {
-    vi.spyOn(Storage.prototype, 'removeItem').mockImplementation(() => { throw new Error('storage error') })
+    // Issue 9372: spy directly on the localStorage instance — see note above.
+    vi.spyOn(window.localStorage, 'removeItem').mockImplementation(() => { throw new Error('storage error') })
     expect(safeRemoveItem('key')).toBe(false)
   })
 })
@@ -83,7 +88,8 @@ describe('safeSetJSON', () => {
   })
 
   it('returns false when setItem throws (quota exceeded)', () => {
-    vi.spyOn(Storage.prototype, 'setItem').mockImplementation(() => { throw new DOMException('QuotaExceededError') })
+    // Issue 9372: spy directly on the localStorage instance — see note in safeSetItem.
+    vi.spyOn(window.localStorage, 'setItem').mockImplementation(() => { throw new DOMException('QuotaExceededError') })
     expect(safeSetJSON('key', { x: 1 })).toBe(false)
   })
 })


### PR DESCRIPTION
## Summary

Fixes Issue 9372 — 3 test failures in `src/lib/utils/__tests__/localStorage.test.ts` introduced by PR #9369:

- `safeSetItem returns false when setItem throws (quota exceeded)`
- `safeRemoveItem returns false when removeItem throws`
- `safeSetJSON returns false when setItem throws`

## Root cause

The tests used `vi.spyOn(Storage.prototype, 'setItem' | 'removeItem')` to force `localStorage` methods to throw. However, `src/test/setup.ts` replaces `window.localStorage` with a plain object literal:

```ts
const localStorageMock = {
  getItem: (key: string) => ...,
  setItem: (key: string, value: string) => ...,
  // ...
}
Object.defineProperty(window, 'localStorage', { value: localStorageMock, writable: true })
```

That mock does **not** inherit from `Storage.prototype`, so spying on `Storage.prototype.setItem` never intercepts the installed mock. The `safe*` helpers ran normally, stored the value, and returned `true` — causing the `.toBe(false)` assertions to fail.

## Fix

Spy directly on the `window.localStorage` instance instead of `Storage.prototype`, which matches how the test setup actually installs the mock. The implementation in `src/lib/utils/localStorage.ts` was already correct (catches errors, returns `false`) — this is a test-only fix.

All 30 tests in `localStorage.test.ts` now pass.

## Test plan

- [x] `npm test -- localStorage.test.ts --no-coverage --run` passes (30/30)
- [ ] CI build/lint pass

Fixes #9372