### PR TITLE
fix(tikv): null-guard home-page ksc_error spike (fixes #9918)

### DIFF
--- a/web/src/components/cards/tikv_status/index.tsx
+++ b/web/src/components/cards/tikv_status/index.tsx
@@ -27,21 +27,42 @@ const USAGE_PCT_ALERT = 85
 const PCT_MULTIPLIER = 100
 const MIN_DECIMAL_PLACES = 1
 const STORE_PAGE_SIZE = 6
+// Fallback summary — used when cached data is malformed (e.g. older schema
+// without `summary`) so render-time property access never throws. See #9918.
+const EMPTY_SUMMARY = {
+  totalStores: 0,
+  upStores: 0,
+  downStores: 0,
+  totalRegions: 0,
+  totalLeaders: 0,
+} as const
 
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
 
-function formatGib(bytes: number): string {
-  if (bytes <= 0) return '—'
+function formatGib(bytes: number | undefined): string {
+  // Guard: undefined/NaN/non-positive → em-dash. Prevents "NaN GiB" render
+  // when a store object is missing capacity/available annotations (#9918).
+  if (typeof bytes !== 'number' || !Number.isFinite(bytes) || bytes <= 0) return '—'
   const gib = bytes / BYTES_PER_GIB
   return `${gib.toFixed(MIN_DECIMAL_PLACES)} GiB`
 }
 
-function usagePct(store: TikvStore): number {
-  if (store.capacityBytes <= 0) return 0
-  const used = store.capacityBytes - store.availableBytes
-  return Math.max(0, Math.min(PCT_MULTIPLIER, (used / store.capacityBytes) * PCT_MULTIPLIER))
+function usagePct(store: Partial<TikvStore> | undefined): number {
+  const capacity = store?.capacityBytes
+  const available = store?.availableBytes
+  if (
+    typeof capacity !== 'number' ||
+    !Number.isFinite(capacity) ||
+    capacity <= 0 ||
+    typeof available !== 'number' ||
+    !Number.isFinite(available)
+  ) {
+    return 0
+  }
+  const used = capacity - available
+  return Math.max(0, Math.min(PCT_MULTIPLIER, (used / capacity) * PCT_MULTIPLIER))
 }
 
 function usageColor(pct: number): string {
@@ -69,9 +90,14 @@ export function TikvStatus() {
   // Rule: never show demo data while still loading
   const isDemoData = isDemoFallback && !isLoading
 
+  // Defensive: cached payloads from older schemas or partial fetches may be
+  // missing `summary` or `health` entirely — never assume nested structure
+  // exists at render time (#9918).
+  const summary = data?.summary ?? EMPTY_SUMMARY
+  const health = data?.health
   // 'not-installed' still counts as "we have data" so the card isn't stuck in skeleton
   const hasAnyData =
-    data.health === 'not-installed' ? true : data.summary.totalStores > 0
+    health === 'not-installed' ? true : (summary.totalStores ?? 0) > 0
 
   const { showSkeleton, showEmptyState } = useCardLoadingState({
     isLoading: isLoading && !hasAnyData,
@@ -87,7 +113,7 @@ export function TikvStatus() {
     return <SkeletonCardWithRefresh showStats={true} rows={STORE_PAGE_SIZE} />
   }
 
-  if (showEmptyState || (data.health === 'not-installed' && !isDemoData)) {
+  if (showEmptyState || (health === 'not-installed' && !isDemoData)) {
     return (
       <div className="h-full flex items-center justify-center p-4">
         <EmptyState
@@ -102,8 +128,11 @@ export function TikvStatus() {
     )
   }
 
-  const isHealthy = data.health === 'healthy'
-  const stores = (data.stores ?? []).slice(0, STORE_PAGE_SIZE)
+  const isHealthy = health === 'healthy'
+  // Guard against non-array cached values (older schema) and nullish store
+  // entries so downstream property access in the render loop never throws.
+  const allStores = Array.isArray(data?.stores) ? data.stores : []
+  const stores = allStores.filter((s): s is TikvStore => s != null).slice(0, STORE_PAGE_SIZE)
 
   return (
     <div className="h-full flex flex-col min-h-card gap-4 overflow-hidden animate-in fade-in duration-500">
@@ -122,23 +151,23 @@ export function TikvStatus() {
 
         <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
           <RefreshCw className={cn('w-3 h-3', isRefreshing ? 'animate-spin' : '')} />
-          <span>{t('tikvStatus.stores', { count: data.summary.totalStores, defaultValue: '{{count}} stores' })}</span>
+          <span>{t('tikvStatus.stores', { count: summary.totalStores ?? 0, defaultValue: '{{count}} stores' })}</span>
         </div>
       </div>
 
       <div className="grid grid-cols-2 @md:grid-cols-4 gap-2">
         <MetricTile
           label={t('tikvStatus.upStores', 'Up')}
-          value={data.summary.upStores}
+          value={summary.upStores ?? 0}
           colorClass="text-green-400"
           icon={<CheckCircle className="w-4 h-4 text-green-400" />}
         />
         <MetricTile
           label={t('tikvStatus.downStores', 'Down')}
-          value={data.summary.downStores}
-          colorClass={data.summary.downStores > 0 ? 'text-red-400' : 'text-green-400'}
+          value={summary.downStores ?? 0}
+          colorClass={(summary.downStores ?? 0) > 0 ? 'text-red-400' : 'text-green-400'}
           icon={
-            data.summary.downStores > 0 ? (
+            (summary.downStores ?? 0) > 0 ? (
               <AlertTriangle className="w-4 h-4 text-red-400" />
             ) : (
               <CheckCircle className="w-4 h-4 text-green-400" />
@@ -147,13 +176,13 @@ export function TikvStatus() {
         />
         <MetricTile
           label={t('tikvStatus.regions', 'Regions')}
-          value={data.summary.totalRegions.toLocaleString()}
+          value={(summary.totalRegions ?? 0).toLocaleString()}
           colorClass="text-cyan-400"
           icon={<Database className="w-4 h-4 text-cyan-400" />}
         />
         <MetricTile
           label={t('tikvStatus.leaders', 'Leaders')}
-          value={data.summary.totalLeaders.toLocaleString()}
+          value={(summary.totalLeaders ?? 0).toLocaleString()}
           colorClass="text-blue-400"
           icon={<Server className="w-4 h-4 text-blue-400" />}
         />
@@ -165,12 +194,19 @@ export function TikvStatus() {
             {t('tikvStatus.noStores', 'No TiKV stores reporting.')}
           </div>
         ) : (
-          stores.map(store => {
+          stores.map((store, idx) => {
+            // Defensive per-field reads: cached or partial responses may miss
+            // fields that are non-optional in the TikvStore type (#9918).
             const pct = usagePct(store)
             const stateUp = store.state === 'Up'
+            const storeState = store.state ?? t('tikvStatus.unknownState', 'Unknown')
+            const regionCount = store.regionCount ?? 0
+            const leaderCount = store.leaderCount ?? 0
+            const storeId = store.storeId ?? idx + 1
+            const address = store.address ?? ''
             return (
               <div
-                key={store.storeId}
+                key={storeId}
                 className="rounded-md bg-secondary/30 px-3 py-2.5 space-y-1"
               >
                 <div className="flex items-center justify-between gap-2">
@@ -181,10 +217,10 @@ export function TikvStatus() {
                       <AlertTriangle className="w-3.5 h-3.5 text-red-400 shrink-0" />
                     )}
                     <span className="text-xs font-medium truncate font-mono">
-                      store-{store.storeId}
+                      store-{storeId}
                     </span>
                     <span className="text-[11px] text-muted-foreground truncate">
-                      {store.address}
+                      {address}
                     </span>
                   </div>
                   <span
@@ -195,13 +231,13 @@ export function TikvStatus() {
                         : 'bg-red-500/20 text-red-400',
                     )}
                   >
-                    {store.state}
+                    {storeState}
                   </span>
                 </div>
 
                 <div className="text-xs text-muted-foreground flex items-center justify-between gap-2">
                   <span className="truncate">
-                    {t('tikvStatus.regionCount', { count: store.regionCount, defaultValue: '{{count}} regions' })} · {t('tikvStatus.leaderCount', { count: store.leaderCount, defaultValue: '{{count}} leaders' })}
+                    {t('tikvStatus.regionCount', { count: regionCount, defaultValue: '{{count}} regions' })} · {t('tikvStatus.leaderCount', { count: leaderCount, defaultValue: '{{count}} leaders' })}
                   </span>
                   <span className={cn('flex items-center gap-1 shrink-0', usageColor(pct))}>
                     <HardDrive className="w-3 h-3" />

--- a/web/src/hooks/useCachedTikv.ts
+++ b/web/src/hooks/useCachedTikv.ts
@@ -158,6 +158,14 @@ function buildStatus(stores: TikvStore[]): TikvStatusData {
 // Fetcher
 // ---------------------------------------------------------------------------
 
+// Response statuses that mean "TiKV API surface is not available here" —
+// treat all of them as "not-installed" rather than throwing. Demo/preview
+// deploys (console.kubestellar.io) return 503 from the MSW catch-all for
+// unmocked `/api/*`; self-hosted consoles without MCP return 404. Either
+// way the user experience should be identical: show the empty state, not
+// a `ksc_error` spike on the home page (#9918).
+const NOT_INSTALLED_STATUSES = new Set<number>([404, 501, 503])
+
 async function fetchTikvStatus(): Promise<TikvStatusData> {
   const params = new URLSearchParams({
     group: '',
@@ -171,12 +179,20 @@ async function fetchTikvStatus(): Promise<TikvStatusData> {
   })
 
   if (!resp.ok) {
-    if (resp.status === 404) return buildStatus([])
+    if (NOT_INSTALLED_STATUSES.has(resp.status)) return buildStatus([])
     throw new Error(`HTTP ${resp.status}`)
   }
 
-  const body = (await resp.json()) as PodListResponse
-  const items = Array.isArray(body.items) ? body.items : []
+  // Defensive JSON parse — Netlify's SPA fallback may return index.html
+  // (text/html) if a redirect is missing, which would otherwise throw an
+  // `Unexpected token '<'` syntax error that bubbles up as `ksc_error`.
+  let body: PodListResponse
+  try {
+    body = (await resp.json()) as PodListResponse
+  } catch {
+    return buildStatus([])
+  }
+  const items = Array.isArray(body?.items) ? body.items : []
   const tikvPods = items.filter(isTikvPod)
   const stores = tikvPods.map((pod, idx) => podToStore(pod, idx + 1))
   return buildStatus(stores)

--- a/web/src/locales/en/cards.json
+++ b/web/src/locales/en/cards.json
@@ -3112,6 +3112,7 @@
     "regions": "Regions",
     "leaders": "Leaders",
     "noStores": "No TiKV stores reporting.",
+    "unknownState": "Unknown",
     "stores_one": "{{count}} store",
     "stores_other": "{{count}} stores",
     "regionCount_one": "{{count}} region",


### PR DESCRIPTION
## Summary

Harden the TiKV Status card (shipped in #9916) and its cached hook against malformed or absent response shapes. The GA4 `ksc_error` spike (5.3x baseline) on the home page correlated with the card's merge was traced to three failure modes:

1. **Fetcher throwing on 503** — `console.kubestellar.io` has no Netlify Function for `/api/mcp/custom-resources`, so MSW's catch-all returns HTTP 503. The old fetcher only special-cased 404 and threw on every other non-OK status, surfacing as unhandled rejections under some timing conditions.
2. **Unguarded `data.summary.*` access** — the card assumed nested `summary` always existed. A stale or partial cache entry without `summary` threw `TypeError: Cannot read properties of undefined (reading 'totalStores')`.
3. **Unguarded per-store field reads** — `store.storeId`, `store.address`, `store.state`, `store.regionCount`, `store.leaderCount`, `store.capacityBytes`, `store.availableBytes` were all read directly inside `.map()`. A partial response or i18next `count: undefined` could throw.

## Changes

- **Fetcher** (`useCachedTikv.ts`):
  - Treat `404`, `501`, `503` as "TiKV not installed" (`NOT_INSTALLED_STATUSES`) rather than throwing.
  - Wrap `resp.json()` in try/catch — the Netlify SPA fallback may return `text/html`; fall back to `buildStatus([])` instead of letting `Unexpected token '<'` escape.
  - `Array.isArray(body?.items)` check with optional chaining.
- **Component** (`tikv_status/index.tsx`):
  - `summary = data?.summary ?? EMPTY_SUMMARY` and `health = data?.health` at the top — every downstream read uses these locals.
  - `Array.isArray(data?.stores)` + `.filter(s => s != null)` before slicing.
  - Per-store defensive reads for every field with `?? 0` / `?? ''` fallbacks.
  - `formatGib` / `usagePct` reject `NaN` and non-numeric inputs instead of producing `"NaN GiB"` or NaN percentages.
- **i18n** (`locales/en/cards.json`): added `tikvStatus.unknownState` for the fallback state badge.

Happy path and demo mode behaviour are unchanged — only degraded / malformed input paths are affected.

Fixes #9918

## Test plan

- [ ] Netlify deploy preview renders the TiKV card without `ksc_error` spikes
- [ ] Home page with live MCP backend still renders live data correctly
- [ ] `console.kubestellar.io` (demo mode) shows demo data with yellow outline + Demo badge
- [ ] No new `ai-non-localized` ratchet failures