### PR TITLE
feat(federation): add Karmada provider (PR C)

### DIFF
--- a/pkg/agent/federation/providers/karmada.go
+++ b/pkg/agent/federation/providers/karmada.go
@@ -1,0 +1,264 @@
+package providers
+
+import (
+	"context"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/rest"
+
+	"github.com/kubestellar/console/pkg/agent/federation"
+)
+
+func init() {
+	federation.Register(&karmadaProvider{})
+}
+
+var (
+	karmadaClusterGVR = schema.GroupVersionResource{
+		Group:    "cluster.karmada.io",
+		Version:  "v1alpha1",
+		Resource: "clusters",
+	}
+	karmadaPropagationPolicyGVR = schema.GroupVersionResource{
+		Group:    "policy.karmada.io",
+		Version:  "v1alpha1",
+		Resource: "propagationpolicies",
+	}
+)
+
+const (
+	karmadaConditionReady = "Ready"
+)
+
+type karmadaProvider struct{}
+
+func (p *karmadaProvider) Name() federation.FederationProviderName {
+	return federation.ProviderKarmada
+}
+
+func (p *karmadaProvider) Detect(ctx context.Context, cfg *rest.Config) (federation.DetectResult, error) {
+	dc, err := dynamic.NewForConfig(cfg)
+	if err != nil {
+		return federation.DetectResult{}, err
+	}
+	_, err = dc.Resource(karmadaClusterGVR).List(ctx, metav1.ListOptions{Limit: 1})
+	if err != nil {
+		if isNotFoundOrGroupNotFound(err) {
+			return federation.DetectResult{Detected: false}, nil
+		}
+		return federation.DetectResult{}, err
+	}
+	return federation.DetectResult{Detected: true, Version: "v1alpha1"}, nil
+}
+
+func (p *karmadaProvider) ReadClusters(ctx context.Context, cfg *rest.Config) ([]federation.FederatedCluster, error) {
+	dc, err := dynamic.NewForConfig(cfg)
+	if err != nil {
+		return nil, err
+	}
+	list, err := dc.Resource(karmadaClusterGVR).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		if isNotFoundOrGroupNotFound(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+
+	out := make([]federation.FederatedCluster, 0, len(list.Items))
+	for i := range list.Items {
+		fc := parseKarmadaCluster(&list.Items[i])
+		out = append(out, fc)
+	}
+	return out, nil
+}
+
+func (p *karmadaProvider) ReadGroups(ctx context.Context, cfg *rest.Config) ([]federation.FederatedGroup, error) {
+	dc, err := dynamic.NewForConfig(cfg)
+	if err != nil {
+		return nil, err
+	}
+	list, err := dc.Resource(karmadaPropagationPolicyGVR).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		if isNotFoundOrGroupNotFound(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+
+	out := make([]federation.FederatedGroup, 0, len(list.Items))
+	for i := range list.Items {
+		fg := parseKarmadaPropagationPolicy(&list.Items[i])
+		out = append(out, fg)
+	}
+	return out, nil
+}
+
+func (p *karmadaProvider) ReadPendingJoins(ctx context.Context, cfg *rest.Config) ([]federation.PendingJoin, error) {
+	dc, err := dynamic.NewForConfig(cfg)
+	if err != nil {
+		return nil, err
+	}
+	list, err := dc.Resource(karmadaClusterGVR).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		if isNotFoundOrGroupNotFound(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+
+	out := make([]federation.PendingJoin, 0)
+	for i := range list.Items {
+		cluster := &list.Items[i]
+		if karmadaExtractState(cluster) != federation.ClusterStatePending {
+			continue
+		}
+		name := cluster.GetName()
+		createdAt := cluster.GetCreationTimestamp().Time
+		out = append(out, federation.PendingJoin{
+			Provider:    federation.ProviderKarmada,
+			ClusterName: name,
+			RequestedAt: createdAt,
+			Detail:      "Cluster Ready condition is not True",
+		})
+	}
+	return out, nil
+}
+
+func parseKarmadaCluster(obj *unstructured.Unstructured) federation.FederatedCluster {
+	name := obj.GetName()
+	labels := obj.GetLabels()
+	if labels == nil {
+		labels = map[string]string{}
+	}
+
+	state := karmadaExtractState(obj)
+	available := karmadaExtractAvailable(obj)
+	apiServerURL, _, _ := unstructured.NestedString(obj.Object, "spec", "apiEndpoint")
+	taints := karmadaExtractTaints(obj)
+
+	return federation.FederatedCluster{
+		Provider:     federation.ProviderKarmada,
+		Name:         name,
+		State:        state,
+		Available:    available,
+		Labels:       labels,
+		APIServerURL: apiServerURL,
+		Taints:       taints,
+		Raw:          obj.Object,
+	}
+}
+
+func karmadaExtractState(obj *unstructured.Unstructured) federation.ClusterState {
+	conditions, found, _ := unstructured.NestedSlice(obj.Object, "status", "conditions")
+	if !found {
+		return federation.ClusterStateUnknown
+	}
+	for _, c := range conditions {
+		cond, ok := c.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		condType, _ := cond["type"].(string)
+		condStatus, _ := cond["status"].(string)
+		if condType == karmadaConditionReady {
+			if condStatus == "True" {
+				return federation.ClusterStateJoined
+			}
+			return federation.ClusterStatePending
+		}
+	}
+	return federation.ClusterStateUnknown
+}
+
+func karmadaExtractAvailable(obj *unstructured.Unstructured) string {
+	conditions, found, _ := unstructured.NestedSlice(obj.Object, "status", "conditions")
+	if !found {
+		return "Unknown"
+	}
+	for _, c := range conditions {
+		cond, ok := c.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		condType, _ := cond["type"].(string)
+		condStatus, _ := cond["status"].(string)
+		if condType == karmadaConditionReady {
+			return condStatus
+		}
+	}
+	return "Unknown"
+}
+
+func karmadaExtractTaints(obj *unstructured.Unstructured) []federation.Taint {
+	raw, found, _ := unstructured.NestedSlice(obj.Object, "spec", "taints")
+	if !found || len(raw) == 0 {
+		return nil
+	}
+	taints := make([]federation.Taint, 0, len(raw))
+	for _, t := range raw {
+		tm, ok := t.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		key, _ := tm["key"].(string)
+		value, _ := tm["value"].(string)
+		effect, _ := tm["effect"].(string)
+		taints = append(taints, federation.Taint{Key: key, Value: value, Effect: effect})
+	}
+	return taints
+}
+
+func parseKarmadaPropagationPolicy(obj *unstructured.Unstructured) federation.FederatedGroup {
+	name, _, _ := unstructured.NestedString(obj.Object, "metadata", "name")
+
+	// Extract cluster names from spec.placement.clusterAffinity.clusterNames
+	members := extractKarmadaClusterNames(obj)
+
+	// Extract label selectors from spec.placement.clusterAffinity.labelSelector.matchLabels
+	// and represent as synthetic selector group members if no explicit cluster names
+	if len(members) == 0 {
+		members = extractKarmadaSelectorMembers(obj)
+	}
+
+	return federation.FederatedGroup{
+		Provider: federation.ProviderKarmada,
+		Name:     name,
+		Members:  members,
+		Kind:     federation.FederatedGroupSelector,
+	}
+}
+
+func extractKarmadaClusterNames(obj *unstructured.Unstructured) []string {
+	raw, found, _ := unstructured.NestedSlice(obj.Object, "spec", "placement", "clusterAffinity", "clusterNames")
+	if !found || len(raw) == 0 {
+		return nil
+	}
+	names := make([]string, 0, len(raw))
+	for _, r := range raw {
+		if s, ok := r.(string); ok {
+			names = append(names, s)
+		}
+	}
+	return names
+}
+
+func extractKarmadaSelectorMembers(obj *unstructured.Unstructured) []string {
+	matchLabels, found, _ := unstructured.NestedStringMap(
+		obj.Object, "spec", "placement", "clusterAffinity", "labelSelector", "matchLabels",
+	)
+	if !found || len(matchLabels) == 0 {
+		return []string{}
+	}
+	// Represent each matchLabel as "key=value" for display
+	members := make([]string, 0, len(matchLabels))
+	for k, v := range matchLabels {
+		members = append(members, k+"="+v)
+	}
+	return members
+}
+
+// Ensure compile-time interface conformance.
+var _ federation.Provider = (*karmadaProvider)(nil)

--- a/pkg/agent/federation/providers/karmada_test.go
+++ b/pkg/agent/federation/providers/karmada_test.go
@@ -1,0 +1,180 @@
+package providers
+
+import (
+	"testing"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	"github.com/kubestellar/console/pkg/agent/federation"
+)
+
+func TestParseKarmadaCluster_Joined(t *testing.T) {
+	obj := &unstructured.Unstructured{Object: map[string]interface{}{
+		"metadata": map[string]interface{}{
+			"name": "member-1",
+			"labels": map[string]interface{}{
+				"region": "us-east-1",
+			},
+		},
+		"spec": map[string]interface{}{
+			"apiEndpoint": "https://member-1.example.com:6443",
+		},
+		"status": map[string]interface{}{
+			"conditions": []interface{}{
+				map[string]interface{}{
+					"type":   "Ready",
+					"status": "True",
+				},
+			},
+		},
+	}}
+
+	fc := parseKarmadaCluster(obj)
+	if fc.Name != "member-1" {
+		t.Errorf("expected name member-1, got %s", fc.Name)
+	}
+	if fc.State != federation.ClusterStateJoined {
+		t.Errorf("expected state joined, got %s", fc.State)
+	}
+	if fc.Available != "True" {
+		t.Errorf("expected available True, got %s", fc.Available)
+	}
+	if fc.APIServerURL != "https://member-1.example.com:6443" {
+		t.Errorf("expected apiServerURL https://member-1.example.com:6443, got %s", fc.APIServerURL)
+	}
+	if fc.Provider != federation.ProviderKarmada {
+		t.Errorf("expected provider karmada, got %s", fc.Provider)
+	}
+}
+
+func TestParseKarmadaCluster_Pending(t *testing.T) {
+	obj := &unstructured.Unstructured{Object: map[string]interface{}{
+		"metadata": map[string]interface{}{
+			"name": "member-2",
+		},
+		"spec": map[string]interface{}{
+			"apiEndpoint": "https://member-2.example.com:6443",
+		},
+		"status": map[string]interface{}{
+			"conditions": []interface{}{
+				map[string]interface{}{
+					"type":   "Ready",
+					"status": "False",
+				},
+			},
+		},
+	}}
+
+	fc := parseKarmadaCluster(obj)
+	if fc.State != federation.ClusterStatePending {
+		t.Errorf("expected state pending, got %s", fc.State)
+	}
+	if fc.Available != "False" {
+		t.Errorf("expected available False, got %s", fc.Available)
+	}
+}
+
+func TestParseKarmadaCluster_WithTaints(t *testing.T) {
+	obj := &unstructured.Unstructured{Object: map[string]interface{}{
+		"metadata": map[string]interface{}{
+			"name": "member-tainted",
+		},
+		"spec": map[string]interface{}{
+			"apiEndpoint": "https://member-tainted.example.com:6443",
+			"taints": []interface{}{
+				map[string]interface{}{
+					"key":    "cluster.karmada.io/not-ready",
+					"effect": "NoSchedule",
+				},
+			},
+		},
+		"status": map[string]interface{}{
+			"conditions": []interface{}{
+				map[string]interface{}{
+					"type":   "Ready",
+					"status": "True",
+				},
+			},
+		},
+	}}
+
+	fc := parseKarmadaCluster(obj)
+	if len(fc.Taints) != 1 {
+		t.Fatalf("expected 1 taint, got %d", len(fc.Taints))
+	}
+	if fc.Taints[0].Key != "cluster.karmada.io/not-ready" {
+		t.Errorf("unexpected taint key: %s", fc.Taints[0].Key)
+	}
+	if fc.Taints[0].Effect != "NoSchedule" {
+		t.Errorf("unexpected taint effect: %s", fc.Taints[0].Effect)
+	}
+}
+
+func TestParseKarmadaPropagationPolicy(t *testing.T) {
+	obj := &unstructured.Unstructured{Object: map[string]interface{}{
+		"metadata": map[string]interface{}{
+			"name": "deploy-to-members",
+		},
+		"spec": map[string]interface{}{
+			"placement": map[string]interface{}{
+				"clusterAffinity": map[string]interface{}{
+					"clusterNames": []interface{}{"member-1", "member-2"},
+				},
+			},
+		},
+	}}
+
+	fg := parseKarmadaPropagationPolicy(obj)
+	if fg.Name != "deploy-to-members" {
+		t.Errorf("expected name deploy-to-members, got %s", fg.Name)
+	}
+	if fg.Kind != federation.FederatedGroupSelector {
+		t.Errorf("expected kind selector, got %s", fg.Kind)
+	}
+	if len(fg.Members) != 2 {
+		t.Fatalf("expected 2 members, got %d", len(fg.Members))
+	}
+	if fg.Members[0] != "member-1" || fg.Members[1] != "member-2" {
+		t.Errorf("unexpected members: %v", fg.Members)
+	}
+	if fg.Provider != federation.ProviderKarmada {
+		t.Errorf("expected provider karmada, got %s", fg.Provider)
+	}
+}
+
+func TestParseKarmadaPropagationPolicy_LabelSelector(t *testing.T) {
+	obj := &unstructured.Unstructured{Object: map[string]interface{}{
+		"metadata": map[string]interface{}{
+			"name": "select-by-region",
+		},
+		"spec": map[string]interface{}{
+			"placement": map[string]interface{}{
+				"clusterAffinity": map[string]interface{}{
+					"labelSelector": map[string]interface{}{
+						"matchLabels": map[string]interface{}{
+							"region": "us-east-1",
+						},
+					},
+				},
+			},
+		},
+	}}
+
+	fg := parseKarmadaPropagationPolicy(obj)
+	if fg.Name != "select-by-region" {
+		t.Errorf("expected name select-by-region, got %s", fg.Name)
+	}
+	if len(fg.Members) != 1 {
+		t.Fatalf("expected 1 synthetic member, got %d", len(fg.Members))
+	}
+	if fg.Members[0] != "region=us-east-1" {
+		t.Errorf("expected member 'region=us-east-1', got %s", fg.Members[0])
+	}
+}
+
+func TestKarmadaProviderName(t *testing.T) {
+	p := &karmadaProvider{}
+	if p.Name() != federation.ProviderKarmada {
+		t.Errorf("expected provider name 'karmada', got '%s'", p.Name())
+	}
+}

--- a/web/src/hooks/useFederation.ts
+++ b/web/src/hooks/useFederation.ts
@@ -162,6 +162,7 @@ const DEMO_HUBS: ProviderHubStatus[] = [
   { provider: 'ocm', hubContext: 'hub-prod', detected: true, version: 'v1' },
   { provider: 'ocm', hubContext: 'hub-staging', detected: true, version: 'v1' },
   { provider: 'capi', hubContext: 'capi-mgmt', detected: true, version: 'v1beta1' },
+  { provider: 'karmada', hubContext: 'karmada-control', detected: true, version: 'v1alpha1' },
 ]
 
 const DEMO_CLUSTERS: FederatedCluster[] = [
@@ -225,19 +226,40 @@ const DEMO_CLUSTERS: FederatedCluster[] = [
       readyMachines: 0,
     },
   },
+  {
+    provider: 'karmada', hubContext: 'karmada-control', name: 'karmada-member-1',
+    state: 'joined', available: 'True',
+    labels: { env: 'prod', region: 'ap-southeast-1' },
+    apiServerURL: 'https://karmada-member-1.ap-southeast-1.example.com:6443',
+  },
+  {
+    provider: 'karmada', hubContext: 'karmada-control', name: 'karmada-member-2',
+    state: 'pending', available: 'False',
+    labels: { env: 'staging', region: 'eu-west-1' },
+    apiServerURL: 'https://karmada-member-2.eu-west-1.example.com:6443',
+  },
 ]
 
 const DEMO_GROUPS: FederatedGroup[] = [
   { provider: 'ocm', hubContext: 'hub-prod', name: 'production', members: ['eks-prod-us-east-1', 'openshift-prod'], kind: 'set' },
   { provider: 'ocm', hubContext: 'hub-staging', name: 'staging', members: ['gke-staging'], kind: 'set' },
   { provider: 'capi', hubContext: 'capi-mgmt', name: 'capi:awscluster', members: ['workload-prod-aws', 'workload-staging-aws'], kind: 'infra' },
+  { provider: 'karmada', hubContext: 'karmada-control', name: 'deploy-to-apac', members: ['karmada-member-1'], kind: 'selector' },
 ]
+
+const FIVE_MINUTES_MS = 300_000;
+const TEN_MINUTES_MS = 600_000;
 
 const DEMO_PENDING: PendingJoin[] = [
   {
     provider: 'ocm', hubContext: 'hub-staging', clusterName: 'aks-dev-westeu',
-    requestedAt: new Date(Date.now() - 300_000).toISOString(),
+    requestedAt: new Date(Date.now() - FIVE_MINUTES_MS).toISOString(),
     detail: 'CSR: csr-aks-dev-westeu-1',
+  },
+  {
+    provider: 'karmada', hubContext: 'karmada-control', clusterName: 'karmada-member-2',
+    requestedAt: new Date(Date.now() - TEN_MINUTES_MS).toISOString(),
+    detail: 'Cluster Ready condition is not True',
   },
 ]
 


### PR DESCRIPTION
## Summary

- Implements the Karmada federation provider (`pkg/agent/federation/providers/karmada.go`) following the same plugin pattern as OCM (PR B)
- Reads `cluster.karmada.io/v1alpha1/clusters` for cluster state and `policy.karmada.io/v1alpha1/propagationpolicies` for group membership
- Maps Karmada `Ready` condition to joined/pending state, extracts `spec.apiEndpoint`, `spec.taints`, and PropagationPolicy cluster selectors
- Adds 6 unit tests covering joined, pending, taints, propagation policy (explicit names + label selectors), and provider name
- Adds Karmada demo data (1 hub, 2 clusters, 1 group, 1 pending join) to `useFederation.ts`

**This is PR C of the multi-cluster federation plan (Issue #9368).** PR A landed the interface/registry/server, PR B landed the OCM provider. This PR adds the second provider (Karmada) with zero changes to the existing interface or OCM code.

## Test plan

- [x] `go test ./pkg/agent/federation/providers/ -run Karmada` — all 6 tests pass
- [ ] CI build/lint pass
- [ ] Demo mode shows Karmada hub, clusters, group, and pending join in federation overlay