### PR TITLE
feat(keda): add KEDA monitoring card (kubestellar/console-marketplace#23)

### DIFF
--- a/web/src/config/cards/index.ts
+++ b/web/src/config/cards/index.ts
@@ -66,6 +66,7 @@ import { contourStatusConfig } from './contour-status'
 import { containerdStatusConfig } from './containerd-status'
 import { envoyStatusConfig } from './envoy-status'
 import { grpcStatusConfig } from './grpc-status'
+import { kedaStatusConfig } from './keda-status'
 import { linkerdStatusConfig } from './linkerd-status'
 import { tikvStatusConfig } from './tikv-status'
 import { nightlyReleasePulseConfig } from './nightly-release-pulse'
@@ -255,6 +256,7 @@ export const CARD_CONFIGS: CardConfigRegistry = {
   containerd_status: containerdStatusConfig,
   envoy_status: envoyStatusConfig,
   grpc_status: grpcStatusConfig,
+  keda_status: kedaStatusConfig,
   linkerd_status: linkerdStatusConfig,
   tikv_status: tikvStatusConfig,
   nightly_release_pulse: nightlyReleasePulseConfig,

--- a/web/src/config/cards/keda-status.ts
+++ b/web/src/config/cards/keda-status.ts
@@ -1,0 +1,73 @@
+/**
+ * KEDA Status Card Configuration
+ *
+ * KEDA (Kubernetes Event-Driven Autoscaling) is a CNCF graduated project
+ * for event-driven autoscaling of Kubernetes workloads. This card surfaces
+ * the KEDA operator health plus per-ScaledObject replica state and trigger
+ * metadata (Kafka / Prometheus / Cron / SQS / RabbitMQ / Redis / etc.).
+ *
+ * The runtime card component lives at
+ * `components/cards/keda_status/KedaStatus.tsx` and drives its own layout;
+ * this config exists so the card participates in the unified registry
+ * (browse catalog, search, marketplace mapping).
+ *
+ * Implements kubestellar/console-marketplace#23.
+ */
+
+import type { UnifiedCardConfig } from '../../lib/unified/types'
+
+export const kedaStatusConfig: UnifiedCardConfig = {
+  type: 'keda_status',
+  title: 'KEDA',
+  category: 'workloads',
+  description:
+    'KEDA event-driven autoscaling: ScaledObject status, triggers (Kafka/Prometheus/Cron/SQS), and replica counts.',
+
+  // Appearance
+  icon: 'TrendingUp',
+  iconColor: 'text-green-400',
+  defaultWidth: 6,
+  defaultHeight: 4,
+
+  // Data source — routes through the unified registry to useCachedKeda,
+  // which is wired up in lib/unified/registerHooks.ts.
+  dataSource: {
+    type: 'hook',
+    hook: 'useCachedKeda',
+  },
+
+  // Content — list visualization with ScaledObject rows.
+  content: {
+    type: 'list',
+    pageSize: 8,
+    columns: [
+      { field: 'name', header: 'ScaledObject', primary: true, render: 'truncate' },
+      { field: 'namespace', header: 'Namespace', width: 140, render: 'truncate' },
+      { field: 'target', header: 'Target', width: 160, render: 'truncate' },
+      { field: 'currentReplicas', header: 'Current', width: 80, align: 'right' },
+      { field: 'maxReplicas', header: 'Max', width: 70, align: 'right' },
+      { field: 'status', header: 'Status', width: 90, render: 'status-badge' },
+    ],
+  },
+
+  emptyState: {
+    icon: 'TrendingUp',
+    title: 'KEDA not detected',
+    message:
+      'No KEDA operator pods found. Deploy KEDA to enable event-driven autoscaling.',
+    variant: 'info',
+  },
+
+  loadingState: {
+    type: 'list',
+    rows: 5,
+  },
+
+  // The card does its own live/demo gating via useKedaStatus; keep the
+  // registry flags aligned with TiKV / HPA (live when data available,
+  // demo fallback handled by the cache layer).
+  isDemoData: false,
+  isLive: true,
+}
+
+export default kedaStatusConfig

--- a/web/src/hooks/useCachedKeda.ts
+++ b/web/src/hooks/useCachedKeda.ts
@@ -1,0 +1,16 @@
+/**
+ * useCachedKeda — Top-level re-export of the KEDA cached-status hook.
+ *
+ * The canonical implementation lives alongside the card at
+ * `components/cards/keda_status/useKedaStatus.ts`. This file re-exports it
+ * under the conventional `useCachedKeda` name so the unified card registry
+ * and external consumers (marketplace, docs, tests) can import from
+ * `hooks/useCachedKeda` — mirroring the pattern used by `useCachedLinkerd`,
+ * `useCachedTikv`, `useCachedContainerd`, and `useCachedCiliumStatus`.
+ */
+
+export { useKedaStatus as useCachedKeda } from '../components/cards/keda_status/useKedaStatus'
+export type {
+  KedaStatus,
+  UseKedaStatusResult as UseCachedKedaResult,
+} from '../components/cards/keda_status/useKedaStatus'

--- a/web/src/lib/demo/keda.ts
+++ b/web/src/lib/demo/keda.ts
@@ -1,0 +1,19 @@
+/**
+ * KEDA demo seed re-export.
+ *
+ * The canonical demo data lives alongside the KEDA card in
+ * `components/cards/keda_status/demoData.ts`. This file re-exports it so
+ * callers outside the card folder (docs, tests, future drill-downs,
+ * unified-system consumers) can import a stable demo seed from
+ * `lib/demo/keda` — mirrors the pattern used by `lib/demo/linkerd`,
+ * `lib/demo/tikv`, `lib/demo/envoy`, and `lib/demo/containerd`.
+ */
+
+export {
+  KEDA_DEMO_DATA,
+  type KedaDemoData,
+  type KedaScaledObject,
+  type KedaScaledObjectStatus,
+  type KedaTrigger,
+  type KedaTriggerType,
+} from '../../components/cards/keda_status/demoData'

--- a/web/src/lib/unified/registerHooks.ts
+++ b/web/src/lib/unified/registerHooks.ts
@@ -52,6 +52,7 @@ import { useContourStatus } from '../../components/cards/contour_status/useConto
 import { useCachedContainerd } from '../../hooks/useCachedContainerd'
 import { useCachedEnvoy } from '../../components/cards/envoy_status/useCachedEnvoy'
 import { useCachedGrpc } from '../../hooks/useCachedGrpc'
+import { useCachedKeda } from '../../hooks/useCachedKeda'
 import { useCachedLinkerd } from '../../hooks/useCachedLinkerd'
 import { useCachedTikv } from '../../hooks/useCachedTikv'
 
@@ -1076,6 +1077,23 @@ function useUnifiedGrpcStatus() {
   }
 }
 
+function useUnifiedKedaStatus() {
+  const result = useCachedKeda()
+  // Surface the ScaledObject list as the primary row set for generic list
+  // renderers. `data.scaledObjects` can be undefined while the cache is
+  // hydrating, so guard defensively per CLAUDE.md array-safety rule.
+  return {
+    data: (result.data?.scaledObjects ?? []),
+    isLoading: result.showSkeleton,
+    error: result.error ? new Error('Failed to fetch KEDA status') : null,
+    refetch: async () => {
+      // useKedaStatus doesn't expose refetch directly; the cache layer
+      // refreshes on its own schedule. This is a no-op placeholder that
+      // preserves the expected unified-hook shape.
+    },
+  }
+}
+
 function useUnifiedLinkerdStatus() {
   const result = useCachedLinkerd()
   // Surface the meshed deployment list as the primary row set for generic list renderers.
@@ -1287,6 +1305,7 @@ export function registerUnifiedHooks(): void {
   registerDataHook('useCachedContainerd', useUnifiedContainerdStatus)
   registerDataHook('useCachedEnvoy', useUnifiedEnvoyStatus)
   registerDataHook('useCachedGrpc', useUnifiedGrpcStatus)
+  registerDataHook('useCachedKeda', useUnifiedKedaStatus)
   registerDataHook('useCachedLinkerd', useUnifiedLinkerdStatus)
   registerDataHook('useCachedTikv', useUnifiedTikvStatus)
   registerDataHook('useProviderHealth', useProviderHealth)


### PR DESCRIPTION
## Summary

Implements [kubestellar/console-marketplace#23](https://github.com/kubestellar/console-marketplace/issues/23) — **KEDA (CNCF graduated)** event-driven autoscaling card.

Wires the existing KEDA card into the unified card-config registry, matching the pattern used by TiKV / Linkerd / Containerd / Envoy. The runtime component, fetcher, demo data, and translation keys already exist from prior work (#2420, #8905, #8957); this PR completes the marketplace-card wiring.

**New files**
- `web/src/config/cards/keda-status.ts` — `UnifiedCardConfig` entry (browse catalog, search, marketplace mapping)
- `web/src/lib/demo/keda.ts` — stable demo-seed re-export for callers outside the card folder
- `web/src/hooks/useCachedKeda.ts` — top-level hook re-export following the `useCached*` naming convention

**Registry updates**
- `web/src/config/cards/index.ts` — register `kedaStatusConfig` in `CARD_CONFIGS`
- `web/src/lib/unified/registerHooks.ts` — `registerDataHook('useCachedKeda', useUnifiedKedaStatus)` so generic list renderers can reach ScaledObjects via the unified registry

**KEDA surface** (already rendered by the card):
- Operator pod readiness + overall health
- ScaledObject status (ready/degraded/paused/error) with min/max/current replicas
- Trigger metadata (Kafka / Prometheus / Cron / SQS / RabbitMQ / Redis / CPU / Memory / external)
- Scaled job count
- Live via `keda.sh/v1alpha1` CRDs, demo fallback when not installed

## Test plan

- [x] `npm run build` — passes (all post-build safety checks)
- [x] `npm run lint` — clean
- [ ] Playwright — ignored (per CLAUDE.md)

Closes kubestellar/console-marketplace#23