### PR TITLE
🐛 Fix 4 community bugs: token flush, spin-loop, localStorage, concurrency

### DIFF
--- a/pkg/agent/prediction_worker.go
+++ b/pkg/agent/prediction_worker.go
@@ -286,7 +286,12 @@ func (w *PredictionWorker) runLoop() {
 		}
 
 		// Wait for next interval or stop signal using the reused timer.
-		interval := time.Duration(settings.Interval) * time.Minute
+		// Guard against zero/negative interval to prevent busy-loop DoS (#9620).
+		intervalMinutes := settings.Interval
+		if intervalMinutes < 1 {
+			intervalMinutes = 10
+		}
+		interval := time.Duration(intervalMinutes) * time.Minute
 		intervalTimer.Reset(interval)
 		select {
 		case <-intervalTimer.C:

--- a/pkg/agent/server_ai.go
+++ b/pkg/agent/server_ai.go
@@ -479,8 +479,13 @@ func (s *Server) handleChatMessageStreaming(conn *websocket.Conn, msg protocol.M
 	ctx, cancel := context.WithTimeout(context.Background(), missionExecutionTimeout)
 	defer cancel()
 
-	// Register cancel function so handleCancelChat can stop this session
+	// Register cancel function so handleCancelChat can stop this session.
+	// If a previous request is still running for this SessionID, cancel it
+	// first to prevent orphaned goroutines (#9619).
 	s.activeChatCtxsMu.Lock()
+	if prevCancel, exists := s.activeChatCtxs[req.SessionID]; exists {
+		prevCancel()
+	}
 	s.activeChatCtxs[req.SessionID] = cancel
 	s.activeChatCtxsMu.Unlock()
 	defer func() {
@@ -1593,14 +1598,16 @@ func (s *Server) addTokenUsage(usage *ProviderTokenUsage) {
 	s.todayTokensIn += int64(usage.InputTokens)
 	s.todayTokensOut += int64(usage.OutputTokens)
 
-	// Schedule a debounced flush: reset the timer if one is already pending,
-	// otherwise create a new one. This coalesces rapid-fire token updates into
-	// a single disk write (#9483).
-	if s.tokenFlushTimer != nil {
-		s.tokenFlushTimer.Stop()
-		s.tokenFlushTimer.Reset(tokenUsageFlushInterval)
-	} else {
+	// Schedule a non-resetting flush: if no timer is pending, start one.
+	// Unlike the previous debounce that reset on every call (#9616), this
+	// guarantees the flush fires within tokenUsageFlushInterval of the FIRST
+	// token update, preventing unbounded data loss if tokens arrive faster
+	// than the interval.
+	if s.tokenFlushTimer == nil {
 		s.tokenFlushTimer = time.AfterFunc(tokenUsageFlushInterval, func() {
+			s.tokenMux.Lock()
+			s.tokenFlushTimer = nil
+			s.tokenMux.Unlock()
 			s.saveTokenUsage()
 		})
 	}

--- a/web/src/hooks/useMissionStorage.ts
+++ b/web/src/hooks/useMissionStorage.ts
@@ -44,7 +44,19 @@ export function loadMissions(): Mission[] {
   try {
     const stored = localStorage.getItem(MISSIONS_STORAGE_KEY)
     if (stored) {
-      const parsed = JSON.parse(stored)
+      let parsed: unknown
+      try {
+        parsed = JSON.parse(stored)
+      } catch (parseErr) {
+        console.error('[Missions] Corrupted localStorage JSON — clearing:', parseErr)
+        localStorage.removeItem(MISSIONS_STORAGE_KEY)
+        return []
+      }
+      if (!Array.isArray(parsed)) {
+        console.warn('[Missions] localStorage value is not an array — clearing')
+        localStorage.removeItem(MISSIONS_STORAGE_KEY)
+        return []
+      }
       // In demo mode, replace stale demo data with fresh demo missions
       // (catches both empty arrays and outdated demo entries without steps)
       if (getDemoMode() && Array.isArray(parsed) && (


### PR DESCRIPTION
Fixes #9616, #9619, #9620, #9622

## Changes

### Token flush forever-reset (#9616)
`addTokenUsage` debounce timer was resetting on every call — if tokens arrived faster than 5s, `saveTokenUsage` never fired. Now the timer fires once after the first update, guaranteeing a flush within the interval.

### Prediction spin-loop DoS (#9620)
`PredictionWorker` accepted `Interval=0` causing a busy-loop. Now validates `>= 1` minute, defaults to 10.

### localStorage JSON parse crash (#9622)
`loadMissions()` called `JSON.parse` without handling corrupted data. Now catches parse errors explicitly, clears bad data, returns empty array.

### activeChatCtxs concurrency hazard (#9619)
Second request with same SessionID overwrote the first cancel function, orphaning the first goroutine. Now cancels the previous request before registering the new one.

## Not in this PR
- #9617 (persistence bottleneck) — needs debounced save, separate PR
- #9618 (orphaned goroutines on WS disconnect) — needs deeper refactor