### PR TITLE
🐛 fix kagenti provider unable to retrieve cluster list (#9535)

### DIFF
--- a/web/src/hooks/mcp/__tests__/shared-cache-fetch.test.ts
+++ b/web/src/hooks/mcp/__tests__/shared-cache-fetch.test.ts
@@ -86,7 +86,6 @@ import {
   GPU_POLL_INTERVAL_MS,
   CACHE_TTL_MS,
   MIN_REFRESH_INDICATOR_MS,
-  LOCAL_AGENT_URL,
   // Pure functions
   getEffectiveInterval,
   shareMetricsBetweenSameServerClusters,
@@ -527,12 +526,25 @@ describe('fullFetchClusters', () => {
 
     await fullFetchClusters()
 
-    // LOCAL_AGENT_URL is re-exported from shared.ts as LOCAL_AGENT_HTTP_URL —
-    // using it here keeps the assertion tracking the kc-agent migration
-    // (phase 4.5b, #7993 / #8173) instead of re-hardcoding the REST path.
-    expect(mockApiGet).toHaveBeenCalledWith(`${LOCAL_AGENT_URL}/clusters`)
+    // The backend API fallback now uses the same-origin /api/mcp/clusters endpoint
+    // which works regardless of agent backend (kc-agent, kagenti, kagent). (#9535)
+    expect(mockApiGet).toHaveBeenCalledWith('/api/mcp/clusters')
     expect(clusterCache.isLoading).toBe(false)
     expect(clusterCache.clusters.some(c => c.name === 'backend-cluster')).toBe(true)
+  })
+
+  it('routes cluster fetch through backend API when kagenti backend is preferred (#9535)', async () => {
+    localStorage.setItem('kc_agent_backend_preference', 'kagenti')
+    const KAGENTI_CLUSTERS = [makeCluster({ name: 'kagenti-cluster' })]
+    mockApiGet.mockResolvedValue({ data: { clusters: KAGENTI_CLUSTERS } })
+    // globalThis.fetch should NOT be called — kagenti path uses api.get
+    globalThis.fetch = vi.fn().mockRejectedValue(new Error('should not be called'))
+
+    await fullFetchClusters()
+
+    expect(mockApiGet).toHaveBeenCalledWith('/api/mcp/clusters')
+    expect(clusterCache.isLoading).toBe(false)
+    expect(clusterCache.clusters.some(c => c.name === 'kagenti-cluster')).toBe(true)
   })
 
   it('skips backend when no auth token', async () => {

--- a/web/src/hooks/mcp/shared.ts
+++ b/web/src/hooks/mcp/shared.ts
@@ -965,6 +965,36 @@ if (import.meta.hot) {
   })
 }
 
+/** Storage key used by useKagentBackend to persist the preferred backend. */
+const BACKEND_PREF_KEY = 'kc_agent_backend_preference'
+
+/** Read the preferred agent backend from localStorage (non-React). */
+function getPreferredBackend(): string {
+  try {
+    return localStorage.getItem(BACKEND_PREF_KEY) || 'kc-agent'
+  } catch {
+    return 'kc-agent'
+  }
+}
+
+/**
+ * Fetch cluster list from the backend API (/api/mcp/clusters).
+ * This endpoint works independently of kc-agent — it uses the MCP bridge or
+ * direct k8s client, making it the right choice when kagenti/kagent is active. (#9535)
+ */
+async function fetchClusterListFromBackendAPI(): Promise<ClusterInfo[] | null> {
+  try {
+    const { data } = await api.get<{ clusters: ClusterInfo[] }>('/api/mcp/clusters')
+    if (data?.clusters) {
+      reportAgentDataSuccess()
+      return data.clusters
+    }
+  } catch {
+    // Backend API unavailable
+  }
+  return null
+}
+
 // Fetch basic cluster list from local agent (fast, no health check)
 async function fetchClusterListFromAgent(): Promise<ClusterInfo[] | null> {
   // On Netlify deployments (isNetlifyDeployment), skip agent entirely — there is
@@ -972,6 +1002,14 @@ async function fetchClusterListFromAgent(): Promise<ClusterInfo[] | null> {
   // On localhost, always attempt to reach the agent — it may be running even if
   // AgentManager has not detected it yet.
   if (isNetlifyDeployment) return null
+
+  // When kagenti or kagent is the preferred backend, fetch clusters from the
+  // backend API (/api/mcp/clusters) which works independently of kc-agent.
+  // kc-agent's /clusters endpoint is only available when kc-agent is running. (#9535)
+  const preferred = getPreferredBackend()
+  if (preferred === 'kagenti' || preferred === 'kagent') {
+    return fetchClusterListFromBackendAPI()
+  }
 
   try {
     const controller = new AbortController()
@@ -1598,8 +1636,8 @@ export async function fullFetchClusters() {
       return
     }
 
-    // Fall back to backend API
-    const { data } = await api.get<{ clusters: ClusterInfo[] }>(`${LOCAL_AGENT_HTTP_URL}/clusters`)
+    // Fall back to backend API (/api/mcp/clusters works regardless of agent backend)
+    const { data } = await api.get<{ clusters: ClusterInfo[] }>('/api/mcp/clusters')
     // Merge new cluster list with existing cached data (preserve distribution, health, etc.)
     const existingClusters = clusterCache.clusters
     const mergedClusters = (data.clusters || []).map(newCluster => {


### PR DESCRIPTION
When kagenti is selected as the active agent backend, the cluster list fetch fails because `fetchClusterListFromAgent()` is hardcoded to hit kc-agent at `http://127.0.0.1:8585/clusters` — an endpoint that does not exist on kagenti-provider. The console falls back to demo data instead of querying the available backend.

## Changes

- **Route cluster fetch to backend API when kagenti/kagent is preferred**: `fetchClusterListFromAgent()` now checks `localStorage` for the preferred backend and uses `/api/mcp/clusters` (which works via MCP bridge or direct k8s client) instead of the kc-agent endpoint.
- **Fix fallback URL**: `fullFetchClusters()` fallback changed from `${LOCAL_AGENT_HTTP_URL}/clusters` (kc-agent) to `/api/mcp/clusters` (same-origin backend), making it work regardless of agent backend.
- **Test coverage**: Added test for kagenti cluster fetch path; updated existing test assertion for new URL.

## How it works

| Backend preference | Primary path | Fallback |
|---|---|---|
| `kc-agent` | `http://127.0.0.1:8585/clusters` (kc-agent) | `/api/mcp/clusters` (backend API) |
| `kagenti` / `kagent` | `/api/mcp/clusters` (backend API) | demo data |

Closes #9535