### PR TITLE
feat: add Karmada federation actions (PR G)

### DIFF
--- a/pkg/agent/federation/actions.go
+++ b/pkg/agent/federation/actions.go
@@ -38,7 +38,7 @@ type ActionRequest struct {
 	// for hub-scoped actions (e.g. approving a CSR by name in Payload).
 	ClusterName string `json:"clusterName,omitempty"`
 	// Payload carries action-specific parameters (e.g. taint key/value/effect
-	// for ocm.taintCluster). Keys are action-defined.
+	// for karmada.taintCluster). Keys are action-defined.
 	Payload map[string]interface{} `json:"payload,omitempty"`
 }
 
@@ -47,7 +47,7 @@ type ActionResult struct {
 	// OK is true when the action completed successfully.
 	OK bool `json:"ok"`
 	// Already is true when the action was a no-op because the desired state
-	// already existed (e.g. cluster already accepted, CSR already approved).
+	// already existed (e.g. cluster already joined, taint already present).
 	// OK is also true when Already is true.
 	Already bool `json:"already"`
 	// Message carries a human-readable status string on both success and

--- a/pkg/agent/federation/providers/karmada_actions.go
+++ b/pkg/agent/federation/providers/karmada_actions.go
@@ -1,0 +1,246 @@
+package providers
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/rest"
+
+	"github.com/kubestellar/console/pkg/agent/federation"
+)
+
+// Karmada action IDs — stable identifiers referenced by the UI and tests.
+const (
+	karmadaActionJoinCluster   = "karmada.joinCluster"
+	karmadaActionUnjoinCluster = "karmada.unjoinCluster"
+	karmadaActionTaintCluster  = "karmada.taintCluster"
+)
+
+// Actions returns the set of imperative actions the Karmada provider supports.
+// See ActionProvider interface in pkg/agent/federation/actions.go.
+func (p *karmadaProvider) Actions() []federation.ActionDescriptor {
+	return []federation.ActionDescriptor{
+		{
+			ID:          karmadaActionJoinCluster,
+			Label:       "Join Cluster",
+			Verb:        "create",
+			Provider:    federation.ProviderKarmada,
+			Destructive: false,
+		},
+		{
+			ID:          karmadaActionUnjoinCluster,
+			Label:       "Unjoin Cluster",
+			Verb:        "delete",
+			Provider:    federation.ProviderKarmada,
+			Destructive: true,
+		},
+		{
+			ID:          karmadaActionTaintCluster,
+			Label:       "Taint Cluster",
+			Verb:        "patch",
+			Provider:    federation.ProviderKarmada,
+			Destructive: false,
+		},
+	}
+}
+
+// Execute dispatches the action request to the appropriate Karmada handler.
+func (p *karmadaProvider) Execute(ctx context.Context, cfg *rest.Config, req federation.ActionRequest) (federation.ActionResult, error) {
+	switch req.ActionID {
+	case karmadaActionJoinCluster:
+		return executeKarmadaJoinCluster(ctx, cfg, req)
+	case karmadaActionUnjoinCluster:
+		return executeKarmadaUnjoinCluster(ctx, cfg, req)
+	case karmadaActionTaintCluster:
+		return executeKarmadaTaintCluster(ctx, cfg, req)
+	default:
+		return federation.ActionResult{}, fmt.Errorf("unknown Karmada action: %s", req.ActionID)
+	}
+}
+
+// executeKarmadaJoinCluster creates a clusters.cluster.karmada.io resource to
+// register a cluster with the Karmada control plane. The cluster name comes
+// from req.ClusterName; the API server endpoint is expected in
+// Payload["apiEndpoint"]. Idempotent — if the Cluster CR already exists,
+// returns Already=true.
+func executeKarmadaJoinCluster(ctx context.Context, cfg *rest.Config, req federation.ActionRequest) (federation.ActionResult, error) {
+	if req.ClusterName == "" {
+		return federation.ActionResult{}, fmt.Errorf("clusterName is required for %s", karmadaActionJoinCluster)
+	}
+	apiEndpoint, _ := req.Payload["apiEndpoint"].(string)
+	if apiEndpoint == "" {
+		return federation.ActionResult{}, fmt.Errorf("payload.apiEndpoint is required for %s", karmadaActionJoinCluster)
+	}
+
+	dc, err := dynamic.NewForConfig(cfg)
+	if err != nil {
+		return federation.ActionResult{}, fmt.Errorf("building dynamic client: %w", err)
+	}
+
+	// Check if the Cluster CR already exists — idempotency guard.
+	_, err = dc.Resource(karmadaClusterGVR).Get(ctx, req.ClusterName, metav1.GetOptions{})
+	if err == nil {
+		return federation.ActionResult{
+			OK:      true,
+			Already: true,
+			Message: fmt.Sprintf("Karmada Cluster %s already exists", req.ClusterName),
+		}, nil
+	}
+	if !isNotFoundError(err) {
+		return federation.ActionResult{}, fmt.Errorf("checking Cluster %s: %w", req.ClusterName, err)
+	}
+
+	// Build the minimal Cluster CR.
+	clusterObj := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "cluster.karmada.io/v1alpha1",
+			"kind":       "Cluster",
+			"metadata": map[string]interface{}{
+				"name": req.ClusterName,
+			},
+			"spec": map[string]interface{}{
+				"apiEndpoint": apiEndpoint,
+				"syncMode":    "Pull",
+			},
+		},
+	}
+
+	_, err = dc.Resource(karmadaClusterGVR).Create(ctx, clusterObj, metav1.CreateOptions{})
+	if err != nil {
+		if isConflictError(err) {
+			// Race: another actor created it between our Get and Create.
+			return federation.ActionResult{
+				OK:      true,
+				Already: true,
+				Message: fmt.Sprintf("Karmada Cluster %s already exists (conflict)", req.ClusterName),
+			}, nil
+		}
+		return federation.ActionResult{}, fmt.Errorf("creating Karmada Cluster %s: %w", req.ClusterName, err)
+	}
+
+	return federation.ActionResult{
+		OK:      true,
+		Message: fmt.Sprintf("Karmada Cluster %s created", req.ClusterName),
+	}, nil
+}
+
+// executeKarmadaUnjoinCluster deletes the clusters.cluster.karmada.io resource
+// to remove a cluster from the Karmada control plane. This is destructive —
+// the UI MUST confirm before calling. If the Cluster CR does not exist,
+// returns Already=true (idempotent).
+func executeKarmadaUnjoinCluster(ctx context.Context, cfg *rest.Config, req federation.ActionRequest) (federation.ActionResult, error) {
+	if req.ClusterName == "" {
+		return federation.ActionResult{}, fmt.Errorf("clusterName is required for %s", karmadaActionUnjoinCluster)
+	}
+
+	dc, err := dynamic.NewForConfig(cfg)
+	if err != nil {
+		return federation.ActionResult{}, fmt.Errorf("building dynamic client: %w", err)
+	}
+
+	err = dc.Resource(karmadaClusterGVR).Delete(ctx, req.ClusterName, metav1.DeleteOptions{})
+	if err != nil {
+		if isNotFoundError(err) {
+			return federation.ActionResult{
+				OK:      true,
+				Already: true,
+				Message: fmt.Sprintf("Karmada Cluster %s already deleted", req.ClusterName),
+			}, nil
+		}
+		return federation.ActionResult{}, fmt.Errorf("deleting Karmada Cluster %s: %w", req.ClusterName, err)
+	}
+
+	return federation.ActionResult{
+		OK:      true,
+		Message: fmt.Sprintf("Karmada Cluster %s deleted", req.ClusterName),
+	}, nil
+}
+
+// executeKarmadaTaintCluster adds a taint to the Karmada Cluster's spec.taints.
+// The taint is specified in Payload as "key", "value", "effect". If the exact
+// taint already exists on the cluster, returns Already=true (idempotent).
+func executeKarmadaTaintCluster(ctx context.Context, cfg *rest.Config, req federation.ActionRequest) (federation.ActionResult, error) {
+	if req.ClusterName == "" {
+		return federation.ActionResult{}, fmt.Errorf("clusterName is required for %s", karmadaActionTaintCluster)
+	}
+
+	taintKey, _ := req.Payload["key"].(string)
+	taintValue, _ := req.Payload["value"].(string)
+	taintEffect, _ := req.Payload["effect"].(string)
+	if taintKey == "" || taintEffect == "" {
+		return federation.ActionResult{}, fmt.Errorf("payload.key and payload.effect are required for %s", karmadaActionTaintCluster)
+	}
+
+	dc, err := dynamic.NewForConfig(cfg)
+	if err != nil {
+		return federation.ActionResult{}, fmt.Errorf("building dynamic client: %w", err)
+	}
+
+	current, err := dc.Resource(karmadaClusterGVR).Get(ctx, req.ClusterName, metav1.GetOptions{})
+	if err != nil {
+		return federation.ActionResult{}, fmt.Errorf("getting Karmada Cluster %s: %w", req.ClusterName, err)
+	}
+
+	existingTaints, _, _ := unstructured.NestedSlice(current.Object, "spec", "taints")
+
+	// Check if the exact taint already exists — idempotency guard.
+	for _, t := range existingTaints {
+		tm, ok := t.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		k, _ := tm["key"].(string)
+		v, _ := tm["value"].(string)
+		e, _ := tm["effect"].(string)
+		if k == taintKey && v == taintValue && e == taintEffect {
+			return federation.ActionResult{
+				OK:      true,
+				Already: true,
+				Message: fmt.Sprintf("taint %s=%s:%s already exists on Karmada Cluster %s", taintKey, taintValue, taintEffect, req.ClusterName),
+			}, nil
+		}
+	}
+
+	// Append the new taint and patch.
+	newTaint := map[string]interface{}{
+		"key":    taintKey,
+		"value":  taintValue,
+		"effect": taintEffect,
+	}
+	updatedTaints := append(existingTaints, newTaint)
+
+	patchBody := map[string]interface{}{
+		"spec": map[string]interface{}{
+			"taints": updatedTaints,
+		},
+	}
+	patchBytes, err := json.Marshal(patchBody)
+	if err != nil {
+		return federation.ActionResult{}, fmt.Errorf("marshaling taint patch: %w", err)
+	}
+
+	_, err = dc.Resource(karmadaClusterGVR).Patch(ctx, req.ClusterName, types.MergePatchType, patchBytes, metav1.PatchOptions{})
+	if err != nil {
+		if isConflictError(err) {
+			return federation.ActionResult{
+				OK:      true,
+				Already: true,
+				Message: "patch conflict — taint may already exist",
+			}, nil
+		}
+		return federation.ActionResult{}, fmt.Errorf("patching taints on Karmada Cluster %s: %w", req.ClusterName, err)
+	}
+
+	return federation.ActionResult{
+		OK:      true,
+		Message: fmt.Sprintf("taint %s=%s:%s added to Karmada Cluster %s", taintKey, taintValue, taintEffect, req.ClusterName),
+	}, nil
+}
+
+// Ensure compile-time ActionProvider conformance.
+var _ federation.ActionProvider = (*karmadaProvider)(nil)

--- a/pkg/agent/federation/providers/karmada_actions_test.go
+++ b/pkg/agent/federation/providers/karmada_actions_test.go
@@ -1,0 +1,93 @@
+package providers
+
+import (
+	"testing"
+
+	"github.com/kubestellar/console/pkg/agent/federation"
+)
+
+func TestKarmadaProviderActions(t *testing.T) {
+	p := &karmadaProvider{}
+	actions := p.Actions()
+
+	// Karmada exposes exactly 3 actions in Phase 2.
+	const expectedActionCount = 3
+	if len(actions) != expectedActionCount {
+		t.Fatalf("expected %d actions, got %d", expectedActionCount, len(actions))
+	}
+
+	// Build a lookup by ID for easier per-action assertions.
+	byID := map[string]federation.ActionDescriptor{}
+	for _, a := range actions {
+		byID[a.ID] = a
+	}
+
+	// All actions should be owned by the Karmada provider.
+	for _, a := range actions {
+		if a.Provider != federation.ProviderKarmada {
+			t.Errorf("action %s has provider %s, expected karmada", a.ID, a.Provider)
+		}
+	}
+
+	// joinCluster: create verb, non-destructive.
+	if a, ok := byID[karmadaActionJoinCluster]; !ok {
+		t.Error("missing action karmada.joinCluster")
+	} else {
+		if a.Verb != "create" {
+			t.Errorf("joinCluster verb = %s, want create", a.Verb)
+		}
+		if a.Destructive {
+			t.Error("joinCluster should not be destructive")
+		}
+	}
+
+	// unjoinCluster: delete verb, destructive.
+	if a, ok := byID[karmadaActionUnjoinCluster]; !ok {
+		t.Error("missing action karmada.unjoinCluster")
+	} else {
+		if a.Verb != "delete" {
+			t.Errorf("unjoinCluster verb = %s, want delete", a.Verb)
+		}
+		if !a.Destructive {
+			t.Error("unjoinCluster should be destructive")
+		}
+	}
+
+	// taintCluster: patch verb, non-destructive.
+	if a, ok := byID[karmadaActionTaintCluster]; !ok {
+		t.Error("missing action karmada.taintCluster")
+	} else {
+		if a.Verb != "patch" {
+			t.Errorf("taintCluster verb = %s, want patch", a.Verb)
+		}
+		if a.Destructive {
+			t.Error("taintCluster should not be destructive")
+		}
+	}
+}
+
+func TestKarmadaActionProviderInterface(t *testing.T) {
+	// Verify that karmadaProvider satisfies the ActionProvider interface at the
+	// type level. The compile-time check in karmada_actions.go catches this too,
+	// but this test makes the assertion explicit and test-discoverable.
+	var p federation.Provider = &karmadaProvider{}
+	ap, ok := p.(federation.ActionProvider)
+	if !ok {
+		t.Fatal("karmadaProvider does not implement ActionProvider")
+	}
+	if ap.Name() != federation.ProviderKarmada {
+		t.Errorf("expected provider name karmada, got %s", ap.Name())
+	}
+}
+
+func TestKarmadaExecuteUnknownAction(t *testing.T) {
+	p := &karmadaProvider{}
+	req := federation.ActionRequest{
+		ActionID: "karmada.nonexistent",
+		Provider: federation.ProviderKarmada,
+	}
+	_, err := p.Execute(nil, nil, req)
+	if err == nil {
+		t.Error("expected error for unknown action")
+	}
+}


### PR DESCRIPTION
## Summary
- Adds `karmada_actions.go` implementing `ActionProvider` for Karmada
- Three actions: `karmada.joinCluster` (idempotent create), `karmada.unjoinCluster` (destructive delete), `karmada.taintCluster` (idempotent patch)
- All actions idempotent with conflict/not-found handling matching OCM patterns
- Adds `action_errors.go` to consolidate `isConflictError`/`isNotFoundError` helpers shared across action providers (extracted from PR F's `ocm_actions.go`)
- Forward-ports `actions.go` (ActionProvider interface) from PR F so this branch builds and tests standalone
- Tests for action descriptors (count, IDs, verbs, destructive flags), interface conformance, and unknown action error

## Test plan
- [ ] `go test ./pkg/agent/federation/providers/... -run TestKarmada`
- [ ] CI build/lint pass

## Notes on merge order
This PR depends on #9397 (PR F — action framework). When merging:
1. Merge PR F first
2. Before merging this PR, remove the forward-ported `pkg/agent/federation/actions.go` (duplicate of PR F's copy) and reconcile `isConflictError`/`isNotFoundError` between `ocm_actions.go` and `action_errors.go`

Depends on: #9397 (PR F — action framework)