### PR TITLE
test(jaeger): fix failing JaegerStatus + useCachedJaegerStatus tests (fixes #9886)

### DIFF
--- a/web/src/components/cards/jaeger_status/__tests__/JaegerStatus.test.tsx
+++ b/web/src/components/cards/jaeger_status/__tests__/JaegerStatus.test.tsx
@@ -1,47 +1,119 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { render, screen, waitFor } from '@testing-library/react'
+import { render, screen } from '@testing-library/react'
 import '@testing-library/jest-dom'
-import { JaegerStatus } from '../index'
 import React from 'react'
 
 // Mock i18next
 vi.mock('react-i18next', () => ({
     useTranslation: () => ({ t: (k: string) => k }),
+    Trans: ({ children }: { children: React.ReactNode }) => children,
 }))
 
-// Mock custom hooks
+// Mock the cached-data hook
 const mockUseCachedJaegerStatus = vi.fn()
 vi.mock('../../../../hooks/useCachedData', () => ({
     useCachedJaegerStatus: () => mockUseCachedJaegerStatus(),
 }))
 
+// Mock useGlobalFilters — the card itself calls selectedClusters; cardHooks.useCardData
+// also uses this hook internally and needs a fuller shape (customFilter, filter helpers, ...).
 vi.mock('../../../../hooks/useGlobalFilters', () => ({
-    useGlobalFilters: () => ({ selectedClusters: [] }),
+    useGlobalFilters: () => ({
+        selectedClusters: [],
+        setSelectedClusters: vi.fn(),
+        toggleCluster: vi.fn(),
+        selectAllClusters: vi.fn(),
+        deselectAllClusters: vi.fn(),
+        isAllClustersSelected: true,
+        isClustersFiltered: false,
+        availableClusters: [],
+        clusterInfoMap: {},
+        clusterGroups: [],
+        addClusterGroup: vi.fn(),
+        updateClusterGroup: vi.fn(),
+        deleteClusterGroup: vi.fn(),
+        selectClusterGroup: vi.fn(),
+        selectedSeverities: [],
+        setSelectedSeverities: vi.fn(),
+        toggleSeverity: vi.fn(),
+        selectAllSeverities: vi.fn(),
+        deselectAllSeverities: vi.fn(),
+        isAllSeveritiesSelected: true,
+        isSeveritiesFiltered: false,
+        selectedStatuses: [],
+        setSelectedStatuses: vi.fn(),
+        toggleStatus: vi.fn(),
+        selectAllStatuses: vi.fn(),
+        deselectAllStatuses: vi.fn(),
+        isAllStatusesSelected: true,
+        isStatusesFiltered: false,
+        selectedDistributions: [],
+        toggleDistribution: vi.fn(),
+        selectAllDistributions: vi.fn(),
+        deselectAllDistributions: vi.fn(),
+        isAllDistributionsSelected: true,
+        isDistributionsFiltered: false,
+        availableDistributions: [],
+        customFilter: '',
+        setCustomFilter: vi.fn(),
+        clearCustomFilter: vi.fn(),
+        hasCustomFilter: false,
+        isFiltered: false,
+        clearAllFilters: vi.fn(),
+        savedFilterSets: [],
+        saveCurrentFilters: vi.fn(),
+        applySavedFilterSet: vi.fn(),
+        deleteSavedFilterSet: vi.fn(),
+        activeFilterSetId: null,
+        filterByCluster: <T,>(items: T[]) => items,
+        filterBySeverity: <T,>(items: T[]) => items,
+        filterByStatus: <T,>(items: T[]) => items,
+        filterByCustomText: <T,>(items: T[]) => items,
+        filterItems: <T,>(items: T[]) => items,
+    }),
 }))
 
 vi.mock('../../../../hooks/useDrillDown', () => ({
     useDrillDownActions: () => ({ drillToNode: vi.fn() }),
 }))
 
-vi.mock('../../../../hooks/useCardLoadingState', () => ({
+// Mock useCardLoadingState from CardDataContext (the actual import path used by index.tsx)
+vi.mock('../../CardDataContext', () => ({
     useCardLoadingState: () => ({
         showSkeleton: false,
-        showSpinner: false,
-        showEmpty: false,
-        showError: false,
-        isInteractive: true,
+        showEmptyState: false,
+        hasData: true,
+        isRefreshing: false,
     }),
+    useReportCardDataState: vi.fn(),
 }))
 
-vi.mock('../../../../hooks/useCardData', () => ({
-    useCardData: () => ({
-        data: null,
-        error: null,
-        isLoading: false,
-        isRefreshing: false,
-        refetch: vi.fn(),
-    }),
-}))
+// Mock useCardData from lib/cards — the card imports it as `from '../../../lib/cards'`,
+// which re-exports from `lib/cards/cardHooks.ts`.
+vi.mock('../../../../lib/cards', async (importOriginal) => {
+    const actual = (await importOriginal()) as Record<string, unknown>
+    return {
+        ...actual,
+        useCardData: (items: unknown[]) => ({
+            items: items || [],
+            totalItems: (items || []).length,
+            currentPage: 1,
+            totalPages: 1,
+            itemsPerPage: 4,
+            goToPage: vi.fn(),
+            setItemsPerPage: vi.fn(),
+            needsPagination: false,
+            sorting: {
+                sortBy: 'name',
+                setSortBy: vi.fn(),
+                sortDirection: 'asc' as const,
+                setSortDirection: vi.fn(),
+            },
+            containerRef: { current: null },
+            containerStyle: {},
+        }),
+    }
+})
 
 // Mock CardControls and other UI components to avoid dependency issues
 vi.mock('../../../ui/CardControls', () => ({
@@ -55,6 +127,8 @@ vi.mock('../../../ui/StatusBadge', () => ({
 vi.mock('../../../ui/RefreshIndicator', () => ({
     RefreshIndicator: () => <div data-testid="refresh-indicator" />,
 }))
+
+import { JaegerStatus } from '../index'
 
 describe('JaegerStatus', () => {
     beforeEach(() => {

--- a/web/src/hooks/useCachedJaegerStatus.test.ts
+++ b/web/src/hooks/useCachedJaegerStatus.test.ts
@@ -1,28 +1,54 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { renderHook } from '@testing-library/react'
-import { useCachedJaegerStatus } from './useCachedJaegerStatus'
 
-// Mock useCache
+// Mock useCache (the hook wraps this)
 const mockUseCache = vi.fn()
-vi.mock('./useCache', () => ({
+vi.mock('../lib/cache', () => ({
     useCache: (options: any) => mockUseCache(options),
 }))
 
-// Mock demo mode
-let mockIsDemoMode = false
-vi.mock('../lib/demoMode', () => ({
-    isDemoMode: () => mockIsDemoMode,
+// Mock useDemoMode — the hook actually imports `useDemoMode` from `./useDemoMode`,
+// NOT `isDemoMode` directly from `../lib/demoMode`. Mocking `../lib/demoMode` would
+// break transitive imports (e.g. `isNetlifyDeployment` is used by `hooks/mcp/shared.ts`).
+const mockIsDemoMode = vi.fn(() => false)
+vi.mock('./useDemoMode', () => ({
+    useDemoMode: () => ({ isDemoMode: mockIsDemoMode() }),
+    isDemoModeForced: () => false,
+    canToggleDemoMode: () => true,
+    isNetlifyDeployment: () => false,
+    isDemoToken: () => false,
+    hasRealToken: () => true,
+    setDemoToken: vi.fn(),
+    getDemoMode: () => false,
+    setGlobalDemoMode: vi.fn(),
 }))
 
-// Mock demo data
+// Mock demo data for the jaeger status hook
 vi.mock('./useCachedData/demoData', () => ({
-    getDemoJaegerStatus: () => ({ status: 'Healthy', version: 'demo-1.0' }),
+    getDemoJaegerStatus: () => ({
+        status: 'Healthy',
+        version: 'demo-1.0',
+        collectors: { count: 1, status: 'Healthy', items: [] },
+        query: { status: 'Healthy' },
+        metrics: {
+            servicesCount: 0,
+            tracesLastHour: 0,
+            dependenciesCount: 0,
+            avgLatencyMs: 0,
+            p95LatencyMs: 0,
+            p99LatencyMs: 0,
+            spansDroppedLastHour: 0,
+            avgQueueLength: 0,
+        },
+    }),
 }))
+
+import { useCachedJaegerStatus } from './useCachedJaegerStatus'
 
 describe('useCachedJaegerStatus', () => {
     beforeEach(() => {
         vi.clearAllMocks()
-        mockIsDemoMode = false
+        mockIsDemoMode.mockReturnValue(false)
         mockUseCache.mockReturnValue({
             data: { status: 'Healthy', version: '1.57.0' },
             isLoading: false,
@@ -42,7 +68,7 @@ describe('useCachedJaegerStatus', () => {
     })
 
     it('returns demo data when in demo mode', () => {
-        mockIsDemoMode = true
+        mockIsDemoMode.mockReturnValue(true)
         const { result } = renderHook(() => useCachedJaegerStatus())
         expect(result.current.data.version).toBe('demo-1.0')
         expect(result.current.isDemoData).toBe(true)


### PR DESCRIPTION
Fixes #9886

Follows up on #9878 (Jaeger card merge) to fix 4 test failures detected in Coverage Suite run #1375:
- JaegerStatus.test.tsx × 3 assertions
- useCachedJaegerStatus.test.ts (failed to load)

## Root causes

**JaegerStatus.test.tsx**: `TypeError: Cannot read properties of undefined (reading 'trim')` at `src/lib/cards/cardHooks.ts:246`. The test mocked `useGlobalFilters` with only `selectedClusters`, but `useCardData` (used internally by the card via `lib/cards/cardHooks.ts`) reads `customFilter`, `filterByCluster`, `filterByStatus`, and more from the same context. The test also mocked non-existent paths (`hooks/useCardData`, `hooks/useCardLoadingState`) so those mocks had no effect — the real `useCardData` ran against an incomplete context mock.

**useCachedJaegerStatus.test.ts**: `No "isNetlifyDeployment" export is defined on the "../lib/demoMode" mock`. The test mocked `../lib/demoMode` with only `isDemoMode`, but transitively-loaded modules (`hooks/mcp/shared.ts`, `hooks/useCachedData/agentFetchers.ts`) import `isNetlifyDeployment` from the same module, which became undefined and crashed at module-load time.

## Fix

Both tests now follow established patterns from sibling tests:
- `JaegerStatus.test.tsx` — follows `KServeStatus.test.tsx`: mock `CardDataContext` for `useCardLoadingState`, mock `lib/cards` (with `importOriginal` spread) for `useCardData`, and provide a complete `useGlobalFilters` shape.
- `useCachedJaegerStatus.test.ts` — follows `useCachedCiliumStatus.test.ts`: mock `./useDemoMode` (what the hook actually consumes) instead of `../lib/demoMode`, preserving transitive `isNetlifyDeployment` resolution.

Only test files are touched; production code in `jaeger_status/index.tsx` and `useCachedJaegerStatus.ts` is unchanged.