### PR TITLE
fix: guard enterprise compliance pages against render errors

### DIFF
--- a/web/src/components/cards/cardRegistry.ts
+++ b/web/src/components/cards/cardRegistry.ts
@@ -509,9 +509,9 @@ const RAW_CARD_COMPONENTS: Record<string, CardComponent> = {
   risk_register: RiskRegisterCard,
   risk_appetite: RiskAppetiteCard,
   // Dashboard content cards (full-width, lazy loaded individually)
-  sbom_dashboard: lazy(() => import('../compliance/SBOMDashboard').then(m => ({ default: m.SBOMDashboardContent }))),
-  sigstore_dashboard: lazy(() => import('../compliance/SigstoreDashboard').then(m => ({ default: m.SigstoreDashboardContent }))),
-  slsa_dashboard: lazy(() => import('../compliance/SLSADashboard').then(m => ({ default: m.SLSADashboardContent }))),
+  sbom_dashboard: safeLazy(() => import('../compliance/SBOMDashboard'), 'SBOMDashboardContent'),
+  sigstore_dashboard: safeLazy(() => import('../compliance/SigstoreDashboard'), 'SigstoreDashboardContent'),
+  slsa_dashboard: safeLazy(() => import('../compliance/SLSADashboard'), 'SLSADashboardContent'),
   // Enterprise dashboard content cards (full dashboards as cards)
   compliance_frameworks_dashboard: ComplianceFrameworksDashboardCard,
   change_control_dashboard: ChangeControlDashboardCard,

--- a/web/src/components/compliance/ChangeControlAudit.tsx
+++ b/web/src/components/compliance/ChangeControlAudit.tsx
@@ -81,10 +81,14 @@ export function ChangeControlAuditContent() {
         authFetch('/api/compliance/change-control/policies'),
       ])
       if (!sRes.ok || !cRes.ok || !vRes.ok || !pRes.ok) throw new Error('Failed to load change control data')
-      setSummary(await sRes.json())
-      setChanges(await cRes.json())
-      setViolations(await vRes.json())
-      setPolicies(await pRes.json())
+      const sData = await sRes.json()
+      const cData = await cRes.json()
+      const vData = await vRes.json()
+      const pData = await pRes.json()
+      setSummary(sData ?? null)
+      setChanges(Array.isArray(cData) ? cData : [])
+      setViolations(Array.isArray(vData) ? vData : [])
+      setPolicies(Array.isArray(pData) ? pData : [])
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to load data')
     } finally {
@@ -95,7 +99,7 @@ export function ChangeControlAuditContent() {
   useEffect(() => { fetchData() }, [])
 
   const filteredChanges = useMemo(() =>
-    filterApproval === 'all' ? changes : changes.filter(c => c.approval_status === filterApproval),
+    filterApproval === 'all' ? (changes || []) : (changes || []).filter(c => c.approval_status === filterApproval),
     [changes, filterApproval]
   )
 
@@ -163,7 +167,7 @@ export function ChangeControlAuditContent() {
               </Select>
             </div>
           </div>
-          {filteredChanges.map(change => {
+          {(filteredChanges || []).map(change => {
             const approval = APPROVAL_STYLES[change.approval_status] ?? APPROVAL_STYLES.pending
             return (
               <div key={change.id} className="rounded-lg border border-zinc-700/30 bg-zinc-800/50 p-4">
@@ -194,7 +198,7 @@ export function ChangeControlAuditContent() {
 
       {activeTab === 'violations' && (
         <div className="space-y-2">
-          {violations.length === 0 ? <p className="text-zinc-500 text-sm text-center py-8">No policy violations detected</p> : violations.map(v => (
+          {(violations || []).length === 0 ? <p className="text-zinc-500 text-sm text-center py-8">No policy violations detected</p> : (violations || []).map(v => (
             <div key={v.id} className="rounded-lg border border-zinc-700/30 bg-zinc-900/30 p-3">
               <div className="flex items-center justify-between mb-1">
                 <div className="flex items-center gap-2">
@@ -211,7 +215,7 @@ export function ChangeControlAuditContent() {
 
       {activeTab === 'policies' && (
         <div className="space-y-2">
-          {policies.map(p => (
+          {(policies || []).map(p => (
             <div key={p.id} className="rounded-lg border border-zinc-700/30 bg-zinc-900/30 p-4">
               <div className="flex items-center justify-between mb-2">
                 <div className="flex items-center gap-2">

--- a/web/src/components/compliance/SLSADashboard.tsx
+++ b/web/src/components/compliance/SLSADashboard.tsx
@@ -109,9 +109,12 @@ export function SLSADashboardContent() {
           authFetch('/api/v1/compliance/slsa/summary'),
         ])
         if (!aRes.ok || !pRes.ok || !sRes.ok) throw new Error('Failed to fetch SLSA data')
-        setAttestations(await aRes.json())
-        setProvenance(await pRes.json())
-        setSummary(await sRes.json())
+        const aData = await aRes.json()
+        const pData = await pRes.json()
+        const sData = await sRes.json()
+        setAttestations(Array.isArray(aData) ? aData : [])
+        setProvenance(Array.isArray(pData) ? pData : [])
+        setSummary(sData ?? null)
       } catch (e) {
         setError(e instanceof Error ? e.message : 'Unknown error')
       } finally {
@@ -255,7 +258,7 @@ export function SLSADashboardContent() {
               </tr>
             </thead>
             <tbody>
-              {attestations.map((a) => (
+              {(attestations || []).map((a) => (
                 <tr key={a.id} className="border-b border-gray-800 hover:bg-gray-800/30">
                   <td className="py-2 px-3 text-white font-mono text-xs max-w-xs truncate">{a.artifact}</td>
                   <td className="py-2 px-3 text-gray-300 text-xs">{a.builder}</td>
@@ -292,7 +295,7 @@ export function SLSADashboardContent() {
               </tr>
             </thead>
             <tbody>
-              {provenance.map((p) => (
+              {(provenance || []).map((p) => (
                 <tr key={p.id} className="border-b border-gray-800 hover:bg-gray-800/30">
                   <td className="py-2 px-3 text-white font-mono text-xs max-w-xs truncate">{p.artifact}</td>
                   <td className="py-2 px-3 text-gray-300 text-xs">{p.builder_id}</td>


### PR DESCRIPTION
## Summary

- Add `Array.isArray()` guards on API JSON responses in `ChangeControlAudit` and `SLSADashboard` to prevent uncaught render errors when endpoints return non-array data
- Add `(arr || [])` guards on all `.map()`, `.filter()`, and `.length` calls in render paths for both components
- Switch supply-chain dashboard card lazy imports (`sbom_dashboard`, `sigstore_dashboard`, `slsa_dashboard`) from bare `lazy()` to `safeLazy()` for retry/timeout resilience

Fixes #9787

## Test plan

- [ ] Navigate to `/enterprise/change-control` — page loads without render errors
- [ ] Navigate to `/enterprise/slsa` — page loads without render errors
- [ ] Verify GA4 shows no new `uncaught_render` events on these pages
- [ ] Verify tabs (changes/violations/policies on change-control; attestations/provenance on SLSA) render correctly