### PR TITLE
fix: address remaining GA4 errors post-fix (#9804, #9805)

### DIFF
--- a/web/src/components/compliance/ChangeControlAudit.tsx
+++ b/web/src/components/compliance/ChangeControlAudit.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useMemo } from 'react'
+import { useState, useEffect, useMemo, memo } from 'react'
 import { UnifiedDashboard } from '../../lib/unified/dashboard/UnifiedDashboard'
 import { changeControlDashboardConfig } from '../../config/dashboards/change-control'
 import {
@@ -60,7 +60,7 @@ function riskBg(score: number): string {
   return 'bg-emerald-500/20'
 }
 
-export function ChangeControlAuditContent() {
+export const ChangeControlAuditContent = memo(function ChangeControlAuditContent() {
   const [summary, setSummary] = useState<AuditSummary | null>(null)
   const [changes, setChanges] = useState<ChangeRecord[]>([])
   const [violations, setViolations] = useState<PolicyViolation[]>([])
@@ -235,7 +235,7 @@ export function ChangeControlAuditContent() {
       )}
     </div>
   )
-}
+})
 
 function SummaryCard({ label, value, icon, accent }: { label: string; value: number; icon: React.ReactNode; accent?: string }) {
   return (

--- a/web/src/components/compliance/IncidentResponseDashboard.tsx
+++ b/web/src/components/compliance/IncidentResponseDashboard.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { memo } from 'react'
 import { useState, useEffect } from 'react'
 import {
   AlertTriangle, CheckCircle2, Loader2, Clock,
@@ -73,7 +73,7 @@ const TREND_COLORS: Record<string, string> = {
   degrading: 'text-red-400',
 }
 
-export default function IncidentResponseDashboard() {
+const IncidentResponseDashboard = memo(function IncidentResponseDashboard() {
   const [incidents, setIncidents] = useState<Incident[]>([])
   const [metrics, setMetrics] = useState<IncidentMetrics | null>(null)
   const [playbooks, setPlaybooks] = useState<Playbook[]>([])
@@ -311,4 +311,6 @@ export default function IncidentResponseDashboard() {
       )}
     </div>
   )
-}
+})
+
+export default IncidentResponseDashboard

--- a/web/src/components/compliance/SIEMDashboard.tsx
+++ b/web/src/components/compliance/SIEMDashboard.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { memo } from 'react'
 import { useState, useEffect } from 'react'
 import {
   Monitor, CheckCircle2, Loader2,
@@ -65,7 +65,7 @@ const STATUS_ICON: Record<string, React.ReactNode> = {
   resolved: <CheckCircle2 className="w-4 h-4 text-green-400" />,
 }
 
-export default function SIEMDashboard() {
+const SIEMDashboard = memo(function SIEMDashboard() {
   const [events, setEvents] = useState<SIEMEvent[]>([])
   const [alerts, setAlerts] = useState<SIEMAlert[]>([])
   const [summary, setSummary] = useState<SIEMSummary | null>(null)
@@ -279,4 +279,6 @@ export default function SIEMDashboard() {
       )}
     </div>
   )
-}
+})
+
+export default SIEMDashboard

--- a/web/src/components/compliance/SLSADashboard.tsx
+++ b/web/src/components/compliance/SLSADashboard.tsx
@@ -4,7 +4,7 @@
  * Build provenance level indicators (L1–L4), attestation verification,
  * source integrity checks, and build reproducibility.
  */
-import { useState, useEffect } from 'react'
+import { useState, useEffect, memo } from 'react'
 import {
   GitCommitHorizontal, CheckCircle2, Loader2, AlertTriangle,
   XCircle, Shield, Lock
@@ -92,7 +92,7 @@ const STATUS_ICON: Record<string, React.ReactNode> = {
 
 // ── Content Component ───────────────────────────────────────────────────
 
-export function SLSADashboardContent() {
+export const SLSADashboardContent = memo(function SLSADashboardContent() {
   const [attestations, setAttestations] = useState<SLSAAttestation[]>([])
   const [provenance, setProvenance] = useState<SLSAProvenance[]>([])
   const [summary, setSummary] = useState<SLSASummary | null>(null)
@@ -318,7 +318,7 @@ export function SLSADashboardContent() {
       )}
     </div>
   )
-}
+})
 
 // ── Page Component (rendered by App.tsx route) ──────────────────────────
 

--- a/web/src/components/compliance/ThreatIntelDashboard.tsx
+++ b/web/src/components/compliance/ThreatIntelDashboard.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { memo } from 'react'
 import { useState, useEffect } from 'react'
 import {
   Shield, CheckCircle2, Loader2,
@@ -96,7 +96,7 @@ function RiskScoreRing({ score, size = 80 }: { score: number; size?: number }) {
   )
 }
 
-export default function ThreatIntelDashboard() {
+const ThreatIntelDashboard = memo(function ThreatIntelDashboard() {
   const [feeds, setFeeds] = useState<ThreatFeed[]>([])
   const [iocs, setIOCs] = useState<IOCMatch[]>([])
   const [summary, setSummary] = useState<ThreatIntelSummary | null>(null)
@@ -329,4 +329,6 @@ export default function ThreatIntelDashboard() {
       )}
     </div>
   )
-}
+})
+
+export default ThreatIntelDashboard

--- a/web/src/lib/analytics-core.ts
+++ b/web/src/lib/analytics-core.ts
@@ -807,6 +807,10 @@ export function startGlobalErrorTracking() {
       if (msg.includes('send was called before connect') || msg.includes('InvalidStateError')) return
       // Skip BackendUnavailableError on Netlify / console.kubestellar.io
       if (isNetlifyDeployment && msg.includes('Backend API is currently unavailable')) return
+      // Skip transient network errors — tracked by individual hook error handling
+      if (msg.includes('Failed to fetch') || msg.includes('NetworkError') || msg.includes('net::ERR_')) return
+      // Skip WebGL context errors — benign GPU process resets
+      if (msg.includes('WebGL') || msg.includes('context lost')) return
       emitError('unhandled_rejection', msg)
     } finally {
       isEmitting = false
@@ -836,6 +840,28 @@ export function startGlobalErrorTracking() {
       // frame. Multiple cards on the dashboard use ResizeObserver, and layout
       // shifts during initial render or window resize trigger this harmlessly.
       if (event.message.includes('ResizeObserver loop')) return
+      // WebGL context lost/restored events fire when the GPU process resets
+      // (tab backgrounded, driver update, resource pressure). The globe
+      // animation and game cards handle this gracefully via Three.js internals.
+      if (
+        event.message.includes('WebGL') ||
+        event.message.includes('context lost') ||
+        event.message.includes('GL_INVALID')
+      ) return
+      // Canvas errors from 2D/WebGL rendering (toDataURL on tainted canvas,
+      // drawing to a canvas whose context was lost, etc.) are not actionable.
+      if (event.message.includes('canvas') || event.message.includes('CanvasRenderingContext')) return
+      // Network errors surfacing as runtime errors (e.g. image/script load
+      // failures due to transient connectivity). These are tracked separately
+      // via fetch error handling in individual hooks.
+      if (
+        event.message.includes('Failed to fetch') ||
+        event.message.includes('NetworkError') ||
+        event.message.includes('net::ERR_')
+      ) return
+      // Chrome fires "Non-Error promise rejection captured" for non-Error
+      // objects thrown in promise chains — typically from third-party scripts.
+      if (event.message.includes('Non-Error')) return
       // Stale chunks can surface as runtime errors (Safari: "Importing a module script failed")
       if (tryChunkReloadRecovery(event.message)) return
       emitError('runtime', event.message)


### PR DESCRIPTION
## Summary

- **#9804 (uncaught_render on enterprise pages):** 5 compliance page components were missing `React.memo()` wrapping, causing cascading re-renders from `VersionCheckProvider` in `EnterpriseLayout`. Components wrapped: `ChangeControlAudit`, `SLSADashboard`, `IncidentResponseDashboard`, `SIEMDashboard`, `ThreatIntelDashboard`.
- **#9805 (runtime errors on /):** After the ResizeObserver filter (PR #9790), other benign browser noise was surfacing as `runtime` errors. Added filters for: WebGL context lost/restored events (globe animation, game cards), Canvas rendering errors, transient network errors (`Failed to fetch`, `NetworkError`, `net::ERR_*`), and Chrome `Non-Error promise rejection` noise. Matching filters also added to the `unhandledrejection` handler.

## Test plan

- [ ] Verify enterprise pages (`/enterprise/frameworks`, `/enterprise/change-control`, etc.) render without console errors
- [ ] Verify no `uncaught_render` GA4 errors fire on enterprise page navigation
- [ ] Verify dashboard `/` does not fire `runtime` GA4 errors for WebGL/Canvas/network noise
- [ ] Monitor GA4 error counts for 24h post-deploy to confirm reduction

Fixes #9804, Fixes #9805