### PR TITLE
fix: address unaddressed Copilot review findings from 48h merged PRs

### DIFF
--- a/pkg/api/handlers/benchmarks.go
+++ b/pkg/api/handlers/benchmarks.go
@@ -429,6 +429,11 @@ func (h *BenchmarkHandlers) throttle(ctx context.Context) error {
 	case <-time.After(delay):
 		return nil
 	case <-ctx.Done():
+		// Restore lastReq so the cancelled reservation does not block future
+		// requests: the slot was never used, so we clear it to zero time.
+		h.reqMu.Lock()
+		h.lastReq = time.Time{}
+		h.reqMu.Unlock()
 		return ctx.Err()
 	}
 }

--- a/pkg/api/handlers/hipaa_test.go
+++ b/pkg/api/handlers/hipaa_test.go
@@ -25,6 +25,7 @@ func TestHIPAASafeguards(t *testing.T) {
 	if err != nil {
 		t.Fatalf("request failed: %v", err)
 	}
+	defer resp.Body.Close()
 	if resp.StatusCode != 200 {
 		t.Fatalf("expected 200, got %d", resp.StatusCode)
 	}
@@ -45,6 +46,7 @@ func TestHIPAAPHINamespaces(t *testing.T) {
 	if err != nil {
 		t.Fatalf("request failed: %v", err)
 	}
+	defer resp.Body.Close()
 	if resp.StatusCode != 200 {
 		t.Fatalf("expected 200, got %d", resp.StatusCode)
 	}
@@ -65,6 +67,7 @@ func TestHIPAADataFlows(t *testing.T) {
 	if err != nil {
 		t.Fatalf("request failed: %v", err)
 	}
+	defer resp.Body.Close()
 	if resp.StatusCode != 200 {
 		t.Fatalf("expected 200, got %d", resp.StatusCode)
 	}
@@ -85,6 +88,7 @@ func TestHIPAASummary(t *testing.T) {
 	if err != nil {
 		t.Fatalf("request failed: %v", err)
 	}
+	defer resp.Body.Close()
 	if resp.StatusCode != 200 {
 		t.Fatalf("expected 200, got %d", resp.StatusCode)
 	}

--- a/pkg/api/handlers/youtube.go
+++ b/pkg/api/handlers/youtube.go
@@ -129,14 +129,15 @@ func fetchPlaylistViaInvidious() ([]PlaylistVideo, error) {
 			lastErr = fmt.Errorf("invidious %s: %w", instance, err)
 			continue
 		}
-		defer resp.Body.Close()
 
 		if resp.StatusCode != http.StatusOK {
+			resp.Body.Close()
 			lastErr = fmt.Errorf("invidious %s returned %d", instance, resp.StatusCode)
 			continue
 		}
 
 		body, err := io.ReadAll(io.LimitReader(resp.Body, maxYouTubeResponseBytes))
+		resp.Body.Close()
 		if err != nil {
 			lastErr = fmt.Errorf("invidious %s read: %w", instance, err)
 			continue

--- a/pkg/compliance/reports/pdf.go
+++ b/pkg/compliance/reports/pdf.go
@@ -168,7 +168,7 @@ func paginateLines(lines []reportLine, usableHeight float64, defaultLineHeight f
 	return pages
 }
 
-func buildPageStream(lines []reportLine, fontObj, fontBoldObj int) string {
+func buildPageStream(lines []reportLine, _, _ int) string {
 	var sb strings.Builder
 	sb.WriteString("BT\n")
 
@@ -188,16 +188,20 @@ func buildPageStream(lines []reportLine, fontObj, fontBoldObj int) string {
 		}
 
 		x := float64(pdfMargin) + line.indent
-		font := fontObj
+		// Font resource names must match /F1 (regular) and /F2 (bold) as
+		// declared in the page's /Resources /Font dictionary. Using the
+		// object-number directly (e.g. /F3) would leave the font unresolved
+		// and produce blank text in compliant PDF readers.
+		fontName := "F1"
 		if line.bold {
-			font = fontBoldObj
+			fontName = "F2"
 		}
 		size := line.size
 		if size == 0 {
 			size = pdfFontSize
 		}
 
-		sb.WriteString(fmt.Sprintf("/F%d %g Tf\n", font, size))
+		sb.WriteString(fmt.Sprintf("/%s %g Tf\n", fontName, size))
 		sb.WriteString(fmt.Sprintf("%g %g Td\n", x, y))
 		sb.WriteString(fmt.Sprintf("(%s) Tj\n", escapePDF(line.text)))
 		// Reset position for next absolute placement

--- a/pkg/compliance/sod/engine.go
+++ b/pkg/compliance/sod/engine.go
@@ -63,13 +63,21 @@ func (e *Engine) Summary() SoDSummary {
 		ByConflictType:  make(map[string]int),
 	}
 
+	// Build a rule-ID → conflict-type lookup so we can count violations by
+	// conflict type (not rules, which would always count 1 per rule regardless
+	// of how many actual violations were detected).
+	ruleConflict := make(map[string]ConflictType, len(e.rules))
+	for _, r := range e.rules {
+		ruleConflict[r.ID] = r.Conflict
+	}
+
 	conflicted := map[string]bool{}
 	for _, v := range e.violations {
 		s.BySeverity[string(v.Severity)]++
 		conflicted[v.Principal] = true
-	}
-	for _, r := range e.rules {
-		s.ByConflictType[string(r.Conflict)]++
+		if ct, ok := ruleConflict[v.RuleID]; ok {
+			s.ByConflictType[string(ct)]++
+		}
 	}
 
 	s.ConflictedPrincipals = len(conflicted)

--- a/web/netlify/functions/acmm-badge.mts
+++ b/web/netlify/functions/acmm-badge.mts
@@ -74,13 +74,26 @@ const LEVEL_NAMES: Record<number, string> = {
 
 const ALLOWED_ORIGIN_RE = /^https?:\/\/(.*\.kubestellar\.io|localhost(:\d+)?)$/;
 
-function corsHeaders(origin: string | null, cacheSeconds = BADGE_CACHE_SECONDS): Record<string, string> {
+function corsHeaders(
+  origin: string | null,
+  cacheSeconds = BADGE_CACHE_SECONDS,
+  withSWR = true,
+): Record<string, string> {
+  // stale-while-revalidate must only appear on success responses; attaching
+  // it to error responses causes intermediary caches to serve stale error
+  // badges long after the upstream recovers.
+  const cacheControl = withSWR
+    ? `public, max-age=${cacheSeconds}, stale-while-revalidate=86400`
+    : `public, max-age=${cacheSeconds}`;
   const headers: Record<string, string> = {
-    "Cache-Control": `public, max-age=${cacheSeconds}, stale-while-revalidate=86400`,
+    "Cache-Control": cacheControl,
     "Access-Control-Allow-Origin": "*",
   };
   if (origin && ALLOWED_ORIGIN_RE.test(origin)) {
     headers["Access-Control-Allow-Origin"] = origin;
+    // Vary: Origin is required so shared caches (CDNs, proxies) key responses
+    // by origin and do not serve an origin-restricted response to other clients.
+    headers["Vary"] = "Origin";
   }
   return headers;
 }
@@ -310,7 +323,7 @@ export default async (req: Request) => {
   const force = url.searchParams.get("force") === "true";
 
   if (!REPO_RE.test(repo)) {
-    const headers = corsHeaders(origin, BADGE_ERROR_CACHE_SECONDS);
+    const headers = corsHeaders(origin, BADGE_ERROR_CACHE_SECONDS, false);
     return new Response(
       JSON.stringify({
         schemaVersion: 1,
@@ -366,7 +379,7 @@ export default async (req: Request) => {
   }
 
   // ── Layer 5: last-resort "unavailable" badge ──────────────────────────
-  const headers = corsHeaders(origin, BADGE_ERROR_CACHE_SECONDS);
+  const headers = corsHeaders(origin, BADGE_ERROR_CACHE_SECONDS, false);
   return new Response(
     JSON.stringify({
       schemaVersion: 1,

--- a/web/src/components/NotFound.tsx
+++ b/web/src/components/NotFound.tsx
@@ -30,8 +30,8 @@ export default function NotFound() {
 
   const featureRequestUrl =
     `https://github.com/kubestellar/console/issues/new?` +
-    `template=feature_request.md&title=${encodeURIComponent(`Feature request: ${path}`)}&` +
-    `labels=enhancement&body=${encodeURIComponent(
+    `template=feature_request.yaml&title=${encodeURIComponent(`Feature request: ${path}`)}&` +
+    `labels=kind%2Ffeature&body=${encodeURIComponent(
       `## Feature Request\n\nI visited \`${path}\` and expected to find a page here.\n\n` +
       `### What I was looking for\n\n_Describe the feature or page you expected to see._\n\n` +
       `### Why it would be useful\n\n_How would this help your workflow?_`
@@ -42,8 +42,8 @@ export default function NotFound() {
       <div className="max-w-lg w-full text-center space-y-8">
         {/* Animated compass icon */}
         <div className="relative inline-flex items-center justify-center">
-          <div className="absolute inset-0 w-24 h-24 mx-auto rounded-full bg-gradient-to-br from-purple-500/20 to-blue-500/20 blur-xl animate-pulse" />
-          <Compass className="w-20 h-20 text-purple-400 relative animate-spin" style={{ animationDuration: '8s' }} />
+          <div className="absolute inset-0 w-24 h-24 mx-auto rounded-full bg-gradient-to-br from-purple-500/20 to-blue-500/20 blur-xl motion-safe:animate-pulse" />
+          <Compass className="w-20 h-20 text-purple-400 relative motion-safe:animate-spin" style={{ animationDuration: '8s' }} />
         </div>
 
         {/* Main message */}

--- a/web/src/components/acmm/useACMMStats.ts
+++ b/web/src/components/acmm/useACMMStats.ts
@@ -26,10 +26,8 @@ export function useACMMStats() {
   const { scan } = useACMM()
   const { level, data } = scan
   const detectedIds = data.detectedIds
-  const detectedSet = detectedIds instanceof Set ? detectedIds : new Set(detectedIds as string[] || [])
 
   const totalCriteria = ALL_CRITERIA.length
-  const detectedCount = detectedSet.size
 
   const nextLevel = level.level < MAX_LEVEL ? level.level + 1 : null
   const nextRequired = nextLevel ? level.requiredByLevel[nextLevel] ?? 0 : 0
@@ -37,6 +35,12 @@ export function useACMMStats() {
   const nextRemaining = nextRequired - nextDetected
 
   const getStatValue = useCallback((blockId: string): StatBlockValue => {
+    // Derive detectedSet inside the callback so it is always consistent with
+    // the detectedIds captured in this closure (avoids stale-closure bugs
+    // where detectedSet derived outside would reference an earlier render).
+    const detectedSet = detectedIds instanceof Set ? detectedIds : new Set(detectedIds as string[] || [])
+    const detectedCount = detectedSet.size
+
     switch (blockId) {
       case 'acmm_level':
         return {
@@ -78,7 +82,7 @@ export function useACMMStats() {
       default:
         return { value: '-' }
     }
-  }, [level, detectedCount, totalCriteria, nextLevel, nextDetected, nextRemaining, nextRequired, detectedIds])
+  }, [level, totalCriteria, nextLevel, nextDetected, nextRemaining, nextRequired, detectedIds])
 
   return { getStatValue }
 }

--- a/web/src/components/cards/GPUNamespaceAllocations.tsx
+++ b/web/src/components/cards/GPUNamespaceAllocations.tsx
@@ -257,7 +257,7 @@ function GPUNamespaceAllocationsInternal({ config: _config }: GPUNamespaceAlloca
               }
             }}
             className="p-3 rounded-lg bg-secondary/30 hover:bg-secondary/50 transition-colors cursor-pointer group focus:outline-none focus-visible:ring-2 focus-visible:ring-purple-400"
-            aria-label={`View GPU namespace ${ns.namespace}`}
+            aria-label={t('cards:gpuNamespaceAllocations.viewNamespaceAria', { namespace: ns.namespace })}
           >
             <div className="flex items-center gap-2 mb-2 min-w-0">
               <Box className="w-4 h-4 text-purple-400 shrink-0" />

--- a/web/src/components/cards/IframeEmbed.tsx
+++ b/web/src/components/cards/IframeEmbed.tsx
@@ -128,16 +128,16 @@ export function IframeEmbed({ config }: { config?: IframeEmbedConfig }) {
     setLastRefresh(new Date())
   }, [url])
 
-  // Auto-refresh
+  // Auto-refresh (disabled in demo mode because the iframe itself is disabled)
   useEffect(() => {
-    if (refreshInterval <= 0 || !url) return
+    if (isDemoMode || refreshInterval <= 0 || !url) return
 
     const interval = setInterval(() => {
       handleRefresh()
     }, refreshInterval * 1000)
 
     return () => clearInterval(interval)
-  }, [refreshInterval, url, handleRefresh])
+  }, [isDemoMode, refreshInterval, url, handleRefresh])
 
   const handleLoad = () => {
     setIsLoading(false)
@@ -371,7 +371,7 @@ export function IframeEmbed({ config }: { config?: IframeEmbedConfig }) {
               >
                 <Globe className="w-10 h-10 opacity-40" />
                 <span className="text-sm font-medium">{title}</span>
-                <span className="text-xs opacity-60">Demo mode — iframe disabled</span>
+                <span className="text-xs opacity-60">{t('cards:iframeEmbed.demoModePlaceholder')}</span>
               </div>
             )}
 

--- a/web/src/components/cards/ResourceUsage.tsx
+++ b/web/src/components/cards/ResourceUsage.tsx
@@ -210,7 +210,7 @@ function ResourceUsageInternal() {
         role="button"
         tabIndex={0}
         className="flex-1 flex items-center justify-around cursor-pointer hover:opacity-80 transition-opacity flex-wrap gap-2 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-400"
-        aria-label="View resource usage details"
+        aria-label={t('cards:resourceUsage.viewDetailsAria')}
         onClick={handleDrillDown}
         onKeyDown={(e) => {
           if (e.key === 'Enter' || e.key === ' ') {

--- a/web/src/components/compliance/ChangeControlAudit.tsx
+++ b/web/src/components/compliance/ChangeControlAudit.tsx
@@ -118,7 +118,7 @@ export function ChangeControlAuditContent() {
             <p className="text-sm text-zinc-400">SOX/PCI-compliant change tracking with approval workflows</p>
           </div>
         </div>
-        <button onClick={fetchData} className="text-zinc-400 hover:text-zinc-200 p-2 rounded-lg hover:bg-zinc-700/50 transition-colors"><RefreshCw className="w-4 h-4" /></button>
+        <button onClick={fetchData} type="button" aria-label="Refresh change control data" className="text-zinc-400 hover:text-zinc-200 p-2 rounded-lg hover:bg-zinc-700/50 transition-colors"><RefreshCw className="w-4 h-4" /></button>
       </div>
 
       {summary && (
@@ -132,7 +132,7 @@ export function ChangeControlAuditContent() {
             <div className="flex items-baseline gap-2">
               <p className={`text-2xl font-bold ${riskColor(summary.risk_score)}`}>{summary.risk_score}</p>
               <span className={`text-xs px-1.5 py-0.5 rounded ${riskBg(summary.risk_score)} ${riskColor(summary.risk_score)}`}>
-                {summary.risk_score >= 70 ? 'HIGH' : summary.risk_score >= 40 ? 'MEDIUM' : 'LOW'}/100
+                {summary.risk_score >= 70 ? 'HIGH' : summary.risk_score >= 40 ? 'MEDIUM' : summary.risk_score >= 20 ? 'LOW-MEDIUM' : 'LOW'}/100
               </span>
             </div>
           </div>

--- a/web/src/components/compliance/SegregationOfDuties.tsx
+++ b/web/src/components/compliance/SegregationOfDuties.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useMemo } from 'react'
+import { useState, useEffect, useMemo, useCallback } from 'react'
 import { UnifiedDashboard } from '../../lib/unified/dashboard/UnifiedDashboard'
 import { sodDashboardConfig } from '../../config/dashboards/segregation-of-duties'
 import {
@@ -56,7 +56,7 @@ export function SegregationOfDutiesContent() {
   const [filterSeverity, setFilterSeverity] = useState('all')
   const [activeTab, setActiveTab] = useState<'violations' | 'principals' | 'rules'>('violations')
 
-  const fetchData = async () => {
+  const fetchData = useCallback(async () => {
     setLoading(true)
     setError(null)
     try {
@@ -76,9 +76,9 @@ export function SegregationOfDutiesContent() {
     } finally {
       setLoading(false)
     }
-  }
+  }, [])
 
-  useEffect(() => { fetchData() }, [])
+  useEffect(() => { fetchData() }, [fetchData])
 
   const filteredViolations = useMemo(() =>
     filterSeverity === 'all' ? violations : violations.filter(v => v.severity === filterSeverity),
@@ -104,7 +104,7 @@ export function SegregationOfDutiesContent() {
             <p className="text-sm text-zinc-400">Detect conflicting privilege assignments across RBAC roles</p>
           </div>
         </div>
-        <button onClick={fetchData} className="text-zinc-400 hover:text-zinc-200 p-2 rounded-lg hover:bg-zinc-700/50 transition-colors"><RefreshCw className="w-4 h-4" /></button>
+        <button onClick={fetchData} type="button" aria-label="Refresh segregation of duties data" className="text-zinc-400 hover:text-zinc-200 p-2 rounded-lg hover:bg-zinc-700/50 transition-colors"><RefreshCw className="w-4 h-4" /></button>
       </div>
 
       {summary && (
@@ -140,6 +140,7 @@ export function SegregationOfDutiesContent() {
                 <option value="critical">Critical</option>
                 <option value="high">High</option>
                 <option value="medium">Medium</option>
+                <option value="low">Low</option>
               </Select>
             </div>
           </div>

--- a/web/src/components/missions/browser/helpers.ts
+++ b/web/src/components/missions/browser/helpers.ts
@@ -10,7 +10,15 @@ import type { TreeNode } from './types'
  *   3. Slugified title (lowercase, non-alphanum → hyphens, dedupe, trim)
  */
 export function getMissionSlug(mission: MissionExport): string {
-  if (mission.name) return mission.name
+  if (mission.name) {
+    // Normalize the name field the same way as the title-based fallback to
+    // ensure consistent, URL-safe slugs (lowercase, non-alphanum → hyphens).
+    return mission.name
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, '-')
+      .replace(/-+/g, '-')
+      .replace(/^-|-$/g, '')
+  }
   if (mission.missionClass === 'install' && mission.cncfProject) {
     return `install-${mission.cncfProject.toLowerCase()}`
   }

--- a/web/src/locales/en/cards.json
+++ b/web/src/locales/en/cards.json
@@ -2408,7 +2408,8 @@
     "podCount_other": "{{count}} pods",
     "gpuCountLabel": "{{count}} GPUs",
     "gpuCountLabel_one": "{{count}} GPU",
-    "gpuCountLabel_other": "{{count}} GPUs"
+    "gpuCountLabel_other": "{{count}} GPUs",
+    "viewNamespaceAria": "View GPU namespace {{namespace}}"
   },
   "gpuOverview": {
     "noReachableClusters": "No reachable clusters",
@@ -2722,7 +2723,8 @@
     "totalRAM": "Total RAM",
     "cores": "cores",
     "totalLabel": "Total {{label}}",
-    "overcommitted": "{{used}}/{{total}} overcommitted"
+    "overcommitted": "{{used}}/{{total}} overcommitted",
+    "viewDetailsAria": "View resource usage details"
   },
   "serviceExports": {
     "loadFailed": "Failed to load service exports",
@@ -3633,7 +3635,8 @@
     "clickSettings": "Click settings to add a URL",
     "autoRefreshEvery": "Auto-refreshes every {{seconds}}s",
     "titlePlaceholder": "My Dashboard",
-    "closeSettingsAria": "Close settings"
+    "closeSettingsAria": "Close settings",
+    "demoModePlaceholder": "Demo mode — iframe disabled"
   },
   "namespaceOverview": {
     "noNamespaces": "No namespaces",

--- a/web/src/mocks/handlers.ts
+++ b/web/src/mocks/handlers.ts
@@ -1072,7 +1072,7 @@ export const handlers = [
   http.get('/api/compliance/stig/benchmarks', async () => {
     await delay(150)
     return HttpResponse.json([
-      { id: 'kubernetes-stig-v2r1', title: 'Kubernetes STIG', version: 'V2R1', release: 'Release 1', status: 'current', profile: 'MAC-I Classified', total_rules: 95, findings_count: 12 },
+      { id: 'kubernetes-stig-v2r1', title: 'Kubernetes STIG', version: 'V2R1', release: 'Release 1', status: 'compliant', profile: 'MAC-I Classified', total_rules: 95, findings_count: 12 },
     ])
   }),
 


### PR DESCRIPTION
## Summary

Triages and fixes all actionable unaddressed Copilot inline review comments from PRs merged in the last 48 hours. Skipped test-coverage gaps, architectural suggestions, and items already fixed in main.

## Changes by source PR

### #9685 — `pkg/compliance/reports/pdf.go`
- Font resource names in `buildPageStream` now use `/F1`/`/F2` (matching the page `/Resources` dict) instead of the PDF object numbers `/F3`/`/F4`, which caused blank text in compliant readers.

### #9692 — `pkg/compliance/sod/engine.go`
- `ByConflictType` in `Summary()` now iterates **violations** (not rules) and looks up conflict type via `RuleID`, producing accurate per-type violation counts instead of always 1 per rule.

### #9692 — `web/src/components/compliance/SegregationOfDuties.tsx`
- Wrapped `fetchData` in `useCallback` and added it to the `useEffect` dep array (exhaustive-deps lint fix).
- Added missing `low` option to the severity filter.
- Added `aria-label` and `type="button"` to the refresh button.

### #9691 — `web/src/components/compliance/ChangeControlAudit.tsx`
- Added a `LOW-MEDIUM` (20–39) tier to the risk score label so it aligns with the four-tier `riskColor()` function.
- Added `aria-label` and `type="button"` to the refresh button.

### #9573 — `pkg/api/handlers/youtube.go`
- Close `resp.Body` explicitly before each `continue` in the Invidious retry loop instead of using `defer` (which keeps all bodies open until the function returns).

### #9695 — `pkg/api/handlers/hipaa_test.go`
- Added `defer resp.Body.Close()` to all four HIPAA test cases.

### #9554 — `pkg/api/handlers/benchmarks.go`
- On `ctx.Done()` inside `throttle()`, reset `h.lastReq` to zero so a cancelled slot reservation does not block future requests.

### #9566 — `web/netlify/functions/acmm-badge.mts`
- Added `Vary: Origin` header when a specific origin is matched.
- Suppress `stale-while-revalidate` on error responses.

### #9572 — `web/src/components/cards/IframeEmbed.tsx`
- Guard auto-refresh `useEffect` with `isDemoMode`.
- Replace hardcoded English demo-mode string with i18n `t()` call; key added to `cards.json`.

### #9684 — `web/src/components/NotFound.tsx`
- Fix GitHub issue URL: template `feature_request.md` → `feature_request.yaml`; label `enhancement` → `kind/feature`.
- Wrap animations in `motion-safe:` Tailwind prefix.

### #9716 — `web/src/mocks/handlers.ts`
- STIG benchmark demo `status: 'current'` → `'compliant'` to match `STIGDashboard` render condition.

### #9723 — `web/src/components/cards/ResourceUsage.tsx` + `GPUNamespaceAllocations.tsx`
- Replace hardcoded English `aria-label` strings with `t(...)` calls; added keys to `locales/en/cards.json`.

### #9554 — `web/src/components/acmm/useACMMStats.ts`
- Move `detectedSet` derivation inside `useCallback` body to eliminate stale-closure risk.

### #9706 — `web/src/components/missions/browser/helpers.ts`
- Apply lowercase + sanitize normalization to `mission.name` fast-path in `getMissionSlug`.

## Items verified already fixed in main
- `evaluator.go` — `deriveControlStatus` 4-arg, `StatusError` counting, `c.UserContext()` all correct ✓
- `ComplianceFrameworks.tsx` — auto-select `useEffect` already correct ✓
- `useKServeStatus.ts` — `Number.isFinite` guards already in place ✓
- `KServeStatus.tsx` — empty-state branch already distinguishes search vs no-search ✓
- `Compliance.tsx` — stat IDs already use `checks_passing`/`checks_failing` ✓
- `useMissionStorage.ts` — JSON parse failure already seeds demo missions ✓

## Test plan
- [ ] `go build ./...` passes (verified locally)
- [ ] CI build/lint passes
- [ ] STIG dashboard demo mode shows green checkmark for Kubernetes STIG
- [ ] IframeEmbed demo mode shows localized placeholder, no auto-refresh timer fires
- [ ] NotFound animations suppressed under `prefers-reduced-motion: reduce`
- [ ] SegregationOfDuties Low severity filter appears and filters correctly
- [ ] PDF compliance report text renders (not blank)