### PR TITLE
fix: None filter button flashes but does nothing

### DIFF
--- a/web/src/hooks/useGlobalFilters.tsx
+++ b/web/src/hooks/useGlobalFilters.tsx
@@ -242,9 +242,9 @@ export function GlobalFiltersProvider({ children }: { children: ReactNode }) {
   // This prevents filters from getting stuck on clusters that have been removed from kubeconfig
   useEffect(() => {
     if (selectedClusters.length === 0 || availableClusters.length === 0) return
+    if (selectedClusters.includes('__none__')) return
     const validSelections = selectedClusters.filter(c => availableClusters.includes(c))
     if (validSelections.length !== selectedClusters.length) {
-      // Some selected clusters no longer exist — fall back to "all" if none remain
       setSelectedClustersState(validSelections.length === 0 ? [] : validSelections)
     }
   }, [availableClusters, selectedClusters])


### PR DESCRIPTION
## Summary

- Fix the "None" button in the global cluster filter panel that flashed but snapped back to "All"
- Root cause: reconciliation `useEffect` validated `selectedClusters` against `availableClusters`, stripping the `__none__` sentinel (not a real cluster name), which reset state to `[]` (all selected)
- Added early return when `__none__` sentinel is present to preserve the "nothing selected" state

## Test plan

- [ ] Click "None" in the cluster filter panel — all clusters should deselect
- [ ] Verify cluster-dependent cards show empty/no-data state
- [ ] Click "All" to restore — all clusters reappear
- [ ] Remove a cluster from kubeconfig, reload — reconciliation still drops stale clusters