### PR TITLE
fix: update useGlobalFilters tests to match __none__ sentinel preservation

### DIFF
--- a/web/src/hooks/__tests__/useGlobalFilters-edge-cases.test.tsx
+++ b/web/src/hooks/__tests__/useGlobalFilters-edge-cases.test.tsx
@@ -400,15 +400,16 @@ describe('edge cases', () => {
   })
 
   it('deselectAllClusters then selectAllClusters both resolve to all mode', () => {
-    // PR #5449: reconciliation drops __none__ immediately, so deselectAll
-    // already reverts to all-selected; selectAll is a no-op after that
+    // deselectAllClusters sets the __none__ sentinel, which is preserved
+    // (not reconciled away) so filterByCluster returns empty.
+    // selectAllClusters then clears the sentinel, restoring all mode.
     const { result } = renderHook(() => useGlobalFilters(), { wrapper })
 
     act(() => {
       result.current.deselectAllClusters()
     })
-    // Reconciliation already restored all mode
-    expect(result.current.filterByCluster(SAMPLE_ITEMS)).toEqual(SAMPLE_ITEMS)
+    // __none__ sentinel is preserved — nothing passes the filter
+    expect(result.current.filterByCluster(SAMPLE_ITEMS)).toEqual([])
 
     act(() => {
       result.current.selectAllClusters()
@@ -868,8 +869,9 @@ describe('combined isFiltered flag with edge combinations', () => {
 })
 
 describe('filterByCluster with __none__ sentinel edge cases', () => {
-  it('deselectAllClusters is reconciled to all mode — returns all items', () => {
-    // PR #5449: reconciliation drops __none__ sentinel, reverting to all mode
+  it('deselectAllClusters preserves __none__ sentinel — returns empty', () => {
+    // __none__ sentinel is preserved during reconciliation, so
+    // filterByCluster returns an empty array (nothing selected)
     const { result } = renderHook(() => useGlobalFilters(), { wrapper })
 
     act(() => {
@@ -880,8 +882,8 @@ describe('filterByCluster with __none__ sentinel edge cases', () => {
       { name: 'no-cluster' },
       { name: 'has-cluster', cluster: 'cluster-a' },
     ]
-    // All items returned because reconciliation restored all-selected mode
-    expect(result.current.filterByCluster(items)).toEqual(items)
+    // __none__ sentinel means nothing is selected — empty result
+    expect(result.current.filterByCluster(items)).toEqual([])
   })
 })
 

--- a/web/src/hooks/__tests__/useGlobalFilters-filter-funcs.test.tsx
+++ b/web/src/hooks/__tests__/useGlobalFilters-filter-funcs.test.tsx
@@ -97,15 +97,16 @@ describe('filterByCluster', () => {
     expect(filtered.every(item => item.cluster === 'cluster-a')).toBe(true)
   })
 
-  it('deselectAllClusters is reconciled to all-selected (returns all items)', () => {
-    // PR #5449: reconciliation drops __none__ sentinel, reverting to all mode
+  it('deselectAllClusters preserves __none__ sentinel (returns empty)', () => {
+    // __none__ sentinel is preserved during reconciliation, so
+    // filterByCluster returns an empty array (nothing selected)
     const { result } = renderHook(() => useGlobalFilters(), { wrapper })
 
     act(() => {
       result.current.deselectAllClusters()
     })
 
-    expect(result.current.filterByCluster(SAMPLE_ITEMS)).toEqual(SAMPLE_ITEMS)
+    expect(result.current.filterByCluster(SAMPLE_ITEMS)).toEqual([])
   })
 
   it('excludes items without a cluster field', () => {

--- a/web/src/hooks/__tests__/useGlobalFilters-init-selection.test.tsx
+++ b/web/src/hooks/__tests__/useGlobalFilters-init-selection.test.tsx
@@ -434,19 +434,19 @@ describe('cluster selection', () => {
     expect(result.current.isClustersFiltered).toBe(false)
   })
 
-  it('deselectAllClusters is reconciled back to all-selected mode', () => {
-    // PR #5449: reconciliation drops __none__ (not in availableClusters),
-    // reverting to all-selected mode
+  it('deselectAllClusters preserves __none__ sentinel (nothing selected)', () => {
+    // __none__ sentinel is preserved during reconciliation, so
+    // isAllClustersSelected is false and filterByCluster returns empty
     const { result } = renderHook(() => useGlobalFilters(), { wrapper })
 
     act(() => {
       result.current.deselectAllClusters()
     })
 
-    // Reconciliation resets to all-selected because __none__ is not a real cluster
-    expect(result.current.isAllClustersSelected).toBe(true)
+    // __none__ sentinel is preserved — not reconciled away
+    expect(result.current.isAllClustersSelected).toBe(false)
     const filtered = result.current.filterByCluster(SAMPLE_ITEMS)
-    expect(filtered).toEqual(SAMPLE_ITEMS)
+    expect(filtered).toEqual([])
   })
 
   describe('toggleCluster', () => {


### PR DESCRIPTION
## Summary
- Updates 4 failing `useGlobalFilters` test expectations to match the current hook behavior where the `__none__` sentinel is preserved during reconciliation (not dropped)
- `deselectAllClusters` correctly keeps the `__none__` sentinel, meaning `filterByCluster` returns empty and `isAllClustersSelected` is `false`
- The old tests incorrectly assumed `__none__` would be reconciled away to all-selected mode

## Test plan
- [x] All 181 useGlobalFilters tests pass (`npx vitest run` on all 3 test files)
- [x] No hook logic changed — only test expectations updated

Fixes #9813