### PR TITLE
feat: add 'Add more...' button to Enterprise sidebar

### DIFF
--- a/web/src/components/enterprise/EnterpriseSidebar.tsx
+++ b/web/src/components/enterprise/EnterpriseSidebar.tsx
@@ -23,6 +23,7 @@ import { useDashboardContextOptional } from '../../hooks/useDashboardContext'
 const SIDEBAR_FEATURES = {
   missions: true,
   addCard: true,
+  addMore: true,
   clusterStatus: true,
   collapsePin: true,
   resize: true,


### PR DESCRIPTION
## Summary
- Adds `addMore: true` to Enterprise sidebar features config
- Wires `onAddMore` callback to `openAddCardModal('dashboards')` so clicking "Add more..." opens Console Studio in the Dashboard Manager context
- Preserves existing `onAddCard` handler and memoization patterns to avoid re-render loops (#9753, #9754)

Follows up on #9785 which restored the button in the main sidebar.

Fixes #9783