### PR TITLE
fix: use safeJson helper in enterprise API fetches

### DIFF
--- a/web/src/components/cards/EnterpriseComplianceCards.tsx
+++ b/web/src/components/cards/EnterpriseComplianceCards.tsx
@@ -6,7 +6,7 @@
  */
 import { useState, useEffect } from 'react'
 import { Shield, FileText, Activity, Lock, WifiOff, Award, CheckCircle2, XCircle, KeyRound, Clock, Package, Scale } from 'lucide-react'
-import { authFetch } from '../../lib/api'
+import { authFetch, safeJson } from '../../lib/api'
 import { useNavigate } from 'react-router-dom'
 
 // ── Shared helpers ──────────────────────────────────────────────────────
@@ -66,7 +66,7 @@ export function HIPAACard() {
   const nav = useNavigate()
   const [data, setData] = useState<Record<string, number> | null>(null)
   useEffect(() => {
-    authFetch('/api/compliance/hipaa/summary').then(r => r.ok ? r.json() : null).then(setData).catch(() => {})
+    authFetch('/api/compliance/hipaa/summary').then(r => r.ok ? safeJson<Record<string, number>>(r) : null).then(setData).catch(() => {})
   }, [])
   return (
     <CardShell title="HIPAA Compliance" icon={Shield} onClick={() => nav('/hipaa')}>
@@ -91,7 +91,7 @@ export function GxPCard() {
   const nav = useNavigate()
   const [data, setData] = useState<Record<string, unknown> | null>(null)
   useEffect(() => {
-    authFetch('/api/compliance/gxp/summary').then(r => r.ok ? r.json() : null).then(setData).catch(() => {})
+    authFetch('/api/compliance/gxp/summary').then(r => r.ok ? safeJson<Record<string, unknown>>(r) : null).then(setData).catch(() => {})
   }, [])
   return (
     <CardShell title="GxP Validation (21 CFR 11)" icon={FileText} onClick={() => nav('/gxp')}>
@@ -120,7 +120,7 @@ export function BAACard() {
   const nav = useNavigate()
   const [data, setData] = useState<Record<string, number> | null>(null)
   useEffect(() => {
-    authFetch('/api/compliance/baa/summary').then(r => r.ok ? r.json() : null).then(setData).catch(() => {})
+    authFetch('/api/compliance/baa/summary').then(r => r.ok ? safeJson<Record<string, number>>(r) : null).then(setData).catch(() => {})
   }, [])
   return (
     <CardShell title="BAA Tracker" icon={FileText} onClick={() => nav('/baa')}>
@@ -225,7 +225,7 @@ export function NISTCard() {
   const nav = useNavigate()
   const [data, setData] = useState<Record<string, number> | null>(null)
   useEffect(() => {
-    authFetch('/api/compliance/nist/summary').then(r => r.ok ? r.json() : null).then(setData).catch(() => {})
+    authFetch('/api/compliance/nist/summary').then(r => r.ok ? safeJson<Record<string, number>>(r) : null).then(setData).catch(() => {})
   }, [])
   return (
     <CardShell title="NIST 800-53" icon={Shield} onClick={() => nav('/nist')}>
@@ -250,7 +250,7 @@ export function STIGCard() {
   const nav = useNavigate()
   const [data, setData] = useState<Record<string, number> | null>(null)
   useEffect(() => {
-    authFetch('/api/compliance/stig/summary').then(r => r.ok ? r.json() : null).then(setData).catch(() => {})
+    authFetch('/api/compliance/stig/summary').then(r => r.ok ? safeJson<Record<string, number>>(r) : null).then(setData).catch(() => {})
   }, [])
   return (
     <CardShell title="DISA STIG" icon={Shield} onClick={() => nav('/stig')}>
@@ -275,7 +275,7 @@ export function AirGapCard() {
   const nav = useNavigate()
   const [data, setData] = useState<Record<string, number> | null>(null)
   useEffect(() => {
-    authFetch('/api/compliance/airgap/summary').then(r => r.ok ? r.json() : null).then(setData).catch(() => {})
+    authFetch('/api/compliance/airgap/summary').then(r => r.ok ? safeJson<Record<string, number>>(r) : null).then(setData).catch(() => {})
   }, [])
   return (
     <CardShell title="Air-Gap Readiness" icon={WifiOff} onClick={() => nav('/air-gap')}>
@@ -300,7 +300,7 @@ export function SIEMIntegrationCard() {
   const nav = useNavigate()
   const [data, setData] = useState<Record<string, number> | null>(null)
   useEffect(() => {
-    authFetch('/api/v1/compliance/siem/summary').then(r => r.ok ? r.json() : null).then(setData).catch(() => {})
+    authFetch('/api/v1/compliance/siem/summary').then(r => r.ok ? safeJson<Record<string, number>>(r) : null).then(setData).catch(() => {})
   }, [])
   return (
     <CardShell title="SIEM Integration" icon={Activity} onClick={() => nav('/enterprise/siem')}>
@@ -322,7 +322,7 @@ export function IncidentResponseCard() {
   const nav = useNavigate()
   const [data, setData] = useState<Record<string, unknown> | null>(null)
   useEffect(() => {
-    authFetch('/api/v1/compliance/incidents/metrics').then(r => r.ok ? r.json() : null).then(setData).catch(() => {})
+    authFetch('/api/v1/compliance/incidents/metrics').then(r => r.ok ? safeJson<Record<string, unknown>>(r) : null).then(setData).catch(() => {})
   }, [])
   return (
     <CardShell title="Incident Response" icon={Shield} onClick={() => nav('/enterprise/incident-response')}>
@@ -344,7 +344,7 @@ export function ThreatIntelCard() {
   const nav = useNavigate()
   const [data, setData] = useState<Record<string, number> | null>(null)
   useEffect(() => {
-    authFetch('/api/v1/compliance/threat-intel/summary').then(r => r.ok ? r.json() : null).then(setData).catch(() => {})
+    authFetch('/api/v1/compliance/threat-intel/summary').then(r => r.ok ? safeJson<Record<string, number>>(r) : null).then(setData).catch(() => {})
   }, [])
   return (
     <CardShell title="Threat Intelligence" icon={Shield} onClick={() => nav('/enterprise/threat-intel')}>
@@ -369,7 +369,7 @@ export function FedRAMPCard() {
   const nav = useNavigate()
   const [data, setData] = useState<Record<string, unknown> | null>(null)
   useEffect(() => {
-    authFetch('/api/compliance/fedramp/score').then(r => r.ok ? r.json() : null).then(setData).catch(() => {})
+    authFetch('/api/compliance/fedramp/score').then(r => r.ok ? safeJson<Record<string, unknown>>(r) : null).then(setData).catch(() => {})
   }, [])
   return (
     <CardShell title="FedRAMP Readiness" icon={Award} onClick={() => nav('/fedramp')}>
@@ -394,7 +394,7 @@ export function OIDCFederationCard() {
   const nav = useNavigate()
   const [data, setData] = useState<Record<string, number> | null>(null)
   useEffect(() => {
-    authFetch('/api/identity/oidc/summary').then(r => r.ok ? r.json() : null).then(setData).catch(() => {})
+    authFetch('/api/identity/oidc/summary').then(r => r.ok ? safeJson<Record<string, number>>(r) : null).then(setData).catch(() => {})
   }, [])
   return (
     <CardShell title="OIDC Federation" icon={KeyRound} onClick={() => nav('/enterprise/oidc')}>
@@ -416,7 +416,7 @@ export function RBACAuditCard() {
   const nav = useNavigate()
   const [data, setData] = useState<Record<string, number> | null>(null)
   useEffect(() => {
-    authFetch('/api/identity/rbac/summary').then(r => r.ok ? r.json() : null).then(setData).catch(() => {})
+    authFetch('/api/identity/rbac/summary').then(r => r.ok ? safeJson<Record<string, number>>(r) : null).then(setData).catch(() => {})
   }, [])
   return (
     <CardShell title="RBAC Audit" icon={Lock} onClick={() => nav('/enterprise/rbac-audit')}>
@@ -441,7 +441,7 @@ export function SessionManagementCard() {
   const nav = useNavigate()
   const [data, setData] = useState<Record<string, number> | null>(null)
   useEffect(() => {
-    authFetch('/api/identity/sessions/summary').then(r => r.ok ? r.json() : null).then(setData).catch(() => {})
+    authFetch('/api/identity/sessions/summary').then(r => r.ok ? safeJson<Record<string, number>>(r) : null).then(setData).catch(() => {})
   }, [])
   return (
     <CardShell title="Session Management" icon={Clock} onClick={() => nav('/enterprise/sessions')}>
@@ -463,7 +463,7 @@ export function SBOMManagerCard() {
   const nav = useNavigate()
   const [data, setData] = useState<Record<string, number> | null>(null)
   useEffect(() => {
-    authFetch('/api/v1/compliance/sbom/summary').then(r => r.ok ? r.json() : null).then(setData).catch(() => {})
+    authFetch('/api/v1/compliance/sbom/summary').then(r => r.ok ? safeJson<Record<string, number>>(r) : null).then(setData).catch(() => {})
   }, [])
   return (
     <CardShell title="SBOM Manager" icon={Package} onClick={() => nav('/enterprise/sbom')}>
@@ -485,7 +485,7 @@ export function SigstoreVerifyCard() {
   const nav = useNavigate()
   const [data, setData] = useState<Record<string, number> | null>(null)
   useEffect(() => {
-    authFetch('/api/v1/compliance/sigstore/summary').then(r => r.ok ? r.json() : null).then(setData).catch(() => {})
+    authFetch('/api/v1/compliance/sigstore/summary').then(r => r.ok ? safeJson<Record<string, number>>(r) : null).then(setData).catch(() => {})
   }, [])
   return (
     <CardShell title="Sigstore Verify" icon={Shield} onClick={() => nav('/enterprise/sigstore')}>
@@ -507,7 +507,7 @@ export function SLSAProvenanceCard() {
   const nav = useNavigate()
   const [data, setData] = useState<Record<string, number> | null>(null)
   useEffect(() => {
-    authFetch('/api/v1/compliance/slsa/summary').then(r => r.ok ? r.json() : null).then(setData).catch(() => {})
+    authFetch('/api/v1/compliance/slsa/summary').then(r => r.ok ? safeJson<Record<string, number>>(r) : null).then(setData).catch(() => {})
   }, [])
   return (
     <CardShell title="SLSA Provenance" icon={Lock} onClick={() => nav('/enterprise/slsa')}>
@@ -529,7 +529,7 @@ export function RiskMatrixCard() {
   const nav = useNavigate()
   const [data, setData] = useState<Record<string, number> | null>(null)
   useEffect(() => {
-    authFetch('/api/v1/compliance/erm/risk-matrix/summary').then(r => r.ok ? r.json() : null).then(setData).catch(() => {})
+    authFetch('/api/v1/compliance/erm/risk-matrix/summary').then(r => r.ok ? safeJson<Record<string, number>>(r) : null).then(setData).catch(() => {})
   }, [])
   return (
     <CardShell title="Risk Matrix" icon={Scale} onClick={() => nav('/enterprise/risk-matrix')}>
@@ -551,7 +551,7 @@ export function RiskRegisterCard() {
   const nav = useNavigate()
   const [data, setData] = useState<Record<string, number> | null>(null)
   useEffect(() => {
-    authFetch('/api/v1/compliance/erm/risk-register/summary').then(r => r.ok ? r.json() : null).then(setData).catch(() => {})
+    authFetch('/api/v1/compliance/erm/risk-register/summary').then(r => r.ok ? safeJson<Record<string, number>>(r) : null).then(setData).catch(() => {})
   }, [])
   return (
     <CardShell title="Risk Register" icon={Scale} onClick={() => nav('/enterprise/risk-register')}>
@@ -573,7 +573,7 @@ export function RiskAppetiteCard() {
   const nav = useNavigate()
   const [data, setData] = useState<Record<string, number> | null>(null)
   useEffect(() => {
-    authFetch('/api/v1/compliance/erm/risk-appetite/summary').then(r => r.ok ? r.json() : null).then(setData).catch(() => {})
+    authFetch('/api/v1/compliance/erm/risk-appetite/summary').then(r => r.ok ? safeJson<Record<string, number>>(r) : null).then(setData).catch(() => {})
   }, [])
   return (
     <CardShell title="Risk Appetite" icon={Scale} onClick={() => nav('/enterprise/risk-appetite')}>

--- a/web/src/mocks/handlers.ts
+++ b/web/src/mocks/handlers.ts
@@ -2042,7 +2042,13 @@ export const handlers = [
   // The enterprise compliance dashboards fetch '/api/compliance/<vertical>/<resource>'
   // which slipped through the old catch-all, hit the Netlify SPA fallback,
   // and received index.html (200 OK, text/html) instead of JSON.
-  http.all(/^\/api\//, () => {
+  //
+  // IMPORTANT (#9831): MSW applies regex matchers to the FULL request URL
+  // (e.g. 'https://host/api/compliance/...'), not just the path. An anchored
+  // pattern like /^\/api\// never matches because the URL starts with the
+  // protocol. Drop the `^` anchor so the regex matches '/api/' anywhere in
+  // the URL.
+  http.all(/\/api\//, () => {
     return HttpResponse.json(
       { error: 'not available in demo mode' },
       { status: 503 },


### PR DESCRIPTION
Fixes #9831

## Summary

Two fixes flagged by Copilot review on PR #9814:

### 1. `safeJson()` wired into enterprise API fetches

`safeJson()` was introduced in #9797 as defense-in-depth for HTML responses (Netlify SPA fallback returning `index.html`), but had no callers in `web/src`. Switched all 19 enterprise compliance card fetches in `EnterpriseComplianceCards.tsx` from `response.json()` to `safeJson(response)`.

Now when an enterprise dashboard API returns HTML instead of JSON, callers get a descriptive error (`Expected JSON response but received text/html...`) rather than a cryptic `Unexpected token '<'` parse error.

### 2. MSW catch-all regex fixed

`http.all(/^\/api\//, ...)` in `handlers.ts:2045` was anchored to the start of the string, but MSW v2 applies regex matchers to the full request URL (including protocol + host), so the anchored pattern never matched anything.

Changed to `http.all(/\/api\//, ...)` so the regex matches `/api/` anywhere in the URL.

## Test plan

- [ ] CI build/lint pass
- [ ] Verify enterprise compliance cards still render in demo mode (MSW catch-all returns JSON 503 instead of passing through)
- [ ] Verify enterprise compliance cards still render in production (safeJson is a drop-in replacement for `.json()` when Content-Type is application/json)