### PR TITLE
fix(playwright-nightly): stabilize flaky cross-browser tests

### DIFF
--- a/web/e2e/helpers/setup.ts
+++ b/web/e2e/helpers/setup.ts
@@ -59,8 +59,11 @@ export const EXPECTED_ERROR_PATTERNS = [
   /blocked by CORS policy/i, // Chromium CORS wording (Firefox uses pattern above)
   /Access to fetch.*has been blocked by CORS/i, // Chromium-specific phrasing; Medium blog public fallback is cross-origin from vite preview (localhost:4173 → console.kubestellar.io)
   /Notification permission/i, // Firefox blocks notification requests outside user gestures
+  /Notification prompting can only be done from a user gesture/i, // WebKit/Safari wording for notification gesture block
   /ERR_CONNECTION_REFUSED/i, // Backend/agent not running in CI
   /net::ERR_/i, // Any network-level Chrome error in demo mode
+  /Could not connect to [0-9.]+/i, // WebKit wording for connection refused (no net:: prefix)
+  /Connection refused/i, // Generic connection refused wording across browsers
   /502.*Bad Gateway/i, // Reverse proxy errors when backend not running
   /Failed to load resource/i, // Generic resource load failures in demo mode
   // SQLite WASM cache worker — webkit/Safari can't streaming-compile the

--- a/web/e2e/responsive-regression.spec.ts
+++ b/web/e2e/responsive-regression.spec.ts
@@ -19,6 +19,17 @@ const VIEWPORTS = [
   { width: 1440, height: 900, name: 'desktop' },
 ]
 
+/** Tolerance in pixels when checking element right-edge overflow. */
+const OVERFLOW_TOLERANCE_PX = 5
+/** Timeout (ms) for root element visibility. */
+const ROOT_VISIBLE_TIMEOUT_MS = 10_000
+/** Minimum body text length to consider the page non-blank. */
+const MIN_BODY_TEXT_LEN = 20
+/** Timeout (ms) for hamburger/sidebar-toggle visibility probe. */
+const MOBILE_NAV_PROBE_TIMEOUT_MS = 5_000
+/** Max viewport width (px) below which mobile/hamburger nav is expected. */
+const MOBILE_NAV_MAX_WIDTH_PX = 1024
+
 const KEY_ROUTES = [
   { path: '/', name: 'Dashboard' },
   { path: '/clusters', name: 'Clusters' },
@@ -55,14 +66,14 @@ test.describe('Responsive Breakpoint Tests', () => {
 
           // Root should be visible
           const root = page.locator('#root')
-          await expect(root).toBeVisible({ timeout: 10000 })
+          await expect(root).toBeVisible({ timeout: ROOT_VISIBLE_TIMEOUT_MS })
 
           // Page should have meaningful content
           const bodyText = await page.textContent('body')
           expect(
             bodyText?.length,
             `${route.path} at ${viewport.name}: blank or near-empty page`
-          ).toBeGreaterThan(20)
+          ).toBeGreaterThan(MIN_BODY_TEXT_LEN)
 
           // Check for horizontal overflow (a common responsive bug)
           const hasOverflow = await page.evaluate(() => {
@@ -77,18 +88,46 @@ test.describe('Responsive Breakpoint Tests', () => {
             )
           }
 
-          // Verify no elements extend beyond viewport width (regression #3035)
-          const overflowingElements = await page.evaluate((vw) => {
-            const elements = document.querySelectorAll('button, .modal, [role="dialog"], nav')
-            const overflowing: string[] = []
-            elements.forEach((el) => {
-              const rect = el.getBoundingClientRect()
-              if (rect.right > vw + 5) { // 5px tolerance
-                overflowing.push(`${el.tagName}.${el.className?.split(' ')[0] || ''} (right: ${Math.round(rect.right)}px)`)
-              }
-            })
-            return overflowing
-          }, viewport.width)
+          // Verify no VISIBLE elements extend beyond viewport width (regression #3035).
+          // Skip elements that are intentionally off-canvas (display:none,
+          // visibility:hidden, aria-hidden, or inside a hidden/closed
+          // dialog/drawer) — those are not user-visible overflow. #9877
+          const overflowingElements = await page.evaluate(
+            ({ vw, tolerance }: { vw: number; tolerance: number }) => {
+              const elements = document.querySelectorAll('button, .modal, [role="dialog"], nav')
+              const overflowing: string[] = []
+              elements.forEach((el) => {
+                const htmlEl = el as HTMLElement
+                const style = window.getComputedStyle(htmlEl)
+                // Skip non-visible elements: they cannot cause user-visible overflow.
+                if (
+                  style.display === 'none' ||
+                  style.visibility === 'hidden' ||
+                  style.opacity === '0' ||
+                  htmlEl.hidden ||
+                  htmlEl.getAttribute('aria-hidden') === 'true'
+                ) {
+                  return
+                }
+                // Skip elements inside a closed/hidden dialog or drawer.
+                if (htmlEl.closest('[aria-hidden="true"], [hidden], [data-state="closed"]')) {
+                  return
+                }
+                const rect = htmlEl.getBoundingClientRect()
+                // Zero-sized elements can't be visually overflowing.
+                if (rect.width === 0 || rect.height === 0) {
+                  return
+                }
+                if (rect.right > vw + tolerance) {
+                  overflowing.push(
+                    `${el.tagName}.${el.className?.split(' ')[0] || ''} (right: ${Math.round(rect.right)}px)`
+                  )
+                }
+              })
+              return overflowing
+            },
+            { vw: viewport.width, tolerance: OVERFLOW_TOLERANCE_PX }
+          )
 
           expect(
             overflowingElements,
@@ -103,12 +142,12 @@ test.describe('Responsive Breakpoint Tests', () => {
         await page.waitForLoadState('domcontentloaded')
 
         // At mobile/tablet, expect a hamburger or sidebar toggle
-        if (viewport.width < 1024) {
+        if (viewport.width < MOBILE_NAV_MAX_WIDTH_PX) {
           const mobileNav = page.locator('[data-testid="mobile-menu-toggle"]')
             .or(page.locator('button[aria-label*="menu" i]'))
             .or(page.locator('[data-testid="sidebar-toggle"]'))
 
-          const hasHamburger = await mobileNav.first().isVisible({ timeout: 5000 }).catch(() => false)
+          const hasHamburger = await mobileNav.first().isVisible({ timeout: MOBILE_NAV_PROBE_TIMEOUT_MS }).catch(() => false)
 
           // Either hamburger menu is present OR nav items are visible
           if (!hasHamburger) {
@@ -122,7 +161,7 @@ test.describe('Responsive Breakpoint Tests', () => {
         } else {
           // On larger viewports, main nav should be visible
           const nav = page.locator('nav')
-          await expect(nav.first()).toBeVisible({ timeout: 5000 })
+          await expect(nav.first()).toBeVisible({ timeout: MOBILE_NAV_PROBE_TIMEOUT_MS })
         }
       })
     })

--- a/web/e2e/smoke.spec.ts
+++ b/web/e2e/smoke.spec.ts
@@ -72,11 +72,53 @@ test.describe('Smoke Tests', () => {
         { text: 'Settings', expectedPath: '/settings' },
       ]
 
+      // Scope to the sidebar (data-testid="sidebar") because the main <nav>
+      // navbar does not contain these route links — they live in the sidebar.
+      // Using a bare `nav` locator matched multiple <nav> elements (navbar +
+      // sidebar section navs) and violated strict mode. #9877
+      const sidebar = page.getByTestId('sidebar')
+
+      // On mobile viewports (<md) the sidebar is rendered off-canvas and must
+      // be opened via the hamburger button before its links are clickable.
+      // #9877
+      const hamburger = page
+        .locator('[data-testid="mobile-menu-toggle"]')
+        .or(page.locator('button[aria-label*="menu" i]'))
+        .first()
+      const viewportSize = page.viewportSize()
+      const MOBILE_SIDEBAR_MAX_WIDTH_PX = 768
+      const HAMBURGER_PROBE_TIMEOUT_MS = 2_000
+      if (viewportSize && viewportSize.width < MOBILE_SIDEBAR_MAX_WIDTH_PX) {
+        const hamburgerVisible = await hamburger
+          .isVisible({ timeout: HAMBURGER_PROBE_TIMEOUT_MS })
+          .catch(() => false)
+        if (hamburgerVisible) {
+          await hamburger.click()
+        }
+      }
+
       for (const { text, expectedPath } of navLinks) {
-        // Use modern locator chain instead of deprecated >> syntax. #9523
-        await page.locator('nav').getByText(text, { exact: true }).click()
+        // Use `.first()` to guard against duplicate renderings (e.g., when a
+        // responsive variant renders both a mobile and desktop label).
+        await sidebar.getByText(text, { exact: true }).first().click()
         await waitForNetworkIdleBestEffort(page, NETWORK_IDLE_TIMEOUT_MS, `nav to ${expectedPath}`)
         expect(page.url()).toContain(expectedPath)
+        // Re-open mobile sidebar if navigation closed it.
+        if (viewportSize && viewportSize.width < MOBILE_SIDEBAR_MAX_WIDTH_PX) {
+          const stillVisible = await sidebar
+            .getByText(text, { exact: true })
+            .first()
+            .isVisible({ timeout: HAMBURGER_PROBE_TIMEOUT_MS })
+            .catch(() => false)
+          if (!stillVisible) {
+            const hamburgerVisible = await hamburger
+              .isVisible({ timeout: HAMBURGER_PROBE_TIMEOUT_MS })
+              .catch(() => false)
+            if (hamburgerVisible) {
+              await hamburger.click()
+            }
+          }
+        }
       }
     })
 
@@ -102,8 +144,10 @@ test.describe('Smoke Tests', () => {
       await waitForNetworkIdleBestEffort(page, NETWORK_IDLE_TIMEOUT_MS, '/settings')
       expect(page.url()).toContain('/settings')
 
-      // Click the logo button (has aria-label "Go to home dashboard")
-      const logoButton = page.locator('nav button[aria-label*="home"]')
+      // Click the logo button (has aria-label "Go to home dashboard").
+      // The navbar renders two such buttons — the logo and the wordmark —
+      // so use .first() to avoid a strict-mode violation. #9877
+      const logoButton = page.locator('nav button[aria-label*="home"]').first()
       await expect(logoButton).toBeVisible()
       await logoButton.click()
 
@@ -226,10 +270,13 @@ test.describe('Smoke Tests', () => {
       await page.goto('/')
       await waitForNetworkIdleBestEffort(page)
 
-      // Check for demo mode badge/indicator
-      const demoIndicator = page.locator('text=/demo/i')
-        .or(page.getByTestId('demo-mode-indicator'))
-        .or(page.locator('[aria-label*="demo"]'))
+      // Check for demo mode badge/indicator. The AgentStatusIndicator also
+      // renders a "Demo Mode" <span> that is hidden on <sm viewports (mobile)
+      // via `hidden sm:inline`; filter to visible matches so the first hit
+      // isn't a hidden element. #9877
+      const demoIndicator = page.locator(':visible').filter({
+        hasText: /demo/i,
+      })
 
       // Assert the demo indicator is visible — a missing indicator is a regression. #9524
       await expect(demoIndicator.first()).toBeVisible({ timeout: OPTIONAL_PROBE_TIMEOUT_MS })


### PR DESCRIPTION
Fixes #9877

## Summary
The nightly Playwright Cross-Browser workflow (`playwright-nightly.yml`) was failing across all four browser jobs (webkit, firefox, mobile-chrome, mobile-safari) in run [24877125837](https://github.com/kubestellar/console/actions/runs/24877125837). This PR diagnoses the root causes and stabilizes the five most impactful failure clusters.

- **webkit console-error noise**: `EXPECTED_ERROR_PATTERNS` missed webkit's wording for "Connection refused" and "Notification prompting can only be done from a user gesture." All 7 `/smoke.spec.ts Route Loading` tests on webkit failed because these emitted as unexpected console errors. Added the missing patterns to `web/e2e/helpers/setup.ts`.
- **`navbar links navigate correctly` strict-mode violation**: `page.locator('nav').getByText('Clusters')` matched both the top `<nav>` navbar and the sidebar's per-section `<nav>` elements. Scoped to `getByTestId('sidebar')` and open the hamburger menu first on mobile viewports where the sidebar is off-canvas.
- **`clicking navbar logo` strict-mode violation**: two buttons carry `aria-label="Go to home dashboard"` (logo + wordmark). Added `.first()`.
- **`demo mode indicator is visible` on mobile**: hit the hidden `AgentStatusIndicator` span (`hidden sm:inline`) before the visible demo banner. Filter to visible matches via `page.locator(':visible').filter({ hasText: /demo/i })`.
- **`responsive-regression` overflow false positive**: flagged `BUTTON.flex (right: 1582px)` at 1440x900, which was an off-canvas / hidden button. Skip elements that are `display:none`, `visibility:hidden`, `aria-hidden`, zero-sized, or inside a closed dialog/drawer.

All magic numbers introduced are named constants with comments per `CLAUDE.md`.

## Test plan
- [ ] nightly Playwright Cross-Browser workflow passes on next scheduled run
- [ ] webkit + firefox + mobile-chrome + mobile-safari smoke Route Loading tests no longer fail on notification/connection-refused console errors
- [ ] `navbar links navigate correctly` passes on mobile-chrome and mobile-safari (sidebar opens via hamburger before click)
- [ ] `clicking navbar logo` passes with strict-mode on (logo + wordmark both present)
- [ ] `demo mode indicator is visible` passes on mobile viewports (visible filter)
- [ ] `responsive-regression` overflow check no longer reports hidden off-canvas buttons