### PR TITLE
fix: repair ComplianceFrameworks test mock after render fix

### DIFF
--- a/web/src/components/compliance/ComplianceFrameworks.test.tsx
+++ b/web/src/components/compliance/ComplianceFrameworks.test.tsx
@@ -30,16 +30,22 @@ vi.mock('../../hooks/useComplianceFrameworks', () => ({
   useFrameworkEvaluation: () => mockEvalReturn,
 }))
 
-// Mock the shared cluster cache used by the lightweight useClusterNames hook (#9769)
-vi.mock('../../hooks/mcp/shared', () => ({
-  clusterCache: {
-    clusters: [
-      { name: 'prod-east', reachable: true },
-      { name: 'prod-west', reachable: true },
-    ],
-  },
-  subscribeClusterData: () => () => {},
-}))
+// Mock the shared cluster cache used by the lightweight useClusterNames hook (#9769).
+// Use importOriginal so that re-exported constants (CLUSTER_POLL_INTERVAL_MS, etc.)
+// remain available to transitive imports such as ClusterMetrics → cardRegistry.
+vi.mock('../../hooks/mcp/shared', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../hooks/mcp/shared')>()
+  return {
+    ...actual,
+    clusterCache: {
+      clusters: [
+        { name: 'prod-east', reachable: true },
+        { name: 'prod-west', reachable: true },
+      ],
+    },
+    subscribeClusterData: () => () => {},
+  }
+})
 
 import { ComplianceFrameworksContent as ComplianceFrameworks } from './ComplianceFrameworks'
 


### PR DESCRIPTION
## Summary
- The `vi.mock('../../hooks/mcp/shared')` in `ComplianceFrameworks.test.tsx` only stubbed `clusterCache` and `subscribeClusterData`, dropping all other exports from the module
- Transitive imports (e.g. `ClusterMetrics.tsx` via `cardRegistry.ts`) need `CLUSTER_POLL_INTERVAL_MS` and other constants from the same module, causing a load-time error
- Fixed by using `importOriginal` to spread the real module exports and only override the two cluster-cache symbols needed for the test

## Test plan
- [x] `npx vitest run src/components/compliance/ComplianceFrameworks.test.tsx` — all 11 tests pass
- [ ] CI build/lint passes

Fixes #9775