### PR TITLE
fix: reduce excessive header spacing on My Clusters page

### DIFF
--- a/web/src/lib/dashboards/DashboardPage.tsx
+++ b/web/src/lib/dashboards/DashboardPage.tsx
@@ -344,7 +344,7 @@ export function DashboardPage({
     // fixed-position children (FAB, customizer, modals) must live OUTSIDE it
     // to avoid clipping when ancestors create a new containing block (issue 8464).
     <>
-      <div className="pt-16 min-w-0 max-w-full overflow-x-hidden" data-testid={testId}>
+      <div className="pt-4 min-w-0 max-w-full overflow-x-hidden" data-testid={testId}>
         {/* Header */}
         <DashboardHeader
           title={title}


### PR DESCRIPTION
## Summary
- Reduced top padding in `DashboardPage` from `pt-16` (64px) to `pt-4` (16px) to eliminate excessive empty space between the navbar and page content
- The Layout component already applies 64px of navbar-height padding via inline styles, so the additional 64px from `pt-16` was redundant and created visible layout imbalance
- Now matches the home Dashboard page (`pt-4`) for consistent spacing across all dashboard pages

## Test plan
- [ ] Navigate to My Clusters page — verify header spacing is reduced and content is closer to the navbar
- [ ] Navigate to other dashboard pages (Workloads, Compute, Events, etc.) — verify consistent spacing
- [ ] Compare with the home Dashboard page — spacing should now match

Fixes #9425