### PR TITLE
🐛 fix distribution filter and kubescape modal cluster switching (#9531, #9541)

### DIFF
--- a/web/src/components/cards/ComplianceCards.tsx
+++ b/web/src/components/cards/ComplianceCards.tsx
@@ -715,6 +715,8 @@ Please proceed step by step.`,
           onClose={() => setModalCluster(null)}
           clusterName={modalCluster}
           status={statuses[modalCluster]}
+          clusters={Object.keys(statuses).filter(c => statuses[c].installed)}
+          onClusterChange={(newCluster) => setModalCluster(newCluster)}
           onRefresh={() => refetch()}
           isRefreshing={isRefreshing}
         />

--- a/web/src/components/cards/kubescape/KubescapeDetailModal.tsx
+++ b/web/src/components/cards/kubescape/KubescapeDetailModal.tsx
@@ -29,6 +29,10 @@ interface KubescapeDetailModalProps {
   onClose: () => void
   clusterName: string
   status: KubescapeClusterStatus
+  /** All cluster names available in the kubescape statuses */
+  clusters?: string[]
+  /** Callback to switch to a different cluster */
+  onClusterChange?: (cluster: string) => void
   onRefresh: () => void
   isRefreshing?: boolean
 }
@@ -38,6 +42,8 @@ export function KubescapeDetailModal({
   onClose,
   clusterName,
   status,
+  clusters,
+  onClusterChange,
   onRefresh,
   isRefreshing = false }: KubescapeDetailModalProps) {
   const [search, setSearch] = useState('')
@@ -75,11 +81,24 @@ export function KubescapeDetailModal({
           </StatusBadge>
         }
         extra={
-          <RefreshButton
-            isRefreshing={isRefreshing}
-            onRefresh={onRefresh}
-            size="sm"
-          />
+          <div className="flex items-center gap-2">
+            {clusters && clusters.length > 1 && onClusterChange && (
+              <select
+                value={clusterName}
+                onChange={(e) => onClusterChange(e.target.value)}
+                className="text-xs bg-secondary/50 border border-border rounded px-2 py-1 text-foreground focus:outline-none focus:ring-1 focus:ring-purple-500"
+              >
+                {clusters.map(c => (
+                  <option key={c} value={c}>{c}</option>
+                ))}
+              </select>
+            )}
+            <RefreshButton
+              isRefreshing={isRefreshing}
+              onRefresh={onRefresh}
+              size="sm"
+            />
+          </div>
         }
       />
 

--- a/web/src/components/clusters/Clusters.tsx
+++ b/web/src/components/clusters/Clusters.tsx
@@ -73,7 +73,9 @@ export function Clusters() {
     clusterGroups,
     addClusterGroup,
     deleteClusterGroup,
-    selectClusterGroup } = useGlobalFilters()
+    selectClusterGroup,
+    selectedDistributions,
+    isAllDistributionsSelected } = useGlobalFilters()
   const [searchParams, setSearchParams] = useSearchParams()
   const location = useLocation()
   const navigate = useNavigate()
@@ -216,6 +218,8 @@ export function Clusters() {
     globalSelectedClusters,
     isAllClustersSelected,
     customFilter,
+    selectedDistributions,
+    isAllDistributionsSelected,
     sortBy,
     sortAsc,
     customOrder })

--- a/web/src/components/clusters/useClusterFiltering.ts
+++ b/web/src/components/clusters/useClusterFiltering.ts
@@ -14,6 +14,10 @@ export interface ClusterFilteringParams {
   isAllClustersSelected: boolean
   /** Custom text filter from the global filter search */
   customFilter: string
+  /** Globally selected distributions from useGlobalFilters */
+  selectedDistributions: string[]
+  /** Whether all distributions are selected in the global filter */
+  isAllDistributionsSelected: boolean
   /** Sort field */
   sortBy: 'name' | 'nodes' | 'pods' | 'health' | 'provider' | 'custom'
   /** Sort ascending */
@@ -40,6 +44,8 @@ export function useClusterFiltering({
   globalSelectedClusters,
   isAllClustersSelected,
   customFilter,
+  selectedDistributions,
+  isAllDistributionsSelected,
   sortBy,
   sortAsc,
   customOrder }: ClusterFilteringParams): ClusterFilteringResult {
@@ -60,6 +66,19 @@ export function useClusterFiltering({
         c.server?.toLowerCase().includes(query) ||
         c.user?.toLowerCase().includes(query)
       )
+    }
+
+    // Apply distribution filter
+    if (!isAllDistributionsSelected) {
+      if (selectedDistributions.includes('__none__')) {
+        result = []
+      } else {
+        const distLower = selectedDistributions.map(d => d.toLowerCase())
+        result = result.filter(c => {
+          const clusterDist = (c.distribution || detectCloudProvider(c.name, c.server, c.namespaces, c.user) || 'unknown').toLowerCase()
+          return distLower.includes(clusterDist)
+        })
+      }
     }
 
     // Apply local health filter
@@ -115,7 +134,7 @@ export function useClusterFiltering({
     }
 
     return result
-  }, [clusters, filter, globalSelectedClusters, isAllClustersSelected, customFilter, sortBy, sortAsc, customOrder])
+  }, [clusters, filter, globalSelectedClusters, isAllClustersSelected, customFilter, selectedDistributions, isAllDistributionsSelected, sortBy, sortAsc, customOrder])
 
   // Base clusters after global filter (before local health filter)
   const globalFilteredClusters = (() => {
@@ -135,6 +154,19 @@ export function useClusterFiltering({
         c.server?.toLowerCase().includes(query) ||
         c.user?.toLowerCase().includes(query)
       )
+    }
+
+    // Apply distribution filter
+    if (!isAllDistributionsSelected) {
+      if (selectedDistributions.includes('__none__')) {
+        result = []
+      } else {
+        const distLower = selectedDistributions.map(d => d.toLowerCase())
+        result = result.filter(c => {
+          const clusterDist = (c.distribution || detectCloudProvider(c.name, c.server, c.namespaces, c.user) || 'unknown').toLowerCase()
+          return distLower.includes(clusterDist)
+        })
+      }
     }
 
     return result

--- a/web/src/components/layout/navbar/ClusterFilterPanel.tsx
+++ b/web/src/components/layout/navbar/ClusterFilterPanel.tsx
@@ -1,6 +1,6 @@
 import { useState, useRef, useEffect, ReactNode } from 'react'
 import { useTranslation } from 'react-i18next'
-import { Search, Server, Activity, Filter, Check, AlertTriangle, Save, X, Trash2, WifiOff } from 'lucide-react'
+import { Search, Server, Activity, Filter, Check, AlertTriangle, Save, X, Trash2, WifiOff, Globe } from 'lucide-react'
 import { AlertCircle, CheckCircle2 } from 'lucide-react'
 import { useGlobalFilters, SEVERITY_LEVELS, SEVERITY_CONFIG, STATUS_LEVELS, STATUS_CONFIG } from '../../../hooks/useGlobalFilters'
 import { useModalState } from '../../../lib/modals'
@@ -105,6 +105,12 @@ export function ClusterFilterPanel() {
     hasCustomFilter,
     isFiltered,
     clearAllFilters,
+    selectedDistributions,
+    toggleDistribution,
+    selectAllDistributions,
+    deselectAllDistributions,
+    isAllDistributionsSelected,
+    availableDistributions,
     savedFilterSets,
     saveCurrentFilters,
     applySavedFilterSet,
@@ -306,6 +312,46 @@ export function ClusterFilterPanel() {
               onSelectAll={selectAllStatuses}
               onDeselectAll={deselectAllStatuses}
             />
+
+            {/* Distribution Filter Section */}
+            {availableDistributions.length > 0 && (
+              <div className="p-3 border-b border-border">
+                <div className="flex items-center justify-between mb-2">
+                  <div className="flex items-center gap-2">
+                    <Globe className="w-4 h-4 text-blue-400" />
+                    <span className="text-sm font-medium text-foreground">{t('common:filters.distribution', 'Distribution')}</span>
+                  </div>
+                  <div className="flex gap-2">
+                    <button onClick={selectAllDistributions} className="text-xs text-purple-400 hover:text-purple-300">
+                      {t('common.all')}
+                    </button>
+                    <button onClick={deselectAllDistributions} className="text-xs text-muted-foreground hover:text-foreground">
+                      {t('common.none')}
+                    </button>
+                  </div>
+                </div>
+                <div className="flex flex-wrap gap-1.5">
+                  {availableDistributions.map((dist) => {
+                    const isSelected = isAllDistributionsSelected || selectedDistributions.includes(dist)
+                    return (
+                      <button
+                        key={dist}
+                        onClick={() => toggleDistribution(dist)}
+                        className={cn(
+                          'flex items-center gap-1.5 px-2 py-1 rounded text-xs font-medium transition-colors capitalize',
+                          isSelected
+                            ? 'bg-blue-500/20 text-blue-400'
+                            : 'bg-secondary/50 text-muted-foreground hover:text-foreground'
+                        )}
+                      >
+                        {isSelected && <Check className="w-3 h-3" />}
+                        {dist}
+                      </button>
+                    )
+                  })}
+                </div>
+              </div>
+            )}
 
             {/* Cluster Filter Section */}
             <div className="p-3 border-b border-border">

--- a/web/src/hooks/useGlobalFilters.tsx
+++ b/web/src/hooks/useGlobalFilters.tsx
@@ -3,6 +3,7 @@ import { createContext, useContext, useState, useEffect, useMemo, ReactNode } fr
 // (~254 KB). Only clusters.ts + shared.ts are needed here.
 import { useClusters } from './mcp/clusters'
 import type { ClusterInfo } from './mcp/types'
+import { detectCloudProvider } from '../components/ui/CloudProviderIcon'
 import { emitGlobalClusterFilterChanged, emitGlobalSeverityFilterChanged, emitGlobalStatusFilterChanged } from '../lib/analytics'
 
 // Severity levels
@@ -48,6 +49,7 @@ export interface SavedFilterSet {
   clusters: string[]      // empty = all clusters
   severities: string[]    // empty = all severities
   statuses: string[]      // empty = all statuses
+  distributions: string[] // empty = all distributions
   customText: string
 }
 
@@ -88,6 +90,15 @@ interface GlobalFiltersContextType {
   isAllStatusesSelected: boolean
   isStatusesFiltered: boolean
 
+  // Distribution filtering
+  selectedDistributions: string[]
+  toggleDistribution: (distribution: string) => void
+  selectAllDistributions: () => void
+  deselectAllDistributions: () => void
+  isAllDistributionsSelected: boolean
+  isDistributionsFiltered: boolean
+  availableDistributions: string[]
+
   // Custom text filter
   customFilter: string
   setCustomFilter: (filter: string) => void
@@ -118,6 +129,7 @@ const GlobalFiltersContext = createContext<GlobalFiltersContextType | null>(null
 const CLUSTER_STORAGE_KEY = 'globalFilter:clusters'
 const SEVERITY_STORAGE_KEY = 'globalFilter:severities'
 const STATUS_STORAGE_KEY = 'globalFilter:statuses'
+const DISTRIBUTION_STORAGE_KEY = 'globalFilter:distributions'
 const CUSTOM_FILTER_STORAGE_KEY = 'globalFilter:customText'
 const GROUPS_STORAGE_KEY = 'globalFilter:clusterGroups'
 const SAVED_FILTER_SETS_KEY = 'globalFilter:savedFilterSets'
@@ -219,6 +231,20 @@ export function GlobalFiltersProvider({ children }: { children: ReactNode }) {
     return [] // Empty means all statuses
   })
 
+  // Initialize distributions from localStorage or default to all
+  const [selectedDistributions, setSelectedDistributionsState] = useState<string[]>(() => {
+    try {
+      const stored = localStorage.getItem(DISTRIBUTION_STORAGE_KEY)
+      if (stored) {
+        const parsed = JSON.parse(stored)
+        return parsed === null ? [] : parsed
+      }
+    } catch {
+      // Ignore parse errors
+    }
+    return [] // Empty means all distributions
+  })
+
   // Initialize custom text filter from localStorage
   const [customFilter, setCustomFilterState] = useState<string>(() => {
     try {
@@ -266,6 +292,10 @@ export function GlobalFiltersProvider({ children }: { children: ReactNode }) {
   useEffect(() => {
     localStorage.setItem(STATUS_STORAGE_KEY, JSON.stringify(selectedStatuses.length === 0 ? null : selectedStatuses))
   }, [selectedStatuses])
+
+  useEffect(() => {
+    localStorage.setItem(DISTRIBUTION_STORAGE_KEY, JSON.stringify(selectedDistributions.length === 0 ? null : selectedDistributions))
+  }, [selectedDistributions])
 
   useEffect(() => {
     localStorage.setItem(CUSTOM_FILTER_STORAGE_KEY, customFilter)
@@ -444,6 +474,48 @@ export function GlobalFiltersProvider({ children }: { children: ReactNode }) {
   // Get effective selected statuses (for filtering)
   const effectiveSelectedStatuses = isAllStatusesSelected ? STATUS_LEVELS : selectedStatuses
 
+  // Distribution filtering — derives available distributions from clusters
+  const availableDistributions = useMemo(() => {
+    const distSet = new Set<string>()
+    for (const c of deduplicatedClusters) {
+      const dist = c.distribution || detectCloudProvider(c.name, c.server, c.namespaces, c.user) || 'unknown'
+      distSet.add(dist)
+    }
+    return Array.from(distSet).sort()
+  }, [deduplicatedClusters])
+
+  // Reconcile selected distributions against available ones
+  useEffect(() => {
+    if (selectedDistributions.length === 0 || availableDistributions.length === 0) return
+    const validSelections = selectedDistributions.filter(d => availableDistributions.includes(d))
+    if (validSelections.length !== selectedDistributions.length) {
+      setSelectedDistributionsState(validSelections.length === 0 ? [] : validSelections)
+    }
+  }, [availableDistributions, selectedDistributions])
+
+  const toggleDistribution = (distribution: string) => {
+    setSelectedDistributionsState(prev => {
+      if (prev.length === 0) {
+        // Currently "all" → switch to all except this one
+        return availableDistributions.filter(d => d !== distribution)
+      }
+      if (prev.includes(distribution)) {
+        const next = prev.filter(d => d !== distribution)
+        return next.length === 0 ? [] : next
+      } else {
+        const next = [...prev, distribution]
+        return next.length === availableDistributions.length ? [] : next
+      }
+    })
+  }
+
+  const selectAllDistributions = () => setSelectedDistributionsState([])
+  const deselectAllDistributions = () => setSelectedDistributionsState(['__none__'])
+
+  const isAllDistributionsSelected = selectedDistributions.length === 0
+  const isDistributionsFiltered = !isAllDistributionsSelected
+  const effectiveSelectedDistributions = isAllDistributionsSelected ? availableDistributions : selectedDistributions
+
   // Custom text filter
   const setCustomFilter = (filter: string) => {
     setCustomFilterState(filter)
@@ -456,12 +528,13 @@ export function GlobalFiltersProvider({ children }: { children: ReactNode }) {
   const hasCustomFilter = customFilter.trim().length > 0
 
   // Combined filter state
-  const isFiltered = isClustersFiltered || isSeveritiesFiltered || isStatusesFiltered || hasCustomFilter
+  const isFiltered = isClustersFiltered || isSeveritiesFiltered || isStatusesFiltered || isDistributionsFiltered || hasCustomFilter
 
   const clearAllFilters = () => {
     setSelectedClustersState([])
     setSelectedSeveritiesState([])
     setSelectedStatusesState([])
+    setSelectedDistributionsState([])
     setCustomFilterState('')
   }
 
@@ -475,6 +548,7 @@ export function GlobalFiltersProvider({ children }: { children: ReactNode }) {
       clusters: [...selectedClusters],
       severities: [...selectedSeverities],
       statuses: [...selectedStatuses],
+      distributions: [...selectedDistributions],
       customText: customFilter }
     setSavedFilterSets(prev => [...prev, newSet])
   }
@@ -485,6 +559,7 @@ export function GlobalFiltersProvider({ children }: { children: ReactNode }) {
     setSelectedClustersState(filterSet.clusters)
     setSelectedSeveritiesState(filterSet.severities as SeverityLevel[])
     setSelectedStatusesState(filterSet.statuses as StatusLevel[])
+    setSelectedDistributionsState(filterSet.distributions || [])
     setCustomFilterState(filterSet.customText)
   }
 
@@ -498,8 +573,9 @@ export function GlobalFiltersProvider({ children }: { children: ReactNode }) {
       const clustersMatch = JSON.stringify([...fs.clusters].sort()) === JSON.stringify([...selectedClusters].sort())
       const severitiesMatch = JSON.stringify([...fs.severities].sort()) === JSON.stringify([...selectedSeverities].sort())
       const statusesMatch = JSON.stringify([...fs.statuses].sort()) === JSON.stringify([...selectedStatuses].sort())
+      const distributionsMatch = JSON.stringify([...(fs.distributions || [])].sort()) === JSON.stringify([...selectedDistributions].sort())
       const textMatch = fs.customText === customFilter
-      if (clustersMatch && severitiesMatch && statusesMatch && textMatch) return fs.id
+      if (clustersMatch && severitiesMatch && statusesMatch && distributionsMatch && textMatch) return fs.id
     }
     return null
   })()
@@ -593,6 +669,15 @@ export function GlobalFiltersProvider({ children }: { children: ReactNode }) {
     isAllStatusesSelected,
     isStatusesFiltered,
 
+    // Distribution filtering
+    selectedDistributions: effectiveSelectedDistributions,
+    toggleDistribution,
+    selectAllDistributions,
+    deselectAllDistributions,
+    isAllDistributionsSelected,
+    isDistributionsFiltered,
+    availableDistributions,
+
     // Custom text filter
     customFilter,
     setCustomFilter,
@@ -644,6 +729,13 @@ export function GlobalFiltersProvider({ children }: { children: ReactNode }) {
     deselectAllStatuses,
     isAllStatusesSelected,
     isStatusesFiltered,
+    effectiveSelectedDistributions,
+    toggleDistribution,
+    selectAllDistributions,
+    deselectAllDistributions,
+    isAllDistributionsSelected,
+    isDistributionsFiltered,
+    availableDistributions,
     customFilter,
     setCustomFilter,
     clearCustomFilter,
@@ -709,6 +801,14 @@ const DEFAULT_GLOBAL_FILTERS: GlobalFiltersContextType = {
   deselectAllStatuses: () => {},
   isAllStatusesSelected: true,
   isStatusesFiltered: false,
+
+  selectedDistributions: [],
+  toggleDistribution: () => {},
+  selectAllDistributions: () => {},
+  deselectAllDistributions: () => {},
+  isAllDistributionsSelected: true,
+  isDistributionsFiltered: false,
+  availableDistributions: [],
 
   customFilter: '',
   setCustomFilter: () => {},


### PR DESCRIPTION
### Distribution/provider filter (#9541)
Adds a new **Distribution** filter to the global filter panel. When users select a distribution type (e.g., GKE, EKS, kind), only clusters matching that distribution appear in the cluster list.

**Changes:**
- `useGlobalFilters.tsx`: New distribution state, toggle/select/deselect functions, localStorage persistence
- `useClusterFiltering.ts`: Distribution filter applied in both main and global filter pipelines
- `ClusterFilterPanel.tsx`: New Distribution section with toggle buttons
- `Clusters.tsx`: Passes distribution params to useClusterFiltering

### Kubescape modal cluster switching (#9531)
Adds a cluster dropdown to the Kubescape detail modal so users can switch between clusters without closing and reopening.

**Changes:**
- `KubescapeDetailModal.tsx`: New `clusters` and `onClusterChange` props; `<select>` in modal header
- `ComplianceCards.tsx`: Passes cluster list and change handler to modal

Closes #9531
Closes #9541