### PR TITLE
fix: correct mobile sidebar z-index stacking and dropdown accessibility

### DIFF
--- a/web/src/components/layout/SidebarShell.tsx
+++ b/web/src/components/layout/SidebarShell.tsx
@@ -561,7 +561,8 @@ export function SidebarShell({
         onMouseEnter={handleSidebarMouseEnter}
         onMouseLeave={handleSidebarMouseLeave}
         className={cn(
-          'fixed left-0 top-16 bottom-0 glass border-r border-border/50 overflow-y-auto scroll-enhanced z-sidebar',
+          'fixed left-0 top-16 bottom-0 glass border-r border-border/50 overflow-y-auto scroll-enhanced',
+          isMobile ? 'z-modal' : 'z-sidebar',
           !isResizing && 'transition-all duration-300',
           !isMobile && (config.collapsed ? 'p-3' : 'p-4'),
           isMobile && 'p-4',


### PR DESCRIPTION
## Summary
- Fixed mobile sidebar being covered by its own backdrop overlay due to z-index stacking issue
- The backdrop used `z-overlay` (300) while the sidebar used `z-sidebar` (150), causing the backdrop to render on top of the sidebar content
- On mobile, the sidebar now uses `z-modal` (400) so it renders above the backdrop, making dashboard navigation links accessible

## Root Cause
In `SidebarShell.tsx`, the mobile backdrop overlay (`z-overlay` = 300) had a higher z-index than the sidebar itself (`z-sidebar` = 150). This caused:
1. The semi-transparent black backdrop to cover the sidebar, making the entire UI appear "faded"
2. Click events being intercepted by the backdrop (which triggers `closeMobileSidebar`), preventing users from selecting dashboards

## Fix
Conditionally apply `z-modal` (400) on mobile instead of `z-sidebar` (150), ensuring the sidebar content always renders above the backdrop overlay. Desktop behavior is unchanged.

Fixes #9758

## Test plan
- [ ] Open on iPhone Safari (or responsive mode at mobile width)
- [ ] Tap hamburger menu to open sidebar
- [ ] Verify sidebar content is visible and interactive (not faded)
- [ ] Verify dashboard navigation links can be tapped
- [ ] Verify tapping outside the sidebar (on the backdrop) closes it
- [ ] Verify desktop sidebar behavior is unchanged