### PR TITLE
🐛 fix CI/nightly failures: test mocks, Playwright patterns, roundtrip workflow

### DIFF
--- a/.github/workflows/console-app-roundtrip.yml
+++ b/.github/workflows/console-app-roundtrip.yml
@@ -180,10 +180,11 @@ jobs:
           # 4. Fetch the issue back and verify attribution. Use a
           #    different token (GITHUB_TOKEN) for the read to mirror
           #    what the rewards classifier sees in production.
-          sleep 3  # small settle time for GitHub indexing
+          sleep 5  # settle time for GitHub indexing (increased from 3s)
           READ_RESP=$(curl -sS \
             -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
             -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
             "https://api.github.com/repos/${TEST_REPO_OWNER}/${TEST_REPO_NAME}/issues/${ISSUE_NUMBER}")
 
           ACTUAL_SLUG=$(echo "$READ_RESP" | python3 -c "

--- a/web/e2e/helpers/setup.ts
+++ b/web/e2e/helpers/setup.ts
@@ -46,7 +46,7 @@ export const MOCK_DEMO_USER = {
 export const EXPECTED_ERROR_PATTERNS = [
   /Failed to fetch/i, // Network errors in demo mode
   /WebSocket/i, // WebSocket not available in tests
-  /can't establish a connection/i, // Firefox WebSocket connection errors
+  /can[\u2018\u2019']t establish a connection/i, // Firefox WebSocket connection errors (Firefox uses curly apostrophes)
   /ResizeObserver loop (?:limit exceeded|completed with undelivered notifications)/i, // Benign ResizeObserver loop warning
   /validateDOMNesting/i, // Already tracked by Auto-QA DOM errors check
   /act\(\)/i, // React testing warnings

--- a/web/src/hooks/__tests__/useCachedData.rest-paths.test.ts
+++ b/web/src/hooks/__tests__/useCachedData.rest-paths.test.ts
@@ -625,6 +625,7 @@ describe('useCachedData', () => {
         clusterCacheRef: {
           clusters: [{ name: 'c1', reachable: true }],
         },
+        deduplicateClustersByServer: (clusters: unknown[]) => clusters,
       }))
 
       vi.stubGlobal('fetch', vi.fn().mockResolvedValue({

--- a/web/src/hooks/__tests__/useCachedGPU.test.ts
+++ b/web/src/hooks/__tests__/useCachedGPU.test.ts
@@ -21,14 +21,15 @@ vi.mock('../../lib/cache/fetcherUtils', () => ({
   AGENT_HTTP_TIMEOUT_MS: 30000,
 }))
 
-vi.mock('../../lib/constants', () => ({
-  LOCAL_AGENT_HTTP_URL: 'http://localhost:8585',
-}))
+vi.mock('../../lib/constants', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../lib/constants')>()
+  return { ...actual, LOCAL_AGENT_HTTP_URL: 'http://localhost:8585' }
+})
 
-vi.mock('../../lib/constants/network', () => ({
-  FETCH_DEFAULT_TIMEOUT_MS: 5000,
-  AI_PREDICTION_TIMEOUT_MS: 30000,
-}))
+vi.mock('../../lib/constants/network', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../lib/constants/network')>()
+  return { ...actual, FETCH_DEFAULT_TIMEOUT_MS: 5000, AI_PREDICTION_TIMEOUT_MS: 30000 }
+})
 
 vi.mock('../useCachedData/demoData', () => ({
   getDemoGPUNodes: () => [],


### PR DESCRIPTION
## Summary

Fixes multiple CI/nightly failures in one PR:

### 1. Coverage Suite test failures (#9509)
- **`useCachedGPU.test.ts`**: Mock for `../../lib/constants` was too narrow — stripped transitive imports like `STORAGE_KEY_DEMO_MODE` and `MCP_HOOK_TIMEOUT_MS`. Switched to `importOriginal` to preserve all actual exports while overriding only the needed values.
- **`useCachedData.rest-paths.test.ts`**: The `setupAllClusters` helper mocked `../mcp/shared` without `deduplicateClustersByServer`, which `useCachedGPU.ts` now imports. Added the missing mock.

### 2. Playwright cross-browser failures (#9514)
- Firefox uses curly/smart apostrophes (`'` U+2019) in error messages like `"can't establish a connection"`. The `EXPECTED_ERROR_PATTERNS` regex used a straight apostrophe (`'` U+0027), causing the filter to miss Firefox WebSocket errors. Updated the pattern to match both straight and curly apostrophes.

### 3. Console-bot roundtrip failure (#9511)
- The issue read-back `curl` was missing the `X-GitHub-Api-Version: 2022-11-28` header, which may cause the API to omit the `performed_via_github_app` field. Added the header and increased the settle time from 3s to 5s.

Closes #9509
Refs #9511, #9514