### PR TITLE
fix: cross-tab timestamp erasure, stats card truncation, compliance metrics alignment

### DIFF
--- a/web/src/components/compliance/Compliance.tsx
+++ b/web/src/components/compliance/Compliance.tsx
@@ -162,11 +162,15 @@ export function Compliance() {
         return allDemo
           ? { value: (reachableClusters.length || 1) * MOCK_CHECKS_PER_CLUSTER, sublabel: 'total checks', isDemo: true, isClickable: false }
           : { value: realData.totalChecks, sublabel: 'total checks', onClick: () => { emitComplianceDrillDown('total_checks'); drillToCompliance(undefined, { passing: realData.passing, failing: realData.failing, totalChecks: realData.totalChecks }) }, isClickable: realData.totalChecks > 0 }
-      case 'passing':
+      // #9717 — IDs must match COMPLIANCE_STAT_BLOCKS in StatsBlockDefinitions.ts
+      // ('checks_passing' / 'checks_failing'), not the generic 'passing'/'failing'
+      // used by the Operators dashboard. Mismatched IDs caused these blocks to fall
+      // through to the default case and return '-', misaligning the stats bar.
+      case 'checks_passing':
         return allDemo
           ? { value: Math.floor((reachableClusters.length || 1) * MOCK_CHECKS_PER_CLUSTER * MOCK_PASS_RATE), sublabel: 'passing', isDemo: true, isClickable: false }
           : { value: realData.passing, sublabel: 'passing', onClick: () => { emitComplianceDrillDown('passing'); drillToCompliance('passing', { passing: realData.passing, failing: realData.failing, totalChecks: realData.totalChecks }) }, isClickable: realData.passing > 0 }
-      case 'failing':
+      case 'checks_failing':
         return allDemo
           ? { value: Math.floor((reachableClusters.length || 1) * MOCK_CHECKS_PER_CLUSTER * MOCK_FAIL_RATE), sublabel: 'failing', isDemo: true, isClickable: false }
           : { value: realData.failing, sublabel: 'failing', onClick: () => { emitComplianceDrillDown('failing'); drillToCompliance('failing', { passing: realData.passing, failing: realData.failing, totalChecks: realData.totalChecks }) }, isClickable: realData.failing > 0 }

--- a/web/src/components/ui/StatsOverview.tsx
+++ b/web/src/components/ui/StatsOverview.tsx
@@ -381,7 +381,11 @@ const StatBlock = memo(function StatBlock({ block, data, hasData, isLoading, his
         /* Default numeric mode */
         <>
           <div className={`text-3xl font-bold ${isLoading ? 'text-muted-foreground/30' : valueColor}`}>{displayValue}</div>
-          {mode === 'sparkline' && !hasEnoughHistory && !isLoading && hasData && (
+          {/* #9708 — Only show "Building trend…" when there is no sublabel.
+              Both elements appearing together overflows the card height and
+              creates visual inconsistency across stat cards. The sublabel
+              (e.g. "healthy pods") is more informative and takes priority. */}
+          {mode === 'sparkline' && !hasEnoughHistory && !isLoading && hasData && !data.sublabel && (
             <div className="text-2xs text-muted-foreground/50 mt-0.5">Building trend…</div>
           )}
           {data.sublabel && <div className="text-xs text-muted-foreground">{wrapAbbreviations(data.sublabel)}</div>}

--- a/web/src/hooks/useMissionStorage.ts
+++ b/web/src/hooks/useMissionStorage.ts
@@ -240,7 +240,17 @@ export function mergeMissions(prev: Mission[], reloaded: Mission[]): Mission[] {
     }
     const localTime = new Date(local.updatedAt).getTime()
     const remoteTime = new Date(remote.updatedAt).getTime()
-    merged.push(remoteTime >= localTime ? remote : local)
+    // #9699 — When timestamps are identical (same-millisecond burst-write from
+    // Tab A), `remoteTime >= localTime` used to unconditionally pick the remote
+    // copy, silently discarding local edits made in the same millisecond.
+    // Tie-break by message count: the version with more messages contains
+    // more user actions and should win. If counts also match, prefer remote
+    // (already-persisted) as before.
+    if (remoteTime === localTime) {
+      merged.push(remote.messages.length >= local.messages.length ? remote : local)
+    } else {
+      merged.push(remoteTime > localTime ? remote : local)
+    }
   }
   for (const remote of reloaded) {
     if (!seen.has(remote.id)) {


### PR DESCRIPTION
## Summary

- **Fixes #9699**: `mergeMissions()` used `remoteTime >= localTime` for tie-breaking, so same-millisecond burst-writes (e.g. rapidly selecting multiple AI suggestions) always discarded local edits silently. Now ties are broken by message count — the copy with more messages (more user actions) wins.

- **Fixes #9708**: The "Building trend…" label and the stat card sublabel (e.g. "healthy pods") both rendered simultaneously when a sparkline stat hadn't yet accumulated enough history, overflowing the card height. "Building trend…" is now suppressed when a sublabel is present.

- **Fixes #9717**: `COMPLIANCE_STAT_BLOCKS` defines block IDs `checks_passing` and `checks_failing`, but `getDashboardStatValue()` switched on `passing`/`failing` (the Operators dashboard IDs). The mismatch caused those blocks to fall through to the default case and return `'-'`, misaligning PCI, Gatekeeper, Kyverno, Kubescape, and CVE metrics in the Security Compliance stats bar.

## Files changed

- `web/src/hooks/useMissionStorage.ts` — same-ms tie-break by message count
- `web/src/components/ui/StatsOverview.tsx` — suppress "Building trend…" when sublabel present
- `web/src/components/compliance/Compliance.tsx` — fix stat block ID mismatch (`checks_passing`/`checks_failing`)

## Test plan

- [ ] Open Mission Control in two tabs, rapidly submit suggestions in Tab A, verify Tab B reflects all assignments without erasure
- [ ] Open any dashboard with Stats Overview; confirm "Healthy" and "Pods" cards show only the sublabel (no "Building trend…" overflow)
- [ ] Navigate to `/compliance`; verify CIS, NSA, PCI, Gatekeeper, Kyverno, Kubescape, and CVE metrics all display values (not `-`) in a single aligned row