### PR TITLE
fix: kill process group on mission timeout to prevent zombie sub-processes

### DIFF
--- a/pkg/agent/procgroup_unix.go
+++ b/pkg/agent/procgroup_unix.go
@@ -1,0 +1,47 @@
+//go:build !windows
+
+// Platform-specific helper that configures a child process to run in its
+// own process group so the entire tree can be killed on context
+// cancellation. Without this, exec.CommandContext only sends SIGKILL to
+// the direct child, leaving grandchild processes (helm install, kubectl
+// apply, drasi init, etc.) running as zombies after a mission timeout.
+//
+// See procgroup_windows.go for the Windows equivalent (#9442).
+package agent
+
+import (
+	"os"
+	"os/exec"
+	"syscall"
+	"time"
+)
+
+// processGroupGracePeriod is how long to wait after sending SIGTERM to the
+// process group before exec.Cmd falls back to SIGKILL. This gives
+// well-behaved children (helm, kubectl) time to clean up.
+const processGroupGracePeriod = 5 * time.Second
+
+// configureProcessGroup places cmd in a new process group (Setpgid) and
+// overrides the context-cancellation behavior so that SIGTERM is sent to
+// the entire group (negative PID) instead of only the root process.
+// A WaitDelay is also set so that pipe-reader goroutines are not leaked
+// if the children ignore the signal.
+func configureProcessGroup(cmd *exec.Cmd) {
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+
+	// cmd.Cancel is called when the associated context is done.
+	// Send SIGTERM to the whole process group (-pgid).
+	cmd.Cancel = func() error {
+		if cmd.Process == nil {
+			return nil
+		}
+		pgid, err := syscall.Getpgid(cmd.Process.Pid)
+		if err != nil {
+			// Fallback: kill the process directly.
+			return cmd.Process.Signal(os.Kill)
+		}
+		return syscall.Kill(-pgid, syscall.SIGTERM)
+	}
+
+	cmd.WaitDelay = processGroupGracePeriod
+}

--- a/pkg/agent/procgroup_windows.go
+++ b/pkg/agent/procgroup_windows.go
@@ -1,0 +1,17 @@
+//go:build windows
+
+// Platform-specific helper — Windows equivalent of procgroup_unix.go.
+// Windows does not have POSIX process groups, so this is a best-effort
+// no-op. exec.CommandContext already calls Process.Kill on cancellation,
+// which terminates the direct child; grandchildren may still linger but
+// there is no portable way to fix that on Windows without Job Objects.
+//
+// See procgroup_unix.go for the Unix implementation (#9442).
+package agent
+
+import "os/exec"
+
+// configureProcessGroup is a no-op on Windows.
+func configureProcessGroup(_ *exec.Cmd) {
+	// intentionally empty — no POSIX process groups on Windows
+}

--- a/pkg/agent/provider_antigravity.go
+++ b/pkg/agent/provider_antigravity.go
@@ -172,6 +172,7 @@ func (a *AntigravityProvider) StreamChat(ctx context.Context, req *ChatRequest, 
 
 	cmd := exec.CommandContext(execCtx, a.cliPath, "-p", prompt)
 	cmd.Env = append(os.Environ(), "NO_COLOR=1")
+	configureProcessGroup(cmd) // #9442: kill entire process tree on timeout
 
 	stdout, err := cmd.StdoutPipe()
 	if err != nil {

--- a/pkg/agent/provider_bob.go
+++ b/pkg/agent/provider_bob.go
@@ -198,6 +198,7 @@ func (b *BobProvider) Chat(ctx context.Context, req *ChatRequest) (*ChatResponse
 	}
 
 	cmd := exec.CommandContext(ctx, b.cliPath, args...)
+	configureProcessGroup(cmd) // #9442: kill entire process tree on timeout
 
 	var stdout, stderr bytes.Buffer
 	cmd.Stdout = &stdout

--- a/pkg/agent/provider_claudecode.go
+++ b/pkg/agent/provider_claudecode.go
@@ -291,6 +291,7 @@ func (c *ClaudeCodeProvider) StreamChatWithProgress(ctx context.Context, req *Ch
 
 	cmd := exec.CommandContext(ctx, c.cliPath, args...)
 	cmd.Env = cleanEnvForCLI()
+	configureProcessGroup(cmd) // #9442: kill entire process tree on timeout
 
 	stdout, err := cmd.StdoutPipe()
 	if err != nil {
@@ -478,6 +479,7 @@ Provide a clear, concise analysis of what this output shows.`, lastToolOutput)
 
 		analysisCmd := exec.CommandContext(ctx, c.cliPath, analysisArgs...)
 		analysisCmd.Env = cleanEnvForCLI()
+		configureProcessGroup(analysisCmd) // #9442: kill entire process tree on timeout
 		analysisStdout, err := analysisCmd.StdoutPipe()
 		if err == nil {
 			if startErr := analysisCmd.Start(); startErr == nil {

--- a/pkg/agent/provider_codex.go
+++ b/pkg/agent/provider_codex.go
@@ -105,6 +105,7 @@ func (c *CodexProvider) StreamChat(ctx context.Context, req *ChatRequest, onChun
 	// --full-auto: allow tool execution without confirmation
 	cmd := exec.CommandContext(execCtx, c.cliPath, "exec", "--full-auto", prompt)
 	cmd.Env = append(os.Environ(), "NO_COLOR=1")
+	configureProcessGroup(cmd) // #9442: kill entire process tree on timeout
 
 	stdout, err := cmd.StdoutPipe()
 	if err != nil {

--- a/pkg/agent/provider_copilotcli.go
+++ b/pkg/agent/provider_copilotcli.go
@@ -121,6 +121,7 @@ func (c *CopilotCLIProvider) StreamChatWithProgress(ctx context.Context, req *Ch
 	// --allow-all-paths: allow access to any file path for kubectl/helm operations
 	cmd := exec.CommandContext(ctx, c.cliPath, "-p", prompt, "--silent", "--no-ask-user", "--no-color", "--allow-all-tools", "--allow-all-paths")
 	cmd.Env = append(os.Environ(), "NO_COLOR=1")
+	configureProcessGroup(cmd) // #9442: kill entire process tree on timeout
 
 	stdout, err := cmd.StdoutPipe()
 	if err != nil {

--- a/pkg/agent/provider_geminicli.go
+++ b/pkg/agent/provider_geminicli.go
@@ -101,6 +101,7 @@ func (g *GeminiCLIProvider) StreamChat(ctx context.Context, req *ChatRequest, on
 
 	cmd := exec.CommandContext(execCtx, g.cliPath, "-p", prompt)
 	cmd.Env = append(os.Environ(), "NO_COLOR=1")
+	configureProcessGroup(cmd) // #9442: kill entire process tree on timeout
 
 	stdout, err := cmd.StdoutPipe()
 	if err != nil {

--- a/pkg/agent/provider_goose.go
+++ b/pkg/agent/provider_goose.go
@@ -116,6 +116,7 @@ func (g *GooseProvider) StreamChat(ctx context.Context, req *ChatRequest, onChun
 	// --no-session: don't persist session state
 	cmd := exec.CommandContext(execCtx, g.cliPath, "run", "-t", prompt, "-q", "--no-session")
 	cmd.Env = append(os.Environ(), "NO_COLOR=1")
+	configureProcessGroup(cmd) // #9442: kill entire process tree on timeout
 
 	stdout, err := cmd.StdoutPipe()
 	if err != nil {


### PR DESCRIPTION
## Summary
- Adds `configureProcessGroup()` helper (build-tagged for Unix/Windows) that places CLI child processes in their own process group (`Setpgid`) and overrides `cmd.Cancel` to send `SIGTERM` to the entire group (`-pgid`) on context cancellation
- Sets `cmd.WaitDelay = 5s` to give children time to clean up before `SIGKILL`
- Applied to all 7 AI provider execution paths: Claude Code, Bob, Antigravity, Gemini CLI, Copilot CLI, Codex, and Goose

Without this fix, `exec.CommandContext` only kills the direct child process on timeout. Sub-processes spawned by the CLI agent (e.g., `helm install`, `kubectl apply`, `drasi init`) continue running as zombies after the user sees "Mission Timed Out".

## Test plan
- [ ] Verify `go vet ./pkg/agent/...` passes (done locally)
- [ ] CI build passes
- [ ] Start a mission that spawns a long-running subprocess, let it timeout, verify `ps aux` shows no orphaned children

Fixes #9442