### PR TITLE
fix: filter ResizeObserver loop errors from GA4 runtime tracking

### DIFF
--- a/web/src/lib/__tests__/analytics-error-tracking.test.ts
+++ b/web/src/lib/__tests__/analytics-error-tracking.test.ts
@@ -375,6 +375,20 @@ describe('startGlobalErrorTracking sets up listeners', () => {
     const event = new ErrorEvent('error', { message: 'ReferenceError: foo is not defined' })
     expect(() => window.dispatchEvent(event)).not.toThrow()
   })
+
+  it('skips ResizeObserver loop errors (benign browser noise)', () => {
+    startGlobalErrorTracking()
+    // Chrome/Edge message
+    const event1 = new ErrorEvent('error', {
+      message: 'ResizeObserver loop completed with undelivered notifications.',
+    })
+    expect(() => window.dispatchEvent(event1)).not.toThrow()
+    // Older browser message
+    const event2 = new ErrorEvent('error', {
+      message: 'ResizeObserver loop limit exceeded',
+    })
+    expect(() => window.dispatchEvent(event2)).not.toThrow()
+  })
 })
 
 describe('markErrorReported and dedup integration', () => {

--- a/web/src/lib/analytics-core.ts
+++ b/web/src/lib/analytics-core.ts
@@ -831,6 +831,11 @@ export function startGlobalErrorTracking() {
         event.filename.startsWith('moz-extension://') ||
         event.filename.startsWith('safari-extension://')
       )) return
+      // ResizeObserver loop errors are benign browser noise — the W3C spec
+      // fires this when observations can't be delivered in a single animation
+      // frame. Multiple cards on the dashboard use ResizeObserver, and layout
+      // shifts during initial render or window resize trigger this harmlessly.
+      if (event.message.includes('ResizeObserver loop')) return
       // Stale chunks can surface as runtime errors (Safari: "Importing a module script failed")
       if (tryChunkReloadRecovery(event.message)) return
       emitError('runtime', event.message)


### PR DESCRIPTION
## Summary
- Filter benign `ResizeObserver loop` errors from the global window error handler in `analytics-core.ts`, preventing them from being reported as `runtime` category GA4 events
- Add test coverage for both Chrome/Edge ("completed with undelivered notifications") and older browser ("limit exceeded") message variants

## Root cause
The dashboard root `/` renders multiple cards that use `ResizeObserver` (CardWrapper, DrasiReactiveGraph, PipelineFlow, MobileBrowser, VirtualizedMissionGrid). When many observers fire during layout shifts (initial render, window resize), the browser emits a "ResizeObserver loop completed with undelivered notifications" error on the window `error` event. This is benign browser noise — the W3C spec acknowledges it as informational. The global error handler was not filtering these, causing persistent ~2 hits per GA4 reviewer pass.

## Test plan
- [x] Added test for both ResizeObserver error message variants
- [ ] CI build/lint passes

Fixes #9774