### PR TITLE
🐛 fix unaddressed Copilot review findings from 50 merged PRs

### DIFF
--- a/pkg/agent/scrub.go
+++ b/pkg/agent/scrub.go
@@ -2,6 +2,7 @@ package agent
 
 import (
 	"fmt"
+	"html"
 	"regexp"
 	"strings"
 )
@@ -15,7 +16,7 @@ import (
 // 16 characters of base64 alphabet to avoid false positives on short strings.
 const scrubBase64MinLen = 16
 
-var scrubBase64SecretRe = regexp.MustCompile(`(?i)(data:\s*\n(?:\s+\w+:\s*))([A-Za-z0-9+/=]{` + "16" + `,})`)
+var scrubBase64SecretRe = regexp.MustCompile(`(?i)(data:\s*\n(?:\s+[\w.-]+:\s*))([A-Za-z0-9+/=]{` + "16" + `,})`)
 
 // scrubAnthropicKeyRe matches Anthropic API key patterns (sk-ant-...)
 var scrubAnthropicKeyRe = regexp.MustCompile(`sk-ant-[A-Za-z0-9_-]{20,}`)
@@ -71,8 +72,8 @@ func ScrubSecrets(input string) string {
 
 	// Scrub large standalone base64 blocks (likely encoded certs/keys)
 	result = scrubGenericBase64BlockRe.ReplaceAllStringFunc(result, func(match string) string {
-		// Only redact if it looks like pure base64 (not a URL or path)
-		if strings.Contains(match, "http") || strings.Contains(match, "/") {
+		// Only skip redaction for URLs (not bare / which is valid base64)
+		if strings.Contains(match, "http://") || strings.Contains(match, "https://") {
 			return match
 		}
 		return redactedPlaceholder
@@ -90,9 +91,10 @@ func WrapUntrustedData(source string, data string) string {
 	if data == "" {
 		return data
 	}
+	// Escape data to prevent prompt injection via closing tags
 	return fmt.Sprintf(
 		"<cluster-data source=%q trust=\"untrusted\">%s</cluster-data>",
-		source, data)
+		source, html.EscapeString(data))
 }
 
 // UntrustedDataSystemPrompt is a system prompt prefix that instructs the AI

--- a/pkg/agent/server.go
+++ b/pkg/agent/server.go
@@ -253,7 +253,7 @@ func NewServer(cfg Config) (*Server, error) {
 		agentToken = generated
 		slog.Info("KC_AGENT_TOKEN is not set — auto-generated a random token for this session")
 		// Print to stdout so the operator can copy-paste it into clients.
-		fmt.Printf("Auto-generated KC_AGENT_TOKEN: %s\n", agentToken) //nolint:forbidigo // intentional stdout for operator UX
+		fmt.Fprintf(os.Stderr, "Auto-generated KC_AGENT_TOKEN: %s\n", agentToken) //nolint:forbidigo // intentional stderr for operator UX
 	}
 
 	// Resolve per-session token quota from env, falling back to the compiled

--- a/pkg/agent/server_ai.go
+++ b/pkg/agent/server_ai.go
@@ -1548,9 +1548,9 @@ func (s *Server) isSessionQuotaExceeded() bool {
 	if s.sessionTokenQuota <= 0 {
 		return false // unlimited
 	}
-	s.tokenMux.RLock()
+	s.tokenMux.Lock()
 	total := s.sessionTokensIn + s.sessionTokensOut
-	s.tokenMux.RUnlock()
+	s.tokenMux.Unlock()
 	return total >= s.sessionTokenQuota
 }
 
@@ -1597,6 +1597,7 @@ func (s *Server) addTokenUsage(usage *ProviderTokenUsage) {
 	// otherwise create a new one. This coalesces rapid-fire token updates into
 	// a single disk write (#9483).
 	if s.tokenFlushTimer != nil {
+		s.tokenFlushTimer.Stop()
 		s.tokenFlushTimer.Reset(tokenUsageFlushInterval)
 	} else {
 		s.tokenFlushTimer = time.AfterFunc(tokenUsageFlushInterval, func() {

--- a/pkg/api/handlers/benchmarks.go
+++ b/pkg/api/handlers/benchmarks.go
@@ -413,18 +413,24 @@ func NewBenchmarkHandlers(apiKey, folderID string) *BenchmarkHandlers {
 // The lock is only held briefly to read/update timestamps; the actual
 // sleep (if needed) happens outside the lock so concurrent goroutines
 // are not blocked for the full delay.
-func (h *BenchmarkHandlers) throttle() {
+// The context is checked so that cancellation is not blocked by sleep.
+func (h *BenchmarkHandlers) throttle(ctx context.Context) error {
 	h.reqMu.Lock()
 	elapsed := time.Since(h.lastReq)
 	if elapsed >= driveRequestDelay {
 		h.lastReq = time.Now()
 		h.reqMu.Unlock()
-		return
+		return ctx.Err()
 	}
 	delay := driveRequestDelay - elapsed
 	h.lastReq = time.Now().Add(delay) // reserve a future slot
 	h.reqMu.Unlock()
-	time.Sleep(delay)
+	select {
+	case <-time.After(delay):
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
 }
 
 // driveGet performs a throttled HTTP GET with the proper User-Agent header.
@@ -433,7 +439,9 @@ func (h *BenchmarkHandlers) driveGet(ctx context.Context, url string) (*http.Res
 	if err := ctx.Err(); err != nil {
 		return nil, err
 	}
-	h.throttle()
+	if err := h.throttle(ctx); err != nil {
+		return nil, err
+	}
 	req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
 	if err != nil {
 		return nil, err
@@ -616,6 +624,10 @@ func (h *BenchmarkHandlers) StreamReports(c *fiber.Ctx) error {
 			return
 		}
 
+		// streamMu protects shared state (allReports, pendingBatch, counters, w)
+		// across concurrent goroutines, including the keepalive ticker.
+		var streamMu sync.Mutex
+
 		// Start keepalive ticker — send comment heartbeats every 5s
 		keepaliveDone := make(chan struct{})
 		go func() {
@@ -624,8 +636,10 @@ func (h *BenchmarkHandlers) StreamReports(c *fiber.Ctx) error {
 			for {
 				select {
 				case <-ticker.C:
+					streamMu.Lock()
 					fmt.Fprintf(w, ": keepalive\n\n")
 					safeFlush()
+					streamMu.Unlock()
 				case <-keepaliveDone:
 					return
 				case <-ctx.Done():
@@ -666,11 +680,11 @@ func (h *BenchmarkHandlers) StreamReports(c *fiber.Ctx) error {
 		fmt.Fprintf(w, "event: progress\ndata: {\"status\":\"fetching\",\"experiments\":%d,\"total\":0,\"skipped\":%d}\n\n", len(experiments), skippedFolders)
 		safeFlush()
 
-		// streamMu protects shared state (allReports, pendingBatch, counters)
-		// across concurrent goroutines.
-		var streamMu sync.Mutex
 		var streamWg sync.WaitGroup
 		streamSem := make(chan struct{}, driveFetchConcurrency)
+		// Separate semaphore for inner run goroutines to prevent deadlock when
+		// all outer slots are held while inner goroutines wait for the same pool.
+		innerSem := make(chan struct{}, driveFetchConcurrency)
 
 		for _, item := range experiments {
 			if ctx.Err() != nil {
@@ -717,14 +731,14 @@ func (h *BenchmarkHandlers) StreamReports(c *fiber.Ctx) error {
 					runItem := runItem // capture
 					innerWg.Add(1)
 					select {
-					case streamSem <- struct{}{}:
+					case innerSem <- struct{}{}:
 					case <-ctx.Done():
 						innerWg.Done()
 						continue
 					}
 					go func() {
 						defer innerWg.Done()
-						defer func() { <-streamSem }()
+						defer func() { <-innerSem }()
 
 						if ctx.Err() != nil {
 							return
@@ -752,9 +766,10 @@ func (h *BenchmarkHandlers) StreamReports(c *fiber.Ctx) error {
 						if len(pendingBatch) > 0 {
 							flushBatch()
 						}
+						sentSnapshot := totalSent
 						streamMu.Unlock()
 						if len(reports) > 0 {
-							slog.Info("[benchmarks] streamed reports", "count", len(reports), "experiment", item.Name, "run", runItem.Name, "totalSent", totalSent)
+							slog.Info("[benchmarks] streamed reports", "count", len(reports), "experiment", item.Name, "run", runItem.Name, "totalSent", sentSnapshot)
 						}
 					}()
 				}
@@ -818,17 +833,13 @@ func (h *BenchmarkHandlers) fetchAllReports(ctx context.Context, cutoff time.Tim
 		experiments = append(experiments, item)
 	}
 
-	type runResult struct {
-		reports  []BenchmarkReport
-		failures int
-	}
-
 	var (
 		mu             sync.Mutex
 		allReports     []BenchmarkReport
 		totalFailures  int
 		wg             sync.WaitGroup
 		sem            = make(chan struct{}, driveFetchConcurrency)
+		innerSem       = make(chan struct{}, driveFetchConcurrency)
 	)
 
 	for _, item := range experiments {
@@ -856,10 +867,10 @@ func (h *BenchmarkHandlers) fetchAllReports(ctx context.Context, cutoff time.Tim
 				}
 				runItem := runItem // capture
 				innerWg.Add(1)
-				sem <- struct{}{} // share the same semaphore
+				innerSem <- struct{}{} // separate semaphore for inner work
 				go func() {
 					defer innerWg.Done()
-					defer func() { <-sem }()
+					defer func() { <-innerSem }()
 
 					reports, failures, runErr := h.fetchRunFolder(ctx, runItem.ID, item.Name, runItem.Name)
 					if runErr != nil {

--- a/pkg/api/handlers/rewards.go
+++ b/pkg/api/handlers/rewards.go
@@ -19,10 +19,11 @@ import (
 
 // Point values for GitHub contributions
 const (
-	rewardsCacheTTL   = 10 * time.Minute
-	rewardsAPITimeout = 30 * time.Second
-	rewardsPerPage    = 100 // GitHub max per page
-	rewardsMaxPages   = 100 // REST Issues API supports up to 10,000 per repo
+	rewardsCacheTTL          = 10 * time.Minute
+	rewardsAPITimeout        = 30 * time.Second
+	rewardsPerPage           = 100 // GitHub max per page
+	rewardsMaxPages          = 100 // REST Issues API supports up to 10,000 per repo
+	maxRewardsResponseBytes  = 10 * 1024 * 1024 // 10 MiB cap on GitHub API responses
 )
 
 // RewardsConfig holds configuration for the rewards handler.
@@ -279,7 +280,7 @@ func (h *RewardsHandler) listRepoItems(repo, login, sinceISO, token string) ([]s
 			return allItems, fmt.Errorf("execute request: %w", err)
 		}
 
-		body, err := io.ReadAll(resp.Body)
+		body, err := io.ReadAll(io.LimitReader(resp.Body, maxRewardsResponseBytes))
 		resp.Body.Close()
 
 		if err != nil {

--- a/web/src/components/acmm/useACMMStats.ts
+++ b/web/src/components/acmm/useACMMStats.ts
@@ -26,9 +26,10 @@ export function useACMMStats() {
   const { scan } = useACMM()
   const { level, data } = scan
   const detectedIds = data.detectedIds
+  const detectedSet = detectedIds instanceof Set ? detectedIds : new Set(detectedIds as string[] || [])
 
   const totalCriteria = ALL_CRITERIA.length
-  const detectedCount = detectedIds instanceof Set ? detectedIds.size : (detectedIds as string[] || []).length // ai-quality-ignore
+  const detectedCount = detectedSet.size
 
   const nextLevel = level.level < MAX_LEVEL ? level.level + 1 : null
   const nextRequired = nextLevel ? level.requiredByLevel[nextLevel] ?? 0 : 0
@@ -62,9 +63,7 @@ export function useACMMStats() {
       case 'acmm_by_source': {
         const segments = SOURCE_IDS.map((sid) => {
           const srcCriteria = ALL_CRITERIA.filter((c) => c.source === sid)
-          const srcDetected = srcCriteria.filter((c) =>
-            detectedIds instanceof Set ? detectedIds.has(c.id) : (detectedIds as string[] || []).includes(c.id), // ai-quality-ignore
-          ).length
+          const srcDetected = srcCriteria.filter((c) => detectedSet.has(c.id)).length
           return {
             label: SOURCE_NAMES[sid],
             value: srcCriteria.length > 0 ? Math.round((srcDetected / srcCriteria.length) * 100) : 0, // ai-quality-ignore

--- a/web/src/components/layout/navbar/AgentStatusIndicator.tsx
+++ b/web/src/components/layout/navbar/AgentStatusIndicator.tsx
@@ -330,7 +330,7 @@ export function AgentStatusIndicator() {
       {showAgentStatus && (
         <div
           ref={dropdownRef}
-          className="absolute top-full right-0 mt-2 w-96 bg-card border border-border rounded-lg shadow-xl z-50"
+          className="absolute top-full right-0 mt-2 w-96 bg-card border border-border rounded-lg shadow-xl z-dropdown"
         >
           {/* Demo Mode Toggle */}
           <div className="p-3 border-b border-border">

--- a/web/src/components/layout/navbar/ClusterFilterPanel.tsx
+++ b/web/src/components/layout/navbar/ClusterFilterPanel.tsx
@@ -190,7 +190,7 @@ export function ClusterFilterPanel() {
 
         {/* Filter dropdown */}
         {showDropdown && (
-          <div className="absolute top-full right-0 mt-2 w-80 bg-card border border-border rounded-lg shadow-xl z-50 max-h-[80vh] overflow-y-auto">
+          <div className="absolute top-full right-0 mt-2 w-80 bg-card border border-border rounded-lg shadow-xl z-dropdown max-h-[80vh] overflow-y-auto">
 
             {/* Clear All — shown at top when filters are active */}
             {isFiltered && (

--- a/web/src/components/layout/navbar/TokenUsageWidget.tsx
+++ b/web/src/components/layout/navbar/TokenUsageWidget.tsx
@@ -88,7 +88,7 @@ export function TokenUsageWidget() {
 
       {/* Token details dropdown */}
       {showTokenDetails && (
-        <div className="absolute top-full right-0 mt-2 w-64 bg-card border border-border rounded-lg shadow-xl p-4 z-50">
+        <div className="absolute top-full right-0 mt-2 w-64 bg-card border border-border rounded-lg shadow-xl p-4 z-dropdown">
           <div className="flex items-center justify-between mb-3">
             <h4 className="text-sm font-medium text-foreground">{t('layout.navbar.tokenUsage')}</h4>
             {isDemoData && (

--- a/web/src/components/mission-control/MissionControlDialog.tsx
+++ b/web/src/components/mission-control/MissionControlDialog.tsx
@@ -352,7 +352,7 @@ export function MissionControlDialog({ open, onClose, initialKubaraChart, review
                   // Next button being enabled). Without this, highestReached clamps
                   // the index to 0 on first pass, blocking a11y keyboard navigation.
                   const upperBound = (delta > 0 && canAdvance)
-                    ? highestReached + 1
+                    ? Math.min(highestReached + 1, PHASE_STEPS.length - 1)
                     : highestReached
                   const nextIdx = Math.max(0, Math.min(upperBound, currentStepIndex + delta))
                   if (nextIdx !== currentStepIndex) {

--- a/web/src/components/mission-control/useMissionControl.ts
+++ b/web/src/components/mission-control/useMissionControl.ts
@@ -855,17 +855,18 @@ export function useMissionControl() {
   useEffect(() => {
     if (!state.aiStreaming) return
     const timer = setTimeout(() => {
+      // #9496 — Cancel the backend mission to stop the stream. Use the ref
+      // for the latest planningMissionId to avoid a stale closure.
+      // Perform side effects outside setState to avoid replayed updaters.
+      const missionId = planningMissionIdRef.current
+      if (missionId) {
+        try { dismissMission(missionId) } catch { /* ignore */ }
+      }
       setState((prev) => {
         if (!prev.aiStreaming) return prev
         aiRequestInFlightRef.current = false // #6827
         // #9496 — Mark as timed out so the parse effect ignores late arrivals
         aiTimedOutRef.current = true
-        // #9496 — Cancel the backend mission to stop the stream. Use the ref
-        // for the latest planningMissionId to avoid a stale closure.
-        const missionId = planningMissionIdRef.current
-        if (missionId) {
-          try { dismissMission(missionId) } catch { /* ignore */ }
-        }
         return { ...prev, aiStreaming: false }
       })
     }, AI_SUGGEST_TIMEOUT_MS)

--- a/web/src/hooks/usePersistence.ts
+++ b/web/src/hooks/usePersistence.ts
@@ -192,7 +192,7 @@ export function usePersistence() {
 
     setSyncing(true)
     try {
-      const response = await fetch('/api/persistence/sync', { method: 'POST', headers: { 'X-Requested-With': 'XMLHttpRequest' }, signal: AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS) })
+      const response = await fetch('/api/persistence/sync', { method: 'POST', headers: { 'X-Requested-With': 'XMLHttpRequest' }, credentials: 'include', signal: AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS) })
       if (response.ok) {
         await fetchStatus()
         return true

--- a/web/src/hooks/useVersionCheck.tsx
+++ b/web/src/hooks/useVersionCheck.tsx
@@ -488,6 +488,10 @@ function useVersionCheckCore() {
     setChannelState(newChannel)
     localStorage.setItem(UPDATE_STORAGE_KEYS.CHANNEL, newChannel)
 
+    // Mark channel as changed before the async sync so that the effect
+    // triggered by setChannelState sees the flag immediately.
+    channelChangedRef.current = true
+
     // Sync to kc-agent
     try {
       await fetch(`${LOCAL_AGENT_HTTP_URL}/auto-update/config`, {
@@ -498,9 +502,6 @@ function useVersionCheckCore() {
     } catch {
       // Agent not available, local state is still saved
     }
-
-    // Trigger a fresh check for the new channel so the UI updates immediately
-    channelChangedRef.current = true
   }, [autoUpdateEnabled])
 
   /**
@@ -892,6 +893,8 @@ function useVersionCheckCore() {
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [channel])
 
+  const clearLastCheckResult = useCallback(() => setLastCheckResult(null), [])
+
   return {
     // State
     currentVersion,
@@ -927,7 +930,7 @@ function useVersionCheckCore() {
     triggerUpdate,
     cancelUpdate,
     setUpdateProgress,
-    clearLastCheckResult: () => setLastCheckResult(null) }
+    clearLastCheckResult }
 }
 
 // ---------------------------------------------------------------------------

--- a/web/src/lib/kubara.ts
+++ b/web/src/lib/kubara.ts
@@ -60,23 +60,26 @@ let cachedCatalogTimestamp = 0
 // Resolved once from /api/kubara/config; falls back to defaults if unreachable
 let resolvedRepo = KUBARA_DEFAULT_REPO
 let resolvedPath = KUBARA_DEFAULT_PATH
-let configFetched = false
+let configPromise: Promise<void> | null = null
 
 async function ensureConfig(): Promise<void> {
-  if (configFetched) return
-  configFetched = true
-  try {
-    const res = await fetch('/api/kubara/config', {
-      signal: AbortSignal.timeout(KUBARA_CATALOG_FETCH_TIMEOUT_MS),
-    })
-    if (res.ok) {
-      const cfg = (await res.json()) as { repo?: string; path?: string }
-      if (cfg.repo) resolvedRepo = cfg.repo
-      if (cfg.path) resolvedPath = cfg.path
+  if (configPromise) return configPromise
+  configPromise = (async () => {
+    try {
+      const res = await fetch('/api/kubara/config', {
+        signal: AbortSignal.timeout(KUBARA_CATALOG_FETCH_TIMEOUT_MS),
+      })
+      if (res.ok) {
+        const cfg = (await res.json()) as { repo?: string; path?: string }
+        if (cfg.repo) resolvedRepo = cfg.repo
+        if (cfg.path) resolvedPath = cfg.path
+      }
+    } catch {
+      // Backend unreachable — allow retry on next call
+      configPromise = null
     }
-  } catch {
-    // Backend unreachable — stick with defaults
-  }
+  })()
+  return configPromise
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Audited all 50 PRs merged in the last 48 hours. Found **146 Copilot inline review comments** across 44 PRs — none had replies or follow-up. After verifying each against current `main`, **21 still-present issues** are fixed in this PR.

### Go backend — concurrency & security (12 fixes)

| Fix | File | Severity | Issue |
|-----|------|----------|-------|
| Protect keepalive writes with streamMu | `benchmarks.go` | 🔴 Critical | Data race — `bufio.Writer` concurrent access |
| Separate inner/outer semaphores | `benchmarks.go` | 🔴 Critical | Deadlock — nested semaphore acquisition |
| Read totalSent under lock | `benchmarks.go` | 🟠 High | Data race on shared counter |
| Make throttle() context-aware | `benchmarks.go` | 🟡 Medium | Cancellation blocked by `time.Sleep` |
| Remove unused runResult type | `benchmarks.go` | 🟡 Medium | Dead code in non-streaming path |
| Escape data in WrapUntrustedData | `scrub.go` | 🔴 Critical | Prompt injection via closing XML tags |
| Fix base64 `/` exclusion | `scrub.go` | 🟠 High | Secret leak — valid base64 never redacted |
| Match dotted Secret keys | `scrub.go` | 🟠 High | `tls.crt`, `ca.crt` keys never scrubbed |
| Print token to stderr | `server.go` | 🟠 High | Credential leak via captured stdout |
| Stop timer before Reset | `server_ai.go` | 🟡 Medium | Timer race in debounced flush |
| Write-lock in quota check | `server_ai.go` | 🟠 High | Concurrent prompts overshoot quota |
| Cap GitHub API reads | `rewards.go` | 🟡 Medium | Unbounded `io.ReadAll` → OOM risk |

### Frontend — state & UX (9 fixes)

| Fix | File | Severity | Issue |
|-----|------|----------|-------|
| Clamp upperBound to array length | `MissionControlDialog.tsx` | 🔴 Critical | Out-of-bounds crash on ArrowRight |
| Promise-based config dedup | `kubara.ts` | 🔴 Critical | Race — concurrent callers get defaults |
| Move side effect outside setState | `useMissionControl.ts` | 🟠 High | Replayed updater → duplicate cancellation |
| Add credentials to sync fetch | `usePersistence.ts` | 🟠 High | 401 on admin-only endpoint |
| Wrap clearLastCheckResult in useCallback | `useVersionCheck.tsx` | 🟡 Medium | Unstable reference resets timers |
| Set channelChangedRef before await | `useVersionCheck.tsx` | 🟡 Medium | Effect misses flag due to timing |
| Convert detectedIds to Set | `useACMMStats.ts` | 🟡 Medium | O(n²) → O(n) membership checks |
| Use z-dropdown token for navbar panels | 3 navbar files | 🟡 Medium | Consistent semantic z-index layering |

### Methodology
1. Searched all 50 merged PRs for `copilot-pull-request-reviewer[bot]` / `Copilot` inline comments
2. Categorized 146 comments by type (bug/race/security, test request, style)
3. Verified each against current `main` using 3 parallel analysis agents
4. Applied rubber-duck critique to the fix plan before implementing
5. All Go tests pass, TypeScript type-checks clean, no new lint issues