### PR TITLE
fix: align enterprise sidebar width with main sidebar default

### DIFF
--- a/web/src/components/enterprise/EnterpriseLayout.tsx
+++ b/web/src/components/enterprise/EnterpriseLayout.tsx
@@ -36,11 +36,13 @@ export default function EnterpriseLayout() {
   const location = useLocation()
   const dashboardContext = useDashboardContextOptional()
 
+  // Enterprise sidebar always uses the standard default width — it does not
+  // inherit the user-resized width from the main console sidebar (#9823).
   const sidebarWidthPx = isMobile
     ? 0
     : config.collapsed
       ? SIDEBAR_COLLAPSED_WIDTH_PX
-      : (config.width ?? SIDEBAR_DEFAULT_WIDTH_PX)
+      : SIDEBAR_DEFAULT_WIDTH_PX
 
   const handleOpenStudio = useCallback(() => {
     dashboardContext?.openAddCardModal()

--- a/web/src/components/enterprise/EnterpriseSidebar.tsx
+++ b/web/src/components/enterprise/EnterpriseSidebar.tsx
@@ -18,6 +18,7 @@ import { SidebarShell } from '../layout/SidebarShell'
 import type { NavSection } from '../layout/SidebarShell'
 import { ENTERPRISE_NAV_SECTIONS } from './enterpriseNav'
 import { useDashboardContextOptional } from '../../hooks/useDashboardContext'
+import { SIDEBAR_DEFAULT_WIDTH_PX } from '../../hooks/useSidebarConfig'
 
 /** Stable features config — created once outside the component */
 const SIDEBAR_FEATURES = {
@@ -69,6 +70,7 @@ export default function EnterpriseSidebar() {
       branding={branding}
       onAddCard={handleAddCard}
       onAddMore={handleAddMore}
+      widthOverride={SIDEBAR_DEFAULT_WIDTH_PX}
     />
   )
 }

--- a/web/src/components/layout/SidebarShell.tsx
+++ b/web/src/components/layout/SidebarShell.tsx
@@ -114,6 +114,12 @@ export interface SidebarShellProps {
   onAddCard?: () => void
   /** Custom children rendered between nav and footer */
   children?: React.ReactNode
+  /**
+   * Override the sidebar width instead of using the shared config width.
+   * Used by portal sidebars (e.g. Enterprise) that should not inherit a
+   * user-resized width from the main console sidebar.
+   */
+  widthOverride?: number
 }
 
 // ---------------------------------------------------------------------------
@@ -166,6 +172,7 @@ export function SidebarShell({
   onAddMore,
   onAddCard,
   children,
+  widthOverride,
 }: SidebarShellProps) {
   const { config, toggleCollapsed, setCollapsed, reorderItems, updateItem, removeItem, closeMobileSidebar, setWidth } = useSidebarConfig()
   const { isMobile } = useMobile()
@@ -235,7 +242,9 @@ export function SidebarShell({
   useEffect(() => () => clearAutoHideTimer(), [clearAutoHideTimer])
 
   const isCollapsed = !isMobile && config.collapsed
-  const sidebarWidth = isCollapsed ? SIDEBAR_COLLAPSED_WIDTH_PX : (config.width ?? SIDEBAR_DEFAULT_WIDTH_PX)
+  const sidebarWidth = isCollapsed
+    ? SIDEBAR_COLLAPSED_WIDTH_PX
+    : (widthOverride ?? config.width ?? SIDEBAR_DEFAULT_WIDTH_PX)
 
   // ---- Resize handle ----
   const [isResizing, setIsResizing] = useState(false)
@@ -243,7 +252,7 @@ export function SidebarShell({
     e.preventDefault()
     setIsResizing(true)
     const startX = e.clientX
-    const startWidth = config.width ?? SIDEBAR_DEFAULT_WIDTH_PX
+    const startWidth = widthOverride ?? config.width ?? SIDEBAR_DEFAULT_WIDTH_PX
 
     const handleMouseMove = (moveEvent: MouseEvent) => {
       const newWidth = Math.min(


### PR DESCRIPTION
## Summary
- The enterprise sidebar was inheriting the user-resized width from the shared `useSidebarConfig()` state, causing it to render at ~370px instead of the standard 256px
- Added a `widthOverride` prop to `SidebarShell` so portal sidebars can opt out of the shared resize width
- Wired `widthOverride={SIDEBAR_DEFAULT_WIDTH_PX}` in `EnterpriseSidebar` and updated `EnterpriseLayout` to use the fixed default width for content margin calculation

## Test plan
- [ ] Navigate to `/enterprise` — sidebar should render at 256px (not 370px)
- [ ] Resize the main console sidebar to a custom width, then navigate to `/enterprise` — enterprise sidebar should still be 256px
- [ ] Verify enterprise sidebar collapse/expand still works correctly
- [ ] Verify enterprise sidebar content cards span the full available width

Fixes #9823