### PR TITLE
🐛 Replace unregistered card types in enterprise dashboard configs

### DIFF
--- a/web/src/config/dashboards/airgap.ts
+++ b/web/src/config/dashboards/airgap.ts
@@ -8,8 +8,8 @@ export const airgapDashboardConfig: UnifiedDashboardConfig = {
   statsType: 'security',
   cards: [
     { id: 'airgap-cluster-health', cardType: 'cluster_health', title: 'Cluster Health', position: { w: 4, h: 3 } },
-    { id: 'airgap-workloads', cardType: 'workload_status', title: 'Workload Status', position: { w: 4, h: 3 } },
-    { id: 'airgap-compliance', cardType: 'air_gap_readiness', title: 'Air-Gap Summary', position: { w: 4, h: 3 } },
+    { id: 'airgap-network-policy-status', cardType: 'network_policy_status', title: 'Network Policy Status', position: { w: 4, h: 3 } },
+    { id: 'airgap-node-status', cardType: 'node_status', title: 'Node Status', position: { w: 4, h: 3 } },
   ],
   features: { dragDrop: true, addCard: true, autoRefresh: true, autoRefreshInterval: 60_000 },
   storageKey: 'airgap-dashboard-cards',

--- a/web/src/config/dashboards/baa.ts
+++ b/web/src/config/dashboards/baa.ts
@@ -8,8 +8,8 @@ export const baaDashboardConfig: UnifiedDashboardConfig = {
   statsType: 'security',
   cards: [
     { id: 'baa-cluster-health', cardType: 'cluster_health', title: 'Cluster Health', position: { w: 4, h: 3 } },
-    { id: 'baa-workloads', cardType: 'workload_status', title: 'Workload Status', position: { w: 4, h: 3 } },
-    { id: 'baa-compliance', cardType: 'baa_tracker', title: 'BAA Summary', position: { w: 4, h: 3 } },
+    { id: 'baa-workload-monitor', cardType: 'workload_monitor', title: 'Workload Monitor', position: { w: 4, h: 3 } },
+    { id: 'baa-policy-violations', cardType: 'policy_violations', title: 'Policy Violations', position: { w: 4, h: 3 } },
   ],
   features: { dragDrop: true, addCard: true, autoRefresh: true, autoRefreshInterval: 60_000 },
   storageKey: 'baa-dashboard-cards',

--- a/web/src/config/dashboards/change-control.ts
+++ b/web/src/config/dashboards/change-control.ts
@@ -7,9 +7,9 @@ export const changeControlDashboardConfig: UnifiedDashboardConfig = {
   route: '/change-control',
   statsType: 'security',
   cards: [
-    { id: 'cc-cluster-health', cardType: 'cluster_health', title: 'Cluster Health', position: { w: 4, h: 3 } },
-    { id: 'cc-workloads', cardType: 'workload_status', title: 'Workload Status', position: { w: 4, h: 3 } },
-    { id: 'cc-compliance', cardType: 'change_control', title: 'Change Control Summary', position: { w: 4, h: 3 } },
+    { id: 'cc-compliance-drift', cardType: 'compliance_drift', title: 'Compliance Drift', position: { w: 4, h: 3 } },
+    { id: 'cc-warning-events', cardType: 'warning_events', title: 'Warning Events', position: { w: 4, h: 3 } },
+    { id: 'cc-deployment-status', cardType: 'deployment_status', title: 'Deployment Status', position: { w: 4, h: 3 } },
   ],
   features: { dragDrop: true, addCard: true, autoRefresh: true, autoRefreshInterval: 60_000 },
   storageKey: 'change-control-dashboard-cards',

--- a/web/src/config/dashboards/compliance-frameworks.ts
+++ b/web/src/config/dashboards/compliance-frameworks.ts
@@ -10,9 +10,9 @@ export const complianceFrameworksDashboardConfig: UnifiedDashboardConfig = {
   route: '/compliance-frameworks',
   statsType: 'security',
   cards: [
-    { id: 'cf-cluster-health', cardType: 'cluster_health', title: 'Cluster Health', position: { w: 4, h: 3 } },
-    { id: 'cf-workloads', cardType: 'workload_status', title: 'Workload Status', position: { w: 4, h: 3 } },
-    { id: 'cf-compliance', cardType: 'compliance_frameworks', title: 'Frameworks Summary', position: { w: 4, h: 3 } },
+    { id: 'cf-compliance-score', cardType: 'compliance_score', title: 'Compliance Score', position: { w: 4, h: 3 } },
+    { id: 'cf-fleet-compliance-heatmap', cardType: 'fleet_compliance_heatmap', title: 'Fleet Compliance Heatmap', position: { w: 4, h: 3 } },
+    { id: 'cf-kyverno-policies', cardType: 'kyverno_policies', title: 'Kyverno Policies', position: { w: 4, h: 3 } },
   ],
   features: { dragDrop: true, addCard: true, autoRefresh: true, autoRefreshInterval: 60_000 },
   storageKey: 'compliance-frameworks-dashboard-cards',

--- a/web/src/config/dashboards/compliance-reports.ts
+++ b/web/src/config/dashboards/compliance-reports.ts
@@ -10,9 +10,9 @@ export const complianceReportsDashboardConfig: UnifiedDashboardConfig = {
   route: '/compliance-reports',
   statsType: 'security',
   cards: [
-    { id: 'cr-cluster-health', cardType: 'cluster_health', title: 'Cluster Health', position: { w: 4, h: 3 } },
-    { id: 'cr-workloads', cardType: 'workload_status', title: 'Workload Status', position: { w: 4, h: 3 } },
-    { id: 'cr-compliance', cardType: 'compliance_reports', title: 'Reports Summary', position: { w: 4, h: 3 } },
+    { id: 'cr-compliance-score', cardType: 'compliance_score', title: 'Compliance Score', position: { w: 4, h: 3 } },
+    { id: 'cr-trestle-scan', cardType: 'trestle_scan', title: 'Trestle Scan', position: { w: 4, h: 3 } },
+    { id: 'cr-fleet-compliance-heatmap', cardType: 'fleet_compliance_heatmap', title: 'Fleet Compliance Heatmap', position: { w: 4, h: 3 } },
   ],
   features: { dragDrop: true, addCard: true, autoRefresh: true, autoRefreshInterval: 60_000 },
   storageKey: 'compliance-reports-dashboard-cards',

--- a/web/src/config/dashboards/data-residency.ts
+++ b/web/src/config/dashboards/data-residency.ts
@@ -11,8 +11,8 @@ export const dataResidencyDashboardConfig: UnifiedDashboardConfig = {
   statsType: 'security',
   cards: [
     { id: 'dr-cluster-health', cardType: 'cluster_health', title: 'Cluster Health', position: { w: 4, h: 3 } },
-    { id: 'dr-workloads', cardType: 'workload_status', title: 'Workload Status', position: { w: 4, h: 3 } },
-    { id: 'dr-compliance', cardType: 'data_residency', title: 'Residency Summary', position: { w: 4, h: 3 } },
+    { id: 'dr-namespace-overview', cardType: 'namespace_overview', title: 'Namespace Overview', position: { w: 4, h: 3 } },
+    { id: 'dr-network-policy-status', cardType: 'network_policy_status', title: 'Network Policy Status', position: { w: 4, h: 3 } },
   ],
   features: { dragDrop: true, addCard: true, autoRefresh: true, autoRefreshInterval: 60_000 },
   storageKey: 'data-residency-dashboard-cards',

--- a/web/src/config/dashboards/fedramp.ts
+++ b/web/src/config/dashboards/fedramp.ts
@@ -8,8 +8,8 @@ export const fedrampDashboardConfig: UnifiedDashboardConfig = {
   statsType: 'security',
   cards: [
     { id: 'fedramp-cluster-health', cardType: 'cluster_health', title: 'Cluster Health', position: { w: 4, h: 3 } },
-    { id: 'fedramp-workloads', cardType: 'workload_status', title: 'Workload Status', position: { w: 4, h: 3 } },
-    { id: 'fedramp-compliance', cardType: 'fedramp_readiness', title: 'FedRAMP Summary', position: { w: 4, h: 3 } },
+    { id: 'fedramp-compliance-score', cardType: 'compliance_score', title: 'Compliance Score', position: { w: 4, h: 3 } },
+    { id: 'fedramp-trivy-scan', cardType: 'trivy_scan', title: 'Trivy Scan', position: { w: 4, h: 3 } },
   ],
   features: { dragDrop: true, addCard: true, autoRefresh: true, autoRefreshInterval: 60_000 },
   storageKey: 'fedramp-dashboard-cards',

--- a/web/src/config/dashboards/gxp.ts
+++ b/web/src/config/dashboards/gxp.ts
@@ -8,8 +8,8 @@ export const gxpDashboardConfig: UnifiedDashboardConfig = {
   statsType: 'security',
   cards: [
     { id: 'gxp-cluster-health', cardType: 'cluster_health', title: 'Cluster Health', position: { w: 4, h: 3 } },
-    { id: 'gxp-workloads', cardType: 'workload_status', title: 'Workload Status', position: { w: 4, h: 3 } },
-    { id: 'gxp-compliance', cardType: 'gxp_validation', title: 'GxP Summary', position: { w: 4, h: 3 } },
+    { id: 'gxp-workload-monitor', cardType: 'workload_monitor', title: 'Workload Monitor', position: { w: 4, h: 3 } },
+    { id: 'gxp-compliance-score', cardType: 'compliance_score', title: 'Compliance Score', position: { w: 4, h: 3 } },
   ],
   features: { dragDrop: true, addCard: true, autoRefresh: true, autoRefreshInterval: 60_000 },
   storageKey: 'gxp-dashboard-cards',

--- a/web/src/config/dashboards/hipaa.ts
+++ b/web/src/config/dashboards/hipaa.ts
@@ -8,8 +8,8 @@ export const hipaaDashboardConfig: UnifiedDashboardConfig = {
   statsType: 'security',
   cards: [
     { id: 'hipaa-cluster-health', cardType: 'cluster_health', title: 'Cluster Health', position: { w: 4, h: 3 } },
-    { id: 'hipaa-workloads', cardType: 'workload_status', title: 'Workload Status', position: { w: 4, h: 3 } },
-    { id: 'hipaa-compliance', cardType: 'hipaa_compliance', title: 'HIPAA Summary', position: { w: 4, h: 3 } },
+    { id: 'hipaa-workload-monitor', cardType: 'workload_monitor', title: 'Workload Monitor', position: { w: 4, h: 3 } },
+    { id: 'hipaa-compliance-score', cardType: 'compliance_score', title: 'Compliance Score', position: { w: 4, h: 3 } },
   ],
   features: { dragDrop: true, addCard: true, autoRefresh: true, autoRefreshInterval: 60_000 },
   storageKey: 'hipaa-dashboard-cards',

--- a/web/src/config/dashboards/incident-response.ts
+++ b/web/src/config/dashboards/incident-response.ts
@@ -7,9 +7,9 @@ export const incidentResponseDashboardConfig: UnifiedDashboardConfig = {
   route: '/enterprise/incident-response',
   statsType: 'security',
   cards: [
-    { id: 'ir-incidents-1', cardType: 'incident_response', title: 'Active Incidents', position: { w: 4, h: 3 } },
-    { id: 'ir-playbooks-1', cardType: 'incident_response', title: 'Playbooks', position: { w: 4, h: 3 } },
-    { id: 'ir-metrics-1', cardType: 'incident_response', title: 'MTTR Metrics', position: { w: 4, h: 3 } },
+    { id: 'ir-active-alerts', cardType: 'active_alerts', title: 'Active Alerts', position: { w: 4, h: 3 } },
+    { id: 'ir-pod-issues', cardType: 'pod_issues', title: 'Pod Issues', position: { w: 4, h: 3 } },
+    { id: 'ir-warning-events', cardType: 'warning_events', title: 'Warning Events', position: { w: 4, h: 3 } },
   ],
   features: { dragDrop: true, addCard: true, autoRefresh: true, autoRefreshInterval: 30_000 },
   storageKey: 'incident-response-dashboard-cards',

--- a/web/src/config/dashboards/nist.ts
+++ b/web/src/config/dashboards/nist.ts
@@ -7,9 +7,9 @@ export const nistDashboardConfig: UnifiedDashboardConfig = {
   route: '/nist-800-53',
   statsType: 'security',
   cards: [
-    { id: 'nist-cluster-health', cardType: 'cluster_health', title: 'Cluster Health', position: { w: 4, h: 3 } },
-    { id: 'nist-workloads', cardType: 'workload_status', title: 'Workload Status', position: { w: 4, h: 3 } },
-    { id: 'nist-compliance', cardType: 'nist_800_53', title: 'NIST Summary', position: { w: 4, h: 3 } },
+    { id: 'nist-compliance-score', cardType: 'compliance_score', title: 'Compliance Score', position: { w: 4, h: 3 } },
+    { id: 'nist-fleet-compliance-heatmap', cardType: 'fleet_compliance_heatmap', title: 'Fleet Compliance Heatmap', position: { w: 4, h: 3 } },
+    { id: 'nist-trestle-scan', cardType: 'trestle_scan', title: 'Trestle Scan', position: { w: 4, h: 3 } },
   ],
   features: { dragDrop: true, addCard: true, autoRefresh: true, autoRefreshInterval: 60_000 },
   storageKey: 'nist-dashboard-cards',

--- a/web/src/config/dashboards/oidc.ts
+++ b/web/src/config/dashboards/oidc.ts
@@ -8,8 +8,8 @@ export const oidcDashboardConfig: UnifiedDashboardConfig = {
   statsType: 'security',
   cards: [
     { id: 'oidc-cluster-health', cardType: 'cluster_health', title: 'Cluster Health', position: { w: 4, h: 3 } },
-    { id: 'oidc-workloads', cardType: 'workload_status', title: 'Workload Status', position: { w: 4, h: 3 } },
-    { id: 'oidc-compliance', cardType: 'oidc_federation', title: 'OIDC Summary', position: { w: 4, h: 3 } },
+    { id: 'oidc-service-account-status', cardType: 'service_account_status', title: 'Service Account Status', position: { w: 4, h: 3 } },
+    { id: 'oidc-role-binding-status', cardType: 'role_binding_status', title: 'Role Binding Status', position: { w: 4, h: 3 } },
   ],
   features: { dragDrop: true, addCard: true, autoRefresh: true, autoRefreshInterval: 60_000 },
   storageKey: 'oidc-dashboard-cards',

--- a/web/src/config/dashboards/rbac-audit.ts
+++ b/web/src/config/dashboards/rbac-audit.ts
@@ -8,8 +8,8 @@ export const rbacAuditDashboardConfig: UnifiedDashboardConfig = {
   statsType: 'security',
   cards: [
     { id: 'rbac-cluster-health', cardType: 'cluster_health', title: 'Cluster Health', position: { w: 4, h: 3 } },
-    { id: 'rbac-workloads', cardType: 'workload_status', title: 'Workload Status', position: { w: 4, h: 3 } },
-    { id: 'rbac-compliance', cardType: 'rbac_audit', title: 'RBAC Summary', position: { w: 4, h: 3 } },
+    { id: 'rbac-role-binding-status', cardType: 'role_binding_status', title: 'Role Binding Status', position: { w: 4, h: 3 } },
+    { id: 'rbac-namespace-rbac', cardType: 'namespace_rbac', title: 'Namespace RBAC', position: { w: 4, h: 3 } },
   ],
   features: { dragDrop: true, addCard: true, autoRefresh: true, autoRefreshInterval: 60_000 },
   storageKey: 'rbac-audit-dashboard-cards',

--- a/web/src/config/dashboards/risk-appetite.ts
+++ b/web/src/config/dashboards/risk-appetite.ts
@@ -7,9 +7,9 @@ export const riskAppetiteDashboardConfig: UnifiedDashboardConfig = {
   route: '/enterprise/risk-appetite',
   statsType: 'security',
   cards: [
-    { id: 'ra-cluster-health', cardType: 'cluster_health', title: 'Cluster Health', position: { w: 4, h: 3 } },
-    { id: 'ra-workloads', cardType: 'workload_status', title: 'Workload Status', position: { w: 4, h: 3 } },
-    { id: 'ra-risk-appetite', cardType: 'risk_appetite', title: 'Risk Appetite Summary', position: { w: 4, h: 3 } },
+    { id: 'ra-compliance-score', cardType: 'compliance_score', title: 'Compliance Score', position: { w: 4, h: 3 } },
+    { id: 'ra-resource-capacity', cardType: 'resource_capacity', title: 'Resource Capacity', position: { w: 4, h: 3 } },
+    { id: 'ra-cluster-metrics', cardType: 'cluster_metrics', title: 'Cluster Metrics', position: { w: 4, h: 3 } },
   ],
   features: { dragDrop: true, addCard: true, autoRefresh: true, autoRefreshInterval: 60_000 },
   storageKey: 'risk-appetite-dashboard-cards',

--- a/web/src/config/dashboards/risk-matrix.ts
+++ b/web/src/config/dashboards/risk-matrix.ts
@@ -7,9 +7,9 @@ export const riskMatrixDashboardConfig: UnifiedDashboardConfig = {
   route: '/enterprise/risk-matrix',
   statsType: 'security',
   cards: [
-    { id: 'rm-cluster-health', cardType: 'cluster_health', title: 'Cluster Health', position: { w: 4, h: 3 } },
-    { id: 'rm-workloads', cardType: 'workload_status', title: 'Workload Status', position: { w: 4, h: 3 } },
-    { id: 'rm-risk-matrix', cardType: 'risk_matrix', title: 'Risk Matrix Summary', position: { w: 4, h: 3 } },
+    { id: 'rm-compliance-score', cardType: 'compliance_score', title: 'Compliance Score', position: { w: 4, h: 3 } },
+    { id: 'rm-fleet-compliance-heatmap', cardType: 'fleet_compliance_heatmap', title: 'Fleet Compliance Heatmap', position: { w: 4, h: 3 } },
+    { id: 'rm-active-alerts', cardType: 'active_alerts', title: 'Active Alerts', position: { w: 4, h: 3 } },
   ],
   features: { dragDrop: true, addCard: true, autoRefresh: true, autoRefreshInterval: 60_000 },
   storageKey: 'risk-matrix-dashboard-cards',

--- a/web/src/config/dashboards/risk-register.ts
+++ b/web/src/config/dashboards/risk-register.ts
@@ -7,9 +7,9 @@ export const riskRegisterDashboardConfig: UnifiedDashboardConfig = {
   route: '/enterprise/risk-register',
   statsType: 'security',
   cards: [
-    { id: 'rr-cluster-health', cardType: 'cluster_health', title: 'Cluster Health', position: { w: 4, h: 3 } },
-    { id: 'rr-workloads', cardType: 'workload_status', title: 'Workload Status', position: { w: 4, h: 3 } },
-    { id: 'rr-risk-register', cardType: 'risk_register', title: 'Risk Register Summary', position: { w: 4, h: 3 } },
+    { id: 'rr-compliance-score', cardType: 'compliance_score', title: 'Compliance Score', position: { w: 4, h: 3 } },
+    { id: 'rr-warning-events', cardType: 'warning_events', title: 'Warning Events', position: { w: 4, h: 3 } },
+    { id: 'rr-pod-issues', cardType: 'pod_issues', title: 'Pod Issues', position: { w: 4, h: 3 } },
   ],
   features: { dragDrop: true, addCard: true, autoRefresh: true, autoRefreshInterval: 60_000 },
   storageKey: 'risk-register-dashboard-cards',

--- a/web/src/config/dashboards/sbom.ts
+++ b/web/src/config/dashboards/sbom.ts
@@ -7,9 +7,9 @@ export const sbomDashboardConfig: UnifiedDashboardConfig = {
   route: '/enterprise/sbom',
   statsType: 'security',
   cards: [
-    { id: 'sbom-cluster', cardType: 'cluster_health', title: 'Cluster Health', position: { w: 4, h: 3 } },
-    { id: 'sbom-workloads', cardType: 'workload_status', title: 'Workload Status', position: { w: 4, h: 3 } },
-    { id: 'sbom-summary', cardType: 'sbom_manager', title: 'SBOM Summary', position: { w: 4, h: 3 } },
+    { id: 'sbom-trivy-scan', cardType: 'trivy_scan', title: 'Trivy Scan', position: { w: 4, h: 3 } },
+    { id: 'sbom-cluster-health', cardType: 'cluster_health', title: 'Cluster Health', position: { w: 4, h: 3 } },
+    { id: 'sbom-pod-health-trend', cardType: 'pod_health_trend', title: 'Pod Health Trend', position: { w: 4, h: 3 } },
   ],
   features: { dragDrop: true, addCard: true, autoRefresh: true, autoRefreshInterval: 60_000 },
   storageKey: 'sbom-dashboard-cards',

--- a/web/src/config/dashboards/segregation-of-duties.ts
+++ b/web/src/config/dashboards/segregation-of-duties.ts
@@ -7,9 +7,9 @@ export const sodDashboardConfig: UnifiedDashboardConfig = {
   route: '/segregation-of-duties',
   statsType: 'security',
   cards: [
-    { id: 'sod-cluster-health', cardType: 'cluster_health', title: 'Cluster Health', position: { w: 4, h: 3 } },
-    { id: 'sod-workloads', cardType: 'workload_status', title: 'Workload Status', position: { w: 4, h: 3 } },
-    { id: 'sod-compliance', cardType: 'segregation_of_duties', title: 'SoD Summary', position: { w: 4, h: 3 } },
+    { id: 'sod-role-binding-status', cardType: 'role_binding_status', title: 'Role Binding Status', position: { w: 4, h: 3 } },
+    { id: 'sod-role-status', cardType: 'role_status', title: 'Role Status', position: { w: 4, h: 3 } },
+    { id: 'sod-namespace-rbac', cardType: 'namespace_rbac', title: 'Namespace RBAC', position: { w: 4, h: 3 } },
   ],
   features: { dragDrop: true, addCard: true, autoRefresh: true, autoRefreshInterval: 60_000 },
   storageKey: 'sod-dashboard-cards',

--- a/web/src/config/dashboards/session-management.ts
+++ b/web/src/config/dashboards/session-management.ts
@@ -8,8 +8,8 @@ export const sessionManagementDashboardConfig: UnifiedDashboardConfig = {
   statsType: 'security',
   cards: [
     { id: 'session-cluster-health', cardType: 'cluster_health', title: 'Cluster Health', position: { w: 4, h: 3 } },
-    { id: 'session-workloads', cardType: 'workload_status', title: 'Workload Status', position: { w: 4, h: 3 } },
-    { id: 'session-compliance', cardType: 'session_management', title: 'Session Summary', position: { w: 4, h: 3 } },
+    { id: 'session-active-alerts', cardType: 'active_alerts', title: 'Active Alerts', position: { w: 4, h: 3 } },
+    { id: 'session-service-status', cardType: 'service_status', title: 'Service Status', position: { w: 4, h: 3 } },
   ],
   features: { dragDrop: true, addCard: true, autoRefresh: true, autoRefreshInterval: 60_000 },
   storageKey: 'session-management-dashboard-cards',

--- a/web/src/config/dashboards/siem.ts
+++ b/web/src/config/dashboards/siem.ts
@@ -7,9 +7,9 @@ export const siemDashboardConfig: UnifiedDashboardConfig = {
   route: '/enterprise/siem',
   statsType: 'security',
   cards: [
-    { id: 'siem-events-1', cardType: 'siem_integration', title: 'Event Timeline', position: { w: 4, h: 3 } },
-    { id: 'siem-alerts-1', cardType: 'siem_integration', title: 'Alert Correlation', position: { w: 4, h: 3 } },
-    { id: 'siem-summary-1', cardType: 'siem_integration', title: 'Severity Distribution', position: { w: 4, h: 3 } },
+    { id: 'siem-event-stream', cardType: 'event_stream', title: 'Event Stream', position: { w: 4, h: 3 } },
+    { id: 'siem-warning-events', cardType: 'warning_events', title: 'Warning Events', position: { w: 4, h: 3 } },
+    { id: 'siem-active-alerts', cardType: 'active_alerts', title: 'Active Alerts', position: { w: 4, h: 3 } },
   ],
   features: { dragDrop: true, addCard: true, autoRefresh: true, autoRefreshInterval: 60_000 },
   storageKey: 'siem-dashboard-cards',

--- a/web/src/config/dashboards/sigstore.ts
+++ b/web/src/config/dashboards/sigstore.ts
@@ -7,9 +7,9 @@ export const sigstoreDashboardConfig: UnifiedDashboardConfig = {
   route: '/enterprise/sigstore',
   statsType: 'security',
   cards: [
-    { id: 'sigstore-cluster', cardType: 'cluster_health', title: 'Cluster Health', position: { w: 4, h: 3 } },
-    { id: 'sigstore-workloads', cardType: 'workload_status', title: 'Workload Status', position: { w: 4, h: 3 } },
-    { id: 'sigstore-summary', cardType: 'sigstore_verify', title: 'Sigstore Summary', position: { w: 4, h: 3 } },
+    { id: 'sigstore-cluster-health', cardType: 'cluster_health', title: 'Cluster Health', position: { w: 4, h: 3 } },
+    { id: 'sigstore-policy-violations', cardType: 'policy_violations', title: 'Policy Violations', position: { w: 4, h: 3 } },
+    { id: 'sigstore-security-issues', cardType: 'security_issues', title: 'Security Issues', position: { w: 4, h: 3 } },
   ],
   features: { dragDrop: true, addCard: true, autoRefresh: true, autoRefreshInterval: 60_000 },
   storageKey: 'sigstore-dashboard-cards',

--- a/web/src/config/dashboards/slsa.ts
+++ b/web/src/config/dashboards/slsa.ts
@@ -7,9 +7,9 @@ export const slsaDashboardConfig: UnifiedDashboardConfig = {
   route: '/enterprise/slsa',
   statsType: 'security',
   cards: [
-    { id: 'slsa-cluster', cardType: 'cluster_health', title: 'Cluster Health', position: { w: 4, h: 3 } },
-    { id: 'slsa-workloads', cardType: 'workload_status', title: 'Workload Status', position: { w: 4, h: 3 } },
-    { id: 'slsa-summary', cardType: 'slsa_provenance', title: 'SLSA Summary', position: { w: 4, h: 3 } },
+    { id: 'slsa-cluster-health', cardType: 'cluster_health', title: 'Cluster Health', position: { w: 4, h: 3 } },
+    { id: 'slsa-compliance-score', cardType: 'compliance_score', title: 'Compliance Score', position: { w: 4, h: 3 } },
+    { id: 'slsa-deployment-status', cardType: 'deployment_status', title: 'Deployment Status', position: { w: 4, h: 3 } },
   ],
   features: { dragDrop: true, addCard: true, autoRefresh: true, autoRefreshInterval: 60_000 },
   storageKey: 'slsa-dashboard-cards',

--- a/web/src/config/dashboards/stig.ts
+++ b/web/src/config/dashboards/stig.ts
@@ -8,8 +8,8 @@ export const stigDashboardConfig: UnifiedDashboardConfig = {
   statsType: 'security',
   cards: [
     { id: 'stig-cluster-health', cardType: 'cluster_health', title: 'Cluster Health', position: { w: 4, h: 3 } },
-    { id: 'stig-workloads', cardType: 'workload_status', title: 'Workload Status', position: { w: 4, h: 3 } },
-    { id: 'stig-compliance', cardType: 'stig_compliance', title: 'STIG Summary', position: { w: 4, h: 3 } },
+    { id: 'stig-kubescape-scan', cardType: 'kubescape_scan', title: 'Kubescape Scan', position: { w: 4, h: 3 } },
+    { id: 'stig-security-issues', cardType: 'security_issues', title: 'Security Issues', position: { w: 4, h: 3 } },
   ],
   features: { dragDrop: true, addCard: true, autoRefresh: true, autoRefreshInterval: 60_000 },
   storageKey: 'stig-dashboard-cards',

--- a/web/src/config/dashboards/threat-intel.ts
+++ b/web/src/config/dashboards/threat-intel.ts
@@ -7,9 +7,9 @@ export const threatIntelDashboardConfig: UnifiedDashboardConfig = {
   route: '/enterprise/threat-intel',
   statsType: 'security',
   cards: [
-    { id: 'ti-feeds-1', cardType: 'threat_intel', title: 'Threat Feeds', position: { w: 4, h: 3 } },
-    { id: 'ti-iocs-1', cardType: 'threat_intel', title: 'IOC Matches', position: { w: 4, h: 3 } },
-    { id: 'ti-risk-1', cardType: 'threat_intel', title: 'Risk Score', position: { w: 4, h: 3 } },
+    { id: 'ti-trivy-scan', cardType: 'trivy_scan', title: 'Trivy Scan', position: { w: 4, h: 3 } },
+    { id: 'ti-security-issues', cardType: 'security_issues', title: 'Security Issues', position: { w: 4, h: 3 } },
+    { id: 'ti-active-alerts', cardType: 'active_alerts', title: 'Active Alerts', position: { w: 4, h: 3 } },
   ],
   features: { dragDrop: true, addCard: true, autoRefresh: true, autoRefreshInterval: 120_000 },
   storageKey: 'threat-intel-dashboard-cards',


### PR DESCRIPTION
All 24 enterprise dashboard configs referenced card types that don't exist in the card registry (e.g. `workload_status`, `hipaa_compliance`, `nist_800_53`), causing 'Unknown card type' errors in the UnifiedDashboard grid.

Replaced with real registered cards relevant to each compliance vertical.