### PR TITLE
fix: add user-facing error toasts for silent catch blocks

### DIFF
--- a/web/src/components/cards/ClusterLocations.tsx
+++ b/web/src/components/cards/ClusterLocations.tsx
@@ -10,6 +10,7 @@ import DOMPurify from 'dompurify'
 import WorldMapSvgUrl from '../../assets/world-map.svg'
 import { useCardLoadingState } from './CardDataContext'
 import { useTranslation } from 'react-i18next'
+import { useToast } from '../ui/Toast'
 import { useDemoMode } from '../../hooks/useDemoMode'
 
 /** Search input debounce delay (#6213). */
@@ -218,6 +219,7 @@ type StatusFilter = 'all' | 'healthy' | 'unhealthy'
 
 export function ClusterLocations({ config: _config }: ClusterLocationsProps) {
   const { t } = useTranslation(['cards', 'common'])
+  const { showToast } = useToast()
   const { deduplicatedClusters: allClusters, isLoading, isRefreshing } = useClusters()
   const { drillToCluster } = useDrillDownActions()
   const { isDemoMode } = useDemoMode()
@@ -259,6 +261,7 @@ export function ClusterLocations({ config: _config }: ClusterLocationsProps) {
       .catch(err => {
         if (err.name !== 'AbortError') {
           console.error('Failed to load world map:', err)
+          showToast('Failed to load world map', 'error')
           setMapError(true)
           setMapLoading(false)
         }

--- a/web/src/components/mission-control/useMissionControl.ts
+++ b/web/src/components/mission-control/useMissionControl.ts
@@ -6,6 +6,7 @@
  */
 
 import { useState, useEffect, useLayoutEffect, useRef, useMemo, useCallback } from 'react'
+import { useToast } from '../ui/Toast'
 import { useMissions } from '../../hooks/useMissions'
 import { useDebouncedValue } from '../../hooks/useDebouncedValue'
 import { useHelmReleases } from '../../hooks/mcp/helm'
@@ -513,6 +514,7 @@ function extractBalancedBlocks(text: string, warnKey?: string): string[] {
 // ---------------------------------------------------------------------------
 
 export function useMissionControl() {
+  const { showToast } = useToast()
   const [state, setState] = useState<MissionControlState>(() =>
     makeInitialState(loadPersistedState())
   )
@@ -1061,6 +1063,7 @@ Include real CNCF projects only. Consider dependencies between projects.`
       } catch (err) {
         aiRequestInFlightRef.current = false
         console.error('[MissionControl] #6811 — askAIForSuggestions failed:', err)
+        showToast('AI suggestion request failed — please try again', 'error')
       }
     }
 
@@ -1214,6 +1217,7 @@ Order phases by dependency — prerequisites first. Each phase completes before 
       } catch (err) {
         aiRequestInFlightRef.current = false
         console.error('[MissionControl] #7117 — askAIForAssignments failed:', err)
+        showToast('AI assignment request failed — please try again', 'error')
       }
     }
 

--- a/web/src/components/namespaces/NamespaceManager.tsx
+++ b/web/src/components/namespaces/NamespaceManager.tsx
@@ -333,6 +333,7 @@ export function NamespaceManager() {
     } catch (err) {
       console.error('Failed to delete namespace:', err)
       setError('Failed to delete namespace')
+      showToast('Failed to delete namespace', 'error')
       setNamespaceToDelete(null)
     }
   }
@@ -369,6 +370,7 @@ export function NamespaceManager() {
     } catch (err) {
       console.error('Failed to revoke access:', err)
       setError('Failed to revoke access')
+      showToast('Failed to revoke access', 'error')
     }
   }
 


### PR DESCRIPTION
## Summary
- Add toast notifications to 5 catch blocks that previously only logged errors to `console.error` without notifying the user
- **ClusterLocations.tsx**: map SVG load failure now shows error toast
- **NamespaceManager.tsx**: namespace deletion and access revocation failures now show error toasts
- **useMissionControl.ts**: AI suggestion and assignment request failures now show error toasts
- 9 lines added across 3 files (size S)

## Test plan
- [ ] Verify toast appears when world map SVG fails to load (e.g., network offline)
- [ ] Verify toast appears when namespace deletion fails
- [ ] Verify toast appears when access revocation fails
- [ ] Verify toast appears when AI suggestion/assignment requests fail in Mission Control

Fixes #9390