### PR TITLE
fix: suppress benign ResizeObserver loop errors on dashboard

### DIFF
--- a/web/src/lib/__tests__/analytics-error-tracking.test.ts
+++ b/web/src/lib/__tests__/analytics-error-tracking.test.ts
@@ -375,6 +375,22 @@ describe('startGlobalErrorTracking sets up listeners', () => {
     const event = new ErrorEvent('error', { message: 'ReferenceError: foo is not defined' })
     expect(() => window.dispatchEvent(event)).not.toThrow()
   })
+
+  it('skips ResizeObserver loop errors', () => {
+    startGlobalErrorTracking()
+    const event = new ErrorEvent('error', {
+      message: 'ResizeObserver loop completed with undelivered notifications.',
+    })
+    expect(() => window.dispatchEvent(event)).not.toThrow()
+  })
+
+  it('skips ResizeObserver loop limit exceeded errors', () => {
+    startGlobalErrorTracking()
+    const event = new ErrorEvent('error', {
+      message: 'ResizeObserver loop limit exceeded',
+    })
+    expect(() => window.dispatchEvent(event)).not.toThrow()
+  })
 })
 
 describe('markErrorReported and dedup integration', () => {

--- a/web/src/lib/analytics-core.ts
+++ b/web/src/lib/analytics-core.ts
@@ -833,6 +833,11 @@ export function startGlobalErrorTracking() {
       )) return
       // Stale chunks can surface as runtime errors (Safari: "Importing a module script failed")
       if (tryChunkReloadRecovery(event.message)) return
+      // Skip benign ResizeObserver loop errors — these fire when the browser
+      // can't deliver all ResizeObserver notifications in a single animation
+      // frame. Common with dynamically resized dashboard cards/grids and
+      // completely harmless (the browser retries on the next frame).
+      if (event.message.includes('ResizeObserver loop')) return
       emitError('runtime', event.message)
     } finally {
       isEmitting = false


### PR DESCRIPTION
## Summary
- Filter out `ResizeObserver loop` errors from GA4 runtime error tracking in the global `window` error listener
- These are benign browser warnings that fire when the browser can't deliver all ResizeObserver notifications in a single animation frame (common with dynamically resized dashboard cards/grids)
- The browser automatically retries on the next frame — no user impact
- Added two test cases covering both Chrome and Firefox error message variants

## Context
GA4 was reporting 2 persistent `runtime` errors per monitoring pass on `/` (dashboard root), with 0 in the 7-day baseline. The errors appeared after compliance epic PRs merged, which added more cards with dynamic layouts that trigger ResizeObserver callbacks.

Fixes #9774

## Test plan
- [ ] Verify `npm run build` passes in CI
- [ ] Verify existing analytics error tracking tests pass
- [ ] Verify new ResizeObserver test cases pass
- [ ] Monitor GA4 runtime error count on `/` — should drop to 0