### PR TITLE
🐛 Remove standalone modals — Console Studio is the single entry point

### DIFF
--- a/web/src/components/dashboard/Dashboard.tsx
+++ b/web/src/components/dashboard/Dashboard.tsx
@@ -38,9 +38,7 @@ import { CardRecommendations } from './CardRecommendations'
 import { safeGetItem, safeSetItem, safeGetJSON, safeSetJSON } from '../../lib/utils/localStorage'
 import { MissionSuggestions } from './MissionSuggestions'
 import { GettingStartedBanner } from './GettingStartedBanner'
-import { SidebarCustomizer } from '../layout/SidebarCustomizer'
 import { useMissions } from '../../hooks/useMissions'
-import { CreateDashboardModal } from './CreateDashboardModal'
 import { FloatingDashboardActions } from './FloatingDashboardActions'
 import { DashboardCustomizer } from './customizer/DashboardCustomizer'
 import { DashboardTemplate } from './templates'
@@ -122,9 +120,7 @@ export function Dashboard() {
   const [isDragging, setIsDragging] = useState(false)
   const [insertAtIndex, setInsertAtIndex] = useState<number | null>(null)
   const [__dragOverDashboard, setDragOverDashboard] = useState<string | null>(null)
-  const { isOpen: isCreateDashboardOpen, open: openCreateDashboard, close: closeCreateDashboard } = useModalState()
   const { isOpen: isWidgetExportOpen, open: openWidgetExport, close: closeWidgetExport } = useModalState()
-  const { isOpen: isSidebarCustomizerOpen, open: openSidebarCustomizer, close: closeSidebarCustomizer } = useModalState()
 
   // Get context for modals that can be triggered from sidebar
   const {
@@ -515,40 +511,7 @@ export function Dashboard() {
   }
 
   const handleCreateDashboard = () => {
-    openCreateDashboard()
-  }
-
-  const handleCreateDashboardConfirm = async (name: string, template?: DashboardTemplate) => {
-    try {
-      const newDashboard = await createDashboard(name)
-
-      // If a template was selected, apply template cards to the new dashboard
-      if (template && newDashboard.id) {
-        const templateCards = template.cards.map((tc, index) => ({
-          id: `template-${Date.now()}-${index}`,
-          card_type: tc.card_type,
-          config: tc.config || {},
-          position: { x: 0, y: 0, w: tc.position?.w || 4, h: tc.position?.h || 2 },
-          title: tc.title }))
-
-        // Persist template cards to the new dashboard
-        for (const card of templateCards) {
-          try {
-            await api.post(`/api/dashboards/${newDashboard.id}/cards`, card)
-          } catch (error) {
-            console.error('Failed to add template card:', error)
-            showToast('Failed to add template card', 'error')
-          }
-        }
-
-        showToast(`Created "${newDashboard.name}" with ${templateCards.length} cards from "${template.name}"`, 'success')
-      } else {
-        showToast(`Created "${newDashboard.name}"`, 'success')
-      }
-    } catch (error) {
-      console.error('Failed to create dashboard:', error)
-      showToast('Failed to create dashboard', 'error')
-    }
+    openAddCardModal('dashboards')
   }
 
   // Load dashboard on mount and when navigating back to the page.
@@ -1044,7 +1007,7 @@ export function Dashboard() {
       <GettingStartedBanner
         onBrowseCards={openAddCardModal}
         onTryMission={openMissionSidebar}
-        onExploreDashboards={openSidebarCustomizer}
+        onExploreDashboards={() => openAddCardModal('dashboards')}
       />
 
       {/* Demo-to-local CTA — shown on console.kubestellar.io for demo visitors */}
@@ -1233,14 +1196,6 @@ export function Dashboard() {
 
       {/* Templates are now accessed via Dashboard Studio */}
 
-      {/* Create Dashboard Modal */}
-      <CreateDashboardModal
-        isOpen={isCreateDashboardOpen}
-        onClose={closeCreateDashboard}
-        onCreate={handleCreateDashboardConfirm}
-        existingNames={dashboards.map(d => d.name)}
-      />
-
       {/* Widget Export Modal — opened from nudge banner */}
       <WidgetExportModal
         isOpen={isWidgetExportOpen}
@@ -1257,11 +1212,6 @@ export function Dashboard() {
         sourceCluster={pendingDeploy?.sourceCluster ?? ''}
         targetClusters={pendingDeploy?.targetClusters ?? []}
         groupName={pendingDeploy?.groupName}
-      />
-
-      <SidebarCustomizer
-        isOpen={isSidebarCustomizerOpen}
-        onClose={closeSidebarCustomizer}
       />
     </div>
   )

--- a/web/src/components/dashboard/FloatingDashboardActions.tsx
+++ b/web/src/components/dashboard/FloatingDashboardActions.tsx
@@ -1,14 +1,12 @@
 import { useRef, useEffect } from 'react'
 import { useTranslation } from 'react-i18next'
-import { useSearchParams } from 'react-router-dom'
-import { Plus, Layout, RotateCcw, Download, Pencil, Undo2, Redo2, Palette } from 'lucide-react'
+import { Plus, Layout, RotateCcw, Download, Undo2, Redo2, Palette } from 'lucide-react'
 import { useModalState } from '../../lib/modals'
 import { useMissions } from '../../hooks/useMissions'
 import { useMobile } from '../../hooks/useMobile'
 import { useFeatureHints } from '../../hooks/useFeatureHints'
 import { ResetMode } from '../../hooks/useDashboardReset'
 import { ResetDialog } from './ResetDialog'
-import { SidebarCustomizer } from '../layout/SidebarCustomizer'
 import { DashboardHealthIndicator } from './DashboardHealthIndicator'
 
 /** Size classes for the FAB circle — desktop and mobile variants.
@@ -71,31 +69,14 @@ export function FloatingDashboardActions({
   const { t } = useTranslation()
   const { isSidebarOpen, isSidebarMinimized, isFullScreen: isMissionFullScreen } = useMissions()
   const { isMobile } = useMobile()
-  const [searchParams, setSearchParams] = useSearchParams()
   const fabHint = useFeatureHints('fab-add')
   const menu = useModalState()
   const resetDialog = useModalState()
-  const customizer = useModalState()
   const menuRef = useRef<HTMLDivElement>(null)
   const { isOpen: menuIsOpen, close: closeMenu } = menu
-  const { open: openCustomizer } = customizer
 
   // Use unified mode when onOpenCustomizer is provided
   const isUnifiedMode = !!onOpenCustomizer
-
-  // Auto-open via URL params
-  useEffect(() => {
-    if (isUnifiedMode) {
-      // Unified mode: URL params handled by parent DashboardPage
-      return
-    }
-    if (searchParams.get('customizeSidebar') === 'true') {
-      openCustomizer()
-      const cleaned = new URLSearchParams(searchParams)
-      cleaned.delete('customizeSidebar')
-      setSearchParams(cleaned, { replace: true })
-    }
-  }, [searchParams, setSearchParams, openCustomizer, isUnifiedMode])
 
   // Cmd+K shortcut — unified mode only
   useEffect(() => {
@@ -211,6 +192,7 @@ export function FloatingDashboardActions({
 
   // =========================================================================
   // Legacy mode: expandable FAB menu (for Dashboard.tsx, CustomDashboard.tsx, etc.)
+  // Opens Console Studio for customize actions.
   // =========================================================================
   return (
     <>
@@ -256,10 +238,6 @@ export function FloatingDashboardActions({
                 {t('dashboard.actions.reset')}
               </button>
             )}
-            <button role="menuitem" onClick={() => { menu.close(); customizer.open() }} className={menuBtnClass}>
-              <Pencil className="w-3.5 h-3.5" />
-              {t('dashboard.actions.customize')}
-            </button>
             {onOpenTemplates && (
               <button role="menuitem" onClick={() => { menu.close(); onOpenTemplates() }} data-tour="templates" className={menuBtnClass}>
                 <Layout className="w-3.5 h-3.5" />
@@ -294,7 +272,6 @@ export function FloatingDashboardActions({
       </div>
 
       <ResetDialog isOpen={resetDialog.isOpen} onClose={resetDialog.close} onReset={handleReset} />
-      <SidebarCustomizer isOpen={customizer.isOpen} onClose={customizer.close} />
     </>
   )
 }

--- a/web/src/components/layout/Sidebar.tsx
+++ b/web/src/components/layout/Sidebar.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef, useEffect, useCallback, lazy, Suspense } from 'react'
+import { useState, useRef, useEffect, useCallback } from 'react'
 import { useTranslation } from 'react-i18next'
 import { NavLink, useNavigate, useLocation } from 'react-router-dom'
 import { Plus, ChevronLeft, ChevronRight, CheckCircle2, AlertTriangle, WifiOff, GripVertical, X, User, Pin, PinOff, Satellite, Loader2 } from 'lucide-react'
@@ -25,11 +25,6 @@ import { useUpgradeState } from '../../hooks/useUpgradeState'
 import { STORAGE_KEY_GROUND_CONTROL_DASHBOARDS } from '../../lib/constants/storage'
 import { SIDEBAR_CONTROLS_LEFT_OFFSET_PX } from '../../lib/constants/ui'
 import { safeGetJSON } from '../../lib/utils/localStorage'
-
-// Lazy-load SidebarCustomizer — it pulls in dnd-kit and heavy UI (~50 KB)
-const SidebarCustomizer = lazy(() =>
-  import('./SidebarCustomizer').then(m => ({ default: m.SidebarCustomizer }))
-)
 
 /** Sidebar resize limits in pixels */
 const SIDEBAR_MIN_WIDTH_PX = 180
@@ -168,8 +163,6 @@ export function Sidebar() {
     document.addEventListener('mouseup', handleMouseUp)
   }
 
-  // Sidebar customizer modal state
-  const [showCustomizer, setShowCustomizer] = useState(false)
 
   // Inline rename state for custom sidebar items
   const [editingItemId, setEditingItemId] = useState<string | null>(null)
@@ -488,11 +481,7 @@ export function Sidebar() {
         {!isCollapsed && (
           <button
             onClick={() => {
-              if (dashboardContext) {
-                dashboardContext.openAddCardModal('dashboards')
-              } else {
-                setShowCustomizer(true)
-              }
+              dashboardContext?.openAddCardModal('dashboards')
             }}
             className="w-full flex items-center gap-3 px-3 py-1.5 mt-1 text-xs text-muted-foreground/60 hover:text-muted-foreground hover:bg-secondary/30 rounded-lg transition-colors"
           >
@@ -678,12 +667,6 @@ export function Sidebar() {
         />
       )}
 
-      {/* Sidebar customizer modal */}
-      {showCustomizer && (
-        <Suspense fallback={null}>
-          <SidebarCustomizer isOpen={showCustomizer} onClose={() => setShowCustomizer(false)} />
-        </Suspense>
-      )}
     </>
   )
 }


### PR DESCRIPTION
## Problem
Multiple standalone modal dialogs (Customize Sidebar, Create Dashboard) could be opened independently from Console Studio, creating a confusing UX with redundant entry points.

## Fix
Removed all standalone modal triggers. Console Studio is now the **only** way to:
- Add/manage dashboards
- Add cards
- Create custom cards/stat blocks
- Customize sidebar navigation

### Changes (3 files, -96 lines)
- **Sidebar.tsx** — 'Add more' button opens Console Studio at dashboards section
- **Dashboard.tsx** — Remove standalone CreateDashboardModal and SidebarCustomizer renders; GettingStartedBanner routes to Console Studio
- **FloatingDashboardActions.tsx** — Remove legacy Customize button, SidebarCustomizer render, and `?customizeSidebar` URL param handling

## Testing
- `npm run build` passes
- Console Studio remains fully functional (embedded mode in NavigationSection preserved)