### PR TITLE
fix(api): persist audit log entries for GPU/mission mutations (fixes #9890)

### DIFF
--- a/pkg/api/audit/audit.go
+++ b/pkg/api/audit/audit.go
@@ -40,6 +40,12 @@ const (
 	ActionUserLogin  = "user_login"
 	ActionUserLogout = "user_logout"
 	ActionAuthFailed = "auth_failed"
+
+	// Phase 3 (#9890): GPU reservation and mission mutations.
+	ActionCreateGPUReservation = "create_gpu_reservation"
+	ActionUpdateGPUReservation = "update_gpu_reservation"
+	ActionDeleteGPUReservation = "delete_gpu_reservation"
+	ActionShareMissionGitHub   = "share_mission_github"
 )
 
 // storeMu guards the package-level store reference.

--- a/pkg/api/handlers/gpu.go
+++ b/pkg/api/handlers/gpu.go
@@ -11,6 +11,7 @@ import (
 	"github.com/gofiber/fiber/v2"
 	"github.com/google/uuid"
 
+	"github.com/kubestellar/console/pkg/api/audit"
 	"github.com/kubestellar/console/pkg/api/middleware"
 	"github.com/kubestellar/console/pkg/models"
 	"github.com/kubestellar/console/pkg/store"
@@ -141,6 +142,10 @@ func (h *GPUHandler) CreateReservation(c *fiber.Ctx) error {
 		}
 		return fiber.NewError(fiber.StatusInternalServerError, "Failed to create reservation")
 	}
+
+	// #9890: persist audit entry after successful mutation.
+	audit.Log(c, audit.ActionCreateGPUReservation, "gpu_reservation", reservation.ID.String(),
+		fmt.Sprintf("cluster=%s namespace=%s gpus=%d", reservation.Cluster, reservation.Namespace, reservation.GPUCount))
 
 	return c.Status(fiber.StatusCreated).JSON(reservation)
 }
@@ -381,12 +386,19 @@ func (h *GPUHandler) UpdateReservation(c *fiber.Ctx) error {
 			}
 			return fiber.NewError(fiber.StatusInternalServerError, "Failed to update reservation")
 		}
+		// #9890: persist audit entry after successful mutation.
+		audit.Log(c, audit.ActionUpdateGPUReservation, "gpu_reservation", existing.ID.String(),
+			fmt.Sprintf("cluster=%s namespace=%s gpus=%d status=%s", existing.Cluster, existing.Namespace, existing.GPUCount, existing.Status))
 		return c.JSON(existing)
 	}
 
 	if err := h.store.UpdateGPUReservation(c.UserContext(), existing); err != nil {
 		return fiber.NewError(fiber.StatusInternalServerError, "Failed to update reservation")
 	}
+
+	// #9890: persist audit entry after successful mutation.
+	audit.Log(c, audit.ActionUpdateGPUReservation, "gpu_reservation", existing.ID.String(),
+		fmt.Sprintf("cluster=%s namespace=%s gpus=%d status=%s", existing.Cluster, existing.Namespace, existing.GPUCount, existing.Status))
 
 	return c.JSON(existing)
 }
@@ -419,6 +431,10 @@ func (h *GPUHandler) DeleteReservation(c *fiber.Ctx) error {
 	if err := h.store.DeleteGPUReservation(c.UserContext(), id); err != nil {
 		return fiber.NewError(fiber.StatusInternalServerError, "Failed to delete reservation")
 	}
+
+	// #9890: persist audit entry after successful mutation.
+	audit.Log(c, audit.ActionDeleteGPUReservation, "gpu_reservation", existing.ID.String(),
+		fmt.Sprintf("cluster=%s namespace=%s gpus=%d", existing.Cluster, existing.Namespace, existing.GPUCount))
 
 	return c.JSON(fiber.Map{"status": "ok"})
 }

--- a/pkg/api/handlers/missions.go
+++ b/pkg/api/handlers/missions.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/gofiber/fiber/v2"
 
+	"github.com/kubestellar/console/pkg/api/audit"
 	"github.com/kubestellar/console/pkg/settings"
 )
 
@@ -1353,6 +1354,10 @@ func (h *MissionsHandler) ShareToGitHub(c *fiber.Ctx) error {
 	if prHTMLURL == "" {
 		return c.Status(502).JSON(fiber.Map{"error": "GitHub PR response missing html_url"})
 	}
+
+	// #9890: persist audit entry after successful external PR creation.
+	audit.Log(c, audit.ActionShareMissionGitHub, "mission", req.FilePath,
+		fmt.Sprintf("repo=%s branch=%s fork=%s pr=%s", req.Repo, req.Branch, forkFullName, prHTMLURL))
 
 	return c.JSON(fiber.Map{
 		"success": true,


### PR DESCRIPTION
Fixes #9890

Adds audit_log persistence to handlers that were previously bypassing it. Scoped to 2-3 mutation endpoints to keep review manageable; additional coverage can follow in subsequent PRs.