### PR TITLE
🐛 Fix build workflow failure and coverage test failures

### DIFF
--- a/web/src/hooks/useMissions.websocket-reconnect.test.tsx
+++ b/web/src/hooks/useMissions.websocket-reconnect.test.tsx
@@ -651,10 +651,11 @@ describe('mission reconnection on WebSocket open', () => {
     act(() => { result.current.connectToAgent() })
     await act(async () => { MockWebSocket.lastInstance?.simulateOpen() })
 
-    // Wait for the MISSION_RECONNECT_DELAY_MS (500ms) timer to fire
-    await act(async () => {
-      await new Promise(resolve => setTimeout(resolve, 600))
-    })
+    // Wait for the MISSION_RECONNECT_DELAY_MS (500ms) timer to fire.
+    // Fake timers are active (set in beforeEach), so we must advance the
+    // clock rather than relying on a real setTimeout that would never fire.
+    act(() => { vi.advanceTimersByTime(600) })
+    await act(async () => { await Promise.resolve() })
 
     // Check all WS send calls to see what types were sent
     const allCalls = MockWebSocket.lastInstance?.send.mock.calls ?? []


### PR DESCRIPTION
## Summary

- **Issue #9702** (Build and Deploy KC failure): The TypeScript build failure caused by corrupted MSW `handlers.ts` syntax (missing commas between array entries) was already resolved by PR #9703. This PR closes the tracking issue.
- **Issue #9704** (31 test failures in Coverage Suite): Root cause was a single test timeout cascading into 30 downstream failures.

### Root cause of #9704

The test `sends reconnection chat message after delay` (line 634 of `useMissions.websocket-reconnect.test.tsx`) called:

```ts
await act(async () => {
  await new Promise(resolve => setTimeout(resolve, 600))
})
```

However, `vi.useFakeTimers()` is active for the entire test file (set in `beforeEach`). With fake timers, `setTimeout` never fires, so the promise never resolves, hitting the 5000ms test timeout. This left the test environment in a broken state where `result.current` was null for all subsequent tests — causing 30 cascading `TypeError: Cannot read properties of null` failures.

### Fix

Replaced the real-timer promise with a fake-timer advance:

```ts
act(() => { vi.advanceTimersByTime(600) })
await act(async () => { await Promise.resolve() })
```

This correctly fires the `MISSION_RECONNECT_DELAY_MS` (500ms) timer under fake timers and then flushes the microtask queue.

## Test plan

- [ ] Coverage Suite passes with 0 failures in `useMissions.websocket-reconnect.test.tsx`
- [ ] `Build and Deploy KC` workflow continues to pass

Fixes #9702, Fixes #9704