### PR TITLE
🐛 Fix corrupted MSW mock handlers for BAA, HIPAA, and GxP

### DIFF
--- a/web/src/mocks/handlers.ts
+++ b/web/src/mocks/handlers.ts
@@ -741,33 +741,6 @@ export const handlers = [
     })
   }),
 
-  // BAA Tracker mock handlers (demo mode)
-  http.get('/api/compliance/baa/agreements', async () => {
-    await delay(150)
-    return HttpResponse.json([
-      { id: 'baa-001', provider: 'Amazon Web Services', provider_type: 'cloud', baa_signed_date: '2025-06-15', baa_expiry_date: '2027-06-15', covered_clusters: ['prod-east', 'staging-east'], contact_name: 'AWS Enterprise Support', contact_email: 'aws-baa@example.com', status: 'active', notes: 'Covers all HIPAA-eligible services in us-east-1' },
-      { id: 'baa-002', provider: 'Google Cloud Platform', provider_type: 'cloud', baa_signed_date: '2025-08-01', baa_expiry_date: '2026-08-01', covered_clusters: ['prod-west'], contact_name: 'GCP Healthcare Team', contact_email: 'gcp-baa@example.com', status: 'active', notes: 'Covers GKE, Cloud SQL, BigQuery in us-west1' },
-      { id: 'baa-003', provider: 'Datadog', provider_type: 'saas', baa_signed_date: '2025-03-01', baa_expiry_date: '2026-05-15', covered_clusters: ['prod-east', 'prod-west'], contact_name: 'Datadog Compliance', contact_email: 'compliance@datadog.example.com', status: 'expiring_soon', notes: 'Monitoring and logging for PHI workloads' },
-      { id: 'baa-004', provider: 'Snowflake', provider_type: 'saas', baa_signed_date: '2024-01-01', baa_expiry_date: '2026-01-01', covered_clusters: [], contact_name: 'Snowflake Legal', contact_email: 'legal@snowflake.example.com', status: 'expired', notes: 'Analytics warehouse — BAA lapsed' },
-      { id: 'baa-005', provider: 'Acme Consulting', provider_type: 'consulting', baa_signed_date: '', baa_expiry_date: '', covered_clusters: ['dev-central'], contact_name: 'Acme PM', contact_email: 'pm@acme.example.com', status: 'pending', notes: 'BAA under legal review' },
-      { id: 'baa-006', provider: 'Azure', provider_type: 'cloud', baa_signed_date: '2025-11-01', baa_expiry_date: '2027-11-01', covered_clusters: ['dr-central'], contact_name: 'Microsoft Enterprise', contact_email: 'azure-baa@example.com', status: 'active', notes: 'Disaster recovery in Central US' },
-    ])
-  }),
-
-  http.get('/api/compliance/baa/alerts', async () => {
-    await delay(150)
-    return HttpResponse.json([
-      { agreement_id: 'baa-003', provider: 'Datadog', expiry_date: '2026-05-15', days_left: 22, severity: 'critical' },
-      { agreement_id: 'baa-004', provider: 'Snowflake', expiry_date: '2026-01-01', days_left: 0, severity: 'critical' },
-    ])
-  }),
-
-  http.get('/api/compliance/baa/summary', async () => {
-    await delay(150)
-    return HttpResponse.json({
-      total_agreements: 6, active_agreements: 3, expiring_soon: 1,
-      expired: 1, pending: 1, covered_clusters: 5, uncovered_clusters: 1,
-      active_alerts: 2, evaluated_at: new Date().toISOString(),
   // HIPAA compliance mock handlers (demo mode)
   http.get('/api/compliance/hipaa/safeguards', async () => {
     await delay(150)
@@ -826,6 +799,10 @@ export const handlers = [
       overall_score: 60, safeguards_passed: 2, safeguards_failed: 1,
       safeguards_partial: 2, total_safeguards: 5, phi_namespaces: 4,
       compliant_namespaces: 2, data_flows: 6, encrypted_flows: 5,
+      evaluated_at: new Date().toISOString(),
+    })
+  }),
+
   // GxP / 21 CFR Part 11 mock handlers (demo mode)
   http.get('/api/compliance/gxp/config', async () => {
     await delay(150)
@@ -877,6 +854,36 @@ export const handlers = [
       total_records: 8, total_signatures: 7, chain_integrity: true,
       last_verified: new Date().toISOString(), pending_signatures: 1,
       evaluated_at: new Date().toISOString(),
+    })
+  }),
+
+  // BAA Tracker mock handlers (demo mode)
+  http.get('/api/compliance/baa/agreements', async () => {
+    await delay(150)
+    return HttpResponse.json([
+      { id: 'baa-001', provider: 'Amazon Web Services', provider_type: 'cloud', baa_signed_date: '2025-06-15', baa_expiry_date: '2027-06-15', covered_clusters: ['prod-east', 'staging-east'], contact_name: 'AWS Enterprise Support', contact_email: 'aws-baa@example.com', status: 'active', notes: 'Covers all HIPAA-eligible services in us-east-1' },
+      { id: 'baa-002', provider: 'Google Cloud Platform', provider_type: 'cloud', baa_signed_date: '2025-08-01', baa_expiry_date: '2026-08-01', covered_clusters: ['prod-west'], contact_name: 'GCP Healthcare Team', contact_email: 'gcp-baa@example.com', status: 'active', notes: 'Covers GKE, Cloud SQL, BigQuery in us-west1' },
+      { id: 'baa-003', provider: 'Datadog', provider_type: 'saas', baa_signed_date: '2025-03-01', baa_expiry_date: '2026-05-15', covered_clusters: ['prod-east', 'prod-west'], contact_name: 'Datadog Compliance', contact_email: 'compliance@datadog.example.com', status: 'expiring_soon', notes: 'Monitoring and logging for PHI workloads' },
+      { id: 'baa-004', provider: 'Snowflake', provider_type: 'saas', baa_signed_date: '2024-01-01', baa_expiry_date: '2026-01-01', covered_clusters: [], contact_name: 'Snowflake Legal', contact_email: 'legal@snowflake.example.com', status: 'expired', notes: 'Analytics warehouse — BAA lapsed' },
+      { id: 'baa-005', provider: 'Acme Consulting', provider_type: 'consulting', baa_signed_date: '', baa_expiry_date: '', covered_clusters: ['dev-central'], contact_name: 'Acme PM', contact_email: 'pm@acme.example.com', status: 'pending', notes: 'BAA under legal review' },
+      { id: 'baa-006', provider: 'Azure', provider_type: 'cloud', baa_signed_date: '2025-11-01', baa_expiry_date: '2027-11-01', covered_clusters: ['dr-central'], contact_name: 'Microsoft Enterprise', contact_email: 'azure-baa@example.com', status: 'active', notes: 'Disaster recovery in Central US' },
+    ])
+  }),
+
+  http.get('/api/compliance/baa/alerts', async () => {
+    await delay(150)
+    return HttpResponse.json([
+      { agreement_id: 'baa-003', provider: 'Datadog', expiry_date: '2026-05-15', days_left: 22, severity: 'critical' },
+      { agreement_id: 'baa-004', provider: 'Snowflake', expiry_date: '2026-01-01', days_left: 0, severity: 'critical' },
+    ])
+  }),
+
+  http.get('/api/compliance/baa/summary', async () => {
+    await delay(150)
+    return HttpResponse.json({
+      total_agreements: 6, active_agreements: 3, expiring_soon: 1,
+      expired: 1, pending: 1, covered_clusters: 5, uncovered_clusters: 1,
+      active_alerts: 2, evaluated_at: new Date().toISOString(),
     })
   }),
 


### PR DESCRIPTION
## Problem
The previous merge conflict resolution during HIPAA (#9695) and GxP (#9696) merges left `handlers.ts` with syntax errors:
- BAA summary handler missing closing braces (`HttpResponse.json` unclosed)
- HIPAA summary handler missing closing braces
- BAA mocks placed inside a broken scope before HIPAA/GxP

This caused TypeScript build failures, breaking the `console.kubestellar.io` demo site.

## Fix
- Removed the corrupt first BAA mock block
- Added proper closing for HIPAA summary handler
- Placed clean BAA mocks after GxP section (correct position)

## Testing
- `npm run build` — passes ✅
- `go test ./pkg/compliance/baa/...` — 6/6 pass ✅
- `go test ./pkg/api/handlers/...` — all pass ✅
- `go build ./...` — clean ✅

Closes #9645