### PR TITLE
🐛 Fix compliance page demo mode — add /api/compliance/ to public prefixes

### DIFF
--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -21,7 +21,7 @@ const TOKEN_REFRESH_HEADER = 'X-Token-Refresh' // server signals when token shou
 const AUTH_LOGOUT_ENDPOINT = '/auth/logout'
 
 // Public API paths that don't require authentication (served without JWT on the backend)
-const PUBLIC_API_PREFIXES = ['/api/missions/browse', '/api/missions/file']
+const PUBLIC_API_PREFIXES = ['/api/missions/browse', '/api/missions/file', '/api/compliance/']
 
 // Error class for unauthenticated requests
 export class UnauthenticatedError extends Error {


### PR DESCRIPTION
## Root Cause

`api.get()` checks `hasToken()` before making the fetch request. In demo mode (Netlify), there's no JWT token, so `UnauthenticatedError` is thrown **before MSW can intercept** the request. The compliance page shows 'No authentication token available'.

## Fix

Add `/api/compliance/` to `PUBLIC_API_PREFIXES` so the token check is skipped for compliance endpoints. MSW mock handlers (added in #9693) then serve demo framework data.

## Testing
- Build passes, all 32 compliance tests pass
- One-line change in `web/src/lib/api.ts`