### PR TITLE
fix: wire Security page tabs to distinct content per tab

### DIFF
--- a/web/src/components/security/Security.tsx
+++ b/web/src/components/security/Security.tsx
@@ -991,7 +991,7 @@ export function Security() {
       </div>
 
       {/* Tab content rendered immediately below tab buttons so each tab shows
-          distinct content (Fixes #9856). */}
+          distinct content. */}
       <div className="mb-6">
         {tabContent}
       </div>

--- a/web/src/components/security/Security.tsx
+++ b/web/src/components/security/Security.tsx
@@ -324,133 +324,61 @@ export function Security() {
 
   const getStatValue = (blockId: string) => createMergedStatValueGetter(getDashboardStatValue, getUniversalStatValue)(blockId)
 
-  // Tabs section (rendered between stats and cards)
-  const tabsSection = (
-    <>
-      {/* Error Banner */}
-      {refreshError && (
-        <div className="mb-6 p-4 rounded-lg bg-red-500/10 border border-red-500/20 text-red-400 flex items-center gap-3">
-          <AlertTriangle className="w-5 h-5 shrink-0" />
-          <div className="flex-1">
-            <p className="font-medium">{t('cards:security.refreshFailed')}</p>
-            <p className="text-sm text-red-300/80">{refreshError}</p>
+  // Per-tab content. Issue 9856: previously this lived in `children` of
+  // `DashboardPage`, which renders BELOW the dashboard cards section. The static
+  // "Security Cards" section between the tab buttons and this content made
+  // every tab look identical (the cards section never changed). Defined here
+  // and rendered inside `tabsSection` (via `beforeCards`) so the active tab's
+  // content appears immediately under the tab buttons.
+  const tabContent = forceSkeletonForOffline ? (
+    <div className="space-y-6">
+      {/* Quick Stats Skeleton */}
+      <div className="grid grid-cols-4 gap-4">
+        {[1, 2, 3, 4].map((i) => (
+          <div key={i} className="glass p-4 rounded-lg">
+            <div className="flex items-center gap-3">
+              <Skeleton variant="circular" width={40} height={40} />
+              <div>
+                <Skeleton variant="text" width={60} height={28} className="mb-1" />
+                <Skeleton variant="text" width={80} height={12} />
+              </div>
+            </div>
           </div>
-          <button
-            onClick={handleRefresh}
-            className="px-3 py-1.5 rounded-lg bg-red-500/20 hover:bg-red-500/30 text-red-300 text-sm font-medium transition-colors"
-          >
-            {t('common:common.retry')}
-          </button>
-        </div>
-      )}
-
-      {/* Tabs */}
-      <div className="flex gap-1 mb-6 border-b border-border">
-        {[
-          { id: 'overview', label: t('cards:security.overview'), icon: Shield },
-          { id: 'issues', label: t('cards:security.issues'), icon: ShieldAlert, count: stats.total },
-          { id: 'rbac', label: t('cards:security.rbac'), icon: Users, count: stats.rbacTotal },
-          { id: 'compliance', label: t('cards:security.compliance'), icon: ShieldCheck },
-        ].map(tab => {
-          const Icon = tab.icon
-          return (
-            <button
-              key={tab.id}
-              onClick={() => setActiveTab(tab.id as ViewTab)}
-              className={cn(
-                'flex items-center gap-2 px-4 py-2 text-sm font-medium border-b-2 mb-[-2px] transition-colors',
-                activeTab === tab.id
-                  ? 'border-purple-500 text-purple-400'
-                  : 'border-transparent text-muted-foreground hover:text-foreground'
-              )}
-            >
-              <Icon className="w-4 h-4" />
-              {tab.label}
-              {tab.count !== undefined && tab.count > 0 && (
-                <span className={cn(
-                  'px-1.5 py-0.5 text-xs rounded-full',
-                  tab.id === 'issues' && stats.high > 0 ? 'bg-red-500/20 text-red-400' : 'bg-card text-muted-foreground'
-                )}>
-                  {tab.count}
-                </span>
-              )}
-            </button>
-          )
-        })}
+        ))}
       </div>
-    </>
-  )
-
-  return (
-    <DashboardPage
-      title={t('common:navigation.security')}
-      subtitle={t('cards:security.subtitle')}
-      icon="Shield"
-      rightExtra={<RotatingTip page="security" />}
-      storageKey={SECURITY_CARDS_KEY}
-      defaultCards={DEFAULT_SECURITY_CARDS}
-      statsType="security"
-      getStatValue={getStatValue}
-      onRefresh={handleRefresh}
-      isLoading={false}
-      isRefreshing={securityLoading || dataRefreshing || securityRefreshing}
-      lastUpdated={lastUpdated}
-      hasData={stats.total > 0 || securityIssues.length > 0}
-      beforeCards={tabsSection}
-      emptyState={{
-        title: t('cards:security.securityDashboard'),
-        description: t('cards:security.emptyDescription') }}
-    >
-      {/* Show skeleton when agent is offline and demo mode is OFF */}
-      {forceSkeletonForOffline ? (
-        <div className="space-y-6">
-          {/* Quick Stats Skeleton */}
-          <div className="grid grid-cols-4 gap-4">
-            {[1, 2, 3, 4].map((i) => (
-              <div key={i} className="glass p-4 rounded-lg">
-                <div className="flex items-center gap-3">
-                  <Skeleton variant="circular" width={40} height={40} />
-                  <div>
-                    <Skeleton variant="text" width={60} height={28} className="mb-1" />
+      {/* Charts Skeleton */}
+      <div className="grid grid-cols-3 gap-4">
+        {[1, 2, 3].map((i) => (
+          <div key={i} className="glass p-4 rounded-lg">
+            <Skeleton variant="text" width={100} height={16} className="mb-4" />
+            <div className="flex justify-center">
+              <Skeleton variant="circular" width={150} height={150} />
+            </div>
+          </div>
+        ))}
+      </div>
+      {/* Lists Skeleton */}
+      <div className="grid grid-cols-2 gap-4">
+        {[1, 2].map((i) => (
+          <div key={i} className="glass p-4 rounded-lg">
+            <Skeleton variant="text" width={120} height={16} className="mb-4" />
+            <div className="space-y-2">
+              {[1, 2, 3].map((j) => (
+                <div key={j} className="flex items-center gap-3 p-2 rounded bg-secondary/20">
+                  <Skeleton variant="circular" width={16} height={16} />
+                  <div className="flex-1">
+                    <Skeleton variant="text" width={150} height={14} className="mb-1" />
                     <Skeleton variant="text" width={80} height={12} />
                   </div>
                 </div>
-              </div>
-            ))}
+              ))}
+            </div>
           </div>
-          {/* Charts Skeleton */}
-          <div className="grid grid-cols-3 gap-4">
-            {[1, 2, 3].map((i) => (
-              <div key={i} className="glass p-4 rounded-lg">
-                <Skeleton variant="text" width={100} height={16} className="mb-4" />
-                <div className="flex justify-center">
-                  <Skeleton variant="circular" width={150} height={150} />
-                </div>
-              </div>
-            ))}
-          </div>
-          {/* Lists Skeleton */}
-          <div className="grid grid-cols-2 gap-4">
-            {[1, 2].map((i) => (
-              <div key={i} className="glass p-4 rounded-lg">
-                <Skeleton variant="text" width={120} height={16} className="mb-4" />
-                <div className="space-y-2">
-                  {[1, 2, 3].map((j) => (
-                    <div key={j} className="flex items-center gap-3 p-2 rounded bg-secondary/20">
-                      <Skeleton variant="circular" width={16} height={16} />
-                      <div className="flex-1">
-                        <Skeleton variant="text" width={150} height={14} className="mb-1" />
-                        <Skeleton variant="text" width={80} height={12} />
-                      </div>
-                    </div>
-                  ))}
-                </div>
-              </div>
-            ))}
-          </div>
-        </div>
-      ) : (
-      <>
+        ))}
+      </div>
+    </div>
+  ) : (
+    <>
       {/* Overview Tab */}
       {activeTab === 'overview' && (
         <div className="space-y-6">
@@ -997,8 +925,98 @@ export function Security() {
           })}
         </div>
       )}
-      </>
+    </>
+  )
+
+  // Tabs + tab-specific content (rendered between stats and the dashboard cards
+  // section). Issue 9856: previously the tab buttons lived in `beforeCards` while
+  // the per-tab content was passed via `children` (which renders BELOW the
+  // dashboard cards section). The static "Security Cards" section between the
+  // tabs and the per-tab content made every tab look identical because users
+  // couldn't see the content change. Render tab content directly under the tab
+  // buttons so the active tab's content is the first thing the user sees after
+  // clicking.
+  const tabsSection = (
+    <>
+      {/* Error Banner */}
+      {refreshError && (
+        <div className="mb-6 p-4 rounded-lg bg-red-500/10 border border-red-500/20 text-red-400 flex items-center gap-3">
+          <AlertTriangle className="w-5 h-5 shrink-0" />
+          <div className="flex-1">
+            <p className="font-medium">{t('cards:security.refreshFailed')}</p>
+            <p className="text-sm text-red-300/80">{refreshError}</p>
+          </div>
+          <button
+            onClick={handleRefresh}
+            className="px-3 py-1.5 rounded-lg bg-red-500/20 hover:bg-red-500/30 text-red-300 text-sm font-medium transition-colors"
+          >
+            {t('common:common.retry')}
+          </button>
+        </div>
       )}
-    </DashboardPage>
+
+      {/* Tabs */}
+      <div className="flex gap-1 mb-6 border-b border-border">
+        {[
+          { id: 'overview', label: t('cards:security.overview'), icon: Shield },
+          { id: 'issues', label: t('cards:security.issues'), icon: ShieldAlert, count: stats.total },
+          { id: 'rbac', label: t('cards:security.rbac'), icon: Users, count: stats.rbacTotal },
+          { id: 'compliance', label: t('cards:security.compliance'), icon: ShieldCheck },
+        ].map(tab => {
+          const Icon = tab.icon
+          return (
+            <button
+              key={tab.id}
+              onClick={() => setActiveTab(tab.id as ViewTab)}
+              className={cn(
+                'flex items-center gap-2 px-4 py-2 text-sm font-medium border-b-2 mb-[-2px] transition-colors',
+                activeTab === tab.id
+                  ? 'border-purple-500 text-purple-400'
+                  : 'border-transparent text-muted-foreground hover:text-foreground'
+              )}
+            >
+              <Icon className="w-4 h-4" />
+              {tab.label}
+              {tab.count !== undefined && tab.count > 0 && (
+                <span className={cn(
+                  'px-1.5 py-0.5 text-xs rounded-full',
+                  tab.id === 'issues' && stats.high > 0 ? 'bg-red-500/20 text-red-400' : 'bg-card text-muted-foreground'
+                )}>
+                  {tab.count}
+                </span>
+              )}
+            </button>
+          )
+        })}
+      </div>
+
+      {/* Tab content rendered immediately below tab buttons so each tab shows
+          distinct content (Fixes #9856). */}
+      <div className="mb-6">
+        {tabContent}
+      </div>
+    </>
+  )
+
+  return (
+    <DashboardPage
+      title={t('common:navigation.security')}
+      subtitle={t('cards:security.subtitle')}
+      icon="Shield"
+      rightExtra={<RotatingTip page="security" />}
+      storageKey={SECURITY_CARDS_KEY}
+      defaultCards={DEFAULT_SECURITY_CARDS}
+      statsType="security"
+      getStatValue={getStatValue}
+      onRefresh={handleRefresh}
+      isLoading={false}
+      isRefreshing={securityLoading || dataRefreshing || securityRefreshing}
+      lastUpdated={lastUpdated}
+      hasData={stats.total > 0 || securityIssues.length > 0}
+      beforeCards={tabsSection}
+      emptyState={{
+        title: t('cards:security.securityDashboard'),
+        description: t('cards:security.emptyDescription') }}
+    />
   )
 }


### PR DESCRIPTION
Fixes #9856

## Problem

On the Security page (`/security`), clicking between the Overview, Issues, RBAC, and Compliance tabs did not appear to change the content. All tabs looked identical, showing the same "Security Cards" section with the ISO 27001 Security Audit and Security Issues cards.

## Root Cause

The tab buttons were rendered via `DashboardPage`'s `beforeCards` slot (between the stats overview and the dashboard cards section), but the per-tab content (Overview / Issues / RBAC / Compliance) was passed as `children`, which `DashboardPage` renders BELOW the dashboard cards section.

Because the static "Security Cards" section sat between the tab buttons and the per-tab content — and that cards section never changed — users perceived the tabs as broken. The conditional content WAS being switched correctly, it was just hidden below the cards section and frequently scrolled off-screen.

## Fix

Extract the per-tab content into a `tabContent` variable and render it inside `tabsSection` (the value passed to `beforeCards`), directly underneath the tab buttons. The dashboard cards section now follows the tab content instead of being sandwiched between the tabs and their content.

This preserves all existing per-tab markup verbatim — the only structural change is where it's rendered in the DOM relative to the dashboard cards section.

## Behavior after fix

- Overview tab: shows quick stats grid, distribution charts, recent critical issues, high-risk RBAC, and recommendations
- Issues tab: shows severity stats, type quick-filters, and the full issues list
- RBAC tab: shows RBAC stats and bindings list with risk levels and permissions
- Compliance tab: shows overall compliance score and compliance checks grouped by category

## Test plan

- [ ] Navigate to `/security`, click each tab, confirm content visibly changes between tabs
- [ ] Confirm tab content appears immediately below the tab buttons (above the dashboard cards section)
- [ ] Confirm "Security Cards" section (ISO 27001 + Security Issues + Active Alerts) still renders below the tab content
- [ ] Confirm offline-skeleton state still renders inside the tab content area when agent is disconnected and demo mode is off
- [ ] Confirm cross-tab actions still work (e.g., clicking the "Critical Issues" stat on Overview switches to Issues tab with severity filter applied)