### PR TITLE
fix: add missing Netlify Functions for identity API endpoints

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -150,6 +150,54 @@
   to = "/.netlify/functions/rewards-badge/:splat"
   status = 200
 
+# Identity OIDC API — proxy to Netlify Functions (enterprise OIDC dashboard)
+[[redirects]]
+  from = "/api/identity/oidc/summary"
+  to = "/.netlify/functions/identity-oidc-summary"
+  status = 200
+
+[[redirects]]
+  from = "/api/identity/oidc/providers"
+  to = "/.netlify/functions/identity-oidc-providers"
+  status = 200
+
+[[redirects]]
+  from = "/api/identity/oidc/sessions"
+  to = "/.netlify/functions/identity-oidc-sessions"
+  status = 200
+
+# Identity RBAC API — proxy to Netlify Functions (enterprise RBAC Audit dashboard)
+[[redirects]]
+  from = "/api/identity/rbac/summary"
+  to = "/.netlify/functions/identity-rbac-summary"
+  status = 200
+
+[[redirects]]
+  from = "/api/identity/rbac/bindings"
+  to = "/.netlify/functions/identity-rbac-bindings"
+  status = 200
+
+[[redirects]]
+  from = "/api/identity/rbac/findings"
+  to = "/.netlify/functions/identity-rbac-findings"
+  status = 200
+
+# Identity Sessions API — proxy to Netlify Functions (enterprise Session dashboard)
+[[redirects]]
+  from = "/api/identity/sessions/summary"
+  to = "/.netlify/functions/identity-sessions-summary"
+  status = 200
+
+[[redirects]]
+  from = "/api/identity/sessions/active"
+  to = "/.netlify/functions/identity-sessions-active"
+  status = 200
+
+[[redirects]]
+  from = "/api/identity/sessions/policies"
+  to = "/.netlify/functions/identity-sessions-policies"
+  status = 200
+
 # SPA routing - redirect all routes to index.html (only if file doesn't exist)
 [[redirects]]
   from = "/*"

--- a/web/netlify/functions/identity-oidc-providers.mts
+++ b/web/netlify/functions/identity-oidc-providers.mts
@@ -1,0 +1,29 @@
+/**
+ * Netlify Function: Identity OIDC Providers
+ *
+ * Returns demo OIDC provider list for the enterprise OIDC dashboard.
+ */
+
+/** Offset constants for demo timestamps (milliseconds) */
+const FIVE_MINUTES_MS = 300_000;
+const TEN_MINUTES_MS = 600_000;
+const FIFTEEN_MINUTES_MS = 900_000;
+const TWENTY_MINUTES_MS = 1_200_000;
+const ONE_DAY_MS = 86_400_000;
+
+export default async () => {
+  const now = Date.now();
+  return new Response(
+    JSON.stringify([
+      { id: "oidc-1", name: "Okta Production", issuer_url: "https://company.okta.com", status: "connected", protocol: "OIDC", client_id: "okta-prod-001", users_synced: 485, last_sync: new Date(now - FIVE_MINUTES_MS).toISOString(), groups_mapped: 12 },
+      { id: "oidc-2", name: "Azure AD", issuer_url: "https://login.microsoftonline.com/tenant-id", status: "connected", protocol: "OIDC", client_id: "azure-ad-001", users_synced: 312, last_sync: new Date(now - TEN_MINUTES_MS).toISOString(), groups_mapped: 8 },
+      { id: "oidc-3", name: "GitHub Enterprise", issuer_url: "https://github.com/login/oauth", status: "connected", protocol: "OAuth2", client_id: "gh-ent-001", users_synced: 198, last_sync: new Date(now - FIFTEEN_MINUTES_MS).toISOString(), groups_mapped: 15 },
+      { id: "oidc-4", name: "Google Workspace", issuer_url: "https://accounts.google.com", status: "connected", protocol: "OIDC", client_id: "gws-001", users_synced: 252, last_sync: new Date(now - TWENTY_MINUTES_MS).toISOString(), groups_mapped: 6 },
+      { id: "oidc-5", name: "Keycloak Staging", issuer_url: "https://keycloak.staging.internal", status: "degraded", protocol: "OIDC", client_id: "kc-staging-001", users_synced: 0, last_sync: new Date(now - ONE_DAY_MS).toISOString(), groups_mapped: 3 },
+    ]),
+    {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    },
+  );
+};

--- a/web/netlify/functions/identity-oidc-sessions.mts
+++ b/web/netlify/functions/identity-oidc-sessions.mts
@@ -1,0 +1,38 @@
+/**
+ * Netlify Function: Identity OIDC Sessions
+ *
+ * Returns demo OIDC session list for the enterprise OIDC dashboard.
+ */
+
+/** Offset constants for demo timestamps (milliseconds) */
+const TEN_MINUTES_MS = 600_000;
+const THIRTY_MINUTES_MS = 1_800_000;
+const FORTY_FIVE_MINUTES_MS = 2_700_000;
+const ONE_HOUR_MS = 3_600_000;
+const NINETY_MINUTES_MS = 5_400_000;
+const TWO_HOURS_MS = 7_200_000;
+const TWO_AND_HALF_HOURS_MS = 9_000_000;
+const THREE_HOURS_MS = 10_800_000;
+const FOUR_HOURS_MS = 14_400_000;
+const FIFTEEN_MINUTES_MS = 900_000;
+const SEVENTY_FIVE_MINUTES_MS = 4_500_000;
+
+export default async () => {
+  const now = Date.now();
+  return new Response(
+    JSON.stringify([
+      { id: "sess-1", user: "alice@company.com", provider_id: "oidc-1", provider_name: "Okta Production", login_time: new Date(now - ONE_HOUR_MS).toISOString(), expires_at: new Date(now + TWO_HOURS_MS).toISOString(), ip_address: "10.0.1.42", active: true },
+      { id: "sess-2", user: "bob@company.com", provider_id: "oidc-2", provider_name: "Azure AD", login_time: new Date(now - TWO_HOURS_MS).toISOString(), expires_at: new Date(now + ONE_HOUR_MS).toISOString(), ip_address: "10.0.2.18", active: true },
+      { id: "sess-3", user: "carol@company.com", provider_id: "oidc-3", provider_name: "GitHub Enterprise", login_time: new Date(now - THIRTY_MINUTES_MS).toISOString(), expires_at: new Date(now + NINETY_MINUTES_MS).toISOString(), ip_address: "10.0.1.55", active: true },
+      { id: "sess-4", user: "dave@company.com", provider_id: "oidc-1", provider_name: "Okta Production", login_time: new Date(now - NINETY_MINUTES_MS).toISOString(), expires_at: new Date(now + THIRTY_MINUTES_MS).toISOString(), ip_address: "172.16.0.22", active: true },
+      { id: "sess-5", user: "eve@company.com", provider_id: "oidc-4", provider_name: "Google Workspace", login_time: new Date(now - TEN_MINUTES_MS).toISOString(), expires_at: new Date(now + THREE_HOURS_MS).toISOString(), ip_address: "10.0.3.7", active: true },
+      { id: "sess-6", user: "frank@company.com", provider_id: "oidc-2", provider_name: "Azure AD", login_time: new Date(now - FOUR_HOURS_MS).toISOString(), expires_at: new Date(now - THIRTY_MINUTES_MS).toISOString(), ip_address: "10.0.1.91", active: false },
+      { id: "sess-7", user: "grace@company.com", provider_id: "oidc-1", provider_name: "Okta Production", login_time: new Date(now - FIFTEEN_MINUTES_MS).toISOString(), expires_at: new Date(now + TWO_AND_HALF_HOURS_MS).toISOString(), ip_address: "192.168.1.14", active: true },
+      { id: "sess-8", user: "hank@company.com", provider_id: "oidc-3", provider_name: "GitHub Enterprise", login_time: new Date(now - FORTY_FIVE_MINUTES_MS).toISOString(), expires_at: new Date(now + SEVENTY_FIVE_MINUTES_MS).toISOString(), ip_address: "10.0.2.33", active: true },
+    ]),
+    {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    },
+  );
+};

--- a/web/netlify/functions/identity-oidc-summary.mts
+++ b/web/netlify/functions/identity-oidc-summary.mts
@@ -1,0 +1,25 @@
+/**
+ * Netlify Function: Identity OIDC Summary
+ *
+ * Returns demo OIDC identity provider summary data for the enterprise
+ * OIDC dashboard. On production (console.kubestellar.io), this serves
+ * the same static demo data as the MSW handler so enterprise dashboards
+ * render correctly without a Go backend.
+ */
+export default async () => {
+  return new Response(
+    JSON.stringify({
+      total_providers: 5,
+      active_providers: 4,
+      total_users: 1247,
+      active_sessions: 89,
+      failed_logins_24h: 7,
+      mfa_adoption: 82,
+      evaluated_at: new Date().toISOString(),
+    }),
+    {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    },
+  );
+};

--- a/web/netlify/functions/identity-rbac-bindings.mts
+++ b/web/netlify/functions/identity-rbac-bindings.mts
@@ -1,0 +1,43 @@
+/**
+ * Netlify Function: Identity RBAC Bindings
+ *
+ * Returns demo RBAC binding list for the enterprise RBAC Audit dashboard.
+ */
+
+/** Offset constants for demo timestamps (milliseconds) */
+const TWO_MINUTES_MS = 120_000;
+const FIVE_MINUTES_MS = 300_000;
+const TEN_MINUTES_MS = 600_000;
+const THIRTY_MINUTES_MS = 1_800_000;
+const ONE_HOUR_MS = 3_600_000;
+const TWO_HOURS_MS = 7_200_000;
+const TWELVE_HOURS_MS = 43_200_000;
+const ONE_DAY_MS = 86_400_000;
+const TWO_DAYS_MS = 172_800_000;
+const THREE_DAYS_MS = 259_200_000;
+const SEVEN_DAYS_MS = 604_800_000;
+const THIRTY_DAYS_MS = 2_592_000_000;
+
+export default async () => {
+  const now = Date.now();
+  return new Response(
+    JSON.stringify([
+      { id: "rb-1", name: "admin-binding", kind: "ClusterRoleBinding", subject_kind: "User", subject_name: "alice@company.com", role_name: "cluster-admin", namespace: "", cluster: "prod-east", risk_level: "critical", last_used: new Date(now - ONE_DAY_MS).toISOString() },
+      { id: "rb-2", name: "dev-edit-binding", kind: "RoleBinding", subject_kind: "Group", subject_name: "developers", role_name: "edit", namespace: "app-dev", cluster: "prod-east", risk_level: "medium", last_used: new Date(now - TWO_DAYS_MS).toISOString() },
+      { id: "rb-3", name: "ci-deploy", kind: "RoleBinding", subject_kind: "ServiceAccount", subject_name: "ci-deployer", role_name: "deploy-manager", namespace: "ci-cd", cluster: "prod-east", risk_level: "high", last_used: new Date(now - ONE_HOUR_MS).toISOString() },
+      { id: "rb-4", name: "monitoring-view", kind: "ClusterRoleBinding", subject_kind: "ServiceAccount", subject_name: "prometheus", role_name: "view", namespace: "", cluster: "prod-west", risk_level: "low", last_used: new Date(now - FIVE_MINUTES_MS).toISOString() },
+      { id: "rb-5", name: "qa-edit-binding", kind: "RoleBinding", subject_kind: "Group", subject_name: "qa-team", role_name: "edit", namespace: "qa", cluster: "staging", risk_level: "medium", last_used: new Date(now - SEVEN_DAYS_MS).toISOString() },
+      { id: "rb-6", name: "old-admin-binding", kind: "ClusterRoleBinding", subject_kind: "User", subject_name: "former-admin@company.com", role_name: "cluster-admin", namespace: "", cluster: "prod-east", risk_level: "critical", last_used: new Date(now - THIRTY_DAYS_MS).toISOString() },
+      { id: "rb-7", name: "secrets-reader", kind: "RoleBinding", subject_kind: "ServiceAccount", subject_name: "vault-agent", role_name: "secret-reader", namespace: "vault", cluster: "prod-east", risk_level: "high", last_used: new Date(now - TWO_HOURS_MS).toISOString() },
+      { id: "rb-8", name: "ingress-controller", kind: "ClusterRoleBinding", subject_kind: "ServiceAccount", subject_name: "nginx-ingress", role_name: "ingress-nginx", namespace: "", cluster: "prod-east", risk_level: "medium", last_used: new Date(now - TEN_MINUTES_MS).toISOString() },
+      { id: "rb-9", name: "dev-readonly", kind: "RoleBinding", subject_kind: "Group", subject_name: "interns", role_name: "view", namespace: "sandbox", cluster: "staging", risk_level: "low", last_used: new Date(now - THREE_DAYS_MS).toISOString() },
+      { id: "rb-10", name: "backup-operator", kind: "ClusterRoleBinding", subject_kind: "ServiceAccount", subject_name: "velero", role_name: "backup-admin", namespace: "", cluster: "prod-west", risk_level: "high", last_used: new Date(now - TWELVE_HOURS_MS).toISOString() },
+      { id: "rb-11", name: "app-deployer", kind: "RoleBinding", subject_kind: "Group", subject_name: "sre-team", role_name: "admin", namespace: "production", cluster: "prod-east", risk_level: "high", last_used: new Date(now - THIRTY_MINUTES_MS).toISOString() },
+      { id: "rb-12", name: "log-collector", kind: "ClusterRoleBinding", subject_kind: "ServiceAccount", subject_name: "fluentd", role_name: "log-reader", namespace: "", cluster: "prod-east", risk_level: "low", last_used: new Date(now - TWO_MINUTES_MS).toISOString() },
+    ]),
+    {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    },
+  );
+};

--- a/web/netlify/functions/identity-rbac-findings.mts
+++ b/web/netlify/functions/identity-rbac-findings.mts
@@ -1,0 +1,21 @@
+/**
+ * Netlify Function: Identity RBAC Findings
+ *
+ * Returns demo RBAC audit findings for the enterprise RBAC Audit dashboard.
+ */
+export default async () => {
+  return new Response(
+    JSON.stringify([
+      { id: "find-1", finding_type: "cluster_admin_user", severity: "critical", subject: "alice@company.com", description: "User has cluster-admin role bound directly. This grants unrestricted access to all resources.", cluster: "prod-east", namespace: "*", recommendation: "Replace with scoped roles targeting specific namespaces and resources." },
+      { id: "find-2", finding_type: "stale_binding", severity: "high", subject: "former-admin@company.com", description: "ClusterRoleBinding for cluster-admin has not been used in 30+ days. User may have left the organization.", cluster: "prod-east", namespace: "*", recommendation: "Remove the binding and verify user employment status." },
+      { id: "find-3", finding_type: "wildcard_resource", severity: "high", subject: "ci-deployer", description: "ServiceAccount has wildcard resource permissions in the ci-cd namespace.", cluster: "prod-east", namespace: "ci-cd", recommendation: "Restrict to specific resource types: deployments, services, configmaps." },
+      { id: "find-4", finding_type: "excessive_secrets_access", severity: "medium", subject: "developers", description: "Group \"developers\" can list and read secrets in the app-dev namespace.", cluster: "prod-east", namespace: "app-dev", recommendation: "Use CSI secret store driver instead of direct secret access." },
+      { id: "find-5", finding_type: "unused_binding", severity: "medium", subject: "interns", description: "RoleBinding for \"interns\" group has not been used in 3+ days. May indicate stale permissions.", cluster: "staging", namespace: "sandbox", recommendation: "Review and remove if no longer needed." },
+      { id: "find-6", finding_type: "broad_namespace_admin", severity: "high", subject: "sre-team", description: "Group has admin role in production namespace, granting full control including RBAC modification.", cluster: "prod-east", namespace: "production", recommendation: "Use edit role instead and manage RBAC separately through policy." },
+    ]),
+    {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    },
+  );
+};

--- a/web/netlify/functions/identity-rbac-summary.mts
+++ b/web/netlify/functions/identity-rbac-summary.mts
@@ -1,0 +1,22 @@
+/**
+ * Netlify Function: Identity RBAC Summary
+ *
+ * Returns demo RBAC audit summary data for the enterprise RBAC dashboard.
+ */
+export default async () => {
+  return new Response(
+    JSON.stringify({
+      total_bindings: 147,
+      cluster_role_bindings: 34,
+      role_bindings: 113,
+      over_privileged: 8,
+      unused_bindings: 12,
+      compliance_score: 78,
+      evaluated_at: new Date().toISOString(),
+    }),
+    {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    },
+  );
+};

--- a/web/netlify/functions/identity-sessions-active.mts
+++ b/web/netlify/functions/identity-sessions-active.mts
@@ -1,0 +1,43 @@
+/**
+ * Netlify Function: Identity Sessions Active
+ *
+ * Returns demo active session list for the enterprise Session dashboard.
+ */
+
+/** Offset constants for demo timestamps (milliseconds) */
+const THIRTY_SECONDS_MS = 30_000;
+const FORTY_FIVE_SECONDS_MS = 45_000;
+const ONE_MINUTE_MS = 60_000;
+const TWO_MINUTES_MS = 120_000;
+const TEN_MINUTES_MS = 600_000;
+const FIFTEEN_MINUTES_MS = 900_000;
+const THIRTY_MINUTES_MS = 1_800_000;
+const FORTY_FIVE_MINUTES_MS = 2_700_000;
+const FIFTY_MINUTES_MS = 3_000_000;
+const ONE_HOUR_MS = 3_600_000;
+const NINETY_MINUTES_MS = 5_400_000;
+const TWO_HOURS_MS = 7_200_000;
+const TWO_AND_HALF_HOURS_MS = 9_000_000;
+const THREE_HOURS_MS = 10_800_000;
+const FOUR_HOURS_MS = 14_400_000;
+const SEVENTY_FIVE_MINUTES_MS = 4_500_000;
+
+export default async () => {
+  const now = Date.now();
+  return new Response(
+    JSON.stringify([
+      { id: "as-1", user: "alice@company.com", login_time: new Date(now - ONE_HOUR_MS).toISOString(), last_activity: new Date(now - TWO_MINUTES_MS).toISOString(), ip_address: "10.0.1.42", user_agent: "Chrome/125 (macOS)", provider: "Okta", status: "active", expires_at: new Date(now + TWO_HOURS_MS).toISOString() },
+      { id: "as-2", user: "bob@company.com", login_time: new Date(now - TWO_HOURS_MS).toISOString(), last_activity: new Date(now - THIRTY_MINUTES_MS).toISOString(), ip_address: "10.0.2.18", user_agent: "Firefox/128 (Linux)", provider: "Azure AD", status: "idle", expires_at: new Date(now + ONE_HOUR_MS).toISOString() },
+      { id: "as-3", user: "carol@company.com", login_time: new Date(now - THIRTY_MINUTES_MS).toISOString(), last_activity: new Date(now - ONE_MINUTE_MS).toISOString(), ip_address: "10.0.1.55", user_agent: "Safari/18 (macOS)", provider: "GitHub", status: "active", expires_at: new Date(now + NINETY_MINUTES_MS).toISOString() },
+      { id: "as-4", user: "dave@company.com", login_time: new Date(now - NINETY_MINUTES_MS).toISOString(), last_activity: new Date(now - FIFTY_MINUTES_MS).toISOString(), ip_address: "172.16.0.22", user_agent: "kubectl/v1.30 (linux/amd64)", provider: "Okta", status: "idle", expires_at: new Date(now + THIRTY_MINUTES_MS).toISOString() },
+      { id: "as-5", user: "eve@company.com", login_time: new Date(now - TEN_MINUTES_MS).toISOString(), last_activity: new Date(now - THIRTY_SECONDS_MS).toISOString(), ip_address: "10.0.3.7", user_agent: "Chrome/125 (Windows)", provider: "Google", status: "active", expires_at: new Date(now + THREE_HOURS_MS).toISOString() },
+      { id: "as-6", user: "frank@company.com", login_time: new Date(now - FOUR_HOURS_MS).toISOString(), last_activity: new Date(now - TWO_HOURS_MS).toISOString(), ip_address: "10.0.1.91", user_agent: "Edge/125 (Windows)", provider: "Azure AD", status: "expired", expires_at: new Date(now - THIRTY_MINUTES_MS).toISOString() },
+      { id: "as-7", user: "grace@company.com", login_time: new Date(now - FIFTEEN_MINUTES_MS).toISOString(), last_activity: new Date(now - FORTY_FIVE_SECONDS_MS).toISOString(), ip_address: "192.168.1.14", user_agent: "Chrome/125 (macOS)", provider: "Okta", status: "active", expires_at: new Date(now + TWO_AND_HALF_HOURS_MS).toISOString() },
+      { id: "as-8", user: "hank@company.com", login_time: new Date(now - FORTY_FIVE_MINUTES_MS).toISOString(), last_activity: new Date(now - TEN_MINUTES_MS).toISOString(), ip_address: "10.0.2.33", user_agent: "kubectl/v1.31 (darwin/arm64)", provider: "GitHub", status: "active", expires_at: new Date(now + SEVENTY_FIVE_MINUTES_MS).toISOString() },
+    ]),
+    {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    },
+  );
+};

--- a/web/netlify/functions/identity-sessions-policies.mts
+++ b/web/netlify/functions/identity-sessions-policies.mts
@@ -1,0 +1,18 @@
+/**
+ * Netlify Function: Identity Sessions Policies
+ *
+ * Returns demo session policy list for the enterprise Session dashboard.
+ */
+export default async () => {
+  return new Response(
+    JSON.stringify([
+      { id: "pol-1", name: "Default Session Policy", description: "Standard session timeouts for all users", idle_timeout_minutes: 30, absolute_timeout_hours: 8, max_concurrent: 3, enforce_mfa: true, scope: "global" },
+      { id: "pol-2", name: "Admin Session Policy", description: "Stricter timeouts for cluster administrators", idle_timeout_minutes: 15, absolute_timeout_hours: 4, max_concurrent: 1, enforce_mfa: true, scope: "admin" },
+      { id: "pol-3", name: "Service Account Policy", description: "Long-lived sessions for automation and CI/CD", idle_timeout_minutes: 120, absolute_timeout_hours: 24, max_concurrent: 10, enforce_mfa: false, scope: "service-accounts" },
+    ]),
+    {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    },
+  );
+};

--- a/web/netlify/functions/identity-sessions-summary.mts
+++ b/web/netlify/functions/identity-sessions-summary.mts
@@ -1,0 +1,22 @@
+/**
+ * Netlify Function: Identity Sessions Summary
+ *
+ * Returns demo session management summary for the enterprise Session dashboard.
+ */
+export default async () => {
+  return new Response(
+    JSON.stringify({
+      active_sessions: 42,
+      unique_users: 31,
+      avg_duration_minutes: 47,
+      sessions_terminated_24h: 15,
+      policy_violations: 3,
+      mfa_sessions_pct: 88,
+      evaluated_at: new Date().toISOString(),
+    }),
+    {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    },
+  );
+};


### PR DESCRIPTION
## Summary

Fixes #9797 — Every enterprise dashboard (`/enterprise/*`) was showing "Failed to execute 'json' on 'Response': Unexpected token '<'" because the 9 `/api/identity/*` endpoints introduced in PR #9719 were missing Netlify Functions and `netlify.toml` redirects. On `console.kubestellar.io`, these requests fell through to the SPA catch-all and returned `index.html` (HTML) instead of JSON.

## Changes

- **9 new Netlify Functions** in `web/netlify/functions/`:
  - `identity-oidc-summary.mts` — `/api/identity/oidc/summary`
  - `identity-oidc-providers.mts` — `/api/identity/oidc/providers`
  - `identity-oidc-sessions.mts` — `/api/identity/oidc/sessions`
  - `identity-rbac-summary.mts` — `/api/identity/rbac/summary`
  - `identity-rbac-bindings.mts` — `/api/identity/rbac/bindings`
  - `identity-rbac-findings.mts` — `/api/identity/rbac/findings`
  - `identity-sessions-summary.mts` — `/api/identity/sessions/summary`
  - `identity-sessions-active.mts` — `/api/identity/sessions/active`
  - `identity-sessions-policies.mts` — `/api/identity/sessions/policies`
- **9 new redirects** in `netlify.toml` mapping each `/api/identity/*` route to its Netlify Function
- MSW handlers already existed (lines 1178-1274 in `handlers.ts`) — no changes needed there

## Test plan

- [ ] Deploy preview loads any enterprise dashboard without the doctype JSON parse error
- [ ] Each `/api/identity/*` endpoint returns valid JSON on the deploy preview
- [ ] Demo mode (MSW) still works correctly for local development