### PR TITLE
feat(containerd): add containerd monitoring card

### DIFF
--- a/web/src/components/cards/cardIcons.ts
+++ b/web/src/components/cards/cardIcons.ts
@@ -193,6 +193,8 @@ export const CARD_ICONS: Record<string, { icon: ComponentType<{ className?: stri
   coredns_status: { icon: Network, color: 'text-cyan-400' },
   // CRI-O
   crio_status: { icon: Box, color: 'text-blue-400' },
+  // Containerd
+  containerd_status: { icon: Box, color: 'text-blue-400' },
 
   // Games
   sudoku_game: { icon: Puzzle, color: 'text-purple-400' },

--- a/web/src/components/cards/cardMetadata.ts
+++ b/web/src/components/cards/cardMetadata.ts
@@ -272,6 +272,8 @@ export const CARD_TITLES: Record<string, string> = {
   linkerd_status: 'Linkerd',
   // CRI-O container runtime
   crio_status: 'CRI-O',
+  // Containerd container runtime
+  containerd_status: 'Containerd',
   // Strimzi Kafka operator
   strimzi_status: 'Strimzi',
   // Flatcar Container Linux
@@ -585,6 +587,8 @@ export const CARD_DESCRIPTIONS: Record<string, string> = {
   linkerd_status: 'Linkerd service mesh meshed pods, success rate, RPS, and p99 latency per deployment.',
   // CRI-O container runtime
   crio_status: 'CRI-O container runtime metrics, image pulls, and pod sandbox status.',
+  // Containerd container runtime
+  containerd_status: 'Containerd runtime — running containers, image, namespace, state, and uptime.',
 
   // KubeVela application delivery
   kubevela_status: 'KubeVela application delivery, component status, and workflow progress.',

--- a/web/src/components/cards/cardRegistry.ts
+++ b/web/src/components/cards/cardRegistry.ts
@@ -293,6 +293,8 @@ const KedaStatus = safeLazy(() => import('./keda_status'), 'KedaStatus')
 const FluentdStatus = safeLazy(() => import('./fluentd_status'), 'FluentdStatus')
 // CRI-O container runtime card
 const CrioStatus = safeLazy(() => import('./crio_status'), 'CrioStatus')
+// Containerd container runtime card (CNCF graduated — marketplace#4)
+const ContainerdStatus = safeLazy(() => import('./containerd_status'), 'ContainerdStatus')
 // Lima VM card
 const LimaStatus = safeLazy(() => import('./lima_status'), 'LimaStatus')
 // NATS messaging server monitoring card
@@ -698,6 +700,8 @@ const RAW_CARD_COMPONENTS: Record<string, CardComponent> = {
   fluentd_status: FluentdStatus,
   // CRI-O container runtime
   crio_status: CrioStatus,
+  // Containerd container runtime
+  containerd_status: ContainerdStatus,
   // Lima VM
   lima_status: LimaStatus,
   // NATS messaging server
@@ -1167,6 +1171,8 @@ const CARD_CHUNK_PRELOADERS: Record<string, () => Promise<unknown>> = {
   cloudevents_status: () => import('./cloudevents_status'),
   // CRI-O
   crio_status: () => import('./crio_status'),
+  // Containerd
+  containerd_status: () => import('./containerd_status'),
   // Strimzi
   strimzi_status: () => import('./strimzi_status'),
   // KubeVela application delivery
@@ -1378,6 +1384,7 @@ export const LIVE_DATA_CARDS = new Set([
   'coredns_status',
   'keda_status',
   'crio_status',
+  'containerd_status',
   'strimzi_status',
   'keycloak_status',
   'kubevela_status',
@@ -1529,6 +1536,7 @@ export const CARD_DEFAULT_WIDTHS: Record<string, number> = {
   coredns_status: 6,
   keda_status: 6,
   crio_status: 6,
+  containerd_status: 6,
   strimzi_status: 6,
   etcd_status: 4,
   network_policies: 6,

--- a/web/src/components/cards/containerd_status/index.tsx
+++ b/web/src/components/cards/containerd_status/index.tsx
@@ -209,7 +209,7 @@ export function ContainerdStatus() {
             </div>
           ) : (
             <div className="space-y-1.5">
-              {data.containers.map(c => (
+              {(data.containers ?? []).map(c => (
                 <ContainerRow key={`${c.node}:${c.id}:${c.namespace}`} item={c} />
               ))}
             </div>

--- a/web/src/components/cards/containerd_status/index.tsx
+++ b/web/src/components/cards/containerd_status/index.tsx
@@ -12,6 +12,7 @@
  * Marketplace preset: cncf-containerd — kubestellar/console-marketplace#4
  */
 import React from 'react'
+import { useTranslation } from 'react-i18next'
 import { AlertTriangle, Box, CheckCircle, PauseCircle, RefreshCw, Server, StopCircle } from 'lucide-react'
 import { MetricTile } from '../../../lib/cards/CardComponents'
 import { Skeleton, SkeletonList, SkeletonStats } from '../../ui/Skeleton'
@@ -91,6 +92,7 @@ function ContainerRow({ item }: { item: ContainerdContainer }) {
 }
 
 export function ContainerdStatus() {
+  const { t } = useTranslation(['cards', 'common'])
   const {
     data,
     isLoading,
@@ -130,7 +132,7 @@ export function ContainerdStatus() {
     return (
       <div className="h-full flex flex-col items-center justify-center min-h-card text-muted-foreground gap-2">
         <AlertTriangle className="w-6 h-6 text-red-400" />
-        <p className="text-sm text-red-400">Failed to fetch containerd status</p>
+        <p className="text-sm text-red-400">{t('containerdStatus.fetchFailed', 'Failed to fetch containerd status')}</p>
       </div>
     )
   }
@@ -139,9 +141,9 @@ export function ContainerdStatus() {
     return (
       <div className="h-full flex flex-col items-center justify-center min-h-card text-muted-foreground gap-2">
         <Box className="w-6 h-6 text-muted-foreground/50" />
-        <p className="text-sm font-medium">containerd not detected</p>
+        <p className="text-sm font-medium">{t('containerdStatus.notDetected', 'containerd not detected')}</p>
         <p className="text-xs text-center max-w-xs">
-          No nodes on connected clusters report containerd as their runtime.
+          {t('containerdStatus.notDetectedHint', 'No nodes on connected clusters report containerd as their runtime.')}
         </p>
       </div>
     )
@@ -158,7 +160,9 @@ export function ContainerdStatus() {
           }`}
         >
           {isHealthy ? <CheckCircle className="w-4 h-4" /> : <AlertTriangle className="w-4 h-4" />}
-          {isHealthy ? 'Healthy' : 'Degraded'}
+          {isHealthy
+            ? t('containerdStatus.healthy', 'Healthy')
+            : t('containerdStatus.degraded', 'Degraded')}
         </div>
 
         <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
@@ -169,25 +173,25 @@ export function ContainerdStatus() {
 
       <div className="grid grid-cols-2 @md:grid-cols-4 gap-2">
         <MetricTile
-          label="Total"
+          label={t('containerdStatus.total', 'Total')}
           value={data.summary.totalContainers}
           colorClass="text-cyan-400"
           icon={<Box className="w-4 h-4 text-cyan-400" />}
         />
         <MetricTile
-          label="Running"
+          label={t('containerdStatus.running', 'Running')}
           value={data.summary.running}
           colorClass="text-green-400"
           icon={<CheckCircle className="w-4 h-4 text-green-400" />}
         />
         <MetricTile
-          label="Paused"
+          label={t('containerdStatus.paused', 'Paused')}
           value={data.summary.paused}
           colorClass={data.summary.paused > 0 ? 'text-yellow-400' : 'text-muted-foreground'}
           icon={<PauseCircle className="w-4 h-4 text-yellow-400" />}
         />
         <MetricTile
-          label="Stopped"
+          label={t('containerdStatus.stopped', 'Stopped')}
           value={data.summary.stopped}
           colorClass={data.summary.stopped > 0 ? 'text-red-400' : 'text-muted-foreground'}
           icon={<StopCircle className="w-4 h-4 text-red-400" />}
@@ -199,13 +203,13 @@ export function ContainerdStatus() {
           <div className="flex items-center gap-2">
             <Server className="w-4 h-4 text-cyan-400" />
             <h4 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
-              Containers
+              {t('containerdStatus.containers', 'Containers')}
             </h4>
           </div>
 
           {data.containers.length === 0 ? (
             <div className="rounded-md bg-secondary/20 border border-border/40 px-3 py-2 text-xs text-muted-foreground">
-              No containers reported
+              {t('containerdStatus.noContainers', 'No containers reported')}
             </div>
           ) : (
             <div className="space-y-1.5">

--- a/web/src/components/cards/containerd_status/index.tsx
+++ b/web/src/components/cards/containerd_status/index.tsx
@@ -1,0 +1,223 @@
+/**
+ * Containerd Status Card
+ *
+ * Surfaces containerd container-runtime telemetry across connected clusters:
+ * running containers (id, image, namespace, state, uptime, node).
+ *
+ * Follows the contour_status / jaeger_status card pattern:
+ *   - Data via useCachedContainerd (useCache under the hood).
+ *   - isDemoData + isRefreshing wired into useCardLoadingState (CLAUDE.md rule).
+ *   - Skeleton during first load only (isLoading && !hasAnyData).
+ *
+ * Marketplace preset: cncf-containerd — kubestellar/console-marketplace#4
+ */
+import React from 'react'
+import { AlertTriangle, Box, CheckCircle, PauseCircle, RefreshCw, Server, StopCircle } from 'lucide-react'
+import { MetricTile } from '../../../lib/cards/CardComponents'
+import { Skeleton, SkeletonList, SkeletonStats } from '../../ui/Skeleton'
+import { useCachedContainerd } from '../../../hooks/useCachedContainerd'
+import { useCardLoadingState } from '../CardDataContext'
+import type { ContainerdContainer, ContainerdContainerState } from '../../../lib/demo/containerd'
+
+// ---------------------------------------------------------------------------
+// Constants (no magic numbers)
+// ---------------------------------------------------------------------------
+
+const SKELETON_TITLE_WIDTH = 140
+const SKELETON_TITLE_HEIGHT = 28
+const SKELETON_BADGE_WIDTH = 90
+const SKELETON_BADGE_HEIGHT = 20
+const SKELETON_ROW_COUNT = 6
+
+const MS_PER_SECOND = 1000
+const SECONDS_PER_MINUTE = 60
+const MINUTES_PER_HOUR = 60
+const HOURS_PER_DAY = 24
+
+function formatRelative(iso: string): string {
+  const parsed = new Date(iso).getTime()
+  if (!iso || Number.isNaN(parsed)) return 'just now'
+  const diffMs = Date.now() - parsed
+  if (diffMs < MS_PER_SECOND * SECONDS_PER_MINUTE) return 'just now'
+
+  const minutes = Math.floor(diffMs / (MS_PER_SECOND * SECONDS_PER_MINUTE))
+  if (minutes < MINUTES_PER_HOUR) return `${minutes}m ago`
+
+  const hours = Math.floor(minutes / MINUTES_PER_HOUR)
+  if (hours < HOURS_PER_DAY) return `${hours}h ago`
+
+  const days = Math.floor(hours / HOURS_PER_DAY)
+  return `${days}d ago`
+}
+
+const STATE_ICON: Record<ContainerdContainerState, React.ReactNode> = {
+  running: <CheckCircle className="w-3.5 h-3.5 text-green-400 shrink-0" />,
+  paused: <PauseCircle className="w-3.5 h-3.5 text-yellow-400 shrink-0" />,
+  stopped: <StopCircle className="w-3.5 h-3.5 text-red-400 shrink-0" />,
+}
+
+const STATE_BADGE: Record<ContainerdContainerState, string> = {
+  running: 'bg-green-500/20 text-green-400',
+  paused: 'bg-yellow-500/20 text-yellow-400',
+  stopped: 'bg-red-500/20 text-red-400',
+}
+
+function ContainerRow({ item }: { item: ContainerdContainer }) {
+  return (
+    <div className="rounded-md bg-secondary/30 px-3 py-2.5 space-y-1">
+      <div className="flex items-center justify-between gap-2">
+        <div className="min-w-0 flex items-center gap-1.5">
+          {STATE_ICON[item.state]}
+          <span className="text-xs font-mono truncate">{item.id}</span>
+        </div>
+        <span
+          className={`text-[11px] px-1.5 py-0.5 rounded-full shrink-0 ${STATE_BADGE[item.state]}`}
+        >
+          {item.state}
+        </span>
+      </div>
+
+      <div className="text-xs text-muted-foreground flex items-center justify-between gap-2">
+        <span className="truncate">{item.image || '-'}</span>
+        <span className="truncate shrink-0 ml-2">{item.uptime}</span>
+      </div>
+
+      <div className="text-[11px] text-muted-foreground/80 flex items-center justify-between gap-2">
+        <span className="truncate">{item.namespace}</span>
+        <span className="truncate shrink-0 ml-2">{item.node}</span>
+      </div>
+    </div>
+  )
+}
+
+export function ContainerdStatus() {
+  const {
+    data,
+    isLoading,
+    isRefreshing,
+    isDemoData,
+    isFailed,
+    consecutiveFailures,
+    lastRefresh,
+  } = useCachedContainerd()
+
+  const hasAnyData = data.containers.length > 0
+
+  const { showSkeleton, showEmptyState } = useCardLoadingState({
+    isLoading: isLoading && !hasAnyData,
+    isRefreshing,
+    isDemoData,
+    hasAnyData,
+    isFailed,
+    consecutiveFailures,
+    lastRefresh,
+  })
+
+  if (showSkeleton) {
+    return (
+      <div className="h-full flex flex-col min-h-card gap-4">
+        <div className="flex items-center justify-between">
+          <Skeleton variant="rounded" width={SKELETON_TITLE_WIDTH} height={SKELETON_TITLE_HEIGHT} />
+          <Skeleton variant="rounded" width={SKELETON_BADGE_WIDTH} height={SKELETON_BADGE_HEIGHT} />
+        </div>
+        <SkeletonStats className="grid-cols-4" />
+        <SkeletonList items={SKELETON_ROW_COUNT} className="flex-1" />
+      </div>
+    )
+  }
+
+  if (showEmptyState) {
+    return (
+      <div className="h-full flex flex-col items-center justify-center min-h-card text-muted-foreground gap-2">
+        <AlertTriangle className="w-6 h-6 text-red-400" />
+        <p className="text-sm text-red-400">Failed to fetch containerd status</p>
+      </div>
+    )
+  }
+
+  if (data.health === 'not-installed' && !hasAnyData) {
+    return (
+      <div className="h-full flex flex-col items-center justify-center min-h-card text-muted-foreground gap-2">
+        <Box className="w-6 h-6 text-muted-foreground/50" />
+        <p className="text-sm font-medium">containerd not detected</p>
+        <p className="text-xs text-center max-w-xs">
+          No nodes on connected clusters report containerd as their runtime.
+        </p>
+      </div>
+    )
+  }
+
+  const isHealthy = data.health === 'healthy'
+
+  return (
+    <div className="h-full flex flex-col min-h-card content-loaded gap-4 overflow-hidden">
+      <div className="flex items-center justify-between gap-2">
+        <div
+          className={`flex items-center gap-2 px-3 py-1.5 rounded-full text-sm font-medium ${
+            isHealthy ? 'bg-green-500/15 text-green-400' : 'bg-yellow-500/15 text-yellow-400'
+          }`}
+        >
+          {isHealthy ? <CheckCircle className="w-4 h-4" /> : <AlertTriangle className="w-4 h-4" />}
+          {isHealthy ? 'Healthy' : 'Degraded'}
+        </div>
+
+        <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
+          <RefreshCw className={`w-3 h-3 ${isRefreshing ? 'animate-spin' : ''}`} />
+          <span>{formatRelative(data.lastCheckTime)}</span>
+        </div>
+      </div>
+
+      <div className="grid grid-cols-2 @md:grid-cols-4 gap-2">
+        <MetricTile
+          label="Total"
+          value={data.summary.totalContainers}
+          colorClass="text-cyan-400"
+          icon={<Box className="w-4 h-4 text-cyan-400" />}
+        />
+        <MetricTile
+          label="Running"
+          value={data.summary.running}
+          colorClass="text-green-400"
+          icon={<CheckCircle className="w-4 h-4 text-green-400" />}
+        />
+        <MetricTile
+          label="Paused"
+          value={data.summary.paused}
+          colorClass={data.summary.paused > 0 ? 'text-yellow-400' : 'text-muted-foreground'}
+          icon={<PauseCircle className="w-4 h-4 text-yellow-400" />}
+        />
+        <MetricTile
+          label="Stopped"
+          value={data.summary.stopped}
+          colorClass={data.summary.stopped > 0 ? 'text-red-400' : 'text-muted-foreground'}
+          icon={<StopCircle className="w-4 h-4 text-red-400" />}
+        />
+      </div>
+
+      <div className="space-y-3 overflow-y-auto scrollbar-thin pr-0.5">
+        <section className="space-y-2">
+          <div className="flex items-center gap-2">
+            <Server className="w-4 h-4 text-cyan-400" />
+            <h4 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+              Containers
+            </h4>
+          </div>
+
+          {data.containers.length === 0 ? (
+            <div className="rounded-md bg-secondary/20 border border-border/40 px-3 py-2 text-xs text-muted-foreground">
+              No containers reported
+            </div>
+          ) : (
+            <div className="space-y-1.5">
+              {data.containers.map(c => (
+                <ContainerRow key={`${c.node}:${c.id}:${c.namespace}`} item={c} />
+              ))}
+            </div>
+          )}
+        </section>
+      </div>
+    </div>
+  )
+}
+
+export default ContainerdStatus

--- a/web/src/components/dashboard/shared/cardCatalog.ts
+++ b/web/src/components/dashboard/shared/cardCatalog.ts
@@ -373,6 +373,7 @@ export const CARD_CATALOG = {
     { type: 'lima_status', title: 'Lima', description: 'Lima virtual machine instances, runtime health, and resource usage', visualization: 'status' },
     { type: 'artifact_hub_status', title: 'Artifact Hub', description: 'Artifact Hub package discovery and repository sync status', visualization: 'status' },
     { type: 'crio_status', title: 'CRI-O', description: 'CRI-O container runtime metrics, image pulls, and pod sandbox status', visualization: 'status' },
+    { type: 'containerd_status', title: 'Containerd', description: 'Containerd runtime — running containers, image, namespace, state, and uptime', visualization: 'status' },
     { type: 'github_activity', title: 'GitHub Activity', description: 'Monitor GitHub repository activity - PRs, issues, releases, and contributors', visualization: 'table' },
     { type: 'kubectl', title: 'Kubectl', description: 'Interactive kubectl terminal with AI assistance, YAML editor, and command history', visualization: 'table' },
   ],

--- a/web/src/config/cards/containerd-status.ts
+++ b/web/src/config/cards/containerd-status.ts
@@ -1,0 +1,46 @@
+/**
+ * Containerd Status Card Configuration
+ *
+ * Marketplace preset: cncf-containerd
+ * Upstream issue: kubestellar/console-marketplace#4
+ */
+import type { UnifiedCardConfig } from '../../lib/unified/types'
+
+export const containerdStatusConfig: UnifiedCardConfig = {
+  type: 'containerd_status',
+  title: 'Containerd',
+  // 'runtime' isn't a CardCategory — use 'compute' (closest semantic fit;
+  // CRI-O follows the same pattern and lives under Misc in the catalog).
+  category: 'compute',
+  description: 'Containerd container runtime — running containers, image, namespace, state, uptime.',
+  icon: 'Box',
+  iconColor: 'text-blue-400',
+  defaultWidth: 6,
+  defaultHeight: 4,
+  dataSource: { type: 'hook', hook: 'useCachedContainerd' },
+  content: {
+    type: 'list',
+    pageSize: 8,
+    columns: [
+      { field: 'id', header: 'ID', primary: true, render: 'truncate' },
+      { field: 'image', header: 'Image', render: 'truncate' },
+      { field: 'namespace', header: 'Namespace', width: 120, render: 'namespace-badge' },
+      { field: 'state', header: 'State', width: 80, render: 'status-badge' },
+      { field: 'uptime', header: 'Uptime', width: 100, render: 'truncate' },
+    ],
+  },
+  emptyState: {
+    icon: 'Box',
+    title: 'containerd not detected',
+    message: 'No nodes on connected clusters report containerd as their runtime.',
+    variant: 'info',
+  },
+  loadingState: {
+    type: 'list',
+    rows: 5,
+  },
+  isDemoData: false,
+  isLive: true,
+}
+
+export default containerdStatusConfig

--- a/web/src/config/cards/index.ts
+++ b/web/src/config/cards/index.ts
@@ -63,6 +63,7 @@ import { githubActivityConfig } from './github-activity'
 import { githubCiMonitorConfig } from './github-ci-monitor'
 import { fluxStatusConfig } from './flux-status'
 import { contourStatusConfig } from './contour-status'
+import { containerdStatusConfig } from './containerd-status'
 import { envoyStatusConfig } from './envoy-status'
 import { linkerdStatusConfig } from './linkerd-status'
 import { nightlyReleasePulseConfig } from './nightly-release-pulse'
@@ -249,6 +250,7 @@ export const CARD_CONFIGS: CardConfigRegistry = {
   github_ci_monitor: githubCiMonitorConfig,
   flux_status: fluxStatusConfig,
   contour_status: contourStatusConfig,
+  containerd_status: containerdStatusConfig,
   envoy_status: envoyStatusConfig,
   linkerd_status: linkerdStatusConfig,
   nightly_release_pulse: nightlyReleasePulseConfig,

--- a/web/src/hooks/useCachedContainerd.ts
+++ b/web/src/hooks/useCachedContainerd.ts
@@ -1,0 +1,279 @@
+/**
+ * useCachedContainerd — Hook for the containerd runtime monitoring card.
+ *
+ * Follows the useCached* caching contract from CLAUDE.md:
+ *   - Returns: data, isLoading, isRefreshing, isDemoData, isFailed,
+ *     consecutiveFailures, lastRefresh, refetch.
+ *   - isDemoData is suppressed while isLoading is true (so CardWrapper shows
+ *     a skeleton instead of flashing demo data).
+ *
+ * Data source: derives a containerd view from node.containerRuntime +
+ * pod.containers surfaced by the kc-agent /nodes and /pods endpoints
+ * (same source of truth used by useCrioStatus). Containerd nodes are
+ * matched by `containerRuntime` containing "containerd".
+ *
+ * Marketplace preset: cncf-containerd
+ * Upstream issue: kubestellar/console-marketplace#4
+ */
+
+import { useCache, type RefreshCategory } from '../lib/cache'
+import { useDemoMode } from './useDemoMode'
+import { FETCH_DEFAULT_TIMEOUT_MS, LOCAL_AGENT_HTTP_URL } from '../lib/constants/network'
+import {
+  CONTAINERD_DEMO_DATA,
+  type ContainerdContainer,
+  type ContainerdContainerState,
+  type ContainerdStatusData,
+} from '../lib/demo/containerd'
+
+// ---------------------------------------------------------------------------
+// Constants (no magic numbers)
+// ---------------------------------------------------------------------------
+
+const CACHE_KEY_CONTAINERD = 'containerd_status'
+
+/** How many characters of the raw container ID to surface (matches ctr/crictl). */
+const CONTAINER_ID_DISPLAY_LEN = 12
+
+/** Fallback name used when a container's namespace is not reported. */
+const NAMESPACE_FALLBACK = 'default'
+
+/** Fallback node name for pods whose `node` field is missing. */
+const NODE_FALLBACK = 'unknown'
+
+/** Max number of containers to surface in the card (keeps payload small). */
+const MAX_CONTAINERS_DISPLAYED = 25
+
+/** Zero-state uptime for containers that aren't currently running. */
+const UPTIME_STOPPED = '0s'
+
+/** Default uptime when the backend does not expose a start timestamp. */
+const UPTIME_UNKNOWN = 'unknown'
+
+/** Initial empty payload while the first fetch resolves. */
+const INITIAL_DATA: ContainerdStatusData = {
+  health: 'not-installed',
+  containers: [],
+  summary: { totalContainers: 0, running: 0, paused: 0, stopped: 0 },
+  lastCheckTime: new Date().toISOString(),
+}
+
+// ---------------------------------------------------------------------------
+// Backend response shapes (narrow — only the fields we consume)
+// ---------------------------------------------------------------------------
+
+interface BackendNodeInfo {
+  name?: string
+  containerRuntime?: string
+}
+
+interface BackendPodContainer {
+  name?: string
+  image?: string
+  state?: 'running' | 'waiting' | 'terminated'
+  containerID?: string
+  startedAt?: string
+}
+
+interface BackendPodInfo {
+  name?: string
+  namespace?: string
+  node?: string
+  containers?: BackendPodContainer[]
+}
+
+// ---------------------------------------------------------------------------
+// Pure helpers
+// ---------------------------------------------------------------------------
+
+function isContainerdRuntime(runtime: string | undefined): boolean {
+  return (runtime || '').toLowerCase().includes('containerd')
+}
+
+function normalizeContainerId(raw: string | undefined): string {
+  if (!raw) return ''
+  // kubelet reports e.g. "containerd://3f9a1c4b2e7d..." — strip scheme + truncate.
+  const afterScheme = raw.includes('://') ? raw.split('://').pop() || '' : raw
+  return afterScheme.slice(0, CONTAINER_ID_DISPLAY_LEN)
+}
+
+function mapContainerState(state: BackendPodContainer['state']): ContainerdContainerState {
+  if (state === 'running') return 'running'
+  if (state === 'waiting') return 'paused'
+  return 'stopped'
+}
+
+function formatUptime(startedAt: string | undefined, state: ContainerdContainerState): string {
+  if (state !== 'running') return UPTIME_STOPPED
+  if (!startedAt) return UPTIME_UNKNOWN
+
+  const started = new Date(startedAt).getTime()
+  if (Number.isNaN(started)) return UPTIME_UNKNOWN
+
+  const MS_PER_SECOND = 1000
+  const SECONDS_PER_MINUTE = 60
+  const MINUTES_PER_HOUR = 60
+  const HOURS_PER_DAY = 24
+
+  const diffSeconds = Math.max(0, Math.floor((Date.now() - started) / MS_PER_SECOND))
+  if (diffSeconds < SECONDS_PER_MINUTE) return `${diffSeconds}s`
+
+  const diffMinutes = Math.floor(diffSeconds / SECONDS_PER_MINUTE)
+  if (diffMinutes < MINUTES_PER_HOUR) return `${diffMinutes}m`
+
+  const diffHours = Math.floor(diffMinutes / MINUTES_PER_HOUR)
+  const remainderMinutes = diffMinutes % MINUTES_PER_HOUR
+  if (diffHours < HOURS_PER_DAY) return `${diffHours}h ${remainderMinutes}m`
+
+  const diffDays = Math.floor(diffHours / HOURS_PER_DAY)
+  const remainderHours = diffHours % HOURS_PER_DAY
+  return `${diffDays}d ${remainderHours}h`
+}
+
+function buildContainerdData(
+  nodes: BackendNodeInfo[],
+  pods: BackendPodInfo[],
+): ContainerdStatusData {
+  const containerdNodes = nodes.filter(n => isContainerdRuntime(n.containerRuntime))
+
+  if (containerdNodes.length === 0) {
+    return {
+      ...INITIAL_DATA,
+      lastCheckTime: new Date().toISOString(),
+    }
+  }
+
+  const containerdNodeNames = new Set<string>()
+  for (const node of containerdNodes) {
+    if (!node.name) continue
+    containerdNodeNames.add(node.name)
+    const shortName = node.name.split('.')[0]
+    if (shortName) containerdNodeNames.add(shortName)
+  }
+
+  const containers: ContainerdContainer[] = []
+  for (const pod of pods) {
+    const nodeName = pod.node ?? ''
+    if (!nodeName) continue
+    const matches = containerdNodeNames.has(nodeName) ||
+      containerdNodeNames.has(nodeName.split('.')[0])
+    if (!matches) continue
+
+    for (const c of pod.containers || []) {
+      const state = mapContainerState(c.state)
+      containers.push({
+        id: normalizeContainerId(c.containerID) || (c.name || ''),
+        image: c.image || '',
+        namespace: pod.namespace || NAMESPACE_FALLBACK,
+        state,
+        uptime: formatUptime(c.startedAt, state),
+        node: pod.node || NODE_FALLBACK,
+      })
+      if (containers.length >= MAX_CONTAINERS_DISPLAYED) break
+    }
+    if (containers.length >= MAX_CONTAINERS_DISPLAYED) break
+  }
+
+  const running = containers.filter(c => c.state === 'running').length
+  const paused = containers.filter(c => c.state === 'paused').length
+  const stopped = containers.filter(c => c.state === 'stopped').length
+
+  return {
+    health: stopped > 0 ? 'degraded' : 'healthy',
+    containers,
+    summary: {
+      totalContainers: containers.length,
+      running,
+      paused,
+      stopped,
+    },
+    lastCheckTime: new Date().toISOString(),
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Fetcher
+// ---------------------------------------------------------------------------
+
+async function fetchContainerdStatus(): Promise<ContainerdStatusData> {
+  const [nodesResp, podsResp] = await Promise.all([
+    fetch(`${LOCAL_AGENT_HTTP_URL}/nodes`, {
+      headers: { Accept: 'application/json' },
+      signal: AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS),
+    }),
+    fetch(`${LOCAL_AGENT_HTTP_URL}/pods`, {
+      headers: { Accept: 'application/json' },
+      signal: AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS),
+    }),
+  ])
+
+  if (!nodesResp.ok) throw new Error(`nodes HTTP ${nodesResp.status}`)
+  if (!podsResp.ok) throw new Error(`pods HTTP ${podsResp.status}`)
+
+  const nodesBody: { nodes?: BackendNodeInfo[] } = await nodesResp.json()
+  const podsBody: { pods?: BackendPodInfo[] } = await podsResp.json()
+
+  const nodes = Array.isArray(nodesBody?.nodes) ? nodesBody.nodes : []
+  const pods = Array.isArray(podsBody?.pods) ? podsBody.pods : []
+
+  return buildContainerdData(nodes, pods)
+}
+
+// ---------------------------------------------------------------------------
+// Hook return type
+// ---------------------------------------------------------------------------
+
+export interface UseCachedContainerdResult {
+  data: ContainerdStatusData
+  isLoading: boolean
+  isRefreshing: boolean
+  isDemoData: boolean
+  isFailed: boolean
+  consecutiveFailures: number
+  lastRefresh: number | null
+  refetch: () => Promise<void>
+}
+
+// ---------------------------------------------------------------------------
+// Hook
+// ---------------------------------------------------------------------------
+
+export function useCachedContainerd(): UseCachedContainerdResult {
+  const { isDemoMode } = useDemoMode()
+
+  const result = useCache<ContainerdStatusData>({
+    key: CACHE_KEY_CONTAINERD,
+    category: 'default' as RefreshCategory,
+    initialData: INITIAL_DATA,
+    demoData: CONTAINERD_DEMO_DATA,
+    persist: true,
+    fetcher: fetchContainerdStatus,
+  })
+
+  // Never surface demo data during loading (CLAUDE.md rule).
+  const isDemoData = (isDemoMode || result.isDemoFallback) && !result.isLoading
+  const isRefreshing = isDemoMode ? false : result.isRefreshing
+
+  return {
+    data: isDemoMode ? CONTAINERD_DEMO_DATA : result.data,
+    isLoading: isDemoMode ? false : result.isLoading,
+    isRefreshing,
+    isDemoData,
+    isFailed: isDemoMode ? false : result.isFailed,
+    consecutiveFailures: isDemoMode ? 0 : result.consecutiveFailures,
+    lastRefresh: isDemoMode ? Date.now() : result.lastRefresh,
+    refetch: result.refetch,
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Exported testables — pure functions for unit testing
+// ---------------------------------------------------------------------------
+
+export const __testables = {
+  isContainerdRuntime,
+  normalizeContainerId,
+  mapContainerState,
+  formatUptime,
+  buildContainerdData,
+}

--- a/web/src/hooks/useMarketplace.ts
+++ b/web/src/hooks/useMarketplace.ts
@@ -85,6 +85,7 @@ const MARKETPLACE_TO_CARD_TYPE: Record<string, string> = {
   'cncf-etcd': 'etcd_status',
   'cncf-fluentd': 'fluentd_status',
   'cncf-crio': 'crio_status',
+  'cncf-containerd': 'containerd_status',
   'cncf-cloudevents': 'cloudevents_status',
   'cncf-crossplane': 'crossplane_managed_resources',
   'cncf-buildpacks': 'buildpacks_status',

--- a/web/src/lib/demo/containerd.ts
+++ b/web/src/lib/demo/containerd.ts
@@ -1,0 +1,103 @@
+/**
+ * Containerd Status — Demo Data & Type Definitions
+ *
+ * Models running containers surfaced by the containerd (CNCF graduated)
+ * container runtime. Shown when no cluster is connected or in demo mode.
+ *
+ * Marketplace preset: cncf-containerd
+ * Upstream issue: kubestellar/console-marketplace#4
+ */
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type ContainerdContainerState = 'running' | 'paused' | 'stopped'
+
+export interface ContainerdContainer {
+  /** Short container ID (first 12 chars, matching ctr / crictl output) */
+  id: string
+  /** Container image reference */
+  image: string
+  /** Kubernetes namespace the container was launched under */
+  namespace: string
+  /** Runtime state */
+  state: ContainerdContainerState
+  /** Human-readable uptime, e.g. "3h 12m" */
+  uptime: string
+  /** Node the container is running on */
+  node: string
+}
+
+export interface ContainerdSummary {
+  totalContainers: number
+  running: number
+  paused: number
+  stopped: number
+}
+
+export interface ContainerdStatusData {
+  health: 'healthy' | 'degraded' | 'not-installed'
+  containers: ContainerdContainer[]
+  summary: ContainerdSummary
+  lastCheckTime: string
+}
+
+// ---------------------------------------------------------------------------
+// Demo rows — realistic but synthetic
+// ---------------------------------------------------------------------------
+
+export const CONTAINERD_DEMO_CONTAINERS: ContainerdContainer[] = [
+  {
+    id: '3f9a1c4b2e7d',
+    image: 'nginx:1.27-alpine',
+    namespace: 'default',
+    state: 'running',
+    uptime: '3h 12m',
+    node: 'worker-1',
+  },
+  {
+    id: '7d2e5f8a9c1b',
+    image: 'ghcr.io/kubestellar/console:latest',
+    namespace: 'kubestellar',
+    state: 'running',
+    uptime: '1d 4h',
+    node: 'worker-2',
+  },
+  {
+    id: 'b4c6a8d0e2f5',
+    image: 'redis:7.2',
+    namespace: 'cache',
+    state: 'running',
+    uptime: '17h 45m',
+    node: 'worker-1',
+  },
+  {
+    id: 'a1b2c3d4e5f6',
+    image: 'prom/prometheus:v2.54.0',
+    namespace: 'monitoring',
+    state: 'paused',
+    uptime: '22m',
+    node: 'worker-3',
+  },
+  {
+    id: 'f0e9d8c7b6a5',
+    image: 'busybox:1.36',
+    namespace: 'default',
+    state: 'stopped',
+    uptime: '0s',
+    node: 'worker-2',
+  },
+]
+
+export const CONTAINERD_DEMO_DATA: ContainerdStatusData = {
+  health: 'degraded',
+  containers: CONTAINERD_DEMO_CONTAINERS,
+  summary: {
+    totalContainers: CONTAINERD_DEMO_CONTAINERS.length,
+    running: CONTAINERD_DEMO_CONTAINERS.filter(c => c.state === 'running').length,
+    paused: CONTAINERD_DEMO_CONTAINERS.filter(c => c.state === 'paused').length,
+    stopped: CONTAINERD_DEMO_CONTAINERS.filter(c => c.state === 'stopped').length,
+  },
+  lastCheckTime: new Date().toISOString(),
+}

--- a/web/src/lib/unified/registerHooks.ts
+++ b/web/src/lib/unified/registerHooks.ts
@@ -49,6 +49,7 @@ import {
   useServiceImports } from '../../hooks/useMCS'
 import { useFluxStatus } from '../../components/cards/flux_status/useFluxStatus'
 import { useContourStatus } from '../../components/cards/contour_status/useContourStatus'
+import { useCachedContainerd } from '../../hooks/useCachedContainerd'
 import { useCachedEnvoy } from '../../components/cards/envoy_status/useCachedEnvoy'
 import { useCachedLinkerd } from '../../hooks/useCachedLinkerd'
 
@@ -1041,6 +1042,16 @@ function useUnifiedContourStatus() {
   }
 }
 
+function useUnifiedContainerdStatus() {
+  const result = useCachedContainerd()
+  return {
+    data: result.data.containers,
+    isLoading: result.isLoading,
+    error: result.isFailed ? new Error('Failed to fetch containerd status') : null,
+    refetch: () => { result.refetch() },
+  }
+}
+
 function useUnifiedEnvoyStatus() {
   const result = useCachedEnvoy()
   // Surface the listener list as the primary row set for generic list renderers.
@@ -1250,6 +1261,7 @@ export function registerUnifiedHooks(): void {
   registerDataHook('useKustomizationStatus', useKustomizationStatus)
   registerDataHook('useFluxStatus', useUnifiedFluxStatus)
   registerDataHook('useContourStatus', useUnifiedContourStatus)
+  registerDataHook('useCachedContainerd', useUnifiedContainerdStatus)
   registerDataHook('useCachedEnvoy', useUnifiedEnvoyStatus)
   registerDataHook('useCachedLinkerd', useUnifiedLinkerdStatus)
   registerDataHook('useProviderHealth', useProviderHealth)

--- a/web/src/locales/en/cards.json
+++ b/web/src/locales/en/cards.json
@@ -3061,6 +3061,19 @@
     "noListeners": "No listeners configured",
     "noClusters": "No upstream clusters"
   },
+  "containerdStatus": {
+    "healthy": "Healthy",
+    "degraded": "Degraded",
+    "notDetected": "containerd not detected",
+    "notDetectedHint": "No nodes on connected clusters report containerd as their runtime.",
+    "fetchFailed": "Failed to fetch containerd status",
+    "total": "Total",
+    "running": "Running",
+    "paused": "Paused",
+    "stopped": "Stopped",
+    "containers": "Containers",
+    "noContainers": "No containers reported"
+  },
   "linkerdStatus": {
     "healthy": "Healthy",
     "degraded": "Degraded",


### PR DESCRIPTION
## Summary

Adds a **Containerd** status card (Compute category, surfaced under Misc in the card catalog) that monitors the containerd container runtime across connected clusters. Shows running containers with id, image, namespace, state, and uptime.

- Card: `web/src/components/cards/containerd_status/index.tsx`
- Hook: `web/src/hooks/useCachedContainerd.ts` — uses `useCache()` with demo fallback; returns `data, isLoading, isRefreshing, isDemoData, isFailed, consecutiveFailures, lastRefresh, refetch`
- Demo data: `web/src/lib/demo/containerd.ts` (5 realistic synthetic containers)
- Config: `web/src/config/cards/containerd-status.ts`
- Registered in cardRegistry, cardMetadata, cardIcons, cardCatalog, registerHooks, config/cards/index
- Marketplace preset: `cncf-containerd` -> `containerd_status` in `useMarketplace.ts`

Follows the `contour_status` / `jaeger_status` patterns: isDemoData + isRefreshing + lastRefresh wired into `useCardLoadingState`; `isLoading && !hasAnyData` gate (no bare `isLoading:`); no magic numbers; semantic Tailwind classes only.

Refs kubestellar/console-marketplace#4