### PR TITLE
fix: match agent selector height to + button in compact mode

### DIFF
--- a/web/src/components/agent/AgentSelector.tsx
+++ b/web/src/components/agent/AgentSelector.tsx
@@ -603,7 +603,8 @@ export function AgentSelector({
           aria-haspopup="listbox"
           aria-expanded={isOpen}
           className={cn(
-            "flex items-center gap-2 px-3 py-1.5 h-9 rounded-lg border transition-colors",
+            "flex items-center rounded-lg border transition-colors",
+            compact ? "p-1.5 gap-1" : "px-3 py-1.5 h-9 gap-2",
             "bg-secondary/50 border-border hover:bg-secondary",
             isOpen && "ring-1 ring-primary",
           )}


### PR DESCRIPTION
## Summary
- In compact mode (sidebar/navbar), the agent selector dropdown button was taller (h-9 = 36px) than the adjacent + button (p-1.5 = ~28px)
- Now uses `p-1.5 gap-1` in compact mode to match the + button's dimensions
- Non-compact mode retains original `h-9` sizing

## Test plan
- [ ] Verify + button and agent dropdown are same height in sidebar
- [ ] Verify agent dropdown in navbar also matches
- [ ] Verify non-compact agent selector (if used) retains original sizing

🤖 Generated with [Claude Code](https://claude.com/claude-code)