### PR TITLE
fix: network controls feedback and topology UX

### DIFF
--- a/web/src/components/cards/ClusterNetwork.tsx
+++ b/web/src/components/cards/ClusterNetwork.tsx
@@ -50,6 +50,11 @@ export function ClusterNetwork({ config }: ClusterNetworkProps) {
     return result
   })()
 
+  // Detect when the selected cluster is hidden by global filters
+  const isSelectedClusterFiltered = selectedCluster !== '' &&
+    !clusters.some(c => c.name === selectedCluster) &&
+    allClusters.some(c => c.name === selectedCluster)
+
   const cluster = clusters.find(c => c.name === selectedCluster)
 
   // Parse server URL for display
@@ -88,12 +93,12 @@ export function ClusterNetwork({ config }: ClusterNetworkProps) {
     )
   }
 
-  if (!selectedCluster) {
+  if (!selectedCluster || isSelectedClusterFiltered) {
     return (
       <div className="h-full flex flex-col min-h-card">
         <div className="flex items-center justify-end mb-4">
           <select
-            value={selectedCluster}
+            value={isSelectedClusterFiltered ? '' : selectedCluster}
             onChange={(e) => setSelectedCluster(e.target.value)}
             className="px-3 py-1.5 rounded-lg bg-secondary border border-border text-sm text-foreground"
           >
@@ -103,8 +108,10 @@ export function ClusterNetwork({ config }: ClusterNetworkProps) {
             ))}
           </select>
         </div>
-        <div className="flex-1 flex items-center justify-center text-muted-foreground">
-          {t('cards:clusterNetwork.selectClusterToView')}
+        <div className="flex-1 flex items-center justify-center text-muted-foreground text-sm text-center px-4">
+          {isSelectedClusterFiltered
+            ? t('cards:clusterNetwork.clusterHiddenByFilter')
+            : t('cards:clusterNetwork.selectClusterToView')}
         </div>
       </div>
     )

--- a/web/src/components/cards/NetworkPolicyCoverage.tsx
+++ b/web/src/components/cards/NetworkPolicyCoverage.tsx
@@ -4,6 +4,9 @@ import { useCachedPods } from '../../hooks/useCachedData'
 import { useNetworkPolicies } from '../../hooks/mcp/networking'
 import { useCardLoadingState } from './CardDataContext'
 
+/** Maximum number of namespaces to display before showing a truncation indicator */
+const MAX_DISPLAYED_NAMESPACES = 30
+
 interface NamespaceCoverage {
   namespace: string
   cluster: string
@@ -153,7 +156,7 @@ export function NetworkPolicyCoverage() {
 
       {/* Namespace list */}
       <div className="space-y-1 max-h-[250px] overflow-y-auto">
-        {displayed.slice(0, 30).map(ns => (
+        {displayed.slice(0, MAX_DISPLAYED_NAMESPACES).map(ns => (
           <div key={`${ns.cluster}/${ns.namespace}`} className="flex flex-wrap items-center justify-between gap-y-2 px-2 py-1 rounded-lg bg-muted/30 hover:bg-muted/50 transition-colors">
             <div className="flex items-center gap-2 min-w-0">
               <div className={`w-2 h-2 rounded-full ${ns.hasPolicies ? 'bg-green-500' : 'bg-red-500'}`} />
@@ -170,6 +173,11 @@ export function NetworkPolicyCoverage() {
             </div>
           </div>
         ))}
+        {displayed.length > MAX_DISPLAYED_NAMESPACES && (
+          <div className="text-xs text-muted-foreground text-center py-1">
+            {t('networkPolicyCoverage.showingOf', { shown: MAX_DISPLAYED_NAMESPACES, total: displayed.length })}
+          </div>
+        )}
       </div>
     </div>
   )

--- a/web/src/components/cards/NetworkUtils.tsx
+++ b/web/src/components/cards/NetworkUtils.tsx
@@ -383,11 +383,13 @@ export function NetworkUtils() {
             <div className="flex gap-2 mb-3">
               <button
                 onClick={() => setContinuousPing(!continuousPing)}
-                className={`flex-1 flex items-center justify-center gap-1 px-3 py-1.5 text-sm rounded transition-colors ${
+                disabled={!continuousPing && pingHosts.length === 0}
+                className={`flex-1 flex items-center justify-center gap-1 px-3 py-1.5 text-sm rounded transition-colors disabled:opacity-50 disabled:cursor-not-allowed ${
                   continuousPing
                     ? 'bg-red-500/20 text-red-400 hover:bg-red-500/30'
                     : 'bg-green-500/20 text-green-400 hover:bg-green-500/30'
                 }`}
+                title={pingHosts.length === 0 ? t('networkUtils.noHostsWarning') : undefined}
               >
                 {continuousPing ? (
                   <>
@@ -416,7 +418,7 @@ export function NetworkUtils() {
               </select>
               <button
                 onClick={pingAllHosts}
-                disabled={isPinging || continuousPing}
+                disabled={isPinging || continuousPing || pingHosts.length === 0}
                 className="flex items-center gap-1 px-3 py-1.5 text-sm bg-secondary hover:bg-secondary/80 rounded disabled:opacity-50"
                 title={t('networkUtils.pingOnce')}
               >

--- a/web/src/components/cards/ServiceTopology.tsx
+++ b/web/src/components/cards/ServiceTopology.tsx
@@ -112,8 +112,15 @@ export function ServiceTopology({ config: _config }: ServiceTopologyProps) {
     return positions
   }, [nodesByCluster])
 
-  const handleZoomIn = () => setZoom(z => Math.min(z + 0.2, 2))
-  const handleZoomOut = () => setZoom(z => Math.max(z - 0.2, 0.5))
+  /** Minimum zoom level for the topology view */
+  const MIN_ZOOM = 0.5
+  /** Maximum zoom level for the topology view */
+  const MAX_ZOOM = 2
+  /** Zoom step increment/decrement per click */
+  const ZOOM_STEP = 0.2
+
+  const handleZoomIn = () => setZoom(z => Math.min(z + ZOOM_STEP, MAX_ZOOM))
+  const handleZoomOut = () => setZoom(z => Math.max(z - ZOOM_STEP, MIN_ZOOM))
   const handleResetZoom = () => setZoom(1)
 
   const selectedNodeData = selectedNode ? nodes.find(n => n.id === selectedNode) : null
@@ -129,6 +136,17 @@ export function ServiceTopology({ config: _config }: ServiceTopologyProps) {
     )
   }
 
+  // Empty state when no services/nodes are found
+  if (nodes.length === 0) {
+    return (
+      <div className="h-full flex flex-col items-center justify-center min-h-card text-muted-foreground">
+        <ZoomIn className="w-8 h-8 mb-2 opacity-40" />
+        <p className="text-sm">{t('serviceTopology.noServices')}</p>
+        <p className="text-xs mt-1">{t('serviceTopology.noServicesHint')}</p>
+      </div>
+    )
+  }
+
   return (
     <div className="h-full flex flex-col min-h-card">
       {/* Header */}
@@ -139,6 +157,7 @@ export function ServiceTopology({ config: _config }: ServiceTopologyProps) {
             size="sm"
             icon={<ZoomOut className="w-3.5 h-3.5" />}
             onClick={handleZoomOut}
+            disabled={zoom <= MIN_ZOOM}
             title={t('serviceTopology.zoomOut')}
             className="p-1 hover:bg-secondary rounded"
           />
@@ -155,6 +174,7 @@ export function ServiceTopology({ config: _config }: ServiceTopologyProps) {
             size="sm"
             icon={<ZoomIn className="w-3.5 h-3.5" />}
             onClick={handleZoomIn}
+            disabled={zoom >= MAX_ZOOM}
             title={t('serviceTopology.zoomIn')}
             className="p-1 hover:bg-secondary rounded"
           />
@@ -295,8 +315,7 @@ export function ServiceTopology({ config: _config }: ServiceTopologyProps) {
                   cx={pos.x}
                   cy={pos.y}
                   r={radius}
-                  className={`${colorClass} ${isSelected || isHovered ? 'opacity-100' : 'opacity-80'} transition-all`}
-                  stroke={isSelected ? 'white' : 'transparent'}
+                  className={`${colorClass} ${isSelected || isHovered ? 'opacity-100' : 'opacity-80'} transition-all ${isSelected ? 'stroke-foreground' : ''}`}
                   strokeWidth={isSelected ? 0.5 : 0}
                 />
 

--- a/web/src/locales/en/cards.json
+++ b/web/src/locales/en/cards.json
@@ -1308,7 +1308,8 @@
     "host": "Host",
     "connectionStatus": "Connection Status",
     "connected": "Connected",
-    "disconnected": "Disconnected"
+    "disconnected": "Disconnected",
+    "clusterHiddenByFilter": "Selected cluster is hidden by the global filter. Choose another cluster or adjust the filter."
   },
   "kagenti": {
     "agents": "Agents",
@@ -2110,7 +2111,8 @@
     "podsCount_other": "{{count}} pods",
     "policiesAndPods": "{{policies}} policies, {{pods}} pods",
     "estimated": "Estimated (policy API unavailable)",
-    "estimatedTooltip": "NetworkPolicy resources could not be fetched. Coverage is estimated based on namespace type (system vs user). Connect the agent or check API access for accurate data."
+    "estimatedTooltip": "NetworkPolicy resources could not be fetched. Coverage is estimated based on namespace type (system vs user). Connect the agent or check API access for accurate data.",
+    "showingOf": "Showing {{shown}} of {{total}} namespaces"
   },
   "quotaHeatmap": {
     "noNamespaceData": "No namespace data",
@@ -2721,7 +2723,9 @@
     "exported": "Exported",
     "imported": "Imported",
     "nEndpoints_one": "{{count}} endpoint",
-    "nEndpoints_other": "{{count}} endpoints"
+    "nEndpoints_other": "{{count}} endpoints",
+    "noServices": "No services found",
+    "noServicesHint": "Service topology will appear when services are discovered in connected clusters"
   },
   "crdHealth": {
     "group": "Group",

--- a/web/src/locales/en/common.json
+++ b/web/src/locales/en/common.json
@@ -1422,7 +1422,8 @@
     "cookiesEnabled": "Cookies Enabled",
     "yes": "Yes",
     "no": "No",
-    "diagnosticsNote": "Full network diagnostics (traceroute, DNS lookup, port scanning) require backend API support due to browser security restrictions."
+    "diagnosticsNote": "Full network diagnostics (traceroute, DNS lookup, port scanning) require backend API support due to browser security restrictions.",
+    "noHostsWarning": "Add at least one host before starting"
   },
   "cardFactory": {
     "formatText": "Text",


### PR DESCRIPTION
## Summary

- **NetworkUtils ping**: Disable Start and single-ping buttons when no hosts are configured, preventing a timer that monitors nothing
- **NetworkPolicyCoverage**: Show "Showing 30 of N namespaces" indicator when the list is truncated, replacing the silent cutoff
- **ClusterNetwork**: Detect when the selected cluster is hidden by the global filter and show an explanatory message instead of a blank selector
- **ServiceTopology selection ring**: Use `stroke-foreground` (theme-aware) instead of hardcoded white, so selections are visible in light mode
- **ServiceTopology zoom buttons**: Disable zoom-out at min zoom (0.5) and zoom-in at max zoom (2.0); extract named constants for limits
- **ServiceTopology empty state**: Show a message when no services are found instead of a blank canvas

## Test plan

- [ ] Open NetworkUtils card with no hosts configured — Start button should be disabled with tooltip
- [ ] Open NetworkPolicyCoverage on a cluster with >30 namespaces — truncation message should appear
- [ ] Select a cluster in ClusterNetwork, then apply a global filter that hides it — message should appear
- [ ] Switch to light mode and click a node in ServiceTopology — selection ring should be visible (dark stroke)
- [ ] Zoom all the way out in ServiceTopology — zoom-out button should be disabled
- [ ] Open ServiceTopology on a cluster with no services — empty state message should appear

Fixes #9468, Fixes #9469