### PR TITLE
fix: update useDataSource test to expect CSRF header

### DIFF
--- a/web/src/lib/unified/card/hooks/__tests__/useDataSource.test.ts
+++ b/web/src/lib/unified/card/hooks/__tests__/useDataSource.test.ts
@@ -637,7 +637,7 @@ describe('useDataSource — api type', () => {
     const fetchCall = mockFetch.mock.calls[0]
     expect(fetchCall[0]).toBe('/api/query')
     expect(fetchCall[1].method).toBe('POST')
-    expect(fetchCall[1].headers).toEqual({ 'Content-Type': 'application/json' })
+    expect(fetchCall[1].headers).toEqual({ 'Content-Type': 'application/json', 'X-Requested-With': 'XMLHttpRequest' })
     expect(fetchCall[1].body).toBe(JSON.stringify(params))
   })
 


### PR DESCRIPTION
## Summary
- Updates the `useDataSource` test "sends JSON body for POST requests" to expect the `X-Requested-With: XMLHttpRequest` header that was added by PR #9450
- PR #9450 added the CSRF header to all raw fetch POST calls but did not update the test assertion, causing an exact-equality check to fail

Fixes #9451

## Test plan
- [ ] `vitest run src/lib/unified/card/hooks/__tests__/useDataSource.test.ts` passes
- [ ] CI build/lint green