### PR TITLE
fix: eagerly import Login/AuthCallback to prevent chunk_load errors

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -41,8 +41,12 @@ const DrillDownModal = safeLazy(() => import('./components/drilldown/DrillDownMo
 // Lazy load all page components for better code splitting.
 // safeLazy() validates the named export exists, throwing a recognisable
 // "chunk may be stale" error that ChunkErrorBoundary auto-recovers from.
-const Login = safeLazy(() => import('./components/auth/Login'), 'Login')
-const AuthCallback = safeLazy(() => import('./components/auth/AuthCallback'), 'AuthCallback')
+// Login and AuthCallback are eagerly imported — they are on the critical auth
+// path and must render reliably.  Lazy-loading them caused chunk_load errors
+// during OAuth redirects when the browser navigated away before the chunk
+// finished downloading (#9803).
+import { Login } from './components/auth/Login'
+import { AuthCallback } from './components/auth/AuthCallback'
 const CustomDashboard = safeLazy(() => import('./components/dashboard/CustomDashboard'), 'CustomDashboard')
 const Settings = safeLazy(() => import('./components/settings/Settings'), 'Settings')
 // Eagerly import key sidebar dashboards to prevent React Router's
@@ -631,8 +635,8 @@ function FullDashboardApp({ liveLocation }: { liveLocation: Location }) {
       <OrbitAutoRunner />
       <ChunkErrorBoundary>
       <Routes location={liveLocation}>
-        <Route path={ROUTES.LOGIN} element={<SuspenseRoute><Login /></SuspenseRoute>} />
-        <Route path={ROUTES.AUTH_CALLBACK} element={<SuspenseRoute><AuthCallback /></SuspenseRoute>} />
+        <Route path={ROUTES.LOGIN} element={<Login />} />
+        <Route path={ROUTES.AUTH_CALLBACK} element={<AuthCallback />} />
         {/* PWA Mini Dashboard - lightweight widget mode (no auth required for local monitoring) */}
         <Route path={ROUTES.WIDGET} element={<SuspenseRoute><MiniDashboard /></SuspenseRoute>} />
 

--- a/web/src/components/auth/Login.tsx
+++ b/web/src/components/auth/Login.tsx
@@ -12,8 +12,14 @@ import { useBranding } from '../../hooks/useBranding'
 import { UI_FEEDBACK_TIMEOUT_MS } from '../../lib/constants/network'
 import { copyToClipboard } from '../../lib/clipboard'
 
-// Lazy load the heavy Three.js globe animation
-const GlobeAnimation = lazy(() => import('../animations/globe').then(m => ({ default: m.GlobeAnimation })))
+// Lazy load the heavy Three.js globe animation.
+// Swallow import failures so a missing/stale chunk doesn't crash the login
+// page — the globe is cosmetic and the Suspense fallback (spinner) is fine.
+const GlobeAnimation = lazy(() =>
+  import('../animations/globe')
+    .then(m => ({ default: m.GlobeAnimation }))
+    .catch(() => ({ default: () => null }))
+)
 
 // Apache 2.0 license is the project's effective terms; link opens in a new tab (#8376).
 const TERMS_OF_SERVICE_URL = 'https://github.com/kubestellar/console/blob/main/LICENSE'

--- a/web/src/components/auth/Login.tsx
+++ b/web/src/components/auth/Login.tsx
@@ -15,12 +15,17 @@ import { copyToClipboard } from '../../lib/clipboard'
 // Lazy load the heavy Three.js globe animation.
 // Swallow import failures so a missing/stale chunk doesn't crash the login
 // page — the globe is cosmetic and the Suspense fallback (spinner) is fine.
-const GlobeAnimation = lazy(() =>
-  import('../animations/globe')
-    .then(m => ({ default: m.GlobeAnimation }))
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    .catch((): { default: React.ComponentType<any> } => ({ default: () => null }))
-)
+// The empty fallback component renders nothing — the globe area stays blank
+// rather than crashing the login page with a chunk error.
+const GlobeFallback = () => null
+const GlobeAnimation = lazy(async () => {
+  try {
+    const m = await import('../animations/globe')
+    return { default: m.GlobeAnimation }
+  } catch {
+    return { default: GlobeFallback as unknown as typeof import('../animations/globe')['GlobeAnimation'] }
+  }
+})
 
 // Apache 2.0 license is the project's effective terms; link opens in a new tab (#8376).
 const TERMS_OF_SERVICE_URL = 'https://github.com/kubestellar/console/blob/main/LICENSE'

--- a/web/src/components/auth/Login.tsx
+++ b/web/src/components/auth/Login.tsx
@@ -18,7 +18,8 @@ import { copyToClipboard } from '../../lib/clipboard'
 const GlobeAnimation = lazy(() =>
   import('../animations/globe')
     .then(m => ({ default: m.GlobeAnimation }))
-    .catch(() => ({ default: () => null }))
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    .catch((): { default: React.ComponentType<any> } => ({ default: () => null }))
 )
 
 // Apache 2.0 license is the project's effective terms; link opens in a new tab (#8376).


### PR DESCRIPTION
## Summary
- Eagerly import `Login` and `AuthCallback` instead of lazy-loading via `safeLazy()` — these are small components (~579 and ~150 lines) on the critical auth path that must render reliably
- Swallow import failures in the `GlobeAnimation` lazy import inside `Login.tsx` so a missing/stale Three.js chunk degrades gracefully instead of crashing the login page
- Remove unnecessary `SuspenseRoute` wrappers from the Login and AuthCallback routes since they are no longer lazy-loaded

## Root cause
Lazy-loading the Login component meant that during OAuth redirects the browser could navigate away before the chunk finished downloading, producing `chunk_load` errors on `/login`. PR #9768 fixed chunk **prefetch** on `/login`, but the Login route itself was still lazy-loaded. This PR eliminates the lazy import entirely.

## Test plan
- [ ] Visit `/login` — page renders immediately without Suspense spinner
- [ ] Complete OAuth flow — AuthCallback processes correctly
- [ ] Globe animation renders on wide viewports; gracefully absent if chunk fails
- [ ] Monitor GA4 `chunk_load` errors on `/login` — should drop to zero

Fixes #9803