### PR TITLE
fix: cluster filter None button does nothing

### DIFF
--- a/web/src/hooks/useGlobalFilters.tsx
+++ b/web/src/hooks/useGlobalFilters.tsx
@@ -264,12 +264,18 @@ export function GlobalFiltersProvider({ children }: { children: ReactNode }) {
     return []
   })
 
+  // Sentinel value used by deselectAll* to represent "no items selected".
+  // Must be preserved during reconciliation so that filterBy* functions
+  // can recognise the "select none" state and return an empty result set.
+  const NONE_SENTINEL = '__none__'
+
   // Reconcile selected clusters against available clusters — drop any that no longer exist.
   // This prevents filters from getting stuck on clusters that have been removed from kubeconfig.
-  // Also reconciles the __none__ sentinel (from deselectAllClusters) back to all-selected
-  // mode, since __none__ is not a real cluster name and will be filtered out.
+  // Skip reconciliation when the __none__ sentinel is present (user explicitly deselected all).
   useEffect(() => {
     if (selectedClusters.length === 0 || availableClusters.length === 0) return
+    // Preserve the "select none" sentinel — it is not a real cluster name
+    if (selectedClusters.includes(NONE_SENTINEL)) return
     const validSelections = selectedClusters.filter(c => availableClusters.includes(c))
     if (validSelections.length !== selectedClusters.length) {
       setSelectedClustersState(validSelections.length === 0 ? [] : validSelections)
@@ -484,9 +490,11 @@ export function GlobalFiltersProvider({ children }: { children: ReactNode }) {
     return Array.from(distSet).sort()
   }, [deduplicatedClusters])
 
-  // Reconcile selected distributions against available ones
+  // Reconcile selected distributions against available ones.
+  // Skip when the __none__ sentinel is present (user explicitly deselected all).
   useEffect(() => {
     if (selectedDistributions.length === 0 || availableDistributions.length === 0) return
+    if (selectedDistributions.includes(NONE_SENTINEL)) return
     const validSelections = selectedDistributions.filter(d => availableDistributions.includes(d))
     if (validSelections.length !== selectedDistributions.length) {
       setSelectedDistributionsState(validSelections.length === 0 ? [] : validSelections)


### PR DESCRIPTION
## Summary
- Fix the "None" button in the cluster filter panel which had no effect when clicked
- Root cause: the reconciliation effect that prunes stale cluster names was also stripping the `__none__` sentinel used by `deselectAllClusters`, resetting state back to `[]` (all selected)
- Same bug existed in the distribution filter reconciliation — fixed both

## Details
The `deselectAll*` handlers set state to `['__none__']` as a sentinel representing "no items selected". The `filterByCluster` and related functions correctly check for this sentinel and return empty results. However, the `useEffect` that reconciles selected clusters against `availableClusters` was filtering out `__none__` (since it's not a real cluster name), and when the result was empty, it reset to `[]` — which means "all selected". This made the None button appear to do nothing.

The fix adds a guard to skip reconciliation when the `__none__` sentinel is present.

Fixes #9782