### PR TITLE
refactor: extract errNoClusterAccess helper, dedup 60+ handler guards

### DIFF
--- a/pkg/api/handlers/demo_data.go
+++ b/pkg/api/handlers/demo_data.go
@@ -15,6 +15,10 @@ func isDemoMode(c *fiber.Ctx) bool {
 	return c.Get("X-Demo-Mode") == "true"
 }
 
+func errNoClusterAccess(c *fiber.Ctx) error {
+	return c.Status(fiber.StatusServiceUnavailable).JSON(fiber.Map{"error": "No cluster access"})
+}
+
 // Demo cluster data - matches frontend getDemoClusters() for consistency
 func getDemoClusters() []k8s.ClusterInfo {
 	return []k8s.ClusterInfo{

--- a/pkg/api/handlers/gateway.go
+++ b/pkg/api/handlers/gateway.go
@@ -30,7 +30,7 @@ func NewGatewayHandlers(k8sClient *k8s.MultiClusterClient, hub *Hub) *GatewayHan
 // GET /api/gateway/gateways
 func (h *GatewayHandlers) ListGateways(c *fiber.Ctx) error {
 	if h.k8sClient == nil {
-		return c.Status(503).JSON(fiber.Map{"error": "Kubernetes client not available"})
+		return errNoClusterAccess(c)
 	}
 
 	// Optional filters
@@ -71,7 +71,7 @@ func (h *GatewayHandlers) ListGateways(c *fiber.Ctx) error {
 // GET /api/gateway/httproutes
 func (h *GatewayHandlers) ListHTTPRoutes(c *fiber.Ctx) error {
 	if h.k8sClient == nil {
-		return c.Status(503).JSON(fiber.Map{"error": "Kubernetes client not available"})
+		return errNoClusterAccess(c)
 	}
 
 	// Optional filters
@@ -112,7 +112,7 @@ func (h *GatewayHandlers) ListHTTPRoutes(c *fiber.Ctx) error {
 // GET /api/gateway/status
 func (h *GatewayHandlers) GetGatewayAPIStatus(c *fiber.Ctx) error {
 	if h.k8sClient == nil {
-		return c.Status(503).JSON(fiber.Map{"error": "Kubernetes client not available"})
+		return errNoClusterAccess(c)
 	}
 
 	ctx, cancel := context.WithTimeout(c.Context(), gatewayDefaultTimeout)
@@ -146,7 +146,7 @@ func (h *GatewayHandlers) GetGatewayAPIStatus(c *fiber.Ctx) error {
 // GET /api/gateway/gateways/:cluster/:namespace/:name
 func (h *GatewayHandlers) GetGateway(c *fiber.Ctx) error {
 	if h.k8sClient == nil {
-		return c.Status(503).JSON(fiber.Map{"error": "Kubernetes client not available"})
+		return errNoClusterAccess(c)
 	}
 
 	cluster := c.Params("cluster")
@@ -174,7 +174,7 @@ func (h *GatewayHandlers) GetGateway(c *fiber.Ctx) error {
 // GET /api/gateway/httproutes/:cluster/:namespace/:name
 func (h *GatewayHandlers) GetHTTPRoute(c *fiber.Ctx) error {
 	if h.k8sClient == nil {
-		return c.Status(503).JSON(fiber.Map{"error": "Kubernetes client not available"})
+		return errNoClusterAccess(c)
 	}
 
 	cluster := c.Params("cluster")

--- a/pkg/api/handlers/gitops.go
+++ b/pkg/api/handlers/gitops.go
@@ -636,7 +636,7 @@ func (h *GitOpsHandlers) StreamOperators(c *fiber.Ctx) error {
 	}
 
 	if h.k8sClient == nil {
-		return c.Status(503).JSON(fiber.Map{"error": "No cluster access"})
+		return errNoClusterAccess(c)
 	}
 
 	// Single cluster — return as single SSE event
@@ -1042,7 +1042,7 @@ func (h *GitOpsHandlers) StreamOperatorSubscriptions(c *fiber.Ctx) error {
 	}
 
 	if h.k8sClient == nil {
-		return c.Status(503).JSON(fiber.Map{"error": "No cluster access"})
+		return errNoClusterAccess(c)
 	}
 
 	if cluster != "" {
@@ -1213,7 +1213,7 @@ func (h *GitOpsHandlers) StreamHelmReleases(c *fiber.Ctx) error {
 	}
 
 	if h.k8sClient == nil {
-		return c.Status(503).JSON(fiber.Map{"error": "No cluster access"})
+		return errNoClusterAccess(c)
 	}
 
 	if cluster != "" {

--- a/pkg/api/handlers/mcp_cluster.go
+++ b/pkg/api/handlers/mcp_cluster.go
@@ -112,7 +112,7 @@ func (h *MCPHandlers) ListClusters(c *fiber.Ctx) error {
 		return c.JSON(fiber.Map{"clusters": clusters, "source": "k8s"})
 	}
 
-	return c.Status(503).JSON(fiber.Map{"error": "No cluster access available"})
+	return errNoClusterAccess(c)
 }
 
 // GetClusterHealth returns health for a specific cluster
@@ -148,7 +148,7 @@ func (h *MCPHandlers) GetClusterHealth(c *fiber.Ctx) error {
 		return c.JSON(health)
 	}
 
-	return c.Status(503).JSON(fiber.Map{"error": "No cluster access available"})
+	return errNoClusterAccess(c)
 }
 
 // GetAllClusterHealth returns health for all clusters
@@ -170,7 +170,7 @@ func (h *MCPHandlers) GetAllClusterHealth(c *fiber.Ctx) error {
 		return c.JSON(fiber.Map{"health": health})
 	}
 
-	return c.Status(503).JSON(fiber.Map{"error": "No cluster access available"})
+	return errNoClusterAccess(c)
 }
 
 // GetNodes returns detailed node information
@@ -237,7 +237,7 @@ func (h *MCPHandlers) GetNodes(c *fiber.Ctx) error {
 		return c.JSON(fiber.Map{"nodes": nodes, "source": "k8s"})
 	}
 
-	return c.Status(503).JSON(fiber.Map{"error": "No cluster access available"})
+	return errNoClusterAccess(c)
 }
 
 // GetEvents returns events from clusters
@@ -343,7 +343,7 @@ func (h *MCPHandlers) GetEvents(c *fiber.Ctx) error {
 		return c.JSON(fiber.Map{"events": events, "source": "k8s", "cluster": cluster})
 	}
 
-	return c.Status(503).JSON(fiber.Map{"error": "No cluster access available"})
+	return errNoClusterAccess(c)
 }
 
 // GetWarningEvents returns warning events from clusters
@@ -446,7 +446,7 @@ func (h *MCPHandlers) GetWarningEvents(c *fiber.Ctx) error {
 		return c.JSON(fiber.Map{"events": events, "source": "k8s", "cluster": cluster})
 	}
 
-	return c.Status(503).JSON(fiber.Map{"error": "No cluster access available"})
+	return errNoClusterAccess(c)
 }
 
 // CheckSecurityIssues returns security misconfigurations
@@ -516,5 +516,5 @@ func (h *MCPHandlers) CheckSecurityIssues(c *fiber.Ctx) error {
 		return c.JSON(fiber.Map{"issues": issues, "source": "k8s"})
 	}
 
-	return c.Status(503).JSON(fiber.Map{"error": "No cluster access available"})
+	return errNoClusterAccess(c)
 }

--- a/pkg/api/handlers/mcp_resources.go
+++ b/pkg/api/handlers/mcp_resources.go
@@ -83,7 +83,7 @@ func (h *MCPHandlers) GetGPUNodes(c *fiber.Ctx) error {
 		return c.JSON(fiber.Map{"nodes": nodes, "source": "k8s"})
 	}
 
-	return c.Status(503).JSON(fiber.Map{"error": "No cluster access available"})
+	return errNoClusterAccess(c)
 }
 
 // GetGPUNodeHealth returns proactive health check results for GPU nodes
@@ -148,7 +148,7 @@ func (h *MCPHandlers) GetGPUNodeHealth(c *fiber.Ctx) error {
 		return c.JSON(fiber.Map{"nodes": nodes, "source": "k8s"})
 	}
 
-	return c.Status(503).JSON(fiber.Map{"error": "No cluster access available"})
+	return errNoClusterAccess(c)
 }
 
 // GetGPUHealthCronJobStatus returns the installation status of the GPU health CronJob
@@ -166,7 +166,7 @@ func (h *MCPHandlers) GetGPUHealthCronJobStatus(c *fiber.Ctx) error {
 	}
 
 	if h.k8sClient == nil {
-		return c.Status(503).JSON(fiber.Map{"error": "No cluster access"})
+		return errNoClusterAccess(c)
 	}
 
 	ctx, cancel := context.WithTimeout(c.Context(), mcpDefaultTimeout)
@@ -203,7 +203,7 @@ func (h *MCPHandlers) GetGPUHealthCronJobResults(c *fiber.Ctx) error {
 	}
 
 	if h.k8sClient == nil {
-		return c.Status(503).JSON(fiber.Map{"error": "No cluster access"})
+		return errNoClusterAccess(c)
 	}
 
 	ctx, cancel := context.WithTimeout(c.Context(), mcpDefaultTimeout)
@@ -277,7 +277,7 @@ func (h *MCPHandlers) GetNVIDIAOperatorStatus(c *fiber.Ctx) error {
 		return c.JSON(fiber.Map{"operators": []*k8s.NVIDIAOperatorStatus{status}, "source": "k8s"})
 	}
 
-	return c.Status(503).JSON(fiber.Map{"error": "No cluster access available"})
+	return errNoClusterAccess(c)
 }
 
 // GetConfigMaps returns ConfigMaps from clusters
@@ -345,7 +345,7 @@ func (h *MCPHandlers) GetConfigMaps(c *fiber.Ctx) error {
 		return c.JSON(fiber.Map{"configmaps": configmaps, "source": "k8s"})
 	}
 
-	return c.Status(503).JSON(fiber.Map{"error": "No cluster access available"})
+	return errNoClusterAccess(c)
 }
 
 // GetSecrets returns Secrets from clusters
@@ -413,7 +413,7 @@ func (h *MCPHandlers) GetSecrets(c *fiber.Ctx) error {
 		return c.JSON(fiber.Map{"secrets": secrets, "source": "k8s"})
 	}
 
-	return c.Status(503).JSON(fiber.Map{"error": "No cluster access available"})
+	return errNoClusterAccess(c)
 }
 
 // GetServiceAccounts returns ServiceAccounts from clusters
@@ -481,7 +481,7 @@ func (h *MCPHandlers) GetServiceAccounts(c *fiber.Ctx) error {
 		return c.JSON(fiber.Map{"serviceAccounts": serviceAccounts, "source": "k8s"})
 	}
 
-	return c.Status(503).JSON(fiber.Map{"error": "No cluster access available"})
+	return errNoClusterAccess(c)
 }
 
 // GetPVCs returns PersistentVolumeClaims from clusters
@@ -549,7 +549,7 @@ func (h *MCPHandlers) GetPVCs(c *fiber.Ctx) error {
 		return c.JSON(fiber.Map{"pvcs": pvcs, "source": "k8s"})
 	}
 
-	return c.Status(503).JSON(fiber.Map{"error": "No cluster access available"})
+	return errNoClusterAccess(c)
 }
 
 // GetPVs returns PersistentVolumes from clusters
@@ -615,7 +615,7 @@ func (h *MCPHandlers) GetPVs(c *fiber.Ctx) error {
 		return c.JSON(fiber.Map{"pvs": pvs, "source": "k8s"})
 	}
 
-	return c.Status(503).JSON(fiber.Map{"error": "No cluster access available"})
+	return errNoClusterAccess(c)
 }
 
 // GetResourceQuotas returns resource quotas from clusters
@@ -683,7 +683,7 @@ func (h *MCPHandlers) GetResourceQuotas(c *fiber.Ctx) error {
 		return c.JSON(fiber.Map{"resourceQuotas": quotas, "source": "k8s"})
 	}
 
-	return c.Status(503).JSON(fiber.Map{"error": "No cluster access available"})
+	return errNoClusterAccess(c)
 }
 
 // GetLimitRanges returns limit ranges from clusters
@@ -751,7 +751,7 @@ func (h *MCPHandlers) GetLimitRanges(c *fiber.Ctx) error {
 		return c.JSON(fiber.Map{"limitRanges": ranges, "source": "k8s"})
 	}
 
-	return c.Status(503).JSON(fiber.Map{"error": "No cluster access available"})
+	return errNoClusterAccess(c)
 }
 
 // CreateOrUpdateResourceQuota creates or updates a ResourceQuota
@@ -822,7 +822,7 @@ func (h *MCPHandlers) CreateOrUpdateResourceQuota(c *fiber.Ctx) error {
 		return c.JSON(fiber.Map{"resourceQuota": quota, "source": "k8s"})
 	}
 
-	return c.Status(503).JSON(fiber.Map{"error": "No cluster access available"})
+	return errNoClusterAccess(c)
 }
 
 // DeleteResourceQuota deletes a ResourceQuota
@@ -861,7 +861,7 @@ func (h *MCPHandlers) DeleteResourceQuota(c *fiber.Ctx) error {
 		return c.JSON(fiber.Map{"deleted": true, "name": name, "namespace": namespace, "cluster": cluster})
 	}
 
-	return c.Status(503).JSON(fiber.Map{"error": "No cluster access available"})
+	return errNoClusterAccess(c)
 }
 
 // GetPodLogs returns logs from a pod
@@ -904,7 +904,7 @@ func (h *MCPHandlers) GetPodLogs(c *fiber.Ctx) error {
 		return c.JSON(fiber.Map{"logs": logs, "source": "k8s"})
 	}
 
-	return c.Status(503).JSON(fiber.Map{"error": "No cluster access available"})
+	return errNoClusterAccess(c)
 }
 
 // CallToolRequest represents a request to call an MCP tool
@@ -1145,7 +1145,7 @@ func (h *MCPHandlers) GetFlatcarNodes(c *fiber.Ctx) error {
 		return c.JSON(fiber.Map{"nodes": nodes, "source": "k8s"})
 	}
 
-	return c.Status(503).JSON(fiber.Map{"error": "No cluster access available"})
+	return errNoClusterAccess(c)
 }
 
 // GetIngresses returns Ingresses from clusters
@@ -1213,7 +1213,7 @@ func (h *MCPHandlers) GetIngresses(c *fiber.Ctx) error {
 		return c.JSON(fiber.Map{"ingresses": items, "source": "k8s"})
 	}
 
-	return c.Status(503).JSON(fiber.Map{"error": "No cluster access available"})
+	return errNoClusterAccess(c)
 }
 
 // GetNetworkPolicies returns NetworkPolicies from clusters
@@ -1281,7 +1281,7 @@ func (h *MCPHandlers) GetNetworkPolicies(c *fiber.Ctx) error {
 		return c.JSON(fiber.Map{"networkpolicies": items, "source": "k8s"})
 	}
 
-	return c.Status(503).JSON(fiber.Map{"error": "No cluster access available"})
+	return errNoClusterAccess(c)
 }
 
 // podNetworkStatsTimeout is the per-cluster timeout for network stats queries.
@@ -1343,7 +1343,7 @@ func (h *MCPHandlers) GetPodNetworkStats(c *fiber.Ctx) error {
 	}
 
 	if h.k8sClient == nil {
-		return c.Status(503).JSON(fiber.Map{"error": "No cluster access available"})
+		return errNoClusterAccess(c)
 	}
 
 	clusters, _, err := h.k8sClient.HealthyClusters(c.Context())

--- a/pkg/api/handlers/mcp_test.go
+++ b/pkg/api/handlers/mcp_test.go
@@ -111,7 +111,7 @@ func TestMCPGetPods_NoClusterAccessReturns503(t *testing.T) {
 
 	var payload map[string]interface{}
 	require.NoError(t, json.NewDecoder(resp.Body).Decode(&payload))
-	assert.Equal(t, "No cluster access available", payload["error"])
+	assert.Equal(t, "No cluster access", payload["error"])
 }
 
 func TestMCPGetPods_SingleClusterEmptyIsArray(t *testing.T) {

--- a/pkg/api/handlers/mcp_workloads.go
+++ b/pkg/api/handlers/mcp_workloads.go
@@ -94,7 +94,7 @@ func (h *MCPHandlers) GetPods(c *fiber.Ctx) error {
 		return c.JSON(fiber.Map{"pods": pods, "source": "k8s"})
 	}
 
-	return c.Status(503).JSON(fiber.Map{"error": "No cluster access available"})
+	return errNoClusterAccess(c)
 }
 
 // FindPodIssues returns pods with issues
@@ -176,7 +176,7 @@ func (h *MCPHandlers) FindPodIssues(c *fiber.Ctx) error {
 		return c.JSON(fiber.Map{"issues": issues, "source": "k8s"})
 	}
 
-	return c.Status(503).JSON(fiber.Map{"error": "No cluster access available"})
+	return errNoClusterAccess(c)
 }
 
 // FindDeploymentIssues returns deployments with issues
@@ -245,7 +245,7 @@ func (h *MCPHandlers) FindDeploymentIssues(c *fiber.Ctx) error {
 		return c.JSON(fiber.Map{"issues": issues, "source": "k8s"})
 	}
 
-	return c.Status(503).JSON(fiber.Map{"error": "No cluster access available"})
+	return errNoClusterAccess(c)
 }
 
 // GetDeployments returns deployments with rollout status
@@ -310,7 +310,7 @@ func (h *MCPHandlers) GetDeployments(c *fiber.Ctx) error {
 		return c.JSON(fiber.Map{"deployments": deployments, "source": "k8s"})
 	}
 
-	return c.Status(503).JSON(fiber.Map{"error": "No cluster access available"})
+	return errNoClusterAccess(c)
 }
 
 // GetServices returns services from clusters
@@ -412,7 +412,7 @@ func (h *MCPHandlers) GetServices(c *fiber.Ctx) error {
 		return c.JSON(fiber.Map{"services": services, "source": "k8s"})
 	}
 
-	return c.Status(503).JSON(fiber.Map{"error": "No cluster access available"})
+	return errNoClusterAccess(c)
 }
 
 // GetJobs returns jobs from clusters
@@ -477,7 +477,7 @@ func (h *MCPHandlers) GetJobs(c *fiber.Ctx) error {
 		return c.JSON(fiber.Map{"jobs": jobs, "source": "k8s"})
 	}
 
-	return c.Status(503).JSON(fiber.Map{"error": "No cluster access available"})
+	return errNoClusterAccess(c)
 }
 
 // GetHPAs returns HPAs from clusters
@@ -542,7 +542,7 @@ func (h *MCPHandlers) GetHPAs(c *fiber.Ctx) error {
 		return c.JSON(fiber.Map{"hpas": hpas, "source": "k8s"})
 	}
 
-	return c.Status(503).JSON(fiber.Map{"error": "No cluster access available"})
+	return errNoClusterAccess(c)
 }
 
 // GetReplicaSets returns ReplicaSets from clusters
@@ -607,7 +607,7 @@ func (h *MCPHandlers) GetReplicaSets(c *fiber.Ctx) error {
 		return c.JSON(fiber.Map{"replicasets": items, "source": "k8s"})
 	}
 
-	return c.Status(503).JSON(fiber.Map{"error": "No cluster access available"})
+	return errNoClusterAccess(c)
 }
 
 // GetStatefulSets returns StatefulSets from clusters
@@ -672,7 +672,7 @@ func (h *MCPHandlers) GetStatefulSets(c *fiber.Ctx) error {
 		return c.JSON(fiber.Map{"statefulsets": items, "source": "k8s"})
 	}
 
-	return c.Status(503).JSON(fiber.Map{"error": "No cluster access available"})
+	return errNoClusterAccess(c)
 }
 
 // GetDaemonSets returns DaemonSets from clusters
@@ -737,7 +737,7 @@ func (h *MCPHandlers) GetDaemonSets(c *fiber.Ctx) error {
 		return c.JSON(fiber.Map{"daemonsets": items, "source": "k8s"})
 	}
 
-	return c.Status(503).JSON(fiber.Map{"error": "No cluster access available"})
+	return errNoClusterAccess(c)
 }
 
 // GetCronJobs returns CronJobs from clusters
@@ -802,7 +802,7 @@ func (h *MCPHandlers) GetCronJobs(c *fiber.Ctx) error {
 		return c.JSON(fiber.Map{"cronjobs": items, "source": "k8s"})
 	}
 
-	return c.Status(503).JSON(fiber.Map{"error": "No cluster access available"})
+	return errNoClusterAccess(c)
 }
 
 // GetWorkloads returns an aggregate view of workloads (Deployments, StatefulSets,
@@ -814,7 +814,7 @@ func (h *MCPHandlers) GetWorkloads(c *fiber.Ctx) error {
 	}
 
 	if h.k8sClient == nil {
-		return c.Status(503).JSON(fiber.Map{"error": "No cluster access available"})
+		return errNoClusterAccess(c)
 	}
 
 	cluster := c.Query("cluster")

--- a/pkg/api/handlers/mcs.go
+++ b/pkg/api/handlers/mcs.go
@@ -29,7 +29,7 @@ func NewMCSHandlers(k8sClient *k8s.MultiClusterClient, hub *Hub) *MCSHandlers {
 // GET /api/mcs/exports
 func (h *MCSHandlers) ListServiceExports(c *fiber.Ctx) error {
 	if h.k8sClient == nil {
-		return c.Status(503).JSON(fiber.Map{"error": "Kubernetes client not available"})
+		return errNoClusterAccess(c)
 	}
 
 	// Optional filters
@@ -65,7 +65,7 @@ func (h *MCSHandlers) ListServiceExports(c *fiber.Ctx) error {
 // GET /api/mcs/imports
 func (h *MCSHandlers) ListServiceImports(c *fiber.Ctx) error {
 	if h.k8sClient == nil {
-		return c.Status(503).JSON(fiber.Map{"error": "Kubernetes client not available"})
+		return errNoClusterAccess(c)
 	}
 
 	// Optional filters
@@ -101,7 +101,7 @@ func (h *MCSHandlers) ListServiceImports(c *fiber.Ctx) error {
 // GET /api/mcs/status
 func (h *MCSHandlers) GetMCSStatus(c *fiber.Ctx) error {
 	if h.k8sClient == nil {
-		return c.Status(503).JSON(fiber.Map{"error": "Kubernetes client not available"})
+		return errNoClusterAccess(c)
 	}
 
 	ctx, cancel := context.WithTimeout(c.Context(), mcsDefaultTimeout)
@@ -135,7 +135,7 @@ func (h *MCSHandlers) GetMCSStatus(c *fiber.Ctx) error {
 // GET /api/mcs/exports/:cluster/:namespace/:name
 func (h *MCSHandlers) GetServiceExport(c *fiber.Ctx) error {
 	if h.k8sClient == nil {
-		return c.Status(503).JSON(fiber.Map{"error": "Kubernetes client not available"})
+		return errNoClusterAccess(c)
 	}
 
 	cluster := c.Params("cluster")
@@ -163,7 +163,7 @@ func (h *MCSHandlers) GetServiceExport(c *fiber.Ctx) error {
 // GET /api/mcs/imports/:cluster/:namespace/:name
 func (h *MCSHandlers) GetServiceImport(c *fiber.Ctx) error {
 	if h.k8sClient == nil {
-		return c.Status(503).JSON(fiber.Map{"error": "Kubernetes client not available"})
+		return errNoClusterAccess(c)
 	}
 
 	cluster := c.Params("cluster")

--- a/pkg/api/handlers/pod_logs_test.go
+++ b/pkg/api/handlers/pod_logs_test.go
@@ -84,7 +84,7 @@ func TestMCPGetPodLogs_NoClusterAccessReturns503(t *testing.T) {
 
 	var payload map[string]interface{}
 	require.NoError(t, json.NewDecoder(resp.Body).Decode(&payload))
-	assert.Equal(t, "No cluster access available", payload["error"])
+	assert.Equal(t, "No cluster access", payload["error"])
 }
 
 // TestMCPGetPodLogs_FakeClientReturnsLogs exercises the real success path:

--- a/pkg/api/handlers/sse.go
+++ b/pkg/api/handlers/sse.go
@@ -584,7 +584,7 @@ func (h *MCPHandlers) GetPodsStream(c *fiber.Ctx) error {
 		return streamDemoSSE(c, "pods", getDemoPods())
 	}
 	if h.k8sClient == nil {
-		return c.Status(503).JSON(fiber.Map{"error": "No cluster access"})
+		return errNoClusterAccess(c)
 	}
 
 	namespace := c.Query("namespace")
@@ -607,7 +607,7 @@ func (h *MCPHandlers) FindPodIssuesStream(c *fiber.Ctx) error {
 		return streamDemoSSE(c, "issues", getDemoPodIssues())
 	}
 	if h.k8sClient == nil {
-		return c.Status(503).JSON(fiber.Map{"error": "No cluster access"})
+		return errNoClusterAccess(c)
 	}
 
 	namespace := c.Query("namespace")
@@ -630,7 +630,7 @@ func (h *MCPHandlers) GetDeploymentsStream(c *fiber.Ctx) error {
 		return streamDemoSSE(c, "deployments", getDemoDeployments())
 	}
 	if h.k8sClient == nil {
-		return c.Status(503).JSON(fiber.Map{"error": "No cluster access"})
+		return errNoClusterAccess(c)
 	}
 
 	namespace := c.Query("namespace")
@@ -653,7 +653,7 @@ func (h *MCPHandlers) GetEventsStream(c *fiber.Ctx) error {
 		return streamDemoSSE(c, "events", getDemoEvents())
 	}
 	if h.k8sClient == nil {
-		return c.Status(503).JSON(fiber.Map{"error": "No cluster access"})
+		return errNoClusterAccess(c)
 	}
 
 	namespace := c.Query("namespace")
@@ -685,7 +685,7 @@ func (h *MCPHandlers) GetServicesStream(c *fiber.Ctx) error {
 		return streamDemoSSE(c, "services", getDemoServices())
 	}
 	if h.k8sClient == nil {
-		return c.Status(503).JSON(fiber.Map{"error": "No cluster access"})
+		return errNoClusterAccess(c)
 	}
 
 	namespace := c.Query("namespace")
@@ -708,7 +708,7 @@ func (h *MCPHandlers) CheckSecurityIssuesStream(c *fiber.Ctx) error {
 		return streamDemoSSE(c, "issues", getDemoSecurityIssues())
 	}
 	if h.k8sClient == nil {
-		return c.Status(503).JSON(fiber.Map{"error": "No cluster access"})
+		return errNoClusterAccess(c)
 	}
 
 	namespace := c.Query("namespace")
@@ -731,7 +731,7 @@ func (h *MCPHandlers) FindDeploymentIssuesStream(c *fiber.Ctx) error {
 		return streamDemoSSE(c, "issues", getDemoDeploymentIssues())
 	}
 	if h.k8sClient == nil {
-		return c.Status(503).JSON(fiber.Map{"error": "No cluster access"})
+		return errNoClusterAccess(c)
 	}
 
 	namespace := c.Query("namespace")
@@ -754,7 +754,7 @@ func (h *MCPHandlers) GetNodesStream(c *fiber.Ctx) error {
 		return streamDemoSSE(c, "nodes", getDemoNodes())
 	}
 	if h.k8sClient == nil {
-		return c.Status(503).JSON(fiber.Map{"error": "No cluster access"})
+		return errNoClusterAccess(c)
 	}
 
 	return streamClusters(c, h, sseClusterStreamConfig{
@@ -771,7 +771,7 @@ func (h *MCPHandlers) GetGPUNodesStream(c *fiber.Ctx) error {
 		return streamDemoSSE(c, "nodes", getDemoGPUNodes())
 	}
 	if h.k8sClient == nil {
-		return c.Status(503).JSON(fiber.Map{"error": "No cluster access"})
+		return errNoClusterAccess(c)
 	}
 
 	return streamClusters(c, h, sseClusterStreamConfig{
@@ -788,7 +788,7 @@ func (h *MCPHandlers) GetGPUNodeHealthStream(c *fiber.Ctx) error {
 		return streamDemoSSE(c, "nodes", getDemoGPUNodeHealth())
 	}
 	if h.k8sClient == nil {
-		return c.Status(503).JSON(fiber.Map{"error": "No cluster access"})
+		return errNoClusterAccess(c)
 	}
 
 	return streamClusters(c, h, sseClusterStreamConfig{
@@ -813,7 +813,7 @@ func (h *MCPHandlers) GetWarningEventsStream(c *fiber.Ctx) error {
 		return streamDemoSSE(c, "events", getDemoWarningEvents())
 	}
 	if h.k8sClient == nil {
-		return c.Status(503).JSON(fiber.Map{"error": "No cluster access"})
+		return errNoClusterAccess(c)
 	}
 
 	namespace := c.Query("namespace")
@@ -853,7 +853,7 @@ func (h *MCPHandlers) GetJobsStream(c *fiber.Ctx) error {
 		return streamDemoSSE(c, "jobs", getDemoJobs())
 	}
 	if h.k8sClient == nil {
-		return c.Status(503).JSON(fiber.Map{"error": "No cluster access"})
+		return errNoClusterAccess(c)
 	}
 
 	namespace := c.Query("namespace")
@@ -872,7 +872,7 @@ func (h *MCPHandlers) GetConfigMapsStream(c *fiber.Ctx) error {
 		return streamDemoSSE(c, "configmaps", getDemoConfigMaps())
 	}
 	if h.k8sClient == nil {
-		return c.Status(503).JSON(fiber.Map{"error": "No cluster access"})
+		return errNoClusterAccess(c)
 	}
 
 	namespace := c.Query("namespace")
@@ -897,7 +897,7 @@ func (h *MCPHandlers) GetSecretsStream(c *fiber.Ctx) error {
 		return streamDemoSSE(c, "secrets", getDemoSecrets())
 	}
 	if h.k8sClient == nil {
-		return c.Status(503).JSON(fiber.Map{"error": "No cluster access"})
+		return errNoClusterAccess(c)
 	}
 
 	namespace := c.Query("namespace")
@@ -916,7 +916,7 @@ func (h *MCPHandlers) GetWorkloadsStream(c *fiber.Ctx) error {
 		return streamDemoSSE(c, "workloads", getDemoWorkloads())
 	}
 	if h.k8sClient == nil {
-		return c.Status(503).JSON(fiber.Map{"error": "No cluster access"})
+		return errNoClusterAccess(c)
 	}
 
 	namespace := c.Query("namespace")
@@ -940,7 +940,7 @@ func (h *MCPHandlers) GetNVIDIAOperatorStatusStream(c *fiber.Ctx) error {
 		return streamDemoSSE(c, "operators", getDemoNVIDIAOperatorStatus())
 	}
 	if h.k8sClient == nil {
-		return c.Status(503).JSON(fiber.Map{"error": "No cluster access"})
+		return errNoClusterAccess(c)
 	}
 
 	return streamClusters(c, h, sseClusterStreamConfig{

--- a/pkg/api/handlers/workloads.go
+++ b/pkg/api/handlers/workloads.go
@@ -76,7 +76,7 @@ func (h *WorkloadHandlers) requireAdmin(c *fiber.Ctx) error {
 // GET /api/workloads
 func (h *WorkloadHandlers) ListWorkloads(c *fiber.Ctx) error {
 	if h.k8sClient == nil {
-		return c.Status(503).JSON(fiber.Map{"error": "Kubernetes client not available"})
+		return errNoClusterAccess(c)
 	}
 
 	// Optional filters
@@ -99,7 +99,7 @@ func (h *WorkloadHandlers) ListWorkloads(c *fiber.Ctx) error {
 // GET /api/workloads/:cluster/:namespace/:name
 func (h *WorkloadHandlers) GetWorkload(c *fiber.Ctx) error {
 	if h.k8sClient == nil {
-		return c.Status(503).JSON(fiber.Map{"error": "Kubernetes client not available"})
+		return errNoClusterAccess(c)
 	}
 
 	cluster := c.Params("cluster")
@@ -130,7 +130,7 @@ func (h *WorkloadHandlers) GetWorkload(c *fiber.Ctx) error {
 // GET /api/workloads/resolve-deps/:cluster/:namespace/:name
 func (h *WorkloadHandlers) ResolveDependencies(c *fiber.Ctx) error {
 	if h.k8sClient == nil {
-		return c.Status(503).JSON(fiber.Map{"error": "Kubernetes client not available"})
+		return errNoClusterAccess(c)
 	}
 
 	cluster := c.Params("cluster")
@@ -187,7 +187,7 @@ func (h *WorkloadHandlers) ResolveDependencies(c *fiber.Ctx) error {
 // GET /api/workloads/monitor/:cluster/:namespace/:name
 func (h *WorkloadHandlers) MonitorWorkload(c *fiber.Ctx) error {
 	if h.k8sClient == nil {
-		return c.Status(503).JSON(fiber.Map{"error": "Kubernetes client not available"})
+		return errNoClusterAccess(c)
 	}
 
 	cluster := c.Params("cluster")
@@ -213,7 +213,7 @@ func (h *WorkloadHandlers) MonitorWorkload(c *fiber.Ctx) error {
 // GET /api/workloads/deploy-status/:cluster/:namespace/:name
 func (h *WorkloadHandlers) GetDeployStatus(c *fiber.Ctx) error {
 	if h.k8sClient == nil {
-		return c.Status(503).JSON(fiber.Map{"error": "Kubernetes client not available"})
+		return errNoClusterAccess(c)
 	}
 
 	cluster := c.Params("cluster")
@@ -626,7 +626,7 @@ func (h *WorkloadHandlers) SyncClusterGroups(c *fiber.Ctx) error {
 // POST /api/cluster-groups/evaluate
 func (h *WorkloadHandlers) EvaluateClusterQuery(c *fiber.Ctx) error {
 	if h.k8sClient == nil {
-		return c.Status(503).JSON(fiber.Map{"error": "Kubernetes client not available"})
+		return errNoClusterAccess(c)
 	}
 
 	var query ClusterGroupQuery
@@ -1032,7 +1032,7 @@ func buildClusterContextForAI(healthData []k8s.ClusterHealth) string {
 // GET /api/workloads/capabilities
 func (h *WorkloadHandlers) GetClusterCapabilities(c *fiber.Ctx) error {
 	if h.k8sClient == nil {
-		return c.Status(503).JSON(fiber.Map{"error": "Kubernetes client not available"})
+		return errNoClusterAccess(c)
 	}
 
 	ctx, cancel := context.WithTimeout(c.Context(), workloadListTimeout)
@@ -1050,7 +1050,7 @@ func (h *WorkloadHandlers) GetClusterCapabilities(c *fiber.Ctx) error {
 // GET /api/workloads/policies
 func (h *WorkloadHandlers) ListBindingPolicies(c *fiber.Ctx) error {
 	if h.k8sClient == nil {
-		return c.Status(503).JSON(fiber.Map{"error": "Kubernetes client not available"})
+		return errNoClusterAccess(c)
 	}
 
 	ctx, cancel := context.WithTimeout(c.Context(), workloadDefaultTimeout)
@@ -1069,7 +1069,7 @@ func (h *WorkloadHandlers) ListBindingPolicies(c *fiber.Ctx) error {
 // GET /api/workloads/deploy-logs/:cluster/:namespace/:name?tail=8
 func (h *WorkloadHandlers) GetDeployLogs(c *fiber.Ctx) error {
 	if h.k8sClient == nil {
-		return c.Status(503).JSON(fiber.Map{"error": "Kubernetes client not available"})
+		return errNoClusterAccess(c)
 	}
 
 	cluster := c.Params("cluster")


### PR DESCRIPTION
## Summary
- 11 handler files had 60+ copy-pasted "no cluster access" error responses with 3 inconsistent messages
- Extracted a single `errNoClusterAccess(c)` helper in `demo_data.go`
- Unified error message to `"No cluster access"` across all endpoints
- Updated 2 test files to match the unified message

## Files changed
- `pkg/api/handlers/demo_data.go` — new `errNoClusterAccess()` helper
- `pkg/api/handlers/sse.go` — 16 replacements
- `pkg/api/handlers/mcp_resources.go` — 19 replacements
- `pkg/api/handlers/mcp_workloads.go` — 12 replacements
- `pkg/api/handlers/mcp_cluster.go` — 7 replacements
- `pkg/api/handlers/workloads.go` — 9 replacements
- `pkg/api/handlers/gateway.go` — 5 replacements
- `pkg/api/handlers/mcs.go` — 5 replacements
- `pkg/api/handlers/gitops.go` — 3 replacements
- `pkg/api/handlers/mcp_test.go` — updated assertion
- `pkg/api/handlers/pod_logs_test.go` — updated assertion

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./pkg/api/handlers/...` passes
- [x] `npm run build` passes
- [ ] No regression on cluster-less mode (503 responses still correct)

🤖 Generated with [Claude Code](https://claude.com/claude-code)