### PR TITLE
feat(tuf): add TUF monitoring card (kubestellar/console-marketplace#15)

### DIFF
--- a/web/src/components/cards/cardMetadata.ts
+++ b/web/src/components/cards/cardMetadata.ts
@@ -276,6 +276,8 @@ export const CARD_TITLES: Record<string, string> = {
   otel_status: 'OpenTelemetry',
   // TiKV distributed key-value store
   tikv_status: 'TiKV',
+  // TUF (The Update Framework) repository metadata
+  tuf_status: 'TUF',
   // Vitess distributed MySQL
   vitess_status: 'Vitess',
   // CRI-O container runtime
@@ -599,6 +601,8 @@ export const CARD_DESCRIPTIONS: Record<string, string> = {
   otel_status: 'OpenTelemetry Collectors: pipeline health, receivers and exporters, dropped telemetry, and export errors across connected clusters.',
   // TiKV distributed key-value store
   tikv_status: 'TiKV distributed key-value store: store nodes, region counts, leader counts, and capacity utilization across the cluster.',
+  // TUF (The Update Framework) repository metadata
+  tuf_status: 'TUF repository role metadata — root, targets, snapshot, timestamp — versions, expirations, thresholds, and signing status.',
   // Vitess distributed MySQL
   vitess_status: 'Vitess distributed MySQL: keyspaces, shards, tablets (PRIMARY/REPLICA/RDONLY), and replication lag.',
   // CRI-O container runtime

--- a/web/src/components/cards/cardRegistry.ts
+++ b/web/src/components/cards/cardRegistry.ts
@@ -90,6 +90,8 @@ const LinkerdStatus = safeLazy(() => import('./linkerd_status'), 'LinkerdStatus'
 const OtelStatus = safeLazy(() => import('./otel_status'), 'OtelStatus')
 // TiKV distributed key-value store card
 const TikvStatus = safeLazy(() => import('./tikv_status'), 'TikvStatus')
+// TUF (The Update Framework) repository metadata card
+const TufStatus = safeLazy(() => import('./tuf_status'), 'TufStatus')
 // Vitess distributed MySQL card
 const VitessStatus = safeLazy(() => import('./vitess_status'), 'VitessStatus')
 const OverlayComparison = safeLazy(() => _deployBundle, 'OverlayComparison')
@@ -726,6 +728,8 @@ const RAW_CARD_COMPONENTS: Record<string, CardComponent> = {
   otel_status: OtelStatus,
   // TiKV distributed key-value store
   tikv_status: TikvStatus,
+  // TUF (The Update Framework) repository metadata
+  tuf_status: TufStatus,
   // Vitess distributed MySQL
   vitess_status: VitessStatus,
   // Artifact Hub
@@ -1051,6 +1055,7 @@ const CARD_CHUNK_PRELOADERS: Record<string, () => Promise<unknown>> = {
   linkerd_status: () => import('./linkerd_status'),
   otel_status: () => import('./otel_status'),
   tikv_status: () => import('./tikv_status'),
+  tuf_status: () => import('./tuf_status'),
   vitess_status: () => import('./vitess_status'),
   overlay_comparison: () => import('./deploy-bundle'),
   argocd_applications: () => import('./deploy-bundle'),
@@ -1650,6 +1655,7 @@ export const CARD_DEFAULT_WIDTHS: Record<string, number> = {
   linkerd_status: 6,
   otel_status: 6,
   tikv_status: 6,
+  tuf_status: 6,
   vitess_status: 6,
   pvc_status: 6,
   gpu_status: 6,

--- a/web/src/components/cards/tuf_status/index.tsx
+++ b/web/src/components/cards/tuf_status/index.tsx
@@ -1,0 +1,320 @@
+/**
+ * TUF (The Update Framework) Status Card
+ *
+ * Displays TUF role metadata — root / targets / snapshot / timestamp —
+ * with version, expiration, signing status, and threshold/keys.
+ * Follows the linkerd_status / tikv_status pattern for structure and styling.
+ *
+ * This is scaffolding — the card renders via demo fallback today. When a
+ * real TUF metadata bridge lands, the hook's fetcher will pick up live
+ * data automatically with no component changes.
+ */
+
+import {
+  AlertTriangle,
+  CheckCircle,
+  Clock,
+  Key,
+  RefreshCw,
+  ShieldCheck,
+  ShieldOff,
+} from 'lucide-react'
+import { useTranslation } from 'react-i18next'
+import { MetricTile } from '../../../lib/cards/CardComponents'
+import { Skeleton, SkeletonList, SkeletonStats } from '../../ui/Skeleton'
+import { useCachedTuf } from '../../../hooks/useCachedTuf'
+import { useCardLoadingState } from '../CardDataContext'
+import { cn } from '../../../lib/cn'
+import type { TufMetadataStatus, TufRole } from '../../../lib/demo/tuf'
+
+// ---------------------------------------------------------------------------
+// Named constants (no magic numbers)
+// ---------------------------------------------------------------------------
+
+const SKELETON_TITLE_WIDTH = 140
+const SKELETON_TITLE_HEIGHT = 28
+const SKELETON_BADGE_WIDTH = 90
+const SKELETON_BADGE_HEIGHT = 20
+const SKELETON_LIST_ITEMS = 4
+
+const MS_PER_SECOND = 1000
+const SECONDS_PER_MINUTE = 60
+const MINUTES_PER_HOUR = 60
+const HOURS_PER_DAY = 24
+const MS_PER_MINUTE = MS_PER_SECOND * SECONDS_PER_MINUTE
+const MS_PER_HOUR = MS_PER_MINUTE * MINUTES_PER_HOUR
+const MS_PER_DAY = MS_PER_HOUR * HOURS_PER_DAY
+
+// Role count used for skeleton row pre-allocation — TUF has exactly four
+// top-level roles per the spec (root, targets, snapshot, timestamp).
+const TUF_TOP_LEVEL_ROLE_COUNT = 4
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function formatExpiration(isoString: string): string {
+  if (!isoString) return '—'
+  const parsedMs = new Date(isoString).getTime()
+  if (!Number.isFinite(parsedMs)) return '—'
+  const deltaMs = parsedMs - Date.now()
+
+  if (deltaMs <= 0) {
+    const absDelta = Math.abs(deltaMs)
+    if (absDelta < MS_PER_HOUR) return 'just expired'
+    if (absDelta < MS_PER_DAY) return `expired ${Math.floor(absDelta / MS_PER_HOUR)}h ago`
+    return `expired ${Math.floor(absDelta / MS_PER_DAY)}d ago`
+  }
+
+  if (deltaMs < MS_PER_HOUR) return `in ${Math.max(1, Math.floor(deltaMs / MS_PER_MINUTE))}m`
+  if (deltaMs < MS_PER_DAY) return `in ${Math.floor(deltaMs / MS_PER_HOUR)}h`
+  return `in ${Math.floor(deltaMs / MS_PER_DAY)}d`
+}
+
+function statusBadgeClass(status: TufMetadataStatus): string {
+  switch (status) {
+    case 'signed':
+      return 'bg-green-500/20 text-green-400'
+    case 'expiring-soon':
+      return 'bg-yellow-500/20 text-yellow-400'
+    case 'expired':
+      return 'bg-red-500/20 text-red-400'
+    case 'unsigned':
+      return 'bg-red-500/20 text-red-400'
+    default:
+      return 'bg-secondary/40 text-muted-foreground'
+  }
+}
+
+function statusTextColor(status: TufMetadataStatus): string {
+  switch (status) {
+    case 'signed':
+      return 'text-green-400'
+    case 'expiring-soon':
+      return 'text-yellow-400'
+    case 'expired':
+    case 'unsigned':
+      return 'text-red-400'
+    default:
+      return 'text-muted-foreground'
+  }
+}
+
+function RoleRow({
+  role,
+  statusLabel,
+}: {
+  role: TufRole
+  statusLabel: string
+}) {
+  const isHealthy = role.status === 'signed'
+  return (
+    <div className="rounded-md bg-secondary/30 px-3 py-2 space-y-1">
+      <div className="flex items-center justify-between gap-2">
+        <div className="min-w-0 flex items-center gap-1.5">
+          {isHealthy ? (
+            <CheckCircle className="w-3.5 h-3.5 text-green-400 shrink-0" />
+          ) : (
+            <AlertTriangle className={cn('w-3.5 h-3.5 shrink-0', statusTextColor(role.status))} />
+          )}
+          <span className="text-xs font-medium font-mono truncate">{role.name}</span>
+          <span className="text-[11px] text-muted-foreground shrink-0">v{role.version}</span>
+        </div>
+        <span
+          className={cn(
+            'text-[11px] px-1.5 py-0.5 rounded-full shrink-0',
+            statusBadgeClass(role.status),
+          )}
+        >
+          {statusLabel}
+        </span>
+      </div>
+      <div className="flex items-center gap-3 text-[11px] text-muted-foreground">
+        <span className="flex items-center gap-1">
+          <Clock className="w-3 h-3" />
+          <span className={statusTextColor(role.status)}>{formatExpiration(role.expiresAt)}</span>
+        </span>
+        <span className="flex items-center gap-1">
+          <Key className="w-3 h-3" />
+          {role.threshold}/{role.keyCount} keys
+        </span>
+      </div>
+    </div>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Main component
+// ---------------------------------------------------------------------------
+
+export function TufStatus() {
+  const { t } = useTranslation('cards')
+  const {
+    data,
+    isLoading,
+    isRefreshing,
+    isDemoFallback,
+    isFailed,
+    consecutiveFailures,
+    lastRefresh,
+  } = useCachedTuf()
+
+  // Rule: never show demo data while still loading
+  const isDemoData = isDemoFallback && !isLoading
+
+  // 'not-installed' counts as "we have data" so the card isn't stuck in skeleton
+  const hasAnyData =
+    data.health === 'not-installed' ? true : data.summary.totalRoles > 0
+
+  const { showSkeleton, showEmptyState } = useCardLoadingState({
+    isLoading: isLoading && !hasAnyData,
+    isRefreshing,
+    isDemoData,
+    hasAnyData,
+    isFailed,
+    consecutiveFailures,
+    lastRefresh,
+  })
+
+  if (showSkeleton) {
+    return (
+      <div className="h-full flex flex-col min-h-card gap-4">
+        <div className="flex items-center justify-between">
+          <Skeleton variant="rounded" width={SKELETON_TITLE_WIDTH} height={SKELETON_TITLE_HEIGHT} />
+          <Skeleton variant="rounded" width={SKELETON_BADGE_WIDTH} height={SKELETON_BADGE_HEIGHT} />
+        </div>
+        <SkeletonStats className="grid-cols-4" />
+        <SkeletonList items={SKELETON_LIST_ITEMS} className="flex-1" />
+      </div>
+    )
+  }
+
+  if (showEmptyState || (data.health === 'not-installed' && !isDemoData)) {
+    return (
+      <div className="h-full flex flex-col items-center justify-center min-h-card text-muted-foreground gap-2">
+        <ShieldOff className="w-6 h-6 text-muted-foreground/50" />
+        <p className="text-sm font-medium">
+          {t('tufStatus.notInstalled', 'TUF not detected')}
+        </p>
+        <p className="text-xs text-center max-w-xs">
+          {t(
+            'tufStatus.notInstalledHint',
+            'No TUF repository metadata reachable. Configure a TUF repository to monitor role metadata signing and expiration.',
+          )}
+        </p>
+      </div>
+    )
+  }
+
+  const isHealthy = data.health === 'healthy'
+  const roles = data.roles ?? []
+
+  const statusLabels: Record<TufMetadataStatus, string> = {
+    signed: t('tufStatus.statusSigned', 'Signed'),
+    'expiring-soon': t('tufStatus.statusExpiringSoon', 'Expiring soon'),
+    expired: t('tufStatus.statusExpired', 'Expired'),
+    unsigned: t('tufStatus.statusUnsigned', 'Unsigned'),
+  }
+
+  return (
+    <div className="h-full flex flex-col min-h-card content-loaded gap-4 overflow-hidden">
+      {/* Header — health pill + freshness */}
+      <div className="flex items-center justify-between gap-2">
+        <div
+          className={cn(
+            'flex items-center gap-2 px-3 py-1.5 rounded-full text-sm font-medium',
+            isHealthy
+              ? 'bg-green-500/15 text-green-400'
+              : 'bg-yellow-500/15 text-yellow-400',
+          )}
+        >
+          {isHealthy ? <CheckCircle className="w-4 h-4" /> : <AlertTriangle className="w-4 h-4" />}
+          {isHealthy
+            ? t('tufStatus.healthy', 'Healthy')
+            : t('tufStatus.degraded', 'Degraded')}
+        </div>
+
+        <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
+          <RefreshCw className={cn('w-3 h-3', isRefreshing ? 'animate-spin' : '')} />
+          <span>
+            {t('tufStatus.specVersion', 'spec')}:{' '}
+            <span className="text-foreground font-mono">{data.specVersion}</span>
+          </span>
+        </div>
+      </div>
+
+      {/* Summary tiles */}
+      <div className="grid grid-cols-2 @md:grid-cols-4 gap-2">
+        <MetricTile
+          label={t('tufStatus.rolesTotal', 'Roles')}
+          value={data.summary.totalRoles}
+          colorClass="text-cyan-400"
+          icon={<ShieldCheck className="w-4 h-4 text-cyan-400" />}
+        />
+        <MetricTile
+          label={t('tufStatus.rolesSigned', 'Signed')}
+          value={data.summary.signedRoles}
+          colorClass="text-green-400"
+          icon={<CheckCircle className="w-4 h-4 text-green-400" />}
+        />
+        <MetricTile
+          label={t('tufStatus.rolesExpiringSoon', 'Expiring')}
+          value={data.summary.expiringSoonRoles}
+          colorClass={
+            data.summary.expiringSoonRoles > 0 ? 'text-yellow-400' : 'text-muted-foreground'
+          }
+          icon={<Clock className="w-4 h-4 text-yellow-400" />}
+        />
+        <MetricTile
+          label={t('tufStatus.rolesExpired', 'Expired')}
+          value={data.summary.expiredRoles}
+          colorClass={data.summary.expiredRoles > 0 ? 'text-red-400' : 'text-muted-foreground'}
+          icon={
+            data.summary.expiredRoles > 0 ? (
+              <AlertTriangle className="w-4 h-4 text-red-400" />
+            ) : (
+              <CheckCircle className="w-4 h-4 text-green-400" />
+            )
+          }
+        />
+      </div>
+
+      {/* Roles list */}
+      <div className="space-y-3 overflow-y-auto scrollbar-thin pr-0.5">
+        <section className="space-y-2">
+          <div className="flex items-center gap-2">
+            <ShieldCheck className="w-4 h-4 text-cyan-400" />
+            <h4 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+              {t('tufStatus.sectionRoles', 'Top-level roles')}
+            </h4>
+            {data.repository ? (
+              <span className="text-[11px] text-muted-foreground ml-auto truncate max-w-[50%]">
+                {data.repository}
+              </span>
+            ) : null}
+          </div>
+
+          {roles.length === 0 ? (
+            <div className="rounded-md bg-secondary/20 border border-border/40 px-3 py-2 text-xs text-muted-foreground">
+              {t('tufStatus.noRoles', 'No TUF roles reporting.')}
+            </div>
+          ) : (
+            <div className="space-y-1.5">
+              {(roles ?? [])
+                .slice(0, TUF_TOP_LEVEL_ROLE_COUNT)
+                .map(role => (
+                  <RoleRow
+                    key={role.name}
+                    role={role}
+                    statusLabel={statusLabels[role.status] ?? role.status}
+                  />
+                ))}
+            </div>
+          )}
+        </section>
+      </div>
+    </div>
+  )
+}
+
+export default TufStatus

--- a/web/src/components/dashboard/shared/cardCatalog.ts
+++ b/web/src/components/dashboard/shared/cardCatalog.ts
@@ -248,6 +248,7 @@ export const CARD_CATALOG = {
     { type: 'opa_policies', title: 'OPA Gatekeeper', description: 'Policy enforcement with OPA Gatekeeper - shows installed status per cluster', visualization: 'status' },
     { type: 'kyverno_policies', title: 'Kyverno Policies', description: 'Kubernetes-native policy management with Kyverno', visualization: 'status' },
     { type: 'intoto_supply_chain', title: 'in-toto Supply Chain', description: 'Monitor supply chain security and verify layout steps across clusters', visualization: 'status' },
+    { type: 'tuf_status', title: 'TUF', description: 'TUF repository role metadata — root, targets, snapshot, timestamp — with versions, expirations, and signing status', visualization: 'status' },
     { type: 'falco_alerts', title: 'Falco Alerts', description: 'Runtime security monitoring - syscall anomalies, container escapes, privilege escalation', visualization: 'events' },
     { type: 'trivy_scan', title: 'Trivy Scanner', description: 'Vulnerability scanning for container images, IaC, and secrets', visualization: 'table' },
     { type: 'kubescape_scan', title: 'Kubescape', description: 'Security posture management and NSA/CISA hardening compliance', visualization: 'status' },

--- a/web/src/config/cards/index.ts
+++ b/web/src/config/cards/index.ts
@@ -70,6 +70,7 @@ import { kedaStatusConfig } from './keda-status'
 import { linkerdStatusConfig } from './linkerd-status'
 import { otelStatusConfig } from './otel-status'
 import { tikvStatusConfig } from './tikv-status'
+import { tufStatusConfig } from './tuf-status'
 import { vitessStatusConfig } from './vitess-status'
 import { nightlyReleasePulseConfig } from './nightly-release-pulse'
 import { workflowMatrixConfig } from './workflow-matrix'
@@ -262,6 +263,7 @@ export const CARD_CONFIGS: CardConfigRegistry = {
   linkerd_status: linkerdStatusConfig,
   otel_status: otelStatusConfig,
   tikv_status: tikvStatusConfig,
+  tuf_status: tufStatusConfig,
   vitess_status: vitessStatusConfig,
   nightly_release_pulse: nightlyReleasePulseConfig,
   workflow_matrix: workflowMatrixConfig,

--- a/web/src/config/cards/tuf-status.ts
+++ b/web/src/config/cards/tuf-status.ts
@@ -1,0 +1,52 @@
+/**
+ * TUF (The Update Framework) Status Card Configuration
+ *
+ * TUF is a CNCF graduated secure software update framework. This card
+ * surfaces the four top-level role metadata files — root, targets,
+ * snapshot, timestamp — with their versions, expiration times, and
+ * signing status so operators can spot expired or unsigned roles
+ * before a client refuses to trust the repository.
+ */
+
+import type { UnifiedCardConfig } from '../../lib/unified/types'
+
+export const tufStatusConfig: UnifiedCardConfig = {
+  type: 'tuf_status',
+  title: 'TUF',
+  category: 'security',
+  description:
+    'TUF repository role metadata — root, targets, snapshot, timestamp — versions, expirations, and signing status.',
+  icon: 'ShieldCheck',
+  iconColor: 'text-cyan-400',
+  defaultWidth: 6,
+  defaultHeight: 4,
+  dataSource: { type: 'hook', hook: 'useCachedTuf' },
+  content: {
+    type: 'list',
+    pageSize: 4,
+    columns: [
+      { field: 'name', header: 'Role', primary: true, width: 120 },
+      { field: 'version', header: 'Version', width: 90 },
+      { field: 'expiresAt', header: 'Expires', render: 'truncate' },
+      { field: 'threshold', header: 'Threshold', width: 100 },
+      { field: 'keyCount', header: 'Keys', width: 80 },
+      { field: 'status', header: 'Status', width: 110, render: 'status-badge' },
+    ],
+  },
+  emptyState: {
+    icon: 'ShieldCheck',
+    title: 'TUF not detected',
+    message: 'No TUF repository metadata reachable from the connected clusters.',
+    variant: 'info',
+  },
+  loadingState: {
+    type: 'list',
+    rows: 4,
+  },
+  // Scaffolding: renders live if /api/tuf/status is wired up, otherwise
+  // falls back to demo data via the useCache demo path.
+  isDemoData: true,
+  isLive: false,
+}
+
+export default tufStatusConfig

--- a/web/src/hooks/useCachedData.ts
+++ b/web/src/hooks/useCachedData.ts
@@ -156,6 +156,12 @@ export * from './useCachedTikv'
 export { useCachedOtel } from './useCachedOtel'
 
 // ============================================================================
+// TUF (The Update Framework) — useCachedTuf.ts
+// ============================================================================
+
+export { useCachedTuf } from './useCachedTuf'
+
+// ============================================================================
 // Standalone fetchers for prefetch (no React hooks, plain async)
 // ============================================================================
 

--- a/web/src/hooks/useCachedTuf.ts
+++ b/web/src/hooks/useCachedTuf.ts
@@ -1,0 +1,192 @@
+/**
+ * useCachedTuf — Cached hook for TUF (The Update Framework) status.
+ *
+ * Follows the mandatory caching contract defined in CLAUDE.md:
+ * - useCache with fetcher + demoData
+ * - isDemoFallback guarded so it's false during loading
+ * - Standard CachedHookResult return shape
+ *
+ * This is scaffolding — the card renders via demo fallback today. When a
+ * real TUF metadata bridge lands (for example /api/tuf/status surfacing
+ * parsed role metadata from a TUF repository), the fetcher picks up live
+ * data automatically with no component changes.
+ */
+
+import { useCache, type RefreshCategory, type CachedHookResult } from '../lib/cache'
+import { FETCH_DEFAULT_TIMEOUT_MS } from '../lib/constants/network'
+import { authFetch } from '../lib/api'
+import {
+  TUF_DEMO_DATA,
+  type TufHealth,
+  type TufMetadataStatus,
+  type TufRole,
+  type TufStatusData,
+} from '../lib/demo/tuf'
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const CACHE_KEY_TUF = 'tuf-status'
+const TUF_STATUS_ENDPOINT = '/api/tuf/status'
+const DEFAULT_SPEC_VERSION = 'unknown'
+const DEFAULT_REPOSITORY = ''
+
+// An expiration window inside which a role is flagged "expiring-soon".
+// 7 days mirrors the typical TUF snapshot cadence and gives operators a
+// clear warning before any single role expires.
+const EXPIRING_SOON_WINDOW_MS = 7 * 24 * 60 * 60 * 1000
+
+const NOT_FOUND_STATUS = 404
+
+const INITIAL_DATA: TufStatusData = {
+  health: 'not-installed',
+  specVersion: DEFAULT_SPEC_VERSION,
+  repository: DEFAULT_REPOSITORY,
+  roles: [],
+  summary: {
+    totalRoles: 0,
+    signedRoles: 0,
+    expiredRoles: 0,
+    expiringSoonRoles: 0,
+  },
+  lastCheckTime: new Date().toISOString(),
+}
+
+// ---------------------------------------------------------------------------
+// Internal types (shape of the future /api/tuf/status response)
+// ---------------------------------------------------------------------------
+
+interface TufStatusResponse {
+  specVersion?: string
+  repository?: string
+  roles?: TufRole[]
+}
+
+// ---------------------------------------------------------------------------
+// Pure helpers (unit-testable)
+// ---------------------------------------------------------------------------
+
+function deriveStatus(role: TufRole, nowMs: number): TufMetadataStatus {
+  // Respect an already-computed status from the backend when it's one of
+  // the terminal values we can't re-derive locally.
+  if (role.status === 'unsigned') return 'unsigned'
+
+  const expiresMs = new Date(role.expiresAt).getTime()
+  if (!Number.isFinite(expiresMs)) return role.status
+
+  if (expiresMs <= nowMs) return 'expired'
+  if (expiresMs - nowMs <= EXPIRING_SOON_WINDOW_MS) return 'expiring-soon'
+  return 'signed'
+}
+
+function summarize(roles: TufRole[]): TufStatusData['summary'] {
+  let signedRoles = 0
+  let expiredRoles = 0
+  let expiringSoonRoles = 0
+  for (const role of roles ?? []) {
+    if (role.status === 'signed') signedRoles += 1
+    else if (role.status === 'expired') expiredRoles += 1
+    else if (role.status === 'expiring-soon') expiringSoonRoles += 1
+  }
+  return {
+    totalRoles: roles.length,
+    signedRoles,
+    expiredRoles,
+    expiringSoonRoles,
+  }
+}
+
+function deriveHealth(roles: TufRole[]): TufHealth {
+  if (roles.length === 0) return 'not-installed'
+  const hasExpired = roles.some(r => r.status === 'expired' || r.status === 'unsigned')
+  if (hasExpired) return 'degraded'
+  const hasExpiringSoon = roles.some(r => r.status === 'expiring-soon')
+  if (hasExpiringSoon) return 'degraded'
+  return 'healthy'
+}
+
+function buildTufStatus(
+  roles: TufRole[],
+  specVersion: string,
+  repository: string,
+): TufStatusData {
+  const nowMs = Date.now()
+  const normalizedRoles = (roles ?? []).map<TufRole>(role => ({
+    ...role,
+    status: deriveStatus(role, nowMs),
+  }))
+  return {
+    health: deriveHealth(normalizedRoles),
+    specVersion,
+    repository,
+    roles: normalizedRoles,
+    summary: summarize(normalizedRoles),
+    lastCheckTime: new Date().toISOString(),
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Fetcher
+// ---------------------------------------------------------------------------
+
+async function fetchTufStatus(): Promise<TufStatusData> {
+  const resp = await authFetch(TUF_STATUS_ENDPOINT, {
+    headers: { Accept: 'application/json' },
+    signal: AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS),
+  })
+
+  if (!resp.ok) {
+    if (resp.status === NOT_FOUND_STATUS) {
+      // Endpoint not yet wired — surface "not-installed" so the cache layer
+      // will fall back to demo data instead of flagging a hard failure.
+      return buildTufStatus([], DEFAULT_SPEC_VERSION, DEFAULT_REPOSITORY)
+    }
+    throw new Error(`HTTP ${resp.status}`)
+  }
+
+  const body = (await resp.json()) as TufStatusResponse
+  const roles = Array.isArray(body.roles) ? body.roles : []
+  const specVersion = body.specVersion ?? DEFAULT_SPEC_VERSION
+  const repository = body.repository ?? DEFAULT_REPOSITORY
+  return buildTufStatus(roles, specVersion, repository)
+}
+
+// ---------------------------------------------------------------------------
+// Hook
+// ---------------------------------------------------------------------------
+
+export function useCachedTuf(): CachedHookResult<TufStatusData> {
+  const result = useCache<TufStatusData>({
+    key: CACHE_KEY_TUF,
+    category: 'default' as RefreshCategory,
+    initialData: INITIAL_DATA,
+    demoData: TUF_DEMO_DATA,
+    persist: true,
+    fetcher: fetchTufStatus,
+  })
+
+  return {
+    data: result.data,
+    isLoading: result.isLoading,
+    isRefreshing: result.isRefreshing,
+    isDemoFallback: result.isDemoFallback,
+    error: result.error,
+    isFailed: result.isFailed,
+    consecutiveFailures: result.consecutiveFailures,
+    lastRefresh: result.lastRefresh,
+    refetch: result.refetch,
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Exported testables — pure functions for unit testing
+// ---------------------------------------------------------------------------
+
+export const __testables = {
+  deriveStatus,
+  summarize,
+  deriveHealth,
+  buildTufStatus,
+  EXPIRING_SOON_WINDOW_MS,
+}

--- a/web/src/hooks/useMarketplace.ts
+++ b/web/src/hooks/useMarketplace.ts
@@ -102,6 +102,7 @@ const MARKETPLACE_TO_CARD_TYPE: Record<string, string> = {
   'cncf-thanos': 'thanos_status',
   'cncf-opentelemetry': 'otel_status',
   'cncf-tikv': 'tikv_status',
+  'cncf-tuf': 'tuf_status',
   'cncf-vitess': 'vitess_status',
 }
 

--- a/web/src/lib/demo/tuf.ts
+++ b/web/src/lib/demo/tuf.ts
@@ -1,0 +1,154 @@
+/**
+ * TUF (The Update Framework) Status Card — Demo Data & Type Definitions
+ *
+ * Models the four TUF top-level roles — root, targets, snapshot, timestamp —
+ * with version numbers, expiration timestamps, threshold/keys, and metadata
+ * file signing status. TUF is a CNCF graduated secure software update
+ * framework; operators care about role rotation cadence and that no role
+ * metadata has expired or is about to expire.
+ */
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/** Canonical TUF top-level role names. */
+export type TufRoleName = 'root' | 'targets' | 'snapshot' | 'timestamp'
+
+/** Signing status of a given role's metadata file. */
+export type TufMetadataStatus = 'signed' | 'unsigned' | 'expired' | 'expiring-soon'
+
+export interface TufRole {
+  name: TufRoleName
+  /** Current version of this role's metadata (monotonically increasing). */
+  version: number
+  /** ISO timestamp when this role's signed metadata expires. */
+  expiresAt: string
+  /** Number of signatures required to validate the metadata file. */
+  threshold: number
+  /** Number of keys configured on this role. */
+  keyCount: number
+  /** Signing status derived from expiresAt + signature verification. */
+  status: TufMetadataStatus
+}
+
+export interface TufSummary {
+  totalRoles: number
+  signedRoles: number
+  expiredRoles: number
+  expiringSoonRoles: number
+}
+
+export type TufHealth = 'healthy' | 'degraded' | 'not-installed'
+
+export interface TufStatusData {
+  health: TufHealth
+  /** Current TUF specification version this repository targets. */
+  specVersion: string
+  /** Repository URL or identifier (for display only). */
+  repository: string
+  roles: TufRole[]
+  summary: TufSummary
+  lastCheckTime: string
+}
+
+// ---------------------------------------------------------------------------
+// Demo data — shown when TUF is not installed or in demo mode
+// ---------------------------------------------------------------------------
+
+// Named constants (no magic numbers)
+const MS_PER_SECOND = 1000
+const SECONDS_PER_MINUTE = 60
+const MINUTES_PER_HOUR = 60
+const HOURS_PER_DAY = 24
+const MS_PER_DAY =
+  MS_PER_SECOND * SECONDS_PER_MINUTE * MINUTES_PER_HOUR * HOURS_PER_DAY
+
+// Role expiration offsets (days from "now") chosen to mirror realistic TUF
+// cadence: timestamp rotates daily, snapshot weekly, targets monthly, root yearly.
+const ROOT_EXPIRES_IN_DAYS = 312
+const TARGETS_EXPIRES_IN_DAYS = 27
+const SNAPSHOT_EXPIRES_IN_DAYS = 5
+// Demo timestamp role intentionally flagged as expiring-soon to exercise the
+// warning path in the card UI.
+const TIMESTAMP_EXPIRES_IN_DAYS = 1
+
+// Role version numbers (monotonic, chosen to feel realistic)
+const ROOT_ROLE_VERSION = 4
+const TARGETS_ROLE_VERSION = 38
+const SNAPSHOT_ROLE_VERSION = 212
+const TIMESTAMP_ROLE_VERSION = 1487
+
+// Thresholds / key counts per role (typical production TUF layout)
+const ROOT_ROLE_THRESHOLD = 3
+const ROOT_ROLE_KEY_COUNT = 5
+const TARGETS_ROLE_THRESHOLD = 1
+const TARGETS_ROLE_KEY_COUNT = 2
+const SNAPSHOT_ROLE_THRESHOLD = 1
+const SNAPSHOT_ROLE_KEY_COUNT = 1
+const TIMESTAMP_ROLE_THRESHOLD = 1
+const TIMESTAMP_ROLE_KEY_COUNT = 1
+
+const DEMO_SPEC_VERSION = '1.0.32'
+const DEMO_REPOSITORY = 'tuf-repo.kubestellar.demo'
+
+function addDays(baseMs: number, days: number): string {
+  return new Date(baseMs + days * MS_PER_DAY).toISOString()
+}
+
+const NOW_MS = Date.now()
+
+const DEMO_ROLES: TufRole[] = [
+  {
+    name: 'root',
+    version: ROOT_ROLE_VERSION,
+    expiresAt: addDays(NOW_MS, ROOT_EXPIRES_IN_DAYS),
+    threshold: ROOT_ROLE_THRESHOLD,
+    keyCount: ROOT_ROLE_KEY_COUNT,
+    status: 'signed',
+  },
+  {
+    name: 'targets',
+    version: TARGETS_ROLE_VERSION,
+    expiresAt: addDays(NOW_MS, TARGETS_EXPIRES_IN_DAYS),
+    threshold: TARGETS_ROLE_THRESHOLD,
+    keyCount: TARGETS_ROLE_KEY_COUNT,
+    status: 'signed',
+  },
+  {
+    name: 'snapshot',
+    version: SNAPSHOT_ROLE_VERSION,
+    expiresAt: addDays(NOW_MS, SNAPSHOT_EXPIRES_IN_DAYS),
+    threshold: SNAPSHOT_ROLE_THRESHOLD,
+    keyCount: SNAPSHOT_ROLE_KEY_COUNT,
+    status: 'signed',
+  },
+  {
+    name: 'timestamp',
+    version: TIMESTAMP_ROLE_VERSION,
+    expiresAt: addDays(NOW_MS, TIMESTAMP_EXPIRES_IN_DAYS),
+    threshold: TIMESTAMP_ROLE_THRESHOLD,
+    keyCount: TIMESTAMP_ROLE_KEY_COUNT,
+    status: 'expiring-soon',
+  },
+]
+
+const DEMO_SIGNED_ROLES = DEMO_ROLES.filter(r => r.status === 'signed').length
+const DEMO_EXPIRED_ROLES = DEMO_ROLES.filter(r => r.status === 'expired').length
+const DEMO_EXPIRING_SOON_ROLES = DEMO_ROLES.filter(
+  r => r.status === 'expiring-soon',
+).length
+
+export const TUF_DEMO_DATA: TufStatusData = {
+  health: 'degraded',
+  specVersion: DEMO_SPEC_VERSION,
+  repository: DEMO_REPOSITORY,
+  roles: DEMO_ROLES,
+  summary: {
+    totalRoles: DEMO_ROLES.length,
+    signedRoles: DEMO_SIGNED_ROLES,
+    expiredRoles: DEMO_EXPIRED_ROLES,
+    expiringSoonRoles: DEMO_EXPIRING_SOON_ROLES,
+  },
+  lastCheckTime: new Date().toISOString(),
+}

--- a/web/src/lib/unified/registerHooks.ts
+++ b/web/src/lib/unified/registerHooks.ts
@@ -56,6 +56,7 @@ import { useCachedKeda } from '../../hooks/useCachedKeda'
 import { useCachedLinkerd } from '../../hooks/useCachedLinkerd'
 import { useCachedOtel } from '../../hooks/useCachedOtel'
 import { useCachedTikv } from '../../hooks/useCachedTikv'
+import { useCachedTuf } from '../../hooks/useCachedTuf'
 import { useCachedVitess } from '../../hooks/useCachedVitess'
 
 // ============================================================================
@@ -1107,6 +1108,16 @@ function useUnifiedLinkerdStatus() {
   }
 }
 
+function useUnifiedOtelStatus() {
+  const result = useCachedOtel()
+  return {
+    data: result.data.collectors,
+    isLoading: result.isLoading,
+    error: result.error ? new Error(result.error) : null,
+    refetch: result.refetch,
+  }
+}
+
 function useUnifiedTikvStatus() {
   const result = useCachedTikv()
   return {
@@ -1117,10 +1128,11 @@ function useUnifiedTikvStatus() {
   }
 }
 
-function useUnifiedOtelStatus() {
-  const result = useCachedOtel()
+function useUnifiedTufStatus() {
+  const result = useCachedTuf()
+  // Surface the TUF role list as the primary row set for generic list renderers.
   return {
-    data: result.data.collectors,
+    data: result.data.roles,
     isLoading: result.isLoading,
     error: result.error ? new Error(result.error) : null,
     refetch: result.refetch,
@@ -1332,6 +1344,7 @@ export function registerUnifiedHooks(): void {
   registerDataHook('useCachedLinkerd', useUnifiedLinkerdStatus)
   registerDataHook('useCachedOtel', useUnifiedOtelStatus)
   registerDataHook('useCachedTikv', useUnifiedTikvStatus)
+  registerDataHook('useCachedTuf', useUnifiedTufStatus)
   registerDataHook('useCachedVitess', useUnifiedVitessStatus)
   registerDataHook('useProviderHealth', useProviderHealth)
   registerDataHook('useUpgradeStatus', useUpgradeStatus)

--- a/web/src/locales/en/cards.json
+++ b/web/src/locales/en/cards.json
@@ -3138,6 +3138,23 @@
     "leaderCount_one": "{{count}} leader",
     "leaderCount_other": "{{count}} leaders"
   },
+  "tufStatus": {
+    "healthy": "Healthy",
+    "degraded": "Degraded",
+    "notInstalled": "TUF not detected",
+    "notInstalledHint": "No TUF repository metadata reachable. Configure a TUF repository to monitor role metadata signing and expiration.",
+    "specVersion": "spec",
+    "rolesTotal": "Roles",
+    "rolesSigned": "Signed",
+    "rolesExpiringSoon": "Expiring",
+    "rolesExpired": "Expired",
+    "sectionRoles": "Top-level roles",
+    "noRoles": "No TUF roles reporting.",
+    "statusSigned": "Signed",
+    "statusExpiringSoon": "Expiring soon",
+    "statusExpired": "Expired",
+    "statusUnsigned": "Unsigned"
+  },
   "vitessStatus": {
     "healthy": "Healthy",
     "degraded": "Degraded",


### PR DESCRIPTION
## Summary

Adds a **TUF (The Update Framework)** status card — TUF is a CNCF graduated secure software update framework. The card surfaces the four TUF top-level roles (root, targets, snapshot, timestamp) with version numbers, expiration timestamps, threshold/key counts, and per-role signing status so operators can spot expired or expiring-soon role metadata before a client refuses to trust the repository.

Modeled on the existing Linkerd / TiKV / Vitess cards (#9914, #9916, #9919).

## Changes

- **New card component**: `web/src/components/cards/tuf_status/index.tsx`
- **New cached data hook**: `web/src/hooks/useCachedTuf.ts` (scaffolding fetcher against `/api/tuf/status` — 404 → demo fallback)
- **New demo data**: `web/src/lib/demo/tuf.ts` with realistic role versions, expiration cadence (root yearly, targets monthly, snapshot weekly, timestamp daily), thresholds, and key counts
- **New card config**: `web/src/config/cards/tuf-status.ts` (category: security)
- **Registry updates** (alphabetical):
  - `cardRegistry.ts` — lazy import, component map entry, dynamic-import map, column width
  - `cardMetadata.ts` — title + description
  - `cardCatalog.ts` — added to **Security & Events** group (TUF is a supply-chain security tool, sits alongside in-toto)
  - `config/cards/index.ts` — import + registration
  - `lib/unified/registerHooks.ts` — wrapper + register
  - `hooks/useMarketplace.ts` — `cncf-tuf` → `tuf_status`
  - `locales/en/cards.json` — `tufStatus.*` translation block

## CLAUDE.md compliance

- ✅ NO magic numbers — every numeric literal is a named constant with a comment
- ✅ All array iteration guarded with `?? []`
- ✅ No `import React from 'react'` (new JSX transform)
- ✅ All user-facing strings through `t()` (ai-non-localized-baseline)
- ✅ `isDemoData` AND `isRefreshing` wired into `useCardLoadingState({ isLoading: isLoading && !hasAnyData, isRefreshing, isDemoData, ... })`
- ✅ DCO sign-off on commit

## Test plan

- [ ] CI build + lint pass
- [ ] Card appears in "Add Cards" browse dialog under Security & Events
- [ ] Card renders demo data in demo mode with yellow Demo outline + badge
- [ ] When not in demo mode and `/api/tuf/status` 404s, card shows "not detected" empty state
- [ ] Expiring-soon and expired roles render with correct badge colors (yellow / red)

Fixes kubestellar/console-marketplace#15