### PR TITLE
fix: skip chunk prefetch on /login to prevent chunk_load errors

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -142,7 +142,13 @@ if (typeof window !== 'undefined') {
   /** Max wait (ms) for the enabled-dashboards list before prefetching all chunks */
   const PREFETCH_DASHBOARD_TIMEOUT_MS = 2_000
 
+  /** Routes where chunk prefetching is skipped to avoid errors during OAuth flow (#9767) */
+  const SKIP_PREFETCH_PATHS = new Set(['/login', '/auth/callback'])
+
   const prefetchRoutes = async () => {
+    // Skip prefetching on auth pages — during OAuth redirects, the browser
+    // navigates away before chunks finish loading, causing chunk_load errors.
+    if (SKIP_PREFETCH_PATHS.has(window.location.pathname)) return
     // Wait for the enabled dashboards list from /health so we only
     // prefetch chunks the user will actually see. Timeout after 2s
     // and prefetch all chunks — better to over-prefetch than leave


### PR DESCRIPTION
## Summary
- Skip route chunk prefetching on `/login` and `/auth/callback` pages to prevent `chunk_load` GA4 errors during OAuth redirect flow
- During OAuth, the browser navigates away from `/login` before prefetched chunks finish downloading, causing chunk load failures (4 hits today)
- These are transient auth pages — prefetching is wasteful and the dashboard prefetch runs after redirect completes

## Test plan
- [ ] Verify login page loads without chunk_load errors in browser console
- [ ] Verify OAuth redirect flow completes successfully
- [ ] Verify dashboard chunk prefetch still runs after successful auth redirect
- [ ] Monitor GA4 chunk_load errors on /login — expect 0 after deploy

Fixes #9767

🤖 Generated with [Claude Code](https://claude.com/claude-code)