### PR TITLE
fix: consolidate EnterprisePortal refresh logic into single function

### DIFF
--- a/web/src/components/enterprise/EnterprisePortal.tsx
+++ b/web/src/components/enterprise/EnterprisePortal.tsx
@@ -158,9 +158,7 @@ export default function EnterprisePortal() {
   // Wire autoRefresh toggle to a periodic refresh interval
   useEffect(() => {
     if (autoRefresh) {
-      intervalRef.current = setInterval(() => {
-        setLastUpdated(new Date())
-      }, AUTO_REFRESH_INTERVAL_MS)
+      intervalRef.current = setInterval(handleRefresh, AUTO_REFRESH_INTERVAL_MS)
     }
     return () => {
       if (intervalRef.current) {
@@ -168,7 +166,7 @@ export default function EnterprisePortal() {
         intervalRef.current = null
       }
     }
-  }, [autoRefresh])
+  }, [autoRefresh, handleRefresh])
 
   const handleAddMore = useCallback(() => {
     if (dashboardContext?.openAddCardModal) {


### PR DESCRIPTION
## Summary
- Consolidates duplicated `setLastUpdated(new Date())` call in the `setInterval` callback to reuse `handleRefresh` instead, preventing future drift between manual and auto-refresh paths
- Adds `handleRefresh` to the `useEffect` dependency array for correctness

## Test plan
- [ ] Verify manual refresh button still updates the `lastUpdated` timestamp
- [ ] Verify auto-refresh interval still triggers periodic updates
- [ ] Confirm no console errors on `/enterprise` page

Fixes #9836