### PR TITLE
🐛 fix UI bugs batch (#9515–#9539)

### DIFF
--- a/web/src/components/dashboard/Dashboard.tsx
+++ b/web/src/components/dashboard/Dashboard.tsx
@@ -332,8 +332,14 @@ export function Dashboard() {
       // Return empty — don't let sortable card droppables capture workload drags
       return []
     }
-    // Normal card reorder uses closestCenter
-    return closestCenter(args)
+    // Normal card reorder — but first check if hovering over a dashboard drop zone
+    const centerCollisions = closestCenter(args)
+    const pointerCollisions = pointerWithin(args)
+    const dashboardDropTarget = pointerCollisions.find(
+      (c) => String(c.id).startsWith('dashboard-drop-') || String(c.id) === 'create-new-dashboard'
+    )
+    if (dashboardDropTarget) return [dashboardDropTarget]
+    return centerCollisions
   }
 
   const handleDragStart = (event: DragStartEvent) => {

--- a/web/src/components/drilldown/views/ClusterDrillDown.tsx
+++ b/web/src/components/drilldown/views/ClusterDrillDown.tsx
@@ -268,10 +268,10 @@ export function ClusterDrillDown({ data }: Props) {
             <span className="text-sm text-muted-foreground">{t('common.status')}</span>
           </div>
           <div className="text-2xl font-bold text-foreground">
-            {health?.reachable === false ? 'Offline' :
+            {health?.reachable === false ? t('common.offline', 'Offline') :
               (health?.nodeCount && health.nodeCount > 0)
-                ? (health.readyNodes === health.nodeCount ? 'Healthy' : 'Degraded')
-                : (health?.healthy ? 'Healthy' : 'Unknown')}
+                ? (health.readyNodes === health.nodeCount ? t('common.healthy', 'Healthy') : t('common.degraded', 'Degraded'))
+                : (health?.healthy ? t('common.healthy', 'Healthy') : t('common.unknown', 'Unknown'))}
           </div>
         </div>
 

--- a/web/src/components/drilldown/views/ComplianceDrillDown.tsx
+++ b/web/src/components/drilldown/views/ComplianceDrillDown.tsx
@@ -174,10 +174,10 @@ export function ComplianceDrillDown({ data }: Props) {
       : <ChevronDown className="w-3 h-3" />
   }
 
-  // Summary stats
-  const passCount = filteredRows.filter(r => r.status === 'pass').length
-  const failCount = filteredRows.filter(r => r.status === 'fail').length
-  const otherCount = filteredRows.filter(r => r.status === 'other' || r.status === 'not-applicable').length
+  // Summary stats — always computed from allRows so they are unaffected by filters
+  const passCount = allRows.filter(r => r.status === 'pass').length
+  const failCount = allRows.filter(r => r.status === 'fail').length
+  const otherCount = allRows.filter(r => r.status === 'other' || r.status === 'not-applicable').length
   const activeFilters = [statusFilter, severityFilter, clusterFilter, profileFilter, searchQuery].filter(Boolean).length
 
   return (
@@ -203,7 +203,7 @@ export function ComplianceDrillDown({ data }: Props) {
               !statusFilter ? 'border-teal-500/40 bg-teal-500/10' : 'border-border bg-card/50 hover:border-border/80'
             )}
           >
-            <div className="text-xl font-bold text-foreground">{filteredRows.length}</div>
+            <div className="text-xl font-bold text-foreground">{allRows.length}</div>
             <div className="text-xs text-muted-foreground">Total Controls</div>
           </button>
           <button

--- a/web/src/components/drilldown/views/ConfigMapDrillDown.tsx
+++ b/web/src/components/drilldown/views/ConfigMapDrillDown.tsx
@@ -155,10 +155,10 @@ export function ConfigMapDrillDown({ data }: Props) {
   }
 
   const TABS: { id: TabType; label: string; icon: typeof Info }[] = [
-    { id: 'overview', label: 'Overview', icon: Info },
-    { id: 'data', label: 'Data', icon: Database },
-    { id: 'describe', label: 'Describe', icon: FileText },
-    { id: 'yaml', label: 'YAML', icon: Code },
+    { id: 'overview', label: t('drilldown.tabs.overview', 'Overview'), icon: Info },
+    { id: 'data', label: t('drilldown.tabs.data', 'Data'), icon: Database },
+    { id: 'describe', label: t('drilldown.tabs.describe', 'Describe'), icon: FileText },
+    { id: 'yaml', label: t('drilldown.tabs.yaml', 'YAML'), icon: Code },
   ]
 
   const dataEntries = Object.entries(configmapData || {})

--- a/web/src/components/drilldown/views/DeploymentDrillDown.tsx
+++ b/web/src/components/drilldown/views/DeploymentDrillDown.tsx
@@ -440,11 +440,11 @@ export function DeploymentDrillDown({ data }: Props) {
   const isHealthy = readyReplicas === replicas && replicas > 0
 
   const TABS: { id: TabType; label: string; icon: typeof Info }[] = [
-    { id: 'overview', label: 'Overview', icon: Info },
-    { id: 'pods', label: `Pods (${pods.length})`, icon: Box },
-    { id: 'events', label: 'Events', icon: Zap },
-    { id: 'describe', label: 'Describe', icon: FileText },
-    { id: 'yaml', label: 'YAML', icon: Code },
+    { id: 'overview', label: t('drilldown.tabs.overview', 'Overview'), icon: Info },
+    { id: 'pods', label: `${t('drilldown.tabs.pods', 'Pods')} (${pods.length})`, icon: Box },
+    { id: 'events', label: t('drilldown.tabs.events', 'Events'), icon: Zap },
+    { id: 'describe', label: t('drilldown.tabs.describe', 'Describe'), icon: FileText },
+    { id: 'yaml', label: t('drilldown.tabs.yaml', 'YAML'), icon: Code },
   ]
 
   return (

--- a/web/src/components/drilldown/views/EventsDrillDown.tsx
+++ b/web/src/components/drilldown/views/EventsDrillDown.tsx
@@ -159,7 +159,7 @@ export function EventsDrillDown({ data }: Props) {
         <div className="p-6 rounded-lg bg-yellow-500/10 border border-yellow-500/30 text-center">
           <AlertCircle className="w-8 h-8 text-yellow-400 mx-auto mb-3" />
           <h4 className="font-medium text-yellow-400 mb-2">
-            {error ? 'Failed to load events' : 'No events found'}
+            {error ? t('drilldown.events.failedToLoad', 'Failed to load events') : t('drilldown.events.noEventsFound', 'No events found')}
           </h4>
           <p className="text-sm text-muted-foreground mb-4">
             {error || `No events found for ${objectName || clusterShort}. Events may have expired or the cluster may be unreachable.`}
@@ -170,7 +170,7 @@ export function EventsDrillDown({ data }: Props) {
               className="flex items-center gap-2 px-4 py-2 rounded-lg bg-card border border-border text-sm hover:bg-card/80 transition-colors"
             >
               <RefreshCw className={`w-4 h-4 ${isLoading ? 'animate-spin' : ''}`} />
-              Retry
+              {t('common.retry', 'Retry')}
             </button>
           </div>
         </div>
@@ -179,7 +179,7 @@ export function EventsDrillDown({ data }: Props) {
         <div className="p-4 rounded-lg bg-card/50 border border-border">
           <h4 className="text-sm font-semibold text-foreground mb-3 flex items-center gap-2">
             <Terminal className="w-4 h-4" />
-            Get Events via kubectl
+            {t('drilldown.actions.getEvents', 'Get Events via kubectl')}
           </h4>
           <div className="flex items-center justify-between p-2 rounded bg-background/50 font-mono text-xs">
             <code className="text-muted-foreground truncate">
@@ -226,13 +226,13 @@ export function EventsDrillDown({ data }: Props) {
       <div className="grid grid-cols-3 gap-4">
         <div className="p-4 rounded-lg bg-card/50 border border-border">
           <div className="text-2xl font-bold text-foreground">{filteredEvents.length}</div>
-          <div className="text-sm text-muted-foreground">Total Events</div>
+          <div className="text-sm text-muted-foreground">{t('drilldown.events.totalEvents', 'Total Events')}</div>
         </div>
         <div className="p-4 rounded-lg bg-card/50 border border-border">
           <div className="text-2xl font-bold text-yellow-400">
             {filteredEvents.filter(e => e.type === 'Warning').length}
           </div>
-          <div className="text-sm text-muted-foreground">Warnings</div>
+          <div className="text-sm text-muted-foreground">{t('common.warnings', 'Warnings')}</div>
         </div>
         <div className="p-4 rounded-lg bg-card/50 border border-border">
           <div className="text-2xl font-bold text-green-400">
@@ -280,15 +280,15 @@ export function EventsDrillDown({ data }: Props) {
       {filteredEvents.length === 0 && (
         <div className="space-y-4">
           <div className="text-center py-6">
-            <p className="text-muted-foreground">No events found for {objectName || clusterShort}</p>
-            <p className="text-xs text-muted-foreground mt-1">Events may have expired or require authentication</p>
+            <p className="text-muted-foreground">{t('drilldown.events.noEventsFoundFor', { name: objectName || clusterShort, defaultValue: `No events found for ${objectName || clusterShort}` })}</p>
+            <p className="text-xs text-muted-foreground mt-1">{t('drilldown.events.eventsExpiredHint', 'Events may have expired or require authentication')}</p>
           </div>
 
           {/* Kubectl fallback */}
           <div className="p-4 rounded-lg bg-card/50 border border-border">
             <h4 className="text-sm font-semibold text-foreground mb-3 flex items-center gap-2">
               <Terminal className="w-4 h-4" />
-              Get Events via kubectl
+              {t('drilldown.actions.getEvents', 'Get Events via kubectl')}
             </h4>
             <div className="flex items-center justify-between p-2 rounded bg-background/50 font-mono text-xs">
               <code className="text-muted-foreground truncate">

--- a/web/src/components/drilldown/views/LogsDrillDown.tsx
+++ b/web/src/components/drilldown/views/LogsDrillDown.tsx
@@ -53,7 +53,7 @@ export function LogsDrillDown({ data }: Props) {
   const clusterShort = cluster?.split('/').pop() || cluster
   const [tailLines, setTailLines] = useState<number>(DEFAULT_TAIL_LINES)
   const [isLoading, setIsLoading] = useState(false)
-  const [error] = useState<string | null>(null)
+  const [error, setError] = useState<string | null>(null)
   const [follow, setFollow] = useState(false)
   // Refresh bumps the generatedAt timestamp which regenerates the seed lines
   // so the user sees that the fetch actually took effect.
@@ -119,6 +119,7 @@ export function LogsDrillDown({ data }: Props) {
   }, [follow, followLines])
 
   const handleRefresh = () => {
+    setError(null)
     setIsLoading(true)
     if (refreshTimeoutRef.current !== null) clearTimeout(refreshTimeoutRef.current)
     refreshTimeoutRef.current = setTimeout(() => {

--- a/web/src/components/drilldown/views/NamespaceDrillDown.tsx
+++ b/web/src/components/drilldown/views/NamespaceDrillDown.tsx
@@ -82,9 +82,9 @@ export function NamespaceDrillDown({ data }: Props) {
   })()
 
   const tabs: { id: TabType; label: string; count: number }[] = [
-    { id: 'issues', label: 'Issues', count: podIssues.length + deploymentIssues.length },
+    { id: 'issues', label: t('drilldown.tabs.issues', 'Issues'), count: podIssues.length + deploymentIssues.length },
     { id: 'events', label: t('drilldown.fields.recentEvents'), count: nsEvents.length },
-    { id: 'resources', label: 'Resources', count: (allDeployments?.length || 0) + (allServices?.length || 0) + (allPVCs?.length || 0) + (allPods?.length || 0) },
+    { id: 'resources', label: t('drilldown.tabs.resources', 'Resources'), count: (allDeployments?.length || 0) + (allServices?.length || 0) + (allPVCs?.length || 0) + (allPods?.length || 0) },
   ]
 
   return (
@@ -107,11 +107,11 @@ export function NamespaceDrillDown({ data }: Props) {
       {/* Overview Stats */}
       <div className="grid grid-cols-3 gap-4">
         <div className="p-4 rounded-lg bg-card/50 border border-border">
-          <div className="text-sm text-muted-foreground mb-2">Deployments with Issues</div>
+          <div className="text-sm text-muted-foreground mb-2">{t('drilldown.namespace.deploymentsWithIssues', 'Deployments with Issues')}</div>
           <div className="text-2xl font-bold text-foreground">{deploymentIssues.length}</div>
         </div>
         <div className="p-4 rounded-lg bg-card/50 border border-border">
-          <div className="text-sm text-muted-foreground mb-2">Pods with Issues</div>
+          <div className="text-sm text-muted-foreground mb-2">{t('drilldown.namespace.podsWithIssues', 'Pods with Issues')}</div>
           <div className="text-2xl font-bold text-foreground">{podIssues.length}</div>
         </div>
         <div className="p-4 rounded-lg bg-card/50 border border-border">
@@ -156,7 +156,7 @@ export function NamespaceDrillDown({ data }: Props) {
           {/* Deployment Issues */}
           {deploymentIssues.length > 0 && (
             <div>
-              <h3 className="text-lg font-semibold text-foreground mb-4">Deployment Issues</h3>
+              <h3 className="text-lg font-semibold text-foreground mb-4">{t('drilldown.namespace.deploymentIssues', 'Deployment Issues')}</h3>
               <div className="space-y-2">
                 {deploymentIssues.map((issue, i) => (
                   <div
@@ -190,7 +190,7 @@ export function NamespaceDrillDown({ data }: Props) {
           {/* Pod Issues */}
           {podIssues.length > 0 && (
             <div>
-              <h3 className="text-lg font-semibold text-foreground mb-4">Pod Issues</h3>
+              <h3 className="text-lg font-semibold text-foreground mb-4">{t('drilldown.namespace.podIssues', 'Pod Issues')}</h3>
               <div className="space-y-2">
                 {podIssues.map((issue, i) => (
                   <div
@@ -210,9 +210,9 @@ export function NamespaceDrillDown({ data }: Props) {
                           <span>{issue.restarts} restarts</span>
                           {issue.reason && <span>• {issue.reason}</span>}
                         </div>
-                        {issue.issues.length > 0 && (
+                        {(issue.issues?.length ?? 0) > 0 && (
                           <div className="flex flex-wrap gap-1 mt-2">
-                            {issue.issues.map((iss, j) => (
+                            {issue.issues?.map((iss, j) => (
                               <StatusBadge key={j} color="red" size="xs">
                                 {iss}
                               </StatusBadge>

--- a/web/src/components/drilldown/views/SecretDrillDown.tsx
+++ b/web/src/components/drilldown/views/SecretDrillDown.tsx
@@ -176,10 +176,10 @@ export function SecretDrillDown({ data }: Props) {
   }
 
   const TABS: { id: TabType; label: string; icon: typeof Info }[] = [
-    { id: 'overview', label: 'Overview', icon: Info },
-    { id: 'data', label: 'Data', icon: Lock },
-    { id: 'describe', label: 'Describe', icon: FileText },
-    { id: 'yaml', label: 'YAML', icon: Code },
+    { id: 'overview', label: t('drilldown.tabs.overview', 'Overview'), icon: Info },
+    { id: 'data', label: t('drilldown.tabs.data', 'Data'), icon: Lock },
+    { id: 'describe', label: t('drilldown.tabs.describe', 'Describe'), icon: FileText },
+    { id: 'yaml', label: t('drilldown.tabs.yaml', 'YAML'), icon: Code },
   ]
 
   const dataEntries = Object.entries(secretData || {})

--- a/web/src/components/drilldown/views/YAMLDrillDown.tsx
+++ b/web/src/components/drilldown/views/YAMLDrillDown.tsx
@@ -164,22 +164,14 @@ export function YAMLDrillDown({ data }: Props) {
 
       {/* YAML Content */}
       <div className="relative">
+        {isLoading && yaml && (
+          <div className="absolute inset-0 z-10 flex items-center justify-center bg-background/60 rounded-lg backdrop-blur-sm">
+            <div className="spinner w-6 h-6" />
+          </div>
+        )}
         <pre className="p-4 rounded-lg bg-card/50 border border-border overflow-auto max-h-[60vh] text-sm font-mono text-foreground whitespace-pre">
           {yaml}
         </pre>
-      </div>
-
-      {/* Quick Actions */}
-      <div className="flex flex-wrap gap-2">
-        <button className="px-3 py-1.5 rounded bg-card/50 border border-border text-sm text-muted-foreground hover:text-foreground hover:bg-card transition-colors">
-          Apply Changes
-        </button>
-        <button className="px-3 py-1.5 rounded bg-card/50 border border-border text-sm text-muted-foreground hover:text-foreground hover:bg-card transition-colors">
-          Compare with Git
-        </button>
-        <button className="px-3 py-1.5 rounded bg-card/50 border border-border text-sm text-muted-foreground hover:text-foreground hover:bg-card transition-colors">
-          View in Editor
-        </button>
       </div>
     </div>
   )

--- a/web/src/components/feedback/FeedbackModal.tsx
+++ b/web/src/components/feedback/FeedbackModal.tsx
@@ -571,6 +571,11 @@ export function FeedbackModal({ isOpen, onClose, initialType = 'feature' }: Feed
                       <Send className="w-4 h-4" />
                     )}
                     {isSubmitting ? 'Creating issue...' : `Submit & Earn ${coins} Coins`}
+                    {!isSubmitting && (
+                      <kbd className="ml-1 px-1.5 py-0.5 rounded bg-white/20 text-[10px] font-mono leading-none">
+                        {navigator.platform?.includes('Mac') ? '⌘' : 'Ctrl'}↵
+                      </kbd>
+                    )}
                   </button>
                 </div>
               </form>

--- a/web/src/components/layout/navbar/AgentStatusIndicator.tsx
+++ b/web/src/components/layout/navbar/AgentStatusIndicator.tsx
@@ -397,7 +397,7 @@ export function AgentStatusIndicator() {
                         ? 'bg-yellow-400'
                         : isConnected
                           ? 'bg-green-400'
-                          : agentStatus === 'connecting'
+                          : stableStatus === 'connecting'
                             ? 'bg-yellow-400'
                             : 'bg-red-400',
                 )}
@@ -416,7 +416,7 @@ export function AgentStatusIndicator() {
                       ? t('agent.localAgentDegraded')
                       : isConnected
                         ? t('agent.localAgentConnectedLabel')
-                        : agentStatus === 'connecting'
+                        : stableStatus === 'connecting'
                           ? t('agent.localAgentConnecting')
                           : t('agent.localAgentDisconnectedLabel')}
               </span>

--- a/web/src/components/layout/navbar/Navbar.tsx
+++ b/web/src/components/layout/navbar/Navbar.tsx
@@ -80,7 +80,7 @@ export function Navbar({ topOffset = 0 }: NavbarProps) {
         <button
           type="button"
           onClick={() => navigate(ROUTES.HOME)}
-          className="flex items-center gap-2 md:gap-3 p-2 -m-2 min-w-[44px] min-h-[44px] hover:opacity-80 transition-opacity"
+          className="flex items-center gap-2 md:gap-3 p-2 -m-2 min-w-[44px] min-h-[44px] hover:opacity-80 transition-opacity cursor-pointer"
           aria-label={t('navbar.goHome')}
         >
           <LogoWithStar className="w-8 h-8 md:w-9 md:h-9" showStar={false} />
@@ -88,7 +88,7 @@ export function Navbar({ topOffset = 0 }: NavbarProps) {
         <button
           type="button"
           onClick={() => navigate(ROUTES.HOME)}
-          className="hidden lg:flex flex-col leading-tight justify-center min-h-[44px] hover:opacity-80 transition-opacity text-left"
+          className="hidden lg:flex flex-col leading-tight justify-center min-h-[44px] hover:opacity-80 transition-opacity text-left cursor-pointer"
           aria-label={t('navbar.goHome')}
         >
           <span className="text-base md:text-lg font-semibold text-foreground">{branding.appName}</span>

--- a/web/src/components/missions/ConfirmMissionPromptDialog.tsx
+++ b/web/src/components/missions/ConfirmMissionPromptDialog.tsx
@@ -18,7 +18,7 @@
  *   />
  */
 
-import { useState } from 'react'
+import { useState, useEffect, useCallback } from 'react'
 import { Wand2, Info } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 import { BaseModal } from '../../lib/modals/BaseModal'
@@ -62,6 +62,25 @@ export function ConfirmMissionPromptDialog({
 
   const trimmed = prompt.trim()
   const confirmDisabled = trimmed.length === 0
+
+  const handleConfirm = useCallback(() => {
+    if (!confirmDisabled) onConfirm(prompt)
+  }, [confirmDisabled, onConfirm, prompt])
+
+  // Ctrl/Cmd+Enter submits the mission
+  useEffect(() => {
+    if (!open) return
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) {
+        e.preventDefault()
+        handleConfirm()
+      }
+    }
+    window.addEventListener('keydown', handleKeyDown)
+    return () => window.removeEventListener('keydown', handleKeyDown)
+  }, [open, handleConfirm])
+
+  const isMac = typeof navigator !== 'undefined' && /Mac|iPod|iPhone|iPad/.test(navigator.platform ?? '')
 
   return (
     <BaseModal isOpen={open} onClose={onCancel} size="lg">
@@ -124,11 +143,14 @@ export function ConfirmMissionPromptDialog({
         <Button
           variant="accent"
           size="sm"
-          onClick={() => onConfirm(prompt)}
+          onClick={handleConfirm}
           disabled={confirmDisabled}
-          className="ml-auto"
+          className="ml-auto gap-2"
         >
           {t('confirmMissionPrompt.confirm', 'Run mission')}
+          <kbd className="hidden sm:inline-flex px-1.5 py-0.5 rounded bg-white/10 text-[10px] font-mono leading-none">
+            {isMac ? '\u2318' : 'Ctrl'}\u21b5
+          </kbd>
         </Button>
       </BaseModal.Footer>
     </BaseModal>

--- a/web/src/components/ui/StatsConfig.tsx
+++ b/web/src/components/ui/StatsConfig.tsx
@@ -182,7 +182,7 @@ const DASHBOARD_CATEGORIES: { type: DashboardStatsType; name: string; icon: stri
   { type: 'storage', name: 'Storage', icon: '💽' },
   { type: 'network', name: 'Network', icon: '🌐' },
   { type: 'security', name: 'Security', icon: '🛡️' },
-  { type: 'compliance', name: 'Security Posture', icon: '🔒' },
+  { type: 'compliance', name: 'Compliance', icon: '🔒' },
   { type: 'data-compliance', name: 'Data Compliance', icon: '📋' },
   { type: 'events', name: 'Events', icon: '📜' },
   { type: 'cost', name: 'Cost', icon: '💵' },

--- a/web/src/locales/en/common.json
+++ b/web/src/locales/en/common.json
@@ -2029,7 +2029,7 @@
     "cardRequestAction": "Request Card",
     "cardRequestRequested": "Requested",
     "cardRequestRetry": "Retry",
-    "cardRequestSending": "Sending\u2026",
+    "cardRequestSending": "Sending…",
     "reminderTitle": "Orbital maintenance due",
     "reminderDismiss": "Dismiss",
     "standaloneTitle": "New Orbit Mission",
@@ -2106,7 +2106,8 @@
       "more": "+{{count}} more",
       "more_one": "+{{count}} more",
       "more_other": "+{{count}} more",
-      "manifest": "Manifest"
+      "manifest": "Manifest",
+      "issues": "Issues"
     },
     "ai": {
       "title": "AI Analysis",
@@ -2459,6 +2460,19 @@
       "optimizationRecommendations": "Optimization recommendations",
       "clickAnalyze": "Click \"Analyze Buildpack\" to get AI-powered insights",
       "analyzeHint": "AI will analyze the buildpack and suggest improvements"
+    },
+    "namespace": {
+      "deploymentIssues": "Deployment Issues",
+      "podIssues": "Pod Issues",
+      "deploymentsWithIssues": "Deployments with Issues",
+      "podsWithIssues": "Pods with Issues"
+    },
+    "events": {
+      "failedToLoad": "Failed to load events",
+      "noEventsFound": "No events found",
+      "totalEvents": "Total Events",
+      "noEventsFoundFor": "No events found for {{name}}",
+      "eventsExpiredHint": "Events may have expired or require authentication"
     }
   },
   "pagination": {
@@ -3601,12 +3615,12 @@
     "connectionLost": "Connection lost",
     "connectionLostHint": "Could not reach the backend — restart the server to reconnect",
     "copiedRestartCommand": "Copied — run this in your project root terminal",
-    "restarting": "Restarting\u2026",
-    "restartedWaiting": "Restarted, waiting for connection\u2026",
+    "restarting": "Restarting…",
+    "restartedWaiting": "Restarted, waiting for connection…",
     "restartBackendServer": "Restart the backend server",
     "restart": "Restart",
     "reconnected": "Reconnected",
-    "startingUp": "Starting up\u2026",
+    "startingUp": "Starting up…",
     "newVersionAvailable": "A new version is available",
     "reload": "Reload",
     "sidebar": {


### PR DESCRIPTION
Batch fix for 12 UI bugs found during QA sweep.

## Changes
- **#9516** — Make logo/title visually clickable with cursor-pointer
- **#9515** — Fix compliance header mislabel "Security Posture" → "Compliance"
- **#9528** — Fix move card popup: collision detection now prioritizes dashboard drop zones during normal card drags
- **#9529** — Fix compliance trestle stats to always show unfiltered totals regardless of active filter
- **#9530** — Add Ctrl/Cmd+Enter keyboard shortcut to run mission modal
- **#9532** — Show keyboard shortcut icon (⌘↵ / Ctrl↵) on submit buttons in mission and feedback modals
- **#9533** — Fix AgentStatusIndicator dropdown using stableStatus instead of raw agentStatus
- **#9534** — Remove non-functional "Apply Changes", "Compare with Git", "View in Editor" buttons from YAML drilldown
- **#9536** — Fix LogsDrillDown error state: `setError` was not destructured, so errors could never display
- **#9537** — Fix null safety crash in namespace drilldown when pod issue missing `issues` array
- **#9538** — Add loading overlay to YAML drilldown on refresh (backdrop blur over existing content)
- **#9539** — Fix i18n: translate hardcoded English text in Deployment, Cluster, Namespace, Events, ConfigMap, and Secret drilldowns

Closes #9515, #9516, #9528, #9529, #9530, #9532, #9533, #9534, #9536, #9537, #9538, #9539