### PR TITLE
fix: guard against nil pointer in RewardsHandler.fetchUserRewardsForBadge

### DIFF
--- a/pkg/api/handlers/rewards.go
+++ b/pkg/api/handlers/rewards.go
@@ -95,7 +95,7 @@ func (h *RewardsHandler) GetGitHubRewards(c *fiber.Ctx) error {
 
 	// Check cache
 	h.mu.RLock()
-	if entry, ok := h.cache[githubLogin]; ok && time.Since(entry.fetchedAt) < rewardsCacheTTL {
+	if entry, ok := h.cache[githubLogin]; ok && time.Since(entry.fetchedAt) < rewardsCacheTTL && entry.response != nil {
 		h.mu.RUnlock()
 		resp := *entry.response
 		resp.FromCache = true
@@ -113,7 +113,7 @@ func (h *RewardsHandler) GetGitHubRewards(c *fiber.Ctx) error {
 
 		// Return stale cache if available
 		h.mu.RLock()
-		if entry, ok := h.cache[githubLogin]; ok {
+		if entry, ok := h.cache[githubLogin]; ok && entry.response != nil {
 			h.mu.RUnlock()
 			stale := *entry.response
 			stale.FromCache = true

--- a/pkg/api/handlers/rewards_badge.go
+++ b/pkg/api/handlers/rewards_badge.go
@@ -83,6 +83,9 @@ func (h *RewardsHandler) fetchUserRewardsForBadge(login string) (*GitHubRewardsR
 	h.mu.RLock()
 	if entry, ok := h.cache[login]; ok && time.Since(entry.fetchedAt) < rewardsCacheTTL {
 		h.mu.RUnlock()
+		if entry.response == nil {
+			return nil, true, errBadgeUnknownLogin
+		}
 		resp := *entry.response
 		return &resp, true, nil
 	}


### PR DESCRIPTION
## Summary

- Add nil checks for `entry.response` before dereferencing cached rewards entries in `rewards_badge.go` and `rewards.go`
- Prevents SIGSEGV panic if a cache entry exists with a nil response pointer (race condition or future refactor)
- Three dereference sites fixed: badge cache hit, fresh cache hit, and stale cache fallback

Fixes #9403

## Test plan

- [ ] CI build and lint pass
- [ ] Existing rewards and badge handler tests continue to pass
- [ ] Verify nil-response cache entries no longer cause panics