### PR TITLE
✨ harden Netlify ACMM badge caching

### DIFF
--- a/web/netlify/functions/__tests__/acmm-badge.test.ts
+++ b/web/netlify/functions/__tests__/acmm-badge.test.ts
@@ -1,0 +1,225 @@
+/**
+ * Unit tests for the ACMM badge Netlify function.
+ *
+ * Mocks Netlify Blobs and global fetch so we can exercise every code path
+ * without network access.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// ── Mock @netlify/blobs ─────────────────────────────────────────────────
+const mockGet = vi.fn();
+const mockSetJSON = vi.fn();
+vi.mock("@netlify/blobs", () => ({
+  getStore: () => ({ get: mockGet, setJSON: mockSetJSON }),
+}));
+
+// ── Mock the shared ACMM module ─────────────────────────────────────────
+vi.mock("../../../src/lib/acmm/scannableIdsByLevel", () => ({
+  SCANNABLE_IDS_BY_LEVEL: {
+    2: ["acmm:agent-instructions", "acmm:claude-md"],
+    3: ["acmm:ci-matrix"],
+    4: ["acmm:security-ai-md"],
+    5: ["acmm:policy-as-code"],
+    6: ["acmm:merge-queue"],
+  },
+  AGENT_INSTRUCTION_FILE_IDS: new Set(["acmm:claude-md"]),
+}));
+
+// Import the handler after mocks are set up
+import handler from "../acmm-badge.mts";
+
+// ── Helpers ─────────────────────────────────────────────────────────────
+function makeRequest(repo: string, extra?: { origin?: string; force?: boolean }): Request {
+  const params = new URLSearchParams();
+  if (repo) params.set("repo", repo);
+  if (extra?.force) params.set("force", "true");
+  const url = `https://console.kubestellar.io/api/acmm/badge?${params}`;
+  return new Request(url, {
+    headers: extra?.origin ? { Origin: extra.origin } : {},
+  });
+}
+
+async function json(res: Response) {
+  return res.json();
+}
+
+function freshBlobEntry(detectedIds: string[] = ["acmm:claude-md", "acmm:ci-matrix"]) {
+  return {
+    scannedAt: new Date().toISOString(),
+    detectedIds,
+  };
+}
+
+function staleBlobEntry(detectedIds: string[] = ["acmm:claude-md"]) {
+  return {
+    scannedAt: new Date(Date.now() - 2 * 60 * 60 * 1000).toISOString(), // 2 hours ago
+    detectedIds,
+  };
+}
+
+// ── Tests ───────────────────────────────────────────────────────────────
+describe("acmm-badge", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    mockGet.mockReset();
+    mockSetJSON.mockReset();
+    // Default: no blob data, all fetches fail
+    mockGet.mockResolvedValue(null);
+    mockSetJSON.mockResolvedValue(undefined);
+    vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new Error("network")));
+  });
+
+  // 1. Happy path — returns valid shields.io JSON
+  it("returns valid shields.io JSON with schemaVersion, label, message, color", async () => {
+    mockGet.mockResolvedValue(freshBlobEntry(["acmm:claude-md", "acmm:ci-matrix"]));
+
+    const res = await handler(makeRequest("owner/repo"));
+    expect(res.status).toBe(200);
+
+    const body = await json(res);
+    expect(body).toMatchObject({
+      schemaVersion: 1,
+      label: "ACMM",
+      color: expect.any(String),
+      namedLogo: "github",
+    });
+    expect(body.message).toMatch(/^L\d+ · .+ · \d+\/\d+$/);
+  });
+
+  // 2. Blobs cache hit — returns cached badge without calling scan endpoint
+  it("returns cached badge from Blobs without calling scan endpoint", async () => {
+    mockGet.mockResolvedValue(freshBlobEntry());
+    const fetchSpy = vi.fn();
+    vi.stubGlobal("fetch", fetchSpy);
+
+    const res = await handler(makeRequest("owner/repo"));
+    expect(res.status).toBe(200);
+    // fetch should never have been called — Blobs were fresh
+    expect(fetchSpy).not.toHaveBeenCalled();
+
+    const body = await json(res);
+    expect(body.schemaVersion).toBe(1);
+  });
+
+  // 3. Blobs miss + scan success — calls scan, returns badge, stores in Blobs
+  it("calls scan endpoint on Blobs miss and stores result", async () => {
+    mockGet.mockResolvedValue(null);
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ detectedIds: ["acmm:claude-md"] }),
+      }),
+    );
+
+    const res = await handler(makeRequest("owner/repo"));
+    expect(res.status).toBe(200);
+
+    const body = await json(res);
+    expect(body.label).toBe("ACMM");
+    expect(body.message).toContain("L");
+
+    // Should have written to Blobs
+    // Give the fire-and-forget writeBlobCache a tick to execute
+    await new Promise((r) => setTimeout(r, 10));
+    expect(mockSetJSON).toHaveBeenCalled();
+  });
+
+  // 4. Blobs miss + scan fail + direct GitHub success — fallback path works
+  it("falls back to direct GitHub when scan endpoint fails", async () => {
+    mockGet.mockResolvedValue(null);
+    const fetchMock = vi
+      .fn()
+      // scan endpoint fails
+      .mockRejectedValueOnce(new Error("scan timeout"))
+      // direct GitHub: repo info
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ default_branch: "main" }),
+      })
+      // direct GitHub: tree
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          tree: [
+            { path: "CLAUDE.md" },
+            { path: ".github/workflows/ci.yml" },
+          ],
+        }),
+      });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const res = await handler(makeRequest("owner/repo"));
+    expect(res.status).toBe(200);
+
+    const body = await json(res);
+    expect(body.label).toBe("ACMM");
+    expect(body.message).toContain("L");
+    // Should have attempted all three fetch calls
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+  });
+
+  // 5. All paths fail — returns "unavailable" badge with status 200
+  it("returns 'unavailable' badge with status 200 when all paths fail", async () => {
+    mockGet.mockResolvedValue(null);
+    vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new Error("network")));
+
+    const res = await handler(makeRequest("owner/repo"));
+    expect(res.status).toBe(200);
+
+    const body = await json(res);
+    expect(body).toMatchObject({
+      schemaVersion: 1,
+      label: "ACMM",
+      message: "unavailable",
+      color: "lightgrey",
+    });
+  });
+
+  // 6. cacheSeconds value — 900 in success response, 300 in error
+  it("uses cacheSeconds=900 for success and 300 for errors", async () => {
+    // Success path
+    mockGet.mockResolvedValue(freshBlobEntry());
+    const successRes = await handler(makeRequest("owner/repo"));
+    const successBody = await json(successRes);
+    expect(successBody.cacheSeconds).toBe(900);
+
+    // Error path (all fail → unavailable)
+    mockGet.mockResolvedValue(null);
+    vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new Error("network")));
+    const errorRes = await handler(makeRequest("other/repo"));
+    const errorBody = await json(errorRes);
+    expect(errorBody.cacheSeconds).toBe(300);
+  });
+
+  // 7. CORS headers — Access-Control-Allow-Origin: * present
+  it("includes CORS Access-Control-Allow-Origin header", async () => {
+    mockGet.mockResolvedValue(freshBlobEntry());
+    const res = await handler(makeRequest("owner/repo"));
+    expect(res.headers.get("Access-Control-Allow-Origin")).toBe("*");
+
+    // Also check with a kubestellar origin
+    const res2 = await handler(
+      makeRequest("owner/repo", { origin: "https://console.kubestellar.io" }),
+    );
+    expect(res2.headers.get("Access-Control-Allow-Origin")).toBe(
+      "https://console.kubestellar.io",
+    );
+  });
+
+  // 8. Invalid repo — returns "invalid repo" badge (not HTTP error)
+  it("returns 'invalid repo' badge for malformed repo param", async () => {
+    const res = await handler(makeRequest("not a valid repo!!!"));
+    expect(res.status).toBe(200);
+
+    const body = await json(res);
+    expect(body).toMatchObject({
+      schemaVersion: 1,
+      label: "ACMM",
+      message: "invalid repo",
+      color: "red",
+      cacheSeconds: 300,
+    });
+    expect(res.headers.get("Access-Control-Allow-Origin")).toBe("*");
+  });
+});

--- a/web/netlify/functions/acmm-badge.mts
+++ b/web/netlify/functions/acmm-badge.mts
@@ -26,21 +26,21 @@ const LEVEL_COMPLETION_THRESHOLD = 0.7;
 const MAX_LEVEL = 6;
 /**
  * Badge cache window for successful responses. ACMM level changes slowly
- * (file-tree shape, not commit activity), so 5 min is plenty. This is shared
+ * (file-tree shape, not commit activity), so 15 min is plenty. This is shared
  * across three layers:
  *   1. shields.io respects this in its `cacheSeconds` JSON field below
  *   2. our CDN respects this in the `Cache-Control` header below
  *   3. GitHub's camo image proxy fetches the badge SVG and caches it itself
- * Kept at 5 min (was 1 h) so a transient Netlify outage doesn't lock the
- * badge into "inaccessible" for an hour (#4086).
+ * Combined with stale-while-revalidate=86400 to eliminate "inaccessible"
+ * badges during transient outages.
  */
-const BADGE_CACHE_SECONDS = 300;
+const BADGE_CACHE_SECONDS = 900;
 
 /**
- * Short cache for error/unavailable responses so shields.io retries quickly
- * after a transient failure instead of caching "inaccessible" for 5 min.
+ * Error cache window. Set to 5 min so shields.io doesn't retry too
+ * aggressively but also doesn't lock "unavailable" for ages.
  */
-const BADGE_ERROR_CACHE_SECONDS = 60;
+const BADGE_ERROR_CACHE_SECONDS = 300;
 
 /**
  * ACMM_IDS_BY_LEVEL and AGENT_INSTRUCTION_FILE_IDS are now imported from
@@ -74,14 +74,13 @@ const LEVEL_NAMES: Record<number, string> = {
 
 const ALLOWED_ORIGIN_RE = /^https?:\/\/(.*\.kubestellar\.io|localhost(:\d+)?)$/;
 
-function corsHeaders(origin: string | null): Record<string, string> {
+function corsHeaders(origin: string | null, cacheSeconds = BADGE_CACHE_SECONDS): Record<string, string> {
   const headers: Record<string, string> = {
-    "Cache-Control": `public, max-age=${BADGE_CACHE_SECONDS}`,
+    "Cache-Control": `public, max-age=${cacheSeconds}, stale-while-revalidate=86400`,
+    "Access-Control-Allow-Origin": "*",
   };
   if (origin && ALLOWED_ORIGIN_RE.test(origin)) {
     headers["Access-Control-Allow-Origin"] = origin;
-  } else {
-    headers["Access-Control-Allow-Origin"] = "*";
   }
   return headers;
 }
@@ -123,28 +122,41 @@ function computeLevel(rawDetectedIds: Set<string>): { level: number; totalDetect
   return { level: currentLevel, totalDetected, totalAcmm };
 }
 
-async function fetchDetectedIds(origin: string, repo: string, force = false): Promise<string[]> {
-  // Fast path: read directly from Netlify Blobs (same store the scan function writes to).
-  // This avoids a same-origin HTTP round-trip that frequently times out inside
-  // Netlify Functions (cold-start + CDN routing overhead exceeds API_TIMEOUT_MS).
-  if (!force) {
-    try {
-      const store = getStore(BLOB_CACHE_STORE);
-      const cacheKey = `scan:${repo}`;
-      const raw = await store.get(cacheKey, { type: "json" });
-      if (raw) {
-        const entry = raw as { scannedAt?: string; detectedIds?: string[] };
-        const age = entry.scannedAt ? Date.now() - new Date(entry.scannedAt).getTime() : Infinity;
-        if (age < BLOB_CACHE_TTL_MS) {
-          return entry.detectedIds || [];
-        }
-      }
-    } catch {
-      // blob read failed — fall through to HTTP
+/** Try to read from Netlify Blobs, returning { data, fresh } or null. */
+async function readBlobCache(repo: string): Promise<{ detectedIds: string[]; fresh: boolean } | null> {
+  try {
+    const store = getStore(BLOB_CACHE_STORE);
+    const cacheKey = `scan:${repo}`;
+    const raw = await store.get(cacheKey, { type: "json" });
+    if (raw) {
+      const entry = raw as { scannedAt?: string; detectedIds?: string[] };
+      const age = entry.scannedAt ? Date.now() - new Date(entry.scannedAt).getTime() : Infinity;
+      return {
+        detectedIds: entry.detectedIds || [],
+        fresh: age < BLOB_CACHE_TTL_MS,
+      };
     }
+  } catch {
+    // blob read failed
   }
+  return null;
+}
 
-  // HTTP path: call the scan endpoint (forces a fresh GitHub scan when force=true).
+/** Write scan results to Netlify Blobs so future badge requests can use them. */
+async function writeBlobCache(repo: string, detectedIds: string[]): Promise<void> {
+  try {
+    const store = getStore(BLOB_CACHE_STORE);
+    const cacheKey = `scan:${repo}`;
+    await store.setJSON(cacheKey, {
+      scannedAt: new Date().toISOString(),
+      detectedIds,
+    });
+  } catch {
+    // best-effort — don't fail the badge
+  }
+}
+
+async function fetchFromScanEndpoint(origin: string, repo: string, force = false): Promise<string[]> {
   const forceParam = force ? "&force=true" : "";
   const url = `${origin}/api/acmm/scan?repo=${encodeURIComponent(repo)}${forceParam}`;
   const res = await fetch(url, { signal: AbortSignal.timeout(API_TIMEOUT_MS) });
@@ -293,12 +305,12 @@ async function fetchDetectedIdsDirect(repo: string, token: string): Promise<stri
 
 export default async (req: Request) => {
   const origin = req.headers.get("Origin");
-  const headers = corsHeaders(origin);
   const url = new URL(req.url);
   const repo = url.searchParams.get("repo") || "";
   const force = url.searchParams.get("force") === "true";
 
   if (!REPO_RE.test(repo)) {
+    const headers = corsHeaders(origin, BADGE_ERROR_CACHE_SECONDS);
     return new Response(
       JSON.stringify({
         schemaVersion: 1,
@@ -314,33 +326,67 @@ export default async (req: Request) => {
     );
   }
 
-  let detectedIds: string[] = [];
-  try {
-    detectedIds = await fetchDetectedIds(url.origin, repo, force);
-  } catch {
-    const token = process.env.GITHUB_TOKEN || "";
-    try {
-      detectedIds = await fetchDetectedIdsDirect(repo, token);
-    } catch {
-      return new Response(
-        JSON.stringify({
-          schemaVersion: 1,
-          label: "ACMM",
-          message: "unavailable",
-          color: "lightgrey",
-          cacheSeconds: BADGE_ERROR_CACHE_SECONDS,
-        }),
-        {
-          status: 200,
-          headers: { ...headers, "Content-Type": "application/json" },
-        },
-      );
+  // ── Layer 1: Blobs cache (fastest, no network) ───────────────────────
+  let blobResult: { detectedIds: string[]; fresh: boolean } | null = null;
+  if (!force) {
+    blobResult = await readBlobCache(repo);
+    if (blobResult?.fresh) {
+      return badgeResponse(blobResult.detectedIds, origin);
     }
   }
 
+  // ── Layer 2: scan endpoint ────────────────────────────────────────────
+  // If we have stale Blob data, use it as guaranteed fallback.
+  let detectedIds: string[] | null = null;
+  try {
+    detectedIds = await fetchFromScanEndpoint(url.origin, repo, force);
+    // Persist to Blobs for next request
+    writeBlobCache(repo, detectedIds).catch(() => {});
+  } catch {
+    // scan endpoint unreachable — try direct GitHub
+  }
+
+  if (detectedIds) {
+    return badgeResponse(detectedIds, origin);
+  }
+
+  // ── Layer 3: direct GitHub ────────────────────────────────────────────
+  const token = process.env.GITHUB_TOKEN || "";
+  try {
+    detectedIds = await fetchDetectedIdsDirect(repo, token);
+    writeBlobCache(repo, detectedIds).catch(() => {});
+    return badgeResponse(detectedIds, origin);
+  } catch {
+    // direct GitHub also failed
+  }
+
+  // ── Layer 4: stale Blob fallback (better than "unavailable") ──────────
+  if (blobResult) {
+    return badgeResponse(blobResult.detectedIds, origin);
+  }
+
+  // ── Layer 5: last-resort "unavailable" badge ──────────────────────────
+  const headers = corsHeaders(origin, BADGE_ERROR_CACHE_SECONDS);
+  return new Response(
+    JSON.stringify({
+      schemaVersion: 1,
+      label: "ACMM",
+      message: "unavailable",
+      color: "lightgrey",
+      cacheSeconds: BADGE_ERROR_CACHE_SECONDS,
+    }),
+    {
+      status: 200,
+      headers: { ...headers, "Content-Type": "application/json" },
+    },
+  );
+};
+
+function badgeResponse(detectedIds: string[], origin: string | null): Response {
   const { level, totalDetected, totalAcmm } = computeLevel(new Set(detectedIds));
   const name = LEVEL_NAMES[level];
   const color = LEVEL_COLORS[level];
+  const headers = corsHeaders(origin, BADGE_CACHE_SECONDS);
 
   return new Response(
     JSON.stringify({
@@ -356,7 +402,7 @@ export default async (req: Request) => {
       headers: { ...headers, "Content-Type": "application/json" },
     },
   );
-};
+}
 
 export const config = {
   path: "/api/acmm/badge",

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -255,7 +255,7 @@ export default defineConfig(({ mode }) => ({
     environment: 'jsdom',
     setupFiles: './src/test/setup.ts',
     css: true,
-    include: ['src/**/*.{test,spec}.{ts,tsx}'],
+    include: ['src/**/*.{test,spec}.{ts,tsx}', 'netlify/functions/__tests__/*.{test,spec}.{ts,tsx}'],
     exclude: ['node_modules', 'e2e/**/*'],
     teardownTimeout: process.env.CI ? 60_000 : 10_000, // CI runners need more time to terminate workers
     // CI runners (2-core, 7GB) OOM with 600+ test files at full concurrency


### PR DESCRIPTION
Layer 2 of combined server+edge caching to eliminate shields.io 'inaccessible' badges.

## Changes
- Increase shields.io cacheSeconds 300→900 (15min vs 5min)
- Increase error cacheSeconds 60→300 (5min vs 1min)
- Add Cache-Control stale-while-revalidate=86400 headers (24hr)
- Harden Blobs fallback to always serve last known good value
- Add writeBlobCache for direct GitHub fallback path
- 8 unit tests covering all code paths
- Expand vitest include to cover netlify functions tests

## Result
Badge endpoint always returns valid JSON (status 200), never errors. Combined with Go backend caching (separate PR), eliminates 'inaccessible' badges.

## Architecture
```
Layer 1: Blob cache (fresh <1hr) → immediate return
Layer 2: Scan endpoint → return + write to Blobs
Layer 3: Direct GitHub → return + write to Blobs
Layer 4: Stale Blob fallback → last known good
Layer 5: 'unavailable' badge (status 200, never HTTP error)
```