### PR TITLE
fix: add tool dependency check for AI agents and sync settings UI with registry

### DIFF
--- a/pkg/agent/provider_claudecode.go
+++ b/pkg/agent/provider_claudecode.go
@@ -12,6 +12,45 @@ import (
 	"time"
 )
 
+// RequiredMissionTools lists the CLI binaries that must be available in
+// PATH for AI missions to execute cluster operations. Each entry is a
+// binary name passed to exec.LookPath during the pre-launch readiness
+// check. Keep this list in sync with the tools referenced in
+// ClaudeCodeSystemPrompt and the --allowedTools flag below.
+var RequiredMissionTools = []string{
+	"kubectl", // Kubernetes CLI — cluster inspection & management
+	"helm",    // Helm — chart-based deployments
+	"git",     // Git — version control operations
+	"gh",      // GitHub CLI — PR creation, issue triage
+}
+
+// ToolDependencyError is returned when one or more required CLI tools
+// are missing from PATH. The MissingTools field lists the binary names
+// that were not found so callers can surface actionable guidance.
+type ToolDependencyError struct {
+	MissingTools []string
+}
+
+func (e *ToolDependencyError) Error() string {
+	return fmt.Sprintf("missing required tools: %s — install them before running AI missions", strings.Join(e.MissingTools, ", "))
+}
+
+// CheckToolDependencies verifies that every binary in RequiredMissionTools
+// is available on PATH via exec.LookPath. Returns nil when all tools are
+// present, or a *ToolDependencyError listing the missing ones.
+func CheckToolDependencies() error {
+	var missing []string
+	for _, tool := range RequiredMissionTools {
+		if _, err := exec.LookPath(tool); err != nil {
+			missing = append(missing, tool)
+		}
+	}
+	if len(missing) > 0 {
+		return &ToolDependencyError{MissingTools: missing}
+	}
+	return nil
+}
+
 // claudeCodeStreamEvent represents events in Claude Code CLI stream-json output
 type claudeCodeStreamEvent struct {
 	Type    string `json:"type"`
@@ -261,6 +300,14 @@ func (c *ClaudeCodeProvider) StreamChat(ctx context.Context, req *ChatRequest, o
 func (c *ClaudeCodeProvider) StreamChatWithProgress(ctx context.Context, req *ChatRequest, onChunk func(chunk string), onProgress func(event StreamEvent)) (*ChatResponse, error) {
 	if c.cliPath == "" {
 		return nil, fmt.Errorf("claude CLI not found")
+	}
+
+	// Pre-flight: verify that required mission tools (kubectl, helm, git,
+	// gh) are on PATH before spawning the CLI subprocess. Failing fast
+	// here gives operators an actionable error instead of a cryptic
+	// mid-mission "command not found" from the agent (#9487).
+	if err := CheckToolDependencies(); err != nil {
+		return nil, fmt.Errorf("tool dependency check failed: %w", err)
 	}
 
 	// Build prompt with history for context

--- a/pkg/agent/provider_claudecode_test.go
+++ b/pkg/agent/provider_claudecode_test.go
@@ -64,3 +64,35 @@ func TestCleanEnvForCLI(t *testing.T) {
 		}
 	}
 }
+
+func TestCheckToolDependencies_AllPresent(t *testing.T) {
+	// On any CI or dev machine, at least git and kubectl are likely present.
+	// This test verifies the function returns without error when tools exist.
+	// If a tool is missing in the test environment, the error type is checked.
+	err := CheckToolDependencies()
+	if err != nil {
+		tde, ok := err.(*ToolDependencyError)
+		if !ok {
+			t.Fatalf("expected *ToolDependencyError, got %T", err)
+		}
+		// Verify the error message lists the missing tools
+		if len(tde.MissingTools) == 0 {
+			t.Error("ToolDependencyError should list at least one missing tool")
+		}
+		t.Logf("missing tools (expected in some environments): %v", tde.MissingTools)
+	}
+}
+
+func TestCheckToolDependencies_ErrorMessage(t *testing.T) {
+	err := &ToolDependencyError{MissingTools: []string{"kubectl", "helm"}}
+	msg := err.Error()
+	if !containsSubstring(msg, "kubectl") || !containsSubstring(msg, "helm") {
+		t.Errorf("error message should list missing tools, got %q", msg)
+	}
+}
+
+func TestRequiredMissionTools_NotEmpty(t *testing.T) {
+	if len(RequiredMissionTools) == 0 {
+		t.Error("RequiredMissionTools must not be empty")
+	}
+}

--- a/pkg/agent/server_ai.go
+++ b/pkg/agent/server_ai.go
@@ -1728,10 +1728,14 @@ type KeyStatus struct {
 	BaseURLSource string `json:"baseURLSource,omitempty"`
 }
 
-// KeysStatusResponse is the response for GET /settings/keys
+// KeysStatusResponse is the response for GET /settings/keys.
+// RegisteredProviders is populated from the live agent registry so the
+// frontend settings UI can display only providers that are actually
+// registered in the backend, avoiding stale hardcoded lists (#9488).
 type KeysStatusResponse struct {
-	Keys       []KeyStatus `json:"keys"`
-	ConfigPath string      `json:"configPath"`
+	Keys                []KeyStatus    `json:"keys"`
+	ConfigPath          string         `json:"configPath"`
+	RegisteredProviders []ProviderInfo `json:"registeredProviders"`
 }
 
 // SetKeyRequest is the request body for POST /settings/keys.

--- a/pkg/agent/server_operations.go
+++ b/pkg/agent/server_operations.go
@@ -381,9 +381,15 @@ func (s *Server) handleGetKeysStatus(w http.ResponseWriter, r *http.Request) {
 		keys = append(keys, status)
 	}
 
+	// Include the live provider registry so the frontend settings UI can
+	// filter its display to only show providers that are actually
+	// registered in the backend, eliminating the hardcoded mismatch (#9488).
+	registeredProviders := GetRegistry().List()
+
 	json.NewEncoder(w).Encode(KeysStatusResponse{
-		Keys:       keys,
-		ConfigPath: cm.GetConfigPath(),
+		Keys:                keys,
+		ConfigPath:          cm.GetConfigPath(),
+		RegisteredProviders: registeredProviders,
 	})
 }
 

--- a/web/src/components/agent/APIKeySettings.tsx
+++ b/web/src/components/agent/APIKeySettings.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback, useRef } from 'react'
+import { useState, useEffect, useCallback, useRef, useMemo } from 'react'
 import { Key, Check, AlertCircle, Loader2, Trash2, Eye, EyeOff, ExternalLink, Copy, Plug } from 'lucide-react'
 import { cn } from '../../lib/cn'
 import { AgentIcon } from './AgentIcon'
@@ -45,9 +45,22 @@ interface KeyStatus {
   baseURLSource?: 'env' | 'config'
 }
 
+/** Provider info from the backend agent registry (mirrors Go ProviderInfo). */
+interface RegisteredProvider {
+  name: string
+  displayName: string
+  description: string
+  provider: string
+  available: boolean
+  capabilities: number
+}
+
 interface KeysStatusResponse {
   keys: KeyStatus[]
   configPath: string
+  /** Live provider registry from the backend — used to filter the settings
+   *  UI so it only displays providers that are actually registered (#9488). */
+  registeredProviders?: RegisteredProvider[]
 }
 
 interface APIKeySettingsProps {
@@ -55,51 +68,12 @@ interface APIKeySettingsProps {
   onClose: () => void
 }
 
+// PROVIDER_INFO is a fallback lookup table for providers whose docs URL
+// and key placeholder cannot be derived from the backend registry.
+// The settings UI now sources its display list from the backend's
+// registeredProviders field (#9488) — entries here are only consulted
+// when the backend does not supply metadata for a given provider key.
 const PROVIDER_INFO: Record<string, { docsUrl: string; placeholder: string }> = {
-  claude: {
-    docsUrl: AI_PROVIDER_DOCS.claude,
-    placeholder: 'sk-ant-api03-...',
-  },
-  openai: {
-    docsUrl: AI_PROVIDER_DOCS.openai,
-    placeholder: 'sk-...',
-  },
-  gemini: {
-    docsUrl: AI_PROVIDER_DOCS.gemini,
-    placeholder: 'AIza...',
-  },
-  cursor: {
-    docsUrl: AI_PROVIDER_DOCS.cursor,
-    placeholder: 'cursor-...',
-  },
-  vscode: {
-    docsUrl: AI_PROVIDER_DOCS.vscode,
-    placeholder: 'vscode-...',
-  },
-  windsurf: {
-    docsUrl: AI_PROVIDER_DOCS.windsurf,
-    placeholder: 'codeium-...',
-  },
-  cline: {
-    docsUrl: AI_PROVIDER_DOCS.cline,
-    placeholder: 'cline-...',
-  },
-  jetbrains: {
-    docsUrl: AI_PROVIDER_DOCS.jetbrains,
-    placeholder: 'jb-...',
-  },
-  zed: {
-    docsUrl: AI_PROVIDER_DOCS.zed,
-    placeholder: 'zed-...',
-  },
-  continue: {
-    docsUrl: AI_PROVIDER_DOCS.continue,
-    placeholder: 'continue-...',
-  },
-  raycast: {
-    docsUrl: AI_PROVIDER_DOCS.raycast,
-    placeholder: 'raycast-...',
-  },
   'open-webui': {
     docsUrl: AI_PROVIDER_DOCS['open-webui'],
     placeholder: 'owui-...',
@@ -142,20 +116,13 @@ const PROVIDER_INFO: Record<string, { docsUrl: string; placeholder: string }> = 
   },
 }
 
-// Map backend provider key names to AgentIcon provider values
+// Map backend provider key names to AgentIcon provider values.
+// Only includes providers that are actually registered in the backend
+// registry (see InitializeProviders in pkg/agent/registry.go). Stale
+// entries for unregistered API-only / IDE providers were removed in
+// #9488 to keep this in sync with the backend.
 function providerToIconMap(provider: string): string {
   const map: Record<string, string> = {
-    claude: 'anthropic',
-    openai: 'openai',
-    gemini: 'google',
-    cursor: 'anysphere',
-    vscode: 'microsoft',
-    windsurf: 'codeium',
-    cline: 'cline',
-    jetbrains: 'jetbrains',
-    zed: 'zed',
-    continue: 'continue',
-    raycast: 'raycast',
     'open-webui': 'open-webui',
     openrouter: 'openrouter',
     groq: 'groq',
@@ -173,6 +140,7 @@ function providerToIconMap(provider: string): string {
 export function APIKeySettings({ isOpen, onClose }: APIKeySettingsProps) {
   const { t } = useTranslation(['common', 'cards'])
   const [keysStatus, setKeysStatus] = useState<KeyStatus[]>([])
+  const [registeredProviders, setRegisteredProviders] = useState<RegisteredProvider[]>([])
   const [configPath, setConfigPath] = useState<string>('')
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
@@ -216,6 +184,7 @@ export function APIKeySettings({ isOpen, onClose }: APIKeySettingsProps) {
       }
       const data: KeysStatusResponse = await response.json()
       setKeysStatus(data.keys)
+      setRegisteredProviders(data.registeredProviders || [])
       setConfigPath(data.configPath)
     } catch (err) {
       setError(err instanceof Error ? err.message : t('agent.failedToConnect'))
@@ -355,6 +324,18 @@ export function APIKeySettings({ isOpen, onClose }: APIKeySettingsProps) {
     setShowKey(false)
   }
 
+  // Filter displayed keys to only show providers that are actually
+  // registered in the backend's provider registry. When the registry
+  // data is unavailable (older kc-agent, network error), fall back to
+  // showing all keys returned by the backend (#9488).
+  const filteredKeys = useMemo(() => {
+    if (registeredProviders.length === 0) return keysStatus
+    const registeredNames = new Set(
+      (registeredProviders || []).map(p => p.name),
+    )
+    return keysStatus.filter(k => registeredNames.has(k.provider))
+  }, [keysStatus, registeredProviders])
+
   return (
     <BaseModal isOpen={isOpen} onClose={onClose} size="md" closeOnBackdrop={false}>
       <BaseModal.Header
@@ -369,7 +350,7 @@ export function APIKeySettings({ isOpen, onClose }: APIKeySettingsProps) {
             <div className="flex items-center justify-center py-8">
               <Loader2 className="w-6 h-6 animate-spin text-muted-foreground" />
             </div>
-          ) : error && keysStatus.length === 0 ? (
+          ) : error && filteredKeys.length === 0 ? (
             <div className="text-center py-6">
               <div className="p-3 rounded-full bg-orange-500/20 w-fit mx-auto mb-4">
                 <Plug className="w-8 h-8 text-orange-400" />
@@ -419,7 +400,7 @@ export function APIKeySettings({ isOpen, onClose }: APIKeySettingsProps) {
                 </div>
               )}
 
-              {keysStatus.map((key) => (
+              {filteredKeys.map((key) => (
                 <div
                   key={key.provider}
                   className="p-4 bg-secondary/30 border border-border rounded-lg"


### PR DESCRIPTION
## Summary

- **#9487**: Adds a pre-launch readiness check in `ClaudeCodeProvider.StreamChatWithProgress()` that verifies required CLI binaries (`kubectl`, `helm`, `git`, `gh`) are on PATH via `exec.LookPath()` before spawning the subprocess. Returns a clear `ToolDependencyError` listing missing tools. Required tools are defined as a named `RequiredMissionTools` slice (no magic values).
- **#9488**: The settings UI API key modal now sources its provider display list from the backend's live agent registry. `GET /settings/keys` response includes a new `registeredProviders` field populated from `GetRegistry().List()`. The frontend filters displayed keys against this list, removing the hardcoded mismatch. Stale `PROVIDER_INFO` entries for 11 unregistered providers (claude, openai, gemini, cursor, vscode, windsurf, cline, jetbrains, zed, continue, raycast) were removed.

Fixes #9487, Fixes #9488

## Test plan

- [ ] Verify `CheckToolDependencies()` returns nil when all tools are on PATH
- [ ] Verify `ToolDependencyError` lists missing tools when some are absent
- [ ] Verify `go test ./pkg/agent/...` passes with new tests
- [ ] Verify Settings modal only shows providers registered in the backend
- [ ] Verify fallback: when `registeredProviders` is empty (older kc-agent), all keys still display