### PR TITLE
🐛 Fix enterprise portal: scroll, studio, tip bar, add-more

### DIFF
--- a/web/src/components/enterprise/EnterpriseLayout.tsx
+++ b/web/src/components/enterprise/EnterpriseLayout.tsx
@@ -9,14 +9,16 @@
  * content area needs an explicit left margin to clear it — mirroring the
  * approach used by the primary Layout component.
  */
-import { lazy, Suspense } from 'react'
+import { lazy, Suspense, useCallback } from 'react'
 import { Outlet, useLocation } from 'react-router-dom'
 import EnterpriseSidebar from './EnterpriseSidebar'
 import { VersionCheckProvider } from '../../hooks/useVersionCheck'
 import { useSidebarConfig, SIDEBAR_COLLAPSED_WIDTH_PX, SIDEBAR_DEFAULT_WIDTH_PX } from '../../hooks/useSidebarConfig'
 import { useMobile } from '../../hooks/useMobile'
+import { useDashboardContextOptional } from '../../hooks/useDashboardContext'
 import { Navbar } from '../layout/navbar/index'
 import { NAVBAR_HEIGHT_PX, SIDEBAR_CONTROLS_OFFSET_PX } from '../../lib/constants/ui'
+import { FloatingDashboardActions } from '../dashboard/FloatingDashboardActions'
 
 const MissionSidebar = lazy(() =>
   import('../layout/mission-sidebar').then((m) => ({ default: m.MissionSidebar })),
@@ -31,6 +33,7 @@ export default function EnterpriseLayout() {
   const { config } = useSidebarConfig()
   const { isMobile } = useMobile()
   const location = useLocation()
+  const dashboardContext = useDashboardContextOptional()
 
   const sidebarWidthPx = isMobile
     ? 0
@@ -38,9 +41,16 @@ export default function EnterpriseLayout() {
       ? SIDEBAR_COLLAPSED_WIDTH_PX
       : (config.width ?? SIDEBAR_DEFAULT_WIDTH_PX)
 
+  const handleOpenStudio = useCallback(() => {
+    dashboardContext?.openAddCardModal()
+  }, [dashboardContext])
+
   return (
     <VersionCheckProvider>
-      <div className="h-screen bg-gray-950 text-white overflow-hidden">
+      {/* flex flex-col is required so the flex container below stretches
+          to fill remaining height, giving <main> a constrained height
+          for overflow-y-auto to work (scroll fix). */}
+      <div className="h-screen bg-gray-950 text-white overflow-hidden flex flex-col">
         <Navbar />
 
         <div
@@ -55,13 +65,16 @@ export default function EnterpriseLayout() {
               marginLeft: isMobile ? 0 : sidebarWidthPx + SIDEBAR_CONTROLS_OFFSET_PX,
               marginRight: isMobile ? 0 : `calc(var(--mission-sidebar-width, 0px) + ${SIDEBAR_CONTROLS_OFFSET_PX}px)`,
             }}
-            className="relative flex-1 p-4 pb-24 md:p-6 md:pb-28 transition-[margin] duration-300 overflow-y-auto overflow-x-hidden scroll-enhanced min-w-0"
+            className="relative flex-1 p-4 pb-24 pb-[calc(6rem+env(safe-area-inset-bottom))] md:p-6 md:pb-28 md:pb-[calc(7rem+env(safe-area-inset-bottom))] transition-[margin] duration-300 overflow-y-auto overflow-x-hidden scroll-enhanced min-w-0"
           >
             <div key={location.pathname} className="contents">
               <Outlet />
             </div>
           </main>
         </div>
+
+        {/* Console Studio floating action button */}
+        <FloatingDashboardActions onOpenCustomizer={handleOpenStudio} />
 
         {/* AI Mission sidebar — same as main Layout */}
         <Suspense fallback={null}>

--- a/web/src/components/enterprise/EnterprisePortal.tsx
+++ b/web/src/components/enterprise/EnterprisePortal.tsx
@@ -4,12 +4,16 @@
  * Shows a dashboard overview of all compliance verticals with
  * status cards linking to each epic's dashboards.
  */
+import { useState, useCallback } from 'react'
 import { useNavigate } from 'react-router-dom'
 import {
   Landmark, Heart, Shield, KeyRound, Radar, Container, Scale, TrendingUp,
-  CheckCircle2, AlertTriangle, Clock, ArrowRight,
+  CheckCircle2, AlertTriangle, Clock, ArrowRight, Plus,
 } from 'lucide-react'
 import { ENTERPRISE_NAV_SECTIONS } from './enterpriseNav'
+import { DashboardHeader } from '../shared/DashboardHeader'
+import { RotatingTip } from '../ui/RotatingTip'
+import { useDashboardContextOptional } from '../../hooks/useDashboardContext'
 
 const VERTICAL_META: Record<string, {
   icon: React.ComponentType<{ className?: string }>
@@ -139,18 +143,37 @@ function VerticalCard({ sectionId, title, items, onNavigate }: {
 
 export default function EnterprisePortal() {
   const navigate = useNavigate()
+  const [autoRefresh, setAutoRefresh] = useState(true)
+  const [lastUpdated] = useState(() => new Date())
+  const dashboardContext = useDashboardContextOptional()
+
+  const handleRefresh = useCallback(() => {
+    // Force re-render with fresh timestamp
+    window.location.reload()
+  }, [])
+
+  const handleAddMore = useCallback(() => {
+    if (dashboardContext?.openAddCardModal) {
+      dashboardContext.openAddCardModal('dashboards')
+    }
+  }, [dashboardContext])
 
   const sections = ENTERPRISE_NAV_SECTIONS.filter((s) => s.id !== 'overview')
 
   return (
     <div className="p-6 max-w-7xl mx-auto">
-      {/* Header */}
-      <div className="mb-8">
-        <h1 className="text-2xl font-bold text-white mb-1">Enterprise Compliance Portal</h1>
-        <p className="text-sm text-gray-400">
-          Unified governance, risk, and compliance across all Kubernetes clusters
-        </p>
-      </div>
+      {/* Header with tip bar, auto-refresh, and refresh button */}
+      <DashboardHeader
+        title="Enterprise Compliance Portal"
+        subtitle="Unified governance, risk, and compliance across all Kubernetes clusters"
+        isFetching={false}
+        onRefresh={handleRefresh}
+        autoRefresh={autoRefresh}
+        onAutoRefreshChange={setAutoRefresh}
+        autoRefreshId="enterprise-auto-refresh"
+        lastUpdated={lastUpdated}
+        rightExtra={<RotatingTip page="enterprise" />}
+      />
 
       {/* Summary Stats */}
       <div className="grid grid-cols-4 gap-4 mb-8">
@@ -194,6 +217,24 @@ export default function EnterprisePortal() {
             onNavigate={(href) => navigate(href)}
           />
         ))}
+
+        {/* Add More tile */}
+        <button
+          onClick={handleAddMore}
+          className="rounded-xl border-2 border-dashed border-gray-700 hover:border-purple-500/50 bg-gray-900/30 hover:bg-purple-500/5 p-5 flex flex-col items-center justify-center gap-3 transition-all group min-h-[200px]"
+        >
+          <div className="p-3 rounded-full bg-gray-800 group-hover:bg-purple-500/20 transition-colors">
+            <Plus className="w-6 h-6 text-gray-400 group-hover:text-purple-400 transition-colors" />
+          </div>
+          <div className="text-center">
+            <p className="text-sm font-medium text-gray-400 group-hover:text-purple-300 transition-colors">
+              Add More
+            </p>
+            <p className="text-xs text-gray-500 mt-1">
+              Dashboards, cards &amp; widgets
+            </p>
+          </div>
+        </button>
       </div>
     </div>
   )

--- a/web/src/components/ui/RotatingTip.tsx
+++ b/web/src/components/ui/RotatingTip.tsx
@@ -173,6 +173,14 @@ const TIPS: Record<string, string[]> = {
     'Click an agent to see its recent operations and permission scope.',
     'Agent actions are logged for audit and can be replayed as missions.',
   ],
+  enterprise: [
+    'Pin your most-used dashboards to the sidebar for one-click access.',
+    'The Enterprise Portal covers 7 compliance verticals across 24 dashboards.',
+    'Use Console Studio (gear icon) to add cards, dashboards, and widgets.',
+    'Each vertical has its own compliance score based on automated checks.',
+    'AI Missions can detect and remediate compliance gaps automatically.',
+    'Export compliance reports as PDF for your next audit cycle.',
+  ],
   'ci-cd': [
     'CI/CD cards aggregate pipeline status from GitHub Actions and more.',
     'Failed workflows are highlighted with links to the failing job.',


### PR DESCRIPTION
Fixes four enterprise portal issues:

1. **Scroll broken** — outer div was missing `flex flex-col`, preventing `overflow-y-auto` on `<main>` from working
2. **Console Studio missing** — `FloatingDashboardActions` (gear FAB) now rendered in EnterpriseLayout
3. **Tip bar missing** — `DashboardHeader` with `RotatingTip` and auto-refresh added to portal header
4. **Add More missing** — dashed tile at end of vertical grid opens Dashboard Studio's dashboards section

Also added enterprise-specific rotating tips.