### PR TITLE
fix: guard enterprise ChangeControl and SLSA against render errors

### DIFF
--- a/web/src/components/compliance/AirGapDashboard.tsx
+++ b/web/src/components/compliance/AirGapDashboard.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useMemo } from 'react'
+import { useState, useEffect, useMemo, memo } from 'react'
 import { UnifiedDashboard } from '../../lib/unified/dashboard/UnifiedDashboard'
 import { airgapDashboardConfig } from '../../config/dashboards/airgap'
 import {
@@ -64,7 +64,7 @@ const statusColor = (status: string) => {
   }
 }
 
-export function AirGapDashboardContent() {
+export const AirGapDashboardContent = memo(function AirGapDashboardContent() {
   const [requirements, setRequirements] = useState<Requirement[]>([])
   const [clusters, setClusters] = useState<ClusterReadiness[]>([])
   const [summary, setSummary] = useState<AirGapSummary | null>(null)
@@ -302,7 +302,7 @@ export function AirGapDashboardContent() {
       )}
     </div>
   )
-}
+})
 
 export default function AirGapDashboard() {
   return (<>

--- a/web/src/components/compliance/BAADashboard.tsx
+++ b/web/src/components/compliance/BAADashboard.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useMemo } from 'react'
+import { useState, useEffect, useMemo, memo } from 'react'
 import { UnifiedDashboard } from '../../lib/unified/dashboard/UnifiedDashboard'
 import { baaDashboardConfig } from '../../config/dashboards/baa'
 import {
@@ -33,7 +33,7 @@ const PROVIDER_ICONS: Record<string, typeof Cloud> = {
   cloud: Cloud, saas: Server, managed_service: Building2, consulting: FileText,
 }
 
-export function BAADashboardContent() {
+export const BAADashboardContent = memo(function BAADashboardContent() {
   const [agreements, setAgreements] = useState<BAAgreement[]>([])
   const [alerts, setAlerts] = useState<BAAAlert[]>([])
   const [summary, setSummary] = useState<BAASummary | null>(null)
@@ -280,7 +280,7 @@ export function BAADashboardContent() {
       )}
     </div>
   )
-}
+})
 
 export default function BAADashboard() {
   return (<>

--- a/web/src/components/compliance/ChangeControlAudit.tsx
+++ b/web/src/components/compliance/ChangeControlAudit.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useMemo, memo } from 'react'
+import { useState, useEffect, useMemo, useCallback, memo } from 'react'
 import { UnifiedDashboard } from '../../lib/unified/dashboard/UnifiedDashboard'
 import { changeControlDashboardConfig } from '../../config/dashboards/change-control'
 import {
@@ -70,7 +70,7 @@ export const ChangeControlAuditContent = memo(function ChangeControlAuditContent
   const [filterApproval, setFilterApproval] = useState('all')
   const [activeTab, setActiveTab] = useState<'changes' | 'violations' | 'policies'>('changes')
 
-  const fetchData = async () => {
+  const fetchData = useCallback(async () => {
     setLoading(true)
     setError(null)
     try {
@@ -81,18 +81,26 @@ export const ChangeControlAuditContent = memo(function ChangeControlAuditContent
         authFetch('/api/compliance/change-control/policies'),
       ])
       if (!sRes.ok || !cRes.ok || !vRes.ok || !pRes.ok) throw new Error('Failed to load change control data')
-      setSummary(await sRes.json())
-      setChanges(await cRes.json())
-      setViolations(await vRes.json())
-      setPolicies(await pRes.json())
+
+      const [summaryData, changesData, violationsData, policiesData] = await Promise.all([
+        sRes.json(),
+        cRes.json(),
+        vRes.json(),
+        pRes.json(),
+      ])
+
+      setSummary(summaryData ?? null)
+      setChanges(Array.isArray(changesData) ? changesData : [])
+      setViolations(Array.isArray(violationsData) ? violationsData : [])
+      setPolicies(Array.isArray(policiesData) ? policiesData : [])
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to load data')
     } finally {
       setLoading(false)
     }
-  }
+  }, [])
 
-  useEffect(() => { fetchData() }, [])
+  useEffect(() => { fetchData() }, [fetchData])
 
   const filteredChanges = useMemo(() =>
     filterApproval === 'all' ? changes : changes.filter(c => c.approval_status === filterApproval),
@@ -231,7 +239,7 @@ export const ChangeControlAuditContent = memo(function ChangeControlAuditContent
       )}
     </div>
   )
-}
+})
 
 function SummaryCard({ label, value, icon, accent }: { label: string; value: number; icon: React.ReactNode; accent?: string }) {
   return (
@@ -240,7 +248,7 @@ function SummaryCard({ label, value, icon, accent }: { label: string; value: num
       <p className={`text-2xl font-bold ${accent === 'red' ? 'text-red-400' : accent === 'orange' ? 'text-orange-400' : 'text-zinc-100'}`}>{value}</p>
     </div>
   )
-})
+}
 
 export default function ChangeControlAudit() {
   return (<>

--- a/web/src/components/compliance/ChangeControlAudit.tsx
+++ b/web/src/components/compliance/ChangeControlAudit.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useMemo } from 'react'
+import { useState, useEffect, useMemo, memo } from 'react'
 import { UnifiedDashboard } from '../../lib/unified/dashboard/UnifiedDashboard'
 import { changeControlDashboardConfig } from '../../config/dashboards/change-control'
 import {
@@ -60,7 +60,7 @@ function riskBg(score: number): string {
   return 'bg-emerald-500/20'
 }
 
-export function ChangeControlAuditContent() {
+export const ChangeControlAuditContent = memo(function ChangeControlAuditContent() {
   const [summary, setSummary] = useState<AuditSummary | null>(null)
   const [changes, setChanges] = useState<ChangeRecord[]>([])
   const [violations, setViolations] = useState<PolicyViolation[]>([])
@@ -240,7 +240,7 @@ function SummaryCard({ label, value, icon, accent }: { label: string; value: num
       <p className={`text-2xl font-bold ${accent === 'red' ? 'text-red-400' : accent === 'orange' ? 'text-orange-400' : 'text-zinc-100'}`}>{value}</p>
     </div>
   )
-}
+})
 
 export default function ChangeControlAudit() {
   return (<>

--- a/web/src/components/compliance/ComplianceReports.tsx
+++ b/web/src/components/compliance/ComplianceReports.tsx
@@ -4,7 +4,7 @@
  * Lets users pick a framework and cluster, choose PDF or JSON format,
  * and download a timestamped compliance report.
  */
-import { useState, useEffect, useMemo } from 'react'
+import { useState, useEffect, useMemo, memo } from 'react'
 import { UnifiedDashboard } from '../../lib/unified/dashboard/UnifiedDashboard'
 import { complianceReportsDashboardConfig } from '../../config/dashboards/compliance-reports'
 import { FileText, Download, Shield, Loader2 } from 'lucide-react'
@@ -15,7 +15,7 @@ import { Select } from '../ui/Select'
 
 type ReportFormat = 'pdf' | 'json'
 
-export function ComplianceReportsContent() {
+export const ComplianceReportsContent = memo(function ComplianceReportsContent() {
   const { frameworks, isLoading: fwLoading } = useComplianceFrameworks()
   const { clusters } = useClusters()
   const clusterNames = useMemo(() => clusters?.map((c: { name: string }) => c.name) ?? [], [clusters])
@@ -228,7 +228,7 @@ export function ComplianceReportsContent() {
       </div>
     </div>
   )
-}
+})
 
 export default function ComplianceReports() {
   return (<>

--- a/web/src/components/compliance/DataResidency.tsx
+++ b/web/src/components/compliance/DataResidency.tsx
@@ -278,7 +278,7 @@ export const DataResidencyContent = memo(function DataResidencyContent() {
       </div>
     </div>
   )
-}
+})
 
 /* ─── Summary Card ─── */
 
@@ -292,7 +292,7 @@ function SummaryCard({ label, value, icon, accent }: { label: string; value: num
       <p className={`text-2xl font-bold ${accent === 'red' ? 'text-red-400' : 'text-zinc-100'}`}>{value}</p>
     </div>
   )
-})
+}
 
 export default function DataResidency() {
   return (<>

--- a/web/src/components/compliance/DataResidency.tsx
+++ b/web/src/components/compliance/DataResidency.tsx
@@ -4,7 +4,7 @@
  * Shows a world-map-style view of cluster regions, data classification rules,
  * and violations where workloads are running outside their allowed jurisdictions.
  */
-import { useState, useEffect, useMemo, useCallback } from 'react'
+import { useState, useEffect, useMemo, useCallback, memo } from 'react'
 import { UnifiedDashboard } from '../../lib/unified/dashboard/UnifiedDashboard'
 import { dataResidencyDashboardConfig } from '../../config/dashboards/data-residency'
 import { Globe, ShieldAlert, MapPin, CheckCircle2, XCircle, AlertTriangle, Loader2, RefreshCw } from 'lucide-react'
@@ -80,7 +80,7 @@ const REGION_LABELS: Record<string, string> = {
 
 /* ─── Main Component ─── */
 
-export function DataResidencyContent() {
+export const DataResidencyContent = memo(function DataResidencyContent() {
   const [summary, setSummary] = useState<ResidencySummary | null>(null)
   const [rules, setRules] = useState<ResidencyRule[]>([])
   const [clusters, setClusters] = useState<ClusterRegion[]>([])
@@ -292,7 +292,7 @@ function SummaryCard({ label, value, icon, accent }: { label: string; value: num
       <p className={`text-2xl font-bold ${accent === 'red' ? 'text-red-400' : 'text-zinc-100'}`}>{value}</p>
     </div>
   )
-}
+})
 
 export default function DataResidency() {
   return (<>

--- a/web/src/components/compliance/FedRAMPDashboard.tsx
+++ b/web/src/components/compliance/FedRAMPDashboard.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useMemo } from 'react'
+import { useState, useEffect, useMemo, memo } from 'react'
 import { UnifiedDashboard } from '../../lib/unified/dashboard/UnifiedDashboard'
 import { fedrampDashboardConfig } from '../../config/dashboards/fedramp'
 import {
@@ -77,7 +77,7 @@ const milestoneStatusBadge = (status: string) => {
   }
 }
 
-export function FedRAMPDashboardContent() {
+export const FedRAMPDashboardContent = memo(function FedRAMPDashboardContent() {
   const [controls, setControls] = useState<Control[]>([])
   const [poams, setPOAMs] = useState<POAM[]>([])
   const [score, setScore] = useState<FedRAMPScore | null>(null)
@@ -332,7 +332,7 @@ export function FedRAMPDashboardContent() {
       )}
     </div>
   )
-}
+})
 
 export default function FedRAMPDashboard() {
   return (<>

--- a/web/src/components/compliance/GxPDashboard.tsx
+++ b/web/src/components/compliance/GxPDashboard.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useMemo } from 'react'
+import { useState, useEffect, useMemo, memo } from 'react'
 import { UnifiedDashboard } from '../../lib/unified/dashboard/UnifiedDashboard'
 import { gxpDashboardConfig } from '../../config/dashboards/gxp'
 import {
@@ -41,7 +41,7 @@ const ACTION_STYLES: Record<string, string> = {
   review: 'bg-purple-500/20 text-purple-300',
 }
 
-export function GxPDashboardContent() {
+export const GxPDashboardContent = memo(function GxPDashboardContent() {
   const [summary, setSummary] = useState<GxPSummary | null>(null)
   const [records, setRecords] = useState<AuditRecord[]>([])
   const [signatures, setSignatures] = useState<Signature[]>([])
@@ -300,7 +300,7 @@ export function GxPDashboardContent() {
       )}
     </div>
   )
-}
+})
 
 export default function GxPDashboard() {
   return (<>

--- a/web/src/components/compliance/HIPAADashboard.tsx
+++ b/web/src/components/compliance/HIPAADashboard.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useMemo } from 'react'
+import { useState, useEffect, useMemo, memo } from 'react'
 import { UnifiedDashboard } from '../../lib/unified/dashboard/UnifiedDashboard'
 import { hipaaDashboardConfig } from '../../config/dashboards/hipaa'
 import {
@@ -44,7 +44,7 @@ const SAFEGUARD_ICONS: Record<string, typeof Shield> = {
   '164.312(d)': UserCheck, '164.312(e)': Network,
 }
 
-export function HIPAADashboardContent() {
+export const HIPAADashboardContent = memo(function HIPAADashboardContent() {
   const [safeguards, setSafeguards] = useState<HIPAASafeguard[]>([])
   const [phiNamespaces, setPHINamespaces] = useState<PHINamespace[]>([])
   const [dataFlows, setDataFlows] = useState<DataFlow[]>([])
@@ -318,7 +318,7 @@ export function HIPAADashboardContent() {
       )}
     </div>
   )
-}
+})
 
 export default function HIPAADashboard() {
   return (<>

--- a/web/src/components/compliance/NISTDashboard.tsx
+++ b/web/src/components/compliance/NISTDashboard.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useMemo, useCallback } from 'react'
+import { useState, useEffect, useMemo, useCallback, memo } from 'react'
 import { UnifiedDashboard } from '../../lib/unified/dashboard/UnifiedDashboard'
 import { nistDashboardConfig } from '../../config/dashboards/nist'
 import {
@@ -65,7 +65,7 @@ const statusLabel = (status: string) => {
   }
 }
 
-export function NISTDashboardContent() {
+export const NISTDashboardContent = memo(function NISTDashboardContent() {
   const [families, setFamilies] = useState<ControlFamily[]>([])
   const [mappings, setMappings] = useState<ControlMapping[]>([])
   const [summary, setSummary] = useState<NISTSummary | null>(null)
@@ -329,7 +329,7 @@ export function NISTDashboardContent() {
       )}
     </div>
   )
-}
+})
 
 export default function NISTDashboard() {
   return (<>

--- a/web/src/components/compliance/OIDCDashboard.tsx
+++ b/web/src/components/compliance/OIDCDashboard.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from 'react'
+import { useState, useEffect, useCallback, memo } from 'react'
 import { UnifiedDashboard } from '../../lib/unified/dashboard/UnifiedDashboard'
 import { oidcDashboardConfig } from '../../config/dashboards/oidc'
 import {
@@ -32,7 +32,7 @@ const STATUS_STYLES: Record<string, string> = {
   error: 'bg-red-500/20 text-red-300 border-red-500/30',
 }
 
-export function OIDCDashboardContent() {
+export const OIDCDashboardContent = memo(function OIDCDashboardContent() {
   const [providers, setProviders] = useState<OIDCProvider[]>([])
   const [sessions, setSessions] = useState<OIDCSession[]>([])
   const [summary, setSummary] = useState<OIDCSummary | null>(null)
@@ -242,7 +242,7 @@ export function OIDCDashboardContent() {
       )}
     </div>
   )
-}
+})
 
 export default function OIDCDashboard() {
   return (<>

--- a/web/src/components/compliance/RBACAuditDashboard.tsx
+++ b/web/src/components/compliance/RBACAuditDashboard.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useMemo } from 'react'
+import { useState, useEffect, useMemo, memo } from 'react'
 import { UnifiedDashboard } from '../../lib/unified/dashboard/UnifiedDashboard'
 import { rbacAuditDashboardConfig } from '../../config/dashboards/rbac-audit'
 import {
@@ -42,7 +42,7 @@ const RISK_STYLES: Record<string, string> = {
   low: 'text-emerald-400',
 }
 
-export function RBACAuditDashboardContent() {
+export const RBACAuditDashboardContent = memo(function RBACAuditDashboardContent() {
   const [bindings, setBindings] = useState<RBACBinding[]>([])
   const [findings, setFindings] = useState<RBACFinding[]>([])
   const [summary, setSummary] = useState<RBACSummary | null>(null)
@@ -276,7 +276,7 @@ export function RBACAuditDashboardContent() {
       )}
     </div>
   )
-}
+})
 
 export default function RBACAuditDashboard() {
   return (<>

--- a/web/src/components/compliance/RiskAppetiteDashboard.tsx
+++ b/web/src/components/compliance/RiskAppetiteDashboard.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react'
+import { useState, useEffect, memo } from 'react'
 import { UnifiedDashboard } from '../../lib/unified/dashboard/UnifiedDashboard'
 import { riskAppetiteDashboardConfig } from '../../config/dashboards/risk-appetite'
 import {
@@ -62,7 +62,7 @@ const BAR_COLOR = {
 
 // ── Component ─────────────────────────────────────────────────────────
 
-export function RiskAppetiteDashboardContent() {
+export const RiskAppetiteDashboardContent = memo(function RiskAppetiteDashboardContent() {
   const [thresholds, setThresholds] = useState<AppetiteThreshold[]>([])
   const [kris, setKRIs] = useState<KRI[]>([])
   const [summary, setSummary] = useState<AppetiteSummary | null>(null)
@@ -330,7 +330,7 @@ export function RiskAppetiteDashboardContent() {
       )}
     </div>
   )
-}
+})
 
 export default function RiskAppetiteDashboard() {
   return (<>

--- a/web/src/components/compliance/RiskMatrixDashboard.tsx
+++ b/web/src/components/compliance/RiskMatrixDashboard.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useMemo } from 'react'
+import { useState, useEffect, useMemo, memo } from 'react'
 import { UnifiedDashboard } from '../../lib/unified/dashboard/UnifiedDashboard'
 import { riskMatrixDashboardConfig } from '../../config/dashboards/risk-matrix'
 import {
@@ -64,7 +64,7 @@ function severityBadge(score: number) {
 
 // ── Component ─────────────────────────────────────────────────────────
 
-export function RiskMatrixDashboardContent() {
+export const RiskMatrixDashboardContent = memo(function RiskMatrixDashboardContent() {
   const [risks, setRisks] = useState<Risk[]>([])
   const [heatmap, setHeatmap] = useState<HeatmapCell[]>([])
   const [summary, setSummary] = useState<RiskSummary | null>(null)
@@ -349,7 +349,7 @@ export function RiskMatrixDashboardContent() {
       </div>
     </div>
   )
-}
+})
 
 export default function RiskMatrixDashboard() {
   return (<>

--- a/web/src/components/compliance/RiskRegisterDashboard.tsx
+++ b/web/src/components/compliance/RiskRegisterDashboard.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useMemo } from 'react'
+import { useState, useEffect, useMemo, memo } from 'react'
 import { UnifiedDashboard } from '../../lib/unified/dashboard/UnifiedDashboard'
 import { riskRegisterDashboardConfig } from '../../config/dashboards/risk-register'
 import {
@@ -75,7 +75,7 @@ function statusColor(status: string): string {
 
 // ── Component ─────────────────────────────────────────────────────────
 
-export function RiskRegisterDashboardContent() {
+export const RiskRegisterDashboardContent = memo(function RiskRegisterDashboardContent() {
   const [risks, setRisks] = useState<Risk[]>([])
   const [categories, setCategories] = useState<CategorySummary[]>([])
   const [summary, setSummary] = useState<RegisterSummary | null>(null)
@@ -312,7 +312,7 @@ export function RiskRegisterDashboardContent() {
       )}
     </div>
   )
-}
+})
 
 export default function RiskRegisterDashboard() {
   return (<>

--- a/web/src/components/compliance/SBOMDashboard.tsx
+++ b/web/src/components/compliance/SBOMDashboard.tsx
@@ -4,7 +4,7 @@
  * Package inventory, vulnerability scanning, license compliance,
  * and dependency tree visualization.
  */
-import { useState, useEffect } from 'react'
+import { useState, useEffect, memo } from 'react'
 import {
   Package, CheckCircle2, Loader2, AlertTriangle,
   XCircle, Shield, FileText
@@ -74,7 +74,7 @@ const STATUS_ICON: Record<string, React.ReactNode> = {
 
 // ── Content Component ───────────────────────────────────────────────────
 
-export function SBOMDashboardContent() {
+export const SBOMDashboardContent = memo(function SBOMDashboardContent() {
   const [packages, setPackages] = useState<SBOMPackage[]>([])
   const [vulnerabilities, setVulnerabilities] = useState<SBOMVulnerability[]>([])
   const [summary, setSummary] = useState<SBOMSummary | null>(null)
@@ -295,7 +295,7 @@ export function SBOMDashboardContent() {
       )}
     </div>
   )
-}
+})
 
 // ── Page Component (rendered by App.tsx route) ──────────────────────────
 

--- a/web/src/components/compliance/SLSADashboard.tsx
+++ b/web/src/components/compliance/SLSADashboard.tsx
@@ -4,10 +4,10 @@
  * Build provenance level indicators (L1–L4), attestation verification,
  * source integrity checks, and build reproducibility.
  */
-import { useState, useEffect, memo } from 'react'
+import { useState, useEffect, useCallback, memo } from 'react'
 import {
   GitCommitHorizontal, CheckCircle2, Loader2, AlertTriangle,
-  XCircle, Shield, Lock
+  XCircle, Shield, Lock, RefreshCw
 } from 'lucide-react'
 import { authFetch } from '../../lib/api'
 import { UnifiedDashboard } from '../../lib/unified/dashboard/UnifiedDashboard'
@@ -100,26 +100,34 @@ export const SLSADashboardContent = memo(function SLSADashboardContent() {
   const [error, setError] = useState<string | null>(null)
   const [activeTab, setActiveTab] = useState<'attestations' | 'provenance'>('attestations')
 
-  useEffect(() => {
-    const load = async () => {
-      try {
-        const [aRes, pRes, sRes] = await Promise.all([
-          authFetch('/api/v1/compliance/slsa/attestations'),
-          authFetch('/api/v1/compliance/slsa/provenance'),
-          authFetch('/api/v1/compliance/slsa/summary'),
-        ])
-        if (!aRes.ok || !pRes.ok || !sRes.ok) throw new Error('Failed to fetch SLSA data')
-        setAttestations(await aRes.json())
-        setProvenance(await pRes.json())
-        setSummary(await sRes.json())
-      } catch (e) {
-        setError(e instanceof Error ? e.message : 'Unknown error')
-      } finally {
-        setLoading(false)
-      }
+  const fetchData = useCallback(async () => {
+    setLoading(true)
+    setError(null)
+    try {
+      const [aRes, pRes, sRes] = await Promise.all([
+        authFetch('/api/v1/compliance/slsa/attestations'),
+        authFetch('/api/v1/compliance/slsa/provenance'),
+        authFetch('/api/v1/compliance/slsa/summary'),
+      ])
+      if (!aRes.ok || !pRes.ok || !sRes.ok) throw new Error('Failed to fetch SLSA data')
+
+      const [attestationsData, provenanceData, summaryData] = await Promise.all([
+        aRes.json(),
+        pRes.json(),
+        sRes.json(),
+      ])
+
+      setAttestations(Array.isArray(attestationsData) ? attestationsData : [])
+      setProvenance(Array.isArray(provenanceData) ? provenanceData : [])
+      setSummary(summaryData ?? null)
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Unknown error')
+    } finally {
+      setLoading(false)
     }
-    load()
   }, [])
+
+  useEffect(() => { fetchData() }, [fetchData])
 
   if (loading) return (
     <div className="flex items-center justify-center h-64">
@@ -129,8 +137,9 @@ export const SLSADashboardContent = memo(function SLSADashboardContent() {
   )
 
   if (error) return (
-    <div className="p-6 bg-red-500/10 border border-red-500/30 rounded-lg">
-      <p className="text-red-400">{error}</p>
+    <div className="flex flex-col items-center justify-center h-64 gap-3">
+      <p className="text-red-400 font-medium">{error}</p>
+      <button onClick={fetchData} className="text-indigo-400 hover:text-indigo-300 text-sm flex items-center gap-1"><RefreshCw className="w-4 h-4" /> Retry</button>
     </div>
   )
 
@@ -139,12 +148,15 @@ export const SLSADashboardContent = memo(function SLSADashboardContent() {
   return (
     <div className="space-y-6">
       {/* Header */}
-      <div className="flex items-center gap-3">
-        <GitCommitHorizontal className="w-8 h-8 text-emerald-400" />
-        <div>
-          <h1 className="text-2xl font-bold text-white">SLSA Provenance</h1>
-          <p className="text-gray-400">Build provenance levels, attestation verification, and source integrity</p>
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-3">
+          <GitCommitHorizontal className="w-8 h-8 text-emerald-400" />
+          <div>
+            <h1 className="text-2xl font-bold text-white">SLSA Provenance</h1>
+            <p className="text-gray-400">Build provenance levels, attestation verification, and source integrity</p>
+          </div>
         </div>
+        <button onClick={fetchData} type="button" aria-label="Refresh SLSA data" className="text-zinc-400 hover:text-zinc-200 p-2 rounded-lg hover:bg-zinc-700/50 transition-colors"><RefreshCw className="w-4 h-4" /></button>
       </div>
 
       {/* Summary stats */}

--- a/web/src/components/compliance/SLSADashboard.tsx
+++ b/web/src/components/compliance/SLSADashboard.tsx
@@ -4,7 +4,7 @@
  * Build provenance level indicators (L1–L4), attestation verification,
  * source integrity checks, and build reproducibility.
  */
-import { useState, useEffect } from 'react'
+import { useState, useEffect, memo } from 'react'
 import {
   GitCommitHorizontal, CheckCircle2, Loader2, AlertTriangle,
   XCircle, Shield, Lock
@@ -92,7 +92,7 @@ const STATUS_ICON: Record<string, React.ReactNode> = {
 
 // ── Content Component ───────────────────────────────────────────────────
 
-export function SLSADashboardContent() {
+export const SLSADashboardContent = memo(function SLSADashboardContent() {
   const [attestations, setAttestations] = useState<SLSAAttestation[]>([])
   const [provenance, setProvenance] = useState<SLSAProvenance[]>([])
   const [summary, setSummary] = useState<SLSASummary | null>(null)
@@ -315,7 +315,7 @@ export function SLSADashboardContent() {
       )}
     </div>
   )
-}
+})
 
 // ── Page Component (rendered by App.tsx route) ──────────────────────────
 

--- a/web/src/components/compliance/STIGDashboard.tsx
+++ b/web/src/components/compliance/STIGDashboard.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useMemo } from 'react'
+import { useState, useEffect, useMemo, memo } from 'react'
 import { UnifiedDashboard } from '../../lib/unified/dashboard/UnifiedDashboard'
 import { stigDashboardConfig } from '../../config/dashboards/stig'
 import {
@@ -68,7 +68,7 @@ const statusLabel = (status: string) => {
   }
 }
 
-export function STIGDashboardContent() {
+export const STIGDashboardContent = memo(function STIGDashboardContent() {
   const [findings, setFindings] = useState<Finding[]>([])
   const [benchmarks, setBenchmarks] = useState<Benchmark[]>([])
   const [summary, setSummary] = useState<STIGSummary | null>(null)
@@ -316,7 +316,7 @@ export function STIGDashboardContent() {
       )}
     </div>
   )
-}
+})
 
 export default function STIGDashboard() {
   return (<>

--- a/web/src/components/compliance/SegregationOfDuties.tsx
+++ b/web/src/components/compliance/SegregationOfDuties.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useMemo, useCallback } from 'react'
+import { useState, useEffect, useMemo, useCallback, memo } from 'react'
 import { UnifiedDashboard } from '../../lib/unified/dashboard/UnifiedDashboard'
 import { sodDashboardConfig } from '../../config/dashboards/segregation-of-duties'
 import {
@@ -46,7 +46,7 @@ function scoreColor(score: number): string {
   return 'text-red-400'
 }
 
-export function SegregationOfDutiesContent() {
+export const SegregationOfDutiesContent = memo(function SegregationOfDutiesContent() {
   const [summary, setSummary] = useState<SoDSummary | null>(null)
   const [rules, setRules] = useState<SoDRule[]>([])
   const [principals, setPrincipals] = useState<Principal[]>([])
@@ -220,7 +220,7 @@ function SummaryCard({ label, value, icon, accent }: { label: string; value: num
       <p className={`text-2xl font-bold ${accent === 'red' ? 'text-red-400' : 'text-zinc-100'}`}>{value}</p>
     </div>
   )
-}
+})
 
 export default function SegregationOfDuties() {
   return (<>

--- a/web/src/components/compliance/SegregationOfDuties.tsx
+++ b/web/src/components/compliance/SegregationOfDuties.tsx
@@ -211,7 +211,7 @@ export const SegregationOfDutiesContent = memo(function SegregationOfDutiesConte
       )}
     </div>
   )
-}
+})
 
 function SummaryCard({ label, value, icon, accent }: { label: string; value: number; icon: React.ReactNode; accent?: string }) {
   return (
@@ -220,7 +220,7 @@ function SummaryCard({ label, value, icon, accent }: { label: string; value: num
       <p className={`text-2xl font-bold ${accent === 'red' ? 'text-red-400' : 'text-zinc-100'}`}>{value}</p>
     </div>
   )
-})
+}
 
 export default function SegregationOfDuties() {
   return (<>

--- a/web/src/components/compliance/SessionDashboard.tsx
+++ b/web/src/components/compliance/SessionDashboard.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react'
+import { useState, useEffect, memo } from 'react'
 import { UnifiedDashboard } from '../../lib/unified/dashboard/UnifiedDashboard'
 import { sessionManagementDashboardConfig } from '../../config/dashboards/session-management'
 import {
@@ -32,7 +32,7 @@ const STATUS_STYLES: Record<string, string> = {
   terminated: 'bg-red-500/20 text-red-300 border-red-500/30',
 }
 
-export function SessionDashboardContent() {
+export const SessionDashboardContent = memo(function SessionDashboardContent() {
   const [sessions, setSessions] = useState<ActiveSession[]>([])
   const [policies, setPolicies] = useState<SessionPolicy[]>([])
   const [summary, setSummary] = useState<SessionSummary | null>(null)
@@ -242,7 +242,7 @@ export function SessionDashboardContent() {
       )}
     </div>
   )
-}
+})
 
 export default function SessionDashboard() {
   return (<>

--- a/web/src/components/compliance/SigstoreDashboard.tsx
+++ b/web/src/components/compliance/SigstoreDashboard.tsx
@@ -4,7 +4,7 @@
  * Cosign verification results, transparency log entries,
  * and trust chain visualization.
  */
-import { useState, useEffect } from 'react'
+import { useState, useEffect, memo } from 'react'
 import {
   BadgeCheck, CheckCircle2, Loader2, AlertTriangle,
   XCircle, ShieldCheck, FileKey
@@ -81,7 +81,7 @@ const RESULT_ICON: Record<string, React.ReactNode> = {
 
 // ── Content Component ───────────────────────────────────────────────────
 
-export function SigstoreDashboardContent() {
+export const SigstoreDashboardContent = memo(function SigstoreDashboardContent() {
   const [signatures, setSignatures] = useState<SigstoreSignature[]>([])
   const [verifications, setVerifications] = useState<SigstoreVerification[]>([])
   const [summary, setSummary] = useState<SigstoreSummary | null>(null)
@@ -269,7 +269,7 @@ export function SigstoreDashboardContent() {
       )}
     </div>
   )
-}
+})
 
 // ── Page Component (rendered by App.tsx route) ──────────────────────────
 


### PR DESCRIPTION
## Summary
- Wrap `fetchData` in `useCallback` with correct `useEffect` deps to prevent re-render loops from `VersionCheckProvider` cascading through `EnterpriseLayout` (same pattern as PRs #9759, #9765, #9772)
- Add `Array.isArray` guards on API response data to prevent crashes when endpoints return non-array values
- Wrap both content components in `React.memo` to prevent parent-triggered re-renders
- Add retry/refresh button to `SLSADashboard` error state and header for consistency

## Test plan
- [ ] Navigate to `/enterprise/change-control` -- no uncaught render errors in console
- [ ] Navigate to `/enterprise/slsa` -- no uncaught render errors in console
- [ ] Both pages load data correctly and display content
- [ ] Refresh buttons work on both pages
- [ ] Error state shows retry button on both pages

Fixes #9787