### PR TITLE
feat(federation): add provider interface + multi-hub fan-out skeleton

### DIFF
--- a/pkg/agent/federation/federation_test.go
+++ b/pkg/agent/federation/federation_test.go
@@ -1,0 +1,257 @@
+package federation
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"k8s.io/client-go/rest"
+)
+
+// fakeProvider is a configurable stub that supports every Provider method.
+// Tests construct one per scenario — Name() drives registry keying, and the
+// error / result channels drive fan-out behavior deterministically.
+type fakeProvider struct {
+	name FederationProviderName
+
+	detectResult DetectResult
+	detectErr    error
+	detectDelay  time.Duration
+	detectCalls  int32
+
+	clusters    []FederatedCluster
+	clustersErr error
+
+	groups    []FederatedGroup
+	groupsErr error
+
+	pending    []PendingJoin
+	pendingErr error
+}
+
+func (f *fakeProvider) Name() FederationProviderName { return f.name }
+
+func (f *fakeProvider) Detect(ctx context.Context, _ *rest.Config) (DetectResult, error) {
+	atomic.AddInt32(&f.detectCalls, 1)
+	if f.detectDelay > 0 {
+		select {
+		case <-time.After(f.detectDelay):
+		case <-ctx.Done():
+			return DetectResult{}, ctx.Err()
+		}
+	}
+	return f.detectResult, f.detectErr
+}
+
+func (f *fakeProvider) ReadClusters(context.Context, *rest.Config) ([]FederatedCluster, error) {
+	return f.clusters, f.clustersErr
+}
+
+func (f *fakeProvider) ReadGroups(context.Context, *rest.Config) ([]FederatedGroup, error) {
+	return f.groups, f.groupsErr
+}
+
+func (f *fakeProvider) ReadPendingJoins(context.Context, *rest.Config) ([]PendingJoin, error) {
+	return f.pending, f.pendingErr
+}
+
+func TestRegistry_EmptyInitialState(t *testing.T) {
+	// PR A ships with the registry empty — every `go test` invocation should
+	// see zero providers registered by default. If a future PR accidentally
+	// registers a provider from this package's init(), this test catches it.
+	Reset()
+	if got := All(); len(got) != 0 {
+		t.Fatalf("registry should start empty; got %d providers", len(got))
+	}
+	if _, ok := Get(ProviderOCM); ok {
+		t.Fatalf("Get should miss on an empty registry")
+	}
+}
+
+func TestRegistry_RegisterAndGet(t *testing.T) {
+	Reset()
+	defer Reset()
+
+	ocm := &fakeProvider{name: ProviderOCM}
+	karmada := &fakeProvider{name: ProviderKarmada}
+	Register(ocm)
+	Register(karmada)
+
+	if got, ok := Get(ProviderOCM); !ok || got != ocm {
+		t.Fatalf("Get(OCM) mismatch: ok=%v", ok)
+	}
+	if got, ok := Get(ProviderKarmada); !ok || got != karmada {
+		t.Fatalf("Get(Karmada) mismatch: ok=%v", ok)
+	}
+	// All() must be lexicographic by Name so iteration order is stable in
+	// other callers (e.g. UI-rendered provider tiles).
+	all := All()
+	if len(all) != 2 {
+		t.Fatalf("All() returned %d, want 2", len(all))
+	}
+	if all[0].Name() != ProviderKarmada || all[1].Name() != ProviderOCM {
+		t.Fatalf("All() not sorted; got %v, %v", all[0].Name(), all[1].Name())
+	}
+}
+
+func TestRegistry_RegisterNilPanics(t *testing.T) {
+	Reset()
+	defer Reset()
+	defer func() {
+		if r := recover(); r == nil {
+			t.Fatalf("Register(nil) should panic; did not")
+		}
+	}()
+	Register(nil)
+}
+
+func TestRegistry_ResetClears(t *testing.T) {
+	Reset()
+	Register(&fakeProvider{name: ProviderOCM})
+	if len(All()) != 1 {
+		t.Fatalf("sanity: registry should have 1 entry before Reset")
+	}
+	Reset()
+	if len(All()) != 0 {
+		t.Fatalf("Reset should empty the registry")
+	}
+}
+
+// testConfigResolver always returns a non-nil *rest.Config so fake providers
+// can be invoked without a real kubeconfig. Returning a shared pointer is
+// fine — fake providers don't touch the config.
+func testConfigResolver(string) (*rest.Config, error) {
+	return &rest.Config{}, nil
+}
+
+// fanOutHelpers are re-exported from the agent package in real life; the
+// tests below exercise the server-package fan-out in the agent test file.
+// This file covers registry-level behavior only. For scenarios that need
+// the fan-out helper itself, see server_federation_test.go.
+
+func TestFederationError_ImplementsError(t *testing.T) {
+	// FederationError must satisfy `error` so callers can return it directly
+	// anywhere `error` is expected.
+	var e error = &FederationError{
+		Provider:   ProviderOCM,
+		HubContext: "hub-a",
+		Type:       ClusterErrorAuth,
+		Message:    "forbidden",
+	}
+	if e.Error() != "auth: forbidden" {
+		t.Fatalf("unexpected Error(): %q", e.Error())
+	}
+	var nilE *FederationError
+	if nilE.Error() != "" {
+		t.Fatalf("nil FederationError should Error() to empty string")
+	}
+}
+
+// TestFanOut_ParallelExecution asserts that Detect is invoked concurrently
+// across providers rather than serialized. We construct N providers that
+// each block for a fixed delay and verify that the total elapsed time is
+// less than N * delay. The margin is wide enough (N * delay / 2) that this
+// is not flaky under CI load.
+func TestFanOut_ParallelExecution(t *testing.T) {
+	const n = 5
+	const delay = 100 * time.Millisecond
+	providers := make([]Provider, 0, n)
+	for i := 0; i < n; i++ {
+		providers = append(providers, &fakeProvider{
+			name:         FederationProviderName(string(rune('a' + i))),
+			detectResult: DetectResult{Detected: true},
+			detectDelay:  delay,
+		})
+	}
+
+	// Invoke Detect on all providers in parallel and measure wall-clock.
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	var wg sync.WaitGroup
+	start := time.Now()
+	for _, p := range providers {
+		wg.Add(1)
+		go func(p Provider) {
+			defer wg.Done()
+			_, _ = p.Detect(ctx, &rest.Config{})
+		}(p)
+	}
+	wg.Wait()
+	elapsed := time.Since(start)
+
+	// Serial would be n*delay = 500ms; parallel should be ~delay = 100ms.
+	// Allow up to 2.5× delay for CI jitter while still catching serialization.
+	maxAllowed := time.Duration(float64(delay) * 2.5)
+	if elapsed > maxAllowed {
+		t.Fatalf("providers ran serially (elapsed=%v > %v)", elapsed, maxAllowed)
+	}
+
+	for i, p := range providers {
+		fp := p.(*fakeProvider)
+		if got := atomic.LoadInt32(&fp.detectCalls); got != 1 {
+			t.Fatalf("provider %d: Detect called %d times, want 1", i, got)
+		}
+	}
+}
+
+// TestFanOut_OneProviderErrorDoesNotPoisonOthers verifies the plan's
+// cross-provider isolation guarantee: one provider returning an auth error
+// must not prevent another provider's results from being collected. This
+// test targets the provider-level behavior; the server-level fan-out test
+// (server_federation_test.go) repeats the assertion at the HTTP layer.
+func TestFanOut_OneProviderErrorDoesNotPoisonOthers(t *testing.T) {
+	Reset()
+	defer Reset()
+
+	// Provider A: auth failure on every read.
+	providerA := &fakeProvider{
+		name:        ProviderOCM,
+		clustersErr: errors.New("forbidden: 403"),
+	}
+	// Provider B: normal results.
+	clusterB := FederatedCluster{
+		Provider:   ProviderKarmada,
+		HubContext: "hub-b",
+		Name:       "member-1",
+		State:      ClusterStateJoined,
+	}
+	providerB := &fakeProvider{
+		name:     ProviderKarmada,
+		clusters: []FederatedCluster{clusterB},
+	}
+	Register(providerA)
+	Register(providerB)
+
+	all := All()
+	if len(all) != 2 {
+		t.Fatalf("expected 2 registered providers; got %d", len(all))
+	}
+
+	// Simulate the server's per-provider branch. We expect A to err and B
+	// to succeed; we assert both outcomes are visible to the caller.
+	ctx := context.Background()
+	cfg := &rest.Config{}
+
+	var gotErr error
+	var gotClusters []FederatedCluster
+
+	for _, p := range all {
+		cs, err := p.ReadClusters(ctx, cfg)
+		if err != nil {
+			gotErr = err
+			continue
+		}
+		gotClusters = append(gotClusters, cs...)
+	}
+
+	if gotErr == nil {
+		t.Fatalf("expected provider A to report an error")
+	}
+	if len(gotClusters) != 1 || gotClusters[0].Name != clusterB.Name {
+		t.Fatalf("provider B's result was poisoned: got %+v", gotClusters)
+	}
+}

--- a/pkg/agent/federation/provider.go
+++ b/pkg/agent/federation/provider.go
@@ -1,0 +1,55 @@
+package federation
+
+import (
+	"context"
+
+	"k8s.io/client-go/rest"
+)
+
+// Provider is the plugin contract every multi-cluster-management backend
+// implements. Phase 1 (read-only) exposes Detect + three readers; Phase 2
+// extends this interface with Actions()/Execute() — see the master plan at
+// /Users/andan02/.claude/plans/glistening-stargazing-toast.md.
+//
+// Implementations MUST be safe to call concurrently — the server fans out
+// every registered provider against every kubeconfig context in parallel.
+//
+// Implementations MUST NOT cache the *rest.Config between calls. The server
+// may pass a fresh config per request (e.g. after kubeconfig reload). The
+// provider is expected to build its dynamic client on every call from the
+// supplied config. If that is too expensive, the server layer can be
+// extended with a config-keyed cache without changing this contract.
+//
+// Every error returned SHOULD be classifiable by the caller via
+// ClusterErrorType; providers that cannot distinguish a missing CRD from a
+// real failure should return an empty slice and a nil error to represent
+// "not installed" — the server's Detect() stage is the canonical source of
+// installation truth.
+type Provider interface {
+	// Name returns the stable provider identifier used by the server, the
+	// UI, and the JSON payload. Must match one of the ProviderXxx constants.
+	Name() FederationProviderName
+
+	// Detect probes whether the provider's control plane is present on the
+	// cluster reachable via cfg. It is the cheapest possible check (API
+	// group discovery or a single list on a marker CRD) because the server
+	// calls it on every (provider, context) pair before the reader methods.
+	// A detected=false result SHOULD NOT return an error — that shape is
+	// reserved for probe failures that the UI can surface distinctly from
+	// "provider simply not installed."
+	Detect(ctx context.Context, cfg *rest.Config) (DetectResult, error)
+
+	// ReadClusters returns every cluster the controller on cfg reports.
+	// Phase 1 has no concept of a "current" cluster — the caller iterates
+	// every context and stamps HubContext on each returned row.
+	ReadClusters(ctx context.Context, cfg *rest.Config) ([]FederatedCluster, error)
+
+	// ReadGroups returns every cluster group (ClusterSet, selector group,
+	// peer relationship, infra bucket) the controller on cfg reports.
+	ReadGroups(ctx context.Context, cfg *rest.Config) ([]FederatedGroup, error)
+
+	// ReadPendingJoins returns every in-flight registration on cfg.
+	// Providers with no concept of pending joins (fully-static federations)
+	// return an empty slice and a nil error.
+	ReadPendingJoins(ctx context.Context, cfg *rest.Config) ([]PendingJoin, error)
+}

--- a/pkg/agent/federation/registry.go
+++ b/pkg/agent/federation/registry.go
@@ -1,0 +1,76 @@
+package federation
+
+import "sync"
+
+// registry holds the process-wide set of federation Providers. It is
+// intentionally package-local; callers go through Register / All / Get so
+// that tests can manipulate the set deterministically via Reset.
+//
+// PR A ships with the registry empty. Each subsequent provider PR (OCM in B,
+// Karmada in C, CAPI in D, Clusternet/Liqo/KubeAdmiral in E) registers its
+// own plugin in an init() on its package, and the cmd/kc-agent binary
+// imports those packages with a blank identifier to trigger registration.
+// Until PR B lands, the server returns empty slices for every read.
+var (
+	registryMu sync.RWMutex
+	registry   = map[FederationProviderName]Provider{}
+)
+
+// Register adds p to the global registry. Overwrite is allowed to make test
+// injection (and future hot-reload) straightforward; production providers
+// each register a unique Name() so collisions never occur. Panics on a nil
+// provider to catch init-order bugs loudly rather than silently swallowing.
+func Register(p Provider) {
+	if p == nil {
+		panic("federation.Register: nil provider")
+	}
+	registryMu.Lock()
+	defer registryMu.Unlock()
+	registry[p.Name()] = p
+}
+
+// All returns every registered Provider in a stable iteration order. The
+// returned slice is a copy — callers may mutate it without affecting the
+// registry. Iteration order is lexicographic by provider name so test
+// assertions don't flake on Go map randomization.
+func All() []Provider {
+	registryMu.RLock()
+	defer registryMu.RUnlock()
+
+	out := make([]Provider, 0, len(registry))
+	for _, p := range registry {
+		out = append(out, p)
+	}
+	sortProviders(out)
+	return out
+}
+
+// Get returns the Provider registered under name, if any.
+func Get(name FederationProviderName) (Provider, bool) {
+	registryMu.RLock()
+	defer registryMu.RUnlock()
+	p, ok := registry[name]
+	return p, ok
+}
+
+// Reset empties the registry. Exported only for tests — production code
+// never calls it. Providers are expected to register once at init-time and
+// remain for the process lifetime.
+func Reset() {
+	registryMu.Lock()
+	defer registryMu.Unlock()
+	registry = map[FederationProviderName]Provider{}
+}
+
+// sortProviders orders providers by Name() for stable iteration in All().
+// Broken out so tests can exercise the ordering without reaching into the
+// unexported registry map.
+func sortProviders(ps []Provider) {
+	// Insertion sort — N is at most 6 in this plan, so this is simpler than
+	// sort.Slice and avoids allocating a comparator closure.
+	for i := 1; i < len(ps); i++ {
+		for j := i; j > 0 && ps[j-1].Name() > ps[j].Name(); j-- {
+			ps[j-1], ps[j] = ps[j], ps[j-1]
+		}
+	}
+}

--- a/pkg/agent/federation/types.go
+++ b/pkg/agent/federation/types.go
@@ -1,0 +1,244 @@
+// Package federation defines the provider-plugin interface that kc-agent uses
+// to report multi-cluster-management awareness (federation hubs, registered
+// clusters, lifecycle state, etc.) back to the console UI.
+//
+// See /Users/andan02/.claude/plans/glistening-stargazing-toast.md and Issue
+// 9368 for the broader rollout plan. PR A introduces the types, interface,
+// registry, and multi-hub fan-out server with NO provider implementations.
+// Each subsequent PR (B-E for readers, F-I for actions) adds one provider at
+// a time — all UI work ships in PR B onwards.
+//
+// IMPORTANT: this package intentionally contains no network or kubeconfig
+// lookup logic itself. Providers read through the dynamic client they receive
+// from the server layer, which is built from the user's kubeconfig —
+// NEVER from InClusterConfig. That constraint keeps federation reads aligned
+// with the console-wide identity rule (pod SA is reserved for bootstrap,
+// GPU reservation, and self-upgrade only).
+package federation
+
+import "time"
+
+// FederationProviderName identifies one multi-cluster-management backend. It
+// exists as a distinct string alias (not a bare string) so callers that
+// accidentally pass a UI-facing label cannot silently be routed to the wrong
+// provider by the registry.
+type FederationProviderName string
+
+const (
+	// ProviderOCM is Red Hat / CNCF Sandbox Open Cluster Management
+	// (cluster.open-cluster-management.io).
+	ProviderOCM FederationProviderName = "ocm"
+	// ProviderKarmada is CNCF Incubating Karmada (cluster.karmada.io).
+	ProviderKarmada FederationProviderName = "karmada"
+	// ProviderClusternet is CNCF Sandbox Clusternet (clusters.clusternet.io).
+	ProviderClusternet FederationProviderName = "clusternet"
+	// ProviderLiqo is CNCF Sandbox Liqo (discovery.liqo.io).
+	ProviderLiqo FederationProviderName = "liqo"
+	// ProviderKubeAdmiral is CNCF Sandbox KubeAdmiral (core.kubeadmiral.io).
+	ProviderKubeAdmiral FederationProviderName = "kubeadmiral"
+	// ProviderCAPI is CNCF Incubating Cluster API (cluster.x-k8s.io). CAPI
+	// is lifecycle-oriented rather than federation-oriented, but lives in the
+	// same plugin because "My Clusters" surfaces both pools together.
+	ProviderCAPI FederationProviderName = "capi"
+)
+
+// ClusterState is the unified state enum shared across federation-style and
+// lifecycle-style providers. Federation providers (OCM, Karmada, Clusternet,
+// Liqo, KubeAdmiral) emit the first group; CAPI emits the lifecycle group.
+// The cross-provider union lets a single UI row render either flavor without
+// a parallel schema. See Issue 9368.
+type ClusterState string
+
+const (
+	// ClusterStateJoined — federation controller has accepted the cluster.
+	ClusterStateJoined ClusterState = "joined"
+	// ClusterStatePending — registration in progress (CSR awaiting approval,
+	// ForeignCluster peering, Machine bootstrapping, ...).
+	ClusterStatePending ClusterState = "pending"
+	// ClusterStateUnknown — controller reports the cluster but not its state.
+	ClusterStateUnknown ClusterState = "unknown"
+	// ClusterStateNotMember — cluster is visible to the hub but explicitly
+	// not part of any ClusterSet / selector.
+	ClusterStateNotMember ClusterState = "not-member"
+	// ClusterStateProvisioning — CAPI is creating infrastructure.
+	ClusterStateProvisioning ClusterState = "provisioning"
+	// ClusterStateProvisioned — CAPI reports the cluster is up; user may or
+	// may not have imported the kubeconfig yet.
+	ClusterStateProvisioned ClusterState = "provisioned"
+	// ClusterStateFailed — CAPI provisioning failed; user retry required.
+	ClusterStateFailed ClusterState = "failed"
+	// ClusterStateDeleting — CAPI is tearing the cluster down.
+	ClusterStateDeleting ClusterState = "deleting"
+)
+
+// ClusterErrorType classifies per-provider, per-hub failures so the UI can
+// render distinct affordances (retry, reauth, install-guide) without parsing
+// error message strings. Mirrors pkg/k8s classifyError() output vocabulary
+// so the same UI can consume both shapes — see NodeClusterError from PR 9359.
+type ClusterErrorType string
+
+const (
+	// ClusterErrorAuth — 401/403, expired token, missing credentials.
+	ClusterErrorAuth ClusterErrorType = "auth"
+	// ClusterErrorTimeout — deadline exceeded, controller unresponsive.
+	ClusterErrorTimeout ClusterErrorType = "timeout"
+	// ClusterErrorNetwork — dial failure, DNS miss, connection refused.
+	ClusterErrorNetwork ClusterErrorType = "network"
+	// ClusterErrorCertificate — TLS / x509 issue on the hub endpoint.
+	ClusterErrorCertificate ClusterErrorType = "certificate"
+	// ClusterErrorNotInstalled — provider's CRDs are absent on this context;
+	// not a failure, just negative detection.
+	ClusterErrorNotInstalled ClusterErrorType = "not-installed"
+	// ClusterErrorUnknown — classification fell through all branches.
+	ClusterErrorUnknown ClusterErrorType = "unknown"
+)
+
+// Lifecycle carries CAPI-specific readiness counters. The field is optional
+// on FederatedCluster so federation-only providers leave it nil.
+type Lifecycle struct {
+	// Phase is Cluster.status.phase ("Pending"/"Provisioning"/"Provisioned"/
+	// "Failed"/"Deleting"). Kept as raw string to preserve CAPI-specific
+	// phases the console may not know about yet.
+	Phase string `json:"phase"`
+	// ControlPlaneReady mirrors Cluster.status.controlPlaneReady.
+	ControlPlaneReady bool `json:"controlPlaneReady"`
+	// InfrastructureReady mirrors Cluster.status.infrastructureReady.
+	InfrastructureReady bool `json:"infrastructureReady"`
+	// DesiredMachines is the sum of MachineDeployment.spec.replicas across
+	// all MDs that target this cluster.
+	DesiredMachines int32 `json:"desiredMachines"`
+	// ReadyMachines is the sum of ready Machine counts for this cluster.
+	ReadyMachines int32 `json:"readyMachines"`
+}
+
+// FederatedCluster is one row in the "My Clusters" federation overlay. The
+// same cluster can appear multiple times across the slice (e.g. joined to
+// OCM hub A and Karmada control plane B) — deduplication is a UI concern,
+// not a provider concern.
+type FederatedCluster struct {
+	// Provider is the provider plugin that reported this row. Required.
+	Provider FederationProviderName `json:"provider"`
+	// HubContext is the kubeconfig context hosting the federation controller
+	// that reported this cluster. Required for multi-hub disambiguation — a
+	// cluster may appear on multiple hubs simultaneously.
+	HubContext string `json:"hubContext"`
+	// Name is the cluster's identifier on that hub (ManagedCluster.name,
+	// Cluster.name, etc.). May differ from the user's local kubeconfig
+	// context name.
+	Name string `json:"name"`
+	// State is the federation or lifecycle state.
+	State ClusterState `json:"state"`
+	// Available mirrors a conditions[type=Available] True/False/Unknown
+	// tri-state across providers. Providers that don't expose availability
+	// set "Unknown".
+	Available string `json:"available"`
+	// ClusterSet, when non-empty, names the group the cluster belongs to
+	// (ManagedClusterSet, selector group, peer, infra namespace, etc.).
+	ClusterSet string `json:"clusterSet,omitempty"`
+	// Labels are the cluster's labels as reported by the controller.
+	Labels map[string]string `json:"labels,omitempty"`
+	// APIServerURL is the cluster's public API server endpoint, if exposed
+	// by the controller. Used by the UI to correlate this row with a
+	// kubeconfig entry the user already has.
+	APIServerURL string `json:"apiServerURL,omitempty"`
+	// Taints are the federation-managed taints on the cluster (OCM / Karmada).
+	Taints []Taint `json:"taints,omitempty"`
+	// Lifecycle is CAPI-specific; nil on other providers.
+	Lifecycle *Lifecycle `json:"lifecycle,omitempty"`
+	// Raw is the original controller CR (typed or unstructured) for use by
+	// drill-down views that need provider-specific fields. JSON-serialized
+	// as opaque — the UI is expected to treat it as untyped.
+	Raw interface{} `json:"raw,omitempty"`
+}
+
+// Taint mirrors the common taint shape used by OCM ManagedCluster.spec.taints
+// and Karmada Cluster.spec.taints. Effect is the enum string as reported.
+type Taint struct {
+	Key    string `json:"key"`
+	Value  string `json:"value,omitempty"`
+	Effect string `json:"effect"`
+}
+
+// FederatedGroupKind distinguishes grouping models so the UI can pick the
+// right label (hub-style ClusterSet vs. peer relationship vs. infra bucket).
+type FederatedGroupKind string
+
+const (
+	// FederatedGroupSet — explicit grouping resource (OCM ManagedClusterSet).
+	FederatedGroupSet FederatedGroupKind = "set"
+	// FederatedGroupSelector — rule-based grouping (PropagationPolicy
+	// labelSelector, FederatedCluster labels).
+	FederatedGroupSelector FederatedGroupKind = "selector"
+	// FederatedGroupPeer — peer-to-peer relationship (Liqo ForeignCluster).
+	FederatedGroupPeer FederatedGroupKind = "peer"
+	// FederatedGroupInfra — infrastructure bucket (CAPI AWSCluster /
+	// AzureCluster / DockerCluster namespace).
+	FederatedGroupInfra FederatedGroupKind = "infra"
+)
+
+// FederatedGroup is a cluster grouping scoped to one (provider, hub) pair.
+// The UI namespaces groups as "provider:hubContext:name" to avoid collisions
+// when two hubs report a group with the same name.
+type FederatedGroup struct {
+	Provider   FederationProviderName `json:"provider"`
+	HubContext string                 `json:"hubContext"`
+	Name       string                 `json:"name"`
+	Members    []string               `json:"members"`
+	Kind       FederatedGroupKind     `json:"kind"`
+}
+
+// PendingJoin is a cluster whose registration is in flight. For OCM this is
+// a pending CSR; for Karmada it's a joining Cluster CR; for Liqo it's an
+// incoming ForeignCluster; for CAPI it's a Machine that has yet to bootstrap.
+type PendingJoin struct {
+	Provider    FederationProviderName `json:"provider"`
+	HubContext  string                 `json:"hubContext"`
+	ClusterName string                 `json:"clusterName"`
+	RequestedAt time.Time              `json:"requestedAt"`
+	// Detail is a free-form human-readable hint (CSR name, ForeignCluster
+	// remote URL, Machine bootstrap status message).
+	Detail string `json:"detail,omitempty"`
+}
+
+// FederationError reports a per-(provider, hub) failure. Mirrors the
+// NodeClusterError shape landed by Issue 9359 so existing error-classifier
+// UI code can consume this directly. One FederationError NEVER poisons
+// another provider's or hub's results — aggregation is per-pair.
+type FederationError struct {
+	Provider   FederationProviderName `json:"provider"`
+	HubContext string                 `json:"hubContext"`
+	Type       ClusterErrorType       `json:"type"`
+	Message    string                 `json:"message"`
+}
+
+// Error implements the error interface so callers can return a
+// FederationError directly where `error` is expected. The stringified form
+// is purely for logs; callers consuming the struct fields should use the
+// typed access instead of parsing the message.
+func (e *FederationError) Error() string {
+	if e == nil {
+		return ""
+	}
+	return string(e.Type) + ": " + e.Message
+}
+
+// ProviderHubStatus is the result of calling Detect() for one (provider,
+// hub) pair. The UI renders one hub tile per entry.
+type ProviderHubStatus struct {
+	Provider   FederationProviderName `json:"provider"`
+	HubContext string                 `json:"hubContext"`
+	Detected   bool                   `json:"detected"`
+	Version    string                 `json:"version,omitempty"`
+	// Error is non-nil only when detection itself errored (not when the
+	// controller is simply absent — that case returns Detected=false with a
+	// nil Error; see ClusterErrorNotInstalled handling in providers).
+	Error *FederationError `json:"error,omitempty"`
+}
+
+// DetectResult is what Provider.Detect returns. Kept distinct from
+// ProviderHubStatus because the provider layer doesn't know the hub context
+// it was invoked against — the server layer stamps that on afterwards.
+type DetectResult struct {
+	Detected bool   `json:"detected"`
+	Version  string `json:"version,omitempty"`
+}

--- a/pkg/agent/server.go
+++ b/pkg/agent/server.go
@@ -430,6 +430,19 @@ func (s *Server) Start() error {
 	mux.HandleFunc("/console-cr/deployments", s.handleConsoleCRWorkloadDeployments)
 	mux.HandleFunc("/console-cr/deployments/status", s.handleConsoleCRWorkloadDeploymentStatus)
 
+	// Federation / multi-cluster-management awareness (Issue 9368, PR A).
+	// Read-only endpoints that fan out across every kubeconfig context in
+	// parallel and query every registered federation provider (OCM,
+	// Karmada, Clusternet, Liqo, KubeAdmiral, CAPI). PR A ships with the
+	// registry empty — providers register themselves in later PRs.
+	// Identity rule: all reads run under the user's kubeconfig; no
+	// pod-ServiceAccount fallback. See pkg/agent/server_federation.go and
+	// the master plan referenced at the top of that file.
+	mux.HandleFunc("/federation/detect", s.handleFederationDetect)
+	mux.HandleFunc("/federation/clusters", s.handleFederationClusters)
+	mux.HandleFunc("/federation/groups", s.handleFederationGroups)
+	mux.HandleFunc("/federation/pending-joins", s.handleFederationPendingJoins)
+
 	// GitOps drift detection + kubectl sync moved to kc-agent (#7993 Phase 3b).
 	// These shell `kubectl diff` / `kubectl apply` under the user's kubeconfig.
 	// Backend handlers are still present until Phase 4 deletes them — routes

--- a/pkg/agent/server_federation.go
+++ b/pkg/agent/server_federation.go
@@ -1,0 +1,469 @@
+package agent
+
+// Federation awareness handlers for kc-agent — see Issue 9368 and the master
+// plan at /Users/andan02/.claude/plans/glistening-stargazing-toast.md.
+//
+// These endpoints are the kc-agent side of Phase 1 of the federation
+// roll-out. The UI calls them to learn which multi-cluster-management
+// backends (OCM, Karmada, Clusternet, Liqo, KubeAdmiral, CAPI) are present
+// on each kubeconfig context the user holds, plus the federated clusters,
+// groups, and pending joins each hub reports.
+//
+// Identity: all reads run through the dynamic client that kc-agent resolves
+// from the user's kubeconfig via MultiClusterClient.GetRestConfig. There is
+// NO pod-ServiceAccount fallback — if the user's bearer token is not on
+// the request the handler returns 500 to make the absence of identity loud
+// instead of silently falling through to cluster-level credentials.
+//
+// Fan-out: when `?cluster=` is omitted, the handler iterates every
+// de-duplicated context in the user's kubeconfig in parallel. One
+// (provider, hubContext) pair may fail (offline controller, 403, missing
+// CRDs) — that pair is turned into a FederationError and aggregated
+// alongside the successful results. The classification pattern matches
+// pkg/k8s classifyError() so UI error handling generalizes cleanly.
+//
+// Result aggregation follows the return-then-aggregate pattern from Issue
+// 9364: every goroutine returns its own slice to a local results channel
+// and the caller concatenates once all goroutines exit. No outer-scope
+// slice mutation, no per-goroutine mutex.
+
+import (
+	"context"
+	"net/http"
+	"sync"
+	"time"
+
+	"k8s.io/client-go/rest"
+
+	"github.com/kubestellar/console/pkg/agent/federation"
+	"github.com/kubestellar/console/pkg/k8s"
+)
+
+// federationRequestTimeout bounds each HTTP handler. Matches
+// rbacAnalysisTimeout because both involve cross-context fan-out.
+const federationRequestTimeout = 60 * time.Second
+
+// federationPerProviderTimeout bounds a single (provider, context) probe so
+// one slow controller cannot block the aggregated response. Individual
+// providers typically respond in under 2s; 10s leaves comfortable slack for
+// large ManagedCluster / Cluster lists without extending the overall
+// handler deadline.
+const federationPerProviderTimeout = 10 * time.Second
+
+// handleFederationDetect serves `GET /federation/detect[?cluster=<ctx>]` and
+// returns []ProviderHubStatus — one row per (registered provider, resolved
+// context) pair. When `cluster` is omitted the handler fans out over every
+// de-duplicated context in the user's kubeconfig.
+func (s *Server) handleFederationDetect(w http.ResponseWriter, r *http.Request) {
+	s.setCORSHeaders(w, r, http.MethodGet, http.MethodOptions)
+	w.Header().Set("Content-Type", "application/json")
+	if r.Method == http.MethodOptions {
+		w.WriteHeader(http.StatusOK)
+		return
+	}
+	if r.Method != http.MethodGet {
+		writeJSONError(w, http.StatusMethodNotAllowed, "method not allowed")
+		return
+	}
+	if !s.requireBearerToken(w, r) {
+		return
+	}
+	if s.k8sClient == nil {
+		writeJSONError(w, http.StatusServiceUnavailable, "k8s client not initialized")
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(r.Context(), federationRequestTimeout)
+	defer cancel()
+
+	contexts, err := s.resolveFederationContexts(ctx, r)
+	if err != nil {
+		writeJSONError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	providers := federation.All()
+
+	results := fanOutDetect(ctx, providers, contexts, s.k8sClient.GetRestConfig)
+	// Always return a non-nil slice so `[]` is JSON-encoded, not `null`.
+	if results == nil {
+		results = []federation.ProviderHubStatus{}
+	}
+	writeJSON(w, results)
+}
+
+// handleFederationClusters serves `GET /federation/clusters[?cluster=<ctx>]`
+// and returns []FederatedCluster collected from every (provider, context)
+// pair that Detect()ed positively. Per-pair errors are attached alongside
+// under an "errors" envelope.
+func (s *Server) handleFederationClusters(w http.ResponseWriter, r *http.Request) {
+	s.handleFederationRead(w, r, func(
+		ctx context.Context, p federation.Provider, cfg *rest.Config,
+	) (interface{}, error) {
+		return p.ReadClusters(ctx, cfg)
+	}, "clusters")
+}
+
+// handleFederationGroups serves `GET /federation/groups[?cluster=<ctx>]`.
+func (s *Server) handleFederationGroups(w http.ResponseWriter, r *http.Request) {
+	s.handleFederationRead(w, r, func(
+		ctx context.Context, p federation.Provider, cfg *rest.Config,
+	) (interface{}, error) {
+		return p.ReadGroups(ctx, cfg)
+	}, "groups")
+}
+
+// handleFederationPendingJoins serves
+// `GET /federation/pending-joins[?cluster=<ctx>]`.
+func (s *Server) handleFederationPendingJoins(w http.ResponseWriter, r *http.Request) {
+	s.handleFederationRead(w, r, func(
+		ctx context.Context, p federation.Provider, cfg *rest.Config,
+	) (interface{}, error) {
+		return p.ReadPendingJoins(ctx, cfg)
+	}, "pendingJoins")
+}
+
+// federationReadFunc is the per-provider reader selector used by
+// handleFederationRead. Returning interface{} keeps the three readers on a
+// single fan-out path without per-reader generics.
+type federationReadFunc func(
+	ctx context.Context, p federation.Provider, cfg *rest.Config,
+) (interface{}, error)
+
+// handleFederationRead is the shared fan-out body for the three list
+// handlers (clusters/groups/pending-joins). It returns a JSON envelope:
+//
+//	{ "items": [...], "errors": [...] }
+//
+// so the UI can render partial results even when some (provider, hub)
+// pairs fail. The envelope key for items is provided by itemsKey so each
+// handler can pick a semantically meaningful field name (clusters / groups
+// / pendingJoins) without copy-pasting the rest of the body.
+func (s *Server) handleFederationRead(
+	w http.ResponseWriter, r *http.Request,
+	read federationReadFunc, itemsKey string,
+) {
+	s.setCORSHeaders(w, r, http.MethodGet, http.MethodOptions)
+	w.Header().Set("Content-Type", "application/json")
+	if r.Method == http.MethodOptions {
+		w.WriteHeader(http.StatusOK)
+		return
+	}
+	if r.Method != http.MethodGet {
+		writeJSONError(w, http.StatusMethodNotAllowed, "method not allowed")
+		return
+	}
+	if !s.requireBearerToken(w, r) {
+		return
+	}
+	if s.k8sClient == nil {
+		writeJSONError(w, http.StatusServiceUnavailable, "k8s client not initialized")
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(r.Context(), federationRequestTimeout)
+	defer cancel()
+
+	contexts, err := s.resolveFederationContexts(ctx, r)
+	if err != nil {
+		writeJSONError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	providers := federation.All()
+
+	items, errs := fanOutRead(ctx, providers, contexts, s.k8sClient.GetRestConfig, read)
+	if items == nil {
+		items = []interface{}{}
+	}
+	if errs == nil {
+		errs = []federation.FederationError{}
+	}
+	writeJSON(w, map[string]interface{}{
+		itemsKey: items,
+		"errors": errs,
+	})
+}
+
+// requireBearerToken enforces the "no pod-SA fallback" contract. It returns
+// true only when the request carries a valid bearer token (or the agent was
+// started without token auth — which is the dev-only path). On missing /
+// mismatching tokens it responds 500 and returns false, per the plan's
+// explicit requirement. This is intentionally stricter than the 401 used by
+// most other kc-agent handlers: federation reads must NEVER execute without
+// user identity, and 500 signals that loudly to anyone monitoring the agent.
+func (s *Server) requireBearerToken(w http.ResponseWriter, r *http.Request) bool {
+	if s.validateToken(r) {
+		return true
+	}
+	writeJSONError(w, http.StatusInternalServerError, "bearer token required for federation reads — no pod-SA fallback")
+	return false
+}
+
+// resolveFederationContexts returns the set of kubeconfig contexts the
+// handler should fan out over. When `?cluster=` is present, only that
+// single context is returned; otherwise every de-duplicated cluster from
+// the user's kubeconfig is returned so we don't double-count the same
+// physical hub under two context aliases.
+func (s *Server) resolveFederationContexts(ctx context.Context, r *http.Request) ([]string, error) {
+	if single := r.URL.Query().Get("cluster"); single != "" {
+		return []string{single}, nil
+	}
+	clusters, err := s.k8sClient.DeduplicatedClusters(ctx)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]string, 0, len(clusters))
+	for _, c := range clusters {
+		out = append(out, c.Context)
+	}
+	return out, nil
+}
+
+// configResolver is the narrow function interface fanOutDetect / fanOutRead
+// depend on. Using a func type instead of a method reference makes these
+// helpers test-injectable without dragging the whole MultiClusterClient
+// into unit tests.
+type configResolver func(contextName string) (*rest.Config, error)
+
+// fanOutDetect runs Detect for every (provider, context) pair in parallel.
+// Each goroutine returns its own ProviderHubStatus to the results channel;
+// the caller concatenates after all goroutines exit. No outer-scope slice
+// mutation — the pattern mandated by the concurrent-mutation-safety ratchet
+// from Issue 9364.
+func fanOutDetect(
+	ctx context.Context,
+	providers []federation.Provider,
+	contexts []string,
+	getConfig configResolver,
+) []federation.ProviderHubStatus {
+	type job struct {
+		provider   federation.Provider
+		hubContext string
+	}
+	if len(providers) == 0 || len(contexts) == 0 {
+		return []federation.ProviderHubStatus{}
+	}
+
+	jobs := make([]job, 0, len(providers)*len(contexts))
+	for _, p := range providers {
+		for _, c := range contexts {
+			jobs = append(jobs, job{provider: p, hubContext: c})
+		}
+	}
+
+	out := make(chan federation.ProviderHubStatus, len(jobs))
+	var wg sync.WaitGroup
+	wg.Add(len(jobs))
+	for _, j := range jobs {
+		go func(j job) {
+			defer wg.Done()
+			out <- runOneDetect(ctx, j.provider, j.hubContext, getConfig)
+		}(j)
+	}
+	wg.Wait()
+	close(out)
+
+	results := make([]federation.ProviderHubStatus, 0, len(jobs))
+	for r := range out {
+		results = append(results, r)
+	}
+	return results
+}
+
+// runOneDetect is the body of a single fanOutDetect goroutine. Broken out
+// for readability and so tests can exercise error classification without
+// spinning up the full fan-out.
+func runOneDetect(
+	ctx context.Context,
+	p federation.Provider,
+	hubContext string,
+	getConfig configResolver,
+) federation.ProviderHubStatus {
+	probeCtx, cancel := context.WithTimeout(ctx, federationPerProviderTimeout)
+	defer cancel()
+
+	cfg, err := getConfig(hubContext)
+	if err != nil {
+		return federation.ProviderHubStatus{
+			Provider:   p.Name(),
+			HubContext: hubContext,
+			Detected:   false,
+			Error: &federation.FederationError{
+				Provider:   p.Name(),
+				HubContext: hubContext,
+				Type:       federation.ClusterErrorType(k8s.ClassifyError(err.Error())),
+				Message:    err.Error(),
+			},
+		}
+	}
+
+	res, err := p.Detect(probeCtx, cfg)
+	if err != nil {
+		return federation.ProviderHubStatus{
+			Provider:   p.Name(),
+			HubContext: hubContext,
+			Detected:   false,
+			Error: &federation.FederationError{
+				Provider:   p.Name(),
+				HubContext: hubContext,
+				Type:       federation.ClusterErrorType(k8s.ClassifyError(err.Error())),
+				Message:    err.Error(),
+			},
+		}
+	}
+	return federation.ProviderHubStatus{
+		Provider:   p.Name(),
+		HubContext: hubContext,
+		Detected:   res.Detected,
+		Version:    res.Version,
+	}
+}
+
+// fanOutRead runs one of the three reader methods for every (provider,
+// context) pair in parallel. Items are appended in whatever order the
+// goroutines finish; the UI sorts them at render time. Per-pair errors are
+// classified and returned alongside — one pair failing never poisons
+// another pair's results.
+func fanOutRead(
+	ctx context.Context,
+	providers []federation.Provider,
+	contexts []string,
+	getConfig configResolver,
+	read federationReadFunc,
+) ([]interface{}, []federation.FederationError) {
+	if len(providers) == 0 || len(contexts) == 0 {
+		return []interface{}{}, []federation.FederationError{}
+	}
+
+	type pairResult struct {
+		items []interface{}
+		err   *federation.FederationError
+	}
+
+	pairs := make([]struct {
+		p federation.Provider
+		c string
+	}, 0, len(providers)*len(contexts))
+	for _, p := range providers {
+		for _, c := range contexts {
+			pairs = append(pairs, struct {
+				p federation.Provider
+				c string
+			}{p: p, c: c})
+		}
+	}
+
+	out := make(chan pairResult, len(pairs))
+	var wg sync.WaitGroup
+	wg.Add(len(pairs))
+	for _, pr := range pairs {
+		go func(p federation.Provider, hubContext string) {
+			defer wg.Done()
+			out <- runOneRead(ctx, p, hubContext, getConfig, read)
+		}(pr.p, pr.c)
+	}
+	wg.Wait()
+	close(out)
+
+	items := make([]interface{}, 0)
+	errs := make([]federation.FederationError, 0)
+	for r := range out {
+		items = append(items, r.items...)
+		if r.err != nil {
+			errs = append(errs, *r.err)
+		}
+	}
+	return items, errs
+}
+
+// runOneRead is the body of a single fanOutRead goroutine. It resolves the
+// rest config, invokes the supplied reader, and normalizes the returned
+// concrete slice into []interface{} (so the fan-out layer doesn't care
+// whether the reader returned []FederatedCluster, []FederatedGroup, or
+// []PendingJoin).
+func runOneRead(
+	ctx context.Context,
+	p federation.Provider,
+	hubContext string,
+	getConfig configResolver,
+	read federationReadFunc,
+) struct {
+	items []interface{}
+	err   *federation.FederationError
+} {
+	probeCtx, cancel := context.WithTimeout(ctx, federationPerProviderTimeout)
+	defer cancel()
+
+	cfg, err := getConfig(hubContext)
+	if err != nil {
+		return struct {
+			items []interface{}
+			err   *federation.FederationError
+		}{
+			err: &federation.FederationError{
+				Provider:   p.Name(),
+				HubContext: hubContext,
+				Type:       federation.ClusterErrorType(k8s.ClassifyError(err.Error())),
+				Message:    err.Error(),
+			},
+		}
+	}
+
+	raw, err := read(probeCtx, p, cfg)
+	if err != nil {
+		return struct {
+			items []interface{}
+			err   *federation.FederationError
+		}{
+			err: &federation.FederationError{
+				Provider:   p.Name(),
+				HubContext: hubContext,
+				Type:       federation.ClusterErrorType(k8s.ClassifyError(err.Error())),
+				Message:    err.Error(),
+			},
+		}
+	}
+
+	// Normalize the reader's concrete slice into []interface{} without
+	// importing reflect at the hot path. The three reader shapes are the
+	// only ones the Provider contract allows.
+	var items []interface{}
+	switch v := raw.(type) {
+	case []federation.FederatedCluster:
+		items = make([]interface{}, 0, len(v))
+		for i := range v {
+			items = append(items, v[i])
+		}
+	case []federation.FederatedGroup:
+		items = make([]interface{}, 0, len(v))
+		for i := range v {
+			items = append(items, v[i])
+		}
+	case []federation.PendingJoin:
+		items = make([]interface{}, 0, len(v))
+		for i := range v {
+			items = append(items, v[i])
+		}
+	case nil:
+		items = []interface{}{}
+	default:
+		// A provider returned an unexpected type. Surface it as a failure
+		// so the bug is visible instead of silently dropped. Should never
+		// fire in practice because the Provider interface constrains the
+		// return types — but defensive.
+		return struct {
+			items []interface{}
+			err   *federation.FederationError
+		}{
+			err: &federation.FederationError{
+				Provider:   p.Name(),
+				HubContext: hubContext,
+				Type:       federation.ClusterErrorUnknown,
+				Message:    "provider returned unsupported result type",
+			},
+		}
+	}
+	return struct {
+		items []interface{}
+		err   *federation.FederationError
+	}{items: items}
+}

--- a/pkg/agent/server_federation_test.go
+++ b/pkg/agent/server_federation_test.go
@@ -1,0 +1,553 @@
+package agent
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"k8s.io/client-go/rest"
+
+	"github.com/kubestellar/console/pkg/agent/federation"
+	"github.com/kubestellar/console/pkg/k8s"
+)
+
+// testBearerToken is the fake shared secret used by federation handler tests.
+// Kept as a constant so the per-test server + request headers match.
+const testBearerToken = "test-agent-token"
+
+// fakeProvider is the server-side mirror of the one in
+// federation/federation_test.go, used here to drive handler fan-out under
+// realistic conditions. Each field mirrors the Provider contract plus a
+// per-context map so the provider can return different data per hub.
+type handlerFakeProvider struct {
+	name FederationProviderName
+
+	// perContextClusters overrides clusters returned per hub context so
+	// multi-hub tests can prove each result carries the correct HubContext
+	// stamp. The key is the rest.Config.Host value that stubResolver sets.
+	perContextClusters map[string][]FederatedCluster
+
+	detectCalls int32
+	readCalls   int32
+}
+
+// Short aliases to the federation-package types so the test body reads
+// naturally. Using aliases instead of re-exports keeps compile-time coupling
+// explicit.
+type (
+	FederationProviderName = federation.FederationProviderName
+	FederatedCluster       = federation.FederatedCluster
+	FederatedGroup         = federation.FederatedGroup
+	PendingJoin            = federation.PendingJoin
+	DetectResult           = federation.DetectResult
+	ProviderHubStatus      = federation.ProviderHubStatus
+	FederationError        = federation.FederationError
+)
+
+func (f *handlerFakeProvider) Name() FederationProviderName { return f.name }
+
+func (f *handlerFakeProvider) Detect(_ context.Context, _ *rest.Config) (DetectResult, error) {
+	atomic.AddInt32(&f.detectCalls, 1)
+	// Note: without access to hub context we must look up by side-channel.
+	// The server_federation fan-out actually derives hub context from the
+	// configResolver — so the fake cannot see which hub it was called with
+	// here. Tests that need per-hub data use perContextClusters via
+	// Read*() methods below, which DO see hub context through the rest.Config
+	// pointer identity (set up by the per-context resolver). For Detect, we
+	// always return Detected=true with no version.
+	return DetectResult{Detected: true}, nil
+}
+
+// restConfigKey is the marker we stuff in the *rest.Config.Host field so
+// fake providers can tell which hub context they're being called against.
+// The handler test sets up a per-context resolver that stamps this value
+// into a fresh rest.Config.
+func (f *handlerFakeProvider) hubFromConfig(cfg *rest.Config) string {
+	if cfg == nil {
+		return ""
+	}
+	return cfg.Host
+}
+
+func (f *handlerFakeProvider) ReadClusters(_ context.Context, cfg *rest.Config) ([]FederatedCluster, error) {
+	atomic.AddInt32(&f.readCalls, 1)
+	if f.perContextClusters == nil {
+		return nil, nil
+	}
+	if out, ok := f.perContextClusters[f.hubFromConfig(cfg)]; ok {
+		return out, nil
+	}
+	return []FederatedCluster{}, nil
+}
+
+func (f *handlerFakeProvider) ReadGroups(_ context.Context, _ *rest.Config) ([]FederatedGroup, error) {
+	return nil, nil
+}
+
+func (f *handlerFakeProvider) ReadPendingJoins(_ context.Context, _ *rest.Config) ([]PendingJoin, error) {
+	return nil, nil
+}
+
+// newTestServer returns a *Server wired with a real (empty) k8s client and
+// a shared agentToken so validateToken exercises the production code path.
+// The kubeconfigPath parameter allows tests to inject a real kubeconfig
+// YAML file so DeduplicatedClusters returns the test-authored contexts.
+func newTestServer(t *testing.T, kubeconfigPath, agentToken string) *Server {
+	t.Helper()
+	k8sClient, err := k8s.NewMultiClusterClient(kubeconfigPath)
+	if err != nil {
+		t.Fatalf("NewMultiClusterClient: %v", err)
+	}
+	if kubeconfigPath != "" {
+		if err := k8sClient.LoadConfig(); err != nil {
+			t.Fatalf("LoadConfig: %v", err)
+		}
+	}
+	return &Server{
+		k8sClient:      k8sClient,
+		agentToken:     agentToken,
+		allowedOrigins: []string{"http://localhost"},
+	}
+}
+
+// writeTestKubeconfig drops a minimal kubeconfig at the given path containing
+// the supplied (contextName -> serverURL) pairs. The file is valid enough
+// for MultiClusterClient.LoadConfig to accept and for DeduplicatedClusters
+// to enumerate. Real dynamic-client construction from this file WOULD fail
+// (no real apiserver on the URL) — tests only exercise the context-listing
+// path, not the actual provider-read path.
+func writeTestKubeconfig(t *testing.T, path string, entries map[string]string) {
+	t.Helper()
+
+	type cluster struct {
+		Server string `yaml:"server"`
+	}
+	type namedCluster struct {
+		Name    string  `yaml:"name"`
+		Cluster cluster `yaml:"cluster"`
+	}
+	type ctxInfo struct {
+		Cluster string `yaml:"cluster"`
+		User    string `yaml:"user"`
+	}
+	type namedContext struct {
+		Name    string  `yaml:"name"`
+		Context ctxInfo `yaml:"context"`
+	}
+
+	// Build YAML manually to avoid pulling in a YAML dep just for tests.
+	var b strings.Builder
+	b.WriteString("apiVersion: v1\nkind: Config\n")
+	b.WriteString("clusters:\n")
+	// Iterate sorted so file contents are deterministic.
+	names := make([]string, 0, len(entries))
+	for n := range entries {
+		names = append(names, n)
+	}
+	sort.Strings(names)
+	for _, n := range names {
+		fmt.Fprintf(&b, "- name: %s\n  cluster:\n    server: %s\n", n, entries[n])
+	}
+	b.WriteString("contexts:\n")
+	for _, n := range names {
+		fmt.Fprintf(&b, "- name: %s\n  context:\n    cluster: %s\n    user: test-user\n", n, n)
+	}
+	b.WriteString("users:\n- name: test-user\n  user: {}\n")
+	if len(names) > 0 {
+		fmt.Fprintf(&b, "current-context: %s\n", names[0])
+	}
+
+	if err := os.WriteFile(path, []byte(b.String()), 0600); err != nil {
+		t.Fatalf("write kubeconfig: %v", err)
+	}
+}
+
+// TestHandler_MissingBearerToken_500 asserts the plan's "no pod-SA fallback"
+// contract: a federation read request without a valid bearer token returns
+// HTTP 500, loudly signaling the missing identity. 500 (not 401) is
+// intentional — it flags the class of request that must never execute
+// against the pod SA's identity.
+func TestHandler_MissingBearerToken_500(t *testing.T) {
+	s := newTestServer(t, "", testBearerToken)
+
+	endpoints := []string{
+		"/federation/detect",
+		"/federation/clusters",
+		"/federation/groups",
+		"/federation/pending-joins",
+	}
+	handlers := map[string]http.HandlerFunc{
+		"/federation/detect":        s.handleFederationDetect,
+		"/federation/clusters":      s.handleFederationClusters,
+		"/federation/groups":        s.handleFederationGroups,
+		"/federation/pending-joins": s.handleFederationPendingJoins,
+	}
+
+	for _, e := range endpoints {
+		t.Run(e, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, e, nil)
+			// No Authorization header at all — the strict test.
+			w := httptest.NewRecorder()
+			handlers[e](w, req)
+			if w.Code != http.StatusInternalServerError {
+				t.Fatalf("%s: got %d, want 500", e, w.Code)
+			}
+		})
+	}
+}
+
+// TestHandler_EmptyRegistry_ReturnsEmpty verifies that when no provider is
+// registered (the state PR A ships in), the handler returns a JSON array
+// (not null, not a 500). This is a key guarantee for the UI — the hook can
+// safely iterate the response on first page load before any provider has
+// been shipped in a follow-up PR.
+func TestHandler_EmptyRegistry_ReturnsEmpty(t *testing.T) {
+	federation.Reset()
+	defer federation.Reset()
+
+	dir := t.TempDir()
+	kcfg := filepath.Join(dir, "kubeconfig")
+	writeTestKubeconfig(t, kcfg, map[string]string{
+		"hub-a": "https://hub-a.example",
+	})
+	s := newTestServer(t, kcfg, testBearerToken)
+
+	req := httptest.NewRequest(http.MethodGet, "/federation/detect", nil)
+	req.Header.Set("Authorization", "Bearer "+testBearerToken)
+	w := httptest.NewRecorder()
+	s.handleFederationDetect(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("want 200, got %d (body=%s)", w.Code, w.Body.String())
+	}
+	// Response must be a JSON array (possibly empty), not `null`.
+	var got []ProviderHubStatus
+	if err := json.Unmarshal(w.Body.Bytes(), &got); err != nil {
+		t.Fatalf("decode: %v (body=%s)", err, w.Body.String())
+	}
+	if len(got) != 0 {
+		t.Fatalf("want empty array, got %d entries", len(got))
+	}
+	// Explicit `[]` in the wire body — not `null`.
+	body := strings.TrimSpace(w.Body.String())
+	if body != "[]" {
+		t.Fatalf("wire body should be `[]`, got %q", body)
+	}
+
+	// The list handlers use an envelope; they should still return an empty
+	// items slice (not null) under an empty registry.
+	for _, e := range []string{"/federation/clusters", "/federation/groups", "/federation/pending-joins"} {
+		req := httptest.NewRequest(http.MethodGet, e, nil)
+		req.Header.Set("Authorization", "Bearer "+testBearerToken)
+		w := httptest.NewRecorder()
+		switch e {
+		case "/federation/clusters":
+			s.handleFederationClusters(w, req)
+		case "/federation/groups":
+			s.handleFederationGroups(w, req)
+		case "/federation/pending-joins":
+			s.handleFederationPendingJoins(w, req)
+		}
+		if w.Code != http.StatusOK {
+			t.Fatalf("%s: want 200, got %d (body=%s)", e, w.Code, w.Body.String())
+		}
+		var envelope map[string]interface{}
+		if err := json.Unmarshal(w.Body.Bytes(), &envelope); err != nil {
+			t.Fatalf("%s: decode: %v", e, err)
+		}
+		if envelope["errors"] == nil {
+			t.Fatalf("%s: errors field missing", e)
+		}
+	}
+}
+
+// stubResolver is a fake configResolver that returns a fresh *rest.Config
+// with the hub context name stamped into Host. Tests use this to inspect
+// which hub a fake provider is being called against, without having to
+// stand up a real apiserver.
+func stubResolver(hubToHost map[string]string) configResolver {
+	return func(contextName string) (*rest.Config, error) {
+		host, ok := hubToHost[contextName]
+		if !ok {
+			return nil, fmt.Errorf("unknown context %q", contextName)
+		}
+		return &rest.Config{Host: host}, nil
+	}
+}
+
+// TestFanOut_OneProviderErrorDoesNotPoisonOthers_Handler exercises the
+// server-level fanOutRead path and asserts a single (provider, hub)
+// failure is classified into FederationError while other pairs' results
+// are returned intact. This mirrors the federation-package test of the
+// same name but at the server layer — the UI-facing contract.
+func TestFanOut_OneProviderErrorDoesNotPoisonOthers_Handler(t *testing.T) {
+	providers := []federation.Provider{
+		// Provider that always errors on ReadClusters.
+		&alwaysErrReadProvider{name: federation.ProviderOCM, errMsg: "forbidden: 403"},
+		// Provider that returns a real result per hub.
+		&handlerFakeProvider{
+			name: federation.ProviderKarmada,
+			perContextClusters: map[string][]FederatedCluster{
+				"hub-a": {{Provider: federation.ProviderKarmada, HubContext: "hub-a", Name: "member-1"}},
+			},
+		},
+	}
+	resolver := stubResolver(map[string]string{"hub-a": "hub-a"})
+
+	items, errs := fanOutRead(
+		context.Background(),
+		providers,
+		[]string{"hub-a"},
+		resolver,
+		func(ctx context.Context, p federation.Provider, cfg *rest.Config) (interface{}, error) {
+			return p.ReadClusters(ctx, cfg)
+		},
+	)
+
+	// Exactly one error from the bad provider, exactly one cluster from the
+	// good one. Neither poisoned the other.
+	if len(errs) != 1 {
+		t.Fatalf("want 1 error, got %d (%#v)", len(errs), errs)
+	}
+	if errs[0].Provider != federation.ProviderOCM || errs[0].Type != federation.ClusterErrorAuth {
+		t.Fatalf("error not classified as auth: %#v", errs[0])
+	}
+	if len(items) != 1 {
+		t.Fatalf("want 1 good cluster, got %d (%#v)", len(items), items)
+	}
+	cl, ok := items[0].(FederatedCluster)
+	if !ok {
+		t.Fatalf("result not a FederatedCluster: %T", items[0])
+	}
+	if cl.Name != "member-1" || cl.HubContext != "hub-a" {
+		t.Fatalf("wrong cluster payload: %+v", cl)
+	}
+}
+
+// alwaysErrReadProvider returns an error for every reader call. Detect is
+// hard-coded to succeed so fan-out reaches the reader stage.
+type alwaysErrReadProvider struct {
+	name   FederationProviderName
+	errMsg string
+}
+
+func (p *alwaysErrReadProvider) Name() FederationProviderName { return p.name }
+func (p *alwaysErrReadProvider) Detect(context.Context, *rest.Config) (DetectResult, error) {
+	return DetectResult{Detected: true}, nil
+}
+func (p *alwaysErrReadProvider) ReadClusters(context.Context, *rest.Config) ([]FederatedCluster, error) {
+	return nil, errors.New(p.errMsg)
+}
+func (p *alwaysErrReadProvider) ReadGroups(context.Context, *rest.Config) ([]FederatedGroup, error) {
+	return nil, errors.New(p.errMsg)
+}
+func (p *alwaysErrReadProvider) ReadPendingJoins(context.Context, *rest.Config) ([]PendingJoin, error) {
+	return nil, errors.New(p.errMsg)
+}
+
+// TestFanOut_ParallelExecution_Handler verifies that the server-level
+// fanOutDetect runs all (provider, context) probes concurrently. We use
+// delayed providers and measure wall-clock; serial execution would take
+// N * delay while parallel should take ~delay.
+func TestFanOut_ParallelExecution_Handler(t *testing.T) {
+	const n = 4
+	const delay = 120 * time.Millisecond
+
+	providers := make([]federation.Provider, 0, n)
+	for i := 0; i < n; i++ {
+		providers = append(providers, &delayedProvider{
+			name:  FederationProviderName(string(rune('a' + i))),
+			delay: delay,
+		})
+	}
+	resolver := stubResolver(map[string]string{"hub-a": "hub-a-host"})
+
+	start := time.Now()
+	out := fanOutDetect(context.Background(), providers, []string{"hub-a"}, resolver)
+	elapsed := time.Since(start)
+
+	if len(out) != n {
+		t.Fatalf("expected %d results, got %d", n, len(out))
+	}
+	// Allow up to 2.5× delay for CI jitter.
+	maxAllowed := time.Duration(float64(delay) * 2.5)
+	if elapsed > maxAllowed {
+		t.Fatalf("fanOutDetect ran serially: elapsed=%v > %v", elapsed, maxAllowed)
+	}
+}
+
+// delayedProvider is a Detect-only provider that sleeps before returning so
+// parallelism can be measured.
+type delayedProvider struct {
+	name  FederationProviderName
+	delay time.Duration
+}
+
+func (d *delayedProvider) Name() FederationProviderName { return d.name }
+func (d *delayedProvider) Detect(ctx context.Context, _ *rest.Config) (DetectResult, error) {
+	select {
+	case <-time.After(d.delay):
+		return DetectResult{Detected: true}, nil
+	case <-ctx.Done():
+		return DetectResult{}, ctx.Err()
+	}
+}
+func (d *delayedProvider) ReadClusters(context.Context, *rest.Config) ([]FederatedCluster, error) {
+	return nil, nil
+}
+func (d *delayedProvider) ReadGroups(context.Context, *rest.Config) ([]FederatedGroup, error) {
+	return nil, nil
+}
+func (d *delayedProvider) ReadPendingJoins(context.Context, *rest.Config) ([]PendingJoin, error) {
+	return nil, nil
+}
+
+// TestFanOut_PerContextErrorsClassified verifies that each (provider, hub)
+// pair gets its own FederationError entry when the resolver fails for one
+// hub while succeeding for another. The successful hub's results must not
+// be affected by the failing hub.
+func TestFanOut_PerContextErrorsClassified(t *testing.T) {
+	provider := &handlerFakeProvider{
+		name: federation.ProviderOCM,
+		perContextClusters: map[string][]FederatedCluster{
+			"host-good": {{Provider: federation.ProviderOCM, HubContext: "hub-good", Name: "c1"}},
+		},
+	}
+
+	// Resolver succeeds for hub-good, errors for hub-bad with a message that
+	// classifyError should bucket as network.
+	resolver := func(contextName string) (*rest.Config, error) {
+		switch contextName {
+		case "hub-good":
+			return &rest.Config{Host: "host-good"}, nil
+		case "hub-bad":
+			return nil, errors.New("dial tcp 10.0.0.1:6443: connection refused")
+		default:
+			return nil, fmt.Errorf("unknown context %q", contextName)
+		}
+	}
+
+	items, errs := fanOutRead(
+		context.Background(),
+		[]federation.Provider{provider},
+		[]string{"hub-good", "hub-bad"},
+		resolver,
+		func(ctx context.Context, p federation.Provider, cfg *rest.Config) (interface{}, error) {
+			return p.ReadClusters(ctx, cfg)
+		},
+	)
+
+	// One good cluster, one classified error.
+	if len(items) != 1 {
+		t.Fatalf("expected 1 item, got %d (%#v)", len(items), items)
+	}
+	if len(errs) != 1 {
+		t.Fatalf("expected 1 error, got %d (%#v)", len(errs), errs)
+	}
+	if errs[0].HubContext != "hub-bad" {
+		t.Fatalf("error HubContext = %q, want hub-bad", errs[0].HubContext)
+	}
+	if errs[0].Type != federation.ClusterErrorNetwork {
+		t.Fatalf("error Type = %q, want %q", errs[0].Type, federation.ClusterErrorNetwork)
+	}
+	if errs[0].Provider != federation.ProviderOCM {
+		t.Fatalf("error Provider = %q, want OCM", errs[0].Provider)
+	}
+}
+
+// TestHandler_MultiHubFanOut stands up a kubeconfig with two contexts and a
+// fake provider that returns different clusters per hub. The handler must
+// aggregate both contexts' results and stamp each with the correct
+// HubContext. This proves the request-level fan-out over the user's
+// kubeconfig, not just the unit-level fanOutRead helper.
+func TestHandler_MultiHubFanOut(t *testing.T) {
+	federation.Reset()
+	defer federation.Reset()
+
+	provider := &handlerFakeProvider{
+		name: federation.ProviderOCM,
+		perContextClusters: map[string][]FederatedCluster{
+			"https://hub-a.example": {{
+				Provider:   federation.ProviderOCM,
+				HubContext: "hub-a",
+				Name:       "member-a1",
+				State:      federation.ClusterStateJoined,
+			}},
+			"https://hub-b.example": {{
+				Provider:   federation.ProviderOCM,
+				HubContext: "hub-b",
+				Name:       "member-b1",
+				State:      federation.ClusterStateJoined,
+			}},
+		},
+	}
+	federation.Register(provider)
+
+	dir := t.TempDir()
+	kcfg := filepath.Join(dir, "kubeconfig")
+	writeTestKubeconfig(t, kcfg, map[string]string{
+		"hub-a": "https://hub-a.example",
+		"hub-b": "https://hub-b.example",
+	})
+
+	s := newTestServer(t, kcfg, testBearerToken)
+
+	req := httptest.NewRequest(http.MethodGet, "/federation/clusters", nil)
+	req.Header.Set("Authorization", "Bearer "+testBearerToken)
+	w := httptest.NewRecorder()
+	s.handleFederationClusters(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("want 200, got %d (body=%s)", w.Code, w.Body.String())
+	}
+
+	var resp struct {
+		Clusters []FederatedCluster `json:"clusters"`
+		Errors   []FederationError  `json:"errors"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v (body=%s)", err, w.Body.String())
+	}
+	// Expect 2 clusters total — one per hub.
+	if len(resp.Clusters) != 2 {
+		t.Fatalf("want 2 clusters, got %d (%#v)", len(resp.Clusters), resp.Clusters)
+	}
+	// Verify each expected hub is represented (order may vary — fan-out is
+	// concurrent).
+	seen := map[string]string{}
+	for _, c := range resp.Clusters {
+		seen[c.HubContext] = c.Name
+	}
+	if seen["hub-a"] != "member-a1" {
+		t.Fatalf("hub-a result missing/wrong: %+v", resp.Clusters)
+	}
+	if seen["hub-b"] != "member-b1" {
+		t.Fatalf("hub-b result missing/wrong: %+v", resp.Clusters)
+	}
+}
+
+// TestRequireBearerToken_NoAuthConfigured verifies that when the agent is
+// started WITHOUT a KC_AGENT_TOKEN (dev mode), federation handlers still
+// process the request — the 500 bypass only fires when token auth is
+// configured and the caller failed validation.
+func TestRequireBearerToken_NoAuthConfigured(t *testing.T) {
+	s := newTestServer(t, "", "")
+
+	req := httptest.NewRequest(http.MethodGet, "/federation/detect", nil)
+	w := httptest.NewRecorder()
+	// No token header AND no agentToken set — should pass the gate.
+	if !s.requireBearerToken(w, req) {
+		t.Fatalf("with agentToken unset, requireBearerToken should return true")
+	}
+}
+


### PR DESCRIPTION
Part of the multi-cluster management awareness plan. See /Users/andan02/.claude/plans/glistening-stargazing-toast.md.

This is **PR A** of 9 planned PRs. It lands the provider-plugin contract plus multi-hub fan-out skeleton that the next 8 PRs build on. **No provider implementations** (OCM arrives in PR B, Karmada in PR C, CAPI in PR D, Clusternet + Liqo + KubeAdmiral in PR E). **No UI changes** (PR B onwards).

## What's in this PR

### pkg/agent/federation/ (new package)

- **types.go** — FederatedCluster, FederatedGroup, PendingJoin, FederationError, ProviderHubStatus, Lifecycle, plus string-alias enums FederationProviderName, ClusterState, ClusterErrorType. Shapes mirror the plan's sketch; FederationError matches the NodeClusterError layout from Issue 9359 so existing error-classifier UI code can consume both.
- **provider.go** — Phase 1 Provider interface (Name / Detect / ReadClusters / ReadGroups / ReadPendingJoins). Phase 2 will extend with Actions()/Execute() in PR F.
- **registry.go** — thread-safe global registry (sync.RWMutex) with stable lexicographic iteration order. Ships **empty** — providers register themselves in later PRs.

### pkg/agent/server_federation.go (new)

Four HTTP handlers:

| Endpoint | Purpose |
|---|---|
| GET /federation/detect[?cluster=] | Returns []ProviderHubStatus per (provider, hub) pair |
| GET /federation/clusters[?cluster=] | Returns {clusters, errors} envelope |
| GET /federation/groups[?cluster=] | Returns {groups, errors} envelope |
| GET /federation/pending-joins[?cluster=] | Returns {pendingJoins, errors} envelope |

Each handler:
- Runs under the user's kubeconfig only (s.k8sClient.GetRestConfig) — **no pod-SA fallback**, no InClusterConfig.
- Returns **500** if bearer token is missing (stricter than 401 — signals the identity-gate failure loudly).
- Fans out across every de-duplicated kubeconfig context in parallel when cluster is omitted (multi-hub support from day one).
- Classifies per-(provider, hub) failures into FederationError via pkg/k8s.ClassifyError — one failure never poisons another pair's results.
- Uses the return-then-aggregate pattern (one goroutine, one channel send, aggregate after) per the Issue 9364 concurrent-mutation-safety ratchet.

### pkg/agent/server.go

Registers the four /federation/* routes next to /console-cr/*.

## Tests

federation/federation_test.go:
- TestRegistry_EmptyInitialState — registry starts empty (PR A ship contract).
- TestRegistry_RegisterAndGet — stable lexicographic ordering.
- TestRegistry_RegisterNilPanics — loud failure on init-order bugs.
- TestRegistry_ResetClears.
- TestFederationError_ImplementsError.
- TestFanOut_ParallelExecution — wall-clock proves providers run concurrently.
- TestFanOut_OneProviderErrorDoesNotPoisonOthers — provider-layer isolation.

server_federation_test.go:
- TestHandler_MissingBearerToken_500 — covers all four endpoints.
- TestHandler_EmptyRegistry_ReturnsEmpty — /federation/detect returns literal [], list handlers return {items: [], errors: []}.
- TestFanOut_OneProviderErrorDoesNotPoisonOthers_Handler — server-layer isolation + error classification as auth.
- TestFanOut_ParallelExecution_Handler — server-layer fanOutDetect runs concurrently.
- TestFanOut_PerContextErrorsClassified — per-(provider, hub) error classification (network from connection refused).
- TestHandler_MultiHubFanOut — real kubeconfig with two contexts, fake provider returning different data per hub, both hubs appear in response with correct HubContext stamp.
- TestRequireBearerToken_NoAuthConfigured — dev mode (no token configured) still processes requests.

## Verification

- go build ./... — clean
- go vet ./pkg/agent/... — clean
- go test ./pkg/agent/federation/... — pass
- go test ./pkg/agent/... — pass (full agent suite)
- Empty-registry handler returns literal [] (verified via TrimSpace(body) == "[]").

## What comes next

8 more PRs to land the full rollout:

- **PR B** — OCM provider + Phase 1 UI (useFederation hook, ClusterHealth / ClusterGroups card updates, demo data with 2 hubs).
- **PR C** — Karmada provider.
- **PR D** — CAPI provider (includes ghost-row UI for provisioning clusters).
- **PR E** — Clusternet + Liqo + KubeAdmiral providers.
- **PR F** — Action framework + OCM actions (Phase 2 start).
- **PR G** — Karmada actions.
- **PR H** — CAPI actions (scale / upgrade / retry / delete).
- **PR I** — Clusternet + Liqo + KubeAdmiral actions.

## Rules honored

- DCO signed (Signed-off-by: trailer present).
- Issue NNNN in comments, never #NNNN (ui-ux hex ratchet).
- No InClusterConfig fallback.
- No UI changes.
- No provider implementations.