### PR TITLE
test: add coverage for Array.isArray guards and ResizeObserver filtering

### DIFF
--- a/web/src/components/compliance/ChangeControlAudit.test.tsx
+++ b/web/src/components/compliance/ChangeControlAudit.test.tsx
@@ -66,4 +66,52 @@ describe('ChangeControlAudit', () => {
       expect(screen.getByText('Network error')).toBeInTheDocument()
     })
   })
+
+  /* ── Array.isArray guard tests (PR #9794 regression coverage) ─── */
+
+  it('renders without crashing when /changes returns a non-array object', async () => {
+    vi.spyOn(globalThis, 'fetch').mockImplementation((url: RequestInfo | URL) => {
+      const u = typeof url === 'string' ? url : url.toString()
+      if (u.includes('/summary')) return Promise.resolve(new Response(JSON.stringify(mockSummary)))
+      if (u.includes('/changes')) return Promise.resolve(new Response(JSON.stringify({ unexpected: 'object' })))
+      if (u.includes('/violations')) return Promise.resolve(new Response(JSON.stringify(mockViolations)))
+      if (u.includes('/policies')) return Promise.resolve(new Response(JSON.stringify(mockPolicies)))
+      return Promise.resolve(new Response('{}'))
+    })
+    render(<ChangeControlAudit />)
+    await waitFor(() => {
+      expect(screen.getByText('Change Control Audit Trail')).toBeInTheDocument()
+      expect(screen.getByText('Total Changes')).toBeInTheDocument()
+    })
+  })
+
+  it('renders without crashing when /violations returns null', async () => {
+    vi.spyOn(globalThis, 'fetch').mockImplementation((url: RequestInfo | URL) => {
+      const u = typeof url === 'string' ? url : url.toString()
+      if (u.includes('/summary')) return Promise.resolve(new Response(JSON.stringify(mockSummary)))
+      if (u.includes('/changes')) return Promise.resolve(new Response(JSON.stringify(mockChanges)))
+      if (u.includes('/violations')) return Promise.resolve(new Response(JSON.stringify(null)))
+      if (u.includes('/policies')) return Promise.resolve(new Response(JSON.stringify(mockPolicies)))
+      return Promise.resolve(new Response('{}'))
+    })
+    render(<ChangeControlAudit />)
+    await waitFor(() => {
+      expect(screen.getByText('Change Control Audit Trail')).toBeInTheDocument()
+    })
+  })
+
+  it('renders without crashing when all array endpoints return non-array data', async () => {
+    vi.spyOn(globalThis, 'fetch').mockImplementation((url: RequestInfo | URL) => {
+      const u = typeof url === 'string' ? url : url.toString()
+      if (u.includes('/summary')) return Promise.resolve(new Response(JSON.stringify(mockSummary)))
+      if (u.includes('/changes')) return Promise.resolve(new Response(JSON.stringify('string-payload')))
+      if (u.includes('/violations')) return Promise.resolve(new Response(JSON.stringify(42)))
+      if (u.includes('/policies')) return Promise.resolve(new Response(JSON.stringify(null)))
+      return Promise.resolve(new Response('{}'))
+    })
+    render(<ChangeControlAudit />)
+    await waitFor(() => {
+      expect(screen.getByText('Change Control Audit Trail')).toBeInTheDocument()
+    })
+  })
 })

--- a/web/src/components/compliance/SLSADashboard.test.tsx
+++ b/web/src/components/compliance/SLSADashboard.test.tsx
@@ -1,0 +1,88 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { authFetch } from '../../lib/api'
+import { SLSADashboardContent as SLSADashboard } from './SLSADashboard'
+
+/* ── Mock authFetch at the top level ─────────────────────────────── */
+
+vi.mock('../../lib/api', () => ({
+  authFetch: vi.fn(),
+}))
+
+const mockedAuthFetch = vi.mocked(authFetch)
+
+/* ── Valid fixtures ──────────────────────────────────────────────── */
+
+const mockAttestations = [
+  { id: 'a-1', artifact: 'img:latest', builder: 'github-actions', slsa_level: 3, verified: true, build_type: 'container', source_repo: 'org/repo', timestamp: '2026-04-23T01:00:00Z', status: 'pass' },
+]
+const mockProvenance = [
+  { id: 'p-1', artifact: 'img:latest', builder_id: 'gh-actions', build_level: 3, source_uri: 'https://github.com/org/repo', source_digest: 'sha256:abc', reproducible: true, hermetic: true, parameterless: false, timestamp: '2026-04-23T01:00:00Z' },
+]
+const mockSummary = {
+  total_artifacts: 1, attested_artifacts: 1,
+  level_1: 0, level_2: 0, level_3: 1, level_4: 0,
+  verified_attestations: 1, failed_attestations: 0, pending_attestations: 0,
+  source_integrity_pass: 1, source_integrity_fail: 0,
+  reproducible_builds: 1, total_builds: 1,
+}
+
+/* ── Helpers ─────────────────────────────────────────────────────── */
+
+/** Configure mockedAuthFetch to resolve each endpoint to the given payloads */
+function setupAuthFetch(overrides: {
+  attestations?: unknown
+  provenance?: unknown
+  summary?: unknown
+} = {}) {
+  mockedAuthFetch.mockImplementation((url: string) => {
+    const data =
+      url.includes('/attestations') ? (overrides.attestations ?? mockAttestations) :
+      url.includes('/provenance')   ? (overrides.provenance ?? mockProvenance) :
+      url.includes('/summary')      ? (overrides.summary ?? mockSummary) :
+      {}
+    return Promise.resolve({ ok: true, json: () => Promise.resolve(data) } as Response)
+  })
+}
+
+/* ── Tests ───────────────────────────────────────────────────────── */
+
+describe('SLSADashboard', () => {
+  beforeEach(() => { vi.clearAllMocks() })
+
+  it('renders the dashboard header with valid array data', async () => {
+    setupAuthFetch()
+    render(<SLSADashboard />)
+    await waitFor(() => expect(screen.getByText('SLSA Provenance')).toBeInTheDocument())
+  })
+
+  it('renders without crashing when attestations endpoint returns a non-array (object)', async () => {
+    setupAuthFetch({ attestations: { unexpected: 'object' } })
+    render(<SLSADashboard />)
+    await waitFor(() => expect(screen.getByText('SLSA Provenance')).toBeInTheDocument())
+  })
+
+  it('renders without crashing when provenance endpoint returns null', async () => {
+    setupAuthFetch({ provenance: null })
+    render(<SLSADashboard />)
+    await waitFor(() => expect(screen.getByText('SLSA Provenance')).toBeInTheDocument())
+  })
+
+  it('renders without crashing when both array endpoints return non-array data', async () => {
+    setupAuthFetch({ attestations: 'string-payload', provenance: 42 })
+    render(<SLSADashboard />)
+    await waitFor(() => expect(screen.getByText('SLSA Provenance')).toBeInTheDocument())
+  })
+
+  it('shows zero-count summary when array endpoints return non-array data', async () => {
+    setupAuthFetch({
+      attestations: {},
+      provenance: null,
+      summary: { ...mockSummary, total_artifacts: 0, attested_artifacts: 0 },
+    })
+    render(<SLSADashboard />)
+    await waitFor(() => {
+      expect(screen.getByText('Total Artifacts')).toBeInTheDocument()
+    })
+  })
+})

--- a/web/src/lib/__tests__/analytics-error-tracking.test.ts
+++ b/web/src/lib/__tests__/analytics-error-tracking.test.ts
@@ -388,7 +388,16 @@ describe('startGlobalErrorTracking sets up listeners', () => {
       message: 'ResizeObserver loop limit exceeded',
     })
     expect(() => window.dispatchEvent(event2)).not.toThrow()
+    // Partial match — future browser variants
+    const event3 = new ErrorEvent('error', {
+      message: 'Uncaught: ResizeObserver loop error detected',
+    })
+    expect(() => window.dispatchEvent(event3)).not.toThrow()
   })
+
+  // Full send-count verification (ResizeObserver errors NOT reported to GA4)
+  // is in analytics-resize-observer-filter.test.ts — it initializes the
+  // analytics pipeline end-to-end and asserts navigator.sendBeacon counts.
 })
 
 describe('markErrorReported and dedup integration', () => {

--- a/web/src/lib/__tests__/analytics-resize-observer-filter.test.ts
+++ b/web/src/lib/__tests__/analytics-resize-observer-filter.test.ts
@@ -1,0 +1,108 @@
+/**
+ * Integration test verifying ResizeObserver loop errors are filtered
+ * and NOT reported to GA4 analytics.
+ *
+ * This test initializes the analytics pipeline end-to-end (init + first
+ * interaction + gtag timeout) and asserts that navigator.sendBeacon is
+ * called for real runtime errors but NOT for ResizeObserver loop errors.
+ *
+ * Covers: issue #9809 (PR #9790 fix regression coverage)
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+
+/* ── Mock automated-environment check BEFORE importing analytics ──── */
+
+vi.mock('../analytics-session', async () => {
+  const actual = await vi.importActual<typeof import('../analytics-session')>('../analytics-session')
+  return {
+    ...actual,
+    // Force isAutomatedEnvironment to return false so initAnalytics proceeds
+    isAutomatedEnvironment: () => false,
+  }
+})
+
+import { initAnalytics, startGlobalErrorTracking } from '../analytics'
+
+/* ── Constants ──────────────────────────────────────────────────────── */
+
+/** Timeout for gtag.js load decision (mirrors GTAG_LOAD_TIMEOUT_MS in analytics-core) */
+const GTAG_LOAD_TIMEOUT_MS = 5_000
+/** Small buffer added after gtag timeout to ensure decision is made */
+const TIMER_BUFFER_MS = 200
+
+describe('ResizeObserver errors are NOT reported to GA4', () => {
+  let sendBeaconSpy: ReturnType<typeof vi.fn>
+
+  beforeEach(() => {
+    vi.useFakeTimers()
+    // Spy on navigator.sendBeacon — the final output of the proxy send path
+    sendBeaconSpy = vi.fn(() => true)
+    Object.defineProperty(navigator, 'sendBeacon', {
+      value: sendBeaconSpy,
+      writable: true,
+      configurable: true,
+    })
+    // Prevent actual fetch calls from the proxy path
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response(''))
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    vi.restoreAllMocks()
+  })
+
+  it('filters ResizeObserver loop errors while reporting normal runtime errors', () => {
+    // Step 1: Initialize analytics (sets initialized = true)
+    initAnalytics()
+
+    // Step 2: Set up error tracking listeners
+    startGlobalErrorTracking()
+
+    // Step 3: Simulate first user interaction to ungate the send pipeline
+    document.dispatchEvent(new MouseEvent('mousedown', { bubbles: true }))
+
+    // Step 4: Advance timers past the gtag load timeout so gtagDecided = true
+    // (gtag.js won't actually load in jsdom, so proxy path is used)
+    vi.advanceTimersByTime(GTAG_LOAD_TIMEOUT_MS + TIMER_BUFFER_MS)
+
+    // Baseline: record sendBeacon call count before errors
+    const baselineCount = sendBeaconSpy.mock.calls.length
+
+    // Step 5: Dispatch a NORMAL runtime error — should reach sendBeacon
+    window.dispatchEvent(new ErrorEvent('error', {
+      message: 'TypeError: Cannot read properties of undefined',
+    }))
+
+    const afterNormalError = sendBeaconSpy.mock.calls.length
+    // The normal error should have triggered at least one sendBeacon call
+    expect(afterNormalError).toBeGreaterThan(baselineCount)
+
+    // Step 6: Dispatch ResizeObserver errors — should NOT increase send count
+    window.dispatchEvent(new ErrorEvent('error', {
+      message: 'ResizeObserver loop completed with undelivered notifications.',
+    }))
+    window.dispatchEvent(new ErrorEvent('error', {
+      message: 'ResizeObserver loop limit exceeded',
+    }))
+
+    const afterResizeErrors = sendBeaconSpy.mock.calls.length
+    // ResizeObserver errors must NOT produce any additional sendBeacon calls
+    expect(afterResizeErrors).toBe(afterNormalError)
+  })
+
+  it('filters ResizeObserver errors with partial message match', () => {
+    initAnalytics()
+    startGlobalErrorTracking()
+    document.dispatchEvent(new MouseEvent('mousedown', { bubbles: true }))
+    vi.advanceTimersByTime(GTAG_LOAD_TIMEOUT_MS + TIMER_BUFFER_MS)
+
+    const beforeCount = sendBeaconSpy.mock.calls.length
+
+    // Hypothetical future browser message variant containing "ResizeObserver loop"
+    window.dispatchEvent(new ErrorEvent('error', {
+      message: 'Uncaught: ResizeObserver loop error detected',
+    }))
+
+    expect(sendBeaconSpy.mock.calls.length).toBe(beforeCount)
+  })
+})


### PR DESCRIPTION
## Summary
- Add unit tests for `SLSADashboard` and `ChangeControlAudit` verifying `Array.isArray()` guards handle non-array API responses (objects, null, strings, numbers) without crashing
- Add integration test verifying ResizeObserver loop errors are filtered and NOT reported to GA4 via `navigator.sendBeacon`, while normal runtime errors are reported
- Enhance existing ResizeObserver test in `analytics-error-tracking.test.ts` with additional partial-match variant

Fixes #9808, Fixes #9809

## Test plan
- [x] All 62 tests pass across the 4 test files
- [x] SLSADashboard renders with non-array payloads (object, null, string, number)
- [x] ChangeControlAudit renders with non-array payloads for /changes, /violations, /policies
- [x] ResizeObserver errors do NOT trigger `navigator.sendBeacon` (GA4 send)
- [x] Normal runtime errors DO trigger `navigator.sendBeacon`
- [x] No vitest warnings about hoisted mocks