### PR TITLE
feat: add Clusternet, Liqo, and KubeAdmiral federation providers

### DIFF
--- a/pkg/agent/federation/providers/clusternet.go
+++ b/pkg/agent/federation/providers/clusternet.go
@@ -1,0 +1,210 @@
+package providers
+
+import (
+	"context"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/rest"
+
+	"github.com/kubestellar/console/pkg/agent/federation"
+)
+
+func init() {
+	federation.Register(&clusternetProvider{})
+}
+
+var clusternetManagedClusterGVR = schema.GroupVersionResource{
+	Group:    "clusters.clusternet.io",
+	Version:  "v1beta1",
+	Resource: "managedclusters",
+}
+
+const (
+	clusternetConditionReady    = "Ready"
+	clusternetClusterIDLabelKey = "clusternet.io/cluster-id"
+)
+
+type clusternetProvider struct{}
+
+func (p *clusternetProvider) Name() federation.FederationProviderName {
+	return federation.ProviderClusternet
+}
+
+func (p *clusternetProvider) Detect(ctx context.Context, cfg *rest.Config) (federation.DetectResult, error) {
+	dc, err := dynamic.NewForConfig(cfg)
+	if err != nil {
+		return federation.DetectResult{}, err
+	}
+	_, err = dc.Resource(clusternetManagedClusterGVR).List(ctx, metav1.ListOptions{Limit: 1})
+	if err != nil {
+		if isNotFoundOrGroupNotFound(err) {
+			return federation.DetectResult{Detected: false}, nil
+		}
+		return federation.DetectResult{}, err
+	}
+	return federation.DetectResult{Detected: true, Version: "v1beta1"}, nil
+}
+
+func (p *clusternetProvider) ReadClusters(ctx context.Context, cfg *rest.Config) ([]federation.FederatedCluster, error) {
+	dc, err := dynamic.NewForConfig(cfg)
+	if err != nil {
+		return nil, err
+	}
+	list, err := dc.Resource(clusternetManagedClusterGVR).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		if isNotFoundOrGroupNotFound(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+
+	out := make([]federation.FederatedCluster, 0, len(list.Items))
+	for i := range list.Items {
+		fc := parseClusternetManagedCluster(&list.Items[i])
+		out = append(out, fc)
+	}
+	return out, nil
+}
+
+func (p *clusternetProvider) ReadGroups(ctx context.Context, cfg *rest.Config) ([]federation.FederatedGroup, error) {
+	dc, err := dynamic.NewForConfig(cfg)
+	if err != nil {
+		return nil, err
+	}
+	list, err := dc.Resource(clusternetManagedClusterGVR).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		if isNotFoundOrGroupNotFound(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+
+	// Build synthetic groups from common label keys. Clusters that share the
+	// same clusternet.io/cluster-id label value are grouped together.
+	groups := map[string][]string{}
+	for i := range list.Items {
+		labels := list.Items[i].GetLabels()
+		if labels == nil {
+			continue
+		}
+		if id, ok := labels[clusternetClusterIDLabelKey]; ok {
+			groups[id] = append(groups[id], list.Items[i].GetName())
+		}
+	}
+
+	out := make([]federation.FederatedGroup, 0, len(groups))
+	for id, members := range groups {
+		out = append(out, federation.FederatedGroup{
+			Provider: federation.ProviderClusternet,
+			Name:     id,
+			Members:  members,
+			Kind:     federation.FederatedGroupSelector,
+		})
+	}
+	return out, nil
+}
+
+func (p *clusternetProvider) ReadPendingJoins(ctx context.Context, cfg *rest.Config) ([]federation.PendingJoin, error) {
+	dc, err := dynamic.NewForConfig(cfg)
+	if err != nil {
+		return nil, err
+	}
+	list, err := dc.Resource(clusternetManagedClusterGVR).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		if isNotFoundOrGroupNotFound(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+
+	out := make([]federation.PendingJoin, 0)
+	for i := range list.Items {
+		obj := &list.Items[i]
+		state := clusternetExtractState(obj)
+		if state != federation.ClusterStatePending {
+			continue
+		}
+		name := obj.GetName()
+		createdAt := obj.GetCreationTimestamp().Time
+		out = append(out, federation.PendingJoin{
+			Provider:    federation.ProviderClusternet,
+			ClusterName: name,
+			RequestedAt: createdAt,
+			Detail:      "ManagedCluster: " + name + " (Ready=False or missing)",
+		})
+	}
+	return out, nil
+}
+
+func parseClusternetManagedCluster(obj *unstructured.Unstructured) federation.FederatedCluster {
+	name := obj.GetName()
+	labels := obj.GetLabels()
+	if labels == nil {
+		labels = map[string]string{}
+	}
+
+	state := clusternetExtractState(obj)
+	available := clusternetExtractAvailable(obj)
+	apiServerURL, _, _ := unstructured.NestedString(obj.Object, "status", "apiServerURL")
+
+	clusterSet := labels[clusternetClusterIDLabelKey]
+
+	return federation.FederatedCluster{
+		Provider:     federation.ProviderClusternet,
+		Name:         name,
+		State:        state,
+		Available:    available,
+		ClusterSet:   clusterSet,
+		Labels:       labels,
+		APIServerURL: apiServerURL,
+		Raw:          obj.Object,
+	}
+}
+
+func clusternetExtractState(obj *unstructured.Unstructured) federation.ClusterState {
+	conditions, found, _ := unstructured.NestedSlice(obj.Object, "status", "conditions")
+	if !found {
+		return federation.ClusterStatePending
+	}
+	for _, c := range conditions {
+		cond, ok := c.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		condType, _ := cond["type"].(string)
+		condStatus, _ := cond["status"].(string)
+		if condType == clusternetConditionReady {
+			if condStatus == "True" {
+				return federation.ClusterStateJoined
+			}
+			return federation.ClusterStatePending
+		}
+	}
+	// Ready condition not found — treat as pending.
+	return federation.ClusterStatePending
+}
+
+func clusternetExtractAvailable(obj *unstructured.Unstructured) string {
+	conditions, found, _ := unstructured.NestedSlice(obj.Object, "status", "conditions")
+	if !found {
+		return "Unknown"
+	}
+	for _, c := range conditions {
+		cond, ok := c.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		condType, _ := cond["type"].(string)
+		condStatus, _ := cond["status"].(string)
+		if condType == clusternetConditionReady {
+			return condStatus
+		}
+	}
+	return "Unknown"
+}
+
+// Ensure compile-time interface conformance.
+var _ federation.Provider = (*clusternetProvider)(nil)

--- a/pkg/agent/federation/providers/clusternet_test.go
+++ b/pkg/agent/federation/providers/clusternet_test.go
@@ -1,0 +1,97 @@
+package providers
+
+import (
+	"testing"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	"github.com/kubestellar/console/pkg/agent/federation"
+)
+
+func TestParseClusternetManagedCluster_Joined(t *testing.T) {
+	obj := &unstructured.Unstructured{Object: map[string]interface{}{
+		"metadata": map[string]interface{}{
+			"name": "child-1",
+			"labels": map[string]interface{}{
+				"clusternet.io/cluster-id": "abc-123",
+				"env":                      "prod",
+			},
+		},
+		"status": map[string]interface{}{
+			"conditions": []interface{}{
+				map[string]interface{}{
+					"type":   "Ready",
+					"status": "True",
+				},
+			},
+			"apiServerURL": "https://child-1:6443",
+		},
+	}}
+
+	fc := parseClusternetManagedCluster(obj)
+	if fc.Name != "child-1" {
+		t.Errorf("expected name child-1, got %s", fc.Name)
+	}
+	if fc.State != federation.ClusterStateJoined {
+		t.Errorf("expected state joined, got %s", fc.State)
+	}
+	if fc.Available != "True" {
+		t.Errorf("expected available True, got %s", fc.Available)
+	}
+	if fc.APIServerURL != "https://child-1:6443" {
+		t.Errorf("expected apiServerURL https://child-1:6443, got %s", fc.APIServerURL)
+	}
+	if fc.ClusterSet != "abc-123" {
+		t.Errorf("expected clusterSet abc-123, got %s", fc.ClusterSet)
+	}
+	if fc.Provider != federation.ProviderClusternet {
+		t.Errorf("expected provider clusternet, got %s", fc.Provider)
+	}
+}
+
+func TestParseClusternetManagedCluster_Pending(t *testing.T) {
+	obj := &unstructured.Unstructured{Object: map[string]interface{}{
+		"metadata": map[string]interface{}{
+			"name": "child-2",
+		},
+		"status": map[string]interface{}{
+			"conditions": []interface{}{
+				map[string]interface{}{
+					"type":   "Ready",
+					"status": "False",
+				},
+			},
+		},
+	}}
+
+	fc := parseClusternetManagedCluster(obj)
+	if fc.State != federation.ClusterStatePending {
+		t.Errorf("expected state pending, got %s", fc.State)
+	}
+	if fc.Available != "False" {
+		t.Errorf("expected available False, got %s", fc.Available)
+	}
+}
+
+func TestParseClusternetManagedCluster_NoConditions(t *testing.T) {
+	obj := &unstructured.Unstructured{Object: map[string]interface{}{
+		"metadata": map[string]interface{}{
+			"name": "child-3",
+		},
+	}}
+
+	fc := parseClusternetManagedCluster(obj)
+	if fc.State != federation.ClusterStatePending {
+		t.Errorf("expected state pending when no conditions, got %s", fc.State)
+	}
+	if fc.Available != "Unknown" {
+		t.Errorf("expected available Unknown, got %s", fc.Available)
+	}
+}
+
+func TestClusternetProviderName(t *testing.T) {
+	p := &clusternetProvider{}
+	if p.Name() != federation.ProviderClusternet {
+		t.Errorf("expected provider name 'clusternet', got '%s'", p.Name())
+	}
+}

--- a/pkg/agent/federation/providers/kubeadmiral.go
+++ b/pkg/agent/federation/providers/kubeadmiral.go
@@ -1,0 +1,202 @@
+package providers
+
+import (
+	"context"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/rest"
+
+	"github.com/kubestellar/console/pkg/agent/federation"
+)
+
+func init() {
+	federation.Register(&kubeAdmiralProvider{})
+}
+
+var kubeAdmiralFederatedClusterGVR = schema.GroupVersionResource{
+	Group:    "core.kubeadmiral.io",
+	Version:  "v1alpha1",
+	Resource: "federatedclusters",
+}
+
+const kubeAdmiralConditionReady = "Ready"
+
+type kubeAdmiralProvider struct{}
+
+func (p *kubeAdmiralProvider) Name() federation.FederationProviderName {
+	return federation.ProviderKubeAdmiral
+}
+
+func (p *kubeAdmiralProvider) Detect(ctx context.Context, cfg *rest.Config) (federation.DetectResult, error) {
+	dc, err := dynamic.NewForConfig(cfg)
+	if err != nil {
+		return federation.DetectResult{}, err
+	}
+	_, err = dc.Resource(kubeAdmiralFederatedClusterGVR).List(ctx, metav1.ListOptions{Limit: 1})
+	if err != nil {
+		if isNotFoundOrGroupNotFound(err) {
+			return federation.DetectResult{Detected: false}, nil
+		}
+		return federation.DetectResult{}, err
+	}
+	return federation.DetectResult{Detected: true, Version: "v1alpha1"}, nil
+}
+
+func (p *kubeAdmiralProvider) ReadClusters(ctx context.Context, cfg *rest.Config) ([]federation.FederatedCluster, error) {
+	dc, err := dynamic.NewForConfig(cfg)
+	if err != nil {
+		return nil, err
+	}
+	list, err := dc.Resource(kubeAdmiralFederatedClusterGVR).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		if isNotFoundOrGroupNotFound(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+
+	out := make([]federation.FederatedCluster, 0, len(list.Items))
+	for i := range list.Items {
+		fc := parseKubeAdmiralFederatedCluster(&list.Items[i])
+		out = append(out, fc)
+	}
+	return out, nil
+}
+
+func (p *kubeAdmiralProvider) ReadGroups(ctx context.Context, cfg *rest.Config) ([]federation.FederatedGroup, error) {
+	dc, err := dynamic.NewForConfig(cfg)
+	if err != nil {
+		return nil, err
+	}
+	list, err := dc.Resource(kubeAdmiralFederatedClusterGVR).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		if isNotFoundOrGroupNotFound(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+
+	// Build synthetic groups from labels, similar to Clusternet. Group by
+	// each unique label key-value pair.
+	groups := map[string][]string{}
+	for i := range list.Items {
+		labels := list.Items[i].GetLabels()
+		for k, v := range labels {
+			groupKey := k + "=" + v
+			groups[groupKey] = append(groups[groupKey], list.Items[i].GetName())
+		}
+	}
+
+	out := make([]federation.FederatedGroup, 0, len(groups))
+	for name, members := range groups {
+		out = append(out, federation.FederatedGroup{
+			Provider: federation.ProviderKubeAdmiral,
+			Name:     name,
+			Members:  members,
+			Kind:     federation.FederatedGroupSelector,
+		})
+	}
+	return out, nil
+}
+
+func (p *kubeAdmiralProvider) ReadPendingJoins(ctx context.Context, cfg *rest.Config) ([]federation.PendingJoin, error) {
+	dc, err := dynamic.NewForConfig(cfg)
+	if err != nil {
+		return nil, err
+	}
+	list, err := dc.Resource(kubeAdmiralFederatedClusterGVR).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		if isNotFoundOrGroupNotFound(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+
+	out := make([]federation.PendingJoin, 0)
+	for i := range list.Items {
+		obj := &list.Items[i]
+		state := kubeAdmiralExtractState(obj)
+		if state != federation.ClusterStatePending {
+			continue
+		}
+		name := obj.GetName()
+		createdAt := obj.GetCreationTimestamp().Time
+		out = append(out, federation.PendingJoin{
+			Provider:    federation.ProviderKubeAdmiral,
+			ClusterName: name,
+			RequestedAt: createdAt,
+			Detail:      "FederatedCluster: " + name + " (Ready=False or missing)",
+		})
+	}
+	return out, nil
+}
+
+func parseKubeAdmiralFederatedCluster(obj *unstructured.Unstructured) federation.FederatedCluster {
+	name := obj.GetName()
+	labels := obj.GetLabels()
+	if labels == nil {
+		labels = map[string]string{}
+	}
+
+	state := kubeAdmiralExtractState(obj)
+	available := kubeAdmiralExtractAvailable(obj)
+	apiServerURL, _, _ := unstructured.NestedString(obj.Object, "spec", "apiEndpoint")
+
+	return federation.FederatedCluster{
+		Provider:     federation.ProviderKubeAdmiral,
+		Name:         name,
+		State:        state,
+		Available:    available,
+		Labels:       labels,
+		APIServerURL: apiServerURL,
+		Raw:          obj.Object,
+	}
+}
+
+func kubeAdmiralExtractState(obj *unstructured.Unstructured) federation.ClusterState {
+	conditions, found, _ := unstructured.NestedSlice(obj.Object, "status", "conditions")
+	if !found {
+		return federation.ClusterStatePending
+	}
+	for _, c := range conditions {
+		cond, ok := c.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		condType, _ := cond["type"].(string)
+		condStatus, _ := cond["status"].(string)
+		if condType == kubeAdmiralConditionReady {
+			if condStatus == "True" {
+				return federation.ClusterStateJoined
+			}
+			return federation.ClusterStatePending
+		}
+	}
+	// Ready condition not present — treat as pending.
+	return federation.ClusterStatePending
+}
+
+func kubeAdmiralExtractAvailable(obj *unstructured.Unstructured) string {
+	conditions, found, _ := unstructured.NestedSlice(obj.Object, "status", "conditions")
+	if !found {
+		return "Unknown"
+	}
+	for _, c := range conditions {
+		cond, ok := c.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		condType, _ := cond["type"].(string)
+		condStatus, _ := cond["status"].(string)
+		if condType == kubeAdmiralConditionReady {
+			return condStatus
+		}
+	}
+	return "Unknown"
+}
+
+// Ensure compile-time interface conformance.
+var _ federation.Provider = (*kubeAdmiralProvider)(nil)

--- a/pkg/agent/federation/providers/kubeadmiral_test.go
+++ b/pkg/agent/federation/providers/kubeadmiral_test.go
@@ -1,0 +1,95 @@
+package providers
+
+import (
+	"testing"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	"github.com/kubestellar/console/pkg/agent/federation"
+)
+
+func TestParseKubeAdmiralFederatedCluster_Joined(t *testing.T) {
+	obj := &unstructured.Unstructured{Object: map[string]interface{}{
+		"metadata": map[string]interface{}{
+			"name": "member-1",
+			"labels": map[string]interface{}{
+				"region": "us-west-2",
+			},
+		},
+		"spec": map[string]interface{}{
+			"apiEndpoint": "https://member-1:6443",
+		},
+		"status": map[string]interface{}{
+			"conditions": []interface{}{
+				map[string]interface{}{
+					"type":   "Ready",
+					"status": "True",
+				},
+			},
+		},
+	}}
+
+	fc := parseKubeAdmiralFederatedCluster(obj)
+	if fc.Name != "member-1" {
+		t.Errorf("expected name member-1, got %s", fc.Name)
+	}
+	if fc.State != federation.ClusterStateJoined {
+		t.Errorf("expected state joined, got %s", fc.State)
+	}
+	if fc.Available != "True" {
+		t.Errorf("expected available True, got %s", fc.Available)
+	}
+	if fc.APIServerURL != "https://member-1:6443" {
+		t.Errorf("expected apiServerURL https://member-1:6443, got %s", fc.APIServerURL)
+	}
+	if fc.Provider != federation.ProviderKubeAdmiral {
+		t.Errorf("expected provider kubeadmiral, got %s", fc.Provider)
+	}
+}
+
+func TestParseKubeAdmiralFederatedCluster_Pending(t *testing.T) {
+	obj := &unstructured.Unstructured{Object: map[string]interface{}{
+		"metadata": map[string]interface{}{
+			"name": "member-2",
+		},
+		"status": map[string]interface{}{
+			"conditions": []interface{}{
+				map[string]interface{}{
+					"type":   "Ready",
+					"status": "False",
+				},
+			},
+		},
+	}}
+
+	fc := parseKubeAdmiralFederatedCluster(obj)
+	if fc.State != federation.ClusterStatePending {
+		t.Errorf("expected state pending, got %s", fc.State)
+	}
+	if fc.Available != "False" {
+		t.Errorf("expected available False, got %s", fc.Available)
+	}
+}
+
+func TestParseKubeAdmiralFederatedCluster_NoConditions(t *testing.T) {
+	obj := &unstructured.Unstructured{Object: map[string]interface{}{
+		"metadata": map[string]interface{}{
+			"name": "member-3",
+		},
+	}}
+
+	fc := parseKubeAdmiralFederatedCluster(obj)
+	if fc.State != federation.ClusterStatePending {
+		t.Errorf("expected state pending when no conditions, got %s", fc.State)
+	}
+	if fc.Available != "Unknown" {
+		t.Errorf("expected available Unknown, got %s", fc.Available)
+	}
+}
+
+func TestKubeAdmiralProviderName(t *testing.T) {
+	p := &kubeAdmiralProvider{}
+	if p.Name() != federation.ProviderKubeAdmiral {
+		t.Errorf("expected provider name 'kubeadmiral', got '%s'", p.Name())
+	}
+}

--- a/pkg/agent/federation/providers/liqo.go
+++ b/pkg/agent/federation/providers/liqo.go
@@ -1,0 +1,205 @@
+package providers
+
+import (
+	"context"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/rest"
+
+	"github.com/kubestellar/console/pkg/agent/federation"
+)
+
+func init() {
+	federation.Register(&liqoProvider{})
+}
+
+var liqoForeignClusterGVR = schema.GroupVersionResource{
+	Group:    "discovery.liqo.io",
+	Version:  "v1alpha1",
+	Resource: "foreignclusters",
+}
+
+const (
+	// liqoPeeringConditionOutgoing is the condition type for an outgoing
+	// peering relationship in ForeignCluster.status.peeringConditions.
+	liqoPeeringConditionOutgoing = "OutgoingPeering"
+	// liqoPeeringConditionIncoming is the condition type for an incoming
+	// peering relationship in ForeignCluster.status.peeringConditions.
+	liqoPeeringConditionIncoming = "IncomingPeering"
+	// liqoPeeringStatusActive marks an active peering relationship.
+	liqoPeeringStatusActive = "Active"
+	// liqoPeersGroupName is the synthetic group name for all peered clusters.
+	liqoPeersGroupName = "peers"
+)
+
+type liqoProvider struct{}
+
+func (p *liqoProvider) Name() federation.FederationProviderName {
+	return federation.ProviderLiqo
+}
+
+func (p *liqoProvider) Detect(ctx context.Context, cfg *rest.Config) (federation.DetectResult, error) {
+	dc, err := dynamic.NewForConfig(cfg)
+	if err != nil {
+		return federation.DetectResult{}, err
+	}
+	_, err = dc.Resource(liqoForeignClusterGVR).List(ctx, metav1.ListOptions{Limit: 1})
+	if err != nil {
+		if isNotFoundOrGroupNotFound(err) {
+			return federation.DetectResult{Detected: false}, nil
+		}
+		return federation.DetectResult{}, err
+	}
+	return federation.DetectResult{Detected: true, Version: "v1alpha1"}, nil
+}
+
+func (p *liqoProvider) ReadClusters(ctx context.Context, cfg *rest.Config) ([]federation.FederatedCluster, error) {
+	dc, err := dynamic.NewForConfig(cfg)
+	if err != nil {
+		return nil, err
+	}
+	list, err := dc.Resource(liqoForeignClusterGVR).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		if isNotFoundOrGroupNotFound(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+
+	out := make([]federation.FederatedCluster, 0, len(list.Items))
+	for i := range list.Items {
+		fc := parseLiqoForeignCluster(&list.Items[i])
+		out = append(out, fc)
+	}
+	return out, nil
+}
+
+func (p *liqoProvider) ReadGroups(ctx context.Context, cfg *rest.Config) ([]federation.FederatedGroup, error) {
+	dc, err := dynamic.NewForConfig(cfg)
+	if err != nil {
+		return nil, err
+	}
+	list, err := dc.Resource(liqoForeignClusterGVR).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		if isNotFoundOrGroupNotFound(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+
+	// Liqo is peer-to-peer. Group all peered clusters into a single "peers"
+	// group using the FederatedGroupPeer kind.
+	members := make([]string, 0, len(list.Items))
+	for i := range list.Items {
+		if liqoIsPeeringActive(&list.Items[i]) {
+			members = append(members, list.Items[i].GetName())
+		}
+	}
+
+	if len(members) == 0 {
+		return nil, nil
+	}
+	return []federation.FederatedGroup{{
+		Provider: federation.ProviderLiqo,
+		Name:     liqoPeersGroupName,
+		Members:  members,
+		Kind:     federation.FederatedGroupPeer,
+	}}, nil
+}
+
+func (p *liqoProvider) ReadPendingJoins(ctx context.Context, cfg *rest.Config) ([]federation.PendingJoin, error) {
+	dc, err := dynamic.NewForConfig(cfg)
+	if err != nil {
+		return nil, err
+	}
+	list, err := dc.Resource(liqoForeignClusterGVR).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		if isNotFoundOrGroupNotFound(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+
+	out := make([]federation.PendingJoin, 0)
+	for i := range list.Items {
+		obj := &list.Items[i]
+		if liqoIsPeeringActive(obj) {
+			continue
+		}
+		name := obj.GetName()
+		createdAt := obj.GetCreationTimestamp().Time
+		out = append(out, federation.PendingJoin{
+			Provider:    federation.ProviderLiqo,
+			ClusterName: name,
+			RequestedAt: createdAt,
+			Detail:      "ForeignCluster: " + name + " (peering not active)",
+		})
+	}
+	return out, nil
+}
+
+func parseLiqoForeignCluster(obj *unstructured.Unstructured) federation.FederatedCluster {
+	name := obj.GetName()
+	labels := obj.GetLabels()
+	if labels == nil {
+		labels = map[string]string{}
+	}
+
+	active := liqoIsPeeringActive(obj)
+	var state federation.ClusterState
+	if active {
+		state = federation.ClusterStateJoined
+	} else {
+		state = federation.ClusterStatePending
+	}
+
+	available := "Unknown"
+	if active {
+		available = "True"
+	}
+
+	// Liqo stores the remote endpoint in spec.foreignAuthURL or
+	// spec.controlPlaneEndpoint depending on version.
+	apiServerURL, _, _ := unstructured.NestedString(obj.Object, "spec", "controlPlaneEndpoint")
+	if apiServerURL == "" {
+		apiServerURL, _, _ = unstructured.NestedString(obj.Object, "spec", "foreignAuthURL")
+	}
+
+	return federation.FederatedCluster{
+		Provider:     federation.ProviderLiqo,
+		Name:         name,
+		State:        state,
+		Available:    available,
+		Labels:       labels,
+		APIServerURL: apiServerURL,
+		Raw:          obj.Object,
+	}
+}
+
+// liqoIsPeeringActive returns true when at least one peering direction
+// (outgoing or incoming) is active in status.peeringConditions.
+func liqoIsPeeringActive(obj *unstructured.Unstructured) bool {
+	conditions, found, _ := unstructured.NestedSlice(obj.Object, "status", "peeringConditions")
+	if !found {
+		return false
+	}
+	for _, c := range conditions {
+		cond, ok := c.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		condType, _ := cond["type"].(string)
+		condStatus, _ := cond["status"].(string)
+		if (condType == liqoPeeringConditionOutgoing || condType == liqoPeeringConditionIncoming) &&
+			condStatus == liqoPeeringStatusActive {
+			return true
+		}
+	}
+	return false
+}
+
+// Ensure compile-time interface conformance.
+var _ federation.Provider = (*liqoProvider)(nil)

--- a/pkg/agent/federation/providers/liqo_test.go
+++ b/pkg/agent/federation/providers/liqo_test.go
@@ -1,0 +1,149 @@
+package providers
+
+import (
+	"testing"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	"github.com/kubestellar/console/pkg/agent/federation"
+)
+
+func TestParseLiqoForeignCluster_Joined(t *testing.T) {
+	obj := &unstructured.Unstructured{Object: map[string]interface{}{
+		"metadata": map[string]interface{}{
+			"name": "remote-cluster-1",
+			"labels": map[string]interface{}{
+				"liqo.io/remote-cluster-id": "cl-abc",
+			},
+		},
+		"spec": map[string]interface{}{
+			"controlPlaneEndpoint": "https://remote-1:6443",
+		},
+		"status": map[string]interface{}{
+			"peeringConditions": []interface{}{
+				map[string]interface{}{
+					"type":   "OutgoingPeering",
+					"status": "Active",
+				},
+			},
+		},
+	}}
+
+	fc := parseLiqoForeignCluster(obj)
+	if fc.Name != "remote-cluster-1" {
+		t.Errorf("expected name remote-cluster-1, got %s", fc.Name)
+	}
+	if fc.State != federation.ClusterStateJoined {
+		t.Errorf("expected state joined, got %s", fc.State)
+	}
+	if fc.Available != "True" {
+		t.Errorf("expected available True, got %s", fc.Available)
+	}
+	if fc.APIServerURL != "https://remote-1:6443" {
+		t.Errorf("expected apiServerURL https://remote-1:6443, got %s", fc.APIServerURL)
+	}
+	if fc.Provider != federation.ProviderLiqo {
+		t.Errorf("expected provider liqo, got %s", fc.Provider)
+	}
+}
+
+func TestParseLiqoForeignCluster_FallbackAuthURL(t *testing.T) {
+	obj := &unstructured.Unstructured{Object: map[string]interface{}{
+		"metadata": map[string]interface{}{
+			"name": "remote-cluster-2",
+		},
+		"spec": map[string]interface{}{
+			"foreignAuthURL": "https://remote-2:9443/auth",
+		},
+		"status": map[string]interface{}{
+			"peeringConditions": []interface{}{
+				map[string]interface{}{
+					"type":   "IncomingPeering",
+					"status": "Active",
+				},
+			},
+		},
+	}}
+
+	fc := parseLiqoForeignCluster(obj)
+	if fc.APIServerURL != "https://remote-2:9443/auth" {
+		t.Errorf("expected apiServerURL from foreignAuthURL, got %s", fc.APIServerURL)
+	}
+	if fc.State != federation.ClusterStateJoined {
+		t.Errorf("expected state joined via IncomingPeering, got %s", fc.State)
+	}
+}
+
+func TestParseLiqoForeignCluster_Pending(t *testing.T) {
+	obj := &unstructured.Unstructured{Object: map[string]interface{}{
+		"metadata": map[string]interface{}{
+			"name": "remote-cluster-3",
+		},
+		"status": map[string]interface{}{
+			"peeringConditions": []interface{}{
+				map[string]interface{}{
+					"type":   "OutgoingPeering",
+					"status": "Pending",
+				},
+			},
+		},
+	}}
+
+	fc := parseLiqoForeignCluster(obj)
+	if fc.State != federation.ClusterStatePending {
+		t.Errorf("expected state pending, got %s", fc.State)
+	}
+	if fc.Available != "Unknown" {
+		t.Errorf("expected available Unknown, got %s", fc.Available)
+	}
+}
+
+func TestParseLiqoForeignCluster_NoConditions(t *testing.T) {
+	obj := &unstructured.Unstructured{Object: map[string]interface{}{
+		"metadata": map[string]interface{}{
+			"name": "remote-cluster-4",
+		},
+	}}
+
+	fc := parseLiqoForeignCluster(obj)
+	if fc.State != federation.ClusterStatePending {
+		t.Errorf("expected state pending when no conditions, got %s", fc.State)
+	}
+}
+
+func TestLiqoIsPeeringActive(t *testing.T) {
+	active := &unstructured.Unstructured{Object: map[string]interface{}{
+		"status": map[string]interface{}{
+			"peeringConditions": []interface{}{
+				map[string]interface{}{
+					"type":   "OutgoingPeering",
+					"status": "Active",
+				},
+			},
+		},
+	}}
+	if !liqoIsPeeringActive(active) {
+		t.Error("expected active peering to be detected")
+	}
+
+	inactive := &unstructured.Unstructured{Object: map[string]interface{}{
+		"status": map[string]interface{}{
+			"peeringConditions": []interface{}{
+				map[string]interface{}{
+					"type":   "OutgoingPeering",
+					"status": "Pending",
+				},
+			},
+		},
+	}}
+	if liqoIsPeeringActive(inactive) {
+		t.Error("expected pending peering to NOT be detected as active")
+	}
+}
+
+func TestLiqoProviderName(t *testing.T) {
+	p := &liqoProvider{}
+	if p.Name() != federation.ProviderLiqo {
+		t.Errorf("expected provider name 'liqo', got '%s'", p.Name())
+	}
+}

--- a/web/src/hooks/useFederation.ts
+++ b/web/src/hooks/useFederation.ts
@@ -163,6 +163,9 @@ const DEMO_HUBS: ProviderHubStatus[] = [
   { provider: 'ocm', hubContext: 'hub-staging', detected: true, version: 'v1' },
   { provider: 'capi', hubContext: 'capi-mgmt', detected: true, version: 'v1beta1' },
   { provider: 'karmada', hubContext: 'karmada-control', detected: true, version: 'v1alpha1' },
+  { provider: 'clusternet', hubContext: 'clusternet-parent', detected: true, version: 'v1beta1' },
+  { provider: 'liqo', hubContext: 'liqo-local', detected: true, version: 'v1alpha1' },
+  { provider: 'kubeadmiral', hubContext: 'kubeadmiral-ctl', detected: true, version: 'v1alpha1' },
 ]
 
 const DEMO_CLUSTERS: FederatedCluster[] = [
@@ -238,6 +241,39 @@ const DEMO_CLUSTERS: FederatedCluster[] = [
     labels: { env: 'staging', region: 'eu-west-1' },
     apiServerURL: 'https://karmada-member-2.eu-west-1.example.com:6443',
   },
+  {
+    provider: 'clusternet', hubContext: 'clusternet-parent', name: 'child-cluster-1',
+    state: 'joined', available: 'True',
+    labels: { 'clusternet.io/cluster-id': 'cn-abc-123', env: 'prod' },
+    apiServerURL: 'https://child-1.clusternet.example.com:6443',
+  },
+  {
+    provider: 'clusternet', hubContext: 'clusternet-parent', name: 'child-cluster-2',
+    state: 'pending', available: 'False',
+    labels: { 'clusternet.io/cluster-id': 'cn-def-456' },
+  },
+  {
+    provider: 'liqo', hubContext: 'liqo-local', name: 'peer-rome',
+    state: 'joined', available: 'True',
+    labels: { 'liqo.io/remote-cluster-id': 'lq-rome' },
+    apiServerURL: 'https://peer-rome.liqo.example.com:6443',
+  },
+  {
+    provider: 'liqo', hubContext: 'liqo-local', name: 'peer-berlin',
+    state: 'pending', available: 'Unknown',
+    labels: { 'liqo.io/remote-cluster-id': 'lq-berlin' },
+  },
+  {
+    provider: 'kubeadmiral', hubContext: 'kubeadmiral-ctl', name: 'member-east',
+    state: 'joined', available: 'True',
+    labels: { region: 'us-east-1', tier: 'production' },
+    apiServerURL: 'https://member-east.kubeadmiral.example.com:6443',
+  },
+  {
+    provider: 'kubeadmiral', hubContext: 'kubeadmiral-ctl', name: 'member-west',
+    state: 'pending', available: 'False',
+    labels: { region: 'us-west-2' },
+  },
 ]
 
 const DEMO_GROUPS: FederatedGroup[] = [
@@ -245,10 +281,15 @@ const DEMO_GROUPS: FederatedGroup[] = [
   { provider: 'ocm', hubContext: 'hub-staging', name: 'staging', members: ['gke-staging'], kind: 'set' },
   { provider: 'capi', hubContext: 'capi-mgmt', name: 'capi:awscluster', members: ['workload-prod-aws', 'workload-staging-aws'], kind: 'infra' },
   { provider: 'karmada', hubContext: 'karmada-control', name: 'deploy-to-apac', members: ['karmada-member-1'], kind: 'selector' },
+  { provider: 'clusternet', hubContext: 'clusternet-parent', name: 'cn-abc-123', members: ['child-cluster-1'], kind: 'selector' },
+  { provider: 'liqo', hubContext: 'liqo-local', name: 'peers', members: ['peer-rome'], kind: 'peer' },
+  { provider: 'kubeadmiral', hubContext: 'kubeadmiral-ctl', name: 'region=us-east-1', members: ['member-east'], kind: 'selector' },
 ]
 
-const FIVE_MINUTES_MS = 300_000;
-const TEN_MINUTES_MS = 600_000;
+const FIVE_MINUTES_MS = 300_000
+const TEN_MINUTES_MS = 600_000
+const TWO_MINUTES_MS = 120_000
+const THREE_MINUTES_MS = 180_000
 
 const DEMO_PENDING: PendingJoin[] = [
   {
@@ -260,6 +301,21 @@ const DEMO_PENDING: PendingJoin[] = [
     provider: 'karmada', hubContext: 'karmada-control', clusterName: 'karmada-member-2',
     requestedAt: new Date(Date.now() - TEN_MINUTES_MS).toISOString(),
     detail: 'Cluster Ready condition is not True',
+  },
+  {
+    provider: 'clusternet', hubContext: 'clusternet-parent', clusterName: 'child-cluster-2',
+    requestedAt: new Date(Date.now() - TWO_MINUTES_MS).toISOString(),
+    detail: 'ManagedCluster: child-cluster-2 (Ready=False or missing)',
+  },
+  {
+    provider: 'liqo', hubContext: 'liqo-local', clusterName: 'peer-berlin',
+    requestedAt: new Date(Date.now() - TEN_MINUTES_MS).toISOString(),
+    detail: 'ForeignCluster: peer-berlin (peering not active)',
+  },
+  {
+    provider: 'kubeadmiral', hubContext: 'kubeadmiral-ctl', clusterName: 'member-west',
+    requestedAt: new Date(Date.now() - THREE_MINUTES_MS).toISOString(),
+    detail: 'FederatedCluster: member-west (Ready=False or missing)',
   },
 ]
 


### PR DESCRIPTION
## Summary

PR E of the multi-cluster management federation plan (Issue #9368). Adds three small federation providers that follow the plugin architecture established in PR A (interface/registry/server) and PR B (OCM provider):

- **Clusternet** (`clusters.clusternet.io/v1beta1/managedclusters`): Maps `Ready` condition to joined/pending state. Builds synthetic groups from `clusternet.io/cluster-id` labels. ~150 LOC.
- **Liqo** (`discovery.liqo.io/v1alpha1/foreignclusters`): Maps `OutgoingPeering`/`IncomingPeering` Active status to joined state. Groups all peered clusters into a single "peers" group with `FederatedGroupPeer` kind (peer-to-peer model, not hub-and-spoke). ~170 LOC.
- **KubeAdmiral** (`core.kubeadmiral.io/v1alpha1/federatedclusters`): Maps `Ready` condition to joined/pending state. Builds label-based selector groups. ~150 LOC.

All three providers:
- Register via `init()` (blank import in `cmd/kc-agent/main.go` already exists)
- Include `var _ federation.Provider = (*xxxProvider)(nil)` compile checks
- Reuse `isNotFoundOrGroupNotFound()` from the shared package
- Have unit tests for joined/pending parsing and provider name

Demo data in `useFederation.ts` updated with sample hubs, clusters, groups, and pending joins for all three providers.

## Test plan

- [x] `go test ./pkg/agent/federation/providers/` — all 20 tests pass
- [ ] CI build/lint pass
- [ ] Verify demo mode renders Clusternet, Liqo, and KubeAdmiral hubs in the federation overlay