### PR TITLE
🐛 Bump enterprise dashboard storage keys to clear stale cache

### DIFF
--- a/web/src/config/dashboards/airgap.ts
+++ b/web/src/config/dashboards/airgap.ts
@@ -12,7 +12,7 @@ export const airgapDashboardConfig: UnifiedDashboardConfig = {
     { id: 'airgap-node-status', cardType: 'node_status', title: 'Node Status', position: { w: 4, h: 3 } },
   ],
   features: { dragDrop: true, addCard: true, autoRefresh: true, autoRefreshInterval: 60_000 },
-  storageKey: 'airgap-dashboard-cards',
+  storageKey: 'airgap-dashboard-cards-v2',
 }
 
 export default airgapDashboardConfig

--- a/web/src/config/dashboards/baa.ts
+++ b/web/src/config/dashboards/baa.ts
@@ -12,7 +12,7 @@ export const baaDashboardConfig: UnifiedDashboardConfig = {
     { id: 'baa-policy-violations', cardType: 'policy_violations', title: 'Policy Violations', position: { w: 4, h: 3 } },
   ],
   features: { dragDrop: true, addCard: true, autoRefresh: true, autoRefreshInterval: 60_000 },
-  storageKey: 'baa-dashboard-cards',
+  storageKey: 'baa-dashboard-cards-v2',
 }
 
 export default baaDashboardConfig

--- a/web/src/config/dashboards/change-control.ts
+++ b/web/src/config/dashboards/change-control.ts
@@ -12,7 +12,7 @@ export const changeControlDashboardConfig: UnifiedDashboardConfig = {
     { id: 'cc-deployment-status', cardType: 'deployment_status', title: 'Deployment Status', position: { w: 4, h: 3 } },
   ],
   features: { dragDrop: true, addCard: true, autoRefresh: true, autoRefreshInterval: 60_000 },
-  storageKey: 'change-control-dashboard-cards',
+  storageKey: 'change-control-dashboard-cards-v2',
 }
 
 export default changeControlDashboardConfig

--- a/web/src/config/dashboards/compliance-frameworks.ts
+++ b/web/src/config/dashboards/compliance-frameworks.ts
@@ -15,7 +15,7 @@ export const complianceFrameworksDashboardConfig: UnifiedDashboardConfig = {
     { id: 'cf-kyverno-policies', cardType: 'kyverno_policies', title: 'Kyverno Policies', position: { w: 4, h: 3 } },
   ],
   features: { dragDrop: true, addCard: true, autoRefresh: true, autoRefreshInterval: 60_000 },
-  storageKey: 'compliance-frameworks-dashboard-cards',
+  storageKey: 'compliance-frameworks-dashboard-cards-v2',
 }
 
 export default complianceFrameworksDashboardConfig

--- a/web/src/config/dashboards/compliance-reports.ts
+++ b/web/src/config/dashboards/compliance-reports.ts
@@ -15,7 +15,7 @@ export const complianceReportsDashboardConfig: UnifiedDashboardConfig = {
     { id: 'cr-fleet-compliance-heatmap', cardType: 'fleet_compliance_heatmap', title: 'Fleet Compliance Heatmap', position: { w: 4, h: 3 } },
   ],
   features: { dragDrop: true, addCard: true, autoRefresh: true, autoRefreshInterval: 60_000 },
-  storageKey: 'compliance-reports-dashboard-cards',
+  storageKey: 'compliance-reports-dashboard-cards-v2',
 }
 
 export default complianceReportsDashboardConfig

--- a/web/src/config/dashboards/data-residency.ts
+++ b/web/src/config/dashboards/data-residency.ts
@@ -15,7 +15,7 @@ export const dataResidencyDashboardConfig: UnifiedDashboardConfig = {
     { id: 'dr-network-policy-status', cardType: 'network_policy_status', title: 'Network Policy Status', position: { w: 4, h: 3 } },
   ],
   features: { dragDrop: true, addCard: true, autoRefresh: true, autoRefreshInterval: 60_000 },
-  storageKey: 'data-residency-dashboard-cards',
+  storageKey: 'data-residency-dashboard-cards-v2',
 }
 
 export default dataResidencyDashboardConfig

--- a/web/src/config/dashboards/fedramp.ts
+++ b/web/src/config/dashboards/fedramp.ts
@@ -12,7 +12,7 @@ export const fedrampDashboardConfig: UnifiedDashboardConfig = {
     { id: 'fedramp-trivy-scan', cardType: 'trivy_scan', title: 'Trivy Scan', position: { w: 4, h: 3 } },
   ],
   features: { dragDrop: true, addCard: true, autoRefresh: true, autoRefreshInterval: 60_000 },
-  storageKey: 'fedramp-dashboard-cards',
+  storageKey: 'fedramp-dashboard-cards-v2',
 }
 
 export default fedrampDashboardConfig

--- a/web/src/config/dashboards/gxp.ts
+++ b/web/src/config/dashboards/gxp.ts
@@ -12,7 +12,7 @@ export const gxpDashboardConfig: UnifiedDashboardConfig = {
     { id: 'gxp-compliance-score', cardType: 'compliance_score', title: 'Compliance Score', position: { w: 4, h: 3 } },
   ],
   features: { dragDrop: true, addCard: true, autoRefresh: true, autoRefreshInterval: 60_000 },
-  storageKey: 'gxp-dashboard-cards',
+  storageKey: 'gxp-dashboard-cards-v2',
 }
 
 export default gxpDashboardConfig

--- a/web/src/config/dashboards/hipaa.ts
+++ b/web/src/config/dashboards/hipaa.ts
@@ -12,7 +12,7 @@ export const hipaaDashboardConfig: UnifiedDashboardConfig = {
     { id: 'hipaa-compliance-score', cardType: 'compliance_score', title: 'Compliance Score', position: { w: 4, h: 3 } },
   ],
   features: { dragDrop: true, addCard: true, autoRefresh: true, autoRefreshInterval: 60_000 },
-  storageKey: 'hipaa-dashboard-cards',
+  storageKey: 'hipaa-dashboard-cards-v2',
 }
 
 export default hipaaDashboardConfig

--- a/web/src/config/dashboards/incident-response.ts
+++ b/web/src/config/dashboards/incident-response.ts
@@ -12,7 +12,7 @@ export const incidentResponseDashboardConfig: UnifiedDashboardConfig = {
     { id: 'ir-warning-events', cardType: 'warning_events', title: 'Warning Events', position: { w: 4, h: 3 } },
   ],
   features: { dragDrop: true, addCard: true, autoRefresh: true, autoRefreshInterval: 30_000 },
-  storageKey: 'incident-response-dashboard-cards',
+  storageKey: 'incident-response-dashboard-cards-v2',
 }
 
 export default incidentResponseDashboardConfig

--- a/web/src/config/dashboards/nist.ts
+++ b/web/src/config/dashboards/nist.ts
@@ -12,7 +12,7 @@ export const nistDashboardConfig: UnifiedDashboardConfig = {
     { id: 'nist-trestle-scan', cardType: 'trestle_scan', title: 'Trestle Scan', position: { w: 4, h: 3 } },
   ],
   features: { dragDrop: true, addCard: true, autoRefresh: true, autoRefreshInterval: 60_000 },
-  storageKey: 'nist-dashboard-cards',
+  storageKey: 'nist-dashboard-cards-v2',
 }
 
 export default nistDashboardConfig

--- a/web/src/config/dashboards/oidc.ts
+++ b/web/src/config/dashboards/oidc.ts
@@ -12,7 +12,7 @@ export const oidcDashboardConfig: UnifiedDashboardConfig = {
     { id: 'oidc-role-binding-status', cardType: 'role_binding_status', title: 'Role Binding Status', position: { w: 4, h: 3 } },
   ],
   features: { dragDrop: true, addCard: true, autoRefresh: true, autoRefreshInterval: 60_000 },
-  storageKey: 'oidc-dashboard-cards',
+  storageKey: 'oidc-dashboard-cards-v2',
 }
 
 export default oidcDashboardConfig

--- a/web/src/config/dashboards/rbac-audit.ts
+++ b/web/src/config/dashboards/rbac-audit.ts
@@ -12,7 +12,7 @@ export const rbacAuditDashboardConfig: UnifiedDashboardConfig = {
     { id: 'rbac-namespace-rbac', cardType: 'namespace_rbac', title: 'Namespace RBAC', position: { w: 4, h: 3 } },
   ],
   features: { dragDrop: true, addCard: true, autoRefresh: true, autoRefreshInterval: 60_000 },
-  storageKey: 'rbac-audit-dashboard-cards',
+  storageKey: 'rbac-audit-dashboard-cards-v2',
 }
 
 export default rbacAuditDashboardConfig

--- a/web/src/config/dashboards/risk-appetite.ts
+++ b/web/src/config/dashboards/risk-appetite.ts
@@ -12,7 +12,7 @@ export const riskAppetiteDashboardConfig: UnifiedDashboardConfig = {
     { id: 'ra-cluster-metrics', cardType: 'cluster_metrics', title: 'Cluster Metrics', position: { w: 4, h: 3 } },
   ],
   features: { dragDrop: true, addCard: true, autoRefresh: true, autoRefreshInterval: 60_000 },
-  storageKey: 'risk-appetite-dashboard-cards',
+  storageKey: 'risk-appetite-dashboard-cards-v2',
 }
 
 export default riskAppetiteDashboardConfig

--- a/web/src/config/dashboards/risk-matrix.ts
+++ b/web/src/config/dashboards/risk-matrix.ts
@@ -12,7 +12,7 @@ export const riskMatrixDashboardConfig: UnifiedDashboardConfig = {
     { id: 'rm-active-alerts', cardType: 'active_alerts', title: 'Active Alerts', position: { w: 4, h: 3 } },
   ],
   features: { dragDrop: true, addCard: true, autoRefresh: true, autoRefreshInterval: 60_000 },
-  storageKey: 'risk-matrix-dashboard-cards',
+  storageKey: 'risk-matrix-dashboard-cards-v2',
 }
 
 export default riskMatrixDashboardConfig

--- a/web/src/config/dashboards/risk-register.ts
+++ b/web/src/config/dashboards/risk-register.ts
@@ -12,7 +12,7 @@ export const riskRegisterDashboardConfig: UnifiedDashboardConfig = {
     { id: 'rr-pod-issues', cardType: 'pod_issues', title: 'Pod Issues', position: { w: 4, h: 3 } },
   ],
   features: { dragDrop: true, addCard: true, autoRefresh: true, autoRefreshInterval: 60_000 },
-  storageKey: 'risk-register-dashboard-cards',
+  storageKey: 'risk-register-dashboard-cards-v2',
 }
 
 export default riskRegisterDashboardConfig

--- a/web/src/config/dashboards/sbom.ts
+++ b/web/src/config/dashboards/sbom.ts
@@ -12,7 +12,7 @@ export const sbomDashboardConfig: UnifiedDashboardConfig = {
     { id: 'sbom-pod-health-trend', cardType: 'pod_health_trend', title: 'Pod Health Trend', position: { w: 4, h: 3 } },
   ],
   features: { dragDrop: true, addCard: true, autoRefresh: true, autoRefreshInterval: 60_000 },
-  storageKey: 'sbom-dashboard-cards',
+  storageKey: 'sbom-dashboard-cards-v2',
 }
 
 export default sbomDashboardConfig

--- a/web/src/config/dashboards/segregation-of-duties.ts
+++ b/web/src/config/dashboards/segregation-of-duties.ts
@@ -12,7 +12,7 @@ export const sodDashboardConfig: UnifiedDashboardConfig = {
     { id: 'sod-namespace-rbac', cardType: 'namespace_rbac', title: 'Namespace RBAC', position: { w: 4, h: 3 } },
   ],
   features: { dragDrop: true, addCard: true, autoRefresh: true, autoRefreshInterval: 60_000 },
-  storageKey: 'sod-dashboard-cards',
+  storageKey: 'sod-dashboard-cards-v2',
 }
 
 export default sodDashboardConfig

--- a/web/src/config/dashboards/session-management.ts
+++ b/web/src/config/dashboards/session-management.ts
@@ -12,7 +12,7 @@ export const sessionManagementDashboardConfig: UnifiedDashboardConfig = {
     { id: 'session-service-status', cardType: 'service_status', title: 'Service Status', position: { w: 4, h: 3 } },
   ],
   features: { dragDrop: true, addCard: true, autoRefresh: true, autoRefreshInterval: 60_000 },
-  storageKey: 'session-management-dashboard-cards',
+  storageKey: 'session-management-dashboard-cards-v2',
 }
 
 export default sessionManagementDashboardConfig

--- a/web/src/config/dashboards/siem.ts
+++ b/web/src/config/dashboards/siem.ts
@@ -12,7 +12,7 @@ export const siemDashboardConfig: UnifiedDashboardConfig = {
     { id: 'siem-active-alerts', cardType: 'active_alerts', title: 'Active Alerts', position: { w: 4, h: 3 } },
   ],
   features: { dragDrop: true, addCard: true, autoRefresh: true, autoRefreshInterval: 60_000 },
-  storageKey: 'siem-dashboard-cards',
+  storageKey: 'siem-dashboard-cards-v2',
 }
 
 export default siemDashboardConfig

--- a/web/src/config/dashboards/sigstore.ts
+++ b/web/src/config/dashboards/sigstore.ts
@@ -12,7 +12,7 @@ export const sigstoreDashboardConfig: UnifiedDashboardConfig = {
     { id: 'sigstore-security-issues', cardType: 'security_issues', title: 'Security Issues', position: { w: 4, h: 3 } },
   ],
   features: { dragDrop: true, addCard: true, autoRefresh: true, autoRefreshInterval: 60_000 },
-  storageKey: 'sigstore-dashboard-cards',
+  storageKey: 'sigstore-dashboard-cards-v2',
 }
 
 export default sigstoreDashboardConfig

--- a/web/src/config/dashboards/slsa.ts
+++ b/web/src/config/dashboards/slsa.ts
@@ -12,7 +12,7 @@ export const slsaDashboardConfig: UnifiedDashboardConfig = {
     { id: 'slsa-deployment-status', cardType: 'deployment_status', title: 'Deployment Status', position: { w: 4, h: 3 } },
   ],
   features: { dragDrop: true, addCard: true, autoRefresh: true, autoRefreshInterval: 60_000 },
-  storageKey: 'slsa-dashboard-cards',
+  storageKey: 'slsa-dashboard-cards-v2',
 }
 
 export default slsaDashboardConfig

--- a/web/src/config/dashboards/stig.ts
+++ b/web/src/config/dashboards/stig.ts
@@ -12,7 +12,7 @@ export const stigDashboardConfig: UnifiedDashboardConfig = {
     { id: 'stig-security-issues', cardType: 'security_issues', title: 'Security Issues', position: { w: 4, h: 3 } },
   ],
   features: { dragDrop: true, addCard: true, autoRefresh: true, autoRefreshInterval: 60_000 },
-  storageKey: 'stig-dashboard-cards',
+  storageKey: 'stig-dashboard-cards-v2',
 }
 
 export default stigDashboardConfig

--- a/web/src/config/dashboards/threat-intel.ts
+++ b/web/src/config/dashboards/threat-intel.ts
@@ -12,7 +12,7 @@ export const threatIntelDashboardConfig: UnifiedDashboardConfig = {
     { id: 'ti-active-alerts', cardType: 'active_alerts', title: 'Active Alerts', position: { w: 4, h: 3 } },
   ],
   features: { dragDrop: true, addCard: true, autoRefresh: true, autoRefreshInterval: 120_000 },
-  storageKey: 'threat-intel-dashboard-cards',
+  storageKey: 'threat-intel-dashboard-cards-v2',
 }
 
 export default threatIntelDashboardConfig


### PR DESCRIPTION
Old localStorage keys still held configs with unregistered card types (workload_status, hipaa_compliance, etc). Bumping storageKey to -v2 forces fresh defaults with corrected registered card types.