### PR TITLE
fix(orbits): confirm before creating orbit with empty cluster selection

### DIFF
--- a/web/src/components/missions/StandaloneOrbitDialog.tsx
+++ b/web/src/components/missions/StandaloneOrbitDialog.tsx
@@ -16,6 +16,7 @@ import { ORBIT_DEFAULT_CADENCE } from '../../lib/constants/orbit'
 import { emitOrbitMissionCreated } from '../../lib/analytics'
 import { isDemoMode } from '../../lib/demoMode'
 import { SetupInstructionsDialog } from '../setup/SetupInstructionsDialog'
+import { ConfirmDialog } from '../../lib/modals'
 import type { OrbitCadence, OrbitType, OrbitConfig } from '../../lib/missions/types'
 
 interface StandaloneOrbitDialogProps {
@@ -41,6 +42,9 @@ export function StandaloneOrbitDialog({ onClose }: StandaloneOrbitDialogProps) {
   const [selectedClusters, setSelectedClusters] = useState<Set<string>>(new Set())
   const [showClusterPicker, setShowClusterPicker] = useState(false)
   const [showSetupDialog, setShowSetupDialog] = useState(false)
+  // Issue 9373: confirm before creating an orbit with an empty cluster selection
+  // (which would otherwise silently target every connected cluster).
+  const [showAllClustersConfirm, setShowAllClustersConfirm] = useState(false)
 
   const clusters = deduplicatedClusters || []
 
@@ -61,14 +65,11 @@ export function StandaloneOrbitDialog({ onClose }: StandaloneOrbitDialogProps) {
     setSelectedClusters(new Set())
   }, [])
 
-  const handleCreate = useCallback(() => {
+  // Actually build + persist the orbit mission. Split out so both the
+  // primary Create button and the "run on all clusters" confirmation
+  // can invoke it (Issue 9373).
+  const persistOrbitMission = useCallback(() => {
     if (!selectedOrbit) return
-
-    // In demo mode, redirect to local install setup dialog
-    if (isDemoMode()) {
-      setShowSetupDialog(true)
-      return
-    }
 
     const template = templates.find(tpl => tpl.orbitType === selectedOrbit)
     if (!template) return
@@ -100,6 +101,31 @@ export function StandaloneOrbitDialog({ onClose }: StandaloneOrbitDialogProps) {
     emitOrbitMissionCreated(selectedOrbit, cadence)
     onClose()
   }, [selectedOrbit, cadence, autoRun, selectedClusters, templates, saveMission, onClose])
+
+  const handleCreate = useCallback(() => {
+    if (!selectedOrbit) return
+
+    // In demo mode, redirect to local install setup dialog
+    if (isDemoMode()) {
+      setShowSetupDialog(true)
+      return
+    }
+
+    // Issue 9373: If the user left the cluster picker empty we would
+    // otherwise silently target every connected cluster. Surface a
+    // confirmation modal instead of proceeding silently.
+    if (selectedClusters.size === 0 && clusters.length > 0) {
+      setShowAllClustersConfirm(true)
+      return
+    }
+
+    persistOrbitMission()
+  }, [selectedOrbit, selectedClusters, clusters.length, persistOrbitMission])
+
+  const handleConfirmAllClusters = useCallback(() => {
+    setShowAllClustersConfirm(false)
+    persistOrbitMission()
+  }, [persistOrbitMission])
 
   return (
     <>
@@ -301,6 +327,17 @@ export function StandaloneOrbitDialog({ onClose }: StandaloneOrbitDialogProps) {
     {showSetupDialog && (
       <SetupInstructionsDialog isOpen={showSetupDialog} onClose={() => setShowSetupDialog(false)} />
     )}
+    {/* Issue 9373: Empty cluster selection fallback confirmation. */}
+    <ConfirmDialog
+      isOpen={showAllClustersConfirm}
+      onClose={() => setShowAllClustersConfirm(false)}
+      onConfirm={handleConfirmAllClusters}
+      title={t('orbit.confirmAllClustersTitle')}
+      message={t('orbit.confirmAllClustersMessage', { count: clusters.length })}
+      confirmLabel={t('orbit.confirmAllClustersContinue')}
+      cancelLabel={t('common.cancel', { defaultValue: 'Cancel' })}
+      variant="warning"
+    />
     </>
   )
 }

--- a/web/src/components/missions/__tests__/StandaloneOrbitDialog.test.tsx
+++ b/web/src/components/missions/__tests__/StandaloneOrbitDialog.test.tsx
@@ -1,0 +1,164 @@
+/**
+ * StandaloneOrbitDialog unit tests
+ *
+ * Covers: smoke render, and the Issue 9373 confirmation flow when the user
+ * clicks Create Orbit with no clusters selected (which would otherwise
+ * silently target every connected cluster).
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+
+// ── Mocks ────────────────────────────────────────────────────────────────
+
+// Force real (non-demo) mode so handleCreate runs the real save path
+// (in demo mode it short-circuits to the SetupInstructionsDialog).
+vi.mock('../../../lib/demoMode', () => ({
+  isDemoMode: () => false,
+  getDemoMode: () => false,
+  isNetlifyDeployment: false,
+  isDemoModeForced: false,
+  canToggleDemoMode: () => true,
+  setDemoMode: vi.fn(),
+  toggleDemoMode: vi.fn(),
+  subscribeDemoMode: () => () => {},
+  isDemoToken: () => false,
+  hasRealToken: () => true,
+  setDemoToken: vi.fn(),
+  isFeatureEnabled: () => true,
+}))
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    // Return the key so we can assert on it (with interpolation baked in
+    // for count-style keys we actually check).
+    t: (key: string, opts?: Record<string, unknown>) => {
+      if (opts && typeof opts.count === 'number') {
+        return `${key}:count=${opts.count}`
+      }
+      if (opts && typeof opts.defaultValue === 'string') {
+        return opts.defaultValue
+      }
+      return key
+    },
+  }),
+}))
+
+const saveMissionMock = vi.fn()
+vi.mock('../../../hooks/useMissions', () => ({
+  useMissions: () => ({ saveMission: saveMissionMock }),
+}))
+
+// Two fake connected clusters so the "empty selection silently targets all"
+// branch is exercised (the guard requires clusters.length > 0).
+vi.mock('../../../hooks/mcp/clusters', () => ({
+  useClusters: () => ({
+    clusters: [
+      { name: 'prod-us-east-1', healthy: true },
+      { name: 'prod-eu-west-1', healthy: true },
+    ],
+    deduplicatedClusters: [
+      { name: 'prod-us-east-1', healthy: true },
+      { name: 'prod-eu-west-1', healthy: true },
+    ],
+    isLoading: false,
+  }),
+}))
+
+vi.mock('../../../lib/analytics', () => ({
+  emitOrbitMissionCreated: vi.fn(),
+  emitNavigate: vi.fn(),
+  emitLogin: vi.fn(),
+  emitEvent: vi.fn(),
+  analyticsReady: Promise.resolve(),
+}))
+
+// SetupInstructionsDialog pulls in heavy deps; stub it.
+vi.mock('../../setup/SetupInstructionsDialog', () => ({
+  SetupInstructionsDialog: () => null,
+}))
+
+import { StandaloneOrbitDialog } from '../StandaloneOrbitDialog'
+
+describe('StandaloneOrbitDialog', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('renders without crashing', () => {
+    const { container } = render(<StandaloneOrbitDialog onClose={vi.fn()} />)
+    expect(container).toBeTruthy()
+    expect(screen.getByText('orbit.standaloneTitle')).toBeInTheDocument()
+  })
+
+  // Issue 9373: clicking Create with no clusters selected should open
+  // a confirmation modal (not silently target all clusters).
+  it('Issue 9373: shows confirmation dialog when creating with no clusters selected', async () => {
+    const user = userEvent.setup()
+    const onClose = vi.fn()
+
+    render(<StandaloneOrbitDialog onClose={onClose} />)
+
+    // Primary Create button uses the orbit.standaloneCreate translation key
+    const createBtn = screen.getByText('orbit.standaloneCreate')
+    await user.click(createBtn)
+
+    // Confirmation dialog title should appear
+    expect(screen.getByText('orbit.confirmAllClustersTitle')).toBeInTheDocument()
+    // Message should include the cluster count (2 from our mock)
+    expect(
+      screen.getByText('orbit.confirmAllClustersMessage:count=2'),
+    ).toBeInTheDocument()
+
+    // Mission should NOT have been persisted yet.
+    expect(saveMissionMock).not.toHaveBeenCalled()
+    expect(onClose).not.toHaveBeenCalled()
+  })
+
+  // Issue 9373: confirming the "run on all clusters" modal should proceed
+  // with persistence (legitimate run-on-all intent).
+  it('Issue 9373: confirming the empty-selection modal persists the mission', async () => {
+    const user = userEvent.setup()
+    const onClose = vi.fn()
+
+    render(<StandaloneOrbitDialog onClose={onClose} />)
+
+    await user.click(screen.getByText('orbit.standaloneCreate'))
+
+    // Click the confirm button.
+    const confirmBtn = screen.getByText('orbit.confirmAllClustersContinue')
+    await user.click(confirmBtn)
+
+    // Mission should now have been saved with an empty cluster list
+    // (the "all clusters" semantics are a downstream concern).
+    expect(saveMissionMock).toHaveBeenCalledTimes(1)
+    const saved = saveMissionMock.mock.calls[0][0] as {
+      context: { orbitConfig: { clusters: string[] } }
+    }
+    expect(saved.context.orbitConfig.clusters).toEqual([])
+    expect(onClose).toHaveBeenCalledTimes(1)
+  })
+
+  // Issue 9373: cancelling the modal must not persist anything and must
+  // leave the primary dialog open so the user can pick clusters.
+  it('Issue 9373: cancelling the confirm dialog does not persist', async () => {
+    const user = userEvent.setup()
+    const onClose = vi.fn()
+
+    render(<StandaloneOrbitDialog onClose={onClose} />)
+
+    await user.click(screen.getByText('orbit.standaloneCreate'))
+    // Confirm dialog open — two "Cancel" buttons exist now (parent dialog +
+    // the ConfirmDialog). The ConfirmDialog is appended last, so its button
+    // is the last one in DOM order.
+    const cancelButtons = screen.getAllByText('Cancel')
+    const confirmCancel = cancelButtons[cancelButtons.length - 1]
+    await user.click(confirmCancel)
+
+    expect(saveMissionMock).not.toHaveBeenCalled()
+    // Parent dialog should still be open (Create button still in DOM)
+    expect(screen.getByText('orbit.standaloneCreate')).toBeInTheDocument()
+    expect(onClose).not.toHaveBeenCalled()
+  })
+})

--- a/web/src/locales/en/common.json
+++ b/web/src/locales/en/common.json
@@ -2040,7 +2040,10 @@
     "standaloneSelectAll": "Select all",
     "standaloneDeselectAll": "Deselect all",
     "standaloneCreate": "Create Orbit",
-    "addOrbit": "Add Orbit"
+    "addOrbit": "Add Orbit",
+    "confirmAllClustersTitle": "No clusters selected",
+    "confirmAllClustersMessage": "This orbit will run against all {{count}} connected cluster(s). Do you want to continue?",
+    "confirmAllClustersContinue": "Run on all clusters"
   },
   "update": {
     "available": "Update Available",


### PR DESCRIPTION
## Summary

When creating a standalone Orbit mission without selecting any clusters, the dialog previously persisted the mission silently — downstream code treats an empty cluster list as "run against every connected cluster". Users had no warning that clicking Create with an empty selection was a blast-radius decision.

This PR adds a warning-variant `ConfirmDialog` that surfaces the implicit "all clusters" target, shows the count of connected clusters, and requires explicit confirmation. If the user cancels, the primary dialog remains open so they can scope the orbit before saving.

- Split `persistOrbitMission()` out of `handleCreate()` so both the direct path and the confirm path can reuse it.
- Reuse the shared `ConfirmDialog` from `lib/modals` (same component used by `ClusterGroups` and other dialogs).
- Add three i18n keys (`confirmAllClustersTitle` / `Message` / `Continue`) in `locales/en/common.json`.

Reported-by: @ghanshyam2005singh

## Test plan

- [x] New test file `StandaloneOrbitDialog.test.tsx` covering:
  - Smoke render
  - Issue 9373: clicking Create with empty selection opens the confirmation (does NOT persist)
  - Issue 9373: confirming the modal persists the mission with an empty cluster list (explicit "run on all" intent)
  - Issue 9373: cancelling the modal does not persist and leaves the primary dialog open
- [x] All existing `src/components/missions/__tests__/` tests still pass (42/42)
- [x] `ui-ux-standards` and `no-magic-numbers` ratchet tests still pass
- [ ] Manually verify: open Add Orbit, leave clusters empty, click Create Orbit, see warning modal with correct count

Fixes #9373