### PR TITLE
fix: guard against null kubectlProxy responses in agent fetchers

### DIFF
--- a/web/src/hooks/mcp/workloads.ts
+++ b/web/src/hooks/mcp/workloads.ts
@@ -693,9 +693,11 @@ export function usePodIssues(cluster?: string, namespace?: string) {
         const clusterInfo = clusterCacheRef.clusters.find(c => c.name === cluster)
         const kubectlContext = clusterInfo?.context || cluster
         const podIssuesData = await kubectlProxy.getPodIssues(kubectlContext, namespace)
+        // Guard against null/undefined when proxy is disconnected or in cooldown
+        const safePodIssues = podIssuesData || []
         const now = new Date()
-        podIssuesCache = { data: podIssuesData, timestamp: now, key: cacheKey }
-        setIssues(podIssuesData)
+        podIssuesCache = { data: safePodIssues, timestamp: now, key: cacheKey }
+        setIssues(safePodIssues)
         setError(null)
         setLastUpdated(now)
         setConsecutiveFailures(0)

--- a/web/src/hooks/useCachedCoreWorkloads.ts
+++ b/web/src/hooks/useCachedCoreWorkloads.ts
@@ -403,7 +403,8 @@ export function useCachedPodIssues(
           const clusterInfo = clusterCacheRef.clusters.find(c => c.name === cluster)
           const ctx = clusterInfo?.context || cluster
           issues = await kubectlProxy.getPodIssues(ctx, namespace)
-          issues = issues.map(i => ({ ...i, cluster: cluster }))
+          // Guard against null/undefined when proxy is disconnected or in cooldown
+          issues = (issues || []).map(i => ({ ...i, cluster: cluster }))
         } else {
           issues = await fetchPodIssuesViaAgent(namespace)
         }

--- a/web/src/hooks/useCachedData/agentFetchers.ts
+++ b/web/src/hooks/useCachedData/agentFetchers.ts
@@ -48,7 +48,8 @@ export async function fetchPodIssuesViaAgent(namespace?: string, onProgress?: (p
     const ctx = context || name
     const issues = await kubectlProxy.getPodIssues(ctx, namespace)
     // Always use the short name — kubectlProxy returns context path as cluster
-    return issues.map(i => ({ ...i, cluster: name }))
+    // Guard against null/undefined when proxy is disconnected or in cooldown
+    return (issues || []).map(i => ({ ...i, cluster: name }))
   })
 
   const accumulated: PodIssue[] = []


### PR DESCRIPTION
## Summary
- Adds defensive `(data || [])` guards before `.map()` calls on `kubectlProxy.getPodIssues()` results in three files: `agentFetchers.ts`, `useCachedCoreWorkloads.ts`, and `mcp/workloads.ts`
- Prevents `TypeError: Cannot read properties of null (reading 'map')` when the kubectl proxy is disconnected or in cooldown during local agent fallback

## Test plan
- [ ] Disconnect kc-agent or trigger WebSocket timeout, navigate to Pods/Issues view — no crash
- [ ] Verify normal operation still works when proxy is connected

Fixes #9404