### PR TITLE
🐛 Fix missing BAA Tracker, Sigstore, SLSA icons in Enterprise sidebar

### DIFF
--- a/web/src/lib/icons.ts
+++ b/web/src/lib/icons.ts
@@ -246,6 +246,9 @@ import {
   Zap,
   ZoomIn,
   ZoomOut,
+  Handshake,
+  BadgeCheck,
+  GitCommitHorizontal,
 } from 'lucide-react'
 
 export type { LucideIcon }
@@ -493,6 +496,9 @@ export const iconRegistry: Record<string, LucideIcon> = {
   Zap,
   ZoomIn,
   ZoomOut,
+  Handshake,
+  BadgeCheck,
+  GitCommitHorizontal,
 }
 
 /**


### PR DESCRIPTION
Fixes #9798

`Handshake`, `BadgeCheck`, and `GitCommitHorizontal` were missing from `iconRegistry` in `lib/icons.ts`. The enterprise sidebar resolves icons via this registry (through `SidebarShell`), so BAA Tracker, Sigstore Verify, and SLSA Provenance showed no icon.