### PR TITLE
fix: make all bug report template fields optional

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -20,7 +20,7 @@ body:
       placeholder: |
         What happened? What did you expect to happen?
     validations:
-      required: true
+      required: false
 
   - type: textarea
     id: environment
@@ -34,7 +34,7 @@ body:
         - KC Version: (e.g., 0.1.0)
         - Kubernetes cluster type: (e.g., OpenShift 4.14, kind, EKS)
     validations:
-      required: true
+      required: false
 
   - type: textarea
     id: reproducing
@@ -46,7 +46,7 @@ body:
         2. Click on '...'
         3. See the error
     validations:
-      required: true
+      required: false
 
   - type: textarea
     id: expected
@@ -54,7 +54,7 @@ body:
       label: Expected Behavior
       description: A clear and concise description of what you expected to happen.
     validations:
-      required: true
+      required: false
 
   - type: textarea
     id: logs


### PR DESCRIPTION
Allow filing bugs with just a title. All template fields remain but are now optional.