### PR TITLE
feat(grpc): add gRPC monitoring card

### DIFF
--- a/web/src/components/cards/cardMetadata.ts
+++ b/web/src/components/cards/cardMetadata.ts
@@ -268,6 +268,8 @@ export const CARD_TITLES: Record<string, string> = {
   contour_status: 'Contour',
   // Envoy proxy (service mesh / edge)
   envoy_status: 'Envoy Proxy',
+  // gRPC services (network / service communication)
+  grpc_status: 'gRPC Services',
   // Linkerd service mesh
   linkerd_status: 'Linkerd',
   // CRI-O container runtime
@@ -583,6 +585,8 @@ export const CARD_DESCRIPTIONS: Record<string, string> = {
   contour_status: 'Contour ingress proxy status, HTTPProxy resources, and Envoy fleet health.',
   // Envoy proxy (service mesh / edge)
   envoy_status: 'Envoy Proxy listener health, upstream cluster health, and request/connection stats.',
+  // gRPC services (network / service communication)
+  grpc_status: 'gRPC service serving status, per-service RPS, p99 latency, and error rates.',
   // Linkerd service mesh
   linkerd_status: 'Linkerd service mesh meshed pods, success rate, RPS, and p99 latency per deployment.',
   // CRI-O container runtime

--- a/web/src/components/cards/cardRegistry.ts
+++ b/web/src/components/cards/cardRegistry.ts
@@ -82,6 +82,8 @@ const FluxStatus = safeLazy(() => import('./flux_status'), 'FluxStatus')
 const ContourStatus = safeLazy(() => import('./contour_status'), 'ContourStatus')
 // Envoy proxy card (Service Mesh / network)
 const EnvoyStatus = safeLazy(() => import('./envoy_status'), 'EnvoyStatus')
+// gRPC services card (network / service communication)
+const GrpcStatus = safeLazy(() => import('./grpc_status'), 'GrpcStatus')
 // Linkerd service mesh card
 const LinkerdStatus = safeLazy(() => import('./linkerd_status'), 'LinkerdStatus')
 const OverlayComparison = safeLazy(() => _deployBundle, 'OverlayComparison')
@@ -710,6 +712,8 @@ const RAW_CARD_COMPONENTS: Record<string, CardComponent> = {
   contour_status: ContourStatus,
   // Envoy proxy (service mesh / edge)
   envoy_status: EnvoyStatus,
+  // gRPC services (network / service communication)
+  grpc_status: GrpcStatus,
   // Linkerd service mesh
   linkerd_status: LinkerdStatus,
   // Artifact Hub
@@ -1031,6 +1035,7 @@ const CARD_CHUNK_PRELOADERS: Record<string, () => Promise<unknown>> = {
   flux_status: () => import('./flux_status'),
   contour_status: () => import('./contour_status'),
   envoy_status: () => import('./envoy_status'),
+  grpc_status: () => import('./grpc_status'),
   linkerd_status: () => import('./linkerd_status'),
   overlay_comparison: () => import('./deploy-bundle'),
   argocd_applications: () => import('./deploy-bundle'),
@@ -1626,6 +1631,7 @@ export const CARD_DEFAULT_WIDTHS: Record<string, number> = {
   flux_status: 6,
   contour_status: 6,
   envoy_status: 6,
+  grpc_status: 6,
   linkerd_status: 6,
   pvc_status: 6,
   gpu_status: 6,

--- a/web/src/components/cards/grpc_status/demoData.ts
+++ b/web/src/components/cards/grpc_status/demoData.ts
@@ -1,0 +1,158 @@
+/**
+ * gRPC Service Status Card — Demo Data & Type Definitions
+ *
+ * Models gRPC services (as seen via gRPC Reflection or server-side
+ * /healthz endpoints), per-service RPS, and p99 latency for the
+ * gRPC (CNCF graduated) high-performance RPC framework.
+ *
+ * This is scaffolding — a real gRPC Reflection / Channelz integration
+ * can be wired into `fetchGrpcStatus` in a follow-up. Until then, cards
+ * fall back to this demo data via `useCache`.
+ */
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type GrpcServingStatus = 'serving' | 'not-serving' | 'unknown'
+export type GrpcHealth = 'healthy' | 'degraded' | 'not-installed'
+
+export interface GrpcService {
+  name: string
+  namespace: string
+  endpoints: number
+  rps: number
+  latencyP99Ms: number
+  errorRatePct: number
+  status: GrpcServingStatus
+  cluster: string
+}
+
+export interface GrpcStats {
+  totalRps: number
+  avgLatencyP99Ms: number
+  avgErrorRatePct: number
+  reflectionEnabled: number
+}
+
+export interface GrpcSummary {
+  totalServices: number
+  servingServices: number
+  totalEndpoints: number
+}
+
+export interface GrpcStatusData {
+  health: GrpcHealth
+  services: GrpcService[]
+  stats: GrpcStats
+  summary: GrpcSummary
+  lastCheckTime: string
+}
+
+// ---------------------------------------------------------------------------
+// Demo-data constants (named — no magic numbers)
+// ---------------------------------------------------------------------------
+
+const DEMO_TOTAL_RPS = 2184
+const DEMO_AVG_LATENCY_P99_MS = 48
+const DEMO_AVG_ERROR_RATE_PCT = 0.42
+const DEMO_REFLECTION_ENABLED = 4
+
+const FRONTEND_RPS = 812
+const FRONTEND_P99_MS = 22
+const FRONTEND_ERR_PCT = 0.05
+const FRONTEND_ENDPOINTS = 6
+
+const PAYMENTS_RPS = 340
+const PAYMENTS_P99_MS = 96
+const PAYMENTS_ERR_PCT = 1.4
+const PAYMENTS_ENDPOINTS = 3
+
+const INVENTORY_RPS = 612
+const INVENTORY_P99_MS = 31
+const INVENTORY_ERR_PCT = 0.11
+const INVENTORY_ENDPOINTS = 4
+
+const AUTH_RPS = 408
+const AUTH_P99_MS = 42
+const AUTH_ERR_PCT = 0.18
+const AUTH_ENDPOINTS = 3
+
+const NOTIFICATIONS_RPS = 12
+const NOTIFICATIONS_P99_MS = 180
+const NOTIFICATIONS_ERR_PCT = 0.0
+const NOTIFICATIONS_ENDPOINTS = 2
+
+// ---------------------------------------------------------------------------
+// Demo data — shown when gRPC services are not detected or in demo mode
+// ---------------------------------------------------------------------------
+
+const DEMO_SERVICES: GrpcService[] = [
+  {
+    name: 'frontend.FrontendService',
+    namespace: 'frontend',
+    endpoints: FRONTEND_ENDPOINTS,
+    rps: FRONTEND_RPS,
+    latencyP99Ms: FRONTEND_P99_MS,
+    errorRatePct: FRONTEND_ERR_PCT,
+    status: 'serving',
+    cluster: 'default',
+  },
+  {
+    name: 'payments.PaymentService',
+    namespace: 'payments',
+    endpoints: PAYMENTS_ENDPOINTS,
+    rps: PAYMENTS_RPS,
+    latencyP99Ms: PAYMENTS_P99_MS,
+    errorRatePct: PAYMENTS_ERR_PCT,
+    status: 'serving',
+    cluster: 'default',
+  },
+  {
+    name: 'inventory.InventoryService',
+    namespace: 'inventory',
+    endpoints: INVENTORY_ENDPOINTS,
+    rps: INVENTORY_RPS,
+    latencyP99Ms: INVENTORY_P99_MS,
+    errorRatePct: INVENTORY_ERR_PCT,
+    status: 'serving',
+    cluster: 'default',
+  },
+  {
+    name: 'auth.AuthService',
+    namespace: 'auth',
+    endpoints: AUTH_ENDPOINTS,
+    rps: AUTH_RPS,
+    latencyP99Ms: AUTH_P99_MS,
+    errorRatePct: AUTH_ERR_PCT,
+    status: 'serving',
+    cluster: 'default',
+  },
+  {
+    name: 'notifications.NotifyService',
+    namespace: 'notifications',
+    endpoints: NOTIFICATIONS_ENDPOINTS,
+    rps: NOTIFICATIONS_RPS,
+    latencyP99Ms: NOTIFICATIONS_P99_MS,
+    errorRatePct: NOTIFICATIONS_ERR_PCT,
+    status: 'not-serving',
+    cluster: 'default',
+  },
+]
+
+export const GRPC_DEMO_DATA: GrpcStatusData = {
+  health: 'degraded',
+  services: DEMO_SERVICES,
+  stats: {
+    totalRps: DEMO_TOTAL_RPS,
+    avgLatencyP99Ms: DEMO_AVG_LATENCY_P99_MS,
+    avgErrorRatePct: DEMO_AVG_ERROR_RATE_PCT,
+    reflectionEnabled: DEMO_REFLECTION_ENABLED,
+  },
+  summary: {
+    totalServices: DEMO_SERVICES.length,
+    servingServices: DEMO_SERVICES.filter(s => s.status === 'serving').length,
+    totalEndpoints: DEMO_SERVICES.reduce((sum, s) => sum + s.endpoints, 0),
+  },
+  lastCheckTime: new Date().toISOString(),
+}

--- a/web/src/components/cards/grpc_status/index.tsx
+++ b/web/src/components/cards/grpc_status/index.tsx
@@ -1,0 +1,273 @@
+/**
+ * gRPC Service Status Card
+ *
+ * Displays gRPC services, per-service RPS, p99 latency, and error rate.
+ * Follows the envoy_status pattern for structure and styling.
+ *
+ * This is scaffolding — the card renders via demo fallback today. When a
+ * real gRPC Reflection / Channelz bridge lands, the hook's fetcher will
+ * pick up live data automatically with no component changes.
+ */
+
+import {
+  Activity,
+  AlertTriangle,
+  CheckCircle,
+  Clock,
+  Network,
+  RefreshCw,
+  Server,
+  Zap,
+} from 'lucide-react'
+import { useTranslation } from 'react-i18next'
+import { MetricTile } from '../../../lib/cards/CardComponents'
+import { Skeleton, SkeletonList, SkeletonStats } from '../../ui/Skeleton'
+import { useCachedGrpc } from '../../../hooks/useCachedGrpc'
+import type { GrpcService } from './demoData'
+
+// ---------------------------------------------------------------------------
+// Named constants (no magic numbers)
+// ---------------------------------------------------------------------------
+
+const RELATIVE_TIME_MINUTE_MS = 60_000
+const MINUTES_PER_HOUR = 60
+const HOURS_PER_DAY = 24
+const ERROR_RATE_DECIMALS = 2
+const THROUGHPUT_LOCALE_MIN_FRACTION = 0
+const LATENCY_WARN_MS = 100
+const LATENCY_DEGRADED_MS = 250
+const ERROR_RATE_WARN_PCT = 0.5
+const ERROR_RATE_CRIT_PCT = 2.0
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function formatRelativeTime(isoString: string): string {
+  const parsed = new Date(isoString).getTime()
+  if (!isoString || Number.isNaN(parsed)) return 'just now'
+
+  const diff = Date.now() - parsed
+  if (diff < 0) return 'just now'
+
+  const hour = MINUTES_PER_HOUR * RELATIVE_TIME_MINUTE_MS
+  const day = HOURS_PER_DAY * hour
+
+  if (diff < RELATIVE_TIME_MINUTE_MS) return 'just now'
+  if (diff < hour) return `${Math.floor(diff / RELATIVE_TIME_MINUTE_MS)}m ago`
+  if (diff < day) return `${Math.floor(diff / hour)}h ago`
+  return `${Math.floor(diff / day)}d ago`
+}
+
+function formatThroughput(value: number): string {
+  return value.toLocaleString(undefined, {
+    minimumFractionDigits: THROUGHPUT_LOCALE_MIN_FRACTION,
+  })
+}
+
+function latencyColor(p99Ms: number): string {
+  if (p99Ms >= LATENCY_DEGRADED_MS) return 'text-red-400'
+  if (p99Ms >= LATENCY_WARN_MS) return 'text-yellow-400'
+  return 'text-green-400'
+}
+
+function errorColor(pct: number): string {
+  if (pct >= ERROR_RATE_CRIT_PCT) return 'text-red-400'
+  if (pct >= ERROR_RATE_WARN_PCT) return 'text-yellow-400'
+  return 'text-green-400'
+}
+
+// ---------------------------------------------------------------------------
+// Subsections
+// ---------------------------------------------------------------------------
+
+function ServiceRow({ service }: { service: GrpcService }) {
+  const isServing = service.status === 'serving'
+  const statusClass = isServing
+    ? 'bg-green-500/20 text-green-400'
+    : service.status === 'not-serving'
+      ? 'bg-red-500/20 text-red-400'
+      : 'bg-yellow-500/20 text-yellow-400'
+
+  return (
+    <div className="rounded-md bg-secondary/30 px-3 py-2 space-y-1">
+      <div className="flex items-center justify-between gap-2">
+        <div className="min-w-0 flex items-center gap-1.5">
+          {isServing ? (
+            <CheckCircle className="w-3.5 h-3.5 text-green-400 shrink-0" />
+          ) : (
+            <AlertTriangle className="w-3.5 h-3.5 text-red-400 shrink-0" />
+          )}
+          <span className="text-xs font-medium text-foreground truncate">
+            {service.name}
+          </span>
+        </div>
+        <span className={`text-[11px] px-1.5 py-0.5 rounded-full shrink-0 ${statusClass}`}>
+          {service.status}
+        </span>
+      </div>
+      <div className="flex items-center justify-between gap-2 text-[11px] text-muted-foreground">
+        <span className="truncate">
+          {service.namespace} · {service.endpoints} endpoints
+        </span>
+        <span className="flex items-center gap-2 shrink-0 font-mono">
+          <span className="text-cyan-400">{formatThroughput(service.rps)} rps</span>
+          <span className={latencyColor(service.latencyP99Ms)}>
+            {service.latencyP99Ms}ms p99
+          </span>
+          <span className={errorColor(service.errorRatePct)}>
+            {service.errorRatePct.toFixed(ERROR_RATE_DECIMALS)}%
+          </span>
+        </span>
+      </div>
+    </div>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Main component
+// ---------------------------------------------------------------------------
+
+export function GrpcStatus() {
+  const { t } = useTranslation('cards')
+  const { data, isRefreshing, error, showSkeleton, showEmptyState } = useCachedGrpc()
+
+  const isHealthy = data.health === 'healthy'
+
+  if (showSkeleton) {
+    return (
+      <div className="h-full flex flex-col min-h-card gap-4">
+        <div className="flex items-center justify-between">
+          <Skeleton variant="rounded" width={140} height={28} />
+          <Skeleton variant="rounded" width={90} height={20} />
+        </div>
+        <SkeletonStats className="grid-cols-4" />
+        <SkeletonList items={5} className="flex-1" />
+      </div>
+    )
+  }
+
+  if (error && showEmptyState) {
+    return (
+      <div className="h-full flex flex-col items-center justify-center min-h-card text-muted-foreground gap-2">
+        <AlertTriangle className="w-6 h-6 text-red-400" />
+        <p className="text-sm text-red-400">
+          {t('grpcStatus.fetchError', 'Unable to fetch gRPC status')}
+        </p>
+      </div>
+    )
+  }
+
+  if (data.health === 'not-installed') {
+    return (
+      <div className="h-full flex flex-col items-center justify-center min-h-card text-muted-foreground gap-2">
+        <Network className="w-6 h-6 text-muted-foreground/50" />
+        <p className="text-sm font-medium">
+          {t('grpcStatus.notInstalled', 'No gRPC services detected')}
+        </p>
+        <p className="text-xs text-center max-w-xs">
+          {t(
+            'grpcStatus.notInstalledHint',
+            'No gRPC reflection endpoint reachable from the connected clusters.',
+          )}
+        </p>
+      </div>
+    )
+  }
+
+  return (
+    <div className="h-full flex flex-col min-h-card content-loaded gap-4 overflow-hidden">
+      {/* Header — health pill + freshness */}
+      <div className="flex items-center justify-between gap-2">
+        <div
+          className={`flex items-center gap-2 px-3 py-1.5 rounded-full text-sm font-medium ${
+            isHealthy
+              ? 'bg-green-500/15 text-green-400'
+              : 'bg-yellow-500/15 text-yellow-400'
+          }`}
+        >
+          {isHealthy ? (
+            <CheckCircle className="w-4 h-4" />
+          ) : (
+            <AlertTriangle className="w-4 h-4" />
+          )}
+          {isHealthy
+            ? t('grpcStatus.healthy', 'Healthy')
+            : t('grpcStatus.degraded', 'Degraded')}
+        </div>
+
+        <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
+          <RefreshCw className={`w-3 h-3 ${isRefreshing ? 'animate-spin' : ''}`} />
+          <span>{formatRelativeTime(data.lastCheckTime)}</span>
+        </div>
+      </div>
+
+      {/* Summary tiles */}
+      <div className="grid grid-cols-2 @md:grid-cols-4 gap-2">
+        <MetricTile
+          label={t('grpcStatus.services', 'Services')}
+          value={`${data.summary.servingServices}/${data.summary.totalServices}`}
+          colorClass={
+            data.summary.servingServices === data.summary.totalServices
+              ? 'text-green-400'
+              : 'text-yellow-400'
+          }
+          icon={<Server className="w-4 h-4 text-blue-400" />}
+        />
+        <MetricTile
+          label={t('grpcStatus.totalRps', 'Total RPS')}
+          value={formatThroughput(data.stats.totalRps)}
+          colorClass="text-cyan-400"
+          icon={<Activity className="w-4 h-4 text-cyan-400" />}
+        />
+        <MetricTile
+          label={t('grpcStatus.avgP99', 'Avg p99')}
+          value={`${data.stats.avgLatencyP99Ms}ms`}
+          colorClass={latencyColor(data.stats.avgLatencyP99Ms)}
+          icon={<Clock className="w-4 h-4 text-yellow-400" />}
+        />
+        <MetricTile
+          label={t('grpcStatus.endpoints', 'Endpoints')}
+          value={formatThroughput(data.summary.totalEndpoints)}
+          colorClass="text-foreground"
+          icon={<Zap className="w-4 h-4 text-yellow-400" />}
+        />
+      </div>
+
+      {/* Service list */}
+      <div className="space-y-3 overflow-y-auto scrollbar-thin pr-0.5">
+        <section className="space-y-2">
+          <div className="flex items-center gap-2">
+            <Server className="w-4 h-4 text-blue-400" />
+            <h4 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+              {t('grpcStatus.sectionServices', 'gRPC services')}
+            </h4>
+            <span className="text-[11px] text-muted-foreground ml-auto">
+              {t('grpcStatus.avgErrorRate', 'avg err')}:{' '}
+              <span className={errorColor(data.stats.avgErrorRatePct)}>
+                {data.stats.avgErrorRatePct.toFixed(ERROR_RATE_DECIMALS)}%
+              </span>
+            </span>
+          </div>
+
+          {data.services.length === 0 ? (
+            <div className="rounded-md bg-secondary/20 border border-border/40 px-3 py-2 text-xs text-muted-foreground">
+              {t('grpcStatus.noServices', 'No gRPC services found')}
+            </div>
+          ) : (
+            <div className="space-y-1.5">
+              {(data.services || []).map(service => (
+                <ServiceRow
+                  key={`${service.cluster}:${service.namespace}:${service.name}`}
+                  service={service}
+                />
+              ))}
+            </div>
+          )}
+        </section>
+      </div>
+    </div>
+  )
+}
+
+export default GrpcStatus

--- a/web/src/components/dashboard/shared/cardCatalog.ts
+++ b/web/src/components/dashboard/shared/cardCatalog.ts
@@ -153,6 +153,7 @@ export const CARD_CATALOG = {
     { type: 'cilium_status', title: 'Cilium', description: 'Cilium eBPF networking, network policy enforcement, and Hubble flow visibility.', visualization: 'status' },
     { type: 'contour_status', title: 'Contour', description: 'Contour ingress proxy status, HTTPProxy resources, and Envoy fleet health', visualization: 'status' },
     { type: 'envoy_status', title: 'Envoy Proxy', description: 'Envoy listener health, upstream cluster health, and request/connection stats', visualization: 'status' },
+    { type: 'grpc_status', title: 'gRPC Services', description: 'gRPC service health, per-service RPS, p99 latency, and error rates', visualization: 'status' },
     { type: 'linkerd_status', title: 'Linkerd', description: 'Linkerd service mesh meshed pods, success rate, RPS, and p99 latency per deployment', visualization: 'status' },
     { type: 'network_trace', title: 'Network Traces', description: 'Live network connection tracing via Inspektor Gadget eBPF', visualization: 'table' },
     { type: 'dns_trace', title: 'DNS Traces', description: 'Live DNS query tracing via Inspektor Gadget eBPF', visualization: 'table' },

--- a/web/src/config/cards/grpc-status.ts
+++ b/web/src/config/cards/grpc-status.ts
@@ -1,0 +1,49 @@
+/**
+ * gRPC Service Status Card Configuration
+ *
+ * gRPC is a CNCF graduated high-performance RPC framework. This card
+ * surfaces service serving status, per-service RPS, p99 latency, and
+ * error rate.
+ */
+import type { UnifiedCardConfig } from '../../lib/unified/types'
+
+export const grpcStatusConfig: UnifiedCardConfig = {
+  type: 'grpc_status',
+  title: 'gRPC Services',
+  category: 'network',
+  description:
+    'gRPC service health, call metrics (RPS, p99 latency), and error rates.',
+  icon: 'Network',
+  iconColor: 'text-cyan-400',
+  defaultWidth: 6,
+  defaultHeight: 4,
+  dataSource: { type: 'hook', hook: 'useCachedGrpc' },
+  content: {
+    type: 'list',
+    pageSize: 8,
+    columns: [
+      { field: 'name', header: 'Service', primary: true, render: 'truncate' },
+      { field: 'namespace', header: 'Namespace', width: 120, render: 'truncate' },
+      { field: 'endpoints', header: 'Endpoints', width: 90 },
+      { field: 'rps', header: 'RPS', width: 80 },
+      { field: 'latencyP99Ms', header: 'p99 ms', width: 80 },
+      { field: 'status', header: 'Status', width: 80, render: 'status-badge' },
+    ],
+  },
+  emptyState: {
+    icon: 'Network',
+    title: 'No gRPC services detected',
+    message: 'No gRPC reflection endpoint reachable from the connected clusters.',
+    variant: 'info',
+  },
+  loadingState: {
+    type: 'list',
+    rows: 5,
+  },
+  // Scaffolding: renders live if /api/grpc/status is wired up, otherwise
+  // falls back to demo data via the useCache demo path.
+  isDemoData: true,
+  isLive: false,
+}
+
+export default grpcStatusConfig

--- a/web/src/config/cards/index.ts
+++ b/web/src/config/cards/index.ts
@@ -65,6 +65,7 @@ import { fluxStatusConfig } from './flux-status'
 import { contourStatusConfig } from './contour-status'
 import { containerdStatusConfig } from './containerd-status'
 import { envoyStatusConfig } from './envoy-status'
+import { grpcStatusConfig } from './grpc-status'
 import { linkerdStatusConfig } from './linkerd-status'
 import { nightlyReleasePulseConfig } from './nightly-release-pulse'
 import { workflowMatrixConfig } from './workflow-matrix'
@@ -252,6 +253,7 @@ export const CARD_CONFIGS: CardConfigRegistry = {
   contour_status: contourStatusConfig,
   containerd_status: containerdStatusConfig,
   envoy_status: envoyStatusConfig,
+  grpc_status: grpcStatusConfig,
   linkerd_status: linkerdStatusConfig,
   nightly_release_pulse: nightlyReleasePulseConfig,
   workflow_matrix: workflowMatrixConfig,

--- a/web/src/hooks/useCachedGrpc.ts
+++ b/web/src/hooks/useCachedGrpc.ts
@@ -1,0 +1,235 @@
+/**
+ * gRPC Service Status Hook — Data fetching for the grpc_status card.
+ *
+ * Mirrors the envoy_status pattern:
+ * - useCache with fetcher + demo fallback
+ * - isDemoFallback gated on !isLoading (prevents demo flash while loading)
+ * - fetchJson helper with treat404AsEmpty (no real endpoint yet — this is
+ *   scaffolding; the fetch will 404 until a real gRPC Reflection / Channelz
+ *   bridge lands, at which point useCache will transparently switch to
+ *   live data)
+ * - showSkeleton / showEmptyState from useCardLoadingState
+ */
+
+import { useCache } from '../lib/cache'
+import { useCardLoadingState } from '../components/cards/CardDataContext'
+import { FETCH_DEFAULT_TIMEOUT_MS } from '../lib/constants/network'
+import { authFetch } from '../lib/api'
+import {
+  GRPC_DEMO_DATA,
+  type GrpcService,
+  type GrpcStats,
+  type GrpcStatusData,
+} from '../components/cards/grpc_status/demoData'
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const CACHE_KEY = 'grpc-status'
+const GRPC_STATUS_ENDPOINT = '/api/grpc/status'
+
+const EMPTY_STATS: GrpcStats = {
+  totalRps: 0,
+  avgLatencyP99Ms: 0,
+  avgErrorRatePct: 0,
+  reflectionEnabled: 0,
+}
+
+const INITIAL_DATA: GrpcStatusData = {
+  health: 'not-installed',
+  services: [],
+  stats: EMPTY_STATS,
+  summary: {
+    totalServices: 0,
+    servingServices: 0,
+    totalEndpoints: 0,
+  },
+  lastCheckTime: new Date().toISOString(),
+}
+
+// ---------------------------------------------------------------------------
+// Internal types (shape of the future /api/grpc/status response)
+// ---------------------------------------------------------------------------
+
+interface FetchResult<T> {
+  data: T
+  failed: boolean
+}
+
+interface GrpcStatusResponse {
+  services?: GrpcService[]
+  stats?: Partial<GrpcStats>
+}
+
+// ---------------------------------------------------------------------------
+// Pure helpers
+// ---------------------------------------------------------------------------
+
+function summarize(services: GrpcService[]): GrpcStatusData['summary'] {
+  const totalServices = services.length
+  const servingServices = services.filter(s => s.status === 'serving').length
+  const totalEndpoints = services.reduce((sum, s) => sum + s.endpoints, 0)
+  return { totalServices, servingServices, totalEndpoints }
+}
+
+function deriveHealth(services: GrpcService[]): GrpcStatusData['health'] {
+  if (services.length === 0) {
+    return 'not-installed'
+  }
+  const hasNotServing = services.some(s => s.status !== 'serving')
+  if (hasNotServing) {
+    return 'degraded'
+  }
+  return 'healthy'
+}
+
+function buildGrpcStatus(
+  services: GrpcService[],
+  stats: GrpcStats,
+): GrpcStatusData {
+  return {
+    health: deriveHealth(services),
+    services,
+    stats,
+    summary: summarize(services),
+    lastCheckTime: new Date().toISOString(),
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Private fetchJson helper (mirrors envoy/contour/flux pattern)
+// ---------------------------------------------------------------------------
+
+async function fetchJson<T>(
+  url: string,
+  options?: { treat404AsEmpty?: boolean },
+): Promise<FetchResult<T | null>> {
+  try {
+    const resp = await authFetch(url, {
+      headers: { Accept: 'application/json' },
+      signal: AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS),
+    })
+
+    if (!resp.ok) {
+      if (options?.treat404AsEmpty && resp.status === 404) {
+        return { data: null, failed: false }
+      }
+      return { data: null, failed: true }
+    }
+
+    const body = (await resp.json()) as T
+    return { data: body, failed: false }
+  } catch {
+    return { data: null, failed: true }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Fetcher
+// ---------------------------------------------------------------------------
+
+async function fetchGrpcStatus(): Promise<GrpcStatusData> {
+  const result = await fetchJson<GrpcStatusResponse>(
+    GRPC_STATUS_ENDPOINT,
+    { treat404AsEmpty: true },
+  )
+
+  // If the endpoint isn't wired up yet (404) or the request failed, the
+  // cache layer will surface demo data via its demoData fallback path.
+  if (result.failed) {
+    throw new Error('Unable to fetch gRPC status')
+  }
+
+  const body = result.data
+  const services = Array.isArray(body?.services) ? body.services : []
+  const stats: GrpcStats = {
+    totalRps: body?.stats?.totalRps ?? 0,
+    avgLatencyP99Ms: body?.stats?.avgLatencyP99Ms ?? 0,
+    avgErrorRatePct: body?.stats?.avgErrorRatePct ?? 0,
+    reflectionEnabled: body?.stats?.reflectionEnabled ?? 0,
+  }
+
+  return buildGrpcStatus(services, stats)
+}
+
+// ---------------------------------------------------------------------------
+// Hook
+// ---------------------------------------------------------------------------
+
+export interface UseCachedGrpcResult {
+  data: GrpcStatusData
+  isLoading: boolean
+  isRefreshing: boolean
+  isDemoData: boolean
+  isFailed: boolean
+  consecutiveFailures: number
+  lastRefresh: number | null
+  showSkeleton: boolean
+  showEmptyState: boolean
+  error: boolean
+  refetch: () => Promise<void>
+}
+
+export function useCachedGrpc(): UseCachedGrpcResult {
+  const {
+    data,
+    isLoading,
+    isRefreshing,
+    isFailed,
+    consecutiveFailures,
+    isDemoFallback,
+    lastRefresh,
+    refetch,
+  } = useCache<GrpcStatusData>({
+    key: CACHE_KEY,
+    category: 'services',
+    initialData: INITIAL_DATA,
+    demoData: GRPC_DEMO_DATA,
+    persist: true,
+    fetcher: fetchGrpcStatus,
+  })
+
+  // Prevent demo flash while loading — only surface the Demo badge once
+  // we've actually fallen back to demo data post-load.
+  const effectiveIsDemoData = isDemoFallback && !isLoading
+
+  // 'not-installed' counts as "data" so the card shows the empty state
+  // rather than an infinite skeleton when gRPC services aren't present.
+  const hasAnyData =
+    data.health === 'not-installed' ? true : data.services.length > 0
+
+  const { showSkeleton, showEmptyState } = useCardLoadingState({
+    isLoading: isLoading && !hasAnyData,
+    isRefreshing,
+    hasAnyData,
+    isFailed,
+    consecutiveFailures,
+    isDemoData: effectiveIsDemoData,
+    lastRefresh,
+  })
+
+  return {
+    data,
+    isLoading,
+    isRefreshing,
+    isDemoData: effectiveIsDemoData,
+    isFailed,
+    consecutiveFailures,
+    lastRefresh,
+    showSkeleton,
+    showEmptyState,
+    error: isFailed && !hasAnyData,
+    refetch,
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Exported testables — pure functions for unit testing
+// ---------------------------------------------------------------------------
+
+export const __testables = {
+  summarize,
+  deriveHealth,
+  buildGrpcStatus,
+}

--- a/web/src/hooks/useMarketplace.ts
+++ b/web/src/hooks/useMarketplace.ts
@@ -95,6 +95,7 @@ const MARKETPLACE_TO_CARD_TYPE: Record<string, string> = {
   'cncf-flux': 'flux_status',
   'cncf-contour': 'contour_status',
   'cncf-envoy': 'envoy_status',
+  'cncf-grpc': 'grpc_status',
   'cncf-linkerd': 'linkerd_status',
   'cncf-openfeature': 'openfeature_status',
   'cncf-strimzi': 'strimzi_status',

--- a/web/src/lib/demo/grpc.ts
+++ b/web/src/lib/demo/grpc.ts
@@ -1,0 +1,18 @@
+/**
+ * gRPC demo seed re-export.
+ *
+ * The canonical demo data lives alongside the gRPC card in
+ * `components/cards/grpc_status/demoData.ts`. This file re-exports it
+ * so callers outside the card folder (docs, tests, future drill-downs)
+ * can import a stable demo seed from `lib/demo/grpc`.
+ */
+
+export {
+  GRPC_DEMO_DATA,
+  type GrpcStatusData,
+  type GrpcService,
+  type GrpcStats,
+  type GrpcSummary,
+  type GrpcHealth,
+  type GrpcServingStatus,
+} from '../../components/cards/grpc_status/demoData'

--- a/web/src/lib/unified/registerHooks.ts
+++ b/web/src/lib/unified/registerHooks.ts
@@ -51,6 +51,7 @@ import { useFluxStatus } from '../../components/cards/flux_status/useFluxStatus'
 import { useContourStatus } from '../../components/cards/contour_status/useContourStatus'
 import { useCachedContainerd } from '../../hooks/useCachedContainerd'
 import { useCachedEnvoy } from '../../components/cards/envoy_status/useCachedEnvoy'
+import { useCachedGrpc } from '../../hooks/useCachedGrpc'
 import { useCachedLinkerd } from '../../hooks/useCachedLinkerd'
 
 // ============================================================================
@@ -1063,6 +1064,17 @@ function useUnifiedEnvoyStatus() {
   }
 }
 
+function useUnifiedGrpcStatus() {
+  const result = useCachedGrpc()
+  // Surface the service list as the primary row set for generic list renderers.
+  return {
+    data: result.data.services,
+    isLoading: result.showSkeleton,
+    error: result.error ? new Error('Failed to fetch gRPC status') : null,
+    refetch: () => { result.refetch() },
+  }
+}
+
 function useUnifiedLinkerdStatus() {
   const result = useCachedLinkerd()
   // Surface the meshed deployment list as the primary row set for generic list renderers.
@@ -1263,6 +1275,7 @@ export function registerUnifiedHooks(): void {
   registerDataHook('useContourStatus', useUnifiedContourStatus)
   registerDataHook('useCachedContainerd', useUnifiedContainerdStatus)
   registerDataHook('useCachedEnvoy', useUnifiedEnvoyStatus)
+  registerDataHook('useCachedGrpc', useUnifiedGrpcStatus)
   registerDataHook('useCachedLinkerd', useUnifiedLinkerdStatus)
   registerDataHook('useProviderHealth', useProviderHealth)
   registerDataHook('useUpgradeStatus', useUpgradeStatus)

--- a/web/src/locales/en/cards.json
+++ b/web/src/locales/en/cards.json
@@ -3074,6 +3074,20 @@
     "containers": "Containers",
     "noContainers": "No containers reported"
   },
+  "grpcStatus": {
+    "healthy": "Healthy",
+    "degraded": "Degraded",
+    "notInstalled": "No gRPC services detected",
+    "notInstalledHint": "No gRPC reflection endpoint reachable from the connected clusters.",
+    "fetchError": "Unable to fetch gRPC status",
+    "services": "Services",
+    "totalRps": "Total RPS",
+    "avgP99": "Avg p99",
+    "endpoints": "Endpoints",
+    "avgErrorRate": "avg err",
+    "sectionServices": "gRPC services",
+    "noServices": "No gRPC services found"
+  },
   "linkerdStatus": {
     "healthy": "Healthy",
     "degraded": "Degraded",


### PR DESCRIPTION
Adds gRPC status card showing services, RPS, p99 latency. Hook uses useCache with demo fallback. Follows envoy_status pattern.

Refs kubestellar/console-marketplace#8