### PR TITLE
fix: allow reconciliation to drop __none__ cluster sentinel

### DIFF
--- a/web/src/hooks/useGlobalFilters.tsx
+++ b/web/src/hooks/useGlobalFilters.tsx
@@ -238,11 +238,12 @@ export function GlobalFiltersProvider({ children }: { children: ReactNode }) {
     return []
   })
 
-  // Reconcile selected clusters against available clusters — drop any that no longer exist
-  // This prevents filters from getting stuck on clusters that have been removed from kubeconfig
+  // Reconcile selected clusters against available clusters — drop any that no longer exist.
+  // This prevents filters from getting stuck on clusters that have been removed from kubeconfig.
+  // Also reconciles the __none__ sentinel (from deselectAllClusters) back to all-selected
+  // mode, since __none__ is not a real cluster name and will be filtered out.
   useEffect(() => {
     if (selectedClusters.length === 0 || availableClusters.length === 0) return
-    if (selectedClusters.includes('__none__')) return
     const validSelections = selectedClusters.filter(c => availableClusters.includes(c))
     if (validSelections.length !== selectedClusters.length) {
       setSelectedClustersState(validSelections.length === 0 ? [] : validSelections)


### PR DESCRIPTION
## Summary
- Removed the `__none__` early-return guard from the cluster reconciliation `useEffect` in `useGlobalFilters`
- The guard was preventing `deselectAllClusters()` from being reconciled back to all-selected mode, since `__none__` (not a real cluster) was being preserved instead of filtered out
- This fixes 4 test failures in the Coverage Suite run #1226

## Root cause
The reconciliation effect (lines 243-250) had `if (selectedClusters.includes('__none__')) return` which skipped reconciliation entirely when `deselectAllClusters()` set the sentinel value `['__none__']`. Without reconciliation, `__none__` persisted as the selected cluster, causing `filterByCluster` to return an empty array instead of reverting to all-selected mode.

## Test plan
- [x] All 181 tests in the 3 affected test files pass locally
- [x] CI build/lint will verify no regressions

Fixes #9414