### PR TITLE
fix(ui): guard array iteration against undefined in core components (fixes #9889)

### DIFF
--- a/web/src/components/cards/AppStatus.tsx
+++ b/web/src/components/cards/AppStatus.tsx
@@ -67,7 +67,8 @@ export function AppStatus(_props: AppStatusProps) {
   const rawApps = useMemo((): AppData[] => {
     const appMap = new Map<string, AppData>()
 
-    deployments.forEach(dep => {
+    // Guard against undefined hook return (malformed API response) per CLAUDE.md array safety rule (#9889).
+    ;(deployments || []).forEach(dep => {
       const key = dep.name
       if (!appMap.has(key)) {
         appMap.set(key, {
@@ -221,7 +222,7 @@ export function AppStatus(_props: AppStatusProps) {
         <div className="flex items-center justify-center h-full text-muted-foreground text-sm">
           No workloads found
         </div>
-      ) : apps.map((app, idx) => {
+      ) : (apps || []).map((app, idx) => {
         const total = app.status.healthy + app.status.warning + app.status.pending
 
         return (
@@ -284,7 +285,7 @@ export function AppStatus(_props: AppStatusProps) {
 
             {/* Cluster badges */}
             <div className="flex flex-wrap gap-1 mt-2 overflow-hidden">
-              {app.clusters.map((cluster) => (
+              {(app.clusters || []).map((cluster) => (
                 <ClusterBadge key={cluster} cluster={cluster} showIcon={false} />
               ))}
             </div>

--- a/web/src/components/cards/NamespaceOverview.tsx
+++ b/web/src/components/cards/NamespaceOverview.tsx
@@ -91,15 +91,18 @@ export function NamespaceOverview({ config }: NamespaceOverviewProps) {
     }
   }, [selectedCluster, selectedNamespace, namespaces])
 
-  // Filter by namespace
+  // Filter by namespace. Guard hook return values against undefined
+  // (malformed API response) per CLAUDE.md array safety rule (#9889).
   const podIssues = (() => {
-    if (!selectedNamespace) return allPodIssues
-    return allPodIssues.filter(p => p.namespace === selectedNamespace)
+    const safeAllPodIssues = allPodIssues || []
+    if (!selectedNamespace) return safeAllPodIssues
+    return safeAllPodIssues.filter(p => p.namespace === selectedNamespace)
   })()
 
   const deploymentIssues = (() => {
-    if (!selectedNamespace) return allDeploymentIssues
-    return allDeploymentIssues.filter(d => d.namespace === selectedNamespace)
+    const safeAllDeploymentIssues = allDeploymentIssues || []
+    if (!selectedNamespace) return safeAllDeploymentIssues
+    return safeAllDeploymentIssues.filter(d => d.namespace === selectedNamespace)
   })()
 
   const cluster = clusters.find(c => c.name === selectedCluster)
@@ -178,7 +181,7 @@ export function NamespaceOverview({ config }: NamespaceOverviewProps) {
           title={t('cards:namespaceOverview.selectClusterTitle')}
         >
           <option value="">{t('selectors.selectCluster')}</option>
-          {clusters.map(c => (
+          {(clusters || []).map(c => (
             <option key={c.name} value={c.name}>{c.name}</option>
           ))}
         </select>
@@ -190,7 +193,7 @@ export function NamespaceOverview({ config }: NamespaceOverviewProps) {
           title={selectedCluster ? t('cards:namespaceOverview.selectNamespaceTitle') : t('cards:namespaceOverview.selectClusterFirst')}
         >
           <option value="">{t('selectors.selectNamespace')}</option>
-          {namespaces.map(ns => (
+          {(namespaces || []).map(ns => (
             <option key={ns} value={ns}>{ns}</option>
           ))}
         </select>

--- a/web/src/pages/Welcome.tsx
+++ b/web/src/pages/Welcome.tsx
@@ -29,10 +29,12 @@ const META_DESCRIPTION =
 /*  so they stay in sync as the codebase evolves.                      */
 /* ------------------------------------------------------------------ */
 
-/** Total unique dashboards = default sidebar + discoverable dashboards */
+/** Total unique dashboards = default sidebar + discoverable dashboards.
+ * Guard against undefined imports (e.g. a malformed chunk during HMR) per
+ * CLAUDE.md array safety rule (#9889). */
 const TOTAL_DASHBOARDS = new Set([
-  ...DEFAULT_PRIMARY_NAV.map(d => d.id),
-  ...DISCOVERABLE_DASHBOARDS.map(d => d.id),
+  ...(DEFAULT_PRIMARY_NAV || []).map(d => d.id),
+  ...(DISCOVERABLE_DASHBOARDS || []).map(d => d.id),
 ]).size
 
 const HERO_STATS_PLACEHOLDER = '…'


### PR DESCRIPTION
Fixes #9889

Adds `(array || [])` fallback guards around `.map()` / `.filter()` / `.forEach()` calls in core components where hooks/API data can return undefined, per CLAUDE.md's mandatory array-safety rule.

Scoped to the clearest cases in AppStatus.tsx / Welcome.tsx (issue focus). Broader audit can follow up.