### PR TITLE
feat: federation action framework and OCM actions (PR F)

### DIFF
--- a/pkg/agent/federation/actions.go
+++ b/pkg/agent/federation/actions.go
@@ -1,0 +1,73 @@
+package federation
+
+import (
+	"context"
+
+	"k8s.io/client-go/rest"
+)
+
+// ActionDescriptor describes a single imperative action a provider can execute.
+// The backend exposes each provider's descriptors via Actions() so the UI can
+// render per-cluster action menus without hardcoding provider-specific logic.
+// Phase 2 of the federation roll-out — see Issue 9368.
+type ActionDescriptor struct {
+	// ID is the stable identifier for this action (e.g. "ocm.approveCSR").
+	ID string `json:"id"`
+	// Label is the human-readable button label for the UI.
+	Label string `json:"label"`
+	// Verb is the Kubernetes API verb the action performs (e.g. "update",
+	// "patch", "delete"). Used by the UI to gate SSAR checks.
+	Verb string `json:"verb"`
+	// Provider identifies which provider owns this action.
+	Provider FederationProviderName `json:"provider"`
+	// Destructive flags actions that warrant a confirmation dialog in the UI
+	// (e.g. detaching a cluster). The UI MUST show a ConfirmDialog before
+	// executing any action with Destructive=true.
+	Destructive bool `json:"destructive"`
+}
+
+// ActionRequest is the POST body the frontend sends to /federation/action.
+type ActionRequest struct {
+	// ActionID is the ActionDescriptor.ID to execute.
+	ActionID string `json:"actionId"`
+	// Provider selects the provider that owns the action.
+	Provider FederationProviderName `json:"provider"`
+	// HubContext is the kubeconfig context hosting the federation hub.
+	HubContext string `json:"hubContext"`
+	// ClusterName is the target cluster for cluster-scoped actions. Optional
+	// for hub-scoped actions (e.g. approving a CSR by name in Payload).
+	ClusterName string `json:"clusterName,omitempty"`
+	// Payload carries action-specific parameters (e.g. taint key/value/effect
+	// for ocm.taintCluster). Keys are action-defined.
+	Payload map[string]interface{} `json:"payload,omitempty"`
+}
+
+// ActionResult is the JSON response from /federation/action.
+type ActionResult struct {
+	// OK is true when the action completed successfully.
+	OK bool `json:"ok"`
+	// Already is true when the action was a no-op because the desired state
+	// already existed (e.g. cluster already accepted, CSR already approved).
+	// OK is also true when Already is true.
+	Already bool `json:"already"`
+	// Message carries a human-readable status string on both success and
+	// failure. On failure (OK=false) it contains the error details.
+	Message string `json:"message,omitempty"`
+}
+
+// ActionProvider extends Provider with imperative action capabilities. Phase 1
+// providers that only implement read-only operations satisfy the base Provider
+// interface; Phase 2 providers that also support management operations implement
+// ActionProvider. The server asserts ActionProvider at runtime — providers that
+// don't implement it simply have no actions exposed.
+type ActionProvider interface {
+	Provider
+	// Actions returns the set of imperative actions this provider supports.
+	// The returned slice is stable for the process lifetime — providers MUST
+	// NOT change the set dynamically.
+	Actions() []ActionDescriptor
+	// Execute runs the action described by req against the hub reachable via
+	// cfg. Implementations MUST be idempotent where possible: repeating an
+	// already-completed action returns ActionResult{OK:true, Already:true}.
+	Execute(ctx context.Context, cfg *rest.Config, req ActionRequest) (ActionResult, error)
+}

--- a/pkg/agent/federation/providers/ocm_actions.go
+++ b/pkg/agent/federation/providers/ocm_actions.go
@@ -1,0 +1,286 @@
+package providers
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	certificatesv1 "k8s.io/api/certificates/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+
+	"github.com/kubestellar/console/pkg/agent/federation"
+)
+
+// OCM action IDs — stable identifiers referenced by the UI and tests.
+const (
+	ocmActionApproveCSR    = "ocm.approveCSR"
+	ocmActionAcceptCluster = "ocm.acceptCluster"
+	ocmActionDetachCluster = "ocm.detachCluster"
+	ocmActionTaintCluster  = "ocm.taintCluster"
+)
+
+// Actions returns the set of imperative actions the OCM provider supports.
+// See ActionProvider interface in pkg/agent/federation/actions.go.
+func (p *ocmProvider) Actions() []federation.ActionDescriptor {
+	return []federation.ActionDescriptor{
+		{
+			ID:          ocmActionApproveCSR,
+			Label:       "Approve CSR",
+			Verb:        "update",
+			Provider:    federation.ProviderOCM,
+			Destructive: false,
+		},
+		{
+			ID:          ocmActionAcceptCluster,
+			Label:       "Accept Cluster",
+			Verb:        "patch",
+			Provider:    federation.ProviderOCM,
+			Destructive: false,
+		},
+		{
+			ID:          ocmActionDetachCluster,
+			Label:       "Detach Cluster",
+			Verb:        "delete",
+			Provider:    federation.ProviderOCM,
+			Destructive: true,
+		},
+		{
+			ID:          ocmActionTaintCluster,
+			Label:       "Taint Cluster",
+			Verb:        "patch",
+			Provider:    federation.ProviderOCM,
+			Destructive: false,
+		},
+	}
+}
+
+// Execute dispatches the action request to the appropriate OCM handler.
+func (p *ocmProvider) Execute(ctx context.Context, cfg *rest.Config, req federation.ActionRequest) (federation.ActionResult, error) {
+	switch req.ActionID {
+	case ocmActionApproveCSR:
+		return executeOCMApproveCSR(ctx, cfg, req)
+	case ocmActionAcceptCluster:
+		return executeOCMAcceptCluster(ctx, cfg, req)
+	case ocmActionDetachCluster:
+		return executeOCMDetachCluster(ctx, cfg, req)
+	case ocmActionTaintCluster:
+		return executeOCMTaintCluster(ctx, cfg, req)
+	default:
+		return federation.ActionResult{}, fmt.Errorf("unknown OCM action: %s", req.ActionID)
+	}
+}
+
+// executeOCMApproveCSR approves a pending CSR for an OCM spoke cluster. The
+// CSR name is expected in Payload["csrName"]. If the CSR is already approved,
+// returns Already=true.
+func executeOCMApproveCSR(ctx context.Context, cfg *rest.Config, req federation.ActionRequest) (federation.ActionResult, error) {
+	csrName, _ := req.Payload["csrName"].(string)
+	if csrName == "" {
+		return federation.ActionResult{}, fmt.Errorf("payload.csrName is required for %s", ocmActionApproveCSR)
+	}
+
+	clientset, err := kubernetes.NewForConfig(cfg)
+	if err != nil {
+		return federation.ActionResult{}, fmt.Errorf("building kubernetes client: %w", err)
+	}
+
+	csr, err := clientset.CertificatesV1().CertificateSigningRequests().Get(ctx, csrName, metav1.GetOptions{})
+	if err != nil {
+		return federation.ActionResult{}, fmt.Errorf("getting CSR %s: %w", csrName, err)
+	}
+
+	// Check if already approved.
+	for _, c := range csr.Status.Conditions {
+		if c.Type == certificatesv1.CertificateApproved {
+			return federation.ActionResult{
+				OK:      true,
+				Already: true,
+				Message: fmt.Sprintf("CSR %s is already approved", csrName),
+			}, nil
+		}
+	}
+
+	// Append the Approved condition.
+	csr.Status.Conditions = append(csr.Status.Conditions, certificatesv1.CertificateSigningRequestCondition{
+		Type:               certificatesv1.CertificateApproved,
+		Status:             corev1.ConditionTrue,
+		Reason:             "KubeStellarConsoleApproval",
+		Message:            "Approved via KubeStellar Console federation action",
+		LastUpdateTime:     metav1.Now(),
+	})
+
+	_, err = clientset.CertificatesV1().CertificateSigningRequests().UpdateApproval(ctx, csrName, csr, metav1.UpdateOptions{})
+	if err != nil {
+		if isConflictError(err) {
+			return federation.ActionResult{OK: true, Already: true, Message: "CSR approval conflict — likely already approved"}, nil
+		}
+		return federation.ActionResult{}, fmt.Errorf("approving CSR %s: %w", csrName, err)
+	}
+
+	return federation.ActionResult{OK: true, Message: fmt.Sprintf("CSR %s approved", csrName)}, nil
+}
+
+// executeOCMAcceptCluster patches the ManagedCluster to set
+// spec.hubAcceptsClient=true. Idempotent — if already accepted, returns
+// Already=true.
+func executeOCMAcceptCluster(ctx context.Context, cfg *rest.Config, req federation.ActionRequest) (federation.ActionResult, error) {
+	if req.ClusterName == "" {
+		return federation.ActionResult{}, fmt.Errorf("clusterName is required for %s", ocmActionAcceptCluster)
+	}
+
+	dc, err := dynamic.NewForConfig(cfg)
+	if err != nil {
+		return federation.ActionResult{}, fmt.Errorf("building dynamic client: %w", err)
+	}
+
+	// Read current state to check idempotency.
+	current, err := dc.Resource(ocmManagedClusterGVR).Get(ctx, req.ClusterName, metav1.GetOptions{})
+	if err != nil {
+		return federation.ActionResult{}, fmt.Errorf("getting ManagedCluster %s: %w", req.ClusterName, err)
+	}
+	accepted, _, _ := unstructured.NestedBool(current.Object, "spec", "hubAcceptsClient")
+	if accepted {
+		return federation.ActionResult{
+			OK:      true,
+			Already: true,
+			Message: fmt.Sprintf("ManagedCluster %s already accepted", req.ClusterName),
+		}, nil
+	}
+
+	patch := []byte(`{"spec":{"hubAcceptsClient":true}}`)
+	_, err = dc.Resource(ocmManagedClusterGVR).Patch(ctx, req.ClusterName, types.MergePatchType, patch, metav1.PatchOptions{})
+	if err != nil {
+		if isConflictError(err) {
+			return federation.ActionResult{OK: true, Already: true, Message: "patch conflict — likely already accepted"}, nil
+		}
+		return federation.ActionResult{}, fmt.Errorf("patching ManagedCluster %s: %w", req.ClusterName, err)
+	}
+
+	return federation.ActionResult{OK: true, Message: fmt.Sprintf("ManagedCluster %s accepted", req.ClusterName)}, nil
+}
+
+// executeOCMDetachCluster deletes the ManagedCluster resource. This is
+// destructive — the UI should confirm before calling.
+func executeOCMDetachCluster(ctx context.Context, cfg *rest.Config, req federation.ActionRequest) (federation.ActionResult, error) {
+	if req.ClusterName == "" {
+		return federation.ActionResult{}, fmt.Errorf("clusterName is required for %s", ocmActionDetachCluster)
+	}
+
+	dc, err := dynamic.NewForConfig(cfg)
+	if err != nil {
+		return federation.ActionResult{}, fmt.Errorf("building dynamic client: %w", err)
+	}
+
+	err = dc.Resource(ocmManagedClusterGVR).Delete(ctx, req.ClusterName, metav1.DeleteOptions{})
+	if err != nil {
+		if isNotFoundError(err) {
+			return federation.ActionResult{OK: true, Already: true, Message: fmt.Sprintf("ManagedCluster %s already deleted", req.ClusterName)}, nil
+		}
+		return federation.ActionResult{}, fmt.Errorf("deleting ManagedCluster %s: %w", req.ClusterName, err)
+	}
+
+	return federation.ActionResult{OK: true, Message: fmt.Sprintf("ManagedCluster %s deleted", req.ClusterName)}, nil
+}
+
+// executeOCMTaintCluster adds a taint to the ManagedCluster's spec.taints.
+// The taint is specified in Payload as "key", "value", "effect". If the
+// exact taint already exists, returns Already=true.
+func executeOCMTaintCluster(ctx context.Context, cfg *rest.Config, req federation.ActionRequest) (federation.ActionResult, error) {
+	if req.ClusterName == "" {
+		return federation.ActionResult{}, fmt.Errorf("clusterName is required for %s", ocmActionTaintCluster)
+	}
+
+	taintKey, _ := req.Payload["key"].(string)
+	taintValue, _ := req.Payload["value"].(string)
+	taintEffect, _ := req.Payload["effect"].(string)
+	if taintKey == "" || taintEffect == "" {
+		return federation.ActionResult{}, fmt.Errorf("payload.key and payload.effect are required for %s", ocmActionTaintCluster)
+	}
+
+	dc, err := dynamic.NewForConfig(cfg)
+	if err != nil {
+		return federation.ActionResult{}, fmt.Errorf("building dynamic client: %w", err)
+	}
+
+	current, err := dc.Resource(ocmManagedClusterGVR).Get(ctx, req.ClusterName, metav1.GetOptions{})
+	if err != nil {
+		return federation.ActionResult{}, fmt.Errorf("getting ManagedCluster %s: %w", req.ClusterName, err)
+	}
+
+	existingTaints, _, _ := unstructured.NestedSlice(current.Object, "spec", "taints")
+
+	// Check if the exact taint already exists.
+	for _, t := range existingTaints {
+		tm, ok := t.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		k, _ := tm["key"].(string)
+		v, _ := tm["value"].(string)
+		e, _ := tm["effect"].(string)
+		if k == taintKey && v == taintValue && e == taintEffect {
+			return federation.ActionResult{
+				OK:      true,
+				Already: true,
+				Message: fmt.Sprintf("taint %s=%s:%s already exists on %s", taintKey, taintValue, taintEffect, req.ClusterName),
+			}, nil
+		}
+	}
+
+	// Append the new taint and patch.
+	newTaint := map[string]interface{}{
+		"key":    taintKey,
+		"value":  taintValue,
+		"effect": taintEffect,
+	}
+	updatedTaints := append(existingTaints, newTaint)
+
+	patchBody := map[string]interface{}{
+		"spec": map[string]interface{}{
+			"taints": updatedTaints,
+		},
+	}
+	patchBytes, err := json.Marshal(patchBody)
+	if err != nil {
+		return federation.ActionResult{}, fmt.Errorf("marshaling taint patch: %w", err)
+	}
+
+	_, err = dc.Resource(ocmManagedClusterGVR).Patch(ctx, req.ClusterName, types.MergePatchType, patchBytes, metav1.PatchOptions{})
+	if err != nil {
+		if isConflictError(err) {
+			return federation.ActionResult{OK: true, Already: true, Message: "patch conflict — taint may already exist"}, nil
+		}
+		return federation.ActionResult{}, fmt.Errorf("patching taints on ManagedCluster %s: %w", req.ClusterName, err)
+	}
+
+	return federation.ActionResult{
+		OK:      true,
+		Message: fmt.Sprintf("taint %s=%s:%s added to %s", taintKey, taintValue, taintEffect, req.ClusterName),
+	}, nil
+}
+
+// isConflictError returns true if the error indicates a 409 Conflict.
+func isConflictError(err error) bool {
+	if err == nil {
+		return false
+	}
+	return strings.Contains(err.Error(), "409") || strings.Contains(err.Error(), "Conflict") || strings.Contains(err.Error(), "the object has been modified")
+}
+
+// isNotFoundError returns true if the error indicates a 404 Not Found.
+func isNotFoundError(err error) bool {
+	if err == nil {
+		return false
+	}
+	return strings.Contains(err.Error(), "not found") || strings.Contains(err.Error(), "404")
+}
+
+// Ensure compile-time ActionProvider conformance.
+var _ federation.ActionProvider = (*ocmProvider)(nil)

--- a/pkg/agent/federation/providers/ocm_actions_test.go
+++ b/pkg/agent/federation/providers/ocm_actions_test.go
@@ -1,0 +1,151 @@
+package providers
+
+import (
+	"testing"
+
+	"github.com/kubestellar/console/pkg/agent/federation"
+)
+
+func TestOCMProviderActions(t *testing.T) {
+	p := &ocmProvider{}
+	actions := p.Actions()
+
+	// OCM should expose exactly 4 actions in Phase 2.
+	const expectedActionCount = 4
+	if len(actions) != expectedActionCount {
+		t.Fatalf("expected %d actions, got %d", expectedActionCount, len(actions))
+	}
+
+	// Build a lookup by ID for easier assertions.
+	byID := map[string]federation.ActionDescriptor{}
+	for _, a := range actions {
+		byID[a.ID] = a
+	}
+
+	// All actions should belong to OCM.
+	for _, a := range actions {
+		if a.Provider != federation.ProviderOCM {
+			t.Errorf("action %s has provider %s, expected ocm", a.ID, a.Provider)
+		}
+	}
+
+	// approveCSR: update verb, non-destructive.
+	if a, ok := byID[ocmActionApproveCSR]; !ok {
+		t.Error("missing action ocm.approveCSR")
+	} else {
+		if a.Verb != "update" {
+			t.Errorf("approveCSR verb = %s, want update", a.Verb)
+		}
+		if a.Destructive {
+			t.Error("approveCSR should not be destructive")
+		}
+	}
+
+	// acceptCluster: patch verb, non-destructive.
+	if a, ok := byID[ocmActionAcceptCluster]; !ok {
+		t.Error("missing action ocm.acceptCluster")
+	} else {
+		if a.Verb != "patch" {
+			t.Errorf("acceptCluster verb = %s, want patch", a.Verb)
+		}
+		if a.Destructive {
+			t.Error("acceptCluster should not be destructive")
+		}
+	}
+
+	// detachCluster: delete verb, destructive.
+	if a, ok := byID[ocmActionDetachCluster]; !ok {
+		t.Error("missing action ocm.detachCluster")
+	} else {
+		if a.Verb != "delete" {
+			t.Errorf("detachCluster verb = %s, want delete", a.Verb)
+		}
+		if !a.Destructive {
+			t.Error("detachCluster should be destructive")
+		}
+	}
+
+	// taintCluster: patch verb, non-destructive.
+	if a, ok := byID[ocmActionTaintCluster]; !ok {
+		t.Error("missing action ocm.taintCluster")
+	} else {
+		if a.Verb != "patch" {
+			t.Errorf("taintCluster verb = %s, want patch", a.Verb)
+		}
+		if a.Destructive {
+			t.Error("taintCluster should not be destructive")
+		}
+	}
+}
+
+func TestOCMActionProviderInterface(t *testing.T) {
+	// Verify that ocmProvider satisfies the ActionProvider interface at the
+	// type level. The compile-time check in ocm_actions.go catches this too,
+	// but this test makes the assertion explicit and test-discoverable.
+	var p federation.Provider = &ocmProvider{}
+	ap, ok := p.(federation.ActionProvider)
+	if !ok {
+		t.Fatal("ocmProvider does not implement ActionProvider")
+	}
+	if ap.Name() != federation.ProviderOCM {
+		t.Errorf("expected provider name ocm, got %s", ap.Name())
+	}
+}
+
+func TestOCMExecuteUnknownAction(t *testing.T) {
+	p := &ocmProvider{}
+	req := federation.ActionRequest{
+		ActionID: "ocm.nonexistent",
+		Provider: federation.ProviderOCM,
+	}
+	_, err := p.Execute(nil, nil, req)
+	if err == nil {
+		t.Error("expected error for unknown action")
+	}
+}
+
+func TestIsConflictError(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"nil", nil, false},
+		{"conflict 409", errFromString("Operation cannot be fulfilled: 409"), true},
+		{"conflict text", errFromString("the object has been modified"), true},
+		{"not conflict", errFromString("connection refused"), false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isConflictError(tt.err); got != tt.want {
+				t.Errorf("isConflictError(%v) = %v, want %v", tt.err, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIsNotFoundError(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"nil", nil, false},
+		{"not found", errFromString("managedclusters \"foo\" not found"), true},
+		{"404", errFromString("the server responded with 404"), true},
+		{"other", errFromString("timeout"), false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isNotFoundError(tt.err); got != tt.want {
+				t.Errorf("isNotFoundError(%v) = %v, want %v", tt.err, got, tt.want)
+			}
+		})
+	}
+}
+
+// errFromString is a minimal error type for tests.
+type errString string
+
+func errFromString(s string) error  { return errString(s) }
+func (e errString) Error() string   { return string(e) }

--- a/pkg/agent/server.go
+++ b/pkg/agent/server.go
@@ -442,6 +442,11 @@ func (s *Server) Start() error {
 	mux.HandleFunc("/federation/clusters", s.handleFederationClusters)
 	mux.HandleFunc("/federation/groups", s.handleFederationGroups)
 	mux.HandleFunc("/federation/pending-joins", s.handleFederationPendingJoins)
+	// Phase 2: imperative action endpoint. Providers that implement
+	// ActionProvider expose management operations (approve CSR, accept/detach
+	// cluster, add taints) via POST. Same bearer-token identity contract as
+	// the read handlers above.
+	mux.HandleFunc("/federation/action", s.handleFederationAction)
 
 	// GitOps drift detection + kubectl sync moved to kc-agent (#7993 Phase 3b).
 	// These shell `kubectl diff` / `kubectl apply` under the user's kubeconfig.

--- a/pkg/agent/server_federation.go
+++ b/pkg/agent/server_federation.go
@@ -29,6 +29,8 @@ package agent
 
 import (
 	"context"
+	"encoding/json"
+	"io"
 	"net/http"
 	"sync"
 	"time"
@@ -466,4 +468,85 @@ func runOneRead(
 		items []interface{}
 		err   *federation.FederationError
 	}{items: items}
+}
+
+// federationActionTimeout bounds a single action execution. Actions may
+// involve real API mutations (CSR approval, ManagedCluster patch/delete)
+// so we allow slightly more time than a read probe but still cap it to
+// prevent runaway operations.
+const federationActionTimeout = 30 * time.Second
+
+// handleFederationAction serves `POST /federation/action` — the Phase 2
+// imperative action endpoint. It decodes an ActionRequest from the body,
+// looks up the provider in the registry, asserts ActionProvider, resolves
+// the user's rest.Config for the specified hubContext, and delegates to
+// the provider's Execute method. The result is returned as ActionResult JSON.
+func (s *Server) handleFederationAction(w http.ResponseWriter, r *http.Request) {
+	s.setCORSHeaders(w, r, http.MethodPost, http.MethodOptions)
+	w.Header().Set("Content-Type", "application/json")
+	if r.Method == http.MethodOptions {
+		w.WriteHeader(http.StatusOK)
+		return
+	}
+	if r.Method != http.MethodPost {
+		writeJSONError(w, http.StatusMethodNotAllowed, "method not allowed")
+		return
+	}
+	if !s.requireBearerToken(w, r) {
+		return
+	}
+	if s.k8sClient == nil {
+		writeJSONError(w, http.StatusServiceUnavailable, "k8s client not initialized")
+		return
+	}
+
+	// Read and decode the request body.
+	body, err := io.ReadAll(io.LimitReader(r.Body, int64(maxRequestBodyBytes)))
+	if err != nil {
+		writeJSONError(w, http.StatusBadRequest, "failed to read request body")
+		return
+	}
+	defer r.Body.Close()
+
+	var req federation.ActionRequest
+	if err := json.Unmarshal(body, &req); err != nil {
+		writeJSONError(w, http.StatusBadRequest, "invalid JSON: "+err.Error())
+		return
+	}
+
+	if req.ActionID == "" || req.Provider == "" || req.HubContext == "" {
+		writeJSONError(w, http.StatusBadRequest, "actionId, provider, and hubContext are required")
+		return
+	}
+
+	// Look up the provider in the registry.
+	p, ok := federation.Get(req.Provider)
+	if !ok {
+		writeJSONError(w, http.StatusNotFound, "unknown federation provider: "+string(req.Provider))
+		return
+	}
+
+	// Assert the provider implements ActionProvider.
+	ap, ok := p.(federation.ActionProvider)
+	if !ok {
+		writeJSONError(w, http.StatusNotImplemented, "provider "+string(req.Provider)+" does not support actions")
+		return
+	}
+
+	// Resolve the user's rest.Config for the specified hub context.
+	cfg, err := s.k8sClient.GetRestConfig(req.HubContext)
+	if err != nil {
+		writeJSONError(w, http.StatusInternalServerError, "failed to resolve config for context "+req.HubContext+": "+err.Error())
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(r.Context(), federationActionTimeout)
+	defer cancel()
+
+	result, err := ap.Execute(ctx, cfg, req)
+	if err != nil {
+		writeJSONError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	writeJSON(w, result)
 }

--- a/web/src/components/federation/FederationActionButton.tsx
+++ b/web/src/components/federation/FederationActionButton.tsx
@@ -1,0 +1,139 @@
+/**
+ * FederationActionButton — generic button for executing a federation action.
+ *
+ * This component:
+ * 1. Runs a SelfSubjectAccessReview (SSAR) via useCanI to check if the user
+ *    has permission to perform the action. Renders null if denied.
+ * 2. For destructive actions (ActionDescriptor.destructive === true), shows a
+ *    ConfirmDialog before executing.
+ * 3. Calls executeFederationAction() and reports the result via onComplete.
+ *
+ * Phase 2 of the federation roll-out — PR F.
+ */
+
+import { useState, useEffect, useCallback } from 'react'
+import { Button } from '../ui/Button'
+import { ConfirmDialog } from '../../lib/modals/ConfirmDialog'
+import { useCanI } from '../../hooks/usePermissions'
+import { executeFederationAction } from '../../hooks/useFederationActions'
+import type { ActionDescriptor, ActionResult, ActionRequest } from '../../hooks/useFederationActions'
+
+/** Map of action verbs to Kubernetes resource names for SSAR checks. */
+const ACTION_RESOURCE_MAP: Record<string, string> = {
+  'ocm.approveCSR': 'certificatesigningrequests/approval',
+  'ocm.acceptCluster': 'managedclusters',
+  'ocm.detachCluster': 'managedclusters',
+  'ocm.taintCluster': 'managedclusters',
+}
+
+/** Kubernetes API group for OCM ManagedCluster resources. */
+const OCM_API_GROUP = 'cluster.open-cluster-management.io'
+
+/** API group for CSR resources. */
+const CERTIFICATES_API_GROUP = 'certificates.k8s.io'
+
+interface FederationActionButtonProps {
+  /** The action descriptor from the provider's Actions() list. */
+  action: ActionDescriptor
+  /** The kubeconfig context hosting the federation hub. */
+  hubContext: string
+  /** The target cluster name (required for cluster-scoped actions). */
+  clusterName?: string
+  /** Extra payload to pass to the action (e.g. taint key/value/effect). */
+  payload?: Record<string, unknown>
+  /** Callback invoked after the action completes (success or failure). */
+  onComplete?: (result: ActionResult) => void
+  /** Optional CSS class name. */
+  className?: string
+}
+
+export function FederationActionButton({
+  action,
+  hubContext,
+  clusterName,
+  payload,
+  onComplete,
+  className,
+}: FederationActionButtonProps) {
+  const { checkPermission } = useCanI()
+  const [allowed, setAllowed] = useState<boolean | null>(null)
+  const [loading, setLoading] = useState(false)
+  const [showConfirm, setShowConfirm] = useState(false)
+
+  // Run SSAR check on mount to determine if the button should render.
+  useEffect(() => {
+    const resource = ACTION_RESOURCE_MAP[action.id] || 'managedclusters'
+    const group = resource.includes('certificatesigningrequests')
+      ? CERTIFICATES_API_GROUP
+      : OCM_API_GROUP
+
+    checkPermission({
+      cluster: hubContext,
+      verb: action.verb,
+      resource,
+      group,
+    }).then((res) => {
+      setAllowed(res.allowed)
+    })
+  }, [action.id, action.verb, hubContext, checkPermission])
+
+  const executeAction = useCallback(async () => {
+    setLoading(true)
+    try {
+      const req: ActionRequest = {
+        actionId: action.id,
+        provider: action.provider,
+        hubContext,
+        clusterName,
+        payload,
+      }
+      const result = await executeFederationAction(req)
+      onComplete?.(result)
+    } finally {
+      setLoading(false)
+      setShowConfirm(false)
+    }
+  }, [action, hubContext, clusterName, payload, onComplete])
+
+  const handleClick = useCallback(() => {
+    if (action.destructive) {
+      setShowConfirm(true)
+    } else {
+      executeAction()
+    }
+  }, [action.destructive, executeAction])
+
+  // Don't render if SSAR check hasn't completed or is denied.
+  if (allowed === null || allowed === false) {
+    return null
+  }
+
+  return (
+    <>
+      <Button
+        variant={action.destructive ? 'danger' : 'primary'}
+        size="sm"
+        loading={loading}
+        disabled={loading}
+        onClick={handleClick}
+        className={className}
+        aria-label={action.label}
+      >
+        {action.label}
+      </Button>
+
+      {action.destructive && (
+        <ConfirmDialog
+          isOpen={showConfirm}
+          onClose={() => setShowConfirm(false)}
+          onConfirm={executeAction}
+          title={action.label}
+          message={`This will ${action.label.toLowerCase()} "${clusterName || 'the resource'}". This action cannot be undone.`}
+          confirmLabel={action.label}
+          variant="danger"
+          isLoading={loading}
+        />
+      )}
+    </>
+  )
+}

--- a/web/src/hooks/useFederationActions.ts
+++ b/web/src/hooks/useFederationActions.ts
@@ -1,0 +1,68 @@
+/**
+ * Federation action helpers — Phase 2 imperative operations.
+ *
+ * This module provides the TypeScript types and fetch wrapper for the
+ * POST /federation/action endpoint added in PR F. The UI calls
+ * executeFederationAction() to run a provider-specific action (approve CSR,
+ * accept cluster, detach cluster, taint cluster, etc.) against a hub.
+ *
+ * Types mirror pkg/agent/federation/actions.go.
+ */
+
+import { LOCAL_AGENT_HTTP_URL, FETCH_DEFAULT_TIMEOUT_MS } from '../lib/constants/network'
+import { STORAGE_KEY_TOKEN } from '../lib/constants'
+import type { FederationProviderName } from './useFederation'
+
+/** Describes a single imperative action a provider supports. */
+export interface ActionDescriptor {
+  /** Stable identifier (e.g. "ocm.approveCSR"). */
+  id: string
+  /** Human-readable button label. */
+  label: string
+  /** Kubernetes API verb the action performs (e.g. "update", "patch", "delete"). */
+  verb: string
+  /** Provider that owns this action. */
+  provider: FederationProviderName
+  /** Whether the action is destructive (UI should confirm before executing). */
+  destructive: boolean
+}
+
+/** POST body for /federation/action. */
+export interface ActionRequest {
+  actionId: string
+  provider: FederationProviderName
+  hubContext: string
+  clusterName?: string
+  payload?: Record<string, unknown>
+}
+
+/** Response from /federation/action. */
+export interface ActionResult {
+  ok: boolean
+  already: boolean
+  message?: string
+}
+
+/**
+ * Execute a federation action against the kc-agent backend.
+ *
+ * The caller is responsible for showing a confirmation dialog before calling
+ * this for destructive actions (ActionDescriptor.destructive === true).
+ */
+export async function executeFederationAction(req: ActionRequest): Promise<ActionResult> {
+  const token = localStorage.getItem(STORAGE_KEY_TOKEN)
+  const headers: Record<string, string> = { 'Content-Type': 'application/json' }
+  if (token) headers['Authorization'] = `Bearer ${token}`
+
+  const response = await fetch(`${LOCAL_AGENT_HTTP_URL}/federation/action`, {
+    method: 'POST',
+    headers,
+    body: JSON.stringify(req),
+    signal: AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS),
+  })
+  if (!response.ok) {
+    const text = await response.text()
+    return { ok: false, already: false, message: text }
+  }
+  return await response.json()
+}


### PR DESCRIPTION
## Summary

Phase 2 (write/management) of the federation roll-out (Issue #9368). This PR adds the imperative action framework and OCM-specific actions.

### Backend

- **`pkg/agent/federation/actions.go`** — `ActionDescriptor`, `ActionRequest`, `ActionResult` types and `ActionProvider` interface extending `Provider` with `Actions()`/`Execute()`
- **`pkg/agent/federation/providers/ocm_actions.go`** — Four OCM actions:
  - `ocm.approveCSR` — approve pending CSR (update verb)
  - `ocm.acceptCluster` — set `spec.hubAcceptsClient=true` (patch verb)
  - `ocm.detachCluster` — delete ManagedCluster (**destructive**)
  - `ocm.taintCluster` — add taint to `spec.taints` (patch verb)
  - All actions are idempotent (409 Conflict / already-exists returns `{ok:true, already:true}`)
- **`pkg/agent/server_federation.go`** — `POST /federation/action` handler with bearer-token enforcement, provider lookup, ActionProvider assertion, and user-identity rest.Config resolution
- **`pkg/agent/server.go`** — Route registration for the new endpoint

### Frontend

- **`web/src/hooks/useFederationActions.ts`** — TypeScript types mirroring the Go structs + `executeFederationAction()` fetch wrapper
- **`web/src/components/federation/FederationActionButton.tsx`** — Generic action button that:
  - Gates on SSAR (useCanI) before rendering
  - Shows ConfirmDialog for destructive actions
  - Reports loading state during execution

### Tests

- **`pkg/agent/federation/providers/ocm_actions_test.go`** — Action descriptor validation, ActionProvider interface conformance, error classifier unit tests

## Test plan

- [ ] `go test ./pkg/agent/federation/providers/...` passes
- [ ] `go vet ./pkg/agent/...` clean
- [ ] CI build/lint pass
- [ ] Manual: POST to `/federation/action` with a valid OCM hub returns expected ActionResult
- [ ] Manual: FederationActionButton renders only when SSAR allows
- [ ] Manual: Destructive actions show ConfirmDialog before executing