### PR TITLE
fix: consistent icon size across navbar buttons

### DIFF
--- a/web/src/components/layout/navbar/LearnDropdown.tsx
+++ b/web/src/components/layout/navbar/LearnDropdown.tsx
@@ -75,7 +75,7 @@ export function LearnDropdown() {
         )}
         title={t('layout.navbar.learn.title')}
       >
-        <BookOpen className="w-5 h-5" />
+        <BookOpen className="w-4 h-4" />
         <span className="hidden xl:inline">{t('layout.navbar.learn.title')}</span>
       </button>
 


### PR DESCRIPTION
## Summary

- Learn button icon was `w-5 h-5` (20px) while Agent and AI Missions both use `w-4 h-4` (16px)
- Reduced Learn icon to `w-4 h-4` so all navbar buttons match

## Test plan

- [ ] Verify Agent, AI Missions, and Learn buttons look the same size in the navbar

🤖 Generated with [Claude Code](https://claude.com/claude-code)