### PR TITLE
fix: 30s tagline rotation with random transitions + modal z-index

### DIFF
--- a/web/src/components/layout/navbar/Navbar.tsx
+++ b/web/src/components/layout/navbar/Navbar.tsx
@@ -60,7 +60,7 @@ export function Navbar({ topOffset = 0 }: NavbarProps) {
   }, [location.pathname])
 
   return (
-    <nav data-tour="navbar" style={{ top: topOffset }} className="fixed left-0 right-0 h-16 glass z-toast px-3 md:px-6 flex items-center justify-between">
+    <nav data-tour="navbar" style={{ top: topOffset }} className="fixed left-0 right-0 h-16 glass z-sticky px-3 md:px-6 flex items-center justify-between">
       {/* Left side: Hamburger + Logo — shrink-0 so logo is never compressed */}
       <div className="flex items-center gap-2 md:gap-3 shrink-0">
         {/* Hamburger menu - mobile only */}

--- a/web/src/components/layout/navbar/RotatingTagline.tsx
+++ b/web/src/components/layout/navbar/RotatingTagline.tsx
@@ -1,16 +1,8 @@
-import { useState, useEffect, useCallback } from 'react'
+import { useState, useEffect, useCallback, useMemo } from 'react'
 
-/** Interval between tagline rotations (ms). Long enough that users absorb it
- *  subconsciously — the tagline is ambient branding, not a ticker. */
-const ROTATION_INTERVAL_MS = 180_000
-/** Duration of the fade transition (ms). */
-const FADE_DURATION_MS = 600
+const ROTATION_INTERVAL_MS = 30_000
+const TRANSITION_DURATION_MS = 600
 
-/**
- * Static taglines that rotate in the sidebar header. A random one is
- * picked on every page load so returning visitors see variety instead
- * of the same line every time.
- */
 const TAGLINES: readonly string[] = [
   'multi-cluster first, saving time and tokens',
   'not a dashboard — THIS is AI Ops',
@@ -22,34 +14,80 @@ const TAGLINES: readonly string[] = [
   'AI-driven multi-cluster management',
 ] as const
 
-/** Pick a random index in [0, length). Used once at mount time so
- *  each page load starts on a different tagline. */
-function randomStart(length: number): number {
+type TransitionStyle = 'fade' | 'slideUp' | 'slideDown' | 'slideLeft' | 'blur' | 'scaleDown'
+
+const TRANSITIONS: readonly TransitionStyle[] = [
+  'fade', 'slideUp', 'slideDown', 'slideLeft', 'blur', 'scaleDown',
+] as const
+
+function randomIndex(length: number): number {
   return Math.floor(Math.random() * length)
 }
 
-/**
- * RotatingTagline cycles through a set of static taglines with a smooth
- * fade transition. Starts on a random tagline on every page load. When
- * a live AI agent is connected, an AI-generated tagline (contextual to
- * user behavior) can be injected into the rotation.
- */
-export function RotatingTagline({ aiTagline }: { aiTagline?: string }) {
-  // Build the full list: static taglines + optional AI-generated one
-  const allTaglines = aiTagline
-    ? [...TAGLINES, aiTagline]
-    : TAGLINES
+function pickTransition(): TransitionStyle {
+  return TRANSITIONS[randomIndex(TRANSITIONS.length)]
+}
 
-  const [index, setIndex] = useState(() => randomStart(allTaglines.length))
+function getTransitionCSS(transition: TransitionStyle, visible: boolean): React.CSSProperties {
+  const duration = `${TRANSITION_DURATION_MS}ms`
+  const easing = 'cubic-bezier(0.4, 0, 0.2, 1)'
+
+  switch (transition) {
+    case 'fade':
+      return {
+        opacity: visible ? 1 : 0,
+        transition: `opacity ${duration} ${easing}`,
+      }
+    case 'slideUp':
+      return {
+        opacity: visible ? 1 : 0,
+        transform: visible ? 'translateY(0)' : 'translateY(-8px)',
+        transition: `opacity ${duration} ${easing}, transform ${duration} ${easing}`,
+      }
+    case 'slideDown':
+      return {
+        opacity: visible ? 1 : 0,
+        transform: visible ? 'translateY(0)' : 'translateY(8px)',
+        transition: `opacity ${duration} ${easing}, transform ${duration} ${easing}`,
+      }
+    case 'slideLeft':
+      return {
+        opacity: visible ? 1 : 0,
+        transform: visible ? 'translateX(0)' : 'translateX(-12px)',
+        transition: `opacity ${duration} ${easing}, transform ${duration} ${easing}`,
+      }
+    case 'blur':
+      return {
+        opacity: visible ? 1 : 0,
+        filter: visible ? 'blur(0)' : 'blur(4px)',
+        transition: `opacity ${duration} ${easing}, filter ${duration} ${easing}`,
+      }
+    case 'scaleDown':
+      return {
+        opacity: visible ? 1 : 0,
+        transform: visible ? 'scale(1)' : 'scale(0.92)',
+        transition: `opacity ${duration} ${easing}, transform ${duration} ${easing}`,
+      }
+  }
+}
+
+export function RotatingTagline({ aiTagline }: { aiTagline?: string }) {
+  const allTaglines = useMemo(
+    () => (aiTagline ? [...TAGLINES, aiTagline] : TAGLINES),
+    [aiTagline],
+  )
+
+  const [index, setIndex] = useState(() => randomIndex(allTaglines.length))
   const [visible, setVisible] = useState(true)
+  const [transition, setTransition] = useState<TransitionStyle>('fade')
 
   const advance = useCallback(() => {
-    // Fade out, swap text, fade in
+    setTransition(pickTransition())
     setVisible(false)
     const tid = setTimeout(() => {
       setIndex(prev => (prev + 1) % allTaglines.length)
       setVisible(true)
-    }, FADE_DURATION_MS)
+    }, TRANSITION_DURATION_MS)
     return () => clearTimeout(tid)
   }, [allTaglines.length])
 
@@ -58,16 +96,12 @@ export function RotatingTagline({ aiTagline }: { aiTagline?: string }) {
     return () => clearInterval(id)
   }, [advance])
 
-  // Clamp index if tagline list shrinks (AI tagline removed)
   const safeIndex = index < allTaglines.length ? index : 0
 
   return (
     <span
-      className="text-[10px] text-muted-foreground tracking-wide transition-opacity"
-      style={{
-        opacity: visible ? 1 : 0,
-        transitionDuration: `${FADE_DURATION_MS}ms`,
-      }}
+      className="text-[10px] text-muted-foreground tracking-wide inline-block"
+      style={getTransitionCSS(transition, visible)}
     >
       {allTaglines[safeIndex]}
     </span>


### PR DESCRIPTION
## Summary

- Tagline now rotates every 30s (was 3min) with random transition effects: fade, slideUp, slideDown, slideLeft, blur, scaleDown
- Fixed navbar z-index from `z-toast` (500) to `z-sticky` (200) so modals (like ACMM intro) render above the navbar instead of behind it

## Test plan

- [ ] Watch tagline rotate — should change every 30s with varied animations
- [ ] Open ACMM intro modal — should render fully above the navbar
- [ ] Verify navbar dropdowns (filter, agent, learn) still work correctly