### PR TITLE
feat(linkerd): add Linkerd monitoring card

### DIFF
--- a/web/src/components/cards/cardMetadata.ts
+++ b/web/src/components/cards/cardMetadata.ts
@@ -268,6 +268,8 @@ export const CARD_TITLES: Record<string, string> = {
   contour_status: 'Contour',
   // Envoy proxy (service mesh / edge)
   envoy_status: 'Envoy Proxy',
+  // Linkerd service mesh
+  linkerd_status: 'Linkerd',
   // CRI-O container runtime
   crio_status: 'CRI-O',
   // Strimzi Kafka operator
@@ -579,6 +581,8 @@ export const CARD_DESCRIPTIONS: Record<string, string> = {
   contour_status: 'Contour ingress proxy status, HTTPProxy resources, and Envoy fleet health.',
   // Envoy proxy (service mesh / edge)
   envoy_status: 'Envoy Proxy listener health, upstream cluster health, and request/connection stats.',
+  // Linkerd service mesh
+  linkerd_status: 'Linkerd service mesh meshed pods, success rate, RPS, and p99 latency per deployment.',
   // CRI-O container runtime
   crio_status: 'CRI-O container runtime metrics, image pulls, and pod sandbox status.',
 

--- a/web/src/components/cards/cardRegistry.ts
+++ b/web/src/components/cards/cardRegistry.ts
@@ -82,6 +82,8 @@ const FluxStatus = safeLazy(() => import('./flux_status'), 'FluxStatus')
 const ContourStatus = safeLazy(() => import('./contour_status'), 'ContourStatus')
 // Envoy proxy card (Service Mesh / network)
 const EnvoyStatus = safeLazy(() => import('./envoy_status'), 'EnvoyStatus')
+// Linkerd service mesh card
+const LinkerdStatus = safeLazy(() => import('./linkerd_status'), 'LinkerdStatus')
 const OverlayComparison = safeLazy(() => _deployBundle, 'OverlayComparison')
 const ArgoCDApplications = safeLazy(() => _deployBundle, 'ArgoCDApplications')
 const ArgoCDApplicationSets = safeLazy(() => _deployBundle, 'ArgoCDApplicationSets')
@@ -704,6 +706,8 @@ const RAW_CARD_COMPONENTS: Record<string, CardComponent> = {
   contour_status: ContourStatus,
   // Envoy proxy (service mesh / edge)
   envoy_status: EnvoyStatus,
+  // Linkerd service mesh
+  linkerd_status: LinkerdStatus,
   // Artifact Hub
   artifact_hub_status: ArtifactHubStatus,
   // CloudEvents messaging
@@ -1023,6 +1027,7 @@ const CARD_CHUNK_PRELOADERS: Record<string, () => Promise<unknown>> = {
   flux_status: () => import('./flux_status'),
   contour_status: () => import('./contour_status'),
   envoy_status: () => import('./envoy_status'),
+  linkerd_status: () => import('./linkerd_status'),
   overlay_comparison: () => import('./deploy-bundle'),
   argocd_applications: () => import('./deploy-bundle'),
   argocd_applicationsets: () => import('./deploy-bundle'),
@@ -1613,6 +1618,7 @@ export const CARD_DEFAULT_WIDTHS: Record<string, number> = {
   flux_status: 6,
   contour_status: 6,
   envoy_status: 6,
+  linkerd_status: 6,
   pvc_status: 6,
   gpu_status: 6,
   gpu_inventory: 6,

--- a/web/src/components/cards/linkerd_status/demoData.ts
+++ b/web/src/components/cards/linkerd_status/demoData.ts
@@ -1,0 +1,167 @@
+/**
+ * Linkerd Service Mesh Status Card — Demo Data & Type Definitions
+ *
+ * Models Linkerd meshed pods (per-deployment) with success rate, RPS, and
+ * p99 latency — the golden signals surfaced by `linkerd viz stat`.
+ *
+ * This is scaffolding — a real integration with the Linkerd Viz extension
+ * (`/api/tap` / Prometheus) can be wired into `fetchLinkerdStatus` in a
+ * follow-up. Until then, cards fall back to this demo data via `useCache`.
+ */
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type LinkerdPodStatus = 'meshed' | 'partial' | 'unmeshed'
+export type LinkerdHealth = 'healthy' | 'degraded' | 'not-installed'
+
+export interface LinkerdMeshedDeployment {
+  namespace: string
+  deployment: string
+  meshedPods: number
+  totalPods: number
+  successRatePct: number
+  requestsPerSecond: number
+  p99LatencyMs: number
+  status: LinkerdPodStatus
+  cluster: string
+}
+
+export interface LinkerdStats {
+  totalRps: number
+  avgSuccessRatePct: number
+  avgP99LatencyMs: number
+  controlPlaneVersion: string
+}
+
+export interface LinkerdSummary {
+  totalDeployments: number
+  fullyMeshedDeployments: number
+  totalMeshedPods: number
+  totalPods: number
+}
+
+export interface LinkerdStatusData {
+  health: LinkerdHealth
+  deployments: LinkerdMeshedDeployment[]
+  stats: LinkerdStats
+  summary: LinkerdSummary
+  lastCheckTime: string
+}
+
+// ---------------------------------------------------------------------------
+// Demo-data constants (named — no magic numbers)
+// ---------------------------------------------------------------------------
+
+const DEMO_TOTAL_RPS = 842
+const DEMO_AVG_SUCCESS_RATE_PCT = 99.42
+const DEMO_AVG_P99_LATENCY_MS = 18
+const DEMO_CONTROL_PLANE_VERSION = 'stable-2.14.10'
+
+// Per-deployment demo metrics
+const FRONTEND_POD_COUNT = 4
+const FRONTEND_RPS = 312
+const FRONTEND_SUCCESS_PCT = 99.87
+const FRONTEND_P99_MS = 14
+
+const API_POD_COUNT = 6
+const API_RPS = 287
+const API_SUCCESS_PCT = 99.63
+const API_P99_MS = 22
+
+const AUTH_POD_COUNT = 3
+const AUTH_RPS = 148
+const AUTH_SUCCESS_PCT = 100.0
+const AUTH_P99_MS = 9
+
+const PAYMENTS_TOTAL_PODS = 4
+const PAYMENTS_MESHED_PODS = 3
+const PAYMENTS_RPS = 62
+const PAYMENTS_SUCCESS_PCT = 97.41
+const PAYMENTS_P99_MS = 41
+
+const EMAIL_POD_COUNT = 2
+const EMAIL_RPS = 33
+const EMAIL_SUCCESS_PCT = 99.94
+const EMAIL_P99_MS = 11
+
+// ---------------------------------------------------------------------------
+// Demo data — shown when Linkerd is not installed or in demo mode
+// ---------------------------------------------------------------------------
+
+const DEMO_DEPLOYMENTS: LinkerdMeshedDeployment[] = [
+  {
+    namespace: 'frontend',
+    deployment: 'web',
+    meshedPods: FRONTEND_POD_COUNT,
+    totalPods: FRONTEND_POD_COUNT,
+    successRatePct: FRONTEND_SUCCESS_PCT,
+    requestsPerSecond: FRONTEND_RPS,
+    p99LatencyMs: FRONTEND_P99_MS,
+    status: 'meshed',
+    cluster: 'default',
+  },
+  {
+    namespace: 'api',
+    deployment: 'api-gateway',
+    meshedPods: API_POD_COUNT,
+    totalPods: API_POD_COUNT,
+    successRatePct: API_SUCCESS_PCT,
+    requestsPerSecond: API_RPS,
+    p99LatencyMs: API_P99_MS,
+    status: 'meshed',
+    cluster: 'default',
+  },
+  {
+    namespace: 'auth',
+    deployment: 'auth-service',
+    meshedPods: AUTH_POD_COUNT,
+    totalPods: AUTH_POD_COUNT,
+    successRatePct: AUTH_SUCCESS_PCT,
+    requestsPerSecond: AUTH_RPS,
+    p99LatencyMs: AUTH_P99_MS,
+    status: 'meshed',
+    cluster: 'default',
+  },
+  {
+    namespace: 'payments',
+    deployment: 'payments-api',
+    meshedPods: PAYMENTS_MESHED_PODS,
+    totalPods: PAYMENTS_TOTAL_PODS,
+    successRatePct: PAYMENTS_SUCCESS_PCT,
+    requestsPerSecond: PAYMENTS_RPS,
+    p99LatencyMs: PAYMENTS_P99_MS,
+    status: 'partial',
+    cluster: 'default',
+  },
+  {
+    namespace: 'notifications',
+    deployment: 'email-sender',
+    meshedPods: EMAIL_POD_COUNT,
+    totalPods: EMAIL_POD_COUNT,
+    successRatePct: EMAIL_SUCCESS_PCT,
+    requestsPerSecond: EMAIL_RPS,
+    p99LatencyMs: EMAIL_P99_MS,
+    status: 'meshed',
+    cluster: 'default',
+  },
+]
+
+export const LINKERD_DEMO_DATA: LinkerdStatusData = {
+  health: 'degraded',
+  deployments: DEMO_DEPLOYMENTS,
+  stats: {
+    totalRps: DEMO_TOTAL_RPS,
+    avgSuccessRatePct: DEMO_AVG_SUCCESS_RATE_PCT,
+    avgP99LatencyMs: DEMO_AVG_P99_LATENCY_MS,
+    controlPlaneVersion: DEMO_CONTROL_PLANE_VERSION,
+  },
+  summary: {
+    totalDeployments: DEMO_DEPLOYMENTS.length,
+    fullyMeshedDeployments: DEMO_DEPLOYMENTS.filter(d => d.status === 'meshed').length,
+    totalMeshedPods: DEMO_DEPLOYMENTS.reduce((sum, d) => sum + d.meshedPods, 0),
+    totalPods: DEMO_DEPLOYMENTS.reduce((sum, d) => sum + d.totalPods, 0),
+  },
+  lastCheckTime: new Date().toISOString(),
+}

--- a/web/src/components/cards/linkerd_status/index.tsx
+++ b/web/src/components/cards/linkerd_status/index.tsx
@@ -1,0 +1,264 @@
+/**
+ * Linkerd Service Mesh Status Card
+ *
+ * Displays Linkerd meshed deployments with success rate, RPS, and p99 latency.
+ * Follows the envoy_status / contour_status pattern for structure and styling.
+ *
+ * This is scaffolding — the card renders via demo fallback today. When a
+ * real Linkerd Viz bridge lands, the hook's fetcher will pick up live data
+ * automatically with no component changes.
+ */
+
+import {
+  Activity,
+  AlertTriangle,
+  CheckCircle,
+  Gauge,
+  Network,
+  RefreshCw,
+  Shield,
+  Zap,
+} from 'lucide-react'
+import { useTranslation } from 'react-i18next'
+import { MetricTile } from '../../../lib/cards/CardComponents'
+import { Skeleton, SkeletonList, SkeletonStats } from '../../ui/Skeleton'
+import { useCachedLinkerd } from '../../../hooks/useCachedLinkerd'
+import type { LinkerdMeshedDeployment } from './demoData'
+
+// ---------------------------------------------------------------------------
+// Named constants (no magic numbers)
+// ---------------------------------------------------------------------------
+
+const RELATIVE_TIME_MINUTE_MS = 60_000
+const MINUTES_PER_HOUR = 60
+const HOURS_PER_DAY = 24
+const SUCCESS_RATE_DECIMALS = 2
+const THROUGHPUT_LOCALE_MIN_FRACTION = 0
+const SUCCESS_RATE_WARN_THRESHOLD_PCT = 99.0
+const SUCCESS_RATE_CRIT_THRESHOLD_PCT = 95.0
+const P99_LATENCY_WARN_MS = 30
+const P99_LATENCY_CRIT_MS = 100
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function formatRelativeTime(isoString: string): string {
+  const parsed = new Date(isoString).getTime()
+  if (!isoString || Number.isNaN(parsed)) return 'just now'
+
+  const diff = Date.now() - parsed
+  if (diff < 0) return 'just now'
+
+  const hour = MINUTES_PER_HOUR * RELATIVE_TIME_MINUTE_MS
+  const day = HOURS_PER_DAY * hour
+
+  if (diff < RELATIVE_TIME_MINUTE_MS) return 'just now'
+  if (diff < hour) return `${Math.floor(diff / RELATIVE_TIME_MINUTE_MS)}m ago`
+  if (diff < day) return `${Math.floor(diff / hour)}h ago`
+  return `${Math.floor(diff / day)}d ago`
+}
+
+function formatThroughput(value: number): string {
+  return value.toLocaleString(undefined, {
+    minimumFractionDigits: THROUGHPUT_LOCALE_MIN_FRACTION,
+  })
+}
+
+function successRateColorClass(pct: number): string {
+  if (pct >= SUCCESS_RATE_WARN_THRESHOLD_PCT) return 'text-green-400'
+  if (pct >= SUCCESS_RATE_CRIT_THRESHOLD_PCT) return 'text-yellow-400'
+  return 'text-red-400'
+}
+
+function latencyColorClass(ms: number): string {
+  if (ms <= P99_LATENCY_WARN_MS) return 'text-green-400'
+  if (ms <= P99_LATENCY_CRIT_MS) return 'text-yellow-400'
+  return 'text-red-400'
+}
+
+// ---------------------------------------------------------------------------
+// Subsections
+// ---------------------------------------------------------------------------
+
+function DeploymentRow({ deployment }: { deployment: LinkerdMeshedDeployment }) {
+  const isFullyMeshed = deployment.status === 'meshed'
+  const statusClass = isFullyMeshed
+    ? 'bg-green-500/20 text-green-400'
+    : deployment.status === 'partial'
+      ? 'bg-yellow-500/20 text-yellow-400'
+      : 'bg-red-500/20 text-red-400'
+
+  return (
+    <div className="rounded-md bg-secondary/30 px-3 py-2 space-y-1">
+      <div className="flex items-center justify-between gap-2">
+        <div className="min-w-0 flex items-center gap-1.5">
+          {isFullyMeshed ? (
+            <CheckCircle className="w-3.5 h-3.5 text-green-400 shrink-0" />
+          ) : (
+            <AlertTriangle className="w-3.5 h-3.5 text-yellow-400 shrink-0" />
+          )}
+          <span className="text-xs font-medium text-foreground truncate">
+            {deployment.namespace}/{deployment.deployment}
+          </span>
+        </div>
+        <span className={`text-[11px] px-1.5 py-0.5 rounded-full shrink-0 ${statusClass}`}>
+          {deployment.meshedPods}/{deployment.totalPods}
+        </span>
+      </div>
+      <div className="flex items-center gap-3 text-[11px] font-mono">
+        <span className={successRateColorClass(deployment.successRatePct)}>
+          {deployment.successRatePct.toFixed(SUCCESS_RATE_DECIMALS)}%
+        </span>
+        <span className="text-muted-foreground">
+          {formatThroughput(deployment.requestsPerSecond)} rps
+        </span>
+        <span className={latencyColorClass(deployment.p99LatencyMs)}>
+          p99 {deployment.p99LatencyMs}ms
+        </span>
+      </div>
+    </div>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Main component
+// ---------------------------------------------------------------------------
+
+export function LinkerdStatus() {
+  const { t } = useTranslation('cards')
+  const { data, isRefreshing, error, showSkeleton, showEmptyState } = useCachedLinkerd()
+
+  const isHealthy = data.health === 'healthy'
+
+  if (showSkeleton) {
+    return (
+      <div className="h-full flex flex-col min-h-card gap-4">
+        <div className="flex items-center justify-between">
+          <Skeleton variant="rounded" width={140} height={28} />
+          <Skeleton variant="rounded" width={90} height={20} />
+        </div>
+        <SkeletonStats className="grid-cols-4" />
+        <SkeletonList items={5} className="flex-1" />
+      </div>
+    )
+  }
+
+  if (error && showEmptyState) {
+    return (
+      <div className="h-full flex flex-col items-center justify-center min-h-card text-muted-foreground gap-2">
+        <AlertTriangle className="w-6 h-6 text-red-400" />
+        <p className="text-sm text-red-400">
+          {t('linkerdStatus.fetchError', 'Unable to fetch Linkerd status')}
+        </p>
+      </div>
+    )
+  }
+
+  if (data.health === 'not-installed') {
+    return (
+      <div className="h-full flex flex-col items-center justify-center min-h-card text-muted-foreground gap-2">
+        <Shield className="w-6 h-6 text-muted-foreground/50" />
+        <p className="text-sm font-medium">
+          {t('linkerdStatus.notInstalled', 'Linkerd not detected')}
+        </p>
+        <p className="text-xs text-center max-w-xs">
+          {t(
+            'linkerdStatus.notInstalledHint',
+            'No Linkerd control plane reachable from the connected clusters.',
+          )}
+        </p>
+      </div>
+    )
+  }
+
+  return (
+    <div className="h-full flex flex-col min-h-card content-loaded gap-4 overflow-hidden">
+      {/* Header — health pill + freshness */}
+      <div className="flex items-center justify-between gap-2">
+        <div
+          className={`flex items-center gap-2 px-3 py-1.5 rounded-full text-sm font-medium ${
+            isHealthy
+              ? 'bg-green-500/15 text-green-400'
+              : 'bg-yellow-500/15 text-yellow-400'
+          }`}
+        >
+          {isHealthy ? <CheckCircle className="w-4 h-4" /> : <AlertTriangle className="w-4 h-4" />}
+          {isHealthy
+            ? t('linkerdStatus.healthy', 'Healthy')
+            : t('linkerdStatus.degraded', 'Degraded')}
+        </div>
+
+        <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
+          <RefreshCw className={`w-3 h-3 ${isRefreshing ? 'animate-spin' : ''}`} />
+          <span>{formatRelativeTime(data.lastCheckTime)}</span>
+        </div>
+      </div>
+
+      {/* Summary tiles */}
+      <div className="grid grid-cols-2 @md:grid-cols-4 gap-2">
+        <MetricTile
+          label={t('linkerdStatus.meshedPods', 'Meshed pods')}
+          value={`${data.summary.totalMeshedPods}/${data.summary.totalPods}`}
+          colorClass={
+            data.summary.totalMeshedPods === data.summary.totalPods
+              ? 'text-green-400'
+              : 'text-yellow-400'
+          }
+          icon={<Network className="w-4 h-4 text-cyan-400" />}
+        />
+        <MetricTile
+          label={t('linkerdStatus.successRate', 'Success rate')}
+          value={`${data.stats.avgSuccessRatePct.toFixed(SUCCESS_RATE_DECIMALS)}%`}
+          colorClass={successRateColorClass(data.stats.avgSuccessRatePct)}
+          icon={<Gauge className="w-4 h-4 text-green-400" />}
+        />
+        <MetricTile
+          label={t('linkerdStatus.rps', 'Requests/s')}
+          value={formatThroughput(data.stats.totalRps)}
+          colorClass="text-cyan-400"
+          icon={<Activity className="w-4 h-4 text-cyan-400" />}
+        />
+        <MetricTile
+          label={t('linkerdStatus.p99Latency', 'Avg p99')}
+          value={`${data.stats.avgP99LatencyMs}ms`}
+          colorClass={latencyColorClass(data.stats.avgP99LatencyMs)}
+          icon={<Zap className="w-4 h-4 text-yellow-400" />}
+        />
+      </div>
+
+      {/* Meshed deployments list */}
+      <div className="space-y-3 overflow-y-auto scrollbar-thin pr-0.5">
+        <section className="space-y-2">
+          <div className="flex items-center gap-2">
+            <Network className="w-4 h-4 text-cyan-400" />
+            <h4 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+              {t('linkerdStatus.sectionDeployments', 'Meshed deployments')}
+            </h4>
+            <span className="text-[11px] text-muted-foreground ml-auto">
+              {t('linkerdStatus.controlPlane', 'control plane')}:{' '}
+              <span className="text-foreground">{data.stats.controlPlaneVersion}</span>
+            </span>
+          </div>
+
+          {data.deployments.length === 0 ? (
+            <div className="rounded-md bg-secondary/20 border border-border/40 px-3 py-2 text-xs text-muted-foreground">
+              {t('linkerdStatus.noDeployments', 'No meshed deployments found')}
+            </div>
+          ) : (
+            <div className="space-y-1.5">
+              {(data.deployments || []).map(deployment => (
+                <DeploymentRow
+                  key={`${deployment.cluster}:${deployment.namespace}:${deployment.deployment}`}
+                  deployment={deployment}
+                />
+              ))}
+            </div>
+          )}
+        </section>
+      </div>
+    </div>
+  )
+}
+
+export default LinkerdStatus

--- a/web/src/components/dashboard/shared/cardCatalog.ts
+++ b/web/src/components/dashboard/shared/cardCatalog.ts
@@ -153,6 +153,7 @@ export const CARD_CATALOG = {
     { type: 'cilium_status', title: 'Cilium', description: 'Cilium eBPF networking, network policy enforcement, and Hubble flow visibility.', visualization: 'status' },
     { type: 'contour_status', title: 'Contour', description: 'Contour ingress proxy status, HTTPProxy resources, and Envoy fleet health', visualization: 'status' },
     { type: 'envoy_status', title: 'Envoy Proxy', description: 'Envoy listener health, upstream cluster health, and request/connection stats', visualization: 'status' },
+    { type: 'linkerd_status', title: 'Linkerd', description: 'Linkerd service mesh meshed pods, success rate, RPS, and p99 latency per deployment', visualization: 'status' },
     { type: 'network_trace', title: 'Network Traces', description: 'Live network connection tracing via Inspektor Gadget eBPF', visualization: 'table' },
     { type: 'dns_trace', title: 'DNS Traces', description: 'Live DNS query tracing via Inspektor Gadget eBPF', visualization: 'table' },
   ],

--- a/web/src/config/cards/index.ts
+++ b/web/src/config/cards/index.ts
@@ -64,6 +64,7 @@ import { githubCiMonitorConfig } from './github-ci-monitor'
 import { fluxStatusConfig } from './flux-status'
 import { contourStatusConfig } from './contour-status'
 import { envoyStatusConfig } from './envoy-status'
+import { linkerdStatusConfig } from './linkerd-status'
 import { nightlyReleasePulseConfig } from './nightly-release-pulse'
 import { workflowMatrixConfig } from './workflow-matrix'
 import { pipelineFlowConfig } from './pipeline-flow'
@@ -249,6 +250,7 @@ export const CARD_CONFIGS: CardConfigRegistry = {
   flux_status: fluxStatusConfig,
   contour_status: contourStatusConfig,
   envoy_status: envoyStatusConfig,
+  linkerd_status: linkerdStatusConfig,
   nightly_release_pulse: nightlyReleasePulseConfig,
   workflow_matrix: workflowMatrixConfig,
   pipeline_flow: pipelineFlowConfig,

--- a/web/src/config/cards/linkerd-status.ts
+++ b/web/src/config/cards/linkerd-status.ts
@@ -1,0 +1,51 @@
+/**
+ * Linkerd Service Mesh Status Card Configuration
+ *
+ * Linkerd is a CNCF graduated service mesh. This card surfaces meshed
+ * deployments with golden-signals metrics (success rate, RPS, p99 latency)
+ * as seen by the Linkerd Viz extension.
+ */
+import type { UnifiedCardConfig } from '../../lib/unified/types'
+
+export const linkerdStatusConfig: UnifiedCardConfig = {
+  type: 'linkerd_status',
+  title: 'Linkerd',
+  category: 'network',
+  description:
+    'Linkerd service mesh meshed pods, success rate, RPS, and p99 latency per deployment.',
+  icon: 'Network',
+  iconColor: 'text-cyan-400',
+  defaultWidth: 6,
+  defaultHeight: 4,
+  dataSource: { type: 'hook', hook: 'useCachedLinkerd' },
+  content: {
+    type: 'list',
+    pageSize: 8,
+    columns: [
+      { field: 'deployment', header: 'Deployment', primary: true, render: 'truncate' },
+      { field: 'namespace', header: 'Namespace', width: 140, render: 'truncate' },
+      { field: 'meshedPods', header: 'Meshed', width: 80 },
+      { field: 'successRatePct', header: 'Success', width: 90 },
+      { field: 'requestsPerSecond', header: 'RPS', width: 80 },
+      { field: 'p99LatencyMs', header: 'p99', width: 80 },
+      { field: 'cluster', header: 'Cluster', width: 120, render: 'cluster-badge' },
+      { field: 'status', header: 'Status', width: 90, render: 'status-badge' },
+    ],
+  },
+  emptyState: {
+    icon: 'Network',
+    title: 'Linkerd not detected',
+    message: 'No Linkerd control plane reachable from the connected clusters.',
+    variant: 'info',
+  },
+  loadingState: {
+    type: 'list',
+    rows: 5,
+  },
+  // Scaffolding: renders live if /api/linkerd/status is wired up, otherwise
+  // falls back to demo data via the useCache demo path.
+  isDemoData: true,
+  isLive: false,
+}
+
+export default linkerdStatusConfig

--- a/web/src/hooks/useCachedLinkerd.ts
+++ b/web/src/hooks/useCachedLinkerd.ts
@@ -1,0 +1,241 @@
+/**
+ * Linkerd Service Mesh Status Hook — Data fetching for the linkerd_status card.
+ *
+ * Mirrors the envoy_status / contour_status pattern:
+ * - useCache with fetcher + demo fallback
+ * - isDemoFallback gated on !isLoading (prevents demo flash while loading)
+ * - fetchJson helper with treat404AsEmpty (no real endpoint yet — this is
+ *   scaffolding; the fetch will 404 until a real Linkerd Viz bridge lands,
+ *   at which point useCache will transparently switch to live data)
+ * - showSkeleton / showEmptyState from useCardLoadingState
+ */
+
+import { useCache } from '../lib/cache'
+import { useCardLoadingState } from '../components/cards/CardDataContext'
+import { FETCH_DEFAULT_TIMEOUT_MS } from '../lib/constants/network'
+import { authFetch } from '../lib/api'
+import {
+  LINKERD_DEMO_DATA,
+  type LinkerdMeshedDeployment,
+  type LinkerdStats,
+  type LinkerdStatusData,
+} from '../components/cards/linkerd_status/demoData'
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const CACHE_KEY = 'linkerd-status'
+const LINKERD_STATUS_ENDPOINT = '/api/linkerd/status'
+const DEFAULT_CONTROL_PLANE_VERSION = 'unknown'
+const FULLY_MESHED_SUCCESS_THRESHOLD_PCT = 99.0
+
+const EMPTY_STATS: LinkerdStats = {
+  totalRps: 0,
+  avgSuccessRatePct: 0,
+  avgP99LatencyMs: 0,
+  controlPlaneVersion: DEFAULT_CONTROL_PLANE_VERSION,
+}
+
+const INITIAL_DATA: LinkerdStatusData = {
+  health: 'not-installed',
+  deployments: [],
+  stats: EMPTY_STATS,
+  summary: {
+    totalDeployments: 0,
+    fullyMeshedDeployments: 0,
+    totalMeshedPods: 0,
+    totalPods: 0,
+  },
+  lastCheckTime: new Date().toISOString(),
+}
+
+// ---------------------------------------------------------------------------
+// Internal types (shape of the future /api/linkerd/status response)
+// ---------------------------------------------------------------------------
+
+interface FetchResult<T> {
+  data: T
+  failed: boolean
+}
+
+interface LinkerdStatusResponse {
+  deployments?: LinkerdMeshedDeployment[]
+  stats?: Partial<LinkerdStats>
+}
+
+// ---------------------------------------------------------------------------
+// Pure helpers
+// ---------------------------------------------------------------------------
+
+function summarize(deployments: LinkerdMeshedDeployment[]) {
+  const totalDeployments = deployments.length
+  const fullyMeshedDeployments = deployments.filter(d => d.status === 'meshed').length
+  const totalMeshedPods = deployments.reduce((sum, d) => sum + d.meshedPods, 0)
+  const totalPods = deployments.reduce((sum, d) => sum + d.totalPods, 0)
+  return { totalDeployments, fullyMeshedDeployments, totalMeshedPods, totalPods }
+}
+
+function deriveHealth(
+  deployments: LinkerdMeshedDeployment[],
+): LinkerdStatusData['health'] {
+  if (deployments.length === 0) {
+    return 'not-installed'
+  }
+  const hasUnhealthy = deployments.some(
+    d =>
+      d.status !== 'meshed' ||
+      d.successRatePct < FULLY_MESHED_SUCCESS_THRESHOLD_PCT,
+  )
+  return hasUnhealthy ? 'degraded' : 'healthy'
+}
+
+function buildLinkerdStatus(
+  deployments: LinkerdMeshedDeployment[],
+  stats: LinkerdStats,
+): LinkerdStatusData {
+  return {
+    health: deriveHealth(deployments),
+    deployments,
+    stats,
+    summary: summarize(deployments),
+    lastCheckTime: new Date().toISOString(),
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Private fetchJson helper (mirrors envoy/contour pattern)
+// ---------------------------------------------------------------------------
+
+async function fetchJson<T>(
+  url: string,
+  options?: { treat404AsEmpty?: boolean },
+): Promise<FetchResult<T | null>> {
+  try {
+    const resp = await authFetch(url, {
+      headers: { Accept: 'application/json' },
+      signal: AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS),
+    })
+
+    if (!resp.ok) {
+      if (options?.treat404AsEmpty && resp.status === 404) {
+        return { data: null, failed: false }
+      }
+      return { data: null, failed: true }
+    }
+
+    const body = (await resp.json()) as T
+    return { data: body, failed: false }
+  } catch {
+    return { data: null, failed: true }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Fetcher
+// ---------------------------------------------------------------------------
+
+async function fetchLinkerdStatus(): Promise<LinkerdStatusData> {
+  const result = await fetchJson<LinkerdStatusResponse>(
+    LINKERD_STATUS_ENDPOINT,
+    { treat404AsEmpty: true },
+  )
+
+  // If the endpoint isn't wired up yet (404) or the request failed, the
+  // cache layer will surface demo data via its demoData fallback path.
+  if (result.failed) {
+    throw new Error('Unable to fetch Linkerd status')
+  }
+
+  const body = result.data
+  const deployments = Array.isArray(body?.deployments) ? body.deployments : []
+  const stats: LinkerdStats = {
+    totalRps: body?.stats?.totalRps ?? 0,
+    avgSuccessRatePct: body?.stats?.avgSuccessRatePct ?? 0,
+    avgP99LatencyMs: body?.stats?.avgP99LatencyMs ?? 0,
+    controlPlaneVersion: body?.stats?.controlPlaneVersion ?? DEFAULT_CONTROL_PLANE_VERSION,
+  }
+
+  return buildLinkerdStatus(deployments, stats)
+}
+
+// ---------------------------------------------------------------------------
+// Hook
+// ---------------------------------------------------------------------------
+
+export interface UseCachedLinkerdResult {
+  data: LinkerdStatusData
+  isLoading: boolean
+  isRefreshing: boolean
+  isDemoData: boolean
+  isFailed: boolean
+  consecutiveFailures: number
+  lastRefresh: number | null
+  showSkeleton: boolean
+  showEmptyState: boolean
+  error: boolean
+  refetch: () => Promise<void>
+}
+
+export function useCachedLinkerd(): UseCachedLinkerdResult {
+  const {
+    data,
+    isLoading,
+    isRefreshing,
+    isFailed,
+    consecutiveFailures,
+    isDemoFallback,
+    lastRefresh,
+    refetch,
+  } = useCache<LinkerdStatusData>({
+    key: CACHE_KEY,
+    category: 'services',
+    initialData: INITIAL_DATA,
+    demoData: LINKERD_DEMO_DATA,
+    persist: true,
+    fetcher: fetchLinkerdStatus,
+  })
+
+  // Prevent demo flash while loading — only surface the Demo badge once
+  // we've actually fallen back to demo data post-load.
+  const effectiveIsDemoData = isDemoFallback && !isLoading
+
+  // 'not-installed' counts as "data" so the card shows the empty state
+  // rather than an infinite skeleton when Linkerd isn't present.
+  const hasAnyData =
+    data.health === 'not-installed' ? true : data.deployments.length > 0
+
+  const { showSkeleton, showEmptyState } = useCardLoadingState({
+    isLoading: isLoading && !hasAnyData,
+    isRefreshing,
+    hasAnyData,
+    isFailed,
+    consecutiveFailures,
+    isDemoData: effectiveIsDemoData,
+    lastRefresh,
+  })
+
+  return {
+    data,
+    isLoading,
+    isRefreshing,
+    isDemoData: effectiveIsDemoData,
+    isFailed,
+    consecutiveFailures,
+    lastRefresh,
+    showSkeleton,
+    showEmptyState,
+    error: isFailed && !hasAnyData,
+    refetch,
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Exported testables — pure functions for unit testing
+// ---------------------------------------------------------------------------
+
+export const __testables = {
+  summarize,
+  deriveHealth,
+  buildLinkerdStatus,
+}

--- a/web/src/hooks/useMarketplace.ts
+++ b/web/src/hooks/useMarketplace.ts
@@ -94,6 +94,7 @@ const MARKETPLACE_TO_CARD_TYPE: Record<string, string> = {
   'cncf-flux': 'flux_status',
   'cncf-contour': 'contour_status',
   'cncf-envoy': 'envoy_status',
+  'cncf-linkerd': 'linkerd_status',
   'cncf-openfeature': 'openfeature_status',
   'cncf-strimzi': 'strimzi_status',
   'cncf-thanos': 'thanos_status' }

--- a/web/src/lib/demo/linkerd.ts
+++ b/web/src/lib/demo/linkerd.ts
@@ -1,0 +1,18 @@
+/**
+ * Linkerd demo seed re-export.
+ *
+ * The canonical demo data lives alongside the Linkerd card in
+ * `components/cards/linkerd_status/demoData.ts`. This file re-exports it
+ * so callers outside the card folder (docs, tests, future drill-downs)
+ * can import a stable demo seed from `lib/demo/linkerd`.
+ */
+
+export {
+  LINKERD_DEMO_DATA,
+  type LinkerdStatusData,
+  type LinkerdMeshedDeployment,
+  type LinkerdStats,
+  type LinkerdSummary,
+  type LinkerdHealth,
+  type LinkerdPodStatus,
+} from '../../components/cards/linkerd_status/demoData'

--- a/web/src/lib/unified/registerHooks.ts
+++ b/web/src/lib/unified/registerHooks.ts
@@ -50,6 +50,7 @@ import {
 import { useFluxStatus } from '../../components/cards/flux_status/useFluxStatus'
 import { useContourStatus } from '../../components/cards/contour_status/useContourStatus'
 import { useCachedEnvoy } from '../../components/cards/envoy_status/useCachedEnvoy'
+import { useCachedLinkerd } from '../../hooks/useCachedLinkerd'
 
 // ============================================================================
 // Wrapper hooks that convert params object to positional args
@@ -1051,6 +1052,17 @@ function useUnifiedEnvoyStatus() {
   }
 }
 
+function useUnifiedLinkerdStatus() {
+  const result = useCachedLinkerd()
+  // Surface the meshed deployment list as the primary row set for generic list renderers.
+  return {
+    data: result.data.deployments,
+    isLoading: result.showSkeleton,
+    error: result.error ? new Error('Failed to fetch Linkerd status') : null,
+    refetch: () => { result.refetch() },
+  }
+}
+
 function useProviderHealth() {
   return useDemoDataHook(DEMO_PROVIDER_HEALTH)
 }
@@ -1239,6 +1251,7 @@ export function registerUnifiedHooks(): void {
   registerDataHook('useFluxStatus', useUnifiedFluxStatus)
   registerDataHook('useContourStatus', useUnifiedContourStatus)
   registerDataHook('useCachedEnvoy', useUnifiedEnvoyStatus)
+  registerDataHook('useCachedLinkerd', useUnifiedLinkerdStatus)
   registerDataHook('useProviderHealth', useProviderHealth)
   registerDataHook('useUpgradeStatus', useUpgradeStatus)
   registerDataHook('useProwStatus', useProwStatus)

--- a/web/src/locales/en/cards.json
+++ b/web/src/locales/en/cards.json
@@ -3061,6 +3061,20 @@
     "noListeners": "No listeners configured",
     "noClusters": "No upstream clusters"
   },
+  "linkerdStatus": {
+    "healthy": "Healthy",
+    "degraded": "Degraded",
+    "notInstalled": "Linkerd not detected",
+    "notInstalledHint": "No Linkerd control plane reachable from the connected clusters.",
+    "fetchError": "Unable to fetch Linkerd status",
+    "meshedPods": "Meshed pods",
+    "successRate": "Success rate",
+    "rps": "Requests/s",
+    "p99Latency": "Avg p99",
+    "controlPlane": "control plane",
+    "sectionDeployments": "Meshed deployments",
+    "noDeployments": "No meshed deployments found"
+  },
   "kubecostOverview": {
     "monthlyCost": "Monthly Cost",
     "savingsRecommendations": "Savings Recommendations",


### PR DESCRIPTION
Adds Linkerd status card (Service Mesh) showing meshed pods, success rate, RPS, p99. Hook uses useCache with demo fallback. Follows envoy_status pattern.

Refs kubestellar/console-marketplace#10