### PR TITLE
fix: consistent font size across navbar buttons

### DIFF
--- a/web/src/components/layout/navbar/AgentStatusIndicator.tsx
+++ b/web/src/components/layout/navbar/AgentStatusIndicator.tsx
@@ -299,7 +299,7 @@ export function AgentStatusIndicator() {
           )}
         >
           <Loader2 className="w-4 h-4 animate-spin" />
-          <span className="text-xs font-medium hidden sm:inline whitespace-nowrap">
+          <span className="text-sm font-medium hidden sm:inline whitespace-nowrap">
             {t('agent.connecting')}
           </span>
         </div>
@@ -318,7 +318,7 @@ export function AgentStatusIndicator() {
         title={pillStyle.title}
       >
         <pillStyle.Icon className="w-4 h-4" />
-        <span className="text-xs font-medium hidden sm:inline whitespace-nowrap">
+        <span className="text-sm font-medium hidden sm:inline whitespace-nowrap">
           {pillStyle.label}
         </span>
         <span


### PR DESCRIPTION
## Summary

- Agent status pill used `text-xs` while AI Missions and Learn buttons used `text-sm`
- Updated both the connected and connecting states to `text-sm` for visual consistency

## Test plan

- [ ] Verify Agent, AI Missions, and Learn buttons are the same font size in the navbar

🤖 Generated with [Claude Code](https://claude.com/claude-code)