### PR TITLE
feat: orbit resource targeting (namespaced + cluster-scoped) + post-mission monitor offer

### DIFF
--- a/web/src/components/layout/mission-sidebar/MissionChat.tsx
+++ b/web/src/components/layout/mission-sidebar/MissionChat.tsx
@@ -36,12 +36,14 @@ import { PreflightFailure } from '../../missions/PreflightFailure'
 import { SaveResolutionDialog } from '../../missions/SaveResolutionDialog'
 import { SetupInstructionsDialog } from '../../setup/SetupInstructionsDialog'
 import { OrbitSetupOffer } from '../../missions/OrbitSetupOffer'
+import { OrbitMonitorOffer } from '../../missions/OrbitMonitorOffer'
+import type { OrbitResourceFilter } from '../../../lib/missions/types'
 import { STATUS_CONFIG, TYPE_ICONS } from './types'
 import type { FontSize } from './types'
 import { TypingIndicator } from './TypingIndicator'
 import { MemoizedMessage } from './MemoizedMessage'
 
-export function MissionChat({ mission, isFullScreen = false, fontSize = 'base' as FontSize, onToggleFullScreen }: { mission: Mission; isFullScreen?: boolean; fontSize?: FontSize; onToggleFullScreen?: () => void }) {
+export function MissionChat({ mission, isFullScreen = false, fontSize = 'base' as FontSize, onToggleFullScreen, onOpenOrbitDialog }: { mission: Mission; isFullScreen?: boolean; fontSize?: FontSize; onToggleFullScreen?: () => void; onOpenOrbitDialog?: (prefill: { clusters?: string[]; resourceFilters?: Record<string, OrbitResourceFilter[]> }) => void }) {
   const { t } = useTranslation('common')
   // #6226: useToast for download error feedback (replaces an unhandled
   // exception path that could white-screen the dialog).
@@ -927,6 +929,14 @@ export function MissionChat({ mission, isFullScreen = false, fontSize = 'base' a
                 onDashboardCreated={() => {/* navigation handled internally */}}
                 onSkip={() => {/* dismiss is internal */}}
               />
+            )}
+
+            {/* Monitor offer — shown after repair/troubleshoot/analyze missions complete */}
+            {mission.importedFrom?.missionClass !== 'install' &&
+             mission.importedFrom?.missionClass !== 'orbit' &&
+             mission.type !== 'deploy' &&
+             onOpenOrbitDialog && (
+              <OrbitMonitorOffer mission={mission} onOpenOrbitDialog={onOpenOrbitDialog} />
             )}
 
             {/* Follow-up input — allow continuing the conversation after completion (#5735) */}

--- a/web/src/components/layout/mission-sidebar/MissionSidebar.tsx
+++ b/web/src/components/layout/mission-sidebar/MissionSidebar.tsx
@@ -35,7 +35,7 @@ const MissionBrowser = lazy(() =>
 )
 import { MissionControlDialog } from '../../mission-control/MissionControlDialog'
 import { MissionDetailView } from '../../missions/MissionDetailView'
-import type { MissionExport } from '../../../lib/missions/types'
+import type { MissionExport, OrbitResourceFilter } from '../../../lib/missions/types'
 import type { Mission } from '../../../hooks/useMissions'
 import { MissionListItem } from './MissionListItem'
 import { OrbitReminderBanner } from '../../missions/OrbitReminderBanner'
@@ -189,6 +189,7 @@ export function MissionSidebar() {
   /** Kubara chart name to pre-populate in Mission Control Phase 1 (#8483) */
   const [pendingKubaraChart, setPendingKubaraChart] = useState<string | undefined>(undefined)
   const [showOrbitDialog, setShowOrbitDialog] = useState(false)
+  const [orbitDialogPrefill, setOrbitDialogPrefill] = useState<{ clusters?: string[]; resourceFilters?: Record<string, OrbitResourceFilter[]> } | undefined>(undefined)
   const [newMissionPrompt, setNewMissionPrompt] = useState('')
   const [showSavedToast, setShowSavedToast] = useState<string | null>(null)
   /** Countdown seconds remaining for the saved-mission toast */
@@ -1097,7 +1098,15 @@ export function MissionSidebar() {
                 {t('missionSidebar.backToMissions', { count: listTotalMissions })}
               </button>
             )}
-            <MissionChat mission={activeMission} isFullScreen={isFullScreen} onToggleFullScreen={() => setFullScreen(true)} />
+            <MissionChat
+              mission={activeMission}
+              isFullScreen={isFullScreen}
+              onToggleFullScreen={() => setFullScreen(true)}
+              onOpenOrbitDialog={(prefill) => {
+                setOrbitDialogPrefill(prefill)
+                setShowOrbitDialog(true)
+              }}
+            />
           </div>
         </div>
       ) : (
@@ -1346,7 +1355,10 @@ export function MissionSidebar() {
 
       {/* Standalone Orbit Mission Dialog */}
       {showOrbitDialog && (
-        <StandaloneOrbitDialog onClose={() => setShowOrbitDialog(false)} />
+        <StandaloneOrbitDialog
+          onClose={() => { setShowOrbitDialog(false); setOrbitDialogPrefill(undefined) }}
+          prefill={orbitDialogPrefill}
+        />
       )}
 
       {/* Cluster Selection Dialog for install missions */}

--- a/web/src/components/missions/OrbitMonitorOffer.tsx
+++ b/web/src/components/missions/OrbitMonitorOffer.tsx
@@ -1,0 +1,59 @@
+/**
+ * OrbitMonitorOffer — post-completion inline offer to set up ongoing monitoring.
+ *
+ * Shown in MissionChat after non-install, non-orbit missions complete.
+ * Opens StandaloneOrbitDialog pre-populated with the mission's cluster and
+ * a default set of workload resource kinds.
+ */
+
+import { useState } from 'react'
+import { Satellite, X } from 'lucide-react'
+import { DEFAULT_MONITOR_KINDS } from '../../lib/constants/k8sResources'
+import type { OrbitResourceFilter } from '../../lib/missions/types'
+import type { Mission } from '../../hooks/useMissions'
+
+interface OrbitMonitorOfferProps {
+  mission: Mission
+  onOpenOrbitDialog: (prefill: {
+    clusters?: string[]
+    resourceFilters?: Record<string, OrbitResourceFilter[]>
+  }) => void
+}
+
+export function OrbitMonitorOffer({ mission, onOpenOrbitDialog }: OrbitMonitorOfferProps) {
+  const [dismissed, setDismissed] = useState(false)
+
+  if (dismissed) return null
+
+  const handleSetupMonitor = () => {
+    const clusters = mission.cluster ? [mission.cluster] : []
+    const resourceFilters: Record<string, OrbitResourceFilter[]> = {}
+    if (mission.cluster) {
+      resourceFilters[mission.cluster] = DEFAULT_MONITOR_KINDS.map(k => ({ ...k }))
+    }
+    onOpenOrbitDialog({ clusters, resourceFilters })
+  }
+
+  return (
+    <div className="mx-4 my-2 rounded-lg border border-purple-500/25 bg-purple-500/5 px-3 py-2.5 flex items-center gap-3">
+      <Satellite className="w-4 h-4 text-purple-400 flex-shrink-0" />
+      <div className="flex-1 min-w-0">
+        <p className="text-xs text-foreground">Want to keep watching this?</p>
+        <p className="text-[10px] text-muted-foreground">Set up an orbit to monitor it automatically.</p>
+      </div>
+      <button
+        onClick={handleSetupMonitor}
+        className="flex-shrink-0 text-xs font-medium text-purple-400 hover:text-purple-300 border border-purple-500/30 rounded px-2 py-1 transition-colors hover:bg-purple-500/10"
+      >
+        Set up monitor
+      </button>
+      <button
+        onClick={() => setDismissed(true)}
+        className="flex-shrink-0 p-0.5 text-muted-foreground/50 hover:text-muted-foreground rounded transition-colors"
+        aria-label="Dismiss"
+      >
+        <X className="w-3.5 h-3.5" />
+      </button>
+    </div>
+  )
+}

--- a/web/src/components/missions/StandaloneOrbitDialog.tsx
+++ b/web/src/components/missions/StandaloneOrbitDialog.tsx
@@ -2,7 +2,8 @@
  * StandaloneOrbitDialog -- Create an orbit mission without a prior install mission.
  *
  * Allows users to pick an orbit template, cadence, auto-run toggle,
- * and target clusters, then saves the mission to the library.
+ * target clusters, and per-cluster resource scope (namespaced or cluster-scoped
+ * Kubernetes objects), then saves the mission to the library.
  */
 
 import { useState, useCallback } from 'react'
@@ -11,27 +12,222 @@ import { Satellite, Orbit, X, ChevronDown, ChevronUp } from 'lucide-react'
 import { cn } from '../../lib/cn'
 import { useClusters } from '../../hooks/mcp/clusters'
 import { useMissions } from '../../hooks/useMissions'
+import { useNamespaces } from '../../hooks/mcp/namespaces'
 import { getApplicableOrbitTemplates } from '../../lib/orbit/orbitTemplates'
 import { ORBIT_DEFAULT_CADENCE } from '../../lib/constants/orbit'
+import { ORBIT_CLUSTER_SCOPED_KINDS, ORBIT_NAMESPACED_KINDS } from '../../lib/constants/k8sResources'
 import { emitOrbitMissionCreated } from '../../lib/analytics'
 import { isDemoMode } from '../../lib/demoMode'
 import { SetupInstructionsDialog } from '../setup/SetupInstructionsDialog'
 import { ConfirmDialog } from '../../lib/modals'
-import type { OrbitCadence, OrbitType, OrbitConfig } from '../../lib/missions/types'
+import type { OrbitCadence, OrbitType, OrbitConfig, OrbitResourceFilter } from '../../lib/missions/types'
 
 interface StandaloneOrbitDialogProps {
-  /** Close the dialog */
   onClose: () => void
+  prefill?: {
+    clusters?: string[]
+    resourceFilters?: Record<string, OrbitResourceFilter[]>
+  }
 }
 
 const CADENCE_OPTIONS: OrbitCadence[] = ['daily', 'weekly', 'monthly']
 
-export function StandaloneOrbitDialog({ onClose }: StandaloneOrbitDialogProps) {
+// ---------------------------------------------------------------------------
+// ClusterScopeSection — per-cluster resource kind + namespace picker
+// Must be a real component (not rendered inside a loop) so that
+// useNamespaces() is called at the top level of a component, not inside a map.
+// ---------------------------------------------------------------------------
+
+interface ClusterScopeSectionProps {
+  clusterName: string
+  value: OrbitResourceFilter[]
+  onChange: (clusterName: string, filters: OrbitResourceFilter[]) => void
+}
+
+function ClusterScopeSection({ clusterName, value, onChange }: ClusterScopeSectionProps) {
+  const [expanded, setExpanded] = useState(value.length > 0)
+  const { namespaces, isLoading: nsLoading } = useNamespaces(clusterName)
+  const nsOptions = (namespaces || []) as string[]
+
+  const isKindChecked = (kind: string) => value.some(f => f.kind === kind)
+
+  const getNamespacesForKind = (kind: string): string[] =>
+    value.find(f => f.kind === kind)?.namespaces ?? []
+
+  const toggleKind = useCallback((meta: { kind: string; clusterScoped: boolean }) => {
+    if (isKindChecked(meta.kind)) {
+      onChange(clusterName, value.filter(f => f.kind !== meta.kind))
+    } else {
+      onChange(clusterName, [...value, { kind: meta.kind, clusterScoped: meta.clusterScoped, namespaces: [] }])
+    }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [clusterName, value, onChange])
+
+  const toggleNamespace = useCallback((kind: string, ns: string) => {
+    const existing = value.find(f => f.kind === kind)
+    if (!existing) return
+    const nsSet = new Set(existing.namespaces ?? [])
+    if (nsSet.has(ns)) nsSet.delete(ns)
+    else nsSet.add(ns)
+    onChange(clusterName, value.map(f => f.kind === kind ? { ...f, namespaces: [...nsSet] } : f))
+  }, [clusterName, value, onChange])
+
+  const activeCount = value.length
+
+  // Group kinds by their `group` field for display
+  const clusterGroups = ORBIT_CLUSTER_SCOPED_KINDS.reduce<Record<string, typeof ORBIT_CLUSTER_SCOPED_KINDS>>((acc, k) => {
+    ;(acc[k.group] ??= []).push(k)
+    return acc
+  }, {})
+  const namespacedGroups = ORBIT_NAMESPACED_KINDS.reduce<Record<string, typeof ORBIT_NAMESPACED_KINDS>>((acc, k) => {
+    ;(acc[k.group] ??= []).push(k)
+    return acc
+  }, {})
+
+  return (
+    <div className="mt-1 ml-6 border-l border-border pl-3">
+      <button
+        onClick={() => setExpanded(p => !p)}
+        className="flex items-center gap-1.5 text-[10px] text-muted-foreground hover:text-foreground transition-colors py-0.5"
+      >
+        {expanded ? <ChevronUp className="w-3 h-3" /> : <ChevronDown className="w-3 h-3" />}
+        <span>Scope</span>
+        {activeCount > 0 && (
+          <span className="bg-purple-500/20 text-purple-400 px-1 rounded-full">
+            {activeCount}
+          </span>
+        )}
+        {activeCount === 0 && <span className="text-[9px] opacity-50">(all resources)</span>}
+      </button>
+
+      {expanded && (
+        <div className="mt-2 space-y-3">
+          {/* Cluster-scoped section */}
+          <div>
+            <p className="text-[10px] font-medium text-muted-foreground mb-1">Cluster-scoped</p>
+            <div className="space-y-2">
+              {Object.entries(clusterGroups).map(([group, kinds]) => (
+                <div key={group}>
+                  <p className="text-[9px] uppercase tracking-wide text-muted-foreground/60 mb-0.5">{group}</p>
+                  <div className="flex flex-wrap gap-1.5">
+                    {kinds.map(k => (
+                      <label key={k.kind} className="flex items-center gap-1 cursor-pointer">
+                        <input
+                          type="checkbox"
+                          checked={isKindChecked(k.kind)}
+                          onChange={() => toggleKind(k)}
+                          className="accent-purple-500 w-3 h-3"
+                        />
+                        <span className={cn(
+                          'text-[10px]',
+                          isKindChecked(k.kind) ? 'text-foreground' : 'text-muted-foreground',
+                        )}>{k.label}</span>
+                      </label>
+                    ))}
+                  </div>
+                </div>
+              ))}
+            </div>
+          </div>
+
+          {/* Namespaced section */}
+          <div>
+            <p className="text-[10px] font-medium text-muted-foreground mb-1">Namespaced</p>
+            <div className="space-y-2">
+              {Object.entries(namespacedGroups).map(([group, kinds]) => (
+                <div key={group}>
+                  <p className="text-[9px] uppercase tracking-wide text-muted-foreground/60 mb-0.5">{group}</p>
+                  <div className="space-y-1">
+                    {kinds.map(k => (
+                      <div key={k.kind}>
+                        <label className="flex items-center gap-1 cursor-pointer">
+                          <input
+                            type="checkbox"
+                            checked={isKindChecked(k.kind)}
+                            onChange={() => toggleKind(k)}
+                            className="accent-purple-500 w-3 h-3"
+                          />
+                          <span className={cn(
+                            'text-[10px]',
+                            isKindChecked(k.kind) ? 'text-foreground' : 'text-muted-foreground',
+                          )}>{k.label}</span>
+                        </label>
+
+                        {/* Namespace picker — only shown when kind is checked */}
+                        {isKindChecked(k.kind) && (
+                          <div className="ml-4 mt-1">
+                            {nsLoading ? (
+                              <span className="text-[9px] text-muted-foreground">Loading namespaces…</span>
+                            ) : nsOptions.length === 0 ? (
+                              <span className="text-[9px] text-muted-foreground">All namespaces</span>
+                            ) : (
+                              <div className="flex flex-wrap gap-1">
+                                {nsOptions.map(ns => {
+                                  const checked = getNamespacesForKind(k.kind).includes(ns)
+                                  return (
+                                    <button
+                                      key={ns}
+                                      onClick={() => toggleNamespace(k.kind, ns)}
+                                      className={cn(
+                                        'text-[9px] px-1.5 py-0.5 rounded border transition-colors',
+                                        checked
+                                          ? 'bg-purple-500/20 border-purple-500/40 text-purple-300'
+                                          : 'border-border text-muted-foreground hover:border-purple-500/40',
+                                      )}
+                                    >
+                                      {ns}
+                                    </button>
+                                  )
+                                })}
+                                {getNamespacesForKind(k.kind).length === 0 && (
+                                  <span className="text-[9px] text-muted-foreground/60 self-center">all namespaces</span>
+                                )}
+                              </div>
+                            )}
+                          </div>
+                        )}
+                      </div>
+                    ))}
+                  </div>
+                </div>
+              ))}
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// buildScopeString — injects resource filter selections into the orbit prompt
+// ---------------------------------------------------------------------------
+
+function buildScopeString(filters: Record<string, OrbitResourceFilter[]>): string {
+  const lines = Object.entries(filters)
+    .filter(([, f]) => f.length > 0)
+    .map(([cluster, f]) => {
+      const parts = f.map(r =>
+        r.clusterScoped
+          ? `${r.kind} (cluster-scoped)`
+          : (r.namespaces ?? []).length
+            ? `${r.kind} in namespaces: ${r.namespaces!.join(', ')}`
+            : `${r.kind} (all namespaces)`
+      )
+      return `- ${cluster}: ${parts.join('; ')}`
+    })
+  return lines.length ? `\n\nFocus on:\n${lines.join('\n')}` : ''
+}
+
+// ---------------------------------------------------------------------------
+// StandaloneOrbitDialog
+// ---------------------------------------------------------------------------
+
+export function StandaloneOrbitDialog({ onClose, prefill }: StandaloneOrbitDialogProps) {
   const { t } = useTranslation()
   const { saveMission } = useMissions()
   const { deduplicatedClusters, isLoading: clustersLoading } = useClusters()
 
-  // All orbit templates are applicable (wildcard categories)
   const templates = getApplicableOrbitTemplates(['*'])
 
   const [selectedOrbit, setSelectedOrbit] = useState<OrbitType | null>(
@@ -39,8 +235,15 @@ export function StandaloneOrbitDialog({ onClose }: StandaloneOrbitDialogProps) {
   )
   const [cadence, setCadence] = useState<OrbitCadence>(ORBIT_DEFAULT_CADENCE)
   const [autoRun, setAutoRun] = useState(false)
-  const [selectedClusters, setSelectedClusters] = useState<Set<string>>(new Set())
-  const [showClusterPicker, setShowClusterPicker] = useState(false)
+  const [selectedClusters, setSelectedClusters] = useState<Set<string>>(
+    new Set(prefill?.clusters ?? [])
+  )
+  const [resourceFilters, setResourceFilters] = useState<Record<string, OrbitResourceFilter[]>>(
+    prefill?.resourceFilters ?? {}
+  )
+  const [showClusterPicker, setShowClusterPicker] = useState(
+    (prefill?.clusters?.length ?? 0) > 0
+  )
   const [showSetupDialog, setShowSetupDialog] = useState(false)
   // Issue 9373: confirm before creating an orbit with an empty cluster selection
   // (which would otherwise silently target every connected cluster).
@@ -51,8 +254,17 @@ export function StandaloneOrbitDialog({ onClose }: StandaloneOrbitDialogProps) {
   const toggleCluster = useCallback((name: string) => {
     setSelectedClusters(prev => {
       const next = new Set(prev)
-      if (next.has(name)) next.delete(name)
-      else next.add(name)
+      if (next.has(name)) {
+        next.delete(name)
+        // clean up filters for deselected cluster
+        setResourceFilters(f => {
+          const updated = { ...f }
+          delete updated[name]
+          return updated
+        })
+      } else {
+        next.add(name)
+      }
       return next
     })
   }, [])
@@ -63,6 +275,11 @@ export function StandaloneOrbitDialog({ onClose }: StandaloneOrbitDialogProps) {
 
   const deselectAllClusters = useCallback(() => {
     setSelectedClusters(new Set())
+    setResourceFilters({})
+  }, [])
+
+  const handleScopeChange = useCallback((clusterName: string, filters: OrbitResourceFilter[]) => {
+    setResourceFilters(prev => ({ ...prev, [clusterName]: filters }))
   }, [])
 
   // Actually build + persist the orbit mission. Split out so both the
@@ -79,12 +296,18 @@ export function StandaloneOrbitDialog({ onClose }: StandaloneOrbitDialogProps) {
       ? `${template.title} -- ${clusterNames.join(', ')}`
       : template.title
 
+    const activeFilters: Record<string, OrbitResourceFilter[]> = {}
+    for (const [c, f] of Object.entries(resourceFilters)) {
+      if (f.length > 0) activeFilters[c] = f
+    }
+
     const orbitConfig: OrbitConfig = {
       cadence,
       orbitType: selectedOrbit,
       clusters: clusterNames,
       autoRun,
       lastRunAt: null,
+      ...(Object.keys(activeFilters).length > 0 ? { resourceFilters: activeFilters } : {}),
     }
 
     saveMission({
@@ -94,13 +317,13 @@ export function StandaloneOrbitDialog({ onClose }: StandaloneOrbitDialogProps) {
       missionClass: 'orbit',
       steps: template.steps.map(s => ({ title: s.title, description: s.description })),
       tags: ['orbit', selectedOrbit, cadence],
-      initialPrompt: template.description,
+      initialPrompt: template.description + buildScopeString(activeFilters),
       context: { orbitConfig },
     })
 
     emitOrbitMissionCreated(selectedOrbit, cadence)
     onClose()
-  }, [selectedOrbit, cadence, autoRun, selectedClusters, templates, saveMission, onClose])
+  }, [selectedOrbit, cadence, autoRun, selectedClusters, resourceFilters, templates, saveMission, onClose])
 
   const handleCreate = useCallback(() => {
     if (!selectedOrbit) return
@@ -221,7 +444,7 @@ export function StandaloneOrbitDialog({ onClose }: StandaloneOrbitDialogProps) {
             <span className="text-xs text-foreground">{t('orbit.autoRunDescription')}</span>
           </label>
 
-          {/* Target clusters */}
+          {/* Target clusters + per-cluster scope */}
           <div>
             <button
               onClick={() => setShowClusterPicker(!showClusterPicker)}
@@ -243,7 +466,7 @@ export function StandaloneOrbitDialog({ onClose }: StandaloneOrbitDialogProps) {
             </button>
 
             {showClusterPicker && (
-              <div className="mt-2 space-y-1 max-h-40 overflow-y-auto rounded-lg border border-border p-2">
+              <div className="mt-2 space-y-1 max-h-96 overflow-y-auto rounded-lg border border-border p-2">
                 {clustersLoading ? (
                   <p className="text-[10px] text-muted-foreground py-2 text-center">
                     {t('orbit.standaloneClustersLoading')}
@@ -269,29 +492,39 @@ export function StandaloneOrbitDialog({ onClose }: StandaloneOrbitDialogProps) {
                       </button>
                     </div>
                     {clusters.map(c => (
-                      <label
-                        key={c.name}
-                        className={cn(
-                          'flex items-center gap-2 px-2 py-1.5 rounded cursor-pointer transition-colors',
-                          selectedClusters.has(c.name)
-                            ? 'bg-purple-500/10'
-                            : 'hover:bg-secondary/50',
+                      <div key={c.name}>
+                        <label
+                          className={cn(
+                            'flex items-center gap-2 px-2 py-1.5 rounded cursor-pointer transition-colors',
+                            selectedClusters.has(c.name)
+                              ? 'bg-purple-500/10'
+                              : 'hover:bg-secondary/50',
+                          )}
+                        >
+                          <input
+                            type="checkbox"
+                            checked={selectedClusters.has(c.name)}
+                            onChange={() => toggleCluster(c.name)}
+                            className="accent-purple-500"
+                          />
+                          <span className="text-xs text-foreground truncate">{c.name}</span>
+                          <span className={cn(
+                            'ml-auto text-[10px] flex-shrink-0',
+                            c.healthy ? 'text-green-400' : 'text-red-400',
+                          )}>
+                            {c.healthy ? 'Healthy' : 'Unhealthy'}
+                          </span>
+                        </label>
+
+                        {/* Per-cluster resource scope — only when cluster is selected */}
+                        {selectedClusters.has(c.name) && (
+                          <ClusterScopeSection
+                            clusterName={c.name}
+                            value={resourceFilters[c.name] ?? []}
+                            onChange={handleScopeChange}
+                          />
                         )}
-                      >
-                        <input
-                          type="checkbox"
-                          checked={selectedClusters.has(c.name)}
-                          onChange={() => toggleCluster(c.name)}
-                          className="accent-purple-500"
-                        />
-                        <span className="text-xs text-foreground truncate">{c.name}</span>
-                        <span className={cn(
-                          'ml-auto text-[10px] flex-shrink-0',
-                          c.healthy ? 'text-green-400' : 'text-red-400',
-                        )}>
-                          {c.healthy ? 'Healthy' : 'Unhealthy'}
-                        </span>
-                      </label>
+                      </div>
                     ))}
                   </>
                 )}

--- a/web/src/lib/constants/k8sResources.ts
+++ b/web/src/lib/constants/k8sResources.ts
@@ -1,0 +1,39 @@
+export interface K8sKindMeta {
+  kind: string
+  clusterScoped: boolean
+  label: string
+  group: string
+}
+
+export const ORBIT_CLUSTER_SCOPED_KINDS: K8sKindMeta[] = [
+  { kind: 'Node', clusterScoped: true, label: 'Node', group: 'Infrastructure' },
+  { kind: 'Namespace', clusterScoped: true, label: 'Namespace', group: 'Infrastructure' },
+  { kind: 'PersistentVolume', clusterScoped: true, label: 'PersistentVolume', group: 'Storage' },
+  { kind: 'StorageClass', clusterScoped: true, label: 'StorageClass', group: 'Storage' },
+  { kind: 'ClusterRole', clusterScoped: true, label: 'ClusterRole', group: 'RBAC' },
+  { kind: 'ClusterRoleBinding', clusterScoped: true, label: 'ClusterRoleBinding', group: 'RBAC' },
+  { kind: 'CustomResourceDefinition', clusterScoped: true, label: 'CRD', group: 'Extensions' },
+]
+
+export const ORBIT_NAMESPACED_KINDS: K8sKindMeta[] = [
+  { kind: 'Deployment', clusterScoped: false, label: 'Deployment', group: 'Workloads' },
+  { kind: 'StatefulSet', clusterScoped: false, label: 'StatefulSet', group: 'Workloads' },
+  { kind: 'DaemonSet', clusterScoped: false, label: 'DaemonSet', group: 'Workloads' },
+  { kind: 'Pod', clusterScoped: false, label: 'Pod', group: 'Workloads' },
+  { kind: 'Job', clusterScoped: false, label: 'Job', group: 'Workloads' },
+  { kind: 'CronJob', clusterScoped: false, label: 'CronJob', group: 'Workloads' },
+  { kind: 'Service', clusterScoped: false, label: 'Service', group: 'Networking' },
+  { kind: 'Ingress', clusterScoped: false, label: 'Ingress', group: 'Networking' },
+  { kind: 'ConfigMap', clusterScoped: false, label: 'ConfigMap', group: 'Config' },
+  { kind: 'Secret', clusterScoped: false, label: 'Secret', group: 'Config' },
+  { kind: 'PersistentVolumeClaim', clusterScoped: false, label: 'PVC', group: 'Storage' },
+  { kind: 'HorizontalPodAutoscaler', clusterScoped: false, label: 'HPA', group: 'Scaling' },
+  { kind: 'ResourceQuota', clusterScoped: false, label: 'ResourceQuota', group: 'Governance' },
+]
+
+/** Default resource kinds pre-selected when suggesting an orbit after a mission completes */
+export const DEFAULT_MONITOR_KINDS: Array<{ kind: string; clusterScoped: boolean; namespaces: string[] }> = [
+  { kind: 'Deployment', clusterScoped: false, namespaces: [] },
+  { kind: 'StatefulSet', clusterScoped: false, namespaces: [] },
+  { kind: 'Pod', clusterScoped: false, namespaces: [] },
+]

--- a/web/src/lib/missions/types.ts
+++ b/web/src/lib/missions/types.ts
@@ -31,6 +31,13 @@ export interface OrbitRunHistoryEntry {
   summary?: string
 }
 
+export interface OrbitResourceFilter {
+  kind: string
+  clusterScoped: boolean
+  /** Targeted namespaces for namespaced kinds. Empty array = all namespaces. Ignored for cluster-scoped kinds. */
+  namespaces?: string[]
+}
+
 export interface OrbitConfig {
   cadence: OrbitCadence
   orbitType: OrbitType
@@ -40,6 +47,11 @@ export interface OrbitConfig {
   projects?: string[]
   /** Target clusters for this orbit */
   clusters?: string[]
+  /**
+   * Per-cluster resource scope. Key = cluster name.
+   * Absent or empty entry for a cluster = all resources (backward-compat).
+   */
+  resourceFilters?: Record<string, OrbitResourceFilter[]>
   /** ISO timestamp of the last run */
   lastRunAt?: string | null
   /** Result of the last run */


### PR DESCRIPTION
## Summary

Addresses two orbit use cases:

**1. Proactive orbit with resource scope** — users can now target specific Kubernetes objects when creating a standalone orbit, without needing a prior install mission. Per selected cluster, an expandable **Scope** section lets them pick:
- **Cluster-scoped kinds**: Node, Namespace, PersistentVolume, StorageClass, ClusterRole/Binding, CRD
- **Namespaced kinds**: Deployment, StatefulSet, DaemonSet, Pod, Job, CronJob, Service, Ingress, ConfigMap, Secret, PVC, HPA, ResourceQuota — with optional namespace multi-select (fetched live via `useNamespaces`)

If no scope is set, the orbit monitors all resources (backward-compat with existing saved orbits).

The selected resource scope is injected into the orbit AI prompt as a `Focus on:` block, e.g.:
```
- prod-cluster: Deployment in namespaces: llm-d, kube-system; Node (cluster-scoped)
```

**2. Reactive orbit after mission completion** — a dismissible `OrbitMonitorOffer` banner appears in MissionChat after repair/troubleshoot/analyze missions complete. Clicking "Set up monitor" opens `StandaloneOrbitDialog` pre-populated with the mission's cluster and default workload kinds (Deployment, StatefulSet, Pod), which the user can adjust before confirming.

## Changes

| File | What changed |
|---|---|
| `lib/missions/types.ts` | `OrbitResourceFilter` type + `resourceFilters` field on `OrbitConfig` |
| `lib/constants/k8sResources.ts` | New — static kind lists + default monitor kinds |
| `missions/StandaloneOrbitDialog.tsx` | `prefill` prop + `ClusterScopeSection` sub-component |
| `missions/OrbitMonitorOffer.tsx` | New — post-completion monitor offer banner |
| `mission-sidebar/MissionChat.tsx` | `onOpenOrbitDialog` prop + renders `OrbitMonitorOffer` |
| `mission-sidebar/MissionSidebar.tsx` | `orbitDialogPrefill` state + wiring |

## Test plan
- [ ] New orbit → select cluster → expand Scope → check Node (cluster-scoped) → create → inspect `mission.context.orbitConfig.resourceFilters`
- [ ] Check a namespaced kind (Deployment) → select namespace pills → verify prompt includes "Deployment in namespaces: ..."
- [ ] No scope selected → `resourceFilters` is `undefined`, prompt unchanged
- [ ] Complete a repair/troubleshoot mission → "Want to keep watching this?" banner appears
- [ ] Click "Set up monitor" → dialog opens with cluster pre-selected, Deployment/StatefulSet/Pod pre-checked
- [ ] Existing saved orbit missions (no `resourceFilters`) still render and run correctly
- [ ] `npm run build` passes ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)