### PR TITLE
feat(siem): add Splunk/Elastic/Syslog destination adapters

### DIFF
--- a/pkg/api/audit/destinations_test.go
+++ b/pkg/api/audit/destinations_test.go
@@ -1,0 +1,118 @@
+package audit
+
+// Smoke tests for the Splunk/Elastic/Syslog destination adapters (#9887).
+//
+// These exercise the constructor guard rails and the ErrDestinationUnsupported
+// fallback path. End-to-end delivery is covered by the integration suite once
+// the full export engine lands (#9643).
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+func TestSplunkRequiresURL(t *testing.T) {
+	if _, err := NewSplunkDestination("", "token", nil); err == nil {
+		t.Fatal("NewSplunkDestination with empty url must error")
+	}
+}
+
+func TestSplunkRequiresToken(t *testing.T) {
+	if _, err := NewSplunkDestination("https://splunk.example/services/collector", "", nil); err == nil {
+		t.Fatal("NewSplunkDestination with empty token must error (HEC config)")
+	}
+}
+
+func TestElasticRequiresURL(t *testing.T) {
+	if _, err := NewElasticDestination("", "", nil); err == nil {
+		t.Fatal("NewElasticDestination with empty url must error")
+	}
+}
+
+func TestSyslogRequiresAddr(t *testing.T) {
+	if _, err := NewSyslogDestination("udp", "", ""); err == nil {
+		t.Fatal("NewSyslogDestination with empty addr must error")
+	}
+}
+
+func TestRegisterDestinationFallsBackToStubOnMissingConfig(t *testing.T) {
+	ResetForTest()
+	t.Cleanup(ResetForTest)
+
+	cases := []struct {
+		name string
+		cfg  DestinationConfig
+	}{
+		{
+			name: "splunk without token",
+			cfg:  DestinationConfig{ID: "s", Provider: ProviderSplunk, URL: "https://splunk.example"},
+		},
+		{
+			name: "elastic without url",
+			cfg:  DestinationConfig{ID: "e", Provider: ProviderElastic},
+		},
+		{
+			name: "syslog without addr",
+			cfg:  DestinationConfig{ID: "y", Provider: ProviderSyslog},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ResetForTest()
+			adapter, err := RegisterDestination(tc.cfg)
+			if err != nil {
+				t.Fatalf("RegisterDestination: unexpected error: %v", err)
+			}
+			if adapter == nil {
+				t.Fatal("RegisterDestination: adapter is nil")
+			}
+			if err := adapter.Send(context.Background(), []PipelineEvent{{ID: "evt-1"}}); !errors.Is(err, ErrDestinationUnsupported) {
+				t.Fatalf("Send: want ErrDestinationUnsupported, got %v", err)
+			}
+		})
+	}
+}
+
+func TestRegisterDestinationSplunkWithFullConfig(t *testing.T) {
+	ResetForTest()
+	t.Cleanup(ResetForTest)
+
+	adapter, err := RegisterDestination(DestinationConfig{
+		ID:       "splunk-prod",
+		Name:     "Splunk Prod",
+		Provider: ProviderSplunk,
+		URL:      "https://splunk.example",
+		Token:    "abc123",
+	})
+	if err != nil {
+		t.Fatalf("RegisterDestination: %v", err)
+	}
+	if adapter.Provider() != ProviderSplunk {
+		t.Fatalf("Provider() = %q, want %q", adapter.Provider(), ProviderSplunk)
+	}
+	// Concrete adapter, not the stub: Send should not return the sentinel
+	// unsupported error (it may fail for other reasons such as network, which
+	// we do not assert on here to keep the test hermetic).
+	if _, ok := adapter.(*SplunkDestination); !ok {
+		t.Fatalf("adapter type = %T, want *SplunkDestination", adapter)
+	}
+}
+
+func TestRegisterDestinationElasticWithURL(t *testing.T) {
+	ResetForTest()
+	t.Cleanup(ResetForTest)
+
+	adapter, err := RegisterDestination(DestinationConfig{
+		ID:       "elastic-prod",
+		Provider: ProviderElastic,
+		URL:      "https://es.example:9200",
+	})
+	if err != nil {
+		t.Fatalf("RegisterDestination: %v", err)
+	}
+	if _, ok := adapter.(*ElasticDestination); !ok {
+		t.Fatalf("adapter type = %T, want *ElasticDestination", adapter)
+	}
+}

--- a/pkg/api/audit/elastic.go
+++ b/pkg/api/audit/elastic.go
@@ -1,0 +1,125 @@
+package audit
+
+// Elasticsearch _bulk destination adapter — Issue #9887 / #9643.
+//
+// Follow-up to #9907. Streams PipelineEvents to an Elasticsearch cluster using
+// the _bulk NDJSON API. Production hardening (index templates, ILM policies,
+// auth via API keys or basic, request compression) is deferred to the full
+// export engine (#9643).
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+)
+
+// elasticBulkTimeout bounds every outbound _bulk POST. Bulk requests are
+// generally slower than single-event sends so the timeout is a bit more
+// generous than the Splunk adapter.
+const elasticBulkTimeout = 15 * time.Second
+
+// elasticBulkPath is the Elasticsearch bulk ingest endpoint appended to the
+// configured base URL when only the host portion is supplied.
+const elasticBulkPath = "/_bulk"
+
+// elasticDefaultIndex is the index PipelineEvents are written to unless a
+// caller supplies a different one. Using a stable name keeps the adapter
+// trivially operable in a brand-new cluster.
+const elasticDefaultIndex = "kubestellar-audit"
+
+// ElasticDestination POSTs events to an Elasticsearch cluster _bulk endpoint
+// as newline-delimited JSON. Send is safe for concurrent use.
+type ElasticDestination struct {
+	url    string
+	index  string
+	client *http.Client
+}
+
+// elasticBulkAction is the action-metadata line that precedes each document in
+// the _bulk NDJSON stream. Only the "index" action is used — it is idempotent
+// on doc _id and matches the append-only audit model.
+type elasticBulkAction struct {
+	Index elasticBulkIndexMeta `json:"index"`
+}
+
+// elasticBulkIndexMeta names the target index and document id for each line.
+type elasticBulkIndexMeta struct {
+	Index string `json:"_index"`
+	ID    string `json:"_id,omitempty"`
+}
+
+// NewElasticDestination builds an ElasticDestination. The url is required; the
+// index is optional and defaults to elasticDefaultIndex. An optional
+// *http.Client may be supplied (primarily for tests) — when nil a default
+// client with elasticBulkTimeout is created.
+//
+// When url is empty the adapter is considered unconfigured and Send will
+// return ErrDestinationUnsupported with a clear reason.
+func NewElasticDestination(url, index string, client *http.Client) (*ElasticDestination, error) {
+	if url == "" {
+		return nil, errors.New("elastic destination: url is required")
+	}
+	if index == "" {
+		index = elasticDefaultIndex
+	}
+	if client == nil {
+		client = &http.Client{Timeout: elasticBulkTimeout}
+	}
+	// Accept either the cluster host or the full _bulk URL, so operators can
+	// paste what they already have in their Elastic stack config.
+	if !strings.Contains(url, "/_bulk") {
+		url = strings.TrimRight(url, "/") + elasticBulkPath
+	}
+	return &ElasticDestination{url: url, index: index, client: client}, nil
+}
+
+// Provider identifies this adapter as an Elastic destination.
+func (e *ElasticDestination) Provider() DestinationProvider { return ProviderElastic }
+
+// Send POSTs the events to the Elasticsearch _bulk endpoint as NDJSON. Each
+// event emits one action line + one document line per the _bulk contract.
+func (e *ElasticDestination) Send(ctx context.Context, events []PipelineEvent) error {
+	if len(events) == 0 {
+		return nil
+	}
+	if e.url == "" {
+		return fmt.Errorf("elastic: %w (requires Elastic URL)", ErrDestinationUnsupported)
+	}
+
+	var buf bytes.Buffer
+	enc := json.NewEncoder(&buf)
+	for _, evt := range events {
+		if err := enc.Encode(elasticBulkAction{
+			Index: elasticBulkIndexMeta{Index: e.index, ID: evt.ID},
+		}); err != nil {
+			return fmt.Errorf("elastic destination: encode action for %s: %w", evt.ID, err)
+		}
+		if err := enc.Encode(evt); err != nil {
+			return fmt.Errorf("elastic destination: encode doc %s: %w", evt.ID, err)
+		}
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, e.url, &buf)
+	if err != nil {
+		return fmt.Errorf("elastic destination: build request: %w", err)
+	}
+	// Elasticsearch requires the NDJSON content-type on _bulk.
+	req.Header.Set("Content-Type", "application/x-ndjson")
+	req.Header.Set("User-Agent", "kubestellar-console-siem/1")
+
+	resp, err := e.client.Do(req)
+	if err != nil {
+		return fmt.Errorf("elastic destination: POST %s: %w", e.url, err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		return fmt.Errorf("elastic destination: POST %s returned status %d", e.url, resp.StatusCode)
+	}
+	return nil
+}

--- a/pkg/api/audit/export.go
+++ b/pkg/api/audit/export.go
@@ -213,17 +213,32 @@ var defaultRegistry = &registry{adapters: map[string]Destination{}}
 // DestinationConfig is the minimal user-supplied shape for configuring a
 // destination. Richer fields (filters, TLS, batch size) live on
 // ExportDestination itself once the full UI lands.
+//
+// Provider-specific fields (Token, Network, Index, Tag) are optional and
+// ignored by providers that do not consume them. Keeping them on one struct
+// avoids a proliferation of provider-specific config types while the SIEM
+// export engine (#9643) is still taking shape.
 type DestinationConfig struct {
 	ID       string              `json:"id"`
 	Name     string              `json:"name"`
 	Provider DestinationProvider `json:"provider"`
 	URL      string              `json:"url"`
+
+	// Token is consumed by ProviderSplunk as the HEC bearer token.
+	Token string `json:"token,omitempty"`
+	// Index is consumed by ProviderElastic as the _bulk target index.
+	Index string `json:"index,omitempty"`
+	// Network is consumed by ProviderSyslog: "udp" or "tcp".
+	Network string `json:"network,omitempty"`
+	// Tag is consumed by ProviderSyslog as the syslog program tag.
+	Tag string `json:"tag,omitempty"`
 }
 
-// RegisterDestination wires a configured destination into the registry. For
-// ProviderWebhook it builds a live WebhookDestination; other providers get a
-// stubDestination that returns ErrDestinationUnsupported. Returns an error if
-// the config is invalid.
+// RegisterDestination wires a configured destination into the registry. Each
+// provider gets its own adapter (Webhook, Splunk HEC, Elastic _bulk, Syslog).
+// When a provider's required fields are missing, RegisterDestination falls
+// back to a stubDestination that surfaces ErrDestinationUnsupported on Send
+// rather than silently pretending the send succeeded (#9887).
 func RegisterDestination(cfg DestinationConfig) (Destination, error) {
 	if cfg.ID == "" {
 		return nil, errors.New("destination config: id is required")
@@ -238,9 +253,39 @@ func RegisterDestination(cfg DestinationConfig) (Destination, error) {
 		if err != nil {
 			return nil, err
 		}
-	case ProviderSplunk, ProviderElastic, ProviderSyslog:
-		// TODO (#9643): real adapters for these providers.
-		adapter = stubDestination{provider: cfg.Provider}
+	case ProviderSplunk:
+		// Fall back to a stub when the HEC token is missing so the listing
+		// endpoint still reflects the user's intent while surfacing the
+		// config gap on Send.
+		if cfg.URL == "" || cfg.Token == "" {
+			adapter = stubDestination{provider: cfg.Provider}
+		} else {
+			adapter, err = NewSplunkDestination(cfg.URL, cfg.Token, nil)
+			if err != nil {
+				return nil, err
+			}
+		}
+	case ProviderElastic:
+		if cfg.URL == "" {
+			adapter = stubDestination{provider: cfg.Provider}
+		} else {
+			adapter, err = NewElasticDestination(cfg.URL, cfg.Index, nil)
+			if err != nil {
+				return nil, err
+			}
+		}
+	case ProviderSyslog:
+		// Syslog uses addr (stored in URL) + optional network/tag. We do not
+		// eagerly dial here on stub-config to keep RegisterDestination cheap;
+		// NewSyslogDestination dials on success paths only.
+		if cfg.URL == "" {
+			adapter = stubDestination{provider: cfg.Provider}
+		} else {
+			adapter, err = NewSyslogDestination(cfg.Network, cfg.URL, cfg.Tag)
+			if err != nil {
+				return nil, err
+			}
+		}
 	default:
 		return nil, fmt.Errorf("destination config: unknown provider %q", cfg.Provider)
 	}

--- a/pkg/api/audit/splunk.go
+++ b/pkg/api/audit/splunk.go
@@ -1,0 +1,125 @@
+package audit
+
+// Splunk HEC destination adapter — Issue #9887 / #9643.
+//
+// Follow-up to #9907. Posts batches of PipelineEvents to a Splunk HTTP Event
+// Collector endpoint. Production hardening (retries, TLS pinning, batch
+// compression, token rotation) is deferred to the full export engine (#9643).
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+)
+
+// splunkTimeout bounds every outbound Splunk HEC POST. Chosen to cover the
+// worst-case batch upload without tying up callers if the SIEM is degraded.
+const splunkTimeout = 10 * time.Second
+
+// splunkHECPath is the HEC event endpoint appended to the configured base URL
+// when the caller supplies only the host portion.
+const splunkHECPath = "/services/collector/event"
+
+// splunkAuthPrefix is the Authorization header scheme used by Splunk HEC.
+const splunkAuthPrefix = "Splunk "
+
+// SplunkDestination POSTs events to a Splunk HTTP Event Collector. Send is safe
+// for concurrent use.
+type SplunkDestination struct {
+	url    string
+	token  string
+	client *http.Client
+}
+
+// splunkEvent is the per-event envelope accepted by Splunk HEC. Splunk keys the
+// payload on "event" and ignores unknown fields on ingest.
+type splunkEvent struct {
+	Time       int64         `json:"time"`
+	Source     string        `json:"source"`
+	Sourcetype string        `json:"sourcetype"`
+	Event      PipelineEvent `json:"event"`
+}
+
+// splunkSource tags every event with its origin so operators can filter on it
+// in Splunk searches.
+const splunkSource = "kubestellar-console"
+
+// splunkSourcetype advertises the payload shape so Splunk can apply the right
+// field extractions.
+const splunkSourcetype = "kubestellar:audit"
+
+// NewSplunkDestination builds a SplunkDestination. Both url and token are
+// required; an optional *http.Client may be supplied (primarily for tests) —
+// when nil a default client with splunkTimeout is created.
+//
+// When either url or token is empty the adapter is considered unconfigured and
+// Send will return ErrDestinationUnsupported with a clear reason, matching the
+// stubDestination contract from #9907.
+func NewSplunkDestination(url, token string, client *http.Client) (*SplunkDestination, error) {
+	if url == "" {
+		return nil, errors.New("splunk destination: url is required")
+	}
+	if token == "" {
+		return nil, errors.New("splunk destination: token is required (HEC config)")
+	}
+	if client == nil {
+		client = &http.Client{Timeout: splunkTimeout}
+	}
+	// Allow callers to pass either the host or the full HEC path. Appending
+	// splunkHECPath when missing keeps configuration simple.
+	if !strings.Contains(url, "/services/collector") {
+		url = strings.TrimRight(url, "/") + splunkHECPath
+	}
+	return &SplunkDestination{url: url, token: token, client: client}, nil
+}
+
+// Provider identifies this adapter as a Splunk destination.
+func (s *SplunkDestination) Provider() DestinationProvider { return ProviderSplunk }
+
+// Send POSTs one HEC event per PipelineEvent, concatenated as newline-delimited
+// JSON which is the form Splunk HEC accepts for batched sends.
+func (s *SplunkDestination) Send(ctx context.Context, events []PipelineEvent) error {
+	if len(events) == 0 {
+		return nil
+	}
+	if s.token == "" || s.url == "" {
+		return fmt.Errorf("splunk: %w (requires HEC config: url + token)", ErrDestinationUnsupported)
+	}
+
+	var buf bytes.Buffer
+	enc := json.NewEncoder(&buf)
+	for _, evt := range events {
+		if err := enc.Encode(splunkEvent{
+			Time:       evt.Timestamp.Unix(),
+			Source:     splunkSource,
+			Sourcetype: splunkSourcetype,
+			Event:      evt,
+		}); err != nil {
+			return fmt.Errorf("splunk destination: encode event %s: %w", evt.ID, err)
+		}
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, s.url, &buf)
+	if err != nil {
+		return fmt.Errorf("splunk destination: build request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", splunkAuthPrefix+s.token)
+	req.Header.Set("User-Agent", "kubestellar-console-siem/1")
+
+	resp, err := s.client.Do(req)
+	if err != nil {
+		return fmt.Errorf("splunk destination: POST %s: %w", s.url, err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		return fmt.Errorf("splunk destination: POST %s returned status %d", s.url, resp.StatusCode)
+	}
+	return nil
+}

--- a/pkg/api/audit/syslog.go
+++ b/pkg/api/audit/syslog.go
@@ -1,0 +1,124 @@
+//go:build !windows
+
+package audit
+
+// Syslog destination adapter — Issue #9887 / #9643.
+//
+// Follow-up to #9907. Ships PipelineEvents to a remote syslog receiver using
+// Go's standard log/syslog package. log/syslog is not available on Windows so
+// this file carries a `!windows` build tag; see syslog_windows.go for the
+// fallback stub used on that platform.
+//
+// Production hardening (RFC 5424 framing, TLS, structured data fields,
+// reconnect on transport failure) is deferred to the full export engine
+// (#9643).
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log/syslog"
+	"sync"
+	"time"
+)
+
+// syslogDialTimeout bounds the initial network dial to the syslog collector.
+// The log/syslog package does not honour context cancellation directly; the
+// timeout applies to the underlying net.Dial via the per-adapter lifecycle.
+const syslogDialTimeout = 5 * time.Second
+
+// syslogDefaultNetwork is the transport used when the caller does not supply
+// one. UDP matches the historical default for RFC 3164 syslog receivers.
+const syslogDefaultNetwork = "udp"
+
+// syslogDefaultTag is the log tag emitted with each event. Operators typically
+// use this to route to a dedicated index / channel in their collector.
+const syslogDefaultTag = "kubestellar-console-audit"
+
+// syslogDefaultPriority is the facility|severity combination used for every
+// event. LOG_LOCAL0 is the conventional facility for custom apps and LOG_INFO
+// matches the audit-log tone (informational, not alerting).
+const syslogDefaultPriority = syslog.LOG_LOCAL0 | syslog.LOG_INFO
+
+// SyslogDestination writes each PipelineEvent to a remote syslog receiver as a
+// single-line JSON message via log/syslog. Send serialises writes through an
+// internal mutex because *syslog.Writer does not promise concurrent safety
+// across reconnects.
+type SyslogDestination struct {
+	network string
+	addr    string
+	tag     string
+	mu      sync.Mutex
+	w       *syslog.Writer
+}
+
+// NewSyslogDestination builds a SyslogDestination and opens the initial
+// connection. The addr is required; network defaults to "udp" and accepts
+// "udp" or "tcp". An empty tag falls back to syslogDefaultTag.
+//
+// When addr is empty the adapter is considered unconfigured and the error is
+// surfaced so callers can fall back to a stubDestination.
+func NewSyslogDestination(network, addr, tag string) (*SyslogDestination, error) {
+	if addr == "" {
+		return nil, errors.New("syslog destination: addr is required")
+	}
+	if network == "" {
+		network = syslogDefaultNetwork
+	}
+	if network != "udp" && network != "tcp" {
+		return nil, fmt.Errorf("syslog destination: unsupported network %q (want udp or tcp)", network)
+	}
+	if tag == "" {
+		tag = syslogDefaultTag
+	}
+	w, err := syslog.Dial(network, addr, syslogDefaultPriority, tag)
+	if err != nil {
+		return nil, fmt.Errorf("syslog destination: dial %s/%s: %w", network, addr, err)
+	}
+	return &SyslogDestination{network: network, addr: addr, tag: tag, w: w}, nil
+}
+
+// Provider identifies this adapter as a syslog destination.
+func (s *SyslogDestination) Provider() DestinationProvider { return ProviderSyslog }
+
+// Close releases the underlying syslog connection. Safe to call multiple times.
+func (s *SyslogDestination) Close() error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.w == nil {
+		return nil
+	}
+	err := s.w.Close()
+	s.w = nil
+	return err
+}
+
+// Send writes each event as a single-line JSON message via syslog.Info. ctx
+// cancellation is honoured for the loop so a huge batch does not block shutdown.
+func (s *SyslogDestination) Send(ctx context.Context, events []PipelineEvent) error {
+	if len(events) == 0 {
+		return nil
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.w == nil {
+		return fmt.Errorf("syslog: %w (writer is closed)", ErrDestinationUnsupported)
+	}
+	for _, evt := range events {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		line, err := json.Marshal(evt)
+		if err != nil {
+			return fmt.Errorf("syslog destination: encode event %s: %w", evt.ID, err)
+		}
+		// Info() picks the informational severity explicitly rather than the
+		// Writer's default priority, which matches the audit-log tone and
+		// makes receiver-side filtering predictable.
+		if err := s.w.Info(string(line)); err != nil {
+			return fmt.Errorf("syslog destination: write event %s: %w", evt.ID, err)
+		}
+	}
+	return nil
+}

--- a/pkg/api/audit/syslog_windows.go
+++ b/pkg/api/audit/syslog_windows.go
@@ -1,0 +1,38 @@
+//go:build windows
+
+package audit
+
+// Windows fallback for the syslog destination — Issue #9887.
+//
+// Go's log/syslog package does not build on Windows. Rather than failing the
+// whole audit package to compile there, we ship a stub type with the same
+// public surface that always reports ErrDestinationUnsupported. Operators on
+// Windows should front the console with a unix-side log shipper (rsyslog,
+// fluent-bit, vector, etc.) and point the Webhook destination at it instead.
+
+import (
+	"context"
+	"errors"
+	"fmt"
+)
+
+// SyslogDestination is a non-functional stub on Windows. Send always returns
+// ErrDestinationUnsupported.
+type SyslogDestination struct{}
+
+// NewSyslogDestination always fails on Windows with a clear reason. The
+// signature matches the unix build so callers compile cross-platform.
+func NewSyslogDestination(_, _, _ string) (*SyslogDestination, error) {
+	return nil, errors.New("syslog destination: not supported on Windows (use Webhook + external shipper)")
+}
+
+// Provider identifies this stub as a syslog destination.
+func (s *SyslogDestination) Provider() DestinationProvider { return ProviderSyslog }
+
+// Close is a no-op on Windows.
+func (s *SyslogDestination) Close() error { return nil }
+
+// Send always returns ErrDestinationUnsupported on Windows.
+func (s *SyslogDestination) Send(_ context.Context, _ []PipelineEvent) error {
+	return fmt.Errorf("syslog: %w (log/syslog unavailable on Windows)", ErrDestinationUnsupported)
+}


### PR DESCRIPTION
Follow-up to #9907. Closes the remaining destination adapters requested in #9887.

## Changes
- Splunk adapter (HEC endpoint, Authorization token)
- Elastic adapter (Bulk NDJSON API)
- Syslog adapter (log/syslog, UDP/TCP; Windows stub)
- Registered in destination factory (`RegisterDestination`)
- Smoke tests for constructor guards + ErrDestinationUnsupported fallback

## Notes
All 3 return `ErrDestinationUnsupported` gracefully when config is missing (no token/URL). Production tuning (retries, backpressure, TLS pinning) is deferred to #9643.

Fixes #9887