### PR TITLE
fix: improve update check feedback and timestamp handling

### DIFF
--- a/web/src/components/settings/UpdateSettings.tsx
+++ b/web/src/components/settings/UpdateSettings.tsx
@@ -55,6 +55,9 @@ const TRIGGER_STALL_TIMEOUT_MS = 30_000
 /** Countdown tick interval in milliseconds */
 const COUNTDOWN_TICK_MS = 1000
 
+/** Duration (ms) to show the transient "check complete" banner before auto-dismiss */
+const CHECK_RESULT_DISPLAY_MS = 4000
+
 /** Scroll to a settings section by ID (mirrors Settings.tsx logic) */
 function scrollToSettingsSection(sectionId: string) {
   const element = document.getElementById(sectionId)
@@ -91,6 +94,8 @@ export function UpdateSettings() {
     setAutoUpdateEnabled,
     triggerUpdate,
     cancelUpdate,
+    lastCheckResult,
+    clearLastCheckResult,
   } = useVersionCheck()
 
   // WebSocket-driven update progress from kc-agent
@@ -187,6 +192,13 @@ export function UpdateSettings() {
     forceCheck()
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
+
+  // Auto-dismiss the transient check result banner after a short delay
+  useEffect(() => {
+    if (!lastCheckResult) return
+    const timer = setTimeout(() => clearLastCheckResult(), CHECK_RESULT_DISPLAY_MS)
+    return () => clearTimeout(timer)
+  }, [lastCheckResult, clearLastCheckResult])
 
   // Clear triggered state once WebSocket progress starts or update fails.
   // Emit GA4 lifecycle events for update completion/failure.
@@ -551,12 +563,22 @@ export function UpdateSettings() {
         </div>
       )}
 
-      {/* Dev Mode Warning */}
-      {!isDeveloperChannel && !currentVersion.includes('nightly') && !currentVersion.includes('weekly') && currentVersion !== 'unknown' && (
+      {/* Dev Mode Warning — only shown for actual dev installs (running from source)
+           where the version doesn't match a release tag pattern. Helm/binary installs
+           often report versions without the 'v' prefix (e.g., "0.3.21") which is normal. */}
+      {installMethod === 'dev' && !isDeveloperChannel && !currentVersion.includes('nightly') && !currentVersion.includes('weekly') && currentVersion !== 'unknown' && (
         <div className="p-3 rounded-lg mb-4 bg-yellow-500/10 border border-yellow-500/20">
           <p className="text-xs text-yellow-400">
             {t('settings.updates.devVersion', { envVar: 'VITE_APP_VERSION' })}
           </p>
+        </div>
+      )}
+
+      {/* Transient check-complete feedback — auto-dismissed after CHECK_RESULT_DISPLAY_MS */}
+      {lastCheckResult === 'success' && !isChecking && !isVisuallySpinning && !hasUpdate && !error && (
+        <div data-testid="check-complete-banner" className="mb-4 p-3 rounded-lg bg-green-500/10 border border-green-500/20 flex items-center gap-2 animate-in fade-in">
+          <Check className="w-4 h-4 text-green-400 shrink-0" />
+          <p className="text-sm text-green-400">{t('settings.updates.upToDate')}</p>
         </div>
       )}
 

--- a/web/src/hooks/useVersionCheck-version-compare.test.tsx
+++ b/web/src/hooks/useVersionCheck-version-compare.test.tsx
@@ -244,12 +244,16 @@ describe('isDevVersion', () => {
     expect(isDevVersion('dev')).toBe(true)
   })
 
-  it('returns true for semver without v prefix (e.g. "0.1.0")', () => {
-    expect(isDevVersion('0.1.0')).toBe(true)
+  it('returns true for "0.0.0" placeholder version', () => {
+    expect(isDevVersion('0.0.0')).toBe(true)
   })
 
-  it('returns true for "1.0.0" (no v prefix)', () => {
-    expect(isDevVersion('1.0.0')).toBe(true)
+  it('returns false for semver without v prefix (e.g. "0.1.0") — Helm installs', () => {
+    expect(isDevVersion('0.1.0')).toBe(false)
+  })
+
+  it('returns false for "1.0.0" (no v prefix) — valid release', () => {
+    expect(isDevVersion('1.0.0')).toBe(false)
   })
 
   it('returns false for proper tagged version with v prefix', () => {
@@ -278,9 +282,14 @@ describe('isNewerVersion', () => {
     expect(isNewerVersion('v1.0.0', 'v2.0.0', 'developer')).toBe(false)
   })
 
-  it('returns false for dev version current tag', () => {
-    // "0.1.0" without v prefix is a dev version
-    expect(isNewerVersion('0.1.0', 'v2.0.0', 'stable')).toBe(false)
+  it('returns true for version without v prefix when newer is available', () => {
+    // "0.1.0" without v prefix is a valid release (e.g., Helm install)
+    expect(isNewerVersion('0.1.0', 'v2.0.0', 'stable')).toBe(true)
+  })
+
+  it('returns false for "0.0.0" placeholder dev version', () => {
+    // "0.0.0" is a dev placeholder — no update shown
+    expect(isNewerVersion('0.0.0', 'v2.0.0', 'stable')).toBe(false)
   })
 
   it('returns false for "unknown" current tag', () => {

--- a/web/src/hooks/useVersionCheck.tsx
+++ b/web/src/hooks/useVersionCheck.tsx
@@ -109,13 +109,15 @@ export function getLatestForChannel(
  * Development versions are simple semver without nightly/weekly suffix.
  */
 export function isDevVersion(version: string): boolean {
-  // Dev versions: 0.1.0, 1.0.0, unknown, dev
+  // Sentinel values used when no real version is set
   if (version === 'unknown' || version === 'dev') return true
-  // Simple semver without suffix (no nightly/weekly)
-  const parsed = parseReleaseTag(version)
-  // If it parsed as 'stable' type but doesn't start with 'v' or has no date, it's dev
-  if (parsed.type === 'stable' && !version.startsWith('v')) return true
-  return false
+  // Versions like "0.0.0" are placeholder dev builds (unset VITE_APP_VERSION)
+  if (version === '0.0.0') return true
+  // A version matching semver (with or without 'v' prefix) is a real release.
+  // Helm installs report versions without the 'v' prefix (e.g., "0.3.21")
+  // which should NOT be treated as dev builds.
+  if (/^v?\d+\.\d+\.\d+/.test(version)) return false
+  return true
 }
 
 /**
@@ -285,6 +287,14 @@ function useVersionCheckCore() {
   // ERROR_DISPLAY_THRESHOLD consecutive failures to avoid flicker on transient errors.
   const consecutiveFailuresRef = useRef(0)
 
+  // Signals that the user just changed the update channel, so forceCheck
+  // should run once the new channel state is committed.
+  const channelChangedRef = useRef(false)
+
+  // Transient result of the last completed check — shown briefly in the UI
+  // so the user gets feedback after clicking "Check Now".
+  const [lastCheckResult, setLastCheckResult] = useState<'success' | 'no-update' | null>(null)
+
   // Auto-update state
   const [autoUpdateEnabled, setAutoUpdateEnabledState] = useState(loadAutoUpdateEnabled)
   // Initialize install method: localhost always means dev mode (running from source)
@@ -393,6 +403,10 @@ function useVersionCheckCore() {
           localStorage.setItem(DEV_SHA_CACHE_KEY, sha)
           localStorage.removeItem('kc-github-rate-limit-until')
         }
+        // Update lastChecked timestamp so the UI reflects the check time
+        const now = Date.now()
+        setLastChecked(now)
+        localStorage.setItem(UPDATE_STORAGE_KEYS.LAST_CHECK, String(now))
       } else if (resp.status === 403 || resp.status === 429) {
         // Rate limited — back off for 15 minutes
         const resetHeader = resp.headers.get('X-RateLimit-Reset')
@@ -467,6 +481,7 @@ function useVersionCheckCore() {
 
   /**
    * Set update channel and persist to localStorage + kc-agent.
+   * Triggers a fresh version check so the UI immediately reflects the new channel.
    */
   const setChannel = useCallback(async (newChannel: UpdateChannel) => {
     setChannelState(newChannel)
@@ -482,6 +497,9 @@ function useVersionCheckCore() {
     } catch {
       // Agent not available, local state is still saved
     }
+
+    // Trigger a fresh check for the new channel so the UI updates immediately
+    channelChangedRef.current = true
   }, [autoUpdateEnabled])
 
   /**
@@ -679,10 +697,13 @@ function useVersionCheckCore() {
 
   /**
    * Force a fresh check, bypassing cache.
+   * Sets lastCheckResult so the UI can show transient success/no-update feedback.
    */
   const forceCheck = async (): Promise<void> => {
     console.debug('[version-check] Force check — channel:', channel, 'agentSupportsAutoUpdate:', agentSupportsAutoUpdate)
     setIsChecking(true)
+    // Clear any previous transient result while the new check is in progress
+    setLastCheckResult(null)
     // Reset consecutive failure counter on user-initiated check so a single
     // success clears the error, and a single failure doesn't flash red.
     consecutiveFailuresRef.current = 0
@@ -705,6 +726,16 @@ function useVersionCheckCore() {
       await fetchReleases(true)
     } finally {
       setIsChecking(false)
+      // Signal a transient result so the UI can flash feedback.
+      // An error means the check failed (error state is already set above),
+      // so only set a result when there is no error.
+      if (consecutiveFailuresRef.current === 0) {
+        // hasUpdate is derived from state that was just set, but React hasn't
+        // re-rendered yet. We use 'success' here as a generic "check succeeded"
+        // signal — the UI will read hasUpdate on the next render to decide
+        // whether to show "Update available" or "Up to date".
+        setLastCheckResult('success')
+      }
     }
   }
 
@@ -851,6 +882,15 @@ function useVersionCheckCore() {
     }
   }, [channel, hasUpdate, fetchRecentCommits])
 
+  // When the user changes the update channel, trigger a fresh check so the
+  // UI immediately reflects the new channel's latest release / SHA.
+  useEffect(() => {
+    if (!channelChangedRef.current) return
+    channelChangedRef.current = false
+    forceCheck()
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [channel])
+
   return {
     // State
     currentVersion,
@@ -864,6 +904,7 @@ function useVersionCheckCore() {
     lastChecked,
     skippedVersions,
     releases,
+    lastCheckResult,
 
     // Auto-update state
     autoUpdateEnabled,
@@ -884,7 +925,8 @@ function useVersionCheckCore() {
     setAutoUpdateEnabled,
     triggerUpdate,
     cancelUpdate,
-    setUpdateProgress }
+    setUpdateProgress,
+    clearLastCheckResult: () => setLastCheckResult(null) }
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- **Channel change triggers fresh check**: Changing the release channel now automatically runs a version check so the UI immediately reflects the new channel's releases
- **"Check Now" shows completion feedback**: A transient "Up to date" banner appears for 4 seconds after a successful check completes, so users know the check worked
- **Developer channel timestamp fix**: `fetchLatestMainSHA` now updates the "Last checked" timestamp, fixing the stale "6 minutes ago" display
- **Helm version detection fix**: `isDevVersion` no longer treats valid semver without 'v' prefix (e.g., "0.3.21") as dev builds — only "0.0.0", "unknown", and "dev" are true dev versions. This allows Helm users to see available updates
- **Dev mode warning scoped correctly**: The confusing "Set VITE_APP_VERSION" warning only shows for actual dev installs (`installMethod === 'dev'`), not for Helm/binary users running stable releases

Fixes #9495

## Test plan
- [ ] Click "Check Now" on stable channel — spinner runs, then "Up to date" banner appears briefly
- [ ] Click "Check Now" on developer channel without kc-agent — "Last checked" updates to "Just now"
- [ ] Switch channel from Stable to Unstable — version check runs automatically, latest release updates
- [ ] Helm install with version "0.3.21" — no "Set VITE_APP_VERSION" warning shown
- [ ] Dev install from source — "Set VITE_APP_VERSION" warning still shown when appropriate
- [ ] Existing tests pass with updated assertions for isDevVersion behavior