### PR TITLE
fix: GPU inventory multi-cluster aggregation and version compare test

### DIFF
--- a/web/src/hooks/useCachedGPU.ts
+++ b/web/src/hooks/useCachedGPU.ts
@@ -8,8 +8,10 @@
 import { useState } from 'react'
 import { useCache, type RefreshCategory } from '../lib/cache'
 import { fetchAPI, fetchFromAllClusters, fetchViaSSE, getToken, AGENT_HTTP_TIMEOUT_MS } from '../lib/cache/fetcherUtils'
+import { settledWithConcurrency } from '../lib/utils/concurrency'
 import { LOCAL_AGENT_HTTP_URL } from '../lib/constants'
 import { FETCH_DEFAULT_TIMEOUT_MS, AI_PREDICTION_TIMEOUT_MS } from '../lib/constants/network'
+import { clusterCacheRef, deduplicateClustersByServer } from './mcp/shared'
 import {
   getDemoGPUNodes,
   getDemoCachedGPUNodeHealth,
@@ -189,14 +191,53 @@ export function useCachedGPUNodes(
         const data = validateArrayResponse<{ nodes: GPUNode[] }>(GPUNodesResponseSchema, raw, '/api/mcp/gpu-nodes', 'nodes')
         return (data.nodes || []).map(n => ({ ...n, cluster }))
       }
-      return await fetchFromAllClusters<GPUNode>(
-        'gpu-nodes',
-        'nodes',
-        undefined,
-        true,
-        undefined,
-        gpuFetchOptions,
+
+      // Deduplicate clusters before fan-out (#9502). Multiple kubeconfig
+      // contexts can point to the same physical cluster. Without dedup,
+      // fetchFromAllClusters queries every raw context — if two contexts
+      // share a server, one cluster's GPUs appear twice while the other
+      // GPU-bearing cluster's data may be lost due to name collisions in
+      // the accumulated results. See MEMORY.md: "ALWAYS use
+      // DeduplicatedClusters() when iterating clusters".
+      const allClusters = clusterCacheRef.clusters || []
+      const deduped = deduplicateClustersByServer(allClusters)
+      const reachable = deduped.filter(
+        (c) => c.reachable !== false && !c.name.includes('/'),
       )
+      if (reachable.length === 0) {
+        throw new Error(
+          'No reachable clusters (agent connecting or backend not authenticated)',
+        )
+      }
+
+      const tasks = reachable.map((cl) => async () => {
+        const raw = await fetchAPI<unknown>('gpu-nodes', { cluster: cl.name })
+        const data = validateArrayResponse<{ nodes: GPUNode[] }>(
+          GPUNodesResponseSchema, raw, '/api/mcp/gpu-nodes', 'nodes',
+        )
+        return (data.nodes || []).map(n => ({ ...n, cluster: cl.name }))
+      })
+
+      const accumulated: GPUNode[] = []
+      let failedCount = 0
+      function handleSettled(result: PromiseSettledResult<GPUNode[]>) {
+        if (result.status === 'fulfilled') {
+          accumulated.push(...result.value)
+        } else {
+          failedCount++
+        }
+      }
+      await settledWithConcurrency(tasks, undefined, handleSettled)
+
+      // Partial-failure protection (#8080, #8081): if any cluster errored
+      // and the accumulated result is empty, preserve stale cache.
+      if (accumulated.length === 0 && failedCount > 0) {
+        throw new Error(
+          `Partial cluster failure yielded empty GPU result (${failedCount}/${reachable.length} clusters errored) — preserving existing cache`,
+        )
+      }
+
+      return accumulated
     },
     progressiveFetcher: cluster ? undefined : async (onProgress) => {
       return await fetchViaSSE<GPUNode>('gpu-nodes', 'nodes', {}, onProgress, gpuFetchOptions)

--- a/web/src/hooks/useVersionCheck.tsx
+++ b/web/src/hooks/useVersionCheck.tsx
@@ -115,8 +115,9 @@ export function isDevVersion(version: string): boolean {
   if (version === '0.0.0') return true
   // A version matching semver (with or without 'v' prefix) is a real release.
   // Helm installs report versions without the 'v' prefix (e.g., "0.3.21")
-  // which should NOT be treated as dev builds.
-  if (/^v?\d+\.\d+\.\d+/.test(version)) return false
+  // which should NOT be treated as dev builds. Two-part versions like "v1.0"
+  // are also valid release tags (#9506).
+  if (/^v?\d+\.\d+(\.\d+)?/.test(version)) return false
   return true
 }
 


### PR DESCRIPTION
## Summary
- Fixes GPU Inventory card only showing GPUs from one cluster by applying `deduplicateClustersByServer()` in the `useCachedGPUNodes` fetcher, following the same pattern as `useCachedAllNodes` (#9502)
- Fixes `isDevVersion` regex to accept 2-part version tags like `v1.0` so the `isNewerVersion` test passes (#9506)

## Changes
- `web/src/hooks/useCachedGPU.ts`: Replace `fetchFromAllClusters` with custom dedup-aware fan-out that uses `deduplicateClustersByServer` before iterating clusters
- `web/src/hooks/useVersionCheck.tsx`: Update regex from `/^v?\d+\.\d+\.\d+/` to `/^v?\d+\.\d+(\.\d+)?/` to match both 2-part and 3-part version tags

## Test plan
- [x] `useVersionCheck-version-compare.test.tsx` — all 53 tests pass (was 1 failing)
- [x] `useCachedData.progressive-gpu.test.ts` — all 54 tests pass
- [ ] CI build/lint

Fixes #9502, Fixes #9506