### PR TITLE
fix: add file locking for multi-instance token persistence

### DIFF
--- a/pkg/agent/flock_unix.go
+++ b/pkg/agent/flock_unix.go
@@ -1,0 +1,39 @@
+//go:build !windows
+
+// Platform-specific file locking using flock(2) for Unix systems.
+// Used by saveTokenUsage / loadTokenUsage to serialize access across
+// concurrent kc-agent instances (#9730).
+package agent
+
+import (
+	"fmt"
+	"os"
+	"syscall"
+)
+
+// acquireFileLock opens (or creates) the lock file at path and acquires an
+// exclusive flock. The caller MUST call the returned release function when
+// done — it releases the lock and closes the file descriptor.
+//
+// Using flock rather than an in-process mutex ensures that multiple OS
+// processes (separate kc-agent instances) are serialized, not just
+// goroutines within a single process.
+func acquireFileLock(path string) (release func(), err error) {
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR, agentFileMode)
+	if err != nil {
+		return nil, fmt.Errorf("open lock file: %w", err)
+	}
+
+	if err := syscall.Flock(int(f.Fd()), syscall.LOCK_EX); err != nil {
+		f.Close()
+		return nil, fmt.Errorf("flock: %w", err)
+	}
+
+	release = func() {
+		// Errors on unlock/close are non-fatal — the OS releases the lock
+		// when the fd is closed regardless.
+		_ = syscall.Flock(int(f.Fd()), syscall.LOCK_UN)
+		_ = f.Close()
+	}
+	return release, nil
+}

--- a/pkg/agent/flock_windows.go
+++ b/pkg/agent/flock_windows.go
@@ -1,0 +1,67 @@
+//go:build windows
+
+// Platform-specific file locking for Windows using LockFileEx.
+// Used by saveTokenUsage / loadTokenUsage to serialize access across
+// concurrent kc-agent instances (#9730).
+package agent
+
+import (
+	"fmt"
+	"os"
+	"syscall"
+	"unsafe"
+)
+
+var (
+	modkernel32      = syscall.NewLazyDLL("kernel32.dll")
+	procLockFileEx   = modkernel32.NewProc("LockFileEx")
+	procUnlockFileEx = modkernel32.NewProc("UnlockFileEx")
+)
+
+// lockfileExclusiveLock requests an exclusive lock (LOCKFILE_EXCLUSIVE_LOCK).
+const lockfileExclusiveLock = 0x00000002
+
+// acquireFileLock opens (or creates) the lock file at path and acquires an
+// exclusive lock via LockFileEx. The caller MUST call the returned release
+// function when done.
+func acquireFileLock(path string) (release func(), err error) {
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR, agentFileMode)
+	if err != nil {
+		return nil, fmt.Errorf("open lock file: %w", err)
+	}
+
+	// LockFileEx(handle, flags, reserved, nNumberOfBytesToLockLow, nNumberOfBytesToLockHigh, *overlapped)
+	ol := new(syscall.Overlapped)
+	handle := syscall.Handle(f.Fd())
+	r1, _, e1 := procLockFileEx.Call(
+		uintptr(handle),
+		uintptr(lockfileExclusiveLock),
+		0,
+		1, 0,
+		uintptr(unsafe.Pointer(ol)),
+	)
+	if r1 == 0 {
+		f.Close()
+		return nil, fmt.Errorf("LockFileEx: %w", e1)
+	}
+
+	release = func() {
+		_ = unlockFileWindows(handle, ol)
+		_ = f.Close()
+	}
+	return release, nil
+}
+
+// unlockFileWindows releases the lock obtained by LockFileEx.
+func unlockFileWindows(handle syscall.Handle, ol *syscall.Overlapped) error {
+	r1, _, e1 := procUnlockFileEx.Call(
+		uintptr(handle),
+		0,
+		1, 0,
+		uintptr(unsafe.Pointer(ol)),
+	)
+	if r1 == 0 {
+		return e1
+	}
+	return nil
+}

--- a/pkg/agent/server.go
+++ b/pkg/agent/server.go
@@ -157,6 +157,8 @@ type Server struct {
 	todayTokensIn     int64
 	todayTokensOut    int64
 	todayDate         string // YYYY-MM-DD format to detect day change
+	lastSavedIn       int64  // todayTokensIn at last saveTokenUsage, for delta computation (#9730)
+	lastSavedOut      int64  // todayTokensOut at last saveTokenUsage, for delta computation (#9730)
 	sessionTokenQuota int64  // max total tokens per session; 0 = unlimited (#9438)
 
 	// Prediction system

--- a/pkg/agent/server_ai.go
+++ b/pkg/agent/server_ai.go
@@ -1709,9 +1709,27 @@ func getTokenUsagePath() string {
 	return home + "/.kc-agent-tokens.json"
 }
 
-// loadTokenUsage loads token usage from disk on startup
+// tokenUsageLockSuffix is appended to the token usage file path to form
+// the advisory lock file path used by flock (#9730).
+const tokenUsageLockSuffix = ".lock"
+
+// loadTokenUsage loads token usage from disk on startup.
+// An advisory file lock (flock) is held during the read to prevent
+// observing a partially-written file from a concurrent instance (#9730).
 func (s *Server) loadTokenUsage() {
 	path := getTokenUsagePath()
+	lockPath := path + tokenUsageLockSuffix
+
+	release, err := acquireFileLock(lockPath)
+	if err != nil {
+		slog.Warn("could not acquire file lock for token load", "error", err)
+		// Fall through to best-effort unlocked read so a single-instance
+		// deployment is not broken by a lock failure.
+	}
+	if release != nil {
+		defer release()
+	}
+
 	data, err := os.ReadFile(path)
 	if err != nil {
 		return // File doesn't exist yet
@@ -1732,33 +1750,82 @@ func (s *Server) loadTokenUsage() {
 		s.todayTokensIn = usage.InputIn
 		s.todayTokensOut = usage.OutputOut
 		s.todayDate = today
+		// Seed lastSaved so the first saveTokenUsage computes the correct
+		// delta relative to what was already on disk (#9730).
+		s.lastSavedIn = usage.InputIn
+		s.lastSavedOut = usage.OutputOut
 		slog.Info("loaded token usage", "inputTokens", usage.InputIn, "outputTokens", usage.OutputOut)
 	}
 }
 
 // saveTokenUsage persists token usage to disk.
-// tokenFileMux serializes the entire read-snapshot-write cycle so concurrent
-// goroutines spawned by addTokenUsage cannot clobber each other (#9441).
+//
+// To prevent multi-instance data corruption (#9730), this function:
+//  1. Acquires an inter-process advisory file lock (flock / LockFileEx).
+//  2. Reads the current on-disk state (which may include writes from other
+//     instances since our last save).
+//  3. Computes the delta this instance has accumulated since its last save.
+//  4. Merges the delta into the on-disk totals.
+//  5. Writes the merged result back and releases the lock.
+//
+// tokenFileMux continues to serialize concurrent goroutines within this
+// process (#9441); flock serializes across OS processes.
 func (s *Server) saveTokenUsage() {
 	s.tokenFileMux.Lock()
 	defer s.tokenFileMux.Unlock()
 
-	s.tokenMux.RLock()
-	usage := tokenUsageData{
-		Date:      s.todayDate,
-		InputIn:   s.todayTokensIn,
-		OutputOut: s.todayTokensOut,
-	}
-	s.tokenMux.RUnlock()
+	path := getTokenUsagePath()
+	lockPath := path + tokenUsageLockSuffix
 
-	data, err := json.Marshal(usage)
+	// Acquire inter-process lock (#9730).
+	release, lockErr := acquireFileLock(lockPath)
+	if lockErr != nil {
+		slog.Warn("could not acquire file lock for token save", "error", lockErr)
+		// Fall through to best-effort unlocked write for single-instance
+		// deployments where flock is unavailable (e.g. NFS without lock
+		// daemon). The in-process tokenFileMux still prevents goroutine races.
+	}
+	if release != nil {
+		defer release()
+	}
+
+	// Snapshot current in-memory counters.
+	s.tokenMux.Lock()
+	currentDate := s.todayDate
+	currentIn := s.todayTokensIn
+	currentOut := s.todayTokensOut
+	prevSavedIn := s.lastSavedIn
+	prevSavedOut := s.lastSavedOut
+	s.tokenMux.Unlock()
+
+	// Compute the delta this instance accumulated since its last save.
+	deltaIn := currentIn - prevSavedIn
+	deltaOut := currentOut - prevSavedOut
+
+	// Read on-disk state (may contain writes from other instances).
+	var onDisk tokenUsageData
+	if diskData, err := os.ReadFile(path); err == nil {
+		_ = json.Unmarshal(diskData, &onDisk)
+	}
+
+	// Merge: if the on-disk date matches, add our delta to the on-disk
+	// totals. Otherwise start fresh for the new day.
+	merged := tokenUsageData{Date: currentDate}
+	if onDisk.Date == currentDate {
+		merged.InputIn = onDisk.InputIn + deltaIn
+		merged.OutputOut = onDisk.OutputOut + deltaOut
+	} else {
+		merged.InputIn = deltaIn
+		merged.OutputOut = deltaOut
+	}
+
+	data, err := json.Marshal(merged)
 	if err != nil {
 		return
 	}
 
-	path := getTokenUsagePath()
 	// Atomic write: write to a temp file then rename to avoid corruption
-	// when multiple goroutines persist concurrently (#6996).
+	// if the process is killed mid-write (#6996).
 	tmpPath := path + ".tmp"
 	if err := os.WriteFile(tmpPath, data, agentFileMode); err != nil {
 		slog.Warn("could not write token usage temp file", "error", err)
@@ -1766,7 +1833,26 @@ func (s *Server) saveTokenUsage() {
 	}
 	if err := os.Rename(tmpPath, path); err != nil {
 		slog.Warn("could not rename token usage temp file", "error", err)
+		return
 	}
+
+	// Update last-saved watermarks so the next save computes the correct
+	// delta. Also update in-memory counters to reflect the merged on-disk
+	// totals (includes other instances' contributions).
+	s.tokenMux.Lock()
+	s.lastSavedIn = currentIn
+	s.lastSavedOut = currentOut
+	// If another instance wrote tokens while we held the lock, our
+	// in-memory view should reflect the merged total so that getClaudeInfo
+	// reports accurate numbers.
+	if currentDate == s.todayDate {
+		s.todayTokensIn = merged.InputIn
+		s.todayTokensOut = merged.OutputOut
+		// Re-base lastSaved to merged totals so the next delta is correct.
+		s.lastSavedIn = merged.InputIn
+		s.lastSavedOut = merged.OutputOut
+	}
+	s.tokenMux.Unlock()
 }
 
 // extractCommandsFromResponse parses an LLM thinking response to find

--- a/pkg/agent/server_ai_test.go
+++ b/pkg/agent/server_ai_test.go
@@ -97,6 +97,58 @@ func TestServer_TokenUsage(t *testing.T) {
 	s.tokenMux.RUnlock()
 }
 
+// TestServer_MultiInstanceTokenMerge verifies that two simulated kc-agent
+// instances correctly merge token counts via the flock-guarded
+// read-modify-write cycle, preventing data loss (#9730).
+func TestServer_MultiInstanceTokenMerge(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "agent-multi-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tmpDir)
+	t.Setenv("HOME", tmpDir)
+
+	today := time.Now().Format("2006-01-02")
+
+	// Instance A accumulates 100/50 and saves.
+	a := &Server{todayDate: today, todayTokensIn: 100, todayTokensOut: 50}
+	a.saveTokenUsage()
+
+	// Instance B loads the file (simulating startup after A's save),
+	// then accumulates an additional 200/100 and saves.
+	b := &Server{}
+	b.loadTokenUsage()
+	b.addTokenUsage(&ProviderTokenUsage{InputTokens: 200, OutputTokens: 100})
+	b.saveTokenUsage()
+
+	// Instance A accumulates another 50/25 and saves.
+	// Without flock-based merge, A would clobber B's 200/100 contribution.
+	a.addTokenUsage(&ProviderTokenUsage{InputTokens: 50, OutputTokens: 25})
+	a.saveTokenUsage()
+
+	// Read the persisted file — it should contain the merged total:
+	//   A's contributions: 100 + 50 = 150 input, 50 + 25 = 75 output
+	//   B's contributions: 200 input, 100 output
+	//   Total: 350 input, 175 output
+	path := getTokenUsagePath()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("Failed to read usage file: %v", err)
+	}
+
+	var saved tokenUsageData
+	if err := json.Unmarshal(data, &saved); err != nil {
+		t.Fatalf("Failed to unmarshal: %v", err)
+	}
+
+	const expectedIn int64 = 350
+	const expectedOut int64 = 175
+	if saved.InputIn != expectedIn || saved.OutputOut != expectedOut {
+		t.Errorf("Expected %d/%d merged on disk, got %d/%d",
+			expectedIn, expectedOut, saved.InputIn, saved.OutputOut)
+	}
+}
+
 // TestServer_SessionTokenQuota verifies that the per-session aggregate
 // token quota rejects new prompts once the limit is reached (#9438).
 func TestServer_SessionTokenQuota(t *testing.T) {


### PR DESCRIPTION
## Summary
- Adds inter-process file locking (`flock` on Unix, `LockFileEx` on Windows) to `saveTokenUsage` and `loadTokenUsage` in `kc-agent`, preventing concurrent instances from clobbering each other's token usage data
- Implements a delta-based merge strategy: each save computes the tokens added since the last save, reads the current on-disk state under the lock, and adds the delta — so contributions from all instances are preserved
- Adds `lastSavedIn`/`lastSavedOut` watermark fields to `Server` for accurate delta computation across save cycles
- Adds `TestServer_MultiInstanceTokenMerge` test that simulates two instances writing interleaved saves and verifies the merged total is correct

Fixes #9730

## Test plan
- [x] Existing `TestServer_TokenUsage` passes (single-instance behavior unchanged)
- [x] New `TestServer_MultiInstanceTokenMerge` passes (verifies merge correctness)
- [ ] CI build/lint passes