### PR TITLE
fix: ACMM stat blocks clarity and MAX_LEVEL bug

### DIFF
--- a/web/src/components/acmm/useACMMStats.ts
+++ b/web/src/components/acmm/useACMMStats.ts
@@ -10,17 +10,16 @@ import { useCallback } from 'react'
 import type { StatBlockValue } from '../ui/StatsOverview'
 import { useACMM } from './ACMMProvider'
 import { ALL_CRITERIA } from '../../lib/acmm/sources'
+import { MAX_LEVEL } from '../../lib/acmm/computeLevel'
 import type { SourceId } from '../../lib/acmm/sources/types'
-
-const MAX_LEVEL = 5
 
 /** Source IDs in display order. */
 const SOURCE_IDS: SourceId[] = ['acmm', 'fullsend', 'agentic-engineering-framework', 'claude-reflect']
-const SOURCE_SHORT_NAMES: Record<SourceId, string> = {
+const SOURCE_NAMES: Record<SourceId, string> = {
   acmm: 'ACMM',
-  fullsend: 'FS',
+  fullsend: 'Fullsend',
   'agentic-engineering-framework': 'AEF',
-  'claude-reflect': 'Refl',
+  'claude-reflect': 'Claude Reflect',
 }
 
 export function useACMMStats() {
@@ -43,38 +42,38 @@ export function useACMMStats() {
           value: level.level,
           sublabel: level.levelName,
           max: MAX_LEVEL,
+          format: (v: number) => `L${v}`,
         }
       case 'acmm_detected':
         return {
           value: detectedCount,
-          sublabel: `of ${totalCriteria}`,
+          sublabel: `${detectedCount} of ${totalCriteria} criteria`,
           max: totalCriteria,
         }
       case 'acmm_next_level':
         if (!nextLevel) {
-          return { value: MAX_LEVEL, sublabel: 'Max level', max: MAX_LEVEL }
+          return { value: MAX_LEVEL, sublabel: `L${MAX_LEVEL} reached`, max: MAX_LEVEL, format: (v: number) => `L${v}` }
         }
         return {
           value: nextDetected,
-          sublabel: `${nextRemaining} to L${nextLevel}`,
+          sublabel: `${nextRemaining} more for L${nextLevel}`,
           max: nextRequired,
         }
       case 'acmm_by_source': {
-        // Build per-source detection ratios for the mini-bar visualization
         const segments = SOURCE_IDS.map((sid) => {
           const srcCriteria = ALL_CRITERIA.filter((c) => c.source === sid)
           const srcDetected = srcCriteria.filter((c) =>
             detectedIds instanceof Set ? detectedIds.has(c.id) : (detectedIds as string[] || []).includes(c.id), // ai-quality-ignore
           ).length
           return {
-            label: SOURCE_SHORT_NAMES[sid],
+            label: SOURCE_NAMES[sid],
             value: srcCriteria.length > 0 ? Math.round((srcDetected / srcCriteria.length) * 100) : 0, // ai-quality-ignore
           }
         })
         const bestSource = segments.reduce((a, b) => (b.value > a.value ? b : a), segments[0])
         return {
           value: `${bestSource?.value ?? 0}%`, // ai-quality-ignore
-          sublabel: `Best: ${bestSource?.label ?? '-'}`,
+          sublabel: `${bestSource?.label ?? '-'} (${segments.length} sources)`,
         }
       }
       default:

--- a/web/src/components/cards/cardMetadata.ts
+++ b/web/src/components/cards/cardMetadata.ts
@@ -326,7 +326,7 @@ export const CARD_TITLES: Record<string, string> = {
 
 // Short descriptions shown via info icon tooltip in the card header
 export const CARD_DESCRIPTIONS: Record<string, string> = {
-  acmm_level: "The repo's current level on the AI Codebase Maturity Model (L1–L5).",
+  acmm_level: "The repo's current level on the AI Codebase Maturity Model (L1–L6).",
   acmm_feedback_loops: 'Inventory of criteria from ACMM, Fullsend, AEF, and Claude-Reflect.',
   acmm_recommendations: 'Your current role and prioritized missing criteria for the next level.',
   cluster_health: 'Overall health status of all connected Kubernetes clusters.',

--- a/web/src/components/charts/ProgressBar.tsx
+++ b/web/src/components/charts/ProgressBar.tsx
@@ -156,6 +156,7 @@ interface CircularProgressProps {
   color?: string
   showValue?: boolean
   label?: string
+  formatValue?: (percentage: number) => string
   thresholds?: {
     warning: number
     critical: number
@@ -170,6 +171,7 @@ export function CircularProgress({
   color,
   showValue = true,
   label,
+  formatValue,
   thresholds,
 }: CircularProgressProps) {
   const percentage = max > 0 ? Math.min((value / max) * 100, 100) : 0
@@ -221,7 +223,7 @@ export function CircularProgress({
         {showValue && (
           <div className="absolute inset-0 flex items-center justify-center">
             <span className="text-lg font-bold text-foreground">
-              {Math.round(percentage)}%
+              {formatValue ? formatValue(percentage) : `${Math.round(percentage)}%`}
             </span>
           </div>
         )}

--- a/web/src/components/dashboard/shared/cardCatalog.ts
+++ b/web/src/components/dashboard/shared/cardCatalog.ts
@@ -347,7 +347,7 @@ export const CARD_CATALOG = {
     { type: 'drasi_reactive_graph', title: 'Drasi Reactive Graph', description: 'Reactive data pipeline — sources, continuous queries, reactions, and live results with animated flow', visualization: 'status' },
   ],
   'Maturity': [
-    { type: 'acmm_level', title: 'Current Level', description: "The repo's current level on the AI Codebase Maturity Model (L1–L5)", visualization: 'gauge' },
+    { type: 'acmm_level', title: 'Current Level', description: "The repo's current level on the AI Codebase Maturity Model (L1–L6)", visualization: 'gauge' },
     { type: 'acmm_balance', title: 'Human vs AI Balance', description: 'Weekly AI vs human contribution trend with a balance target slider anchored to ACMM levels', visualization: 'timeseries' },
     { type: 'acmm_feedback_loops', title: 'Feedback Loop Inventory', description: 'Inventory of criteria from ACMM + Fullsend + Agentic Engineering Framework + Claude Reflect', visualization: 'status' },
     { type: 'acmm_recommendations', title: 'Your Role + Next Steps', description: 'Current role and prioritized missing criteria for the next level', visualization: 'status' },

--- a/web/src/components/ui/StatsBlockDefinitions.ts
+++ b/web/src/components/ui/StatsBlockDefinitions.ts
@@ -417,10 +417,10 @@ export const MULTI_TENANCY_STAT_BLOCKS: StatBlockConfig[] = [
  * Default stat blocks for the ACMM dashboard
  */
 export const ACMM_STAT_BLOCKS: StatBlockConfig[] = [
-  { id: 'acmm_level', name: 'Level', icon: 'BarChart3', visible: true, color: 'purple', displayMode: 'ring' },
-  { id: 'acmm_detected', name: 'Detected', icon: 'CheckCircle2', visible: true, color: 'green', displayMode: 'gauge' },
-  { id: 'acmm_next_level', name: 'To Next Level', icon: 'TrendingUp', visible: true, color: 'cyan', displayMode: 'ring' },
-  { id: 'acmm_by_source', name: 'By Source', icon: 'Layers', visible: true, color: 'blue', displayMode: 'mini-bar' },
+  { id: 'acmm_level', name: 'Maturity Level', icon: 'BarChart3', visible: true, color: 'purple', displayMode: 'ring' },
+  { id: 'acmm_detected', name: 'Criteria Met', icon: 'CheckCircle2', visible: true, color: 'green', displayMode: 'gauge' },
+  { id: 'acmm_next_level', name: 'Next Level', icon: 'TrendingUp', visible: true, color: 'cyan', displayMode: 'ring' },
+  { id: 'acmm_by_source', name: 'Best Source', icon: 'Layers', visible: true, color: 'blue', displayMode: 'mini-bar' },
 ]
 
 /**

--- a/web/src/components/ui/StatsOverview.tsx
+++ b/web/src/components/ui/StatsOverview.tsx
@@ -291,6 +291,7 @@ const StatBlock = memo(function StatBlock({ block, data, hasData, isLoading, his
               size={RING_SIZE_PX}
               strokeWidth={RING_STROKE_PX}
               color={hexColor}
+              formatValue={data.format && typeof rawValue === 'number' ? () => data.format!(rawValue as number) : undefined}
             />
           </div>
           {data.sublabel && <div className="text-xs text-muted-foreground text-center mt-1">{wrapAbbreviations(data.sublabel)}</div>}


### PR DESCRIPTION
## Summary
- **Level block**: Was showing raw number (e.g. "5") — now shows "L5" with level name sublabel. Ring center displays "L5" instead of "100%"
- **Criteria Met block** (was "Detected"): Sublabel now reads "40 of 85 criteria" instead of cryptic "of 85"
- **Next Level block**: `MAX_LEVEL` was hardcoded to 5, missing L6 (Fully Autonomous). Now imports from `computeLevel.ts`. At L5 shows "2 more for L6" instead of "Max level"
- **Best Source block** (was "By Source"): Shows full source name with count instead of cryptic abbreviation
- Added `formatValue` prop to `CircularProgress` for custom ring center text
- Updated card descriptions from L1–L5 to L1–L6

Fixes the stat block confusion reported after the L5 criteria were implemented in #9462.

## Test plan
- [ ] Verify Level ring shows "L5" (not "5" or "100%") with "Semi-Automated" sublabel
- [ ] Verify Criteria Met gauge shows correct count with "X of Y criteria" sublabel
- [ ] Verify Next Level shows progress toward L6 (not "Max level") for L5 repos
- [ ] Verify Best Source shows full source name
- [ ] Verify demo mode renders correctly