### PR TITLE
fix: replace hardcoded English text with i18n keys in AI/ML cards

### DIFF
--- a/web/src/components/cards/GPUOverview.tsx
+++ b/web/src/components/cards/GPUOverview.tsx
@@ -144,8 +144,8 @@ export function GPUOverview({ config: _config }: GPUOverviewProps) {
           <div className="w-12 h-12 rounded-full bg-secondary flex items-center justify-center mb-3">
             <Activity className="w-6 h-6 text-muted-foreground" />
           </div>
-          <p className="text-foreground font-medium">{t('gpuStatus.noGPUData')}</p>
-          <p className="text-sm text-muted-foreground">{t('gpuStatus.gpuMetricsNotAvailable')}</p>
+          <p className="text-foreground font-medium">{t('gpuOverview.noGPUData')}</p>
+          <p className="text-sm text-muted-foreground">{t('gpuOverview.gpuMetricsNotAvailable')}</p>
         </div>
       </div>
     )

--- a/web/src/components/cards/kagent/KagentSecurity.tsx
+++ b/web/src/components/cards/kagent/KagentSecurity.tsx
@@ -3,6 +3,7 @@ import { Shield, ShieldCheck, ShieldAlert, AlertTriangle, Lock } from 'lucide-re
 import { useKagentCRDAgents, useKagentCRDTools } from '../../../hooks/mcp/kagent_crds'
 import { useCardLoadingState } from '../CardDataContext'
 import { DynamicCardErrorBoundary } from '../DynamicCardErrorBoundary'
+import { useTranslation } from 'react-i18next'
 
 /** Percentage threshold at or above which the bar is green (healthy) */
 const HIGH_PCT_THRESHOLD = 80
@@ -12,6 +13,7 @@ const MID_PCT_THRESHOLD = 50
 const PERCENT_MULTIPLIER = 100
 
 function KagentSecurityInternal({ config }: { config?: Record<string, unknown> }) {
+  const { t } = useTranslation(['cards'])
   const cluster = config?.cluster as string | undefined
   const {
     data: agents,
@@ -89,7 +91,7 @@ function KagentSecurityInternal({ config }: { config?: Record<string, unknown> }
       <div className="rounded-lg border border-border bg-secondary p-3">
         <div className="flex items-center gap-2 mb-2">
           <Shield className="w-4 h-4 text-blue-400" />
-          <span className="text-sm text-foreground font-medium">Agent Type Coverage</span>
+          <span className="text-sm text-foreground font-medium">{t('kagentSecurity.agentTypeCoverage')}</span>
         </div>
         <div className="flex items-center gap-3 mb-2">
           <div className="flex-1 h-3 bg-secondary rounded-full overflow-hidden">
@@ -103,11 +105,11 @@ function KagentSecurityInternal({ config }: { config?: Record<string, unknown> }
         <div className="grid grid-cols-2 gap-2 text-center">
           <div className="rounded bg-green-400/10 py-1.5">
             <div className="text-sm font-bold text-green-400">{stats.declarative}</div>
-            <div className="text-xs text-muted-foreground">Declarative</div>
+            <div className="text-xs text-muted-foreground">{t('kagentSecurity.declarative')}</div>
           </div>
           <div className="rounded bg-yellow-400/10 py-1.5">
             <div className="text-sm font-bold text-yellow-400">{stats.byo}</div>
-            <div className="text-xs text-muted-foreground">BYO</div>
+            <div className="text-xs text-muted-foreground">{t('kagentSecurity.byo')}</div>
           </div>
         </div>
       </div>
@@ -116,7 +118,7 @@ function KagentSecurityInternal({ config }: { config?: Record<string, unknown> }
       <div className="rounded-lg border border-border bg-secondary p-3">
         <div className="flex items-center gap-2 mb-2">
           <Lock className="w-4 h-4 text-blue-400" />
-          <span className="text-sm text-foreground font-medium">Model Auth Status</span>
+          <span className="text-sm text-foreground font-medium">{t('kagentSecurity.modelAuthStatus')}</span>
         </div>
         <div className="flex items-center gap-3 mb-1">
           <div className="flex-1 h-2 bg-secondary rounded-full overflow-hidden">
@@ -128,21 +130,21 @@ function KagentSecurityInternal({ config }: { config?: Record<string, unknown> }
           <span className="text-sm font-bold text-foreground">{stats.modelAuthPct}%</span>
         </div>
         <div className="text-xs text-muted-foreground">
-          {stats.agentsWithModel}/{stats.totalAgents} agents with model config
+          {t('kagentSecurity.agentsWithModelConfig', { configured: stats.agentsWithModel, total: stats.totalAgents })}
         </div>
       </div>
 
       {/* Tool Server Status */}
       <div className="px-1">
-        <div className="text-xs uppercase tracking-wider text-muted-foreground mb-1.5">Tool Servers</div>
+        <div className="text-xs uppercase tracking-wider text-muted-foreground mb-1.5">{t('kagentSecurity.toolServers')}</div>
         <div className="grid grid-cols-2 gap-2 text-center">
           <div className="rounded bg-cyan-400/10 py-1.5">
             <div className="text-sm font-bold text-cyan-400">{stats.readyTools}/{stats.totalTools}</div>
-            <div className="text-xs text-muted-foreground">Ready</div>
+            <div className="text-xs text-muted-foreground">{t('kagentSecurity.ready')}</div>
           </div>
           <div className="rounded bg-purple-400/10 py-1.5">
             <div className="text-sm font-bold text-purple-400">{stats.remoteTools}</div>
-            <div className="text-xs text-muted-foreground">Remote</div>
+            <div className="text-xs text-muted-foreground">{t('kagentSecurity.remote')}</div>
           </div>
         </div>
       </div>
@@ -152,7 +154,7 @@ function KagentSecurityInternal({ config }: { config?: Record<string, unknown> }
         <div>
           <div className="flex items-center gap-1.5 mb-1.5">
             <AlertTriangle className="w-3.5 h-3.5 text-yellow-400" />
-            <span className="text-xs text-yellow-400 font-medium">BYO Agents (Less Controlled)</span>
+            <span className="text-xs text-yellow-400 font-medium">{t('kagentSecurity.byoAgentsWarning')}</span>
           </div>
           <div className="space-y-1">
             {byoAgents.map(agent => (
@@ -172,12 +174,12 @@ function KagentSecurityInternal({ config }: { config?: Record<string, unknown> }
       {byoAgents.length === 0 && stats.totalAgents > 0 && (
         <div className="flex items-center gap-2 text-xs text-green-400 bg-green-400/5 rounded-lg p-3 border border-green-400/10">
           <ShieldCheck className="w-4 h-4" />
-          <span>All {stats.totalAgents} agents are Declarative (fully managed)</span>
+          <span>{t('kagentSecurity.allDeclarative', { count: stats.totalAgents })}</span>
         </div>
       )}
 
       {stats.totalAgents === 0 && stats.totalTools === 0 && (
-        <div className="text-center py-6 text-muted-foreground text-xs">No kagent resources found</div>
+        <div className="text-center py-6 text-muted-foreground text-xs">{t('kagentSecurity.noResources')}</div>
       )}
     </div>
   )

--- a/web/src/components/cards/kagent/KagentToolRegistry.tsx
+++ b/web/src/components/cards/kagent/KagentToolRegistry.tsx
@@ -6,6 +6,7 @@ import { DynamicCardErrorBoundary } from '../DynamicCardErrorBoundary'
 import { CardSearchInput, CardControlsRow, CardPaginationFooter } from '../../../lib/cards/CardComponents'
 import { useCardData, commonComparators } from '../../../lib/cards/cardHooks'
 import { Skeleton } from '../../ui/Skeleton'
+import { useTranslation } from 'react-i18next'
 
 interface KagentToolRegistryProps {
   config?: { cluster?: string }
@@ -54,15 +55,16 @@ function ProtocolBadge({ protocol }: { protocol: string }) {
 
 type SortField = 'name' | 'kind' | 'status' | 'cluster'
 
-const SORT_OPTIONS: { value: SortField; label: string }[] = [
-  { value: 'name', label: 'Name' },
-  { value: 'kind', label: 'Kind' },
-  { value: 'status', label: 'Status' },
-  { value: 'cluster', label: 'Cluster' },
-]
+const SORT_OPTION_KEYS = [
+  { value: 'name' as const, labelKey: 'kagentToolRegistry.sortName' },
+  { value: 'kind' as const, labelKey: 'kagentToolRegistry.sortKind' },
+  { value: 'status' as const, labelKey: 'kagentToolRegistry.sortStatus' },
+  { value: 'cluster' as const, labelKey: 'kagentToolRegistry.sortCluster' },
+] as const
 
 // #6216 part 2: wrapped at the bottom in DynamicCardErrorBoundary.
 function KagentToolRegistryInternal({ config }: KagentToolRegistryProps) {
+  const { t } = useTranslation(['cards'])
   const [expandedTool, setExpandedTool] = useState<string | null>(null)
 
   const {
@@ -129,8 +131,8 @@ function KagentToolRegistryInternal({ config }: KagentToolRegistryProps) {
     return (
       <div className="flex flex-col items-center justify-center py-8 text-center">
         <Wrench className="w-10 h-10 text-muted-foreground/30 mb-3" />
-        <div className="text-sm font-medium text-muted-foreground">No Tool Servers</div>
-        <div className="text-xs text-muted-foreground/60 mt-1">Deploy ToolServer or RemoteMCPServer CRDs</div>
+        <div className="text-sm font-medium text-muted-foreground">{t('kagentToolRegistry.noToolServers')}</div>
+        <div className="text-xs text-muted-foreground/60 mt-1">{t('kagentToolRegistry.deployHint')}</div>
       </div>
     )
   }
@@ -156,13 +158,13 @@ function KagentToolRegistryInternal({ config }: KagentToolRegistryProps) {
           limit: itemsPerPage,
           onLimitChange: setItemsPerPage,
           sortBy: sorting.sortBy,
-          sortOptions: SORT_OPTIONS,
+          sortOptions: SORT_OPTION_KEYS.map(opt => ({ value: opt.value, label: t(opt.labelKey) })),
           onSortChange: (v) => sorting.setSortBy(v as SortField),
           sortDirection: sorting.sortDirection,
           onSortDirectionChange: sorting.setSortDirection,
         }}
         extra={
-          <CardSearchInput value={filters.search} onChange={filters.setSearch} placeholder="Search tool servers..." />
+          <CardSearchInput value={filters.search} onChange={filters.setSearch} placeholder={t('kagentToolRegistry.searchPlaceholder')} />
         }
       />
 
@@ -190,7 +192,7 @@ function KagentToolRegistryInternal({ config }: KagentToolRegistryProps) {
                 <ProtocolBadge protocol={tool.protocol} />
                 {toolCount > 0 && (
                   <span className="text-xs text-muted-foreground">
-                    {toolCount} tool{toolCount !== 1 ? 's' : ''}
+                    {t('kagentToolRegistry.toolCount', { count: toolCount })}
                   </span>
                 )}
                 <StatusBadge status={tool.status} />

--- a/web/src/components/cards/workload-detection/MLJobs.tsx
+++ b/web/src/components/cards/workload-detection/MLJobs.tsx
@@ -71,13 +71,13 @@ export function MLJobs({ config: _config }: MLJobsProps) {
   const getStatusBadge = (status: string) => {
     switch (status) {
       case 'running':
-        return <StatusBadge color="green" icon={<Play className="w-2.5 h-2.5" />}>Running</StatusBadge>
+        return <StatusBadge color="green" icon={<Play className="w-2.5 h-2.5" />}>{t('mlJobs.statusRunning')}</StatusBadge>
       case 'queued':
-        return <StatusBadge color="yellow" icon={<Clock className="w-2.5 h-2.5" />}>Queued</StatusBadge>
+        return <StatusBadge color="yellow" icon={<Clock className="w-2.5 h-2.5" />}>{t('mlJobs.statusQueued')}</StatusBadge>
       case 'completed':
-        return <StatusBadge color="blue" icon={<CheckCircle className="w-2.5 h-2.5" />}>Completed</StatusBadge>
+        return <StatusBadge color="blue" icon={<CheckCircle className="w-2.5 h-2.5" />}>{t('mlJobs.statusCompleted')}</StatusBadge>
       case 'failed':
-        return <StatusBadge color="red" icon={<XCircle className="w-2.5 h-2.5" />}>Failed</StatusBadge>
+        return <StatusBadge color="red" icon={<XCircle className="w-2.5 h-2.5" />}>{t('mlJobs.statusFailed')}</StatusBadge>
       default:
         return <StatusBadge color="gray">{status}</StatusBadge>
     }

--- a/web/src/components/cards/workload-detection/MLNotebooks.tsx
+++ b/web/src/components/cards/workload-detection/MLNotebooks.tsx
@@ -10,11 +10,11 @@ import { useTranslation } from 'react-i18next'
 type Notebook = typeof DEMO_NOTEBOOKS[number]
 type SortByOption = 'name' | 'user' | 'status'
 
-const SORT_OPTIONS = [
-  { value: 'name' as const, label: 'Name' },
-  { value: 'user' as const, label: 'User' },
-  { value: 'status' as const, label: 'Status' },
-]
+const SORT_OPTION_KEYS = [
+  { value: 'name' as const, labelKey: 'mlNotebooks.sortName' },
+  { value: 'user' as const, labelKey: 'mlNotebooks.sortUser' },
+  { value: 'status' as const, labelKey: 'mlNotebooks.sortStatus' },
+] as const
 
 interface MLNotebooksProps {
   config?: Record<string, unknown>
@@ -89,7 +89,7 @@ export function MLNotebooks({ config: _config }: MLNotebooksProps) {
             limit: itemsPerPage,
             onLimitChange: setItemsPerPage,
             sortBy: sorting.sortBy,
-            sortOptions: SORT_OPTIONS,
+            sortOptions: SORT_OPTION_KEYS.map(opt => ({ value: opt.value, label: t(opt.labelKey) })),
             onSortChange: (v) => sorting.setSortBy(v as SortByOption),
             sortDirection: sorting.sortDirection,
             onSortDirectionChange: sorting.setSortDirection,
@@ -102,7 +102,7 @@ export function MLNotebooks({ config: _config }: MLNotebooksProps) {
       <CardSearchInput
         value={filters.search}
         onChange={filters.setSearch}
-        placeholder="Search notebooks..."
+        placeholder={t('mlNotebooks.searchNotebooks')}
         className="mb-3"
       />
 
@@ -125,8 +125,8 @@ export function MLNotebooks({ config: _config }: MLNotebooksProps) {
         <table className="w-full text-sm">
           <thead>
             <tr className="text-xs text-muted-foreground border-b border-border/50">
-              <th className="text-left py-2">Notebook</th>
-              <th className="text-left py-2">User</th>
+              <th className="text-left py-2">{t('mlNotebooks.columnNotebook')}</th>
+              <th className="text-left py-2">{t('mlNotebooks.columnUser')}</th>
               <th className="text-right py-2">{t('common:common.resources')}</th>
               <th className="text-right py-2">{t('common:common.status')}</th>
             </tr>

--- a/web/src/locales/en/cards.json
+++ b/web/src/locales/en/cards.json
@@ -2387,7 +2387,9 @@
     "gaugeTooltip": "GPU Utilization: {{allocated}} of {{total}} GPUs allocated ({{percent}}%)",
     "gpuTypeRowTitle": "{{count}} {{type}} GPUs - Click to view nodes with this GPU type",
     "gpuTypeRowTitle_one": "{{count}} {{type}} GPU - Click to view nodes with this GPU type",
-    "gpuTypeRowTitle_other": "{{count}} {{type}} GPUs - Click to view nodes with this GPU type"
+    "gpuTypeRowTitle_other": "{{count}} {{type}} GPUs - Click to view nodes with this GPU type",
+    "noGPUData": "No GPU Data",
+    "gpuMetricsNotAvailable": "GPU metrics not available"
   },
   "gpuStatus": {
     "noGPUData": "No GPU Data",
@@ -2890,7 +2892,13 @@
     "notebookDetection": "Notebook Detection",
     "notebookDetectionDescription": "Scans for JupyterHub and standalone notebook servers.",
     "idle": "Idle",
-    "stopped": "Stopped"
+    "stopped": "Stopped",
+    "sortName": "Name",
+    "sortUser": "User",
+    "sortStatus": "Status",
+    "searchNotebooks": "Search notebooks...",
+    "columnNotebook": "Notebook",
+    "columnUser": "User"
   },
   "configDrift": {
     "noDriftDetected": "No config drift detected",
@@ -3385,6 +3393,31 @@
   "kagentAgentPicker": {
     "noAgentsAvailable": "No kagent agents available"
   },
+  "kagentSecurity": {
+    "agentTypeCoverage": "Agent Type Coverage",
+    "declarative": "Declarative",
+    "byo": "BYO",
+    "modelAuthStatus": "Model Auth Status",
+    "agentsWithModelConfig": "{{configured}}/{{total}} agents with model config",
+    "toolServers": "Tool Servers",
+    "ready": "Ready",
+    "remote": "Remote",
+    "byoAgentsWarning": "BYO Agents (Less Controlled)",
+    "allDeclarative_one": "All {{count}} agent is Declarative (fully managed)",
+    "allDeclarative_other": "All {{count}} agents are Declarative (fully managed)",
+    "noResources": "No kagent resources found"
+  },
+  "kagentToolRegistry": {
+    "sortName": "Name",
+    "sortKind": "Kind",
+    "sortStatus": "Status",
+    "sortCluster": "Cluster",
+    "searchPlaceholder": "Search tool servers...",
+    "noToolServers": "No Tool Servers",
+    "deployHint": "Deploy ToolServer or RemoteMCPServer CRDs",
+    "toolCount_one": "{{count}} tool",
+    "toolCount_other": "{{count}} tools"
+  },
   "falcoAlerts": {
     "integration": "Falco Integration",
     "installDescription": "Install Falco for runtime security monitoring.",
@@ -3788,7 +3821,11 @@
     "sortStatus": "Status",
     "sortFramework": "Framework",
     "sortGpus": "GPUs",
-    "searchJobs": "Search jobs..."
+    "searchJobs": "Search jobs...",
+    "statusRunning": "Running",
+    "statusQueued": "Queued",
+    "statusCompleted": "Completed",
+    "statusFailed": "Failed"
   },
   "nats_status": {
     "healthy": "Healthy",


### PR DESCRIPTION
Fixes #9456

## Summary
- Move ML Jobs status badge labels (Running, Queued, Done, Failed) to translation keys
- Move ML Notebooks sort option labels, search placeholder, and column headers to translation keys
- Move KagentSecurity UI strings (section titles, summary text, labels) to translation keys with interpolation
- Replace manual English pluralization in KagentToolRegistry (`tool`/`tools`) with i18n `count` plural system
- Create proper `gpuOverview.*` keys for GPUOverview empty state instead of borrowing from `gpuStatus.*`

## Test plan
- [ ] ML Jobs card status badges display correctly (Running, Queued, Done, Failed)
- [ ] ML Notebooks sort dropdown, search placeholder, and table headers display correctly
- [ ] KagentSecurity "All N agents are Declarative" message renders with correct count
- [ ] KagentToolRegistry tool count pluralizes correctly (1 tool, 2 tools)
- [ ] GPUOverview empty state shows "No GPU Data" / "GPU metrics not available" from own namespace
- [ ] No hardcoded English strings remain in badge labels, search, sort, columns