### PR TITLE
fix: update tests for GitOps SSE + RBAC hook factory extraction

### DIFF
--- a/web/src/hooks/useMissions.preflight-agents.test.tsx
+++ b/web/src/hooks/useMissions.preflight-agents.test.tsx
@@ -33,6 +33,7 @@ vi.mock('../lib/constants', async (importOriginal) => {
 } })
 
 vi.mock('../lib/analytics', () => ({
+  emitError: vi.fn(),
   emitMissionStarted: vi.fn(),
   emitMissionCompleted: vi.fn(),
   emitMissionError: vi.fn(),

--- a/web/src/lib/__tests__/api.test.ts
+++ b/web/src/lib/__tests__/api.test.ts
@@ -20,6 +20,7 @@ vi.mock('../constants', async (importOriginal) => {
 })
 
 vi.mock('../analytics', () => ({
+  emitError: vi.fn(),
   emitSessionExpired: vi.fn(),
 }))
 

--- a/web/src/lib/widgets/__tests__/styleConverter.test.ts
+++ b/web/src/lib/widgets/__tests__/styleConverter.test.ts
@@ -61,7 +61,7 @@ describe('tailwindToCSS', () => {
 
   it('handles glass effect', () => {
     const result = tailwindToCSS('glass')
-    expect(result.backdropFilter).toContain('blur-sm')
+    expect(result.backdropFilter).toContain('blur(12px)')
   })
 
   it('converts hidden', () => {


### PR DESCRIPTION
## Summary
- Add missing `emitError` mock to analytics in `api.test.ts` and `useMissions.preflight-agents.test.tsx` (PR #9751 added `emitError` import to `useMissions.tsx` and `api.ts`)
- Fix `styleConverter.test.ts` to expect actual CSS value `blur(12px)` instead of Tailwind class `blur-sm`

Fixes #9756

## Root cause
PR #9751 wired `emitError` into `useMissions.tsx` and `api.ts`, but the test mocks for `../lib/analytics` didn't include this new export. When `emitError` was called during preflight failure, the missing mock threw an error that short-circuited the expected test flow. The styleConverter test was checking for a Tailwind class name instead of the actual CSS value produced by the converter.

## Test plan
- [x] All 4 previously failing tests now pass
- [x] All 98 tests in the 3 affected files pass