### PR TITLE
fix: update compliance tests for Epic 5 SecOps changes

### DIFF
--- a/web/src/components/compliance/Compliance.test.tsx
+++ b/web/src/components/compliance/Compliance.test.tsx
@@ -300,10 +300,10 @@ describe('Compliance dashboard component', () => {
     const totalChecks = getStatValue('total_checks')
     expect(totalChecks.value).toBe(215)
 
-    const passing = getStatValue('passing')
+    const passing = getStatValue('checks_passing')
     expect(passing.value).toBe(165)
 
-    const failing = getStatValue('failing')
+    const failing = getStatValue('checks_failing')
     expect(failing.value).toBe(42)
 
     const warning = getStatValue('warning')

--- a/web/src/components/compliance/NISTDashboard.test.tsx
+++ b/web/src/components/compliance/NISTDashboard.test.tsx
@@ -31,12 +31,12 @@ describe('NISTDashboard', () => {
 
   it('shows overall score', async () => {
     render(<NISTDashboard />)
-    await waitFor(() => expect(screen.getByText('83%')).toBeInTheDocument())
+    await waitFor(() => expect(screen.getAllByText('83%').length).toBeGreaterThanOrEqual(1))
   })
 
   it('renders control family', async () => {
     render(<NISTDashboard />)
-    await waitFor(() => expect(screen.getByText('AC — Access Control')).toBeInTheDocument())
+    await waitFor(() => expect(screen.getAllByText('AC — Access Control').length).toBeGreaterThanOrEqual(1))
   })
 
   it('shows implemented count', async () => {


### PR DESCRIPTION
## Summary
- Update `Compliance.test.tsx` to use renamed stat block IDs (`checks_passing`/`checks_failing` instead of `passing`/`failing`) after #9717 renamed them in `StatsBlockDefinitions.ts`
- Update `NISTDashboard.test.tsx` to use `getAllByText` for elements that now appear in multiple places (filter buttons + family headings)

Fixes #9731