### PR TITLE
🐛 Fix WebSocket goroutine/token leak and reduce DoS body limit

### DIFF
--- a/pkg/agent/server_ai.go
+++ b/pkg/agent/server_ai.go
@@ -89,6 +89,12 @@ func (s *Server) handleWebSocket(w http.ResponseWriter, r *http.Request) {
 	// closed is set when the read loop exits; goroutines check it before writing
 	var closed atomic.Bool
 
+	// connCtx is cancelled when the WebSocket read loop exits (client disconnect).
+	// AI goroutines derive their context from connCtx so that in-progress
+	// StreamChat calls are interrupted immediately on disconnect (#9709).
+	connCtx, connCancel := context.WithCancel(context.Background())
+	defer connCancel()
+
 	// Semaphore to limit concurrent work goroutines per connection (#7277)
 	sem := make(chan struct{}, maxWSGoroutines)
 
@@ -162,7 +168,7 @@ func (s *Server) handleWebSocket(w http.ResponseWriter, r *http.Request) {
 						}
 					}
 				}()
-				s.handleChatMessageStreaming(conn, m, fa, writeMu, &closed)
+				s.handleChatMessageStreaming(connCtx, conn, m, fa, writeMu, &closed)
 			}(msg, forceAgent)
 		} else if msg.Type == protocol.TypeCancelChat {
 			// Cancel an in-progress chat by session ID
@@ -410,7 +416,7 @@ func (s *Server) handleKubectlMessage(msg protocol.Message) protocol.Message {
 // a write failure we log it, mark the connection closed, and early-out of
 // future safeWrite calls. The caller's outer goroutine sees closed.Load()
 // == true and will finish its work without further WebSocket traffic.
-func (s *Server) handleChatMessageStreaming(conn *websocket.Conn, msg protocol.Message, forceAgent string, writeMu *sync.Mutex, closed *atomic.Bool) {
+func (s *Server) handleChatMessageStreaming(connCtx context.Context, conn *websocket.Conn, msg protocol.Message, forceAgent string, writeMu *sync.Mutex, closed *atomic.Bool) {
 	safeWrite := func(ctx context.Context, outMsg protocol.Message) {
 		if closed.Load() || ctx.Err() != nil {
 			return
@@ -473,10 +479,12 @@ func (s *Server) handleChatMessageStreaming(conn *websocket.Conn, msg protocol.M
 	}
 
 	// Create a context with both cancel and timeout so that:
-	//   1. cancel_chat messages can stop this session immediately, and
+	//   1. cancel_chat messages can stop this session immediately,
 	//   2. a hard deadline prevents missions from running forever when the
-	//      AI provider hangs or never responds (#2375).
-	ctx, cancel := context.WithTimeout(context.Background(), missionExecutionTimeout)
+	//      AI provider hangs or never responds (#2375), and
+	//   3. client disconnect (connCtx cancelled) stops in-progress
+	//      StreamChat calls immediately, preventing goroutine/token leaks (#9709).
+	ctx, cancel := context.WithTimeout(connCtx, missionExecutionTimeout)
 	defer cancel()
 
 	// Register cancel function so handleCancelChat can stop this session.

--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -56,7 +56,8 @@ const (
 
 	// feedbackBodyLimit is the global Fiber BodyLimit, elevated to support
 	// base64-encoded screenshot uploads in POST /api/feedback/requests.
-	feedbackBodyLimit = 20 * 1024 * 1024 // 20 MB — base64 screenshot uploads
+	// Reduced from 20 MB to 5 MB to limit memory-based DoS surface (#9710).
+	feedbackBodyLimit = 5 * 1024 * 1024 // 5 MB — base64 screenshot uploads
 )
 
 // Version is the build version, injected via ldflags at build time.
@@ -236,13 +237,11 @@ func NewServer(cfg Config) (*Server, error) {
 		"::1/128",        // IPv6 loopback
 	}
 
-	// BodyLimit is set to feedbackBodyLimit (20 MB) because the feedback endpoint
+	// BodyLimit is set to feedbackBodyLimit (5 MB) because the feedback endpoint
 	// accepts base64-encoded screenshot uploads. Per-route enforcement is done by
 	// bodyGuard middleware (1 MB for most routes) and analyticsBodyGuard (64 KB).
-	// Fiber buffers up to BodyLimit before middleware runs, so a concurrent flood
-	// of max-size bodies can still cause memory pressure (#7039). ReadTimeout (30s)
-	// bounds the buffering window; for stricter enforcement, deploy behind an
-	// ingress controller with its own body-size limit (e.g. nginx client_max_body_size).
+	// Reduced from 20 MB to 5 MB to limit memory-based DoS surface (#9710).
+	// ReadTimeout (30s) further bounds the buffering window.
 	app := fiber.New(fiber.Config{
 		ErrorHandler:            customErrorHandler,
 		ReadBufferSize:          16384,


### PR DESCRIPTION
## Summary

Fixes two critical security/reliability issues:

### 1. AI Goroutine & Token Leak on WebSocket Disconnect (#9709)

**Problem:** When a client disconnects mid-chat, the AI streaming goroutine continues running for up to 5 minutes (the mission timeout), consuming tokens and memory.

**Fix:** Added a connection-level context (`connCtx`) that is cancelled when the WebSocket read loop exits. `handleChatMessageStreaming` now derives its timeout context from `connCtx` instead of `context.Background()`, so in-progress `StreamChat` calls are interrupted immediately on disconnect.

### 2. Global Request Body Buffering DoS (#9710)

**Problem:** Fiber's global `BodyLimit` was 20 MB, allowing any endpoint (including `/health`) to buffer 20 MB per request into RAM before middleware runs.

**Fix:** Reduced `feedbackBodyLimit` from 20 MB to 5 MB (still sufficient for base64 screenshot uploads). Combined with the existing `bodyGuard` middleware (1 MB for non-feedback routes) and 30s ReadTimeout, this reduces the DoS surface by 75%.

## Changes (2 files)
- `pkg/agent/server_ai.go` — Add `connCtx`, pass to `handleChatMessageStreaming`, derive timeout from it
- `pkg/api/server.go` — Reduce `feedbackBodyLimit` 20→5 MB

## Testing
- All Go tests pass (`pkg/agent`, `pkg/api`, middleware, handlers)
- No behavioral change for normal usage — only affects disconnect cleanup and max body size

Fixes #9709
Fixes #9710