### PR TITLE
fix: add CSRF header to raw fetch POST calls and CORS config

### DIFF
--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -414,7 +414,7 @@ func (s *Server) setupMiddleware() {
 	s.app.Use(cors.New(cors.Config{
 		AllowOrigins:     s.config.FrontendURL,
 		AllowMethods:     "GET,POST,PUT,DELETE,OPTIONS",
-		AllowHeaders:     "Origin,Content-Type,Accept,Authorization",
+		AllowHeaders:     "Origin,Content-Type,Accept,Authorization,X-Requested-With,X-KC-Client-Auth",
 		ExposeHeaders:    "X-Token-Refresh",
 		AllowCredentials: true,
 	}))

--- a/web/src/components/cards/drasi/DrasiReactiveGraph.tsx
+++ b/web/src/components/cards/drasi/DrasiReactiveGraph.tsx
@@ -285,7 +285,7 @@ export function DrasiReactiveGraph() {
       try {
         await fetch(`/api/drasi/proxy${path}?${drasiProxyTarget()}`, {
           method: isCreate ? 'POST' : 'PUT',
-          headers: { 'content-type': 'application/json' },
+          headers: { 'content-type': 'application/json', 'X-Requested-With': 'XMLHttpRequest' },
           body: JSON.stringify({ id: config.name, spec: { kind: config.kind } }),
           signal: AbortSignal.timeout(DRASI_PROXY_TIMEOUT_MS),
         })
@@ -317,7 +317,7 @@ export function DrasiReactiveGraph() {
       try {
         await fetch(`/api/drasi/proxy${path}?${drasiProxyTarget()}`, {
           method: isCreate ? 'POST' : 'PUT',
-          headers: { 'content-type': 'application/json' },
+          headers: { 'content-type': 'application/json', 'X-Requested-With': 'XMLHttpRequest' },
           body: JSON.stringify({
             id: config.name,
             spec: { mode: config.language.replace(/ QUERY$/, ''), query: config.queryText },
@@ -354,7 +354,7 @@ export function DrasiReactiveGraph() {
       try {
         await fetch(`/api/drasi/proxy${drasiResourcePath('reaction')}?${drasiProxyTarget()}`, {
           method: 'POST',
-          headers: { 'content-type': 'application/json' },
+          headers: { 'content-type': 'application/json', 'X-Requested-With': 'XMLHttpRequest' },
           body: JSON.stringify({
             id: defaultName,
             spec: { kind: 'SSE', queries: queries.map(q => ({ id: q.id })) },
@@ -386,7 +386,7 @@ export function DrasiReactiveGraph() {
     try {
       await fetch(`/api/drasi/proxy${drasiResourcePath('reaction')}?${drasiProxyTarget()}`, {
         method: 'POST',
-        headers: { 'content-type': 'application/json' },
+        headers: { 'content-type': 'application/json', 'X-Requested-With': 'XMLHttpRequest' },
         body: JSON.stringify({
           id: reactionName,
           spec: { kind: 'Result', queries: [{ id: queryId }] },

--- a/web/src/components/settings/sections/GitHubTokenSection.tsx
+++ b/web/src/components/settings/sections/GitHubTokenSection.tsx
@@ -29,7 +29,9 @@ const DEEP_LINK_RENDER_DELAY_MS = 300
 /** Build JWT auth headers for backend proxy requests */
 function authHeaders(): Record<string, string> {
   const token = safeGetItem(STORAGE_KEY_TOKEN)
-  return token ? { Authorization: `Bearer ${token}` } : {}
+  const headers: Record<string, string> = { 'X-Requested-With': 'XMLHttpRequest' }
+  if (token) headers['Authorization'] = `Bearer ${token}`
+  return headers
 }
 
 export function GitHubTokenSection({ forceVersionCheck }: GitHubTokenSectionProps) {

--- a/web/src/contexts/AlertsContext.tsx
+++ b/web/src/contexts/AlertsContext.tsx
@@ -1010,6 +1010,7 @@ export function AlertsProvider({ children }: { children: ReactNode }) {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
+          'X-Requested-With': 'XMLHttpRequest',
           Authorization: `Bearer ${token}` },
         body: JSON.stringify({ alert, channels }),
         signal: AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS) })
@@ -1053,6 +1054,7 @@ export function AlertsProvider({ children }: { children: ReactNode }) {
               method: 'POST',
               headers: {
                 'Content-Type': 'application/json',
+                'X-Requested-With': 'XMLHttpRequest',
                 Authorization: `Bearer ${token}` },
               body: JSON.stringify({ alert, channels }),
               signal: AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS) })

--- a/web/src/hooks/useActiveUsers.ts
+++ b/web/src/hooks/useActiveUsers.ts
@@ -136,7 +136,7 @@ async function sendHeartbeat() {
   try {
     await fetch('/api/active-users', {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
+      headers: { 'Content-Type': 'application/json', 'X-Requested-With': 'XMLHttpRequest' },
       body: JSON.stringify({ sessionId: getSessionId() }),
       signal: AbortSignal.timeout(5000)
     })

--- a/web/src/hooks/useAlerts.ts
+++ b/web/src/hooks/useAlerts.ts
@@ -206,7 +206,7 @@ export function useSlackNotification() {
         // Route through backend notification service (#5713, Copilot followup)
         const response = await fetch('/api/notifications/send', {
           method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
+          headers: { 'Content-Type': 'application/json', 'X-Requested-With': 'XMLHttpRequest' },
           signal: AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS),
           body: JSON.stringify({
             alert: {

--- a/web/src/hooks/useClusterGroups.ts
+++ b/web/src/hooks/useClusterGroups.ts
@@ -71,7 +71,7 @@ function saveGroups(groups: ClusterGroup[]) {
 
 function authHeaders(): Record<string, string> {
   const token = localStorage.getItem(STORAGE_KEY_TOKEN)
-  const headers: Record<string, string> = { 'Content-Type': 'application/json' }
+  const headers: Record<string, string> = { 'Content-Type': 'application/json', 'X-Requested-With': 'XMLHttpRequest' }
   if (token) headers['Authorization'] = `Bearer ${token}`
   return headers
 }

--- a/web/src/hooks/useGitHubPipelines.ts
+++ b/web/src/hooks/useGitHubPipelines.ts
@@ -483,6 +483,7 @@ export function usePipelineMutations() {
       try {
         const res = await fetch(`/api/github-pipelines?${p.toString()}`, {
           method: 'POST',
+          headers: { 'X-Requested-With': 'XMLHttpRequest' },
           signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
         })
         const body = (await res.json().catch(() => ({}))) as { error?: string }

--- a/web/src/hooks/useNPSSurvey.ts
+++ b/web/src/hooks/useNPSSurvey.ts
@@ -116,7 +116,7 @@ export function useNPSSurvey(): NPSSurveyState {
     try {
       const resp = await fetch(`${apiBase}/api/nps`, {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
+        headers: { 'Content-Type': 'application/json', 'X-Requested-With': 'XMLHttpRequest' },
         body: JSON.stringify({
           score,
           feedback: feedback?.trim() || undefined,

--- a/web/src/hooks/useNotificationAPI.ts
+++ b/web/src/hooks/useNotificationAPI.ts
@@ -23,6 +23,7 @@ export function useNotificationAPI() {
     const token = localStorage.getItem(STORAGE_KEY_AUTH_TOKEN)
     return {
       'Content-Type': 'application/json',
+      'X-Requested-With': 'XMLHttpRequest',
       ...(token && { Authorization: `Bearer ${token}` }) }
   }
 

--- a/web/src/hooks/usePersistence.ts
+++ b/web/src/hooks/usePersistence.ts
@@ -172,7 +172,7 @@ export function usePersistence() {
     try {
       const response = await fetch('/api/persistence/test', {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
+        headers: { 'Content-Type': 'application/json', 'X-Requested-With': 'XMLHttpRequest' },
         body: JSON.stringify({ cluster }),
         signal: AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS) })
 
@@ -192,7 +192,7 @@ export function usePersistence() {
 
     setSyncing(true)
     try {
-      const response = await fetch('/api/persistence/sync', { method: 'POST', signal: AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS) })
+      const response = await fetch('/api/persistence/sync', { method: 'POST', headers: { 'X-Requested-With': 'XMLHttpRequest' }, signal: AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS) })
       if (response.ok) {
         await fetchStatus()
         return true

--- a/web/src/hooks/useSelfUpgrade.ts
+++ b/web/src/hooks/useSelfUpgrade.ts
@@ -150,6 +150,7 @@ export function useSelfUpgrade() {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
+          'X-Requested-With': 'XMLHttpRequest',
           ...(token ? { Authorization: `Bearer ${token}` } : {}) },
         body: JSON.stringify({ imageTag }),
         signal: AbortSignal.timeout(SELF_UPGRADE_TIMEOUT_MS) })

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -514,7 +514,7 @@ class ApiClient {
     }
   }
 
-  async post<T = unknown>(path: string, body?: unknown, options?: { timeout?: number }): Promise<{ data: T }> {
+  async post<T = unknown>(path: string, body?: unknown, options?: { timeout?: number; headers?: Record<string, string> }): Promise<{ data: T }> {
     // Check backend availability
     const available = await checkBackendAvailability()
     if (!available) {
@@ -526,7 +526,7 @@ class ApiClient {
     try {
       const response = await fetch(`${API_BASE}${path}`, {
         method: 'POST',
-        headers: this.getHeaders(),
+        headers: { ...this.getHeaders(), ...options?.headers },
         body: body ? JSON.stringify(body) : undefined,
         signal: controller.signal,
       })

--- a/web/src/lib/unified/card/hooks/useDataSource.ts
+++ b/web/src/lib/unified/card/hooks/useDataSource.ts
@@ -277,7 +277,7 @@ function useApiDataSourceInternal(
 
       const response = await fetch(url, {
         method,
-        headers: method === 'POST' ? { 'Content-Type': 'application/json' } : undefined,
+        headers: method === 'POST' ? { 'Content-Type': 'application/json', 'X-Requested-With': 'XMLHttpRequest' } : undefined,
         body: method === 'POST' && params ? JSON.stringify(params) : undefined,
         signal: AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS) })
 


### PR DESCRIPTION
## Summary
- Adds `X-Requested-With` to CORS `AllowHeaders` so cross-origin setups (Vite dev server -> Go backend) allow the CSRF header through preflight
- Adds `X-Requested-With: XMLHttpRequest` to all raw `fetch()` POST calls that target `/api/` endpoints but bypass the `ApiClient`
- Updates `api.post()` to accept and merge custom headers from options (fixes silently dropped `X-KC-Client-Auth` from `createRequest`)

The `RequireCSRF` middleware (#8738) was applied to the entire `/api` group, but only `ApiClient.getHeaders()` and `authFetch()` were updated (#8830). Dozens of raw `fetch()` POST calls across hooks and components were left without the header, causing 403 "CSRF header required" on any state-changing request that bypasses the api client.

**Files fixed:** useActiveUsers, useAlerts, useClusterGroups, useDataSource, useGitHubPipelines, useNPSSurvey, useNotificationAPI, usePersistence, useSelfUpgrade, AlertsContext, DrasiReactiveGraph, GitHubTokenSection, server.go (CORS), api.ts (post options)

## Test plan
- [ ] Run console locally (`startup-oauth.sh`), open Contribute modal, submit an issue — should succeed without CSRF error
- [ ] Run with `--dev` flag (Vite on 5174, backend on 8081) and repeat — cross-origin preflight should allow `X-Requested-With`
- [ ] Verify alert notification send, cluster group create/evaluate, persistence sync, NPS survey POST all work without 403

Fixes #9439