### PR TITLE
🐛 Fix enterprise routes crash: missing VersionCheckProvider

### DIFF
--- a/web/src/components/enterprise/EnterpriseLayout.tsx
+++ b/web/src/components/enterprise/EnterpriseLayout.tsx
@@ -6,14 +6,17 @@
  */
 import { Outlet } from 'react-router-dom'
 import EnterpriseSidebar from './EnterpriseSidebar'
+import { VersionCheckProvider } from '../../hooks/useVersionCheck'
 
 export default function EnterpriseLayout() {
   return (
-    <div className="flex h-screen bg-gray-950 text-white overflow-hidden">
-      <EnterpriseSidebar />
-      <main className="flex-1 overflow-y-auto overflow-x-hidden p-4 md:p-6 pb-24">
-        <Outlet />
-      </main>
-    </div>
+    <VersionCheckProvider>
+      <div className="flex h-screen bg-gray-950 text-white overflow-hidden">
+        <EnterpriseSidebar />
+        <main className="flex-1 overflow-y-auto overflow-x-hidden p-4 md:p-6 pb-24">
+          <Outlet />
+        </main>
+      </div>
+    </VersionCheckProvider>
   )
 }


### PR DESCRIPTION
## Problem
All `/enterprise/*` routes crash with:
```
useVersionCheck must be used within a <VersionCheckProvider>
```

## Root Cause
PR #9740 introduced `SidebarShell` which calls `useVersionCheck()`. The `EnterpriseSidebar` composes `SidebarShell`, but `EnterpriseLayout` renders outside the main `Layout` tree where `VersionCheckProvider` lives.

## Fix
Wrap `EnterpriseLayout` with `<VersionCheckProvider>` so all enterprise routes have access to the version check context.

## Testing
- `tsc --noEmit` passes clean