### PR TITLE
fix(security): tighten Netlify Function CORS origins (#9879)

### DIFF
--- a/web/netlify/functions/_shared/cors.ts
+++ b/web/netlify/functions/_shared/cors.ts
@@ -1,0 +1,105 @@
+/**
+ * Shared CORS helper for Netlify Functions.
+ *
+ * Why: OWASP ZAP (issue #9879) flagged "Cross-Domain Misconfiguration" on
+ * production — previously, most of our Netlify Functions responded with a
+ * blanket `Access-Control-Allow-Origin: *`. That is wrong for endpoints
+ * consumed by the console itself, because several frontend hooks (auth,
+ * rewards, persistence, version-check) send `credentials: 'include'`, and
+ * the combination of `*` + credentialed requests is a documented
+ * cross-origin leakage pattern.
+ *
+ * This helper echoes the request origin back only if it matches an
+ * explicit allowlist, and adds `Vary: Origin` so shared caches key
+ * responses per-origin. For disallowed origins, CORS headers are simply
+ * omitted — the browser will still reject the cross-origin read.
+ *
+ * Endpoints that are intentionally cross-origin (shields.io badge
+ * embeddings: acmm-badge, rewards-badge) must NOT use this helper and
+ * may keep their explicit `*` — they are public, unauthenticated, and
+ * designed to be fetched from arbitrary README hosts.
+ */
+
+/** Production origin for the hosted console. */
+const PROD_ORIGIN = "https://console.kubestellar.io";
+
+/** Netlify preview deploys — `{branch}--{sitename}.netlify.app`. */
+const NETLIFY_PREVIEW_RE = /^https:\/\/[a-z0-9-]+--kubestellar-console\.netlify\.app$/i;
+
+/** Netlify branch + PR deploys for the kubestellar console site. */
+const NETLIFY_DEPLOY_RE =
+  /^https:\/\/deploy-preview-\d+--kubestellar-console\.netlify\.app$/i;
+
+/** Local development (Vite default + project-standard port 5174). */
+const LOCALHOST_RE = /^http:\/\/(localhost|127\.0\.0\.1):(5173|5174|8080|8888)$/;
+
+/** Static allowlist of exact-match allowed origins. */
+const ALLOWED_EXACT = new Set<string>([PROD_ORIGIN]);
+
+/**
+ * Return true if the given Origin header value is allowed to make CORS
+ * requests to our Netlify Functions.
+ */
+export function isAllowedOrigin(origin: string | null | undefined): boolean {
+  if (!origin) return false;
+  if (ALLOWED_EXACT.has(origin)) return true;
+  if (NETLIFY_PREVIEW_RE.test(origin)) return true;
+  if (NETLIFY_DEPLOY_RE.test(origin)) return true;
+  if (LOCALHOST_RE.test(origin)) return true;
+  return false;
+}
+
+export interface CorsOptions {
+  /** Allowed HTTP methods, e.g. "GET, OPTIONS" or "POST, OPTIONS". */
+  methods: string;
+  /** Allowed request headers, e.g. "Content-Type, Authorization". */
+  headers?: string;
+  /**
+   * Expose specific response headers to browser JS. Rarely needed.
+   */
+  exposeHeaders?: string;
+}
+
+/**
+ * Build a per-request CORS header set. Only echoes `Access-Control-Allow-Origin`
+ * when the request Origin is on the allowlist; otherwise CORS headers are
+ * omitted entirely. Always sets `X-Content-Type-Options: nosniff` (addresses
+ * a separate low-severity ZAP finding on the same endpoints).
+ */
+export function buildCorsHeaders(
+  request: Request,
+  opts: CorsOptions,
+): Record<string, string> {
+  const headers: Record<string, string> = {
+    "X-Content-Type-Options": "nosniff",
+    Vary: "Origin",
+  };
+
+  const origin = request.headers.get("origin");
+  if (isAllowedOrigin(origin)) {
+    headers["Access-Control-Allow-Origin"] = origin as string;
+    headers["Access-Control-Allow-Methods"] = opts.methods;
+    if (opts.headers) {
+      headers["Access-Control-Allow-Headers"] = opts.headers;
+    }
+    if (opts.exposeHeaders) {
+      headers["Access-Control-Expose-Headers"] = opts.exposeHeaders;
+    }
+  }
+
+  return headers;
+}
+
+/**
+ * Handle a preflight OPTIONS request. Returns a 204 with the CORS headers
+ * if the origin is allowed, or 403 otherwise. Callers should invoke this
+ * at the top of their handler when `request.method === "OPTIONS"`.
+ */
+export function handlePreflight(
+  request: Request,
+  opts: CorsOptions,
+): Response {
+  const origin = request.headers.get("origin");
+  const status = isAllowedOrigin(origin) ? 204 : 403;
+  return new Response(null, { status, headers: buildCorsHeaders(request, opts) });
+}

--- a/web/netlify/functions/acmm-badge.mts
+++ b/web/netlify/functions/acmm-badge.mts
@@ -85,6 +85,11 @@ function corsHeaders(
   const cacheControl = withSWR
     ? `public, max-age=${cacheSeconds}, stale-while-revalidate=86400`
     : `public, max-age=${cacheSeconds}`;
+  // This is a public, unauthenticated, embeddable badge endpoint — the `*`
+  // CORS is intentional so shields.io and any README host (github.com,
+  // raw.githubusercontent.com, pkg.go.dev, crates.io, etc.) can fetch it.
+  // Do NOT tighten this origin (see web/netlify/functions/_shared/cors.ts
+  // for the tightened console-internal endpoints per #9879).
   const headers: Record<string, string> = {
     "Cache-Control": cacheControl,
     "Access-Control-Allow-Origin": "*",

--- a/web/netlify/functions/analytics-dashboard.mts
+++ b/web/netlify/functions/analytics-dashboard.mts
@@ -10,6 +10,7 @@
  */
 
 import { getStore } from "@netlify/blobs";
+import { buildCorsHeaders, handlePreflight } from "./_shared/cors";
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -868,15 +869,20 @@ async function fetchDashboardData(
 // ---------------------------------------------------------------------------
 
 export default async (req: Request) => {
+  // See web/netlify/functions/_shared/cors.ts for allowlist rationale (#9879).
+  const corsOpts = {
+    methods: "GET, OPTIONS",
+    headers: "Content-Type",
+  };
+  /** Browser cache: 15 min — analytics rollups refresh infrequently. */
+  const ANALYTICS_BROWSER_CACHE_S = 900;
   const corsHeaders: Record<string, string> = {
-    "Access-Control-Allow-Origin": "*",
-    "Access-Control-Allow-Methods": "GET, OPTIONS",
-    "Access-Control-Allow-Headers": "Content-Type",
-    "Cache-Control": "public, max-age=900", // 15 min browser cache
+    ...buildCorsHeaders(req, corsOpts),
+    "Cache-Control": `public, max-age=${ANALYTICS_BROWSER_CACHE_S}`,
   };
 
   if (req.method === "OPTIONS") {
-    return new Response(null, { status: 204, headers: corsHeaders });
+    return handlePreflight(req, corsOpts);
   }
 
   // Load service account credentials

--- a/web/netlify/functions/feedback-app.mts
+++ b/web/netlify/functions/feedback-app.mts
@@ -46,6 +46,7 @@
  */
 
 import { createPrivateKey, createSign } from "node:crypto";
+import { buildCorsHeaders, handlePreflight } from "./_shared/cors";
 
 const GITHUB_API = "https://api.github.com";
 /** Only issues on these repos may be created via the proxy. */
@@ -64,6 +65,12 @@ const GH_TIMEOUT_MS = 20_000;
 /** Non-obvious header name for the per-user client credential. */
 const CLIENT_AUTH_HEADER = "x-kc-client-auth";
 
+// See web/netlify/functions/_shared/cors.ts for allowlist rationale (#9879).
+const CORS_OPTS = {
+  methods: "POST, OPTIONS",
+  headers: `Content-Type, ${CLIENT_AUTH_HEADER}`,
+} as const;
+
 interface IssueRequest {
   repoOwner: string;
   repoName: string;
@@ -79,14 +86,16 @@ interface CachedInstallCred {
 
 let cachedInstallCred: CachedInstallCred | null = null;
 
-function jsonResponse(status: number, body: unknown): Response {
+function jsonResponse(
+  request: Request,
+  status: number,
+  body: unknown,
+): Response {
   return new Response(JSON.stringify(body), {
     status,
     headers: {
       "Content-Type": "application/json",
-      "Access-Control-Allow-Origin": "*",
-      "Access-Control-Allow-Headers": `Content-Type, ${CLIENT_AUTH_HEADER}`,
-      "Access-Control-Allow-Methods": "POST, OPTIONS",
+      ...buildCorsHeaders(request, CORS_OPTS),
     },
   });
 }
@@ -247,30 +256,30 @@ async function verifyClientAuth(
 
 export default async function handler(request: Request): Promise<Response> {
   if (request.method === "OPTIONS") {
-    return jsonResponse(204, {});
+    return handlePreflight(request, CORS_OPTS);
   }
   if (request.method !== "POST") {
-    return jsonResponse(405, { error: "Method not allowed" });
+    return jsonResponse(request, 405, { error: "Method not allowed" });
   }
 
   const clientAuth = request.headers.get(CLIENT_AUTH_HEADER);
   if (!clientAuth) {
-    return jsonResponse(401, { error: "Missing client credential" });
+    return jsonResponse(request, 401, { error: "Missing client credential" });
   }
 
   let payload: IssueRequest;
   try {
     payload = (await request.json()) as IssueRequest;
   } catch {
-    return jsonResponse(400, { error: "Invalid JSON body" });
+    return jsonResponse(request, 400, { error: "Invalid JSON body" });
   }
   if (!payload.repoOwner || !payload.repoName || !payload.title || !payload.body) {
-    return jsonResponse(400, { error: "repoOwner, repoName, title, body required" });
+    return jsonResponse(request, 400, { error: "repoOwner, repoName, title, body required" });
   }
 
   const repoSlug = `${payload.repoOwner}/${payload.repoName}`;
   if (!ALLOWED_REPOS.has(repoSlug)) {
-    return jsonResponse(403, { error: `Repo ${repoSlug} not allowed` });
+    return jsonResponse(request, 403, { error: `Repo ${repoSlug} not allowed` });
   }
 
   let user: { login: string; id: number };
@@ -278,7 +287,7 @@ export default async function handler(request: Request): Promise<Response> {
     user = await verifyClientAuth(clientAuth);
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
-    return jsonResponse(401, { error: `Client auth invalid: ${msg}` });
+    return jsonResponse(request, 401, { error: `Client auth invalid: ${msg}` });
   }
 
   let installCred: string;
@@ -286,7 +295,7 @@ export default async function handler(request: Request): Promise<Response> {
     installCred = await getInstallationCred();
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
-    return jsonResponse(502, { error: `App credential unavailable: ${msg}` });
+    return jsonResponse(request, 502, { error: `App credential unavailable: ${msg}` });
   }
 
   // Footer proves which GitHub user the proxy authenticated. Localhost
@@ -322,19 +331,19 @@ export default async function handler(request: Request): Promise<Response> {
     );
     if (!resp.ok) {
       const txt = await resp.text();
-      return jsonResponse(resp.status, {
+      return jsonResponse(request, resp.status, {
         error: `GitHub issue create failed: ${txt}`,
       });
     }
     const data = (await resp.json()) as { number: number; html_url: string };
-    return jsonResponse(200, {
+    return jsonResponse(request, 200, {
       number: data.number,
       html_url: data.html_url,
       submitter: user.login,
     });
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
-    return jsonResponse(502, { error: `Issue creation failed: ${msg}` });
+    return jsonResponse(request, 502, { error: `Issue creation failed: ${msg}` });
   } finally {
     clearTimeout(timeout);
   }

--- a/web/netlify/functions/github-rewards.mts
+++ b/web/netlify/functions/github-rewards.mts
@@ -15,6 +15,7 @@
  */
 
 import { getStore } from "@netlify/blobs";
+import { buildCorsHeaders, handlePreflight } from "./_shared/cors";
 
 const GITHUB_API = "https://api.github.com";
 const CACHE_STORE = "github-rewards";
@@ -195,15 +196,18 @@ async function searchItems(
 // ---------------------------------------------------------------------------
 
 export default async (req: Request) => {
+  // See web/netlify/functions/_shared/cors.ts for allowlist rationale (#9879).
+  const corsOpts = {
+    methods: "GET, OPTIONS",
+    headers: "Content-Type, Authorization, Accept",
+  };
   const corsHeaders = {
-    "Access-Control-Allow-Origin": "*",
-    "Access-Control-Allow-Methods": "GET, OPTIONS",
-    "Access-Control-Allow-Headers": "Content-Type, Authorization, Accept",
+    ...buildCorsHeaders(req, corsOpts),
     "Cache-Control": "no-cache, no-store",
   };
 
   if (req.method === "OPTIONS") {
-    return new Response(null, { status: 204, headers: corsHeaders });
+    return handlePreflight(req, corsOpts);
   }
 
   if (req.method !== "GET") {

--- a/web/netlify/functions/issue-stats.mts
+++ b/web/netlify/functions/issue-stats.mts
@@ -12,6 +12,7 @@
  */
 
 import { getStore } from "@netlify/blobs";
+import { buildCorsHeaders, handlePreflight } from "./_shared/cors";
 
 const GITHUB_API = "https://api.github.com";
 const CACHE_STORE = "issue-stats";
@@ -100,14 +101,15 @@ async function fetchAllPages(
 // ---------------------------------------------------------------------------
 
 export default async function handler(request: Request): Promise<Response> {
-  const corsHeaders = {
-    "Access-Control-Allow-Origin": "*",
-    "Access-Control-Allow-Methods": "GET, OPTIONS",
-    "Access-Control-Allow-Headers": "Content-Type",
+  // See web/netlify/functions/_shared/cors.ts for allowlist rationale (#9879).
+  const corsOpts = {
+    methods: "GET, OPTIONS",
+    headers: "Content-Type",
   };
+  const corsHeaders = buildCorsHeaders(request, corsOpts);
 
   if (request.method === "OPTIONS") {
-    return new Response(null, { status: 204, headers: corsHeaders });
+    return handlePreflight(request, corsOpts);
   }
 
   if (request.method !== "GET") {

--- a/web/netlify/functions/missions-browse.mts
+++ b/web/netlify/functions/missions-browse.mts
@@ -7,6 +7,7 @@
  * No GITHUB_TOKEN required — the repo is public.
  */
 import { getStore } from "@netlify/blobs";
+import { buildCorsHeaders, handlePreflight } from "./_shared/cors";
 
 const GITHUB_API_URL = "https://api.github.com";
 const KB_REPO = "kubestellar/console-kb";
@@ -21,11 +22,11 @@ const CACHE_TTL_MS = 60 * 60 * 1000;
 /** CDN edge cache: tell Netlify CDN to cache successful responses for 10 minutes */
 const CDN_CACHE_MAX_AGE_S = 600;
 
-const CORS_HEADERS: Record<string, string> = {
-  "Access-Control-Allow-Origin": "*",
-  "Access-Control-Allow-Methods": "GET, OPTIONS",
-  "Access-Control-Allow-Headers": "Content-Type",
-};
+// See web/netlify/functions/_shared/cors.ts for allowlist rationale (#9879).
+const CORS_OPTS = {
+  methods: "GET, OPTIONS",
+  headers: "Content-Type",
+} as const;
 
 interface GitHubEntry {
   type: string;
@@ -41,8 +42,10 @@ interface BrowseCacheEntry {
 
 export default async (request: Request): Promise<Response> => {
   if (request.method === "OPTIONS") {
-    return new Response(null, { status: 204, headers: CORS_HEADERS });
+    return handlePreflight(request, CORS_OPTS);
   }
+
+  const corsHeaders = buildCorsHeaders(request, CORS_OPTS);
 
   const url = new URL(request.url);
   const path = url.searchParams.get("path") || "";
@@ -59,7 +62,7 @@ export default async (request: Request): Promise<Response> => {
           "Content-Type": "application/json",
           "Cache-Control": `public, max-age=${CDN_CACHE_MAX_AGE_S}`,
           "X-Cache": "HIT",
-          ...CORS_HEADERS,
+          ...corsHeaders,
         },
       });
     }
@@ -79,12 +82,12 @@ export default async (request: Request): Promise<Response> => {
           headers: {
             "Content-Type": "application/json",
             "X-Cache": "STALE",
-            ...CORS_HEADERS,
+            ...corsHeaders,
           },
         });
       }
       const code = resp.status === 403 || resp.status === 429 ? "rate_limited" : "github_error";
-      return jsonResponse({ error: "GitHub API error", status: resp.status, code }, resp.status);
+      return jsonResponse(corsHeaders, { error: "GitHub API error", status: resp.status, code }, resp.status);
     }
 
     const ghEntries = (await resp.json()) as GitHubEntry[];
@@ -125,19 +128,23 @@ export default async (request: Request): Promise<Response> => {
         "Content-Type": "application/json",
         "Cache-Control": `public, max-age=${CDN_CACHE_MAX_AGE_S}`,
         "X-Cache": "MISS",
-        ...CORS_HEADERS,
+        ...corsHeaders,
       },
     });
   } catch (err) {
     const message = err instanceof Error ? err.message : "unknown error";
     console.error("[missions-browse] Error:", message);
-    return jsonResponse({ error: "upstream request failed", detail: message }, 502);
+    return jsonResponse(corsHeaders, { error: "upstream request failed", detail: message }, 502);
   }
 };
 
-function jsonResponse(data: Record<string, unknown>, status = 200): Response {
+function jsonResponse(
+  corsHeaders: Record<string, string>,
+  data: Record<string, unknown>,
+  status = 200,
+): Response {
   return new Response(JSON.stringify(data), {
     status,
-    headers: { "Content-Type": "application/json", ...CORS_HEADERS },
+    headers: { "Content-Type": "application/json", ...corsHeaders },
   });
 }

--- a/web/netlify/functions/missions-file.mts
+++ b/web/netlify/functions/missions-file.mts
@@ -7,6 +7,7 @@
  * No GITHUB_TOKEN required — the repo is public.
  */
 import { getStore } from "@netlify/blobs";
+import { buildCorsHeaders, handlePreflight } from "./_shared/cors";
 
 const GITHUB_RAW_URL = "https://raw.githubusercontent.com";
 const KB_REPO = "kubestellar/console-kb";
@@ -24,11 +25,11 @@ const CACHE_TTL_MS = 15 * 60 * 1000;
 /** CDN edge cache: tell Netlify CDN to cache successful responses for 10 minutes */
 const CDN_CACHE_MAX_AGE_S = 600;
 
-const CORS_HEADERS: Record<string, string> = {
-  "Access-Control-Allow-Origin": "*",
-  "Access-Control-Allow-Methods": "GET, OPTIONS",
-  "Access-Control-Allow-Headers": "Content-Type",
-};
+// See web/netlify/functions/_shared/cors.ts for allowlist rationale (#9879).
+const CORS_OPTS = {
+  methods: "GET, OPTIONS",
+  headers: "Content-Type",
+} as const;
 
 interface CacheEntry {
   body: string;
@@ -38,13 +39,15 @@ interface CacheEntry {
 
 export default async (request: Request): Promise<Response> => {
   if (request.method === "OPTIONS") {
-    return new Response(null, { status: 204, headers: CORS_HEADERS });
+    return handlePreflight(request, CORS_OPTS);
   }
+
+  const corsHeaders = buildCorsHeaders(request, CORS_OPTS);
 
   const url = new URL(request.url);
   const path = url.searchParams.get("path");
   if (!path) {
-    return jsonResponse({ error: "path query parameter is required" }, 400);
+    return jsonResponse(corsHeaders, { error: "path query parameter is required" }, 400);
   }
   const ref = url.searchParams.get("ref") || DEFAULT_REF;
   const cacheKey = `file:${ref}:${path}`;
@@ -60,7 +63,7 @@ export default async (request: Request): Promise<Response> => {
           "Content-Type": cached.contentType,
           "Cache-Control": `public, max-age=${CDN_CACHE_MAX_AGE_S}`,
           "X-Cache": "HIT",
-          ...CORS_HEADERS,
+          ...corsHeaders,
         },
       });
     }
@@ -72,7 +75,7 @@ export default async (request: Request): Promise<Response> => {
     });
 
     if (resp.status === 404) {
-      return jsonResponse({ error: "file not found" }, 404);
+      return jsonResponse(corsHeaders, { error: "file not found" }, 404);
     }
     if (!resp.ok) {
       // If GitHub fails but we have stale cache, serve it
@@ -82,16 +85,16 @@ export default async (request: Request): Promise<Response> => {
           headers: {
             "Content-Type": cached.contentType,
             "X-Cache": "STALE",
-            ...CORS_HEADERS,
+            ...corsHeaders,
           },
         });
       }
-      return jsonResponse({ error: "GitHub raw content error", status: resp.status }, resp.status);
+      return jsonResponse(corsHeaders, { error: "GitHub raw content error", status: resp.status }, resp.status);
     }
 
     const body = await resp.text();
     if (body.length > MAX_BODY_BYTES) {
-      return jsonResponse({ error: "response too large" }, 413);
+      return jsonResponse(corsHeaders, { error: "response too large" }, 413);
     }
 
     const contentType = path.endsWith(".json") ? "application/json" : "text/plain";
@@ -106,19 +109,23 @@ export default async (request: Request): Promise<Response> => {
         "Content-Type": contentType,
         "Cache-Control": `public, max-age=${CDN_CACHE_MAX_AGE_S}`,
         "X-Cache": "MISS",
-        ...CORS_HEADERS,
+        ...corsHeaders,
       },
     });
   } catch (err) {
     const message = err instanceof Error ? err.message : "unknown error";
     console.error("[missions-file] Error:", message);
-    return jsonResponse({ error: "upstream request failed", detail: message }, 502);
+    return jsonResponse(corsHeaders, { error: "upstream request failed", detail: message }, 502);
   }
 };
 
-function jsonResponse(data: Record<string, unknown>, status = 200): Response {
+function jsonResponse(
+  corsHeaders: Record<string, string>,
+  data: Record<string, unknown>,
+  status = 200,
+): Response {
   return new Response(JSON.stringify(data), {
     status,
-    headers: { "Content-Type": "application/json", ...CORS_HEADERS },
+    headers: { "Content-Type": "application/json", ...corsHeaders },
   });
 }

--- a/web/netlify/functions/missions-scores.mts
+++ b/web/netlify/functions/missions-scores.mts
@@ -7,6 +7,7 @@
  * Caches responses in Netlify Blobs to avoid hitting GitHub on every request.
  */
 import { getStore } from "@netlify/blobs";
+import { buildCorsHeaders, handlePreflight } from "./_shared/cors";
 
 const GITHUB_RAW_URL = "https://raw.githubusercontent.com";
 const KB_REPO = "kubestellar/console-kb";
@@ -21,11 +22,11 @@ const CACHE_TTL_MS = 15 * 60 * 1000;
 /** CDN edge cache: tell Netlify CDN to cache successful responses for 10 minutes */
 const CDN_CACHE_MAX_AGE_S = 600;
 
-const CORS_HEADERS: Record<string, string> = {
-  "Access-Control-Allow-Origin": "*",
-  "Access-Control-Allow-Methods": "GET, OPTIONS",
-  "Access-Control-Allow-Headers": "Content-Type, X-Demo-Mode",
-};
+// See web/netlify/functions/_shared/cors.ts for allowlist rationale (#9879).
+const CORS_OPTS = {
+  methods: "GET, OPTIONS",
+  headers: "Content-Type, X-Demo-Mode",
+} as const;
 
 interface CacheEntry {
   body: string;
@@ -60,8 +61,10 @@ interface ScoreEntry {
 
 export default async (request: Request): Promise<Response> => {
   if (request.method === "OPTIONS") {
-    return new Response(null, { status: 204, headers: CORS_HEADERS });
+    return handlePreflight(request, CORS_OPTS);
   }
+
+  const corsHeaders = buildCorsHeaders(request, CORS_OPTS);
 
   const url = new URL(request.url);
   const projectParam = url.searchParams.get("project");
@@ -70,7 +73,7 @@ export default async (request: Request): Promise<Response> => {
   // Check for demo mode
   if (request.headers.get("X-Demo-Mode") === "true") {
     if (projectParam && idParam) {
-      return jsonResponse({
+      return jsonResponse(corsHeaders, {
         path: "fixes/demo/demo-123.json",
         project: "demo",
         title: "Demo Mission",
@@ -80,7 +83,7 @@ export default async (request: Request): Promise<Response> => {
         qualitySuggestions: ["Improve context"]
       }, 200);
     } else {
-      return jsonResponse({
+      return jsonResponse(corsHeaders, {
         count: 1,
         scores: [
           {
@@ -117,12 +120,12 @@ export default async (request: Request): Promise<Response> => {
           bodyText = cached.body;
           servedFromCache = true;
         } else {
-          return jsonResponse({ error: "GitHub raw content error", status: resp.status }, resp.status);
+          return jsonResponse(corsHeaders, { error: "GitHub raw content error", status: resp.status }, resp.status);
         }
       } else {
         bodyText = await resp.text();
         if (bodyText.length > MAX_BODY_BYTES) {
-          return jsonResponse({ error: "response too large" }, 413);
+          return jsonResponse(corsHeaders, { error: "response too large" }, 413);
         }
         const entry: CacheEntry = { body: bodyText, contentType: "application/json", fetchedAt: Date.now() };
         store.setJSON(cacheKey, entry).catch(() => {});
@@ -130,14 +133,14 @@ export default async (request: Request): Promise<Response> => {
     }
 
     if (!bodyText) {
-      return jsonResponse({ error: "failed to fetch index" }, 502);
+      return jsonResponse(corsHeaders, { error: "failed to fetch index" }, 502);
     }
 
     let index: MissionIndex;
     try {
       index = JSON.parse(bodyText) as MissionIndex;
     } catch {
-      return jsonResponse({ error: "failed to parse index" }, 502);
+      return jsonResponse(corsHeaders, { error: "failed to parse index" }, 502);
     }
 
     if (projectParam && idParam) {
@@ -148,9 +151,9 @@ export default async (request: Request): Promise<Response> => {
         const idNoExt = idParam.endsWith(".json") ? idParam.slice(0, -5) : idParam;
         if (mProject === projectParam && mBaseNoExt === idNoExt) {
           if (m.qualityScore == null) {
-            return jsonResponse({ error: "Mission found but has no score associated" }, 404);
+            return jsonResponse(corsHeaders, { error: "Mission found but has no score associated" }, 404);
           }
-          return jsonResponse({
+          return jsonResponse(corsHeaders, {
             path: m.path,
             project: mProject,
             title: m.title,
@@ -161,7 +164,7 @@ export default async (request: Request): Promise<Response> => {
           }, 200, servedFromCache ? "HIT" : "MISS");
         }
       }
-      return jsonResponse({ error: "KB mission not found" }, 404);
+      return jsonResponse(corsHeaders, { error: "KB mission not found" }, 404);
     } else {
       const results: ScoreEntry[] = [];
       for (const m of (index.missions || [])) {
@@ -176,23 +179,28 @@ export default async (request: Request): Promise<Response> => {
           });
         }
       }
-      return jsonResponse({ count: results.length, scores: results }, 200, servedFromCache ? "HIT" : "MISS");
+      return jsonResponse(corsHeaders, { count: results.length, scores: results }, 200, servedFromCache ? "HIT" : "MISS");
     }
   } catch (err) {
     const message = err instanceof Error ? err.message : "unknown error";
     console.error("[missions-scores] Error:", message);
-    return jsonResponse({ error: "upstream request failed", detail: message }, 502);
+    return jsonResponse(corsHeaders, { error: "upstream request failed", detail: message }, 502);
   }
 };
 
-function jsonResponse(data: Record<string, unknown>, status = 200, cacheHead = "NONE"): Response {
+function jsonResponse(
+  corsHeaders: Record<string, string>,
+  data: Record<string, unknown>,
+  status = 200,
+  cacheHead = "NONE",
+): Response {
   return new Response(JSON.stringify(data), {
     status,
     headers: {
       "Content-Type": "application/json",
       "Cache-Control": `public, max-age=${CDN_CACHE_MAX_AGE_S}`,
       "X-Cache": cacheHead,
-      ...CORS_HEADERS,
+      ...corsHeaders,
     },
   });
 }

--- a/web/netlify/functions/nightly-e2e.mts
+++ b/web/netlify/functions/nightly-e2e.mts
@@ -10,6 +10,7 @@
  */
 import { getStore } from "@netlify/blobs";
 import { unzipSync } from "fflate";
+import { buildCorsHeaders, handlePreflight } from "./_shared/cors";
 
 const CACHE_STORE = "nightly-e2e";
 const CACHE_KEY = "runs";
@@ -618,15 +619,18 @@ async function fetchAll(
 // ---------------------------------------------------------------------------
 
 export default async (req: Request) => {
+  // See web/netlify/functions/_shared/cors.ts for allowlist rationale (#9879).
+  const corsOpts = {
+    methods: "GET, OPTIONS",
+    headers: "Content-Type, Authorization, Accept",
+  };
   const corsHeaders = {
-    "Access-Control-Allow-Origin": "*",
-    "Access-Control-Allow-Methods": "GET, OPTIONS",
-    "Access-Control-Allow-Headers": "Content-Type, Authorization, Accept",
+    ...buildCorsHeaders(req, corsOpts),
     "Cache-Control": "no-cache, no-store",
   };
 
   if (req.method === "OPTIONS") {
-    return new Response(null, { status: 204, headers: corsHeaders });
+    return handlePreflight(req, corsOpts);
   }
 
   const token = process.env.GITHUB_TOKEN || "";

--- a/web/netlify/functions/umami-collect.mts
+++ b/web/netlify/functions/umami-collect.mts
@@ -9,46 +9,57 @@
  */
 
 import type { Config } from "@netlify/functions"
+import { buildCorsHeaders, handlePreflight, isAllowedOrigin } from "./_shared/cors"
 
 const UMAMI_COLLECT_URL = "https://analytics.kubestellar.io/api/send"
 
-const ALLOWED_HOSTS = new Set([
+/**
+ * Hosts allowed via Referer fallback when Origin is absent. Keep
+ * separate from the CORS allowlist because Referer is a weaker signal
+ * (can be stripped by Referrer-Policy) — only used when Origin is
+ * entirely missing (e.g. beacon sendBeacon() without CORS).
+ */
+const REFERER_FALLBACK_HOSTS = new Set([
   "console.kubestellar.io",
   "localhost",
   "127.0.0.1",
 ])
 
-function isAllowedOrigin(req: Request): boolean {
-  const origin = req.headers.get("origin") || ""
-  const referer = req.headers.get("referer") || ""
+function isRequestAllowed(req: Request): boolean {
+  // Prefer the CORS allowlist via the Origin header.
+  if (isAllowedOrigin(req.headers.get("origin"))) return true
 
-  for (const header of [origin, referer]) {
-    if (!header) continue
+  // Fall back to Referer for requests where Origin is not sent.
+  const referer = req.headers.get("referer")
+  if (referer) {
     try {
-      const hostname = new URL(header).hostname
-      if (ALLOWED_HOSTS.has(hostname) || hostname.endsWith(".netlify.app")) {
+      const hostname = new URL(referer).hostname
+      if (REFERER_FALLBACK_HOSTS.has(hostname) || hostname.endsWith(".netlify.app")) {
         return true
       }
     } catch {
       /* ignore parse errors */
     }
   }
-  // Allow if neither header present (browsers always send one for fetch)
-  return !origin && !referer
+
+  // Allow if neither Origin nor Referer is present (rare, same-origin POST with strict Referrer-Policy).
+  return !req.headers.get("origin") && !referer
 }
 
+// See web/netlify/functions/_shared/cors.ts for allowlist rationale (#9879).
+const CORS_OPTS = {
+  methods: "POST, OPTIONS",
+  headers: "Content-Type",
+} as const
+
 export default async (req: Request) => {
-  const corsHeaders: Record<string, string> = {
-    "Access-Control-Allow-Origin": "*",
-    "Access-Control-Allow-Methods": "POST, OPTIONS",
-    "Access-Control-Allow-Headers": "Content-Type",
-  }
+  const corsHeaders: Record<string, string> = buildCorsHeaders(req, CORS_OPTS)
 
   if (req.method === "OPTIONS") {
-    return new Response(null, { status: 204, headers: corsHeaders })
+    return handlePreflight(req, CORS_OPTS)
   }
 
-  if (!isAllowedOrigin(req)) {
+  if (!isRequestAllowed(req)) {
     return new Response("Forbidden", { status: 403, headers: corsHeaders })
   }
 


### PR DESCRIPTION
## Summary

OWASP ZAP baseline scan on console.kubestellar.io flagged a Medium-severity **Cross-Domain Misconfiguration** (rule 10098, 1 instance) on [run 24877982206](https://github.com/kubestellar/console/actions/runs/24877982206). Root cause: nine Netlify Functions responded with a blanket `Access-Control-Allow-Origin: *`, which combined with frontend `credentials: 'include'` fetches is a known CORS-leakage pattern.

## Changes

- **New** `web/netlify/functions/_shared/cors.ts` — single-source allowlist and helpers (`buildCorsHeaders`, `handlePreflight`, `isAllowedOrigin`). Allows `https://console.kubestellar.io`, Netlify previews/branch deploys (`*--kubestellar-console.netlify.app`, `deploy-preview-N--...`), and localhost (5173/5174/8080/8888). Always emits `X-Content-Type-Options: nosniff` and `Vary: Origin`.

- **Tightened** CORS on nine console-internal Netlify Functions to echo only allowlisted request origins (no more `*`):
  - `nightly-e2e.mts`, `github-rewards.mts`, `analytics-dashboard.mts`, `issue-stats.mts`
  - `missions-browse.mts`, `missions-file.mts`, `missions-scores.mts`
  - `feedback-app.mts` (POST with client credential)
  - `umami-collect.mts` (keeps existing Referer fallback for beacon sends)

- **Intentionally kept `*`** on `acmm-badge.mts` — it is a public, unauthenticated, shields.io-embeddable badge endpoint that must be fetchable from arbitrary README hosts. Added an explanatory comment next to the `*` so future maintainers don't tighten it by mistake. (`rewards-badge.mts` never emitted CORS headers and is unchanged.)

## Security findings addressed

- Medium: **Cross-Domain Misconfiguration** [ZAP 10098] — fixed
- Low (partial): **X-Content-Type-Options Header Missing** [ZAP 10021] — `nosniff` now emitted on every CORS response from the tightened endpoints

## Test plan

- [ ] Netlify build + function bundling passes in CI
- [ ] Deploy-preview console loads (origin echoed back, not `*`)
- [ ] Frontend hooks that use `credentials: 'include'` (auth, rewards, persistence) still work in the deploy preview
- [ ] Next nightly ZAP run shows `Cross-Domain Misconfiguration [10098]` drops from WARN-NEW to PASS (or IGNORE)

Fixes #9879