### PR TITLE
fix: nil client pointers after MCP bridge stop

### DIFF
--- a/pkg/mcp/bridge.go
+++ b/pkg/mcp/bridge.go
@@ -172,14 +172,10 @@ func (b *Bridge) Start(ctx context.Context) error {
 		// failure are still running. Stop them so we don't leak
 		// goroutines, child processes, or file descriptors on a partial
 		// Start failure (#6624).
+		// Stop() nils the client pointers, so no additional cleanup needed.
 		if stopErr := b.Stop(); stopErr != nil {
 			slog.Warn("[MCP] errors during Start rollback", "error", stopErr)
 		}
-		b.mu.Lock()
-		b.opsClient = nil
-		b.deployClient = nil
-		b.gadgetClient = nil
-		b.mu.Unlock()
 		return fmt.Errorf("failed to start MCP clients: %v", errs)
 	}
 
@@ -197,18 +193,21 @@ func (b *Bridge) Stop() error {
 		if err := b.opsClient.Stop(); err != nil {
 			errs = append(errs, fmt.Errorf("ops client: %w", err))
 		}
+		b.opsClient = nil
 	}
 
 	if b.deployClient != nil {
 		if err := b.deployClient.Stop(); err != nil {
 			errs = append(errs, fmt.Errorf("deploy client: %w", err))
 		}
+		b.deployClient = nil
 	}
 
 	if b.gadgetClient != nil {
 		if err := b.gadgetClient.Stop(); err != nil {
 			errs = append(errs, fmt.Errorf("gadget client: %w", err))
 		}
+		b.gadgetClient = nil
 	}
 
 	if len(errs) > 0 {


### PR DESCRIPTION
## Summary
- **Fixes #9382** — `Stop()` now nils `opsClient`, `deployClient`, and `gadgetClient` after stopping each one, preventing callers from invoking methods on terminated client objects after a Stop+restart failure cycle.
- Removed redundant nil-out in `Start()`'s rollback path since `Stop()` now handles it.

## Test plan
- [ ] Verify `Stop()` sets all three client pointers to nil
- [ ] Verify `Start()` rollback no longer manually nils (delegates to `Stop()`)
- [ ] Verify public methods (`ListClusters`, `CallOpsTool`, etc.) return "not available" after `Stop()` due to nil guards already in place