### PR TITLE
🐛 Fix 16 mission deep-link slug collisions

### DIFF
--- a/web/src/components/missions/browser/helpers.ts
+++ b/web/src/components/missions/browser/helpers.ts
@@ -4,10 +4,13 @@ import type { TreeNode } from './types'
 
 /**
  * Generate a stable, URL-safe slug for any mission.
- * - Installers with cncfProject: `install-<cncfProject>` (e.g. `install-prometheus`)
- * - All others: slugified title (lowercase, non-alphanum → hyphens, dedupe, trim)
+ * Priority order:
+ *   1. `name` field from console-kb (unique per mission, e.g. "install-argo-workflows")
+ *   2. Installers with cncfProject: `install-<cncfProject>` (legacy fallback)
+ *   3. Slugified title (lowercase, non-alphanum → hyphens, dedupe, trim)
  */
 export function getMissionSlug(mission: MissionExport): string {
+  if (mission.name) return mission.name
   if (mission.missionClass === 'install' && mission.cncfProject) {
     return `install-${mission.cncfProject.toLowerCase()}`
   }
@@ -92,6 +95,7 @@ export function normalizeMission(raw: Record<string, unknown>): MissionExport | 
 
   return {
     version: (raw.version as string) ?? (raw.format as string) ?? 'kc-mission-v1',
+    name: (raw.name as string) ?? undefined,
     title: (m.title as string) ?? '',
     description: (m.description as string) ?? '',
     type: (m.type as string) ?? 'troubleshoot',

--- a/web/src/components/missions/browser/missionCache.ts
+++ b/web/src/components/missions/browser/missionCache.ts
@@ -113,8 +113,13 @@ const MISSION_FILE_FORMAT_VERSION = 'kc-mission-v1'
 
 /** Convert an index entry to a MissionExport (browsing metadata only — steps loaded on demand) */
 function indexEntryToMission(entry: IndexEntry): MissionExport {
+  // Derive stable name from path: "fixes/cncf-install/install-opa.json" → "install-opa"
+  const name = entry.path
+    ? entry.path.replace(/^.*\//, '').replace(/\.json$/, '')
+    : undefined
   return {
     version: MISSION_FILE_FORMAT_VERSION,
+    name,
     title: entry.title || '',
     description: entry.description || '',
     type: (entry.type as MissionExport['type']) || 'custom',

--- a/web/src/lib/missions/types.ts
+++ b/web/src/lib/missions/types.ts
@@ -66,6 +66,8 @@ export interface OrbitConfig {
 
 export interface MissionExport {
   version: string
+  /** Stable unique identifier from console-kb (e.g. "install-open-policy-agent-opa"). Used as the canonical deep-link slug when present. */
+  name?: string
   title: string
   description: string
   type: MissionType


### PR DESCRIPTION
## Problem

Audited all 1480 mission deep links from console-kb. Found **16 missions** (in 11 collision groups) that resolve to the **wrong mission** when accessed via deep link.

Root cause: `getMissionSlug()` derives installer slugs from `cncfProject`, but sub-projects share the parent project name:
- Argo Workflows, Argo Events, Argo Rollouts → all slug to `install-argo`
- Node Exporter, Pushgateway, Alertmanager → all slug to `install-prometheus`
- OpenTelemetry Collector, OpenTelemetry Operator → all slug to `install-opentelemetry`

## Fix

`getMissionSlug()` now prefers the `name` field from console-kb mission files. Each KB file has a unique `name` (e.g. `install-argo-workflows`, `install-node-exporter`) that becomes the canonical deep-link slug.

**Before:** 1464 unique slugs, 11 collisions (16 wrong-target)
**After:** 1479 unique slugs, 1 collision (duplicate `install-openeverest` in KB data)

## Changes (3 files)

- `web/src/lib/missions/types.ts` — Add `name?: string` to MissionExport
- `web/src/components/missions/browser/helpers.ts` — getMissionSlug prefers name
- `web/src/components/missions/browser/missionCache.ts` — Derive name from file path in indexEntryToMission, pass through in normalizeMission

## Testing

- All 43 mission tests pass
- Verified slug uniqueness: 1479/1480 unique (only genuine KB data dupe remains)