### PR TITLE
fix: handle HTML responses in enterprise dashboard API fetch

### DIFF
--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -677,6 +677,27 @@ export const api = new ApiClient()
  *
  * Existing callers only need to change `fetch(url, init)` -> `authFetch(url, init)`.
  */
+/**
+ * Safely parse a Response as JSON, guarding against HTML responses.
+ *
+ * On Netlify, unmatched API routes fall through to the SPA catch-all which
+ * returns index.html (200 OK, text/html). Calling `.json()` on that response
+ * throws "Unexpected token '<'" (#9797). This helper checks the Content-Type
+ * header first and throws a descriptive error instead of a cryptic parse error.
+ *
+ * Usage:
+ *   const data = await safeJson<MyType>(response)
+ */
+export async function safeJson<T = unknown>(response: Response): Promise<T> {
+  const contentType = response.headers.get('content-type') || ''
+  if (!contentType.includes('application/json')) {
+    throw new Error(
+      `Expected JSON response but received ${contentType || 'unknown content-type'} (status ${response.status})`,
+    )
+  }
+  return response.json() as Promise<T>
+}
+
 export function authFetch(input: RequestInfo | URL, init?: RequestInit): Promise<Response> {
   const token = localStorage.getItem(STORAGE_KEY_TOKEN)
   const headers = new Headers(init?.headers)

--- a/web/src/mocks/handlers.ts
+++ b/web/src/mocks/handlers.ts
@@ -2034,7 +2034,15 @@ export const handlers = [
   // catch-all which returns index.html (200 OK, text/html). Code calling
   // .json() then throws "Unexpected token '<'". This catch-all returns a
   // proper JSON 503 so callers hit their error paths gracefully.
-  http.all('/api/*', () => {
+  //
+  // IMPORTANT (#9797): Use a regex instead of '/api/*' because MSW v2 path
+  // patterns treat '*' as a single-segment wildcard. '/api/*' only matches
+  // paths like '/api/foo' but NOT multi-segment paths like
+  // '/api/compliance/frameworks/' or '/api/compliance/nist/families'.
+  // The enterprise compliance dashboards fetch '/api/compliance/<vertical>/<resource>'
+  // which slipped through the old catch-all, hit the Netlify SPA fallback,
+  // and received index.html (200 OK, text/html) instead of JSON.
+  http.all(/^\/api\//, () => {
     return HttpResponse.json(
       { error: 'not available in demo mode' },
       { status: 503 },


### PR DESCRIPTION
## Summary
- Fixed MSW catch-all handler that used `'/api/*'` (single-segment wildcard) to use a regex `/^\/api\//` that matches all nested paths under `/api/`
- MSW v2 treats `*` as a single-segment wildcard, so multi-segment paths like `/api/compliance/nist/families` slipped through and hit Netlify's SPA fallback, returning `index.html` (200 OK, text/html) instead of JSON
- Added `safeJson()` utility in `lib/api.ts` for defense-in-depth content-type validation

## Root Cause
Enterprise compliance dashboards fetch multi-segment API paths (e.g., `/api/compliance/airgap/requirements`, `/api/v1/compliance/siem/events`). The MSW catch-all `http.all('/api/*')` only matched single-segment paths like `/api/foo`. Unmatched requests fell through to Netlify's SPA catch-all which returned `index.html` with status 200. The dashboards checked `.ok` (which was true for 200), then called `.json()` on HTML content, throwing "Unexpected token '<'".

## Test plan
- [ ] Visit console.kubestellar.io/enterprise/frameworks — should show error state, not crash
- [ ] Visit console.kubestellar.io/enterprise/hipaa — should show error state, not crash
- [ ] Visit console.kubestellar.io/enterprise/nist — should show error state, not crash
- [ ] Other enterprise dashboards load without "Unexpected token" error
- [ ] Non-enterprise pages still work normally

Fixes #9797