### PR TITLE
🐛 fix YouTube playlist — add Invidious API fallback for dead RSS feed

### DIFF
--- a/pkg/api/handlers/youtube.go
+++ b/pkg/api/handlers/youtube.go
@@ -74,23 +74,95 @@ var cache = &playlistCache{}
 var playlistSingleflight singleflight.Group
 
 func fetchPlaylistFromYouTube() ([]PlaylistVideo, error) {
-	// Primary: RSS feed (fast, no dependencies).
+	// Primary: Invidious API (reliable, no auth required).
+	videos, invErr := fetchPlaylistViaInvidious()
+	if invErr == nil && len(videos) > 0 {
+		return videos, nil
+	}
+
+	// Fallback 1: RSS feed.
 	videos, rssErr := fetchPlaylistViaRSS()
 	if rssErr == nil && len(videos) > 0 {
 		return videos, nil
 	}
 
-	// Fallback: yt-dlp (handles playlists where RSS returns 404).
+	// Fallback 2: yt-dlp (handles playlists where RSS returns 404).
 	videos, ytErr := fetchPlaylistViaYTDLP()
 	if ytErr == nil && len(videos) > 0 {
 		return videos, nil
 	}
 
-	// Both failed — return the more informative error.
+	// All failed — return the most informative error.
+	if invErr != nil {
+		return nil, invErr
+	}
 	if rssErr != nil {
 		return nil, rssErr
 	}
 	return nil, ytErr
+}
+
+// invidiousInstances is a list of public Invidious API instances tried in order.
+// These provide a YouTube-compatible JSON API without requiring auth.
+var invidiousInstances = []string{
+	"https://inv.nadeko.net",
+	"https://invidious.fdn.fr",
+	"https://vid.puffyan.us",
+}
+
+// invidiousPlaylistVideo is the JSON shape from /api/v1/playlists/:id.
+type invidiousPlaylistVideo struct {
+	VideoID string `json:"videoId"`
+	Title   string `json:"title"`
+}
+
+type invidiousPlaylistResp struct {
+	Videos []invidiousPlaylistVideo `json:"videos"`
+}
+
+func fetchPlaylistViaInvidious() ([]PlaylistVideo, error) {
+	var lastErr error
+	for _, instance := range invidiousInstances {
+		apiURL := fmt.Sprintf("%s/api/v1/playlists/%s", instance, playlistID)
+		resp, err := youtubeHTTPClient.Get(apiURL)
+		if err != nil {
+			lastErr = fmt.Errorf("invidious %s: %w", instance, err)
+			continue
+		}
+		defer resp.Body.Close()
+
+		if resp.StatusCode != http.StatusOK {
+			lastErr = fmt.Errorf("invidious %s returned %d", instance, resp.StatusCode)
+			continue
+		}
+
+		body, err := io.ReadAll(io.LimitReader(resp.Body, maxYouTubeResponseBytes))
+		if err != nil {
+			lastErr = fmt.Errorf("invidious %s read: %w", instance, err)
+			continue
+		}
+
+		var playlist invidiousPlaylistResp
+		if err := json.Unmarshal(body, &playlist); err != nil {
+			lastErr = fmt.Errorf("invidious %s parse: %w", instance, err)
+			continue
+		}
+
+		if len(playlist.Videos) == 0 {
+			lastErr = fmt.Errorf("invidious %s: empty playlist", instance)
+			continue
+		}
+
+		videos := make([]PlaylistVideo, 0, len(playlist.Videos))
+		for _, v := range playlist.Videos {
+			videos = append(videos, PlaylistVideo{
+				ID:    v.VideoID,
+				Title: v.Title,
+			})
+		}
+		return videos, nil
+	}
+	return nil, lastErr
 }
 
 func fetchPlaylistViaRSS() ([]PlaylistVideo, error) {

--- a/web/netlify/functions/youtube-playlist.mts
+++ b/web/netlify/functions/youtube-playlist.mts
@@ -86,27 +86,65 @@ export default async (req: Request) => {
   }
 
   try {
+    // Primary: Invidious API (reliable, no auth required)
+    const invidiousInstances = [
+      "https://inv.nadeko.net",
+      "https://invidious.fdn.fr",
+      "https://vid.puffyan.us",
+    ];
+
+    for (const instance of invidiousInstances) {
+      try {
+        const invResp = await fetch(
+          `${instance}/api/v1/playlists/${PLAYLIST_ID}`,
+          { signal: AbortSignal.timeout(8000) }
+        );
+        if (invResp.ok) {
+          const data = (await invResp.json()) as { videos?: Array<{ videoId: string; title: string }> };
+          if (data.videos && data.videos.length > 0) {
+            const videos: PlaylistVideo[] = data.videos.map((v) => ({
+              id: v.videoId,
+              title: v.title,
+            }));
+            return new Response(
+              JSON.stringify({
+                videos,
+                playlistId: PLAYLIST_ID,
+                playlistUrl: `https://www.youtube.com/playlist?list=${PLAYLIST_ID}`,
+              }),
+              { status: 200, headers }
+            );
+          }
+        }
+      } catch {
+        // try next instance
+      }
+    }
+
+    // Fallback: RSS feed
     const resp = await fetch(FEED_URL, {
       headers: { "User-Agent": "KubeStellar-Console/1.0" },
     });
 
-    if (!resp.ok) {
-      return new Response(
-        JSON.stringify({ error: "YouTube returned " + resp.status }),
-        { status: 502, headers }
-      );
+    if (resp.ok) {
+      const xml = await resp.text();
+      const videos = parseAtomFeed(xml);
+      if (videos.length > 0) {
+        return new Response(
+          JSON.stringify({
+            videos,
+            playlistId: PLAYLIST_ID,
+            playlistUrl: `https://www.youtube.com/playlist?list=${PLAYLIST_ID}`,
+          }),
+          { status: 200, headers }
+        );
+      }
     }
 
-    const xml = await resp.text();
-    const videos = parseAtomFeed(xml);
-
+    // All sources failed
     return new Response(
-      JSON.stringify({
-        videos,
-        playlistId: PLAYLIST_ID,
-        playlistUrl: `https://www.youtube.com/playlist?list=${PLAYLIST_ID}`,
-      }),
-      { status: 200, headers }
+      JSON.stringify({ error: "All video sources unavailable", videos: [] }),
+      { status: 502, headers }
     );
   } catch (err) {
     console.error("Failed to fetch YouTube playlist:", err);


### PR DESCRIPTION
## Problem
The YouTube RSS feed (`/feeds/videos.xml?playlist_id=...`) now returns **404**, breaking the Learn dropdown — 0 videos shown. The newest tutorial ("Add GitHub OAuth to Console") and all others are invisible.

## Root Cause
YouTube deprecated/broke their playlist RSS feed endpoint. The `yt-dlp` fallback doesn't help on Netlify (not installed).

## Solution
Add **Invidious API** as the primary video source with multi-instance failover:
- `inv.nadeko.net` → `invidious.fdn.fr` → `vid.puffyan.us`
- Falls back to RSS → yt-dlp if all Invidious instances fail
- Applied to both Go handler and Netlify function

## Verified
```bash
curl -s 'https://inv.nadeko.net/api/v1/playlists/PL1ALKGr_qZKc-xehA_8iUCdiKsCo6p6nD' | jq '.videos | length'
# 4 (all playlist videos returned)
```

## Files Changed
- `pkg/api/handlers/youtube.go` — add `fetchPlaylistViaInvidious()` with instance failover
- `web/netlify/functions/youtube-playlist.mts` — add Invidious primary with RSS fallback