### PR TITLE
🐛 Fix undefined.trim in NightlyReleasePulse and missing GA4 error_category on cluster-access errors

### DIFF
--- a/web/src/components/cards/console-missions/shared.tsx
+++ b/web/src/components/cards/console-missions/shared.tsx
@@ -5,6 +5,7 @@ import { useMissions } from '../../../hooks/useMissions'
 import { isAgentConnected } from '../../../hooks/useLocalAgent'
 import { useToast } from '../../ui/Toast'
 import { getSettingsWithHash } from '../../../config/routes'
+import { emitError } from '../../../lib/analytics'
 
 export const ANTHROPIC_KEY_STORAGE = 'kubestellar-anthropic-key'
 
@@ -87,6 +88,7 @@ export function ApiKeyPromptModal({ isOpen, onDismiss, onGoToSettings }: {
 }) {
   useEffect(() => {
     if (!isOpen) return
+    emitError('config', 'No AI agent available. Please configure an API key')
     const handleKeyDown = (e: KeyboardEvent) => {
       if (e.key === 'Escape') {
         e.stopPropagation()

--- a/web/src/hooks/useGitHubPipelines.ts
+++ b/web/src/hooks/useGitHubPipelines.ts
@@ -331,6 +331,23 @@ async function fetchView<T>(params: URLSearchParams): Promise<T> {
   return body
 }
 
+/**
+ * Coerce string fields in a MatrixPayload that the GitHub API can return as
+ * null/undefined when a workflow run has no name (e.g., anonymous workflow
+ * runs). Without this guard the client crashes with `Cannot read properties
+ * of undefined (reading 'trim')` when rendering WorkflowRow.
+ */
+function normalizeMatrixPayload(payload: MatrixPayload): MatrixPayload {
+  return {
+    ...payload,
+    workflows: (payload.workflows ?? []).map((wf) => ({
+      ...wf,
+      name: wf.name != null ? String(wf.name) : '',
+      repo: wf.repo != null ? String(wf.repo) : '',
+    })),
+  }
+}
+
 // ---------------------------------------------------------------------------
 // Unified payload — returned by view=all, consumed by PipelineDataContext
 // ---------------------------------------------------------------------------
@@ -383,10 +400,14 @@ export function useUnifiedPipelineData(repo: string | null, days: number = UNIFI
     initialData,
     demoData: initialData,
     liveInDemoMode: true,
-    fetcher: () => {
+    fetcher: async () => {
       const p = new URLSearchParams({ view: 'all', days: String(days) })
       if (repo) p.set('repo', repo)
-      return fetchView<UnifiedPipelinePayload>(p)
+      const payload = await fetchView<UnifiedPipelinePayload>(p)
+      return {
+        ...payload,
+        matrix: payload.matrix ? normalizeMatrixPayload(payload.matrix) : payload.matrix,
+      }
     },
   })
 }
@@ -424,10 +445,11 @@ export function usePipelineMatrix(repo: string | null, days: number, enabled = t
     demoData: demo,
     liveInDemoMode: true,
     enabled,
-    fetcher: () => {
+    fetcher: async () => {
       const p = new URLSearchParams({ view: 'matrix', days: String(days) })
       if (repo) p.set('repo', repo)
-      return fetchView<MatrixPayload>(p)
+      const payload = await fetchView<MatrixPayload>(p)
+      return normalizeMatrixPayload(payload)
     },
   })
 }

--- a/web/src/hooks/useMissions.tsx
+++ b/web/src/hooks/useMissions.tsx
@@ -4,7 +4,7 @@ import { AgentCapabilityToolExec } from '../types/agent'
 import { getDemoMode } from './useDemoMode'
 import { addCategoryTokens, setActiveTokenCategory, clearActiveTokenCategory } from './useTokenUsage'
 import { LOCAL_AGENT_WS_URL, LOCAL_AGENT_HTTP_URL } from '../lib/constants'
-import { emitMissionStarted, emitMissionCompleted, emitMissionError, emitMissionRated } from '../lib/analytics'
+import { emitError, emitMissionStarted, emitMissionCompleted, emitMissionError, emitMissionRated } from '../lib/analytics'
 import { scanForMaliciousContent } from '../lib/missions/scanner/malicious'
 import { runPreflightCheck, type PreflightResult } from '../lib/missions/preflightCheck'
 import { kubectlProxy } from '../lib/kubectlProxy'
@@ -1940,6 +1940,9 @@ The WebSocket connection to the agent at \`${LOCAL_AGENT_WS_URL}\` was lost and 
           preflight.error?.code || 'preflight_unknown',
           preflight.error?.message
         )
+        if (preflight.error?.message) {
+          emitError('cluster_access', preflight.error.message)
+        }
         return
       }
 
@@ -2375,6 +2378,9 @@ Install the console locally with the KubeStellar Console agent to use AI mission
             ]
           } : m
         ))
+        if (preflight.error?.message) {
+          emitError('cluster_access', preflight.error.message)
+        }
         return
       }
 

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -7,7 +7,7 @@ import {
   DEMO_TOKEN_VALUE,
   FETCH_DEFAULT_TIMEOUT_MS,
 } from './constants'
-import { emitSessionExpired } from './analytics'
+import { emitError, emitSessionExpired } from './analytics'
 
 const API_BASE = ''
 const DEFAULT_TIMEOUT = MCP_HOOK_TIMEOUT_MS
@@ -454,6 +454,7 @@ class ApiClient {
     // Skip API calls to protected endpoints when not authenticated
     const isPublicPath = PUBLIC_API_PREFIXES.some(prefix => path.startsWith(prefix))
     if (options?.requiresAuth !== false && !isPublicPath && !this.hasToken()) {
+      emitError('auth', 'No authentication token available')
       throw new UnauthenticatedError()
     }
 


### PR DESCRIPTION
## Summary

Fixes 2 \`card_render\` errors (\`undefined.trim\` on \`/ci-cd\`) and 9 \`ksc_error\` events missing \`error_category\`/\`error_page\` dimensions in GA4.

- **Fix 1 — \`undefined.trim\` in NightlyReleasePulse** (2 GA4 hits): The GitHub API can return workflow runs with \`name: null\` or \`name: undefined\`. Added \`normalizeMatrixPayload()\` in \`useGitHubPipelines.ts\` that coerces \`wf.name\` and \`wf.repo\` to strings, applied in both \`usePipelineMatrix\` and \`useUnifiedPipelineData\` fetchers. Old cached entries with \`name: null\` are sanitized on next fetch.

- **Fix 2 — Missing \`error_category\`/\`error_page\` on cluster-access errors** (9 GA4 hits): Several error paths were not calling \`emitError(category, detail)\`, so \`ksc_error\` events lacked the \`error_category\` and \`error_page\` GA4 dimensions:
  - \`useMissions.tsx\`: added \`emitError('cluster_access', ...)\` at both preflight failure sites (initial check and retry)
  - \`api.ts\`: added \`emitError('auth', 'No authentication token available')\` before throwing \`UnauthenticatedError\`
  - \`shared.tsx\` (\`ApiKeyPromptModal\`): added \`emitError('config', 'No AI agent available. Please configure an API key')\` when the overlay opens

## Test plan

- [ ] Navigate to \`/ci-cd\` — NightlyReleasePulse card renders without console errors even for repos with anonymous workflow runs
- [ ] Trigger a preflight failure (disconnect cluster) — verify \`ksc_error\` event in GA4 DebugView shows \`error_category: cluster_access\` and \`error_page\`
- [ ] Open the app without auth token — verify \`ksc_error\` event shows \`error_category: auth\`
- [ ] Open the AI agent required modal — verify \`ksc_error\` event shows \`error_category: config\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)