### PR TITLE
fix: unify 503 error message in remaining handlers via errNoClusterAccess

### DIFF
--- a/pkg/api/handlers/console_persistence.go
+++ b/pkg/api/handlers/console_persistence.go
@@ -112,7 +112,10 @@ func (h *ConsolePersistenceHandlers) checkClusterHealth(ctx context.Context, clu
 // matches the factory signature.
 func (h *ConsolePersistenceHandlers) getClusterClient(clusterName string) (dynamic.Interface, *rest.Config, error) {
 	if h.k8sClient == nil {
-		return nil, nil, fiber.NewError(503, "Kubernetes client not available")
+		// Factory callback has no *fiber.Ctx, so we cannot call
+		// errNoClusterAccess(c) directly. Use the shared noClusterAccessMsg
+		// constant so the error message stays unified with the helper (#9830).
+		return nil, nil, fiber.NewError(fiber.StatusServiceUnavailable, noClusterAccessMsg)
 	}
 
 	client, err := h.k8sClient.GetDynamicClient(clusterName)

--- a/pkg/api/handlers/demo_data.go
+++ b/pkg/api/handlers/demo_data.go
@@ -15,8 +15,14 @@ func isDemoMode(c *fiber.Ctx) bool {
 	return c.Get("X-Demo-Mode") == "true"
 }
 
+// noClusterAccessMsg is the unified error message returned by every handler
+// when the Kubernetes client is unavailable (e.g., no kubeconfig loaded, or
+// the kc-agent websocket is disconnected). Keeping this as a single constant
+// ensures the message stays in sync across handlers (#9830).
+const noClusterAccessMsg = "No cluster access"
+
 func errNoClusterAccess(c *fiber.Ctx) error {
-	return c.Status(fiber.StatusServiceUnavailable).JSON(fiber.Map{"error": "No cluster access"})
+	return c.Status(fiber.StatusServiceUnavailable).JSON(fiber.Map{"error": noClusterAccessMsg})
 }
 
 // Demo cluster data - matches frontend getDemoClusters() for consistency

--- a/pkg/api/handlers/namespaces.go
+++ b/pkg/api/handlers/namespaces.go
@@ -41,7 +41,7 @@ func (h *NamespaceHandler) ListNamespaces(c *fiber.Ctx) error {
 	}
 
 	if h.k8sClient == nil {
-		return fiber.NewError(fiber.StatusServiceUnavailable, "Kubernetes client not available")
+		return errNoClusterAccess(c)
 	}
 
 	cluster := c.Query("cluster")
@@ -79,7 +79,7 @@ func (h *NamespaceHandler) GetNamespaceAccess(c *fiber.Ctx) error {
 	}
 
 	if h.k8sClient == nil {
-		return fiber.NewError(fiber.StatusServiceUnavailable, "Kubernetes client not available")
+		return errNoClusterAccess(c)
 	}
 
 	cluster := c.Query("cluster")

--- a/pkg/api/handlers/rbac.go
+++ b/pkg/api/handlers/rbac.go
@@ -213,7 +213,7 @@ func (h *RBACHandler) ListK8sServiceAccounts(c *fiber.Ctx) error {
 	}
 
 	if h.k8sClient == nil {
-		return fiber.NewError(fiber.StatusServiceUnavailable, "Kubernetes client not available")
+		return errNoClusterAccess(c)
 	}
 
 	cluster := c.Query("cluster")
@@ -301,7 +301,7 @@ func (h *RBACHandler) ListK8sRoles(c *fiber.Ctx) error {
 	}
 
 	if h.k8sClient == nil {
-		return fiber.NewError(fiber.StatusServiceUnavailable, "Kubernetes client not available")
+		return errNoClusterAccess(c)
 	}
 
 	cluster := c.Query("cluster")
@@ -349,7 +349,7 @@ func (h *RBACHandler) ListK8sRoleBindings(c *fiber.Ctx) error {
 	}
 
 	if h.k8sClient == nil {
-		return fiber.NewError(fiber.StatusServiceUnavailable, "Kubernetes client not available")
+		return errNoClusterAccess(c)
 	}
 
 	cluster := c.Query("cluster")
@@ -412,7 +412,7 @@ func (h *RBACHandler) ListK8sUsers(c *fiber.Ctx) error {
 	}
 
 	if h.k8sClient == nil {
-		return fiber.NewError(fiber.StatusServiceUnavailable, "Kubernetes client not available")
+		return errNoClusterAccess(c)
 	}
 
 	cluster := c.Query("cluster")
@@ -447,7 +447,7 @@ func (h *RBACHandler) ListOpenShiftUsers(c *fiber.Ctx) error {
 	}
 
 	if h.k8sClient == nil {
-		return fiber.NewError(fiber.StatusServiceUnavailable, "Kubernetes client not available")
+		return errNoClusterAccess(c)
 	}
 
 	cluster := c.Query("cluster")

--- a/pkg/api/handlers/topology.go
+++ b/pkg/api/handlers/topology.go
@@ -73,7 +73,7 @@ type TopologyClusterSummary struct {
 // GET /api/topology
 func (h *TopologyHandlers) GetTopology(c *fiber.Ctx) error {
 	if h.k8sClient == nil {
-		return c.Status(fiber.StatusServiceUnavailable).JSON(fiber.Map{"error": "Kubernetes client not available"})
+		return errNoClusterAccess(c)
 	}
 
 	ctx, cancel := context.WithTimeout(c.Context(), topologyTimeout)


### PR DESCRIPTION
Fixes #9830

## Summary

The #9826 refactor introduced `errNoClusterAccess()` in `demo_data.go` to unify the "Kubernetes client unavailable" 503 response, but several handlers still returned the old `"Kubernetes client not available"` message directly. Copilot flagged these in its review of #9826.

Switch all remaining call sites to `errNoClusterAccess(c)`:
- `pkg/api/handlers/topology.go:76`
- `pkg/api/handlers/namespaces.go:44, 82`
- `pkg/api/handlers/rbac.go:216, 304, 352, 415, 450`
- `pkg/api/handlers/console_persistence.go:115`

For the one call site with no `*fiber.Ctx` available (the `getClusterClient` factory callback in `console_persistence.go`), extract the unified text into a shared constant `noClusterAccessMsg` and reference it from both the helper and the factory return, so the two paths can never drift out of sync again.

## Test plan
- [ ] CI build/lint passes
- [ ] Existing tests (`mcp_test.go`, `pod_logs_test.go`) that assert the `"No cluster access"` payload continue to pass
- [ ] No remaining occurrences of `"Kubernetes client not available"` in `pkg/api/handlers/`