### PR TITLE
fix: show navbar upgrade spinner during helm self-upgrade

### DIFF
--- a/web/src/components/updates/WhatsNewModal.tsx
+++ b/web/src/components/updates/WhatsNewModal.tsx
@@ -5,6 +5,7 @@ import remarkGfm from 'remark-gfm'
 import remarkBreaks from 'remark-breaks'
 import { BaseModal } from '../../lib/modals'
 import { useVersionCheck } from '../../hooks/useVersionCheck'
+import { useSelfUpgrade } from '../../hooks/useSelfUpgrade'
 import { useToast } from '../ui/Toast'
 import { useTranslation } from 'react-i18next'
 import { buildReleaseNotesComponents } from '../../lib/markdown/releaseNotesComponents'
@@ -73,6 +74,7 @@ export function WhatsNewModal({ isOpen, onClose }: WhatsNewModalProps) {
     skipVersion,
     triggerUpdate,
   } = useVersionCheck()
+  const { triggerUpgrade } = useSelfUpgrade()
 
   const [updating, setUpdating] = useState(false)
   const [showPreviousReleases, setShowPreviousReleases] = useState(false)
@@ -163,12 +165,10 @@ export function WhatsNewModal({ isOpen, onClose }: WhatsNewModalProps) {
     setUpdating(true)
     try {
       if (installMethod === 'helm') {
-        const res = await fetch('/api/self-upgrade/trigger', {
-          method: 'POST',
-          signal: AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS),
-        })
-        if (!res.ok) {
-          showToast(`Update failed: ${res.status}`, 'error')
+        const tag = latestRelease?.tag ?? ''
+        const result = await triggerUpgrade(tag)
+        if (!result.success) {
+          showToast(result.error ?? 'Update failed', 'error')
           return
         }
       } else {
@@ -186,7 +186,7 @@ export function WhatsNewModal({ isOpen, onClose }: WhatsNewModalProps) {
     } finally {
       setUpdating(false)
     }
-  }, [installMethod, triggerUpdate, showToast, onClose])
+  }, [installMethod, triggerUpdate, triggerUpgrade, latestRelease?.tag, showToast, onClose])
 
   const handleSkip = useCallback(() => {
     if (latestRelease) {


### PR DESCRIPTION
## Summary

The WhatsNewModal was doing a raw `fetch('/api/self-upgrade/trigger')` for helm upgrades, bypassing the `useSelfUpgrade` hook. This meant the global `upgradeState` never transitioned from `'idle'` to `'triggering'`, so:

- The **UpdateIndicator** in the navbar never showed the spinning cyan Loader2 icon during background upgrades
- The pulsing cyan dot never appeared
- The user had no visual indication that an upgrade was running after the toast dismissed

**Fix:** Wire the helm path through `useSelfUpgrade().triggerUpgrade()`, which sets the global upgrade state and triggers restart polling. The navbar spinner now appears immediately and transitions through triggering → restarting → complete.

## Test plan

- [ ] Click "Update Now" in the What's New modal on a helm-installed console
- [ ] Verify the blue "Update running in background" toast appears
- [ ] Verify the navbar shows a spinning cyan icon with pulsing dot while the upgrade runs
- [ ] Verify the icon transitions to a green checkmark when the pod comes back
- [ ] Verify developer-mode (non-helm) updates still work unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)