### PR TITLE
fix: assert 4-arg emitError call in DynamicCardErrorBoundary test

### DIFF
--- a/web/src/components/cards/__tests__/DynamicCardErrorBoundary.test.tsx
+++ b/web/src/components/cards/__tests__/DynamicCardErrorBoundary.test.tsx
@@ -153,10 +153,18 @@ describe('DynamicCardErrorBoundary', () => {
       </DynamicCardErrorBoundary>,
     )
     expect(markErrorReported).toHaveBeenCalledWith('TSX execution crash')
+    // Source now passes a 4th `extra` arg with { error, componentStack } so
+    // emitError can populate the GA4 error_type / component_name dimensions
+    // added in #9861. vitest's toHaveBeenCalledWith is strict on arity, so the
+    // assertion must include all 4 args.
     expect(emitError).toHaveBeenCalledWith(
       'card_render',
       '[analytics-card] TSX execution crash',
       'analytics-card',
+      expect.objectContaining({
+        error: expect.objectContaining({ message: 'TSX execution crash' }),
+        componentStack: expect.any(String),
+      }),
     )
   })
 })


### PR DESCRIPTION
Fixes #9868

The DynamicCardErrorBoundary source was updated (in PR #9864 / #9861) to pass a 4th `extra` argument to `emitError(category, detail, cardId, { error, componentStack })` so the GA4 `error_type` and `component_name` custom dimensions populate from React error boundaries. The test assertion in `DynamicCardErrorBoundary.test.tsx > emits analytics error when a crash occurs` still asserted only the first 3 arguments. vitest's `toHaveBeenCalledWith` is strict on arity, so the test failed once the source started passing 4 args.

This PR updates the assertion to include the 4th argument via `expect.objectContaining({ error, componentStack })`. Production behavior is unchanged — this is a test-only fix.