### PR TITLE
fix: ML Jobs/Notebooks demo badge and display inconsistencies

### DIFF
--- a/web/src/components/cards/workload-detection/MLJobs.tsx
+++ b/web/src/components/cards/workload-detection/MLJobs.tsx
@@ -75,7 +75,7 @@ export function MLJobs({ config: _config }: MLJobsProps) {
       case 'queued':
         return <StatusBadge color="yellow" icon={<Clock className="w-2.5 h-2.5" />}>Queued</StatusBadge>
       case 'completed':
-        return <StatusBadge color="blue" icon={<CheckCircle className="w-2.5 h-2.5" />}>Done</StatusBadge>
+        return <StatusBadge color="blue" icon={<CheckCircle className="w-2.5 h-2.5" />}>Completed</StatusBadge>
       case 'failed':
         return <StatusBadge color="red" icon={<XCircle className="w-2.5 h-2.5" />}>Failed</StatusBadge>
       default:
@@ -104,7 +104,7 @@ export function MLJobs({ config: _config }: MLJobsProps) {
               {filters.localClusterFilter.length}/{filters.availableClusters.length}
             </span>
           )}
-          <StatusBadge color="yellow">
+          <StatusBadge color="green">
             {jobs.filter(j => j.status === 'running').length} running
           </StatusBadge>
         </div>
@@ -146,7 +146,7 @@ export function MLJobs({ config: _config }: MLJobsProps) {
           <p className="text-yellow-400 font-medium">ML Job Detection</p>
           <p className="text-muted-foreground">
             Auto-detects Kubeflow, Ray, and custom ML training jobs.{' '}
-            <a href="https://www.kubeflow.org/docs/started/installing-kubeflow/" target="_blank" rel="noopener noreferrer" className="text-yellow-400 hover:underline inline-block py-2">
+            <a href="https://www.kubeflow.org/docs/started/installing-kubeflow/" target="_blank" rel="noopener noreferrer" className="text-yellow-400 hover:underline inline">
               Kubeflow docs <ExternalLink className="w-3 h-3 inline" />
             </a>
           </p>

--- a/web/src/components/cards/workload-detection/MLNotebooks.tsx
+++ b/web/src/components/cards/workload-detection/MLNotebooks.tsx
@@ -113,7 +113,7 @@ export function MLNotebooks({ config: _config }: MLNotebooksProps) {
           <p className="text-blue-400 font-medium">{t('cards:mlNotebooks.notebookDetection')}</p>
           <p className="text-muted-foreground">
             {t('cards:mlNotebooks.notebookDetectionDescription')}{' '}
-            <a href="https://jupyterhub.readthedocs.io/en/stable/getting-started/index.html" target="_blank" rel="noopener noreferrer" className="text-blue-400 hover:underline inline-block py-2">
+            <a href="https://jupyterhub.readthedocs.io/en/stable/getting-started/index.html" target="_blank" rel="noopener noreferrer" className="text-blue-400 hover:underline inline">
               JupyterHub docs <ExternalLink className="w-3 h-3 inline" />
             </a>
           </p>

--- a/web/src/components/cards/workload-detection/shared.ts
+++ b/web/src/components/cards/workload-detection/shared.ts
@@ -1,5 +1,6 @@
 import { useState, useMemo } from 'react'
 import type { ClusterInfo } from '../../../hooks/mcp/types'
+import { useDemoMode } from '../../../hooks/useDemoMode'
 
 export interface DemoState {
   isLoading: boolean
@@ -11,7 +12,8 @@ export interface DemoState {
 export function useDemoData<T>(data: T): DemoState & { data: T } {
   const [isLoading] = useState(false)
   const [lastUpdated] = useState<Date | null>(new Date())
-  return { data, isLoading, isRefreshing: false, isDemoData: true, lastUpdated }
+  const { isDemoMode } = useDemoMode()
+  return { data, isLoading, isRefreshing: false, isDemoData: isDemoMode, lastUpdated }
 }
 
 // Keywords that indicate a cluster may have LLM-d or AI/ML workloads


### PR DESCRIPTION
Fixes #9453, Fixes #9454

## Summary
- Wire `isDemoData` through `useDemoMode()` instead of hardcoding `true` in `useDemoData` hook, so Demo badge only shows when actually in demo mode
- Change Running job count badge color from yellow to green to match individual row status indicators
- Rename completed job status label from "Done" to "Completed" for consistency
- Fix oversized click targets on Kubeflow docs and JupyterHub links by replacing `inline-block py-2` with `inline`

## Test plan
- [ ] ML Jobs/Notebooks show Demo badge only when in demo mode, not with real data
- [ ] Running count uses green badge matching row-level Running indicators
- [ ] Completed jobs show "Completed" not "Done"
- [ ] Kubeflow docs and JupyterHub doc links have normal-sized click targets