### PR TITLE
fix: close feedback modal on outside click

### DIFF
--- a/web/src/components/feedback/FeatureRequestModal.tsx
+++ b/web/src/components/feedback/FeatureRequestModal.tsx
@@ -256,7 +256,7 @@ export function FeatureRequestModal({ isOpen, onClose, initialTab, initialReques
   }, [forceClose])
 
   return (
-    <BaseModal isOpen={isOpen} onClose={handleClose} size="lg" closeOnBackdrop={false} closeOnEscape={true} className="!h-[80vh]">
+    <BaseModal isOpen={isOpen} onClose={handleClose} size="lg" closeOnBackdrop={true} closeOnEscape={true} className="!h-[80vh]">
       {/* Discard/Save Draft confirmation */}
       {showDiscardConfirm && (
         <DiscardConfirmDialog


### PR DESCRIPTION
## Summary
- The FeatureRequestModal (Contribute dialog) had `closeOnBackdrop={false}` on its `BaseModal` wrapper, which prevented clicking outside the modal from closing it
- Changed to `closeOnBackdrop={true}` so backdrop clicks route through the existing `handleClose` flow, which correctly shows the unsaved-changes confirmation when the user has typed content

## Test plan
- [ ] Open the Contribute modal (via profile dropdown or feedback button)
- [ ] Click outside the modal on the dimmed backdrop — modal should close
- [ ] Type some text in the description, then click outside — should show "Discard unsaved changes?" confirmation
- [ ] After successful submission, click outside — should close without confirmation

Fixes #9419