### PR TITLE
fix: enable dashboard selection on mobile sidebar (Safari)

### DIFF
--- a/web/src/components/layout/SidebarShell.tsx
+++ b/web/src/components/layout/SidebarShell.tsx
@@ -384,7 +384,9 @@ export function SidebarShell({
     return IconComponent ? <IconComponent className={className} /> : null
   }
 
-  const canDrag = features.dragReorder !== false
+  /* Disable drag-reorder on mobile — draggable elements intercept touch
+   * events on Safari, preventing NavLink taps from registering. */
+  const canDrag = features.dragReorder !== false && !isMobile
 
   const renderNavItem = (item: SidebarNavItem, sectionId: string) => {
     const isEditing = editingItemId === item.id
@@ -547,7 +549,7 @@ export function SidebarShell({
   // ---- Main render ----
   return (
     <>
-      {/* Mobile backdrop */}
+      {/* Mobile backdrop — closes sidebar when tapped outside the sidebar panel */}
       {isMobile && config.isMobileOpen && (
         <div
           className="fixed inset-0 bg-black/60 backdrop-blur-xs z-overlay md:hidden"
@@ -562,7 +564,7 @@ export function SidebarShell({
         onMouseLeave={handleSidebarMouseLeave}
         className={cn(
           'fixed left-0 top-16 bottom-0 glass border-r border-border/50 overflow-y-auto scroll-enhanced',
-          isMobile ? 'z-modal' : 'z-sidebar',
+          isMobile ? 'z-modal touch-manipulation' : 'z-sidebar',
           !isResizing && 'transition-all duration-300',
           !isMobile && (config.collapsed ? 'p-3' : 'p-4'),
           isMobile && 'p-4',


### PR DESCRIPTION
## Summary
- Disable `draggable` attribute on nav items when on mobile viewports — Safari intercepts touch events on draggable elements for drag handling, preventing NavLink taps from registering
- Add `touch-manipulation` CSS to the mobile sidebar panel to eliminate Safari's 300ms tap delay and double-tap-to-zoom interference

Fixes #9758

## Context
PR #9764 fixed the visual "fade" issue by raising the mobile sidebar's z-index above the backdrop overlay. However, users still could not tap dashboard links on mobile Safari. Two remaining issues caused this:

1. **`draggable=true` on touch devices**: The nav items had `draggable={true}` on mobile. Safari treats touch-start events on draggable elements as potential drag gestures, consuming the tap before the NavLink click handler fires. Drag-reorder is a desktop feature and is now disabled on mobile.

2. **Missing `touch-action: manipulation`**: Without this CSS property, Safari applies a 300ms tap delay (waiting to see if a double-tap-to-zoom follows). This delay can cause taps to be lost or feel unresponsive. The `touch-manipulation` utility removes both the delay and double-tap-to-zoom.

## Test plan
- [ ] Open on iPhone Safari — hamburger menu opens, dashboard links are tappable
- [ ] Tapping a dashboard link navigates to that dashboard and closes the sidebar
- [ ] Tapping the backdrop (outside the sidebar) closes the sidebar
- [ ] Desktop drag-reorder still works normally
- [ ] No regressions on Chrome/Firefox mobile