### PR TITLE
fix: network card data accuracy and i18n wrapping

### DIFF
--- a/web/src/components/cards/ClusterNetwork.tsx
+++ b/web/src/components/cards/ClusterNetwork.tsx
@@ -184,7 +184,9 @@ export function ClusterNetwork({ config }: ClusterNetworkProps) {
               <Shield className="w-4 h-4 text-purple-400" />
               <span className="text-sm text-muted-foreground">TLS</span>
             </div>
-            <span className="text-sm font-medium text-green-400">{t('common:common.enabled')}</span>
+            <span className={`text-sm font-medium ${serverInfo?.protocol === 'https' ? 'text-green-400' : 'text-red-400'}`}>
+              {serverInfo?.protocol === 'https' ? t('common:common.enabled') : t('common:common.disabled')}
+            </span>
           </div>
         </div>
 

--- a/web/src/components/cards/DNSHealth.tsx
+++ b/web/src/components/cards/DNSHealth.tsx
@@ -95,7 +95,9 @@ export function DNSHealth() {
             </div>
             <div className="flex gap-1 mt-1 flex-wrap">
               {clusterPods.map(pod => {
-                const version = pod.containers?.[0]?.image?.split(':')[1] || ''
+                const rawVersion = pod.containers?.[0]?.image?.split(':')[1] || ''
+                // Strip @sha256 digest suffix and normalize leading 'v' prefix
+                const version = rawVersion.split('@')[0].replace(/^v+/, '')
                 return (
                   <span
                     key={pod.name}

--- a/web/src/components/cards/NetworkOverview.tsx
+++ b/web/src/components/cards/NetworkOverview.tsx
@@ -10,8 +10,10 @@ import { useChartFilters } from '../../lib/cards/cardHooks'
 import { ClusterStatusDot } from '../ui/ClusterStatusBadge'
 import { RefreshIndicator } from '../ui/RefreshIndicator'
 import { Skeleton, SkeletonStats, SkeletonList } from '../ui/Skeleton'
+import { useTranslation } from 'react-i18next'
 
 export function NetworkOverview() {
+  const { t } = useTranslation(['cards', 'common'])
   const { deduplicatedClusters: clusters, isLoading, isRefreshing: clustersRefreshing, lastRefresh: clustersLastRefreshDate } = useClusters()
   // #6271: useClusters returns lastRefresh as `Date | null`, but the
   // freshness merge below expects a numeric epoch. Normalize once.
@@ -127,8 +129,8 @@ export function NetworkOverview() {
   if (showEmptyState) {
     return (
       <div className="h-full flex flex-col items-center justify-center min-h-card text-muted-foreground">
-        <p className="text-sm">No network services</p>
-        <p className="text-xs mt-1">Services will appear when deployed</p>
+        <p className="text-sm">{t('cards:networkOverview.noNetworkServices')}</p>
+        <p className="text-xs mt-1">{t('cards:networkOverview.servicesWillAppear')}</p>
       </div>
     )
   }
@@ -139,23 +141,23 @@ export function NetworkOverview() {
       {filteredClusters.length > 0 && (
         <div className="flex items-center gap-2 mb-3 px-2 py-1.5 bg-secondary/30 rounded-lg">
           <Activity className="w-3 h-3 text-muted-foreground" />
-          <span className="text-xs text-muted-foreground">Cluster Health:</span>
+          <span className="text-xs text-muted-foreground">{t('cards:networkOverview.clusterHealth')}</span>
           {stats.healthyClusters > 0 && (
             <span className="flex items-center gap-1 text-xs">
               <ClusterStatusDot state="healthy" size="sm" />
-              <span className="text-green-400">{stats.healthyClusters} healthy</span>
+              <span className="text-green-400">{stats.healthyClusters} {t('cards:networkOverview.healthy')}</span>
             </span>
           )}
           {stats.degradedClusters > 0 && (
             <span className="flex items-center gap-1 text-xs">
               <ClusterStatusDot state="degraded" size="sm" />
-              <span className="text-orange-400">{stats.degradedClusters} degraded</span>
+              <span className="text-orange-400">{stats.degradedClusters} {t('cards:networkOverview.degraded')}</span>
             </span>
           )}
           {stats.offlineClusters > 0 && (
             <span className="flex items-center gap-1 text-xs">
               <ClusterStatusDot state="unreachable-timeout" size="sm" />
-              <span className="text-yellow-400">{stats.offlineClusters} offline</span>
+              <span className="text-yellow-400">{stats.offlineClusters} {t('cards:networkOverview.offline')}</span>
             </span>
           )}
         </div>
@@ -216,31 +218,25 @@ export function NetworkOverview() {
         className={`p-3 rounded-lg bg-cyan-500/10 border border-cyan-500/20 mb-4 ${stats.totalServices > 0 ? 'cursor-pointer hover:bg-cyan-500/20 focus:outline-none focus-visible:ring-2 focus-visible:ring-cyan-400' : 'cursor-default'} transition-colors`}
         {...(stats.totalServices > 0 ? { role: 'button' as const, tabIndex: 0 } : {})}
         onClick={() => {
-          if (stats.totalServices > 0 && filteredServices[0]) {
-            const svc = filteredServices[0]
-            if (svc.cluster && svc.namespace) {
-              drillToService(svc.cluster, svc.namespace, svc.name)
-            }
+          if (stats.totalServices > 0) {
+            drillToAllServices(undefined, { services: filteredServices })
           }
         }}
         onKeyDown={(e) => {
-          if ((e.key === 'Enter' || e.key === ' ') && stats.totalServices > 0 && filteredServices[0]) {
+          if ((e.key === 'Enter' || e.key === ' ') && stats.totalServices > 0) {
             e.preventDefault()
-            const svc = filteredServices[0]
-            if (svc.cluster && svc.namespace) {
-              drillToService(svc.cluster, svc.namespace, svc.name)
-            }
+            drillToAllServices(undefined, { services: filteredServices })
           }
         }}
         title={stats.totalServices > 0 ? `${stats.totalServices} total services across ${stats.clustersWithServices} cluster${stats.clustersWithServices !== 1 ? 's' : ''} - Click to view details` : 'No services found'}
       >
         <div className="flex items-center gap-2 mb-1">
           <Layers className="w-4 h-4 text-cyan-400" />
-          <span className="text-xs text-cyan-400">Total Services</span>
+          <span className="text-xs text-cyan-400">{t('cards:networkOverview.totalServices')}</span>
         </div>
         <span className="text-2xl font-bold text-foreground">{stats.totalServices}</span>
         <div className="text-xs text-muted-foreground mt-1">
-          across {stats.clustersWithServices} cluster{stats.clustersWithServices !== 1 ? 's' : ''}
+          {t('cards:networkOverview.acrossClusters', { count: stats.clustersWithServices })}
         </div>
       </div>
 
@@ -355,7 +351,7 @@ export function NetworkOverview() {
       {/* Top Namespaces */}
       {stats.namespaces.length > 0 && (
         <div className="flex-1">
-          <div className="text-xs text-muted-foreground mb-2">Top Namespaces</div>
+          <div className="text-xs text-muted-foreground mb-2">{t('cards:networkOverview.topNamespaces')}</div>
           {/* Issue 8883: Top Namespaces is a roving-tabindex list; arrow keys
               traverse siblings, Home/End jump to ends, Enter/Space activate. */}
           <div className="space-y-1.5" role="list">
@@ -399,7 +395,7 @@ export function NetworkOverview() {
                   title={`${count} service${count !== 1 ? 's' : ''} in namespace ${name}${isInteractive ? ' - Click or press Enter to view' : ''}`}
                 >
                   <span className="text-sm text-foreground truncate min-w-0 flex-1">{name}</span>
-                  <span className="text-xs text-muted-foreground shrink-0">{count} services</span>
+                  <span className="text-xs text-muted-foreground shrink-0">{t('cards:networkOverview.servicesCount', { count })}</span>
                 </div>
               )
             })}
@@ -409,7 +405,7 @@ export function NetworkOverview() {
 
       {/* Footer */}
       <div className="mt-3 pt-3 border-t border-border/50 text-xs text-muted-foreground">
-        {`${stats.totalServices} services across ${filteredClusters.length} clusters`}
+        {t('cards:networkOverview.footerSummary', { services: stats.totalServices, clusters: filteredClusters.length })}
       </div>
     </div>
   )

--- a/web/src/components/cards/NetworkPolicyCoverage.tsx
+++ b/web/src/components/cards/NetworkPolicyCoverage.tsx
@@ -33,7 +33,7 @@ export function NetworkPolicyCoverage() {
     isDemoData: isDemoFallback,
     isFailed,
     consecutiveFailures: podsFailures,
-    errorMessage: isFailed ? 'Failed to load network policy data' : undefined })
+    errorMessage: isFailed ? t('networkPolicyCoverage.failedToLoad') : undefined })
 
   // Build a set of namespace keys that have real NetworkPolicy resources
   const policyNamespaceKeys = (() => {

--- a/web/src/locales/en/cards.json
+++ b/web/src/locales/en/cards.json
@@ -1164,7 +1164,16 @@
     "servicesWillAppear": "Services will appear when deployed",
     "clusterHealth": "Cluster Health:",
     "healthy": "healthy",
-    "topNamespaces": "Top Namespaces"
+    "degraded": "degraded",
+    "offline": "offline",
+    "topNamespaces": "Top Namespaces",
+    "acrossClusters": "across {{count}} cluster",
+    "acrossClusters_one": "across {{count}} cluster",
+    "acrossClusters_other": "across {{count}} clusters",
+    "servicesCount": "{{count}} services",
+    "servicesCount_one": "{{count}} service",
+    "servicesCount_other": "{{count}} services",
+    "footerSummary": "{{services}} services across {{clusters}} clusters"
   },
   "dataCompliance": {
     "gdpr": "GDPR",
@@ -2112,7 +2121,8 @@
     "policiesAndPods": "{{policies}} policies, {{pods}} pods",
     "estimated": "Estimated (policy API unavailable)",
     "estimatedTooltip": "NetworkPolicy resources could not be fetched. Coverage is estimated based on namespace type (system vs user). Connect the agent or check API access for accurate data.",
-    "showingOf": "Showing {{shown}} of {{total}} namespaces"
+    "showingOf": "Showing {{shown}} of {{total}} namespaces",
+    "failedToLoad": "Failed to load network policy data"
   },
   "quotaHeatmap": {
     "noNamespaceData": "No namespace data",


### PR DESCRIPTION
## Summary
- **ClusterNetwork TLS**: now checks whether the cluster URL uses `https://` before showing TLS Enabled; shows Disabled (red) for non-TLS clusters
- **NetworkOverview Total Services**: clicking the count now drills into the all-services list view instead of navigating to a single arbitrary service
- **DNSHealth versions**: strips `@sha256:...` digest suffix and normalizes double-`v` prefix so versions display cleanly (e.g. `v1.11.3` instead of `vv1.11.3@sha256:abc...`)
- **NetworkOverview i18n**: wrapped all hardcoded English strings (Cluster Health, healthy/degraded/offline, Total Services, across N clusters, Top Namespaces, N services, empty state, footer) in `t()` calls
- **NetworkPolicyCoverage i18n**: wrapped hardcoded "Failed to load network policy data" error message in `t()` call
- Added 9 new i18n keys to `cards.json` under `networkOverview` and `networkPolicyCoverage` namespaces

## Test plan
- [ ] Open ClusterNetwork card with an HTTP-only cluster and verify TLS shows "Disabled" in red
- [ ] Open ClusterNetwork card with an HTTPS cluster and verify TLS shows "Enabled" in green
- [ ] Click "Total Services" count in NetworkOverview and verify it opens the all-services drill-down (not a single service)
- [ ] Check DNSHealth card with digest-pinned CoreDNS images and verify version displays without `@sha256` or `vv` prefix
- [ ] Verify all NetworkOverview visible text renders correctly from i18n keys
- [ ] Verify NetworkPolicyCoverage error state shows localized error message

Fixes #9467, Fixes #9471