### PR TITLE
fix: mock useToast in ClusterLocations tests

### DIFF
--- a/web/src/components/cards/__tests__/ClusterLocations.test.tsx
+++ b/web/src/components/cards/__tests__/ClusterLocations.test.tsx
@@ -56,6 +56,10 @@ vi.mock('../../../hooks/useGlobalFilters', () => ({
 
 vi.mock('../../../assets/world-map.svg', () => ({ default: 'mock.svg' }))
 
+vi.mock('../../ui/Toast', () => ({
+  useToast: () => ({ showToast: vi.fn() }),
+}))
+
 import { ClusterLocations } from '../ClusterLocations'
 
 describe('ClusterLocations', () => {


### PR DESCRIPTION
## Summary
- Adds `vi.mock('../../ui/Toast', ...)` to `ClusterLocations.test.tsx` to provide a mock `useToast` returning `{ showToast: vi.fn() }`
- PR #9391 added `useToast` to `ClusterLocations.tsx` but the test file was not updated, causing all 7 tests to fail

Fixes #9392

🤖 Generated with [Claude Code](https://claude.com/claude-code)