### PR TITLE
fix: wire enterprise autoRefresh and replace full page reload

### DIFF
--- a/web/src/components/enterprise/EnterprisePortal.tsx
+++ b/web/src/components/enterprise/EnterprisePortal.tsx
@@ -4,7 +4,7 @@
  * Shows a dashboard overview of all compliance verticals with
  * status cards linking to each epic's dashboards.
  */
-import { useState, useCallback } from 'react'
+import { useState, useCallback, useEffect, useRef } from 'react'
 import { useNavigate } from 'react-router-dom'
 import {
   Landmark, Heart, Shield, KeyRound, Radar, Container, Scale, TrendingUp,
@@ -141,16 +141,34 @@ function VerticalCard({ sectionId, title, items, onNavigate }: {
   )
 }
 
+/** Interval between auto-refresh ticks in milliseconds */
+const AUTO_REFRESH_INTERVAL_MS = 30_000
+
 export default function EnterprisePortal() {
   const navigate = useNavigate()
   const [autoRefresh, setAutoRefresh] = useState(true)
-  const [lastUpdated] = useState(() => new Date())
+  const [lastUpdated, setLastUpdated] = useState(() => new Date())
   const dashboardContext = useDashboardContextOptional()
+  const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null)
 
   const handleRefresh = useCallback(() => {
-    // Force re-render with fresh timestamp
-    window.location.reload()
+    setLastUpdated(new Date())
   }, [])
+
+  // Wire autoRefresh toggle to a periodic refresh interval
+  useEffect(() => {
+    if (autoRefresh) {
+      intervalRef.current = setInterval(() => {
+        setLastUpdated(new Date())
+      }, AUTO_REFRESH_INTERVAL_MS)
+    }
+    return () => {
+      if (intervalRef.current) {
+        clearInterval(intervalRef.current)
+        intervalRef.current = null
+      }
+    }
+  }, [autoRefresh])
 
   const handleAddMore = useCallback(() => {
     if (dashboardContext?.openAddCardModal) {


### PR DESCRIPTION
## Summary
- Replace `window.location.reload()` in `handleRefresh` with a `lastUpdated` state update that triggers re-render without losing page state
- Wire the `autoRefresh` toggle to a `useEffect` with `setInterval` (`AUTO_REFRESH_INTERVAL_MS = 30_000`) so enabling auto-refresh actually triggers periodic updates
- Use a named constant for the interval per project conventions

Fixes #9807

## Test plan
- [ ] Toggle auto-refresh on — verify `lastUpdated` timestamp updates every 30s
- [ ] Toggle auto-refresh off — verify updates stop
- [ ] Click manual refresh — verify timestamp updates without full page reload
- [ ] Verify no state loss (scroll position, expanded cards) on refresh