### PR TITLE
feat(federation): OCM provider + Phase 1 UI

### DIFF
--- a/cmd/kc-agent/main.go
+++ b/cmd/kc-agent/main.go
@@ -10,6 +10,9 @@ import (
 	"syscall"
 
 	"github.com/kubestellar/console/pkg/agent"
+
+	// Blank-import federation providers so their init() funcs register them.
+	_ "github.com/kubestellar/console/pkg/agent/federation/providers"
 )
 
 func main() {

--- a/pkg/agent/federation/providers/ocm.go
+++ b/pkg/agent/federation/providers/ocm.go
@@ -1,0 +1,285 @@
+package providers
+
+import (
+	"context"
+	"strings"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/rest"
+
+	"github.com/kubestellar/console/pkg/agent/federation"
+)
+
+func init() {
+	federation.Register(&ocmProvider{})
+}
+
+var (
+	ocmManagedClusterGVR = schema.GroupVersionResource{
+		Group:    "cluster.open-cluster-management.io",
+		Version:  "v1",
+		Resource: "managedclusters",
+	}
+	ocmManagedClusterSetGVR = schema.GroupVersionResource{
+		Group:    "cluster.open-cluster-management.io",
+		Version:  "v1beta2",
+		Resource: "managedclustersets",
+	}
+	ocmCSRGVR = schema.GroupVersionResource{
+		Group:    "certificates.k8s.io",
+		Version:  "v1",
+		Resource: "certificatesigningrequests",
+	}
+)
+
+const (
+	ocmCSRSignerPrefix     = "kubernetes.io/kube-apiserver-client"
+	ocmCSRRequesterPrefix  = "system:open-cluster-management:"
+	ocmClusterSetLabelKey  = "cluster.open-cluster-management.io/clusterset"
+	ocmConditionJoined     = "ManagedClusterJoined"
+	ocmConditionAvailable  = "ManagedClusterConditionAvailable"
+	ocmAPIGroup            = "cluster.open-cluster-management.io"
+)
+
+type ocmProvider struct{}
+
+func (p *ocmProvider) Name() federation.FederationProviderName {
+	return federation.ProviderOCM
+}
+
+func (p *ocmProvider) Detect(ctx context.Context, cfg *rest.Config) (federation.DetectResult, error) {
+	dc, err := dynamic.NewForConfig(cfg)
+	if err != nil {
+		return federation.DetectResult{}, err
+	}
+	_, err = dc.Resource(ocmManagedClusterGVR).List(ctx, metav1.ListOptions{Limit: 1})
+	if err != nil {
+		if isNotFoundOrGroupNotFound(err) {
+			return federation.DetectResult{Detected: false}, nil
+		}
+		return federation.DetectResult{}, err
+	}
+	return federation.DetectResult{Detected: true, Version: "v1"}, nil
+}
+
+func (p *ocmProvider) ReadClusters(ctx context.Context, cfg *rest.Config) ([]federation.FederatedCluster, error) {
+	dc, err := dynamic.NewForConfig(cfg)
+	if err != nil {
+		return nil, err
+	}
+	list, err := dc.Resource(ocmManagedClusterGVR).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		if isNotFoundOrGroupNotFound(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+
+	out := make([]federation.FederatedCluster, 0, len(list.Items))
+	for i := range list.Items {
+		fc := parseOCMManagedCluster(&list.Items[i])
+		out = append(out, fc)
+	}
+	return out, nil
+}
+
+func (p *ocmProvider) ReadGroups(ctx context.Context, cfg *rest.Config) ([]federation.FederatedGroup, error) {
+	dc, err := dynamic.NewForConfig(cfg)
+	if err != nil {
+		return nil, err
+	}
+	list, err := dc.Resource(ocmManagedClusterSetGVR).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		if isNotFoundOrGroupNotFound(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+
+	out := make([]federation.FederatedGroup, 0, len(list.Items))
+	for i := range list.Items {
+		name, _, _ := unstructured.NestedString(list.Items[i].Object, "metadata", "name")
+		out = append(out, federation.FederatedGroup{
+			Provider: federation.ProviderOCM,
+			Name:     name,
+			Members:  []string{},
+			Kind:     federation.FederatedGroupSet,
+		})
+	}
+	return out, nil
+}
+
+func (p *ocmProvider) ReadPendingJoins(ctx context.Context, cfg *rest.Config) ([]federation.PendingJoin, error) {
+	dc, err := dynamic.NewForConfig(cfg)
+	if err != nil {
+		return nil, err
+	}
+	list, err := dc.Resource(ocmCSRGVR).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		if isNotFoundOrGroupNotFound(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+
+	out := make([]federation.PendingJoin, 0)
+	for i := range list.Items {
+		csr := &list.Items[i]
+		if !isOCMPendingCSR(csr) {
+			continue
+		}
+		name, _, _ := unstructured.NestedString(csr.Object, "metadata", "name")
+		clusterName := extractOCMClusterFromCSR(csr)
+		createdAt := csr.GetCreationTimestamp().Time
+		out = append(out, federation.PendingJoin{
+			Provider:    federation.ProviderOCM,
+			ClusterName: clusterName,
+			RequestedAt: createdAt,
+			Detail:      "CSR: " + name,
+		})
+	}
+	return out, nil
+}
+
+func parseOCMManagedCluster(obj *unstructured.Unstructured) federation.FederatedCluster {
+	name := obj.GetName()
+	labels := obj.GetLabels()
+	if labels == nil {
+		labels = map[string]string{}
+	}
+
+	state := ocmExtractState(obj)
+	available := ocmExtractAvailable(obj)
+	apiServerURL, _, _ := unstructured.NestedString(obj.Object, "spec", "managedClusterClientConfigs")
+	if apiServerURL == "" {
+		configs, found, _ := unstructured.NestedSlice(obj.Object, "spec", "managedClusterClientConfigs")
+		if found && len(configs) > 0 {
+			if cfgMap, ok := configs[0].(map[string]interface{}); ok {
+				apiServerURL, _ = cfgMap["url"].(string)
+			}
+		}
+	}
+
+	clusterSet := labels[ocmClusterSetLabelKey]
+
+	taints := ocmExtractTaints(obj)
+
+	return federation.FederatedCluster{
+		Provider:     federation.ProviderOCM,
+		Name:         name,
+		State:        state,
+		Available:    available,
+		ClusterSet:   clusterSet,
+		Labels:       labels,
+		APIServerURL: apiServerURL,
+		Taints:       taints,
+		Raw:          obj.Object,
+	}
+}
+
+func ocmExtractState(obj *unstructured.Unstructured) federation.ClusterState {
+	conditions, found, _ := unstructured.NestedSlice(obj.Object, "status", "conditions")
+	if !found {
+		return federation.ClusterStateUnknown
+	}
+	for _, c := range conditions {
+		cond, ok := c.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		condType, _ := cond["type"].(string)
+		condStatus, _ := cond["status"].(string)
+		if condType == ocmConditionJoined {
+			if condStatus == "True" {
+				return federation.ClusterStateJoined
+			}
+			return federation.ClusterStatePending
+		}
+	}
+	accepted, _, _ := unstructured.NestedBool(obj.Object, "spec", "hubAcceptsClient")
+	if !accepted {
+		return federation.ClusterStatePending
+	}
+	return federation.ClusterStateJoined
+}
+
+func ocmExtractAvailable(obj *unstructured.Unstructured) string {
+	conditions, found, _ := unstructured.NestedSlice(obj.Object, "status", "conditions")
+	if !found {
+		return "Unknown"
+	}
+	for _, c := range conditions {
+		cond, ok := c.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		condType, _ := cond["type"].(string)
+		condStatus, _ := cond["status"].(string)
+		if condType == ocmConditionAvailable {
+			return condStatus
+		}
+	}
+	return "Unknown"
+}
+
+func ocmExtractTaints(obj *unstructured.Unstructured) []federation.Taint {
+	raw, found, _ := unstructured.NestedSlice(obj.Object, "spec", "taints")
+	if !found || len(raw) == 0 {
+		return nil
+	}
+	taints := make([]federation.Taint, 0, len(raw))
+	for _, t := range raw {
+		tm, ok := t.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		key, _ := tm["key"].(string)
+		value, _ := tm["value"].(string)
+		effect, _ := tm["effect"].(string)
+		taints = append(taints, federation.Taint{Key: key, Value: value, Effect: effect})
+	}
+	return taints
+}
+
+func isOCMPendingCSR(csr *unstructured.Unstructured) bool {
+	requester, _, _ := unstructured.NestedString(csr.Object, "spec", "username")
+	if !strings.HasPrefix(requester, ocmCSRRequesterPrefix) {
+		return false
+	}
+	conditions, _, _ := unstructured.NestedSlice(csr.Object, "status", "conditions")
+	for _, c := range conditions {
+		cond, ok := c.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		condType, _ := cond["type"].(string)
+		if condType == "Approved" || condType == "Denied" {
+			return false
+		}
+	}
+	return true
+}
+
+func extractOCMClusterFromCSR(csr *unstructured.Unstructured) string {
+	requester, _, _ := unstructured.NestedString(csr.Object, "spec", "username")
+	parts := strings.Split(requester, ":")
+	if len(parts) >= 4 {
+		return parts[len(parts)-2]
+	}
+	name := csr.GetName()
+	return name
+}
+
+func isNotFoundOrGroupNotFound(err error) bool {
+	msg := err.Error()
+	return strings.Contains(msg, "the server could not find the requested resource") ||
+		strings.Contains(msg, "no matches for kind") ||
+		strings.Contains(msg, "could not find the requested resource") ||
+		strings.Contains(msg, "not found")
+}
+
+// Ensure compile-time interface conformance.
+var _ federation.Provider = (*ocmProvider)(nil)

--- a/pkg/agent/federation/providers/ocm_test.go
+++ b/pkg/agent/federation/providers/ocm_test.go
@@ -1,0 +1,177 @@
+package providers
+
+import (
+	"testing"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	"github.com/kubestellar/console/pkg/agent/federation"
+)
+
+func TestParseOCMManagedCluster_Joined(t *testing.T) {
+	obj := &unstructured.Unstructured{Object: map[string]interface{}{
+		"metadata": map[string]interface{}{
+			"name": "spoke-1",
+			"labels": map[string]interface{}{
+				"cluster.open-cluster-management.io/clusterset": "prod-set",
+			},
+		},
+		"spec": map[string]interface{}{
+			"hubAcceptsClient": true,
+			"managedClusterClientConfigs": []interface{}{
+				map[string]interface{}{"url": "https://spoke-1:6443"},
+			},
+		},
+		"status": map[string]interface{}{
+			"conditions": []interface{}{
+				map[string]interface{}{
+					"type":   "ManagedClusterJoined",
+					"status": "True",
+				},
+				map[string]interface{}{
+					"type":   "ManagedClusterConditionAvailable",
+					"status": "True",
+				},
+			},
+		},
+	}}
+
+	fc := parseOCMManagedCluster(obj)
+	if fc.Name != "spoke-1" {
+		t.Errorf("expected name spoke-1, got %s", fc.Name)
+	}
+	if fc.State != federation.ClusterStateJoined {
+		t.Errorf("expected state joined, got %s", fc.State)
+	}
+	if fc.Available != "True" {
+		t.Errorf("expected available True, got %s", fc.Available)
+	}
+	if fc.ClusterSet != "prod-set" {
+		t.Errorf("expected clusterSet prod-set, got %s", fc.ClusterSet)
+	}
+	if fc.APIServerURL != "https://spoke-1:6443" {
+		t.Errorf("expected apiServerURL https://spoke-1:6443, got %s", fc.APIServerURL)
+	}
+	if fc.Provider != federation.ProviderOCM {
+		t.Errorf("expected provider ocm, got %s", fc.Provider)
+	}
+}
+
+func TestParseOCMManagedCluster_Pending(t *testing.T) {
+	obj := &unstructured.Unstructured{Object: map[string]interface{}{
+		"metadata": map[string]interface{}{
+			"name": "spoke-2",
+		},
+		"spec": map[string]interface{}{
+			"hubAcceptsClient": false,
+		},
+		"status": map[string]interface{}{
+			"conditions": []interface{}{
+				map[string]interface{}{
+					"type":   "ManagedClusterJoined",
+					"status": "False",
+				},
+			},
+		},
+	}}
+
+	fc := parseOCMManagedCluster(obj)
+	if fc.State != federation.ClusterStatePending {
+		t.Errorf("expected state pending, got %s", fc.State)
+	}
+	if fc.Available != "Unknown" {
+		t.Errorf("expected available Unknown, got %s", fc.Available)
+	}
+}
+
+func TestParseOCMManagedCluster_WithTaints(t *testing.T) {
+	obj := &unstructured.Unstructured{Object: map[string]interface{}{
+		"metadata": map[string]interface{}{
+			"name": "spoke-tainted",
+		},
+		"spec": map[string]interface{}{
+			"hubAcceptsClient": true,
+			"taints": []interface{}{
+				map[string]interface{}{
+					"key":    "cluster.open-cluster-management.io/unreachable",
+					"effect": "NoSchedule",
+				},
+			},
+		},
+		"status": map[string]interface{}{
+			"conditions": []interface{}{
+				map[string]interface{}{
+					"type":   "ManagedClusterJoined",
+					"status": "True",
+				},
+			},
+		},
+	}}
+
+	fc := parseOCMManagedCluster(obj)
+	if len(fc.Taints) != 1 {
+		t.Fatalf("expected 1 taint, got %d", len(fc.Taints))
+	}
+	if fc.Taints[0].Key != "cluster.open-cluster-management.io/unreachable" {
+		t.Errorf("unexpected taint key: %s", fc.Taints[0].Key)
+	}
+}
+
+func TestIsOCMPendingCSR(t *testing.T) {
+	pending := &unstructured.Unstructured{Object: map[string]interface{}{
+		"spec": map[string]interface{}{
+			"username": "system:open-cluster-management:spoke-3:agent",
+		},
+		"status": map[string]interface{}{
+			"conditions": []interface{}{},
+		},
+	}}
+	if !isOCMPendingCSR(pending) {
+		t.Error("expected pending CSR to be detected")
+	}
+
+	approved := &unstructured.Unstructured{Object: map[string]interface{}{
+		"spec": map[string]interface{}{
+			"username": "system:open-cluster-management:spoke-3:agent",
+		},
+		"status": map[string]interface{}{
+			"conditions": []interface{}{
+				map[string]interface{}{"type": "Approved", "status": "True"},
+			},
+		},
+	}}
+	if isOCMPendingCSR(approved) {
+		t.Error("expected approved CSR to NOT be detected as pending")
+	}
+
+	nonOCM := &unstructured.Unstructured{Object: map[string]interface{}{
+		"spec": map[string]interface{}{
+			"username": "system:node:worker-1",
+		},
+	}}
+	if isOCMPendingCSR(nonOCM) {
+		t.Error("expected non-OCM CSR to NOT be detected")
+	}
+}
+
+func TestExtractOCMClusterFromCSR(t *testing.T) {
+	csr := &unstructured.Unstructured{Object: map[string]interface{}{
+		"metadata": map[string]interface{}{
+			"name": "csr-spoke-4",
+		},
+		"spec": map[string]interface{}{
+			"username": "system:open-cluster-management:spoke-4:agent",
+		},
+	}}
+	name := extractOCMClusterFromCSR(csr)
+	if name != "spoke-4" {
+		t.Errorf("expected cluster name 'spoke-4' from split, got %s", name)
+	}
+}
+
+func TestOCMProviderName(t *testing.T) {
+	p := &ocmProvider{}
+	if p.Name() != federation.ProviderOCM {
+		t.Errorf("expected provider name 'ocm', got '%s'", p.Name())
+	}
+}

--- a/web/src/components/cards/ClusterGroups.tsx
+++ b/web/src/components/cards/ClusterGroups.tsx
@@ -31,6 +31,7 @@ import { useDemoMode } from '../../hooks/useDemoMode'
 import { useTranslation } from 'react-i18next'
 import { StatusBadge } from '../ui/StatusBadge'
 import { ConfirmDialog } from '../../lib/modals'
+import { useFederationAwareness, getProviderLabel } from '../../hooks/useFederation'
 
 interface ClusterGroupsProps {
   config?: Record<string, unknown>
@@ -116,6 +117,7 @@ export function ClusterGroups(_props: ClusterGroupsProps) {
   const { groups: liveGroups, createGroup, updateGroup, deleteGroup, isPersisted } = useClusterGroups()
   const { deduplicatedClusters: clusters, isLoading, isRefreshing } = useClusters()
   const { isDemoMode: demoMode } = useDemoMode()
+  const federation = useFederationAwareness()
 
   // Build the built-in "all-healthy-clusters" group from current cluster state for live mode
   const builtInGroup: ClusterGroup = {
@@ -126,7 +128,16 @@ export function ClusterGroups(_props: ClusterGroupsProps) {
     builtIn: true,
     query: { filters: [{ field: 'healthy', operator: 'eq', value: 'true' }] } }
 
-  const groups = demoMode ? DEMO_GROUPS : [builtInGroup, ...liveGroups]
+  const federationGroups: ClusterGroup[] = (federation.groups || []).map(fg => ({
+    name: `${getProviderLabel(fg.provider)}:${fg.hubContext}:${fg.name}`,
+    kind: 'dynamic' as ClusterGroupKind,
+    clusters: fg.members || [],
+    color: fg.kind === 'set' ? 'cyan' : fg.kind === 'peer' ? 'purple' : 'blue',
+    builtIn: true,
+    icon: fg.kind,
+  }))
+
+  const groups = demoMode ? DEMO_GROUPS : [builtInGroup, ...federationGroups, ...liveGroups]
   const [isCreating, setIsCreating] = useState(false)
   // Track which group is pending delete confirmation (#5197)
   const [deleteConfirmName, setDeleteConfirmName] = useState<string | null>(null)

--- a/web/src/components/cards/ClusterHealth.tsx
+++ b/web/src/components/cards/ClusterHealth.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react'
-import { CheckCircle, WifiOff, Cpu, Loader2, ExternalLink, AlertTriangle, KeyRound } from 'lucide-react'
+import { CheckCircle, WifiOff, Cpu, Loader2, ExternalLink, AlertTriangle, KeyRound, Server } from 'lucide-react'
 import { RefreshIndicator } from '../ui/RefreshIndicator'
 import { useClusters, ClusterInfo } from '../../hooks/useMCP'
 import { useCachedGPUNodes } from '../../hooks/useCachedData'
@@ -15,6 +15,7 @@ import { StatusBadge } from '../ui/StatusBadge'
 import { useCardLoadingState } from './CardDataContext'
 import { useTranslation } from 'react-i18next'
 import { useDemoMode } from '../../hooks/useDemoMode'
+import { useFederationAwareness, getProviderLabel, getStateLabel, getStateColorClasses, type FederatedCluster } from '../../hooks/useFederation'
 
 // Console URL generation for cloud providers
 function getConsoleUrl(provider: CloudProvider, clusterName: string, apiServerUrl?: string): string | null {
@@ -91,6 +92,7 @@ export function ClusterHealth() {
   const { isMobile } = useMobile()
   const { isDemoMode } = useDemoMode()
   const [selectedCluster, setSelectedCluster] = useState<string | null>(null)
+  const federation = useFederationAwareness()
 
   // Use shared card data hook for filtering, sorting, and pagination
   const {
@@ -293,6 +295,26 @@ export function ClusterHealth() {
           </div>
           <span className="text-2xl font-bold text-foreground">{networkOfflineClusters}</span>
         </div>
+        {(federation.hubs || []).filter(h => h.detected).map(hub => {
+          const hubClusters = (federation.clusters || []).filter(
+            fc => fc.provider === hub.provider && fc.hubContext === hub.hubContext
+          )
+          const joinedCount = hubClusters.filter(fc => fc.state === 'joined' || fc.state === 'provisioned').length
+          return (
+            <div
+              key={`${hub.provider}-${hub.hubContext}`}
+              className="p-3 rounded-lg bg-blue-500/10 border border-blue-500/20 min-w-0 overflow-hidden"
+              title={`${getProviderLabel(hub.provider)} hub: ${hub.hubContext} — ${joinedCount}/${hubClusters.length} clusters active`}
+            >
+              <div className="flex items-center gap-1.5 mb-1 min-w-0">
+                <Server className="w-4 h-4 text-blue-400 shrink-0" />
+                <span className="text-xs text-blue-400 truncate">{getProviderLabel(hub.provider)}</span>
+              </div>
+              <span className="text-2xl font-bold text-foreground">{hubClusters.length}</span>
+              <span className="text-xs text-muted-foreground ml-1">{t('clusterHealth.clustersLabel').toLowerCase()}</span>
+            </div>
+          )
+        })}
       </div>
 
       {/* Cluster list */}
@@ -342,6 +364,21 @@ export function ClusterHealth() {
                   <CloudProviderIcon provider={provider} size={14} />
                 </span>
                 <span className="text-sm text-foreground truncate">{cluster.name}</span>
+                {(() => {
+                  const pills = (federation.clusters || []).filter(
+                    (fc: FederatedCluster) => fc.name === cluster.name || (cluster.server && fc.apiServerURL === cluster.server)
+                  )
+                  if (pills.length === 0) return null
+                  return pills.map((fc: FederatedCluster) => (
+                    <span
+                      key={`${fc.provider}-${fc.hubContext}`}
+                      className={`inline-flex items-center gap-0.5 text-2xs px-1.5 py-0.5 rounded border shrink-0 ${getStateColorClasses(fc.state)}`}
+                      title={`${getProviderLabel(fc.provider)} [${fc.hubContext}]: ${getStateLabel(fc.state)}`}
+                    >
+                      {getProviderLabel(fc.provider)}:{getStateLabel(fc.state)}
+                    </span>
+                  ))
+                })()}
                 {/* Warn when cluster is internally reachable but API server is externally unreachable (#4202) */}
                 {!clusterUnreachable && !clusterLoading && cluster.externallyReachable === false && (
                   <span

--- a/web/src/components/cards/ClusterHealth.tsx
+++ b/web/src/components/cards/ClusterHealth.tsx
@@ -15,7 +15,7 @@ import { StatusBadge } from '../ui/StatusBadge'
 import { useCardLoadingState } from './CardDataContext'
 import { useTranslation } from 'react-i18next'
 import { useDemoMode } from '../../hooks/useDemoMode'
-import { useFederationAwareness, getProviderLabel, getStateLabel, getStateColorClasses, type FederatedCluster } from '../../hooks/useFederation'
+import { useFederationAwareness, getProviderLabel as getFederationProviderLabel, getStateLabel, getStateColorClasses, type FederatedCluster } from '../../hooks/useFederation'
 
 // Console URL generation for cloud providers
 function getConsoleUrl(provider: CloudProvider, clusterName: string, apiServerUrl?: string): string | null {
@@ -304,11 +304,11 @@ export function ClusterHealth() {
             <div
               key={`${hub.provider}-${hub.hubContext}`}
               className="p-3 rounded-lg bg-blue-500/10 border border-blue-500/20 min-w-0 overflow-hidden"
-              title={`${getProviderLabel(hub.provider)} hub: ${hub.hubContext} — ${joinedCount}/${hubClusters.length} clusters active`}
+              title={`${getFederationProviderLabel(hub.provider)} hub: ${hub.hubContext} — ${joinedCount}/${hubClusters.length} clusters active`}
             >
               <div className="flex items-center gap-1.5 mb-1 min-w-0">
                 <Server className="w-4 h-4 text-blue-400 shrink-0" />
-                <span className="text-xs text-blue-400 truncate">{getProviderLabel(hub.provider)}</span>
+                <span className="text-xs text-blue-400 truncate">{getFederationProviderLabel(hub.provider)}</span>
               </div>
               <span className="text-2xl font-bold text-foreground">{hubClusters.length}</span>
               <span className="text-xs text-muted-foreground ml-1">{t('clusterHealth.clustersLabel').toLowerCase()}</span>
@@ -373,9 +373,9 @@ export function ClusterHealth() {
                     <span
                       key={`${fc.provider}-${fc.hubContext}`}
                       className={`inline-flex items-center gap-0.5 text-2xs px-1.5 py-0.5 rounded border shrink-0 ${getStateColorClasses(fc.state)}`}
-                      title={`${getProviderLabel(fc.provider)} [${fc.hubContext}]: ${getStateLabel(fc.state)}`}
+                      title={`${getFederationProviderLabel(fc.provider)} [${fc.hubContext}]: ${getStateLabel(fc.state)}`}
                     >
-                      {getProviderLabel(fc.provider)}:{getStateLabel(fc.state)}
+                      {getFederationProviderLabel(fc.provider)}:{getStateLabel(fc.state)}
                     </span>
                   ))
                 })()}

--- a/web/src/hooks/useClusterGroups.ts
+++ b/web/src/hooks/useClusterGroups.ts
@@ -30,6 +30,8 @@ export interface ClusterGroup {
   query?: ClusterGroupQuery
   lastEvaluated?: string
   builtIn?: boolean
+  source?: 'local' | 'federation'
+  provider?: string
 }
 
 export interface AIQueryResult {

--- a/web/src/hooks/useFederation.test.ts
+++ b/web/src/hooks/useFederation.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+
+const mockIsDemoMode = vi.fn(() => false)
+
+vi.mock('./useDemoMode', () => ({
+  useDemoMode: () => ({ isDemoMode: mockIsDemoMode() }),
+}))
+
+vi.mock('../lib/constants/network', () => ({
+  LOCAL_AGENT_HTTP_URL: 'http://127.0.0.1:8585',
+  FETCH_DEFAULT_TIMEOUT_MS: 10_000,
+}))
+
+vi.mock('../lib/constants', () => ({
+  STORAGE_KEY_TOKEN: 'token',
+}))
+
+describe('useFederation', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    mockIsDemoMode.mockReturnValue(false)
+    global.fetch = vi.fn()
+    localStorage.clear()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    vi.restoreAllMocks()
+  })
+
+  it('returns empty awareness when agent returns no detected hubs', async () => {
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve([]),
+    })
+    global.fetch = mockFetch
+
+    const { useFederationAwareness, resetFederationCache } = await import('./useFederation')
+    resetFederationCache()
+
+    const { result } = renderHook(() => useFederationAwareness())
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(100)
+    })
+
+    expect(result.current.clusters).toEqual([])
+    expect(result.current.hubs).toEqual([])
+    expect(result.current.isDemoFallback).toBe(false)
+  })
+
+  it('returns demo data in demo mode', async () => {
+    mockIsDemoMode.mockReturnValue(true)
+
+    const { useFederationAwareness, resetFederationCache } = await import('./useFederation')
+    resetFederationCache()
+
+    const { result } = renderHook(() => useFederationAwareness())
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(100)
+    })
+
+    expect(result.current.isDemoFallback).toBe(true)
+    expect(result.current.clusters.length).toBeGreaterThan(0)
+    expect(result.current.hubs.length).toBeGreaterThan(0)
+    expect(result.current.clusters[0].provider).toBe('ocm')
+  })
+
+  it('exports provider and state helpers', async () => {
+    const { getProviderLabel, getStateLabel, getStateColorClasses } = await import('./useFederation')
+
+    expect(getProviderLabel('ocm')).toBe('OCM')
+    expect(getProviderLabel('karmada')).toBe('Karmada')
+    expect(getProviderLabel('capi')).toBe('CAPI')
+
+    expect(getStateLabel('joined')).toBe('Joined')
+    expect(getStateLabel('pending')).toBe('Pending')
+    expect(getStateLabel('provisioning')).toBe('Provisioning')
+
+    expect(getStateColorClasses('joined')).toContain('green')
+    expect(getStateColorClasses('failed')).toContain('red')
+    expect(getStateColorClasses('pending')).toContain('yellow')
+  })
+})

--- a/web/src/hooks/useFederation.ts
+++ b/web/src/hooks/useFederation.ts
@@ -1,0 +1,350 @@
+import { useEffect, useSyncExternalStore } from 'react'
+import { LOCAL_AGENT_HTTP_URL, FETCH_DEFAULT_TIMEOUT_MS } from '../lib/constants/network'
+import { STORAGE_KEY_TOKEN } from '../lib/constants'
+import { useDemoMode } from './useDemoMode'
+
+// ============================================================================
+// Types — mirrors pkg/agent/federation/types.go
+// ============================================================================
+
+export type FederationProviderName =
+  | 'ocm' | 'karmada' | 'clusternet' | 'liqo' | 'kubeadmiral' | 'capi'
+
+export type ClusterState =
+  | 'joined' | 'pending' | 'unknown' | 'not-member'
+  | 'provisioning' | 'provisioned' | 'failed' | 'deleting'
+
+export type ClusterErrorType =
+  | 'auth' | 'timeout' | 'network' | 'certificate' | 'not-installed' | 'unknown'
+
+export interface FederatedCluster {
+  provider: FederationProviderName
+  hubContext: string
+  name: string
+  state: ClusterState
+  available: string
+  clusterSet?: string
+  labels?: Record<string, string>
+  apiServerURL?: string
+  taints?: Array<{ key: string; value?: string; effect: string }>
+  lifecycle?: {
+    phase: string
+    controlPlaneReady: boolean
+    infrastructureReady: boolean
+    desiredMachines: number
+    readyMachines: number
+  }
+  raw?: unknown
+}
+
+export interface FederatedGroup {
+  provider: FederationProviderName
+  hubContext: string
+  name: string
+  members: string[]
+  kind: 'set' | 'selector' | 'peer' | 'infra'
+}
+
+export interface PendingJoin {
+  provider: FederationProviderName
+  hubContext: string
+  clusterName: string
+  requestedAt: string
+  detail?: string
+}
+
+export interface FederationError {
+  provider: FederationProviderName
+  hubContext: string
+  type: ClusterErrorType
+  message: string
+}
+
+export interface ProviderHubStatus {
+  provider: FederationProviderName
+  hubContext: string
+  detected: boolean
+  version?: string
+  error?: FederationError
+}
+
+export interface FederationAwareness {
+  hubs: ProviderHubStatus[]
+  clusters: FederatedCluster[]
+  groups: FederatedGroup[]
+  pendingJoins: PendingJoin[]
+  errors: readonly FederationError[]
+  isDemoFallback: boolean
+}
+
+// ============================================================================
+// Provider display helpers
+// ============================================================================
+
+const PROVIDER_LABELS: Record<FederationProviderName, string> = {
+  ocm: 'OCM',
+  karmada: 'Karmada',
+  clusternet: 'Clusternet',
+  liqo: 'Liqo',
+  kubeadmiral: 'KubeAdmiral',
+  capi: 'CAPI',
+}
+
+export function getProviderLabel(provider: FederationProviderName): string {
+  return PROVIDER_LABELS[provider] || provider
+}
+
+const STATE_LABELS: Record<ClusterState, string> = {
+  joined: 'Joined',
+  pending: 'Pending',
+  unknown: 'Unknown',
+  'not-member': 'Not Member',
+  provisioning: 'Provisioning',
+  provisioned: 'Provisioned',
+  failed: 'Failed',
+  deleting: 'Deleting',
+}
+
+export function getStateLabel(state: ClusterState): string {
+  return STATE_LABELS[state] || state
+}
+
+const STATE_COLORS: Record<ClusterState, string> = {
+  joined: 'text-green-400 bg-green-500/15 border-green-500/25',
+  pending: 'text-yellow-400 bg-yellow-500/15 border-yellow-500/25',
+  unknown: 'text-muted-foreground bg-secondary/50 border-border/30',
+  'not-member': 'text-muted-foreground bg-secondary/50 border-border/30',
+  provisioning: 'text-blue-400 bg-blue-500/15 border-blue-500/25',
+  provisioned: 'text-green-400 bg-green-500/15 border-green-500/25',
+  failed: 'text-red-400 bg-red-500/15 border-red-500/25',
+  deleting: 'text-orange-400 bg-orange-500/15 border-orange-500/25',
+}
+
+export function getStateColorClasses(state: ClusterState): string {
+  return STATE_COLORS[state] || STATE_COLORS.unknown
+}
+
+// ============================================================================
+// Module-level subscribable snapshot (PR 9359 pattern)
+// ============================================================================
+
+const EMPTY_AWARENESS: FederationAwareness = {
+  hubs: [],
+  clusters: [],
+  groups: [],
+  pendingJoins: [],
+  errors: [],
+  isDemoFallback: false,
+}
+
+let federationSnapshot: FederationAwareness = EMPTY_AWARENESS
+const federationListeners = new Set<() => void>()
+
+function subscribeFederation(listener: () => void): () => void {
+  federationListeners.add(listener)
+  return () => federationListeners.delete(listener)
+}
+
+function getFederationSnapshot(): FederationAwareness {
+  return federationSnapshot
+}
+
+function publishFederation(next: FederationAwareness): void {
+  federationSnapshot = next
+  federationListeners.forEach(listener => listener())
+}
+
+// ============================================================================
+// Demo data
+// ============================================================================
+
+const DEMO_HUBS: ProviderHubStatus[] = [
+  { provider: 'ocm', hubContext: 'hub-prod', detected: true, version: 'v1' },
+  { provider: 'ocm', hubContext: 'hub-staging', detected: true, version: 'v1' },
+]
+
+const DEMO_CLUSTERS: FederatedCluster[] = [
+  {
+    provider: 'ocm', hubContext: 'hub-prod', name: 'eks-prod-us-east-1',
+    state: 'joined', available: 'True', clusterSet: 'production',
+    labels: { env: 'prod', region: 'us-east-1' },
+    apiServerURL: 'https://eks-prod.us-east-1.eks.amazonaws.com',
+  },
+  {
+    provider: 'ocm', hubContext: 'hub-prod', name: 'openshift-prod',
+    state: 'joined', available: 'True', clusterSet: 'production',
+    labels: { env: 'prod', distribution: 'openshift' },
+    apiServerURL: 'https://api.openshift-prod.example.com:6443',
+  },
+  {
+    provider: 'ocm', hubContext: 'hub-staging', name: 'gke-staging',
+    state: 'joined', available: 'True', clusterSet: 'staging',
+    labels: { env: 'staging', region: 'us-central1' },
+    apiServerURL: 'https://gke-staging.us-central1.gke.io',
+  },
+  {
+    provider: 'ocm', hubContext: 'hub-staging', name: 'aks-dev-westeu',
+    state: 'pending', available: 'Unknown',
+    labels: { env: 'dev', region: 'westeurope' },
+  },
+]
+
+const DEMO_GROUPS: FederatedGroup[] = [
+  { provider: 'ocm', hubContext: 'hub-prod', name: 'production', members: ['eks-prod-us-east-1', 'openshift-prod'], kind: 'set' },
+  { provider: 'ocm', hubContext: 'hub-staging', name: 'staging', members: ['gke-staging'], kind: 'set' },
+]
+
+const DEMO_PENDING: PendingJoin[] = [
+  {
+    provider: 'ocm', hubContext: 'hub-staging', clusterName: 'aks-dev-westeu',
+    requestedAt: new Date(Date.now() - 300_000).toISOString(),
+    detail: 'CSR: csr-aks-dev-westeu-1',
+  },
+]
+
+function getDemoFederationAwareness(): FederationAwareness {
+  return {
+    hubs: DEMO_HUBS,
+    clusters: DEMO_CLUSTERS,
+    groups: DEMO_GROUPS,
+    pendingJoins: DEMO_PENDING,
+    errors: [],
+    isDemoFallback: true,
+  }
+}
+
+// ============================================================================
+// Fetch helpers
+// ============================================================================
+
+const FEDERATION_POLL_INTERVAL_MS = 30_000
+const FEDERATION_DETECT_CACHE_TTL_MS = 300_000
+
+function authHeaders(): Record<string, string> {
+  const token = localStorage.getItem(STORAGE_KEY_TOKEN)
+  const headers: Record<string, string> = { 'Content-Type': 'application/json' }
+  if (token) headers['Authorization'] = `Bearer ${token}`
+  return headers
+}
+
+async function fetchFederationEndpoint<T>(path: string): Promise<T | null> {
+  if (!LOCAL_AGENT_HTTP_URL) return null
+  try {
+    const response = await fetch(`${LOCAL_AGENT_HTTP_URL}${path}`, {
+      headers: authHeaders(),
+      signal: AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS),
+    })
+    if (!response.ok) return null
+    return await response.json() as T
+  } catch {
+    return null
+  }
+}
+
+// ============================================================================
+// Fetcher
+// ============================================================================
+
+let lastDetectTime = 0
+let cachedHubs: ProviderHubStatus[] = []
+let fetchInFlight = false
+
+async function fetchFederationData(): Promise<void> {
+  if (fetchInFlight) return
+  fetchInFlight = true
+
+  try {
+    const now = Date.now()
+    if (now - lastDetectTime > FEDERATION_DETECT_CACHE_TTL_MS || cachedHubs.length === 0) {
+      const hubs = await fetchFederationEndpoint<ProviderHubStatus[]>('/federation/detect')
+      if (hubs) {
+        cachedHubs = hubs
+        lastDetectTime = now
+      }
+    }
+
+    const detectedHubs = cachedHubs.filter(h => h.detected)
+    if (detectedHubs.length === 0) {
+      publishFederation({
+        hubs: cachedHubs,
+        clusters: [],
+        groups: [],
+        pendingJoins: [],
+        errors: (cachedHubs || []).filter(h => h.error).map(h => h.error!),
+        isDemoFallback: false,
+      })
+      return
+    }
+
+    const [clustersRes, groupsRes, pendingRes] = await Promise.all([
+      fetchFederationEndpoint<{ clusters: FederatedCluster[]; errors: FederationError[] }>('/federation/clusters'),
+      fetchFederationEndpoint<{ groups: FederatedGroup[]; errors: FederationError[] }>('/federation/groups'),
+      fetchFederationEndpoint<{ pendingJoins: PendingJoin[]; errors: FederationError[] }>('/federation/pending-joins'),
+    ])
+
+    const allErrors: FederationError[] = [
+      ...(cachedHubs || []).filter(h => h.error).map(h => h.error!),
+      ...(clustersRes?.errors || []),
+      ...(groupsRes?.errors || []),
+      ...(pendingRes?.errors || []),
+    ]
+
+    publishFederation({
+      hubs: cachedHubs,
+      clusters: clustersRes?.clusters || [],
+      groups: groupsRes?.groups || [],
+      pendingJoins: pendingRes?.pendingJoins || [],
+      errors: allErrors,
+      isDemoFallback: false,
+    })
+  } catch {
+    // leave current snapshot in place
+  } finally {
+    fetchInFlight = false
+  }
+}
+
+// ============================================================================
+// Hook
+// ============================================================================
+
+export function useFederationAwareness(): FederationAwareness {
+  const { isDemoMode } = useDemoMode()
+
+  useEffect(() => {
+    if (isDemoMode) {
+      publishFederation(getDemoFederationAwareness())
+      return
+    }
+
+    fetchFederationData()
+    const interval = setInterval(fetchFederationData, FEDERATION_POLL_INTERVAL_MS)
+    return () => clearInterval(interval)
+  }, [isDemoMode])
+
+  return useSyncExternalStore(subscribeFederation, getFederationSnapshot)
+}
+
+export function useFederationForCluster(clusterName: string, apiServerURL?: string): {
+  pills: Array<{ provider: FederationProviderName; hubContext: string; state: ClusterState }>
+} {
+  const awareness = useFederationAwareness()
+
+  const pills = (awareness.clusters || []).filter(fc => {
+    if (fc.name === clusterName) return true
+    if (apiServerURL && fc.apiServerURL && fc.apiServerURL === apiServerURL) return true
+    return false
+  }).map(fc => ({
+    provider: fc.provider,
+    hubContext: fc.hubContext,
+    state: fc.state,
+  }))
+
+  return { pills }
+}
+
+export function resetFederationCache(): void {
+  lastDetectTime = 0
+  cachedHubs = []
+  publishFederation(EMPTY_AWARENESS)
+}

--- a/web/src/locales/en/cards.json
+++ b/web/src/locales/en/cards.json
@@ -129,7 +129,25 @@
     "clustersOfflineNetwork": "{{count}} cluster(s) offline - check network connection",
     "clustersOfflineNetwork_one": "{{count}} cluster(s) offline - check network connection",
     "clustersOfflineNetwork_other": "{{count}} cluster(s) offline - check network connection",
-    "checkNetworkVpn": "Check network connectivity and VPN status"
+    "checkNetworkVpn": "Check network connectivity and VPN status",
+    "federation": {
+      "hubDetected": "{{provider}} hub detected on {{context}}",
+      "hubClusters": "{{count}} managed clusters",
+      "hubClusters_one": "{{count}} managed cluster",
+      "hubClusters_other": "{{count}} managed clusters",
+      "pendingJoins": "{{count}} pending join requests",
+      "pendingJoins_one": "{{count}} pending join request",
+      "pendingJoins_other": "{{count}} pending join requests",
+      "providerAccessDenied": "Access denied for {{provider}} on {{context}}",
+      "providers": {
+        "ocm": { "label": "OCM", "fullName": "Open Cluster Management" },
+        "karmada": { "label": "Karmada", "fullName": "Karmada" },
+        "clusternet": { "label": "Clusternet", "fullName": "Clusternet" },
+        "liqo": { "label": "Liqo", "fullName": "Liqo" },
+        "kubeadmiral": { "label": "KubeAdmiral", "fullName": "KubeAdmiral" },
+        "capi": { "label": "CAPI", "fullName": "Cluster API" }
+      }
+    }
   },
   "titles": {
     "cluster_health": "Cluster Health",


### PR DESCRIPTION
## Summary
- Adds the first concrete federation provider (Open Cluster Management) implementing the `Provider` interface from PR #9377
- Wires Phase 1 read-only federation awareness into `ClusterHealth` and `ClusterGroups` cards
- New `useFederationAwareness` hook with subscribable snapshot, 30s polling, 5-min detect cache, and demo mode fallback
- Federation pills render on cluster rows showing `OCM:Joined`/`OCM:Pending` state
- Hub stat tiles appear in the stats grid when federation hubs are detected
- Federation-sourced groups (e.g. `OCM:hub-prod:production`) injected as read-only built-ins into ClusterGroups

## Files changed
**Backend:**
- `pkg/agent/federation/providers/ocm.go` — OCM provider: Detect, ReadClusters, ReadGroups, ReadPendingJoins
- `pkg/agent/federation/providers/ocm_test.go` — unit tests for parsing and CSR detection
- `cmd/kc-agent/main.go` — blank import for provider registration

**Frontend:**
- `web/src/hooks/useFederation.ts` — subscribable-snapshot hook + types + display helpers
- `web/src/hooks/useFederation.test.ts` — tests for empty awareness, demo mode, helper exports
- `web/src/components/cards/ClusterHealth.tsx` — federation pills on rows + hub stat tiles
- `web/src/components/cards/ClusterGroups.tsx` — federation group injection
- `web/src/hooks/useClusterGroups.ts` — extended ClusterGroup type with optional source/provider
- `web/src/locales/en/cards.json` — federation i18n strings

## Test plan
- [x] go test ./pkg/agent/federation/providers/... — all pass
- [x] go build ./cmd/kc-agent/ — compiles clean
- [ ] CI: build, fullstack-smoke, card-standard, coverage-gate, ts-null-safety, ui-ux-standard
- [ ] Demo mode: open /clusters — federation pills render on demo clusters, hub tiles in stats grid
- [ ] No OCM installed: cards render identically to before (zero-provider path)

Fixes Issue 9368 (Phase 1, PR B per plan)