### PR TITLE
fix(cards): standardize red/green color shades per design system (fixes #9881)

### DIFF
--- a/web/src/components/cards/HardwareHealthCard.tsx
+++ b/web/src/components/cards/HardwareHealthCard.tsx
@@ -455,12 +455,13 @@ export function HardwareHealthCard() {
         </div>
       )}
       {/* Status Summary */}
+      {/* #9881 — Normalize tile backgrounds to the design-system pattern (bg-*-500/10 + border-*-500/20). */}
       <div className="grid grid-cols-2 @md:grid-cols-3 gap-1.5 @md:gap-2 mb-4">
         <div className={cn(
           'p-2 rounded-lg border',
           criticalCount > 0
-            ? 'bg-red-500/20 border-red-500/20'
-            : 'bg-green-500/20 border-green-500/20'
+            ? 'bg-red-500/10 border-red-500/20'
+            : 'bg-green-500/10 border-green-500/20'
         )}>
           <div className="text-xl font-bold text-foreground">{criticalCount}</div>
           <div className={cn('text-2xs', criticalCount > 0 ? 'text-red-400' : 'text-green-400')}>
@@ -470,8 +471,8 @@ export function HardwareHealthCard() {
         <div className={cn(
           'p-2 rounded-lg border',
           warningCount > 0
-            ? 'bg-yellow-500/20 border-yellow-500/20'
-            : 'bg-green-500/20 border-green-500/20'
+            ? 'bg-yellow-500/10 border-yellow-500/20'
+            : 'bg-green-500/10 border-green-500/20'
         )}>
           <div className="text-xl font-bold text-foreground">{warningCount}</div>
           <div className={cn('text-2xs', warningCount > 0 ? 'text-yellow-400' : 'text-green-400')}>

--- a/web/src/components/cards/ProactiveGPUNodeHealthMonitor.tsx
+++ b/web/src/components/cards/ProactiveGPUNodeHealthMonitor.tsx
@@ -47,10 +47,12 @@ const CHECK_LABELS: Record<string, string> = {
   gpu_events: 'GPU Events' }
 
 function StatusBadge({ status }: { status: string }) {
+  // #9881 — Normalize status colors to the design-system pattern
+  // (text-*-400 with bg-*-500/10) used across cilium_status and other cards.
   const config = {
-    healthy: { icon: CheckCircle, bg: 'bg-green-500/15', text: 'text-green-400', label: 'Healthy' },
-    degraded: { icon: AlertTriangle, bg: 'bg-yellow-500/15', text: 'text-yellow-400', label: 'Degraded' },
-    unhealthy: { icon: XCircle, bg: 'bg-red-500/15', text: 'text-red-400', label: 'Unhealthy' } }[status] || { icon: AlertTriangle, bg: 'bg-gray-500/15 dark:bg-gray-400/15', text: 'text-muted-foreground', label: status }
+    healthy: { icon: CheckCircle, bg: 'bg-green-500/10', text: 'text-green-400', label: 'Healthy' },
+    degraded: { icon: AlertTriangle, bg: 'bg-yellow-500/10', text: 'text-yellow-400', label: 'Degraded' },
+    unhealthy: { icon: XCircle, bg: 'bg-red-500/10', text: 'text-red-400', label: 'Unhealthy' } }[status] || { icon: AlertTriangle, bg: 'bg-gray-500/10 dark:bg-gray-400/10', text: 'text-muted-foreground', label: status }
 
   const Icon = config.icon
   return (
@@ -525,11 +527,12 @@ function ProactiveGPUNodeHealthMonitorInternal() {
     <div className="flex flex-col gap-2 h-full">
       {/* Summary row */}
       <div className="flex gap-2">
-        <div className={cn('flex-1 rounded-lg px-3 py-2 text-center', summary.unhealthy > 0 ? 'bg-red-500/15 ring-1 ring-red-500/30' : 'bg-secondary')}>
+        {/* #9881 — Normalize summary backgrounds to the /10 bg + /20 ring pattern used by cilium_status. */}
+        <div className={cn('flex-1 rounded-lg px-3 py-2 text-center', summary.unhealthy > 0 ? 'bg-red-500/10 ring-1 ring-red-500/20' : 'bg-secondary')}>
           <div className={cn('text-lg font-bold', summary.unhealthy > 0 ? 'text-red-400' : 'text-white/30')}>{summary.unhealthy}</div>
           <div className="text-2xs text-white/40 uppercase tracking-wider">{t('cards:gpuNodeHealth.unhealthy')}</div>
         </div>
-        <div className={cn('flex-1 rounded-lg px-3 py-2 text-center', summary.degraded > 0 ? 'bg-yellow-500/15 ring-1 ring-yellow-500/30' : 'bg-secondary')}>
+        <div className={cn('flex-1 rounded-lg px-3 py-2 text-center', summary.degraded > 0 ? 'bg-yellow-500/10 ring-1 ring-yellow-500/20' : 'bg-secondary')}>
           <div className={cn('text-lg font-bold', summary.degraded > 0 ? 'text-yellow-400' : 'text-white/30')}>{summary.degraded}</div>
           <div className="text-2xs text-white/40 uppercase tracking-wider">{t('cards:gpuNodeHealth.degraded')}</div>
         </div>

--- a/web/src/components/cards/workload-detection/ProwStatus.tsx
+++ b/web/src/components/cards/workload-detection/ProwStatus.tsx
@@ -38,7 +38,8 @@ export function ProwStatus({ config: _config }: ProwStatusProps) {
     <div className="h-full flex flex-col min-h-card">
       {/* Status badge */}
       <div className="flex flex-wrap items-center justify-between gap-y-2 mb-4">
-        <span className={`text-xs px-1.5 py-0.5 rounded ${status.healthy ? 'bg-green-500/20 text-green-400' : 'bg-red-500/20 text-red-400'}`}>
+        {/* #9881 — Align status badge shades with design-system pattern (bg-*-500/10 + text-*-400 + border-*-500/20). */}
+        <span className={`text-xs px-1.5 py-0.5 rounded border ${status.healthy ? 'bg-green-500/10 text-green-400 border-green-500/20' : 'bg-red-500/10 text-red-400 border-red-500/20'}`}>
           {status.healthy ? 'Healthy' : 'Unhealthy'}
         </span>
         <RefreshIndicator

--- a/web/src/components/dashboard/CardFactoryModal.tsx
+++ b/web/src/components/dashboard/CardFactoryModal.tsx
@@ -564,7 +564,8 @@ export function CardFactoryModal({ isOpen, onClose, onCardCreated, embedded = fa
   const [t1Layout, setT1Layout] = useState<'list' | 'stats' | 'stats-and-list'>('list')
   const [t1Columns, setT1Columns] = useState<DynamicCardColumn[]>([
     { field: 'name', label: 'Name' },
-    { field: 'status', label: 'Status', format: 'badge', badgeColors: { healthy: 'bg-green-500/20 text-green-400', error: 'bg-red-500/20 text-red-400' } },
+    // #9881 — Use design-system default shade (bg-*-500/10 + text-*-400) so generated cards match built-in cards.
+    { field: 'status', label: 'Status', format: 'badge', badgeColors: { healthy: 'bg-green-500/10 text-green-400', error: 'bg-red-500/10 text-red-400' } },
   ])
   const [t1DataJson, setT1DataJson] = useState(T1_SAMPLE_DATA_JSON)
   // #9061 — Track whether the user has already focused the JSON textarea


### PR DESCRIPTION
Fixes #9881

Normalizes status color shades (red-400/green-400 for text; red-500/10, green-500/10 for bg) across a few Auto-QA flagged cards to align with existing design-system patterns.

Scoped to 3-5 files; additional Auto-QA findings can be addressed in follow-up PRs per Auto-QA's size-S guidance.