### PR TITLE
🐛 fix(release): fix cosign bundle format and debounced token test

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -298,30 +298,20 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           VERSION: ${{ needs.determine-version.outputs.version }}
         run: |
-          # Sign checksums file with keyless cosign (Sigstore OIDC)
-          # The scorecard Signed-Releases check looks for .sig files
-          # attached to GitHub release assets
-          #
-          # --new-bundle-format=false: cosign v3.x defaults this to true and
-          # then requires --bundle to be specified; with the flag enabled the
-          # legacy --output-signature / --output-certificate flags are silently
-          # ignored and cosign fails with
+          # Sign checksums file with keyless cosign (Sigstore OIDC).
+          # Use --bundle (new cosign v3 default) since the legacy
+          # --output-signature / --output-certificate flags are ignored
+          # when the new bundle format is active, causing:
           #   "create bundle file: open : no such file or directory"
-          # because no --bundle path is set. Disabling the new bundle format
-          # restores the legacy .sig/.pem output that the scorecard
-          # Signed-Releases check and prior releases rely on. See
-          # https://github.com/sigstore/cosign/releases/tag/v3.0.1 for the
-          # v3 --bundle-required change.
+          # The OpenSSF Scorecard Signed-Releases check accepts .bundle
+          # files as valid signing evidence.
           cosign sign-blob --yes \
-            --new-bundle-format=false \
-            --output-signature dist/checksums.txt.sig \
-            --output-certificate dist/checksums.txt.pem \
+            --bundle dist/checksums.txt.bundle \
             dist/checksums.txt
 
-          # Upload signatures to the release
+          # Upload signing bundle to the release
           gh release upload "${VERSION}" \
-            dist/checksums.txt.sig \
-            dist/checksums.txt.pem \
+            dist/checksums.txt.bundle \
             --repo "${{ github.repository }}" \
             --clobber
 

--- a/pkg/agent/server_ai_test.go
+++ b/pkg/agent/server_ai_test.go
@@ -35,10 +35,6 @@ func TestServer_TokenUsage(t *testing.T) {
 	// 1. Add usage
 	s.addTokenUsage(usage)
 
-	// Wait for async save (short sleep is ugly but saveTokenUsage is a goroutine)
-	// In a real test we might want to wait for the goroutine
-	time.Sleep(100 * time.Millisecond)
-
 	s.tokenMux.RLock()
 	if s.sessionTokensIn != 100 || s.sessionTokensOut != 50 {
 		t.Errorf("Expected 100/50 session tokens, got %d/%d", s.sessionTokensIn, s.sessionTokensOut)
@@ -50,7 +46,6 @@ func TestServer_TokenUsage(t *testing.T) {
 
 	// 2. Add more usage
 	s.addTokenUsage(usage)
-	time.Sleep(100 * time.Millisecond)
 
 	s.tokenMux.RLock()
 	if s.sessionTokensIn != 200 || s.sessionTokensOut != 100 {
@@ -58,7 +53,11 @@ func TestServer_TokenUsage(t *testing.T) {
 	}
 	s.tokenMux.RUnlock()
 
-	// 3. Verify persistence
+	// 3. Verify persistence — force a synchronous flush because
+	// addTokenUsage uses a debounced 5 s timer (#9483) that will not
+	// have fired yet.
+	s.saveTokenUsage()
+
 	path := getTokenUsagePath()
 	data, err := os.ReadFile(path)
 	if err != nil {


### PR DESCRIPTION
## Problem

The nightly Release workflow failed on **two consecutive days**:

### Apr 21 — `release` job / `Sign release artifacts with cosign` step
```
WARNING: --output-signature is deprecated when using --new-bundle-format and will be ignored
WARNING: --output-certificate is deprecated when using --new-bundle-format and will be ignored
Error: signing dist/checksums.txt: create bundle file: open : no such file or directory
```
cosign v3.x ignores `--new-bundle-format=false` and silently drops the legacy `--output-signature` / `--output-certificate` flags, then fails because no `--bundle` path is set.

### Apr 22 — `test` job / `Run Go tests` step
```
server_ai_test.go:65: Failed to read usage file: open /tmp/agent-test-…/.kc-agent-tokens.json: no such file or directory
--- FAIL: TestServer_TokenUsage (0.20s)
```
Commit 768b6489 introduced a 5 s debounced flush timer for token usage writes (#9483), but the test only slept 100 ms before reading the file from disk.

## Fix

1. **cosign**: Switch to `--bundle dist/checksums.txt.bundle` (the v3 default). The OpenSSF Scorecard `Signed-Releases` check accepts `.bundle` files.
2. **test**: Call `saveTokenUsage()` synchronously before asserting on disk content; remove the now-unnecessary `time.Sleep` calls.

## Validation
- `go test ./pkg/agent/ -run TestServer_TokenUsage -v` → PASS
- All `TestServer_*` tests pass