### PR TITLE
fix(auth): enforce /auth/refresh contract (fixes #9904)

### DIFF
--- a/.github/workflows/auth-login-smoke.yml
+++ b/.github/workflows/auth-login-smoke.yml
@@ -59,17 +59,27 @@ jobs:
           echo $! > /tmp/backend.pid
 
       # ── 3. Wait for health ───────────────────────────────────────
+      # Wait for the REAL backend (status=ok), not the loading server.
+      # The temporary loading server returns HTTP 503 with body
+      # {"status":"starting"} while the real Fiber app is still
+      # initializing (#9904). Previously `curl -sf` accepted any 2xx and
+      # the suite raced ahead to /auth/github before the real routes were
+      # registered — the loading page's catch-all `/` handler answered
+      # with HTTP 200 + HTML, which looked like a broken auth contract
+      # but was actually the loading page. Assert status=ok explicitly.
       - name: Wait for backend health
         run: |
-          MAX_WAIT_SECONDS=30
+          MAX_WAIT_SECONDS=60
           for i in $(seq 1 "$MAX_WAIT_SECONDS"); do
-            if curl -sf http://localhost:8081/health > /dev/null 2>&1; then
-              echo "Backend healthy after ${i}s"
+            RESP=$(curl -sS --max-time 2 http://localhost:8081/health 2>/dev/null || true)
+            STATUS=$(echo "$RESP" | jq -r '.status // empty' 2>/dev/null || echo "")
+            if [ "$STATUS" = "ok" ]; then
+              echo "Backend healthy (status=ok) after ${i}s"
               exit 0
             fi
             sleep 1
           done
-          echo "::error::Backend did not become healthy within ${MAX_WAIT_SECONDS}s"
+          echo "::error::Backend did not reach status=ok within ${MAX_WAIT_SECONDS}s"
           exit 1
 
       # ── 4. Test /health returns JSON with expected fields ────────

--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -375,10 +375,24 @@ func NewServer(cfg Config) (*Server, error) {
 
 // startLoadingServer starts a temporary HTTP server that serves a loading page.
 // It returns immediately — the server runs in a background goroutine.
+//
+// The loading server intentionally returns HTTP 503 (Service Unavailable) on
+// /health while the real Fiber app is still initializing. This matters for
+// readiness probes, smoke tests, and `curl -sf` style checks (#9904): without
+// it, callers think the backend is ready as soon as the loading page binds,
+// race ahead to real API routes like /auth/github, and get the loading HTML
+// back with HTTP 200 — which looks like a broken auth contract but is
+// actually the loading page's catch-all `/` handler answering the request.
+// A 503 on /health forces probes to keep polling until the real server is up.
 func startLoadingServer(addr string) *http.Server {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/health", func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
+		// 503 + Retry-After tells orchestrators and smoke tests the backend is
+		// not ready yet. The body still describes the state for human debugging.
+		const loadingHealthRetryAfterSec = "1"
+		w.Header().Set("Retry-After", loadingHealthRetryAfterSec)
+		w.WriteHeader(http.StatusServiceUnavailable)
 		w.Write([]byte(`{"status":"starting"}`))
 	})
 	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {

--- a/pkg/api/server_test.go
+++ b/pkg/api/server_test.go
@@ -1,10 +1,71 @@
 package api
 
 import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
+
+// loadingServerTestTimeout bounds all HTTP calls in the loading-server test
+// so a hung server cannot stall CI.
+const loadingServerTestTimeout = 2 * time.Second
+
+// loadingServerShutdownTimeout bounds the graceful shutdown of the test's
+// loading server.
+const loadingServerShutdownTimeout = 1 * time.Second
+
+// TestLoadingServer_HealthReturns503 enforces the #9904 regression guard:
+// while the backend is still initializing, the temporary loading server
+// MUST report /health as HTTP 503 so readiness probes, `curl -sf`, and the
+// auth-login smoke test keep polling until the real Fiber app is up.
+//
+// Before this contract was in place, the loading server's /health returned
+// HTTP 200 + {"status":"starting"}; smoke tests accepted that as "ready",
+// immediately hit /auth/github, and got HTTP 200 back from the loading
+// page's catch-all `/` handler — which looked like a broken auth contract
+// but was actually just the loading page answering. Keeping /health at 503
+// during init ensures the smoke test never races past the loading phase.
+func TestLoadingServer_HealthReturns503(t *testing.T) {
+	// Bind to an ephemeral port so parallel test runs don't collide.
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err, "must be able to reserve a loopback port")
+	port := ln.Addr().(*net.TCPAddr).Port
+	ln.Close()
+
+	addr := fmt.Sprintf("127.0.0.1:%d", port)
+	srv := startLoadingServer(addr)
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), loadingServerShutdownTimeout)
+		defer cancel()
+		_ = srv.Shutdown(ctx)
+	})
+
+	client := &http.Client{Timeout: loadingServerTestTimeout}
+	resp, err := client.Get("http://" + addr + "/health")
+	require.NoError(t, err, "loading server must answer /health")
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusServiceUnavailable, resp.StatusCode,
+		"loading /health must return 503 while backend is initializing (#9904)")
+	assert.NotEmpty(t, resp.Header.Get("Retry-After"),
+		"loading /health must include Retry-After so clients back off (#9904)")
+
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	var parsed map[string]string
+	require.NoError(t, json.Unmarshal(body, &parsed),
+		"loading /health body must be JSON: %s", string(body))
+	assert.Equal(t, "starting", parsed["status"],
+		"loading /health body must report status=starting for UX/debugging")
+}
 
 // TestHealth_OAuthConfiguredRequiresBothIdAndSecret covers #6056: the
 // /health endpoint must report oauth_configured=true ONLY when BOTH the


### PR DESCRIPTION
Fixes #9904.

## What broke
The hourly `auth-login-smoke` workflow was failing at the **`Get dev-mode auth cookie`** step:

```
Calling GET /auth/github (dev mode login)...
HTTP status: 200 (expect 307 redirect)
::error::Dev-mode login did not set kc_auth cookie
```

At first glance this looks like a `/auth/refresh` contract violation (#6590 / #8107), but the handler (`pkg/api/handlers/auth.go` `RefreshToken`) is already correct: body is `{refreshed: true, onboarded}`, no `token` field, fresh HttpOnly `kc_auth` cookie via `setJWTCookie`. The `TestAuthRefreshContract_*` unit tests still enforce this.

## Real root cause
The temporary **loading server** (`startLoadingServer` in `pkg/api/server.go`) answered `/health` with HTTP 200 + `{"status":"starting"}` while the real Fiber app was still initializing. The smoke test's readiness check used `curl -sf /health`, accepted that 200, raced ahead to `/auth/github`, and got back the loading page's catch-all `/` handler (HTTP 200 + loading HTML). That looked like a broken auth contract but was actually the loading page answering the request before the real routes were registered.

## Fix
- **Loading `/health` now returns HTTP 503 + `Retry-After`** while the backend initializes. Body stays `{"status":"starting"}` for human debugging and for consumers (`cmd/watcher/watcher.go`, `web/src/hooks/useUpdateProgress.ts`) that already parse the status field regardless of status code.
- **Smoke test** now explicitly waits for `status=ok` from the real backend, not any 2xx, and extends the deadline to 60s.
- **New unit test** `TestLoadingServer_HealthReturns503` in `pkg/api/server_test.go` locks the 503 contract so this regression cannot recur.

## Verified-safe consumers of the loading `/health`
| Consumer | Behavior with 503 |
|---|---|
| `cmd/watcher/watcher.go` `checkBackendHealth` | Parses `body.status`, ignores HTTP code — still sees `"starting"` → unhealthy (correct) |
| `web/src/hooks/useUpdateProgress.ts` | Already gates on `resp.ok && data.status === 'ok'` before reporting "done" |

Per #6590 contract enforced by #8107 — the `/auth/refresh` contract itself is unchanged and remains enforced by `TestAuthRefreshContract_TokenNotInResponseBody` / `TestAuthRefreshContract_OnboardedFalse`.