### PR TITLE
fix: replace hardcoded colors with design tokens

### DIFF
--- a/web/src/components/cards/GPUUtilization.tsx
+++ b/web/src/components/cards/GPUUtilization.tsx
@@ -16,7 +16,10 @@ import {
   CHART_GRID_STROKE,
   CHART_AXIS_STROKE,
   CHART_TOOLTIP_CONTENT_STYLE,
-  CHART_TICK_COLOR } from '../../lib/constants'
+  CHART_TICK_COLOR,
+  CHART_MARK_LINE_LABEL,
+  CHART_MARK_LINE_STROKE } from '../../lib/constants'
+import { PURPLE_600, hexToRgba } from '../../lib/theme/chartColors'
 
 interface GPUPoint {
   time: string
@@ -24,6 +27,13 @@ interface GPUPoint {
   available: number
   total: number
 }
+
+/** Opacity at the top of area-fill gradients */
+const AREA_GRADIENT_TOP_ALPHA = 0.4
+/** Opacity at the bottom of area-fill gradients (fully transparent) */
+const AREA_GRADIENT_BOTTOM_ALPHA = 0
+/** Font size for mark-line labels on the chart */
+const MARK_LINE_FONT_SIZE = 9
 
 type TimeRange = '15m' | '1h' | '6h' | '24h'
 
@@ -203,16 +213,16 @@ export function GPUUtilization() {
         type: 'line',
         step: 'end' as const,
         data: history.map(d => d.allocated),
-        lineStyle: { color: '#9333ea', width: 2 },
-        itemStyle: { color: '#9333ea' },
+        lineStyle: { color: PURPLE_600, width: 2 },
+        itemStyle: { color: PURPLE_600 },
         areaStyle: {
           color: { type: 'linear', x: 0, y: 0, x2: 0, y2: 1,
-            colorStops: [{ offset: 0, color: 'rgba(147,51,234,0.4)' }, { offset: 1, color: 'rgba(147,51,234,0)' }] },
+            colorStops: [{ offset: 0, color: hexToRgba(PURPLE_600, AREA_GRADIENT_TOP_ALPHA) }, { offset: 1, color: hexToRgba(PURPLE_600, AREA_GRADIENT_BOTTOM_ALPHA) }] },
         },
         showSymbol: false,
         markLine: {
           silent: true,
-          data: [{ yAxis: currentStats.total, label: { formatter: 'Total', position: 'end', color: '#888', fontSize: 9 }, lineStyle: { color: '#666', type: 'dashed' } }],
+          data: [{ yAxis: currentStats.total, label: { formatter: 'Total', position: 'end', color: CHART_MARK_LINE_LABEL, fontSize: MARK_LINE_FONT_SIZE }, lineStyle: { color: CHART_MARK_LINE_STROKE, type: 'dashed' } }],
         },
       },
     ],

--- a/web/src/components/cards/IssueActivityChart.tsx
+++ b/web/src/components/cards/IssueActivityChart.tsx
@@ -23,7 +23,15 @@ import {
   CHART_TOOLTIP_CONTENT_STYLE,
   CHART_TOOLTIP_TEXT_COLOR,
   CHART_TOOLTIP_LABEL_COLOR,
+  CHART_DATAZOOM_BORDER,
+  CHART_DATAZOOM_BG,
+  CHART_DATAZOOM_FILLER,
+  CHART_DATAZOOM_HANDLE,
+  CHART_DATAZOOM_TEXT,
+  CHART_DATAZOOM_DATA_LINE,
+  CHART_DATAZOOM_DATA_AREA,
 } from '../../lib/constants'
+import { hexToRgba } from '../../lib/theme/chartColors'
 
 // ── Constants ───────────────────────────────────────────────────────────────
 
@@ -61,6 +69,10 @@ const CHART_HEIGHT_PX = 320
 const DATA_ZOOM_SLIDER_HEIGHT_PX = 20
 /** Slider bottom offset in pixels */
 const DATA_ZOOM_SLIDER_BOTTOM_PX = 5
+/** Opacity for area-fill behind the PR-merged line */
+const PR_MERGED_AREA_ALPHA = 0.08
+/** Font size for dataZoom text labels */
+const DATAZOOM_FONT_SIZE = 10
 /** Full zoom range start percentage */
 const ZOOM_RANGE_START = 0
 /** Full zoom range end percentage */
@@ -535,7 +547,7 @@ export function IssueActivityChart(props: { config?: IssueActivityConfig }) {
           symbolSize: 4,
           lineStyle: { color: COLOR_PR_MERGED, width: 2 },
           itemStyle: { color: COLOR_PR_MERGED },
-          areaStyle: { color: 'rgba(237, 125, 49, 0.08)' },
+          areaStyle: { color: hexToRgba(COLOR_PR_MERGED, PR_MERGED_AREA_ALPHA) },
         },
       ],
       dataZoom: [
@@ -550,14 +562,14 @@ export function IssueActivityChart(props: { config?: IssueActivityConfig }) {
           end: ZOOM_RANGE_END,
           height: DATA_ZOOM_SLIDER_HEIGHT_PX,
           bottom: DATA_ZOOM_SLIDER_BOTTOM_PX,
-          borderColor: '#444',
-          backgroundColor: 'rgba(50,50,50,0.3)',
-          fillerColor: 'rgba(68,114,196,0.15)',
-          handleStyle: { color: '#666' },
-          textStyle: { color: '#888', fontSize: 10 },
+          borderColor: CHART_DATAZOOM_BORDER,
+          backgroundColor: CHART_DATAZOOM_BG,
+          fillerColor: CHART_DATAZOOM_FILLER,
+          handleStyle: { color: CHART_DATAZOOM_HANDLE },
+          textStyle: { color: CHART_DATAZOOM_TEXT, fontSize: DATAZOOM_FONT_SIZE },
           dataBackground: {
-            lineStyle: { color: '#555' },
-            areaStyle: { color: 'rgba(100,100,100,0.2)' },
+            lineStyle: { color: CHART_DATAZOOM_DATA_LINE },
+            areaStyle: { color: CHART_DATAZOOM_DATA_AREA },
           },
         },
       ],

--- a/web/src/components/cards/PodHealthTrend.tsx
+++ b/web/src/components/cards/PodHealthTrend.tsx
@@ -16,6 +16,7 @@ import {
   CHART_TICK_COLOR } from '../../lib/constants'
 import { useDemoMode } from '../../hooks/useDemoMode'
 import { safeGet, safeSet } from '../../lib/safeLocalStorage'
+import { ORANGE_500, YELLOW_500, GREEN_500_BRIGHT, hexToRgba } from '../../lib/theme/chartColors'
 
 interface HealthPoint {
   time: string
@@ -25,6 +26,11 @@ interface HealthPoint {
 }
 
 type TimeRange = '15m' | '1h' | '6h' | '24h'
+
+/** Opacity at the top of area-fill gradients */
+const AREA_GRADIENT_TOP_ALPHA = 0.4
+/** Opacity at the bottom of area-fill gradients (fully transparent) */
+const AREA_GRADIENT_BOTTOM_ALPHA = 0
 
 /** Maximum data points to display per time range selection */
 const TIME_RANGE_MAX_POINTS: Record<TimeRange, number> = {
@@ -280,11 +286,11 @@ export function PodHealthTrend() {
         stack: 'total',
         smooth: true,
         data: visibleHistory.map(d => d.issues),
-        lineStyle: { color: '#f97316', width: 2 },
-        itemStyle: { color: '#f97316' },
+        lineStyle: { color: ORANGE_500, width: 2 },
+        itemStyle: { color: ORANGE_500 },
         areaStyle: {
           color: { type: 'linear', x: 0, y: 0, x2: 0, y2: 1,
-            colorStops: [{ offset: 0, color: 'rgba(249,115,22,0.4)' }, { offset: 1, color: 'rgba(249,115,22,0)' }] },
+            colorStops: [{ offset: 0, color: hexToRgba(ORANGE_500, AREA_GRADIENT_TOP_ALPHA) }, { offset: 1, color: hexToRgba(ORANGE_500, AREA_GRADIENT_BOTTOM_ALPHA) }] },
         },
         showSymbol: false,
       },
@@ -294,11 +300,11 @@ export function PodHealthTrend() {
         stack: 'total',
         smooth: true,
         data: visibleHistory.map(d => d.pending),
-        lineStyle: { color: '#eab308', width: 2 },
-        itemStyle: { color: '#eab308' },
+        lineStyle: { color: YELLOW_500, width: 2 },
+        itemStyle: { color: YELLOW_500 },
         areaStyle: {
           color: { type: 'linear', x: 0, y: 0, x2: 0, y2: 1,
-            colorStops: [{ offset: 0, color: 'rgba(234,179,8,0.4)' }, { offset: 1, color: 'rgba(234,179,8,0)' }] },
+            colorStops: [{ offset: 0, color: hexToRgba(YELLOW_500, AREA_GRADIENT_TOP_ALPHA) }, { offset: 1, color: hexToRgba(YELLOW_500, AREA_GRADIENT_BOTTOM_ALPHA) }] },
         },
         showSymbol: false,
       },
@@ -308,11 +314,11 @@ export function PodHealthTrend() {
         stack: 'total',
         smooth: true,
         data: visibleHistory.map(d => d.healthy),
-        lineStyle: { color: '#22c55e', width: 2 },
-        itemStyle: { color: '#22c55e' },
+        lineStyle: { color: GREEN_500_BRIGHT, width: 2 },
+        itemStyle: { color: GREEN_500_BRIGHT },
         areaStyle: {
           color: { type: 'linear', x: 0, y: 0, x2: 0, y2: 1,
-            colorStops: [{ offset: 0, color: 'rgba(34,197,94,0.4)' }, { offset: 1, color: 'rgba(34,197,94,0)' }] },
+            colorStops: [{ offset: 0, color: hexToRgba(GREEN_500_BRIGHT, AREA_GRADIENT_TOP_ALPHA) }, { offset: 1, color: hexToRgba(GREEN_500_BRIGHT, AREA_GRADIENT_BOTTOM_ALPHA) }] },
         },
         showSymbol: false,
       },
@@ -321,8 +327,8 @@ export function PodHealthTrend() {
         type: 'line',
         data: visibleHistory.map(d => d.issues),
         smooth: true,
-        lineStyle: { color: '#f97316', width: 2, type: 'dashed' as const },
-        itemStyle: { color: '#f97316' },
+        lineStyle: { color: ORANGE_500, width: 2, type: 'dashed' as const },
+        itemStyle: { color: ORANGE_500 },
         showSymbol: false,
         silent: true,
       },

--- a/web/src/components/cards/StockMarketTicker.tsx
+++ b/web/src/components/cards/StockMarketTicker.tsx
@@ -10,6 +10,7 @@ import { useCardLoadingState } from './CardDataContext'
 import { useCache } from '../../lib/cache'
 import { useTranslation } from 'react-i18next'
 import { FETCH_EXTERNAL_TIMEOUT_MS } from '../../lib/constants'
+import { GREEN_500_BRIGHT, RED_500 } from '../../lib/theme/chartColors'
 import { useToast } from '../ui/Toast'
 import type { TFunction } from 'i18next'
 
@@ -389,7 +390,7 @@ function Sparkline({ data, isPositive }: { data: number[]; isPositive: boolean }
       <polyline
         points={points}
         fill="none"
-        stroke={isPositive ? 'rgb(34, 197, 94)' : 'rgb(239, 68, 68)'}
+        stroke={isPositive ? GREEN_500_BRIGHT : RED_500}
         strokeWidth="2"
         vectorEffect="non-scaling-stroke"
       />

--- a/web/src/lib/constants/ui.ts
+++ b/web/src/lib/constants/ui.ts
@@ -43,6 +43,24 @@ export const CHART_TOOLTIP_CONTENT_STYLE_GRAY: React.CSSProperties = {
 export const CHART_GRID_STROKE = '#333'
 export const CHART_AXIS_STROKE = '#333'
 export const CHART_TICK_COLOR = '#888'
+/** DataZoom slider border color */
+export const CHART_DATAZOOM_BORDER = '#444'
+/** DataZoom slider background overlay */
+export const CHART_DATAZOOM_BG = 'rgba(50,50,50,0.3)'
+/** DataZoom slider selected-range filler */
+export const CHART_DATAZOOM_FILLER = 'rgba(68,114,196,0.15)'
+/** DataZoom slider handle color */
+export const CHART_DATAZOOM_HANDLE = '#666'
+/** DataZoom label text color */
+export const CHART_DATAZOOM_TEXT = '#888'
+/** DataZoom data-background line color */
+export const CHART_DATAZOOM_DATA_LINE = '#555'
+/** DataZoom data-background area color */
+export const CHART_DATAZOOM_DATA_AREA = 'rgba(100,100,100,0.2)'
+/** Chart mark-line label color (secondary text on dark background) */
+export const CHART_MARK_LINE_LABEL = '#888'
+/** Chart mark-line stroke color (dashed guide lines) */
+export const CHART_MARK_LINE_STROKE = '#666'
 /** Tooltip item/content text — verified 13:1 contrast on CHART_TOOLTIP_BG (#1a1a2e) */
 export const CHART_TOOLTIP_TEXT_COLOR = '#e0e0e0'
 /** Tooltip label text — verified 11:1 contrast on CHART_TOOLTIP_BG (#1a1a2e) */

--- a/web/src/lib/theme/chartColors.ts
+++ b/web/src/lib/theme/chartColors.ts
@@ -34,6 +34,8 @@ export const PINK_500 = '#ec4899'
 export const TEAL_500 = '#14b8a6'
 /** Tailwind indigo-500 */
 export const INDIGO_500 = '#6366f1'
+/** Tailwind yellow-500 */
+export const YELLOW_500 = '#eab308'
 /** Tailwind green-500 (brighter variant used for "free/available" areas) */
 export const GREEN_500_BRIGHT = '#22c55e'
 
@@ -117,3 +119,28 @@ export const KAGENT_RUNTIME_BYO = '#9ca3af'
 export const KAGENT_EDGE_AGENT_TOOL = CYAN_500
 /** Agent-to-model edge color */
 export const KAGENT_EDGE_AGENT_MODEL = GREEN_500
+
+// ── Utility ─────────────────────────────────────────────────────────────────
+
+/** Number of hex digits per RGB channel */
+const HEX_CHANNEL_LEN = 2
+/** Start index of the red channel in a 7-char hex string (e.g. "#9333ea") */
+const HEX_RED_START = 1
+/** Start index of the green channel */
+const HEX_GREEN_START = 3
+/** Start index of the blue channel */
+const HEX_BLUE_START = 5
+/** Radix for parsing hex strings */
+const HEX_RADIX = 16
+
+/**
+ * Convert a hex color to an rgba() string with the given alpha.
+ * Accepts "#RRGGBB" format. Falls through to the raw hex if parsing fails.
+ */
+export function hexToRgba(hex: string, alpha: number): string {
+  const r = parseInt(hex.slice(HEX_RED_START, HEX_RED_START + HEX_CHANNEL_LEN), HEX_RADIX)
+  const g = parseInt(hex.slice(HEX_GREEN_START, HEX_GREEN_START + HEX_CHANNEL_LEN), HEX_RADIX)
+  const b = parseInt(hex.slice(HEX_BLUE_START, HEX_BLUE_START + HEX_CHANNEL_LEN), HEX_RADIX)
+  if (Number.isNaN(r) || Number.isNaN(g) || Number.isNaN(b)) return hex
+  return `rgba(${r},${g},${b},${alpha})`
+}


### PR DESCRIPTION
## Summary
- Replaces hardcoded hex/rgba color values in PodHealthTrend, GPUUtilization, IssueActivityChart, and StockMarketTicker with named constants from `theme/chartColors.ts` and `constants/ui.ts`
- Adds `hexToRgba()` utility for deriving area-gradient colors from named hex tokens
- Adds `YELLOW_500` constant and `CHART_DATAZOOM_*` constants for slider chrome
- Game cards (KubeGalaga, KubeSnake, KubeDoom) left unchanged — canvas-rendered colors with computed shading are intentionally hardcoded

Fixes #9479