### PR TITLE
fix: resolve Cancelling... UI infinite deadlock

### DIFF
--- a/web/src/hooks/useMissions.save-run.test.tsx
+++ b/web/src/hooks/useMissions.save-run.test.tsx
@@ -850,6 +850,31 @@ describe('cancelling mission receives terminal messages', () => {
     expect(result.current.missions.find(m => m.id === missionId)?.status).toBe('cancelled')
   })
 
+  // #9477 — When the backend sends `{type: "result", payload: {cancelled: true}}`
+  // WITHOUT a `sessionId` field, the hook should resolve the mission ID from
+  // the active cancel intents and still finalize the cancellation instead of
+  // leaving the UI stuck on "Cancelling..." forever.
+  it('finalizes cancellation on result with cancelled:true but no sessionId (#9477)', async () => {
+    const { result } = renderHook(() => useMissions(), { wrapper })
+    const { missionId } = await startMissionWithConnection(result)
+
+    act(() => { result.current.cancelMission(missionId) })
+    expect(result.current.missions.find(m => m.id === missionId)?.status).toBe('cancelling')
+
+    // Backend replies with cancelled:true but omits sessionId entirely
+    act(() => {
+      MockWebSocket.lastInstance?.simulateMessage({
+        id: `cancel-${Date.now()}`,
+        type: 'result',
+        payload: { cancelled: true },
+      })
+    })
+
+    const mission = result.current.missions.find(m => m.id === missionId)
+    expect(mission?.status).toBe('cancelled')
+    expect(mission?.messages.some(m => m.content.includes('cancelled by user'))).toBe(true)
+  })
+
   it('prevents double-cancel (no duplicate timeout)', async () => {
     const { result } = renderHook(() => useMissions(), { wrapper })
     const { missionId } = await startMissionWithConnection(result)

--- a/web/src/hooks/useMissions.tsx
+++ b/web/src/hooks/useMissions.tsx
@@ -1409,12 +1409,21 @@ The WebSocket connection to the agent at \`${LOCAL_AGENT_WS_URL}\` was lost and 
     const isDedicatedCancelAck =
       message.type === CANCEL_ACK_MESSAGE_TYPE ||
       message.type === CANCEL_CONFIRMED_MESSAGE_TYPE
+    // #9477 — The backend may send `cancelled` without `sessionId` in the
+    // payload (e.g. when the cancel request payload itself had an empty
+    // sessionId, or when a proxy strips the field). Previously the check
+    // required BOTH `cancelled` AND `sessionId` in the payload, causing the
+    // message to fall through to the generic result handler where it was
+    // silently dropped (the cancel message's `id` is `cancel-<ts>`, which
+    // is never registered in pendingRequests). This left the UI stuck on
+    // "Cancelling..." indefinitely. Now we only require `cancelled` in the
+    // payload, and fall back to resolving the mission ID from cancelIntents
+    // or the missions list when `sessionId`/`id` are absent.
     const isCancelResultMessage =
       message.type === 'result' &&
       !!message.payload &&
       typeof message.payload === 'object' &&
-      'cancelled' in (message.payload as Record<string, unknown>) &&
-      'sessionId' in (message.payload as Record<string, unknown>)
+      'cancelled' in (message.payload as Record<string, unknown>)
     if (isDedicatedCancelAck || isCancelResultMessage) {
       const payload = message.payload as {
         sessionId?: string
@@ -1425,7 +1434,23 @@ The WebSocket connection to the agent at \`${LOCAL_AGENT_WS_URL}\` was lost and 
       }
       // #7310 — Backend may send `id` instead of `sessionId` in the cancel_ack
       // payload. Check both fields to avoid a permanent cancelling state lock.
-      const cancelledMissionId = payload.sessionId || payload.id
+      // #9477 — When neither field is present, resolve the mission ID from the
+      // active cancel intents or from missions currently in 'cancelling' status.
+      let cancelledMissionId = payload.sessionId || payload.id
+      if (!cancelledMissionId) {
+        // First try cancelIntents — the authoritative set of missions with
+        // pending cancellation requests.
+        const intentIds = Array.from(cancelIntents.current)
+        if (intentIds.length === 1) {
+          cancelledMissionId = intentIds[0]
+        } else {
+          // Fall back to the first mission in 'cancelling' status.
+          const cancellingMission = missionsRef.current.find(m => m.status === 'cancelling')
+          if (cancellingMission) {
+            cancelledMissionId = cancellingMission.id
+          }
+        }
+      }
       if (cancelledMissionId) {
         // Treat either `success === false` (cancel_ack shape) or
         // `cancelled === false` (result shape from handleCancelChat) as a


### PR DESCRIPTION
## Summary
- Fixes the cancel acknowledgment mismatch where backend sends `{type: "result", payload: {cancelled: true}}` but the hook required both `cancelled` AND `sessionId` in the payload
- When `sessionId` is absent, the hook now resolves the mission ID from `cancelIntents` or from missions in `cancelling` status
- UI no longer gets stuck on "Cancelling..." after canceling an AI mission

Fixes #9477

## Test plan
- [ ] Start an AI mission, click Cancel during "Processing with AI..."
- [ ] Verify UI unlocks immediately instead of getting stuck on "Cancelling..."
- [ ] Verify normal mission completion still works
- [ ] New test case covers `cancelled:true` without `sessionId` in payload