### PR TITLE
fix: make mission timeout configurable and respect user's primary agent

### DIFF
--- a/pkg/agent/insight_worker.go
+++ b/pkg/agent/insight_worker.go
@@ -215,10 +215,14 @@ func (w *InsightWorker) Enrich(req InsightEnrichmentRequest) (*InsightEnrichment
 	return &resp, nil
 }
 
-// providerPriority lists provider names in preference order for insight enrichment
-var providerPriority = []string{"claude-code", "bob", "claude", "openai", "gemini", "ollama"}
+// defaultProviderPriority is the fallback ordering when no primary agent has
+// been selected by the user.  Used by callAIProvider (#9484).
+var defaultProviderPriority = []string{"claude-code", "bob", "claude", "openai", "gemini", "ollama"}
 
-// callAIProvider sends insights to the AI provider for enrichment
+// callAIProvider sends insights to the AI provider for enrichment.
+// If the user has selected a primary agent (via the registry default), that
+// agent is tried first.  If it fails or is unavailable the remaining providers
+// in defaultProviderPriority are tried in order (#9484).
 func (w *InsightWorker) callAIProvider(insights []InsightSummary) ([]AIInsightEnrichment, string, error) {
 	if w.registry == nil {
 		return nil, "", fmt.Errorf("no provider registry available")
@@ -239,7 +243,13 @@ func (w *InsightWorker) callAIProvider(insights []InsightSummary) ([]AIInsightEn
 	ctx, cancel := context.WithTimeout(parent, InsightEnrichmentTimeout)
 	defer cancel()
 
-	for _, name := range providerPriority {
+	// Build the effective priority list: if the user selected a primary
+	// agent, try it first, then fall back to the default list (skipping
+	// duplicates so the primary isn't attempted twice).
+	primaryAgent := w.registry.GetDefaultName()
+	order := buildProviderOrder(primaryAgent, defaultProviderPriority)
+
+	for _, name := range order {
 		provider, err := w.registry.Get(name)
 		if err != nil || !provider.IsAvailable() {
 			continue
@@ -269,6 +279,24 @@ func (w *InsightWorker) callAIProvider(insights []InsightSummary) ([]AIInsightEn
 	}
 
 	return nil, "", fmt.Errorf("no available AI providers")
+}
+
+// buildProviderOrder returns a provider ordering that places primaryAgent
+// first (if non-empty) followed by the remaining entries from fallback,
+// skipping duplicates.
+func buildProviderOrder(primaryAgent string, fallback []string) []string {
+	if primaryAgent == "" {
+		return fallback
+	}
+	// Pre-size: primary + full fallback list (at most one duplicate removed).
+	order := make([]string, 0, len(fallback)+1)
+	order = append(order, primaryAgent)
+	for _, name := range fallback {
+		if name != primaryAgent {
+			order = append(order, name)
+		}
+	}
+	return order
 }
 
 // buildInsightEnrichmentPrompt creates a structured prompt for the AI

--- a/pkg/agent/server.go
+++ b/pkg/agent/server.go
@@ -64,12 +64,15 @@ const (
 	// ("anonymous") so resources created via either path look identical.
 	deployedByAnonymousMarker = "anonymous"
 
-	// missionExecutionTimeout is the maximum wall-clock time a single mission
-	// chat execution (AI provider call) is allowed to run before the context
-	// is cancelled and the frontend receives a timeout error.  This prevents
-	// missions from staying in "Running/Processing" state indefinitely when the
-	// AI provider hangs or never responds (#2375).
-	missionExecutionTimeout = 5 * time.Minute
+	// defaultMissionExecutionTimeout is the compiled default for mission
+	// execution.  Operators can override it at startup via the
+	// KC_MISSION_TIMEOUT environment variable (accepts Go duration strings
+	// such as "10m", "600s", "1h").  See #9482.
+	defaultMissionExecutionTimeout = 5 * time.Minute
+
+	// missionTimeoutEnvVar is the environment variable operators can set
+	// to override the per-mission execution timeout.
+	missionTimeoutEnvVar = "KC_MISSION_TIMEOUT"
 
 	// missionHeartbeatInterval is how often the backend sends a heartbeat
 	// progress event during mission execution.  This prevents the frontend's
@@ -88,6 +91,11 @@ const (
 	// missionExecutionTimeout because they intentionally run tools.
 	handleChatMessageTimeout = 30 * time.Second
 )
+
+// missionExecutionTimeout is the effective mission execution deadline.
+// Initialised to defaultMissionExecutionTimeout and optionally overridden
+// from KC_MISSION_TIMEOUT in NewServer (#9482).
+var missionExecutionTimeout = defaultMissionExecutionTimeout
 
 // Version is set by ldflags during build
 var Version = "dev"
@@ -244,6 +252,18 @@ func NewServer(cfg Config) (*Server, error) {
 	}
 	if sessionQuota > 0 {
 		slog.Info("session token quota enabled", "limit", sessionQuota)
+	}
+
+	// Resolve mission execution timeout from env, falling back to the
+	// compiled default (#9482).
+	if raw := os.Getenv(missionTimeoutEnvVar); raw != "" {
+		if parsed, err := time.ParseDuration(raw); err == nil && parsed > 0 {
+			missionExecutionTimeout = parsed
+			slog.Info("mission execution timeout overridden", "timeout", missionExecutionTimeout)
+		} else {
+			slog.Warn("invalid KC_MISSION_TIMEOUT value, using default",
+				"value", raw, "default", defaultMissionExecutionTimeout)
+		}
 	}
 
 	now := time.Now()


### PR DESCRIPTION
## Summary
- **#9482**: Mission execution timeout was hardcoded at 5 minutes. Now configurable via `KC_MISSION_TIMEOUT` env var (accepts Go duration strings like `"10m"`, `"1h"`). Falls back to the existing 5-minute default when unset or invalid.
- **#9484**: Insight worker AI provider priority was a hardcoded list ignoring the user's selected primary agent. Now tries the registry's default agent first (set via UI agent selector), then falls back to the existing priority list for remaining providers.

Fixes #9482, Fixes #9484

## Changes
- `pkg/agent/server.go`: Extract `missionExecutionTimeout` from `const` to `var`, add `KC_MISSION_TIMEOUT` env var parsing in `NewServer` (follows same pattern as `KC_SESSION_TOKEN_QUOTA`)
- `pkg/agent/insight_worker.go`: Rename `providerPriority` to `defaultProviderPriority`, add `buildProviderOrder()` helper that places the user's primary agent first, deduplicating against the fallback list

## Test plan
- [ ] Set `KC_MISSION_TIMEOUT=10m` and verify log message "mission execution timeout overridden"
- [ ] Set `KC_MISSION_TIMEOUT=invalid` and verify warning log with fallback to default
- [ ] Unset `KC_MISSION_TIMEOUT` and verify 5m default is used
- [ ] Select a primary agent in UI, trigger insight enrichment, verify selected agent is tried first
- [ ] With no primary agent selected, verify default priority list is used unchanged