### PR TITLE
♻️ Deduplicate CachedHookResult<T> across 9 hook files (-130 lines)

### DIFF
--- a/web/src/hooks/useCachedCiliumStatus.ts
+++ b/web/src/hooks/useCachedCiliumStatus.ts
@@ -7,7 +7,7 @@ import type { CiliumStatus } from '../types/cilium'
 
 const CACHE_KEY_CILIUM = 'cilium_status'
 
-export interface CachedHookResult<T> {
+export interface CiliumCacheResult<T> {
     data: T
     isLoading: boolean
     isRefreshing: boolean
@@ -18,7 +18,7 @@ export interface CachedHookResult<T> {
     refetch: () => Promise<void>
 }
 
-export function useCachedCiliumStatus(): CachedHookResult<CiliumStatus> {
+export function useCachedCiliumStatus(): CiliumCacheResult<CiliumStatus> {
     const { isDemoMode } = useDemoMode()
     const result = useCache<CiliumStatus>({
         key: CACHE_KEY_CILIUM,

--- a/web/src/hooks/useCachedCoreWorkloads.ts
+++ b/web/src/hooks/useCachedCoreWorkloads.ts
@@ -6,7 +6,7 @@
  * Extracted from useCachedData.ts for maintainability.
  */
 
-import { useCache, type RefreshCategory } from '../lib/cache'
+import { useCache, type RefreshCategory, type CachedHookResult } from '../lib/cache'
 import { isBackendUnavailable, authFetch } from '../lib/api'
 import { kubectlProxy } from '../lib/kubectlProxy'
 import { clusterCacheRef } from './mcp/shared'
@@ -58,19 +58,6 @@ import type { Workload } from './useWorkloads'
 // ============================================================================
 // Shared types
 // ============================================================================
-
-/** Shared result shape for all useCached* hooks */
-interface CachedHookResult<T> {
-  data: T
-  isLoading: boolean
-  isRefreshing: boolean
-  isDemoFallback: boolean
-  error: string | null
-  isFailed: boolean
-  consecutiveFailures: number
-  lastRefresh: number | null
-  refetch: () => Promise<void>
-}
 
 // ============================================================================
 // Private: Security kubectl scanner

--- a/web/src/hooks/useCachedGPU.ts
+++ b/web/src/hooks/useCachedGPU.ts
@@ -6,7 +6,7 @@
  */
 
 import { useState } from 'react'
-import { useCache, type RefreshCategory } from '../lib/cache'
+import { useCache, type RefreshCategory, type CachedHookResult } from '../lib/cache'
 import { fetchAPI, fetchFromAllClusters, fetchViaSSE, getToken, AGENT_HTTP_TIMEOUT_MS } from '../lib/cache/fetcherUtils'
 import { settledWithConcurrency } from '../lib/utils/concurrency'
 import { LOCAL_AGENT_HTTP_URL } from '../lib/constants'
@@ -29,19 +29,6 @@ import type { GPUNode, GPUNodeHealthStatus, ClusterEvent, GPUHealthCronJobStatus
 // ============================================================================
 // Shared types
 // ============================================================================
-
-/** Shared result shape for all useCached* hooks */
-interface CachedHookResult<T> {
-  data: T
-  isLoading: boolean
-  isRefreshing: boolean
-  isDemoFallback: boolean
-  error: string | null
-  isFailed: boolean
-  consecutiveFailures: number
-  lastRefresh: number | null
-  refetch: () => Promise<void>
-}
 
 // ============================================================================
 // Hardware health types (canonical definitions)

--- a/web/src/hooks/useCachedGitOps.ts
+++ b/web/src/hooks/useCachedGitOps.ts
@@ -11,7 +11,7 @@
  * BuildpackImages) are kept as standalone functions.
  */
 
-import { useCache, type RefreshCategory } from '../lib/cache'
+import { useCache, type RefreshCategory, type CachedHookResult } from '../lib/cache'
 import { fetchGitOpsAPI, fetchViaGitOpsSSE, fetchRbacAPI } from '../lib/cache/fetcherUtils'
 import {
   getDemoHelmReleases,
@@ -36,23 +36,6 @@ import type {
   K8sRoleBinding,
   K8sServiceAccountInfo,
 } from './useMCP'
-
-// ============================================================================
-// Shared types
-// ============================================================================
-
-/** Shared result shape for all useCached* hooks */
-interface CachedHookResult<T> {
-  data: T
-  isLoading: boolean
-  isRefreshing: boolean
-  isDemoFallback: boolean
-  error: string | null
-  isFailed: boolean
-  consecutiveFailures: number
-  lastRefresh: number | null
-  refetch: () => Promise<void>
-}
 
 // ============================================================================
 // GitOps SSE factory — cluster-only hooks using fetchGitOpsAPI + SSE

--- a/web/src/hooks/useCachedISO27001.ts
+++ b/web/src/hooks/useCachedISO27001.ts
@@ -6,28 +6,12 @@
  * Extracted from useCachedData.ts for maintainability.
  */
 
-import { useCache, type RefreshCategory } from '../lib/cache'
+import { useCache, type RefreshCategory, type CachedHookResult } from '../lib/cache'
 import { kubectlProxy } from '../lib/kubectlProxy'
 import { KUBECTL_EXTENDED_TIMEOUT_MS } from '../lib/constants/network'
 import { clusterCacheRef } from './mcp/shared'
 import { isAgentUnavailable } from './useLocalAgent'
 import { settledWithConcurrency } from '../lib/utils/concurrency'
-
-// ============================================================================
-// Shared Types
-// ============================================================================
-
-interface CachedHookResult<T> {
-  data: T
-  isLoading: boolean
-  isRefreshing: boolean
-  isDemoFallback: boolean
-  error: string | null
-  isFailed: boolean
-  consecutiveFailures: number
-  lastRefresh: number | null
-  refetch: () => Promise<void>
-}
 
 // ============================================================================
 // ISO 27001 Audit Types

--- a/web/src/hooks/useCachedK8sResources.ts
+++ b/web/src/hooks/useCachedK8sResources.ts
@@ -6,7 +6,7 @@
  * useCachedNamespaces has a unique fetcher shape and is defined separately.
  */
 
-import { useCache, type RefreshCategory } from '../lib/cache'
+import { useCache, type RefreshCategory, type CachedHookResult } from '../lib/cache'
 import { fetchAPI, fetchFromAllClusters, fetchViaSSE, getToken } from '../lib/cache/fetcherUtils'
 import { FETCH_DEFAULT_TIMEOUT_MS } from '../lib/constants/network'
 import {
@@ -38,23 +38,6 @@ import type {
   Ingress,
   NetworkPolicy,
 } from './useMCP'
-
-// ============================================================================
-// Shared types
-// ============================================================================
-
-/** Shared result shape for all useCached* hooks */
-interface CachedHookResult<T> {
-  data: T
-  isLoading: boolean
-  isRefreshing: boolean
-  isDemoFallback: boolean
-  error: string | null
-  isFailed: boolean
-  consecutiveFailures: number
-  lastRefresh: number | null
-  refetch: () => Promise<void>
-}
 
 // ============================================================================
 // Factory

--- a/web/src/hooks/useCachedLLMd.ts
+++ b/web/src/hooks/useCachedLLMd.ts
@@ -5,27 +5,11 @@
  * Extracted from useCachedData.ts for maintainability.
  */
 
-import { useCache, type RefreshCategory } from '../lib/cache'
+import { useCache, type RefreshCategory, type CachedHookResult } from '../lib/cache'
 import { kubectlProxy } from '../lib/kubectlProxy'
 import { KUBECTL_EXTENDED_TIMEOUT_MS } from '../lib/constants/network'
 import { settledWithConcurrency } from '../lib/utils/concurrency'
 import type { LLMdServer, LLMdStatus, LLMdModel } from './useLLMd'
-
-// ============================================================================
-// Shared Types
-// ============================================================================
-
-interface CachedHookResult<T> {
-  data: T
-  isLoading: boolean
-  isRefreshing: boolean
-  isDemoFallback: boolean
-  error: string | null
-  isFailed: boolean
-  consecutiveFailures: number
-  lastRefresh: number | null
-  refetch: () => Promise<void>
-}
 
 // ============================================================================
 // Demo Data

--- a/web/src/hooks/useCachedNodes.ts
+++ b/web/src/hooks/useCachedNodes.ts
@@ -5,7 +5,7 @@
  */
 
 import { useSyncExternalStore } from 'react'
-import { useCache, type RefreshCategory } from '../lib/cache'
+import { useCache, type RefreshCategory, type CachedHookResult } from '../lib/cache'
 import { clusterCacheRef, deduplicateClustersByServer } from './mcp/shared'
 import { fetchAPI, fetchFromAllClusters, fetchViaSSE } from '../lib/cache/fetcherUtils'
 import { settledWithConcurrency } from '../lib/utils/concurrency'
@@ -68,19 +68,6 @@ function publishNodeClusterErrors(next: readonly NodeClusterError[]) {
 // ============================================================================
 // Shared types
 // ============================================================================
-
-/** Shared result shape for all useCached* hooks */
-interface CachedHookResult<T> {
-  data: T
-  isLoading: boolean
-  isRefreshing: boolean
-  isDemoFallback: boolean
-  error: string | null
-  isFailed: boolean
-  consecutiveFailures: number
-  lastRefresh: number | null
-  refetch: () => Promise<void>
-}
 
 // ============================================================================
 // CoreDNS types (defined here — this is the canonical location)

--- a/web/src/hooks/useCachedProw.ts
+++ b/web/src/hooks/useCachedProw.ts
@@ -5,26 +5,10 @@
  * Extracted from useCachedData.ts for maintainability.
  */
 
-import { useCache, type RefreshCategory } from '../lib/cache'
+import { useCache, type RefreshCategory, type CachedHookResult } from '../lib/cache'
 import { kubectlProxy } from '../lib/kubectlProxy'
 import { KUBECTL_EXTENDED_TIMEOUT_MS } from '../lib/constants/network'
 import type { ProwJob, ProwStatus } from './useProw'
-
-// ============================================================================
-// Shared Types
-// ============================================================================
-
-interface CachedHookResult<T> {
-  data: T
-  isLoading: boolean
-  isRefreshing: boolean
-  isDemoFallback: boolean
-  error: string | null
-  isFailed: boolean
-  consecutiveFailures: number
-  lastRefresh: number | null
-  refetch: () => Promise<void>
-}
 
 // ============================================================================
 // Constants

--- a/web/src/hooks/useCachedThanosStatus.ts
+++ b/web/src/hooks/useCachedThanosStatus.ts
@@ -4,7 +4,7 @@
  * Provides cached hooks for fetching Thanos status data.
  */
 
-import { useCache, type RefreshCategory } from '@/lib/cache'
+import { useCache, type RefreshCategory, type CachedHookResult } from '@/lib/cache'
 import { FETCH_DEFAULT_TIMEOUT_MS } from '../lib/constants/network'
 
 // ============================================================================
@@ -29,18 +29,6 @@ export interface ThanosStatus {
     storeGateways: ThanosStoreGateway[]
     queryHealth: 'healthy' | 'degraded'
     lastCheckTime: string
-}
-
-interface CachedHookResult<T> {
-    data: T
-    isLoading: boolean
-    isRefreshing: boolean
-    isDemoFallback: boolean
-    error: string | null
-    isFailed: boolean
-    consecutiveFailures: number
-    lastRefresh: number | null
-    refetch: () => Promise<void>
 }
 
 // ============================================================================

--- a/web/src/lib/cache/index.ts
+++ b/web/src/lib/cache/index.ts
@@ -1104,6 +1104,9 @@ export interface UseCacheResult<T> {
   isDemoFallback: boolean
 }
 
+/** Hook return shape without clearAndRefetch — used by useCached* wrapper hooks */
+export type CachedHookResult<T> = Omit<UseCacheResult<T>, 'clearAndRefetch'>
+
 export function useCache<T>({
   key,
   fetcher,


### PR DESCRIPTION
## Summary
- Extract `CachedHookResult<T>` as a shared type alias from `lib/cache/index.ts` (defined as `Omit<UseCacheResult<T>, 'clearAndRefetch'>`)
- Remove 9 identical copy-pasted interface definitions across hook files
- Net **-130 lines** of pure type duplication
- `useCachedCiliumStatus` keeps its own `CiliumCacheResult<T>` (divergent shape: `isDemoData` vs `isDemoFallback`, no `error` field)
- Follows the hook factory refactors from #9743 and #9752

## Files changed (11)
- `web/src/lib/cache/index.ts` — add `CachedHookResult<T>` type export
- 9 hook files — remove local interface, import from `../lib/cache`
- `web/src/hooks/useCachedCiliumStatus.ts` — rename to `CiliumCacheResult` to avoid name collision

## Test plan
- [x] `npm run build` passes
- [x] No lint errors on changed files
- [x] Zero behavioral change — type alias is structurally identical

🤖 Generated with [Claude Code](https://claude.com/claude-code)