### PR TITLE
fix: add DashboardHeader with Tip/Auto/Pin controls to compliance pages

### DIFF
--- a/web/src/components/compliance/AirGapDashboard.test.tsx
+++ b/web/src/components/compliance/AirGapDashboard.test.tsx
@@ -10,6 +10,10 @@ const mockClusters = [
 ]
 const mockSummary = { total_requirements: 12, ready: 9, not_ready: 1, partial: 2, overall_readiness: 85, evaluated_at: new Date().toISOString() }
 
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key, i18n: { language: 'en', changeLanguage: vi.fn() } }),
+}))
 vi.mock('../../lib/api', () => ({
   authFetch: vi.fn((url: string) => {
     if (url.includes('/requirements')) return Promise.resolve({ ok: true, json: () => Promise.resolve(mockRequirements) })

--- a/web/src/components/compliance/AirGapDashboard.tsx
+++ b/web/src/components/compliance/AirGapDashboard.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useMemo, memo } from 'react'
+import { useState, useEffect, useMemo, useCallback, memo } from 'react'
 import { UnifiedDashboard } from '../../lib/unified/dashboard/UnifiedDashboard'
 import { airgapDashboardConfig } from '../../config/dashboards/airgap'
 import {
@@ -6,6 +6,8 @@ import {
   ArrowRight, WifiOff
 } from 'lucide-react'
 import { authFetch } from '../../lib/api'
+import { DashboardHeader } from '../shared/DashboardHeader'
+import { RotatingTip } from '../ui/RotatingTip'
 
 interface Requirement {
   id: string
@@ -72,27 +74,29 @@ export const AirGapDashboardContent = memo(function AirGapDashboardContent() {
   const [error, setError] = useState<string | null>(null)
   const [activeTab, setActiveTab] = useState<'requirements' | 'clusters' | 'summary'>('requirements')
   const [categoryFilter, setCategoryFilter] = useState<string>('all')
+  const [autoRefresh, setAutoRefresh] = useState(false)
 
-  useEffect(() => {
-    const load = async () => {
-      try {
-        const [rRes, cRes, sRes] = await Promise.all([
-          authFetch('/api/compliance/airgap/requirements'),
-          authFetch('/api/compliance/airgap/clusters'),
-          authFetch('/api/compliance/airgap/summary'),
-        ])
-        if (!rRes.ok || !cRes.ok || !sRes.ok) throw new Error('Failed to fetch air-gap data')
-        setRequirements(await rRes.json())
-        setClusters(await cRes.json())
-        setSummary(await sRes.json())
-      } catch (e) {
-        setError(e instanceof Error ? e.message : 'Unknown error')
-      } finally {
-        setLoading(false)
-      }
+  const fetchData = useCallback(async () => {
+    setLoading(true)
+    setError(null)
+    try {
+      const [rRes, cRes, sRes] = await Promise.all([
+        authFetch('/api/compliance/airgap/requirements'),
+        authFetch('/api/compliance/airgap/clusters'),
+        authFetch('/api/compliance/airgap/summary'),
+      ])
+      if (!rRes.ok || !cRes.ok || !sRes.ok) throw new Error('Failed to fetch air-gap data')
+      setRequirements(await rRes.json())
+      setClusters(await cRes.json())
+      setSummary(await sRes.json())
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Unknown error')
+    } finally {
+      setLoading(false)
     }
-    load()
   }, [])
+
+  useEffect(() => { fetchData() }, [fetchData])
 
   const filteredRequirements = useMemo(() => {
     if (categoryFilter === 'all') return requirements
@@ -114,13 +118,16 @@ export const AirGapDashboardContent = memo(function AirGapDashboardContent() {
 
   return (
     <div className="space-y-6">
-      <div className="flex items-center gap-3">
-        <WifiOff className="w-8 h-8 text-blue-400" />
-        <div>
-          <h1 className="text-2xl font-bold text-white">Air-Gap Readiness</h1>
-          <p className="text-gray-400">Disconnected environment readiness assessment for Kubernetes clusters</p>
-        </div>
-      </div>
+      <DashboardHeader
+        title="Air-Gap Readiness"
+        subtitle="Disconnected environment readiness assessment for Kubernetes clusters"
+        isFetching={loading}
+        onRefresh={fetchData}
+        autoRefresh={autoRefresh}
+        onAutoRefreshChange={setAutoRefresh}
+        autoRefreshId="airgap-auto-refresh"
+        rightExtra={<RotatingTip page="compliance" />}
+      />
 
       {/* Summary cards */}
       {summary && (

--- a/web/src/components/compliance/BAADashboard.test.tsx
+++ b/web/src/components/compliance/BAADashboard.test.tsx
@@ -10,6 +10,10 @@ const mockSummary = {
   active_alerts: 2, evaluated_at: '2026-04-23T10:00:00Z',
 }
 
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key, i18n: { language: 'en', changeLanguage: vi.fn() } }),
+}))
 vi.mock('../../lib/api', () => ({
   authFetch: vi.fn((url: string) => {
     if (url.includes('/agreements')) return ok([

--- a/web/src/components/compliance/BAADashboard.tsx
+++ b/web/src/components/compliance/BAADashboard.tsx
@@ -6,6 +6,8 @@ import {
   RefreshCw, Clock, Building2, Cloud, Server, Mail,
 } from 'lucide-react'
 import { authFetch } from '../../lib/api'
+import { DashboardHeader } from '../shared/DashboardHeader'
+import { RotatingTip } from '../ui/RotatingTip'
 
 interface BAAgreement {
   id: string; provider: string; provider_type: string
@@ -41,6 +43,7 @@ export const BAADashboardContent = memo(function BAADashboardContent() {
   const [error, setError] = useState<string | null>(null)
   const [activeTab, setActiveTab] = useState<'agreements' | 'alerts'>('agreements')
   const [statusFilter, setStatusFilter] = useState<string>('all')
+  const [autoRefresh, setAutoRefresh] = useState(false)
 
   const fetchData = async () => {
     setLoading(true)
@@ -86,21 +89,16 @@ export const BAADashboardContent = memo(function BAADashboardContent() {
 
   return (
     <div className="space-y-6 p-6">
-      {/* Header */}
-      <div className="flex items-center justify-between">
-        <div>
-          <h1 className="text-2xl font-bold text-white flex items-center gap-3">
-            <FileText className="w-7 h-7 text-blue-400" />
-            Business Associate Agreements
-          </h1>
-          <p className="text-gray-400 mt-1">
-            HIPAA BAA tracking across cloud providers and vendors
-          </p>
-        </div>
-        <button onClick={fetchData} className="p-2 hover:bg-white/10 rounded-lg transition-colors" title="Refresh">
-          <RefreshCw className="w-5 h-5 text-gray-400" />
-        </button>
-      </div>
+      <DashboardHeader
+        title="Business Associate Agreements"
+        subtitle="HIPAA BAA tracking across cloud providers and vendors"
+        isFetching={loading}
+        onRefresh={fetchData}
+        autoRefresh={autoRefresh}
+        onAutoRefreshChange={setAutoRefresh}
+        autoRefreshId="baa-auto-refresh"
+        rightExtra={<RotatingTip page="compliance" />}
+      />
 
       {/* Summary Cards */}
       {summary && (

--- a/web/src/components/compliance/ChangeControlAudit.test.tsx
+++ b/web/src/components/compliance/ChangeControlAudit.test.tsx
@@ -2,6 +2,10 @@ import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render, screen, waitFor } from '@testing-library/react'
 import { ChangeControlAuditContent as ChangeControlAudit } from './ChangeControlAudit'
 
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key, i18n: { language: 'en', changeLanguage: vi.fn() } }),
+}))
+
 const mockSummary = {
   total_changes: 8, approved_changes: 4, unapproved_changes: 3, emergency_changes: 1,
   policy_violations: 5, risk_score: 55,

--- a/web/src/components/compliance/ChangeControlAudit.tsx
+++ b/web/src/components/compliance/ChangeControlAudit.tsx
@@ -6,6 +6,8 @@ import {
   Clock, GitCommit, Loader2, RefreshCw, Filter, User, FileText,
 } from 'lucide-react'
 import { authFetch } from '../../lib/api'
+import { DashboardHeader } from '../shared/DashboardHeader'
+import { RotatingTip } from '../ui/RotatingTip'
 import { Select } from '../ui/Select'
 
 interface ChangeRecord {
@@ -68,6 +70,7 @@ export const ChangeControlAuditContent = memo(function ChangeControlAuditContent
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
   const [filterApproval, setFilterApproval] = useState('all')
+  const [autoRefresh, setAutoRefresh] = useState(false)
   const [activeTab, setActiveTab] = useState<'changes' | 'violations' | 'policies'>('changes')
 
   const fetchData = async () => {
@@ -114,16 +117,16 @@ export const ChangeControlAuditContent = memo(function ChangeControlAuditContent
 
   return (
     <div className="space-y-6">
-      <div className="flex items-center justify-between">
-        <div className="flex items-center gap-3">
-          <div className="p-2 rounded-lg bg-violet-500/10"><ClipboardCheck className="w-6 h-6 text-violet-400" /></div>
-          <div>
-            <h1 className="text-xl font-semibold text-zinc-100">Change Control Audit Trail</h1>
-            <p className="text-sm text-zinc-400">SOX/PCI-compliant change tracking with approval workflows</p>
-          </div>
-        </div>
-        <button onClick={fetchData} type="button" aria-label="Refresh change control data" className="text-zinc-400 hover:text-zinc-200 p-2 rounded-lg hover:bg-zinc-700/50 transition-colors"><RefreshCw className="w-4 h-4" /></button>
-      </div>
+      <DashboardHeader
+        title="Change Control Audit Trail"
+        subtitle="SOX/PCI-compliant change tracking with approval workflows"
+        isFetching={loading}
+        onRefresh={fetchData}
+        autoRefresh={autoRefresh}
+        onAutoRefreshChange={setAutoRefresh}
+        autoRefreshId="change-control-auto-refresh"
+        rightExtra={<RotatingTip page="compliance" />}
+      />
 
       {summary && (
         <div className="grid grid-cols-2 md:grid-cols-5 gap-4">

--- a/web/src/components/compliance/ComplianceFrameworks.test.tsx
+++ b/web/src/components/compliance/ComplianceFrameworks.test.tsx
@@ -25,6 +25,10 @@ let mockEvalReturn = {
   evaluate: mockEvaluate,
 }
 
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key, i18n: { language: 'en', changeLanguage: vi.fn() } }),
+}))
 vi.mock('../../hooks/useComplianceFrameworks', () => ({
   useComplianceFrameworks: () => mockFrameworksReturn,
   useFrameworkEvaluation: () => mockEvalReturn,

--- a/web/src/components/compliance/ComplianceFrameworks.tsx
+++ b/web/src/components/compliance/ComplianceFrameworks.tsx
@@ -20,6 +20,8 @@ import { UnifiedDashboard } from '../../lib/unified/dashboard/UnifiedDashboard'
 import { complianceFrameworksDashboardConfig } from '../../config/dashboards/compliance-frameworks'
 import { useComplianceFrameworks, useFrameworkEvaluation, type Framework, type ControlResult, type ComplianceCheck } from '../../hooks/useComplianceFrameworks'
 import { clusterCache, subscribeClusterData } from '../../hooks/mcp/shared'
+import { DashboardHeader } from '../shared/DashboardHeader'
+import { RotatingTip } from '../ui/RotatingTip'
 
 /* ────────── status badge helpers ────────── */
 
@@ -202,6 +204,7 @@ export const ComplianceFrameworksContent = memo(function ComplianceFrameworksCon
 
   const [selectedFwId, setSelectedFwId] = useState<string | null>(null)
   const [selectedCluster, setSelectedCluster] = useState<string>('')
+  const [autoRefresh, setAutoRefresh] = useState(false)
 
   // Stable ID of the first framework — avoids re-running the effect when the
   // frameworks array gets a new reference but its contents haven't changed.
@@ -259,26 +262,16 @@ export const ComplianceFrameworksContent = memo(function ComplianceFrameworksCon
 
   return (
     <div className="p-6 space-y-6 max-w-7xl mx-auto">
-      {/* Header */}
-      <div className="flex items-center justify-between">
-        <div>
-          <h1 className="text-xl font-bold text-white flex items-center gap-2">
-            <Shield className="w-5 h-5 text-blue-400" />
-            Compliance Frameworks
-          </h1>
-          <p className="text-sm text-zinc-400 mt-0.5">
-            Evaluate clusters against PCI-DSS 4.0, SOC 2 Type II, and other regulatory standards
-          </p>
-        </div>
-        <button
-          onClick={refetch}
-          className="p-2 rounded-md border border-zinc-700 text-zinc-400 hover:text-zinc-200 hover:border-zinc-600 transition-colors"
-          title="Refresh frameworks"
-          type="button"
-        >
-          <RefreshCw className="w-4 h-4" />
-        </button>
-      </div>
+      <DashboardHeader
+        title="Compliance Frameworks"
+        subtitle="Evaluate clusters against PCI-DSS 4.0, SOC 2 Type II, and other regulatory standards"
+        isFetching={fwLoading}
+        onRefresh={refetch}
+        autoRefresh={autoRefresh}
+        onAutoRefreshChange={setAutoRefresh}
+        autoRefreshId="frameworks-auto-refresh"
+        rightExtra={<RotatingTip page="compliance" />}
+      />
 
       {/* Framework picker */}
       <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">

--- a/web/src/components/compliance/ComplianceReports.test.tsx
+++ b/web/src/components/compliance/ComplianceReports.test.tsx
@@ -3,6 +3,10 @@ import { render, screen } from '@testing-library/react'
 import { MemoryRouter } from 'react-router-dom'
 
 // Mock hooks before importing the component
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key, i18n: { language: 'en', changeLanguage: vi.fn() } }),
+}))
 vi.mock('../../lib/unified/dashboard/UnifiedDashboard', () => ({
   UnifiedDashboard: () => null,
 }))

--- a/web/src/components/compliance/ComplianceReports.tsx
+++ b/web/src/components/compliance/ComplianceReports.tsx
@@ -4,7 +4,7 @@
  * Lets users pick a framework and cluster, choose PDF or JSON format,
  * and download a timestamped compliance report.
  */
-import { useState, useEffect, useMemo, memo } from 'react'
+import { useState, useEffect, useMemo, useCallback, memo } from 'react'
 import { UnifiedDashboard } from '../../lib/unified/dashboard/UnifiedDashboard'
 import { complianceReportsDashboardConfig } from '../../config/dashboards/compliance-reports'
 import { FileText, Download, Shield, Loader2 } from 'lucide-react'
@@ -12,11 +12,13 @@ import { useComplianceFrameworks, type Framework } from '../../hooks/useComplian
 import { useClusters } from '../../hooks/useMCP'
 import { authFetch } from '../../lib/api'
 import { Select } from '../ui/Select'
+import { DashboardHeader } from '../shared/DashboardHeader'
+import { RotatingTip } from '../ui/RotatingTip'
 
 type ReportFormat = 'pdf' | 'json'
 
 export const ComplianceReportsContent = memo(function ComplianceReportsContent() {
-  const { frameworks, isLoading: fwLoading } = useComplianceFrameworks()
+  const { frameworks, isLoading: fwLoading, refetch } = useComplianceFrameworks()
   const { clusters } = useClusters()
   const clusterNames = useMemo(() => clusters?.map((c: { name: string }) => c.name) ?? [], [clusters])
 
@@ -26,6 +28,7 @@ export const ComplianceReportsContent = memo(function ComplianceReportsContent()
   const [generating, setGenerating] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const [success, setSuccess] = useState<string | null>(null)
+  const [autoRefresh, setAutoRefresh] = useState(false)
 
   // Auto-select first framework and cluster when data loads
   useEffect(() => {
@@ -86,16 +89,16 @@ export const ComplianceReportsContent = memo(function ComplianceReportsContent()
 
   return (
     <div className="space-y-6">
-      {/* Header */}
-      <div className="flex items-center gap-3">
-        <div className="p-2 rounded-lg bg-indigo-500/10">
-          <FileText className="w-6 h-6 text-indigo-400" />
-        </div>
-        <div>
-          <h1 className="text-xl font-semibold text-zinc-100">Compliance Reports</h1>
-          <p className="text-sm text-zinc-400">Generate audit-ready compliance reports in PDF or JSON format</p>
-        </div>
-      </div>
+      <DashboardHeader
+        title="Compliance Reports"
+        subtitle="Generate audit-ready compliance reports in PDF or JSON format"
+        isFetching={fwLoading}
+        onRefresh={refetch}
+        autoRefresh={autoRefresh}
+        onAutoRefreshChange={setAutoRefresh}
+        autoRefreshId="reports-auto-refresh"
+        rightExtra={<RotatingTip page="compliance" />}
+      />
 
       {/* Generator Card */}
       <div className="rounded-xl border border-zinc-700/50 bg-zinc-800/50 p-6 space-y-5">

--- a/web/src/components/compliance/DataResidency.test.tsx
+++ b/web/src/components/compliance/DataResidency.test.tsx
@@ -2,6 +2,10 @@ import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render, screen, waitFor } from '@testing-library/react'
 import { DataResidencyContent as DataResidency } from './DataResidency'
 
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key, i18n: { language: 'en', changeLanguage: vi.fn() } }),
+}))
+
 /* ─── Mock data ─── */
 
 const mockSummary = {

--- a/web/src/components/compliance/DataResidency.tsx
+++ b/web/src/components/compliance/DataResidency.tsx
@@ -9,6 +9,8 @@ import { UnifiedDashboard } from '../../lib/unified/dashboard/UnifiedDashboard'
 import { dataResidencyDashboardConfig } from '../../config/dashboards/data-residency'
 import { Globe, ShieldAlert, MapPin, CheckCircle2, XCircle, AlertTriangle, Loader2, RefreshCw } from 'lucide-react'
 import { authFetch } from '../../lib/api'
+import { DashboardHeader } from '../shared/DashboardHeader'
+import { RotatingTip } from '../ui/RotatingTip'
 import { Select } from '../ui/Select'
 
 /* ─── Types ─── */
@@ -88,6 +90,7 @@ export const DataResidencyContent = memo(function DataResidencyContent() {
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
   const [filterSeverity, setFilterSeverity] = useState<string>('all')
+  const [autoRefresh, setAutoRefresh] = useState(false)
 
   const fetchData = useCallback(async () => {
     setLoading(true)
@@ -152,21 +155,16 @@ export const DataResidencyContent = memo(function DataResidencyContent() {
 
   return (
     <div className="space-y-6">
-      {/* Header */}
-      <div className="flex items-center justify-between">
-        <div className="flex items-center gap-3">
-          <div className="p-2 rounded-lg bg-emerald-500/10">
-            <Globe className="w-6 h-6 text-emerald-400" />
-          </div>
-          <div>
-            <h1 className="text-xl font-semibold text-zinc-100">Data Residency Enforcement</h1>
-            <p className="text-sm text-zinc-400">Ensure workloads with sensitive data only run in approved geographic regions</p>
-          </div>
-        </div>
-        <button onClick={fetchData} className="text-zinc-400 hover:text-zinc-200 p-2 rounded-lg hover:bg-zinc-700/50 transition-colors">
-          <RefreshCw className="w-4 h-4" />
-        </button>
-      </div>
+      <DashboardHeader
+        title="Data Residency Enforcement"
+        subtitle="Ensure workloads with sensitive data only run in approved geographic regions"
+        isFetching={loading}
+        onRefresh={fetchData}
+        autoRefresh={autoRefresh}
+        onAutoRefreshChange={setAutoRefresh}
+        autoRefreshId="data-residency-auto-refresh"
+        rightExtra={<RotatingTip page="compliance" />}
+      />
 
       {/* Summary Cards */}
       {summary && (

--- a/web/src/components/compliance/FedRAMPDashboard.test.tsx
+++ b/web/src/components/compliance/FedRAMPDashboard.test.tsx
@@ -10,6 +10,10 @@ const mockPOAMs = [
 ]
 const mockScore = { overall_score: 71, authorization_status: 'in_process', impact_level: 'moderate', controls_satisfied: 142, controls_partially_satisfied: 38, controls_planned: 20, controls_total: 200, poams_open: 12, poams_closed: 8, evaluated_at: new Date().toISOString() }
 
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key, i18n: { language: 'en', changeLanguage: vi.fn() } }),
+}))
 vi.mock('../../lib/api', () => ({
   authFetch: vi.fn((url: string) => {
     if (url.includes('/controls')) return Promise.resolve({ ok: true, json: () => Promise.resolve(mockControls) })

--- a/web/src/components/compliance/FedRAMPDashboard.tsx
+++ b/web/src/components/compliance/FedRAMPDashboard.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useMemo, memo } from 'react'
+import { useState, useEffect, useMemo, memo, useCallback } from 'react'
 import { UnifiedDashboard } from '../../lib/unified/dashboard/UnifiedDashboard'
 import { fedrampDashboardConfig } from '../../config/dashboards/fedramp'
 import {
@@ -6,6 +6,8 @@ import {
   Shield, ArrowRight, Clock
 } from 'lucide-react'
 import { authFetch } from '../../lib/api'
+import { DashboardHeader } from '../shared/DashboardHeader'
+import { RotatingTip } from '../ui/RotatingTip'
 
 interface Control {
   id: string
@@ -85,27 +87,29 @@ export const FedRAMPDashboardContent = memo(function FedRAMPDashboardContent() {
   const [error, setError] = useState<string | null>(null)
   const [activeTab, setActiveTab] = useState<'controls' | 'poams' | 'readiness'>('controls')
   const [statusFilter, setStatusFilter] = useState<string>('all')
+  const [autoRefresh, setAutoRefresh] = useState(false)
 
-  useEffect(() => {
-    const load = async () => {
-      try {
-        const [cRes, pRes, sRes] = await Promise.all([
-          authFetch('/api/compliance/fedramp/controls'),
-          authFetch('/api/compliance/fedramp/poams'),
-          authFetch('/api/compliance/fedramp/score'),
-        ])
-        if (!cRes.ok || !pRes.ok || !sRes.ok) throw new Error('Failed to fetch FedRAMP data')
-        setControls(await cRes.json())
-        setPOAMs(await pRes.json())
-        setScore(await sRes.json())
-      } catch (e) {
-        setError(e instanceof Error ? e.message : 'Unknown error')
-      } finally {
-        setLoading(false)
-      }
+  const fetchData = useCallback(async () => {
+    setLoading(true)
+    setError(null)
+    try {
+      const [cRes, pRes, sRes] = await Promise.all([
+        authFetch('/api/compliance/fedramp/controls'),
+        authFetch('/api/compliance/fedramp/poams'),
+        authFetch('/api/compliance/fedramp/score'),
+      ])
+      if (!cRes.ok || !pRes.ok || !sRes.ok) throw new Error('Failed to fetch FedRAMP data')
+      setControls(await cRes.json())
+      setPOAMs(await pRes.json())
+      setScore(await sRes.json())
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Unknown error')
+    } finally {
+      setLoading(false)
     }
-    load()
   }, [])
+
+  useEffect(() => { fetchData() }, [fetchData])
 
   const filteredControls = useMemo(() => {
     if (statusFilter === 'all') return controls
@@ -127,13 +131,16 @@ export const FedRAMPDashboardContent = memo(function FedRAMPDashboardContent() {
 
   return (
     <div className="space-y-6">
-      <div className="flex items-center gap-3">
-        <Shield className="w-8 h-8 text-blue-400" />
-        <div>
-          <h1 className="text-2xl font-bold text-white">FedRAMP Readiness</h1>
-          <p className="text-gray-400">Federal Risk and Authorization Management Program compliance assessment</p>
-        </div>
-      </div>
+      <DashboardHeader
+        title="FedRAMP Readiness"
+        subtitle="Federal Risk and Authorization Management Program compliance assessment"
+        isFetching={loading}
+        onRefresh={fetchData}
+        autoRefresh={autoRefresh}
+        onAutoRefreshChange={setAutoRefresh}
+        autoRefreshId="fedramp-auto-refresh"
+        rightExtra={<RotatingTip page="compliance" />}
+      />
 
       {/* Summary cards */}
       {score && (

--- a/web/src/components/compliance/GxPDashboard.test.tsx
+++ b/web/src/components/compliance/GxPDashboard.test.tsx
@@ -18,6 +18,10 @@ const mockSignatures = [
 ]
 const mockChain = { valid: true, total_records: 8, verified_records: 8, broken_at_index: -1, verified_at: '2026-04-23T10:00:00Z', message: 'Hash chain intact' }
 
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key, i18n: { language: 'en', changeLanguage: vi.fn() } }),
+}))
 vi.mock('../../lib/api', () => ({
   authFetch: vi.fn((url: string) => {
     if (url.includes('/summary')) return ok(mockSummary)

--- a/web/src/components/compliance/GxPDashboard.tsx
+++ b/web/src/components/compliance/GxPDashboard.tsx
@@ -6,6 +6,8 @@ import {
   RefreshCw, Lock, FileCheck, Link2, PenTool, Clock, Hash,
 } from 'lucide-react'
 import { authFetch } from '../../lib/api'
+import { DashboardHeader } from '../shared/DashboardHeader'
+import { RotatingTip } from '../ui/RotatingTip'
 
 interface AuditRecord {
   id: string; timestamp: string; user_id: string; action: string
@@ -49,6 +51,7 @@ export const GxPDashboardContent = memo(function GxPDashboardContent() {
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
   const [activeTab, setActiveTab] = useState<'overview' | 'audit' | 'signatures'>('overview')
+  const [autoRefresh, setAutoRefresh] = useState(false)
 
   const fetchData = async () => {
     setLoading(true)
@@ -101,21 +104,16 @@ export const GxPDashboardContent = memo(function GxPDashboardContent() {
 
   return (
     <div className="space-y-6 p-6">
-      {/* Header */}
-      <div className="flex items-center justify-between">
-        <div>
-          <h1 className="text-2xl font-bold text-white flex items-center gap-3">
-            <FileCheck className="w-7 h-7 text-green-400" />
-            GxP Validation Mode
-          </h1>
-          <p className="text-gray-400 mt-1">
-            21 CFR Part 11 — Electronic records and signatures
-          </p>
-        </div>
-        <button onClick={fetchData} className="p-2 hover:bg-white/10 rounded-lg transition-colors" title="Refresh">
-          <RefreshCw className="w-5 h-5 text-gray-400" />
-        </button>
-      </div>
+      <DashboardHeader
+        title="GxP Validation Mode"
+        subtitle="21 CFR Part 11 — Electronic records and signatures"
+        isFetching={loading}
+        onRefresh={fetchData}
+        autoRefresh={autoRefresh}
+        onAutoRefreshChange={setAutoRefresh}
+        autoRefreshId="gxp-auto-refresh"
+        rightExtra={<RotatingTip page="compliance" />}
+      />
 
       {/* Summary Cards */}
       {summary && (

--- a/web/src/components/compliance/HIPAADashboard.test.tsx
+++ b/web/src/components/compliance/HIPAADashboard.test.tsx
@@ -19,6 +19,10 @@ const mockSummary = {
   evaluated_at: '2026-04-23T10:00:00Z',
 }
 
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key, i18n: { language: 'en', changeLanguage: vi.fn() } }),
+}))
 vi.mock('../../lib/api', () => ({
   authFetch: vi.fn((url: string) => {
     const ok = (data: unknown) => Promise.resolve({ ok: true, json: () => Promise.resolve(data) })

--- a/web/src/components/compliance/HIPAADashboard.tsx
+++ b/web/src/components/compliance/HIPAADashboard.tsx
@@ -7,6 +7,8 @@ import {
   ArrowRight, Server,
 } from 'lucide-react'
 import { authFetch } from '../../lib/api'
+import { DashboardHeader } from '../shared/DashboardHeader'
+import { RotatingTip } from '../ui/RotatingTip'
 
 interface HIPAACheck {
   id: string; name: string; description: string; status: string
@@ -53,6 +55,7 @@ export const HIPAADashboardContent = memo(function HIPAADashboardContent() {
   const [error, setError] = useState<string | null>(null)
   const [expandedSafeguard, setExpandedSafeguard] = useState<string | null>(null)
   const [activeTab, setActiveTab] = useState<'safeguards' | 'phi' | 'flows'>('safeguards')
+  const [autoRefresh, setAutoRefresh] = useState(false)
 
   const fetchData = async () => {
     setLoading(true)
@@ -102,21 +105,16 @@ export const HIPAADashboardContent = memo(function HIPAADashboardContent() {
 
   return (
     <div className="space-y-6 p-6">
-      {/* Header */}
-      <div className="flex items-center justify-between">
-        <div>
-          <h1 className="text-2xl font-bold text-white flex items-center gap-3">
-            <Shield className="w-7 h-7 text-blue-400" />
-            HIPAA Security Rule Compliance
-          </h1>
-          <p className="text-gray-400 mt-1">
-            Technical safeguards assessment per 45 CFR §164.312
-          </p>
-        </div>
-        <button onClick={fetchData} className="p-2 hover:bg-white/10 rounded-lg transition-colors" title="Refresh">
-          <RefreshCw className="w-5 h-5 text-gray-400" />
-        </button>
-      </div>
+      <DashboardHeader
+        title="HIPAA Security Rule Compliance"
+        subtitle="Technical safeguards assessment per 45 CFR §164.312"
+        isFetching={loading}
+        onRefresh={fetchData}
+        autoRefresh={autoRefresh}
+        onAutoRefreshChange={setAutoRefresh}
+        autoRefreshId="hipaa-auto-refresh"
+        rightExtra={<RotatingTip page="compliance" />}
+      />
 
       {/* Summary Cards */}
       {summary && (

--- a/web/src/components/compliance/IncidentResponseDashboard.tsx
+++ b/web/src/components/compliance/IncidentResponseDashboard.tsx
@@ -1,10 +1,12 @@
 import React, { memo } from 'react'
-import { useState, useEffect } from 'react'
+import { useState, useEffect, useCallback } from 'react'
 import {
   AlertTriangle, CheckCircle2, Loader2, Clock,
   XCircle, ArrowRight, Play, Shield
 } from 'lucide-react'
 import { authFetch } from '../../lib/api'
+import { DashboardHeader } from '../shared/DashboardHeader'
+import { RotatingTip } from '../ui/RotatingTip'
 
 // ── Types ───────────────────────────────────────────────────────────────
 
@@ -80,27 +82,29 @@ const IncidentResponseDashboard = memo(function IncidentResponseDashboard() {
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
   const [activeTab, setActiveTab] = useState<'incidents' | 'playbooks' | 'metrics'>('incidents')
+  const [autoRefresh, setAutoRefresh] = useState(false)
 
-  useEffect(() => {
-    const load = async () => {
-      try {
-        const [iRes, mRes, pRes] = await Promise.all([
-          authFetch('/api/v1/compliance/incidents'),
-          authFetch('/api/v1/compliance/incidents/metrics'),
-          authFetch('/api/v1/compliance/incidents/playbooks'),
-        ])
-        if (!iRes.ok || !mRes.ok || !pRes.ok) throw new Error('Failed to fetch incident data')
-        setIncidents(await iRes.json())
-        setMetrics(await mRes.json())
-        setPlaybooks(await pRes.json())
-      } catch (e) {
-        setError(e instanceof Error ? e.message : 'Unknown error')
-      } finally {
-        setLoading(false)
-      }
+  const fetchData = useCallback(async () => {
+    setLoading(true)
+    setError(null)
+    try {
+      const [iRes, mRes, pRes] = await Promise.all([
+        authFetch('/api/v1/compliance/incidents'),
+        authFetch('/api/v1/compliance/incidents/metrics'),
+        authFetch('/api/v1/compliance/incidents/playbooks'),
+      ])
+      if (!iRes.ok || !mRes.ok || !pRes.ok) throw new Error('Failed to fetch incident data')
+      setIncidents(await iRes.json())
+      setMetrics(await mRes.json())
+      setPlaybooks(await pRes.json())
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Unknown error')
+    } finally {
+      setLoading(false)
     }
-    load()
   }, [])
+
+  useEffect(() => { fetchData() }, [fetchData])
 
   if (loading) return (
     <div className="flex items-center justify-center h-64">
@@ -117,13 +121,16 @@ const IncidentResponseDashboard = memo(function IncidentResponseDashboard() {
 
   return (
     <div className="space-y-6">
-      <div className="flex items-center gap-3">
-        <AlertTriangle className="w-8 h-8 text-orange-400" />
-        <div>
-          <h1 className="text-2xl font-bold text-white">Incident Response</h1>
-          <p className="text-gray-400">Active incident tracking, playbook management, and MTTR metrics</p>
-        </div>
-      </div>
+      <DashboardHeader
+        title="Incident Response"
+        subtitle="Security incident tracking, response timelines, and playbook execution"
+        isFetching={loading}
+        onRefresh={fetchData}
+        autoRefresh={autoRefresh}
+        onAutoRefreshChange={setAutoRefresh}
+        autoRefreshId="incident-auto-refresh"
+        rightExtra={<RotatingTip page="compliance" />}
+      />
 
       {/* Summary cards */}
       {metrics && (

--- a/web/src/components/compliance/NISTDashboard.test.tsx
+++ b/web/src/components/compliance/NISTDashboard.test.tsx
@@ -12,6 +12,10 @@ const mockMappings = [
 ]
 const mockSummary = { total_controls: 19, implemented_controls: 13, partial_controls: 4, planned_controls: 1, not_applicable: 1, overall_score: 83, baseline: 'moderate', evaluated_at: new Date().toISOString() }
 
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key, i18n: { language: 'en', changeLanguage: vi.fn() } }),
+}))
 vi.mock('../../lib/api', () => ({
   authFetch: vi.fn((url: string) => {
     if (url.includes('/families')) return Promise.resolve({ ok: true, json: () => Promise.resolve(mockFamilies) })

--- a/web/src/components/compliance/NISTDashboard.tsx
+++ b/web/src/components/compliance/NISTDashboard.tsx
@@ -6,6 +6,8 @@ import {
   Shield, ArrowRight, Clock
 } from 'lucide-react'
 import { authFetch } from '../../lib/api'
+import { DashboardHeader } from '../shared/DashboardHeader'
+import { RotatingTip } from '../ui/RotatingTip'
 
 interface Control {
   id: string
@@ -73,6 +75,7 @@ export const NISTDashboardContent = memo(function NISTDashboardContent() {
   const [error, setError] = useState<string | null>(null)
   const [activeTab, setActiveTab] = useState<'families' | 'mappings' | 'summary'>('families')
   const [familyFilter, setFamilyFilter] = useState<string>('all')
+  const [autoRefresh, setAutoRefresh] = useState(false)
 
   const fetchData = useCallback(async () => {
     setLoading(true)
@@ -123,13 +126,16 @@ export const NISTDashboardContent = memo(function NISTDashboardContent() {
 
   return (
     <div className="space-y-6">
-      <div className="flex items-center gap-3">
-        <Shield className="w-8 h-8 text-blue-400" />
-        <div>
-          <h1 className="text-2xl font-bold text-white">NIST 800-53 Control Mapping</h1>
-          <p className="text-gray-400">Federal information security controls mapped to Kubernetes infrastructure</p>
-        </div>
-      </div>
+      <DashboardHeader
+        title="NIST 800-53 Control Mapping"
+        subtitle="Federal information security controls mapped to Kubernetes infrastructure"
+        isFetching={loading}
+        onRefresh={fetchData}
+        autoRefresh={autoRefresh}
+        onAutoRefreshChange={setAutoRefresh}
+        autoRefreshId="nist-auto-refresh"
+        rightExtra={<RotatingTip page="compliance" />}
+      />
 
       {/* Summary cards */}
       {summary && (

--- a/web/src/components/compliance/OIDCDashboard.tsx
+++ b/web/src/components/compliance/OIDCDashboard.tsx
@@ -6,6 +6,8 @@ import {
   RefreshCw, Users, ShieldCheck, Fingerprint, Clock,
 } from 'lucide-react'
 import { authFetch } from '../../lib/api'
+import { DashboardHeader } from '../shared/DashboardHeader'
+import { RotatingTip } from '../ui/RotatingTip'
 
 interface OIDCProvider {
   id: string; name: string; issuer_url: string; status: string
@@ -39,6 +41,7 @@ export const OIDCDashboardContent = memo(function OIDCDashboardContent() {
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
   const [activeTab, setActiveTab] = useState<'providers' | 'sessions'>('providers')
+  const [autoRefresh, setAutoRefresh] = useState(false)
 
   const fetchData = useCallback(async () => {
     setLoading(true)
@@ -79,21 +82,16 @@ export const OIDCDashboardContent = memo(function OIDCDashboardContent() {
 
   return (
     <div className="space-y-6 p-6">
-      {/* Header */}
-      <div className="flex items-center justify-between">
-        <div>
-          <h1 className="text-2xl font-bold text-white flex items-center gap-3">
-            <KeyRound className="w-7 h-7 text-blue-400" />
-            OIDC Federation
-          </h1>
-          <p className="text-gray-400 mt-1">
-            Identity provider federation and session management
-          </p>
-        </div>
-        <button onClick={fetchData} className="p-2 hover:bg-white/10 rounded-lg transition-colors" title="Refresh">
-          <RefreshCw className="w-5 h-5 text-gray-400" />
-        </button>
-      </div>
+      <DashboardHeader
+        title="OIDC Federation"
+        subtitle="Identity provider federation and session management"
+        isFetching={loading}
+        onRefresh={fetchData}
+        autoRefresh={autoRefresh}
+        onAutoRefreshChange={setAutoRefresh}
+        autoRefreshId="oidc-auto-refresh"
+        rightExtra={<RotatingTip page="compliance" />}
+      />
 
       {/* Summary Cards */}
       {summary && (

--- a/web/src/components/compliance/RBACAuditDashboard.tsx
+++ b/web/src/components/compliance/RBACAuditDashboard.tsx
@@ -7,6 +7,8 @@ import {
 } from 'lucide-react'
 import { authFetch } from '../../lib/api'
 import { Select } from '../ui/Select'
+import { DashboardHeader } from '../shared/DashboardHeader'
+import { RotatingTip } from '../ui/RotatingTip'
 
 interface RBACBinding {
   id: string; name: string; kind: string; subject_kind: string
@@ -50,6 +52,7 @@ export const RBACAuditDashboardContent = memo(function RBACAuditDashboardContent
   const [error, setError] = useState<string | null>(null)
   const [activeTab, setActiveTab] = useState<'findings' | 'bindings'>('findings')
   const [severityFilter, setSeverityFilter] = useState('all')
+  const [autoRefresh, setAutoRefresh] = useState(false)
 
   const fetchData = async () => {
     setLoading(true)
@@ -102,21 +105,16 @@ export const RBACAuditDashboardContent = memo(function RBACAuditDashboardContent
 
   return (
     <div className="space-y-6 p-6">
-      {/* Header */}
-      <div className="flex items-center justify-between">
-        <div>
-          <h1 className="text-2xl font-bold text-white flex items-center gap-3">
-            <Lock className="w-7 h-7 text-blue-400" />
-            RBAC Audit &amp; Least-Privilege Analysis
-          </h1>
-          <p className="text-gray-400 mt-1">
-            Role binding audit, over-privilege detection, and compliance scoring
-          </p>
-        </div>
-        <button onClick={fetchData} className="p-2 hover:bg-white/10 rounded-lg transition-colors" title="Refresh">
-          <RefreshCw className="w-5 h-5 text-gray-400" />
-        </button>
-      </div>
+      <DashboardHeader
+        title="RBAC Audit & Least-Privilege Analysis"
+        subtitle="Role binding audit, over-privilege detection, and compliance scoring"
+        isFetching={loading}
+        onRefresh={fetchData}
+        autoRefresh={autoRefresh}
+        onAutoRefreshChange={setAutoRefresh}
+        autoRefreshId="rbac-auto-refresh"
+        rightExtra={<RotatingTip page="compliance" />}
+      />
 
       {/* Summary Cards */}
       {summary && (

--- a/web/src/components/compliance/RiskAppetiteDashboard.tsx
+++ b/web/src/components/compliance/RiskAppetiteDashboard.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, memo } from 'react'
+import { useState, useEffect, memo, useCallback } from 'react'
 import { UnifiedDashboard } from '../../lib/unified/dashboard/UnifiedDashboard'
 import { riskAppetiteDashboardConfig } from '../../config/dashboards/risk-appetite'
 import {
@@ -6,6 +6,8 @@ import {
   TrendingUp, ArrowRight,
 } from 'lucide-react'
 import { authFetch } from '../../lib/api'
+import { DashboardHeader } from '../shared/DashboardHeader'
+import { RotatingTip } from '../ui/RotatingTip'
 
 // ── Types ─────────────────────────────────────────────────────────────
 
@@ -69,27 +71,29 @@ export const RiskAppetiteDashboardContent = memo(function RiskAppetiteDashboardC
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
   const [activeTab, setActiveTab] = useState<'appetite' | 'kris' | 'trends'>('appetite')
+  const [autoRefresh, setAutoRefresh] = useState(false)
 
-  useEffect(() => {
-    const load = async () => {
-      try {
-        const [tRes, kRes, sRes] = await Promise.all([
-          authFetch('/api/v1/compliance/erm/risk-appetite/thresholds'),
-          authFetch('/api/v1/compliance/erm/risk-appetite/kris'),
-          authFetch('/api/v1/compliance/erm/risk-appetite/summary'),
-        ])
-        if (!tRes.ok || !kRes.ok || !sRes.ok) throw new Error('Failed to fetch risk appetite data')
-        setThresholds(await tRes.json())
-        setKRIs(await kRes.json())
-        setSummary(await sRes.json())
-      } catch (e) {
-        setError(e instanceof Error ? e.message : 'Unknown error')
-      } finally {
-        setLoading(false)
-      }
+  const fetchData = useCallback(async () => {
+    setLoading(true)
+    setError(null)
+    try {
+      const [tRes, kRes, sRes] = await Promise.all([
+        authFetch('/api/v1/compliance/erm/risk-appetite/thresholds'),
+        authFetch('/api/v1/compliance/erm/risk-appetite/kris'),
+        authFetch('/api/v1/compliance/erm/risk-appetite/summary'),
+      ])
+      if (!tRes.ok || !kRes.ok || !sRes.ok) throw new Error('Failed to fetch risk appetite data')
+      setThresholds(await tRes.json())
+      setKRIs(await kRes.json())
+      setSummary(await sRes.json())
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Unknown error')
+    } finally {
+      setLoading(false)
     }
-    load()
   }, [])
+
+  useEffect(() => { fetchData() }, [fetchData])
 
   if (loading) return (
     <div className="flex items-center justify-center h-64">
@@ -109,13 +113,16 @@ export const RiskAppetiteDashboardContent = memo(function RiskAppetiteDashboardC
   return (
     <div className="space-y-6">
       {/* Header */}
-      <div className="flex items-center gap-3">
-        <Gauge className="w-8 h-8 text-orange-400" />
-        <div>
-          <h1 className="text-2xl font-bold text-white">Risk Appetite</h1>
-          <p className="text-gray-400">Risk tolerance monitoring, KRI tracking, and appetite vs exposure analysis</p>
-        </div>
-      </div>
+      <DashboardHeader
+        title="Risk Appetite"
+        subtitle="Organizational risk appetite definition, thresholds, and tracking"
+        isFetching={loading}
+        onRefresh={fetchData}
+        autoRefresh={autoRefresh}
+        onAutoRefreshChange={setAutoRefresh}
+        autoRefreshId="risk-appetite-auto-refresh"
+        rightExtra={<RotatingTip page="compliance" />}
+      />
 
       {/* Summary cards */}
       {summary && (

--- a/web/src/components/compliance/RiskMatrixDashboard.tsx
+++ b/web/src/components/compliance/RiskMatrixDashboard.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useMemo, memo } from 'react'
+import { useState, useEffect, useMemo, memo, useCallback } from 'react'
 import { UnifiedDashboard } from '../../lib/unified/dashboard/UnifiedDashboard'
 import { riskMatrixDashboardConfig } from '../../config/dashboards/risk-matrix'
 import {
@@ -6,6 +6,8 @@ import {
   ArrowRight, ChevronDown,
 } from 'lucide-react'
 import { authFetch } from '../../lib/api'
+import { DashboardHeader } from '../shared/DashboardHeader'
+import { RotatingTip } from '../ui/RotatingTip'
 
 // ── Types ─────────────────────────────────────────────────────────────
 
@@ -71,27 +73,29 @@ export const RiskMatrixDashboardContent = memo(function RiskMatrixDashboardConte
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
   const [selectedCell, setSelectedCell] = useState<{ l: number; i: number } | null>(null)
+  const [autoRefresh, setAutoRefresh] = useState(false)
 
-  useEffect(() => {
-    const load = async () => {
-      try {
-        const [rRes, hRes, sRes] = await Promise.all([
-          authFetch('/api/v1/compliance/erm/risk-matrix/risks'),
-          authFetch('/api/v1/compliance/erm/risk-matrix/heatmap'),
-          authFetch('/api/v1/compliance/erm/risk-matrix/summary'),
-        ])
-        if (!rRes.ok || !hRes.ok || !sRes.ok) throw new Error('Failed to fetch risk matrix data')
-        setRisks(await rRes.json())
-        setHeatmap(await hRes.json())
-        setSummary(await sRes.json())
-      } catch (e) {
-        setError(e instanceof Error ? e.message : 'Unknown error')
-      } finally {
-        setLoading(false)
-      }
+  const fetchData = useCallback(async () => {
+    setLoading(true)
+    setError(null)
+    try {
+      const [rRes, hRes, sRes] = await Promise.all([
+        authFetch('/api/v1/compliance/erm/risk-matrix/risks'),
+        authFetch('/api/v1/compliance/erm/risk-matrix/heatmap'),
+        authFetch('/api/v1/compliance/erm/risk-matrix/summary'),
+      ])
+      if (!rRes.ok || !hRes.ok || !sRes.ok) throw new Error('Failed to fetch risk matrix data')
+      setRisks(await rRes.json())
+      setHeatmap(await hRes.json())
+      setSummary(await sRes.json())
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Unknown error')
+    } finally {
+      setLoading(false)
     }
-    load()
   }, [])
+
+  useEffect(() => { fetchData() }, [fetchData])
 
   // Build a lookup from heatmap data
   const heatmapLookup = useMemo(() => {
@@ -129,13 +133,16 @@ export const RiskMatrixDashboardContent = memo(function RiskMatrixDashboardConte
   return (
     <div className="space-y-6">
       {/* Header */}
-      <div className="flex items-center gap-3">
-        <BarChart3 className="w-8 h-8 text-orange-400" />
-        <div>
-          <h1 className="text-2xl font-bold text-white">Risk Matrix</h1>
-          <p className="text-gray-400">Interactive 5×5 risk heat map with likelihood vs impact assessment</p>
-        </div>
-      </div>
+      <DashboardHeader
+        title="Risk Matrix"
+        subtitle="Interactive 5x5 risk heat map with likelihood vs impact assessment"
+        isFetching={loading}
+        onRefresh={fetchData}
+        autoRefresh={autoRefresh}
+        onAutoRefreshChange={setAutoRefresh}
+        autoRefreshId="risk-matrix-auto-refresh"
+        rightExtra={<RotatingTip page="compliance" />}
+      />
 
       {/* Summary cards */}
       {summary && (

--- a/web/src/components/compliance/RiskRegisterDashboard.tsx
+++ b/web/src/components/compliance/RiskRegisterDashboard.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useMemo, memo } from 'react'
+import { useState, useEffect, useMemo, memo, useCallback } from 'react'
 import { UnifiedDashboard } from '../../lib/unified/dashboard/UnifiedDashboard'
 import { riskRegisterDashboardConfig } from '../../config/dashboards/risk-register'
 import {
@@ -6,6 +6,8 @@ import {
   ChevronRight, X, Filter,
 } from 'lucide-react'
 import { authFetch } from '../../lib/api'
+import { DashboardHeader } from '../shared/DashboardHeader'
+import { RotatingTip } from '../ui/RotatingTip'
 
 // ── Types ─────────────────────────────────────────────────────────────
 
@@ -85,27 +87,29 @@ export const RiskRegisterDashboardContent = memo(function RiskRegisterDashboardC
   const [statusFilter, setStatusFilter] = useState('All')
   const [severityFilter, setSeverityFilter] = useState('All')
   const [selectedRisk, setSelectedRisk] = useState<Risk | null>(null)
+  const [autoRefresh, setAutoRefresh] = useState(false)
 
-  useEffect(() => {
-    const load = async () => {
-      try {
-        const [rRes, cRes, sRes] = await Promise.all([
-          authFetch('/api/v1/compliance/erm/risk-register/risks'),
-          authFetch('/api/v1/compliance/erm/risk-register/categories'),
-          authFetch('/api/v1/compliance/erm/risk-register/summary'),
-        ])
-        if (!rRes.ok || !cRes.ok || !sRes.ok) throw new Error('Failed to fetch risk register data')
-        setRisks(await rRes.json())
-        setCategories(await cRes.json())
-        setSummary(await sRes.json())
-      } catch (e) {
-        setError(e instanceof Error ? e.message : 'Unknown error')
-      } finally {
-        setLoading(false)
-      }
+  const fetchData = useCallback(async () => {
+    setLoading(true)
+    setError(null)
+    try {
+      const [rRes, cRes, sRes] = await Promise.all([
+        authFetch('/api/v1/compliance/erm/risk-register/risks'),
+        authFetch('/api/v1/compliance/erm/risk-register/categories'),
+        authFetch('/api/v1/compliance/erm/risk-register/summary'),
+      ])
+      if (!rRes.ok || !cRes.ok || !sRes.ok) throw new Error('Failed to fetch risk register data')
+      setRisks(await rRes.json())
+      setCategories(await cRes.json())
+      setSummary(await sRes.json())
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Unknown error')
+    } finally {
+      setLoading(false)
     }
-    load()
   }, [])
+
+  useEffect(() => { fetchData() }, [fetchData])
 
   const filteredRisks = useMemo(() => {
     return risks.filter(r => {
@@ -132,13 +136,16 @@ export const RiskRegisterDashboardContent = memo(function RiskRegisterDashboardC
   return (
     <div className="space-y-6">
       {/* Header */}
-      <div className="flex items-center gap-3">
-        <ClipboardList className="w-8 h-8 text-orange-400" />
-        <div>
-          <h1 className="text-2xl font-bold text-white">Risk Register</h1>
-          <p className="text-gray-400">Comprehensive risk tracking with mitigation plans and controls</p>
-        </div>
-      </div>
+      <DashboardHeader
+        title="Risk Register"
+        subtitle="Comprehensive risk tracking with mitigation plans and controls"
+        isFetching={loading}
+        onRefresh={fetchData}
+        autoRefresh={autoRefresh}
+        onAutoRefreshChange={setAutoRefresh}
+        autoRefreshId="risk-register-auto-refresh"
+        rightExtra={<RotatingTip page="compliance" />}
+      />
 
       {/* Summary cards */}
       {summary && (

--- a/web/src/components/compliance/SBOMDashboard.tsx
+++ b/web/src/components/compliance/SBOMDashboard.tsx
@@ -4,7 +4,7 @@
  * Package inventory, vulnerability scanning, license compliance,
  * and dependency tree visualization.
  */
-import { useState, useEffect, memo } from 'react'
+import { useState, useEffect, memo, useCallback } from 'react'
 import {
   Package, CheckCircle2, Loader2, AlertTriangle,
   XCircle, Shield, FileText
@@ -12,6 +12,8 @@ import {
 import { authFetch } from '../../lib/api'
 import { UnifiedDashboard } from '../../lib/unified/dashboard/UnifiedDashboard'
 import { sbomDashboardConfig } from '../../config/dashboards/sbom'
+import { DashboardHeader } from '../shared/DashboardHeader'
+import { RotatingTip } from '../ui/RotatingTip'
 
 // ── Types ───────────────────────────────────────────────────────────────
 
@@ -81,27 +83,29 @@ export const SBOMDashboardContent = memo(function SBOMDashboardContent() {
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
   const [activeTab, setActiveTab] = useState<'packages' | 'vulnerabilities'>('packages')
+  const [autoRefresh, setAutoRefresh] = useState(false)
 
-  useEffect(() => {
-    const load = async () => {
-      try {
-        const [pRes, vRes, sRes] = await Promise.all([
-          authFetch('/api/v1/compliance/sbom/packages'),
-          authFetch('/api/v1/compliance/sbom/vulnerabilities'),
-          authFetch('/api/v1/compliance/sbom/summary'),
-        ])
-        if (!pRes.ok || !vRes.ok || !sRes.ok) throw new Error('Failed to fetch SBOM data')
-        setPackages(await pRes.json())
-        setVulnerabilities(await vRes.json())
-        setSummary(await sRes.json())
-      } catch (e) {
-        setError(e instanceof Error ? e.message : 'Unknown error')
-      } finally {
-        setLoading(false)
-      }
+  const fetchData = useCallback(async () => {
+    setLoading(true)
+    setError(null)
+    try {
+      const [pRes, vRes, sRes] = await Promise.all([
+        authFetch('/api/v1/compliance/sbom/packages'),
+        authFetch('/api/v1/compliance/sbom/vulnerabilities'),
+        authFetch('/api/v1/compliance/sbom/summary'),
+      ])
+      if (!pRes.ok || !vRes.ok || !sRes.ok) throw new Error('Failed to fetch SBOM data')
+      setPackages(await pRes.json())
+      setVulnerabilities(await vRes.json())
+      setSummary(await sRes.json())
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Unknown error')
+    } finally {
+      setLoading(false)
     }
-    load()
   }, [])
+
+  useEffect(() => { fetchData() }, [fetchData])
 
   if (loading) return (
     <div className="flex items-center justify-center h-64">
@@ -126,13 +130,16 @@ export const SBOMDashboardContent = memo(function SBOMDashboardContent() {
   return (
     <div className="space-y-6">
       {/* Header */}
-      <div className="flex items-center gap-3">
-        <Package className="w-8 h-8 text-blue-400" />
-        <div>
-          <h1 className="text-2xl font-bold text-white">SBOM Manager</h1>
-          <p className="text-gray-400">Software bill of materials, vulnerability tracking, and license compliance</p>
-        </div>
-      </div>
+      <DashboardHeader
+        title="SBOM Manager"
+        subtitle="Software bill of materials, vulnerability tracking, and license compliance"
+        isFetching={loading}
+        onRefresh={fetchData}
+        autoRefresh={autoRefresh}
+        onAutoRefreshChange={setAutoRefresh}
+        autoRefreshId="sbom-auto-refresh"
+        rightExtra={<RotatingTip page="compliance" />}
+      />
 
       {/* Summary stats */}
       {summary && (

--- a/web/src/components/compliance/SIEMDashboard.tsx
+++ b/web/src/components/compliance/SIEMDashboard.tsx
@@ -1,10 +1,12 @@
 import React, { memo } from 'react'
-import { useState, useEffect } from 'react'
+import { useState, useEffect, useCallback } from 'react'
 import {
   Monitor, CheckCircle2, Loader2,
   ArrowRight, Clock, XCircle
 } from 'lucide-react'
 import { authFetch } from '../../lib/api'
+import { DashboardHeader } from '../shared/DashboardHeader'
+import { RotatingTip } from '../ui/RotatingTip'
 
 // ── Types ───────────────────────────────────────────────────────────────
 
@@ -72,27 +74,29 @@ const SIEMDashboard = memo(function SIEMDashboard() {
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
   const [activeTab, setActiveTab] = useState<'events' | 'alerts' | 'overview'>('overview')
+  const [autoRefresh, setAutoRefresh] = useState(false)
 
-  useEffect(() => {
-    const load = async () => {
-      try {
-        const [eRes, aRes, sRes] = await Promise.all([
-          authFetch('/api/v1/compliance/siem/events'),
-          authFetch('/api/v1/compliance/siem/alerts'),
-          authFetch('/api/v1/compliance/siem/summary'),
-        ])
-        if (!eRes.ok || !aRes.ok || !sRes.ok) throw new Error('Failed to fetch SIEM data')
-        setEvents(await eRes.json())
-        setAlerts(await aRes.json())
-        setSummary(await sRes.json())
-      } catch (e) {
-        setError(e instanceof Error ? e.message : 'Unknown error')
-      } finally {
-        setLoading(false)
-      }
+  const fetchData = useCallback(async () => {
+    setLoading(true)
+    setError(null)
+    try {
+      const [eRes, aRes, sRes] = await Promise.all([
+        authFetch('/api/v1/compliance/siem/events'),
+        authFetch('/api/v1/compliance/siem/alerts'),
+        authFetch('/api/v1/compliance/siem/summary'),
+      ])
+      if (!eRes.ok || !aRes.ok || !sRes.ok) throw new Error('Failed to fetch SIEM data')
+      setEvents(await eRes.json())
+      setAlerts(await aRes.json())
+      setSummary(await sRes.json())
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Unknown error')
+    } finally {
+      setLoading(false)
     }
-    load()
   }, [])
+
+  useEffect(() => { fetchData() }, [fetchData])
 
   if (loading) return (
     <div className="flex items-center justify-center h-64">
@@ -109,13 +113,16 @@ const SIEMDashboard = memo(function SIEMDashboard() {
 
   return (
     <div className="space-y-6">
-      <div className="flex items-center gap-3">
-        <Monitor className="w-8 h-8 text-blue-400" />
-        <div>
-          <h1 className="text-2xl font-bold text-white">SIEM Integration</h1>
-          <p className="text-gray-400">Security event monitoring, log aggregation, and alert correlation</p>
-        </div>
-      </div>
+      <DashboardHeader
+        title="SIEM Integration"
+        subtitle="Security event monitoring, log aggregation, and alert correlation"
+        isFetching={loading}
+        onRefresh={fetchData}
+        autoRefresh={autoRefresh}
+        onAutoRefreshChange={setAutoRefresh}
+        autoRefreshId="siem-auto-refresh"
+        rightExtra={<RotatingTip page="compliance" />}
+      />
 
       {/* Summary cards */}
       {summary && (

--- a/web/src/components/compliance/SLSADashboard.test.tsx
+++ b/web/src/components/compliance/SLSADashboard.test.tsx
@@ -5,6 +5,10 @@ import { SLSADashboardContent as SLSADashboard } from './SLSADashboard'
 
 /* ── Mock authFetch at the top level ─────────────────────────────── */
 
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key, i18n: { language: 'en', changeLanguage: vi.fn() } }),
+}))
 vi.mock('../../lib/api', () => ({
   authFetch: vi.fn(),
 }))

--- a/web/src/components/compliance/SLSADashboard.tsx
+++ b/web/src/components/compliance/SLSADashboard.tsx
@@ -4,7 +4,7 @@
  * Build provenance level indicators (L1–L4), attestation verification,
  * source integrity checks, and build reproducibility.
  */
-import { useState, useEffect, memo } from 'react'
+import { useState, useEffect, memo, useCallback } from 'react'
 import {
   GitCommitHorizontal, CheckCircle2, Loader2, AlertTriangle,
   XCircle, Shield, Lock
@@ -12,6 +12,8 @@ import {
 import { authFetch } from '../../lib/api'
 import { UnifiedDashboard } from '../../lib/unified/dashboard/UnifiedDashboard'
 import { slsaDashboardConfig } from '../../config/dashboards/slsa'
+import { DashboardHeader } from '../shared/DashboardHeader'
+import { RotatingTip } from '../ui/RotatingTip'
 
 // ── Types ───────────────────────────────────────────────────────────────
 
@@ -99,30 +101,32 @@ export const SLSADashboardContent = memo(function SLSADashboardContent() {
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
   const [activeTab, setActiveTab] = useState<'attestations' | 'provenance'>('attestations')
+  const [autoRefresh, setAutoRefresh] = useState(false)
 
-  useEffect(() => {
-    const load = async () => {
-      try {
-        const [aRes, pRes, sRes] = await Promise.all([
-          authFetch('/api/v1/compliance/slsa/attestations'),
-          authFetch('/api/v1/compliance/slsa/provenance'),
-          authFetch('/api/v1/compliance/slsa/summary'),
-        ])
-        if (!aRes.ok || !pRes.ok || !sRes.ok) throw new Error('Failed to fetch SLSA data')
-        const aData = await aRes.json()
-        const pData = await pRes.json()
-        const sData = await sRes.json()
-        setAttestations(Array.isArray(aData) ? aData : [])
-        setProvenance(Array.isArray(pData) ? pData : [])
-        setSummary(sData ?? null)
-      } catch (e) {
-        setError(e instanceof Error ? e.message : 'Unknown error')
-      } finally {
-        setLoading(false)
-      }
+  const fetchData = useCallback(async () => {
+    setLoading(true)
+    setError(null)
+    try {
+      const [aRes, pRes, sRes] = await Promise.all([
+        authFetch('/api/v1/compliance/slsa/attestations'),
+        authFetch('/api/v1/compliance/slsa/provenance'),
+        authFetch('/api/v1/compliance/slsa/summary'),
+      ])
+      if (!aRes.ok || !pRes.ok || !sRes.ok) throw new Error('Failed to fetch SLSA data')
+      const aData = await aRes.json()
+      const pData = await pRes.json()
+      const sData = await sRes.json()
+      setAttestations(Array.isArray(aData) ? aData : [])
+      setProvenance(Array.isArray(pData) ? pData : [])
+      setSummary(sData ?? null)
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Unknown error')
+    } finally {
+      setLoading(false)
     }
-    load()
   }, [])
+
+  useEffect(() => { fetchData() }, [fetchData])
 
   if (loading) return (
     <div className="flex items-center justify-center h-64">
@@ -142,13 +146,16 @@ export const SLSADashboardContent = memo(function SLSADashboardContent() {
   return (
     <div className="space-y-6">
       {/* Header */}
-      <div className="flex items-center gap-3">
-        <GitCommitHorizontal className="w-8 h-8 text-emerald-400" />
-        <div>
-          <h1 className="text-2xl font-bold text-white">SLSA Provenance</h1>
-          <p className="text-gray-400">Build provenance levels, attestation verification, and source integrity</p>
-        </div>
-      </div>
+      <DashboardHeader
+        title="SLSA Provenance"
+        subtitle="Build provenance levels, attestation verification, and source integrity"
+        isFetching={loading}
+        onRefresh={fetchData}
+        autoRefresh={autoRefresh}
+        onAutoRefreshChange={setAutoRefresh}
+        autoRefreshId="slsa-auto-refresh"
+        rightExtra={<RotatingTip page="compliance" />}
+      />
 
       {/* Summary stats */}
       {summary && (

--- a/web/src/components/compliance/STIGDashboard.test.tsx
+++ b/web/src/components/compliance/STIGDashboard.test.tsx
@@ -10,6 +10,10 @@ const mockFindings = [
 ]
 const mockSummary = { compliance_score: 76, total_findings: 120, open: 14, cat_i_open: 3, cat_ii_open: 8, cat_iii_open: 3, evaluated_at: new Date().toISOString() }
 
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key, i18n: { language: 'en', changeLanguage: vi.fn() } }),
+}))
 vi.mock('../../lib/api', () => ({
   authFetch: vi.fn((url: string) => {
     if (url.includes('/benchmarks')) return Promise.resolve({ ok: true, json: () => Promise.resolve(mockBenchmarks) })

--- a/web/src/components/compliance/STIGDashboard.tsx
+++ b/web/src/components/compliance/STIGDashboard.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useMemo, memo } from 'react'
+import { useState, useEffect, useMemo, memo, useCallback } from 'react'
 import { UnifiedDashboard } from '../../lib/unified/dashboard/UnifiedDashboard'
 import { stigDashboardConfig } from '../../config/dashboards/stig'
 import {
@@ -6,6 +6,8 @@ import {
   Shield, ArrowRight, Clock, Search
 } from 'lucide-react'
 import { authFetch } from '../../lib/api'
+import { DashboardHeader } from '../shared/DashboardHeader'
+import { RotatingTip } from '../ui/RotatingTip'
 
 interface Finding {
   id: string
@@ -76,27 +78,29 @@ export const STIGDashboardContent = memo(function STIGDashboardContent() {
   const [error, setError] = useState<string | null>(null)
   const [activeTab, setActiveTab] = useState<'findings' | 'benchmarks' | 'summary'>('findings')
   const [severityFilter, setSeverityFilter] = useState<string>('all')
+  const [autoRefresh, setAutoRefresh] = useState(false)
 
-  useEffect(() => {
-    const load = async () => {
-      try {
-        const [bRes, fRes, sRes] = await Promise.all([
-          authFetch('/api/compliance/stig/benchmarks'),
-          authFetch('/api/compliance/stig/findings'),
-          authFetch('/api/compliance/stig/summary'),
-        ])
-        if (!bRes.ok || !fRes.ok || !sRes.ok) throw new Error('Failed to fetch STIG data')
-        setBenchmarks(await bRes.json())
-        setFindings(await fRes.json())
-        setSummary(await sRes.json())
-      } catch (e) {
-        setError(e instanceof Error ? e.message : 'Unknown error')
-      } finally {
-        setLoading(false)
-      }
+  const fetchData = useCallback(async () => {
+    setLoading(true)
+    setError(null)
+    try {
+      const [bRes, fRes, sRes] = await Promise.all([
+        authFetch('/api/compliance/stig/benchmarks'),
+        authFetch('/api/compliance/stig/findings'),
+        authFetch('/api/compliance/stig/summary'),
+      ])
+      if (!bRes.ok || !fRes.ok || !sRes.ok) throw new Error('Failed to fetch STIG data')
+      setBenchmarks(await bRes.json())
+      setFindings(await fRes.json())
+      setSummary(await sRes.json())
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Unknown error')
+    } finally {
+      setLoading(false)
     }
-    load()
   }, [])
+
+  useEffect(() => { fetchData() }, [fetchData])
 
   const filteredFindings = useMemo(() => {
     if (severityFilter === 'all') return findings
@@ -118,13 +122,16 @@ export const STIGDashboardContent = memo(function STIGDashboardContent() {
 
   return (
     <div className="space-y-6">
-      <div className="flex items-center gap-3">
-        <Shield className="w-8 h-8 text-blue-400" />
-        <div>
-          <h1 className="text-2xl font-bold text-white">DISA STIG Compliance</h1>
-          <p className="text-gray-400">Security Technical Implementation Guides for hardened Kubernetes clusters</p>
-        </div>
-      </div>
+      <DashboardHeader
+        title="DISA STIG Compliance"
+        subtitle="Security Technical Implementation Guides for hardened Kubernetes clusters"
+        isFetching={loading}
+        onRefresh={fetchData}
+        autoRefresh={autoRefresh}
+        onAutoRefreshChange={setAutoRefresh}
+        autoRefreshId="stig-auto-refresh"
+        rightExtra={<RotatingTip page="compliance" />}
+      />
 
       {/* Summary cards */}
       {summary && (

--- a/web/src/components/compliance/SegregationOfDuties.test.tsx
+++ b/web/src/components/compliance/SegregationOfDuties.test.tsx
@@ -2,6 +2,10 @@ import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render, screen, waitFor } from '@testing-library/react'
 import { SegregationOfDutiesContent as SegregationOfDuties } from './SegregationOfDuties'
 
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key, i18n: { language: 'en', changeLanguage: vi.fn() } }),
+}))
+
 const mockSummary = {
   total_rules: 5, total_principals: 10, total_violations: 5,
   by_severity: { critical: 2, high: 2, medium: 1 },

--- a/web/src/components/compliance/SegregationOfDuties.tsx
+++ b/web/src/components/compliance/SegregationOfDuties.tsx
@@ -6,6 +6,8 @@ import {
   Loader2, RefreshCw, Filter, UserCheck, UserX,
 } from 'lucide-react'
 import { authFetch } from '../../lib/api'
+import { DashboardHeader } from '../shared/DashboardHeader'
+import { RotatingTip } from '../ui/RotatingTip'
 import { Select } from '../ui/Select'
 
 interface SoDRule {
@@ -55,6 +57,7 @@ export const SegregationOfDutiesContent = memo(function SegregationOfDutiesConte
   const [error, setError] = useState<string | null>(null)
   const [filterSeverity, setFilterSeverity] = useState('all')
   const [activeTab, setActiveTab] = useState<'violations' | 'principals' | 'rules'>('violations')
+  const [autoRefresh, setAutoRefresh] = useState(false)
 
   const fetchData = useCallback(async () => {
     setLoading(true)
@@ -96,16 +99,16 @@ export const SegregationOfDutiesContent = memo(function SegregationOfDutiesConte
 
   return (
     <div className="space-y-6">
-      <div className="flex items-center justify-between">
-        <div className="flex items-center gap-3">
-          <div className="p-2 rounded-lg bg-amber-500/10"><Users className="w-6 h-6 text-amber-400" /></div>
-          <div>
-            <h1 className="text-xl font-semibold text-zinc-100">Segregation of Duties</h1>
-            <p className="text-sm text-zinc-400">Detect conflicting privilege assignments across RBAC roles</p>
-          </div>
-        </div>
-        <button onClick={fetchData} type="button" aria-label="Refresh segregation of duties data" className="text-zinc-400 hover:text-zinc-200 p-2 rounded-lg hover:bg-zinc-700/50 transition-colors"><RefreshCw className="w-4 h-4" /></button>
-      </div>
+      <DashboardHeader
+        title="Segregation of Duties"
+        subtitle="Detect conflicting privilege assignments across RBAC roles"
+        isFetching={loading}
+        onRefresh={fetchData}
+        autoRefresh={autoRefresh}
+        onAutoRefreshChange={setAutoRefresh}
+        autoRefreshId="sod-auto-refresh"
+        rightExtra={<RotatingTip page="compliance" />}
+      />
 
       {summary && (
         <div className="grid grid-cols-2 md:grid-cols-5 gap-4">

--- a/web/src/components/compliance/SessionDashboard.tsx
+++ b/web/src/components/compliance/SessionDashboard.tsx
@@ -6,6 +6,8 @@ import {
   Users, ShieldCheck, AlertTriangle, Monitor,
 } from 'lucide-react'
 import { authFetch } from '../../lib/api'
+import { DashboardHeader } from '../shared/DashboardHeader'
+import { RotatingTip } from '../ui/RotatingTip'
 
 interface ActiveSession {
   id: string; user: string; login_time: string; last_activity: string
@@ -39,6 +41,7 @@ export const SessionDashboardContent = memo(function SessionDashboardContent() {
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
   const [activeTab, setActiveTab] = useState<'sessions' | 'policies'>('sessions')
+  const [autoRefresh, setAutoRefresh] = useState(false)
 
   const fetchData = async () => {
     setLoading(true)
@@ -79,21 +82,16 @@ export const SessionDashboardContent = memo(function SessionDashboardContent() {
 
   return (
     <div className="space-y-6 p-6">
-      {/* Header */}
-      <div className="flex items-center justify-between">
-        <div>
-          <h1 className="text-2xl font-bold text-white flex items-center gap-3">
-            <Clock className="w-7 h-7 text-blue-400" />
-            Session Management
-          </h1>
-          <p className="text-gray-400 mt-1">
-            Active session monitoring and policy enforcement
-          </p>
-        </div>
-        <button onClick={fetchData} className="p-2 hover:bg-white/10 rounded-lg transition-colors" title="Refresh">
-          <RefreshCw className="w-5 h-5 text-gray-400" />
-        </button>
-      </div>
+      <DashboardHeader
+        title="Session Management"
+        subtitle="Active session monitoring and policy enforcement"
+        isFetching={loading}
+        onRefresh={fetchData}
+        autoRefresh={autoRefresh}
+        onAutoRefreshChange={setAutoRefresh}
+        autoRefreshId="session-auto-refresh"
+        rightExtra={<RotatingTip page="compliance" />}
+      />
 
       {/* Summary Cards */}
       {summary && (

--- a/web/src/components/compliance/SigstoreDashboard.tsx
+++ b/web/src/components/compliance/SigstoreDashboard.tsx
@@ -4,7 +4,7 @@
  * Cosign verification results, transparency log entries,
  * and trust chain visualization.
  */
-import { useState, useEffect, memo } from 'react'
+import { useState, useEffect, memo, useCallback } from 'react'
 import {
   BadgeCheck, CheckCircle2, Loader2, AlertTriangle,
   XCircle, ShieldCheck, FileKey
@@ -12,6 +12,8 @@ import {
 import { authFetch } from '../../lib/api'
 import { UnifiedDashboard } from '../../lib/unified/dashboard/UnifiedDashboard'
 import { sigstoreDashboardConfig } from '../../config/dashboards/sigstore'
+import { DashboardHeader } from '../shared/DashboardHeader'
+import { RotatingTip } from '../ui/RotatingTip'
 
 // ── Types ───────────────────────────────────────────────────────────────
 
@@ -88,27 +90,29 @@ export const SigstoreDashboardContent = memo(function SigstoreDashboardContent()
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
   const [activeTab, setActiveTab] = useState<'signatures' | 'verifications'>('signatures')
+  const [autoRefresh, setAutoRefresh] = useState(false)
 
-  useEffect(() => {
-    const load = async () => {
-      try {
-        const [sigRes, verRes, sumRes] = await Promise.all([
-          authFetch('/api/v1/compliance/sigstore/signatures'),
-          authFetch('/api/v1/compliance/sigstore/verifications'),
-          authFetch('/api/v1/compliance/sigstore/summary'),
-        ])
-        if (!sigRes.ok || !verRes.ok || !sumRes.ok) throw new Error('Failed to fetch Sigstore data')
-        setSignatures(await sigRes.json())
-        setVerifications(await verRes.json())
-        setSummary(await sumRes.json())
-      } catch (e) {
-        setError(e instanceof Error ? e.message : 'Unknown error')
-      } finally {
-        setLoading(false)
-      }
+  const fetchData = useCallback(async () => {
+    setLoading(true)
+    setError(null)
+    try {
+      const [sigRes, verRes, sumRes] = await Promise.all([
+        authFetch('/api/v1/compliance/sigstore/signatures'),
+        authFetch('/api/v1/compliance/sigstore/verifications'),
+        authFetch('/api/v1/compliance/sigstore/summary'),
+      ])
+      if (!sigRes.ok || !verRes.ok || !sumRes.ok) throw new Error('Failed to fetch Sigstore data')
+      setSignatures(await sigRes.json())
+      setVerifications(await verRes.json())
+      setSummary(await sumRes.json())
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Unknown error')
+    } finally {
+      setLoading(false)
     }
-    load()
   }, [])
+
+  useEffect(() => { fetchData() }, [fetchData])
 
   if (loading) return (
     <div className="flex items-center justify-center h-64">
@@ -128,13 +132,16 @@ export const SigstoreDashboardContent = memo(function SigstoreDashboardContent()
   return (
     <div className="space-y-6">
       {/* Header */}
-      <div className="flex items-center gap-3">
-        <BadgeCheck className="w-8 h-8 text-green-400" />
-        <div>
-          <h1 className="text-2xl font-bold text-white">Sigstore Verification</h1>
-          <p className="text-gray-400">Image signature verification, cosign results, and transparency log</p>
-        </div>
-      </div>
+      <DashboardHeader
+        title="Sigstore Verification"
+        subtitle="Cryptographic signing and verification of container images and artifacts"
+        isFetching={loading}
+        onRefresh={fetchData}
+        autoRefresh={autoRefresh}
+        onAutoRefreshChange={setAutoRefresh}
+        autoRefreshId="sigstore-auto-refresh"
+        rightExtra={<RotatingTip page="compliance" />}
+      />
 
       {/* Summary stats */}
       {summary && (

--- a/web/src/components/compliance/ThreatIntelDashboard.tsx
+++ b/web/src/components/compliance/ThreatIntelDashboard.tsx
@@ -1,10 +1,12 @@
 import React, { memo } from 'react'
-import { useState, useEffect } from 'react'
+import { useState, useEffect, useCallback } from 'react'
 import {
   Shield, CheckCircle2, Loader2,
   Clock, XCircle, Eye
 } from 'lucide-react'
 import { authFetch } from '../../lib/api'
+import { DashboardHeader } from '../shared/DashboardHeader'
+import { RotatingTip } from '../ui/RotatingTip'
 
 // ── Types ───────────────────────────────────────────────────────────────
 
@@ -103,27 +105,29 @@ const ThreatIntelDashboard = memo(function ThreatIntelDashboard() {
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
   const [activeTab, setActiveTab] = useState<'overview' | 'feeds' | 'iocs'>('overview')
+  const [autoRefresh, setAutoRefresh] = useState(false)
 
-  useEffect(() => {
-    const load = async () => {
-      try {
-        const [fRes, iRes, sRes] = await Promise.all([
-          authFetch('/api/v1/compliance/threat-intel/feeds'),
-          authFetch('/api/v1/compliance/threat-intel/iocs'),
-          authFetch('/api/v1/compliance/threat-intel/summary'),
-        ])
-        if (!fRes.ok || !iRes.ok || !sRes.ok) throw new Error('Failed to fetch threat intel data')
-        setFeeds(await fRes.json())
-        setIOCs(await iRes.json())
-        setSummary(await sRes.json())
-      } catch (e) {
-        setError(e instanceof Error ? e.message : 'Unknown error')
-      } finally {
-        setLoading(false)
-      }
+  const fetchData = useCallback(async () => {
+    setLoading(true)
+    setError(null)
+    try {
+      const [fRes, iRes, sRes] = await Promise.all([
+        authFetch('/api/v1/compliance/threat-intel/feeds'),
+        authFetch('/api/v1/compliance/threat-intel/iocs'),
+        authFetch('/api/v1/compliance/threat-intel/summary'),
+      ])
+      if (!fRes.ok || !iRes.ok || !sRes.ok) throw new Error('Failed to fetch threat intel data')
+      setFeeds(await fRes.json())
+      setIOCs(await iRes.json())
+      setSummary(await sRes.json())
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Unknown error')
+    } finally {
+      setLoading(false)
     }
-    load()
   }, [])
+
+  useEffect(() => { fetchData() }, [fetchData])
 
   if (loading) return (
     <div className="flex items-center justify-center h-64">
@@ -140,13 +144,16 @@ const ThreatIntelDashboard = memo(function ThreatIntelDashboard() {
 
   return (
     <div className="space-y-6">
-      <div className="flex items-center gap-3">
-        <Shield className="w-8 h-8 text-purple-400" />
-        <div>
-          <h1 className="text-2xl font-bold text-white">Threat Intelligence</h1>
-          <p className="text-gray-400">Threat feed monitoring, IOC matching, and vulnerability correlation</p>
-        </div>
-      </div>
+      <DashboardHeader
+        title="Threat Intelligence"
+        subtitle="CVE monitoring, threat feeds, and vulnerability correlation"
+        isFetching={loading}
+        onRefresh={fetchData}
+        autoRefresh={autoRefresh}
+        onAutoRefreshChange={setAutoRefresh}
+        autoRefreshId="threatintel-auto-refresh"
+        rightExtra={<RotatingTip page="compliance" />}
+      />
 
       {/* Summary cards */}
       {summary && (


### PR DESCRIPTION
## Summary
- Replace hand-rolled headers in all 24 compliance dashboard components with the shared `DashboardHeader` component, matching Enterprise Home
- Each dashboard now shows consistent **Tip**, **Auto-refresh** checkbox, **refresh icon**, and **last-updated timestamp** controls
- For dashboards that previously used inline `useEffect` data loading, the fetch logic is extracted into a named `fetchData` callback to support the refresh button
- All 13 corresponding test files updated with `react-i18next` mocks required by `DashboardHeader`

Fixes #9822

## Test plan
- [ ] Verify compliance dashboards render with DashboardHeader (title, subtitle, refresh, auto-refresh, tip)
- [ ] Verify refresh button triggers data re-fetch
- [ ] Verify auto-refresh checkbox toggles state
- [ ] Verify RotatingTip shows compliance tips
- [ ] Verify existing tests pass with new react-i18next mocks

🤖 Generated with [Claude Code](https://claude.com/claude-code)