### PR TITLE
feat: add Cluster API (CAPI) federation provider

### DIFF
--- a/pkg/agent/federation/providers/capi.go
+++ b/pkg/agent/federation/providers/capi.go
@@ -1,0 +1,325 @@
+package providers
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/rest"
+
+	"github.com/kubestellar/console/pkg/agent/federation"
+)
+
+func init() {
+	federation.Register(&capiProvider{})
+}
+
+var (
+	capiClusterGVR = schema.GroupVersionResource{
+		Group:    "cluster.x-k8s.io",
+		Version:  "v1beta1",
+		Resource: "clusters",
+	}
+	capiMachineDeploymentGVR = schema.GroupVersionResource{
+		Group:    "cluster.x-k8s.io",
+		Version:  "v1beta1",
+		Resource: "machinedeployments",
+	}
+	capiKubeadmControlPlaneGVR = schema.GroupVersionResource{
+		Group:    "controlplane.cluster.x-k8s.io",
+		Version:  "v1beta1",
+		Resource: "kubeadmcontrolplanes",
+	}
+)
+
+const (
+	// capiPhaseProvisioning is the CAPI Cluster.status.phase when
+	// infrastructure is being created.
+	capiPhaseProvisioning = "Provisioning"
+	// capiPhasePending is the initial phase before provisioning starts.
+	capiPhasePending = "Pending"
+	// capiPhaseProvisioned is set once the cluster is fully up.
+	capiPhaseProvisioned = "Provisioned"
+	// capiPhaseFailed is set when provisioning has permanently errored.
+	capiPhaseFailed = "Failed"
+	// capiPhaseDeleting is set when the cluster is being torn down.
+	capiPhaseDeleting = "Deleting"
+
+	// capiClusterNameLabel is used by MachineDeployments and
+	// KubeadmControlPlanes to identify the owning CAPI Cluster.
+	capiClusterNameLabel = "cluster.x-k8s.io/cluster-name"
+
+	// capiInfraGroupPrefix is prepended to the infrastructure reference
+	// kind to form the federation group name (e.g. "capi:aws").
+	capiInfraGroupPrefix = "capi:"
+)
+
+type capiProvider struct{}
+
+func (p *capiProvider) Name() federation.FederationProviderName {
+	return federation.ProviderCAPI
+}
+
+func (p *capiProvider) Detect(ctx context.Context, cfg *rest.Config) (federation.DetectResult, error) {
+	dc, err := dynamic.NewForConfig(cfg)
+	if err != nil {
+		return federation.DetectResult{}, err
+	}
+	_, err = dc.Resource(capiClusterGVR).List(ctx, metav1.ListOptions{Limit: 1})
+	if err != nil {
+		if isNotFoundOrGroupNotFound(err) {
+			return federation.DetectResult{Detected: false}, nil
+		}
+		return federation.DetectResult{}, err
+	}
+	return federation.DetectResult{Detected: true, Version: "v1beta1"}, nil
+}
+
+func (p *capiProvider) ReadClusters(ctx context.Context, cfg *rest.Config) ([]federation.FederatedCluster, error) {
+	dc, err := dynamic.NewForConfig(cfg)
+	if err != nil {
+		return nil, err
+	}
+
+	clusterList, err := dc.Resource(capiClusterGVR).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		if isNotFoundOrGroupNotFound(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+
+	// Batch-fetch MachineDeployments for machine counts.
+	mdByCluster := capiIndexMachineDeployments(ctx, dc)
+
+	// Batch-fetch KubeadmControlPlanes for control-plane readiness.
+	kcpByCluster := capiIndexKubeadmControlPlanes(ctx, dc)
+
+	out := make([]federation.FederatedCluster, 0, len(clusterList.Items))
+	for i := range clusterList.Items {
+		fc := parseCAPICluster(&clusterList.Items[i], mdByCluster, kcpByCluster)
+		out = append(out, fc)
+	}
+	return out, nil
+}
+
+func (p *capiProvider) ReadGroups(ctx context.Context, cfg *rest.Config) ([]federation.FederatedGroup, error) {
+	dc, err := dynamic.NewForConfig(cfg)
+	if err != nil {
+		return nil, err
+	}
+
+	clusterList, err := dc.Resource(capiClusterGVR).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		if isNotFoundOrGroupNotFound(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+
+	// Group clusters by infrastructure reference kind.
+	groupMembers := map[string][]string{}
+	for i := range clusterList.Items {
+		obj := &clusterList.Items[i]
+		name := obj.GetName()
+		infraKind := capiInfraRefKind(obj)
+		if infraKind == "" {
+			continue
+		}
+		groupName := capiInfraGroupPrefix + strings.ToLower(infraKind)
+		groupMembers[groupName] = append(groupMembers[groupName], name)
+	}
+
+	out := make([]federation.FederatedGroup, 0, len(groupMembers))
+	for gName, members := range groupMembers {
+		out = append(out, federation.FederatedGroup{
+			Provider: federation.ProviderCAPI,
+			Name:     gName,
+			Members:  members,
+			Kind:     federation.FederatedGroupInfra,
+		})
+	}
+	return out, nil
+}
+
+func (p *capiProvider) ReadPendingJoins(_ context.Context, _ *rest.Config) ([]federation.PendingJoin, error) {
+	// CAPI clusters in provisioning state are already surfaced as clusters
+	// with ClusterStateProvisioning — no separate pending-join concept.
+	return nil, nil
+}
+
+// ---------------------------------------------------------------------------
+// Parsing helpers
+// ---------------------------------------------------------------------------
+
+func parseCAPICluster(
+	obj *unstructured.Unstructured,
+	mdByCluster map[string]capiMachineSummary,
+	kcpByCluster map[string]bool,
+) federation.FederatedCluster {
+	name := obj.GetName()
+	labels := obj.GetLabels()
+	if labels == nil {
+		labels = map[string]string{}
+	}
+
+	phase, _, _ := unstructured.NestedString(obj.Object, "status", "phase")
+	state := capiPhaseToState(phase)
+
+	controlPlaneReady := capiControlPlaneReady(obj, kcpByCluster)
+	infraReady, _, _ := unstructured.NestedBool(obj.Object, "status", "infrastructureReady")
+
+	md := mdByCluster[name]
+
+	apiServerURL := capiAPIServerURL(obj)
+
+	return federation.FederatedCluster{
+		Provider:   federation.ProviderCAPI,
+		Name:       name,
+		State:      state,
+		Available:  capiAvailableFromState(state),
+		Labels:     labels,
+		APIServerURL: apiServerURL,
+		Lifecycle: &federation.Lifecycle{
+			Phase:               phase,
+			ControlPlaneReady:   controlPlaneReady,
+			InfrastructureReady: infraReady,
+			DesiredMachines:     md.desired,
+			ReadyMachines:       md.ready,
+		},
+		Raw: obj.Object,
+	}
+}
+
+func capiPhaseToState(phase string) federation.ClusterState {
+	switch phase {
+	case capiPhaseProvisioning, capiPhasePending:
+		return federation.ClusterStateProvisioning
+	case capiPhaseProvisioned:
+		return federation.ClusterStateProvisioned
+	case capiPhaseFailed:
+		return federation.ClusterStateFailed
+	case capiPhaseDeleting:
+		return federation.ClusterStateDeleting
+	default:
+		return federation.ClusterStateUnknown
+	}
+}
+
+// capiAvailableFromState derives a tri-state availability string from
+// the lifecycle state. Provisioned clusters are "True"; failed ones
+// are "False"; everything else is "Unknown".
+func capiAvailableFromState(state federation.ClusterState) string {
+	switch state {
+	case federation.ClusterStateProvisioned:
+		return "True"
+	case federation.ClusterStateFailed:
+		return "False"
+	default:
+		return "Unknown"
+	}
+}
+
+func capiAPIServerURL(obj *unstructured.Unstructured) string {
+	host, _, _ := unstructured.NestedString(obj.Object, "spec", "controlPlaneEndpoint", "host")
+	port, found, _ := unstructured.NestedInt64(obj.Object, "spec", "controlPlaneEndpoint", "port")
+	if host == "" {
+		return ""
+	}
+	if !found || port == 0 {
+		return fmt.Sprintf("https://%s", host)
+	}
+	return fmt.Sprintf("https://%s:%d", host, port)
+}
+
+func capiInfraRefKind(obj *unstructured.Unstructured) string {
+	kind, _, _ := unstructured.NestedString(obj.Object, "spec", "infrastructureRef", "kind")
+	return kind
+}
+
+// capiControlPlaneReady checks the Cluster status conditions first, then
+// falls back to a matching KubeadmControlPlane.
+func capiControlPlaneReady(obj *unstructured.Unstructured, kcpByCluster map[string]bool) bool {
+	conditions, found, _ := unstructured.NestedSlice(obj.Object, "status", "conditions")
+	if found {
+		for _, c := range conditions {
+			cond, ok := c.(map[string]interface{})
+			if !ok {
+				continue
+			}
+			condType, _ := cond["type"].(string)
+			condStatus, _ := cond["status"].(string)
+			if condType == "ControlPlaneReady" && condStatus == "True" {
+				return true
+			}
+		}
+	}
+	// Fallback: check KubeadmControlPlane index.
+	return kcpByCluster[obj.GetName()]
+}
+
+// ---------------------------------------------------------------------------
+// MachineDeployment index
+// ---------------------------------------------------------------------------
+
+type capiMachineSummary struct {
+	desired int32
+	ready   int32
+}
+
+// capiIndexMachineDeployments lists all MachineDeployments and groups their
+// replica counts by the cluster-name label.
+func capiIndexMachineDeployments(ctx context.Context, dc dynamic.Interface) map[string]capiMachineSummary {
+	out := map[string]capiMachineSummary{}
+	list, err := dc.Resource(capiMachineDeploymentGVR).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return out
+	}
+	for i := range list.Items {
+		md := &list.Items[i]
+		clusterName := md.GetLabels()[capiClusterNameLabel]
+		if clusterName == "" {
+			continue
+		}
+		desired, _, _ := unstructured.NestedInt64(md.Object, "spec", "replicas")
+		ready, _, _ := unstructured.NestedInt64(md.Object, "status", "readyReplicas")
+		summary := out[clusterName]
+		summary.desired += int32(desired)
+		summary.ready += int32(ready)
+		out[clusterName] = summary
+	}
+	return out
+}
+
+// ---------------------------------------------------------------------------
+// KubeadmControlPlane index
+// ---------------------------------------------------------------------------
+
+// capiIndexKubeadmControlPlanes lists all KubeadmControlPlanes and builds a
+// map[clusterName]ready boolean. If the CRD is absent, returns an empty map.
+func capiIndexKubeadmControlPlanes(ctx context.Context, dc dynamic.Interface) map[string]bool {
+	out := map[string]bool{}
+	list, err := dc.Resource(capiKubeadmControlPlaneGVR).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return out
+	}
+	for i := range list.Items {
+		kcp := &list.Items[i]
+		clusterName := kcp.GetLabels()[capiClusterNameLabel]
+		if clusterName == "" {
+			continue
+		}
+		ready, _, _ := unstructured.NestedBool(kcp.Object, "status", "ready")
+		if ready {
+			out[clusterName] = true
+		}
+	}
+	return out
+}
+
+// Ensure compile-time interface conformance.
+var _ federation.Provider = (*capiProvider)(nil)

--- a/pkg/agent/federation/providers/capi_test.go
+++ b/pkg/agent/federation/providers/capi_test.go
@@ -1,0 +1,249 @@
+package providers
+
+import (
+	"testing"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	"github.com/kubestellar/console/pkg/agent/federation"
+)
+
+func TestParseCAPICluster_Provisioned(t *testing.T) {
+	obj := &unstructured.Unstructured{Object: map[string]interface{}{
+		"metadata": map[string]interface{}{
+			"name": "workload-prod-1",
+			"labels": map[string]interface{}{
+				"env": "prod",
+			},
+		},
+		"spec": map[string]interface{}{
+			"controlPlaneEndpoint": map[string]interface{}{
+				"host": "10.0.0.1",
+				"port": int64(6443),
+			},
+			"infrastructureRef": map[string]interface{}{
+				"kind": "AWSCluster",
+			},
+		},
+		"status": map[string]interface{}{
+			"phase":               "Provisioned",
+			"infrastructureReady": true,
+			"conditions": []interface{}{
+				map[string]interface{}{
+					"type":   "ControlPlaneReady",
+					"status": "True",
+				},
+			},
+		},
+	}}
+
+	mdByCluster := map[string]capiMachineSummary{
+		"workload-prod-1": {desired: 3, ready: 3},
+	}
+	kcpByCluster := map[string]bool{}
+
+	fc := parseCAPICluster(obj, mdByCluster, kcpByCluster)
+
+	if fc.Name != "workload-prod-1" {
+		t.Errorf("expected name workload-prod-1, got %s", fc.Name)
+	}
+	if fc.Provider != federation.ProviderCAPI {
+		t.Errorf("expected provider capi, got %s", fc.Provider)
+	}
+	if fc.State != federation.ClusterStateProvisioned {
+		t.Errorf("expected state provisioned, got %s", fc.State)
+	}
+	if fc.Available != "True" {
+		t.Errorf("expected available True, got %s", fc.Available)
+	}
+	if fc.APIServerURL != "https://10.0.0.1:6443" {
+		t.Errorf("expected apiServerURL https://10.0.0.1:6443, got %s", fc.APIServerURL)
+	}
+	if fc.Lifecycle == nil {
+		t.Fatal("expected lifecycle to be non-nil")
+	}
+	if fc.Lifecycle.Phase != "Provisioned" {
+		t.Errorf("expected lifecycle phase Provisioned, got %s", fc.Lifecycle.Phase)
+	}
+	if !fc.Lifecycle.ControlPlaneReady {
+		t.Error("expected controlPlaneReady true")
+	}
+	if !fc.Lifecycle.InfrastructureReady {
+		t.Error("expected infrastructureReady true")
+	}
+	if fc.Lifecycle.DesiredMachines != 3 {
+		t.Errorf("expected 3 desired machines, got %d", fc.Lifecycle.DesiredMachines)
+	}
+	if fc.Lifecycle.ReadyMachines != 3 {
+		t.Errorf("expected 3 ready machines, got %d", fc.Lifecycle.ReadyMachines)
+	}
+}
+
+func TestParseCAPICluster_Provisioning(t *testing.T) {
+	obj := &unstructured.Unstructured{Object: map[string]interface{}{
+		"metadata": map[string]interface{}{
+			"name": "workload-staging",
+		},
+		"spec": map[string]interface{}{},
+		"status": map[string]interface{}{
+			"phase":               "Pending",
+			"infrastructureReady": false,
+		},
+	}}
+
+	fc := parseCAPICluster(obj, map[string]capiMachineSummary{}, map[string]bool{})
+
+	if fc.State != federation.ClusterStateProvisioning {
+		t.Errorf("expected state provisioning for Pending phase, got %s", fc.State)
+	}
+	if fc.Available != "Unknown" {
+		t.Errorf("expected available Unknown, got %s", fc.Available)
+	}
+	if fc.Lifecycle == nil {
+		t.Fatal("expected lifecycle to be non-nil")
+	}
+	if fc.Lifecycle.Phase != "Pending" {
+		t.Errorf("expected lifecycle phase Pending, got %s", fc.Lifecycle.Phase)
+	}
+	if fc.Lifecycle.InfrastructureReady {
+		t.Error("expected infrastructureReady false")
+	}
+}
+
+func TestParseCAPICluster_Failed(t *testing.T) {
+	obj := &unstructured.Unstructured{Object: map[string]interface{}{
+		"metadata": map[string]interface{}{
+			"name": "workload-broken",
+		},
+		"spec": map[string]interface{}{},
+		"status": map[string]interface{}{
+			"phase":               "Failed",
+			"infrastructureReady": false,
+		},
+	}}
+
+	fc := parseCAPICluster(obj, map[string]capiMachineSummary{}, map[string]bool{})
+
+	if fc.State != federation.ClusterStateFailed {
+		t.Errorf("expected state failed, got %s", fc.State)
+	}
+	if fc.Available != "False" {
+		t.Errorf("expected available False, got %s", fc.Available)
+	}
+	if fc.Lifecycle.Phase != "Failed" {
+		t.Errorf("expected lifecycle phase Failed, got %s", fc.Lifecycle.Phase)
+	}
+}
+
+func TestCAPIInfraRefGrouping(t *testing.T) {
+	aws := &unstructured.Unstructured{Object: map[string]interface{}{
+		"metadata": map[string]interface{}{"name": "cluster-aws-1"},
+		"spec": map[string]interface{}{
+			"infrastructureRef": map[string]interface{}{"kind": "AWSCluster"},
+		},
+	}}
+	docker := &unstructured.Unstructured{Object: map[string]interface{}{
+		"metadata": map[string]interface{}{"name": "cluster-docker-1"},
+		"spec": map[string]interface{}{
+			"infrastructureRef": map[string]interface{}{"kind": "DockerCluster"},
+		},
+	}}
+
+	if kind := capiInfraRefKind(aws); kind != "AWSCluster" {
+		t.Errorf("expected AWSCluster, got %s", kind)
+	}
+	if kind := capiInfraRefKind(docker); kind != "DockerCluster" {
+		t.Errorf("expected DockerCluster, got %s", kind)
+	}
+}
+
+func TestCAPIProviderName(t *testing.T) {
+	p := &capiProvider{}
+	if p.Name() != federation.ProviderCAPI {
+		t.Errorf("expected provider name 'capi', got '%s'", p.Name())
+	}
+}
+
+func TestCAPIControlPlaneReady_FromKCP(t *testing.T) {
+	// No conditions on the Cluster itself — should fall back to KCP index.
+	obj := &unstructured.Unstructured{Object: map[string]interface{}{
+		"metadata": map[string]interface{}{
+			"name": "workload-kcp",
+		},
+		"spec":   map[string]interface{}{},
+		"status": map[string]interface{}{},
+	}}
+
+	kcpByCluster := map[string]bool{"workload-kcp": true}
+	ready := capiControlPlaneReady(obj, kcpByCluster)
+	if !ready {
+		t.Error("expected controlPlaneReady true from KCP fallback")
+	}
+}
+
+func TestCAPIPhaseToState(t *testing.T) {
+	cases := []struct {
+		phase string
+		want  federation.ClusterState
+	}{
+		{"Provisioning", federation.ClusterStateProvisioning},
+		{"Pending", federation.ClusterStateProvisioning},
+		{"Provisioned", federation.ClusterStateProvisioned},
+		{"Failed", federation.ClusterStateFailed},
+		{"Deleting", federation.ClusterStateDeleting},
+		{"", federation.ClusterStateUnknown},
+		{"SomethingNew", federation.ClusterStateUnknown},
+	}
+	for _, tc := range cases {
+		got := capiPhaseToState(tc.phase)
+		if got != tc.want {
+			t.Errorf("capiPhaseToState(%q) = %q, want %q", tc.phase, got, tc.want)
+		}
+	}
+}
+
+func TestCAPIAPIServerURL(t *testing.T) {
+	cases := []struct {
+		name string
+		obj  map[string]interface{}
+		want string
+	}{
+		{
+			name: "host and port",
+			obj: map[string]interface{}{
+				"spec": map[string]interface{}{
+					"controlPlaneEndpoint": map[string]interface{}{
+						"host": "10.0.0.1",
+						"port": int64(6443),
+					},
+				},
+			},
+			want: "https://10.0.0.1:6443",
+		},
+		{
+			name: "host only",
+			obj: map[string]interface{}{
+				"spec": map[string]interface{}{
+					"controlPlaneEndpoint": map[string]interface{}{
+						"host": "my-cluster.example.com",
+					},
+				},
+			},
+			want: "https://my-cluster.example.com",
+		},
+		{
+			name: "empty",
+			obj: map[string]interface{}{
+				"spec": map[string]interface{}{},
+			},
+			want: "",
+		},
+	}
+	for _, tc := range cases {
+		u := &unstructured.Unstructured{Object: tc.obj}
+		got := capiAPIServerURL(u)
+		if got != tc.want {
+			t.Errorf("%s: capiAPIServerURL() = %q, want %q", tc.name, got, tc.want)
+		}
+	}
+}

--- a/web/src/hooks/useFederation.ts
+++ b/web/src/hooks/useFederation.ts
@@ -161,6 +161,7 @@ function publishFederation(next: FederationAwareness): void {
 const DEMO_HUBS: ProviderHubStatus[] = [
   { provider: 'ocm', hubContext: 'hub-prod', detected: true, version: 'v1' },
   { provider: 'ocm', hubContext: 'hub-staging', detected: true, version: 'v1' },
+  { provider: 'capi', hubContext: 'capi-mgmt', detected: true, version: 'v1beta1' },
 ]
 
 const DEMO_CLUSTERS: FederatedCluster[] = [
@@ -187,11 +188,49 @@ const DEMO_CLUSTERS: FederatedCluster[] = [
     state: 'pending', available: 'Unknown',
     labels: { env: 'dev', region: 'westeurope' },
   },
+  {
+    provider: 'capi', hubContext: 'capi-mgmt', name: 'workload-prod-aws',
+    state: 'provisioned', available: 'True',
+    labels: { env: 'prod', infra: 'aws' },
+    apiServerURL: 'https://workload-prod-aws.us-east-1.elb.amazonaws.com:6443',
+    lifecycle: {
+      phase: 'Provisioned',
+      controlPlaneReady: true,
+      infrastructureReady: true,
+      desiredMachines: 3,
+      readyMachines: 3,
+    },
+  },
+  {
+    provider: 'capi', hubContext: 'capi-mgmt', name: 'workload-staging-aws',
+    state: 'provisioning', available: 'Unknown',
+    labels: { env: 'staging', infra: 'aws' },
+    lifecycle: {
+      phase: 'Provisioning',
+      controlPlaneReady: false,
+      infrastructureReady: false,
+      desiredMachines: 2,
+      readyMachines: 0,
+    },
+  },
+  {
+    provider: 'capi', hubContext: 'capi-mgmt', name: 'workload-dev-docker',
+    state: 'failed', available: 'False',
+    labels: { env: 'dev', infra: 'docker' },
+    lifecycle: {
+      phase: 'Failed',
+      controlPlaneReady: false,
+      infrastructureReady: false,
+      desiredMachines: 1,
+      readyMachines: 0,
+    },
+  },
 ]
 
 const DEMO_GROUPS: FederatedGroup[] = [
   { provider: 'ocm', hubContext: 'hub-prod', name: 'production', members: ['eks-prod-us-east-1', 'openshift-prod'], kind: 'set' },
   { provider: 'ocm', hubContext: 'hub-staging', name: 'staging', members: ['gke-staging'], kind: 'set' },
+  { provider: 'capi', hubContext: 'capi-mgmt', name: 'capi:awscluster', members: ['workload-prod-aws', 'workload-staging-aws'], kind: 'infra' },
 ]
 
 const DEMO_PENDING: PendingJoin[] = [


### PR DESCRIPTION
## Summary

This is **PR D** of the multi-cluster federation plan (Issue #9368). It adds the Cluster API (CAPI) provider to the federation plugin architecture established in PR A (interface/registry/server) and PR B (OCM provider).

CAPI is lifecycle-oriented rather than pure federation — it surfaces provisioning/provisioned/failed/deleting states instead of joined/pending. The provider reads three `cluster.x-k8s.io/v1beta1` CRDs:

- **Clusters** — main resource, maps `status.phase` to unified `ClusterState`
- **MachineDeployments** — aggregated for desired/ready machine counts per cluster
- **KubeadmControlPlanes** — fallback for control plane readiness when Cluster conditions are absent

Key design decisions:
- `ReadPendingJoins()` returns empty — CAPI clusters in provisioning state are already shown as clusters with `ClusterStateProvisioning`, no separate pending-join concept needed
- `ReadGroups()` groups clusters by infrastructure reference kind (e.g., AWSCluster → `capi:awscluster`, DockerCluster → `capi:dockercluster`) using `FederatedGroupInfra` kind
- `Available` tri-state derived from lifecycle state (provisioned=True, failed=False, else Unknown)
- Reuses `isNotFoundOrGroupNotFound()` from the same package (ocm.go)

## Changes

- `pkg/agent/federation/providers/capi.go` — full `Provider` interface implementation
- `pkg/agent/federation/providers/capi_test.go` — 8 unit tests covering phase mapping, lifecycle parsing, infra grouping, API server URL construction, KCP fallback
- `web/src/hooks/useFederation.ts` — demo data: 1 CAPI hub, 3 CAPI clusters (provisioned, provisioning, failed), 1 infra group

## Test plan

- [x] `go test ./pkg/agent/federation/providers/` — all 14 tests pass (8 CAPI + 6 OCM)
- [ ] CI build/lint passes
- [ ] Demo mode shows CAPI clusters with lifecycle badges in federation overlay