### PR TITLE
perf: apply React efficiency improvements to flagged components

### DIFF
--- a/web/src/components/ui/CloudProviderIcon.tsx
+++ b/web/src/components/ui/CloudProviderIcon.tsx
@@ -206,6 +206,11 @@ const CoreWeaveIcon: React.FC<{ size: number; className?: string }> = ({ size, c
   </svg>
 )
 
+// Hoisted style object — keeping it out of render avoids allocating a new
+// object on every render (auto-qa flagged inline style objects as re-render
+// triggers).
+const KIND_ICON_STYLE: React.CSSProperties = { objectFit: 'contain' }
+
 // Kind icon - official logo (ship in bottle)
 const KindIcon: React.FC<{ size: number; className?: string }> = ({ size, className }) => (
   <img
@@ -214,7 +219,7 @@ const KindIcon: React.FC<{ size: number; className?: string }> = ({ size, classN
     width={size}
     height={size}
     className={className}
-    style={{ objectFit: 'contain' }}
+    style={KIND_ICON_STYLE}
   />
 )
 

--- a/web/src/components/ui/ProgressRing.tsx
+++ b/web/src/components/ui/ProgressRing.tsx
@@ -2,6 +2,7 @@
  * Subtle progress ring — shows scan progress as a circular indicator.
  * Used across compliance cards to show cluster-checking progress.
  */
+import { memo } from 'react'
 
 /** Full circle circumference for a unit circle (r=1), scaled at render time */
 const TWO_PI = 2 * Math.PI
@@ -16,7 +17,9 @@ interface ProgressRingProps {
   className?: string
 }
 
-export function ProgressRing({
+// Wrapped in memo — all props are primitives so shallow compare is safe and
+// avoids re-renders when parent re-renders without changing progress values.
+export const ProgressRing = memo(function ProgressRing({
   progress,
   size = 16,
   strokeWidth = 2,
@@ -62,4 +65,4 @@ export function ProgressRing({
       />
     </svg>
   )
-}
+})

--- a/web/src/components/ui/RefreshIndicator.tsx
+++ b/web/src/components/ui/RefreshIndicator.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef } from 'react'
+import { memo, useState, useEffect, useRef } from 'react'
 import { RefreshCw, Clock, AlertTriangle } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 import { cn } from '../../lib/cn'
@@ -32,8 +32,11 @@ interface RefreshIndicatorProps {
  * - Idle: Shows clock icon with "Updated Xs ago"
  * - Refreshing: Shows spinning refresh icon with "Updating" label
  * - Stale: Shows amber clock icon with warning styling
+ *
+ * Wrapped in memo — all props are primitives / Date, so shallow compare is
+ * safe and avoids re-rendering this leaf on every parent re-render tick.
  */
-export function RefreshIndicator({
+export const RefreshIndicator = memo(function RefreshIndicator({
   isRefreshing,
   lastUpdated,
   className,
@@ -115,7 +118,7 @@ export function RefreshIndicator({
       )}
     </span>
   )
-}
+})
 
 // Button variant for manual refresh with failure state
 interface RefreshButtonProps {
@@ -232,8 +235,9 @@ export function RefreshButton({
   )
 }
 
-// Simple spinning indicator without button (for inline use)
-export function RefreshSpinner({
+// Simple spinning indicator without button (for inline use).
+// Wrapped in memo — all props are primitives so shallow compare is safe.
+export const RefreshSpinner = memo(function RefreshSpinner({
   isRefreshing,
   size = 'md',
   className = '',
@@ -274,4 +278,4 @@ export function RefreshSpinner({
   return (
     <RefreshCw className={`${sizeClasses} text-blue-400 animate-spin-min ${className}`} />
   )
-}
+})


### PR DESCRIPTION
Fixes #9847

Targeted a small, low-risk slice of the auto-qa efficiency findings.

## What changed

- `ProgressRing` (ui/ProgressRing.tsx) — wrapped in `React.memo`. All props are primitives (`progress`, `size`, `strokeWidth`, `className`), so shallow compare is safe. This leaf is rendered inside ~7 compliance cards that re-render frequently.
- `RefreshIndicator` (ui/RefreshIndicator.tsx) — wrapped in `React.memo`. Props are primitives + `Date | null`. Used in ~25 card components.
- `RefreshSpinner` (ui/RefreshIndicator.tsx) — wrapped in `React.memo`. Primitive props only.
- `KindIcon` inline `style={{ objectFit: 'contain' }}` — hoisted to module-level `KIND_ICON_STYLE` constant so it is not re-allocated on every render.

## What was intentionally skipped

Per the issue's own guidance ("Do NOT memo-wrap components with children props or context consumers where shallow compare won't help"):

- `StatusBadge`, `FeatureHintTooltip` — accept `children` / `ReactNode` props or take uncached callbacks from parents (shallow compare defeated).
- `AccessibleStatusBadge`/`Text` — consume `useAccessibility()` context.
- `AlertBadge`, `RefreshButton` — consume multiple contexts (`useAlerts`, `useMissions`, etc.) and/or take inline callback props.
- Test files flagged for `import * as fs from 'node:fs'` — that's intentional Node namespace import style in test utilities, not a tree-shaking concern.

## Size

3 files changed, 21 insertions, 9 deletions — well under the "size S" 50-line guidance.

## Test plan

- [ ] CI build + lint pass
- [ ] Existing `RefreshIndicator.test.tsx` and `ProgressRing.test.tsx` still pass (they use `render()`, not `typeof === 'function'`, so they're compatible with `memo`-wrapped exports)
- [ ] Storybook meta types (`Meta<typeof RefreshIndicator>`, `Meta<typeof ProgressRing>`) still resolve correctly