### PR TITLE
feat(tikv): add TiKV monitoring card

### DIFF
--- a/web/src/components/cards/cardMetadata.ts
+++ b/web/src/components/cards/cardMetadata.ts
@@ -270,6 +270,8 @@ export const CARD_TITLES: Record<string, string> = {
   envoy_status: 'Envoy Proxy',
   // Linkerd service mesh
   linkerd_status: 'Linkerd',
+  // TiKV distributed key-value store
+  tikv_status: 'TiKV',
   // CRI-O container runtime
   crio_status: 'CRI-O',
   // Strimzi Kafka operator
@@ -583,6 +585,8 @@ export const CARD_DESCRIPTIONS: Record<string, string> = {
   envoy_status: 'Envoy Proxy listener health, upstream cluster health, and request/connection stats.',
   // Linkerd service mesh
   linkerd_status: 'Linkerd service mesh meshed pods, success rate, RPS, and p99 latency per deployment.',
+  // TiKV distributed key-value store
+  tikv_status: 'TiKV distributed key-value store: store nodes, region counts, leader counts, and capacity utilization across the cluster.',
   // CRI-O container runtime
   crio_status: 'CRI-O container runtime metrics, image pulls, and pod sandbox status.',
 

--- a/web/src/components/cards/cardRegistry.ts
+++ b/web/src/components/cards/cardRegistry.ts
@@ -84,6 +84,8 @@ const ContourStatus = safeLazy(() => import('./contour_status'), 'ContourStatus'
 const EnvoyStatus = safeLazy(() => import('./envoy_status'), 'EnvoyStatus')
 // Linkerd service mesh card
 const LinkerdStatus = safeLazy(() => import('./linkerd_status'), 'LinkerdStatus')
+// TiKV distributed key-value store card
+const TikvStatus = safeLazy(() => import('./tikv_status'), 'TikvStatus')
 const OverlayComparison = safeLazy(() => _deployBundle, 'OverlayComparison')
 const ArgoCDApplications = safeLazy(() => _deployBundle, 'ArgoCDApplications')
 const ArgoCDApplicationSets = safeLazy(() => _deployBundle, 'ArgoCDApplicationSets')
@@ -708,6 +710,8 @@ const RAW_CARD_COMPONENTS: Record<string, CardComponent> = {
   envoy_status: EnvoyStatus,
   // Linkerd service mesh
   linkerd_status: LinkerdStatus,
+  // TiKV distributed key-value store
+  tikv_status: TikvStatus,
   // Artifact Hub
   artifact_hub_status: ArtifactHubStatus,
   // CloudEvents messaging
@@ -1028,6 +1032,7 @@ const CARD_CHUNK_PRELOADERS: Record<string, () => Promise<unknown>> = {
   contour_status: () => import('./contour_status'),
   envoy_status: () => import('./envoy_status'),
   linkerd_status: () => import('./linkerd_status'),
+  tikv_status: () => import('./tikv_status'),
   overlay_comparison: () => import('./deploy-bundle'),
   argocd_applications: () => import('./deploy-bundle'),
   argocd_applicationsets: () => import('./deploy-bundle'),
@@ -1619,6 +1624,7 @@ export const CARD_DEFAULT_WIDTHS: Record<string, number> = {
   contour_status: 6,
   envoy_status: 6,
   linkerd_status: 6,
+  tikv_status: 6,
   pvc_status: 6,
   gpu_status: 6,
   gpu_inventory: 6,

--- a/web/src/components/cards/tikv_status/index.tsx
+++ b/web/src/components/cards/tikv_status/index.tsx
@@ -1,0 +1,221 @@
+/**
+ * TiKV Status Card
+ *
+ * Shows TiKV store nodes for a TiKV (CNCF graduated) distributed
+ * key-value cluster: per-store state, region/leader counts, and
+ * capacity utilization. Demo fallback is used when TiKV is not
+ * installed or the user is in demo mode.
+ */
+
+import React from 'react'
+import { useTranslation } from 'react-i18next'
+import { AlertTriangle, CheckCircle, Database, HardDrive, RefreshCw, Server } from 'lucide-react'
+import { useCachedTikv } from '../../../hooks/useCachedTikv'
+import { useCardLoadingState } from '../CardDataContext'
+import { SkeletonCardWithRefresh } from '../../ui/Skeleton'
+import { EmptyState } from '../../ui/EmptyState'
+import { MetricTile } from '../../../lib/cards/CardComponents'
+import { cn } from '../../../lib/cn'
+import type { TikvStore } from '../../../lib/demo/tikv'
+
+// ---------------------------------------------------------------------------
+// Named constants (no magic numbers)
+// ---------------------------------------------------------------------------
+
+const BYTES_PER_GIB = 1024 * 1024 * 1024
+const USAGE_PCT_WARN = 70
+const USAGE_PCT_ALERT = 85
+const PCT_MULTIPLIER = 100
+const MIN_DECIMAL_PLACES = 1
+const STORE_PAGE_SIZE = 6
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function formatGib(bytes: number): string {
+  if (bytes <= 0) return '—'
+  const gib = bytes / BYTES_PER_GIB
+  return `${gib.toFixed(MIN_DECIMAL_PLACES)} GiB`
+}
+
+function usagePct(store: TikvStore): number {
+  if (store.capacityBytes <= 0) return 0
+  const used = store.capacityBytes - store.availableBytes
+  return Math.max(0, Math.min(PCT_MULTIPLIER, (used / store.capacityBytes) * PCT_MULTIPLIER))
+}
+
+function usageColor(pct: number): string {
+  if (pct >= USAGE_PCT_ALERT) return 'text-red-400'
+  if (pct >= USAGE_PCT_WARN) return 'text-yellow-400'
+  return 'text-green-400'
+}
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+export function TikvStatus() {
+  const { t } = useTranslation(['cards', 'common'])
+  const {
+    data,
+    isLoading,
+    isRefreshing,
+    isDemoFallback,
+    isFailed,
+    consecutiveFailures,
+    lastRefresh,
+  } = useCachedTikv()
+
+  // Rule: never show demo data while still loading
+  const isDemoData = isDemoFallback && !isLoading
+
+  // 'not-installed' still counts as "we have data" so the card isn't stuck in skeleton
+  const hasAnyData =
+    data.health === 'not-installed' ? true : data.summary.totalStores > 0
+
+  const { showSkeleton, showEmptyState } = useCardLoadingState({
+    isLoading: isLoading && !hasAnyData,
+    isRefreshing,
+    isDemoData,
+    hasAnyData,
+    isFailed,
+    consecutiveFailures,
+    lastRefresh,
+  })
+
+  if (showSkeleton) {
+    return <SkeletonCardWithRefresh showStats={true} rows={STORE_PAGE_SIZE} />
+  }
+
+  if (showEmptyState || (data.health === 'not-installed' && !isDemoData)) {
+    return (
+      <div className="h-full flex items-center justify-center p-4">
+        <EmptyState
+          icon={<Database className="w-8 h-8 text-muted-foreground/40" />}
+          title={t('tikvStatus.notInstalled', 'TiKV not detected')}
+          description={t(
+            'tikvStatus.notInstalledHint',
+            'No TiKV store pods found. Deploy TiKV to monitor the distributed key-value store.',
+          )}
+        />
+      </div>
+    )
+  }
+
+  const isHealthy = data.health === 'healthy'
+  const stores = data.stores.slice(0, STORE_PAGE_SIZE)
+
+  return (
+    <div className="h-full flex flex-col min-h-card gap-4 overflow-hidden animate-in fade-in duration-500">
+      <div className="flex items-center justify-between gap-2">
+        <div
+          className={cn(
+            'flex items-center gap-2 px-3 py-1.5 rounded-full text-sm font-medium',
+            isHealthy ? 'bg-green-500/15 text-green-400' : 'bg-yellow-500/15 text-yellow-400',
+          )}
+        >
+          {isHealthy ? <CheckCircle className="w-4 h-4" /> : <AlertTriangle className="w-4 h-4" />}
+          {isHealthy
+            ? t('tikvStatus.healthy', 'Healthy')
+            : t('tikvStatus.degraded', 'Degraded')}
+        </div>
+
+        <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
+          <RefreshCw className={cn('w-3 h-3', isRefreshing ? 'animate-spin' : '')} />
+          <span>{t('tikvStatus.stores', { count: data.summary.totalStores, defaultValue: '{{count}} stores' })}</span>
+        </div>
+      </div>
+
+      <div className="grid grid-cols-2 @md:grid-cols-4 gap-2">
+        <MetricTile
+          label={t('tikvStatus.upStores', 'Up')}
+          value={data.summary.upStores}
+          colorClass="text-green-400"
+          icon={<CheckCircle className="w-4 h-4 text-green-400" />}
+        />
+        <MetricTile
+          label={t('tikvStatus.downStores', 'Down')}
+          value={data.summary.downStores}
+          colorClass={data.summary.downStores > 0 ? 'text-red-400' : 'text-green-400'}
+          icon={
+            data.summary.downStores > 0 ? (
+              <AlertTriangle className="w-4 h-4 text-red-400" />
+            ) : (
+              <CheckCircle className="w-4 h-4 text-green-400" />
+            )
+          }
+        />
+        <MetricTile
+          label={t('tikvStatus.regions', 'Regions')}
+          value={data.summary.totalRegions.toLocaleString()}
+          colorClass="text-cyan-400"
+          icon={<Database className="w-4 h-4 text-cyan-400" />}
+        />
+        <MetricTile
+          label={t('tikvStatus.leaders', 'Leaders')}
+          value={data.summary.totalLeaders.toLocaleString()}
+          colorClass="text-blue-400"
+          icon={<Server className="w-4 h-4 text-blue-400" />}
+        />
+      </div>
+
+      <div className="space-y-1.5 overflow-y-auto scrollbar-thin pr-0.5">
+        {stores.length === 0 ? (
+          <div className="rounded-md bg-secondary/20 border border-border/40 px-3 py-2 text-xs text-muted-foreground">
+            {t('tikvStatus.noStores', 'No TiKV stores reporting.')}
+          </div>
+        ) : (
+          stores.map(store => {
+            const pct = usagePct(store)
+            const stateUp = store.state === 'Up'
+            return (
+              <div
+                key={store.storeId}
+                className="rounded-md bg-secondary/30 px-3 py-2.5 space-y-1"
+              >
+                <div className="flex items-center justify-between gap-2">
+                  <div className="min-w-0 flex items-center gap-1.5">
+                    {stateUp ? (
+                      <CheckCircle className="w-3.5 h-3.5 text-green-400 shrink-0" />
+                    ) : (
+                      <AlertTriangle className="w-3.5 h-3.5 text-red-400 shrink-0" />
+                    )}
+                    <span className="text-xs font-medium truncate font-mono">
+                      store-{store.storeId}
+                    </span>
+                    <span className="text-[11px] text-muted-foreground truncate">
+                      {store.address}
+                    </span>
+                  </div>
+                  <span
+                    className={cn(
+                      'text-[11px] px-1.5 py-0.5 rounded-full shrink-0',
+                      stateUp
+                        ? 'bg-green-500/20 text-green-400'
+                        : 'bg-red-500/20 text-red-400',
+                    )}
+                  >
+                    {store.state}
+                  </span>
+                </div>
+
+                <div className="text-xs text-muted-foreground flex items-center justify-between gap-2">
+                  <span className="truncate">
+                    {t('tikvStatus.regionCount', { count: store.regionCount, defaultValue: '{{count}} regions' })} · {t('tikvStatus.leaderCount', { count: store.leaderCount, defaultValue: '{{count}} leaders' })}
+                  </span>
+                  <span className={cn('flex items-center gap-1 shrink-0', usageColor(pct))}>
+                    <HardDrive className="w-3 h-3" />
+                    {formatGib(store.availableBytes)} / {formatGib(store.capacityBytes)}
+                  </span>
+                </div>
+              </div>
+            )
+          })
+        )}
+      </div>
+    </div>
+  )
+}
+
+export default TikvStatus

--- a/web/src/components/cards/tikv_status/index.tsx
+++ b/web/src/components/cards/tikv_status/index.tsx
@@ -104,7 +104,7 @@ export function TikvStatus() {
   }
 
   const isHealthy = data.health === 'healthy'
-  const stores = data.stores.slice(0, STORE_PAGE_SIZE)
+  const stores = (data.stores ?? []).slice(0, STORE_PAGE_SIZE)
 
   return (
     <div className="h-full flex flex-col min-h-card gap-4 overflow-hidden animate-in fade-in duration-500">

--- a/web/src/components/cards/tikv_status/index.tsx
+++ b/web/src/components/cards/tikv_status/index.tsx
@@ -7,7 +7,6 @@
  * installed or the user is in demo mode.
  */
 
-import React from 'react'
 import { useTranslation } from 'react-i18next'
 import { AlertTriangle, CheckCircle, Database, HardDrive, RefreshCw, Server } from 'lucide-react'
 import { useCachedTikv } from '../../../hooks/useCachedTikv'

--- a/web/src/components/dashboard/shared/cardCatalog.ts
+++ b/web/src/components/dashboard/shared/cardCatalog.ts
@@ -136,6 +136,7 @@ export const CARD_CATALOG = {
     { type: 'pv_status', title: 'Persistent Volumes', description: 'Persistent Volumes with capacity, access modes, and reclaim policy', visualization: 'table' },
     { type: 'fluid_status', title: 'Fluid', description: 'Fluid dataset caching status, runtime health, and data load progress', visualization: 'status' },
     { type: 'cubefs_status', title: 'CubeFS', description: 'CubeFS distributed file system health, volume status, and node topology', visualization: 'status' },
+    { type: 'tikv_status', title: 'TiKV', description: 'TiKV distributed key-value store: store nodes, regions, leaders, and capacity', visualization: 'status' },
   ],
   'Provisioning': [
     { type: 'harbor_status', title: 'Harbor Registry', description: 'Harbor registry projects, repositories, and vulnerability scan results', visualization: 'status' },

--- a/web/src/config/cards/index.ts
+++ b/web/src/config/cards/index.ts
@@ -65,6 +65,7 @@ import { fluxStatusConfig } from './flux-status'
 import { contourStatusConfig } from './contour-status'
 import { envoyStatusConfig } from './envoy-status'
 import { linkerdStatusConfig } from './linkerd-status'
+import { tikvStatusConfig } from './tikv-status'
 import { nightlyReleasePulseConfig } from './nightly-release-pulse'
 import { workflowMatrixConfig } from './workflow-matrix'
 import { pipelineFlowConfig } from './pipeline-flow'
@@ -251,6 +252,7 @@ export const CARD_CONFIGS: CardConfigRegistry = {
   contour_status: contourStatusConfig,
   envoy_status: envoyStatusConfig,
   linkerd_status: linkerdStatusConfig,
+  tikv_status: tikvStatusConfig,
   nightly_release_pulse: nightlyReleasePulseConfig,
   workflow_matrix: workflowMatrixConfig,
   pipeline_flow: pipelineFlowConfig,

--- a/web/src/config/cards/tikv-status.ts
+++ b/web/src/config/cards/tikv-status.ts
@@ -1,0 +1,57 @@
+/**
+ * TiKV Status Card Configuration
+ *
+ * Displays TiKV distributed key-value store nodes, region counts,
+ * and capacity utilization for a TiKV (CNCF graduated) cluster.
+ */
+
+import type { UnifiedCardConfig } from '../../lib/unified/types'
+
+export const tikvStatusConfig: UnifiedCardConfig = {
+  type: 'tikv_status',
+  title: 'TiKV',
+  category: 'storage',
+  description: 'TiKV distributed key-value store: store nodes, regions, leaders, and capacity.',
+
+  // Appearance
+  icon: 'Database',
+  iconColor: 'text-orange-400',
+  defaultWidth: 6,
+  defaultHeight: 4,
+
+  // Data source
+  dataSource: {
+    type: 'hook',
+    hook: 'useCachedTikv',
+  },
+
+  // Content — list visualization with store rows
+  content: {
+    type: 'list',
+    pageSize: 6,
+    columns: [
+      { field: 'storeId', header: 'Store', primary: true, width: 80 },
+      { field: 'address', header: 'Address', render: 'truncate' },
+      { field: 'state', header: 'State', width: 80, render: 'status-badge' },
+      { field: 'regionCount', header: 'Regions', width: 100 },
+      { field: 'leaderCount', header: 'Leaders', width: 100 },
+    ],
+  },
+
+  emptyState: {
+    icon: 'Database',
+    title: 'TiKV not detected',
+    message: 'No TiKV store pods found on connected clusters.',
+    variant: 'info',
+  },
+
+  loadingState: {
+    type: 'list',
+    rows: 4,
+  },
+
+  isDemoData: false,
+  isLive: true,
+}
+
+export default tikvStatusConfig

--- a/web/src/hooks/useCachedData.ts
+++ b/web/src/hooks/useCachedData.ts
@@ -144,6 +144,12 @@ export * from './useCachedCiliumStatus'
 export * from './useCachedJaegerStatus'
 
 // ============================================================================
+// TiKV Distributed Key-Value Store — useCachedTikv.ts
+// ============================================================================
+
+export * from './useCachedTikv'
+
+// ============================================================================
 // Standalone fetchers for prefetch (no React hooks, plain async)
 // ============================================================================
 

--- a/web/src/hooks/useCachedTikv.ts
+++ b/web/src/hooks/useCachedTikv.ts
@@ -1,0 +1,224 @@
+/**
+ * useCachedTikv — Cached hook for TiKV store status.
+ *
+ * Follows the mandatory caching contract defined in CLAUDE.md:
+ * - useCache with fetcher + demoData
+ * - isDemoFallback guarded so it's false during loading
+ * - Standard CachedHookResult return shape
+ *
+ * Fetches TiKV Pod resources via the MCP bridge and derives per-store
+ * health from container readiness. When PD (Placement Driver) statistics
+ * are exposed via a metrics endpoint they can be layered in later; for
+ * now region/leader counts and capacity come from annotations when
+ * present, otherwise fall back to zero (no synthetic live values).
+ */
+
+import { useCache, type RefreshCategory, type CachedHookResult } from '../lib/cache'
+import { FETCH_DEFAULT_TIMEOUT_MS } from '../lib/constants/network'
+import { authFetch } from '../lib/api'
+import { TIKV_DEMO_DATA, type TikvStatusData, type TikvStore, type TikvStoreState } from '../lib/demo/tikv'
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const CACHE_KEY_TIKV = 'tikv-status'
+
+const INITIAL_DATA: TikvStatusData = {
+  health: 'not-installed',
+  stores: [],
+  summary: { totalStores: 0, upStores: 0, downStores: 0, totalRegions: 0, totalLeaders: 0 },
+  lastCheckTime: new Date().toISOString(),
+}
+
+// TiKV/PD annotation keys commonly set by operator-managed deployments.
+// When absent we default the value to zero rather than fabricating data.
+const ANNOT_REGION_COUNT = 'tikv.kubestellar.io/region-count'
+const ANNOT_LEADER_COUNT = 'tikv.kubestellar.io/leader-count'
+const ANNOT_CAPACITY_BYTES = 'tikv.kubestellar.io/capacity-bytes'
+const ANNOT_AVAILABLE_BYTES = 'tikv.kubestellar.io/available-bytes'
+const ANNOT_STORE_ID = 'tikv.kubestellar.io/store-id'
+
+const TIKV_DEFAULT_PORT = 20160
+
+// ---------------------------------------------------------------------------
+// Internal types (shape of MCP custom-resource response)
+// ---------------------------------------------------------------------------
+
+interface PodItem {
+  name: string
+  namespace?: string
+  cluster?: string
+  status?: {
+    phase?: string
+    podIP?: string
+    containerStatuses?: Array<{ name?: string; ready?: boolean; image?: string }>
+  }
+  metadata?: {
+    labels?: Record<string, string>
+    annotations?: Record<string, string>
+  }
+}
+
+interface PodListResponse {
+  items?: PodItem[]
+}
+
+// ---------------------------------------------------------------------------
+// Helpers (pure, unit-testable)
+// ---------------------------------------------------------------------------
+
+function isTikvPod(pod: PodItem): boolean {
+  const name = pod.name?.toLowerCase() || ''
+  const labels = pod.metadata?.labels || {}
+  if (labels['app.kubernetes.io/component'] === 'tikv') return true
+  if (labels['app.kubernetes.io/name'] === 'tikv') return true
+  if (labels['app'] === 'tikv') return true
+  return name.startsWith('tikv-') || name.includes('-tikv-')
+}
+
+function parseIntOrZero(value: string | undefined): number {
+  if (!value) return 0
+  const n = Number.parseInt(value, 10)
+  return Number.isFinite(n) ? n : 0
+}
+
+function deriveStoreState(pod: PodItem): TikvStoreState {
+  const phase = pod.status?.phase
+  if (phase === 'Running') {
+    const containers = pod.status?.containerStatuses || []
+    const allReady = containers.length > 0 && containers.every(c => c.ready === true)
+    return allReady ? 'Up' : 'Down'
+  }
+  if (phase === 'Pending') return 'Offline'
+  if (phase === 'Failed') return 'Down'
+  return 'Down'
+}
+
+function parseVersion(pod: PodItem): string {
+  const containers = pod.status?.containerStatuses || []
+  const tikvContainer = containers.find(c => (c.name || '').toLowerCase().includes('tikv'))
+  const image = tikvContainer?.image || containers[0]?.image || ''
+  if (!image) return ''
+  const withoutDigest = image.split('@')[0]
+  const colonIdx = withoutDigest.lastIndexOf(':')
+  if (colonIdx < 0) return ''
+  return withoutDigest.substring(colonIdx + 1)
+}
+
+function podToStore(pod: PodItem, fallbackStoreId: number): TikvStore {
+  const annotations = pod.metadata?.annotations || {}
+  const ip = pod.status?.podIP || ''
+  const address = ip ? `${ip}:${TIKV_DEFAULT_PORT}` : pod.name
+  const storeId = parseIntOrZero(annotations[ANNOT_STORE_ID]) || fallbackStoreId
+  return {
+    storeId,
+    address,
+    state: deriveStoreState(pod),
+    version: parseVersion(pod),
+    regionCount: parseIntOrZero(annotations[ANNOT_REGION_COUNT]),
+    leaderCount: parseIntOrZero(annotations[ANNOT_LEADER_COUNT]),
+    capacityBytes: parseIntOrZero(annotations[ANNOT_CAPACITY_BYTES]),
+    availableBytes: parseIntOrZero(annotations[ANNOT_AVAILABLE_BYTES]),
+  }
+}
+
+function summarize(stores: TikvStore[]): TikvStatusData['summary'] {
+  let upStores = 0
+  let totalRegions = 0
+  let totalLeaders = 0
+  for (const store of stores) {
+    if (store.state === 'Up') upStores += 1
+    totalRegions += store.regionCount
+    totalLeaders += store.leaderCount
+  }
+  return {
+    totalStores: stores.length,
+    upStores,
+    downStores: stores.length - upStores,
+    totalRegions,
+    totalLeaders,
+  }
+}
+
+function buildStatus(stores: TikvStore[]): TikvStatusData {
+  const summary = summarize(stores)
+  let health: TikvStatusData['health'] = 'healthy'
+  if (summary.totalStores === 0) health = 'not-installed'
+  else if (summary.downStores > 0) health = 'degraded'
+  return {
+    health,
+    stores,
+    summary,
+    lastCheckTime: new Date().toISOString(),
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Fetcher
+// ---------------------------------------------------------------------------
+
+async function fetchTikvStatus(): Promise<TikvStatusData> {
+  const params = new URLSearchParams({
+    group: '',
+    version: 'v1',
+    resource: 'pods',
+  })
+
+  const resp = await authFetch(`/api/mcp/custom-resources?${params.toString()}`, {
+    headers: { Accept: 'application/json' },
+    signal: AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS),
+  })
+
+  if (!resp.ok) {
+    if (resp.status === 404) return buildStatus([])
+    throw new Error(`HTTP ${resp.status}`)
+  }
+
+  const body = (await resp.json()) as PodListResponse
+  const items = Array.isArray(body.items) ? body.items : []
+  const tikvPods = items.filter(isTikvPod)
+  const stores = tikvPods.map((pod, idx) => podToStore(pod, idx + 1))
+  return buildStatus(stores)
+}
+
+// ---------------------------------------------------------------------------
+// Hook
+// ---------------------------------------------------------------------------
+
+export function useCachedTikv(): CachedHookResult<TikvStatusData> {
+  const result = useCache<TikvStatusData>({
+    key: CACHE_KEY_TIKV,
+    category: 'default' as RefreshCategory,
+    initialData: INITIAL_DATA,
+    demoData: TIKV_DEMO_DATA,
+    persist: true,
+    fetcher: fetchTikvStatus,
+  })
+
+  return {
+    data: result.data,
+    isLoading: result.isLoading,
+    isRefreshing: result.isRefreshing,
+    isDemoFallback: result.isDemoFallback,
+    error: result.error,
+    isFailed: result.isFailed,
+    consecutiveFailures: result.consecutiveFailures,
+    lastRefresh: result.lastRefresh,
+    refetch: result.refetch,
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Exported testables — pure functions for unit testing
+// ---------------------------------------------------------------------------
+
+export const __testables = {
+  isTikvPod,
+  parseIntOrZero,
+  deriveStoreState,
+  parseVersion,
+  podToStore,
+  summarize,
+  buildStatus,
+}

--- a/web/src/hooks/useMarketplace.ts
+++ b/web/src/hooks/useMarketplace.ts
@@ -97,7 +97,8 @@ const MARKETPLACE_TO_CARD_TYPE: Record<string, string> = {
   'cncf-linkerd': 'linkerd_status',
   'cncf-openfeature': 'openfeature_status',
   'cncf-strimzi': 'strimzi_status',
-  'cncf-thanos': 'thanos_status' }
+  'cncf-thanos': 'thanos_status',
+  'cncf-tikv': 'tikv_status' }
 
 /**
  * Reconcile marketplace items against the local card registry.

--- a/web/src/lib/demo/tikv.ts
+++ b/web/src/lib/demo/tikv.ts
@@ -1,0 +1,113 @@
+/**
+ * TiKV Status Card — Demo Data & Type Definitions
+ *
+ * Models TiKV store nodes for the TiKV (CNCF graduated) distributed
+ * key-value store. Each store reports region/leader counts and capacity
+ * utilization so operators can spot hotspots or uneven leader distribution.
+ */
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type TikvStoreState = 'Up' | 'Offline' | 'Tombstone' | 'Down'
+
+export interface TikvStore {
+  storeId: number
+  address: string
+  state: TikvStoreState
+  version: string
+  regionCount: number
+  leaderCount: number
+  /** Total store capacity in bytes. */
+  capacityBytes: number
+  /** Available capacity in bytes. */
+  availableBytes: number
+}
+
+export interface TikvSummary {
+  totalStores: number
+  upStores: number
+  downStores: number
+  totalRegions: number
+  totalLeaders: number
+}
+
+export interface TikvStatusData {
+  health: 'healthy' | 'degraded' | 'not-installed'
+  stores: TikvStore[]
+  summary: TikvSummary
+  lastCheckTime: string
+}
+
+// ---------------------------------------------------------------------------
+// Demo data — shown when TiKV is not installed or in demo mode
+// ---------------------------------------------------------------------------
+
+// Named constants (no magic numbers)
+const BYTES_PER_GIB = 1024 * 1024 * 1024
+const DEMO_CAPACITY_GIB = 500
+const DEMO_AVAILABLE_GIB_HEALTHY = 320
+const DEMO_AVAILABLE_GIB_WARM = 180
+const DEMO_AVAILABLE_GIB_LOW = 90
+
+const DEMO_STORES: TikvStore[] = [
+  {
+    storeId: 1,
+    address: 'tikv-0.tikv-peer.tidb:20160',
+    state: 'Up',
+    version: '7.5.1',
+    regionCount: 1248,
+    leaderCount: 420,
+    capacityBytes: DEMO_CAPACITY_GIB * BYTES_PER_GIB,
+    availableBytes: DEMO_AVAILABLE_GIB_HEALTHY * BYTES_PER_GIB,
+  },
+  {
+    storeId: 2,
+    address: 'tikv-1.tikv-peer.tidb:20160',
+    state: 'Up',
+    version: '7.5.1',
+    regionCount: 1256,
+    leaderCount: 416,
+    capacityBytes: DEMO_CAPACITY_GIB * BYTES_PER_GIB,
+    availableBytes: DEMO_AVAILABLE_GIB_WARM * BYTES_PER_GIB,
+  },
+  {
+    storeId: 3,
+    address: 'tikv-2.tikv-peer.tidb:20160',
+    state: 'Up',
+    version: '7.5.1',
+    regionCount: 1233,
+    leaderCount: 412,
+    capacityBytes: DEMO_CAPACITY_GIB * BYTES_PER_GIB,
+    availableBytes: DEMO_AVAILABLE_GIB_HEALTHY * BYTES_PER_GIB,
+  },
+  {
+    storeId: 4,
+    address: 'tikv-3.tikv-peer.tidb:20160',
+    state: 'Down',
+    version: '7.5.1',
+    regionCount: 0,
+    leaderCount: 0,
+    capacityBytes: DEMO_CAPACITY_GIB * BYTES_PER_GIB,
+    availableBytes: DEMO_AVAILABLE_GIB_LOW * BYTES_PER_GIB,
+  },
+]
+
+const DEMO_TOTAL_REGIONS = DEMO_STORES.reduce((acc, s) => acc + s.regionCount, 0)
+const DEMO_TOTAL_LEADERS = DEMO_STORES.reduce((acc, s) => acc + s.leaderCount, 0)
+const DEMO_UP_STORES = DEMO_STORES.filter(s => s.state === 'Up').length
+const DEMO_DOWN_STORES = DEMO_STORES.length - DEMO_UP_STORES
+
+export const TIKV_DEMO_DATA: TikvStatusData = {
+  health: 'degraded',
+  stores: DEMO_STORES,
+  summary: {
+    totalStores: DEMO_STORES.length,
+    upStores: DEMO_UP_STORES,
+    downStores: DEMO_DOWN_STORES,
+    totalRegions: DEMO_TOTAL_REGIONS,
+    totalLeaders: DEMO_TOTAL_LEADERS,
+  },
+  lastCheckTime: new Date().toISOString(),
+}

--- a/web/src/lib/unified/registerHooks.ts
+++ b/web/src/lib/unified/registerHooks.ts
@@ -51,6 +51,7 @@ import { useFluxStatus } from '../../components/cards/flux_status/useFluxStatus'
 import { useContourStatus } from '../../components/cards/contour_status/useContourStatus'
 import { useCachedEnvoy } from '../../components/cards/envoy_status/useCachedEnvoy'
 import { useCachedLinkerd } from '../../hooks/useCachedLinkerd'
+import { useCachedTikv } from '../../hooks/useCachedTikv'
 
 // ============================================================================
 // Wrapper hooks that convert params object to positional args
@@ -1063,6 +1064,16 @@ function useUnifiedLinkerdStatus() {
   }
 }
 
+function useUnifiedTikvStatus() {
+  const result = useCachedTikv()
+  return {
+    data: result.data.stores,
+    isLoading: result.isLoading,
+    error: result.error ? new Error(result.error) : null,
+    refetch: result.refetch,
+  }
+}
+
 function useProviderHealth() {
   return useDemoDataHook(DEMO_PROVIDER_HEALTH)
 }
@@ -1252,6 +1263,7 @@ export function registerUnifiedHooks(): void {
   registerDataHook('useContourStatus', useUnifiedContourStatus)
   registerDataHook('useCachedEnvoy', useUnifiedEnvoyStatus)
   registerDataHook('useCachedLinkerd', useUnifiedLinkerdStatus)
+  registerDataHook('useCachedTikv', useUnifiedTikvStatus)
   registerDataHook('useProviderHealth', useProviderHealth)
   registerDataHook('useUpgradeStatus', useUpgradeStatus)
   registerDataHook('useProwStatus', useProwStatus)

--- a/web/src/locales/en/cards.json
+++ b/web/src/locales/en/cards.json
@@ -3075,6 +3075,23 @@
     "sectionDeployments": "Meshed deployments",
     "noDeployments": "No meshed deployments found"
   },
+  "tikvStatus": {
+    "healthy": "Healthy",
+    "degraded": "Degraded",
+    "notInstalled": "TiKV not detected",
+    "notInstalledHint": "No TiKV store pods found. Deploy TiKV to monitor the distributed key-value store.",
+    "upStores": "Up",
+    "downStores": "Down",
+    "regions": "Regions",
+    "leaders": "Leaders",
+    "noStores": "No TiKV stores reporting.",
+    "stores_one": "{{count}} store",
+    "stores_other": "{{count}} stores",
+    "regionCount_one": "{{count}} region",
+    "regionCount_other": "{{count}} regions",
+    "leaderCount_one": "{{count}} leader",
+    "leaderCount_other": "{{count}} leaders"
+  },
   "kubecostOverview": {
     "monthlyCost": "Monthly Cost",
     "savingsRecommendations": "Savings Recommendations",


### PR DESCRIPTION
Adds TiKV status card (Database) showing store nodes, region count, leader count, capacity. Hook uses useCache with demo fallback. Follows envoy_status pattern.

Refs kubestellar/console-marketplace#12