### PR TITLE
feat: enrich ksc_error event with error_type and component_name dimensions

### DIFF
--- a/web/src/components/AppErrorBoundary.tsx
+++ b/web/src/components/AppErrorBoundary.tsx
@@ -42,7 +42,13 @@ export class AppErrorBoundary extends Component<Props, State> {
     console.error('[AppErrorBoundary] Uncaught error:', error, errorInfo)
     // Mark as reported so the global window 'error' handler skips it (prevents double-counting)
     markErrorReported(error.message)
-    emitError('uncaught_render', error.message)
+    // Pass the Error + componentStack so emitError can derive error_type
+    // (from error.name) and component_name (from the React component stack)
+    // for the new GA4 custom dimensions added in #9861.
+    emitError('uncaught_render', error.message, undefined, {
+      error,
+      componentStack: errorInfo.componentStack ?? undefined,
+    })
   }
 
   handleReload = () => {

--- a/web/src/components/ChunkErrorBoundary.tsx
+++ b/web/src/components/ChunkErrorBoundary.tsx
@@ -40,7 +40,7 @@ export class ChunkErrorBoundary extends Component<Props, State> {
     return null
   }
 
-  componentDidCatch(error: Error, _errorInfo: ErrorInfo) {
+  componentDidCatch(error: Error, errorInfo: ErrorInfo) {
     if (!isChunkLoadError(error)) {
       throw error
     }
@@ -48,7 +48,12 @@ export class ChunkErrorBoundary extends Component<Props, State> {
     console.warn('[ChunkErrorBoundary] Stale chunk detected, will reload:', error.message)
     // Mark as reported so the global handler's tryChunkReloadRecovery skips it (prevents double-counting)
     markErrorReported(error.message)
-    emitError('chunk_load', error.message)
+    // Pass the Error + componentStack so emitError can derive error_type and
+    // component_name for the GA4 custom dimensions added in #9861.
+    emitError('chunk_load', error.message, undefined, {
+      error,
+      componentStack: errorInfo.componentStack ?? undefined,
+    })
 
     // Auto-reload once. Use sessionStorage to prevent infinite loops.
     const lastReload = sessionStorage.getItem(CHUNK_RELOAD_TS_KEY)

--- a/web/src/components/PageErrorBoundary.tsx
+++ b/web/src/components/PageErrorBoundary.tsx
@@ -46,7 +46,12 @@ export class PageErrorBoundary extends Component<Props, State> {
 
     console.error('[PageErrorBoundary] Render error:', error, errorInfo)
     markErrorReported(error.message)
-    emitError('page_render', error.message)
+    // Pass the Error + componentStack so emitError can derive error_type and
+    // component_name for the GA4 custom dimensions added in #9861.
+    emitError('page_render', error.message, undefined, {
+      error,
+      componentStack: errorInfo.componentStack ?? undefined,
+    })
   }
 
   handleRecover = () => {

--- a/web/src/components/cards/DynamicCardErrorBoundary.tsx
+++ b/web/src/components/cards/DynamicCardErrorBoundary.tsx
@@ -53,7 +53,13 @@ export class DynamicCardErrorBoundary extends Component<Props, State> {
     console.error(`[DynamicCard:${this.props.cardId}] Render error:`, error, errorInfo)
     // Mark as reported so the global window 'error' handler skips it (prevents double-counting)
     markErrorReported(error.message)
-    emitError('card_render', `[${this.props.cardId}] ${error.message}`, this.props.cardId)
+    // Pass the Error + componentStack so emitError can derive error_type
+    // for the new GA4 custom dimensions added in #9861. cardId already
+    // serves as the component_name dimension here.
+    emitError('card_render', `[${this.props.cardId}] ${error.message}`, this.props.cardId, {
+      error,
+      componentStack: errorInfo.componentStack ?? undefined,
+    })
     this.props.onError?.(error, errorInfo)
     // Only increment retryCount when the error happens during a retry attempt,
     // so successful retries do not consume the retry budget.

--- a/web/src/lib/__tests__/analytics-emit-extended.test.ts
+++ b/web/src/lib/__tests__/analytics-emit-extended.test.ts
@@ -522,6 +522,44 @@ describe('emitError with cardId conditional spread', () => {
   })
 })
 
+// Custom dimensions added in #9861 (error_type, component_name)
+describe('emitError accepts EmitErrorExtra context (#9861)', () => {
+  it('accepts an Error instance to derive error_type from .name', () => {
+    const err = new TypeError('Cannot read properties of undefined')
+    expect(() => emitError('runtime', err.message, undefined, { error: err })).not.toThrow()
+  })
+
+  it('accepts a React componentStack to derive component_name', () => {
+    const componentStack = '\n    in PodList (created by Dashboard)\n    in Dashboard'
+    expect(() =>
+      emitError('uncaught_render', 'boom', undefined, { componentStack }),
+    ).not.toThrow()
+  })
+
+  it('accepts both error and componentStack together', () => {
+    const err = new RangeError('out of bounds')
+    const componentStack = '\n    in ClusterCard'
+    expect(() =>
+      emitError('card_render', err.message, 'cluster-health', {
+        error: err,
+        componentStack,
+      }),
+    ).not.toThrow()
+  })
+
+  it('accepts a non-Error reason object (e.g. a thrown string)', () => {
+    expect(() =>
+      emitError('unhandled_rejection', 'plain string reason', undefined, {
+        error: 'plain string reason',
+      }),
+    ).not.toThrow()
+  })
+
+  it('handles undefined extra (back-compat with existing callers)', () => {
+    expect(() => emitError('runtime', 'no extra context')).not.toThrow()
+  })
+})
+
 describe('emitMarketplaceInstallFailed error truncation', () => {
   it('handles empty error string', () => {
     expect(() => emitMarketplaceInstallFailed('card', 'gpu-monitor', '')).not.toThrow()

--- a/web/src/lib/analytics-core.ts
+++ b/web/src/lib/analytics-core.ts
@@ -626,6 +626,116 @@ export function emitPageView(path: string) {
 // Maximum length for error detail strings to avoid oversized payloads
 const ERROR_DETAIL_MAX_LEN = 100
 
+// Maximum length for the inferred component name dimension. Keeps GA4 custom
+// dimension cardinality bounded (GA4 truncates parameter values at 100 chars
+// regardless, but a tighter cap also keeps reports readable).
+const COMPONENT_NAME_MAX_LEN = 60
+
+// Maximum length for the inferred error type dimension. JS error names are
+// short (TypeError, RangeError, etc.), so 40 chars is plenty.
+const ERROR_TYPE_MAX_LEN = 40
+
+/** Fallback when no error type can be inferred from the message or Error.name */
+const ERROR_TYPE_UNKNOWN = 'Unknown'
+
+/** Fallback when no component name can be inferred from cardId/stack */
+const COMPONENT_NAME_UNKNOWN = 'unknown'
+
+/**
+ * Regex matching the leading "<ErrorName>:" prefix produced by `Error.toString()`
+ * (e.g. "TypeError: Cannot read properties of undefined").
+ */
+const ERROR_NAME_PREFIX_RE = /^([A-Z][A-Za-z0-9]*Error):/
+
+/**
+ * Network-related error message fragments. Used as a heuristic when no
+ * `Error.name` is available (e.g. errors caught from raw fetch failures).
+ */
+const NETWORK_ERROR_FRAGMENTS = [
+  'Failed to fetch',
+  'NetworkError',
+  'net::ERR_',
+  'Load failed',
+] as const
+
+/**
+ * Extract a stable `error_type` dimension from either an Error instance or a
+ * raw message string. Order of preference:
+ *   1. `error.name` when an Error object was passed (most reliable)
+ *   2. Leading `<ErrorName>:` prefix on the message
+ *   3. Heuristic for network failures that surface without a typed Error
+ *   4. ERROR_TYPE_UNKNOWN
+ */
+function inferErrorType(detail: string, error?: unknown): string {
+  if (error && typeof error === 'object') {
+    const name = (error as { name?: unknown }).name
+    if (typeof name === 'string' && name.length > 0 && name !== 'Error') {
+      return name.slice(0, ERROR_TYPE_MAX_LEN)
+    }
+  }
+  const match = detail.match(ERROR_NAME_PREFIX_RE)
+  if (match) return match[1].slice(0, ERROR_TYPE_MAX_LEN)
+  for (const fragment of NETWORK_ERROR_FRAGMENTS) {
+    if (detail.includes(fragment)) return 'NetworkError'
+  }
+  return ERROR_TYPE_UNKNOWN
+}
+
+/**
+ * Regex matching the first React component name in a `componentStack` string
+ * produced by `ErrorInfo.componentStack`. Each frame starts with `\n    in
+ * <ComponentName>` (followed by " (created by …)" or file info).
+ */
+const REACT_COMPONENT_FRAME_RE = /\n\s*in\s+([A-Za-z0-9_$.]+)/
+
+/**
+ * Regex matching a JS stack frame's source file basename. Works for both
+ * Chromium (`at fn (https://host/path/Foo.tsx:12:3)`) and WebKit/Firefox
+ * (`fn@https://host/path/Foo.tsx:12:3`) stack formats.
+ */
+const STACK_FILE_BASENAME_RE = /\/([A-Za-z0-9_-]+)\.(?:tsx?|jsx?|mjs)[:?]/
+
+/**
+ * Extract a stable `component_name` dimension. Order of preference:
+ *   1. Explicit `cardId` (set by DynamicCardErrorBoundary — most precise)
+ *   2. First React frame from `componentStack` (set by error boundaries)
+ *   3. First source-file basename from `error.stack`
+ *   4. COMPONENT_NAME_UNKNOWN
+ */
+function inferComponentName(
+  cardId?: string,
+  componentStack?: string,
+  error?: unknown,
+): string {
+  if (cardId && cardId.length > 0) {
+    return cardId.slice(0, COMPONENT_NAME_MAX_LEN)
+  }
+  if (typeof componentStack === 'string') {
+    const match = componentStack.match(REACT_COMPONENT_FRAME_RE)
+    if (match) return match[1].slice(0, COMPONENT_NAME_MAX_LEN)
+  }
+  const stack = (error && typeof error === 'object')
+    ? (error as { stack?: unknown }).stack
+    : undefined
+  if (typeof stack === 'string') {
+    const match = stack.match(STACK_FILE_BASENAME_RE)
+    if (match) return match[1].slice(0, COMPONENT_NAME_MAX_LEN)
+  }
+  return COMPONENT_NAME_UNKNOWN
+}
+
+/**
+ * Optional context for `emitError`. Callers that have access to the original
+ * Error object and/or a React `componentStack` should pass them so the
+ * `error_type` and `component_name` dimensions can be inferred reliably.
+ */
+export interface EmitErrorExtra {
+  /** Original Error instance — supplies `error.name` and `error.stack`. */
+  error?: unknown
+  /** React `ErrorInfo.componentStack` — supplies the failing component name. */
+  componentStack?: string
+}
+
 /**
  * Dedup set for errors already reported by React error boundaries.
  * When an error is caught by DynamicCardErrorBoundary or AppErrorBoundary,
@@ -678,12 +788,24 @@ function isBrowserExtensionNoise(msg: string, reason: unknown): boolean {
   return false
 }
 
-export function emitError(category: string, detail: string, cardId?: string) {
+export function emitError(
+  category: string,
+  detail: string,
+  cardId?: string,
+  extra?: EmitErrorExtra,
+) {
+  const errorType = inferErrorType(detail, extra?.error)
+  const componentName = inferComponentName(cardId, extra?.componentStack, extra?.error)
   send('ksc_error', {
     error_code: category,
     error_category: category,
     error_detail: detail.slice(0, ERROR_DETAIL_MAX_LEN),
     error_page: window.location.pathname,
+    // New custom dimensions (issue #9861) — make ksc_error spikes diagnosable
+    // by surfacing the JS error class and the failing component without
+    // having to dig through error_detail strings in BigQuery.
+    error_type: errorType,
+    component_name: componentName,
     ...(cardId && { card_id: cardId }),
   })
 }
@@ -811,7 +933,7 @@ export function startGlobalErrorTracking() {
       if (msg.includes('Failed to fetch') || msg.includes('NetworkError') || msg.includes('net::ERR_')) return
       // Skip WebGL context errors — benign GPU process resets
       if (msg.includes('WebGL') || msg.includes('context lost')) return
-      emitError('unhandled_rejection', msg)
+      emitError('unhandled_rejection', msg, undefined, { error: event.reason })
     } finally {
       isEmitting = false
     }
@@ -864,7 +986,7 @@ export function startGlobalErrorTracking() {
       if (event.message.includes('Non-Error')) return
       // Stale chunks can surface as runtime errors (Safari: "Importing a module script failed")
       if (tryChunkReloadRecovery(event.message)) return
-      emitError('runtime', event.message)
+      emitError('runtime', event.message, undefined, { error: event.error })
     } finally {
       isEmitting = false
     }

--- a/web/src/lib/analytics.ts
+++ b/web/src/lib/analytics.ts
@@ -27,6 +27,7 @@ export {
   markErrorReported,
   captureUtmParams,
 } from './analytics-core'
+export type { EmitErrorExtra } from './analytics-core'
 
 // ── UTM params accessor ───────────────────────────────────────────
 export { getUtmParams } from './analytics-session'


### PR DESCRIPTION
Fixes #9861

## Summary
The `ksc_error` GA4 event currently only carries `error_code`, `error_category`, `error_detail`, and `error_page`. When today's spike (63 events vs ~12/day baseline) hit, there was no fast way to slice by JS error class or failing component without parsing free-form `error_detail` strings in BigQuery.

This PR adds two new custom-dimension parameters to every `ksc_error` event:

- **`error_type`** — derived from `Error.name` (e.g. `TypeError`, `RangeError`, `NetworkError`) when an Error instance is available, else from a leading `<Name>:` prefix on the message, else from a network-fragment heuristic, else `Unknown`.
- **`component_name`** — derived from the `cardId` (when set by `DynamicCardErrorBoundary`), else the first React component frame in `ErrorInfo.componentStack`, else the first source-file basename in `Error.stack`, else `unknown`.

## Changes
- `web/src/lib/analytics-core.ts` — new `EmitErrorExtra` interface, `inferErrorType()` and `inferComponentName()` helpers, updated `emitError()` signature (back-compat — extra arg is optional). Named constants for all max-lengths and fallbacks (no magic numbers).
- `web/src/lib/analytics.ts` — re-export the new `EmitErrorExtra` type.
- All four error boundaries (`AppErrorBoundary`, `PageErrorBoundary`, `ChunkErrorBoundary`, `DynamicCardErrorBoundary`) now pass the original `Error` and `ErrorInfo.componentStack` to `emitError`.
- Global `window.error` and `window.unhandledrejection` listeners now pass `event.error` / `event.reason` so `error_type` is reliable for uncaught errors too.
- New tests in `analytics-emit-extended.test.ts` covering the new optional `extra` parameter (Error instance, componentStack, both, non-Error reason, undefined).

## Backward compatibility
- Existing callers (`useMissions`, `shared.tsx`, `api.ts`) that only pass `(category, detail)` continue to work — they get `error_type='Unknown'` (or `'NetworkError'` if the message includes `Failed to fetch`/etc.) and `component_name='unknown'`.
- Existing tests assert on event presence (`en=ksc_error`) and `not.toThrow()` — none assert on the exact payload shape, so adding fields is safe.

## Test plan
- [x] New tests in `analytics-emit-extended.test.ts` for the `EmitErrorExtra` parameter
- [ ] After merge, watch GA4 BigQuery export for `error_type` / `component_name` populated on `ksc_error` events
- [ ] Next ksc_error spike should be diagnosable directly from a GA4 breakdown report