### PR TITLE
🐛 Fix missing icons in Enterprise sidebar (Monitor, AlertTriangle)

### DIFF
--- a/web/src/components/enterprise/EnterpriseSidebar.tsx
+++ b/web/src/components/enterprise/EnterpriseSidebar.tsx
@@ -13,6 +13,7 @@ import {
   ShieldCheck, FlaskConical, Handshake, BookOpen, ShieldAlert,
   WifiOff, Award, Fingerprint, Lock, Clock, Radio, Siren, Bug,
   Package, BadgeCheck, GitCommitHorizontal,
+  Monitor, AlertTriangle,
 } from 'lucide-react'
 import { ENTERPRISE_NAV_SECTIONS } from './enterpriseNav'
 import type { EnterpriseNavSection } from './enterpriseNav'
@@ -23,6 +24,7 @@ const ICON_MAP: Record<string, React.ComponentType<{ className?: string }>> = {
   ShieldCheck, FlaskConical, Handshake, BookOpen, ShieldAlert,
   WifiOff, Award, Fingerprint, Lock, Clock, Radio, Siren, Bug,
   Package, BadgeCheck, GitCommitHorizontal,
+  Monitor, AlertTriangle,
 }
 
 function SectionIcon({ name, className }: { name: string; className?: string }) {


### PR DESCRIPTION
Fixes #9798

SIEM Integration and Incident Response nav items had no icon because `Monitor` and `AlertTriangle` were referenced in `enterpriseNav.ts` but not imported or added to `ICON_MAP` in `EnterpriseSidebar.tsx`.