### PR TITLE
fix: add per-session aggregate token quota to prevent exhaustion

### DIFF
--- a/pkg/agent/server.go
+++ b/pkg/agent/server.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"os"
 	"os/exec"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -46,6 +47,16 @@ const (
 
 	maxQueryLimit       = 1000    // Upper bound for client-supplied limit query parameter
 	maxRequestBodyBytes = 1 << 20 // 1MB upper bound for request body reads
+
+	// defaultSessionTokenQuota is the maximum total tokens (input + output)
+	// allowed per agent session before new prompts are rejected. Prevents
+	// bill-shock from runaway or malicious clients (#9438). Configurable
+	// via KC_SESSION_TOKEN_QUOTA env var. 0 = unlimited. Default: 5 million.
+	defaultSessionTokenQuota int64 = 5_000_000
+
+	// sessionTokenQuotaEnvVar is the environment variable operators can set
+	// to override the per-session aggregate token limit.
+	sessionTokenQuotaEnvVar = "KC_SESSION_TOKEN_QUOTA"
 
 	// deployedByAnonymousMarker is the default value recorded on workloads
 	// created via kc-agent when the caller did not supply a "deployedBy"
@@ -122,14 +133,15 @@ type Server struct {
 	agentToken     string // Optional shared secret for authentication
 
 	// Token tracking
-	tokenMux         sync.RWMutex
-	tokenFileMux     sync.Mutex // serializes file I/O in saveTokenUsage to prevent race (#9441)
-	sessionStart     time.Time
-	sessionTokensIn  int64
-	sessionTokensOut int64
-	todayTokensIn    int64
-	todayTokensOut   int64
-	todayDate        string // YYYY-MM-DD format to detect day change
+	tokenMux          sync.RWMutex
+	tokenFileMux      sync.Mutex // serializes file I/O in saveTokenUsage to prevent race (#9441)
+	sessionStart      time.Time
+	sessionTokensIn   int64
+	sessionTokensOut  int64
+	todayTokensIn     int64
+	todayTokensOut    int64
+	todayDate         string // YYYY-MM-DD format to detect day change
+	sessionTokenQuota int64  // max total tokens per session; 0 = unlimited (#9438)
 
 	// Prediction system
 	predictionWorker *PredictionWorker
@@ -219,19 +231,35 @@ func NewServer(cfg Config) (*Server, error) {
 		slog.Warn("KC_AGENT_TOKEN is not set — all requests will be accepted without authentication. Set KC_AGENT_TOKEN to enable token validation.")
 	}
 
+	// Resolve per-session token quota from env, falling back to the compiled
+	// default. 0 means unlimited (operator opted out of the safety net).
+	sessionQuota := defaultSessionTokenQuota
+	if raw := os.Getenv(sessionTokenQuotaEnvVar); raw != "" {
+		if parsed, err := strconv.ParseInt(raw, 10, 64); err == nil && parsed >= 0 {
+			sessionQuota = parsed
+		} else {
+			slog.Warn("invalid KC_SESSION_TOKEN_QUOTA value, using default",
+				"value", raw, "default", defaultSessionTokenQuota)
+		}
+	}
+	if sessionQuota > 0 {
+		slog.Info("session token quota enabled", "limit", sessionQuota)
+	}
+
 	now := time.Now()
 	server := &Server{
-		config:         cfg,
-		kubectl:        kubectl,
-		k8sClient:      k8sClient,
-		registry:       GetRegistry(),
-		clients:        make(map[*websocket.Conn]*wsClient),
-		allowedOrigins: allowedOrigins,
-		agentToken:     agentToken,
-		sessionStart:   now,
-		todayDate:      now.Format("2006-01-02"),
-		activeChatCtxs: make(map[string]context.CancelFunc),
-		dryRunSessions: make(map[string]bool),
+		config:            cfg,
+		kubectl:           kubectl,
+		k8sClient:         k8sClient,
+		registry:          GetRegistry(),
+		clients:           make(map[*websocket.Conn]*wsClient),
+		allowedOrigins:    allowedOrigins,
+		agentToken:        agentToken,
+		sessionStart:      now,
+		todayDate:         now.Format("2006-01-02"),
+		activeChatCtxs:    make(map[string]context.CancelFunc),
+		dryRunSessions:    make(map[string]bool),
+		sessionTokenQuota: sessionQuota,
 	}
 
 	server.upgrader = websocket.Upgrader{

--- a/pkg/agent/server_ai.go
+++ b/pkg/agent/server_ai.go
@@ -459,6 +459,13 @@ func (s *Server) handleChatMessageStreaming(conn *websocket.Conn, msg protocol.M
 		return
 	}
 
+	// SECURITY: Reject new prompts when the session token quota is exhausted
+	// to prevent unbounded AI API spend (#9438).
+	if s.isSessionQuotaExceeded() {
+		safeWrite(context.Background(), s.errorResponse(msg.ID, "token_quota_exceeded", s.sessionTokenQuotaMessage()))
+		return
+	}
+
 	// Generate a unique session ID when the client omits one so that
 	// concurrent anonymous chats do not collide in activeChatCtxs (#4263).
 	if req.SessionID == "" {
@@ -899,6 +906,12 @@ func (s *Server) handleChatMessage(msg protocol.Message, forceAgent string) prot
 
 	if req.Prompt == "" {
 		return s.errorResponse(msg.ID, "empty_prompt", "Prompt cannot be empty")
+	}
+
+	// SECURITY: Reject new prompts when the session token quota is exhausted
+	// to prevent unbounded AI API spend (#9438).
+	if s.isSessionQuotaExceeded() {
+		return s.errorResponse(msg.ID, "token_quota_exceeded", s.sessionTokenQuotaMessage())
 	}
 
 	// Generate a unique session ID when the client omits one so that
@@ -1500,6 +1513,29 @@ func (s *Server) getClaudeInfo() *protocol.ClaudeInfo {
 			},
 		},
 	}
+}
+
+// isSessionQuotaExceeded returns true when the aggregate session token count
+// (input + output) has reached or passed the configured quota. A quota of 0
+// means unlimited — the check is skipped (#9438).
+func (s *Server) isSessionQuotaExceeded() bool {
+	if s.sessionTokenQuota <= 0 {
+		return false // unlimited
+	}
+	s.tokenMux.RLock()
+	total := s.sessionTokensIn + s.sessionTokensOut
+	s.tokenMux.RUnlock()
+	return total >= s.sessionTokenQuota
+}
+
+// sessionTokenQuotaMessage builds a human-readable error string returned to
+// the client when the session token quota is exceeded.
+func (s *Server) sessionTokenQuotaMessage() string {
+	return fmt.Sprintf(
+		"Session token quota exceeded (limit: %d tokens). "+
+			"Restart kc-agent to reset the session quota, or increase "+
+			"the limit via the %s environment variable.",
+		s.sessionTokenQuota, sessionTokenQuotaEnvVar)
 }
 
 // addTokenUsage accumulates token usage from a chat response

--- a/pkg/agent/server_ai_test.go
+++ b/pkg/agent/server_ai_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"strings"
 	"testing"
 	"time"
 
@@ -95,6 +96,101 @@ func TestServer_TokenUsage(t *testing.T) {
 		t.Errorf("Session tokens should accumulate across days, got %d/%d", s.sessionTokensIn, s.sessionTokensOut)
 	}
 	s.tokenMux.RUnlock()
+}
+
+// TestServer_SessionTokenQuota verifies that the per-session aggregate
+// token quota rejects new prompts once the limit is reached (#9438).
+func TestServer_SessionTokenQuota(t *testing.T) {
+	const testQuota int64 = 500 // intentionally small for the test
+
+	s := &Server{
+		todayDate:         time.Now().Format("2006-01-02"),
+		sessionTokenQuota: testQuota,
+	}
+
+	// Before any usage, the quota should NOT be exceeded
+	if s.isSessionQuotaExceeded() {
+		t.Fatal("quota should not be exceeded before any usage")
+	}
+
+	// Add usage that stays under the quota
+	s.addTokenUsage(&ProviderTokenUsage{InputTokens: 100, OutputTokens: 100, TotalTokens: 200})
+	time.Sleep(50 * time.Millisecond) // let async save fire
+	if s.isSessionQuotaExceeded() {
+		t.Fatal("quota should not be exceeded at 200/500")
+	}
+
+	// Push over the limit
+	s.addTokenUsage(&ProviderTokenUsage{InputTokens: 200, OutputTokens: 200, TotalTokens: 400})
+	time.Sleep(50 * time.Millisecond)
+	if !s.isSessionQuotaExceeded() {
+		t.Fatal("quota should be exceeded at 600/500")
+	}
+
+	// Verify the error message mentions the env var
+	msg := s.sessionTokenQuotaMessage()
+	if !strings.Contains(msg, "KC_SESSION_TOKEN_QUOTA") {
+		t.Errorf("quota message should mention env var, got: %s", msg)
+	}
+}
+
+// TestServer_SessionTokenQuota_Unlimited verifies that a quota of 0
+// disables the limit (#9438).
+func TestServer_SessionTokenQuota_Unlimited(t *testing.T) {
+	s := &Server{
+		todayDate:         time.Now().Format("2006-01-02"),
+		sessionTokenQuota: 0, // unlimited
+	}
+
+	// Even with huge usage, the quota should never trigger
+	s.addTokenUsage(&ProviderTokenUsage{InputTokens: 999_999_999, OutputTokens: 999_999_999})
+	time.Sleep(50 * time.Millisecond)
+	if s.isSessionQuotaExceeded() {
+		t.Fatal("quota of 0 should mean unlimited")
+	}
+}
+
+// TestServer_HandleChatMessage_QuotaExceeded verifies that handleChatMessage
+// returns a token_quota_exceeded error when the session quota is blown (#9438).
+func TestServer_HandleChatMessage_QuotaExceeded(t *testing.T) {
+	const testQuota int64 = 100
+
+	registry := &Registry{providers: make(map[string]AIProvider)}
+	registry.Register(&ServerMockProvider{name: "mock"})
+	registry.SetDefault("mock")
+
+	s := &Server{
+		todayDate:         time.Now().Format("2006-01-02"),
+		sessionTokenQuota: testQuota,
+		registry:          registry,
+	}
+
+	// Blow through the quota
+	s.addTokenUsage(&ProviderTokenUsage{InputTokens: 80, OutputTokens: 80})
+	time.Sleep(50 * time.Millisecond)
+
+	msg := protocol.Message{
+		ID:   "test-1",
+		Type: protocol.TypeChat,
+		Payload: protocol.ChatRequest{
+			Prompt: "hello",
+		},
+	}
+
+	resp := s.handleChatMessage(msg, "")
+	if resp.Type != protocol.TypeError {
+		t.Fatalf("expected error response, got type %s", resp.Type)
+	}
+
+	// Extract the error code from the payload
+	payloadBytes, _ := json.Marshal(resp.Payload)
+	var errPayload struct {
+		Code string `json:"code"`
+	}
+	_ = json.Unmarshal(payloadBytes, &errPayload)
+	if errPayload.Code != "token_quota_exceeded" {
+		t.Errorf("expected code token_quota_exceeded, got %s", errPayload.Code)
+	}
 }
 
 // TestServer_SmartRouting tests the promptNeedsToolExecution heuristic


### PR DESCRIPTION
## Summary
- Adds a configurable per-session aggregate token quota (`KC_SESSION_TOKEN_QUOTA` env var, default 5M tokens) to kc-agent
- Rejects new chat prompts with a clear `token_quota_exceeded` error once the cumulative input+output token count reaches the limit
- Enforced in both streaming (`handleChatMessageStreaming`) and non-streaming (`handleChatMessage`) paths, **before** the prompt reaches any AI provider
- Setting the quota to `0` disables the limit entirely for operators who want no cap
- Includes unit tests for quota enforcement, unlimited mode, and the handleChatMessage rejection path

## Test plan
- [ ] CI build and lint pass
- [ ] New unit tests: `TestServer_SessionTokenQuota`, `TestServer_SessionTokenQuota_Unlimited`, `TestServer_HandleChatMessage_QuotaExceeded`
- [ ] Existing `TestServer_TokenUsage` test continues to pass (verified locally)
- [ ] Manual: start kc-agent with `KC_SESSION_TOKEN_QUOTA=1000`, send a few prompts, observe rejection after quota is hit

Fixes #9438

🤖 Generated with [Claude Code](https://claude.com/claude-code)