### PR TITLE
fix: update Pods and Workloads test mocks after contributor badges PR

### DIFF
--- a/web/src/components/pods/__tests__/Pods.test.tsx
+++ b/web/src/components/pods/__tests__/Pods.test.tsx
@@ -116,10 +116,11 @@ vi.mock('react-i18next', () => ({
 }))
 
 const showToastSpy = vi.fn()
-vi.mock('../../../hooks/useToast', () => ({
+vi.mock('../../ui/Toast', () => ({
   useToast: () => ({
     showToast: showToastSpy,
   }),
+  ToastProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
 }))
 
 vi.mock('../../../lib/kubectlProxy', () => ({
@@ -157,6 +158,7 @@ describe('Pods Component', () => {
   })
 
   it('renders the empty state message when no pods', () => {
+    mockPodIssues = []
     renderPods()
     expect(screen.getByText('No Pod Issues')).toBeTruthy()
     expect(

--- a/web/src/components/workloads/__tests__/Workloads.test.tsx
+++ b/web/src/components/workloads/__tests__/Workloads.test.tsx
@@ -93,10 +93,11 @@ vi.mock('react-i18next', () => ({
 }))
 
 const showToastSpy = vi.fn()
-vi.mock('../../../hooks/useToast', () => ({
+vi.mock('../../ui/Toast', () => ({
     useToast: () => ({
         showToast: showToastSpy,
     }),
+    ToastProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
 }))
 
 vi.mock('../../../lib/kubectlProxy', () => ({
@@ -153,6 +154,15 @@ describe('Workloads Component', () => {
     })
 
     describe('status color rendering', () => {
+        beforeEach(() => {
+            vi.mocked(useGlobalFilters).mockReturnValue({
+                selectedClusters: [],
+                isAllClustersSelected: true,
+                customFilter: 'deploy',
+                filterByCluster: (items: any[]) => items,
+            } as any)
+        })
+
         it('uses red border for failed deployment', () => {
             mockDeployments = [{ name: 'fail-deploy', namespace: 'default', cluster: 'ctx/prod', status: 'failed', replicas: 3, readyReplicas: 1 }]
             renderWorkloads()


### PR DESCRIPTION
## Summary
- Updated `vi.mock` path for `useToast` from `../../../hooks/useToast` to `../../ui/Toast` in both Pods and Workloads tests, matching the import change made in PR #9105
- Added `customFilter` mock in Workloads status color tests so individual deployments render (required for border color assertions)
- Guarded empty state test in Pods against the `beforeEach` that populates `mockPodIssues`

Fixes #9385

## Test plan
- [x] All 18 previously failing tests now pass locally
- [ ] CI build/lint passes