### PR TITLE
fix: harden CORS origin validation in Netlify functions

### DIFF
--- a/web/netlify/functions/affiliate-clicks.mts
+++ b/web/netlify/functions/affiliate-clicks.mts
@@ -75,11 +75,14 @@ const ALLOWED_ORIGINS = [
 
 function corsOrigin(origin: string | null): string {
   if (!origin) return ALLOWED_ORIGINS[0];
-  if (
-    ALLOWED_ORIGINS.some((o) => origin === o) ||
-    origin.endsWith(".kubestellar.io")
-  ) {
-    return origin;
+  if (ALLOWED_ORIGINS.includes(origin)) return origin;
+  try {
+    const host = new URL(origin).hostname.toLowerCase();
+    if (host === "kubestellar.io" || host.endsWith(".kubestellar.io")) {
+      return origin;
+    }
+  } catch {
+    // Malformed origin — fall through to default
   }
   return ALLOWED_ORIGINS[0];
 }

--- a/web/netlify/functions/github-pipelines.mts
+++ b/web/netlify/functions/github-pipelines.mts
@@ -190,10 +190,16 @@ interface HistoryDay {
 
 function corsOrigin(origin: string | null): string {
   if (!origin) return ALLOWED_ORIGINS[0];
-  if (ALLOWED_ORIGINS.some((o) => origin === o) || origin.endsWith(".kubestellar.io")) {
-    return origin;
+  if (ALLOWED_ORIGINS.includes(origin)) return origin;
+  try {
+    const host = new URL(origin).hostname.toLowerCase();
+    if (host === "kubestellar.io" || host.endsWith(".kubestellar.io")) {
+      return origin;
+    }
+    if (host === "localhost") return origin;
+  } catch {
+    // Malformed origin — fall through to default
   }
-  if (origin.startsWith("http://localhost:")) return origin;
   return ALLOWED_ORIGINS[0];
 }
 


### PR DESCRIPTION
## Summary
- `affiliate-clicks.mts` and `github-pipelines.mts` used raw `origin.endsWith(".kubestellar.io")` to validate CORS origins
- This accepts crafted origins like `evil-kubestellar.io` because the string suffix matches without verifying it's a subdomain
- Same vulnerability class as CodeQL `js/incomplete-url-substring-sanitization` (#9119), already fixed in `bonus-points.mts`

## Fix
Parse the origin URL and check the parsed hostname instead of raw string matching. Follows the pattern from `bonus-points.mts`:
```ts
const host = new URL(origin).hostname.toLowerCase();
if (host === "kubestellar.io" || host.endsWith(".kubestellar.io")) { ... }
```

## Files changed
- `web/netlify/functions/affiliate-clicks.mts` — replaced raw `endsWith` with URL-parsed hostname check
- `web/netlify/functions/github-pipelines.mts` — same fix, preserved localhost passthrough

## Test plan
- [x] `npm run build` passes
- [ ] Verify CORS headers on console.kubestellar.io deploy preview
- [ ] Verify `evil-kubestellar.io` origin is rejected

🤖 Generated with [Claude Code](https://claude.com/claude-code)