### PR TITLE
feat(envoy): add Envoy Proxy monitoring card

### DIFF
--- a/web/src/components/cards/cardMetadata.ts
+++ b/web/src/components/cards/cardMetadata.ts
@@ -266,6 +266,8 @@ export const CARD_TITLES: Record<string, string> = {
   coredns_status: 'CoreDNS',
   // Contour ingress proxy
   contour_status: 'Contour',
+  // Envoy proxy (service mesh / edge)
+  envoy_status: 'Envoy Proxy',
   // CRI-O container runtime
   crio_status: 'CRI-O',
   // Strimzi Kafka operator
@@ -575,6 +577,8 @@ export const CARD_DESCRIPTIONS: Record<string, string> = {
   coredns_status: 'CoreDNS pod health, restart counts, and cluster status across clusters.',
   // Contour ingress proxy
   contour_status: 'Contour ingress proxy status, HTTPProxy resources, and Envoy fleet health.',
+  // Envoy proxy (service mesh / edge)
+  envoy_status: 'Envoy Proxy listener health, upstream cluster health, and request/connection stats.',
   // CRI-O container runtime
   crio_status: 'CRI-O container runtime metrics, image pulls, and pod sandbox status.',
 

--- a/web/src/components/cards/cardRegistry.ts
+++ b/web/src/components/cards/cardRegistry.ts
@@ -80,6 +80,8 @@ const KustomizationStatus = safeLazy(() => _deployBundle, 'KustomizationStatus')
 const FluxStatus = safeLazy(() => import('./flux_status'), 'FluxStatus')
 // Contour ingress proxy card
 const ContourStatus = safeLazy(() => import('./contour_status'), 'ContourStatus')
+// Envoy proxy card (Service Mesh / network)
+const EnvoyStatus = safeLazy(() => import('./envoy_status'), 'EnvoyStatus')
 const OverlayComparison = safeLazy(() => _deployBundle, 'OverlayComparison')
 const ArgoCDApplications = safeLazy(() => _deployBundle, 'ArgoCDApplications')
 const ArgoCDApplicationSets = safeLazy(() => _deployBundle, 'ArgoCDApplicationSets')
@@ -700,6 +702,8 @@ const RAW_CARD_COMPONENTS: Record<string, CardComponent> = {
   nats_status: NatsStatus,
   // Contour ingress proxy
   contour_status: ContourStatus,
+  // Envoy proxy (service mesh / edge)
+  envoy_status: EnvoyStatus,
   // Artifact Hub
   artifact_hub_status: ArtifactHubStatus,
   // CloudEvents messaging
@@ -1018,6 +1022,7 @@ const CARD_CHUNK_PRELOADERS: Record<string, () => Promise<unknown>> = {
   kustomization_status: () => import('./deploy-bundle'),
   flux_status: () => import('./flux_status'),
   contour_status: () => import('./contour_status'),
+  envoy_status: () => import('./envoy_status'),
   overlay_comparison: () => import('./deploy-bundle'),
   argocd_applications: () => import('./deploy-bundle'),
   argocd_applicationsets: () => import('./deploy-bundle'),
@@ -1607,6 +1612,7 @@ export const CARD_DEFAULT_WIDTHS: Record<string, number> = {
   kustomization_status: 6,
   flux_status: 6,
   contour_status: 6,
+  envoy_status: 6,
   pvc_status: 6,
   gpu_status: 6,
   gpu_inventory: 6,

--- a/web/src/components/cards/envoy_status/demoData.ts
+++ b/web/src/components/cards/envoy_status/demoData.ts
@@ -1,0 +1,148 @@
+/**
+ * Envoy Proxy Status Card — Demo Data & Type Definitions
+ *
+ * Models Envoy listeners, clusters (upstream pools), and basic admin stats
+ * for the Envoy Proxy (CNCF graduated) edge/service proxy.
+ *
+ * This is scaffolding — a real Envoy Admin API integration (/listeners,
+ * /clusters, /stats) can be wired into `fetchEnvoyStatus` in a follow-up.
+ * Until then, cards fall back to this demo data via `useCache`.
+ */
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type EnvoyListenerStatus = 'active' | 'draining' | 'warming'
+export type EnvoyClusterHealth = 'healthy' | 'degraded' | 'unhealthy'
+export type EnvoyHealth = 'healthy' | 'degraded' | 'not-installed'
+
+export interface EnvoyListener {
+  name: string
+  address: string
+  port: number
+  status: EnvoyListenerStatus
+  cluster: string
+}
+
+export interface EnvoyUpstreamCluster {
+  name: string
+  upstream: string
+  endpointsTotal: number
+  endpointsHealthy: number
+  cluster: string
+}
+
+export interface EnvoyStats {
+  requestsPerSecond: number
+  activeConnections: number
+  totalRequests: number
+  http5xxRate: number
+}
+
+export interface EnvoySummary {
+  totalListeners: number
+  activeListeners: number
+  totalClusters: number
+  healthyClusters: number
+}
+
+export interface EnvoyStatusData {
+  health: EnvoyHealth
+  listeners: EnvoyListener[]
+  clusters: EnvoyUpstreamCluster[]
+  stats: EnvoyStats
+  summary: EnvoySummary
+  lastCheckTime: string
+}
+
+// ---------------------------------------------------------------------------
+// Demo-data constants (named — no magic numbers)
+// ---------------------------------------------------------------------------
+
+const DEMO_REQUESTS_PER_SECOND = 1247
+const DEMO_ACTIVE_CONNECTIONS = 384
+const DEMO_TOTAL_REQUESTS = 8_942_331
+const DEMO_HTTP_5XX_RATE_PCT = 0.14
+
+const PORT_HTTP = 80
+const PORT_HTTPS = 443
+const PORT_GRPC = 9000
+
+// ---------------------------------------------------------------------------
+// Demo data — shown when Envoy is not installed or in demo mode
+// ---------------------------------------------------------------------------
+
+const DEMO_LISTENERS: EnvoyListener[] = [
+  {
+    name: 'listener_http',
+    address: '0.0.0.0',
+    port: PORT_HTTP,
+    status: 'active',
+    cluster: 'default',
+  },
+  {
+    name: 'listener_https',
+    address: '0.0.0.0',
+    port: PORT_HTTPS,
+    status: 'active',
+    cluster: 'default',
+  },
+  {
+    name: 'listener_grpc',
+    address: '0.0.0.0',
+    port: PORT_GRPC,
+    status: 'warming',
+    cluster: 'default',
+  },
+]
+
+const DEMO_CLUSTERS: EnvoyUpstreamCluster[] = [
+  {
+    name: 'service_frontend',
+    upstream: 'frontend.default.svc:8080',
+    endpointsTotal: 6,
+    endpointsHealthy: 6,
+    cluster: 'default',
+  },
+  {
+    name: 'service_api',
+    upstream: 'api.api.svc:8080',
+    endpointsTotal: 4,
+    endpointsHealthy: 3,
+    cluster: 'default',
+  },
+  {
+    name: 'service_auth',
+    upstream: 'auth.auth.svc:8080',
+    endpointsTotal: 3,
+    endpointsHealthy: 3,
+    cluster: 'default',
+  },
+  {
+    name: 'service_payments',
+    upstream: 'payments.payments.svc:8080',
+    endpointsTotal: 2,
+    endpointsHealthy: 0,
+    cluster: 'default',
+  },
+]
+
+export const ENVOY_DEMO_DATA: EnvoyStatusData = {
+  health: 'degraded',
+  listeners: DEMO_LISTENERS,
+  clusters: DEMO_CLUSTERS,
+  stats: {
+    requestsPerSecond: DEMO_REQUESTS_PER_SECOND,
+    activeConnections: DEMO_ACTIVE_CONNECTIONS,
+    totalRequests: DEMO_TOTAL_REQUESTS,
+    http5xxRate: DEMO_HTTP_5XX_RATE_PCT,
+  },
+  summary: {
+    totalListeners: DEMO_LISTENERS.length,
+    activeListeners: DEMO_LISTENERS.filter(l => l.status === 'active').length,
+    totalClusters: DEMO_CLUSTERS.length,
+    healthyClusters: DEMO_CLUSTERS.filter(c => c.endpointsHealthy === c.endpointsTotal).length,
+  },
+  lastCheckTime: new Date().toISOString(),
+}

--- a/web/src/components/cards/envoy_status/index.tsx
+++ b/web/src/components/cards/envoy_status/index.tsx
@@ -1,0 +1,290 @@
+/**
+ * Envoy Proxy Status Card
+ *
+ * Displays Envoy listeners, upstream clusters, and basic admin stats.
+ * Follows the contour_status pattern for structure and styling.
+ *
+ * This is scaffolding — the card renders via demo fallback today. When a
+ * real Envoy admin bridge lands, the hook's fetcher will pick up live data
+ * automatically with no component changes.
+ */
+
+import {
+  Activity,
+  AlertTriangle,
+  CheckCircle,
+  Network,
+  RefreshCw,
+  Server,
+  Shield,
+  Zap,
+} from 'lucide-react'
+import { useTranslation } from 'react-i18next'
+import { MetricTile } from '../../../lib/cards/CardComponents'
+import { Skeleton, SkeletonList, SkeletonStats } from '../../ui/Skeleton'
+import { useCachedEnvoy } from './useCachedEnvoy'
+import type { EnvoyListener, EnvoyUpstreamCluster } from './demoData'
+
+// ---------------------------------------------------------------------------
+// Named constants (no magic numbers)
+// ---------------------------------------------------------------------------
+
+const RELATIVE_TIME_MINUTE_MS = 60_000
+const MINUTES_PER_HOUR = 60
+const HOURS_PER_DAY = 24
+const HTTP_5XX_PERCENT_DECIMALS = 2
+const THROUGHPUT_LOCALE_MIN_FRACTION = 0
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function formatRelativeTime(isoString: string): string {
+  const parsed = new Date(isoString).getTime()
+  if (!isoString || Number.isNaN(parsed)) return 'just now'
+
+  const diff = Date.now() - parsed
+  if (diff < 0) return 'just now'
+
+  const hour = MINUTES_PER_HOUR * RELATIVE_TIME_MINUTE_MS
+  const day = HOURS_PER_DAY * hour
+
+  if (diff < RELATIVE_TIME_MINUTE_MS) return 'just now'
+  if (diff < hour) return `${Math.floor(diff / RELATIVE_TIME_MINUTE_MS)}m ago`
+  if (diff < day) return `${Math.floor(diff / hour)}h ago`
+  return `${Math.floor(diff / day)}d ago`
+}
+
+function formatThroughput(value: number): string {
+  return value.toLocaleString(undefined, {
+    minimumFractionDigits: THROUGHPUT_LOCALE_MIN_FRACTION,
+  })
+}
+
+// ---------------------------------------------------------------------------
+// Subsections
+// ---------------------------------------------------------------------------
+
+function ListenerRow({ listener }: { listener: EnvoyListener }) {
+  const isActive = listener.status === 'active'
+  const statusClass = isActive
+    ? 'bg-green-500/20 text-green-400'
+    : listener.status === 'warming'
+      ? 'bg-cyan-500/20 text-cyan-400'
+      : 'bg-yellow-500/20 text-yellow-400'
+
+  return (
+    <div className="rounded-md bg-secondary/30 px-3 py-2 flex items-center justify-between gap-2">
+      <div className="min-w-0 flex items-center gap-1.5">
+        {isActive ? (
+          <CheckCircle className="w-3.5 h-3.5 text-green-400 shrink-0" />
+        ) : (
+          <AlertTriangle className="w-3.5 h-3.5 text-yellow-400 shrink-0" />
+        )}
+        <span className="text-xs font-medium text-foreground truncate">{listener.name}</span>
+        <span className="text-xs text-muted-foreground shrink-0">
+          {listener.address}:{listener.port}
+        </span>
+      </div>
+      <span className={`text-[11px] px-1.5 py-0.5 rounded-full shrink-0 ${statusClass}`}>
+        {listener.status}
+      </span>
+    </div>
+  )
+}
+
+function ClusterRow({ cluster }: { cluster: EnvoyUpstreamCluster }) {
+  const isFullyHealthy =
+    cluster.endpointsTotal > 0 && cluster.endpointsHealthy === cluster.endpointsTotal
+  const hasAnyHealthy = cluster.endpointsHealthy > 0
+  const ringClass = isFullyHealthy
+    ? 'text-green-400'
+    : hasAnyHealthy
+      ? 'text-yellow-400'
+      : 'text-red-400'
+
+  return (
+    <div className="rounded-md bg-secondary/30 px-3 py-2 space-y-1">
+      <div className="flex items-center justify-between gap-2">
+        <div className="min-w-0 flex items-center gap-1.5">
+          <Server className={`w-3.5 h-3.5 shrink-0 ${ringClass}`} />
+          <span className="text-xs font-medium text-foreground truncate">{cluster.name}</span>
+        </div>
+        <span className={`text-[11px] font-mono shrink-0 ${ringClass}`}>
+          {cluster.endpointsHealthy}/{cluster.endpointsTotal}
+        </span>
+      </div>
+      <div className="text-xs text-muted-foreground truncate">{cluster.upstream}</div>
+    </div>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Main component
+// ---------------------------------------------------------------------------
+
+export function EnvoyStatus() {
+  const { t } = useTranslation('cards')
+  const { data, isRefreshing, error, showSkeleton, showEmptyState } = useCachedEnvoy()
+
+  const isHealthy = data.health === 'healthy'
+
+  if (showSkeleton) {
+    return (
+      <div className="h-full flex flex-col min-h-card gap-4">
+        <div className="flex items-center justify-between">
+          <Skeleton variant="rounded" width={140} height={28} />
+          <Skeleton variant="rounded" width={90} height={20} />
+        </div>
+        <SkeletonStats className="grid-cols-4" />
+        <SkeletonList items={5} className="flex-1" />
+      </div>
+    )
+  }
+
+  if (error && showEmptyState) {
+    return (
+      <div className="h-full flex flex-col items-center justify-center min-h-card text-muted-foreground gap-2">
+        <AlertTriangle className="w-6 h-6 text-red-400" />
+        <p className="text-sm text-red-400">{t('envoyStatus.fetchError', 'Unable to fetch Envoy status')}</p>
+      </div>
+    )
+  }
+
+  if (data.health === 'not-installed') {
+    return (
+      <div className="h-full flex flex-col items-center justify-center min-h-card text-muted-foreground gap-2">
+        <Shield className="w-6 h-6 text-muted-foreground/50" />
+        <p className="text-sm font-medium">
+          {t('envoyStatus.notInstalled', 'Envoy not detected')}
+        </p>
+        <p className="text-xs text-center max-w-xs">
+          {t(
+            'envoyStatus.notInstalledHint',
+            'No Envoy admin endpoint reachable from the connected clusters.',
+          )}
+        </p>
+      </div>
+    )
+  }
+
+  return (
+    <div className="h-full flex flex-col min-h-card content-loaded gap-4 overflow-hidden">
+      {/* Header — health pill + freshness */}
+      <div className="flex items-center justify-between gap-2">
+        <div
+          className={`flex items-center gap-2 px-3 py-1.5 rounded-full text-sm font-medium ${
+            isHealthy
+              ? 'bg-green-500/15 text-green-400'
+              : 'bg-yellow-500/15 text-yellow-400'
+          }`}
+        >
+          {isHealthy ? <CheckCircle className="w-4 h-4" /> : <AlertTriangle className="w-4 h-4" />}
+          {isHealthy
+            ? t('envoyStatus.healthy', 'Healthy')
+            : t('envoyStatus.degraded', 'Degraded')}
+        </div>
+
+        <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
+          <RefreshCw className={`w-3 h-3 ${isRefreshing ? 'animate-spin' : ''}`} />
+          <span>{formatRelativeTime(data.lastCheckTime)}</span>
+        </div>
+      </div>
+
+      {/* Summary tiles */}
+      <div className="grid grid-cols-2 @md:grid-cols-4 gap-2">
+        <MetricTile
+          label={t('envoyStatus.listeners', 'Listeners')}
+          value={`${data.summary.activeListeners}/${data.summary.totalListeners}`}
+          colorClass={
+            data.summary.activeListeners === data.summary.totalListeners
+              ? 'text-green-400'
+              : 'text-yellow-400'
+          }
+          icon={<Network className="w-4 h-4 text-cyan-400" />}
+        />
+        <MetricTile
+          label={t('envoyStatus.clusters', 'Clusters')}
+          value={`${data.summary.healthyClusters}/${data.summary.totalClusters}`}
+          colorClass={
+            data.summary.healthyClusters === data.summary.totalClusters
+              ? 'text-green-400'
+              : 'text-yellow-400'
+          }
+          icon={<Server className="w-4 h-4 text-blue-400" />}
+        />
+        <MetricTile
+          label={t('envoyStatus.rps', 'Requests/s')}
+          value={formatThroughput(data.stats.requestsPerSecond)}
+          colorClass="text-cyan-400"
+          icon={<Activity className="w-4 h-4 text-cyan-400" />}
+        />
+        <MetricTile
+          label={t('envoyStatus.activeConnections', 'Active conns')}
+          value={formatThroughput(data.stats.activeConnections)}
+          colorClass="text-foreground"
+          icon={<Zap className="w-4 h-4 text-yellow-400" />}
+        />
+      </div>
+
+      {/* Listener + cluster lists */}
+      <div className="space-y-3 overflow-y-auto scrollbar-thin pr-0.5">
+        <section className="space-y-2">
+          <div className="flex items-center gap-2">
+            <Network className="w-4 h-4 text-cyan-400" />
+            <h4 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+              {t('envoyStatus.sectionListeners', 'Listeners')}
+            </h4>
+            <span className="text-[11px] text-muted-foreground ml-auto">
+              {t('envoyStatus.http5xx', '5xx rate')}:{' '}
+              <span className={data.stats.http5xxRate > 0 ? 'text-yellow-400' : 'text-green-400'}>
+                {data.stats.http5xxRate.toFixed(HTTP_5XX_PERCENT_DECIMALS)}%
+              </span>
+            </span>
+          </div>
+
+          {data.listeners.length === 0 ? (
+            <div className="rounded-md bg-secondary/20 border border-border/40 px-3 py-2 text-xs text-muted-foreground">
+              {t('envoyStatus.noListeners', 'No listeners configured')}
+            </div>
+          ) : (
+            <div className="space-y-1.5">
+              {(data.listeners || []).map(listener => (
+                <ListenerRow
+                  key={`${listener.cluster}:${listener.name}:${listener.port}`}
+                  listener={listener}
+                />
+              ))}
+            </div>
+          )}
+        </section>
+
+        <section className="space-y-2">
+          <div className="flex items-center gap-2">
+            <Server className="w-4 h-4 text-blue-400" />
+            <h4 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+              {t('envoyStatus.sectionClusters', 'Upstream clusters')}
+            </h4>
+          </div>
+
+          {data.clusters.length === 0 ? (
+            <div className="rounded-md bg-secondary/20 border border-border/40 px-3 py-2 text-xs text-muted-foreground">
+              {t('envoyStatus.noClusters', 'No upstream clusters')}
+            </div>
+          ) : (
+            <div className="space-y-1.5">
+              {(data.clusters || []).map(cluster => (
+                <ClusterRow
+                  key={`${cluster.cluster}:${cluster.name}`}
+                  cluster={cluster}
+                />
+              ))}
+            </div>
+          )}
+        </section>
+      </div>
+    </div>
+  )
+}
+
+export default EnvoyStatus

--- a/web/src/components/cards/envoy_status/useCachedEnvoy.ts
+++ b/web/src/components/cards/envoy_status/useCachedEnvoy.ts
@@ -1,0 +1,254 @@
+/**
+ * Envoy Proxy Status Hook — Data fetching for the envoy_status card.
+ *
+ * Mirrors the contour_status pattern:
+ * - useCache with fetcher + demo fallback
+ * - isDemoFallback gated on !isLoading (prevents demo flash while loading)
+ * - fetchJson helper with treat404AsEmpty (no real endpoint yet — this is
+ *   scaffolding; the fetch will 404 until a real Envoy admin bridge lands,
+ *   at which point useCache will transparently switch to live data)
+ * - showSkeleton / showEmptyState from useCardLoadingState
+ */
+
+import { useCache } from '../../../lib/cache'
+import { useCardLoadingState } from '../CardDataContext'
+import { FETCH_DEFAULT_TIMEOUT_MS } from '../../../lib/constants/network'
+import { authFetch } from '../../../lib/api'
+import {
+  ENVOY_DEMO_DATA,
+  type EnvoyListener,
+  type EnvoyStats,
+  type EnvoyStatusData,
+  type EnvoyUpstreamCluster,
+} from './demoData'
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const CACHE_KEY = 'envoy-status'
+const ENVOY_STATUS_ENDPOINT = '/api/envoy/status'
+
+const EMPTY_STATS: EnvoyStats = {
+  requestsPerSecond: 0,
+  activeConnections: 0,
+  totalRequests: 0,
+  http5xxRate: 0,
+}
+
+const INITIAL_DATA: EnvoyStatusData = {
+  health: 'not-installed',
+  listeners: [],
+  clusters: [],
+  stats: EMPTY_STATS,
+  summary: {
+    totalListeners: 0,
+    activeListeners: 0,
+    totalClusters: 0,
+    healthyClusters: 0,
+  },
+  lastCheckTime: new Date().toISOString(),
+}
+
+// ---------------------------------------------------------------------------
+// Internal types (shape of the future /api/envoy/status response)
+// ---------------------------------------------------------------------------
+
+interface FetchResult<T> {
+  data: T
+  failed: boolean
+}
+
+interface EnvoyStatusResponse {
+  listeners?: EnvoyListener[]
+  clusters?: EnvoyUpstreamCluster[]
+  stats?: Partial<EnvoyStats>
+}
+
+// ---------------------------------------------------------------------------
+// Pure helpers
+// ---------------------------------------------------------------------------
+
+function summarize(
+  listeners: EnvoyListener[],
+  clusters: EnvoyUpstreamCluster[],
+) {
+  const totalListeners = listeners.length
+  const activeListeners = listeners.filter(l => l.status === 'active').length
+  const totalClusters = clusters.length
+  const healthyClusters = clusters.filter(
+    c => c.endpointsTotal > 0 && c.endpointsHealthy === c.endpointsTotal,
+  ).length
+
+  return { totalListeners, activeListeners, totalClusters, healthyClusters }
+}
+
+function deriveHealth(
+  listeners: EnvoyListener[],
+  clusters: EnvoyUpstreamCluster[],
+): EnvoyStatusData['health'] {
+  if (listeners.length === 0 && clusters.length === 0) {
+    return 'not-installed'
+  }
+  const hasUnhealthyCluster = clusters.some(
+    c => c.endpointsTotal > 0 && c.endpointsHealthy < c.endpointsTotal,
+  )
+  const hasInactiveListener = listeners.some(l => l.status !== 'active')
+  if (hasUnhealthyCluster || hasInactiveListener) {
+    return 'degraded'
+  }
+  return 'healthy'
+}
+
+function buildEnvoyStatus(
+  listeners: EnvoyListener[],
+  clusters: EnvoyUpstreamCluster[],
+  stats: EnvoyStats,
+): EnvoyStatusData {
+  return {
+    health: deriveHealth(listeners, clusters),
+    listeners,
+    clusters,
+    stats,
+    summary: summarize(listeners, clusters),
+    lastCheckTime: new Date().toISOString(),
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Private fetchJson helper (mirrors contour/flux pattern)
+// ---------------------------------------------------------------------------
+
+async function fetchJson<T>(
+  url: string,
+  options?: { treat404AsEmpty?: boolean },
+): Promise<FetchResult<T | null>> {
+  try {
+    const resp = await authFetch(url, {
+      headers: { Accept: 'application/json' },
+      signal: AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS),
+    })
+
+    if (!resp.ok) {
+      if (options?.treat404AsEmpty && resp.status === 404) {
+        return { data: null, failed: false }
+      }
+      return { data: null, failed: true }
+    }
+
+    const body = (await resp.json()) as T
+    return { data: body, failed: false }
+  } catch {
+    return { data: null, failed: true }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Fetcher
+// ---------------------------------------------------------------------------
+
+async function fetchEnvoyStatus(): Promise<EnvoyStatusData> {
+  const result = await fetchJson<EnvoyStatusResponse>(
+    ENVOY_STATUS_ENDPOINT,
+    { treat404AsEmpty: true },
+  )
+
+  // If the endpoint isn't wired up yet (404) or the request failed, the
+  // cache layer will surface demo data via its demoData fallback path.
+  if (result.failed) {
+    throw new Error('Unable to fetch Envoy status')
+  }
+
+  const body = result.data
+  const listeners = Array.isArray(body?.listeners) ? body.listeners : []
+  const clusters = Array.isArray(body?.clusters) ? body.clusters : []
+  const stats: EnvoyStats = {
+    requestsPerSecond: body?.stats?.requestsPerSecond ?? 0,
+    activeConnections: body?.stats?.activeConnections ?? 0,
+    totalRequests: body?.stats?.totalRequests ?? 0,
+    http5xxRate: body?.stats?.http5xxRate ?? 0,
+  }
+
+  return buildEnvoyStatus(listeners, clusters, stats)
+}
+
+// ---------------------------------------------------------------------------
+// Hook
+// ---------------------------------------------------------------------------
+
+export interface UseCachedEnvoyResult {
+  data: EnvoyStatusData
+  isLoading: boolean
+  isRefreshing: boolean
+  isDemoData: boolean
+  isFailed: boolean
+  consecutiveFailures: number
+  lastRefresh: number | null
+  showSkeleton: boolean
+  showEmptyState: boolean
+  error: boolean
+  refetch: () => Promise<void>
+}
+
+export function useCachedEnvoy(): UseCachedEnvoyResult {
+  const {
+    data,
+    isLoading,
+    isRefreshing,
+    isFailed,
+    consecutiveFailures,
+    isDemoFallback,
+    lastRefresh,
+    refetch,
+  } = useCache<EnvoyStatusData>({
+    key: CACHE_KEY,
+    category: 'services',
+    initialData: INITIAL_DATA,
+    demoData: ENVOY_DEMO_DATA,
+    persist: true,
+    fetcher: fetchEnvoyStatus,
+  })
+
+  // Prevent demo flash while loading — only surface the Demo badge once
+  // we've actually fallen back to demo data post-load.
+  const effectiveIsDemoData = isDemoFallback && !isLoading
+
+  // 'not-installed' counts as "data" so the card shows the empty state
+  // rather than an infinite skeleton when Envoy isn't present.
+  const hasAnyData =
+    data.health === 'not-installed' ? true : data.listeners.length > 0 || data.clusters.length > 0
+
+  const { showSkeleton, showEmptyState } = useCardLoadingState({
+    isLoading: isLoading && !hasAnyData,
+    isRefreshing,
+    hasAnyData,
+    isFailed,
+    consecutiveFailures,
+    isDemoData: effectiveIsDemoData,
+    lastRefresh,
+  })
+
+  return {
+    data,
+    isLoading,
+    isRefreshing,
+    isDemoData: effectiveIsDemoData,
+    isFailed,
+    consecutiveFailures,
+    lastRefresh,
+    showSkeleton,
+    showEmptyState,
+    error: isFailed && !hasAnyData,
+    refetch,
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Exported testables — pure functions for unit testing
+// ---------------------------------------------------------------------------
+
+export const __testables = {
+  summarize,
+  deriveHealth,
+  buildEnvoyStatus,
+}

--- a/web/src/components/dashboard/shared/cardCatalog.ts
+++ b/web/src/components/dashboard/shared/cardCatalog.ts
@@ -152,6 +152,7 @@ export const CARD_CATALOG = {
     { type: 'network_policy_status', title: 'Network Policy Status', description: 'NetworkPolicy resources with pod selectors and rules', visualization: 'table' },
     { type: 'cilium_status', title: 'Cilium', description: 'Cilium eBPF networking, network policy enforcement, and Hubble flow visibility.', visualization: 'status' },
     { type: 'contour_status', title: 'Contour', description: 'Contour ingress proxy status, HTTPProxy resources, and Envoy fleet health', visualization: 'status' },
+    { type: 'envoy_status', title: 'Envoy Proxy', description: 'Envoy listener health, upstream cluster health, and request/connection stats', visualization: 'status' },
     { type: 'network_trace', title: 'Network Traces', description: 'Live network connection tracing via Inspektor Gadget eBPF', visualization: 'table' },
     { type: 'dns_trace', title: 'DNS Traces', description: 'Live DNS query tracing via Inspektor Gadget eBPF', visualization: 'table' },
   ],

--- a/web/src/config/cards/envoy-status.ts
+++ b/web/src/config/cards/envoy-status.ts
@@ -1,0 +1,47 @@
+/**
+ * Envoy Proxy Status Card Configuration
+ *
+ * Envoy is a CNCF graduated edge/service proxy. This card surfaces
+ * listener health, upstream cluster health, and basic admin stats.
+ */
+import type { UnifiedCardConfig } from '../../lib/unified/types'
+
+export const envoyStatusConfig: UnifiedCardConfig = {
+  type: 'envoy_status',
+  title: 'Envoy Proxy',
+  category: 'network',
+  description:
+    'Envoy Proxy listener health, upstream cluster health, and request/connection stats.',
+  icon: 'Network',
+  iconColor: 'text-cyan-400',
+  defaultWidth: 6,
+  defaultHeight: 4,
+  dataSource: { type: 'hook', hook: 'useCachedEnvoy' },
+  content: {
+    type: 'list',
+    pageSize: 8,
+    columns: [
+      { field: 'name', header: 'Name', primary: true, render: 'truncate' },
+      { field: 'address', header: 'Address', width: 140, render: 'truncate' },
+      { field: 'port', header: 'Port', width: 80 },
+      { field: 'cluster', header: 'Cluster', width: 120, render: 'cluster-badge' },
+      { field: 'status', header: 'Status', width: 80, render: 'status-badge' },
+    ],
+  },
+  emptyState: {
+    icon: 'Network',
+    title: 'Envoy not detected',
+    message: 'No Envoy admin endpoint reachable from the connected clusters.',
+    variant: 'info',
+  },
+  loadingState: {
+    type: 'list',
+    rows: 5,
+  },
+  // Scaffolding: renders live if /api/envoy/status is wired up, otherwise
+  // falls back to demo data via the useCache demo path.
+  isDemoData: true,
+  isLive: false,
+}
+
+export default envoyStatusConfig

--- a/web/src/config/cards/index.ts
+++ b/web/src/config/cards/index.ts
@@ -63,6 +63,7 @@ import { githubActivityConfig } from './github-activity'
 import { githubCiMonitorConfig } from './github-ci-monitor'
 import { fluxStatusConfig } from './flux-status'
 import { contourStatusConfig } from './contour-status'
+import { envoyStatusConfig } from './envoy-status'
 import { nightlyReleasePulseConfig } from './nightly-release-pulse'
 import { workflowMatrixConfig } from './workflow-matrix'
 import { pipelineFlowConfig } from './pipeline-flow'
@@ -247,6 +248,7 @@ export const CARD_CONFIGS: CardConfigRegistry = {
   github_ci_monitor: githubCiMonitorConfig,
   flux_status: fluxStatusConfig,
   contour_status: contourStatusConfig,
+  envoy_status: envoyStatusConfig,
   nightly_release_pulse: nightlyReleasePulseConfig,
   workflow_matrix: workflowMatrixConfig,
   pipeline_flow: pipelineFlowConfig,

--- a/web/src/hooks/useMarketplace.ts
+++ b/web/src/hooks/useMarketplace.ts
@@ -93,6 +93,7 @@ const MARKETPLACE_TO_CARD_TYPE: Record<string, string> = {
   'cncf-lima': 'lima_status',
   'cncf-flux': 'flux_status',
   'cncf-contour': 'contour_status',
+  'cncf-envoy': 'envoy_status',
   'cncf-openfeature': 'openfeature_status',
   'cncf-strimzi': 'strimzi_status',
   'cncf-thanos': 'thanos_status' }

--- a/web/src/lib/demo/envoy.ts
+++ b/web/src/lib/demo/envoy.ts
@@ -1,0 +1,20 @@
+/**
+ * Envoy demo seed re-export.
+ *
+ * The canonical demo data lives alongside the Envoy card in
+ * `components/cards/envoy_status/demoData.ts`. This file re-exports it
+ * so callers outside the card folder (docs, tests, future drill-downs)
+ * can import a stable demo seed from `lib/demo/envoy`.
+ */
+
+export {
+  ENVOY_DEMO_DATA,
+  type EnvoyStatusData,
+  type EnvoyListener,
+  type EnvoyUpstreamCluster,
+  type EnvoyStats,
+  type EnvoySummary,
+  type EnvoyHealth,
+  type EnvoyListenerStatus,
+  type EnvoyClusterHealth,
+} from '../../components/cards/envoy_status/demoData'

--- a/web/src/lib/unified/registerHooks.ts
+++ b/web/src/lib/unified/registerHooks.ts
@@ -49,6 +49,7 @@ import {
   useServiceImports } from '../../hooks/useMCS'
 import { useFluxStatus } from '../../components/cards/flux_status/useFluxStatus'
 import { useContourStatus } from '../../components/cards/contour_status/useContourStatus'
+import { useCachedEnvoy } from '../../components/cards/envoy_status/useCachedEnvoy'
 
 // ============================================================================
 // Wrapper hooks that convert params object to positional args
@@ -1039,6 +1040,17 @@ function useUnifiedContourStatus() {
   }
 }
 
+function useUnifiedEnvoyStatus() {
+  const result = useCachedEnvoy()
+  // Surface the listener list as the primary row set for generic list renderers.
+  return {
+    data: result.data.listeners,
+    isLoading: result.showSkeleton,
+    error: result.error ? new Error('Failed to fetch Envoy status') : null,
+    refetch: () => { result.refetch() },
+  }
+}
+
 function useProviderHealth() {
   return useDemoDataHook(DEMO_PROVIDER_HEALTH)
 }
@@ -1226,6 +1238,7 @@ export function registerUnifiedHooks(): void {
   registerDataHook('useKustomizationStatus', useKustomizationStatus)
   registerDataHook('useFluxStatus', useUnifiedFluxStatus)
   registerDataHook('useContourStatus', useUnifiedContourStatus)
+  registerDataHook('useCachedEnvoy', useUnifiedEnvoyStatus)
   registerDataHook('useProviderHealth', useProviderHealth)
   registerDataHook('useUpgradeStatus', useUpgradeStatus)
   registerDataHook('useProwStatus', useProwStatus)

--- a/web/src/locales/en/cards.json
+++ b/web/src/locales/en/cards.json
@@ -3045,6 +3045,22 @@
     "syncedHoursAgo": "{{count}}h ago",
     "syncedDaysAgo": "{{count}}d ago"
   },
+  "envoyStatus": {
+    "healthy": "Healthy",
+    "degraded": "Degraded",
+    "notInstalled": "Envoy not detected",
+    "notInstalledHint": "No Envoy admin endpoint reachable from the connected clusters.",
+    "fetchError": "Unable to fetch Envoy status",
+    "listeners": "Listeners",
+    "clusters": "Clusters",
+    "rps": "Requests/s",
+    "activeConnections": "Active conns",
+    "http5xx": "5xx rate",
+    "sectionListeners": "Listeners",
+    "sectionClusters": "Upstream clusters",
+    "noListeners": "No listeners configured",
+    "noClusters": "No upstream clusters"
+  },
   "kubecostOverview": {
     "monthlyCost": "Monthly Cost",
     "savingsRecommendations": "Savings Recommendations",


### PR DESCRIPTION
Adds EnvoyStatus card (Service Mesh / network category) with listeners, upstream clusters, and basic admin stats view.

## Changes
- New card component `components/cards/envoy_status/index.tsx` (listener + upstream cluster lists, 4-tile summary header, health pill, 5xx rate indicator)
- Hook `components/cards/envoy_status/useCachedEnvoy.ts` using `useCache` with demo fallback, SWR, and failure tracking
- Card config `config/cards/envoy-status.ts` (category: network, width 6, list content)
- Demo data seed in both `components/cards/envoy_status/demoData.ts` (canonical) and `lib/demo/envoy.ts` (stable re-export)
- Registered in `cardRegistry.ts` (lazy import + type map + preloader + default-width), `config/cards/index.ts`, `cardMetadata.ts`, `cardCatalog.ts`, `registerHooks.ts`, and `useMarketplace.ts` (for the `cncf-envoy` marketplace slug)
- English translations added; other locales fall back to English

## Design notes
- Follows the `contour_status` pattern line-for-line (same folder layout, same hook shape, same fetcher gating)
- Uses `isLoading && !hasAnyData` card-standard (no bare `isLoading`); `isDemoData` wired into `useCardLoadingState` so the Demo badge + yellow outline show correctly
- `not-installed` treated as `hasAnyData=true` to avoid infinite skeleton when Envoy is absent
- All numeric literals are named constants; all colors are semantic Tailwind classes (no raw hex)

## Scaffolding note
Real Envoy Admin API integration (`/listeners`, `/clusters`, `/stats`) is deferred to a follow-up. The hook already hits `/api/envoy/status`; when that endpoint lands, the card picks up live data automatically. Until then the card renders demo data in demo mode and shows `not-installed` when connected to a real cluster without Envoy.

Refs kubestellar/console-marketplace#3