### PR TITLE
fix: extract hardcoded route paths to route constants

### DIFF
--- a/web/src/components/cards/drasi/DrasiReactiveGraph.tsx
+++ b/web/src/components/cards/drasi/DrasiReactiveGraph.tsx
@@ -27,6 +27,7 @@ import { AnimatePresence } from 'framer-motion'
 import { Search, Plus, Settings, Rocket, Code2, Zap, Server } from 'lucide-react'
 import { useNavigate } from 'react-router-dom'
 import { useTranslation } from 'react-i18next'
+import { getMissionRoute } from '../../../config/routes'
 import { ConfirmDialog } from '../../../lib/modals'
 import { useCardDemoState, useReportCardDataState } from '../CardDataContext'
 import { useDrasiResources } from '../../../hooks/useDrasiResources'
@@ -837,7 +838,7 @@ export function DrasiReactiveGraph() {
           </div>
           <button
             type="button"
-            onClick={() => navigate('/missions/install-drasi')}
+            onClick={() => navigate(getMissionRoute('install-drasi'))}
             className="shrink-0 px-2.5 py-1 text-[11px] rounded bg-cyan-600 hover:bg-cyan-500 text-white flex items-center gap-1.5"
           >
             <Rocket className="w-3 h-3" />

--- a/web/src/components/enterprise/ComingSoon.tsx
+++ b/web/src/components/enterprise/ComingSoon.tsx
@@ -4,6 +4,7 @@
 import { useLocation } from 'react-router-dom'
 import { Construction, ArrowLeft } from 'lucide-react'
 import { useNavigate } from 'react-router-dom'
+import { ROUTES } from '../../config/routes'
 
 export default function ComingSoon() {
   const navigate = useNavigate()
@@ -20,7 +21,7 @@ export default function ComingSoon() {
           This compliance vertical is under development and will be available in a future release.
         </p>
         <button
-          onClick={() => navigate('/enterprise')}
+          onClick={() => navigate(ROUTES.ENTERPRISE)}
           className="inline-flex items-center gap-2 px-4 py-2 rounded-lg bg-purple-600 hover:bg-purple-500 text-white text-sm transition-colors"
         >
           <ArrowLeft className="w-4 h-4" />


### PR DESCRIPTION
## Summary
- Replace hardcoded `'/missions/install-drasi'` in `DrasiReactiveGraph.tsx` with `getMissionRoute('install-drasi')` from `config/routes.ts`
- Replace hardcoded `'/enterprise'` in `ComingSoon.tsx` with `ROUTES.ENTERPRISE` from `config/routes.ts`
- The third finding (EnterpriseSidebar `navigate('/')`) was already resolved in a prior refactor

Fixes #9742