### PR TITLE
fix(missions): align Kubara info button on same row as root node

### DIFF
--- a/web/src/components/missions/browser/TreeNodeItem.tsx
+++ b/web/src/components/missions/browser/TreeNodeItem.tsx
@@ -88,7 +88,7 @@ export const TreeNodeItem = memo(function TreeNodeItem({
     }
   }
 
-  const showHeaderActions = showRemoveButton || showRefreshButton || (depth === 0 && !!onAdd)
+  const showHeaderActions = showRemoveButton || showRefreshButton || (depth === 0 && !!onAdd) || (depth === 0 && !!node.infoTooltip)
 
   // Memoize inline style objects to avoid creating new references on each render
   const paddingStyle = { paddingLeft: `${depth * 16 + 8}px` }


### PR DESCRIPTION
## Summary
- `showHeaderActions` was missing the `infoTooltip` condition, so the flex wrapper was not applied when only an info tooltip button was present
- The ⓘ button rendered on the next line instead of inline with the Kubara node label
- One-line fix: add `|| (depth === 0 && !!node.infoTooltip)` to the condition

Fixes the visual regression introduced in #9424.

## Test plan
- [ ] Open Mission Browser, expand the sidebar tree
- [ ] Verify the ⓘ button appears on the same row as the Kubara catalog root node

🤖 Generated with [Claude Code](https://claude.com/claude-code)