### PR TITLE
🐛 Fix 'Add more' sidebar button to open Console Studio

### DIFF
--- a/web/src/components/layout/Sidebar.tsx
+++ b/web/src/components/layout/Sidebar.tsx
@@ -488,8 +488,11 @@ export function Sidebar() {
         {!isCollapsed && (
           <button
             onClick={() => {
-              // Always open SidebarCustomizer — reliable from any page
-              setShowCustomizer(true)
+              if (dashboardContext) {
+                dashboardContext.openAddCardModal('dashboards')
+              } else {
+                setShowCustomizer(true)
+              }
             }}
             className="w-full flex items-center gap-3 px-3 py-1.5 mt-1 text-xs text-muted-foreground/60 hover:text-muted-foreground hover:bg-secondary/30 rounded-lg transition-colors"
           >


### PR DESCRIPTION
## Problem
The sidebar 'Add more...' button opens the **Customize Sidebar** dialog instead of **Console Studio** at the Dashboards section.

## Fix
Changed the onClick handler to use `openAddCardModal('dashboards')` from the dashboard context, which opens Console Studio with the Manage Dashboards section pre-selected. Falls back to SidebarCustomizer on non-dashboard pages where the context isn't available.

## Changes
- `web/src/components/layout/Sidebar.tsx` — 1 line change in onClick handler