### PR TITLE
fix: resolve React render errors on /enterprise/frameworks

### DIFF
--- a/web/src/components/compliance/ComplianceFrameworks.test.tsx
+++ b/web/src/components/compliance/ComplianceFrameworks.test.tsx
@@ -30,18 +30,15 @@ vi.mock('../../hooks/useComplianceFrameworks', () => ({
   useFrameworkEvaluation: () => mockEvalReturn,
 }))
 
-vi.mock('../../hooks/useMCP', () => ({
-  useClusters: () => ({
+// Mock the shared cluster cache used by the lightweight useClusterNames hook (#9769)
+vi.mock('../../hooks/mcp/shared', () => ({
+  clusterCache: {
     clusters: [
       { name: 'prod-east', reachable: true },
       { name: 'prod-west', reachable: true },
     ],
-    isLoading: false,
-    refetch: vi.fn(),
-    lastUpdated: null,
-    isRefreshing: false,
-    error: null,
-  }),
+  },
+  subscribeClusterData: () => () => {},
 }))
 
 import { ComplianceFrameworksContent as ComplianceFrameworks } from './ComplianceFrameworks'

--- a/web/src/components/compliance/ComplianceFrameworks.tsx
+++ b/web/src/components/compliance/ComplianceFrameworks.tsx
@@ -3,13 +3,23 @@
  *
  * Shows PCI-DSS 4.0, SOC 2 Type II, and other frameworks with per-control
  * pass/fail results and an overall compliance score.
+ *
+ * NOTE (#9769): This component previously called `useClusters()` directly
+ * just to populate the cluster dropdown. That heavyweight hook subscribes
+ * to the shared cluster cache and triggers re-renders on every cache update
+ * (health checks, WS pings, etc.). Combined with VersionCheckProvider
+ * cascading re-renders through EnterpriseLayout, this produced React error
+ * #185 ("Cannot update a component while rendering a different component").
+ * Fix: replaced useClusters() with a lightweight `useClusterNames()` hook
+ * that subscribes via useSyncExternalStore and only re-renders when the
+ * actual list of cluster names changes.
  */
-import { useState, useMemo, useEffect, useCallback } from 'react'
+import { useState, useMemo, useEffect, useCallback, useSyncExternalStore, memo } from 'react'
 import { Shield, ChevronDown, ChevronRight, CheckCircle2, XCircle, AlertTriangle, MinusCircle, Loader2, RefreshCw } from 'lucide-react'
 import { UnifiedDashboard } from '../../lib/unified/dashboard/UnifiedDashboard'
 import { complianceFrameworksDashboardConfig } from '../../config/dashboards/compliance-frameworks'
 import { useComplianceFrameworks, useFrameworkEvaluation, type Framework, type ControlResult, type ComplianceCheck } from '../../hooks/useComplianceFrameworks'
-import { useClusters } from '../../hooks/useMCP'
+import { clusterCache, subscribeClusterData } from '../../hooks/mcp/shared'
 
 /* ────────── status badge helpers ────────── */
 
@@ -149,11 +159,45 @@ function FrameworkCard({ fw, selected, onSelect }: { fw: Framework; selected: bo
   )
 }
 
+/* ────────── lightweight cluster names hook (#9769) ────────── */
+
+/**
+ * Subscribe callback adapter for useSyncExternalStore.
+ * Wraps the data-subscriber API so we can pass it to useSyncExternalStore.
+ */
+function subscribeClusterNames(onStoreChange: () => void): () => void {
+  return subscribeClusterData(() => onStoreChange())
+}
+
+/**
+ * Snapshot function for useSyncExternalStore.
+ * Returns a *stable* comma-joined string of cluster names so React can
+ * cheaply compare snapshots with Object.is. The component splits this
+ * back into an array via useMemo.
+ */
+function getClusterNamesSnapshot(): string {
+  return clusterCache.clusters.map(c => c.name).join('\0')
+}
+
+/**
+ * Lightweight hook that returns only cluster names.
+ * Unlike useClusters(), this does NOT subscribe to UI-indicator updates
+ * (isLoading, isRefreshing, error) or heavy data slices, so it only
+ * triggers a re-render when the set of cluster names actually changes.
+ */
+function useClusterNames(): string[] {
+  const snapshot = useSyncExternalStore(subscribeClusterNames, getClusterNamesSnapshot)
+  return useMemo(
+    () => (snapshot ? snapshot.split('\0') : []),
+    [snapshot],
+  )
+}
+
 /* ────────── main page ────────── */
 
-export function ComplianceFrameworksContent() {
+export const ComplianceFrameworksContent = memo(function ComplianceFrameworksContent() {
   const { frameworks, isLoading: fwLoading, error: fwError, refetch } = useComplianceFrameworks()
-  const { clusters } = useClusters()
+  const clusterNames = useClusterNames()
   const { result, isEvaluating, error: evalError, evaluate } = useFrameworkEvaluation()
 
   const [selectedFwId, setSelectedFwId] = useState<string | null>(null)
@@ -170,9 +214,6 @@ export function ComplianceFrameworksContent() {
     }
   }, [firstFwId, selectedFwId])
 
-  // Stable list of cluster names — avoids creating a new array reference
-  // on every render when useClusters() returns a fresh clusters object.
-  const clusterNames = useMemo(() => clusters.map(c => c.name), [clusters])
   const firstClusterName = clusterNames.length > 0 ? clusterNames[0] : null
 
   // Auto-select first cluster
@@ -330,7 +371,7 @@ export function ComplianceFrameworksContent() {
       )}
     </div>
   )
-}
+})
 
 export default function ComplianceFrameworks() {
   return (<>

--- a/web/src/hooks/useVersionCheck.tsx
+++ b/web/src/hooks/useVersionCheck.tsx
@@ -944,10 +944,55 @@ const VersionCheckContext = createContext<VersionCheckValue | null>(null)
 /**
  * Provider that creates a single version-check instance shared by all consumers.
  * Mount once near the app root (e.g. in Layout).
+ *
+ * IMPORTANT (#9769): The context value is memoized against every state/action
+ * field returned by useVersionCheckCore(). Without memoization, every internal
+ * state change (e.g. isChecking toggle, auto-update poll result) creates a new
+ * object reference, forcing ALL consumers (Navbar, Sidebar, UpdateIndicator,
+ * every card in the enterprise portal) to re-render. The cascade amplifies
+ * through hooks like useClusters() / useDashboardHealth() and can trip React
+ * error #185 on pages with many hook subscribers (e.g. /enterprise/frameworks).
  */
 export function VersionCheckProvider({ children }: { children: ReactNode }) {
   const value = useVersionCheckCore()
-  return <VersionCheckContext.Provider value={value}>{children}</VersionCheckContext.Provider>
+
+  // Memoize against individual fields so consumers only re-render when a
+  // value they might read actually changes. Actions (useCallback) are stable
+  // across renders, so they don't contribute to unnecessary invalidations.
+  const memoized = useMemo(() => value, [
+    value.currentVersion,
+    value.commitHash,
+    value.channel,
+    value.latestRelease,
+    value.hasUpdate,
+    value.isChecking,
+    value.error,
+    value.lastChecked,
+    value.skippedVersions,
+    value.releases,
+    value.lastCheckResult,
+    value.autoUpdateEnabled,
+    value.installMethod,
+    value.autoUpdateStatus,
+    value.updateProgress,
+    value.agentConnected,
+    value.hasCodingAgent,
+    value.latestMainSHA,
+    value.recentCommits,
+    // Actions — stable useCallback references, included for completeness
+    value.setChannel,
+    value.checkForUpdates,
+    value.forceCheck,
+    value.skipVersion,
+    value.clearSkippedVersions,
+    value.setAutoUpdateEnabled,
+    value.triggerUpdate,
+    value.cancelUpdate,
+    value.setUpdateProgress,
+    value.clearLastCheckResult,
+  ])
+
+  return <VersionCheckContext.Provider value={memoized}>{children}</VersionCheckContext.Provider>
 }
 
 /**


### PR DESCRIPTION
## Summary

- Replace heavyweight `useClusters()` call in `ComplianceFrameworksContent` with a lightweight `useClusterNames()` hook using `useSyncExternalStore` -- only re-renders when cluster names actually change (not on every cache health check / WS ping / UI indicator update)
- Wrap `ComplianceFrameworksContent` in `React.memo` to prevent parent-triggered re-renders from `VersionCheckProvider` cascading through `EnterpriseLayout`
- Memoize `VersionCheckProvider` context value (14 useState variables) so consumers only re-render when a field they read actually changes

Fixes #9769

## Test plan

- [ ] Navigate to `/enterprise/frameworks` -- page loads without React #185 error
- [ ] Verify framework auto-selection still works
- [ ] Verify cluster dropdown populates and auto-selects first cluster
- [ ] Verify Run Evaluation button works with selected framework + cluster
- [ ] Verify sidebar collapse/expand still works in enterprise portal
- [ ] Verify existing unit tests pass (`ComplianceFrameworks.test.tsx`)