### PR TITLE
fix: update GPUOverview test for empty GPU state

### DIFF
--- a/web/src/components/cards/__tests__/GPUOverview.test.tsx
+++ b/web/src/components/cards/__tests__/GPUOverview.test.tsx
@@ -147,7 +147,7 @@ describe('GPUOverview', () => {
     it('shows no GPU data when clusters reachable but no GPU nodes', () => {
       render(<GPUOverview />)
       // nodes=[], totalGPUs=0 → empty state
-      expect(screen.getByText('gpuStatus.noGPUData')).toBeTruthy()
+      expect(screen.getByText('gpuOverview.noGPUData')).toBeTruthy()
     })
   })
 


### PR DESCRIPTION
Fixes #9475

The `Empty GPU state` test was asserting on the wrong i18n key (`gpuStatus.noGPUData`) instead of the correct key used by the component (`gpuOverview.noGPUData`). This was a pre-existing bug in the test that surfaced after the CSRF header commit (d4a155c) likely due to test ordering or cache changes.