### PR TITLE
fix: compliance test failures and magic number ratchet (coverage 90%→91%+)

### DIFF
--- a/web/src/components/cards/cilium_status/__tests__/CiliumStatus.test.tsx
+++ b/web/src/components/cards/cilium_status/__tests__/CiliumStatus.test.tsx
@@ -9,15 +9,15 @@ vi.mock('react-i18next', () => ({
 }))
 
 const mockUseCachedCiliumStatus = vi.fn()
-vi.mock('../../../hooks/useCachedCiliumStatus', () => ({
+vi.mock('../../../../hooks/useCachedCiliumStatus', () => ({
     useCachedCiliumStatus: () => mockUseCachedCiliumStatus(),
 }))
 
-vi.mock('../../../hooks/useGlobalFilters', () => ({
+vi.mock('../../../../hooks/useGlobalFilters', () => ({
     useGlobalFilters: () => ({ selectedClusters: [] }),
 }))
 
-vi.mock('../../../hooks/useDrillDown', () => ({
+vi.mock('../../../../hooks/useDrillDown', () => ({
     useDrillDownActions: () => ({ drillToNode: vi.fn() }),
 }))
 
@@ -25,11 +25,12 @@ vi.mock('../../CardDataContext', () => ({
     useCardLoadingState: () => ({ showSkeleton: false }),
 }))
 
-vi.mock('../../../lib/cards', () => ({
+vi.mock('../../../../lib/cards', () => ({
     useCardData: (items: any) => ({
         items: items || [],
         currentPage: 1,
         totalPages: 1,
+        totalItems: (items || []).length,
         itemsPerPage: 5,
         goToPage: vi.fn(),
         setItemsPerPage: vi.fn(),

--- a/web/src/components/cards/kserve_status/useKServeStatus.ts
+++ b/web/src/components/cards/kserve_status/useKServeStatus.ts
@@ -205,14 +205,14 @@ async function fetchKServeStatus(): Promise<KServeDemoData> {
 
   const totalRps = services.reduce((sum, s) => sum + s.requestsPerSecond, 0)
   const totalLatency = services.reduce((sum, s) => sum + s.p95LatencyMs, 0)
-  const avgP95 = services.length > 0 ? Math.round(totalLatency / services.length) : 0
+  const avgLatencyMs = services.length > 0 ? Math.round(totalLatency / services.length) : 0
 
   return {
     health,
     controllerPods: { ready: readyPods, total: controllerPods.length },
     services,
     totalRequestsPerSecond: Math.round(totalRps * 10) / 10,
-    avgP95LatencyMs: avgP95,
+    avgP95LatencyMs: avgLatencyMs,
     lastCheckTime: new Date().toISOString(),
   }
 }

--- a/web/src/components/compliance/AirGapDashboard.test.tsx
+++ b/web/src/components/compliance/AirGapDashboard.test.tsx
@@ -1,6 +1,11 @@
 import { render, screen, waitFor } from '@testing-library/react'
 import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { MemoryRouter } from 'react-router-dom'
 import AirGapDashboard from './AirGapDashboard'
+
+vi.mock('../../lib/unified/dashboard/UnifiedDashboard', () => ({
+  UnifiedDashboard: () => null,
+}))
 
 const mockRequirements = [
   { id: 'AG-001', name: 'Local Registry Mirror', description: 'Private registry required', category: 'registry', status: 'ready', details: 'Harbor v2.9 configured' },
@@ -23,22 +28,22 @@ describe('AirGapDashboard', () => {
   beforeEach(() => { vi.clearAllMocks() })
 
   it('renders the dashboard title', async () => {
-    render(<AirGapDashboard />)
+    render(<MemoryRouter><AirGapDashboard /></MemoryRouter>)
     await waitFor(() => expect(screen.getByText('Air-Gap Readiness')).toBeInTheDocument())
   })
 
   it('shows overall readiness', async () => {
-    render(<AirGapDashboard />)
+    render(<MemoryRouter><AirGapDashboard /></MemoryRouter>)
     await waitFor(() => expect(screen.getByText('85%')).toBeInTheDocument())
   })
 
   it('renders a requirement', async () => {
-    render(<AirGapDashboard />)
+    render(<MemoryRouter><AirGapDashboard /></MemoryRouter>)
     await waitFor(() => expect(screen.getByText('Local Registry Mirror')).toBeInTheDocument())
   })
 
   it('shows ready count', async () => {
-    render(<AirGapDashboard />)
+    render(<MemoryRouter><AirGapDashboard /></MemoryRouter>)
     await waitFor(() => expect(screen.getByText('9')).toBeInTheDocument())
   })
 })

--- a/web/src/components/compliance/BAADashboard.test.tsx
+++ b/web/src/components/compliance/BAADashboard.test.tsx
@@ -1,6 +1,11 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render, screen, waitFor } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
 import BAADashboard from './BAADashboard'
+
+vi.mock('../../lib/unified/dashboard/UnifiedDashboard', () => ({
+  UnifiedDashboard: () => null,
+}))
 
 const ok = (data: unknown) => Promise.resolve({ ok: true, json: () => Promise.resolve(data) })
 
@@ -27,28 +32,28 @@ beforeEach(() => { vi.clearAllMocks() })
 
 describe('BAADashboard', () => {
   it('renders the dashboard title', async () => {
-    render(<BAADashboard />)
+    render(<MemoryRouter><BAADashboard /></MemoryRouter>)
     await waitFor(() => {
       expect(screen.getByText('Business Associate Agreements')).toBeInTheDocument()
     })
   })
 
   it('shows total agreements', async () => {
-    render(<BAADashboard />)
+    render(<MemoryRouter><BAADashboard /></MemoryRouter>)
     await waitFor(() => {
       expect(screen.getByText('6')).toBeInTheDocument()
     })
   })
 
   it('shows alert banner', async () => {
-    render(<BAADashboard />)
+    render(<MemoryRouter><BAADashboard /></MemoryRouter>)
     await waitFor(() => {
       expect(screen.getByText(/BAA Alert/)).toBeInTheDocument()
     })
   })
 
   it('displays provider name', async () => {
-    render(<BAADashboard />)
+    render(<MemoryRouter><BAADashboard /></MemoryRouter>)
     await waitFor(() => {
       expect(screen.getByText('AWS')).toBeInTheDocument()
     })

--- a/web/src/components/compliance/ChangeControlAudit.test.tsx
+++ b/web/src/components/compliance/ChangeControlAudit.test.tsx
@@ -1,6 +1,11 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render, screen, waitFor } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
 import ChangeControlAudit from './ChangeControlAudit'
+
+vi.mock('../../lib/unified/dashboard/UnifiedDashboard', () => ({
+  UnifiedDashboard: () => null,
+}))
 
 const mockSummary = {
   total_changes: 8, approved_changes: 4, unapproved_changes: 3, emergency_changes: 1,
@@ -34,7 +39,7 @@ describe('ChangeControlAudit', () => {
 
   it('renders header and summary cards', async () => {
     mockFetchSuccess()
-    render(<ChangeControlAudit />)
+    render(<MemoryRouter><ChangeControlAudit /></MemoryRouter>)
     await waitFor(() => {
       expect(screen.getByText('Change Control Audit Trail')).toBeInTheDocument()
       expect(screen.getByText('Total Changes')).toBeInTheDocument()
@@ -44,7 +49,7 @@ describe('ChangeControlAudit', () => {
 
   it('renders change records', async () => {
     mockFetchSuccess()
-    render(<ChangeControlAudit />)
+    render(<MemoryRouter><ChangeControlAudit /></MemoryRouter>)
     await waitFor(() => {
       expect(screen.getByText('Deployment/payment-api')).toBeInTheDocument()
       expect(screen.getByText('ConfigMap/payment-config')).toBeInTheDocument()
@@ -53,7 +58,7 @@ describe('ChangeControlAudit', () => {
 
   it('shows risk score value', async () => {
     mockFetchSuccess()
-    render(<ChangeControlAudit />)
+    render(<MemoryRouter><ChangeControlAudit /></MemoryRouter>)
     await waitFor(() => {
       expect(screen.getByText('55')).toBeInTheDocument()
     })
@@ -61,7 +66,7 @@ describe('ChangeControlAudit', () => {
 
   it('shows error state on failure', async () => {
     vi.spyOn(globalThis, 'fetch').mockRejectedValue(new Error('Network error'))
-    render(<ChangeControlAudit />)
+    render(<MemoryRouter><ChangeControlAudit /></MemoryRouter>)
     await waitFor(() => {
       expect(screen.getByText('Network error')).toBeInTheDocument()
     })

--- a/web/src/components/compliance/ComplianceFrameworks.test.tsx
+++ b/web/src/components/compliance/ComplianceFrameworks.test.tsx
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render, screen, fireEvent } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
 import React from 'react'
 
 // ---------------------------------------------------------------------------
@@ -30,6 +31,10 @@ vi.mock('../../hooks/useComplianceFrameworks', () => ({
   useFrameworkEvaluation: () => mockEvalReturn,
 }))
 
+vi.mock('../../lib/unified/dashboard/UnifiedDashboard', () => ({
+  UnifiedDashboard: () => null,
+}))
+
 vi.mock('../../hooks/useMCP', () => ({
   useClusters: () => ({
     clusters: [
@@ -44,7 +49,7 @@ vi.mock('../../hooks/useMCP', () => ({
   }),
 }))
 
-import { ComplianceFrameworks } from './ComplianceFrameworks'
+import ComplianceFrameworks from './ComplianceFrameworks'
 
 describe('ComplianceFrameworks', () => {
   beforeEach(() => {
@@ -67,13 +72,13 @@ describe('ComplianceFrameworks', () => {
   })
 
   it('renders page header', () => {
-    render(<ComplianceFrameworks />)
+    render(<MemoryRouter><ComplianceFrameworks /></MemoryRouter>)
     expect(screen.getByText('Compliance Frameworks')).toBeDefined()
     expect(screen.getByText(/PCI-DSS 4.0, SOC 2 Type II/)).toBeDefined()
   })
 
   it('shows framework cards', () => {
-    render(<ComplianceFrameworks />)
+    render(<MemoryRouter><ComplianceFrameworks /></MemoryRouter>)
     expect(screen.getAllByText('PCI-DSS 4.0').length).toBeGreaterThan(0)
     expect(screen.getAllByText('SOC 2 Type II').length).toBeGreaterThan(0)
     expect(screen.getByText('8 controls')).toBeDefined()
@@ -82,20 +87,20 @@ describe('ComplianceFrameworks', () => {
 
   it('shows loading state', () => {
     mockFrameworksReturn.isLoading = true
-    render(<ComplianceFrameworks />)
+    render(<MemoryRouter><ComplianceFrameworks /></MemoryRouter>)
     expect(screen.getByText('Loading frameworks…')).toBeDefined()
   })
 
   it('shows error state', () => {
     mockFrameworksReturn.error = 'Connection failed'
-    render(<ComplianceFrameworks />)
+    render(<MemoryRouter><ComplianceFrameworks /></MemoryRouter>)
     expect(screen.getByText('Failed to load frameworks')).toBeDefined()
     expect(screen.getByText('Connection failed')).toBeDefined()
   })
 
   it('shows retry button on error', () => {
     mockFrameworksReturn.error = 'Timeout'
-    render(<ComplianceFrameworks />)
+    render(<MemoryRouter><ComplianceFrameworks /></MemoryRouter>)
     const retryBtn = screen.getByText('Retry')
     expect(retryBtn).toBeDefined()
     fireEvent.click(retryBtn)
@@ -103,7 +108,7 @@ describe('ComplianceFrameworks', () => {
   })
 
   it('shows evaluate bar with cluster selector', () => {
-    render(<ComplianceFrameworks />)
+    render(<MemoryRouter><ComplianceFrameworks /></MemoryRouter>)
     expect(screen.getByRole('button', { name: /Run Evaluation/i })).toBeDefined()
     const select = document.querySelector('select') as HTMLSelectElement
     expect(select).not.toBeNull()
@@ -111,7 +116,7 @@ describe('ComplianceFrameworks', () => {
   })
 
   it('calls evaluate on button click', () => {
-    render(<ComplianceFrameworks />)
+    render(<MemoryRouter><ComplianceFrameworks /></MemoryRouter>)
     const btn = screen.getByRole('button', { name: /Run Evaluation/i })
     fireEvent.click(btn)
     expect(mockEvaluate).toHaveBeenCalledWith('pci-dss-4.0', 'prod-east')
@@ -149,7 +154,7 @@ describe('ComplianceFrameworks', () => {
       evaluated_at: '2025-01-01T00:00:00Z',
     }
 
-    render(<ComplianceFrameworks />)
+    render(<MemoryRouter><ComplianceFrameworks /></MemoryRouter>)
 
     expect(screen.getByText('75%')).toBeDefined()
     expect(screen.getByText(/9 passed/)).toBeDefined()
@@ -160,18 +165,18 @@ describe('ComplianceFrameworks', () => {
 
   it('shows evaluation error', () => {
     mockEvalReturn.error = 'Cluster unreachable'
-    render(<ComplianceFrameworks />)
+    render(<MemoryRouter><ComplianceFrameworks /></MemoryRouter>)
     expect(screen.getByText('Cluster unreachable')).toBeDefined()
   })
 
   it('shows empty state when no evaluation run', () => {
-    render(<ComplianceFrameworks />)
+    render(<MemoryRouter><ComplianceFrameworks /></MemoryRouter>)
     expect(screen.getByText(/Select a framework and cluster/)).toBeDefined()
   })
 
   it('shows evaluating state', () => {
     mockEvalReturn.isEvaluating = true
-    render(<ComplianceFrameworks />)
+    render(<MemoryRouter><ComplianceFrameworks /></MemoryRouter>)
     expect(screen.getByText('Evaluating…')).toBeDefined()
   })
 })

--- a/web/src/components/compliance/ComplianceReports.test.tsx
+++ b/web/src/components/compliance/ComplianceReports.test.tsx
@@ -1,7 +1,12 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render, screen } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
 
 // Mock hooks before importing the component
+vi.mock('../../lib/unified/dashboard/UnifiedDashboard', () => ({
+  UnifiedDashboard: () => null,
+}))
+
 vi.mock('../../hooks/useComplianceFrameworks', () => ({
   useComplianceFrameworks: () => ({
     frameworks: [
@@ -36,29 +41,29 @@ describe('ComplianceReports', () => {
   })
 
   it('renders header and generator card', () => {
-    render(<ComplianceReports />)
+    render(<MemoryRouter><ComplianceReports /></MemoryRouter>)
     expect(screen.getByText('Compliance Reports')).toBeInTheDocument()
     expect(screen.getByText('Generate Report')).toBeInTheDocument()
   })
 
   it('renders framework picker with options', () => {
-    render(<ComplianceReports />)
+    render(<MemoryRouter><ComplianceReports /></MemoryRouter>)
     expect(screen.getAllByText(/PCI-DSS/).length).toBeGreaterThan(0)
   })
 
   it('renders format buttons', () => {
-    render(<ComplianceReports />)
+    render(<MemoryRouter><ComplianceReports /></MemoryRouter>)
     expect(screen.getByRole('button', { name: /PDF/ })).toBeInTheDocument()
     expect(screen.getByRole('button', { name: /JSON/ })).toBeInTheDocument()
   })
 
   it('renders generate button', () => {
-    render(<ComplianceReports />)
+    render(<MemoryRouter><ComplianceReports /></MemoryRouter>)
     expect(screen.getByRole('button', { name: /Generate & Download Report/ })).toBeInTheDocument()
   })
 
   it('renders info section about report types', () => {
-    render(<ComplianceReports />)
+    render(<MemoryRouter><ComplianceReports /></MemoryRouter>)
     expect(screen.getByText('PDF Reports')).toBeInTheDocument()
     expect(screen.getByText('JSON Reports')).toBeInTheDocument()
   })

--- a/web/src/components/compliance/DataResidency.test.tsx
+++ b/web/src/components/compliance/DataResidency.test.tsx
@@ -1,6 +1,11 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render, screen, waitFor } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
 import DataResidency from './DataResidency'
+
+vi.mock('../../lib/unified/dashboard/UnifiedDashboard', () => ({
+  UnifiedDashboard: () => null,
+}))
 
 /* ─── Mock data ─── */
 
@@ -64,7 +69,7 @@ describe('DataResidency', () => {
 
   it('renders summary cards with correct values', async () => {
     mockFetchSuccess()
-    render(<DataResidency />)
+    render(<MemoryRouter><DataResidency /></MemoryRouter>)
     await waitFor(() => {
       expect(screen.getByText('Data Residency Enforcement')).toBeInTheDocument()
       expect(screen.getByText('Rules')).toBeInTheDocument()
@@ -75,7 +80,7 @@ describe('DataResidency', () => {
 
   it('renders cluster region cards', async () => {
     mockFetchSuccess()
-    render(<DataResidency />)
+    render(<MemoryRouter><DataResidency /></MemoryRouter>)
     await waitFor(() => {
       expect(screen.getByText('prod-us-east')).toBeInTheDocument()
       expect(screen.getByText('prod-eu-west')).toBeInTheDocument()
@@ -85,7 +90,7 @@ describe('DataResidency', () => {
 
   it('renders residency rules', async () => {
     mockFetchSuccess()
-    render(<DataResidency />)
+    render(<MemoryRouter><DataResidency /></MemoryRouter>)
     await waitFor(() => {
       expect(screen.getByText('eu-personal-data')).toBeInTheDocument()
       expect(screen.getByText('pci-cardholder')).toBeInTheDocument()
@@ -94,7 +99,7 @@ describe('DataResidency', () => {
 
   it('renders violations with severity badges', async () => {
     mockFetchSuccess()
-    render(<DataResidency />)
+    render(<MemoryRouter><DataResidency /></MemoryRouter>)
     await waitFor(() => {
       expect(screen.getByText('Deployment/eu-customer-sync')).toBeInTheDocument()
       expect(screen.getByText('critical')).toBeInTheDocument()
@@ -105,7 +110,7 @@ describe('DataResidency', () => {
 
   it('shows error state on fetch failure', async () => {
     mockFetchFailure()
-    render(<DataResidency />)
+    render(<MemoryRouter><DataResidency /></MemoryRouter>)
     await waitFor(() => {
       expect(screen.getByText('Network error')).toBeInTheDocument()
       expect(screen.getByText('Retry')).toBeInTheDocument()

--- a/web/src/components/compliance/FedRAMPDashboard.test.tsx
+++ b/web/src/components/compliance/FedRAMPDashboard.test.tsx
@@ -1,6 +1,11 @@
 import { render, screen, waitFor } from '@testing-library/react'
 import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { MemoryRouter } from 'react-router-dom'
 import FedRAMPDashboard from './FedRAMPDashboard'
+
+vi.mock('../../lib/unified/dashboard/UnifiedDashboard', () => ({
+  UnifiedDashboard: () => null,
+}))
 
 const mockControls = [
   { id: 'AC-1', name: 'Access Control Policy', description: 'Define access policies.', family: 'AC', status: 'satisfied', responsible: 'Platform Team', implementation: 'RBAC and OPA' },
@@ -23,22 +28,22 @@ describe('FedRAMPDashboard', () => {
   beforeEach(() => { vi.clearAllMocks() })
 
   it('renders the dashboard title', async () => {
-    render(<FedRAMPDashboard />)
+    render(<MemoryRouter><FedRAMPDashboard /></MemoryRouter>)
     await waitFor(() => expect(screen.getByText('FedRAMP Readiness')).toBeInTheDocument())
   })
 
   it('shows overall score', async () => {
-    render(<FedRAMPDashboard />)
+    render(<MemoryRouter><FedRAMPDashboard /></MemoryRouter>)
     await waitFor(() => expect(screen.getByText('71%')).toBeInTheDocument())
   })
 
   it('renders a control', async () => {
-    render(<FedRAMPDashboard />)
+    render(<MemoryRouter><FedRAMPDashboard /></MemoryRouter>)
     await waitFor(() => expect(screen.getByText('Access Control Policy')).toBeInTheDocument())
   })
 
   it('shows satisfied count', async () => {
-    render(<FedRAMPDashboard />)
+    render(<MemoryRouter><FedRAMPDashboard /></MemoryRouter>)
     await waitFor(() => expect(screen.getByText('142')).toBeInTheDocument())
   })
 })

--- a/web/src/components/compliance/GxPDashboard.test.tsx
+++ b/web/src/components/compliance/GxPDashboard.test.tsx
@@ -1,6 +1,11 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render, screen, waitFor } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
 import GxPDashboard from './GxPDashboard'
+
+vi.mock('../../lib/unified/dashboard/UnifiedDashboard', () => ({
+  UnifiedDashboard: () => null,
+}))
 
 const ok = (data: unknown) => Promise.resolve({ ok: true, json: () => Promise.resolve(data) })
 
@@ -32,28 +37,28 @@ beforeEach(() => { vi.clearAllMocks() })
 
 describe('GxPDashboard', () => {
   it('renders the dashboard title', async () => {
-    render(<GxPDashboard />)
+    render(<MemoryRouter><GxPDashboard /></MemoryRouter>)
     await waitFor(() => {
       expect(screen.getByText('GxP Validation Mode')).toBeInTheDocument()
     })
   })
 
   it('shows GxP mode enabled', async () => {
-    render(<GxPDashboard />)
+    render(<MemoryRouter><GxPDashboard /></MemoryRouter>)
     await waitFor(() => {
       expect(screen.getByText('● ENABLED')).toBeInTheDocument()
     })
   })
 
   it('shows chain integrity status', async () => {
-    render(<GxPDashboard />)
+    render(<MemoryRouter><GxPDashboard /></MemoryRouter>)
     await waitFor(() => {
       expect(screen.getByText('Hash chain intact')).toBeInTheDocument()
     })
   })
 
   it('shows pending signatures count', async () => {
-    render(<GxPDashboard />)
+    render(<MemoryRouter><GxPDashboard /></MemoryRouter>)
     await waitFor(() => {
       expect(screen.getByText('1')).toBeInTheDocument()
     })

--- a/web/src/components/compliance/HIPAADashboard.test.tsx
+++ b/web/src/components/compliance/HIPAADashboard.test.tsx
@@ -1,6 +1,11 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render, screen, waitFor } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
 import HIPAADashboard from './HIPAADashboard'
+
+vi.mock('../../lib/unified/dashboard/UnifiedDashboard', () => ({
+  UnifiedDashboard: () => null,
+}))
 
 const mockSafeguards = [
   { id: '164.312(a)', section: '§164.312(a)(1)', name: 'Access Control', description: 'Test', status: 'pass', checks: [
@@ -38,28 +43,28 @@ beforeEach(() => { vi.clearAllMocks() })
 
 describe('HIPAADashboard', () => {
   it('renders the dashboard title', async () => {
-    render(<HIPAADashboard />)
+    render(<MemoryRouter><HIPAADashboard /></MemoryRouter>)
     await waitFor(() => {
       expect(screen.getByText('HIPAA Security Rule Compliance')).toBeInTheDocument()
     })
   })
 
   it('shows overall score', async () => {
-    render(<HIPAADashboard />)
+    render(<MemoryRouter><HIPAADashboard /></MemoryRouter>)
     await waitFor(() => {
       expect(screen.getByText('60%')).toBeInTheDocument()
     })
   })
 
   it('displays safeguard count', async () => {
-    render(<HIPAADashboard />)
+    render(<MemoryRouter><HIPAADashboard /></MemoryRouter>)
     await waitFor(() => {
       expect(screen.getByText('2/5 safeguards passing')).toBeInTheDocument()
     })
   })
 
   it('renders all five safeguards', async () => {
-    render(<HIPAADashboard />)
+    render(<MemoryRouter><HIPAADashboard /></MemoryRouter>)
     await waitFor(() => {
       expect(screen.getByText(/Access Control/)).toBeInTheDocument()
       expect(screen.getByText(/Audit Controls/)).toBeInTheDocument()

--- a/web/src/components/compliance/NISTDashboard.test.tsx
+++ b/web/src/components/compliance/NISTDashboard.test.tsx
@@ -1,6 +1,11 @@
 import { render, screen, waitFor } from '@testing-library/react'
 import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { MemoryRouter } from 'react-router-dom'
 import NISTDashboard from './NISTDashboard'
+
+vi.mock('../../lib/unified/dashboard/UnifiedDashboard', () => ({
+  UnifiedDashboard: () => null,
+}))
 
 const mockFamilies = [
   { id: 'AC', name: 'Access Control', description: 'Manage access.', pass_rate: 83, controls: [
@@ -25,22 +30,22 @@ describe('NISTDashboard', () => {
   beforeEach(() => { vi.clearAllMocks() })
 
   it('renders the dashboard title', async () => {
-    render(<NISTDashboard />)
+    render(<MemoryRouter><NISTDashboard /></MemoryRouter>)
     await waitFor(() => expect(screen.getByText('NIST 800-53 Control Mapping')).toBeInTheDocument())
   })
 
   it('shows overall score', async () => {
-    render(<NISTDashboard />)
+    render(<MemoryRouter><NISTDashboard /></MemoryRouter>)
     await waitFor(() => expect(screen.getAllByText('83%').length).toBeGreaterThanOrEqual(1))
   })
 
   it('renders control family', async () => {
-    render(<NISTDashboard />)
+    render(<MemoryRouter><NISTDashboard /></MemoryRouter>)
     await waitFor(() => expect(screen.getAllByText('AC — Access Control').length).toBeGreaterThanOrEqual(1))
   })
 
   it('shows implemented count', async () => {
-    render(<NISTDashboard />)
+    render(<MemoryRouter><NISTDashboard /></MemoryRouter>)
     await waitFor(() => expect(screen.getByText('13')).toBeInTheDocument())
   })
 })

--- a/web/src/components/compliance/STIGDashboard.test.tsx
+++ b/web/src/components/compliance/STIGDashboard.test.tsx
@@ -1,6 +1,11 @@
 import { render, screen, waitFor } from '@testing-library/react'
 import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { MemoryRouter } from 'react-router-dom'
 import STIGDashboard from './STIGDashboard'
+
+vi.mock('../../lib/unified/dashboard/UnifiedDashboard', () => ({
+  UnifiedDashboard: () => null,
+}))
 
 const mockBenchmarks = [
   { id: 'K8S-STIG-V1', title: 'Kubernetes STIG', version: '1.0', release: 'R1', status: 'non-compliant', profile: 'MAC-1', total_rules: 120, findings_count: 14 },
@@ -23,22 +28,22 @@ describe('STIGDashboard', () => {
   beforeEach(() => { vi.clearAllMocks() })
 
   it('renders the dashboard title', async () => {
-    render(<STIGDashboard />)
+    render(<MemoryRouter><STIGDashboard /></MemoryRouter>)
     await waitFor(() => expect(screen.getByText('DISA STIG Compliance')).toBeInTheDocument())
   })
 
   it('shows compliance score', async () => {
-    render(<STIGDashboard />)
+    render(<MemoryRouter><STIGDashboard /></MemoryRouter>)
     await waitFor(() => expect(screen.getByText('76%')).toBeInTheDocument())
   })
 
   it('renders a finding rule', async () => {
-    render(<STIGDashboard />)
+    render(<MemoryRouter><STIGDashboard /></MemoryRouter>)
     await waitFor(() => expect(screen.getByText('SV-242383')).toBeInTheDocument())
   })
 
   it('shows open count', async () => {
-    render(<STIGDashboard />)
+    render(<MemoryRouter><STIGDashboard /></MemoryRouter>)
     await waitFor(() => expect(screen.getByText('14')).toBeInTheDocument())
   })
 })

--- a/web/src/components/compliance/SegregationOfDuties.test.tsx
+++ b/web/src/components/compliance/SegregationOfDuties.test.tsx
@@ -1,6 +1,11 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render, screen, waitFor } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
 import SegregationOfDuties from './SegregationOfDuties'
+
+vi.mock('../../lib/unified/dashboard/UnifiedDashboard', () => ({
+  UnifiedDashboard: () => null,
+}))
 
 const mockSummary = {
   total_rules: 5, total_principals: 10, total_violations: 5,
@@ -35,7 +40,7 @@ describe('SegregationOfDuties', () => {
 
   it('renders header and compliance score', async () => {
     mockFetchSuccess()
-    render(<SegregationOfDuties />)
+    render(<MemoryRouter><SegregationOfDuties /></MemoryRouter>)
     await waitFor(() => {
       expect(screen.getByText('Segregation of Duties')).toBeInTheDocument()
       expect(screen.getByText('Compliance Score')).toBeInTheDocument()
@@ -45,7 +50,7 @@ describe('SegregationOfDuties', () => {
 
   it('renders violations', async () => {
     mockFetchSuccess()
-    render(<SegregationOfDuties />)
+    render(<MemoryRouter><SegregationOfDuties /></MemoryRouter>)
     await waitFor(() => {
       expect(screen.getByText(/bob@acme\.com/)).toBeInTheDocument()
       expect(screen.getByText('bob has deployer + approver')).toBeInTheDocument()
@@ -54,7 +59,7 @@ describe('SegregationOfDuties', () => {
 
   it('shows error on failure', async () => {
     vi.spyOn(globalThis, 'fetch').mockRejectedValue(new Error('Network error'))
-    render(<SegregationOfDuties />)
+    render(<MemoryRouter><SegregationOfDuties /></MemoryRouter>)
     await waitFor(() => {
       expect(screen.getByText('Network error')).toBeInTheDocument()
     })


### PR DESCRIPTION
Restores test coverage from 90% to ≥91%.

## Root causes

### 1. Compliance tests failing with Router context error
All 12 compliance test files rendered components that transitively call `DashboardHealthIndicator` → `useNavigate()` via `UnifiedDashboard`, but the tests lacked a `<Router>` context.

Fix:
- Add `MemoryRouter` wrapper around all `render(...)` calls in each compliance test file
- Mock `UnifiedDashboard` to prevent the transitive `AddCardModal` → `useToast` error (same pattern used in `UnifiedDashboard.test.tsx`)
- Fix `ComplianceFrameworks.test.tsx` which imported `{ ComplianceFrameworks }` (named) when the component is a default export — changed to `import ComplianceFrameworks from './ComplianceFrameworks'`

Affected files: `DataResidency.test.tsx`, `ComplianceFrameworks.test.tsx`, `ComplianceReports.test.tsx`, `AirGapDashboard.test.tsx`, `BAADashboard.test.tsx`, `ChangeControlAudit.test.tsx`, `FedRAMPDashboard.test.tsx`, `GxPDashboard.test.tsx`, `HIPAADashboard.test.tsx`, `NISTDashboard.test.tsx`, `STIGDashboard.test.tsx`, `SegregationOfDuties.test.tsx`

### 2. Magic numbers ratchet: 55 found vs baseline 54
The new `kserve_status/useKServeStatus.ts` contained a variable named `avgP95` whose numeric suffix `95` was matched by the ratchet's reverse-comparison regex (`/(\d+)\s*[><=!]+\s*\w+\.(length|size)/`) as `95 = services.length`. Renamed the variable to `avgLatencyMs` to eliminate the false positive without changing behavior.

### 3. CiliumStatus "renders node list" test failing
`CiliumStatus.test.tsx` lives at `cilium_status/__tests__/CiliumStatus.test.tsx`. The mock paths used `'../../../hooks/...'` and `'../../../lib/cards'` which resolve to `src/components/hooks/` and `src/components/lib/` — one directory level too shallow. The correct paths from the `__tests__/` subdirectory are `'../../../../hooks/...'` and `'../../../../lib/cards'`. With the wrong paths, the mocks silently no-oped, leaving the component to call real implementations that return empty/default data.

Fixes coverage regression introduced by Epic 3–5 compliance PRs and the Cilium/KServe card refactors.