### PR TITLE
fix: replace O(N^2) cache eviction with sorted-slice approach

### DIFF
--- a/pkg/agent/insight_worker.go
+++ b/pkg/agent/insight_worker.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log/slog"
+	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -184,24 +185,24 @@ func (w *InsightWorker) Enrich(req InsightEnrichmentRequest) (*InsightEnrichment
 	for _, e := range enrichments {
 		w.cache[e.InsightID] = insightCacheEntry{enrichment: e, cachedAt: cacheNow}
 	}
-	// Evict entries beyond the size cap — delete the oldest entries first
+	// Evict entries beyond the size cap — collect all keys, sort by
+	// cachedAt ascending, and delete the oldest entries in one pass.
+	// This is O(N log N) instead of the previous O(N^2) approach (#9443).
 	if len(w.cache) > insightCacheMaxEntries {
-		var oldestKey string
-		var oldestTime time.Time
-		for len(w.cache) > insightCacheMaxEntries {
-			oldestKey = ""
-			oldestTime = cacheNow
-			for k, v := range w.cache {
-				if v.cachedAt.Before(oldestTime) {
-					oldestKey = k
-					oldestTime = v.cachedAt
-				}
-			}
-			if oldestKey != "" {
-				delete(w.cache, oldestKey)
-			} else {
-				break
-			}
+		type cacheRef struct {
+			key      string
+			cachedAt time.Time
+		}
+		entries := make([]cacheRef, 0, len(w.cache))
+		for k, v := range w.cache {
+			entries = append(entries, cacheRef{key: k, cachedAt: v.cachedAt})
+		}
+		sort.Slice(entries, func(i, j int) bool {
+			return entries[i].cachedAt.Before(entries[j].cachedAt)
+		})
+		evictCount := len(w.cache) - insightCacheMaxEntries
+		for i := 0; i < evictCount; i++ {
+			delete(w.cache, entries[i].key)
 		}
 	}
 	w.cacheTime = cacheNow


### PR DESCRIPTION
## Summary
- Replaces the O(N^2) cache eviction in `InsightWorker.Enrich()` with an O(N log N) sorted-slice approach
- Collects all cache entries into a slice, sorts by `cachedAt` timestamp, and deletes the oldest entries in a single pass
- Previously the code looped N times (once per entry to evict), each time scanning the entire map to find the oldest entry

Fixes #9443

🤖 Generated with [Claude Code](https://claude.com/claude-code)