### PR TITLE
fix: navbar dropdowns hidden behind mission sidebar, tooltip delay, dashboard padding

### DIFF
--- a/web/src/components/layout/Layout.tsx
+++ b/web/src/components/layout/Layout.tsx
@@ -609,7 +609,7 @@ export function Layout({ children: _children }: LayoutProps) {
           id="main-content"
           style={{
             marginLeft: isMobile ? 0 : sidebarWidthPx + SIDEBAR_CONTROLS_OFFSET_PX,
-            marginRight: 'var(--mission-sidebar-width, 0px)' }}
+            marginRight: isMobile ? 0 : `calc(var(--mission-sidebar-width, 0px) + ${SIDEBAR_CONTROLS_OFFSET_PX}px)` }}
           // overflow-x-hidden prevents stray wide children from pushing the
           // entire main column past the viewport at narrow breakpoints
           // (issues 6385, 6387, 6394). Individual scrollable children

--- a/web/src/components/layout/navbar/LearnDropdown.tsx
+++ b/web/src/components/layout/navbar/LearnDropdown.tsx
@@ -81,7 +81,7 @@ export function LearnDropdown() {
 
       {/* Dropdown */}
       {isOpen && (
-        <div className="fixed sm:absolute left-1/2 -translate-x-1/2 sm:left-auto sm:translate-x-0 sm:right-0 top-14 sm:top-full sm:mt-2 w-[calc(100vw-1rem)] sm:w-96 bg-card border border-border rounded-lg shadow-xl z-50 overflow-hidden max-h-[calc(100vh-4rem)] overflow-y-auto">
+        <div className="fixed sm:absolute left-1/2 -translate-x-1/2 sm:left-auto sm:translate-x-0 sm:right-0 top-14 sm:top-full sm:mt-2 w-[calc(100vw-1rem)] sm:w-96 bg-card border border-border rounded-lg shadow-xl z-toast overflow-hidden max-h-[calc(100vh-4rem)] overflow-y-auto">
           {/* Tour */}
           <button
             onClick={handleStartTour}

--- a/web/src/components/layout/navbar/SearchDropdown.tsx
+++ b/web/src/components/layout/navbar/SearchDropdown.tsx
@@ -88,7 +88,7 @@ function SearchResultsPanel({
   let flatIndex = 0
 
   return (
-    <div className="absolute top-full left-0 right-0 mt-2 bg-card border border-border rounded-lg shadow-xl overflow-hidden z-dropdown">
+    <div className="absolute top-full left-0 right-0 mt-2 bg-card border border-border rounded-lg shadow-xl overflow-hidden z-toast">
       {flatResults.length > 0 ? (
         <div ref={resultsRef} data-testid="global-search-results" className="py-1 max-h-96 overflow-y-auto">
           {CATEGORY_ORDER.map(cat => {

--- a/web/src/components/missions/browser/TreeNodeItem.tsx
+++ b/web/src/components/missions/browser/TreeNodeItem.tsx
@@ -1,9 +1,10 @@
-import { memo, useState, useRef, useEffect } from 'react'
+import { memo, useState, useRef, useEffect, useCallback } from 'react'
 import {
   Folder, FolderOpen, FileJson, FileCode, FileText, ChevronRight, ChevronDown,
   Loader2, Globe, HardDrive, Trash2, Plus, RefreshCw, Info } from 'lucide-react'
 import { Github } from '@/lib/icons'
 import { cn } from '../../../lib/cn'
+import { TOOLTIP_SHOW_DELAY_MS } from '../../../lib/constants/network'
 import type { TreeNode } from './types'
 
 /**
@@ -53,6 +54,11 @@ function InfoPopover({ tooltip }: { tooltip: string }) {
   const [show, setShow] = useState(false)
   const [pinned, setPinned] = useState(false)
   const ref = useRef<HTMLDivElement>(null)
+  const hoverTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  const clearHoverTimer = useCallback(() => {
+    if (hoverTimer.current) { clearTimeout(hoverTimer.current); hoverTimer.current = null }
+  }, [])
 
   useEffect(() => {
     if (!pinned) return
@@ -66,12 +72,14 @@ function InfoPopover({ tooltip }: { tooltip: string }) {
     return () => document.removeEventListener('mousedown', onClickOutside)
   }, [pinned])
 
+  useEffect(() => clearHoverTimer, [clearHoverTimer])
+
   return (
     <div
       ref={ref}
       className="relative flex-shrink-0"
-      onMouseEnter={() => setShow(true)}
-      onMouseLeave={() => { if (!pinned) setShow(false) }}
+      onMouseEnter={() => { clearHoverTimer(); hoverTimer.current = setTimeout(() => setShow(true), TOOLTIP_SHOW_DELAY_MS) }}
+      onMouseLeave={() => { clearHoverTimer(); if (!pinned) setShow(false) }}
     >
       <button
         onClick={(e) => { e.stopPropagation(); setPinned(p => !p); setShow(true) }}

--- a/web/src/components/ui/AlertBadge.tsx
+++ b/web/src/components/ui/AlertBadge.tsx
@@ -291,7 +291,7 @@ export function AlertBadge() {
               isMobile
                 ? 'fixed inset-x-0 bottom-0 rounded-t-2xl max-h-[70vh]'
                 : 'absolute right-0 top-full mt-2 w-96 rounded-lg'
-            } bg-background border border-border shadow-xl z-50`}
+            } bg-background border border-border shadow-xl z-toast`}
           >
             {/* Drag handle for mobile */}
             {isMobile && (

--- a/web/src/lib/constants/network.ts
+++ b/web/src/lib/constants/network.ts
@@ -247,6 +247,9 @@ export const POPUP_HIDE_DELAY_MS = 150
 /** Hover tooltip hide delay (50ms) */
 export const TOOLTIP_HIDE_DELAY_MS = 50
 
+/** Hover tooltip/popover show delay — prevents flicker from incidental cursor pass-through */
+export const TOOLTIP_SHOW_DELAY_MS = 250
+
 // ============================================================================
 // AI Mission Chat Limits
 // ============================================================================


### PR DESCRIPTION
## Summary
- **Navbar dropdown z-index**: Learn, AlertBadge, and SearchDropdown were using `z-50` / `z-dropdown` (100), which is below the AI Missions sidebar's `z-modal` (400). Raised all to `z-toast` (500) so they render on top of the sidebar.
- **Tooltip show delay**: Added `TOOLTIP_SHOW_DELAY_MS = 250` constant in `network.ts` and applied it to `InfoPopover` in `TreeNodeItem.tsx` to prevent tooltip flicker from incidental cursor pass-through.
- **Dashboard padding symmetry**: The main content area had `SIDEBAR_CONTROLS_OFFSET_PX` (48px) added to the left margin for sidebar controls, but no matching offset on the right. Added symmetric right margin so dashboard cards have equal spacing on both sides.

Fixes the navbar dropdown clipping, tooltip hover delay, and asymmetric dashboard borders.

## Test plan
- [ ] Open AI Missions sidebar, then click Learn dropdown — should render on top of sidebar
- [ ] Open AI Missions sidebar, then click alerts bell — should render on top
- [ ] Open AI Missions sidebar, then click search — results should render on top
- [ ] Hover over Kubara info (i) icon — tooltip should appear after ~250ms delay, not instantly
- [ ] Click info (i) icon — tooltip should pin open
- [ ] Navigate to any dashboard — left and right content margins should be equal
- [ ] Check mobile layout — no regressions in responsive behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)