### PR TITLE
🐛 fix goroutine leak on client disconnect (#9517, #9527)

### DIFF
--- a/pkg/api/handlers/acmm_scan.go
+++ b/pkg/api/handlers/acmm_scan.go
@@ -195,13 +195,16 @@ func ACMMScanHandler(c *fiber.Ctx) error {
 	}
 
 	// We are the primary scanner.
+	// Use a detached context so the scan continues even if the primary
+	// requester disconnects — other concurrent waiters should still
+	// receive the result (#9527).
 	defer func() {
 		acmmScanInFlight.Delete(repo)
 		close(waiter.done)
 	}()
 
 	token := settings.ResolveGitHubTokenEnv()
-	ctx, cancel := context.WithTimeout(c.Context(), time.Duration(acmmAPITimeoutMS)*time.Millisecond)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Duration(acmmAPITimeoutMS)*time.Millisecond)
 	defer cancel()
 
 	// Fetch repo tree

--- a/pkg/api/handlers/benchmarks.go
+++ b/pkg/api/handlers/benchmarks.go
@@ -428,9 +428,13 @@ func (h *BenchmarkHandlers) throttle() {
 }
 
 // driveGet performs a throttled HTTP GET with the proper User-Agent header.
-func (h *BenchmarkHandlers) driveGet(url string) (*http.Response, error) {
+// The context is used to cancel in-flight requests when the client disconnects.
+func (h *BenchmarkHandlers) driveGet(ctx context.Context, url string) (*http.Response, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
 	h.throttle()
-	req, err := http.NewRequest("GET", url, nil)
+	req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -439,15 +443,22 @@ func (h *BenchmarkHandlers) driveGet(url string) (*http.Response, error) {
 }
 
 // driveGetWithRetry performs an HTTP GET with throttling and retry on 403 errors.
-func (h *BenchmarkHandlers) driveGetWithRetry(url string) (*http.Response, error) {
+func (h *BenchmarkHandlers) driveGetWithRetry(ctx context.Context, url string) (*http.Response, error) {
 	var lastErr error
 	for attempt := 0; attempt <= driveMaxRetries; attempt++ {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
 		if attempt > 0 {
 			backoff := driveRetryBaseDelay * time.Duration(1<<(attempt-1))
 			slog.Info("[benchmarks] retrying", "backoff", backoff, "attempt", attempt, "maxRetries", driveMaxRetries)
-			time.Sleep(backoff)
+			select {
+			case <-time.After(backoff):
+			case <-ctx.Done():
+				return nil, ctx.Err()
+			}
 		}
-		resp, err := h.driveGet(url)
+		resp, err := h.driveGet(ctx, url)
 		if err != nil {
 			lastErr = fmt.Errorf("HTTP error: %w", err)
 			continue
@@ -493,7 +504,7 @@ func (h *BenchmarkHandlers) GetReports(c *fiber.Ctx) error {
 	}
 
 	// Fetch from Google Drive
-	reports, parseFailures, err := h.fetchAllReports(cutoff)
+	reports, parseFailures, err := h.fetchAllReports(context.Background(), cutoff)
 	if err != nil {
 		slog.Error("[benchmarks] Google Drive fetch error", "error", err)
 		h.cache.mu.RLock()
@@ -557,6 +568,11 @@ func (h *BenchmarkHandlers) StreamReports(c *fiber.Ctx) error {
 	c.Set("Connection", "keep-alive")
 
 	c.Context().SetBodyStreamWriter(func(w *bufio.Writer) {
+		// Create a cancellable context so all goroutines and Drive API calls
+		// abort promptly when the client disconnects (#9517).
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
 		allReports := make([]BenchmarkReport, 0)
 		totalSent := 0
 		skippedFolders := 0
@@ -566,8 +582,20 @@ func (h *BenchmarkHandlers) StreamReports(c *fiber.Ctx) error {
 		const batchSize = 8
 		var pendingBatch []BenchmarkReport
 
+		// safeFlush writes pending data and cancels the context on write error
+		// (which signals that the client has disconnected).
+		safeFlush := func() {
+			if err := w.Flush(); err != nil {
+				slog.Info("[benchmarks] client disconnected, cancelling stream", "error", err)
+				cancel()
+			}
+		}
+
 		flushBatch := func() {
 			if len(pendingBatch) == 0 {
+				return
+			}
+			if ctx.Err() != nil {
 				return
 			}
 			batch, err := json.Marshal(pendingBatch)
@@ -576,14 +604,17 @@ func (h *BenchmarkHandlers) StreamReports(c *fiber.Ctx) error {
 				return
 			}
 			fmt.Fprintf(w, "event: batch\ndata: %s\n\n", batch)
-			w.Flush()
+			safeFlush()
 			slog.Info("[benchmarks] flushed batch", "batchSize", len(pendingBatch), "totalSent", totalSent)
 			pendingBatch = pendingBatch[:0]
 		}
 
 		// Send immediate progress event so the client knows we're connected
 		fmt.Fprintf(w, "event: progress\ndata: {\"status\":\"connecting\",\"total\":0}\n\n")
-		w.Flush()
+		safeFlush()
+		if ctx.Err() != nil {
+			return
+		}
 
 		// Start keepalive ticker — send comment heartbeats every 5s
 		keepaliveDone := make(chan struct{})
@@ -594,19 +625,25 @@ func (h *BenchmarkHandlers) StreamReports(c *fiber.Ctx) error {
 				select {
 				case <-ticker.C:
 					fmt.Fprintf(w, ": keepalive\n\n")
-					w.Flush()
+					safeFlush()
 				case <-keepaliveDone:
+					return
+				case <-ctx.Done():
 					return
 				}
 			}
 		}()
 		defer close(keepaliveDone)
 
-		topLevel, err := h.listDriveFolder(h.folderID)
+		topLevel, err := h.listDriveFolder(ctx, h.folderID)
 		if err != nil {
+			if ctx.Err() != nil {
+				slog.Info("[benchmarks] stream cancelled during folder listing")
+				return
+			}
 			slog.Info("[benchmarks] error listing drive folder", "error", err)
 			fmt.Fprintf(w, "event: error\ndata: {\"error\":\"failed to fetch benchmark data\"}\n\n")
-			w.Flush()
+			safeFlush()
 			return
 		}
 
@@ -627,7 +664,7 @@ func (h *BenchmarkHandlers) StreamReports(c *fiber.Ctx) error {
 			slog.Info("[benchmarks] skipped old experiment folders", "skipped", skippedFolders, "since", since)
 		}
 		fmt.Fprintf(w, "event: progress\ndata: {\"status\":\"fetching\",\"experiments\":%d,\"total\":0,\"skipped\":%d}\n\n", len(experiments), skippedFolders)
-		w.Flush()
+		safeFlush()
 
 		// streamMu protects shared state (allReports, pendingBatch, counters)
 		// across concurrent goroutines.
@@ -636,21 +673,38 @@ func (h *BenchmarkHandlers) StreamReports(c *fiber.Ctx) error {
 		streamSem := make(chan struct{}, driveFetchConcurrency)
 
 		for _, item := range experiments {
+			if ctx.Err() != nil {
+				break
+			}
 			item := item // capture
 			streamWg.Add(1)
-			streamSem <- struct{}{}
+			// Use select for semaphore acquisition so we can bail on cancellation.
+			select {
+			case streamSem <- struct{}{}:
+			case <-ctx.Done():
+				streamWg.Done()
+				continue
+			}
 			go func() {
 				defer streamWg.Done()
 				defer func() { <-streamSem }()
 
-				runFolders, listErr := h.listDriveFolder(item.ID)
+				if ctx.Err() != nil {
+					return
+				}
+				runFolders, listErr := h.listDriveFolder(ctx, item.ID)
 				if listErr != nil {
-					slog.Error("[benchmarks] error listing experiment", "experiment", item.Name, "error", listErr)
+					if ctx.Err() == nil {
+						slog.Error("[benchmarks] error listing experiment", "experiment", item.Name, "error", listErr)
+					}
 					return
 				}
 
 				var innerWg sync.WaitGroup
 				for _, runItem := range runFolders {
+					if ctx.Err() != nil {
+						break
+					}
 					if runItem.MimeType != driveFolderMIME {
 						continue
 					}
@@ -662,12 +716,20 @@ func (h *BenchmarkHandlers) StreamReports(c *fiber.Ctx) error {
 					}
 					runItem := runItem // capture
 					innerWg.Add(1)
-					streamSem <- struct{}{}
+					select {
+					case streamSem <- struct{}{}:
+					case <-ctx.Done():
+						innerWg.Done()
+						continue
+					}
 					go func() {
 						defer innerWg.Done()
 						defer func() { <-streamSem }()
 
-						reports, failures, runErr := h.fetchRunFolderStreaming(runItem.ID, item.Name, runItem.Name, func(report BenchmarkReport) {
+						if ctx.Err() != nil {
+							return
+						}
+						reports, failures, runErr := h.fetchRunFolderStreaming(ctx, runItem.ID, item.Name, runItem.Name, func(report BenchmarkReport) {
 							streamMu.Lock()
 							allReports = append(allReports, report)
 							totalSent++
@@ -681,7 +743,9 @@ func (h *BenchmarkHandlers) StreamReports(c *fiber.Ctx) error {
 						totalParseFailures += failures
 						streamMu.Unlock()
 						if runErr != nil {
-							slog.Error("[benchmarks] error in experiment run", "experiment", item.Name, "run", runItem.Name, "error", runErr)
+							if ctx.Err() == nil {
+								slog.Error("[benchmarks] error in experiment run", "experiment", item.Name, "run", runItem.Name, "error", runErr)
+							}
 							return
 						}
 						streamMu.Lock()
@@ -702,10 +766,15 @@ func (h *BenchmarkHandlers) StreamReports(c *fiber.Ctx) error {
 		// Flush any final remaining reports
 		flushBatch()
 
+		if ctx.Err() != nil {
+			slog.Info("[benchmarks] stream cancelled, skipping cache update", "totalSent", totalSent)
+			return
+		}
+
 		h.cache.set(allReports, since)
 		slog.Info("[benchmarks] stream complete", "totalSent", totalSent, "skipped", skippedFolders, "parseFailures", totalParseFailures, "since", since)
 		fmt.Fprintf(w, "event: done\ndata: {\"total\":%d,\"source\":\"live\",\"parse_failures\":%d}\n\n", totalSent, totalParseFailures)
-		w.Flush()
+		safeFlush()
 	})
 
 	return nil
@@ -713,8 +782,8 @@ func (h *BenchmarkHandlers) StreamReports(c *fiber.Ctx) error {
 
 // fetchRunFolderStreaming delegates to fetchRunFolder and calls onReport for each
 // parsed report, ensuring the streaming and non-streaming paths never diverge.
-func (h *BenchmarkHandlers) fetchRunFolderStreaming(folderID, experimentName, runName string, onReport func(BenchmarkReport)) ([]BenchmarkReport, int, error) {
-	reports, parseFailures, err := h.fetchRunFolder(folderID, experimentName, runName)
+func (h *BenchmarkHandlers) fetchRunFolderStreaming(ctx context.Context, folderID, experimentName, runName string, onReport func(BenchmarkReport)) ([]BenchmarkReport, int, error) {
+	reports, parseFailures, err := h.fetchRunFolder(ctx, folderID, experimentName, runName)
 	if err != nil {
 		return nil, parseFailures, err
 	}
@@ -731,8 +800,8 @@ func (h *BenchmarkHandlers) fetchRunFolderStreaming(folderID, experimentName, ru
 // Experiment and run folders are processed concurrently (bounded by
 // driveFetchConcurrency).  The per-request throttle() still serialises
 // actual HTTP calls so the Drive API rate limit is respected.
-func (h *BenchmarkHandlers) fetchAllReports(cutoff time.Time) ([]BenchmarkReport, int, error) {
-	topLevel, err := h.listDriveFolder(h.folderID)
+func (h *BenchmarkHandlers) fetchAllReports(ctx context.Context, cutoff time.Time) ([]BenchmarkReport, int, error) {
+	topLevel, err := h.listDriveFolder(ctx, h.folderID)
 	if err != nil {
 		return nil, 0, fmt.Errorf("listing top-level folder: %w", err)
 	}
@@ -770,7 +839,7 @@ func (h *BenchmarkHandlers) fetchAllReports(cutoff time.Time) ([]BenchmarkReport
 			defer wg.Done()
 			defer func() { <-sem }() // release slot
 
-			runFolders, listErr := h.listDriveFolder(item.ID)
+			runFolders, listErr := h.listDriveFolder(ctx, item.ID)
 			if listErr != nil {
 				slog.Error("[benchmarks] error listing experiment", "experiment", item.Name, "error", listErr)
 				return
@@ -792,7 +861,7 @@ func (h *BenchmarkHandlers) fetchAllReports(cutoff time.Time) ([]BenchmarkReport
 					defer innerWg.Done()
 					defer func() { <-sem }()
 
-					reports, failures, runErr := h.fetchRunFolder(runItem.ID, item.Name, runItem.Name)
+					reports, failures, runErr := h.fetchRunFolder(ctx, runItem.ID, item.Name, runItem.Name)
 					if runErr != nil {
 						slog.Error("[benchmarks] error in experiment run", "experiment", item.Name, "run", runItem.Name, "error", runErr)
 						return
@@ -814,8 +883,8 @@ func (h *BenchmarkHandlers) fetchAllReports(cutoff time.Time) ([]BenchmarkReport
 // fetchRunFolder downloads benchmark YAML files from a run folder.
 // Handles nested layouts: run → results → individual-result → benchmark_report*.yaml
 // Returns reports and a count of files that failed to download or parse.
-func (h *BenchmarkHandlers) fetchRunFolder(folderID, experimentName, runName string) ([]BenchmarkReport, int, error) {
-	items, err := h.listDriveFolder(folderID)
+func (h *BenchmarkHandlers) fetchRunFolder(ctx context.Context, folderID, experimentName, runName string) ([]BenchmarkReport, int, error) {
+	items, err := h.listDriveFolder(ctx, folderID)
 	if err != nil {
 		return nil, 0, err
 	}
@@ -830,7 +899,7 @@ func (h *BenchmarkHandlers) fetchRunFolder(folderID, experimentName, runName str
 			continue
 		}
 		if strings.HasPrefix(f.Name, benchmarkFilePrefix) && strings.HasSuffix(f.Name, benchmarkFileSuffix) {
-			report, err := h.downloadAndParseReport(f, experimentName, runName)
+			report, err := h.downloadAndParseReport(ctx, f, experimentName, runName)
 			if err != nil {
 				parseFailures++
 				continue
@@ -847,7 +916,7 @@ func (h *BenchmarkHandlers) fetchRunFolder(folderID, experimentName, runName str
 		if !strings.EqualFold(sub.Name, "results") {
 			continue
 		}
-		resultFolders, err := h.listDriveFolder(sub.ID)
+		resultFolders, err := h.listDriveFolder(ctx, sub.ID)
 		if err != nil {
 			slog.Error("[benchmarks] error listing results", "experiment", experimentName, "run", runName, "error", err)
 			continue
@@ -856,7 +925,7 @@ func (h *BenchmarkHandlers) fetchRunFolder(folderID, experimentName, runName str
 			if rf.MimeType != driveFolderMIME {
 				continue
 			}
-			r, failures, err := h.collectBenchmarkFiles(rf.ID, experimentName, runName)
+			r, failures, err := h.collectBenchmarkFiles(ctx, rf.ID, experimentName, runName)
 			if err != nil {
 				continue
 			}
@@ -869,8 +938,8 @@ func (h *BenchmarkHandlers) fetchRunFolder(folderID, experimentName, runName str
 
 // collectBenchmarkFiles finds and parses benchmark YAML files in a single folder.
 // Returns the parsed reports and a count of files that failed to parse.
-func (h *BenchmarkHandlers) collectBenchmarkFiles(folderID, experimentName, runName string) ([]BenchmarkReport, int, error) {
-	files, err := h.listDriveFolder(folderID)
+func (h *BenchmarkHandlers) collectBenchmarkFiles(ctx context.Context, folderID, experimentName, runName string) ([]BenchmarkReport, int, error) {
+	files, err := h.listDriveFolder(ctx, folderID)
 	if err != nil {
 		return nil, 0, err
 	}
@@ -881,7 +950,7 @@ func (h *BenchmarkHandlers) collectBenchmarkFiles(folderID, experimentName, runN
 			continue
 		}
 		if strings.HasPrefix(f.Name, benchmarkFilePrefix) && strings.HasSuffix(f.Name, benchmarkFileSuffix) {
-			report, err := h.downloadAndParseReport(f, experimentName, runName)
+			report, err := h.downloadAndParseReport(ctx, f, experimentName, runName)
 			if err != nil {
 				parseFailures++
 				continue
@@ -893,8 +962,8 @@ func (h *BenchmarkHandlers) collectBenchmarkFiles(folderID, experimentName, runN
 }
 
 // downloadAndParseReport downloads a single benchmark YAML file and parses it.
-func (h *BenchmarkHandlers) downloadAndParseReport(f driveFile, experimentName, runName string) (BenchmarkReport, error) {
-	data, err := h.downloadDriveFile(f.ID)
+func (h *BenchmarkHandlers) downloadAndParseReport(ctx context.Context, f driveFile, experimentName, runName string) (BenchmarkReport, error) {
+	data, err := h.downloadDriveFile(ctx, f.ID)
 	if err != nil {
 		slog.Error("[benchmarks] error downloading file", "file", f.Name, "error", err)
 		return BenchmarkReport{}, err
@@ -909,7 +978,7 @@ func (h *BenchmarkHandlers) downloadAndParseReport(f driveFile, experimentName, 
 
 // listDriveFolder lists all files in a Google Drive folder, handling pagination
 // so that folders with more than 1000 items are not silently truncated.
-func (h *BenchmarkHandlers) listDriveFolder(folderID string) ([]driveFile, error) {
+func (h *BenchmarkHandlers) listDriveFolder(ctx context.Context, folderID string) ([]driveFile, error) {
 	var allFiles []driveFile
 	pageToken := ""
 
@@ -920,7 +989,7 @@ func (h *BenchmarkHandlers) listDriveFolder(folderID string) ([]driveFile, error
 			reqURL += "&pageToken=" + pageToken
 		}
 
-		resp, err := h.driveGetWithRetry(reqURL)
+		resp, err := h.driveGetWithRetry(ctx, reqURL)
 		if err != nil {
 			return nil, err
 		}
@@ -958,10 +1027,10 @@ func (h *BenchmarkHandlers) listDriveFolder(folderID string) ([]driveFile, error
 // downloadDriveFile downloads file content from Google Drive.
 // Uses webContentLink (drive.google.com/uc?id=...&export=download) which is more
 // resilient to Google's anti-bot protection than the API's alt=media endpoint.
-func (h *BenchmarkHandlers) downloadDriveFile(fileID string) ([]byte, error) {
+func (h *BenchmarkHandlers) downloadDriveFile(ctx context.Context, fileID string) ([]byte, error) {
 	downloadURL := fmt.Sprintf("https://drive.google.com/uc?id=%s&export=download", fileID)
 
-	resp, err := h.driveGet(downloadURL)
+	resp, err := h.driveGet(ctx, downloadURL)
 	if err != nil {
 		return nil, fmt.Errorf("HTTP error: %w", err)
 	}


### PR DESCRIPTION
Fixes goroutine and resource leaks when clients disconnect.

## Changes

### StreamReports (#9517)
- Propagate `context.Context` through all Drive API functions (`driveGet`, `driveGetWithRetry`, `listDriveFolder`, `downloadDriveFile`, `fetchRunFolder`, etc.)
- Use `http.NewRequestWithContext` so in-flight HTTP requests are cancelled when context is done
- Detect client disconnect via `w.Flush()` errors and cancel the shared context
- Use `select` with `ctx.Done()` for semaphore acquisition so goroutines don't block on a full channel when cancelled
- Replace `time.Sleep` in retry backoff with `select` on `time.After` / `ctx.Done()`
- Skip cache update and suppress noisy error logs when cancellation is the root cause

### ACMM scan (#9527)
- Decouple the scan work context from the primary HTTP request context
- Use `context.Background()` with timeout instead of `c.Context()` so the shared scan continues even if the first requester disconnects
- Other concurrent waiters still receive results as expected

Closes #9517, #9527