### PR TITLE
🐛 Fix compliance framework test failures blocking weekly release

### DIFF
--- a/pkg/api/handlers/compliance_frameworks.go
+++ b/pkg/api/handlers/compliance_frameworks.go
@@ -20,8 +20,10 @@ func NewComplianceFrameworksHandler(evaluator *frameworks.Evaluator) *Compliance
 }
 
 // RegisterRoutes wires up the compliance frameworks routes under the given group.
-// POST endpoints (evaluate) require authentication.
+// GET endpoints are read-only; POST endpoints (evaluate) require authentication.
 func (h *ComplianceFrameworksHandler) RegisterRoutes(group fiber.Router) {
+	group.Get("/", h.ListFrameworks)
+	group.Get("/:id", h.GetFramework)
 	group.Post("/:id/evaluate", h.EvaluateFramework)
 }
 


### PR DESCRIPTION
## Problem
`TestListFrameworks` and `TestGetFramework` fail because `RegisterRoutes()` only registered the POST `/evaluate` endpoint but not the GET `/` and `GET /:id` endpoints. Tests call `RegisterRoutes` and expect GET to work → 404.

This blocks the weekly release workflow (`test` job fails → `release` job skipped).

## Fix
Add GET routes to `RegisterRoutes()` alongside POST. The public (unauthenticated) routes from `RegisterPublicRoutes()` remain unchanged — server.go calls both, so GET endpoints are accessible both with and without auth.

## Verified
- All compliance framework tests pass (8/8)
- Full `go test ./...` passes (only pre-existing `pkg/agent` network-dependent tests fail)