### PR TITLE
fix: resolve React re-render loops on enterprise compliance pages

### DIFF
--- a/web/src/components/compliance/ComplianceFrameworks.tsx
+++ b/web/src/components/compliance/ComplianceFrameworks.tsx
@@ -4,7 +4,7 @@
  * Shows PCI-DSS 4.0, SOC 2 Type II, and other frameworks with per-control
  * pass/fail results and an overall compliance score.
  */
-import { useState, useMemo, useEffect } from 'react'
+import { useState, useMemo, useEffect, useCallback } from 'react'
 import { Shield, ChevronDown, ChevronRight, CheckCircle2, XCircle, AlertTriangle, MinusCircle, Loader2, RefreshCw } from 'lucide-react'
 import { UnifiedDashboard } from '../../lib/unified/dashboard/UnifiedDashboard'
 import { complianceFrameworksDashboardConfig } from '../../config/dashboards/compliance-frameworks'
@@ -159,31 +159,39 @@ export function ComplianceFrameworksContent() {
   const [selectedFwId, setSelectedFwId] = useState<string | null>(null)
   const [selectedCluster, setSelectedCluster] = useState<string>('')
 
+  // Stable ID of the first framework — avoids re-running the effect when the
+  // frameworks array gets a new reference but its contents haven't changed.
+  const firstFwId = frameworks.length > 0 ? frameworks[0].id : null
+
   // Auto-select first framework when loaded
   useEffect(() => {
-    if (!selectedFwId && frameworks.length > 0) {
-      setSelectedFwId(frameworks[0].id)
+    if (!selectedFwId && firstFwId) {
+      setSelectedFwId(firstFwId)
     }
-  }, [frameworks, selectedFwId])
+  }, [firstFwId, selectedFwId])
+
+  // Stable list of cluster names — avoids creating a new array reference
+  // on every render when useClusters() returns a fresh clusters object.
+  const clusterNames = useMemo(() => clusters.map(c => c.name), [clusters])
+  const firstClusterName = clusterNames.length > 0 ? clusterNames[0] : null
 
   // Auto-select first cluster
-  const clusterNames = useMemo(() => clusters.map(c => c.name), [clusters])
   useEffect(() => {
-    if (!selectedCluster && clusterNames.length > 0) {
-      setSelectedCluster(clusterNames[0])
+    if (!selectedCluster && firstClusterName) {
+      setSelectedCluster(firstClusterName)
     }
-  }, [clusterNames, selectedCluster])
+  }, [firstClusterName, selectedCluster])
 
   const selectedFw = useMemo(() => {
     if (selectedFwId) return frameworks.find(f => f.id === selectedFwId) ?? null
     return null
   }, [frameworks, selectedFwId])
 
-  const handleEvaluate = () => {
+  const handleEvaluate = useCallback(() => {
     if (selectedFw && selectedCluster) {
       evaluate(selectedFw.id, selectedCluster)
     }
-  }
+  }, [selectedFw, selectedCluster, evaluate])
 
   /* ────────── render ────────── */
 

--- a/web/src/components/compliance/OIDCDashboard.tsx
+++ b/web/src/components/compliance/OIDCDashboard.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react'
+import { useState, useEffect, useCallback } from 'react'
 import { UnifiedDashboard } from '../../lib/unified/dashboard/UnifiedDashboard'
 import { oidcDashboardConfig } from '../../config/dashboards/oidc'
 import {
@@ -40,7 +40,7 @@ export function OIDCDashboardContent() {
   const [error, setError] = useState<string | null>(null)
   const [activeTab, setActiveTab] = useState<'providers' | 'sessions'>('providers')
 
-  const fetchData = async () => {
+  const fetchData = useCallback(async () => {
     setLoading(true)
     setError(null)
     try {
@@ -58,9 +58,9 @@ export function OIDCDashboardContent() {
     } finally {
       setLoading(false)
     }
-  }
+  }, [])
 
-  useEffect(() => { fetchData() }, [])
+  useEffect(() => { fetchData() }, [fetchData])
 
   if (loading) return (
     <div className="flex items-center justify-center h-64">

--- a/web/src/components/enterprise/EnterpriseSidebar.tsx
+++ b/web/src/components/enterprise/EnterpriseSidebar.tsx
@@ -4,42 +4,57 @@
  * Replaces the main sidebar when the user navigates to /enterprise.
  * Organized by compliance vertical (epic) with collapsible sections.
  * Now composes SidebarShell for consistent chrome (collapse, pin, resize, mobile).
+ *
+ * IMPORTANT: navSections, features, and branding are memoized to prevent
+ * cascading re-renders in SidebarShell. Without memoization, every parent
+ * re-render (from VersionCheckProvider, cluster cache, etc.) creates new
+ * prop objects, which re-render SidebarShell and all its hook subscribers,
+ * amplifying into a React #185 "too many re-renders" loop on enterprise
+ * compliance pages (#9753, #9754).
  */
+import { useMemo } from 'react'
 import { Building2 } from 'lucide-react'
 import { SidebarShell } from '../layout/SidebarShell'
 import type { NavSection } from '../layout/SidebarShell'
 import { ENTERPRISE_NAV_SECTIONS } from './enterpriseNav'
 
+/** Stable features config — created once outside the component */
+const SIDEBAR_FEATURES = {
+  missions: true,
+  addCard: true,
+  clusterStatus: true,
+  collapsePin: true,
+  resize: true,
+  activeUsers: true,
+} as const
+
 export default function EnterpriseSidebar() {
-  const navSections: NavSection[] = ENTERPRISE_NAV_SECTIONS.map(section => ({
-    id: section.id,
-    label: section.title,
-    items: section.items.map(item => ({
-      id: item.id,
-      label: item.label,
-      href: item.href,
-      icon: item.icon,
-      badge: item.badge,
+  const navSections: NavSection[] = useMemo(() =>
+    ENTERPRISE_NAV_SECTIONS.map(section => ({
+      id: section.id,
+      label: section.title,
+      items: section.items.map(item => ({
+        id: item.id,
+        label: item.label,
+        href: item.href,
+        icon: item.icon,
+        badge: item.badge,
+      })),
+      collapsible: true,
     })),
-    collapsible: true,
-  }))
+  [])
+
+  const branding = useMemo(() => ({
+    title: 'Enterprise',
+    logo: <Building2 className="w-5 h-5 text-purple-400" />,
+    subtitle: 'Compliance Portal',
+  }), [])
 
   return (
     <SidebarShell
       navSections={navSections}
-      features={{
-        missions: true,
-        addCard: true,
-        clusterStatus: true,
-        collapsePin: true,
-        resize: true,
-        activeUsers: true,
-      }}
-      branding={{
-        title: 'Enterprise',
-        logo: <Building2 className="w-5 h-5 text-purple-400" />,
-        subtitle: 'Compliance Portal',
-      }}
+      features={SIDEBAR_FEATURES}
+      branding={branding}
     />
   )
 }


### PR DESCRIPTION
## Summary

- Memoize `EnterpriseSidebar` props (navSections, features, branding) to prevent cascading re-renders through SidebarShell when VersionCheckProvider or cluster cache triggers parent updates
- Extract `firstFwId`/`firstClusterName` as primitive useEffect deps in `ComplianceFrameworksContent` so auto-select only fires on actual value changes, not array reference changes
- Wrap `OIDCDashboardContent.fetchData` in `useCallback` for correct exhaustive-deps compliance

Fixes #9753, Fixes #9754

## Test plan

- [ ] Navigate to `/enterprise/frameworks` — page loads without React #185 error
- [ ] Navigate to `/enterprise/oidc` — page loads without React #185 error
- [ ] Verify framework auto-selection still works on `/enterprise/frameworks`
- [ ] Verify cluster dropdown auto-selection still works
- [ ] Verify OIDC data loads and tabs switch correctly
- [ ] Verify sidebar collapse/expand still works in enterprise portal