### PR TITLE
fix: add DashboardHeader to compliance dashboards and fix enterprise sidebar width

### DIFF
--- a/web/src/components/compliance/AirGapDashboard.tsx
+++ b/web/src/components/compliance/AirGapDashboard.tsx
@@ -6,6 +6,8 @@ import {
   ArrowRight, WifiOff
 } from 'lucide-react'
 import { authFetch } from '../../lib/api'
+import { DashboardHeader } from '../shared/DashboardHeader'
+import { RotatingTip } from '../ui/RotatingTip'
 
 interface Requirement {
   id: string
@@ -65,6 +67,7 @@ const statusColor = (status: string) => {
 }
 
 export const AirGapDashboardContent = memo(function AirGapDashboardContent() {
+  const [autoRefresh, setAutoRefresh] = useState(true)
   const [requirements, setRequirements] = useState<Requirement[]>([])
   const [clusters, setClusters] = useState<ClusterReadiness[]>([])
   const [summary, setSummary] = useState<AirGapSummary | null>(null)
@@ -114,13 +117,17 @@ export const AirGapDashboardContent = memo(function AirGapDashboardContent() {
 
   return (
     <div className="space-y-6">
-      <div className="flex items-center gap-3">
-        <WifiOff className="w-8 h-8 text-blue-400" />
-        <div>
-          <h1 className="text-2xl font-bold text-white">Air-Gap Readiness</h1>
-          <p className="text-gray-400">Disconnected environment readiness assessment for Kubernetes clusters</p>
-        </div>
-      </div>
+      <DashboardHeader
+        title="Air-Gap Readiness"
+        subtitle="Disconnected environment readiness assessment for Kubernetes clusters"
+        icon={<WifiOff className="w-7 h-7 text-blue-400" />}
+        isFetching={false}
+        onRefresh={() => window.location.reload()}
+        autoRefresh={autoRefresh}
+        onAutoRefreshChange={setAutoRefresh}
+        autoRefreshId="air-gap-auto-refresh"
+        rightExtra={<RotatingTip page="air-gap" />}
+      />
 
       {/* Summary cards */}
       {summary && (

--- a/web/src/components/compliance/BAADashboard.tsx
+++ b/web/src/components/compliance/BAADashboard.tsx
@@ -3,7 +3,7 @@ import { UnifiedDashboard } from '../../lib/unified/dashboard/UnifiedDashboard'
 import { baaDashboardConfig } from '../../config/dashboards/baa'
 import {
   FileText, CheckCircle2, XCircle, AlertTriangle, Loader2,
-  RefreshCw, Clock, Building2, Cloud, Server, Mail,
+  Clock, Building2, Cloud, Server, Mail,
 } from 'lucide-react'
 import { authFetch } from '../../lib/api'
 import { DashboardHeader } from '../shared/DashboardHeader'

--- a/web/src/components/compliance/BAADashboard.tsx
+++ b/web/src/components/compliance/BAADashboard.tsx
@@ -6,6 +6,8 @@ import {
   RefreshCw, Clock, Building2, Cloud, Server, Mail,
 } from 'lucide-react'
 import { authFetch } from '../../lib/api'
+import { DashboardHeader } from '../shared/DashboardHeader'
+import { RotatingTip } from '../ui/RotatingTip'
 
 interface BAAgreement {
   id: string; provider: string; provider_type: string
@@ -34,6 +36,7 @@ const PROVIDER_ICONS: Record<string, typeof Cloud> = {
 }
 
 export const BAADashboardContent = memo(function BAADashboardContent() {
+  const [autoRefresh, setAutoRefresh] = useState(true)
   const [agreements, setAgreements] = useState<BAAgreement[]>([])
   const [alerts, setAlerts] = useState<BAAAlert[]>([])
   const [summary, setSummary] = useState<BAASummary | null>(null)
@@ -86,21 +89,17 @@ export const BAADashboardContent = memo(function BAADashboardContent() {
 
   return (
     <div className="space-y-6 p-6">
-      {/* Header */}
-      <div className="flex items-center justify-between">
-        <div>
-          <h1 className="text-2xl font-bold text-white flex items-center gap-3">
-            <FileText className="w-7 h-7 text-blue-400" />
-            Business Associate Agreements
-          </h1>
-          <p className="text-gray-400 mt-1">
-            HIPAA BAA tracking across cloud providers and vendors
-          </p>
-        </div>
-        <button onClick={fetchData} className="p-2 hover:bg-white/10 rounded-lg transition-colors" title="Refresh">
-          <RefreshCw className="w-5 h-5 text-gray-400" />
-        </button>
-      </div>
+      <DashboardHeader
+        title="Business Associate Agreements"
+        subtitle="HIPAA BAA tracking across cloud providers and vendors"
+        icon={<FileText className="w-7 h-7 text-blue-400" />}
+        isFetching={false}
+        onRefresh={fetchData}
+        autoRefresh={autoRefresh}
+        onAutoRefreshChange={setAutoRefresh}
+        autoRefreshId="baa-auto-refresh"
+        rightExtra={<RotatingTip page="baa" />}
+      />
 
       {/* Summary Cards */}
       {summary && (

--- a/web/src/components/compliance/ChangeControlAudit.tsx
+++ b/web/src/components/compliance/ChangeControlAudit.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useMemo, memo } from 'react'
+import { useState, useEffect, useMemo } from 'react'
 import { UnifiedDashboard } from '../../lib/unified/dashboard/UnifiedDashboard'
 import { changeControlDashboardConfig } from '../../config/dashboards/change-control'
 import {
@@ -7,6 +7,8 @@ import {
 } from 'lucide-react'
 import { authFetch } from '../../lib/api'
 import { Select } from '../ui/Select'
+import { DashboardHeader } from '../shared/DashboardHeader'
+import { RotatingTip } from '../ui/RotatingTip'
 
 interface ChangeRecord {
   id: string; timestamp: string; cluster: string; namespace: string
@@ -60,7 +62,8 @@ function riskBg(score: number): string {
   return 'bg-emerald-500/20'
 }
 
-export const ChangeControlAuditContent = memo(function ChangeControlAuditContent() {
+export function ChangeControlAuditContent() {
+  const [autoRefresh, setAutoRefresh] = useState(true)
   const [summary, setSummary] = useState<AuditSummary | null>(null)
   const [changes, setChanges] = useState<ChangeRecord[]>([])
   const [violations, setViolations] = useState<PolicyViolation[]>([])
@@ -114,16 +117,17 @@ export const ChangeControlAuditContent = memo(function ChangeControlAuditContent
 
   return (
     <div className="space-y-6">
-      <div className="flex items-center justify-between">
-        <div className="flex items-center gap-3">
-          <div className="p-2 rounded-lg bg-violet-500/10"><ClipboardCheck className="w-6 h-6 text-violet-400" /></div>
-          <div>
-            <h1 className="text-xl font-semibold text-zinc-100">Change Control Audit Trail</h1>
-            <p className="text-sm text-zinc-400">SOX/PCI-compliant change tracking with approval workflows</p>
-          </div>
-        </div>
-        <button onClick={fetchData} type="button" aria-label="Refresh change control data" className="text-zinc-400 hover:text-zinc-200 p-2 rounded-lg hover:bg-zinc-700/50 transition-colors"><RefreshCw className="w-4 h-4" /></button>
-      </div>
+      <DashboardHeader
+        title="Change Control Audit Trail"
+        subtitle="SOX/PCI-compliant change tracking with approval workflows"
+        icon={<ClipboardCheck className="w-5 h-5 text-violet-400" />}
+        isFetching={false}
+        onRefresh={fetchData}
+        autoRefresh={autoRefresh}
+        onAutoRefreshChange={setAutoRefresh}
+        autoRefreshId="change-control-auto-refresh"
+        rightExtra={<RotatingTip page="change-control" />}
+      />
 
       {summary && (
         <div className="grid grid-cols-2 md:grid-cols-5 gap-4">
@@ -235,7 +239,7 @@ export const ChangeControlAuditContent = memo(function ChangeControlAuditContent
       )}
     </div>
   )
-})
+}
 
 function SummaryCard({ label, value, icon, accent }: { label: string; value: number; icon: React.ReactNode; accent?: string }) {
   return (

--- a/web/src/components/compliance/ComplianceFrameworks.tsx
+++ b/web/src/components/compliance/ComplianceFrameworks.tsx
@@ -15,7 +15,7 @@
  * actual list of cluster names changes.
  */
 import { useState, useMemo, useEffect, useCallback, useSyncExternalStore, memo } from 'react'
-import { Shield, ChevronDown, ChevronRight, CheckCircle2, XCircle, AlertTriangle, MinusCircle, Loader2, RefreshCw } from 'lucide-react'
+import { Shield, ChevronDown, ChevronRight, CheckCircle2, XCircle, AlertTriangle, MinusCircle, Loader2 } from 'lucide-react'
 import { UnifiedDashboard } from '../../lib/unified/dashboard/UnifiedDashboard'
 import { complianceFrameworksDashboardConfig } from '../../config/dashboards/compliance-frameworks'
 import { useComplianceFrameworks, useFrameworkEvaluation, type Framework, type ControlResult, type ComplianceCheck } from '../../hooks/useComplianceFrameworks'

--- a/web/src/components/compliance/ComplianceFrameworks.tsx
+++ b/web/src/components/compliance/ComplianceFrameworks.tsx
@@ -20,6 +20,8 @@ import { UnifiedDashboard } from '../../lib/unified/dashboard/UnifiedDashboard'
 import { complianceFrameworksDashboardConfig } from '../../config/dashboards/compliance-frameworks'
 import { useComplianceFrameworks, useFrameworkEvaluation, type Framework, type ControlResult, type ComplianceCheck } from '../../hooks/useComplianceFrameworks'
 import { clusterCache, subscribeClusterData } from '../../hooks/mcp/shared'
+import { DashboardHeader } from '../shared/DashboardHeader'
+import { RotatingTip } from '../ui/RotatingTip'
 
 /* ────────── status badge helpers ────────── */
 
@@ -196,6 +198,7 @@ function useClusterNames(): string[] {
 /* ────────── main page ────────── */
 
 export const ComplianceFrameworksContent = memo(function ComplianceFrameworksContent() {
+  const [autoRefresh, setAutoRefresh] = useState(true)
   const { frameworks, isLoading: fwLoading, error: fwError, refetch } = useComplianceFrameworks()
   const clusterNames = useClusterNames()
   const { result, isEvaluating, error: evalError, evaluate } = useFrameworkEvaluation()
@@ -259,26 +262,17 @@ export const ComplianceFrameworksContent = memo(function ComplianceFrameworksCon
 
   return (
     <div className="p-6 space-y-6 max-w-7xl mx-auto">
-      {/* Header */}
-      <div className="flex items-center justify-between">
-        <div>
-          <h1 className="text-xl font-bold text-white flex items-center gap-2">
-            <Shield className="w-5 h-5 text-blue-400" />
-            Compliance Frameworks
-          </h1>
-          <p className="text-sm text-zinc-400 mt-0.5">
-            Evaluate clusters against PCI-DSS 4.0, SOC 2 Type II, and other regulatory standards
-          </p>
-        </div>
-        <button
-          onClick={refetch}
-          className="p-2 rounded-md border border-zinc-700 text-zinc-400 hover:text-zinc-200 hover:border-zinc-600 transition-colors"
-          title="Refresh frameworks"
-          type="button"
-        >
-          <RefreshCw className="w-4 h-4" />
-        </button>
-      </div>
+      <DashboardHeader
+        title="Compliance Frameworks"
+        subtitle="Evaluate clusters against PCI-DSS 4.0, SOC 2 Type II, and other regulatory standards"
+        icon={<Shield className="w-5 h-5 text-blue-400" />}
+        isFetching={false}
+        onRefresh={refetch}
+        autoRefresh={autoRefresh}
+        onAutoRefreshChange={setAutoRefresh}
+        autoRefreshId="compliance-frameworks-auto-refresh"
+        rightExtra={<RotatingTip page="compliance-frameworks" />}
+      />
 
       {/* Framework picker */}
       <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">

--- a/web/src/components/compliance/ComplianceReports.tsx
+++ b/web/src/components/compliance/ComplianceReports.tsx
@@ -12,10 +12,13 @@ import { useComplianceFrameworks, type Framework } from '../../hooks/useComplian
 import { useClusters } from '../../hooks/useMCP'
 import { authFetch } from '../../lib/api'
 import { Select } from '../ui/Select'
+import { DashboardHeader } from '../shared/DashboardHeader'
+import { RotatingTip } from '../ui/RotatingTip'
 
 type ReportFormat = 'pdf' | 'json'
 
 export const ComplianceReportsContent = memo(function ComplianceReportsContent() {
+  const [autoRefresh, setAutoRefresh] = useState(true)
   const { frameworks, isLoading: fwLoading } = useComplianceFrameworks()
   const { clusters } = useClusters()
   const clusterNames = useMemo(() => clusters?.map((c: { name: string }) => c.name) ?? [], [clusters])
@@ -86,16 +89,17 @@ export const ComplianceReportsContent = memo(function ComplianceReportsContent()
 
   return (
     <div className="space-y-6">
-      {/* Header */}
-      <div className="flex items-center gap-3">
-        <div className="p-2 rounded-lg bg-indigo-500/10">
-          <FileText className="w-6 h-6 text-indigo-400" />
-        </div>
-        <div>
-          <h1 className="text-xl font-semibold text-zinc-100">Compliance Reports</h1>
-          <p className="text-sm text-zinc-400">Generate audit-ready compliance reports in PDF or JSON format</p>
-        </div>
-      </div>
+      <DashboardHeader
+        title="Compliance Reports"
+        subtitle="Generate audit-ready compliance reports in PDF or JSON format"
+        icon={<FileText className="w-5 h-5 text-indigo-400" />}
+        isFetching={false}
+        onRefresh={() => window.location.reload()}
+        autoRefresh={autoRefresh}
+        onAutoRefreshChange={setAutoRefresh}
+        autoRefreshId="compliance-reports-auto-refresh"
+        rightExtra={<RotatingTip page="compliance-reports" />}
+      />
 
       {/* Generator Card */}
       <div className="rounded-xl border border-zinc-700/50 bg-zinc-800/50 p-6 space-y-5">

--- a/web/src/components/compliance/DataResidency.tsx
+++ b/web/src/components/compliance/DataResidency.tsx
@@ -10,6 +10,8 @@ import { dataResidencyDashboardConfig } from '../../config/dashboards/data-resid
 import { Globe, ShieldAlert, MapPin, CheckCircle2, XCircle, AlertTriangle, Loader2, RefreshCw } from 'lucide-react'
 import { authFetch } from '../../lib/api'
 import { Select } from '../ui/Select'
+import { DashboardHeader } from '../shared/DashboardHeader'
+import { RotatingTip } from '../ui/RotatingTip'
 
 /* ─── Types ─── */
 
@@ -81,6 +83,7 @@ const REGION_LABELS: Record<string, string> = {
 /* ─── Main Component ─── */
 
 export const DataResidencyContent = memo(function DataResidencyContent() {
+  const [autoRefresh, setAutoRefresh] = useState(true)
   const [summary, setSummary] = useState<ResidencySummary | null>(null)
   const [rules, setRules] = useState<ResidencyRule[]>([])
   const [clusters, setClusters] = useState<ClusterRegion[]>([])
@@ -152,21 +155,17 @@ export const DataResidencyContent = memo(function DataResidencyContent() {
 
   return (
     <div className="space-y-6">
-      {/* Header */}
-      <div className="flex items-center justify-between">
-        <div className="flex items-center gap-3">
-          <div className="p-2 rounded-lg bg-emerald-500/10">
-            <Globe className="w-6 h-6 text-emerald-400" />
-          </div>
-          <div>
-            <h1 className="text-xl font-semibold text-zinc-100">Data Residency Enforcement</h1>
-            <p className="text-sm text-zinc-400">Ensure workloads with sensitive data only run in approved geographic regions</p>
-          </div>
-        </div>
-        <button onClick={fetchData} className="text-zinc-400 hover:text-zinc-200 p-2 rounded-lg hover:bg-zinc-700/50 transition-colors">
-          <RefreshCw className="w-4 h-4" />
-        </button>
-      </div>
+      <DashboardHeader
+        title="Data Residency Enforcement"
+        subtitle="Ensure workloads with sensitive data only run in approved geographic regions"
+        icon={<Globe className="w-5 h-5 text-emerald-400" />}
+        isFetching={false}
+        onRefresh={fetchData}
+        autoRefresh={autoRefresh}
+        onAutoRefreshChange={setAutoRefresh}
+        autoRefreshId="data-residency-auto-refresh"
+        rightExtra={<RotatingTip page="data-residency" />}
+      />
 
       {/* Summary Cards */}
       {summary && (

--- a/web/src/components/compliance/FedRAMPDashboard.tsx
+++ b/web/src/components/compliance/FedRAMPDashboard.tsx
@@ -6,6 +6,8 @@ import {
   Shield, ArrowRight, Clock
 } from 'lucide-react'
 import { authFetch } from '../../lib/api'
+import { DashboardHeader } from '../shared/DashboardHeader'
+import { RotatingTip } from '../ui/RotatingTip'
 
 interface Control {
   id: string
@@ -78,6 +80,7 @@ const milestoneStatusBadge = (status: string) => {
 }
 
 export const FedRAMPDashboardContent = memo(function FedRAMPDashboardContent() {
+  const [autoRefresh, setAutoRefresh] = useState(true)
   const [controls, setControls] = useState<Control[]>([])
   const [poams, setPOAMs] = useState<POAM[]>([])
   const [score, setScore] = useState<FedRAMPScore | null>(null)
@@ -127,13 +130,17 @@ export const FedRAMPDashboardContent = memo(function FedRAMPDashboardContent() {
 
   return (
     <div className="space-y-6">
-      <div className="flex items-center gap-3">
-        <Shield className="w-8 h-8 text-blue-400" />
-        <div>
-          <h1 className="text-2xl font-bold text-white">FedRAMP Readiness</h1>
-          <p className="text-gray-400">Federal Risk and Authorization Management Program compliance assessment</p>
-        </div>
-      </div>
+      <DashboardHeader
+        title="FedRAMP Readiness"
+        subtitle="Federal Risk and Authorization Management Program compliance assessment"
+        icon={<Shield className="w-7 h-7 text-blue-400" />}
+        isFetching={false}
+        onRefresh={() => window.location.reload()}
+        autoRefresh={autoRefresh}
+        onAutoRefreshChange={setAutoRefresh}
+        autoRefreshId="fedramp-auto-refresh"
+        rightExtra={<RotatingTip page="fedramp" />}
+      />
 
       {/* Summary cards */}
       {score && (

--- a/web/src/components/compliance/GxPDashboard.tsx
+++ b/web/src/components/compliance/GxPDashboard.tsx
@@ -6,6 +6,8 @@ import {
   RefreshCw, Lock, FileCheck, Link2, PenTool, Clock, Hash,
 } from 'lucide-react'
 import { authFetch } from '../../lib/api'
+import { DashboardHeader } from '../shared/DashboardHeader'
+import { RotatingTip } from '../ui/RotatingTip'
 
 interface AuditRecord {
   id: string; timestamp: string; user_id: string; action: string
@@ -42,6 +44,7 @@ const ACTION_STYLES: Record<string, string> = {
 }
 
 export const GxPDashboardContent = memo(function GxPDashboardContent() {
+  const [autoRefresh, setAutoRefresh] = useState(true)
   const [summary, setSummary] = useState<GxPSummary | null>(null)
   const [records, setRecords] = useState<AuditRecord[]>([])
   const [signatures, setSignatures] = useState<Signature[]>([])
@@ -101,21 +104,17 @@ export const GxPDashboardContent = memo(function GxPDashboardContent() {
 
   return (
     <div className="space-y-6 p-6">
-      {/* Header */}
-      <div className="flex items-center justify-between">
-        <div>
-          <h1 className="text-2xl font-bold text-white flex items-center gap-3">
-            <FileCheck className="w-7 h-7 text-green-400" />
-            GxP Validation Mode
-          </h1>
-          <p className="text-gray-400 mt-1">
-            21 CFR Part 11 — Electronic records and signatures
-          </p>
-        </div>
-        <button onClick={fetchData} className="p-2 hover:bg-white/10 rounded-lg transition-colors" title="Refresh">
-          <RefreshCw className="w-5 h-5 text-gray-400" />
-        </button>
-      </div>
+      <DashboardHeader
+        title="GxP Validation Mode"
+        subtitle="21 CFR Part 11 — Electronic records and signatures"
+        icon={<FileCheck className="w-7 h-7 text-green-400" />}
+        isFetching={false}
+        onRefresh={fetchData}
+        autoRefresh={autoRefresh}
+        onAutoRefreshChange={setAutoRefresh}
+        autoRefreshId="gxp-auto-refresh"
+        rightExtra={<RotatingTip page="gxp" />}
+      />
 
       {/* Summary Cards */}
       {summary && (

--- a/web/src/components/compliance/GxPDashboard.tsx
+++ b/web/src/components/compliance/GxPDashboard.tsx
@@ -3,7 +3,7 @@ import { UnifiedDashboard } from '../../lib/unified/dashboard/UnifiedDashboard'
 import { gxpDashboardConfig } from '../../config/dashboards/gxp'
 import {
   CheckCircle2, XCircle, AlertTriangle, Loader2,
-  RefreshCw, Lock, FileCheck, Link2, PenTool, Clock, Hash,
+  Lock, FileCheck, Link2, PenTool, Clock, Hash,
 } from 'lucide-react'
 import { authFetch } from '../../lib/api'
 import { DashboardHeader } from '../shared/DashboardHeader'

--- a/web/src/components/compliance/HIPAADashboard.tsx
+++ b/web/src/components/compliance/HIPAADashboard.tsx
@@ -3,7 +3,7 @@ import { UnifiedDashboard } from '../../lib/unified/dashboard/UnifiedDashboard'
 import { hipaaDashboardConfig } from '../../config/dashboards/hipaa'
 import {
   Shield, CheckCircle2, XCircle, AlertTriangle, Loader2,
-  RefreshCw, Activity, Lock, Eye, UserCheck, Network,
+  Activity, Lock, Eye, UserCheck, Network,
   ArrowRight, Server,
 } from 'lucide-react'
 import { authFetch } from '../../lib/api'

--- a/web/src/components/compliance/HIPAADashboard.tsx
+++ b/web/src/components/compliance/HIPAADashboard.tsx
@@ -7,6 +7,8 @@ import {
   ArrowRight, Server,
 } from 'lucide-react'
 import { authFetch } from '../../lib/api'
+import { DashboardHeader } from '../shared/DashboardHeader'
+import { RotatingTip } from '../ui/RotatingTip'
 
 interface HIPAACheck {
   id: string; name: string; description: string; status: string
@@ -45,6 +47,7 @@ const SAFEGUARD_ICONS: Record<string, typeof Shield> = {
 }
 
 export const HIPAADashboardContent = memo(function HIPAADashboardContent() {
+  const [autoRefresh, setAutoRefresh] = useState(true)
   const [safeguards, setSafeguards] = useState<HIPAASafeguard[]>([])
   const [phiNamespaces, setPHINamespaces] = useState<PHINamespace[]>([])
   const [dataFlows, setDataFlows] = useState<DataFlow[]>([])
@@ -102,21 +105,17 @@ export const HIPAADashboardContent = memo(function HIPAADashboardContent() {
 
   return (
     <div className="space-y-6 p-6">
-      {/* Header */}
-      <div className="flex items-center justify-between">
-        <div>
-          <h1 className="text-2xl font-bold text-white flex items-center gap-3">
-            <Shield className="w-7 h-7 text-blue-400" />
-            HIPAA Security Rule Compliance
-          </h1>
-          <p className="text-gray-400 mt-1">
-            Technical safeguards assessment per 45 CFR §164.312
-          </p>
-        </div>
-        <button onClick={fetchData} className="p-2 hover:bg-white/10 rounded-lg transition-colors" title="Refresh">
-          <RefreshCw className="w-5 h-5 text-gray-400" />
-        </button>
-      </div>
+      <DashboardHeader
+        title="HIPAA Security Rule Compliance"
+        subtitle="Technical safeguards assessment per 45 CFR §164.312"
+        icon={<Shield className="w-7 h-7 text-blue-400" />}
+        isFetching={false}
+        onRefresh={fetchData}
+        autoRefresh={autoRefresh}
+        onAutoRefreshChange={setAutoRefresh}
+        autoRefreshId="hipaa-auto-refresh"
+        rightExtra={<RotatingTip page="hipaa" />}
+      />
 
       {/* Summary Cards */}
       {summary && (

--- a/web/src/components/compliance/IncidentResponseDashboard.tsx
+++ b/web/src/components/compliance/IncidentResponseDashboard.tsx
@@ -1,10 +1,12 @@
-import React, { memo } from 'react'
+import React from 'react'
 import { useState, useEffect } from 'react'
 import {
   AlertTriangle, CheckCircle2, Loader2, Clock,
   XCircle, ArrowRight, Play, Shield
 } from 'lucide-react'
 import { authFetch } from '../../lib/api'
+import { DashboardHeader } from '../shared/DashboardHeader'
+import { RotatingTip } from '../ui/RotatingTip'
 
 // ── Types ───────────────────────────────────────────────────────────────
 
@@ -73,7 +75,8 @@ const TREND_COLORS: Record<string, string> = {
   degrading: 'text-red-400',
 }
 
-const IncidentResponseDashboard = memo(function IncidentResponseDashboard() {
+function IncidentResponseDashboard() {
+  const [autoRefresh, setAutoRefresh] = useState(true)
   const [incidents, setIncidents] = useState<Incident[]>([])
   const [metrics, setMetrics] = useState<IncidentMetrics | null>(null)
   const [playbooks, setPlaybooks] = useState<Playbook[]>([])
@@ -117,13 +120,17 @@ const IncidentResponseDashboard = memo(function IncidentResponseDashboard() {
 
   return (
     <div className="space-y-6">
-      <div className="flex items-center gap-3">
-        <AlertTriangle className="w-8 h-8 text-orange-400" />
-        <div>
-          <h1 className="text-2xl font-bold text-white">Incident Response</h1>
-          <p className="text-gray-400">Active incident tracking, playbook management, and MTTR metrics</p>
-        </div>
-      </div>
+      <DashboardHeader
+        title="Incident Response"
+        subtitle="Active incident tracking, playbook management, and MTTR metrics"
+        icon={<AlertTriangle className="w-7 h-7 text-orange-400" />}
+        isFetching={false}
+        onRefresh={() => window.location.reload()}
+        autoRefresh={autoRefresh}
+        onAutoRefreshChange={setAutoRefresh}
+        autoRefreshId="incident-response-auto-refresh"
+        rightExtra={<RotatingTip page="incident-response" />}
+      />
 
       {/* Summary cards */}
       {metrics && (
@@ -311,6 +318,6 @@ const IncidentResponseDashboard = memo(function IncidentResponseDashboard() {
       )}
     </div>
   )
-})
+}
 
 export default IncidentResponseDashboard

--- a/web/src/components/compliance/NISTDashboard.tsx
+++ b/web/src/components/compliance/NISTDashboard.tsx
@@ -6,6 +6,8 @@ import {
   Shield, ArrowRight, Clock
 } from 'lucide-react'
 import { authFetch } from '../../lib/api'
+import { DashboardHeader } from '../shared/DashboardHeader'
+import { RotatingTip } from '../ui/RotatingTip'
 
 interface Control {
   id: string
@@ -66,6 +68,7 @@ const statusLabel = (status: string) => {
 }
 
 export const NISTDashboardContent = memo(function NISTDashboardContent() {
+  const [autoRefresh, setAutoRefresh] = useState(true)
   const [families, setFamilies] = useState<ControlFamily[]>([])
   const [mappings, setMappings] = useState<ControlMapping[]>([])
   const [summary, setSummary] = useState<NISTSummary | null>(null)
@@ -123,13 +126,17 @@ export const NISTDashboardContent = memo(function NISTDashboardContent() {
 
   return (
     <div className="space-y-6">
-      <div className="flex items-center gap-3">
-        <Shield className="w-8 h-8 text-blue-400" />
-        <div>
-          <h1 className="text-2xl font-bold text-white">NIST 800-53 Control Mapping</h1>
-          <p className="text-gray-400">Federal information security controls mapped to Kubernetes infrastructure</p>
-        </div>
-      </div>
+      <DashboardHeader
+        title="NIST 800-53 Control Mapping"
+        subtitle="Federal information security controls mapped to Kubernetes infrastructure"
+        icon={<Shield className="w-7 h-7 text-blue-400" />}
+        isFetching={false}
+        onRefresh={fetchData}
+        autoRefresh={autoRefresh}
+        onAutoRefreshChange={setAutoRefresh}
+        autoRefreshId="nist-auto-refresh"
+        rightExtra={<RotatingTip page="nist" />}
+      />
 
       {/* Summary cards */}
       {summary && (

--- a/web/src/components/compliance/OIDCDashboard.tsx
+++ b/web/src/components/compliance/OIDCDashboard.tsx
@@ -3,7 +3,7 @@ import { UnifiedDashboard } from '../../lib/unified/dashboard/UnifiedDashboard'
 import { oidcDashboardConfig } from '../../config/dashboards/oidc'
 import {
   KeyRound, CheckCircle2, XCircle, AlertTriangle, Loader2,
-  RefreshCw, Users, ShieldCheck, Fingerprint, Clock,
+  Users, ShieldCheck, Fingerprint, Clock,
 } from 'lucide-react'
 import { authFetch } from '../../lib/api'
 import { DashboardHeader } from '../shared/DashboardHeader'

--- a/web/src/components/compliance/OIDCDashboard.tsx
+++ b/web/src/components/compliance/OIDCDashboard.tsx
@@ -6,6 +6,8 @@ import {
   RefreshCw, Users, ShieldCheck, Fingerprint, Clock,
 } from 'lucide-react'
 import { authFetch } from '../../lib/api'
+import { DashboardHeader } from '../shared/DashboardHeader'
+import { RotatingTip } from '../ui/RotatingTip'
 
 interface OIDCProvider {
   id: string; name: string; issuer_url: string; status: string
@@ -33,6 +35,7 @@ const STATUS_STYLES: Record<string, string> = {
 }
 
 export const OIDCDashboardContent = memo(function OIDCDashboardContent() {
+  const [autoRefresh, setAutoRefresh] = useState(true)
   const [providers, setProviders] = useState<OIDCProvider[]>([])
   const [sessions, setSessions] = useState<OIDCSession[]>([])
   const [summary, setSummary] = useState<OIDCSummary | null>(null)
@@ -79,21 +82,17 @@ export const OIDCDashboardContent = memo(function OIDCDashboardContent() {
 
   return (
     <div className="space-y-6 p-6">
-      {/* Header */}
-      <div className="flex items-center justify-between">
-        <div>
-          <h1 className="text-2xl font-bold text-white flex items-center gap-3">
-            <KeyRound className="w-7 h-7 text-blue-400" />
-            OIDC Federation
-          </h1>
-          <p className="text-gray-400 mt-1">
-            Identity provider federation and session management
-          </p>
-        </div>
-        <button onClick={fetchData} className="p-2 hover:bg-white/10 rounded-lg transition-colors" title="Refresh">
-          <RefreshCw className="w-5 h-5 text-gray-400" />
-        </button>
-      </div>
+      <DashboardHeader
+        title="OIDC Federation"
+        subtitle="Identity provider federation and session management"
+        icon={<KeyRound className="w-7 h-7 text-blue-400" />}
+        isFetching={false}
+        onRefresh={fetchData}
+        autoRefresh={autoRefresh}
+        onAutoRefreshChange={setAutoRefresh}
+        autoRefreshId="oidc-auto-refresh"
+        rightExtra={<RotatingTip page="oidc" />}
+      />
 
       {/* Summary Cards */}
       {summary && (

--- a/web/src/components/compliance/RBACAuditDashboard.tsx
+++ b/web/src/components/compliance/RBACAuditDashboard.tsx
@@ -3,7 +3,7 @@ import { UnifiedDashboard } from '../../lib/unified/dashboard/UnifiedDashboard'
 import { rbacAuditDashboardConfig } from '../../config/dashboards/rbac-audit'
 import {
   Lock, CheckCircle2, XCircle, AlertTriangle, Loader2,
-  RefreshCw, ShieldAlert, Users, Server,
+  ShieldAlert, Users, Server,
 } from 'lucide-react'
 import { authFetch } from '../../lib/api'
 import { Select } from '../ui/Select'

--- a/web/src/components/compliance/RBACAuditDashboard.tsx
+++ b/web/src/components/compliance/RBACAuditDashboard.tsx
@@ -7,6 +7,8 @@ import {
 } from 'lucide-react'
 import { authFetch } from '../../lib/api'
 import { Select } from '../ui/Select'
+import { DashboardHeader } from '../shared/DashboardHeader'
+import { RotatingTip } from '../ui/RotatingTip'
 
 interface RBACBinding {
   id: string; name: string; kind: string; subject_kind: string
@@ -43,6 +45,7 @@ const RISK_STYLES: Record<string, string> = {
 }
 
 export const RBACAuditDashboardContent = memo(function RBACAuditDashboardContent() {
+  const [autoRefresh, setAutoRefresh] = useState(true)
   const [bindings, setBindings] = useState<RBACBinding[]>([])
   const [findings, setFindings] = useState<RBACFinding[]>([])
   const [summary, setSummary] = useState<RBACSummary | null>(null)
@@ -102,21 +105,17 @@ export const RBACAuditDashboardContent = memo(function RBACAuditDashboardContent
 
   return (
     <div className="space-y-6 p-6">
-      {/* Header */}
-      <div className="flex items-center justify-between">
-        <div>
-          <h1 className="text-2xl font-bold text-white flex items-center gap-3">
-            <Lock className="w-7 h-7 text-blue-400" />
-            RBAC Audit &amp; Least-Privilege Analysis
-          </h1>
-          <p className="text-gray-400 mt-1">
-            Role binding audit, over-privilege detection, and compliance scoring
-          </p>
-        </div>
-        <button onClick={fetchData} className="p-2 hover:bg-white/10 rounded-lg transition-colors" title="Refresh">
-          <RefreshCw className="w-5 h-5 text-gray-400" />
-        </button>
-      </div>
+      <DashboardHeader
+        title="RBAC Audit &amp; Least-Privilege Analysis"
+        subtitle="Role binding audit, over-privilege detection, and compliance scoring"
+        icon={<Lock className="w-7 h-7 text-blue-400" />}
+        isFetching={false}
+        onRefresh={fetchData}
+        autoRefresh={autoRefresh}
+        onAutoRefreshChange={setAutoRefresh}
+        autoRefreshId="rbac-audit-auto-refresh"
+        rightExtra={<RotatingTip page="rbac-audit" />}
+      />
 
       {/* Summary Cards */}
       {summary && (

--- a/web/src/components/compliance/RiskAppetiteDashboard.tsx
+++ b/web/src/components/compliance/RiskAppetiteDashboard.tsx
@@ -6,6 +6,8 @@ import {
   TrendingUp, ArrowRight,
 } from 'lucide-react'
 import { authFetch } from '../../lib/api'
+import { DashboardHeader } from '../shared/DashboardHeader'
+import { RotatingTip } from '../ui/RotatingTip'
 
 // ── Types ─────────────────────────────────────────────────────────────
 
@@ -63,6 +65,7 @@ const BAR_COLOR = {
 // ── Component ─────────────────────────────────────────────────────────
 
 export const RiskAppetiteDashboardContent = memo(function RiskAppetiteDashboardContent() {
+  const [autoRefresh, setAutoRefresh] = useState(true)
   const [thresholds, setThresholds] = useState<AppetiteThreshold[]>([])
   const [kris, setKRIs] = useState<KRI[]>([])
   const [summary, setSummary] = useState<AppetiteSummary | null>(null)
@@ -108,14 +111,17 @@ export const RiskAppetiteDashboardContent = memo(function RiskAppetiteDashboardC
 
   return (
     <div className="space-y-6">
-      {/* Header */}
-      <div className="flex items-center gap-3">
-        <Gauge className="w-8 h-8 text-orange-400" />
-        <div>
-          <h1 className="text-2xl font-bold text-white">Risk Appetite</h1>
-          <p className="text-gray-400">Risk tolerance monitoring, KRI tracking, and appetite vs exposure analysis</p>
-        </div>
-      </div>
+      <DashboardHeader
+        title="Risk Appetite"
+        subtitle="Risk tolerance monitoring, KRI tracking, and appetite vs exposure analysis"
+        icon={<Gauge className="w-7 h-7 text-orange-400" />}
+        isFetching={false}
+        onRefresh={() => window.location.reload()}
+        autoRefresh={autoRefresh}
+        onAutoRefreshChange={setAutoRefresh}
+        autoRefreshId="risk-appetite-auto-refresh"
+        rightExtra={<RotatingTip page="risk-appetite" />}
+      />
 
       {/* Summary cards */}
       {summary && (

--- a/web/src/components/compliance/RiskMatrixDashboard.tsx
+++ b/web/src/components/compliance/RiskMatrixDashboard.tsx
@@ -6,6 +6,8 @@ import {
   ArrowRight, ChevronDown,
 } from 'lucide-react'
 import { authFetch } from '../../lib/api'
+import { DashboardHeader } from '../shared/DashboardHeader'
+import { RotatingTip } from '../ui/RotatingTip'
 
 // ── Types ─────────────────────────────────────────────────────────────
 
@@ -65,6 +67,7 @@ function severityBadge(score: number) {
 // ── Component ─────────────────────────────────────────────────────────
 
 export const RiskMatrixDashboardContent = memo(function RiskMatrixDashboardContent() {
+  const [autoRefresh, setAutoRefresh] = useState(true)
   const [risks, setRisks] = useState<Risk[]>([])
   const [heatmap, setHeatmap] = useState<HeatmapCell[]>([])
   const [summary, setSummary] = useState<RiskSummary | null>(null)
@@ -128,14 +131,17 @@ export const RiskMatrixDashboardContent = memo(function RiskMatrixDashboardConte
 
   return (
     <div className="space-y-6">
-      {/* Header */}
-      <div className="flex items-center gap-3">
-        <BarChart3 className="w-8 h-8 text-orange-400" />
-        <div>
-          <h1 className="text-2xl font-bold text-white">Risk Matrix</h1>
-          <p className="text-gray-400">Interactive 5×5 risk heat map with likelihood vs impact assessment</p>
-        </div>
-      </div>
+      <DashboardHeader
+        title="Risk Matrix"
+        subtitle="Interactive 5x5 risk heat map with likelihood vs impact assessment"
+        icon={<BarChart3 className="w-7 h-7 text-orange-400" />}
+        isFetching={false}
+        onRefresh={() => window.location.reload()}
+        autoRefresh={autoRefresh}
+        onAutoRefreshChange={setAutoRefresh}
+        autoRefreshId="risk-matrix-auto-refresh"
+        rightExtra={<RotatingTip page="risk-matrix" />}
+      />
 
       {/* Summary cards */}
       {summary && (

--- a/web/src/components/compliance/RiskRegisterDashboard.tsx
+++ b/web/src/components/compliance/RiskRegisterDashboard.tsx
@@ -6,6 +6,8 @@ import {
   ChevronRight, X, Filter,
 } from 'lucide-react'
 import { authFetch } from '../../lib/api'
+import { DashboardHeader } from '../shared/DashboardHeader'
+import { RotatingTip } from '../ui/RotatingTip'
 
 // ── Types ─────────────────────────────────────────────────────────────
 
@@ -76,6 +78,7 @@ function statusColor(status: string): string {
 // ── Component ─────────────────────────────────────────────────────────
 
 export const RiskRegisterDashboardContent = memo(function RiskRegisterDashboardContent() {
+  const [autoRefresh, setAutoRefresh] = useState(true)
   const [risks, setRisks] = useState<Risk[]>([])
   const [categories, setCategories] = useState<CategorySummary[]>([])
   const [summary, setSummary] = useState<RegisterSummary | null>(null)
@@ -131,14 +134,17 @@ export const RiskRegisterDashboardContent = memo(function RiskRegisterDashboardC
 
   return (
     <div className="space-y-6">
-      {/* Header */}
-      <div className="flex items-center gap-3">
-        <ClipboardList className="w-8 h-8 text-orange-400" />
-        <div>
-          <h1 className="text-2xl font-bold text-white">Risk Register</h1>
-          <p className="text-gray-400">Comprehensive risk tracking with mitigation plans and controls</p>
-        </div>
-      </div>
+      <DashboardHeader
+        title="Risk Register"
+        subtitle="Comprehensive risk tracking with mitigation plans and controls"
+        icon={<ClipboardList className="w-7 h-7 text-orange-400" />}
+        isFetching={false}
+        onRefresh={() => window.location.reload()}
+        autoRefresh={autoRefresh}
+        onAutoRefreshChange={setAutoRefresh}
+        autoRefreshId="risk-register-auto-refresh"
+        rightExtra={<RotatingTip page="risk-register" />}
+      />
 
       {/* Summary cards */}
       {summary && (

--- a/web/src/components/compliance/SBOMDashboard.tsx
+++ b/web/src/components/compliance/SBOMDashboard.tsx
@@ -12,6 +12,8 @@ import {
 import { authFetch } from '../../lib/api'
 import { UnifiedDashboard } from '../../lib/unified/dashboard/UnifiedDashboard'
 import { sbomDashboardConfig } from '../../config/dashboards/sbom'
+import { DashboardHeader } from '../shared/DashboardHeader'
+import { RotatingTip } from '../ui/RotatingTip'
 
 // ── Types ───────────────────────────────────────────────────────────────
 
@@ -75,6 +77,7 @@ const STATUS_ICON: Record<string, React.ReactNode> = {
 // ── Content Component ───────────────────────────────────────────────────
 
 export const SBOMDashboardContent = memo(function SBOMDashboardContent() {
+  const [autoRefresh, setAutoRefresh] = useState(true)
   const [packages, setPackages] = useState<SBOMPackage[]>([])
   const [vulnerabilities, setVulnerabilities] = useState<SBOMVulnerability[]>([])
   const [summary, setSummary] = useState<SBOMSummary | null>(null)
@@ -125,14 +128,17 @@ export const SBOMDashboardContent = memo(function SBOMDashboardContent() {
 
   return (
     <div className="space-y-6">
-      {/* Header */}
-      <div className="flex items-center gap-3">
-        <Package className="w-8 h-8 text-blue-400" />
-        <div>
-          <h1 className="text-2xl font-bold text-white">SBOM Manager</h1>
-          <p className="text-gray-400">Software bill of materials, vulnerability tracking, and license compliance</p>
-        </div>
-      </div>
+      <DashboardHeader
+        title="SBOM Manager"
+        subtitle="Software bill of materials, vulnerability tracking, and license compliance"
+        icon={<Package className="w-7 h-7 text-blue-400" />}
+        isFetching={false}
+        onRefresh={() => window.location.reload()}
+        autoRefresh={autoRefresh}
+        onAutoRefreshChange={setAutoRefresh}
+        autoRefreshId="sbom-auto-refresh"
+        rightExtra={<RotatingTip page="sbom" />}
+      />
 
       {/* Summary stats */}
       {summary && (

--- a/web/src/components/compliance/SIEMDashboard.tsx
+++ b/web/src/components/compliance/SIEMDashboard.tsx
@@ -1,10 +1,12 @@
-import React, { memo } from 'react'
+import React from 'react'
 import { useState, useEffect } from 'react'
 import {
   Monitor, CheckCircle2, Loader2,
   ArrowRight, Clock, XCircle
 } from 'lucide-react'
 import { authFetch } from '../../lib/api'
+import { DashboardHeader } from '../shared/DashboardHeader'
+import { RotatingTip } from '../ui/RotatingTip'
 
 // ── Types ───────────────────────────────────────────────────────────────
 
@@ -65,7 +67,8 @@ const STATUS_ICON: Record<string, React.ReactNode> = {
   resolved: <CheckCircle2 className="w-4 h-4 text-green-400" />,
 }
 
-const SIEMDashboard = memo(function SIEMDashboard() {
+function SIEMDashboard() {
+  const [autoRefresh, setAutoRefresh] = useState(true)
   const [events, setEvents] = useState<SIEMEvent[]>([])
   const [alerts, setAlerts] = useState<SIEMAlert[]>([])
   const [summary, setSummary] = useState<SIEMSummary | null>(null)
@@ -109,13 +112,17 @@ const SIEMDashboard = memo(function SIEMDashboard() {
 
   return (
     <div className="space-y-6">
-      <div className="flex items-center gap-3">
-        <Monitor className="w-8 h-8 text-blue-400" />
-        <div>
-          <h1 className="text-2xl font-bold text-white">SIEM Integration</h1>
-          <p className="text-gray-400">Security event monitoring, log aggregation, and alert correlation</p>
-        </div>
-      </div>
+      <DashboardHeader
+        title="SIEM Integration"
+        subtitle="Security event monitoring, log aggregation, and alert correlation"
+        icon={<Monitor className="w-7 h-7 text-blue-400" />}
+        isFetching={false}
+        onRefresh={() => window.location.reload()}
+        autoRefresh={autoRefresh}
+        onAutoRefreshChange={setAutoRefresh}
+        autoRefreshId="siem-auto-refresh"
+        rightExtra={<RotatingTip page="siem" />}
+      />
 
       {/* Summary cards */}
       {summary && (
@@ -279,6 +286,6 @@ const SIEMDashboard = memo(function SIEMDashboard() {
       )}
     </div>
   )
-})
+}
 
 export default SIEMDashboard

--- a/web/src/components/compliance/SLSADashboard.tsx
+++ b/web/src/components/compliance/SLSADashboard.tsx
@@ -4,7 +4,7 @@
  * Build provenance level indicators (L1–L4), attestation verification,
  * source integrity checks, and build reproducibility.
  */
-import { useState, useEffect, memo } from 'react'
+import { useState, useEffect } from 'react'
 import {
   GitCommitHorizontal, CheckCircle2, Loader2, AlertTriangle,
   XCircle, Shield, Lock
@@ -12,6 +12,8 @@ import {
 import { authFetch } from '../../lib/api'
 import { UnifiedDashboard } from '../../lib/unified/dashboard/UnifiedDashboard'
 import { slsaDashboardConfig } from '../../config/dashboards/slsa'
+import { DashboardHeader } from '../shared/DashboardHeader'
+import { RotatingTip } from '../ui/RotatingTip'
 
 // ── Types ───────────────────────────────────────────────────────────────
 
@@ -92,7 +94,8 @@ const STATUS_ICON: Record<string, React.ReactNode> = {
 
 // ── Content Component ───────────────────────────────────────────────────
 
-export const SLSADashboardContent = memo(function SLSADashboardContent() {
+export function SLSADashboardContent() {
+  const [autoRefresh, setAutoRefresh] = useState(true)
   const [attestations, setAttestations] = useState<SLSAAttestation[]>([])
   const [provenance, setProvenance] = useState<SLSAProvenance[]>([])
   const [summary, setSummary] = useState<SLSASummary | null>(null)
@@ -141,14 +144,17 @@ export const SLSADashboardContent = memo(function SLSADashboardContent() {
 
   return (
     <div className="space-y-6">
-      {/* Header */}
-      <div className="flex items-center gap-3">
-        <GitCommitHorizontal className="w-8 h-8 text-emerald-400" />
-        <div>
-          <h1 className="text-2xl font-bold text-white">SLSA Provenance</h1>
-          <p className="text-gray-400">Build provenance levels, attestation verification, and source integrity</p>
-        </div>
-      </div>
+      <DashboardHeader
+        title="SLSA Provenance"
+        subtitle="Build provenance levels, attestation verification, and source integrity"
+        icon={<GitCommitHorizontal className="w-7 h-7 text-emerald-400" />}
+        isFetching={false}
+        onRefresh={() => window.location.reload()}
+        autoRefresh={autoRefresh}
+        onAutoRefreshChange={setAutoRefresh}
+        autoRefreshId="slsa-auto-refresh"
+        rightExtra={<RotatingTip page="slsa" />}
+      />
 
       {/* Summary stats */}
       {summary && (
@@ -318,7 +324,7 @@ export const SLSADashboardContent = memo(function SLSADashboardContent() {
       )}
     </div>
   )
-})
+}
 
 // ── Page Component (rendered by App.tsx route) ──────────────────────────
 

--- a/web/src/components/compliance/STIGDashboard.tsx
+++ b/web/src/components/compliance/STIGDashboard.tsx
@@ -6,6 +6,8 @@ import {
   Shield, ArrowRight, Clock, Search
 } from 'lucide-react'
 import { authFetch } from '../../lib/api'
+import { DashboardHeader } from '../shared/DashboardHeader'
+import { RotatingTip } from '../ui/RotatingTip'
 
 interface Finding {
   id: string
@@ -69,6 +71,7 @@ const statusLabel = (status: string) => {
 }
 
 export const STIGDashboardContent = memo(function STIGDashboardContent() {
+  const [autoRefresh, setAutoRefresh] = useState(true)
   const [findings, setFindings] = useState<Finding[]>([])
   const [benchmarks, setBenchmarks] = useState<Benchmark[]>([])
   const [summary, setSummary] = useState<STIGSummary | null>(null)
@@ -118,13 +121,17 @@ export const STIGDashboardContent = memo(function STIGDashboardContent() {
 
   return (
     <div className="space-y-6">
-      <div className="flex items-center gap-3">
-        <Shield className="w-8 h-8 text-blue-400" />
-        <div>
-          <h1 className="text-2xl font-bold text-white">DISA STIG Compliance</h1>
-          <p className="text-gray-400">Security Technical Implementation Guides for hardened Kubernetes clusters</p>
-        </div>
-      </div>
+      <DashboardHeader
+        title="DISA STIG Compliance"
+        subtitle="Security Technical Implementation Guides for hardened Kubernetes clusters"
+        icon={<Shield className="w-7 h-7 text-blue-400" />}
+        isFetching={false}
+        onRefresh={() => window.location.reload()}
+        autoRefresh={autoRefresh}
+        onAutoRefreshChange={setAutoRefresh}
+        autoRefreshId="stig-auto-refresh"
+        rightExtra={<RotatingTip page="stig" />}
+      />
 
       {/* Summary cards */}
       {summary && (

--- a/web/src/components/compliance/SegregationOfDuties.tsx
+++ b/web/src/components/compliance/SegregationOfDuties.tsx
@@ -7,6 +7,8 @@ import {
 } from 'lucide-react'
 import { authFetch } from '../../lib/api'
 import { Select } from '../ui/Select'
+import { DashboardHeader } from '../shared/DashboardHeader'
+import { RotatingTip } from '../ui/RotatingTip'
 
 interface SoDRule {
   id: string; name: string; description: string; role_a: string; role_b: string
@@ -47,6 +49,7 @@ function scoreColor(score: number): string {
 }
 
 export const SegregationOfDutiesContent = memo(function SegregationOfDutiesContent() {
+  const [autoRefresh, setAutoRefresh] = useState(true)
   const [summary, setSummary] = useState<SoDSummary | null>(null)
   const [rules, setRules] = useState<SoDRule[]>([])
   const [principals, setPrincipals] = useState<Principal[]>([])
@@ -96,16 +99,17 @@ export const SegregationOfDutiesContent = memo(function SegregationOfDutiesConte
 
   return (
     <div className="space-y-6">
-      <div className="flex items-center justify-between">
-        <div className="flex items-center gap-3">
-          <div className="p-2 rounded-lg bg-amber-500/10"><Users className="w-6 h-6 text-amber-400" /></div>
-          <div>
-            <h1 className="text-xl font-semibold text-zinc-100">Segregation of Duties</h1>
-            <p className="text-sm text-zinc-400">Detect conflicting privilege assignments across RBAC roles</p>
-          </div>
-        </div>
-        <button onClick={fetchData} type="button" aria-label="Refresh segregation of duties data" className="text-zinc-400 hover:text-zinc-200 p-2 rounded-lg hover:bg-zinc-700/50 transition-colors"><RefreshCw className="w-4 h-4" /></button>
-      </div>
+      <DashboardHeader
+        title="Segregation of Duties"
+        subtitle="Detect conflicting privilege assignments across RBAC roles"
+        icon={<Users className="w-5 h-5 text-amber-400" />}
+        isFetching={false}
+        onRefresh={fetchData}
+        autoRefresh={autoRefresh}
+        onAutoRefreshChange={setAutoRefresh}
+        autoRefreshId="segregation-of-duties-auto-refresh"
+        rightExtra={<RotatingTip page="segregation-of-duties" />}
+      />
 
       {summary && (
         <div className="grid grid-cols-2 md:grid-cols-5 gap-4">

--- a/web/src/components/compliance/SessionDashboard.tsx
+++ b/web/src/components/compliance/SessionDashboard.tsx
@@ -2,7 +2,7 @@ import { useState, useEffect, memo } from 'react'
 import { UnifiedDashboard } from '../../lib/unified/dashboard/UnifiedDashboard'
 import { sessionManagementDashboardConfig } from '../../config/dashboards/session-management'
 import {
-  Clock, CheckCircle2, XCircle, Loader2, RefreshCw,
+  Clock, CheckCircle2, XCircle, Loader2,
   Users, ShieldCheck, AlertTriangle, Monitor,
 } from 'lucide-react'
 import { authFetch } from '../../lib/api'

--- a/web/src/components/compliance/SessionDashboard.tsx
+++ b/web/src/components/compliance/SessionDashboard.tsx
@@ -6,6 +6,8 @@ import {
   Users, ShieldCheck, AlertTriangle, Monitor,
 } from 'lucide-react'
 import { authFetch } from '../../lib/api'
+import { DashboardHeader } from '../shared/DashboardHeader'
+import { RotatingTip } from '../ui/RotatingTip'
 
 interface ActiveSession {
   id: string; user: string; login_time: string; last_activity: string
@@ -33,6 +35,7 @@ const STATUS_STYLES: Record<string, string> = {
 }
 
 export const SessionDashboardContent = memo(function SessionDashboardContent() {
+  const [autoRefresh, setAutoRefresh] = useState(true)
   const [sessions, setSessions] = useState<ActiveSession[]>([])
   const [policies, setPolicies] = useState<SessionPolicy[]>([])
   const [summary, setSummary] = useState<SessionSummary | null>(null)
@@ -79,21 +82,17 @@ export const SessionDashboardContent = memo(function SessionDashboardContent() {
 
   return (
     <div className="space-y-6 p-6">
-      {/* Header */}
-      <div className="flex items-center justify-between">
-        <div>
-          <h1 className="text-2xl font-bold text-white flex items-center gap-3">
-            <Clock className="w-7 h-7 text-blue-400" />
-            Session Management
-          </h1>
-          <p className="text-gray-400 mt-1">
-            Active session monitoring and policy enforcement
-          </p>
-        </div>
-        <button onClick={fetchData} className="p-2 hover:bg-white/10 rounded-lg transition-colors" title="Refresh">
-          <RefreshCw className="w-5 h-5 text-gray-400" />
-        </button>
-      </div>
+      <DashboardHeader
+        title="Session Management"
+        subtitle="Active session monitoring and policy enforcement"
+        icon={<Clock className="w-7 h-7 text-blue-400" />}
+        isFetching={false}
+        onRefresh={fetchData}
+        autoRefresh={autoRefresh}
+        onAutoRefreshChange={setAutoRefresh}
+        autoRefreshId="session-auto-refresh"
+        rightExtra={<RotatingTip page="session" />}
+      />
 
       {/* Summary Cards */}
       {summary && (

--- a/web/src/components/compliance/SigstoreDashboard.tsx
+++ b/web/src/components/compliance/SigstoreDashboard.tsx
@@ -12,6 +12,8 @@ import {
 import { authFetch } from '../../lib/api'
 import { UnifiedDashboard } from '../../lib/unified/dashboard/UnifiedDashboard'
 import { sigstoreDashboardConfig } from '../../config/dashboards/sigstore'
+import { DashboardHeader } from '../shared/DashboardHeader'
+import { RotatingTip } from '../ui/RotatingTip'
 
 // ── Types ───────────────────────────────────────────────────────────────
 
@@ -82,6 +84,7 @@ const RESULT_ICON: Record<string, React.ReactNode> = {
 // ── Content Component ───────────────────────────────────────────────────
 
 export const SigstoreDashboardContent = memo(function SigstoreDashboardContent() {
+  const [autoRefresh, setAutoRefresh] = useState(true)
   const [signatures, setSignatures] = useState<SigstoreSignature[]>([])
   const [verifications, setVerifications] = useState<SigstoreVerification[]>([])
   const [summary, setSummary] = useState<SigstoreSummary | null>(null)
@@ -127,14 +130,17 @@ export const SigstoreDashboardContent = memo(function SigstoreDashboardContent()
 
   return (
     <div className="space-y-6">
-      {/* Header */}
-      <div className="flex items-center gap-3">
-        <BadgeCheck className="w-8 h-8 text-green-400" />
-        <div>
-          <h1 className="text-2xl font-bold text-white">Sigstore Verification</h1>
-          <p className="text-gray-400">Image signature verification, cosign results, and transparency log</p>
-        </div>
-      </div>
+      <DashboardHeader
+        title="Sigstore Verification"
+        subtitle="Image signature verification, cosign results, and transparency log"
+        icon={<BadgeCheck className="w-7 h-7 text-green-400" />}
+        isFetching={false}
+        onRefresh={() => window.location.reload()}
+        autoRefresh={autoRefresh}
+        onAutoRefreshChange={setAutoRefresh}
+        autoRefreshId="sigstore-auto-refresh"
+        rightExtra={<RotatingTip page="sigstore" />}
+      />
 
       {/* Summary stats */}
       {summary && (

--- a/web/src/components/compliance/ThreatIntelDashboard.tsx
+++ b/web/src/components/compliance/ThreatIntelDashboard.tsx
@@ -1,10 +1,12 @@
-import React, { memo } from 'react'
+import React from 'react'
 import { useState, useEffect } from 'react'
 import {
   Shield, CheckCircle2, Loader2,
   Clock, XCircle, Eye
 } from 'lucide-react'
 import { authFetch } from '../../lib/api'
+import { DashboardHeader } from '../shared/DashboardHeader'
+import { RotatingTip } from '../ui/RotatingTip'
 
 // ── Types ───────────────────────────────────────────────────────────────
 
@@ -96,7 +98,8 @@ function RiskScoreRing({ score, size = 80 }: { score: number; size?: number }) {
   )
 }
 
-const ThreatIntelDashboard = memo(function ThreatIntelDashboard() {
+function ThreatIntelDashboard() {
+  const [autoRefresh, setAutoRefresh] = useState(true)
   const [feeds, setFeeds] = useState<ThreatFeed[]>([])
   const [iocs, setIOCs] = useState<IOCMatch[]>([])
   const [summary, setSummary] = useState<ThreatIntelSummary | null>(null)
@@ -140,13 +143,17 @@ const ThreatIntelDashboard = memo(function ThreatIntelDashboard() {
 
   return (
     <div className="space-y-6">
-      <div className="flex items-center gap-3">
-        <Shield className="w-8 h-8 text-purple-400" />
-        <div>
-          <h1 className="text-2xl font-bold text-white">Threat Intelligence</h1>
-          <p className="text-gray-400">Threat feed monitoring, IOC matching, and vulnerability correlation</p>
-        </div>
-      </div>
+      <DashboardHeader
+        title="Threat Intelligence"
+        subtitle="Threat feed monitoring, IOC matching, and vulnerability correlation"
+        icon={<Shield className="w-7 h-7 text-purple-400" />}
+        isFetching={false}
+        onRefresh={() => window.location.reload()}
+        autoRefresh={autoRefresh}
+        onAutoRefreshChange={setAutoRefresh}
+        autoRefreshId="threat-intel-auto-refresh"
+        rightExtra={<RotatingTip page="threat-intel" />}
+      />
 
       {/* Summary cards */}
       {summary && (
@@ -329,6 +336,6 @@ const ThreatIntelDashboard = memo(function ThreatIntelDashboard() {
       )}
     </div>
   )
-})
+}
 
 export default ThreatIntelDashboard

--- a/web/src/components/enterprise/EnterpriseSidebar.tsx
+++ b/web/src/components/enterprise/EnterpriseSidebar.tsx
@@ -27,7 +27,7 @@ const SIDEBAR_FEATURES = {
   addMore: true,
   clusterStatus: true,
   collapsePin: true,
-  resize: true,
+  resize: false,
   activeUsers: true,
 } as const
 


### PR DESCRIPTION
Fixes #9822
Fixes #9823

## Changes
- Add `DashboardHeader` with Tip/Auto-refresh/refresh controls to all 24 compliance dashboard Content components, matching the Enterprise Portal pattern
- Fix enterprise sidebar width: disable resize so it always uses the default 256px width matching the main sidebar
- Fix `EnterpriseLayout` margin calculation to use `SIDEBAR_DEFAULT_WIDTH_PX` instead of persisted `config.width`

## Files changed (26)
- 24 compliance dashboard components in `web/src/components/compliance/`
- `web/src/components/enterprise/EnterpriseSidebar.tsx` — set `resize: false`
- `web/src/components/enterprise/EnterpriseLayout.tsx` — use default width for margin