### PR TITLE
feat(dapr): add Dapr monitoring card (kubestellar/console-marketplace#21)

### DIFF
--- a/web/src/components/cards/cardMetadata.ts
+++ b/web/src/components/cards/cardMetadata.ts
@@ -266,6 +266,8 @@ export const CARD_TITLES: Record<string, string> = {
   coredns_status: 'CoreDNS',
   // Contour ingress proxy
   contour_status: 'Contour',
+  // Dapr distributed application runtime
+  dapr_status: 'Dapr',
   // Envoy proxy (service mesh / edge)
   envoy_status: 'Envoy Proxy',
   // gRPC services (network / service communication)
@@ -589,6 +591,8 @@ export const CARD_DESCRIPTIONS: Record<string, string> = {
   coredns_status: 'CoreDNS pod health, restart counts, and cluster status across clusters.',
   // Contour ingress proxy
   contour_status: 'Contour ingress proxy status, HTTPProxy resources, and Envoy fleet health.',
+  // Dapr distributed application runtime
+  dapr_status: 'Dapr control plane health, Dapr-enabled application count, and configured components (state store / pub-sub / binding).',
   // Envoy proxy (service mesh / edge)
   envoy_status: 'Envoy Proxy listener health, upstream cluster health, and request/connection stats.',
   // gRPC services (network / service communication)

--- a/web/src/components/cards/cardRegistry.ts
+++ b/web/src/components/cards/cardRegistry.ts
@@ -80,6 +80,8 @@ const KustomizationStatus = safeLazy(() => _deployBundle, 'KustomizationStatus')
 const FluxStatus = safeLazy(() => import('./flux_status'), 'FluxStatus')
 // Contour ingress proxy card
 const ContourStatus = safeLazy(() => import('./contour_status'), 'ContourStatus')
+// Dapr distributed application runtime card
+const DaprStatus = safeLazy(() => import('./dapr_status'), 'DaprStatus')
 // Envoy proxy card (Service Mesh / network)
 const EnvoyStatus = safeLazy(() => import('./envoy_status'), 'EnvoyStatus')
 // gRPC services card (network / service communication)
@@ -716,6 +718,8 @@ const RAW_CARD_COMPONENTS: Record<string, CardComponent> = {
   nats_status: NatsStatus,
   // Contour ingress proxy
   contour_status: ContourStatus,
+  // Dapr distributed application runtime
+  dapr_status: DaprStatus,
   // Envoy proxy (service mesh / edge)
   envoy_status: EnvoyStatus,
   // gRPC services (network / service communication)
@@ -1046,6 +1050,7 @@ const CARD_CHUNK_PRELOADERS: Record<string, () => Promise<unknown>> = {
   kustomization_status: () => import('./deploy-bundle'),
   flux_status: () => import('./flux_status'),
   contour_status: () => import('./contour_status'),
+  dapr_status: () => import('./dapr_status'),
   envoy_status: () => import('./envoy_status'),
   grpc_status: () => import('./grpc_status'),
   linkerd_status: () => import('./linkerd_status'),
@@ -1645,6 +1650,7 @@ export const CARD_DEFAULT_WIDTHS: Record<string, number> = {
   kustomization_status: 6,
   flux_status: 6,
   contour_status: 6,
+  dapr_status: 6,
   envoy_status: 6,
   grpc_status: 6,
   linkerd_status: 6,

--- a/web/src/components/cards/dapr_status/demoData.ts
+++ b/web/src/components/cards/dapr_status/demoData.ts
@@ -1,0 +1,208 @@
+/**
+ * Dapr Status Card — Demo Data & Type Definitions
+ *
+ * Models Dapr (Distributed Application Runtime, CNCF graduated) control
+ * plane health, sidecar-injected application count, and configured
+ * components (state stores, pub/sub brokers, bindings).
+ *
+ * This is scaffolding — a real Dapr integration (dashboard API or direct
+ * control plane scrape) can be wired into `fetchDaprStatus` in a follow-up.
+ * Until then, cards fall back to this demo data via `useCache`.
+ */
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type DaprControlPlanePodStatus = 'running' | 'pending' | 'failed' | 'unknown'
+export type DaprComponentType = 'state-store' | 'pubsub' | 'binding'
+export type DaprHealth = 'healthy' | 'degraded' | 'not-installed'
+
+export interface DaprControlPlanePod {
+  /** Logical name of the control plane component. */
+  name: 'operator' | 'placement' | 'sentry' | 'sidecarInjector'
+  namespace: string
+  status: DaprControlPlanePodStatus
+  replicasDesired: number
+  replicasReady: number
+  cluster: string
+}
+
+export interface DaprComponent {
+  name: string
+  namespace: string
+  type: DaprComponentType
+  /** e.g. "state.redis", "pubsub.kafka", "bindings.kafka" */
+  componentImpl: string
+  cluster: string
+}
+
+export interface DaprAppSidecar {
+  /** Count of Deployments/Pods that have the Dapr sidecar injected. */
+  total: number
+  /** Distinct namespaces running at least one Dapr-enabled app. */
+  namespaces: number
+}
+
+export interface DaprBuildingBlockCounts {
+  /** Number of state-store components configured. */
+  stateStores: number
+  /** Number of pub/sub components configured. */
+  pubsubs: number
+  /** Number of binding components configured. */
+  bindings: number
+}
+
+export interface DaprSummary {
+  totalControlPlanePods: number
+  runningControlPlanePods: number
+  totalComponents: number
+  totalDaprApps: number
+}
+
+export interface DaprStatusData {
+  health: DaprHealth
+  controlPlane: DaprControlPlanePod[]
+  components: DaprComponent[]
+  apps: DaprAppSidecar
+  buildingBlocks: DaprBuildingBlockCounts
+  summary: DaprSummary
+  lastCheckTime: string
+}
+
+// ---------------------------------------------------------------------------
+// Demo-data constants (named — no magic numbers)
+// ---------------------------------------------------------------------------
+
+const DEMO_REPLICAS_SINGLE = 1
+const DEMO_REPLICAS_HA = 3
+const DEMO_PLACEMENT_REPLICAS = 3
+const DEMO_APP_SIDECAR_TOTAL = 42
+const DEMO_APP_SIDECAR_NAMESPACES = 7
+
+const DEMO_NAMESPACE_SYSTEM = 'dapr-system'
+const DEMO_NAMESPACE_ORDERS = 'orders'
+const DEMO_NAMESPACE_CHECKOUT = 'checkout'
+const DEMO_NAMESPACE_INVENTORY = 'inventory'
+
+// ---------------------------------------------------------------------------
+// Demo data — shown when Dapr is not installed or in demo mode
+// ---------------------------------------------------------------------------
+
+const DEMO_CONTROL_PLANE: DaprControlPlanePod[] = [
+  {
+    name: 'operator',
+    namespace: DEMO_NAMESPACE_SYSTEM,
+    status: 'running',
+    replicasDesired: DEMO_REPLICAS_SINGLE,
+    replicasReady: DEMO_REPLICAS_SINGLE,
+    cluster: 'default',
+  },
+  {
+    name: 'placement',
+    namespace: DEMO_NAMESPACE_SYSTEM,
+    status: 'running',
+    replicasDesired: DEMO_PLACEMENT_REPLICAS,
+    replicasReady: DEMO_PLACEMENT_REPLICAS,
+    cluster: 'default',
+  },
+  {
+    name: 'sentry',
+    namespace: DEMO_NAMESPACE_SYSTEM,
+    status: 'running',
+    replicasDesired: DEMO_REPLICAS_SINGLE,
+    replicasReady: DEMO_REPLICAS_SINGLE,
+    cluster: 'default',
+  },
+  {
+    name: 'sidecarInjector',
+    namespace: DEMO_NAMESPACE_SYSTEM,
+    status: 'pending',
+    replicasDesired: DEMO_REPLICAS_HA,
+    replicasReady: 2,
+    cluster: 'default',
+  },
+]
+
+const DEMO_COMPONENTS: DaprComponent[] = [
+  {
+    name: 'orders-statestore',
+    namespace: DEMO_NAMESPACE_ORDERS,
+    type: 'state-store',
+    componentImpl: 'state.redis',
+    cluster: 'default',
+  },
+  {
+    name: 'checkout-statestore',
+    namespace: DEMO_NAMESPACE_CHECKOUT,
+    type: 'state-store',
+    componentImpl: 'state.postgresql',
+    cluster: 'default',
+  },
+  {
+    name: 'orders-pubsub',
+    namespace: DEMO_NAMESPACE_ORDERS,
+    type: 'pubsub',
+    componentImpl: 'pubsub.kafka',
+    cluster: 'default',
+  },
+  {
+    name: 'checkout-pubsub',
+    namespace: DEMO_NAMESPACE_CHECKOUT,
+    type: 'pubsub',
+    componentImpl: 'pubsub.rabbitmq',
+    cluster: 'default',
+  },
+  {
+    name: 'inventory-binding-kafka',
+    namespace: DEMO_NAMESPACE_INVENTORY,
+    type: 'binding',
+    componentImpl: 'bindings.kafka',
+    cluster: 'default',
+  },
+  {
+    name: 'inventory-binding-cron',
+    namespace: DEMO_NAMESPACE_INVENTORY,
+    type: 'binding',
+    componentImpl: 'bindings.cron',
+    cluster: 'default',
+  },
+]
+
+function countByType(components: DaprComponent[], type: DaprComponentType): number {
+  return components.filter(c => c.type === type).length
+}
+
+function buildSummary(
+  controlPlane: DaprControlPlanePod[],
+  components: DaprComponent[],
+  apps: DaprAppSidecar,
+): DaprSummary {
+  return {
+    totalControlPlanePods: controlPlane.length,
+    runningControlPlanePods: controlPlane.filter(p => p.status === 'running').length,
+    totalComponents: components.length,
+    totalDaprApps: apps.total,
+  }
+}
+
+export const DAPR_DEMO_DATA: DaprStatusData = {
+  health: 'degraded',
+  controlPlane: DEMO_CONTROL_PLANE,
+  components: DEMO_COMPONENTS,
+  apps: {
+    total: DEMO_APP_SIDECAR_TOTAL,
+    namespaces: DEMO_APP_SIDECAR_NAMESPACES,
+  },
+  buildingBlocks: {
+    stateStores: countByType(DEMO_COMPONENTS, 'state-store'),
+    pubsubs: countByType(DEMO_COMPONENTS, 'pubsub'),
+    bindings: countByType(DEMO_COMPONENTS, 'binding'),
+  },
+  summary: buildSummary(
+    DEMO_CONTROL_PLANE,
+    DEMO_COMPONENTS,
+    { total: DEMO_APP_SIDECAR_TOTAL, namespaces: DEMO_APP_SIDECAR_NAMESPACES },
+  ),
+  lastCheckTime: new Date().toISOString(),
+}

--- a/web/src/components/cards/dapr_status/index.tsx
+++ b/web/src/components/cards/dapr_status/index.tsx
@@ -1,0 +1,354 @@
+/**
+ * Dapr Status Card
+ *
+ * Displays Dapr (Distributed Application Runtime, CNCF graduated) control
+ * plane pod health, Dapr-enabled application count, and configured
+ * components grouped by building block (state store / pubsub / binding).
+ *
+ * Follows the envoy_status / contour_status pattern for structure and
+ * styling.
+ *
+ * This is scaffolding — the card renders via demo fallback today. When a
+ * real Dapr control plane bridge lands, the hook's fetcher will pick up
+ * live data automatically with no component changes.
+ */
+
+import {
+  AlertTriangle,
+  Boxes,
+  CheckCircle,
+  Database,
+  Layers,
+  Link2,
+  Radio,
+  RefreshCw,
+  Server,
+  Shield,
+} from 'lucide-react'
+import { useTranslation } from 'react-i18next'
+import type { TFunction } from 'i18next'
+import { MetricTile } from '../../../lib/cards/CardComponents'
+import { Skeleton, SkeletonList, SkeletonStats } from '../../ui/Skeleton'
+import { useCachedDapr } from '../../../hooks/useCachedDapr'
+import type {
+  DaprComponent,
+  DaprComponentType,
+  DaprControlPlanePod,
+} from './demoData'
+
+// ---------------------------------------------------------------------------
+// Named constants (no magic numbers)
+// ---------------------------------------------------------------------------
+
+const SKELETON_TITLE_WIDTH = 140
+const SKELETON_TITLE_HEIGHT = 28
+const SKELETON_BADGE_WIDTH = 90
+const SKELETON_BADGE_HEIGHT = 20
+const SKELETON_LIST_ITEMS = 5
+
+const RELATIVE_TIME_MINUTE_MS = 60_000
+const MINUTES_PER_HOUR = 60
+const HOURS_PER_DAY = 24
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function formatRelativeTime(isoString: string): string {
+  const parsed = new Date(isoString).getTime()
+  if (!isoString || Number.isNaN(parsed)) return 'just now'
+
+  const diff = Date.now() - parsed
+  if (diff < 0) return 'just now'
+
+  const hour = MINUTES_PER_HOUR * RELATIVE_TIME_MINUTE_MS
+  const day = HOURS_PER_DAY * hour
+
+  if (diff < RELATIVE_TIME_MINUTE_MS) return 'just now'
+  if (diff < hour) return `${Math.floor(diff / RELATIVE_TIME_MINUTE_MS)}m ago`
+  if (diff < day) return `${Math.floor(diff / hour)}h ago`
+  return `${Math.floor(diff / day)}d ago`
+}
+
+function componentTypeLabel(
+  type: DaprComponentType,
+  t: TFunction<'cards'>,
+): string {
+  if (type === 'state-store') return t('daprStatus.componentStateStore', 'State store')
+  if (type === 'pubsub') return t('daprStatus.componentPubSub', 'Pub/sub')
+  return t('daprStatus.componentBinding', 'Binding')
+}
+
+function componentTypeColor(type: DaprComponentType): string {
+  if (type === 'state-store') return 'text-emerald-400'
+  if (type === 'pubsub') return 'text-violet-400'
+  return 'text-cyan-400'
+}
+
+function ComponentIcon({ type }: { type: DaprComponentType }) {
+  const color = componentTypeColor(type)
+  const className = `w-3.5 h-3.5 shrink-0 ${color}`
+  if (type === 'state-store') return <Database className={className} />
+  if (type === 'pubsub') return <Radio className={className} />
+  return <Link2 className={className} />
+}
+
+// ---------------------------------------------------------------------------
+// Subsections
+// ---------------------------------------------------------------------------
+
+function ControlPlaneRow({ pod }: { pod: DaprControlPlanePod }) {
+  const isRunning = pod.status === 'running' && pod.replicasReady === pod.replicasDesired
+  const statusClass = isRunning
+    ? 'bg-green-500/20 text-green-400'
+    : pod.status === 'pending'
+      ? 'bg-yellow-500/20 text-yellow-400'
+      : 'bg-red-500/20 text-red-400'
+
+  return (
+    <div className="rounded-md bg-secondary/30 px-3 py-2 flex items-center justify-between gap-2">
+      <div className="min-w-0 flex items-center gap-1.5">
+        {isRunning ? (
+          <CheckCircle className="w-3.5 h-3.5 text-green-400 shrink-0" />
+        ) : (
+          <AlertTriangle className="w-3.5 h-3.5 text-yellow-400 shrink-0" />
+        )}
+        <span className="text-xs font-medium text-foreground truncate">{pod.name}</span>
+        <span className="text-xs text-muted-foreground shrink-0">{pod.namespace}</span>
+      </div>
+      <div className="flex items-center gap-2 shrink-0">
+        <span className="text-[11px] font-mono text-muted-foreground">
+          {pod.replicasReady}/{pod.replicasDesired}
+        </span>
+        <span className={`text-[11px] px-1.5 py-0.5 rounded-full ${statusClass}`}>
+          {pod.status}
+        </span>
+      </div>
+    </div>
+  )
+}
+
+function ComponentRow({
+  component,
+  t,
+}: {
+  component: DaprComponent
+  t: TFunction<'cards'>
+}) {
+  return (
+    <div className="rounded-md bg-secondary/30 px-3 py-2 flex items-center justify-between gap-2">
+      <div className="min-w-0 flex items-center gap-1.5">
+        <ComponentIcon type={component.type} />
+        <span className="text-xs font-medium text-foreground truncate">{component.name}</span>
+        <span className="text-xs text-muted-foreground shrink-0">{component.namespace}</span>
+      </div>
+      <div className="flex items-center gap-2 shrink-0">
+        <span className="text-[11px] text-muted-foreground font-mono truncate max-w-[9rem]">
+          {component.componentImpl}
+        </span>
+        <span
+          className={`text-[11px] px-1.5 py-0.5 rounded-full bg-secondary/50 ${componentTypeColor(component.type)}`}
+        >
+          {componentTypeLabel(component.type, t)}
+        </span>
+      </div>
+    </div>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Main component
+// ---------------------------------------------------------------------------
+
+export function DaprStatus() {
+  const { t } = useTranslation('cards')
+  const { data, isRefreshing, error, showSkeleton, showEmptyState } = useCachedDapr()
+
+  const isHealthy = data.health === 'healthy'
+
+  if (showSkeleton) {
+    return (
+      <div className="h-full flex flex-col min-h-card gap-4">
+        <div className="flex items-center justify-between">
+          <Skeleton variant="rounded" width={SKELETON_TITLE_WIDTH} height={SKELETON_TITLE_HEIGHT} />
+          <Skeleton variant="rounded" width={SKELETON_BADGE_WIDTH} height={SKELETON_BADGE_HEIGHT} />
+        </div>
+        <SkeletonStats className="grid-cols-4" />
+        <SkeletonList items={SKELETON_LIST_ITEMS} className="flex-1" />
+      </div>
+    )
+  }
+
+  if (error && showEmptyState) {
+    return (
+      <div className="h-full flex flex-col items-center justify-center min-h-card text-muted-foreground gap-2">
+        <AlertTriangle className="w-6 h-6 text-red-400" />
+        <p className="text-sm text-red-400">
+          {t('daprStatus.fetchError', 'Unable to fetch Dapr status')}
+        </p>
+      </div>
+    )
+  }
+
+  if (data.health === 'not-installed') {
+    return (
+      <div className="h-full flex flex-col items-center justify-center min-h-card text-muted-foreground gap-2">
+        <Shield className="w-6 h-6 text-muted-foreground/50" />
+        <p className="text-sm font-medium">
+          {t('daprStatus.notInstalled', 'Dapr not detected')}
+        </p>
+        <p className="text-xs text-center max-w-xs">
+          {t(
+            'daprStatus.notInstalledHint',
+            'No Dapr control plane reachable from the connected clusters.',
+          )}
+        </p>
+      </div>
+    )
+  }
+
+  return (
+    <div className="h-full flex flex-col min-h-card content-loaded gap-4 overflow-hidden">
+      {/* Header — health pill + freshness */}
+      <div className="flex items-center justify-between gap-2">
+        <div
+          className={`flex items-center gap-2 px-3 py-1.5 rounded-full text-sm font-medium ${
+            isHealthy
+              ? 'bg-green-500/15 text-green-400'
+              : 'bg-yellow-500/15 text-yellow-400'
+          }`}
+        >
+          {isHealthy ? <CheckCircle className="w-4 h-4" /> : <AlertTriangle className="w-4 h-4" />}
+          {isHealthy
+            ? t('daprStatus.healthy', 'Healthy')
+            : t('daprStatus.degraded', 'Degraded')}
+        </div>
+
+        <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
+          <RefreshCw className={`w-3 h-3 ${isRefreshing ? 'animate-spin' : ''}`} />
+          <span>{formatRelativeTime(data.lastCheckTime)}</span>
+        </div>
+      </div>
+
+      {/* Summary tiles */}
+      <div className="grid grid-cols-2 @md:grid-cols-4 gap-2">
+        <MetricTile
+          label={t('daprStatus.controlPlane', 'Control plane')}
+          value={`${data.summary.runningControlPlanePods}/${data.summary.totalControlPlanePods}`}
+          colorClass={
+            data.summary.runningControlPlanePods === data.summary.totalControlPlanePods
+              ? 'text-green-400'
+              : 'text-yellow-400'
+          }
+          icon={<Server className="w-4 h-4 text-blue-400" />}
+        />
+        <MetricTile
+          label={t('daprStatus.apps', 'Dapr apps')}
+          value={data.summary.totalDaprApps}
+          colorClass="text-cyan-400"
+          icon={<Boxes className="w-4 h-4 text-cyan-400" />}
+        />
+        <MetricTile
+          label={t('daprStatus.components', 'Components')}
+          value={data.summary.totalComponents}
+          colorClass="text-foreground"
+          icon={<Layers className="w-4 h-4 text-violet-400" />}
+        />
+        <MetricTile
+          label={t('daprStatus.namespaces', 'Namespaces')}
+          value={data.apps.namespaces}
+          colorClass="text-foreground"
+          icon={<Layers className="w-4 h-4 text-emerald-400" />}
+        />
+      </div>
+
+      {/* Building block breakdown */}
+      <div className="grid grid-cols-3 gap-2">
+        <div className="rounded-md bg-secondary/30 px-3 py-2 flex items-center gap-2">
+          <Database className="w-4 h-4 text-emerald-400 shrink-0" />
+          <div className="min-w-0">
+            <div className="text-[11px] text-muted-foreground uppercase tracking-wide">
+              {t('daprStatus.stateStores', 'State stores')}
+            </div>
+            <div className="text-sm font-semibold text-foreground">
+              {data.buildingBlocks.stateStores}
+            </div>
+          </div>
+        </div>
+        <div className="rounded-md bg-secondary/30 px-3 py-2 flex items-center gap-2">
+          <Radio className="w-4 h-4 text-violet-400 shrink-0" />
+          <div className="min-w-0">
+            <div className="text-[11px] text-muted-foreground uppercase tracking-wide">
+              {t('daprStatus.pubsubs', 'Pub/sub')}
+            </div>
+            <div className="text-sm font-semibold text-foreground">
+              {data.buildingBlocks.pubsubs}
+            </div>
+          </div>
+        </div>
+        <div className="rounded-md bg-secondary/30 px-3 py-2 flex items-center gap-2">
+          <Link2 className="w-4 h-4 text-cyan-400 shrink-0" />
+          <div className="min-w-0">
+            <div className="text-[11px] text-muted-foreground uppercase tracking-wide">
+              {t('daprStatus.bindings', 'Bindings')}
+            </div>
+            <div className="text-sm font-semibold text-foreground">
+              {data.buildingBlocks.bindings}
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {/* Control plane + component lists */}
+      <div className="space-y-3 overflow-y-auto scrollbar-thin pr-0.5">
+        <section className="space-y-2">
+          <div className="flex items-center gap-2">
+            <Server className="w-4 h-4 text-blue-400" />
+            <h4 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+              {t('daprStatus.sectionControlPlane', 'Control plane')}
+            </h4>
+          </div>
+
+          {data.controlPlane.length === 0 ? (
+            <div className="rounded-md bg-secondary/20 border border-border/40 px-3 py-2 text-xs text-muted-foreground">
+              {t('daprStatus.noControlPlane', 'No Dapr control plane pods detected')}
+            </div>
+          ) : (
+            <div className="space-y-1.5">
+              {(data.controlPlane ?? []).map(pod => (
+                <ControlPlaneRow key={`${pod.cluster}:${pod.namespace}:${pod.name}`} pod={pod} />
+              ))}
+            </div>
+          )}
+        </section>
+
+        <section className="space-y-2">
+          <div className="flex items-center gap-2">
+            <Layers className="w-4 h-4 text-violet-400" />
+            <h4 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+              {t('daprStatus.sectionComponents', 'Components')}
+            </h4>
+          </div>
+
+          {data.components.length === 0 ? (
+            <div className="rounded-md bg-secondary/20 border border-border/40 px-3 py-2 text-xs text-muted-foreground">
+              {t('daprStatus.noComponents', 'No Dapr components configured')}
+            </div>
+          ) : (
+            <div className="space-y-1.5">
+              {(data.components ?? []).map(component => (
+                <ComponentRow
+                  key={`${component.cluster}:${component.namespace}:${component.name}`}
+                  component={component}
+                  t={t}
+                />
+              ))}
+            </div>
+          )}
+        </section>
+      </div>
+    </div>
+  )
+}
+
+export default DaprStatus

--- a/web/src/components/dashboard/shared/cardCatalog.ts
+++ b/web/src/components/dashboard/shared/cardCatalog.ts
@@ -116,6 +116,7 @@ export const CARD_CATALOG = {
     { type: 'configmap_status', title: 'ConfigMap Status', description: 'ConfigMaps across clusters with data key counts', visualization: 'table' },
     { type: 'secret_status', title: 'Secret Status', description: 'Secrets across clusters with types and key counts', visualization: 'table' },
     { type: 'kubevela_status', title: 'KubeVela', description: 'KubeVela controller health and OAM application delivery status', visualization: 'status' },
+    { type: 'dapr_status', title: 'Dapr', description: 'Dapr control plane health, Dapr-enabled apps, and configured components (state store / pub-sub / binding)', visualization: 'status' },
   ],
   'Compute': [
     { type: 'compute_overview', title: 'Compute Overview', description: 'CPU, memory, and GPU summary with live data', visualization: 'status' },

--- a/web/src/config/cards/dapr-status.ts
+++ b/web/src/config/cards/dapr-status.ts
@@ -1,0 +1,55 @@
+/**
+ * Dapr Status Card Configuration
+ *
+ * Dapr (Distributed Application Runtime) is a CNCF graduated project that
+ * provides portable microservice APIs (state management, pub/sub, bindings,
+ * service invocation). This card surfaces:
+ *
+ * - Control plane pod health (operator, placement, sentry, sidecarInjector)
+ * - Number of apps with a Dapr sidecar injected
+ * - Configured components grouped by building block (state store, pub/sub,
+ *   binding)
+ *
+ * Source: kubestellar/console-marketplace#21
+ */
+import type { UnifiedCardConfig } from '../../lib/unified/types'
+
+export const daprStatusConfig: UnifiedCardConfig = {
+  type: 'dapr_status',
+  title: 'Dapr',
+  category: 'workloads',
+  description:
+    'Dapr control plane health, Dapr-enabled application count, and configured components (state store / pub-sub / binding).',
+  icon: 'Boxes',
+  iconColor: 'text-cyan-400',
+  defaultWidth: 6,
+  defaultHeight: 4,
+  dataSource: { type: 'hook', hook: 'useCachedDapr' },
+  content: {
+    type: 'list',
+    pageSize: 8,
+    columns: [
+      { field: 'name', header: 'Name', primary: true, render: 'truncate' },
+      { field: 'namespace', header: 'Namespace', width: 140, render: 'truncate' },
+      { field: 'type', header: 'Type', width: 110, render: 'status-badge' },
+      { field: 'componentImpl', header: 'Impl', width: 140, render: 'truncate' },
+      { field: 'cluster', header: 'Cluster', width: 120, render: 'cluster-badge' },
+    ],
+  },
+  emptyState: {
+    icon: 'Boxes',
+    title: 'Dapr not detected',
+    message: 'No Dapr control plane reachable from the connected clusters.',
+    variant: 'info',
+  },
+  loadingState: {
+    type: 'list',
+    rows: 5,
+  },
+  // Scaffolding: renders live if /api/dapr/status is wired up, otherwise
+  // falls back to demo data via the useCache demo path.
+  isDemoData: true,
+  isLive: false,
+}
+
+export default daprStatusConfig

--- a/web/src/config/cards/index.ts
+++ b/web/src/config/cards/index.ts
@@ -64,6 +64,7 @@ import { githubCiMonitorConfig } from './github-ci-monitor'
 import { fluxStatusConfig } from './flux-status'
 import { contourStatusConfig } from './contour-status'
 import { containerdStatusConfig } from './containerd-status'
+import { daprStatusConfig } from './dapr-status'
 import { envoyStatusConfig } from './envoy-status'
 import { grpcStatusConfig } from './grpc-status'
 import { kedaStatusConfig } from './keda-status'
@@ -256,6 +257,7 @@ export const CARD_CONFIGS: CardConfigRegistry = {
   flux_status: fluxStatusConfig,
   contour_status: contourStatusConfig,
   containerd_status: containerdStatusConfig,
+  dapr_status: daprStatusConfig,
   envoy_status: envoyStatusConfig,
   grpc_status: grpcStatusConfig,
   keda_status: kedaStatusConfig,

--- a/web/src/hooks/useCachedDapr.ts
+++ b/web/src/hooks/useCachedDapr.ts
@@ -1,0 +1,276 @@
+/**
+ * Dapr Status Hook — Data fetching for the dapr_status card.
+ *
+ * Mirrors the envoy_status / contour_status pattern:
+ * - useCache with fetcher + demo fallback
+ * - isDemoFallback gated on !isLoading (prevents demo flash while loading)
+ * - fetchJson helper with treat404AsEmpty (no real endpoint yet — this is
+ *   scaffolding; the fetch will 404 until a real Dapr control plane bridge
+ *   lands, at which point useCache will transparently switch to live data)
+ * - showSkeleton / showEmptyState from useCardLoadingState
+ */
+
+import { useCache } from '../lib/cache'
+import { useCardLoadingState } from '../components/cards/CardDataContext'
+import { FETCH_DEFAULT_TIMEOUT_MS } from '../lib/constants/network'
+import { authFetch } from '../lib/api'
+import {
+  DAPR_DEMO_DATA,
+  type DaprAppSidecar,
+  type DaprBuildingBlockCounts,
+  type DaprComponent,
+  type DaprControlPlanePod,
+  type DaprStatusData,
+  type DaprSummary,
+} from '../components/cards/dapr_status/demoData'
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const CACHE_KEY = 'dapr-status'
+const DAPR_STATUS_ENDPOINT = '/api/dapr/status'
+
+const EMPTY_APPS: DaprAppSidecar = {
+  total: 0,
+  namespaces: 0,
+}
+
+const EMPTY_BUILDING_BLOCKS: DaprBuildingBlockCounts = {
+  stateStores: 0,
+  pubsubs: 0,
+  bindings: 0,
+}
+
+const INITIAL_DATA: DaprStatusData = {
+  health: 'not-installed',
+  controlPlane: [],
+  components: [],
+  apps: EMPTY_APPS,
+  buildingBlocks: EMPTY_BUILDING_BLOCKS,
+  summary: {
+    totalControlPlanePods: 0,
+    runningControlPlanePods: 0,
+    totalComponents: 0,
+    totalDaprApps: 0,
+  },
+  lastCheckTime: new Date().toISOString(),
+}
+
+// ---------------------------------------------------------------------------
+// Internal types (shape of the future /api/dapr/status response)
+// ---------------------------------------------------------------------------
+
+interface FetchResult<T> {
+  data: T
+  failed: boolean
+}
+
+interface DaprStatusResponse {
+  controlPlane?: DaprControlPlanePod[]
+  components?: DaprComponent[]
+  apps?: Partial<DaprAppSidecar>
+}
+
+// ---------------------------------------------------------------------------
+// Pure helpers
+// ---------------------------------------------------------------------------
+
+function countByType(
+  components: DaprComponent[],
+  type: DaprComponent['type'],
+): number {
+  return components.filter(c => c.type === type).length
+}
+
+function summarize(
+  controlPlane: DaprControlPlanePod[],
+  components: DaprComponent[],
+  apps: DaprAppSidecar,
+): DaprSummary {
+  return {
+    totalControlPlanePods: controlPlane.length,
+    runningControlPlanePods: controlPlane.filter(p => p.status === 'running').length,
+    totalComponents: components.length,
+    totalDaprApps: apps.total,
+  }
+}
+
+function buildBuildingBlocks(components: DaprComponent[]): DaprBuildingBlockCounts {
+  return {
+    stateStores: countByType(components, 'state-store'),
+    pubsubs: countByType(components, 'pubsub'),
+    bindings: countByType(components, 'binding'),
+  }
+}
+
+function deriveHealth(
+  controlPlane: DaprControlPlanePod[],
+  components: DaprComponent[],
+  apps: DaprAppSidecar,
+): DaprStatusData['health'] {
+  if (controlPlane.length === 0 && components.length === 0 && apps.total === 0) {
+    return 'not-installed'
+  }
+  const hasDegradedControlPlane = controlPlane.some(
+    p => p.status !== 'running' || p.replicasReady < p.replicasDesired,
+  )
+  if (hasDegradedControlPlane) {
+    return 'degraded'
+  }
+  return 'healthy'
+}
+
+function buildDaprStatus(
+  controlPlane: DaprControlPlanePod[],
+  components: DaprComponent[],
+  apps: DaprAppSidecar,
+): DaprStatusData {
+  return {
+    health: deriveHealth(controlPlane, components, apps),
+    controlPlane,
+    components,
+    apps,
+    buildingBlocks: buildBuildingBlocks(components),
+    summary: summarize(controlPlane, components, apps),
+    lastCheckTime: new Date().toISOString(),
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Private fetchJson helper (mirrors contour/flux/envoy pattern)
+// ---------------------------------------------------------------------------
+
+async function fetchJson<T>(
+  url: string,
+  options?: { treat404AsEmpty?: boolean },
+): Promise<FetchResult<T | null>> {
+  try {
+    const resp = await authFetch(url, {
+      headers: { Accept: 'application/json' },
+      signal: AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS),
+    })
+
+    if (!resp.ok) {
+      if (options?.treat404AsEmpty && resp.status === 404) {
+        return { data: null, failed: false }
+      }
+      return { data: null, failed: true }
+    }
+
+    const body = (await resp.json()) as T
+    return { data: body, failed: false }
+  } catch {
+    return { data: null, failed: true }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Fetcher
+// ---------------------------------------------------------------------------
+
+async function fetchDaprStatus(): Promise<DaprStatusData> {
+  const result = await fetchJson<DaprStatusResponse>(
+    DAPR_STATUS_ENDPOINT,
+    { treat404AsEmpty: true },
+  )
+
+  if (result.failed) {
+    throw new Error('Unable to fetch Dapr status')
+  }
+
+  const body = result.data
+  const controlPlane = Array.isArray(body?.controlPlane) ? body.controlPlane : []
+  const components = Array.isArray(body?.components) ? body.components : []
+  const apps: DaprAppSidecar = {
+    total: body?.apps?.total ?? 0,
+    namespaces: body?.apps?.namespaces ?? 0,
+  }
+
+  return buildDaprStatus(controlPlane, components, apps)
+}
+
+// ---------------------------------------------------------------------------
+// Hook
+// ---------------------------------------------------------------------------
+
+export interface UseCachedDaprResult {
+  data: DaprStatusData
+  isLoading: boolean
+  isRefreshing: boolean
+  isDemoData: boolean
+  isFailed: boolean
+  consecutiveFailures: number
+  lastRefresh: number | null
+  showSkeleton: boolean
+  showEmptyState: boolean
+  error: boolean
+  refetch: () => Promise<void>
+}
+
+export function useCachedDapr(): UseCachedDaprResult {
+  const {
+    data,
+    isLoading,
+    isRefreshing,
+    isFailed,
+    consecutiveFailures,
+    isDemoFallback,
+    lastRefresh,
+    refetch,
+  } = useCache<DaprStatusData>({
+    key: CACHE_KEY,
+    category: 'services',
+    initialData: INITIAL_DATA,
+    demoData: DAPR_DEMO_DATA,
+    persist: true,
+    fetcher: fetchDaprStatus,
+  })
+
+  // Prevent demo flash while loading — only surface the Demo badge once
+  // we've actually fallen back to demo data post-load.
+  const effectiveIsDemoData = isDemoFallback && !isLoading
+
+  // 'not-installed' counts as "data" so the card shows the empty state
+  // rather than an infinite skeleton when Dapr isn't present.
+  const hasAnyData =
+    data.health === 'not-installed'
+      ? true
+      : data.controlPlane.length > 0 || data.components.length > 0
+
+  const { showSkeleton, showEmptyState } = useCardLoadingState({
+    isLoading: isLoading && !hasAnyData,
+    isRefreshing,
+    hasAnyData,
+    isFailed,
+    consecutiveFailures,
+    isDemoData: effectiveIsDemoData,
+    lastRefresh,
+  })
+
+  return {
+    data,
+    isLoading,
+    isRefreshing,
+    isDemoData: effectiveIsDemoData,
+    isFailed,
+    consecutiveFailures,
+    lastRefresh,
+    showSkeleton,
+    showEmptyState,
+    error: isFailed && !hasAnyData,
+    refetch,
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Exported testables — pure functions for unit testing
+// ---------------------------------------------------------------------------
+
+export const __testables = {
+  summarize,
+  deriveHealth,
+  buildDaprStatus,
+  buildBuildingBlocks,
+  countByType,
+}

--- a/web/src/hooks/useCachedData.ts
+++ b/web/src/hooks/useCachedData.ts
@@ -150,6 +150,12 @@ export * from './useCachedJaegerStatus'
 export * from './useCachedTikv'
 
 // ============================================================================
+// Dapr Distributed Application Runtime — useCachedDapr.ts
+// ============================================================================
+
+export { useCachedDapr } from './useCachedDapr'
+
+// ============================================================================
 // OpenTelemetry Collector — useCachedOtel.ts
 // ============================================================================
 

--- a/web/src/hooks/useMarketplace.ts
+++ b/web/src/hooks/useMarketplace.ts
@@ -94,6 +94,7 @@ const MARKETPLACE_TO_CARD_TYPE: Record<string, string> = {
   'cncf-lima': 'lima_status',
   'cncf-flux': 'flux_status',
   'cncf-contour': 'contour_status',
+  'cncf-dapr': 'dapr_status',
   'cncf-envoy': 'envoy_status',
   'cncf-grpc': 'grpc_status',
   'cncf-linkerd': 'linkerd_status',

--- a/web/src/lib/demo/dapr.ts
+++ b/web/src/lib/demo/dapr.ts
@@ -1,0 +1,26 @@
+/**
+ * Dapr demo seed re-export.
+ *
+ * The canonical demo data lives alongside the Dapr card in
+ * `components/cards/dapr_status/demoData.ts`. This file re-exports it so
+ * callers outside the card folder (docs, tests, future drill-downs) can
+ * import a stable demo seed from `lib/demo/dapr`.
+ *
+ * Shape covers:
+ * - Control plane pods (operator / placement / sentry / sidecarInjector)
+ * - Sidecar-injected application count (and distinct namespaces)
+ * - Components (state-store / pubsub / binding) with building-block counts
+ */
+
+export {
+  DAPR_DEMO_DATA,
+  type DaprStatusData,
+  type DaprControlPlanePod,
+  type DaprControlPlanePodStatus,
+  type DaprComponent,
+  type DaprComponentType,
+  type DaprAppSidecar,
+  type DaprBuildingBlockCounts,
+  type DaprSummary,
+  type DaprHealth,
+} from '../../components/cards/dapr_status/demoData'

--- a/web/src/lib/unified/registerHooks.ts
+++ b/web/src/lib/unified/registerHooks.ts
@@ -50,6 +50,7 @@ import {
 import { useFluxStatus } from '../../components/cards/flux_status/useFluxStatus'
 import { useContourStatus } from '../../components/cards/contour_status/useContourStatus'
 import { useCachedContainerd } from '../../hooks/useCachedContainerd'
+import { useCachedDapr } from '../../hooks/useCachedDapr'
 import { useCachedEnvoy } from '../../components/cards/envoy_status/useCachedEnvoy'
 import { useCachedGrpc } from '../../hooks/useCachedGrpc'
 import { useCachedKeda } from '../../hooks/useCachedKeda'
@@ -1068,6 +1069,17 @@ function useUnifiedEnvoyStatus() {
   }
 }
 
+function useUnifiedDaprStatus() {
+  const result = useCachedDapr()
+  // Surface the component list as the primary row set for generic list renderers.
+  return {
+    data: result.data.components,
+    isLoading: result.showSkeleton,
+    error: result.error ? new Error('Failed to fetch Dapr status') : null,
+    refetch: () => { result.refetch() },
+  }
+}
+
 function useUnifiedGrpcStatus() {
   const result = useCachedGrpc()
   // Surface the service list as the primary row set for generic list renderers.
@@ -1326,6 +1338,7 @@ export function registerUnifiedHooks(): void {
   registerDataHook('useFluxStatus', useUnifiedFluxStatus)
   registerDataHook('useContourStatus', useUnifiedContourStatus)
   registerDataHook('useCachedContainerd', useUnifiedContainerdStatus)
+  registerDataHook('useCachedDapr', useUnifiedDaprStatus)
   registerDataHook('useCachedEnvoy', useUnifiedEnvoyStatus)
   registerDataHook('useCachedGrpc', useUnifiedGrpcStatus)
   registerDataHook('useCachedKeda', useUnifiedKedaStatus)

--- a/web/src/locales/en/cards.json
+++ b/web/src/locales/en/cards.json
@@ -3045,6 +3045,27 @@
     "syncedHoursAgo": "{{count}}h ago",
     "syncedDaysAgo": "{{count}}d ago"
   },
+  "daprStatus": {
+    "healthy": "Healthy",
+    "degraded": "Degraded",
+    "notInstalled": "Dapr not detected",
+    "notInstalledHint": "No Dapr control plane reachable from the connected clusters.",
+    "fetchError": "Unable to fetch Dapr status",
+    "controlPlane": "Control plane",
+    "apps": "Dapr apps",
+    "components": "Components",
+    "namespaces": "Namespaces",
+    "stateStores": "State stores",
+    "pubsubs": "Pub/sub",
+    "bindings": "Bindings",
+    "componentStateStore": "State store",
+    "componentPubSub": "Pub/sub",
+    "componentBinding": "Binding",
+    "sectionControlPlane": "Control plane",
+    "sectionComponents": "Components",
+    "noControlPlane": "No Dapr control plane pods detected",
+    "noComponents": "No Dapr components configured"
+  },
   "envoyStatus": {
     "healthy": "Healthy",
     "degraded": "Degraded",


### PR DESCRIPTION
Fixes kubestellar/console-marketplace#21

## Summary

Adds a Dapr (Distributed Application Runtime — CNCF graduated, portable microservice APIs) monitoring card to the **Workloads** category. Scaffolding: renders via demo fallback today and will transparently pick up live data when `/api/dapr/status` is wired up.

The card surfaces:

- **Control plane pod health** — operator / placement / sentry / sidecarInjector with replica readiness
- **Dapr-enabled application count** — total sidecar-injected apps and distinct namespaces
- **Components grouped by building block** — state store / pub-sub / binding with per-type counts

## Files added

- `web/src/components/cards/dapr_status/index.tsx` — card component
- `web/src/components/cards/dapr_status/demoData.ts` — types + demo seed
- `web/src/hooks/useCachedDapr.ts` — data hook (useCache + useCardLoadingState)
- `web/src/lib/demo/dapr.ts` — stable demo-seed re-export
- `web/src/config/cards/dapr-status.ts` — UnifiedCardConfig (category: `workloads`)

## Registered in

- `cardRegistry.ts` (4 spots — alphabetical, dapr < envoy)
- `cardMetadata.ts` (title + description)
- `cardCatalog.ts` (Workloads group)
- `config/cards/index.ts`
- `lib/unified/registerHooks.ts` (`useCachedDapr` -> unified list of components)
- `hooks/useCachedData.ts`
- `hooks/useMarketplace.ts` (`cncf-dapr` -> `dapr_status`)
- `locales/en/cards.json` (`daprStatus.*`)

## CLAUDE.md compliance

- No magic numbers — every literal is a named constant
- `?? []` guards on all `.map()` iterations over array data
- No `import React` — pure JSX transforms
- All user-facing strings via `t()` with the `cards` namespace
- Full `useCardLoadingState` wiring with both `isDemoData` and `isRefreshing`
- Hook uses `isDemoFallback && !isLoading` to prevent demo-flash during load
- `'not-installed'` treated as data so card shows empty state rather than infinite skeleton

## Test plan

- [ ] Card appears in Add Cards -> Workloads browse catalog
- [ ] Demo badge + yellow outline show when no live endpoint
- [ ] Refresh icon spins during background refresh
- [ ] Loading skeleton -> data transition has no demo flash
- [ ] `cncf-dapr` marketplace ID correctly resolves to `dapr_status` so the Dapr marketplace entry flips from help-wanted to implemented