### PR TITLE
fix(tests): update test mocks for taint-aware filtering and DashboardPage changes

### DIFF
--- a/web/src/components/gpu/__tests__/GPUReservations.test.tsx
+++ b/web/src/components/gpu/__tests__/GPUReservations.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, afterEach } from 'vitest'
-import { render, screen, cleanup } from '@testing-library/react'
+import { render, screen, cleanup, fireEvent, act } from '@testing-library/react'
 import { MemoryRouter } from 'react-router-dom'
 import { useGPUNodes } from '../../../hooks/useMCP'
 
@@ -51,7 +51,7 @@ vi.mock('../../../hooks/useMCP', () => ({
   useClusters: () => ({
     clusters: [], isLoading: false, isRefreshing: false, refetch: vi.fn(), error: null,
   }),
-  useGPUNodes: () => ({ nodes: [], isLoading: false, refetch: vi.fn() }),
+  useGPUNodes: vi.fn(() => ({ nodes: [], isLoading: false, refetch: vi.fn() })),
   useResourceQuotas: () => ({ resourceQuotas: [] }),
   useNamespaces: () => ({ namespaces: [], isLoading: false }),
 }))
@@ -240,17 +240,17 @@ describe('GPUReservations Component', () => {
       renderGPU()
       // Switch to inventory tab
       const inventoryTab = screen.getByRole('tab', { name: /inventory/i })
-      inventoryTab.click()
+      await act(async () => { fireEvent.click(inventoryTab) })
 
-      expect(screen.getByText('cluster-a')).toBeTruthy()
-      expect(screen.getByText('cluster-b')).toBeTruthy()
-      expect(screen.getByText('NVIDIA A100')).toBeTruthy()
-      expect(screen.getByText('Google TPU v4')).toBeTruthy()
-      expect(screen.getByText('node-1')).toBeTruthy()
-      expect(screen.getByText('node-2')).toBeTruthy()
+      expect(screen.getAllByText('cluster-a').length).toBeGreaterThan(0)
+      expect(screen.getAllByText('cluster-b').length).toBeGreaterThan(0)
+      expect(screen.getAllByText('NVIDIA A100').length).toBeGreaterThan(0)
+      expect(screen.getAllByText('Google TPU v4').length).toBeGreaterThan(0)
+      expect(screen.getAllByText('node-1').length).toBeGreaterThan(0)
+      expect(screen.getAllByText('node-2').length).toBeGreaterThan(0)
     })
 
-    it('calculates usage bars correctly', () => {
+    it('calculates usage bars correctly', async () => {
       vi.mocked(useGPUNodes).mockReturnValue({
         nodes: [
           { name: 'node-1', cluster: 'cluster-a', gpuType: 'NVIDIA A100', gpuCount: 10, gpuAllocated: 7, acceleratorType: 'GPU' },
@@ -259,15 +259,13 @@ describe('GPUReservations Component', () => {
       } as any)
 
       renderGPU()
-      screen.getByRole('tab', { name: /inventory/i }).click()
+      await act(async () => { fireEvent.click(screen.getByRole('tab', { name: /inventory/i })) })
 
-      // Total should be 10, allocated 7, available 3
-      expect(screen.getByText(/10/)).toBeTruthy()
-      expect(screen.getByText(/7/)).toBeTruthy()
-      expect(screen.getByText(/3/)).toBeTruthy()
+      // Allocated/Total should show 7/10 for the node row
+      expect(screen.getByText('7/10')).toBeTruthy()
     })
 
-    it('applies taint-aware filtering', () => {
+    it('applies taint-aware filtering', async () => {
       vi.mocked(useGPUNodes).mockReturnValue({
         nodes: [
           { name: 'node-safe', cluster: 'c1', gpuType: 'A100', gpuCount: 4, gpuAllocated: 0, acceleratorType: 'GPU', taints: [] },
@@ -277,7 +275,7 @@ describe('GPUReservations Component', () => {
       } as any)
 
       renderGPU()
-      screen.getByRole('tab', { name: /inventory/i }).click()
+      await act(async () => { fireEvent.click(screen.getByRole('tab', { name: /inventory/i })) })
 
       // node-tainted should be filtered out by default (untolerated)
       expect(screen.queryByText('node-tainted')).toBeNull()

--- a/web/src/components/missions/__tests__/MissionBrowser.test.tsx
+++ b/web/src/components/missions/__tests__/MissionBrowser.test.tsx
@@ -88,6 +88,7 @@ vi.mock('../browser', () => ({
   MissionFetchErrorBanner: ({ message }: { message: string }) => <div data-testid="fetch-error">{message}</div>,
   getMissionSlug: (m: { title?: string }) => (m.title || '').toLowerCase().replace(/\s+/g, '-'),
   getMissionShareUrl: () => 'https://example.com/missions/test',
+  getKubaraConfig: vi.fn().mockResolvedValue({ baseUrl: '', repo: '', branch: '' }),
   updateNodeInTree: vi.fn((nodes: unknown[]) => nodes),
   removeNodeFromTree: vi.fn((nodes: unknown[]) => nodes),
   missionCache: {

--- a/web/src/components/nodes/__tests__/Nodes.test.tsx
+++ b/web/src/components/nodes/__tests__/Nodes.test.tsx
@@ -37,7 +37,7 @@ vi.mock('../../../hooks/useMCP', () => ({
     deduplicatedClusters: [], clusters: [], isLoading: false, isRefreshing: false,
     lastUpdated: null, refetch: vi.fn(), error: null,
   }),
-  useGPUNodes: () => ({ nodes: [] }),
+  useGPUNodes: vi.fn(() => ({ nodes: [] })),
 }))
 
 vi.mock('../../../hooks/useGlobalFilters', () => ({
@@ -60,7 +60,7 @@ vi.mock('../../../hooks/useDrillDown', () => ({
 
 vi.mock('../../../hooks/useUniversalStats', () => ({
   useUniversalStats: () => ({ getStatValue: () => ({ value: 0 }) }),
-  createMergedStatValueGetter: () => () => ({ value: 0 }),
+  createMergedStatValueGetter: (primary: Function, fallback: Function) => (id: string) => primary(id) ?? fallback(id),
 }))
 
 vi.mock('react-i18next', () => ({

--- a/web/src/lib/dashboards/__tests__/DashboardPage.test.tsx
+++ b/web/src/lib/dashboards/__tests__/DashboardPage.test.tsx
@@ -297,7 +297,7 @@ describe('DashboardPage', () => {
     // The outer wrapper is the first div inside the test render. Without an
     // explicit testId it must not emit a stray `data-testid` attribute —
     // keeps existing selectors (dashboard-page, etc.) unambiguous.
-    const wrapper = container.querySelector('div.pt-16')
+    const wrapper = container.querySelector('div.pt-4')
     expect(wrapper).not.toBeNull()
     expect(wrapper?.hasAttribute('data-testid')).toBe(false)
   })


### PR DESCRIPTION
## Summary
- **GPUReservations**: use `vi.fn()` for `useGPUNodes` mock so `mockReturnValue` works, wrap tab clicks in `act()`, use `getAllByText` for elements appearing multiple times in the inventory view, fix usage bar assertion to match actual rendered format (`7/10`)
- **MissionBrowser**: add missing `getKubaraConfig` export to the `../browser` mock (new export from PR #9432)
- **Nodes**: fix `createMergedStatValueGetter` mock to delegate to the primary getter instead of always returning `{ value: 0 }`
- **DashboardPage**: update CSS selector from `div.pt-16` to `div.pt-4` after header spacing change in PR #9427

Fixes #9435

## Test plan
- [x] All 13 previously failing tests now pass
- [x] All 39 tests across the 4 affected files pass locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)