### PR TITLE
fix: guard isDemoData during loading, harden ACCM CORS, extract skeleton constants

### DIFF
--- a/web/netlify/functions/acmm-scan.mts
+++ b/web/netlify/functions/acmm-scan.mts
@@ -71,8 +71,12 @@ const API_TIMEOUT_MS = 15_000;
 const WEEKS_OF_HISTORY = 16;
 /** Valid repo slug: owner/name with word chars, dots, dashes */
 const REPO_RE = /^[\w.-]+\/[\w.-]+$/;
-/** CORS origins: *.kubestellar.io and localhost */
-const ALLOWED_ORIGIN_RE = /^https?:\/\/(.*\.kubestellar\.io|localhost(:\d+)?)$/;
+/** Allowed CORS origins (exact match) */
+const ALLOWED_ORIGINS = [
+  "https://console.kubestellar.io",
+  "https://kubestellar.io",
+  "https://www.kubestellar.io",
+];
 /** AI-generated label used to classify AI contributions */
 const AI_LABEL = "ai-generated";
 /** Known AI authors (shared logins + bots) */
@@ -219,11 +223,21 @@ interface GitTreeEntry {
 // Helpers
 // ---------------------------------------------------------------------------
 
+/** Validate CORS origin via URL-parsed hostname check */
+function corsOrigin(origin: string | null): string {
+  if (!origin) return ALLOWED_ORIGINS[0];
+  if (ALLOWED_ORIGINS.includes(origin)) return origin;
+  try {
+    const host = new URL(origin).hostname.toLowerCase();
+    if (host === "localhost") return origin;
+    if (host === "kubestellar.io" || host.endsWith(".kubestellar.io")) return origin;
+  } catch { /* invalid URL */ }
+  return ALLOWED_ORIGINS[0];
+}
+
 function corsHeaders(origin: string | null): Record<string, string> {
-  const allowed =
-    origin && ALLOWED_ORIGIN_RE.test(origin) ? origin : "https://console.kubestellar.io";
   return {
-    "Access-Control-Allow-Origin": allowed,
+    "Access-Control-Allow-Origin": corsOrigin(origin),
     "Access-Control-Allow-Methods": "GET, OPTIONS",
     "Access-Control-Allow-Headers": "Content-Type",
     "Cache-Control": "public, max-age=900",

--- a/web/netlify/functions/analytics-accm.mts
+++ b/web/netlify/functions/analytics-accm.mts
@@ -69,8 +69,12 @@ const CI_WORKFLOWS: Record<string, string> = {
   nightly: "Nightly Compliance & Perf",
 };
 
-/** CORS origins: *.kubestellar.io and localhost */
-const ALLOWED_ORIGIN_RE = /^https?:\/\/(.*\.kubestellar\.io|localhost(:\d+)?)$/;
+/** Allowed CORS origins (exact match) */
+const ALLOWED_ORIGINS = [
+  "https://console.kubestellar.io",
+  "https://kubestellar.io",
+  "https://www.kubestellar.io",
+];
 
 // ---------------------------------------------------------------------------
 // Types
@@ -122,12 +126,22 @@ interface CacheEntry {
 // Helpers
 // ---------------------------------------------------------------------------
 
+/** Validate CORS origin via URL-parsed hostname check */
+function corsOrigin(origin: string | null): string {
+  if (!origin) return ALLOWED_ORIGINS[0];
+  if (ALLOWED_ORIGINS.includes(origin)) return origin;
+  try {
+    const host = new URL(origin).hostname.toLowerCase();
+    if (host === "localhost") return origin;
+    if (host === "kubestellar.io" || host.endsWith(".kubestellar.io")) return origin;
+  } catch { /* invalid URL */ }
+  return ALLOWED_ORIGINS[0];
+}
+
 /** Build CORS headers, reflecting the origin if it matches the allow list */
 function corsHeaders(origin: string | null): Record<string, string> {
-  const allowed =
-    origin && ALLOWED_ORIGIN_RE.test(origin) ? origin : "https://console.kubestellar.io";
   return {
-    "Access-Control-Allow-Origin": allowed,
+    "Access-Control-Allow-Origin": corsOrigin(origin),
     "Access-Control-Allow-Methods": "GET, OPTIONS",
     "Access-Control-Allow-Headers": "Content-Type",
     "Cache-Control": "public, max-age=3600",

--- a/web/src/components/cards/DeploymentRiskScore.tsx
+++ b/web/src/components/cards/DeploymentRiskScore.tsx
@@ -109,7 +109,7 @@ export function DeploymentRiskScore() {
 
   const isLoading = argo.isLoading || kyverno.isLoading || pods.isLoading
   const isRefreshing = !!argo.isRefreshing || !!kyverno.isRefreshing || !!pods.isRefreshing
-  const isDemoData = !!argo.isDemoData || !!kyverno.isDemoData || !!pods.isDemoFallback
+  const isDemoData = (!!argo.isDemoData || !!kyverno.isDemoData || !!pods.isDemoFallback) && !isLoading
   const consecutiveFailures = Math.max(
     argo.consecutiveFailures || 0,
     kyverno.consecutiveFailures || 0,

--- a/web/src/components/cards/envoy_status/index.tsx
+++ b/web/src/components/cards/envoy_status/index.tsx
@@ -29,6 +29,12 @@ import type { EnvoyListener, EnvoyUpstreamCluster } from './demoData'
 // Named constants (no magic numbers)
 // ---------------------------------------------------------------------------
 
+const SKELETON_TITLE_WIDTH = 140
+const SKELETON_TITLE_HEIGHT = 28
+const SKELETON_BADGE_WIDTH = 90
+const SKELETON_BADGE_HEIGHT = 20
+const SKELETON_LIST_ITEMS = 5
+
 const RELATIVE_TIME_MINUTE_MS = 60_000
 const MINUTES_PER_HOUR = 60
 const HOURS_PER_DAY = 24
@@ -133,11 +139,11 @@ export function EnvoyStatus() {
     return (
       <div className="h-full flex flex-col min-h-card gap-4">
         <div className="flex items-center justify-between">
-          <Skeleton variant="rounded" width={140} height={28} />
-          <Skeleton variant="rounded" width={90} height={20} />
+          <Skeleton variant="rounded" width={SKELETON_TITLE_WIDTH} height={SKELETON_TITLE_HEIGHT} />
+          <Skeleton variant="rounded" width={SKELETON_BADGE_WIDTH} height={SKELETON_BADGE_HEIGHT} />
         </div>
         <SkeletonStats className="grid-cols-4" />
-        <SkeletonList items={5} className="flex-1" />
+        <SkeletonList items={SKELETON_LIST_ITEMS} className="flex-1" />
       </div>
     )
   }

--- a/web/src/components/cards/linkerd_status/index.tsx
+++ b/web/src/components/cards/linkerd_status/index.tsx
@@ -29,6 +29,12 @@ import type { LinkerdMeshedDeployment } from './demoData'
 // Named constants (no magic numbers)
 // ---------------------------------------------------------------------------
 
+const SKELETON_TITLE_WIDTH = 140
+const SKELETON_TITLE_HEIGHT = 28
+const SKELETON_BADGE_WIDTH = 90
+const SKELETON_BADGE_HEIGHT = 20
+const SKELETON_LIST_ITEMS = 5
+
 const RELATIVE_TIME_MINUTE_MS = 60_000
 const MINUTES_PER_HOUR = 60
 const HOURS_PER_DAY = 24
@@ -135,11 +141,11 @@ export function LinkerdStatus() {
     return (
       <div className="h-full flex flex-col min-h-card gap-4">
         <div className="flex items-center justify-between">
-          <Skeleton variant="rounded" width={140} height={28} />
-          <Skeleton variant="rounded" width={90} height={20} />
+          <Skeleton variant="rounded" width={SKELETON_TITLE_WIDTH} height={SKELETON_TITLE_HEIGHT} />
+          <Skeleton variant="rounded" width={SKELETON_BADGE_WIDTH} height={SKELETON_BADGE_HEIGHT} />
         </div>
         <SkeletonStats className="grid-cols-4" />
-        <SkeletonList items={5} className="flex-1" />
+        <SkeletonList items={SKELETON_LIST_ITEMS} className="flex-1" />
       </div>
     )
   }


### PR DESCRIPTION
## Summary

- **DeploymentRiskScore isDemoData guard**: Add `&& !isLoading` to prevent demo badge from flashing during initial data load — matches the established pattern in contour, cubefs, harbor, flatcar cards
- **CORS origin hardening**: Replace vulnerable regex-based `ALLOWED_ORIGIN_RE` in `analytics-accm.mts` and `acmm-scan.mts` with URL-parsed hostname validation (same fix applied in PR #9882 to affiliate-clicks and github-pipelines)
- **Skeleton magic numbers**: Extract hardcoded Skeleton dimension literals (140, 28, 90, 20, 5) in envoy_status and linkerd_status to named constants, matching the containerd_status pattern

## Test plan

- [x] `npm run build` passes
- [x] `npm run lint` passes (no new errors)
- [ ] DeploymentRiskScore card shows loading skeleton first, then data/demo badge
- [ ] CORS preflight requests rejected for crafted origins like `evil-kubestellar.io`


🤖 Generated with [Claude Code](https://claude.com/claude-code)