### PR TITLE
🌱 Fix keyboard nav gaps, Playwright auth token pattern, error-resilience assertion

### DIFF
--- a/web/e2e/AIMode.spec.ts
+++ b/web/e2e/AIMode.spec.ts
@@ -28,9 +28,12 @@ async function setupAIModeTest(page: Page) {
     })
   )
 
-  // Set auth token
-  await page.goto('/login')
-  await page.evaluate(() => {
+  // Seed localStorage BEFORE any page script runs so the auth guard sees
+  // the token on first execution. page.evaluate() runs after the page has
+  // already parsed and executed scripts, which is too late for webkit/Safari
+  // where the auth redirect fires synchronously on script evaluation.
+  // page.addInitScript() injects the snippet ahead of any page code (#9096).
+  await page.addInitScript(() => {
     localStorage.setItem('token', 'test-token')
     localStorage.setItem('demo-user-onboarded', 'true')
   })

--- a/web/e2e/compliance/error-resilience.spec.ts
+++ b/web/e2e/compliance/error-resilience.spec.ts
@@ -48,8 +48,10 @@ const SETTLE_MS = 2_000
 
 // Minimum number of resilience checks that must have executed (non-skip) for
 // the aggregated report to be considered meaningful. Must match the assertion
-// in the `generate report` test.
-const MIN_EXECUTED_CHECKS = 2
+// in the `generate report` test. The suite has 5 checks; requiring at least 4
+// ensures a meaningful signal — accepting 2 (the old value) allowed 3 of 5 to
+// silently skip while still reporting green (#9722).
+const MIN_EXECUTED_CHECKS = 4
 
 // ---------------------------------------------------------------------------
 // Report persistence

--- a/web/src/components/cards/GPUNamespaceAllocations.tsx
+++ b/web/src/components/cards/GPUNamespaceAllocations.tsx
@@ -241,11 +241,23 @@ function GPUNamespaceAllocationsInternal({ config: _config }: GPUNamespaceAlloca
         {displayItems.map((ns) => (
           <div
             key={ns.namespace}
+            role="button"
+            tabIndex={0}
             onClick={() => drillToGPUNamespace(ns.namespace, {
               gpuRequested: ns.gpuRequested,
               podCount: ns.podCount,
               clusters: ns.clusters })}
-            className="p-3 rounded-lg bg-secondary/30 hover:bg-secondary/50 transition-colors cursor-pointer group"
+            onKeyDown={(e) => {
+              if (e.key === 'Enter' || e.key === ' ') {
+                e.preventDefault()
+                drillToGPUNamespace(ns.namespace, {
+                  gpuRequested: ns.gpuRequested,
+                  podCount: ns.podCount,
+                  clusters: ns.clusters })
+              }
+            }}
+            className="p-3 rounded-lg bg-secondary/30 hover:bg-secondary/50 transition-colors cursor-pointer group focus:outline-none focus-visible:ring-2 focus-visible:ring-purple-400"
+            aria-label={`View GPU namespace ${ns.namespace}`}
           >
             <div className="flex items-center gap-2 mb-2 min-w-0">
               <Box className="w-4 h-4 text-purple-400 shrink-0" />

--- a/web/src/components/cards/ResourceUsage.tsx
+++ b/web/src/components/cards/ResourceUsage.tsx
@@ -207,8 +207,17 @@ function ResourceUsageInternal() {
       </div>
 
       <div
-        className="flex-1 flex items-center justify-around cursor-pointer hover:opacity-80 transition-opacity flex-wrap gap-2"
+        role="button"
+        tabIndex={0}
+        className="flex-1 flex items-center justify-around cursor-pointer hover:opacity-80 transition-opacity flex-wrap gap-2 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-400"
+        aria-label="View resource usage details"
         onClick={handleDrillDown}
+        onKeyDown={(e) => {
+          if (e.key === 'Enter' || e.key === ' ') {
+            e.preventDefault()
+            handleDrillDown()
+          }
+        }}
       >
         <div className="flex flex-col items-center">
           <Gauge

--- a/web/src/components/cards/__tests__/PodIssues.test.tsx
+++ b/web/src/components/cards/__tests__/PodIssues.test.tsx
@@ -97,7 +97,7 @@ vi.mock('../../../lib/cards/CardComponents', () => ({
     children: React.ReactNode
     onClick: () => void
   }) => (
-    <div data-testid="card-list-item" onClick={onClick}>
+    <div role="button" tabIndex={0} data-testid="card-list-item" onClick={onClick}>
       {children}
     </div>
   ),


### PR DESCRIPTION
## Summary

Fixes three issues in a single PR:

### Fixes #9690 — Keyboard navigation gaps (accessibility)
- `GPUNamespaceAllocations.tsx`: clickable namespace rows lacked `role="button"`, `tabIndex={0}`, `onKeyDown`, and `aria-label`; added all four.
- `ResourceUsage.tsx`: clickable gauge area lacked `role="button"`, `tabIndex={0}`, `onKeyDown`, and `aria-label`; added all four.
- `PodIssues.test.tsx`: `CardListItem` mock `<div>` lacked `role="button"` and `tabIndex`; added both so the test harness matches the production component contract.

### Fixes #9721 — `AIMode.spec.ts` uses `page.evaluate()` to set auth token instead of `page.addInitScript()`
Replace `page.goto('/login') + page.evaluate(localStorage.setItem)` with `page.addInitScript()`, consistent with the pattern documented in #9096 and already applied to `Sidebar.spec.ts`, `Tour.spec.ts`, and 10+ other spec files. `page.evaluate()` runs after page scripts execute, which is too late for WebKit/Safari where the auth guard fires synchronously — causing the tests to run without a valid token and produce false positives.

### Fixes #9722 — `MIN_EXECUTED_CHECKS = 2` allows 3 of 5 resilience checks to silently skip
Raise `MIN_EXECUTED_CHECKS` from `2` to `4` in `error-resilience.spec.ts`. The suite has 5 resilience tests (API 500, timeout, partial failure, SSE disconnect, auth expiry). The old threshold of 2 meant CI remained green even when 60% of checks skipped due to backend connectivity issues. Requiring 4 of 5 to execute provides meaningful signal while still tolerating a single environment flake.

## Test plan

- [ ] Verify `AIMode.spec.ts` passes on all three Playwright browsers including WebKit
- [ ] Verify `error-resilience.spec.ts` assertion triggers correctly when backend is unavailable
- [ ] Verify keyboard Tab/Enter/Space navigation works on GPU namespace rows and resource usage gauge area
- [ ] Confirm `PodIssues.test.tsx` still passes with the updated mock

Fixes #9690, Fixes #9721, Fixes #9722