### PR TITLE
fix: harden mixed-mode command parsing and synchronize token persistence

### DIFF
--- a/pkg/agent/server.go
+++ b/pkg/agent/server.go
@@ -123,6 +123,7 @@ type Server struct {
 
 	// Token tracking
 	tokenMux         sync.RWMutex
+	tokenFileMux     sync.Mutex // serializes file I/O in saveTokenUsage to prevent race (#9441)
 	sessionStart     time.Time
 	sessionTokensIn  int64
 	sessionTokensOut int64

--- a/pkg/agent/server_ai.go
+++ b/pkg/agent/server_ai.go
@@ -7,6 +7,7 @@ import (
 	"log/slog"
 	"net/http"
 	"os"
+	"regexp"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -20,6 +21,13 @@ import (
 // maxWSGoroutines limits concurrent chat/kubectl goroutines per connection
 // to prevent resource exhaustion from bursty or malicious traffic (#7277).
 const maxWSGoroutines = 20
+
+// cmdPrefixRe matches lines like "CMD: ...", "CMD:...", "Command: ...", or "command: ..."
+// used by extractCommandsFromResponse to parse mixed-mode thinking output (#9440).
+var cmdPrefixRe = regexp.MustCompile(`(?i)^(?:cmd|command)\s*:\s*(.+)`)
+
+// codeBlockCmdRe matches kubectl/helm/oc commands inside markdown code blocks (#9440).
+var codeBlockCmdRe = regexp.MustCompile(`^\s*(kubectl|helm|oc)\s+.+`)
 
 // wsMaxMessageBytes caps the size of any single WebSocket frame the agent
 // will accept from a client. Without this, an authenticated client could
@@ -1194,16 +1202,8 @@ User request: %s`, req.Prompt)
 		},
 	})
 
-	// Extract commands from thinking response (lines starting with CMD:)
-	var commands []string
-	for _, line := range strings.Split(thinkingResp.Content, "\n") {
-		trimmed := strings.TrimSpace(line)
-		if strings.HasPrefix(trimmed, "CMD: ") {
-			commands = append(commands, strings.TrimPrefix(trimmed, "CMD: "))
-		} else if strings.HasPrefix(trimmed, "CMD:") {
-			commands = append(commands, strings.TrimPrefix(trimmed, "CMD:"))
-		}
-	}
+	// Extract commands from thinking response using robust heuristics (#9440).
+	commands := extractCommandsFromResponse(thinkingResp.Content)
 
 	if len(commands) == 0 {
 		// No commands to execute - just return thinking response
@@ -1572,8 +1572,13 @@ func (s *Server) loadTokenUsage() {
 	}
 }
 
-// saveTokenUsage persists token usage to disk
+// saveTokenUsage persists token usage to disk.
+// tokenFileMux serializes the entire read-snapshot-write cycle so concurrent
+// goroutines spawned by addTokenUsage cannot clobber each other (#9441).
 func (s *Server) saveTokenUsage() {
+	s.tokenFileMux.Lock()
+	defer s.tokenFileMux.Unlock()
+
 	s.tokenMux.RLock()
 	usage := tokenUsageData{
 		Date:      s.todayDate,
@@ -1598,6 +1603,54 @@ func (s *Server) saveTokenUsage() {
 	if err := os.Rename(tmpPath, path); err != nil {
 		slog.Warn("could not rename token usage temp file", "error", err)
 	}
+}
+
+// extractCommandsFromResponse parses an LLM thinking response to find
+// executable commands. It handles multiple formats (#9440):
+//   - Lines prefixed with "CMD: ", "CMD:", "Command: ", "command:" (case-insensitive)
+//   - kubectl/helm/oc commands inside markdown fenced code blocks (```...```)
+//   - Bare kubectl/helm/oc commands on standalone lines
+func extractCommandsFromResponse(content string) []string {
+	var commands []string
+	seen := make(map[string]bool) // deduplicate commands
+	inCodeBlock := false
+
+	for _, line := range strings.Split(content, "\n") {
+		trimmed := strings.TrimSpace(line)
+
+		// Track markdown fenced code block boundaries
+		if strings.HasPrefix(trimmed, "```") {
+			inCodeBlock = !inCodeBlock
+			continue
+		}
+
+		// 1. Check for CMD:/Command: prefix (case-insensitive)
+		if m := cmdPrefixRe.FindStringSubmatch(trimmed); m != nil {
+			cmd := strings.TrimSpace(m[1])
+			if cmd != "" && !seen[cmd] {
+				seen[cmd] = true
+				commands = append(commands, cmd)
+			}
+			continue
+		}
+
+		// 2. Inside a code block, accept kubectl/helm/oc commands
+		if inCodeBlock {
+			if codeBlockCmdRe.MatchString(trimmed) && !seen[trimmed] {
+				seen[trimmed] = true
+				commands = append(commands, trimmed)
+			}
+			continue
+		}
+
+		// 3. Bare kubectl/helm/oc commands outside code blocks (standalone lines)
+		if codeBlockCmdRe.MatchString(trimmed) && !seen[trimmed] {
+			seen[trimmed] = true
+			commands = append(commands, trimmed)
+		}
+	}
+
+	return commands
 }
 
 // KeyStatus represents the status of an API key for a provider

--- a/pkg/agent/server_ai_test.go
+++ b/pkg/agent/server_ai_test.go
@@ -254,3 +254,72 @@ func TestServer_SessionIDGeneration(t *testing.T) {
 		t.Errorf("Generated SessionID is not a valid UUID: %v", err)
 	}
 }
+
+// TestExtractCommandsFromResponse covers robust command extraction (#9440).
+func TestExtractCommandsFromResponse(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []string
+	}{
+		{
+			name:     "CMD with space prefix",
+			input:    "Analysis done.\nCMD: kubectl get pods\nCMD: kubectl get svc",
+			expected: []string{"kubectl get pods", "kubectl get svc"},
+		},
+		{
+			name:     "CMD without space",
+			input:    "CMD:kubectl get pods",
+			expected: []string{"kubectl get pods"},
+		},
+		{
+			name:     "Command prefix case-insensitive",
+			input:    "Command: kubectl get nodes\ncommand: helm list",
+			expected: []string{"kubectl get nodes", "helm list"},
+		},
+		{
+			name:     "markdown code block",
+			input:    "Here are the commands:\n```bash\nkubectl get pods -A\nhelm install foo bar\n```",
+			expected: []string{"kubectl get pods -A", "helm install foo bar"},
+		},
+		{
+			name:     "bare kubectl outside code block",
+			input:    "You should run:\nkubectl describe pod foo\n\nThat will show the details.",
+			expected: []string{"kubectl describe pod foo"},
+		},
+		{
+			name:     "oc command support",
+			input:    "CMD: oc get routes",
+			expected: []string{"oc get routes"},
+		},
+		{
+			name:     "deduplication",
+			input:    "CMD: kubectl get pods\nkubectl get pods",
+			expected: []string{"kubectl get pods"},
+		},
+		{
+			name:     "no commands",
+			input:    "I think we should check the cluster status.\nLet me know if you need help.",
+			expected: nil,
+		},
+		{
+			name:     "mixed formats",
+			input:    "Analysis:\nCMD: kubectl get pods\n```\nhelm list -A\n```\ncommand: kubectl get svc",
+			expected: []string{"kubectl get pods", "helm list -A", "kubectl get svc"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := extractCommandsFromResponse(tt.input)
+			if len(got) != len(tt.expected) {
+				t.Fatalf("expected %d commands, got %d: %v", len(tt.expected), len(got), got)
+			}
+			for i, cmd := range got {
+				if cmd != tt.expected[i] {
+					t.Errorf("command[%d] = %q, want %q", i, cmd, tt.expected[i])
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- **#9440 — Brittle Command Parsing**: Replaced the fragile `CMD: ` string-prefix heuristic in `handleMixedModeChat` with `extractCommandsFromResponse()`, which uses compiled regexes to handle:
  - `CMD:` / `Command:` prefixes (case-insensitive, with or without space)
  - kubectl/helm/oc commands inside markdown fenced code blocks
  - Bare kubectl/helm/oc commands on standalone lines
  - Automatic deduplication of extracted commands

- **#9441 — Token Persistence Race Condition**: Added a dedicated `tokenFileMux` (`sync.Mutex`) on the `Server` struct that serializes the entire file I/O cycle in `saveTokenUsage()`. The existing `tokenMux` only protected in-memory state; concurrent goroutines spawned by `addTokenUsage` could still clobber each other during the write-to-disk phase.

Fixes #9440, Fixes #9441

## Test plan

- [x] Added `TestExtractCommandsFromResponse` with 9 sub-tests covering all parsing formats
- [x] Existing `TestServer_TokenUsage` continues to pass
- [x] `go build ./pkg/agent/...` compiles cleanly
- [ ] CI build/lint pass