### PR TITLE
test(jaeger): align JaegerStatus test assertions with rendered output (fixes #9897)

### DIFF
--- a/web/src/components/cards/jaeger_status/__tests__/JaegerStatus.test.tsx
+++ b/web/src/components/cards/jaeger_status/__tests__/JaegerStatus.test.tsx
@@ -133,6 +133,8 @@ import { JaegerStatus } from '../index'
 describe('JaegerStatus', () => {
     beforeEach(() => {
         vi.clearAllMocks()
+        // Use unique numeric values for each metric so getByText('<number>')
+        // resolves to exactly one element in the rendered DOM.
         mockUseCachedJaegerStatus.mockReturnValue({
             data: {
                 status: 'Healthy',
@@ -144,14 +146,14 @@ describe('JaegerStatus', () => {
                 },
                 query: { status: 'Healthy' },
                 metrics: {
-                    servicesCount: 10,
-                    tracesLastHour: 100,
-                    dependenciesCount: 5,
-                    avgLatencyMs: 10,
-                    p95LatencyMs: 20,
-                    p99LatencyMs: 30,
-                    spansDroppedLastHour: 5,
-                    avgQueueLength: 12
+                    servicesCount: 11,
+                    tracesLastHour: 101,
+                    dependenciesCount: 6,
+                    avgLatencyMs: 13,
+                    p95LatencyMs: 23,
+                    p99LatencyMs: 33,
+                    spansDroppedLastHour: 7,
+                    avgQueueLength: 14,
                 }
             },
             isLoading: false,
@@ -167,13 +169,15 @@ describe('JaegerStatus', () => {
     it('renders Jaeger title and metrics', async () => {
         render(<JaegerStatus />)
         expect(await screen.findByText('jaeger.title')).toBeInTheDocument()
-        expect(screen.getByText('10')).toBeInTheDocument()
+        // servicesCount: 11 — unique value, rendered in the MetricTile for jaeger.services
+        expect(screen.getByText('11')).toBeInTheDocument()
     })
 
     it('renders health KPIs', async () => {
         render(<JaegerStatus />)
         expect(await screen.findByText('jaeger.dropped')).toBeInTheDocument()
-        expect(screen.getByText('5')).toBeInTheDocument()
+        // spansDroppedLastHour: 7 — unique value, rendered in the KPIField for jaeger.dropped
+        expect(screen.getByText('7')).toBeInTheDocument()
     })
 
     it('renders collectors list', async () => {


### PR DESCRIPTION
Fixes #9897

Follow-up to #9888: the 'title and metrics' and 'health KPIs' tests still assert on text that doesn't appear uniquely in the rendered DOM.

## Root cause
The mock data had duplicate numeric values across different metric fields:
- `servicesCount: 10` and `avgLatencyMs: 10` both rendered as "10"
- `dependenciesCount: 5` and `spansDroppedLastHour: 5` both rendered as "5"

`screen.getByText('10')` and `screen.getByText('5')` therefore threw `Found multiple elements with the text`.

## Fix
Changed the mock metrics to use unique numeric values per field and updated the two failing assertions to match the uniquely-rendered numbers (`11` for servicesCount, `7` for spansDroppedLastHour). Production code and the third test (`renders collectors list`) are unchanged.