### PR TITLE
🐛 Fix mission save bottleneck, orphaned goroutines, nightly git conflict

### DIFF
--- a/.github/workflows/nightly-test-suite.yml
+++ b/.github/workflows/nightly-test-suite.yml
@@ -153,8 +153,11 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
-          # Pull latest main to avoid rejection (other workflows may have pushed)
-          git pull --rebase origin main || git pull origin main
+          # Pull latest main to avoid rejection (other workflows may have pushed).
+          # Stash any uncommitted test results first to prevent merge conflicts (#9621).
+          git stash --include-untracked || true
+          git pull --rebase origin main || git pull origin main || true
+          git stash pop || true
 
           git add "${RESULTS_DIR}/${{ steps.tests.outputs.date }}.json"
           git commit -m "chore: nightly test results for ${{ steps.tests.outputs.date }}

--- a/pkg/agent/server_ai.go
+++ b/pkg/agent/server_ai.go
@@ -1218,6 +1218,14 @@ User request: %s`, req.Prompt)
 		Context:   chatCtx,
 	}
 
+	// #9618 — Check if WebSocket is still alive before expensive provider call.
+	// Without this, orphaned goroutines continue running AI requests for up to
+	// 5 minutes after the client disconnects.
+	if closed.Load() {
+		slog.Info("[MixedMode] connection closed before thinking call", "sessionID", sessionID)
+		return
+	}
+
 	thinkingResp, err := thinkingProvider.Chat(ctx, &thinkingReq)
 	if err != nil {
 		if ctx.Err() != nil {
@@ -1285,6 +1293,11 @@ User request: %s`, req.Prompt)
 
 	var execContent string
 
+	if closed.Load() {
+		slog.Info("[MixedMode] connection closed before execution call", "sessionID", sessionID)
+		return
+	}
+
 	execResp, err := execProvider.Chat(ctx, &execReq)
 	if err != nil {
 		if ctx.Err() != nil {
@@ -1339,6 +1352,11 @@ Command output:
 		Prompt:    analysisPrompt,
 		SessionID: sessionID,
 		History:   append(history, ChatMessage{Role: "assistant", Content: thinkingResp.Content}),
+	}
+
+	if closed.Load() {
+		slog.Info("[MixedMode] connection closed before analysis call", "sessionID", sessionID)
+		return
 	}
 
 	analysisResp, err := thinkingProvider.Chat(ctx, &analysisReq)

--- a/web/src/hooks/useMissions.tsx
+++ b/web/src/hooks/useMissions.tsx
@@ -426,8 +426,15 @@ export function MissionProvider({ children }: { children: ReactNode }) {
       suppressNextSaveRef.current = false
       return
     }
-    lastWrittenAtRef.current = Date.now()
-    saveMissions(missions)
+    // #9617 — Debounce saves to avoid JSON.stringify on every SSE chunk.
+    // During streaming, missions update on every chunk (~50ms). Without
+    // debouncing, saveMissions runs synchronous JSON.stringify on the full
+    // mission array for every chunk, blocking the main thread.
+    const timer = setTimeout(() => {
+      lastWrittenAtRef.current = Date.now()
+      saveMissions(missions)
+    }, 500)
+    return () => clearTimeout(timer)
   }, [missions])
 
   // #6668 — Listen for cross-tab mission updates. When another tab writes


### PR DESCRIPTION
Fixes #9617, #9618, #9621

## Changes

### Debounce mission persistence (#9617)
`useMissions` effect called `saveMissions()` (synchronous `JSON.stringify`) on every SSE chunk during streaming. Added 500ms debounce so saves coalesce during rapid updates.

### Orphaned goroutines on disconnect (#9618)
`handleMixedModeChat` made 3 provider calls without checking if the WebSocket was still alive. Added `closed.Load()` checks before each `provider.Chat()` call so goroutines exit immediately when client disconnects instead of running for 5 minutes.

### Nightly git merge conflict (#9621)
Nightly test suite workflow wrote results to the worktree then tried `git pull --rebase`, which failed on dirty files. Added `git stash` before pull and `git stash pop` after.