### PR TITLE
fix: add missing user feedback on form submissions and cache refresh

### DIFF
--- a/web/src/components/acmm/RepoPicker.tsx
+++ b/web/src/components/acmm/RepoPicker.tsx
@@ -13,6 +13,7 @@ import { Input } from '../ui/Input'
 import { cn } from '../../lib/cn'
 import { useACMM, DEFAULT_REPO, normalizeRepoInput } from './ACMMProvider'
 import { ALL_CRITERIA } from '../../lib/acmm/sources'
+import { useToast } from '../ui/Toast'
 
 /** ACMM-source criteria only — used for the badge preview to match the
  *  shields.io badge endpoint which counts only ACMM criteria, not criteria
@@ -69,6 +70,7 @@ function BadgePreview({ level, levelName, detected, total }: {
 
 export function RepoPicker() {
   const { repo, setRepo, recentRepos, scan, openIntro } = useACMM()
+  const { showToast } = useToast()
   const [input, setInput] = useState(repo)
   const [error, setError] = useState<string | null>(null)
   const [showBadge, setShowBadge] = useState(false)
@@ -109,6 +111,7 @@ export function RepoPicker() {
     setError(null)
     if (normalized !== next) setInput(normalized)
     setRepo(normalized)
+    showToast(`Scanning ${normalized}`, 'success')
   }
 
   const detected = scan.data.detectedIds?.length ?? 0

--- a/web/src/components/cards/IssueActivityChart.tsx
+++ b/web/src/components/cards/IssueActivityChart.tsx
@@ -17,6 +17,7 @@ import { usePipelineFilter } from './pipelines/PipelineFilterContext'
 import { RepoSubtitle } from './pipelines/RepoSubtitle'
 import { Button } from '../ui/Button'
 import { useDemoMode } from '../../hooks/useDemoMode'
+import { useToast } from '../ui/Toast'
 import { useCardLoadingState } from './CardDataContext'
 import {
   CHART_TOOLTIP_CONTENT_STYLE,
@@ -291,6 +292,7 @@ async function fetchIssueStats(
 export function IssueActivityChart(props: { config?: IssueActivityConfig }) {
   const { t } = useTranslation('cards')
   const { isDemoMode } = useDemoMode()
+  const { showToast } = useToast()
   const shared = usePipelineFilter()
   const repo = shared?.repoFilter || props.config?.repo || DEFAULT_REPO
   const initialDays = props.config?.days || DEFAULT_LOOKBACK_DAYS
@@ -604,6 +606,7 @@ export function IssueActivityChart(props: { config?: IssueActivityConfig }) {
               // Clear cache and reload
               try { localStorage.removeItem(getCacheKey(repo, days)) } catch { /* ignore */ }
               loadData(days)
+              showToast('Chart data refreshed', 'info')
             }}
             title={t('issueActivityChart.refresh', 'Refresh')}
           >

--- a/web/src/components/missions/MissionBrowserSidebar.tsx
+++ b/web/src/components/missions/MissionBrowserSidebar.tsx
@@ -14,6 +14,7 @@ import { cn } from '../../lib/cn'
 import { SIDEBAR_WIDTH, MISSION_FILE_ACCEPT } from './missionBrowserConstants'
 import { TreeNodeItem, updateNodeInTree } from './browser'
 import type { TreeNode } from './browser'
+import { useToast } from '../ui/Toast'
 
 interface MissionBrowserSidebarProps {
   treeNodes: TreeNode[]
@@ -81,6 +82,7 @@ export function MissionBrowserSidebar({
   setExpandedNodes,
 }: MissionBrowserSidebarProps) {
   const fileInputRef = useRef<HTMLInputElement>(null)
+  const { showToast } = useToast()
 
   return (
     <div
@@ -146,6 +148,7 @@ export function MissionBrowserSidebar({
                     const val = newRepoValue.trim()
                     if (val && !watchedRepos.includes(val)) {
                       onAddRepo(val)
+                      showToast(`Repository "${val}" added`, 'success')
                     }
                     setNewRepoValue('')
                     setAddingRepo(false)
@@ -195,6 +198,7 @@ export function MissionBrowserSidebar({
                     const val = newPathValue.trim()
                     if (val && !watchedPaths.includes(val)) {
                       onAddPath(val)
+                      showToast(`Path "${val}" added`, 'success')
                     }
                     setNewPathValue('')
                     setAddingPath(false)


### PR DESCRIPTION
## Summary
- Add success toast to **RepoPicker** after repo submission (`Scanning <repo>`)
- Add success toast to **MissionBrowserSidebar** after adding a repo or path
- Add info toast to **IssueActivityChart** on cache refresh button click

Several items in the issue were triaged as false positives:
- **UserManagement.tsx** (lines 486, 535): already has `ConfirmDialog` for delete
- **ClusterGroups.tsx** (lines 286, 289, 378): already has `ConfirmDialog` for delete
- **ACMMFeedbackLoops.tsx:63**: `sessionStorage.removeItem` in a utility, not a user-facing delete
- **ClusterCosts.tsx:218**: `localStorage.removeItem` in a persistence effect, not user-facing
- **WorkloadDeployment.tsx:574, Missions.tsx:197**: localStorage for cluster filter state, not destructive
- **LLMdAIInsights.tsx**: chat form shows inline AI response as feedback — toast would be redundant

Fixes #9428