### PR TITLE
fix: guard against render errors on enterprise data-residency and NIST pages

### DIFF
--- a/web/src/components/compliance/DataResidency.tsx
+++ b/web/src/components/compliance/DataResidency.tsx
@@ -4,7 +4,7 @@
  * Shows a world-map-style view of cluster regions, data classification rules,
  * and violations where workloads are running outside their allowed jurisdictions.
  */
-import { useState, useEffect, useMemo } from 'react'
+import { useState, useEffect, useMemo, useCallback } from 'react'
 import { UnifiedDashboard } from '../../lib/unified/dashboard/UnifiedDashboard'
 import { dataResidencyDashboardConfig } from '../../config/dashboards/data-residency'
 import { Globe, ShieldAlert, MapPin, CheckCircle2, XCircle, AlertTriangle, Loader2, RefreshCw } from 'lucide-react'
@@ -89,7 +89,7 @@ export function DataResidencyContent() {
   const [error, setError] = useState<string | null>(null)
   const [filterSeverity, setFilterSeverity] = useState<string>('all')
 
-  const fetchData = async () => {
+  const fetchData = useCallback(async () => {
     setLoading(true)
     setError(null)
     try {
@@ -104,18 +104,25 @@ export function DataResidencyContent() {
         throw new Error('Failed to load residency data')
       }
 
-      setSummary(await summaryRes.json())
-      setRules(await rulesRes.json())
-      setClusters(await clustersRes.json())
-      setViolations(await violationsRes.json())
+      const [summaryData, rulesData, clustersData, violationsData] = await Promise.all([
+        summaryRes.json(),
+        rulesRes.json(),
+        clustersRes.json(),
+        violationsRes.json(),
+      ])
+
+      setSummary(summaryData ?? null)
+      setRules(Array.isArray(rulesData) ? rulesData : [])
+      setClusters(Array.isArray(clustersData) ? clustersData : [])
+      setViolations(Array.isArray(violationsData) ? violationsData : [])
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to load data')
     } finally {
       setLoading(false)
     }
-  }
+  }, [])
 
-  useEffect(() => { fetchData() }, [])
+  useEffect(() => { fetchData() }, [fetchData])
 
   const filteredViolations = useMemo(() =>
     filterSeverity === 'all'

--- a/web/src/components/compliance/NISTDashboard.tsx
+++ b/web/src/components/compliance/NISTDashboard.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useMemo } from 'react'
+import { useState, useEffect, useMemo, useCallback } from 'react'
 import { UnifiedDashboard } from '../../lib/unified/dashboard/UnifiedDashboard'
 import { nistDashboardConfig } from '../../config/dashboards/nist'
 import {
@@ -74,26 +74,34 @@ export function NISTDashboardContent() {
   const [activeTab, setActiveTab] = useState<'families' | 'mappings' | 'summary'>('families')
   const [familyFilter, setFamilyFilter] = useState<string>('all')
 
-  useEffect(() => {
-    const load = async () => {
-      try {
-        const [fRes, mRes, sRes] = await Promise.all([
-          authFetch('/api/compliance/nist/families'),
-          authFetch('/api/compliance/nist/mappings'),
-          authFetch('/api/compliance/nist/summary'),
-        ])
-        if (!fRes.ok || !mRes.ok || !sRes.ok) throw new Error('Failed to fetch NIST data')
-        setFamilies(await fRes.json())
-        setMappings(await mRes.json())
-        setSummary(await sRes.json())
-      } catch (e) {
-        setError(e instanceof Error ? e.message : 'Unknown error')
-      } finally {
-        setLoading(false)
-      }
+  const fetchData = useCallback(async () => {
+    setLoading(true)
+    setError(null)
+    try {
+      const [fRes, mRes, sRes] = await Promise.all([
+        authFetch('/api/compliance/nist/families'),
+        authFetch('/api/compliance/nist/mappings'),
+        authFetch('/api/compliance/nist/summary'),
+      ])
+      if (!fRes.ok || !mRes.ok || !sRes.ok) throw new Error('Failed to fetch NIST data')
+
+      const [familiesData, mappingsData, summaryData] = await Promise.all([
+        fRes.json(),
+        mRes.json(),
+        sRes.json(),
+      ])
+
+      setFamilies(Array.isArray(familiesData) ? familiesData : [])
+      setMappings(Array.isArray(mappingsData) ? mappingsData : [])
+      setSummary(summaryData ?? null)
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Unknown error')
+    } finally {
+      setLoading(false)
     }
-    load()
   }, [])
+
+  useEffect(() => { fetchData() }, [fetchData])
 
   const filteredFamilies = useMemo(() => {
     if (familyFilter === 'all') return families
@@ -204,7 +212,7 @@ export function NISTDashboardContent() {
                   </tr>
                 </thead>
                 <tbody>
-                  {family.controls.map(ctrl => (
+                  {(family.controls || []).map(ctrl => (
                     <tr key={ctrl.id} className="border-b border-gray-700/50 hover:bg-gray-700/30">
                       <td className="p-3 font-mono text-blue-300">{ctrl.id}</td>
                       <td className="p-3 text-white">{ctrl.name}</td>


### PR DESCRIPTION
## Summary

- Wrap `fetchData` in `useCallback` with stable `[]` deps in both `DataResidencyContent` and `NISTDashboardContent` to prevent re-render loops (same pattern as PR #9759)
- Add `Array.isArray()` guards on all API response data before setting state — prevents crashes when endpoints return `null` or non-array values
- Guard `family.controls` with `|| []` fallback before `.map()` in NIST family table

Fixes #9761, Fixes #9762

## Test plan

- [ ] Navigate to `/enterprise/data-residency` — page loads without uncaught_render error
- [ ] Navigate to `/enterprise/nist` — page loads without uncaught_render error
- [ ] Verify data-residency summary cards, cluster regions, rules, and violations render correctly
- [ ] Verify NIST control families, resource mappings, and assessment summary tabs all render correctly
- [ ] Verify refresh button on data-residency page works without errors