### PR TITLE
fix(compliance): guard array .map()/.join() against undefined API responses

### DIFF
--- a/web/src/components/compliance/DataResidency.tsx
+++ b/web/src/components/compliance/DataResidency.tsx
@@ -215,7 +215,7 @@ export function DataResidencyContent() {
                     </span>
                   </div>
                   <div className="flex gap-1">
-                    {rule.allowed_regions.map(r => (
+                    {(rule.allowed_regions || []).map(r => (
                       <span key={r} className="text-xs bg-zinc-700/30 px-1.5 py-0.5 rounded text-zinc-400">{REGION_LABELS[r] ?? r}</span>
                     ))}
                   </div>
@@ -262,7 +262,7 @@ export function DataResidencyContent() {
                 <div className="flex gap-2 mt-1.5 text-xs text-zinc-500">
                   <span>Namespace: {v.namespace}</span>
                   <span>·</span>
-                  <span>Allowed: {v.allowed_regions.map(r => REGION_LABELS[r] ?? r).join(', ')}</span>
+                  <span>Allowed: {(v.allowed_regions || []).map(r => REGION_LABELS[r] ?? r).join(', ')}</span>
                 </div>
               </div>
             ))}

--- a/web/src/components/compliance/NISTDashboard.tsx
+++ b/web/src/components/compliance/NISTDashboard.tsx
@@ -244,13 +244,13 @@ export function NISTDashboardContent() {
                   <td className="p-3 font-mono text-blue-300">{m.control_id}</td>
                   <td className="p-3">
                     <div className="flex gap-1 flex-wrap">
-                      {m.resources.map(r => (
+                      {(m.resources || []).map(r => (
                         <span key={r} className="px-2 py-0.5 rounded bg-gray-700 text-gray-300 text-xs">{r}</span>
                       ))}
                     </div>
                   </td>
-                  <td className="p-3 text-gray-300">{m.namespaces.join(', ')}</td>
-                  <td className="p-3 text-gray-300">{m.clusters.join(', ')}</td>
+                  <td className="p-3 text-gray-300">{(m.namespaces || []).join(', ')}</td>
+                  <td className="p-3 text-gray-300">{(m.clusters || []).join(', ')}</td>
                   <td className="p-3">
                     {m.automated
                       ? <CheckCircle2 className="w-4 h-4 text-green-400" />

--- a/web/src/components/compliance/SIEMDashboard.tsx
+++ b/web/src/components/compliance/SIEMDashboard.tsx
@@ -187,7 +187,7 @@ export default function SIEMDashboard() {
             <div className="bg-gray-800/50 rounded-lg border border-gray-700 p-6">
               <h3 className="text-lg font-semibold text-white mb-4">Top Event Sources</h3>
               <div className="space-y-3">
-                {summary.top_sources.map(src => (
+                {(summary.top_sources || []).map(src => (
                   <div key={src.source} className="flex items-center gap-3">
                     <span className="w-32 text-sm text-gray-300 truncate">{src.source}</span>
                     <div className="flex-1 h-2 bg-gray-700 rounded-full overflow-hidden">

--- a/web/src/components/compliance/SegregationOfDuties.tsx
+++ b/web/src/components/compliance/SegregationOfDuties.tsx
@@ -179,9 +179,9 @@ export function SegregationOfDutiesContent() {
                   </div>
                 </div>
                 <div className="flex flex-wrap gap-1 mt-1">
-                  {p.roles.map(r => <span key={r} className="text-xs bg-zinc-700/50 px-1.5 py-0.5 rounded text-zinc-300">{r}</span>)}
+                  {(p.roles || []).map(r => <span key={r} className="text-xs bg-zinc-700/50 px-1.5 py-0.5 rounded text-zinc-300">{r}</span>)}
                 </div>
-                <div className="text-xs text-zinc-500 mt-1">Clusters: {p.clusters.join(', ')}</div>
+                <div className="text-xs text-zinc-500 mt-1">Clusters: {(p.clusters || []).join(', ')}</div>
               </div>
             )
           })}


### PR DESCRIPTION
## Problem

GA4 reports **3 hits of `Cannot read properties of undefined (reading 'map')`** on `/enterprise/data-residency` in the last 7 days, plus **10 hits of React error #185** on `/` over the same period.

The `undefined.map` errors are caused by `.map()` and `.join()` calls on properties of API response objects that the backend can return as `null` or omit entirely (e.g. `rule.allowed_regions`, `v.allowed_regions`, `m.resources`, `m.namespaces`, `m.clusters`, `summary.top_sources`, `p.roles`, `p.clusters`).

The React #185 root causes (unconditional `setState` in `ComplianceFrameworks.tsx` `useMemo` block, and `fetchData` not wrapped in `useCallback` in `SegregationOfDuties.tsx`) were fixed in PR #9739 and are confirmed resolved in the current codebase. This PR focuses on the remaining `undefined.map` crashes.

## Fix

Apply `(arr || [])` guards to every `.map()` / `.join()` call on an API-returned object property that could be `undefined`:

| File | Location | Fix |
|------|----------|-----|
| `DataResidency.tsx` | `rule.allowed_regions.map(...)` | `(rule.allowed_regions \|\| []).map(...)` |
| `DataResidency.tsx` | `v.allowed_regions.map(...).join(...)` | `(v.allowed_regions \|\| []).map(...).join(...)` |
| `NISTDashboard.tsx` | `m.resources.map(...)` | `(m.resources \|\| []).map(...)` |
| `NISTDashboard.tsx` | `m.namespaces.join(...)` | `(m.namespaces \|\| []).join(...)` |
| `NISTDashboard.tsx` | `m.clusters.join(...)` | `(m.clusters \|\| []).join(...)` |
| `SIEMDashboard.tsx` | `summary.top_sources.map(...)` | `(summary.top_sources \|\| []).map(...)` |
| `SegregationOfDuties.tsx` | `p.roles.map(...)` | `(p.roles \|\| []).map(...)` |
| `SegregationOfDuties.tsx` | `p.clusters.join(...)` | `(p.clusters \|\| []).join(...)` |

Follows the project rule from `CLAUDE.md §Array Safety`: **NEVER call `.map()` or `.join()` on values that might be `undefined`**.

## GA4 Data

- 10 hits of React error #185 on `/` in the last 7 days
- 3 hits of `Cannot read properties of undefined (reading 'map')` on `/enterprise/data-residency`

## Related

- Fixes #9738 — fixed self-referencing card infinite loop (React #185 on enterprise dashboards)
- Fixes #9739 — fixed unconditional setState in ComplianceFrameworks.tsx and missing useCallback in SegregationOfDuties.tsx