### PR TITLE
fix: prevent stats overview label truncation on My Clusters page

### DIFF
--- a/web/src/components/clusters/components/StatsOverview.tsx
+++ b/web/src/components/clusters/components/StatsOverview.tsx
@@ -265,13 +265,11 @@ export function StatsOverview({
   }
 
   // Dynamic grid columns based on visible blocks.
-  // For 7+ blocks we keep two rows on lg (1024px) and only collapse to a single
-  // row at xl (1280px+) where each card is wide enough to show its full label
-  // without ellipsis truncation
-  const gridCols = visibleBlocks.length <= 5 ? 'grid-cols-5' :
-    visibleBlocks.length <= 6 ? 'grid-cols-6' :
-    visibleBlocks.length <= 8 ? 'grid-cols-4 xl:grid-cols-8' :
-    'grid-cols-5 xl:grid-cols-10'
+  // Cap at 5 columns per row so every label (e.g. "Unhealthy", "Storage")
+  // remains fully readable without mid-word breaks or truncation.
+  // Blocks beyond 5 simply wrap to a second row.
+  const gridCols = visibleBlocks.length <= 4 ? 'grid-cols-2 md:grid-cols-4' :
+    'grid-cols-2 md:grid-cols-3 lg:grid-cols-5'
 
   return (
     <div className="relative mb-6">

--- a/web/src/components/ui/StatsOverview.tsx
+++ b/web/src/components/ui/StatsOverview.tsx
@@ -487,14 +487,11 @@ export function StatsOverview({
 
   // Dynamic grid columns based on visible blocks.
   // Mobile: max 2 columns, tablet+: responsive based on count.
-  // For 7+ blocks we keep two rows on lg (1024px) and only collapse to a single
-  // row at xl (1280px+) where each card is wide enough to show its full label
-  // without ellipsis truncation
+  // Cap at 5 columns per row so every label (e.g. "Unhealthy", "Storage")
+  // remains fully readable without mid-word breaks or truncation.
+  // Blocks beyond 5 simply wrap to a second row.
   const gridCols = visibleBlocks.length <= 4 ? 'grid-cols-2 md:grid-cols-4' :
-    visibleBlocks.length <= 5 ? 'grid-cols-2 md:grid-cols-5' :
-    visibleBlocks.length <= 6 ? 'grid-cols-2 md:grid-cols-3 lg:grid-cols-6' :
-    visibleBlocks.length <= 8 ? 'grid-cols-2 md:grid-cols-4 xl:grid-cols-8' :
-    'grid-cols-2 md:grid-cols-5 xl:grid-cols-10'
+    'grid-cols-2 md:grid-cols-3 lg:grid-cols-5'
 
   return (
     <div className={`mb-6 ${className}`}>


### PR DESCRIPTION
## Summary
- Caps the stat grid at 5 columns per row so labels like "Unhealthy", "Storage", and "Clusters" remain fully readable at all viewport widths
- Blocks beyond 5 wrap to a second row instead of being squeezed into a single row where labels break mid-word or become unreadable
- Fixes both the shared `ui/StatsOverview` and the clusters-specific `StatsOverview`

Fixes #9416

## Test plan
- [ ] Navigate to My Clusters page and verify all 10 stat labels are fully readable (no truncation or mid-word breaks)
- [ ] Verify stats display in two rows of 5 on large screens
- [ ] Verify responsive behavior: 3 columns on md, 2 columns on mobile
- [ ] Check Dashboard page stats still render correctly (6 blocks should show as 2 rows of 3 on md, 1+rows of 5 on lg)